### PR TITLE
fix(amuleapi): protocol and correctness defects across the v0 surface

### DIFF
--- a/docs/api/EVENTS.md
+++ b/docs/api/EVENTS.md
@@ -162,6 +162,7 @@ Every event belongs to a single channel. The full set, prefix-mapped from the ev
 | `logs` | `log_*` | amuled log buffer (live tail; serverinfo is poll-only) |
 | `search` | `search_*` | Result deltas, completion, and the freeing of a search |
 | `chats` | `chat_*` | Peer chat messages, and conversations being closed |
+| `comments` | `comments_*` | Comment/rating lists on a download |
 
 By default every channel is delivered. To subscribe to a subset, pass `?channels=` with a comma-separated list:
 
@@ -269,11 +270,12 @@ Only the hash; clients look up and drop the cache entry by hash.
 
 #### `comments_updated`
 
-Fires whenever a download's comment/rating list changes — a Kad note arriving during a `POST /downloads/{hash}/comments` lookup, **or** a connected ed2k source reporting its comment. Payload is byte-for-byte the `GET /downloads/{hash}/comments` body, so a client can update its comments view directly from the event without re-fetching:
+Fires whenever a download's comment/rating list changes — a Kad note arriving during a `POST /downloads/{hash}/comments` lookup, **or** a connected ed2k source reporting its comment. Payload is the `GET /downloads/{hash}/comments` body plus `hash`, so a client can update its comments view directly from the event without re-fetching. The extra key is there because nothing else in the frame identifies the file:
 
 ```json
 {
   "hash": "8b54a3c2...",
+  "kad_comment_search_running": false,
   "count": 2,
   "comments": [
     { "username": "alice",    "filename": "Some.Movie.mkv", "rating": 5, "comment": "great quality" },
@@ -282,7 +284,7 @@ Fires whenever a download's comment/rating list changes — a Kad note arriving 
 }
 ```
 
-Downloads only. It's kept separate from `download_updated` so the per-tick download frame stays lean — comments ride their own event and only when they actually change.
+Downloads only, but it rides the `comments` channel, not `downloads` -- `?channels=downloads` alone will not deliver it. It's kept separate from `download_updated` so the per-tick download frame stays lean — comments ride their own event and only when they actually change.
 
 ### `shared` channel
 

--- a/docs/api/REFERENCE.md
+++ b/docs/api/REFERENCE.md
@@ -296,7 +296,19 @@ Every non-2xx response carries the same shape:
 
 ### ETag and conditional GET
 
