### PR TITLE
fix(amuleapi): two live defects and the paper trail #1107 left behind

### DIFF
--- a/docs/QUICKSTART-AMULEAPI.md
+++ b/docs/QUICKSTART-AMULEAPI.md
@@ -112,8 +112,10 @@ All are readable only by you.
 ## Checking it works
 
 ```sh
-# No login needed.
-curl -s http://127.0.0.1:4713/api/v0/version
+# Is it up? /health is the probe: no login, and it answers from amuleapi's own
+# state without waiting on amuled, so it stays fast even when the daemon is
+# busy. The body also tells you whether the link to amuled is up.
+curl -s http://127.0.0.1:4713/api/v0/health
 
 # Log in, then use the token.
 TOKEN=$(curl -s -X POST "http://127.0.0.1:4713/api/v0/auth/login?type=bearer" \
@@ -121,6 +123,10 @@ TOKEN=$(curl -s -X POST "http://127.0.0.1:4713/api/v0/auth/login?type=bearer" \
     -d '{"password":"mySecret123"}' | jq -r .token)
 
 curl -s -H "Authorization: Bearer $TOKEN" http://127.0.0.1:4713/api/v0/status
+
+# Which versions are these? /version answers without a login too, but it only
+# reports the daemon's update-availability to a caller that has one.
+curl -s -H "Authorization: Bearer $TOKEN" http://127.0.0.1:4713/api/v0/version
 ```
 
 Browsers should call `/auth/login` *without* `?type=bearer` — they get a
@@ -199,6 +205,9 @@ Encryption=1              ; encrypt the link to amuled
 LoginFailureWindowSeconds=60
 LoginFailureThreshold=5   ; this many bad logins...
 LoginLockoutSeconds=300   ; ...locks that address out for this long
+TokenFailureWindowSeconds=60
+TokenFailureThreshold=30  ; same, for rejected tokens on any other endpoint
+TokenLockoutSeconds=300
 
 [Streaming]
 EventBusRingCapacity=16384

--- a/docs/api/EVENTS.md
+++ b/docs/api/EVENTS.md
@@ -75,6 +75,8 @@ If the daemon restarts between steps 1 and 2, or the ring buffer overflows on a 
 
 `GET /api/v0/events` opens the stream. Auth runs synchronously BEFORE the worker thread is spawned and before the 32-slot streaming budget is touched, so an unauthenticated peer can't tie up a slot for the read-timeout window.
 
