### PR TITLE
fix(packaging): ship the WebUI inside the static tarball and find it next to the binary

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -36,8 +36,7 @@ on:
           Comma-separated list of platform tracks to run.
           Default empty = run all. Useful during iteration to focus
           on the failing tracks without paying for the green ones.
-          Valid: appimage, flatpak, macos, windows, linux-static,
-          frontend.
+          Valid: appimage, flatpak, macos, windows, linux-static.
         required: false
         type: string
         default: ''
@@ -127,62 +126,6 @@ jobs:
   # runtime shared-library deps, for containers / minimal / musl hosts.
   # See packaging/docker/Dockerfile.static-daemon.
   # ------------------------------------------------------------------
-  # ------------------------------------------------------------------
-  # amuleapi web frontend — platform-independent, so one job, no matrix
-  # ------------------------------------------------------------------
-  frontend:
-    name: amuleapi frontend
-    if: >-
-      github.event_name != 'workflow_dispatch' ||
-      inputs.only == '' ||
-      contains(inputs.only, 'frontend')
-    runs-on: ubuntu-22.04
-    steps:
-      - uses: actions/checkout@v7
-        with:
-          fetch-depth: 0  # git describe for the version string
-
-      - name: Pack the frontend
-        run: |
-          set -euo pipefail
-          VERSION=$(git describe --tags --always --dirty 2>/dev/null || echo snapshot)
-          STEM="aMule-${VERSION#v}-amuleapi-frontend"
-          mkdir -p "dist/${STEM}"
-          # Copy the tree verbatim. The daemon ships no assets of its own,
-          # so a static-binary operator needs this whole directory to point
-          # StaticRoot at -- shell, stylesheet, every module including the
-          # vendored ones and their LICENSEs, the i18n dictionaries, the
-          # favicon and the logo.
-          cp -R src/webapi/static/. "dist/${STEM}/"
-          # The zip must be the tracked tree, not a subset someone has to
-          # remember to extend. Compare counts against git rather than
-          # spot-checking filenames: a new view, dictionary or image is then
-          # covered the day it lands instead of the day someone updates a
-          # list here.
-          tracked=$(git ls-files src/webapi/static | wc -l | tr -d ' ')
-          packed=$(find "dist/${STEM}" -type f | wc -l | tr -d ' ')
-          if [ "$packed" -ne "$tracked" ]; then
-            echo "::error::frontend bundle has ${packed} files, git tracks ${tracked}"
-            exit 1
-          fi
-          # An entry point that cannot load is worse than a missing asset,
-          # because it fails in the browser rather than here.
-          for required in index.html css/app.css js/app.js; do
-            if [ ! -s "dist/${STEM}/${required}" ]; then
-              echo "::error::frontend bundle is missing ${required}"
-              exit 1
-            fi
-          done
-          echo "frontend bundle: ${packed} files"
-          (cd dist && zip -qr "${STEM}.zip" "${STEM}")
-          rm -rf "dist/${STEM}"
-
-      - uses: actions/upload-artifact@v7
-        with:
-          name: amuleapi-frontend
-          path: dist/aMule-*-amuleapi-frontend.zip
-          if-no-files-found: error
-
   linux-static:
     name: Linux static (${{ matrix.arch }})
     if: >-

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -229,12 +229,6 @@ jobs:
         with:
           name: source-bundle
           path: dist/
-      - name: Download amuleapi frontend bundle
-        uses: actions/download-artifact@v8
-        with:
-          name: amuleapi-frontend
-          path: dist/
-
       - name: List artifacts
         run: ls -la dist/
 
@@ -267,12 +261,11 @@ jobs:
           check "Windows installer .exe (x64 + arm64)" 2 'aMule-*-Windows-Setup-*.exe'
           check "Linux static daemon (x86_64 + aarch64)" 2 'aMule-*-Linux-*-static.tar.gz'
           check "Source bundle"                     1 'aMule-*-src.tar.gz'
-          check "amuleapi frontend bundle"          1 'aMule-*-amuleapi-frontend.zip'
           if [ "$fail" -ne 0 ]; then
             echo "::error::Artifact manifest incomplete — refusing to assemble the draft Release."
             exit 1
           fi
-          echo "All 13 expected release artifacts present."
+          echo "All 12 expected release artifacts present."
 
       - name: Create draft Release
         env:

--- a/docs/QUICKSTART-AMULEAPI.md
+++ b/docs/QUICKSTART-AMULEAPI.md
@@ -218,18 +218,18 @@ matching settings for one run.
 
 ## Web frontend
 
