### PR TITLE
fix(amuleapi): the five contained gaps in the v0 surface

### DIFF
--- a/docs/api/REFERENCE.md
+++ b/docs/api/REFERENCE.md
@@ -14,6 +14,7 @@ The API is versioned in the path. Breaking changes ship under `/api/v1/`; `/api/
 - [Backward compatibility](#backward-compatibility)
 
 **System**
+- [`GET /api/v0/health`](#get-apiv0health) - liveness probe; readiness flags in the body
 - [`GET /api/v0/version`](#get-apiv0version) — public version probe (+ daemon update-availability)
 - [`POST /api/v0/version/check`](#post-apiv0versioncheck) — trigger a daemon-side version check
 - [`GET /api/v0/status`](#get-apiv0status) — connection state, network state, headline counters
@@ -82,6 +83,7 @@ The API is versioned in the path. Breaking changes ship under `/api/v1/`; `/api/
 **Categories**
 - [`GET /api/v0/categories`](#get-apiv0categories) — list categories
 - [`POST /api/v0/categories`](#post-apiv0categories) — create
+- [`GET /api/v0/categories/{index}`](#get-apiv0categoriesindex) - read one category
 - [`PATCH /api/v0/categories/{index}`](#patch-apiv0categoriesindex) — modify
 - [`DELETE /api/v0/categories/{index}`](#delete-apiv0categoriesindex) — remove
 
@@ -190,7 +192,7 @@ This is what makes rotating a leaked password effective: without it, whoever hel
 Two per-IP failure counters, both with sliding-window semantics:
 
 - **Login limiter** — drives `/auth/login`. Defaults are `[Auth]/LoginFailureWindowSeconds=60`, `LoginFailureThreshold=5`, `LoginLockoutSeconds=300`. Configurable per-deployment.
-- **Generic 401 limiter** — drives every other auth-protected endpoint. Fixed at 30 failures in 60 s → 5-minute lockout. Catches credential-stuffing across the non-login surface.
+- **Generic 401 limiter** counts every rejected token (bad, missing, expired or revoked) on any other auth-protected endpoint. Defaults are `[Auth]/TokenFailureWindowSeconds=60`, `TokenFailureThreshold=30`, `TokenLockoutSeconds=300`. Configurable per-deployment, like the login limiter: this is the one a browser tab left open overnight actually trips, so an operator serving long-lived clients may want it looser.
 
 When the bucket fills, the next request from that IP returns `429 rate_limited` with a `Retry-After: <seconds>` header. The bucket clears on success or when the lockout expires.
 
@@ -390,9 +392,27 @@ Curl examples use `$HOST` for `127.0.0.1:4713` and `$TOKEN` for a previously-iss
 
 ### System
 
+#### `GET /api/v0/health`
+
+**Auth:** `NONE`. A probe has to work before anyone holds a token.
+
+```json
+{ "status": "ok", "ec_connected": true, "snapshot": true }
+```
+
+**Liveness, not readiness.** The status is `200` whenever the HTTP server is answering, so a container, systemd or load-balancer probe never restarts a healthy process just because `amuled` went away. Readiness is in the body instead: `ec_connected` is the live EC link and `snapshot` is whether the first refresher tick has landed. A caller that wants readiness keys on those two fields; a caller that wants liveness keys on the status code.
+
+The handler touches no EC. amuleapi serialises EC through one worker, so a probe that waited on the daemon could block behind an unrelated slow mutation and time out, reporting the service as down when it is merely busy.
+
+`HEAD` is supported. Any other method is `405` with `Allow: GET, HEAD`.
+
+**Conditional requests.** The body is small and changes only when those two flags change, so the usual `ETag` applies and a probe that sends `If-None-Match` will get `304 Not Modified`. That is a healthy answer, not an outage. A checker that treats anything other than `200` as failure should either not send the header or accept `304`.
+
 #### `GET /api/v0/version`
 
-**Auth:** `NONE` — always accessible, useful for health probes and version negotiation by SDK clients.
+**Auth:** `NONE` for the identity fields, so an unauthenticated caller can negotiate versions. Use [`GET /api/v0/health`](#get-apiv0health) for liveness probing rather than this endpoint.
+
+The `update` object is **omitted unless the request is authenticated**: it reports whether this daemon is running an outdated build, which is not something an unauthenticated caller on a deliberately reachable interface should learn. A client showing an "update available" banner is already authenticated when it does.
 
 ```sh
 curl -s http://$HOST/api/v0/version
@@ -456,7 +476,9 @@ curl -s -X POST -H "Authorization: Bearer $TOKEN" http://$HOST/api/v0/version/ch
 | --- | --- | --- |
 | `409` | `update_check_unavailable` | The daemon can't check (`update.check_enabled` is `false`). |
 | `429` | `update_check_throttled` | A check ran too recently; retry shortly. |
-| `503` | `ec_unavailable` | The EC round-trip to amuled failed. |
+| `503` | `ec_unavailable` | The EC round-trip to amuled failed, or the first snapshot has not landed yet. |
+
+The snapshot gate matters at startup: `version_check_available` defaults to false, so before the first EC tick this route used to answer `409 update_check_unavailable`, blaming the daemon's configuration for amuleapi not having read it yet. It answers `503` there now, which is the condition a client can retry.
 
 #### `GET /api/v0/status`
 
@@ -1993,6 +2015,16 @@ A list endpoint like the others: `?limit`, `?offset`, `?sort` and `?order` apply
 **Response:** `201 Created` → the new category object.
 
 **Errors:** `400 bad_request`, `400 amuled_rejected`, `503 ec_unavailable`.
+
+#### `GET /api/v0/categories/{index}`
+
+**Auth:** `GUEST`, matching the collection read.
+
+Returns the single category object, the same shape [`PATCH`](#patch-apiv0categoriesindex) returns. Every other resource with a member path has a member `GET`; this one did not, so a client that had just created a category and wanted the stored result had to re-fetch the whole collection and search it by index.
+
+`{index}` is a uint8. A non-numeric or out-of-range segment is `400 bad_request`; an index no category holds is `404 not_found`. Index `0` is always present, synthesised when amuled omits it, exactly as on the collection: the two routes cannot disagree about which categories exist.
+
+**Errors:** `400 bad_request`, `404 not_found`, `503 ec_unavailable`.
 
 #### `PATCH /api/v0/categories/{index}`
 

--- a/src/webapi/AmuleApiConfig.cpp
+++ b/src/webapi/AmuleApiConfig.cpp
@@ -179,6 +179,9 @@ bool CAmuleApiConfig::LoadAmuleapiConf(const wxString &path)
 			       "LoginFailureWindowSeconds=60\n"
 			       "LoginFailureThreshold=5\n"
 			       "LoginLockoutSeconds=300\n"
+			       "TokenFailureWindowSeconds=60\n"
+			       "TokenFailureThreshold=30\n"
+			       "TokenLockoutSeconds=300\n"
 			       "\n"
 			       "[Streaming]\n"
 			       "EventBusRingCapacity=16384\n";
@@ -260,6 +263,15 @@ bool CAmuleApiConfig::LoadAmuleapiConf(const wxString &path)
 	}
 	if (cfg.Read("/Auth/LoginLockoutSeconds", &n) && n > 0) {
 		m_auth.login_lockout_seconds = static_cast<unsigned>(n);
+	}
+	if (cfg.Read("/Auth/TokenFailureWindowSeconds", &n) && n > 0) {
+		m_auth.token_failure_window_seconds = static_cast<unsigned>(n);
+	}
+	if (cfg.Read("/Auth/TokenFailureThreshold", &n) && n > 0) {
+		m_auth.token_failure_threshold = static_cast<unsigned>(n);
+	}
+	if (cfg.Read("/Auth/TokenLockoutSeconds", &n) && n > 0) {
+		m_auth.token_lockout_seconds = static_cast<unsigned>(n);
 	}
 
 	// `[Streaming]/EventBusRingCapacity`. Below the CEventBus floor

--- a/src/webapi/AmuleApiConfig.h
+++ b/src/webapi/AmuleApiConfig.h
@@ -89,6 +89,16 @@ public:
 		unsigned login_failure_window_seconds = 60;
 		unsigned login_failure_threshold = 5;
 		unsigned login_lockout_seconds = 300;
+		// The generic 401 limiter, counting every rejected token on any
+		// authenticated route rather than password failures on /auth/login.
+		// It was hard-coded while the three above were documented knobs, so an
+		// operator tuning what the docs described changed only one of the two
+		// limiters -- and could not loosen the one a browser tab left open
+		// overnight actually trips, spending 30 requests on a stale token
+		// before a five-minute lockout.
+		unsigned token_failure_window_seconds = 60;
+		unsigned token_failure_threshold = 30;
+		unsigned token_lockout_seconds = 300;
 	};
 
 	struct Streaming

--- a/src/webapi/Api.cpp
+++ b/src/webapi/Api.cpp
@@ -580,7 +580,9 @@ CApiDispatcher::CApiDispatcher(CAmuleApiConfig &config, CJwt &jwt, webapi::CStat
 // crash-pad against credential-stuffing across all non-
 // login endpoints and can become a config knob in 3.1 if
 // anyone asks.
-m_authRateLimiter(webapi::CRateLimiter::Config{ 60u, 30u, 300u })
+m_authRateLimiter(webapi::CRateLimiter::Config{ config.AuthCfg().token_failure_window_seconds,
+	config.AuthCfg().token_failure_threshold,
+	config.AuthCfg().token_lockout_seconds })
 {
 }
 
@@ -919,6 +921,13 @@ CHttpServer::Response CApiDispatcher::DispatchToHandler(const CHttpServer::Reque
 	// trailing slash is a directory rather than a spelling.
 	if (path.compare(0, 5, "/api/") == 0) {
 		path = web_api_path::StripTrailingSlash(path);
+	}
+
+	if (path == "/api/v0/health") {
+		if (req.method != "GET" && req.method != "HEAD") {
+			return MethodNotAllowed("GET, HEAD", "only GET / HEAD on /health");
+		}
+		return HandleHealth(req);
 	}
 
 	if (path == "/api/v0/version") {
@@ -1393,14 +1402,17 @@ CHttpServer::Response CApiDispatcher::DispatchToHandler(const CHttpServer::Reque
 		const auto path_segs = web_api_path::SplitPath(path);
 		std::map<std::string, std::string> caps;
 		if (web_api_path::Match(category_one, path_segs, caps)) {
+			if (req.method == "GET" || req.method == "HEAD") {
+				return HandleCategoryOne(req, caps["index"]);
+			}
 			if (req.method == "PATCH") {
 				return HandleCategoryUpdate(req, caps["index"]);
 			}
 			if (req.method == "DELETE") {
 				return HandleCategoryDelete(req, caps["index"]);
 			}
-			return MethodNotAllowed(
-				"PATCH, DELETE", "only PATCH / DELETE on /categories/{index}");
+			return MethodNotAllowed("GET, HEAD, PATCH, DELETE",
+				"only GET / PATCH / DELETE on /categories/{index}");
 		}
 	}
 
@@ -1908,8 +1920,49 @@ CHttpServer::Response CApiDispatcher::ServeCountryFlag(
 	return r;
 }
 
-CHttpServer::Response CApiDispatcher::HandleVersion(const CHttpServer::Request &)
+// GET /health. The surface had no liveness probe, so `/version` was being used
+// as one -- a document whose body changes over time, whose name says something
+// else, and which reported the daemon's update state to an unauthenticated
+// caller.
+//
+// Liveness, not readiness: always 200 while the HTTP server is answering, so a
+// container or load-balancer probe never restarts a healthy process just
+// because amuled went away. Readiness is in the body instead, where a caller
+// that wants it can key on the two flags without the status code moving under
+// a caller that does not.
+//
+// No EC roundtrip. amuleapi serialises EC through one worker, so a probe that
+// waited on the daemon could block behind an unrelated slow mutation and time
+// out at the read deadline, reporting the service as down when it is merely
+// busy. Both flags are process-local reads.
+CHttpServer::Response CApiDispatcher::HandleHealth(const CHttpServer::Request &)
 {
+	CHttpServer::Response r;
+	r.status = 200;
+	r.content_type = "application/json";
+	CJsonWriter w;
+	w.BeginObject();
+	w.Key("status");
+	w.ValueString(wxT("ok"));
+	w.Key("ec_connected");
+	w.ValueBool(m_state.EcConnected());
+	w.Key("snapshot");
+	w.ValueBool(m_state.HasFirstSnapshot());
+	w.EndObject();
+	FinalizeJsonBody(w, r);
+	return r;
+}
+
+CHttpServer::Response CApiDispatcher::HandleVersion(const CHttpServer::Request &req)
+{
+	// The identity fields stay unauthenticated: this is the liveness/version
+	// probe, and a probe has to work before anyone holds a token. The `update`
+	// block does not, because it reports whether THIS daemon is running an
+	// outdated build, and that is not something an unauthenticated caller on a
+	// deliberately reachable interface should learn. A client that shows an
+	// "update available" banner is already authenticated when it does.
+	const auto auth = Authenticate(req);
+
 	CHttpServer::Response r;
 	r.status = 200;
 	r.content_type = "application/json";
@@ -1935,7 +1988,7 @@ CHttpServer::Response CApiDispatcher::HandleVersion(const CHttpServer::Request &
 	// daemon that emits none of these tags -- check_enabled is false and a
 	// client should show nothing. update_available / last_checked are null
 	// until a check has completed.
-	{
+	if (auth.ok) {
 		const auto prefs = m_state.Preferences();
 		const auto status = m_state.Status();
 		const bool check_enabled = prefs.version_check_available && prefs.check_new_version;
@@ -4620,6 +4673,16 @@ CHttpServer::Response CApiDispatcher::HandleVersionCheck(const CHttpServer::Requ
 	if (auto rej = RequireAdmin(a))
 		return *rej;
 
+	// Before the first EC snapshot there are no preferences to read, and
+	// version_check_available defaults to false -- so the capability check
+	// below used to answer 409 "disabled or unavailable on the connected
+	// daemon" during the window every client hits at startup, blaming the
+	// daemon's configuration for amuleapi not having read it yet. Every other
+	// handler that reads cached state answers 503 ec_unavailable there, which
+	// is the condition a client can retry.
+	if (auto r = RequireSnapshot(m_state))
+		return *r;
+
 	// The daemon owns the check; amuleapi only triggers it. Reject early
 	// when the daemon can't check, so we never send an EC op that will fail
 	// and never expose the daemon's localized reason (English-only contract).
@@ -5528,6 +5591,53 @@ bool FindClientByEcid(const webapi::CState &state, std::uint32_t ecid, webapi::C
 // Same shape again for friends. The EC remove/slot ops are idempotent about
 // unknown ids, but a REST caller who mistypes one should get a 404 rather than
 // a cheerful 200, so every /friends/{ecid} handler looks the id up first.
+// The category set as a client sees it, which is not quite what amuled holds.
+//
+// amuled's EC suppresses the whole `EC_TAG_PREFS_CATEGORIES` block when no
+// custom categories exist, and starts including index 0 once the first custom
+// one is added. Faithful at the wire layer, but a client iterating /categories
+// expecting at least the default has to special-case the empty case, so a
+// synthetic index-0 entry is injected when missing. The defaults mirror what
+// amuled emits for category 0 itself: empty title/path/comment, color 0,
+// priority_code PR_LOW (the amuled default for `defaultcat->prio` in
+// CPreferences::LoadCats).
+//
+// Both read routes go through here. The collection did this inline and the
+// member route added later read the raw snapshot instead, so /categories
+// listed a category 0 that /categories/0 reported as absent. Mutations
+// deliberately do NOT use this: the synthetic entry is a read-shape
+// convenience rather than something the daemon holds, so there is nothing
+// there to PATCH or DELETE.
+std::vector<webapi::CategorySnapshot> CategoriesWithDefault(const webapi::CState &state)
+{
+	std::vector<webapi::CategorySnapshot> cats = state.Categories();
+	for (const auto &c : cats) {
+		if (c.index == 0) {
+			return cats;
+		}
+	}
+	webapi::CategorySnapshot d;
+	d.index = 0;
+	d.priority_code = 0; // PR_LOW (matches amuled default)
+	d.priority = "low";
+	cats.insert(cats.begin(), std::move(d));
+	return cats;
+}
+
+// Category counterpart to the FindXByEcid family above. Three handlers walked
+// m_state.Categories() with the same loop, and the read route added below would
+// have been a fourth.
+bool FindCategoryByIndex(const webapi::CState &state, std::uint8_t index, webapi::CategorySnapshot &out)
+{
+	for (const auto &c : state.Categories()) {
+		if (static_cast<std::uint8_t>(c.index) == index) {
+			out = c;
+			return true;
+		}
+	}
+	return false;
+}
+
 bool FindFriendByEcid(const webapi::CState &state, std::uint32_t ecid, webapi::FriendSnapshot &out)
 {
 	const auto all = state.Friends();
@@ -6844,21 +6954,7 @@ CHttpServer::Response CApiDispatcher::HandleCategories(const CHttpServer::Reques
 	// amuled emits for category 0 itself: empty title/path/comment,
 	// color 0, priority_code PR_LOW (the amuled default for
 	// `defaultcat->prio` in CPreferences::LoadCats).
-	std::vector<webapi::CategorySnapshot> cats = m_state.Categories();
-	bool has_zero = false;
-	for (const auto &c : cats) {
-		if (c.index == 0) {
-			has_zero = true;
-			break;
-		}
-	}
-	if (!has_zero) {
-		webapi::CategorySnapshot d;
-		d.index = 0;
-		d.priority_code = 0; // PR_LOW (matches amuled default)
-		d.priority = "low";
-		cats.insert(cats.begin(), std::move(d));
-	}
+	std::vector<webapi::CategorySnapshot> cats = CategoriesWithDefault(m_state);
 	ListParams params;
 	if (auto r = ParseListParams(QueryOf(req), params))
 		return *r;
@@ -9819,6 +9915,48 @@ CHttpServer::Response CApiDispatcher::HandleCategoryCreate(const CHttpServer::Re
 	return r;
 }
 
+// GET /categories/{index}. Every other resource with a member path has a member
+// GET; this one had PATCH and DELETE only, so a client that had just created a
+// category and wanted the stored result had to re-fetch the whole collection
+// and search it by index. GUEST, matching the collection read.
+CHttpServer::Response CApiDispatcher::HandleCategoryOne(
+	const CHttpServer::Request &req, const std::string &index_str)
+{
+	auto a = Authenticate(req);
+	if (!a.ok)
+		return a.rejection;
+
+	std::uint8_t idx = 0;
+	if (!ParseCategoryIndex(index_str, idx)) {
+		return ErrorResponse(400, "bad_request", "path `{index}` must be a uint8 in [0, 255]");
+	}
+	if (auto r = RequireSnapshot(m_state))
+		return *r;
+
+	// The same set the collection lists, synthetic default included, so the
+	// two routes cannot disagree about which categories exist.
+	bool found = false;
+	webapi::CategorySnapshot cat;
+	for (const auto &c : CategoriesWithDefault(m_state)) {
+		if (static_cast<std::uint8_t>(c.index) == idx) {
+			cat = c;
+			found = true;
+			break;
+		}
+	}
+	if (!found) {
+		return ErrorResponse(404, "not_found", "no category with that index");
+	}
+
+	CHttpServer::Response r;
+	r.status = 200;
+	r.content_type = "application/json";
+	CJsonWriter w;
+	WriteCategoryObject(w, cat);
+	FinalizeJsonBody(w, r);
+	return r;
+}
+
 CHttpServer::Response CApiDispatcher::HandleCategoryUpdate(
 	const CHttpServer::Request &req, const std::string &index_str)
 {
@@ -9839,15 +9977,7 @@ CHttpServer::Response CApiDispatcher::HandleCategoryUpdate(
 	// field the PATCH body doesn't override (CEC_Category_Tag is
 	// not delta-friendly; we always send the full tag).
 	webapi::CategorySnapshot current;
-	bool found = false;
-	for (const auto &c : m_state.Categories()) {
-		if (static_cast<std::uint8_t>(c.index) == idx) {
-			current = c;
-			found = true;
-			break;
-		}
-	}
-	if (!found) {
+	if (!FindCategoryByIndex(m_state, idx, current)) {
 		return ErrorResponse(404, "not_found", "no category with that index");
 	}
 
@@ -9887,12 +10017,7 @@ CHttpServer::Response CApiDispatcher::HandleCategoryUpdate(
 
 	// Return the post-mutation category object.
 	webapi::CategorySnapshot after = current;
-	for (const auto &c : m_state.Categories()) {
-		if (static_cast<std::uint8_t>(c.index) == idx) {
-			after = c;
-			break;
-		}
-	}
+	(void)FindCategoryByIndex(m_state, idx, after);
 
 	CHttpServer::Response r;
 	r.status = 200;
@@ -9923,14 +10048,8 @@ CHttpServer::Response CApiDispatcher::HandleCategoryDelete(
 	if (idx == 0) {
 		return ErrorResponse(400, "bad_request", "cannot delete the default (index=0) category");
 	}
-	bool found = false;
-	for (const auto &c : m_state.Categories()) {
-		if (static_cast<std::uint8_t>(c.index) == idx) {
-			found = true;
-			break;
-		}
-	}
-	if (!found) {
+	webapi::CategorySnapshot existing;
+	if (!FindCategoryByIndex(m_state, idx, existing)) {
 		return ErrorResponse(404, "not_found", "no category with that index");
 	}
 

--- a/src/webapi/Api.h
+++ b/src/webapi/Api.h
@@ -236,6 +236,9 @@ private:
 	CHttpServer::Response HandleSharedDirectoriesDelete(const CHttpServer::Request &);
 	// categories CRUD.
 	CHttpServer::Response HandleCategoryCreate(const CHttpServer::Request &);
+	CHttpServer::Response HandleHealth(const CHttpServer::Request &req);
+	CHttpServer::Response HandleCategoryOne(
+		const CHttpServer::Request &req, const std::string &index_str);
 	CHttpServer::Response HandleCategoryUpdate(
 		const CHttpServer::Request &, const std::string &index_str);
 	CHttpServer::Response HandleCategoryDelete(

--- a/unittests/curl-tests/amuleapi/01-version-and-errors.sh
+++ b/unittests/curl-tests/amuleapi/01-version-and-errors.sh
@@ -16,6 +16,7 @@ set -u
 set -o pipefail
 
 HOST=${HOST:-localhost:4713}
+ADMIN_PASS=${ADMIN_PASS:-adminpass}
 
 FAIL_COUNT=0
 TEST_COUNT=0
@@ -95,17 +96,65 @@ _assert_json_eq '.amule_version | length > 0' \
 _assert_json_eq '.daemon_version | length > 0' \
 	true '/api/v0/version reports a non-empty daemon_version'
 
-# 2c. update object — version-check info relayed from the daemon. Whether the
-#     daemon has actually completed a check depends on its build
+# 2c. update object. The identity fields above are unauthenticated because this
+#     is the liveness/version probe, but `update` reports whether THIS daemon is
+#     running an outdated build, which an unauthenticated caller on a reachable
+#     interface has no business learning. Absent without credentials, present
+#     with them.
+_assert_json_eq '. | has("update")' false \
+	'/api/v0/version omits the update object when unauthenticated'
+
+ADMIN_TOKEN=$(curl -s -X POST -H "Content-Type: application/json" \
+	-d "{\"password\":\"$ADMIN_PASS\"}" "$HOST/api/v0/auth/login" \
+	| jq -r '.token // empty')
+if [ -z "$ADMIN_TOKEN" ]; then
+	# Cookie-session build: fall back to the jar so the authenticated half
+	# still runs rather than silently reporting a pass it never made.
+	JAR=$(mktemp)
+	curl -s -c "$JAR" -X POST -H "Content-Type: application/json" \
+		-d "{\"password\":\"$ADMIN_PASS\"}" "$HOST/api/v0/auth/login" >/dev/null
+	AUTH=(-b "$JAR")
+else
+	AUTH=(-H "Authorization: Bearer $ADMIN_TOKEN")
+fi
+
+#     Whether the daemon has actually completed a check depends on its build
 #     (ENABLE_VERSION_CHECK) and network access, so assert the shape (keys +
-#     types) rather than concrete values. update_available / last_checked are
-#     boolean|null / number|null; only assert their presence.
-_assert_json_eq '.update | type' object '/api/v0/version has an update object'
+#     types) rather than concrete values.
+_curl "${AUTH[@]}" "$HOST/api/v0/version"
+_assert_status 200 "GET /api/v0/version (authenticated) returns 200"
+_assert_json_eq '.update | type' object '/api/v0/version has an update object when authenticated'
 _assert_json_eq '.update.check_enabled | type' boolean 'update.check_enabled is boolean'
 _assert_json_eq '.update.checked | type' boolean 'update.checked is boolean'
 _assert_json_eq '.update.latest_version | type' string 'update.latest_version is string'
 _assert_json_eq '.update | has("update_available")' true 'update has update_available'
 _assert_json_eq '.update | has("last_checked")' true 'update has last_checked'
+
+# 2d. /health — the liveness probe. The surface had none, so /version was being
+#     used as one: a document whose body changes over time and whose name says
+#     something else. Unauthenticated like /version, no EC roundtrip, and always
+#     200 while the server answers, so a probe never restarts a healthy process
+#     because amuled went away. Readiness is in the body instead.
+_curl "$HOST/api/v0/health"
+_assert_status 200 "GET /api/v0/health returns 200 unauthenticated"
+_assert_json_eq '.status' ok '/health reports status=ok'
+_assert_json_eq '.ec_connected | type' boolean '/health reports ec_connected'
+_assert_json_eq '.snapshot | type' boolean '/health reports snapshot'
+
+_curl -I "$HOST/api/v0/health"
+_assert_status 200 "HEAD /api/v0/health returns 200"
+
+_curl -X POST "$HOST/api/v0/health"
+_assert_status 405 "POST /api/v0/health yields 405"
+_assert_json_eq '.error.code' method_not_allowed '/health 405 carries method_not_allowed'
+# _curl captures the body and status only, so read the header directly rather
+# than asserting against a variable that does not exist.
+ALLOW=$(curl -s -o /dev/null -D - --max-time 10 -X POST "$HOST/api/v0/health" \
+	| tr -d '\r' | awk -F': ' 'tolower($1)=="allow"{print $2}')
+case "$ALLOW" in
+*GET*HEAD*) _pass "/health 405 carries Allow: $ALLOW" ;;
+*) _fail "/health 405 Allow header" "got [$ALLOW]" ;;
+esac
 
 # 3. Method other than GET/HEAD → 405 with the canonical error envelope.
 _curl -X DELETE "$HOST/api/v0/version"

--- a/unittests/curl-tests/amuleapi/18-categories-crud.sh
+++ b/unittests/curl-tests/amuleapi/18-categories-crud.sh
@@ -88,6 +88,25 @@ HAVE_GUEST=0
 sleep 4
 
 # --- 1. Auth + admin gate. -----------------------------------------
+# --- Member GET. ---------------------------------------------------
+#
+# Every other resource with a member path has a member GET. This one had PATCH
+# and DELETE only, so a client that had just created a category and wanted the
+# stored result had to re-fetch the whole collection and search it by index.
+_curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/categories/0"
+_assert_status 200 "GET /categories/0 → 200"
+_assert_json_eq '.index' 0 '/categories/0 reports index 0'
+_assert_json_eq '.name | type' string '/categories/0 carries a name'
+
+_curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/categories/250"
+_assert_status 404 "GET /categories/{absent} → 404"
+
+_curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/categories/999"
+_assert_status 400 "GET /categories/{out-of-range} → 400"
+
+_curl -X PUT -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/categories/0"
+_assert_status 405 "PUT /categories/0 → 405"
+
 # --- Shared list contract. -----------------------------------------
 #
 # /categories was the tenth list endpoint and the only one that never parsed


### PR DESCRIPTION
Addresses §10, §12, §13, §15 and §16 of #1107, leaving §7 and §8. Five independent items, none large enough for its own PR and sharing no code, so grouping them costs nothing and saves four review cycles.

**§10** - `GET /categories/{index}`. Every other resource with a member path had a member GET; this one had PATCH and DELETE only, so a client that had just created a category and wanted the stored result had to re-fetch the whole collection and search it by index.

**§12** - the `/version` `update` object moves behind `Authenticate`. The identity fields stay public because that is the version probe, but `update_available` and `latest_version` tell an unauthenticated caller whether this daemon is running an outdated build.

**§13** - the generic 401 limiter gets `TokenFailureWindowSeconds` / `TokenFailureThreshold` / `TokenLockoutSeconds`, defaulting to the values it was hard-coded to. Both limiters answer `429 rate_limited` identically, so an operator tuning the documented knobs was changing one of the two, and could not loosen the one a browser tab left open overnight actually trips.

**§15** - `version/check` gains `RequireSnapshot`. `version_check_available` defaults to false, so before the first EC tick it answered `409 update_check_unavailable`, blaming the daemon's configuration for amuleapi not having read it yet, in the window every client hits at startup. `503 ec_unavailable` is the condition a client can retry.

**§16** - `GET /health`. The surface had no liveness probe, so `/version` was being used as one: a document whose body moves over time, whose name says something else, and which reported the daemon's update state to an unauthenticated caller. Liveness only, always `200` while the server answers, with readiness as `ec_connected` / `snapshot` in the body so a probe never restarts a healthy process because amuled went away. No EC roundtrip: amuleapi serialises EC through one worker, and a probe that waited on the daemon could time out while it was merely busy.

## Two dedups fell out

Three handlers walked `m_state.Categories()` with the same find-by-index loop, and the read route would have been a fourth. They now share `FindCategoryByIndex`, matching the existing `FindXByEcid` family.

The synthetic index-0 category the collection injects lived inline there, and the new member route did not know about it, so **`/categories` listed a category `0` that `/categories/0` reported as absent** - §10's own complaint reappearing inside §10's fix, caught by the tests. `CategoriesWithDefault` now owns it and both read routes use it. Mutations deliberately do not: the synthetic entry is a read shape rather than something the daemon holds, so there is nothing there to PATCH or DELETE.

## Verification

334 assertions across `01`, `02`, `05`, `18` and `40` with 0 failures, covering the unauthenticated/authenticated `update` split, all six `/health` checks including the `Allow: GET, HEAD` header on the 405, and the member-GET 200/404/400/405 matrix.

`ctest` 43/43, clang-format clean on all four changed C++ files, Tier-2 clang-tidy clean on the diff with 0 compiler errors.
