### PR TITLE
fix(search): report a search that kept no results as finished, not idle

### DIFF
--- a/src/SearchList.cpp
+++ b/src/SearchList.cpp
@@ -1333,8 +1333,34 @@ CSearchList::SearchLifecycleState CSearchList::GetSearchLifecycleStateById(wxUIn
 	if (searchID == m_currentSearch) {
 		return GetSearchLifecycleState();
 	}
-	// Otherwise: results retained => finished; nothing => idle/unknown.
-	return HasSearchResults(searchID) ? SEARCH_LIFECYCLE_FINISHED : SEARCH_LIFECYCLE_IDLE;
+	// Otherwise this id is done, whatever any sweep is still doing: results are
+	// filed under the scalar m_currentSearch (ProcessSearchAnswer /
+	// ProcessUDPSearchAnswer), so once a newer ed2k search takes that scalar
+	// nothing further can land in this id's bucket. Unreachable, not idle.
+	//
+	// Deliberately NOT "no other ed2k search is in flight", which is false on
+	// one of the two paths: only the EC start handler finalizes the previous
+	// sweep (StopInFlightEd2kSearch, whose sole caller it is), while the
+	// monolithic dialog calls StartNewSearch directly and merely abandons it,
+	// so an older search's sweep may well still be running. Reachability of the
+	// bucket is the narrower property, and the one that holds on both paths.
+	//
+	// Deciding this from the retained results instead reported every search
+	// that indexed *nothing* as IDLE forever -- a query no server matched, one
+	// whose every hit AddToList dropped on the file-type filter, or a global
+	// sweep stopped before its first result. IDLE is not terminal, so
+	// GetSearchBarStatusById fell through to the running percent (0) and every
+	// consumer read a finished search as running at 0%: the Stop button stayed
+	// live, the bar never cleared, the EC lifecycle tag said "idle", and the
+	// "an eD2k search is still running" prompt fired on a tab that had long
+	// since finished (issue #1103).
+	//
+	// IsKnownSearchId is the discriminator the result bucket could not be:
+	// m_searchStrings is written when the search starts, independent of what
+	// it kept, so a search started here reads FINISHED whether or not it
+	// retained anything, while an id that is genuinely unknown -- never
+	// started here, or already evicted -- still reads IDLE.
+	return IsKnownSearchId(sid) ? SEARCH_LIFECYCLE_FINISHED : SEARCH_LIFECYCLE_IDLE;
 }
 
 uint8 CSearchList::GetSearchLifecyclePercentById(wxUIntPtr searchID) const

--- a/unittests/curl-tests/amuleapi/19-search.sh
+++ b/unittests/curl-tests/amuleapi/19-search.sh
@@ -1070,6 +1070,53 @@ else
 	_fail "failed start: subsequent search" "POST /search returned no id ($AFTER_BAD)"
 fi
 
+# --- 13.1 A search that retained no results still reports a terminal state.
+#
+# The per-id lifecycle used to be inferred from the retained result bucket, so a
+# search that indexed nothing -- no server match, every hit dropped by the file
+# type filter, or a global sweep stopped before its first result -- reported
+# `idle` forever. `idle` is not terminal, so the progress sentinel fell through
+# to the running percent (0) and every consumer read a finished search as still
+# running at 0%: Stop stayed live, the bar never cleared, and amulegui's "an
+# eD2k search is still running" prompt fired on a long-finished tab (issue
+# #1103).
+#
+# Two searches are needed. While a search is the most recent one its state comes
+# from the live scalar, which was always right; only the older of the two takes
+# the inferred path this asserts on.
+ZERO_QUERY="amuleapi19nosuchkeyword"
+_curl -X POST -H "Authorization: Bearer $ADMIN_TOKEN" \
+	-H "Content-Type: application/json" \
+	-d "{\"query\":\"$ZERO_QUERY\",\"type\":\"global\"}" "$HOST/api/v0/search"
+_assert_status 202 "POST /search (zero-result probe) → 202"
+ZERO_SID=$(printf '%s' "$CURL_BODY" | jq -r '.search_id')
+
+_curl -X POST -H "Authorization: Bearer $ADMIN_TOKEN" \
+	-H "Content-Type: application/json" \
+	-d "{\"query\":\"${ZERO_QUERY}b\",\"type\":\"global\"}" "$HOST/api/v0/search"
+_assert_status 202 "POST /search (demotes the zero-result probe) → 202"
+DEMOTER_SID=$(printf '%s' "$CURL_BODY" | jq -r '.search_id')
+
+_curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/search"
+_assert_status 200 "GET /search → 200 (after the zero-result probe)"
+ZERO_COUNT=$(printf '%s' "$CURL_BODY" \
+	| jq -r "[.searches[] | select(.search_id == $ZERO_SID)][0].result_count // empty")
+# Guarded on the probe actually having retained nothing: on a daemon where the
+# nonsense keyword somehow matched, this assertion would pass through the
+# results-retained branch and prove nothing.
+if [ "$ZERO_COUNT" = "0" ]; then
+	_assert_json_eq "[.searches[] | select(.search_id == $ZERO_SID)][0].state" finished \
+		'a demoted search that retained no results reports finished, not idle'
+else
+	_skip "zero-result lifecycle: probe retained ${ZERO_COUNT:-no} result(s), not 0"
+fi
+
+# Free both probes so the browse contract below sees the search set it expects.
+for sid in "$ZERO_SID" "$DEMOTER_SID"; do
+	curl -s -X DELETE -H "Authorization: Bearer $ADMIN_TOKEN" \
+		"$HOST/api/v0/search/$sid" > /dev/null 2>&1
+done
+
 # --- Browse ("View Files") contract. -------------------------------
 # POST /clients/{ecid}/shared_files starts a browse and returns a
 # search_id; the files themselves arrive over the network from the peer,