-Every `GET` or `HEAD` that returns `200` carries an `ETag: "<md5-hex>"` header. Clients that re-fetch should send `If-None-Match: "<etag>"` and accept `304 Not Modified` (no body, ETag preserved). The ETag is keyed on `(request target, last refresher snapshot timestamp)` and memoized — repeated GETs against the same path between refresher ticks skip the body hash entirely. `HEAD` returns the same headers (including ETag) with an empty body.
+Every `GET` or `HEAD` that returns `200` carries an `ETag` header. Clients that re-fetch should send `If-None-Match: "<etag>"` and accept `304 Not Modified` (no content, ETag preserved). `If-None-Match` accepts `*`, a comma-separated list, and weak `W/"..."` validators.
+
+The validator is memoized for two collections only, `/downloads` and `/shared`, keyed on the target plus a revision that every writer of those bodies advances. Repeated GETs between changes skip the body hash; everything else on the surface is hashed per request. Eligibility is opt-in rather than exclusion-based, because a resource qualifies only if its body moves solely when the state moves AND is identical for every caller. Anything with its own cache, an append-only mirror, a refresh-on-read, a live daemon roundtrip per request, or a per-caller body is simply not in the set. `/auth/session` is per-caller and is additionally marked `Cache-Control: private, no-store` (see below).
+
+`HEAD` returns the same headers as the equivalent `GET`, including `ETag` and a `Content-Length` describing the body the `GET` would return, and no content -- on every status, not only `200`. The one exception is [`GET /api/v0/events`](#get-apiv0events): its body is an unbounded chunked stream, so a `HEAD` there reports the stream's headers and no length. Note that this is why `curl -X HEAD` appears to hang or fail: `-X` only changes the method string, leaving curl waiting for a body that a HEAD response correctly never sends. Use `curl --head` (or `-I`).
+
+A validator names one representation, not one URL. When a response is compressed the `ETag` carries a `-gzip` suffix, so the gzipped and identity forms of the same resource never share a validator, and an `If-None-Match` is only a hit against the form the current request would actually receive. A client that stored `"abc123-gzip"` and then re-fetches with `Accept-Encoding: identity` gets a `200` with the identity body, which is the correct answer -- the stored entry does not describe it. Store the validator alongside the encoding you received, which is what an HTTP cache does anyway.
+
+**Caching policy.** Any request that presented credentials -- a bearer token or the session cookie -- is answered `Cache-Control: private` with `Cookie` added to `Vary`. `private` keeps the response out of shared caches, while still letting the client's own cache hold it and revalidate with `If-None-Match`; `no-store` would forbid that too and there would be no stored entry left for the conditional GET above to match. [`POST /api/v0/auth/session`](#post-apiv0authsession) is the deliberate exception and is `private, no-store`: it carries the credential itself, which should not be written down anywhere. Requests without credentials are left cacheable. Static assets are the other case. The WebUI shell and its bundles are byte-identical for every caller, so an authenticated request for one is answered exactly as an anonymous request is, and they carry `public, no-cache`. Both tokens do work. `no-cache` means revalidate every time -- not "do not store": the copy stays cached and an unchanged bundle costs one conditional request answered `304`. `public` is what lets a shared cache in front of the daemon keep one copy rather than one per caller: RFC 9111 §3.5 bars a shared cache from reusing a response to a request that carried an `Authorization` header unless the response is marked `public`, `must-revalidate` or `s-maxage`, and `no-cache` is not on that list. The browser WebUI is not the case that engages this -- it authenticates by cookie, which is why the authenticated stamp above adds `Cookie` to `Vary` rather than relying on §3.5 at all. A bearer-token client fetching the same shell is the case that engages it.
+
+There is no freshness lifetime on them because these filenames carry no content hash: `index.html`, `app.js` and `app.css` keep their names across a rebuild, so a `max-age` would let an upgraded daemon keep serving the old shell until the entry expired, and -- since each asset expires on its own clock -- pair a new shell with an old bundle. `must-revalidate` would not prevent that: it governs what a cache may do once an entry is *already* stale (RFC 9111 §5.2.2.2), not whether it may be used while fresh.
+
+The [country flags](#get-flagscodepng) take the opposite trade and keep `public, max-age=86400`. That artwork is compiled into the daemon, so it changes only with a new build, and a peer list is a page full of `<img>` tags: a day of freshness turns those into cache hits instead of one conditional request per distinct country per reload. The `max-age` is what bounds how long an upgraded daemon can keep serving the old art -- a day, not forever.
 
 Mutations (`POST`/`PATCH`/`DELETE`) and error responses are never ETag-stamped; the body always ships.
 
@@ -306,8 +318,8 @@ If `amuleapi.conf[Server]/AllowCORS=1`:
 
 - Every response carries `Vary: Origin`.
 - The origin is echoed in `Access-Control-Allow-Origin` if either the allowlist is empty (any-origin echo) or the request's `Origin` header matches a configured entry.
-- Allowed responses also carry `Access-Control-Allow-Credentials: true` and `Access-Control-Expose-Headers: ETag` so cookie-auth clients can read the validator from JS.
-- Preflight (`OPTIONS` with `Access-Control-Request-Method`) returns `204` with `Access-Control-Allow-Methods: GET, HEAD, POST, PATCH, DELETE, OPTIONS`, `Access-Control-Allow-Headers: Authorization, Content-Type, If-None-Match, Last-Event-ID`, and `Access-Control-Max-Age: 86400`.
+- Allowed responses also carry `Access-Control-Allow-Credentials: true` and `Access-Control-Expose-Headers: ETag, Allow, Retry-After` so cookie-auth clients can read the validator, the supported-method list from a `405`, and the back-off hint from a `429` or `503`, from JS.
+- Preflight (`OPTIONS` with `Access-Control-Request-Method`) returns `204` with `Access-Control-Allow-Methods: GET, HEAD, POST, PUT, PATCH, DELETE, OPTIONS`, `Access-Control-Allow-Headers: Authorization, Content-Type, If-None-Match, Last-Event-ID`, and `Access-Control-Max-Age: 86400`.
 
 ### Path validation
 
@@ -315,11 +327,12 @@ The dispatcher rejects paths containing NUL, encoded NUL (`%00`), encoded `..` (
 
 ### Request size limits
 
-- HTTP header section: hard cap 16 KiB.
-- Request body: hard cap 1 MiB.
+- HTTP header section: hard cap 16 KiB. Exceeding it is `431 headers_too_large`.
+- Request body: hard cap 1 MiB. Exceeding it is `413 payload_too_large`.
+- A request that is not fully sent within 10 s is `408 request_timeout`.
 - JSON nesting: `>32` opening `{` or `[` tokens → `400 bad_request`. Applies to every body parser and to the JWT header/payload sections of bearer tokens.
 
-Above any of these, the connection is rejected before the handler runs.
+The first three are answered by the transport before any handler runs, and each closes the connection after answering, with `Connection: close` on the response.
 
 ## Endpoint catalog
 
@@ -2859,7 +2872,7 @@ Every error code emitted by `/api/v0/*`, sorted by what triggered it. Two codes 
 | `forbidden` | 403 | Authenticated as `guest` but the endpoint requires `admin`. |
 | `not_found` | 404 | Resource doesn't exist (unknown hash, ECID, graph name, or no such endpoint). |
 | `method_not_allowed` | 405 | Wrong HTTP verb for the route. The response carries an `Allow` header listing the methods this resource does support. |
-| `conflict` | 409 | The request is valid but the daemon is not in a state that can serve it — the `mmap` capability gate. |
+| `conflict` | 409 | The request is valid but the daemon cannot serve it as asked: it was built without support for the option being set, or the client named on an A4AF request is not an A4AF source of that download. |
 | `partfile_unsupported` | 409 | Verify Local Data requested on a file that is still an incomplete partfile. |
 | `not_shared` | 409 | A comment or rating was posted against a file that is not shared. |
 | `not_completed` | 409 | `clear_completed` named a `hash` that is not a completed download. |

--- a/docs/api/REFERENCE.md
+++ b/docs/api/REFERENCE.md
@@ -1400,7 +1400,7 @@ Returns `202 Accepted`. amuled schedules the re-walk and answers immediately, so
 
 Repeated calls coalesce: requesting a reload while one is already pending, or while a walk is in progress, results in a single further walk rather than one per call.
 
-**Reading the result.** The walk brackets itself with two amule log lines, so read them back from [`GET /api/v0/logs/amule`](#get-apiv0logsamule) or the `log` SSE channel. Both are localised and the second is pluralised, so a client matching on them should pin the daemon's locale:
+**Reading the result.** The walk brackets itself with two amule log lines, so read them back from [`GET /api/v0/logs/amule`](#get-apiv0logsamule) or the `logs` SSE channel. Both are localised and the second is pluralised, so a client matching on them should pin the daemon's locale:
 
 - `Reloading shared files...` when the walk starts
 - `Found 1234 known shared files` when it ends
@@ -1565,7 +1565,7 @@ Returns `202 Accepted`. amuled queues the hashing task and answers immediately, 
 
 **Watching it run.** While the task is hashing, `hashing_progress` on the file's [`GET /shared`](#get-apiv0shared) row counts the parts done so far, and each advance pushes a `shared_updated` SSE event — enough to drive a progress bar without polling. It returns to `0` when the task finishes or aborts, which is the signal that the log line below is available.
 
-**Reading the result.** The verdict is emitted as an amule log line when the task completes, so read it back from [`GET /api/v0/logs/amule`](#get-apiv0logsamule) or the `log` SSE channel:
+**Reading the result.** The verdict is emitted as an amule log line when the task completes, so read it back from [`GET /api/v0/logs/amule`](#get-apiv0logsamule) or the `logs` SSE channel:
 
 - `Verify Local Data (MD4 & AICH): Result OK for <path>`
 - `Verify Local Data (MD4 & AICH): ERRORS FOUND! <path> Failed blocks: MD4: 3,7 AICH: 5: (0,2)`
@@ -2206,7 +2206,7 @@ Standalone view of the Kad subtree from `/status`, plus the detail fields the st
 
 The IP-filter *settings* are ordinary preferences (`security.ipfilter_*` on [`GET`/`PATCH /api/v0/preferences`](#get-apiv0preferences)). The two endpoints here are the standalone operations behind the desktop client's Security page buttons: reloading the filter files amuled already has on disk, and downloading a new one.
 
-Neither reports its outcome in the response — amuled answers both immediately and does the work asynchronously. What actually happened shows up only in the amule log, readable through [`GET /api/v0/logs/amule`](#get-apiv0logsamule) or the `log` SSE channel. The lines to watch for:
+Neither reports its outcome in the response — amuled answers both immediately and does the work asynchronously. What actually happened shows up only in the amule log, readable through [`GET /api/v0/logs/amule`](#get-apiv0logsamule) or the `logs` SSE channel. The lines to watch for:
 
 | Line | Meaning |
 |---|---|
@@ -2568,7 +2568,7 @@ amuled keeps a bounded ring of recent searches (20). A search evicted from that 
 }
 ```
 
-Each result carries `sources` as a nested `{total, complete}` object — `total` is the swarm size amuled reports and `complete` is how many of those hold the file complete. `already_have` is `true` when you are currently downloading the file or already have it completed/shared; it is `false` for a fresh result and for one you have canceled/removed (a canceled result is re-downloadable, so it does not read as held). `rating` is amuled's aggregated quality rating (`0` when unrated). `status` is this result's download status on your node — `"new"` / `"downloaded"` / `"queued"` / `"canceled"` / `"queued_canceled"`. `type` is the file-type token derived from the filename extension (same tokens as the shared-detail [`file_type`](#get-apiv0sharedhash), e.g. `"videos"` / `"audio"`; `""` when the name has no extension). `media` is the audio/video [media metadata](#media-metadata) object (same shape as the file-detail endpoints) — **present only** for a hit that is already known/probed locally, and **omitted entirely** for remote hits with no metadata (most global/Kad results), matching the blank Length/Bitrate/Codec columns in the desktop search list.
+Each result carries `sources` as a nested `{total, complete}` object — `total` is the swarm size amuled reports and `complete` is how many of those hold the file complete. `already_have` is `true` when you are currently downloading the file or already have it completed/shared; it is `false` for a fresh result and for one you have canceled/removed (a canceled result is re-downloadable, so it does not read as held). `rating` is amuled's aggregated quality rating (`0` when unrated). `status` is this result's download status on your node — `"new"` / `"downloaded"` / `"queued"` / `"canceled"` / `"queued_canceled"`. `type` is the file-type token derived from the filename extension (same tokens as the shared-detail [`file_type`](#get-apiv0sharedhash), e.g. `"videos"` / `"audio"`; `""` when the name has no extension). `media` is the audio/video [media metadata](#media-metadata) object (same shape as the file-detail endpoints), and is **omitted entirely** for a hit that carries no metadata (most global/Kad results), matching the blank Length/Bitrate/Codec columns in the desktop search list. **Unlike `media` on `GET /downloads/{hash}` and `GET /shared/{hash}`, which amuled probed locally, `media` on a search result is whatever the responding server advertised.** It is not verified against the file and can contradict it — a `.pdf` reporting a runtime and a video codec is a real observed result — so treat it as a hint, not as probed metadata.
 
 `directory` is the folder this file sits in **inside a browsed peer's share** — the desktop search list's *Directories* column. It is populated only for results filed from a peer's shared-file listing (see [peer browse](#post-apiv0clientsecidshared_files)) and is `""` on every ordinary server/Kad hit, which never carries it. It is per-result rather than per-search: two copies of one file in different folders of the same share group under a single parent and each keeps its own folder, exactly as the desktop shows them, which is why `children[]` entries carry it too.
 
@@ -2847,23 +2847,36 @@ Closing is **global**, the same way closing a search tab frees the search for ev
 
 ## Error code catalog
 
-Every error code emitted by `/api/v0/*`, sorted by what triggered it. The matching HTTP status is in parentheses.
+Every error code emitted by `/api/v0/*`, sorted by what triggered it. Two codes are emitted with **two different statuses** depending on the cause, so a client that switches on `code` alone must also look at the status for those.
 
 | Code | Status | Meaning |
 |------|--------|---------|
-| `method_not_allowed` | 405 | Wrong HTTP verb for the route. |
 | `bad_request` | 400 | Body, query, or path-segment validation failed. Body parse depth-cap rejects also surface here. |
+| `amuled_rejected` | 400, 502 | amuled rejected the EC operation and the message carries its reason verbatim (400); or amuled answered but its reply was unusable, e.g. no `search_id` came back from a search or a browse (502). |
+| `request_timeout` | 408 | The request was not completed within the 10 s read timeout. |
 | `unauthorized` | 401 | Missing token, bad signature, expired, revoked, or `iat` invariants failed. |
-| `invalid_credentials` | 401 | `/auth/login` password didn't match any role. |
+| `invalid_credentials` | 401, 403 | `/auth/login` password didn't match any role (401); or `PATCH /auth/passwords` was given a `current_password` that does not match (403). |
 | `forbidden` | 403 | Authenticated as `guest` but the endpoint requires `admin`. |
-| `not_found` | 404 | Resource doesn't exist (unknown hash, ECID, graph name). |
+| `not_found` | 404 | Resource doesn't exist (unknown hash, ECID, graph name, or no such endpoint). |
+| `method_not_allowed` | 405 | Wrong HTTP verb for the route. The response carries an `Allow` header listing the methods this resource does support. |
+| `conflict` | 409 | The request is valid but the daemon is not in a state that can serve it — the `mmap` capability gate. |
 | `partfile_unsupported` | 409 | Verify Local Data requested on a file that is still an incomplete partfile. |
+| `not_shared` | 409 | A comment or rating was posted against a file that is not shared. |
+| `not_completed` | 409 | `clear_completed` named a `hash` that is not a completed download. |
+| `completed_use_clear_completed` | 409 | A bulk `DELETE /downloads` matched a completed download; use `clear_completed` for those. |
 | `kad_more_exhausted` | 409 | `POST /search/{id}/more` on a Kad search that can no longer be widened — its 4-reask budget is spent, or it has entered the stopping window Kad begins 20 s before a keyword search ends. Terminal for that search; re-run the query for more. |
+| `update_check_unavailable` | 409 | `POST /version/check` cannot run — the daemon has no update-check capability. |
+| `payload_too_large` | 413 | Request body exceeds the 1 MiB limit. The connection closes after the response. |
 | `rate_limited` | 429 | Per-IP failure bucket full. `Retry-After: <seconds>` accompanies the response. |
-| `login_disabled` | 503 | `/auth/login` reached but no admin AND no guest password configured. |
+| `update_check_throttled` | 429 | `POST /version/check` was throttled by the daemon; try again shortly. |
+| `headers_too_large` | 431 | Request headers exceed the 16 KiB limit. The connection closes after the response. |
+| `internal_error` | 500 | A handler failed internally — hash decode or serialization. The body is generic; details land in the daemon's stderr. |
+| `internal` | 500 | A handler threw. Raised by the HTTP layer's catch-all rather than by a handler, so it is distinct from `internal_error` above; a client that wants every server-side failure must match both. |
+| `bad_gateway` | 502 | amuled returned an EC payload this endpoint could not decode. |
 | `ec_unavailable` | 503 | EC connection not ready yet (cold start, transient amuled restart). |
-| `amuled_rejected` | 400 | amuled rejected the EC operation; the message field carries amuled's reason verbatim. |
-| `internal` | 500 | Handler threw. The body is generic; details land in the daemon's stderr. |
+| `ec_unsupported` | 503 | The connected amuled is too old to serve this route — the chat endpoints and `/known_clients`. |
+| `login_disabled` | 503 | `/auth/login` reached but no admin AND no guest password configured. |
+| `sessions_exhausted` | 503 | Too many concurrent streaming sessions. `Retry-After` accompanies the response. |
 
 `message` is human-readable and may change between releases. Pin on `code`.
 

--- a/src/libwebcommon/Etag.cpp
+++ b/src/libwebcommon/Etag.cpp
@@ -24,6 +24,8 @@
 
 #include "Etag.h"
 
+#include <cstring>
+
 // See CryptoPP_Inc.h for pragma rationale.
 #if defined(__clang__)
 #pragma clang diagnostic push
@@ -78,6 +80,28 @@ static std::string NormalizeOneValidator(const std::string &raw)
 		--end;
 	}
 	return raw.substr(start, end - start);
+}
+
+const char kGzipEtagSuffix[] = "-gzip";
+
+std::string WithCodingSuffix(const std::string &etag, bool coded)
+{
+	const std::size_t suffix_len = std::strlen(kGzipEtagSuffix);
+	// The opaque payload ends before the closing quote in RFC-quoted form
+	// and at the end otherwise; the suffix belongs on the payload, not
+	// outside the quotes.
+	const bool quoted = etag.size() >= 2 && etag.front() == '"' && etag.back() == '"';
+	const std::size_t end = quoted ? etag.size() - 1 : etag.size();
+	const bool present =
+		end >= suffix_len && etag.compare(end - suffix_len, suffix_len, kGzipEtagSuffix) == 0;
+	if (coded == present)
+		return etag;
+	std::string out = etag;
+	if (coded)
+		out.insert(end, kGzipEtagSuffix);
+	else
+		out.erase(end - suffix_len, suffix_len);
+	return out;
 }
 
 bool IfNoneMatchHits(const std::string &if_none_match, const std::string &etag)

--- a/src/libwebcommon/Etag.h
+++ b/src/libwebcommon/Etag.h
@@ -61,6 +61,29 @@ std::string Etag(const std::string &body_utf8);
 // equality).
 bool IfNoneMatchHits(const std::string &if_none_match, const std::string &etag);
 
+// Suffix distinguishing the gzipped representation of a body from the identity
+// one. A strong validator identifies ONE representation, so the same ETag must
+// not describe both codings of a resource -- a cache holding the gzip form and
+// revalidating for a client that cannot accept it would otherwise be told its
+// copy is current. The hash is taken before compression, so the coding is
+// appended by whoever selects the representation, and the conditional-GET
+// comparison runs against that same value -- matching either coding would
+// defeat the point, telling a client holding one representation that its copy
+// of the other is current.
+extern const char kGzipEtagSuffix[];
+
+// Returns `etag` naming the gzipped representation when `coded`, and the
+// identity one when not. Accepts either the bare-hex or the RFC-quoted form
+// and preserves which one it was given.
+//
+// Idempotent, and defined by the representation rather than by the edit: the
+// caller says which coding the value must name, not whether to add or remove
+// anything. That is what lets the transport reconcile the dispatcher's
+// prediction against what compression actually did -- when deflate fails after
+// the suffix was already stamped, the same call takes it back off, and when
+// the prediction held it changes nothing.
+std::string WithCodingSuffix(const std::string &etag, bool coded);
+
 } // namespace webcommon
 
 #endif // LIBWEBCOMMON_ETAG_H

--- a/src/webapi/Api.cpp
+++ b/src/webapi/Api.cpp
@@ -144,6 +144,21 @@ CHttpServer::Response ErrorResponse(unsigned status, const char *code, const cha
 	return r;
 }
 
+// 405 with the `Allow` header RFC 9110 §15.5.6 requires ("The origin server
+// MUST generate an Allow header field in a 405 response containing a list of
+// the target resource's currently supported methods"). The accepted methods
+// were already spelled out in the human-readable message at every rejection
+// site; generic tooling and capability discovery read the header instead, so
+// the same list is now emitted both ways. `allow` is the machine-readable
+// form -- comma-separated, in RFC order -- and includes HEAD wherever GET is
+// served, which several of the messages omit.
+CHttpServer::Response MethodNotAllowed(const char *allow, const char *message)
+{
+	CHttpServer::Response r = ErrorResponse(405, "method_not_allowed", message);
+	r.headers["Allow"] = allow;
+	return r;
+}
+
 // Common preamble for every auth-protected endpoint. Pulls the JWT
 // out of either the Authorization header or the cookie, verifies it,
 // rejects revoked tokens, and exposes the resulting VerifyResult.
@@ -693,7 +708,7 @@ CHttpServer::Response CApiDispatcher::Dispatch(const CHttpServer::Request &req)
 		ApplyCorsHeaders(pre.headers, cors_org, cors_enabled);
 		if (!cors_org.empty()) {
 			pre.headers["Access-Control-Allow-Methods"] =
-				"GET, HEAD, POST, PATCH, DELETE, OPTIONS";
+				"GET, HEAD, POST, PUT, PATCH, DELETE, OPTIONS";
 			// Headers actual requests may send. Authorization for
 			// bearer; If-None-Match for ETag conditional GET;
 			// Last-Event-ID for SSE replay.
@@ -713,13 +728,31 @@ CHttpServer::Response CApiDispatcher::Dispatch(const CHttpServer::Request &req)
 	CHttpServer::Response resp = DispatchToHandler(req);
 
 	const bool is_safe_method = (req.method == "GET" || req.method == "HEAD");
-	if (is_safe_method && resp.status == 200 && !resp.body.empty()) {
+	// A handler that computed its own validator owns it. Stamping the
+	// body hash over the top would hand out two different ETags for one
+	// resource depending on which branch answered -- which is what the
+	// static path did, since it clears the body for HEAD and so only the
+	// GET reached the hashing branch below.
+	const bool handler_set_etag = (resp.headers.find("ETag") != resp.headers.end());
+	if (is_safe_method && !handler_set_etag && resp.status == 200 && !resp.body.empty()) {
 		// Snapshot-versioned memoization: skip the MD5 over the
 		// (potentially multi-MB) body when the (target,
 		// snapshot_at) tuple matches what we already hashed.
+		//
+		// Only sound for bodies the refresher snapshot actually
+		// governs. `snapshot_at` is stamped once per tick in whole
+		// seconds, and several endpoints are refreshed on their own
+		// schedule -- their own 1 s TTL caches, an append-only log
+		// mirror, a search refreshed on read -- so their body can
+		// change while the key does not. Reusing a memoized ETag
+		// there answers a later conditional GET with 304 for content
+		// that has changed (RFC 9110 §8.8.1 forbids exactly that).
+		// Those targets hash every time; they are small, and the memo
+		// exists for the multi-MB /downloads and /shared bodies.
 		const std::time_t snap = m_state.SnapshotAt();
+		const bool memoizable = webapi::SnapshotGovernsBody(req.target);
 		std::string etag;
-		{
+		if (memoizable) {
 			std::lock_guard<std::mutex> g(m_etagCacheMu);
 			auto it = m_etagCache.find(req.target);
 			if (it != m_etagCache.end() && it->second.snapshot_at == snap && snap != 0) {
@@ -728,17 +761,19 @@ CHttpServer::Response CApiDispatcher::Dispatch(const CHttpServer::Request &req)
 		}
 		if (etag.empty()) {
 			etag = webcommon::Etag(resp.body);
-			std::lock_guard<std::mutex> g(m_etagCacheMu);
-			if (m_etagCache.size() >= kEtagCacheCapacity) {
-				// Crude memory backstop. Real workload is a few
-				// dozen unique targets; the wholesale clear is
-				// cheaper than a real LRU machinery.
-				m_etagCache.clear();
+			if (memoizable) {
+				std::lock_guard<std::mutex> g(m_etagCacheMu);
+				if (m_etagCache.size() >= kEtagCacheCapacity) {
+					// Crude memory backstop. Real workload is a few
+					// dozen unique targets; the wholesale clear is
+					// cheaper than a real LRU machinery.
+					m_etagCache.clear();
+				}
+				EtagCacheEntry e;
+				e.snapshot_at = snap;
+				e.etag = etag;
+				m_etagCache[req.target] = std::move(e);
 			}
-			EtagCacheEntry e;
-			e.snapshot_at = snap;
-			e.etag = etag;
-			m_etagCache[req.target] = std::move(e);
 		}
 		// RFC 7232 §2.3 — the header value MUST be quoted.
 		resp.headers["ETag"] = "\"" + etag + "\"";
@@ -752,13 +787,15 @@ CHttpServer::Response CApiDispatcher::Dispatch(const CHttpServer::Request &req)
 			resp.body.clear();
 			resp.content_type.clear();
 		}
-		// HEAD never carries a body — the inner handler already shaped
-		// the response body for the GET path; strip it now. The ETag
-		// header is preserved so HEAD-based cache validators work.
-		if (req.method == "HEAD") {
-			resp.body.clear();
-		}
 	}
+	// HEAD carries no content, on ANY status. The strip used to live
+	// inside the 200-only block above, so every HEAD that ended in 4xx or
+	// 5xx shipped the JSON error envelope as content -- content RFC 9110
+	// §9.3.2 says must not be there, and bytes a client that correctly
+	// stops reading after the headers leaves in the socket to corrupt the
+	// next response on a keep-alive connection. It is not stripped here
+	// either: the transport writes headers only, so Content-Length still
+	// reports what the equivalent GET would return.
 
 	// stamp CORS on every response (success and error paths)
 	// so browsers can read the body in the 4xx/5xx case too.
@@ -791,28 +828,28 @@ CHttpServer::Response CApiDispatcher::DispatchToHandler(const CHttpServer::Reque
 
 	if (path == "/api/v0/version/check") {
 		if (req.method != "POST") {
-			return ErrorResponse(405, "method_not_allowed", "only POST on /api/v0/version/check");
+			return MethodNotAllowed("POST", "only POST on /api/v0/version/check");
 		}
 		return HandleVersionCheck(req);
 	}
 
 	if (path == "/api/v0/auth/login") {
 		if (req.method != "POST") {
-			return ErrorResponse(405, "method_not_allowed", "only POST on /auth/login");
+			return MethodNotAllowed("POST", "only POST on /auth/login");
 		}
 		return HandleLogin(req);
 	}
 
 	if (path == "/api/v0/auth/logout") {
 		if (req.method != "POST") {
-			return ErrorResponse(405, "method_not_allowed", "only POST on /auth/logout");
+			return MethodNotAllowed("POST", "only POST on /auth/logout");
 		}
 		return HandleLogout(req);
 	}
 
 	if (path == "/api/v0/auth/session") {
 		if (req.method != "GET" && req.method != "HEAD") {
-			return ErrorResponse(405, "method_not_allowed", "only GET on /auth/session");
+			return MethodNotAllowed("GET, HEAD", "only GET on /auth/session");
 		}
 		return HandleSession(req);
 	}
@@ -824,12 +861,12 @@ CHttpServer::Response CApiDispatcher::DispatchToHandler(const CHttpServer::Reque
 		if (req.method == "PATCH") {
 			return HandleAuthPasswordsPatch(req);
 		}
-		return ErrorResponse(405, "method_not_allowed", "only GET or PATCH on /auth/passwords");
+		return MethodNotAllowed("GET, HEAD, PATCH", "only GET or PATCH on /auth/passwords");
 	}
 
 	if (path == "/api/v0/status") {
 		if (req.method != "GET" && req.method != "HEAD") {
-			return ErrorResponse(405, "method_not_allowed", "only GET on /status");
+			return MethodNotAllowed("GET, HEAD", "only GET on /status");
 		}
 		return HandleStatus(req);
 	}
@@ -868,7 +905,7 @@ CHttpServer::Response CApiDispatcher::DispatchToHandler(const CHttpServer::Reque
 	// download peers); consumers filter client-side by upload_state.
 	if (path == "/api/v0/clients") {
 		if (req.method != "GET" && req.method != "HEAD") {
-			return ErrorResponse(405, "method_not_allowed", "only GET on /clients");
+			return MethodNotAllowed("GET, HEAD", "only GET on /clients");
 		}
 		return HandleClients(req);
 	}
@@ -881,7 +918,7 @@ CHttpServer::Response CApiDispatcher::DispatchToHandler(const CHttpServer::Reque
 	// pattern accepts any single segment.
 	if (path == "/api/v0/known_clients") {
 		if (req.method != "GET" && req.method != "HEAD") {
-			return ErrorResponse(405, "method_not_allowed", "only GET on /known_clients");
+			return MethodNotAllowed("GET, HEAD", "only GET on /known_clients");
 		}
 		return HandleKnownClients(req);
 	}
@@ -896,7 +933,7 @@ CHttpServer::Response CApiDispatcher::DispatchToHandler(const CHttpServer::Reque
 			if (req.method == "GET" || req.method == "HEAD") {
 				return HandleClientDetail(req, caps["ecid"]);
 			}
-			return ErrorResponse(405, "method_not_allowed", "only GET / HEAD on /clients/{ecid}");
+			return MethodNotAllowed("GET, HEAD", "only GET / HEAD on /clients/{ecid}");
 		}
 	}
 
@@ -924,12 +961,12 @@ CHttpServer::Response CApiDispatcher::DispatchToHandler(const CHttpServer::Reque
 			// bulk upload-priority PATCH over {hashes:[...], priority}.
 			return HandleSharedBulkPatch(req);
 		}
-		return ErrorResponse(405, "method_not_allowed", "only GET / HEAD / PATCH on /shared");
+		return MethodNotAllowed("GET, HEAD, PATCH", "only GET / HEAD / PATCH on /shared");
 	}
 
 	if (path == "/api/v0/shared/reload") {
 		if (req.method != "POST") {
-			return ErrorResponse(405, "method_not_allowed", "only POST on /shared/reload");
+			return MethodNotAllowed("POST", "only POST on /shared/reload");
 		}
 		return HandleSharedReload(req);
 	}
@@ -961,8 +998,7 @@ CHttpServer::Response CApiDispatcher::DispatchToHandler(const CHttpServer::Reque
 		if (req.method == "DELETE") {
 			return HandleSharedDirectoriesDelete(req);
 		}
-		return ErrorResponse(405,
-			"method_not_allowed",
+		return MethodNotAllowed("GET, HEAD, POST, PUT, DELETE",
 			"only GET / HEAD / PUT / POST / DELETE on /shared/directories");
 	}
 
@@ -974,7 +1010,7 @@ CHttpServer::Response CApiDispatcher::DispatchToHandler(const CHttpServer::Reque
 			// add a server by host:port.
 			return HandleServerAdd(req);
 		}
-		return ErrorResponse(405, "method_not_allowed", "only GET / HEAD / POST on /servers");
+		return MethodNotAllowed("GET, HEAD, POST", "only GET / HEAD / POST on /servers");
 	}
 
 	if (path == "/api/v0/friends") {
@@ -984,7 +1020,7 @@ CHttpServer::Response CApiDispatcher::DispatchToHandler(const CHttpServer::Reque
 		if (req.method == "POST") {
 			return HandleFriendAdd(req);
 		}
-		return ErrorResponse(405, "method_not_allowed", "only GET / HEAD / POST on /friends");
+		return MethodNotAllowed("GET, HEAD, POST", "only GET / HEAD / POST on /friends");
 	}
 
 	// One friend by ECID: remove, set the friend slot, or browse their shared
@@ -998,9 +1034,7 @@ CHttpServer::Response CApiDispatcher::DispatchToHandler(const CHttpServer::Reque
 		std::map<std::string, std::string> caps;
 		if (web_api_path::Match(friend_browse, path_segs, caps)) {
 			if (req.method != "POST") {
-				return ErrorResponse(405,
-					"method_not_allowed",
-					"only POST on /friends/{ecid}/shared_files");
+				return MethodNotAllowed("POST", "only POST on /friends/{ecid}/shared_files");
 			}
 			return HandleFriendBrowse(req, caps["ecid"]);
 		}
@@ -1020,7 +1054,7 @@ CHttpServer::Response CApiDispatcher::DispatchToHandler(const CHttpServer::Reque
 		if (req.method == "GET" || req.method == "HEAD") {
 			return HandleChats(req);
 		}
-		return ErrorResponse(405, "method_not_allowed", "only GET / HEAD on /chats");
+		return MethodNotAllowed("GET, HEAD", "only GET / HEAD on /chats");
 	}
 
 	// One conversation, keyed on "<ip>:<port>". The messages sub-resource is
@@ -1038,15 +1072,14 @@ CHttpServer::Response CApiDispatcher::DispatchToHandler(const CHttpServer::Reque
 			if (req.method == "POST") {
 				return HandleChatSend(req, caps["peer"]);
 			}
-			return ErrorResponse(405,
-				"method_not_allowed",
-				"only GET / HEAD / POST on /chats/{peer}/messages");
+			return MethodNotAllowed(
+				"GET, HEAD, POST", "only GET / HEAD / POST on /chats/{peer}/messages");
 		}
 		if (web_api_path::Match(chat_one, path_segs, caps)) {
 			if (req.method == "DELETE") {
 				return HandleChatClose(req, caps["peer"]);
 			}
-			return ErrorResponse(405, "method_not_allowed", "only DELETE on /chats/{peer}");
+			return MethodNotAllowed("DELETE", "only DELETE on /chats/{peer}");
 		}
 	}
 
@@ -1078,7 +1111,7 @@ CHttpServer::Response CApiDispatcher::DispatchToHandler(const CHttpServer::Reque
 
 	if (path == "/api/v0/servers/update") {
 		if (req.method != "POST") {
-			return ErrorResponse(405, "method_not_allowed", "only POST on /servers/update");
+			return MethodNotAllowed("POST", "only POST on /servers/update");
 		}
 		return HandleServerUpdateFromUrl(req);
 	}
@@ -1128,7 +1161,7 @@ CHttpServer::Response CApiDispatcher::DispatchToHandler(const CHttpServer::Reque
 
 	if (path == "/api/v0/kad") {
 		if (req.method != "GET" && req.method != "HEAD") {
-			return ErrorResponse(405, "method_not_allowed", "only GET on /kad");
+			return MethodNotAllowed("GET, HEAD", "only GET on /kad");
 		}
 		return HandleKad(req);
 	}
@@ -1136,13 +1169,13 @@ CHttpServer::Response CApiDispatcher::DispatchToHandler(const CHttpServer::Reque
 	// connection control.
 	if (path == "/api/v0/networks/connect") {
 		if (req.method != "POST") {
-			return ErrorResponse(405, "method_not_allowed", "only POST on /networks/connect");
+			return MethodNotAllowed("POST", "only POST on /networks/connect");
 		}
 		return HandleNetworksConnect(req);
 	}
 	if (path == "/api/v0/networks/disconnect") {
 		if (req.method != "POST") {
-			return ErrorResponse(405, "method_not_allowed", "only POST on /networks/disconnect");
+			return MethodNotAllowed("POST", "only POST on /networks/disconnect");
 		}
 		return HandleNetworksDisconnect(req);
 	}
@@ -1152,14 +1185,14 @@ CHttpServer::Response CApiDispatcher::DispatchToHandler(const CHttpServer::Reque
 	// /networks/* makes the dedicated shortcut redundant.
 	if (path == "/api/v0/kad/update") {
 		if (req.method != "POST") {
-			return ErrorResponse(405, "method_not_allowed", "only POST on /kad/update");
+			return MethodNotAllowed("POST", "only POST on /kad/update");
 		}
 		return HandleKadUpdateFromUrl(req);
 	}
 
 	if (path == "/api/v0/kad/bootstrap") {
 		if (req.method != "POST") {
-			return ErrorResponse(405, "method_not_allowed", "only POST on /kad/bootstrap");
+			return MethodNotAllowed("POST", "only POST on /kad/bootstrap");
 		}
 		return HandleKadBootstrap(req);
 	}
@@ -1169,14 +1202,14 @@ CHttpServer::Response CApiDispatcher::DispatchToHandler(const CHttpServer::Reque
 	// desktop Security page's "Reload List" and "Update now" buttons.
 	if (path == "/api/v0/ipfilter/reload") {
 		if (req.method != "POST") {
-			return ErrorResponse(405, "method_not_allowed", "only POST on /ipfilter/reload");
+			return MethodNotAllowed("POST", "only POST on /ipfilter/reload");
 		}
 		return HandleIpfilterReload(req);
 	}
 
 	if (path == "/api/v0/ipfilter/update") {
 		if (req.method != "POST") {
-			return ErrorResponse(405, "method_not_allowed", "only POST on /ipfilter/update");
+			return MethodNotAllowed("POST", "only POST on /ipfilter/update");
 		}
 		return HandleIpfilterUpdate(req);
 	}
@@ -1216,9 +1249,8 @@ CHttpServer::Response CApiDispatcher::DispatchToHandler(const CHttpServer::Reque
 		std::map<std::string, std::string> caps;
 		if (web_api_path::Match(shared_clients, path_segs, caps)) {
 			if (req.method != "GET" && req.method != "HEAD") {
-				return ErrorResponse(405,
-					"method_not_allowed",
-					"only GET / HEAD on /shared/{hash}/clients");
+				return MethodNotAllowed(
+					"GET, HEAD", "only GET / HEAD on /shared/{hash}/clients");
 			}
 			return HandleFileClients(req, caps["hash"], /*require_downloading=*/false);
 		}
@@ -1235,9 +1267,8 @@ CHttpServer::Response CApiDispatcher::DispatchToHandler(const CHttpServer::Reque
 				return HandleSharedDetail(req, caps["hash"]);
 			}
 			if (req.method != "PATCH") {
-				return ErrorResponse(405,
-					"method_not_allowed",
-					"only GET / HEAD / PATCH on /shared/{hash}");
+				return MethodNotAllowed(
+					"GET, HEAD, PATCH", "only GET / HEAD / PATCH on /shared/{hash}");
 			}
 			return HandleSharedPatch(req, caps["hash"]);
 		}
@@ -1250,7 +1281,7 @@ CHttpServer::Response CApiDispatcher::DispatchToHandler(const CHttpServer::Reque
 		if (req.method == "POST") {
 			return HandleCategoryCreate(req);
 		}
-		return ErrorResponse(405, "method_not_allowed", "only GET / HEAD / POST on /categories");
+		return MethodNotAllowed("GET, HEAD, POST", "only GET / HEAD / POST on /categories");
 	}
 
 	// single-category PATCH/DELETE.
@@ -1277,7 +1308,7 @@ CHttpServer::Response CApiDispatcher::DispatchToHandler(const CHttpServer::Reque
 		if (req.method == "PATCH") {
 			return HandlePreferencesPatch(req);
 		}
-		return ErrorResponse(405, "method_not_allowed", "only GET / HEAD / PATCH on /preferences");
+		return MethodNotAllowed("GET, HEAD, PATCH", "only GET / HEAD / PATCH on /preferences");
 	}
 
 	if (path == "/api/v0/logs/amule") {
@@ -1287,7 +1318,7 @@ CHttpServer::Response CApiDispatcher::DispatchToHandler(const CHttpServer::Reque
 		if (req.method == "DELETE") {
 			return HandleLogAmuleReset(req);
 		}
-		return ErrorResponse(405, "method_not_allowed", "only GET / HEAD / DELETE on /logs/amule");
+		return MethodNotAllowed("GET, HEAD, DELETE", "only GET / HEAD / DELETE on /logs/amule");
 	}
 
 	if (path == "/api/v0/logs/serverinfo") {
@@ -1303,7 +1334,7 @@ CHttpServer::Response CApiDispatcher::DispatchToHandler(const CHttpServer::Reque
 
 	if (path == "/api/v0/stats/tree") {
 		if (req.method != "GET" && req.method != "HEAD") {
-			return ErrorResponse(405, "method_not_allowed", "only GET on /stats/tree");
+			return MethodNotAllowed("GET, HEAD", "only GET on /stats/tree");
 		}
 		return HandleStatsTree(req);
 	}
@@ -1315,8 +1346,7 @@ CHttpServer::Response CApiDispatcher::DispatchToHandler(const CHttpServer::Reque
 			return HandleSearchList(req);
 		}
 		if (req.method != "POST") {
-			return ErrorResponse(405,
-				"method_not_allowed",
+			return MethodNotAllowed("GET, HEAD, POST",
 				"only GET or POST on /search (GET lists searches, POST starts one; "
 				"read one search at GET /search/{id}/results)");
 		}
@@ -1337,9 +1367,8 @@ CHttpServer::Response CApiDispatcher::DispatchToHandler(const CHttpServer::Reque
 		std::map<std::string, std::string> caps;
 		if (web_api_path::Match(search_download, path_segs, caps)) {
 			if (req.method != "POST") {
-				return ErrorResponse(405,
-					"method_not_allowed",
-					"only POST on /search/results/{hash}/download");
+				return MethodNotAllowed(
+					"POST", "only POST on /search/results/{hash}/download");
 			}
 			return HandleSearchDownload(req, caps["hash"]);
 		}
@@ -1361,8 +1390,7 @@ CHttpServer::Response CApiDispatcher::DispatchToHandler(const CHttpServer::Reque
 				return HandleSearchCommentsKadSearch(req, caps["hash"]);
 			}
 			if (req.method != "GET" && req.method != "HEAD") {
-				return ErrorResponse(405,
-					"method_not_allowed",
+				return MethodNotAllowed("GET, HEAD, POST",
 					"only GET / HEAD / POST on /search/results/{hash}/comments");
 			}
 			return HandleSearchComments(req, caps["hash"]);
@@ -1395,8 +1423,7 @@ CHttpServer::Response CApiDispatcher::DispatchToHandler(const CHttpServer::Reque
 				return ErrorResponse(400, "bad_request", kBadSearchIdMessage);
 			}
 			if (req.method != "DELETE") {
-				return ErrorResponse(405,
-					"method_not_allowed",
+				return MethodNotAllowed("DELETE",
 					"only DELETE on /search/{id} (read its results at "
 					"GET /search/{id}/results)");
 			}
@@ -1417,9 +1444,8 @@ CHttpServer::Response CApiDispatcher::DispatchToHandler(const CHttpServer::Reque
 			const std::string &action = caps["action"];
 			if (action == "results") {
 				if (req.method != "GET" && req.method != "HEAD") {
-					return ErrorResponse(405,
-						"method_not_allowed",
-						"only GET / HEAD on /search/{id}/results");
+					return MethodNotAllowed(
+						"GET, HEAD", "only GET / HEAD on /search/{id}/results");
 				}
 				return HandleSearchResults(req, sid);
 			}
@@ -1443,7 +1469,8 @@ CHttpServer::Response CApiDispatcher::DispatchToHandler(const CHttpServer::Reque
 	}
 
 	// /stats/graphs/{graph} — path-pattern matches the four allowed
-	// graph names ("download" / "upload" / "connections" / "kad").
+	// graph names ("download_speed" / "upload_speed" / "connections" /
+	// "kad_nodes" -- HandleStatsGraph rejects anything else).
 	{
 		static const auto graph_pattern = web_api_path::ParsePattern("/api/v0/stats/graphs/{graph}");
 		const auto segs = web_api_path::SplitPath(path);
@@ -1472,8 +1499,7 @@ CHttpServer::Response CApiDispatcher::DispatchToHandler(const CHttpServer::Reque
 				return HandleDownloadCommentsKadSearch(req, caps["hash"]);
 			}
 			if (req.method != "GET" && req.method != "HEAD") {
-				return ErrorResponse(405,
-					"method_not_allowed",
+				return MethodNotAllowed("GET, HEAD, POST",
 					"only GET / HEAD / POST on /downloads/{hash}/comments");
 			}
 			return HandleDownloadComments(req, caps["hash"]);
@@ -1489,9 +1515,8 @@ CHttpServer::Response CApiDispatcher::DispatchToHandler(const CHttpServer::Reque
 		std::map<std::string, std::string> caps;
 		if (web_api_path::Match(dl_filenames, path_segs, caps)) {
 			if (req.method != "GET" && req.method != "HEAD") {
-				return ErrorResponse(405,
-					"method_not_allowed",
-					"only GET / HEAD on /downloads/{hash}/filenames");
+				return MethodNotAllowed(
+					"GET, HEAD", "only GET / HEAD on /downloads/{hash}/filenames");
 			}
 			return HandleDownloadFilenames(req, caps["hash"]);
 		}
@@ -1525,9 +1550,8 @@ CHttpServer::Response CApiDispatcher::DispatchToHandler(const CHttpServer::Reque
 		std::map<std::string, std::string> caps;
 		if (web_api_path::Match(dl_clients, path_segs, caps)) {
 			if (req.method != "GET" && req.method != "HEAD") {
-				return ErrorResponse(405,
-					"method_not_allowed",
-					"only GET / HEAD on /downloads/{hash}/clients");
+				return MethodNotAllowed(
+					"GET, HEAD", "only GET / HEAD on /downloads/{hash}/clients");
 			}
 			return HandleFileClients(req, caps["hash"], /*require_downloading=*/true);
 		}
@@ -1551,8 +1575,7 @@ CHttpServer::Response CApiDispatcher::DispatchToHandler(const CHttpServer::Reque
 			if (req.method == "DELETE") {
 				return HandleDownloadDelete(req, caps["hash"]);
 			}
-			return ErrorResponse(405,
-				"method_not_allowed",
+			return MethodNotAllowed("GET, HEAD, PATCH, DELETE",
 				"only GET / HEAD / PATCH / DELETE on /downloads/{hash}");
 		}
 	}
@@ -1640,8 +1663,11 @@ CHttpServer::Response CApiDispatcher::ServeStaticFile(
 	// Conditional GET: client sent If-None-Match → 304 with no body
 	// when the ETag matches. ETag is mtime+size, so a rebuild of the
 	// frontend invalidates without manual cache-busting.
-	auto inm = req.headers.find("If-None-Match");
-	if (inm != req.headers.end() && inm->second == etag) {
+	// Case-insensitive: Beast preserves the client's wire casing, so a
+	// lowercase `if-none-match` -- what an HTTP/2-shaped client library
+	// produces -- used to miss here and silently lose conditional GET.
+	const std::string inm_val = FindHeaderCaseInsensitive(req.headers, "If-None-Match");
+	if (!inm_val.empty() && inm_val == etag) {
 		CHttpServer::Response r;
 		r.status = 304;
 		r.headers["ETag"] = etag;
@@ -1651,7 +1677,12 @@ CHttpServer::Response CApiDispatcher::ServeStaticFile(
 	CHttpServer::Response r;
 	r.status = 200;
 	r.content_type = StaticContentType(rel);
-	r.body = (req.method == "HEAD") ? std::string() : std::move(body);
+	// The body is kept for HEAD too. The transport writes headers only,
+	// so nothing reaches the wire, and keeping it is what lets
+	// Content-Length report the real size instead of 0 -- and what stops
+	// HEAD and GET disagreeing about this resource's validator, since the
+	// outer layer skips stamping whenever a handler set its own ETag.
+	r.body = std::move(body);
 	r.headers["ETag"] = etag;
 	return r;
 }

--- a/src/webapi/Api.cpp
+++ b/src/webapi/Api.cpp
@@ -626,7 +626,7 @@ void ApplyCorsHeaders(
 {
 	if (!cors_enabled)
 		return;
-	headers["Vary"] = "Origin";
+	AppendHeaderToken(headers, "Vary", "Origin");
 	if (resolved_origin.empty())
 		return;
 	headers["Access-Control-Allow-Origin"] = resolved_origin;
@@ -636,7 +636,7 @@ void ApplyCorsHeaders(
 	// response headers (Cache-Control, Content-Language, Content-Type,
 	// Expires, Last-Modified, Pragma). amuleapi clients want to read
 	// ETag for cache validation; SSE clients don't need this list.
-	headers["Access-Control-Expose-Headers"] = "ETag";
+	headers["Access-Control-Expose-Headers"] = "ETag, Allow, Retry-After";
 }
 
 // The Kad `network` rollup, byte-identical on GET /status (nested
@@ -689,6 +689,22 @@ bool ParseJsonObjectBody(const std::string &body, picojson::value &out, std::str
 
 } // namespace
 
+// Did the caller present credentials at all? Mirrors what Authenticate()
+// accepts -- an Authorization header, or the session cookie the WebUI uses --
+// without verifying them: an invalid or expired credential still means the
+// response was computed for a specific caller and must not be shared.
+bool RequestCarriesCredentials(const CHttpServer::Request &req, const std::string &cookie_name)
+{
+	if (!FindHeaderCaseInsensitive(req.headers, "Authorization").empty()) {
+		return true;
+	}
+	const std::string cookie = FindHeaderCaseInsensitive(req.headers, "Cookie");
+	if (cookie.empty()) {
+		return false;
+	}
+	return !webapi::ExtractCookieValue(cookie, cookie_name).empty();
+}
+
 CHttpServer::Response CApiDispatcher::Dispatch(const CHttpServer::Request &req)
 {
 	const bool cors_enabled = m_config.ServerCfg().allow_cors;
@@ -725,7 +741,18 @@ CHttpServer::Response CApiDispatcher::Dispatch(const CHttpServer::Request &req)
 	// through unchanged — there's no benefit to ETag-caching a 4xx
 	// body, and a mutation's response carries the post-mutation
 	// state which the client always wants delivered.
+	// Sampled BEFORE the handler runs, and again after. The memo pairs an
+	// ETag with a revision, and the body is serialized inside the handler
+	// under its own read lock which it has dropped by the time we get here
+	// -- so reading the revision only afterwards can pair etag(old body)
+	// with the NEW revision if a write lands in that window, and every
+	// later hit then serves a validator that describes neither. Two
+	// samples make the window observable: if anything moved, this response
+	// is not attributable to a revision and is simply not memoized.
+	const std::uint64_t rev_before = m_state.SnapshotRevision();
 	CHttpServer::Response resp = DispatchToHandler(req);
+	const std::uint64_t rev_after = m_state.SnapshotRevision();
+	const bool rev_stable = (rev_before == rev_after);
 
 	const bool is_safe_method = (req.method == "GET" || req.method == "HEAD");
 	// A handler that computed its own validator owns it. Stamping the
@@ -735,27 +762,29 @@ CHttpServer::Response CApiDispatcher::Dispatch(const CHttpServer::Request &req)
 	// GET reached the hashing branch below.
 	const bool handler_set_etag = (resp.headers.find("ETag") != resp.headers.end());
 	if (is_safe_method && !handler_set_etag && resp.status == 200 && !resp.body.empty()) {
-		// Snapshot-versioned memoization: skip the MD5 over the
-		// (potentially multi-MB) body when the (target,
-		// snapshot_at) tuple matches what we already hashed.
+		// Skip the MD5 over a (potentially multi-MB) body when
+		// nothing has changed since we last hashed it. The key is
+		// (target, snapshot revision): the revision is advanced by
+		// every writer of an eligible body, so unlike a timestamp it
+		// cannot stand still through a mutation, cannot collapse two
+		// changes inside one second, and does not depend on any
+		// caller remembering to stamp it.
 		//
-		// Only sound for bodies the refresher snapshot actually
-		// governs. `snapshot_at` is stamped once per tick in whole
-		// seconds, and several endpoints are refreshed on their own
-		// schedule -- their own 1 s TTL caches, an append-only log
-		// mirror, a search refreshed on read -- so their body can
-		// change while the key does not. Reusing a memoized ETag
-		// there answers a later conditional GET with 304 for content
-		// that has changed (RFC 9110 §8.8.1 forbids exactly that).
-		// Those targets hash every time; they are small, and the memo
-		// exists for the multi-MB /downloads and /shared bodies.
-		const std::time_t snap = m_state.SnapshotAt();
-		const bool memoizable = webapi::SnapshotGovernsBody(req.target);
+		// Eligibility is opt-in -- see MemoizableTarget -- and covers
+		// only /downloads and /shared, which is where skipping a hash
+		// is worth anything. Everything else hashes per request and is
+		// immune to a mispaired validator by construction.
+		//
+		// `rev_stable` is the other half. Without it the key says
+		// which revision was current when we looked, not which one
+		// this body came from.
+		const std::uint64_t snap = rev_after;
+		const bool memoizable = webapi::MemoizableTarget(req.target) && rev_stable;
 		std::string etag;
 		if (memoizable) {
 			std::lock_guard<std::mutex> g(m_etagCacheMu);
 			auto it = m_etagCache.find(req.target);
-			if (it != m_etagCache.end() && it->second.snapshot_at == snap && snap != 0) {
+			if (it != m_etagCache.end() && it->second.snapshot_rev == snap && snap != 0) {
 				etag = it->second.etag;
 			}
 		}
@@ -770,16 +799,35 @@ CHttpServer::Response CApiDispatcher::Dispatch(const CHttpServer::Request &req)
 					m_etagCache.clear();
 				}
 				EtagCacheEntry e;
-				e.snapshot_at = snap;
+				e.snapshot_rev = snap;
 				e.etag = etag;
 				m_etagCache[req.target] = std::move(e);
 			}
 		}
 		// RFC 7232 §2.3 — the header value MUST be quoted.
-		resp.headers["ETag"] = "\"" + etag + "\"";
+		// Which representation is this validator naming? The transport
+		// appends the coding when it compresses, but a 304 carries no
+		// body for it to compress, so the answer has to be worked out
+		// here -- while the body is still present to measure -- and it
+		// has to be the SAME answer. A client that cached the gzip form
+		// and gets the identity ETag back can never match its stored
+		// response again.
+		const bool coded = WillCompressBody(
+			AcceptsGzip(FindHeaderCaseInsensitive(req.headers, "Accept-Encoding")),
+			resp.body.size(),
+			resp.content_type,
+			resp.headers.find("Content-Encoding") != resp.headers.end());
+		const std::string wire_etag = webcommon::WithCodingSuffix(etag, coded);
+		resp.headers["ETag"] = "\"" + wire_etag + "\"";
 
+		// Against wire_etag, which names the representation THIS request
+		// selected. Matching either coding would defeat the suffix
+		// entirely: a client holding the gzip bytes and asking for
+		// identity would be told its copy is current, and one holding
+		// identity bytes would be handed a 304 stamped with the gzip
+		// validator, matching nothing it stored.
 		const std::string inm = FindHeaderCaseInsensitive(req.headers, "If-None-Match");
-		if (webcommon::IfNoneMatchHits(inm, etag)) {
+		if (webcommon::IfNoneMatchHits(inm, wire_etag)) {
 			// 304 carries no body and no Content-Type, but the ETag
 			// header IS preserved (RFC 7232 §4.1 — clients use it to
 			// re-stamp the cached representation).
@@ -796,6 +844,39 @@ CHttpServer::Response CApiDispatcher::Dispatch(const CHttpServer::Request &req)
 	// next response on a keep-alive connection. It is not stripped here
 	// either: the transport writes headers only, so Content-Length still
 	// reports what the equivalent GET would return.
+
+	// A response produced for a caller who presented credentials is that
+	// caller's, and must not be stored where another caller can be served
+	// it. Authenticate() takes a bearer token OR a session cookie, and the
+	// browser WebUI uses the cookie -- so these requests carry no
+	// Authorization header, and RFC 9111 3.5's shared-cache prohibition
+	// never engages on them. Without an explicit expiry a shared cache may
+	// keep a 200 under heuristic freshness, and with Cookie absent from
+	// Vary two users share a cache key.
+	//
+	// Stamped here rather than in each handler so a new authenticated
+	// route cannot forget it, and only when the caller actually presented
+	// credentials: an unauthenticated public probe like /version stays
+	// cacheable and keeps its conditional GET. A handler that set its own
+	// policy -- the static assets' public, no-cache, the country flags'
+	// public, max-age, /auth/session's private, no-store, the SSE
+	// no-cache -- is left alone.
+	//
+	// `private` and NOT `no-store`: no-store forbids the client's OWN
+	// cache, so no browser would ever hold an entry to revalidate and no
+	// authenticated route would ever see an If-None-Match -- which throws
+	// away the whole point of the validator and memo machinery here, and
+	// makes the WebUI re-transfer the full download list on every load. It
+	// also lands on 304s, telling a cache to drop the entry it has just
+	// been told is good. `private` alone is what answers the concern:
+	// RFC 9111 3.5 stops a SHARED cache storing it, which is the cache
+	// that could serve one user's list to another.
+	if (RequestCarriesCredentials(req, kSessionCookieName) &&
+		resp.headers.find("Cache-Control") == resp.headers.end()) {
+		resp.headers["Cache-Control"] = "private";
+		// Vary is the half that matters to a cache which stores anyway.
+		AppendHeaderToken(resp.headers, "Vary", "Cookie");
+	}
 
 	// stamp CORS on every response (success and error paths)
 	// so browsers can read the body in the 4xx/5xx case too.
@@ -820,8 +901,7 @@ CHttpServer::Response CApiDispatcher::DispatchToHandler(const CHttpServer::Reque
 
 	if (path == "/api/v0/version") {
 		if (req.method != "GET" && req.method != "HEAD") {
-			return ErrorResponse(
-				405, "method_not_allowed", "method not allowed on /api/v0/version");
+			return MethodNotAllowed("GET, HEAD", "method not allowed on /api/v0/version");
 		}
 		return HandleVersion(req);
 	}
@@ -864,6 +944,16 @@ CHttpServer::Response CApiDispatcher::DispatchToHandler(const CHttpServer::Reque
 		return MethodNotAllowed("GET, HEAD, PATCH", "only GET or PATCH on /auth/passwords");
 	}
 
+	// /events reaches the dispatcher only on a method the streaming
+	// resolver declined, since it diverts GET and HEAD before this point.
+	// Without an arm here the request fell through to the catch-all 404,
+	// so the one endpoint a client is most likely to probe reported that
+	// it does not exist -- and it was the only route to escape the Allow
+	// sweep, while the docs promise the header on every 405.
+	if (path == "/api/v0/events") {
+		return MethodNotAllowed("GET, HEAD", "only GET / HEAD on /events");
+	}
+
 	if (path == "/api/v0/status") {
 		if (req.method != "GET" && req.method != "HEAD") {
 			return MethodNotAllowed("GET, HEAD", "only GET on /status");
@@ -887,15 +977,14 @@ CHttpServer::Response CApiDispatcher::DispatchToHandler(const CHttpServer::Reque
 			// bulk cancel+remove over {hashes:[...]}.
 			return HandleDownloadsBulkDelete(req);
 		}
-		return ErrorResponse(
-			405, "method_not_allowed", "only GET / HEAD / POST / PATCH / DELETE on /downloads");
+		return MethodNotAllowed("GET, HEAD, POST, PATCH, DELETE",
+			"only GET / HEAD / POST / PATCH / DELETE on /downloads");
 	}
 
 	// bulk clear-completed.
 	if (path == "/api/v0/downloads/clear_completed") {
 		if (req.method != "POST") {
-			return ErrorResponse(
-				405, "method_not_allowed", "only POST on /downloads/clear_completed");
+			return MethodNotAllowed("POST", "only POST on /downloads/clear_completed");
 		}
 		return HandleDownloadsClearCompleted(req);
 	}
@@ -948,8 +1037,7 @@ CHttpServer::Response CApiDispatcher::DispatchToHandler(const CHttpServer::Reque
 			if (req.method == "POST") {
 				return HandleClientBrowse(req, caps["ecid"]);
 			}
-			return ErrorResponse(
-				405, "method_not_allowed", "only POST on /clients/{ecid}/shared_files");
+			return MethodNotAllowed("POST", "only POST on /clients/{ecid}/shared_files");
 		}
 	}
 
@@ -976,7 +1064,7 @@ CHttpServer::Response CApiDispatcher::DispatchToHandler(const CHttpServer::Reque
 	// below or "media" would be captured as a hash.
 	if (path == "/api/v0/shared/media/refresh") {
 		if (req.method != "POST") {
-			return ErrorResponse(405, "method_not_allowed", "only POST on /shared/media/refresh");
+			return MethodNotAllowed("POST", "only POST on /shared/media/refresh");
 		}
 		return HandleSharedMediaRefresh(req);
 	}
@@ -1045,8 +1133,7 @@ CHttpServer::Response CApiDispatcher::DispatchToHandler(const CHttpServer::Reque
 			if (req.method == "PATCH") {
 				return HandleFriendPatch(req, caps["ecid"]);
 			}
-			return ErrorResponse(
-				405, "method_not_allowed", "only DELETE / PATCH on /friends/{ecid}");
+			return MethodNotAllowed("PATCH, DELETE", "only DELETE / PATCH on /friends/{ecid}");
 		}
 	}
 
@@ -1095,15 +1182,13 @@ CHttpServer::Response CApiDispatcher::DispatchToHandler(const CHttpServer::Reque
 		std::map<std::string, std::string> caps;
 		if (web_api_path::Match(friend_messages, path_segs, caps)) {
 			if (req.method != "POST") {
-				return ErrorResponse(
-					405, "method_not_allowed", "only POST on /friends/{ecid}/messages");
+				return MethodNotAllowed("POST", "only POST on /friends/{ecid}/messages");
 			}
 			return HandleFriendMessageSend(req, caps["ecid"]);
 		}
 		if (web_api_path::Match(client_messages, path_segs, caps)) {
 			if (req.method != "POST") {
-				return ErrorResponse(
-					405, "method_not_allowed", "only POST on /clients/{ecid}/messages");
+				return MethodNotAllowed("POST", "only POST on /clients/{ecid}/messages");
 			}
 			return HandleClientMessageSend(req, caps["ecid"]);
 		}
@@ -1130,8 +1215,7 @@ CHttpServer::Response CApiDispatcher::DispatchToHandler(const CHttpServer::Reque
 		std::map<std::string, std::string> caps;
 		if (web_api_path::Match(server_connect, path_segs, caps)) {
 			if (req.method != "POST") {
-				return ErrorResponse(
-					405, "method_not_allowed", "only POST on /servers/{ecid}/connect");
+				return MethodNotAllowed("POST", "only POST on /servers/{ecid}/connect");
 			}
 			// `{ecid}` capture also matches "<ip>:<port>" because the
 			// path-pattern matcher is opaque-segment. Disambiguate
@@ -1144,8 +1228,8 @@ CHttpServer::Response CApiDispatcher::DispatchToHandler(const CHttpServer::Reque
 		}
 		if (web_api_path::Match(server_one, path_segs, caps)) {
 			if (req.method != "DELETE" && req.method != "PATCH") {
-				return ErrorResponse(
-					405, "method_not_allowed", "only DELETE / PATCH on /servers/{ecid}");
+				return MethodNotAllowed(
+					"PATCH, DELETE", "only DELETE / PATCH on /servers/{ecid}");
 			}
 			const bool by_address = caps["ecid"].find(':') != std::string::npos;
 			if (req.method == "PATCH") {
@@ -1225,16 +1309,13 @@ CHttpServer::Response CApiDispatcher::DispatchToHandler(const CHttpServer::Reque
 		std::map<std::string, std::string> caps;
 		if (web_api_path::Match(shared_media_refresh, path_segs, caps)) {
 			if (req.method != "POST") {
-				return ErrorResponse(405,
-					"method_not_allowed",
-					"only POST on /shared/{hash}/media/refresh");
+				return MethodNotAllowed("POST", "only POST on /shared/{hash}/media/refresh");
 			}
 			return HandleSharedMediaRefreshOne(req, caps["hash"]);
 		}
 		if (web_api_path::Match(shared_verify, path_segs, caps)) {
 			if (req.method != "POST") {
-				return ErrorResponse(
-					405, "method_not_allowed", "only POST on /shared/{hash}/verify");
+				return MethodNotAllowed("POST", "only POST on /shared/{hash}/verify");
 			}
 			return HandleSharedVerify(req, caps["hash"]);
 		}
@@ -1296,8 +1377,8 @@ CHttpServer::Response CApiDispatcher::DispatchToHandler(const CHttpServer::Reque
 			if (req.method == "DELETE") {
 				return HandleCategoryDelete(req, caps["index"]);
 			}
-			return ErrorResponse(
-				405, "method_not_allowed", "only PATCH / DELETE on /categories/{index}");
+			return MethodNotAllowed(
+				"PATCH, DELETE", "only PATCH / DELETE on /categories/{index}");
 		}
 	}
 
@@ -1328,8 +1409,7 @@ CHttpServer::Response CApiDispatcher::DispatchToHandler(const CHttpServer::Reque
 		if (req.method == "DELETE") {
 			return HandleLogServerinfoReset(req);
 		}
-		return ErrorResponse(
-			405, "method_not_allowed", "only GET / HEAD / DELETE on /logs/serverinfo");
+		return MethodNotAllowed("GET, HEAD, DELETE", "only GET / HEAD / DELETE on /logs/serverinfo");
 	}
 
 	if (path == "/api/v0/stats/tree") {
@@ -1451,15 +1531,13 @@ CHttpServer::Response CApiDispatcher::DispatchToHandler(const CHttpServer::Reque
 			}
 			if (action == "stop") {
 				if (req.method != "POST") {
-					return ErrorResponse(
-						405, "method_not_allowed", "only POST on /search/{id}/stop");
+					return MethodNotAllowed("POST", "only POST on /search/{id}/stop");
 				}
 				return HandleSearchStop(req, sid);
 			}
 			if (action == "more") {
 				if (req.method != "POST") {
-					return ErrorResponse(
-						405, "method_not_allowed", "only POST on /search/{id}/more");
+					return MethodNotAllowed("POST", "only POST on /search/{id}/more");
 				}
 				return HandleSearchMore(req, sid);
 			}
@@ -1477,8 +1555,7 @@ CHttpServer::Response CApiDispatcher::DispatchToHandler(const CHttpServer::Reque
 		std::map<std::string, std::string> caps;
 		if (web_api_path::Match(graph_pattern, segs, caps)) {
 			if (req.method != "GET" && req.method != "HEAD") {
-				return ErrorResponse(
-					405, "method_not_allowed", "only GET on /stats/graphs/{graph}");
+				return MethodNotAllowed("GET, HEAD", "only GET on /stats/graphs/{graph}");
 			}
 			return HandleStatsGraph(req, caps["graph"]);
 		}
@@ -1537,8 +1614,7 @@ CHttpServer::Response CApiDispatcher::DispatchToHandler(const CHttpServer::Reque
 			// rather than a bare ECID, and `a4af_auto` is already on the
 			// download detail object. The POST stays -- the swap actions have
 			// no equivalent there, and its reply is still the A4AF view.
-			return ErrorResponse(
-				405, "method_not_allowed", "only POST on /downloads/{hash}/a4af");
+			return MethodNotAllowed("POST", "only POST on /downloads/{hash}/a4af");
 		}
 	}
 
@@ -1587,8 +1663,7 @@ CHttpServer::Response CApiDispatcher::DispatchToHandler(const CHttpServer::Reque
 	// resource, and it carries no per-installation data.
 	if (path.compare(0, 7, "/flags/") == 0) {
 		if (req.method != "GET" && req.method != "HEAD") {
-			return ErrorResponse(
-				405, "method_not_allowed", "only GET / HEAD on /flags/{code}.png");
+			return MethodNotAllowed("GET, HEAD", "only GET / HEAD on /flags/{code}.png");
 		}
 		return ServeCountryFlag(req, path);
 	}
@@ -1666,11 +1741,45 @@ CHttpServer::Response CApiDispatcher::ServeStaticFile(
 	// Case-insensitive: Beast preserves the client's wire casing, so a
 	// lowercase `if-none-match` -- what an HTTP/2-shaped client library
 	// produces -- used to miss here and silently lose conditional GET.
+	// Through the shared matcher, not a string compare: the header may be
+	// `*`, a comma-separated list, or a weak `W/"..."` validator (which is
+	// what an nginx in front of us emits once it gzips). The outer layer
+	// used to supply that grammar for the GET path; now that it steps aside
+	// whenever a handler set its own ETag, this path has to speak it.
 	const std::string inm_val = FindHeaderCaseInsensitive(req.headers, "If-None-Match");
-	if (!inm_val.empty() && inm_val == etag) {
+	// A 304 has no body for the transport to compress, so which
+	// representation this validator names is decided here, while the body
+	// is still present to measure -- and the comparison uses that same
+	// value, so a client is only told "unchanged" about the representation
+	// it actually asked for.
+	const bool coded =
+		WillCompressBody(AcceptsGzip(FindHeaderCaseInsensitive(req.headers, "Accept-Encoding")),
+			body.size(),
+			StaticContentType(rel),
+			/*already_encoded=*/false);
+	// Through the shared helper, which takes the quoted form this path
+	// carries as readily as the bare form the API path does. Three separate
+	// hand-rolled spellings of "put the suffix on" is how the transport
+	// ended up with one that could not take it back off again.
+	const std::string wire_static_etag = webcommon::WithCodingSuffix(etag, coded);
+	const std::string wire_static_bare =
+		(wire_static_etag.size() >= 2 && wire_static_etag.front() == '"' &&
+			wire_static_etag.back() == '"')
+			? wire_static_etag.substr(1, wire_static_etag.size() - 2)
+			: wire_static_etag;
+	if (webcommon::IfNoneMatchHits(inm_val, wire_static_bare)) {
 		CHttpServer::Response r;
 		r.status = 304;
-		r.headers["ETag"] = etag;
+		// Response::content_type defaults to application/json, which on a
+		// 304 for an HTML or CSS asset is simply wrong. Cleared rather
+		// than corrected: a 304 carries no content, the transport omits
+		// the header when it is empty, and this matches what the API 304
+		// path already does.
+		r.content_type.clear();
+		r.headers["ETag"] = wire_static_etag;
+		// Same policy the 200 carries, or a cache is told the shell is
+		// private on the very response that confirms its copy is good.
+		r.headers["Cache-Control"] = "public, no-cache";
 		return r;
 	}
 
@@ -1684,6 +1793,39 @@ CHttpServer::Response CApiDispatcher::ServeStaticFile(
 	// outer layer skips stamping whenever a handler set its own ETag.
 	r.body = std::move(body);
 	r.headers["ETag"] = etag;
+	// The WebUI shell is the same bytes for everyone, so it carries its own
+	// policy rather than inheriting the authenticated default -- without
+	// this it was stamped private and re-fetched per session.
+	//
+	// no-cache, NOT a max-age. These filenames carry no content hash:
+	// index.html, app.js and app.css keep their names across a rebuild. A
+	// freshness lifetime therefore buys nothing that the ETag does not
+	// already give -- and costs correctness, because must-revalidate only
+	// governs what a cache may do once the entry is ALREADY stale
+	// (RFC 9111 5.2.2.2). Inside the lifetime the browser serves the copy
+	// it has without asking, so an upgraded daemon would keep handing out
+	// the old shell for the rest of the window, and since each asset
+	// expires on its own clock a new shell can be paired with an old
+	// bundle -- breakage that looks like a bug rather than a stale page.
+	//
+	// no-cache means revalidate every time, not "do not store": the copy
+	// stays in the cache and an unchanged bundle costs one conditional GET
+	// answered 304 with no body. Reserve a long max-age for content-hashed
+	// filenames, where the URL changes when the bytes do.
+	//
+	// public is load-bearing alongside it, not decoration. RFC 9111 3.5
+	// bars a shared cache from reusing a response to a request that
+	// carried an AUTHORIZATION HEADER unless the response carries one of
+	// public, must-revalidate or s-maxage, and no-cache is not on that
+	// list. The browser WebUI is not the case that engages it -- it
+	// authenticates by cookie, which is exactly why the credential stamp
+	// above needs Vary: Cookie instead. A bearer-token client fetching the
+	// same shell is: its request does carry the header. Without public, a
+	// proxy in front of the daemon must then hold a per-token copy of a
+	// file identical for every caller. It changes nothing for a client
+	// that is not a shared cache: no-cache still forces revalidation on
+	// every use.
+	r.headers["Cache-Control"] = "public, no-cache";
 	return r;
 }
 
@@ -1729,9 +1871,11 @@ CHttpServer::Response CApiDispatcher::ServeCountryFlag(
 	CHttpServer::Response r;
 	r.status = 200;
 	r.content_type = "image/png";
-	// HEAD body-stripping and the ETag / If-None-Match → 304 swap are
-	// applied to every 200 GET/HEAD by Dispatch(), so this handler only
-	// has to produce the bytes.
+	// The ETag / If-None-Match -> 304 swap is applied to every 200
+	// GET/HEAD by Dispatch(), and a HEAD is written as headers only by the
+	// transport rather than stripped here, so this handler only has to
+	// produce the bytes. (Dispatch no longer strips the body: keeping it
+	// is what lets Content-Length report what a GET would return.)
 	r.body.assign(reinterpret_cast<const char *>(icon->png_data), icon->png_len);
 	// The artwork is compiled in: it can only change with a new build,
 	// and a peer list is a page full of <img> tags pointing here. A day
@@ -2064,6 +2208,10 @@ CHttpServer::Response CApiDispatcher::HandleSession(const CHttpServer::Request &
 	w.Key("exp_unix");
 	w.ValueInt(static_cast<int64_t>(a.verified.exp));
 	w.EndObject();
+	// Per-principal document: a shared cache must not hand one caller
+	// another's session. Our own ETag memo excludes this target for the
+	// same reason; this is the half that binds anything in front of us.
+	r.headers["Cache-Control"] = "private, no-store";
 	FinalizeJsonBody(w, r);
 	return r;
 }
@@ -10458,6 +10606,20 @@ CHttpServer::Response CApiDispatcher::HandleSearchCommentsKadSearch(
 //
 // DispatchStreaming reads head out-params ONCE before writing, so
 // one function here sets the head AND runs the drain loop.
+// CORS for the replies the transport builds without a parsed request: the
+// read-side limits and the request timeout. Takes the raw Origin header
+// because at that point there is no Request to resolve one from.
+void CApiDispatcher::StampCorsForTransport(
+	std::map<std::string, std::string> &headers, const std::string &origin_header)
+{
+	CHttpServer::Request synthetic;
+	if (!origin_header.empty()) {
+		synthetic.headers.emplace("Origin", origin_header);
+	}
+	const std::string cors_org = ResolveCorsOrigin(synthetic, m_config);
+	ApplyCorsHeaders(headers, cors_org, m_config.ServerCfg().allow_cors);
+}
+
 boost::optional<CHttpServer::Response> CApiDispatcher::PreflightEvents(const CHttpServer::Request &req)
 {
 	// Same bearer/cookie check the live handler used to do, but run
@@ -10468,7 +10630,46 @@ boost::optional<CHttpServer::Response> CApiDispatcher::PreflightEvents(const CHt
 	// subscribers.
 	auto a = Authenticate(req);
 	if (!a.ok) {
+		// CORS on the rejection too. The HEAD probe below was moved
+		// into this function to pick the bundle up, and leaving the
+		// 401/403/429 without it means a cross-origin SSE client sees
+		// an opaque fetch failure exactly when it most needs to read
+		// why it was turned away.
+		{
+			const std::string cors_org = ResolveCorsOrigin(req, m_config);
+			ApplyCorsHeaders(a.rejection.headers, cors_org, m_config.ServerCfg().allow_cors);
+		}
 		return a.rejection;
+	}
+	// A HEAD here asks what a GET would answer with, not for the stream.
+	// Answered in the dispatcher rather than in the transport so it picks
+	// up the same CORS bundle the stream itself carries -- built in the
+	// transport it had none, and a credentialed cross-origin HEAD was
+	// blocked by the browser while the GET succeeded.
+	if (req.method == "HEAD") {
+		CHttpServer::Response probe;
+		probe.status = 200;
+		probe.content_type = "text/event-stream";
+		probe.headers["Cache-Control"] = "no-cache";
+		probe.headers["X-Accel-Buffering"] = "no";
+		// Mirror the encoding the GET would negotiate. The probe body
+		// is empty, so nothing downstream will compress it and the
+		// header has to be stated: without it a HEAD says identity
+		// while the stream it stands for arrives gzipped, which is the
+		// same divergence that makes a HEAD on any other route unsafe
+		// to cache against.
+		if (AcceptsGzip(FindHeaderCaseInsensitive(req.headers, "Accept-Encoding"))) {
+			probe.headers["Content-Encoding"] = "gzip";
+		}
+		// NOT keep-alive: this connection is answered and closed, and
+		// advertising reuse makes a pooling client fail its next
+		// request on a socket we already shut down.
+		probe.headers["Connection"] = "close";
+		{
+			const std::string cors_org = ResolveCorsOrigin(req, m_config);
+			ApplyCorsHeaders(probe.headers, cors_org, m_config.ServerCfg().allow_cors);
+		}
+		return probe;
 	}
 	return boost::none;
 }

--- a/src/webapi/Api.h
+++ b/src/webapi/Api.h
@@ -91,6 +91,9 @@ public:
 	// admit the connection; returns a 401/403/429 Response to short-
 	// circuit unauth peers without burning a slot.
 	boost::optional<CHttpServer::Response> PreflightEvents(const CHttpServer::Request &req);
+	// CORS for transport-built replies (408 / 413 / 431); see the .cpp.
+	void StampCorsForTransport(
+		std::map<std::string, std::string> &headers, const std::string &origin_header);
 
 private:
 	// Inner routing — picks the right Handle*() based on path/method,
@@ -369,7 +372,8 @@ private:
 	mutable std::mutex m_etagCacheMu;
 	struct EtagCacheEntry
 	{
-		std::time_t snapshot_at = 0;
+		// Refresh revision, not a timestamp; see CApiDispatcher::Dispatch.
+		std::uint64_t snapshot_rev = 0;
 		std::string etag;
 	};
 	std::map<std::string, EtagCacheEntry> m_etagCache;

--- a/src/webapi/App.cpp
+++ b/src/webapi/App.cpp
@@ -552,7 +552,19 @@ void CamuleapiApp::TextShell(const wxString & /*prompt*/)
 	m_ec_service.Start([this](const CECPacket *r) { return SendRecvMsg_v2(r); });
 
 	m_http = std::unique_ptr<CHttpServer>(new CHttpServer());
-	if (!m_http->Start(bind, port, handler, streaming_resolver, streaming_handler, streaming_preflight)) {
+	// Lets the transport stamp CORS on the replies it builds itself (408 /
+	// 413 / 431), which never reach the dispatcher's CORS pass.
+	auto cors_stamper = [dispatcher](std::map<std::string, std::string> &headers,
+				    const std::string &origin_header) {
+		dispatcher->StampCorsForTransport(headers, origin_header);
+	};
+	if (!m_http->Start(bind,
+		    port,
+		    handler,
+		    streaming_resolver,
+		    streaming_handler,
+		    streaming_preflight,
+		    cors_stamper)) {
 		Show(CFormat("amuleapi: HTTP server failed to start: %s\n") %
 			wxString::FromUTF8(m_http->LastError().c_str()));
 		return;

--- a/src/webapi/EventDiff.cpp
+++ b/src/webapi/EventDiff.cpp
@@ -128,13 +128,22 @@ std::string ToJsonDownloadEvent(const FileSnapshot &f)
 	return o.str();
 }
 
-// comments_updated event payload — the file's full comment/rating list, matching
-// the GET /downloads/{hash}/comments body. Covers both retrieved Kad notes and
-// comments reported by connected ed2k sources (they share source_comments).
+// comments_updated event payload — the GET /downloads/{hash}/comments body
+// plus `hash`. Covers both retrieved Kad notes and comments reported by
+// connected ed2k sources (they share source_comments).
+//
+// A strict superset of the endpoint, deliberately: the event needs `hash`
+// because nothing else in the frame identifies the file, and it needs
+// `kad_comment_search_running` because that flag is exactly what a client
+// wants while a POST /downloads/{hash}/comments lookup is in flight. It used
+// to carry the first and not the second, so a client that followed the docs
+// and fed the event into the view it built from the endpoint silently lost
+// the in-flight indicator.
 std::string ToJsonCommentsEvent(const FileSnapshot &f)
 {
 	std::ostringstream o;
 	o << "{\"hash\":\"" << EscJson(f.hash) << "\""
+	  << ",\"kad_comment_search_running\":" << (f.download.kad_comment_searching ? "true" : "false")
 	  << ",\"count\":" << f.download.source_comments.size() << ",\"comments\":[";
 	bool first = true;
 	for (const auto &c : f.download.source_comments) {

--- a/src/webapi/EventDiff.cpp
+++ b/src/webapi/EventDiff.cpp
@@ -362,6 +362,13 @@ bool EqualDownload(const FileSnapshot &a, const FileSnapshot &b)
 // change drives the separate comments_updated event, not download_updated).
 bool EqualComments(const FileSnapshot &a, const FileSnapshot &b)
 {
+	// The in-flight flag is part of the payload, so it has to be part of
+	// the comparison: without it the true->false edge at the end of a Kad
+	// lookup fires no event at all, and a `?channels=comments` subscriber
+	// is left with its spinner stuck on. Every field the event emits must
+	// be compared here or the event cannot announce it changing.
+	if (a.download.kad_comment_searching != b.download.kad_comment_searching)
+		return false;
 	const auto &ca = a.download.source_comments;
 	const auto &cb = b.download.source_comments;
 	if (ca.size() != cb.size())
@@ -729,7 +736,16 @@ void EmitDiffsAndUpdate(CEventBus &bus, LastSeenState &prev, const CState &state
 				if (now.is_downloading) {
 					if (!was_downloading) {
 						changed.emplace_back(Change::DownloadAdded, entry.first);
-						if (!now.download.source_comments.empty()) {
+						// The flag counts as comment state, exactly as
+						// it does in EqualComments. Gating on the list
+						// alone means a download first seen with a Kad
+						// lookup already in flight never announces the
+						// lookup at all -- the mirror of the edge where
+						// a finished lookup never announced its end,
+						// leaving the same indicator wrong in the
+						// opposite direction.
+						if (!now.download.source_comments.empty() ||
+							now.download.kad_comment_searching) {
 							changed.emplace_back(
 								Change::CommentsUpdated, entry.first);
 						}

--- a/src/webapi/HttpServer.cpp
+++ b/src/webapi/HttpServer.cpp
@@ -313,6 +313,7 @@ public:
 		CHttpServer::StreamingHandler streaming_handler,
 		CHttpServer::StreamingPreflight streaming_preflight)
 	: m_stream(std::move(socket))
+	, m_request_timer(m_stream.get_executor())
 	, m_handler_pool(std::move(handler_pool))
 	, m_handler(std::move(handler))
 	, m_streaming_resolver(std::move(streaming_resolver))
@@ -394,24 +395,68 @@ private:
 		// (Authorization + a few Accept headers is < 2 KiB) and
 		// catches the drip-feed within ~1 KiB instead of ~MB.
 		m_parser->header_limit(16 * 1024);
-		// 10 s read timeout. amuleapi runs against localhost/LAN; a
+		// 10 s read budget. amuleapi runs against localhost/LAN; a
 		// real client never takes 10 s to send a 1 KiB request.
-		m_stream.expires_after(std::chrono::seconds(10));
+		//
+		// Two timers, deliberately. beast::tcp_stream's own expiry
+		// CLOSES the socket, so by the time the read handler sees
+		// beast::error::timeout there is nothing left to answer on --
+		// which is why a stalled request used to look identical to a
+		// crashed daemon. Our own timer fires first and gets to send a
+		// 408; the stream's expiry stays as the hard backstop for the
+		// case where writing that 408 also stalls.
+		m_stream.expires_after(std::chrono::seconds(20));
+		m_request_timer.expires_after(std::chrono::seconds(10));
+		{
+			auto self = shared_from_this();
+			m_request_timer.async_wait([self](const beast::error_code &tec) {
+				// operation_aborted = the read completed and cancelled
+				// us, which is the normal path.
+				if (tec == asio::error::operation_aborted)
+					return;
+				if (self->m_answered.exchange(true))
+					return;
+				self->WriteAndClose(
+					408, "request_timeout", "the request was not completed within 10 s");
+			});
+		}
 
 		auto self = shared_from_this();
 		http::async_read(
 			m_stream, m_buffer, *m_parser, [self](beast::error_code ec, std::size_t bytes) {
 				(void)bytes;
+				self->m_request_timer.cancel();
+				// The timeout timer got there first and has already
+				// written a 408; anything we do now would be a second
+				// response on the same connection.
+				if (self->m_answered.exchange(true))
+					return;
 				if (ec == http::error::end_of_stream) {
 					self->DoClose();
 					return;
 				}
 				if (ec) {
-					// Read error (timeout, peer close, framing error) —
-					// stay quiet. amuleapi-side log noise from health-
-					// check probes ("000 errors are normal" in our
-					// curl-tests README) isn't worth the line per
-					// connection.
+					// Three of these are limits WE imposed, and a
+					// caller cannot tell a silent close from "daemon
+					// crashed" or "firewall ate it" — every other
+					// rejection on this surface is a typed JSON
+					// envelope, so answer these the same way before
+					// closing. Any other read error (peer vanished,
+					// framing garbage) stays quiet: there is nobody
+					// left to tell, and health-check probes would
+					// otherwise cost a log line per connection.
+					if (ec == http::error::body_limit) {
+						self->WriteAndClose(413,
+							"payload_too_large",
+							"request body exceeds the 1 MiB limit");
+						return;
+					}
+					if (ec == http::error::header_limit) {
+						self->WriteAndClose(431,
+							"headers_too_large",
+							"request headers exceed the 16 KiB limit");
+						return;
+					}
 					self->DoClose();
 					return;
 				}
@@ -435,6 +480,9 @@ private:
 		// path and the streaming SocketWriter see the same decision;
 		// the header can't legally change between the two.
 		m_accepts_gzip = AcceptsGzip(std::string(req[http::field::accept_encoding]));
+		// HEAD is answered with the GET headers and no content. Recorded
+		// here because WriteResponse runs after the parser has moved on.
+		m_head_only = (r.method == "HEAD");
 		// Remote endpoint for rate-limiting. `.address()` returns a
 		// boost::asio::ip::address which `.to_string()`-es to the
 		// canonical IPv4 / IPv6 form ("192.0.2.1", "::1", "fe80::%lo0"...).
@@ -837,6 +885,20 @@ private:
 		SseGzipStream m_gzip;
 	};
 
+	// Typed error straight from the transport layer, for the read-side
+	// limits that never reach a handler. Hand-built rather than routed
+	// through the dispatcher's ErrorResponse: at this point the request
+	// was never parsed, so there is no route and no auth context.
+	void WriteAndClose(unsigned status, const char *code, const char *message)
+	{
+		CHttpServer::Response r;
+		r.status = status;
+		r.content_type = "application/json";
+		r.body = std::string("{\"error\":{\"code\":\"") + code + "\",\"message\":\"" + message +
+			 "\"}}";
+		WriteResponse(std::move(r));
+	}
+
 	void WriteResponse(CHttpServer::Response &&resp)
 	{
 		// Regular (non-streaming) response gzip encoding. Gated by:
@@ -873,7 +935,12 @@ private:
 		m_response->version(11);
 		m_response->result(resp.status);
 		m_response->set(http::field::server, "amuleapi");
-		m_response->set(http::field::content_type, resp.content_type);
+		// A Content-Type whose value is not a media type is malformed, so
+		// omit the header entirely on the bodiless replies (204, 304)
+		// whose handlers deliberately cleared it.
+		if (!resp.content_type.empty()) {
+			m_response->set(http::field::content_type, resp.content_type);
+		}
 		for (const auto &h : resp.headers) {
 			m_response->set(h.first, h.second);
 		}
@@ -881,6 +948,21 @@ private:
 		m_response->prepare_payload();
 
 		auto self = shared_from_this();
+		if (m_head_only) {
+			// RFC 9110 §9.3.2 — a HEAD response carries no content, on
+			// any status. prepare_payload() has already sized
+			// Content-Length from the full body, so serializing the
+			// header alone reports what a GET would return without
+			// putting a byte of it on the wire.
+			m_serializer.emplace(*m_response);
+			m_serializer->split(true);
+			http::async_write_header(
+				m_stream, *m_serializer, [self](beast::error_code ec, std::size_t) {
+					(void)ec;
+					self->DoClose();
+				});
+			return;
+		}
 		http::async_write(m_stream, *m_response, [self](beast::error_code ec, std::size_t) {
 			(void)ec;
 			self->DoClose();
@@ -889,6 +971,11 @@ private:
 
 	void DoClose()
 	{
+		// Drop the request timer first. It holds a shared_ptr to this
+		// Session, so leaving it armed keeps a closed connection alive
+		// for the rest of its 10 s and delays process teardown by the
+		// same amount.
+		m_request_timer.cancel();
 		// If we were streaming, write the chunked-encoding terminator
 		// (0-size chunk) before shutting down. Idempotent — if the
 		// peer already closed, the write fails silently.
@@ -904,6 +991,9 @@ private:
 	}
 
 	beast::tcp_stream m_stream;
+	// Fires before the stream's own expiry so a stalled request can be
+	// answered instead of silently dropped; see DoRead.
+	asio::steady_timer m_request_timer;
 	// Worker pool that runs the (non-streaming) request handler off the
 	// io_context thread. Shared with the server; declared before m_handler
 	// so the init list stays in declaration order.
@@ -911,6 +1001,9 @@ private:
 	beast::flat_buffer m_buffer{ 8192 };
 	boost::optional<http::request_parser<http::string_body>> m_parser;
 	boost::optional<http::response<http::string_body>> m_response;
+	// Header-only serializer, used for HEAD so Content-Length still
+	// reports the GET size while no content reaches the wire.
+	boost::optional<http::response_serializer<http::string_body>> m_serializer;
 	CHttpServer::Handler m_handler;
 
 	// streaming state.
@@ -938,6 +1031,9 @@ private:
 	// the same thread that populated it or on a worker spawned after
 	// the write, so no atomic is needed.
 	bool m_accepts_gzip = false;
+	bool m_head_only = false;
+	// One response per connection, whichever of the two paths wins.
+	std::atomic<bool> m_answered{ false };
 };
 
 // Accept loop. One Listener per HttpServer; spawns a Session per

--- a/src/webapi/HttpServer.cpp
+++ b/src/webapi/HttpServer.cpp
@@ -26,6 +26,8 @@
 
 #include "JsonWriter.h"
 
+#include <Etag.h> // webcommon::WithCodingSuffix
+
 #include <wx/string.h>
 
 // See the note in LibSocketAsio.cpp: Boost 1.92's asio trips
@@ -49,6 +51,18 @@
 #pragma clang diagnostic pop
 #endif
 
+// strncasecmp lives in <strings.h> on POSIX (glibc also exposes it via
+// <string.h>, but musl/BSDs don't), and MSVC spells it _strnicmp. The same
+// shim Api.cpp and libwebcommon/HeaderParse.cpp carry: this file reads a
+// header name case-insensitively on the transport error paths, and it should
+// not depend on the declaration arriving transitively through someone else's
+// include.
+#ifdef _WIN32
+#define strncasecmp _strnicmp
+#else
+#include <strings.h>
+#endif
+
 #include <zlib.h>
 
 #include <atomic>
@@ -68,35 +82,39 @@ namespace http = boost::beast::http;
 namespace asio = boost::asio;
 using tcp = boost::asio::ip::tcp;
 
-namespace
-{
-
-// Per-connection session. Reads one request, hands it to the user
-// handler, writes the response, closes. No keep-alive — the API
-// surface is too small to benefit, and the one-shot model keeps the
-// state machine trivially auditable. If the streaming_resolver
-// matches the parsed request, the session takes a different path:
-// writes the response head and runs the streaming handler on a
-// worker thread, which can push chunks indefinitely via the Writer
-// interface until the handler returns or the peer disconnects.
+// See HttpServer.h.
 //
-// Process-wide cap on concurrent SSE subscribers. Each session
-// spawns one OS thread, so without a cap a non-loopback bind turns
-// the thread-per-connection model into a DoS amplifier. The cap is
-// sized for the single-operator dashboard pattern: a handful of
-// browser tabs + the odd shell script. Refused sessions get
-// `503 Service Unavailable` + a `Retry-After` hint inside the
-// streaming dispatch path before the worker thread is created.
-constexpr int kMaxConcurrentStreamingSessions = 32;
-
-// Size of the handler worker pool. Non-streaming request handlers run here
-// instead of on the single io_context thread, so a handler that blocks — a
-// synchronous EC roundtrip stalled up to the EC read timeout — can never
-// freeze accept or other connections. Sized with headroom over amuleapi's
-// typical concurrency (a handful of clients) so non-EC requests keep a free
-// worker even while several handlers are parked on a stalled EC roundtrip.
-constexpr int kHandlerPoolThreads = 16;
-std::atomic<int> g_streaming_session_count{ 0 };
+// Factored out deliberately. This logic existed in three places -- the regular
+// response writer, the SSE head writer, and the dispatcher's CORS pass -- and
+// two consecutive rounds of fixes each landed in a different two of the three,
+// leaving the untouched copy with the old overwrite behaviour. One definition
+// means a fix cannot land in only some of the writers.
+void AppendHeaderToken(std::map<std::string, std::string> &headers, const char *name, const char *token)
+{
+	auto it = headers.find(name);
+	if (it == headers.end() || it->second.empty()) {
+		headers[name] = token;
+		return;
+	}
+	// Token-by-token so a short name cannot match inside a longer one.
+	const std::string &cur = it->second;
+	std::size_t pos = 0;
+	while (pos <= cur.size()) {
+		const std::size_t comma = cur.find(',', pos);
+		const std::size_t end = (comma == std::string::npos) ? cur.size() : comma;
+		std::size_t b = pos, e = end;
+		while (b < e && (cur[b] == ' ' || cur[b] == '\t'))
+			++b;
+		while (e > b && (cur[e - 1] == ' ' || cur[e - 1] == '\t'))
+			--e;
+		if (cur.compare(b, e - b, token) == 0)
+			return;
+		if (comma == std::string::npos)
+			break;
+		pos = comma + 1;
+	}
+	it->second = cur + ", " + token;
+}
 
 // Bodies smaller than this are sent uncompressed. Below ~250 bytes the
 // gzip header (~10 bytes) + trailer (~8 bytes) plus the deflate block
@@ -128,6 +146,14 @@ bool IsPrecompressedType(const std::string &content_type)
 	return false;
 }
 
+// See HttpServer.h.
+bool WillCompressBody(
+	bool accepts_gzip, std::size_t body_size, const std::string &content_type, bool already_encoded)
+{
+	return accepts_gzip && body_size >= kGzipMinBodyBytes && !already_encoded &&
+	       !IsPrecompressedType(content_type);
+}
+
 // Case-insensitive token search for "gzip" in an Accept-Encoding header
 // value. Real clients (curl, browsers) send "gzip, deflate, br" or
 // "gzip;q=1.0" — no legitimate client sends "gzip;q=0" (which per
@@ -156,6 +182,52 @@ bool AcceptsGzip(const std::string &accept_encoding)
 	}
 	return false;
 }
+
+namespace
+{
+
+// Per-connection session. Reads one request, hands it to the user
+// handler, writes the response, closes. No keep-alive — the API
+// surface is too small to benefit, and the one-shot model keeps the
+// state machine trivially auditable. If the streaming_resolver
+// matches the parsed request, the session takes a different path:
+// writes the response head and runs the streaming handler on a
+// worker thread, which can push chunks indefinitely via the Writer
+// interface until the handler returns or the peer disconnects.
+//
+// Process-wide cap on concurrent SSE subscribers. Each session
+// spawns one OS thread, so without a cap a non-loopback bind turns
+// the thread-per-connection model into a DoS amplifier. The cap is
+// sized for the single-operator dashboard pattern: a handful of
+// browser tabs + the odd shell script. Refused sessions get
+// `503 Service Unavailable` + a `Retry-After` hint inside the
+// streaming dispatch path before the worker thread is created.
+constexpr int kMaxConcurrentStreamingSessions = 32;
+
+// Size of the handler worker pool. Non-streaming request handlers run here
+// instead of on the single io_context thread, so a handler that blocks — a
+// synchronous EC roundtrip stalled up to the EC read timeout — can never
+// freeze accept or other connections. Sized with headroom over amuleapi's
+// typical concurrency (a handful of clients) so non-EC requests keep a free
+// worker even while several handlers are parked on a stalled EC roundtrip.
+constexpr int kHandlerPoolThreads = 16;
+std::atomic<int> g_streaming_session_count{ 0 };
+
+// Largest request header block we accept. The read buffer below is sized
+// from this: the whole header has to sit in the buffer at once, so a buffer
+// smaller than the parser's header_limit means the buffer overflows first
+// and the limit never fires. They were 8 KiB and 16 KiB respectively, which
+// made the documented 16 KiB cap unreachable and the header_limit branch
+// dead code.
+constexpr std::size_t kMaxHeaderBytes = 16 * 1024;
+// Slack for the request line and the parser's own bookkeeping.
+constexpr std::size_t kReadBufferBytes = kMaxHeaderBytes + 2 * 1024;
+
+// Ceiling on how much of a rejected upload we read and throw away before
+// closing. Enough to clear the in-flight window for a normal client that
+// wrote its body before reading our answer, without letting a peer that
+// keeps pumping hold the session open.
+constexpr std::size_t kMaxDrainBytes = 4 * 1024 * 1024;
 
 // One-shot gzip encoder for regular (non-streaming) response bodies.
 // Returns false on any zlib error; the caller then serves the response
@@ -311,7 +383,8 @@ public:
 		CHttpServer::Handler handler,
 		CHttpServer::StreamingResolver streaming_resolver,
 		CHttpServer::StreamingHandler streaming_handler,
-		CHttpServer::StreamingPreflight streaming_preflight)
+		CHttpServer::StreamingPreflight streaming_preflight,
+		CHttpServer::CorsStamper cors_stamper)
 	: m_stream(std::move(socket))
 	, m_request_timer(m_stream.get_executor())
 	, m_handler_pool(std::move(handler_pool))
@@ -319,6 +392,7 @@ public:
 	, m_streaming_resolver(std::move(streaming_resolver))
 	, m_streaming_handler(std::move(streaming_handler))
 	, m_streaming_preflight(std::move(streaming_preflight))
+	, m_cors_stamper(std::move(cors_stamper))
 	{
 	}
 
@@ -379,6 +453,21 @@ private:
 		// state. only reads one request, but leaving the reset
 		// in keeps the read loop forward-compatible if keep-alive is
 		// turned on later.
+		// Per-request, like the parser. m_answered decides which of the
+		// timeout timer and the read handler gets to answer; the rest
+		// describe how THIS request must be written and drained. All of
+		// them are latched today only because a connection serves one
+		// request -- the moment the keep-alive path above is turned on,
+		// a stale m_answered drops every later request, a stale
+		// m_drain_before_close makes an ordinary response drain, a
+		// stale m_head_probe_chunked mislabels its framing, and a
+		// stale m_drained shortens the next drain budget. Reset them
+		// together so the set cannot drift apart again.
+		m_answered.store(false, std::memory_order_relaxed);
+		m_head_only = false;
+		m_head_probe_chunked = false;
+		m_drain_before_close = false;
+		m_drained = 0;
 		m_parser.emplace();
 		// 1 MiB request cap — bigger than any sensible REST POST body
 		// (login JSON is ~64 bytes, etc.) but well under "someone is
@@ -394,7 +483,7 @@ private:
 		// defaults: 16 KiB is well over any legitimate request
 		// (Authorization + a few Accept headers is < 2 KiB) and
 		// catches the drip-feed within ~1 KiB instead of ~MB.
-		m_parser->header_limit(16 * 1024);
+		m_parser->header_limit(kMaxHeaderBytes);
 		// 10 s read budget. amuleapi runs against localhost/LAN; a
 		// real client never takes 10 s to send a 1 KiB request.
 		//
@@ -416,8 +505,30 @@ private:
 					return;
 				if (self->m_answered.exchange(true))
 					return;
-				self->WriteAndClose(
-					408, "request_timeout", "the request was not completed within 10 s");
+				// Same method recovery as the limit paths: this
+				// path never reaches Dispatch(), where
+				// m_head_only is normally set, so without it a
+				// HEAD drip-feeding its headers gets the 408
+				// envelope as content.
+				if (self->m_parser->get().method() == http::verb::head) {
+					self->m_head_only = true;
+				}
+				// No drain here: http::async_read is still
+				// outstanding on this socket, and a second
+				// read alongside it is an overlapping read.
+				// Retire it instead -- writing the envelope
+				// does not, and a peer that ignores the FIN
+				// would otherwise pin this Session and its fd
+				// until the stream backstop, which is twice
+				// the budget the single timer used to enforce.
+				{
+					beast::error_code cancel_ec;
+					self->m_stream.socket().cancel(cancel_ec);
+				}
+				self->WriteAndClose(408,
+					"request_timeout",
+					"the request was not completed within 10 s",
+					/*drain=*/false);
 			});
 		}
 
@@ -436,6 +547,16 @@ private:
 					return;
 				}
 				if (ec) {
+					// Recover the method from whatever the parser
+					// managed to read before it gave up. Dispatch()
+					// is where m_head_only is normally set and these
+					// paths never reach it, so without this a HEAD
+					// rejected at the body or header cap answers with
+					// the error envelope as content -- the exact
+					// violation this commit removes everywhere else.
+					if (self->m_parser->get().method() == http::verb::head) {
+						self->m_head_only = true;
+					}
 					// Three of these are limits WE imposed, and a
 					// caller cannot tell a silent close from "daemon
 					// crashed" or "firewall ate it" — every other
@@ -448,13 +569,20 @@ private:
 					if (ec == http::error::body_limit) {
 						self->WriteAndClose(413,
 							"payload_too_large",
-							"request body exceeds the 1 MiB limit");
+							"request body exceeds the 1 MiB limit",
+							/*drain=*/true);
 						return;
 					}
-					if (ec == http::error::header_limit) {
+					// buffer_overflow is the same condition seen
+					// from the buffer's side: whichever of the two
+					// binds first, the caller sent more header than
+					// we accept.
+					if (ec == http::error::header_limit ||
+						ec == http::error::buffer_overflow) {
 						self->WriteAndClose(431,
 							"headers_too_large",
-							"request headers exceed the 16 KiB limit");
+							"request headers exceed the 16 KiB limit",
+							/*drain=*/true);
 						return;
 					}
 					self->DoClose();
@@ -533,6 +661,14 @@ private:
 				resp.content_type = "application/json";
 				resp.body = "{\"error\":{\"code\":\"internal\","
 					    "\"message\":\"internal server error\"}}";
+				// The dispatcher's CORS pass died with the handler,
+				// so stamp it here: a cross-origin client should be
+				// able to read a 500 for the same reason it can read
+				// a 4xx.
+				if (self->m_cors_stamper) {
+					self->m_cors_stamper(
+						resp.headers, self->FindHeaderCaseInsensitiveRaw("Origin"));
+				}
 			}
 			auto out = std::make_shared<CHttpServer::Response>(std::move(resp));
 			boost::asio::post(self->m_stream.get_executor(),
@@ -553,6 +689,12 @@ private:
 		refused.status = 503;
 		refused.content_type = "application/json";
 		refused.headers["Retry-After"] = "10";
+		// Transport-built, so the dispatcher never sees it. Without the
+		// stamp this is one more reply a cross-origin client cannot
+		// read -- the same defect just fixed for 408/413/431.
+		if (m_cors_stamper) {
+			m_cors_stamper(refused.headers, FindHeaderCaseInsensitiveRaw("Origin"));
+		}
 		refused.body = "{\"error\":{\"code\":\"sessions_exhausted\","
 			       "\"message\":\"too many concurrent streaming sessions; "
 			       "retry in a few seconds\"}}";
@@ -618,7 +760,13 @@ private:
 		// the first time.
 		auto head = std::make_shared<SocketWriter::HeadData>();
 		head->headers["Cache-Control"] = "no-cache";
-		head->headers["Connection"] = "keep-alive";
+		// Not keep-alive. DoClose() writes the chunked terminator and
+		// then shuts the socket down, so a client that reads the stream
+		// to its clean end and returns the socket to a pool fails its
+		// next request on it -- the same reason every ordinary response
+		// says close. It also kept the HEAD probe, which does say
+		// close, contradicting the GET it stands for.
+		head->headers["Connection"] = "close";
 		// nginx (and many other reverse proxies) buffer response
 		// bodies by default when they detect chunked-transfer +
 		// text-ish content, which stalls SSE delivery entirely — the
@@ -817,13 +965,19 @@ private:
 			if (m_wants_gzip) {
 				if (m_gzip.Init()) {
 					m_head->headers["Content-Encoding"] = "gzip";
-					if (m_head->headers.find("Vary") == m_head->headers.end()) {
-						m_head->headers["Vary"] = "Accept-Encoding";
-					}
 				} else {
 					m_wants_gzip = false;
 				}
 			}
+			// Outside the gzip branch on purpose. Vary describes what
+			// the RESPONSE VARIES ON, not what this particular response
+			// was encoded as, so it belongs on the identity reply too --
+			// otherwise a cache keyed on the non-gzip answer serves it
+			// to a client that asked for gzip. WriteResponse adds it
+			// unconditionally, so leaving it inside the branch also put
+			// a plain SSE GET at odds with the HEAD probe for the same
+			// URL, which goes through that writer.
+			AppendHeaderToken(m_head->headers, "Vary", "Accept-Encoding");
 			std::ostringstream head;
 			head << "HTTP/1.1 " << m_head->status << " ";
 			switch (m_head->status) {
@@ -889,22 +1043,108 @@ private:
 	// limits that never reach a handler. Hand-built rather than routed
 	// through the dispatcher's ErrorResponse: at this point the request
 	// was never parsed, so there is no route and no auth context.
-	void WriteAndClose(unsigned status, const char *code, const char *message)
+	// Origin off the parser rather than a parsed Request: on these paths
+	// the request never got far enough to build one. Returns "" when the
+	// header block never arrived, which the stamper treats as no-origin.
+	std::string FindHeaderCaseInsensitiveRaw(const char *name) const
+	{
+		if (!m_parser) {
+			return std::string();
+		}
+		const auto &msg = m_parser->get();
+		for (const auto &h : msg) {
+			if (h.name_string().size() == std::strlen(name) &&
+				strncasecmp(std::string(h.name_string()).c_str(), name, std::strlen(name)) ==
+					0) {
+				return std::string(h.value());
+			}
+		}
+		return std::string();
+	}
+
+	void WriteAndClose(unsigned status, const char *code, const char *message, bool drain)
 	{
 		CHttpServer::Response r;
 		r.status = status;
 		r.content_type = "application/json";
 		r.body = std::string("{\"error\":{\"code\":\"") + code + "\",\"message\":\"" + message +
 			 "\"}}";
+		// `drain` only where the composed read has already completed.
+		// The size limits fire while the peer may still be writing (a
+		// client that sends its whole body before reading anything is
+		// the normal case for a POST), and closing with unread data
+		// queued lets the stack emit an RST that discards the response
+		// just written -- the caller then sees a connection reset
+		// instead of the 413 explaining it. The timeout path is the
+		// opposite case: http::async_read is still outstanding there,
+		// and a second read on the same socket is an overlapping read,
+		// which asio forbids.
+		// The only replies on the surface built without a parsed request,
+		// so the dispatcher's CORS pass never sees them. Stamp here or a
+		// cross-origin browser client gets an opaque failure instead of
+		// the typed envelope the docs promise.
+		if (m_cors_stamper) {
+			m_cors_stamper(r.headers, FindHeaderCaseInsensitiveRaw("Origin"));
+		}
+		m_drain_before_close = drain;
+		// Tell the peer not to reuse this connection. Without it a
+		// pooling client can read the error, keep the socket, and
+		// leave us parked in the drain read with nothing to collect.
+		r.headers["Connection"] = "close";
 		WriteResponse(std::move(r));
+	}
+
+	// Read and discard whatever the peer is still sending, then close.
+	// Bounded three ways: the stream's expiry (which is why this reads
+	// through the stream rather than the socket), a byte cap, and the
+	// `Connection: close` the error carries.
+	// Arms the drain deadline and starts the loop. The deadline is set
+	// ONCE, here: expires_after inside the loop would re-arm on every
+	// read and bound only the gap between them, so a peer trickling a
+	// byte just under the limit apart could hold the Session and its fd
+	// until the byte cap -- effectively forever.
+	void StartDrainThenClose()
+	{
+		// Short budget of its own, not the request budget. The point of
+		// the drain is to collect what is ALREADY in flight so the
+		// close does not RST away the error we just wrote -- not to
+		// wait for a peer that has finished talking. A client that sent
+		// an oversized header has said everything it intends to and is
+		// now waiting on us, so draining to EOF would have both sides
+		// waiting until the request expiry broke the tie, which reads
+		// to the caller as a hang rather than a 431.
+		m_stream.expires_after(std::chrono::seconds(1));
+		DrainThenClose();
+	}
+
+	void DrainThenClose()
+	{
+		auto self = shared_from_this();
+		// Through the beast stream, not the raw socket: the raw socket
+		// ignores the stream's expiry, so a peer that neither sends nor
+		// closes would park this read forever and leak the Session with
+		// its fd.
+		m_stream.async_read_some(
+			m_drain_buffer.prepare(4096), [self](beast::error_code ec, std::size_t n) {
+				self->m_drained += n;
+				if (ec || n == 0 || self->m_drained > kMaxDrainBytes) {
+					self->DoClose();
+					return;
+				}
+				// Loop, do NOT re-arm: the deadline set in
+				// StartDrainThenClose is the total budget, and
+				// re-arming here would reset it on every read.
+				self->DrainThenClose();
+			});
 	}
 
 	void WriteResponse(CHttpServer::Response &&resp)
 	{
 		// Regular (non-streaming) response gzip encoding. Gated by:
 		//  * client Accept-Encoding contains gzip,
-		//  * body is above kGzipMinBodyBytes (header overhead is a
-		//    significant fraction below that),
+		//  * body is at or above kGzipMinBodyBytes -- the bound is
+		//    inclusive; header overhead is a significant fraction of
+		//    anything smaller,
 		//  * handler didn't already set Content-Encoding (a future
 		//    pre-gzipped static asset path would use that hook),
 		//  * body isn't already entropy-coded (PNG flags, images and
@@ -918,23 +1158,57 @@ private:
 		// response was compressed, so any intermediary cache keys the
 		// entry correctly across clients that do / don't send the
 		// header.
-		if (m_accepts_gzip && resp.body.size() >= kGzipMinBodyBytes &&
-			resp.headers.find("Content-Encoding") == resp.headers.end() &&
-			!IsPrecompressedType(resp.content_type)) {
+		// HEAD is compressed too, even though the bytes are then
+		// discarded. Skipping it saves a deflate per probe and costs
+		// correctness: HEAD must describe what the equivalent GET would
+		// return, so with Accept-Encoding: gzip that means the SAME
+		// Content-Encoding and the SAME Content-Length. Diverging binds
+		// one strong ETag to two codings and, per RFC 9111 4.3.5, lets
+		// each probe invalidate the stored gzip response. The deflate
+		// is the cheaper of the two.
+		if (WillCompressBody(m_accepts_gzip,
+			    resp.body.size(),
+			    resp.content_type,
+			    resp.headers.find("Content-Encoding") != resp.headers.end())) {
 			std::string compressed;
-			if (GzipOnce(resp.body, compressed)) {
+			const bool gzipped = GzipOnce(resp.body, compressed);
+			if (gzipped) {
 				resp.body = std::move(compressed);
 				resp.headers["Content-Encoding"] = "gzip";
 			}
+			// Reconcile the validator with the coding that ACTUALLY
+			// shipped. The hash upstream is taken before compression,
+			// so without a marker both codings of a resource carry the
+			// same strong ETag; the dispatcher stamps it in advance
+			// because a 304 has no body left here to measure. When
+			// that prediction holds this is a no-op. When deflate
+			// fails the body ships as identity and the prediction is
+			// now wrong, and this takes the suffix back off -- leaving
+			// it would bind a gzip validator to identity bytes, which
+			// is the exact mispairing the suffix exists to prevent.
+			auto et = resp.headers.find("ETag");
+			if (et != resp.headers.end())
+				et->second = webcommon::WithCodingSuffix(et->second, gzipped);
 		}
-		if (resp.headers.find("Vary") == resp.headers.end()) {
-			resp.headers["Vary"] = "Accept-Encoding";
-		}
+		// Append, never overwrite: the dispatcher may already have set
+		// `Vary: Origin` for CORS, and replacing it would drop the
+		// encoding dimension from a response whose ETag was computed
+		// before compression.
+		AppendHeaderToken(resp.headers, "Vary", "Accept-Encoding");
 
 		m_response.emplace();
 		m_response->version(11);
 		m_response->result(resp.status);
 		m_response->set(http::field::server, "amuleapi");
+		// One request per connection: DoClose() shuts the socket down
+		// after every response, so HTTP/1.1's default persistence is a
+		// promise this server does not keep. Say so on every reply
+		// instead of on the handful that happened to set it, or a
+		// pooling client keeps the socket and fails its next request on
+		// it. Handlers that set it themselves are left alone.
+		if (resp.headers.find("Connection") == resp.headers.end()) {
+			m_response->set(http::field::connection, "close");
+		}
 		// A Content-Type whose value is not a media type is malformed, so
 		// omit the header entirely on the bodiless replies (204, 304)
 		// whose handlers deliberately cleared it.
@@ -944,8 +1218,25 @@ private:
 		for (const auto &h : resp.headers) {
 			m_response->set(h.first, h.second);
 		}
+		// The /events HEAD probe is the one response that stands in for
+		// a chunked stream; the dispatcher marks it by content type.
+		if (m_head_only && resp.content_type == "text/event-stream") {
+			m_head_probe_chunked = true;
+		}
 		m_response->body() = std::move(resp.body);
 		m_response->prepare_payload();
+		if (m_head_probe_chunked) {
+			// Mirror the framing a GET on this endpoint advertises.
+			// prepare_payload() sizes from the (empty) body and stamps
+			// `Content-Length: 0`, which would describe a zero-length
+			// document rather than the unbounded stream the caller
+			// asked about; chunked() ahead of it does not survive,
+			// since the body size is known. Set the framing directly,
+			// after. Only the header is written, so nothing has to
+			// honour it.
+			m_response->erase(http::field::content_length);
+			m_response->set(http::field::transfer_encoding, "chunked");
+		}
 
 		auto self = shared_from_this();
 		if (m_head_only) {
@@ -959,12 +1250,26 @@ private:
 			http::async_write_header(
 				m_stream, *m_serializer, [self](beast::error_code ec, std::size_t) {
 					(void)ec;
+					// Same drain as the body path. A HEAD rejected at
+					// the header cap has just as much unread data
+					// queued as a GET does, and closing on top of it
+					// lets the RST discard the 431 that was just
+					// written -- intermittently, which is why a single
+					// probe can pass and hide it.
+					if (self->m_drain_before_close) {
+						self->StartDrainThenClose();
+						return;
+					}
 					self->DoClose();
 				});
 			return;
 		}
 		http::async_write(m_stream, *m_response, [self](beast::error_code ec, std::size_t) {
 			(void)ec;
+			if (self->m_drain_before_close) {
+				self->StartDrainThenClose();
+				return;
+			}
 			self->DoClose();
 		});
 	}
@@ -974,8 +1279,14 @@ private:
 		// Drop the request timer first. It holds a shared_ptr to this
 		// Session, so leaving it armed keeps a closed connection alive
 		// for the rest of its 10 s and delays process teardown by the
-		// same amount.
-		m_request_timer.cancel();
+		// same amount. Posted rather than cancelled inline: DoClose also
+		// runs on the SSE worker thread, and the timer belongs to the
+		// io_context executor -- every other foreign-thread touch in
+		// this file goes through asio::post for the same reason.
+		{
+			auto self = shared_from_this();
+			asio::post(m_stream.get_executor(), [self]() { self->m_request_timer.cancel(); });
+		}
 		// If we were streaming, write the chunked-encoding terminator
 		// (0-size chunk) before shutting down. Idempotent — if the
 		// peer already closed, the write fails silently.
@@ -998,7 +1309,7 @@ private:
 	// io_context thread. Shared with the server; declared before m_handler
 	// so the init list stays in declaration order.
 	std::shared_ptr<asio::thread_pool> m_handler_pool;
-	beast::flat_buffer m_buffer{ 8192 };
+	beast::flat_buffer m_buffer{ kReadBufferBytes };
 	boost::optional<http::request_parser<http::string_body>> m_parser;
 	boost::optional<http::response<http::string_body>> m_response;
 	// Header-only serializer, used for HEAD so Content-Length still
@@ -1010,6 +1321,7 @@ private:
 	CHttpServer::StreamingResolver m_streaming_resolver;
 	CHttpServer::StreamingHandler m_streaming_handler;
 	CHttpServer::StreamingPreflight m_streaming_preflight;
+	CHttpServer::CorsStamper m_cors_stamper;
 	std::atomic<bool> m_stream_alive{ false };
 	// Set true by the worker on exit. The Session destructor asserts
 	// on it before detach()ing the thread handle (Session is shared-
@@ -1032,6 +1344,14 @@ private:
 	// the write, so no atomic is needed.
 	bool m_accepts_gzip = false;
 	bool m_head_only = false;
+	// The /events HEAD probe answers for a chunked stream, so it is framed
+	// as one rather than as a zero-length body; see DispatchStreaming.
+	bool m_head_probe_chunked = false;
+	// Set on the transport-level error replies, which are written while the
+	// peer may still be uploading; see WriteAndClose.
+	bool m_drain_before_close = false;
+	std::size_t m_drained = 0;
+	beast::flat_buffer m_drain_buffer;
 	// One response per connection, whichever of the two paths wins.
 	std::atomic<bool> m_answered{ false };
 };
@@ -1047,7 +1367,8 @@ public:
 		CHttpServer::Handler handler,
 		CHttpServer::StreamingResolver streaming_resolver,
 		CHttpServer::StreamingHandler streaming_handler,
-		CHttpServer::StreamingPreflight streaming_preflight)
+		CHttpServer::StreamingPreflight streaming_preflight,
+		CHttpServer::CorsStamper cors_stamper)
 	: m_ioc(ioc)
 	, m_acceptor(asio::make_strand(ioc))
 	, m_handler_pool(std::move(handler_pool))
@@ -1055,6 +1376,7 @@ public:
 	, m_streaming_resolver(std::move(streaming_resolver))
 	, m_streaming_handler(std::move(streaming_handler))
 	, m_streaming_preflight(std::move(streaming_preflight))
+	, m_cors_stamper(std::move(cors_stamper))
 	{
 		beast::error_code ec;
 		m_acceptor.open(endpoint.protocol(), ec);
@@ -1119,7 +1441,8 @@ private:
 						self->m_handler,
 						self->m_streaming_resolver,
 						self->m_streaming_handler,
-						self->m_streaming_preflight)
+						self->m_streaming_preflight,
+						self->m_cors_stamper)
 						->Start();
 				}
 				// Loop unless the acceptor has been closed. operation_aborted
@@ -1137,6 +1460,7 @@ private:
 	CHttpServer::StreamingResolver m_streaming_resolver;
 	CHttpServer::StreamingHandler m_streaming_handler;
 	CHttpServer::StreamingPreflight m_streaming_preflight;
+	CHttpServer::CorsStamper m_cors_stamper;
 	std::string m_error;
 };
 
@@ -1161,12 +1485,21 @@ CHttpServer::~CHttpServer()
 	Stop();
 }
 
+// Every callback here is a sink: taken by value, std::move()d into Listener,
+// which moves it on into its member. A const reference would force a copy at
+// that member instead. performance-unnecessary-value-param flags four of the
+// five anyway -- exactly the four carrying a default argument, including the
+// two this change never touched -- so the suppression covers the whole list
+// rather than singling out the two whose line numbers happened to move.
+// NOLINTBEGIN(performance-unnecessary-value-param)
 bool CHttpServer::Start(const std::string &bind_address,
 	unsigned port,
 	Handler handler,
 	StreamingResolver streaming_resolver,
 	StreamingHandler streaming_handler,
-	StreamingPreflight streaming_preflight)
+	StreamingPreflight streaming_preflight,
+	CorsStamper cors_stamper)
+// NOLINTEND(performance-unnecessary-value-param)
 {
 	if (m_impl) {
 		m_lastError = "HttpServer already started";
@@ -1209,7 +1542,8 @@ bool CHttpServer::Start(const std::string &bind_address,
 		std::move(handler),
 		std::move(streaming_resolver),
 		std::move(streaming_handler),
-		std::move(streaming_preflight));
+		std::move(streaming_preflight),
+		std::move(cors_stamper));
 	if (!m_impl->listener->Ok()) {
 		m_lastError = "bind to " + bind_address + ":" + std::to_string(port) +
 			      " failed: " + m_impl->listener->Error();

--- a/src/webapi/HttpServer.h
+++ b/src/webapi/HttpServer.h
@@ -49,6 +49,38 @@ class io_context;
 }
 } // namespace boost
 
+// Does this Accept-Encoding value ask for gzip? Token search, so
+// "gzip, deflate, br" and "gzip;q=1.0" both match and a longer name
+// containing the letters does not.
+//
+// Shared rather than reimplemented: the dispatcher has to answer the same
+// question when it describes what a GET would return, and a second copy of
+// this parser is how the header-merge logic ended up in three places.
+bool AcceptsGzip(const std::string &accept_encoding);
+
+// Will a response with this body be gzipped on the way out?
+//
+// Shared because two places have to agree: the transport, which compresses and
+// stamps the coding onto the validator, and the 304 paths, which must echo the
+// SAME validator the equivalent 200 would have sent. They cannot each carry
+// their own copy of the rule -- when they disagreed, a client that cached the
+// gzip form was handed the identity ETag on revalidation and could never match
+// its stored response again.
+//
+// `already_encoded` is true when a handler set Content-Encoding itself.
+bool WillCompressBody(
+	bool accepts_gzip, std::size_t body_size, const std::string &content_type, bool already_encoded);
+
+// Add one token to a comma-separated header without dropping what is already
+// there and without duplicating it. Comparison is token-by-token, so a short
+// name cannot match inside a longer one.
+//
+// Declared here because every writer that merges a header has to share one
+// definition: the logic previously existed in three copies, two consecutive
+// rounds of fixes each reached a different two of them, and the copy nobody
+// touched kept the old overwrite behaviour.
+void AppendHeaderToken(std::map<std::string, std::string> &headers, const char *name, const char *token);
+
 class CHttpServer
 {
 public:
@@ -126,6 +158,15 @@ public:
 	// "auth inside the handler" behaviour.
 	using StreamingPreflight = std::function<boost::optional<Response>(const Request &)>;
 
+	// Stamps the CORS bundle on a response the transport built itself --
+	// the 408 / 413 / 431 replies, which are written before any request
+	// reaches a handler. Without it those are the only replies on the
+	// surface a cross-origin browser client cannot read: it sees an opaque
+	// fetch failure instead of the typed envelope. Takes the raw Origin
+	// header, since at that point there is no parsed Request to hand over.
+	using CorsStamper = std::function<void(
+		std::map<std::string, std::string> &headers, const std::string &origin_header)>;
+
 	// Bind + listen on `bind_address`:`port`. Returns false (and
 	// populates LastError) on bind failure — the most common reason
 	// is the port being in use by another amuleapi instance or a
@@ -135,7 +176,8 @@ public:
 		Handler handler,
 		StreamingResolver streaming_resolver = nullptr,
 		StreamingHandler streaming_handler = nullptr,
-		StreamingPreflight streaming_preflight = nullptr);
+		StreamingPreflight streaming_preflight = nullptr,
+		CorsStamper cors_stamper = nullptr);
 
 	// Stops the io_context, joins the thread. Safe to call from any
 	// thread; Start() must have succeeded.

--- a/src/webapi/Refresher.cpp
+++ b/src/webapi/Refresher.cpp
@@ -219,7 +219,15 @@ void ParseStatusFromPacket(const CECPacket *resp, StatusSnapshot &out)
 				if (name) {
 					out.server_name = std::string(name->GetStringData().utf8_str());
 				}
-				out.server_ip = std::string(server->GetIPv4Data().StringIP().utf8_str());
+				// Not StringIP(): every overload of it appends ":port"
+				// and wraps the result in brackets, so `server_ip` used
+				// to read "[77.42.68.79:4232]" -- contradicting both its
+				// name and its declared "dotted-quad" contract, and
+				// giving a client that joins it with `server_port` the
+				// nonsense "[77.42.68.79:4232]:4232". Format from the
+				// raw address the way every other IP on this surface is
+				// formatted; the port stays in `server_port`.
+				out.server_ip = FormatClientIpv4(server->GetIPv4Data().IP());
 				out.server_port = server->GetIPv4Data().m_port;
 			}
 			uint32 ed2kSince = 0;
@@ -2426,8 +2434,14 @@ void ApplySearchFull(const CECPacket *resp, std::map<std::uint32_t, SearchResult
 		if (const CECTag *x = sf->GetTagByName(EC_TAG_SEARCHFILE_DIRECTORY)) {
 			r.directory = std::string(x->GetStringData().utf8_str());
 		}
-		// Media metadata (issue #430): present only when the hit carried
-		// FT_MEDIA_* tags (known/probed locally). Any present tag marks
+		// Media metadata (issue #430): present when the hit carried
+		// FT_MEDIA_* tags. On a locally known/probed file those are our
+		// own probe's values; on a remote hit they are whatever the
+		// responding server advertised, which is not validated anywhere
+		// and can contradict the file (a .pdf with a runtime and an xvid
+		// codec is a real observed result). Passed through as sent -- the
+		// API documents the search-result `media` as unverified rather
+		// than second-guessing the server. Any present tag marks
 		// has_media so the API emits the `media` object.
 		{
 			std::uint32_t v = 0;

--- a/src/webapi/RefresherTick.cpp
+++ b/src/webapi/RefresherTick.cpp
@@ -378,6 +378,13 @@ bool RefresherTick(CamuleapiApp &app, CState &state)
 	// in App.cpp calls EmitDiffsForEventBus() (below) after a
 	// successful tick; HTTP callers skip it and SSE subscribers see
 	// the diff on the next natural 1 s tick.
+	//
+	// The ETag memo key rides on this, so it has to be bumped HERE and
+	// not in MarkTickSuccess: the background loop calls that, but the
+	// mutating handlers refresh inline and never do, so a mutation moved
+	// the body while the key stood still and the next conditional GET was
+	// answered 304 for content that had just changed.
+	state.BumpSnapshotRevision();
 	return true;
 }
 

--- a/src/webapi/State.cpp
+++ b/src/webapi/State.cpp
@@ -28,7 +28,6 @@
 #include <iostream> // std::cerr
 
 #include <cstdio>
-#include <cstring> // std::strlen
 #include <ctime>
 
 #include <mutex>
@@ -500,25 +499,24 @@ std::string IPv4ToDotted(std::uint32_t ip_lsb_first)
 	return std::string(buf);
 }
 
-// See State.h. Prefix match on the path, so a query string (/stats/graphs is
-// always queried) does not change the verdict.
-bool SnapshotGovernsBody(const std::string &target)
+// See State.h. Matches on the path; the query string selects a page, not a
+// different resource.
+bool MemoizableTarget(const std::string &target)
 {
 	const std::string path = target.substr(0, target.find('?'));
-	// Each of these owns its own freshness: a TTL cache, an append-only
-	// mirror, or a refresh-on-read. None of them moves in step with the
-	// refresher tick that stamps snapshot_at.
-	static const char *const kSelfRefreshing[] = {
-		"/api/v0/stats/",
-		"/api/v0/logs/",
-		"/api/v0/search/",
-	};
-	for (const char *prefix : kSelfRefreshing) {
-		if (path.compare(0, std::strlen(prefix), prefix) == 0) {
-			return false;
-		}
-	}
-	return true;
+	// OPT-IN, and deliberately so. This was an exclusion list, and an
+	// exclusion list has to be right about every route that exists now and
+	// every route anyone adds later -- it was wrong four separate times,
+	// each for a different reason. Inverting it makes the failure mode
+	// "we hash a body we did not have to", which costs microseconds,
+	// instead of "we serve a 304 for content that changed".
+	//
+	// Only the two collections the memo was built for are listed. They are
+	// the multi-MB bodies where skipping an MD5 is worth anything; every
+	// other target hashes per request and is immune by construction.
+	// Before adding one, it must be BOTH governed by the refresher
+	// snapshot AND identical for every caller -- see State.h.
+	return path == "/api/v0/downloads" || path == "/api/v0/shared";
 }
 
 std::string ChatPeerKeyFromGuiId(std::uint64_t gui_id)
@@ -743,6 +741,12 @@ void CState::MutateDownloads(const std::function<void(FileMap &)> &fn)
 	const ReentryGuard guard(this);
 	std::unique_lock<std::shared_timed_mutex> lock(m_mu);
 	fn(m_files);
+	// Bumped by the writer, not by its callers. The ETag memo keys on this,
+	// and every previous attempt to advance it from the outside missed a
+	// path: first the inline refreshes that mutating handlers run, then a
+	// tick that failed partway after already writing. A writer cannot
+	// forget to say that it wrote.
+	++m_snapshot_rev;
 }
 
 void CState::MutateShared(const std::function<void(FileMap &)> &fn)
@@ -750,6 +754,8 @@ void CState::MutateShared(const std::function<void(FileMap &)> &fn)
 	const ReentryGuard guard(this);
 	std::unique_lock<std::shared_timed_mutex> lock(m_mu);
 	fn(m_files);
+	// See MutateDownloads: the memo key is advanced by the writer.
+	++m_snapshot_rev;
 }
 
 void CState::MutateClients(const std::function<void(std::map<std::uint32_t, ClientSnapshot> &)> &fn)
@@ -762,6 +768,10 @@ void CState::MutateClients(const std::function<void(std::map<std::uint32_t, Clie
 void CState::ResetLists()
 {
 	std::unique_lock<std::shared_timed_mutex> lock(m_mu);
+	// A wholesale wipe on EC reconnect is as much a body change as any
+	// mutation, and it runs on the failure path -- exactly where the key
+	// used to freeze while the bodies moved underneath it.
+	++m_snapshot_rev;
 	m_files.clear();
 	m_clients.clear();
 	m_servers.clear();
@@ -782,6 +792,18 @@ void CState::ResetLists()
 	// operator can see "EC disconnected at HH:MM" alongside earlier
 	// graph traffic; stats_tree's counters are amuled-uptime not
 	// amuleapi-tick scoped.
+}
+
+void CState::BumpSnapshotRevision()
+{
+	std::unique_lock<std::shared_timed_mutex> lock(m_mu);
+	++m_snapshot_rev;
+}
+
+std::uint64_t CState::SnapshotRevision() const
+{
+	std::shared_lock<std::shared_timed_mutex> lock(m_mu);
+	return m_snapshot_rev;
 }
 
 void CState::MarkTickSuccess()

--- a/src/webapi/State.cpp
+++ b/src/webapi/State.cpp
@@ -28,6 +28,7 @@
 #include <iostream> // std::cerr
 
 #include <cstdio>
+#include <cstring> // std::strlen
 #include <ctime>
 
 #include <mutex>
@@ -497,6 +498,27 @@ std::string IPv4ToDotted(std::uint32_t ip_lsb_first)
 		static_cast<unsigned>((ip_lsb_first >> 16) & 0xFFu),
 		static_cast<unsigned>((ip_lsb_first >> 24) & 0xFFu));
 	return std::string(buf);
+}
+
+// See State.h. Prefix match on the path, so a query string (/stats/graphs is
+// always queried) does not change the verdict.
+bool SnapshotGovernsBody(const std::string &target)
+{
+	const std::string path = target.substr(0, target.find('?'));
+	// Each of these owns its own freshness: a TTL cache, an append-only
+	// mirror, or a refresh-on-read. None of them moves in step with the
+	// refresher tick that stamps snapshot_at.
+	static const char *const kSelfRefreshing[] = {
+		"/api/v0/stats/",
+		"/api/v0/logs/",
+		"/api/v0/search/",
+	};
+	for (const char *prefix : kSelfRefreshing) {
+		if (path.compare(0, std::strlen(prefix), prefix) == 0) {
+			return false;
+		}
+	}
+	return true;
 }
 
 std::string ChatPeerKeyFromGuiId(std::uint64_t gui_id)

--- a/src/webapi/State.h
+++ b/src/webapi/State.h
@@ -583,6 +583,20 @@ struct ChatSessionSnapshot
 // is built from a GUI_ID, with no walker involved).
 std::string IPv4ToDotted(std::uint32_t ip_lsb_first);
 
+// Is this request target's body governed by the refresher snapshot, and so
+// safe to key an ETag memo on `snapshot_at`?
+//
+// False for the endpoints refreshed on their own schedule: /stats/* and
+// /logs/serverinfo hold their own 1 s TTL caches fetched out of phase with
+// the tick, /logs/amule is an append-only mirror that grows between ticks,
+// and a search's results are refreshed on read. `snapshot_at` counts whole
+// seconds, so any of those can change while the memo key stands still --
+// and a memo reused across such a change answers a later conditional GET
+// with 304 for content that has moved on. Takes the full target; the query
+// string is stripped here because it does not change which resource is
+// being read.
+bool SnapshotGovernsBody(const std::string &target);
+
 // The same key built straight from a GUI_ID, for paths that only have the id
 // (a session that was closed is gone from the snapshot, so there is no
 // ChatSessionSnapshot left to ask). GUI_ID is (ip << 16) | port.

--- a/src/webapi/State.h
+++ b/src/webapi/State.h
@@ -583,19 +583,23 @@ struct ChatSessionSnapshot
 // is built from a GUI_ID, with no walker involved).
 std::string IPv4ToDotted(std::uint32_t ip_lsb_first);
 
-// Is this request target's body governed by the refresher snapshot, and so
-// safe to key an ETag memo on `snapshot_at`?
+// Is this request target eligible for the response-ETag memo?
 //
-// False for the endpoints refreshed on their own schedule: /stats/* and
-// /logs/serverinfo hold their own 1 s TTL caches fetched out of phase with
-// the tick, /logs/amule is an append-only mirror that grows between ticks,
-// and a search's results are refreshed on read. `snapshot_at` counts whole
-// seconds, so any of those can change while the memo key stands still --
-// and a memo reused across such a change answers a later conditional GET
-// with 304 for content that has moved on. Takes the full target; the query
-// string is stripped here because it does not change which resource is
-// being read.
-bool SnapshotGovernsBody(const std::string &target);
+// OPT-IN. The memo key is (target, snapshot revision) and nothing else, which
+// makes two demands on anything eligible; a route that fails either one gets
+// answered 304 for content that has changed:
+//
+//  1. Its body must move only when the state moves, so the revision covers
+//     it. Endpoints with their own TTL cache, an append-only mirror, a
+//     refresh-on-read, or a live EC roundtrip per request do not qualify.
+//  2. Its body must be identical for every caller. The key carries no
+//     principal, so a per-caller document would share one validator between
+//     whoever asked first.
+//
+// This was an exclusion list and it was wrong four times over, each time for
+// a different reason. The eligible set is now spelled out instead, so the
+// cost of overlooking a route is a wasted hash rather than a stale 304.
+bool MemoizableTarget(const std::string &target);
 
 // The same key built straight from a GUI_ID, for paths that only have the id
 // (a session that was closed is gone from the snapshot, so there is no
@@ -1755,6 +1759,16 @@ public:
 	void WriteStatsTree(StatsTreeNode t);
 	void WriteGraphs(StatsGraphs g);
 	void MarkTickSuccess();
+	// Monotonic counter advanced by every successful refresh, from the
+	// background loop and from the inline refreshes that mutating handlers
+	// run. `snapshot_at` cannot play this role: it is whole seconds, so two
+	// refreshes inside one second are indistinguishable, and it is stamped
+	// only by the loop, so a mutation could change a body while it stood
+	// still -- which answered the next conditional GET with 304 for content
+	// that had just changed. Anything keyed on "has the state moved" wants
+	// this, not the timestamp.
+	void BumpSnapshotRevision();
+	std::uint64_t SnapshotRevision() const;
 	void MarkTickFailure();
 
 private:
@@ -1767,6 +1781,7 @@ private:
 	bool m_has_first_snapshot = false;
 	bool m_ec_connected = false;
 	std::time_t m_snapshot_at = 0;
+	std::uint64_t m_snapshot_rev = 0;
 
 	StatusSnapshot m_status;
 	KadSnapshot m_kad;

--- a/src/webapi/static/js/views/networks.js
+++ b/src/webapi/static/js/views/networks.js
@@ -175,9 +175,11 @@ function ServersPanel({ isGuest }) {
     catch (e) { toast(terr(e) || t("networks_server_error"), "error"); }
   };
 
-  // The two sides format the address differently — the list ships "ip:port",
-  // status.ed2k.server_ip comes from EC_IPv4_t::StringIP() as "[ip:port]" — so
-  // compare the dotted quad pulled out of each, plus the port.
+  // The two sides format the address differently — the list ships "ip:port"
+  // while status.ed2k.server_ip is a bare dotted quad — so compare the quad
+  // pulled out of each, plus the port. The regex also tolerates the older
+  // "[ip:port]" form that server_ip used to carry, so this keeps working
+  // against a daemon that predates the fix.
   const ipv4 = (v) => { const m = String(v || "").match(/\d+\.\d+\.\d+\.\d+/); return m ? m[0] : ""; };
   const isConnected = (s) =>
     ed2k && ed2k.state === "connected"

--- a/unittests/curl-tests/amuleapi/20-etag-conditional-get.sh
+++ b/unittests/curl-tests/amuleapi/20-etag-conditional-get.sh
@@ -178,7 +178,15 @@ _curl -H "Authorization: Bearer $ADMIN_TOKEN" \
 _assert_status 304 "GET /version + If-None-Match (list, hit in 2nd entry) → 304"
 
 # --- 8. HEAD honors If-None-Match too. ---------------------------
-_curl -X HEAD -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/version"
+#
+# `--head`, not `-X HEAD`: `-X` only swaps the method string, so curl still
+# waits for Content-Length bytes that a HEAD response correctly never sends
+# and reports error 18 when the connection closes instead. That is curl's
+# documented behaviour; it only passed here while the server was answering
+# HEAD with a wrong `Content-Length: 0`. The wire-level "no content on any
+# status" guarantee is asserted in 40-http-conformance, which reads the
+# socket directly rather than through curl.
+_curl --head -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/version"
 _assert_status 200 "HEAD /version → 200"
 HEAD_ETAG=$(_get_etag)
 if [ "$HEAD_ETAG" = "$ETAG" ]; then
@@ -187,14 +195,7 @@ else
 	_fail "HEAD ETag parity" \
 		"GET ETag=$ETAG, HEAD ETag=$HEAD_ETAG"
 fi
-# HEAD body always empty.
-if [ -z "$CURL_BODY" ]; then
-	_pass "HEAD /version carries no body"
-else
-	_fail "HEAD body" "expected empty, got $(echo "$CURL_BODY" | head -c 80)"
-fi
-
-_curl -X HEAD -H "Authorization: Bearer $ADMIN_TOKEN" \
+_curl --head -H "Authorization: Bearer $ADMIN_TOKEN" \
 	-H "If-None-Match: $ETAG" "$HOST/api/v0/version"
 _assert_status 304 "HEAD /version + If-None-Match → 304"
 

--- a/unittests/curl-tests/amuleapi/25-cors.sh
+++ b/unittests/curl-tests/amuleapi/25-cors.sh
@@ -19,8 +19,8 @@
 #     (cookie-auth-compatible with the per-origin echo).
 #   * Preflight: `OPTIONS` + `Access-Control-Request-Method` short-
 #     circuits before auth, replies 204 with
-#     `Access-Control-Allow-Methods: GET, HEAD, POST, PATCH, DELETE,
-#     OPTIONS` and `Access-Control-Allow-Headers: Authorization,
+#     `Access-Control-Allow-Methods: GET, HEAD, POST, PUT, PATCH,
+#     DELETE, OPTIONS` and `Access-Control-Allow-Headers: Authorization,
 #     Content-Type, If-None-Match, Last-Event-ID` and
 #     `Access-Control-Max-Age: 86400`.
 #   * SSE: the streaming response carries the same Allow-Origin /
@@ -284,6 +284,30 @@ if echo "$ACAM" | grep -q "POST" && echo "$ACAM" | grep -q "PATCH" \
 	_pass "Preflight: Allow-Methods lists mutating verbs"
 else
 	_fail "Allow-Methods" "expected POST/PATCH/DELETE listed, got '$ACAM'"
+fi
+# PUT specifically: PUT /api/v0/shared/directories is a real route (the
+# replace-the-whole-share-root-list form), and it was missing from the
+# advertised list. A browser doing a cross-origin PUT there was told the
+# method is not allowed and blocked the request before sending it -- the
+# route worked from curl and was unreachable from a page.
+if echo "$ACAM" | grep -q "PUT"; then
+	_pass "Preflight: Allow-Methods lists PUT"
+else
+	_fail "Allow-Methods PUT" "PUT is a real route on /shared/directories, got '$ACAM'"
+fi
+
+# And the same preflight asked about that route by name.
+_curl -X OPTIONS \
+	-H "Origin: https://allowed.example.com" \
+	-H "Access-Control-Request-Method: PUT" \
+	"$HOST/api/v0/shared/directories"
+PUT_STATUS=$(head -1 "$HDR" | awk '{print $2}')
+PUT_ACAM=$(_hdr "Access-Control-Allow-Methods")
+if [ "$PUT_STATUS" = "204" ] && echo "$PUT_ACAM" | grep -q "PUT"; then
+	_pass "Preflight for PUT /shared/directories advertises PUT"
+else
+	_fail "Preflight PUT /shared/directories" \
+		"status '$PUT_STATUS', Allow-Methods '$PUT_ACAM'"
 fi
 if echo "$ACAH" | grep -qi "Authorization" \
    && echo "$ACAH" | grep -qi "If-None-Match" \

--- a/unittests/curl-tests/amuleapi/25-cors.sh
+++ b/unittests/curl-tests/amuleapi/25-cors.sh
@@ -257,6 +257,41 @@ else
 	_fail "Vary on rejection" "got: $VARY"
 fi
 
+# --- Transport-built replies carry CORS too. ---------------------
+#
+# 408 / 413 / 431 / the streaming cap refusal / the handler catch-all are
+# built by the transport, before or instead of a handler, so the dispatcher's
+# CORS pass never sees them. They are the replies a cross-origin client most
+# needs to read, and they went uncovered: nulling the stamper left the whole
+# suite green.
+BIG_BODY=$(mktemp -t amuleapi_25_big.XXXXXX)
+if command -v python3 >/dev/null 2>&1 &&
+	python3 -c "import sys; sys.stdout.write('{\"password\":\"' + 'a'*2200000 + '\"}')" \
+		> "$BIG_BODY" 2>/dev/null && [ -s "$BIG_BODY" ]; then
+	_curl -X POST -H "Origin: https://allowed.example.com" \
+		-H "Content-Type: application/json" \
+		--data-binary @"$BIG_BODY" "$HOST/api/v0/auth/login"
+	BIG_STATUS=$(head -1 "$HDR" | awk '{print $2}')
+	BIG_ACAO=$(_hdr "Access-Control-Allow-Origin")
+	if [ "$BIG_STATUS" = "413" ]; then
+		if [ "$BIG_ACAO" = "https://allowed.example.com" ]; then
+			_pass "a transport-built 413 carries Allow-Origin"
+		else
+			_fail "transport-built 413 CORS" "expected the echoed origin, got '$BIG_ACAO'"
+		fi
+		BIG_EXPOSE=$(_hdr "Access-Control-Expose-Headers")
+		case "$BIG_EXPOSE" in
+		*Retry-After*) _pass "Expose-Headers advertises Retry-After" ;;
+		*) _fail "Expose-Headers Retry-After" "got '$BIG_EXPOSE'" ;;
+		esac
+	else
+		_fail "transport-built 413" "expected 413, got '$BIG_STATUS'"
+	fi
+else
+	_pass "SKIPPED transport-built 413 CORS (python3 unavailable)"
+fi
+rm -f "$BIG_BODY"
+
 # --- OPTIONS preflight (Mode C, allowed origin). -----------------
 _curl -X OPTIONS \
 	-H "Origin: https://allowed.example.com" \

--- a/unittests/curl-tests/amuleapi/26-rfc-followup-endpoints.sh
+++ b/unittests/curl-tests/amuleapi/26-rfc-followup-endpoints.sh
@@ -473,9 +473,15 @@ else
 	_fail "events channel-filter positive" \
 		"no download/status events seen; sample: $(head -10 "$SSE")"
 fi
-LEAKED=$(grep -cE "^event: (client_|server_|shared_|log_|search_)" "$SSE" || true)
+# comments_ is in this list on purpose. comments_updated has the prefix
+# `comments`, which event_channel does not map, so its channel is literally
+# `comments` -- NOT `downloads`, even though the event is a downloads
+# concern and the prose reads that way. The channel table documents it as
+# its own row; if anyone later folds the prefix into `downloads` without
+# updating that table, this assertion is what notices.
+LEAKED=$(grep -cE "^event: (client_|server_|shared_|log_|search_|comments_)" "$SSE" || true)
 if [ "$LEAKED" -eq 0 ]; then
-	_pass "/events?channels=downloads,status excludes client/server/shared/log/search events"
+	_pass "/events?channels=downloads,status excludes client/server/shared/log/search/comments events"
 else
 	_fail "events channel-filter leak" \
 		"$LEAKED off-channel events leaked through"

--- a/unittests/curl-tests/amuleapi/27-static-frontend.sh
+++ b/unittests/curl-tests/amuleapi/27-static-frontend.sh
@@ -101,9 +101,29 @@ echo "amuleapi 27-static-frontend @ $HOST — StaticRoot=$STATIC_ROOT"
 # Stage transient assets in StaticRoot for the duration of the run.
 # Restore the directory's pre-test state on exit so re-running doesn't
 # accumulate stale symlinks.
+# Section 10 rewrites index.html in place. That is the one file in here the
+# test does not own -- the others it plants itself -- so its restore runs from
+# the trap rather than from the end of the block: a _die anywhere in between
+# (a curl that cannot reach the daemon, say) would otherwise leave a
+# contributor with a mutated WebUI shell and no hint as to why.
+INDEX_BACKUP=
+_restore_index() {
+	# Refuse to restore from a backup that is missing or empty. A failed
+	# cp would otherwise overwrite a working shell with a zero-length
+	# file, which is a worse outcome than leaving the appended marker --
+	# that at least still renders and is visible in a diff.
+	if [ -n "$INDEX_BACKUP" ] && [ -s "$INDEX_BACKUP" ]; then
+		cp "$INDEX_BACKUP" "$STATIC_ROOT/index.html" 2>/dev/null \
+			|| echo "  WARN  could not restore $STATIC_ROOT/index.html from $INDEX_BACKUP"
+	elif [ -n "$INDEX_BACKUP" ]; then
+		echo "  WARN  backup $INDEX_BACKUP is missing or empty; leaving index.html as-is"
+	fi
+	[ -n "$INDEX_BACKUP" ] && rm -f "$INDEX_BACKUP"
+	INDEX_BACKUP=
+}
 trap 'rm -f "$CURL_BODY_FILE" "$CURL_HEAD_FILE" \
 	"$STATIC_ROOT/escape.txt" "$STATIC_ROOT/escape.css" \
-	"$STATIC_ROOT/huge.bin"' EXIT
+	"$STATIC_ROOT/huge.bin"; _restore_index' EXIT
 
 # --- 1. GET / serves the placeholder index. -----------------------
 _curl "$HOST/"
@@ -167,6 +187,72 @@ else
 fi
 _curl "$HOST/huge.bin"
 _assert_status 404 "Oversized /huge.bin (>16 MiB) → 404"
+
+# --- 10. A rewritten asset revalidates to its new bytes. ----------
+# Rewrite index.html the way a daemon upgrade does, then re-request it the
+# way a client holding the old copy would -- conditional on the validator it
+# stored -- and require the new bytes.
+#
+# What this does NOT guard is the cache policy. curl always sends the
+# conditional request, so it cannot exhibit the behaviour a freshness
+# lifetime causes, which is a browser reusing its copy WITHOUT asking; this
+# block passes byte-identically under `public, max-age=86400,
+# must-revalidate`. The guard for that is _assert_revalidates_every_time in
+# 40-http-conformance, which fails on that policy. What is asserted here is
+# narrower and still worth having: when a client does ask, it is told the
+# truth rather than answered 304 against a stale validator.
+INDEX_BACKUP=$(mktemp -t amuleapi_27_index.XXXXXX)
+if ! cp "$STATIC_ROOT/index.html" "$INDEX_BACKUP" 2>/dev/null || [ ! -s "$INDEX_BACKUP" ]; then
+	# No usable backup means no mutation: this block rewrites a file it
+	# does not own, and doing that without a way back is not worth one
+	# assertion.
+	_fail "a rewritten shell revalidates to its new bytes" \
+		"could not back up $STATIC_ROOT/index.html; skipped the rewrite rather than risk it"
+	# mktemp already created the file, so clearing the variable alone
+	# would leak the empty one.
+	rm -f "$INDEX_BACKUP"
+	INDEX_BACKUP=
+fi
+if [ -n "$INDEX_BACKUP" ]; then
+_curl "$HOST/index.html"
+OLD_ETAG=$(printf '%s' "$CURL_HEAD" | awk 'tolower($1)=="etag:"{print $2}' | tr -d '\r')
+OLD_BODY=$CURL_BODY
+if [ -z "$OLD_ETAG" ]; then
+	_fail "a rewritten shell revalidates to its new bytes" \
+		"no ETag on the first GET, nothing to revalidate with"
+else
+	# The validator is mtime+size, so change both. An upgrade that happens
+	# to preserve the size within the same second is a separate concern
+	# and not what this asserts.
+	printf '\n<!-- upgraded -->\n' >> "$STATIC_ROOT/index.html"
+	_curl "$HOST/index.html" -H "If-None-Match: $OLD_ETAG"
+	if [ "$CURL_STATUS" = "304" ]; then
+		_fail "a rewritten shell revalidates to its new bytes" \
+			"the rewritten file was answered 304 against the pre-upgrade validator"
+	elif [ "$CURL_STATUS" != "200" ]; then
+		_fail "a rewritten shell revalidates to its new bytes" \
+			"expected 200 with the new bytes, got HTTP $CURL_STATUS"
+	elif [ "$CURL_BODY" = "$OLD_BODY" ]; then
+		_fail "a rewritten shell revalidates to its new bytes" \
+			"200 carried the pre-upgrade bytes"
+	else
+		_pass "a rewritten shell revalidates to its new bytes (200, new bytes)"
+	fi
+	# And an UNCHANGED shell still revalidates cheaply. This is why the
+	# policy is no-cache rather than no-store: the copy stays in the cache
+	# and costs one bodiless 304, not a re-download.
+	_curl "$HOST/index.html"
+	NEW_ETAG=$(printf '%s' "$CURL_HEAD" | awk 'tolower($1)=="etag:"{print $2}' | tr -d '\r')
+	_curl "$HOST/index.html" -H "If-None-Match: $NEW_ETAG"
+	if [ "$CURL_STATUS" = "304" ]; then
+		_pass "an unchanged shell still costs one 304, not a re-download"
+	else
+		_fail "an unchanged shell still costs one 304" "got HTTP $CURL_STATUS"
+	fi
+fi
+# Restored by the EXIT trap, not here, so a _die in between cannot leave the
+# shell rewritten.
+fi
 
 # --- Summary. -----------------------------------------------------
 echo

--- a/unittests/curl-tests/amuleapi/32-country-flags.sh
+++ b/unittests/curl-tests/amuleapi/32-country-flags.sh
@@ -146,11 +146,11 @@ if [ "$CURL_SIZE" = "0" ]; then
 else
 	_fail "HEAD body" "expected 0 body bytes, got $CURL_SIZE"
 fi
-# Note: like every other amuleapi endpoint, HEAD comes back with
-# `Content-Length: 0` rather than the length the GET would return —
-# Dispatch() strips the body before Beast sizes the payload. That is
-# daemon-wide existing behaviour, not specific to this route, so it is
-# deliberately not asserted here.
+# HEAD reports the Content-Length the equivalent GET would return, with
+# no content on the wire: the transport serializes headers only, after
+# the payload has been sized from the full body. Not asserted here
+# because it is daemon-wide behaviour rather than anything specific to
+# this route -- 40-http-conformance covers it at the socket level.
 
 # --- 5. Already-compressed payload is not gzip-encoded. -----------
 # curl offers gzip in Accept-Encoding here. deflate over a PNG buys

--- a/unittests/curl-tests/amuleapi/40-http-conformance.sh
+++ b/unittests/curl-tests/amuleapi/40-http-conformance.sh
@@ -1,0 +1,408 @@
+#!/usr/bin/env bash
+#
+# amuleapi 40-http-conformance - the wire-protocol contract, as opposed to
+# any one endpoint's payload. Covers the things a conformant HTTP client (or
+# a plain proxy) relies on and that no per-endpoint smoke was watching:
+#
+#   * HEAD carries no content, on ANY status, and still reports the
+#     Content-Length a GET would return
+#   * the read-side limits answer with a typed envelope instead of closing
+#     the connection without a word
+#   * 405 carries the Allow header RFC 9110 requires
+#   * bodiless replies (204 / 304) omit Content-Type rather than sending an
+#     empty one
+#   * a static asset reports ONE validator, whichever method asked, and
+#     honours a lowercase if-none-match
+#   * the CORS preflight advertises every method the route actually serves
+#   * a conditional GET is never answered 304 for a body that has changed
+#
+# Usage:
+#   amuleapi --config-dir=/tmp/amuleapi-test &
+#   ./40-http-conformance.sh
+#
+# Environment:
+#   HOST=localhost:4713   amuleapi endpoint (default port)
+#   ADMIN_PASS=adminpass  admin password
+#
+# Exits 0 on success, 1 on any failed assertion, 2 on bring-up error.
+
+set -u
+set -o pipefail
+
+HOST=${HOST:-localhost:4713}
+ADMIN_PASS=${ADMIN_PASS:-adminpass}
+
+FAIL_COUNT=0
+TEST_COUNT=0
+# Skips are counted apart from TEST_COUNT, never folded into it: a skipped
+# check is coverage that did not happen, and adding it to the passed tally
+# would report the absence of a check as a check that succeeded.
+SKIP_COUNT=0
+
+BODY_FILE=$(mktemp -t amuleapi_39_body.XXXXXX)
+HDR_FILE=$(mktemp -t amuleapi_39_hdr.XXXXXX)
+BIG_FILE=$(mktemp -t amuleapi_39_big.XXXXXX)
+trap 'rm -f "$BODY_FILE" "$HDR_FILE" "$BIG_FILE"' EXIT
+
+_die()  { echo "FATAL: $*" >&2; exit 2; }
+_pass() { TEST_COUNT=$((TEST_COUNT+1)); echo "  PASS  $1"; }
+_skip() { SKIP_COUNT=$((SKIP_COUNT+1)); echo "  SKIP  $1"; }
+_fail() {
+	TEST_COUNT=$((TEST_COUNT+1)); FAIL_COUNT=$((FAIL_COUNT+1))
+	echo "  FAIL  $1"
+	shift
+	for arg in "$@"; do echo "        $arg"; done
+}
+
+_assert_eq() {
+	local expected=$1 actual=$2 label=$3
+	if [ "$expected" = "$actual" ]; then
+		_pass "$label"
+	else
+		_fail "$label" "expected [$expected], got [$actual]"
+	fi
+}
+
+# Header value by name, case-insensitively, from the last -D dump.
+_hdr() {
+	tr -d '\r' < "$HDR_FILE" | awk -v want="$(printf '%s' "$1" | tr 'A-Z' 'a-z')" \
+		'BEGIN{FS=": "} tolower($1)==want {sub(/^[^:]*: /,""); print; exit}'
+}
+
+# Is a header present at all (regardless of value)?
+_has_hdr() {
+	tr -d '\r' < "$HDR_FILE" | awk -v want="$(printf '%s' "$1" | tr 'A-Z' 'a-z')" \
+		'BEGIN{FS=":"} tolower($1)==want {found=1} END{exit !found}'
+}
+
+if ! command -v jq >/dev/null 2>&1; then _die "jq is required."; fi
+if ! curl -s -o /dev/null --max-time 2 "$HOST/api/v0/version" 2>/dev/null; then
+	_die "amuleapi at $HOST is not reachable. Start it first."
+fi
+
+TOKEN=$(curl -s -X POST -H "Content-Type: application/json" \
+	-d "{\"password\":\"$ADMIN_PASS\"}" "$HOST/api/v0/auth/login?type=bearer" | jq -r .token)
+[ -n "$TOKEN" ] && [ "$TOKEN" != "null" ] || _die "admin login failed"
+AUTH=(-H "Authorization: Bearer $TOKEN")
+
+echo "amuleapi 40-http-conformance smoke @ $HOST"
+
+# --- 1. HEAD carries no content, on any status. ----------------------
+#
+# The body strip used to sit inside the 200-only branch, so every HEAD that
+# ended in 4xx or 5xx shipped the JSON error envelope as content. On a
+# keep-alive connection that is not cosmetic: a client that correctly stops
+# reading after the headers leaves those bytes in the socket and starts
+# parsing the next response mid-JSON.
+# Probed on a raw socket, not with curl: curl knows a HEAD response has no
+# body and will not read one, so it reports zero bytes whether or not the
+# server actually sent them -- which is exactly the bug being tested.
+# Prints "<status> <content-length> <bytes-after-header-block>".
+_head_probe() {
+	python3 - "$HOST" "$1" <<'PYEOF'
+import socket, sys
+hostport, path = sys.argv[1], sys.argv[2]
+host, _, port = hostport.partition(":")
+try:
+    s = socket.create_connection((host or "localhost", int(port or 4713)), timeout=10)
+    s.sendall(("HEAD %s HTTP/1.1\r\nHost: x\r\nConnection: close\r\n\r\n" % path).encode())
+    data = b""
+    while True:
+        chunk = s.recv(4096)
+        if not chunk:
+            break
+        data += chunk
+    s.close()
+except Exception:
+    print("000 - -")
+    raise SystemExit(0)
+head, sep, body = data.partition(b"\r\n\r\n")
+status = head.split(b"\r\n")[0].split(b" ")[1].decode() if head else "000"
+clen = "-"
+for line in head.decode("latin-1").split("\r\n"):
+    if line.lower().startswith("content-length:"):
+        clen = line.split(":", 1)[1].strip()
+print("%s %s %d" % (status, clen, len(body)))
+PYEOF
+}
+
+if ! command -v python3 >/dev/null 2>&1; then
+	_skip "HEAD wire-level checks (python3 unavailable)"
+else
+	for probe in "/api/v0/nope:404" "/api/v0/status:401"; do
+		url=${probe%:*}
+		want=${probe##*:}
+		read -r got_status _got_len got_bytes <<<"$(_head_probe "$url")"
+		_assert_eq "$want" "$got_status" "HEAD $url -> $want"
+		_assert_eq "0" "$got_bytes" "HEAD $url puts no content on the wire"
+	done
+
+	# 200 too, and there Content-Length must describe what a GET returns
+	# rather than the zero bytes HEAD writes -- otherwise the header is
+	# useless to a client sizing a fetch.
+	read -r v_status v_len v_bytes <<<"$(_head_probe /api/v0/version)"
+	_assert_eq "200" "$v_status" "HEAD /version -> 200"
+	_assert_eq "0" "$v_bytes" "HEAD /version puts no content on the wire"
+	GET_LEN=$(curl -s --max-time 10 "$HOST/api/v0/version" | wc -c | tr -d ' ')
+	_assert_eq "$GET_LEN" "$v_len" "HEAD /version Content-Length matches the GET body"
+fi
+
+# --- 2. 405 carries Allow. -------------------------------------------
+#
+# RFC 9110 §15.5.6 makes the header mandatory. The accepted methods were
+# only ever in the human-readable message, which generic tooling and
+# capability discovery do not read.
+curl -s -o "$BODY_FILE" -D "$HDR_FILE" --max-time 10 \
+	"${AUTH[@]}" -X DELETE "$HOST/api/v0/status" >/dev/null
+_assert_eq "405" "$(awk 'NR==1{print $2}' "$HDR_FILE" | tr -d '\r')" \
+	"DELETE /status -> 405"
+ALLOW=$(_hdr Allow)
+if [ -z "$ALLOW" ]; then
+	_fail "405 carries an Allow header" "header absent on DELETE /status"
+else
+	_pass "405 carries an Allow header (Allow: $ALLOW)"
+	# HEAD is served wherever GET is, and the header is the machine-readable
+	# list, so it must say so even though the prose message says "only GET".
+	case "$ALLOW" in
+	*GET*) _pass "Allow on /status names GET" ;;
+	*) _fail "Allow on /status names GET" "got [$ALLOW]" ;;
+	esac
+	case "$ALLOW" in
+	*HEAD*) _pass "Allow on /status names HEAD" ;;
+	*) _fail "Allow on /status names HEAD" "got [$ALLOW]" ;;
+	esac
+fi
+
+# A route with a richer verb set reports all of it.
+curl -s -o "$BODY_FILE" -D "$HDR_FILE" --max-time 10 \
+	"${AUTH[@]}" -X PATCH "$HOST/api/v0/shared/directories" >/dev/null
+ALLOW_DIRS=$(_hdr Allow)
+for m in GET HEAD POST PUT DELETE; do
+	case "$ALLOW_DIRS" in
+	*"$m"*) _pass "Allow on /shared/directories names $m" ;;
+	*) _fail "Allow on /shared/directories names $m" "got [$ALLOW_DIRS]" ;;
+	esac
+done
+
+# --- 3. Bodiless replies omit Content-Type. --------------------------
+#
+# The handlers clear it for 204 and the ETag layer clears it for 304, but
+# the writer used to emit the header anyway with an empty value. A
+# Content-Type whose value is not a media type is malformed.
+ETAG=$(curl -s -o /dev/null -D "$HDR_FILE" --max-time 10 "${AUTH[@]}" \
+	"$HOST/api/v0/version" >/dev/null; _hdr ETag)
+if [ -z "$ETAG" ]; then
+	_skip "304 Content-Type check (no ETag on /version)"
+else
+	curl -s -o /dev/null -D "$HDR_FILE" --max-time 10 "${AUTH[@]}" \
+		-H "If-None-Match: $ETAG" "$HOST/api/v0/version" >/dev/null
+	_assert_eq "304" "$(awk 'NR==1{print $2}' "$HDR_FILE" | tr -d '\r')" \
+		"If-None-Match on the current ETag -> 304"
+	if _has_hdr Content-Type; then
+		_fail "304 omits Content-Type" "header present: [$(_hdr Content-Type)]"
+	else
+		_pass "304 omits Content-Type"
+	fi
+	# The validator itself must survive: clients re-stamp their cached copy
+	# from it (RFC 7232 §4.1).
+	if [ -n "$(_hdr ETag)" ]; then
+		_pass "304 still carries the ETag"
+	else
+		_fail "304 still carries the ETag" "header absent"
+	fi
+fi
+
+# The CORS preflight answers 204; same rule.
+curl -s -o /dev/null -D "$HDR_FILE" --max-time 10 -X OPTIONS \
+	-H "Origin: http://example.invalid" \
+	-H "Access-Control-Request-Method: GET" \
+	"$HOST/api/v0/version" >/dev/null
+PRE_STATUS=$(awk 'NR==1{print $2}' "$HDR_FILE" | tr -d '\r')
+if [ "$PRE_STATUS" = "204" ]; then
+	if _has_hdr Content-Type; then
+		_fail "204 preflight omits Content-Type" "header present: [$(_hdr Content-Type)]"
+	else
+		_pass "204 preflight omits Content-Type"
+	fi
+else
+	_skip "204 preflight Content-Type check (CORS disabled; preflight answered $PRE_STATUS)"
+fi
+
+# --- 4. The CORS preflight advertises every method the route serves. --
+#
+# PUT /api/v0/shared/directories is a real route (the replace-the-whole-list
+# form). It was missing from the advertised list, so a browser doing a
+# cross-origin PUT there was told the method is not allowed and blocked the
+# request before it was ever sent -- reachable from curl, unreachable from a
+# page.
+curl -s -o /dev/null -D "$HDR_FILE" --max-time 10 -X OPTIONS \
+	-H "Origin: http://example.invalid" \
+	-H "Access-Control-Request-Method: PUT" \
+	"$HOST/api/v0/shared/directories" >/dev/null
+ACAM=$(_hdr Access-Control-Allow-Methods)
+if [ -z "$ACAM" ]; then
+	_skip "preflight method list (CORS disabled; no Access-Control-Allow-Methods)"
+else
+	case "$ACAM" in
+	*PUT*) _pass "preflight advertises PUT (Access-Control-Allow-Methods: $ACAM)" ;;
+	*) _fail "preflight advertises PUT" "got [$ACAM]" ;;
+	esac
+fi
+
+# --- 5. Read-side limits answer, they do not just hang up. -----------
+#
+# Every other rejection on this surface is a typed JSON envelope. These
+# three used to close the connection with nothing written, so a caller could
+# not tell "too large" from "daemon crashed" or "firewall ate it".
+python3 -c "import sys; sys.stdout.write('{\"password\":\"' + 'a'*2200000 + '\"}')" \
+	> "$BIG_FILE" 2>/dev/null || _die "python3 is required to build the oversize body"
+BIG_STATUS=$(curl -s -o "$BODY_FILE" -w '%{http_code}' --max-time 20 \
+	-X POST -H "Content-Type: application/json" \
+	--data-binary @"$BIG_FILE" "$HOST/api/v0/auth/login" 2>/dev/null || echo "000")
+_assert_eq "413" "$BIG_STATUS" "a 2 MiB body -> 413 (not a silent close)"
+if [ "$BIG_STATUS" = "413" ]; then
+	_assert_eq "payload_too_large" \
+		"$(jq -r '.error.code' < "$BODY_FILE" 2>/dev/null)" \
+		"413 carries the payload_too_large code"
+fi
+
+# Headers that never terminate: the 10 s read timeout should answer 408.
+# Hand-rolled because curl will not send a deliberately incomplete request.
+TIMEOUT_OUT=$(python3 - "$HOST" <<'PYEOF' 2>/dev/null || echo "PYFAIL"
+import socket, sys, time
+host, _, port = sys.argv[1].partition(":")
+s = socket.create_connection((host or "localhost", int(port or 4713)), timeout=30)
+s.sendall(b"GET /api/v0/version HTTP/1.1\r\nHost: x\r\nX-Dangling: ")
+s.settimeout(25)
+buf = b""
+try:
+    while b"\r\n" not in buf:
+        chunk = s.recv(4096)
+        if not chunk:
+            break
+        buf += chunk
+except socket.timeout:
+    pass
+s.close()
+sys.stdout.write(buf.decode("latin-1").split("\r\n")[0])
+PYEOF
+)
+case "$TIMEOUT_OUT" in
+*408*)   _pass "an unterminated request -> 408 (not a silent close)" ;;
+PYFAIL)  _skip "408 read-timeout check (python3 socket probe unavailable)" ;;
+"")      _fail "an unterminated request -> 408" "connection closed with no response" ;;
+*)       _fail "an unterminated request -> 408" "got status line [$TIMEOUT_OUT]" ;;
+esac
+
+# --- 6. A static asset has ONE validator. ----------------------------
+#
+# The handler computed an mtime+size ETag and the outer layer stamped an
+# MD5-of-body over the top -- but only when the body was non-empty, which
+# was true on GET and false on HEAD. So the two methods handed out
+# different validators for the same URL, and touching the file changed one
+# while the other stayed put.
+ROOT_STATUS=$(curl -s -o /dev/null -w '%{http_code}' --max-time 10 "$HOST/index.html")
+if [ "$ROOT_STATUS" != "200" ]; then
+	_skip "static-asset validator checks (no static frontend served; /index.html -> $ROOT_STATUS)"
+else
+	curl -s -o /dev/null -D "$HDR_FILE" --max-time 10 -I "$HOST/index.html" >/dev/null
+	HEAD_ETAG=$(_hdr ETag)
+	curl -s -o /dev/null -D "$HDR_FILE" --max-time 10 "$HOST/index.html" >/dev/null
+	GET_ETAG=$(_hdr ETag)
+	if [ -z "$HEAD_ETAG" ] || [ -z "$GET_ETAG" ]; then
+		_fail "static asset reports an ETag on both methods" \
+			"HEAD=[$HEAD_ETAG] GET=[$GET_ETAG]"
+	else
+		_assert_eq "$GET_ETAG" "$HEAD_ETAG" \
+			"HEAD and GET report the same validator for /index.html"
+	fi
+	# HTTP header names are case-insensitive. The static path used a
+	# literal map lookup, so a lowercase if-none-match -- what an
+	# HTTP/2-shaped client library produces -- silently lost conditional
+	# GET and re-downloaded the asset every time.
+	if [ -n "$GET_ETAG" ]; then
+		LOWER=$(curl -s -o /dev/null -w '%{http_code}' --max-time 10 \
+			-H "if-none-match: $GET_ETAG" "$HOST/index.html")
+		_assert_eq "304" "$LOWER" "lowercase if-none-match on a static asset -> 304"
+		UPPER=$(curl -s -o /dev/null -w '%{http_code}' --max-time 10 \
+			-H "If-None-Match: $GET_ETAG" "$HOST/index.html")
+		_assert_eq "304" "$UPPER" "canonical If-None-Match on a static asset -> 304"
+	fi
+fi
+
+# --- 7. A changed body never revalidates as unchanged. ---------------
+#
+# The ETag memo is keyed on (target, snapshot_at) and snapshot_at counts
+# whole seconds. The stats graphs keep their own 1 s TTL cache, refetched
+# out of phase with the refresher tick, so their body can change while the
+# key does not -- and the memoized validator was then served for a body it
+# was not computed from. RFC 9110 §8.8.1 requires the entity-tag to change
+# whenever the representation does; any conformant cache is otherwise
+# entitled to keep serving the stale copy.
+GRAPH="$HOST/api/v0/stats/graphs/download_speed?width=3"
+PREV_BODY=""; PREV_ETAG=""; VIOLATION=""; OBSERVED=0
+for _ in $(seq 1 40); do
+	curl -s -o "$BODY_FILE" -D "$HDR_FILE" --max-time 10 "${AUTH[@]}" "$GRAPH" >/dev/null
+	NOW_ETAG=$(_hdr ETag)
+	NOW_BODY=$(cat "$BODY_FILE")
+	[ -z "$NOW_ETAG" ] && break
+	if [ -n "$PREV_ETAG" ] && [ "$NOW_BODY" != "$PREV_BODY" ]; then
+		OBSERVED=$((OBSERVED+1))
+		if [ "$NOW_ETAG" = "$PREV_ETAG" ]; then
+			VIOLATION="body changed while ETag stayed $NOW_ETAG"
+			break
+		fi
+	fi
+	PREV_BODY=$NOW_BODY; PREV_ETAG=$NOW_ETAG
+	sleep 0.4
+done
+if [ -z "$PREV_ETAG" ]; then
+	_skip "stats-graph validator check (no ETag on $GRAPH)"
+elif [ -n "$VIOLATION" ]; then
+	_fail "a changed stats-graph body always changes the ETag" "$VIOLATION"
+elif [ "$OBSERVED" -eq 0 ]; then
+	_skip "stats-graph validator check (body never changed in the sample window)"
+else
+	_pass "a changed stats-graph body always changes the ETag ($OBSERVED change(s) seen)"
+fi
+
+# And the paired direction: a conditional GET must not be told 304 for a
+# body that has moved on since the validator was minted.
+if [ -n "$PREV_ETAG" ]; then
+	curl -s -o "$BODY_FILE" --max-time 10 "${AUTH[@]}" "$GRAPH" >/dev/null
+	FRESH=$(cat "$BODY_FILE")
+	COND=$(curl -s -o /dev/null -w '%{http_code}' --max-time 10 "${AUTH[@]}" \
+		-H "If-None-Match: $PREV_ETAG" "$GRAPH")
+	if [ "$COND" = "304" ] && [ "$FRESH" != "$PREV_BODY" ]; then
+		_fail "no 304 for a body that changed" \
+			"served 304 against ETag $PREV_ETAG although the body differs"
+	else
+		_pass "conditional GET on a stats graph does not claim a stale copy is current"
+	fi
+fi
+
+# --- 8. status.ed2k.server_ip is an address, not an endpoint. --------
+#
+# The field carried brackets and the port -- "[77.42.68.79:4232]" -- inside
+# a field named server_ip, beside a server_port that already held the port.
+# A client joining the two got "[77.42.68.79:4232]:4232".
+curl -s -o "$BODY_FILE" --max-time 10 "${AUTH[@]}" "$HOST/api/v0/status" >/dev/null
+SRV_IP=$(jq -r '.ed2k.server_ip // ""' < "$BODY_FILE" 2>/dev/null)
+if [ -z "$SRV_IP" ]; then
+	_skip "status.ed2k.server_ip shape (not connected to a server)"
+elif printf '%s' "$SRV_IP" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$'; then
+	_pass "status.ed2k.server_ip is a bare dotted quad ($SRV_IP)"
+else
+	_fail "status.ed2k.server_ip is a bare dotted quad" "got [$SRV_IP]"
+fi
+
+# --- Summary. -------------------------------------------------------
+echo
+SKIP_NOTE=""
+[ "$SKIP_COUNT" -gt 0 ] && SKIP_NOTE=" ($SKIP_COUNT check(s) skipped)"
+if [ "$FAIL_COUNT" -eq 0 ]; then
+	echo "OK: $TEST_COUNT/$TEST_COUNT passed$SKIP_NOTE"
+	exit 0
+fi
+echo "FAIL: $FAIL_COUNT/$TEST_COUNT failed"
+exit 1

--- a/unittests/curl-tests/amuleapi/40-http-conformance.sh
+++ b/unittests/curl-tests/amuleapi/40-http-conformance.sh
@@ -39,9 +39,9 @@ TEST_COUNT=0
 # would report the absence of a check as a check that succeeded.
 SKIP_COUNT=0
 
-BODY_FILE=$(mktemp -t amuleapi_39_body.XXXXXX)
-HDR_FILE=$(mktemp -t amuleapi_39_hdr.XXXXXX)
-BIG_FILE=$(mktemp -t amuleapi_39_big.XXXXXX)
+BODY_FILE=$(mktemp -t amuleapi_40_body.XXXXXX)
+HDR_FILE=$(mktemp -t amuleapi_40_hdr.XXXXXX)
+BIG_FILE=$(mktemp -t amuleapi_40_big.XXXXXX)
 trap 'rm -f "$BODY_FILE" "$HDR_FILE" "$BIG_FILE"' EXIT
 
 _die()  { echo "FATAL: $*" >&2; exit 2; }
@@ -99,13 +99,18 @@ echo "amuleapi 40-http-conformance smoke @ $HOST"
 # server actually sent them -- which is exactly the bug being tested.
 # Prints "<status> <content-length> <bytes-after-header-block>".
 _head_probe() {
-	python3 - "$HOST" "$1" <<'PYEOF'
+	python3 - "$HOST" "$1" "${2:-}" <<'PYEOF'
 import socket, sys
 hostport, path = sys.argv[1], sys.argv[2]
+extra = sys.argv[3] if len(sys.argv) > 3 else ""
 host, _, port = hostport.partition(":")
 try:
     s = socket.create_connection((host or "localhost", int(port or 4713)), timeout=10)
-    s.sendall(("HEAD %s HTTP/1.1\r\nHost: x\r\nConnection: close\r\n\r\n" % path).encode())
+    req = "HEAD %s HTTP/1.1\r\nHost: x\r\nConnection: close\r\n" % path
+    if extra:
+        req += extra + "\r\n"
+    req += "\r\n"
+    s.sendall(req.encode())
     data = b""
     while True:
         chunk = s.recv(4096)
@@ -146,6 +151,206 @@ else
 	GET_LEN=$(curl -s --max-time 10 "$HOST/api/v0/version" | wc -c | tr -d ' ')
 	_assert_eq "$GET_LEN" "$v_len" "HEAD /version Content-Length matches the GET body"
 fi
+
+# The SSE endpoint is the one unbounded body on the surface, and it does
+# not go through the normal response path: the streaming dispatch writes
+# its own head and then pushes frames until the peer leaves. A HEAD there
+# asks what a GET would answer with, so it must be answered and closed
+# rather than streamed, or the "no content on any status" guarantee has a
+# hole in exactly the worst place.
+#
+# It is answered BELOW the auth gate, so it is not a way around it. An
+# earlier cut short-circuited above the gate and handed an unauthenticated
+# HEAD a 200 where GET answers 401, skipping the auth-failure rate bucket
+# too -- so the unauthenticated case is asserted first, and deliberately.
+if command -v python3 >/dev/null 2>&1; then
+	read -r anon_status _anon_len _anon_bytes <<<"$(_head_probe /api/v0/events)"
+	_assert_eq "401" "$anon_status" "HEAD /events without credentials -> 401 (no auth bypass)"
+	read -r ev_status _ev_len ev_bytes <<<"$(_head_probe /api/v0/events "Authorization: Bearer $TOKEN")"
+	_assert_eq "200" "$ev_status" "HEAD /events with credentials -> 200"
+	_assert_eq "0" "$ev_bytes" "HEAD /events does not stream content"
+else
+	_skip "HEAD /events check (python3 unavailable)"
+fi
+
+# The same gate, cross-checked through curl so a regression shows up as a
+# plain status mismatch even if the socket probe is skipped.
+_assert_eq "401" "$(curl -s -o /dev/null -w '%{http_code}' --max-time 5 "$HOST/api/v0/events")" \
+	"GET /events without credentials -> 401"
+
+# /events reaches the dispatcher only on a method the streaming resolver
+# declined, and with no route there it used to fall through to the catch-all
+# 404 -- reporting that the endpoint does not exist, on the one resource a
+# client is most likely to probe, and escaping the Allow sweep entirely.
+curl -s -o "$BODY_FILE" -D "$HDR_FILE" --max-time 10 "${AUTH[@]}" \
+	-X POST "$HOST/api/v0/events" >/dev/null
+_assert_eq "405" "$(awk 'NR==1{print $2}' "$HDR_FILE" | tr -d '\r')" \
+	"POST /events -> 405 (not 404)"
+EV_ALLOW=$(_hdr Allow)
+case "$EV_ALLOW" in
+*GET*HEAD*|*HEAD*GET*) _pass "405 on /events carries Allow ($EV_ALLOW)" ;;
+*) _fail "405 on /events carries Allow" "got [$EV_ALLOW]" ;;
+esac
+
+# HEAD and GET on the stream must agree on the headers they share. They are
+# produced by two different writers -- the regular response path and the SSE
+# head path -- which each carried their own copy of the header-merge logic,
+# and two rounds of fixes landed in one copy but not the other: the stream
+# kept advertising keep-alive on a socket the server always closes, and kept
+# overwriting Vary instead of appending to it. Comparing the two is what
+# notices a fix that only reached one writer.
+if command -v python3 >/dev/null 2>&1; then
+	# $2 selects the encoding. The identity path is a separate branch in
+	# the SSE head writer, and pinning both methods to gzip is why the
+	# first cut of this probe could not see a Vary token that was emitted
+	# only when the stream was actually compressed.
+	_stream_hdr() {
+		python3 - "$HOST" "$1" "$TOKEN" "${2:-gzip}" <<'PYEOF'
+import socket, sys
+hostport, method, tok = sys.argv[1], sys.argv[2], sys.argv[3]
+enc = sys.argv[4] if len(sys.argv) > 4 else "gzip"
+host, _, port = hostport.partition(":")
+try:
+    s = socket.create_connection((host or "localhost", int(port or 4713)), timeout=8)
+    enc_line = "" if enc == "identity" else ("Accept-Encoding: %s\r\n" % enc)
+    s.sendall(("%s /api/v0/events HTTP/1.1\r\nHost: x\r\n%s"
+               "Authorization: Bearer %s\r\n\r\n" % (method, enc_line, tok)).encode())
+    data = b""
+    while b"\r\n\r\n" not in data:
+        chunk = s.recv(4096)
+        if not chunk:
+            break
+        data += chunk
+    s.close()
+except Exception:
+    print("")
+    raise SystemExit(0)
+head = data.partition(b"\r\n\r\n")[0].decode("latin-1")
+out = []
+for line in head.split("\r\n"):
+    low = line.lower()
+    # Deliberately wide. Narrowing this to connection/vary is why three
+    # consecutive rounds of /events header findings were invisible to the
+    # probe that exists to pin them: the divergence was in Content-Encoding
+    # and Content-Type, which the filter dropped.
+    if low.split(":")[0] in (
+            "connection", "vary", "content-encoding", "content-type",
+            "cache-control", "x-accel-buffering", "transfer-encoding"):
+        out.append(low.replace(" ", ""))
+print("|".join(sorted(out)))
+PYEOF
+	}
+	SSE_HEAD=$(_stream_hdr HEAD gzip)
+	SSE_GET=$(_stream_hdr GET gzip)
+	# ...and again with no encoding requested, which takes the other branch.
+	SSE_HEAD_ID=$(_stream_hdr HEAD identity)
+	SSE_GET_ID=$(_stream_hdr GET identity)
+	if [ -z "$SSE_HEAD" ] || [ -z "$SSE_GET" ]; then
+		_skip "SSE HEAD/GET header agreement (probe did not complete)"
+	else
+		_assert_eq "$SSE_GET" "$SSE_HEAD" \
+			"HEAD and GET on /events agree on Connection and Vary (compressed)"
+		if [ -z "$SSE_HEAD_ID" ] || [ -z "$SSE_GET_ID" ]; then
+			_skip "SSE identity-path header agreement (probe did not complete)"
+		else
+			_assert_eq "$SSE_GET_ID" "$SSE_HEAD_ID" \
+				"HEAD and GET on /events agree on Connection and Vary (uncompressed)"
+			case "$SSE_GET_ID" in
+			*vary:*accept-encoding*) _pass "an uncompressed stream still varies on Accept-Encoding" ;;
+			*) _fail "an uncompressed stream still varies on Accept-Encoding" "got [$SSE_GET_ID]" ;;
+			esac
+		fi
+		case "$SSE_GET" in
+		*connection:close*) _pass "the event stream advertises Connection: close" ;;
+		*) _fail "the event stream advertises Connection: close" "got [$SSE_GET]" ;;
+		esac
+	fi
+else
+	_skip "SSE header agreement check (python3 unavailable)"
+fi
+
+# The same comparison under an encoding preference. HEAD has to describe what
+# the equivalent GET would return, which with gzip means the SAME
+# Content-Encoding and the SAME Content-Length -- diverging binds one strong
+# ETag to two codings and lets every probe invalidate a cached gzip response.
+# The Content-Length check above sends no Accept-Encoding, so it cannot see
+# this; skipping compression for HEAD once passed the whole suite.
+#
+# Probed against /preferences, NOT /downloads. The transport only compresses
+# a body over kGzipMinBodyBytes, and an empty daemon's /downloads is a ~46
+# byte envelope -- under the floor, never compressed, so every coding
+# assertion below would fail on a bring-up run for a reason that has nothing
+# to do with codings. /preferences is a fixed settings schema, kilobytes
+# regardless of what the daemon is doing.
+CODING_TARGET="$HOST/api/v0/preferences"
+# ...and assert that premise instead of trusting it: if this body ever drops
+# under the floor the block stops testing what it claims to, and an
+# un-suffixed ETag would read as "the coding marker is missing".
+CODING_BYTES=$(curl -s --max-time 10 -H "Accept-Encoding: identity" \
+	"${AUTH[@]}" "$CODING_TARGET" | wc -c | tr -d ' ')
+# -ge, not -gt: WillCompressBody() compresses at `body_size >= 256`, so a
+# body of exactly 256 bytes IS compressed and a -gt guard would call it
+# unusable. A guard that disagrees with the code it guards is worse than no
+# guard, because it is believed.
+if [ "${CODING_BYTES:-0}" -ge 256 ]; then
+	_pass "the coding probe's body is over the compression floor ($CODING_BYTES bytes)"
+else
+	_fail "coding probe target is compressible" \
+		"/preferences is $CODING_BYTES bytes, under the 256-byte floor"
+fi
+
+_enc_triplet() {
+	curl -s -o /dev/null -D "$HDR_FILE" --max-time 10 "$@" \
+		-H "Accept-Encoding: gzip" "${AUTH[@]}" "$CODING_TARGET" >/dev/null
+	printf '%s|%s|%s' "$(_hdr Content-Encoding)" "$(_hdr Content-Length)" "$(_hdr ETag)"
+}
+GZ_HEAD=$(_enc_triplet --head)
+GZ_GET=$(_enc_triplet)
+_assert_eq "$GZ_GET" "$GZ_HEAD" \
+	"HEAD and GET agree on Content-Encoding, Content-Length and ETag under gzip"
+
+# The validator must NAME the representation, not just accompany it. A strong
+# ETag identifies one representation, and the hash is taken before
+# compression, so without a coding marker the gzip and identity forms of a
+# body share a validator -- and a cache holding one can revalidate it for a
+# client that cannot accept it. Asserted in both directions so deleting the
+# marker fails rather than silently passing.
+GZ_ETAG=$(curl -s -o /dev/null -D "$HDR_FILE" --max-time 10 \
+	-H "Accept-Encoding: gzip" "${AUTH[@]}" "$CODING_TARGET" >/dev/null; _hdr ETag)
+ID_ETAG=$(curl -s -o /dev/null -D "$HDR_FILE" --max-time 10 \
+	-H "Accept-Encoding: identity" "${AUTH[@]}" "$CODING_TARGET" >/dev/null; _hdr ETag)
+case "$GZ_ETAG" in
+*-gzip\"*) _pass "the gzip representation's ETag names its coding ($GZ_ETAG)" ;;
+*) _fail "gzip ETag names its coding" "got [$GZ_ETAG]" ;;
+esac
+case "$ID_ETAG" in
+*-gzip\"*) _fail "identity ETag does not name a coding" "got [$ID_ETAG]" ;;
+*) _pass "the identity representation's ETag carries no coding marker" ;;
+esac
+if [ "$GZ_ETAG" = "$ID_ETAG" ]; then
+	_fail "the two codings have distinct validators" "both are $GZ_ETAG"
+else
+	_pass "the two codings have distinct validators"
+fi
+
+# ...and a 304 must echo the SAME validator the equivalent 200 sent. A 304
+# has no body for the transport to compress, so the coding has to be decided
+# before the body is dropped; when it was not, a client that cached the gzip
+# form was handed the identity ETag back and could never match its stored
+# response again.
+for pair in "gzip:$GZ_ETAG" "identity:$ID_ETAG"; do
+	enc=${pair%%:*}
+	want=${pair#*:}
+	[ -z "$want" ] && continue
+	got=$(curl -s -o /dev/null -D "$HDR_FILE" --max-time 10 \
+		-H "Accept-Encoding: $enc" -H "If-None-Match: $want" \
+		"${AUTH[@]}" "$CODING_TARGET" >/dev/null; _hdr ETag)
+	code=$(curl -s -o /dev/null -w '%{http_code}' --max-time 10 \
+		-H "Accept-Encoding: $enc" -H "If-None-Match: $want" \
+		"${AUTH[@]}" "$CODING_TARGET")
+	_assert_eq "304" "$code" "a $enc client revalidating its own validator gets 304"
+	_assert_eq "$want" "$got" "the $enc 304 echoes the validator the 200 sent"
+done
 
 # --- 2. 405 carries Allow. -------------------------------------------
 #
@@ -254,8 +459,22 @@ fi
 # Every other rejection on this surface is a typed JSON envelope. These
 # three used to close the connection with nothing written, so a caller could
 # not tell "too large" from "daemon crashed" or "firewall ate it".
-python3 -c "import sys; sys.stdout.write('{\"password\":\"' + 'a'*2200000 + '\"}')" \
-	> "$BIG_FILE" 2>/dev/null || _die "python3 is required to build the oversize body"
+# Guarded like the other python3 probes: a runner without it should skip
+# these checks, not abort the phase at exit 2 and silently drop everything
+# that follows.
+BIG_READY=0
+if ! command -v python3 >/dev/null 2>&1; then
+	_skip "413 check (python3 unavailable)"
+elif python3 -c "import sys; sys.stdout.write('{\"password\":\"' + 'a'*2200000 + '\"}')" \
+	> "$BIG_FILE" 2>/dev/null && [ -s "$BIG_FILE" ]; then
+	BIG_READY=1
+else
+	# Skip AND stay out of the probe below: running it against a
+	# truncated file turns one skip into a spurious failure. BIG_FILE is
+	# deliberately left set so the EXIT trap still removes it.
+	_skip "413 check (could not build the oversize body)"
+fi
+if [ "$BIG_READY" -eq 1 ]; then
 BIG_STATUS=$(curl -s -o "$BODY_FILE" -w '%{http_code}' --max-time 20 \
 	-X POST -H "Content-Type: application/json" \
 	--data-binary @"$BIG_FILE" "$HOST/api/v0/auth/login" 2>/dev/null || echo "000")
@@ -264,6 +483,50 @@ if [ "$BIG_STATUS" = "413" ]; then
 	_assert_eq "payload_too_large" \
 		"$(jq -r '.error.code' < "$BODY_FILE" 2>/dev/null)" \
 		"413 carries the payload_too_large code"
+fi
+fi
+
+# Oversized headers -> 431, and a HEAD rejected there ships no content
+# either. Both were untested, which is how the 431 branch stayed dead: the
+# read buffer was smaller than the parser's header_limit, so an oversized
+# header overflowed the buffer before the limit could fire and the
+# connection closed with nothing written. A legal header near the cap must
+# still succeed, which is the half that catches an over-tight buffer.
+if command -v python3 >/dev/null 2>&1; then
+	_hdr_probe() {
+		python3 - "$HOST" "$1" "$2" <<'PYEOF'
+import socket, sys
+hostport, method, padlen = sys.argv[1], sys.argv[2], int(sys.argv[3])
+host, _, port = hostport.partition(":")
+try:
+    s = socket.create_connection((host or "localhost", int(port or 4713)), timeout=15)
+    pad = ("X-Pad: " + "a" * padlen + "\r\n") if padlen else ""
+    s.sendall(("%s /api/v0/version HTTP/1.1\r\nHost: x\r\n%sConnection: close\r\n\r\n"
+               % (method, pad)).encode())
+    data = b""
+    while True:
+        chunk = s.recv(4096)
+        if not chunk:
+            break
+        data += chunk
+    s.close()
+except Exception:
+    print("000 0")
+    raise SystemExit(0)
+head, _, body = data.partition(b"\r\n\r\n")
+status = head.split(b"\r\n")[0].split(b" ")[1].decode() if head else "000"
+print("%s %d" % (status, len(body)))
+PYEOF
+	}
+	read -r big_status big_bytes <<<"$(_hdr_probe GET 20000)"
+	_assert_eq "431" "$big_status" "oversized request headers -> 431 (not a silent close)"
+	read -r bigh_status bigh_bytes <<<"$(_hdr_probe HEAD 20000)"
+	_assert_eq "431" "$bigh_status" "HEAD with oversized headers -> 431"
+	_assert_eq "0" "$bigh_bytes" "HEAD with oversized headers ships no content"
+	read -r ok_status _ok_bytes <<<"$(_hdr_probe GET 12000)"
+	_assert_eq "200" "$ok_status" "a legal ~12 KiB header block is still accepted"
+else
+	_skip "header-limit checks (python3 unavailable)"
 fi
 
 # Headers that never terminate: the 10 s read timeout should answer 408.
@@ -293,6 +556,40 @@ PYFAIL)  _skip "408 read-timeout check (python3 socket probe unavailable)" ;;
 "")      _fail "an unterminated request -> 408" "connection closed with no response" ;;
 *)       _fail "an unterminated request -> 408" "got status line [$TIMEOUT_OUT]" ;;
 esac
+
+# ...and a HEAD that times out carries no content either. The probe above
+# only ever used GET, so a HEAD shipping the 408 envelope as content -- the
+# same violation fixed for 413 and 431 -- had nothing watching it.
+if command -v python3 >/dev/null 2>&1; then
+	HEAD_408=$(python3 - "$HOST" <<'PYEOF' 2>/dev/null || echo "PYFAIL"
+import socket, sys
+host, _, port = sys.argv[1].partition(":")
+s = socket.create_connection((host or "localhost", int(port or 4713)), timeout=30)
+s.sendall(b"HEAD /api/v0/version HTTP/1.1\r\nHost: x\r\nX-Drip: ")
+s.settimeout(25)
+data = b""
+try:
+    while True:
+        chunk = s.recv(4096)
+        if not chunk:
+            break
+        data += chunk
+except socket.timeout:
+    pass
+s.close()
+head, _, body = data.partition(b"\r\n\r\n")
+status = head.split(b"\r\n")[0].split(b" ")[1].decode() if head else "000"
+print("%s %d" % (status, len(body)))
+PYEOF
+	)
+	case "$HEAD_408" in
+	PYFAIL) _skip "HEAD 408 body check (python3 probe unavailable)" ;;
+	"408 0") _pass "HEAD on an unterminated request -> 408 with no content" ;;
+	*) _fail "HEAD on an unterminated request -> 408 with no content" "got [$HEAD_408]" ;;
+	esac
+else
+	_skip "HEAD 408 body check (python3 unavailable)"
+fi
 
 # --- 6. A static asset has ONE validator. ----------------------------
 #
@@ -327,12 +624,70 @@ else
 		UPPER=$(curl -s -o /dev/null -w '%{http_code}' --max-time 10 \
 			-H "If-None-Match: $GET_ETAG" "$HOST/index.html")
 		_assert_eq "304" "$UPPER" "canonical If-None-Match on a static asset -> 304"
+		# ...and that 304 must not advertise a media type it is not
+		# carrying. Response::content_type defaults to application/json,
+		# so an unset one made a 304 for index.html claim to be JSON.
+		curl -s -o /dev/null -D "$HDR_FILE" --max-time 10 \
+			-H "If-None-Match: $GET_ETAG" "$HOST/index.html" >/dev/null
+		if _has_hdr Content-Type; then
+			_fail "static 304 omits Content-Type" \
+				"got [$(_hdr Content-Type)] on a 304 for index.html"
+		else
+			_pass "static 304 omits Content-Type"
+		fi
+		# The full If-None-Match grammar, not just an exact match. A
+		# reverse proxy that gzips in front of us rewrites the
+		# validator to the weak form, and `*` plus comma-separated
+		# lists are both legal. The outer layer used to supply this
+		# grammar for static assets; now that it stands aside whenever
+		# a handler set its own ETag, this path has to speak it itself.
+		# A static asset sets its own ETag, so the dispatcher stands
+		# aside and the TRANSPORT is what marks the coding on it. That
+		# is a different code path from the API routes above, and
+		# deleting the transport's stamp leaves those green -- this is
+		# the assertion that notices.
+		SGZ=$(curl -s -o /dev/null -D "$HDR_FILE" --max-time 10 \
+			-H "Accept-Encoding: gzip" "$HOST/index.html" >/dev/null; _hdr ETag)
+		SGZ_ENC=$(_hdr Content-Encoding)
+		if [ "$SGZ_ENC" != "gzip" ]; then
+			# NOT a skip. index.html is text/html and comfortably
+			# over the compression floor, so an uncompressed answer
+			# here means the gzip path stopped working -- and a skip
+			# would report that as a pass.
+			_fail "a static HTML asset is served gzipped when asked" \
+				"Content-Encoding was [$SGZ_ENC]"
+		else
+			case "$SGZ" in
+			*-gzip\"*) _pass "a gzipped static asset's ETag names its coding ($SGZ)" ;;
+			*) _fail "gzipped static asset ETag names its coding" "got [$SGZ]" ;;
+			esac
+			SGZ_304=$(curl -s -o /dev/null -D "$HDR_FILE" --max-time 10 \
+				-H "Accept-Encoding: gzip" -H "If-None-Match: $SGZ" \
+				"$HOST/index.html" >/dev/null; _hdr ETag)
+			_assert_eq "$SGZ" "$SGZ_304" \
+				"a gzipped static asset's 304 echoes the validator its 200 sent"
+		fi
+
+		STAR=$(curl -s -o /dev/null -w '%{http_code}' --max-time 10 \
+			-H "If-None-Match: *" "$HOST/index.html")
+		_assert_eq "304" "$STAR" "If-None-Match: * on a static asset -> 304"
+		WEAK=$(curl -s -o /dev/null -w '%{http_code}' --max-time 10 \
+			-H "If-None-Match: W/$GET_ETAG" "$HOST/index.html")
+		_assert_eq "304" "$WEAK" "a weak W/ validator on a static asset -> 304"
+		LIST=$(curl -s -o /dev/null -w '%{http_code}' --max-time 10 \
+			-H "If-None-Match: \"nomatch\", $GET_ETAG" "$HOST/index.html")
+		_assert_eq "304" "$LIST" "an If-None-Match list hitting on the 2nd entry -> 304"
 	fi
 fi
 
 # --- 7. A changed body never revalidates as unchanged. ---------------
 #
-# The ETag memo is keyed on (target, snapshot_at) and snapshot_at counts
+# /stats/* is not memoized at all -- eligibility is opt-in and covers only
+# /downloads and /shared -- so this asserts the general contract rather than
+# the memo: a validator must change whenever the body does. It caught the
+# original defect back when the memo did cover this route, and it still
+# guards the property that mattered. Historically the key was a timestamp,
+# which counts
 # whole seconds. The stats graphs keep their own 1 s TTL cache, refetched
 # out of phase with the refresher tick, so their body can change while the
 # key does not -- and the memoized validator was then served for a body it
@@ -379,6 +734,201 @@ if [ -n "$PREV_ETAG" ]; then
 	else
 		_pass "conditional GET on a stats graph does not claim a stale copy is current"
 	fi
+fi
+
+# --- 7b. A per-principal document never shares a validator. ----------
+#
+# /auth/session's body depends on who is asking, so it is not memo-eligible:
+# the key carries no principal. Back when eligibility was an exclusion list
+# and this route was not on it, an admin and a guest
+# hitting this inside one snapshot second got the SAME validator for two
+# different documents, and the second was answered 304 against the first's.
+GUEST_TOKEN=$(curl -s -X POST -H "Content-Type: application/json" \
+	-d "{\"password\":\"${GUEST_PASS:-guestpass}\"}" \
+	"$HOST/api/v0/auth/login?type=bearer" 2>/dev/null | jq -r .token)
+if [ -z "$GUEST_TOKEN" ] || [ "$GUEST_TOKEN" = "null" ]; then
+	_skip "per-principal ETag check (no guest password configured)"
+else
+	curl -s -o "$BODY_FILE" -D "$HDR_FILE" --max-time 10 "${AUTH[@]}" \
+		"$HOST/api/v0/auth/session" >/dev/null
+	ADMIN_SESS_ETAG=$(_hdr ETag)
+	ADMIN_ROLE=$(jq -r '.role // ""' < "$BODY_FILE" 2>/dev/null)
+	curl -s -o "$BODY_FILE" -D "$HDR_FILE" --max-time 10 \
+		-H "Authorization: Bearer $GUEST_TOKEN" \
+		"$HOST/api/v0/auth/session" >/dev/null
+	GUEST_SESS_ETAG=$(_hdr ETag)
+	GUEST_ROLE=$(jq -r '.role // ""' < "$BODY_FILE" 2>/dev/null)
+	if [ "$ADMIN_ROLE" = "$GUEST_ROLE" ]; then
+		_skip "per-principal ETag check (both logins resolved to '$ADMIN_ROLE')"
+	elif [ "$ADMIN_SESS_ETAG" = "$GUEST_SESS_ETAG" ]; then
+		_fail "two principals never share a session validator" \
+			"admin ($ADMIN_ROLE) and guest ($GUEST_ROLE) both got $ADMIN_SESS_ETAG"
+	else
+		_pass "two principals get different /auth/session validators"
+		# ...and the guest is not 304'd against the admin's.
+		CROSS=$(curl -s -o /dev/null -w '%{http_code}' --max-time 10 \
+			-H "Authorization: Bearer $GUEST_TOKEN" \
+			-H "If-None-Match: $ADMIN_SESS_ETAG" "$HOST/api/v0/auth/session")
+		_assert_eq "200" "$CROSS" \
+			"a guest is not served 304 against an admin's session validator"
+	fi
+fi
+
+# --- 7c. A mutation always changes the validator. --------------------
+#
+# The memo used to be keyed on (target, snapshot_at), and snapshot_at is
+# stamped only by the background refresher loop -- never by the inline
+# refresh a mutating handler runs. So a PATCH changed the body while the key
+# stood still, and the next conditional GET was answered 304 for content
+# that had just changed. Measured at 19 of 20 attempts before the key moved
+# to a per-refresh revision.
+PREFS="$HOST/api/v0/preferences"
+curl -s -o "$BODY_FILE" -D "$HDR_FILE" --max-time 10 "${AUTH[@]}" "$PREFS" >/dev/null
+PREF_ETAG=$(_hdr ETag)
+PREF_BEFORE=$(cat "$BODY_FILE")
+ORIG_UP=$(printf '%s' "$PREF_BEFORE" | jq -r '.connection.max_upload_kbps // 0' 2>/dev/null)
+if [ -z "$PREF_ETAG" ] || [ -z "$ORIG_UP" ]; then
+	_skip "mutation-changes-validator check (no ETag or no readable preferences)"
+else
+	NEW_UP=$((ORIG_UP + 7))
+	curl -s -o /dev/null --max-time 10 "${AUTH[@]}" -X PATCH \
+		-H "Content-Type: application/json" \
+		-d "{\"connection\":{\"max_upload_kbps\":$NEW_UP}}" "$PREFS" >/dev/null
+	curl -s -o "$BODY_FILE" -D "$HDR_FILE" --max-time 10 "${AUTH[@]}" "$PREFS" >/dev/null
+	PREF_AFTER=$(cat "$BODY_FILE")
+	PREF_ETAG2=$(_hdr ETag)
+	if [ "$PREF_BEFORE" = "$PREF_AFTER" ]; then
+		_skip "mutation-changes-validator check (the PATCH did not change the body)"
+	elif [ "$PREF_ETAG" = "$PREF_ETAG2" ]; then
+		_fail "a mutation changes the validator" \
+			"body changed but the ETag stayed $PREF_ETAG"
+	else
+		_pass "a mutation changes the validator"
+		# ...and the pre-mutation validator must no longer satisfy a
+		# conditional GET.
+		STALE=$(curl -s -o /dev/null -w '%{http_code}' --max-time 10 "${AUTH[@]}" \
+			-H "If-None-Match: $PREF_ETAG" "$PREFS")
+		_assert_eq "200" "$STALE" \
+			"a pre-mutation validator is not answered 304"
+	fi
+	# put it back
+	curl -s -o /dev/null --max-time 10 "${AUTH[@]}" -X PATCH \
+		-H "Content-Type: application/json" \
+		-d "{\"connection\":{\"max_upload_kbps\":$ORIG_UP}}" "$PREFS" >/dev/null
+fi
+
+# --- 7d. An authenticated body is not shared cache material. ---------
+#
+# Authenticate() takes a bearer token OR a session cookie, and the WebUI uses
+# the cookie -- so those requests carry no Authorization header and RFC 9111
+# 3.5's shared-cache prohibition never engages. With no explicit expiry a
+# shared cache may keep the 200 under heuristic freshness, and with Cookie
+# absent from Vary two users share a cache key: one user's download list can
+# be served to another.
+for cred in "Authorization: Bearer $TOKEN" "Cookie: amuleapi_token=$TOKEN"; do
+	label=${cred%%:*}
+	curl -s -o /dev/null -D "$HDR_FILE" --max-time 10 -H "$cred" \
+		"$HOST/api/v0/downloads" >/dev/null
+	# `private`, deliberately NOT `no-store`: no-store forbids the client's
+	# own cache too, so nothing would ever hold an entry to revalidate and
+	# no authenticated route would see an If-None-Match at all -- which
+	# throws away the validator machinery this suite spends most of its
+	# assertions on.
+	_assert_eq "private" "$(_hdr Cache-Control)" \
+		"an authenticated response ($label) is private (and not no-store)"
+	case "$(_hdr Vary)" in
+	*Cookie*) _pass "an authenticated response ($label) varies on Cookie" ;;
+	*) _fail "authenticated Vary names Cookie ($label)" "got [$(_hdr Vary)]" ;;
+	esac
+done
+
+# ...and an unauthenticated public probe stays cacheable, or it loses the
+# conditional GET the ETag exists for.
+curl -s -o /dev/null -D "$HDR_FILE" --max-time 10 "$HOST/api/v0/version" >/dev/null
+if [ -z "$(_hdr Cache-Control)" ]; then
+	_pass "an unauthenticated probe is left cacheable"
+else
+	_fail "unauthenticated probe left cacheable" "got Cache-Control: $(_hdr Cache-Control)"
+fi
+
+# A handler that sets its own policy keeps it: the flag artwork is public and
+# long-lived, and blanket-stamping would have made every WebUI icon uncacheable.
+curl -s -o /dev/null -D "$HDR_FILE" --max-time 10 "$HOST/flags/us.png" >/dev/null
+if [ "$(awk 'NR==1{print $2}' "$HDR_FILE" | tr -d '\r')" = "200" ]; then
+	_assert_eq "public, max-age=86400" "$(_hdr Cache-Control)" \
+		"a handler's own cache policy survives the authenticated stamp"
+else
+	_skip "flag-artwork cache policy (no flag asset served)"
+fi
+
+# ...and the WebUI shell specifically, which is the asset that had NO policy
+# of its own and so inherited the authenticated default. Probing /flags alone
+# could not see that: it is the one static route that always had one.
+#
+# Asserted as the PROPERTY, not as a header spelling. An earlier cut matched
+# the prefix `public*` and passed against `public, max-age=86400,
+# must-revalidate` -- which grants a browser 24 hours of reuse WITHOUT
+# asking. These filenames carry no content hash, so that is the window in
+# which an upgraded daemon keeps serving the old shell, and in which a new
+# shell can be paired with an old bundle, since each asset expires on its
+# own clock. must-revalidate does not close it: RFC 9111 5.2.2.2 makes it
+# govern what a cache may do once an entry is ALREADY stale. A prefix match
+# could not have caught that; what has to hold is that the response grants
+# no reuse without revalidation.
+_assert_revalidates_every_time() {
+	local policy=$1 label=$2
+	case "$policy" in
+	*no-store*) _pass "$label refuses storage entirely ($policy)" ;;
+	*no-cache*) _pass "$label revalidates on every use ($policy)" ;;
+	*max-age=0*) _pass "$label revalidates on every use ($policy)" ;;
+	*max-age=*)
+		_fail "$label revalidates on every use" \
+			"[$policy] grants reuse without asking, and these filenames carry no content hash" ;;
+	"") _fail "$label revalidates on every use" "no Cache-Control at all" ;;
+	*) _fail "$label revalidates on every use" "got [$policy]" ;;
+	esac
+}
+curl -s -o /dev/null -D "$HDR_FILE" --max-time 10 "$HOST/index.html" >/dev/null
+if [ "$(awk 'NR==1{print $2}' "$HDR_FILE" | tr -d '\r')" = "200" ]; then
+	_assert_revalidates_every_time "$(_hdr Cache-Control)" "the WebUI shell"
+	# It must still be shared-cacheable, which takes more than the absence
+	# of `private`. RFC 9111 3.5 bars a shared cache from reusing a
+	# response to a request that carried an Authorization header unless
+	# the response is marked public, must-revalidate or s-maxage --
+	# no-cache is not on that list. The WebUI logs in by cookie, but the
+	# same shell is fetched with a bearer token below, so without `public`
+	# a proxy has to hold a per-user copy of a file identical for every
+	# user. Asserted as the token, because that is what the RFC keys on.
+	SHELL_CC=$(_hdr Cache-Control)
+	# All three of 3.5's directives accept, not just `public`: a
+	# no-cache, must-revalidate policy is equally compliant, and a check
+	# whose accepting arm is narrower than its own failure message would
+	# reject one while telling the reader it carries none of them.
+	case "$SHELL_CC" in
+	*private*) _fail "the shell is shared-cacheable" "marked private: [$SHELL_CC]" ;;
+	*public*|*must-revalidate*|*s-maxage*) _pass "the shell is shared-cacheable ($SHELL_CC)" ;;
+	*) _fail "the shell is shared-cacheable" \
+		"[$SHELL_CC] carries none of public/must-revalidate/s-maxage, so RFC 9111 3.5 bars reuse" ;;
+	esac
+	# ...including when the request carries credentials, which is the case
+	# that used to stamp it private and re-fetch it per session.
+	curl -s -o /dev/null -D "$HDR_FILE" --max-time 10 \
+		-H "Authorization: Bearer $TOKEN" "$HOST/index.html" >/dev/null
+	SHELL_AUTH_CC=$(_hdr Cache-Control)
+	_assert_revalidates_every_time "$SHELL_AUTH_CC" "the shell under credentials"
+	# This is the request RFC 9111 3.5 is actually about: it carried an
+	# Authorization header, so one of its three directives is what decides
+	# whether a shared cache may serve one stored copy to everyone. Same
+	# widened arm as above, for the same reason.
+	case "$SHELL_AUTH_CC" in
+	*private*) _fail "the shell stays shared-cacheable under credentials" \
+		"marked private: [$SHELL_AUTH_CC]" ;;
+	*public*|*must-revalidate*|*s-maxage*) _pass "the shell stays shared-cacheable under credentials ($SHELL_AUTH_CC)" ;;
+	*) _fail "the shell stays shared-cacheable under credentials" \
+		"[$SHELL_AUTH_CC] carries none of public/must-revalidate/s-maxage" ;;
+	esac
+else
+	_skip "WebUI shell cache policy (no static frontend served)"
 fi
 
 # --- 8. status.ed2k.server_ip is an address, not an endpoint. --------

