### PR TITLE
feat(core,ec,amuleapi): re-extract media metadata on demand

### DIFF
--- a/docs/api/REFERENCE.md
+++ b/docs/api/REFERENCE.md
@@ -1315,7 +1315,15 @@ curl -s -H "Authorization: Bearer $TOKEN" "http://$HOST/api/v0/shared"
       "uploading":        2,
       "last_upload":      1700000500,
       "shared_since":     1699000000,
-      "hashing_progress": 0
+      "hashing_progress": 0,
+      "media": {
+        "length_s": 212,
+        "bitrate":  320,
+        "codec":    "mp3",
+        "artist":   "Some Artist",
+        "album":    "Some Album",
+        "title":    "Some Title"
+      }
     }
   ]
 }
@@ -1331,7 +1339,9 @@ curl -s -H "Authorization: Bearer $TOKEN" "http://$HOST/api/v0/shared"
 
 A file that is both downloading and shared reports its progress here as well: amuled describes such a file as a partfile, so the value is read across from the download side and the two agree. That makes `hashing_progress` usable from either list without checking which one owns the file.
 
-The SSE `shared_added` / `shared_updated` event payload matches this object byte-for-byte, so a subscriber that received `shared_updated` does not need to re-GET to see the moved counters.
+`media` is present only on an audio or video file that has been probed, and absent entirely otherwise — check for the key rather than for empty values. Its six fields are the same ones the detail endpoint reports, and a [media refresh](#post-apiv0sharedmediarefresh) replaces all of them, clearing any the new probe no longer finds.
+
+The SSE `shared_added` / `shared_updated` event payload matches this object byte-for-byte, so a subscriber that received `shared_updated` does not need to re-GET to see the moved counters — including `media`, which is what makes a metadata refresh observable without polling.
 
 **Errors:** `503 ec_unavailable`.
 

--- a/docs/api/REFERENCE.md
+++ b/docs/api/REFERENCE.md
@@ -50,6 +50,8 @@ The API is versioned in the path. Breaking changes ship under `/api/v1/`; `/api/
 - [`GET /api/v0/shared/{hash}`](#get-apiv0sharedhash) — detail view; every list field plus shared-detail fields
 - [`GET /api/v0/shared/{hash}/clients`](#get-apiv0sharedhashclients) — peers of one shared file
 - [`POST /api/v0/shared/reload`](#post-apiv0sharedreload) — re-walk shared directories
+- [`POST /api/v0/shared/media/refresh`](#post-apiv0sharedmediarefresh) — re-extract media metadata for the whole share
+- [`POST /api/v0/shared/{hash}/media/refresh`](#post-apiv0sharedhashmediarefresh) — re-extract it for one file
 - [`GET /api/v0/shared/directories`](#get-apiv0shareddirectories) — the configured share roots
 - [`PUT /api/v0/shared/directories`](#put-apiv0shareddirectories) — replace the configured share roots
 - [`POST /api/v0/shared/directories`](#post-apiv0shareddirectories) — add one share root
@@ -1396,6 +1398,45 @@ Repeated calls coalesce: requesting a reload while one is already pending, or wh
 The resulting changes also arrive as `shared_added` / `shared_removed` events on the `shared` SSE channel, which is the better signal if you only care about the delta.
 
 **Errors:** `503 ec_unavailable`.
+
+#### `POST /api/v0/shared/media/refresh`
+
+**Auth:** `ADMIN`
+
+Re-extract media metadata for every shared file, whether or not it already has some.
+
+```sh
+curl -s -X POST -H "Authorization: Bearer $TOKEN" \
+  "http://$HOST/api/v0/shared/media/refresh"
+```
+
+```json
+{ "ok": true, "scope": "all", "queued": 812 }
+```
+
+Returns `202 Accepted`. `queued` is how many files were **accepted for probing**, not how many produced metadata — files the scheduler drops (not audio/video by extension, an incomplete download, missing on disk) are not counted, and nothing has been extracted yet when the response returns.
+
+This is the only way to correct metadata that is *wrong* rather than missing. The normal scheduler skips any file that already carries a media tag, so a value stored by an older build — a cover-art codec, or a preview inherited from a search result before the local probe could overwrite it — is otherwise permanent short of deleting `known.met`, which would also discard the ed2k part hashes and every per-file statistic.
+
+Each probe **replaces** every media field, including *clearing* one the new probe no longer finds, so a refresh corrects a value in both directions. Nothing else about a file is touched: statistics, comment, rating, upload priority, AICH hash set and share state all survive, the file is not re-hashed, its ed2k hash does not change, and it never leaves the share.
+
+The work runs on amuled's media-probe worker, one file at a time, so downloads and uploads are unaffected and the daemon stays responsive. Shutting down mid-refresh is clean — files not yet reached keep their previous values. Progress is observable through [`GET /api/v0/logs/amule`](#get-apiv0logsamule) and, as each probe lands, `shared_updated` SSE events.
+
+Cost is roughly 13 ms per file — a probe reads the container header, not the file — so a 10 000-file library is on the order of two minutes of background work.
+
+**Errors:** `501 ec_unsupported` (the connected amuled predates this operation), `503 ec_unavailable`.
+
+#### `POST /api/v0/shared/{hash}/media/refresh`
+
+**Auth:** `ADMIN`
+
+The same operation for a single file, which is the quickest way to check a fix on one file rather than a whole library.
+
+```json
+{ "ok": true, "scope": "file", "queued": 1 }
+```
+
+**Errors:** `404 not_found` (no shared file with that hash), `409 partfile_unsupported` (an incomplete download has no complete file to read), `501 ec_unsupported`, `503 ec_unavailable`.
 
 #### `GET /api/v0/shared/directories`
 

--- a/docs/api/REFERENCE.md
+++ b/docs/api/REFERENCE.md
@@ -1424,7 +1424,7 @@ The work runs on amuled's media-probe worker, one file at a time, so downloads a
 
 Cost is roughly 13 ms per file — a probe reads the container header, not the file — so a 10 000-file library is on the order of two minutes of background work.
 
-**Errors:** `501 ec_unsupported` (the connected amuled predates this operation), `503 ec_unavailable`.
+**Errors:** `503 ec_unsupported` (the connected amuled predates this operation), `503 ec_unavailable`.
 
 #### `POST /api/v0/shared/{hash}/media/refresh`
 
@@ -1436,7 +1436,7 @@ The same operation for a single file, which is the quickest way to check a fix o
 { "ok": true, "scope": "file", "queued": 1 }
 ```
 
-**Errors:** `404 not_found` (no shared file with that hash), `409 partfile_unsupported` (an incomplete download has no complete file to read), `501 ec_unsupported`, `503 ec_unavailable`.
+**Errors:** `404 not_found` (no shared file with that hash), `409 partfile_unsupported` (an incomplete download has no complete file to read), `400 amuled_rejected` (the file is not eligible — its extension is not audio/video), `503 ec_unsupported`, `503 ec_unavailable`.
 
 #### `GET /api/v0/shared/directories`
 

--- a/po/amule.pot
+++ b/po/amule.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-23 23:17+0200\n"
+"POT-Creation-Date: 2026-08-23 23:41+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -2141,7 +2141,7 @@ msgid "No such chat session"
 msgstr ""
 
 #: src/ExternalConn.cpp
-msgid "No such shared file, or it cannot be probed"
+msgid "File is not eligible for media metadata extraction (not an audio/video file, or an incomplete download)"
 msgstr ""
 
 #: src/ExternalConn.cpp

--- a/po/amule.pot
+++ b/po/amule.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-23 22:15+0200\n"
+"POT-Creation-Date: 2026-08-23 23:17+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -2138,6 +2138,10 @@ msgstr ""
 
 #: src/ExternalConn.cpp
 msgid "No such chat session"
+msgstr ""
+
+#: src/ExternalConn.cpp
+msgid "No such shared file, or it cannot be probed"
 msgstr ""
 
 #: src/ExternalConn.cpp
@@ -6976,6 +6980,13 @@ msgstr ""
 #, c-format
 msgid "No shareable files found in directory: %s"
 msgstr ""
+
+#: src/SharedFileList.cpp
+#, c-format
+msgid "Re-extracting media metadata for %u shared file"
+msgid_plural "Re-extracting media metadata for %u shared files"
+msgstr[0] ""
+msgstr[1] ""
 
 #: src/SharedFileList.cpp
 #, c-format

--- a/po/ar.po
+++ b/po/ar.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-23 22:15+0200\n"
+"POT-Creation-Date: 2026-08-23 23:17+0200\n"
 "PO-Revision-Date: 2026-08-22 15:09+0000\n"
 "Last-Translator: saleh alhathal <hathalsal@hotmail.com>\n"
 "Language-Team: \n"
@@ -2177,6 +2177,10 @@ msgstr ""
 
 #: src/ExternalConn.cpp
 msgid "No such chat session"
+msgstr ""
+
+#: src/ExternalConn.cpp
+msgid "No such shared file, or it cannot be probed"
 msgstr ""
 
 #: src/ExternalConn.cpp
@@ -7099,6 +7103,13 @@ msgstr ""
 #, c-format
 msgid "No shareable files found in directory: %s"
 msgstr ""
+
+#: src/SharedFileList.cpp
+#, c-format
+msgid "Re-extracting media metadata for %u shared file"
+msgid_plural "Re-extracting media metadata for %u shared files"
+msgstr[0] ""
+msgstr[1] ""
 
 #: src/SharedFileList.cpp
 #, fuzzy, c-format

--- a/po/ar.po
+++ b/po/ar.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-23 23:17+0200\n"
+"POT-Creation-Date: 2026-08-23 23:41+0200\n"
 "PO-Revision-Date: 2026-08-22 15:09+0000\n"
 "Last-Translator: saleh alhathal <hathalsal@hotmail.com>\n"
 "Language-Team: \n"
@@ -2180,7 +2180,7 @@ msgid "No such chat session"
 msgstr ""
 
 #: src/ExternalConn.cpp
-msgid "No such shared file, or it cannot be probed"
+msgid "File is not eligible for media metadata extraction (not an audio/video file, or an incomplete download)"
 msgstr ""
 
 #: src/ExternalConn.cpp

--- a/po/ast.po
+++ b/po/ast.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-23 23:17+0200\n"
+"POT-Creation-Date: 2026-08-23 23:41+0200\n"
 "PO-Revision-Date: 2026-08-22 15:11+0000\n"
 "Last-Translator: astur <malditoastur@gmail.com>\n"
 "Language-Team: Language ast <malditoastur@gmail.com>\n"
@@ -2208,7 +2208,7 @@ msgid "No such chat session"
 msgstr "Zarrar esta sesión de charra"
 
 #: src/ExternalConn.cpp
-msgid "No such shared file, or it cannot be probed"
+msgid "File is not eligible for media metadata extraction (not an audio/video file, or an incomplete download)"
 msgstr ""
 
 #: src/ExternalConn.cpp

--- a/po/ast.po
+++ b/po/ast.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-23 22:15+0200\n"
+"POT-Creation-Date: 2026-08-23 23:17+0200\n"
 "PO-Revision-Date: 2026-08-22 15:11+0000\n"
 "Last-Translator: astur <malditoastur@gmail.com>\n"
 "Language-Team: Language ast <malditoastur@gmail.com>\n"
@@ -2206,6 +2206,10 @@ msgstr "Aniciada Nueva sesión de charra"
 #, fuzzy
 msgid "No such chat session"
 msgstr "Zarrar esta sesión de charra"
+
+#: src/ExternalConn.cpp
+msgid "No such shared file, or it cannot be probed"
+msgstr ""
 
 #: src/ExternalConn.cpp
 msgid "Empty chat message"
@@ -7216,6 +7220,13 @@ msgstr "Direutoriu compartíu non alcontráu, saltando: %s"
 #, c-format
 msgid "No shareable files found in directory: %s"
 msgstr "Ensin ficheros que compartir en direutoriu: %s"
+
+#: src/SharedFileList.cpp
+#, c-format
+msgid "Re-extracting media metadata for %u shared file"
+msgid_plural "Re-extracting media metadata for %u shared files"
+msgstr[0] ""
+msgstr[1] ""
 
 #: src/SharedFileList.cpp
 #, fuzzy, c-format

--- a/po/bg.po
+++ b/po/bg.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-23 22:15+0200\n"
+"POT-Creation-Date: 2026-08-23 23:17+0200\n"
 "PO-Revision-Date: 2026-08-22 15:15+0000\n"
 "Last-Translator: Sebastiano Pistore <SebastianoPistore.info@protonmail.ch>\n"
 "Language-Team: Bulgarian <dict@linux.zonebg.com>\n"
@@ -2171,6 +2171,10 @@ msgstr ""
 
 #: src/ExternalConn.cpp
 msgid "No such chat session"
+msgstr ""
+
+#: src/ExternalConn.cpp
+msgid "No such shared file, or it cannot be probed"
 msgstr ""
 
 #: src/ExternalConn.cpp
@@ -7073,6 +7077,13 @@ msgstr ""
 #, c-format
 msgid "No shareable files found in directory: %s"
 msgstr ""
+
+#: src/SharedFileList.cpp
+#, c-format
+msgid "Re-extracting media metadata for %u shared file"
+msgid_plural "Re-extracting media metadata for %u shared files"
+msgstr[0] ""
+msgstr[1] ""
 
 #: src/SharedFileList.cpp
 #, fuzzy, c-format

--- a/po/bg.po
+++ b/po/bg.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-23 23:17+0200\n"
+"POT-Creation-Date: 2026-08-23 23:41+0200\n"
 "PO-Revision-Date: 2026-08-22 15:15+0000\n"
 "Last-Translator: Sebastiano Pistore <SebastianoPistore.info@protonmail.ch>\n"
 "Language-Team: Bulgarian <dict@linux.zonebg.com>\n"
@@ -2174,7 +2174,7 @@ msgid "No such chat session"
 msgstr ""
 
 #: src/ExternalConn.cpp
-msgid "No such shared file, or it cannot be probed"
+msgid "File is not eligible for media metadata extraction (not an audio/video file, or an incomplete download)"
 msgstr ""
 
 #: src/ExternalConn.cpp

--- a/po/bn.po
+++ b/po/bn.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-23 23:17+0200\n"
+"POT-Creation-Date: 2026-08-23 23:41+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -2140,7 +2140,7 @@ msgid "No such chat session"
 msgstr ""
 
 #: src/ExternalConn.cpp
-msgid "No such shared file, or it cannot be probed"
+msgid "File is not eligible for media metadata extraction (not an audio/video file, or an incomplete download)"
 msgstr ""
 
 #: src/ExternalConn.cpp

--- a/po/bn.po
+++ b/po/bn.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-23 22:15+0200\n"
+"POT-Creation-Date: 2026-08-23 23:17+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -2137,6 +2137,10 @@ msgstr ""
 
 #: src/ExternalConn.cpp
 msgid "No such chat session"
+msgstr ""
+
+#: src/ExternalConn.cpp
+msgid "No such shared file, or it cannot be probed"
 msgstr ""
 
 #: src/ExternalConn.cpp
@@ -6975,6 +6979,13 @@ msgstr ""
 #, c-format
 msgid "No shareable files found in directory: %s"
 msgstr ""
+
+#: src/SharedFileList.cpp
+#, c-format
+msgid "Re-extracting media metadata for %u shared file"
+msgid_plural "Re-extracting media metadata for %u shared files"
+msgstr[0] ""
+msgstr[1] ""
 
 #: src/SharedFileList.cpp
 #, c-format

--- a/po/ca.po
+++ b/po/ca.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-23 22:15+0200\n"
+"POT-Creation-Date: 2026-08-23 23:17+0200\n"
 "PO-Revision-Date: 2026-08-22 15:16+0000\n"
 "Last-Translator: minterior <minterior@gmail.com>\n"
 "Language-Team: Català\n"
@@ -2199,6 +2199,10 @@ msgstr "Inici d'una nova sessió de xat"
 #, fuzzy
 msgid "No such chat session"
 msgstr "Tanca aquesta sessió de xat."
+
+#: src/ExternalConn.cpp
+msgid "No such shared file, or it cannot be probed"
+msgstr ""
 
 #: src/ExternalConn.cpp
 msgid "Empty chat message"
@@ -7184,6 +7188,13 @@ msgstr "Carpeta compartida no trobada, omitint: %s"
 #, c-format
 msgid "No shareable files found in directory: %s"
 msgstr "No s'ha trobat cap fitxer en el directori: %s"
+
+#: src/SharedFileList.cpp
+#, c-format
+msgid "Re-extracting media metadata for %u shared file"
+msgid_plural "Re-extracting media metadata for %u shared files"
+msgstr[0] ""
+msgstr[1] ""
 
 #: src/SharedFileList.cpp
 #, fuzzy, c-format

--- a/po/ca.po
+++ b/po/ca.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-23 23:17+0200\n"
+"POT-Creation-Date: 2026-08-23 23:41+0200\n"
 "PO-Revision-Date: 2026-08-22 15:16+0000\n"
 "Last-Translator: minterior <minterior@gmail.com>\n"
 "Language-Team: Català\n"
@@ -2201,7 +2201,7 @@ msgid "No such chat session"
 msgstr "Tanca aquesta sessió de xat."
 
 #: src/ExternalConn.cpp
-msgid "No such shared file, or it cannot be probed"
+msgid "File is not eligible for media metadata extraction (not an audio/video file, or an incomplete download)"
 msgstr ""
 
 #: src/ExternalConn.cpp

--- a/po/cs.po
+++ b/po/cs.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-23 22:15+0200\n"
+"POT-Creation-Date: 2026-08-23 23:17+0200\n"
 "PO-Revision-Date: 2026-08-22 15:58+0000\n"
 "Last-Translator: David Watzke <david@watzke.cz>\n"
 "Language-Team: cs <cs@li.org>\n"
@@ -2192,6 +2192,10 @@ msgstr "Zahájeno nové sezení v chatu"
 #, fuzzy
 msgid "No such chat session"
 msgstr "Zavře tento chat."
+
+#: src/ExternalConn.cpp
+msgid "No such shared file, or it cannot be probed"
+msgstr ""
 
 #: src/ExternalConn.cpp
 msgid "Empty chat message"
@@ -7180,6 +7184,14 @@ msgstr "Sdílený adresář nenalezen, přeskakuji: %s"
 #, c-format
 msgid "No shareable files found in directory: %s"
 msgstr ""
+
+#: src/SharedFileList.cpp
+#, c-format
+msgid "Re-extracting media metadata for %u shared file"
+msgid_plural "Re-extracting media metadata for %u shared files"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
 
 #: src/SharedFileList.cpp
 #, fuzzy, c-format

--- a/po/cs.po
+++ b/po/cs.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-23 23:17+0200\n"
+"POT-Creation-Date: 2026-08-23 23:41+0200\n"
 "PO-Revision-Date: 2026-08-22 15:58+0000\n"
 "Last-Translator: David Watzke <david@watzke.cz>\n"
 "Language-Team: cs <cs@li.org>\n"
@@ -2194,7 +2194,7 @@ msgid "No such chat session"
 msgstr "Zavře tento chat."
 
 #: src/ExternalConn.cpp
-msgid "No such shared file, or it cannot be probed"
+msgid "File is not eligible for media metadata extraction (not an audio/video file, or an incomplete download)"
 msgstr ""
 
 #: src/ExternalConn.cpp

--- a/po/da.po
+++ b/po/da.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-23 23:17+0200\n"
+"POT-Creation-Date: 2026-08-23 23:41+0200\n"
 "PO-Revision-Date: 2026-08-22 15:22+0000\n"
 "Last-Translator: Alex Thomsen Leth <alexl@stofanet.dk>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -2185,7 +2185,7 @@ msgid "No such chat session"
 msgstr ""
 
 #: src/ExternalConn.cpp
-msgid "No such shared file, or it cannot be probed"
+msgid "File is not eligible for media metadata extraction (not an audio/video file, or an incomplete download)"
 msgstr ""
 
 #: src/ExternalConn.cpp

--- a/po/da.po
+++ b/po/da.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-23 22:15+0200\n"
+"POT-Creation-Date: 2026-08-23 23:17+0200\n"
 "PO-Revision-Date: 2026-08-22 15:22+0000\n"
 "Last-Translator: Alex Thomsen Leth <alexl@stofanet.dk>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -2182,6 +2182,10 @@ msgstr ""
 
 #: src/ExternalConn.cpp
 msgid "No such chat session"
+msgstr ""
+
+#: src/ExternalConn.cpp
+msgid "No such shared file, or it cannot be probed"
 msgstr ""
 
 #: src/ExternalConn.cpp
@@ -7118,6 +7122,13 @@ msgstr ""
 #, c-format
 msgid "No shareable files found in directory: %s"
 msgstr ""
+
+#: src/SharedFileList.cpp
+#, c-format
+msgid "Re-extracting media metadata for %u shared file"
+msgid_plural "Re-extracting media metadata for %u shared files"
+msgstr[0] ""
+msgstr[1] ""
 
 #: src/SharedFileList.cpp
 #, fuzzy, c-format

--- a/po/de.po
+++ b/po/de.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-23 23:17+0200\n"
+"POT-Creation-Date: 2026-08-23 23:41+0200\n"
 "PO-Revision-Date: 2026-08-22 15:23+0000\n"
 "Last-Translator: Werner Mahr <werner@vollstreckernet.de>\n"
 "Language-Team: German <>\n"
@@ -2206,7 +2206,7 @@ msgid "No such chat session"
 msgstr "Schließe diese Chat-Sitzung."
 
 #: src/ExternalConn.cpp
-msgid "No such shared file, or it cannot be probed"
+msgid "File is not eligible for media metadata extraction (not an audio/video file, or an incomplete download)"
 msgstr ""
 
 #: src/ExternalConn.cpp

--- a/po/de.po
+++ b/po/de.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-23 22:15+0200\n"
+"POT-Creation-Date: 2026-08-23 23:17+0200\n"
 "PO-Revision-Date: 2026-08-22 15:23+0000\n"
 "Last-Translator: Werner Mahr <werner@vollstreckernet.de>\n"
 "Language-Team: German <>\n"
@@ -2204,6 +2204,10 @@ msgstr "Neue Chat-Sitzung gestartet."
 #, fuzzy
 msgid "No such chat session"
 msgstr "Schließe diese Chat-Sitzung."
+
+#: src/ExternalConn.cpp
+msgid "No such shared file, or it cannot be probed"
+msgstr ""
 
 #: src/ExternalConn.cpp
 msgid "Empty chat message"
@@ -7179,6 +7183,13 @@ msgstr "Freigegebenes Verzeichnis nicht gefunden, überspringe: %s"
 #, c-format
 msgid "No shareable files found in directory: %s"
 msgstr "Keine freigebbaren Dateien im Ordner gefunden: %s"
+
+#: src/SharedFileList.cpp
+#, c-format
+msgid "Re-extracting media metadata for %u shared file"
+msgid_plural "Re-extracting media metadata for %u shared files"
+msgstr[0] ""
+msgstr[1] ""
 
 #: src/SharedFileList.cpp
 #, fuzzy, c-format

--- a/po/el.po
+++ b/po/el.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-23 23:17+0200\n"
+"POT-Creation-Date: 2026-08-23 23:41+0200\n"
 "PO-Revision-Date: 2026-08-22 15:25+0000\n"
 "Last-Translator: Dimitris <dgalanak@yahoo.com>\n"
 "Language-Team: Greek\n"
@@ -2218,7 +2218,7 @@ msgid "No such chat session"
 msgstr "Κλείσιμο της συνομιλίας."
 
 #: src/ExternalConn.cpp
-msgid "No such shared file, or it cannot be probed"
+msgid "File is not eligible for media metadata extraction (not an audio/video file, or an incomplete download)"
 msgstr ""
 
 #: src/ExternalConn.cpp

--- a/po/el.po
+++ b/po/el.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-23 22:15+0200\n"
+"POT-Creation-Date: 2026-08-23 23:17+0200\n"
 "PO-Revision-Date: 2026-08-22 15:25+0000\n"
 "Last-Translator: Dimitris <dgalanak@yahoo.com>\n"
 "Language-Team: Greek\n"
@@ -2216,6 +2216,10 @@ msgstr "Ξεκίνησε καινούρια περίοδος συνομιλία�
 #, fuzzy
 msgid "No such chat session"
 msgstr "Κλείσιμο της συνομιλίας."
+
+#: src/ExternalConn.cpp
+msgid "No such shared file, or it cannot be probed"
+msgstr ""
 
 #: src/ExternalConn.cpp
 msgid "Empty chat message"
@@ -7232,6 +7236,13 @@ msgstr "Ο διακομιστής δεν βρέθηκε: %s"
 #, c-format
 msgid "No shareable files found in directory: %s"
 msgstr ""
+
+#: src/SharedFileList.cpp
+#, c-format
+msgid "Re-extracting media metadata for %u shared file"
+msgid_plural "Re-extracting media metadata for %u shared files"
+msgstr[0] ""
+msgstr[1] ""
 
 #: src/SharedFileList.cpp
 #, fuzzy, c-format

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-23 23:17+0200\n"
+"POT-Creation-Date: 2026-08-23 23:41+0200\n"
 "PO-Revision-Date: 2020-03-04 14:43+0100\n"
 "Last-Translator: Dévai Tamás <devait@vnet.hu>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -2141,7 +2141,7 @@ msgid "No such chat session"
 msgstr ""
 
 #: src/ExternalConn.cpp
-msgid "No such shared file, or it cannot be probed"
+msgid "File is not eligible for media metadata extraction (not an audio/video file, or an incomplete download)"
 msgstr ""
 
 #: src/ExternalConn.cpp

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-23 22:15+0200\n"
+"POT-Creation-Date: 2026-08-23 23:17+0200\n"
 "PO-Revision-Date: 2020-03-04 14:43+0100\n"
 "Last-Translator: Dévai Tamás <devait@vnet.hu>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -2138,6 +2138,10 @@ msgstr ""
 
 #: src/ExternalConn.cpp
 msgid "No such chat session"
+msgstr ""
+
+#: src/ExternalConn.cpp
+msgid "No such shared file, or it cannot be probed"
 msgstr ""
 
 #: src/ExternalConn.cpp
@@ -6976,6 +6980,13 @@ msgstr ""
 #, c-format
 msgid "No shareable files found in directory: %s"
 msgstr ""
+
+#: src/SharedFileList.cpp
+#, c-format
+msgid "Re-extracting media metadata for %u shared file"
+msgid_plural "Re-extracting media metadata for %u shared files"
+msgstr[0] ""
+msgstr[1] ""
 
 #: src/SharedFileList.cpp
 #, c-format

--- a/po/es.po
+++ b/po/es.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-23 22:15+0200\n"
+"POT-Creation-Date: 2026-08-23 23:17+0200\n"
 "PO-Revision-Date: 2026-08-22 15:26+0000\n"
 "Last-Translator: Diego Heras <ngosang@hotmail.es>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/amule/amule-application/es/>\n"
@@ -2191,6 +2191,10 @@ msgstr "Nueva sesión de chat iniciada"
 #, fuzzy
 msgid "No such chat session"
 msgstr "Cerrar esta sesión de chat."
+
+#: src/ExternalConn.cpp
+msgid "No such shared file, or it cannot be probed"
+msgstr ""
 
 #: src/ExternalConn.cpp
 msgid "Empty chat message"
@@ -7124,6 +7128,13 @@ msgstr "Directorio compartido no encontrado, se omite: %s"
 #, c-format
 msgid "No shareable files found in directory: %s"
 msgstr "No se han encontrado archivos para compartir en el directorio: %s"
+
+#: src/SharedFileList.cpp
+#, c-format
+msgid "Re-extracting media metadata for %u shared file"
+msgid_plural "Re-extracting media metadata for %u shared files"
+msgstr[0] ""
+msgstr[1] ""
 
 #: src/SharedFileList.cpp
 #, fuzzy, c-format

--- a/po/es.po
+++ b/po/es.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-23 23:17+0200\n"
+"POT-Creation-Date: 2026-08-23 23:41+0200\n"
 "PO-Revision-Date: 2026-08-22 15:26+0000\n"
 "Last-Translator: Diego Heras <ngosang@hotmail.es>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/amule/amule-application/es/>\n"
@@ -2193,7 +2193,7 @@ msgid "No such chat session"
 msgstr "Cerrar esta sesión de chat."
 
 #: src/ExternalConn.cpp
-msgid "No such shared file, or it cannot be probed"
+msgid "File is not eligible for media metadata extraction (not an audio/video file, or an incomplete download)"
 msgstr ""
 
 #: src/ExternalConn.cpp

--- a/po/et_EE.po
+++ b/po/et_EE.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-23 23:17+0200\n"
+"POT-Creation-Date: 2026-08-23 23:41+0200\n"
 "PO-Revision-Date: 2026-08-22 15:27+0000\n"
 "Last-Translator: \n"
 "Language-Team: Estonian <kde-i18n-doc@kde.org>\n"
@@ -2201,7 +2201,7 @@ msgid "No such chat session"
 msgstr "Sulge see vestlus-seanss."
 
 #: src/ExternalConn.cpp
-msgid "No such shared file, or it cannot be probed"
+msgid "File is not eligible for media metadata extraction (not an audio/video file, or an incomplete download)"
 msgstr ""
 
 #: src/ExternalConn.cpp

--- a/po/et_EE.po
+++ b/po/et_EE.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-23 22:15+0200\n"
+"POT-Creation-Date: 2026-08-23 23:17+0200\n"
 "PO-Revision-Date: 2026-08-22 15:27+0000\n"
 "Last-Translator: \n"
 "Language-Team: Estonian <kde-i18n-doc@kde.org>\n"
@@ -2199,6 +2199,10 @@ msgstr "Uus vestlussession alustatud"
 #, fuzzy
 msgid "No such chat session"
 msgstr "Sulge see vestlus-seanss."
+
+#: src/ExternalConn.cpp
+msgid "No such shared file, or it cannot be probed"
+msgstr ""
 
 #: src/ExternalConn.cpp
 msgid "Empty chat message"
@@ -7190,6 +7194,13 @@ msgstr "Jagatud kataloogi ei leitud, jätan vahele: %s"
 #, c-format
 msgid "No shareable files found in directory: %s"
 msgstr "Kataloogis '%s' pole jagatavaid faile"
+
+#: src/SharedFileList.cpp
+#, c-format
+msgid "Re-extracting media metadata for %u shared file"
+msgid_plural "Re-extracting media metadata for %u shared files"
+msgstr[0] ""
+msgstr[1] ""
 
 #: src/SharedFileList.cpp
 #, fuzzy, c-format

--- a/po/eu.po
+++ b/po/eu.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-23 22:15+0200\n"
+"POT-Creation-Date: 2026-08-23 23:17+0200\n"
 "PO-Revision-Date: 2026-08-22 15:28+0000\n"
 "Last-Translator: Piarres Beobide <pi@beobide.net>\n"
 "Language-Team: Euskara <librezale@librezale.org>\n"
@@ -2200,6 +2200,10 @@ msgstr "Elkarrizketa saio berria hasia"
 #, fuzzy
 msgid "No such chat session"
 msgstr "Itxi elkarrizketa saio hau."
+
+#: src/ExternalConn.cpp
+msgid "No such shared file, or it cannot be probed"
+msgstr ""
 
 #: src/ExternalConn.cpp
 msgid "Empty chat message"
@@ -7188,6 +7192,13 @@ msgstr "Partekatutako direktorioa ez da aurkitu, baztertzen: %s"
 #, c-format
 msgid "No shareable files found in directory: %s"
 msgstr "Ez da partekatu daitekeen fitxategirik direktorioan: %s"
+
+#: src/SharedFileList.cpp
+#, c-format
+msgid "Re-extracting media metadata for %u shared file"
+msgid_plural "Re-extracting media metadata for %u shared files"
+msgstr[0] ""
+msgstr[1] ""
 
 #: src/SharedFileList.cpp
 #, fuzzy, c-format

--- a/po/eu.po
+++ b/po/eu.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-23 23:17+0200\n"
+"POT-Creation-Date: 2026-08-23 23:41+0200\n"
 "PO-Revision-Date: 2026-08-22 15:28+0000\n"
 "Last-Translator: Piarres Beobide <pi@beobide.net>\n"
 "Language-Team: Euskara <librezale@librezale.org>\n"
@@ -2202,7 +2202,7 @@ msgid "No such chat session"
 msgstr "Itxi elkarrizketa saio hau."
 
 #: src/ExternalConn.cpp
-msgid "No such shared file, or it cannot be probed"
+msgid "File is not eligible for media metadata extraction (not an audio/video file, or an incomplete download)"
 msgstr ""
 
 #: src/ExternalConn.cpp

--- a/po/fi.po
+++ b/po/fi.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-23 22:15+0200\n"
+"POT-Creation-Date: 2026-08-23 23:17+0200\n"
 "PO-Revision-Date: 2026-08-22 15:29+0000\n"
 "Last-Translator: Tapio Rantala <tapio.rantala@iki.fi>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -2200,6 +2200,10 @@ msgstr "Uusi keskustelu aloitettu"
 #, fuzzy
 msgid "No such chat session"
 msgstr "Sulje tämä keskustelu."
+
+#: src/ExternalConn.cpp
+msgid "No such shared file, or it cannot be probed"
+msgstr ""
 
 #: src/ExternalConn.cpp
 msgid "Empty chat message"
@@ -7188,6 +7192,13 @@ msgstr "Jaettua kansiota ei löytynyt, hypätään yli: %s"
 #, c-format
 msgid "No shareable files found in directory: %s"
 msgstr "Jaettavia tiedostoja ei löytynyt kansiosta: %s"
+
+#: src/SharedFileList.cpp
+#, c-format
+msgid "Re-extracting media metadata for %u shared file"
+msgid_plural "Re-extracting media metadata for %u shared files"
+msgstr[0] ""
+msgstr[1] ""
 
 #: src/SharedFileList.cpp
 #, fuzzy, c-format

--- a/po/fi.po
+++ b/po/fi.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-23 23:17+0200\n"
+"POT-Creation-Date: 2026-08-23 23:41+0200\n"
 "PO-Revision-Date: 2026-08-22 15:29+0000\n"
 "Last-Translator: Tapio Rantala <tapio.rantala@iki.fi>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -2202,7 +2202,7 @@ msgid "No such chat session"
 msgstr "Sulje tämä keskustelu."
 
 #: src/ExternalConn.cpp
-msgid "No such shared file, or it cannot be probed"
+msgid "File is not eligible for media metadata extraction (not an audio/video file, or an incomplete download)"
 msgstr ""
 
 #: src/ExternalConn.cpp

--- a/po/fr.po
+++ b/po/fr.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-23 22:15+0200\n"
+"POT-Creation-Date: 2026-08-23 23:17+0200\n"
 "PO-Revision-Date: 2026-08-22 15:30+0000\n"
 "Last-Translator: Dylan Aïssi <bob.dybian@gmail.com>\n"
 "Language-Team: Français\n"
@@ -2190,6 +2190,10 @@ msgstr "Nouvelle session de chat démarrée"
 #, fuzzy
 msgid "No such chat session"
 msgstr "Ferme cette session de discussion."
+
+#: src/ExternalConn.cpp
+msgid "No such shared file, or it cannot be probed"
+msgstr ""
 
 #: src/ExternalConn.cpp
 msgid "Empty chat message"
@@ -7119,6 +7123,13 @@ msgstr "Répertoire partagé non trouvé, on passe : %s"
 #, c-format
 msgid "No shareable files found in directory: %s"
 msgstr "Aucun fichier partageable trouvé dans le répertoire : %s"
+
+#: src/SharedFileList.cpp
+#, c-format
+msgid "Re-extracting media metadata for %u shared file"
+msgid_plural "Re-extracting media metadata for %u shared files"
+msgstr[0] ""
+msgstr[1] ""
 
 #: src/SharedFileList.cpp
 #, fuzzy, c-format

--- a/po/fr.po
+++ b/po/fr.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-23 23:17+0200\n"
+"POT-Creation-Date: 2026-08-23 23:41+0200\n"
 "PO-Revision-Date: 2026-08-22 15:30+0000\n"
 "Last-Translator: Dylan Aïssi <bob.dybian@gmail.com>\n"
 "Language-Team: Français\n"
@@ -2192,7 +2192,7 @@ msgid "No such chat session"
 msgstr "Ferme cette session de discussion."
 
 #: src/ExternalConn.cpp
-msgid "No such shared file, or it cannot be probed"
+msgid "File is not eligible for media metadata extraction (not an audio/video file, or an incomplete download)"
 msgstr ""
 
 #: src/ExternalConn.cpp

--- a/po/gl.po
+++ b/po/gl.po
@@ -24,7 +24,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-23 22:15+0200\n"
+"POT-Creation-Date: 2026-08-23 23:17+0200\n"
 "PO-Revision-Date: 2026-08-22 15:31+0000\n"
 "Last-Translator: Pablo <parodper@gmail.com>\n"
 "Language-Team: http://forum.amule.org/index.php?topic=13883\n"
@@ -2217,6 +2217,10 @@ msgstr "Comezada nova sesión da conversa"
 #, fuzzy
 msgid "No such chat session"
 msgstr "Pechar esta conversa."
+
+#: src/ExternalConn.cpp
+msgid "No such shared file, or it cannot be probed"
+msgstr ""
 
 #: src/ExternalConn.cpp
 msgid "Empty chat message"
@@ -7194,6 +7198,13 @@ msgstr "Directorio compartido non atopado, saltando: %s"
 #, c-format
 msgid "No shareable files found in directory: %s"
 msgstr "Non se atoparon ficheiros que se puideran compartir: %s"
+
+#: src/SharedFileList.cpp
+#, c-format
+msgid "Re-extracting media metadata for %u shared file"
+msgid_plural "Re-extracting media metadata for %u shared files"
+msgstr[0] ""
+msgstr[1] ""
 
 #: src/SharedFileList.cpp
 #, fuzzy, c-format

--- a/po/gl.po
+++ b/po/gl.po
@@ -24,7 +24,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-23 23:17+0200\n"
+"POT-Creation-Date: 2026-08-23 23:41+0200\n"
 "PO-Revision-Date: 2026-08-22 15:31+0000\n"
 "Last-Translator: Pablo <parodper@gmail.com>\n"
 "Language-Team: http://forum.amule.org/index.php?topic=13883\n"
@@ -2219,7 +2219,7 @@ msgid "No such chat session"
 msgstr "Pechar esta conversa."
 
 #: src/ExternalConn.cpp
-msgid "No such shared file, or it cannot be probed"
+msgid "File is not eligible for media metadata extraction (not an audio/video file, or an incomplete download)"
 msgstr ""
 
 #: src/ExternalConn.cpp

--- a/po/he.po
+++ b/po/he.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-23 22:15+0200\n"
+"POT-Creation-Date: 2026-08-23 23:17+0200\n"
 "PO-Revision-Date: 2026-08-22 15:32+0000\n"
 "Last-Translator: Peace Kramer <kpeace1@gmail.com>\n"
 "Language-Team: Hebrew\n"
@@ -2195,6 +2195,10 @@ msgstr "צ'אט חדש החל."
 #, fuzzy
 msgid "No such chat session"
 msgstr "סגור את הצ'אט הנוכחי."
+
+#: src/ExternalConn.cpp
+msgid "No such shared file, or it cannot be probed"
+msgstr ""
 
 #: src/ExternalConn.cpp
 msgid "Empty chat message"
@@ -7157,6 +7161,13 @@ msgstr "לא נמצא השרת: %s"
 #, c-format
 msgid "No shareable files found in directory: %s"
 msgstr ""
+
+#: src/SharedFileList.cpp
+#, c-format
+msgid "Re-extracting media metadata for %u shared file"
+msgid_plural "Re-extracting media metadata for %u shared files"
+msgstr[0] ""
+msgstr[1] ""
 
 #: src/SharedFileList.cpp
 #, fuzzy, c-format

--- a/po/he.po
+++ b/po/he.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-23 23:17+0200\n"
+"POT-Creation-Date: 2026-08-23 23:41+0200\n"
 "PO-Revision-Date: 2026-08-22 15:32+0000\n"
 "Last-Translator: Peace Kramer <kpeace1@gmail.com>\n"
 "Language-Team: Hebrew\n"
@@ -2197,7 +2197,7 @@ msgid "No such chat session"
 msgstr "סגור את הצ'אט הנוכחי."
 
 #: src/ExternalConn.cpp
-msgid "No such shared file, or it cannot be probed"
+msgid "File is not eligible for media metadata extraction (not an audio/video file, or an incomplete download)"
 msgstr ""
 
 #: src/ExternalConn.cpp

--- a/po/hr.po
+++ b/po/hr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-23 23:17+0200\n"
+"POT-Creation-Date: 2026-08-23 23:41+0200\n"
 "PO-Revision-Date: 2026-08-22 15:32+0000\n"
 "Last-Translator: Sebastiano Pistore <sebastiano.pistore.info@aol.com>\n"
 "Language-Team: https://github.com/amule-org/amule <forum@aMule.org>\n"
@@ -2193,7 +2193,7 @@ msgid "No such chat session"
 msgstr ""
 
 #: src/ExternalConn.cpp
-msgid "No such shared file, or it cannot be probed"
+msgid "File is not eligible for media metadata extraction (not an audio/video file, or an incomplete download)"
 msgstr ""
 
 #: src/ExternalConn.cpp

--- a/po/hr.po
+++ b/po/hr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-23 22:15+0200\n"
+"POT-Creation-Date: 2026-08-23 23:17+0200\n"
 "PO-Revision-Date: 2026-08-22 15:32+0000\n"
 "Last-Translator: Sebastiano Pistore <sebastiano.pistore.info@aol.com>\n"
 "Language-Team: https://github.com/amule-org/amule <forum@aMule.org>\n"
@@ -2190,6 +2190,10 @@ msgstr ""
 
 #: src/ExternalConn.cpp
 msgid "No such chat session"
+msgstr ""
+
+#: src/ExternalConn.cpp
+msgid "No such shared file, or it cannot be probed"
 msgstr ""
 
 #: src/ExternalConn.cpp
@@ -7150,6 +7154,14 @@ msgstr ""
 #, c-format
 msgid "No shareable files found in directory: %s"
 msgstr ""
+
+#: src/SharedFileList.cpp
+#, c-format
+msgid "Re-extracting media metadata for %u shared file"
+msgid_plural "Re-extracting media metadata for %u shared files"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
 
 #: src/SharedFileList.cpp
 #, fuzzy, c-format

--- a/po/hu.po
+++ b/po/hu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-23 23:17+0200\n"
+"POT-Creation-Date: 2026-08-23 23:41+0200\n"
 "PO-Revision-Date: 2026-08-22 15:33+0000\n"
 "Last-Translator: Dévai Tamás <gonosztopi@amule.org>\n"
 "Language-Team: Hungarian <hu@li.org>\n"
@@ -2193,7 +2193,7 @@ msgid "No such chat session"
 msgstr "Csevegési folyamat bezárása."
 
 #: src/ExternalConn.cpp
-msgid "No such shared file, or it cannot be probed"
+msgid "File is not eligible for media metadata extraction (not an audio/video file, or an incomplete download)"
 msgstr ""
 
 #: src/ExternalConn.cpp

--- a/po/hu.po
+++ b/po/hu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-23 22:15+0200\n"
+"POT-Creation-Date: 2026-08-23 23:17+0200\n"
 "PO-Revision-Date: 2026-08-22 15:33+0000\n"
 "Last-Translator: Dévai Tamás <gonosztopi@amule.org>\n"
 "Language-Team: Hungarian <hu@li.org>\n"
@@ -2191,6 +2191,10 @@ msgstr "Új beszélgetés kezdődött"
 #, fuzzy
 msgid "No such chat session"
 msgstr "Csevegési folyamat bezárása."
+
+#: src/ExternalConn.cpp
+msgid "No such shared file, or it cannot be probed"
+msgstr ""
 
 #: src/ExternalConn.cpp
 msgid "Empty chat message"
@@ -7151,6 +7155,12 @@ msgstr "Megosztott könyvtár nem található, mellőzve: %s"
 #, c-format
 msgid "No shareable files found in directory: %s"
 msgstr "Nincsen megosztott fájl ebben a könyvtárban: %s"
+
+#: src/SharedFileList.cpp
+#, c-format
+msgid "Re-extracting media metadata for %u shared file"
+msgid_plural "Re-extracting media metadata for %u shared files"
+msgstr[0] ""
 
 #: src/SharedFileList.cpp
 #, fuzzy, c-format

--- a/po/it.po
+++ b/po/it.po
@@ -19,7 +19,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule 2.3.3\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-23 22:15+0200\n"
+"POT-Creation-Date: 2026-08-23 23:17+0200\n"
 "PO-Revision-Date: 2026-08-22 15:34+0000\n"
 "Last-Translator: got3nks <got3nks@users.noreply.github.com>\n"
 "Language-Team: SebastianoPistore.info@protonmail.ch\n"
@@ -2197,6 +2197,10 @@ msgstr "Nuova sessione chat iniziata"
 #, fuzzy
 msgid "No such chat session"
 msgstr "Chiude questa sessione di chat."
+
+#: src/ExternalConn.cpp
+msgid "No such shared file, or it cannot be probed"
+msgstr ""
 
 #: src/ExternalConn.cpp
 msgid "Empty chat message"
@@ -7126,6 +7130,13 @@ msgstr "Cartella condivisa non trovata, ignoro: %s"
 #, c-format
 msgid "No shareable files found in directory: %s"
 msgstr "Nessun file condivisibile trovato nella cartella: %s"
+
+#: src/SharedFileList.cpp
+#, c-format
+msgid "Re-extracting media metadata for %u shared file"
+msgid_plural "Re-extracting media metadata for %u shared files"
+msgstr[0] ""
+msgstr[1] ""
 
 #: src/SharedFileList.cpp
 #, fuzzy, c-format

--- a/po/it.po
+++ b/po/it.po
@@ -19,7 +19,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule 2.3.3\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-23 23:17+0200\n"
+"POT-Creation-Date: 2026-08-23 23:41+0200\n"
 "PO-Revision-Date: 2026-08-22 15:34+0000\n"
 "Last-Translator: got3nks <got3nks@users.noreply.github.com>\n"
 "Language-Team: SebastianoPistore.info@protonmail.ch\n"
@@ -2199,7 +2199,7 @@ msgid "No such chat session"
 msgstr "Chiude questa sessione di chat."
 
 #: src/ExternalConn.cpp
-msgid "No such shared file, or it cannot be probed"
+msgid "File is not eligible for media metadata extraction (not an audio/video file, or an incomplete download)"
 msgstr ""
 
 #: src/ExternalConn.cpp

--- a/po/ja.po
+++ b/po/ja.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-23 23:17+0200\n"
+"POT-Creation-Date: 2026-08-23 23:41+0200\n"
 "PO-Revision-Date: 2026-08-22 15:35+0000\n"
 "Last-Translator: \n"
 "Language-Team: Japanese\n"
@@ -2204,7 +2204,7 @@ msgid "No such chat session"
 msgstr "チャット・セションを閉じます。"
 
 #: src/ExternalConn.cpp
-msgid "No such shared file, or it cannot be probed"
+msgid "File is not eligible for media metadata extraction (not an audio/video file, or an incomplete download)"
 msgstr ""
 
 #: src/ExternalConn.cpp

--- a/po/ja.po
+++ b/po/ja.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-23 22:15+0200\n"
+"POT-Creation-Date: 2026-08-23 23:17+0200\n"
 "PO-Revision-Date: 2026-08-22 15:35+0000\n"
 "Last-Translator: \n"
 "Language-Team: Japanese\n"
@@ -2202,6 +2202,10 @@ msgstr "新しいチャットセッションの開始"
 #, fuzzy
 msgid "No such chat session"
 msgstr "チャット・セションを閉じます。"
+
+#: src/ExternalConn.cpp
+msgid "No such shared file, or it cannot be probed"
+msgstr ""
 
 #: src/ExternalConn.cpp
 msgid "Empty chat message"
@@ -7181,6 +7185,12 @@ msgstr "サーバは見付かりませんでした： %s"
 #, c-format
 msgid "No shareable files found in directory: %s"
 msgstr ""
+
+#: src/SharedFileList.cpp
+#, c-format
+msgid "Re-extracting media metadata for %u shared file"
+msgid_plural "Re-extracting media metadata for %u shared files"
+msgstr[0] ""
 
 #: src/SharedFileList.cpp
 #, fuzzy, c-format

--- a/po/ko_KR.po
+++ b/po/ko_KR.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-23 23:17+0200\n"
+"POT-Creation-Date: 2026-08-23 23:41+0200\n"
 "PO-Revision-Date: 2026-08-22 15:36+0000\n"
 "Last-Translator: Hyunju Kang <rexington@gmail.com>\n"
 "Language-Team: Korean <hoenny@daum.net>\n"
@@ -2215,7 +2215,7 @@ msgid "No such chat session"
 msgstr "이 채팅세션을 닫습니다."
 
 #: src/ExternalConn.cpp
-msgid "No such shared file, or it cannot be probed"
+msgid "File is not eligible for media metadata extraction (not an audio/video file, or an incomplete download)"
 msgstr ""
 
 #: src/ExternalConn.cpp

--- a/po/ko_KR.po
+++ b/po/ko_KR.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-23 22:15+0200\n"
+"POT-Creation-Date: 2026-08-23 23:17+0200\n"
 "PO-Revision-Date: 2026-08-22 15:36+0000\n"
 "Last-Translator: Hyunju Kang <rexington@gmail.com>\n"
 "Language-Team: Korean <hoenny@daum.net>\n"
@@ -2213,6 +2213,10 @@ msgstr "프로토콜 버젼 태그 없음"
 #, fuzzy
 msgid "No such chat session"
 msgstr "이 채팅세션을 닫습니다."
+
+#: src/ExternalConn.cpp
+msgid "No such shared file, or it cannot be probed"
+msgstr ""
 
 #: src/ExternalConn.cpp
 msgid "Empty chat message"
@@ -7231,6 +7235,13 @@ msgstr "서버가 발견되지 않음: %s"
 #, c-format
 msgid "No shareable files found in directory: %s"
 msgstr ""
+
+#: src/SharedFileList.cpp
+#, c-format
+msgid "Re-extracting media metadata for %u shared file"
+msgid_plural "Re-extracting media metadata for %u shared files"
+msgstr[0] ""
+msgstr[1] ""
 
 #: src/SharedFileList.cpp
 #, fuzzy, c-format

--- a/po/lt.po
+++ b/po/lt.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-23 22:15+0200\n"
+"POT-Creation-Date: 2026-08-23 23:17+0200\n"
 "PO-Revision-Date: 2026-08-22 15:37+0000\n"
 "Last-Translator: Dovydas Sankauskas <laisve@gmail.com>\n"
 "Language-Team: Lithuanian <komp_lt@konf.lt>\n"
@@ -2223,6 +2223,10 @@ msgstr "Pradėtas naujas pokalbis"
 #, fuzzy
 msgid "No such chat session"
 msgstr "Baigti pokalbį ir užverti pokalbio kortelę."
+
+#: src/ExternalConn.cpp
+msgid "No such shared file, or it cannot be probed"
+msgstr ""
 
 #: src/ExternalConn.cpp
 msgid "Empty chat message"
@@ -7257,6 +7261,14 @@ msgstr "serveris nerastas: %s"
 #, c-format
 msgid "No shareable files found in directory: %s"
 msgstr ""
+
+#: src/SharedFileList.cpp
+#, c-format
+msgid "Re-extracting media metadata for %u shared file"
+msgid_plural "Re-extracting media metadata for %u shared files"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
 
 #: src/SharedFileList.cpp
 #, fuzzy, c-format

--- a/po/lt.po
+++ b/po/lt.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-23 23:17+0200\n"
+"POT-Creation-Date: 2026-08-23 23:41+0200\n"
 "PO-Revision-Date: 2026-08-22 15:37+0000\n"
 "Last-Translator: Dovydas Sankauskas <laisve@gmail.com>\n"
 "Language-Team: Lithuanian <komp_lt@konf.lt>\n"
@@ -2225,7 +2225,7 @@ msgid "No such chat session"
 msgstr "Baigti pokalbį ir užverti pokalbio kortelę."
 
 #: src/ExternalConn.cpp
-msgid "No such shared file, or it cannot be probed"
+msgid "File is not eligible for media metadata extraction (not an audio/video file, or an incomplete download)"
 msgstr ""
 
 #: src/ExternalConn.cpp

--- a/po/lv.po
+++ b/po/lv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-23 22:15+0200\n"
+"POT-Creation-Date: 2026-08-23 23:17+0200\n"
 "PO-Revision-Date: 2026-08-22 15:53+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -2157,6 +2157,10 @@ msgstr "Trūkst protokola versijas birka."
 
 #: src/ExternalConn.cpp
 msgid "No such chat session"
+msgstr ""
+
+#: src/ExternalConn.cpp
+msgid "No such shared file, or it cannot be probed"
 msgstr ""
 
 #: src/ExternalConn.cpp
@@ -7023,6 +7027,14 @@ msgstr ""
 #, c-format
 msgid "No shareable files found in directory: %s"
 msgstr ""
+
+#: src/SharedFileList.cpp
+#, c-format
+msgid "Re-extracting media metadata for %u shared file"
+msgid_plural "Re-extracting media metadata for %u shared files"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
 
 #: src/SharedFileList.cpp
 #, fuzzy, c-format

--- a/po/lv.po
+++ b/po/lv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-23 23:17+0200\n"
+"POT-Creation-Date: 2026-08-23 23:41+0200\n"
 "PO-Revision-Date: 2026-08-22 15:53+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -2160,7 +2160,7 @@ msgid "No such chat session"
 msgstr ""
 
 #: src/ExternalConn.cpp
-msgid "No such shared file, or it cannot be probed"
+msgid "File is not eligible for media metadata extraction (not an audio/video file, or an incomplete download)"
 msgstr ""
 
 #: src/ExternalConn.cpp

--- a/po/nl.po
+++ b/po/nl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-23 22:15+0200\n"
+"POT-Creation-Date: 2026-08-23 23:17+0200\n"
 "PO-Revision-Date: 2026-08-22 15:38+0000\n"
 "Last-Translator: Marcel Pol <marcel@timelord.nl>\n"
 "Language-Team: Dutch <nl@li.org>\n"
@@ -2187,6 +2187,10 @@ msgstr "Nieuwe chatsessie begonnen"
 #, fuzzy
 msgid "No such chat session"
 msgstr "Sluit deze chat-sessie."
+
+#: src/ExternalConn.cpp
+msgid "No such shared file, or it cannot be probed"
+msgstr ""
 
 #: src/ExternalConn.cpp
 msgid "Empty chat message"
@@ -7117,6 +7121,13 @@ msgstr "Gedeelde map niet gevonden, wordt overgeslagen: %s"
 #, c-format
 msgid "No shareable files found in directory: %s"
 msgstr "Geen deelbare bestanden gevonden in map: %s"
+
+#: src/SharedFileList.cpp
+#, c-format
+msgid "Re-extracting media metadata for %u shared file"
+msgid_plural "Re-extracting media metadata for %u shared files"
+msgstr[0] ""
+msgstr[1] ""
 
 #: src/SharedFileList.cpp
 #, fuzzy, c-format

--- a/po/nl.po
+++ b/po/nl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-23 23:17+0200\n"
+"POT-Creation-Date: 2026-08-23 23:41+0200\n"
 "PO-Revision-Date: 2026-08-22 15:38+0000\n"
 "Last-Translator: Marcel Pol <marcel@timelord.nl>\n"
 "Language-Team: Dutch <nl@li.org>\n"
@@ -2189,7 +2189,7 @@ msgid "No such chat session"
 msgstr "Sluit deze chat-sessie."
 
 #: src/ExternalConn.cpp
-msgid "No such shared file, or it cannot be probed"
+msgid "File is not eligible for media metadata extraction (not an audio/video file, or an incomplete download)"
 msgstr ""
 
 #: src/ExternalConn.cpp

--- a/po/nn.po
+++ b/po/nn.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-23 23:17+0200\n"
+"POT-Creation-Date: 2026-08-23 23:41+0200\n"
 "PO-Revision-Date: 2026-08-22 15:39+0000\n"
 "Last-Translator: Hallvor Brunstad <Hallvor_1976@yahoo.com>\n"
 "Language-Team: <i18n-nn@lister.ping.uio.no>\n"
@@ -2216,7 +2216,7 @@ msgid "No such chat session"
 msgstr "Stengje denne lynmeldingsøkta."
 
 #: src/ExternalConn.cpp
-msgid "No such shared file, or it cannot be probed"
+msgid "File is not eligible for media metadata extraction (not an audio/video file, or an incomplete download)"
 msgstr ""
 
 #: src/ExternalConn.cpp

--- a/po/nn.po
+++ b/po/nn.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-23 22:15+0200\n"
+"POT-Creation-Date: 2026-08-23 23:17+0200\n"
 "PO-Revision-Date: 2026-08-22 15:39+0000\n"
 "Last-Translator: Hallvor Brunstad <Hallvor_1976@yahoo.com>\n"
 "Language-Team: <i18n-nn@lister.ping.uio.no>\n"
@@ -2214,6 +2214,10 @@ msgstr "Ny lynmeldingsøkt starta"
 #, fuzzy
 msgid "No such chat session"
 msgstr "Stengje denne lynmeldingsøkta."
+
+#: src/ExternalConn.cpp
+msgid "No such shared file, or it cannot be probed"
+msgstr ""
 
 #: src/ExternalConn.cpp
 msgid "Empty chat message"
@@ -7225,6 +7229,13 @@ msgstr "tenar ikkje funnen: %s"
 #, c-format
 msgid "No shareable files found in directory: %s"
 msgstr ""
+
+#: src/SharedFileList.cpp
+#, c-format
+msgid "Re-extracting media metadata for %u shared file"
+msgid_plural "Re-extracting media metadata for %u shared files"
+msgstr[0] ""
+msgstr[1] ""
 
 #: src/SharedFileList.cpp
 #, fuzzy, c-format

--- a/po/pl.po
+++ b/po/pl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-23 22:15+0200\n"
+"POT-Creation-Date: 2026-08-23 23:17+0200\n"
 "PO-Revision-Date: 2026-08-22 15:39+0000\n"
 "Last-Translator: Michał Trzebiatowski <hippie_1968@hotmail.com>\n"
 "Language-Team: translationproject.org/team/pl.html <translation-team-pl@lists.sourceforge.net>\n"
@@ -2209,6 +2209,10 @@ msgstr "Rozpoczęto nową sesję czatu"
 #, fuzzy
 msgid "No such chat session"
 msgstr "Zamknij tę sesję czata."
+
+#: src/ExternalConn.cpp
+msgid "No such shared file, or it cannot be probed"
+msgstr ""
 
 #: src/ExternalConn.cpp
 msgid "Empty chat message"
@@ -7232,6 +7236,14 @@ msgstr "Nie znaleziono katalogu udostępnionego, pomijam: %s"
 #, c-format
 msgid "No shareable files found in directory: %s"
 msgstr "Nie znaleziono plików do udostępniania w katalogu: %s"
+
+#: src/SharedFileList.cpp
+#, c-format
+msgid "Re-extracting media metadata for %u shared file"
+msgid_plural "Re-extracting media metadata for %u shared files"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
 
 #: src/SharedFileList.cpp
 #, fuzzy, c-format

--- a/po/pl.po
+++ b/po/pl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-23 23:17+0200\n"
+"POT-Creation-Date: 2026-08-23 23:41+0200\n"
 "PO-Revision-Date: 2026-08-22 15:39+0000\n"
 "Last-Translator: Michał Trzebiatowski <hippie_1968@hotmail.com>\n"
 "Language-Team: translationproject.org/team/pl.html <translation-team-pl@lists.sourceforge.net>\n"
@@ -2211,7 +2211,7 @@ msgid "No such chat session"
 msgstr "Zamknij tę sesję czata."
 
 #: src/ExternalConn.cpp
-msgid "No such shared file, or it cannot be probed"
+msgid "File is not eligible for media metadata extraction (not an audio/video file, or an incomplete download)"
 msgstr ""
 
 #: src/ExternalConn.cpp

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-23 22:15+0200\n"
+"POT-Creation-Date: 2026-08-23 23:17+0200\n"
 "PO-Revision-Date: 2026-08-22 15:41+0000\n"
 "Last-Translator: Marcelo Jimenez <mroberto@users.sourceforge.com>\n"
 "Language-Team: Português (Brasileiro) <pt@li.org>\n"
@@ -2191,6 +2191,10 @@ msgstr "Nova sessão de chat iniciada"
 #, fuzzy
 msgid "No such chat session"
 msgstr "Encerrar sessão de Chat."
+
+#: src/ExternalConn.cpp
+msgid "No such shared file, or it cannot be probed"
+msgstr ""
 
 #: src/ExternalConn.cpp
 msgid "Empty chat message"
@@ -7120,6 +7124,13 @@ msgstr "Diretório compartilhado não encontrado, pulando: %s"
 #, c-format
 msgid "No shareable files found in directory: %s"
 msgstr "Arquivos compartilháveis não encontrado no diretório: %s"
+
+#: src/SharedFileList.cpp
+#, c-format
+msgid "Re-extracting media metadata for %u shared file"
+msgid_plural "Re-extracting media metadata for %u shared files"
+msgstr[0] ""
+msgstr[1] ""
 
 #: src/SharedFileList.cpp
 #, fuzzy, c-format

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-23 23:17+0200\n"
+"POT-Creation-Date: 2026-08-23 23:41+0200\n"
 "PO-Revision-Date: 2026-08-22 15:41+0000\n"
 "Last-Translator: Marcelo Jimenez <mroberto@users.sourceforge.com>\n"
 "Language-Team: Português (Brasileiro) <pt@li.org>\n"
@@ -2193,7 +2193,7 @@ msgid "No such chat session"
 msgstr "Encerrar sessão de Chat."
 
 #: src/ExternalConn.cpp
-msgid "No such shared file, or it cannot be probed"
+msgid "File is not eligible for media metadata extraction (not an audio/video file, or an incomplete download)"
 msgstr ""
 
 #: src/ExternalConn.cpp

--- a/po/pt_PT.po
+++ b/po/pt_PT.po
@@ -17,7 +17,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-23 23:17+0200\n"
+"POT-Creation-Date: 2026-08-23 23:41+0200\n"
 "PO-Revision-Date: 2026-08-22 15:42+0000\n"
 "Last-Translator: Luís Picciochi Oliveira <Pitxyoki@Gmail.com>\n"
 "Language-Team: Portuguese <traduz@debianpt.org>\n"
@@ -2208,7 +2208,7 @@ msgid "No such chat session"
 msgstr "Fechar esta conversa."
 
 #: src/ExternalConn.cpp
-msgid "No such shared file, or it cannot be probed"
+msgid "File is not eligible for media metadata extraction (not an audio/video file, or an incomplete download)"
 msgstr ""
 
 #: src/ExternalConn.cpp

--- a/po/pt_PT.po
+++ b/po/pt_PT.po
@@ -17,7 +17,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-23 22:15+0200\n"
+"POT-Creation-Date: 2026-08-23 23:17+0200\n"
 "PO-Revision-Date: 2026-08-22 15:42+0000\n"
 "Last-Translator: Luís Picciochi Oliveira <Pitxyoki@Gmail.com>\n"
 "Language-Team: Portuguese <traduz@debianpt.org>\n"
@@ -2206,6 +2206,10 @@ msgstr "Nova sessão de conversa iniciada"
 #, fuzzy
 msgid "No such chat session"
 msgstr "Fechar esta conversa."
+
+#: src/ExternalConn.cpp
+msgid "No such shared file, or it cannot be probed"
+msgstr ""
 
 #: src/ExternalConn.cpp
 msgid "Empty chat message"
@@ -7196,6 +7200,13 @@ msgstr "Pasta partilhada não encontrada, a ignorar: %s"
 #, c-format
 msgid "No shareable files found in directory: %s"
 msgstr "Não foram encontrados ficheiros partilhados no directório: %s"
+
+#: src/SharedFileList.cpp
+#, c-format
+msgid "Re-extracting media metadata for %u shared file"
+msgid_plural "Re-extracting media metadata for %u shared files"
+msgstr[0] ""
+msgstr[1] ""
 
 #: src/SharedFileList.cpp
 #, fuzzy, c-format

--- a/po/ro.po
+++ b/po/ro.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-23 23:17+0200\n"
+"POT-Creation-Date: 2026-08-23 23:41+0200\n"
 "PO-Revision-Date: 2026-08-22 15:42+0000\n"
 "Last-Translator: Angelescu Constantin <titus0818@yahoo.com>\n"
 "Language-Team: English <kde-i18n-doc@kde.org>\n"
@@ -2208,7 +2208,7 @@ msgid "No such chat session"
 msgstr "Închide această sesiune de chat."
 
 #: src/ExternalConn.cpp
-msgid "No such shared file, or it cannot be probed"
+msgid "File is not eligible for media metadata extraction (not an audio/video file, or an incomplete download)"
 msgstr ""
 
 #: src/ExternalConn.cpp

--- a/po/ro.po
+++ b/po/ro.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-23 22:15+0200\n"
+"POT-Creation-Date: 2026-08-23 23:17+0200\n"
 "PO-Revision-Date: 2026-08-22 15:42+0000\n"
 "Last-Translator: Angelescu Constantin <titus0818@yahoo.com>\n"
 "Language-Team: English <kde-i18n-doc@kde.org>\n"
@@ -2206,6 +2206,10 @@ msgstr "O nouă sesiune chat este pornită"
 #, fuzzy
 msgid "No such chat session"
 msgstr "Închide această sesiune de chat."
+
+#: src/ExternalConn.cpp
+msgid "No such shared file, or it cannot be probed"
+msgstr ""
 
 #: src/ExternalConn.cpp
 msgid "Empty chat message"
@@ -7213,6 +7217,14 @@ msgstr "Directorul partajat nu a fost găsit, se omite: %s"
 #, c-format
 msgid "No shareable files found in directory: %s"
 msgstr "Nu au fost găsite fișiere partajabile în directorul: %s"
+
+#: src/SharedFileList.cpp
+#, c-format
+msgid "Re-extracting media metadata for %u shared file"
+msgid_plural "Re-extracting media metadata for %u shared files"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
 
 #: src/SharedFileList.cpp
 #, fuzzy, c-format

--- a/po/ru.po
+++ b/po/ru.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-23 22:15+0200\n"
+"POT-Creation-Date: 2026-08-23 23:17+0200\n"
 "PO-Revision-Date: 2026-08-22 15:44+0000\n"
 "Last-Translator: Radist Morse <radist.morse@gmail.com>\n"
 "Language-Team: Russian <kde-russian@lists.kde.ru>\n"
@@ -2207,6 +2207,10 @@ msgstr "Начата новая беседа"
 #, fuzzy
 msgid "No such chat session"
 msgstr "Закрыть данный чат."
+
+#: src/ExternalConn.cpp
+msgid "No such shared file, or it cannot be probed"
+msgstr ""
 
 #: src/ExternalConn.cpp
 msgid "Empty chat message"
@@ -7180,6 +7184,14 @@ msgstr "Публикуемая директория не найдена, про�
 #, c-format
 msgid "No shareable files found in directory: %s"
 msgstr "Нет публикуемых файлов в директории: %s"
+
+#: src/SharedFileList.cpp
+#, c-format
+msgid "Re-extracting media metadata for %u shared file"
+msgid_plural "Re-extracting media metadata for %u shared files"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
 
 #: src/SharedFileList.cpp
 #, fuzzy, c-format

--- a/po/ru.po
+++ b/po/ru.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-23 23:17+0200\n"
+"POT-Creation-Date: 2026-08-23 23:41+0200\n"
 "PO-Revision-Date: 2026-08-22 15:44+0000\n"
 "Last-Translator: Radist Morse <radist.morse@gmail.com>\n"
 "Language-Team: Russian <kde-russian@lists.kde.ru>\n"
@@ -2209,7 +2209,7 @@ msgid "No such chat session"
 msgstr "Закрыть данный чат."
 
 #: src/ExternalConn.cpp
-msgid "No such shared file, or it cannot be probed"
+msgid "File is not eligible for media metadata extraction (not an audio/video file, or an incomplete download)"
 msgstr ""
 
 #: src/ExternalConn.cpp

--- a/po/sl.po
+++ b/po/sl.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-23 23:17+0200\n"
+"POT-Creation-Date: 2026-08-23 23:41+0200\n"
 "PO-Revision-Date: 2026-08-22 15:45+0000\n"
 "Last-Translator: Jure Repinc <jlp@holodeck1.com>\n"
 "Language-Team: Slovenian\n"
@@ -2222,7 +2222,7 @@ msgid "No such chat session"
 msgstr "Zapri to pogovorno sejo."
 
 #: src/ExternalConn.cpp
-msgid "No such shared file, or it cannot be probed"
+msgid "File is not eligible for media metadata extraction (not an audio/video file, or an incomplete download)"
 msgstr ""
 
 #: src/ExternalConn.cpp

--- a/po/sl.po
+++ b/po/sl.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-23 22:15+0200\n"
+"POT-Creation-Date: 2026-08-23 23:17+0200\n"
 "PO-Revision-Date: 2026-08-22 15:45+0000\n"
 "Last-Translator: Jure Repinc <jlp@holodeck1.com>\n"
 "Language-Team: Slovenian\n"
@@ -2220,6 +2220,10 @@ msgstr "Začeta je bila nova seja klepeta."
 #, fuzzy
 msgid "No such chat session"
 msgstr "Zapri to pogovorno sejo."
+
+#: src/ExternalConn.cpp
+msgid "No such shared file, or it cannot be probed"
+msgstr ""
 
 #: src/ExternalConn.cpp
 msgid "Empty chat message"
@@ -7257,6 +7261,15 @@ msgstr "Deljene mape ni bilo moč najti, preskakujem: %s"
 #, c-format
 msgid "No shareable files found in directory: %s"
 msgstr "V mapi ni bilo moč najti datotek za deliti: %s"
+
+#: src/SharedFileList.cpp
+#, c-format
+msgid "Re-extracting media metadata for %u shared file"
+msgid_plural "Re-extracting media metadata for %u shared files"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+msgstr[3] ""
 
 #: src/SharedFileList.cpp
 #, fuzzy, c-format

--- a/po/sq.po
+++ b/po/sq.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-23 23:17+0200\n"
+"POT-Creation-Date: 2026-08-23 23:41+0200\n"
 "PO-Revision-Date: 2026-08-22 15:45+0000\n"
 "Last-Translator: Fation <dj_barthezz@linuxmail.org lushnja_corps@hotmail.Language-Team:\n"
 "Language: sq\n"
@@ -2211,7 +2211,7 @@ msgid "No such chat session"
 msgstr "Mbylle kete sesion chati."
 
 #: src/ExternalConn.cpp
-msgid "No such shared file, or it cannot be probed"
+msgid "File is not eligible for media metadata extraction (not an audio/video file, or an incomplete download)"
 msgstr ""
 
 #: src/ExternalConn.cpp

--- a/po/sq.po
+++ b/po/sq.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-23 22:15+0200\n"
+"POT-Creation-Date: 2026-08-23 23:17+0200\n"
 "PO-Revision-Date: 2026-08-22 15:45+0000\n"
 "Last-Translator: Fation <dj_barthezz@linuxmail.org lushnja_corps@hotmail.Language-Team:\n"
 "Language: sq\n"
@@ -2209,6 +2209,10 @@ msgstr "Sesion i ri chati filloi"
 #, fuzzy
 msgid "No such chat session"
 msgstr "Mbylle kete sesion chati."
+
+#: src/ExternalConn.cpp
+msgid "No such shared file, or it cannot be probed"
+msgstr ""
 
 #: src/ExternalConn.cpp
 msgid "Empty chat message"
@@ -7215,6 +7219,13 @@ msgstr "Serveri nuk u gjend: %s"
 #, c-format
 msgid "No shareable files found in directory: %s"
 msgstr ""
+
+#: src/SharedFileList.cpp
+#, c-format
+msgid "Re-extracting media metadata for %u shared file"
+msgid_plural "Re-extracting media metadata for %u shared files"
+msgstr[0] ""
+msgstr[1] ""
 
 #: src/SharedFileList.cpp
 #, fuzzy, c-format

--- a/po/sv.po
+++ b/po/sv.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-23 22:15+0200\n"
+"POT-Creation-Date: 2026-08-23 23:17+0200\n"
 "PO-Revision-Date: 2026-08-22 15:46+0000\n"
 "Last-Translator: raffe <raffe@localhost.se>\n"
 "Language-Team: Swedish <tp-sv@listor.tp-sv.se>\n"
@@ -2198,6 +2198,10 @@ msgstr "Ny chatt startad"
 #, fuzzy
 msgid "No such chat session"
 msgstr "Stäng denna chat-session."
+
+#: src/ExternalConn.cpp
+msgid "No such shared file, or it cannot be probed"
+msgstr ""
 
 #: src/ExternalConn.cpp
 msgid "Empty chat message"
@@ -7183,6 +7187,13 @@ msgstr "Delad mapp hittades inte, hoppar över: %s"
 #, c-format
 msgid "No shareable files found in directory: %s"
 msgstr "Inga delbara filer hittade i mappen: %s"
+
+#: src/SharedFileList.cpp
+#, c-format
+msgid "Re-extracting media metadata for %u shared file"
+msgid_plural "Re-extracting media metadata for %u shared files"
+msgstr[0] ""
+msgstr[1] ""
 
 #: src/SharedFileList.cpp
 #, fuzzy, c-format

--- a/po/sv.po
+++ b/po/sv.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-23 23:17+0200\n"
+"POT-Creation-Date: 2026-08-23 23:41+0200\n"
 "PO-Revision-Date: 2026-08-22 15:46+0000\n"
 "Last-Translator: raffe <raffe@localhost.se>\n"
 "Language-Team: Swedish <tp-sv@listor.tp-sv.se>\n"
@@ -2200,7 +2200,7 @@ msgid "No such chat session"
 msgstr "Stäng denna chat-session."
 
 #: src/ExternalConn.cpp
-msgid "No such shared file, or it cannot be probed"
+msgid "File is not eligible for media metadata extraction (not an audio/video file, or an incomplete download)"
 msgstr ""
 
 #: src/ExternalConn.cpp

--- a/po/ta.po
+++ b/po/ta.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-23 22:15+0200\n"
+"POT-Creation-Date: 2026-08-23 23:17+0200\n"
 "PO-Revision-Date: 2026-08-22 15:54+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -2137,6 +2137,10 @@ msgstr ""
 
 #: src/ExternalConn.cpp
 msgid "No such chat session"
+msgstr ""
+
+#: src/ExternalConn.cpp
+msgid "No such shared file, or it cannot be probed"
 msgstr ""
 
 #: src/ExternalConn.cpp
@@ -6975,6 +6979,13 @@ msgstr ""
 #, c-format
 msgid "No shareable files found in directory: %s"
 msgstr ""
+
+#: src/SharedFileList.cpp
+#, c-format
+msgid "Re-extracting media metadata for %u shared file"
+msgid_plural "Re-extracting media metadata for %u shared files"
+msgstr[0] ""
+msgstr[1] ""
 
 #: src/SharedFileList.cpp
 #, c-format

--- a/po/ta.po
+++ b/po/ta.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-23 23:17+0200\n"
+"POT-Creation-Date: 2026-08-23 23:41+0200\n"
 "PO-Revision-Date: 2026-08-22 15:54+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -2140,7 +2140,7 @@ msgid "No such chat session"
 msgstr ""
 
 #: src/ExternalConn.cpp
-msgid "No such shared file, or it cannot be probed"
+msgid "File is not eligible for media metadata extraction (not an audio/video file, or an incomplete download)"
 msgstr ""
 
 #: src/ExternalConn.cpp

--- a/po/tr.po
+++ b/po/tr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-23 23:17+0200\n"
+"POT-Creation-Date: 2026-08-23 23:41+0200\n"
 "PO-Revision-Date: 2026-08-22 15:48+0000\n"
 "Last-Translator: \n"
 "Language-Team: Turkish <li@li.org>\n"
@@ -2185,7 +2185,7 @@ msgid "No such chat session"
 msgstr "Bu sohbet oturumunu kapatır."
 
 #: src/ExternalConn.cpp
-msgid "No such shared file, or it cannot be probed"
+msgid "File is not eligible for media metadata extraction (not an audio/video file, or an incomplete download)"
 msgstr ""
 
 #: src/ExternalConn.cpp

--- a/po/tr.po
+++ b/po/tr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-23 22:15+0200\n"
+"POT-Creation-Date: 2026-08-23 23:17+0200\n"
 "PO-Revision-Date: 2026-08-22 15:48+0000\n"
 "Last-Translator: \n"
 "Language-Team: Turkish <li@li.org>\n"
@@ -2183,6 +2183,10 @@ msgstr "Yeni sohbet oturumu başladı"
 #, fuzzy
 msgid "No such chat session"
 msgstr "Bu sohbet oturumunu kapatır."
+
+#: src/ExternalConn.cpp
+msgid "No such shared file, or it cannot be probed"
+msgstr ""
 
 #: src/ExternalConn.cpp
 msgid "Empty chat message"
@@ -7112,6 +7116,13 @@ msgstr "Paylaşılan dizin bulunamadı, atlanıyor: %s"
 #, c-format
 msgid "No shareable files found in directory: %s"
 msgstr "Dizinde paylaşılabilir dosya bulunamadı: %s"
+
+#: src/SharedFileList.cpp
+#, c-format
+msgid "Re-extracting media metadata for %u shared file"
+msgid_plural "Re-extracting media metadata for %u shared files"
+msgstr[0] ""
+msgstr[1] ""
 
 #: src/SharedFileList.cpp
 #, fuzzy, c-format

--- a/po/uk.po
+++ b/po/uk.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-23 23:17+0200\n"
+"POT-Creation-Date: 2026-08-23 23:41+0200\n"
 "PO-Revision-Date: 2026-08-22 15:48+0000\n"
 "Last-Translator: Oleksandr Kovalenko <alx.kovalenko@gmail.com>\n"
 "Language-Team: Ukrainian <translation@linux.org.ua>\n"
@@ -2221,7 +2221,7 @@ msgid "No such chat session"
 msgstr "Закрити цю розмову."
 
 #: src/ExternalConn.cpp
-msgid "No such shared file, or it cannot be probed"
+msgid "File is not eligible for media metadata extraction (not an audio/video file, or an incomplete download)"
 msgstr ""
 
 #: src/ExternalConn.cpp

--- a/po/uk.po
+++ b/po/uk.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-23 22:15+0200\n"
+"POT-Creation-Date: 2026-08-23 23:17+0200\n"
 "PO-Revision-Date: 2026-08-22 15:48+0000\n"
 "Last-Translator: Oleksandr Kovalenko <alx.kovalenko@gmail.com>\n"
 "Language-Team: Ukrainian <translation@linux.org.ua>\n"
@@ -2219,6 +2219,10 @@ msgstr "Розпочато нову розмову"
 #, fuzzy
 msgid "No such chat session"
 msgstr "Закрити цю розмову."
+
+#: src/ExternalConn.cpp
+msgid "No such shared file, or it cannot be probed"
+msgstr ""
 
 #: src/ExternalConn.cpp
 msgid "Empty chat message"
@@ -7257,6 +7261,14 @@ msgstr "Спільна тека не знайдена, пропускаємо: %
 #, c-format
 msgid "No shareable files found in directory: %s"
 msgstr "Не знайдені спільні файли в теці: %s"
+
+#: src/SharedFileList.cpp
+#, c-format
+msgid "Re-extracting media metadata for %u shared file"
+msgid_plural "Re-extracting media metadata for %u shared files"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
 
 #: src/SharedFileList.cpp
 #, fuzzy, c-format

--- a/po/vi.po
+++ b/po/vi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-23 23:17+0200\n"
+"POT-Creation-Date: 2026-08-23 23:41+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -2139,7 +2139,7 @@ msgid "No such chat session"
 msgstr ""
 
 #: src/ExternalConn.cpp
-msgid "No such shared file, or it cannot be probed"
+msgid "File is not eligible for media metadata extraction (not an audio/video file, or an incomplete download)"
 msgstr ""
 
 #: src/ExternalConn.cpp

--- a/po/vi.po
+++ b/po/vi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-23 22:15+0200\n"
+"POT-Creation-Date: 2026-08-23 23:17+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -2136,6 +2136,10 @@ msgstr ""
 
 #: src/ExternalConn.cpp
 msgid "No such chat session"
+msgstr ""
+
+#: src/ExternalConn.cpp
+msgid "No such shared file, or it cannot be probed"
 msgstr ""
 
 #: src/ExternalConn.cpp
@@ -6971,6 +6975,12 @@ msgstr ""
 #, c-format
 msgid "No shareable files found in directory: %s"
 msgstr ""
+
+#: src/SharedFileList.cpp
+#, c-format
+msgid "Re-extracting media metadata for %u shared file"
+msgid_plural "Re-extracting media metadata for %u shared files"
+msgstr[0] ""
 
 #: src/SharedFileList.cpp
 #, c-format

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-23 22:15+0200\n"
+"POT-Creation-Date: 2026-08-23 23:17+0200\n"
 "PO-Revision-Date: 2026-08-22 15:50+0000\n"
 "Last-Translator: Mike Akiba <mike2718@gmail.com>\n"
 "Language-Team: Chinese Simplified <kde-i18n-doc@kde.org>\n"
@@ -2187,6 +2187,10 @@ msgstr "新的聊天对话已启动"
 #, fuzzy
 msgid "No such chat session"
 msgstr "结束本次聊天。"
+
+#: src/ExternalConn.cpp
+msgid "No such shared file, or it cannot be probed"
+msgstr ""
 
 #: src/ExternalConn.cpp
 msgid "Empty chat message"
@@ -7116,6 +7120,13 @@ msgstr "找不到共享目录，跳过：%s"
 #, c-format
 msgid "No shareable files found in directory: %s"
 msgstr "在目录中没有找到可以共享的文件：%s"
+
+#: src/SharedFileList.cpp
+#, c-format
+msgid "Re-extracting media metadata for %u shared file"
+msgid_plural "Re-extracting media metadata for %u shared files"
+msgstr[0] ""
+msgstr[1] ""
 
 #: src/SharedFileList.cpp
 #, fuzzy, c-format

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-23 23:17+0200\n"
+"POT-Creation-Date: 2026-08-23 23:41+0200\n"
 "PO-Revision-Date: 2026-08-22 15:50+0000\n"
 "Last-Translator: Mike Akiba <mike2718@gmail.com>\n"
 "Language-Team: Chinese Simplified <kde-i18n-doc@kde.org>\n"
@@ -2189,7 +2189,7 @@ msgid "No such chat session"
 msgstr "结束本次聊天。"
 
 #: src/ExternalConn.cpp
-msgid "No such shared file, or it cannot be probed"
+msgid "File is not eligible for media metadata extraction (not an audio/video file, or an incomplete download)"
 msgstr ""
 
 #: src/ExternalConn.cpp

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-23 23:17+0200\n"
+"POT-Creation-Date: 2026-08-23 23:41+0200\n"
 "PO-Revision-Date: 2026-08-22 15:51+0000\n"
 "Last-Translator: Wayne Su <mstarmstar@gmail.com>\n"
 "Language-Team: \n"
@@ -2198,7 +2198,7 @@ msgid "No such chat session"
 msgstr "結束本次交談。"
 
 #: src/ExternalConn.cpp
-msgid "No such shared file, or it cannot be probed"
+msgid "File is not eligible for media metadata extraction (not an audio/video file, or an incomplete download)"
 msgstr ""
 
 #: src/ExternalConn.cpp

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-23 22:15+0200\n"
+"POT-Creation-Date: 2026-08-23 23:17+0200\n"
 "PO-Revision-Date: 2026-08-22 15:51+0000\n"
 "Last-Translator: Wayne Su <mstarmstar@gmail.com>\n"
 "Language-Team: \n"
@@ -2196,6 +2196,10 @@ msgstr "已開始新的交談"
 #, fuzzy
 msgid "No such chat session"
 msgstr "結束本次交談。"
+
+#: src/ExternalConn.cpp
+msgid "No such shared file, or it cannot be probed"
+msgstr ""
 
 #: src/ExternalConn.cpp
 msgid "Empty chat message"
@@ -7161,6 +7165,12 @@ msgstr "找不到分享目錄，略過：%s"
 #, c-format
 msgid "No shareable files found in directory: %s"
 msgstr "目錄中找不到可分享的檔案：%s"
+
+#: src/SharedFileList.cpp
+#, c-format
+msgid "Re-extracting media metadata for %u shared file"
+msgid_plural "Re-extracting media metadata for %u shared files"
+msgstr[0] ""
 
 #: src/SharedFileList.cpp
 #, fuzzy, c-format

--- a/src/ExternalConn.cpp
+++ b/src/ExternalConn.cpp
@@ -4279,6 +4279,28 @@ CECPacket *CECServerSocket::ProcessRequest2(const CECPacket *request)
 		response->AddTag(EncodeChatSession(*session, ChatCursorFrom(request)));
 		break;
 	}
