### PR TITLE
refactor(amuleapi): declare the file priority levels once

### DIFF
--- a/docs/api/REFERENCE.md
+++ b/docs/api/REFERENCE.md
@@ -282,6 +282,21 @@ Processing is **best-effort per item** — each item is an independent EC roundt
 
 A malformed **request** (missing/empty `hashes`, an invalid patch field) is still a top-level `400 bad_request` and returns the plain error envelope, not `results`. The `hashes` array is capped at 500 entries.
 
+### Priority levels
+
+`priority` appears on four resources and accepts three different sets. The differences are deliberate rather than drift, and they reflect what the daemon can actually store:
+
+| Resource | Accepted |
+|---|---|
+| Downloads (`PATCH /downloads`, `PATCH /downloads/{hash}`) | `low`, `normal`, `high`, `auto` |
+| Shared files (`PATCH /shared`, `PATCH /shared/{hash}`) | `very_low`, `low`, `normal`, `high`, `release`, `auto` |
+| Categories (`POST /categories`, `PATCH /categories/{index}`) | `low`, `normal`, `high`, `auto` |
+| Servers (`PATCH /servers/{ecid}`) | `low`, `normal`, `high` |
+
+`very_low` and `release` are upload-side levels only: the `.part.met` loader clamps anything outside low/normal/high back to normal on restart, so a download pinned to one of them would silently lose it. Categories apply their priority to member files as a *download* priority, so they take the download set. Servers have three levels and no `auto`.
+
+A rejection names the set that endpoint accepts, so sending a wrong value tells you the right ones. Note that a file which is both downloading and shared carries two independent priorities from the two sets, and changing one does not affect the other.
+
 ### Localization and number formatting
 
 The API is a machine contract: **all API text is English and all numbers use the C locale** (a `.` decimal separator, no digit grouping), independent of the `amuleapi`/`amuled` locale or the `--locale` option. Localization is a client concern.

--- a/src/webapi/Api.cpp
+++ b/src/webapi/Api.cpp
@@ -3585,22 +3585,72 @@ bool IsEcFailedResponse(const CECPacket *resp, std::string &out_msg)
 // what the daemon can actually hold; the shared side keeps the full
 // set in SharedPriorityToCode.
 // Returns false if the wire string isn't a known download priority.
-bool DownloadPriorityToCode(const std::string &name, std::uint8_t &out)
+// The one place the file-priority vocabulary is declared.
+//
+// /downloads, /shared and /categories all speak the PR_* code space and differ
+// only in which names they accept, which is how three near-identical converters
+// came to exist: adding or renaming a level was a multi-site edit with no
+// compiler help, and each call site additionally spelled its accepted set out
+// again in a rejection string.
+//
+// The differences in what each accepts are deliberate and stay. The .part.met
+// loader clamps anything but PR_LOW/PR_NORMAL/PR_HIGH back to Normal on
+// restart, so very_low and release are upload-side levels only and are refused
+// on the download path on purpose. Categories apply their priority to member
+// files as a download priority, so they inherit the download set.
+//
+// Servers are deliberately NOT in this table. SRV_PR_* is a different code
+// space in which the same word means a different number -- `low` is 0 for a
+// file and 2 for a server -- so folding them together would produce one table
+// that lies about half its rows. ServerPriorityCode stays where it is.
+enum PriorityDomain : unsigned
 {
-	if (name == "low") {
-		out = PR_LOW;
-		return true;
-	} else if (name == "normal") {
-		out = PR_NORMAL;
-		return true;
-	} else if (name == "high") {
-		out = PR_HIGH;
-		return true;
-	} else if (name == "auto") {
-		out = PR_AUTO;
-		return true;
+	kPrioDownload = 1u << 0,
+	kPrioShared = 1u << 1,
+	kPrioCategory = 1u << 2,
+};
+
+struct FilePriorityLevel
+{
+	const char *name;
+	std::uint8_t code;
+	unsigned domains;
+};
+
+const FilePriorityLevel kFilePriorities[] = {
+	{ "very_low", PR_VERY_LOW, kPrioShared },
+	{ "low", PR_LOW, kPrioDownload | kPrioShared | kPrioCategory },
+	{ "normal", PR_NORMAL, kPrioDownload | kPrioShared | kPrioCategory },
+	{ "high", PR_HIGH, kPrioDownload | kPrioShared | kPrioCategory },
+	{ "release", PR_VERYHIGH, kPrioShared },
+	{ "auto", PR_AUTO, kPrioDownload | kPrioShared | kPrioCategory },
+};
+
+bool FilePriorityToCode(const std::string &name, unsigned domain, std::uint8_t &out)
+{
+	for (const FilePriorityLevel &level : kFilePriorities) {
+		if ((level.domains & domain) != 0 && name == level.name) {
+			out = level.code;
+			return true;
+		}
 	}
 	return false;
+}
+
+// The rejection names exactly what this domain accepts, built from the table
+// rather than restated at each call site -- five sites had their own copy, so a
+// new level would have been announced in some of them and not others.
+std::string FilePriorityAccepted(unsigned domain)
+{
+	std::string out;
+	for (const FilePriorityLevel &level : kFilePriorities) {
+		if ((level.domains & domain) == 0)
+			continue;
+		if (!out.empty())
+			out += ", ";
+		out += level.name;
+	}
+	return "`priority` must be one of " + out;
 }
 
 // The three "fetch a list from a URL" endpoints — /servers/update,
@@ -4962,11 +5012,9 @@ CHttpServer::Response CApiDispatcher::HandleDownloadPatch(
 					400, "bad_request", "`priority` must be a wire-string enum");
 			}
 			std::uint8_t code = 0;
