### PR TITLE
feat(amulecmd): separate list fields with tabs, with --space-separated to opt out

### DIFF
--- a/docs/man/amulecmd.1.in
+++ b/docs/man/amulecmd.1.in
@@ -14,6 +14,7 @@ amulecmd \- Console-based program to control aMule
 .RB_untranslated [ \-v ]
 .RB [ \-l " " \fI<lang> ]
 .RB { " " [ \-w ] " " | " " [ \-c " " \fI<command> ] " " }
+.RB_untranslated [ \-\-space\-separated ]
 
 .B_untranslated amulecmd
 .RB [ \-\-create\-config\-from = \fI<path> ]
@@ -69,6 +70,10 @@ Turning it off leaves everything after the login readable, and modifiable, by an
 .B_untranslated [ \-\-force\-zlib ]\fR
 Force ZLIB compression on the External Connection link regardless of the dialed-IP locality.
 Useful when the server side is reachable over a VPN tunnel that resolves to a LAN IP and the heuristic would otherwise skip compression.
+.TP
+.B_untranslated [ \-\-space\-separated ]\fR
+Separate the fields of the list commands with spaces, as earlier versions did, instead of tabs.
+Client names and file names may contain spaces, so the default tab separator is what lets a script split a row back into its fields; use this only for scripts written against the older output.
 .TP
 .B_untranslated [ \-\-version ]\fR
 Displays the current version number.

--- a/docs/man/po/manpages-de.po
+++ b/docs/man/po/manpages-de.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: manpages-de\n"
-"POT-Creation-Date: 2026-07-30 17:31+0200\n"
+"POT-Creation-Date: 2026-08-24 19:02+0200\n"
 "PO-Revision-Date: 2026-08-22 15:51+0000\n"
 "Last-Translator: Balla Marcell <marcell.balla@gmx.at>\n"
 "Language-Team: German <kde-i18n-de@kde.org>\n"
@@ -514,6 +514,11 @@ msgstr ""
 #: amulecmd.1.in amuleweb.1.in
 msgid "Force ZLIB compression on the External Connection link regardless of the dialed-IP locality.  Useful when the server side is reachable over a VPN tunnel that resolves to a LAN IP and the heuristic would otherwise skip compression."
 msgstr "Erzwingt ZLIB Kompression der externen Verbindung, unabhängig von der Lokalität der gewählten IP. Nützlich, wenn der Server über einen VPN Tunnel erreichbar ist, der eine LAN IP ist, und die Heuristik sonst Kompression deaktivieren würde."
+
+#. type: Plain text
+#: amulecmd.1.in
+msgid "Separate the fields of the list commands with spaces, as earlier versions did, instead of tabs.  Client names and file names may contain spaces, so the default tab separator is what lets a script split a row back into its fields; use this only for scripts written against the older output."
+msgstr ""
 
 # type: SH
 #. type: SH

--- a/docs/man/po/manpages-es.po
+++ b/docs/man/po/manpages-es.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: es\n"
-"POT-Creation-Date: 2026-07-30 17:31+0200\n"
+"POT-Creation-Date: 2026-08-24 19:02+0200\n"
 "PO-Revision-Date: 2026-08-22 15:51+0000\n"
 "Last-Translator: Mad-Soft <mad.soft@gmail.com>\n"
 "Language-Team: Spanish <es_ES@li.org>\n"
@@ -453,6 +453,11 @@ msgstr "No cifran el enlace de conexión externa.  El cifrado se negocia automá
 #: amulecmd.1.in amuleweb.1.in
 msgid "Force ZLIB compression on the External Connection link regardless of the dialed-IP locality.  Useful when the server side is reachable over a VPN tunnel that resolves to a LAN IP and the heuristic would otherwise skip compression."
 msgstr "Forzar la compresión ZLIB en el protocolo de Conexiones Externas aunque se esté conectando a una IP local/LAN. Esto es útil cuando la conexión al servidor se realiza a través de un túnel VPN que se resuelve a una IP de LAN, lo que por defecto desactivaría la compresión."
+
+#. type: Plain text
+#: amulecmd.1.in
+msgid "Separate the fields of the list commands with spaces, as earlier versions did, instead of tabs.  Client names and file names may contain spaces, so the default tab separator is what lets a script split a row back into its fields; use this only for scripts written against the older output."
+msgstr ""
 
 #. type: SH
 #: amulecmd.1.in

--- a/docs/man/po/manpages-fr.po
+++ b/docs/man/po/manpages-fr.po
@@ -9,7 +9,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
-"POT-Creation-Date: 2026-07-30 17:31+0200\n"
+"POT-Creation-Date: 2026-08-24 19:02+0200\n"
 "PO-Revision-Date: 2026-08-22 15:51+0000\n"
 "Last-Translator: Dylan Aïssi <bob.dybian@gmail.com>\n"
 "Language-Team: Français\n"
@@ -454,6 +454,11 @@ msgstr "Ne pas chiffrer le lien de Connexion externe.  Le chiffrement est négoc
 #: amulecmd.1.in amuleweb.1.in
 msgid "Force ZLIB compression on the External Connection link regardless of the dialed-IP locality.  Useful when the server side is reachable over a VPN tunnel that resolves to a LAN IP and the heuristic would otherwise skip compression."
 msgstr "Forcer la compression ZLIB sur le lien Connexion Externe quelle que soit l'adresse IP de destination.  Utile lorsque le serveur est accessible via un tunnel VPN qui se résout en une adresse IP du réseau local et que l'heuristique ignorerait autrement la compression."
+
+#. type: Plain text
+#: amulecmd.1.in
+msgid "Separate the fields of the list commands with spaces, as earlier versions did, instead of tabs.  Client names and file names may contain spaces, so the default tab separator is what lets a script split a row back into its fields; use this only for scripts written against the older output."
+msgstr ""
 
 #. type: SH
 #: amulecmd.1.in

--- a/docs/man/po/manpages-hu.po
+++ b/docs/man/po/manpages-hu.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: po 4a\n"
-"POT-Creation-Date: 2026-07-30 17:31+0200\n"
+"POT-Creation-Date: 2026-08-24 19:02+0200\n"
 "PO-Revision-Date: 2026-08-22 15:51+0000\n"
 "Last-Translator: Dévai Tamás <gonosztopi@amule.org>\n"
 "Language-Team: none\n"
@@ -454,6 +454,11 @@ msgstr ""
 #. type: Plain text
 #: amulecmd.1.in amuleweb.1.in
 msgid "Force ZLIB compression on the External Connection link regardless of the dialed-IP locality.  Useful when the server side is reachable over a VPN tunnel that resolves to a LAN IP and the heuristic would otherwise skip compression."
+msgstr ""
+
+#. type: Plain text
+#: amulecmd.1.in
+msgid "Separate the fields of the list commands with spaces, as earlier versions did, instead of tabs.  Client names and file names may contain spaces, so the default tab separator is what lets a script split a row back into its fields; use this only for scripts written against the older output."
 msgstr ""
 
 #. type: SH

--- a/docs/man/po/manpages-it.po
+++ b/docs/man/po/manpages-it.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: aMule SVN\n"
-"POT-Creation-Date: 2026-07-30 17:31+0200\n"
+"POT-Creation-Date: 2026-08-24 19:02+0200\n"
 "PO-Revision-Date: 2026-08-22 15:52+0000\n"
 "Last-Translator: Sebastiano Pistore <SebastianoPistore.info@protonmail.ch>\n"
 "Language-Team: none\n"
@@ -520,6 +520,11 @@ msgstr "Non cifrare il collegamento di connessione esterna. La cifratura viene n
 #: amulecmd.1.in amuleweb.1.in
 msgid "Force ZLIB compression on the External Connection link regardless of the dialed-IP locality.  Useful when the server side is reachable over a VPN tunnel that resolves to a LAN IP and the heuristic would otherwise skip compression."
 msgstr "Forza la compressione ZLIB sulla connessione esterna indipendentemente dalla località dell'IP contattato.  Utile quando il server è raggiungibile attraverso un tunnel VPN che risolve a un IP di LAN e l'euristica salterebbe altrimenti la compressione."
