### PR TITLE
fix(web-ui): send If-None-Match back verbatim, and show the server port

### DIFF
--- a/src/webapi/static/js/api.js
+++ b/src/webapi/static/js/api.js
@@ -69,7 +69,8 @@ async function request(method, path, { body, useEtag = false, noGate = false } =
   if (useEtag && (method === "GET" || method === "HEAD")) {
     cacheKey = url;
     const cached = etagCache.get(cacheKey);
-    if (cached) headers["If-None-Match"] = '"' + cached.etag + '"';
+    // Verbatim: re-quoting a stripped `W/"abc"` gives `"W/abc"`, matching nothing.
+    if (cached) headers["If-None-Match"] = cached.etag;
   }
 
   const init = { method, headers, credentials: "include" };
@@ -111,7 +112,7 @@ async function request(method, path, { body, useEtag = false, noGate = false } =
   }
 
   if (cacheKey) {
-    const etag = (resp.headers.get("ETag") || "").replace(/"/g, "");
+    const etag = (resp.headers.get("ETag") || "").trim();
     if (etag) etagCache.set(cacheKey, { etag, data: payload });
   }
 

--- a/src/webapi/static/js/app.js
+++ b/src/webapi/static/js/app.js
@@ -310,7 +310,9 @@ function ConnectionStatus({ status }) {
   if (ed2k) {
     if (ed2k.state === "connected") {
       e2Cls = ed2k.high_id ? "ok" : "low";
-      e2Text = (ed2k.server_name || ed2k.server_ip || t("app_connected")) +
+      const e2Server = ed2k.server_name ||
+        (ed2k.server_ip ? ed2k.server_ip + ":" + ed2k.server_port : "");
+      e2Text = (e2Server || t("app_connected")) +
         " · " + (ed2k.high_id ? t("app_high_id") : t("app_low_id"));
     } else if (ed2k.state === "connecting") {
       e2Cls = "warn"; e2Text = t("app_connecting");

--- a/src/webapi/static/js/events.js
+++ b/src/webapi/static/js/events.js
@@ -192,7 +192,7 @@ function openSse() {
 
   // Comments ride their own event (EVENTS.md §comments_updated) instead of
   // download_updated, so the per-tick download frame stays lean. The payload is
-  // byte-for-byte the GET downloads/{hash}/comments body — the detail view
+  // the GET downloads/{hash}/comments body plus `hash` — the detail view
   // applies it directly rather than re-fetching.
   es.addEventListener("comments_updated", (ev) => {
     try { store.set("comments:updated", JSON.parse(ev.data)); } catch (_) {}


### PR DESCRIPTION
Three loose ends on the client side of the v0 surface, found while checking that #1104 was fully implemented.

The ETag cache stripped every quote from the header it received and re-quoted the value on the way out. That round-trips a strong validator by luck, but it turns a weak one -- `W/"abc"`, which is what an nginx in front of us emits once it gzips -- into `"W/abc"`, matching nothing, so the conditional GET silently degraded to a full re-transfer on every poll. The value is now stored and replayed exactly as received. Confirmed against the daemon: `If-None-Match: W/"..."` answers 304 while the old re-quoted spelling answers 200, and the normal path still goes 200 -> 304 -> 304 under both identity and gzip, coding suffix intact.

`status.ed2k.server_ip` is a bare dotted quad since #1113 fixed it, so the connection label's nameless-server fallback lost the port it used to show as part of the old `[ip:port]` value. It is joined back on from `server_port`.

The `comments_updated` comment claimed the payload was byte-for-byte the `GET /downloads/{hash}/comments` body. #1113 made it that body plus `hash`, which is the key the handler right below it dispatches on.