### PR TITLE
feat(gui): re-extract media metadata from the shared-files context menu

### DIFF
--- a/docs/api/REFERENCE.md
+++ b/docs/api/REFERENCE.md
@@ -1448,7 +1448,7 @@ The same operation for a single file, which is the quickest way to check a fix o
 { "ok": true, "scope": "file", "queued": 1 }
 ```
 
-**Errors:** `404 not_found` (no shared file with that hash), `409 partfile_unsupported` (an incomplete download has no complete file to read), `400 amuled_rejected` (the file is not eligible — its extension is not audio/video), `503 ec_unsupported`, `503 ec_unavailable`.
+**Errors:** `404 not_found` (no shared file with that hash), `409 partfile_unsupported` (an incomplete download has no complete file to read), `400 amuled_rejected` (the file is not eligible: media metadata extraction is disabled in amuled's preferences, the file is not audio/video, or it is an incomplete download), `503 ec_unsupported`, `503 ec_unavailable`.
 
 #### `GET /api/v0/shared/directories`
 

--- a/docs/api/REFERENCE.md
+++ b/docs/api/REFERENCE.md
@@ -1436,7 +1436,9 @@ The work runs on amuled's media-probe worker, one file at a time, so downloads a
 
 Cost is roughly 13 ms per file — a probe reads the container header, not the file — so a 10 000-file library is on the order of two minutes of background work.
 
-**Errors:** `503 ec_unsupported` (the connected amuled predates this operation), `503 ec_unavailable`.
+**Errors:** `400 amuled_rejected` (media metadata extraction is disabled in amuled's preferences), `503 ec_unsupported` (the connected amuled predates this operation), `503 ec_unavailable`.
+
+`queued: 0` means the share held no eligible file, which is a legitimate answer for a share with no audio or video in it. It is no longer how a disabled feature reports itself: that is a `400`, so the two cannot be confused.
 
 #### `POST /api/v0/shared/{hash}/media/refresh`
 
@@ -1448,7 +1450,7 @@ The same operation for a single file, which is the quickest way to check a fix o
 { "ok": true, "scope": "file", "queued": 1 }
 ```
 