+
+#. type: Plain text
+#: amulecmd.1.in
+msgid "Separate the fields of the list commands with spaces, as earlier versions did, instead of tabs.  Client names and file names may contain spaces, so the default tab separator is what lets a script split a row back into its fields; use this only for scripts written against the older output."
+msgstr ""
 
 # type: SH
 #. type: SH

--- a/docs/man/po/manpages-pt_BR.po
+++ b/docs/man/po/manpages-pt_BR.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: aMule man pages\n"
-"POT-Creation-Date: 2026-07-30 17:31+0200\n"
+"POT-Creation-Date: 2026-08-24 19:02+0200\n"
 "PO-Revision-Date: 2026-08-22 15:52+0000\n"
 "Last-Translator: \n"
 "Language-Team: Marcelo Roberto Jimenez <mroberto@users.sourceforge.net>\n"
@@ -451,6 +451,11 @@ msgstr "Não criptografe o link de Conexões Externas.  A criptografia é negoci
 #: amulecmd.1.in amuleweb.1.in
 msgid "Force ZLIB compression on the External Connection link regardless of the dialed-IP locality.  Useful when the server side is reachable over a VPN tunnel that resolves to a LAN IP and the heuristic would otherwise skip compression."
 msgstr "Força compressão ZLIB no link de Conexões Externas independente da localidade IP-discada. Útil quando o lado do servidor for alcançável com um túnel VPN que resolve para um IP de LAN e a heurística iria pular a compressão."
+
+#. type: Plain text
+#: amulecmd.1.in
+msgid "Separate the fields of the list commands with spaces, as earlier versions did, instead of tabs.  Client names and file names may contain spaces, so the default tab separator is what lets a script split a row back into its fields; use this only for scripts written against the older output."
+msgstr ""
 
 #. type: SH
 #: amulecmd.1.in

--- a/docs/man/po/manpages-ro.po
+++ b/docs/man/po/manpages-ro.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"POT-Creation-Date: 2026-07-30 17:31+0200\n"
+"POT-Creation-Date: 2026-08-24 19:02+0200\n"
 "PO-Revision-Date: 2026-08-22 15:52+0000\n"
 "Last-Translator: Sebastiano Pistore <SebastianoPistore.info@protonmail.ch>\n"
 "Language-Team: Romanian <kde-i18n-doc@kde.org>\n"
@@ -454,6 +454,11 @@ msgstr ""
 #. type: Plain text
 #: amulecmd.1.in amuleweb.1.in
 msgid "Force ZLIB compression on the External Connection link regardless of the dialed-IP locality.  Useful when the server side is reachable over a VPN tunnel that resolves to a LAN IP and the heuristic would otherwise skip compression."
+msgstr ""
+
+#. type: Plain text
+#: amulecmd.1.in
+msgid "Separate the fields of the list commands with spaces, as earlier versions did, instead of tabs.  Client names and file names may contain spaces, so the default tab separator is what lets a script split a row back into its fields; use this only for scripts written against the older output."
 msgstr ""
 
 #. type: SH

--- a/docs/man/po/manpages-ru.po
+++ b/docs/man/po/manpages-ru.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: manpages-ru\n"
-"POT-Creation-Date: 2026-07-30 17:31+0200\n"
+"POT-Creation-Date: 2026-08-24 19:02+0200\n"
 "PO-Revision-Date: 2026-08-22 15:52+0000\n"
 "Last-Translator: Sebastiano Pistore <SebastianoPistore.info@protonmail.ch>\n"
 "Language-Team: Russian <LL@li.org>\n"
@@ -452,6 +452,11 @@ msgstr "Не шифровать соединение внешнего подкл
 #: amulecmd.1.in amuleweb.1.in
 msgid "Force ZLIB compression on the External Connection link regardless of the dialed-IP locality.  Useful when the server side is reachable over a VPN tunnel that resolves to a LAN IP and the heuristic would otherwise skip compression."
 msgstr "Принудительно использовать сжатие ZLIB для соединения внешнего подключения независимо от локальности вызванного IP-адреса. Полезно, когда серверная сторона доступна через VPN-туннель, который разрешается в локальный IP-адрес, и эвристика в противном случае пропустила бы сжатие."
+
+#. type: Plain text
+#: amulecmd.1.in
+msgid "Separate the fields of the list commands with spaces, as earlier versions did, instead of tabs.  Client names and file names may contain spaces, so the default tab separator is what lets a script split a row back into its fields; use this only for scripts written against the older output."
+msgstr ""
 
 #. type: SH
 #: amulecmd.1.in

--- a/docs/man/po/manpages-tr.po
+++ b/docs/man/po/manpages-tr.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
-"POT-Creation-Date: 2026-07-30 17:31+0200\n"
+"POT-Creation-Date: 2026-08-24 19:02+0200\n"
 "PO-Revision-Date: 2026-08-22 15:52+0000\n"
 "Last-Translator: Sebastiano Pistore <SebastianoPistore.info@protonmail.ch>\n"
 "Language-Team: \n"
@@ -449,6 +449,11 @@ msgstr "Harici Bağlantı bağlantısını şifreleme.  Şifreleme uzaktaki aMul
 #: amulecmd.1.in amuleweb.1.in
 msgid "Force ZLIB compression on the External Connection link regardless of the dialed-IP locality.  Useful when the server side is reachable over a VPN tunnel that resolves to a LAN IP and the heuristic would otherwise skip compression."
 msgstr "Seçilen IP adresinin konumuna bakılmaksızın Harici Bağlantı için ZLIB sıkıştırmasını zorlar.  Sunucuya, bir LAN IP adresine çözümlenen VPN tüneli üzerinden erişilebildiğinde ve aksi takdirde sezgisel algoritmanın sıkıştırmayı atlayacağı durumlarda kullanışlıdır."
+
+#. type: Plain text
+#: amulecmd.1.in
+msgid "Separate the fields of the list commands with spaces, as earlier versions did, instead of tabs.  Client names and file names may contain spaces, so the default tab separator is what lets a script split a row back into its fields; use this only for scripts written against the older output."
+msgstr ""
 
 #. type: SH
 #: amulecmd.1.in

--- a/docs/man/po/manpages-zh_TW.po
+++ b/docs/man/po/manpages-zh_TW.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule Manual zh_TW\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-30 17:31+0200\n"
+"POT-Creation-Date: 2026-08-24 19:02+0200\n"
 "PO-Revision-Date: 2026-08-22 15:53+0000\n"
 "Last-Translator: Wayne Su <mstarmstar@gmail.com>\n"
 "Language-Team: \n"
@@ -461,6 +461,11 @@ msgstr ""
 #. type: Plain text
 #: amulecmd.1.in amuleweb.1.in
 msgid "Force ZLIB compression on the External Connection link regardless of the dialed-IP locality.  Useful when the server side is reachable over a VPN tunnel that resolves to a LAN IP and the heuristic would otherwise skip compression."
+msgstr ""
+
+#. type: Plain text
+#: amulecmd.1.in
+msgid "Separate the fields of the list commands with spaces, as earlier versions did, instead of tabs.  Client names and file names may contain spaces, so the default tab separator is what lets a script split a row back into its fields; use this only for scripts written against the older output."
 msgstr ""
 
 #. type: SH

--- a/docs/man/po/manpages.pot
+++ b/docs/man/po/manpages.pot
@@ -5,7 +5,7 @@
 #
 #, fuzzy
 msgid ""
