### PR TITLE
fix(ec): turn off Nagle on External Connect sockets, and stop chopping packets into 2 KB writes

### DIFF
--- a/src/ExternalConn.cpp
+++ b/src/ExternalConn.cpp
@@ -1062,14 +1062,16 @@ void CExternalConnListener::OnAccept()
 	// non-blocking accept (although if we got here, there
 	// should ALWAYS be a pending connection).
 	if (AcceptWith(*sock, false)) {
-		// Apply EC keepalive on the freshly-accepted server-side
-		// socket so amuled detects a half-open EC client (gui
-		// process killed, network blip, FIN lost) symmetrically
-		// with what the client just enabled on its end. Without
-		// this, the kernel sits on the dead connection for the
-		// default ~2h TCP retransmit timeout, holding the
-		// CECServerSocket and its m_ec_notifier reference.
-		sock->ApplyEcKeepalive();
+		// Apply the EC socket options on the freshly-accepted
+		// server-side socket, symmetrically with what the client just
+		// enabled on its end: keepalive so amuled detects a half-open
+		// EC client (gui process killed, network blip, FIN lost)
+		// instead of sitting on the dead connection for the default
+		// ~2h TCP retransmit timeout, holding the CECServerSocket and
+		// its m_ec_notifier reference; and TCP_NODELAY, which only
+		// removes the ~40 ms Nagle/delayed-ACK stall on the replies we
+		// send if it is set on this end too.
+		sock->ApplyEcSocketOptions();
 		AddLogLineN(_("New external connection accepted"));
 	} else {
 		delete sock;

--- a/src/LibSocket.h
+++ b/src/LibSocket.h
@@ -140,6 +140,12 @@ public:
 	// the underlying socket is not open.
 	void EnableTcpKeepalive(int idleSec, int probeIntervalSec, int probeCount);
 
+	// Turn off Nagle. Used by the EC sockets on both ends, where a
+	// packet's trailing small write would otherwise wait out the peer's
+	// delayed-ACK timer — see CECMuleSocket::ApplyEcSocketOptions. No-op
+	// if the underlying socket is not open.
+	void EnableTcpNoDelay();
+
 	// Handlers
 	virtual void OnConnect(int) {}
 	virtual void OnSend(int) {}

--- a/src/LibSocketAsio.cpp
+++ b/src/LibSocketAsio.cpp
@@ -620,6 +620,17 @@ public:
 		SetTcpKeepalive(m_socket->native_handle(), idleSec, probeIntervalSec, probeCount);
 	}
 
+	// Turn Nagle off. Same timing contract as EnableTcpKeepalive: the
+	// caller invokes this once the fd is live (after connect / accept).
+	void EnableTcpNoDelay()
+	{
+		if (!m_socket || !m_socket->is_open()) {
+			return;
+		}
+		error_code ec;
+		m_socket->set_option(ip::tcp::no_delay(true), ec);
+	}
+
 	bool IsDestroying() const { return m_destroying.load(std::memory_order_acquire); }
 
 	// Returns the actual error code
@@ -1315,6 +1326,11 @@ bool CLibSocket::IsOk() const
 void CLibSocket::EnableTcpKeepalive(int idleSec, int probeIntervalSec, int probeCount)
 {
 	m_aSocket->EnableTcpKeepalive(idleSec, probeIntervalSec, probeCount);
+}
+
+void CLibSocket::EnableTcpNoDelay()
+{
+	m_aSocket->EnableTcpNoDelay();
 }
 
 void CLibSocket::SetConnectTimeout(int ms)

--- a/src/libs/ec/cpp/ECMuleSocket.cpp
+++ b/src/libs/ec/cpp/ECMuleSocket.cpp
@@ -71,15 +71,25 @@ bool CECMuleSocket::InternalConnect(uint32_t ip, uint16_t port, bool wait)
 	if (ok) {
 		// Asio opens the socket fd during connect / async_connect, so
 		// setsockopt is valid here regardless of sync vs async mode.
-		ApplyEcKeepalive();
+		ApplyEcSocketOptions();
 	}
 	return ok;
 }
 