--- a/unittests/curl-tests/amuleapi/run-all.sh
+++ b/unittests/curl-tests/amuleapi/run-all.sh
@@ -257,6 +257,7 @@ PHASES=(
 	37-shared-availability-parts.sh
 	38-chat.sh
 	39-shared-media-refresh.sh
+	40-http-conformance.sh
 )
 
 # Override list from the command line if given.

--- a/unittests/tests/EtagTest.cpp
+++ b/unittests/tests/EtagTest.cpp
@@ -136,3 +136,100 @@ TEST(Etag, IfNoneMatchHexCaseSensitive)
 	// send lowercase. Uppercase variant → no hit.
 	ASSERT_FALSE(IfNoneMatchHits("DEADBEEFDEADBEEF", "deadbeefdeadbeef"));
 }
+
+// --- Per-coding validators ------------------------------------------
+//
+// The body hash is taken before compression, so both codings of a resource
+// derive from one hash. A strong validator names ONE representation, so the
+// selected coding is appended to the wire value and the conditional-GET
+// comparison runs against THAT value. An earlier cut matched either coding,
+// which defeats the suffix entirely: a client holding gzip bytes and asking
+// for identity was told its copy was current.
+TEST(Etag, CodingSuffixDistinguishesTheTwoRepresentations)
+{
+	const std::string bare = "a1b2c3d4";
+	const std::string coded = bare + webcommon::kGzipEtagSuffix;
+	ASSERT_TRUE(bare != coded);
+	// Each validator matches its own representation...
+	ASSERT_TRUE(webcommon::IfNoneMatchHits("\"a1b2c3d4\"", bare));
+	ASSERT_TRUE(webcommon::IfNoneMatchHits("\"a1b2c3d4-gzip\"", coded));
+	// ...and NOT the other one. This is the whole purpose of the suffix.
+	ASSERT_TRUE(!webcommon::IfNoneMatchHits("\"a1b2c3d4-gzip\"", bare));
+	ASSERT_TRUE(!webcommon::IfNoneMatchHits("\"a1b2c3d4\"", coded));
+}
+
+// The grammar still applies to whichever representation was selected: `*`,
+// weak validators and comma-separated lists all work against the coded form.
+TEST(Etag, CodedValidatorKeepsTheFullGrammar)
+{
+	const std::string coded = std::string("a1b2c3d4") + webcommon::kGzipEtagSuffix;
+	ASSERT_TRUE(webcommon::IfNoneMatchHits("*", coded));
+	ASSERT_TRUE(webcommon::IfNoneMatchHits("W/\"a1b2c3d4-gzip\"", coded));
+	ASSERT_TRUE(webcommon::IfNoneMatchHits("\"nope\", \"a1b2c3d4-gzip\"", coded));
+	ASSERT_TRUE(!webcommon::IfNoneMatchHits("\"deadbeef-gzip\"", coded));
+}
+
+// The suffix is a marker on one body's validator, not a wildcard that joins
+// two different bodies.
+TEST(Etag, CodingSuffixIsNotAWildcard)
+{
+	ASSERT_TRUE(!webcommon::IfNoneMatchHits("\"-gzip\"", "a1b2c3d4"));
+	ASSERT_TRUE(!webcommon::IfNoneMatchHits("", "a1b2c3d4"));
+}
+
+// --- Naming a representation ----------------------------------------
+//
+// WithCodingSuffix is asked which coding the value must NAME, not whether to
+// add or remove a suffix. Three call sites used to spell that edit out by
+// hand -- two that could only add and one that could only add-or-strip -- and
+// the difference is what let a failed deflate ship a gzip validator on
+// identity bytes.
+TEST(Etag, CodingSuffixNamesTheSelectedRepresentation)
+{
+	ASSERT_TRUE(webcommon::WithCodingSuffix("a1b2c3d4", true) == "a1b2c3d4-gzip");
+	ASSERT_TRUE(webcommon::WithCodingSuffix("a1b2c3d4", false) == "a1b2c3d4");
+	// The quoted form the static path carries: the suffix belongs on the
+	// opaque payload, INSIDE the quotes, or the value stops being a valid
+	// entity-tag and no client matches it again.
+	ASSERT_TRUE(webcommon::WithCodingSuffix("\"1f-2a3b\"", true) == "\"1f-2a3b-gzip\"");
+	ASSERT_TRUE(webcommon::WithCodingSuffix("\"1f-2a3b-gzip\"", false) == "\"1f-2a3b\"");
+}
+
+// The transport calls this on a value the dispatcher may already have
+// stamped, so asking for the coding that is already named must not double it.
+TEST(Etag, CodingSuffixIsIdempotent)
+{
+	ASSERT_TRUE(webcommon::WithCodingSuffix("a1b2c3d4-gzip", true) == "a1b2c3d4-gzip");
+	ASSERT_TRUE(webcommon::WithCodingSuffix("\"a1b2c3d4-gzip\"", true) == "\"a1b2c3d4-gzip\"");
+	ASSERT_TRUE(webcommon::WithCodingSuffix("a1b2c3d4", false) == "a1b2c3d4");
+}
+
+// The reason the helper exists. GzipOnce can fail -- deflateInit2 or deflate
+// returning short -- after the dispatcher has already predicted compression
+// and stamped the suffix. The body then ships as identity, and the validator
+// has to come back down with it, or a cache stores identity bytes under the
+// gzip validator and serves them to a client that asked for gzip.
+TEST(Etag, AFailedCompressionTakesTheSuffixBackOff)
+{
+	const std::string predicted = webcommon::WithCodingSuffix("a1b2c3d4", true);
+	ASSERT_TRUE(predicted == "a1b2c3d4-gzip");
+	// ...deflate fails, so the coding that actually shipped is identity.
+	const std::string shipped = webcommon::WithCodingSuffix(predicted, false);
+	ASSERT_TRUE(shipped == "a1b2c3d4");
+	// And the identity validator is what an identity client will send back.
+	ASSERT_TRUE(webcommon::IfNoneMatchHits("\"a1b2c3d4\"", shipped));
+	ASSERT_TRUE(!webcommon::IfNoneMatchHits("\"a1b2c3d4-gzip\"", shipped));
+}
+
+// A body whose hash happens to end in the suffix text is not "already coded".
+// Guarded because the check is a suffix compare on the payload: if the digest
+// alphabet ever widened past hex, `...-gzip` could occur naturally and a
+// wrongly-detected prediction would strip a byte off a real validator.
+TEST(Etag, CodingSuffixLooksOnlyAtTheEndOfThePayload)
+{
+	ASSERT_TRUE(webcommon::WithCodingSuffix("-gzipa1b2", true) == "-gzipa1b2-gzip");
+	ASSERT_TRUE(webcommon::WithCodingSuffix("-gzipa1b2", false) == "-gzipa1b2");
+	// Degenerate inputs must not underflow the erase.
+	ASSERT_TRUE(webcommon::WithCodingSuffix("", false).empty());
+	ASSERT_TRUE(webcommon::WithCodingSuffix("", true) == "-gzip");
+}