-msgstr "Project-Id-Version: PACKAGE VERSION\nPOT-Creation-Date: 2026-07-30 17:31+0200\nPO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\nLast-Translator: FULL NAME <EMAIL@ADDRESS>\nLanguage-Team: LANGUAGE <LL@li.org>\nLanguage: \nMIME-Version: 1.0\nContent-Type: text/plain; charset=UTF-8\nContent-Transfer-Encoding: 8bit\n"
+msgstr "Project-Id-Version: PACKAGE VERSION\nPOT-Creation-Date: 2026-08-24 19:02+0200\nPO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\nLast-Translator: FULL NAME <EMAIL@ADDRESS>\nLanguage-Team: LANGUAGE <LL@li.org>\nLanguage: \nMIME-Version: 1.0\nContent-Type: text/plain; charset=UTF-8\nContent-Transfer-Encoding: 8bit\n"
 
 #. type: TH
 #: amule.1.in
@@ -440,6 +440,11 @@ msgstr ""
 #. type: Plain text
 #: amulecmd.1.in amuleweb.1.in
 msgid "Force ZLIB compression on the External Connection link regardless of the dialed-IP locality.  Useful when the server side is reachable over a VPN tunnel that resolves to a LAN IP and the heuristic would otherwise skip compression."
+msgstr ""
+
+#. type: Plain text
+#: amulecmd.1.in
+msgid "Separate the fields of the list commands with spaces, as earlier versions did, instead of tabs.  Client names and file names may contain spaces, so the default tab separator is what lets a script split a row back into its fields; use this only for scripts written against the older output."
 msgstr ""
 
 #. type: SH

--- a/po/amule.pot
+++ b/po/amule.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 15:13+0200\n"
+"POT-Creation-Date: 2026-08-24 19:01+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -7555,6 +7555,10 @@ msgstr ""
 
 #: src/TextClient.cpp
 msgid "Execute <str> and exit."
+msgstr ""
+
+#: src/TextClient.cpp
+msgid "Separate list fields with spaces, as before, instead of tabs."
 msgstr ""
 
 #: src/TextClient.cpp

--- a/po/ar.po
+++ b/po/ar.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 15:13+0200\n"
+"POT-Creation-Date: 2026-08-24 19:01+0200\n"
 "PO-Revision-Date: 2026-08-22 15:09+0000\n"
 "Last-Translator: saleh alhathal <hathalsal@hotmail.com>\n"
 "Language-Team: \n"
@@ -7688,6 +7688,10 @@ msgstr ""
 
 #: src/TextClient.cpp
 msgid "Execute <str> and exit."
+msgstr ""
+
+#: src/TextClient.cpp
+msgid "Separate list fields with spaces, as before, instead of tabs."
 msgstr ""
 
 #: src/TextClient.cpp

--- a/po/ast.po
+++ b/po/ast.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 15:13+0200\n"
+"POT-Creation-Date: 2026-08-24 19:01+0200\n"
 "PO-Revision-Date: 2026-08-22 15:11+0000\n"
 "Last-Translator: astur <malditoastur@gmail.com>\n"
 "Language-Team: Language ast <malditoastur@gmail.com>\n"
@@ -7808,6 +7808,10 @@ msgstr "Comandu `%s' con pid `%d' finó con códigu `%d'."
 #: src/TextClient.cpp
 msgid "Execute <str> and exit."
 msgstr "Executa <str> y cuela."
+
+#: src/TextClient.cpp
+msgid "Separate list fields with spaces, as before, instead of tabs."
+msgstr ""
 
 #: src/TextClient.cpp
 msgid "Invalid IP format. Use xxx.xxx.xxx.xxx:xxxx\n"

--- a/po/bg.po
+++ b/po/bg.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 15:13+0200\n"
+"POT-Creation-Date: 2026-08-24 19:01+0200\n"
 "PO-Revision-Date: 2026-08-22 15:15+0000\n"
 "Last-Translator: Sebastiano Pistore <SebastianoPistore.info@protonmail.ch>\n"
 "Language-Team: Bulgarian <dict@linux.zonebg.com>\n"
@@ -7661,6 +7661,10 @@ msgstr ""
 
 #: src/TextClient.cpp
 msgid "Execute <str> and exit."
+msgstr ""
+
+#: src/TextClient.cpp
+msgid "Separate list fields with spaces, as before, instead of tabs."
 msgstr ""
 
 #: src/TextClient.cpp

--- a/po/bn.po
+++ b/po/bn.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 15:13+0200\n"
+"POT-Creation-Date: 2026-08-24 19:01+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -7554,6 +7554,10 @@ msgstr ""
 
 #: src/TextClient.cpp
 msgid "Execute <str> and exit."
+msgstr ""
+
+#: src/TextClient.cpp
+msgid "Separate list fields with spaces, as before, instead of tabs."
 msgstr ""
 
 #: src/TextClient.cpp

--- a/po/ca.po
+++ b/po/ca.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 15:13+0200\n"
+"POT-Creation-Date: 2026-08-24 19:01+0200\n"
 "PO-Revision-Date: 2026-08-22 15:16+0000\n"
 "Last-Translator: minterior <minterior@gmail.com>\n"
 "Language-Team: Català\n"
@@ -7768,6 +7768,10 @@ msgstr "L'ordre '%s' amb pid '%d' ha finalitzat amb el codi d'estat '%d'."
 #: src/TextClient.cpp
 msgid "Execute <str> and exit."
 msgstr "Executa <str> i surt."
+
+#: src/TextClient.cpp
+msgid "Separate list fields with spaces, as before, instead of tabs."
+msgstr ""
 
 #: src/TextClient.cpp
 msgid "Invalid IP format. Use xxx.xxx.xxx.xxx:xxxx\n"

--- a/po/cs.po
+++ b/po/cs.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 15:13+0200\n"
+"POT-Creation-Date: 2026-08-24 19:01+0200\n"
 "PO-Revision-Date: 2026-08-22 15:58+0000\n"
 "Last-Translator: David Watzke <david@watzke.cz>\n"
 "Language-Team: cs <cs@li.org>\n"
@@ -7784,6 +7784,10 @@ msgstr ""
 #: src/TextClient.cpp
 msgid "Execute <str> and exit."
 msgstr "Spustí <str> a ukončí se."
+
+#: src/TextClient.cpp
+msgid "Separate list fields with spaces, as before, instead of tabs."
+msgstr ""
 
 #: src/TextClient.cpp
 msgid "Invalid IP format. Use xxx.xxx.xxx.xxx:xxxx\n"

--- a/po/da.po
+++ b/po/da.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 15:13+0200\n"
+"POT-Creation-Date: 2026-08-24 19:01+0200\n"
 "PO-Revision-Date: 2026-08-22 15:22+0000\n"
 "Last-Translator: Alex Thomsen Leth <alexl@stofanet.dk>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -7709,6 +7709,10 @@ msgstr ""
 
 #: src/TextClient.cpp
 msgid "Execute <str> and exit."
+msgstr ""
+
+#: src/TextClient.cpp
+msgid "Separate list fields with spaces, as before, instead of tabs."
 msgstr ""
 
 #: src/TextClient.cpp

--- a/po/de.po
+++ b/po/de.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 15:13+0200\n"
+"POT-Creation-Date: 2026-08-24 19:01+0200\n"
 "PO-Revision-Date: 2026-08-22 15:23+0000\n"
 "Last-Translator: Werner Mahr <werner@vollstreckernet.de>\n"
 "Language-Team: German <>\n"
@@ -7763,6 +7763,10 @@ msgstr "Befehl '%s' mit pid '%d' wurde mit Status-Code '%d' abgeschlossen."
 #: src/TextClient.cpp
 msgid "Execute <str> and exit."
 msgstr "Führe <str> aus und beende."
+
+#: src/TextClient.cpp
+msgid "Separate list fields with spaces, as before, instead of tabs."
+msgstr ""
 
 #: src/TextClient.cpp
 msgid "Invalid IP format. Use xxx.xxx.xxx.xxx:xxxx\n"

