### PR TITLE
fix(amuleapi): category 0 labels, a4af set-not-toggle, limit echo, quad-only IPs

### DIFF
--- a/docs/api/REFERENCE.md
+++ b/docs/api/REFERENCE.md
@@ -9,7 +9,7 @@ The API is versioned in the path. Breaking changes ship under `/api/v1/`; `/api/
 **Cross-cutting concerns**
 - [Base URL and transport](#base-url-and-transport)
 - [Authentication](#authentication) — [Login response shape](#login-response-shape), [Role model](#role-model), [Rate limiting](#rate-limiting), [JWT structure](#jwt-structure)
-- [Response model](#response-model) — [Success envelope](#success-envelope), [Mutation responses](#mutation-responses), [List pagination and sorting](#list-pagination-and-sorting), [Bulk mutations and the `results` envelope](#bulk-mutations-and-the-results-envelope), [Error envelope](#error-envelope), [ETag and conditional GET](#etag-and-conditional-get), [CORS](#cors), [Path validation](#path-validation), [Request size limits](#request-size-limits)
+- [Response model](#response-model) — [Success envelope](#success-envelope), [Mutation responses](#mutation-responses), [Idempotency](#idempotency), [IP addresses](#ip-addresses), [List pagination and sorting](#list-pagination-and-sorting), [Bulk mutations and the `results` envelope](#bulk-mutations-and-the-results-envelope), [Error envelope](#error-envelope), [ETag and conditional GET](#etag-and-conditional-get), [CORS](#cors), [Path validation](#path-validation), [Request size limits](#request-size-limits)
 - [Error code catalog](#error-code-catalog)
 - [Backward compatibility](#backward-compatibility)
 
@@ -223,7 +223,23 @@ Three bodies are deliberate exceptions, because each reports something no later 
 
 - the per-item [`results` envelope](#bulk-mutations-and-the-results-envelope), which carries a real outcome per input item;
 - `message` on the connection-control routes, which is the daemon's own explanation of what it did with the request;
-- `ip` / `port` on [`POST /kad/bootstrap`](#post-apiv0kadbootstrap), which reports **which** address the daemon parsed out of the two accepted input forms.
+- `ip` / `port` on [`POST /kad/bootstrap`](#post-apiv0kadbootstrap), which reports **which** address the daemon parsed.
+
+### Idempotency
+
+**Every endpoint is idempotent: sending the same request twice leaves the daemon in the state one request would have left it in.** A client library, a proxy or a browser can repeat a request without the caller knowing, so a surface that toggles rather than sets turns an invisible retry into a silent, wrong state change.
+
+In practice that means a mutation names the value it wants rather than the change it wants. `PATCH /downloads/{hash}` with `{"a4af_auto": true}` reaches `true` from either starting point and stays there however many times it arrives; there is deliberately no "flip it" spelling. Where the daemon's own operation was a flip, amuleapi does not paper over it by reading the current value and deciding -- the value goes down to the core, which stores it.
+
+Two things are idempotent without looking it: a `DELETE` of something already gone is a `404` rather than a second delete, and `POST /downloads` with a link already queued is refused per-item in the [`results` envelope](#bulk-mutations-and-the-results-envelope). Both report that the request had no effect, which is the point; neither does the work twice.
+
+The exceptions are the endpoints whose whole purpose is to do something again: `POST /shared_reload`, `POST /shared/{hash}/verify`, the `*/update` fetches, and `POST /search/{id}/more`. Asking twice asks for the work twice, which is what the caller meant.
+
+### IP addresses
+
+**Every IP address on this surface, in either direction, is a dotted-quad string.** `"203.0.113.5"`, never `3405803781`, and never a byte-order the caller has to know about. That covers request bodies, query parameters and response fields alike.
+
+The conversion to and from the host-order integers EC carries happens inside amuleapi. `POST /kad/bootstrap` used to accept a `uint32` alongside the quad, and the two disagreed: the quad parser packed `a.b.c.d` least-significant byte first while the integer was taken verbatim, so `2130706433` (`0x7F000001`, which is what a client computing an IPv4 integer the conventional way writes for `127.0.0.1`) reached the daemon as `1.0.0.127`. Only the quad is accepted now, and the question does not arise.
 
 ### Query parameter validation
 
@@ -254,7 +270,7 @@ Sorting is applied to the full filtered set **before** slicing, so pagination is
 
 - `total` — item count after any endpoint-specific filter (e.g. `/clients?filter=`), before slicing.
 - `offset` — the offset applied.
-- `limit` — the effective page size (equals the number of items returned when `limit` was omitted).
+- `limit` — the page size the request asked for, or `null` when it asked for none. It is not the row count: that is `total`. It reported the row count once, which no caller could reuse as a page size, since re-sending it is a `400` as soon as the list is longer than the `500` cap.
 
 Omitting all four parameters preserves the previous response exactly, plus the additive `total` / `offset` / `limit` keys.
 
@@ -962,10 +978,11 @@ Force A4AF source-swapping for this download. Downloads-only.
 | action | Effect |
 |---|---|
 | `swap_this` | Make other files' A4AF sources take over **this** file. |
-| `swap_this_auto` | Toggle automatic A4AF swapping for this file. |
 | `swap_others` | Release this file's sources to the other files that want them. |
 
-`client_ecid` is optional and valid **only with `swap_this`**, where it narrows the action from every A4AF source of this file to the single named one — the per-peer "Swap to this file" of the desktop client. It must name a client in the current snapshot that is an A4AF source of *this* download; pairing it with `swap_this_auto` or `swap_others` is a `400`, because the core has no per-source form of those.
+Both move sources one way. A third action, `swap_this_auto`, flipped the `a4af_auto` flag and is gone: a flip cannot be retried safely, and it set a field the download object already reports. Set it with [`PATCH /downloads/{hash}`](#patch-apiv0downloadshash) and `{"a4af_auto": true|false}` instead. Sending `swap_this_auto` here is a `400` naming the replacement.
+
+`client_ecid` is optional and valid **only with `swap_this`**, where it narrows the action from every A4AF source of this file to the single named one — the per-peer "Swap to this file" of the desktop client. It must name a client in the current snapshot that is an A4AF source of *this* download; pairing it with `swap_others` is a `400`, because the core has no per-source form of it.
 
 The swap moves the peer between two files' source lists, so an SSE subscriber sees `download_updated` for **both** the peer's former download and this one, plus `client_updated` for the peer itself.
 
@@ -977,7 +994,7 @@ The swap moves the peer between two files' source lists, so an SSE subscriber se
 
 `source_ecids` are the ECIDs of the peers holding this file as an A4AF source, joinable against [`GET /api/v0/clients`](#get-apiv0clients). The array is the post-action state, so a `swap_this` naming a single peer shows up as that ECID having left it. The same peers appear as rows with `"a4af": true` on [`GET /api/v0/downloads/{hash}/clients`](#get-apiv0downloadshashclients--get-apiv0sharedhashclients), which carries the whole peer object rather than a bare ECID.
 
-**Errors:** `400 bad_request` (missing or unknown `action`; a non-integer `client_ecid`; `client_ecid` with the wrong action), `400 amuled_rejected` (the daemon refused the swap — most commonly because the peer is actively sending data, which it will not be swapped away from), `404 not_found` (no download with that hash, or no client with that ECID), `409 conflict` (that client is not an A4AF source of this download), `503 ec_unavailable`.
+**Errors:** `400 bad_request` (missing or unknown `action`; `swap_this_auto`, which moved to `PATCH`; a non-integer `client_ecid`; `client_ecid` with the wrong action), `400 amuled_rejected` (the daemon refused the swap — most commonly because the peer is actively sending data, which it will not be swapped away from), `404 not_found` (no download with that hash, or no client with that ECID), `409 conflict` (that client is not an A4AF source of this download), `503 ec_unavailable`.
 
 #### `POST /api/v0/downloads`
 
@@ -1056,6 +1073,7 @@ Mutates one or more fields of a single partfile. `{hash}` is the 32-char MD4 hex
 - `status` — `"paused"`, `"resumed"` or `"stopped"`. `"paused"` halts transfer but keeps the file's sources; `"stopped"` additionally drops all known sources and resets the Kad source search (a stopped file must rediscover sources from scratch on resume); `"resumed"` clears either state. A stopped file reports `status: "stopped"` in the download object (see [`GET /downloads`](#get-apiv0downloads)).
 - `priority` — `"low"` / `"normal"` / `"high"` / `"auto"`. Downloads support only these levels and any other value is a `400`; the reason is that the daemon's `.part.met` loader would clamp it back to `normal` on the next restart. (Shared files support the wider `very_low` … `release` set — see [`PATCH /shared/{hash}`](#patch-apiv0sharedhash) and [Priority levels](#priority-levels).)
 - `category` — uint8
+- `a4af_auto` — bool. Turns automatic A4AF source-swapping on or off for this file. A named value, not a flip: sending `true` twice leaves it `true`. This is the only way to set the flag; the `swap_this_auto` action on [`POST /downloads/{hash}/a4af`](#post-apiv0downloadshasha4af) that used to toggle it is gone, because a toggle cannot survive a retry (see [Idempotency](#idempotency)).
 - `comment` + `rating` — set the file's comment (string, ≤ 50 chars) and rating (integer `0`–`5`). Must be sent **together**; only settable when the partfile is also shared (≥ 1 complete chunk), else `409 not_shared`. Primarily a shared-file action — see [`PATCH /shared/{hash}`](#patch-apiv0sharedhash).
 - `name` — rename the file (string). Must be non-empty and contain no path separators (`/` or `\`). See the [Takeover flow](#get-apiv0downloadshashfilenames).
 
@@ -2010,13 +2028,15 @@ amuled's category system lets users tag downloads with one of N user-defined buc
 
 A list endpoint like the others: `?limit`, `?offset`, `?sort` and `?order` apply, and the `total` / `offset` / `limit` trio describes the window. See [List pagination and sorting](#list-pagination-and-sorting); the sort keys are `index` and `name`.
 
-Category `0` is always present, so the list is never empty. The sample above is what a daemon that reports it looks like, which is the ordinary case. When amuled omits the row, amuleapi synthesises a placeholder rather than inventing values it was not told:
+Category `0` is always present, so the list is never empty. amuled's EC omits the row entirely until the first custom category exists, so amuleapi synthesises it when missing:
 
 ```json
