### PR TITLE
fix(core): bound the wait for an ed2k search's server answer

### DIFF
--- a/po/amule.pot
+++ b/po/amule.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 11:28+0200\n"
+"POT-Creation-Date: 2026-08-24 12:18+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -6374,6 +6374,10 @@ msgstr ""
 
 #: src/SearchList.cpp
 msgid "Unexpected error while attempting Kad search: "
+msgstr ""
+
+#: src/SearchList.cpp
+msgid "Search timed out: the server did not answer."
 msgstr ""
 
 #: src/SearchList.cpp

--- a/po/ar.po
+++ b/po/ar.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 11:28+0200\n"
+"POT-Creation-Date: 2026-08-24 12:18+0200\n"
 "PO-Revision-Date: 2026-08-22 15:09+0000\n"
 "Last-Translator: saleh alhathal <hathalsal@hotmail.com>\n"
 "Language-Team: \n"
@@ -6477,6 +6477,10 @@ msgstr ""
 
 #: src/SearchList.cpp
 msgid "Unexpected error while attempting Kad search: "
+msgstr ""
+
+#: src/SearchList.cpp
+msgid "Search timed out: the server did not answer."
 msgstr ""
 
 #: src/SearchList.cpp

--- a/po/ast.po
+++ b/po/ast.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 11:28+0200\n"
+"POT-Creation-Date: 2026-08-24 12:18+0200\n"
 "PO-Revision-Date: 2026-08-22 15:11+0000\n"
 "Last-Translator: astur <malditoastur@gmail.com>\n"
 "Language-Team: Language ast <malditoastur@gmail.com>\n"
@@ -6598,6 +6598,10 @@ msgstr "Pallabra clave pa gueta: %s"
 #: src/SearchList.cpp
 msgid "Unexpected error while attempting Kad search: "
 msgstr "Fallu non esperáu mentantu tentaba guetar en Kad: "
+
+#: src/SearchList.cpp
+msgid "Search timed out: the server did not answer."
+msgstr ""
 
 #: src/SearchList.cpp
 msgid "Kad search: requested wider results from one more peer."

--- a/po/bg.po
+++ b/po/bg.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 11:28+0200\n"
+"POT-Creation-Date: 2026-08-24 12:18+0200\n"
 "PO-Revision-Date: 2026-08-22 15:15+0000\n"
 "Last-Translator: Sebastiano Pistore <SebastianoPistore.info@protonmail.ch>\n"
 "Language-Team: Bulgarian <dict@linux.zonebg.com>\n"
@@ -6453,6 +6453,10 @@ msgstr ""
 
 #: src/SearchList.cpp
 msgid "Unexpected error while attempting Kad search: "
+msgstr ""
+
+#: src/SearchList.cpp
+msgid "Search timed out: the server did not answer."
 msgstr ""
 
 #: src/SearchList.cpp

--- a/po/bn.po
+++ b/po/bn.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 11:28+0200\n"
+"POT-Creation-Date: 2026-08-24 12:18+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -6373,6 +6373,10 @@ msgstr ""
 
 #: src/SearchList.cpp
 msgid "Unexpected error while attempting Kad search: "
+msgstr ""
+
+#: src/SearchList.cpp
+msgid "Search timed out: the server did not answer."
 msgstr ""
 
 #: src/SearchList.cpp

--- a/po/ca.po
+++ b/po/ca.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 11:28+0200\n"
+"POT-Creation-Date: 2026-08-24 12:18+0200\n"
 "PO-Revision-Date: 2026-08-22 15:16+0000\n"
 "Last-Translator: minterior <minterior@gmail.com>\n"
 "Language-Team: Català\n"
@@ -6570,6 +6570,10 @@ msgstr "No hi ha cap paraula clau per a la cerca Kad - s'està avortant"
 #: src/SearchList.cpp
 msgid "Unexpected error while attempting Kad search: "
 msgstr "Error inesperat mentre s'intentava fer una cerca Kad: "
+
+#: src/SearchList.cpp
+msgid "Search timed out: the server did not answer."
+msgstr ""
 
 #: src/SearchList.cpp
 msgid "Kad search: requested wider results from one more peer."

--- a/po/cs.po
+++ b/po/cs.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 11:28+0200\n"
+"POT-Creation-Date: 2026-08-24 12:18+0200\n"
 "PO-Revision-Date: 2026-08-22 15:58+0000\n"
 "Last-Translator: David Watzke <david@watzke.cz>\n"
 "Language-Team: cs <cs@li.org>\n"
@@ -6558,6 +6558,10 @@ msgstr ""
 #: src/SearchList.cpp
 msgid "Unexpected error while attempting Kad search: "
 msgstr "Neočekávaná chyba během vyhledávání v síti Kad: "
+
+#: src/SearchList.cpp
+msgid "Search timed out: the server did not answer."
+msgstr ""
 
 #: src/SearchList.cpp
 msgid "Kad search: requested wider results from one more peer."

--- a/po/da.po
+++ b/po/da.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 11:28+0200\n"
+"POT-Creation-Date: 2026-08-24 12:18+0200\n"
 "PO-Revision-Date: 2026-08-22 15:22+0000\n"
 "Last-Translator: Alex Thomsen Leth <alexl@stofanet.dk>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -6495,6 +6495,10 @@ msgstr ""
 
 #: src/SearchList.cpp
 msgid "Unexpected error while attempting Kad search: "
+msgstr ""
+
+#: src/SearchList.cpp
+msgid "Search timed out: the server did not answer."
 msgstr ""
 
 #: src/SearchList.cpp