--- a/po/el.po
+++ b/po/el.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 15:13+0200\n"
+"POT-Creation-Date: 2026-08-24 19:01+0200\n"
 "PO-Revision-Date: 2026-08-22 15:25+0000\n"
 "Last-Translator: Dimitris <dgalanak@yahoo.com>\n"
 "Language-Team: Greek\n"
@@ -7824,6 +7824,10 @@ msgstr "Η εντολή `%s' με pid `%d' τελείωση με κωδικό κ
 #: src/TextClient.cpp
 msgid "Execute <str> and exit."
 msgstr "Εκτέλεση <str> και έξοδος."
+
+#: src/TextClient.cpp
+msgid "Separate list fields with spaces, as before, instead of tabs."
+msgstr ""
 
 #: src/TextClient.cpp
 msgid "Invalid IP format. Use xxx.xxx.xxx.xxx:xxxx\n"

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 15:13+0200\n"
+"POT-Creation-Date: 2026-08-24 19:01+0200\n"
 "PO-Revision-Date: 2020-03-04 14:43+0100\n"
 "Last-Translator: Dévai Tamás <devait@vnet.hu>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -7555,6 +7555,10 @@ msgstr ""
 
 #: src/TextClient.cpp
 msgid "Execute <str> and exit."
+msgstr ""
+
+#: src/TextClient.cpp
+msgid "Separate list fields with spaces, as before, instead of tabs."
 msgstr ""
 
 #: src/TextClient.cpp

--- a/po/es.po
+++ b/po/es.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 15:13+0200\n"
+"POT-Creation-Date: 2026-08-24 19:01+0200\n"
 "PO-Revision-Date: 2026-08-22 15:26+0000\n"
 "Last-Translator: Diego Heras <ngosang@hotmail.es>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/amule/amule-application/es/>\n"
@@ -7709,6 +7709,10 @@ msgstr "El comando '%s' con pid '%d' ha terminado con el código de salida '%d'.
 #: src/TextClient.cpp
 msgid "Execute <str> and exit."
 msgstr "Ejecute <str> y salga."
+
+#: src/TextClient.cpp
+msgid "Separate list fields with spaces, as before, instead of tabs."
+msgstr ""
 
 #: src/TextClient.cpp
 msgid "Invalid IP format. Use xxx.xxx.xxx.xxx:xxxx\n"

--- a/po/et_EE.po
+++ b/po/et_EE.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 15:13+0200\n"
+"POT-Creation-Date: 2026-08-24 19:01+0200\n"
 "PO-Revision-Date: 2026-08-22 15:27+0000\n"
 "Last-Translator: \n"
 "Language-Team: Estonian <kde-i18n-doc@kde.org>\n"
@@ -7777,6 +7777,10 @@ msgstr "Käsk '%s' protsessi'id '%d' lõpetas staatusega '%d'."
 #: src/TextClient.cpp
 msgid "Execute <str> and exit."
 msgstr "Käivita <str> ja välju."
+
+#: src/TextClient.cpp
+msgid "Separate list fields with spaces, as before, instead of tabs."
+msgstr ""
 
 #: src/TextClient.cpp
 msgid "Invalid IP format. Use xxx.xxx.xxx.xxx:xxxx\n"

--- a/po/eu.po
+++ b/po/eu.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 15:13+0200\n"
+"POT-Creation-Date: 2026-08-24 19:01+0200\n"
 "PO-Revision-Date: 2026-08-22 15:28+0000\n"
 "Last-Translator: Piarres Beobide <pi@beobide.net>\n"
 "Language-Team: Euskara <librezale@librezale.org>\n"
@@ -7773,6 +7773,10 @@ msgstr "'%2$d' pid-a duen '%1$s' komandoa '%3$d' egoera kodeaz amaitu da."
 #: src/TextClient.cpp
 msgid "Execute <str> and exit."
 msgstr "<str> exekutatu eta irten."
+
+#: src/TextClient.cpp
+msgid "Separate list fields with spaces, as before, instead of tabs."
+msgstr ""
 
 #: src/TextClient.cpp
 msgid "Invalid IP format. Use xxx.xxx.xxx.xxx:xxxx\n"

--- a/po/fi.po
+++ b/po/fi.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 15:13+0200\n"
+"POT-Creation-Date: 2026-08-24 19:01+0200\n"
 "PO-Revision-Date: 2026-08-22 15:29+0000\n"
 "Last-Translator: Tapio Rantala <tapio.rantala@iki.fi>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -7773,6 +7773,10 @@ msgstr "Komento '%s' prosessinumerolla '%d' on suoritettu paluukoodilla '%d'."
 #: src/TextClient.cpp
 msgid "Execute <str> and exit."
 msgstr "Suorita <str> ja poistu."
+
+#: src/TextClient.cpp
+msgid "Separate list fields with spaces, as before, instead of tabs."
+msgstr ""
 
 #: src/TextClient.cpp
 msgid "Invalid IP format. Use xxx.xxx.xxx.xxx:xxxx\n"

--- a/po/fr.po
+++ b/po/fr.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 15:13+0200\n"
+"POT-Creation-Date: 2026-08-24 19:01+0200\n"
 "PO-Revision-Date: 2026-08-22 15:30+0000\n"
 "Last-Translator: Dylan Aïssi <bob.dybian@gmail.com>\n"
 "Language-Team: Français\n"
@@ -7704,6 +7704,10 @@ msgstr "La commande '%s' avec le PID '%d' s'est terminée avec le code '%d'."
 #: src/TextClient.cpp
 msgid "Execute <str> and exit."
 msgstr "Exécute <str> et quitte."
+
+#: src/TextClient.cpp
+msgid "Separate list fields with spaces, as before, instead of tabs."
+msgstr ""
 
 #: src/TextClient.cpp
 msgid "Invalid IP format. Use xxx.xxx.xxx.xxx:xxxx\n"

--- a/po/gl.po
+++ b/po/gl.po
@@ -24,7 +24,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 15:13+0200\n"
+"POT-Creation-Date: 2026-08-24 19:01+0200\n"
 "PO-Revision-Date: 2026-08-22 15:31+0000\n"
 "Last-Translator: Pablo <parodper@gmail.com>\n"
 "Language-Team: http://forum.amule.org/index.php?topic=13883\n"
@@ -7778,6 +7778,10 @@ msgstr "Comando «%s» con pid «%d» rematou con código de estado «%d»."
 #: src/TextClient.cpp
 msgid "Execute <str> and exit."
 msgstr "Executa <str> e sae."
+
+#: src/TextClient.cpp
+msgid "Separate list fields with spaces, as before, instead of tabs."
+msgstr ""
 
 #: src/TextClient.cpp
 msgid "Invalid IP format. Use xxx.xxx.xxx.xxx:xxxx\n"

--- a/po/he.po
+++ b/po/he.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 15:13+0200\n"
+"POT-Creation-Date: 2026-08-24 19:01+0200\n"
 "PO-Revision-Date: 2026-08-22 15:32+0000\n"
 "Last-Translator: Peace Kramer <kpeace1@gmail.com>\n"
 "Language-Team: Hebrew\n"
@@ -7749,6 +7749,10 @@ msgstr "פקודת '%s עם pid '%d' סיים עם קוד סטטוס '%d'."
 #: src/TextClient.cpp
 msgid "Execute <str> and exit."
 msgstr "הרץ <str> וצא."
+
+#: src/TextClient.cpp
+msgid "Separate list fields with spaces, as before, instead of tabs."
+msgstr ""
 
 #: src/TextClient.cpp
 msgid "Invalid IP format. Use xxx.xxx.xxx.xxx:xxxx\n"

