### PR TITLE
fix(amuleapi): rename three ambiguous v0 field names and document the /kad payload

### DIFF
--- a/docs/api/EVENTS.md
+++ b/docs/api/EVENTS.md
@@ -495,7 +495,7 @@ Rate impact is small: the overhead rates move about as often as the speeds alrea
   "ed2k": {
     "state":       "connected",
     "high_id":     true,
-    "id":          1234567890,
+    "user_id":     1234567890,
     "public_ip":   "210.2.150.73",
     "connected_since": 1751000000,
     "server_name": "eMule Server",
@@ -505,7 +505,7 @@ Rate impact is small: the overhead rates move about as often as the speeds alrea
   },
   "kad": {
     "state":      "connected",
-    "firewalled": false,
+    "firewalled_tcp": false,
     "connected_since": 1751000000,
     "network":    { "users": 5400000, "files": 1400000000, "nodes": 2400 }
   },

--- a/docs/api/REFERENCE.md
+++ b/docs/api/REFERENCE.md
@@ -539,7 +539,7 @@ curl -s -H "Authorization: Bearer $TOKEN" http://$HOST/api/v0/status
   "ed2k": {
     "state": "connected",
     "high_id": true,
-    "id": 1234567890,
+    "user_id": 1234567890,
     "public_ip": "210.2.150.73",
     "connected_since": 1751000000,
     "server_name": "eMule Server",
@@ -549,7 +549,7 @@ curl -s -H "Authorization: Bearer $TOKEN" http://$HOST/api/v0/status
   },
   "kad": {
     "state": "connected",
-    "firewalled": false,
+    "firewalled_tcp": false,
     "connected_since": 1751000000,
     "network": { "users": 5400000, "files": 1400000000, "nodes": 2400 }
   },
@@ -568,9 +568,13 @@ curl -s -H "Authorization: Bearer $TOKEN" http://$HOST/api/v0/status
 
 `ed2k.connected_since` / `kad.connected_since` are unix timestamps of the most recent connect, `0` while not connected — gate on `ed2k.state` / `kad.state` rather than trust a `0` timestamp alone.
 