-{ "index": 0, "name": "", "path": "", "comment": "", "color": 0, "priority": "low" }
+{ "index": 0, "name": "Default", "path": "/home/user/aMule/Incoming", "comment": "", "color": 0, "priority": "low" }
 ```
 
-`name` and `path` are empty because the daemon did not supply them, and `priority` is `low` because that is amuled's own default for the row. A client rendering a category picker should treat an empty `name` on index `0` as "the category a download with no category belongs to" and label it itself -- the API does not put a display string there that the daemon never sent.
+`name` and `path` are filled in for index `0` whether the row came from the daemon or was synthesised here. amuled holds neither -- its `defaultcat` is built with an empty title and path -- so a client rendering a category picker was left with a blank row it had to label itself, and nothing to show for where an uncategorised download lands. `path` is `directories.incoming` from [`GET /preferences`](#get-apiv0preferences), which is genuinely where such a file is saved. `priority` is `low`, amuled's own default for the row.
+
+Filling both in unconditionally is deliberate: doing it only for the synthesised row would mean `/categories/0` answered `"Default"` on a daemon with no custom categories and `""` as soon as the operator added one, which is a response shape that depends on unrelated state.
 
 **Errors:** `400 bad_request` (bad list params), `503 ec_unavailable`.
 
@@ -2048,7 +2068,7 @@ Category `0` is always present, so the list is never empty. The sample above is 
 
 Returns the single category object, the same shape [`PATCH`](#patch-apiv0categoriesindex) returns. Every other resource with a member path has a member `GET`; this one did not, so a client that had just created a category and wanted the stored result had to re-fetch the whole collection and search it by index.
 
-`{index}` is a uint8. A non-numeric or out-of-range segment is `400 bad_request`; an index no category holds is `404 not_found`. Index `0` is always present, synthesised when amuled omits it, exactly as on the collection: the two routes cannot disagree about which categories exist.
+`{index}` is a uint8. A non-numeric or out-of-range segment is `400 bad_request`; an index no category holds is `404 not_found`. Index `0` is always present, synthesised when amuled omits it and carrying the same `name` / `path` fill-in, exactly as on the collection: the two routes cannot disagree about which categories exist or about what they hold.
 
 **Errors:** `400 bad_request`, `404 not_found`, `503 ec_unavailable`.
 
@@ -2263,7 +2283,7 @@ These endpoints drive amuled's connect/disconnect to the ed2k network, the Kad n
 
 Manual Kad bootstrap against a single known-good Kad node. Fires `EC_OP_KAD_BOOTSTRAP_FROM_IP` against amuled. This is the only Kad bootstrap surface the EC protocol exposes — `nodes.dat` is read by amuled at startup from its own data directory and is NOT manageable via REST.
 
-**Body:** `{ "ip": "203.0.113.5" | <uint32 host-order>, "port": <uint16> }`. `ip` accepts either the dotted-quad string form or the uint32 host-order integer form (amuled's wire-level shape). `port` is the contact's UDP port.
+**Body:** `{ "ip": "203.0.113.5", "port": <uint16> }`. `ip` is a dotted-quad string, per the [IP addresses](#ip-addresses) rule; the conversion to the integer EC carries happens inside amuleapi. `port` is the contact's UDP port. A `uint32` was accepted here too and is now a `400`: the two spellings disagreed about byte order, so the same address reached the daemon differently depending on how it was written.
 
 ```sh
 curl -s -X POST -H "Authorization: Bearer $TOKEN" \

