### PR TITLE
fix(amulecmd): keep a tab or newline inside a name from breaking the row

### DIFF
--- a/src/TextClient.cpp
+++ b/src/TextClient.cpp
@@ -227,9 +227,10 @@ void CamulecmdApp::OnInitCmdLine(wxCmdLineParser &parser)
 		_("Execute <str> and exit."),
 		wxCMD_LINE_VAL_STRING,
 		wxCMD_LINE_PARAM_OPTIONAL);
-	parser.AddSwitch(wxEmptyString,
+	parser.AddSwitch("",
 		"space-separated",
-		_("Separate list fields with spaces, as before, instead of tabs."));
+		_("Separate list fields with spaces, as before, instead of tabs."),
+		wxCMD_LINE_PARAM_OPTIONAL);
 }
 
 bool CamulecmdApp::OnCmdLineParsed(wxCmdLineParser &parser)
@@ -956,7 +957,7 @@ void CamulecmdApp::Process_Answer_v2(const CECPacket *response)
 			// Still two lines per entry: the newline delimits records and the
 			// leading tab marks the continuation, so splitting each line on
 			// the separator stays unambiguous.
-			s << tag->FileHashString() << Sep(" ") << tag->FileName()
+			s << tag->FileHashString() << Sep(" ") << Field(tag->FileName())
 			  << (CFormat("\n\t [%.1f%%]") % ((float)donesize / ((float)filesize) * 100.0))
 			  << Sep(" ")
 			  << (CFormat("%4i/%4i") %
@@ -997,8 +998,9 @@ void CamulecmdApp::Process_Answer_v2(const CECPacket *response)
 			if (clientName && partfileName && partfileSizeXfer && partfileSpeed) {
 				s << "\n"
 				  << CFormat("%10u") % tag->GetInt() << Sep(" ")
-				  << clientName->GetStringData() << Sep(" ") << partfileName->GetStringData()
-				  << Sep(" ") << CastItoXBytes(partfileSizeXfer->GetInt()) << Sep(" ")
+				  << Field(clientName->GetStringData()) << Sep(" ")
+				  << Field(partfileName->GetStringData()) << Sep(" ")
+				  << CastItoXBytes(partfileSizeXfer->GetInt()) << Sep(" ")
 				  << CastItoSpeed(partfileSpeed->GetInt());
 			}
 		}
@@ -1025,7 +1027,7 @@ void CamulecmdApp::Process_Answer_v2(const CECPacket *response)
 				} else {
 					s << ip << "\t";
 				}
-				s << serverName->GetStringData();
+				s << Field(serverName->GetStringData());
 				if (country && !country->GetStringData().IsEmpty()) {
 					s << Sep(" ") << "[" << country->GetStringData() << "]";
 				}
@@ -1053,14 +1055,14 @@ void CamulecmdApp::Process_Answer_v2(const CECPacket *response)
 			if (ispartfile) {
 				s << _("[PartFile]") << Sep(" ");
 			} else {
-				s << filePath
+				s << Field(filePath)
 #ifdef __WINDOWS__
 				  << '\\';
 #else
 				  << '/';
 #endif
 			}
-			s << tag->FileName() << "\n\t"
+			s << Field(tag->FileName()) << "\n\t"
 			  << PriorityToStr(tag->UpPrio() % 10, tag->UpPrio() >= 10) << Sep(" - ")
 			  << CFormat("%i(%i)") % tag->GetRequests() % tag->GetAllRequests() << Sep(" / ")
 			  << CFormat("%i(%i)") % tag->GetAccepts() % tag->GetAllAccepts() << Sep(" - ")

--- a/src/TextClient.h
+++ b/src/TextClient.h
@@ -82,7 +82,7 @@ private:
 	 * this restores the previous output byte for byte for scripts written
 	 * against it.
 	 */
-	bool m_spaceSeparated;
+	bool m_spaceSeparated = false;
 
 	/**
 	 * The separator to print where @a legacy used to be printed.
@@ -93,7 +93,45 @@ private:
 	 * are still translated -- a parser wanting stable text still wants
 	 * LC_ALL=C, or the REST API.
 	 */
