### PR TITLE
fix(web-ui): read the bulk clear's results, and drop a dead ETA branch

### DIFF
--- a/src/webapi/static/js/views/download-detail.js
+++ b/src/webapi/static/js/views/download-detail.js
@@ -52,7 +52,7 @@ export function DownloadDetail({ hash, isGuest, categories = [], onPatch, onDele
   // then), but not the percent bar above -- that is the download's own
   // completeness.
   const parts = (d.progress && d.progress.parts) || [];
-  const eta = (d.remaining_time == null || d.remaining_time < 0) ? "—" : formatDuration(d.remaining_time);
+  const eta = d.remaining_time == null ? "—" : formatDuration(d.remaining_time);
 
   const copy = (text) => copyText(text)
     .then(() => toast(t("downloads_detail_copied"), "success"))

--- a/src/webapi/static/js/views/downloads.js
+++ b/src/webapi/static/js/views/downloads.js
@@ -126,9 +126,17 @@ export default function Downloads({ isGuest }) {
   // Apply the same field change (priority/category) to every selected row.
   const bulkPatch = (patch) => runBulk((h) => api.patch("downloads", { hashes: h, ...patch }));
 
+  // Clears every completed entry, so it reports per entry: a refusal is a
+  // 207 row, not a throw.
   const clearCompleted = async () => {
     if (!(await confirmDialog(t("downloads_confirm_clear_completed")))) return;
-    mutate(() => api.post("downloads_clear_completed"));
+    mutate(async () => {
+      const res = await api.post("downloads_clear_completed");
+      const failed = bulkFailures(res);
+      if (failed.length)
+        toast(t("common_bulk_partial", { failed: failed.length, total: res.results.length,
+                message: terr(failed[0].error) }), "warn");
+    });
   };
   // Same endpoint scoped to one hash, for the detail panel's Clear button.
   const clearOne = (h) => mutate(() => api.post("downloads_clear_completed", { hash: h }));


### PR DESCRIPTION
Two leftovers from the API work in issue #1107, both in the downloads view.

#1146 gave POST /downloads_clear_completed the `results[]` envelope every other multi-item mutation uses, so a per-entry failure finally had somewhere to appear -- and a batch that partly fails now answers 207 rather than 200. The view kept posting it through `mutate()`, which refreshes and reports a thrown error but reads any 2xx as success, so the entries that refused to clear vanished silently: the list redrew with the same rows still in it and nothing said why.

It stays on `mutate()` -- the try/catch and the refresh are already right -- and only reads the response, raising `common_bulk_partial` the way the five sibling bulk call sites do. clearOne() needs none of it: one hash is a single-entry outcome the API reports as a top-level 404/409, not as a `results[]` row.

The ETA branch is smaller. #1145 replaced `remaining_time: -1` with null, so `d.remaining_time < 0` has been unreachable since; the `== null` test beside it already covers the case.

Verified in the browser against a live amuleapi. A stubbed 207 carrying one ok row and two failures raises the warn toast "2 de 3 fallaron: download is not completed"; the real call, with no completed entries, answers 200 with `{"results":[]}` and stays quiet. The detail panel renders both null timestamps as an em dash -- "Tiempo restante" and "Visto completo por última vez". No console errors on either path, and both files pass node --check.