### PR TITLE
fix(core): destroy the shared-dir watcher outside the event dispatch loop

### DIFF
--- a/src/SharedDirWatcher.cpp
+++ b/src/SharedDirWatcher.cpp
@@ -104,7 +104,28 @@ CSharedDirWatcher::CSharedDirWatcher(CSharedFileList *parent)
 
 CSharedDirWatcher::~CSharedDirWatcher()
 {
-	Disable();
+	StopTimers();
+	// Synchronous here, unlike Disable(): a CallAfter queued on a handler that
+	// is being destroyed is purged along with it, so a deferred delete would
+	// simply never run -- leaking the watcher along with its inotify fd and
+	// the event loop source wx registered for it.
+	//
+	// This can run from inside a dispatch, so it is not a dispatch-free spot:
+	// the macOS daemon build calls OnExit() straight out of OnCoreTimer
+	// (amule.cpp:1955). It is safe there for reasons that do not generalise --
+	// macOS watches through FSEvents/CFRunLoop rather than a wxFDIOHandler, so
+	// there is no epoll source to dangle, and the call is followed by
+	// _exit(0). Treat it as that exception rather than as a guarantee.
+	//
+	// Detach before the delete, for the reason spelled out in Disable():
+	// ~wxFileSystemWatcherBase runs RemoveAll(), which can emit a synchronous
+	// wxFSW_EVENT_WARNING -- here that would run OnFileSystemEvent() against
+	// the object under destruction.
+	if (m_watcher) {
+		m_watcher->SetOwner(nullptr);
+	}
+	delete m_watcher;
+	ReapPendingWatchers();
 }
 
 void CSharedDirWatcher::Enable()
@@ -156,7 +177,7 @@ void CSharedDirWatcher::Enable()
 	AddDebugLogLineN(logKnownFiles, "Shared-dir watcher enabled");
 }
 
-void CSharedDirWatcher::Disable()
+void CSharedDirWatcher::StopTimers()
 {
 	if (m_debounceTimer.IsRunning()) {
 		m_debounceTimer.Stop();
@@ -166,11 +187,57 @@ void CSharedDirWatcher::Disable()
 		m_macPumpTimer.Stop();
 	}
 #endif
+}
+
+void CSharedDirWatcher::ReapPendingWatchers()
+{
+	// Walk a local copy: ~wxFileSystemWatcher can re-enter this object through
+	// wx (see Disable()), and a Disable() reached from there would push_back
+	// into the vector being iterated.
+	std::vector<wxFileSystemWatcher *> doomed;
+	doomed.swap(m_pendingDelete);
+	for (wxFileSystemWatcher *w : doomed) {
+		delete w;
+	}
+}
+
+void CSharedDirWatcher::Disable()
+{
+	StopTimers();
 	if (!m_watcher) {
 		return;
 	}
-	delete m_watcher;
+	// Detach now, destroy from the pending-event queue. ~wxFileSystemWatcher
+	// frees the wxFDIOEventLoopSourceHandler wx registered for its inotify fd
+	// (fswatcher_inotify.cpp: Init() adds the source, Close() deletes it), and
+	// wxEpollDispatcher::Dispatch walks a stack snapshot of the ready events
+	// without re-checking a handler -- so freeing one from inside that loop
+	// leaves it calling OnReadWaiting() on freed memory the moment the same
+	// batch reaches this fd.
+	//
+	// No caller reaches here from inside that loop today: Disable() comes from
+	// the destructor, from the prefs dialog, from the guarded call in
+	// CamuleApp::OnInit, and from CEC_Prefs_Packet::Apply(), which the EC layer
+	// reaches through a queued wx event -- the pending-event phase that
+	// wxEventLoopManual::ProcessEvents drains *before* calling Dispatch. But
+	// fs-watcher events themselves are delivered from inside the loop
+	// (fswatcher_inotify.cpp SendEvent() does a synchronous ProcessEvent from
+	// the inotify source's OnReadWaiting), so one caller reached from
+	// OnFileSystemEvent would make this fatal. Deferring costs nothing and
+	// removes the question.
+	//
+	// Drop the owner as part of the detach: a detached watcher outlives the
+	// call, and SetOwner(nullptr) points its owner back at itself, where
+	// nothing is bound. Without that, everything it still emits before the
+	// reap lands on us -- the deltas the backend had already queued, and the
+	// wxFSW_EVENT_WARNING wxFSWatcherImplUnix::DoRemove() sends synchronously
+	// from RemoveAll() when inotify_rm_watch loses the race wx documents. That
+	// warning reads as a backend drop, so OnFileSystemEvent() would clear
+	// m_pendingEvents and force a full RequestReload() re-walk for nothing.
+	m_watcher->SetOwner(nullptr);
+	m_pendingDelete.push_back(m_watcher);
 	m_watcher = NULL;
+	CallAfter(&CSharedDirWatcher::ReapPendingWatchers);
 	AddDebugLogLineN(logKnownFiles, "Shared-dir watcher disabled");
 }
 
