### PR TITLE
fix(amulecmd,ec): decode the union search progress reply, and name each search

### DIFF
--- a/docs/EC_Protocol.md
+++ b/docs/EC_Protocol.md
@@ -351,6 +351,11 @@ request. A daemon that keyed the union off "no ids named" would answer a
 client that named several about only the first, and the client would read
 every other search's absence as an expiry.
 
+Each entry also carries `EC_TAG_SEARCH_NAME`, the query the search was
+started with — or, for a browse, the peer's nickname. It is the same tag
+and the same string `EC_OP_SEARCH_LIST` reports, so a client polling
+progress can label what it is reporting on without also fetching the list.
+
 The union reply carries no `EC_TAG_SEARCH_EXPIRED`: it reports the whole
 set, so an id the client asked about and did not get back is one the
 daemon no longer holds.

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -71,6 +71,7 @@ src/PrefsUnifiedDlg.cpp
 src/SearchDlg.cpp
 src/SearchList.cpp
 src/SearchListCtrl.cpp
+src/SearchProgressReport.cpp
 src/ServerConnect.cpp
 src/Server.cpp
 src/ServerList.cpp

--- a/po/amule.pot
+++ b/po/amule.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 13:43+0200\n"
+"POT-Creation-Date: 2026-08-24 15:13+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -6450,6 +6450,45 @@ msgstr ""
 msgid "New"
 msgstr ""
 
+#: src/SearchProgressReport.cpp
+msgid "running"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+msgid "finished"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+msgid "idle"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+#, c-format
+msgid "Search %u: %s, %u %% (%u results)\n"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+#, c-format
+msgid "Search %u \"%s\": %s, %u %% (%u results)\n"
+msgstr ""
+
+#: src/SearchProgressReport.cpp src/TextClient.cpp
+msgid "Search expired or unknown ID. Start a new search.\n"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+#, c-format
+msgid "Search progress: %u %% \n"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+msgid "Search progress not available"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+msgid "No search to report on.\n"
+msgstr ""
+
 #: src/ServerConnect.cpp
 msgid "Failed to connect to all obfuscated static servers listed. Making another pass without obfuscation."
 msgstr ""
@@ -7676,21 +7715,8 @@ msgid "[PartFile]"
 msgstr ""
 
 #: src/TextClient.cpp
-msgid "Search expired or unknown ID. Start a new search.\n"
-msgstr ""
-
-#: src/TextClient.cpp
 #, c-format
 msgid "Number of search results: %i\n"
-msgstr ""
-
-#: src/TextClient.cpp
-#, c-format
-msgid "Search progress: %u %% \n"
-msgstr ""
-
-#: src/TextClient.cpp
-msgid "Search progress not available"
 msgstr ""
 
 #: src/TextClient.cpp

--- a/po/ar.po
+++ b/po/ar.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 13:43+0200\n"
+"POT-Creation-Date: 2026-08-24 15:13+0200\n"
 "PO-Revision-Date: 2026-08-22 15:09+0000\n"
 "Last-Translator: saleh alhathal <hathalsal@hotmail.com>\n"
 "Language-Team: \n"
@@ -6555,6 +6555,47 @@ msgstr "إلغاء"
 msgid "New"
 msgstr ""
 
+#: src/SearchProgressReport.cpp
+msgid "running"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+#, fuzzy
+msgid "finished"
+msgstr "الفلنديه"
+
+#: src/SearchProgressReport.cpp
+msgid "idle"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+#, c-format
+msgid "Search %u: %s, %u %% (%u results)\n"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+#, c-format
+msgid "Search %u \"%s\": %s, %u %% (%u results)\n"
+msgstr ""
+
+#: src/SearchProgressReport.cpp src/TextClient.cpp
+msgid "Search expired or unknown ID. Start a new search.\n"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+#, c-format
+msgid "Search progress: %u %% \n"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+#, fuzzy
+msgid "Search progress not available"
+msgstr "%s غير متوفر"
+
+#: src/SearchProgressReport.cpp
+msgid "No search to report on.\n"
+msgstr ""
+
 #: src/ServerConnect.cpp
 #, fuzzy
 msgid "Failed to connect to all obfuscated static servers listed. Making another pass without obfuscation."
@@ -7807,23 +7848,9 @@ msgid "[PartFile]"
 msgstr ""
 
 #: src/TextClient.cpp
-msgid "Search expired or unknown ID. Start a new search.\n"
-msgstr ""
-
-#: src/TextClient.cpp
 #, c-format
 msgid "Number of search results: %i\n"
 msgstr ""
-
-#: src/TextClient.cpp
-#, c-format
-msgid "Search progress: %u %% \n"
-msgstr ""
-
-#: src/TextClient.cpp
-#, fuzzy
-msgid "Search progress not available"
-msgstr "%s غير متوفر"
 
 #: src/TextClient.cpp
 #, c-format

--- a/po/ast.po
+++ b/po/ast.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 13:43+0200\n"
+"POT-Creation-Date: 2026-08-24 15:13+0200\n"
 "PO-Revision-Date: 2026-08-22 15:11+0000\n"
 "Last-Translator: astur <malditoastur@gmail.com>\n"
 "Language-Team: Language ast <malditoastur@gmail.com>\n"
@@ -6678,6 +6678,48 @@ msgstr "Encaboxar"
 msgid "New"
 msgstr ""
 
+#: src/SearchProgressReport.cpp
+#, fuzzy
+msgid "running"
+msgstr "Executando"
+
+#: src/SearchProgressReport.cpp
+#, fuzzy
+msgid "finished"
+msgstr "Finlandés"
+
+#: src/SearchProgressReport.cpp
+msgid "idle"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+#, c-format
+msgid "Search %u: %s, %u %% (%u results)\n"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+#, c-format
+msgid "Search %u \"%s\": %s, %u %% (%u results)\n"
+msgstr ""
+
+#: src/SearchProgressReport.cpp src/TextClient.cpp
+msgid "Search expired or unknown ID. Start a new search.\n"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+#, c-format
+msgid "Search progress: %u %% \n"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+#, fuzzy
+msgid "Search progress not available"
+msgstr "Amosar porcentax de progresu"
+
+#: src/SearchProgressReport.cpp
+msgid "No search to report on.\n"
+msgstr ""
+
 #: src/ServerConnect.cpp
 #, fuzzy
 msgid "Failed to connect to all obfuscated static servers listed. Making another pass without obfuscation."
@@ -7936,23 +7978,9 @@ msgid "[PartFile]"
 msgstr "[Ficheru part]"
 
 #: src/TextClient.cpp
-msgid "Search expired or unknown ID. Start a new search.\n"
-msgstr ""
-
-#: src/TextClient.cpp
 #, c-format
 msgid "Number of search results: %i\n"
 msgstr "Númberu de resultaos de la gueta: %i\n"
-
-#: src/TextClient.cpp
-#, c-format
-msgid "Search progress: %u %% \n"
-msgstr ""
-
-#: src/TextClient.cpp
-#, fuzzy
-msgid "Search progress not available"
-msgstr "Amosar porcentax de progresu"
 
 #: src/TextClient.cpp
 #, c-format

--- a/po/bg.po
+++ b/po/bg.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 13:43+0200\n"
+"POT-Creation-Date: 2026-08-24 15:13+0200\n"
 "PO-Revision-Date: 2026-08-22 15:15+0000\n"
 "Last-Translator: Sebastiano Pistore <SebastianoPistore.info@protonmail.ch>\n"
 "Language-Team: Bulgarian <dict@linux.zonebg.com>\n"
@@ -6531,6 +6531,46 @@ msgstr "Отказ"
 msgid "New"
 msgstr ""
 
+#: src/SearchProgressReport.cpp
+msgid "running"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+#, fuzzy
+msgid "finished"
+msgstr "фински"
+
+#: src/SearchProgressReport.cpp
+msgid "idle"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+#, c-format
+msgid "Search %u: %s, %u %% (%u results)\n"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+#, c-format
+msgid "Search %u \"%s\": %s, %u %% (%u results)\n"
+msgstr ""
+
+#: src/SearchProgressReport.cpp src/TextClient.cpp
+msgid "Search expired or unknown ID. Start a new search.\n"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+#, c-format
+msgid "Search progress: %u %% \n"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+msgid "Search progress not available"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+msgid "No search to report on.\n"
+msgstr ""
+
 #: src/ServerConnect.cpp
 #, fuzzy
 msgid "Failed to connect to all obfuscated static servers listed. Making another pass without obfuscation."
@@ -7783,21 +7823,8 @@ msgid "[PartFile]"
 msgstr ""
 
 #: src/TextClient.cpp
-msgid "Search expired or unknown ID. Start a new search.\n"
-msgstr ""
-
-#: src/TextClient.cpp
 #, c-format
 msgid "Number of search results: %i\n"
-msgstr ""
-
-#: src/TextClient.cpp
-#, c-format
-msgid "Search progress: %u %% \n"
-msgstr ""
-
-#: src/TextClient.cpp
-msgid "Search progress not available"
 msgstr ""
 
 #: src/TextClient.cpp

--- a/po/bn.po
+++ b/po/bn.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 13:43+0200\n"
+"POT-Creation-Date: 2026-08-24 15:13+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -6449,6 +6449,45 @@ msgstr ""
 msgid "New"
 msgstr ""
 
+#: src/SearchProgressReport.cpp
+msgid "running"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+msgid "finished"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+msgid "idle"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+#, c-format
+msgid "Search %u: %s, %u %% (%u results)\n"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+#, c-format
+msgid "Search %u \"%s\": %s, %u %% (%u results)\n"
+msgstr ""
+
+#: src/SearchProgressReport.cpp src/TextClient.cpp
+msgid "Search expired or unknown ID. Start a new search.\n"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+#, c-format
+msgid "Search progress: %u %% \n"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+msgid "Search progress not available"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+msgid "No search to report on.\n"
+msgstr ""
+
 #: src/ServerConnect.cpp
 msgid "Failed to connect to all obfuscated static servers listed. Making another pass without obfuscation."
 msgstr ""
@@ -7675,21 +7714,8 @@ msgid "[PartFile]"
 msgstr ""
 
 #: src/TextClient.cpp
-msgid "Search expired or unknown ID. Start a new search.\n"
-msgstr ""
-
-#: src/TextClient.cpp
 #, c-format
 msgid "Number of search results: %i\n"
-msgstr ""
-
-#: src/TextClient.cpp
-#, c-format
-msgid "Search progress: %u %% \n"
-msgstr ""
-
-#: src/TextClient.cpp
-msgid "Search progress not available"
 msgstr ""
 
 #: src/TextClient.cpp

--- a/po/ca.po
+++ b/po/ca.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 13:43+0200\n"
+"POT-Creation-Date: 2026-08-24 15:13+0200\n"
 "PO-Revision-Date: 2026-08-22 15:16+0000\n"
 "Last-Translator: minterior <minterior@gmail.com>\n"
 "Language-Team: Català\n"
@@ -6649,6 +6649,47 @@ msgstr "Cancel·lat"
 msgid "New"
 msgstr "Nou"
 
+#: src/SearchProgressReport.cpp
+#, fuzzy
+msgid "running"
+msgstr "Funcionant"
+
+#: src/SearchProgressReport.cpp
+#, fuzzy
+msgid "finished"
+msgstr "Finès"
+
+#: src/SearchProgressReport.cpp
+msgid "idle"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+#, c-format
+msgid "Search %u: %s, %u %% (%u results)\n"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+#, c-format
+msgid "Search %u \"%s\": %s, %u %% (%u results)\n"
+msgstr ""
+
+#: src/SearchProgressReport.cpp src/TextClient.cpp
+msgid "Search expired or unknown ID. Start a new search.\n"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+#, c-format
+msgid "Search progress: %u %% \n"
+msgstr "Progrés de la cerca: %u %% \n"
+
+#: src/SearchProgressReport.cpp
+msgid "Search progress not available"
+msgstr "Progrés de cerca no disponible"
+
+#: src/SearchProgressReport.cpp
+msgid "No search to report on.\n"
+msgstr ""
+
 #: src/ServerConnect.cpp
 #, fuzzy
 msgid "Failed to connect to all obfuscated static servers listed. Making another pass without obfuscation."
@@ -7902,22 +7943,9 @@ msgid "[PartFile]"
 msgstr "[Fitxer de parts]"
 
 #: src/TextClient.cpp
-msgid "Search expired or unknown ID. Start a new search.\n"
-msgstr ""
-
-#: src/TextClient.cpp
 #, c-format
 msgid "Number of search results: %i\n"
 msgstr "Número de resultats de la cerca: %i\n"
-
-#: src/TextClient.cpp
-#, c-format
-msgid "Search progress: %u %% \n"
-msgstr "Progrés de la cerca: %u %% \n"
-
-#: src/TextClient.cpp
-msgid "Search progress not available"
-msgstr "Progrés de cerca no disponible"
 
 #: src/TextClient.cpp
 #, c-format

--- a/po/cs.po
+++ b/po/cs.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 13:43+0200\n"
+"POT-Creation-Date: 2026-08-24 15:13+0200\n"
 "PO-Revision-Date: 2026-08-22 15:58+0000\n"
 "Last-Translator: David Watzke <david@watzke.cz>\n"
 "Language-Team: cs <cs@li.org>\n"
@@ -6637,6 +6637,48 @@ msgstr "Zrušeno"
 msgid "New"
 msgstr "Nový"
 
+#: src/SearchProgressReport.cpp
+#, fuzzy
+msgid "running"
+msgstr "Běží"
+
+#: src/SearchProgressReport.cpp
+#, fuzzy
+msgid "finished"
+msgstr "Finština"
+
+#: src/SearchProgressReport.cpp
+msgid "idle"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+#, c-format
+msgid "Search %u: %s, %u %% (%u results)\n"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+#, c-format
+msgid "Search %u \"%s\": %s, %u %% (%u results)\n"
+msgstr ""
+
+#: src/SearchProgressReport.cpp src/TextClient.cpp
+msgid "Search expired or unknown ID. Start a new search.\n"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+#, c-format
+msgid "Search progress: %u %% \n"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+#, fuzzy
+msgid "Search progress not available"
+msgstr "Zobrazit procenta průběhu"
+
+#: src/SearchProgressReport.cpp
+msgid "No search to report on.\n"
+msgstr ""
+
 #: src/ServerConnect.cpp
 msgid "Failed to connect to all obfuscated static servers listed. Making another pass without obfuscation."
 msgstr "Selhalo připojení ke všem stálým serverům s obfuskací. Zkouším to znovu bez obfuskace."
@@ -7912,23 +7954,9 @@ msgid "[PartFile]"
 msgstr "[PartSoubor]"
 
 #: src/TextClient.cpp
-msgid "Search expired or unknown ID. Start a new search.\n"
-msgstr ""
-
-#: src/TextClient.cpp
 #, c-format
 msgid "Number of search results: %i\n"
 msgstr "Počet výsledků vyhledávání: %i\n"
-
-#: src/TextClient.cpp
-#, c-format
-msgid "Search progress: %u %% \n"
-msgstr ""
-
-#: src/TextClient.cpp
-#, fuzzy
-msgid "Search progress not available"
-msgstr "Zobrazit procenta průběhu"
 
 #: src/TextClient.cpp
 #, c-format

