### PR TITLE
fix(core,gui,ec): render a client's version one way everywhere

### DIFF
--- a/cmake/source-vars.cmake
+++ b/cmake/source-vars.cmake
@@ -131,6 +131,7 @@ if (BUILD_MONOLITHIC OR BUILD_DAEMON OR BUILD_REMOTEGUI)
 		ProtocolHandlerManager.cpp
 		$<$<BOOL:${APPLE}>:ProtocolHandlerManager_mac.mm>
 		ClientRef.cpp
+		ClientVersionString.cpp
 		ECSpecialMuleTags.cpp
 		GetTickCount.cpp
 		GuiEvents.cpp

--- a/src/BaseClient.cpp
+++ b/src/BaseClient.cpp
@@ -58,8 +58,9 @@
 #include "MemFile.h"           // Needed for CMemFile
 #include "Packet.h"            // Needed for CPacket
 #include "Friend.h"            // Needed for CFriend
-#include "ClientList.h"        // Needed for CClientList
-#include "ChatSessionStore.h"  // Needed for CChatSessionStore
+#include "ClientVersionString.h"
+#include "ClientList.h"       // Needed for CClientList
+#include "ChatSessionStore.h" // Needed for CChatSessionStore
 #ifndef AMULE_DAEMON
 #include "amuleDlg.h"      // Needed for CamuleDlg
 #include "CaptchaDialog.h" // Needed for CCaptchaDialog
@@ -2019,40 +2020,16 @@ void CUpDownClient::ReGetClientSoft()
 			m_nClientVersion =
 				MAKE_CLIENT_VERSION(nClientMajVersion, nClientMinVersion, nClientUpVersion);
 