--- a/src/ExternalConn.cpp
+++ b/src/ExternalConn.cpp
@@ -2306,6 +2306,22 @@ static CECPacket *Get_EC_Response_PartFile_Cmd(const CECPacket *request)
 		case EC_OP_PARTFILE_SWAP_A4AF_THIS_AUTO:
 			CoreNotify_PartFile_Swap_A4AF_Auto(pfile);
 			break;
+		case EC_OP_PARTFILE_SET_A4AF_AUTO:
+			// Set, rather than flip. The op above cannot express "make it
+			// true": a caller that cannot see the current value cannot ask
+			// for a particular one, and a repeated request undoes itself.
+			// That is fine for the GUI menu item driving it, and wrong for
+			// an HTTP API, where a library or a browser may retry without
+			// the caller knowing.
+			//
+			// SetA4AFAuto() only marks the file EC-changed when the value
+			// actually moves, so re-sending the value it already holds
+			// costs nothing and pushes no update.
+			//
+			// Value rides as a child of EC_TAG_PARTFILE, the same shape
+			// EC_OP_PARTFILE_SET_CAT and _PRIO_SET use.
+			pfile->SetA4AFAuto(hashtag.GetFirstTagSafe()->GetInt() != 0);
+			break;
 		case EC_OP_PARTFILE_SWAP_A4AF_OTHERS:
 			CoreNotify_PartFile_Swap_A4AF_Others(pfile);
 			break;
@@ -3784,6 +3800,7 @@ CECPacket *CECServerSocket::ProcessRequest2(const CECPacket *request)
 		break;
 	case EC_OP_PARTFILE_SWAP_A4AF_THIS:
 	case EC_OP_PARTFILE_SWAP_A4AF_THIS_AUTO:
+	case EC_OP_PARTFILE_SET_A4AF_AUTO:
 	case EC_OP_PARTFILE_SWAP_A4AF_OTHERS:
 	case EC_OP_PARTFILE_PAUSE:
 	case EC_OP_PARTFILE_RESUME:

--- a/src/libs/ec/abstracts/ECCodes.abstract
+++ b/src/libs/ec/abstracts/ECCodes.abstract
@@ -192,6 +192,21 @@ EC_OP_CHAT_CLOSE_SESSION            0x66
 ## op is user-triggered once, not polled, so an old core sees a single
 ## rejected request rather than a repeating one.
 EC_OP_REFRESH_MEDIA_METADATA        0x67
+
+## Set a partfile's A4AF-auto flag to a given value, rather than flipping it.
+## Addressed like every other PARTFILE command (EC_TAG_PARTFILE with the hash)
+## and carries EC_TAG_PARTFILE_A4AFAUTO with the value to store.
+##
+## EC_OP_PARTFILE_SWAP_A4AF_THIS_AUTO maps to SetA4AFAuto(!IsA4AFAuto()), so a
+## caller that cannot see the current value cannot ask for a particular one,
+## and any retried request flips it back. That is fine for a GUI menu item
+## driven by a checkbox the user is looking at, which is why the flip op stays
+## for amulegui, and wrong for an HTTP API, where a library or a browser may
+## repeat a request without the caller knowing.
+##
+## Additive: the flip op is unchanged, so an older client is unaffected, and a
+## core that does not know this one answers EC_OP_FAILED.
+EC_OP_PARTFILE_SET_A4AF_AUTO        0x68
 [/Section]
 
 [Section Content]

--- a/src/webapi/Api.cpp
+++ b/src/webapi/Api.cpp
@@ -3509,17 +3509,26 @@ std::unique_ptr<CHttpServer::Response> BuildListWindow(const std::vector<T> &ite
 	return BuildListWindowFromPtrs(ptrs, params, comparators, out_window, out_total);
 }
 
-// Emit the `total` / `offset` / `limit` pagination metadata. `limit`
-// echoes the effective page size (the actual number returned when the
-// caller omitted `limit`).
-void WritePageMeta(CJsonWriter &w, std::size_t total, const ListParams &params, std::size_t returned)
+// Emit the `total` / `offset` / `limit` pagination metadata. `limit` echoes
+// the page size the caller asked for, and is null when they asked for none.
+//
+// It used to report the row count instead, which is not a page size and could
+// not be used as one: a caller that stored it pinned its window to whatever
+// the first response happened to hold, and re-sending it is a 400 as soon as
+// the list is longer than the 500 cap -- the envelope handing back a value the
+// endpoint then rejects. null says what is true, that no window was applied;
+// `total` is where the row count already lives.
+void WritePageMeta(CJsonWriter &w, std::size_t total, const ListParams &params)
 {
 	w.Key("total");
 	w.ValueUInt(total);
 	w.Key("offset");
 	w.ValueUInt(params.offset);
 	w.Key("limit");
-	w.ValueUInt(params.has_limit ? params.limit : returned);
+	if (params.has_limit)
+		w.ValueUInt(params.limit);
+	else
+		w.ValueNull();
 }
 
 // Extract the raw query string from a request target ("/x?a=1" -> "a=1").