-**Errors:** `404 not_found` (no shared file with that hash), `409 partfile_unsupported` (an incomplete download has no complete file to read), `400 amuled_rejected` (the file is not eligible: media metadata extraction is disabled in amuled's preferences, the file is not audio/video, or it is an incomplete download), `503 ec_unsupported`, `503 ec_unavailable`.
+**Errors:** `404 not_found` (no shared file with that hash), `409 partfile_unsupported` (an incomplete download has no complete file to read), `400 amuled_rejected` (media metadata extraction is disabled, or the file is not eligible: not audio/video, or an incomplete download), `503 ec_unsupported`, `503 ec_unavailable`.
 
 #### `GET /api/v0/shared/directories`
 

--- a/po/amule.pot
+++ b/po/amule.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 12:18+0200\n"
+"POT-Creation-Date: 2026-08-24 13:43+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -2143,6 +2143,10 @@ msgstr ""
 
 #: src/ExternalConn.cpp
 msgid "No such chat session"
+msgstr ""
+
+#: src/ExternalConn.cpp
+msgid "Media metadata extraction is disabled in preferences"
 msgstr ""
 
 #: src/ExternalConn.cpp
@@ -7020,6 +7024,10 @@ msgid "No shareable files found in directory: %s"
 msgstr ""
 
 #: src/SharedFileList.cpp
+msgid "Media metadata extraction is disabled in preferences, so there is nothing to re-extract."
+msgstr ""
+
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Re-extracting media metadata for %u shared file"
 msgid_plural "Re-extracting media metadata for %u shared files"
@@ -7110,6 +7118,10 @@ msgid "Verify Local Data"
 msgstr ""
 
 #: src/SharedFilesCtrl.cpp
+msgid "Re-extract &media metadata"
+msgstr ""
+
+#: src/SharedFilesCtrl.cpp
 msgid "Add files in collection to transfer list"
 msgstr ""
 
@@ -7148,6 +7160,49 @@ msgstr ""
 #: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Verify Local Data on PartFile is currently not supported: %s"
+msgstr ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "Media metadata: skipping %u incomplete download"
+msgid_plural "Media metadata: skipping %u incomplete downloads"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "Media metadata: skipping %u file that is not audio or video"
+msgid_plural "Media metadata: skipping %u files that are not audio or video"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "Re-extract media metadata for %u file?"
+msgid_plural "Re-extract media metadata for %u files?"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "%u incomplete download will be skipped."
+msgid_plural "%u incomplete downloads will be skipped."
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "%u file is not audio or video and will be skipped."
+msgid_plural "%u files are not audio or video and will be skipped."
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedFilesCtrl.cpp
+msgid "This runs in the background. Progress is reported in the log."
+msgstr ""
+
+#: src/SharedFilesCtrl.cpp
+msgid "Re-extract media metadata"
 msgstr ""
 
 #: src/SharedFilesCtrl.cpp

--- a/po/ar.po
+++ b/po/ar.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 12:18+0200\n"
+"POT-Creation-Date: 2026-08-24 13:43+0200\n"
 "PO-Revision-Date: 2026-08-22 15:09+0000\n"
 "Last-Translator: saleh alhathal <hathalsal@hotmail.com>\n"
 "Language-Team: \n"
@@ -2182,6 +2182,10 @@ msgstr ""
 
 #: src/ExternalConn.cpp
 msgid "No such chat session"
+msgstr ""
+
+#: src/ExternalConn.cpp
+msgid "Media metadata extraction is disabled in preferences"
 msgstr ""
 
 #: src/ExternalConn.cpp
@@ -7143,6 +7147,10 @@ msgid "No shareable files found in directory: %s"
 msgstr ""
 
 #: src/SharedFileList.cpp
+msgid "Media metadata extraction is disabled in preferences, so there is nothing to re-extract."
+msgstr ""
+
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Re-extracting media metadata for %u shared file"
 msgid_plural "Re-extracting media metadata for %u shared files"
@@ -7239,6 +7247,10 @@ msgid "Verify Local Data"
 msgstr ""
 
 #: src/SharedFilesCtrl.cpp
+msgid "Re-extract &media metadata"
+msgstr ""
+
+#: src/SharedFilesCtrl.cpp
 msgid "Add files in collection to transfer list"
 msgstr ""
 
@@ -7278,6 +7290,49 @@ msgstr ""
 #: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Verify Local Data on PartFile is currently not supported: %s"
+msgstr ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "Media metadata: skipping %u incomplete download"
+msgid_plural "Media metadata: skipping %u incomplete downloads"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "Media metadata: skipping %u file that is not audio or video"
+msgid_plural "Media metadata: skipping %u files that are not audio or video"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "Re-extract media metadata for %u file?"
+msgid_plural "Re-extract media metadata for %u files?"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "%u incomplete download will be skipped."
+msgid_plural "%u incomplete downloads will be skipped."
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "%u file is not audio or video and will be skipped."
+msgid_plural "%u files are not audio or video and will be skipped."
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedFilesCtrl.cpp
+msgid "This runs in the background. Progress is reported in the log."
+msgstr ""
+
+#: src/SharedFilesCtrl.cpp
+msgid "Re-extract media metadata"
 msgstr ""
 
 #: src/SharedFilesCtrl.cpp

--- a/po/ast.po
+++ b/po/ast.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 12:18+0200\n"
+"POT-Creation-Date: 2026-08-24 13:43+0200\n"
 "PO-Revision-Date: 2026-08-22 15:11+0000\n"
 "Last-Translator: astur <malditoastur@gmail.com>\n"
 "Language-Team: Language ast <malditoastur@gmail.com>\n"
@@ -2211,6 +2211,11 @@ msgstr "Aniciada Nueva sesión de charra"
 #, fuzzy
 msgid "No such chat session"
 msgstr "Zarrar esta sesión de charra"
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "Media metadata extraction is disabled in preferences"
+msgstr "Kad ta deshabilitáu n'opciones."
 
 #: src/ExternalConn.cpp
 msgid "File is not eligible for media metadata extraction (not an audio/video file, or an incomplete download)"
@@ -7260,6 +7265,10 @@ msgid "No shareable files found in directory: %s"
 msgstr "Ensin ficheros que compartir en direutoriu: %s"
 
 #: src/SharedFileList.cpp
+msgid "Media metadata extraction is disabled in preferences, so there is nothing to re-extract."
+msgstr ""
+
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Re-extracting media metadata for %u shared file"
 msgid_plural "Re-extracting media metadata for %u shared files"
@@ -7355,6 +7364,10 @@ msgid "Verify Local Data"
 msgstr ""
 
 #: src/SharedFilesCtrl.cpp
+msgid "Re-extract &media metadata"
+msgstr ""
+
+#: src/SharedFilesCtrl.cpp
 msgid "Add files in collection to transfer list"
 msgstr "Amestar ficheros en colleición a la llista de descargues"
 
@@ -7394,6 +7407,49 @@ msgstr ""
 #: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Verify Local Data on PartFile is currently not supported: %s"
+msgstr ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "Media metadata: skipping %u incomplete download"
+msgid_plural "Media metadata: skipping %u incomplete downloads"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "Media metadata: skipping %u file that is not audio or video"
+msgid_plural "Media metadata: skipping %u files that are not audio or video"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "Re-extract media metadata for %u file?"
+msgid_plural "Re-extract media metadata for %u files?"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "%u incomplete download will be skipped."
+msgid_plural "%u incomplete downloads will be skipped."
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "%u file is not audio or video and will be skipped."
+msgid_plural "%u files are not audio or video and will be skipped."
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedFilesCtrl.cpp
+msgid "This runs in the background. Progress is reported in the log."
+msgstr ""
+
+#: src/SharedFilesCtrl.cpp
+msgid "Re-extract media metadata"
 msgstr ""
 
 #: src/SharedFilesCtrl.cpp

--- a/po/bg.po
+++ b/po/bg.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 12:18+0200\n"
+"POT-Creation-Date: 2026-08-24 13:43+0200\n"
 "PO-Revision-Date: 2026-08-22 15:15+0000\n"
 "Last-Translator: Sebastiano Pistore <SebastianoPistore.info@protonmail.ch>\n"
 "Language-Team: Bulgarian <dict@linux.zonebg.com>\n"
@@ -2176,6 +2176,10 @@ msgstr ""
 
 #: src/ExternalConn.cpp
 msgid "No such chat session"
+msgstr ""
+
+#: src/ExternalConn.cpp
+msgid "Media metadata extraction is disabled in preferences"
 msgstr ""
 
 #: src/ExternalConn.cpp
@@ -7117,6 +7121,10 @@ msgid "No shareable files found in directory: %s"
 msgstr ""
 
 #: src/SharedFileList.cpp
+msgid "Media metadata extraction is disabled in preferences, so there is nothing to re-extract."
+msgstr ""
+
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Re-extracting media metadata for %u shared file"
 msgid_plural "Re-extracting media metadata for %u shared files"
@@ -7213,6 +7221,10 @@ msgid "Verify Local Data"
 msgstr ""
 
 #: src/SharedFilesCtrl.cpp
+msgid "Re-extract &media metadata"
+msgstr ""
+
+#: src/SharedFilesCtrl.cpp
 msgid "Add files in collection to transfer list"
 msgstr ""
 
@@ -7252,6 +7264,49 @@ msgstr ""
 #: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Verify Local Data on PartFile is currently not supported: %s"
+msgstr ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "Media metadata: skipping %u incomplete download"
+msgid_plural "Media metadata: skipping %u incomplete downloads"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "Media metadata: skipping %u file that is not audio or video"
+msgid_plural "Media metadata: skipping %u files that are not audio or video"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "Re-extract media metadata for %u file?"
+msgid_plural "Re-extract media metadata for %u files?"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "%u incomplete download will be skipped."
+msgid_plural "%u incomplete downloads will be skipped."
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "%u file is not audio or video and will be skipped."
+msgid_plural "%u files are not audio or video and will be skipped."
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedFilesCtrl.cpp
+msgid "This runs in the background. Progress is reported in the log."
+msgstr ""
+
+#: src/SharedFilesCtrl.cpp
+msgid "Re-extract media metadata"
 msgstr ""
 
 #: src/SharedFilesCtrl.cpp

--- a/po/bn.po
+++ b/po/bn.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 12:18+0200\n"
+"POT-Creation-Date: 2026-08-24 13:43+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -2142,6 +2142,10 @@ msgstr ""
 
 #: src/ExternalConn.cpp
 msgid "No such chat session"
+msgstr ""
+
+#: src/ExternalConn.cpp
+msgid "Media metadata extraction is disabled in preferences"
 msgstr ""
 
 #: src/ExternalConn.cpp
@@ -7019,6 +7023,10 @@ msgid "No shareable files found in directory: %s"
 msgstr ""
 
 #: src/SharedFileList.cpp
+msgid "Media metadata extraction is disabled in preferences, so there is nothing to re-extract."
+msgstr ""
+
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Re-extracting media metadata for %u shared file"
 msgid_plural "Re-extracting media metadata for %u shared files"
@@ -7109,6 +7117,10 @@ msgid "Verify Local Data"
 msgstr ""
 
 #: src/SharedFilesCtrl.cpp
+msgid "Re-extract &media metadata"
+msgstr ""
+
+#: src/SharedFilesCtrl.cpp
 msgid "Add files in collection to transfer list"
 msgstr ""
 
@@ -7147,6 +7159,49 @@ msgstr ""
 #: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Verify Local Data on PartFile is currently not supported: %s"
+msgstr ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "Media metadata: skipping %u incomplete download"
+msgid_plural "Media metadata: skipping %u incomplete downloads"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "Media metadata: skipping %u file that is not audio or video"
+msgid_plural "Media metadata: skipping %u files that are not audio or video"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "Re-extract media metadata for %u file?"
+msgid_plural "Re-extract media metadata for %u files?"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "%u incomplete download will be skipped."
+msgid_plural "%u incomplete downloads will be skipped."
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "%u file is not audio or video and will be skipped."
+msgid_plural "%u files are not audio or video and will be skipped."
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedFilesCtrl.cpp
+msgid "This runs in the background. Progress is reported in the log."
+msgstr ""
+
+#: src/SharedFilesCtrl.cpp
+msgid "Re-extract media metadata"
 msgstr ""
 
 #: src/SharedFilesCtrl.cpp

--- a/po/ca.po
+++ b/po/ca.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 12:18+0200\n"
+"POT-Creation-Date: 2026-08-24 13:43+0200\n"
 "PO-Revision-Date: 2026-08-22 15:16+0000\n"
 "Last-Translator: minterior <minterior@gmail.com>\n"
 "Language-Team: Català\n"
@@ -2204,6 +2204,11 @@ msgstr "Inici d'una nova sessió de xat"
 #, fuzzy
 msgid "No such chat session"
 msgstr "Tanca aquesta sessió de xat."
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "Media metadata extraction is disabled in preferences"
+msgstr "Kad està inhabilitada a les preferències."
 
 #: src/ExternalConn.cpp
 msgid "File is not eligible for media metadata extraction (not an audio/video file, or an incomplete download)"
@@ -7228,6 +7233,10 @@ msgid "No shareable files found in directory: %s"
 msgstr "No s'ha trobat cap fitxer en el directori: %s"
 
 #: src/SharedFileList.cpp
+msgid "Media metadata extraction is disabled in preferences, so there is nothing to re-extract."
+msgstr ""
+
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Re-extracting media metadata for %u shared file"
 msgid_plural "Re-extracting media metadata for %u shared files"
@@ -7318,6 +7327,10 @@ msgid "Verify Local Data"
 msgstr ""
 
 #: src/SharedFilesCtrl.cpp
+msgid "Re-extract &media metadata"
+msgstr ""
+
+#: src/SharedFilesCtrl.cpp
 msgid "Add files in collection to transfer list"
 msgstr "Afegeix els fitxers de la col·lecció a les transferències"
 
@@ -7356,6 +7369,49 @@ msgstr ""
 #: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Verify Local Data on PartFile is currently not supported: %s"
+msgstr ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "Media metadata: skipping %u incomplete download"
+msgid_plural "Media metadata: skipping %u incomplete downloads"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "Media metadata: skipping %u file that is not audio or video"
+msgid_plural "Media metadata: skipping %u files that are not audio or video"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "Re-extract media metadata for %u file?"
+msgid_plural "Re-extract media metadata for %u files?"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "%u incomplete download will be skipped."
+msgid_plural "%u incomplete downloads will be skipped."
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "%u file is not audio or video and will be skipped."
+msgid_plural "%u files are not audio or video and will be skipped."
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedFilesCtrl.cpp
+msgid "This runs in the background. Progress is reported in the log."
+msgstr ""
+
+#: src/SharedFilesCtrl.cpp
+msgid "Re-extract media metadata"
 msgstr ""
 
 #: src/SharedFilesCtrl.cpp

--- a/po/cs.po
+++ b/po/cs.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 12:18+0200\n"
+"POT-Creation-Date: 2026-08-24 13:43+0200\n"
 "PO-Revision-Date: 2026-08-22 15:58+0000\n"
 "Last-Translator: David Watzke <david@watzke.cz>\n"
 "Language-Team: cs <cs@li.org>\n"
@@ -2197,6 +2197,11 @@ msgstr "Zahájeno nové sezení v chatu"
 #, fuzzy
 msgid "No such chat session"
 msgstr "Zavře tento chat."
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "Media metadata extraction is disabled in preferences"
+msgstr "Kad je zakázaný v nastavení."
 
 #: src/ExternalConn.cpp
 msgid "File is not eligible for media metadata extraction (not an audio/video file, or an incomplete download)"
@@ -7226,6 +7231,11 @@ msgid "No shareable files found in directory: %s"
 msgstr ""
 
 #: src/SharedFileList.cpp
+#, fuzzy
+msgid "Media metadata extraction is disabled in preferences, so there is nothing to re-extract."
+msgstr "Extrakce metadat médií"
+
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Re-extracting media metadata for %u shared file"
 msgid_plural "Re-extracting media metadata for %u shared files"
@@ -7323,6 +7333,10 @@ msgid "Verify Local Data"
 msgstr ""
 
 #: src/SharedFilesCtrl.cpp
+msgid "Re-extract &media metadata"
+msgstr ""
+
+#: src/SharedFilesCtrl.cpp
 msgid "Add files in collection to transfer list"
 msgstr ""
 
@@ -7362,6 +7376,54 @@ msgstr ""
 #: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Verify Local Data on PartFile is currently not supported: %s"
+msgstr ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "Media metadata: skipping %u incomplete download"
+msgid_plural "Media metadata: skipping %u incomplete downloads"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "Media metadata: skipping %u file that is not audio or video"
+msgid_plural "Media metadata: skipping %u files that are not audio or video"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "Re-extract media metadata for %u file?"
+msgid_plural "Re-extract media metadata for %u files?"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "%u incomplete download will be skipped."
+msgid_plural "%u incomplete downloads will be skipped."
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "%u file is not audio or video and will be skipped."
+msgid_plural "%u files are not audio or video and will be skipped."
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: src/SharedFilesCtrl.cpp
+msgid "This runs in the background. Progress is reported in the log."
+msgstr ""
+
+#: src/SharedFilesCtrl.cpp
+msgid "Re-extract media metadata"
 msgstr ""
 
 #: src/SharedFilesCtrl.cpp

--- a/po/da.po
+++ b/po/da.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 12:18+0200\n"
+"POT-Creation-Date: 2026-08-24 13:43+0200\n"
 "PO-Revision-Date: 2026-08-22 15:22+0000\n"
 "Last-Translator: Alex Thomsen Leth <alexl@stofanet.dk>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -2187,6 +2187,10 @@ msgstr ""
 
 #: src/ExternalConn.cpp
 msgid "No such chat session"
+msgstr ""
+
+#: src/ExternalConn.cpp
+msgid "Media metadata extraction is disabled in preferences"
 msgstr ""
 
 #: src/ExternalConn.cpp
@@ -7162,6 +7166,10 @@ msgid "No shareable files found in directory: %s"
 msgstr ""
 
 #: src/SharedFileList.cpp
+msgid "Media metadata extraction is disabled in preferences, so there is nothing to re-extract."
+msgstr ""
+
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Re-extracting media metadata for %u shared file"
 msgid_plural "Re-extracting media metadata for %u shared files"
@@ -7258,6 +7266,10 @@ msgid "Verify Local Data"
 msgstr ""
 
 #: src/SharedFilesCtrl.cpp
+msgid "Re-extract &media metadata"
+msgstr ""
+
+#: src/SharedFilesCtrl.cpp
 msgid "Add files in collection to transfer list"
 msgstr "Tilføj filer i samling til overførelses liste"
 
@@ -7297,6 +7309,49 @@ msgstr ""
 #: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Verify Local Data on PartFile is currently not supported: %s"
+msgstr ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "Media metadata: skipping %u incomplete download"
+msgid_plural "Media metadata: skipping %u incomplete downloads"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "Media metadata: skipping %u file that is not audio or video"
+msgid_plural "Media metadata: skipping %u files that are not audio or video"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "Re-extract media metadata for %u file?"
+msgid_plural "Re-extract media metadata for %u files?"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "%u incomplete download will be skipped."
+msgid_plural "%u incomplete downloads will be skipped."
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "%u file is not audio or video and will be skipped."
+msgid_plural "%u files are not audio or video and will be skipped."
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedFilesCtrl.cpp
+msgid "This runs in the background. Progress is reported in the log."
+msgstr ""
+
+#: src/SharedFilesCtrl.cpp
+msgid "Re-extract media metadata"
 msgstr ""
 
 #: src/SharedFilesCtrl.cpp

--- a/po/de.po
+++ b/po/de.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 12:18+0200\n"
+"POT-Creation-Date: 2026-08-24 13:43+0200\n"
 "PO-Revision-Date: 2026-08-22 15:23+0000\n"
 "Last-Translator: Werner Mahr <werner@vollstreckernet.de>\n"
 "Language-Team: German <>\n"
@@ -2209,6 +2209,11 @@ msgstr "Neue Chat-Sitzung gestartet."
 #, fuzzy
 msgid "No such chat session"
 msgstr "Schließe diese Chat-Sitzung."
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "Media metadata extraction is disabled in preferences"
+msgstr "Kad ist in den Einstellungen deaktiviert."
 
 #: src/ExternalConn.cpp
 msgid "File is not eligible for media metadata extraction (not an audio/video file, or an incomplete download)"
@@ -7223,6 +7228,10 @@ msgid "No shareable files found in directory: %s"
 msgstr "Keine freigebbaren Dateien im Ordner gefunden: %s"
 
 #: src/SharedFileList.cpp
+msgid "Media metadata extraction is disabled in preferences, so there is nothing to re-extract."
+msgstr ""
+
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Re-extracting media metadata for %u shared file"
 msgid_plural "Re-extracting media metadata for %u shared files"
@@ -7313,6 +7322,10 @@ msgid "Verify Local Data"
 msgstr ""
 
 #: src/SharedFilesCtrl.cpp
+msgid "Re-extract &media metadata"
+msgstr ""
+
+#: src/SharedFilesCtrl.cpp
 msgid "Add files in collection to transfer list"
 msgstr "Füge Dateien aus Sammlung zur Übertragungsliste"
 
@@ -7351,6 +7364,49 @@ msgstr ""
 #: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Verify Local Data on PartFile is currently not supported: %s"
+msgstr ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "Media metadata: skipping %u incomplete download"
+msgid_plural "Media metadata: skipping %u incomplete downloads"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "Media metadata: skipping %u file that is not audio or video"
+msgid_plural "Media metadata: skipping %u files that are not audio or video"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "Re-extract media metadata for %u file?"
+msgid_plural "Re-extract media metadata for %u files?"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "%u incomplete download will be skipped."
+msgid_plural "%u incomplete downloads will be skipped."
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "%u file is not audio or video and will be skipped."
+msgid_plural "%u files are not audio or video and will be skipped."
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedFilesCtrl.cpp
+msgid "This runs in the background. Progress is reported in the log."
+msgstr ""
+
+#: src/SharedFilesCtrl.cpp
+msgid "Re-extract media metadata"
 msgstr ""
 
 #: src/SharedFilesCtrl.cpp

--- a/po/el.po
+++ b/po/el.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 12:18+0200\n"
+"POT-Creation-Date: 2026-08-24 13:43+0200\n"
 "PO-Revision-Date: 2026-08-22 15:25+0000\n"
 "Last-Translator: Dimitris <dgalanak@yahoo.com>\n"
 "Language-Team: Greek\n"
@@ -2221,6 +2221,11 @@ msgstr "Ξεκίνησε καινούρια περίοδος συνομιλία�
 #, fuzzy
 msgid "No such chat session"
 msgstr "Κλείσιμο της συνομιλίας."
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "Media metadata extraction is disabled in preferences"
+msgstr "Το Kad έχει απενεργοποιηθεί στις προτιμήσεις."
 
 #: src/ExternalConn.cpp
 msgid "File is not eligible for media metadata extraction (not an audio/video file, or an incomplete download)"
@@ -7276,6 +7281,10 @@ msgid "No shareable files found in directory: %s"
 msgstr ""
 
 #: src/SharedFileList.cpp
+msgid "Media metadata extraction is disabled in preferences, so there is nothing to re-extract."
+msgstr ""
+
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Re-extracting media metadata for %u shared file"
 msgid_plural "Re-extracting media metadata for %u shared files"
@@ -7371,6 +7380,10 @@ msgid "Verify Local Data"
 msgstr ""
 
 #: src/SharedFilesCtrl.cpp
+msgid "Re-extract &media metadata"
+msgstr ""
+
+#: src/SharedFilesCtrl.cpp
 msgid "Add files in collection to transfer list"
 msgstr "Προσθήκη των αρχείων της συλλογής στην λίστα με τα μεταφερόμενα"
 
@@ -7410,6 +7423,49 @@ msgstr ""
 #: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Verify Local Data on PartFile is currently not supported: %s"
+msgstr ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "Media metadata: skipping %u incomplete download"
+msgid_plural "Media metadata: skipping %u incomplete downloads"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "Media metadata: skipping %u file that is not audio or video"
+msgid_plural "Media metadata: skipping %u files that are not audio or video"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "Re-extract media metadata for %u file?"
+msgid_plural "Re-extract media metadata for %u files?"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "%u incomplete download will be skipped."
+msgid_plural "%u incomplete downloads will be skipped."
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "%u file is not audio or video and will be skipped."
+msgid_plural "%u files are not audio or video and will be skipped."
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedFilesCtrl.cpp
+msgid "This runs in the background. Progress is reported in the log."
+msgstr ""
+
+#: src/SharedFilesCtrl.cpp
+msgid "Re-extract media metadata"
 msgstr ""
 
 #: src/SharedFilesCtrl.cpp

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 12:18+0200\n"
+"POT-Creation-Date: 2026-08-24 13:43+0200\n"
 "PO-Revision-Date: 2020-03-04 14:43+0100\n"
 "Last-Translator: Dévai Tamás <devait@vnet.hu>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -2143,6 +2143,10 @@ msgstr ""
 
 #: src/ExternalConn.cpp
 msgid "No such chat session"
+msgstr ""
+
+#: src/ExternalConn.cpp
+msgid "Media metadata extraction is disabled in preferences"
 msgstr ""
 
 #: src/ExternalConn.cpp
@@ -7020,6 +7024,10 @@ msgid "No shareable files found in directory: %s"
 msgstr ""
 
 #: src/SharedFileList.cpp
+msgid "Media metadata extraction is disabled in preferences, so there is nothing to re-extract."
+msgstr ""
+
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Re-extracting media metadata for %u shared file"
 msgid_plural "Re-extracting media metadata for %u shared files"
@@ -7110,6 +7118,10 @@ msgid "Verify Local Data"
 msgstr ""
 
 #: src/SharedFilesCtrl.cpp
+msgid "Re-extract &media metadata"
+msgstr ""
+
+#: src/SharedFilesCtrl.cpp
 msgid "Add files in collection to transfer list"
 msgstr ""
 
@@ -7148,6 +7160,49 @@ msgstr ""
 #: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Verify Local Data on PartFile is currently not supported: %s"
+msgstr ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "Media metadata: skipping %u incomplete download"
+msgid_plural "Media metadata: skipping %u incomplete downloads"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "Media metadata: skipping %u file that is not audio or video"
+msgid_plural "Media metadata: skipping %u files that are not audio or video"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "Re-extract media metadata for %u file?"
+msgid_plural "Re-extract media metadata for %u files?"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "%u incomplete download will be skipped."
+msgid_plural "%u incomplete downloads will be skipped."
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "%u file is not audio or video and will be skipped."
+msgid_plural "%u files are not audio or video and will be skipped."
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedFilesCtrl.cpp
+msgid "This runs in the background. Progress is reported in the log."
+msgstr ""
+
+#: src/SharedFilesCtrl.cpp
+msgid "Re-extract media metadata"
 msgstr ""
 
 #: src/SharedFilesCtrl.cpp

--- a/po/es.po
+++ b/po/es.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 12:18+0200\n"
+"POT-Creation-Date: 2026-08-24 13:43+0200\n"
 "PO-Revision-Date: 2026-08-22 15:26+0000\n"
 "Last-Translator: Diego Heras <ngosang@hotmail.es>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/amule/amule-application/es/>\n"
@@ -2196,6 +2196,11 @@ msgstr "Nueva sesión de chat iniciada"
 #, fuzzy
 msgid "No such chat session"
 msgstr "Cerrar esta sesión de chat."
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "Media metadata extraction is disabled in preferences"
+msgstr "Kad está deshabilitado en las preferencias."
 
 #: src/ExternalConn.cpp
 msgid "File is not eligible for media metadata extraction (not an audio/video file, or an incomplete download)"
@@ -7168,6 +7173,11 @@ msgid "No shareable files found in directory: %s"
 msgstr "No se han encontrado archivos para compartir en el directorio: %s"
 
 #: src/SharedFileList.cpp
+#, fuzzy
+msgid "Media metadata extraction is disabled in preferences, so there is nothing to re-extract."
+msgstr "Extracción de metadatos multimedia"
+
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Re-extracting media metadata for %u shared file"
 msgid_plural "Re-extracting media metadata for %u shared files"
@@ -7258,6 +7268,10 @@ msgid "Verify Local Data"
 msgstr "Verificar datos locales"
 
 #: src/SharedFilesCtrl.cpp
+msgid "Re-extract &media metadata"
+msgstr ""
+
+#: src/SharedFilesCtrl.cpp
 msgid "Add files in collection to transfer list"
 msgstr "Añadir los archivos de la colección a la lista de descargas"
 
@@ -7297,6 +7311,49 @@ msgstr "Exportar archivos seleccionados a una Colección de eMule"
 #, c-format
 msgid "Verify Local Data on PartFile is currently not supported: %s"
 msgstr "La verificación de datos locales en archivos de partes no está aún implementada: %s"
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "Media metadata: skipping %u incomplete download"
+msgid_plural "Media metadata: skipping %u incomplete downloads"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "Media metadata: skipping %u file that is not audio or video"
+msgid_plural "Media metadata: skipping %u files that are not audio or video"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "Re-extract media metadata for %u file?"
+msgid_plural "Re-extract media metadata for %u files?"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "%u incomplete download will be skipped."
+msgid_plural "%u incomplete downloads will be skipped."
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "%u file is not audio or video and will be skipped."
+msgid_plural "%u files are not audio or video and will be skipped."
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedFilesCtrl.cpp
+msgid "This runs in the background. Progress is reported in the log."
+msgstr ""
+
+#: src/SharedFilesCtrl.cpp
+msgid "Re-extract media metadata"
+msgstr ""
 
 #: src/SharedFilesCtrl.cpp
 msgid "You need a HighID to create a valid sourcelink"

--- a/po/et_EE.po
+++ b/po/et_EE.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 12:18+0200\n"
+"POT-Creation-Date: 2026-08-24 13:43+0200\n"
 "PO-Revision-Date: 2026-08-22 15:27+0000\n"
 "Last-Translator: \n"
 "Language-Team: Estonian <kde-i18n-doc@kde.org>\n"
@@ -2204,6 +2204,11 @@ msgstr "Uus vestlussession alustatud"
 #, fuzzy
 msgid "No such chat session"
 msgstr "Sulge see vestlus-seanss."
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "Media metadata extraction is disabled in preferences"
+msgstr "Kad on seadetes väljalülitatud."
 
 #: src/ExternalConn.cpp
 msgid "File is not eligible for media metadata extraction (not an audio/video file, or an incomplete download)"
@@ -7234,6 +7239,10 @@ msgid "No shareable files found in directory: %s"
 msgstr "Kataloogis '%s' pole jagatavaid faile"
 
 #: src/SharedFileList.cpp
+msgid "Media metadata extraction is disabled in preferences, so there is nothing to re-extract."
+msgstr ""
+
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Re-extracting media metadata for %u shared file"
 msgid_plural "Re-extracting media metadata for %u shared files"
@@ -7326,6 +7335,10 @@ msgid "Verify Local Data"
 msgstr ""
 
 #: src/SharedFilesCtrl.cpp
+msgid "Re-extract &media metadata"
+msgstr ""
+
+#: src/SharedFilesCtrl.cpp
 msgid "Add files in collection to transfer list"
 msgstr "Lisa failid ülekantavate failide loetellu"
 
@@ -7365,6 +7378,49 @@ msgstr ""
 #: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Verify Local Data on PartFile is currently not supported: %s"
+msgstr ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "Media metadata: skipping %u incomplete download"
+msgid_plural "Media metadata: skipping %u incomplete downloads"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "Media metadata: skipping %u file that is not audio or video"
+msgid_plural "Media metadata: skipping %u files that are not audio or video"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "Re-extract media metadata for %u file?"
+msgid_plural "Re-extract media metadata for %u files?"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "%u incomplete download will be skipped."
+msgid_plural "%u incomplete downloads will be skipped."
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "%u file is not audio or video and will be skipped."
+msgid_plural "%u files are not audio or video and will be skipped."
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedFilesCtrl.cpp
+msgid "This runs in the background. Progress is reported in the log."
+msgstr ""
+
+#: src/SharedFilesCtrl.cpp
+msgid "Re-extract media metadata"
 msgstr ""
 
 #: src/SharedFilesCtrl.cpp

--- a/po/eu.po
+++ b/po/eu.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 12:18+0200\n"
+"POT-Creation-Date: 2026-08-24 13:43+0200\n"
 "PO-Revision-Date: 2026-08-22 15:28+0000\n"
 "Last-Translator: Piarres Beobide <pi@beobide.net>\n"
 "Language-Team: Euskara <librezale@librezale.org>\n"
@@ -2205,6 +2205,11 @@ msgstr "Elkarrizketa saio berria hasia"
 #, fuzzy
 msgid "No such chat session"
 msgstr "Itxi elkarrizketa saio hau."
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "Media metadata extraction is disabled in preferences"
+msgstr "Kad ezgaiturik dago hobespenetan."
 
 #: src/ExternalConn.cpp
 msgid "File is not eligible for media metadata extraction (not an audio/video file, or an incomplete download)"
@@ -7232,6 +7237,10 @@ msgid "No shareable files found in directory: %s"
 msgstr "Ez da partekatu daitekeen fitxategirik direktorioan: %s"
 
 #: src/SharedFileList.cpp
+msgid "Media metadata extraction is disabled in preferences, so there is nothing to re-extract."
+msgstr ""
+
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Re-extracting media metadata for %u shared file"
 msgid_plural "Re-extracting media metadata for %u shared files"
@@ -7322,6 +7331,10 @@ msgid "Verify Local Data"
 msgstr ""
 
 #: src/SharedFilesCtrl.cpp
+msgid "Re-extract &media metadata"
+msgstr ""
+
+#: src/SharedFilesCtrl.cpp
 msgid "Add files in collection to transfer list"
 msgstr "Gehitu fitxategiak bildumara zerrenda bidaltzeko"
 
@@ -7361,6 +7374,49 @@ msgstr ""
 #: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Verify Local Data on PartFile is currently not supported: %s"
+msgstr ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "Media metadata: skipping %u incomplete download"
+msgid_plural "Media metadata: skipping %u incomplete downloads"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "Media metadata: skipping %u file that is not audio or video"
+msgid_plural "Media metadata: skipping %u files that are not audio or video"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "Re-extract media metadata for %u file?"
+msgid_plural "Re-extract media metadata for %u files?"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "%u incomplete download will be skipped."
+msgid_plural "%u incomplete downloads will be skipped."
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "%u file is not audio or video and will be skipped."
+msgid_plural "%u files are not audio or video and will be skipped."
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedFilesCtrl.cpp
+msgid "This runs in the background. Progress is reported in the log."
+msgstr ""
+
+#: src/SharedFilesCtrl.cpp
+msgid "Re-extract media metadata"
 msgstr ""
 
 #: src/SharedFilesCtrl.cpp

--- a/po/fi.po
+++ b/po/fi.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 12:18+0200\n"
+"POT-Creation-Date: 2026-08-24 13:43+0200\n"
 "PO-Revision-Date: 2026-08-22 15:29+0000\n"
 "Last-Translator: Tapio Rantala <tapio.rantala@iki.fi>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -2205,6 +2205,11 @@ msgstr "Uusi keskustelu aloitettu"
 #, fuzzy
 msgid "No such chat session"
 msgstr "Sulje tämä keskustelu."
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "Media metadata extraction is disabled in preferences"
+msgstr "Kad on poistettu päältä asetuksissa."
 
 #: src/ExternalConn.cpp
 msgid "File is not eligible for media metadata extraction (not an audio/video file, or an incomplete download)"
@@ -7232,6 +7237,10 @@ msgid "No shareable files found in directory: %s"
 msgstr "Jaettavia tiedostoja ei löytynyt kansiosta: %s"
 
 #: src/SharedFileList.cpp
+msgid "Media metadata extraction is disabled in preferences, so there is nothing to re-extract."
+msgstr ""
+
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Re-extracting media metadata for %u shared file"
 msgid_plural "Re-extracting media metadata for %u shared files"
@@ -7322,6 +7331,10 @@ msgid "Verify Local Data"
 msgstr ""
 
 #: src/SharedFilesCtrl.cpp
+msgid "Re-extract &media metadata"
+msgstr ""
+
+#: src/SharedFilesCtrl.cpp
 msgid "Add files in collection to transfer list"
 msgstr "Lisää tiedostot kokoelmassa siirtolistalle"
 
@@ -7361,6 +7374,49 @@ msgstr ""
 #: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Verify Local Data on PartFile is currently not supported: %s"
+msgstr ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "Media metadata: skipping %u incomplete download"
+msgid_plural "Media metadata: skipping %u incomplete downloads"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "Media metadata: skipping %u file that is not audio or video"
+msgid_plural "Media metadata: skipping %u files that are not audio or video"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "Re-extract media metadata for %u file?"
+msgid_plural "Re-extract media metadata for %u files?"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "%u incomplete download will be skipped."
+msgid_plural "%u incomplete downloads will be skipped."
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "%u file is not audio or video and will be skipped."
+msgid_plural "%u files are not audio or video and will be skipped."
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedFilesCtrl.cpp
+msgid "This runs in the background. Progress is reported in the log."
+msgstr ""
+
+#: src/SharedFilesCtrl.cpp
+msgid "Re-extract media metadata"
 msgstr ""
 
 #: src/SharedFilesCtrl.cpp

--- a/po/fr.po
+++ b/po/fr.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 12:18+0200\n"
+"POT-Creation-Date: 2026-08-24 13:43+0200\n"
 "PO-Revision-Date: 2026-08-22 15:30+0000\n"
 "Last-Translator: Dylan Aïssi <bob.dybian@gmail.com>\n"
 "Language-Team: Français\n"
@@ -2195,6 +2195,11 @@ msgstr "Nouvelle session de chat démarrée"
 #, fuzzy
 msgid "No such chat session"
 msgstr "Ferme cette session de discussion."
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "Media metadata extraction is disabled in preferences"
+msgstr "Kad est désactivé dans les préférences."
 
 #: src/ExternalConn.cpp
 msgid "File is not eligible for media metadata extraction (not an audio/video file, or an incomplete download)"
@@ -7163,6 +7168,11 @@ msgid "No shareable files found in directory: %s"
 msgstr "Aucun fichier partageable trouvé dans le répertoire : %s"
 
 #: src/SharedFileList.cpp
+#, fuzzy
+msgid "Media metadata extraction is disabled in preferences, so there is nothing to re-extract."
+msgstr "Extraction des métadonnées des médias"
+
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Re-extracting media metadata for %u shared file"
 msgid_plural "Re-extracting media metadata for %u shared files"
@@ -7253,6 +7263,10 @@ msgid "Verify Local Data"
 msgstr "Vérifier les données locales"
 
 #: src/SharedFilesCtrl.cpp
+msgid "Re-extract &media metadata"
+msgstr ""
+
+#: src/SharedFilesCtrl.cpp
 msgid "Add files in collection to transfer list"
 msgstr "Ajouter des fichiers de la collection à la liste de transferts"
 
@@ -7292,6 +7306,49 @@ msgstr "Exporter les fichiers sélectionnés vers une emulecollection"
 #, c-format
 msgid "Verify Local Data on PartFile is currently not supported: %s"
 msgstr "La vérification des données locles sur PartFile n'est actuellement pas prise en charge : %s"
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "Media metadata: skipping %u incomplete download"
+msgid_plural "Media metadata: skipping %u incomplete downloads"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "Media metadata: skipping %u file that is not audio or video"
+msgid_plural "Media metadata: skipping %u files that are not audio or video"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "Re-extract media metadata for %u file?"
+msgid_plural "Re-extract media metadata for %u files?"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "%u incomplete download will be skipped."
+msgid_plural "%u incomplete downloads will be skipped."
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "%u file is not audio or video and will be skipped."
+msgid_plural "%u files are not audio or video and will be skipped."
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedFilesCtrl.cpp
+msgid "This runs in the background. Progress is reported in the log."
+msgstr ""
+
+#: src/SharedFilesCtrl.cpp
+msgid "Re-extract media metadata"
+msgstr ""
 
 #: src/SharedFilesCtrl.cpp
 msgid "You need a HighID to create a valid sourcelink"

--- a/po/gl.po
+++ b/po/gl.po
@@ -24,7 +24,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 12:18+0200\n"
+"POT-Creation-Date: 2026-08-24 13:43+0200\n"
 "PO-Revision-Date: 2026-08-22 15:31+0000\n"
 "Last-Translator: Pablo <parodper@gmail.com>\n"
 "Language-Team: http://forum.amule.org/index.php?topic=13883\n"
@@ -2222,6 +2222,11 @@ msgstr "Comezada nova sesión da conversa"
 #, fuzzy
 msgid "No such chat session"
 msgstr "Pechar esta conversa."
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "Media metadata extraction is disabled in preferences"
+msgstr "Kad está desactivado nas preferencias."
 
 #: src/ExternalConn.cpp
 msgid "File is not eligible for media metadata extraction (not an audio/video file, or an incomplete download)"
@@ -7238,6 +7243,10 @@ msgid "No shareable files found in directory: %s"
 msgstr "Non se atoparon ficheiros que se puideran compartir: %s"
 
 #: src/SharedFileList.cpp
+msgid "Media metadata extraction is disabled in preferences, so there is nothing to re-extract."
+msgstr ""
+
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Re-extracting media metadata for %u shared file"
 msgid_plural "Re-extracting media metadata for %u shared files"
@@ -7328,6 +7337,10 @@ msgid "Verify Local Data"
 msgstr ""
 
 #: src/SharedFilesCtrl.cpp
+msgid "Re-extract &media metadata"
+msgstr ""
+
+#: src/SharedFilesCtrl.cpp
 msgid "Add files in collection to transfer list"
 msgstr "Engadir os ficheiros na colección á lista de transferencia"
 
@@ -7366,6 +7379,49 @@ msgstr ""
 #: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Verify Local Data on PartFile is currently not supported: %s"
+msgstr ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "Media metadata: skipping %u incomplete download"
+msgid_plural "Media metadata: skipping %u incomplete downloads"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "Media metadata: skipping %u file that is not audio or video"
+msgid_plural "Media metadata: skipping %u files that are not audio or video"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "Re-extract media metadata for %u file?"
+msgid_plural "Re-extract media metadata for %u files?"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "%u incomplete download will be skipped."
+msgid_plural "%u incomplete downloads will be skipped."
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "%u file is not audio or video and will be skipped."
+msgid_plural "%u files are not audio or video and will be skipped."
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedFilesCtrl.cpp
+msgid "This runs in the background. Progress is reported in the log."
+msgstr ""
+
+#: src/SharedFilesCtrl.cpp
+msgid "Re-extract media metadata"
 msgstr ""
 
 #: src/SharedFilesCtrl.cpp

--- a/po/he.po
+++ b/po/he.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 12:18+0200\n"
+"POT-Creation-Date: 2026-08-24 13:43+0200\n"
 "PO-Revision-Date: 2026-08-22 15:32+0000\n"
 "Last-Translator: Peace Kramer <kpeace1@gmail.com>\n"
 "Language-Team: Hebrew\n"
@@ -2200,6 +2200,11 @@ msgstr "צ'אט חדש החל."
 #, fuzzy
 msgid "No such chat session"
 msgstr "סגור את הצ'אט הנוכחי."
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "Media metadata extraction is disabled in preferences"
+msgstr "קאד מנוטרל בתוך ההעדפות."
 
 #: src/ExternalConn.cpp
 msgid "File is not eligible for media metadata extraction (not an audio/video file, or an incomplete download)"
@@ -7201,6 +7206,10 @@ msgid "No shareable files found in directory: %s"
 msgstr ""
 
 #: src/SharedFileList.cpp
+msgid "Media metadata extraction is disabled in preferences, so there is nothing to re-extract."
+msgstr ""
+
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Re-extracting media metadata for %u shared file"
 msgid_plural "Re-extracting media metadata for %u shared files"
@@ -7297,6 +7306,10 @@ msgid "Verify Local Data"
 msgstr ""
 
 #: src/SharedFilesCtrl.cpp
+msgid "Re-extract &media metadata"
+msgstr ""
+
+#: src/SharedFilesCtrl.cpp
 msgid "Add files in collection to transfer list"
 msgstr "הוסף קבצים שבאסופה לרשימת המשלוח"
 
@@ -7336,6 +7349,49 @@ msgstr ""
 #: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Verify Local Data on PartFile is currently not supported: %s"
+msgstr ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "Media metadata: skipping %u incomplete download"
+msgid_plural "Media metadata: skipping %u incomplete downloads"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "Media metadata: skipping %u file that is not audio or video"
+msgid_plural "Media metadata: skipping %u files that are not audio or video"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "Re-extract media metadata for %u file?"
+msgid_plural "Re-extract media metadata for %u files?"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "%u incomplete download will be skipped."
+msgid_plural "%u incomplete downloads will be skipped."
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "%u file is not audio or video and will be skipped."
+msgid_plural "%u files are not audio or video and will be skipped."
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedFilesCtrl.cpp
+msgid "This runs in the background. Progress is reported in the log."
+msgstr ""
+
+#: src/SharedFilesCtrl.cpp
+msgid "Re-extract media metadata"
 msgstr ""
 
 #: src/SharedFilesCtrl.cpp

--- a/po/hr.po
+++ b/po/hr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 12:18+0200\n"
+"POT-Creation-Date: 2026-08-24 13:43+0200\n"
 "PO-Revision-Date: 2026-08-22 15:32+0000\n"
 "Last-Translator: Sebastiano Pistore <sebastiano.pistore.info@aol.com>\n"
 "Language-Team: https://github.com/amule-org/amule <forum@aMule.org>\n"
@@ -2195,6 +2195,10 @@ msgstr ""
 
 #: src/ExternalConn.cpp
 msgid "No such chat session"
+msgstr ""
+
+#: src/ExternalConn.cpp
+msgid "Media metadata extraction is disabled in preferences"
 msgstr ""
 
 #: src/ExternalConn.cpp
@@ -7196,6 +7200,10 @@ msgid "No shareable files found in directory: %s"
 msgstr ""
 
 #: src/SharedFileList.cpp
+msgid "Media metadata extraction is disabled in preferences, so there is nothing to re-extract."
+msgstr ""
+
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Re-extracting media metadata for %u shared file"
 msgid_plural "Re-extracting media metadata for %u shared files"
@@ -7296,6 +7304,10 @@ msgid "Verify Local Data"
 msgstr ""
 
 #: src/SharedFilesCtrl.cpp
+msgid "Re-extract &media metadata"
+msgstr ""
+
+#: src/SharedFilesCtrl.cpp
 msgid "Add files in collection to transfer list"
 msgstr ""
 
@@ -7335,6 +7347,54 @@ msgstr ""
 #: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Verify Local Data on PartFile is currently not supported: %s"
+msgstr ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "Media metadata: skipping %u incomplete download"
+msgid_plural "Media metadata: skipping %u incomplete downloads"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "Media metadata: skipping %u file that is not audio or video"
+msgid_plural "Media metadata: skipping %u files that are not audio or video"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "Re-extract media metadata for %u file?"
+msgid_plural "Re-extract media metadata for %u files?"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "%u incomplete download will be skipped."
+msgid_plural "%u incomplete downloads will be skipped."
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "%u file is not audio or video and will be skipped."
+msgid_plural "%u files are not audio or video and will be skipped."
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: src/SharedFilesCtrl.cpp
+msgid "This runs in the background. Progress is reported in the log."
+msgstr ""
+
+#: src/SharedFilesCtrl.cpp
+msgid "Re-extract media metadata"
 msgstr ""
 
 #: src/SharedFilesCtrl.cpp

--- a/po/hu.po
+++ b/po/hu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 12:18+0200\n"
+"POT-Creation-Date: 2026-08-24 13:43+0200\n"
 "PO-Revision-Date: 2026-08-22 15:33+0000\n"
 "Last-Translator: Dévai Tamás <gonosztopi@amule.org>\n"
 "Language-Team: Hungarian <hu@li.org>\n"
@@ -2196,6 +2196,11 @@ msgstr "Új beszélgetés kezdődött"
 #, fuzzy
 msgid "No such chat session"
 msgstr "Csevegési folyamat bezárása."
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "Media metadata extraction is disabled in preferences"
+msgstr "A Kad le van tiltva a beállításokban."
 
 #: src/ExternalConn.cpp
 msgid "File is not eligible for media metadata extraction (not an audio/video file, or an incomplete download)"
@@ -7193,6 +7198,10 @@ msgid "No shareable files found in directory: %s"
 msgstr "Nincsen megosztott fájl ebben a könyvtárban: %s"
 
 #: src/SharedFileList.cpp
+msgid "Media metadata extraction is disabled in preferences, so there is nothing to re-extract."
+msgstr ""
+
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Re-extracting media metadata for %u shared file"
 msgid_plural "Re-extracting media metadata for %u shared files"
@@ -7279,6 +7288,10 @@ msgid "Verify Local Data"
 msgstr ""
 
 #: src/SharedFilesCtrl.cpp
+msgid "Re-extract &media metadata"
+msgstr ""
+
+#: src/SharedFilesCtrl.cpp
 msgid "Add files in collection to transfer list"
 msgstr "Add a gyűjteményben szereplő fájlokat az átviteli listához"
 
@@ -7317,6 +7330,44 @@ msgstr ""
 #: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Verify Local Data on PartFile is currently not supported: %s"
+msgstr ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "Media metadata: skipping %u incomplete download"
+msgid_plural "Media metadata: skipping %u incomplete downloads"
+msgstr[0] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "Media metadata: skipping %u file that is not audio or video"
+msgid_plural "Media metadata: skipping %u files that are not audio or video"
+msgstr[0] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "Re-extract media metadata for %u file?"
+msgid_plural "Re-extract media metadata for %u files?"
+msgstr[0] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "%u incomplete download will be skipped."
+msgid_plural "%u incomplete downloads will be skipped."
+msgstr[0] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "%u file is not audio or video and will be skipped."
+msgid_plural "%u files are not audio or video and will be skipped."
+msgstr[0] ""
+
+#: src/SharedFilesCtrl.cpp
+msgid "This runs in the background. Progress is reported in the log."
+msgstr ""
+
+#: src/SharedFilesCtrl.cpp
+msgid "Re-extract media metadata"
 msgstr ""
 
 #: src/SharedFilesCtrl.cpp

--- a/po/it.po
+++ b/po/it.po
@@ -19,7 +19,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule 2.3.3\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 12:18+0200\n"
+"POT-Creation-Date: 2026-08-24 13:43+0200\n"
 "PO-Revision-Date: 2026-08-22 15:34+0000\n"
 "Last-Translator: got3nks <got3nks@users.noreply.github.com>\n"
 "Language-Team: SebastianoPistore.info@protonmail.ch\n"
@@ -2202,6 +2202,11 @@ msgstr "Nuova sessione chat iniziata"
 #, fuzzy
 msgid "No such chat session"
 msgstr "Chiude questa sessione di chat."
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "Media metadata extraction is disabled in preferences"
+msgstr "La rete Kad è disabilitata nelle Preferenze."
 
 #: src/ExternalConn.cpp
 msgid "File is not eligible for media metadata extraction (not an audio/video file, or an incomplete download)"
@@ -7170,6 +7175,11 @@ msgid "No shareable files found in directory: %s"
 msgstr "Nessun file condivisibile trovato nella cartella: %s"
 
 #: src/SharedFileList.cpp
+#, fuzzy
+msgid "Media metadata extraction is disabled in preferences, so there is nothing to re-extract."
+msgstr "Estrazione dei metadati multimediali"
+
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Re-extracting media metadata for %u shared file"
 msgid_plural "Re-extracting media metadata for %u shared files"
@@ -7260,6 +7270,10 @@ msgid "Verify Local Data"
 msgstr "Verifica Dati Locali"
 
 #: src/SharedFilesCtrl.cpp
+msgid "Re-extract &media metadata"
+msgstr ""
+
+#: src/SharedFilesCtrl.cpp
 msgid "Add files in collection to transfer list"
 msgstr "Aggiungi i file della collezione alla lista dei trasferimenti"
 
@@ -7299,6 +7313,49 @@ msgstr "Esporta i file selezionati in una emulecollection"
 #, c-format
 msgid "Verify Local Data on PartFile is currently not supported: %s"
 msgstr "Verifica Dati Locali su PartFile non è supportato al momento: %s"
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "Media metadata: skipping %u incomplete download"
+msgid_plural "Media metadata: skipping %u incomplete downloads"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "Media metadata: skipping %u file that is not audio or video"
+msgid_plural "Media metadata: skipping %u files that are not audio or video"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "Re-extract media metadata for %u file?"
+msgid_plural "Re-extract media metadata for %u files?"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "%u incomplete download will be skipped."
+msgid_plural "%u incomplete downloads will be skipped."
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "%u file is not audio or video and will be skipped."
+msgid_plural "%u files are not audio or video and will be skipped."
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedFilesCtrl.cpp
+msgid "This runs in the background. Progress is reported in the log."
+msgstr ""
+
+#: src/SharedFilesCtrl.cpp
+msgid "Re-extract media metadata"
+msgstr ""
 
 #: src/SharedFilesCtrl.cpp
 msgid "You need a HighID to create a valid sourcelink"

--- a/po/ja.po
+++ b/po/ja.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 12:18+0200\n"
+"POT-Creation-Date: 2026-08-24 13:43+0200\n"
 "PO-Revision-Date: 2026-08-22 15:35+0000\n"
 "Last-Translator: \n"
 "Language-Team: Japanese\n"
@@ -2207,6 +2207,11 @@ msgstr "新しいチャットセッションの開始"
 #, fuzzy
 msgid "No such chat session"
 msgstr "チャット・セションを閉じます。"
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "Media metadata extraction is disabled in preferences"
+msgstr "Kadは個人設定に無効されています。"
 
 #: src/ExternalConn.cpp
 msgid "File is not eligible for media metadata extraction (not an audio/video file, or an incomplete download)"
@@ -7223,6 +7228,10 @@ msgid "No shareable files found in directory: %s"
 msgstr ""
 
 #: src/SharedFileList.cpp
+msgid "Media metadata extraction is disabled in preferences, so there is nothing to re-extract."
+msgstr ""
+
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Re-extracting media metadata for %u shared file"
 msgid_plural "Re-extracting media metadata for %u shared files"
@@ -7314,6 +7323,10 @@ msgid "Verify Local Data"
 msgstr ""
 
 #: src/SharedFilesCtrl.cpp
+msgid "Re-extract &media metadata"
+msgstr ""
+
+#: src/SharedFilesCtrl.cpp
 msgid "Add files in collection to transfer list"
 msgstr "コレクションに存在するファイルを転送リストに追加する"
 
@@ -7353,6 +7366,44 @@ msgstr ""
 #: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Verify Local Data on PartFile is currently not supported: %s"
+msgstr ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "Media metadata: skipping %u incomplete download"
+msgid_plural "Media metadata: skipping %u incomplete downloads"
+msgstr[0] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "Media metadata: skipping %u file that is not audio or video"
+msgid_plural "Media metadata: skipping %u files that are not audio or video"
+msgstr[0] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "Re-extract media metadata for %u file?"
+msgid_plural "Re-extract media metadata for %u files?"
+msgstr[0] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "%u incomplete download will be skipped."
+msgid_plural "%u incomplete downloads will be skipped."
+msgstr[0] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "%u file is not audio or video and will be skipped."
+msgid_plural "%u files are not audio or video and will be skipped."
+msgstr[0] ""
+
+#: src/SharedFilesCtrl.cpp
+msgid "This runs in the background. Progress is reported in the log."
+msgstr ""
+
+#: src/SharedFilesCtrl.cpp
+msgid "Re-extract media metadata"
 msgstr ""
 
 #: src/SharedFilesCtrl.cpp

--- a/po/ko_KR.po
+++ b/po/ko_KR.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 12:18+0200\n"
+"POT-Creation-Date: 2026-08-24 13:43+0200\n"
 "PO-Revision-Date: 2026-08-22 15:36+0000\n"
 "Last-Translator: Hyunju Kang <rexington@gmail.com>\n"
 "Language-Team: Korean <hoenny@daum.net>\n"
@@ -2218,6 +2218,11 @@ msgstr "프로토콜 버젼 태그 없음"
 #, fuzzy
 msgid "No such chat session"
 msgstr "이 채팅세션을 닫습니다."
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "Media metadata extraction is disabled in preferences"
+msgstr "Kad는 환경설정에서 비활성화되어 있습니다."
 
 #: src/ExternalConn.cpp
 msgid "File is not eligible for media metadata extraction (not an audio/video file, or an incomplete download)"
@@ -7275,6 +7280,10 @@ msgid "No shareable files found in directory: %s"
 msgstr ""
 
 #: src/SharedFileList.cpp
+msgid "Media metadata extraction is disabled in preferences, so there is nothing to re-extract."
+msgstr ""
+
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Re-extracting media metadata for %u shared file"
 msgid_plural "Re-extracting media metadata for %u shared files"
@@ -7370,6 +7379,10 @@ msgid "Verify Local Data"
 msgstr ""
 
 #: src/SharedFilesCtrl.cpp
+msgid "Re-extract &media metadata"
+msgstr ""
+
+#: src/SharedFilesCtrl.cpp
 msgid "Add files in collection to transfer list"
 msgstr "컬렉션내의 파일을 전송목록에 추가"
 
@@ -7409,6 +7422,49 @@ msgstr ""
 #: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Verify Local Data on PartFile is currently not supported: %s"
+msgstr ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "Media metadata: skipping %u incomplete download"
+msgid_plural "Media metadata: skipping %u incomplete downloads"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "Media metadata: skipping %u file that is not audio or video"
+msgid_plural "Media metadata: skipping %u files that are not audio or video"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "Re-extract media metadata for %u file?"
+msgid_plural "Re-extract media metadata for %u files?"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "%u incomplete download will be skipped."
+msgid_plural "%u incomplete downloads will be skipped."
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "%u file is not audio or video and will be skipped."
+msgid_plural "%u files are not audio or video and will be skipped."
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedFilesCtrl.cpp
+msgid "This runs in the background. Progress is reported in the log."
+msgstr ""
+
+#: src/SharedFilesCtrl.cpp
+msgid "Re-extract media metadata"
 msgstr ""
 
 #: src/SharedFilesCtrl.cpp

--- a/po/lt.po
+++ b/po/lt.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 12:18+0200\n"
+"POT-Creation-Date: 2026-08-24 13:43+0200\n"
 "PO-Revision-Date: 2026-08-22 15:37+0000\n"
 "Last-Translator: Dovydas Sankauskas <laisve@gmail.com>\n"
 "Language-Team: Lithuanian <komp_lt@konf.lt>\n"
@@ -2228,6 +2228,11 @@ msgstr "Pradėtas naujas pokalbis"
 #, fuzzy
 msgid "No such chat session"
 msgstr "Baigti pokalbį ir užverti pokalbio kortelę."
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "Media metadata extraction is disabled in preferences"
+msgstr "Kademlia išjungta parinktyse."
 
 #: src/ExternalConn.cpp
 msgid "File is not eligible for media metadata extraction (not an audio/video file, or an incomplete download)"
@@ -7303,6 +7308,10 @@ msgid "No shareable files found in directory: %s"
 msgstr ""
 
 #: src/SharedFileList.cpp
+msgid "Media metadata extraction is disabled in preferences, so there is nothing to re-extract."
+msgstr ""
+
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Re-extracting media metadata for %u shared file"
 msgid_plural "Re-extracting media metadata for %u shared files"
@@ -7402,6 +7411,10 @@ msgid "Verify Local Data"
 msgstr ""
 
 #: src/SharedFilesCtrl.cpp
+msgid "Re-extract &media metadata"
+msgstr ""
+
+#: src/SharedFilesCtrl.cpp
 msgid "Add files in collection to transfer list"
 msgstr "Failus iš kolekcijos įkelti į siuntimo sąrašą"
 
@@ -7441,6 +7454,54 @@ msgstr ""
 #: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Verify Local Data on PartFile is currently not supported: %s"
+msgstr ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "Media metadata: skipping %u incomplete download"
+msgid_plural "Media metadata: skipping %u incomplete downloads"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "Media metadata: skipping %u file that is not audio or video"
+msgid_plural "Media metadata: skipping %u files that are not audio or video"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "Re-extract media metadata for %u file?"
+msgid_plural "Re-extract media metadata for %u files?"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "%u incomplete download will be skipped."
+msgid_plural "%u incomplete downloads will be skipped."
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "%u file is not audio or video and will be skipped."
+msgid_plural "%u files are not audio or video and will be skipped."
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: src/SharedFilesCtrl.cpp
+msgid "This runs in the background. Progress is reported in the log."
+msgstr ""
+
+#: src/SharedFilesCtrl.cpp
+msgid "Re-extract media metadata"
 msgstr ""
 
 #: src/SharedFilesCtrl.cpp

--- a/po/lv.po
+++ b/po/lv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 12:18+0200\n"
+"POT-Creation-Date: 2026-08-24 13:43+0200\n"
 "PO-Revision-Date: 2026-08-22 15:53+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -2162,6 +2162,10 @@ msgstr "Trūkst protokola versijas birka."
 
 #: src/ExternalConn.cpp
 msgid "No such chat session"
+msgstr ""
+
+#: src/ExternalConn.cpp
+msgid "Media metadata extraction is disabled in preferences"
 msgstr ""
 
 #: src/ExternalConn.cpp
@@ -7069,6 +7073,10 @@ msgid "No shareable files found in directory: %s"
 msgstr ""
 
 #: src/SharedFileList.cpp
+msgid "Media metadata extraction is disabled in preferences, so there is nothing to re-extract."
+msgstr ""
+
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Re-extracting media metadata for %u shared file"
 msgid_plural "Re-extracting media metadata for %u shared files"
@@ -7163,6 +7171,10 @@ msgid "Verify Local Data"
 msgstr ""
 
 #: src/SharedFilesCtrl.cpp
+msgid "Re-extract &media metadata"
+msgstr ""
+
+#: src/SharedFilesCtrl.cpp
 msgid "Add files in collection to transfer list"
 msgstr ""
 
@@ -7201,6 +7213,54 @@ msgstr ""
 #: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Verify Local Data on PartFile is currently not supported: %s"
+msgstr ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "Media metadata: skipping %u incomplete download"
+msgid_plural "Media metadata: skipping %u incomplete downloads"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "Media metadata: skipping %u file that is not audio or video"
+msgid_plural "Media metadata: skipping %u files that are not audio or video"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "Re-extract media metadata for %u file?"
+msgid_plural "Re-extract media metadata for %u files?"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "%u incomplete download will be skipped."
+msgid_plural "%u incomplete downloads will be skipped."
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "%u file is not audio or video and will be skipped."
+msgid_plural "%u files are not audio or video and will be skipped."
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: src/SharedFilesCtrl.cpp
+msgid "This runs in the background. Progress is reported in the log."
+msgstr ""
+
+#: src/SharedFilesCtrl.cpp
+msgid "Re-extract media metadata"
 msgstr ""
 
 #: src/SharedFilesCtrl.cpp

--- a/po/nl.po
+++ b/po/nl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 12:18+0200\n"
+"POT-Creation-Date: 2026-08-24 13:43+0200\n"
 "PO-Revision-Date: 2026-08-22 15:38+0000\n"
 "Last-Translator: Marcel Pol <marcel@timelord.nl>\n"
 "Language-Team: Dutch <nl@li.org>\n"
@@ -2192,6 +2192,11 @@ msgstr "Nieuwe chatsessie begonnen"
 #, fuzzy
 msgid "No such chat session"
 msgstr "Sluit deze chat-sessie."
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "Media metadata extraction is disabled in preferences"
+msgstr "Kad is uitgeschakeld in voorkeuren."
 
 #: src/ExternalConn.cpp
 msgid "File is not eligible for media metadata extraction (not an audio/video file, or an incomplete download)"
@@ -7161,6 +7166,11 @@ msgid "No shareable files found in directory: %s"
 msgstr "Geen deelbare bestanden gevonden in map: %s"
 
 #: src/SharedFileList.cpp
+#, fuzzy
+msgid "Media metadata extraction is disabled in preferences, so there is nothing to re-extract."
+msgstr "Extractie van mediametagegevens"
+
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Re-extracting media metadata for %u shared file"
 msgid_plural "Re-extracting media metadata for %u shared files"
@@ -7251,6 +7261,10 @@ msgid "Verify Local Data"
 msgstr "Lokale gegevens verifiëren"
 
 #: src/SharedFilesCtrl.cpp
+msgid "Re-extract &media metadata"
+msgstr ""
+
+#: src/SharedFilesCtrl.cpp
 msgid "Add files in collection to transfer list"
 msgstr "Voeg bestanden in verzameling toe aan overdrachtenlijst"
 
@@ -7290,6 +7304,49 @@ msgstr "Exporteer geselecteerde bestanden naar een emulecollection"
 #, c-format
 msgid "Verify Local Data on PartFile is currently not supported: %s"
 msgstr "Lokale gegevens verifiëren op partbestand wordt momenteel niet ondersteund: %s"
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "Media metadata: skipping %u incomplete download"
+msgid_plural "Media metadata: skipping %u incomplete downloads"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "Media metadata: skipping %u file that is not audio or video"
+msgid_plural "Media metadata: skipping %u files that are not audio or video"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "Re-extract media metadata for %u file?"
+msgid_plural "Re-extract media metadata for %u files?"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "%u incomplete download will be skipped."
+msgid_plural "%u incomplete downloads will be skipped."
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "%u file is not audio or video and will be skipped."
+msgid_plural "%u files are not audio or video and will be skipped."
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedFilesCtrl.cpp
+msgid "This runs in the background. Progress is reported in the log."
+msgstr ""
+
+#: src/SharedFilesCtrl.cpp
+msgid "Re-extract media metadata"
+msgstr ""
 
 #: src/SharedFilesCtrl.cpp
 msgid "You need a HighID to create a valid sourcelink"

--- a/po/nn.po
+++ b/po/nn.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 12:18+0200\n"
+"POT-Creation-Date: 2026-08-24 13:43+0200\n"
 "PO-Revision-Date: 2026-08-22 15:39+0000\n"
 "Last-Translator: Hallvor Brunstad <Hallvor_1976@yahoo.com>\n"
 "Language-Team: <i18n-nn@lister.ping.uio.no>\n"
@@ -2219,6 +2219,11 @@ msgstr "Ny lynmeldingsøkt starta"
 #, fuzzy
 msgid "No such chat session"
 msgstr "Stengje denne lynmeldingsøkta."
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "Media metadata extraction is disabled in preferences"
+msgstr "Kad er deaktivert i innstillingar."
 
 #: src/ExternalConn.cpp
 msgid "File is not eligible for media metadata extraction (not an audio/video file, or an incomplete download)"
@@ -7269,6 +7274,10 @@ msgid "No shareable files found in directory: %s"
 msgstr ""
 
 #: src/SharedFileList.cpp
+msgid "Media metadata extraction is disabled in preferences, so there is nothing to re-extract."
+msgstr ""
+
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Re-extracting media metadata for %u shared file"
 msgid_plural "Re-extracting media metadata for %u shared files"
@@ -7364,6 +7373,10 @@ msgid "Verify Local Data"
 msgstr ""
 
 #: src/SharedFilesCtrl.cpp
+msgid "Re-extract &media metadata"
+msgstr ""
+
+#: src/SharedFilesCtrl.cpp
 msgid "Add files in collection to transfer list"
 msgstr "Legg filer frå samlinga til overføringslista"
 
@@ -7403,6 +7416,49 @@ msgstr ""
 #: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Verify Local Data on PartFile is currently not supported: %s"
+msgstr ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "Media metadata: skipping %u incomplete download"
+msgid_plural "Media metadata: skipping %u incomplete downloads"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "Media metadata: skipping %u file that is not audio or video"
+msgid_plural "Media metadata: skipping %u files that are not audio or video"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "Re-extract media metadata for %u file?"
+msgid_plural "Re-extract media metadata for %u files?"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "%u incomplete download will be skipped."
+msgid_plural "%u incomplete downloads will be skipped."
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "%u file is not audio or video and will be skipped."
+msgid_plural "%u files are not audio or video and will be skipped."
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedFilesCtrl.cpp
+msgid "This runs in the background. Progress is reported in the log."
+msgstr ""
+
+#: src/SharedFilesCtrl.cpp
+msgid "Re-extract media metadata"
 msgstr ""
 
 #: src/SharedFilesCtrl.cpp

--- a/po/pl.po
+++ b/po/pl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 12:18+0200\n"
+"POT-Creation-Date: 2026-08-24 13:43+0200\n"
 "PO-Revision-Date: 2026-08-22 15:39+0000\n"
 "Last-Translator: Michał Trzebiatowski <hippie_1968@hotmail.com>\n"
 "Language-Team: translationproject.org/team/pl.html <translation-team-pl@lists.sourceforge.net>\n"
@@ -2214,6 +2214,11 @@ msgstr "Rozpoczęto nową sesję czatu"
 #, fuzzy
 msgid "No such chat session"
 msgstr "Zamknij tę sesję czata."
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "Media metadata extraction is disabled in preferences"
+msgstr "Kad jest wyłączony w preferencjach."
 
 #: src/ExternalConn.cpp
 msgid "File is not eligible for media metadata extraction (not an audio/video file, or an incomplete download)"
@@ -7278,6 +7283,10 @@ msgid "No shareable files found in directory: %s"
 msgstr "Nie znaleziono plików do udostępniania w katalogu: %s"
 
 #: src/SharedFileList.cpp
+msgid "Media metadata extraction is disabled in preferences, so there is nothing to re-extract."
+msgstr ""
+
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Re-extracting media metadata for %u shared file"
 msgid_plural "Re-extracting media metadata for %u shared files"
@@ -7374,6 +7383,10 @@ msgid "Verify Local Data"
 msgstr ""
 
 #: src/SharedFilesCtrl.cpp
+msgid "Re-extract &media metadata"
+msgstr ""
+
+#: src/SharedFilesCtrl.cpp
 msgid "Add files in collection to transfer list"
 msgstr "Dodaj pliki kolekcji do listy pobierania"
 
@@ -7413,6 +7426,54 @@ msgstr ""
 #: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Verify Local Data on PartFile is currently not supported: %s"
+msgstr ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "Media metadata: skipping %u incomplete download"
+msgid_plural "Media metadata: skipping %u incomplete downloads"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "Media metadata: skipping %u file that is not audio or video"
+msgid_plural "Media metadata: skipping %u files that are not audio or video"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "Re-extract media metadata for %u file?"
+msgid_plural "Re-extract media metadata for %u files?"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "%u incomplete download will be skipped."
+msgid_plural "%u incomplete downloads will be skipped."
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "%u file is not audio or video and will be skipped."
+msgid_plural "%u files are not audio or video and will be skipped."
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: src/SharedFilesCtrl.cpp
+msgid "This runs in the background. Progress is reported in the log."
+msgstr ""
+
+#: src/SharedFilesCtrl.cpp
+msgid "Re-extract media metadata"
 msgstr ""
 
 #: src/SharedFilesCtrl.cpp

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 12:18+0200\n"
+"POT-Creation-Date: 2026-08-24 13:43+0200\n"
 "PO-Revision-Date: 2026-08-22 15:41+0000\n"
 "Last-Translator: Marcelo Jimenez <mroberto@users.sourceforge.com>\n"
 "Language-Team: Português (Brasileiro) <pt@li.org>\n"
@@ -2196,6 +2196,11 @@ msgstr "Nova sessão de chat iniciada"
 #, fuzzy
 msgid "No such chat session"
 msgstr "Encerrar sessão de Chat."
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "Media metadata extraction is disabled in preferences"
+msgstr "Kad está desativado nas preferências."
 
 #: src/ExternalConn.cpp
 msgid "File is not eligible for media metadata extraction (not an audio/video file, or an incomplete download)"
@@ -7164,6 +7169,11 @@ msgid "No shareable files found in directory: %s"
 msgstr "Arquivos compartilháveis não encontrado no diretório: %s"
 
 #: src/SharedFileList.cpp
+#, fuzzy
+msgid "Media metadata extraction is disabled in preferences, so there is nothing to re-extract."
+msgstr "Extração de metadados da mídia"
+
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Re-extracting media metadata for %u shared file"
 msgid_plural "Re-extracting media metadata for %u shared files"
@@ -7254,6 +7264,10 @@ msgid "Verify Local Data"
 msgstr "Verificar Dados Locais"
 
 #: src/SharedFilesCtrl.cpp
+msgid "Re-extract &media metadata"
+msgstr ""
+
+#: src/SharedFilesCtrl.cpp
 msgid "Add files in collection to transfer list"
 msgstr "Adicionar arquivo na coleção para lista de transgênica"
 
@@ -7293,6 +7307,49 @@ msgstr "Exportar os arquivos selecionados para uma coleção do eMule"
 #, c-format
 msgid "Verify Local Data on PartFile is currently not supported: %s"
 msgstr "Verificar Dados Locais em PartFile não é atualmente suportado: %s"
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "Media metadata: skipping %u incomplete download"
+msgid_plural "Media metadata: skipping %u incomplete downloads"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "Media metadata: skipping %u file that is not audio or video"
+msgid_plural "Media metadata: skipping %u files that are not audio or video"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "Re-extract media metadata for %u file?"
+msgid_plural "Re-extract media metadata for %u files?"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "%u incomplete download will be skipped."
+msgid_plural "%u incomplete downloads will be skipped."
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "%u file is not audio or video and will be skipped."
+msgid_plural "%u files are not audio or video and will be skipped."
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedFilesCtrl.cpp
+msgid "This runs in the background. Progress is reported in the log."
+msgstr ""
+
+#: src/SharedFilesCtrl.cpp
+msgid "Re-extract media metadata"
+msgstr ""
 
 #: src/SharedFilesCtrl.cpp
 msgid "You need a HighID to create a valid sourcelink"

--- a/po/pt_PT.po
+++ b/po/pt_PT.po
@@ -17,7 +17,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 12:18+0200\n"
+"POT-Creation-Date: 2026-08-24 13:43+0200\n"
 "PO-Revision-Date: 2026-08-22 15:42+0000\n"
 "Last-Translator: Luís Picciochi Oliveira <Pitxyoki@Gmail.com>\n"
 "Language-Team: Portuguese <traduz@debianpt.org>\n"
@@ -2211,6 +2211,11 @@ msgstr "Nova sessão de conversa iniciada"
 #, fuzzy
 msgid "No such chat session"
 msgstr "Fechar esta conversa."
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "Media metadata extraction is disabled in preferences"
+msgstr "A Kad está desactivada nas preferências."
 
 #: src/ExternalConn.cpp
 msgid "File is not eligible for media metadata extraction (not an audio/video file, or an incomplete download)"
@@ -7240,6 +7245,10 @@ msgid "No shareable files found in directory: %s"
 msgstr "Não foram encontrados ficheiros partilhados no directório: %s"
 
 #: src/SharedFileList.cpp
+msgid "Media metadata extraction is disabled in preferences, so there is nothing to re-extract."
+msgstr ""
+
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Re-extracting media metadata for %u shared file"
 msgid_plural "Re-extracting media metadata for %u shared files"
@@ -7330,6 +7339,10 @@ msgid "Verify Local Data"
 msgstr ""
 
 #: src/SharedFilesCtrl.cpp
+msgid "Re-extract &media metadata"
+msgstr ""
+
+#: src/SharedFilesCtrl.cpp
 msgid "Add files in collection to transfer list"
 msgstr "Adicionar ficheiros na colecção à lista de transferências"
 
@@ -7369,6 +7382,49 @@ msgstr ""
 #: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Verify Local Data on PartFile is currently not supported: %s"
+msgstr ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "Media metadata: skipping %u incomplete download"
+msgid_plural "Media metadata: skipping %u incomplete downloads"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "Media metadata: skipping %u file that is not audio or video"
+msgid_plural "Media metadata: skipping %u files that are not audio or video"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "Re-extract media metadata for %u file?"
+msgid_plural "Re-extract media metadata for %u files?"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "%u incomplete download will be skipped."
+msgid_plural "%u incomplete downloads will be skipped."
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "%u file is not audio or video and will be skipped."
+msgid_plural "%u files are not audio or video and will be skipped."
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedFilesCtrl.cpp
+msgid "This runs in the background. Progress is reported in the log."
+msgstr ""
+
+#: src/SharedFilesCtrl.cpp
+msgid "Re-extract media metadata"
 msgstr ""
 
 #: src/SharedFilesCtrl.cpp

--- a/po/ro.po
+++ b/po/ro.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 12:18+0200\n"
+"POT-Creation-Date: 2026-08-24 13:43+0200\n"
 "PO-Revision-Date: 2026-08-22 15:42+0000\n"
 "Last-Translator: Angelescu Constantin <titus0818@yahoo.com>\n"
 "Language-Team: English <kde-i18n-doc@kde.org>\n"
@@ -2211,6 +2211,11 @@ msgstr "O nouă sesiune chat este pornită"
 #, fuzzy
 msgid "No such chat session"
 msgstr "Închide această sesiune de chat."
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "Media metadata extraction is disabled in preferences"
+msgstr "Kad este dezactivat din preferințe."
 
 #: src/ExternalConn.cpp
 msgid "File is not eligible for media metadata extraction (not an audio/video file, or an incomplete download)"
@@ -7259,6 +7264,10 @@ msgid "No shareable files found in directory: %s"
 msgstr "Nu au fost găsite fișiere partajabile în directorul: %s"
 
 #: src/SharedFileList.cpp
+msgid "Media metadata extraction is disabled in preferences, so there is nothing to re-extract."
+msgstr ""
+
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Re-extracting media metadata for %u shared file"
 msgid_plural "Re-extracting media metadata for %u shared files"
@@ -7353,6 +7362,10 @@ msgid "Verify Local Data"
 msgstr ""
 
 #: src/SharedFilesCtrl.cpp
+msgid "Re-extract &media metadata"
+msgstr ""
+
+#: src/SharedFilesCtrl.cpp
 msgid "Add files in collection to transfer list"
 msgstr "Adaugă fișierele în colecție la lista de transfer"
 
@@ -7391,6 +7404,54 @@ msgstr ""
 #: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Verify Local Data on PartFile is currently not supported: %s"
+msgstr ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "Media metadata: skipping %u incomplete download"
+msgid_plural "Media metadata: skipping %u incomplete downloads"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "Media metadata: skipping %u file that is not audio or video"
+msgid_plural "Media metadata: skipping %u files that are not audio or video"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "Re-extract media metadata for %u file?"
+msgid_plural "Re-extract media metadata for %u files?"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "%u incomplete download will be skipped."
+msgid_plural "%u incomplete downloads will be skipped."
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "%u file is not audio or video and will be skipped."
+msgid_plural "%u files are not audio or video and will be skipped."
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: src/SharedFilesCtrl.cpp
+msgid "This runs in the background. Progress is reported in the log."
+msgstr ""
+
+#: src/SharedFilesCtrl.cpp
+msgid "Re-extract media metadata"
 msgstr ""
 
 #: src/SharedFilesCtrl.cpp

--- a/po/ru.po
+++ b/po/ru.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 12:18+0200\n"
+"POT-Creation-Date: 2026-08-24 13:43+0200\n"
 "PO-Revision-Date: 2026-08-22 15:44+0000\n"
 "Last-Translator: Radist Morse <radist.morse@gmail.com>\n"
 "Language-Team: Russian <kde-russian@lists.kde.ru>\n"
@@ -2212,6 +2212,11 @@ msgstr "Начата новая беседа"
 #, fuzzy
 msgid "No such chat session"
 msgstr "Закрыть данный чат."
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "Media metadata extraction is disabled in preferences"
+msgstr "Kad выключена в настройках."
 
 #: src/ExternalConn.cpp
 msgid "File is not eligible for media metadata extraction (not an audio/video file, or an incomplete download)"
@@ -7226,6 +7231,11 @@ msgid "No shareable files found in directory: %s"
 msgstr "Нет публикуемых файлов в директории: %s"
 
 #: src/SharedFileList.cpp
+#, fuzzy
+msgid "Media metadata extraction is disabled in preferences, so there is nothing to re-extract."
+msgstr "Извлечение метаданных медиафайлов"
+
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Re-extracting media metadata for %u shared file"
 msgid_plural "Re-extracting media metadata for %u shared files"
@@ -7322,6 +7332,10 @@ msgid "Verify Local Data"
 msgstr "Проверить локальные данные"
 
 #: src/SharedFilesCtrl.cpp
+msgid "Re-extract &media metadata"
+msgstr ""
+
+#: src/SharedFilesCtrl.cpp
 msgid "Add files in collection to transfer list"
 msgstr "Добавить файлы из коллекции в список передач"
 
@@ -7361,6 +7375,54 @@ msgstr "Экспорт выбранных файлов в коллекцию emu
 #, c-format
 msgid "Verify Local Data on PartFile is currently not supported: %s"
 msgstr "Проверка локальных данных для part-файла в настоящее время не поддерживается: %s"
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "Media metadata: skipping %u incomplete download"
+msgid_plural "Media metadata: skipping %u incomplete downloads"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "Media metadata: skipping %u file that is not audio or video"
+msgid_plural "Media metadata: skipping %u files that are not audio or video"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "Re-extract media metadata for %u file?"
+msgid_plural "Re-extract media metadata for %u files?"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "%u incomplete download will be skipped."
+msgid_plural "%u incomplete downloads will be skipped."
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "%u file is not audio or video and will be skipped."
+msgid_plural "%u files are not audio or video and will be skipped."
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: src/SharedFilesCtrl.cpp
+msgid "This runs in the background. Progress is reported in the log."
+msgstr ""
+
+#: src/SharedFilesCtrl.cpp
+msgid "Re-extract media metadata"
+msgstr ""
 
 #: src/SharedFilesCtrl.cpp
 msgid "You need a HighID to create a valid sourcelink"

--- a/po/sl.po
+++ b/po/sl.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 12:18+0200\n"
+"POT-Creation-Date: 2026-08-24 13:43+0200\n"
 "PO-Revision-Date: 2026-08-22 15:45+0000\n"
 "Last-Translator: Jure Repinc <jlp@holodeck1.com>\n"
 "Language-Team: Slovenian\n"
@@ -2225,6 +2225,11 @@ msgstr "Začeta je bila nova seja klepeta."
 #, fuzzy
 msgid "No such chat session"
 msgstr "Zapri to pogovorno sejo."
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "Media metadata extraction is disabled in preferences"
+msgstr "Kad je onemogočen v nastavitvah."
 
 #: src/ExternalConn.cpp
 msgid "File is not eligible for media metadata extraction (not an audio/video file, or an incomplete download)"
@@ -7305,6 +7310,10 @@ msgid "No shareable files found in directory: %s"
 msgstr "V mapi ni bilo moč najti datotek za deliti: %s"
 
 #: src/SharedFileList.cpp
+msgid "Media metadata extraction is disabled in preferences, so there is nothing to re-extract."
+msgstr ""
+
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Re-extracting media metadata for %u shared file"
 msgid_plural "Re-extracting media metadata for %u shared files"
@@ -7403,6 +7412,10 @@ msgid "Verify Local Data"
 msgstr ""
 
 #: src/SharedFilesCtrl.cpp
+msgid "Re-extract &media metadata"
+msgstr ""
+
+#: src/SharedFilesCtrl.cpp
 msgid "Add files in collection to transfer list"
 msgstr "Dodaj datoteke iz zbirke na seznam prenosov"
 
@@ -7441,6 +7454,59 @@ msgstr ""
 #: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Verify Local Data on PartFile is currently not supported: %s"
+msgstr ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "Media metadata: skipping %u incomplete download"
+msgid_plural "Media metadata: skipping %u incomplete downloads"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+msgstr[3] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "Media metadata: skipping %u file that is not audio or video"
+msgid_plural "Media metadata: skipping %u files that are not audio or video"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+msgstr[3] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "Re-extract media metadata for %u file?"
+msgid_plural "Re-extract media metadata for %u files?"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+msgstr[3] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "%u incomplete download will be skipped."
+msgid_plural "%u incomplete downloads will be skipped."
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+msgstr[3] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "%u file is not audio or video and will be skipped."
+msgid_plural "%u files are not audio or video and will be skipped."
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+msgstr[3] ""
+
+#: src/SharedFilesCtrl.cpp
+msgid "This runs in the background. Progress is reported in the log."
+msgstr ""
+
+#: src/SharedFilesCtrl.cpp
+msgid "Re-extract media metadata"
 msgstr ""
 
 #: src/SharedFilesCtrl.cpp

--- a/po/sq.po
+++ b/po/sq.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 12:18+0200\n"
+"POT-Creation-Date: 2026-08-24 13:43+0200\n"
 "PO-Revision-Date: 2026-08-22 15:45+0000\n"
 "Last-Translator: Fation <dj_barthezz@linuxmail.org lushnja_corps@hotmail.Language-Team:\n"
 "Language: sq\n"
@@ -2214,6 +2214,11 @@ msgstr "Sesion i ri chati filloi"
 #, fuzzy
 msgid "No such chat session"
 msgstr "Mbylle kete sesion chati."
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "Media metadata extraction is disabled in preferences"
+msgstr "Kad-i eshte c'aktivizuar tek Preferencat."
 
 #: src/ExternalConn.cpp
 msgid "File is not eligible for media metadata extraction (not an audio/video file, or an incomplete download)"
@@ -7259,6 +7264,10 @@ msgid "No shareable files found in directory: %s"
 msgstr ""
 
 #: src/SharedFileList.cpp
+msgid "Media metadata extraction is disabled in preferences, so there is nothing to re-extract."
+msgstr ""
+
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Re-extracting media metadata for %u shared file"
 msgid_plural "Re-extracting media metadata for %u shared files"
@@ -7354,6 +7363,10 @@ msgid "Verify Local Data"
 msgstr ""
 
 #: src/SharedFilesCtrl.cpp
+msgid "Re-extract &media metadata"
+msgstr ""
+
+#: src/SharedFilesCtrl.cpp
 msgid "Add files in collection to transfer list"
 msgstr "Shto failet ne koleksionin e listes per transferim"
 
@@ -7393,6 +7406,49 @@ msgstr ""
 #: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Verify Local Data on PartFile is currently not supported: %s"
+msgstr ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "Media metadata: skipping %u incomplete download"
+msgid_plural "Media metadata: skipping %u incomplete downloads"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "Media metadata: skipping %u file that is not audio or video"
+msgid_plural "Media metadata: skipping %u files that are not audio or video"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "Re-extract media metadata for %u file?"
+msgid_plural "Re-extract media metadata for %u files?"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "%u incomplete download will be skipped."
+msgid_plural "%u incomplete downloads will be skipped."
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "%u file is not audio or video and will be skipped."
+msgid_plural "%u files are not audio or video and will be skipped."
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedFilesCtrl.cpp
+msgid "This runs in the background. Progress is reported in the log."
+msgstr ""
+
+#: src/SharedFilesCtrl.cpp
+msgid "Re-extract media metadata"
 msgstr ""
 
 #: src/SharedFilesCtrl.cpp

--- a/po/sv.po
+++ b/po/sv.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 12:18+0200\n"
+"POT-Creation-Date: 2026-08-24 13:43+0200\n"
 "PO-Revision-Date: 2026-08-22 15:46+0000\n"
 "Last-Translator: raffe <raffe@localhost.se>\n"
 "Language-Team: Swedish <tp-sv@listor.tp-sv.se>\n"
@@ -2203,6 +2203,11 @@ msgstr "Ny chatt startad"
 #, fuzzy
 msgid "No such chat session"
 msgstr "Stäng denna chat-session."
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "Media metadata extraction is disabled in preferences"
+msgstr "Kad inaktiverad i inställningarna."
 
 #: src/ExternalConn.cpp
 msgid "File is not eligible for media metadata extraction (not an audio/video file, or an incomplete download)"
@@ -7227,6 +7232,10 @@ msgid "No shareable files found in directory: %s"
 msgstr "Inga delbara filer hittade i mappen: %s"
 
 #: src/SharedFileList.cpp
+msgid "Media metadata extraction is disabled in preferences, so there is nothing to re-extract."
+msgstr ""
+
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Re-extracting media metadata for %u shared file"
 msgid_plural "Re-extracting media metadata for %u shared files"
@@ -7317,6 +7326,10 @@ msgid "Verify Local Data"
 msgstr ""
 
 #: src/SharedFilesCtrl.cpp
+msgid "Re-extract &media metadata"
+msgstr ""
+
+#: src/SharedFilesCtrl.cpp
 msgid "Add files in collection to transfer list"
 msgstr "Lägg till filer i samlingen för att överföringslistan"
 
@@ -7355,6 +7368,49 @@ msgstr ""
 #: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Verify Local Data on PartFile is currently not supported: %s"
+msgstr ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "Media metadata: skipping %u incomplete download"
+msgid_plural "Media metadata: skipping %u incomplete downloads"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "Media metadata: skipping %u file that is not audio or video"
+msgid_plural "Media metadata: skipping %u files that are not audio or video"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "Re-extract media metadata for %u file?"
+msgid_plural "Re-extract media metadata for %u files?"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "%u incomplete download will be skipped."
+msgid_plural "%u incomplete downloads will be skipped."
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "%u file is not audio or video and will be skipped."
+msgid_plural "%u files are not audio or video and will be skipped."
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedFilesCtrl.cpp
+msgid "This runs in the background. Progress is reported in the log."
+msgstr ""
+
+#: src/SharedFilesCtrl.cpp
+msgid "Re-extract media metadata"
 msgstr ""
 
 #: src/SharedFilesCtrl.cpp

--- a/po/ta.po
+++ b/po/ta.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 12:18+0200\n"
+"POT-Creation-Date: 2026-08-24 13:43+0200\n"
 "PO-Revision-Date: 2026-08-22 15:54+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -2142,6 +2142,10 @@ msgstr ""
 
 #: src/ExternalConn.cpp
 msgid "No such chat session"
+msgstr ""
+
+#: src/ExternalConn.cpp
+msgid "Media metadata extraction is disabled in preferences"
 msgstr ""
 
 #: src/ExternalConn.cpp
@@ -7019,6 +7023,10 @@ msgid "No shareable files found in directory: %s"
 msgstr ""
 
 #: src/SharedFileList.cpp
+msgid "Media metadata extraction is disabled in preferences, so there is nothing to re-extract."
+msgstr ""
+
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Re-extracting media metadata for %u shared file"
 msgid_plural "Re-extracting media metadata for %u shared files"
@@ -7109,6 +7117,10 @@ msgid "Verify Local Data"
 msgstr ""
 
 #: src/SharedFilesCtrl.cpp
+msgid "Re-extract &media metadata"
+msgstr ""
+
+#: src/SharedFilesCtrl.cpp
 msgid "Add files in collection to transfer list"
 msgstr ""
 
@@ -7147,6 +7159,49 @@ msgstr ""
 #: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Verify Local Data on PartFile is currently not supported: %s"
+msgstr ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "Media metadata: skipping %u incomplete download"
+msgid_plural "Media metadata: skipping %u incomplete downloads"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "Media metadata: skipping %u file that is not audio or video"
+msgid_plural "Media metadata: skipping %u files that are not audio or video"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "Re-extract media metadata for %u file?"
+msgid_plural "Re-extract media metadata for %u files?"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "%u incomplete download will be skipped."
+msgid_plural "%u incomplete downloads will be skipped."
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "%u file is not audio or video and will be skipped."
+msgid_plural "%u files are not audio or video and will be skipped."
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedFilesCtrl.cpp
+msgid "This runs in the background. Progress is reported in the log."
+msgstr ""
+
+#: src/SharedFilesCtrl.cpp
+msgid "Re-extract media metadata"
 msgstr ""
 
 #: src/SharedFilesCtrl.cpp

--- a/po/tr.po
+++ b/po/tr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 12:18+0200\n"
+"POT-Creation-Date: 2026-08-24 13:43+0200\n"
 "PO-Revision-Date: 2026-08-22 15:48+0000\n"
 "Last-Translator: \n"
 "Language-Team: Turkish <li@li.org>\n"
@@ -2188,6 +2188,11 @@ msgstr "Yeni sohbet oturumu başladı"
 #, fuzzy
 msgid "No such chat session"
 msgstr "Bu sohbet oturumunu kapatır."
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "Media metadata extraction is disabled in preferences"
+msgstr "Kad ayarlarda devre dışı bırakılmış."
 
 #: src/ExternalConn.cpp
 msgid "File is not eligible for media metadata extraction (not an audio/video file, or an incomplete download)"
@@ -7156,6 +7161,11 @@ msgid "No shareable files found in directory: %s"
 msgstr "Dizinde paylaşılabilir dosya bulunamadı: %s"
 
 #: src/SharedFileList.cpp
+#, fuzzy
+msgid "Media metadata extraction is disabled in preferences, so there is nothing to re-extract."
+msgstr "Ortam üst verisi çıkarımı"
+
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Re-extracting media metadata for %u shared file"
 msgid_plural "Re-extracting media metadata for %u shared files"
@@ -7246,6 +7256,10 @@ msgid "Verify Local Data"
 msgstr "Yerel Verileri Kontrol Et"
 
 #: src/SharedFilesCtrl.cpp
+msgid "Re-extract &media metadata"
+msgstr ""
+
+#: src/SharedFilesCtrl.cpp
 msgid "Add files in collection to transfer list"
 msgstr "Koleksiyondaki dosyaları aktarım listesine ekle"
 
@@ -7285,6 +7299,49 @@ msgstr "Seçili dosyaları bir emulecollection dosyasına aktar"
 #, c-format
 msgid "Verify Local Data on PartFile is currently not supported: %s"
 msgstr "PartFile üzerinde Yerel Veri Kontrolü güncel olarak desteklenmemektedir: %s"
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "Media metadata: skipping %u incomplete download"
+msgid_plural "Media metadata: skipping %u incomplete downloads"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "Media metadata: skipping %u file that is not audio or video"
+msgid_plural "Media metadata: skipping %u files that are not audio or video"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "Re-extract media metadata for %u file?"
+msgid_plural "Re-extract media metadata for %u files?"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "%u incomplete download will be skipped."
+msgid_plural "%u incomplete downloads will be skipped."
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "%u file is not audio or video and will be skipped."
+msgid_plural "%u files are not audio or video and will be skipped."
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedFilesCtrl.cpp
+msgid "This runs in the background. Progress is reported in the log."
+msgstr ""
+
+#: src/SharedFilesCtrl.cpp
+msgid "Re-extract media metadata"
+msgstr ""
 
 #: src/SharedFilesCtrl.cpp
 msgid "You need a HighID to create a valid sourcelink"

--- a/po/uk.po
+++ b/po/uk.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 12:18+0200\n"
+"POT-Creation-Date: 2026-08-24 13:43+0200\n"
 "PO-Revision-Date: 2026-08-22 15:48+0000\n"
 "Last-Translator: Oleksandr Kovalenko <alx.kovalenko@gmail.com>\n"
 "Language-Team: Ukrainian <translation@linux.org.ua>\n"
@@ -2224,6 +2224,11 @@ msgstr "Розпочато нову розмову"
 #, fuzzy
 msgid "No such chat session"
 msgstr "Закрити цю розмову."
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "Media metadata extraction is disabled in preferences"
+msgstr "Kad вимкнена в налаштуваннях."
 
 #: src/ExternalConn.cpp
 msgid "File is not eligible for media metadata extraction (not an audio/video file, or an incomplete download)"
@@ -7303,6 +7308,10 @@ msgid "No shareable files found in directory: %s"
 msgstr "Не знайдені спільні файли в теці: %s"
 
 #: src/SharedFileList.cpp
+msgid "Media metadata extraction is disabled in preferences, so there is nothing to re-extract."
+msgstr ""
+
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Re-extracting media metadata for %u shared file"
 msgid_plural "Re-extracting media metadata for %u shared files"
@@ -7402,6 +7411,10 @@ msgid "Verify Local Data"
 msgstr ""
 
 #: src/SharedFilesCtrl.cpp
+msgid "Re-extract &media metadata"
+msgstr ""
+
+#: src/SharedFilesCtrl.cpp
 msgid "Add files in collection to transfer list"
 msgstr "Додати файли зі збірки до переліку передач"
 
@@ -7441,6 +7454,54 @@ msgstr ""
 #: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Verify Local Data on PartFile is currently not supported: %s"
+msgstr ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "Media metadata: skipping %u incomplete download"
+msgid_plural "Media metadata: skipping %u incomplete downloads"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "Media metadata: skipping %u file that is not audio or video"
+msgid_plural "Media metadata: skipping %u files that are not audio or video"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "Re-extract media metadata for %u file?"
+msgid_plural "Re-extract media metadata for %u files?"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "%u incomplete download will be skipped."
+msgid_plural "%u incomplete downloads will be skipped."
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "%u file is not audio or video and will be skipped."
+msgid_plural "%u files are not audio or video and will be skipped."
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: src/SharedFilesCtrl.cpp
+msgid "This runs in the background. Progress is reported in the log."
+msgstr ""
+
+#: src/SharedFilesCtrl.cpp
+msgid "Re-extract media metadata"
 msgstr ""
 
 #: src/SharedFilesCtrl.cpp

--- a/po/vi.po
+++ b/po/vi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 12:18+0200\n"
+"POT-Creation-Date: 2026-08-24 13:43+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -2141,6 +2141,10 @@ msgstr ""
 
 #: src/ExternalConn.cpp
 msgid "No such chat session"
+msgstr ""
+
+#: src/ExternalConn.cpp
+msgid "Media metadata extraction is disabled in preferences"
 msgstr ""
 
 #: src/ExternalConn.cpp
@@ -7013,6 +7017,10 @@ msgid "No shareable files found in directory: %s"
 msgstr ""
 
 #: src/SharedFileList.cpp
+msgid "Media metadata extraction is disabled in preferences, so there is nothing to re-extract."
+msgstr ""
+
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Re-extracting media metadata for %u shared file"
 msgid_plural "Re-extracting media metadata for %u shared files"
@@ -7099,6 +7107,10 @@ msgid "Verify Local Data"
 msgstr ""
 
 #: src/SharedFilesCtrl.cpp
+msgid "Re-extract &media metadata"
+msgstr ""
+
+#: src/SharedFilesCtrl.cpp
 msgid "Add files in collection to transfer list"
 msgstr ""
 
@@ -7137,6 +7149,44 @@ msgstr ""
 #: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Verify Local Data on PartFile is currently not supported: %s"
+msgstr ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "Media metadata: skipping %u incomplete download"
+msgid_plural "Media metadata: skipping %u incomplete downloads"
+msgstr[0] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "Media metadata: skipping %u file that is not audio or video"
+msgid_plural "Media metadata: skipping %u files that are not audio or video"
+msgstr[0] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "Re-extract media metadata for %u file?"
+msgid_plural "Re-extract media metadata for %u files?"
+msgstr[0] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "%u incomplete download will be skipped."
+msgid_plural "%u incomplete downloads will be skipped."
+msgstr[0] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "%u file is not audio or video and will be skipped."
+msgid_plural "%u files are not audio or video and will be skipped."
+msgstr[0] ""
+
+#: src/SharedFilesCtrl.cpp
+msgid "This runs in the background. Progress is reported in the log."
+msgstr ""
+
+#: src/SharedFilesCtrl.cpp
+msgid "Re-extract media metadata"
 msgstr ""
 
 #: src/SharedFilesCtrl.cpp

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 12:18+0200\n"
+"POT-Creation-Date: 2026-08-24 13:43+0200\n"
 "PO-Revision-Date: 2026-08-22 15:50+0000\n"
 "Last-Translator: Mike Akiba <mike2718@gmail.com>\n"
 "Language-Team: Chinese Simplified <kde-i18n-doc@kde.org>\n"
@@ -2192,6 +2192,11 @@ msgstr "新的聊天对话已启动"
 #, fuzzy
 msgid "No such chat session"
 msgstr "结束本次聊天。"
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "Media metadata extraction is disabled in preferences"
+msgstr "Kad 在首选项中被禁用。"
 
 #: src/ExternalConn.cpp
 msgid "File is not eligible for media metadata extraction (not an audio/video file, or an incomplete download)"
@@ -7160,6 +7165,11 @@ msgid "No shareable files found in directory: %s"
 msgstr "在目录中没有找到可以共享的文件：%s"
 
 #: src/SharedFileList.cpp
+#, fuzzy
+msgid "Media metadata extraction is disabled in preferences, so there is nothing to re-extract."
+msgstr "媒体元数据提取"
+
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Re-extracting media metadata for %u shared file"
 msgid_plural "Re-extracting media metadata for %u shared files"
@@ -7250,6 +7260,10 @@ msgid "Verify Local Data"
 msgstr "验证本地数据"
 
 #: src/SharedFilesCtrl.cpp
+msgid "Re-extract &media metadata"
+msgstr ""
+
+#: src/SharedFilesCtrl.cpp
 msgid "Add files in collection to transfer list"
 msgstr "添加收藏中的文件至传输列表"
 
@@ -7289,6 +7303,49 @@ msgstr "导出所选文件到 emulecollection"
 #, c-format
 msgid "Verify Local Data on PartFile is currently not supported: %s"
 msgstr "目前不支持验证 Part 文件的本地数据：%s"
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "Media metadata: skipping %u incomplete download"
+msgid_plural "Media metadata: skipping %u incomplete downloads"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "Media metadata: skipping %u file that is not audio or video"
+msgid_plural "Media metadata: skipping %u files that are not audio or video"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "Re-extract media metadata for %u file?"
+msgid_plural "Re-extract media metadata for %u files?"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "%u incomplete download will be skipped."
+msgid_plural "%u incomplete downloads will be skipped."
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "%u file is not audio or video and will be skipped."
+msgid_plural "%u files are not audio or video and will be skipped."
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/SharedFilesCtrl.cpp
+msgid "This runs in the background. Progress is reported in the log."
+msgstr ""
+
+#: src/SharedFilesCtrl.cpp
+msgid "Re-extract media metadata"
+msgstr ""
 
 #: src/SharedFilesCtrl.cpp
 msgid "You need a HighID to create a valid sourcelink"

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 12:18+0200\n"
+"POT-Creation-Date: 2026-08-24 13:43+0200\n"
 "PO-Revision-Date: 2026-08-22 15:51+0000\n"
 "Last-Translator: Wayne Su <mstarmstar@gmail.com>\n"
 "Language-Team: \n"
@@ -2201,6 +2201,11 @@ msgstr "已開始新的交談"
 #, fuzzy
 msgid "No such chat session"
 msgstr "結束本次交談。"
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "Media metadata extraction is disabled in preferences"
+msgstr "Kad 網路已在偏好設定中被停用了。"
 
 #: src/ExternalConn.cpp
 msgid "File is not eligible for media metadata extraction (not an audio/video file, or an incomplete download)"
@@ -7203,6 +7208,10 @@ msgid "No shareable files found in directory: %s"
 msgstr "目錄中找不到可分享的檔案：%s"
 
 #: src/SharedFileList.cpp
+msgid "Media metadata extraction is disabled in preferences, so there is nothing to re-extract."
+msgstr ""
+
+#: src/SharedFileList.cpp
 #, c-format
 msgid "Re-extracting media metadata for %u shared file"
 msgid_plural "Re-extracting media metadata for %u shared files"
@@ -7289,6 +7298,10 @@ msgid "Verify Local Data"
 msgstr ""
 
 #: src/SharedFilesCtrl.cpp
+msgid "Re-extract &media metadata"
+msgstr ""
+
+#: src/SharedFilesCtrl.cpp
 msgid "Add files in collection to transfer list"
 msgstr "加入收藏中的檔案到傳輸清單"
 
@@ -7328,6 +7341,44 @@ msgstr ""
 #: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "Verify Local Data on PartFile is currently not supported: %s"
+msgstr ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "Media metadata: skipping %u incomplete download"
+msgid_plural "Media metadata: skipping %u incomplete downloads"
+msgstr[0] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "Media metadata: skipping %u file that is not audio or video"
+msgid_plural "Media metadata: skipping %u files that are not audio or video"
+msgstr[0] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "Re-extract media metadata for %u file?"
+msgid_plural "Re-extract media metadata for %u files?"
+msgstr[0] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "%u incomplete download will be skipped."
+msgid_plural "%u incomplete downloads will be skipped."
+msgstr[0] ""
+
+#: src/SharedFilesCtrl.cpp
+#, c-format
+msgid "%u file is not audio or video and will be skipped."
+msgid_plural "%u files are not audio or video and will be skipped."
+msgstr[0] ""
+
+#: src/SharedFilesCtrl.cpp
+msgid "This runs in the background. Progress is reported in the log."
+msgstr ""
+
+#: src/SharedFilesCtrl.cpp
+msgid "Re-extract media metadata"
 msgstr ""
 
 #: src/SharedFilesCtrl.cpp

--- a/src/ExternalConn.cpp
+++ b/src/ExternalConn.cpp
@@ -4284,9 +4284,31 @@ CECPacket *CECServerSocket::ProcessRequest2(const CECPacket *request)
 		// hash, otherwise for the whole share. Answers immediately with how
 		// many probes were queued -- the work happens on the media-probe
 		// worker, so a large library does not block this EC lane.
+		// Disabled is not the same answer as "nothing was eligible", and both
+		// used to arrive as queued = 0. A caller cannot act on that: a share
+		// with no media in it legitimately queues nothing. Answered first, and
+		// as a failure, so REST turns it into an error naming the reason
+		// instead of a cheerful 202 that did nothing.
+		if (!thePrefs::GetMediaMetadataEnabled()) {
+			response = new CECPacket(EC_OP_FAILED);
+			response->AddTag(CECTag(EC_TAG_STRING,
+				wxTRANSLATE("Media metadata extraction is disabled in preferences")));
+			break;
+		}
+		// Every EC_TAG_KNOWNFILE child, not just the first: the GUI sends one
+		// request for a whole selection rather than one packet per file, which
+		// would stall its own polling on the request fifo.
+		std::vector<CMD4Hash> hashes;
+		for (const CECTag &child : *request) {
+			if (child.GetTagName() == EC_TAG_KNOWNFILE) {
+				hashes.push_back(child.GetMD4Data());
+			}
+		}
 		unsigned queued = 0;
-		if (const CECTag *hashTag = request->GetTagByName(EC_TAG_KNOWNFILE)) {
-			const CMD4Hash hash = hashTag->GetMD4Data();
+		if (hashes.size() > 1) {
+			queued = theApp->sharedfiles->RefreshMediaMetadata(hashes);
+		} else if (!hashes.empty()) {
+			const CMD4Hash hash = hashes.front();
 			if (!theApp->sharedfiles->RefreshMediaMetadata(hash)) {
 				// The caller already resolved the hash against its own
 				// snapshot, so "no such file" is not the reason by the time
@@ -4296,9 +4318,8 @@ CECPacket *CECServerSocket::ProcessRequest2(const CECPacket *request)
 				response = new CECPacket(EC_OP_FAILED);
 				response->AddTag(CECTag(EC_TAG_STRING,
 					wxTRANSLATE("File is not eligible for media metadata "
-						    "extraction (metadata extraction is disabled, the "
-						    "file is not audio/video, or it is an incomplete "
-						    "download)")));
+						    "extraction (not an audio/video file, or an "
+						    "incomplete download)")));
 				break;
 			}
 			queued = 1;

