### PR TITLE
refactor(webapi): forward MutateClients to MutateClientsWithFiles

### DIFF
--- a/src/webapi/State.cpp
+++ b/src/webapi/State.cpp
@@ -773,9 +773,11 @@ void CState::MutateShared(const std::function<void(FileMap &)> &fn)
 
 void CState::MutateClients(const std::function<void(std::map<std::uint32_t, ClientSnapshot> &)> &fn)
 {
-	const ReentryGuard guard(this);
-	std::unique_lock<std::shared_timed_mutex> lock(m_mu);
-	fn(m_clients);
+	// Forwards rather than repeating the guard-plus-lock body: the two differ
+	// only in what they hand the callback. Still exactly one acquisition, so
+	// a caller that does not need the files pays nothing for the convenience.
+	MutateClientsWithFiles(
+		[&fn](std::map<std::uint32_t, ClientSnapshot> &clients, const FileMap &) { fn(clients); });
 }
 
 void CState::MutateClientsWithFiles(

--- a/src/webapi/State.h
+++ b/src/webapi/State.h
@@ -1709,6 +1709,10 @@ public:
 	// its internal hash→ECID index in sync on every emplace/erase.
 	void MutateDownloads(const std::function<void(FileMap &)> &fn);
 	void MutateShared(const std::function<void(FileMap &)> &fn);
+	//! Clients only. Reach for MutateClientsWithFiles below when the callback
+	//! also needs the file map, rather than pairing this with WithFiles: that
+	//! pair is two acquisitions where one does, which is what the clients
+	//! walker was moved off.
 	void MutateClients(const std::function<void(std::map<std::uint32_t, ClientSnapshot> &)> &fn);
 	//! Clients plus a read-only view of the file map, under the one acquisition
 	//! this was already taking. The clients walker resolves ECIDs against the


### PR DESCRIPTION
Follow-up to the review notes on #1148 (https://github.com/amule-org/amule/pull/1148#issuecomment-5410812876).

Moving the clients walker onto `MutateClientsWithFiles` left `MutateClients` with no production caller: eight test call sites and nothing else. The two are the same guard-plus-lock body differing only in what they hand the callback, so this forwards one to the other instead of keeping both.

Deleting it was the other option and it makes the tests worse. Seeding client state through a mutator is the right shape for them, and the only other public route into `m_clients` is feeding `ApplyGetUpdateToClients` a synthetic EC packet, which is more code per test and couples state-seeding to the walker. Forwarding keeps the convenient signature for the eight callers that do not need the files, and keeps one copy of the locking.

The header note points the next caller at `MutateClientsWithFiles` rather than at a `WithFiles` + `MutateClients` pair. That pair is two acquisitions where one does, and it is exactly what #1148 moved the clients walker off, so it is worth naming at the declaration rather than leaving it to be rediscovered.

No behaviour change. `StateTest` 52, `EventDiffTest` 32, `RefresherTest` 87, all passing, and clang-format is clean on both files.