--- a/po/da.po
+++ b/po/da.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 13:43+0200\n"
+"POT-Creation-Date: 2026-08-24 15:13+0200\n"
 "PO-Revision-Date: 2026-08-22 15:22+0000\n"
 "Last-Translator: Alex Thomsen Leth <alexl@stofanet.dk>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -6574,6 +6574,48 @@ msgstr "Afbryd"
 msgid "New"
 msgstr ""
 
+#: src/SearchProgressReport.cpp
+#, fuzzy
+msgid "running"
+msgstr "aMule kører"
+
+#: src/SearchProgressReport.cpp
+#, fuzzy
+msgid "finished"
+msgstr "Finnish"
+
+#: src/SearchProgressReport.cpp
+msgid "idle"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+#, c-format
+msgid "Search %u: %s, %u %% (%u results)\n"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+#, c-format
+msgid "Search %u \"%s\": %s, %u %% (%u results)\n"
+msgstr ""
+
+#: src/SearchProgressReport.cpp src/TextClient.cpp
+msgid "Search expired or unknown ID. Start a new search.\n"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+#, c-format
+msgid "Search progress: %u %% \n"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+#, fuzzy
+msgid "Search progress not available"
+msgstr "%s Ikke tilgÃŠngelig"
+
+#: src/SearchProgressReport.cpp
+msgid "No search to report on.\n"
+msgstr ""
+
 #: src/ServerConnect.cpp
 msgid "Failed to connect to all obfuscated static servers listed. Making another pass without obfuscation."
 msgstr ""
@@ -7828,23 +7870,9 @@ msgid "[PartFile]"
 msgstr "[DeleAfFil]"
 
 #: src/TextClient.cpp
-msgid "Search expired or unknown ID. Start a new search.\n"
-msgstr ""
-
-#: src/TextClient.cpp
 #, c-format
 msgid "Number of search results: %i\n"
 msgstr ""
-
-#: src/TextClient.cpp
-#, c-format
-msgid "Search progress: %u %% \n"
-msgstr ""
-
-#: src/TextClient.cpp
-#, fuzzy
-msgid "Search progress not available"
-msgstr "%s Ikke tilgÃŠngelig"
 
 #: src/TextClient.cpp
 #, c-format

--- a/po/de.po
+++ b/po/de.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 13:43+0200\n"
+"POT-Creation-Date: 2026-08-24 15:13+0200\n"
 "PO-Revision-Date: 2026-08-22 15:23+0000\n"
 "Last-Translator: Werner Mahr <werner@vollstreckernet.de>\n"
 "Language-Team: German <>\n"
@@ -6645,6 +6645,47 @@ msgstr "Abgebrochen"
 msgid "New"
 msgstr "Neu"
 
+#: src/SearchProgressReport.cpp
+#, fuzzy
+msgid "running"
+msgstr "Läuft"
+
+#: src/SearchProgressReport.cpp
+#, fuzzy
+msgid "finished"
+msgstr "Finnisch"
+
+#: src/SearchProgressReport.cpp
+msgid "idle"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+#, c-format
+msgid "Search %u: %s, %u %% (%u results)\n"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+#, c-format
+msgid "Search %u \"%s\": %s, %u %% (%u results)\n"
+msgstr ""
+
+#: src/SearchProgressReport.cpp src/TextClient.cpp
+msgid "Search expired or unknown ID. Start a new search.\n"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+#, c-format
+msgid "Search progress: %u %% \n"
+msgstr "Vergleichsfortschritt: %u %% \n"
+
+#: src/SearchProgressReport.cpp
+msgid "Search progress not available"
+msgstr "Fortschritt der Suche nicht verfügbar"
+
+#: src/SearchProgressReport.cpp
+msgid "No search to report on.\n"
+msgstr ""
+
 #: src/ServerConnect.cpp
 #, fuzzy
 msgid "Failed to connect to all obfuscated static servers listed. Making another pass without obfuscation."
@@ -7895,22 +7936,9 @@ msgid "[PartFile]"
 msgstr "[PartFile]"
 
 #: src/TextClient.cpp
-msgid "Search expired or unknown ID. Start a new search.\n"
-msgstr ""
-
-#: src/TextClient.cpp
 #, c-format
 msgid "Number of search results: %i\n"
 msgstr "Anzahl der Suchergebnisse: %i\n"
-
-#: src/TextClient.cpp
-#, c-format
-msgid "Search progress: %u %% \n"
-msgstr "Vergleichsfortschritt: %u %% \n"
-
-#: src/TextClient.cpp
-msgid "Search progress not available"
-msgstr "Fortschritt der Suche nicht verfügbar"
 
 #: src/TextClient.cpp
 #, c-format

--- a/po/el.po
+++ b/po/el.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 13:43+0200\n"
+"POT-Creation-Date: 2026-08-24 15:13+0200\n"
 "PO-Revision-Date: 2026-08-22 15:25+0000\n"
 "Last-Translator: Dimitris <dgalanak@yahoo.com>\n"
 "Language-Team: Greek\n"
@@ -6690,6 +6690,48 @@ msgstr "Ακύρωση"
 msgid "New"
 msgstr ""
 
+#: src/SearchProgressReport.cpp
+#, fuzzy
+msgid "running"
+msgstr "Τρέχει"
+
+#: src/SearchProgressReport.cpp
+#, fuzzy
+msgid "finished"
+msgstr "Φιλανδικά"
+
+#: src/SearchProgressReport.cpp
+msgid "idle"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+#, c-format
+msgid "Search %u: %s, %u %% (%u results)\n"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+#, c-format
+msgid "Search %u \"%s\": %s, %u %% (%u results)\n"
+msgstr ""
+
+#: src/SearchProgressReport.cpp src/TextClient.cpp
+msgid "Search expired or unknown ID. Start a new search.\n"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+#, c-format
+msgid "Search progress: %u %% \n"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+#, fuzzy
+msgid "Search progress not available"
+msgstr "Εμφάνιση ποσοστού προόδου"
+
+#: src/SearchProgressReport.cpp
+msgid "No search to report on.\n"
+msgstr ""
+
 #: src/ServerConnect.cpp
 #, fuzzy
 msgid "Failed to connect to all obfuscated static servers listed. Making another pass without obfuscation."
@@ -7952,23 +7994,9 @@ msgid "[PartFile]"
 msgstr "[Μέρος αρχείου]"
 
 #: src/TextClient.cpp
-msgid "Search expired or unknown ID. Start a new search.\n"
-msgstr ""
-
-#: src/TextClient.cpp
 #, c-format
 msgid "Number of search results: %i\n"
 msgstr "Αριθμός αποτελεσμάτων αναζήτησης: %i\n"
-
-#: src/TextClient.cpp
-#, c-format
-msgid "Search progress: %u %% \n"
-msgstr ""
-
-#: src/TextClient.cpp
-#, fuzzy
-msgid "Search progress not available"
-msgstr "Εμφάνιση ποσοστού προόδου"
 
 #: src/TextClient.cpp
 #, c-format

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 13:43+0200\n"
+"POT-Creation-Date: 2026-08-24 15:13+0200\n"
 "PO-Revision-Date: 2020-03-04 14:43+0100\n"
 "Last-Translator: Dévai Tamás <devait@vnet.hu>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -6450,6 +6450,45 @@ msgstr ""
 msgid "New"
 msgstr ""
 
+#: src/SearchProgressReport.cpp
+msgid "running"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+msgid "finished"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+msgid "idle"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+#, c-format
+msgid "Search %u: %s, %u %% (%u results)\n"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+#, c-format
+msgid "Search %u \"%s\": %s, %u %% (%u results)\n"
+msgstr ""
+
+#: src/SearchProgressReport.cpp src/TextClient.cpp
+msgid "Search expired or unknown ID. Start a new search.\n"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+#, c-format
+msgid "Search progress: %u %% \n"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+msgid "Search progress not available"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+msgid "No search to report on.\n"
+msgstr ""
+
 #: src/ServerConnect.cpp
 msgid "Failed to connect to all obfuscated static servers listed. Making another pass without obfuscation."
 msgstr ""
@@ -7676,21 +7715,8 @@ msgid "[PartFile]"
 msgstr ""
 
 #: src/TextClient.cpp
-msgid "Search expired or unknown ID. Start a new search.\n"
-msgstr ""
-
-#: src/TextClient.cpp
 #, c-format
 msgid "Number of search results: %i\n"
-msgstr ""
-
-#: src/TextClient.cpp
-#, c-format
-msgid "Search progress: %u %% \n"
-msgstr ""
-
-#: src/TextClient.cpp
-msgid "Search progress not available"
 msgstr ""
 
 #: src/TextClient.cpp

--- a/po/es.po
+++ b/po/es.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 13:43+0200\n"
+"POT-Creation-Date: 2026-08-24 15:13+0200\n"
 "PO-Revision-Date: 2026-08-22 15:26+0000\n"
 "Last-Translator: Diego Heras <ngosang@hotmail.es>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/amule/amule-application/es/>\n"
@@ -6599,6 +6599,48 @@ msgstr "Cancelada"
 msgid "New"
 msgstr "Nuevo"
 
+#: src/SearchProgressReport.cpp
+#, fuzzy
+msgid "running"
+msgstr "En ejecución"
+
+#: src/SearchProgressReport.cpp
+#, fuzzy
+msgid "finished"
+msgstr "Finés"
+
+#: src/SearchProgressReport.cpp
+msgid "idle"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+#, c-format
+msgid "Search %u: %s, %u %% (%u results)\n"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+#, c-format
+msgid "Search %u \"%s\": %s, %u %% (%u results)\n"
+msgstr ""
+
+#: src/SearchProgressReport.cpp src/TextClient.cpp
+msgid "Search expired or unknown ID. Start a new search.\n"
+msgstr "Búsqueda expirada o ID desconocido. Inicie una nueva búsqueda.\n"
+
+#: src/SearchProgressReport.cpp
+#, c-format
+msgid "Search progress: %u %% \n"
+msgstr "Progreso de la búsqueda: %u %% \n"
+
+#: src/SearchProgressReport.cpp
+msgid "Search progress not available"
+msgstr "Progreso de la búsqueda no disponible"
+
+#: src/SearchProgressReport.cpp
+#, fuzzy
+msgid "No search to report on.\n"
+msgstr "No se seleccionan archivos para exportar."
+
 #: src/ServerConnect.cpp
 msgid "Failed to connect to all obfuscated static servers listed. Making another pass without obfuscation."
 msgstr "No se pudo conectar a ninguno de los servidores ofuscados estáticos en la lista. Haciendo otro intento sin ofuscación."
@@ -7840,22 +7882,9 @@ msgid "[PartFile]"
 msgstr "[Archivo de partes]"
 
 #: src/TextClient.cpp
-msgid "Search expired or unknown ID. Start a new search.\n"
-msgstr "Búsqueda expirada o ID desconocido. Inicie una nueva búsqueda.\n"
-
-#: src/TextClient.cpp
 #, c-format
 msgid "Number of search results: %i\n"
 msgstr "Número de resultados de la búsqueda: %i\n"
-
-#: src/TextClient.cpp
-#, c-format
-msgid "Search progress: %u %% \n"
-msgstr "Progreso de la búsqueda: %u %% \n"
-
-#: src/TextClient.cpp
-msgid "Search progress not available"
-msgstr "Progreso de la búsqueda no disponible"
 
 #: src/TextClient.cpp
 #, c-format

--- a/po/et_EE.po
+++ b/po/et_EE.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 13:43+0200\n"
+"POT-Creation-Date: 2026-08-24 15:13+0200\n"
 "PO-Revision-Date: 2026-08-22 15:27+0000\n"
 "Last-Translator: \n"
 "Language-Team: Estonian <kde-i18n-doc@kde.org>\n"
@@ -6653,6 +6653,47 @@ msgstr "Loobutud"
 msgid "New"
 msgstr "Uus"
 
+#: src/SearchProgressReport.cpp
+#, fuzzy
+msgid "running"
+msgstr "Töötab"
+
+#: src/SearchProgressReport.cpp
+#, fuzzy
+msgid "finished"
+msgstr "Soome"
+
+#: src/SearchProgressReport.cpp
+msgid "idle"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+#, c-format
+msgid "Search %u: %s, %u %% (%u results)\n"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+#, c-format
+msgid "Search %u \"%s\": %s, %u %% (%u results)\n"
+msgstr ""
+
+#: src/SearchProgressReport.cpp src/TextClient.cpp
+msgid "Search expired or unknown ID. Start a new search.\n"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+#, c-format
+msgid "Search progress: %u %% \n"
+msgstr "Otsing : %u %% \n"
+
+#: src/SearchProgressReport.cpp
+msgid "Search progress not available"
+msgstr "Otsingu edenemist ei saa näidata"
+
+#: src/SearchProgressReport.cpp
+msgid "No search to report on.\n"
+msgstr ""
+
 #: src/ServerConnect.cpp
 #, fuzzy
 msgid "Failed to connect to all obfuscated static servers listed. Making another pass without obfuscation."
@@ -7906,22 +7947,9 @@ msgid "[PartFile]"
 msgstr "[FailiOsa]"
 
 #: src/TextClient.cpp
-msgid "Search expired or unknown ID. Start a new search.\n"
-msgstr ""
-
-#: src/TextClient.cpp
 #, c-format
 msgid "Number of search results: %i\n"
 msgstr "Otsingu tulemusi: %i\n"
-
-#: src/TextClient.cpp
-#, c-format
-msgid "Search progress: %u %% \n"
-msgstr "Otsing : %u %% \n"
-
-#: src/TextClient.cpp
-msgid "Search progress not available"
-msgstr "Otsingu edenemist ei saa näidata"
 
 #: src/TextClient.cpp
 #, c-format

--- a/po/eu.po
+++ b/po/eu.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 13:43+0200\n"
+"POT-Creation-Date: 2026-08-24 15:13+0200\n"
 "PO-Revision-Date: 2026-08-22 15:28+0000\n"
 "Last-Translator: Piarres Beobide <pi@beobide.net>\n"
 "Language-Team: Euskara <librezale@librezale.org>\n"
@@ -6652,6 +6652,47 @@ msgstr "Utzia"
 msgid "New"
 msgstr "Berria"
 
+#: src/SearchProgressReport.cpp
+#, fuzzy
+msgid "running"
+msgstr "Martxan"
+
+#: src/SearchProgressReport.cpp
+#, fuzzy
+msgid "finished"
+msgstr "Finlandiera"
+
+#: src/SearchProgressReport.cpp
+msgid "idle"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+#, c-format
+msgid "Search %u: %s, %u %% (%u results)\n"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+#, c-format
+msgid "Search %u \"%s\": %s, %u %% (%u results)\n"
+msgstr ""
+
+#: src/SearchProgressReport.cpp src/TextClient.cpp
+msgid "Search expired or unknown ID. Start a new search.\n"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+#, c-format
+msgid "Search progress: %u %% \n"
+msgstr "Bilaketa aurrerapena: %u %% \n"
+
+#: src/SearchProgressReport.cpp
+msgid "Search progress not available"
+msgstr "Bilaketa aurrerapena ez dago eskuragarri"
+
+#: src/SearchProgressReport.cpp
+msgid "No search to report on.\n"
+msgstr ""
+
 #: src/ServerConnect.cpp
 #, fuzzy
 msgid "Failed to connect to all obfuscated static servers listed. Making another pass without obfuscation."
