### PR TITLE
fix(web-ui): keep a table's empty/loading placeholder on screen

### DIFF
--- a/src/webapi/static/css/app.css
+++ b/src/webapi/static/css/app.css
@@ -334,6 +334,11 @@ table.data td.num, table.data th.num { text-align: right; }
 table.data td.name { white-space: normal; word-break: break-word; min-width: 220px; max-width: 520px; }
 .row-selected, .row-selected:hover { background: var(--sel) !important; }
 
+/* Empty/error/loading placeholder for a table, rendered as a sibling of the
+   <table>: a table is often wider than the viewport, so a cell centred over its
+   full width lands off-screen. Sticky keeps it in view on sideways scroll. */
+.table-wrap .table-empty { position: sticky; left: 0; }
+
 /* virtualized tables: fixed layout keeps columns from jittering as the visible
    window changes; single-line cells keep every row the same fixed height. */
 .table-wrap.virtual { overflow-y: auto; overflow-x: auto; }

--- a/src/webapi/static/js/table.js
+++ b/src/webapi/static/js/table.js
@@ -291,9 +291,10 @@ export function VirtualTable({
         <thead><tr>${columns.map(th)}</tr></thead>
         <tbody>
           ${total === 0
-            ? html`<tr><td colspan=${ncols}>${empty}</td></tr>`
+            ? null
             : html`${spacer(padTop)}${rows.slice(start, end).map(rowTr)}${spacer(padBot)}`}
         </tbody>
       </table>
+      ${total === 0 ? html`<div class="table-empty">${empty}</div>` : null}
     </div>`;
 }

--- a/src/webapi/static/js/views/categories.js
+++ b/src/webapi/static/js/views/categories.js
@@ -79,8 +79,6 @@ export function CategoriesPanel({ isGuest }) {
         </td>`}
     </tr>`;
 
-  const colspan = isGuest ? 5 : 6;
-
   return html`
     <div class="card">
       <div class="cat-panel-header">
@@ -100,13 +98,11 @@ export function CategoriesPanel({ isGuest }) {
               ${isGuest ? null : html`<th class="admin-only">${t("downloads_cat_actions")}</th>`}
             </tr>
           </thead>
-          <tbody>
-            ${loadErr ? html`<tr><td colspan=${colspan}>${loadErr}</td></tr>`
-              : categories.length
-                ? categories.map(row)
-                : html`<tr><td colspan=${colspan}><${Placeholder} kind="info">${t("downloads_cat_empty")}<//></td></tr>`}
-          </tbody>
+          <tbody>${loadErr ? null : categories.map(row)}</tbody>
         </table>
+        ${loadErr ? html`<div class="table-empty"><${Placeholder} kind="error">${loadErr}<//></div>`
+          : categories.length ? null
+            : html`<div class="table-empty"><${Placeholder} kind="info">${t("downloads_cat_empty")}<//></div>`}
       </div>
     </div>
 


### PR DESCRIPTION
A table wider than its scroller (the virtual tables set a min-width summed from every column, so this is the norm on a phone and happens on a narrow desktop window too) pushed the empty / loading placeholder out of sight: it was a <td colspan> spanning the full table width, so its centred content — including the loading spinner — sat hundreds of pixels to the right of the visible area. The spinner was rendered, just never visible.

Render the placeholder as a sibling <div class="table-empty"> of the <table>, inside .table-wrap: as a plain block it takes the scroller's visible width, so the content centres where it can be seen, and position:sticky;left:0 keeps it there while the table scrolls sideways. Same treatment for the categories panel's non-virtual table, whose header row also overflows on a phone; its load error now uses the standard error placeholder instead of bare cell text.