--- a/po/hr.po
+++ b/po/hr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 15:13+0200\n"
+"POT-Creation-Date: 2026-08-24 19:01+0200\n"
 "PO-Revision-Date: 2026-08-22 15:32+0000\n"
 "Last-Translator: Sebastiano Pistore <sebastiano.pistore.info@aol.com>\n"
 "Language-Team: https://github.com/amule-org/amule <forum@aMule.org>\n"
@@ -7753,6 +7753,10 @@ msgstr ""
 
 #: src/TextClient.cpp
 msgid "Execute <str> and exit."
+msgstr ""
+
+#: src/TextClient.cpp
+msgid "Separate list fields with spaces, as before, instead of tabs."
 msgstr ""
 
 #: src/TextClient.cpp

--- a/po/hu.po
+++ b/po/hu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 15:13+0200\n"
+"POT-Creation-Date: 2026-08-24 19:01+0200\n"
 "PO-Revision-Date: 2026-08-22 15:33+0000\n"
 "Last-Translator: Dévai Tamás <gonosztopi@amule.org>\n"
 "Language-Team: Hungarian <hu@li.org>\n"
@@ -7722,6 +7722,10 @@ msgstr "A '%s' parancs - melynek pid-je '%d' - befejeződési állapotkódja '%d
 #: src/TextClient.cpp
 msgid "Execute <str> and exit."
 msgstr "Végrehajtja az <str>-t és kilép."
+
+#: src/TextClient.cpp
+msgid "Separate list fields with spaces, as before, instead of tabs."
+msgstr ""
 
 #: src/TextClient.cpp
 msgid "Invalid IP format. Use xxx.xxx.xxx.xxx:xxxx\n"

--- a/po/it.po
+++ b/po/it.po
@@ -19,7 +19,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule 2.3.3\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 15:13+0200\n"
+"POT-Creation-Date: 2026-08-24 19:01+0200\n"
 "PO-Revision-Date: 2026-08-22 15:34+0000\n"
 "Last-Translator: got3nks <got3nks@users.noreply.github.com>\n"
 "Language-Team: SebastianoPistore.info@protonmail.ch\n"
@@ -7711,6 +7711,10 @@ msgstr "Il comando `%s' con pid `%d' è terminato con il codice di stato `%d'."
 #: src/TextClient.cpp
 msgid "Execute <str> and exit."
 msgstr "Esegui <str> ed esci."
+
+#: src/TextClient.cpp
+msgid "Separate list fields with spaces, as before, instead of tabs."
+msgstr ""
 
 #: src/TextClient.cpp
 msgid "Invalid IP format. Use xxx.xxx.xxx.xxx:xxxx\n"

--- a/po/ja.po
+++ b/po/ja.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 15:13+0200\n"
+"POT-Creation-Date: 2026-08-24 19:01+0200\n"
 "PO-Revision-Date: 2026-08-22 15:35+0000\n"
 "Last-Translator: \n"
 "Language-Team: Japanese\n"
@@ -7759,6 +7759,10 @@ msgstr "PID `%2$d' のコマンド  `%1$s' がステータスコード  `%3$d' �
 #: src/TextClient.cpp
 msgid "Execute <str> and exit."
 msgstr "<str>を実行してから終了する。"
+
+#: src/TextClient.cpp
+msgid "Separate list fields with spaces, as before, instead of tabs."
+msgstr ""
 
 #: src/TextClient.cpp
 msgid "Invalid IP format. Use xxx.xxx.xxx.xxx:xxxx\n"

--- a/po/ko_KR.po
+++ b/po/ko_KR.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 15:13+0200\n"
+"POT-Creation-Date: 2026-08-24 19:01+0200\n"
 "PO-Revision-Date: 2026-08-22 15:36+0000\n"
 "Last-Translator: Hyunju Kang <rexington@gmail.com>\n"
 "Language-Team: Korean <hoenny@daum.net>\n"
@@ -7821,6 +7821,10 @@ msgstr "`%s' 명령(pid `%d')은 상태코드 `%d'로 종료되었습니다."
 #: src/TextClient.cpp
 msgid "Execute <str> and exit."
 msgstr "<str>을 실행하고 종료합니다."
+
+#: src/TextClient.cpp
+msgid "Separate list fields with spaces, as before, instead of tabs."
+msgstr ""
 
 #: src/TextClient.cpp
 msgid "Invalid IP format. Use xxx.xxx.xxx.xxx:xxxx\n"

--- a/po/lt.po
+++ b/po/lt.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 15:13+0200\n"
+"POT-Creation-Date: 2026-08-24 19:01+0200\n"
 "PO-Revision-Date: 2026-08-22 15:37+0000\n"
 "Last-Translator: Dovydas Sankauskas <laisve@gmail.com>\n"
 "Language-Team: Lithuanian <komp_lt@konf.lt>\n"
@@ -7861,6 +7861,10 @@ msgstr "Komanda „%s“, kurios pid „%d“, baigė darbą pranešdama būseno
 #: src/TextClient.cpp
 msgid "Execute <str> and exit."
 msgstr "Įvykdyti <str> ir baigti darbą."
+
+#: src/TextClient.cpp
+msgid "Separate list fields with spaces, as before, instead of tabs."
+msgstr ""
 
 #: src/TextClient.cpp
 msgid "Invalid IP format. Use xxx.xxx.xxx.xxx:xxxx\n"

--- a/po/lv.po
+++ b/po/lv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 15:13+0200\n"
+"POT-Creation-Date: 2026-08-24 19:01+0200\n"
 "PO-Revision-Date: 2026-08-22 15:53+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -7616,6 +7616,10 @@ msgstr ""
 
 #: src/TextClient.cpp
 msgid "Execute <str> and exit."
+msgstr ""
+
+#: src/TextClient.cpp
+msgid "Separate list fields with spaces, as before, instead of tabs."
 msgstr ""
 
 #: src/TextClient.cpp

--- a/po/nl.po
+++ b/po/nl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 15:13+0200\n"
+"POT-Creation-Date: 2026-08-24 19:01+0200\n"
 "PO-Revision-Date: 2026-08-22 15:38+0000\n"
 "Last-Translator: Marcel Pol <marcel@timelord.nl>\n"
 "Language-Team: Dutch <nl@li.org>\n"
@@ -7702,6 +7702,10 @@ msgstr "Commando `%s' met pid `%d' is geëindigd met statuscode '%d'."
 #: src/TextClient.cpp
 msgid "Execute <str> and exit."
 msgstr "Voer <str> uit en sluit af."
+
+#: src/TextClient.cpp
+msgid "Separate list fields with spaces, as before, instead of tabs."
+msgstr ""
 
 #: src/TextClient.cpp
 msgid "Invalid IP format. Use xxx.xxx.xxx.xxx:xxxx\n"

--- a/po/nn.po
+++ b/po/nn.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 15:13+0200\n"
+"POT-Creation-Date: 2026-08-24 19:01+0200\n"
 "PO-Revision-Date: 2026-08-22 15:39+0000\n"
 "Last-Translator: Hallvor Brunstad <Hallvor_1976@yahoo.com>\n"
 "Language-Team: <i18n-nn@lister.ping.uio.no>\n"
@@ -7816,6 +7816,10 @@ msgstr "Kommandoen·`%s'·med·pid·`%d'·er ferdig med statuskode·`%d'."
 #: src/TextClient.cpp
 msgid "Execute <str> and exit."
 msgstr "Køyr <str> og avslutt."
+
+#: src/TextClient.cpp
+msgid "Separate list fields with spaces, as before, instead of tabs."
+msgstr ""
 
 #: src/TextClient.cpp
 msgid "Invalid IP format. Use xxx.xxx.xxx.xxx:xxxx\n"

