### PR TITLE
fix(core): stop reading and writing unaligned integers through a raw cast

### DIFF
--- a/src/ArchSpecific.h
+++ b/src/ArchSpecific.h
@@ -29,6 +29,8 @@
 #include "Types.h"
 #include "config.h"
 
+#include <cstring> // Needed for memcpy
+
 #define ENDIAN_SWAP_16(x) (wxUINT16_SWAP_ON_BE(x))
 #define ENDIAN_SWAP_I_16(x) x = wxUINT16_SWAP_ON_BE(x)
 #define ENDIAN_SWAP_32(x) (wxUINT32_SWAP_ON_BE(x))
@@ -99,44 +101,44 @@ inline void PokeUInt32(void *p, uint32 nVal);
 inline void PokeUInt64(void *p, uint64 nVal);
 // \}
 
-#if defined(__arm__) || defined(__sparc__) || defined(__mips__) || defined(GCC_USES_STRICT_ALIASING)
-#define ARCHSPECIFIC_USE_MEMCPY
-#endif
+// The Raw* helpers below read and write through pointers whose alignment the
+// caller does not control -- packet buffers, and the 16-byte CMD4Hash array,
+// which sits at a 4-byte-aligned offset inside several objects. Reading eight
+// bytes from there via `*(uint64 *)p` is undefined behaviour regardless of the
+// architecture: it is a property of the C++ object model, not of what the CPU
+// tolerates. x86 and aarch64 happen to execute such a load, which is why this
+// went unnoticed for two decades, but the compiler is still entitled to assume
+// the alignment holds and optimise accordingly.
+//
+// So the memcpy form is now unconditional rather than selected per-arch. It
+// costs nothing: every compiler this project supports folds a fixed-size memcpy
+// into the same single load or store the cast would have emitted, and the two
+// are identical at -O2 on x86-64 and aarch64. The old guard listed __arm__,
+// __sparc__ and __mips__ -- 32-bit ARM only, written years before aarch64
+// existed, and never updated for it.
 
 ///////////////////////////////////////////////////////////////////////////////
 // Peek - helper functions for read-accessing memory without modifying the memory pointer
 
 inline uint16 RawPeekUInt16(const void *p)
 {
-#ifndef ARCHSPECIFIC_USE_MEMCPY
-	return *((uint16 *)p);
-#else
 	uint16 value;
 	memcpy(&value, p, sizeof(uint16));
 	return value;
-#endif
 }
 
 inline uint32 RawPeekUInt32(const void *p)
 {
-#ifndef ARCHSPECIFIC_USE_MEMCPY
-	return *((uint32 *)p);
-#else
 	uint32 value;
 	memcpy(&value, p, sizeof(uint32));
 	return value;
-#endif
 }
 
 inline uint64 RawPeekUInt64(const void *p)
 {
-#ifndef ARCHSPECIFIC_USE_MEMCPY
-	return *((uint64 *)p);
-#else
 	uint64 value;
 	memcpy(&value, p, sizeof(uint64));
 	return value;
-#endif
 }
 
 inline uint8 PeekUInt8(const void *p)
@@ -164,29 +166,17 @@ inline uint64 PeekUInt64(const void *p)
 
 inline void RawPokeUInt16(void *p, uint16 nVal)
 {
-#ifndef ARCHSPECIFIC_USE_MEMCPY
-	*((uint16 *)p) = nVal;
-#else
 	memcpy(p, &nVal, sizeof(uint16));
-#endif
 }
 
 inline void RawPokeUInt32(void *p, uint32 nVal)
 {
-#ifndef ARCHSPECIFIC_USE_MEMCPY
-	*((uint32 *)p) = nVal;
-#else
 	memcpy(p, &nVal, sizeof(uint32));
-#endif
 }
 
 inline void RawPokeUInt64(void *p, uint64 nVal)
 {
-#ifndef ARCHSPECIFIC_USE_MEMCPY
-	*((uint64 *)p) = nVal;
-#else
 	memcpy(p, &nVal, sizeof(uint64));
-#endif
 }
 
 inline void PokeUInt8(void *p, uint8 nVal)
@@ -208,9 +198,6 @@ inline void PokeUInt64(void *p, uint64 nVal)
 {
 	RawPokeUInt64(p, ENDIAN_SWAP_64(nVal));
 }
-
-// Don't pollute the preprocessor namespace
-#undef ARCHSPECIFIC_USE_MEMCPY
 
 #endif
 // File_checked_for_headers


### PR DESCRIPTION
The `Raw{Peek,Poke}UInt{16,32,64}` helpers read and write through pointers whose alignment the caller does not control — packet buffers, and the 16-byte `CMD4Hash` array, which sits at a 4-byte-aligned offset inside several objects. On most builds they did that with `*((uint64 *)p)`, which is undefined behaviour: alignment is a property of the C++ object model, not of what the CPU happens to tolerate.

`CMD4Hash` reaches these on its most basic operations — `operator==`, `IsEmpty()` and its `std::hash` specialisation — so **every hash comparison and every hash-map lookup in the program** went through an unaligned access. A daemon built with `-fsanitize=undefined` reports it immediately, for instance from `CKnownFileList::FindKnownFileByID`:

```
ArchSpecific.h:134: runtime error: load of misaligned address for type 'uint64',
                    which requires 8 byte alignment
```

The memcpy form was already present, but selected by an architecture guard:

```c
#if defined(__arm__) || defined(__sparc__) || defined(__mips__) || defined(GCC_USES_STRICT_ALIASING)
#define ARCHSPECIFIC_USE_MEMCPY
#endif
```

`__arm__` is 32-bit ARM only. The guard dates from 2005, years before aarch64 existed, and was never updated for it — so an Apple Silicon build takes the cast path, as does every x86 and x86-64 build. Those architectures execute an unaligned load happily, which is why this survived two decades unnoticed, but the compiler is still entitled to assume the alignment holds and optimise on that basis.

Rather than add `__aarch64__` to a list that will go stale again, the memcpy form is now unconditional and the guard is gone.

**It costs nothing.** At `-O2` both forms compile to the same single instruction:

| | load | store |
|---|---|---|
| x86-64 cast | `movq (%rdi), %rax` | `movq %rsi, (%rdi)` |
| x86-64 memcpy | `movq (%rdi), %rax` | `movq %rsi, (%rdi)` |
| arm64 cast | `ldr x0, [x0]` | `str x1, [x0]` |
| arm64 memcpy | `ldr x0, [x0]` | `str x1, [x0]` |

**Testing.** A reduced case — a 16-byte hash at a deliberately 4-byte-aligned offset — built against both revisions of the header: the previous one reports a misaligned load *and* a misaligned store under UBSan, this one is silent and computes the same value. Full build of all targets, 41/41 unit tests, clang-format clean, both clang-tidy tiers report nothing on the diff.

**Risk.** Behaviour is unchanged on every architecture aMule ships — the strict-alignment targets already took this path, and the rest now get identical codegen. The change is confined to one header with no API change.