-			if (!DownloadPriorityToCode(it->second.get<std::string>(), code)) {
-				return ErrorResponse(400,
-					"bad_request",
-					"`priority` must be one of "
-					"low, normal, high, auto");
+			if (!FilePriorityToCode(it->second.get<std::string>(), kPrioDownload, code)) {
+				return ErrorResponse(
+					400, "bad_request", FilePriorityAccepted(kPrioDownload).c_str());
 			}
 			auto err = send_op(
 				EC_OP_PARTFILE_PRIO_SET, /*has_inner=*/true, EC_TAG_PARTFILE_PRIO, code);
@@ -8679,29 +8727,6 @@ namespace
 // combined "*_auto" strings are intentionally NOT accepted as input --
 // "auto" is the level the daemon computes, so a caller can't pin it.
 // Returns false on unknown enum.
-bool SharedPriorityToCode(const std::string &name, std::uint8_t &out)
-{
-	if (name == "very_low") {
-		out = PR_VERY_LOW;
-		return true;
-	} else if (name == "low") {
-		out = PR_LOW;
-		return true;
-	} else if (name == "normal") {
-		out = PR_NORMAL;
-		return true;
-	} else if (name == "high") {
-		out = PR_HIGH;
-		return true;
-	} else if (name == "release") {
-		out = PR_VERYHIGH;
-		return true;
-	} else if (name == "auto") {
-		out = PR_AUTO;
-		return true;
-	}
-	return false;
-}
 
 } // namespace
 
@@ -8738,11 +8763,8 @@ CHttpServer::Response CApiDispatcher::HandleSharedPatch(
 			return ErrorResponse(400, "bad_request", "`priority` must be a wire-string enum");
 		}
 		std::uint8_t code = 0;