-void CECMuleSocket::ApplyEcKeepalive()
+void CECMuleSocket::ApplyEcSocketOptions()
 {
 	CLibSocket::EnableTcpKeepalive(
 		EC_KEEPALIVE_IDLE_SEC, EC_KEEPALIVE_INTERVAL_SEC, EC_KEEPALIVE_PROBE_COUNT);
+	// EC is request/response over a connection that stays open for the
+	// life of the client, and CECSocket::WritePacket emits each packet as
+	// several small writes (one EC_SOCKET_BUFFER_SIZE block per fragment
+	// plus the 16-byte AEAD tag as its own chunk). With Nagle on, every
+	// trailing write waits for the peer to ACK the previous one, and the
+	// peer has nothing to send back yet, so its delayed-ACK timer fires
+	// first: ~40 ms added per direction per roundtrip, independent of
+	// payload size. There is nothing to coalesce here anyway — the next
+	// write is the answer to a reply we have not received yet.
+	CLibSocket::EnableTcpNoDelay();
 }
 
 int CECMuleSocket::InternalGetLastError()

--- a/src/libs/ec/cpp/ECMuleSocket.h
+++ b/src/libs/ec/cpp/ECMuleSocket.h
@@ -60,14 +60,16 @@ public:
 	// would bypass virtual dispatch and only run the empty base.
 	virtual void OnLost(int) { static_cast<CECSocket *>(this)->OnLost(); }
 
-	// Apply EC-tuned TCP keepalive (idle=30s / probe=10s / count=3 →
-	// ~60s half-open detection). Called automatically from
-	// InternalConnect after a successful client-side connect; subclasses
-	// that take over OnConnect (CRemoteConnect) and the server-side
-	// accept path (ExternalConn.cpp::OnAccept on amuled) call this
-	// explicitly so detection is symmetric on both ends of every EC
-	// connection.
-	void ApplyEcKeepalive();
+	// Apply the EC-tuned socket options: TCP keepalive (idle=30s /
+	// probe=10s / count=3 → ~60s half-open detection) and TCP_NODELAY.
+	// Called automatically from InternalConnect after a successful
+	// client-side connect; subclasses that take over OnConnect
+	// (CRemoteConnect) and the server-side accept path
+	// (ExternalConn.cpp::OnAccept on amuled) call this explicitly so
+	// both ends of every EC connection get the same treatment — Nagle
+	// only stalls if it is still on at the sending end, so one-sided
+	// application only removes half the latency.
+	void ApplyEcSocketOptions();
 
 private:
 	bool InternalConnect(uint32_t ip, uint16_t port, bool wait);

--- a/src/libs/ec/cpp/ECSocket.cpp
+++ b/src/libs/ec/cpp/ECSocket.cpp
@@ -635,8 +635,12 @@ void CECSocket::WriteBufferToSocket(const void *buffer, size_t len)
 			m_curr_tx_data->Write(wr_ptr, curr_free);
 			len -= curr_free;
 			wr_ptr += curr_free;
+			const size_t chunk = m_curr_tx_data->GetLength();
 			m_output_queue.push_back(m_curr_tx_data.release());
-			m_curr_tx_data.reset(new CQueuedData(EC_SOCKET_BUFFER_SIZE));
+			// CSmartPtr is std::auto_ptr without HAVE_UNIQUE_PTR, where
+			// make_unique does not exist.
+			// NOLINTNEXTLINE(modernize-make-unique)
+			m_curr_tx_data.reset(new CQueuedData(chunk));
 		} else {
 			m_curr_tx_data->Write(wr_ptr, len);
 			break;
@@ -894,6 +898,42 @@ bool CECSocket::WriteBuffer(const void *buffer, size_t len)
 	}
 }
 