--- a/po/de.po
+++ b/po/de.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 11:28+0200\n"
+"POT-Creation-Date: 2026-08-24 12:18+0200\n"
 "PO-Revision-Date: 2026-08-22 15:23+0000\n"
 "Last-Translator: Werner Mahr <werner@vollstreckernet.de>\n"
 "Language-Team: German <>\n"
@@ -6566,6 +6566,10 @@ msgstr "Kein Schlüsselwort für Kad-Suche – abgebrochen"
 #: src/SearchList.cpp
 msgid "Unexpected error while attempting Kad search: "
 msgstr "Unerwarteter Fehler bei der Kad-Suche:"
+
+#: src/SearchList.cpp
+msgid "Search timed out: the server did not answer."
+msgstr ""
 
 #: src/SearchList.cpp
 msgid "Kad search: requested wider results from one more peer."

--- a/po/el.po
+++ b/po/el.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 11:28+0200\n"
+"POT-Creation-Date: 2026-08-24 12:18+0200\n"
 "PO-Revision-Date: 2026-08-22 15:25+0000\n"
 "Last-Translator: Dimitris <dgalanak@yahoo.com>\n"
 "Language-Team: Greek\n"
@@ -6610,6 +6610,10 @@ msgstr ""
 #: src/SearchList.cpp
 msgid "Unexpected error while attempting Kad search: "
 msgstr "Άγνωστο σφάλμα όταν έγινε απόπειρα αναζήτησης στο Kad:"
+
+#: src/SearchList.cpp
+msgid "Search timed out: the server did not answer."
+msgstr ""
 
 #: src/SearchList.cpp
 msgid "Kad search: requested wider results from one more peer."

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 11:28+0200\n"
+"POT-Creation-Date: 2026-08-24 12:18+0200\n"
 "PO-Revision-Date: 2020-03-04 14:43+0100\n"
 "Last-Translator: Dévai Tamás <devait@vnet.hu>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -6374,6 +6374,10 @@ msgstr ""
 
 #: src/SearchList.cpp
 msgid "Unexpected error while attempting Kad search: "
+msgstr ""
+
+#: src/SearchList.cpp
+msgid "Search timed out: the server did not answer."
 msgstr ""
 
 #: src/SearchList.cpp

--- a/po/es.po
+++ b/po/es.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 11:28+0200\n"
+"POT-Creation-Date: 2026-08-24 12:18+0200\n"
 "PO-Revision-Date: 2026-08-22 15:26+0000\n"
 "Last-Translator: Diego Heras <ngosang@hotmail.es>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/amule/amule-application/es/>\n"
@@ -6523,6 +6523,10 @@ msgstr "No hay ninguna palabra para buscar con Kad - cancelada"
 #: src/SearchList.cpp
 msgid "Unexpected error while attempting Kad search: "
 msgstr "Error imprevisto al intentar la búsqueda en Kad: "
+
+#: src/SearchList.cpp
+msgid "Search timed out: the server did not answer."
+msgstr ""
 
 #: src/SearchList.cpp
 msgid "Kad search: requested wider results from one more peer."

--- a/po/et_EE.po
+++ b/po/et_EE.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 11:28+0200\n"
+"POT-Creation-Date: 2026-08-24 12:18+0200\n"
 "PO-Revision-Date: 2026-08-22 15:27+0000\n"
 "Last-Translator: \n"
 "Language-Team: Estonian <kde-i18n-doc@kde.org>\n"
@@ -6574,6 +6574,10 @@ msgstr "Otsingu märksõna: %s"
 #: src/SearchList.cpp
 msgid "Unexpected error while attempting Kad search: "
 msgstr "Ootamatu viga proovides Kad otsingut: "
+
+#: src/SearchList.cpp
+msgid "Search timed out: the server did not answer."
+msgstr ""
 
 #: src/SearchList.cpp
 msgid "Kad search: requested wider results from one more peer."

--- a/po/eu.po
+++ b/po/eu.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 11:28+0200\n"
+"POT-Creation-Date: 2026-08-24 12:18+0200\n"
 "PO-Revision-Date: 2026-08-22 15:28+0000\n"
 "Last-Translator: Piarres Beobide <pi@beobide.net>\n"
 "Language-Team: Euskara <librezale@librezale.org>\n"
@@ -6573,6 +6573,10 @@ msgstr "Bilatzeko gakoa: %s"
 #: src/SearchList.cpp
 msgid "Unexpected error while attempting Kad search: "
 msgstr "Espero gabeko errorea Kad bilaketa egitean: "
+
+#: src/SearchList.cpp
+msgid "Search timed out: the server did not answer."
+msgstr ""
 
 #: src/SearchList.cpp
 msgid "Kad search: requested wider results from one more peer."

--- a/po/fi.po
+++ b/po/fi.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 11:28+0200\n"
+"POT-Creation-Date: 2026-08-24 12:18+0200\n"
 "PO-Revision-Date: 2026-08-22 15:29+0000\n"
 "Last-Translator: Tapio Rantala <tapio.rantala@iki.fi>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -6573,6 +6573,10 @@ msgstr "Avainsana hakuun: %s"
 #: src/SearchList.cpp
 msgid "Unexpected error while attempting Kad search: "
 msgstr "Odottamaton virhe Kad-hakua tehtäessä: "
+
+#: src/SearchList.cpp
+msgid "Search timed out: the server did not answer."
+msgstr ""
 
 #: src/SearchList.cpp
 msgid "Kad search: requested wider results from one more peer."

--- a/po/fr.po
+++ b/po/fr.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 11:28+0200\n"
+"POT-Creation-Date: 2026-08-24 12:18+0200\n"
 "PO-Revision-Date: 2026-08-22 15:30+0000\n"
 "Last-Translator: Dylan Aïssi <bob.dybian@gmail.com>\n"
 "Language-Team: Français\n"