--- a/po/pl.po
+++ b/po/pl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 15:13+0200\n"
+"POT-Creation-Date: 2026-08-24 19:01+0200\n"
 "PO-Revision-Date: 2026-08-22 15:39+0000\n"
 "Last-Translator: Michał Trzebiatowski <hippie_1968@hotmail.com>\n"
 "Language-Team: translationproject.org/team/pl.html <translation-team-pl@lists.sourceforge.net>\n"
@@ -7834,6 +7834,10 @@ msgstr "Komenda `%s' z pid `%d' zakończyła działanie ze statusem `%d'."
 #: src/TextClient.cpp
 msgid "Execute <str> and exit."
 msgstr "Wykonaj <str> i wyjdź."
+
+#: src/TextClient.cpp
+msgid "Separate list fields with spaces, as before, instead of tabs."
+msgstr ""
 
 #: src/TextClient.cpp
 msgid "Invalid IP format. Use xxx.xxx.xxx.xxx:xxxx\n"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 15:13+0200\n"
+"POT-Creation-Date: 2026-08-24 19:01+0200\n"
 "PO-Revision-Date: 2026-08-22 15:41+0000\n"
 "Last-Translator: Marcelo Jimenez <mroberto@users.sourceforge.com>\n"
 "Language-Team: Português (Brasileiro) <pt@li.org>\n"
@@ -7705,6 +7705,10 @@ msgstr "Comando '%s' com pid '%d' foi finalizado com o código de status '%d'."
 #: src/TextClient.cpp
 msgid "Execute <str> and exit."
 msgstr "Executar <str> e sair."
+
+#: src/TextClient.cpp
+msgid "Separate list fields with spaces, as before, instead of tabs."
+msgstr ""
 
 #: src/TextClient.cpp
 msgid "Invalid IP format. Use xxx.xxx.xxx.xxx:xxxx\n"

--- a/po/pt_PT.po
+++ b/po/pt_PT.po
@@ -17,7 +17,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 15:13+0200\n"
+"POT-Creation-Date: 2026-08-24 19:01+0200\n"
 "PO-Revision-Date: 2026-08-22 15:42+0000\n"
 "Last-Translator: Luís Picciochi Oliveira <Pitxyoki@Gmail.com>\n"
 "Language-Team: Portuguese <traduz@debianpt.org>\n"
@@ -7781,6 +7781,10 @@ msgstr "Comando '%s' com pid '%d' terminou com o código '%d'."
 #: src/TextClient.cpp
 msgid "Execute <str> and exit."
 msgstr "Executar <exp> e sair."
+
+#: src/TextClient.cpp
+msgid "Separate list fields with spaces, as before, instead of tabs."
+msgstr ""
 
 #: src/TextClient.cpp
 msgid "Invalid IP format. Use xxx.xxx.xxx.xxx:xxxx\n"

--- a/po/ro.po
+++ b/po/ro.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 15:13+0200\n"
+"POT-Creation-Date: 2026-08-24 19:01+0200\n"
 "PO-Revision-Date: 2026-08-22 15:42+0000\n"
 "Last-Translator: Angelescu Constantin <titus0818@yahoo.com>\n"
 "Language-Team: English <kde-i18n-doc@kde.org>\n"
@@ -7810,6 +7810,10 @@ msgstr "Comanda '%s' cu pid '%d' s-a finalizat cu cod stare '%d'."
 #: src/TextClient.cpp
 msgid "Execute <str> and exit."
 msgstr "Execută <str> și ieși."
+
+#: src/TextClient.cpp
+msgid "Separate list fields with spaces, as before, instead of tabs."
+msgstr ""
 
 #: src/TextClient.cpp
 msgid "Invalid IP format. Use xxx.xxx.xxx.xxx:xxxx\n"

--- a/po/ru.po
+++ b/po/ru.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 15:13+0200\n"
+"POT-Creation-Date: 2026-08-24 19:01+0200\n"
 "PO-Revision-Date: 2026-08-22 15:44+0000\n"
 "Last-Translator: Radist Morse <radist.morse@gmail.com>\n"
 "Language-Team: Russian <kde-russian@lists.kde.ru>\n"
@@ -7781,6 +7781,10 @@ msgstr "Команда «%s» с pid «%d» завершилась с кодом
 #: src/TextClient.cpp
 msgid "Execute <str> and exit."
 msgstr "Выполнить <str> и выйти."
+
+#: src/TextClient.cpp
+msgid "Separate list fields with spaces, as before, instead of tabs."
+msgstr ""
 
 #: src/TextClient.cpp
 msgid "Invalid IP format. Use xxx.xxx.xxx.xxx:xxxx\n"

--- a/po/sl.po
+++ b/po/sl.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 15:13+0200\n"
+"POT-Creation-Date: 2026-08-24 19:01+0200\n"
 "PO-Revision-Date: 2026-08-22 15:45+0000\n"
 "Last-Translator: Jure Repinc <jlp@holodeck1.com>\n"
 "Language-Team: Slovenian\n"
@@ -7867,6 +7867,10 @@ msgstr "Ukaz »%s« s PID-jem »%d« se je končal s statusno kodo »%d«."
 #: src/TextClient.cpp
 msgid "Execute <str> and exit."
 msgstr "Izvrši <str> in končaj."
+
+#: src/TextClient.cpp
+msgid "Separate list fields with spaces, as before, instead of tabs."
+msgstr ""
 
 #: src/TextClient.cpp
 msgid "Invalid IP format. Use xxx.xxx.xxx.xxx:xxxx\n"

--- a/po/sq.po
+++ b/po/sq.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 15:13+0200\n"
+"POT-Creation-Date: 2026-08-24 19:01+0200\n"
 "PO-Revision-Date: 2026-08-22 15:45+0000\n"
 "Last-Translator: Fation <dj_barthezz@linuxmail.org lushnja_corps@hotmail.Language-Team:\n"
 "Language: sq\n"
@@ -7806,6 +7806,10 @@ msgstr "Komanda `%s' me pid `%d' mbaroi me kodin e statusit `%d'."
 #: src/TextClient.cpp
 msgid "Execute <str> and exit."
 msgstr "Shtyp <str> dhe dil."
+
+#: src/TextClient.cpp
+msgid "Separate list fields with spaces, as before, instead of tabs."
+msgstr ""
 
 #: src/TextClient.cpp
 msgid "Invalid IP format. Use xxx.xxx.xxx.xxx:xxxx\n"

--- a/po/sv.po
+++ b/po/sv.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 15:13+0200\n"
+"POT-Creation-Date: 2026-08-24 19:01+0200\n"
 "PO-Revision-Date: 2026-08-22 15:46+0000\n"
 "Last-Translator: raffe <raffe@localhost.se>\n"
 "Language-Team: Swedish <tp-sv@listor.tp-sv.se>\n"
@@ -7767,6 +7767,10 @@ msgstr "Kommando '%s' med pid '%d' är klar med statuskoden '%d'."
 #: src/TextClient.cpp
 msgid "Execute <str> and exit."
 msgstr "Kör <str> och avsluta."
+
+#: src/TextClient.cpp
+msgid "Separate list fields with spaces, as before, instead of tabs."
+msgstr ""
 
 #: src/TextClient.cpp
 msgid "Invalid IP format. Use xxx.xxx.xxx.xxx:xxxx\n"

--- a/po/ta.po
+++ b/po/ta.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 15:13+0200\n"
+"POT-Creation-Date: 2026-08-24 19:01+0200\n"
 "PO-Revision-Date: 2026-08-22 15:54+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -7554,6 +7554,10 @@ msgstr "கட்டளை '%s' pid '%d' உடன் '%d' நிலைக் �
 
 #: src/TextClient.cpp
 msgid "Execute <str> and exit."
+msgstr ""
+
+#: src/TextClient.cpp
+msgid "Separate list fields with spaces, as before, instead of tabs."
 msgstr ""
 
 #: src/TextClient.cpp