@@ -7902,22 +7943,9 @@ msgid "[PartFile]"
 msgstr "[ZatiFitxategia]"
 
 #: src/TextClient.cpp
-msgid "Search expired or unknown ID. Start a new search.\n"
-msgstr ""
-
-#: src/TextClient.cpp
 #, c-format
 msgid "Number of search results: %i\n"
 msgstr "Bilaketa emaitza kopurua: %i\n"
-
-#: src/TextClient.cpp
-#, c-format
-msgid "Search progress: %u %% \n"
-msgstr "Bilaketa aurrerapena: %u %% \n"
-
-#: src/TextClient.cpp
-msgid "Search progress not available"
-msgstr "Bilaketa aurrerapena ez dago eskuragarri"
 
 #: src/TextClient.cpp
 #, c-format

--- a/po/fi.po
+++ b/po/fi.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 13:43+0200\n"
+"POT-Creation-Date: 2026-08-24 15:13+0200\n"
 "PO-Revision-Date: 2026-08-22 15:29+0000\n"
 "Last-Translator: Tapio Rantala <tapio.rantala@iki.fi>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -6652,6 +6652,47 @@ msgstr "Peruutettu"
 msgid "New"
 msgstr "Uusi"
 
+#: src/SearchProgressReport.cpp
+#, fuzzy
+msgid "running"
+msgstr "Käynnissä"
+
+#: src/SearchProgressReport.cpp
+#, fuzzy
+msgid "finished"
+msgstr "Suomi"
+
+#: src/SearchProgressReport.cpp
+msgid "idle"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+#, c-format
+msgid "Search %u: %s, %u %% (%u results)\n"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+#, c-format
+msgid "Search %u \"%s\": %s, %u %% (%u results)\n"
+msgstr ""
+
+#: src/SearchProgressReport.cpp src/TextClient.cpp
+msgid "Search expired or unknown ID. Start a new search.\n"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+#, c-format
+msgid "Search progress: %u %% \n"
+msgstr "Haun edistyminen: %u %% \n"
+
+#: src/SearchProgressReport.cpp
+msgid "Search progress not available"
+msgstr "Haun edistyminen ei ole tiedossa"
+
+#: src/SearchProgressReport.cpp
+msgid "No search to report on.\n"
+msgstr ""
+
 #: src/ServerConnect.cpp
 #, fuzzy
 msgid "Failed to connect to all obfuscated static servers listed. Making another pass without obfuscation."
@@ -7902,22 +7943,9 @@ msgid "[PartFile]"
 msgstr "[Osatiedosto]"
 
 #: src/TextClient.cpp
-msgid "Search expired or unknown ID. Start a new search.\n"
-msgstr ""
-
-#: src/TextClient.cpp
 #, c-format
 msgid "Number of search results: %i\n"
 msgstr "Hakutuloksia: %i\n"
-
-#: src/TextClient.cpp
-#, c-format
-msgid "Search progress: %u %% \n"
-msgstr "Haun edistyminen: %u %% \n"
-
-#: src/TextClient.cpp
-msgid "Search progress not available"
-msgstr "Haun edistyminen ei ole tiedossa"
 
 #: src/TextClient.cpp
 #, c-format

--- a/po/fr.po
+++ b/po/fr.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 13:43+0200\n"
+"POT-Creation-Date: 2026-08-24 15:13+0200\n"
 "PO-Revision-Date: 2026-08-22 15:30+0000\n"
 "Last-Translator: Dylan Aïssi <bob.dybian@gmail.com>\n"
 "Language-Team: Français\n"
@@ -6594,6 +6594,48 @@ msgstr "Annulé"
 msgid "New"
 msgstr "Nouveau"
 
+#: src/SearchProgressReport.cpp
+#, fuzzy
+msgid "running"
+msgstr "En marche"
+
+#: src/SearchProgressReport.cpp
+#, fuzzy
+msgid "finished"
+msgstr "Finlandais"
+
+#: src/SearchProgressReport.cpp
+msgid "idle"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+#, c-format
+msgid "Search %u: %s, %u %% (%u results)\n"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+#, c-format
+msgid "Search %u \"%s\": %s, %u %% (%u results)\n"
+msgstr ""
+
+#: src/SearchProgressReport.cpp src/TextClient.cpp
+msgid "Search expired or unknown ID. Start a new search.\n"
+msgstr "Recherche expirée ou ID inconnue. Démarrez une nouvelle recherche.\n"
+
+#: src/SearchProgressReport.cpp
+#, c-format
+msgid "Search progress: %u %% \n"
+msgstr "État d'avancement de la recherche : %u %% \n"
+
+#: src/SearchProgressReport.cpp
+msgid "Search progress not available"
+msgstr "Progrès de la recherche indisponibles"
+
+#: src/SearchProgressReport.cpp
+#, fuzzy
+msgid "No search to report on.\n"
+msgstr "Aucun fichier n'a été sélectionné pour être exporté."
+
 #: src/ServerConnect.cpp
 msgid "Failed to connect to all obfuscated static servers listed. Making another pass without obfuscation."
 msgstr "Échec de la connexion à tous les serveurs statiques brouillés listés. Nouvel essai sans brouillage."
@@ -7835,22 +7877,9 @@ msgid "[PartFile]"
 msgstr "[Fichier .part]"
 
 #: src/TextClient.cpp
-msgid "Search expired or unknown ID. Start a new search.\n"
-msgstr "Recherche expirée ou ID inconnue. Démarrez une nouvelle recherche.\n"
-
-#: src/TextClient.cpp
 #, c-format
 msgid "Number of search results: %i\n"
 msgstr "Nombres de résultats de la recherche : %i\n"
-
-#: src/TextClient.cpp
-#, c-format
-msgid "Search progress: %u %% \n"
-msgstr "État d'avancement de la recherche : %u %% \n"
-
-#: src/TextClient.cpp
-msgid "Search progress not available"
-msgstr "Progrès de la recherche indisponibles"
 
 #: src/TextClient.cpp
 #, c-format

--- a/po/gl.po
+++ b/po/gl.po
@@ -24,7 +24,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 13:43+0200\n"
+"POT-Creation-Date: 2026-08-24 15:13+0200\n"
 "PO-Revision-Date: 2026-08-22 15:31+0000\n"
 "Last-Translator: Pablo <parodper@gmail.com>\n"
 "Language-Team: http://forum.amule.org/index.php?topic=13883\n"
@@ -6659,6 +6659,47 @@ msgstr "Cancelado"
 msgid "New"
 msgstr "Novo"
 
+#: src/SearchProgressReport.cpp
+#, fuzzy
+msgid "running"
+msgstr "Executando"
+
+#: src/SearchProgressReport.cpp
+#, fuzzy
+msgid "finished"
+msgstr "Finlandés"
+
+#: src/SearchProgressReport.cpp
+msgid "idle"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+#, c-format
+msgid "Search %u: %s, %u %% (%u results)\n"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+#, c-format
+msgid "Search %u \"%s\": %s, %u %% (%u results)\n"
+msgstr ""
+
+#: src/SearchProgressReport.cpp src/TextClient.cpp
+msgid "Search expired or unknown ID. Start a new search.\n"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+#, c-format
+msgid "Search progress: %u %% \n"
+msgstr "Progreso da busca: %u %% \n"
+
+#: src/SearchProgressReport.cpp
+msgid "Search progress not available"
+msgstr "Progreso da busca non dispoñible"
+
+#: src/SearchProgressReport.cpp
+msgid "No search to report on.\n"
+msgstr ""
+
 #: src/ServerConnect.cpp
 #, fuzzy
 msgid "Failed to connect to all obfuscated static servers listed. Making another pass without obfuscation."
@@ -7910,22 +7951,9 @@ msgid "[PartFile]"
 msgstr "[PartFile]"
 
 #: src/TextClient.cpp
-msgid "Search expired or unknown ID. Start a new search.\n"
-msgstr ""
-
-#: src/TextClient.cpp
 #, c-format
 msgid "Number of search results: %i\n"
 msgstr "Número de resultados na busca: %i\n"
-
-#: src/TextClient.cpp
-#, c-format
-msgid "Search progress: %u %% \n"
-msgstr "Progreso da busca: %u %% \n"
-
-#: src/TextClient.cpp
-msgid "Search progress not available"
-msgstr "Progreso da busca non dispoñible"
 
 #: src/TextClient.cpp
 #, c-format

--- a/po/he.po
+++ b/po/he.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 13:43+0200\n"
+"POT-Creation-Date: 2026-08-24 15:13+0200\n"
 "PO-Revision-Date: 2026-08-22 15:32+0000\n"
 "Last-Translator: Peace Kramer <kpeace1@gmail.com>\n"
 "Language-Team: Hebrew\n"
@@ -6615,6 +6615,47 @@ msgstr "ביטול"
 msgid "New"
 msgstr ""
 
+#: src/SearchProgressReport.cpp
+#, fuzzy
+msgid "running"
+msgstr "פועל"
+
+#: src/SearchProgressReport.cpp
+#, fuzzy
+msgid "finished"
+msgstr "פינית"
+
+#: src/SearchProgressReport.cpp
+msgid "idle"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+#, c-format
+msgid "Search %u: %s, %u %% (%u results)\n"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+#, c-format
+msgid "Search %u \"%s\": %s, %u %% (%u results)\n"
+msgstr ""
+
+#: src/SearchProgressReport.cpp src/TextClient.cpp
+msgid "Search expired or unknown ID. Start a new search.\n"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+#, c-format
+msgid "Search progress: %u %% \n"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+msgid "Search progress not available"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+msgid "No search to report on.\n"
+msgstr ""
+
 #: src/ServerConnect.cpp
 #, fuzzy
 msgid "Failed to connect to all obfuscated static servers listed. Making another pass without obfuscation."
@@ -7875,22 +7916,9 @@ msgid "[PartFile]"
 msgstr "[קובץ-חלקים]"
 
 #: src/TextClient.cpp
-msgid "Search expired or unknown ID. Start a new search.\n"
-msgstr ""
-
-#: src/TextClient.cpp
 #, c-format
 msgid "Number of search results: %i\n"
 msgstr "מספר תוצאות חיפוש: %i\n"
-
-#: src/TextClient.cpp
-#, c-format
-msgid "Search progress: %u %% \n"
-msgstr ""
-
-#: src/TextClient.cpp
-msgid "Search progress not available"
-msgstr ""
 
 #: src/TextClient.cpp
 #, c-format

--- a/po/hr.po
+++ b/po/hr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 13:43+0200\n"
+"POT-Creation-Date: 2026-08-24 15:13+0200\n"
 "PO-Revision-Date: 2026-08-22 15:32+0000\n"
 "Last-Translator: Sebastiano Pistore <sebastiano.pistore.info@aol.com>\n"
 "Language-Team: https://github.com/amule-org/amule <forum@aMule.org>\n"
@@ -6601,6 +6601,48 @@ msgstr "Otkaz"
 msgid "New"
 msgstr "Novo"
 
+#: src/SearchProgressReport.cpp
+#, fuzzy
+msgid "running"
+msgstr "Radi"
+
+#: src/SearchProgressReport.cpp
+#, fuzzy
+msgid "finished"
+msgstr "Finski"
+
+#: src/SearchProgressReport.cpp
+msgid "idle"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+#, c-format
+msgid "Search %u: %s, %u %% (%u results)\n"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+#, c-format
+msgid "Search %u \"%s\": %s, %u %% (%u results)\n"
+msgstr ""
+
+#: src/SearchProgressReport.cpp src/TextClient.cpp
+msgid "Search expired or unknown ID. Start a new search.\n"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+#, c-format
+msgid "Search progress: %u %% \n"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+#, fuzzy
+msgid "Search progress not available"
+msgstr "%s Nije dostupan"
+
+#: src/SearchProgressReport.cpp
+msgid "No search to report on.\n"
+msgstr ""
+
 #: src/ServerConnect.cpp
 #, fuzzy
 msgid "Failed to connect to all obfuscated static servers listed. Making another pass without obfuscation."
@@ -7871,23 +7913,9 @@ msgid "[PartFile]"
 msgstr ""
 
 #: src/TextClient.cpp
-msgid "Search expired or unknown ID. Start a new search.\n"
-msgstr ""
-
-#: src/TextClient.cpp
 #, c-format
 msgid "Number of search results: %i\n"
 msgstr ""
-
-#: src/TextClient.cpp
-#, c-format
-msgid "Search progress: %u %% \n"
-msgstr ""
-
-#: src/TextClient.cpp
-#, fuzzy
-msgid "Search progress not available"
-msgstr "%s Nije dostupan"
 
 #: src/TextClient.cpp
 #, c-format

--- a/po/hu.po
+++ b/po/hu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 13:43+0200\n"
+"POT-Creation-Date: 2026-08-24 15:13+0200\n"
 "PO-Revision-Date: 2026-08-22 15:33+0000\n"
 "Last-Translator: Dévai Tamás <gonosztopi@amule.org>\n"
 "Language-Team: Hungarian <hu@li.org>\n"
@@ -6621,6 +6621,47 @@ msgstr "Megszakítva"
 msgid "New"
 msgstr "Új"
 
+#: src/SearchProgressReport.cpp
+#, fuzzy
+msgid "running"
+msgstr "Fut"
+
+#: src/SearchProgressReport.cpp
+#, fuzzy
+msgid "finished"
+msgstr "Finn"
+
+#: src/SearchProgressReport.cpp
+msgid "idle"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+#, c-format
+msgid "Search %u: %s, %u %% (%u results)\n"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+#, c-format
+msgid "Search %u \"%s\": %s, %u %% (%u results)\n"
+msgstr ""
+
+#: src/SearchProgressReport.cpp src/TextClient.cpp
+msgid "Search expired or unknown ID. Start a new search.\n"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+#, c-format
+msgid "Search progress: %u %% \n"
+msgstr "Keresés haladása: %u %% \n"
+
+#: src/SearchProgressReport.cpp
+msgid "Search progress not available"
+msgstr "Keresés haladása nem elérhető"
+
+#: src/SearchProgressReport.cpp
+msgid "No search to report on.\n"
+msgstr ""
+
 #: src/ServerConnect.cpp
 #, fuzzy
 msgid "Failed to connect to all obfuscated static servers listed. Making another pass without obfuscation."
@@ -7856,22 +7897,9 @@ msgid "[PartFile]"
 msgstr "[Részfájl]"
 
 #: src/TextClient.cpp
-msgid "Search expired or unknown ID. Start a new search.\n"
-msgstr ""
-
-#: src/TextClient.cpp
 #, c-format
 msgid "Number of search results: %i\n"
 msgstr "Keresés eredményeinek száma: %i\n"