@@ -6518,6 +6518,10 @@ msgstr "Pas de mot-clé pour la recherche Kad - abandon"
 #: src/SearchList.cpp
 msgid "Unexpected error while attempting Kad search: "
 msgstr "Erreur imprévue lors de la tentative de recherche Kad : "
+
+#: src/SearchList.cpp
+msgid "Search timed out: the server did not answer."
+msgstr ""
 
 #: src/SearchList.cpp
 msgid "Kad search: requested wider results from one more peer."

--- a/po/gl.po
+++ b/po/gl.po
@@ -24,7 +24,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 11:28+0200\n"
+"POT-Creation-Date: 2026-08-24 12:18+0200\n"
 "PO-Revision-Date: 2026-08-22 15:31+0000\n"
 "Last-Translator: Pablo <parodper@gmail.com>\n"
 "Language-Team: http://forum.amule.org/index.php?topic=13883\n"
@@ -6580,6 +6580,10 @@ msgstr "Ren palabras clave para a busca Kad - interrumpindo"
 #: src/SearchList.cpp
 msgid "Unexpected error while attempting Kad search: "
 msgstr "Ocorreu un erro inesperado tentando buscar en Kad: "
+
+#: src/SearchList.cpp
+msgid "Search timed out: the server did not answer."
+msgstr ""
 
 #: src/SearchList.cpp
 msgid "Kad search: requested wider results from one more peer."

--- a/po/he.po
+++ b/po/he.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 11:28+0200\n"
+"POT-Creation-Date: 2026-08-24 12:18+0200\n"
 "PO-Revision-Date: 2026-08-22 15:32+0000\n"
 "Last-Translator: Peace Kramer <kpeace1@gmail.com>\n"
 "Language-Team: Hebrew\n"
@@ -6537,6 +6537,10 @@ msgstr ""
 #: src/SearchList.cpp
 msgid "Unexpected error while attempting Kad search: "
 msgstr "שגיאה לא צפויה בעת ניסיון ביצוע חיפוש ב קאד: "
+
+#: src/SearchList.cpp
+msgid "Search timed out: the server did not answer."
+msgstr ""
 
 #: src/SearchList.cpp
 msgid "Kad search: requested wider results from one more peer."

--- a/po/hr.po
+++ b/po/hr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 11:28+0200\n"
+"POT-Creation-Date: 2026-08-24 12:18+0200\n"
 "PO-Revision-Date: 2026-08-22 15:32+0000\n"
 "Last-Translator: Sebastiano Pistore <sebastiano.pistore.info@aol.com>\n"
 "Language-Team: https://github.com/amule-org/amule <forum@aMule.org>\n"
@@ -6522,6 +6522,10 @@ msgstr ""
 
 #: src/SearchList.cpp
 msgid "Unexpected error while attempting Kad search: "
+msgstr ""
+
+#: src/SearchList.cpp
+msgid "Search timed out: the server did not answer."
 msgstr ""
 
 #: src/SearchList.cpp

--- a/po/hu.po
+++ b/po/hu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 11:28+0200\n"
+"POT-Creation-Date: 2026-08-24 12:18+0200\n"
 "PO-Revision-Date: 2026-08-22 15:33+0000\n"
 "Last-Translator: Dévai Tamás <gonosztopi@amule.org>\n"
 "Language-Team: Hungarian <hu@li.org>\n"
@@ -6542,6 +6542,10 @@ msgstr "A Kad kereséshez nincs kulcsszó - megszakítva"
 #: src/SearchList.cpp
 msgid "Unexpected error while attempting Kad search: "
 msgstr "Nem várt hiba amíg a Kad kereséssel próbálkoztam: "
+
+#: src/SearchList.cpp
+msgid "Search timed out: the server did not answer."
+msgstr ""
 
 #: src/SearchList.cpp
 msgid "Kad search: requested wider results from one more peer."

--- a/po/it.po
+++ b/po/it.po
@@ -19,7 +19,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule 2.3.3\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 11:28+0200\n"
+"POT-Creation-Date: 2026-08-24 12:18+0200\n"
 "PO-Revision-Date: 2026-08-22 15:34+0000\n"
 "Last-Translator: got3nks <got3nks@users.noreply.github.com>\n"
 "Language-Team: SebastianoPistore.info@protonmail.ch\n"
@@ -6525,6 +6525,10 @@ msgstr "Nessuna chiave di ricerca per Kad - interruzione in corso"
 #: src/SearchList.cpp
 msgid "Unexpected error while attempting Kad search: "
 msgstr "Errore imprevisto durante la ricerca su Kad: "
+
+#: src/SearchList.cpp
+msgid "Search timed out: the server did not answer."
+msgstr ""
 
 #: src/SearchList.cpp
 msgid "Kad search: requested wider results from one more peer."

--- a/po/ja.po
+++ b/po/ja.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 11:28+0200\n"
+"POT-Creation-Date: 2026-08-24 12:18+0200\n"
 "PO-Revision-Date: 2026-08-22 15:35+0000\n"
 "Last-Translator: \n"
 "Language-Team: Japanese\n"
@@ -6564,6 +6564,10 @@ msgstr ""
 #: src/SearchList.cpp
 msgid "Unexpected error while attempting Kad search: "
 msgstr "Kadを検索する間に不明なエラーが発生しました： "
+
+#: src/SearchList.cpp
+msgid "Search timed out: the server did not answer."
+msgstr ""
 
 #: src/SearchList.cpp
 msgid "Kad search: requested wider results from one more peer."

--- a/po/ko_KR.po
+++ b/po/ko_KR.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 11:28+0200\n"
+"POT-Creation-Date: 2026-08-24 12:18+0200\n"
 "PO-Revision-Date: 2026-08-22 15:36+0000\n"
 "Last-Translator: Hyunju Kang <rexington@gmail.com>\n"
 "Language-Team: Korean <hoenny@daum.net>\n"
