### PR TITLE
fix(core): restore search results after the download queue, not before

### DIFF
--- a/src/amule-gui.cpp
+++ b/src/amule-gui.cpp
@@ -239,6 +239,18 @@ int CamuleGuiBase::InitGui(bool geometry_enabled, wxString &geom_string)
 		amuledlg = new CamuleDlg(NULL, m_FrameTitle);
 	}
 
+	return 0;
+}
+
+// See CamuleApp::RestoreSearchTabs(). Split out of InitGui() so it can run
+// after the download queue is loaded: CSearchList::LoadSearches() computes
+// each restored result's download status against downloadqueue/knownfiles/
+// canceledfiles, and the queue is still empty while the GUI is being built
+// (#1101 -- restored results that were already downloading came back as NEW,
+// so "Hide Known Files" stopped hiding them and the daemon answered "You are
+// already trying to download the file").
+void CamuleGuiBase::CreateRestoredSearchTabs()
+{
 #ifndef CLIENT_GUI
 	// Create a tab for every search restored from StoredSearches.met
 	// (CSearchList::LoadSearches(), issue #641 Phase 3). Reuses the same
@@ -249,7 +261,7 @@ int CamuleGuiBase::InitGui(bool geometry_enabled, wxString &geom_string)
 	// startup, so every entry here is by construction a restored one.
 	//
 	// Monolithic (CSearchList) only: this file is also compiled into the
-	// amuleGUI (CLIENT_GUI) target sharing CamuleGuiBase::InitGui, where
+	// amuleGUI (CLIENT_GUI) target sharing CamuleGuiBase, where
 	// theApp->searchlist is CSearchListRem -- restored searches reach that
 	// build over EC_OP_SEARCH_LIST instead, once RegisterRestoredSearch()
 	// (amule.cpp) has made them visible to the registry it polls.
@@ -259,7 +271,7 @@ int CamuleGuiBase::InitGui(bool geometry_enabled, wxString &geom_string)
 			static_cast<uint32>(theApp->searchlist->GetSearchLifecycleKindById(kv.first)));
 		// OnSearchAdded labels the tab " (0)", right for a freshly
 		// discovered foreign search but wrong here: the restored results
-		// are already indexed (LoadSearches() ran before this loop), so
+		// are already indexed (LoadSearches() ran before this call), so
 		// the tab's list is already populated -- only the label needs
 		// correcting to match.
 		if (theApp->amuledlg && theApp->amuledlg->m_searchwnd) {
@@ -270,8 +282,6 @@ int CamuleGuiBase::InitGui(bool geometry_enabled, wxString &geom_string)
 		}
 	}
 #endif
-
-	return 0;
 }
 
 // Sets m_FrameTitle

--- a/src/amule.cpp
+++ b/src/amule.cpp
@@ -894,17 +894,6 @@ bool CamuleApp::OnInit()
 	downloadqueue = new CDownloadQueue();
 	uploadqueue = new CUploadQueue();
 
-	// Restore search results saved on a previous clean shutdown (issue #641
-	// Phase 3, StoredSearches.met). Must run only once downloadqueue/
-	// knownfiles/canceledfiles all exist, since LoadSearches() recomputes
-	// each restored result's download status against them. Registering each
-	// restored search with the EC multi-search registry makes it reachable
-	// via EC_OP_SEARCH_LIST for any client (amuleGUI/amuleapi) that connects
-	// later; monolithic tab creation for these is wired separately in
-	// amule-gui.cpp, since the search dialog doesn't exist yet here.
-	for (uint32_t restoredId : searchlist->LoadSearches()) {
-		RegisterRestoredSearch(restoredId);
-	}
 	// partFileWriteThread / partFileHashThread are constructed AFTER
 	// InitGui() further down — both spawn a wxThread in their ctor,
 	// and the amuled `-f` fork only carries the calling thread to the
@@ -1130,6 +1119,35 @@ bool CamuleApp::OnInit()
 	downloadqueue->LoadMetFiles(thePrefs::GetTempDir());
 	sharedfiles->Reload();
 #endif
+
+	// Restore search results saved on a previous clean shutdown (issue #641
+	// Phase 3, StoredSearches.met). Registering each restored search with the
+	// EC multi-search registry makes it reachable via EC_OP_SEARCH_LIST for
+	// any client (amuleGUI/amuleapi) that connects later.
+	//
+	// Deliberately *after* LoadMetFiles() and sharedfiles->Reload(), not
+	// merely after those objects are constructed. LoadSearches() recomputes
+	// each restored result's download status through
+	// CSearchFile::SetDownloadStatus(), which asks three lists whether it
+	// knows the hash. knownfiles and canceledfiles load in their own
+	// constructors, so they answer correctly from the moment they exist --
+	// but CDownloadQueue's constructor only makes an empty queue, and it is
+	// LoadMetFiles() that fills it. Running the restore before that meant
+	// every result asked an empty download queue and was told "no", so
+	// anything already downloading came back NEW instead of QUEUED. Nothing
+	// corrected it afterwards either: LoadMetFiles() appends to m_filelist
+	// directly rather than through AddDownload(), so the
+	// UpdateSearchFileByHash() that would have re-run the check never fires
+	// (#1101 -- "Hide Known Files" stopped hiding those results, while the
+	// daemon still refused the download with "You are already trying to
+	// download the file").
+	for (uint32_t restoredId : searchlist->LoadSearches()) {
+		RegisterRestoredSearch(restoredId);
+	}
+	// The monolithic search tabs are built from what the loop above just
+	// restored, so they follow it rather than sitting in InitGui() where the
+	// list is still empty. No-op on the daemon.
+	RestoreSearchTabs();
 
 	// Source seeds need two things: the part files they belong to, loaded
 	// just above, and a filter to check the seeded IPs against, which the