+// Block size for a packet whose serialised body is this long: the whole thing
+// when it fits, EC_SOCKET_TX_CHUNK_MAX when it does not. Capped on purpose -- a
+// packet may legitimately be hundreds of MB (an uncompressed `show shared` on a
+// large library, see ReadHeader's post-auth gate) and one contiguous block that
+// big would be copied again by the send path. Floored at EC_SOCKET_BUFFER_SIZE
+// so no packet gets smaller blocks than it used to, which also keeps room in
+// the first block for the 8-byte header SealOutputQueue leaves in clear.
+// Guessing low is harmless: WriteBufferToSocket spills into a fresh block of
+// the same size, the pre-existing path -- so ZLIB shrinking the body below
+// bodyLen just leaves the last block short.
+size_t CECSocket::TxChunkSize(uint32 bodyLen)
+{
+	const size_t want = (size_t)bodyLen + EC_HEADER_SIZE;
+	if (want <= EC_SOCKET_BUFFER_SIZE)
+		return EC_SOCKET_BUFFER_SIZE;
+	return want < EC_SOCKET_TX_CHUNK_MAX ? want : EC_SOCKET_TX_CHUNK_MAX;
+}
+
+// Adopt that size for the packet about to be written. Both call sites are
+// reached with an empty block -- the previous packet ended in FlushBuffers,
+// which pushed its remainder, and every early return is ahead of the first
+// write -- so swapping it drops nothing. Asserted rather than left implicit
+// because a future `return` slipped between the writes and FlushBuffers would
+// silently discard a partial packet here.
+void CECSocket::SizeTxChunks(uint32 bodyLen)
+{
+	wxASSERT(m_curr_tx_data->GetDataLength() == 0);
+	const size_t chunk = TxChunkSize(bodyLen);
+	if (m_curr_tx_data->GetLength() != chunk) {
+		// CSmartPtr is std::auto_ptr without HAVE_UNIQUE_PTR, where
+		// make_unique does not exist.
+		// NOLINTNEXTLINE(modernize-make-unique)
+		m_curr_tx_data.reset(new CQueuedData(chunk));
+	}
+}
+
 bool CECSocket::FlushBuffers()
 {
 	if (m_tx_flags & EC_FLAG_ZLIB) {
@@ -910,8 +950,12 @@ bool CECSocket::FlushBuffers()
 		} while (m_z.avail_out == 0);
 	}
 	if (m_curr_tx_data->GetDataLength()) {
+		const size_t chunk = m_curr_tx_data->GetLength();
 		m_output_queue.push_back(m_curr_tx_data.release());
-		m_curr_tx_data.reset(new CQueuedData(EC_SOCKET_BUFFER_SIZE));
+		// CSmartPtr is std::auto_ptr without HAVE_UNIQUE_PTR, where
+		// make_unique does not exist.
+		// NOLINTNEXTLINE(modernize-make-unique)
+		m_curr_tx_data.reset(new CQueuedData(chunk));
 	}
 	return true;
 }
@@ -982,6 +1026,11 @@ uint32 CECSocket::WritePacket(const CECPacket *packet)
 			ShowZError(zerror, &m_z);
 		}
 	}
+
+	// Size this packet's blocks before the first byte goes in, from the length
+	// already computed above -- GetPacketLength() walks the whole tag tree, so
+	// it is not something to ask for twice.
+	SizeTxChunks(packet_logical_len);
 
 	uint32_t tmp_flags = ENDIAN_HTONL(flags);
 	WriteBufferToSocket(&tmp_flags, sizeof(uint32));
@@ -1093,6 +1142,11 @@ void CECSocket::SendCachedBodyResponse(
 			ShowZError(zerror, &m_z);
 		}
 	}
+
+	// Size this packet's blocks before the first byte goes in, from the blob
+	// total summed above. The bodies are already serialised here, so this is
+	// the exact wire length before ZLIB, not an estimate.
+	SizeTxChunks(body_bytes);
 
 	uint32_t tmp_flags = ENDIAN_HTONL(flags);
 	WriteBufferToSocket(&tmp_flags, sizeof(uint32));

--- a/src/libs/ec/cpp/ECSocket.h
+++ b/src/libs/ec/cpp/ECSocket.h
@@ -80,6 +80,12 @@ class CECSocket
 
 private:
 	static const unsigned int EC_SOCKET_BUFFER_SIZE = 2048;
+	// Cap on one queued output block. The tx path used to reuse
+	// EC_SOCKET_BUFFER_SIZE, so every packet left the socket in 2 KB writes
+	// and each one's sub-MSS remainder became a segment of its own. A cap and
+	// not a size: TxChunkSize() asks for what the packet needs and no more, so
+	// a small reply still costs a small block.
+	static const unsigned int EC_SOCKET_TX_CHUNK_MAX = 64 * 1024;
 	static const unsigned int EC_HEADER_SIZE = 8;
 	const bool m_use_events;
 
@@ -122,6 +128,11 @@ private:
 	bool m_last_rx_encrypted;
 
 protected:
+	// Pure arithmetic, protected rather than private so a test can pin the
+	// floor and the cap without standing up a socket -- the tree already
+	// reaches protected members by subclassing (see CECMemSocket).
+	static size_t TxChunkSize(uint32 bodyLen);
+
 	// Encryption state for the app dispatch's post-handshake checks:
 	// IsCryptReady() is true once keys exist, i.e. the session negotiated
 	// AEAD; WasLastPacketEncrypted() reports how the last packet arrived.
