### PR TITLE
test(amuleapi): make the memo's race guards fail a test when deleted

### DIFF
--- a/src/webapi/Api.cpp
+++ b/src/webapi/Api.cpp
@@ -752,7 +752,6 @@ CHttpServer::Response CApiDispatcher::Dispatch(const CHttpServer::Request &req)
 	const std::uint64_t rev_before = m_state.SnapshotRevision();
 	CHttpServer::Response resp = DispatchToHandler(req);
 	const std::uint64_t rev_after = m_state.SnapshotRevision();
-	const bool rev_stable = (rev_before == rev_after);
 
 	const bool is_safe_method = (req.method == "GET" || req.method == "HEAD");
 	// A handler that computed its own validator owns it. Stamping the
@@ -761,7 +760,7 @@ CHttpServer::Response CApiDispatcher::Dispatch(const CHttpServer::Request &req)
 	// static path did, since it clears the body for HEAD and so only the
 	// GET reached the hashing branch below.
 	const bool handler_set_etag = (resp.headers.find("ETag") != resp.headers.end());
-	if (is_safe_method && !handler_set_etag && resp.status == 200 && !resp.body.empty()) {
+	if (webapi::ShouldStampEtag(is_safe_method, handler_set_etag, resp.status, resp.body.empty())) {
 		// Skip the MD5 over a (potentially multi-MB) body when
 		// nothing has changed since we last hashed it. The key is
 		// (target, snapshot revision): the revision is advanced by
@@ -775,11 +774,11 @@ CHttpServer::Response CApiDispatcher::Dispatch(const CHttpServer::Request &req)
 		// is worth anything. Everything else hashes per request and is
 		// immune to a mispaired validator by construction.
 		//
-		// `rev_stable` is the other half. Without it the key says
-		// which revision was current when we looked, not which one
-		// this body came from.
+		// Revision stability is the other half, and MemoUsable carries
+		// it: without it the key says which revision was current when
+		// we looked, not which one this body came from.
 		const std::uint64_t snap = rev_after;
-		const bool memoizable = webapi::MemoizableTarget(req.target) && rev_stable;
+		const bool memoizable = webapi::MemoUsable(req.target, rev_before, rev_after);
 		std::string etag;
 		if (memoizable) {
 			std::lock_guard<std::mutex> g(m_etagCacheMu);

--- a/src/webapi/State.cpp
+++ b/src/webapi/State.cpp
@@ -519,6 +519,19 @@ bool MemoizableTarget(const std::string &target)
 	return path == "/api/v0/downloads" || path == "/api/v0/shared";
 }
 
+// See State.h. Ordered cheap-test-first: the revision comparison is two
+// integer loads, the target match copies and scans a string.
+bool MemoUsable(const std::string &target, std::uint64_t rev_before, std::uint64_t rev_after)
+{
+	return rev_before == rev_after && MemoizableTarget(target);
+}
+
+// See State.h.
+bool ShouldStampEtag(bool is_safe_method, bool handler_set_etag, unsigned status, bool body_empty)
+{
+	return is_safe_method && !handler_set_etag && status == 200 && !body_empty;
+}
+
 std::string ChatPeerKeyFromGuiId(std::uint64_t gui_id)
 {
 	const std::uint32_t ip = static_cast<std::uint32_t>(gui_id >> 16);

--- a/src/webapi/State.h
+++ b/src/webapi/State.h
@@ -601,6 +601,30 @@ std::string IPv4ToDotted(std::uint32_t ip_lsb_first);
 // cost of overlooking a route is a wasted hash rather than a stale 304.
 bool MemoizableTarget(const std::string &target);
 
+// Whether a response may be read from, or written to, the ETag memo. Two
+// independent conditions, both required:
+//
+//  1. MemoizableTarget(target) -- the opt-in eligibility above.
+//  2. The snapshot revision did not move while the handler ran. The body is
+//     serialized inside the handler under its own read lock, dropped before
+//     the caller can sample again; if a write lands in that window the body
+//     belongs to `rev_before` while the key would claim `rev_after`, and every
+//     later hit serves a validator describing neither.
+//
+// Condition 2 guards a race, so nothing in a sequential test notices when it
+// is removed. It lives here, as a decision separate from the dispatch that
+// makes it, so that removing it fails a test instead of nothing.
+bool MemoUsable(const std::string &target, std::uint64_t rev_before, std::uint64_t rev_after);
+
+// Whether the dispatcher should hash the body and stamp its own ETag.
+//
+// `handler_set_etag` is the half worth spelling out: a handler that computed
+// its own validator owns it, and stamping the body hash over the top hands out
+// two different ETags for one resource depending on which branch answered.
+// That is exactly what the static path did before -- it clears the body for
+// HEAD, so only the GET reached the hashing branch.
+bool ShouldStampEtag(bool is_safe_method, bool handler_set_etag, unsigned status, bool body_empty);
+
 // The same key built straight from a GUI_ID, for paths that only have the id
 // (a session that was closed is gone from the snapshot, so there is no
 // ChatSessionSnapshot left to ask). GUI_ID is (ip << 16) | port.

--- a/unittests/tests/StateTest.cpp
+++ b/unittests/tests/StateTest.cpp
@@ -1103,6 +1103,61 @@ TEST(State, ConcurrentReadersDontTearSnapshot)
 
 // The two collections the memo exists for: the multi-MB bodies where skipping
 // an MD5 is worth anything.
+// --- MemoUsable / ShouldStampEtag -----------------------------------
+//
+// Both guard something a sequential test cannot observe: MemoUsable's second
+// condition guards a write landing while a handler serializes, and
+// ShouldStampEtag's `handler_set_etag` guards the dispatcher stamping over a
+// validator a handler already owns. Deleting either used to leave the whole
+// suite green, which is the same as having no guard at all -- these tests
+// exist to go red when that happens.
+
+// The revision moving across the handler is what disqualifies the response:
+// the body belongs to rev_before while the key would claim rev_after.
+TEST(State, MemoUsableRejectsAMovedRevision)
+{
+	ASSERT_TRUE(MemoUsable("/api/v0/downloads", 7, 7));
+	ASSERT_TRUE(!MemoUsable("/api/v0/downloads", 7, 8));
+	// Direction does not matter -- any inequality means the body cannot be
+	// attributed to a revision.
+	ASSERT_TRUE(!MemoUsable("/api/v0/downloads", 8, 7));
+	ASSERT_TRUE(MemoUsable("/api/v0/shared?limit=10", 3, 3));
+	ASSERT_TRUE(!MemoUsable("/api/v0/shared?limit=10", 3, 4));
+}
+
+// Both conditions are required, so an ineligible target stays ineligible even
+// with a perfectly stable revision, and vice versa.
+TEST(State, MemoUsableNeedsBothConditions)
+{
+	ASSERT_TRUE(!MemoUsable("/api/v0/auth/session", 5, 5));
+	ASSERT_TRUE(!MemoUsable("/api/v0/status", 5, 5));
+	ASSERT_TRUE(!MemoUsable("/api/v0/auth/session", 5, 6));
+	// Revision 0 is the pre-first-tick value; eligibility does not depend
+	// on the number, only on it holding still. The caller separately
+	// refuses to serve a memo entry stamped 0.
+	ASSERT_TRUE(MemoUsable("/api/v0/downloads", 0, 0));
+}
+
+// A handler that computed its own ETag owns it. Stamping over the top is what
+// gave the static path two validators for one resource, since it clears the
+// body for HEAD and only the GET reached the hashing branch.
+TEST(State, ShouldStampEtagLeavesAHandlerValidatorAlone)
+{
+	ASSERT_TRUE(ShouldStampEtag(true, false, 200, false));
+	ASSERT_TRUE(!ShouldStampEtag(true, true, 200, false));
+}
+
+// The other three terms: unsafe methods carry post-mutation state the client
+// always wants delivered, non-200s are not worth a validator, and an empty
+// body has nothing to hash.
+TEST(State, ShouldStampEtagOnlyForSafe200sWithABody)
+{
+	ASSERT_TRUE(!ShouldStampEtag(false, false, 200, false));
+	ASSERT_TRUE(!ShouldStampEtag(true, false, 404, false));
+	ASSERT_TRUE(!ShouldStampEtag(true, false, 304, true));
+	ASSERT_TRUE(!ShouldStampEtag(true, false, 200, true));
+}
+
 TEST(State, MemoizableTargetCoversTheTwoBigCollections)
 {
 	ASSERT_TRUE(MemoizableTarget("/api/v0/downloads"));


### PR DESCRIPTION
Addresses item 3 of #1134 — the issue stays open for items 2a and 2b.

Two guards in `Dispatch` had no test that noticed their removal. Deleting `&& rev_stable` left the whole suite green, and so did dropping the `handler_set_etag` term. Both guard something a sequential test cannot observe, so the tests only ever exercised the paths where they do not matter — and an untested guard on a race is indistinguishable from no guard.

Both are decisions rather than mechanics, so they move out of `Dispatch` and next to `MemoizableTarget` as `MemoUsable()` and `ShouldStampEtag()`, in a file cctest already compiles. `Dispatch` now asks the question instead of spelling out the answer.

**What this does not cover.** The decision is tested, its placement is not. Nothing here proves the revision samples still bracket `DispatchToHandler`. That needs a write landed mid-serialization, and `CApiDispatcher` takes a `CamuleapiApp`, so it cannot be constructed in a unit test without putting a test hook in production code. The curl suite's conditional-GET assertions remain the only cover for placement.

## Verification

Each guard was deleted in turn to confirm a test goes red:

| Mutation | Fails |
|---|---|
| drop the revision comparison from `MemoUsable` | `MemoUsableRejectsAMovedRevision` |
| drop `!handler_set_etag` from `ShouldStampEtag` | `ShouldStampEtagLeavesAHandlerValidatorAlone` |

Both are cctest, so CI catches them rather than a live daemon.

`ctest` 43/43. clang-format clean, Tier-2 clang-tidy clean on the diff with 0 compiler errors.

The curl suite was run against an isolated daemon and compared against an identical run of unmodified `master` on the same daemon: 48 assertion failures on this branch, 49 on `master`, no failure unique to this branch. The shared failures are all phases needing a connected daemon with servers, shares and downloads. `40-http-conformance.sh` is 72/72 on both, including every validator and cache-policy assertion — which is the coverage that matters here, since it exercises the memo path `MemoUsable` now decides.
