### PR TITLE
build(release): publish the amuleapi frontend as a release artifact

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -36,7 +36,8 @@ on:
           Comma-separated list of platform tracks to run.
           Default empty = run all. Useful during iteration to focus
           on the failing tracks without paying for the green ones.
-          Valid: appimage, flatpak, macos, windows, linux-static.
+          Valid: appimage, flatpak, macos, windows, linux-static,
+          frontend.
         required: false
         type: string
         default: ''
@@ -126,6 +127,62 @@ jobs:
   # runtime shared-library deps, for containers / minimal / musl hosts.
   # See packaging/docker/Dockerfile.static-daemon.
   # ------------------------------------------------------------------
+  # ------------------------------------------------------------------
+  # amuleapi web frontend — platform-independent, so one job, no matrix
+  # ------------------------------------------------------------------
+  frontend:
+    name: amuleapi frontend
+    if: >-
+      github.event_name != 'workflow_dispatch' ||
+      inputs.only == '' ||
+      contains(inputs.only, 'frontend')
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0  # git describe for the version string
+
+      - name: Pack the frontend
+        run: |
+          set -euo pipefail
+          VERSION=$(git describe --tags --always --dirty 2>/dev/null || echo snapshot)
+          STEM="aMule-${VERSION#v}-amuleapi-frontend"
+          mkdir -p "dist/${STEM}"
+          # Copy the tree verbatim. The daemon ships no assets of its own,
+          # so a static-binary operator needs this whole directory to point
+          # StaticRoot at -- shell, stylesheet, every module including the
+          # vendored ones and their LICENSEs, the i18n dictionaries, the
+          # favicon and the logo.
+          cp -R src/webapi/static/. "dist/${STEM}/"
+          # The zip must be the tracked tree, not a subset someone has to
+          # remember to extend. Compare counts against git rather than
+          # spot-checking filenames: a new view, dictionary or image is then
+          # covered the day it lands instead of the day someone updates a
+          # list here.
+          tracked=$(git ls-files src/webapi/static | wc -l | tr -d ' ')
+          packed=$(find "dist/${STEM}" -type f | wc -l | tr -d ' ')
+          if [ "$packed" -ne "$tracked" ]; then
+            echo "::error::frontend bundle has ${packed} files, git tracks ${tracked}"
+            exit 1
+          fi
+          # An entry point that cannot load is worse than a missing asset,
+          # because it fails in the browser rather than here.
+          for required in index.html css/app.css js/app.js; do
+            if [ ! -s "dist/${STEM}/${required}" ]; then
+              echo "::error::frontend bundle is missing ${required}"
+              exit 1
+            fi
+          done
+          echo "frontend bundle: ${packed} files"
+          (cd dist && zip -qr "${STEM}.zip" "${STEM}")
+          rm -rf "dist/${STEM}"
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: amuleapi-frontend
+          path: dist/aMule-*-amuleapi-frontend.zip
+          if-no-files-found: error
+
   linux-static:
     name: Linux static (${{ matrix.arch }})
     if: >-

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -183,6 +183,46 @@ jobs:
           name: source-bundle
           path: dist/aMule-*-src.tar.gz
 
