### PR TITLE
fix: link libatomic in every target that needs an 8-byte atomic

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -599,6 +599,17 @@ if (BUILD_REMOTEGUI)
 		PRIVATE wxWidgets::NET
 	)
 
+	# KnownFile.cpp's std::atomic<uint64> EC generation counter (and
+	# Statistics.cpp's free-space pair) needs libatomic on 32-bit targets
+	# without a hardware 8-byte CAS (PPC32, ARMv5/v6, MIPS32). amulegui
+	# compiles COMMON_SOURCES but links muleappcommon / muleappgui, not
+	# muleappcore, so it does not inherit muleappcore's copy. LIBATOMIC is
+	# set at the top of the root CMakeLists.txt — empty on 64-bit, "atomic"
+	# on 32-bit.
+	if (LIBATOMIC)
+		target_link_libraries (amulegui PRIVATE ${LIBATOMIC})
+	endif()
+
 	if (HAVE_BFD)
 		target_link_libraries (amulegui
 			PRIVATE ${BFD_LIBRARY}
@@ -918,8 +929,8 @@ if (NEED_LIB_MULEAPPCORE)
 	# needs libatomic on 32-bit targets without a hardware 8-byte
 	# CAS (PPC32, ARMv5/v6, MIPS32). LIBATOMIC is set at the top
 	# of the root CMakeLists.txt — empty on 64-bit, "atomic" on
-	# 32-bit. Linked PUBLIC so amule / amuled / amulegui pick it
-	# up transitively.
+	# 32-bit. Linked PUBLIC so amule / amuled pick it up
+	# transitively.
 	if (LIBATOMIC)
 		target_link_libraries (muleappcore PUBLIC ${LIBATOMIC})
 	endif()

--- a/src/webapi/CMakeLists.txt
+++ b/src/webapi/CMakeLists.txt
@@ -86,6 +86,16 @@ target_link_libraries (amuleapi
 	PRIVATE ZLIB::ZLIB
 )
 
+# CEventBus's std::atomic<uint64_t> event counter needs libatomic on
+# 32-bit targets without a hardware 8-byte CAS (PPC32, ARMv5/v6,
+# MIPS32). muleappcore links it for the same reason, but amuleapi does
+# not depend on muleappcore, so it needs its own copy. LIBATOMIC is set
+# at the top of the root CMakeLists.txt — empty on 64-bit, "atomic" on
+# 32-bit.
+if (LIBATOMIC)
+	target_link_libraries (amuleapi PRIVATE ${LIBATOMIC})
+endif()
+
 # Same gettext shim as amuleweb — _() in the CLI text needs libintl on
 # macOS / MinGW. Glibc bakes the symbols into libc, so the guard is a
 # noop there.

--- a/unittests/tests/CMakeLists.txt
+++ b/unittests/tests/CMakeLists.txt
@@ -568,6 +568,13 @@ target_link_libraries (EventBusTest
 	mulecommon
 )
 
+# CEventBus's std::atomic<uint64_t> event counter needs libatomic on
+# 32-bit targets without a hardware 8-byte CAS (PPC32, ARMv5/v6,
+# MIPS32); same reason amuleapi links it. Empty on 64-bit.
+if (LIBATOMIC)
+	target_link_libraries (EventBusTest ${LIBATOMIC})
+endif()
+
 # amuleapi log-file tee: exercises CRotatingLog's append + two-file size cap.
 # LogTee.cpp is plain POSIX/std (no wx), so only muleunit + mulecommon are
 # needed for the harness.
@@ -611,6 +618,11 @@ target_link_libraries (EventDiffTest
 	webcommon
 	wxWidgets::BASE
 )
+
+# Pulls EventBus.cpp, so it needs libatomic on 32-bit targets too.
+if (LIBATOMIC)
+	target_link_libraries (EventDiffTest ${LIBATOMIC})
+endif()
 
 # amuleapi-specific: tests CAmuleApiConfig's file-IO + mode-bit
 # enforcement. AmuleApiConfig.cpp is statically linked into the test


### PR DESCRIPTION
CEventBus (amuleapi) keeps its event counter in a std::atomic<uint64_t> and CKnownFile stamps files from a std::atomic<uint64> EC generation counter. On 32-bit targets without a hardware 8-byte CAS (ARMv5/v6, PPC32, MIPS32) both expand to __atomic_*_8 library calls that live in libatomic. The root CMakeLists.txt already detects this and sets LIBATOMIC, but only muleappcore links it, so anything not depending on muleappcore was left without -latomic:

  EventBus.cpp.o: in function `webapi::CEventBus::Publish(...)':
  EventBus.cpp:(.text+0x550): undefined reference to `__atomic_fetch_add_8'

That is amuleapi (fails an armv5 build of the daemon + REST API today), amulegui — it compiles COMMON_SOURCES, and KnownFile.cpp's MarkECChanged() / s_globalEcGen sit outside the CLIENT_GUI guards, but it links muleappcommon / muleappgui rather than muleappcore — and the EventBusTest / EventDiffTest unit tests, which compile EventBus.cpp directly.

Link ${LIBATOMIC} into those four targets and correct the muleappcore comment, which claimed amulegui inherited it transitively. The variable is empty on 64-bit targets, so nothing changes there.