### PR TITLE
fix(amuleapi): give collection actions their own paths, and address lookups their own route

### DIFF
--- a/docs/api/REFERENCE.md
+++ b/docs/api/REFERENCE.md
@@ -39,7 +39,7 @@ The API is versioned in the path. Breaking changes ship under `/api/v1/`; `/api/
 - [`DELETE /api/v0/downloads`](#delete-apiv0downloads) — bulk cancel + remove
 - [`PATCH /api/v0/downloads/{hash}`](#patch-apiv0downloadshash) — pause / resume / priority / category
 - [`DELETE /api/v0/downloads/{hash}`](#delete-apiv0downloadshash) — cancel + remove
-- [`POST /api/v0/downloads/clear_completed`](#post-apiv0downloadsclear_completed) — bulk-clear completed staging buffer
+- [`POST /api/v0/downloads_clear_completed`](#post-apiv0downloadsclear_completed) — bulk-clear completed staging buffer
 
 **Clients (peers)**
 - [`GET /api/v0/clients`](#get-apiv0clients) — list peers, optional filter
@@ -50,13 +50,13 @@ The API is versioned in the path. Breaking changes ship under `/api/v1/`; `/api/
 - [`GET /api/v0/shared`](#get-apiv0shared) — list shared files
 - [`GET /api/v0/shared/{hash}`](#get-apiv0sharedhash) — detail view; every list field plus shared-detail fields
 - [`GET /api/v0/shared/{hash}/clients`](#get-apiv0sharedhashclients) — peers of one shared file
-- [`POST /api/v0/shared/reload`](#post-apiv0sharedreload) — re-walk shared directories
+- [`POST /api/v0/shared_reload`](#post-apiv0sharedreload) — re-walk shared directories
 - [`POST /api/v0/shared/media/refresh`](#post-apiv0sharedmediarefresh) — re-extract media metadata for the whole share
 - [`POST /api/v0/shared/{hash}/media/refresh`](#post-apiv0sharedhashmediarefresh) — re-extract it for one file
-- [`GET /api/v0/shared/directories`](#get-apiv0shareddirectories) — the configured share roots
-- [`PUT /api/v0/shared/directories`](#put-apiv0shareddirectories) — replace the configured share roots
-- [`POST /api/v0/shared/directories`](#post-apiv0shareddirectories) — add one share root
-- [`DELETE /api/v0/shared/directories`](#delete-apiv0shareddirectories) — remove one share root
+- [`GET /api/v0/share_directories`](#get-apiv0shareddirectories) — the configured share roots
+- [`PUT /api/v0/share_directories`](#put-apiv0shareddirectories) — replace the configured share roots
+- [`POST /api/v0/share_directories`](#post-apiv0shareddirectories) — add one share root
+- [`DELETE /api/v0/share_directories`](#delete-apiv0shareddirectories) — remove one share root
 - [`POST /api/v0/shared/{hash}/verify`](#post-apiv0sharedhashverify) — re-hash a shared file against its on-disk data
 - [`PATCH /api/v0/shared`](#patch-apiv0shared) — bulk change upload priority
 - [`PATCH /api/v0/shared/{hash}`](#patch-apiv0sharedhash) — change upload priority
@@ -67,7 +67,7 @@ The API is versioned in the path. Breaking changes ship under `/api/v1/`; `/api/
 - [`POST /api/v0/servers/{ecid}/connect`](#post-apiv0serversecidconnect--post-apiv0serversipportconnect) — connect to specific server (ECID or `ip:port`)
 - [`DELETE /api/v0/servers/{ecid}`](#delete-apiv0serversecid--delete-apiv0serversipport) — remove server (ECID or `ip:port`)
 - [`PATCH /api/v0/servers/{ecid}`](#patch-apiv0serversecid--patch-apiv0serversipport) — set server priority / static flag (ECID or `ip:port`)
-- [`POST /api/v0/servers/update`](#post-apiv0serversupdate) — refresh from `server.met` URL
+- [`POST /api/v0/servers_update`](#post-apiv0serversupdate) — refresh from `server.met` URL
 - [`GET /api/v0/friends`](#get-apiv0friends) — list the friends list
 - [`POST /api/v0/friends`](#post-apiv0friends) — add a friend, by connected peer or by address
 - [`DELETE /api/v0/friends/{ecid}`](#delete-apiv0friendsecid) — remove a friend
@@ -932,7 +932,7 @@ curl -H "Authorization: Bearer $TOKEN" \
 
 **Auth:** `ADMIN`
 
-> The `GET` on this path was retired: A4AF sources are rows of [`GET /downloads/{hash}/clients`](#get-apiv0downloadshashclients) now, carrying the whole peer object rather than a bare ECID, and `a4af_auto` is already on the download detail object. `GET` answers `405`.
+> `POST` only; a `GET` here answers `405`. A4AF sources are rows of [`GET /downloads/{hash}/clients`](#get-apiv0downloadshashclients), carrying the whole peer object rather than a bare ECID, and `a4af_auto` is on the download detail object.
 
 Force A4AF source-swapping for this download. Downloads-only.
 
@@ -1068,7 +1068,7 @@ curl -s -X DELETE -H "Authorization: Bearer $TOKEN" \
 
 **Errors:** `400 amuled_rejected`, `404 not_found`, `409 completed_use_clear_completed`, `503 ec_unavailable`.
 
-#### `POST /api/v0/downloads/clear_completed`
+#### `POST /api/v0/downloads_clear_completed`
 
 **Auth:** `ADMIN`
 
@@ -1079,13 +1079,13 @@ Two request shapes share this endpoint:
 ```sh
 # Bulk: no body. Clears every completed entry in one EC roundtrip.
 curl -s -X POST -H "Authorization: Bearer $TOKEN" \
-  "http://$HOST/api/v0/downloads/clear_completed"
+  "http://$HOST/api/v0/downloads_clear_completed"
 
 # Per-entry: clear a single completed entry by hash.
 curl -s -X POST -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"hash": "8b54a3c2..."}' \
-  "http://$HOST/api/v0/downloads/clear_completed"
+  "http://$HOST/api/v0/downloads_clear_completed"
 ```
 
 The response envelope is identical for both shapes:
@@ -1455,7 +1455,7 @@ For a shared file that is also still downloading, the same values are available 
 
 **Errors:** `404 not_found` (no shared file with that hash), `503 ec_unavailable`.
 
-#### `POST /api/v0/shared/reload`
+#### `POST /api/v0/shared_reload`
 
 **Auth:** `ADMIN`
 
@@ -1463,7 +1463,7 @@ Equivalent to the desktop client's "Reload" button — amuled re-walks its share
 
 ```sh
 curl -s -X POST -H "Authorization: Bearer $TOKEN" \
-  "http://$HOST/api/v0/shared/reload"
+  "http://$HOST/api/v0/shared_reload"
 ```
 
 ```json
@@ -1526,7 +1526,7 @@ The same operation for a single file, which is the quickest way to check a fix o
 
 **Errors:** `404 not_found` (no shared file with that hash), `409 partfile_unsupported` (an incomplete download has no complete file to read), `400 amuled_rejected` (media metadata extraction is disabled, or the file is not eligible: not audio/video, or an incomplete download), `503 ec_unsupported`, `503 ec_unavailable`.
 
-#### `GET /api/v0/shared/directories`
+#### `GET /api/v0/share_directories`
 
 **Auth:** `GUEST`
 
@@ -1534,7 +1534,7 @@ The share roots amuled is configured with — as opposed to [`GET /shared`](#get
 
 ```sh
 curl -s -H "Authorization: Bearer $TOKEN" \
-  "http://$HOST/api/v0/shared/directories"
+  "http://$HOST/api/v0/share_directories"
 ```
 
 ```json
@@ -1550,7 +1550,7 @@ curl -s -H "Authorization: Bearer $TOKEN" \
 
 **Errors:** `502 amuled_rejected`, `503 ec_unavailable`.
 
-#### `PUT /api/v0/shared/directories`
+#### `PUT /api/v0/share_directories`
 
 **Auth:** `ADMIN`
 
@@ -1559,7 +1559,7 @@ Replace the whole set of roots. A full replace rather than a merge, because that
 ```sh
 curl -s -X PUT -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
   -d '{"directories":[{"path":"/home/user/media","recursive":true}]}' \
-  "http://$HOST/api/v0/shared/directories"
+  "http://$HOST/api/v0/share_directories"
 ```
 
 ```json
@@ -1581,11 +1581,11 @@ amuled validates every path: a REST client cannot stat the core's filesystem, so
 
 `reason` is `not_found` (missing, or not a directory) or `not_readable`. amuled reports these as codes and the API renders them, so its locale never leaks into your response.
 
-The **rescan is scheduled, not completed**, before the response returns: a successful reply means the new roots are validated and persisted, and that the re-walk will start on amuled's next processing tick. Until it finishes, [`GET /api/v0/shared`](#get-apiv0shared) still serves the previous file list. Observe completion the same way as [`POST /api/v0/shared/reload`](#post-apiv0sharedreload), whose notes on log lines and coalescing apply here too.
+The **rescan is scheduled, not completed**, before the response returns: a successful reply means the new roots are validated and persisted, and that the re-walk will start on amuled's next processing tick. Until it finishes, [`GET /api/v0/shared`](#get-apiv0shared) still serves the previous file list. Observe completion the same way as [`POST /api/v0/shared_reload`](#post-apiv0sharedreload), whose notes on log lines and coalescing apply here too.
 
 **Errors:** `400 bad_request` (`directories` not an array, an entry without a non-empty `path`, non-boolean `recursive`), `502 amuled_rejected`, `503 ec_unavailable`.
 
-#### `POST /api/v0/shared/directories`
+#### `POST /api/v0/share_directories`
 
 **Auth:** `ADMIN`
 
@@ -1594,14 +1594,14 @@ Add a single root, leaving the others alone — the convenience path for scripts
 ```sh
 curl -s -X POST -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
   -d '{"path":"/home/user/new","recursive":true}' \
-  "http://$HOST/api/v0/shared/directories"
+  "http://$HOST/api/v0/share_directories"
 ```
 
 Idempotent: adding a path that is already configured updates its `recursive` flag rather than failing, so "ensure this folder is shared" is safe to repeat. Same `{ok, rejected}` body as `PUT`.
 
 **Errors:** `400 bad_request` (missing/empty `path`, non-boolean `recursive`), `502 amuled_rejected`, `503 ec_unavailable`.
 
-#### `DELETE /api/v0/shared/directories`
+#### `DELETE /api/v0/share_directories`
 
 **Auth:** `ADMIN`
 
@@ -1612,11 +1612,11 @@ Pass the **exact** `path` string returned by `GET /shared/directories`, percent-
 ```sh
 # POSIX root: /home/user/new
 curl -s -X DELETE -H "Authorization: Bearer $TOKEN" \
-  "http://$HOST/api/v0/shared/directories?path=%2Fhome%2Fuser%2Fnew"
+  "http://$HOST/api/v0/share_directories?path=%2Fhome%2Fuser%2Fnew"
 
 # Windows root: C:\Users\bob\My Shares
 curl -s -X DELETE -H "Authorization: Bearer $TOKEN" \
-  "http://$HOST/api/v0/shared/directories?path=C%3A%5CUsers%5Cbob%5CMy%20Shares"
+  "http://$HOST/api/v0/share_directories?path=C%3A%5CUsers%5Cbob%5CMy%20Shares"
 ```
 
 Removing a path that is not configured is a `404` rather than a silent success, so a typo — or a path that does not byte-match what `GET` returned — is visible. Same `{ok, rejected}` body as `PUT`.
@@ -1808,7 +1808,7 @@ Tells amuled to disconnect from its current server and dial the specified one. T
 
 ```sh
 curl -s -X POST -H "Authorization: Bearer $TOKEN" \
-  "http://$HOST/api/v0/servers/203.0.113.5:4242/connect"
+  "http://$HOST/api/v0/servers/by-address/203.0.113.5:4242/connect"
 ```
 
 **Response:** `202 Accepted` → `{ "ok": true, "ecid": 1 }`.
@@ -1850,7 +1850,7 @@ curl -s -X PATCH -H "Authorization: Bearer $TOKEN" \
 
 **Errors:** `400 bad_request` (unknown `priority`, non-bool `static`, or neither field present), `400 amuled_rejected`, `404 not_found`, `503 ec_unavailable`.
 
-#### `POST /api/v0/servers/update`
+#### `POST /api/v0/servers_update`
 
 **Auth:** `ADMIN`
 
@@ -2245,7 +2245,7 @@ curl -s -X POST -H "Authorization: Bearer $TOKEN" \
 
 **Auth:** `ADMIN`
 
-Downloads a `nodes.dat` from the supplied URL and rebuilds the Kad node list from it — the Kad counterpart of [`POST /api/v0/servers/update`](#post-apiv0serversupdate), and the same operation the desktop GUI's "Update node list from URL" button drives.
+Downloads a `nodes.dat` from the supplied URL and rebuilds the Kad node list from it — the Kad counterpart of [`POST /api/v0/servers_update`](#post-apiv0serversupdate), and the same operation the desktop GUI's "Update node list from URL" button drives.
 
 **Body:**
 
@@ -2349,7 +2349,7 @@ curl -s -X POST -H "Authorization: Bearer $TOKEN" \
   "http://$HOST/api/v0/ipfilter/update"
 ```
 
-An explicit URL is **persisted** into the `security.ipfilter_update_url` preference, so a subsequent `GET /preferences` reflects it and the next startup auto-update (`security.ipfilter_auto_update`) uses it — the same side effect [`POST /api/v0/servers/update`](#post-apiv0serversupdate) and [`POST /api/v0/kad/update`](#post-apiv0kadupdate) have.
+An explicit URL is **persisted** into the `security.ipfilter_update_url` preference, so a subsequent `GET /preferences` reflects it and the next startup auto-update (`security.ipfilter_auto_update`) uses it — the same side effect [`POST /api/v0/servers_update`](#post-apiv0serversupdate) and [`POST /api/v0/kad/update`](#post-apiv0kadupdate) have.
 
 **Response:** `202 Accepted` → `{ "ok": true, "ipfilter_url": "..." }`. The effective URL is echoed back, so a caller that omitted it learns which one ran.
 

--- a/src/webapi/Api.cpp
+++ b/src/webapi/Api.cpp
@@ -1013,16 +1013,16 @@ CHttpServer::Response CApiDispatcher::DispatchToHandler(const CHttpServer::Reque
 	}
 
 	// bulk clear-completed.
-	if (path == "/api/v0/downloads/clear_completed") {
+	if (path == "/api/v0/downloads_clear_completed") {
 		if (req.method != "POST") {
 			return MethodNotAllowed("POST", "only POST on /downloads/clear_completed");
 		}
 		return HandleDownloadsClearCompleted(req);
 	}
 
-	// /uploads was retired in — /clients covers the full
-	// peer surface (every upload_state, including queue waiters and
-	// download peers); consumers filter client-side by upload_state.
+	// /clients is the whole peer surface: every upload_state, including
+	// queue waiters and download peers. Consumers filter client-side by
+	// upload_state rather than asking for a pre-filtered view.
 	if (path == "/api/v0/clients") {
 		if (req.method != "GET" && req.method != "HEAD") {
 			return MethodNotAllowed("GET, HEAD", "only GET on /clients");
@@ -1083,7 +1083,7 @@ CHttpServer::Response CApiDispatcher::DispatchToHandler(const CHttpServer::Reque
 		return MethodNotAllowed("GET, HEAD, PATCH", "only GET / HEAD / PATCH on /shared");
 	}
 
-	if (path == "/api/v0/shared/reload") {
+	if (path == "/api/v0/shared_reload") {
 		if (req.method != "POST") {
 			return MethodNotAllowed("POST", "only POST on /shared/reload");
 		}
@@ -1104,7 +1104,7 @@ CHttpServer::Response CApiDispatcher::DispatchToHandler(const CHttpServer::Reque
 	// which lists the files those roots produced. Literal path, so it has to be
 	// matched before the /shared/{hash} patterns below or "directories" would be
 	// captured as a hash.
-	if (path == "/api/v0/shared/directories") {
+	if (path == "/api/v0/share_directories") {
 		if (req.method == "GET" || req.method == "HEAD") {
 			return HandleSharedDirectories(req);
 		}
@@ -1225,7 +1225,7 @@ CHttpServer::Response CApiDispatcher::DispatchToHandler(const CHttpServer::Reque
 		}
 	}
 
-	if (path == "/api/v0/servers/update") {
+	if (path == "/api/v0/servers_update") {
 		if (req.method != "POST") {
 			return MethodNotAllowed("POST", "only POST on /servers/update");
 		}
@@ -1242,18 +1242,35 @@ CHttpServer::Response CApiDispatcher::DispatchToHandler(const CHttpServer::Reque
 		static const auto server_connect =
 			web_api_path::ParsePattern("/api/v0/servers/{ecid}/connect");
 		static const auto server_one = web_api_path::ParsePattern("/api/v0/servers/{ecid}");
+		static const auto server_addr_connect =
+			web_api_path::ParsePattern("/api/v0/servers/by-address/{address}/connect");
+		static const auto server_addr_one =
+			web_api_path::ParsePattern("/api/v0/servers/by-address/{address}");
 		const auto path_segs = web_api_path::SplitPath(path);
 		std::map<std::string, std::string> caps;
+		// The address form has its own path rather than sharing {ecid}.
+		// One capture with two identity domains, disambiguated by sniffing
+		// for a colon, is a dispatch rule invisible from outside -- and it
+		// forecloses ever accepting an IPv6 literal here, since those are
+		// all colons.
+		if (web_api_path::Match(server_addr_connect, path_segs, caps)) {
+			if (req.method != "POST") {
+				return MethodNotAllowed(
+					"POST", "only POST on /servers/by-address/{address}/connect");
+			}
+			return HandleServerConnectByAddress(req, caps["address"]);
+		}
+		if (web_api_path::Match(server_addr_one, path_segs, caps)) {
+			if (req.method != "DELETE" && req.method != "PATCH") {
+				return MethodNotAllowed("PATCH, DELETE",
+					"only DELETE / PATCH on /servers/by-address/{address}");
+			}
+			return req.method == "PATCH" ? HandleServerPatchByAddress(req, caps["address"])
+						     : HandleServerDeleteByAddress(req, caps["address"]);
+		}
 		if (web_api_path::Match(server_connect, path_segs, caps)) {
 			if (req.method != "POST") {
 				return MethodNotAllowed("POST", "only POST on /servers/{ecid}/connect");
-			}
-			// `{ecid}` capture also matches "<ip>:<port>" because the
-			// path-pattern matcher is opaque-segment. Disambiguate
-			// here: if the capture contains a colon, treat it as an
-			// address-keyed alias.
-			if (caps["ecid"].find(':') != std::string::npos) {
-				return HandleServerConnectByAddress(req, caps["ecid"]);
 			}
 			return HandleServerConnect(req, caps["ecid"]);
 		}
@@ -1262,15 +1279,8 @@ CHttpServer::Response CApiDispatcher::DispatchToHandler(const CHttpServer::Reque
 				return MethodNotAllowed(
 					"PATCH, DELETE", "only DELETE / PATCH on /servers/{ecid}");
 			}
-			const bool by_address = caps["ecid"].find(':') != std::string::npos;
-			if (req.method == "PATCH") {
-				return by_address ? HandleServerPatchByAddress(req, caps["ecid"])
-						  : HandleServerPatch(req, caps["ecid"]);
-			}
-			if (by_address) {
-				return HandleServerDeleteByAddress(req, caps["ecid"]);
-			}
-			return HandleServerDelete(req, caps["ecid"]);
+			return req.method == "PATCH" ? HandleServerPatch(req, caps["ecid"])
+						     : HandleServerDelete(req, caps["ecid"]);
 		}
 	}
 
@@ -1511,21 +1521,6 @@ CHttpServer::Response CApiDispatcher::DispatchToHandler(const CHttpServer::Reque
 		}
 	}
 
-	// The two retired paths, answered explicitly rather than falling into the
-	// {id} matcher below -- which would capture "results" / "stop" as an id
-	// and report a confusing "not a valid search id". Naming the replacement
-	// is the whole point of keeping these four lines.
-	if (path == "/api/v0/search/results") {
-		return ErrorResponse(404,
-			"not_found",
-			"retired: results are addressed per search at GET /search/{id}/results");
-	}
-	if (path == "/api/v0/search/stop") {
-		return ErrorResponse(404,
-			"not_found",
-			"retired: use POST /search/{id}/stop, or DELETE /search/{id} to also free it");
-	}
-
 	// /search/{id} — DELETE stops the search AND frees it (results included).
 	{
 		static const auto search_one = web_api_path::ParsePattern("/api/v0/search/{id}");
@@ -1643,11 +1638,12 @@ CHttpServer::Response CApiDispatcher::DispatchToHandler(const CHttpServer::Reque
 			if (req.method == "POST") {
 				return HandleDownloadA4afAction(req, caps["hash"]);
 			}
-			// The read half is retired (issue #984): A4AF sources are rows of
-			// /downloads/{hash}/clients now, carrying the whole peer object
-			// rather than a bare ECID, and `a4af_auto` is already on the
-			// download detail object. The POST stays -- the swap actions have
-			// no equivalent there, and its reply is still the A4AF view.
+			// POST only. A4AF sources are rows of /downloads/{hash}/clients,
+			// carrying the whole peer object rather than a bare ECID, and
+			// `a4af_auto` is on the download detail object, so there is
+			// nothing for a GET here to add. The swap actions have no
+			// equivalent on those routes, and this reply is still the A4AF
+			// view.
 			return MethodNotAllowed("POST", "only POST on /downloads/{hash}/a4af");
 		}
 	}
@@ -2497,12 +2493,11 @@ CHttpServer::Response CApiDispatcher::HandleStatus(const CHttpServer::Request &r
 
 	CJsonWriter w;
 	w.BeginObject();
-	// snapshot_at + snapshot_at_unix were retired from
-	// every envelope response so the ETag/If-None-Match cache
-	// actually gets cache hits on list endpoints.
-	// `ec_connected` is the dedicated staleness signal — it flips
-	// false when the refresher tick fails. Standard HTTP `Date:`
-	// header carries wall-clock for any consumer that needs it.
+	// No snapshot timestamp in the envelope: a value that moves every tick
+	// changes the body bytes and defeats the ETag, so list endpoints would
+	// never see a cache hit. `ec_connected` is the staleness signal, flipping
+	// false when the refresher tick fails, and the HTTP `Date:` header
+	// carries wall-clock for any consumer that needs it.
 	w.Key("ec_connected");
 	w.ValueBool(ec);
 	(void)ts;
@@ -7345,7 +7340,7 @@ CHttpServer::Response CApiDispatcher::HandleStatsTree(const CHttpServer::Request
 	CHttpServer::Response r;
 	r.status = 200;
 	r.content_type = "application/json";
-	// snapshot_at retired in favour of the ETag
+	// No snapshot_at: the ETag is the cache validator
 	// as the cache validator. The TtlPair_StatsTree still tracks the
 	// fetched-at time internally (drives the 1 s TTL coalescer) — it
 	// just isn't surfaced any more.
@@ -7476,7 +7471,7 @@ CHttpServer::Response CApiDispatcher::HandleStatsGraph(
 	// repeating records. `points` is never longer than this.
 	w.Key("max_points");
 	w.ValueInt(static_cast<int64_t>(g.max_points));
-	// snapshot_at retired from the response. WritePointArray
+	// No snapshot_at in the response. WritePointArray
 	// still consumes `ts` to compute per-point timestamps (anchoring
 	// the time-series backwards from the fetch wall-clock).
 	//

--- a/src/webapi/Api.h
+++ b/src/webapi/Api.h
@@ -137,9 +137,9 @@ private:
 		const CHttpServer::Request &, const std::string &key);
 	// source-reported filenames + counts. `key` = 32-char MD4 hash.
 	CHttpServer::Response HandleDownloadFilenames(const CHttpServer::Request &, const std::string &key);
-	// A4AF swap action (POST). `key` = 32-char MD4 hash. The GET that once
-	// listed the sources is retired -- the rows now come from
-	// GET /downloads/{hash}/clients, which flags each one with `a4af`.
+	// A4AF swap action (POST). `key` = 32-char MD4 hash. The source rows
+	// come from GET /downloads/{hash}/clients, which flags each one with
+	// `a4af`.
 	CHttpServer::Response HandleDownloadA4afAction(const CHttpServer::Request &, const std::string &key);
 	// download lifecycle mutations.
 	CHttpServer::Response HandleDownloadAdd(const CHttpServer::Request &);

--- a/src/webapi/State.h
+++ b/src/webapi/State.h
@@ -1568,8 +1568,8 @@ public:
 
 	// Full peer list (all upload_state values, including queue
 	// waiters, idle peers, and banned). Backs /clients.
-	// The legacy /uploads endpoint is retired — consumers query
-	// /clients and filter by role on their side.
+	// Consumers query /clients and filter by role on their side rather
+	// than asking for a pre-filtered upload view.
 	std::vector<ClientSnapshot> Clients() const;
 
 	// --- Known clients (the daemon's credit store) -------------------------

--- a/src/webapi/static/js/views/downloads.js
+++ b/src/webapi/static/js/views/downloads.js
@@ -128,10 +128,10 @@ export default function Downloads({ isGuest }) {
 
   const clearCompleted = async () => {
     if (!(await confirmDialog(t("downloads_confirm_clear_completed")))) return;
-    mutate(() => api.post("downloads/clear_completed"));
+    mutate(() => api.post("downloads_clear_completed"));
   };
   // Same endpoint scoped to one hash, for the detail panel's Clear button.
-  const clearOne = (h) => mutate(() => api.post("downloads/clear_completed", { hash: h }));
+  const clearOne = (h) => mutate(() => api.post("downloads_clear_completed", { hash: h }));
 
   // --- derived ----------------------------------------------------------
   let list = downloads.slice();

--- a/src/webapi/static/js/views/preferences.js
+++ b/src/webapi/static/js/views/preferences.js
@@ -114,7 +114,7 @@ const TABS = [
       { key: "update_list_from_server", type: "bool" },
       { key: "update_list_from_client", type: "bool" },
       { key: "update_url", type: "text",
-        action: { path: "servers/update", body: "servers_url",
+        action: { path: "servers_update", body: "servers_url",
                   titleKey: "prefs_action_servers_update",
                   toastKey: "prefs_action_servers_update_toast" } },
     ] },

--- a/src/webapi/static/js/views/shared.js
+++ b/src/webapi/static/js/views/shared.js
@@ -107,7 +107,7 @@ export default function Shared({ isGuest }) {
     else toast(tn("shared_verify_started_selected", hashes.length), "info");
   };
   const reload = async () => {
-    try { await api.post("shared/reload"); toast(t("shared_toast_reloading"), "success"); setTimeout(() => data.refresh("shared"), 1500); }
+    try { await api.post("shared_reload"); toast(t("shared_toast_reloading"), "success"); setTimeout(() => data.refresh("shared"), 1500); }
     catch (e) { toast(terr(e) || t("shared_error"), "error"); }
   };
 

--- a/unittests/curl-tests/amuleapi/03-read-status.sh
+++ b/unittests/curl-tests/amuleapi/03-read-status.sh
@@ -170,9 +170,10 @@ _assert_json_eq '.disk.incoming_free_bytes | type | . == "number" or . == "null"
 _assert_json_eq '[.disk[]] | map(select(. == 18446744073709551615)) | length == 0' true \
 	'disk figures never report the unsigned free-space sentinel'
 
-# Retired spellings must be gone from the whole body, not merely unused.
+# These spellings are not part of the surface; assert they are absent from the
+# whole body rather than merely unused by the assertions above.
 _assert_json_eq '[paths | join(".")] | map(select(test("low_id|upload_queue_length|total_source_count"))) | length == 0' \
-	true '/status no longer carries the retired field names'
+	true '/status carries none of these field names'
 
 # --- 4. /status with guest bearer also works (any-role read gate). --
 GUEST_TOKEN=$(curl -s -X POST -H "Content-Type: application/json" \

--- a/unittests/curl-tests/amuleapi/04-read-downloads-shared.sh
+++ b/unittests/curl-tests/amuleapi/04-read-downloads-shared.sh
@@ -208,10 +208,9 @@ if [ "$COUNT" -gt 0 ]; then
 	_assert_json_eq '.media | type' null \
 		'/downloads/{hash} omits media when unprobed'
 
-	# The A4AF read sub-resource (issue #421) was retired in favour of the
-	# per-file client rows below (issue #984), which carry the whole peer
-	# object per A4AF source rather than a bare ECID. `a4af_auto` lives on the
-	# download detail object, asserted above. The POST half is unaffected.
+	# A4AF sources are the per-file client rows below, which carry the whole
+	# peer object per source rather than a bare ECID, and `a4af_auto` lives on
+	# the download detail object, asserted above. The a4af path is POST-only.
 
 	# Unknown action → 400 (mutation validation; admin token).
 	_curl -X POST -H "Authorization: Bearer $TOKEN" \
@@ -277,10 +276,10 @@ if [ "$COUNT" -gt 0 ]; then
 		done
 	fi
 
-	# The A4AF read route is retired in favour of the rows above; its POST
-	# stays, so the path must answer 405 rather than 404.
+	# The a4af path exists for POST only, so a GET is 405 rather than 404:
+	# the resource is there, the method is not.
 	_curl -H "Authorization: Bearer $TOKEN" "$HOST/api/v0/downloads/$HASH/a4af"
-	_assert_status 405 "GET /downloads/{hash}/a4af is retired → 405"
+	_assert_status 405 "GET /downloads/{hash}/a4af → 405 (POST-only route)"
 
 	# Per-source swap (issue #983): `client_ecid` narrows swap_this to one
 	# source. Validation is asserted here rather than the swap itself — a

--- a/unittests/curl-tests/amuleapi/06-read-logs.sh
+++ b/unittests/curl-tests/amuleapi/06-read-logs.sh
@@ -142,10 +142,8 @@ _assert_json_eq '.total_bytes' "$TOTAL_BYTES" \
 	'/logs/serverinfo?tail=3 reports the same total_bytes'
 
 # --- 6. Method gate. -----------------------------------------------
-# DELETE on /logs/{amule,serverinfo} now CLEARS the buffer (phase 11
-# / RFC §4.11 alignment); the 405 contract this test originally
-# asserted has been retired. PATCH stays a 405 — the logs are
-# read+reset only, never partially mutable.
+# DELETE on /logs/{amule,serverinfo} clears the buffer. PATCH is a 405:
+# the logs are read+reset only, never partially mutable.
 for ep in logs/amule logs/serverinfo; do
 	_curl -X PATCH -H "Authorization: Bearer $TOKEN" "$HOST/api/v0/$ep"
 	_assert_status 405 "PATCH /api/v0/$ep → 405"

--- a/unittests/curl-tests/amuleapi/09-refresher-consolidation.sh
+++ b/unittests/curl-tests/amuleapi/09-refresher-consolidation.sh
@@ -191,16 +191,7 @@ if [ "$NSERV" -gt 0 ]; then
 		'/servers[0].priority is string'
 fi
 
-# --- 5. /uploads — endpoint retired in Phase 4g. -------------------
-#
-# /clients now covers the full peer surface (every upload_state,
-# including queue waiters and download-side peers). Consumers filter
-# client-side by upload_state == "uploading" when they want the
-# legacy /uploads view. 10-refresher-lazy-ondemand.sh exercises the new shape.
-_curl -H "Authorization: Bearer $TOKEN" "$HOST/api/v0/uploads"
-_assert_status 404 "GET /uploads → 404 (retired in Phase 4g)"
-
-# --- 6. /status, /kad, /preferences — unaffected by the consolidation
+# --- 5. /status, /kad, /preferences — unaffected by the consolidation
 # (they ride on STAT_REQ and GET_PREFERENCES, which we did not touch).
 # A sanity glance to catch unrelated regressions slipping in.
 _curl -H "Authorization: Bearer $TOKEN" "$HOST/api/v0/status"

--- a/unittests/curl-tests/amuleapi/10-refresher-lazy-ondemand.sh
+++ b/unittests/curl-tests/amuleapi/10-refresher-lazy-ondemand.sh
@@ -16,7 +16,7 @@
 #   * /search/{id}/results (EC_OP_SEARCH_RESULTS, on a finished search)
 #
 # Wire changes:
-#   * /uploads RETIRED → /clients is the unified peer surface
+#   * /clients is the unified peer surface
 #   * /clients ships every alive peer (upload + download + queue +
 #     idle), with role-decoded state strings
 #   * lazy endpoints' `snapshot_at` reflects per-endpoint fetch time
@@ -91,16 +91,7 @@ TOKEN=$(curl -s -X POST -H "Content-Type: application/json" \
 # The first tick still needs ~1 s; sleep 4 covers it comfortably.
 sleep 4
 
-# --- 1. /uploads RETIRED → 404. ------------------------------------
-#
-# The legacy endpoint is gone; /clients replaces it with role-decoded
-# state for every peer (upload + download + queue + idle). Consumers
-# wanting the legacy view filter client-side by upload_state ==
-# "uploading".
-_curl -H "Authorization: Bearer $TOKEN" "$HOST/api/v0/uploads"
-_assert_status 404 "GET /uploads → 404 (endpoint retired)"
-
-# --- 2. /clients shape. --------------------------------------------
+# --- 1. /clients shape. --------------------------------------------
 #
 # Phase 4g unified peer surface. Every alive peer in
 # theApp->clientlist surfaces, populated from the EC_TAG_CLIENT

--- a/unittests/curl-tests/amuleapi/13-downloads-delete-clear.sh
+++ b/unittests/curl-tests/amuleapi/13-downloads-delete-clear.sh
@@ -4,7 +4,7 @@
 #
 # Endpoints:
 #   DELETE /api/v0/downloads/{hash}             — drop a single entry
-#   POST   /api/v0/downloads/clear_completed    — drop all completed
+#   POST   /api/v0/downloads_clear_completed    — drop all completed
 #
 # Routing by current state:
 #   * status == "completed" → EC_OP_CLEAR_COMPLETED (by ECID; targets
@@ -103,7 +103,7 @@ sleep 4
 _curl -X DELETE "$HOST/api/v0/downloads/$TEST_HASH"
 _assert_status 401 "DELETE /downloads/{hash} (no token) → 401"
 
-_curl -X POST "$HOST/api/v0/downloads/clear_completed"
+_curl -X POST "$HOST/api/v0/downloads_clear_completed"
 _assert_status 401 "POST /downloads/clear_completed (no token) → 401"
 
 if [ "$HAVE_GUEST" = "1" ]; then
@@ -111,7 +111,7 @@ if [ "$HAVE_GUEST" = "1" ]; then
 		"$HOST/api/v0/downloads/$TEST_HASH"
 	_assert_status 403 "DELETE /downloads/{hash} (guest) → 403"
 	_curl -X POST -H "Authorization: Bearer $GUEST_TOKEN" \
-		"$HOST/api/v0/downloads/clear_completed"
+		"$HOST/api/v0/downloads_clear_completed"
 	_assert_status 403 "POST /downloads/clear_completed (guest) → 403"
 else
 	echo "    info: no guest pass; admin-gate skipped"
@@ -129,7 +129,7 @@ _assert_status 404 "DELETE /downloads/{nonexistent} → 404"
 # may have left a completed entry behind, or it may not have. We
 # call clear once to baseline, then move on.)
 _curl -X POST -H "Authorization: Bearer $ADMIN_TOKEN" \
-	"$HOST/api/v0/downloads/clear_completed"
+	"$HOST/api/v0/downloads_clear_completed"
 _assert_status 200 "POST /downloads/clear_completed (baseline) → 200"
 # The shared results envelope has no top-level `ok`: per-item success lives on
 # each entry, so a partial outcome cannot be reported as a single boolean.
@@ -137,7 +137,7 @@ _assert_json_eq '.results | type' array 'clear_completed returns a results array
 
 # Second call: now nothing is completed. cleared must be 0.
 _curl -X POST -H "Authorization: Bearer $ADMIN_TOKEN" \
-	"$HOST/api/v0/downloads/clear_completed"
+	"$HOST/api/v0/downloads_clear_completed"
 _assert_status 200 "POST /downloads/clear_completed (idempotent no-op) → 200"
 # An empty `results` array is the no-op. It was `cleared: 0`, a shape only this
 # endpoint used.
@@ -201,7 +201,7 @@ _assert_status 404 "DELETE the same hash twice → 404 second time"
 _curl -X POST -H "Authorization: Bearer $ADMIN_TOKEN" \
 	-H "Content-Type: application/json" \
 	-d '{"hash":"baadbaadbaadbaadbaadbaadbaadbaad"}' \
-	"$HOST/api/v0/downloads/clear_completed"
+	"$HOST/api/v0/downloads_clear_completed"
 _assert_status 404 "POST clear_completed {hash:unknown} → 404"
 _assert_json_eq '.error.code' not_found 'clear_completed {hash:unknown}.error.code'
 
@@ -209,13 +209,13 @@ _assert_json_eq '.error.code' not_found 'clear_completed {hash:unknown}.error.co
 _curl -X POST -H "Authorization: Bearer $ADMIN_TOKEN" \
 	-H "Content-Type: application/json" \
 	-d 'not json at all' \
-	"$HOST/api/v0/downloads/clear_completed"
+	"$HOST/api/v0/downloads_clear_completed"
 _assert_status 400 "POST clear_completed (malformed body) → 400"
 
 _curl -X POST -H "Authorization: Bearer $ADMIN_TOKEN" \
 	-H "Content-Type: application/json" \
 	-d '{"hash": 12345}' \
-	"$HOST/api/v0/downloads/clear_completed"
+	"$HOST/api/v0/downloads_clear_completed"
 _assert_status 400 "POST clear_completed {hash: non-string} → 400"
 
 # --- 8. POST clear_completed {hash:active-partfile} → 409. --------
@@ -246,7 +246,7 @@ done
 _curl -X POST -H "Authorization: Bearer $ADMIN_TOKEN" \
 	-H "Content-Type: application/json" \
 	-d "{\"hash\":\"$TEST_HASH\"}" \
-	"$HOST/api/v0/downloads/clear_completed"
+	"$HOST/api/v0/downloads_clear_completed"
 _assert_status 409 "POST clear_completed {hash:active-partfile} → 409"
 _assert_json_eq '.error.code' not_completed \
 	'clear_completed active hash .error.code == not_completed'
@@ -275,7 +275,7 @@ if [ -n "$COMPLETED_HASH" ]; then
 	_curl -X POST -H "Authorization: Bearer $ADMIN_TOKEN" \
 		-H "Content-Type: application/json" \
 		-d "{\"hash\":\"$COMPLETED_HASH\"}" \
-		"$HOST/api/v0/downloads/clear_completed"
+		"$HOST/api/v0/downloads_clear_completed"
 	_assert_status 200 "POST clear_completed {hash:completed} → 200"
 	_assert_json_eq '.results | length' 1 'per-hash clear_completed cleared exactly 1'
 	_assert_json_eq '.results[0].id' "$COMPLETED_HASH" \
@@ -286,7 +286,7 @@ if [ -n "$COMPLETED_HASH" ]; then
 	_curl -X POST -H "Authorization: Bearer $ADMIN_TOKEN" \
 		-H "Content-Type: application/json" \
 		-d "{\"hash\":\"$COMPLETED_HASH\"}" \
-		"$HOST/api/v0/downloads/clear_completed"
+		"$HOST/api/v0/downloads_clear_completed"
 	_assert_status 404 "POST clear_completed {hash:already-cleared} → 404"
 else
 	_skip "DELETE on completed → 409 (no completed entry in test daemon)"

--- a/unittests/curl-tests/amuleapi/14-servers-mutations.sh
+++ b/unittests/curl-tests/amuleapi/14-servers-mutations.sh
@@ -344,35 +344,35 @@ _assert_status 400 "DELETE /servers/not-a-number → 400"
 # caller's mistake (400), one that parses but names no server we hold is
 # simply absent (404). They used to collapse onto the same 404 because the
 # resolver signalled every failure by returning ECID 0.
-# Every case carries a colon on purpose: the dispatcher only routes to the
-# by-address handler when the capture contains one, so a colon-less value
-# would be read as an ECID and 400 for an unrelated reason.
+# The address form has its own path now, so a colon is no longer what selects
+# the handler: a value without one reaches the same place and is rejected for
+# being a malformed address rather than for looking like an ECID.
 for bad in "not-an-ip:4242" "1.2.3.4:" ":4242" "1.2.3.4:0" "1.2.3.4:70000" \
-	"1.2.3.4:abc" "999.1.1.1:4242"; do
+	"1.2.3.4:abc" "999.1.1.1:4242" "no-colon-at-all"; do
 	_curl -X DELETE -H "Authorization: Bearer $ADMIN_TOKEN" \
-		"$HOST/api/v0/servers/$bad"
-	_assert_status 400 "DELETE /servers/$bad (malformed selector) → 400"
+		"$HOST/api/v0/servers/by-address/$bad"
+	_assert_status 400 "DELETE /servers/by-address/$bad (malformed address) → 400"
 done
 
 # Well-formed but absent: TEST-NET-1 (RFC 5737), never a real server.
 _curl -X DELETE -H "Authorization: Bearer $ADMIN_TOKEN" \
-	"$HOST/api/v0/servers/192.0.2.1:4242"
+	"$HOST/api/v0/servers/by-address/192.0.2.1:4242"
 _assert_status 404 "DELETE /servers/192.0.2.1:4242 (unknown server) → 404"
 _assert_json_eq '.error.code' not_found \
 	'unknown ip:port carries error.code=not_found'
 
 # Same split on the other two routes that take the selector.
 _curl -X POST -H "Authorization: Bearer $ADMIN_TOKEN" \
-	"$HOST/api/v0/servers/not-an-ip:4242/connect"
+	"$HOST/api/v0/servers/by-address/not-an-ip:4242/connect"
 _assert_status 400 "POST /servers/{malformed}/connect → 400"
 
 _curl -X POST -H "Authorization: Bearer $ADMIN_TOKEN" \
-	"$HOST/api/v0/servers/192.0.2.1:4242/connect"
+	"$HOST/api/v0/servers/by-address/192.0.2.1:4242/connect"
 _assert_status 404 "POST /servers/{unknown ip:port}/connect → 404"
 
 _curl -X PATCH -H "Authorization: Bearer $ADMIN_TOKEN" \
 	-H "Content-Type: application/json" -d '{"static":true}' \
-	"$HOST/api/v0/servers/not-an-ip:4242"
+	"$HOST/api/v0/servers/by-address/not-an-ip:4242"
 _assert_status 400 "PATCH /servers/{malformed} → 400"
 
 # --- Summary. -----------------------------------------------------

--- a/unittests/curl-tests/amuleapi/17-shared-priority-patch.sh
+++ b/unittests/curl-tests/amuleapi/17-shared-priority-patch.sh
@@ -108,7 +108,7 @@ if [ "$COUNT" = "0" ]; then
 	fi
 	echo "    info: planted fixture $FIXTURE; reloading shares"
 	curl -s -o /dev/null -X POST -H "Authorization: Bearer $ADMIN_TOKEN" \
-		"$HOST/api/v0/shared/reload"
+		"$HOST/api/v0/shared_reload"
 	# Wait for amuled to hash the file and surface it in /shared.
 	for _ in $(seq 1 30); do
 		sleep 1

--- a/unittests/curl-tests/amuleapi/19-search.sh
+++ b/unittests/curl-tests/amuleapi/19-search.sh
@@ -205,11 +205,16 @@ _assert_status 400 "POST /search (malformed JSON) → 400"
 # Multi-search: each POST /search gets its own daemon-allocated search_id
 # and its own result slot; a new search does NOT wipe the others. Every
 # read/stop/free names its id in the path -- there is no implicit target,
-# which is what the retired-route and bad-id assertions below pin down.
+# which is what the bad-id assertions below pin down.
+#
+# `results` and `stop` reach the {id} matcher and are rejected as ids, which
+# is the honest answer: they are not routes, and the rejection already names
+# where to find a real one.
 _curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/search/results"
-_assert_status 404 "GET /search/results → 404 (retired: id goes in the path)"
+_assert_status 400 "GET /search/results → 400 (id goes in the path)"
+_assert_json_eq '.error.code' bad_request '/search/results rejection names the id rule'
 _curl -X POST -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/search/stop"
-_assert_status 404 "POST /search/stop → 404 (retired: id goes in the path)"
+_assert_status 400 "POST /search/stop → 400 (id goes in the path)"
 
 _curl -X POST -H "Authorization: Bearer $ADMIN_TOKEN" \
 	-H "Content-Type: application/json" \

--- a/unittests/curl-tests/amuleapi/20-etag-conditional-get.sh
+++ b/unittests/curl-tests/amuleapi/20-etag-conditional-get.sh
@@ -279,7 +279,7 @@ fi
 
 # --- 12. ETag is stable across ticks when data IS stable. --------
 #
-# Phase 7.1 retired snapshot_at from the envelope — list endpoints
+# The envelope carries no snapshot_at — list endpoints
 # now only churn their ETag when actual data churns. /preferences is
 # the most reliable "stable" surface for this check (no per-tick
 # refresh — it changes only when an operator runs PATCH).

--- a/unittests/curl-tests/amuleapi/25-cors.sh
+++ b/unittests/curl-tests/amuleapi/25-cors.sh
@@ -320,7 +320,7 @@ if echo "$ACAM" | grep -q "POST" && echo "$ACAM" | grep -q "PATCH" \
 else
 	_fail "Allow-Methods" "expected POST/PATCH/DELETE listed, got '$ACAM'"
 fi
-# PUT specifically: PUT /api/v0/shared/directories is a real route (the
+# PUT specifically: PUT /api/v0/share_directories is a real route (the
 # replace-the-whole-share-root-list form), and it was missing from the
 # advertised list. A browser doing a cross-origin PUT there was told the
 # method is not allowed and blocked the request before sending it -- the
@@ -335,7 +335,7 @@ fi
 _curl -X OPTIONS \
 	-H "Origin: https://allowed.example.com" \
 	-H "Access-Control-Request-Method: PUT" \
-	"$HOST/api/v0/shared/directories"
+	"$HOST/api/v0/share_directories"
 PUT_STATUS=$(head -1 "$HDR" | awk '{print $2}')
 PUT_ACAM=$(_hdr "Access-Control-Allow-Methods")
 if [ "$PUT_STATUS" = "204" ] && echo "$PUT_ACAM" | grep -q "PUT"; then

--- a/unittests/curl-tests/amuleapi/26-rfc-followup-endpoints.sh
+++ b/unittests/curl-tests/amuleapi/26-rfc-followup-endpoints.sh
@@ -86,7 +86,7 @@ done
 
 # --- 2. POST /shared/reload. -------------------------------------
 RC=$(curl -s -o /tmp/p11_shared_reload.json -w "%{http_code}" -X POST "${H_AUTH[@]}" \
-	"$HOST/api/v0/shared/reload")
+	"$HOST/api/v0/shared_reload")
 if [ "$RC" = "202" ]; then
 	_pass "POST /shared/reload → 202"
 else
@@ -100,7 +100,7 @@ fi
 
 # --- 3. POST /servers/update — body validation. ------------------
 RC=$(curl -s -o /tmp/p11_su.json -w "%{http_code}" -X POST "${H_AUTH[@]}" \
-	-H "Content-Type: application/json" -d '{}' "$HOST/api/v0/servers/update")
+	-H "Content-Type: application/json" -d '{}' "$HOST/api/v0/servers_update")
 if [ "$RC" = "400" ]; then
 	_pass "POST /servers/update missing url → 400"
 else
@@ -108,7 +108,7 @@ else
 fi
 RC=$(curl -s -o /tmp/p11_su.json -w "%{http_code}" -X POST "${H_AUTH[@]}" \
 	-H "Content-Type: application/json" \
-	-d '{"servers_url":"ftp://nope"}' "$HOST/api/v0/servers/update")
+	-d '{"servers_url":"ftp://nope"}' "$HOST/api/v0/servers_update")
 if [ "$RC" = "400" ]; then
 	_pass "POST /servers/update non-http url → 400"
 else
@@ -117,7 +117,7 @@ fi
 RC=$(curl -s -o /tmp/p11_su.json -w "%{http_code}" -X POST "${H_AUTH[@]}" \
 	-H "Content-Type: application/json" \
 	-d '{"servers_url":"http://upd.emule-security.org/server.met"}' \
-	"$HOST/api/v0/servers/update")
+	"$HOST/api/v0/servers_update")
 if [ "$RC" = "202" ]; then
 	_pass "POST /servers/update valid url → 202"
 else
@@ -131,14 +131,14 @@ fi
 # than being turned away earlier as bad input.
 UNKNOWN_SRV=192.0.2.1:1
 RC=$(curl -s -o /dev/null -w "%{http_code}" -X POST "${H_AUTH[@]}" \
-	"$HOST/api/v0/servers/$UNKNOWN_SRV/connect")
+	"$HOST/api/v0/servers/by-address/$UNKNOWN_SRV/connect")
 if [ "$RC" = "404" ]; then
 	_pass "POST /servers/<unknown-ip:port>/connect → 404"
 else
 	_fail "address alias 404" "expected 404, got $RC"
 fi
 RC=$(curl -s -o /dev/null -w "%{http_code}" -X DELETE "${H_AUTH[@]}" \
-	"$HOST/api/v0/servers/$UNKNOWN_SRV")
+	"$HOST/api/v0/servers/by-address/$UNKNOWN_SRV")
 if [ "$RC" = "404" ]; then
 	_pass "DELETE /servers/<unknown-ip:port> → 404"
 else
@@ -149,9 +149,9 @@ fi
 # ip == 0, so a 0.0.0.0 selector could otherwise resolve to whichever
 # such row shared the port. Rejected as bad input, and the message says
 # so rather than claiming a malformed quad.
-BODY=$(curl -s -X POST "${H_AUTH[@]}" "$HOST/api/v0/servers/0.0.0.0:4242/connect")
+BODY=$(curl -s -X POST "${H_AUTH[@]}" "$HOST/api/v0/servers/by-address/0.0.0.0:4242/connect")
 RC=$(curl -s -o /dev/null -w "%{http_code}" -X POST "${H_AUTH[@]}" \
-	"$HOST/api/v0/servers/0.0.0.0:4242/connect")
+	"$HOST/api/v0/servers/by-address/0.0.0.0:4242/connect")
 if [ "$RC" = "400" ] && printf '%s' "$BODY" | jq -e '.error.code == "bad_request"' >/dev/null 2>&1; then
 	_pass "POST /servers/0.0.0.0:<port>/connect → 400 (not a server address)"
 else
@@ -163,7 +163,7 @@ else
 	_fail "0.0.0.0 rejection message" "still reports a syntax error: $BODY"
 fi
 # A genuinely malformed selector still reports malformed.
-BODY=$(curl -s -X POST "${H_AUTH[@]}" "$HOST/api/v0/servers/not-an-ip:4242/connect")
+BODY=$(curl -s -X POST "${H_AUTH[@]}" "$HOST/api/v0/servers/by-address/not-an-ip:4242/connect")
 if printf '%s' "$BODY" | jq -e '.error.message | test("malformed")' >/dev/null 2>&1; then
 	_pass "a malformed selector still reports malformed"
 else
@@ -177,7 +177,7 @@ ADDR=$(curl -s "${H_AUTH[@]}" "$HOST/api/v0/servers" \
 	| jq -r '.servers[0].address // empty')
 if [ -n "$ADDR" ] && [ "$ADDR" != "null" ]; then
 	RC=$(curl -s -o /dev/null -w "%{http_code}" -X POST "${H_AUTH[@]}" \
-		"$HOST/api/v0/servers/$ADDR/connect")
+		"$HOST/api/v0/servers/by-address/$ADDR/connect")
 	if [ "$RC" = "202" ] || [ "$RC" = "200" ]; then
 		_pass "POST /servers/$ADDR/connect resolves alias and accepts ($RC)"
 	else

--- a/unittests/curl-tests/amuleapi/30-shared-verify.sh
+++ b/unittests/curl-tests/amuleapi/30-shared-verify.sh
@@ -104,7 +104,7 @@ if [ "$COUNT" = "0" ]; then
 	fi
 	echo "    info: planted fixture $FIXTURE; reloading shares"
 	curl -s -o /dev/null -X POST -H "Authorization: Bearer $ADMIN_TOKEN" \
-		"$HOST/api/v0/shared/reload"
+		"$HOST/api/v0/shared_reload"
 	for _ in $(seq 1 30); do
 		sleep 1
 		_curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/shared"

--- a/unittests/curl-tests/amuleapi/31-shared-directories.sh
+++ b/unittests/curl-tests/amuleapi/31-shared-directories.sh
@@ -3,10 +3,10 @@
 # amuleapi 31-shared-directories — the configured share roots.
 #
 # Endpoints:
-#   GET    /api/v0/shared/directories            → {"directories":[{path,recursive}]}
-#   PUT    /api/v0/shared/directories            → replace the whole set
-#   POST   /api/v0/shared/directories            → add one (idempotent)
-#   DELETE /api/v0/shared/directories?path=...   → remove one
+#   GET    /api/v0/share_directories            → {"directories":[{path,recursive}]}
+#   PUT    /api/v0/share_directories            → replace the whole set
+#   POST   /api/v0/share_directories            → add one (idempotent)
+#   DELETE /api/v0/share_directories?path=...   → remove one
 #
 # These are the roots amuled is configured with, as opposed to /shared which
 # lists the files those roots produced. A recursive root is a single entry here
@@ -82,7 +82,7 @@ _restore() {
 			-H "Authorization: Bearer ${ADMIN_TOKEN:-}" \
 			-H "Content-Type: application/json" \
 			-d "{\"directories\":$ORIGINAL_DIRS}" \
-			"$HOST/api/v0/shared/directories" 2>/dev/null || true
+			"$HOST/api/v0/share_directories" 2>/dev/null || true
 	fi
 	rm -f "$CURL_BODY_FILE"
 	rm -rf "$SCRATCH_DIR"
@@ -105,36 +105,36 @@ HAVE_GUEST=0
 [ -n "$GUEST_TOKEN" ] && [ "$GUEST_TOKEN" != "null" ] && HAVE_GUEST=1
 
 # --- 1. Auth + method gates. ----------------------------------------
-_curl "$HOST/api/v0/shared/directories"
+_curl "$HOST/api/v0/share_directories"
 _assert_status 401 "GET /shared/directories (no token) → 401"
 
 _curl -X PUT -H "Content-Type: application/json" \
-	-d '{"directories":[]}' "$HOST/api/v0/shared/directories"
+	-d '{"directories":[]}' "$HOST/api/v0/share_directories"
 _assert_status 401 "PUT /shared/directories (no token) → 401"
 
 if [ "$HAVE_GUEST" = "1" ]; then
 	# Reading the roots is GUEST, matching GET /shared and GET /preferences.
-	_curl -H "Authorization: Bearer $GUEST_TOKEN" "$HOST/api/v0/shared/directories"
+	_curl -H "Authorization: Bearer $GUEST_TOKEN" "$HOST/api/v0/share_directories"
 	_assert_status 200 "GET /shared/directories (guest) → 200"
 
 	_curl -X PUT -H "Authorization: Bearer $GUEST_TOKEN" -H "Content-Type: application/json" \
-		-d '{"directories":[]}' "$HOST/api/v0/shared/directories"
+		-d '{"directories":[]}' "$HOST/api/v0/share_directories"
 	_assert_status 403 "PUT /shared/directories (guest) → 403"
 
 	_curl -X POST -H "Authorization: Bearer $GUEST_TOKEN" -H "Content-Type: application/json" \
-		-d "{\"path\":\"$SCRATCH_DIR\"}" "$HOST/api/v0/shared/directories"
+		-d "{\"path\":\"$SCRATCH_DIR\"}" "$HOST/api/v0/share_directories"
 	_assert_status 403 "POST /shared/directories (guest) → 403"
 
 	_curl -X DELETE -H "Authorization: Bearer $GUEST_TOKEN" \
-		"$HOST/api/v0/shared/directories?path=%2Ftmp"
+		"$HOST/api/v0/share_directories?path=%2Ftmp"
 	_assert_status 403 "DELETE /shared/directories (guest) → 403"
 fi
 
-_curl -X PATCH -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/shared/directories"
+_curl -X PATCH -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/share_directories"
 _assert_status 405 "PATCH /shared/directories → 405"
 
 # --- 2. Read the current configuration (and snapshot it). -----------
-_curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/shared/directories"
+_curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/share_directories"
 _assert_status 200 "GET /shared/directories → 200"
 _assert_json_eq '.directories | type' 'array' "directories is an array"
 ORIGINAL_DIRS=$(printf '%s' "$CURL_BODY" | jq -c '.directories')
@@ -142,27 +142,27 @@ ORIGINAL_DIRS=$(printf '%s' "$CURL_BODY" | jq -c '.directories')
 
 # --- 3. Body validation. --------------------------------------------
 _curl -X PUT -H "Authorization: Bearer $ADMIN_TOKEN" -H "Content-Type: application/json" \
-	-d 'not json' "$HOST/api/v0/shared/directories"
+	-d 'not json' "$HOST/api/v0/share_directories"
 _assert_status 400 "PUT (malformed JSON) → 400"
 
 _curl -X PUT -H "Authorization: Bearer $ADMIN_TOKEN" -H "Content-Type: application/json" \
-	-d '{}' "$HOST/api/v0/shared/directories"
+	-d '{}' "$HOST/api/v0/share_directories"
 _assert_status 400 "PUT (no directories array) → 400"
 
 _curl -X PUT -H "Authorization: Bearer $ADMIN_TOKEN" -H "Content-Type: application/json" \
-	-d '{"directories":[{"path":""}]}' "$HOST/api/v0/shared/directories"
+	-d '{"directories":[{"path":""}]}' "$HOST/api/v0/share_directories"
 _assert_status 400 "PUT (empty path) → 400"
 
 _curl -X PUT -H "Authorization: Bearer $ADMIN_TOKEN" -H "Content-Type: application/json" \
 	-d "{\"directories\":[{\"path\":\"$SCRATCH_DIR\",\"recursive\":\"yes\"}]}" \
-	"$HOST/api/v0/shared/directories"
+	"$HOST/api/v0/share_directories"
 _assert_status 400 "PUT (non-boolean recursive) → 400"
 
 _curl -X POST -H "Authorization: Bearer $ADMIN_TOKEN" -H "Content-Type: application/json" \
-	-d '{}' "$HOST/api/v0/shared/directories"
+	-d '{}' "$HOST/api/v0/share_directories"
 _assert_status 400 "POST (no path) → 400"
 
-_curl -X DELETE -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/shared/directories"
+_curl -X DELETE -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/share_directories"
 _assert_status 400 "DELETE (no path parameter) → 400"
 
 # --- 4. Add a real directory, then read it back. ---------------------
@@ -180,7 +180,7 @@ _assert_status 400 "DELETE (no path parameter) → 400"
 SCRATCH_ENC=$(jq -rn --arg p "$SCRATCH_DIR" '$p|@uri')
 
 _curl -X POST -H "Authorization: Bearer $ADMIN_TOKEN" -H "Content-Type: application/json" \
-	-d "{\"path\":\"$SCRATCH_DIR\",\"recursive\":true}" "$HOST/api/v0/shared/directories"
+	-d "{\"path\":\"$SCRATCH_DIR\",\"recursive\":true}" "$HOST/api/v0/share_directories"
 SCRATCH_REJECTION=$(printf '%s' "$CURL_BODY" |
 	jq -r "[.results[] | select(.id==\"$SCRATCH_DIR\" and .ok==false)][0].error.code" 2>/dev/null)
 SHARE_FS_VISIBLE=1
@@ -199,7 +199,7 @@ _assert_status 200 "POST (add scratch dir, recursive) → 200"
 _assert_json_eq '.results | type' array "POST returns a results array"
 _assert_json_eq '[.results[] | select(.ok==false)] | length' '0' "POST rejected nothing"
 
-_curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/shared/directories"
+_curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/share_directories"
 _assert_json_eq \
 	"[.directories[] | select(.path==\"$SCRATCH_DIR\")] | length" '1' \
 	"added directory is listed"
@@ -209,10 +209,10 @@ _assert_json_eq \
 
 # Idempotent re-add: no duplicate, and the flag follows the new value.
 _curl -X POST -H "Authorization: Bearer $ADMIN_TOKEN" -H "Content-Type: application/json" \
-	-d "{\"path\":\"$SCRATCH_DIR\",\"recursive\":false}" "$HOST/api/v0/shared/directories"
+	-d "{\"path\":\"$SCRATCH_DIR\",\"recursive\":false}" "$HOST/api/v0/share_directories"
 _assert_status 200 "POST (re-add same path) → 200"
 
-_curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/shared/directories"
+_curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/share_directories"
 _assert_json_eq \
 	"[.directories[] | select(.path==\"$SCRATCH_DIR\")] | length" '1' \
 	"re-add did not duplicate the entry"
@@ -226,7 +226,7 @@ fi # SHARE_FS_VISIBLE -- section 4
 # nowhere is rejected either way.
 BOGUS="$SCRATCH_DIR/definitely-not-here"
 _curl -X POST -H "Authorization: Bearer $ADMIN_TOKEN" -H "Content-Type: application/json" \
-	-d "{\"path\":\"$BOGUS\"}" "$HOST/api/v0/shared/directories"
+	-d "{\"path\":\"$BOGUS\"}" "$HOST/api/v0/share_directories"
 # A rejection makes the whole response 207, as with every other multi-item
 # mutation. It was 200, which meant a caller had to read the body to learn that
 # part of the request had not applied.
@@ -235,7 +235,7 @@ _assert_json_eq \
 	"[.results[] | select(.id==\"$BOGUS\")][0].error.code" 'not_found' \
 	"nonexistent path rejected as not_found"
 
-_curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/shared/directories"
+_curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/share_directories"
 _assert_json_eq \
 	"[.directories[] | select(.path==\"$BOGUS\")] | length" '0' \
 	"rejected path was not stored"
@@ -247,10 +247,10 @@ _assert_json_eq \
 
 # --- 6. Remove it again. --------------------------------------------
 _curl -X DELETE -H "Authorization: Bearer $ADMIN_TOKEN" \
-	"$HOST/api/v0/shared/directories?path=$SCRATCH_ENC"
+	"$HOST/api/v0/share_directories?path=$SCRATCH_ENC"
 _assert_status 200 "DELETE (configured path) → 200"
 
-_curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/shared/directories"
+_curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/share_directories"
 _assert_json_eq \
 	"[.directories[] | select(.path==\"$SCRATCH_DIR\")] | length" '0' \
 	"deleted directory is gone"
@@ -258,7 +258,7 @@ fi # SHARE_FS_VISIBLE -- sections 5b and 6
 
 # Never configured, whether or not the scratch dir ever was.
 _curl -X DELETE -H "Authorization: Bearer $ADMIN_TOKEN" \
-	"$HOST/api/v0/shared/directories?path=$SCRATCH_ENC"
+	"$HOST/api/v0/share_directories?path=$SCRATCH_ENC"
 _assert_status 404 "DELETE (path not configured) → 404"
 
 # --- Summary. -------------------------------------------------------

--- a/unittests/curl-tests/amuleapi/36-shared-reload.sh
+++ b/unittests/curl-tests/amuleapi/36-shared-reload.sh
@@ -3,7 +3,7 @@
 # amuleapi 36-shared-reload — POST /shared/reload.
 #
 # Endpoint:
-#   POST /api/v0/shared/reload   → 202 {"ok":true}
+#   POST /api/v0/shared_reload   → 202 {"ok":true}
 #
 # amuled schedules a re-walk of every configured share root and answers
 # immediately, so the call is accepted (202), never completed (200). The walk
@@ -92,18 +92,18 @@ HAVE_GUEST=0
 sleep 4
 
 # --- 1. Auth guards. -----------------------------------------------
-_curl -X POST "$HOST/api/v0/shared/reload"
+_curl -X POST "$HOST/api/v0/shared_reload"
 _assert_status 401 "POST /shared/reload (no creds) → 401"
 
 if [ "$HAVE_GUEST" -eq 1 ]; then
-	_curl -X POST -H "Authorization: Bearer $GUEST_TOKEN" "$HOST/api/v0/shared/reload"
+	_curl -X POST -H "Authorization: Bearer $GUEST_TOKEN" "$HOST/api/v0/shared_reload"
 	_assert_status 403 "POST /shared/reload (guest) → 403"
 else
 	echo "    info: no guest password configured; skipping the 403 guard check"
 fi
 
 # --- 2. Accept path. -----------------------------------------------
-_curl -X POST -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/shared/reload"
+_curl -X POST -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/shared_reload"
 _assert_status 202 "POST /shared/reload (admin) → 202"
 _assert_json_eq '.ok' true "/shared/reload → ok=true"
 
@@ -112,7 +112,7 @@ _assert_json_eq '.ok' true "/shared/reload → ok=true"
 # must be accepted the same way, not rejected as a conflict and not queued
 # into a second walk. Only the status is observable from here; that the two
 # collapse into one walk is amuled-side and shows up in its log.
-_curl -X POST -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/shared/reload"
+_curl -X POST -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/shared_reload"
 _assert_status 202 "POST /shared/reload again immediately → 202"
 _assert_json_eq '.ok' true "second /shared/reload → ok=true"
 
@@ -121,7 +121,7 @@ _assert_json_eq '.ok' true "second /shared/reload → ok=true"
 # behaviour, not a timing guarantee. SimpleConnControlOp also runs an inline
 # RefresherTick, so a handful of EC roundtrips are included in the figure.
 START=$(date +%s)
-_curl -X POST -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/shared/reload"
+_curl -X POST -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/shared_reload"
 ELAPSED=$(( $(date +%s) - START ))
 _assert_status 202 "POST /shared/reload (timed) → 202"
 if [ "$ELAPSED" -le 10 ]; then
@@ -142,10 +142,10 @@ _assert_status 200 "GET /shared right after a reload → 200"
 _assert_json_eq '.shared | type' array "/shared still serves a coherent list"
 
 # --- 6. Method gate. -----------------------------------------------
-_curl -X GET -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/shared/reload"
+_curl -X GET -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/shared_reload"
 _assert_status 405 "GET /shared/reload → 405"
 
-_curl -X DELETE -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/shared/reload"
+_curl -X DELETE -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/shared_reload"
 _assert_status 405 "DELETE /shared/reload → 405"
 
 # --- Summary. -----------------------------------------------------

--- a/unittests/curl-tests/amuleapi/40-http-conformance.sh
+++ b/unittests/curl-tests/amuleapi/40-http-conformance.sh
@@ -440,7 +440,7 @@ fi
 
 # A route with a richer verb set reports all of it.
 curl -s -o "$BODY_FILE" -D "$HDR_FILE" --max-time 10 \
-	"${AUTH[@]}" -X PATCH "$HOST/api/v0/shared/directories" >/dev/null
+	"${AUTH[@]}" -X PATCH "$HOST/api/v0/share_directories" >/dev/null
 ALLOW_DIRS=$(_hdr Allow)
 for m in GET HEAD POST PUT DELETE; do
 	case "$ALLOW_DIRS" in
@@ -495,7 +495,7 @@ fi
 
 # --- 4. The CORS preflight advertises every method the route serves. --
 #
-# PUT /api/v0/shared/directories is a real route (the replace-the-whole-list
+# PUT /api/v0/share_directories is a real route (the replace-the-whole-list
 # form). It was missing from the advertised list, so a browser doing a
 # cross-origin PUT there was told the method is not allowed and blocked the
 # request before it was ever sent -- reachable from curl, unreachable from a
@@ -503,7 +503,7 @@ fi
 curl -s -o /dev/null -D "$HDR_FILE" --max-time 10 -X OPTIONS \
 	-H "Origin: http://example.invalid" \
 	-H "Access-Control-Request-Method: PUT" \
-	"$HOST/api/v0/shared/directories" >/dev/null
+	"$HOST/api/v0/share_directories" >/dev/null
 ACAM=$(_hdr Access-Control-Allow-Methods)
 if [ -z "$ACAM" ]; then
 	_skip "preflight method list (CORS disabled; no Access-Control-Allow-Methods)"

--- a/unittests/tests/PathPatternsTest.cpp
+++ b/unittests/tests/PathPatternsTest.cpp
@@ -329,9 +329,11 @@ TEST(PathPatterns, Match_RejectsAnEmptyCapture)
 // already handled: the comparison simply fails.
 TEST(PathPatterns, Match_StillRejectsAMissegmentedLiteral)
 {
-	const auto pat = ParsePattern("/api/v0/shared/reload");
+	// Same segment count, so the rejection has to come from the literal
+	// comparison rather than from the length check.
+	const auto pat = ParsePattern("/api/v0/version/check");
 	std::map<std::string, std::string> caps;
-	ASSERT_TRUE(!Match(pat, SplitPath("/api/v0/shared/"), caps));
+	ASSERT_TRUE(!Match(pat, SplitPath("/api/v0/version/"), caps));
 }
 
 // ----------------------------------------------------------------------

--- a/unittests/tests/StateTest.cpp
+++ b/unittests/tests/StateTest.cpp
@@ -1182,7 +1182,7 @@ TEST(State, MemoizableTargetExcludesEverythingElse)
 	// live EC roundtrip per read, and the bare collection a trailing-slash
 	// prefix could never match
 	ASSERT_TRUE(!MemoizableTarget("/api/v0/search"));
-	ASSERT_TRUE(!MemoizableTarget("/api/v0/shared/directories"));
+	ASSERT_TRUE(!MemoizableTarget("/api/v0/share_directories"));
 	// per-principal: one key cannot describe two callers' documents
 	ASSERT_TRUE(!MemoizableTarget("/api/v0/auth/session"));
 	// snapshot-backed, but not worth a memo -- and absent by default
@@ -1199,7 +1199,7 @@ TEST(State, MemoizableTargetDoesNotExtendToSubResources)
 	ASSERT_TRUE(!MemoizableTarget("/api/v0/downloads/8b54a3c2"));
 	ASSERT_TRUE(!MemoizableTarget("/api/v0/downloads/8b54a3c2/clients"));
 	ASSERT_TRUE(!MemoizableTarget("/api/v0/shared/8b54a3c2"));
-	ASSERT_TRUE(!MemoizableTarget("/api/v0/shared/directories"));
+	ASSERT_TRUE(!MemoizableTarget("/api/v0/share_directories"));
 	// and no prefix bleed onto a neighbour that merely starts the same
 	ASSERT_TRUE(!MemoizableTarget("/api/v0/downloads_archive"));
 	ASSERT_TRUE(!MemoizableTarget("/api/v0/sharedfiles"));


### PR DESCRIPTION
Addresses §7 and §8 of #1107, the last two sections.

The dispatcher is an ordered if-chain, so a literal path placed before a capture pattern makes that segment value unreachable: `/shared/reload` and `/shared/directories` sit where a file hash goes, `/downloads/clear_completed` where a hash goes, `/servers/update` where an ecid goes. The collision cannot happen today, since a hash is 32 hex chars and an ecid is decimal, but the collection's sub-resources and its members share one namespace, so every future `/shared/<verb>` narrows the hash space again.

They move out: `/share_directories`, `/shared_reload`, `/downloads_clear_completed`, `/servers_update`. The member namespace now holds only members.

**§7:** `{ecid}` also carried two identity domains, disambiguated by sniffing the capture for a colon. That is a dispatch rule invisible from outside, and it forecloses ever accepting an IPv6 literal, since those are all colons. The address form gets `/servers/by-address/{address}`, matched before the `{ecid}` patterns, and the sniffing is gone.

## Tombstones removed

`/search/results` and `/search/stop` existed only to answer `404` with a nicer message. v0 is a work in progress with no compat promise, so they are not worth carrying. Both now reach the `{id}` matcher and are rejected as ids, and that rejection already reads ``` `{id}` must be a positive decimal search_id (see GET /search) ```, so the friendlier error was buying less than its comment claimed.

The same audit removed two curl blocks that existed only to assert a removed `/uploads` still `404`s, and rewrote nine comments across `Api.cpp`, `Api.h`, `State.h`, four curl phases and `REFERENCE.md` that narrated what used to exist rather than describing what does.

Kept, because they are not tombstones: the `a4af` GET and the logs PATCH answer `405` because the resource exists and the method does not, and a search evicted from amuled's ring is "retired as finished" in the daemon's own vocabulary.

## The sweep

87 absolute-path rewrites across ten files, three WebUI call sites, three cctest references. **Four callers were missed by a literal-path regex** and found by the suite or by a second grep: three build their URL from a variable (`"$HOST/api/v0/servers/$UNKNOWN_SRV"`), and two assertions pinned the tombstone 404s. Worth knowing for the next sweep of this shape.

The WebUI was audited against the whole #1107 series, not just this PR: the three renamed call sites are updated, the i18n key `downloads_clear_completed` was left alone despite now matching the new path, and nothing else needed changing.

## Verification

13 affected phases. 11 passed outright; `19` and `20` needed a re-run because the daemon **started the suite connected to a server that answers no searches and drifted to another mid-run** - 33 failures that were entirely the environment. On a server confirmed to answer (248 results for "ubuntu"), the remaining failures are 2, both `Kad search can't be done if Kad is not running` on a daemon with Kad disabled. A `related::` failure that looked real reproduced as a connection flap and passes on re-run.

`ctest` 43/43, clang-format clean, Tier-2 clang-tidy clean on the diff with 0 compiler errors.
