### PR TITLE
fix(amuleapi): one rule for query parameters, and one meaning for `limit`

### DIFF
--- a/docs/api/REFERENCE.md
+++ b/docs/api/REFERENCE.md
@@ -206,14 +206,24 @@ Header: `{"alg":"HS256","typ":"JWT"}`. Payload: `{"role":"admin"|"guest","iat":<
 
 Each endpoint documents its own response shape under the endpoint section. List endpoints wrap their array under the resource plural name (`{"downloads": [...]}`, `{"shared": [...]}`) so clients can extend the envelope with sibling metadata without breaking JSON-parser pipelines.
 
+### Query parameter validation
+
+One rule, everywhere: **a query parameter the server does not understand is a `400 bad_request`, never a silent default.** That covers both halves of "does not understand": a value that will not parse, and a value outside the parameter's documented range.
+
+- Booleans (`include_completed`, `include_parts`) accept `1`/`0`, `true`/`false` and `yes`/`no`. Anything else is a `400`.
+- Counts (`limit`, `offset`, `tail`, `width`, `interval`, `max_client_versions`, `since_id`) accept decimal digits within the range documented for that parameter. A non-numeric value, a negative one, or one outside the range is a `400` naming the bound.
+- An omitted parameter takes the documented default. Only omission does that; an empty value (`?limit=`) is a `400`, not an omission.
+
+Nothing clamps. A count above its cap used to be quietly reduced on some endpoints, so `?limit=99999` returned 500 rows with nothing in the response saying the request had been altered; it is now a rejection, which is the same answer the other endpoints already gave.
+
 ### List pagination and sorting
 
 The list endpoints — `GET /downloads`, `/clients`, `/shared`, `/servers`, `/friends`, the two per-file client routes, and `/search/{id}/results` — accept optional query parameters for server-side windowing and ordering, and always return pagination metadata beside the array:
 
 | Param    | Default          | Notes |
 |----------|------------------|-------|
-| `limit`  | *(all items)*    | Maximum items to return, capped at `500`. Omitted → the full set (pre-pagination behaviour). Non-integer or negative → `400 bad_request`. |
-| `offset` | `0`              | Items to skip before the window. Non-integer or negative → `400 bad_request`. |
+| `limit`  | *(all items)*    | Maximum items to return, `0`–`500`. Omitted → the full set (pre-pagination behaviour). Non-integer, negative or above `500` → `400 bad_request`. |
+| `offset` | `0`              | Items to skip before the window. Non-integer, negative or above `1000000000` → `400 bad_request`. |
 | `sort`   | *(native order)* | Field to sort by; endpoint-specific (table below). Unknown field → `400 bad_request`. |
 | `order`  | `asc`            | `asc` or `desc`; anything else → `400 bad_request`. |
 
@@ -325,9 +335,9 @@ If `amuleapi.conf[Server]/AllowCORS=1`:
 
 The dispatcher rejects paths containing NUL, encoded NUL (`%00`), encoded `..` (any case of `%2e%2e`), or a literal `..` segment with `400 bad_request` before routing. Defence-in-depth against a future endpoint that admits path captures.
 
-**Trailing slash.** Under `/api/`, one trailing `/` is stripped before routing, so `/api/v0/status/` and `/api/v0/status` are the same request. Exactly one is stripped — `//` is a malformed path rather than a synonym, so `/api/v0/downloads//` does not reach `/api/v0/downloads`. The rule stops at the API prefix: a static asset path is a filesystem path, where a trailing slash means a directory.
+**Trailing slash.** Under `/api/`, one trailing `/` is stripped before routing, so `/api/v0/status/` and `/api/v0/status` are the same request. Exactly one is stripped: `//` is a malformed path rather than a synonym, so `/api/v0/downloads//` does not reach `/api/v0/downloads`. The rule stops at the API prefix: a static asset path is a filesystem path, where a trailing slash means a directory.
 
-**Empty path captures.** A segment standing in for a `{capture}` cannot be empty. Every capture names a resource — a hash, an ECID, an index, an address — so a path that binds one to the empty string matches no route and is `404 not_found`, rather than reaching a handler and being rejected there with whatever status that endpoint happens to use.
+**Empty path captures.** A segment standing in for a `{capture}` cannot be empty. Every capture names a resource (a hash, an ECID, an index, an address), so a path that binds one to the empty string matches no route and is `404 not_found`, rather than reaching a handler and being rejected there with whatever status that endpoint happens to use.
 
 ### Request size limits
 