@@ -6601,6 +6601,10 @@ msgstr ""
 #: src/SearchList.cpp
 msgid "Unexpected error while attempting Kad search: "
 msgstr "Kad 검색 시도 중에 예기치 못한 에러: "
+
+#: src/SearchList.cpp
+msgid "Search timed out: the server did not answer."
+msgstr ""
 
 #: src/SearchList.cpp
 msgid "Kad search: requested wider results from one more peer."

--- a/po/lt.po
+++ b/po/lt.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 11:28+0200\n"
+"POT-Creation-Date: 2026-08-24 12:18+0200\n"
 "PO-Revision-Date: 2026-08-22 15:37+0000\n"
 "Last-Translator: Dovydas Sankauskas <laisve@gmail.com>\n"
 "Language-Team: Lithuanian <komp_lt@konf.lt>\n"
@@ -6630,6 +6630,10 @@ msgstr ""
 #: src/SearchList.cpp
 msgid "Unexpected error while attempting Kad search: "
 msgstr "Vykdant Kademlia paiešką įvyko netikėta klaida: "
+
+#: src/SearchList.cpp
+msgid "Search timed out: the server did not answer."
+msgstr ""
 
 #: src/SearchList.cpp
 msgid "Kad search: requested wider results from one more peer."

--- a/po/lv.po
+++ b/po/lv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 11:28+0200\n"
+"POT-Creation-Date: 2026-08-24 12:18+0200\n"
 "PO-Revision-Date: 2026-08-22 15:53+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -6414,6 +6414,10 @@ msgstr ""
 
 #: src/SearchList.cpp
 msgid "Unexpected error while attempting Kad search: "
+msgstr ""
+
+#: src/SearchList.cpp
+msgid "Search timed out: the server did not answer."
 msgstr ""
 
 #: src/SearchList.cpp

--- a/po/nl.po
+++ b/po/nl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 11:28+0200\n"
+"POT-Creation-Date: 2026-08-24 12:18+0200\n"
 "PO-Revision-Date: 2026-08-22 15:38+0000\n"
 "Last-Translator: Marcel Pol <marcel@timelord.nl>\n"
 "Language-Team: Dutch <nl@li.org>\n"
@@ -6516,6 +6516,10 @@ msgstr "Geen zoekwoord opgegeven voor zoeken in Kad - afbreken"
 #: src/SearchList.cpp
 msgid "Unexpected error while attempting Kad search: "
 msgstr "Onverwachte fout bij Kad-zoekopdracht: "
+
+#: src/SearchList.cpp
+msgid "Search timed out: the server did not answer."
+msgstr ""
 
 #: src/SearchList.cpp
 msgid "Kad search: requested wider results from one more peer."

--- a/po/nn.po
+++ b/po/nn.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 11:28+0200\n"
+"POT-Creation-Date: 2026-08-24 12:18+0200\n"
 "PO-Revision-Date: 2026-08-22 15:39+0000\n"
 "Last-Translator: Hallvor Brunstad <Hallvor_1976@yahoo.com>\n"
 "Language-Team: <i18n-nn@lister.ping.uio.no>\n"
@@ -6603,6 +6603,10 @@ msgstr ""
 #: src/SearchList.cpp
 msgid "Unexpected error while attempting Kad search: "
 msgstr "Uventa feil oppstod under søk på Kad: "
+
+#: src/SearchList.cpp
+msgid "Search timed out: the server did not answer."
+msgstr ""
 
 #: src/SearchList.cpp
 msgid "Kad search: requested wider results from one more peer."

--- a/po/pl.po
+++ b/po/pl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 11:28+0200\n"
+"POT-Creation-Date: 2026-08-24 12:18+0200\n"
 "PO-Revision-Date: 2026-08-22 15:39+0000\n"
 "Last-Translator: Michał Trzebiatowski <hippie_1968@hotmail.com>\n"
 "Language-Team: translationproject.org/team/pl.html <translation-team-pl@lists.sourceforge.net>\n"
@@ -6610,6 +6610,10 @@ msgstr "Słowa kluczowe dla wyszukiwania: %s"
 #: src/SearchList.cpp
 msgid "Unexpected error while attempting Kad search: "
 msgstr "Nieoczekiwany błąd podczas próby wyszukiwania Kad: "
+
+#: src/SearchList.cpp
+msgid "Search timed out: the server did not answer."
+msgstr ""
 
 #: src/SearchList.cpp
 msgid "Kad search: requested wider results from one more peer."

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 11:28+0200\n"
+"POT-Creation-Date: 2026-08-24 12:18+0200\n"
 "PO-Revision-Date: 2026-08-22 15:41+0000\n"
 "Last-Translator: Marcelo Jimenez <mroberto@users.sourceforge.com>\n"
 "Language-Team: Português (Brasileiro) <pt@li.org>\n"
@@ -6519,6 +6519,10 @@ msgstr "Sem palavra-chave para busca Kad - interrompendo"
 #: src/SearchList.cpp
 msgid "Unexpected error while attempting Kad search: "
 msgstr "Erro inesperado quando tentava fazer a busca do Kad: "
+
+#: src/SearchList.cpp
+msgid "Search timed out: the server did not answer."
+msgstr ""
 
 #: src/SearchList.cpp
 msgid "Kad search: requested wider results from one more peer."

--- a/po/pt_PT.po
+++ b/po/pt_PT.po
@@ -17,7 +17,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 11:28+0200\n"
+"POT-Creation-Date: 2026-08-24 12:18+0200\n"
 "PO-Revision-Date: 2026-08-22 15:42+0000\n"
 "Last-Translator: Luís Picciochi Oliveira <Pitxyoki@Gmail.com>\n"
 "Language-Team: Portuguese <traduz@debianpt.org>\n"