-			switch (m_clientSoft) {
-			case SO_AMULE:
-			case SO_LXMULE:
-			case SO_HYDRANODE:
-			case SO_MLDONKEY:
-			case SO_NEW_MLDONKEY:
-			case SO_NEW2_MLDONKEY:
-				// Kry - xMule started sending correct version tags on 1.9.1b.
-				// It only took them 4 months, and being told by me and the
-				// eMule+ developers, so I think they're slowly getting smarter.
-				// They are based on our implementation, so we use the same format
-				// for the version string.
-				m_clientVerString = CFormat("v%u.%u.%u") % nClientMajVersion %
-						    nClientMinVersion % nClientUpVersion;
-				break;
-			case SO_LPHANT:
-				m_clientVerString = CFormat(" v%u.%.2u%c") % (nClientMajVersion - 1) %
-						    nClientMinVersion % ('a' + nClientUpVersion);
-				break;
-			case SO_EMULEPLUS:
-				m_clientVerString = CFormat("v%u") % nClientMajVersion;
-				if (nClientMinVersion != 0) {
-					m_clientVerString += CFormat(".%u") % nClientMinVersion;
-				}
-				if (nClientUpVersion != 0) {
-					m_clientVerString += CFormat("%c") % ('a' + nClientUpVersion - 1);
-				}
-				break;
-			default:
+			if (m_clientSoft != SO_AMULE && m_clientSoft != SO_LXMULE &&
+				m_clientSoft != SO_HYDRANODE && m_clientSoft != SO_MLDONKEY &&
+				m_clientSoft != SO_NEW_MLDONKEY && m_clientSoft != SO_NEW2_MLDONKEY &&
+				m_clientSoft != SO_LPHANT && m_clientSoft != SO_EMULEPLUS) {
 				clientModString = GetClientModString();
-				m_clientVerString = CFormat("v%u.%u%c") % nClientMajVersion %
-						    nClientMinVersion % ('a' + nClientUpVersion);
-				break;
 			}
+			// One renderer for every consumer: the history rows derive the same
+			// string from the stored numeric, and used to disagree with this one.
+			m_clientVerString = FormatClientVersion(
+				m_clientSoft, nClientMajVersion, nClientMinVersion, nClientUpVersion);
 		}
 	} else if (m_bIsHybrid) {
 		// seen:

--- a/src/ClientVersionString.cpp
+++ b/src/ClientVersionString.cpp
@@ -1,0 +1,87 @@
+//
+// This file is part of the aMule Project.
+//
+// Copyright (c) 2003-2026 aMule Team ( https://amule-org.github.io )
+// Copyright (c) 2002-2011 Merkur ( devs@emule-project.net / http://www.emule-project.net )
+//
+// Any parts of this program derived from the xMule, lMule or eMule project,
+// or contributed by third-party developers are copyrighted by their
+// respective authors.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301, USA
+//
+
+#include "ClientVersionString.h"
+
+#include <common/Format.h>
+#include <protocol/ed2k/ClientSoftware.h>
+
+#include <wx/string.h>
+
+wxString FormatClientVersion(uint32 clientSoft, uint32 major, uint32 minor, uint32 update)
+{
+	switch (clientSoft) {
+	case SO_AMULE:
+	case SO_LXMULE:
+	case SO_HYDRANODE:
+	case SO_MLDONKEY:
+	case SO_NEW_MLDONKEY:
+	case SO_NEW2_MLDONKEY:
+		// The mule/mldonkey family versions itself with three numbers.
+		return CFormat(wxT("v%u.%u.%u")) % major % minor % update;
+
+	case SO_EDONKEYHYBRID:
+		// Three numbers as well, but it drops a zero update rather than
+		// printing it.
+		if (update == 0) {
+			return CFormat(wxT("v%u.%u")) % major % minor;
+		}
+		return CFormat(wxT("v%u.%u.%u")) % major % minor % update;
+
+	case SO_LPHANT:
+		// Counts its major one higher than the wire does, pads the minor to
+		// two digits, and letters the update from 'a'.
+		return CFormat(wxT(" v%u.%.2u%c")) % (major - 1) % minor % ('a' + update);
+
+	case SO_EMULEPLUS: {
+		// Omits whichever trailing components are zero, and letters the
+		// update from 'a' meaning 1 -- unlike eMule, where 'a' means 0.
+		wxString out = CFormat(wxT("v%u")) % major;
+		if (minor != 0) {
+			out += CFormat(wxT(".%u")) % minor;
+		}
+		if (update != 0) {
+			out += CFormat(wxT("%c")) % ('a' + update - 1);
+		}
+		return out;
+	}
+
+	default:
+		// eMule and everything modelled on it: the update is a letter, 'a'
+		// meaning 0. This is the case the history rows used to render as a
+		// digit.
+		return CFormat(wxT("v%u.%u%c")) % major % minor % ('a' + update);
+	}
+}
+
+wxString FormatPackedClientVersion(uint32 clientSoft, uint32 packedVersion)
+{
+	// MAKE_CLIENT_VERSION is a decimal composite, not a bitfield:
+	// major * 100000 + minor * 1000 + update * 100.
+	return FormatClientVersion(clientSoft,
+		packedVersion / 100000,
+		(packedVersion % 100000) / 1000,
+		(packedVersion % 1000) / 100);
+}

--- a/src/ClientVersionString.h
+++ b/src/ClientVersionString.h
@@ -1,0 +1,60 @@
+//
+// This file is part of the aMule Project.
+//
+// Copyright (c) 2003-2026 aMule Team ( https://amule-org.github.io )
+// Copyright (c) 2002-2011 Merkur ( devs@emule-project.net / http://www.emule-project.net )
+//
+// Any parts of this program derived from the xMule, lMule or eMule project,
+// or contributed by third-party developers are copyrighted by their
+// respective authors.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301, USA
+//
+
+#ifndef CLIENTVERSIONSTRING_H
+#define CLIENTVERSIONSTRING_H
+
+#include "Types.h"
+
+class wxString;
+
+/**
+ * Render a client's version the way that client's own project writes it.
+ *
+ * The conventions differ per software and are not cosmetic: eMule spells its
+ * update component as a letter (0.70b, not 0.70.1), eMule Plus omits zero
+ * components, lPhant counts its major from one higher than the wire does, and
+ * the mule/mldonkey family really is three numbers.
+ *
+ * This exists because the rendering was reachable from two directions that had
+ * drifted apart. The handshake built the string from locals and got it right;
+ * the client-history rows re-derived it from the stored numeric with a fixed
+ * `v%u.%u.%u`, which silently dropped every convention above. The same peer
+ * could therefore be listed twice in one window under two different versions,
+ * depending only on whether it happened to be online (amule-org/amule#1127).
+ *
+ * `major`, `minor` and `update` are the decoded components, not the packed
+ * value MAKE_CLIENT_VERSION produces.
+ */
+wxString FormatClientVersion(uint32 clientSoft, uint32 major, uint32 minor, uint32 update);
+
+/**
+ * As above, from the packed form MAKE_CLIENT_VERSION produces and
+ * CreditStruct/ClientMetaStruct stores, which is a decimal composite rather
+ * than a bitfield.
+ */
+wxString FormatPackedClientVersion(uint32 clientSoft, uint32 packedVersion);
+
+#endif // CLIENTVERSIONSTRING_H

--- a/src/ClientsWnd.cpp
+++ b/src/ClientsWnd.cpp
@@ -22,7 +22,9 @@
 // Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301, USA
 //
 
-#include "ClientsWnd.h" // Interface declarations
+#include "ClientsWnd.h"
+
+#include "ClientVersionString.h" // Interface declarations
 
 #include <wx/sizer.h>
 
@@ -218,8 +220,10 @@ void CClientsWnd::LoadHistory()
 			row.clientSoft = meta.clientSoft;
 			row.sourceFrom = meta.sourceFrom;
 			row.obfuscation = meta.obfuscation;
-			row.version = CFormat(wxT("v%u.%u.%u")) % (meta.version / 100000) %
-				      ((meta.version % 100000) / 1000) % ((meta.version % 1000) / 100);
+			// Rendered the same way the live list renders it, so one peer is
+			// not listed under two different versions depending on whether it
+			// happens to be online.
+			row.version = FormatPackedClientVersion(meta.clientSoft, meta.version);
 		}
 		// Correlate with the live list by hash. Not by ECID: those mean
 		// nothing outside one daemon process, whereas this is the same