--- a/src/ExternalConn.cpp
+++ b/src/ExternalConn.cpp
@@ -4296,8 +4296,9 @@ CECPacket *CECServerSocket::ProcessRequest2(const CECPacket *request)
 				response = new CECPacket(EC_OP_FAILED);
 				response->AddTag(CECTag(EC_TAG_STRING,
 					wxTRANSLATE("File is not eligible for media metadata "
-						    "extraction (not an audio/video file, or an "
-						    "incomplete download)")));
+						    "extraction (metadata extraction is disabled, the "
+						    "file is not audio/video, or it is an incomplete "
+						    "download)")));
 				break;
 			}
 			queued = 1;

--- a/src/OtherFunctions.cpp
+++ b/src/OtherFunctions.cpp
@@ -1301,6 +1301,12 @@ public:
 // get the list initialized *before* any code is accessing it
 CED2KFileTypes theED2KFileTypes;
 
+bool IsMediaProbeCandidate(const CPath &fileName)
+{
+	const EED2KFileType type = GetED2KFileTypeID(fileName);
+	return type == ED2KFT_AUDIO || type == ED2KFT_VIDEO;
+}
+
 EED2KFileType GetED2KFileTypeID(const CPath &fileName)
 {
 	const wxString ext = fileName.GetExt().Lower();

--- a/src/OtherFunctions.h
+++ b/src/OtherFunctions.h
@@ -295,6 +295,21 @@ private:
 };
 
 EED2KFileType GetED2KFileTypeID(const CPath &fileName);