@@ -6581,6 +6581,10 @@ msgstr "Palavra-chave para pesquisa: %s"
 #: src/SearchList.cpp
 msgid "Unexpected error while attempting Kad search: "
 msgstr "Erro inesperado enquanto tentava pesquisar na Kad: "
+
+#: src/SearchList.cpp
+msgid "Search timed out: the server did not answer."
+msgstr ""
 
 #: src/SearchList.cpp
 msgid "Kad search: requested wider results from one more peer."

--- a/po/ro.po
+++ b/po/ro.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 11:28+0200\n"
+"POT-Creation-Date: 2026-08-24 12:18+0200\n"
 "PO-Revision-Date: 2026-08-22 15:42+0000\n"
 "Last-Translator: Angelescu Constantin <titus0818@yahoo.com>\n"
 "Language-Team: English <kde-i18n-doc@kde.org>\n"
@@ -6593,6 +6593,10 @@ msgstr "Cuvinte cheie de căutat: %s"
 #: src/SearchList.cpp
 msgid "Unexpected error while attempting Kad search: "
 msgstr "Eroare neașteptată în timp ce se încerca o căutare Kad:"
+
+#: src/SearchList.cpp
+msgid "Search timed out: the server did not answer."
+msgstr ""
 
 #: src/SearchList.cpp
 msgid "Kad search: requested wider results from one more peer."

--- a/po/ru.po
+++ b/po/ru.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 11:28+0200\n"
+"POT-Creation-Date: 2026-08-24 12:18+0200\n"
 "PO-Revision-Date: 2026-08-22 15:44+0000\n"
 "Last-Translator: Radist Morse <radist.morse@gmail.com>\n"
 "Language-Team: Russian <kde-russian@lists.kde.ru>\n"
@@ -6572,6 +6572,10 @@ msgstr "Нет ключевого слова для поиска Kad — отм�
 #: src/SearchList.cpp
 msgid "Unexpected error while attempting Kad search: "
 msgstr "Ошибка при поиске через Kad: "
+
+#: src/SearchList.cpp
+msgid "Search timed out: the server did not answer."
+msgstr ""
 
 #: src/SearchList.cpp
 msgid "Kad search: requested wider results from one more peer."

--- a/po/sl.po
+++ b/po/sl.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 11:28+0200\n"
+"POT-Creation-Date: 2026-08-24 12:18+0200\n"
 "PO-Revision-Date: 2026-08-22 15:45+0000\n"
 "Last-Translator: Jure Repinc <jlp@holodeck1.com>\n"
 "Language-Team: Slovenian\n"
@@ -6632,6 +6632,10 @@ msgstr "Brez ključne besede za iskanje – prekinjam"
 #: src/SearchList.cpp
 msgid "Unexpected error while attempting Kad search: "
 msgstr "Nepričakovana napaka med iskanjem Kad: "
+
+#: src/SearchList.cpp
+msgid "Search timed out: the server did not answer."
+msgstr ""
 
 #: src/SearchList.cpp
 msgid "Kad search: requested wider results from one more peer."

--- a/po/sq.po
+++ b/po/sq.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 11:28+0200\n"
+"POT-Creation-Date: 2026-08-24 12:18+0200\n"
 "PO-Revision-Date: 2026-08-22 15:45+0000\n"
 "Last-Translator: Fation <dj_barthezz@linuxmail.org lushnja_corps@hotmail.Language-Team:\n"
 "Language: sq\n"
@@ -6593,6 +6593,10 @@ msgstr ""
 #: src/SearchList.cpp
 msgid "Unexpected error while attempting Kad search: "
 msgstr "Gabim i paparashikuar duke kerkuar Kad: "
+
+#: src/SearchList.cpp
+msgid "Search timed out: the server did not answer."
+msgstr ""
 
 #: src/SearchList.cpp
 msgid "Kad search: requested wider results from one more peer."

--- a/po/sv.po
+++ b/po/sv.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 11:28+0200\n"
+"POT-Creation-Date: 2026-08-24 12:18+0200\n"
 "PO-Revision-Date: 2026-08-22 15:46+0000\n"
 "Last-Translator: raffe <raffe@localhost.se>\n"
 "Language-Team: Swedish <tp-sv@listor.tp-sv.se>\n"
@@ -6569,6 +6569,10 @@ msgstr "Sökord för sökning: %s"
 #: src/SearchList.cpp
 msgid "Unexpected error while attempting Kad search: "
 msgstr "Oväntat fel vid försöket med Kadsökningen: "
+
+#: src/SearchList.cpp
+msgid "Search timed out: the server did not answer."
+msgstr ""
 
 #: src/SearchList.cpp
 msgid "Kad search: requested wider results from one more peer."

--- a/po/ta.po
+++ b/po/ta.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 11:28+0200\n"
+"POT-Creation-Date: 2026-08-24 12:18+0200\n"
 "PO-Revision-Date: 2026-08-22 15:54+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -6373,6 +6373,10 @@ msgstr ""
 
 #: src/SearchList.cpp
 msgid "Unexpected error while attempting Kad search: "
+msgstr ""
+
+#: src/SearchList.cpp
+msgid "Search timed out: the server did not answer."
 msgstr ""
 
 #: src/SearchList.cpp

--- a/po/tr.po
+++ b/po/tr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 11:28+0200\n"
+"POT-Creation-Date: 2026-08-24 12:18+0200\n"
 "PO-Revision-Date: 2026-08-22 15:48+0000\n"
 "Last-Translator: \n"
 "Language-Team: Turkish <li@li.org>\n"