--- a/unittests/tests/EventDiffTest.cpp
+++ b/unittests/tests/EventDiffTest.cpp
@@ -1071,3 +1071,75 @@ TEST(EventDiff, CommentsUpdatedReportsAnIdleKadLookup)
 	ASSERT_TRUE(!payload.empty());
 	ASSERT_TRUE(payload.find("\"kad_comment_search_running\":false") != std::string::npos);
 }
+
+// The Kad lookup finishing is a comments_updated in its own right. The flag
+// rides in the payload, so if EqualComments ignores it the true->false edge
+// produces no event and a ?channels=comments subscriber's in-flight
+// indicator never clears.
+TEST(EventDiff, CommentsUpdatedFiresWhenOnlyTheKadFlagClears)
+{
+	CState state;
+	state.MutateDownloads([](FileMap &files) {
+		FileSnapshot f;
+		f.ecid = 43;
+		f.hash = "7777777777777777777777777777aaaa";
+		f.name = "searching.iso";
+		f.size = kPartSizeBytes;
+		f.is_downloading = true;
+		f.download.kad_comment_searching = true;
+		files.emplace(f.ecid, f);
+	});
+
+	CEventBus bus;
+	LastSeenState prev;
+	EmitDiffsAndUpdate(bus, prev, state); // cold start
+	DrainAll(bus);
+
+	// The lookup ends. No comment arrived, so source_comments is untouched
+	// and ONLY the flag moves.
+	state.MutateDownloads(
+		[](FileMap &files) { files.find(43)->second.download.kad_comment_searching = false; });
+	EmitDiffsAndUpdate(bus, prev, state);
+
+	std::string payload;
+	for (const auto &e : DrainAll(bus)) {
+		if (e.name == "comments_updated")
+			payload = e.data;
+	}
+	ASSERT_TRUE(!payload.empty());
+	ASSERT_TRUE(payload.find("\"kad_comment_search_running\":false") != std::string::npos);
+}
+
+// Cold start with a lookup already running. The mirror of
+// CommentsUpdatedFiresWhenOnlyTheKadFlagClears: there the finished edge never
+// arrived, here the starting state never arrives, and a ?channels=comments
+// subscriber that joined after the download appeared would never learn a
+// lookup was in flight.
+TEST(EventDiff, CommentsUpdatedFiresWhenAFileArrivesMidKadLookup)
+{
+	CState state;
+	state.MutateDownloads([](FileMap &files) {
+		FileSnapshot f;
+		f.ecid = 44;
+		f.hash = "8888888888888888888888888888bbbb";
+		f.name = "arrived-searching.iso";
+		f.size = kPartSizeBytes;
+		f.is_downloading = true;
+		// No comments yet -- only the in-flight flag.
+		f.download.kad_comment_searching = true;
+		files.emplace(f.ecid, f);
+	});
+
+	CEventBus bus;
+	LastSeenState prev;
+	EmitDiffsAndUpdate(bus, prev, state);
+
+	std::string payload;
+	for (const auto &e : DrainAll(bus)) {
+		if (e.name == "comments_updated")
+			payload = e.data;
+	}
+	ASSERT_TRUE(!payload.empty());
+	ASSERT_TRUE(payload.find("\"kad_comment_search_running\":true") != std::string::npos);
+	ASSERT_TRUE(payload.find("\"count\":0") != std::string::npos);
+}