-
-#: src/TextClient.cpp
-#, c-format
-msgid "Search progress: %u %% \n"
-msgstr "Keresés haladása: %u %% \n"
-
-#: src/TextClient.cpp
-msgid "Search progress not available"
-msgstr "Keresés haladása nem elérhető"
 
 #: src/TextClient.cpp
 #, c-format

--- a/po/it.po
+++ b/po/it.po
@@ -19,7 +19,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule 2.3.3\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 13:43+0200\n"
+"POT-Creation-Date: 2026-08-24 15:13+0200\n"
 "PO-Revision-Date: 2026-08-22 15:34+0000\n"
 "Last-Translator: got3nks <got3nks@users.noreply.github.com>\n"
 "Language-Team: SebastianoPistore.info@protonmail.ch\n"
@@ -6601,6 +6601,48 @@ msgstr "Annullata"
 msgid "New"
 msgstr "Nuovo"
 
+#: src/SearchProgressReport.cpp
+#, fuzzy
+msgid "running"
+msgstr "Attivo"
+
+#: src/SearchProgressReport.cpp
+#, fuzzy
+msgid "finished"
+msgstr "Finlandese"
+
+#: src/SearchProgressReport.cpp
+msgid "idle"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+#, c-format
+msgid "Search %u: %s, %u %% (%u results)\n"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+#, c-format
+msgid "Search %u \"%s\": %s, %u %% (%u results)\n"
+msgstr ""
+
+#: src/SearchProgressReport.cpp src/TextClient.cpp
+msgid "Search expired or unknown ID. Start a new search.\n"
+msgstr "Ricerca scaduta o ID sconosciuto. Avvia una nuova ricerca.\n"
+
+#: src/SearchProgressReport.cpp
+#, c-format
+msgid "Search progress: %u %% \n"
+msgstr "Avanzamento ricerca: %u %% \n"
+
+#: src/SearchProgressReport.cpp
+msgid "Search progress not available"
+msgstr "Avanzamento ricerca non disponibile"
+
+#: src/SearchProgressReport.cpp
+#, fuzzy
+msgid "No search to report on.\n"
+msgstr "Nessun file selezionato da esportare."
+
 #: src/ServerConnect.cpp
 msgid "Failed to connect to all obfuscated static servers listed. Making another pass without obfuscation."
 msgstr "Impossibile collegarsi ai server statici in lista con offuscamento di protocollo. Ci riprovo senza offuscamento."
@@ -7842,22 +7884,9 @@ msgid "[PartFile]"
 msgstr "[Partfile]"
 
 #: src/TextClient.cpp
-msgid "Search expired or unknown ID. Start a new search.\n"
-msgstr "Ricerca scaduta o ID sconosciuto. Avvia una nuova ricerca.\n"
-
-#: src/TextClient.cpp
 #, c-format
 msgid "Number of search results: %i\n"
 msgstr "Totale risultati della ricerca: %i\n"
-
-#: src/TextClient.cpp
-#, c-format
-msgid "Search progress: %u %% \n"
-msgstr "Avanzamento ricerca: %u %% \n"
-
-#: src/TextClient.cpp
-msgid "Search progress not available"
-msgstr "Avanzamento ricerca non disponibile"
 
 #: src/TextClient.cpp
 #, c-format

--- a/po/ja.po
+++ b/po/ja.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 13:43+0200\n"
+"POT-Creation-Date: 2026-08-24 15:13+0200\n"
 "PO-Revision-Date: 2026-08-22 15:35+0000\n"
 "Last-Translator: \n"
 "Language-Team: Japanese\n"
@@ -6644,6 +6644,47 @@ msgstr "キャンセル"
 msgid "New"
 msgstr ""
 
+#: src/SearchProgressReport.cpp
+#, fuzzy
+msgid "running"
+msgstr "走っています"
+
+#: src/SearchProgressReport.cpp
+#, fuzzy
+msgid "finished"
+msgstr "フィンランド語"
+
+#: src/SearchProgressReport.cpp
+msgid "idle"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+#, c-format
+msgid "Search %u: %s, %u %% (%u results)\n"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+#, c-format
+msgid "Search %u \"%s\": %s, %u %% (%u results)\n"
+msgstr ""
+
+#: src/SearchProgressReport.cpp src/TextClient.cpp
+msgid "Search expired or unknown ID. Start a new search.\n"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+#, c-format
+msgid "Search progress: %u %% \n"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+msgid "Search progress not available"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+msgid "No search to report on.\n"
+msgstr ""
+
 #: src/ServerConnect.cpp
 #, fuzzy
 msgid "Failed to connect to all obfuscated static servers listed. Making another pass without obfuscation."
@@ -7888,22 +7929,9 @@ msgid "[PartFile]"
 msgstr "[部分ファイル]"
 
 #: src/TextClient.cpp
-msgid "Search expired or unknown ID. Start a new search.\n"
-msgstr ""
-
-#: src/TextClient.cpp
 #, c-format
 msgid "Number of search results: %i\n"
 msgstr "検索結果数：%i\n"
-
-#: src/TextClient.cpp
-#, c-format
-msgid "Search progress: %u %% \n"
-msgstr ""
-
-#: src/TextClient.cpp
-msgid "Search progress not available"
-msgstr ""
 
 #: src/TextClient.cpp
 #, c-format

--- a/po/ko_KR.po
+++ b/po/ko_KR.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 13:43+0200\n"
+"POT-Creation-Date: 2026-08-24 15:13+0200\n"
 "PO-Revision-Date: 2026-08-22 15:36+0000\n"
 "Last-Translator: Hyunju Kang <rexington@gmail.com>\n"
 "Language-Team: Korean <hoenny@daum.net>\n"
@@ -6681,6 +6681,47 @@ msgstr "취소"
 msgid "New"
 msgstr ""
 
+#: src/SearchProgressReport.cpp
+#, fuzzy
+msgid "running"
+msgstr "동작중"
+
+#: src/SearchProgressReport.cpp
+#, fuzzy
+msgid "finished"
+msgstr "필란드어"
+
+#: src/SearchProgressReport.cpp
+msgid "idle"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+#, c-format
+msgid "Search %u: %s, %u %% (%u results)\n"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+#, c-format
+msgid "Search %u \"%s\": %s, %u %% (%u results)\n"
+msgstr ""
+
+#: src/SearchProgressReport.cpp src/TextClient.cpp
+msgid "Search expired or unknown ID. Start a new search.\n"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+#, c-format
+msgid "Search progress: %u %% \n"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+msgid "Search progress not available"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+msgid "No search to report on.\n"
+msgstr ""
+
 #: src/ServerConnect.cpp
 #, fuzzy
 msgid "Failed to connect to all obfuscated static servers listed. Making another pass without obfuscation."
@@ -7953,22 +7994,9 @@ msgid "[PartFile]"
 msgstr "[부분 파일]"
 
 #: src/TextClient.cpp
-msgid "Search expired or unknown ID. Start a new search.\n"
-msgstr ""
-
-#: src/TextClient.cpp
 #, c-format
 msgid "Number of search results: %i\n"
 msgstr "검색된 결과 갯수: %i\n"
-
-#: src/TextClient.cpp
-#, c-format
-msgid "Search progress: %u %% \n"
-msgstr ""
-
-#: src/TextClient.cpp
-msgid "Search progress not available"
-msgstr ""
 
 #: src/TextClient.cpp
 #, c-format

--- a/po/lt.po
+++ b/po/lt.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 13:43+0200\n"
+"POT-Creation-Date: 2026-08-24 15:13+0200\n"
 "PO-Revision-Date: 2026-08-22 15:37+0000\n"
 "Last-Translator: Dovydas Sankauskas <laisve@gmail.com>\n"
 "Language-Team: Lithuanian <komp_lt@konf.lt>\n"
@@ -6710,6 +6710,47 @@ msgstr "Atšaukti"
 msgid "New"
 msgstr ""
 
+#: src/SearchProgressReport.cpp
+#, fuzzy
+msgid "running"
+msgstr "Dirbama"
+
+#: src/SearchProgressReport.cpp
+#, fuzzy
+msgid "finished"
+msgstr "Suomių"
+
+#: src/SearchProgressReport.cpp
+msgid "idle"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+#, c-format
+msgid "Search %u: %s, %u %% (%u results)\n"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+#, c-format
+msgid "Search %u \"%s\": %s, %u %% (%u results)\n"
+msgstr ""
+
+#: src/SearchProgressReport.cpp src/TextClient.cpp
+msgid "Search expired or unknown ID. Start a new search.\n"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+#, c-format
+msgid "Search progress: %u %% \n"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+msgid "Search progress not available"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+msgid "No search to report on.\n"
+msgstr ""
+
 #: src/ServerConnect.cpp
 #, fuzzy
 msgid "Failed to connect to all obfuscated static servers listed. Making another pass without obfuscation."
@@ -7990,22 +8031,9 @@ msgid "[PartFile]"
 msgstr "[Dalių failas]"
 
 #: src/TextClient.cpp
-msgid "Search expired or unknown ID. Start a new search.\n"
-msgstr ""
-
-#: src/TextClient.cpp
 #, c-format
 msgid "Number of search results: %i\n"
 msgstr "Paieškos rezultatų kiekis: %i\n"
-
-#: src/TextClient.cpp
-#, c-format
-msgid "Search progress: %u %% \n"
-msgstr ""
-
-#: src/TextClient.cpp
-msgid "Search progress not available"
-msgstr ""
 
 #: src/TextClient.cpp
 #, c-format

--- a/po/lv.po
+++ b/po/lv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 13:43+0200\n"
+"POT-Creation-Date: 2026-08-24 15:13+0200\n"
 "PO-Revision-Date: 2026-08-22 15:53+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -6491,6 +6491,46 @@ msgstr "Atcelts"
 msgid "New"
 msgstr "Jauns"
 
+#: src/SearchProgressReport.cpp
+msgid "running"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+#, fuzzy
+msgid "finished"
+msgstr "Somu"
+
+#: src/SearchProgressReport.cpp
+msgid "idle"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+#, c-format
+msgid "Search %u: %s, %u %% (%u results)\n"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+#, c-format
+msgid "Search %u \"%s\": %s, %u %% (%u results)\n"
+msgstr ""
+
+#: src/SearchProgressReport.cpp src/TextClient.cpp
+msgid "Search expired or unknown ID. Start a new search.\n"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+#, c-format
+msgid "Search progress: %u %% \n"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+msgid "Search progress not available"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+msgid "No search to report on.\n"
+msgstr ""
+
 #: src/ServerConnect.cpp
 msgid "Failed to connect to all obfuscated static servers listed. Making another pass without obfuscation."
 msgstr ""
@@ -7738,21 +7778,8 @@ msgid "[PartFile]"
 msgstr ""
 
 #: src/TextClient.cpp
-msgid "Search expired or unknown ID. Start a new search.\n"
-msgstr ""
-
-#: src/TextClient.cpp
 #, c-format
 msgid "Number of search results: %i\n"
-msgstr ""
-
-#: src/TextClient.cpp
-#, c-format
-msgid "Search progress: %u %% \n"
-msgstr ""
-
-#: src/TextClient.cpp
-msgid "Search progress not available"
 msgstr ""
 
 #: src/TextClient.cpp

--- a/po/nl.po
+++ b/po/nl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 13:43+0200\n"
+"POT-Creation-Date: 2026-08-24 15:13+0200\n"
 "PO-Revision-Date: 2026-08-22 15:38+0000\n"
 "Last-Translator: Marcel Pol <marcel@timelord.nl>\n"
 "Language-Team: Dutch <nl@li.org>\n"
@@ -6592,6 +6592,48 @@ msgstr "Geannuleerd"
 msgid "New"
 msgstr "Nieuw"
 
+#: src/SearchProgressReport.cpp
+#, fuzzy
+msgid "running"
+msgstr "Draaiende"
+
+#: src/SearchProgressReport.cpp
+#, fuzzy
+msgid "finished"
+msgstr "Fins"
+
+#: src/SearchProgressReport.cpp
+msgid "idle"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+#, c-format
+msgid "Search %u: %s, %u %% (%u results)\n"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+#, c-format
+msgid "Search %u \"%s\": %s, %u %% (%u results)\n"
+msgstr ""
+
+#: src/SearchProgressReport.cpp src/TextClient.cpp
+msgid "Search expired or unknown ID. Start a new search.\n"
+msgstr "Zoekopdracht verlopen of onbekende ID. Start een nieuwe zoekopdracht.\n"
+
+#: src/SearchProgressReport.cpp
+#, c-format
+msgid "Search progress: %u %% \n"
+msgstr "Voortgang zoeken: %u %% \n"
+
+#: src/SearchProgressReport.cpp
+msgid "Search progress not available"
+msgstr "Voortgang zoeken niet beschikbaar"
+
+#: src/SearchProgressReport.cpp
+#, fuzzy
+msgid "No search to report on.\n"
+msgstr "Geen bestanden geselecteerd om te exporteren."
+
 #: src/ServerConnect.cpp
 msgid "Failed to connect to all obfuscated static servers listed. Making another pass without obfuscation."
 msgstr "Kon geen verbinding maken met alle vermelde geobfusceerde statische servers. Er wordt nog een poging gedaan zonder obfuscatie."
@@ -7834,22 +7876,9 @@ msgid "[PartFile]"
 msgstr "[PartBestand]"
 
 #: src/TextClient.cpp
-msgid "Search expired or unknown ID. Start a new search.\n"
-msgstr "Zoekopdracht verlopen of onbekende ID. Start een nieuwe zoekopdracht.\n"
-
-#: src/TextClient.cpp
 #, c-format
 msgid "Number of search results: %i\n"
 msgstr "Aantal zoekresultaten: %i\n"
-
-#: src/TextClient.cpp
-#, c-format
-msgid "Search progress: %u %% \n"
-msgstr "Voortgang zoeken: %u %% \n"
-
-#: src/TextClient.cpp
-msgid "Search progress not available"
-msgstr "Voortgang zoeken niet beschikbaar"
 
 #: src/TextClient.cpp
 #, c-format

--- a/po/nn.po
+++ b/po/nn.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 13:43+0200\n"
+"POT-Creation-Date: 2026-08-24 15:13+0200\n"
 "PO-Revision-Date: 2026-08-22 15:39+0000\n"
 "Last-Translator: Hallvor Brunstad <Hallvor_1976@yahoo.com>\n"
 "Language-Team: <i18n-nn@lister.ping.uio.no>\n"
@@ -6683,6 +6683,47 @@ msgstr "Avbryt"
 msgid "New"
 msgstr ""
 
+#: src/SearchProgressReport.cpp
+#, fuzzy
+msgid "running"
+msgstr "Køyrer"
+
+#: src/SearchProgressReport.cpp
+#, fuzzy
+msgid "finished"
+msgstr "Finsk"
+
+#: src/SearchProgressReport.cpp
+msgid "idle"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+#, c-format
+msgid "Search %u: %s, %u %% (%u results)\n"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+#, c-format
+msgid "Search %u \"%s\": %s, %u %% (%u results)\n"
+msgstr ""
+
+#: src/SearchProgressReport.cpp src/TextClient.cpp
+msgid "Search expired or unknown ID. Start a new search.\n"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+#, c-format
+msgid "Search progress: %u %% \n"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+msgid "Search progress not available"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+msgid "No search to report on.\n"
+msgstr ""
+
 #: src/ServerConnect.cpp
 #, fuzzy
 msgid "Failed to connect to all obfuscated static servers listed. Making another pass without obfuscation."