### PR DESCRIPTION
Closes #1103.

`GetSearchLifecycleStateById` decided a non-current ed2k search's state from its retained result bucket, so a search that indexed nothing reported `SEARCH_LIFECYCLE_IDLE` forever. `HasSearchResults` is keyed on the result index and `IndexResult` only creates a search's entry when a result is actually filed, so "kept nothing" and "never heard of it" were the same answer.

`IDLE` is not a terminal state. `GetSearchBarStatusById` emits the `0xffff` / `0xfffe` sentinel only for `FINISHED` and otherwise falls through to the running percent, which is 0 for an `IDLE` id, so every consumer read a finished search as running at 0%:

- the monolithic GUI and amulegui kept **Stop** enabled and never cleared the progress bar
- the "an eD2k search is still running" prompt added in #1046 fired on a tab whose search had long since finished, which is what #1103 reports
- `EC_TAG_SEARCH_LIFECYCLE_STATE` said `idle` to amuleapi / amuleweb / amulecmd, and amuleapi's refresher took its defensive not-complete/not-active branch

Only the *older* of two searches is affected: while a search is `m_currentSearch` its state comes from the live scalar, which was always right. That is why #1103 reproduces on toggling Local/Global back and forth rather than on the first switch.

Three ways to reach it, all indistinguishable to the user: no server matched the query, every hit was dropped by `AddToList`'s file-type or filesize filter, or a global sweep was stopped before its first result — `StopSearch` clears `m_currentSearch`, so the id drops straight to the inferred path.

**The fix.** `IsKnownSearchId` is the discriminator the result bucket could not be: `m_searchStrings` is written when the search starts, independent of what it retained, so a search started here reads `FINISHED` whether or not it kept anything, while a genuinely unknown id — never started here, or already evicted — still reads `IDLE`.

**What `finished` means here.** It is "this search is over, nothing further will be filed under it" — not "every server replied". That is already the shipped meaning: master reports `finished` for a sweep cut short after N hits, because `HasSearchResults` was the only thing separating the two states. What makes that right for a demoted id is narrow: results are filed under the scalar `m_currentSearch` (`ProcessSearchAnswer` / `ProcessUDPSearchAnswer`), so once a newer ed2k search takes that scalar nothing further can land in the older id's bucket. Deliberately *not* "no other ed2k search is in flight" — that is false on the monolithic path, where `SearchDlg` calls `StartNewSearch` directly and merely abandons the previous sweep rather than halting it; only the EC start handler finalises it, via `StopInFlightEd2kSearch`'s sole call site. Bucket reachability is the property that holds on both paths, and it is the one the fix rests on. The inconsistency this removes shows up inside a single listing on master: a naturally completed zero-result search reports `finished` while its demoted twin from the same query reports `idle`.

Kad and browse are unaffected; both return from earlier branches. A Kad keyword search records itself finished from `~CSearch()` regardless of result count, and a browse's state comes from `CBrowseManager` — the browse half of this same bug was already fixed for the listing in #1060.

**Test.** `19-search.sh` gains section 13.1: two searches, then the older one must report `finished` rather than `idle`. Two are needed for the reason above. It is guarded on the probe actually having retained nothing, and placed after the sections that need `FIRST_SID` to still be the most recent search — a new ed2k search finalises the one in flight, so starting these earlier broke section 3.5 and would have starved section 4's result poll.

Verified against a live daemon connected to both ed2k and Kad, running the #1103 scenario directly against `GET /search`:

```
before   {"search_id":1,"query":"testtesttest","state":"idle","result_count":0}
         {"search_id":2,"query":"testtesttestb","state":"finished","result_count":0}

after    {"search_id":1,"query":"testtesttest","state":"finished","result_count":0}
         {"search_id":2,"query":"testtesttestb","state":"finished","result_count":0}
```

The new assertion fails with `expected finished, got idle` on master and passes with the fix; that control run also showed two earlier zero-result `ubuntu` searches stuck at `idle`. Suite goes 139/140 — the single failure is the throwaway test node losing its LowID server connection mid-run, which reproduces on master too. 41/41 unit tests pass; clang-format and both clang-tidy tiers are clean on the diff.

**Not in scope.** A local search whose `OP_SEARCHRESULT` never arrives never reaches a terminal state at all, and reports `running` indefinitely. That is a distinct defect on the current-search path this PR does not touch — filed as #1111.