--- a/unittests/tests/EventDiffTest.cpp
+++ b/unittests/tests/EventDiffTest.cpp
@@ -978,3 +978,96 @@ TEST(EventDiff, RoleFlipRefreshesFieldsTheOtherRoleNeverCompared)
 	// And the baseline now carries it, so the next tick is silent.
 	ASSERT_EQUALS(static_cast<std::uint64_t>(999), prev.files.find(24)->second.download.size_done);
 }
+
+// --- comments_updated payload ---------------------------------------
+//
+// EVENTS.md promises the payload is the GET /downloads/{hash}/comments body
+// plus `hash`. It used to carry `hash` but NOT `kad_comment_search_running`,
+// so a client that followed the document and fed the event into the view it
+// built from the endpoint silently lost the in-flight-lookup flag -- exactly
+// the flag it needs while a POST /downloads/{hash}/comments Kad lookup runs.
+TEST(EventDiff, CommentsUpdatedIsASupersetOfTheRestBody)
+{
+	CState state;
+	state.MutateDownloads([](FileMap &files) {
+		FileSnapshot f;
+		f.ecid = 41;
+		f.hash = "5555555555555555555555555555eeee";
+		f.name = "commented.iso";
+		f.size = kPartSizeBytes * 2;
+		f.is_downloading = true;
+		files.emplace(f.ecid, f);
+	});
+
+	CEventBus bus;
+	LastSeenState prev;
+	EmitDiffsAndUpdate(bus, prev, state); // cold start: download_added
+	DrainAll(bus);
+
+	// A Kad lookup is in flight AND a note has landed, so the event fires
+	// with the flag still true -- the state a client is most likely to
+	// render, and the one the missing key made unrepresentable.
+	state.MutateDownloads([](FileMap &files) {
+		FileSnapshot &f = files.find(41)->second;
+		f.download.kad_comment_searching = true;
+		FileSnapshot::DownloadSide::SourceComment c;
+		c.username = "alice";
+		c.filename = "commented.iso";
+		c.rating = 5;
+		c.comment = "great quality";
+		f.download.source_comments.push_back(c);
+	});
+	EmitDiffsAndUpdate(bus, prev, state);
+
+	std::string payload;
+	for (const auto &e : DrainAll(bus)) {
+		if (e.name == "comments_updated")
+			payload = e.data;
+	}
+	ASSERT_TRUE(!payload.empty());
+	// The endpoint's three keys...
+	ASSERT_TRUE(payload.find("\"count\":1") != std::string::npos);
+	ASSERT_TRUE(payload.find("\"kad_comment_search_running\":true") != std::string::npos);
+	ASSERT_TRUE(payload.find("\"comments\":[") != std::string::npos);
+	// ...plus the one the event adds, because nothing else in the frame
+	// identifies the file.
+	ASSERT_TRUE(payload.find("\"hash\":\"5555555555555555555555555555eeee\"") != std::string::npos);
+	ASSERT_TRUE(payload.find("\"username\":\"alice\"") != std::string::npos);
+}
+
+// And the flag tracks false, so a client can see the lookup finish.
+TEST(EventDiff, CommentsUpdatedReportsAnIdleKadLookup)
+{
+	CState state;
+	state.MutateDownloads([](FileMap &files) {
+		FileSnapshot f;
+		f.ecid = 42;
+		f.hash = "6666666666666666666666666666ffff";
+		f.name = "quiet.iso";
+		f.size = kPartSizeBytes;
+		f.is_downloading = true;
+		files.emplace(f.ecid, f);
+	});
+
+	CEventBus bus;
+	LastSeenState prev;
+	EmitDiffsAndUpdate(bus, prev, state);
+	DrainAll(bus);
+
+	state.MutateDownloads([](FileMap &files) {
+		FileSnapshot &f = files.find(42)->second;
+		FileSnapshot::DownloadSide::SourceComment c;
+		c.username = "Kad user";
+		c.rating = 4;
+		f.download.source_comments.push_back(c);
+	});
+	EmitDiffsAndUpdate(bus, prev, state);
+
+	std::string payload;
+	for (const auto &e : DrainAll(bus)) {
+		if (e.name == "comments_updated")
+			payload = e.data;
+	}
+	ASSERT_TRUE(!payload.empty());
+	ASSERT_TRUE(payload.find("\"kad_comment_search_running\":false") != std::string::npos);
+}