@@ -7945,22 +7986,9 @@ msgid "[PartFile]"
 msgstr "[Delfil]"
 
 #: src/TextClient.cpp
-msgid "Search expired or unknown ID. Start a new search.\n"
-msgstr ""
-
-#: src/TextClient.cpp
 #, c-format
 msgid "Number of search results: %i\n"
 msgstr "Tal på søkjeresultat: %i\n"
-
-#: src/TextClient.cpp
-#, c-format
-msgid "Search progress: %u %% \n"
-msgstr ""
-
-#: src/TextClient.cpp
-msgid "Search progress not available"
-msgstr ""
 
 #: src/TextClient.cpp
 #, c-format

--- a/po/pl.po
+++ b/po/pl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 13:43+0200\n"
+"POT-Creation-Date: 2026-08-24 15:13+0200\n"
 "PO-Revision-Date: 2026-08-22 15:39+0000\n"
 "Last-Translator: Michał Trzebiatowski <hippie_1968@hotmail.com>\n"
 "Language-Team: translationproject.org/team/pl.html <translation-team-pl@lists.sourceforge.net>\n"
@@ -6689,6 +6689,48 @@ msgstr "Anulowane"
 msgid "New"
 msgstr "Nowy"
 
+#: src/SearchProgressReport.cpp
+#, fuzzy
+msgid "running"
+msgstr "Uruchomiony"
+
+#: src/SearchProgressReport.cpp
+#, fuzzy
+msgid "finished"
+msgstr "Fiński"
+
+#: src/SearchProgressReport.cpp
+msgid "idle"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+#, c-format
+msgid "Search %u: %s, %u %% (%u results)\n"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+#, c-format
+msgid "Search %u \"%s\": %s, %u %% (%u results)\n"
+msgstr ""
+
+#: src/SearchProgressReport.cpp src/TextClient.cpp
+msgid "Search expired or unknown ID. Start a new search.\n"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+#, c-format
+msgid "Search progress: %u %% \n"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+#, fuzzy
+msgid "Search progress not available"
+msgstr "Pokaż procent postępu"
+
+#: src/SearchProgressReport.cpp
+msgid "No search to report on.\n"
+msgstr ""
+
 #: src/ServerConnect.cpp
 #, fuzzy
 msgid "Failed to connect to all obfuscated static servers listed. Making another pass without obfuscation."
@@ -7962,23 +8004,9 @@ msgid "[PartFile]"
 msgstr "[Plik części]"
 
 #: src/TextClient.cpp
-msgid "Search expired or unknown ID. Start a new search.\n"
-msgstr ""
-
-#: src/TextClient.cpp
 #, c-format
 msgid "Number of search results: %i\n"
 msgstr "Liczba wyników wyszukiwania: %i\n"
-
-#: src/TextClient.cpp
-#, c-format
-msgid "Search progress: %u %% \n"
-msgstr ""
-
-#: src/TextClient.cpp
-#, fuzzy
-msgid "Search progress not available"
-msgstr "Pokaż procent postępu"
 
 #: src/TextClient.cpp
 #, c-format

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 13:43+0200\n"
+"POT-Creation-Date: 2026-08-24 15:13+0200\n"
 "PO-Revision-Date: 2026-08-22 15:41+0000\n"
 "Last-Translator: Marcelo Jimenez <mroberto@users.sourceforge.com>\n"
 "Language-Team: Português (Brasileiro) <pt@li.org>\n"
@@ -6595,6 +6595,48 @@ msgstr "Cancelado"
 msgid "New"
 msgstr "Novo"
 
+#: src/SearchProgressReport.cpp
+#, fuzzy
+msgid "running"
+msgstr "Rodando"
+
+#: src/SearchProgressReport.cpp
+#, fuzzy
+msgid "finished"
+msgstr "Finlandês"
+
+#: src/SearchProgressReport.cpp
+msgid "idle"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+#, c-format
+msgid "Search %u: %s, %u %% (%u results)\n"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+#, c-format
+msgid "Search %u \"%s\": %s, %u %% (%u results)\n"
+msgstr ""
+
+#: src/SearchProgressReport.cpp src/TextClient.cpp
+msgid "Search expired or unknown ID. Start a new search.\n"
+msgstr "Busca expirada ou ID desconhecido. Comece uma nova busca.\n"
+
+#: src/SearchProgressReport.cpp
+#, c-format
+msgid "Search progress: %u %% \n"
+msgstr "Progresso da busca: %u %% \n"
+
+#: src/SearchProgressReport.cpp
+msgid "Search progress not available"
+msgstr "Progresso da busca não disponível"
+
+#: src/SearchProgressReport.cpp
+#, fuzzy
+msgid "No search to report on.\n"
+msgstr "Nenhum arquivo foi selecionado para exportação."
+
 #: src/ServerConnect.cpp
 msgid "Failed to connect to all obfuscated static servers listed. Making another pass without obfuscation."
 msgstr "Falha ao conectar em todos servidores estáticos ofuscados listados. Tentando de novo sem ofuscação."
@@ -7836,22 +7878,9 @@ msgid "[PartFile]"
 msgstr "[PartFile]"
 
 #: src/TextClient.cpp
-msgid "Search expired or unknown ID. Start a new search.\n"
-msgstr "Busca expirada ou ID desconhecido. Comece uma nova busca.\n"
-
-#: src/TextClient.cpp
 #, c-format
 msgid "Number of search results: %i\n"
 msgstr "Número de resultados da busca: %i\n"
-
-#: src/TextClient.cpp
-#, c-format
-msgid "Search progress: %u %% \n"
-msgstr "Progresso da busca: %u %% \n"
-
-#: src/TextClient.cpp
-msgid "Search progress not available"
-msgstr "Progresso da busca não disponível"
 
 #: src/TextClient.cpp
 #, c-format

--- a/po/pt_PT.po
+++ b/po/pt_PT.po
@@ -17,7 +17,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 13:43+0200\n"
+"POT-Creation-Date: 2026-08-24 15:13+0200\n"
 "PO-Revision-Date: 2026-08-22 15:42+0000\n"
 "Last-Translator: Luís Picciochi Oliveira <Pitxyoki@Gmail.com>\n"
 "Language-Team: Portuguese <traduz@debianpt.org>\n"
@@ -6660,6 +6660,47 @@ msgstr "Cancelado"
 msgid "New"
 msgstr "Novo"
 
+#: src/SearchProgressReport.cpp
+#, fuzzy
+msgid "running"
+msgstr "A Executar"
+
+#: src/SearchProgressReport.cpp
+#, fuzzy
+msgid "finished"
+msgstr "Finlandês"
+
+#: src/SearchProgressReport.cpp
+msgid "idle"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+#, c-format
+msgid "Search %u: %s, %u %% (%u results)\n"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+#, c-format
+msgid "Search %u \"%s\": %s, %u %% (%u results)\n"
+msgstr ""
+
+#: src/SearchProgressReport.cpp src/TextClient.cpp
+msgid "Search expired or unknown ID. Start a new search.\n"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+#, c-format
+msgid "Search progress: %u %% \n"
+msgstr "Progresso da pesquisa: %u %% \n"
+
+#: src/SearchProgressReport.cpp
+msgid "Search progress not available"
+msgstr "Progresso da pesquisa indisponível"
+
+#: src/SearchProgressReport.cpp
+msgid "No search to report on.\n"
+msgstr ""
+
 #: src/ServerConnect.cpp
 #, fuzzy
 msgid "Failed to connect to all obfuscated static servers listed. Making another pass without obfuscation."
@@ -7910,22 +7951,9 @@ msgid "[PartFile]"
 msgstr "[FicheiroPart]"
 
 #: src/TextClient.cpp
-msgid "Search expired or unknown ID. Start a new search.\n"
-msgstr ""
-
-#: src/TextClient.cpp
 #, c-format
 msgid "Number of search results: %i\n"
 msgstr "Número de resultados: %i\n"
-
-#: src/TextClient.cpp
-#, c-format
-msgid "Search progress: %u %% \n"
-msgstr "Progresso da pesquisa: %u %% \n"
-
-#: src/TextClient.cpp
-msgid "Search progress not available"
-msgstr "Progresso da pesquisa indisponível"
 
 #: src/TextClient.cpp
 #, c-format

--- a/po/ro.po
+++ b/po/ro.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 13:43+0200\n"
+"POT-Creation-Date: 2026-08-24 15:13+0200\n"
 "PO-Revision-Date: 2026-08-22 15:42+0000\n"
 "Last-Translator: Angelescu Constantin <titus0818@yahoo.com>\n"
 "Language-Team: English <kde-i18n-doc@kde.org>\n"
@@ -6672,6 +6672,47 @@ msgstr "Anulat"
 msgid "New"
 msgstr "Nou"
 
+#: src/SearchProgressReport.cpp
+#, fuzzy
+msgid "running"
+msgstr "Rulează"
+
+#: src/SearchProgressReport.cpp
+#, fuzzy
+msgid "finished"
+msgstr "Finlandeză"
+
+#: src/SearchProgressReport.cpp
+msgid "idle"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+#, c-format
+msgid "Search %u: %s, %u %% (%u results)\n"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+#, c-format
+msgid "Search %u \"%s\": %s, %u %% (%u results)\n"
+msgstr ""
+
+#: src/SearchProgressReport.cpp src/TextClient.cpp
+msgid "Search expired or unknown ID. Start a new search.\n"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+#, c-format
+msgid "Search progress: %u %% \n"
+msgstr "Progres căutare: %u %% \n"
+
+#: src/SearchProgressReport.cpp
+msgid "Search progress not available"
+msgstr "Progresul căutării nu este disponibil"
+
+#: src/SearchProgressReport.cpp
+msgid "No search to report on.\n"
+msgstr ""
+
 #: src/ServerConnect.cpp
 #, fuzzy
 msgid "Failed to connect to all obfuscated static servers listed. Making another pass without obfuscation."
@@ -7944,22 +7985,9 @@ msgid "[PartFile]"
 msgstr "[Fișier parțial]"
 
 #: src/TextClient.cpp
-msgid "Search expired or unknown ID. Start a new search.\n"
-msgstr ""
-
-#: src/TextClient.cpp
 #, c-format
 msgid "Number of search results: %i\n"
 msgstr "Numărul rezultatelor căutării: %i\n"
-
-#: src/TextClient.cpp
-#, c-format
-msgid "Search progress: %u %% \n"
-msgstr "Progres căutare: %u %% \n"
-
-#: src/TextClient.cpp
-msgid "Search progress not available"
-msgstr "Progresul căutării nu este disponibil"
 
 #: src/TextClient.cpp
 #, c-format

--- a/po/ru.po
+++ b/po/ru.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 13:43+0200\n"
+"POT-Creation-Date: 2026-08-24 15:13+0200\n"
 "PO-Revision-Date: 2026-08-22 15:44+0000\n"
 "Last-Translator: Radist Morse <radist.morse@gmail.com>\n"
 "Language-Team: Russian <kde-russian@lists.kde.ru>\n"
@@ -6648,6 +6648,48 @@ msgstr "Отменено"
 msgid "New"
 msgstr "Новый"
 
+#: src/SearchProgressReport.cpp
+#, fuzzy
+msgid "running"
+msgstr "Выполняется"
+
+#: src/SearchProgressReport.cpp
+#, fuzzy
+msgid "finished"
+msgstr "Финский"
+
+#: src/SearchProgressReport.cpp
+msgid "idle"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+#, c-format
+msgid "Search %u: %s, %u %% (%u results)\n"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+#, c-format
+msgid "Search %u \"%s\": %s, %u %% (%u results)\n"
+msgstr ""
+
+#: src/SearchProgressReport.cpp src/TextClient.cpp
+msgid "Search expired or unknown ID. Start a new search.\n"
+msgstr "Поиск истёк или идентификатор неизвестен. Начните новый поиск.\n"
+
+#: src/SearchProgressReport.cpp
+#, c-format
+msgid "Search progress: %u %% \n"
+msgstr "Состояние поиска: %u %% \n"
+
+#: src/SearchProgressReport.cpp
+msgid "Search progress not available"
+msgstr "Прогресс поиска недоступен"
+
+#: src/SearchProgressReport.cpp
+#, fuzzy
+msgid "No search to report on.\n"
+msgstr "Не выбрано ни одного файла для экспорта."
+
 #: src/ServerConnect.cpp
 msgid "Failed to connect to all obfuscated static servers listed. Making another pass without obfuscation."
 msgstr "Не удалось подключиться ко всем перечисленным замаскированным постоянным серверам. Повторная попытка без маскировки."
@@ -7913,22 +7955,9 @@ msgid "[PartFile]"
 msgstr "[частично]"
 
 #: src/TextClient.cpp
-msgid "Search expired or unknown ID. Start a new search.\n"
-msgstr "Поиск истёк или идентификатор неизвестен. Начните новый поиск.\n"
-
-#: src/TextClient.cpp
 #, c-format
 msgid "Number of search results: %i\n"
 msgstr "Число результатов поиска: %i\n"
-
-#: src/TextClient.cpp
-#, c-format
-msgid "Search progress: %u %% \n"
-msgstr "Состояние поиска: %u %% \n"
-
-#: src/TextClient.cpp
-msgid "Search progress not available"
-msgstr "Прогресс поиска недоступен"
 
 #: src/TextClient.cpp
 #, c-format

--- a/po/sl.po
+++ b/po/sl.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 13:43+0200\n"
+"POT-Creation-Date: 2026-08-24 15:13+0200\n"
 "PO-Revision-Date: 2026-08-22 15:45+0000\n"
 "Last-Translator: Jure Repinc <jlp@holodeck1.com>\n"
 "Language-Team: Slovenian\n"
@@ -6711,6 +6711,47 @@ msgstr "Preklicano"
 msgid "New"
 msgstr "Novo"
 
+#: src/SearchProgressReport.cpp
+#, fuzzy
+msgid "running"
+msgstr "Teče"
+
+#: src/SearchProgressReport.cpp
+#, fuzzy
+msgid "finished"
+msgstr "Finsko"
+
+#: src/SearchProgressReport.cpp
+msgid "idle"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+#, c-format
+msgid "Search %u: %s, %u %% (%u results)\n"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+#, c-format
+msgid "Search %u \"%s\": %s, %u %% (%u results)\n"
+msgstr ""
+
+#: src/SearchProgressReport.cpp src/TextClient.cpp
+msgid "Search expired or unknown ID. Start a new search.\n"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+#, c-format
+msgid "Search progress: %u %% \n"
+msgstr "Napredek iskanja: %u %% \n"
+
+#: src/SearchProgressReport.cpp
+msgid "Search progress not available"
+msgstr "Napredek iskanja ni na voljo"
+
+#: src/SearchProgressReport.cpp
+msgid "No search to report on.\n"
+msgstr ""
+
 #: src/ServerConnect.cpp
 #, fuzzy
 msgid "Failed to connect to all obfuscated static servers listed. Making another pass without obfuscation."