@@ -6511,6 +6511,10 @@ msgstr "Kad araması için anahtar kelime yok - iptal ediliyor"
 #: src/SearchList.cpp
 msgid "Unexpected error while attempting Kad search: "
 msgstr "Kad araması sırasında beklenilmeyen hata oluştu. "
+
+#: src/SearchList.cpp
+msgid "Search timed out: the server did not answer."
+msgstr ""
 
 #: src/SearchList.cpp
 msgid "Kad search: requested wider results from one more peer."

--- a/po/uk.po
+++ b/po/uk.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 11:28+0200\n"
+"POT-Creation-Date: 2026-08-24 12:18+0200\n"
 "PO-Revision-Date: 2026-08-22 15:48+0000\n"
 "Last-Translator: Oleksandr Kovalenko <alx.kovalenko@gmail.com>\n"
 "Language-Team: Ukrainian <translation@linux.org.ua>\n"
@@ -6634,6 +6634,10 @@ msgstr "Ключове слово для пошуку: %s"
 #: src/SearchList.cpp
 msgid "Unexpected error while attempting Kad search: "
 msgstr "Неочікувана помилка, коли намагаюсь шукати в Kad:"
+
+#: src/SearchList.cpp
+msgid "Search timed out: the server did not answer."
+msgstr ""
 
 #: src/SearchList.cpp
 msgid "Kad search: requested wider results from one more peer."

--- a/po/vi.po
+++ b/po/vi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 11:28+0200\n"
+"POT-Creation-Date: 2026-08-24 12:18+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -6368,6 +6368,10 @@ msgstr ""
 
 #: src/SearchList.cpp
 msgid "Unexpected error while attempting Kad search: "
+msgstr ""
+
+#: src/SearchList.cpp
+msgid "Search timed out: the server did not answer."
 msgstr ""
 
 #: src/SearchList.cpp

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 11:28+0200\n"
+"POT-Creation-Date: 2026-08-24 12:18+0200\n"
 "PO-Revision-Date: 2026-08-22 15:50+0000\n"
 "Last-Translator: Mike Akiba <mike2718@gmail.com>\n"
 "Language-Team: Chinese Simplified <kde-i18n-doc@kde.org>\n"
@@ -6515,6 +6515,10 @@ msgstr "Kad 搜索没有关键字 - 中止"
 #: src/SearchList.cpp
 msgid "Unexpected error while attempting Kad search: "
 msgstr "尝试Kad搜索时出现未预料的错误： "
+
+#: src/SearchList.cpp
+msgid "Search timed out: the server did not answer."
+msgstr ""
 
 #: src/SearchList.cpp
 msgid "Kad search: requested wider results from one more peer."

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 11:28+0200\n"
+"POT-Creation-Date: 2026-08-24 12:18+0200\n"
 "PO-Revision-Date: 2026-08-22 15:51+0000\n"
 "Last-Translator: Wayne Su <mstarmstar@gmail.com>\n"
 "Language-Team: \n"
@@ -6551,6 +6551,10 @@ msgstr "搜尋的關鍵字：%s "
 #: src/SearchList.cpp
 msgid "Unexpected error while attempting Kad search: "
 msgstr "試圖 Kad 搜尋時發生無法預料的錯誤："
+
+#: src/SearchList.cpp
+msgid "Search timed out: the server did not answer."
+msgstr ""
 
 #: src/SearchList.cpp
 msgid "Kad search: requested wider results from one more peer."

--- a/src/SearchList.cpp
+++ b/src/SearchList.cpp
@@ -281,6 +281,7 @@ CSearchList::CSearchList()
 , m_64bitSearchPacket(false)
 , m_KadSearchFinished(true)
 , m_ed2kSearchFinished(true)
