### PR TITLE
fix(amulegui): drop stale search results when the core restarts

### DIFF
--- a/src/SearchDlg.cpp
+++ b/src/SearchDlg.cpp
@@ -600,6 +600,20 @@ void CSearchDlg::OnSearchTypeChanged(wxCommandEvent &WXUNUSED(evt))
 	}
 }
 
+void CSearchDlg::ResetResultViews()
+{
+	for (size_t i = 0; i < m_notebook->GetPageCount(); ++i) {
+		CSearchListCtrl *page = dynamic_cast<CSearchListCtrl *>(m_notebook->GetPage(i));
+		if (page == nullptr) {
+			continue;
+		}
+		// Re-show the id the tab already has: same tab, same search, but the
+		// model reloads from the index rather than keeping items that no
+		// longer point at anything.
+		page->ShowResults(page->GetSearchId());
+	}
+}
+
 CSearchListCtrl *CSearchDlg::GetSearchList(wxUIntPtr id)
 {
 	int nPages = m_notebook->GetPageCount();

--- a/src/SearchDlg.h
+++ b/src/SearchDlg.h
@@ -142,6 +142,16 @@ public:
 
 	CSearchListCtrl *GetSearchList(wxUIntPtr id);
 
+	// Drop every open tab's rows, keeping the tabs themselves.
+	//
+	// For a reconnect to a RESTARTED daemon: the stored searches come back
+	// under their original ids, so the tabs still correspond to something --
+	// but every result behind them has been freed, and a tab's rows are raw
+	// CSearchFile pointers (a wxDataViewItem IS the pointer). Resetting the
+	// models makes them re-read the now-empty index instead of painting
+	// through pointers the search list just deleted.
+	void ResetResultViews();
+
 	// Multi-search (remote GUI): remap a tab's search ID from the optimistic
 	// local ID to the daemon-allocated one once the START reply arrives.
 	void RekeySearch(wxUIntPtr oldID, wxUIntPtr newID);

--- a/src/amule-remote-gui.cpp
+++ b/src/amule-remote-gui.cpp
@@ -970,6 +970,29 @@ void CamuleRemoteGuiApp::FinishReconnect(int result)
 			if (friendlist) {
 				friendlist->ResetForNewSession();
 			}
+			if (searchlist) {
+				// Searches survive a restart -- amuled persists them and
+				// re-registers each restored one, so the daemon hands the
+				// same results back under their original search ids. What
+				// does NOT survive is the per-result ECID: the counter
+				// restarts with the process, so every restored result
+				// arrives as an id this client has never seen and is added
+				// alongside the copy it already holds.
+				//
+				// Nothing reaps the stale copy on its own. The search list
+				// deletes only on an explicit EC_TAG_FILE_REMOVED tombstone
+				// (it opted out of the base class's absence sweep so an idle
+				// search costs no traffic), and a daemon that has just
+				// started never emits a tombstone for an ECID it never knew
+				// about. Both copies therefore stay -- issue #1101, where
+				// every result appears twice after a restart.
+				searchlist->ResetForNewSession();
+				if (amuledlg && amuledlg->m_searchwnd) {
+					// Frees every result, so the tabs must drop their rows
+					// before anything repaints through them.
+					amuledlg->m_searchwnd->ResetResultViews();
+				}
+			}
 		} else if (knownfiles) {
 			// Same daemon: the next full poll reconciles every list against
 			// the fresh snapshot in place (update / add / prune) — no wipe,


### PR DESCRIPTION
Fixes #1101.

Reconnecting to a **restarted** daemon left every search result in the tab twice, and "Hide Known Files" stopped applying to the duplicates.

## Why

The GUI already knows how to handle a restarted core. `EC_TAG_SESSION_ID` tells it the process changed, and the comment at that check states the principle:

> Everything we hold is keyed by ECID, and an ECID only means something within one daemon process… we cannot trust a single ID we hold, and starting over is the only correct answer.

It then resets **knownfiles, clients, servers, friends** — and the search list was never added to that list. Three things make that the one omission that produces visible duplicates:

1. **Searches survive a restart.** amuled persists them (`StoredSearches.met`, #641 Phase 3) and `RegisterRestoredSearch()` re-exposes each one, so the daemon really does hand the same results back — under their **original search ids**. `LoadSearches()` uses the persisted id verbatim (`m_searchStrings[entry.id]`, `root->m_searchID = entry.id`) and then reserves it against the fresh counters, precisely so a restored search cannot collide with the first new one of the session.
2. **The per-result ECID does not survive.** `CECID` hands ids out from a counter that restarts with the process, so every restored result arrives bearing an id this client has never seen, and is added alongside the copy it already holds.
3. **Nothing reaps the stale copy.** `CSearchListRem::ProcessUpdate` deletes only on an explicit `EC_TAG_FILE_REMOVED` tombstone — it opted out of the base class's absence-implies-deletion sweep so an idle search costs no traffic — and a daemon that has just started never emits a tombstone for an ECID it never knew about.

So both copies stay. The other lists don't show it precisely because they *are* reset.

## The change

Reset the search list alongside the others.

Because that frees every result, and a tab's rows are raw `CSearchFile` pointers — a `wxDataViewItem` **is** the pointer — the tabs have to drop their rows before anything repaints through them. `CSearchDlg::ResetResultViews()` re-shows each tab's own id so its model reloads from the now-empty index.

**The tabs themselves stay.** The restored searches kept their ids, so the tabs still correspond to something real, and the next poll repopulates them — a restarted daemon holds no per-connection sent-state, so that first poll sends every result. The legacy path (a daemon without partial-update support) re-sends unconditionally anyway.

This should also resolve the second symptom: the entries "Hide Known Files" was failing to hide were the pre-restart copies, whose known/downloaded status was computed against the old session and which nothing refreshes. `LoadSearches()` recomputes it for the restored copies.

## Testing

Builds clean for monolithic and amulegui; clang-format and clang-tidy Tier-2 clean with 0 compiler errors. No new strings.