--- a/src/amule.h
+++ b/src/amule.h
@@ -391,6 +391,18 @@ public:
 	// derived classes may override those
 	virtual int InitGui(bool geometry_enable, wxString &geometry_string);
 
+	/**
+	 * Create a search tab for every search restored from StoredSearches.met.
+	 *
+	 * Separate from InitGui() because the two cannot share a slot in
+	 * startup order: the tabs need the restored results, and the restored
+	 * results need the download queue loaded before their status is
+	 * computed -- which happens well after the GUI is up. Called from
+	 * OnInit() right after CSearchList::LoadSearches(), and a no-op on
+	 * every build without a search dialog.
+	 */
+	virtual void RestoreSearchTabs() {}
+
 	virtual int ShowAlert(wxString msg, wxString title, int flags) = 0;
 
 	// Barry - To find out if app is running or shutting/shut down
@@ -734,6 +746,8 @@ public:
 	static void FollowSystemAppearance();
 
 	virtual int InitGui(bool geometry_enable, wxString &geometry_string);
+	//! See CamuleApp::RestoreSearchTabs().
+	void CreateRestoredSearchTabs();
 	virtual int ShowAlert(wxString msg, wxString title, int flags);
 
 	void AddGuiLogLine(const wxString &line);
@@ -757,6 +771,9 @@ class CamuleGuiApp : public CamuleApp, public CamuleGuiBase
 {
 
 	virtual int InitGui(bool geometry_enable, wxString &geometry_string);
+	// No `override`: this class declares none, and adding the first one
+	// turns -Winconsistent-missing-override into errors on every sibling.
+	virtual void RestoreSearchTabs() { CreateRestoredSearchTabs(); }
 
 	int OnExit();
 	bool OnInit();


### PR DESCRIPTION
Closes #1101, the remaining half of it: #1121 stopped the results being duplicated, and this stops the restored ones coming back with the wrong download status.

A search restored from `StoredSearches.met` came back with every result that was **already downloading** marked `NEW` instead of `QUEUED`. "Hide Known Files" then stopped hiding them, while the daemon still refused the download with "You are already trying to download the file" -- the queue knew, the search result did not.

## Cause

`CSearchList::LoadSearches()` recomputes each restored result's status through `CSearchFile::SetDownloadStatus()`, which asks three lists whether they know the hash:

```cpp
bool isPart     = theApp->downloadqueue->GetFileByID(m_abyFileHash) != NULL;   // -> QUEUED
bool isKnown    = theApp->knownfiles->FindKnownFileByID(m_abyFileHash) != NULL; // -> DOWNLOADED
bool isCanceled = theApp->canceledfiles->IsCanceledFile(m_abyFileHash);
```

Two of the three answer correctly from the moment they exist: `CKnownFileList` and `CCanceledFileList` both load in their constructors. `CDownloadQueue` does not -- its constructor makes an empty queue, and `LoadMetFiles()` fills it 150 lines further down `OnInit()`. The restore ran in between, so every result asked an empty download queue and was told no.

Nothing corrected it afterwards either: `LoadMetFiles()` appends to `m_filelist` directly instead of going through `AddDownload()`, so the `UpdateSearchFileByHash()` that would have re-run the check never fires. The wrong status was permanent for the life of the process -- and since amuleGUI takes the value straight off the EC tag (`tag->DownloadStatus(...)`) rather than computing its own, reconnecting or restarting the client could not fix it. That matches the reporter's finding that a fresh amuleGUI made no difference.

The old comment on the call site asserted the ordering was fine -- "Must run only once downloadqueue/knownfiles/canceledfiles all exist" -- which is true and beside the point. *Exists* is not *loaded*.

## Measured

A probe at the call site, with part files present on disk:

| | part files on disk | queue at `LoadSearches` |
| --- | --- | --- |
| before | 2 | **0** |
| after | 3 | **3** |

## The move

The restore now runs after `LoadMetFiles()` and `sharedfiles->Reload()`.

That alone would have broken the monolithic client: `InitGui()` sits between the two points and builds a tab per restored search from `GetKnownSearchIds()`, which would have been empty by then. The tab creation is split out of `InitGui()` into `CamuleGuiBase::CreateRestoredSearchTabs()`, reached through a new `CamuleApp::RestoreSearchTabs()` hook mirroring the existing `InitGui()` virtual, and called immediately after the restore -- so it sits next to the data it depends on instead of 200 lines ahead of it. A no-op on the daemon, and on amuleGUI where the body is already `#ifndef CLIENT_GUI`.

**Startup ordering is not observable from outside the process.** The EC socket listens from `ReinitializeNetwork()`, but nothing answers a request until `OnInit()` returns and the event loop starts. Verified by stalling the daemon at its load site for 25 s: the port was in `LISTEN` and `amulecmd` blocked with no reply for the whole window, then answered in 0 s once startup finished. So no client can read search data any later than it could before.

## Notes

- **Core-side fix.** amuleGUI needs no change and no rebuild -- it renders the status the daemon sends.
- No `override` on the new hook: `CamuleGuiApp` declares none, and adding the first one turns `-Winconsistent-missing-override` into errors on seven pre-existing siblings. Annotating those is out of scope for a bugfix.

Verified on macOS: `amuled`, `amule`, `amulegui` and `amuleapi` all build; 43 of 43 cctest binaries pass; a daemon restarted with part files on disk loads them and reports the restored downloads queued.