@@ -8001,22 +8042,9 @@ msgid "[PartFile]"
 msgstr "[Delna datoteka]"
 
 #: src/TextClient.cpp
-msgid "Search expired or unknown ID. Start a new search.\n"
-msgstr ""
-
-#: src/TextClient.cpp
 #, c-format
 msgid "Number of search results: %i\n"
 msgstr "Število rezultatov iskanja: %i\n"
-
-#: src/TextClient.cpp
-#, c-format
-msgid "Search progress: %u %% \n"
-msgstr "Napredek iskanja: %u %% \n"
-
-#: src/TextClient.cpp
-msgid "Search progress not available"
-msgstr "Napredek iskanja ni na voljo"
 
 #: src/TextClient.cpp
 #, c-format

--- a/po/sq.po
+++ b/po/sq.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 13:43+0200\n"
+"POT-Creation-Date: 2026-08-24 15:13+0200\n"
 "PO-Revision-Date: 2026-08-22 15:45+0000\n"
 "Last-Translator: Fation <dj_barthezz@linuxmail.org lushnja_corps@hotmail.Language-Team:\n"
 "Language: sq\n"
@@ -6673,6 +6673,47 @@ msgstr "Fshij"
 msgid "New"
 msgstr ""
 
+#: src/SearchProgressReport.cpp
+#, fuzzy
+msgid "running"
+msgstr "Aktive"
+
+#: src/SearchProgressReport.cpp
+#, fuzzy
+msgid "finished"
+msgstr "Finlandeze"
+
+#: src/SearchProgressReport.cpp
+msgid "idle"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+#, c-format
+msgid "Search %u: %s, %u %% (%u results)\n"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+#, c-format
+msgid "Search %u \"%s\": %s, %u %% (%u results)\n"
+msgstr ""
+
+#: src/SearchProgressReport.cpp src/TextClient.cpp
+msgid "Search expired or unknown ID. Start a new search.\n"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+#, c-format
+msgid "Search progress: %u %% \n"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+msgid "Search progress not available"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+msgid "No search to report on.\n"
+msgstr ""
+
 #: src/ServerConnect.cpp
 #, fuzzy
 msgid "Failed to connect to all obfuscated static servers listed. Making another pass without obfuscation."
@@ -7935,22 +7976,9 @@ msgid "[PartFile]"
 msgstr "[File ne shkarkim]"
 
 #: src/TextClient.cpp
-msgid "Search expired or unknown ID. Start a new search.\n"
-msgstr ""
-
-#: src/TextClient.cpp
 #, c-format
 msgid "Number of search results: %i\n"
 msgstr "Numri i rezultateve te kerkimeve: %i\n"
-
-#: src/TextClient.cpp
-#, c-format
-msgid "Search progress: %u %% \n"
-msgstr ""
-
-#: src/TextClient.cpp
-msgid "Search progress not available"
-msgstr ""
 
 #: src/TextClient.cpp
 #, c-format

--- a/po/sv.po
+++ b/po/sv.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 13:43+0200\n"
+"POT-Creation-Date: 2026-08-24 15:13+0200\n"
 "PO-Revision-Date: 2026-08-22 15:46+0000\n"
 "Last-Translator: raffe <raffe@localhost.se>\n"
 "Language-Team: Swedish <tp-sv@listor.tp-sv.se>\n"
@@ -6648,6 +6648,47 @@ msgstr "Avbryten"
 msgid "New"
 msgstr "Ny"
 
+#: src/SearchProgressReport.cpp
+#, fuzzy
+msgid "running"
+msgstr "Kör"
+
+#: src/SearchProgressReport.cpp
+#, fuzzy
+msgid "finished"
+msgstr "Finska"
+
+#: src/SearchProgressReport.cpp
+msgid "idle"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+#, c-format
+msgid "Search %u: %s, %u %% (%u results)\n"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+#, c-format
+msgid "Search %u \"%s\": %s, %u %% (%u results)\n"
+msgstr ""
+
+#: src/SearchProgressReport.cpp src/TextClient.cpp
+msgid "Search expired or unknown ID. Start a new search.\n"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+#, c-format
+msgid "Search progress: %u %% \n"
+msgstr "Sökets framstigande: %u %% \n"
+
+#: src/SearchProgressReport.cpp
+msgid "Search progress not available"
+msgstr "Framskridandet för söket är inte tillgänglig"
+
+#: src/SearchProgressReport.cpp
+msgid "No search to report on.\n"
+msgstr ""
+
 #: src/ServerConnect.cpp
 #, fuzzy
 msgid "Failed to connect to all obfuscated static servers listed. Making another pass without obfuscation."
@@ -7901,22 +7942,9 @@ msgid "[PartFile]"
 msgstr "[PartFile]"
 
 #: src/TextClient.cpp
-msgid "Search expired or unknown ID. Start a new search.\n"
-msgstr ""
-
-#: src/TextClient.cpp
 #, c-format
 msgid "Number of search results: %i\n"
 msgstr "Antal sökresultat: %i\n"
-
-#: src/TextClient.cpp
-#, c-format
-msgid "Search progress: %u %% \n"
-msgstr "Sökets framstigande: %u %% \n"
-
-#: src/TextClient.cpp
-msgid "Search progress not available"
-msgstr "Framskridandet för söket är inte tillgänglig"
 
 #: src/TextClient.cpp
 #, c-format

--- a/po/ta.po
+++ b/po/ta.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 13:43+0200\n"
+"POT-Creation-Date: 2026-08-24 15:13+0200\n"
 "PO-Revision-Date: 2026-08-22 15:54+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -6449,6 +6449,45 @@ msgstr ""
 msgid "New"
 msgstr ""
 
+#: src/SearchProgressReport.cpp
+msgid "running"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+msgid "finished"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+msgid "idle"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+#, c-format
+msgid "Search %u: %s, %u %% (%u results)\n"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+#, c-format
+msgid "Search %u \"%s\": %s, %u %% (%u results)\n"
+msgstr ""
+
+#: src/SearchProgressReport.cpp src/TextClient.cpp
+msgid "Search expired or unknown ID. Start a new search.\n"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+#, c-format
+msgid "Search progress: %u %% \n"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+msgid "Search progress not available"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+msgid "No search to report on.\n"
+msgstr ""
+
 #: src/ServerConnect.cpp
 msgid "Failed to connect to all obfuscated static servers listed. Making another pass without obfuscation."
 msgstr ""
@@ -7675,21 +7714,8 @@ msgid "[PartFile]"
 msgstr ""
 
 #: src/TextClient.cpp
-msgid "Search expired or unknown ID. Start a new search.\n"
-msgstr ""
-
-#: src/TextClient.cpp
 #, c-format
 msgid "Number of search results: %i\n"
-msgstr ""
-
-#: src/TextClient.cpp
-#, c-format
-msgid "Search progress: %u %% \n"
-msgstr ""
-
-#: src/TextClient.cpp
-msgid "Search progress not available"
 msgstr ""
 
 #: src/TextClient.cpp

--- a/po/tr.po
+++ b/po/tr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 13:43+0200\n"
+"POT-Creation-Date: 2026-08-24 15:13+0200\n"
 "PO-Revision-Date: 2026-08-22 15:48+0000\n"
 "Last-Translator: \n"
 "Language-Team: Turkish <li@li.org>\n"
@@ -6587,6 +6587,48 @@ msgstr "İptal edildi"
 msgid "New"
 msgstr "Yeni"
 
+#: src/SearchProgressReport.cpp
+#, fuzzy
+msgid "running"
+msgstr "Çalışıyor"
+
+#: src/SearchProgressReport.cpp
+#, fuzzy
+msgid "finished"
+msgstr "Fince"
+
+#: src/SearchProgressReport.cpp
+msgid "idle"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+#, c-format
+msgid "Search %u: %s, %u %% (%u results)\n"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+#, c-format
+msgid "Search %u \"%s\": %s, %u %% (%u results)\n"
+msgstr ""
+
+#: src/SearchProgressReport.cpp src/TextClient.cpp
+msgid "Search expired or unknown ID. Start a new search.\n"
+msgstr "Arama süresi dolmuş veya bilinmeyen kimlik. Yeni bir arama başlatın.\n"
+
+#: src/SearchProgressReport.cpp
+#, c-format
+msgid "Search progress: %u %% \n"
+msgstr "Arama süreci: %u %% \n"
+
+#: src/SearchProgressReport.cpp
+msgid "Search progress not available"
+msgstr "Arama süreci görüntülenemiyor"
+
+#: src/SearchProgressReport.cpp
+#, fuzzy
+msgid "No search to report on.\n"
+msgstr "Dışa aktarmak için hiçbir dosya seçili değil."
+
 #: src/ServerConnect.cpp
 msgid "Failed to connect to all obfuscated static servers listed. Making another pass without obfuscation."
 msgstr "Listelenen gizlenmiş bağlantılı tüm statik sunuculara bağlanma başarısız. Gizlenmiş bağlantı olmadan geçiş yapılacak."
@@ -7828,22 +7870,9 @@ msgid "[PartFile]"
 msgstr "[Parça Dosyası]"
 
 #: src/TextClient.cpp
-msgid "Search expired or unknown ID. Start a new search.\n"
-msgstr "Arama süresi dolmuş veya bilinmeyen kimlik. Yeni bir arama başlatın.\n"
-
-#: src/TextClient.cpp
 #, c-format
 msgid "Number of search results: %i\n"
 msgstr "Arama sonuçları sayısı:%i\n"
-
-#: src/TextClient.cpp
-#, c-format
-msgid "Search progress: %u %% \n"
-msgstr "Arama süreci: %u %% \n"
-
-#: src/TextClient.cpp
-msgid "Search progress not available"
-msgstr "Arama süreci görüntülenemiyor"
 
 #: src/TextClient.cpp
 #, c-format

--- a/po/uk.po
+++ b/po/uk.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 13:43+0200\n"
+"POT-Creation-Date: 2026-08-24 15:13+0200\n"
 "PO-Revision-Date: 2026-08-22 15:48+0000\n"
 "Last-Translator: Oleksandr Kovalenko <alx.kovalenko@gmail.com>\n"
 "Language-Team: Ukrainian <translation@linux.org.ua>\n"
@@ -6714,6 +6714,48 @@ msgstr "Скасувати"
 msgid "New"
 msgstr ""
 
+#: src/SearchProgressReport.cpp
+#, fuzzy
+msgid "running"
+msgstr "Працює"
+
+#: src/SearchProgressReport.cpp
+#, fuzzy
+msgid "finished"
+msgstr "Фінська"
+
+#: src/SearchProgressReport.cpp
+msgid "idle"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+#, c-format
+msgid "Search %u: %s, %u %% (%u results)\n"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+#, c-format
+msgid "Search %u \"%s\": %s, %u %% (%u results)\n"
+msgstr ""
+
+#: src/SearchProgressReport.cpp src/TextClient.cpp
+msgid "Search expired or unknown ID. Start a new search.\n"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+#, c-format
+msgid "Search progress: %u %% \n"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+#, fuzzy
+msgid "Search progress not available"
+msgstr "Показувати поступ у відсотках"
+
+#: src/SearchProgressReport.cpp
+msgid "No search to report on.\n"
+msgstr ""
+
 #: src/ServerConnect.cpp
 #, fuzzy
 msgid "Failed to connect to all obfuscated static servers listed. Making another pass without obfuscation."
@@ -7991,23 +8033,9 @@ msgid "[PartFile]"
 msgstr "[частковий файл]"
 
 #: src/TextClient.cpp
-msgid "Search expired or unknown ID. Start a new search.\n"
-msgstr ""
-
-#: src/TextClient.cpp
 #, c-format
 msgid "Number of search results: %i\n"
 msgstr "Кількість здобутків пошуку: %i\n"
-
-#: src/TextClient.cpp
-#, c-format
-msgid "Search progress: %u %% \n"
-msgstr ""
-
-#: src/TextClient.cpp
-#, fuzzy
-msgid "Search progress not available"
-msgstr "Показувати поступ у відсотках"
 
 #: src/TextClient.cpp
 #, c-format

--- a/po/vi.po
+++ b/po/vi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 13:43+0200\n"
+"POT-Creation-Date: 2026-08-24 15:13+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -6444,6 +6444,45 @@ msgstr ""
 msgid "New"
 msgstr ""
 
+#: src/SearchProgressReport.cpp
+msgid "running"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+msgid "finished"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+msgid "idle"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+#, c-format
+msgid "Search %u: %s, %u %% (%u results)\n"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+#, c-format
+msgid "Search %u \"%s\": %s, %u %% (%u results)\n"
+msgstr ""
+
+#: src/SearchProgressReport.cpp src/TextClient.cpp
+msgid "Search expired or unknown ID. Start a new search.\n"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+#, c-format
+msgid "Search progress: %u %% \n"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+msgid "Search progress not available"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+msgid "No search to report on.\n"
+msgstr ""
+
 #: src/ServerConnect.cpp
 msgid "Failed to connect to all obfuscated static servers listed. Making another pass without obfuscation."
 msgstr ""
@@ -7658,21 +7697,8 @@ msgid "[PartFile]"
 msgstr ""
 
 #: src/TextClient.cpp
-msgid "Search expired or unknown ID. Start a new search.\n"
-msgstr ""
-
-#: src/TextClient.cpp
 #, c-format
 msgid "Number of search results: %i\n"
-msgstr ""
-
-#: src/TextClient.cpp
-#, c-format
-msgid "Search progress: %u %% \n"
-msgstr ""
-
-#: src/TextClient.cpp
-msgid "Search progress not available"
 msgstr ""
 
 #: src/TextClient.cpp

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 13:43+0200\n"
+"POT-Creation-Date: 2026-08-24 15:13+0200\n"
 "PO-Revision-Date: 2026-08-22 15:50+0000\n"
 "Last-Translator: Mike Akiba <mike2718@gmail.com>\n"
 "Language-Team: Chinese Simplified <kde-i18n-doc@kde.org>\n"
@@ -6591,6 +6591,48 @@ msgstr "已取消"
 msgid "New"
 msgstr "新建"
 
+#: src/SearchProgressReport.cpp
+#, fuzzy
+msgid "running"
+msgstr "正在运行"
+
+#: src/SearchProgressReport.cpp
+#, fuzzy
+msgid "finished"
+msgstr "芬兰语"
+
+#: src/SearchProgressReport.cpp
+msgid "idle"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+#, c-format
+msgid "Search %u: %s, %u %% (%u results)\n"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+#, c-format
+msgid "Search %u \"%s\": %s, %u %% (%u results)\n"
+msgstr ""
+
+#: src/SearchProgressReport.cpp src/TextClient.cpp
+msgid "Search expired or unknown ID. Start a new search.\n"
+msgstr "搜索已过期或未知的ID。开始新的搜索。\n"
+
+#: src/SearchProgressReport.cpp
+#, c-format
+msgid "Search progress: %u %% \n"
+msgstr "搜索进度: %u %% \n"
+
+#: src/SearchProgressReport.cpp
+msgid "Search progress not available"
+msgstr "搜索进度不可用"
+
+#: src/SearchProgressReport.cpp
+#, fuzzy
+msgid "No search to report on.\n"
+msgstr "未选中要导出的文件。"
+
 #: src/ServerConnect.cpp
 msgid "Failed to connect to all obfuscated static servers listed. Making another pass without obfuscation."
 msgstr "无法连接至列出的全部混淆静态服务器，尝试不用混淆再连一次。"