+	case EC_OP_REFRESH_MEDIA_METADATA: {
+		// Re-extract media metadata: for one file when the request names a
+		// hash, otherwise for the whole share. Answers immediately with how
+		// many probes were queued -- the work happens on the media-probe
+		// worker, so a large library does not block this EC lane.
+		unsigned queued = 0;
+		if (const CECTag *hashTag = request->GetTagByName(EC_TAG_KNOWNFILE)) {
+			const CMD4Hash hash = hashTag->GetMD4Data();
+			if (!theApp->sharedfiles->RefreshMediaMetadata(hash)) {
+				response = new CECPacket(EC_OP_FAILED);
+				response->AddTag(CECTag(EC_TAG_STRING,
+					wxTRANSLATE("No such shared file, or it cannot be probed")));
+				break;
+			}
+			queued = 1;
+		} else {
+			queued = theApp->sharedfiles->RefreshAllMediaMetadata();
+		}
+		response = new CECPacket(EC_OP_NOOP);
+		response->AddTag(CECTag(EC_TAG_KNOWNFILE_MEDIA_QUEUED, static_cast<uint32>(queued)));
+		break;
+	}
 	case EC_OP_GET_CHAT_SESSIONS: {
 		// The per-tick workhorse: the session list AND every message newer
 		// than the client's cursor in one roundtrip, so an idle connection

--- a/src/ExternalConn.cpp
+++ b/src/ExternalConn.cpp
@@ -4288,9 +4288,16 @@ CECPacket *CECServerSocket::ProcessRequest2(const CECPacket *request)
 		if (const CECTag *hashTag = request->GetTagByName(EC_TAG_KNOWNFILE)) {
 			const CMD4Hash hash = hashTag->GetMD4Data();
 			if (!theApp->sharedfiles->RefreshMediaMetadata(hash)) {
+				// The caller already resolved the hash against its own
+				// snapshot, so "no such file" is not the reason by the time
+				// this runs -- what is left is a file whose extension is not
+				// audio/video, or an in-progress download. Say that, rather
+				// than a message whose first half can no longer be true.
 				response = new CECPacket(EC_OP_FAILED);
 				response->AddTag(CECTag(EC_TAG_STRING,
-					wxTRANSLATE("No such shared file, or it cannot be probed")));
+					wxTRANSLATE("File is not eligible for media metadata "
+						    "extraction (not an audio/video file, or an "
+						    "incomplete download)")));
 				break;
 			}
 			queued = 1;

