### PR TITLE
fix(amuleapi): bound the preference fields whose declared range the core cannot hold

### DIFF
--- a/docs/api/REFERENCE.md
+++ b/docs/api/REFERENCE.md
@@ -2251,6 +2251,24 @@ amuleapi's own `admin` and `guest` passwords are **not** settable here; `remote_
 
 **Response:** `200 OK` — full preferences object (post-mutation), so a read-modify-write client can confirm what landed without a follow-up GET.
 
+**Numeric fields are bounded to what the daemon can actually hold**, not to the width of their JSON type. A value outside the range is a `400` naming the range; it is never accepted and quietly changed. Several of these bounds are much narrower than they look, because the core stores the setting differently from how the API spells it:
+
+| Field | Range | Step | Why |
+|---|---|---|---|
+| `connection.tcp_port` | `1`–`65532` | | the server UDP socket is TCP+3, and the core substitutes the default port for anything higher |
+| `core_tweaks.file_buffer_bytes` | `0`–`3825000` | `15000` | stored as a `uint8` count of 15000-byte blocks |
+| `core_tweaks.max_upload_queue_clients` | `0`–`25500` | `100` | stored as a `uint8` count of hundreds |
+| `core_tweaks.max_new_connections_per_5s` | `0`–`65535` | | stored as a `uint16` |
+| `core_tweaks.kad_max_source_searches` | `5`–`50` | | clamped to this range at daemon start |
+| `core_tweaks.kad_reask_minutes` | `30`–`60` | | clamped to this range at daemon start |
+| `core_tweaks.source_reask_minutes` | `15`–`60` | | clamped to this range at daemon start; below it the UDP reask gets you auto-banned for reask spam |
+
+The two fields with a **step** accept only whole multiples of it: `file_buffer_bytes: 20000` is a `400`, not a silent round down to `15000`. The names stay in the unit you think in rather than being renamed to the daemon's internal one, and the price is that the API is strict about the values in between.
+
+The three **clamped at daemon start** rows are the reason this is enforced on the write rather than left to the client to check. Their setters assign the value raw, so a `GET` right after the `PATCH` reports it back faithfully and only the next restart reveals that the daemon never kept it.
+
+**A low `connection.max_upload_kbps` caps `max_download_kbps`,** which is the one place a `PATCH` changes a field the request did not name. Below `4` kB/s up the download limit is forced to 3× the upload; below `10` it is forced to 4×. So `PATCH {"connection": {"max_upload_kbps": 3}}` also sets `max_download_kbps` to `9`. This is a deliberate anti-leech rule in the core rather than a defect, it applies whichever of the two you write, and the `PATCH` response echoes the whole preferences object so the adjusted value is visible in the reply.
+
 **Errors:** `400 bad_request` (unknown/mis-typed field, or a body with no recognized fields), `400 amuled_rejected`, `503 ec_unavailable`.
 
 ---

--- a/src/webapi/Api.cpp
+++ b/src/webapi/Api.cpp
@@ -8151,7 +8151,9 @@ bool PrefTakeUint(const picojson::object &o,
 	CECTag &group,
 	const char *key,
 	ec_tagname_t name,
+	std::uint32_t min,
 	std::uint32_t max,
+	std::uint32_t step,
 	bool &any,
 	std::string &err,
 	std::uint32_t scale)
@@ -8164,8 +8166,20 @@ bool PrefTakeUint(const picojson::object &o,
 		return false;
 	}
 	const double v = it->second.get<double>();
