### PR TITLE
fix(amuleapi): one envelope for every multi-item mutation

### DIFF
--- a/docs/api/REFERENCE.md
+++ b/docs/api/REFERENCE.md
@@ -257,7 +257,7 @@ Omitting all four parameters preserves the previous response exactly, plus the a
 
 ### Bulk mutations and the `results` envelope
 
-Every mutation that operates on more than one item — `POST /downloads`, `PATCH /downloads`, `DELETE /downloads`, `PATCH /shared` — reports one entry per input item under a unified `results` array, so a client submitting N items learns the fate of each rather than an aggregate counter or a first-error-only summary:
+Every mutation that operates on more than one item (`POST /downloads`, `PATCH /downloads`, `DELETE /downloads`, `PATCH /shared`, `POST /downloads/clear_completed`, `PUT /shared/directories`) reports one entry per input item under a unified `results` array, so a client submitting N items learns the fate of each rather than an aggregate counter or a first-error-only summary:
 
 ```json
 {
@@ -1069,10 +1069,10 @@ curl -s -X POST -H "Authorization: Bearer $TOKEN" \
 The response envelope is identical for both shapes:
 
 ```json
-{ "ok": true, "cleared": 3, "cleared_hashes": ["...", "...", "..."] }
+{ "results": [ { "id": "<md4>", "ok": true }, { "id": "<md4>", "ok": true } ] }
 ```
 
-Bulk form returns `200 OK` with `cleared: 0` and no `cleared_hashes` field when nothing matches (no-op success, distinguishable from an amuled rejection). Per-entry form returns `404 not_found` if the hash doesn't exist and `409 not_completed` if it exists but isn't on the completed staging list (active partfile — caller probably wants `DELETE /downloads/{hash}` instead).
+One entry per cleared hash, in the shared [`results` envelope](#bulk-mutations-and-the-results-envelope). Bulk form returns `200 OK` with an empty `results` array when nothing matches, which is the no-op and stays distinguishable from an amuled rejection (a 4xx with an error envelope). Per-entry form returns `404 not_found` if the hash does not exist and `409 not_completed` if it exists but is not on the completed staging list (an active partfile, where the caller probably wants `DELETE /downloads/{hash}` instead).
 
 **Errors:** `400 amuled_rejected`, `400 bad_request` (malformed body or non-string `hash`), `404 not_found`, `409 not_completed`, `503 ec_unavailable`.
 
@@ -1541,15 +1541,20 @@ curl -s -X PUT -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/j
 ```
 
 ```json
-{ "ok": true, "rejected": [] }
+{ "results": [ { "id": "/srv/share", "ok": true } ] }
 ```
 
 `recursive` is optional and defaults to `false`.
 
-amuled validates every path — a REST client cannot stat the core's filesystem, so a typo would otherwise become a silently dead share. Paths that pass are applied and persisted before the response returns; the rest come back in `rejected`, so **one bad entry does not discard the edit**:
+amuled validates every path: a REST client cannot stat the core's filesystem, so a typo would otherwise become a silently dead share. Paths that pass are applied and persisted before the response returns, and every submitted path gets an entry either way, so **one bad entry does not discard the edit** and a caller can tell an applied path from one the response simply did not mention. A response with any rejection is `207 Multi-Status`, as with every other multi-item mutation:
 
 ```json
-{ "ok": true, "rejected": [ { "path": "/typo", "reason": "not_found" } ] }
+{
+  "results": [
+    { "id": "/srv/share", "ok": true },
+    { "id": "/typo", "ok": false, "code": "not_found", "message": "no such directory" }
+  ]
+}
 ```
 
 `reason` is `not_found` (missing, or not a directory) or `not_readable`. amuled reports these as codes and the API renders them, so its locale never leaks into your response.