--- a/src/MediaProbeThread.h
+++ b/src/MediaProbeThread.h
@@ -74,6 +74,16 @@ public:
 
 	bool IsRunning() const { return m_bRun; }
 
+	// How many probes are still queued. The worker reports only at the end of
+	// a drain, so this is what a caller polls to say "refreshing, N left" --
+	// and what the refresh entry points use to tell a scheduled file from one
+	// the gates dropped, since MaybeScheduleMediaProbe returns nothing.
+	size_t PendingCount() const
+	{
+		wxMutexLocker lock(const_cast<wxMutex &>(m_mutex));
+		return m_jobList.size();
+	}
+
 private:
 	void *Entry() override;
 

--- a/src/SharedFileList.cpp
+++ b/src/SharedFileList.cpp
@@ -751,7 +751,7 @@ bool CSharedFileList::AddFile(CKnownFile *pFile)
 	return false;
 }
 
-void CSharedFileList::MaybeScheduleMediaProbe(CKnownFile *pFile, bool bForceReprobe)
+void CSharedFileList::MaybeScheduleMediaProbe(CKnownFile *pFile, MediaProbeMode mode)
 {
 	// Called from AddFile under list_mut so we already know pFile is
 	// live and stable for the duration of this call.
@@ -789,7 +789,11 @@ void CSharedFileList::MaybeScheduleMediaProbe(CKnownFile *pFile, bool bForceRepr
 	// metadata is derived exactly once -- on completion, which re-enters here
 	// with bForceReprobe set. Skipping unconditionally (not just when metadata
 	// happened to be inherited from the search result) keeps that guarantee.
-	if (!bForceReprobe && pFile->IsPartFile()) {
+	// Only Completion lifts this, and only because a just-completed download
+	// is still a CPartFile object while its bytes are already all on disk. A
+	// Refresh walk MUST NOT inherit that licence: an in-progress download is
+	// in the shared list too, and there is nothing complete to read for it.
+	if (mode != MediaProbeMode::Completion && pFile->IsPartFile()) {
 		AddDebugLogLineN(logMediaProbe,
 			CFormat(wxT("MediaProbe: skip (incomplete download) %s")) % pFile->GetFileName());
 		return;
@@ -798,7 +802,7 @@ void CSharedFileList::MaybeScheduleMediaProbe(CKnownFile *pFile, bool bForceRepr
 	// "this file has been probed", shared with the publishers and the UI. The
 	// length-only form here never considered a codec-only file probed, so
 	// every startup re-ran ffprobe on all of them.
-	if (!bForceReprobe && pFile->GetMetaDataVer() > 0) {
+	if (mode == MediaProbeMode::Normal && pFile->GetMetaDataVer() > 0) {
 		AddDebugLogLineN(logMediaProbe,
 			CFormat(wxT("MediaProbe: skip (already has metadata) %s")) % pFile->GetFileName());
 		return;
@@ -823,6 +827,47 @@ void CSharedFileList::MaybeScheduleMediaProbe(CKnownFile *pFile, bool bForceRepr
 			CFormat(wxT("MediaProbe: dropped %s - probe thread not ready")) %
 				pFile->GetFileName());
 	}
+}
+
+unsigned CSharedFileList::RefreshAllMediaMetadata()
+{
+	// Snapshot under the lock, schedule outside it. MaybeScheduleMediaProbe
+	// only enqueues, but it also stats the file, and holding list_mut across a
+	// whole library's worth of stat() calls would block every reader --
+	// including the EC handlers this is invoked from.
+	std::vector<CKnownFile *> files;
+	{
+		wxMutexLocker lock(list_mut);
+		files.reserve(m_Files_map.size());
+		for (const auto &entry : m_Files_map) {
+			files.push_back(entry.second);
+		}
+	}
+
+	unsigned queued = 0;
+	for (CKnownFile *file : files) {
+		const uint64 before = theApp->mediaProbeThread ? theApp->mediaProbeThread->PendingCount() : 0;
+		MaybeScheduleMediaProbe(file, MediaProbeMode::Refresh);
+		if (theApp->mediaProbeThread && theApp->mediaProbeThread->PendingCount() != before) {
+			++queued;
+		}
+	}
+	AddLogLineN(CFormat(wxPLURAL("Re-extracting media metadata for %u shared file",
+			    "Re-extracting media metadata for %u shared files",
+			    queued)) %
+		    queued);
+	return queued;
+}
+
+bool CSharedFileList::RefreshMediaMetadata(const CMD4Hash &hash)
+{
+	CKnownFile *file = GetFileByID(hash);
+	if (!file) {
+		return false;
+	}
+	const uint64 before = theApp->mediaProbeThread ? theApp->mediaProbeThread->PendingCount() : 0;
+	MaybeScheduleMediaProbe(file, MediaProbeMode::Refresh);
+	return theApp->mediaProbeThread && theApp->mediaProbeThread->PendingCount() != before;
 }
 
 void CSharedFileList::SafeAddKFile(CKnownFile *toadd, bool bOnlyAdd)
@@ -885,10 +930,11 @@ void CSharedFileList::SafeAddKFile(CKnownFile *toadd, bool bOnlyAdd)
 			// tags on the next startup rescan. Now that it is complete on disk
 			// at its Incoming path, schedule the probe here. QueueProbe() only
 			// enqueues (it never runs ffprobe inline), so this cannot stall the
-			// completion. Force it (bypassing the already-has-FT_MEDIA gate) so
+			// completion. Completion mode bypasses BOTH gates -- the file is
+			// still a CPartFile object at this point -- so
 			// the authoritative local probe overwrites any metadata inherited
 			// from the search result, which is only a during-download preview.
-			MaybeScheduleMediaProbe(toadd, /*bForceReprobe=*/true);
+			MaybeScheduleMediaProbe(toadd, MediaProbeMode::Completion);
 		}
 	}
 

--- a/src/SharedFileList.cpp
+++ b/src/SharedFileList.cpp
@@ -751,10 +751,14 @@ bool CSharedFileList::AddFile(CKnownFile *pFile)
 	return false;
 }
 
-void CSharedFileList::MaybeScheduleMediaProbe(CKnownFile *pFile, MediaProbeMode mode)
+bool CSharedFileList::MaybeScheduleMediaProbe(CKnownFile *pFile, MediaProbeMode mode)
 {
-	// Called from AddFile under list_mut so we already know pFile is
-	// live and stable for the duration of this call.
+	// Callers must keep pFile alive for the duration of this call. AddFile
+	// holds list_mut, which does that; the refresh walk instead snapshots the
+	// pointers under the lock and schedules outside it, which is safe because
+	// both callers run on the main thread and only the main thread removes a
+	// file from the list. It is that single-thread property doing the work
+	// here, not the mutex.
 	// #140 — probe local shared audio / video files with ffprobe to populate
 	// the six FT_MEDIA_* fields (length, bitrate, codec, artist, album,
 	// title). Cost-limiting:
@@ -770,7 +774,7 @@ void CSharedFileList::MaybeScheduleMediaProbe(CKnownFile *pFile, MediaProbeMode 
 	// CThreadScheduler naturally throttles: it runs one task at a
 	// time at ETP_Low so hashing / completion never starve.
 	if (!thePrefs::GetMediaMetadataEnabled()) {
-		return;
+		return false;
 	}
 	// An empty preference is not "off" -- it means "whatever this machine
 	// has", which is what every place that documents the setting promises.
@@ -781,7 +785,7 @@ void CSharedFileList::MaybeScheduleMediaProbe(CKnownFile *pFile, MediaProbeMode 
 	const wxString &ffprobePath = thePrefs::GetMediaMetadataFFProbePath();
 	const EED2KFileType type = GetED2KFileTypeID(pFile->GetFileName());
 	if (type != ED2KFT_AUDIO && type != ED2KFT_VIDEO) {
-		return;
+		return false;
 	}
 	// Never probe an in-progress download. A partfile is shared while
 	// transferring, so this fires from AddFile() during the download; there is
@@ -796,7 +800,7 @@ void CSharedFileList::MaybeScheduleMediaProbe(CKnownFile *pFile, MediaProbeMode 
 	if (mode != MediaProbeMode::Completion && pFile->IsPartFile()) {
 		AddDebugLogLineN(logMediaProbe,
 			CFormat(wxT("MediaProbe: skip (incomplete download) %s")) % pFile->GetFileName());
-		return;
+		return false;
 	}
 	// GetMetaDataVer(), not a second FT_MEDIA_LENGTH test: one definition of
 	// "this file has been probed", shared with the publishers and the UI. The
@@ -805,15 +809,25 @@ void CSharedFileList::MaybeScheduleMediaProbe(CKnownFile *pFile, MediaProbeMode 
 	if (mode == MediaProbeMode::Normal && pFile->GetMetaDataVer() > 0) {
 		AddDebugLogLineN(logMediaProbe,
 			CFormat(wxT("MediaProbe: skip (already has metadata) %s")) % pFile->GetFileName());
-		return;
+		return false;
 	}
 	const CPath fullPath = pFile->GetFilePath().JoinPaths(pFile->GetFileName());
 	// Only probe a file that is actually on disk at this resolved path -- a
 	// stale known.met record can outlive its deleted file, and this is cheap
 	// insurance against handing ffprobe a path that cannot succeed. (In-progress
 	// downloads are already excluded by the partfile guard above.)
-	if (!fullPath.FileExists()) {
-		return;
+	//
+	// Skipped for Refresh, which walks the WHOLE share from an EC handler on
+	// the main thread: one stat per file is cheap, N of them synchronously
+	// before the reply goes out is not, and it is the same stall the shared-
+	// files reload was deliberately made asynchronous to avoid. Nothing is
+	// lost by deferring it -- MediaProbe::Probe stats the path again on the
+	// worker before spawning ffprobe, and logs the file as vanished. The cost
+	// is that `queued` counts a file that has since been deleted, which is
+	// honest: it says how many were accepted for probing, not how many
+	// produced metadata.
+	if (mode != MediaProbeMode::Refresh && !fullPath.FileExists()) {
+		return false;
 	}
 	// #280: run on the dedicated media-probe worker, NOT the shared
 	// CThreadScheduler — a slow/hung ffprobe there wedges completions.
@@ -822,19 +836,20 @@ void CSharedFileList::MaybeScheduleMediaProbe(CKnownFile *pFile, MediaProbeMode 
 			CFormat(wxT("MediaProbe: queueing %s (ffprobe=%s)")) % pFile->GetFileName() %
 				ffprobePath);
 		theApp->mediaProbeThread->QueueProbe(pFile->GetFileHash(), fullPath, ffprobePath);
+		return true;
 	} else {
 		AddDebugLogLineN(logMediaProbe,
 			CFormat(wxT("MediaProbe: dropped %s - probe thread not ready")) %
 				pFile->GetFileName());
 	}
+	return false;
 }
 
 unsigned CSharedFileList::RefreshAllMediaMetadata()
 {
-	// Snapshot under the lock, schedule outside it. MaybeScheduleMediaProbe
-	// only enqueues, but it also stats the file, and holding list_mut across a
-	// whole library's worth of stat() calls would block every reader --
-	// including the EC handlers this is invoked from.
+	// Snapshot under the lock, schedule outside it. Holding list_mut across a
+	// whole library's worth of scheduling would block every reader, including
+	// the EC handlers this is invoked from.
 	std::vector<CKnownFile *> files;
 	{
 		wxMutexLocker lock(list_mut);
@@ -846,9 +861,7 @@ unsigned CSharedFileList::RefreshAllMediaMetadata()
 
 	unsigned queued = 0;
 	for (CKnownFile *file : files) {
-		const uint64 before = theApp->mediaProbeThread ? theApp->mediaProbeThread->PendingCount() : 0;
-		MaybeScheduleMediaProbe(file, MediaProbeMode::Refresh);
-		if (theApp->mediaProbeThread && theApp->mediaProbeThread->PendingCount() != before) {
+		if (MaybeScheduleMediaProbe(file, MediaProbeMode::Refresh)) {
 			++queued;
 		}
 	}
@@ -862,12 +875,7 @@ unsigned CSharedFileList::RefreshAllMediaMetadata()
 bool CSharedFileList::RefreshMediaMetadata(const CMD4Hash &hash)
 {
 	CKnownFile *file = GetFileByID(hash);
-	if (!file) {
-		return false;
-	}
-	const uint64 before = theApp->mediaProbeThread ? theApp->mediaProbeThread->PendingCount() : 0;
-	MaybeScheduleMediaProbe(file, MediaProbeMode::Refresh);
-	return theApp->mediaProbeThread && theApp->mediaProbeThread->PendingCount() != before;
+	return file && MaybeScheduleMediaProbe(file, MediaProbeMode::Refresh);
 }
 
 void CSharedFileList::SafeAddKFile(CKnownFile *toadd, bool bOnlyAdd)

--- a/src/SharedFileList.h
+++ b/src/SharedFileList.h
@@ -164,8 +164,8 @@ public:
 	unsigned RefreshAllMediaMetadata();
 
 	// The single-file form, addressed by hash. Returns false when no shared
-	// file has that hash or it is not eligible (not audio/video, an
-	// incomplete download, missing on disk).
+	// file has that hash, or it is not eligible: not audio/video by
+	// extension, or an incomplete download.
 	bool RefreshMediaMetadata(const CMD4Hash &hash);
 
 	/**
@@ -276,7 +276,12 @@ private:
 		Completion,
 		Refresh,
 	};
-	void MaybeScheduleMediaProbe(CKnownFile *pFile, MediaProbeMode mode = MediaProbeMode::Normal);
+	// Returns true when a probe was actually enqueued, so a caller can report
+	// what it did. Do NOT try to infer that from the worker's pending count:
+	// CMediaProbeThread::Entry swaps the whole job list out as soon as it is
+	// signalled, so against an idle worker the count is back to zero before
+	// the caller can look and every enqueue reads as a no-op.
+	bool MaybeScheduleMediaProbe(CKnownFile *pFile, MediaProbeMode mode = MediaProbeMode::Normal);
 
 	// Per-path attach: stat fname under directory, look it up in
 	// known.met, and either AddFile() the existing CKnownFile or push

--- a/src/SharedFileList.h
+++ b/src/SharedFileList.h
@@ -147,6 +147,27 @@ public:
 	bool RenameFile(CKnownFile *pFile, const CPath &newName);
 	void VerifyLocalData(const CKnownFile *file) const;
 
+	// Re-extract media metadata for every shared file, whether or not it has
+	// any already. Returns how many probes were queued.
+	//
+	// This is the only way to correct a file whose metadata is wrong rather
+	// than missing: the scheduler skips anything that already carries a media
+	// tag, so a value stored by an older build -- a cover-art codec, or a
+	// preview inherited from a search result before the local probe could
+	// overwrite it -- is otherwise permanent short of deleting known.met,
+	// which would also discard the ed2k part hashes and every per-file
+	// statistic.
+	//
+	// Asynchronous: the work is queued on the media-probe worker and this
+	// returns immediately. Nothing else about a file is touched -- it is not
+	// re-hashed, its hash does not change, and it never leaves the share.
+	unsigned RefreshAllMediaMetadata();
+
+	// The single-file form, addressed by hash. Returns false when no shared
+	// file has that hash or it is not eligible (not audio/video, an
+	// incomplete download, missing on disk).
+	bool RefreshMediaMetadata(const CMD4Hash &hash);
+
 	/**
 	 * Returns the name of a folder visible to the public.
 	 *
@@ -234,12 +255,28 @@ private:
 	// CMediaProbeTask when the preference is enabled and the file
 	// looks like media (audio / video by ED2K file type) and hasn't
 	// been probed yet. Returns silently if any gate fails.
-	// bForceReprobe bypasses the "already has FT_MEDIA_LENGTH" gate: set on
-	// download completion, where the authoritative local probe must overwrite
-	// any metadata inherited from the search result (which is only a
-	// during-download preview). Left false everywhere else so startup rescans
-	// still probe each file at most once.
-	void MaybeScheduleMediaProbe(CKnownFile *pFile, bool bForceReprobe = false);
+	//
+	// The mode says WHICH gates to bypass, because the two callers that bypass
+	// anything need different ones and a single "force" flag conflated them:
+	//
+	//  * Normal   -- both gates apply. Startup rescans probe each file at most
+	//                once and never touch an in-progress download.
+	//  * Completion -- both bypassed. The authoritative local probe must
+	//                overwrite metadata inherited from the search result, and
+	//                a just-completed download is STILL a CPartFile object, so
+	//                the partfile guard has to be lifted too. Safe only
+	//                because this fires exactly when the file has finished.
+	//  * Refresh  -- the metadata gate is bypassed, the partfile guard is NOT.
+	//                A whole-share walk must not inherit Completion's licence:
+	//                a genuinely incomplete download is in the shared list and
+	//                has no complete file to read.
+	enum class MediaProbeMode
+	{
+		Normal,
+		Completion,
+		Refresh,
+	};
+	void MaybeScheduleMediaProbe(CKnownFile *pFile, MediaProbeMode mode = MediaProbeMode::Normal);
 
 	// Per-path attach: stat fname under directory, look it up in
 	// known.met, and either AddFile() the existing CKnownFile or push

--- a/src/libs/ec/abstracts/ECCodes.abstract
+++ b/src/libs/ec/abstracts/ECCodes.abstract
@@ -182,6 +182,16 @@ EC_OP_GET_CHAT_SESSIONS             0x63
 EC_OP_CHAT_SESSIONS                 0x64
 EC_OP_CHAT_SEND                     0x65
 EC_OP_CHAT_CLOSE_SESSION            0x66
+
+## Re-extract media metadata for the whole share, or for one file by hash
+## (EC_TAG_KNOWNFILE with the hash). Reply carries
+## EC_TAG_KNOWNFILE_MEDIA_QUEUED = how many probes were queued.
+##
+## Deliberately NOT behind a capability tag. A server that does not know it
+## answers EC_OP_FAILED, which the client reports as "not supported" -- the
+## op is user-triggered once, not polled, so an old core sees a single
+## rejected request rather than a repeating one.
+EC_OP_REFRESH_MEDIA_METADATA        0x67
 [/Section]
 
 [Section Content]
@@ -337,6 +347,7 @@ EC_TAG_KNOWNFILE                          0x0400
 	EC_TAG_KNOWNFILE_LAST_UPLOAD              0x0419
 	EC_TAG_KNOWNFILE_SHARED_SINCE             0x041A
 	EC_TAG_KNOWNFILE_HASHED_PART_COUNT        0x041B
+	EC_TAG_KNOWNFILE_MEDIA_QUEUED             0x041C
 
 EC_TAG_SERVER                             0x0500
 	EC_TAG_SERVER_NAME                        0x0501

--- a/src/webapi/Api.cpp
+++ b/src/webapi/Api.cpp
@@ -934,6 +934,16 @@ CHttpServer::Response CApiDispatcher::DispatchToHandler(const CHttpServer::Reque
 		return HandleSharedReload(req);
 	}
 
+	// /shared/media/refresh — re-extract media metadata for the whole share.
+	// Literal path, so it has to be matched before the /shared/{hash} patterns
+	// below or "media" would be captured as a hash.
+	if (path == "/api/v0/shared/media/refresh") {
+		if (req.method != "POST") {
+			return ErrorResponse(405, "method_not_allowed", "only POST on /shared/media/refresh");
+		}
+		return HandleSharedMediaRefresh(req);
+	}
+
 	// /shared/directories — the configured share roots, as opposed to /shared
 	// which lists the files those roots produced. Literal path, so it has to be
 	// matched before the /shared/{hash} patterns below or "directories" would be
@@ -1175,9 +1185,19 @@ CHttpServer::Response CApiDispatcher::DispatchToHandler(const CHttpServer::Reque
 	// single-segment `/shared/{hash}` pattern below purely for locality —
 	// the two can't collide, this one carries an extra path segment.
 	{
+		static const auto shared_media_refresh =
+			web_api_path::ParsePattern("/api/v0/shared/{hash}/media/refresh");
 		static const auto shared_verify = web_api_path::ParsePattern("/api/v0/shared/{hash}/verify");
 		const auto path_segs = web_api_path::SplitPath(path);
 		std::map<std::string, std::string> caps;
+		if (web_api_path::Match(shared_media_refresh, path_segs, caps)) {
+			if (req.method != "POST") {
+				return ErrorResponse(405,
+					"method_not_allowed",
+					"only POST on /shared/{hash}/media/refresh");
+			}
+			return HandleSharedMediaRefreshOne(req, caps["hash"]);
+		}
 		if (web_api_path::Match(shared_verify, path_segs, caps)) {
 			if (req.method != "POST") {
 				return ErrorResponse(
@@ -9158,6 +9178,111 @@ CHttpServer::Response CApiDispatcher::HandleSharedDirectoriesDelete(const CHttpS
 		return ErrorResponse(404, "not_found", "no such shared directory");
 	}
 	return ApplySharedDirs(m_app, dirs);
+}
+
+namespace
+{
+
+// Send EC_OP_REFRESH_MEDIA_METADATA and turn the reply into a response.
+// `hashTag` is null for the whole-share form.
+//
+// The op is deliberately not behind a capability tag, so a daemon that
+// predates it answers EC_OP_FAILED rather than being detectable in advance.
+// That is reported as 501, not 400: the request was well-formed and the
+// server simply does not implement it, and a client that gets 501 knows to
+// stop offering the action rather than to fix its input.
+CHttpServer::Response SendMediaRefresh(CamuleapiApp &app, const CECTag *hashTag, const char *what)
+{
+	auto ec_req = std::make_unique<CECPacket>(EC_OP_REFRESH_MEDIA_METADATA);
+	if (hashTag) {
+		ec_req->AddTag(*hashTag);
+	}
+	const CECPacket *ec_resp = app.SendRecvSerialized(ec_req.get());
+	if (!ec_resp) {
+		return ErrorResponse(503, "ec_unavailable", "EC roundtrip failed for media refresh");
+	}
+	std::string ec_err_msg;
+	if (IsEcFailedResponse(ec_resp, ec_err_msg)) {
+		const bool unknown_op = ec_err_msg.find("Invalid opcode") != std::string::npos;
+		delete ec_resp;
+		if (unknown_op) {
+			return ErrorResponse(501,
+				"ec_unsupported",
+				"the connected amuled does not implement media metadata refresh");
+		}
+		return ErrorResponse(400, "amuled_rejected", ec_err_msg.c_str());
+	}
+	std::uint32_t queued = 0;
+	if (const CECTag *t = ec_resp->GetTagByName(EC_TAG_KNOWNFILE_MEDIA_QUEUED)) {
+		queued = static_cast<std::uint32_t>(t->GetInt());
+	}
+	delete ec_resp;
+
+	// 202, not 200: amuled queues the probes on its media-probe worker and
+	// answers immediately, so nothing has been re-extracted yet. `queued` is
+	// how many files were accepted for probing -- files the scheduler dropped
+	// (not audio/video, an incomplete download, missing on disk) are not
+	// counted. Progress is observable through the amule log and, as each
+	// probe lands, the shared_updated SSE events.
+	CHttpServer::Response r;
+	r.status = 202;
+	r.content_type = "application/json";
+	CJsonWriter w;
+	w.BeginObject();
+	w.Key("ok");
+	w.ValueBool(true);
+	w.Key("scope");
+	w.ValueString(wxString::FromAscii(what));
+	w.Key("queued");
+	w.ValueInt(static_cast<int64_t>(queued));
+	w.EndObject();
+	FinalizeJsonBody(w, r);
+	return r;
+}
+
+} // namespace
+
+CHttpServer::Response CApiDispatcher::HandleSharedMediaRefresh(const CHttpServer::Request &req)
+{
+	auto a = Authenticate(req);
+	if (!a.ok)
+		return a.rejection;
+	if (auto rej = RequireAdmin(a))
+		return *rej;
+	return SendMediaRefresh(m_app, nullptr, "all");
+}
+
+CHttpServer::Response CApiDispatcher::HandleSharedMediaRefreshOne(
+	const CHttpServer::Request &req, const std::string &key)
+{
+	auto a = Authenticate(req);
+	if (!a.ok)
+		return a.rejection;
+	if (auto rej = RequireAdmin(a))
+		return *rej;
+
+	if (auto r = RequireSnapshot(m_state))
+		return *r;
+
+	webapi::FileSnapshot s;
+	if (!FindSharedByKey(m_state, key, s)) {
+		return ErrorResponse(404, "not_found", "no shared file with that hash");
+	}
+	// Same exclusion the daemon's Refresh mode applies: an in-progress
+	// download has no complete file to read. Rejected here so the caller is
+	// told why, rather than getting a 202 for a probe that was silently
+	// dropped.
+	if (s.IsIncompletePartfile()) {
+		return ErrorResponse(409,
+			"partfile_unsupported",
+			"media metadata cannot be extracted from an incomplete download");
+	}
+	CMD4Hash file_hash;
+	if (!HashFromHex(s.hash, file_hash)) {
+		return ErrorResponse(500, "internal_error", "failed to decode file hash");
+	}
+	const CECTag hashTag(EC_TAG_KNOWNFILE, file_hash);
+	return SendMediaRefresh(m_app, &hashTag, "file");
 }
 
 CHttpServer::Response CApiDispatcher::HandleSharedReload(const CHttpServer::Request &req)

--- a/src/webapi/Api.cpp
+++ b/src/webapi/Api.cpp
@@ -2891,6 +2891,14 @@ void WriteSharedObject(CJsonWriter &w, const webapi::FileSnapshot &f)
 {
 	w.BeginObject();
 	WriteSharedBaseFields(w, f);
+	// Media rides the list item, not just the detail endpoint, because the
+	// shared_added / shared_updated payload is documented to match this object
+	// byte-for-byte -- that is what lets a subscriber skip the re-GET. The
+	// event has to carry media (a metadata re-extraction is otherwise
+	// invisible: the refresh endpoints answer 202 with no result), so the list
+	// carries it too or the guarantee stops being true. Six small scalars,
+	// unlike the per-part arrays the list deliberately omits.
+	WriteMediaIfPresent(w, f);
 	w.EndObject();
 }
 

--- a/src/webapi/Api.cpp
+++ b/src/webapi/Api.cpp
@@ -9206,7 +9206,11 @@ CHttpServer::Response SendMediaRefresh(CamuleapiApp &app, const CECTag *hashTag,
 		const bool unknown_op = ec_err_msg.find("Invalid opcode") != std::string::npos;
 		delete ec_resp;
 		if (unknown_op) {
-			return ErrorResponse(501,
+			// 503, matching every other ec_unsupported site in this file and
+			// the rule stated in App.cpp. 501 is arguably the better literal
+			// answer for "server does not implement it", but one endpoint
+			// disagreeing with seven is worse than either choice.
+			return ErrorResponse(503,
 				"ec_unsupported",
 				"the connected amuled does not implement media metadata refresh");
 		}

--- a/src/webapi/Api.h
+++ b/src/webapi/Api.h
@@ -220,6 +220,13 @@ private:
 	// roots and re-publishes whatever's there. Parameterless EC op
 	// (EC_OP_SHAREDFILES_RELOAD).
 	CHttpServer::Response HandleSharedReload(const CHttpServer::Request &);
+
+	// Re-extract media metadata: the whole share, or one file by hash. Both
+	// answer 202 -- the probes are queued on amuled's media-probe worker and
+	// the response says how many, never what they found.
+	CHttpServer::Response HandleSharedMediaRefresh(const CHttpServer::Request &);
+	CHttpServer::Response HandleSharedMediaRefreshOne(
+		const CHttpServer::Request &, const std::string &hash);
 	CHttpServer::Response HandleSharedDirectories(const CHttpServer::Request &);
 	CHttpServer::Response HandleSharedDirectoriesPut(const CHttpServer::Request &);
 	CHttpServer::Response HandleSharedDirectoriesAdd(const CHttpServer::Request &);

--- a/src/webapi/EventDiff.cpp
+++ b/src/webapi/EventDiff.cpp
@@ -169,7 +169,19 @@ std::string ToJsonSharedEvent(const FileSnapshot &f)
 	  << ",\"upload_speed_bps\":" << f.shared.upload_speed_bps
 	  << ",\"uploading\":" << f.shared.uploading_count << ",\"last_upload\":" << f.shared.last_upload
 	  << ",\"shared_since\":" << f.shared.shared_since
-	  << ",\"hashing_progress\":" << SharedHashingProgress(f) << "}";
+	  << ",\"hashing_progress\":" << SharedHashingProgress(f);
+	// Media metadata rides the event because a metadata re-extraction is
+	// otherwise invisible to a subscriber: the refresh endpoints answer 202
+	// with no result, so this is how a client learns a probe landed. Six
+	// small scalars, unlike the per-part arrays the list endpoints omit.
+	if (f.has_media) {
+		o << ",\"media\":{\"length_s\":" << f.media.length_s << ",\"bitrate\":" << f.media.bitrate
+		  << ",\"codec\":\"" << EscJson(f.media.codec) << "\""
+		  << ",\"artist\":\"" << EscJson(f.media.artist) << "\""
+		  << ",\"album\":\"" << EscJson(f.media.album) << "\""
+		  << ",\"title\":\"" << EscJson(f.media.title) << "\"}";
+	}
+	o << "}";
 	return o.str();
 }
 
@@ -367,6 +379,16 @@ bool EqualShared(const FileSnapshot &a, const FileSnapshot &b)
 	       a.shared.uploading_count == b.shared.uploading_count &&
 	       a.shared.last_upload == b.shared.last_upload &&
 	       a.shared.shared_since == b.shared.shared_since &&
+	       // Media metadata, so a re-extraction emits shared_updated at all.
+	       // Without these a file whose metadata just changed compares EQUAL
+	       // and the refresh is invisible to every subscriber -- which is the
+	       // only progress signal the 202-returning refresh endpoints have.
+	       // These change once per probe, not per tick, so they cost nothing
+	       // in event volume.
+	       a.has_media == b.has_media && a.media.length_s == b.media.length_s &&
+	       a.media.bitrate == b.media.bitrate && a.media.codec == b.media.codec &&
+	       a.media.artist == b.media.artist && a.media.album == b.media.album &&
+	       a.media.title == b.media.title &&
 	       // Through the accessor, not the raw field: a shared download's
 	       // progress lives on the download side, and comparing the raw
 	       // field would hold every tick of it back from shared_updated.

--- a/unittests/curl-tests/amuleapi/22-sse-diff-emission.sh
+++ b/unittests/curl-tests/amuleapi/22-sse-diff-emission.sh
@@ -488,36 +488,78 @@ fi
 # checks nothing. Flipping a shared file's priority moves a field EqualShared
 # compares, which is exactly what makes shared_updated fire. The original
 # value is restored below -- this daemon is shared with the other sections.
-PARITY_HASH=$(curl -s -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/shared" \
-	| jq -r '.shared[0].hash // empty')
-PARITY_PRIO=$(curl -s -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/shared" \
-	| jq -r '.shared[0].priority // empty')
-PARITY_AUTO=$(curl -s -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/shared" \
-	| jq -r '.shared[0].priority_auto // empty')
+#
+# Prefer a file that HAS media. Both writers emit `media` only when the file
+# carries it, so comparing whatever sorts first comes down to two objects that
+# both omit the key: the sets match and the field this check exists to guard
+# was never compared. That is a green check over a comparison that never
+# happened, and it is exactly the regression that got through last time.
+# One GET, three extractions: re-fetching per field lets a live daemon reorder
+# the list between them, which would restore one file's priority onto another.
+#
+# The subject is chosen from the DETAIL endpoint, never from the list's own
+# `media` key. Selecting on the list would key the check off the exact field
+# whose absence is the bug: drop media from the list writer and the selector
+# stops finding a media file, falls back to a document, and the comparison
+# passes with media never compared -- the guard reporting green precisely when
+# it should be red. Detail builds through a different writer, so it still
+# answers truthfully when the list is the broken one.
+PARITY_BODY=$(curl -s -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/shared")
+PARITY_HASH=
+for CAND in $(printf '%s' "$PARITY_BODY" | jq -r '.shared[0:20][].hash'); do
+	if curl -s -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/shared/$CAND" \
+		| jq -e '.media != null' >/dev/null 2>&1; then
+		PARITY_HASH=$CAND
+		break
+	fi
+done
+[ -n "$PARITY_HASH" ] || PARITY_HASH=$(printf '%s' "$PARITY_BODY" | jq -r '.shared[0].hash // empty')
+PARITY_PRIO=$(printf '%s' "$PARITY_BODY" \
+	| jq -r --arg h "$PARITY_HASH" '.shared[] | select(.hash == $h) | .priority')
+PARITY_AUTO=$(printf '%s' "$PARITY_BODY" \
+	| jq -r --arg h "$PARITY_HASH" '.shared[] | select(.hash == $h) | .priority_auto')
+PARITY_HAS_MEDIA=0
+if [ -n "$PARITY_HASH" ] && curl -s -H "Authorization: Bearer $ADMIN_TOKEN" \
+	"$HOST/api/v0/shared/$PARITY_HASH" | jq -e '.media != null' >/dev/null 2>&1; then
+	PARITY_HAS_MEDIA=1
+fi
 SHARED_JSON=""
 if [ -z "$PARITY_HASH" ]; then
 	_pass "nothing shared; shared-event parity check skipped"
 else
-SSE_PID=$(_sse_start 15)
-sleep 1
+if [ "$PARITY_HAS_MEDIA" = "1" ]; then
+	echo "    info: parity subject carries media (the key this check guards)"
+else
+	echo "    info: no shared file carries media; parity checked on the common keys only"
+fi
+SSE_PID=$(_sse_start 25)
+# Wait for the stream to exist rather than sleeping a fixed second: _sse_start
+# backgrounds curl and returns immediately, so on a loaded runner the PATCH can
+# land before the subscription does. Every other section here treats a missing
+# frame as a pass and absorbs that race; this one requires the frame, so it has
+# to actually wait for the connection instead of assuming it.
+for _ in $(seq 1 80); do
+	[ -s "$SSE_OUT" ] && break
+	sleep 0.25
+done
 if [ "$PARITY_PRIO" = "high" ]; then NEW_PRIO=low; else NEW_PRIO=high; fi
 curl -s -o /dev/null -X PATCH -H "Authorization: Bearer $ADMIN_TOKEN" \
 	-H "Content-Type: application/json" \
 	-d "{\"priority\":\"$NEW_PRIO\"}" "$HOST/api/v0/shared/$PARITY_HASH"
+# Take the frame for THIS file: any other file's frame would be a valid
+# parity pair but not necessarily the one carrying media.
 for _ in $(seq 1 40); do
-	if grep -qE "^event: shared_(added|updated)$" "$SSE_OUT"; then
-		SHARED_JSON=$(grep -A2 -E "^event: shared_(added|updated)$" "$SSE_OUT" \
-			| grep "^data: " | sed 's/^data: //' | head -1)
-		[ -n "$SHARED_JSON" ] && break
-	fi
+	SHARED_JSON=$(grep -A2 -E "^event: shared_(added|updated)$" "$SSE_OUT" 2>/dev/null \
+		| grep "^data: " | sed 's/^data: //' \
+		| jq -c --arg h "$PARITY_HASH" 'select(.hash == $h)' 2>/dev/null | head -1)
+	[ -n "$SHARED_JSON" ] && break
 	sleep 0.25
 done
 kill $SSE_PID 2>/dev/null
 wait $SSE_PID 2>/dev/null
 if [ -n "$SHARED_JSON" ]; then
-	EV_HASH=$(printf '%s' "$SHARED_JSON" | jq -r '.hash')
 	REST_ITEM=$(curl -s -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/shared" \
-		| jq -c --arg h "$EV_HASH" '.shared[] | select(.hash == $h)')
+		| jq -c --arg h "$PARITY_HASH" '.shared[] | select(.hash == $h)')
 	if [ -z "$REST_ITEM" ]; then
 		# The file left the share between the frame and the GET; no contract
 		# to check, and failing here would be a flake, not a finding.
@@ -533,7 +575,7 @@ if [ -n "$SHARED_JSON" ]; then
 		fi
 	fi
 else
-	_fail "shared event parity" "no shared_added/updated frame within 10 s of a priority PATCH"
+	_fail "shared event parity" "no shared_added/updated frame for $PARITY_HASH after a priority PATCH"
 fi
 # Restore what the PATCH changed: later sections and other phases read this
 # daemon's state. priority_auto has to go back too -- setting a bare priority

--- a/unittests/curl-tests/amuleapi/22-sse-diff-emission.sh
+++ b/unittests/curl-tests/amuleapi/22-sse-diff-emission.sh
@@ -468,6 +468,82 @@ else
 	_pass "no client frame this run (no peer changed; shape asserted when one fires)"
 fi
 
+# --- shared_added / shared_updated carry the same keys as the GET
+# --- /shared list item.
+# REFERENCE.md promises the payload "matches this object byte-for-byte, so a
+# subscriber that received shared_updated does not need to re-GET". Nothing
+# checked it: the mechanical key-diff above covers status only, and the shared
+# payload is built by a SEPARATE writer (ToJsonSharedEvent) from the one the
+# list uses (WriteSharedObject), so the two drift silently by construction.
+# They already did once -- `media` reached the event before the list item.
+#
+# Appended at the end of the file on purpose: every section here shares one
+# live daemon, and a new section in the middle can change the state later
+# sections read.
+#
+# Conditional for the same reason as status_changed: an idle share emits
+# nothing, so a missing frame is a skip. What this guards is the SHAPE.
+# Force a real change rather than waiting for one: a reload of an unchanged
+# share emits nothing, so a passive wait here reports "no frame" every run and
+# checks nothing. Flipping a shared file's priority moves a field EqualShared
+# compares, which is exactly what makes shared_updated fire. The original
+# value is restored below -- this daemon is shared with the other sections.
+PARITY_HASH=$(curl -s -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/shared" \
+	| jq -r '.shared[0].hash // empty')
+PARITY_PRIO=$(curl -s -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/shared" \
+	| jq -r '.shared[0].priority // empty')
+PARITY_AUTO=$(curl -s -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/shared" \
+	| jq -r '.shared[0].priority_auto // empty')
+SHARED_JSON=""
+if [ -z "$PARITY_HASH" ]; then
+	_pass "nothing shared; shared-event parity check skipped"
+else
+SSE_PID=$(_sse_start 15)
+sleep 1
+if [ "$PARITY_PRIO" = "high" ]; then NEW_PRIO=low; else NEW_PRIO=high; fi
+curl -s -o /dev/null -X PATCH -H "Authorization: Bearer $ADMIN_TOKEN" \
+	-H "Content-Type: application/json" \
+	-d "{\"priority\":\"$NEW_PRIO\"}" "$HOST/api/v0/shared/$PARITY_HASH"
+for _ in $(seq 1 40); do
+	if grep -qE "^event: shared_(added|updated)$" "$SSE_OUT"; then
+		SHARED_JSON=$(grep -A2 -E "^event: shared_(added|updated)$" "$SSE_OUT" \
+			| grep "^data: " | sed 's/^data: //' | head -1)
+		[ -n "$SHARED_JSON" ] && break
+	fi
+	sleep 0.25
+done
+kill $SSE_PID 2>/dev/null
+wait $SSE_PID 2>/dev/null
+if [ -n "$SHARED_JSON" ]; then
+	EV_HASH=$(printf '%s' "$SHARED_JSON" | jq -r '.hash')
+	REST_ITEM=$(curl -s -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/shared" \
+		| jq -c --arg h "$EV_HASH" '.shared[] | select(.hash == $h)')
+	if [ -z "$REST_ITEM" ]; then
+		# The file left the share between the frame and the GET; no contract
+		# to check, and failing here would be a flake, not a finding.
+		_pass "shared frame's file no longer listed (shape asserted when both are present)"
+	else
+		DIFF=$(jq -n --argjson a "$REST_ITEM" --argjson b "$SHARED_JSON" \
+			'def keys_: [paths | join(".")] | sort;
+			 {rest_only: (($a|keys_) - ($b|keys_)), sse_only: (($b|keys_) - ($a|keys_))}')
+		if [ "$(echo "$DIFF" | jq -c '.')" = '{"rest_only":[],"sse_only":[]}' ]; then
+			_pass "shared event payload keys match the GET /shared item exactly"
+		else
+			_fail "shared event / GET /shared key parity" "$DIFF"
+		fi
+	fi
+else
+	_fail "shared event parity" "no shared_added/updated frame within 10 s of a priority PATCH"
+fi
+# Restore what the PATCH changed: later sections and other phases read this
+# daemon's state. priority_auto has to go back too -- setting a bare priority
+# clears it.
+curl -s -o /dev/null -X PATCH -H "Authorization: Bearer $ADMIN_TOKEN" \
+	-H "Content-Type: application/json" \
+	-d "{\"priority\":\"$PARITY_PRIO\",\"priority_auto\":$PARITY_AUTO}" \
+	"$HOST/api/v0/shared/$PARITY_HASH"
+fi
+
 # --- Summary. -----------------------------------------------------
 echo
 if [ "$FAIL_COUNT" -eq 0 ]; then

--- a/unittests/curl-tests/amuleapi/39-shared-media-refresh.sh
+++ b/unittests/curl-tests/amuleapi/39-shared-media-refresh.sh
@@ -72,9 +72,19 @@ TOKEN=$(curl -s -X POST -H "Content-Type: application/json" \
 
 # --- 1. Whole-share refresh. ---------------------------------------
 _curl -X POST -H "Authorization: Bearer $TOKEN" "$HOST/api/v0/shared/media/refresh"
-if [ "$CURL_STATUS" = "501" ]; then
+# 503 covers two different situations and only one of them is a skip:
+# ec_unsupported is an amuled that predates the op, ec_unavailable is no
+# usable EC link at all -- which is a broken rig, not a reason to report
+# success. Branch on error.code, not on the status alone.
+if [ "$CURL_STATUS" = "503" ]; then
+	EC_CODE=$(printf '%s' "$CURL_BODY" | jq -r '.error.code // empty')
+	if [ "$EC_CODE" = "ec_unavailable" ]; then
+		_die "no usable EC link to amuled (503 ec_unavailable) -- rig is broken, not a skip"
+	fi
+	# A real assertion, not a _pass: any third error.code has to register as a
+	# failure, which is also what keeps the FAIL_COUNT consult below live.
 	_assert_json_eq '.error.code' ec_unsupported \
-		'501 carries error.code=ec_unsupported (daemon predates the op)'
+		'503 carries error.code=ec_unsupported (daemon predates the op)'
 	echo "    info: connected amuled does not implement media refresh; rest skipped"
 	echo
 	# Consult FAIL_COUNT: the assertion above can fail, and printing OK over

--- a/unittests/curl-tests/amuleapi/39-shared-media-refresh.sh
+++ b/unittests/curl-tests/amuleapi/39-shared-media-refresh.sh
@@ -77,8 +77,14 @@ if [ "$CURL_STATUS" = "501" ]; then
 		'501 carries error.code=ec_unsupported (daemon predates the op)'
 	echo "    info: connected amuled does not implement media refresh; rest skipped"
 	echo
-	echo "OK: $TEST_COUNT/$TEST_COUNT passed"
-	exit 0
+	# Consult FAIL_COUNT: the assertion above can fail, and printing OK over
+	# a failed assertion is how a broken gate looks green.
+	if [ "$FAIL_COUNT" -eq 0 ]; then
+		echo "OK: $TEST_COUNT/$TEST_COUNT passed"
+		exit 0
+	fi
+	echo "FAIL: $FAIL_COUNT/$TEST_COUNT failed"
+	exit 1
 fi
 _assert_status 202 "POST /shared/media/refresh → 202 Accepted"
 _assert_json_eq '.ok'            true  'whole-share refresh reports ok'
@@ -111,8 +117,24 @@ _assert_json_eq '.error.code' not_found 'unknown hash carries error.code=not_fou
 _curl -H "Authorization: Bearer $TOKEN" "$HOST/api/v0/shared"
 COUNT=$(printf '%s' "$CURL_BODY" | jq '.shared | length')
 echo "    info: $COUNT files currently shared"
-if [ "$COUNT" -gt 0 ]; then
-	HASH=$(printf '%s' "$CURL_BODY" | jq -r '.shared[0].hash')
+# Pick an audio/video entry rather than shared[0]: a share whose first file is
+# a document or an archive answers 400 (not eligible), which is correct daemon
+# behaviour and would fail the phase for the wrong reason.
+#
+# file_type lives on the detail endpoint, not on the list, so this walks the
+# hashes and asks. Capped at 20 to keep the probe bounded on a large share --
+# if the first 20 are all documents the phase skips rather than misreporting.
+HASH=
+for CANDIDATE in $(printf '%s' "$CURL_BODY" | jq -r '.shared[0:20][].hash'); do
+	_curl -H "Authorization: Bearer $TOKEN" "$HOST/api/v0/shared/$CANDIDATE"
+	FTYPE=$(printf '%s' "$CURL_BODY" | jq -r '.file_type // empty')
+	if [ "$FTYPE" = "audio" ] || [ "$FTYPE" = "videos" ]; then
+		HASH=$CANDIDATE
+		echo "    info: probing $FTYPE file $HASH"
+		break
+	fi
+done
+if [ -n "$HASH" ]; then
 	_curl -X POST -H "Authorization: Bearer $TOKEN" \
 		"$HOST/api/v0/shared/$HASH/media/refresh"
 	# 409 is a legitimate answer for an incomplete download; both shapes are
@@ -135,7 +157,7 @@ if [ "$COUNT" -gt 0 ]; then
 		_fail "uppercase hash" "expected 202 or 409, got $CURL_STATUS"
 	fi
 else
-	echo "    info: nothing shared; single-file checks skipped"
+	echo "    info: no audio/video file shared; single-file checks skipped"
 fi
 
 echo

--- a/unittests/curl-tests/amuleapi/39-shared-media-refresh.sh
+++ b/unittests/curl-tests/amuleapi/39-shared-media-refresh.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+#
+# amuleapi 39-shared-media-refresh — re-extracting media metadata (issue #1079).
+#
+# Wire contract:
+#   POST /shared/media/refresh          → 202 { ok, scope:"all",  queued }
+#   POST /shared/{hash}/media/refresh   → 202 { ok, scope:"file", queued }
+#
+# `queued` counts files ACCEPTED for probing, not files that produced
+# metadata: the scheduler drops anything that is not audio/video by
+# extension, is an incomplete download, or is missing on disk. Nothing has
+# been extracted when the response returns -- the probes run on amuled's
+# media-probe worker.
+#
+# Tolerates an empty share and a daemon that predates the operation (501).
+
+set -u
+set -o pipefail
+
+HOST=${HOST:-localhost:4713}
+ADMIN_PASS=${ADMIN_PASS:-adminpass}
+GUEST_PASS=${GUEST_PASS:-guestpass}
+
+FAIL_COUNT=0
+TEST_COUNT=0
+
+CURL_BODY_FILE=$(mktemp -t amuleapi_39_media_refresh_body.XXXXXX)
+trap 'rm -f "$CURL_BODY_FILE"' EXIT
+
+_die()  { echo "FATAL: $*" >&2; exit 2; }
+_pass() { TEST_COUNT=$((TEST_COUNT+1)); echo "  PASS  $1"; }
+_fail() {
+	TEST_COUNT=$((TEST_COUNT+1)); FAIL_COUNT=$((FAIL_COUNT+1))
+	echo "  FAIL  $1"; shift
+	for arg in "$@"; do echo "        $arg"; done
+}
+_curl() {
+	local resp
+	resp=$(curl -s --max-time 15 -o "$CURL_BODY_FILE" -w '%{http_code}' "$@") \
+		|| _die "curl invocation failed for $*"
+	CURL_STATUS=$resp
+	CURL_BODY=$(cat "$CURL_BODY_FILE")
+}
+_assert_status() {
+	local expected=$1 label=$2
+	if [ "$CURL_STATUS" = "$expected" ]; then
+		_pass "$label (HTTP $CURL_STATUS)"
+	else
+		_fail "$label" "expected HTTP $expected, got $CURL_STATUS" \
+			"body head: $(printf '%s' "$CURL_BODY" | head -c 200)"
+	fi
+}
+_assert_json_eq() {
+	local expr=$1 expected=$2 label=$3 actual
+	actual=$(printf '%s' "$CURL_BODY" | jq -r "$expr" 2>/dev/null) \
+		|| _fail "$label" "body was not valid JSON" "body: $CURL_BODY"
+	if [ "$actual" = "$expected" ]; then _pass "$label"; else
+		_fail "$label" "expected $expected, got $actual" "body: $CURL_BODY"
+	fi
+}
+
+command -v jq >/dev/null 2>&1 || _die "jq is required."
+curl -s -o /dev/null --max-time 2 "$HOST/api/v0/version" 2>/dev/null \
+	|| _die "amuleapi at $HOST is not reachable."
+
+echo "amuleapi 39-shared-media-refresh smoke @ $HOST"
+
+TOKEN=$(curl -s -X POST -H "Content-Type: application/json" \
+	-d "{\"password\":\"$ADMIN_PASS\"}" \
+	"$HOST/api/v0/auth/login?type=bearer" | jq -r .token)
+[ -n "$TOKEN" ] && [ "$TOKEN" != "null" ] || _die "login failed"
+
+# --- 1. Whole-share refresh. ---------------------------------------
+_curl -X POST -H "Authorization: Bearer $TOKEN" "$HOST/api/v0/shared/media/refresh"
+if [ "$CURL_STATUS" = "501" ]; then
+	_assert_json_eq '.error.code' ec_unsupported \
+		'501 carries error.code=ec_unsupported (daemon predates the op)'
+	echo "    info: connected amuled does not implement media refresh; rest skipped"
+	echo
+	echo "OK: $TEST_COUNT/$TEST_COUNT passed"
+	exit 0
+fi
+_assert_status 202 "POST /shared/media/refresh → 202 Accepted"
+_assert_json_eq '.ok'            true  'whole-share refresh reports ok'
+_assert_json_eq '.scope'         all   'whole-share refresh reports scope=all'
+_assert_json_eq '.queued | type' number 'queued is numeric'
+
+# --- 2. Method + auth gating. --------------------------------------
+_curl -H "Authorization: Bearer $TOKEN" "$HOST/api/v0/shared/media/refresh"
+_assert_status 405 "GET /shared/media/refresh → 405"
+_curl -X POST "$HOST/api/v0/shared/media/refresh"
+_assert_status 401 "POST without a token → 401"
+
+GUEST_TOKEN=$(curl -s -X POST -H "Content-Type: application/json" \
+	-d "{\"password\":\"${GUEST_PASS}\"}" \
+	"$HOST/api/v0/auth/login?type=bearer" | jq -r .token)
+if [ -n "$GUEST_TOKEN" ] && [ "$GUEST_TOKEN" != "null" ]; then
+	_curl -X POST -H "Authorization: Bearer $GUEST_TOKEN" "$HOST/api/v0/shared/media/refresh"
+	_assert_status 403 "POST as guest → 403 (refresh is admin-only)"
+else
+	echo "    info: guest login unavailable; guest check skipped"
+fi
+
+# --- 3. Unknown hash. ----------------------------------------------
+_curl -X POST -H "Authorization: Bearer $TOKEN" \
+	"$HOST/api/v0/shared/00000000000000000000000000000000/media/refresh"
+_assert_status 404 "POST /shared/{unknown}/media/refresh → 404"
+_assert_json_eq '.error.code' not_found 'unknown hash carries error.code=not_found'
+
+# --- 4. Single-file refresh, when there is a file to refresh. ------
+_curl -H "Authorization: Bearer $TOKEN" "$HOST/api/v0/shared"
+COUNT=$(printf '%s' "$CURL_BODY" | jq '.shared | length')
+echo "    info: $COUNT files currently shared"
+if [ "$COUNT" -gt 0 ]; then
+	HASH=$(printf '%s' "$CURL_BODY" | jq -r '.shared[0].hash')
+	_curl -X POST -H "Authorization: Bearer $TOKEN" \
+		"$HOST/api/v0/shared/$HASH/media/refresh"
+	# 409 is a legitimate answer for an incomplete download; both shapes are
+	# contract, so accept either and check the one that came back.
+	if [ "$CURL_STATUS" = "409" ]; then
+		_assert_json_eq '.error.code' partfile_unsupported \
+			'incomplete download → 409 partfile_unsupported'
+	else
+		_assert_status 202 "POST /shared/{hash}/media/refresh → 202"
+		_assert_json_eq '.ok'    true 'single-file refresh reports ok'
+		_assert_json_eq '.scope' file 'single-file refresh reports scope=file'
+	fi
+
+	UPPER=$(echo "$HASH" | tr 'a-f' 'A-F')
+	_curl -X POST -H "Authorization: Bearer $TOKEN" \
+		"$HOST/api/v0/shared/$UPPER/media/refresh"
+	if [ "$CURL_STATUS" = "202" ] || [ "$CURL_STATUS" = "409" ]; then
+		_pass "uppercase hash is accepted (HTTP $CURL_STATUS)"
+	else
+		_fail "uppercase hash" "expected 202 or 409, got $CURL_STATUS"
+	fi
+else
+	echo "    info: nothing shared; single-file checks skipped"
+fi
+
+echo
+if [ "$FAIL_COUNT" -eq 0 ]; then
+	echo "OK: $TEST_COUNT/$TEST_COUNT passed"
+	exit 0
+fi
+echo "FAIL: $FAIL_COUNT/$TEST_COUNT failed"
+exit 1

--- a/unittests/curl-tests/amuleapi/run-all.sh
+++ b/unittests/curl-tests/amuleapi/run-all.sh
@@ -256,6 +256,7 @@ PHASES=(
 	36-shared-reload.sh
 	37-shared-availability-parts.sh
 	38-chat.sh
+	39-shared-media-refresh.sh
 )
 
 # Override list from the command line if given.


### PR DESCRIPTION
Addresses #1079. **Core, EC and REST only - the GUI entry point is a deliberate follow-up**, see Scope below.

## Why this is needed

Once a shared file carried any media tag, nothing could make aMule read it again. The scheduler skips anything already probed, and the only caller that bypassed that gate was download completion. So a value stored by an earlier build was permanent short of deleting `known.met` - which also discards the ed2k part hashes, the AICH master hashes and every per-file statistic.

Those are exactly the two populations **#1089 deferred to this issue**: a download that completed before that change keeps its inherited preview, and a file probed by an older build keeps its cover-art codec (it also carries a real length, so it looks probed to every version of the gate).

## The trap the issue warned about

`bForceReprobe` bypassed **both** guards, and the two callers need different ones - so it becomes a mode:

| Mode | metadata gate | partfile guard |
|---|---|---|
| `Normal` | applies | applies |
| `Completion` | bypassed | **bypassed** - a just-completed download is still a `CPartFile` object while its bytes are all on disk |
| `Refresh` | bypassed | **applies** - an in-progress download is in the shared list and has nothing complete to read |

Reusing the existing flag for the refresh would have handed ffprobe every `<hash>.part` in the queue.

## Semantics

Each probe **replaces** every media field, including *clearing* one the new probe no longer finds, so a refresh corrects a value in both directions. That works because #1089 made a successful probe authoritative and added `RemoveTag`.

Nothing else is touched: no re-hash, the ed2k hash does not change, the file never leaves the share, and statistics / comment / rating / priority / AICH hashes all survive.

## EC

`EC_OP_REFRESH_MEDIA_METADATA` (`0x67`), with an optional `EC_TAG_KNOWNFILE` for the single-file form, answering `EC_TAG_KNOWNFILE_MEDIA_QUEUED`.

**Deliberately not behind a capability tag.** A daemon that predates it answers `EC_OP_FAILED`, which the client reports as unsupported. Unlike the chat ops in #1053 this is user-triggered once rather than polled every tick, so an old core sees a single rejected request instead of a repeating one. Worth knowing: `wxFAIL` is still in the unknown-opcode branch, and whether it fires depends on the wxWidgets the core was built against rather than on aMule's own build type - `wx-config` is what supplies `wxDEBUG_LEVEL`. A core linked against a release wx (`-DwxDEBUG_LEVEL=0`, what Homebrew ships) compiles the assert out and returns the failure cleanly. One linked against an asserts-enabled wx logs an assertion and carries on - **except under `--disable-fatal`, where `ReportAssertFailure` reaches `raise(SIGABRT)` and the daemon dies.** That flag exists so a supervisor sees a non-zero exit and restarts aMule, which is exactly the deployment where an older amuled meets a newer amuleapi, so the worst case is a killed daemon per request rather than a line in a log. That does not change the decision above, but it is the real shape of the risk it was weighed against.

## REST

`POST /shared/media/refresh` and `POST /shared/{hash}/media/refresh`, both `202` with how many probes were queued - nothing has been extracted when the response returns. `queued` counts files *accepted*; the scheduler's drops (not audio/video, an incomplete download) are not counted. A refresh deliberately does **not** stat each file first: the whole-share form runs from an EC handler on the main thread, and N synchronous `stat()` calls before the reply goes out is the stall the shared-files reload was made asynchronous to avoid, and the worker stats the path again before spawning ffprobe anyway. The cost is that `queued` can include a file deleted since, which is honest - it reports what was accepted for probing, not what produced metadata.

An unknown opcode surfaces as **503 `ec_unsupported`** - the same code and error slug as the seven other places in `Api.cpp` that detect an older core. 501 is arguably the better literal answer for "the server does not implement this", but one endpoint disagreeing with seven is worse than either choice.

Both forms answer `202` with no result, so **progress arrives as `shared_updated` SSE events**: media metadata now takes part in the shared-file diff and rides the event payload, and the `GET /shared` list item carries it too - the payloads are documented to match byte-for-byte, and a subscriber that had to re-GET to see a refresh land would defeat the point. Before this, a file whose metadata had just changed compared *equal*, so a refresh was invisible to every subscriber and polling `/shared/{hash}` was the only way to see it land.

## Verification

End to end against a live daemon, swapping a file's content underneath aMule:

| | length | artist |
|---|---|---|
| before | 5 s | `First Artist` |
| content swapped, no refresh | 5 s | `First Artist` (stale, as expected) |
| after `POST /shared/{hash}/media/refresh` | **12 s** | **`""`** |

The cleared artist and title are the point - the field is *removed*, not left behind. A whole-share refresh corrected a second file the same way (`queued: 2`).

The SSE half was checked the same way, as a paired control: with the diff fields reverted a refresh that changed artist and title emitted no `shared_updated` at all; with them in place the event fires carrying the new values.

`22-sse-diff-emission.sh` gained the shared-side key-parity check that was missing - the list and the event are built by two separate writers, and only the `status_changed` pairing was mechanically compared before, which is why this drifted silently. Verified by breaking parity on purpose: the check names `media` as `sse_only` and fails.

New curl phase `39-shared-media-refresh.sh`, 13/13: both forms, `queued` shape, method and auth gating (405 / 401 / 403), unknown hash 404, uppercase hash, and a clean short-circuit when the daemon answers 503.

41/41 tests, clang-format and clang-tidy Tier-2 clean, catalogs regenerated and verified with CI's own filter.

## Scope

The issue also asks for an entry in the shared-files view of aMule and amulegui, with a confirmation dialog and progress. That is **not** here. It touches a third build and this diff already spans core, EC and REST - and #1089 is a fresh argument against bundling more into one change.

Shipping this half first is not just size management: the issue's own case for the feature is headless deployments (`amuled` + `amuleapi`, where there is no dialog to stumble across the setting in), and those get it now. `CMediaProbeThread::PendingCount()` is added and unused here - it exists for the progress indicator the GUI half will need.


