### PR TITLE
fix(webapi): hand the arenas' free pages back once a minute

### DIFF
--- a/src/webapi/App.cpp
+++ b/src/webapi/App.cpp
@@ -131,6 +131,19 @@ void CapMallocArenas()
 #endif
 }
 
+// glibc shrinks an arena's top on free (systrim / heap_trim) but never the
+// free space fragmented below it, which is what a tick decoding the whole
+// daemon state leaves. malloc_trim walks every arena's free chunks instead.
+//
+// M_TRIM_THRESHOLD, not __GLIBC__ alone: the macro comes from <malloc.h>,
+// included conditionally above, so it is what says the declaration is in scope.
+void TrimMallocArenas()
+{
+#if defined(__GLIBC__) && defined(M_TRIM_THRESHOLD)
+	malloc_trim(0);
+#endif
+}
+
 } // namespace
 
 CamuleapiApp::CamuleapiApp() = default;
@@ -616,6 +629,10 @@ void CamuleapiApp::TextShell(const wxString & /*prompt*/)
 	// keep publishing, so the returning client replays them instead.
 	constexpr unsigned kIdleTicksBeforeSuspend = 5;
 	unsigned idle_ticks = 0;
+	// Off the per-tick path: the call takes every arena's lock. Lands ~61 s
+	// apart, further if a tick overruns its second.
+	constexpr unsigned kTrimEveryTicks = 60;
+	unsigned trim_countdown = 0;
 	while (!g_shutdownRequested.load(std::memory_order_acquire)) {
 		const auto cycle_start = std::chrono::steady_clock::now();
 		if (was_failed) {
@@ -689,6 +706,16 @@ void CamuleapiApp::TextShell(const wxString & /*prompt*/)
 				<< std::chrono::duration_cast<std::chrono::milliseconds>(kOverrunWarn).count()
 				<< " ms budget) — likely EC-mutex contention or a "
 				   "stalled SendRecvSerialized.\n";
+		}
+
+		// Deliberately not gated on "nobody subscribed": that gets it wrong
+		// both ways -- never firing while a browser tab holds the stream, and
+		// firing mid-load for a client that only polls REST.
+		if (trim_countdown > 0) {
+			--trim_countdown;
+		} else {
+			TrimMallocArenas();
+			trim_countdown = kTrimEveryTicks;
 		}
 		// Sleep the REMAINDER of the target cycle in small slices so
 		// shutdown latency stays bounded. A tick that already


### PR DESCRIPTION
The first refresher tick decodes amuled's whole state in one go: on a 12k-file library that is a ~19 MB CECPacket/CECTag tree over ~348k allocations, freed as soon as the tick ends, interleaved with the file snapshots that stay. Peak heap is ~40 MB but peak RSS is ~117 MB, and most of that gap never comes back.

glibc shrinks the top of an arena when a free leaves enough there -- systrim for the main arena, heap_trim for the others. What it does not reclaim is free space *below* the top, fragmented between allocations that outlived their neighbours, which is exactly what that tick leaves. So the process sits near its peak for the rest of its life.

malloc_trim(0) walks every arena's free chunks and madvise(MADV_DONTNEED)s the pages inside them, which is what reaches the fragmented space.

Called on a plain 60-tick countdown, not gated on the daemon looking idle. Gating was the first attempt, and a gate on "nobody subscribed" gets it wrong both ways: an SSE subscriber is the normal state while a browser tab is open, so it never fires exactly when it matters -- with a subscriber a gated build never trims at all, i.e. behaves like no patch -- while a client that only polls REST never subscribes, so the same condition holds mid-load, which is what the gate was meant to avoid.

Measured with amuled + amuleapi on loopback, 12k shared files. RSS 40 s after startup, no client connected, 3 runs each:

              RSS       VmHWM
    before  117.3 MB   117.3 MB
            117.3 MB   117.3 MB
            117.2 MB   117.2 MB
    after    78.7 MB   116.9 MB
             78.5 MB   116.8 MB
             78.6 MB   117.0 MB

Same peak, ~38 MB (-33%) of it handed back. Before, RSS never drops below its high-water mark at all, which is why VmHWM and VmRSS are the same number in every run.

With an SSE subscriber connected inside the startup grace -- what a supervisor restart under an open browser tab looks like, and the case a gate would have missed -- and a 48-way concurrent REST burst on top:

    78.9 MB idle, 79.0 MB after the burst, 79.1 MB 95 s later

Running it regardless of what else is going on costs nothing measurable. Over 300 s with a subscriber connected: 201 CPU jiffies against 205 for the unpatched build, and repeat runs of the patched one vary by more than that gap; 11 minor faults against 0. Timed in-process, the call is 2.0 ms for the 38 MB after startup and 0.08 ms once there is nothing left to give back.

The countdown puts calls ~61 s apart rather than exactly 60, and further if a tick overruns its second; nothing here needs the precision.