+
+//! True when a file's name marks it as something ffprobe could extract media
+//! metadata from -- audio or video by extension.
+//!
+//! Lives here, in muleappcommon, because the core and the GUI must agree on it:
+//! the scheduler uses it to decide what to probe, and the shared-files view
+//! uses it to decide whether to offer the action at all. Two copies of the same
+//! rule would eventually disagree, and the symptom would be a menu entry that
+//! is enabled and silently does nothing.
+//!
+//! Says nothing about whether the file is COMPLETE. An in-progress download is
+//! in the shared list as a partfile with nothing readable on disk, and callers
+//! test that separately -- the core so it can log the two skips distinctly, the
+//! GUI so it can say how many of a selection it left out and why.
+bool IsMediaProbeCandidate(const CPath &fileName);
 wxString GetED2KFileTypeSearchTerm(EED2KFileType iFileID);
 wxString GetFileTypeByName(const CPath &fileName);
 EED2KFileType GetED2KFileTypeSearchID(EED2KFileType iFileID);

--- a/src/SharedFileList.cpp
+++ b/src/SharedFileList.cpp
@@ -875,8 +875,26 @@ bool CSharedFileList::MaybeScheduleMediaProbe(CKnownFile *pFile, MediaProbeMode 
 	return false;
 }
 
