### PR TITLE
minor fix: a server ed2k-link shall not be displayed if not added, and the reason shall be displayed in the log

### DIFF
--- a/src/DownloadQueue.cpp
+++ b/src/DownloadQueue.cpp
@@ -1611,10 +1611,10 @@ bool CDownloadQueue::AddED2KLink(const CED2KServerLink *link)
 
 	server->SetListName(Uint32toStringIP(link->GetIP()));
 
-	theApp->serverlist->AddServer(server);
-
-	Notify_ServerAdd(server);
-
+	if (!theApp->AddServer(server, true)) {
+		delete server;
+		return false;
+	}
 	return true;
 }
 


### PR DESCRIPTION
# Description

This PR fixes the following behavior:

In amule monolithic, when adding a server through an ed2k link whose IP is filtered by the IP filter, the new server is displayed in the server list, even if not really added internally. No message is printed in the log.

In remote amulegui, when adding a server through an ed2k link whose IP is filtered by the IP filter, the log shows a line "Adding ed2k link..." but then nothing happens: no server is added to the list, and no explanation on why is given in the log, so the user has no feedback about why the server was not added.

On the other side, in both monolithic and remotegui, if we manually type the server IP and port in the input field, the server is not added, and the log displays a line explaining why: it is IP-filtered (or any other possible reason).

This fix will treat a server added via the ed2k-link handler as manually added by the user, ie.: the same way as a server added via the GUI by typing its name/IP/port. Therefore, it will produce a log output on both success and error paths, so the user will know what happened.

# Technical details

IP-Filtered servers added through an ed2k://|server|... link were incorrectly displayed in the monolithic amule. The server-list insertion was rejected by the IP filter, but the link handler ignored the result and notified the GUI unconditionally.

The fix checks the result of AddServer, notifies the GUI only after successful insertion, and deletes the server object when insertion fails. This prevents filtered servers from appearing and avoids leaking rejected objects.

Additionally, AddServer is called with fromUser=true when inserting an ed2k link so rejected server links produce a log message explaining why the server was not added, instead of silently doing nothing and letting the user guess why.