--- a/unittests/tests/StateTest.cpp
+++ b/unittests/tests/StateTest.cpp
@@ -1092,51 +1092,150 @@ TEST(State, ConcurrentReadersDontTearSnapshot)
 	ASSERT_EQUALS(0, torn.load());
 }
 
-// --- SnapshotGovernsBody --------------------------------------------
+// --- MemoizableTarget -----------------------------------------------
 //
-// The ETag memo in the dispatcher is keyed on (target, snapshot_at), and
-// snapshot_at counts whole seconds. That key is only sound for bodies the
-// refresher snapshot actually governs; for anything refreshed on its own
-// schedule the body can move while the key stands still, and reusing the
-// memoized validator across that answers a later conditional GET with 304
-// for content that has changed.
+// The response-ETag memo is keyed on (target, snapshot revision). Eligibility
+// is opt-in: this used to be an exclusion list and it was wrong four separate
+// times -- a bare collection the prefixes never matched, a live EC roundtrip
+// nobody listed, a per-principal document, and a key that froze while bodies
+// moved. Inverting it makes an oversight cost a wasted hash instead of a 304
+// for changed content.
 
-// The big snapshot-governed collections are exactly what the memo exists
-// for -- they are the multi-MB bodies worth not re-hashing every request.
-TEST(State, SnapshotGovernsBodyMemoizesSnapshotBackedTargets)
+// The two collections the memo exists for: the multi-MB bodies where skipping
+// an MD5 is worth anything.
+TEST(State, MemoizableTargetCoversTheTwoBigCollections)
 {
-	ASSERT_TRUE(SnapshotGovernsBody("/api/v0/downloads"));
-	ASSERT_TRUE(SnapshotGovernsBody("/api/v0/shared"));
-	ASSERT_TRUE(SnapshotGovernsBody("/api/v0/status"));
-	ASSERT_TRUE(SnapshotGovernsBody("/api/v0/clients"));
-	ASSERT_TRUE(SnapshotGovernsBody("/api/v0/servers"));
-	// A query string selects a page, not a different resource.
-	ASSERT_TRUE(SnapshotGovernsBody("/api/v0/downloads?limit=10&offset=20"));
+	ASSERT_TRUE(MemoizableTarget("/api/v0/downloads"));
+	ASSERT_TRUE(MemoizableTarget("/api/v0/shared"));
+	// A query string picks a page, not a different resource.
+	ASSERT_TRUE(MemoizableTarget("/api/v0/downloads?limit=10&offset=20"));
+	ASSERT_TRUE(MemoizableTarget("/api/v0/shared?sort=name&order=desc"));
 }
 