+`HEAD` returns the stream's headers and no body. Any other method is `405` with `Allow: GET, HEAD`, like every other route — it used to be a `404` here, which read as "the endpoint does not exist" to a client probing the surface. A trailing slash is stripped first, so `/api/v0/events/` opens the same stream.
+
 ```sh
 TOKEN=$(curl -s -X POST -H "Content-Type: application/json" \
   -d '{"password":"adminpass"}' \

--- a/docs/api/REFERENCE.md
+++ b/docs/api/REFERENCE.md
@@ -14,8 +14,8 @@ The API is versioned in the path. Breaking changes ship under `/api/v1/`; `/api/
 - [Backward compatibility](#backward-compatibility)
 
 **System**
-- [`GET /api/v0/health`](#get-apiv0health) - liveness probe; readiness flags in the body
-- [`GET /api/v0/version`](#get-apiv0version) — public version probe (+ daemon update-availability)
+- [`GET /api/v0/health`](#get-apiv0health) — liveness probe; readiness flags in the body
+- [`GET /api/v0/version`](#get-apiv0version) — version negotiation; identity fields are public, the `update` block needs a token
 - [`POST /api/v0/version/check`](#post-apiv0versioncheck) — trigger a daemon-side version check
 - [`GET /api/v0/status`](#get-apiv0status) — connection state, network state, headline counters
 
@@ -32,14 +32,14 @@ The API is versioned in the path. Breaking changes ship under `/api/v1/`; `/api/
 - [`GET /api/v0/downloads/{hash}/comments`](#get-apiv0downloadshashcomments) — per-source comments/ratings list (incl. retrieved Kad notes)
 - [`POST /api/v0/downloads/{hash}/comments`](#post-apiv0downloadshashcomments) — trigger an on-demand Kad notes lookup
 - [`GET /api/v0/downloads/{hash}/filenames`](#get-apiv0downloadshashfilenames) — source-reported filenames + counts
-- [`GET /api/v0/downloads/{hash}/clients`](#get-apiv0downloadshashclients) — sources and A4AF rows of one partfile
+- [`GET /api/v0/downloads/{hash}/clients`](#get-apiv0downloadshashclients--get-apiv0sharedhashclients) — sources and A4AF rows of one partfile
 - [`POST /api/v0/downloads/{hash}/a4af`](#post-apiv0downloadshasha4af) — force A4AF source-swapping
 - [`POST /api/v0/downloads`](#post-apiv0downloads) — add ed2k link(s)
 - [`PATCH /api/v0/downloads`](#patch-apiv0downloads) — bulk pause / resume / priority / category
 - [`DELETE /api/v0/downloads`](#delete-apiv0downloads) — bulk cancel + remove
 - [`PATCH /api/v0/downloads/{hash}`](#patch-apiv0downloadshash) — pause / resume / priority / category
 - [`DELETE /api/v0/downloads/{hash}`](#delete-apiv0downloadshash) — cancel + remove
-- [`POST /api/v0/downloads_clear_completed`](#post-apiv0downloadsclear_completed) — bulk-clear completed staging buffer
+- [`POST /api/v0/downloads_clear_completed`](#post-apiv0downloads_clear_completed) — bulk-clear completed staging buffer
 
 **Clients (peers)**
 - [`GET /api/v0/clients`](#get-apiv0clients) — list peers, optional filter
@@ -49,14 +49,14 @@ The API is versioned in the path. Breaking changes ship under `/api/v1/`; `/api/
 **Shared files**
 - [`GET /api/v0/shared`](#get-apiv0shared) — list shared files
 - [`GET /api/v0/shared/{hash}`](#get-apiv0sharedhash) — detail view; every list field plus shared-detail fields
-- [`GET /api/v0/shared/{hash}/clients`](#get-apiv0sharedhashclients) — peers of one shared file
-- [`POST /api/v0/shared_reload`](#post-apiv0sharedreload) — re-walk shared directories
+- [`GET /api/v0/shared/{hash}/clients`](#get-apiv0downloadshashclients--get-apiv0sharedhashclients) — peers of one shared file
+- [`POST /api/v0/shared_reload`](#post-apiv0shared_reload) — re-walk shared directories
 - [`POST /api/v0/shared/media/refresh`](#post-apiv0sharedmediarefresh) — re-extract media metadata for the whole share
 - [`POST /api/v0/shared/{hash}/media/refresh`](#post-apiv0sharedhashmediarefresh) — re-extract it for one file
-- [`GET /api/v0/share_directories`](#get-apiv0shareddirectories) — the configured share roots
-- [`PUT /api/v0/share_directories`](#put-apiv0shareddirectories) — replace the configured share roots
-- [`POST /api/v0/share_directories`](#post-apiv0shareddirectories) — add one share root
-- [`DELETE /api/v0/share_directories`](#delete-apiv0shareddirectories) — remove one share root
+- [`GET /api/v0/share_directories`](#get-apiv0share_directories) — the configured share roots
+- [`PUT /api/v0/share_directories`](#put-apiv0share_directories) — replace the configured share roots
+- [`POST /api/v0/share_directories`](#post-apiv0share_directories) — add one share root
+- [`DELETE /api/v0/share_directories`](#delete-apiv0share_directories) — remove one share root
 - [`POST /api/v0/shared/{hash}/verify`](#post-apiv0sharedhashverify) — re-hash a shared file against its on-disk data
 - [`PATCH /api/v0/shared`](#patch-apiv0shared) — bulk change upload priority
 - [`PATCH /api/v0/shared/{hash}`](#patch-apiv0sharedhash) — change upload priority
@@ -64,10 +64,10 @@ The API is versioned in the path. Breaking changes ship under `/api/v1/`; `/api/
 **Servers**
 - [`GET /api/v0/servers`](#get-apiv0servers) — list known ed2k servers
 - [`POST /api/v0/servers`](#post-apiv0servers) — add server
-- [`POST /api/v0/servers/{ecid}/connect`](#post-apiv0serversecidconnect--post-apiv0serversipportconnect) — connect to specific server (ECID or `ip:port`)
-- [`DELETE /api/v0/servers/{ecid}`](#delete-apiv0serversecid--delete-apiv0serversipport) — remove server (ECID or `ip:port`)
-- [`PATCH /api/v0/servers/{ecid}`](#patch-apiv0serversecid--patch-apiv0serversipport) — set server priority / static flag (ECID or `ip:port`)
-- [`POST /api/v0/servers_update`](#post-apiv0serversupdate) — refresh from `server.met` URL
+- [`POST /api/v0/servers/{ecid}/connect`](#post-apiv0serversecidconnect--post-apiv0serversby-addressaddressconnect) — connect to specific server (by ECID, or by `ip:port` under `by-address`)
+- [`DELETE /api/v0/servers/{ecid}`](#delete-apiv0serversecid--delete-apiv0serversby-addressaddress) — remove server (by ECID, or by `ip:port` under `by-address`)
+- [`PATCH /api/v0/servers/{ecid}`](#patch-apiv0serversecid--patch-apiv0serversby-addressaddress) — set server priority / static flag (by ECID, or by `ip:port` under `by-address`)
+- [`POST /api/v0/servers_update`](#post-apiv0servers_update) — refresh from `server.met` URL
 - [`GET /api/v0/friends`](#get-apiv0friends) — list the friends list
 - [`POST /api/v0/friends`](#post-apiv0friends) — add a friend, by connected peer or by address
 - [`DELETE /api/v0/friends/{ecid}`](#delete-apiv0friendsecid) — remove a friend
@@ -192,7 +192,7 @@ This is what makes rotating a leaked password effective: without it, whoever hel
 Two per-IP failure counters, both with sliding-window semantics:
 
 - **Login limiter** — drives `/auth/login`. Defaults are `[Auth]/LoginFailureWindowSeconds=60`, `LoginFailureThreshold=5`, `LoginLockoutSeconds=300`. Configurable per-deployment.
-- **Generic 401 limiter** counts every rejected token (bad, missing, expired or revoked) on any other auth-protected endpoint. Defaults are `[Auth]/TokenFailureWindowSeconds=60`, `TokenFailureThreshold=30`, `TokenLockoutSeconds=300`. Configurable per-deployment, like the login limiter: this is the one a browser tab left open overnight actually trips, so an operator serving long-lived clients may want it looser.
+- **Generic 401 limiter** counts every rejected token (bad, missing, expired or revoked) on any other auth-protected endpoint. [`GET /api/v0/version`](#get-apiv0version) is the one exception: authentication there is optional, so a request that presents no credential at all is not counted — otherwise an anonymous poller of a public endpoint could lock real sessions out. A credential that *is* presented and rejected still counts. Defaults are `[Auth]/TokenFailureWindowSeconds=60`, `TokenFailureThreshold=30`, `TokenLockoutSeconds=300`. Configurable per-deployment, like the login limiter: this is the one a browser tab left open overnight actually trips, so an operator serving long-lived clients may want it looser.
 
 When the bucket fills, the next request from that IP returns `429 rate_limited` with a `Retry-After: <seconds>` header. The bucket clears on success or when the lockout expires.
 
@@ -220,7 +220,7 @@ Nothing clamps. A count above its cap used to be quietly reduced on some endpoin
 
 ### List pagination and sorting
 
-The list endpoints (`GET /downloads`, `/clients`, `/shared`, `/servers`, `/friends`, `/categories`, `/search`, the two per-file client routes, and `/search/{id}/results`) accept optional query parameters for server-side windowing and ordering, and always return pagination metadata beside the array:
+The list endpoints (`GET /downloads`, `/clients`, `/known_clients`, `/shared`, `/servers`, `/friends`, `/chats`, `/categories`, `/search`, the two per-file client routes, and `/search/{id}/results` — the same set as the sortable-fields table below) accept optional query parameters for server-side windowing and ordering, and always return pagination metadata beside the array:
 
 | Param    | Default          | Notes |
 |----------|------------------|-------|
@@ -259,7 +259,7 @@ Omitting all four parameters preserves the previous response exactly, plus the a
 
 ### Bulk mutations and the `results` envelope
 
-Every mutation that operates on more than one item (`POST /downloads`, `PATCH /downloads`, `DELETE /downloads`, `PATCH /shared`, `POST /downloads/clear_completed`, `PUT /shared/directories`) reports one entry per input item under a unified `results` array, so a client submitting N items learns the fate of each rather than an aggregate counter or a first-error-only summary:
+Every mutation that operates on more than one item (`POST /downloads`, `PATCH /downloads`, `DELETE /downloads`, `PATCH /shared`, `POST /downloads_clear_completed`, `PUT /share_directories`) reports one entry per input item under a unified `results` array, so a client submitting N items learns the fate of each rather than an aggregate counter or a first-error-only summary:
 
 ```json
 {
@@ -286,7 +286,7 @@ A malformed **request** (missing/empty `hashes`, an invalid patch field) is stil
 
 ### Unknown values
 
-A field whose value is not known is `null`, not a sentinel. `remaining_time` is `null` rather than `-1` when there is no ETA to compute; `last_upload` and `shared_since` are `null` rather than `0` when a file has never uploaded or its `known.met` entry predates the field.
+A field whose value is not known is `null`, not a sentinel. `remaining_time` is `null` rather than `-1` when there is no ETA to compute; `last_upload`, `shared_since` and `last_seen_complete` are `null` rather than `0` when a file has never uploaded, has never been seen complete, or its `known.met` entry predates the field.
 
 A key is **omitted** only where absence itself is the meaning: something the daemon never reported, rather than something known to be absent. `started_at` on [`GET /search`](#get-apiv0search) is the example, missing for a search this process did not start, and `result_count` is missing when the daemon is too old to send it, which has to stay distinguishable from a search that found nothing.
 
@@ -337,11 +337,11 @@ Every `GET` or `HEAD` that returns `200` carries an `ETag` header. Clients that 
 
 The validator is memoized for two collections only, `/downloads` and `/shared`, keyed on the target plus a revision that every writer of those bodies advances. Repeated GETs between changes skip the body hash; everything else on the surface is hashed per request. Eligibility is opt-in rather than exclusion-based, because a resource qualifies only if its body moves solely when the state moves AND is identical for every caller. Anything with its own cache, an append-only mirror, a refresh-on-read, a live daemon roundtrip per request, or a per-caller body is simply not in the set. `/auth/session` is per-caller and is additionally marked `Cache-Control: private, no-store` (see below).
 
-`HEAD` returns the same headers as the equivalent `GET`, including `ETag` and a `Content-Length` describing the body the `GET` would return, and no content -- on every status, not only `200`. The one exception is [`GET /api/v0/events`](#get-apiv0events): its body is an unbounded chunked stream, so a `HEAD` there reports the stream's headers and no length. Note that this is why `curl -X HEAD` appears to hang or fail: `-X` only changes the method string, leaving curl waiting for a body that a HEAD response correctly never sends. Use `curl --head` (or `-I`).
+`HEAD` returns the same headers as the equivalent `GET`, including `ETag` and a `Content-Length` describing the body the `GET` would return, and no content -- on every status, not only `200`. The one exception is [`GET /api/v0/events`](EVENTS.md): its body is an unbounded chunked stream, so a `HEAD` there reports the stream's headers and no length. Note that this is why `curl -X HEAD` appears to hang or fail: `-X` only changes the method string, leaving curl waiting for a body that a HEAD response correctly never sends. Use `curl --head` (or `-I`).
 
 A validator names one representation, not one URL. When a response is compressed the `ETag` carries a `-gzip` suffix, so the gzipped and identity forms of the same resource never share a validator, and an `If-None-Match` is only a hit against the form the current request would actually receive. A client that stored `"abc123-gzip"` and then re-fetches with `Accept-Encoding: identity` gets a `200` with the identity body, which is the correct answer -- the stored entry does not describe it. Store the validator alongside the encoding you received, which is what an HTTP cache does anyway.
 
-**Caching policy.** Any request that presented credentials -- a bearer token or the session cookie -- is answered `Cache-Control: private` with `Cookie` added to `Vary`. `private` keeps the response out of shared caches, while still letting the client's own cache hold it and revalidate with `If-None-Match`; `no-store` would forbid that too and there would be no stored entry left for the conditional GET above to match. [`POST /api/v0/auth/session`](#post-apiv0authsession) is the deliberate exception and is `private, no-store`: it carries the credential itself, which should not be written down anywhere. Requests without credentials are left cacheable. Static assets are the other case. The WebUI shell and its bundles are byte-identical for every caller, so an authenticated request for one is answered exactly as an anonymous request is, and they carry `public, no-cache`. Both tokens do work. `no-cache` means revalidate every time -- not "do not store": the copy stays cached and an unchanged bundle costs one conditional request answered `304`. `public` is what lets a shared cache in front of the daemon keep one copy rather than one per caller: RFC 9111 §3.5 bars a shared cache from reusing a response to a request that carried an `Authorization` header unless the response is marked `public`, `must-revalidate` or `s-maxage`, and `no-cache` is not on that list. The browser WebUI is not the case that engages this -- it authenticates by cookie, which is why the authenticated stamp above adds `Cookie` to `Vary` rather than relying on §3.5 at all. A bearer-token client fetching the same shell is the case that engages it.
+**Caching policy.** Any request that presented credentials -- a bearer token or the session cookie -- is answered `Cache-Control: private` with `Cookie` added to `Vary`. `private` keeps the response out of shared caches, while still letting the client's own cache hold it and revalidate with `If-None-Match`; `no-store` would forbid that too and there would be no stored entry left for the conditional GET above to match. [`GET /api/v0/auth/session`](#get-apiv0authsession) is the deliberate exception and is `private, no-store`: it carries the credential itself, which should not be written down anywhere. Requests without credentials are left cacheable. Static assets are the other case. The WebUI shell and its bundles are byte-identical for every caller, so an authenticated request for one is answered exactly as an anonymous request is, and they carry `public, no-cache`. Both tokens do work. `no-cache` means revalidate every time -- not "do not store": the copy stays cached and an unchanged bundle costs one conditional request answered `304`. `public` is what lets a shared cache in front of the daemon keep one copy rather than one per caller: RFC 9111 §3.5 bars a shared cache from reusing a response to a request that carried an `Authorization` header unless the response is marked `public`, `must-revalidate` or `s-maxage`, and `no-cache` is not on that list. The browser WebUI is not the case that engages this -- it authenticates by cookie, which is why the authenticated stamp above adds `Cookie` to `Vary` rather than relying on §3.5 at all. A bearer-token client fetching the same shell is the case that engages it.
 
 There is no freshness lifetime on them because these filenames carry no content hash: `index.html`, `app.js` and `app.css` keep their names across a rebuild, so a `max-age` would let an upgraded daemon keep serving the old shell until the entry expired, and -- since each asset expires on its own clock -- pair a new shell with an old bundle. `must-revalidate` would not prevent that: it governs what a cache may do once an entry is *already* stale (RFC 9111 §5.2.2.2), not whether it may be used while fresh.
 
@@ -412,7 +412,7 @@ The handler touches no EC. amuleapi serialises EC through one worker, so a probe
 
 **Auth:** `NONE` for the identity fields, so an unauthenticated caller can negotiate versions. Use [`GET /api/v0/health`](#get-apiv0health) for liveness probing rather than this endpoint.
 
-The `update` object is **omitted unless the request is authenticated**: it reports whether this daemon is running an outdated build, which is not something an unauthenticated caller on a deliberately reachable interface should learn. A client showing an "update available" banner is already authenticated when it does.
+The `update` object is **omitted unless the request is authenticated**: it reports whether this daemon is running an outdated build, which is not something an unauthenticated caller on a deliberately reachable interface should learn. A client showing an "update available" banner is already authenticated when it does. Sending no credential is not an error here — the response is `200` with the identity fields, and it does not count against the [generic 401 limiter](#rate-limiting). Sending a *bad* one is also `200` without `update`, but does count.
 
 ```sh
 curl -s http://$HOST/api/v0/version
@@ -778,7 +778,7 @@ Same envelope as the list item, plus the detail-only fields below (all omitted f
 | Field | Type | Meaning |
 |---|---|---|
 | `progress.parts` | array | One entry per ~9.28 MiB chunk: `{ "state": string, "sources": int }` — `state` is `transferring`/`complete`/`empty`/`corrupt`/…, `sources` counts peers offering that chunk. |
-| `last_seen_complete` | int | Unix ts a complete copy was last seen across sources; `0` = never/unknown. |
+| `last_seen_complete` | int \| null | Unix ts a complete copy was last seen across sources; `null` when no complete copy has ever been seen, or the daemon does not report it. |
 | `last_changed` | int | Unix ts the partfile last received data. |
 | `download_active_time` | int | Seconds spent actively downloading. |
 | `available_part_count` | int | Number of parts available across the current sources. |
@@ -794,7 +794,7 @@ Same envelope as the list item, plus the detail-only fields below (all omitted f
 | `queued_count` | int | Clients waiting on this file's upload queue. |
 | `comment` | string | The user's own comment on this file (`""` if none). |
 | `rating` | int | The user's own rating, `0`–`5` (`0` = unrated). See the [rating scale](#get-apiv0downloadshashcomments). |
-| `a4af_auto` | bool | Whether automatic A4AF source-swapping is on for this file. See [A4AF](#get-apiv0downloadshasha4af). |
+| `a4af_auto` | bool | Whether automatic A4AF source-swapping is on for this file. See [A4AF](#post-apiv0downloadshasha4af). |
 | `media` | object | Audio/video metadata — see [Media metadata](#media-metadata). **Omitted entirely** when the file has no probed metadata. |
 
 **Errors:** `404 not_found` (no partfile with that hash), `503 ec_unavailable`.
@@ -932,7 +932,7 @@ curl -H "Authorization: Bearer $TOKEN" \
 
 **Auth:** `ADMIN`
 
-> `POST` only; a `GET` here answers `405`. A4AF sources are rows of [`GET /downloads/{hash}/clients`](#get-apiv0downloadshashclients), carrying the whole peer object rather than a bare ECID, and `a4af_auto` is on the download detail object.
+> `POST` only; a `GET` here answers `405`. A4AF sources are rows of [`GET /downloads/{hash}/clients`](#get-apiv0downloadshashclients--get-apiv0sharedhashclients), carrying the whole peer object rather than a bare ECID, and `a4af_auto` is on the download detail object.
 
 Force A4AF source-swapping for this download. Downloads-only.
 
@@ -954,7 +954,7 @@ The swap moves the peer between two files' source lists, so an SSE subscriber se
 { "a4af_auto": false, "source_ecids": [ 1234, 5678 ] }
 ```
 
-`source_ecids` are the ECIDs of the peers holding this file as an A4AF source, joinable against [`GET /api/v0/clients`](#get-apiv0clients). The array is the post-action state, so a `swap_this` naming a single peer shows up as that ECID having left it. The same peers appear as rows with `"a4af": true` on [`GET /api/v0/downloads/{hash}/clients`](#get-apiv0downloadshashclients), which carries the whole peer object rather than a bare ECID.
+`source_ecids` are the ECIDs of the peers holding this file as an A4AF source, joinable against [`GET /api/v0/clients`](#get-apiv0clients). The array is the post-action state, so a `swap_this` naming a single peer shows up as that ECID having left it. The same peers appear as rows with `"a4af": true` on [`GET /api/v0/downloads/{hash}/clients`](#get-apiv0downloadshashclients--get-apiv0sharedhashclients), which carries the whole peer object rather than a bare ECID.
 
 **Errors:** `400 bad_request` (missing or unknown `action`; a non-integer `client_ecid`; `client_ecid` with the wrong action), `400 amuled_rejected` (the daemon refused the swap — most commonly because the peer is actively sending data, which it will not be swapped away from), `404 not_found` (no download with that hash, or no client with that ECID), `409 conflict` (that client is not an A4AF source of this download), `503 ec_unavailable`.
 
@@ -1018,7 +1018,7 @@ curl -s -X PATCH -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application
 
 **Auth:** `ADMIN`
 
-Bulk cancel + remove of active downloads (deletes each `.part`/`.met` from disk). A completed entry is rejected per-item with `completed_use_clear_completed` — clear those via `POST /downloads/clear_completed`.
+Bulk cancel + remove of active downloads (deletes each `.part`/`.met` from disk). A completed entry is rejected per-item with `completed_use_clear_completed` — clear those via `POST /downloads_clear_completed`.
 
 **Body:** `{ "hashes": ["<md4>", …] }` (non-empty, max 500).
 
@@ -1035,7 +1035,7 @@ Mutates one or more fields of a single partfile. `{hash}` is the 32-char MD4 hex
 **Body:** at least one of:
 
 - `status` — `"paused"`, `"resumed"` or `"stopped"`. `"paused"` halts transfer but keeps the file's sources; `"stopped"` additionally drops all known sources and resets the Kad source search (a stopped file must rediscover sources from scratch on resume); `"resumed"` clears either state. A stopped file reports `status: "stopped"` in the download object (see [`GET /downloads`](#get-apiv0downloads)).
-- `priority` — `"low"` / `"normal"` / `"high"` / `"auto"`. Downloads support only these levels; the daemon clamps any other value to `normal`. (Shared files support the wider `very_low` … `release` set — see [`PATCH /shared/{hash}`](#patch-apiv0sharedhash).)
+- `priority` — `"low"` / `"normal"` / `"high"` / `"auto"`. Downloads support only these levels and any other value is a `400`; the reason is that the daemon's `.part.met` loader would clamp it back to `normal` on the next restart. (Shared files support the wider `very_low` … `release` set — see [`PATCH /shared/{hash}`](#patch-apiv0sharedhash) and [Priority levels](#priority-levels).)
 - `category` — uint8
 - `comment` + `rating` — set the file's comment (string, ≤ 50 chars) and rating (integer `0`–`5`). Must be sent **together**; only settable when the partfile is also shared (≥ 1 complete chunk), else `409 not_shared`. Primarily a shared-file action — see [`PATCH /shared/{hash}`](#patch-apiv0sharedhash).
 - `name` — rename the file (string). Must be non-empty and contain no path separators (`/` or `\`). See the [Takeover flow](#get-apiv0downloadshashfilenames).
@@ -1055,7 +1055,7 @@ curl -s -X PATCH -H "Authorization: Bearer $TOKEN" \
 
 **Auth:** `ADMIN`
 
-Cancels an **active** partfile and deletes its on-disk data. `{hash}` is the 32-char MD4 hex hash (case-insensitive). amuled runs `EC_OP_PARTFILE_DELETE` → `CPartFile::Delete()`, which removes the `.part`, `.part.met`, and `.met.bak` files and adds the hash to its `canceledfiles` list (so re-adding the same ed2k link is silently refused until the operator clears that list out-of-band). Completed entries are out of scope; use [`POST /downloads/clear_completed`](#post-apiv0downloadsclear_completed) instead.
+Cancels an **active** partfile and deletes its on-disk data. `{hash}` is the 32-char MD4 hex hash (case-insensitive). amuled runs `EC_OP_PARTFILE_DELETE` → `CPartFile::Delete()`, which removes the `.part`, `.part.met`, and `.met.bak` files and adds the hash to its `canceledfiles` list (so re-adding the same ed2k link is silently refused until the operator clears that list out-of-band). Completed entries are out of scope; use [`POST /downloads_clear_completed`](#post-apiv0downloads_clear_completed) instead.
 
 ```sh
 curl -s -X DELETE -H "Authorization: Bearer $TOKEN" \
@@ -1297,7 +1297,7 @@ Lists every peer the daemon has ever exchanged data with, from its credit store.
 
 Distinct from [`GET /clients`](#get-apiv0clients), which lists the peers connected **right now**. The two differ in identity as well as content: a live client is keyed by `ecid`, which is meaningful only within one daemon process, while a known client is keyed by `user_hash` and survives daemon restarts. Correlate the two on `user_hash`; the `online` field says whether a given record has a live counterpart at this moment.
 
-Standard [list envelope](#list-envelopes-and-pagination) under the `known_clients` key, with `limit` / `offset` / `sort` / `order`.
+Standard [list envelope](#list-pagination-and-sorting) under the `known_clients` key, with `limit` / `offset` / `sort` / `order`.
 
 ```sh
 curl -s -H "Authorization: Bearer $TOKEN" \
@@ -1581,7 +1581,7 @@ amuled validates every path: a REST client cannot stat the core's filesystem, so
 
 `reason` is `not_found` (missing, or not a directory) or `not_readable`. amuled reports these as codes and the API renders them, so its locale never leaks into your response.
 
-The **rescan is scheduled, not completed**, before the response returns: a successful reply means the new roots are validated and persisted, and that the re-walk will start on amuled's next processing tick. Until it finishes, [`GET /api/v0/shared`](#get-apiv0shared) still serves the previous file list. Observe completion the same way as [`POST /api/v0/shared_reload`](#post-apiv0sharedreload), whose notes on log lines and coalescing apply here too.
+The **rescan is scheduled, not completed**, before the response returns: a successful reply means the new roots are validated and persisted, and that the re-walk will start on amuled's next processing tick. Until it finishes, [`GET /api/v0/shared`](#get-apiv0shared) still serves the previous file list. Observe completion the same way as [`POST /api/v0/shared_reload`](#post-apiv0shared_reload), whose notes on log lines and coalescing apply here too.
 
 **Errors:** `400 bad_request` (`directories` not an array, an entry without a non-empty `path`, non-boolean `recursive`), `502 amuled_rejected`, `503 ec_unavailable`.
 
@@ -1607,7 +1607,7 @@ Idempotent: adding a path that is already configured updates its `recursive` fla
 
 Remove a single root. The path is a query parameter rather than a path segment because it is an absolute filesystem path.
 
-Pass the **exact** `path` string returned by `GET /shared/directories`, percent-encoded — the match is byte-for-byte, so a differing separator or drive-letter case will not match. This is what makes Windows roots work: percent-encoding carries the backslashes, the `C:` colon, and any spaces through unchanged.
+Pass the **exact** `path` string returned by `GET /share_directories`, percent-encoded — the match is byte-for-byte, so a differing separator or drive-letter case will not match. This is what makes Windows roots work: percent-encoding carries the backslashes, the `C:` colon, and any spaces through unchanged.
 
 ```sh
 # POSIX root: /home/user/new
@@ -1800,11 +1800,11 @@ Add a server to amuled's known-server list.
 
 **Errors:** `400 bad_request`, `400 amuled_rejected`, `503 ec_unavailable`.
 
-#### `POST /api/v0/servers/{ecid}/connect` / `POST /api/v0/servers/{ip}:{port}/connect`
+#### `POST /api/v0/servers/{ecid}/connect` / `POST /api/v0/servers/by-address/{address}/connect`
 
 **Auth:** `ADMIN`
 
-Tells amuled to disconnect from its current server and dial the specified one. Two route shapes are equivalent — the address form looks up the ECID by exact `(ip, port)` match against the server cache and delegates to the ECID handler. Hostname-form addresses do NOT resolve here — pass the literal IP.
+Tells amuled to disconnect from its current server and dial the specified one. Two route shapes are equivalent — `{address}` is `<ip>:<port>`, and the address form looks up the ECID by exact `(ip, port)` match against the server cache before delegating to the ECID handler. It has its own `by-address` path rather than being sniffed out of `{ecid}`, so nothing about the URL is ambiguous. Hostname-form addresses do NOT resolve here — pass the literal IP.
 
 ```sh
 curl -s -X POST -H "Authorization: Bearer $TOKEN" \
@@ -1815,7 +1815,7 @@ curl -s -X POST -H "Authorization: Bearer $TOKEN" \
 
 **Errors:** `400 bad_request` (unparseable address/ECID), `404 not_found`, `503 ec_unavailable`.
 
-#### `DELETE /api/v0/servers/{ecid}` / `DELETE /api/v0/servers/{ip}:{port}`
+#### `DELETE /api/v0/servers/{ecid}` / `DELETE /api/v0/servers/by-address/{address}`
 
 **Auth:** `ADMIN`
 
@@ -1823,9 +1823,9 @@ Removes the server from amuled's list.
 
 **Response:** `200 OK` → `{ "ok": true, "ecid": 1 }`.
 
-**Errors:** `400 bad_request` (`{ecid}` is not a non-negative integer, or an `ip:port` selector that is not a dotted quad with a port in 1–65535), `400 amuled_rejected`, `404 not_found` (well-formed but no such server), `503 ec_unavailable`.
+**Errors:** `400 bad_request` (`{ecid}` is not a non-negative integer, or `{address}` is not a dotted quad with a port in 1–65535), `400 amuled_rejected`, `404 not_found` (well-formed but no such server), `503 ec_unavailable`.
 
-#### `PATCH /api/v0/servers/{ecid}` / `PATCH /api/v0/servers/{ip}:{port}`
+#### `PATCH /api/v0/servers/{ecid}` / `PATCH /api/v0/servers/by-address/{address}`
 
 **Auth:** `ADMIN`
 
@@ -2245,7 +2245,7 @@ curl -s -X POST -H "Authorization: Bearer $TOKEN" \
 
 **Auth:** `ADMIN`
 
-Downloads a `nodes.dat` from the supplied URL and rebuilds the Kad node list from it — the Kad counterpart of [`POST /api/v0/servers_update`](#post-apiv0serversupdate), and the same operation the desktop GUI's "Update node list from URL" button drives.
+Downloads a `nodes.dat` from the supplied URL and rebuilds the Kad node list from it — the Kad counterpart of [`POST /api/v0/servers_update`](#post-apiv0servers_update), and the same operation the desktop GUI's "Update node list from URL" button drives.
 
 **Body:**
 
@@ -2349,7 +2349,7 @@ curl -s -X POST -H "Authorization: Bearer $TOKEN" \
   "http://$HOST/api/v0/ipfilter/update"
 ```
 
-An explicit URL is **persisted** into the `security.ipfilter_update_url` preference, so a subsequent `GET /preferences` reflects it and the next startup auto-update (`security.ipfilter_auto_update`) uses it — the same side effect [`POST /api/v0/servers_update`](#post-apiv0serversupdate) and [`POST /api/v0/kad/update`](#post-apiv0kadupdate) have.
+An explicit URL is **persisted** into the `security.ipfilter_update_url` preference, so a subsequent `GET /preferences` reflects it and the next startup auto-update (`security.ipfilter_auto_update`) uses it — the same side effect [`POST /api/v0/servers_update`](#post-apiv0servers_update) and [`POST /api/v0/kad/update`](#post-apiv0kadupdate) have.
 
 **Response:** `202 Accepted` → `{ "ok": true, "ipfilter_url": "..." }`. The effective URL is echoed back, so a caller that omitted it learns which one ran.
 

--- a/src/webapi/Api.cpp
+++ b/src/webapi/Api.cpp
@@ -574,12 +574,13 @@ CApiDispatcher::CApiDispatcher(CAmuleApiConfig &config, CJwt &jwt, webapi::CStat
 	  config.AuthCfg().login_failure_threshold,
 	  config.AuthCfg().login_lockout_seconds })
 ,
-// Generic-401 limiter: 30 failures within 60 s, 5-minute
-// lockout. Hard-coded for now — operators have a separate
-// knob for login-specific limits; the generic 401 cap is a
-// crash-pad against credential-stuffing across all non-
-// login endpoints and can become a config knob in 3.1 if
-// anyone asks.
+// Generic-401 limiter: a crash-pad against credential-
+// stuffing across every authenticated endpoint, counting
+// rejected tokens rather than bad passwords. Its three
+// `[Auth]/Token*` keys default to 30 failures within 60 s
+// and a 5-minute lockout, mirroring the login limiter's
+// keys above -- this is the one a browser tab left open
+// overnight trips, so it has to be tunable too.
 m_authRateLimiter(webapi::CRateLimiter::Config{ config.AuthCfg().token_failure_window_seconds,
 	config.AuthCfg().token_failure_threshold,
 	config.AuthCfg().token_lockout_seconds })
@@ -872,7 +873,7 @@ CHttpServer::Response CApiDispatcher::Dispatch(const CHttpServer::Request &req)
 	//
 	// Stamped here rather than in each handler so a new authenticated
 	// route cannot forget it, and only when the caller actually presented
-	// credentials: an unauthenticated public probe like /version stays
+	// credentials: an unauthenticated public probe like /health stays
 	// cacheable and keeps its conditional GET. A handler that set its own
 	// policy -- the static assets' public, no-cache, the country flags'
 	// public, max-age, /auth/session's private, no-store, the SSE
@@ -1015,7 +1016,7 @@ CHttpServer::Response CApiDispatcher::DispatchToHandler(const CHttpServer::Reque
 	// bulk clear-completed.
 	if (path == "/api/v0/downloads_clear_completed") {
 		if (req.method != "POST") {
-			return MethodNotAllowed("POST", "only POST on /downloads/clear_completed");
+			return MethodNotAllowed("POST", "only POST on /downloads_clear_completed");
 		}
 		return HandleDownloadsClearCompleted(req);
 	}
@@ -1085,7 +1086,7 @@ CHttpServer::Response CApiDispatcher::DispatchToHandler(const CHttpServer::Reque
 
 	if (path == "/api/v0/shared_reload") {
 		if (req.method != "POST") {
-			return MethodNotAllowed("POST", "only POST on /shared/reload");
+			return MethodNotAllowed("POST", "only POST on /shared_reload");
 		}
 		return HandleSharedReload(req);
 	}
@@ -1100,10 +1101,10 @@ CHttpServer::Response CApiDispatcher::DispatchToHandler(const CHttpServer::Reque
 		return HandleSharedMediaRefresh(req);
 	}
 
-	// /shared/directories — the configured share roots, as opposed to /shared
-	// which lists the files those roots produced. Literal path, so it has to be
-	// matched before the /shared/{hash} patterns below or "directories" would be
-	// captured as a hash.
+	// /share_directories — the configured share roots, as opposed to /shared
+	// which lists the files those roots produced. It used to be /shared/
+	// directories, one segment away from being read as a file hash; its own
+	// top-level path is why no ordering against /shared/{hash} is needed here.
 	if (path == "/api/v0/share_directories") {
 		if (req.method == "GET" || req.method == "HEAD") {
 			return HandleSharedDirectories(req);
@@ -1118,7 +1119,7 @@ CHttpServer::Response CApiDispatcher::DispatchToHandler(const CHttpServer::Reque
 			return HandleSharedDirectoriesDelete(req);
 		}
 		return MethodNotAllowed("GET, HEAD, POST, PUT, DELETE",
-			"only GET / HEAD / PUT / POST / DELETE on /shared/directories");
+			"only GET / HEAD / PUT / POST / DELETE on /share_directories");
 	}
 
 	if (path == "/api/v0/servers") {
@@ -1227,17 +1228,17 @@ CHttpServer::Response CApiDispatcher::DispatchToHandler(const CHttpServer::Reque
 
 	if (path == "/api/v0/servers_update") {
 		if (req.method != "POST") {
-			return MethodNotAllowed("POST", "only POST on /servers/update");
+			return MethodNotAllowed("POST", "only POST on /servers_update");
 		}
 		return HandleServerUpdateFromUrl(req);
 	}
 
-	// server connect & remove (single server by ECID).
-	// Address-keyed aliases live in the same block — same handlers,
-	// different lookup path. ECID forms are tried first because they
-	// match a single-segment pattern that's cheaper to dispatch; the
-	// address forms have a colon in the capture which the path pattern
-	// captures as a single segment too.
+	// server connect & remove, by ECID or by address. The two forms share their
+	// handlers and differ only in how they look the server up, so they live in
+	// one block. The address patterns are tried FIRST because they have the same
+	// segment count as their ECID counterparts: a request for the address form
+	// with "connect" as the address would otherwise match the ECID+connect
+	// pattern with `ecid == "by-address"`, and the literal segment has to win.
 	{
 		static const auto server_connect =
 			web_api_path::ParsePattern("/api/v0/servers/{ecid}/connect");
@@ -1951,13 +1952,32 @@ CHttpServer::Response CApiDispatcher::HandleHealth(const CHttpServer::Request &)
 
 CHttpServer::Response CApiDispatcher::HandleVersion(const CHttpServer::Request &req)
 {
-	// The identity fields stay unauthenticated: this is the liveness/version
-	// probe, and a probe has to work before anyone holds a token. The `update`
-	// block does not, because it reports whether THIS daemon is running an
-	// outdated build, and that is not something an unauthenticated caller on a
-	// deliberately reachable interface should learn. A client that shows an
-	// "update available" banner is already authenticated when it does.
-	const auto auth = Authenticate(req);
+	// The identity fields stay unauthenticated: version negotiation has to work
+	// before anyone holds a token. This is NOT the liveness probe, though it was
+	// used as one before there was a better answer -- /health owns that now, see
+	// HandleHealth.
+	//
+	// The `update` block does NOT stay unauthenticated, because it reports
+	// whether THIS daemon is running an outdated build, and that is not
+	// something an unauthenticated caller on a deliberately reachable interface
+	// should learn. A client that shows an "update available" banner is already
+	// authenticated when it does.
+	//
+	// Auth here is OPTIONAL, which is why this does not call Authenticate()
+	// unconditionally: that wrapper counts every 401 against the generic
+	// limiter, and a request with no credential is this endpoint's documented
+	// unauthenticated use rather than an auth failure. Counting it would let an
+	// anonymous poller -- or, behind a reverse proxy, one poller on the address
+	// every client shares -- spend the bucket in 30 requests and lock real
+	// sessions out of the whole authenticated surface for the lockout window.
+	// A credential that IS presented and rejected still counts: the `update`
+	// block appearing is an oracle a token guesser could otherwise read for
+	// free, and the wrapper's lockout pre-check keeps a locked-out address off
+	// the verify path.
+	AuthOutcome auth;
+	if (RequestCarriesCredentials(req, kSessionCookieName)) {
+		auth = Authenticate(req);
+	}
 
 	CHttpServer::Response r;
 	r.status = 200;
@@ -2803,8 +2823,13 @@ void WriteDownloadObject(
 									     f.download.speed_bps)
 						 : 0;
 		}
-		w.Key("last_seen_complete");
-		w.ValueInt(static_cast<int64_t>(f.download.last_seen_complete));
+		// Null rather than 0 for "no complete copy has ever been seen",
+		// the same rule `last_upload` / `shared_since` follow: a unix
+		// timestamp of 0 reads as 1970, not as "never".
+		WriteIntOrNull(w,
+			"last_seen_complete",
+			f.download.last_seen_complete != 0,
+			static_cast<std::int64_t>(f.download.last_seen_complete));
 		w.Key("last_changed");
 		w.ValueInt(static_cast<int64_t>(f.download.last_changed));
 		w.Key("download_active_time");
@@ -3637,16 +3662,9 @@ bool IsEcFailedResponse(const CECPacket *resp, std::string &out_msg)
 	return true;
 }
 
-// Map our wire-string priorities back to amule's PR_* encoding (the
-// inverse of DownloadPriorityName in Refresher.cpp). Downloads support
-// only LOW/NORMAL/HIGH plus AUTO: CPartFile's .part.met loader clamps
-// any download priority that isn't one of those back to PR_NORMAL on
-// load (PR_AUTO=5 is the magic value stored as High + the auto flag),
-// so `very_low` and `release` are shared/upload-side levels only. They
-// are intentionally rejected here so the download PATCH enum matches
-// what the daemon can actually hold; the shared side keeps the full
-// set in SharedPriorityToCode.
-// Returns false if the wire string isn't a known download priority.
+// Map our wire-string priorities back to amule's PR_* encoding -- the inverse of
+// PriorityName in Refresher.cpp, which is likewise one function for all three
+// resources. PR_AUTO=5 is the magic value stored as High plus the auto flag.
 // The one place the file-priority vocabulary is declared.
 //
 // /downloads, /shared and /categories all speak the PR_* code space and differ
@@ -3659,7 +3677,8 @@ bool IsEcFailedResponse(const CECPacket *resp, std::string &out_msg)
 // loader clamps anything but PR_LOW/PR_NORMAL/PR_HIGH back to Normal on
 // restart, so very_low and release are upload-side levels only and are refused
 // on the download path on purpose. Categories apply their priority to member
-// files as a download priority, so they inherit the download set.
+// files as a download priority (CDownloadQueue::SetCatPrio ->
+// CPartFile::SetDownPriority), so they inherit the download set.
 //
 // Servers are deliberately NOT in this table. SRV_PR_* is a different code
 // space in which the same word means a different number -- `low` is 0 for a
@@ -3715,7 +3734,7 @@ std::string FilePriorityAccepted(unsigned domain)
 	return "`priority` must be one of " + out;
 }
 
-// The three "fetch a list from a URL" endpoints — /servers/update,
+// The three "fetch a list from a URL" endpoints — /servers_update,
 // /kad/update and /ipfilter/update — are the same operation over three
 // different lists: take one http(s) URL, hand it to amuled in a single
 // string tag, echo the effective URL back with a 202. amuled persists the
@@ -5191,14 +5210,14 @@ CHttpServer::Response CApiDispatcher::HandleDownloadDelete(
 	// from Incoming, it just acks the post-completion notification.
 	// Conflating the two under one verb confused operators who
 	// reasonably expected DELETE to remove a file from disk. Route
-	// the completed case through POST /downloads/clear_completed
+	// the completed case through POST /downloads_clear_completed
 	// (which accepts an optional {hash} body for per-entry clears)
 	// so the verb-vs-disk-semantic mapping stays unambiguous.
 	if (d.download.status == "completed") {
 		return ErrorResponse(409,
 			"completed_use_clear_completed",
 			"DELETE only removes active downloads (deletes .part/.met "
-			"files from disk). Use POST /downloads/clear_completed "
+			"files from disk). Use POST /downloads_clear_completed "
 			"with optional {\"hash\":\"...\"} body to clear a completed "
 			"entry's post-completion notification — the file in the "
 			"Incoming directory is NEVER removed via this API.");
@@ -7029,13 +7048,13 @@ CHttpServer::Response CApiDispatcher::HandleKad(const CHttpServer::Request &req)
 namespace
 {
 
-// `?tail=N` parser. Returns 0 if the query is absent / unparseable;
-// the caller's contract is "0 means return everything". Negative or
-// non-numeric values clamp to 0.
+// `?tail=N` parser. An absent parameter yields 0, which is every caller's
+// contract for "return everything".
 // 100k lines is the cap: a bogus `?tail=2147483647` would otherwise try to
-// serialise the entire wxString through the JSON escaper. It used to clamp
-// silently, which meant a client asking for more got fewer with nothing saying
-// so; it is a 400 now, like every other out-of-range count.
+// serialise the entire wxString through the JSON escaper. Non-numeric and
+// out-of-range values are a 400, like every other count on the surface; it used
+// to clamp silently, which meant a client asking for more got fewer with
+// nothing saying so.
 std::unique_ptr<CHttpServer::Response> ParseTailParam(const std::string &query, std::size_t &out)
 {
 	const auto qmap = web_api_path::ParseQuery(query);
@@ -8623,7 +8642,7 @@ CHttpServer::Response CApiDispatcher::HandleNetworksDisconnect(const CHttpServer
 
 // POST /kad/update — refresh the Kad node list from a nodes.dat URL (#693).
 //
-// Shares ResolveFetchUrl / UrlFetchOp with /servers/update and
+// Shares ResolveFetchUrl / UrlFetchOp with /servers_update and
 // /ipfilter/update: same validation, same 202. The EC handler
 // (EC_OP_KAD_UPDATE_FROM_URL) persists the URL into preferences itself via
 // SetKadNodesUrl(), so this deliberately does NOT also patch
@@ -8802,20 +8821,12 @@ CHttpServer::Response CApiDispatcher::HandleKadBootstrap(const CHttpServer::Requ
 	return r;
 }
 
-namespace
-{
-
-// Inverse of SharedPriorityName in Refresher.cpp. Wire form mirrors
-// the /shared[].priority enum: bare upload priorities plus "auto".
-// Setting "auto" hands level selection to amuled (it derives the level
-// from the upload queue and reports it back as `priority` + a true
-// `priority_auto`); to pin a fixed level, send the bare name. The
-// combined "*_auto" strings are intentionally NOT accepted as input --
-// "auto" is the level the daemon computes, so a caller can't pin it.
-// Returns false on unknown enum.
-
-} // namespace
-
+// `priority` here mirrors the /shared[].priority enum: bare upload levels plus
+// "auto". Setting "auto" hands level selection to amuled -- it derives the level
+// from the upload queue and reports it back as `priority` plus a true
+// `priority_auto` -- so to pin a fixed level, send the bare name. The combined
+// "*_auto" strings are deliberately NOT accepted as input: "auto" is the level
+// the daemon computes, and a caller cannot pin it.
 CHttpServer::Response CApiDispatcher::HandleSharedPatch(
 	const CHttpServer::Request &req, const std::string &key)
 {
@@ -9090,13 +9101,13 @@ CHttpServer::Response CApiDispatcher::HandleDownloadsBulkDelete(const CHttpServe
 			continue;
 		}
 		// Same guard as the single-item DELETE: completed entries are not
-		// removable here (use POST /downloads/clear_completed).
+		// removable here (use POST /downloads_clear_completed).
 		if (d.download.status == "completed") {
 			results.push_back(BulkErr(raw,
 				409,
 				"completed_use_clear_completed",
 				"DELETE only removes active downloads; use POST "
-				"/downloads/clear_completed to clear a completed entry"));
+				"/downloads_clear_completed to clear a completed entry"));
 			continue;
 		}
 		CMD4Hash file_hash;
@@ -9719,15 +9730,6 @@ bool ParseCategoryIndex(const std::string &s, std::uint8_t &out)
 	out = static_cast<std::uint8_t>(v);
 	return true;
 }
-
-// Inverse of CategoryPriorityName (Refresher.cpp's ParseCategoryTag).
-// A category priority is applied to member files as a DOWNLOAD priority
-// (CDownloadQueue::SetCatPrio -> CPartFile::SetDownPriority), so it must use
-// the same restricted set as DownloadPriorityToCode: low / normal / high /
-// auto. very_low and release are not real download levels -- the .part.met
-// loader clamps anything but PR_LOW/PR_NORMAL/PR_HIGH back to Normal on the
-// next restart -- so accepting them here would be the same silent downgrade
-// #396 fixed for the direct download PATCH path (issue #384).
 
 // Build the CEC_Category_Tag-shaped tag amuled expects. The shape is:
 //  parent tag EC_TAG_CATEGORY with the index as the int payload,

--- a/src/webapi/static/js/views/downloads.js
+++ b/src/webapi/static/js/views/downloads.js
@@ -126,17 +126,11 @@ export default function Downloads({ isGuest }) {
   // Apply the same field change (priority/category) to every selected row.
   const bulkPatch = (patch) => runBulk((h) => api.patch("downloads", { hashes: h, ...patch }));
 
-  // Clears every completed entry, so it reports per entry: a refusal is a
-  // 207 row, not a throw.
+  // The handler clears in one EC roundtrip: every row it returns is an ok,
+  // and any refusal is a whole-request error `mutate` already reports.
   const clearCompleted = async () => {
     if (!(await confirmDialog(t("downloads_confirm_clear_completed")))) return;
-    mutate(async () => {
-      const res = await api.post("downloads_clear_completed");
-      const failed = bulkFailures(res);
-      if (failed.length)
-        toast(t("common_bulk_partial", { failed: failed.length, total: res.results.length,
-                message: terr(failed[0].error) }), "warn");
-    });
+    mutate(() => api.post("downloads_clear_completed"));
   };
   // Same endpoint scoped to one hash, for the detail panel's Clear button.
   const clearOne = (h) => mutate(() => api.post("downloads_clear_completed", { hash: h }));

--- a/unittests/curl-tests/amuleapi/01-version-and-errors.sh
+++ b/unittests/curl-tests/amuleapi/01-version-and-errors.sh
@@ -97,10 +97,10 @@ _assert_json_eq '.daemon_version | length > 0' \
 	true '/api/v0/version reports a non-empty daemon_version'
 
 # 2c. update object. The identity fields above are unauthenticated because this
-#     is the liveness/version probe, but `update` reports whether THIS daemon is
-#     running an outdated build, which an unauthenticated caller on a reachable
-#     interface has no business learning. Absent without credentials, present
-#     with them.
+#     is the version-negotiation probe (liveness is /health's job), but `update`
+#     reports whether THIS daemon is running an outdated build, which an
+#     unauthenticated caller on a reachable interface has no business learning.
+#     Absent without credentials, present with them.
 _assert_json_eq '. | has("update")' false \
 	'/api/v0/version omits the update object when unauthenticated'
 
@@ -183,6 +183,28 @@ _curl "$HOST/api/v0/version/check"
 _assert_status 405 "GET /api/v0/version/check yields 405"
 _assert_json_eq '.error.code' method_not_allowed \
 	'/api/v0/version/check GET 405 carries error.code=method_not_allowed'
+
+# 8. An unauthenticated /version must NOT spend the generic-401 budget.
+#    Emitting `update` only to an authenticated caller is the only reason this
+#    endpoint authenticates at all, so a request with no credential is its
+#    documented unauthenticated use rather than an auth failure. Counted, it
+#    would let an anonymous poller -- or, behind a reverse proxy, one poller on
+#    the address every client shares -- fill the bucket in 30 requests and lock
+#    real sessions out of the entire authenticated surface for five minutes.
+#    Defaults: TokenFailureThreshold=30 within TokenFailureWindowSeconds=60.
+#
+#    Deliberately the last check in this file: if the guard regresses, the
+#    lockout it arms would poison every assertion after it.
+i=0
+while [ "$i" -lt 35 ]; do
+	curl -s -o /dev/null --max-time 10 "$HOST/api/v0/version"
+	i=$((i + 1))
+done
+# /auth/session rather than /status: authenticated, but with no EC dependency
+# that could answer 503 and mask the 429 this is looking for.
+_curl "${AUTH[@]}" "$HOST/api/v0/auth/session"
+_assert_status 200 \
+	"35 anonymous /version requests do not rate-limit an authenticated caller"
 
 # Summary.
 echo

--- a/unittests/curl-tests/amuleapi/02-auth.sh
+++ b/unittests/curl-tests/amuleapi/02-auth.sh
@@ -90,7 +90,7 @@ _assert_header_contains() {
 if ! command -v jq >/dev/null 2>&1; then
 	_die "jq is required. brew install jq."
 fi
-if ! curl -s -o /dev/null --max-time 2 "$HOST/api/v0/version" 2>/dev/null; then
+if ! curl -s -o /dev/null --max-time 2 "$HOST/api/v0/health" 2>/dev/null; then
 	_die "amuleapi at $HOST is not reachable. Start amuleapi first."
 fi
 

--- a/unittests/curl-tests/amuleapi/03-read-status.sh
+++ b/unittests/curl-tests/amuleapi/03-read-status.sh
@@ -81,7 +81,7 @@ _assert_json_eq() {
 if ! command -v jq >/dev/null 2>&1; then
 	_die "jq is required. brew install jq."
 fi
-if ! curl -s -o /dev/null --max-time 2 "$HOST/api/v0/version" 2>/dev/null; then
+if ! curl -s -o /dev/null --max-time 2 "$HOST/api/v0/health" 2>/dev/null; then
 	_die "amuleapi at $HOST is not reachable. Start amuleapi first."
 fi
 
@@ -103,7 +103,7 @@ TOKEN=$(curl -s -X POST -H "Content-Type: application/json" \
 # Wait for the refresher to land its first snapshot. On a fast
 # Linux host the first tick is sub-second; on the Windows VM the
 # 503 ec_unavailable window can stretch a few seconds under load.
-# Poll up to 15 s, same shape run-all.sh uses for /version, so
+# Poll up to 15 s, same shape run-all.sh uses for /health, so
 # the test doesn't drift to "disconnected" under runner pressure.
 for _ in $(seq 1 30); do
 	probe=$(curl -s -o /dev/null -w "%{http_code}" \

--- a/unittests/curl-tests/amuleapi/04-read-downloads-shared.sh
+++ b/unittests/curl-tests/amuleapi/04-read-downloads-shared.sh
@@ -81,7 +81,7 @@ _assert_json_eq() {
 if ! command -v jq >/dev/null 2>&1; then
 	_die "jq is required. brew install jq."
 fi
-if ! curl -s -o /dev/null --max-time 2 "$HOST/api/v0/version" 2>/dev/null; then
+if ! curl -s -o /dev/null --max-time 2 "$HOST/api/v0/health" 2>/dev/null; then
 	_die "amuleapi at $HOST is not reachable. Start amuleapi first."
 fi
 
@@ -160,6 +160,12 @@ if [ "$COUNT" -gt 0 ]; then
 	# which a client had to know meant "unknown".
 	_assert_json_eq '(.remaining_time == null or (.remaining_time | type) == "number")' true \
 		'/downloads/{hash} remaining_time is a number or null'
+	# Same rule: null, not a 0 that reads as 1970, when no complete copy of
+	# the file has ever been seen across the current sources.
+	_assert_json_eq '(.last_seen_complete == null or (.last_seen_complete | type) == "number")' true \
+		'/downloads/{hash} last_seen_complete is a number or null'
+	_assert_json_eq '.last_seen_complete != 0' true \
+		'/downloads/{hash} last_seen_complete never uses 0 as "never"'
 	_assert_json_eq '.aich_hash | type' string \
 		'/downloads/{hash} carries aich_hash'
 	_assert_json_eq '.met_file | type' string \

--- a/unittests/curl-tests/amuleapi/05-read-servers-kad-categories-prefs.sh
+++ b/unittests/curl-tests/amuleapi/05-read-servers-kad-categories-prefs.sh
@@ -67,7 +67,7 @@ _assert_json_eq() {
 if ! command -v jq >/dev/null 2>&1; then
 	_die "jq is required."
 fi
-if ! curl -s -o /dev/null --max-time 2 "$HOST/api/v0/version" 2>/dev/null; then
+if ! curl -s -o /dev/null --max-time 2 "$HOST/api/v0/health" 2>/dev/null; then
 	_die "amuleapi at $HOST is not reachable."
 fi
 

--- a/unittests/curl-tests/amuleapi/06-read-logs.sh
+++ b/unittests/curl-tests/amuleapi/06-read-logs.sh
@@ -63,7 +63,7 @@ _assert_json_eq() {
 if ! command -v jq >/dev/null 2>&1; then
 	_die "jq is required."
 fi
-if ! curl -s -o /dev/null --max-time 2 "$HOST/api/v0/version" 2>/dev/null; then
+if ! curl -s -o /dev/null --max-time 2 "$HOST/api/v0/health" 2>/dev/null; then
 	_die "amuleapi at $HOST is not reachable."
 fi
 

--- a/unittests/curl-tests/amuleapi/07-read-stats-and-search-results.sh
+++ b/unittests/curl-tests/amuleapi/07-read-stats-and-search-results.sh
@@ -59,7 +59,7 @@ _assert_json_eq() {
 if ! command -v jq >/dev/null 2>&1; then
 	_die "jq is required."
 fi
-if ! curl -s -o /dev/null --max-time 2 "$HOST/api/v0/version" 2>/dev/null; then
+if ! curl -s -o /dev/null --max-time 2 "$HOST/api/v0/health" 2>/dev/null; then
 	_die "amuleapi at $HOST is not reachable."
 fi
 

--- a/unittests/curl-tests/amuleapi/08-read-download-parts.sh
+++ b/unittests/curl-tests/amuleapi/08-read-download-parts.sh
@@ -76,7 +76,7 @@ _assert_json_eq() {
 if ! command -v jq >/dev/null 2>&1; then
 	_die "jq is required."
 fi
-if ! curl -s -o /dev/null --max-time 2 "$HOST/api/v0/version" 2>/dev/null; then
+if ! curl -s -o /dev/null --max-time 2 "$HOST/api/v0/health" 2>/dev/null; then
 	_die "amuleapi at $HOST is not reachable."
 fi
 

--- a/unittests/curl-tests/amuleapi/09-refresher-consolidation.sh
+++ b/unittests/curl-tests/amuleapi/09-refresher-consolidation.sh
@@ -83,7 +83,7 @@ _assert_json_eq() {
 if ! command -v jq >/dev/null 2>&1; then
 	_die "jq is required."
 fi
-if ! curl -s -o /dev/null --max-time 2 "$HOST/api/v0/version" 2>/dev/null; then
+if ! curl -s -o /dev/null --max-time 2 "$HOST/api/v0/health" 2>/dev/null; then
 	_die "amuleapi at $HOST is not reachable."
 fi
 

--- a/unittests/curl-tests/amuleapi/10-refresher-lazy-ondemand.sh
+++ b/unittests/curl-tests/amuleapi/10-refresher-lazy-ondemand.sh
@@ -76,7 +76,7 @@ _assert_json_eq() {
 if ! command -v jq >/dev/null 2>&1; then
 	_die "jq is required."
 fi
-if ! curl -s -o /dev/null --max-time 2 "$HOST/api/v0/version" 2>/dev/null; then
+if ! curl -s -o /dev/null --max-time 2 "$HOST/api/v0/health" 2>/dev/null; then
 	_die "amuleapi at $HOST is not reachable."
 fi
 

--- a/unittests/curl-tests/amuleapi/11-downloads-default-filter.sh
+++ b/unittests/curl-tests/amuleapi/11-downloads-default-filter.sh
@@ -19,8 +19,8 @@
 #      regardless of its status.
 #
 # Phase 5b exercises the clear-completed mutations:
-#   `POST /downloads/clear_completed`              (bulk-clear, no body)
-#   `POST /downloads/clear_completed {"hash":...}` (single-entry clear)
+#   `POST /downloads_clear_completed`              (bulk-clear, no body)
+#   `POST /downloads_clear_completed {"hash":...}` (single-entry clear)
 # Both wire to EC_OP_CLEAR_COMPLETED. `DELETE /downloads/{hash}` is
 # active-only and 409s on completed entries — see 13-downloads-delete-clear for the
 # 409 + per-entry clear assertions.
@@ -79,7 +79,7 @@ _assert_json_eq() {
 if ! command -v jq >/dev/null 2>&1; then
 	_die "jq is required."
 fi
-if ! curl -s -o /dev/null --max-time 2 "$HOST/api/v0/version" 2>/dev/null; then
+if ! curl -s -o /dev/null --max-time 2 "$HOST/api/v0/health" 2>/dev/null; then
 	_die "amuleapi at $HOST is not reachable."
 fi
 

--- a/unittests/curl-tests/amuleapi/12-downloads-add-patch.sh
+++ b/unittests/curl-tests/amuleapi/12-downloads-add-patch.sh
@@ -91,7 +91,7 @@ _assert_json_eq() {
 if ! command -v jq >/dev/null 2>&1; then
 	_die "jq is required."
 fi
-if ! curl -s -o /dev/null --max-time 2 "$HOST/api/v0/version" 2>/dev/null; then
+if ! curl -s -o /dev/null --max-time 2 "$HOST/api/v0/health" 2>/dev/null; then
 	_die "amuleapi at $HOST is not reachable."
 fi
 

--- a/unittests/curl-tests/amuleapi/13-downloads-delete-clear.sh
+++ b/unittests/curl-tests/amuleapi/13-downloads-delete-clear.sh
@@ -82,7 +82,7 @@ _assert_json_eq() {
 }
 
 if ! command -v jq >/dev/null 2>&1; then _die "jq is required."; fi
-if ! curl -s -o /dev/null --max-time 2 "$HOST/api/v0/version" 2>/dev/null; then
+if ! curl -s -o /dev/null --max-time 2 "$HOST/api/v0/health" 2>/dev/null; then
 	_die "amuleapi at $HOST is not reachable."
 fi
 
@@ -104,7 +104,7 @@ _curl -X DELETE "$HOST/api/v0/downloads/$TEST_HASH"
 _assert_status 401 "DELETE /downloads/{hash} (no token) → 401"
 
 _curl -X POST "$HOST/api/v0/downloads_clear_completed"
-_assert_status 401 "POST /downloads/clear_completed (no token) → 401"
+_assert_status 401 "POST /downloads_clear_completed (no token) → 401"
 
 if [ "$HAVE_GUEST" = "1" ]; then
 	_curl -X DELETE -H "Authorization: Bearer $GUEST_TOKEN" \
@@ -112,7 +112,7 @@ if [ "$HAVE_GUEST" = "1" ]; then
 	_assert_status 403 "DELETE /downloads/{hash} (guest) → 403"
 	_curl -X POST -H "Authorization: Bearer $GUEST_TOKEN" \
 		"$HOST/api/v0/downloads_clear_completed"
-	_assert_status 403 "POST /downloads/clear_completed (guest) → 403"
+	_assert_status 403 "POST /downloads_clear_completed (guest) → 403"
 else
 	echo "    info: no guest pass; admin-gate skipped"
 fi
@@ -130,7 +130,7 @@ _assert_status 404 "DELETE /downloads/{nonexistent} → 404"
 # call clear once to baseline, then move on.)
 _curl -X POST -H "Authorization: Bearer $ADMIN_TOKEN" \
 	"$HOST/api/v0/downloads_clear_completed"
-_assert_status 200 "POST /downloads/clear_completed (baseline) → 200"
+_assert_status 200 "POST /downloads_clear_completed (baseline) → 200"
 # The shared results envelope has no top-level `ok`: per-item success lives on
 # each entry, so a partial outcome cannot be reported as a single boolean.
 _assert_json_eq '.results | type' array 'clear_completed returns a results array'
@@ -138,7 +138,7 @@ _assert_json_eq '.results | type' array 'clear_completed returns a results array
 # Second call: now nothing is completed. cleared must be 0.
 _curl -X POST -H "Authorization: Bearer $ADMIN_TOKEN" \
 	"$HOST/api/v0/downloads_clear_completed"
-_assert_status 200 "POST /downloads/clear_completed (idempotent no-op) → 200"
+_assert_status 200 "POST /downloads_clear_completed (idempotent no-op) → 200"
 # An empty `results` array is the no-op. It was `cleared: 0`, a shape only this
 # endpoint used.
 _assert_json_eq '.results | length' 0 'clear_completed second call cleared 0 entries'

--- a/unittests/curl-tests/amuleapi/14-servers-mutations.sh
+++ b/unittests/curl-tests/amuleapi/14-servers-mutations.sh
@@ -81,7 +81,7 @@ _assert_json_eq() {
 }
 
 if ! command -v jq >/dev/null 2>&1; then _die "jq is required."; fi
-if ! curl -s -o /dev/null --max-time 2 "$HOST/api/v0/version" 2>/dev/null; then
+if ! curl -s -o /dev/null --max-time 2 "$HOST/api/v0/health" 2>/dev/null; then
 	_die "amuleapi at $HOST is not reachable."
 fi
 
@@ -339,11 +339,12 @@ _curl -X DELETE -H "Authorization: Bearer $ADMIN_TOKEN" \
 _assert_status 400 "DELETE /servers/not-a-number → 400"
 
 # --- 8. ip:port selector: malformed is 400, unknown is 404. --------
-# The routes also accept "<ip>:<port>" in place of an ECID. Parsing and
-# lookup are separate outcomes: a selector that cannot be parsed is the
-# caller's mistake (400), one that parses but names no server we hold is
-# simply absent (404). They used to collapse onto the same 404 because the
-# resolver signalled every failure by returning ECID 0.
+# /servers/by-address/{address} takes an "<ip>:<port>" selector where the
+# ECID routes take a number. Parsing and lookup are separate outcomes: a
+# selector that cannot be parsed is the caller's mistake (400), one that
+# parses but names no server we hold is simply absent (404). They used to
+# collapse onto the same 404 because the resolver signalled every failure by
+# returning ECID 0.
 # The address form has its own path now, so a colon is no longer what selects
 # the handler: a value without one reaches the same place and is rejected for
 # being a malformed address rather than for looking like an ECID.
@@ -357,23 +358,23 @@ done
 # Well-formed but absent: TEST-NET-1 (RFC 5737), never a real server.
 _curl -X DELETE -H "Authorization: Bearer $ADMIN_TOKEN" \
 	"$HOST/api/v0/servers/by-address/192.0.2.1:4242"
-_assert_status 404 "DELETE /servers/192.0.2.1:4242 (unknown server) → 404"
+_assert_status 404 "DELETE /servers/by-address/192.0.2.1:4242 (unknown server) → 404"
 _assert_json_eq '.error.code' not_found \
 	'unknown ip:port carries error.code=not_found'
 
 # Same split on the other two routes that take the selector.
 _curl -X POST -H "Authorization: Bearer $ADMIN_TOKEN" \
 	"$HOST/api/v0/servers/by-address/not-an-ip:4242/connect"
-_assert_status 400 "POST /servers/{malformed}/connect → 400"
+_assert_status 400 "POST /servers/by-address/not-an-ip:4242/connect (malformed) → 400"
 
 _curl -X POST -H "Authorization: Bearer $ADMIN_TOKEN" \
 	"$HOST/api/v0/servers/by-address/192.0.2.1:4242/connect"
-_assert_status 404 "POST /servers/{unknown ip:port}/connect → 404"
+_assert_status 404 "POST /servers/by-address/192.0.2.1:4242/connect (unknown) → 404"
 
 _curl -X PATCH -H "Authorization: Bearer $ADMIN_TOKEN" \
 	-H "Content-Type: application/json" -d '{"static":true}' \
 	"$HOST/api/v0/servers/by-address/not-an-ip:4242"
-_assert_status 400 "PATCH /servers/{malformed} → 400"
+_assert_status 400 "PATCH /servers/by-address/not-an-ip:4242 (malformed) → 400"
 
 # --- Summary. -----------------------------------------------------
 echo

--- a/unittests/curl-tests/amuleapi/15-preferences-patch.sh
+++ b/unittests/curl-tests/amuleapi/15-preferences-patch.sh
@@ -76,7 +76,7 @@ _assert_json_eq() {
 }
 
 if ! command -v jq >/dev/null 2>&1; then _die "jq is required."; fi
-if ! curl -s -o /dev/null --max-time 2 "$HOST/api/v0/version" 2>/dev/null; then
+if ! curl -s -o /dev/null --max-time 2 "$HOST/api/v0/health" 2>/dev/null; then
 	_die "amuleapi at $HOST is not reachable."
 fi
 

--- a/unittests/curl-tests/amuleapi/16-networks-connect.sh
+++ b/unittests/curl-tests/amuleapi/16-networks-connect.sh
@@ -71,7 +71,7 @@ _assert_json_eq() {
 }
 
 if ! command -v jq >/dev/null 2>&1; then _die "jq is required."; fi
-if ! curl -s -o /dev/null --max-time 2 "$HOST/api/v0/version" 2>/dev/null; then
+if ! curl -s -o /dev/null --max-time 2 "$HOST/api/v0/health" 2>/dev/null; then
 	_die "amuleapi at $HOST is not reachable."
 fi
 

--- a/unittests/curl-tests/amuleapi/17-shared-priority-patch.sh
+++ b/unittests/curl-tests/amuleapi/17-shared-priority-patch.sh
@@ -67,7 +67,7 @@ _assert_json_eq() {
 }
 
 if ! command -v jq >/dev/null 2>&1; then _die "jq is required."; fi
-if ! curl -s -o /dev/null --max-time 2 "$HOST/api/v0/version" 2>/dev/null; then
+if ! curl -s -o /dev/null --max-time 2 "$HOST/api/v0/health" 2>/dev/null; then
 	_die "amuleapi at $HOST is not reachable."
 fi
 

--- a/unittests/curl-tests/amuleapi/18-categories-crud.sh
+++ b/unittests/curl-tests/amuleapi/18-categories-crud.sh
@@ -68,7 +68,7 @@ _assert_json_eq() {
 }
 
 if ! command -v jq >/dev/null 2>&1; then _die "jq is required."; fi
-if ! curl -s -o /dev/null --max-time 2 "$HOST/api/v0/version" 2>/dev/null; then
+if ! curl -s -o /dev/null --max-time 2 "$HOST/api/v0/health" 2>/dev/null; then
 	_die "amuleapi at $HOST is not reachable."
 fi
 

--- a/unittests/curl-tests/amuleapi/19-search.sh
+++ b/unittests/curl-tests/amuleapi/19-search.sh
@@ -136,7 +136,7 @@ _assert_json_eq() {
 }
 
 if ! command -v jq >/dev/null 2>&1; then _die "jq is required."; fi
-if ! curl -s -o /dev/null --max-time 2 "$HOST/api/v0/version" 2>/dev/null; then
+if ! curl -s -o /dev/null --max-time 2 "$HOST/api/v0/health" 2>/dev/null; then
 	_die "amuleapi at $HOST is not reachable."
 fi
 
@@ -340,7 +340,7 @@ rm -f "$SECOND_CONFIG_DIR/amuleapi.conf.bak"
 SECOND_PID=$!
 
 for i in 1 2 3 4 5 6 7 8 9 10 11 12; do
-	curl -s -o /dev/null --max-time 1 "http://$SECOND_HOST/api/v0/version" 2>/dev/null && break
+	curl -s -o /dev/null --max-time 1 "http://$SECOND_HOST/api/v0/health" 2>/dev/null && break
 	sleep 0.5
 done
 sleep 4
@@ -965,7 +965,7 @@ if [ -n "$SID_CLOSE" ] && [ "$SID_CLOSE" != "null" ]; then
 		--http-port=4715 >"$SECOND2_LOG" 2>&1 &
 	SECOND2_PID=$!
 	for i in 1 2 3 4 5 6 7 8 9 10 11 12; do
-		curl -s -o /dev/null --max-time 1 "http://localhost:4715/api/v0/version" 2>/dev/null && break
+		curl -s -o /dev/null --max-time 1 "http://localhost:4715/api/v0/health" 2>/dev/null && break
 		sleep 0.5
 	done
 	sleep 2
@@ -1022,7 +1022,7 @@ rm -f "$FOREIGN_CONFIG_DIR/amuleapi.conf.bak"
 	--http-port=4716 >"$FOREIGN_LOG" 2>&1 &
 FOREIGN_PID=$!
 for i in 1 2 3 4 5 6 7 8 9 10 11 12; do
-	curl -s -o /dev/null --max-time 1 "http://localhost:4716/api/v0/version" 2>/dev/null && break
+	curl -s -o /dev/null --max-time 1 "http://localhost:4716/api/v0/health" 2>/dev/null && break
 	sleep 0.5
 done
 sleep 2

--- a/unittests/curl-tests/amuleapi/20-etag-conditional-get.sh
+++ b/unittests/curl-tests/amuleapi/20-etag-conditional-get.sh
@@ -82,7 +82,7 @@ _get_etag() {
 }
 
 if ! command -v jq >/dev/null 2>&1; then _die "jq is required."; fi
-if ! curl -s -o /dev/null --max-time 2 "$HOST/api/v0/version" 2>/dev/null; then
+if ! curl -s -o /dev/null --max-time 2 "$HOST/api/v0/health" 2>/dev/null; then
 	_die "amuleapi at $HOST is not reachable."
 fi
 

--- a/unittests/curl-tests/amuleapi/21-sse-heartbeat.sh
+++ b/unittests/curl-tests/amuleapi/21-sse-heartbeat.sh
@@ -59,7 +59,7 @@ _sse_grab() {
 }
 
 if ! command -v jq >/dev/null 2>&1; then _die "jq is required."; fi
-if ! curl -s -o /dev/null --max-time 2 "$HOST/api/v0/version" 2>/dev/null; then
+if ! curl -s -o /dev/null --max-time 2 "$HOST/api/v0/health" 2>/dev/null; then
 	_die "amuleapi at $HOST is not reachable."
 fi
 

--- a/unittests/curl-tests/amuleapi/22-sse-diff-emission.sh
+++ b/unittests/curl-tests/amuleapi/22-sse-diff-emission.sh
@@ -58,7 +58,7 @@ _fail() {
 }
 
 if ! command -v jq >/dev/null 2>&1; then _die "jq is required."; fi
-if ! curl -s -o /dev/null --max-time 2 "$HOST/api/v0/version" 2>/dev/null; then
+if ! curl -s -o /dev/null --max-time 2 "$HOST/api/v0/health" 2>/dev/null; then
 	_die "amuleapi at $HOST is not reachable."
 fi
 

--- a/unittests/curl-tests/amuleapi/23-sse-replay.sh
+++ b/unittests/curl-tests/amuleapi/23-sse-replay.sh
@@ -46,7 +46,7 @@ _fail() {
 }
 
 if ! command -v jq >/dev/null 2>&1; then _die "jq is required."; fi
-if ! curl -s -o /dev/null --max-time 2 "$HOST/api/v0/version" 2>/dev/null; then
+if ! curl -s -o /dev/null --max-time 2 "$HOST/api/v0/health" 2>/dev/null; then
 	_die "amuleapi at $HOST is not reachable."
 fi
 

--- a/unittests/curl-tests/amuleapi/24-sse-resync.sh
+++ b/unittests/curl-tests/amuleapi/24-sse-resync.sh
@@ -61,7 +61,7 @@ _fail() {
 }
 
 if ! command -v jq >/dev/null 2>&1; then _die "jq is required."; fi
-if ! curl -s -o /dev/null --max-time 2 "$HOST/api/v0/version" 2>/dev/null; then
+if ! curl -s -o /dev/null --max-time 2 "$HOST/api/v0/health" 2>/dev/null; then
 	_die "amuleapi at $HOST is not reachable."
 fi
 
@@ -96,7 +96,7 @@ EOF
 	--host="$EC_HOST" --port="$EC_PORT" \
 	> "$LOG" 2>&1 &
 for _ in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15; do
-	if curl -s -o /dev/null --max-time 1 "$HOST/api/v0/version" 2>/dev/null; then
+	if curl -s -o /dev/null --max-time 1 "$HOST/api/v0/health" 2>/dev/null; then
 		break
 	fi
 	sleep 0.5

--- a/unittests/curl-tests/amuleapi/25-cors.sh
+++ b/unittests/curl-tests/amuleapi/25-cors.sh
@@ -89,7 +89,7 @@ _fail() {
 }
 
 if ! command -v jq >/dev/null 2>&1; then _die "jq is required."; fi
-if ! curl -s -o /dev/null --max-time 2 "$HOST/api/v0/version" 2>/dev/null; then
+if ! curl -s -o /dev/null --max-time 2 "$HOST/api/v0/health" 2>/dev/null; then
 	_die "amuleapi at $HOST is not reachable."
 fi
 if [ ! -x "$BIN" ]; then
@@ -127,9 +127,9 @@ EOF
 	"$BIN" --config-dir="$CONFIG_DIR" \
 		--host="$EC_HOST" --port="$EC_PORT" \
 		> "$LOG" 2>&1 &
-	# Wait for /version to respond.
+	# Wait for /health to respond.
 	for _ in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15; do
-		if curl -s -o /dev/null --max-time 1 "$HOST/api/v0/version" 2>/dev/null; then
+		if curl -s -o /dev/null --max-time 1 "$HOST/api/v0/health" 2>/dev/null; then
 			return 0
 		fi
 		sleep 0.5
@@ -328,7 +328,7 @@ fi
 if echo "$ACAM" | grep -q "PUT"; then
 	_pass "Preflight: Allow-Methods lists PUT"
 else
-	_fail "Allow-Methods PUT" "PUT is a real route on /shared/directories, got '$ACAM'"
+	_fail "Allow-Methods PUT" "PUT is a real route on /share_directories, got '$ACAM'"
 fi
 
 # And the same preflight asked about that route by name.
@@ -339,9 +339,9 @@ _curl -X OPTIONS \
 PUT_STATUS=$(head -1 "$HDR" | awk '{print $2}')
 PUT_ACAM=$(_hdr "Access-Control-Allow-Methods")
 if [ "$PUT_STATUS" = "204" ] && echo "$PUT_ACAM" | grep -q "PUT"; then
-	_pass "Preflight for PUT /shared/directories advertises PUT"
+	_pass "Preflight for PUT /share_directories advertises PUT"
 else
-	_fail "Preflight PUT /shared/directories" \
+	_fail "Preflight PUT /share_directories" \
 		"status '$PUT_STATUS', Allow-Methods '$PUT_ACAM'"
 fi
 if echo "$ACAH" | grep -qi "Authorization" \

--- a/unittests/curl-tests/amuleapi/26-rfc-followup-endpoints.sh
+++ b/unittests/curl-tests/amuleapi/26-rfc-followup-endpoints.sh
@@ -4,10 +4,10 @@
 # review:
 #
 #   * GET    /status                       — `kad.network: {users,files,nodes}` rollup
-#   * POST   /shared/reload                — rescan share roots
-#   * POST   /servers/update               — refresh server list from server.met URL
-#   * POST   /servers/<ip>:<port>/connect  — address-keyed alias
-#   * DELETE /servers/<ip>:<port>          — address-keyed alias
+#   * POST   /shared_reload                — rescan share roots
+#   * POST   /servers_update               — refresh server list from server.met URL
+#   * POST   /servers/by-address/<ip>:<port>/connect — address-keyed route
+#   * DELETE /servers/by-address/<ip>:<port>         — address-keyed route
 #   * DELETE /logs/amule                   — clear amule log + in-process cache
 #   * DELETE /logs/serverinfo              — clear MOTD log + invalidate lazy cache
 #   * POST   /downloads {"links":[...]}    — array body, alongside `ed2k_link`
@@ -57,7 +57,7 @@ _fail() {
 }
 
 if ! command -v jq >/dev/null 2>&1; then _die "jq is required."; fi
-if ! curl -s -o /dev/null --max-time 2 "$HOST/api/v0/version"; then
+if ! curl -s -o /dev/null --max-time 2 "$HOST/api/v0/health"; then
 	_die "amuleapi at $HOST is not reachable."
 fi
 
@@ -84,47 +84,47 @@ for f in users files nodes; do
 	fi
 done
 
-# --- 2. POST /shared/reload. -------------------------------------
+# --- 2. POST /shared_reload. -------------------------------------
 RC=$(curl -s -o /tmp/p11_shared_reload.json -w "%{http_code}" -X POST "${H_AUTH[@]}" \
 	"$HOST/api/v0/shared_reload")
 if [ "$RC" = "202" ]; then
-	_pass "POST /shared/reload → 202"
+	_pass "POST /shared_reload → 202"
 else
-	_fail "shared/reload status" "expected 202, got $RC: $(cat /tmp/p11_shared_reload.json)"
+	_fail "shared_reload status" "expected 202, got $RC: $(cat /tmp/p11_shared_reload.json)"
 fi
 if jq -e '.ok == true' /tmp/p11_shared_reload.json >/dev/null 2>&1; then
-	_pass "POST /shared/reload .ok == true"
+	_pass "POST /shared_reload .ok == true"
 else
-	_fail "shared/reload body" "$(cat /tmp/p11_shared_reload.json)"
+	_fail "shared_reload body" "$(cat /tmp/p11_shared_reload.json)"
 fi
 
-# --- 3. POST /servers/update — body validation. ------------------
+# --- 3. POST /servers_update — body validation. ------------------
 RC=$(curl -s -o /tmp/p11_su.json -w "%{http_code}" -X POST "${H_AUTH[@]}" \
 	-H "Content-Type: application/json" -d '{}' "$HOST/api/v0/servers_update")
 if [ "$RC" = "400" ]; then
-	_pass "POST /servers/update missing url → 400"
+	_pass "POST /servers_update missing url → 400"
 else
-	_fail "servers/update no-body" "expected 400, got $RC"
+	_fail "servers_update no-body" "expected 400, got $RC"
 fi
 RC=$(curl -s -o /tmp/p11_su.json -w "%{http_code}" -X POST "${H_AUTH[@]}" \
 	-H "Content-Type: application/json" \
 	-d '{"servers_url":"ftp://nope"}' "$HOST/api/v0/servers_update")
 if [ "$RC" = "400" ]; then
-	_pass "POST /servers/update non-http url → 400"
+	_pass "POST /servers_update non-http url → 400"
 else
-	_fail "servers/update bad url" "expected 400, got $RC"
+	_fail "servers_update bad url" "expected 400, got $RC"
 fi
 RC=$(curl -s -o /tmp/p11_su.json -w "%{http_code}" -X POST "${H_AUTH[@]}" \
 	-H "Content-Type: application/json" \
 	-d '{"servers_url":"http://upd.emule-security.org/server.met"}' \
 	"$HOST/api/v0/servers_update")
 if [ "$RC" = "202" ]; then
-	_pass "POST /servers/update valid url → 202"
+	_pass "POST /servers_update valid url → 202"
 else
-	_fail "servers/update happy path" "got $RC: $(cat /tmp/p11_su.json)"
+	_fail "servers_update happy path" "got $RC: $(cat /tmp/p11_su.json)"
 fi
 
-# --- 4. /servers/<ip>:<port>/connect + DELETE alias. -------------
+# --- 4. /servers/by-address/<ip>:<port> connect + DELETE. --------
 # 404 path is always testable. 192.0.2.x is TEST-NET-1 (RFC 5737),
 # reserved for documentation and guaranteed never to be a real server,
 # so this reaches the "well-formed but no such server" branch rather
@@ -133,14 +133,14 @@ UNKNOWN_SRV=192.0.2.1:1
 RC=$(curl -s -o /dev/null -w "%{http_code}" -X POST "${H_AUTH[@]}" \
 	"$HOST/api/v0/servers/by-address/$UNKNOWN_SRV/connect")
 if [ "$RC" = "404" ]; then
-	_pass "POST /servers/<unknown-ip:port>/connect → 404"
+	_pass "POST /servers/by-address/<unknown-ip:port>/connect → 404"
 else
 	_fail "address alias 404" "expected 404, got $RC"
 fi
 RC=$(curl -s -o /dev/null -w "%{http_code}" -X DELETE "${H_AUTH[@]}" \
 	"$HOST/api/v0/servers/by-address/$UNKNOWN_SRV")
 if [ "$RC" = "404" ]; then
-	_pass "DELETE /servers/<unknown-ip:port> → 404"
+	_pass "DELETE /servers/by-address/<unknown-ip:port> → 404"
 else
 	_fail "address alias DELETE 404" "expected 404, got $RC"
 fi
@@ -153,7 +153,7 @@ BODY=$(curl -s -X POST "${H_AUTH[@]}" "$HOST/api/v0/servers/by-address/0.0.0.0:4
 RC=$(curl -s -o /dev/null -w "%{http_code}" -X POST "${H_AUTH[@]}" \
 	"$HOST/api/v0/servers/by-address/0.0.0.0:4242/connect")
 if [ "$RC" = "400" ] && printf '%s' "$BODY" | jq -e '.error.code == "bad_request"' >/dev/null 2>&1; then
-	_pass "POST /servers/0.0.0.0:<port>/connect → 400 (not a server address)"
+	_pass "POST /servers/by-address/0.0.0.0:<port>/connect → 400 (not a server address)"
 else
 	_fail "0.0.0.0 selector rejected" "expected 400 bad_request, got $RC: $BODY"
 fi

--- a/unittests/curl-tests/amuleapi/27-static-frontend.sh
+++ b/unittests/curl-tests/amuleapi/27-static-frontend.sh
@@ -69,7 +69,7 @@ _assert_status() {
 if ! command -v jq >/dev/null 2>&1; then
 	_die "jq is required for JSON assertions. brew install jq."
 fi
-if ! curl -s -o /dev/null --max-time 2 "$HOST/api/v0/version" 2>/dev/null; then
+if ! curl -s -o /dev/null --max-time 2 "$HOST/api/v0/health" 2>/dev/null; then
 	_die "amuleapi at $HOST is not reachable. Start amuleapi first."
 fi
 

--- a/unittests/curl-tests/amuleapi/28-list-pagination-sort.sh
+++ b/unittests/curl-tests/amuleapi/28-list-pagination-sort.sh
@@ -85,7 +85,7 @@ _assert_json_le() {
 if ! command -v jq >/dev/null 2>&1; then
 	_die "jq is required. brew install jq."
 fi
-if ! curl -s -o /dev/null --max-time 2 "$HOST/api/v0/version" 2>/dev/null; then
+if ! curl -s -o /dev/null --max-time 2 "$HOST/api/v0/health" 2>/dev/null; then
 	_die "amuleapi at $HOST is not reachable. Start amuleapi first."
 fi
 

--- a/unittests/curl-tests/amuleapi/29-bulk-mutations.sh
+++ b/unittests/curl-tests/amuleapi/29-bulk-mutations.sh
@@ -41,7 +41,7 @@ _status() { [ "$STATUS" = "$1" ] && _pass "$2 (HTTP $STATUS)" || _fail "$2" "wan
 _jq()     { local a; a=$(printf %s "$CURL_BODY" | jq -r "$1" 2>/dev/null); [ "$a" = "$2" ] && _pass "$3" || _fail "$3" "want '$2' got '$a'" "body: $CURL_BODY"; }
 
 command -v jq >/dev/null 2>&1 || _die "jq required"
-curl -s -o /dev/null --max-time 2 "$HOST/api/v0/version" || _die "amuleapi at $HOST not reachable"
+curl -s -o /dev/null --max-time 2 "$HOST/api/v0/health" || _die "amuleapi at $HOST not reachable"
 
 echo "amuleapi 29-bulk-mutations @ $HOST"
 TOKEN=$(curl -s -X POST -H "Content-Type: application/json" -d "{\"password\":\"$ADMIN_PASS\"}" \

--- a/unittests/curl-tests/amuleapi/30-shared-verify.sh
+++ b/unittests/curl-tests/amuleapi/30-shared-verify.sh
@@ -71,7 +71,7 @@ _assert_json_eq() {
 }
 
 if ! command -v jq >/dev/null 2>&1; then _die "jq is required."; fi
-if ! curl -s -o /dev/null --max-time 2 "$HOST/api/v0/version" 2>/dev/null; then
+if ! curl -s -o /dev/null --max-time 2 "$HOST/api/v0/health" 2>/dev/null; then
 	_die "amuleapi at $HOST is not reachable."
 fi
 

--- a/unittests/curl-tests/amuleapi/31-shared-directories.sh
+++ b/unittests/curl-tests/amuleapi/31-shared-directories.sh
@@ -89,7 +89,7 @@ _restore() {
 }
 trap _restore EXIT
 
-if ! curl -s -o /dev/null --max-time 2 "$HOST/api/v0/version" 2>/dev/null; then
+if ! curl -s -o /dev/null --max-time 2 "$HOST/api/v0/health" 2>/dev/null; then
 	_die "amuleapi at $HOST is not reachable."
 fi
 
@@ -106,36 +106,36 @@ HAVE_GUEST=0
 
 # --- 1. Auth + method gates. ----------------------------------------
 _curl "$HOST/api/v0/share_directories"
-_assert_status 401 "GET /shared/directories (no token) → 401"
+_assert_status 401 "GET /share_directories (no token) → 401"
 
 _curl -X PUT -H "Content-Type: application/json" \
 	-d '{"directories":[]}' "$HOST/api/v0/share_directories"
-_assert_status 401 "PUT /shared/directories (no token) → 401"
+_assert_status 401 "PUT /share_directories (no token) → 401"
 
 if [ "$HAVE_GUEST" = "1" ]; then
 	# Reading the roots is GUEST, matching GET /shared and GET /preferences.
 	_curl -H "Authorization: Bearer $GUEST_TOKEN" "$HOST/api/v0/share_directories"
-	_assert_status 200 "GET /shared/directories (guest) → 200"
+	_assert_status 200 "GET /share_directories (guest) → 200"
 
 	_curl -X PUT -H "Authorization: Bearer $GUEST_TOKEN" -H "Content-Type: application/json" \
 		-d '{"directories":[]}' "$HOST/api/v0/share_directories"
-	_assert_status 403 "PUT /shared/directories (guest) → 403"
+	_assert_status 403 "PUT /share_directories (guest) → 403"
 
 	_curl -X POST -H "Authorization: Bearer $GUEST_TOKEN" -H "Content-Type: application/json" \
 		-d "{\"path\":\"$SCRATCH_DIR\"}" "$HOST/api/v0/share_directories"
-	_assert_status 403 "POST /shared/directories (guest) → 403"
+	_assert_status 403 "POST /share_directories (guest) → 403"
 
 	_curl -X DELETE -H "Authorization: Bearer $GUEST_TOKEN" \
 		"$HOST/api/v0/share_directories?path=%2Ftmp"
-	_assert_status 403 "DELETE /shared/directories (guest) → 403"
+	_assert_status 403 "DELETE /share_directories (guest) → 403"
 fi
 
 _curl -X PATCH -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/share_directories"
-_assert_status 405 "PATCH /shared/directories → 405"
+_assert_status 405 "PATCH /share_directories → 405"
 
 # --- 2. Read the current configuration (and snapshot it). -----------
 _curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/share_directories"
-_assert_status 200 "GET /shared/directories → 200"
+_assert_status 200 "GET /share_directories → 200"
 _assert_json_eq '.directories | type' 'array' "directories is an array"
 ORIGINAL_DIRS=$(printf '%s' "$CURL_BODY" | jq -c '.directories')
 [ -n "$ORIGINAL_DIRS" ] || _die "could not snapshot the current shared directories"

--- a/unittests/curl-tests/amuleapi/32-country-flags.sh
+++ b/unittests/curl-tests/amuleapi/32-country-flags.sh
@@ -83,7 +83,7 @@ _assert_status() {
 
 _header() { echo "$CURL_HEAD" | awk -F': ' -v k="$1" 'tolower($1) == k {gsub(/\r/,""); print $2}'; }
 
-if ! curl -s -o /dev/null --max-time 2 "$HOST/api/v0/version" 2>/dev/null; then
+if ! curl -s -o /dev/null --max-time 2 "$HOST/api/v0/health" 2>/dev/null; then
 	_die "amuleapi at $HOST is not reachable. Start amuleapi first."
 fi
 

--- a/unittests/curl-tests/amuleapi/33-known-clients.sh
+++ b/unittests/curl-tests/amuleapi/33-known-clients.sh
@@ -89,7 +89,7 @@ trap 'rm -f /tmp/amuleapi_33_head /tmp/amuleapi_33_body' EXIT
 
 command -v jq >/dev/null 2>&1 || _die "jq is required"
 
-if ! curl -s -o /dev/null --max-time 2 "$HOST/api/v0/version" 2>/dev/null; then
+if ! curl -s -o /dev/null --max-time 2 "$HOST/api/v0/health" 2>/dev/null; then
 	_die "amuleapi at $HOST is not reachable. Start amuleapi first."
 fi
 

--- a/unittests/curl-tests/amuleapi/34-friends.sh
+++ b/unittests/curl-tests/amuleapi/34-friends.sh
@@ -77,7 +77,7 @@ trap 'rm -f /tmp/amuleapi_34_head /tmp/amuleapi_34_body' EXIT
 
 command -v jq >/dev/null 2>&1 || _die "jq is required"
 
-if ! curl -s -o /dev/null --max-time 2 "$HOST/api/v0/version" 2>/dev/null; then
+if ! curl -s -o /dev/null --max-time 2 "$HOST/api/v0/health" 2>/dev/null; then
 	_die "amuleapi at $HOST is not reachable. Start amuleapi first."
 fi
 

--- a/unittests/curl-tests/amuleapi/35-ipfilter-actions.sh
+++ b/unittests/curl-tests/amuleapi/35-ipfilter-actions.sh
@@ -99,7 +99,7 @@ _set_url() {
 }
 
 if ! command -v jq >/dev/null 2>&1; then _die "jq is required."; fi
-if ! curl -s -o /dev/null --max-time 2 "$HOST/api/v0/version" 2>/dev/null; then
+if ! curl -s -o /dev/null --max-time 2 "$HOST/api/v0/health" 2>/dev/null; then
 	_die "amuleapi at $HOST is not reachable."
 fi
 

--- a/unittests/curl-tests/amuleapi/36-shared-reload.sh
+++ b/unittests/curl-tests/amuleapi/36-shared-reload.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# amuleapi 36-shared-reload — POST /shared/reload.
+# amuleapi 36-shared-reload — POST /shared_reload.
 #
 # Endpoint:
 #   POST /api/v0/shared_reload   → 202 {"ok":true}
@@ -74,7 +74,7 @@ _assert_json_eq() {
 }
 
 if ! command -v jq >/dev/null 2>&1; then _die "jq is required."; fi
-if ! curl -s -o /dev/null --max-time 2 "$HOST/api/v0/version" 2>/dev/null; then
+if ! curl -s -o /dev/null --max-time 2 "$HOST/api/v0/health" 2>/dev/null; then
 	_die "amuleapi at $HOST is not reachable."
 fi
 
@@ -93,19 +93,19 @@ sleep 4
 
 # --- 1. Auth guards. -----------------------------------------------
 _curl -X POST "$HOST/api/v0/shared_reload"
-_assert_status 401 "POST /shared/reload (no creds) → 401"
+_assert_status 401 "POST /shared_reload (no creds) → 401"
 
 if [ "$HAVE_GUEST" -eq 1 ]; then
 	_curl -X POST -H "Authorization: Bearer $GUEST_TOKEN" "$HOST/api/v0/shared_reload"
-	_assert_status 403 "POST /shared/reload (guest) → 403"
+	_assert_status 403 "POST /shared_reload (guest) → 403"
 else
 	echo "    info: no guest password configured; skipping the 403 guard check"
 fi
 
 # --- 2. Accept path. -----------------------------------------------
 _curl -X POST -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/shared_reload"
-_assert_status 202 "POST /shared/reload (admin) → 202"
-_assert_json_eq '.ok' true "/shared/reload → ok=true"
+_assert_status 202 "POST /shared_reload (admin) → 202"
+_assert_json_eq '.ok' true "/shared_reload → ok=true"
 
 # --- 3. Repeated calls coalesce. -----------------------------------
 # A second request while the first is still pending (or its walk running)
@@ -113,8 +113,8 @@ _assert_json_eq '.ok' true "/shared/reload → ok=true"
 # into a second walk. Only the status is observable from here; that the two
 # collapse into one walk is amuled-side and shows up in its log.
 _curl -X POST -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/shared_reload"
-_assert_status 202 "POST /shared/reload again immediately → 202"
-_assert_json_eq '.ok' true "second /shared/reload → ok=true"
+_assert_status 202 "POST /shared_reload again immediately → 202"
+_assert_json_eq '.ok' true "second /shared_reload → ok=true"
 
 # --- 4. The reply does not wait for the walk. ----------------------
 # Generous bound: this is a smoke against a regression to the old inline
@@ -123,11 +123,11 @@ _assert_json_eq '.ok' true "second /shared/reload → ok=true"
 START=$(date +%s)
 _curl -X POST -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/shared_reload"
 ELAPSED=$(( $(date +%s) - START ))
-_assert_status 202 "POST /shared/reload (timed) → 202"
+_assert_status 202 "POST /shared_reload (timed) → 202"
 if [ "$ELAPSED" -le 10 ]; then
-	_pass "/shared/reload returned in ${ELAPSED}s (does not block on the walk)"
+	_pass "/shared_reload returned in ${ELAPSED}s (does not block on the walk)"
 else
-	_fail "/shared/reload returned in ${ELAPSED}s" \
+	_fail "/shared_reload returned in ${ELAPSED}s" \
 		"expected the reply to be scheduled, not to wait for the directory walk"
 fi
 
@@ -143,10 +143,10 @@ _assert_json_eq '.shared | type' array "/shared still serves a coherent list"
 
 # --- 6. Method gate. -----------------------------------------------
 _curl -X GET -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/shared_reload"
-_assert_status 405 "GET /shared/reload → 405"
+_assert_status 405 "GET /shared_reload → 405"
 
 _curl -X DELETE -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/shared_reload"
-_assert_status 405 "DELETE /shared/reload → 405"
+_assert_status 405 "DELETE /shared_reload → 405"
 
 # --- Summary. -----------------------------------------------------
 echo

--- a/unittests/curl-tests/amuleapi/37-shared-availability-parts.sh
+++ b/unittests/curl-tests/amuleapi/37-shared-availability-parts.sh
@@ -77,7 +77,7 @@ _assert_json_eq() {
 if ! command -v jq >/dev/null 2>&1; then
 	_die "jq is required."
 fi
-if ! curl -s -o /dev/null --max-time 2 "$HOST/api/v0/version" 2>/dev/null; then
+if ! curl -s -o /dev/null --max-time 2 "$HOST/api/v0/health" 2>/dev/null; then
 	_die "amuleapi at $HOST is not reachable."
 fi
 

--- a/unittests/curl-tests/amuleapi/38-chat.sh
+++ b/unittests/curl-tests/amuleapi/38-chat.sh
@@ -81,7 +81,7 @@ _assert_json_eq() {
 }
 
 command -v jq >/dev/null 2>&1 || _die "jq is required."
-curl -s -o /dev/null --max-time 2 "$HOST/api/v0/version" 2>/dev/null \
+curl -s -o /dev/null --max-time 2 "$HOST/api/v0/health" 2>/dev/null \
 	|| _die "amuleapi at $HOST is not reachable."
 
 echo "amuleapi 38-chat smoke @ $HOST"

--- a/unittests/curl-tests/amuleapi/39-shared-media-refresh.sh
+++ b/unittests/curl-tests/amuleapi/39-shared-media-refresh.sh
@@ -60,7 +60,7 @@ _assert_json_eq() {
 }
 
 command -v jq >/dev/null 2>&1 || _die "jq is required."
-curl -s -o /dev/null --max-time 2 "$HOST/api/v0/version" 2>/dev/null \
+curl -s -o /dev/null --max-time 2 "$HOST/api/v0/health" 2>/dev/null \
 	|| _die "amuleapi at $HOST is not reachable."
 
 echo "amuleapi 39-shared-media-refresh smoke @ $HOST"

--- a/unittests/curl-tests/amuleapi/40-http-conformance.sh
+++ b/unittests/curl-tests/amuleapi/40-http-conformance.sh
@@ -76,7 +76,7 @@ _has_hdr() {
 }
 
 if ! command -v jq >/dev/null 2>&1; then _die "jq is required."; fi
-if ! curl -s -o /dev/null --max-time 2 "$HOST/api/v0/version" 2>/dev/null; then
+if ! curl -s -o /dev/null --max-time 2 "$HOST/api/v0/health" 2>/dev/null; then
 	_die "amuleapi at $HOST is not reachable. Start it first."
 fi
 
@@ -444,8 +444,8 @@ curl -s -o "$BODY_FILE" -D "$HDR_FILE" --max-time 10 \
 ALLOW_DIRS=$(_hdr Allow)
 for m in GET HEAD POST PUT DELETE; do
 	case "$ALLOW_DIRS" in
-	*"$m"*) _pass "Allow on /shared/directories names $m" ;;
-	*) _fail "Allow on /shared/directories names $m" "got [$ALLOW_DIRS]" ;;
+	*"$m"*) _pass "Allow on /share_directories names $m" ;;
+	*) _fail "Allow on /share_directories names $m" "got [$ALLOW_DIRS]" ;;
 	esac
 done
 
@@ -904,7 +904,7 @@ done
 
 # ...and an unauthenticated public probe stays cacheable, or it loses the
 # conditional GET the ETag exists for.
-curl -s -o /dev/null -D "$HDR_FILE" --max-time 10 "$HOST/api/v0/version" >/dev/null
+curl -s -o /dev/null -D "$HDR_FILE" --max-time 10 "$HOST/api/v0/health" >/dev/null
 if [ -z "$(_hdr Cache-Control)" ]; then
 	_pass "an unauthenticated probe is left cacheable"
 else

--- a/unittests/curl-tests/amuleapi/run-all.sh
+++ b/unittests/curl-tests/amuleapi/run-all.sh
@@ -164,14 +164,14 @@ run_phase() {
 	"$BIN" --config-dir=/tmp/amuleapi-regtest \
 		--host="$EC_HOST" --port="$EC_PORT" \
 		> /tmp/amuleapi.log 2>&1 &
-	# Poll /version until the daemon is ready instead of guessing the
+	# Poll /health until the daemon is ready instead of guessing the
 	# cold-start time. The first EC GET_UPDATE roundtrip can take a
 	# couple of seconds on a slow CI runner, and the cap of 12 leaves
 	# headroom while still failing fast on a genuine bring-up bug.
 	local i
 	for i in 1 2 3 4 5 6 7 8 9 10 11 12; do
 		if curl -s -o /dev/null --max-time 1 \
-		    http://localhost:4713/api/v0/version 2>/dev/null; then
+		    http://localhost:4713/api/v0/health 2>/dev/null; then
 			break
 		fi
 		sleep 0.5

--- a/unittests/tests/StateTest.cpp
+++ b/unittests/tests/StateTest.cpp
@@ -1218,14 +1218,15 @@ TEST(State, MemoizableTargetExcludesEverythingElse)
 }
 
 // A sub-resource of an eligible collection is NOT itself eligible: it is a
-// different body, and /shared/directories in particular is a live EC read
-// that an "everything under /shared" rule would have swept back in.
+// different body, so an "everything under /downloads" or "everything under
+// /shared" rule would sweep back in exactly what the opt-in set leaves out.
+// (/share_directories used to be listed here as /shared/directories; it is no
+// longer under /shared at all, and the excluded-set test above covers it.)
 TEST(State, MemoizableTargetDoesNotExtendToSubResources)
 {
 	ASSERT_TRUE(!MemoizableTarget("/api/v0/downloads/8b54a3c2"));
 	ASSERT_TRUE(!MemoizableTarget("/api/v0/downloads/8b54a3c2/clients"));
 	ASSERT_TRUE(!MemoizableTarget("/api/v0/shared/8b54a3c2"));
-	ASSERT_TRUE(!MemoizableTarget("/api/v0/share_directories"));
 	// and no prefix bleed onto a neighbour that merely starts the same
 	ASSERT_TRUE(!MemoizableTarget("/api/v0/downloads_archive"));
 	ASSERT_TRUE(!MemoizableTarget("/api/v0/sharedfiles"));


### PR DESCRIPTION
Reading issue #1107 back section by section against the tree that landed it turned up two changes that behave wrong, and a trail of comments, docs and test labels still describing a surface that no longer exists. The two defects come first; the paper trail is listed at the bottom.

Emitting the `update` block only to an authenticated caller (#1147, issue #1107 §12) made GET /api/v0/version call Authenticate(), which is the rate-limited wrapper: its "missing bearer token or session cookie" path runs NoteFailure(). So 30 anonymous requests to the surface's documented public endpoint within 60 s locked that address out of every authenticated route for five minutes -- and behind a reverse proxy every client shares one remote_addr, so a single anonymous poller could lock out everybody. /version itself still answered 200, which is why nothing saw it.

Authentication there is optional, so the credential check now runs only when the request actually presents one. A credential that IS presented and rejected still counts: the `update` block appearing is an oracle a token guesser could otherwise read for free, and the wrapper's lockout pre-check keeps a locked-out address off the verify path. Reuses the existing RequestCarriesCredentials() helper rather than duplicating the header/cookie extraction a third time.

01-version-and-errors.sh gains the regression check -- 35 anonymous /version requests, then an authenticated /auth/session must still be
200. It is deliberately the file's last assertion, since a regression arms a five-minute lockout that would poison everything after it.

One more value was still a sentinel. #1145 (issue #1107 §11) settled on "a nullable field says null when it does not know", and REFERENCE.md states it as a rule -- "neither is ever spelled 0 or -1" -- three lines above a table documenting `0` = never/unknown for last_seen_complete. It is the same kind of never-timestamp as last_upload and shared_since, which that commit did convert, so it goes through WriteIntOrNull too. The Web UI already renders null as an em dash, and 04-read-downloads- shared.sh gains the type assertion its two neighbours already had.

The rest is the paper trail #1107 left behind:

- The four MethodNotAllowed messages for the renamed collection actions still named the removed paths (/downloads/clear_completed, /shared/reload, /shared/directories, /servers/update), and the two 409 `completed_use_clear_completed` bodies pointed clients at a path that now 404s.
- REFERENCE.md had 19 broken internal anchors: the seven renamed endpoints plus six that never matched their heading (get-apiv0sharedhashclients, post-apiv0authsession with the wrong verb, get-apiv0downloadshasha4af, list-envelopes-and-pagination, get-apiv0events, which lives in EVENTS.md).
- REFERENCE.md still documented POST/DELETE/PATCH /api/v0/servers/{ip}:{port} in three headings; the colon-sniffing form was replaced by /servers/by-address/{address} in #1150.
- The /servers dispatch comment claimed the ECID patterns are tried first; the address ones are, and the reason is segment count, not the colon rationale that no longer applies. The /share_directories comment still justified an ordering against /shared/{hash} that can no longer collide.
- The generic limiter's comment said "hard-coded for now ... can become a config knob in 3.1" directly above the code reading the three [Auth]/Token* keys #1147 added; QUICKSTART's sample [Auth] block was missing them, though the first-run template writes them.
- #1144 left two orphaned comments describing deleted converters, one of them wrapping an empty anonymous namespace, and three live comments named DownloadPriorityName / SharedPriorityName / SharedPriorityToCode -- none of which exist.
- /version was still the liveness probe in 44 test reachability checks and in run-all.sh's bring-up poll; that is what /health is for since #1147. The endpoint-under-test uses stay on /version -- notably the HEAD/Content-Length comparison, whose anonymous body is fixed-length where /health's readiness flags could flip between the two requests. The one exception is 40-http-conformance's "an unauthenticated probe is left cacheable", which is about probes rather than about /version.
- StateTest's sub-resource case listed /share_directories, which is no longer under /shared; the excluded-set test above it already covers it, with the right reason.
- ParseTailParam's comment still described the pre-#1141 contract -- "unparseable ... clamps to 0" -- directly above the sentence saying it is a 400 now, and above the code that returns one.
- REFERENCE.md said a `priority` outside the download set makes "the daemon clamp any other value to normal". The daemon clamping is the reason the set is narrow; what a client gets is a 400.
- EVENTS.md never documented that /events answers 405 with an Allow header, or that a trailing slash opens the same stream -- the two halves of #1107 §1, described only in Api.cpp and in the conformance test.
- REFERENCE.md's list-pagination prose enumerated nine endpoints; its own sortable-fields table below it lists eleven (/known_clients and /chats were missing).
- download-detail.js still tested `remaining_time < 0`, dead since #1145 made it null.
- Four test labels and two header comments still named the colon-sniffed /servers/<ip>:<port> form #1150 replaced, so a failure would have printed a path that now 404s; 14-servers-mutations still opened with "the routes also accept <ip>:<port> in place of an ECID", which the paragraph below it already contradicts. The URLs under test were right -- only what they are called was not.

Verified: amuleapi and StateTest build, StateTest passes, all 41 curl scripts pass bash -n, download-detail.js passes node --check, REFERENCE.md and EVENTS.md have no broken anchors, and no removed path is named anywhere in the tree.