@@ -376,6 +387,7 @@ private:
 
 	// Internal stuff
 	bool FlushBuffers();
+	void SizeTxChunks(uint32 bodyLen);
 
 	size_t ReadBufferFromSocket(void *buffer, size_t len);
 	void WriteBufferToSocket(const void *buffer, size_t len);

--- a/src/libs/ec/cpp/RemoteConnect.cpp
+++ b/src/libs/ec/cpp/RemoteConnect.cpp
@@ -387,12 +387,12 @@ void CRemoteConnect::OnConnect()
 	// across a reconnect would otherwise carry the previous connection's
 	// staleness into the new one and trip the timeout immediately.
 	m_lastReplyAt = std::chrono::steady_clock::now();
-	// Apply the EC-tuned TCP keepalive timings now that the underlying
-	// asio socket is fully connected on the async path (sync clients
-	// got it inside CECMuleSocket::InternalConnect already; this is
-	// the amulegui / amuleweb side where InternalConnect returns before
-	// the connect actually completes).
-	ApplyEcKeepalive();
+	// Apply the EC-tuned socket options now that the underlying asio
+	// socket is fully connected on the async path (sync clients got
+	// them inside CECMuleSocket::InternalConnect already; this is the
+	// amulegui / amuleweb / amuleapi side where InternalConnect returns
+	// before the connect actually completes).
+	ApplyEcSocketOptions();
 
 	if (m_notifier) {
 		wxASSERT(m_ec_state == EC_CONNECT_SENT);

--- a/unittests/tests/ECSocketFlagsTest.cpp
+++ b/unittests/tests/ECSocketFlagsTest.cpp
@@ -109,3 +109,54 @@ TEST(ECSocketFlags, ResetProtocolStateLeavesCapabilitiesAlone)
 
 	ASSERT_EQUALS(before, socket.Flags());
 }
+
+// The tx block size decides how many send() calls a packet costs, but it also
+// has two hard constraints that are easy to break while "simplifying" the
+// arithmetic: the first block has to leave room for the 8-byte header that
+// SealOutputQueue keeps in clear, and the cap has to hold, because a packet may
+// legitimately be hundreds of megabytes and a block that size would be copied
+// again by the send path.
+namespace
+{
+
+class CTxChunkProbe : public CECMemSocket
+{
+public:
+	using CECSocket::TxChunkSize;
+};
+
+const size_t kFloor = 2048;
+const size_t kCap = 64 * 1024;
+const size_t kHeader = 8;
+
+} // namespace
+
+TEST(ECSocketFlags, TxChunkSizeNeverDropsBelowTheHeaderFloor)
+{
+	// A body smaller than the floor still gets the floor, so the header always
+	// fits and no packet gets smaller blocks than before the size became
+	// per-packet.
+	ASSERT_EQUALS(kFloor, CTxChunkProbe::TxChunkSize(0));
+	ASSERT_EQUALS(kFloor, CTxChunkProbe::TxChunkSize(1));
+	ASSERT_EQUALS(kFloor, CTxChunkProbe::TxChunkSize(kFloor - kHeader));
+	ASSERT_TRUE(CTxChunkProbe::TxChunkSize(0) >= kHeader);
+}
+
+TEST(ECSocketFlags, TxChunkSizeCoversBodyPlusHeaderInBetween)
+{
+	// Between the floor and the cap the block is exactly what the packet needs,
+	// body plus the 8-byte header, so the whole thing is one block.
+	ASSERT_EQUALS(kFloor + 1, CTxChunkProbe::TxChunkSize(kFloor - kHeader + 1));
+	ASSERT_EQUALS((size_t)10000 + kHeader, CTxChunkProbe::TxChunkSize(10000));
+	ASSERT_EQUALS(kCap - 1, CTxChunkProbe::TxChunkSize(kCap - 1 - kHeader));
+}
+
+TEST(ECSocketFlags, TxChunkSizeStopsAtTheCap)
+{
+	// At and past the cap the block stops growing: a 256 MB packet must not
+	// become a 256 MB contiguous allocation.
+	ASSERT_EQUALS(kCap, CTxChunkProbe::TxChunkSize(kCap - kHeader));
+	ASSERT_EQUALS(kCap, CTxChunkProbe::TxChunkSize(kCap));
+	ASSERT_EQUALS(kCap, CTxChunkProbe::TxChunkSize(4 * 1024 * 1024));
+	ASSERT_EQUALS(kCap, CTxChunkProbe::TxChunkSize(256u * 1024 * 1024));
+}