@@ -3562,7 +3571,7 @@ CHttpServer::Response ListResponseFromPtrsUnlocked(const char *plural_key,
 	for (const T *item : window)
 		write_item(w, *item);
 	w.EndArray();
-	WritePageMeta(w, total, params, window.size());
+	WritePageMeta(w, total, params);
 	w.EndObject();
 	FinalizeJsonBody(w, r);
 	return r;
@@ -3597,7 +3606,7 @@ CHttpServer::Response ListResponse(const webapi::CState &state,
 	for (const T *item : window)
 		write_item(w, *item);
 	w.EndArray();
-	WritePageMeta(w, total, params, window.size());
+	WritePageMeta(w, total, params);
 	w.EndObject();
 	FinalizeJsonBody(w, r);
 	return r;
@@ -4525,13 +4534,20 @@ CHttpServer::Response CApiDispatcher::HandleDownloadA4afAction(
 	ec_opcode_t op;
 	if (action == "swap_this")
 		op = EC_OP_PARTFILE_SWAP_A4AF_THIS;
-	else if (action == "swap_this_auto")
-		op = EC_OP_PARTFILE_SWAP_A4AF_THIS_AUTO;
 	else if (action == "swap_others")
 		op = EC_OP_PARTFILE_SWAP_A4AF_OTHERS;
-	else {
-		return ErrorResponse(
-			400, "bad_request", "`action` must be one of swap_this, swap_this_auto, swap_others");
+	else if (action == "swap_this_auto") {
+		// Was a third action here, and it was the odd one out: the other two
+		// move sources, while this flipped a flag the download object
+		// reports. A flip cannot be retried safely, so it is now
+		// `PATCH /downloads/{hash} {"a4af_auto": <bool>}` -- named value in,
+		// same value out, no matter how many times it arrives.
+		return ErrorResponse(400,
+			"bad_request",
+			"`swap_this_auto` is not accepted; set the flag with PATCH "
+			"/downloads/{hash} `{\"a4af_auto\": true|false}`");
+	} else {
+		return ErrorResponse(400, "bad_request", "`action` must be one of swap_this, swap_others");
 	}
 
 	// `client_ecid` narrows swap_this from "every A4AF source of this file" to
@@ -5167,6 +5183,36 @@ CHttpServer::Response CApiDispatcher::HandleDownloadPatch(
 		}
 	}
 
+	// a4af_auto: boolean
+	//
+	// A set, not a toggle. EC_OP_PARTFILE_SWAP_A4AF_THIS_AUTO flips the flag,
+	// which is what the desktop menu item wants and what an HTTP API must not
+	// expose: a client library or a browser can retry a request without the
+	// caller knowing, and a retried flip lands on the opposite value. Reaching
+	// a named value takes EC_OP_PARTFILE_SET_A4AF_AUTO, which carries the
+	// value; the core stores it and marks the file changed only if it moved,
+	// so re-sending the same body is a no-op rather than an undo.
+	//
+	// A PATCH field rather than another `action` on POST /downloads/{hash}
+	// /a4af: this sets a field the download object already reports, and the
+	// two remaining actions there (swap_this, swap_others) move sources one
+	// way, which is a different kind of operation.
+	{
+		const auto it = obj.find("a4af_auto");
+		if (it != obj.end()) {
+			if (!it->second.is<bool>()) {
+				return ErrorResponse(400, "bad_request", "`a4af_auto` must be a boolean");
+			}
+			auto err = send_op(EC_OP_PARTFILE_SET_A4AF_AUTO,
+				/*has_inner=*/true,
+				EC_TAG_PARTFILE_A4AFAUTO,
+				static_cast<std::uint8_t>(it->second.get<bool>() ? 1 : 0));
+			if (err.status >= 400)
+				return err;
+			any_change = true;
+		}
+	}
+
 	// comment + rating (both required together; issue #419). Only
 	// settable on a file that is shared (a downloading partfile with
 	// ≥1 complete chunk); otherwise TrySetCommentRating returns 409.
@@ -5641,10 +5687,22 @@ bool FindClientByEcid(const webapi::CState &state, std::uint32_t ecid, webapi::C
 // custom categories exist, and starts including index 0 once the first custom
 // one is added. Faithful at the wire layer, but a client iterating /categories
 // expecting at least the default has to special-case the empty case, so a
-// synthetic index-0 entry is injected when missing. The defaults mirror what
-// amuled emits for category 0 itself: empty title/path/comment, color 0,
-// priority_code PR_LOW (the amuled default for `defaultcat->prio` in
-// CPreferences::LoadCats).
+// synthetic index-0 entry is injected when missing. `priority_code` PR_LOW is
+// the amuled default for `defaultcat->prio` in CPreferences::LoadCats.
+//
+// Category 0 is also given a name and a path, whether it arrived from the
+// daemon or was synthesised here. amuled holds neither -- `defaultcat` is
+// constructed with an empty title and path -- so a client rendering a category
+// picker got a blank row it had to label itself, and had nowhere to show where
+// an uncategorised download lands. Neither value is invented: "Default" names
+// the row every client already has to describe somehow, and the path is
+// `directories.incoming`, which is genuinely where a file with no category is
+// saved.
+//
+// Filling both in unconditionally is the point. Doing it only for the
+// synthetic row would mean /categories/0 answered "Default" on a daemon with
+// no custom categories and "" as soon as the operator added one, which is a
+// response shape that depends on unrelated state.
 //
 // Both read routes go through here. The collection did this inline and the
 // member route added later read the raw snapshot instead, so /categories
@@ -5655,8 +5713,13 @@ bool FindClientByEcid(const webapi::CState &state, std::uint32_t ecid, webapi::C
 std::vector<webapi::CategorySnapshot> CategoriesWithDefault(const webapi::CState &state)
 {
 	std::vector<webapi::CategorySnapshot> cats = state.Categories();
-	for (const auto &c : cats) {
+	const auto fill_default = [&state](webapi::CategorySnapshot &c) {
+		c.name = "Default";
+		c.path = state.Preferences().directories.incoming;
+	};
+	for (auto &c : cats) {
 		if (c.index == 0) {
+			fill_default(c);
 			return cats;
 		}
 	}
@@ -5664,6 +5727,7 @@ std::vector<webapi::CategorySnapshot> CategoriesWithDefault(const webapi::CState
 	d.index = 0;
 	d.priority_code = 0; // PR_LOW (matches amuled default)
 	d.priority = "low";
+	fill_default(d);
 	cats.insert(cats.begin(), std::move(d));
 	return cats;
 }
@@ -6959,10 +7023,9 @@ CHttpServer::Response CApiDispatcher::HandleCategories(const CHttpServer::Reques
 	// wire layer, but a client iterating /categories expecting at
 	// least the default has to special-case the empty case. Inject
 	// a synthetic index-0 entry when missing so clients see the same
-	// shape regardless of category count. The defaults mirror what
-	// amuled emits for category 0 itself: empty title/path/comment,
-	// color 0, priority_code PR_LOW (the amuled default for
-	// `defaultcat->prio` in CPreferences::LoadCats).
+	// shape regardless of category count, and gives category 0 the
+	// name and path amuled does not hold for it -- see
+	// CategoriesWithDefault.
 	std::vector<webapi::CategorySnapshot> cats = CategoriesWithDefault(m_state);
 	ListParams params;
 	if (auto r = ParseListParams(QueryOf(req), params))
@@ -7599,7 +7662,7 @@ CHttpServer::Response CApiDispatcher::HandleSearchResults(
 	for (const webapi::SearchResult *item : window)
 		WriteSearchObject(w, *item);
 	w.EndArray();
-	WritePageMeta(w, total, params, window.size());
+	WritePageMeta(w, total, params);
 	// The search these results belong to. Echoed even though the caller put
 	// it in the path: clients key their tabs on it and it costs nothing.
 	w.Key("search_id");
@@ -8774,32 +8837,31 @@ CHttpServer::Response CApiDispatcher::HandleKadBootstrap(const CHttpServer::Requ
 	}
 	const auto &obj = root.get<picojson::object>();
 
-	// Body: {"ip": "1.2.3.4" | <uint32 host-order>, "port": <uint16>}.
-	// Accept the IP either as a dotted-quad string (friendly) OR as
-	// a uint32 (matches the EC tag's wire shape directly).
+	// Body: {"ip": "1.2.3.4", "port": <uint16>}. A dotted quad, and only that.
+	//
+	// This also took a host-order uint32, matching the EC tag's wire shape,
+	// and the two forms disagreed about byte order: ParseIpv4Dotted() packs
+	// a.b.c.d least-significant byte first (matching Uint32toStringIP), while
+	// the integer branch took the JSON value verbatim -- so 2130706433
+	// (0x7F000001, what a client computing an IPv4 integer the conventional
+	// big-endian way writes for 127.0.0.1) bootstrapped 1.0.0.127. Rather
+	// than pick a byte order for a spelling no other field on this surface
+	// uses, the spelling is gone: every IP the API reads or writes is a quad,
+	// and the conversion to the integer EC wants happens here.
 	std::uint32_t ip_he = 0;
 	{
 		const auto it = obj.find("ip");
 		if (it == obj.end()) {
 			return ErrorResponse(400, "bad_request", "required field `ip` is missing");
 		}
-		if (it->second.is<std::string>()) {
-			// Dotted-quad string. Parse with strtoul on each octet.
-			const std::string &s = it->second.get<std::string>();
-			if (!ParseIpv4Dotted(s, ip_he)) {
-				return ErrorResponse(400,
-					"bad_request",
-					"`ip` must be a dotted-quad IPv4 address or a "
-					"host-order uint32");
-			}
-		} else if (it->second.is<double>()) {
-			const double v = it->second.get<double>();
-			if (v < 0 || v > 4294967295.0) {
-				return ErrorResponse(400, "bad_request", "`ip` uint32 out of range");
-			}
-			ip_he = static_cast<std::uint32_t>(v);
-		} else {
-			return ErrorResponse(400, "bad_request", "`ip` must be a string or number");
+		if (!it->second.is<std::string>()) {
+			return ErrorResponse(400,
+				"bad_request",
+				"`ip` must be a dotted-quad IPv4 address string, e.g. "
+				"\"127.0.0.1\"");
+		}
+		if (!ParseIpv4Dotted(it->second.get<std::string>(), ip_he)) {
+			return ErrorResponse(400, "bad_request", "`ip` must be a dotted-quad IPv4 address");
 		}
 	}
 	std::uint16_t port = 0;
@@ -8839,11 +8901,9 @@ CHttpServer::Response CApiDispatcher::HandleKadBootstrap(const CHttpServer::Requ
 	w.BeginObject();
 	// `ok` dropped. `ip`/`port` stay as the documented exception to the
 	// no-body rule for actions: the echo reports which address the daemon
-	// actually parsed, which the caller cannot recover anywhere else.
-	// Echo the shape the caller may have sent, and the one every other IP on
-	// this surface uses. Answering the host-order integer meant a client that
-	// posted "1.2.3.4" and stored the reply held 16909060, which it could not
-	// post back without converting.
+	// actually parsed, which the caller cannot recover anywhere else. It is a
+	// quad, the same spelling the request used and the one every other IP on
+	// this surface uses, so a caller can post the reply straight back.
 	w.Key("ip");
 	w.ValueString(Uint32toStringIP(ip_he));
 	w.Key("port");

--- a/src/webapi/static/js/views/download-detail.js
+++ b/src/webapi/static/js/views/download-detail.js
@@ -58,9 +58,16 @@ export function DownloadDetail({ hash, isGuest, categories = [], onPatch, onDele
     .then(() => toast(t("downloads_detail_copied"), "success"))
     .catch(() => toast(t("downloads_detail_copy_failed"), "error"));
 
-  // `a4af_auto` is not part of EqualDownload (EventDiff.cpp), so toggling it emits
+  // `a4af_auto` is not part of EqualDownload (EventDiff.cpp), so changing it emits
   // no download_updated and the tick-driven re-fetch never sees it — bump `reload`.
   const a4af = (action) => api.post("downloads/" + hash + "/a4af", { action })
+    .then(() => { toast(t("downloads_a4af_done"), "success"); setReload((n) => n + 1); })
+    .catch((e) => toast(terr(e), "error"));
+
+  // The auto flag is set, not toggled: send the value the button is moving to
+  // rather than asking the daemon to flip whatever it currently holds. A retry
+  // then lands on the same value instead of undoing the press.
+  const setA4afAuto = (value) => api.patch("downloads/" + hash, { a4af_auto: value })
     .then(() => { toast(t("downloads_a4af_done"), "success"); setReload((n) => n + 1); })
     .catch((e) => toast(terr(e), "error"));
 
@@ -146,7 +153,7 @@ export function DownloadDetail({ hash, isGuest, categories = [], onPatch, onDele
             </button>
             <button class=${"btn btn-sm admin-only" + (d.a4af_auto ? " btn-primary" : "")} type="button"
                     title=${t("downloads_a4af_tip_auto")}
-                    aria-pressed=${!!d.a4af_auto} onClick=${() => a4af("swap_this_auto")}>
+                    aria-pressed=${!!d.a4af_auto} onClick=${() => setA4afAuto(!d.a4af_auto)}>
               ${t("downloads_a4af_auto")}
             </button>`)}
         ${IdentityLine({ file: d, copy, titleKey: "downloads_detail_group_identity", extra: [

--- a/unittests/curl-tests/amuleapi/04-read-downloads-shared.sh
+++ b/unittests/curl-tests/amuleapi/04-read-downloads-shared.sh
@@ -224,6 +224,49 @@ if [ "$COUNT" -gt 0 ]; then
 		-d '{"action":"bogus"}' "$HOST/api/v0/downloads/$HASH/a4af"
 	_assert_status 400 "POST /downloads/{hash}/a4af unknown action → 400"
 
+	# `swap_this_auto` was a third action here and is refused, not ignored:
+	# it flipped a flag rather than moving sources, and a flip cannot be
+	# retried safely. The message names where the flag is set instead.
+	_curl -X POST -H "Authorization: Bearer $TOKEN" \
+		-H "Content-Type: application/json" \
+		-d '{"action":"swap_this_auto"}' "$HOST/api/v0/downloads/$HASH/a4af"
+	_assert_status 400 "POST a4af swap_this_auto → 400 (moved to PATCH)"
+	_assert_json_eq '.error.message | test("a4af_auto")' true \
+		'the swap_this_auto 400 names the PATCH field'
+
+	# --- a4af_auto is a set, and setting it twice is not an undo. -------
+	#
+	# This is the whole point of moving it: EC_OP_PARTFILE_SWAP_A4AF_THIS_AUTO
+	# maps to SetA4AFAuto(!IsA4AFAuto()), so the old action landed on the
+	# opposite value whenever a request was repeated -- which an HTTP library
+	# or a browser can do without the caller knowing.
+	for want in true false true; do
+		_curl -X PATCH -H "Authorization: Bearer $TOKEN" \
+			-H "Content-Type: application/json" \
+			-d "{\"a4af_auto\":$want}" "$HOST/api/v0/downloads/$HASH"
+		_assert_status 200 "PATCH a4af_auto=$want → 200"
+		_assert_json_eq '.a4af_auto' "$want" "PATCH a4af_auto=$want reads back $want"
+
+		# Same body again: the value must not move.
+		_curl -X PATCH -H "Authorization: Bearer $TOKEN" \
+			-H "Content-Type: application/json" \
+			-d "{\"a4af_auto\":$want}" "$HOST/api/v0/downloads/$HASH"
+		_assert_status 200 "PATCH a4af_auto=$want again → 200"
+		_assert_json_eq '.a4af_auto' "$want" \
+			"a repeated PATCH a4af_auto=$want is a no-op, not a flip"
+
+		# ...and a re-read agrees, so the PATCH body is not the only place
+		# the new value exists.
+		_curl -H "Authorization: Bearer $TOKEN" "$HOST/api/v0/downloads/$HASH"
+		_assert_json_eq '.a4af_auto' "$want" "GET after PATCH reports $want"
+	done
+
+	# A non-boolean is a 400 rather than a coerced truthy value.
+	_curl -X PATCH -H "Authorization: Bearer $TOKEN" \
+		-H "Content-Type: application/json" \
+		-d '{"a4af_auto":"yes"}' "$HOST/api/v0/downloads/$HASH"
+	_assert_status 400 "PATCH a4af_auto non-boolean → 400"
+
 	# Per-file client rows (issue #984): the peers of one file, with their
 	# relation to it, replacing a client-side join against the global list.
 	_curl -H "Authorization: Bearer $TOKEN" "$HOST/api/v0/downloads/$HASH/clients"

--- a/unittests/curl-tests/amuleapi/16-networks-connect.sh
+++ b/unittests/curl-tests/amuleapi/16-networks-connect.sh
@@ -163,12 +163,19 @@ _assert_status 202 "POST /kad/bootstrap (dotted-quad) → 202"
 _assert_json_eq '. | has("ok")' false 'kad/bootstrap response has no constant ok field'
 _assert_json_eq '.port' 4672   'kad/bootstrap response echoes port'
 
-# Uint32 IP form should also work.
+# The uint32 form is refused. It was accepted alongside the quad and the two
+# disagreed about byte order: ParseIpv4Dotted() packs a.b.c.d least-significant
+# byte first, while the integer was taken verbatim, so 2130706433 (0x7F000001,
+# what a client computing an IPv4 integer the conventional way writes for
+# 127.0.0.1) bootstrapped 1.0.0.127. Every IP on this surface is a quad now, in
+# both directions, so the question does not arise.
 _curl -X POST -H "Authorization: Bearer $ADMIN_TOKEN" \
 	-H "Content-Type: application/json" \
 	-d '{"ip":2130706433,"port":4672}' \
 	"$HOST/api/v0/kad/bootstrap"
-_assert_status 202 "POST /kad/bootstrap (uint32 IP) → 202"
+_assert_status 400 "POST /kad/bootstrap (uint32 IP) → 400 (quad only)"
+_assert_json_eq '.error.message | test("dotted-quad")' true \
+	'the uint32 400 says a dotted quad is wanted'
 
 # Error: missing port.
 _curl -X POST -H "Authorization: Bearer $ADMIN_TOKEN" \
@@ -245,11 +252,11 @@ _assert_status 405 "GET /kad/update → 405"
 
 # --- 7. kad/bootstrap echoes the IP as a dotted quad (#1159 section 2). ---
 #
-# The handler takes `ip` as either a dotted quad or a host-order uint32, and
-# used to answer with the integer whichever form came in. One key, two types
-# across the same request: a client that posted "1.2.3.4" and stored the reply
-# held 16909060, which it could not post back without converting, and which no
-# other endpoint on this surface produces -- every other IP is a dotted quad.
+# The handler answers with the address it parsed, and that echo is a quad --
+# the same spelling the request used, and the one every other IP on this
+# surface uses. It used to answer with the host-order integer, so a client that
+# posted "1.2.3.4" and stored the reply held 16909060, which it could not post
+# back without converting and which no other field on this surface produces.
 _curl -X POST -H "Authorization: Bearer $ADMIN_TOKEN" \
 	-H "Content-Type: application/json" \
 	-d '{"ip":"127.0.0.1","port":4672}' \
@@ -257,28 +264,15 @@ _curl -X POST -H "Authorization: Bearer $ADMIN_TOKEN" \
 _assert_status 202 "POST /kad/bootstrap (dotted-quad) -> 202"
 _assert_json_eq '.ip' '127.0.0.1' 'kad/bootstrap echoes the IP as a dotted quad'
 
-# The integer input form answers with a quad too, so the response shape does
-# not depend on how the caller spelled the request.
-#
-# Asserted as a shape, not a value, deliberately. The two input forms currently
-# disagree about byte order: ParseIpv4Dotted() packs a.b.c.d least-significant
-# byte first (matching Uint32toStringIP), while this branch takes the JSON
-# integer verbatim -- so 2130706433 (0x7F000001, which a client computing an
-# IPv4 integer the conventional big-endian way writes for 127.0.0.1) comes back
-# as 1.0.0.127 and would bootstrap the reversed address. Pinning either reading
-# here would bake in an answer that has not been decided; what section 2 of
-# #1159 is about, and what this asserts, is that the echo is a quad rather than
-# an integer.
+# The echo round-trips: what came back can be posted straight back in, which
+# is what "one notation, both directions" has to mean to be worth anything.
+ECHOED=$(printf '%s' "$CURL_BODY" | jq -r '.ip')
 _curl -X POST -H "Authorization: Bearer $ADMIN_TOKEN" \
 	-H "Content-Type: application/json" \
-	-d '{"ip":2130706433,"port":4672}' \
+	-d "{\"ip\":\"$ECHOED\",\"port\":4672}" \
 	"$HOST/api/v0/kad/bootstrap"
-_assert_status 202 "POST /kad/bootstrap (uint32 IP) -> 202"
-case "$(printf '%s' "$CURL_BODY" | jq -r '.ip')" in
-[0-9]*.[0-9]*.[0-9]*.[0-9]*) _pass "kad/bootstrap echoes a dotted quad for the uint32 form too" ;;
-*) _fail "kad/bootstrap echoes a dotted quad for the uint32 form too" \
-	"got [$(printf '%s' "$CURL_BODY" | jq -r '.ip')]" ;;
-esac
+_assert_status 202 'the echoed ip is accepted verbatim on a second request'
+_assert_json_eq '.ip' "$ECHOED" 'and echoes the same quad again'
 
 # --- Summary. -----------------------------------------------------
 echo

--- a/unittests/curl-tests/amuleapi/18-categories-crud.sh
+++ b/unittests/curl-tests/amuleapi/18-categories-crud.sh
@@ -105,7 +105,21 @@ sleep 4
 _curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/categories/0"
 _assert_status 200 "GET /categories/0 → 200"
 _assert_json_eq '.index' 0 '/categories/0 reports index 0'
-_assert_json_eq '.name | type' string '/categories/0 carries a name'
+
+# Category 0 carries a name and a path amuled does not hold for it: its
+# `defaultcat` is built with an empty title and path, which left a client
+# rendering a picker with a blank row and nowhere to show where an
+# uncategorised download lands. `path` is not invented -- it is
+# directories.incoming, which is genuinely where such a file is saved.
+_assert_json_eq '.name' Default '/categories/0 is named Default'
+INCOMING=$(curl -s -H "Authorization: Bearer $ADMIN_TOKEN" \
+	"$HOST/api/v0/preferences" | jq -r '.directories.incoming')
+_assert_json_eq '.path' "$INCOMING" '/categories/0 path is directories.incoming'
+
+# ...and the same values whether or not the daemon sent the row. This phase
+# creates a custom category below, which is what makes amuled start emitting
+# index 0 itself; asserting again after that would be the real regression
+# test, so section 6b does exactly that before the cleanup.
 
 _curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/categories/250"
 _assert_status 404 "GET /categories/{absent} → 404"
@@ -126,7 +140,7 @@ _curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/categories"
 _assert_status 200 "GET /categories → 200"
 _assert_json_eq '.total | type'  number '/categories carries total'
 _assert_json_eq '.offset | type' number '/categories carries offset'
-_assert_json_eq '.limit | type'  number '/categories carries limit'
+_assert_json_eq '.limit' null '/categories limit is null when unlimited'
 
 _curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/categories?limit=1"
 _assert_status 200 "GET /categories?limit=1 → 200"
@@ -273,6 +287,25 @@ _curl -X PATCH -H "Authorization: Bearer $ADMIN_TOKEN" \
 	-H "Content-Type: application/json" \
 	-d '{"name":"x"}' "$HOST/api/v0/categories/not-a-number"
 _assert_status 400 "PATCH /categories non-numeric index → 400"
+
+# --- 5b. Category 0 reads the same now that amuled sends the row. ---
+#
+# amuled's EC omits index 0 entirely until a custom category exists, and the
+# create above added one -- so this is the same read as section 1, on the other
+# side of that switch. Filling name/path in only for the synthesised row would
+# have made /categories/0 answer "Default" before this point and "" after it,
+# which is a response shape that depends on unrelated state.
+_curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/categories/0"
+_assert_status 200 "GET /categories/0 (amuled now sends it) → 200"
+_assert_json_eq '.name' Default '/categories/0 is still named Default'
+_assert_json_eq '.path' "$INCOMING" '/categories/0 path is still directories.incoming'
+
+# The collection agrees with the member route, on the same daemon state.
+_curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/categories?limit=500"
+_assert_json_eq '[.categories[] | select(.index == 0)][0].name' Default \
+	'/categories lists index 0 as Default too'
+_assert_json_eq '[.categories[] | select(.index == 0)][0].path' "$INCOMING" \
+	'/categories lists index 0 with the incoming path too'
 
 # --- 6. DELETE happy path + cannot-delete-default + no-stale. ----
 _curl -X DELETE -H "Authorization: Bearer $ADMIN_TOKEN" \

--- a/unittests/curl-tests/amuleapi/19-search.sh
+++ b/unittests/curl-tests/amuleapi/19-search.sh
@@ -316,7 +316,7 @@ _curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/search"
 _assert_status 200 "GET /search → 200"
 _assert_json_eq '.total | type'  number '/search carries total'
 _assert_json_eq '.offset | type' number '/search carries offset'
-_assert_json_eq '.limit | type'  number '/search carries limit'
+_assert_json_eq '.limit' null '/search limit is null when unlimited'
 
 _curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/search?limit=1"
 _assert_status 200 "GET /search?limit=1 → 200"

--- a/unittests/curl-tests/amuleapi/28-list-pagination-sort.sh
+++ b/unittests/curl-tests/amuleapi/28-list-pagination-sort.sh
@@ -129,7 +129,13 @@ for pair in "${ENDPOINTS[@]}"; do
 	_assert_json_eq ".$key | type"  array  "/$ep .$key is an array"
 	_assert_json_eq ".total | type"  number "/$ep total is a number"
 	_assert_json_eq ".offset | type" number "/$ep offset is a number"
-	_assert_json_eq ".limit | type"  number "/$ep limit is a number"
+	# `limit` is null when the request did not ask for one -- it is the page
+	# size, and no page size was applied. It used to report the row count,
+	# which is not a page size and could not be reused as one: re-sending it
+	# is a 400 as soon as a list is longer than the 500 cap. The row count
+	# lives in `total`, which is asserted right above.
+	_assert_json_eq ".limit"         null   "/$ep limit is null when unlimited"
+	_assert_json_eq ". | has(\"limit\")" true "/$ep still carries the limit key"
 	_assert_json_eq ".offset"        0      "/$ep default offset is 0"
 
 	# 2. limit bounds the array length; limit echoes back.
@@ -137,6 +143,10 @@ for pair in "${ENDPOINTS[@]}"; do
 	_assert_status 200 "GET /$ep?limit=1 → 200"
 	_assert_json_le ".$key | length" 1 "/$ep?limit=1 returns <= 1 item"
 	_assert_json_eq ".limit" 1 "/$ep?limit=1 echoes limit=1"
+
+	# ...and a limit the caller did choose is echoed as a number, so null
+	# above is "no window", not "the field went away".
+	_assert_json_eq ".limit | type" number "/$ep?limit=1 limit is a number"
 
 	# 3. limit=0 → empty window, total still reported.
 	_curl "${AUTH[@]}" "$HOST/api/v0/$ep?limit=0"


### PR DESCRIPTION
Closes #1159.

Four things ngosang raised on #1159 after the first pass, plus the two rules they generalise to.

## What changed

**Category 0 has a name and a path.** amuled holds neither -- its `defaultcat` is built with an empty title and path -- so a client rendering a category picker got a blank row it had to label itself, and nothing to show for where an uncategorised download lands. It now reports `name: "Default"` and `path` from `directories.incoming`, which is genuinely where such a file is saved.

Filled in whether the row came from the daemon or was synthesised by amuleapi. amuled's EC omits index 0 entirely until the first custom category exists, so doing it only for the synthetic row would have made `/categories/0` answer `"Default"` on a fresh daemon and `""` the moment the operator added a category, which is a response shape that depends on unrelated state.

**`a4af_auto` is set, not toggled.** `POST /downloads/{hash}/a4af` took a `swap_this_auto` action that flipped the flag, because that is all EC could express: `EC_OP_PARTFILE_SWAP_A4AF_THIS_AUTO` maps to `SetA4AFAuto(!IsA4AFAuto())`. A client library, a proxy or a browser can repeat a request without the caller knowing, and a repeated flip lands on the opposite value.

Rather than approximate a set with a compare-then-set against amuleapi's snapshot -- which lags a refresher tick and would race anything else touching the flag -- this adds the operation EC was missing. `EC_OP_PARTFILE_SET_A4AF_AUTO` (`0x68`) carries the existing `EC_TAG_PARTFILE_A4AFAUTO` inbound, in the same child-of-`EC_TAG_PARTFILE` shape `SET_CAT` and `PRIO_SET` already use, and the core stores the value it is given. `CPartFile::SetA4AFAuto()` already marks the file EC-changed only when the value actually moves, so re-sending the value it already holds costs nothing and pushes no update.

Additive on the wire: the flip opcode is untouched, so a deployed amulegui is unaffected, and `ExternalConn.cpp` is `CORE_SOURCES` only so the GUI client never compiles the new branch.

On the API side the flag becomes a field on [`PATCH /downloads/{hash}`](docs/api/REFERENCE.md), which already takes `status` / `priority` / `category` and already answers with the full download object, so the caller sees the resulting value without a re-read. `swap_this_auto` is refused with a `400` naming the replacement; `swap_this` and `swap_others` stay, since both move sources one way and neither has this problem.

**`limit` in the list envelope is `null` when the request did not ask for one.** It reported the row count instead, which is not a page size and could not be used as one: a caller that stored it pinned its window to whatever the first response happened to hold, and re-sending it is a `400` as soon as the list is longer than the `500` cap -- the envelope handing back a value the endpoint then rejects. The row count is `total`, which was always right beside it.

Omitting `limit` still means the full set, and a `limit` above the cap is still a `400` rather than a silent clamp. Only the echo changed.

**`POST /kad/bootstrap` takes a dotted quad and nothing else.** It accepted a host-order `uint32` alongside the quad and the two disagreed about byte order: `ParseIpv4Dotted()` packs `a.b.c.d` least-significant byte first, while the integer branch took the JSON value verbatim, so `2130706433` (`0x7F000001`, what a client computing an IPv4 integer the conventional way writes for `127.0.0.1`) bootstrapped `1.0.0.127`. Sending an integer is now a `400`.

That is the byte-order question left open on #1159, answered by removing the spelling that raised it rather than by picking a reading for it.

## Two new rules in the reference

Both generalise a fix above, and both are stated so the next endpoint does not have to rediscover them:

- **Idempotency** -- every endpoint leaves the daemon in the state one request would have left it in, however many times the request arrives. A mutation names the value it wants, not the change it wants. The exceptions are the endpoints whose purpose is to do the work again (`shared_reload`, `verify`, the `*/update` fetches, `search/{id}/more`).
- **IP addresses** -- every IP on this surface, in either direction, is a dotted-quad string. The conversion to and from the host-order integers EC carries happens inside amuleapi.

## Web UI

`download-detail.js` was posting the removed action. The A4AF-auto button now sends `{"a4af_auto": <the value it is moving to>}` to `PATCH /downloads/{hash}`, so a retried press lands on the value the user asked for rather than undoing it.

## Verification

Against a live amuled on macOS:

- Full curl-smoke suite: **40/40 phases, 1382/1382 assertions**.
- Unit tests: **43/43**.
- `clang-format` on the diff: clean.
- `clang-tidy` Tier-1 and Tier-2 on the diff: 0 findings, 0 compiler errors.
- `scripts/check-potfiles.sh`: clean (no new translatable strings).

The a4af assertions are the ones worth reading: a `PATCH` with the same body twice leaves the value where the first one put it, and a re-read agrees, which is the property the old toggle could not have.

## Not taken

The other half of ngosang's §10 note -- a default `limit` of 100 on every paginated endpoint, and dropping the upper bound so `limit=9999999` is legal -- is not here. It reverses a decision that landed in #1141, where the over-cap `400` was chosen deliberately over the previous silent clamp, and it changes what an omitted `limit` means. Worth doing as its own change against that history rather than folded in beside four unrelated fixes.
