### PR TITLE
fix(amuleapi): give /categories and /search the envelope every other list has

### DIFF
--- a/docs/api/REFERENCE.md
+++ b/docs/api/REFERENCE.md
@@ -218,7 +218,7 @@ Nothing clamps. A count above its cap used to be quietly reduced on some endpoin
 
 ### List pagination and sorting
 
-The list endpoints — `GET /downloads`, `/clients`, `/shared`, `/servers`, `/friends`, the two per-file client routes, and `/search/{id}/results` — accept optional query parameters for server-side windowing and ordering, and always return pagination metadata beside the array:
+The list endpoints (`GET /downloads`, `/clients`, `/shared`, `/servers`, `/friends`, `/categories`, `/search`, the two per-file client routes, and `/search/{id}/results`) accept optional query parameters for server-side windowing and ordering, and always return pagination metadata beside the array:
 
 | Param    | Default          | Notes |
 |----------|------------------|-------|
@@ -252,6 +252,8 @@ Omitting all four parameters preserves the previous response exactly, plus the a
 | `GET /friends`        | `name`, `online` |
 | `GET /chats`          | `last_message_at`, `name` |
 | `GET /search/{id}/results` | `name`, `size`, `sources`, `rating`, `directory` |
+| `GET /search`         | `search_id`, `query`, `started_at`, `result_count` |
+| `GET /categories`     | `index`, `name` |
 
 ### Bulk mutations and the `results` envelope
 
@@ -1931,11 +1933,16 @@ amuled's category system lets users tag downloads with one of N user-defined buc
       "color": 0,
       "priority": "normal"
     }
-  ]
+  ],
+  "total": 1,
+  "offset": 0,
+  "limit": 1
 }
 ```
 
-**Errors:** `503 ec_unavailable`.
+A list endpoint like the others: `?limit`, `?offset`, `?sort` and `?order` apply, and the `total` / `offset` / `limit` trio describes the window. See [List pagination and sorting](#list-pagination-and-sorting); the sort keys are `index` and `name`. Category `0` is always present, synthesised when amuled omits it, so the list is never empty.
+
+**Errors:** `400 bad_request` (bad list params), `503 ec_unavailable`.
 
 #### `POST /api/v0/categories`
 
@@ -2497,9 +2504,14 @@ Lists every search amuled currently holds — including ones started by a **diff
     { "search_id": 42, "query": "ubuntu desktop iso", "kind": "global", "state": "finished", "started_at": 1751000000, "result_count": 182 },
     { "search_id": 43, "query": "debian",             "kind": "kad",    "state": "running",  "started_at": 1751000042, "result_count": 57  },
     { "search_id": 44, "query": "SomePeerNick",       "kind": "browse", "state": "running",  "client_ecid": 621,       "result_count": 237 }
-  ]
+  ],
+  "total": 3,
+  "offset": 0,
+  "limit": 3
 }
 ```
