### PR TITLE
fix(amuleapi): say null when a value is unknown

### DIFF
--- a/docs/api/REFERENCE.md
+++ b/docs/api/REFERENCE.md
@@ -282,6 +282,14 @@ Processing is **best-effort per item** — each item is an independent EC roundt
 
 A malformed **request** (missing/empty `hashes`, an invalid patch field) is still a top-level `400 bad_request` and returns the plain error envelope, not `results`. The `hashes` array is capped at 500 entries.
 
+### Unknown values
+
+A field whose value is not known is `null`, not a sentinel. `remaining_time` is `null` rather than `-1` when there is no ETA to compute; `last_upload` and `shared_since` are `null` rather than `0` when a file has never uploaded or its `known.met` entry predates the field.
+
+A key is **omitted** only where absence itself is the meaning: something the daemon never reported, rather than something known to be absent. `started_at` on [`GET /search`](#get-apiv0search) is the example, missing for a search this process did not start, and `result_count` is missing when the daemon is too old to send it, which has to stay distinguishable from a search that found nothing.
+
+So: `null` means "no value", an absent key means "not reported", and neither is ever spelled `0` or `-1`.
+
 ### Priority levels
 
 `priority` appears on four resources and accepts three different sets. The differences are deliberate rather than drift, and they reflect what the daemon can actually store:
@@ -753,7 +761,7 @@ Same envelope as the list item, plus the detail-only fields below (all omitted f
 | `download_active_time` | int | Seconds spent actively downloading. |
 | `available_part_count` | int | Number of parts available across the current sources. |
 | `part_count` | int | Total parts, `ceil(size / 9.28 MiB)`. |
-| `remaining_time` | int | ETA in seconds; `-1` when stalled or paused (speed ≈ 0). |
+| `remaining_time` | int \| null | ETA in seconds, or `null` when stalled or paused (speed ≈ 0) and there is nothing to compute from. |
 | `lost_to_corruption` | int | Bytes discarded to corruption. |
 | `gained_by_compression` | int | Bytes saved by on-the-wire compression. |
 | `saved_by_ich` | int | Packets recovered by Intelligent Corruption Handling. |
@@ -1375,7 +1383,7 @@ curl -s -H "Authorization: Bearer $TOKEN" "http://$HOST/api/v0/shared"
 
 `xfer.session` / `xfer.total` are bytes uploaded during the current amuled process vs over the file's lifetime. `requests` counts how many peers have asked for the file; `accepts` counts how many of those requests were granted an upload slot. The `session` counters reset on amuled restart; `total` is persisted in `known.met`.
 
-`upload_speed_bps` is the file's current combined upload rate in bytes/sec (summed over the peers it is uploading to), and `uploading` is how many peers it is actively uploading to right now — together the "is this file being seeded" signal, the upload-side analogue of the `/downloads` speed + transferring-source counts. Subtract `uploading` from the queued-client count (`queued_count`, on the detail view) to show `uploading / queued`. Both are live and refresh every tick. `last_upload` is the unix timestamp of the last time data was sent for the file, and `shared_since` is when the file was completed or first shared; both are persisted in `known.met` and are `0` when unknown — a file that has never uploaded, or a `known.met` entry written before these fields existed.
+`upload_speed_bps` is the file's current combined upload rate in bytes/sec (summed over the peers it is uploading to), and `uploading` is how many peers it is actively uploading to right now — together the "is this file being seeded" signal, the upload-side analogue of the `/downloads` speed + transferring-source counts. Subtract `uploading` from the queued-client count (`queued_count`, on the detail view) to show `uploading / queued`. Both are live and refresh every tick. `last_upload` is the unix timestamp of the last time data was sent for the file, and `shared_since` is when the file was completed or first shared; both are persisted in `known.met` and are `null` when unknown: a file that has never uploaded, or a `known.met` entry written before these fields existed.
 
 `priority` is the upload priority — `"very_low"` / `"low"` / `"normal"` / `"high"` / `"release"` — and `priority_auto` is `true` when amuled is deriving that level automatically from the upload queue. This mirrors the `/downloads` shape (base `priority` + separate `priority_auto` flag); on an auto file `priority` reports the current derived level, not the literal string `"auto"`. For a file that is both downloading and shared this upload priority is independent of the download priority reported by [`GET /api/v0/downloads`](#get-apiv0downloads).
 

--- a/src/webapi/Api.cpp
+++ b/src/webapi/Api.cpp
@@ -115,6 +115,21 @@ void SplitPathAndQuery(const std::string &target, std::string &path, std::string
 // Serialise the writer's buffer into the response body. Every JSON response in
 // this file goes through here -- open-coding it is how nine handlers came to
 // hold a stale copy of the conversion.
+// Emit `key` as a number, or as null when the value is not known.
+//
+// Six sites spelled this out as a four-line if/else, which is how one response
+// family came to carry four different spellings of "I don't know". The rule is
+// in REFERENCE.md under `Unknown values`; this is the one place that implements
+// it, so a seventh nullable field cannot quietly pick -1 or 0 instead.
+void WriteIntOrNull(CJsonWriter &w, const char *key, bool known, std::int64_t value)
+{
+	w.Key(key);
+	if (known)
+		w.ValueInt(value);
+	else
+		w.ValueNull();
+}
+
 void FinalizeJsonBody(CJsonWriter &w, CHttpServer::Response &r)
 {
 	// The writer already holds UTF-8, so this is a move, not a convert+copy.
@@ -1939,12 +1954,10 @@ CHttpServer::Response CApiDispatcher::HandleVersion(const CHttpServer::Request &
 		} else {
 			w.ValueNull();
 		}
-		w.Key("last_checked");
-		if (checked && status.version_check_timestamp > 0) {
-			w.ValueUInt(status.version_check_timestamp);
-		} else {
-			w.ValueNull();
-		}
+		WriteIntOrNull(w,
+			"last_checked",
+			checked && status.version_check_timestamp > 0,
+			static_cast<std::int64_t>(status.version_check_timestamp));
 		w.EndObject();
 	}
 	w.EndObject();
@@ -2520,18 +2533,12 @@ CHttpServer::Response CApiDispatcher::HandleStatus(const CHttpServer::Request &r
 	// same reason.
 	w.Key("disk");
 	w.BeginObject();
-	w.Key("temp_free_bytes");
-	if (s.temp_free_bytes < 0) {
-		w.ValueNull();
-	} else {
-		w.ValueInt(static_cast<int64_t>(s.temp_free_bytes));
-	}
-	w.Key("incoming_free_bytes");
-	if (s.incoming_free_bytes < 0) {
-		w.ValueNull();
-	} else {
-		w.ValueInt(static_cast<int64_t>(s.incoming_free_bytes));
-	}
+	WriteIntOrNull(
+		w, "temp_free_bytes", s.temp_free_bytes >= 0, static_cast<std::int64_t>(s.temp_free_bytes));
+	WriteIntOrNull(w,
+		"incoming_free_bytes",
+		s.incoming_free_bytes >= 0,
+		static_cast<std::int64_t>(s.incoming_free_bytes));
 	w.EndObject();
 
 	w.Key("queue");
@@ -2734,10 +2741,15 @@ void WriteDownloadObject(
 		// list. `part_count` and `remaining_time` are computed here from
 		// the snapshot — no EC tag exists for them.
 		const std::int64_t part_count = static_cast<std::int64_t>(webapi::PartCountForSize(f.size));
-		// ETA seconds; -1 when stalled/paused (speed ~0), mirroring the
-		// desktop getTimeRemaining().
-		std::int64_t remaining_time = -1;
+		// ETA seconds, or null when stalled/paused (speed ~0) and there is
+		// nothing to compute from. It was -1, which a client had to know
+		// meant "unknown" while the neighbouring unknowns on this surface
+		// used 0, an omitted key, and null. One rule: nullable field,
+		// unknown is null.
+		bool has_remaining_time = false;
+		std::int64_t remaining_time = 0;
 		if (f.download.speed_bps > 0) {
+			has_remaining_time = true;
 			remaining_time = (f.size > f.download.size_done)
 						 ? static_cast<std::int64_t>((f.size - f.download.size_done) /
 									     f.download.speed_bps)
@@ -2753,8 +2765,7 @@ void WriteDownloadObject(
 		w.ValueInt(static_cast<int64_t>(f.download.available_part_count));
 		w.Key("part_count");
 		w.ValueInt(part_count);
-		w.Key("remaining_time");
-		w.ValueInt(remaining_time);
+		WriteIntOrNull(w, "remaining_time", has_remaining_time, remaining_time);
 		w.Key("lost_to_corruption");
 		w.ValueInt(static_cast<int64_t>(f.download.lost_to_corruption));
 		w.Key("gained_by_compression");
@@ -3057,15 +3068,18 @@ void WriteSharedBaseFields(CJsonWriter &w, const webapi::FileSnapshot &f)
 	w.EndObject();
 	// Live upload activity (issue #466). `upload_speed_bps` + `uploading`
 	// refresh every tick; `last_upload` / `shared_since` are unix seconds,
-	// 0 = unknown (never uploaded / pre-feature known.met entry).
+	// null when unknown -- never uploaded, or a known.met entry that predates
+	// the field. They were 0, which reads as 1970 rather than "no idea".
 	w.Key("upload_speed_bps");
 	w.ValueInt(static_cast<int64_t>(f.shared.upload_speed_bps));
 	w.Key("uploading");
 	w.ValueInt(static_cast<int64_t>(f.shared.uploading_count));
-	w.Key("last_upload");
-	w.ValueInt(static_cast<int64_t>(f.shared.last_upload));
-	w.Key("shared_since");
-	w.ValueInt(static_cast<int64_t>(f.shared.shared_since));
+	WriteIntOrNull(
+		w, "last_upload", f.shared.last_upload != 0, static_cast<std::int64_t>(f.shared.last_upload));
+	WriteIntOrNull(w,
+		"shared_since",
+		f.shared.shared_since != 0,
+		static_cast<std::int64_t>(f.shared.shared_since));
 	// Parts hashed so far by a Verify Local Data or an AICH hashset rebuild
 	// over this share; 0 when idle. Goes through the accessor so a shared
 	// download, which amuled reports as a partfile, still reads correctly.

--- a/unittests/curl-tests/amuleapi/04-read-downloads-shared.sh
+++ b/unittests/curl-tests/amuleapi/04-read-downloads-shared.sh
@@ -156,8 +156,10 @@ if [ "$COUNT" -gt 0 ]; then
 	# Part-A detail fields (issue #417) — detail-only, type-tolerant.
 	_assert_json_eq '.part_count | type' number \
 		'/downloads/{hash} carries part_count'
-	_assert_json_eq '.remaining_time | type' number \
-		'/downloads/{hash} carries remaining_time'
+	# null when stalled/paused: nothing to compute an ETA from. It was -1,
+	# which a client had to know meant "unknown".
+	_assert_json_eq '(.remaining_time == null or (.remaining_time | type) == "number")' true \
+		'/downloads/{hash} remaining_time is a number or null'
 	_assert_json_eq '.aich_hash | type' string \
 		'/downloads/{hash} carries aich_hash'
 	_assert_json_eq '.met_file | type' string \
@@ -368,10 +370,11 @@ if [ "$SHCOUNT" -gt 0 ]; then
 		'/shared[0].upload_speed_bps is numeric (#466)'
 	_assert_json_eq '.shared[0].uploading | type' number \
 		'/shared[0].uploading is numeric (#466)'
-	_assert_json_eq '.shared[0].last_upload | type' number \
-		'/shared[0].last_upload is numeric (#466)'
-	_assert_json_eq '.shared[0].shared_since | type' number \
-		'/shared[0].shared_since is numeric (#466)'
+	# null when never uploaded, or on a known.met entry predating the field.
+	_assert_json_eq '(.shared[0].last_upload == null or (.shared[0].last_upload | type) == "number")' true \
+		'/shared[0].last_upload is a number or null (#466)'
+	_assert_json_eq '(.shared[0].shared_since == null or (.shared[0].shared_since | type) == "number")' true \
+		'/shared[0].shared_since is a number or null (#466)'
 	# Hashing progress on the shared row (issue #1054). Parts hashed so far
 	# by a Verify Local Data / AICH rebuild, 0 when idle. Only the type is
 	# asserted: a smoke run has no hash in flight, and racing one would make


### PR DESCRIPTION
Addresses §11 of #1107. The issue stays open for the rest.

One response family carried four conventions for "I don't know": `remaining_time` used `-1`, `status.disk.*_free_bytes` used `null`, `/search` omitted the key, and `shared[].last_upload` used `0`. Each had a local justification written down at the site, and a client still had to implement all four with nothing in a field's name or type saying which applied.

One rule: **a nullable field is `null` when the value is unknown**, and a key is omitted only where absence itself is the meaning, meaning something the daemon never reported rather than something known to be absent.

That moves two of the four. `remaining_time` is `null` rather than `-1` when there is no ETA to compute, and `last_upload` / `shared_since` are `null` rather than `0` when a file has never uploaded or its `known.met` entry predates the field, since `0` reads as 1970. The omissions on `/search` stay: `started_at` is missing for a search this process did not start, and `result_count` when the daemon is too old to send it, which has to stay distinguishable from a search that found nothing.

`REFERENCE.md` gains an `### Unknown values` section stating the rule once.

## One implementation, not seven

Six sites spelled the emit-or-null decision out as a four-line if/else, and unifying the *convention* while leaving the *mechanism* copied would have been half a fix: the four spellings of "I don't know" existed precisely because each site decided locally. They now go through one `WriteIntOrNull(w, key, known, value)`, so a seventh nullable field cannot quietly pick `-1` or `0` instead.

The two remaining raw `ValueNull()` calls are the helper itself and `update_available`, which is a bool at a single site.

## No frontend change needed

The shipped WebUI already handled this: `formatTimestamp` renders both `0` and `null` as a dash, sort values coerce with `|| 0`, and `download-detail.js` already tested `remaining_time == null` explicitly.

## Verification

Verified **on the wire**, not only through the assertions, which accept number-or-null and would have passed without the change:

| Field | Case | Wire |
|---|---|---|
| `last_upload` | never uploaded | `null` |
| `shared_since` | known | `1787655256` |
| `remaining_time` | stalled (`speed_bps: 0`) | `null` |

Three `| type == number` assertions in `04-read-downloads-shared.sh` pinned the old sentinels and now accept number-or-null. 204 assertions across `04`, `08`, `12` and `17` with 0 failures.

`ctest` 43/43, clang-format clean, Tier-2 clang-tidy clean on the diff with 0 compiler errors.