--- a/po/tr.po
+++ b/po/tr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 15:13+0200\n"
+"POT-Creation-Date: 2026-08-24 19:01+0200\n"
 "PO-Revision-Date: 2026-08-22 15:48+0000\n"
 "Last-Translator: \n"
 "Language-Team: Turkish <li@li.org>\n"
@@ -7697,6 +7697,10 @@ msgstr "`%s' komutu, pid `%d' içermekteydi ve durum kodu `%d' ile sona erdi."
 #: src/TextClient.cpp
 msgid "Execute <str> and exit."
 msgstr "<str> çalıştır ve çık."
+
+#: src/TextClient.cpp
+msgid "Separate list fields with spaces, as before, instead of tabs."
+msgstr ""
 
 #: src/TextClient.cpp
 msgid "Invalid IP format. Use xxx.xxx.xxx.xxx:xxxx\n"

--- a/po/uk.po
+++ b/po/uk.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 15:13+0200\n"
+"POT-Creation-Date: 2026-08-24 19:01+0200\n"
 "PO-Revision-Date: 2026-08-22 15:48+0000\n"
 "Last-Translator: Oleksandr Kovalenko <alx.kovalenko@gmail.com>\n"
 "Language-Team: Ukrainian <translation@linux.org.ua>\n"
@@ -7863,6 +7863,10 @@ msgstr "Команда '%s' з pid '%d' завершилась з кодом с�
 #: src/TextClient.cpp
 msgid "Execute <str> and exit."
 msgstr "Виконати <str> та вийти."
+
+#: src/TextClient.cpp
+msgid "Separate list fields with spaces, as before, instead of tabs."
+msgstr ""
 
 #: src/TextClient.cpp
 msgid "Invalid IP format. Use xxx.xxx.xxx.xxx:xxxx\n"

--- a/po/vi.po
+++ b/po/vi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 15:13+0200\n"
+"POT-Creation-Date: 2026-08-24 19:01+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -7537,6 +7537,10 @@ msgstr ""
 
 #: src/TextClient.cpp
 msgid "Execute <str> and exit."
+msgstr ""
+
+#: src/TextClient.cpp
+msgid "Separate list fields with spaces, as before, instead of tabs."
 msgstr ""
 
 #: src/TextClient.cpp

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 15:13+0200\n"
+"POT-Creation-Date: 2026-08-24 19:01+0200\n"
 "PO-Revision-Date: 2026-08-22 15:50+0000\n"
 "Last-Translator: Mike Akiba <mike2718@gmail.com>\n"
 "Language-Team: Chinese Simplified <kde-i18n-doc@kde.org>\n"
@@ -7701,6 +7701,10 @@ msgstr "命令“%s”，pid “%d”已完成，状态代码为“%d”。"
 #: src/TextClient.cpp
 msgid "Execute <str> and exit."
 msgstr "执行 <str> 然后退出。"
+
+#: src/TextClient.cpp
+msgid "Separate list fields with spaces, as before, instead of tabs."
+msgstr ""
 
 #: src/TextClient.cpp
 msgid "Invalid IP format. Use xxx.xxx.xxx.xxx:xxxx\n"

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 15:13+0200\n"
+"POT-Creation-Date: 2026-08-24 19:01+0200\n"
 "PO-Revision-Date: 2026-08-22 15:51+0000\n"
 "Last-Translator: Wayne Su <mstarmstar@gmail.com>\n"
 "Language-Team: \n"
@@ -7733,6 +7733,10 @@ msgstr "指令「 %s 」(pid %d) 的傳回狀態值爲「%d」。 "
 #: src/TextClient.cpp
 msgid "Execute <str> and exit."
 msgstr "執行 <str> 後離開。"
+
+#: src/TextClient.cpp
+msgid "Separate list fields with spaces, as before, instead of tabs."
+msgstr ""
 
 #: src/TextClient.cpp
 msgid "Invalid IP format. Use xxx.xxx.xxx.xxx:xxxx\n"

--- a/src/TextClient.cpp
+++ b/src/TextClient.cpp
@@ -227,10 +227,14 @@ void CamulecmdApp::OnInitCmdLine(wxCmdLineParser &parser)
 		_("Execute <str> and exit."),
 		wxCMD_LINE_VAL_STRING,
 		wxCMD_LINE_PARAM_OPTIONAL);
+	parser.AddSwitch(wxEmptyString,
+		"space-separated",
+		_("Separate list fields with spaces, as before, instead of tabs."));
 }
 
 bool CamulecmdApp::OnCmdLineParsed(wxCmdLineParser &parser)
 {
+	m_spaceSeparated = parser.Found("space-separated");
 	m_HasCmdOnCmdLine = parser.Found("command", &m_CmdString);
 	if (m_CmdString.Lower().StartsWith("help")) {
 		OnInitCommandSet();
@@ -949,26 +953,36 @@ void CamulecmdApp::Process_Answer_v2(const CECPacket *response)
 			uint64 filesize, donesize;
 			filesize = tag->SizeFull();
 			donesize = tag->SizeDone();
-			s << tag->FileHashString() << " " << tag->FileName()
-			  << (CFormat("\n\t [%.1f%%] %4i/%4i ") %
-				     ((float)donesize / ((float)filesize) * 100.0) %
+			// Still two lines per entry: the newline delimits records and the
+			// leading tab marks the continuation, so splitting each line on
+			// the separator stays unambiguous.
+			s << tag->FileHashString() << Sep(" ") << tag->FileName()
+			  << (CFormat("\n\t [%.1f%%]") % ((float)donesize / ((float)filesize) * 100.0))
+			  << Sep(" ")
+			  << (CFormat("%4i/%4i") %
 				     ((int)tag->SourceCount() - (int)tag->SourceNotCurrCount()) %
 				     (int)tag->SourceCount())
+			  << Sep(" ")
+			  // The no-value branches were padding that stood in for the
+			  // value AND its separator, so in tab mode each becomes one
+			  // empty field -- every row keeps the same field count.
 			  << ((int)tag->SourceCountA4AF()
-					     ? wxString(CFormat("+%2.2i ") % (int)tag->SourceCountA4AF())
-					     : wxString("    "))
+					     ? wxString(CFormat("+%2.2i") % (int)tag->SourceCountA4AF()) +
+						       Sep(" ")
+					     : Sep("    "))
 			  << ((int)tag->SourceXferCount()
-					     ? wxString(CFormat("(%2.2i) - ") % (int)tag->SourceXferCount())
-					     : wxString("     - "))
+					     ? wxString(CFormat("(%2.2i)") % (int)tag->SourceXferCount()) +
+						       Sep(" - ")
+					     : Sep("     - "))
 			  << tag->GetFileStatusString();
-			s << " - " << tag->PartMetName();
+			s << Sep(" - ") << tag->PartMetName();
 			if (tag->DownPrio() < 10) {
-				s << " - " << PriorityToStr((int)tag->DownPrio(), 0);
+				s << Sep(" - ") << PriorityToStr((int)tag->DownPrio(), 0);
 			} else {
-				s << " - " << PriorityToStr((tag->DownPrio() - 10), 1);
+				s << Sep(" - ") << PriorityToStr((tag->DownPrio() - 10), 1);
 			}
 			if (tag->SourceXferCount() > 0) {
-				s << " - " + CastItoSpeed(tag->Speed());
+				s << Sep(" - ") + CastItoSpeed(tag->Speed());
 			}
 			s << "\n";
 		}
