### PR TITLE
fix(core): hand the fragmented arena pages back every 15 minutes

### DIFF
--- a/src/amule.cpp
+++ b/src/amule.cpp
@@ -29,6 +29,14 @@
 
 #include <csignal>
 #include <cstring>
+
+// malloc_trim. Guarded because macOS has no <malloc.h>; the call site below
+// gates on the libc actually providing it.
+#if defined(__has_include)
+#if __has_include(<malloc.h>)
+#include <malloc.h>
+#endif
+#endif
 #include <wx/process.h>
 #include <wx/sstream.h>
 #include "config.h" // Needed for HAVE_GETRLIMIT, HAVE_SETRLIMIT,
@@ -1943,10 +1951,32 @@ void CamuleApp::OnTCPTimer(CTimerEvent &WXUNUSED(evt))
 	serverconnect->ConnectToAnyServer();
 }
 
+namespace
+{
+
+// glibc shrinks an arena's top on free but never the free space fragmented
+// below it, which is what a churning Kad index leaves. Without this the core
+// never returns a page: VmRSS tracks VmHWM for the life of the process. This
+// file is in CORE_SOURCES, so the trim runs in amuled and in the monolithic
+// amule alike -- both churn the same index; amulegui does not link it.
+//
+// Only the trim from amuleapi's #1153, not its mallopt(M_ARENA_MAX): the
+// per-thread arenas hold ~33 MB resident of ~1 GB reserved, so arena count is
+// not what inflates it, and a two-arena cap would put a dozen concurrent
+// threads on one malloc lock.
+void TrimMallocArenas()
+{
+#if defined(__GLIBC__) && defined(M_TRIM_THRESHOLD)
+	malloc_trim(0);
+#endif
+}
+
+} // namespace
+
 void CamuleApp::OnCoreTimer(CTimerEvent &WXUNUSED(evt))
 {
 	// Former TimerProc section
-	static uint64 msPrev1, msPrev5, msPrevSave, msPrevHist, msPrevOS, msPrevKnownMet;
+	static uint64 msPrev1, msPrev5, msPrevSave, msPrevHist, msPrevOS, msPrevKnownMet, msPrevTrim;
 	uint64 msCur = theStats::GetUptimeMillis();
 	TheTime = msCur / 1000;
 
@@ -2078,6 +2108,17 @@ void CamuleApp::OnCoreTimer(CTimerEvent &WXUNUSED(evt))
 	if (msCur - msPrevSave >= 60000) {
 		msPrevSave = msCur;
 		theStats::Save();
+	}
+
+	// The cost of a trim is per call, not per second: each one hands back ~6 MB
+	// the daemon re-faults within two minutes (measured on a live node, minor
+	// faults ~20/min -> ~1600/min at a 60 s cadence, for an unchanged RSS peak),
+	// and the yield per call is no worse at 15 min. Plain countdown, not gated
+	// on the daemon looking idle: the traffic that fragments the arenas is what
+	// busy looks like here, so a gate would skip the trim when it matters.
+	if (msCur - msPrevTrim >= 15 * 60 * 1000) {
+		msPrevTrim = msCur;
+		TrimMallocArenas();
 	}
 
 	// Special


### PR DESCRIPTION
amuled's RSS only ever ratchets up. On an 11k-file node it climbed 3.7-6.2 MB/h
depending on the process generation, one of which reached 1.2 GB in 25 h against
a 2 GB container limit, and VmRSS equalled VmHWM in every single sample taken
over a day: the daemon had never returned a page to the OS since startup.

Not a leak. The churn is Kad indexing: the node takes in ~1300 CKeyEntry/CEntry
objects per hour and CIndexed::Clean() drops about as many every 30 min, so the
live set is in equilibrium. Measured across one prune that freed 633 source and
748 keyword entries, the index ended ~1000 entries smaller than it had been ten
minutes earlier while RSS rose 512 kB. glibc shrinks an arena's top on free but
never the free space fragmented below it, and a churning index leaves exactly
that. malloc_trim(0) on that daemon returns 1 and hands 7-11 MB back per call,
18.6 MB on the first call of a process that had never had one.

The interval is 15 min because the cost of a trim is per call, not per second.
Timed and counted on the live node (x86_64, glibc 2.41, 4 kB pages, ~302 MB
RSS): the walk itself takes 7-11 ms on the timer thread, and each trim hands
back ~6 MB that the daemon re-faults within two minutes -- minor faults over the
minute after a trim run ~1400, against ~20/min for an untouched daemon, and they
fall back to that within three minutes. At a 60 s cadence that is ~1600 faults
every minute forever, and RSS measured just before each trim sat at 302 MB
throughout: the peak never moved, only the reading taken right after the call.
Fifteen minutes amortises the same fixed cost 15 times: 4 walks an hour instead
of 60, ~100 faults a minute instead of ~1600, and the yield per call is if
anything larger (11.4, 7.3 and 10.3 MB on three calls 15 min apart, against
5.8-6.9 MB when called every minute). Nothing past 15 min was measured, but
those three calls show no upward trend in yield, so a longer gap looks like it
would only leave the fragmentation resident for longer.

What the trim recovers is that floor, not the long-run slope: over the same
half hour RSS drifted up ~60-85 kB/min with the trim and without it. The 25 h
history and VmRSS == VmHWM in every sample are what argue the floor keeps
growing; a half-hour window is too short to show it.

amule.cpp is in CORE_SOURCES, so this also runs in the monolithic amule, which
wants it for the same reason: a GUI instance 78 min old was likewise sitting at
VmRSS == VmHWM == 156764 kB, and one call there (glibc 2.44) took 5.4 ms and
gave back 19.0 MB. amulegui does not link this file.

Only the trim from amuleapi's #1153, not its mallopt(M_ARENA_MAX, 2): amuled's
per-thread arenas hold ~33 MB resident of ~1 GB reserved, so arena count is not
what inflates this process, and a two-arena cap would put a dozen genuinely
concurrent threads on one malloc lock. Not gated on the daemon looking idle, for
the reason #1153 gives: the Kad and upload traffic that fragments the arenas is
what busy looks like here, so an idle gate would skip the trim precisely when it
is needed.