+, m_awaitingServerAnswer(false)
 , m_searchStart(0)
 , m_shuttingDown(false)
 {
@@ -692,6 +693,12 @@ wxString CSearchList::StartNewSearch(uint32 *searchID, SearchType type, CSearchP
 		theStats::AddUpOverheadServer(searchPacket->GetPacketSize());
 		theApp->serverconnect->SendPacket(searchPacket, (type == LocalSearch));
 
+		// Bound the wait for the server's answer, for either kind: a local
+		// search has no other terminal path, and a global one's sweep is
+		// armed by the very answer we are waiting for.
+		m_awaitingServerAnswer = true;
+		m_searchTimer.Start(SERVER_ANSWER_TIMEOUT_MS, true /* one shot */);
+
 		if (type == GlobalSearch) {
 			delete m_searchPacket;
 			m_searchPacket = searchPacket;
@@ -729,6 +736,20 @@ wxString CSearchList::StartNewSearch(uint32 *searchID, SearchType type, CSearchP
 
 void CSearchList::LocalSearchEnd()
 {
+	if (!m_searchInProgress) {
+		// Nothing left for this reply to end: the wait for it ran out, or the
+		// search was stopped. Without this, a late answer to a terminalized
+		// global search reaches the wxCHECK_RET below with the packet already
+		// released -- silent under NDEBUG, an assertion in a Debug build.
+		return;
+	}
+
+	// The answer is in; from here the global branch's sweep bounds itself and
+	// the local branch is already terminal, so the one-shot has nothing left
+	// to guard. Cleared before either branch, since the global one restarts
+	// the same timer as the sweep ticker.
+	m_awaitingServerAnswer = false;
+
 	if (m_searchType == GlobalSearch) {
 		wxCHECK_RET(m_searchPacket, "Global search, but no packet");
 
@@ -736,10 +757,19 @@ void CSearchList::LocalSearchEnd()
 		theApp->serverlist->RemoveObserver(&m_serverQueue);
 		m_searchTimer.Start(750);
 	} else {
-		m_searchInProgress = false;
-		m_ed2kSearchFinished = true;
-		Notify_SearchLocalEnd();
+		FinalizeLocalSearch();
 	}
+}
+
+void CSearchList::FinalizeLocalSearch()
+{
+	// Harmless when the server answered in time and the timer never fired;
+	// required when it did not, so the one-shot cannot outlive its search.
+	m_searchTimer.Stop();
+	m_awaitingServerAnswer = false;
+	m_searchInProgress = false;
+	m_ed2kSearchFinished = true;
+	Notify_SearchLocalEnd();
 }
 
 uint32 CSearchList::GetSearchProgress() const
@@ -838,6 +868,23 @@ uint8 CSearchList::GetSearchLifecyclePercent() const
 
 void CSearchList::OnGlobalSearchTimer(CTimerEvent &WXUNUSED(evt))
 {
+	if (m_awaitingServerAnswer && m_searchInProgress) {
+		// The one-shot armed at StartNewSearch: the connected server never
+		// sent OP_SEARCHRESULT, so neither kind of ed2k search has anything
+		// left that would end it. Terminalize through the finalizer the kind
+		// already has rather than leave it reporting RUNNING for good.
+		//
+		// Tested before the packet check below, which a local search would
+		// otherwise fall into: it has no search packet.
+		AddLogLineN(_("Search timed out: the server did not answer."));
+		if (m_searchType == GlobalSearch) {
+			FinalizeGlobalSearch();
+		} else {
+			FinalizeLocalSearch();
+		}
+		return;
+	}
+
 	// Ensure that the server-queue contains the current servers.
 	if (m_searchPacket == NULL) {
 		// This was a pending event, handled after 'Stop' was pressed.
@@ -1017,10 +1064,26 @@ static inline bool IsActiveSearchTypeEd2k(SearchType t)
 	return t == LocalSearch || t == GlobalSearch;
 }
 
+bool CSearchList::CanFileServerAnswer() const
+{
+	// Late server replies keep arriving after a search is over, and where they
+	// may be filed is not the same question as whether the search is still
+	// running. A terminalized search still owns its id -- both the timeout and
+	// the sweep's natural drain leave m_currentSearch alone -- so its results
+	// have a bucket of their own and are worth keeping.
+	//
+	// An explicit stop is what does not: it hands m_currentSearch back to the
+	// sentinel the EC handler pins across all its searches, and filing server
+	// hits there contaminates the bucket StartNewSearch takes care to keep
+	// clean. Test that, rather than m_searchInProgress, so nothing is dropped
+	// that had somewhere to go.
+	return IsActiveSearchTypeEd2k(m_searchType) && m_currentSearch != wxUIntPtr(-1);
+}
+
 void CSearchList::ProcessSearchAnswer(
 	const uint8_t *in_packet, uint32_t size, bool optUTF8, uint32_t serverIP, uint16_t serverPort)
 {
-	if (!IsActiveSearchTypeEd2k(m_searchType)) {
+	if (!CanFileServerAnswer()) {
 		return;
 	}
 	CMemFile packet(in_packet, size);
@@ -1034,7 +1097,7 @@ void CSearchList::ProcessSearchAnswer(
 void CSearchList::ProcessUDPSearchAnswer(
 	const CMemFile &packet, bool optUTF8, uint32_t serverIP, uint16_t serverPort)
 {
-	if (!IsActiveSearchTypeEd2k(m_searchType)) {
+	if (!CanFileServerAnswer()) {
 		return;
 	}
 	AddToList(new CSearchFile(packet, optUTF8, m_currentSearch, serverIP, serverPort), false);
@@ -1274,6 +1337,17 @@ void CSearchList::StopSearch(bool globalOnly)
 	if (m_searchType == GlobalSearch) {
 		FinalizeGlobalSearch();
 		m_currentSearch = -1;
+	} else if (m_searchType == LocalSearch) {
+		// A local search has no sweep to halt, but it does have an armed
+		// answer timeout and an m_searchInProgress that nothing else clears.
+		// Leaving both is what made a stopped local search hang; leaving just
+		// the timer would be worse still, announcing a timeout for a search
+		// the user stopped, against a server that may well have answered.
+		//
+		// Not gated on globalOnly: that spares Kad, and a local search is
+		// ed2k, exactly like the global branch above.
+		FinalizeLocalSearch();
+		m_currentSearch = -1;
 	} else if (m_searchType == KadSearch && !globalOnly) {
 		Kademlia::CSearchManager::StopSearch(m_currentSearch, false);
 		m_currentSearch = -1;
@@ -1447,6 +1521,7 @@ void CSearchList::FinalizeGlobalSearch()
 	m_searchPacket = NULL;
 	m_searchInProgress = false;
 	m_searchTimer.Stop();
+	m_awaitingServerAnswer = false;
 
 	CoreNotify_Search_Update_Progress(0xffff);
 }

--- a/src/SearchList.h
+++ b/src/SearchList.h
@@ -456,6 +456,41 @@ private:
 	void FinalizeGlobalSearch();
 
 	/**
+	 * Shared cleanup for local-search completion, whether the connected
+	 * server answered or the wait for it ran out.
+	 */
+	void FinalizeLocalSearch();
+
+	/**
+	 * Whether a server answer arriving now has a search to be filed under.
+	 *
+	 * Shared by the TCP and UDP result paths so the two cannot drift on what
+	 * counts as filable.
+	 */
+	bool CanFileServerAnswer() const;
+
+	/**
+	 * How long an ed2k search waits for the connected server's
+	 * OP_SEARCHRESULT before it is given up on.
+	 *
+	 * Both kinds need it, for the same reason. A local search has no other
+	 * terminal path at all: the single call to LocalSearchEnd is what ends
+	 * it. A global search does have one -- the sweep drains and calls
+	 * FinalizeGlobalSearch -- but the sweep is armed *by* LocalSearchEnd,
+	 * so until the server answers there is nothing running to bound it
+	 * either. A server that never replies therefore leaves either kind
+	 * RUNNING for as long as it stays the most recent search.
+	 *
+	 * Disconnection does not cover it: CServerConnect passes globalOnly,
+	 * and StopSearch ignores a local search entirely.
+	 *
+	 * Long enough that a slow-but-alive server is not cut off, short enough
+	 * that the progress bar, the Stop button and
+	 * EC_TAG_SEARCH_LIFECYCLE_STATE do not sit wrong for a visible stretch.
+	 */
+	static const int SERVER_ANSWER_TIMEOUT_MS = 12000;
+
+	/**
 	 * Adds the specified file to the current search's results.
 	 *
 	 * @param toadd The result to add.
@@ -534,6 +569,13 @@ private:
 	//! explicit abort). GetSearchLifecycleState uses this as the
 	//! RUNNING vs FINISHED signal for the ED2K branch.
 	bool m_ed2kSearchFinished;
+	/**
+	 * True from an ed2k search going out until the connected server answers.
+	 * Tells OnGlobalSearchTimer whether a tick is the answer-timeout one-shot
+	 * or a sweep tick: m_serverQueue is still inactive on the sweep's first
+	 * tick (that tick is what attaches the observer), so it cannot say.
+	 */
+	bool m_awaitingServerAnswer;
 
 	//! Wall-clock start of the current/last search. Stamped in
 	//! StartNewSearch; feeds the Kad cosmetic progress ramp in


### PR DESCRIPTION
Fixes #1111.

## The gap

Neither kind of ed2k search is bounded before the connected server answers.

`CSearchList::LocalSearchEnd()` has one call site, `ServerSocket.cpp` on `OP_SEARCHRESULT`. It is what clears `m_searchInProgress` for a local search, and what arms the sweep for a global one. A global search's sweep does bound itself - it drains the server queue and calls `FinalizeGlobalSearch()` - but `LocalSearchEnd` is what starts it, so until the answer arrives there is nothing running to bound either kind. `m_searchTimer.Start` appears exactly once on master, downstream of that answer:

```
src/SearchList.cpp:737:		m_searchTimer.Start(750);      <- inside LocalSearchEnd
src/SearchList.cpp:1449:	m_searchTimer.Stop();
```

So a server that never replies, because the connection dropped mid-search or because it simply does not answer, leaves the search `SEARCH_LIFECYCLE_RUNNING` for as long as it stays the most recent one: the progress bar never clears, Stop stays enabled, and `EC_TAG_SEARCH_LIFECYCLE_STATE` reports `running` to amuleapi, amuleweb and amulecmd.

Stopping it does not help either. `StopSearch` handles only `GlobalSearch` and `KadSearch`, so a local search falls through both branches untouched and keeps `m_searchInProgress` set.

## The change

Arm a one-shot when either kind goes out, and terminalize on it through the finalizer that kind already has, so no cleanup is duplicated.

The phase needs its own flag. `!m_serverQueue.IsActive()` looks like the natural discriminator but is also true on the sweep's first tick - that tick is what calls `AddObserver` - so it cannot say whether a tick is the answer timeout or the sweep.

`StopSearch` gains the local branch it never had. Without it a stopped local search simply hung; with a timeout armed and no such branch it would be worse, announcing a timeout twelve seconds later for a search the user stopped, against a server that may well have answered. Not gated on `globalOnly`: that spares Kad, and a local search is ed2k, exactly like the global branch beside it. (`StopSearchById` already covered this, so the gap was only ever in the parameterless form used by the monolithic Stop button and by EC clients that name no id.)

That stop is also what hands `m_currentSearch` back to the sentinel the EC handler pins across all its searches, so late replies to a stopped search would be filed into the bucket `StartNewSearch` takes care to keep clean. Both result paths now test whether the answer has anywhere to go, through one shared predicate so TCP and UDP cannot drift.

This is deliberately not a test of `m_searchInProgress`. A terminalized search still owns its id - neither the timeout nor the sweep's natural drain touches `m_currentSearch` - so its late results still belong somewhere and are kept. Only the sentinel is dropped, which also closes the pre-existing case of a stopped global search, and leaves the UDP tail that keeps arriving after a sweep drains exactly where it belongs.

`LocalSearchEnd` likewise ignores an answer to a search that already ended. Without that, a late answer to a terminalized global search reaches the `wxCHECK_RET` with the packet already released: silent under `NDEBUG`, an assertion in the Debug builds CI runs.

12 s is long enough not to cut off a slow-but-alive server, and short enough that the bar, the Stop button and the lifecycle state do not sit wrong for a visible stretch.

## Verification

Run against live servers with the constant temporarily cut to 50 ms so the timeout wins the race against the reply:

- both kinds terminalize and log `Search timed out: the server did not answer.`
- the late-answer guard is reached in both cases, confirmed with a temporary marker
- a late reply to a timed-out search still lands in its own bucket (75 hits), rather than being discarded
- with the real 12 s value, a normal local search is untouched (73 hits, no timeout, guard not reached)

One of the two servers tried, `eMule Sunrise`, answered nothing at all in 30 s - the failure mode this PR is about, met by accident while testing it.

The parameterless `StopSearch` path is not reachable from a headless daemon (amuleapi always stops by id), so that branch is covered by inspection rather than by a run.

Catalogs regenerated for the new string. Full tree builds clean; clang-format and Tier-2 clang-tidy both clean.