--- a/src/ExternalConn.cpp
+++ b/src/ExternalConn.cpp
@@ -51,6 +51,7 @@
 #include "BrowseManager.h"
 #include "amule.h"      // Needed for theApp
 #include "SearchList.h" // Needed for GetSearchResults
+#include "ClientVersionString.h"
 #include "ClientList.h"
 #include "ChatSessionStore.h"
 #include "ClientCreditsList.h" // Needed for CClientCreditsList
@@ -1928,16 +1929,13 @@ static CECPacket *Get_EC_Response_ClientHistory()
 			entry.AddTag(CECTag(EC_TAG_CLIENT_USER_PORT, meta.lastPort));
 			entry.AddTag(CECTag(EC_TAG_CLIENT_KAD_PORT, meta.kadPort));
 			entry.AddTag(CECTag(EC_TAG_CLIENT_SOFTWARE, meta.clientSoft));
-			// The generic major.minor.update form, not the per-software
-			// rendering ReGetClientSoft() produces. That one branches on
-			// the client type and is built from locals inside the
-			// handshake, so reproducing it here would mean either
-			// duplicating it or refactoring the handshake -- and the
-			// difference only shows on the few clients with a bespoke
-			// format (lPhant, eMule+), in a history row.
+			// The same per-software rendering the live path uses. This used
+			// to be a generic major.minor.update built here, on the reasoning
+			// that only lPhant and eMule+ have a bespoke format -- which
+			// overlooked plain eMule, whose update component is a letter, so
+			// every eMule in the history read as v0.70.1 rather than v0.70b.
 			entry.AddTag(CECTag(EC_TAG_CLIENT_SOFT_VER_STR,
-				CFormat(wxT("v%u.%u.%u")) % (meta.version / 100000) %
-					((meta.version % 100000) / 1000) % ((meta.version % 1000) / 100)));
+				FormatPackedClientVersion(meta.clientSoft, meta.version)));
 			entry.AddTag(CECTag(EC_TAG_CLIENT_FROM, meta.sourceFrom));
 			entry.AddTag(CECTag(EC_TAG_CLIENT_OBFUSCATION_STATUS, meta.obfuscation));
 #ifdef ENABLE_IP2COUNTRY