-	wxString Sep(const wxString &legacy) const { return m_spaceSeparated ? legacy : wxString(wxT("\t")); }
+	wxString Sep(const wxString &legacy) const { return m_spaceSeparated ? legacy : wxString("\t"); }
+
+	/**
+	 * A value on its way into a field, with the active separator taken out of it.
+	 *
+	 * File names, client names and server names reach here from the network or
+	 * from the filesystem, and nothing along the way strips control characters
+	 * from them. A name carrying the separator splits into two fields and puts
+	 * every later field of that row in the wrong column -- which is precisely
+	 * the bug tabs were introduced to fix, since names routinely contain
+	 * spaces. A tab inside a name is the same bug, only rarer, so it must not
+	 * survive into a tab-separated row.
+	 *
+	 * Space-separated mode keeps the tab: that mode exists to reproduce the
+	 * older output byte for byte, and a name containing a space is the
+	 * ambiguity it is opting back into.
+	 *
+	 * A newline is not a separator question and is replaced in BOTH modes. It
+	 * does not blur a field boundary, it fabricates a whole record out of one
+	 * -- every list command ends its rows with a newline, and `show dl` and
+	 * `show ul` additionally rely on it to structure a record. A row split
+	 * across two lines was never parseable in either mode, so nothing that
+	 * worked before can be depending on it. CRLF collapses to a single space
+	 * rather than two.
+	 *
+	 * Only separators are replaced. A value is never truncated, escaped or
+	 * otherwise reworded -- a reader still sees the name the daemon reported.
+	 */
+	wxString Field(const wxString &value) const
+	{
+		wxString out(value);
+		out.Replace("\r\n", " ");
+		out.Replace("\n", " ");
+		out.Replace("\r", " ");
+		if (!m_spaceSeparated) {
+			out.Replace("\t", " ");
+		}
+		return out;
+	}
 	virtual int OnRun();
 
 	int m_last_cmd_id;


### PR DESCRIPTION
Follow-up to #1132, from review.

Tabs became the field separator because names routinely contain spaces, so a space-separated row could not be split back into its fields. That argument applies to tabs too. File names, client names and server names arrive from the network or from the filesystem — a download takes its name from the peer — and nothing along the way strips control characters, so a name carrying a tab splits into two fields and puts every later field of that row in the wrong column. The same bug the change fixed, only rarer, and harder to notice for being rare.

Values that reach a field from outside now go through `Field()`: the file name and path in `show shared`, the file name in `show dl`, the client and file names in `show ul`, and the server name in `show servers`. Only separators are replaced — nothing is truncated, escaped or reworded, so a reader still sees the name the daemon reported.

**The tab** is replaced only when tabs are the separator. `--space-separated` returns it untouched: that mode exists to reproduce the older output byte for byte, and a name containing a space is precisely the ambiguity it opts back into.

**The newline** is replaced in *both* modes, because it is not a separator question. It does not blur a field boundary, it fabricates a whole record out of one — every list command ends its rows with a newline, and `show dl` and `show ul` rely on it to structure a record besides. A row split across two lines was never parseable in either mode, so nothing that worked before can be depending on it. CRLF collapses to a single space rather than two.

**Also from the same review:**

- `m_spaceSeparated` had no initialiser and no constructor to give it one, while `Sep()` reads it. `OnCmdLineParsed` does run first in practice, so this was not reachable, but the read is now defined regardless of ordering.
- The new code reintroduced `wxEmptyString` and `wxT()`, both retired tree-wide in `0edf09e20`. The adjacent switch in the base class already uses the current form (`parser.AddSwitch("", "help", …)`), and `wxT()` is only needed for high-byte narrow literals, which `"\t"` is not.
- The switch now passes `wxCMD_LINE_PARAM_OPTIONAL` like every switch beside it.

## Testing

A live daemon sharing four files — named with a tab, a newline, both, and neither:

```
tab mode      918D7099…<TAB>/srv/media/tab here.bin           fields=2
              D4096778…<TAB>/srv/media/newline here.bin       fields=2
              BA091B7D…<TAB>/srv/media/both and here.bin      fields=2
              D79552D1…<TAB>/srv/media/plain name.bin         fields=2

space mode    918D7099… /srv/media/tab<TAB>here.bin
              D4096778… /srv/media/newline here.bin
```

Every row carries the same field count in tab mode. With `--space-separated` the tab survives — which is what confirms the names genuinely carry one rather than the test proving nothing — while the newline is still replaced. Both modes emit exactly four rows, so no record is fabricated.

43/43 unit tests, clang-format and clang-tidy Tier-2 clean. No string changes, so no catalog churn.
