### PR TITLE
minor: use uint16_t i/o uint32_t for ClientStruct.m_serverPort

### DIFF
--- a/src/SearchFile.cpp
+++ b/src/SearchFile.cpp
@@ -223,7 +223,7 @@ bool CSearchFile::WriteToFile(CFileDataIO *file) const
 		file->WriteUInt32(client.m_ip);
 		file->WriteUInt16(client.m_port);
 		file->WriteUInt32(client.m_serverIP);
-		file->WriteUInt16((uint16)client.m_serverPort);
+		file->WriteUInt16(client.m_serverPort);
 	}
 
 	file->WriteUInt16((uint16)m_children.size());

--- a/src/SearchFile.h
+++ b/src/SearchFile.h
@@ -197,7 +197,7 @@ public:
 		uint32_t m_ip;
 		uint16_t m_port;
 		uint32_t m_serverIP;
-		uint32_t m_serverPort;
+		uint16_t m_serverPort;
 	};
 
 	void AddClient(const ClientStruct &client);


### PR DESCRIPTION
Just saw this the other day.
Unless I'm missing something, there is no reason to use uint32_t for the server port, using uint16_t shall be enough.
I did a search as test, and I get results and can download them.