-amuleapi serves a web frontend at `/` when it can find one. Leave `StaticRoot` empty and it looks for the `amuleapi-static` folder that a normal install puts on disk, so a package install needs no configuration — open `http://127.0.0.1:4713/` and it is there. If nothing is found, `/` answers 404 and the REST API still works; an API-only deployment needs no frontend.
+amuleapi serves a web frontend at `/` when it can find one. Leave `StaticRoot` empty and it looks for an `amuleapi-static` folder in the usual places: inside the macOS `.app` bundle, next to its own executable, at the path it was configured with at build time, and in the platform's shared-data directory. A package install and the Linux static tarball both need no configuration — open `http://127.0.0.1:4713/` and it is there. If nothing is found, `/` answers 404 and the REST API still works; an API-only deployment needs no frontend.
 
-The static Linux daemon is the exception: it is a single binary and carries no files of its own, so there is nothing for it to find. Download `aMule-<version>-amuleapi-frontend.zip` from the release page, unzip it somewhere readable, and point `StaticRoot` at the unzipped folder:
+"Next to its own executable" is what makes the Linux static tarball work: it extracts to three binaries and an `amuleapi-static/` folder beside them, and amuleapi finds that folder wherever you put the directory. Keep them together and rename nothing. Note that this is the directory the binary lives in, not the directory you happen to run it from -- starting the daemon from elsewhere changes nothing.
+
+To serve the frontend from a location of your own, or to keep a modified copy separate from the installed one, copy the folder somewhere readable and point `StaticRoot` at it:
 
 ```ini
 [Server]
-StaticRoot=/opt/amule/aMule-3.1.0-amuleapi-frontend
+StaticRoot=/opt/amule/amuleapi-static
 ```
 
-The same zip works if you want to serve the frontend from a location of your own, or to keep a modified copy separate from the installed one.
-
-Unzip it as a unit and leave the layout alone. The page loads its stylesheet, its modules, the translations and the images by relative path, so moving or renaming anything inside the folder breaks it.
+Copy it as a unit and leave the layout alone. The page loads its stylesheet, its modules, the translations and the images by relative path, so moving or renaming anything inside the folder breaks it.
 
 ## CORS
 

--- a/packaging/linux/build.sh
+++ b/packaging/linux/build.sh
@@ -299,6 +299,38 @@ build_static() {
     local stem="aMule-${version}-Linux-${arch_label}-static"
     mkdir -p "${outdir}/${stem}"
     cp "${outdir}/amuled" "${outdir}/amulecmd" "${outdir}/amuleapi" "${outdir}/${stem}/"
+
+    # The WebUI ships inside this bundle. amuleapi serves no assets of its
+    # own, so a static-binary operator who fetched this tarball had a daemon
+    # that answered /api/v0 and nothing on /, and had to find a separate
+    # download to fix it -- which is why that separate amuleapi-frontend zip
+    # existed and why it no longer needs to. amuleapi finds this copy on its own because it
+    # looks next to its own executable (ResolveDefaultStaticDir), so the
+    # directory name here is load-bearing -- it must stay `amuleapi-static`.
+    local webui="${outdir}/${stem}/amuleapi-static"
+    mkdir -p "${webui}"
+    cp -R "${REPO_ROOT}/src/webapi/static/." "${webui}/"
+
+    # Same guard the frontend-zip job uses: compare against git rather than
+    # spot-checking filenames, so a new view, dictionary or image is covered
+    # the day it lands instead of the day someone remembers to extend a list.
+    local tracked packed
+    tracked=$(cd "${REPO_ROOT}" && git ls-files src/webapi/static | wc -l | tr -d ' ')
+    packed=$(find "${webui}" -type f | wc -l | tr -d ' ')
+    if [ "${packed}" -ne "${tracked}" ]; then
+        echo "fatal: bundled WebUI has ${packed} files, git tracks ${tracked}" >&2
+        exit 1
+    fi
+    # An entry point that cannot load fails in the browser rather than here.
+    local required
+    for required in index.html css/app.css js/app.js; do
+        if [ ! -s "${webui}/${required}" ]; then
+            echo "fatal: bundled WebUI is missing ${required}" >&2
+            exit 1
+        fi
+    done
+    echo "==> Bundled WebUI: ${packed} files"
+
     local tarball="${artifact_dir}/${stem}.tar.gz"
     echo "==> Bundling ${tarball}"
     tar -czf "${tarball}" -C "${outdir}" "${stem}"

--- a/src/webapi/Api.cpp
+++ b/src/webapi/Api.cpp
@@ -515,8 +515,9 @@ std::string BuildStaticEtag(const struct stat &st)
 // [Server]/StaticRoot is empty. Mirrors amuleweb's GetTemplateDir
 // (src/webserver/src/WebInterface.cpp): try the macOS .app bundle's
 // Resources/ first (so an installed aMule.app surfaces the bundled
-// frontend without a conf edit), then the compile-time install path
-// from AMULEAPI_STATIC_DIR, then wxStandardPaths' platform-adjusted
+// frontend without a conf edit), then a copy beside the running binary
+// (the relocatable Linux static tarball), then the compile-time install
+// path from AMULEAPI_STATIC_DIR, then wxStandardPaths' platform-adjusted
 // resource dir. Returns the first existing directory; empty if none.
 std::string ResolveDefaultStaticDir()
 {
@@ -557,6 +558,31 @@ std::string ResolveDefaultStaticDir()
 		}
 	}
 #endif // __WXMAC__