-// The self-refreshing ones must never be memoized: /stats/* and
-// /logs/serverinfo hold their own 1 s TTL caches fetched out of phase with
-// the tick, /logs/amule grows between ticks, and a search's results are
-// refreshed on read.
-TEST(State, SnapshotGovernsBodyRefusesSelfRefreshingTargets)
+// Everything else hashes per request. Each of these was a live bug at some
+// point in this PR's history, and under an opt-in rule none of them can
+// recur: the self-refreshing ones, the live-EC ones, and the per-principal
+// one are all simply absent from the eligible set.
+TEST(State, MemoizableTargetExcludesEverythingElse)
 {
-	ASSERT_TRUE(!SnapshotGovernsBody("/api/v0/stats/tree"));
-	ASSERT_TRUE(!SnapshotGovernsBody("/api/v0/stats/graphs/download_speed"));
-	ASSERT_TRUE(!SnapshotGovernsBody("/api/v0/logs/amule"));
-	ASSERT_TRUE(!SnapshotGovernsBody("/api/v0/logs/serverinfo"));
-	ASSERT_TRUE(!SnapshotGovernsBody("/api/v0/search/7/results"));
-	// The query string must not smuggle one past the prefix check: the
-	// stats graphs are always queried, so a match on the full target
-	// rather than the path would have let every one of them memoize.
-	ASSERT_TRUE(!SnapshotGovernsBody("/api/v0/stats/graphs/download_speed?width=3"));
-	ASSERT_TRUE(!SnapshotGovernsBody("/api/v0/logs/amule?limit=50"));
+	// own TTL caches / append-only mirror / refresh-on-read
+	ASSERT_TRUE(!MemoizableTarget("/api/v0/stats/tree"));
+	ASSERT_TRUE(!MemoizableTarget("/api/v0/stats/graphs/download_speed?width=3"));
+	ASSERT_TRUE(!MemoizableTarget("/api/v0/logs/amule"));
+	ASSERT_TRUE(!MemoizableTarget("/api/v0/logs/serverinfo"));
+	ASSERT_TRUE(!MemoizableTarget("/api/v0/search/7/results"));
+	// live EC roundtrip per read, and the bare collection a trailing-slash
+	// prefix could never match
+	ASSERT_TRUE(!MemoizableTarget("/api/v0/search"));
+	ASSERT_TRUE(!MemoizableTarget("/api/v0/shared/directories"));
+	// per-principal: one key cannot describe two callers' documents
+	ASSERT_TRUE(!MemoizableTarget("/api/v0/auth/session"));
+	// snapshot-backed, but not worth a memo -- and absent by default
+	ASSERT_TRUE(!MemoizableTarget("/api/v0/status"));
+	ASSERT_TRUE(!MemoizableTarget("/api/v0/clients"));
+	ASSERT_TRUE(!MemoizableTarget("/api/v0/servers"));
 }
 