@@ -7832,22 +7874,9 @@ msgid "[PartFile]"
 msgstr "[part 文件]"
 
 #: src/TextClient.cpp
-msgid "Search expired or unknown ID. Start a new search.\n"
-msgstr "搜索已过期或未知的ID。开始新的搜索。\n"
-
-#: src/TextClient.cpp
 #, c-format
 msgid "Number of search results: %i\n"
 msgstr "搜索结果数量：%i\n"
-
-#: src/TextClient.cpp
-#, c-format
-msgid "Search progress: %u %% \n"
-msgstr "搜索进度: %u %% \n"
-
-#: src/TextClient.cpp
-msgid "Search progress not available"
-msgstr "搜索进度不可用"
 
 #: src/TextClient.cpp
 #, c-format

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 13:43+0200\n"
+"POT-Creation-Date: 2026-08-24 15:13+0200\n"
 "PO-Revision-Date: 2026-08-22 15:51+0000\n"
 "Last-Translator: Wayne Su <mstarmstar@gmail.com>\n"
 "Language-Team: \n"
@@ -6630,6 +6630,47 @@ msgstr "已取消"
 msgid "New"
 msgstr "新"
 
+#: src/SearchProgressReport.cpp
+#, fuzzy
+msgid "running"
+msgstr "執行中"
+
+#: src/SearchProgressReport.cpp
+#, fuzzy
+msgid "finished"
+msgstr "芬蘭語"
+
+#: src/SearchProgressReport.cpp
+msgid "idle"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+#, c-format
+msgid "Search %u: %s, %u %% (%u results)\n"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+#, c-format
+msgid "Search %u \"%s\": %s, %u %% (%u results)\n"
+msgstr ""
+
+#: src/SearchProgressReport.cpp src/TextClient.cpp
+msgid "Search expired or unknown ID. Start a new search.\n"
+msgstr ""
+
+#: src/SearchProgressReport.cpp
+#, c-format
+msgid "Search progress: %u %% \n"
+msgstr "搜尋進度：%u %% \n"
+
+#: src/SearchProgressReport.cpp
+msgid "Search progress not available"
+msgstr "沒有進行中的搜尋"
+
+#: src/SearchProgressReport.cpp
+msgid "No search to report on.\n"
+msgstr ""
+
 #: src/ServerConnect.cpp
 #, fuzzy
 msgid "Failed to connect to all obfuscated static servers listed. Making another pass without obfuscation."
@@ -7862,22 +7903,9 @@ msgid "[PartFile]"
 msgstr "[--暫存檔--]"
 
 #: src/TextClient.cpp
-msgid "Search expired or unknown ID. Start a new search.\n"
-msgstr ""
-
-#: src/TextClient.cpp
 #, c-format
 msgid "Number of search results: %i\n"
 msgstr "搜尋結果：%i\n"
-
-#: src/TextClient.cpp
-#, c-format
-msgid "Search progress: %u %% \n"
-msgstr "搜尋進度：%u %% \n"
-
-#: src/TextClient.cpp
-msgid "Search progress not available"
-msgstr "沒有進行中的搜尋"
 
 #: src/TextClient.cpp
 #, c-format

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -172,6 +172,7 @@ if (BUILD_AMULECMD)
 		LoggerConsole.cpp
 		NetworkFunctions.cpp
 		OtherFunctions.cpp
+		SearchProgressReport.cpp
 		TextClient.cpp
 	)
 

--- a/src/ExternalConn.cpp
+++ b/src/ExternalConn.cpp
@@ -3033,6 +3033,10 @@ static void AppendSearchProgress(CECTag &out, wxUIntPtr sid)
 		out.AddTag(CECTag(EC_TAG_SEARCH_STATUS, bar));
 		out.AddTag(CECTag(EC_TAG_SEARCH_BROWSE_STATUS, browseStatus));
 		out.AddTag(CECTag(EC_TAG_SEARCH_ID, static_cast<uint32>(sid)));
+		// The peer's nickname, for a browse. Same tag and same source as the
+		// search list's, so a client polling progress can name what it is
+		// reporting on without a second round trip for the list.
+		out.AddTag(EC_TAG_SEARCH_NAME, theApp->searchlist->GetSearchStringById(sid));
 		out.AddTag(CECTag(EC_TAG_SEARCH_RESULT_COUNT,
 			static_cast<uint32>(theApp->searchlist->GetSearchResults(sid).size())));
 		// Also emit the standard lifecycle tags (mapped from the browse
@@ -3059,6 +3063,11 @@ static void AppendSearchProgress(CECTag &out, wxUIntPtr sid)
 	out.AddTag(CECTag(EC_TAG_SEARCH_STATUS, theApp->searchlist->GetSearchBarStatusById(sid)));
 	// Echo the ID so the client can confirm which search this is for.
 	out.AddTag(CECTag(EC_TAG_SEARCH_ID, static_cast<uint32>(sid)));
+	// ...and the query it was started with, so a progress reply is readable on
+	// its own. The search list carries the same tag from the same source; a
+	// client that polls progress per tab should not have to fetch the list as
+	// well just to label it.
+	out.AddTag(EC_TAG_SEARCH_NAME, theApp->searchlist->GetSearchStringById(sid));
 	out.AddTag(CECTag(EC_TAG_SEARCH_LIFECYCLE_STATE, static_cast<uint8>(st)));
 	// Per-id kind (not the scalar): a multi-search client polls each tab by id
 	// and needs THIS search's real type, e.g. to enable the Kad-only "More"

--- a/src/SearchProgressReport.cpp
+++ b/src/SearchProgressReport.cpp
@@ -1,0 +1,134 @@
+//
+// This file is part of the aMule Project.
+//
+// Copyright (c) 2003-2026 aMule Team ( https://amule-org.github.io )
+//
+// Any parts of this program derived from the xMule, lMule or eMule project,
+// or contributed by third-party developers are copyrighted by their
+// respective authors.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA
+//
+
+#include "SearchProgressReport.h"
+
+#include <ec/cpp/ECPacket.h>
+#include <ec/cpp/ECCodes.h>
+#include <common/Format.h>
+
+#include <wx/intl.h> // _()
+
+namespace
+{
+
+// Wire convention shared with amuleapi's SearchLifecycleStateToString and
+// pinned against CSearchList::SearchLifecycleState by a static_assert in
+// ExternalConn.cpp: 0 idle, 1 running, 2 finished.
+wxString StateName(unsigned state)
+{
+	switch (state) {
+	case 1:
+		return _("running");
+	case 2:
+		return _("finished");
+	default:
+		return _("idle");
+	}
+}
+
+wxString OneLine(unsigned id, const wxString &name, unsigned state, unsigned percent, unsigned results)
+{
+	// The query the search was started with, or the peer's nickname for a
+	// browse. Older daemons do not send it; the line then reads as it did
+	// before rather than showing an empty pair of quotes.
+	if (name.IsEmpty()) {
+		return CFormat(_("Search %u: %s, %u %% (%u results)\n")) % id % StateName(state) % percent %
+		       results;
+	}
+	return CFormat(_("Search %u \"%s\": %s, %u %% (%u results)\n")) % id % name % StateName(state) %
+	       percent % results;
+}
+
+wxString NameOf(const CECTag *tag)
+{
+	return tag ? tag->GetStringData() : wxString();
+}
+
+unsigned IntOr(const CECTag *tag, unsigned fallback)
+{
+	return tag ? static_cast<unsigned>(tag->GetInt()) : fallback;
+}
+
+} // namespace
+
+wxString ecprogress::FormatSearchProgress(const CECPacket &response)
+{
+	if (response.GetTagByName(EC_TAG_SEARCH_EXPIRED)) {
+		return _("Search expired or unknown ID. Start a new search.\n");
+	}
+
+	// Union shape: one child per search, its own value the search id and its
+	// fields nested inside. Presence of EC_TAG_SEARCH_ID is NOT the test --
+	// the single-search reply echoes one as a bare leaf, and an expired
+	// verdict echoes the id it is about. Carrying the nested percent is what
+	// makes a child an entry.
+	wxString out;
+	bool sawEntry = false;
+	for (const CECTag &entry : response) {
+		if (entry.GetTagName() != EC_TAG_SEARCH_ID) {
+			continue;
+		}
+		const CECTag *percent = entry.GetTagByName(EC_TAG_SEARCH_LIFECYCLE_PERCENT);
+		if (percent == nullptr) {
+			continue;
+		}
+		sawEntry = true;
+		out += OneLine(static_cast<unsigned>(entry.GetInt()),
+			NameOf(entry.GetTagByName(EC_TAG_SEARCH_NAME)),
+			IntOr(entry.GetTagByName(EC_TAG_SEARCH_LIFECYCLE_STATE), 0),
+			static_cast<unsigned>(percent->GetInt()),
+			IntOr(entry.GetTagByName(EC_TAG_SEARCH_RESULT_COUNT), 0));
+	}
+	if (sawEntry) {
+		return out;
+	}
+
+	// Single-search reply carrying the lifecycle tags. Preferred over the
+	// sentinel below: a finished search reports 100 % and says so, where the
+	// sentinel only ever said 0 once the search stopped running.
+	if (const CECTag *percent = response.GetTagByName(EC_TAG_SEARCH_LIFECYCLE_PERCENT)) {
+		return OneLine(IntOr(response.GetTagByName(EC_TAG_SEARCH_ID), 0),
+			NameOf(response.GetTagByName(EC_TAG_SEARCH_NAME)),
+			IntOr(response.GetTagByName(EC_TAG_SEARCH_LIFECYCLE_STATE), 0),
+			static_cast<unsigned>(percent->GetInt()),
+			IntOr(response.GetTagByName(EC_TAG_SEARCH_RESULT_COUNT), 0));
+	}
+
+	// Oldest daemons: the overloaded sentinel alone. Values above 100 are its
+	// done/failed markers rather than a percentage.
+	if (const CECTag *status = response.GetTagByName(EC_TAG_SEARCH_STATUS)) {
+		const unsigned progress = static_cast<unsigned>(status->GetInt());
+		if (progress <= 100) {
+			return CFormat(_("Search progress: %u %% \n")) % progress;
+		}
+		// Newline outside the msgid: the string is translated in 28
+		// catalogs and changing it would orphan every one of them.
+		return _("Search progress not available") + wxT("\n");
+	}
+
+	// A union reply with nothing in it: the daemon holds no searches. Distinct
+	// from 0 %, which is a running search that has made no progress.
+	return _("No search to report on.\n");
+}

--- a/src/SearchProgressReport.h
+++ b/src/SearchProgressReport.h
@@ -1,0 +1,56 @@
+//
+// This file is part of the aMule Project.
+//
+// Copyright (c) 2003-2026 aMule Team ( https://amule-org.github.io )
+//
+// Any parts of this program derived from the xMule, lMule or eMule project,
+// or contributed by third-party developers are copyrighted by their
+// respective authors.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA
+//
+
+#ifndef SEARCHPROGRESSREPORT_H
+#define SEARCHPROGRESSREPORT_H
+
+#include <wx/string.h>
+
+class CECPacket;
+
+namespace ecprogress
+{
+
+/**
+ * Render an `EC_OP_SEARCH_PROGRESS` reply as amulecmd's `progress` output.
+ *
+ * The reply comes in three shapes and the client does not get to choose which:
+ * a daemon that echoed `EC_TAG_CAN_SEARCH_PROGRESS_UNION` always answers with
+ * the union, one entry per search, naming ids only narrows which entries come
+ * back. Older daemons answer about a single search, with the lifecycle tags at
+ * the top level or, older still, only the overloaded `EC_TAG_SEARCH_STATUS`
+ * sentinel.
+ *
+ * Reading one shape as another is what made `progress` report 0 %
+ * unconditionally: the union nests `EC_TAG_SEARCH_STATUS` inside each entry,
+ * so a top-level read found nothing and rendered the miss as a number.
+ *
+ * Kept apart from the command loop, and free of theApp, so all three shapes
+ * are reachable from a test.
+ */
+wxString FormatSearchProgress(const CECPacket &response);
+
+} // namespace ecprogress
+
+#endif // SEARCHPROGRESSREPORT_H

--- a/src/TextClient.cpp
+++ b/src/TextClient.cpp
@@ -26,6 +26,8 @@
 #include "config.h" // Needed for VERSION
 #include "TextClient.h"
 
+#include "SearchProgressReport.h"
+
 #ifndef __WINDOWS__
 #include <unistd.h> // Do_not_auto_remove
 #endif
@@ -1071,20 +1073,14 @@ void CamulecmdApp::Process_Answer_v2(const CECPacket *response)
 		ShowResults(m_Results_map);
 		break;
 	}
-	case EC_OP_SEARCH_PROGRESS: {
-		if (response->GetTagByName(EC_TAG_SEARCH_EXPIRED)) {
-			s += _("Search expired or unknown ID. Start a new search.\n");
-			break;
-		}
-		const CECTag *tab = response->GetTagByNameSafe(EC_TAG_SEARCH_STATUS);
-		uint32 progress = tab->GetInt();
-		if (progress <= 100) {
-			s += CFormat(_("Search progress: %u %% \n")) % progress;
-		} else {
-			s += _("Search progress not available");
-		}
+	case EC_OP_SEARCH_PROGRESS:
+		// Every shape the daemon may answer with, decoded in one place. This
+		// used to read EC_TAG_SEARCH_STATUS off the top level, which the union
+		// reply does not carry there -- and since amulecmd advertises the
+		// union capability along with multi-search, the union is exactly what
+		// it gets, so `progress` reported 0 % whatever the search was doing.
+		s += ecprogress::FormatSearchProgress(*response);
 		break;
-	}
 	default:
 		s += CFormat(_("Received an unknown reply from the server, OpCode = %#x.")) %
 		     response->GetOpCode();

--- a/unittests/tests/CMakeLists.txt
+++ b/unittests/tests/CMakeLists.txt
@@ -53,6 +53,39 @@ target_link_libraries (ECIdDiffTest
 	mulecommon
 )
 