+
+	// A copy sitting next to the binary that is running. This is what the
+	// Linux static tarball ships: three binaries and an `amuleapi-static/`
+	// directory beside them, extracted wherever the operator chose, with no
+	// install step and no conf edit. None of the other candidates can find
+	// that -- each resolves through a *resources* directory (a macOS bundle,
+	// a compile-time prefix, wxStandardPaths' platform-adjusted share tree),
+	// and a relocatable bundle has none of them.
+	//
+	// The executable's own directory, deliberately NOT the working
+	// directory: a daemon is commonly started from ~ or /, and resolving
+	// assets against cwd would make what it serves depend on where it
+	// happened to be launched from -- and would let a directory an
+	// unprivileged user can create decide what a root daemon serves.
+	{
+		const wxString exe = wxStandardPaths::Get().GetExecutablePath();
+		if (!exe.empty()) {
+			wxFileName exe_dir(exe);
+			exe_dir.SetFullName(wxEmptyString);
+			const wxString cand = wxFileName(exe_dir.GetPath(), asset).GetFullPath();
+			const std::string s(cand.utf8_str());
+			if (webapi::IsDir(s))
+				return s;
+		}
+	}
 
 #ifdef AMULEAPI_STATIC_DIR
 	if (webapi::IsDir(AMULEAPI_STATIC_DIR)) {


### PR DESCRIPTION
Addresses the packaging half of #1134.

The Linux static tarball carried three binaries and nothing else, so amuleapi answered `/api/v0` and 404'd on `/`. The frontend existed as a separate `aMule-<version>-amuleapi-frontend.zip`, which an operator had to discover, download and wire up by hand with `StaticRoot` before the WebUI worked at all.

## Two halves

**The tarball ships the frontend.** `packaging/linux/build.sh` stages `src/webapi/static` as `amuleapi-static/` beside the binaries, with the guards the frontend-zip job used: the file count is compared against `git ls-files` rather than a list someone has to remember to extend, so a new view, dictionary or image is covered the day it lands; and `index.html`, `css/app.css`, `js/app.js` must be present and non-empty, because an entry point that cannot load fails in the browser rather than in CI.

**amuleapi finds it.** `ResolveDefaultStaticDir()` gains a candidate that looks beside the running executable. The other three cannot find a relocatable bundle - each resolves through a *resources* directory (a macOS `.app`, a compile-time prefix, `wxStandardPaths`' platform-adjusted share tree), and a tarball extracted to an arbitrary path has none of them.

It is the directory the **executable** lives in, deliberately not the working directory. A daemon is commonly started from `~` or `/`, so resolving against cwd would make what it serves depend on where it happened to be launched from - and would let a directory an unprivileged user can create decide what a root daemon serves.

## The separate artifact is removed

The `frontend` job in `packaging.yml`, its entry in the `workflow_dispatch` list, the download step and manifest check in `release.yml`, and the expected-artifact count from 13 to 12.

`QUICKSTART-AMULEAPI.md` documented the manual `StaticRoot` dance for exactly this case. It now lists the four search locations and says which one is the binary's own directory rather than the caller's.

## Verified

Staged a relocatable bundle (binary + sibling `amuleapi-static/`) and pointed it at a live daemon with `StaticRoot=` empty:

| Setup | cwd at launch | `GET /index.html` |
| --- | --- | --- |
| sibling directory present | `/` | **200**, and `css/app.css` 200 |
| sibling removed, decoy `amuleapi-static/` planted in cwd | the decoy's parent | decoy **not** served |

The second case needed a distinguishing marker inside the decoy to interpret: it returns 200 on this machine because the macOS `.app` branch matches, not because cwd was read. Checking the served bytes is what separates the two.

Tarball staging exercised directly: 38 files packed against 38 tracked, layout `aMule-<ver>-Linux-<arch>-static/{amuled,amulecmd,amuleapi,amuleapi-static/}`.

43 of 43 cctest binaries pass; clang-format and both clang-tidy tiers are clean.