-	if (v < 0 || v > static_cast<double>(max)) {
-		err = std::string(key) + " out of range";
+	if (v < 0 || v > static_cast<double>(max) || v < static_cast<double>(min)) {
+		// Name the bounds. These domains are narrower than the field's type for
+		// reasons a caller cannot infer -- a uint8 behind a byte count, a clamp
+		// that does not run until the next daemon start -- so "out of range"
+		// alone leaves them guessing which end they hit and by how much.
+		err = std::string(key) + " out of range (" + std::to_string(min) + "-" + std::to_string(max) +
+		      ")";
+		return false;
+	}
+	// Quantised rows: the core's setter divides, so a value between two steps
+	// is truncated on the way in. Rejected rather than silently rounded, so the
+	// value a client writes is always the value stored.
+	if (step && (static_cast<std::uint64_t>(v) % step) != 0) {
+		err = std::string(key) + " must be a multiple of " + std::to_string(step);
 		return false;
 	}
 	const std::uint64_t scaled = static_cast<std::uint64_t>(v) * (scale ? scale : 1u);
@@ -8474,7 +8488,8 @@ CHttpServer::Response CApiDispatcher::HandlePreferencesPatch(const CHttpServer::
 			break;
 		case webapi::PrefType::Uint16:
 		case webapi::PrefType::Uint32:
-			ok = PrefTakeUint(*src, g, f.key, f.tag, f.max, any_change, err, f.ec_scale);
+			ok = PrefTakeUint(
+				*src, g, f.key, f.tag, f.min, f.max, f.step, any_change, err, f.ec_scale);
 			break;
 		case webapi::PrefType::String:
 			ok = PrefTakeString(*src, g, f.key, f.tag, any_change, err);

--- a/src/webapi/PrefsSchema.cpp
+++ b/src/webapi/PrefsSchema.cpp
@@ -80,6 +80,23 @@ const char *const kIp2CountrySources[] = { "dbip", "maxmind", "custom", nullptr 
 #define PREF_U32_SCALED(cat, key, tag, maxv, acc, memb, scale) \
 	{cat, key, tag, PrefType::Uint32, PrefEnc::Value, false, acc, maxv, nullptr, nullptr, PREF_MEMBER(memb, std::uint32_t), 0, scale}
 
+// Numeric rows whose real domain is narrower than their type. `minv`/`maxv` are
+// both inclusive and both rejected with a 400; `stepv` is the granularity the
+// core stores at, 0 when the row is not quantised. See the notes on
+// PrefField::min and ::step for why this is declared rather than clamped.
+#define PREF_U32_DOMAIN(cat, key, tag, minv, maxv, stepv, acc, memb) \
+	{cat, key, tag, PrefType::Uint32, PrefEnc::Value, false, acc, maxv, nullptr, nullptr, \
+		PREF_MEMBER(memb, std::uint32_t), 0, 0, minv, stepv}
+
+#define PREF_U16_DOMAIN(cat, key, tag, minv, maxv, acc, memb) \
+	{cat, key, tag, PrefType::Uint16, PrefEnc::Value, false, acc, maxv, nullptr, nullptr, \
+		PREF_MEMBER(memb, std::uint16_t), 0, 0, minv, 0}
+
+// Scaled and bounded: bounds are in the API's unit, applied before scaling.
+#define PREF_U32_SCALED_DOMAIN(cat, key, tag, minv, maxv, acc, memb, scale) \
+	{cat, key, tag, PrefType::Uint32, PrefEnc::Value, false, acc, maxv, nullptr, nullptr, \
+		PREF_MEMBER(memb, std::uint32_t), 0, scale, minv, 0}
+
 #define PREF_STR(cat, key, tag, acc, memb) \
 	{cat, key, tag, PrefType::String, PrefEnc::Value, false, acc, 0u, nullptr, nullptr, PREF_MEMBER(memb, std::string), 0}
 
@@ -132,7 +149,10 @@ const PrefField kSchema[] = {
 	PREF_ENUM("connection", "proxy_type", EC_TAG_PROXY_TYPE, kProxyTypes, PrefAccess::ReadWrite, proxy_type),
 	PREF_STR("connection", "proxy_user", EC_TAG_PROXY_USER, PrefAccess::ReadWrite, proxy_user),
 	PREF_BOOL("connection", "reconnect", EC_TAG_CONN_RECONNECT, PrefEnc::Presence, false, PrefAccess::ReadWrite, reconnect),
-	PREF_U16("connection", "tcp_port", EC_TAG_CONN_TCP_PORT, 65535u, PrefAccess::ReadWrite, tcp_port),
+	// 65532, not 65535: SetPort() substitutes DEFAULT_TCP_PORT when val + 3
+	// exceeds 65535, because the server UDP socket is TCP+3. A 65534 here was a
+	// 200 that left the daemon listening on 4662.
+	PREF_U16_DOMAIN("connection", "tcp_port", EC_TAG_CONN_TCP_PORT, 1u, 65532u, PrefAccess::ReadWrite, tcp_port),
 	PREF_U16("connection", "udp_port", EC_TAG_CONN_UDP_PORT, 65535u, PrefAccess::ReadWrite, udp_port),
 	PREF_U32("connection", "upload_slot_kbps", EC_TAG_CONN_SLOT_ALLOCATION, 65535u, PrefAccess::ReadWrite, upload_slot_kbps),
 	PREF_BOOL_INGROUP("connection", "upnp_available", EC_TAG_GENERAL_UPNP_AVAILABLE, PrefEnc::Value, PrefAccess::ReadOnly, upnp_available, EC_TAG_PREFS_GENERAL),
@@ -245,13 +265,21 @@ const PrefField kSchema[] = {
 	PREF_U32("online_signature", "update_frequency_seconds", EC_TAG_ONLINESIG_UPDATE, 65535u, PrefAccess::ReadWrite, online_signature.update_frequency_seconds),
 
 	// [core_tweaks]
-	PREF_U32("core_tweaks", "file_buffer_bytes", EC_TAG_CORETW_FILEBUFFER, 0xFFFFFFFFu, PrefAccess::ReadWrite, core_tweaks.file_buffer_bytes),
-	PREF_U32("core_tweaks", "kad_max_source_searches", EC_TAG_CORETW_KAD_MAX_SEARCHES, 0xFFFFFFFFu, PrefAccess::ReadWrite, core_tweaks.kad_max_source_searches),
-	PREF_U32_SCALED("core_tweaks", "kad_reask_minutes", EC_TAG_CORETW_KAD_REASK_MS, 71582u, PrefAccess::ReadWrite, core_tweaks.kad_reask_minutes, 60000u),
-	PREF_U32("core_tweaks", "max_new_connections_per_5s", EC_TAG_CORETW_MAX_CONN_PER_FIVE, 0xFFFFFFFFu, PrefAccess::ReadWrite, core_tweaks.max_new_connections_per_5s),
-	PREF_U32("core_tweaks", "max_upload_queue_clients", EC_TAG_CORETW_UL_QUEUE, 0xFFFFFFFFu, PrefAccess::ReadWrite, core_tweaks.max_upload_queue_clients),
+	// s_iFileBufferSize is a uint8 holding val/15000, so the domain is 255
+	// blocks of 15000 bytes and nothing between them.
+	PREF_U32_DOMAIN("core_tweaks", "file_buffer_bytes", EC_TAG_CORETW_FILEBUFFER, 0u, 3825000u, 15000u, PrefAccess::ReadWrite, core_tweaks.file_buffer_bytes),
+	// LoadAllItems() clamps this to 5..50 on the next start, so anything else
+	// was a value GET reported until the daemon was restarted.
+	PREF_U32_DOMAIN("core_tweaks", "kad_max_source_searches", EC_TAG_CORETW_KAD_MAX_SEARCHES, 5u, 50u, 0u, PrefAccess::ReadWrite, core_tweaks.kad_max_source_searches),
+	PREF_U32_SCALED_DOMAIN("core_tweaks", "kad_reask_minutes", EC_TAG_CORETW_KAD_REASK_MS, 30u, 60u, PrefAccess::ReadWrite, core_tweaks.kad_reask_minutes, 60000u),
+	// s_MaxConperFive is a uint16; 70000 wrapped to 4464.
+	PREF_U32_DOMAIN("core_tweaks", "max_new_connections_per_5s", EC_TAG_CORETW_MAX_CONN_PER_FIVE, 0u, 65535u, 0u, PrefAccess::ReadWrite, core_tweaks.max_new_connections_per_5s),
+	// s_iQueueSize is a uint8 holding val/100: 255 hundreds, nothing between.
+	PREF_U32_DOMAIN("core_tweaks", "max_upload_queue_clients", EC_TAG_CORETW_UL_QUEUE, 0u, 25500u, 100u, PrefAccess::ReadWrite, core_tweaks.max_upload_queue_clients),
 	PREF_U32_SCALED("core_tweaks", "server_keepalive_timeout_minutes", EC_TAG_CORETW_SRV_KEEPALIVE_TIMEOUT, 71582u, PrefAccess::ReadWrite, core_tweaks.server_keepalive_timeout_minutes, 60000u),
-	PREF_U32_SCALED("core_tweaks", "source_reask_minutes", EC_TAG_CORETW_SOURCE_REASK_MS, 71582u, PrefAccess::ReadWrite, core_tweaks.source_reask_minutes, 60000u),
+	// The 15-minute floor is load-bearing: the UDP reask goes out at
+	// getter - 20s, and below ~10 min peers auto-ban for reask spam.
+	PREF_U32_SCALED_DOMAIN("core_tweaks", "source_reask_minutes", EC_TAG_CORETW_SOURCE_REASK_MS, 15u, 60u, PrefAccess::ReadWrite, core_tweaks.source_reask_minutes, 60000u),
 	PREF_BOOL("core_tweaks", "verbose_logging", EC_TAG_CORETW_VERBOSE, PrefEnc::Presence, false, PrefAccess::ReadWrite, core_tweaks.verbose_logging),
 
 	// [kademlia]

--- a/src/webapi/PrefsSchema.h
+++ b/src/webapi/PrefsSchema.h
@@ -119,6 +119,27 @@ struct PrefField
 	// accepted, reported as success, changed underneath. The API therefore
 	// speaks the unit the daemon can actually hold, and converts here.
 	std::uint32_t ec_scale;
+	// Inclusive lower bound for Uint16 / Uint32, checked with `max` against the
+	// value the caller sent. 0 for a row with no floor, which is most of them.
+	//
+	// `max` alone is not a domain. A core member narrower than the declared
+	// ceiling wraps, and a setter that divides truncates, so a value inside
+	// [0, max] can still be rewritten on the way in -- and three of these
+	// fields are clamped by CPreferences::LoadAllItems() at the NEXT daemon
+	// start, which no amount of read-back checking after the PATCH can see.
+	// The bound belongs here, declaratively, where it cannot race a snapshot.
+	std::uint32_t min;
+	// Granularity the core can actually store, when its setter divides. A value
+	// that is not a multiple is a 400 naming the step, rather than a silent
+	// truncation: SetFileBufferSize() is `val / 15000` into a uint8, so 20000
+	// becomes 15000 and 14999 becomes 0. 0 means the row is not quantised.
+	//
+	// Rejecting rather than renaming the field to its stored unit is deliberate
+	// and is the opposite of what #1159 chose for the three `_minutes` rows.
+	// Those quantised to a unit a user already thinks in, so the rename cost
+	// nothing; nobody thinks in 15000-byte blocks, and `file_buffer_blocks`
+	// would push an implementation detail into the API's vocabulary.
+	std::uint32_t step;
 };
 
 // EC group tag each category packs into. Two categories intentionally share

--- a/src/webapi/static/js/views/preferences.js
+++ b/src/webapi/static/js/views/preferences.js
@@ -68,7 +68,9 @@ const TABS = [
       { key: "upload_slot_kbps", type: "int", min: 1, max: 100000 },
     ] },
     { legendKey: "prefs_group_ports", fields: [
-      { key: "tcp_port", type: "int", min: 0, max: 65535 },
+      // 65532, not 65535: the server UDP socket is TCP+3, and the core
+      // substitutes the default port for anything higher.
+      { key: "tcp_port", type: "int", min: 1, max: 65532 },
       // Not an API field: the desktop shows the server-request UDP port, which
       // the core derives as TCP+3. Computed, read-only, never sent.
       { key: "udp_server_port", type: "int", readonly: true,
@@ -260,14 +262,14 @@ const TABS = [
   ] },
   { id: "core_tweaks", labelKey: "prefs_core_tweaks", cat: "core_tweaks", noteKey: "prefs_core_tweaks_warning", groups: [
     { legendKey: "prefs_group_tweaks", fields: [
-      { key: "max_new_connections_per_5s", type: "int", min: 0 },
-      { key: "kad_max_source_searches", type: "int", min: 0 },
-      { key: "kad_reask_minutes", type: "int", min: 0 },
-      { key: "source_reask_minutes", type: "int", min: 0 },
-      { key: "file_buffer_bytes", type: "int", min: 0 },
+      { key: "max_new_connections_per_5s", type: "int", min: 0, max: 65535 },
+      { key: "kad_max_source_searches", type: "int", min: 5, max: 50 },
+      { key: "kad_reask_minutes", type: "int", min: 30, max: 60 },
+      { key: "source_reask_minutes", type: "int", min: 15, max: 60 },
+      { key: "file_buffer_bytes", type: "int", min: 0, max: 3825000, step: 15000 },
       { key: "mmap_enabled", type: "bool", cat: "files", gatedBy: "mmap_supported" },
       { key: "mmap_supported", type: "bool", cat: "files", hidden: true },
-      { key: "max_upload_queue_clients", type: "int", min: 0 },
+      { key: "max_upload_queue_clients", type: "int", min: 0, max: 25500, step: 100 },
       // Stored in ms, shown in minutes like the desktop slider (0-30).
       { key: "server_keepalive_timeout_minutes", type: "int", min: 0, max: 30 },
       { key: "verbose_logging", type: "bool" },
@@ -489,7 +491,7 @@ export default function Preferences({ isGuest }) {
       <input class="input" id=${id} disabled=${disabled}
              type=${f.type === "int" ? "number" : f.type === "password" ? "password" : "text"}
              autocomplete=${f.type === "password" ? "new-password" : null}
-             min=${f.min} max=${f.max}
+             min=${f.min} max=${f.max} step=${f.step}
              value=${val === undefined || val === null ? "" : val} onInput=${(e) => setVal(id, e.target.value)} />`;
     return html`
       <div class=${"field" + subCls}>
@@ -541,7 +543,12 @@ export default function Preferences({ isGuest }) {
           } else if (f.type === "bool") {
             out = !!val;
           } else if (f.type === "int") {
-            const n = clamp(f.scale ? (parseFloat(val) || 0) : (parseInt(val, 10) || 0), f.min, f.max);
+            let n = clamp(f.scale ? (parseFloat(val) || 0) : (parseInt(val, 10) || 0), f.min, f.max);
+            // Snap to the granularity the core stores at. These fields are
+            // backed by a uint8 the daemon multiplies back up, so the API
+            // rejects a value between two steps rather than truncating it;
+            // rounding here means the form cannot produce that 400.
+            if (f.step) n = clamp(Math.round(n / f.step) * f.step, f.min, f.max);
             out = Math.round(n * (f.scale || 1));
           } else {
             out = val == null ? "" : val;

--- a/unittests/curl-tests/amuleapi/15-preferences-patch.sh
+++ b/unittests/curl-tests/amuleapi/15-preferences-patch.sh
@@ -174,10 +174,30 @@ _curl -X PATCH -H "Authorization: Bearer $ADMIN_TOKEN" \
 	-d '{"connection":{"max_upload_kbps":"forty-two"}}' "$HOST/api/v0/preferences"
 _assert_status 400 "PATCH max_upload_kbps as string → 400"
 
+# Saved because the 65532 probe below is a real write: leaving the daemon's
+# ed2k port on the ceiling would outlive the script.
+_curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/preferences"
+SAVED_TCPPORT=$(printf '%s' "$CURL_BODY" | jq -r '.connection.tcp_port')
+
 _curl -X PATCH -H "Authorization: Bearer $ADMIN_TOKEN" \
 	-H "Content-Type: application/json" \
 	-d '{"connection":{"tcp_port":99999}}' "$HOST/api/v0/preferences"
-_assert_status 400 "PATCH tcp_port out of range (>65535) → 400"
+_assert_status 400 "PATCH tcp_port out of range (>65532) → 400"
+
+# 65533..65535 parse as a port but the core cannot use them: SetPort()
+# substitutes DEFAULT_TCP_PORT when val + 3 exceeds 65535, because the server
+# UDP socket is TCP+3. A 200 here meant the daemon listened on 4662 instead
+# (#1174).
+_curl -X PATCH -H "Authorization: Bearer $ADMIN_TOKEN" \
+	-H "Content-Type: application/json" \
+	-d '{"connection":{"tcp_port":65534}}' "$HOST/api/v0/preferences"
+_assert_status 400 "PATCH tcp_port=65534 → 400 (TCP+3 would overflow)"
+_curl -X PATCH -H "Authorization: Bearer $ADMIN_TOKEN" \
+	-H "Content-Type: application/json" \
+	-d '{"connection":{"tcp_port":65532}}' "$HOST/api/v0/preferences"
+_assert_status 200 "PATCH tcp_port=65532 → 200 (the real ceiling)"
+_curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/preferences"
+_assert_json_eq '.connection.tcp_port' 65532 "tcp_port=65532 reads back unchanged"
 
 _curl -X PATCH -H "Authorization: Bearer $ADMIN_TOKEN" \
 	-H "Content-Type: application/json" \
@@ -486,23 +506,34 @@ _assert_json_eq '.connection.autoconnect' "$SAVED_AUTOCONNECT" \
 # expose that raw: a client writing 90000 read back 60000, and one writing
 # 30000 read back 0 -- accepted, reported as success, changed underneath. The
 # fields speak minutes now, so what goes in comes back.
-for FIELD in kad_reask_minutes source_reask_minutes; do
+# The probe values sit INSIDE each field's supported range and are not the
+# range's own endpoints, so they prove the value is carried rather than snapped
+# to a bound: LoadAllItems() clamps kad_reask to 30..60 and source_reask to
+# 15..60 at the next daemon start, and 7 -- what this loop used to send -- is
+# below both (#1174).
+for FIELD_PROBE in "kad_reask_minutes 31" "source_reask_minutes 16"; do
+	set -- $FIELD_PROBE
+	FIELD=$1
+	VALUE=$2
 	_curl -X PATCH -H "Authorization: Bearer $ADMIN_TOKEN" \
 		-H "Content-Type: application/json" \
-		-d "{\"core_tweaks\":{\"$FIELD\":7}}" "$HOST/api/v0/preferences"
-	_assert_status 200 "PATCH core_tweaks.$FIELD=7 -> 200"
+		-d "{\"core_tweaks\":{\"$FIELD\":$VALUE}}" "$HOST/api/v0/preferences"
+	_assert_status 200 "PATCH core_tweaks.$FIELD=$VALUE -> 200"
 	_curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/preferences"
-	_assert_json_eq ".core_tweaks.$FIELD" 7 "core_tweaks.$FIELD reads back what was written"
+	_assert_json_eq ".core_tweaks.$FIELD" "$VALUE" "core_tweaks.$FIELD reads back what was written"
 done
 
-# The value that used to vanish: 0 is a legitimate setting, and a small
-# non-zero one must not truncate to it.
+# One minute used to be a 200 that the daemon threw away at the next start --
+# LoadAllItems() clamps this field up to 30. The old assertion here checked the
+# right property (a small value is not truncated to 0 by the ms->minutes
+# conversion) with a probe outside the core's range, so it passed on a value
+# the daemon would not keep. Below the floor is a 400 now (#1174).
 _curl -X PATCH -H "Authorization: Bearer $ADMIN_TOKEN" \
 	-H "Content-Type: application/json" \
 	-d '{"core_tweaks":{"kad_reask_minutes":1}}' "$HOST/api/v0/preferences"
-_assert_status 200 "PATCH core_tweaks.kad_reask_minutes=1 -> 200"
+_assert_status 400 "PATCH core_tweaks.kad_reask_minutes=1 -> 400 (below the 30 floor)"
 _curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/preferences"
-_assert_json_eq '.core_tweaks.kad_reask_minutes' 1 "one minute survives (was truncated to 0 as 30000 ms)"
+_assert_json_eq '.core_tweaks.kad_reask_minutes' 31 "the rejected write left the previous value alone"
 
 # --- online_signature.update_frequency_seconds is bounded (#1159 section 4).
 #
@@ -524,6 +555,79 @@ _curl -X PATCH -H "Authorization: Bearer $ADMIN_TOKEN" \
 	"$HOST/api/v0/preferences"
 _assert_status 200 "PATCH online_signature.update_frequency_seconds=65535 -> 200"
 
+# Saved before the boundary sweep below, which leaves every field it touches on
+# an endpoint. Restored with the rest at the end of the file.
+_curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/preferences"
+SAVED_FILEBUF=$(printf '%s' "$CURL_BODY" | jq -r '.core_tweaks.file_buffer_bytes')
+SAVED_ULQUEUE=$(printf '%s' "$CURL_BODY" | jq -r '.core_tweaks.max_upload_queue_clients')
+SAVED_CONN5=$(printf '%s' "$CURL_BODY" | jq -r '.core_tweaks.max_new_connections_per_5s')
+SAVED_KADSEARCH=$(printf '%s' "$CURL_BODY" | jq -r '.core_tweaks.kad_max_source_searches')
+SAVED_MAXUL=$(printf '%s' "$CURL_BODY" | jq -r '.connection.max_upload_kbps')
+SAVED_MAXDL=$(printf '%s' "$CURL_BODY" | jq -r '.connection.max_download_kbps')
+
+# --- #1174: every numeric domain that is narrower than its type. ---
+#
+# Each row was measured against a live daemon before the bounds landed: the
+# write was a 200 and the value came back changed, by integer division, by a
+# uint8/uint16 wrap, or by a clamp that does not run until the next start.
+# Appended at the end of the file on purpose -- the sections here share one
+# daemon, and these leave preferences at their boundary values.
+#
+# reject: the value, and what the daemon used to turn it into.
+for CASE in \
+	"core_tweaks file_buffer_bytes 4000000 150000_uint8_wrap" \
+	"core_tweaks file_buffer_bytes 14999 0_divided_away" \
+	"core_tweaks file_buffer_bytes 20000 15000_truncated_to_the_step" \
+	"core_tweaks max_upload_queue_clients 30000 4400_uint8_wrap" \
+	"core_tweaks max_upload_queue_clients 250 200_truncated_to_the_step" \
+	"core_tweaks max_new_connections_per_5s 70000 4464_uint16_wrap" \
+	"core_tweaks kad_max_source_searches 100000 34464_uint16_wrap" \
+	"core_tweaks kad_max_source_searches 1 5_clamped_at_next_start" \
+	"core_tweaks source_reask_minutes 7 15_clamped_at_next_start" \
+	; do
+	set -- $CASE
+	_curl -X PATCH -H "Authorization: Bearer $ADMIN_TOKEN" \
+		-H "Content-Type: application/json" \
+		-d "{\"$1\":{\"$2\":$3}}" "$HOST/api/v0/preferences"
+	_assert_status 400 "PATCH $1.$2=$3 -> 400 (was silently $4)"
+done
+
+# accept: the domain's own endpoints, which must round-trip untouched. A bound
+# that rejects its own boundary is the failure mode this half guards.
+for CASE in \
+	"core_tweaks file_buffer_bytes 3825000" \
+	"core_tweaks file_buffer_bytes 15000" \
+	"core_tweaks file_buffer_bytes 0" \
+	"core_tweaks max_upload_queue_clients 25500" \
+	"core_tweaks max_upload_queue_clients 100" \
+	"core_tweaks max_new_connections_per_5s 65535" \
+	"core_tweaks kad_max_source_searches 5" \
+	"core_tweaks kad_max_source_searches 50" \
+	"core_tweaks source_reask_minutes 15" \
+	"core_tweaks source_reask_minutes 60" \
+	"core_tweaks kad_reask_minutes 30" \
+	"core_tweaks kad_reask_minutes 60" \
+	; do
+	set -- $CASE
+	_curl -X PATCH -H "Authorization: Bearer $ADMIN_TOKEN" \
+		-H "Content-Type: application/json" \
+		-d "{\"$1\":{\"$2\":$3}}" "$HOST/api/v0/preferences"
+	_assert_status 200 "PATCH $1.$2=$3 -> 200 (domain boundary)"
+	_curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/preferences"
+	_assert_json_eq ".$1.$2" "$3" "$1.$2=$3 reads back unchanged"
+done
+
+# The cross-field rewrite is documented rather than rejected: a low upload cap
+# forces the download cap to 3x (below 4 kB/s) or 4x (below 10). Asserted so
+# the documented behaviour has a test, and so a future change to CheckUlDlRatio
+# cannot alter it silently.
+_curl -X PATCH -H "Authorization: Bearer $ADMIN_TOKEN" \
+	-H "Content-Type: application/json" \
+	-d '{"connection":{"max_upload_kbps":3,"max_download_kbps":100}}' \
+	"$HOST/api/v0/preferences"
+_assert_status 200 "PATCH max_upload_kbps=3 -> 200"
+_assert_json_eq '.connection.max_download_kbps' 9 \
+	"a sub-4 kB/s upload cap forces max_download_kbps to 3x, echoed in the PATCH reply"
 # --- Restore what the two #1159 probes above changed. --------------
 #
 # Section 6 restores before those probes run, so the last writes of the script
@@ -532,9 +636,12 @@ _assert_status 200 "PATCH online_signature.update_frequency_seconds=65535 -> 200
 # This has to stay the last mutation in the file.
 _curl -X PATCH -H "Authorization: Bearer $ADMIN_TOKEN" \
 	-H "Content-Type: application/json" \
-	-d "{\"core_tweaks\":{\"kad_reask_minutes\":$SAVED_KADREASK,\"source_reask_minutes\":$SAVED_SRCREASK},\"online_signature\":{\"update_frequency_seconds\":$SAVED_OSFREQ}}" \
+	-d "{\"core_tweaks\":{\"kad_reask_minutes\":$SAVED_KADREASK,\"source_reask_minutes\":$SAVED_SRCREASK,\"file_buffer_bytes\":$SAVED_FILEBUF,\"max_upload_queue_clients\":$SAVED_ULQUEUE,\"max_new_connections_per_5s\":$SAVED_CONN5,\"kad_max_source_searches\":$SAVED_KADSEARCH},\"connection\":{\"tcp_port\":$SAVED_TCPPORT,\"max_upload_kbps\":$SAVED_MAXUL,\"max_download_kbps\":$SAVED_MAXDL},\"online_signature\":{\"update_frequency_seconds\":$SAVED_OSFREQ}}" \
 	"$HOST/api/v0/preferences"
-_assert_status 200 "PATCH (restore core_tweaks intervals + onlinesig interval) -> 200"
+_assert_status 200 "PATCH (restore core_tweaks + connection + onlinesig) -> 200"
+_curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/preferences"
+_assert_json_eq '.connection.tcp_port' "$SAVED_TCPPORT" \
+	'restored connection.tcp_port to the saved value'
 _curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/preferences"
 _assert_json_eq '.core_tweaks.kad_reask_minutes' "$SAVED_KADREASK" \
 	'restored core_tweaks.kad_reask_minutes to the saved value'

--- a/unittests/tests/RefresherTest.cpp
+++ b/unittests/tests/RefresherTest.cpp
@@ -28,6 +28,7 @@
 
 #include "PrefsSchema.h"
 #include "Server.h" // SRV_PR_*
+#include "PrefsSchema.h"
 #include "Refresher.h"
 #include "State.h"
 
@@ -48,6 +49,10 @@ using namespace muleunit;
 using namespace webapi;
 
 DECLARE_SIMPLE(Refresher)
+// Own suite: the preference-schema domain guards below are about
+// PrefsSchema.cpp, which this target already compiles and links, not about the
+// EC walkers the rest of the file covers.
+DECLARE_SIMPLE(PrefsSchema)
 
 // ----------------------------------------------------------------------
 // EC_TAG_FILE_REMOVED — INC-protocol deletion marker. With GET_UPDATE
@@ -2823,4 +2828,76 @@ TEST(Refresher, StatusWithoutStatsTagsKeepsZeroOverheadAndUnknownDisk)
 	ASSERT_EQUALS(static_cast<std::uint64_t>(0), out.upload_overhead_bps);
 	ASSERT_EQUALS(static_cast<std::int64_t>(-1), out.temp_free_bytes);
 	ASSERT_EQUALS(static_cast<std::int64_t>(-1), out.incoming_free_bytes);
+}
+
+// ----------------------------------------------------------------------
+// Preference schema domains (#1174).
+//
+// The schema's bounds and the core's storage limits are two copies of one
+// fact, and nothing used to fail when they drifted apart: eight fields
+// declared a range wider than what CPreferences could hold, so a PATCH inside
+// the declared range was accepted, answered 200, and the value was changed by
+// integer division, by a uint8/uint16 wrap, or by a clamp that did not run
+// until the next daemon start.
+//
+// These assert the properties that are checkable from the schema alone. They
+// deliberately do not restate each field's numbers -- a test that hardcodes
+// the same constants as the table only asserts the table equals a copy of
+// itself. What they catch is the SHAPE of the defect.
+// ----------------------------------------------------------------------
+
+TEST(PrefsSchema, NumericRowsHaveACoherentDomain)
+{
+	const webapi::PrefField *schema = webapi::PrefSchema();
+	for (std::size_t i = 0; i < webapi::PrefSchemaSize(); ++i) {
+		const webapi::PrefField &f = schema[i];
+		if (f.type != webapi::PrefType::Uint16 && f.type != webapi::PrefType::Uint32)
+			continue;
+		const std::string where = std::string(f.category) + "." + f.key;
+		ASSERT_TRUE_M(f.min <= f.max, (where + ": min above max"));
+		// A Uint16 row whose ceiling does not fit in a uint16 is the
+		// max_new_connections_per_5s defect exactly: the declared range says
+		// one thing and the wire type says another, and the excess wraps.
+		if (f.type == webapi::PrefType::Uint16) {
+			ASSERT_TRUE_M(f.max <= 65535u, (where + ": Uint16 row declares a max above 65535"));
+		}
+		if (f.step) {
+			// Both endpoints have to be reachable, or the range advertises
+			// values the step forbids.
+			ASSERT_TRUE_M((f.max % f.step) == 0, (where + ": max is not a multiple of step"));
+			ASSERT_TRUE_M((f.min % f.step) == 0, (where + ": min is not a multiple of step"));
+		}
+	}
+}
+
+TEST(PrefsSchema, AnUnboundedNumericRowIsADeliberateChoice)
+{
+	// The forcing function. A new numeric row that leaves its ceiling at the
+	// full uint32 range fails here until someone puts it on this list, which
+	// is the review conversation the eight fields in #1174 never had. Both
+	// entries below were resolved to genuine uint32 members in the core during
+	// that audit.
+	static const char *const kKnownUnbounded[] = {
+		"files.min_free_space_mb",
+		"remote_controls.webserver.refresh_seconds",
+	};
+	const webapi::PrefField *schema = webapi::PrefSchema();
+	for (std::size_t i = 0; i < webapi::PrefSchemaSize(); ++i) {
+		const webapi::PrefField &f = schema[i];
+		if (f.type != webapi::PrefType::Uint16 && f.type != webapi::PrefType::Uint32)
+			continue;
+		if (f.max != 0xFFFFFFFFu)
+			continue;
+		const std::string where = std::string(f.category) + "." + f.key;
+		bool listed = false;
+		for (const char *known : kKnownUnbounded) {
+			if (where == known) {
+				listed = true;
+				break;
+			}
+		}
+		ASSERT_TRUE_M(listed,
+			(where + ": numeric row is unbounded; give it a real max, or add it to "
+				 "kKnownUnbounded once you have checked the core's storage width"));
+	}
 }


### PR DESCRIPTION
Fixes #1174.

Eight numeric preferences declared a range wider than what `CPreferences` can store, so a `PATCH` inside the declared range was accepted, answered `200`, and the value was changed underneath the caller. The clamped-at-load kind is the worst of the three: a `GET` right after the `PATCH` reports the value back faithfully, and only the next restart reveals the daemon never kept it.

`PrefField` gains `min` and `step` beside its existing `max`, and `PrefTakeUint` rejects below the floor and off the step with the same `400` it already answered above the ceiling. Declarative, in the schema, rather than a compare-then-write in amuleapi against a snapshot that lags a refresher tick.

| Field | Range | Step | Was |
|---|---|---|---|
| `connection.tcp_port` | `1`-`65532` | | `65534` -> listening on `4662` |
| `core_tweaks.file_buffer_bytes` | `0`-`3825000` | `15000` | `4000000` -> `150000`; `14999` -> `0` |
| `core_tweaks.max_upload_queue_clients` | `0`-`25500` | `100` | `30000` -> `4400`; `250` -> `200` |
| `core_tweaks.max_new_connections_per_5s` | `0`-`65535` | | `70000` -> `4464` |
| `core_tweaks.kad_max_source_searches` | `5`-`50` | | `100000` -> `34464`; `1` -> `5` at next start |
| `core_tweaks.kad_reask_minutes` | `30`-`60` | | `1` -> `30` at next start |
| `core_tweaks.source_reask_minutes` | `15`-`60` | | `7` -> `15` at next start |

## The two decisions the issue left open

**Quantised fields keep their unit and reject a value between two steps**, rather than being renamed to what the core stores. This is the opposite of what #1159 chose for the three `_minutes` rows, for the reason the issue gives: those quantised to a unit a user already thinks in, so the rename cost nothing, while nobody thinks in 15000-byte blocks and `file_buffer_blocks` would push an implementation detail into the API's vocabulary.

**`max_upload_kbps` / `max_download_kbps` is documented, not bounded.** `CheckUlDlRatio` caps download at 3x or 4x upload below certain thresholds, so the valid domain of one field depends on the current value of the other and cannot be expressed as a range on either. It is deliberate anti-leech behaviour, the adjusted value is echoed in the `PATCH` response, and rejecting the combination would refuse a client raising both values in two separate requests.

## Regression guard

The schema's bounds and the core's storage limits are two copies of one fact, and nothing failed when they drifted apart. Two guards go in beside the walker tests, which already compile `PrefsSchema.cpp`, so no new target and no new link surface:

- **`NumericRowsHaveACoherentDomain`** - `min <= max`, a `Uint16` row's `max` fits in 65535, and a `step` divides both endpoints so neither is unreachable.
- **`AnUnboundedNumericRowIsADeliberateChoice`** - a numeric row left at the full uint32 range fails until it is named in an explicit list. That is the review conversation these eight fields never had. The two rows on the list today were resolved to genuine uint32 members during the audit.

They deliberately do not restate each field's numbers: a test that hardcodes the same constants as the table only asserts the table equals a copy of itself. Both were confirmed to fail on a reintroduced regression rather than assumed to work.

## Web UI

`preferences.js` gains the matching `max` and `step`, and the submit path snaps to the step after clamping, so the form cannot produce a `400` it did not used to produce.

## Verified

`15-preferences-patch.sh` **163/163** against a live daemon, on an isolated config rather than a shared node. The file's two blocks that asserted the old behaviour as correct are updated: the `kad_reask_minutes=1 -> 200` case becomes a `400`, and the reask loop's probe of `7` moves inside each field's real range while staying off its endpoints, so it still proves the value is carried rather than snapped to a bound. Nine new rejection cases, twelve boundary round-trips, and an assertion that a sub-4 kB/s upload cap really does force `max_download_kbps` to `9`.

`RefresherTest` 89, `StateTest` 59, clang-format clean.

Out of scope, as the issue notes: `slot_allocation` and `s_byCryptTCPPaddingLength` are not reachable from `/api/v0/`, and `MaxConnectionsPerFiveSeconds`' one-time default bump is guarded and correct as written.
