### PR TITLE
fix(amuleapi): key the by-hash index on the role, not on the hash alone

### DIFF
--- a/src/webapi/Refresher.cpp
+++ b/src/webapi/Refresher.cpp
@@ -1296,7 +1296,7 @@ void ApplyGetUpdateToDownloads(
 			const std::uint32_t ecid = static_cast<std::uint32_t>(t->GetInt());
 			auto fit = cache.find(ecid);
 			if (fit != cache.end()) {
-				fit->second.is_downloading = false;
+				cache.SetDownloading(fit, false);
 				// Reset the download sub-block so a future role-true
 				// transition (or even a stale FindDownload lookup
 				// after the role flag was checked) can't surface
@@ -1327,7 +1327,7 @@ void ApplyGetUpdateToDownloads(
 			DecodeRleBlobsForPartFile(pf, f, rle_state);
 			cache.emplace(ecid, std::move(f));
 		} else {
-			map_it->second.is_downloading = true;
+			cache.SetDownloading(map_it, true);
 			MergePartFileTag(pf, map_it->second, /*is_new=*/false);
 			DecodeRleBlobsForPartFile(pf, map_it->second, rle_state);
 		}
@@ -1363,7 +1363,7 @@ void ApplyGetUpdateToShared(
 			const std::uint32_t ecid = static_cast<std::uint32_t>(t->GetInt());
 			auto fit = cache.find(ecid);
 			if (fit != cache.end()) {
-				fit->second.is_shared = false;
+				cache.SetShared(fit, false);
 				if (!fit->second.is_downloading)
 					cache.erase(fit);
 				else
@@ -1391,7 +1391,7 @@ void ApplyGetUpdateToShared(
 					// preserved (persistent file attribute).
 					auto fit = cache.find(ecid);
 					if (fit != cache.end()) {
-						fit->second.is_shared = false;
+						cache.SetShared(fit, false);
 						ClearSharedRoleKeepPriority(fit->second);
 					}
 					continue;
@@ -1427,9 +1427,9 @@ void ApplyGetUpdateToShared(
 			if (map_it->second.hash.empty()) {
 				const std::string h = TagHashLower(sf);
 				if (!h.empty())
-					map_it->second.hash = h;
+					cache.SetHash(map_it, h);
 			}
-			map_it->second.is_shared = true;
+			cache.SetShared(map_it, true);
 			MergeSharedTag(sf, map_it->second);
 			// PARTFILE tags are decoded by the downloads walker, which
 			// already ran on this same response; decoding them again

--- a/src/webapi/State.cpp
+++ b/src/webapi/State.cpp
@@ -689,7 +689,10 @@ bool CState::FindDownload(const std::string &hash_hex, FileSnapshot &out) const
 {
 	std::shared_lock<std::shared_timed_mutex> lock(m_mu);
 	std::uint32_t ecid = 0;
-	if (!m_files.FindEcidByHash(hash_hex, ecid))
+	// Role-keyed: a share with the same content must not shadow the download
+	// (#1161). The is_downloading check below is now belt-and-braces rather
+	// than the thing standing between the caller and the wrong entry.
+	if (!m_files.FindDownloadEcidByHash(hash_hex, ecid))
 		return false;
 	const auto it = m_files.find(ecid);
 	if (it == m_files.end() || !it->second.is_downloading)
@@ -702,7 +705,9 @@ std::uint64_t CState::DownloadPartCount(const std::string &hash_hex) const
 {
 	std::shared_lock<std::shared_timed_mutex> lock(m_mu);
 	std::uint32_t ecid = 0;
-	if (!m_files.FindEcidByHash(hash_hex, ecid))
+	// Same role-keyed resolution as FindDownload(): this answers a question
+	// about the download, so a share with the same hash must not answer it.
+	if (!m_files.FindDownloadEcidByHash(hash_hex, ecid))
 		return 0;
 	const auto it = m_files.find(ecid);
 	if (it == m_files.end() || !it->second.is_downloading)
@@ -724,7 +729,9 @@ bool CState::FindShared(const std::string &hash_hex, FileSnapshot &out) const
 {
 	std::shared_lock<std::shared_timed_mutex> lock(m_mu);
 	std::uint32_t ecid = 0;
-	if (!m_files.FindEcidByHash(hash_hex, ecid))
+	// Role-keyed, mirroring FindDownload(): the part file being downloaded
+	// must not shadow the share.
+	if (!m_files.FindSharedEcidByHash(hash_hex, ecid))
 		return false;
 	const auto it = m_files.find(ecid);
 	if (it == m_files.end() || !it->second.is_shared)

--- a/src/webapi/State.h
+++ b/src/webapi/State.h
@@ -1392,16 +1392,28 @@ struct StatusSnapshot
 // maintained inline on every emplace/erase so the obvious lookup
 // directions both stay O(1) avg without a per-tick rebuild pass:
 //  * ECID → entry via std::unordered_map::find (file_map[]).
-//  * 32-char hex MD4 hash → ECID via FindEcidByHash (index[]).
+//  * 32-char hex MD4 hash + role → ECID via FindDownloadEcidByHash /
+//    FindSharedEcidByHash (one index per role).
+//
+// One index per role, not one overall, because a hash does NOT name a single
+// file here. A part file and the completed copy someone dropped into a shared
+// folder are two amuled objects with two ECIDs and the same hash, and this map
+// holds both. aMule keeps them apart by having a list per role
+// (CKnownFileList and CSharedFileList are each hash-keyed and de-duplicate on
+// insert, so neither ever holds two files under one hash); this map merges the
+// roles, so it has to carry the role in the key instead. With a single index
+// whichever entry was filed last won the slot and the other became
+// unreachable while still sitting in the map (#1161, reported as #1157).
 //
 // Walkers reach in via find()/emplace()/erase()/begin()/end() — the
 // same surface they had when this was a raw std::map<uint32_t,
 // FileSnapshot>&. The wrapper intercepts the two mutations that move
 // hashes around and keeps the index consistent.
 //
-// Invariant: a FileSnapshot's `hash` is content-derived and never
-// changes once set. Walkers MUST NOT reassign `hash` via the iterator
-// (the index would desync). Set hash before emplace, never after.
+// Invariant: `hash`, `is_downloading` and `is_shared` are what the indexes are
+// built from, so they are not assigned through the iterator -- go through
+// SetHash() / SetDownloading() / SetShared(), which re-file the entry. A raw
+// assignment compiles and silently desyncs the index.
 //
 // Invariant: an entry's key IS its FileSnapshot::ecid, enforced by emplace()
 // rather than left to the caller. A snapshot filed under one id but carrying
@@ -1431,44 +1443,115 @@ public:
 		// The key wins -- readers resolve by it. See the invariant above.
 		f.ecid = ecid;
 		auto r = m_files.emplace(ecid, std::move(f));
-		if (r.second && !r.first->second.hash.empty()) {
-			m_hash_to_ecid[r.first->second.hash] = ecid;
+		if (r.second) {
+			Reindex(r.first);
 		}
 		return r;
 	}
 
+	//! Assign `hash` on an existing entry and re-file it. The refresher can
+	//! learn a hash after the insert (a partfile frame with HASH suppressed,
+	//! then a knownfile frame carrying it), and the index has to follow.
+	void SetHash(iterator it, std::string hash)
+	{
+		if (it == m_files.end() || it->second.hash == hash)
+			return;
+		DropRows(it->first, it->second.hash);
+		it->second.hash = std::move(hash);
+		Reindex(it);
+	}
+
+	//! Add or remove the downloading role, keeping that role's index in step.
+	void SetDownloading(iterator it, bool on)
+	{
+		if (it == m_files.end() || it->second.is_downloading == on)
+			return;
+		it->second.is_downloading = on;
+		Reindex(it);
+	}
+
+	//! Add or remove the shared role, keeping that role's index in step.
+	void SetShared(iterator it, bool on)
+	{
+		if (it == m_files.end() || it->second.is_shared == on)
+			return;
+		it->second.is_shared = on;
+		Reindex(it);
+	}
+
 	iterator erase(iterator it)
 	{
-		if (!it->second.hash.empty()) {
-			auto hit = m_hash_to_ecid.find(it->second.hash);
-			// Defence: only clear the index slot if it still points at
-			// this ECID. A later emplace with the same hash but a
-			// different ECID could have rewired the slot already.
-			if (hit != m_hash_to_ecid.end() && hit->second == it->first) {
-				m_hash_to_ecid.erase(hit);
-			}
-		}
+		DropRows(it->first, it->second.hash);
 		return m_files.erase(it);
 	}
 
 	void clear()
 	{
 		m_files.clear();
-		m_hash_to_ecid.clear();
+		m_download_by_hash.clear();
+		m_shared_by_hash.clear();
 	}
 
-	bool FindEcidByHash(const std::string &hash, std::uint32_t &out) const
+	//! Resolve a hash to the entry carrying the DOWNLOADING role, ignoring a
+	//! share that happens to have the same content.
+	bool FindDownloadEcidByHash(const std::string &hash, std::uint32_t &out) const
 	{
-		auto it = m_hash_to_ecid.find(hash);
-		if (it == m_hash_to_ecid.end())
+		return Lookup(m_download_by_hash, hash, out);
+	}
+
+	//! Resolve a hash to the entry carrying the SHARED role.
+	bool FindSharedEcidByHash(const std::string &hash, std::uint32_t &out) const
+	{
+		return Lookup(m_shared_by_hash, hash, out);
+	}
+
+private:
+	using index_type = std::unordered_map<std::string, std::uint32_t>;
+
+	static bool Lookup(const index_type &idx, const std::string &hash, std::uint32_t &out)
+	{
+		auto it = idx.find(hash);
+		if (it == idx.end())
 			return false;
 		out = it->second;
 		return true;
 	}
 
-private:
+	//! Point `idx[hash]` at `ecid` when the role applies, and clear the row
+	//! when it no longer does -- but only if it still names this entry, since
+	//! the other entry sharing this hash may own the row.
+	static void FileRow(index_type &idx, const std::string &hash, std::uint32_t ecid, bool applies)
+	{
+		auto it = idx.find(hash);
+		if (applies) {
+			idx[hash] = ecid;
+		} else if (it != idx.end() && it->second == ecid) {
+			idx.erase(it);
+		}
+	}
+
+	//! Re-file one entry into whichever role indexes its current flags call
+	//! for. Cheap and idempotent, so callers can just call it after a change.
+	void Reindex(iterator it)
+	{
+		if (it->second.hash.empty())
+			return;
+		FileRow(m_download_by_hash, it->second.hash, it->first, it->second.is_downloading);
+		FileRow(m_shared_by_hash, it->second.hash, it->first, it->second.is_shared);
+	}
+
+	//! Remove every row naming `ecid` under `hash`, in both roles.
+	void DropRows(std::uint32_t ecid, const std::string &hash)
+	{
+		if (hash.empty())
+			return;
+		FileRow(m_download_by_hash, hash, ecid, false);
+		FileRow(m_shared_by_hash, hash, ecid, false);
+	}
+
 	map_type m_files;
-	std::unordered_map<std::string, std::uint32_t> m_hash_to_ecid;
+	index_type m_download_by_hash;
+	index_type m_shared_by_hash;
 };
 
 // One State instance per amuleapi process. The mutex protects every

--- a/unittests/tests/StateTest.cpp
+++ b/unittests/tests/StateTest.cpp
@@ -169,10 +169,13 @@ TEST(State, FileMapEmplaceFilesTheSnapshotUnderItsKey)
 		ASSERT_TRUE(it != files.end());
 		ASSERT_EQUALS(static_cast<std::uint32_t>(42), it->second.ecid);
 		ASSERT_TRUE(files.find(999) == files.end());
-		// The hash index is keyed off the same insert, so it agrees too.
+		// The role index is keyed off the same insert, so it agrees too.
 		std::uint32_t by_hash = 0;
-		ASSERT_TRUE(files.FindEcidByHash("cccc2222cccc2222cccc2222cccc2222", by_hash));
+		ASSERT_TRUE(files.FindDownloadEcidByHash("cccc2222cccc2222cccc2222cccc2222", by_hash));
 		ASSERT_EQUALS(static_cast<std::uint32_t>(42), by_hash);
+		// ...and only under the role the entry actually carries.
+		std::uint32_t as_shared = 0;
+		ASSERT_FALSE(files.FindSharedEcidByHash("cccc2222cccc2222cccc2222cccc2222", as_shared));
 	});
 }
 
@@ -224,6 +227,241 @@ TEST(State, MutateDownloadsRoundtripAndFind)
 
 	FileSnapshot miss;
 	ASSERT_FALSE(s.FindDownload("0000000000000000000000000000000c", miss));
+}
+
+// #1161 -- a part file and its shared copy are two amuled objects with two
+// ECIDs and one hash. aMule keeps them apart because it has a list per role
+// (CKnownFileList and CSharedFileList are both hash-keyed and de-duplicate on
+// insert); amuleapi merges the roles into one map, so both land here.
+//
+// Whichever is emplaced last used to win the single hash->ECID slot, and the
+// other became unreachable: FindDownload() resolved the hash to the shared
+// entry, saw is_downloading == false and reported "no download with that
+// hash" for a download that was in the map and being refreshed the whole time
+// (#1157). Order must not decide the answer -- each role resolves to its own
+// entry.
+TEST(State, AHashSharedByADownloadAndAShareResolvesToBoth)
+{
+	const std::string kHash = "abcd1234abcd1234abcd1234abcd1234";
+	CState s;
+	s.MutateDownloads([&](FileMap &cache) {
+		FileSnapshot dl;
+		dl.ecid = 11;
+		dl.hash = kHash;
+		dl.name = "movie.part";
+		dl.is_downloading = true;
+		cache.emplace(dl.ecid, dl);
+
+		// The completed copy, obtained elsewhere and dropped into a
+		// shared folder: same content, so the same hash, but a
+		// different amuled object and therefore a different ECID.
+		FileSnapshot sh;
+		sh.ecid = 22;
+		sh.hash = kHash;
+		sh.name = "movie.mkv";
+		sh.is_shared = true;
+		cache.emplace(sh.ecid, sh);
+	});
+
+	FileSnapshot d;
+	ASSERT_TRUE(s.FindDownload(kHash, d));
+	ASSERT_EQUALS(static_cast<std::uint32_t>(11), d.ecid);
+	ASSERT_EQUALS(std::string("movie.part"), d.name);
+
+	FileSnapshot sh;
+	ASSERT_TRUE(s.FindShared(kHash, sh));
+	ASSERT_EQUALS(static_cast<std::uint32_t>(22), sh.ecid);
+	ASSERT_EQUALS(std::string("movie.mkv"), sh.name);
+}
+
+// Same pair, inserted the other way round. The bug was order-dependent, so a
+// test that only covers one order passes at 50%.
+TEST(State, ASharedFirstHashStillResolvesTheDownload)
+{
+	const std::string kHash = "beef0000beef0000beef0000beef0000";
+	CState s;
+	s.MutateDownloads([&](FileMap &cache) {
+		FileSnapshot sh;
+		sh.ecid = 22;
+		sh.hash = kHash;
+		sh.is_shared = true;
+		cache.emplace(sh.ecid, sh);
+
+		FileSnapshot dl;
+		dl.ecid = 11;
+		dl.hash = kHash;
+		dl.is_downloading = true;
+		cache.emplace(dl.ecid, dl);
+	});
+
+	FileSnapshot d;
+	ASSERT_TRUE(s.FindDownload(kHash, d));
+	ASSERT_EQUALS(static_cast<std::uint32_t>(11), d.ecid);
+
+	FileSnapshot sh;
+	ASSERT_TRUE(s.FindShared(kHash, sh));
+	ASSERT_EQUALS(static_cast<std::uint32_t>(22), sh.ecid);
+}
+
+// Erasing one role must not take the other's lookup down with it. This is the
+// half users hit as "deleting the shared file did not help": erasing the
+// shared entry cleared the one index row, so the download stopped resolving
+// too.
+TEST(State, ErasingTheShareLeavesTheDownloadResolvable)
+{
+	const std::string kHash = "feed9999feed9999feed9999feed9999";
+	CState s;
+	s.MutateDownloads([&](FileMap &cache) {
+		FileSnapshot dl;
+		dl.ecid = 11;
+		dl.hash = kHash;
+		dl.is_downloading = true;
+		cache.emplace(dl.ecid, dl);
+
+		FileSnapshot sh;
+		sh.ecid = 22;
+		sh.hash = kHash;
+		sh.is_shared = true;
+		cache.emplace(sh.ecid, sh);
+	});
+	s.MutateDownloads([&](FileMap &cache) {
+		const auto it = cache.find(22);
+		ASSERT_TRUE(it != cache.end());
+		cache.erase(it);
+	});
+
+	FileSnapshot d;
+	ASSERT_TRUE(s.FindDownload(kHash, d));
+	ASSERT_EQUALS(static_cast<std::uint32_t>(11), d.ecid);
+
+	FileSnapshot gone;
+	ASSERT_FALSE(s.FindShared(kHash, gone));
+}
+
+// The share slot changes owner. aMule keeps same-hash variants on
+// CKnownFileList::m_duplicateFileList, and Append() promotes one of them to
+// the live record (m_knownFileMap[hash] = Record) when the previous owner is
+// displaced or its file disappears -- so the ECID behind a hash's share is not
+// stable even though the hash is. Both orderings, because a tick can deliver
+// the arrival and the departure either way round.
+TEST(State, ShareHandoverToANewEcidKeepsTheHashResolvable)
+{
+	const std::string kHash = "0a0a11110a0a11110a0a11110a0a1111";
+	CState s;
+	s.MutateDownloads([&](FileMap &cache) {
+		FileSnapshot b;
+		b.ecid = 22;
+		b.hash = kHash;
+		b.name = "old-copy.mkv";
+		b.is_shared = true;
+		cache.emplace(b.ecid, b);
+	});
+	// Departure first, then the replacement.
+	s.MutateDownloads([&](FileMap &cache) {
+		cache.erase(cache.find(22));
+		FileSnapshot c;
+		c.ecid = 33;
+		c.hash = kHash;
+		c.name = "new-copy.mkv";
+		c.is_shared = true;
+		cache.emplace(c.ecid, c);
+	});
+
+	FileSnapshot sh;
+	ASSERT_TRUE(s.FindShared(kHash, sh));
+	ASSERT_EQUALS(static_cast<std::uint32_t>(33), sh.ecid);
+	ASSERT_EQUALS(std::string("new-copy.mkv"), sh.name);
+}
+
+TEST(State, ShareHandoverSurvivesTheReplacementArrivingFirst)
+{
+	const std::string kHash = "0b0b22220b0b22220b0b22220b0b2222";
+	CState s;
+	s.MutateDownloads([&](FileMap &cache) {
+		FileSnapshot b;
+		b.ecid = 22;
+		b.hash = kHash;
+		b.is_shared = true;
+		cache.emplace(b.ecid, b);
+	});
+	// Replacement lands before the old entry is dropped. The stale erase
+	// must not take the new owner's row with it.
+	s.MutateDownloads([&](FileMap &cache) {
+		FileSnapshot c;
+		c.ecid = 33;
+		c.hash = kHash;
+		c.is_shared = true;
+		cache.emplace(c.ecid, c);
+		cache.erase(cache.find(22));
+	});
+
+	FileSnapshot sh;
+	ASSERT_TRUE(s.FindShared(kHash, sh));
+	ASSERT_EQUALS(static_cast<std::uint32_t>(33), sh.ecid);
+}
+
+// The refresher clears a role rather than erasing the entry when a file stops
+// being shared but is still known. The index has to follow that too, and must
+// not take the other role down with it.
+TEST(State, ClearingOneRoleLeavesTheOtherResolvable)
+{
+	const std::string kHash = "0c0c33330c0c33330c0c33330c0c3333";
+	CState s;
+	s.MutateDownloads([&](FileMap &cache) {
+		// A part file is itself shared while it downloads, so one entry
+		// legitimately carries both roles and holds a row in each index.
+		FileSnapshot f;
+		f.ecid = 44;
+		f.hash = kHash;
+		f.is_downloading = true;
+		f.is_shared = true;
+		cache.emplace(f.ecid, f);
+	});
+	FileSnapshot both;
+	ASSERT_TRUE(s.FindDownload(kHash, both));
+	ASSERT_TRUE(s.FindShared(kHash, both));
+
+	s.MutateDownloads([&](FileMap &cache) { cache.SetShared(cache.find(44), false); });
+
+	FileSnapshot d;
+	ASSERT_TRUE(s.FindDownload(kHash, d));
+	ASSERT_EQUALS(static_cast<std::uint32_t>(44), d.ecid);
+	FileSnapshot gone;
+	ASSERT_FALSE(s.FindShared(kHash, gone));
+	// Asserted against the index itself, not only through FindShared(): the
+	// resolvers re-check the role after resolving, so a stale row degrades to
+	// "not found" and a test that only went through them would pass with the
+	// row still there. This is the one that actually watches the index.
+	s.WithFiles([&](const FileMap &files) {
+		std::uint32_t ecid = 0;
+		ASSERT_FALSE(files.FindSharedEcidByHash(kHash, ecid));
+		ASSERT_TRUE(files.FindDownloadEcidByHash(kHash, ecid));
+		ASSERT_EQUALS(static_cast<std::uint32_t>(44), ecid);
+	});
+}
+
+// A hash can arrive after the insert: a partfile frame with HASH suppressed
+// files the entry with an empty hash, and a later knownfile frame carries it.
+// SetHash() exists so that late arrival still reaches the index -- assigning
+// the field through the iterator would leave the entry unreachable by hash.
+TEST(State, AHashLearnedAfterTheInsertStillResolves)
+{
+	const std::string kHash = "0d0d44440d0d44440d0d44440d0d4444";
+	CState s;
+	s.MutateDownloads([&](FileMap &cache) {
+		FileSnapshot f;
+		f.ecid = 55;
+		f.is_downloading = true; // no hash yet
+		cache.emplace(f.ecid, f);
+	});
+	FileSnapshot before;
+	ASSERT_FALSE(s.FindDownload(kHash, before));
+
+	s.MutateDownloads([&](FileMap &cache) { cache.SetHash(cache.find(55), kHash); });
+
+	FileSnapshot after;
+	ASSERT_TRUE(s.FindDownload(kHash, after));
+	ASSERT_EQUALS(static_cast<std::uint32_t>(55), after.ecid);
 }
 
 TEST(State, MutateDownloadsDecodedRleFieldsRoundtrip)


### PR DESCRIPTION
Closes #1161. Closes #1157.

A hash does not name one file. A part file and the completed copy someone drops into a shared folder are two amuled objects with two ECIDs and the same content, and both reach amuleapi. aMule keeps them straight by having a list per role; amuleapi merges the roles into one map and indexed as if the hash were unique, so whichever entry was filed last won the single slot and the other became unreachable while still sitting in the map and being refreshed.

That is what #1157 reported: after the completed copy was shared, the download kept updating its percentage and state in the list, while details and cancel answered `no download with that hash`. amuleGUI and amulecmd were unaffected because they address a download by ECID, which is the observation that localised it.

## How the two entries arise

Traced end to end, since the issue text originally guessed at this:

* `CKnownFileList::Append()` hits its same-hash-different-name branch when the completed copy is hashed. It installs the new record as the live one (`m_knownFileMap[hash] = Record`) and pushes the previous owner - here the `CPartFile` - onto `m_duplicateFileList`. The part file stays in the download queue with its own ECID.
* `CSharedFileList::SafeAddKFile()` sees `AddFile()` refuse the hash, detects the stale pointer and swaps: `RemoveFile(stale)` then `AddFile(toadd)`. Both bump `m_listGeneration`.
* The EC reconcile is gated on those generations, so it runs, stamps surviving encoders with a fresh epoch and sweeps the rest. amuleapi is told the part file left the shared list and a new ECID joined it.
* The refresher therefore clears `is_shared` on one entry and inserts another carrying the same hash. One index cannot hold both.

This also covers the fallback case: aMule keeps same-hash variants on `m_duplicateFileList` (capped at 8, pinned when matched to a real on-disk file), and promotes one back to the live record when the current owner goes away. The ECID behind a hash's share is therefore not stable, even though the hash is.

## The fix

`FileMap` keeps one index per role. `emplace()`, `erase()`, and the new `SetHash()` / `SetDownloading()` / `SetShared()` all re-file through a single `Reindex()`, and a row is only cleared when it still names the entry being changed - so a handover between two ECIDs under one hash cannot strand either. `FindDownload()`, `FindShared()` and `DownloadPartCount()` resolve by role instead of resolving to whatever the hash pointed at and then testing the role.

The six refresher sites that used to assign `hash` / `is_downloading` / `is_shared` through the map iterator now go through the setters. Not a style preference: the old `FileMap` documented "Set hash before emplace, never after" and one walker did it anyway, which was a second route to an entry with no index row.

## Tests

Three cases reproduce #1157 at the `FileMap` level and fail on master:

| test | on master |
| --- | --- |
| `AHashSharedByADownloadAndAShareResolvesToBoth` | `FindDownload` fails - the reported bug |
| `ASharedFirstHashStillResolvesTheDownload` | `FindShared` fails - the mirror case, unreported |
| `ErasingTheShareLeavesTheDownloadResolvable` | `FindDownload` fails - why deleting the share did not help |

Four more cover the fallback: the share slot changing owner with the departure delivered first and with the arrival delivered first, a role cleared rather than erased, and a hash learned after the insert.

Mutation-checked: collapsing the two indexes back into one reddens 5 tests, dropping the row-ownership guard reddens 4, and removing `SetHash()`'s reindex reddens 1. One test - the departure-first handover - stays green under every mutation, because that ordering is correct either way; it is kept as documentation of the sequence rather than as a guard.

Verified on macOS: 43 of 43 cctest binaries pass (59 `StateTest` cases), clang-format clean, both clang-tidy tiers report nothing.