+# amulecmd's `progress` output. The daemon answers EC_OP_SEARCH_PROGRESS in
+# three shapes and the client does not choose which: advertising the union
+# capability alongside multi-search is what decides it. Reading one shape as
+# another is invisible -- a top-level tag that is not there reads as zero, so
+# `progress` reported 0 % for every search whatever it was doing (#1126).
+# Needs no app and no daemon: the EC tag types are the whole dependency.
+add_executable (SearchProgressReportTest
+	SearchProgressReportTest.cpp
+	${CMAKE_SOURCE_DIR}/src/SearchProgressReport.cpp
+	# As for ECIdDiffTest: libec.a references DoECLogLine / theLogger
+	# unconditionally in Debug, so the no-op definitions have to be linked in.
+	${CMAKE_SOURCE_DIR}/src/LoggerConsole.cpp
+)
+
+add_test (NAME SearchProgressReportTest
+	COMMAND SearchProgressReportTest
+)
+
+target_include_directories (SearchProgressReportTest
+	PRIVATE ${CMAKE_BINARY_DIR}
+	PRIVATE ${CMAKE_SOURCE_DIR}/src
+	PRIVATE ${CMAKE_SOURCE_DIR}/src/include
+	PRIVATE ${CMAKE_SOURCE_DIR}/src/libs
+	PRIVATE ${CMAKE_BINARY_DIR}/src/libs
+	PRIVATE ${CMAKE_BINARY_DIR}/src/libs/ec/cpp
+)
+
+target_link_libraries (SearchProgressReportTest
+	muleunit
+	ec
+	mulecommon
+)
+
 add_executable (ECSocketFlagsTest
 	ECSocketFlagsTest.cpp
 	# As for ECIdDiffTest: libec.a references DoECLogLine / theLogger

--- a/unittests/tests/SearchProgressReportTest.cpp
+++ b/unittests/tests/SearchProgressReportTest.cpp
@@ -1,0 +1,208 @@
+//
+// This file is part of the aMule Project.
+//
+// Copyright (c) 2003-2026 aMule Team ( https://amule-org.github.io )
+//
+// Any parts of this program derived from the xMule, lMule or eMule project,
+// or contributed by third-party developers are copyrighted by their
+// respective authors.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA
+//
+
+#include "SearchProgressReport.h"
+
+#include <ec/cpp/ECPacket.h>
+#include <ec/cpp/ECCodes.h>
+#include <muleunit/test.h>
+
+using namespace muleunit;
+
+DECLARE_SIMPLE(SearchProgressReport)
+
+namespace
+{
+
+// One union child: the entry's own value is the search id, its fields nested.
+CECTag MakeEntry(uint32 id, uint8 state, uint8 percent, uint32 results, const wxString &name = wxEmptyString)
+{
+	CECTag entry(EC_TAG_SEARCH_ID, id);
+	if (!name.IsEmpty()) {
+		entry.AddTag(EC_TAG_SEARCH_NAME, name);
+	}
+	entry.AddTag(CECTag(EC_TAG_SEARCH_STATUS, static_cast<uint16>(percent)));
+	entry.AddTag(CECTag(EC_TAG_SEARCH_ID, id));
+	entry.AddTag(CECTag(EC_TAG_SEARCH_LIFECYCLE_STATE, state));
+	entry.AddTag(CECTag(EC_TAG_SEARCH_RESULT_COUNT, results));
+	entry.AddTag(CECTag(EC_TAG_SEARCH_LIFECYCLE_PERCENT, percent));
+	return entry;
+}
+
+} // namespace
+
+// The shape amulecmd actually receives, and the one it used to misread.
+TEST(SearchProgressReport, UnionReportsEverySearchByItsOwnId)
+{
+	CECPacket p(EC_OP_SEARCH_PROGRESS);
+	p.AddTag(MakeEntry(1, 2, 100, 44));
+	p.AddTag(MakeEntry(3, 1, 84, 12));
+
+	const wxString out = ecprogress::FormatSearchProgress(p);
+	ASSERT_TRUE(out.Contains(wxT("Search 1")));
+	ASSERT_TRUE(out.Contains(wxT("100 %")));
+	ASSERT_TRUE(out.Contains(wxT("44 results")));
+	ASSERT_TRUE(out.Contains(wxT("Search 3")));
+	ASSERT_TRUE(out.Contains(wxT("84 %")));
+	ASSERT_TRUE(out.Contains(wxT("12 results")));
+	// One line per search, not one for the reply.
+	ASSERT_EQUALS(2, static_cast<int>(out.Freq(wxT('\n'))));
+}
+
+// The regression itself: a running search must not read as 0 %.
+TEST(SearchProgressReport, AUnionEntryMidSweepIsNotReportedAsZero)
+{
+	CECPacket p(EC_OP_SEARCH_PROGRESS);
+	p.AddTag(MakeEntry(7, 1, 84, 3));
+	ASSERT_TRUE(ecprogress::FormatSearchProgress(p).Contains(wxT("84 %")));
+	ASSERT_FALSE(ecprogress::FormatSearchProgress(p).Contains(wxT("0 %")));
+}
+
+TEST(SearchProgressReport, LifecycleStatesAreNamed)
+{
+	CECPacket running(EC_OP_SEARCH_PROGRESS);
+	running.AddTag(MakeEntry(1, 1, 50, 0));
+	ASSERT_TRUE(ecprogress::FormatSearchProgress(running).Contains(wxT("running")));
+
+	CECPacket done(EC_OP_SEARCH_PROGRESS);
+	done.AddTag(MakeEntry(1, 2, 100, 9));
+	ASSERT_TRUE(ecprogress::FormatSearchProgress(done).Contains(wxT("finished")));
+
+	CECPacket idle(EC_OP_SEARCH_PROGRESS);
+	idle.AddTag(MakeEntry(1, 0, 0, 0));
+	ASSERT_TRUE(ecprogress::FormatSearchProgress(idle).Contains(wxT("idle")));
+}
+
+// A daemon that echoed multi-search but not the union answers about one
+// search with the lifecycle tags at the top level.
+TEST(SearchProgressReport, SingleSearchReplyUsesTheLifecycleTags)
+{
+	CECPacket p(EC_OP_SEARCH_PROGRESS);
+	p.AddTag(CECTag(EC_TAG_SEARCH_STATUS, static_cast<uint16>(0xffff)));
+	p.AddTag(CECTag(EC_TAG_SEARCH_ID, static_cast<uint32>(5)));
+	p.AddTag(CECTag(EC_TAG_SEARCH_LIFECYCLE_STATE, static_cast<uint8>(2)));
+	p.AddTag(CECTag(EC_TAG_SEARCH_RESULT_COUNT, static_cast<uint32>(17)));
+	p.AddTag(CECTag(EC_TAG_SEARCH_LIFECYCLE_PERCENT, static_cast<uint8>(100)));
+
+	const wxString out = ecprogress::FormatSearchProgress(p);
+	// Read through the lifecycle tags, so a finished search says so rather
+	// than rendering the 0xffff sentinel as "not available".
+	ASSERT_TRUE(out.Contains(wxT("Search 5")));
+	ASSERT_TRUE(out.Contains(wxT("finished")));
+	ASSERT_TRUE(out.Contains(wxT("100 %")));
+}
+
+// Oldest daemons send only the overloaded sentinel.
+TEST(SearchProgressReport, SentinelOnlyReplyKeepsTheLegacyLine)
+{
+	CECPacket p(EC_OP_SEARCH_PROGRESS);
+	p.AddTag(CECTag(EC_TAG_SEARCH_STATUS, static_cast<uint16>(42)));
+	ASSERT_TRUE(ecprogress::FormatSearchProgress(p).Contains(wxT("Search progress: 42 %")));
+}
+
+TEST(SearchProgressReport, SentinelAboveOneHundredIsNotAPercentage)
+{
+	CECPacket p(EC_OP_SEARCH_PROGRESS);
+	p.AddTag(CECTag(EC_TAG_SEARCH_STATUS, static_cast<uint16>(0xffff)));
+	ASSERT_TRUE(ecprogress::FormatSearchProgress(p).Contains(wxT("not available")));
+}
+
+TEST(SearchProgressReport, ExpiredIsReportedAsExpired)
+{
+	CECPacket p(EC_OP_SEARCH_PROGRESS);
+	p.AddTag(CECEmptyTag(EC_TAG_SEARCH_EXPIRED));
+	ASSERT_TRUE(ecprogress::FormatSearchProgress(p).Contains(wxT("expired")));
+}
+
+// The discriminator trap: an expired verdict echoes the id it is about, as a
+// bare leaf. Testing for EC_TAG_SEARCH_ID alone would read that as a union.
+TEST(SearchProgressReport, AnExpiredVerdictEchoingItsIdIsStillExpired)
+{
+	CECPacket p(EC_OP_SEARCH_PROGRESS);
+	p.AddTag(CECEmptyTag(EC_TAG_SEARCH_EXPIRED));
+	p.AddTag(CECTag(EC_TAG_SEARCH_ID, static_cast<uint32>(9)));
+	const wxString out = ecprogress::FormatSearchProgress(p);
+	ASSERT_TRUE(out.Contains(wxT("expired")));
+	ASSERT_FALSE(out.Contains(wxT("Search 9")));
+}
+
+// Same trap on the single-search reply, which echoes a bare id leaf beside
+// its top-level fields.
+TEST(SearchProgressReport, ABareIdLeafIsNotAUnionEntry)
+{
+	CECPacket p(EC_OP_SEARCH_PROGRESS);
+	p.AddTag(CECTag(EC_TAG_SEARCH_ID, static_cast<uint32>(4)));
+	p.AddTag(CECTag(EC_TAG_SEARCH_STATUS, static_cast<uint16>(30)));
+	// No nested percent anywhere, so this is the sentinel shape, not a union.
+	ASSERT_TRUE(ecprogress::FormatSearchProgress(p).Contains(wxT("Search progress: 30 %")));
+}
+
+// An empty union means the daemon holds no searches, which is not 0 %.
+TEST(SearchProgressReport, AnEmptyUnionIsNotZeroPercent)
+{
+	CECPacket p(EC_OP_SEARCH_PROGRESS);
+	const wxString out = ecprogress::FormatSearchProgress(p);
+	ASSERT_FALSE(out.Contains(wxT("0 %")));
+	ASSERT_TRUE(out.Contains(wxT("No search")));
+}
+
+// A search that has genuinely made no progress still reports 0 %.
+TEST(SearchProgressReport, AJustStartedSearchStillReportsZero)
+{
+	CECPacket p(EC_OP_SEARCH_PROGRESS);
+	p.AddTag(MakeEntry(2, 1, 0, 0));
+	ASSERT_TRUE(ecprogress::FormatSearchProgress(p).Contains(wxT("0 %")));
+	ASSERT_TRUE(ecprogress::FormatSearchProgress(p).Contains(wxT("running")));
+}
+
+// The daemon now sends the query alongside the progress, so a poll is readable
+// without a second request for the search list.
+TEST(SearchProgressReport, AnEntryIsLabelledWithItsQuery)
+{
+	CECPacket p(EC_OP_SEARCH_PROGRESS);
+	p.AddTag(MakeEntry(1, 1, 40, 5, wxT("freebsd")));
+	p.AddTag(MakeEntry(2, 2, 100, 77, wxT("ubuntu")));
+
+	const wxString out = ecprogress::FormatSearchProgress(p);
+	ASSERT_TRUE(out.Contains(wxT("Search 1 \"freebsd\"")));
+	ASSERT_TRUE(out.Contains(wxT("Search 2 \"ubuntu\"")));
+}
+
+// A daemon too old to send the name must not produce an empty pair of quotes.
+TEST(SearchProgressReport, AnEntryWithoutAQueryKeepsThePlainLine)
+{
+	CECPacket p(EC_OP_SEARCH_PROGRESS);
+	p.AddTag(MakeEntry(1, 1, 40, 5));
+	const wxString out = ecprogress::FormatSearchProgress(p);
+	ASSERT_TRUE(out.Contains(wxT("Search 1:")));
+	ASSERT_FALSE(out.Contains(wxT("\"\"")));
+}
+
+// A browse is named by its peer, through the same tag.
+TEST(SearchProgressReport, ABrowseIsLabelledByItsPeer)
+{
+	CECPacket p(EC_OP_SEARCH_PROGRESS);
+	p.AddTag(MakeEntry(4, 1, 10, 0, wxT("some peer")));
+	ASSERT_TRUE(ecprogress::FormatSearchProgress(p).Contains(wxT("Search 4 \"some peer\"")));
+}


### PR DESCRIPTION
Fixes #1126.

## Cause

`progress` reported 0 % for every search whatever it was doing - mid sweep, after results had arrived, and when asked about a specific id.

amulecmd advertises `EC_TAG_CAN_SEARCH_PROGRESS_UNION`, because `RemoteConnect.cpp:146` gates it on the same `canMultiSearch` flag as `EC_TAG_CAN_MULTI_SEARCH`, and `TextClient.cpp:1423` sets that. A daemon that echoed it then always answers with the union, one entry per search - naming an id narrows which entries come back, it does not opt back into the single-search reply. But the client read `EC_TAG_SEARCH_STATUS` off the top level, where the union does not carry it, and `GetTagByNameSafe` turns that miss into a zero. A missing tag and a search genuinely at 0 % were indistinguishable in the output.

`results` was unaffected because its union is gated on `m_multiSearchActive && incUpdate`, and amulecmd asks for `EC_DETAIL_FULL`. Progress has no equivalent second condition, so the one client that does not decode the union is the one that receives it - amulegui and amuleapi both walk the entries.

Introduced by the commit that defined the union. amulecmd had advertised multi-search since `10b4efac0`, so it began receiving a shape it never decoded the moment that landed, which matches the report's "I remember seeing different values in the past".

## Change

All three reply shapes are decoded in one place, off `theApp` so a test can reach them: the union, the single-search reply carrying the lifecycle tags, and the oldest sentinel-only reply. Reading the lifecycle tags rather than the overloaded sentinel also means a finished search says so at 100 %, instead of falling back to the 0 that `GetSearchProgress()` returns once nothing is running - which is the second half of the report, progress still reading 0 % after results arrived.

The progress reply now also carries `EC_TAG_SEARCH_NAME`: the query the search was started with, or the peer's nickname for a browse. It is the same tag and the same string `EC_OP_SEARCH_LIST` already reports, so a client can label a progress poll without also fetching the list. Together with the id already echoed per entry, that answers the request for progress to say which search it refers to:

```
 > Search 1 "freebsd": finished, 100 % (44 results)
 > Search 2 "ubuntu": running, 50 % (85 results)
```

Compatibility holds both ways: unknown tags are ignored, so older clients are unaffected, and a daemon too old to send the name renders the plain `Search 1: ...` line rather than an empty pair of quotes.

`Search progress not available` keeps its exact msgid - 28 catalogs translate it - so the newline is appended outside the string.

## Verification

14 unit tests over all three shapes, including the two discriminator traps: an expired verdict echoes a bare `EC_TAG_SEARCH_ID`, and the single-search reply echoes one too, so the presence of that tag cannot mean "union" - only a nested percent can.

Run against the pre-fix algorithm, 6 of them fail (`Not true: ...Contains(wxT("84 %"))`); the legacy-shape tests still pass, which is correct, since the old code handled those shapes.

End to end against live servers: the reported steps reproduce on master and are fixed here, checked with `progress`, `progress <id>`, and several concurrent searches. A global search was watched through `running, 50 %` and `running, 100 %` to `finished, 100 %`.

Catalogs regenerated. `docs/EC_Protocol.md` gains a paragraph for the new tag, since its union section describes this reply.