-**Our eD2k identity.** `ed2k.id` is the id the connected server assigned us, and `ed2k.high_id` is `true` when it is a HighID — an id `>= 16777216`, the same threshold the peer-side `high_id` on [`GET /clients/{ecid}`](#get-apiv0clientsecid) uses. A HighID **is** our public IPv4 packed into that integer, which is where `ed2k.public_ip` comes from; a LowID is a small number the server picked for a firewalled client and carries no address, so `public_ip` is `""` there.
+**`kad.firewalled_tcp` is named for its transport.** It is the TCP half of a pair; [`GET /api/v0/kad`](#get-apiv0kad) reports `firewalled_udp` alongside it. The two are independent measurements taken by different mechanisms, not a verdict and a refinement of it. See the `/kad` field table for what each one measures and how their defaults differ.
 
-While disconnected `id` is `0`, `public_ip` is `""` and `high_id` is `false` — so read `high_id` **together with `state`**: `false` means "LowID" only once `state` is `"connected"`, and means "no id yet" otherwise. The transient `0xffffffff` the daemon sends mid-connect is normalized to `0` and never appears.
+**Our eD2k identity.** `ed2k.user_id` is the id the connected server assigned us, and `ed2k.high_id` is `true` when it is a HighID — an id `>= 16777216`, the same threshold the peer-side `high_id` on [`GET /clients/{ecid}`](#get-apiv0clientsecid) uses. A HighID **is** our public IPv4 packed into that integer, which is where `ed2k.public_ip` comes from; a LowID is a small number the server picked for a firewalled client and carries no address, so `public_ip` is `""` there.
+
+While disconnected `user_id` is `0`, `public_ip` is `""` and `high_id` is `false` — so read `high_id` **together with `state`**: `false` means "LowID" only once `state` is `"connected"`, and means "no id yet" otherwise. The transient `0xffffffff` the daemon sends mid-connect is normalized to `0` and never appears.
+
+**`ed2k.user_id` is not the same encoding as a peer's `user_id_hybrid`.** [`GET /api/v0/clients/{ecid}`](#get-apiv0clientsecid) reports `user_id_hybrid` for a remote peer, and the similar name invites the assumption that the two are interchangeable. They are not. Ours is stored exactly as the server sent it and is read least-significant-byte-first to produce `public_ip`; a peer's HighID is **byte-swapped** on the way in. A consumer that compares the two values, or feeds one through the other's IP decoder, gets a reversed address. The `>= 16777216` HighID threshold *is* common to both; the byte order is not.
 
 **Overhead is additive.** `speeds.download_overhead_bps` / `upload_overhead_bps` are protocol and control traffic, counted **separately** from `download_bps` / `upload_bps` rather than being part of them — the desktop shows them as a second figure in parentheses. Both are `0` when the daemon reports nothing.
 
@@ -2327,15 +2331,15 @@ Two side effects are worth planning for. The URL is **persisted** into the `kade
 
 **Auth:** `GUEST`
 
-Standalone view of the Kad subtree from `/status`, plus the detail fields the status rollup omits (`node_id`, `firewalled_udp`, `in_lan_mode`, your `public_ip`, the `indexed` Kad-store counters, and `buddy` contact info for low-ID peers). Together with `GET /api/v0/preferences` (for the TCP/UDP port numbers the firewalled messages quote) this covers every row of the desktop client's **Networks → Kad Info** panel.
+Standalone view of the Kad subtree from `/status`, plus the detail fields the status rollup omits (`node_id`, `firewalled_udp`, `lan_mode`, your `public_ip`, the `indexed` Kad-store counters, and `buddy` contact info for low-ID peers). Together with `GET /api/v0/preferences` (for the TCP/UDP port numbers the firewalled messages quote) this covers every row of the desktop client's **Networks → Kad Info** panel.
 
 ```json
 {
   "state": "connected",
   "node_id": "8f3a1c07d94b2e5a6018bb4c7f209d3e",
-  "firewalled": false,
+  "firewalled_tcp": false,
   "firewalled_udp": false,
-  "in_lan_mode": false,
+  "lan_mode": false,
   "connected_since": 1751000000,
   "public_ip": "203.0.113.5",
   "network": { "users": 5400000, "files": 1400000000, "nodes": 2400 },
@@ -2346,9 +2350,16 @@ Standalone view of the Kad subtree from `/status`, plus the detail fields the st
 
 | Field | Type | Meaning |
 |---|---|---|
+| `state` | string | `disabled` / `connecting` / `connected`. `disabled` means Kad is not running at all, which is the condition several fields below key their "no measurement" value on. The same value `GET /api/v0/status` reports as `kad.state`. |
 | `node_id` | string | This node's own 128-bit Kademlia id, 32 lowercase hex characters (the desktop panel shows the same value uppercase). `""` while Kad is not running, which is exactly when `state` is `disabled`. Persisted by the daemon, so unlike the session-scoped ECIDs and the server-assigned eD2k id it is stable across restarts — the one identifier for the local node a consumer can key on. It is a DHT routing key, not a credential: every Kad contact the daemon talks to learns it. |
 | `connected_since` | int | Unix seconds of the most recent Kad connect, the same value `GET /api/v0/status` reports as `kad.connected_since`. `0` when not connected, so gate on `state` rather than trusting a `0`. |
-| `public_ip` | string | This node's externally-visible IPv4, as a remote Kad contact reported it back. Two "not known" cases, both matching what the desktop panel's *IP address* row shows: `""` while Kad is not connected (the daemon sends the field only then), and `0.0.0.0` while connected but not yet told its own address by any contact. Distinct from `preferences.connection.bind_address`, which is the local interface the daemon binds to. Named `public_ip` rather than `ip` because `buddy.ip` in the same payload belongs to somebody else. |
+| `public_ip` | string | This node's externally-visible IPv4, as a remote Kad contact reported it back. Two "not known" cases, both matching what the desktop panel's *IP address* row shows: `""` while Kad is not connected (the daemon sends the field only then), and `0.0.0.0` while connected but not yet told its own address by any contact. **Two distinct "unknown" sentinels, one of them a syntactically valid address**: a consumer that only checks for `""` will treat `0.0.0.0` as a real IP. Distinct from `preferences.connection.bind_address`, which is the local interface the daemon binds to. Named `public_ip` rather than `ip` because `buddy.ip` in the same payload belongs to somebody else. |
+| `firewalled_tcp` | bool | Whether this node is firewalled for **TCP**. The verdict is a **vote**: two distinct peers must confirm reachability by opening an incoming TCP connection carrying `OP_KAD_FWTCPCHECK_ACK` before it clears to `false`. With no verdict yet it defaults to **`true`**, which is the conservative reading: assume firewalled until proven otherwise. During an IP recheck it freezes at its previous value rather than momentarily reporting a false LowID. Named for the transport because it is one half of a pair, not an overall verdict that `firewalled_udp` refines. |
+| `firewalled_udp` | bool | Whether this node is firewalled for **UDP**, measured by an entirely different mechanism: a directed test with its own state, which can also declare firewalled **by timeout** after six minutes. amuled sends this only while Kad is connected, so it reads **`false` whenever Kad is down**. That is the absence of a measurement, *not* "UDP is open". Note the asymmetry with `firewalled_tcp`, which defaults the other way: a consumer reading both while Kad is disconnected sees `true` / `false` and neither value means anything. This is the most likely field on the payload to be misread. |
+| `lan_mode` | bool | `true` when the daemon is running Kad in LAN mode. It **forces both firewalled fields to `false`** regardless of any measurement, which is why it belongs beside them: a `false` on either flag is only meaningful once you have checked this one. |
+| `network.users` / `.files` / `.nodes` | int | Network-wide estimates for the whole Kad network, not counts belonging to this node. Unlike everything else in this payload they are **not** gated on Kad being connected, so they can be non-zero while `state` is `disabled`. The same values `GET /api/v0/status` reports under `kad.network`. |
+| `indexed.sources` / `.keywords` / `.notes` | int | Kad-store counters: how many entries this node is holding for the network as a DHT participant. Sent only while connected, so all three read `0` while Kad is down. |
+| `indexed.load` | int | A **load figure, not a count**, despite sitting beside three counts: it is the Kad store's fill level. Sent only while connected, so it reads `0` while Kad is down. |
 | `buddy.status` | string | LowID-buddy state for NAT-traversal peers: `no_buddy` / `connecting` / `connected` (`unknown` only if the daemon ever ships a value outside its own enum). Reads `no_buddy` while Kad is not connected — the daemon sends the field only while connected, and that absence is what both the core and the desktop client treat as *no buddy*. `buddy.ip` / `buddy.port` are only meaningful under `connected`: they are `0.0.0.0` / `0` while connected with no buddy, and `""` / `0` while Kad is down. |
 
 ---

--- a/src/webapi/Api.cpp
+++ b/src/webapi/Api.cpp
@@ -2552,9 +2552,11 @@ CHttpServer::Response CApiDispatcher::HandleStatus(const CHttpServer::Request &r
 	w.ValueBool(s.ed2k_high_id);
 	// Our server-assigned id; a HighID (>= 16777216) is our public address
 	// packed LSB-first, which is where public_ip comes from. Both are 0 /
-	// empty while disconnected.
-	w.Key("id");
-	w.ValueInt(static_cast<int64_t>(s.ed2k_id));
+	// empty while disconnected. Not the same encoding as the peer-side
+	// user_id_hybrid on /clients/{ecid}: that one byte-swaps a HighID, so
+	// the two must not be compared or fed through each other's decoder.
+	w.Key("user_id");
+	w.ValueInt(static_cast<int64_t>(s.ed2k_user_id));
 	w.Key("public_ip");
 	w.ValueString(wxString::FromUTF8(s.ed2k_public_ip.c_str()));
 	// 0 when not connected -- gate on ed2k.state, not on this being nonzero.
@@ -2583,8 +2585,11 @@ CHttpServer::Response CApiDispatcher::HandleStatus(const CHttpServer::Request &r
 	w.BeginObject();
 	w.Key("state");
 	w.ValueString(wxString::FromUTF8(s.kad_state.c_str()));
-	w.Key("firewalled");
-	w.ValueBool(s.kad_firewalled);
+	// TCP half of the firewall verdict. Named for the transport because
+	// GET /kad reports it beside firewalled_udp, which is a separate
+	// measurement rather than a refinement of this one.
+	w.Key("firewalled_tcp");
+	w.ValueBool(s.kad_firewalled_tcp);
 	// 0 when not connected -- gate on kad.state, not on this being nonzero.
 	w.Key("connected_since");
 	w.ValueInt(static_cast<int64_t>(s.kad_connected_since));
@@ -7063,12 +7068,17 @@ CHttpServer::Response CApiDispatcher::HandleKad(const CHttpServer::Request &req)
 	// stable across restarts.
 	w.Key("node_id");
 	w.ValueString(wxString::FromUTF8(k.node_id.c_str()));
-	w.Key("firewalled");
-	w.ValueBool(k.firewalled);
+	// Two independent measurements, not a verdict and a refinement.
+	// firewalled_tcp is a vote needing two peers to confirm reachability
+	// and defaults to true with no verdict; firewalled_udp is a directed
+	// test sent only while Kad is connected, so it reads false when Kad
+	// is down. LAN mode forces both to false.
+	w.Key("firewalled_tcp");
+	w.ValueBool(k.firewalled_tcp);
 	w.Key("firewalled_udp");
 	w.ValueBool(k.firewalled_udp);
-	w.Key("in_lan_mode");
-	w.ValueBool(k.in_lan_mode);
+	w.Key("lan_mode");
+	w.ValueBool(k.lan_mode);
 	// Same value GET /status reports as kad.connected_since; 0 when
 	// not connected, so gate on `state` rather than on a nonzero.
 	w.Key("connected_since");

--- a/src/webapi/EventDiff.cpp
+++ b/src/webapi/EventDiff.cpp
@@ -306,7 +306,7 @@ std::string ToJsonStatusEvent(const StatusSnapshot &s, const KadSnapshot &k, boo
 	o << "{"
 	  << "\"ec_connected\":" << (ec_connected ? "true" : "false") << ",\"ed2k\":{"
 	  << "\"state\":\"" << EscJson(s.ed2k_state) << "\""
-	  << ",\"high_id\":" << (s.ed2k_high_id ? "true" : "false") << ",\"id\":" << s.ed2k_id
+	  << ",\"high_id\":" << (s.ed2k_high_id ? "true" : "false") << ",\"user_id\":" << s.ed2k_user_id
 	  << ",\"public_ip\":\"" << EscJson(s.ed2k_public_ip) << "\""
 	  << ",\"connected_since\":" << s.ed2k_connected_since << ",\"server_name\":\""
 	  << EscJson(s.server_name) << "\""
@@ -315,7 +315,7 @@ std::string ToJsonStatusEvent(const StatusSnapshot &s, const KadSnapshot &k, boo
 	  << "\"users\":" << s.ed2k_users << ",\"files\":" << s.ed2k_files << "}}"
 	  << ",\"kad\":{"
 	  << "\"state\":\"" << EscJson(s.kad_state) << "\""
-	  << ",\"firewalled\":" << (s.kad_firewalled ? "true" : "false")
+	  << ",\"firewalled_tcp\":" << (s.kad_firewalled_tcp ? "true" : "false")
 	  << ",\"connected_since\":" << s.kad_connected_since << ",\"network\":{"
 	  << "\"users\":" << k.users << ",\"files\":" << k.files << ",\"nodes\":" << k.nodes << "}"
 	  << "}"
@@ -466,14 +466,15 @@ bool Equal(const ClientSnapshot &a, const ClientSnapshot &b)
 }
 bool Equal(const StatusSnapshot &a, const StatusSnapshot &b)
 {
-	// public_ip is derived from ed2k_id, so comparing the id covers it.
+	// public_ip is derived from ed2k_user_id, so comparing the id covers it.
 	return a.ed2k_state == b.ed2k_state && a.kad_state == b.kad_state &&
-	       a.ed2k_high_id == b.ed2k_high_id && a.ed2k_id == b.ed2k_id &&
+	       a.ed2k_high_id == b.ed2k_high_id && a.ed2k_user_id == b.ed2k_user_id &&
 	       a.ed2k_connected_since == b.ed2k_connected_since &&
-	       a.kad_connected_since == b.kad_connected_since && a.kad_firewalled == b.kad_firewalled &&
-	       a.server_name == b.server_name && a.server_ip == b.server_ip &&
-	       a.server_port == b.server_port && a.download_bps == b.download_bps &&
-	       a.upload_bps == b.upload_bps && a.download_overhead_bps == b.download_overhead_bps &&
+	       a.kad_connected_since == b.kad_connected_since &&
+	       a.kad_firewalled_tcp == b.kad_firewalled_tcp && a.server_name == b.server_name &&
+	       a.server_ip == b.server_ip && a.server_port == b.server_port &&
+	       a.download_bps == b.download_bps && a.upload_bps == b.upload_bps &&
+	       a.download_overhead_bps == b.download_overhead_bps &&
 	       a.upload_overhead_bps == b.upload_overhead_bps && a.temp_free_bytes == b.temp_free_bytes &&
 	       a.incoming_free_bytes == b.incoming_free_bytes && a.ul_queue_len == b.ul_queue_len &&
 	       a.total_src_count == b.total_src_count && a.ed2k_users == b.ed2k_users &&

--- a/src/webapi/Refresher.cpp
+++ b/src/webapi/Refresher.cpp
@@ -199,13 +199,13 @@ void ParseStatusFromPacket(const CECPacket *resp, StatusSnapshot &out)
 		// reads 0, and HasLowID() is "id < HIGHEST_LOWID_ED2K_KAD", so a
 		// disconnected daemon would otherwise be reported as a LowID.
 		out.ed2k_high_id = conn->IsConnectedED2K() && !conn->HasLowID();
-		out.kad_firewalled = conn->IsKadFirewalled();
+		out.kad_firewalled_tcp = conn->IsKadFirewalled();
 		if (conn->IsConnectedED2K()) {
 			// 0xffffffff is the "connect in flight, no id yet" sentinel
 			// (ECSpecialCoreTags.cpp) and must not reach a consumer.
 			const std::uint32_t id = static_cast<std::uint32_t>(conn->GetEd2kId());
 			if (id != 0xffffffffu) {
-				out.ed2k_id = id;
+				out.ed2k_user_id = id;
 				// A HighID *is* our public address, LSB-first, the same
 				// layout EC_TAG_CLIENT_USER_IP uses. A LowID is a small
 				// number the server picked and carries no address.
@@ -1556,7 +1556,7 @@ void ParseKadFromPacket(const CECPacket *resp, KadSnapshot &out)
 
 	out.state = KadStateString(conn);
 	if (conn) {
-		out.firewalled = conn->IsKadFirewalled();
+		out.firewalled_tcp = conn->IsKadFirewalled();
 		// Our own node id. amuled ships EC_TAG_KAD_ID only while Kad
 		// is running, which is the same condition KadStateString()
 		// reports as anything other than "disabled" -- so an absent
@@ -1602,7 +1602,7 @@ void ParseKadFromPacket(const CECPacket *resp, KadSnapshot &out)
 		out.public_ip = IPv4ToDotted(static_cast<std::uint32_t>(t->GetInt()));
 	}
 	if (const CECTag *t = resp->GetTagByName(EC_TAG_STATS_KAD_IN_LAN_MODE)) {
-		out.in_lan_mode = (t->GetInt() != 0);
+		out.lan_mode = (t->GetInt() != 0);
 	}
 	if (const CECTag *t = resp->GetTagByName(EC_TAG_STATS_BUDDY_STATUS)) {
 		out.buddy_status = KadBuddyStatusName(static_cast<std::uint32_t>(t->GetInt()));

--- a/src/webapi/State.h
+++ b/src/webapi/State.h
@@ -653,9 +653,9 @@ struct KadSnapshot
 	// id, this one is persisted (preferencesKad.dat) and survives
 	// daemon restarts.
 	std::string node_id;
-	bool firewalled = false;
+	bool firewalled_tcp = false;
 	bool firewalled_udp = false;
-	bool in_lan_mode = false;
+	bool lan_mode = false;
 	std::uint32_t users = 0;
 	std::uint32_t files = 0;
 	std::uint32_t nodes = 0;
@@ -1329,16 +1329,20 @@ struct StatusSnapshot
 
 	// Our eD2k id as assigned by the connected server. 0 when not
 	// connected; the 0xffffffff "connect in flight" sentinel is normalized
-	// to 0 rather than surfaced.
-	std::uint32_t ed2k_id = 0;
+	// to 0 rather than surfaced. Packed LSB-first, unlike the peer-side
+	// user_id_hybrid on CUpDownClient, which byte-swaps a HighID.
+	std::uint32_t ed2k_user_id = 0;
 
-	// Our public IPv4 in dotted-quad form, derived from ed2k_id when that
+	// Our public IPv4 in dotted-quad form, derived from ed2k_user_id when that
 	// is a HighID -- a HighID *is* the address. Empty for a LowID or while
 	// disconnected, where no address exists. Formatted here rather than in
 	// the handler, matching every other address in these snapshots.
 	std::string ed2k_public_ip;
-	// True when Kad is running but firewalled.
-	bool kad_firewalled = false;
+	// True when Kad is running but firewalled for TCP. The verdict is a
+	// vote: two peers must confirm reachability over an incoming TCP
+	// connection before it clears. Distinct from the UDP test, which is
+	// a different mechanism -- see KadSnapshot::firewalled_udp.
+	bool kad_firewalled_tcp = false;
 
 	// Unix timestamp of the most recent connect (amule-org/amule#174),
 	// from EC_TAG_CONNSTATE's optional {ED2K,KAD}_CONNECTED_SINCE

--- a/src/webapi/static/js/app.js
+++ b/src/webapi/static/js/app.js
@@ -325,8 +325,8 @@ function ConnectionStatus({ status }) {
   const kad = status && status.kad;
   let kText = t("app_not_connected"), kCls = "off";
   if (kad && kad.state === "connected") {
-    kCls = kad.firewalled ? "warn" : "ok";
-    kText = t("app_connected") + (kad.firewalled ? " · " + t("app_firewalled") : "");
+    kCls = kad.firewalled_tcp ? "warn" : "ok";
+    kText = t("app_connected") + (kad.firewalled_tcp ? " · " + t("app_firewalled") : "");
   }
 
   return html`

--- a/src/webapi/static/js/views/networks.js
+++ b/src/webapi/static/js/views/networks.js
@@ -492,7 +492,7 @@ function Ed2kInfoPanel() {
       ], "networks_ed2k_group_connection")}
       ${Section([
         // An identifier, not a quantity -- no thousands separators.
-        statRow("networks_ed2k_id", connected ? String(ed2k.id || 0) : "—"),
+        statRow("networks_ed2k_id", connected ? String(ed2k.user_id || 0) : "—"),
         statRow("networks_ed2k_ip_port", ipPort),
       ], "networks_ed2k_group_identity")}
     </div>`;
@@ -527,15 +527,15 @@ function KadInfoPanel() {
     <div class="detail-sections">
       ${Section([
         statRow("networks_kad_state", html`<span class=${"status-chip " + (kad.state === "connected" ? "ok" : "off")}>${kad.state ? t("networks_kad_conn_" + kad.state) : "—"}</span>`),
-        statRow("networks_kad_firewalled_tcp", yesno(kad.firewalled)),
+        statRow("networks_kad_firewalled_tcp", yesno(kad.firewalled_tcp)),
         statRow("networks_kad_firewalled_udp", yesno(d.firewalled_udp)),
-        statRow("networks_kad_in_lan_mode", yesno(d.in_lan_mode)),
+        statRow("networks_kad_in_lan_mode", yesno(d.lan_mode)),
         statRow("networks_kad_connected_since", formatTimestamp(d.connected_since)),
       ], "networks_kad_group_connection")}
       ${Section([
         statRow("networks_kad_node_id", d.node_id || "—"),
         statRow("networks_kad_your_ip", d.public_ip || "—"),
-        statRow("networks_kad_buddy", buddyText(kad.state, buddy, kad.firewalled, d.firewalled_udp)),
+        statRow("networks_kad_buddy", buddyText(kad.state, buddy, kad.firewalled_tcp, d.firewalled_udp)),
       ], "networks_kad_group_identity")}
       ${Section([
         statRow("networks_kad_users", formatInt(net.users)),

--- a/unittests/curl-tests/amuleapi/03-read-status.sh
+++ b/unittests/curl-tests/amuleapi/03-read-status.sh
@@ -126,8 +126,12 @@ _assert_json_eq '.ed2k.state | test("^(connected|connecting|disconnected)$")' \
 	true 'ed2k.state is a known enum value'
 _assert_json_eq '.ed2k.high_id | type' boolean \
 	'ed2k.high_id is boolean'
-_assert_json_eq '.ed2k.id | type' number \
-	'ed2k.id is numeric'
+_assert_json_eq '.ed2k.user_id | type' number \
+	'ed2k.user_id is numeric'
+# The old spelling was a bare `id`, which read as a local handle rather than
+# the server-assigned identity it actually is.
+_assert_json_eq '.ed2k | has("id")' false \
+	'ed2k.id is gone, replaced by ed2k.user_id'
 _assert_json_eq '.ed2k.public_ip | type' string \
 	'ed2k.public_ip is string'
 # A public address exists exactly when we hold a HighID on a live connection;
@@ -135,16 +139,20 @@ _assert_json_eq '.ed2k.public_ip | type' string \
 _assert_json_eq '(.ed2k.public_ip != "") == (.ed2k.high_id and .ed2k.state == "connected")' \
 	true 'ed2k.public_ip is non-empty exactly when high_id and connected'
 # The 0xffffffff "connect in flight" sentinel must never surface.
-_assert_json_eq '.ed2k.id != 4294967295' true \
-	'ed2k.id never reports the connecting sentinel'
+_assert_json_eq '.ed2k.user_id != 4294967295' true \
+	'ed2k.user_id never reports the connecting sentinel'
 _assert_json_eq '.ed2k.server_name | type' string \
 	'ed2k.server_name is string'
 
 # kad subtree.
 _assert_json_eq '.kad.state | test("^(connected|connecting|disabled)$")' \
 	true 'kad.state is a known enum value'
-_assert_json_eq '.kad.firewalled | type' boolean \
-	'kad.firewalled is boolean'
+# Named for the transport: this is the TCP half of the pair GET /kad reports,
+# not an overall verdict refined by firewalled_udp.
+_assert_json_eq '.kad.firewalled_tcp | type' boolean \
+	'kad.firewalled_tcp is boolean'
+_assert_json_eq '.kad | has("firewalled")' false \
+	'kad.firewalled is gone, replaced by kad.firewalled_tcp'
 
 # speeds + queue subtrees.
 _assert_json_eq '.speeds.download_bps | type' number \

--- a/unittests/curl-tests/amuleapi/05-read-servers-kad-categories-prefs.sh
+++ b/unittests/curl-tests/amuleapi/05-read-servers-kad-categories-prefs.sh
@@ -137,9 +137,25 @@ _curl -H "Authorization: Bearer $TOKEN" "$HOST/api/v0/kad"
 _assert_status 200 "GET /kad (admin) → 200"
 _assert_json_eq '.state | test("^(disabled|connecting|connected)$")' \
 	true '/kad.state is a known enum value'
-_assert_json_eq '.firewalled       | type' boolean '/kad.firewalled is boolean'
+# firewalled_tcp and firewalled_udp are two independent measurements, not a
+# verdict and a refinement -- which is what the unqualified `firewalled` used
+# to imply. The TCP one is a vote (two peers must confirm reachability over an
+# incoming connection); the UDP one is a directed test with its own timeout.
+_assert_json_eq '.firewalled_tcp   | type' boolean '/kad.firewalled_tcp is boolean'
 _assert_json_eq '.firewalled_udp   | type' boolean '/kad.firewalled_udp is boolean'
-_assert_json_eq '.in_lan_mode      | type' boolean '/kad.in_lan_mode is boolean'
+_assert_json_eq '.lan_mode         | type' boolean '/kad.lan_mode is boolean'
+# The pre-rename spellings must be gone, not merely shadowed by the new ones.
+_assert_json_eq 'has("firewalled")'   false '/kad.firewalled is gone'
+_assert_json_eq 'has("in_lan_mode")'  false '/kad.in_lan_mode is gone'
+# LAN mode forces both firewall flags false (Kademlia.h, UDPFirewallTester.cpp),
+# so the three cannot all be true at once.
+_assert_json_eq '(.lan_mode | not) or ((.firewalled_tcp | not) and (.firewalled_udp | not))' \
+	true '/kad LAN mode forces both firewalled flags false'
+# amuled sends the UDP test result only while Kad is connected, so a false
+# there is the absence of a measurement rather than "UDP is open". The TCP
+# side defaults the other way: true until two peers vouch for us.
+_assert_json_eq '(.state == "connected") or (.firewalled_udp | not)' \
+	true '/kad.firewalled_udp reads false while Kad is not connected'
 _assert_json_eq '.connected_since  | type' number  '/kad.connected_since is numeric'
 # Ours. Named apart from the buddy's address, which the rename must not touch.
 _assert_json_eq '.public_ip        | type' string  '/kad.public_ip is string'
@@ -154,6 +170,18 @@ _assert_json_eq '.network.users    | type' number  '/kad.network.users is numeri
 _assert_json_eq '.network.files    | type' number  '/kad.network.files is numeric'
 _assert_json_eq '.network.nodes    | type' number  '/kad.network.nodes is numeric'
 _assert_json_eq '.indexed.sources  | type' number  '/kad.indexed.sources is numeric'
+_assert_json_eq '.indexed.keywords | type' number  '/kad.indexed.keywords is numeric'
+_assert_json_eq '.indexed.notes    | type' number  '/kad.indexed.notes is numeric'
+# A load figure, not a count, despite sitting beside three counts.
+_assert_json_eq '.indexed.load     | type' number  '/kad.indexed.load is numeric'
+# The store counters ride on a tag amuled sends only while connected.
+_assert_json_eq '(.state == "connected") or (.indexed.sources == 0)' \
+	true '/kad.indexed.sources is 0 while Kad is not connected'
+# Two distinct "unknown" sentinels: "" while Kad is not connected, and a
+# syntactically valid 0.0.0.0 while connected but not yet told our address.
+_assert_json_eq '(.state == "connected") or (.public_ip == "")' \
+	true '/kad.public_ip is empty while Kad is not connected'
+_assert_json_eq '.buddy.port       | type' number  '/kad.buddy.port is numeric'
 _assert_json_eq '.buddy.status     | test("^(no_buddy|connecting|connected|unknown)$")' \
 	true '/kad.buddy.status is a known enum value'
 _assert_json_eq '.buddy.ip         | type' string  '/kad.buddy.ip survives the ip rename'

--- a/unittests/tests/EventDiffTest.cpp
+++ b/unittests/tests/EventDiffTest.cpp
@@ -267,18 +267,39 @@ TEST(EventDiff, StatusEventCarriesIdentityFields)
 	StatusSnapshot s;
 	s.ed2k_state = "connected";
 	s.ed2k_high_id = true;
-	s.ed2k_id = 1234567890u;
+	s.ed2k_user_id = 1234567890u;
 	s.ed2k_public_ip = "210.2.150.73";
 	s.download_overhead_bps = 8700;
 
 	const std::string payload = EmitStatusAndGetPayload(s);
 
 	ASSERT_TRUE(payload.find("\"high_id\":true") != std::string::npos);
-	ASSERT_TRUE(payload.find("\"id\":1234567890") != std::string::npos);
+	ASSERT_TRUE(payload.find("\"user_id\":1234567890") != std::string::npos);
 	ASSERT_TRUE(payload.find("\"public_ip\":\"210.2.150.73\"") != std::string::npos);
 	ASSERT_TRUE(payload.find("\"download_overhead_bps\":8700") != std::string::npos);
-	// The retired spelling must not linger anywhere in the payload.
+	// The retired spellings must not linger anywhere in the payload. A bare
+	// "id" would also match inside "user_id", so the quoted key is the test.
 	ASSERT_TRUE(payload.find("low_id") == std::string::npos);
+	ASSERT_TRUE(payload.find("\"id\":") == std::string::npos);
+}
+
+// The Kad firewall verdict is the one field on this payload a subscriber is
+// most likely to be watching for, and Equal(StatusSnapshot) is what decides
+// whether the event is published at all. Drop it from that comparator and a
+// firewall flip stops reaching subscribers entirely -- silently, since the
+// REST body keeps reporting the new value. Pinned here so a future edit to
+// the comparator cannot quietly lose it.
+TEST(EventDiff, StatusEventFiresWhenOnlyKadFirewalledTcpMoved)
+{
+	StatusSnapshot s;
+	s.kad_firewalled_tcp = true;
+
+	const std::string payload = EmitStatusAndGetPayload(s);
+
+	ASSERT_TRUE(!payload.empty());
+	ASSERT_TRUE(payload.find("\"firewalled_tcp\":true") != std::string::npos);
+	// The pre-rename spelling must not survive anywhere in the payload.
+	ASSERT_TRUE(payload.find("\"firewalled\":") == std::string::npos);
 }
 
 // A tick where only the overhead moved still has to fire: the field is in the

--- a/unittests/tests/RefresherTest.cpp
+++ b/unittests/tests/RefresherTest.cpp
@@ -2712,7 +2712,7 @@ TEST(Refresher, StatusHighIdLandsIdAndDottedQuad)
 
 	ASSERT_EQUALS(std::string("connected"), out.ed2k_state);
 	ASSERT_TRUE(out.ed2k_high_id);
-	ASSERT_EQUALS(static_cast<std::uint32_t>(1234567890u), out.ed2k_id);
+	ASSERT_EQUALS(static_cast<std::uint32_t>(1234567890u), out.ed2k_user_id);
 	ASSERT_EQUALS(std::string("210.2.150.73"), out.ed2k_public_ip);
 }
 
@@ -2731,7 +2731,7 @@ TEST(Refresher, StatusLowIdKeepsIdButHasNoPublicAddress)
 
 	ASSERT_EQUALS(std::string("connected"), out.ed2k_state);
 	ASSERT_TRUE(!out.ed2k_high_id);
-	ASSERT_EQUALS(static_cast<std::uint32_t>(42u), out.ed2k_id);
+	ASSERT_EQUALS(static_cast<std::uint32_t>(42u), out.ed2k_user_id);
 	ASSERT_TRUE(out.ed2k_public_ip.empty());
 }
 
@@ -2748,7 +2748,7 @@ TEST(Refresher, StatusConnectingSentinelNeverReachesTheSnapshot)
 	StatusSnapshot out;
 	ParseStatusFromPacket(&resp, out);
 
-	ASSERT_EQUALS(static_cast<std::uint32_t>(0u), out.ed2k_id);
+	ASSERT_EQUALS(static_cast<std::uint32_t>(0u), out.ed2k_user_id);
 	ASSERT_TRUE(out.ed2k_public_ip.empty());
 }
 
@@ -2766,7 +2766,7 @@ TEST(Refresher, StatusDisconnectedIsNotReportedAsLowId)
 
 	ASSERT_EQUALS(std::string("disconnected"), out.ed2k_state);
 	ASSERT_TRUE(!out.ed2k_high_id);
-	ASSERT_EQUALS(static_cast<std::uint32_t>(0u), out.ed2k_id);
+	ASSERT_EQUALS(static_cast<std::uint32_t>(0u), out.ed2k_user_id);
 	ASSERT_TRUE(out.ed2k_public_ip.empty());
 }
 

--- a/unittests/tests/StateTest.cpp
+++ b/unittests/tests/StateTest.cpp
@@ -112,13 +112,13 @@ TEST(State, WriteStatusRoundtrip)
 	in.ed2k_state = "connected";
 	in.kad_state = "connecting";
 	in.ed2k_high_id = true;
-	in.ed2k_id = 1234567890u; // 210.2.150.73 packed LSB-first
+	in.ed2k_user_id = 1234567890u; // 210.2.150.73 packed LSB-first
 	in.ed2k_public_ip = "210.2.150.73";
 	in.download_overhead_bps = 8700;
 	in.upload_overhead_bps = 1100;
 	in.temp_free_bytes = 48318382080LL;
 	in.incoming_free_bytes = -1; // unknown
-	in.kad_firewalled = false;
+	in.kad_firewalled_tcp = false;
 	in.server_name = "Some Server";
 	in.server_ip = "192.0.2.42";
 	in.server_port = 4242;
@@ -132,7 +132,7 @@ TEST(State, WriteStatusRoundtrip)
 	ASSERT_EQUALS(std::string("connected"), out.ed2k_state);
 	ASSERT_EQUALS(std::string("connecting"), out.kad_state);
 	ASSERT_TRUE(out.ed2k_high_id);
-	ASSERT_EQUALS(static_cast<std::uint32_t>(1234567890u), out.ed2k_id);
+	ASSERT_EQUALS(static_cast<std::uint32_t>(1234567890u), out.ed2k_user_id);
 	ASSERT_EQUALS(std::string("210.2.150.73"), out.ed2k_public_ip);
 	ASSERT_EQUALS(static_cast<std::uint64_t>(8700), out.download_overhead_bps);
 	ASSERT_EQUALS(static_cast<std::uint64_t>(1100), out.upload_overhead_bps);
@@ -140,7 +140,7 @@ TEST(State, WriteStatusRoundtrip)
 	// -1 must survive the round trip as -1: it is what the handler turns
 	// into JSON null, and an unsigned slot would make it 1.8e19.
 	ASSERT_EQUALS(static_cast<std::int64_t>(-1), out.incoming_free_bytes);
-	ASSERT_FALSE(out.kad_firewalled);
+	ASSERT_FALSE(out.kad_firewalled_tcp);
 	ASSERT_EQUALS(std::string("Some Server"), out.server_name);
 	ASSERT_EQUALS(std::string("192.0.2.42"), out.server_ip);
 	ASSERT_EQUALS(static_cast<std::uint32_t>(4242), out.server_port);
@@ -635,7 +635,7 @@ TEST(State, WriteKadAndPreferencesRoundtrip)
 	KadSnapshot k;
 	k.state = "connected";
 	k.users = 12345;
-	k.firewalled = true;
+	k.firewalled_tcp = true;
 	k.public_ip = "1.2.3.4";
 	k.node_id = "8f3a1c07d94b2e5a6018bb4c7f209d3e";
 	s.WriteKad(k);
@@ -669,7 +669,7 @@ TEST(State, WriteKadAndPreferencesRoundtrip)
 	const auto k_out = s.Kad();
 	ASSERT_EQUALS(std::string("connected"), k_out.state);
 	ASSERT_EQUALS(static_cast<std::uint32_t>(12345), k_out.users);
-	ASSERT_TRUE(k_out.firewalled);
+	ASSERT_TRUE(k_out.firewalled_tcp);
 	// The two string fields were written but never read back, so a
 	// rename could pass this test while dropping the value.
 	ASSERT_EQUALS(std::string("1.2.3.4"), k_out.public_ip);


### PR DESCRIPTION
Closes #1168.

Three field names on the `/api/v0` surface did not say what the value was. Each is renamed across every producer, every consumer and both docs.

| current | new | where |
|---|---|---|
| `kad.firewalled` | `kad.firewalled_tcp` | `GET /status`, `GET /kad`, SSE `status_changed` |
| `ed2k.id` | `ed2k.user_id` | `GET /status`, SSE `status_changed` |
| `in_lan_mode` | `lan_mode` | `GET /kad` |

## Why `firewalled` was the wrong name

It is specifically the **TCP** verdict, not an overall one that `firewalled_udp` refines. Both `/status` `kad.firewalled` and `/kad` `firewalled` come from the same `IsKadFirewalled()` call, bit `0x08` of `EC_TAG_CONNSTATE`, which amuled sets from `Kademlia::CKademlia::IsFirewalled()`. That verdict is a **vote**: `m_firewalled < 2` means firewalled, so two distinct peers must confirm reachability, and the vote is cast by an incoming **TCP** connection carrying `OP_KAD_FWTCPCHECK_ACK`. `firewalled_udp` is a separate mechanism with its own state that can also declare firewalled by timeout after six minutes.

The Web UI was already working around the name: its helper parameter is called `firewalled_tcp` and the row label reads "Firewalled (TCP)". The codebase had renamed it everywhere except the wire.

All three surfaces move together, since `GET /kad` is documented as a standalone view of the Kad subtree from `/status` and the SSE payload is a mirror of `GET /status`.

## The `user_id` caveat

`ed2k.user_id` and the peer-side `user_id_hybrid` on `GET /clients/{ecid}` are **not the same encoding**, and the new name invites exactly that assumption. `REFERENCE.md` now says so explicitly: ours is stored as the server sent it and read least-significant-byte-first to produce `public_ip`, while a peer's HighID is byte-swapped on the way in (`SetUserIDHybrid(wxUINT32_SWAP_ALWAYS(in_userid))`). A consumer that compares the two, or feeds one through the other's IP decoder, gets a reversed address. The `>= 16777216` HighID threshold is common to both; the byte order is not.

## `/kad` documentation

The field table documented 4 of its 10 fields. It now covers all ten, including the two things most likely to be misread:

- The firewalled pair **defaults in opposite directions**. `firewalled_tcp` is `true` with no verdict (conservative); `firewalled_udp` is `false` when Kad is down, because amuled sends the test result only while connected, which is the absence of a measurement rather than an open port. A consumer reading both while Kad is disconnected sees `true` / `false` and neither value means anything.
- `lan_mode` **forces both flags to `false`** regardless of any measurement, so a `false` on either is only meaningful once you have checked it.

`public_ip`'s row now states that one of its two "unknown" sentinels is a syntactically valid `0.0.0.0`.

## Tests

Not listed in the issue's scope, but the field names are asserted in five files that would otherwise go red.

The `03` and `05` assertions move to the new names and each gains a `has(...)` check that the old spelling is **gone** rather than merely shadowed by the new one. `05` also gains coverage for the six `/kad` fields that had none, and for the LAN-mode invariant.

`EventDiffTest` gains `StatusEventFiresWhenOnlyKadFirewalledTcpMoved`. `Equal(StatusSnapshot)` decides whether `status_changed` is published at all, so dropping the field from that comparator stops a firewall flip reaching subscribers while the REST body keeps reporting the new value. Mutation-checked: removing the comparison reddens exactly that case and nothing else.

## Verification

Against a live amuled on macOS, connected to `!! Sharing-Devils No.2 !!` (LowID), server confirmed before and after the run:

- Unit tests: **43/43**.
- Curl phases `03`, `05`, `22`: **159/159 assertions, all phases passed**, including all 15 new or renamed ones confirmed present in the output by label.
- SSE `status_changed` key set diffed against `GET /status` key-for-key: identical. `22-sse-diff-emission` already asserts that parity dynamically and needed no edit; its assertion passed.
- `clang-format` 18 whole-file over the 7 changed C++ files: 0 violations.
- `clang-tidy` Tier-1 and Tier-2 on the diff: 0 findings, 0 compiler errors.
- `REFERENCE.md` / `EVENTS.md`: no new broken anchors.

The suite was run twice in different daemon states, which covered both sides of the new conditional assertions: once with Kad at `connecting` (exercising `firewalled_udp` reading `false` with Kad down, `indexed.*` at zero, and `public_ip` empty) and once fully connected. The disconnected run showed `firewalled_tcp: true` beside `firewalled_udp: false` live, which is exactly the asymmetry the new documentation warns about.

## Not included

The issue asks that the `Backward compatibility` section of `REFERENCE.md` be reconciled with these renames. It is a placeholder for the first stable version rather than a live constraint on v0, so it is left untouched.