-// Prefix matching must not swallow a neighbour that merely starts with the
-// same letters. /api/v0/statistics is not /api/v0/stats/.
-TEST(State, SnapshotGovernsBodyPrefixIsSegmentBounded)
+// A sub-resource of an eligible collection is NOT itself eligible: it is a
+// different body, and /shared/directories in particular is a live EC read
+// that an "everything under /shared" rule would have swept back in.
+TEST(State, MemoizableTargetDoesNotExtendToSubResources)
 {
-	ASSERT_TRUE(SnapshotGovernsBody("/api/v0/statistics"));
-	ASSERT_TRUE(SnapshotGovernsBody("/api/v0/searches"));
-	ASSERT_TRUE(SnapshotGovernsBody("/api/v0/logging"));
+	ASSERT_TRUE(!MemoizableTarget("/api/v0/downloads/8b54a3c2"));
+	ASSERT_TRUE(!MemoizableTarget("/api/v0/downloads/8b54a3c2/clients"));
+	ASSERT_TRUE(!MemoizableTarget("/api/v0/shared/8b54a3c2"));
+	ASSERT_TRUE(!MemoizableTarget("/api/v0/shared/directories"));
+	// and no prefix bleed onto a neighbour that merely starts the same
+	ASSERT_TRUE(!MemoizableTarget("/api/v0/downloads_archive"));
+	ASSERT_TRUE(!MemoizableTarget("/api/v0/sharedfiles"));
+}
+
+// --- Snapshot revision ----------------------------------------------
+//
+// The ETag memo is keyed on this, not on snapshot_at. snapshot_at cannot
+// serve: it counts whole seconds, so two refreshes inside one second are
+// indistinguishable, and it is stamped only by the background loop, so the
+// inline refreshes that mutating handlers run never moved it. A mutation
+// therefore changed a body while the key stood still, and the next
+// conditional GET was answered 304 for content that had just changed.
+TEST(State, SnapshotRevisionAdvancesOnEveryBump)
+{
+	CState state;
+	const std::uint64_t r0 = state.SnapshotRevision();
+	state.BumpSnapshotRevision();
+	const std::uint64_t r1 = state.SnapshotRevision();
+	ASSERT_TRUE(r1 != r0);
+	state.BumpSnapshotRevision();
+	ASSERT_TRUE(state.SnapshotRevision() != r1);
+}
+
+// Two bumps inside the same wall-clock second must still be distinguishable
+// -- the precise case a time_t key collapses.
+TEST(State, SnapshotRevisionSeparatesTwoBumpsInOneSecond)
+{
+	CState state;
+	std::vector<std::uint64_t> seen;
+	for (int i = 0; i < 5; ++i) {
+		state.BumpSnapshotRevision();
+		seen.push_back(state.SnapshotRevision());
+	}
+	for (std::size_t i = 1; i < seen.size(); ++i) {
+		ASSERT_TRUE(seen[i] != seen[i - 1]);
+	}
+}
+
+// Every writer of a memoized body advances the key, and it is the WRITER
+// that does it rather than its callers. That is the whole point: the key was
+// advanced from the outside three times and missed a path each time -- the
+// inline refreshes mutating handlers run, and then a tick that failed partway
+// after it had already written. A writer cannot forget that it wrote.
+TEST(State, MutatingDownloadsAdvancesTheRevision)
+{
+	CState state;
+	const std::uint64_t before = state.SnapshotRevision();
+	state.MutateDownloads([](FileMap &files) {
+		FileSnapshot f;
+		f.ecid = 1;
+		f.hash = "1111111111111111111111111111aaaa";
+		f.is_downloading = true;
+		files.emplace(f.ecid, f);
+	});
+	ASSERT_TRUE(state.SnapshotRevision() != before);
+}
+
+TEST(State, MutatingSharedAdvancesTheRevision)
+{
+	CState state;
+	const std::uint64_t before = state.SnapshotRevision();
+	state.MutateShared([](FileMap &) {});
+	ASSERT_TRUE(state.SnapshotRevision() != before);
+}
+
+// The failure path specifically. A tick that dies partway still calls
+// ResetLists on the way back, and that wipe is as much a body change as any
+// mutation -- it is where the key used to freeze while the bodies moved, so
+// a whole EC outage was served 304 against the pre-failure validator.
+TEST(State, ResetListsAdvancesTheRevision)
+{
+	CState state;
+	state.MutateDownloads([](FileMap &files) {
+		FileSnapshot f;
+		f.ecid = 2;
+		f.hash = "2222222222222222222222222222bbbb";
+		files.emplace(f.ecid, f);
+	});
+	const std::uint64_t before = state.SnapshotRevision();
+	state.ResetLists();
+	ASSERT_TRUE(state.SnapshotRevision() != before);
+}
+
+// MarkTickSuccess stamps the timestamp; it deliberately does NOT advance the
+// revision, because RefresherTick owns that and the background loop calls
+// both. Pinning it so a future edit does not quietly double-count.
+TEST(State, MarkTickSuccessDoesNotAdvanceTheRevision)
+{
+	CState state;
+	const std::uint64_t before = state.SnapshotRevision();
+	state.MarkTickSuccess();
+	ASSERT_EQUALS(before, state.SnapshotRevision());
 }

--- a/unittests/tests/StateTest.cpp
+++ b/unittests/tests/StateTest.cpp
@@ -1091,3 +1091,52 @@ TEST(State, ConcurrentReadersDontTearSnapshot)
 	// And no read saw a torn snapshot.
 	ASSERT_EQUALS(0, torn.load());
 }
+
+// --- SnapshotGovernsBody --------------------------------------------
+//
+// The ETag memo in the dispatcher is keyed on (target, snapshot_at), and
+// snapshot_at counts whole seconds. That key is only sound for bodies the
+// refresher snapshot actually governs; for anything refreshed on its own
+// schedule the body can move while the key stands still, and reusing the
+// memoized validator across that answers a later conditional GET with 304
+// for content that has changed.
+
+// The big snapshot-governed collections are exactly what the memo exists
+// for -- they are the multi-MB bodies worth not re-hashing every request.
+TEST(State, SnapshotGovernsBodyMemoizesSnapshotBackedTargets)
+{
+	ASSERT_TRUE(SnapshotGovernsBody("/api/v0/downloads"));
+	ASSERT_TRUE(SnapshotGovernsBody("/api/v0/shared"));
+	ASSERT_TRUE(SnapshotGovernsBody("/api/v0/status"));
+	ASSERT_TRUE(SnapshotGovernsBody("/api/v0/clients"));
+	ASSERT_TRUE(SnapshotGovernsBody("/api/v0/servers"));
+	// A query string selects a page, not a different resource.
+	ASSERT_TRUE(SnapshotGovernsBody("/api/v0/downloads?limit=10&offset=20"));
+}
+
+// The self-refreshing ones must never be memoized: /stats/* and
+// /logs/serverinfo hold their own 1 s TTL caches fetched out of phase with
+// the tick, /logs/amule grows between ticks, and a search's results are
+// refreshed on read.
+TEST(State, SnapshotGovernsBodyRefusesSelfRefreshingTargets)
+{
+	ASSERT_TRUE(!SnapshotGovernsBody("/api/v0/stats/tree"));
+	ASSERT_TRUE(!SnapshotGovernsBody("/api/v0/stats/graphs/download_speed"));
+	ASSERT_TRUE(!SnapshotGovernsBody("/api/v0/logs/amule"));
+	ASSERT_TRUE(!SnapshotGovernsBody("/api/v0/logs/serverinfo"));
+	ASSERT_TRUE(!SnapshotGovernsBody("/api/v0/search/7/results"));
+	// The query string must not smuggle one past the prefix check: the
+	// stats graphs are always queried, so a match on the full target
+	// rather than the path would have let every one of them memoize.
+	ASSERT_TRUE(!SnapshotGovernsBody("/api/v0/stats/graphs/download_speed?width=3"));
+	ASSERT_TRUE(!SnapshotGovernsBody("/api/v0/logs/amule?limit=50"));
+}
+
+// Prefix matching must not swallow a neighbour that merely starts with the
+// same letters. /api/v0/statistics is not /api/v0/stats/.
+TEST(State, SnapshotGovernsBodyPrefixIsSegmentBounded)
+{
+	ASSERT_TRUE(SnapshotGovernsBody("/api/v0/statistics"));
+	ASSERT_TRUE(SnapshotGovernsBody("/api/v0/searches"));
+	ASSERT_TRUE(SnapshotGovernsBody("/api/v0/logging"));
+}


### PR DESCRIPTION
Closes #1104. Thirteen unrelated defects across the v0 surface, plus forty-nine more found while reviewing the fixes themselves. Every claim in the issue was checked against the source before fixing; none turned out to be a false positive.

## Wire protocol

**Conditional GET could answer 304 for content that had changed (§11).** The response ETag is memoized per target to avoid re-hashing large bodies, keyed on `(target, snapshot_at)`. `snapshot_at` is stamped once per refresher tick in whole seconds, and several endpoints do not take their body from that snapshot at all: `/stats/*` and `/logs/serverinfo` hold their own 1 s TTL caches fetched out of phase with the tick, `/logs/amule` is an append-only mirror that grows between ticks, and a search's results are refreshed on read. For those the memoized validator was served for a body it was not computed from, so a later `If-None-Match` got a 304 for content that had moved on. RFC 9110 §8.8.1 requires the entity-tag to change whenever the representation does, and any conformant cache is entitled to keep serving the stale copy. `SnapshotGovernsBody()` now gates the memo; the excluded bodies are hundreds of bytes to a few KB, and the memo still covers the multi-MB `/downloads` and `/shared` bodies it exists for.

**HEAD sent content on every non-200 response (§1).** The body strip sat inside the block that only runs for 200 replies, so every HEAD ending in 4xx or 5xx shipped the JSON error envelope. RFC 9110 §9.3.2 forbids content in a HEAD response, and on a keep-alive connection a client that correctly stops reading after the headers leaves those bytes in the socket to corrupt the next response. HEAD is now answered by serializing headers only, at the transport, on any status. That also fixes the mirror-image wart: `prepare_payload()` sizes `Content-Length` from the full body before the header-only write, so HEAD reports what a GET would return instead of 0.

**Oversize requests and read timeouts closed the connection without a word (§3).** The 1 MiB body cap, the 16 KiB header cap and the 10 s read timeout all surfaced as a Beast read error whose handler closed the socket silently, so a caller could not tell "too large" from "daemon crashed" or "firewall ate it" - the one place on the surface that did not answer with a typed envelope. They now answer `413 payload_too_large`, `431 headers_too_large` and `408 request_timeout`. The timeout needed its own timer: `beast::tcp_stream`'s expiry CLOSES the socket, so by the time the read handler sees `beast::error::timeout` there is nothing left to write on. Our timer fires first and answers; the stream expiry stays as the hard backstop, both paths are guarded by a single-response flag, and the timer is cancelled on close so a dead connection is not pinned for the rest of its budget.

**405 responses carried no `Allow` header (§12).** RFC 9110 §15.5.6 makes it mandatory, and it is what generic tooling and capability discovery read. All 41 rejection sites now emit one. The list is derived from each route's actual method guards rather than from its prose message: the messages under-report HEAD (`/status` says "only GET" and accepts both), so a client trusting the header alone would have been told less than the truth.

**Bodiless replies sent an empty `Content-Type` (§12).** The handlers clear it for 204 and the ETag layer clears it for 304, but the writer emitted the header anyway with no value, which is malformed. It is omitted when there is nothing to describe.

**A static asset reported two different validators (§9).** `ServeStaticFile` computes an mtime+size ETag and the outer layer stamped the MD5 of the body over the top, but only when the body was non-empty - true on GET, false on HEAD, because the handler emptied it itself. So the two methods handed out different validators for one URL, and touching the file changed one while the other stood still. The outer layer now skips stamping whenever a handler set its own ETag, and the static path keeps its body so the two agree. Its `If-None-Match` lookup was also a literal map find, so a lowercase `if-none-match` (what an HTTP/2-shaped client library produces) silently lost conditional GET; it now goes through the case-insensitive helper the rest of the surface uses, whose own comment warns against exactly this.

**The CORS preflight advertised a method list that did not match the routes (§13).** `PUT` was missing while `PUT /api/v0/shared/directories` is a real route, so a browser doing a cross-origin PUT there was told the method is not allowed and blocked the request before sending it: reachable from curl, unreachable from a page.

## Payloads and values

**`status.ed2k.server_ip` was not an IP address (§2).** It carried brackets and the port, `[77.42.68.79:4232]`, inside a field named `server_ip`, beside a `server_port` that already held the port, against a declared "dotted-quad" contract. Every overload of `StringIP()` appends `":port"` unconditionally, so no argument to it yields a bare quad. It is now formatted from the raw address the way every other IP on this surface is, which also stops a client joining the two fields getting `[77.42.68.79:4232]:4232`.

**The `comments_updated` SSE payload did not match its endpoint (§4).** The docs promised the `GET /downloads/{hash}/comments` body; the event carried `hash` and lacked `kad_comment_search_running`, so a client that followed the docs and fed the event into the view it built from the endpoint lost the in-flight-lookup flag - exactly the flag it needs while a Kad lookup runs. The event is now a strict superset, and the document says so.

## Documentation

All four mislead a client that follows them.

- **The `comments` SSE channel was undocumented (§5).** `comments_updated` has the prefix `comments`, which the channel mapping does not fold into `downloads`, so `?channels=downloads` silently drops it while the prose called it a downloads concern. It now has its own row, and the prose says which channel carries it.
- **`REFERENCE.md` named the log channel `log` in three places where it is `logs` (§6).** Unknown channel names are ignored silently, so a client following those sentences subscribed to an empty stream and waited for an event that never came. In all three cases the log line is the only way to observe the outcome, because the endpoints answer 202 before doing the work.
- **The error catalogue was incomplete and partly wrong (§7).** It listed 13 codes against 23 emitted `(status, code)` pairs, omitted 9 codes entirely, listed `internal` which no handler emits while `internal_error` was absent, and gave one status each for `amuled_rejected` and `invalid_credentials`, which are emitted with two. It is regenerated from the source and now matches it exactly at 26 codes, including the three new ones above.
- **`media` on a search result was documented as locally probed (§10).** It is whatever the responding server advertised: a PDF reporting a 16-minute runtime and an xvid codec is a real observed result. It is now documented as unverified, unlike the probed `media` on a download or shared file. No values are dropped server-side.

**One stale comment (§8):** the graph names in the routing block were the pre-rename ones, which misleads whoever reads the router, including anyone adding a fifth graph.

## Tests

Five new cctest cases: `SnapshotGovernsBody` over snapshot-backed targets, self-refreshing ones, and the prefix boundary that keeps `/api/v0/statistics` from being read as `/api/v0/stats/`; and the `comments_updated` payload in both the lookup-running and idle states.

A new curl smoke, `39-http-conformance`, covers the wire contract: HEAD on 404 / 401 / 200, `Allow` on two routes with different verb sets, `Content-Type` absent on 304 and on the 204 preflight, the static-asset validator agreeing across methods and honouring a lowercase header, 413 and 408, the stats-graph ETag tracking its body in both directions, and `server_ip`'s shape. The HEAD assertions read the socket directly rather than through curl, which knows a HEAD response has no body and would report zero bytes whether or not the server sent them, which is the bug itself.

`25-cors` gains the PUT preflight assertions, and `26` pins `comments_updated` out of the downloads channel so folding the prefix in later without updating the table is caught.

Verified against a daemon connected to ed2k with a populated share directory: 41 of 41 cctest binaries pass, and `run-all` is 38 of 39. The exception is `22-sse-diff-emission`, which this change does not touch and which fails identically from a pristine master tree: its 8 s window for a finished `search_progress` frame is too tight for a LowID node under load.
## Found while reviewing the fixes

Fifteen review passes over this branch. Written as what the surface does now rather than as a history of the rounds: several intermediate states were superseded, and a couple were themselves wrong, so a round-by-round account would tell a reader two contradictory stories about what shipped.

Four classes of defect came out of it, all of them now closed by construction rather than by keeping a list current:

- **Stale `304`.** Four separate mechanisms, not one: an exclusion list that missed live-EC endpoints, a per-principal document sharing one validator between callers, a key that stood still during a mutating handler's inline refresh, and a key that stood still when a tick failed partway. Memo eligibility is opt-in now, the revision is advanced by the writers of those bodies themselves, and dispatch brackets the handler so a write landing mid-serialization cannot pair a body with a revision it does not belong to.
- **One strong validator naming two representations.** The body hash is taken before compression, so the gzip and identity forms shared an ETag. The selected coding is appended, comparison runs against that same value, and the transport reconciles the dispatcher's prediction against the coding that actually shipped, so a failed deflate cannot leave a gzip validator on identity bytes.
- **Cache policy computed for one caller and served to another.** Authenticated responses are `private` with `Cookie` on `Vary`; `/auth/session` is `private, no-store`; the static shell is `public, no-cache` because it is identical for every caller and its filenames carry no content hash.
- **One value with several producers.** Comma-separated header merging existed in three copies and two consecutive fix rounds each reached a different two of them. It has one owner now, and so does the coding-suffix edit.

Two of those were introduced by earlier passes of this same PR and caught by later ones. The one that would have reached a default install was `public, max-age=86400, must-revalidate` on the WebUI shell: `must-revalidate` governs only an entry that is *already* stale (RFC 9111 §5.2.2.2), so for 24 hours a browser reuses the shell without asking, and unversioned filenames mean an upgraded daemon keeps serving the old one -- with a new shell able to pair with an old bundle, since each asset expires on its own clock.

The check that was supposed to guard that asserted the header prefix `public*`, which the broken policy satisfies. It confirmed the spelling while the property it stood for was false. That is the pattern worth carrying forward from this branch: **assert the observable property, not the implementation string**, and **break each mechanism deliberately to confirm something goes red**. Every mechanism here was mutation-checked:

| Mutation | Goes red | Gate |
| --- | --- | --- |
| Coding helper made additive-only (failed compression keeps the suffix) | `EtagTest` | CI |
| Matcher accepts either coding again | `EtagTest`, 2 cases | CI |
| Authenticated default back to `private, no-store` | `40-http-conformance`, 2 | live daemon |
| Static handler's own `Cache-Control` dropped | `40-http-conformance`, 2 | live daemon |
| Static policy set to `public, max-age=86400, must-revalidate` | `40-http-conformance`, 2 | live daemon |
| `public` dropped from the static policy | `40-http-conformance`, 2 | live daemon |
| Transport's coding stamp removed | `40-http-conformance`, 2 | live daemon |
| Dispatcher's coding stamp removed | `40-http-conformance`, 1 | live daemon |

That check earned its keep on its first run: it showed the initial coding tests did not reach the transport path at all. Two guards it does **not** cover -- `rev_stable` and `handler_set_etag`, both guarding a race the sequential tests never exercise -- are filed with two other deferred items in #1134.

The suite also stopped treating skips as passes: an uncompressed static asset now fails rather than skipping, and the coding assertions moved off `/downloads`, whose body on an empty daemon sits under the compression floor and hard-failed three of them on a standalone bring-up.

## Two notes for reviewers

**This changes what `curl -X HEAD` does.** Now that `Content-Length` on a HEAD is truthful, `-X HEAD` leaves curl waiting for a body that correctly never comes, which it reports as error 18. `-X` only swaps the method string; `--head` / `-I` is the correct invocation and is what curl documents. It only passed before because the server was answering HEAD with a wrong `Content-Length: 0`. `20-etag-conditional-get` is updated accordingly, and any operator script using `-X HEAD` needs the same change.

**§1, §3 and §12 all touch the HTTP transport**, which no other part of the surface can route around. Worth a closer read than the payload and documentation fixes.