+      - name: Create amuleapi frontend bundle
+        run: |
+          set -euo pipefail
+          TAG="${{ steps.tag.outputs.tag }}"
+          STEM="aMule-${TAG#v}-amuleapi-frontend"
+          mkdir -p "dist/${STEM}"
+          # Copy the tree verbatim. The daemon ships no assets of its own,
+          # so a static-binary operator needs this whole directory to point
+          # StaticRoot at -- shell, stylesheet, every module including the
+          # vendored ones and their LICENSEs, the i18n dictionaries, the
+          # favicon and the logo.
+          cp -R src/webapi/static/. "dist/${STEM}/"
+          # The zip must be the tracked tree, not a subset someone has to
+          # remember to extend. Compare counts against git rather than
+          # spot-checking filenames: a new view, dictionary or image is then
+          # covered the day it lands.
+          tracked=$(git ls-files src/webapi/static | wc -l | tr -d ' ')
+          packed=$(find "dist/${STEM}" -type f | wc -l | tr -d ' ')
+          if [ "$packed" -ne "$tracked" ]; then
+            echo "::error::frontend bundle has ${packed} files, git tracks ${tracked}"
+            exit 1
+          fi
+          # An entry point that cannot load is worse than a missing asset,
+          # because it fails in the browser rather than here.
+          for required in index.html css/app.css js/app.js; do
+            if [ ! -s "dist/${STEM}/${required}" ]; then
+              echo "::error::frontend bundle is missing ${required}"
+              exit 1
+            fi
+          done
+          echo "frontend bundle: ${packed} files"
+          (cd dist && zip -qr "${STEM}.zip" "${STEM}")
+          rm -rf "dist/${STEM}"
+
+      - name: Upload amuleapi frontend bundle
+        uses: actions/upload-artifact@v7
+        with:
+          name: amuleapi-frontend
+          path: dist/aMule-*-amuleapi-frontend.zip
+
   release:
     name: Assemble draft Release
     needs: [build, source-bundle]
@@ -229,6 +269,11 @@ jobs:
         with:
           name: source-bundle
           path: dist/
+      - name: Download amuleapi frontend bundle
+        uses: actions/download-artifact@v8
+        with:
+          name: amuleapi-frontend
+          path: dist/
 
       - name: List artifacts
         run: ls -la dist/
@@ -262,11 +307,12 @@ jobs:
           check "Windows installer .exe (x64 + arm64)" 2 'aMule-*-Windows-Setup-*.exe'
           check "Linux static daemon (x86_64 + aarch64)" 2 'aMule-*-Linux-*-static.tar.gz'
           check "Source bundle"                     1 'aMule-*-src.tar.gz'
+          check "amuleapi frontend bundle"          1 'aMule-*-amuleapi-frontend.zip'
           if [ "$fail" -ne 0 ]; then
             echo "::error::Artifact manifest incomplete — refusing to assemble the draft Release."
             exit 1
           fi
-          echo "All 12 expected release artifacts present."
+          echo "All 13 expected release artifacts present."
 
       - name: Create draft Release
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -183,46 +183,6 @@ jobs:
           name: source-bundle
           path: dist/aMule-*-src.tar.gz
 
-      - name: Create amuleapi frontend bundle
-        run: |
-          set -euo pipefail
-          TAG="${{ steps.tag.outputs.tag }}"
-          STEM="aMule-${TAG#v}-amuleapi-frontend"
-          mkdir -p "dist/${STEM}"
-          # Copy the tree verbatim. The daemon ships no assets of its own,
-          # so a static-binary operator needs this whole directory to point
-          # StaticRoot at -- shell, stylesheet, every module including the
-          # vendored ones and their LICENSEs, the i18n dictionaries, the
-          # favicon and the logo.
-          cp -R src/webapi/static/. "dist/${STEM}/"
-          # The zip must be the tracked tree, not a subset someone has to
-          # remember to extend. Compare counts against git rather than
-          # spot-checking filenames: a new view, dictionary or image is then
-          # covered the day it lands.
-          tracked=$(git ls-files src/webapi/static | wc -l | tr -d ' ')
-          packed=$(find "dist/${STEM}" -type f | wc -l | tr -d ' ')
-          if [ "$packed" -ne "$tracked" ]; then
-            echo "::error::frontend bundle has ${packed} files, git tracks ${tracked}"
-            exit 1
-          fi
-          # An entry point that cannot load is worse than a missing asset,
-          # because it fails in the browser rather than here.
-          for required in index.html css/app.css js/app.js; do
-            if [ ! -s "dist/${STEM}/${required}" ]; then
-              echo "::error::frontend bundle is missing ${required}"
-              exit 1
-            fi
-          done
-          echo "frontend bundle: ${packed} files"
-          (cd dist && zip -qr "${STEM}.zip" "${STEM}")
-          rm -rf "dist/${STEM}"
-
-      - name: Upload amuleapi frontend bundle
-        uses: actions/upload-artifact@v7
-        with:
-          name: amuleapi-frontend
-          path: dist/aMule-*-amuleapi-frontend.zip
-
   release:
     name: Assemble draft Release
     needs: [build, source-bundle]