@@ -982,9 +996,9 @@ void CamulecmdApp::Process_Answer_v2(const CECPacket *response)
 			const CECTag *partfileSpeed = tag->GetTagByName(EC_TAG_CLIENT_UP_SPEED);
 			if (clientName && partfileName && partfileSizeXfer && partfileSpeed) {
 				s << "\n"
-				  << CFormat("%10u ") % tag->GetInt() << clientName->GetStringData() << " "
-				  << partfileName->GetStringData() << " "
-				  << CastItoXBytes(partfileSizeXfer->GetInt()) << " "
+				  << CFormat("%10u") % tag->GetInt() << Sep(" ")
+				  << clientName->GetStringData() << Sep(" ") << partfileName->GetStringData()
+				  << Sep(" ") << CastItoXBytes(partfileSizeXfer->GetInt()) << Sep(" ")
 				  << CastItoSpeed(partfileSpeed->GetInt());
 			}
 		}
@@ -1004,10 +1018,16 @@ void CamulecmdApp::Process_Answer_v2(const CECPacket *response)
 			const CECTag *country = tag.GetTagByName(EC_TAG_SERVER_COUNTRY);
 			if (serverName) {
 				wxString ip = tag.GetIPv4Data().StringIP();
-				ip.Append(' ', 24 - ip.Length());
-				s << ip << serverName->GetStringData();
+				if (m_spaceSeparated) {
+					// The column padding was the separator.
+					ip.Append(' ', 24 - ip.Length());
+					s << ip;
+				} else {
+					s << ip << "\t";
+				}
+				s << serverName->GetStringData();
 				if (country && !country->GetStringData().IsEmpty()) {
-					s << " [" << country->GetStringData() << "]";
+					s << Sep(" ") << "[" << country->GetStringData() << "]";
 				}
 				s << "\n";
 			}
@@ -1017,7 +1037,7 @@ void CamulecmdApp::Process_Answer_v2(const CECPacket *response)
 	case EC_OP_SHARED_FILES:
 		for (CECPacket::const_iterator it = response->begin(); it != response->end(); ++it) {
 			const CEC_SharedFile_Tag *tag = static_cast<const CEC_SharedFile_Tag *>(&*it);
-			s << tag->FileHashString() << " ";
+			s << tag->FileHashString() << Sep(" ");
 			wxString filePath = tag->FilePath();
 			bool ispartfile = true;
 			if (filePath.EndsWith(".part")) {
@@ -1031,7 +1051,7 @@ void CamulecmdApp::Process_Answer_v2(const CECPacket *response)
 				ispartfile = false;
 			}
 			if (ispartfile) {
-				s << _("[PartFile]") << " ";
+				s << _("[PartFile]") << Sep(" ");
 			} else {
 				s << filePath
 #ifdef __WINDOWS__
@@ -1041,13 +1061,14 @@ void CamulecmdApp::Process_Answer_v2(const CECPacket *response)
 #endif
 			}
 			s << tag->FileName() << "\n\t"
-			  << PriorityToStr(tag->UpPrio() % 10, tag->UpPrio() >= 10) << " - "
-			  << CFormat("%i(%i) / %i(%i) - %s (%s) - %.2f\n") % tag->GetRequests() %
-					tag->GetAllRequests() % tag->GetAccepts() % tag->GetAllAccepts() %
-					CastItoXBytes(tag->GetXferred()) %
-					CastItoXBytes(tag->GetAllXferred()) %
-					(static_cast<float>(tag->GetAllXferred()) /
-						static_cast<float>(tag->SizeFull()));
+			  << PriorityToStr(tag->UpPrio() % 10, tag->UpPrio() >= 10) << Sep(" - ")
+			  << CFormat("%i(%i)") % tag->GetRequests() % tag->GetAllRequests() << Sep(" / ")
+			  << CFormat("%i(%i)") % tag->GetAccepts() % tag->GetAllAccepts() << Sep(" - ")
+			  << CFormat("%s (%s)") % CastItoXBytes(tag->GetXferred()) %
+					CastItoXBytes(tag->GetAllXferred())
+			  << Sep(" - ")
+			  << CFormat("%.2f\n") % (static_cast<float>(tag->GetAllXferred()) /
+							 static_cast<float>(tag->SizeFull()));
 		}
 		break;
 

--- a/src/TextClient.h
+++ b/src/TextClient.h
@@ -72,6 +72,28 @@ private:
 	void ShowResults(CResultMap results_map);
 	bool m_HasCmdOnCmdLine;
 	wxString m_CmdString;
+
+	/**
+	 * Print list fields separated by spaces, as before, instead of tabs.
+	 *
+	 * The rows carry client names and file names, both of which routinely
+	 * contain spaces, so a space-separated row cannot be split back into its
+	 * fields by anything reading it (discussion #161). Tabs are the default;
+	 * this restores the previous output byte for byte for scripts written
+	 * against it.
+	 */
+	bool m_spaceSeparated;
+
+	/**
+	 * The separator to print where @a legacy used to be printed.
+	 *
+	 * ONLY separators go through here. Column padding stays as it is, values
+	 * that merely contain punctuation (`12/34` source counts, `5(7)` request
+	 * counts) stay one field, and translated values (file status, priority)
+	 * are still translated -- a parser wanting stable text still wants
+	 * LC_ALL=C, or the REST API.
+	 */
+	wxString Sep(const wxString &legacy) const { return m_spaceSeparated ? legacy : wxString(wxT("\t")); }
 	virtual int OnRun();
 
 	int m_last_cmd_id;


### PR DESCRIPTION
Addresses #161.

`show ul` prints `<id> <client name> <file name> <size> <speed>` space-separated, and both name fields routinely contain spaces — so a row cannot be split back into its fields by anything reading it. The other list commands have the same problem.

Tab becomes the field separator. `--space-separated` restores the previous output for scripts written against it.

## Before / after

Tabs shown as `→`.

**`show shared`**
```
before   177E9D3B… /shared/A file name with spaces.mkv
         →Auto [Hi] - 0(0) / 0(0) - 0 bytes (0 bytes) - 0.00
after    177E9D3B…→/shared/A file name with spaces.mkv
         →Auto [Hi]→0(0)→0(0)→0 bytes (0 bytes)→0.00
```

**`show dl`**
```
before   A1B2C3D4… A movie with spaces.mkv
         → [0.0%]    0/   0          - Waiting - 001.part.met - Auto [Hi]
after    A1B2C3D4…→A movie with spaces.mkv
         → [0.0%]→   0/   0→→→Waiting→001.part.met→Auto [Hi]
```

**`show servers`**
```
before   [85.17.116.222:6082]    ed2k-rust [nl]
after    [85.17.116.222:6082]→ed2k-rust→[nl]
```

`show ul` is not shown: reproducing it needs a peer actively uploading from us, which I could not stage. Its renderer is the simplest of the four — five values joined by single spaces — and it is covered by the compatibility check below.

## Scope

**Only separators change.** Column padding stays (`%4i/%4i` still renders `   0/   0`), values containing punctuation stay one field (`0(0)`, `12/34`), and the shared-files path stays one value rather than splitting into directory and name.

**`show dl` keeps its two-line record.** The newline still delimits records and the continuation line still begins with a tab, so splitting each line on the separator remains unambiguous. Where a row previously padded a missing A4AF or transferring-source count with spaces, tab mode emits an **empty field**, so every row has the same field count — that is the `→→→` above.

**Not touched:** `ShowResults`, which lays search hits out in fixed-width columns and truncates long names. That is a different problem from separators.

**Not solved:** the values are still translated — file status, priority, `[PartFile]` — so a script reading them still depends on the daemon's locale. Use `LC_ALL=C`, or the REST API, which is the surface built for machine consumption (`GET /api/v0/clients?filter=uploads` is the direct equivalent of `show ul`).

## Testing

Against a live daemon sharing files with spaces in their names, `--space-separated` output is **byte-identical to master** for `show shared`, `show servers`, `show dl` and `show ul` — checked with the two binaries distinguished by capability (`--help`) and the master output asserted non-empty first, since an empty-vs-empty diff proves nothing.

clang-format and clang-tidy Tier-2 clean. Catalogs regenerated for the new `--space-separated` help string (app + manpages), and the flag documented in `amulecmd.1.in`.
