### PR TITLE
feat(web-ui): download the log as plain text, one line per line

### DIFF
--- a/src/webapi/static/css/app.css
+++ b/src/webapi/static/css/app.css
@@ -597,17 +597,22 @@ table.data.virtual td.name .name-select { width: 100%; max-width: 100%; }
 .prefs-actions { justify-content: center; }
 
 /* --- log/pre views --- */
-.logbox-wrap { position: relative; }
-.logbox-clear {
+.logbox-wrap { position: relative; min-width: 0; }
+/* Floats over the box's top-right corner to save vertical space; opaque so the
+   unwrapped lines scrolling underneath stay hidden. */
+.logbox-actions {
   position: absolute; top: 8px; right: 8px; z-index: 1;
+  display: flex; gap: 6px; padding: 4px; border-radius: var(--radius);
+  background: var(--surface-2);
 }
 .logbox {
   background: var(--surface-2); color: var(--text); border: 1px solid var(--border);
   font-family: var(--mono); font-size: 12.5px;
   padding: 12px; border-radius: var(--radius); overflow: auto; max-height: 30vh;
-  white-space: pre-wrap; word-break: break-word; margin: 0;
+  white-space: pre; margin: 0;
 }
 .logbox-sm { max-height: 22vh; }
+.logbox-err { white-space: pre-wrap; overflow-wrap: anywhere; }
 /* keep the box's line-height (and padding) when there is no log content yet */
 .logbox:empty::before { content: "\00a0"; }
 
@@ -680,8 +685,9 @@ table.data.virtual td.name .name-select { width: 100%; max-width: 100%; }
    dragging the splitter would just move empty space. */
 .net-split .net-pane:last-child { flex: none; min-height: 0; }
 .net-split .net-pane:last-child .net-pane-body { flex: 1 1 auto; min-height: 0; display: flex; flex-direction: column; }
-/* Column so the <pre> is stretched to the wrapper width (cross axis) and wraps,
-   instead of a flex row where it keeps its longest-line width and overflows. */
+/* Column so the <pre> is stretched to the wrapper width (cross axis) and
+   scrolls its long lines, instead of a flex row where it would keep its
+   longest-line width and overflow the pane. */
 .net-split .logbox-wrap { flex: 1 1 auto; min-height: 0; display: flex; flex-direction: column; }
 .net-split .logbox { flex: 1 1 auto; max-height: none; min-height: 0; }
 /* Kad tab graph fills the top pane so it grows/shrinks with the splitter

--- a/src/webapi/static/i18n/en.json
+++ b/src/webapi/static/i18n/en.json
@@ -166,6 +166,7 @@
   "networks_log_clear": "Clear",
   "networks_log_confirm_clear_amule": "Clear the aMule log?",
   "networks_log_confirm_clear_serverinfo": "Clear the server-info log?",
+  "networks_log_download": "Download log",
   "networks_log_error": "Error",
   "networks_log_toast_cleared": "Log cleared",
   "search_actions": "Actions",

--- a/src/webapi/static/i18n/es.json
+++ b/src/webapi/static/i18n/es.json
@@ -166,6 +166,7 @@
   "networks_log_clear": "Limpiar",
   "networks_log_confirm_clear_amule": "¿Limpiar el registro de aMule?",
   "networks_log_confirm_clear_serverinfo": "¿Limpiar el registro de info del servidor?",
+  "networks_log_download": "Descargar registro",
   "networks_log_error": "Error",
   "networks_log_toast_cleared": "Registro limpiado",
   "search_actions": "Acciones",

--- a/src/webapi/static/js/icons.js
+++ b/src/webapi/static/js/icons.js
@@ -31,6 +31,7 @@ const ICONS = {
   connect: () => html`<path d="M9 2v6M15 2v6M7 8h10v2a5 5 0 0 1-10 0z"/><path d="M12 15v7"/>`,
   cancel: () => html`<line x1="6" y1="6" x2="18" y2="18"/><line x1="18" y1="6" x2="6" y2="18"/>`,
   remove: () => html`<line x1="6" y1="6" x2="18" y2="18"/><line x1="18" y1="6" x2="6" y2="18"/>`,
+  trash: () => html`<path d="M4 7h16"/><path d="M9 7V5h6v2"/><path d="M6 7l1 13h10l1-13"/>`,
   edit: () => html`<path d="M12 20h9"/><path d="M16.5 3.5a2.1 2.1 0 0 1 3 3L7 19l-4 1 1-4z"/>`,
   copy: () => html`<rect x="9" y="9" width="11" height="11" rx="2"/><path d="M5 15V5a2 2 0 0 1 2-2h10"/>`,
   pause: () => html`<rect x="6" y="5" width="4" height="14" rx="1"/><rect x="14" y="5" width="4" height="14" rx="1"/>`,

--- a/src/webapi/static/js/views/networks.js
+++ b/src/webapi/static/js/views/networks.js
@@ -333,11 +333,30 @@ const append = (box, text) => {
   box.appendChild(document.createTextNode(text));
   if (stick) box.scrollTop = box.scrollHeight;
 };
+const setText = (box, text, isErr) => {
+  box.textContent = text;
+  box.classList.toggle("logbox-err", !!isErr);
+};
 
-function logBox(clear, boxRef, extraCls) {
+const saveText = (name, text) => {
+  const url = URL.createObjectURL(new Blob([text], { type: "text/plain" }));
+  const a = Object.assign(document.createElement("a"), { href: url, download: name });
+  a.click();
+  // Deferred: revoking in the same task can cancel the download.
+  setTimeout(() => URL.revokeObjectURL(url), 0);
+};
+
+function logBox(clear, save, boxRef, extraCls) {
   return html`
     <div class="logbox-wrap">
-      <button class="btn admin-only logbox-clear" onClick=${clear}>${t("networks_log_clear")}</button>
+      <div class="logbox-actions">
+        <button class="btn btn-icon btn-sm" title=${t("networks_log_download")} onClick=${save}>
+          <${Icon} name="downloads" />
+        </button>
+        <button class="btn btn-icon btn-sm admin-only" title=${t("networks_log_clear")} onClick=${clear}>
+          <${Icon} name="trash" />
+        </button>
+      </div>
       <pre class=${"logbox" + (extraCls ? " " + extraCls : "")} ref=${boxRef}></pre>
     </div>`;
 }
@@ -350,13 +369,18 @@ function AmuleLogPanel() {
     try {
       const r = await api.get("logs/amule?tail=" + AMULE_TAIL);
       if (!boxRef.current) return;
-      boxRef.current.textContent = (r.lines || []).join("");
+      setText(boxRef.current, (r.lines || []).join(""));
       boxRef.current.scrollTop = boxRef.current.scrollHeight;
-    } catch (e) { if (boxRef.current) boxRef.current.textContent = terr(e) || t("networks_log_error"); }
+    } catch (e) { if (boxRef.current) setText(boxRef.current, terr(e) || t("networks_log_error"), true); }
   };
   const clear = async () => {
     if (!(await confirmDialog(t("networks_log_confirm_clear_amule")))) return;
-    try { await api.del("logs/amule"); if (boxRef.current) boxRef.current.textContent = ""; toast(t("networks_log_toast_cleared"), "success"); }
+    try { await api.del("logs/amule"); if (boxRef.current) setText(boxRef.current, ""); toast(t("networks_log_toast_cleared"), "success"); }
+    catch (e) { toast(terr(e) || t("networks_log_error"), "error"); }
+  };
+  // No `tail`: the whole history, not just the lines on screen.
+  const save = async () => {
+    try { const r = await api.get("logs/amule"); saveText("amule-log.txt", (r.lines || []).join("")); }
     catch (e) { toast(terr(e) || t("networks_log_error"), "error"); }
   };
 
@@ -372,7 +396,7 @@ function AmuleLogPanel() {
     return () => unsub();
   }, []);
 
-  return logBox(clear, boxRef);
+  return logBox(clear, save, boxRef);
 }
 
 // No SSE channel for this one — polled.
@@ -383,13 +407,17 @@ function ServerInfoPanel() {
     try {
       const r = await api.get("logs/serverinfo");
       if (!boxRef.current) return;
-      boxRef.current.textContent = r.text || "";
+      setText(boxRef.current, r.text || "");
       boxRef.current.scrollTop = boxRef.current.scrollHeight;
-    } catch (e) { if (boxRef.current) boxRef.current.textContent = terr(e) || t("networks_log_error"); }
+    } catch (e) { if (boxRef.current) setText(boxRef.current, terr(e) || t("networks_log_error"), true); }
   };
   const clear = async () => {
     if (!(await confirmDialog(t("networks_log_confirm_clear_serverinfo")))) return;
-    try { await api.del("logs/serverinfo"); if (boxRef.current) boxRef.current.textContent = ""; toast(t("networks_log_toast_cleared"), "success"); }
+    try { await api.del("logs/serverinfo"); if (boxRef.current) setText(boxRef.current, ""); toast(t("networks_log_toast_cleared"), "success"); }
+    catch (e) { toast(terr(e) || t("networks_log_error"), "error"); }
+  };
+  const save = async () => {
+    try { const r = await api.get("logs/serverinfo"); saveText("server-info.txt", r.text || ""); }
     catch (e) { toast(terr(e) || t("networks_log_error"), "error"); }
   };
 
@@ -399,7 +427,7 @@ function ServerInfoPanel() {
     return () => clearInterval(timer);
   }, []);
 
-  return logBox(clear, boxRef, "logbox-sm");
+  return logBox(clear, save, boxRef, "logbox-sm");
 }
 
 // --- bottom tabs: per-network info grids ---------------------------------


### PR DESCRIPTION
The log panels on the Networks page only offered a text-labelled Clear button, and their < pre> wrapped long lines over several visual rows, which made timestamps and columns hard to follow.

- logBox() now renders two icon-only buttons floating over the box's top-right corner, each with a title and an aria-label: download (reuses the existing 'downloads' icon) and clear (new 'trash' icon). Clear keeps admin-only; guests may still save the log.
- Saving needs no new endpoint or request: the panel text is already in the DOM, so it goes out as a Blob through a synthetic <a download>, named amule-log.txt / server-info.txt.
- .logbox drops white-space: pre-wrap and word-break, so one log line is one screen line; the box's own overflow: auto supplies the horizontal scroll and the page body never scrolls sideways. The floating action bar is opaque so the lines scrolling underneath stay hidden.
- New i18n key networks_log_download (en/es); networks_log_clear is reused as the clear button's tooltip and alt text.

Checked on desktop (1440px) and an emulated 390x844 phone: both tabs, the guest role, the confirm dialog and a clean console.