@@ -285,6 +352,18 @@ void CSharedDirWatcher::RegisterAllPaths()
 
 void CSharedDirWatcher::OnFileSystemEvent(wxFileSystemWatcherEvent &event)
 {
+	// Nothing to act on with no live watcher. Disable() drops the doomed
+	// watcher's owner, so nothing it emits afterwards gets here; what this
+	// catches is an event a backend had *queued* to us before that, which the
+	// MSW one does (wxFSWatcherImplMSW::SendEvent wxQueueEvent()s from its
+	// worker thread). Acting on it would re-arm the debounce timer
+	// StopTimers() just stopped, and a directory CREATE would reach
+	// RegisterNewSubdirectory and persist a shareddir_list change --
+	// SaveSharedFolders() and all -- after the user turned auto-rescan off.
+	if (!m_watcher) {
+		return;
+	}
+
 	const int changeType = event.GetChangeType();
 	const wxFileName &path = event.GetPath();
 

--- a/src/SharedDirWatcher.h
+++ b/src/SharedDirWatcher.h
@@ -57,8 +57,9 @@ public:
 	// already enabled — no-op in that case.
 	void Enable();
 
-	// Stop watching and free the watcher object. Safe to call when
-	// already disabled.
+	// Stop watching. The watcher object itself is freed from the event
+	// queue rather than here -- see Disable(). Safe to call when already
+	// disabled.
 	void Disable();
 
 	bool IsEnabled() const { return m_watcher != NULL; }
@@ -151,8 +152,26 @@ private:
 	// are not still gets fully covered in one pass.
 	void WalkForUnknownSubdirs(const CPath &root, std::set<wxString> &known, std::vector<CPath> &out);
 
+	// Destroy the watchers Disable() detached. Queued with CallAfter() so
+	// the delete lands between dispatches; also called by the destructor
+	// for whatever the queue never reached.
+	void ReapPendingWatchers();
+
+	// Stop the debounce (and, on macOS, the run-loop pump) timer. Shared
+	// by Disable() and the destructor.
+	void StopTimers();
+
 	CSharedFileList *m_parent;
 	wxFileSystemWatcher *m_watcher;
+	//! Watchers detached by Disable() and not yet destroyed. ~wxFileSystemWatcher
+	//! frees the wxFDIOEventLoopSourceHandler wx registered for its inotify fd,
+	//! and wxEpollDispatcher::Dispatch walks a snapshot of the ready events
+	//! without re-checking any handler -- so freeing one from inside an event
+	//! handler makes that loop call a virtual on freed memory as soon as the
+	//! same batch reaches the watcher's fd. Destruction is therefore deferred
+	//! to the pending-event queue, which the event loop drains before it
+	//! dispatches, and the destructor sweeps whatever the queue never reached.
+	std::vector<wxFileSystemWatcher *> m_pendingDelete;
 	wxTimer m_debounceTimer;
 
 	// Per-path accumulator. Keyed on the raw filesystem path. Events


### PR DESCRIPTION
CSharedDirWatcher::Disable() deleted its wxFileSystemWatcher inline.
~wxFileSystemWatcher tears down the wxEventLoopSource wx created for the
inotify fd (fswatcher_inotify.cpp: Init() calls AddSourceForFD, Close()
does wxDELETE(m_source)), which frees the wxFDIOEventLoopSourceHandler
registered in the event loop's FD dispatcher.

wxEpollDispatcher::Dispatch (wxWidgets 3.2.11,
src/unix/epolldispatcher.cpp:205-245) walks a stack snapshot of the ready
events and never re-checks an entry; abridged:

    epoll_event events[16];
    const int rc = DoPoll(events, WXSIZEOF(events), timeout);
    for ( epoll_event *p = events; p < events + rc; p++ )
    {
        wxFDIOHandler * const handler = (wxFDIOHandler *)(p->data.ptr);
        ...
        handler->OnReadWaiting();        // line 233

UnregisterFD() removes the fd from the kernel's epoll set but cannot
scrub a pointer already copied into that array. So freeing a handler
while servicing an earlier event in the same batch leaves the loop
calling a virtual method on freed memory. wx's own wxSelectDispatcher
does not have this problem -- ProcessSets() resolves each ready fd
through FindHandler(fd) instead of trusting a cached pointer -- so the
epoll dispatcher is the outlier.

This is hardening, not a fix for an observed crash. No current caller
reaches Disable() from inside a dispatch: it is reached from the
destructor, from PrefsUnifiedDlg, from the guarded call in
amule.cpp:1167, and from CEC_Prefs_Packet::Apply(), which the EC layer
reaches through a queued wx event -- the pending-event phase that
wxEventLoopManual::ProcessEvents() drains *before* calling Dispatch().
The hazard is real rather than theoretical because fs-watcher events
themselves are delivered from inside the batch loop:
fswatcher_inotify.cpp:541 does ProcessEvent(), synchronously from the
inotify source's OnReadWaiting(). So a future caller reached from
OnFileSystemEvent, or any Disable() from an FD handler, would be fatal.

Fixed by detaching the watcher and destroying it from the pending-event
queue (evtloopcmn.cpp:225-234), so the free happens with no epoll batch
in flight. The destructor sweeps anything the queue never reached and
still deletes synchronously: a CallAfter queued on a handler that is
being destroyed is purged with it, which would leave the watcher alive
with its fd registered and its owner gone.

Detaching means dropping the owner, not just clearing the pointer: a
detached watcher outlives the call, and SetOwner(NULL) points its owner
back at itself, where nothing is bound. Without that, everything it
still emits before the reap lands on us -- the deltas the backend had
already queued, and the wxFSW_EVENT_WARNING
wxFSWatcherImplUnix::DoRemove() sends synchronously from RemoveAll()
when inotify_rm_watch loses the race wx documents (a watched directory
deleted just before the remove). That warning reads as a backend drop,
so OnFileSystemEvent() would clear m_pendingEvents, log "events dropped
by backend" and force a full RequestReload() re-walk for nothing. That
one is pre-existing -- master fires it on every Disable() that hits the
race -- and dropping the owner is what closes it.

The destructor's detach is then the same single line, and it needs it
for the same reason: that RemoveAll() warning would otherwise run
OnFileSystemEvent() against the object under destruction.
m_pendingEvents is deliberately left alone on disable: those deltas
describe changes that really happened on disk, and Enable() re-walks
with ColdDiscoverSubdirs() anyway, so "disable" does not have to mean
"forget".

OnFileSystemEvent() also returns early when there is no live watcher.
With the owner dropped at detach time nothing from a doomed watcher
gets that far; the guard covers an event a backend had queued to us
before it -- the MSW one does exactly that, wxFSWatcherImplMSW::
SendEvent() wxQueueEvent()s from its worker thread. Such an event must
not re-arm the debounce timer Disable()
just stopped or reach RegisterNewSubdirectory, where a directory CREATE
mutates shareddir_list and calls SaveSharedFolders() -- persisting a
config change after the user turned auto-rescan off.

The reap walks a local copy of the pending list: delete can re-enter
this object through wx, and a Disable() reached from there would
push_back into the vector being iterated.

Verified with a standalone wxWidgets program (no aMule) that keeps two
wxFileSystemWatchers on one busy directory and destroys one from the
other's event handler, so both inotify fds land in the same epoll batch:

    destroying inline    6 of 8 runs segfaulted within 45 s
    destroying deferred  0 of 4 runs segfaulted within 180 s

The inline mode faults in wxEpollDispatcher::Dispatch at
epolldispatcher.cpp:233, with the handler pointer taken from the event
array and a garbage vtable pointer read through it.

Relation to #1136: same wx defect, different instance, and this does
NOT fix that crash -- do not close it with this. Shared: the dispatcher
trusting its snapshot, the same object type
(wxFDIOEventLoopSourceHandler, created by AddSourceForFD), the same
fault site, and the same reproducer shape as the one in that report.
Different: there the source is destroyed inside wxWidgets itself, by the
libcurl-backed wxWebRequest tearing down a transfer's source from a curl
callback that runs *within* Dispatch, with no aMule frame on the stack,
2 or more times per daemon startup -- nothing on this code path is
involved, and no aMule-side change fixes it. Here the destroying code is
ours, so we can move it out of the dispatch; but as noted above no
caller currently reaches it from there. The underlying wx defect belongs
upstream in wxWidgets either way.