+
+This is a list endpoint like the others: it takes `?limit`, `?offset`, `?sort` and `?order`, and carries the same `total` / `offset` / `limit` trio. See [List pagination and sorting](#list-pagination-and-sorting); the sort keys are `search_id`, `query`, `started_at` and `result_count`.
 
 `search_id` is the value that fills `{id}` on every search-scoped path: [`GET /search/{id}/results`](#get-apiv0searchidresults) to read its hits, [`POST /search/{id}/stop`](#post-apiv0searchidstop) to stop it, [`DELETE /search/{id}`](#delete-apiv0searchid) to free it. `kind` is `"local"` | `"global"` | `"kad"` | `"browse"`. The first three are the vocabulary `POST /search`'s `type` accepts; `"browse"` is reported only, for a "View Files" listing of one peer's share, which is started through the client endpoints rather than by a query. `state` is `"running"` | `"finished"` | `"idle"`, same vocabulary and meaning as `GET /search/{id}/results`'s `progress.state`.
 
@@ -2509,7 +2521,7 @@ Browsing a peer that is **already being browsed** returns the id already in flig
 
 `query` is the daemon's name for the search. For a `"browse"` that is **the peer's nickname**, not a query string — a browse has no query. `client_ecid` is the browsed peer's ecid and is present **only** on browse entries, so a consumer can tell whose share is being listed and cross-reference [`GET /clients`](#get-apiv0clients); it is omitted entirely on an ordinary search.
 
-`started_at` is the Unix second amuleapi started the search, and it is the **only recency signal on this list**: entries arrive ordered by `search_id`, and id order is not start order — Kad search ids carry a high-bit mask and therefore always sort above eD2k ones. Sort on `started_at` when you need "the newest search".
+`started_at` is the Unix second amuleapi started the search, and it is the **only recency signal on this list**: entries arrive ordered by `search_id`, and id order is not start order, because Kad search ids carry a high-bit mask and therefore always sort above eD2k ones. Ask for `?sort=started_at&order=desc` when you need "the newest search".
 
 It is **omitted** for any search this `amuleapi` process did not start itself — one begun by another client, by the desktop GUI, or restored from the daemon's on-disk ring after a restart. The daemon ships no timestamp of its own, so there is nothing to report for those; treat a missing `started_at` as *unknown*, not as oldest.
 

--- a/src/webapi/Api.cpp
+++ b/src/webapi/Api.cpp
@@ -3173,6 +3173,93 @@ using ListComparators = std::vector<std::pair<std::string, std::function<bool(co
 // Sort keys for peer rows, shared by /clients and by the per-file client
 // routes -- the latter derive theirs from this set, so a key added here shows
 // up on every peer list rather than only the one it was added to.
+// One row of GET /search. The listing is built from a live EC response rather
+// than a snapshot vector, so it needs a materialised row before it can go
+// through the same envelope every other collection uses. Absent values stay
+// absent rather than becoming 0: `started_at` is unknowable for a search this
+// process did not start, and `result_count` is unreported by an older daemon,
+// which has to stay distinguishable from "found nothing".
+struct SearchListRow
+{
+	std::uint32_t search_id = 0;
+	wxString query;
+	std::string kind;
+	std::string state;
+	bool has_client_ecid = false;
+	std::uint32_t client_ecid = 0;
+	std::time_t started_at = 0; // 0 = not started by this process
+	bool has_result_count = false;
+	std::uint32_t result_count = 0;
+};
+
+void WriteSearchListRow(CJsonWriter &w, const SearchListRow &row)
+{
+	w.BeginObject();
+	w.Key("search_id");
+	w.ValueInt(static_cast<int64_t>(row.search_id));
+	w.Key("query");
+	w.ValueString(row.query);
+	w.Key("kind");
+	w.ValueString(wxString::FromUTF8(row.kind.c_str()));
+	w.Key("state");
+	w.ValueString(wxString::FromUTF8(row.state.c_str()));
+	if (row.has_client_ecid) {
+		w.Key("client_ecid");
+		w.ValueInt(static_cast<int64_t>(row.client_ecid));
+	}
+	if (row.started_at != 0) {
+		w.Key("started_at");
+		w.ValueInt(static_cast<int64_t>(row.started_at));
+	}
+	if (row.has_result_count) {
+		w.Key("result_count");
+		w.ValueInt(static_cast<int64_t>(row.result_count));
+	}
+	w.EndObject();
+}
+
+// Sort keys for /search. The daemon hands its searches back id-ascending and id
+// order is not recency (Kad ids carry SEARCH_ID_KAD_MASK and always sort above
+// ed2k ones), so a client had nothing to rank the list by.
+const ListComparators<SearchListRow> &SearchListComparators()
+{
+	static const ListComparators<SearchListRow> kComps = {
+		{ "search_id",
+			[](const SearchListRow &a, const SearchListRow &b) {
+				return a.search_id < b.search_id;
+			} },
+		{ "query", [](const SearchListRow &a, const SearchListRow &b) { return a.query < b.query; } },
+		{ "started_at",
+			[](const SearchListRow &a, const SearchListRow &b) {
+				return a.started_at < b.started_at;
+			} },
+		{ "result_count",
+			[](const SearchListRow &a, const SearchListRow &b) {
+				return a.result_count < b.result_count;
+			} },
+	};
+	return kComps;
+}
+
+// Sort keys for /categories. The tenth list endpoint was also the only one
+// that never parsed ?limit/&offset/&sort/&order, so the same query string was a
+// hard error on /downloads and a silent no-op here -- while the response still
+// carried the page-meta trio a caller could not influence.
+const ListComparators<webapi::CategorySnapshot> &CategoryComparators()
+{
+	static const ListComparators<webapi::CategorySnapshot> kComps = {
+		{ "index",
+			[](const webapi::CategorySnapshot &a, const webapi::CategorySnapshot &b) {
+				return a.index < b.index;
+			} },
+		{ "name",
+			[](const webapi::CategorySnapshot &a, const webapi::CategorySnapshot &b) {
+				return a.name < b.name;
+			} },
+	};
+	return kComps;
+}
+
 const ListComparators<webapi::ClientSnapshot> &ClientComparators()
 {
 	static const ListComparators<webapi::ClientSnapshot> kComps = {
@@ -6729,7 +6816,10 @@ CHttpServer::Response CApiDispatcher::HandleCategories(const CHttpServer::Reques
 		d.priority = "low";
 		cats.insert(cats.begin(), std::move(d));
 	}
-	return ListResponse(m_state, "categories", cats, WriteCategoryObject);
+	ListParams params;
+	if (auto r = ParseListParams(QueryOf(req), params))
+		return *r;
+	return ListResponse(m_state, "categories", cats, WriteCategoryObject, params, CategoryComparators());
 }
 
 CHttpServer::Response CApiDispatcher::HandleKad(const CHttpServer::Request &req)
@@ -7482,78 +7572,50 @@ CHttpServer::Response CApiDispatcher::HandleSearchList(const CHttpServer::Reques
 	if (!a.ok)
 		return a.rejection;
 
+	ListParams params;
+	if (auto r = ParseListParams(QueryOf(req), params))
+		return *r;
+
 	std::unique_ptr<CECPacket> ec_req(new CECPacket(EC_OP_SEARCH_LIST));
 	const CECPacket *ec_resp = m_app.SendRecvSerialized(ec_req.get());
 	if (!ec_resp) {
 		return ErrorResponse(503, "ec_unavailable", "EC roundtrip failed for SEARCH_LIST");
 	}
 
-	CHttpServer::Response r;
-	r.status = 200;
-	r.content_type = "application/json";
-	CJsonWriter w;
-	w.BeginObject();
-	w.Key("searches");
-	w.BeginArray();
+	std::vector<SearchListRow> rows;
 	for (const CECTag &entry : *ec_resp) {
-		w.BeginObject();
-		const std::uint32_t sid = static_cast<std::uint32_t>(entry.GetInt());
-		w.Key("search_id");
-		w.ValueInt(static_cast<int64_t>(sid));
+		SearchListRow row;
+		row.search_id = static_cast<std::uint32_t>(entry.GetInt());
 		const CECTag *nameTag = entry.GetTagByName(EC_TAG_SEARCH_NAME);
-		w.Key("query");
-		w.ValueString(nameTag ? nameTag->GetStringData() : wxString());
+		row.query = nameTag ? nameTag->GetStringData() : wxString();
 		const CECTag *kindTag = entry.GetTagByName(EC_TAG_SEARCH_LIFECYCLE_KIND);
-		w.Key("kind");
-		w.ValueString(SearchKindToString(
-			kindTag ? static_cast<std::uint8_t>(kindTag->GetInt()) : EC_SEARCH_GLOBAL));
+		row.kind = SearchKindToString(kindTag ? static_cast<std::uint8_t>(kindTag->GetInt()) : 0);
 		const CECTag *stateTag = entry.GetTagByName(EC_TAG_SEARCH_LIFECYCLE_STATE);
-		const std::uint8_t state_val = stateTag ? static_cast<std::uint8_t>(stateTag->GetInt()) : 0;
-		w.Key("state");
-		w.ValueString(SearchLifecycleStateToString(state_val));
+		row.state = SearchLifecycleStateToString(
+			stateTag ? static_cast<std::uint8_t>(stateTag->GetInt()) : 0);
 		// Browse ("View Files") entries carry the browsed peer's ecid. Without
 		// it a consumer sees `kind: "browse"` with no way to tell WHOSE share
-		// it is listing -- which is exactly what amulegui uses the tag for when
-		// it rebuilds a browse tab. Omitted entirely on an ordinary search,
-		// which never carries it. `client_` keeps its prefix because this
-		// names a DIFFERENT object than the one being described, unlike the
-		// entry's own `search_id`.
+		// it is listing. Absent on an ordinary search, which never carries it.
 		if (const CECTag *clientTag = entry.GetTagByName(EC_TAG_CLIENT)) {
-			w.Key("client_ecid");
-			w.ValueInt(static_cast<int64_t>(clientTag->GetInt()));
+			row.has_client_ecid = true;
+			row.client_ecid = static_cast<std::uint32_t>(clientTag->GetInt());
 		}
-		// When THIS amuleapi started the search. The daemon ships no
-		// timestamp and hands its searches back id-ascending (the listing
-		// walks a std::map), and id order is not recency -- Kad ids carry
-		// SEARCH_ID_KAD_MASK and always sort above ed2k ones -- so without
-		// this a client has nothing to rank the list by. Omitted, not zeroed,
-		// for a search this process did not start: another client's, or one
-		// the daemon restored from disk. Those are unknowable here, and a 0
-		// would read as 1970 rather than "no idea".
-		if (const std::time_t started = m_state.SearchStartedAt(sid); started != 0) {
-			w.Key("started_at");
-			w.ValueInt(static_cast<int64_t>(started));
-		}
-		// How many hits the daemon holds for this search -- the same number
-		// GET /search/{id}/results reports as `total`. A client that adopts
-		// the listing and fetches results lazily per tab has nothing else to
-		// label an unopened tab with.
-		//
-		// Omitted, not zeroed, when the tag is absent: a daemon older than
-		// this change reports no counts, and "does not report" has to stay
-		// distinguishable from "found nothing". Same rule client_ecid and
-		// started_at already follow above.
+		// When THIS amuleapi started the search. Absent for one this process
+		// did not start -- another client's, or one the daemon restored from
+		// disk -- because a 0 would read as 1970 rather than "no idea".
+		row.started_at = m_state.SearchStartedAt(row.search_id);
+		// The same number GET /search/{id}/results reports as `total`. Absent
+		// when the daemon is older than the tag, so that "does not report"
+		// stays distinguishable from "found nothing".
 		if (const CECTag *countTag = entry.GetTagByName(EC_TAG_SEARCH_RESULT_COUNT)) {
-			w.Key("result_count");
-			w.ValueInt(static_cast<int64_t>(countTag->GetInt()));
+			row.has_result_count = true;
+			row.result_count = static_cast<std::uint32_t>(countTag->GetInt());
 		}
-		w.EndObject();
+		rows.push_back(std::move(row));
 	}
-	w.EndArray();
-	w.EndObject();
-	FinalizeJsonBody(w, r);
 	delete ec_resp;
-	return r;
+
+	return ListResponse(m_state, "searches", rows, WriteSearchListRow, params, SearchListComparators());
 }
 
 CHttpServer::Response CApiDispatcher::HandleLogAmule(const CHttpServer::Request &req)

--- a/unittests/curl-tests/amuleapi/18-categories-crud.sh
+++ b/unittests/curl-tests/amuleapi/18-categories-crud.sh
@@ -88,6 +88,32 @@ HAVE_GUEST=0
 sleep 4
 
 # --- 1. Auth + admin gate. -----------------------------------------
+# --- Shared list contract. -----------------------------------------
+#
+# /categories was the tenth list endpoint and the only one that never parsed
+# ?limit/&offset/&sort/&order: the same query string was a hard error on
+# /downloads and a silent no-op here, while the response still carried the
+# page-meta trio a caller could not influence.
+_curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/categories"
+_assert_status 200 "GET /categories → 200"
+_assert_json_eq '.total | type'  number '/categories carries total'
+_assert_json_eq '.offset | type' number '/categories carries offset'
+_assert_json_eq '.limit | type'  number '/categories carries limit'
+
+_curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/categories?limit=1"
+_assert_status 200 "GET /categories?limit=1 → 200"
+_assert_json_eq '.categories | length' 1 '/categories?limit=1 returns one row'
+_assert_json_eq '.limit' 1 '/categories?limit=1 echoes the limit'
+
+_curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/categories?sort=index&order=desc"
+_assert_status 200 "GET /categories?sort=index&order=desc → 200"
+
+# The parameters are validated now, not ignored.
+for bad in "limit=abc" "limit=99999" "offset=-1" "order=sideways" "sort=nonexistent_field"; do
+	_curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/categories?$bad"
+	_assert_status 400 "GET /categories?$bad → 400"
+done
+
 _curl -X POST -H "Content-Type: application/json" \
 	-d "{\"name\":\"$TEST_NAME\"}" "$HOST/api/v0/categories"
 _assert_status 401 "POST /categories (no token) → 401"

--- a/unittests/curl-tests/amuleapi/19-search.sh
+++ b/unittests/curl-tests/amuleapi/19-search.sh
@@ -265,6 +265,32 @@ _assert_json_eq "[.searches[] | select(.search_id == $FIRST_SID)][0].result_coun
 # ...and it agrees with what the results endpoint reports as `total` -- but only
 # once the search has settled. While it runs, result_count is the daemon's live
 # index and `total` is whatever amuleapi last pulled into its cache, so the two
+# --- GET /search is a list endpoint like the others. ---------------
+#
+# It was the one collection with no envelope: no total, no offset, no limit and
+# no sort, so a client had to special-case it. It is also unbounded (whatever
+# EC_OP_SEARCH_LIST returns, including searches this process never started), and
+# entries arrive id-ascending while id order is not start order, because Kad ids
+# carry a high-bit mask and always sort above eD2k ones.
+_curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/search"
+_assert_status 200 "GET /search → 200"
+_assert_json_eq '.total | type'  number '/search carries total'
+_assert_json_eq '.offset | type' number '/search carries offset'
+_assert_json_eq '.limit | type'  number '/search carries limit'
+
+_curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/search?limit=1"
+_assert_status 200 "GET /search?limit=1 → 200"
+_assert_json_eq '.searches | length' 1 '/search?limit=1 returns one row'
+
+# The recency signal the docs point at is now actually askable.
+_curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/search?sort=started_at&order=desc"
+_assert_status 200 "GET /search?sort=started_at&order=desc → 200"
+
+for bad in "limit=abc" "limit=99999" "order=sideways" "sort=nonexistent_field"; do
+	_curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/search?$bad"
+	_assert_status 400 "GET /search?$bad → 400"
+done
+
 # legitimately differ by a fetch.
 LIST_COUNT=$(printf '%s' "$CURL_BODY" \
 	| jq -r "[.searches[] | select(.search_id == $FIRST_SID)][0].result_count")


### PR DESCRIPTION
Addresses §2 and §5 of #1107. The issue stays open for the rest.

Ten collections carry `total`/`offset`/`limit` and take `?limit`/`&offset`/`&sort`/`&order`. Two did not, each in its own way.

`/categories` was the tenth list endpoint and the only one that never called `ParseListParams`: the same query string was a hard error on `/downloads` and a silent no-op here, while the response still advertised the page-meta trio from a default-constructed `ListParams`, which is pagination metadata for a collection that could not be paginated.

`/search` had no envelope at all, and was the one collection a client had to special-case. It is also unbounded: whatever `EC_OP_SEARCH_LIST` returns, including searches this process never started and ones the daemon restored from disk.

Both now go through `ListResponse`, which is the machinery the other ten already use, so this is adoption rather than new code. `/search` needed a materialised row first because it builds from a live EC response rather than a snapshot vector, so `SearchListRow` carries what the writer used to emit inline, with absent values still absent rather than zeroed.

Sort keys: `index`/`name` for categories, `search_id`/`query`/`started_at`/`result_count` for searches. REFERENCE.md already told clients to "sort on `started_at` when you need the newest search", which was advice they could not act on because there was no `sort` parameter. It now says `?sort=started_at&order=desc` and means it.

## Behaviour change worth naming

`ListResponse` gates on `RequireSnapshot`, so `GET /search` answers `503 ec_unavailable` before the first snapshot instead of serving its live EC roundtrip. That matches every other collection, but it is a dependency the endpoint did not previously have.

No test pinned the old bare-array shape: every existing assertion indexes `.searches[]` / `.categories[]`, which survives.

## Verification

`ctest` 43/43, clang-format clean, Tier-2 clang-tidy clean on the diff with 0 compiler errors.

Curl: phases `18`, `19`, `28` and `40` against a daemon connected to a live ed2k server. All eleven new assertions pass, covering both envelopes' `total`/`offset`/`limit`, `?limit=1` windowing, both sort keys, and `400` on bad list params. The remaining failures in `19` are two Kad cases (`Kad search can't be done if Kad is not running`), and `28` exits 0.

A control run against `master` on the same daemon is in progress; results will be added as a comment.