@@ -869,7 +879,7 @@ curl -H "Authorization: Bearer $TOKEN" \
   "http://$HOST/api/v0/downloads/8b54a3c2…/clients?include_parts=true"
 ```
 
-**Errors:** `404 not_found` (no download / no shared file with that hash), `400 bad_request` (bad list params, or `include_parts` other than `true` / `false`), `503 ec_unavailable`.
+**Errors:** `404 not_found` (no download / no shared file with that hash), `400 bad_request` (bad list params, or an `include_parts` that is not a boolean), `503 ec_unavailable`.
 
 #### `POST /api/v0/downloads/{hash}/a4af`
 
@@ -2432,7 +2442,7 @@ Time-series points behind the desktop Statistics graphs.
 | Parameter | Type | Default | Meaning |
 |---|---|---|---|
 | `interval` | int, `1`–`3600` | `1` | Seconds between samples. Changes what amuled is asked for, so it changes the reach of the window: `interval=10` covers ten times as long at a tenth the resolution. |
-| `width` | int, `1`–`1800` | full window | Tails the response to the last `N` samples. Applied after the fetch — it does not change what is requested, so it never changes the time span each sample covers. |
+| `width` | int, `0`–`1800` | full window | Tails the response to the last `N` samples. Applied after the fetch, so it does not change what is requested, so it never changes the time span each sample covers. `0` means the full window, same as omitting it. |
 
 ```json
 {
@@ -2467,7 +2477,7 @@ Each point has `t` (ISO-8601 UTC), `t_unix` (unix seconds) and `value`, spaced b
 | `kad_node_seconds` | **Not a transfer figure.** The running per-second sum of the Kad node count, i.e. node·seconds. Divide by `duration_seconds` for the session-average node count, which is its only use. |
 | `duration_seconds` | Daemon uptime at the newest point. `0` if the daemon does not report it. Divide any of the three figures above by it to get the session average the desktop plots. |
 
-**Errors:** `400 bad_request` (`interval` outside `1`–`3600` or non-numeric), `404 not_found` (unknown graph name), `503 ec_unavailable`.
+**Errors:** `400 bad_request` (`interval` or `width` non-numeric or out of range), `404 not_found` (unknown graph name), `503 ec_unavailable`.
 
 ---
 
@@ -2790,7 +2800,7 @@ Served from the refresher snapshot — no EC roundtrip per request. Standard [li
 
 **Auth:** `GUEST`
 
-**Query:** `since_id=N` (only messages with `id > N`), `limit=N` (the last N of that window).
+**Query:** `since_id=N` (only messages with `id > N`), `tail=N` (the last N of that window, max `100000`). This selects a tail rather than a page, which is why it is not called `limit`: on the list endpoints `limit` is a window paired with `offset`, and one word meaning two things is a rule a client has to learn twice.
 
 ```json
 {

--- a/src/libwebcommon/PathPatterns.cpp
+++ b/src/libwebcommon/PathPatterns.cpp
@@ -24,6 +24,8 @@
 
 #include "PathPatterns.h"
 
+#include <cstdint>
+
 namespace web_api_path
 {
 
@@ -110,6 +112,43 @@ std::string StripTrailingSlash(const std::string &path)
 		return path.substr(0, path.size() - 1);
 	}
 	return path;
+}
+
+// See PathPatterns.h.
+bool ParseBoundedUint(const std::string &s, std::uint64_t min, std::uint64_t max, std::uint64_t &out)
+{
+	if (s.empty()) {
+		return false;
+	}
+	std::uint64_t v = 0;
+	for (char c : s) {
+		if (c < '0' || c > '9') {
+			return false;
+		}
+		v = v * 10 + static_cast<std::uint64_t>(c - '0');
+		if (v > max) {
+			return false;
+		}
+	}
+	if (v < min) {
+		return false;
+	}
+	out = v;
+	return true;
+}
+
+// See PathPatterns.h.
+bool ParseBoolValue(const std::string &s, bool &out)
+{
+	if (s == "1" || s == "true" || s == "yes") {
+		out = true;
+		return true;
+	}
+	if (s == "0" || s == "false" || s == "no") {
+		out = false;
+		return true;
+	}
+	return false;
 }
 
 namespace

--- a/src/libwebcommon/PathPatterns.h
+++ b/src/libwebcommon/PathPatterns.h
@@ -25,6 +25,7 @@
 #ifndef LIBWEBCOMMON_PATHPATTERNS_H
 #define LIBWEBCOMMON_PATHPATTERNS_H
 
+#include <cstdint>
 #include <map>
 #include <string>
 #include <vector>
@@ -67,6 +68,18 @@ std::string StripTrailingSlash(const std::string &path);
 // Malformed `%hh` triplets pass through verbatim so a stray `%` in
 // a path query doesn't silently drop characters.
 std::map<std::string, std::string> ParseQuery(const std::string &q);
+
+// Parses a decimal query-parameter value into `out`, requiring it to fall in
+// [min, max] inclusive. Returns false on an empty value, any non-digit, or a
+// value outside the range -- the caller turns that into its own rejection.
+//
+// The running value is bounded inside the loop, so a long digit string cannot
+// wrap before the range check sees it.
+bool ParseBoundedUint(const std::string &s, std::uint64_t min, std::uint64_t max, std::uint64_t &out);
+
+// Parses a boolean query-parameter value: 1/0, true/false, yes/no. Returns
+// false on anything else rather than defaulting, so a typo is answerable.
+bool ParseBoolValue(const std::string &s, bool &out);
 
 // A pattern is a path string with optional `{name}` capture segments.
 // Example: "/downloads/{hash}/pause" parses to

--- a/src/webapi/Api.cpp
+++ b/src/webapi/Api.cpp
@@ -3193,39 +3193,74 @@ std::unique_ptr<CHttpServer::Response> BadRequestPtr(const char *message)
 	return std::make_unique<CHttpServer::Response>(ErrorResponse(400, "bad_request", message));
 }
 
-// Parse ?limit/&offset/&sort/&order from a raw query string. `limit` is
-// clamped to 500; a non-numeric/oversized limit or offset, and a bad
-// `order`, are 400s. `sort` is validated later against the endpoint's
-// comparator table (BuildListWindow).
+// Optional unsigned query parameter, with an inclusive upper bound.
+//
+// One parser for every count on the surface. The seven written by hand
+// disagreed about the two questions that decide what a client sees -- what an
+// unparseable value does, and what an out-of-range one does -- so a typo was a
+// hard error on `interval` and a silent behaviour change on `width`, on the
+// same endpoint. Rejecting both, here, is the only version of "consistent" a
+// tenth call site cannot quietly opt out of, and the status, the code and the
+// sentence are contract rather than local wording.
+//
+// Absent leaves `out` untouched, so the caller's default stands. `min` and
+// `max` are inclusive; the running value is bounded inside the loop, so a long
+// digit string cannot wrap before the range check sees it.
+std::unique_ptr<CHttpServer::Response> ParseUintParam(const std::map<std::string, std::string> &qmap,
+	const char *name,
+	std::uint64_t min,
+	std::uint64_t max,
+	std::uint64_t &out)
+{
+	const auto it = qmap.find(name);
+	if (it == qmap.end())
+		return nullptr;
+	if (!web_api_path::ParseBoundedUint(it->second, min, max, out)) {
+		const std::string msg = std::string("`") + name + "` must be an integer between " +
+					std::to_string(min) + " and " + std::to_string(max);
+		return BadRequestPtr(msg.c_str());
+	}
+	return nullptr;
+}
+
+// Optional boolean query parameter. Accepts 1/0, true/false and yes/no, and
+// rejects anything else -- `include_completed` used to read every other value
+// as false while its neighbour `include_parts` answered 400, so the same typo
+// was silent on one endpoint and fatal on the next.
+std::unique_ptr<CHttpServer::Response> ParseBoolParam(
+	const std::map<std::string, std::string> &qmap, const char *name, bool &out)
+{
+	const auto it = qmap.find(name);
+	if (it == qmap.end())
+		return nullptr;
+	if (!web_api_path::ParseBoolValue(it->second, out)) {
+		const std::string msg = std::string("`") + name + "` must be 1/0, true/false or yes/no";
+		return BadRequestPtr(msg.c_str());
+	}
+	return nullptr;
+}
+
+// Parse ?limit/&offset/&sort/&order from a raw query string. A non-numeric or
+// out-of-range `limit`/`offset`, and a bad `order`, are 400s. `sort` is
+// validated later against the endpoint's comparator table (BuildListWindow).
 std::unique_ptr<CHttpServer::Response> ParseListParams(const std::string &query, ListParams &out)
 {
 	const auto qmap = web_api_path::ParseQuery(query);
-	auto parseCount = [](const std::string &s, std::size_t &v) -> bool {
-		if (s.empty() || s.size() > 9) // > ~1e9 is nonsense for these lists
-			return false;
-		std::size_t val = 0;
-		for (char c : s) {
-			if (c < '0' || c > '9')
-				return false;
-			val = val * 10 + static_cast<std::size_t>(c - '0');
-		}
-		v = val;
-		return true;
-	};
-	const auto limit_it = qmap.find("limit");
-	if (limit_it != qmap.end()) {
-		std::size_t v = 0;
-		if (!parseCount(limit_it->second, v))
-			return BadRequestPtr("`limit` must be a non-negative integer");
+	// 500 is the window cap and 1e9 is well past anything these lists hold;
+	// both are now rejections rather than silent clamps, so a client that
+	// asks for more learns it did.
+	if (qmap.count("limit")) {
+		std::uint64_t v = 0;
+		if (auto r = ParseUintParam(qmap, "limit", 0, 500, v))
+			return r;
 		out.has_limit = true;
-		out.limit = std::min<std::size_t>(v, 500);
+		out.limit = static_cast<std::size_t>(v);
 	}
-	const auto offset_it = qmap.find("offset");
-	if (offset_it != qmap.end()) {
-		std::size_t v = 0;
-		if (!parseCount(offset_it->second, v))
-			return BadRequestPtr("`offset` must be a non-negative integer");
-		out.offset = v;
+	{
+		std::uint64_t v = 0;
+		if (auto r = ParseUintParam(qmap, "offset", 0, 1000000000ull, v))
+			return r;
+		out.offset = static_cast<std::size_t>(v);
 	}
 	const auto order_it = qmap.find("order");
 	if (order_it != qmap.end()) {
@@ -3652,11 +3687,8 @@ CHttpServer::Response CApiDispatcher::HandleDownloads(const CHttpServer::Request
 		if (q != std::string::npos)
 			query = req.target.substr(q + 1);
 		const auto qmap = web_api_path::ParseQuery(query);
-		const auto it = qmap.find("include_completed");
-		if (it != qmap.end()) {
-			const std::string &v = it->second;
-			include_completed = (v == "1" || v == "true" || v == "yes");
-		}
+		if (auto r = ParseBoolParam(qmap, "include_completed", include_completed))
+			return *r;
 	}
 
 	ListParams params;
@@ -3830,14 +3862,8 @@ CHttpServer::Response CApiDispatcher::HandleFileClients(
 	bool include_parts = false;
 	{
 		const auto qmap = web_api_path::ParseQuery(QueryOf(req));
-		const auto it = qmap.find("include_parts");
-		if (it != qmap.end()) {
-			if (it->second != "true" && it->second != "false") {
-				return ErrorResponse(
-					400, "bad_request", "`include_parts` must be \"true\" or \"false\"");
-			}
-			include_parts = (it->second == "true");
-		}
+		if (auto r = ParseBoolParam(qmap, "include_parts", include_parts))
+			return *r;
 	}
 
 	const std::uint64_t part_count = webapi::PartCountForSize(file.size);
@@ -5690,27 +5716,24 @@ CHttpServer::Response CApiDispatcher::HandleChatMessages(
 	// process, so a client never sees a duplicate and never skips one. They
 	// reset when the daemon restarts, which also empties the store.
 	std::uint32_t since_id = 0;
-	std::size_t limit = 0;
+	std::size_t tail = 0;
 	const auto qmap = web_api_path::ParseQuery(QueryOf(req));
 	{
-		const auto it = qmap.find("since_id");
-		if (it != qmap.end()) {
-			if (it->second.find_first_not_of("0123456789") != std::string::npos) {
-				return ErrorResponse(
-					400, "bad_request", "`since_id` must be a non-negative integer");
-			}
-			since_id = static_cast<std::uint32_t>(std::strtoul(it->second.c_str(), nullptr, 10));
-		}
+		std::uint64_t v = since_id;
+		if (auto r = ParseUintParam(qmap, "since_id", 0, 0xFFFFFFFFull, v))
+			return *r;
+		since_id = static_cast<std::uint32_t>(v);
 	}
 	{
-		const auto it = qmap.find("limit");
-		if (it != qmap.end()) {
-			if (it->second.find_first_not_of("0123456789") != std::string::npos) {
-				return ErrorResponse(
-					400, "bad_request", "`limit` must be a non-negative integer");
-			}
-			limit = static_cast<std::size_t>(std::strtoul(it->second.c_str(), nullptr, 10));
-		}
+		// `tail`, not `limit`. This selects the last N of the window
+		// rather than a page of it, which is what the log endpoints
+		// already call `tail` -- naming it `limit` gave the surface two
+		// meanings for one word, and the paginated one is the meaning a
+		// client meets on nine other collections.
+		std::uint64_t v = tail;
+		if (auto r = ParseUintParam(qmap, "tail", 0, 100000, v))
+			return *r;
+		tail = static_cast<std::size_t>(v);
 	}
 
 	std::vector<const webapi::ChatMessageSnapshot *> selected;
@@ -5718,11 +5741,11 @@ CHttpServer::Response CApiDispatcher::HandleChatMessages(
 		if (m.id > since_id)
 			selected.push_back(&m);
 	}
-	// `limit` means the LAST n, matching "show me the tail of this
+	// `tail` means the LAST n, matching "show me the tail of this
 	// conversation"; combined with since_id it trims the same window from the
 	// front, so the newest are always the ones kept.
-	if (limit && selected.size() > limit) {
-		selected.erase(selected.begin(), selected.end() - static_cast<std::ptrdiff_t>(limit));
+	if (tail && selected.size() > tail) {
+		selected.erase(selected.begin(), selected.end() - static_cast<std::ptrdiff_t>(tail));
 	}
 
 	CJsonWriter w;
@@ -6785,19 +6808,18 @@ namespace
 // `?tail=N` parser. Returns 0 if the query is absent / unparseable;
 // the caller's contract is "0 means return everything". Negative or
 // non-numeric values clamp to 0.
-std::size_t ParseTailParam(const std::string &query)
+// 100k lines is the cap: a bogus `?tail=2147483647` would otherwise try to
+// serialise the entire wxString through the JSON escaper. It used to clamp
+// silently, which meant a client asking for more got fewer with nothing saying
+// so; it is a 400 now, like every other out-of-range count.
+std::unique_ptr<CHttpServer::Response> ParseTailParam(const std::string &query, std::size_t &out)
 {
 	const auto qmap = web_api_path::ParseQuery(query);
-	const auto it = qmap.find("tail");
-	if (it == qmap.end())
-		return 0;
-	const long n = std::atol(it->second.c_str());
-	if (n <= 0)
-		return 0;
-	// Cap at 100k lines so a bogus `?tail=2147483647` doesn't try to
-	// serialise the entire wxString through the JSON escaper.
-	const long capped = std::min<long>(n, 100000);
-	return static_cast<std::size_t>(capped);
+	std::uint64_t v = 0;
+	if (auto r = ParseUintParam(qmap, "tail", 0, 100000, v))
+		return r;
+	out = static_cast<std::size_t>(v);
+	return nullptr;
 }
 
 // Return a copy of `all` containing at most `tail` trailing lines.
@@ -7051,17 +7073,10 @@ CHttpServer::Response CApiDispatcher::HandleStatsTree(const CHttpServer::Request
 		if (q != std::string::npos)
 			query = req.target.substr(q + 1);
 		const auto qmap = web_api_path::ParseQuery(query);
-		const auto it = qmap.find("max_client_versions");
-		if (it != qmap.end()) {
-			char *end = nullptr;
-			const long n = std::strtol(it->second.c_str(), &end, 10);
-			if (end == it->second.c_str() || *end != '\0' || n < 0 || n > 255) {
-				return ErrorResponse(400,
-					"bad_request",
-					"max_client_versions must be an integer between 0 and 255");
-			}
-			max_client_versions = static_cast<std::uint8_t>(n);
-		}
+		std::uint64_t v = max_client_versions;
+		if (auto r = ParseUintParam(qmap, "max_client_versions", 0, 255, v))
+			return *r;
+		max_client_versions = static_cast<std::uint8_t>(v);
 	}
 
 	// lazy-fetch with 1 s TTL coalescing. The fetcher runs
@@ -7157,16 +7172,10 @@ CHttpServer::Response CApiDispatcher::HandleStatsGraph(
 	// total) — besides, SCALE is a uint16 on the wire.
 	std::uint32_t interval = 1;
 	{
-		const auto it = qmap.find("interval");
-		if (it != qmap.end()) {
-			char *end = nullptr;
-			const long n = std::strtol(it->second.c_str(), &end, 10);
-			if (end == it->second.c_str() || *end != '\0' || n < 1 || n > 3600) {
-				return ErrorResponse(
-					400, "bad_request", "interval must be an integer between 1 and 3600");
-			}
-			interval = static_cast<std::uint32_t>(n);
-		}
+		std::uint64_t v = interval;
+		if (auto r = ParseUintParam(qmap, "interval", 1, 3600, v))
+			return *r;
+		interval = static_cast<std::uint32_t>(v);
 	}
 
 	// Lazy-fetch the full graph bundle (one EC call serves all four named
@@ -7216,12 +7225,10 @@ CHttpServer::Response CApiDispatcher::HandleStatsGraph(
 	// answers every (graph, width) combination.
 	std::size_t width = 0;
 	{
-		const auto it = qmap.find("width");
-		if (it != qmap.end()) {
-			const long n = std::atol(it->second.c_str());
-			if (n > 0)
-				width = static_cast<std::size_t>(std::min<long>(n, 1800));
-		}
+		std::uint64_t v = 0;
+		if (auto r = ParseUintParam(qmap, "width", 0, 1800, v))
+			return *r;
+		width = static_cast<std::size_t>(v);
 	}
 
 	const std::time_t ts = pair.second;
@@ -7562,7 +7569,9 @@ CHttpServer::Response CApiDispatcher::HandleLogAmule(const CHttpServer::Request 
 	if (q != std::string::npos) {
 		query = req.target.substr(q + 1);
 	}
-	const std::size_t tail = ParseTailParam(query);
+	std::size_t tail = 0;
+	if (auto r = ParseTailParam(query, tail))
+		return *r;
 	const auto all = m_state.AmuleLog();
 	const auto sliced = SliceTail(all, tail);
 
@@ -7634,7 +7643,9 @@ CHttpServer::Response CApiDispatcher::HandleLogServerinfo(const CHttpServer::Req
 	if (q != std::string::npos) {
 		query = req.target.substr(q + 1);
 	}
-	const std::size_t tail = ParseTailParam(query);
+	std::size_t tail = 0;
+	if (auto r = ParseTailParam(query, tail))
+		return *r;
 
 	// Lazy-fetch via TtlCache. EC_OP_GET_SERVERINFO ships one
 	// EC_TAG_STRING with the whole accumulated text — amuled rotates

--- a/unittests/curl-tests/amuleapi/06-read-logs.sh
+++ b/unittests/curl-tests/amuleapi/06-read-logs.sh
@@ -112,11 +112,15 @@ _assert_status 200 "GET /logs/amule?tail=0 → 200"
 _assert_json_eq '(.returned == .total_cached)' true \
 	'/logs/amule?tail=0 returns all (tail=0 is "no tailing")'
 
-# Bogus / non-numeric tail clamps to 0 (return all).
+# A non-numeric tail is a 400, not a silent "return all". It used to parse as
+# 0 and quietly hand back the whole buffer, so a typo changed the response
+# without saying so; the count is now validated like every other on the surface.
 _curl -H "Authorization: Bearer $TOKEN" "$HOST/api/v0/logs/amule?tail=notanumber"
-_assert_status 200 "GET /logs/amule?tail=notanumber → 200"
-_assert_json_eq '(.returned == .total_cached)' true \
-	'/logs/amule?tail=<bogus> defaults to "no tailing"'
+_assert_status 400 "GET /logs/amule?tail=notanumber → 400"
+
+# Out of range is the same answer, where it used to clamp to 100000.
+_curl -H "Authorization: Bearer $TOKEN" "$HOST/api/v0/logs/amule?tail=999999"
+_assert_status 400 "GET /logs/amule?tail=999999 → 400"
 
 # --- 4. /logs/serverinfo shape. ------------------------------------
 _curl -H "Authorization: Bearer $TOKEN" "$HOST/api/v0/logs/serverinfo"

--- a/unittests/curl-tests/amuleapi/11-downloads-default-filter.sh
+++ b/unittests/curl-tests/amuleapi/11-downloads-default-filter.sh
@@ -154,8 +154,8 @@ for v in true yes; do
 	fi
 done
 
-# --- 4. include_completed=0 / =false / =garbage → default behavior. -
-for v in 0 false bogus; do
+# --- 4. include_completed=0 / =false → default behavior. -----------
+for v in 0 false no; do
 	_curl -H "Authorization: Bearer $TOKEN" "$HOST/api/v0/downloads?include_completed=$v"
 	_assert_status 200 "GET /downloads?include_completed=$v → 200"
 	c=$(printf '%s' "$CURL_BODY" | jq '.downloads | length')
@@ -166,6 +166,13 @@ for v in 0 false bogus; do
 			"got $c entries, expected $DEFAULT_COUNT (default)"
 	fi
 done
+
+# A value that is not a boolean at all is a 400, not a silent false. It used
+# to fall through to the default here, which meant a typo quietly changed what
+# the caller got while the neighbouring `include_parts` answered 400 for the
+# same mistake.
+_curl -H "Authorization: Bearer $TOKEN" "$HOST/api/v0/downloads?include_completed=bogus"
+_assert_status 400 "GET /downloads?include_completed=bogus → 400"
 
 # --- 5. Detail endpoint UNCHANGED — serves completed files too. ---
 #

--- a/unittests/curl-tests/amuleapi/28-list-pagination-sort.sh
+++ b/unittests/curl-tests/amuleapi/28-list-pagination-sort.sh
@@ -164,10 +164,15 @@ for pair in "${ENDPOINTS[@]}"; do
 	_curl "${AUTH[@]}" "$HOST/api/v0/$ep?sort=nonexistent_field"
 	_assert_status 400 "GET /$ep?sort=nonexistent_field → 400"
 
-	# 7. limit is capped at 500 (echoed limit never exceeds 500).
+	# 7. 500 is the cap, and asking for more is a rejection rather than a
+	# silent reduction: the echoed `limit` used to be the only place a
+	# client could notice its request had been altered, and `width` and
+	# `tail` had no such echo at all.
 	_curl "${AUTH[@]}" "$HOST/api/v0/$ep?limit=99999"
-	_assert_status 200 "GET /$ep?limit=99999 → 200 (clamped)"
-	_assert_json_le ".limit" 500 "/$ep?limit=99999 echoes limit <= 500"
+	_assert_status 400 "GET /$ep?limit=99999 → 400 (over the cap)"
+	_curl "${AUTH[@]}" "$HOST/api/v0/$ep?limit=500"
+	_assert_status 200 "GET /$ep?limit=500 → 200 (the cap is in range)"
+	_assert_json_eq ".limit" 500 "/$ep?limit=500 echoes the limit it used"
 done
 
 curl -s -X DELETE "${AUTH[@]}" "$HOST/api/v0/search/$SEARCH_SID" > /dev/null 2>&1

--- a/unittests/curl-tests/amuleapi/34-friends.sh
+++ b/unittests/curl-tests/amuleapi/34-friends.sh
@@ -116,14 +116,15 @@ _curl "$HOST/api/v0/friends?limit=1&offset=0"
 _assert_status 200 "GET /friends?limit=1"
 [ "$(_jq '.limit')" = "1" ] && _pass "limit is echoed" || _fail "limit echo" "got $(_jq '.limit')"
 
+# Over the cap is a rejection, not a silent clamp. It used to answer 200 with a
+# quietly reduced window, so a client asking for 99999 got 500 rows with nothing
+# in the response saying the request had been altered.
 _curl "$HOST/api/v0/friends?limit=99999"
-_assert_status 200 "GET /friends?limit=99999 (clamped, not rejected)"
-CLAMPED=$(_jq '.limit')
-if [ "$CLAMPED" -le 500 ] 2>/dev/null; then
-	_pass "limit clamped to $CLAMPED"
-else
-	_fail "limit clamp" "expected <= 500, got $CLAMPED"
-fi
+_assert_status 400 "GET /friends?limit=99999 is rejected, not clamped"
+
+# The cap itself is still valid.
+_curl "$HOST/api/v0/friends?limit=500"
+_assert_status 200 "GET /friends?limit=500 (the cap is in range)"
 
 for bad in "limit=abc" "limit=-1" "offset=-1" "order=sideways"; do
 	_curl "$HOST/api/v0/friends?$bad"

--- a/unittests/curl-tests/amuleapi/38-chat.sh
+++ b/unittests/curl-tests/amuleapi/38-chat.sh
@@ -182,6 +182,30 @@ _curl -H "Authorization: Bearer $TOKEN" \
 _assert_json_eq '.messages | length'   1                'since_id returns exactly the new message'
 _assert_json_eq '.messages[0].text'    "second message" 'since_id returns the right message'
 
+# --- 5b. `tail`, not `limit`. --------------------------------------
+#
+# This selects the last N of the window rather than a page of it, which is
+# what the log endpoints already call `tail`. It was called `limit`, which
+# on nine other collections means a window paired with `offset` -- one word
+# with two meanings is a rule a client has to learn twice.
+_curl -H "Authorization: Bearer $TOKEN" \
+	"$HOST/api/v0/chats/$PEER/messages?tail=1"
+_assert_status 200 "GET messages?tail=1 → 200"
+_assert_json_eq '.messages | length' 1 'tail=1 returns just the newest message'
+_assert_json_eq '.messages[0].text' "second message" 'tail keeps the newest, not the oldest'
+
+# The old spelling is now an unknown parameter, which is simply ignored --
+# it is not a count the endpoint honours under another name.
+_curl -H "Authorization: Bearer $TOKEN" \
+	"$HOST/api/v0/chats/$PEER/messages?limit=1"
+_assert_status 200 "GET messages?limit=1 → 200 (unknown param, ignored)"
+_assert_json_eq '.messages | length' 2 'limit no longer truncates the chat window'
+
+# Same strict parsing as every other count on the surface.
+_curl -H "Authorization: Bearer $TOKEN" \
+	"$HOST/api/v0/chats/$PEER/messages?tail=abc"
+_assert_status 400 "GET messages?tail=abc → 400"
+
 # --- 6. Input validation. -----------------------------------------
 _curl -H "Authorization: Bearer $TOKEN" "$HOST/api/v0/chats/notanaddress/messages"
 _assert_status 400 "GET messages with a malformed {peer} → 400"

--- a/unittests/curl-tests/amuleapi/40-http-conformance.sh
+++ b/unittests/curl-tests/amuleapi/40-http-conformance.sh
@@ -179,6 +179,42 @@ _assert_eq "401" "$(curl -s -o /dev/null -w '%{http_code}' --max-time 5 "$HOST/a
 	"GET /events without credentials -> 401"
 
 # ---------------------------------------------------------------------------
+# Query parameters: unparseable and out-of-range are both 400, never a default
+# ---------------------------------------------------------------------------
+# Each parameter used to be parsed by hand and each site picked its own rule, so
+# the same typo was a hard error on one parameter and a silent behaviour change
+# on its neighbour -- `interval=abc` was a 400 while `width=abc` was a 200 that
+# quietly meant "everything", on the same endpoint. These assert the wiring: the
+# unit tests pin ParseBoundedUint/ParseBoolValue, but only a live request shows
+# that a handler routes through them.
+_qp() {
+	# $1 = query, $2 = expected status, $3 = label
+	_assert_eq "$2" "$(curl -s -o /dev/null -w '%{http_code}' --max-time 10 \
+		"${AUTH[@]}" "$HOST/api/v0/$1")" "$3"
+}
+
+# Booleans: one vocabulary, and anything outside it is answerable.
+_qp "downloads?include_completed=1"     200 "include_completed=1 -> 200"
+_qp "downloads?include_completed=false" 200 "include_completed=false -> 200"
+_qp "downloads?include_completed=maybe" 400 "include_completed=maybe -> 400 (was a silent false)"
+
+# Counts: garbage and out-of-range are the same answer.
+_qp "downloads?limit=abc"   400 "limit=abc -> 400"
+_qp "downloads?limit=99999" 400 "limit=99999 -> 400 (was a silent clamp to 500)"
+_qp "downloads?limit=500"   200 "limit=500 -> 200 (the cap itself is valid)"
+_qp "downloads?limit="      400 "limit= (empty) -> 400, not an omission"
+
+# Two numeric parameters on one endpoint used to disagree with each other.
+_qp "stats/graphs/download_speed?interval=abc" 400 "interval=abc -> 400"
+_qp "stats/graphs/download_speed?width=abc"    400 "width=abc -> 400 (was a silent 200)"
+_qp "stats/graphs/download_speed?width=99999"  400 "width=99999 -> 400 (was a silent clamp)"
+_qp "stats/graphs/download_speed?interval=0"   400 "interval=0 -> 400 (below the documented minimum)"
+
+# The log tail clamped silently too.
+_qp "logs/amule?tail=abc"    400 "tail=abc -> 400"
+_qp "logs/amule?tail=999999" 400 "tail=999999 -> 400 (was a silent clamp to 100000)"
+
+# ---------------------------------------------------------------------------
 # Trailing slash: `/x/` names the same resource as `/x`
 # ---------------------------------------------------------------------------
 # The two spellings used to disagree by route kind, not by meaning. A literal

--- a/unittests/tests/PathPatternsTest.cpp
+++ b/unittests/tests/PathPatternsTest.cpp
@@ -333,3 +333,71 @@ TEST(PathPatterns, Match_StillRejectsAMissegmentedLiteral)
 	std::map<std::string, std::string> caps;
 	ASSERT_TRUE(!Match(pat, SplitPath("/api/v0/shared/"), caps));
 }
+
+// ----------------------------------------------------------------------
+// ParseBoundedUint / ParseBoolValue
+// ----------------------------------------------------------------------
+
+// Seven hand-written count parsers disagreed about the two questions that
+// decide what a client sees: what an unparseable value does, and what an
+// out-of-range one does. A typo was a hard error on `interval` and a silent
+// behaviour change on `width` -- on the same endpoint.
+TEST(PathPatterns, ParseBoundedUint_AcceptsInRange)
+{
+	std::uint64_t v = 999;
+	ASSERT_TRUE(ParseBoundedUint("0", 0, 500, v));
+	ASSERT_EQUALS(static_cast<std::uint64_t>(0), v);
+	ASSERT_TRUE(ParseBoundedUint("500", 0, 500, v));
+	ASSERT_EQUALS(static_cast<std::uint64_t>(500), v);
+	ASSERT_TRUE(ParseBoundedUint("1", 1, 3600, v));
+	ASSERT_EQUALS(static_cast<std::uint64_t>(1), v);
+}
+
+// Unparseable and out-of-range are the same answer, which is the whole point:
+// neither silently becomes a default.
+TEST(PathPatterns, ParseBoundedUint_RejectsGarbageAndOutOfRange)
+{
+	std::uint64_t v = 42;
+	ASSERT_TRUE(!ParseBoundedUint("", 0, 500, v));
+	ASSERT_TRUE(!ParseBoundedUint("abc", 0, 500, v));
+	ASSERT_TRUE(!ParseBoundedUint("12x", 0, 500, v));
+	ASSERT_TRUE(!ParseBoundedUint("-1", 0, 500, v));
+	ASSERT_TRUE(!ParseBoundedUint("501", 0, 500, v));
+	ASSERT_TRUE(!ParseBoundedUint("0", 1, 3600, v));
+	// A rejected parse leaves the caller's default alone.
+	ASSERT_EQUALS(static_cast<std::uint64_t>(42), v);
+}
+
+// The bound is checked while accumulating, so a digit string long enough to
+// wrap a uint64 is rejected rather than wrapping into range.
+TEST(PathPatterns, ParseBoundedUint_DoesNotWrapOnLongInput)
+{
+	std::uint64_t v = 7;
+	ASSERT_TRUE(!ParseBoundedUint("99999999999999999999999999", 0, 500, v));
+	ASSERT_TRUE(!ParseBoundedUint("18446744073709551617", 0, 500, v));
+	ASSERT_EQUALS(static_cast<std::uint64_t>(7), v);
+}
+
+// `include_completed` read every unrecognised value as false while its
+// neighbour `include_parts` answered 400, so one typo was silent and the next
+// was fatal. One vocabulary, and anything outside it is answerable.
+TEST(PathPatterns, ParseBoolValue_AcceptsTheThreeSpellings)
+{
+	bool b = false;
+	ASSERT_TRUE(ParseBoolValue("1", b) && b);
+	ASSERT_TRUE(ParseBoolValue("true", b) && b);
+	ASSERT_TRUE(ParseBoolValue("yes", b) && b);
+	ASSERT_TRUE(ParseBoolValue("0", b) && !b);
+	ASSERT_TRUE(ParseBoolValue("false", b) && !b);
+	ASSERT_TRUE(ParseBoolValue("no", b) && !b);
+}
+
+TEST(PathPatterns, ParseBoolValue_RejectsAnythingElse)
+{
+	bool b = true;
+	ASSERT_TRUE(!ParseBoolValue("maybe", b));
+	ASSERT_TRUE(!ParseBoolValue("", b));
+	ASSERT_TRUE(!ParseBoolValue("TRUE", b));
+	// Left alone on rejection.
+	ASSERT_TRUE(b);
+}


### PR DESCRIPTION
Addresses §14 and §4 of #1107. The issue stays open for the rest.

Every optional query parameter was parsed by hand, and each site picked its own answer to the two questions a client actually feels: what an unparseable value does, and what an out-of-range one does. On a single endpoint `interval=abc` was a `400` while `width=abc` was a `200` that quietly meant "everything". `include_completed=maybe` read as false while its neighbour `include_parts=maybe` answered `400`. Three counts clamped in silence, so `?limit=99999` returned 500 rows with nothing in the response saying the request had been altered.

Reject both, everywhere. Seven hand-rolled count parsers and two boolean ones collapse into `ParseBoundedUint` and `ParseBoolValue`, which live in `libwebcommon` next to `ParseQuery`: the parsing is generic, only the rejection shape is API-specific, so `Api.cpp` keeps thin wrappers that add the `400`. `ParseListParams` and `ParseTailParam` are rebuilt on top rather than left as an eighth and ninth parser.

That split is also what makes them testable. No unittest target compiles `Api.cpp`, so a parser living there could not have a test that fails when it is deleted.

**§4:** `limit` now means one thing. On chat messages it meant "the last N", which is what the log endpoints already call `tail`; it is `tail` there now, so `limit` is a window paired with `offset` on every endpoint that takes it.

`REFERENCE.md` gains a `### Query parameter validation` section stating the rule once, plus six endpoint-level corrections.

## Behaviour changes

`include_completed=bogus`, `width=abc` and `tail=notanumber` used to answer `200`; they are `400` now. `?limit=99999`, `?width=99999` and `?tail=999999` were silently clamped; they are `400` now. Chat `?limit=N` is `?tail=N`. Booleans accept `1/0`, `true/false` and `yes/no` everywhere, which widens `include_parts` (previously `true`/`false` only).

Four curl blocks asserted the old behaviour and are updated: `06-read-logs`, `11-downloads-default-filter`, `28-list-pagination-sort`, `34-friends`.

## Verification

Both parsers mutation-checked: dropping the range check fails `ParseBoundedUint_RejectsGarbageAndOutOfRange`, and defaulting the boolean instead of rejecting fails `ParseBoolValue_RejectsAnythingElse`. Includes an overflow case confirming a long digit string cannot wrap into range. `ctest` 43/43.

Curl: the 14 affected phases, derived by grepping for the parameters actually touched rather than picked by hand, run against a daemon connected to a live ed2k server. **696 assertions, 3 failures**, none of them in this area: two are `Kad search can't be done if Kad is not running` and one is an SSE idle-resync timing check. A control run with only the sources reverted confirmed nine of the new assertions fail against `master` and pass here, so they are guards rather than decoration.

clang-format clean, Tier-2 clang-tidy clean on the diff with 0 compiler errors.

The three remaining failures were not themselves controlled: their messages identify the cause and neither path touches query parsing, but that is reasoning rather than a second run.