--- a/unittests/tests/CMakeLists.txt
+++ b/unittests/tests/CMakeLists.txt
@@ -26,6 +26,34 @@ target_link_libraries (CTagTest
 # just stops updating in the GUI -- so the contract is pinned here rather than
 # left to a clean daemon run. Needs no app, no daemon and no database: the EC
 # tag types and their generated codes are the whole dependency.
+# How a peer's version is spelled. Each client project writes its own
+# differently -- eMule letters the update (0.70b), eMule Plus omits zero
+# components, lPhant counts its major one higher -- and the rendering used to
+# exist twice: once in the handshake, once in the client-history rows, which
+# re-derived it from the stored numeric and dropped every convention. The same
+# peer could appear in one window under two versions depending only on whether
+# it was online. Needs no app and no daemon.
+add_executable (ClientVersionStringTest
+	ClientVersionStringTest.cpp
+	${CMAKE_SOURCE_DIR}/src/ClientVersionString.cpp
+)
+
+add_test (NAME ClientVersionStringTest
+	COMMAND ClientVersionStringTest
+)
+
+target_include_directories (ClientVersionStringTest
+	PRIVATE ${CMAKE_BINARY_DIR}
+	PRIVATE ${CMAKE_SOURCE_DIR}/src
+	PRIVATE ${CMAKE_SOURCE_DIR}/src/include
+	PRIVATE ${CMAKE_SOURCE_DIR}/src/libs
+)
+
+target_link_libraries (ClientVersionStringTest
+	muleunit
+	mulecommon
+)
+
 add_executable (ECIdDiffTest
 	ECIdDiffTest.cpp
 	# See the note on CValueMapTest below: libec.a references DoECLogLine /

--- a/unittests/tests/ClientVersionStringTest.cpp
+++ b/unittests/tests/ClientVersionStringTest.cpp
@@ -1,0 +1,103 @@
+//
+// This file is part of the aMule Project.
+//
+// Copyright (c) 2003-2026 aMule Team ( https://amule-org.github.io )
+// Copyright (c) 2002-2011 Merkur ( devs@emule-project.net / http://www.emule-project.net )
+//
+// Any parts of this program derived from the xMule, lMule or eMule project,
+// or contributed by third-party developers are copyrighted by their
+// respective authors.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301, USA
+//
+
+#include "ClientVersionString.h"
+
+#include <muleunit/test.h>
+#include <protocol/ed2k/ClientSoftware.h>
+
+using namespace muleunit;
+
+DECLARE_SIMPLE(ClientVersionString)
+
+// The reported case: eMule spells its update as a letter, and the history rows
+// rendered it as a digit (amule-org/amule#1127).
+TEST(ClientVersionString, EMuleLettersItsUpdateComponent)
+{
+	ASSERT_EQUALS(wxT("v0.70a"), FormatClientVersion(SO_EMULE, 0, 70, 0));
+	ASSERT_EQUALS(wxT("v0.70b"), FormatClientVersion(SO_EMULE, 0, 70, 1));
+	ASSERT_EQUALS(wxT("v0.49d"), FormatClientVersion(SO_EMULE, 0, 49, 3));
+}
+
+// An unknown software is rendered as eMule, which is what the handshake's
+// default branch did.
+TEST(ClientVersionString, AnUnknownSoftwareFollowsEMule)
+{
+	ASSERT_EQUALS(wxT("v0.60a"), FormatClientVersion(0xfe, 0, 60, 0));
+}
+
+TEST(ClientVersionString, TheMuleFamilyUsesThreeNumbers)
+{
+	ASSERT_EQUALS(wxT("v2.3.3"), FormatClientVersion(SO_AMULE, 2, 3, 3));
+	ASSERT_EQUALS(wxT("v1.9.1"), FormatClientVersion(SO_LXMULE, 1, 9, 1));
+	ASSERT_EQUALS(wxT("v3.1.6"), FormatClientVersion(SO_MLDONKEY, 3, 1, 6));
+	ASSERT_EQUALS(wxT("v0.0.0"), FormatClientVersion(SO_HYDRANODE, 0, 0, 0));
+}
+
+// The hybrid drops a zero update rather than printing it.
+TEST(ClientVersionString, TheHybridOmitsAZeroUpdate)
+{
+	ASSERT_EQUALS(wxT("v1.50"), FormatClientVersion(SO_EDONKEYHYBRID, 1, 50, 0));
+	ASSERT_EQUALS(wxT("v1.50.2"), FormatClientVersion(SO_EDONKEYHYBRID, 1, 50, 2));
+}
+
+// eMule Plus omits zero components, and letters from 'a' meaning 1 -- one off
+// from eMule, where 'a' means 0.
+TEST(ClientVersionString, EMulePlusOmitsZeroComponents)
+{
+	ASSERT_EQUALS(wxT("v1"), FormatClientVersion(SO_EMULEPLUS, 1, 0, 0));
+	ASSERT_EQUALS(wxT("v1.2"), FormatClientVersion(SO_EMULEPLUS, 1, 2, 0));
+	ASSERT_EQUALS(wxT("v1.2a"), FormatClientVersion(SO_EMULEPLUS, 1, 2, 1));
+	ASSERT_EQUALS(wxT("v1.2b"), FormatClientVersion(SO_EMULEPLUS, 1, 2, 2));
+}
+
+TEST(ClientVersionString, LPhantCountsItsMajorOneHigher)
+{
+	// major 1 on the wire is lPhant 0.x, and the minor is padded to two.
+	ASSERT_EQUALS(wxT(" v0.05a"), FormatClientVersion(SO_LPHANT, 1, 5, 0));
+	ASSERT_EQUALS(wxT(" v0.51b"), FormatClientVersion(SO_LPHANT, 1, 51, 1));
+}
+
+// MAKE_CLIENT_VERSION is a decimal composite, not a bitfield. The history rows
+// store that form, so the packed helper has to decompose it the same way.
+TEST(ClientVersionString, ThePackedFormDecomposesDecimally)
+{
+	// 0 * 100000 + 70 * 1000 + 1 * 100 -- eMule 0.70b, the reported row.
+	ASSERT_EQUALS(wxT("v0.70b"), FormatPackedClientVersion(SO_EMULE, 70100));
+	ASSERT_EQUALS(wxT("v0.70a"), FormatPackedClientVersion(SO_EMULE, 70000));
+	// 2 * 100000 + 3 * 1000 + 3 * 100 -- aMule 2.3.3.
+	ASSERT_EQUALS(wxT("v2.3.3"), FormatPackedClientVersion(SO_AMULE, 203300));
+}
+
+// The whole point: one peer must not read differently depending on which path
+// rendered it. The live path decodes the wire into components; the history
+// path decodes the stored composite. Both must land on the same string.
+TEST(ClientVersionString, BothPathsAgreeForTheSamePeer)
+{
+	const uint32 major = 0, minor = 70, update = 1;
+	const uint32 packed = major * 100000 + minor * 1000 + update * 100;
+	ASSERT_EQUALS(FormatClientVersion(SO_EMULE, major, minor, update),
+		FormatPackedClientVersion(SO_EMULE, packed));
+}


### PR DESCRIPTION
Fixes #1127.

## Cause

The Known tab showed eMule peers as `v0.70.1`. eMule spells its update component as a letter, so that peer is `v0.70b`.

The rendering existed twice. The handshake built it in `ReGetClientSoft()`, branching per software, and got it right. The client-history rows re-derived it from the stored numeric with a fixed `v%u.%u.%u`, ignoring which software it was: once in `ClientsWnd.cpp` for the monolithic tab, and again in `ExternalConn.cpp` for the tag amulegui and amuleapi read.

Both dropped every per-software convention - eMule's letter, eMule Plus omitting zero components, lPhant counting its major one higher, and the mule/mldonkey family's genuine three numbers.

The comment at the EC site argued the difference "only shows on the few clients with a bespoke format (lPhant, eMule+)". That reasoning missed plain eMule, which is the common case rather than a bespoke one.

Worse than simply wrong, it was inconsistent within a single list: those rows take their version from the live client when the peer happens to be online, so the same eMule read `v0.70b` or `v0.70.1` depending on nothing but whether it was connected at the time.

## Change

The per-software switch moves into `FormatClientVersion()`, called from all three places. `FormatPackedClientVersion()` decomposes the stored form for the two history sites - `MAKE_CLIENT_VERSION` is a decimal composite (`major * 100000 + minor * 1000 + update * 100`), not a bitfield, so the old arithmetic was right and only the convention was missing.

amuleapi needs no change of its own: it consumes `EC_TAG_CLIENT_SOFT_VER_STR` rather than formatting, so it follows the daemon. Nothing new goes on the wire.

The pre-`0x99` handshake path, where only a minor version is known, keeps its own `v0.%u`; it has no update component to spell either way.

`ClientVersionString.cpp` goes in `COMMON_SOURCES` because `BaseClient.cpp` is core-only and `ClientsWnd.cpp` is GUI, and amulegui links one but not the other - that group is the only one all three binaries share.

## Verification

8 unit tests pinning each software's convention. Against the previous rendering they fail with `Expected 'v0.70b' but got 'v0.70.1'`, the reported string exactly.

Live against real peers, the statistics client tree reports `aMule: v2.3.1` and `eMule: v0.50a`, exercising both the three-number and the lettered branch and confirming the handshake refactor is behaviour-preserving.

All three binaries build; clang-format and Tier-2 clang-tidy clean. No new translatable strings, so no catalog churn.