--- a/src/webapi/Api.cpp
+++ b/src/webapi/Api.cpp
@@ -5265,21 +5265,10 @@ CHttpServer::Response CApiDispatcher::HandleDownloadsClearCompleted(const CHttpS
 	}
 
 	if (ecids.empty()) {
-		// Nothing to do — return 200 with cleared:0 so consumers can
-		// distinguish "no-op" from "amuled rejected" (both end up
-		// with no visible change).
-		CHttpServer::Response r;
-		r.status = 200;
-		r.content_type = "application/json";
-		CJsonWriter w;
-		w.BeginObject();
-		w.Key("ok");
-		w.ValueBool(true);
-		w.Key("cleared");
-		w.ValueInt(0);
-		w.EndObject();
-		FinalizeJsonBody(w, r);
-		return r;
+		// Nothing to do. An empty `results` array is the no-op, and it stays
+		// distinguishable from "amuled rejected" -- which is a 4xx with an
+		// error envelope -- without needing a shape of its own.
+		return BulkResultsResponse({}, 200);
 	}
 
 	// One EC roundtrip with all ECIDs (per amulegui's pattern at
@@ -5303,24 +5292,16 @@ CHttpServer::Response CApiDispatcher::HandleDownloadsClearCompleted(const CHttpS
 	// show the post-clear state.
 	(void)RefresherTick(m_app, m_state);
 
-	CHttpServer::Response r;
-	r.status = 200;
-	r.content_type = "application/json";
-	CJsonWriter w;
-	w.BeginObject();
-	w.Key("ok");
-	w.ValueBool(true);
-	w.Key("cleared");
-	w.ValueInt(static_cast<int64_t>(ecids.size()));
-	w.Key("cleared_hashes");
-	w.BeginArray();
+	// One entry per hash, in the envelope every other multi-item mutation
+	// uses. `cleared` was a count and `cleared_hashes` a bare array, so a
+	// per-entry failure had nowhere to appear; the daemon clears them in one
+	// roundtrip today, but the shape no longer assumes that.
+	std::vector<BulkItem> results;
+	results.reserve(hashes_cleared.size());
 	for (const auto &h : hashes_cleared) {
-		w.ValueString(wxString::FromUTF8(h.c_str()));
+		results.push_back(BulkOk(h));
 	}
-	w.EndArray();
-	w.EndObject();
-	FinalizeJsonBody(w, r);
-	return r;
+	return BulkResultsResponse(results, 200);
 }
 
 // --- /servers, /kad, /categories, /preferences -------------------------
@@ -9256,35 +9237,36 @@ CHttpServer::Response ApplySharedDirs(CamuleapiApp &app, const std::vector<Share
 		return ErrorResponse(502, "amuled_rejected", ec_err_msg.c_str());
 	}
 
-	CHttpServer::Response r;
-	r.status = 200;
-	r.content_type = "application/json";
-	CJsonWriter w;
-	w.BeginObject();
-	w.Key("ok");
-	w.ValueBool(true);
-	// Paths the core would not take. Empty when everything applied; the reasons
-	// are rendered here rather than shipped as text from a core whose locale is
-	// not the caller's.
-	w.Key("rejected");
-	w.BeginArray();
+	// One entry per submitted path, in the envelope every other multi-item
+	// mutation uses. It reported only the rejects, in a shape of its own, so a
+	// caller could not tell an applied path from one the response simply did
+	// not mention. The reasons are still rendered here rather than shipped as
+	// text from a core whose locale is not the caller's.
+	std::map<std::string, std::string> rejected; // path -> reason code
 	for (const CECTag &tag : *ec_resp) {
 		if (tag.GetTagName() != EC_TAG_SHAREDDIR_REJECTED) {
 			continue;
 		}
 		const CECTag *err_tag = tag.GetTagByName(EC_TAG_SHAREDDIR_ERROR);
-		w.BeginObject();
-		w.Key("path");
-		w.ValueString(tag.GetStringData());
-		w.Key("reason");
-		w.ValueString((err_tag != nullptr && err_tag->GetInt() == 2) ? "not_readable" : "not_found");
-		w.EndObject();
+		rejected[std::string(tag.GetStringData().utf8_str())] =
+			(err_tag != nullptr && err_tag->GetInt() == 2) ? "not_readable" : "not_found";
 	}