-		if (!SharedPriorityToCode(pit->second.get<std::string>(), code)) {
-			return ErrorResponse(400,
-				"bad_request",
-				"`priority` must be one of "
-				"very_low, low, normal, high, release, auto");
+		if (!FilePriorityToCode(pit->second.get<std::string>(), kPrioShared, code)) {
+			return ErrorResponse(400, "bad_request", FilePriorityAccepted(kPrioShared).c_str());
 		}
 		CMD4Hash file_hash;
 		if (!HashFromHex(s.hash, file_hash)) {
@@ -8881,10 +8903,9 @@ CHttpServer::Response CApiDispatcher::HandleDownloadsBulkPatch(const CHttpServer
 				return ErrorResponse(
 					400, "bad_request", "`priority` must be a wire-string enum");
 			std::uint8_t code = 0;
-			if (!DownloadPriorityToCode(it->second.get<std::string>(), code))
-				return ErrorResponse(400,
-					"bad_request",
-					"`priority` must be one of low, normal, high, auto");
+			if (!FilePriorityToCode(it->second.get<std::string>(), kPrioDownload, code))
+				return ErrorResponse(
+					400, "bad_request", FilePriorityAccepted(kPrioDownload).c_str());
 			ops.push_back({ EC_OP_PARTFILE_PRIO_SET, true, EC_TAG_PARTFILE_PRIO, code });
 		}
 	}
@@ -9047,10 +9068,8 @@ CHttpServer::Response CApiDispatcher::HandleSharedBulkPatch(const CHttpServer::R
 	if (!pit->second.is<std::string>())
 		return ErrorResponse(400, "bad_request", "`priority` must be a wire-string enum");
 	std::uint8_t code = 0;
-	if (!SharedPriorityToCode(pit->second.get<std::string>(), code))
-		return ErrorResponse(400,
-			"bad_request",
-			"`priority` must be one of very_low, low, normal, high, release, auto");
+	if (!FilePriorityToCode(pit->second.get<std::string>(), kPrioShared, code))
+		return ErrorResponse(400, "bad_request", FilePriorityAccepted(kPrioShared).c_str());
 
 	std::vector<BulkItem> results;
 	results.reserve(hashes.size());
@@ -9622,23 +9641,6 @@ bool ParseCategoryIndex(const std::string &s, std::uint8_t &out)
 // loader clamps anything but PR_LOW/PR_NORMAL/PR_HIGH back to Normal on the
 // next restart -- so accepting them here would be the same silent downgrade
 // #396 fixed for the direct download PATCH path (issue #384).
-bool CategoryPriorityToCode(const std::string &name, std::uint8_t &out)
-{
-	if (name == "low") {
-		out = PR_LOW;
-		return true;
-	} else if (name == "normal") {
-		out = PR_NORMAL;
-		return true;
-	} else if (name == "high") {
-		out = PR_HIGH;
-		return true;
-	} else if (name == "auto") {
-		out = PR_AUTO;
-		return true;
-	}
-	return false;
-}
 
 // Build the CEC_Category_Tag-shaped tag amuled expects. The shape is:
 //  parent tag EC_TAG_CATEGORY with the index as the int payload,
@@ -9736,10 +9738,9 @@ CHttpServer::Response ParseCategoryFields(const picojson::object &obj, CategoryF
 				return ErrorResponse(
 					400, "bad_request", "`priority` must be a wire-string enum");
 			}
-			if (!CategoryPriorityToCode(it->second.get<std::string>(), out.prio)) {
-				return ErrorResponse(400,
-					"bad_request",
-					"`priority` must be one of low, normal, high, auto");
+			if (!FilePriorityToCode(it->second.get<std::string>(), kPrioCategory, out.prio)) {
+				return ErrorResponse(
+					400, "bad_request", FilePriorityAccepted(kPrioCategory).c_str());
 			}
 			out.has_prio = true;
 		}


### PR DESCRIPTION
Addresses §6 of #1107. The issue stays open for the rest.

`priority` took three different sets across four resources, with one converter each and no compiler help: adding or renaming a level was a multi-site edit, and **five call sites additionally restated their accepted set as a string literal**, so a rejection could drift out of sync with the converter that produced it.

Downloads, shared files and categories all speak the `PR_*` code space and differ only in which names they accept, so they collapse into one `kFilePriorities` table with a domain mask. `FilePriorityToCode` matches against it, and `FilePriorityAccepted` builds the rejection from the same rows, so a new level announces itself everywhere it is legal and nowhere it is not.

**No behaviour change.** The sets reflect what the daemon can store: the `.part.met` loader clamps anything but `PR_LOW`/`PR_NORMAL`/`PR_HIGH` back to Normal on restart, so `very_low` and `release` stay upload-side only, and categories keep the download set because they apply their priority to member files as a download priority.

## Where this diverges from the issue

The issue proposed collapsing **four** converters. Servers stay out, on purpose: `SRV_PR_*` is a different code space in which the same word means a different number, `low` being `0` for a file and `2` for a server. One table would map one name to two codes and lie about half its rows. `ServerPriorityCode` keeps its own converter, and the table's comment says why, so the next reader does not "finish the job".

`REFERENCE.md` gains a `### Priority levels` table. The per-endpoint sets were already stated at each field; what was missing was that three sets exist deliberately, and the reasons.

## Verification

Checked against the suite that already existed rather than by adding assertions duplicating it. Mutation: widening `very_low` into the download domain fails `PATCH priority=very_low (shared-only) -> 400` in `12-downloads-add-patch`.

Both directions are covered. Downloads and categories reject the shared-only levels (`12`, `18`), and `17-shared-priority-patch` accepts and persists `release` and `very_low` (42 assertions, 0 failures, once given a shared fixture). 278 assertions across `04`, `05`, `12`, `14`, `18`, `29` with 0 failures.

`ctest` 43/43, clang-format clean, Tier-2 clang-tidy clean on the diff with 0 compiler errors.
