### PR TITLE
fix(webapi): resolve a peer's file by ECID instead of copying an index of the library

### DIFF
--- a/src/webapi/Refresher.cpp
+++ b/src/webapi/Refresher.cpp
@@ -803,10 +803,7 @@ void DecodePartStatusTag(const CECTag *client_tag,
 // On a cache-miss the caller pre-populates ecid + hashes; on a hit
 // the AssignIfExist pattern leaves cached values intact when the
 // tag is CValueMap-suppressed by amuled.
-void MergeClientTag(const CEC_UpDownClient_Tag *c,
-	ClientSnapshot &cs,
-	bool is_new,
-	const std::map<std::uint32_t, std::string> &file_hash_by_ecid)
+void MergeClientTag(const CEC_UpDownClient_Tag *c, ClientSnapshot &cs, bool is_new, const FileMap &files)
 {
 	if (const CECTag *t = c->GetTagByName(EC_TAG_CLIENT_NAME)) {
 		cs.client_name = std::string(t->GetStringData().utf8_str());
@@ -889,10 +886,10 @@ void MergeClientTag(const CEC_UpDownClient_Tag *c,
 		cs.download_file_name = std::string(fn.utf8_str());
 	}
 	// UPLOAD_FILE / REQUEST_FILE carry amuled-side ECIDs (the unified
-	// m_FileEncoder map's IDs). Resolve to MD4 hashes via the
-	// file_hash_by_ecid snapshot the caller built from m_files this
-	// tick. Empty hash if the ECID isn't in the map — file may have
-	// been removed between the file walkers and this client walker.
+	// m_FileEncoder map's IDs), which is what `files` is keyed by, so
+	// resolve to MD4 hashes with a lookup per transferring peer. Empty
+	// hash if the ECID isn't there — file may have been removed between
+	// the file walkers and this client walker.
 	//
 	// A zero ECID is the core saying "no file", not "unchanged":
 	// ECSpecialCoreTags.cpp:438-443 emits `file->ECID()` or a literal 0 for
@@ -913,8 +910,9 @@ void MergeClientTag(const CEC_UpDownClient_Tag *c,
 		if (c->AssignIfExist(EC_TAG_CLIENT_UPLOAD_FILE, v)) {
 			std::string next;
 			if (v != 0) {
-				const auto it = file_hash_by_ecid.find(v);
-				next = (it != file_hash_by_ecid.end()) ? it->second : std::string();
+				const auto it = files.find(v);
+				if (it != files.end())
+					next = it->second.hash;
 			}
 			if (next != cs.upload_file_hash) {
 				cs.upload_file_hash = std::move(next);
@@ -929,8 +927,9 @@ void MergeClientTag(const CEC_UpDownClient_Tag *c,
 		if (c->AssignIfExist(EC_TAG_CLIENT_REQUEST_FILE, v)) {
 			std::string next;
 			if (v != 0) {
-				const auto it = file_hash_by_ecid.find(v);
-				next = (it != file_hash_by_ecid.end()) ? it->second : std::string();
+				const auto it = files.find(v);
+				if (it != files.end())
+					next = it->second.hash;
 			}
 			if (next != cs.download_file_hash) {
 				cs.download_file_hash = std::move(next);
@@ -1437,9 +1436,8 @@ void ApplyGetUpdateToShared(
 // --- Clients (rides on the EC_TAG_CLIENT container inside the
 // consolidated GET_UPDATE response).
 
-void ApplyGetUpdateToClients(const CECPacket *resp,
-	std::map<std::uint32_t, ClientSnapshot> &cache,
-	const std::map<std::uint32_t, std::string> &file_hash_by_ecid)
+void ApplyGetUpdateToClients(
+	const CECPacket *resp, std::map<std::uint32_t, ClientSnapshot> &cache, const FileMap &files)
 {
 	if (!resp)
 		return;
@@ -1467,10 +1465,10 @@ void ApplyGetUpdateToClients(const CECPacket *resp,
 		if (map_it == cache.end()) {
 			ClientSnapshot fresh;
 			fresh.ecid = ecid;
-			MergeClientTag(cli, fresh, /*is_new=*/true, file_hash_by_ecid);
+			MergeClientTag(cli, fresh, /*is_new=*/true, files);
 			cache.emplace(ecid, std::move(fresh));
 		} else {
-			MergeClientTag(cli, map_it->second, /*is_new=*/false, file_hash_by_ecid);
+			MergeClientTag(cli, map_it->second, /*is_new=*/false, files);
 		}
 	}
 

--- a/src/webapi/Refresher.h
+++ b/src/webapi/Refresher.h
@@ -271,15 +271,15 @@ SearchProgressSnapshot AdvanceSearchProgress(
 // suppression operates on the tag's *children*, not on the entity
 // itself), so cache entries not seen in this response are gone on
 // amuled's side (peer disconnected, dropped from queue, banned).
-// `file_hash_by_ecid` lets the walker resolve EC_TAG_CLIENT_UPLOAD_FILE
-// / EC_TAG_CLIENT_REQUEST_FILE (raw amuled ECIDs) into MD4 hashes
-// at walker time, so ClientSnapshot can surface the hash directly.
-// Build it from the unified file map AFTER the downloads/shared
-// walkers have run on the same tick. Empty map = correlator hashes
-// stay empty (matches "not currently transferring" semantics).
-void ApplyGetUpdateToClients(const CECPacket *resp,
-	std::map<std::uint32_t, ClientSnapshot> &cache,
-	const std::map<std::uint32_t, std::string> &file_hash_by_ecid);
+// `files` lets the walker resolve EC_TAG_CLIENT_UPLOAD_FILE /
+// EC_TAG_CLIENT_REQUEST_FILE (raw amuled ECIDs) into MD4 hashes at
+// walker time, so ClientSnapshot can surface the hash directly. It is
+// the live map, keyed by the same ECIDs, so pass it via
+// CState::MutateClientsWithFiles AFTER the downloads/shared walkers
+// have run on the same tick. Empty map = correlator hashes stay empty
+// (matches "not currently transferring" semantics).
+void ApplyGetUpdateToClients(
+	const CECPacket *resp, std::map<std::uint32_t, ClientSnapshot> &cache, const FileMap &files);
 
 } // namespace webapi
 

--- a/src/webapi/RefresherTick.cpp
+++ b/src/webapi/RefresherTick.cpp
@@ -119,8 +119,9 @@ bool RefresherTick(CamuleapiApp &app, CState &state)
 	// consumed below, into /clients and /friends respectively — /uploads
 	// stays bound to the upload-queue semantic via EC_OP_GET_ULOAD_QUEUE.
 	//
-	// Three Mutate calls under three separate lock acquisitions —
-	// snapshot_at is set after the whole tick succeeds; per-substruct
+	// Six exclusive acquisitions in this block: five Mutate calls (downloads,
+	// shared, servers, friends, clients+files) plus ReconcileKnownClients at
+	// the end — snapshot_at is set after the whole tick succeeds; per-substruct
 	// atomicity was already best-effort.
 	{
 		std::unique_ptr<CECPacket> req(new CECPacket(EC_OP_GET_UPDATE, EC_DETAIL_INC_UPDATE));
@@ -174,22 +175,14 @@ bool RefresherTick(CamuleapiApp &app, CState &state)
 		});
 
 		// /clients — every alive peer in theApp->clientlist (download
-		// sources, upload slots, queue waiters, etc.). Build an
-		// ecid→hash snapshot from the unified file map first so the
-		// clients walker can resolve EC_TAG_CLIENT_UPLOAD_FILE /
-		// REQUEST_FILE into MD4 hashes at walker time (the wire
-		// contract is hash-only — ECIDs never leak out).
-		std::map<std::uint32_t, std::string> file_hash_by_ecid;
-		state.WithFiles([&file_hash_by_ecid](const FileMap &files) {
-			for (const auto &entry : files) {
-				const FileSnapshot &f = entry.second;
-				if (!f.hash.empty())
-					file_hash_by_ecid.emplace(f.ecid, f.hash);
-			}
-		});
-		state.MutateClients([&](std::map<std::uint32_t, ClientSnapshot> &cache) {
-			ApplyGetUpdateToClients(resp, cache, file_hash_by_ecid);
-		});
+		// sources, upload slots, queue waiters, etc.). The walker turns each
+		// peer's file ECID into an MD4 hash as it goes — the wire contract is
+		// hash-only — so it needs the map the downloads/shared walkers just
+		// wrote: one acquisition hands it both.
+		state.MutateClientsWithFiles(
+			[&](std::map<std::uint32_t, ClientSnapshot> &cache, const FileMap &files) {
+				ApplyGetUpdateToClients(resp, cache, files);
+			});
 		delete resp;
 
 		// Fold this tick's peers into the known-clients store, so it stays

--- a/src/webapi/State.cpp
+++ b/src/webapi/State.cpp
@@ -737,6 +737,14 @@ void CState::MutateClients(const std::function<void(std::map<std::uint32_t, Clie
 	fn(m_clients);
 }
 
+void CState::MutateClientsWithFiles(
+	const std::function<void(std::map<std::uint32_t, ClientSnapshot> &, const FileMap &)> &fn)
+{
+	const ReentryGuard guard(this);
+	std::unique_lock<std::shared_timed_mutex> lock(m_mu);
+	fn(m_clients, m_files);
+}
+
 void CState::ResetLists()
 {
 	std::unique_lock<std::shared_timed_mutex> lock(m_mu);

--- a/src/webapi/State.h
+++ b/src/webapi/State.h
@@ -1360,6 +1360,11 @@ struct StatusSnapshot
 // Invariant: a FileSnapshot's `hash` is content-derived and never
 // changes once set. Walkers MUST NOT reassign `hash` via the iterator
 // (the index would desync). Set hash before emplace, never after.
+//
+// Invariant: an entry's key IS its FileSnapshot::ecid, enforced by emplace()
+// rather than left to the caller. A snapshot filed under one id but carrying
+// another silently breaks every reader that resolves via find() and then
+// trusts what it gets back -- /clients' file hashes among them.
 class FileMap
 {
 public:
@@ -1381,6 +1386,8 @@ public:
 	// variadic emplace is too liberal for our index-keeping discipline.
 	std::pair<iterator, bool> emplace(std::uint32_t ecid, FileSnapshot f)
 	{
+		// The key wins -- readers resolve by it. See the invariant above.
+		f.ecid = ecid;
 		auto r = m_files.emplace(ecid, std::move(f));
 		if (r.second && !r.first->second.hash.empty()) {
 			m_hash_to_ecid[r.first->second.hash] = ecid;
@@ -1661,6 +1668,14 @@ public:
 	void MutateDownloads(const std::function<void(FileMap &)> &fn);
 	void MutateShared(const std::function<void(FileMap &)> &fn);
 	void MutateClients(const std::function<void(std::map<std::uint32_t, ClientSnapshot> &)> &fn);
+	//! Clients plus a read-only view of the file map, under the one acquisition
+	//! this was already taking. The clients walker resolves ECIDs against the
+	//! files but cannot fetch them itself: m_mu is a single non-recursive
+	//! mutex, so reaching back into CState from inside the callback trips
+	//! ReentryGuard. Second argument carries the same borrow contract as
+	//! WithFiles -- valid for the call only, never retained.
+	void MutateClientsWithFiles(
+		const std::function<void(std::map<std::uint32_t, ClientSnapshot> &, const FileMap &)> &fn);
 	void MutateServers(const std::function<void(std::map<std::uint32_t, ServerSnapshot> &)> &fn);
 	void MutateFriends(const std::function<void(std::map<std::uint32_t, FriendSnapshot> &)> &fn);
 	// The walker replaces the whole session vector each tick rather than

--- a/unittests/tests/RefresherTest.cpp
+++ b/unittests/tests/RefresherTest.cpp
@@ -1918,7 +1918,7 @@ static void PutClientWithPartStatus(CECPacket &resp,
 TEST(Refresher, ClientEmptyPartStatusMeansFullSource)
 {
 	std::map<std::uint32_t, ClientSnapshot> cache;
-	std::map<std::uint32_t, std::string> no_files;
+	const FileMap no_files;
 	CECPacket resp(EC_OP_SHARED_FILES);
 	PutClientWithPartStatus(resp, 11, nullptr, 0);
 
@@ -1935,7 +1935,7 @@ TEST(Refresher, ClientEmptyPartStatusMeansFullSource)
 TEST(Refresher, ClientPartStatusIsDecodedLsbFirst)
 {
 	std::map<std::uint32_t, ClientSnapshot> cache;
-	std::map<std::uint32_t, std::string> no_files;
+	const FileMap no_files;
 	CECPacket resp(EC_OP_SHARED_FILES);
 	// 0x05 = bits 0 and 2 set, LSB-first (BitVector::s_posMask).
 	const std::uint8_t buf[] = { 0x05 };
@@ -1973,6 +1973,20 @@ static void PutClientWithReqFileAndPartStatus(CECPacket &resp,
 	resp.AddTag(container);
 }
 
+// ApplyGetUpdateToClients resolves a peer's ECID against the live file map,
+// so the fixtures need FileMap entries rather than a bare ecid->hash map.
+static FileMap FilesWithHashes(std::initializer_list<std::pair<std::uint32_t, const char *>> rows)
+{
+	FileMap m;
+	for (const auto &row : rows) {
+		FileSnapshot f;
+		f.ecid = row.first;
+		f.hash = row.second;
+		m.emplace(row.first, std::move(f));
+	}
+	return m;
+}
+
 TEST(Refresher, ClientPartStatusIsDroppedWhenTheRequestFileChanges)
 {
 	// An A4AF swap. CUpDownClient::SetReqFile clears m_downPartStatus without
@@ -1981,9 +1995,8 @@ TEST(Refresher, ClientPartStatusIsDroppedWhenTheRequestFileChanges)
 	// describe the OLD file and report the peer as holding parts of a file it
 	// has never sent a status for.
 	std::map<std::uint32_t, ClientSnapshot> cache;
-	std::map<std::uint32_t, std::string> files;
-	files[70] = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
-	files[71] = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+	const FileMap files = FilesWithHashes(
+		{ { 70, "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" }, { 71, "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" } });
 
 	const std::uint8_t buf[] = { 0x05 };
 	CECPacket first(EC_OP_SHARED_FILES);
@@ -2009,9 +2022,8 @@ TEST(Refresher, ClientPartStatusInTheSameTickSurvivesTheFileChange)
 	// hash is merged before the PART_STATUS decode, so a peer that swaps and
 	// reports its new status in one tick keeps the new status.
 	std::map<std::uint32_t, ClientSnapshot> cache;
-	std::map<std::uint32_t, std::string> files;
-	files[70] = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
-	files[71] = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+	const FileMap files = FilesWithHashes(
+		{ { 70, "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" }, { 71, "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" } });
 
 	const std::uint8_t old_buf[] = { 0x05 };
 	CECPacket first(EC_OP_SHARED_FILES);
@@ -2035,8 +2047,7 @@ TEST(Refresher, ClientRequestFileZeroClearsTheDownloadHash)
 	// absent tag. Reading that as "unchanged" left a finished peer listed as
 	// a source of the file it had just completed, bitmap and all.
 	std::map<std::uint32_t, ClientSnapshot> cache;
-	std::map<std::uint32_t, std::string> files;
-	files[70] = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+	const FileMap files = FilesWithHashes({ { 70, "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" } });
 
 	const std::uint8_t buf[] = { 0x05 };
 	CECPacket first(EC_OP_SHARED_FILES);
@@ -2065,7 +2076,7 @@ TEST(Refresher, ClientAbsentPartStatusLeavesCachedBitmap)
 		c.has_part_status = true;
 		cache.emplace(13, c);
 	}
-	std::map<std::uint32_t, std::string> no_files;
+	const FileMap no_files;
 	CECPacket resp(EC_OP_SHARED_FILES);
 	PutOneClient(resp, 13, static_cast<std::uint32_t>(SO_AMULE), nullptr);
 
@@ -2080,7 +2091,7 @@ TEST(Refresher, ClientAbsentPartStatusLeavesCachedBitmap)
 TEST(Refresher, ClientVersionUnknownYieldsLocaleIndependentSentinel)
 {
 	std::map<std::uint32_t, ClientSnapshot> cache;
-	std::map<std::uint32_t, std::string> no_files;
+	const FileMap no_files;
 	CECPacket resp(EC_OP_SHARED_FILES);
 	// Unidentified client + a translated version string, as a non-English
 	// daemon would ship it. Must NOT leak into the API response.
@@ -2093,7 +2104,7 @@ TEST(Refresher, ClientVersionUnknownYieldsLocaleIndependentSentinel)
 TEST(Refresher, ClientVersionKnownStringPassesThrough)
 {
 	std::map<std::uint32_t, ClientSnapshot> cache;
-	std::map<std::uint32_t, std::string> no_files;
+	const FileMap no_files;
 	CECPacket resp(EC_OP_SHARED_FILES);
 	PutOneClient(resp, 8, static_cast<std::uint32_t>(SO_AMULE), "aMule 2.3.3");
 	ApplyGetUpdateToClients(&resp, cache, no_files);
@@ -2104,7 +2115,7 @@ TEST(Refresher, ClientVersionKnownStringPassesThrough)
 TEST(Refresher, ClientKnownButNoVersionStringFallsBackToSentinel)
 {
 	std::map<std::uint32_t, ClientSnapshot> cache;
-	std::map<std::uint32_t, std::string> no_files;
+	const FileMap no_files;
 	CECPacket resp(EC_OP_SHARED_FILES);
 	// Known software, but the daemon shipped no version string at all.
 	PutOneClient(resp, 9, static_cast<std::uint32_t>(SO_EMULE), nullptr);
@@ -2122,7 +2133,7 @@ TEST(Refresher, ClientKnownButNoVersionStringFallsBackToSentinel)
 TEST(Refresher, ClientDetailFieldsDecode)
 {
 	std::map<std::uint32_t, ClientSnapshot> cache;
-	std::map<std::uint32_t, std::string> no_files;
+	const FileMap no_files;
 	CECPacket resp(EC_OP_SHARED_FILES);
 	CECTag container(EC_TAG_CLIENT, static_cast<std::uint32_t>(0));
 

--- a/unittests/tests/StateTest.cpp
+++ b/unittests/tests/StateTest.cpp
@@ -150,6 +150,32 @@ TEST(State, WriteStatusRoundtrip)
 	ASSERT_EQUALS(static_cast<std::uint32_t>(17), out.total_src_count);
 }
 
+TEST(State, FileMapEmplaceFilesTheSnapshotUnderItsKey)
+{
+	// The clients walker resolves an amuled ECID with find() and then reads
+	// the snapshot it gets back, so the key and FileSnapshot::ecid have to
+	// agree. emplace() makes them agree instead of trusting the caller: a
+	// snapshot carrying the wrong id would otherwise break /clients silently.
+	CState s;
+	s.MutateDownloads([](FileMap &cache) {
+		FileSnapshot f;
+		f.ecid = 999; // stale / wrong -- the key is what readers look up by
+		f.hash = "cccc2222cccc2222cccc2222cccc2222";
+		f.is_downloading = true;
+		cache.emplace(42, std::move(f));
+	});
+	s.WithFiles([](const FileMap &files) {
+		const auto it = files.find(42);
+		ASSERT_TRUE(it != files.end());
+		ASSERT_EQUALS(static_cast<std::uint32_t>(42), it->second.ecid);
+		ASSERT_TRUE(files.find(999) == files.end());
+		// The hash index is keyed off the same insert, so it agrees too.
+		std::uint32_t by_hash = 0;
+		ASSERT_TRUE(files.FindEcidByHash("cccc2222cccc2222cccc2222cccc2222", by_hash));
+		ASSERT_EQUALS(static_cast<std::uint32_t>(42), by_hash);
+	});
+}
+
 TEST(State, MutateDownloadsRoundtripAndFind)
 {
 	CState s;


### PR DESCRIPTION
The clients walker needs to turn EC_TAG_CLIENT_UPLOAD_FILE / EC_TAG_CLIENT_REQUEST_FILE (amuled-side ECIDs) into MD4 hashes. It was handed an ecid->hash std::map that RefresherTick built by walking the whole file map, every tick -- one std::string plus one red-black tree node per shared file, to answer a couple of lookups per connected peer. On a 12k-file library that is ~12k entries built and thrown away every second, and it was the largest single source of allocator churn in the process.

FileMap is already keyed by those same ECIDs and exposes find(), so the index was a copy of something the state already had. The walker now looks up the few files its peers are actually transferring.

That makes a reader's correctness depend on an entry's key and its FileSnapshot::ecid agreeing, which was true at both inserts but only by convention. FileMap::emplace now sets the field from the key it files under, so the next insert cannot get it wrong, and the class contract says so next to the hash invariant it already documented.

The walker cannot fetch the files itself: CState guards every field with one non-recursive shared_timed_mutex, and reaching back into CState from inside a Mutate callback trips ReentryGuard. Hence MutateClientsWithFiles(), which hands the callback the clients map and a const view of the files under the one acquisition it was already taking -- no extra lock, no nesting, and one CState acquisition per tick fewer than the WithFiles + MutateClients pair it replaces (19 -> 18). It also drops a second full pass over the map: MutateDownloads still walks it once to evict stale RLE state, but the index build was walking it again. The second argument carries the same borrow contract as WithFiles -- valid for the call only.

Measured with amuled + amuleapi on loopback, 12k shared files, no client connected, amuleapi CPU over 300 s of idle 1 Hz ticks:

    before   113 jiffies / 300 s   0.377 %
    after     25 jiffies / 300 s   0.083 %

heaptrack on the same workload no longer attributes any allocation to the index stack.