### PR TITLE
fix(amuleapi): route /x/ and /x the same way, and reject empty captures

### DIFF
--- a/docs/api/REFERENCE.md
+++ b/docs/api/REFERENCE.md
@@ -325,6 +325,10 @@ If `amuleapi.conf[Server]/AllowCORS=1`:
 
 The dispatcher rejects paths containing NUL, encoded NUL (`%00`), encoded `..` (any case of `%2e%2e`), or a literal `..` segment with `400 bad_request` before routing. Defence-in-depth against a future endpoint that admits path captures.
 
+**Trailing slash.** Under `/api/`, one trailing `/` is stripped before routing, so `/api/v0/status/` and `/api/v0/status` are the same request. Exactly one is stripped — `//` is a malformed path rather than a synonym, so `/api/v0/downloads//` does not reach `/api/v0/downloads`. The rule stops at the API prefix: a static asset path is a filesystem path, where a trailing slash means a directory.
+
+**Empty path captures.** A segment standing in for a `{capture}` cannot be empty. Every capture names a resource — a hash, an ECID, an index, an address — so a path that binds one to the empty string matches no route and is `404 not_found`, rather than reaching a handler and being rejected there with whatever status that endpoint happens to use.
+
 ### Request size limits
 
 - HTTP header section: hard cap 16 KiB. Exceeding it is `431 headers_too_large`.

--- a/src/libwebcommon/PathPatterns.cpp
+++ b/src/libwebcommon/PathPatterns.cpp
@@ -103,6 +103,15 @@ bool LooksMalicious(const std::string &path)
 	return false;
 }
 