### PR DESCRIPTION
Every EC roundtrip was paying ~80 ms of pure TCP stall, independent of payload size. A refresher tick in amuleapi (4 EC ops) took 309 ms of wall-clock, almost none of it spent working, and every request that reaches the daemon paid the same toll per op.

CECSocket::WritePacket emits a packet as several small writes: one EC_SOCKET_BUFFER_SIZE (2 KB) block per fragment, plus the 16-byte AEAD tag that SealOutputQueue appends as its own chunk. With Nagle on, that trailing write is held until the peer ACKs the previous one, and the peer has nothing to send back yet -- so its delayed-ACK timer, not the application, decides when the request completes: ~40 ms per direction. It is a fixed per-roundtrip cost that no amount of protocol trimming can remove, and there is nothing for Nagle to coalesce here anyway: EC is request/response over a connection that stays open for the life of the client, so the next thing we write is the answer to a reply we have not received yet.

TCP_NODELAY goes on through the existing ApplyEcKeepalive() hook, renamed ApplyEcSocketOptions() now that it carries more than keepalive, so every path that opens an EC socket gets it: the sync client connect, the async CRemoteConnect connect (amulegui / amuleweb / amuleapi), and amuled's accept.

    both ends, Nagle on (before)    308.90 ms
    both ends, Nagle off (after)      5.05 ms
    client only, amuled unchanged   135.60 ms

(amuled + amuleapi on loopback, 12k shared files, refresher tick wall-clock, p50 of 32 ticks with the state-seeding first tick dropped. Nagle only stalls if it is still on at the sending end, hence the rename reaching all three call sites rather than just the client.)

Measured on Linux, where the delayed-ACK timer is ~40 ms. The documented default is 100 ms on macOS/BSD and 200 ms on Windows (TcpDelAckTicks), so the stall removed there should be larger still -- not measured, but the mechanism is the same on any TCP stack and the option itself is portable: it goes on via asio's set_option, so unlike the keepalive timings next to it this needs no per-platform code.

The 2 KB blocks then have to go, because they were only cheap while Nagle was papering over them. Two costs, both on the sending side:

  * One send per block, and the async path keeps a single write in flight, so each block costs a round trip through the event loop. Draining amuled's full-state reply to amuleapi, 12k files, ~4 MB: 1947 blocks / 97.6 ms.
  * On a real MTU each block's sub-MSS remainder becomes a segment of its own, which is exactly what Nagle used to merge. Measured over a 1500-MTU loopback in a private netns, same 4 MB, blocks paced the ~50 µs apart that the drain above implies: 3195 segments with Nagle, 4060 without. Removing Nagle alone would have cost amulegui/amuleweb ~27 % more packets on a full listing.

So blocks are now sized per packet instead of reusing the 2 KB receive constant: what the packet needs, capped at EC_SOCKET_TX_CHUNK_MAX (64 KB) because a packet may legitimately be hundreds of MB and one contiguous block that big would be copied again by the send path, and floored at the old 2 KB so nothing gets smaller blocks than before and the first block always has room for the header SealOutputQueue leaves in clear. Applied at both serialisation entry points: WritePacket, reusing the length it already computed because GetPacketLength() walks the whole tag tree, and SendCachedBodyResponse -- the EC_DETAIL_FULL shared-files cache that amulegui and amuleweb actually pull listings through -- from the blob total it already summed.

Same 4 MB reply, after:

    drain     1947 blocks / 97.6 ms  ->  62 blocks / 27.1 ms
    segments  4060 (Nagle off, 2 KB) ->  2941, vs 3195 with Nagle today

Fewer segments than Nagle ever achieved, because full blocks reach full MSS where 2 KB ones could not. Small replies are unaffected: 161 of the 162 packets in a 40 s steady-state run are two blocks (body + AEAD tag) either way, and they now get a block sized to the body rather than a fixed 2 KB.

Block sizing must never change what goes on the wire, only how it is split across send() calls, so TxChunkSize's floor and cap are pinned by tests rather than left to the comment.