-	w.EndArray();
-	w.EndObject();
 	delete ec_resp;
-	FinalizeJsonBody(w, r);
-	return r;
+
+	std::vector<BulkItem> results;
+	results.reserve(dirs.size());
+	for (const SharedDirEntry &entry : dirs) {
+		const std::string path(entry.path.utf8_str());
+		const auto it = rejected.find(path);
+		if (it == rejected.end()) {
+			results.push_back(BulkOk(path));
+		} else if (it->second == "not_readable") {
+			results.push_back(BulkErr(path, 403, "not_readable", "amuled cannot read that path"));
+		} else {
+			results.push_back(BulkErr(path, 404, "not_found", "no such directory"));
+		}
+	}
+	return BulkResultsResponse(results, 200);
 }
 } // namespace
 

--- a/unittests/curl-tests/amuleapi/13-downloads-delete-clear.sh
+++ b/unittests/curl-tests/amuleapi/13-downloads-delete-clear.sh
@@ -131,13 +131,17 @@ _assert_status 404 "DELETE /downloads/{nonexistent} → 404"
 _curl -X POST -H "Authorization: Bearer $ADMIN_TOKEN" \
 	"$HOST/api/v0/downloads/clear_completed"
 _assert_status 200 "POST /downloads/clear_completed (baseline) → 200"
-_assert_json_eq '.ok' true 'clear_completed baseline response.ok==true'
+# The shared results envelope has no top-level `ok`: per-item success lives on
+# each entry, so a partial outcome cannot be reported as a single boolean.
+_assert_json_eq '.results | type' array 'clear_completed returns a results array'
 
 # Second call: now nothing is completed. cleared must be 0.
 _curl -X POST -H "Authorization: Bearer $ADMIN_TOKEN" \
 	"$HOST/api/v0/downloads/clear_completed"
 _assert_status 200 "POST /downloads/clear_completed (idempotent no-op) → 200"
-_assert_json_eq '.cleared' 0 'clear_completed second call cleared 0 entries'
+# An empty `results` array is the no-op. It was `cleared: 0`, a shape only this
+# endpoint used.
+_assert_json_eq '.results | length' 0 'clear_completed second call cleared 0 entries'
 
 # --- 4. DELETE on an active partfile (happy path + no-stale GET). --
 #
@@ -273,9 +277,10 @@ if [ -n "$COMPLETED_HASH" ]; then
 		-d "{\"hash\":\"$COMPLETED_HASH\"}" \
 		"$HOST/api/v0/downloads/clear_completed"
 	_assert_status 200 "POST clear_completed {hash:completed} → 200"
-	_assert_json_eq '.cleared' 1 'per-hash clear_completed cleared exactly 1'
-	_assert_json_eq ".cleared_hashes[0]" "$COMPLETED_HASH" \
-		'cleared_hashes echoes the input hash'
+	_assert_json_eq '.results | length' 1 'per-hash clear_completed cleared exactly 1'
+	_assert_json_eq '.results[0].id' "$COMPLETED_HASH" \
+		'results[0].id echoes the input hash'
+	_assert_json_eq '.results[0].ok' true 'results[0] reports success'
 
 	# Second call → 404 (entry is gone).
 	_curl -X POST -H "Authorization: Bearer $ADMIN_TOKEN" \

