### PR TITLE
fix(web-ui): tab strip rule, empty search pane, select-cell hit area

### DIFF
--- a/src/webapi/static/css/app.css
+++ b/src/webapi/static/css/app.css
@@ -331,6 +331,14 @@ table.data tbody tr.connecting:nth-child(even) { background: color-mix(in srgb, 
 table.data tbody tr.connecting:hover { background: color-mix(in srgb, var(--warn) 26%, var(--surface)); }
 table.data tbody tr.connecting td:first-child { box-shadow: inset 3px 0 0 var(--warn); }
 table.data td.num, table.data th.num { text-align: right; }
+/* Select column: .cell-check fills the cell, so the whole cell toggles the row.
+   No position on the th -- it is already sticky (its own containing block), and
+   relative would unstick the select-all header. */
+table.data td.check { position: relative; }
+table.data .cell-check {
+  position: absolute; inset: 0;
+  display: flex; align-items: center; justify-content: center; cursor: pointer;
+}
 table.data td.name { white-space: normal; word-break: break-word; min-width: 220px; max-width: 520px; }
 .row-selected, .row-selected:hover { background: var(--sel) !important; }
 
@@ -635,9 +643,12 @@ table.data.virtual td.name .name-select { width: 100%; max-width: 100%; }
 .tabs-extra { margin-left: auto; display: flex; align-items: center; gap: 6px; margin-bottom: 4px; }
 
 /* --- notebook-style tabs (CMuleNotebook look) --- */
+/* Inset shadow, not border-bottom: a scrolling strip clips at its padding box,
+   so over a real border the active tab could not paint its -1px overhang and
+   would look detached from the pane. */
 .tabs {
   display: flex; gap: 2px; flex-wrap: wrap;
-  border-bottom: 1px solid var(--border); margin-bottom: 12px;
+  box-shadow: inset 0 -1px 0 var(--border); margin-bottom: 12px;
 }
 .tab {
   border: 1px solid var(--border); border-bottom: none;
@@ -657,16 +668,12 @@ table.data.virtual td.name .name-select { width: 100%; max-width: 100%; }
 .tab.active .tab-badge { background: var(--accent); color: var(--accent-contrast); }
 
 /* Search: one tab per search, so the strip scrolls instead of wrapping at
-   every width (the .net-pane rule below only does that on phones). Two things
-   that overflow forces: flex-shrink:0, because an overflow other than
-   `visible` drops a flex item's automatic min-height and the strip would
-   collapse to a few pixels inside .net-pane's column flexbox; and the bottom
-   rule as an inset shadow rather than a border, because the clip is the
-   PADDING box -- over a real border the active tab could never paint its
-   -1px overhang, and every tab would look detached from the pane. */
+   every width (the .net-pane rule below only does that on phones).
+   flex-shrink:0 because an overflow other than `visible` drops a flex item's
+   automatic min-height and the strip would collapse to a few pixels inside
+   .net-pane's column flexbox. */
 .tabs.search-tabs {
   flex: 0 0 auto; flex-wrap: nowrap; overflow-x: auto; overflow-y: hidden;
-  border-bottom: none; box-shadow: inset 0 -1px 0 var(--border);
   scrollbar-width: thin; /* same as .nav: the bar only shows up once tabs overflow */
 }
 .tab-item { display: inline-flex; align-items: stretch; flex: 0 0 auto; }

--- a/src/webapi/static/i18n/en.json
+++ b/src/webapi/static/i18n/en.json
@@ -222,7 +222,6 @@
   "search_update_results": "Update results",
   "search_tab_close": "Close search",
   "search_close_all": "Close all",
-  "search_no_tabs": "No searches open. Start one above.",
   "search_extend": "Extend",
   "search_extend_title": "Ask the Kad nodes already queried for a wider set of results",
   "search_extend_kad_only": "Only a Kad search can be extended",

--- a/src/webapi/static/i18n/es.json
+++ b/src/webapi/static/i18n/es.json
@@ -222,7 +222,6 @@
   "search_update_results": "Actualizar resultados",
   "search_tab_close": "Cerrar búsqueda",
   "search_close_all": "Cerrar todas",
-  "search_no_tabs": "No hay búsquedas abiertas. Inicia una arriba.",
   "search_extend": "Ampliar",
   "search_extend_title": "Pide un conjunto de resultados más amplio a los nodos Kad ya consultados",
   "search_extend_kad_only": "Solo se puede ampliar una búsqueda Kad",

--- a/src/webapi/static/js/components.js
+++ b/src/webapi/static/js/components.js
@@ -41,6 +41,14 @@ export function listPlaceholder(loading, emptyMsg) {
     : html`<${Placeholder} kind="info">${emptyMsg}<//>`;
 }
 
+// Row/select-all checkbox for a table's select column. The <label> fills the
+// cell (see .cell-check), so the whole cell is the click target -- a bare box
+// is a poor one.
+export function checkCell(checked, onToggle, title) {
+  return html`<label class="cell-check"><input type="checkbox" title=${title}
+    checked=${checked} onChange=${(e) => onToggle(e.target.checked)} /></label>`;
+}
+
 // Relative, like BASE in api.js: it has to survive a reverse-proxy subpath.
 const FLAG_BASE = window.location.pathname.replace(/\/?$/, "/") + "flags/";
 const REGIONS = (() => {

--- a/src/webapi/static/js/views/downloads.js
+++ b/src/webapi/static/js/views/downloads.js
@@ -6,7 +6,7 @@
 import { api, bulkFailures } from "../api.js";
 import { data } from "../events.js";
 import { html, useState, useEffect, useStore } from "../dom.js";
-import { ProgressBar, Badge, listPlaceholder, Tabs, toast, confirmDialog, PRIORITIES, prioValue, prioLabel } from "../components.js";
+import { ProgressBar, Badge, checkCell, listPlaceholder, Tabs, toast, confirmDialog, PRIORITIES, prioValue, prioLabel } from "../components.js";
 import { VirtualTable, sortRows, textMatcher, useTablePrefs, ColumnPicker } from "../table.js";
 import { formatBytes, formatFreeSpace, formatSpeed } from "../format.js";
 import { Icon } from "../icons.js";
@@ -39,7 +39,7 @@ export default function Downloads({ isGuest }) {
   // Open (or toggle closed) the detail panel; ignore clicks landing on a row's
   // own controls (checkbox / priority / category / action buttons).
   const onRowClick = (d, e) => {
-    if (e.target.closest("input,select,button,a")) return;
+    if (e.target.closest("input,select,button,a,label")) return;
     setDetailHash((h) => (h === d.hash ? null : d.hash));
   };
 
@@ -154,9 +154,9 @@ export default function Downloads({ isGuest }) {
   }, [filterStatus, filterCategory, filterText]);
 
   const columns = [
-    { always: true, label: html`<input type="checkbox" title=${t("downloads_select_all")} checked=${allSelected}
-                         onChange=${(e) => toggleAll(e.target.checked)} />`, width: "40px",
-      cell: (d) => html`<input type="checkbox" checked=${selection.has(d.hash)} onChange=${(e) => toggleRow(d.hash, e.target.checked)} />` },
+    { always: true, cls: "check", width: "40px",
+      label: checkCell(allSelected, toggleAll, t("downloads_select_all")),
+      cell: (d) => checkCell(selection.has(d.hash), (v) => toggleRow(d.hash, v)) },
     { key: "name", always: true, label: t("downloads_name"), cls: "name", sortable: true,
       sortVal: (d) => (d.name || "").toLowerCase(),
       cell: (d) => html`<span title=${d.name}>${d.name}</span>` },

--- a/src/webapi/static/js/views/search.js
+++ b/src/webapi/static/js/views/search.js
@@ -5,7 +5,7 @@
 
 import { api } from "../api.js";
 import { html, useState, useEffect, useStore } from "../dom.js";
-import { Badge, Placeholder, listPlaceholder, Tabs, CommentsList, ratingLabel, toast } from "../components.js";
+import { Badge, checkCell, listPlaceholder, Tabs, CommentsList, ratingLabel, toast } from "../components.js";
 import { VirtualTable, sortRows, textMatcher, useTablePrefs, ColumnPicker } from "../table.js";
 import { formatBytes, formatDuration, formatInt } from "../format.js";
 import { Icon } from "../icons.js";
@@ -117,6 +117,7 @@ export default function Search({ isGuest }) {
       ${isGuest ? html`<p class="hint">${t("search_guest_readonly")}</p>` : null}
     </form>
 
+    ${active ? html`
     <section class="net-pane pane-fill">
       <${Tabs} cls="search-tabs" tabs=${tabItems} active=${String(reg.activeId)}
                onSelect=${(k) => searches.setActive(Number(k))}
@@ -125,11 +126,9 @@ export default function Search({ isGuest }) {
                  <button class="btn btn-sm admin-only" type="button"
                          onClick=${() => searches.closeAll()}>${t("search_close_all")}</button>` : null} />
       <div class="net-pane-body">
-        ${active
-          ? html`<${ResultsPane} key=${active.id} tab=${active} categories=${categories} />`
-          : html`<${Placeholder} kind="info">${t("search_no_tabs")}<//>`}
+        <${ResultsPane} key=${active.id} tab=${active} categories=${categories} />
       </div>
-    </section>
+    </section>` : null}
     </div>`;
 }
 
@@ -228,9 +227,9 @@ function ResultsPane({ tab, categories }) {
     ${categories.filter((c) => c.index !== 0).map((c) => html`<option value=${c.index}>${c.name || ("#" + c.index)}</option>`)}`;
 
   const columns = [
-    { always: true, label: html`<input type="checkbox" title=${t("search_select_all")} checked=${allSelected}
-                         onChange=${(e) => toggleAll(e.target.checked)} />`, width: "40px",
-      cell: (r) => html`<input type="checkbox" checked=${ui.selection.has(r.hash)} onChange=${(e) => toggleRow(r.hash, e.target.checked)} />` },
+    { always: true, cls: "check", width: "40px",
+      label: checkCell(allSelected, toggleAll, t("search_select_all")),
+      cell: (r) => checkCell(ui.selection.has(r.hash), (v) => toggleRow(r.hash, v)) },
     { key: "name", always: true, label: t("search_name"), cls: "name", sortable: true,
       sortVal: (r) => (r.name || "").toLowerCase(),
       // already_have is signalled by the row background (.row-have), not a badge.

--- a/src/webapi/static/js/views/shared.js
+++ b/src/webapi/static/js/views/shared.js
@@ -7,7 +7,7 @@
 import { api, bulkFailures } from "../api.js";
 import { data } from "../events.js";
 import { html, useState, useEffect, useStore } from "../dom.js";
-import { listPlaceholder, toast, confirmDialog } from "../components.js";
+import { checkCell, listPlaceholder, toast, confirmDialog } from "../components.js";
 import { VirtualTable, sortRows, textMatcher, useTablePrefs, ColumnPicker } from "../table.js";
 import { formatBytes, formatFreeSpace, formatInt, formatSpeed, formatTimestamp, twin } from "../format.js";
 import { t, tn, terr } from "../i18n.js";
@@ -37,7 +37,7 @@ export default function Shared({ isGuest }) {
   // Open (or toggle closed) the detail panel; ignore clicks on a row's own
   // controls (the select-all/select checkbox and the priority dropdown).
   const onRowClick = (s, e) => {
-    if (e.target.closest("input,select,button,a")) return;
+    if (e.target.closest("input,select,button,a,label")) return;
     setDetailHash((h) => (h === s.hash ? null : s.hash));
   };
 
@@ -129,9 +129,9 @@ export default function Shared({ isGuest }) {
   }, [filterStatus, filterText]);
 
   const columns = [
-    { always: true, label: html`<input type="checkbox" title=${t("shared_select_all")} checked=${allSelected}
-                         onChange=${(e) => toggleAll(e.target.checked)} />`, width: "40px",
-      cell: (s) => html`<input type="checkbox" checked=${selection.has(s.hash)} onChange=${(e) => toggleRow(s.hash, e.target.checked)} />` },
+    { always: true, cls: "check", width: "40px",
+      label: checkCell(allSelected, toggleAll, t("shared_select_all")),
+      cell: (s) => checkCell(selection.has(s.hash), (v) => toggleRow(s.hash, v)) },
     { key: "name", always: true, label: t("shared_name"), cls: "name", sortable: true,
       sortVal: (s) => (s.name || "").toLowerCase(),
       cell: (s) => html`<span title=${s.name}>${s.name}</span>` },


### PR DESCRIPTION
Three unrelated UI defects:

- Tab strips drew their bottom rule differently on desktop and on phones. A scrolling strip clips at its padding box, so the active tab could not paint its -1px overhang over a real border-bottom and kept a visible line under it. .tabs.search-tabs already worked around this with an inset shadow; that is now the base .tabs rule and the override is gone.

- The Search view rendered its results pane even with no search open, an empty box holding just a "no searches open" placeholder. The section is now gated on there being an active search, and the unused search_no_tabs string is dropped from both catalogs.

- The tables' select column was hard to hit: only the 13px checkbox itself toggled the row. A shared checkCell() helper wraps it in a <label> that fills the cell (Downloads, Shared Files and Search, header included), so the whole cell is the click target. The row-click handlers now ignore labels too, otherwise a click on the cell background would both toggle the row and open the detail panel.