### PR TITLE
perf(amuleapi): resolve removal hashes outside the locked walk, and cover the untested diff paths

### DIFF
--- a/src/webapi/EventDiff.cpp
+++ b/src/webapi/EventDiff.cpp
@@ -637,6 +637,10 @@ void EmitDiffsAndUpdate(CEventBus &bus, LastSeenState &prev, const CState &state
 		// everything else, resolved against `prev.files` once the lock is
 		// released -- the write-back below leaves that entry equal to the live
 		// one, so it is the same object the payload would have been built from.
+		// Removals name their subject by ECID for the same reason: copying the
+		// hash out would put one string allocation per removed file back under
+		// the lock, and `prev.files` still holds the entry -- the `gone` erase
+		// is deferred until the batch is built.
 		enum class Change
 		{
 			DownloadAdded,
@@ -645,10 +649,11 @@ void EmitDiffsAndUpdate(CEventBus &bus, LastSeenState &prev, const CState &state
 			SharedUpdated,
 			CommentsUpdated,
 		};
-		std::vector<std::pair<const char *, std::string>> removed;
+		std::vector<std::pair<const char *, std::uint32_t>> removed;
 		std::vector<std::pair<Change, std::uint32_t>> changed;
-		// ECIDs to drop from the baseline once the walk is done -- erasing
-		// during it would invalidate the iterator.
+		// ECIDs to drop from the baseline once the batch is built -- erasing
+		// during the walk would invalidate the iterator, and erasing before
+		// the batch would take the removal payloads' hashes with it.
 		std::vector<std::uint32_t> gone;
 		state.WithFiles([&](const FileMap &files) {
 			// _removed first — clients can tear down their cache slot
@@ -657,10 +662,10 @@ void EmitDiffsAndUpdate(CEventBus &bus, LastSeenState &prev, const CState &state
 				const auto it = files.find(kv.first);
 				const bool absent = (it == files.end());
 				if (kv.second.is_downloading && (absent || !it->second.is_downloading)) {
-					removed.emplace_back("download_removed", kv.second.hash);
+					removed.emplace_back("download_removed", kv.first);
 				}
 				if (kv.second.is_shared && (absent || !it->second.is_shared)) {
-					removed.emplace_back("shared_removed", kv.second.hash);
+					removed.emplace_back("shared_removed", kv.first);
 				}
 				if (absent)
 					gone.push_back(kv.first);
@@ -713,13 +718,16 @@ void EmitDiffsAndUpdate(CEventBus &bus, LastSeenState &prev, const CState &state
 					prev.files.emplace(entry.first, now);
 			}
 		});
-		for (const std::uint32_t ecid : gone)
-			prev.files.erase(ecid);
-
 		std::vector<std::pair<std::string, std::string>> batch;
 		batch.reserve(removed.size() + changed.size());
-		for (const auto &r : removed)
-			batch.emplace_back(r.first, RemovedHashPayload(r.second));
+		for (const auto &r : removed) {
+			// Still in the baseline: `gone` is erased below, once every
+			// payload that reads through it has been built.
+			const auto it = prev.files.find(r.second);
+			if (it == prev.files.end())
+				continue;
+			batch.emplace_back(r.first, RemovedHashPayload(it->second.hash));
+		}
 		for (const auto &c : changed) {
 			// Every recorded change set `moved`, so its entry was written
 			// back; `gone` holds only ECIDs absent from the live map, which
@@ -746,6 +754,8 @@ void EmitDiffsAndUpdate(CEventBus &bus, LastSeenState &prev, const CState &state
 				break;
 			}
 		}
+		for (const std::uint32_t ecid : gone)
+			prev.files.erase(ecid);
 		bus.PublishBatch(batch);
 	}
 	DiffMap(bus, "server", prev.servers, new_servers, [](const ServerSnapshot &s) {

--- a/src/webapi/EventDiff.cpp
+++ b/src/webapi/EventDiff.cpp
@@ -543,6 +543,21 @@ void EnforceSinglePublisher()
 	std::abort();
 }
 
+// Every file event resolves its payload through `prev.files` after the locked
+// walk, which holds only because nothing erases from that map in between: the
+// `gone` sweep runs after the batch is built, and `gone` is disjoint from
+// everything the walk recorded. Unreachable today -- but a dropped event is
+// invisible, and a lost `shared_removed` leaves a ghost row on every client
+// until something else happens to touch that file. Hard-abort for the same
+// reason EnforceSinglePublisher does: the check has to survive -DNDEBUG,
+// because that is where the ordering will actually get broken.
+[[noreturn]] void AbortOnMissingBaseline(const char *event_name, std::uint32_t ecid)
+{
+	std::cerr << "amuleapi: file diff lost the baseline entry for ECID " << ecid << " while building "
+		  << event_name << "; the prev.files erase has moved ahead of the batch build.\n";
+	std::abort();
+}
+
 } // namespace
 
 // One chat message as the `message` object both the SSE payload and
@@ -725,7 +740,7 @@ void EmitDiffsAndUpdate(CEventBus &bus, LastSeenState &prev, const CState &state
 			// payload that reads through it has been built.
 			const auto it = prev.files.find(r.second);
 			if (it == prev.files.end())
-				continue;
+				AbortOnMissingBaseline(r.first, r.second);
 			batch.emplace_back(r.first, RemovedHashPayload(it->second.hash));
 		}
 		for (const auto &c : changed) {
@@ -734,7 +749,7 @@ void EmitDiffsAndUpdate(CEventBus &bus, LastSeenState &prev, const CState &state
 			// these are not.
 			const auto it = prev.files.find(c.second);
 			if (it == prev.files.end())
-				continue;
+				AbortOnMissingBaseline("a file event", c.second);
 			const FileSnapshot &f = it->second;
 			switch (c.first) {
 			case Change::DownloadAdded:

--- a/unittests/tests/EventDiffTest.cpp
+++ b/unittests/tests/EventDiffTest.cpp
@@ -40,12 +40,21 @@ using namespace webapi;
 
 DECLARE_SIMPLE(EventDiff)
 
+// Drain `bus` non-blockingly and return every event newer than `since` in id
+// order. Drain is a replay from a cursor, not a consume: draining from 0 twice
+// yields the same events twice, so a test asserting that a later tick emitted
+// *nothing* has to carry the cursor forward.
+static std::vector<Event> DrainSince(CEventBus &bus, std::uint64_t since)
+{
+	std::vector<Event> out;
+	bus.Drain(since, std::chrono::milliseconds(0), out);
+	return out;
+}
+
 // Drain `bus` non-blockingly and return all events in id order.
 static std::vector<Event> DrainAll(CEventBus &bus)
 {
-	std::vector<Event> out;
-	bus.Drain(0, std::chrono::milliseconds(0), out);
-	return out;
+	return DrainSince(bus, 0);
 }
 
 // log_appended cold-start: the first tick must not emit log_appended
@@ -800,4 +809,172 @@ TEST(EventDiff, DownloadUpdatedFiresWhenOnlyHashingProgressMoved)
 	}
 	ASSERT_TRUE(!payload.empty());
 	ASSERT_TRUE(payload.find("\"hashing_progress\":5") != std::string::npos);
+}
+
+// A file leaving the map fires download_removed carrying its hash, and drops
+// out of the baseline — the `gone` erase. Without it the baseline would grow
+// without bound across a session and keep re-firing the removal every tick.
+TEST(EventDiff, DownloadRemovedFiresWhenTheFileLeavesTheMap)
+{
+	CState state;
+	state.MutateDownloads([](FileMap &files) {
+		FileSnapshot f;
+		f.ecid = 21;
+		f.hash = "3333333333333333333333333333cccc";
+		f.name = "gone.iso";
+		f.size = kPartSizeBytes * 2;
+		f.is_downloading = true;
+		files.emplace(f.ecid, f);
+	});
+
+	CEventBus bus;
+	LastSeenState prev;
+	EmitDiffsAndUpdate(bus, prev, state); // baseline: download_added
+	DrainAll(bus);
+	ASSERT_EQUALS(static_cast<std::size_t>(1), prev.files.size());
+
+	// FileMap::erase is iterator-only — it keeps the hash index in step.
+	state.MutateDownloads([](FileMap &files) { files.erase(files.find(21)); });
+	EmitDiffsAndUpdate(bus, prev, state);
+
+	int removed_events = 0;
+	std::string payload;
+	for (const auto &e : DrainAll(bus)) {
+		if (e.name == "download_removed") {
+			++removed_events;
+			payload = e.data;
+		}
+	}
+	ASSERT_EQUALS(1, removed_events);
+	ASSERT_TRUE(payload.find("3333333333333333333333333333cccc") != std::string::npos);
+	// Baseline entry erased, so a third tick stays silent.
+	ASSERT_TRUE(prev.files.empty());
+	const std::uint64_t cursor = bus.NewestId();
+	EmitDiffsAndUpdate(bus, prev, state);
+	ASSERT_TRUE(DrainSince(bus, cursor).empty());
+}
+
+// The share flag clearing on a file that stays in the map fires shared_removed
+// without erasing the baseline entry: the ECID is still live, only that role
+// ended.
+TEST(EventDiff, SharedRemovedFiresWhenOnlyTheRoleFlagClears)
+{
+	CState state;
+	state.MutateShared([](FileMap &files) {
+		FileSnapshot f;
+		f.ecid = 22;
+		f.hash = "4444444444444444444444444444dddd";
+		f.name = "unshared.iso";
+		f.size = kPartSizeBytes * 2;
+		f.is_shared = true;
+		f.is_downloading = true;
+		files.emplace(f.ecid, f);
+	});
+
+	CEventBus bus;
+	LastSeenState prev;
+	EmitDiffsAndUpdate(bus, prev, state);
+	DrainAll(bus);
+
+	state.MutateShared([](FileMap &files) { files.find(22)->second.is_shared = false; });
+	EmitDiffsAndUpdate(bus, prev, state);
+
+	int shared_removed = 0, download_removed = 0;
+	for (const auto &e : DrainAll(bus)) {
+		if (e.name == "shared_removed")
+			++shared_removed;
+		if (e.name == "download_removed")
+			++download_removed;
+	}
+	ASSERT_EQUALS(1, shared_removed);
+	// The download role is untouched, so nothing tears down that side.
+	ASSERT_EQUALS(0, download_removed);
+	// Entry stays in the baseline, with the cleared flag written back.
+	ASSERT_EQUALS(static_cast<std::size_t>(1), prev.files.size());
+	ASSERT_TRUE(!prev.files.find(22)->second.is_shared);
+}
+
+// One ECID swapping roles in a single tick emits both families, removed first:
+// a client tearing down its download slot must not see the shared_added for
+// the same file arrive before the download_removed.
+TEST(EventDiff, RoleFlipEmitsRemovedBeforeAdded)
+{
+	CState state;
+	state.MutateDownloads([](FileMap &files) {
+		FileSnapshot f;
+		f.ecid = 23;
+		f.hash = "5555555555555555555555555555eeee";
+		f.name = "completed.iso";
+		f.size = kPartSizeBytes * 2;
+		f.is_downloading = true;
+		files.emplace(f.ecid, f);
+	});
+
+	CEventBus bus;
+	LastSeenState prev;
+	EmitDiffsAndUpdate(bus, prev, state);
+	DrainAll(bus);
+
+	// The download finished: it stops being a download and starts being shared.
+	state.MutateDownloads([](FileMap &files) {
+		FileSnapshot &f = files.find(23)->second;
+		f.is_downloading = false;
+		f.is_shared = true;
+	});
+	EmitDiffsAndUpdate(bus, prev, state);
+
+	int removed_at = -1, added_at = -1, i = 0;
+	for (const auto &e : DrainAll(bus)) {
+		if (e.name == "download_removed")
+			removed_at = i;
+		if (e.name == "shared_added")
+			added_at = i;
+		++i;
+	}
+	ASSERT_TRUE(removed_at >= 0);
+	ASSERT_TRUE(added_at >= 0);
+	ASSERT_TRUE(removed_at < added_at);
+}
+
+// The write-back trap: a role flag flipping is itself enough to refresh the
+// whole baseline entry, so fields the *other* role's predicate never compared
+// cannot reach the payload stale. Here the download sub-block moves during the
+// same tick that is_downloading goes false→true; the download_added must carry
+// the new value, not the one the entry was parked with while it was shared-only.
+TEST(EventDiff, RoleFlipRefreshesFieldsTheOtherRoleNeverCompared)
+{
+	CState state;
+	state.MutateShared([](FileMap &files) {
+		FileSnapshot f;
+		f.ecid = 24;
+		f.hash = "6666666666666666666666666666ffff";
+		f.name = "reshared.iso";
+		f.size = kPartSizeBytes * 4;
+		f.is_shared = true;
+		f.download.size_done = 111;
+		files.emplace(f.ecid, f);
+	});
+
+	CEventBus bus;
+	LastSeenState prev;
+	EmitDiffsAndUpdate(bus, prev, state); // shared_added; download side never compared
+	DrainAll(bus);
+
+	state.MutateShared([](FileMap &files) {
+		FileSnapshot &f = files.find(24)->second;
+		f.is_downloading = true;
+		f.download.size_done = 999;
+	});
+	EmitDiffsAndUpdate(bus, prev, state);
+
+	std::string payload;
+	for (const auto &e : DrainAll(bus)) {
+		if (e.name == "download_added")
+			payload = e.data;
+	}
+	ASSERT_TRUE(!payload.empty());
+	ASSERT_TRUE(payload.find("999") != std::string::npos);
+	ASSERT_TRUE(payload.find("111") == std::string::npos);
+	// And the baseline now carries it, so the next tick is silent.
+	ASSERT_EQUALS(static_cast<std::uint64_t>(999), prev.files.find(24)->second.download.size_done);
 }


### PR DESCRIPTION
Follow-up to #1098, addressing the two findings left open when it merged.

**Removal hashes were still copied under the lock.** The file diff recorded each removal as `(event name, hash)`, copying the string out of the baseline while CState's shared lock was held — one allocation per removed file, so a 12k-file teardown tick put ~12k of them back under the lock that #1098's payload hoist had just cleared. It now records the ECID and resolves the hash when the batch is built, which means the `gone` erase moves to after the batch: a removal for a file that left the map reads its hash through the very entry `gone` drops.

One subtlety worth stating. For an entry still present with its role flag cleared, the hash now comes from the post-write-back snapshot rather than the pre-write-back one. Same value in practice — ECID→hash is the file's identity and doesn't move, and both equality predicates compare `hash` anyway — but it is a real ordering change, not a pure refactor.

**The removal paths had no tests at all.** The `gone` erase, a role flag clearing on a file that stays in the map, and the write-back invariant the diff depends on each ran zero times in CI. Four tests now cover them:

- `DownloadRemovedFiresWhenTheFileLeavesTheMap` — the `gone` erase, including that a later tick stays silent instead of re-firing
- `SharedRemovedFiresWhenOnlyTheRoleFlagClears` — role clear without map removal; the download side must stay untouched
- `RoleFlipEmitsRemovedBeforeAdded` — the removed-before-added ordering `EVENTS.md` promises
- `RoleFlipRefreshesFieldsTheOtherRoleNeverCompared` — the write-back invariant: a field the other role's predicate never compared must not reach the payload stale

Each was checked against a deliberately broken diff rather than only against the working one. Dropping the `gone` erase fails the first; removing the role-flag terms from `moved` fails the last.

`DrainAll` grew a `DrainSince` sibling and is now expressed in terms of it. `Drain` replays from a cursor rather than consuming, so asserting a tick emitted *nothing* needs the cursor carried forward — draining from `0` twice just re-reads the previous tick's events, which is what made the first version of the erase test pass for the wrong reason.

Verified locally: `EventDiffTest` 28/28, clang-format clean whole-file, Tier-2 clang-tidy clean on the diff with 0 compiler errors.