--- a/unittests/curl-tests/amuleapi/31-shared-directories.sh
+++ b/unittests/curl-tests/amuleapi/31-shared-directories.sh
@@ -182,7 +182,7 @@ SCRATCH_ENC=$(jq -rn --arg p "$SCRATCH_DIR" '$p|@uri')
 _curl -X POST -H "Authorization: Bearer $ADMIN_TOKEN" -H "Content-Type: application/json" \
 	-d "{\"path\":\"$SCRATCH_DIR\",\"recursive\":true}" "$HOST/api/v0/shared/directories"
 SCRATCH_REJECTION=$(printf '%s' "$CURL_BODY" |
-	jq -r "[.rejected[] | select(.path==\"$SCRATCH_DIR\")][0].reason" 2>/dev/null)
+	jq -r "[.results[] | select(.id==\"$SCRATCH_DIR\" and .ok==false)][0].error.code" 2>/dev/null)
 SHARE_FS_VISIBLE=1
 case "$SCRATCH_REJECTION" in
 not_found | not_readable)
@@ -196,8 +196,8 @@ esac
 
 if [ "$SHARE_FS_VISIBLE" -eq 1 ]; then
 _assert_status 200 "POST (add scratch dir, recursive) → 200"
-_assert_json_eq '.ok' 'true' "POST reports ok"
-_assert_json_eq '.rejected | length' '0' "POST rejected nothing"
+_assert_json_eq '.results | type' array "POST returns a results array"
+_assert_json_eq '[.results[] | select(.ok==false)] | length' '0' "POST rejected nothing"
 
 _curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/shared/directories"
 _assert_json_eq \
@@ -227,9 +227,12 @@ fi # SHARE_FS_VISIBLE -- section 4
 BOGUS="$SCRATCH_DIR/definitely-not-here"
 _curl -X POST -H "Authorization: Bearer $ADMIN_TOKEN" -H "Content-Type: application/json" \
 	-d "{\"path\":\"$BOGUS\"}" "$HOST/api/v0/shared/directories"
-_assert_status 200 "POST (nonexistent path) → 200 with a rejection"
+# A rejection makes the whole response 207, as with every other multi-item
+# mutation. It was 200, which meant a caller had to read the body to learn that
+# part of the request had not applied.
+_assert_status 207 "POST (nonexistent path) → 207 with a rejection"
 _assert_json_eq \
-	"[.rejected[] | select(.path==\"$BOGUS\")][0].reason" 'not_found' \
+	"[.results[] | select(.id==\"$BOGUS\")][0].error.code" 'not_found' \
 	"nonexistent path rejected as not_found"
 
 _curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/shared/directories"


### PR DESCRIPTION
Addresses §9 of #1107. The issue stays open for §7, §8, §10, §12, §13, §15 and §16.

Four routes reported per-item outcomes under `results[]`. Two more did the same job in shapes of their own: `clear_completed` answered `{ok, cleared, cleared_hashes[]}` and `PUT /shared/directories` answered `{ok, rejected[{path, reason}]}`. Both now use the shared envelope.

**The directories case is the one that actually cost a caller something.** It listed only the rejects, so an applied path and a path the response simply did not mention were indistinguishable. Every submitted path now gets an entry either way, and the reasons carry through as the per-item `error.code` (`not_found` / `not_readable`) rather than a `reason` field this endpoint alone used.

`clear_completed` loses `cleared` and `cleared_hashes`: the count is the array length and the hashes are the ids. A per-entry failure now has somewhere to appear. The daemon clears them in one roundtrip today so nothing *can* fail individually, but the shape no longer assumes that. The no-op is an empty `results` array, still distinguishable from an amuled rejection, which is a 4xx with an error envelope.

## Behaviour change

A partial rejection on `PUT /shared/directories` is `207`, not `200`, matching every other multi-item mutation. All-OK statuses are unchanged: `POST /downloads` stays `202` because the daemon does that work later, and the rest stay `200`.

## Verification

85 assertions across `13`, `29` and `31` with 0 failures, including the new `207` and the per-item `error.code` on a nonexistent path.

`ctest` 43/43, clang-format clean, Tier-2 clang-tidy clean on the diff with 0 compiler errors.

Five assertions pinned the old shapes. Worth recording that **two of my replacements were wrong on the first pass**: the envelope has no top-level `ok`, and per-item errors nest under `error.code` rather than `code`. `29-bulk-mutations` was the working reference for both, and the corrected assertions now match it.