+// See PathPatterns.h.
+std::string StripTrailingSlash(const std::string &path)
+{
+	if (path.size() > 1 && path.back() == '/') {
+		return path.substr(0, path.size() - 1);
+	}
+	return path;
+}
+
 namespace
 {
 int HexNibble(char c)
@@ -195,6 +204,10 @@ bool Match(const RoutePattern &pattern,
 	std::map<std::string, std::string> caps;
 	for (size_t i = 0; i < pattern.segments.size(); ++i) {
 		if (!pattern.capture_names[i].empty()) {
+			// See the header: an empty capture names no resource.
+			if (path_segments[i].empty()) {
+				return false;
+			}
 			caps[pattern.capture_names[i]] = path_segments[i];
 		} else if (pattern.segments[i] != path_segments[i]) {
 			return false;

--- a/src/libwebcommon/PathPatterns.h
+++ b/src/libwebcommon/PathPatterns.h
@@ -49,6 +49,19 @@ std::vector<std::string> SplitPath(const std::string &path);
 // protection.
 bool LooksMalicious(const std::string &path);
 
+// Strips one trailing '/' so `/x/` routes exactly as `/x` does.
+//
+// Without it the two spellings disagree in a way that depends on which
+// kind of route they land on: a literal route is compared with `==` and
+// simply misses, while a capture route matches with the capture bound to
+// the empty string and the handler is left to reject a URL that names no
+// resource -- picking its own status code as it does so.
+//
+// Never strips the root, and never strips more than one: `//` is a
+// malformed path rather than a synonym, and collapsing it would let
+// `/a//b` reach the route for `/a/b`.
+std::string StripTrailingSlash(const std::string &path);
+
 // Parses ?k=v&k2=v2 into a map. Percent-decodes `%hh` pairs and
 // converts `+` to space per application/x-www-form-urlencoded.
 // Malformed `%hh` triplets pass through verbatim so a stray `%` in
@@ -70,6 +83,12 @@ RoutePattern ParsePattern(const std::string &pattern);
 
 // Matches `path_segments` against `pattern`. On match, fills
 // `out_captures` with the captured segment values and returns true.
+//
+// An empty capture is not a match. Every capture on the surface names a
+// resource -- a hash, an ecid, an index, an address -- and none of them
+// can be the empty string, so a path that binds one is malformed rather
+// than merely absent. Rejecting it here keeps that judgement in one place
+// instead of leaving each handler to invent a status code for it.
 bool Match(const RoutePattern &pattern,
 	const std::vector<std::string> &path_segments,
 	std::map<std::string, std::string> &out_captures);

--- a/src/webapi/Api.cpp
+++ b/src/webapi/Api.cpp
@@ -898,6 +898,14 @@ CHttpServer::Response CApiDispatcher::DispatchToHandler(const CHttpServer::Reque
 		return ErrorResponse(400, "bad_request", "path contains a traversal/injection token");
 	}
 
+	// `/api/v0/status/` and `/api/v0/status` name the same resource, so
+	// route them the same way. Confined to the API prefix on purpose: the
+	// static fallthrough below maps a path onto a filesystem, where a
+	// trailing slash is a directory rather than a spelling.
+	if (path.compare(0, 5, "/api/") == 0) {
+		path = web_api_path::StripTrailingSlash(path);
+	}
+
 	if (path == "/api/v0/version") {
 		if (req.method != "GET" && req.method != "HEAD") {
 			return MethodNotAllowed("GET, HEAD", "method not allowed on /api/v0/version");
@@ -5318,6 +5326,21 @@ bool ParseEcidPath(const std::string &s, std::uint32_t &out)
 	return true;
 }
 
+// Path-capture counterpart to RequireSnapshot above, used the same way:
+// ` if (auto r = RequireEcidPath(caps["ecid"], ecid)) return *r;`.
+//
+// Nine handlers had spelled out the same parse-and-reject, and the status,
+// the code and the sentence are part of the API contract rather than local
+// wording -- a tenth route inheriting a different one is how a surface stops
+// being predictable.
+std::unique_ptr<CHttpServer::Response> RequireEcidPath(const std::string &s, std::uint32_t &out)
+{
+	if (!ParseEcidPath(s, out)) {
+		return BadRequestPtr("path `{ecid}` must be a non-negative integer");
+	}
+	return nullptr;
+}
+
 // Look up a server in the State cache by ECID. Returns false if
 // no match — the handler then 404s.
 bool FindServerByEcid(const webapi::CState &state, std::uint32_t ecid, webapi::ServerSnapshot &out)
@@ -5584,9 +5607,8 @@ CHttpServer::Response CApiDispatcher::HandleClientDetail(
 		return a.rejection;
 
 	std::uint32_t ecid = 0;
-	if (!ParseEcidPath(ecid_str, ecid)) {
-		return ErrorResponse(400, "bad_request", "path `{ecid}` must be a non-negative integer");
-	}
+	if (auto r = RequireEcidPath(ecid_str, ecid))
+		return *r;
 	if (auto r = RequireSnapshot(m_state))
 		return *r;
 	webapi::ClientSnapshot cli;
@@ -5830,9 +5852,8 @@ CHttpServer::Response CApiDispatcher::HandleFriendMessageSend(
 			503, "ec_unsupported", "the connected amuled does not serve chat sessions");
 	}
 	std::uint32_t ecid = 0;
-	if (!ParseEcidPath(ecid_str, ecid)) {
-		return ErrorResponse(400, "bad_request", "path `{ecid}` must be a non-negative integer");
-	}
+	if (auto r = RequireEcidPath(ecid_str, ecid))
+		return *r;
 	return SendChatMessageTo(req, CECTag(EC_TAG_FRIEND, ecid));
 }
 
@@ -5849,9 +5870,8 @@ CHttpServer::Response CApiDispatcher::HandleClientMessageSend(
 			503, "ec_unsupported", "the connected amuled does not serve chat sessions");
 	}
 	std::uint32_t ecid = 0;
-	if (!ParseEcidPath(ecid_str, ecid)) {
-		return ErrorResponse(400, "bad_request", "path `{ecid}` must be a non-negative integer");
-	}
+	if (auto r = RequireEcidPath(ecid_str, ecid))
+		return *r;
 	return SendChatMessageTo(req, CECTag(EC_TAG_CLIENT, ecid));
 }
 
@@ -6094,9 +6114,8 @@ CHttpServer::Response CApiDispatcher::HandleFriendRemove(
 		return *r;
 
 	std::uint32_t ecid = 0;
-	if (!ParseEcidPath(ecid_str, ecid)) {
-		return ErrorResponse(400, "bad_request", "path `{ecid}` must be a non-negative integer");
-	}
+	if (auto r = RequireEcidPath(ecid_str, ecid))
+		return *r;
 	webapi::FriendSnapshot existing;
 	if (!FindFriendByEcid(m_state, ecid, existing)) {
 		return ErrorResponse(404, "not_found", "no friend with that ecid");
@@ -6147,9 +6166,8 @@ CHttpServer::Response CApiDispatcher::HandleFriendPatch(
 		return *r;
 
 	std::uint32_t ecid = 0;
-	if (!ParseEcidPath(ecid_str, ecid)) {
-		return ErrorResponse(400, "bad_request", "path `{ecid}` must be a non-negative integer");
-	}
+	if (auto r = RequireEcidPath(ecid_str, ecid))
+		return *r;
 	webapi::FriendSnapshot existing;
 	if (!FindFriendByEcid(m_state, ecid, existing)) {
 		return ErrorResponse(404, "not_found", "no friend with that ecid");
@@ -6287,9 +6305,8 @@ CHttpServer::Response CApiDispatcher::HandleServerConnect(
 		return *rej;
 
 	std::uint32_t ecid = 0;
-	if (!ParseEcidPath(ecid_str, ecid)) {
-		return ErrorResponse(400, "bad_request", "path `{ecid}` must be a non-negative integer");
-	}
+	if (auto r = RequireEcidPath(ecid_str, ecid))
+		return *r;
 	if (auto r = RequireSnapshot(m_state))
 		return *r;
 	webapi::ServerSnapshot srv;
@@ -6343,9 +6360,8 @@ CHttpServer::Response CApiDispatcher::HandleServerDelete(
 		return *rej;
 
 	std::uint32_t ecid = 0;
-	if (!ParseEcidPath(ecid_str, ecid)) {
-		return ErrorResponse(400, "bad_request", "path `{ecid}` must be a non-negative integer");
-	}
+	if (auto r = RequireEcidPath(ecid_str, ecid))
+		return *r;
 	if (auto r = RequireSnapshot(m_state))
 		return *r;
 	webapi::ServerSnapshot srv;
@@ -6540,9 +6556,8 @@ CHttpServer::Response CApiDispatcher::HandleServerPatch(
 		return *rej;
 
 	std::uint32_t ecid = 0;
-	if (!ParseEcidPath(ecid_str, ecid)) {
-		return ErrorResponse(400, "bad_request", "path `{ecid}` must be a non-negative integer");
-	}
+	if (auto r = RequireEcidPath(ecid_str, ecid))
+		return *r;
 
 	picojson::value root;
 	std::string parse_err;
@@ -9956,9 +9971,8 @@ CHttpServer::Response CApiDispatcher::HandleBrowse(
 		return *rej;
 
 	std::uint32_t ecid = 0;
-	if (!ParseEcidPath(ecid_str, ecid)) {
-		return ErrorResponse(400, "bad_request", "path `{ecid}` must be a non-negative integer");
-	}
+	if (auto r = RequireEcidPath(ecid_str, ecid))
+		return *r;
 
 	// Ask amuled to browse this peer's shared file list. In multi-search mode
 	// (amuleapi always is) the daemon allocates a browse search_id, echoes it in

--- a/src/webapi/App.cpp
+++ b/src/webapi/App.cpp
@@ -30,7 +30,8 @@
 #include "Refresher.h"
 
 #include "MD4Hash.h"
-#include "config.h" // VERSION
+#include "PathPatterns.h" // StripTrailingSlash
+#include "config.h"       // VERSION
 
 #include <ec/cpp/RemoteConnect.h> // SetEcConnectionLostHandler
 #include <wx/filename.h>          // wxFileName::FileExists
@@ -523,11 +524,13 @@ void CamuleapiApp::TextShell(const wxString & /*prompt*/)
 	auto streaming_resolver = [](const CHttpServer::Request &req) {
 		if (req.method != "GET" && req.method != "HEAD")
 			return false;
-		// Tolerate optional ?query / trailing slashes.
+		// Tolerate optional ?query / trailing slash. Both are handled
+		// the same way the dispatcher handles them, so a request that
+		// streams here is exactly the set that would route there.
 		const std::string &t = req.target;
 		const std::size_t q = t.find('?');
-		std::string path = (q == std::string::npos) ? t : t.substr(0, q);
-		return path == "/api/v0/events";
+		const std::string path = (q == std::string::npos) ? t : t.substr(0, q);
+		return web_api_path::StripTrailingSlash(path) == "/api/v0/events";
 	};
 	auto streaming_handler = [dispatcher](const CHttpServer::Request &req,
 					 CHttpServer::Writer &writer,

--- a/unittests/curl-tests/amuleapi/40-http-conformance.sh
+++ b/unittests/curl-tests/amuleapi/40-http-conformance.sh
@@ -178,6 +178,30 @@ fi
 _assert_eq "401" "$(curl -s -o /dev/null -w '%{http_code}' --max-time 5 "$HOST/api/v0/events")" \
 	"GET /events without credentials -> 401"
 
+# ---------------------------------------------------------------------------
+# Trailing slash: `/x/` names the same resource as `/x`
+# ---------------------------------------------------------------------------
+# The two spellings used to disagree by route kind, not by meaning. A literal
+# route is compared with `==` so `/status/` simply missed and answered "no such
+# endpoint"; a capture route matched with the capture bound to the empty string,
+# so `/clients/` reached the handler and was rejected there -- as a 400, for a
+# URL that names no resource, while an empty `{hash}` was a 404 for an equally
+# meaningless one.
+#
+# These assert the wiring, which the unit tests for StripTrailingSlash and the
+# empty-capture guard cannot: that the dispatcher actually applies the rule.
+for p in status version downloads clients shared servers friends; do
+	bare=$(curl -s -o /dev/null -w '%{http_code}' --max-time 10 "${AUTH[@]}" "$HOST/api/v0/$p")
+	slash=$(curl -s -o /dev/null -w '%{http_code}' --max-time 10 "${AUTH[@]}" "$HOST/api/v0/$p/")
+	_assert_eq "$bare" "$slash" "/$p and /$p/ answer alike ($bare)"
+done
+
+# The static fallthrough is deliberately not normalised -- there a trailing
+# slash is a directory rather than a spelling -- so the rule must not have
+# leaked outside the API prefix.
+_assert_eq "200" "$(curl -s -o /dev/null -w '%{http_code}' --max-time 10 "$HOST/")" \
+	"the static root still answers 200"
+
 # /events reaches the dispatcher only on a method the streaming resolver
 # declined, and with no route there it used to fall through to the catch-all
 # 404 -- reporting that the endpoint does not exist, on the one resource a

--- a/unittests/tests/PathPatternsTest.cpp
+++ b/unittests/tests/PathPatternsTest.cpp
@@ -275,3 +275,61 @@ TEST(PathPatterns, ShapeEqual_DifferentLengths)
 	RoutePattern b = ParsePattern("/a/b/c");
 	ASSERT_FALSE(ShapeEqual(a, b));
 }
+
+// ----------------------------------------------------------------------
+// StripTrailingSlash
+// ----------------------------------------------------------------------
+
+// `/x/` and `/x` name the same resource. Without this the two spellings
+// disagree by route kind: a literal route misses outright, a capture route
+// matches with an empty capture.
+TEST(PathPatterns, StripTrailingSlash_RemovesOne)
+{
+	ASSERT_EQUALS(std::string("/api/v0/status"), StripTrailingSlash("/api/v0/status/"));
+	ASSERT_EQUALS(std::string("/api/v0/clients"), StripTrailingSlash("/api/v0/clients/"));
+}
+
+// Already-bare paths are returned unchanged, and the root is not a spelling
+// of the empty string.
+TEST(PathPatterns, StripTrailingSlash_LeavesBareAndRootAlone)
+{
+	ASSERT_EQUALS(std::string("/api/v0/status"), StripTrailingSlash("/api/v0/status"));
+	ASSERT_EQUALS(std::string("/"), StripTrailingSlash("/"));
+	ASSERT_EQUALS(std::string(""), StripTrailingSlash(""));
+}
+
+// Only one. `//` is a malformed path rather than a synonym -- collapsing it
+// would let `/a//b` reach the route for `/a/b`.
+TEST(PathPatterns, StripTrailingSlash_StripsOnlyOne)
+{
+	ASSERT_EQUALS(std::string("/a/"), StripTrailingSlash("/a//"));
+}
+
+// ----------------------------------------------------------------------
+// Match: empty captures
+// ----------------------------------------------------------------------
+
+// Every capture on the surface names a resource -- a hash, an ecid, an
+// index, an address -- and none of them can be the empty string. Binding
+// one used to hand the handler a URL that names nothing and leave it to
+// pick a status code, which is why an empty {ecid} was a 400 while an empty
+// {hash} was a 404.
+TEST(PathPatterns, Match_RejectsAnEmptyCapture)
+{
+	const auto pat = ParsePattern("/api/v0/clients/{ecid}");
+	std::map<std::string, std::string> caps;
+	ASSERT_TRUE(!Match(pat, SplitPath("/api/v0/clients/"), caps));
+	// The non-empty case still matches, so the guard is not just refusing
+	// everything.
+	ASSERT_TRUE(Match(pat, SplitPath("/api/v0/clients/42"), caps));
+	ASSERT_EQUALS(std::string("42"), caps["ecid"]);
+}
+
+// A literal segment that happens to be empty is a different question and was
+// already handled: the comparison simply fails.
+TEST(PathPatterns, Match_StillRejectsAMissegmentedLiteral)
+{
+	const auto pat = ParsePattern("/api/v0/shared/reload");
+	std::map<std::string, std::string> caps;
+	ASSERT_TRUE(!Match(pat, SplitPath("/api/v0/shared/"), caps));
+}


### PR DESCRIPTION
Addresses §3 and the remainder of §1 from #1107 — the issue stays open for the rest.

Two spellings of one resource disagreed, and which way they disagreed depended on the kind of route they landed on. A literal route is compared with `==`, so `/api/v0/status/` simply missed and answered "no such endpoint". A capture route matched with the capture bound to the empty string, so `/api/v0/clients/` reached the handler and was rejected there — as a `400`, for a URL that names no resource, while an empty `{hash}` was a `404` for an equally meaningless one.

Strip one trailing slash before routing, and stop `Match` binding a capture to the empty string. Both live in `libwebcommon` so the streaming resolver in `App.cpp` applies the same rule the dispatcher does: `/events/` now streams instead of 404ing, and the resolver's comment about tolerating a trailing slash stops being half true.

Exactly one slash, and only under `/api/`. `//` is a malformed path rather than a synonym, and the static fallthrough maps a path onto a filesystem, where a trailing slash means a directory rather than a spelling.

**The dedup this unlocks.** With empty captures gone from the router, the nine handlers that each spelled out the same parse-and-reject for `{ecid}` fold into `RequireEcidPath`, following `RequireSnapshot`'s idiom — whose own comment records that thirty handlers had previously spelled out its four lines by hand.

§1's main claim is already fixed on master; what remained was the resolver half.

## Behaviour change

`/api/v0/shared/` and `/api/v0/clients/` previously errored (`404` and `400`) and now return the collection. `/api/v0/downloads//` still errors, but as a plain `404` rather than whatever the handler chose. `REFERENCE.md` documents both rules under `### Path validation`.

## Verification

Each guard deleted in turn: making `StripTrailingSlash` an identity fails `StripTrailingSlash_RemovesOne`; restoring empty captures fails `Match_RejectsAnEmptyCapture`. Both cctest, so CI catches them rather than a live daemon.

The curl assertions cover what the unit tests cannot — that the dispatcher applies the rule — and were checked the same way. Running the full suite against an isolated daemon, then again with only the sources reverted and the new assertions kept: **48 assertion failures on this branch, 56 on `master`, and no failure unique to this branch.** The delta is the seven `answer alike` assertions plus the known-flaky `address alias connect`. The shared failures are the phases that need a connected daemon with servers, shares and downloads.

`ctest` 43/43. clang-format clean, Tier-2 clang-tidy clean on the diff with 0 compiler errors.