--- a/docs/QUICKSTART-AMULEAPI.md
+++ b/docs/QUICKSTART-AMULEAPI.md
@@ -207,6 +207,21 @@ EventBusRingCapacity=16384
 `--bind`, `--http-port`, `--host`, `--port` and `--config-dir` override the
 matching settings for one run.
 
+## Web frontend
+
+amuleapi serves a web frontend at `/` when it can find one. Leave `StaticRoot` empty and it looks for the `amuleapi-static` folder that a normal install puts on disk, so a package install needs no configuration — open `http://127.0.0.1:4713/` and it is there. If nothing is found, `/` answers 404 and the REST API still works; an API-only deployment needs no frontend.
+
+The static Linux daemon is the exception: it is a single binary and carries no files of its own, so there is nothing for it to find. Download `aMule-<version>-amuleapi-frontend.zip` from the release page, unzip it somewhere readable, and point `StaticRoot` at the unzipped folder:
+
+```ini
+[Server]
+StaticRoot=/opt/amule/aMule-3.1.0-amuleapi-frontend
+```
+
+The same zip works if you want to serve the frontend from a location of your own, or to keep a modified copy separate from the installed one.
+
+Unzip it as a unit and leave the layout alone. The page loads its stylesheet, its modules, the translations and the images by relative path, so moving or renaming anything inside the folder breaks it.
+
 ## CORS
 
 Off by default, so only pages served from the same origin can call the API.


### PR DESCRIPTION
Addresses item 2a of #1134 — the issue stays open for 2b.

The static Linux daemon is one binary and carries no assets, so an operator who downloads it has to go find the frontend in a source tarball and place it by hand. Nothing on the release page contains it.

This ships `src/webapi/static` as `aMule-<version>-amuleapi-frontend.zip`, packed in `packaging.yml` alongside every other artifact — release.yml only assembles what packaging produces, and it already invokes packaging as a reusable workflow. It is the same tree a package install puts on disk, packaged so it can be downloaded and pointed at with `StaticRoot`. No bundling and no toolchain — the served bytes are unchanged, so the existing static tests still cover exactly what ships. The manifest gate that guards the draft Release counts it too, so a run that loses the bundle refuses to assemble rather than publishing 12 of 13 assets. Because packaging fires on pushes to master under a path filter that already covers `src/**`, the packing step and its guards run whenever the frontend changes rather than a release being the first thing that executes them.

The packing step counts what it packed against `git ls-files` rather than checking for a list of filenames. A new view, dictionary or image is covered the day it lands instead of the day someone remembers to extend a list, and the vendored modules' `LICENSE` files cannot be dropped silently. It additionally refuses to publish a bundle whose shell, stylesheet or entry module is missing or empty — that failure would otherwise surface in a browser rather than in CI.

`QUICKSTART-AMULEAPI.md` gains a section for it. Worth stating there that an empty `StaticRoot` already resolves the installed `amuleapi-static` directory, so a package install needs no configuration at all; the zip is for the static daemon, and for serving a copy from somewhere else.

## Verification

Dispatched on the fork against this branch (`only=frontend`, so one job rather than the matrix) and the produced artifact was checked rather than assumed:

- 38 files in the zip, 38 tracked by `git ls-files` — and the log shows `frontend bundle: 38 files`, so the count guard executed rather than being skipped.
- `diff -r` between the unzipped bundle and `src/webapi/static` is empty: nothing altered or dropped in the round trip.
- `index.html`, `css/app.css`, `js/app.js`, `img/favicon.ico`, `img/logo.png`, both i18n dictionaries and the vendored `preact`/`htm` LICENSEs all present.
- Named `aMule-3.0.1-706-gb67550876-amuleapi-frontend.zip` on a non-tag build — the `git describe` form, which becomes `aMule-3.1.0-amuleapi-frontend.zip` on a tag.

Locally: deleting one file from the staged copy makes the count guard fail, as intended. Both workflows parse, and the embedded shell is `bash -n` clean.