+// A user-triggered refresh must never decline in silence. The scheduler's own
+// "feature is off" check is a debug line, which compiles out of release builds,
+// so a refresh with media metadata disabled did exactly nothing and said
+// nothing -- the GUI greys its entry out for this now, but an older GUI, a
+// script driving EC, or the REST endpoint can still ask.
+static bool MediaRefreshAvailable()
+{
+	if (thePrefs::GetMediaMetadataEnabled()) {
+		return true;
+	}
+	AddLogLineN(_("Media metadata extraction is disabled in preferences, so there is nothing to "
+		      "re-extract."));
+	return false;
+}
+
 unsigned CSharedFileList::RefreshAllMediaMetadata()
 {
+	if (!MediaRefreshAvailable()) {
+		return 0;
+	}
 	// Snapshot under the lock, schedule outside it. Holding list_mut across a
 	// whole library's worth of scheduling would block every reader, including
 	// the EC handlers this is invoked from.
@@ -904,6 +922,9 @@ unsigned CSharedFileList::RefreshAllMediaMetadata()
 
 bool CSharedFileList::RefreshMediaMetadata(const CMD4Hash &hash)
 {
+	if (!MediaRefreshAvailable()) {
+		return false;
+	}
 	CKnownFile *file = GetFileByID(hash);
 	return file && MaybeScheduleMediaProbe(file, MediaProbeMode::Refresh);
 }

--- a/src/SharedFileList.cpp
+++ b/src/SharedFileList.cpp
@@ -798,8 +798,11 @@ bool CSharedFileList::MaybeScheduleMediaProbe(CKnownFile *pFile, MediaProbeMode 
 	// subprocess off this thread and pays for it once per process rather
 	// than once per file.
 	const wxString &ffprobePath = thePrefs::GetMediaMetadataFFProbePath();
-	const EED2KFileType type = GetED2KFileTypeID(pFile->GetFileName());
-	if (type != ED2KFT_AUDIO && type != ED2KFT_VIDEO) {
+	// Shared with the GUI's menu-enable test (IsMediaProbeCandidate, in
+	// OtherFunctions): the view must not offer an action the scheduler will
+	// silently drop, which is what two copies of this rule would eventually
+	// produce.
+	if (!IsMediaProbeCandidate(pFile->GetFileName())) {
 		return false;
 	}
 	// Never probe an in-progress download. A partfile is shared while

--- a/src/SharedFileList.cpp
+++ b/src/SharedFileList.cpp
@@ -920,6 +920,24 @@ unsigned CSharedFileList::RefreshAllMediaMetadata()
 	return queued;
 }
 
+unsigned CSharedFileList::RefreshMediaMetadata(const std::vector<CMD4Hash> &hashes)
+{
+	if (!MediaRefreshAvailable()) {
+		return 0;
+	}
+	unsigned queued = 0;
+	for (const CMD4Hash &hash : hashes) {
+		CKnownFile *file = GetFileByID(hash);
+		// bulk: a selection of many files is one user action and reports one
+		// summary, the same as a whole-share refresh. A selection of one is a
+		// single file the user is looking at, and keeps its per-file line.
+		if (file && MaybeScheduleMediaProbe(file, MediaProbeMode::Refresh, hashes.size() > 1)) {
+			++queued;
+		}
+	}
+	return queued;
+}
+
 bool CSharedFileList::RefreshMediaMetadata(const CMD4Hash &hash)
 {
 	if (!MediaRefreshAvailable()) {

--- a/src/SharedFileList.h
+++ b/src/SharedFileList.h
@@ -168,6 +168,13 @@ public:
 	// extension, or an incomplete download.
 	bool RefreshMediaMetadata(const CMD4Hash &hash);
 
+	// The batched form the GUI uses. Returns how many probes were queued.
+	// Exists so amulegui can send ONE EC request for a selection rather than
+	// one per file: its request fifo stalls the GUI's own polling past about
+	// twenty in flight, and a "select all, refresh" would otherwise put one
+	// packet per shared file into the socket in a tight loop.
+	unsigned RefreshMediaMetadata(const std::vector<CMD4Hash> &hashes);
+
 	/**
 	 * Returns the name of a folder visible to the public.
 	 *

--- a/src/SharedFilesCtrl.cpp
+++ b/src/SharedFilesCtrl.cpp
@@ -307,8 +307,10 @@ void CSharedFilesCtrl::OnItemRightClicked(wxDataViewEvent &event)
 		// Built from the right-clicked row while the handler acts on the whole
 		// selection, exactly as Verify Local Data does -- a mixed selection is
 		// filtered there, and the dialog says what it left out.
-		m_menu->Enable(MP_REFRESHMEDIAMETA,
-			ClassifyForMediaRefresh(file) == MediaRefreshEligibility::Eligible);
+		// From the selection, not from `file`: the handler refreshes every
+		// eligible file in the selection and the confirmation accounts for the
+		// rest, so the entry is available whenever there is anything to do.
+		m_menu->Enable(MP_REFRESHMEDIAMETA, !PartitionForMediaRefresh().eligible.empty());
 
 		int priority = file->IsAutoUpPriority() ? PR_AUTO : file->GetUpPriority();
 
@@ -404,35 +406,44 @@ void CSharedFilesCtrl::OnVerifyLocalData(wxCommandEvent &WXUNUSED(event))
 	}
 }
 
-void CSharedFilesCtrl::OnRefreshMediaMetadata(wxCommandEvent &WXUNUSED(event))
+CSharedFilesCtrl::MediaRefreshSelection CSharedFilesCtrl::PartitionForMediaRefresh() const
 {
-	// The menu was enabled from the right-clicked row, but this acts on the
-	// whole selection -- right-click a completed .mp3 with a partfile and a
-	// .zip also selected and all three arrive here. Partition first, so the
-	// confirmation can say what it will actually do rather than quoting a
-	// selection size it is not going to honour.
-	std::vector<CKnownFile *> eligible;
-	unsigned incomplete = 0;
-	unsigned notMedia = 0;
+	// The action applies to the SELECTION, so the menu has to be enabled from
+	// the selection too. Judging it by the right-clicked row instead meant a
+	// mixed selection greyed the entry out whenever the row under the cursor
+	// happened to be the ineligible one -- select a .mp3 and a .zip,
+	// right-click the .zip, and an action that would have refreshed the .mp3
+	// was unavailable. Which row the cursor is over is not something the user
+	// is choosing with; the selection is.
+	MediaRefreshSelection out;
 	for (wxUIntPtr data : GetSelectedItemData()) {
 		CKnownFile *file = reinterpret_cast<CKnownFile *>(data);
 		switch (ClassifyForMediaRefresh(file)) {
 		case MediaRefreshEligibility::FeatureDisabled:
-			// Global, so this classifies every file the same way and the
-			// selection ends up empty -- the menu entry is greyed out in that
-			// state and this is only defensive.
+			// Global rather than per-file: with the feature off every file
+			// lands here, the eligible list comes back empty, and the entry is
+			// greyed for the whole selection.
 			break;
 		case MediaRefreshEligibility::Incomplete:
-			++incomplete;
+			++out.incomplete;
 			break;
 		case MediaRefreshEligibility::NotMedia:
-			++notMedia;
+			++out.notMedia;
 			break;
 		case MediaRefreshEligibility::Eligible:
-			eligible.push_back(file);
+			out.eligible.push_back(file);
 			break;
 		}
 	}
+	return out;
+}
+
+void CSharedFilesCtrl::OnRefreshMediaMetadata(wxCommandEvent &WXUNUSED(event))
+{
+	const MediaRefreshSelection sel = PartitionForMediaRefresh();
+	const std::vector<CKnownFile *> &eligible = sel.eligible;
+	const unsigned incomplete = sel.incomplete;
+	const unsigned notMedia = sel.notMedia;
 	if (eligible.empty()) {
 		return;
 	}

--- a/src/SharedFilesCtrl.cpp
+++ b/src/SharedFilesCtrl.cpp
@@ -61,12 +61,25 @@ namespace
 enum class MediaRefreshEligibility
 {
 	Eligible,
-	Incomplete, //!< an in-progress download has no complete file to read
-	NotMedia,   //!< nothing for ffprobe to extract
+	FeatureDisabled, //!< media metadata extraction is switched off in preferences
+	Incomplete,      //!< an in-progress download has no complete file to read
+	NotMedia,        //!< nothing for ffprobe to extract
 };
 
 MediaRefreshEligibility ClassifyForMediaRefresh(const CKnownFile *file)
 {
+	// First, because it decides the answer for every file at once: with the
+	// feature off the scheduler drops the job before looking at the file, so
+	// the entry would be enabled and do nothing at all -- which is exactly
+	// what happens today and gives the user no clue why.
+	//
+	// Correct in amulegui too. The daemon sends this preference over EC as a
+	// presence tag, and the receiving side maps an absent tag to false
+	// (ApplyBoolean in ECSpecialMuleTags), so a remote GUI reports the
+	// DAEMON's setting rather than its own default.
+	if (!thePrefs::GetMediaMetadataEnabled()) {
+		return MediaRefreshEligibility::FeatureDisabled;
+	}
 	// IsPartFile() is answered correctly in both binaries: amulegui files a
 	// shared partfile into its shared list as the very CPartFile the download
 	// queue holds, not a plain CKnownFile.
@@ -404,6 +417,11 @@ void CSharedFilesCtrl::OnRefreshMediaMetadata(wxCommandEvent &WXUNUSED(event))
 	for (wxUIntPtr data : GetSelectedItemData()) {
 		CKnownFile *file = reinterpret_cast<CKnownFile *>(data);
 		switch (ClassifyForMediaRefresh(file)) {
+		case MediaRefreshEligibility::FeatureDisabled:
+			// Global, so this classifies every file the same way and the
+			// selection ends up empty -- the menu entry is greyed out in that
+			// state and this is only defensive.
+			break;
 		case MediaRefreshEligibility::Incomplete:
 			++incomplete;
 			break;

--- a/src/SharedFilesCtrl.cpp
+++ b/src/SharedFilesCtrl.cpp
@@ -49,7 +49,39 @@
 #include "DownloadQueue.h"    // Needed for CDownloadQueue
 #include "TransferWnd.h"      // Needed for CTransferWnd
 #include "Logger.h"           // Needed for AddLogLine
-#include "OtherFunctions.h"   // Needed for FormatLocalDateTime
+#include "OtherFunctions.h"   // Needed for FormatLocalDateTime, IsMediaProbeCandidate
+
+namespace
+{
+
+// Why a shared file can or cannot be re-probed. One classifier rather than the
+// same two conditions written at both call sites: the menu asks whether to
+// enable the entry, the handler asks how many of a selection it is leaving out
+// and why, and those answers must not be able to disagree.
+enum class MediaRefreshEligibility
+{
+	Eligible,
+	Incomplete, //!< an in-progress download has no complete file to read
+	NotMedia,   //!< nothing for ffprobe to extract
+};
+
+MediaRefreshEligibility ClassifyForMediaRefresh(const CKnownFile *file)
+{
+	// IsPartFile() is answered correctly in both binaries: amulegui files a
+	// shared partfile into its shared list as the very CPartFile the download
+	// queue holds, not a plain CKnownFile.
+	if (file->IsPartFile()) {
+		return MediaRefreshEligibility::Incomplete;
+	}
+	// The scheduler's own test, through the shared predicate in
+	// OtherFunctions, so the view cannot offer what the core will drop.
+	if (!IsMediaProbeCandidate(file->GetFileName())) {
+		return MediaRefreshEligibility::NotMedia;
+	}
+	return MediaRefreshEligibility::Eligible;
+}
+
+} // namespace
 
 wxBEGIN_EVENT_TABLE(CSharedFilesCtrl, CMuleVirtualDataViewCtrl)
 	EVT_DATAVIEW_ITEM_CONTEXT_MENU(wxID_ANY, CSharedFilesCtrl::OnItemRightClicked)
@@ -79,6 +111,7 @@ wxBEGIN_EVENT_TABLE(CSharedFilesCtrl, CMuleVirtualDataViewCtrl)
 	EVT_MENU(MP_GETAICHED2KLINK, CSharedFilesCtrl::OnCreateURI)
 	EVT_MENU(MP_GETAICHED2KLINKSRC, CSharedFilesCtrl::OnCreateURI)
 	EVT_MENU(MP_RENAME, CSharedFilesCtrl::OnRename)
+	EVT_MENU(MP_REFRESHMEDIAMETA, CSharedFilesCtrl::OnRefreshMediaMetadata)
 	EVT_MENU(MP_WS, CSharedFilesCtrl::OnGetFeedback)
 	EVT_MENU(MP_VERIFY, CSharedFilesCtrl::OnVerifyLocalData)
 wxEND_EVENT_TABLE()
@@ -191,6 +224,7 @@ void CSharedFilesCtrl::OnItemRightClicked(wxDataViewEvent &event)
 		m_menu->AppendSeparator();
 
 		m_menu->Append(MP_VERIFY, _("Verify Local Data"));
+		m_menu->Append(MP_REFRESHMEDIAMETA, _("Re-extract &media metadata"));
 		m_menu->AppendSeparator();
 
 		const bool isCollection = file->GetFileName().GetExt() == "emulecollection";
@@ -250,6 +284,18 @@ void CSharedFilesCtrl::OnItemRightClicked(wxDataViewEvent &event)
 		// shared partfile into its shared list as the very CPartFile the
 		// download queue holds (amule-remote-gui.cpp), not a plain CKnownFile.
 		m_menu->Enable(MP_VERIFY, !file->IsPartFile());
+		// Same two conditions the scheduler applies, asked through the shared
+		// predicate rather than a second copy of the rule: an in-progress
+		// download has no complete file for ffprobe to read, and a file that
+		// is not audio or video has nothing to extract. Greyed out rather
+		// than accepted and silently dropped, so the state is visible before
+		// the click (issue #1079).
+		//
+		// Built from the right-clicked row while the handler acts on the whole
+		// selection, exactly as Verify Local Data does -- a mixed selection is
+		// filtered there, and the dialog says what it left out.
+		m_menu->Enable(MP_REFRESHMEDIAMETA,
+			ClassifyForMediaRefresh(file) == MediaRefreshEligibility::Eligible);
 
 		int priority = file->IsAutoUpPriority() ? PR_AUTO : file->GetUpPriority();
 
@@ -342,6 +388,70 @@ void CSharedFilesCtrl::OnVerifyLocalData(wxCommandEvent &WXUNUSED(event))
 		} else {
 			theApp->sharedfiles->VerifyLocalData(file);
 		}
+	}
+}
+
+void CSharedFilesCtrl::OnRefreshMediaMetadata(wxCommandEvent &WXUNUSED(event))
+{
+	// The menu was enabled from the right-clicked row, but this acts on the
+	// whole selection -- right-click a completed .mp3 with a partfile and a
+	// .zip also selected and all three arrive here. Partition first, so the
+	// confirmation can say what it will actually do rather than quoting a
+	// selection size it is not going to honour.
+	std::vector<CKnownFile *> eligible;
+	unsigned incomplete = 0;
+	unsigned notMedia = 0;
+	for (wxUIntPtr data : GetSelectedItemData()) {
+		CKnownFile *file = reinterpret_cast<CKnownFile *>(data);
+		switch (ClassifyForMediaRefresh(file)) {
+		case MediaRefreshEligibility::Incomplete:
+			++incomplete;
+			break;
+		case MediaRefreshEligibility::NotMedia:
+			++notMedia;
+			break;
+		case MediaRefreshEligibility::Eligible:
+			eligible.push_back(file);
+			break;
+		}
+	}
+	if (eligible.empty()) {
+		return;
+	}
+
+	// One file is the "check whether this fixes it" case and queues straight
+	// away; a dialog there would cost a click on the common action. More than
+	// one is where the warning earns its place -- the cost is roughly 13 ms
+	// per file, so a large selection is real background work, and on slow
+	// media (network mounts, spun-down disks) considerably more.
+	if (eligible.size() > 1) {
+		wxString message = CFormat(wxPLURAL("Re-extract media metadata for %u file?",
+					   "Re-extract media metadata for %u files?",
+					   eligible.size())) %
+				   eligible.size();
+		if (incomplete > 0) {
+			message << wxT("\n\n")
+				<< (CFormat(wxPLURAL("%u incomplete download will be skipped.",
+					    "%u incomplete downloads will be skipped.",
+					    incomplete)) %
+					   incomplete);
+		}
+		if (notMedia > 0) {
+			message << (incomplete > 0 ? wxT("\n") : wxT("\n\n"))
+				<< (CFormat(wxPLURAL("%u file is not audio or video and will be skipped.",
+					    "%u files are not audio or video and will be skipped.",
+					    notMedia)) %
+					   notMedia);
+		}
+		message << wxT("\n\n") << _("This runs in the background. Progress is reported in the log.");
+		if (wxMessageBox(message, _("Re-extract media metadata"), wxYES_NO | wxICON_QUESTION, this) !=
+			wxYES) {
+			return;
+		}
+	}
+
+	for (const CKnownFile *file : eligible) {
+		theApp->sharedfiles->RefreshMediaMetadata(file->GetFileHash());
 	}
 }
 

--- a/src/SharedFilesCtrl.cpp
+++ b/src/SharedFilesCtrl.cpp
@@ -431,7 +431,7 @@ CSharedFilesCtrl::MediaRefreshSelection CSharedFilesCtrl::PartitionForMediaRefre
 			++out.notMedia;
 			break;
 		case MediaRefreshEligibility::Eligible:
-			out.eligible.push_back(file);
+			out.eligible.push_back(file->GetFileHash());
 			break;
 		}
 	}
@@ -441,11 +441,30 @@ CSharedFilesCtrl::MediaRefreshSelection CSharedFilesCtrl::PartitionForMediaRefre
 void CSharedFilesCtrl::OnRefreshMediaMetadata(wxCommandEvent &WXUNUSED(event))
 {
 	const MediaRefreshSelection sel = PartitionForMediaRefresh();
-	const std::vector<CKnownFile *> &eligible = sel.eligible;
+	const std::vector<CMD4Hash> &eligible = sel.eligible;
 	const unsigned incomplete = sel.incomplete;
 	const unsigned notMedia = sel.notMedia;
 	if (eligible.empty()) {
 		return;
+	}
+
+	// Say what is being left out whether or not a dialog follows. Select one
+	// .mp3 and ten .zip files and the dialog never appears, so without this the
+	// ten are passed over in silence -- and "I selected eleven files and it
+	// only did one" is precisely the kind of thing the log has to answer.
+	// Verify Local Data, the model for this handler, reports every file it
+	// refuses regardless of what else succeeded.
+	if (incomplete > 0) {
+		AddLogLineN(CFormat(wxPLURAL("Media metadata: skipping %u incomplete download",
+				    "Media metadata: skipping %u incomplete downloads",
+				    incomplete)) %
+			    incomplete);
+	}
+	if (notMedia > 0) {
+		AddLogLineN(CFormat(wxPLURAL("Media metadata: skipping %u file that is not audio or video",
+				    "Media metadata: skipping %u files that are not audio or video",
+				    notMedia)) %
+			    notMedia);
 	}
 
 	// One file is the "check whether this fixes it" case and queues straight
@@ -479,9 +498,11 @@ void CSharedFilesCtrl::OnRefreshMediaMetadata(wxCommandEvent &WXUNUSED(event))
 		}
 	}
 
-	for (const CKnownFile *file : eligible) {
-		theApp->sharedfiles->RefreshMediaMetadata(file->GetFileHash());
-	}
+	// One call for the whole set, not one per file: amulegui turns each into an
+	// EC request, and the request fifo stalls the GUI's own polling past about
+	// twenty in flight -- "select all, refresh" on a large share would put one
+	// packet per shared file into the socket in a tight loop.
+	theApp->sharedfiles->RefreshMediaMetadata(eligible);
 }
 
 void CSharedFilesCtrl::OnGetFeedback(wxCommandEvent &WXUNUSED(event))

--- a/src/SharedFilesCtrl.h
+++ b/src/SharedFilesCtrl.h
@@ -317,6 +317,17 @@ private:
 	void OnRename(wxCommandEvent &event);
 	void OnRefreshMediaMetadata(wxCommandEvent &event);
 
+	//! The current selection split by whether a media re-extraction can act on
+	//! it. Shared by the menu's enable rule and the handler so the two cannot
+	//! disagree about what the action would do.
+	struct MediaRefreshSelection
+	{
+		std::vector<CKnownFile *> eligible;
+		unsigned incomplete = 0; //!< in-progress downloads, nothing complete to read
+		unsigned notMedia = 0;   //!< not audio or video
+	};
+	MediaRefreshSelection PartitionForMediaRefresh() const;
+
 	/**
 	 * Checks for renaming via F2.
 	 */

--- a/src/SharedFilesCtrl.h
+++ b/src/SharedFilesCtrl.h
@@ -315,6 +315,7 @@ private:
 	 * Event-handler for the Rename menu item.
 	 */
 	void OnRename(wxCommandEvent &event);
+	void OnRefreshMediaMetadata(wxCommandEvent &event);
 
 	/**
 	 * Checks for renaming via F2.

--- a/src/SharedFilesCtrl.h
+++ b/src/SharedFilesCtrl.h
@@ -27,6 +27,7 @@
 #define SHAREDFILESCTRL_H
 
 #include "MuleVirtualDataViewCtrl.h" // Needed for CMuleVirtualDataViewCtrl
+#include "MD4Hash.h"                 // Needed for CMD4Hash in MediaRefreshSelection
 
 #define COLUMN_SHARED_NAME 0
 #define COLUMN_SHARED_SIZE 1
@@ -322,7 +323,14 @@ private:
 	//! disagree about what the action would do.
 	struct MediaRefreshSelection
 	{
-		std::vector<CKnownFile *> eligible;
+		// Hashes, not CKnownFile pointers. The confirmation dialog runs a
+		// nested event loop, and in amulegui the EC poll timer keeps running
+		// inside it -- CKnownFilesRem::DeleteItem ends in `delete file` for
+		// anything the daemon stops listing, so a pointer collected before the
+		// dialog can be dangling after it. A hash cannot dangle, and the
+		// refresh call takes one anyway; a file that went away in the meantime
+		// simply fails to resolve.
+		std::vector<CMD4Hash> eligible;
 		unsigned incomplete = 0; //!< in-progress downloads, nothing complete to read
 		unsigned notMedia = 0;   //!< not audio or video
 	};

--- a/src/amule-remote-gui.cpp
+++ b/src/amule-remote-gui.cpp
@@ -2081,6 +2081,18 @@ void CSharedFilesRem::VerifyLocalData(const CKnownFile *file) const
 	m_conn->SendPacket(&request);
 }
 
+bool CSharedFilesRem::RefreshMediaMetadata(const CMD4Hash &hash)
+{
+	CECPacket request(EC_OP_REFRESH_MEDIA_METADATA);
+	request.AddTag(CECTag(EC_TAG_KNOWNFILE, hash));
+	m_conn->SendPacket(&request);
+	// Sent, not probed. A daemon that predates the opcode answers EC_OP_FAILED
+	// and the reply is dropped here as it is for every other fire-and-forget
+	// request on this class; the user sees nothing happen, which is the same
+	// outcome as the action not existing.
+	return true;
+}
+
 void CSharedFilesRem::SetFileCommentRating(CKnownFile *file, const wxString &newComment, int8 newRating)
 {
 	CECPacket request(EC_OP_SHARED_FILE_SET_COMMENT);

--- a/src/amule-remote-gui.cpp
+++ b/src/amule-remote-gui.cpp
@@ -2081,6 +2081,29 @@ void CSharedFilesRem::VerifyLocalData(const CKnownFile *file) const
 	m_conn->SendPacket(&request);
 }
 
+unsigned CSharedFilesRem::RefreshMediaMetadata(const std::vector<CMD4Hash> &hashes)
+{
+	if (hashes.empty()) {
+		return 0;
+	}
+	// ONE packet carrying every hash. One request per file would push the
+	// selection through m_req_fifo a packet at a time, and OnPollTimer stops
+	// updating the GUI while that fifo is full -- on a large selection the
+	// window would go quiet for as long as it took to drain.
+	CECPacket request(EC_OP_REFRESH_MEDIA_METADATA);
+	for (const CMD4Hash &hash : hashes) {
+		// A FRESH tag per hash, deliberately. CECTag::AddTag swaps the
+		// argument's contents into the child list and leaves the original
+		// empty, so adding the same tag object twice appends one real child
+		// and one blank -- silently sending fewer hashes than intended.
+		request.AddTag(CECTag(EC_TAG_KNOWNFILE, hash));
+	}
+	m_conn->SendPacket(&request);
+	// Sent, not probed: the daemon decides eligibility and reports what it did
+	// in its own log, which this GUI displays.
+	return hashes.size();
+}
+
 bool CSharedFilesRem::RefreshMediaMetadata(const CMD4Hash &hash)
 {
 	CECPacket request(EC_OP_REFRESH_MEDIA_METADATA);

--- a/src/amule-remote-gui.h
+++ b/src/amule-remote-gui.h
@@ -599,6 +599,7 @@ public:
 	// the daemon decides eligibility and reports the outcome in its own log.
 	// The monolithic form can answer for real because it schedules inline.
 	bool RefreshMediaMetadata(const CMD4Hash &hash);
+	unsigned RefreshMediaMetadata(const std::vector<CMD4Hash> &hashes);
 	void SearchKadNotes(CAbstractFile *file);
 	void CopyFileList(std::vector<CKnownFile *> &out_list) const;
 

--- a/src/amule-remote-gui.h
+++ b/src/amule-remote-gui.h
@@ -589,6 +589,16 @@ public:
 	bool RenameFile(CKnownFile *file, const CPath &newName);
 	void SetFileCommentRating(CKnownFile *file, const wxString &newComment, int8 newRating);
 	void VerifyLocalData(const CKnownFile *file) const;
+
+	// Mirrors CSharedFileList's signature so the one call site in
+	// CSharedFilesCtrl compiles for both binaries -- muleappgui is built once
+	// and carries no build-variant defines, so the split has to live in the
+	// type of theApp->sharedfiles rather than in an #ifdef at the call site.
+	//
+	// Returns true when the request was SENT, not when anything was probed:
+	// the daemon decides eligibility and reports the outcome in its own log.
+	// The monolithic form can answer for real because it schedules inline.
+	bool RefreshMediaMetadata(const CMD4Hash &hash);
 	void SearchKadNotes(CAbstractFile *file);
 	void CopyFileList(std::vector<CKnownFile *> &out_list) const;
 

--- a/src/include/common/MenuIDs.h
+++ b/src/include/common/MenuIDs.h
@@ -89,6 +89,7 @@ enum
 	MP_CLOSE_OTHER_TABS,
 	MP_RENAME,
 	MP_VERIFY,
+	MP_REFRESHMEDIAMETA,
 
 	/* Razor 1a - Modif by MikaelB
 	     Opcodes for :


### PR DESCRIPTION
Closes #1079. The core, EC and REST sides shipped in #1106; this is the GUI half the issue asked for.

## One entry, both binaries

`muleappgui` is built once and carries no build-variant defines, so the split lives in the type of `theApp->sharedfiles`: the monolithic build calls `CSharedFileList::RefreshMediaMetadata` and schedules inline, while amulegui calls a new `CSharedFilesRem` method that sends `EC_OP_REFRESH_MEDIA_METADATA`. That is the same shape `VerifyLocalData` already uses, and it is why this works against a remote daemon instead of looping in the GUI.

## Greyed out rather than silently refused

The entry is disabled for a file the scheduler would drop: an in-progress download has no complete file for ffprobe to read, and a file that is not audio or video has nothing to extract. Both conditions come from one classifier, and the audio/video half is a new `IsMediaProbeCandidate` in `muleappcommon` that the core's own gate now calls too. The view must not offer an action the core will refuse, which is what two copies of that rule would eventually produce.

The same applies to the feature being switched off entirely. The scheduler drops the job on that preference before it looks at the file, so the entry greys out for it too. That works in amulegui because the daemon sends the preference over EC as a presence tag and the receiving side maps an absent tag to false, so a remote GUI reports the daemon's setting rather than its own default.

A disabled feature and an empty result are no longer the same answer. The whole-share endpoint returned `queued: 0` for both, which a caller cannot act on, since zero is legitimate for a share with no media in it; disabled is now a `400` naming the reason. The core reports a declined refresh as well. Greying the entry out fixes the GUI, but an older GUI, a script driving EC, or the REST endpoint can still ask -- and a whole-share refresh used to answer `queued: 0` with no reason at all, while the single-file form answered 400 with a message naming only the two per-file causes.

## Mixed selections

A menu built from the right-clicked row cannot speak for the whole selection, so the handler partitions it: right-click a completed `.mp3` with a partfile and a `.zip` also selected and all three arrive. The confirmation names how many will be refreshed and how many are skipped, and for which reason, so a mixed selection is honest about what it will do. Cancelling queues nothing.

The confirmation appears for a multi-file selection only. One file is the "check whether this fixes it" case and queues straight away; the warning earns its place in bulk, where the roughly 13 ms per file adds up and slow media costs considerably more.

The selection is carried as hashes rather than `CKnownFile` pointers. The confirmation runs a nested event loop, and in amulegui the EC poll timer keeps running inside it, freeing any file the daemon stops listing -- so a pointer collected before the dialog could be dangling after it. A hash cannot dangle, and it is what the refresh call takes anyway.

amulegui sends one request for the whole selection, not one per file. `SendPacket` pushes onto the request fifo and `OnPollTimer` stops updating the GUI while that fifo is full, so a "select all, refresh" would otherwise stall the window until it drained. The daemon reads every `EC_TAG_KNOWNFILE` child rather than the first.

Skipped files are reported in the log whether or not a dialog appears, so selecting one `.mp3` and ten `.zip` files does not queue the one and pass over the ten in silence.

## No progress indicator

The worker reports every probe in the core log, which both binaries display. A live indicator in amulegui would need a new EC signal carrying the pending job count, to tell the user something the log already says.

## Verification

All three binaries build, and `aMule` and `aMuleGUI` each carry the call site resolved to their own implementation. 41/41 tests, clang-format and Tier-2 clang-tidy clean, catalogs regenerated for the new strings.

Manually tested on macOS against both binaries, including amulegui driving a remote daemon, which is the path with the least prior coverage. That testing found two defects, both fixed here:

- With media metadata disabled in preferences the entry was enabled, triggering it did nothing, and nothing was logged, because the scheduler's "feature is off" trace is a debug line that compiles out of release builds.
- A selection mixing media and non-media files greyed the entry out, because the enable rule judged a single row while the handler acts on the selection.

The EC batching was exercised separately by making the REST layer emit a two-hash packet, confirming the daemon reads every child and reports one summary rather than per-file lines. That scaffold is not part of the diff.
