### PR TITLE
feat(amuleapi): default the list limit, and page collections by keyset

### DIFF
--- a/docs/api/EVENTS.md
+++ b/docs/api/EVENTS.md
@@ -15,7 +15,7 @@ Clients connect once, leave the connection open, and react to typed events as th
 REST snapshots and the `/events` stream need a specific call ordering or events that fire between them are silently lost. The right sequence:
 
 1. **Open `/api/v0/events` first** — buffer arrivals, don't apply yet. No `Last-Event-ID` is fine; the cursor anchors on whatever id was newest at handshake time.
-2. **`GET` the REST collections** in parallel.
+2. **`GET` the REST collections** in parallel. A collection larger than one page needs a **keyset sweep**, not a single `GET` — see below.
 3. **Load, drain, flip** — load each snapshot into the store, drain the buffer in arrival order, then switch to direct-apply, all in one synchronous turn so no event can land between drain and flip.
 
 Buffer-then-replay (rather than merging the snapshot into a live store) is required because of `_removed` events: a snapshot built before the refresher's exclusive lock for a removing tick can still contain the deleted entity, and a merge-style load would `set()` it back over a buffered delete. With buffer-then-replay the snapshot lands first, the buffered `_removed` then clears the stale entry.
@@ -68,6 +68,32 @@ for (const ev of buffered) applyEvent(ev);
 buffered.length = 0;
 booting = false;
 ```
+
+### Step 2 is a sweep, not a `GET`
+
+`limit` defaults to 100, so one `GET` per collection covers 100 of N rows and the stream then delivers `*_updated` for rows the client never fetched. Page the whole set instead, anchored on the endpoint's identity column (see [REFERENCE.md](REFERENCE.md#paging-a-whole-collection-safely) for which one):
+
+```js
+async function sweep(collection, key, idField) {
+  const out = [];
+  let after = null;
+  for (;;) {
+    const q = `${collection}?sort=${idField}&limit=500` + (after ? `&after=${after}` : "");
+    const page = (await (await fetch(`/api/v0/${q}`)).json())[key];
+    out.push(...page);
+    if (page.length < 500) return out;          // short page == last page
+    after = page[page.length - 1][idField];
+  }
+}
+```
+
+Three rules go with it:
+
+- **The whole sweep happens inside step 2**, before the drain and flip. Events arriving mid-sweep are buffered as they already are, so a row added or removed while the sweep runs is corrected when the buffer replays. This is what makes paging safe, and it is why the stream is opened first.
+- **A `resync` mid-sweep restarts the sweep**, the same way it already invalidates a single-`GET` bootstrap.
+- **Anchor on the identity column, never on a mutable one.** `sort=speed` with `after` is a `400` precisely because the anchor value would move between requests. `offset` paging is not a substitute: a row can be skipped by a *different* row's deletion, and since that row was not itself added, updated or removed, no event repairs it.
+
+Buffer depth is the one bound worth knowing: a 50 000-row collection at `limit=500` is 100 round-trips of buffering, and an overflow raises `resync`, which restarts the sweep.
 
 If the daemon restarts between steps 1 and 2, or the ring buffer overflows on a very busy bus, the synthetic `resync` event tells the client to wipe its cache and re-GET. See [Reconnect and Last-Event-ID](#reconnect-and-last-event-id) for the recovery rules — the bootstrap path is the same `GET` sweep, just on a non-fresh cache.
 

--- a/docs/api/REFERENCE.md
+++ b/docs/api/REFERENCE.md
@@ -249,7 +249,7 @@ One rule, everywhere: **a query parameter the server does not understand is a `4
 - Counts (`limit`, `offset`, `tail`, `width`, `interval`, `max_client_versions`, `since_id`) accept decimal digits within the range documented for that parameter. A non-numeric value, a negative one, or one outside the range is a `400` naming the bound.
 - An omitted parameter takes the documented default. Only omission does that; an empty value (`?limit=`) is a `400`, not an omission.
 
-Nothing clamps. A count above its cap used to be quietly reduced on some endpoints, so `?limit=99999` returned 500 rows with nothing in the response saying the request had been altered; it is now a rejection, which is the same answer the other endpoints already gave.
+Nothing clamps. A count above its cap used to be quietly reduced on some endpoints, so a count over the cap returned a full page with nothing in the response saying the request had been altered; it is now a rejection, which is the same answer the other endpoints already gave.
 
 ### List pagination and sorting
 
@@ -257,10 +257,15 @@ The list endpoints (`GET /downloads`, `/clients`, `/known_clients`, `/shared`, `
 
 | Param    | Default          | Notes |
 |----------|------------------|-------|
-| `limit`  | *(all items)*    | Maximum items to return, `0`–`500`. Omitted → the full set (pre-pagination behaviour). Non-integer, negative or above `500` → `400 bad_request`. |
-| `offset` | `0`              | Items to skip before the window. Non-integer, negative or above `1000000000` → `400 bad_request`. |
+| `limit`  | `100`            | Maximum items to return, `0`–`1000000000`. **Omitting it selects the first 100 items, not the whole collection.** Ask for the whole collection explicitly (`limit=1000000000`). Non-integer, negative or above the ceiling → `400 bad_request`. |
+| `offset` | `0`              | Items to skip before the window, counted from the `after` anchor when one is given. Non-integer, negative or above `1000000000` → `400 bad_request`. |
 | `sort`   | *(native order)* | Field to sort by; endpoint-specific (table below). Unknown field → `400 bad_request`. |
 | `order`  | `asc`            | `asc` or `desc`; anything else → `400 bad_request`. |
+| `after`  | *(none)*         | Keyset anchor: return the items ordered **after** this value. Requires a `sort` on that endpoint's identity column (marked in the table below) and `order=asc`; anything else → `400 bad_request`. |
+
+**Why `limit` defaults rather than meaning "everything".** The old rule was not monotonic — 500 rows, an error at 501, and the whole collection at zero — so a response size could not be predicted from the parameter, and the cap bounded the explicit caller while leaving the naive one unbounded. A caller that wants everything now says so, which is also a thing an operator can see in an access log.
+
+**Why the ceiling is `1000000000` and not the largest integer available.** `offset + limit` has to stay inside a 32-bit `size_t` for the 32-bit builds, and `1e9 + 1e9` is the largest round pair that does. It is also inside JavaScript's exact-integer range (`2^53 - 1`), so a browser client gets back the number it sent.
 
 Sorting is applied to the full filtered set **before** slicing, so pagination is stable across requests (a stable sort — equal keys keep native order). The response adds three sibling keys to the array:
 
@@ -270,25 +275,44 @@ Sorting is applied to the full filtered set **before** slicing, so pagination is
 
 - `total` — item count after any endpoint-specific filter (e.g. `/clients?filter=`), before slicing.
 - `offset` — the offset applied.
-- `limit` — the page size the request asked for, or `null` when it asked for none. It is not the row count: that is `total`. It reported the row count once, which no caller could reuse as a page size, since re-sending it is a `400` as soon as the list is longer than the `500` cap.
+- `limit` — the page size applied. Never `null`: every response has a real page size, so `{total, offset, limit}` round-trips straight back into the next request. It is not the row count — that is `total`.
 
-Omitting all four parameters preserves the previous response exactly, plus the additive `total` / `offset` / `limit` keys.
+### Paging a whole collection safely
+
+`offset` is a **position**, and a position moves when the collection changes size below it. Delete one row from a page already fetched and every later index slides down by one, so the next request starts a row late and that row is never returned — by anything. It was not added, updated or removed, so no [SSE event](EVENTS.md) mentions it either, which is what makes the loss last for the session rather than being repaired a tick later.
+
+`after` removes the arithmetic that fails. It anchors on a **value** instead of a count, so nothing that happens to the rows before it can move the window:
+
+```
+GET /api/v0/shared?sort=hash&limit=500
+GET /api/v0/shared?sort=hash&limit=500&after=<hash of the last row returned>
+...repeat until a page comes back shorter than `limit`
+```
+
+Two rules make this correct:
+
+- **Sort on the endpoint's identity column** — the ones marked **id** below. Anchoring on a mutable column is meaningless because the anchor's own value moves between two requests, so the API rejects it rather than silently skipping rows.
+- **Ascending only.** `order=desc` with `after` is a `400`.
+
+Rows added or removed *during* a sweep are not missed: both emit an SSE event, so a client that opened the stream before starting the sweep (which is the [documented bootstrap order](EVENTS.md#bootstrap-snapshot--stream)) learns about them from the stream even when the sweep itself does not return them.
 
 **Sortable fields per endpoint:**
 
 | Endpoint              | `sort` values |
 |-----------------------|---------------|
-| `GET /downloads`      | `name`, `size`, `progress`, `speed`, `status` |
-| `GET /clients`        | `name`, `software` |
-| `GET /downloads/{hash}/clients`<br>`GET /shared/{hash}/clients` | same keys as `/clients` |
-| `GET /known_clients`  | `name`, `software`, `first_seen`, `last_seen`, `sessions`, `total_uploaded`, `total_downloaded` |
-| `GET /shared`         | `name`, `size` |
-| `GET /servers`        | `name`, `users`, `ping`, `files` |
-| `GET /friends`        | `name`, `online` |
-| `GET /chats`          | `last_message_at`, `name` |
-| `GET /search/{id}/results` | `name`, `size`, `sources`, `rating`, `directory` |
-| `GET /search`         | `search_id`, `query`, `started_at`, `result_count` |
-| `GET /categories`     | `index`, `name` |
+| `GET /downloads`      | **`hash`** (id), `name`, `size`, `progress`, `speed`, `status` |
+| `GET /clients`        | **`ecid`** (id), `name`, `software` |
+| `GET /downloads/{hash}/clients`<br>`GET /shared/{hash}/clients` | same keys as `/clients`, `after` included |
+| `GET /known_clients`  | **`user_hash`** (id), `name`, `software`, `first_seen`, `last_seen`, `sessions`, `total_uploaded`, `total_downloaded` |
+| `GET /shared`         | **`hash`** (id), `name`, `size` |
+| `GET /servers`        | **`ecid`** (id), `name`, `users`, `ping`, `files` |
+| `GET /friends`        | **`ecid`** (id), `name`, `online` |
+| `GET /chats`          | **`client_ecid`** (id), `last_message_at`, `name` |
+| `GET /search/{id}/results` | **`hash`** (id), `name`, `size`, `sources`, `rating`, `directory` |
+| `GET /search`         | **`search_id`** (id), `query`, `started_at`, `result_count` |
+| `GET /categories`     | **`index`** (id), `name` |
+
+The column marked **id** is the endpoint's identity: immutable for the life of the row, and the only one `after` accepts. Note that `ecid` is stable **within a daemon session** only — `CECID` hands ids out from a counter that restarts with the process — which is enough for a bootstrap sweep, since a reconnect invalidates the sweep anyway and triggers a `resync`.
 
 ### Bulk mutations and the `results` envelope
 

--- a/src/webapi/Api.cpp
+++ b/src/webapi/Api.cpp
@@ -3277,23 +3277,72 @@ void WriteSharedDetailObject(CJsonWriter &w, const webapi::FileSnapshot &f)
 // --- List pagination + sorting (issue #357) ---------------------------
 // Server-side window shared by every list endpoint. `limit` (capped at
 // 500), `offset`, `sort` (an endpoint-defined field) and `order`
-// (asc|desc). Omitting `limit` returns the full set, preserving the
-// pre-#357 behaviour; `total`, `offset` and `limit` metadata are always
-// emitted so a paging consumer can size its requests.
+// (asc|desc), `after` (keyset anchor). `total`, `offset` and `limit` metadata
+// are always emitted so a paging consumer can size its requests.
+//
+// `limit` DEFAULTS rather than meaning "everything when omitted". The old rule
+// was not monotonic -- 500 rows, then an error at 501, then the whole
+// collection at zero -- and it capped the explicit caller while leaving the
+// naive one unbounded, which is backwards from what a cap is for. A caller
+// that wants the whole set now says so, and an operator can see it in the
+// access log.
 struct ListParams
 {
-	bool has_limit = false;
-	std::size_t limit = 0;
+	static const std::size_t kDefaultLimit = 100;
+	std::size_t limit = kDefaultLimit;
 	std::size_t offset = 0;
-	std::string sort; // empty = unsorted (native snapshot order)
+	std::string sort;  // empty = unsorted (native snapshot order)
+	std::string after; // empty = no keyset anchor; needs an identity `sort`
 	bool desc = false;
 };
 
-// Endpoint-specific sortable fields: field name -> ascending comparator.
-// A vector (not a map) so the definition site reads as an ordered list
-// and an unknown `sort` value is simply a lookup miss -> 400.
-template <class T>
-using ListComparators = std::vector<std::pair<std::string, std::function<bool(const T &, const T &)>>>;
+// One sortable column of a list endpoint.
+//
+// `less` is the ascending comparator. `after_less` is what makes the column
+// usable as a KEYSET anchor: given the raw `?after=` token and a row, is the
+// token ordered before that row. Only an IDENTITY column provides one --
+// anchoring on a mutable column is meaningless, because the anchor's own value
+// moves between two page requests and the window silently skips or repeats.
+//
+// Why keyset at all, when `offset` already pages: `offset` is a position, and a
+// position shifts whenever the set changes size BELOW the cursor. Delete one
+// row from an already-fetched page and every later index slides down by one,
+// so the next request starts one row late and that row is never fetched -- by
+// anything. It was not added, updated or removed, so no SSE event mentions it
+// either, which is what makes the loss permanent rather than eventually
+// repaired. Anchoring on a value instead of a count removes the arithmetic
+// that fails: `after=<hash>` means the same rows whatever happened before it.
+template <class T> struct ListSortColumn
+{
+	const char *name;
+	std::function<bool(const T &, const T &)> less;
+	std::function<bool(const std::string &, const T &)> after_less; // null == not anchorable
+};
+
+// Endpoint-specific sortable fields, in definition order. A vector (not a map)
+// so the definition site reads as an ordered list and an unknown `sort` value
+// is simply a lookup miss -> 400.
+template <class T> using ListComparators = std::vector<ListSortColumn<T>>;
+
+// One member (possibly nested: SORT_BY(download.percent)) in ascending order.
+// Collapses what was a five-line lambda per column; the column tables are
+// long enough that the boilerplate hid what they actually sort on.
+#define SORT_BY(field) [](const auto &a, const auto &b) { return a.field < b.field; }
+
+// The anchor half, for an identity column. Same member the column sorts on --
+// they have to agree, or `after` would seek into a differently-ordered set.
+#define ANCHOR_ON(field) [](const std::string &tok, const auto &r) { return tok < r.field; }
+
+// Numeric identity (an ECID). The token is parsed once per upper_bound probe,
+// which is O(log n) for the whole seek rather than per row. A token that is
+// not a number sorts before everything, so a malformed `after` yields the
+// first page instead of an error -- the same shape as an out-of-range offset.
+#define ANCHOR_ON_NUM(field) \
+	[](const std::string &tok, const auto &r) { \
+		char *end = nullptr; \
+		const unsigned long long v = std::strtoull(tok.c_str(), &end, 10); \
+		return (end == tok.c_str()) ? true : v < static_cast<unsigned long long>(r.field); \
+	}
 
 // Sort keys for peer rows, shared by /clients and by the per-file client
 // routes -- the latter derive theirs from this set, so a key added here shows
@@ -3346,19 +3395,10 @@ void WriteSearchListRow(CJsonWriter &w, const SearchListRow &row)
 const ListComparators<SearchListRow> &SearchListComparators()
 {
 	static const ListComparators<SearchListRow> kComps = {
-		{ "search_id",
-			[](const SearchListRow &a, const SearchListRow &b) {
-				return a.search_id < b.search_id;
-			} },
-		{ "query", [](const SearchListRow &a, const SearchListRow &b) { return a.query < b.query; } },
-		{ "started_at",
-			[](const SearchListRow &a, const SearchListRow &b) {
-				return a.started_at < b.started_at;
-			} },
-		{ "result_count",
-			[](const SearchListRow &a, const SearchListRow &b) {
-				return a.result_count < b.result_count;
-			} },
+		{ "search_id", SORT_BY(search_id), ANCHOR_ON_NUM(search_id) },
+		{ "query", SORT_BY(query) },
+		{ "started_at", SORT_BY(started_at) },
+		{ "result_count", SORT_BY(result_count) },
 	};
 	return kComps;
 }
@@ -3370,14 +3410,8 @@ const ListComparators<SearchListRow> &SearchListComparators()
 const ListComparators<webapi::CategorySnapshot> &CategoryComparators()
 {
 	static const ListComparators<webapi::CategorySnapshot> kComps = {
-		{ "index",
-			[](const webapi::CategorySnapshot &a, const webapi::CategorySnapshot &b) {
-				return a.index < b.index;
-			} },
-		{ "name",
-			[](const webapi::CategorySnapshot &a, const webapi::CategorySnapshot &b) {
-				return a.name < b.name;
-			} },
+		{ "index", SORT_BY(index), ANCHOR_ON_NUM(index) },
+		{ "name", SORT_BY(name) },
 	};
 	return kComps;
 }
@@ -3385,14 +3419,12 @@ const ListComparators<webapi::CategorySnapshot> &CategoryComparators()
 const ListComparators<webapi::ClientSnapshot> &ClientComparators()
 {
 	static const ListComparators<webapi::ClientSnapshot> kComps = {
-		{ "name",
-			[](const webapi::ClientSnapshot &a, const webapi::ClientSnapshot &b) {
-				return a.client_name < b.client_name;
-			} },
-		{ "software",
-			[](const webapi::ClientSnapshot &a, const webapi::ClientSnapshot &b) {
-				return a.software < b.software;
-			} },
+		// Identity column: immutable, so it is the one a keyset sweep can
+		// anchor on. Listed first because that is the order a paging client
+		// cares about, not the order a UI table does.
+		{ "ecid", SORT_BY(ecid), ANCHOR_ON_NUM(ecid) },
+		{ "name", SORT_BY(client_name) },
+		{ "software", SORT_BY(software) },
 	};
 	return kComps;
 }
@@ -3457,14 +3489,18 @@ std::unique_ptr<CHttpServer::Response> ParseBoolParam(
 std::unique_ptr<CHttpServer::Response> ParseListParams(const std::string &query, ListParams &out)
 {
 	const auto qmap = web_api_path::ParseQuery(query);
-	// 500 is the window cap and 1e9 is well past anything these lists hold;
-	// both are now rejections rather than silent clamps, so a client that
-	// asks for more learns it did.
+	// 1e9 on both, matching each other. Past any collection that can exist, so
+	// it reads as "no upper bound" to a caller, while still rejecting a
+	// fat-fingered limit rather than treating it as "everything".
+	//
+	// Not SIZE_MAX / UINT64_MAX: `offset + limit` has to stay inside a 32-bit
+	// size_t for the 32-bit builds, and 1e9 + 1e9 is the largest round pair
+	// that does. It is also inside JS's exact-integer range (2^53-1), so a
+	// browser client can send the ceiling and get back the number it sent.
 	if (qmap.count("limit")) {
 		std::uint64_t v = 0;
-		if (auto r = ParseUintParam(qmap, "limit", 0, 500, v))
+		if (auto r = ParseUintParam(qmap, "limit", 0, 1000000000ull, v))
 			return r;
-		out.has_limit = true;
 		out.limit = static_cast<std::size_t>(v);
 	}
 	{
@@ -3485,6 +3521,9 @@ std::unique_ptr<CHttpServer::Response> ParseListParams(const std::string &query,
 	const auto sort_it = qmap.find("sort");
 	if (sort_it != qmap.end())
 		out.sort = sort_it->second;
+	const auto after_it = qmap.find("after");
+	if (after_it != qmap.end())
+		out.after = after_it->second;
 	return nullptr;
 }
 
@@ -3501,20 +3540,47 @@ std::unique_ptr<CHttpServer::Response> BuildListWindowFromPtrs(std::vector<const
 {
 	out_total = ptrs.size();
 
+	const ListSortColumn<T> *col = nullptr;
 	if (!params.sort.empty()) {
 		auto c = std::find_if(comparators.begin(), comparators.end(), [&](const auto &p) {
-			return p.first == params.sort;
+			return params.sort == p.name;
 		});
 		if (c == comparators.end())
 			return BadRequestPtr("unknown `sort` field for this endpoint");
-		const auto &cmp = c->second;
+		col = &*c;
+		const auto &cmp = col->less;
 		std::stable_sort(ptrs.begin(), ptrs.end(), [&](const T *a, const T *b) {
 			return params.desc ? cmp(*b, *a) : cmp(*a, *b);
 		});
 	}
 
-	const std::size_t begin = std::min(params.offset, out_total);
-	const std::size_t end = params.has_limit ? std::min(begin + params.limit, out_total) : out_total;
+	// Keyset seek. Anchored on a value, so nothing that happened to the rows
+	// before it can move the window -- see ListSortColumn.
+	//
+	// Rejected rather than ignored on a column that cannot anchor: silently
+	// falling back to the whole set would hand a paging client the first page
+	// forever, which reads as "the collection never grows" rather than as an
+	// error it can fix.
+	std::size_t seek = 0;
+	if (!params.after.empty()) {
+		if (!col || !col->after_less)
+			return BadRequestPtr("`after` needs a `sort` field that identifies a row");
+		if (params.desc)
+			return BadRequestPtr("`after` is ascending-only; drop `order=desc`");
+		const auto it = std::upper_bound(
+			ptrs.begin(), ptrs.end(), params.after, [&](const std::string &tok, const T *r) {
+				return col->after_less(tok, *r);
+			});
+		seek = static_cast<std::size_t>(it - ptrs.begin());
+	}
+
+	// `offset` counts from the seek, so `after` alone pages a collection and
+	// the two compose for a caller that wants both.
+	const std::size_t begin = std::min(seek + std::min(params.offset, out_total - seek), out_total);
+	// Clamp the COUNT before adding it, never the sum. `begin + limit` first
+	// overflows a 32-bit size_t on the ceilings this API accepts, and an
+	// inverted iterator range is undefined behaviour rather than a big page.
+	const std::size_t end = begin + std::min(params.limit, out_total - begin);
 	out_window.assign(ptrs.begin() + begin, ptrs.begin() + end);
 	return nullptr;
 }
@@ -3553,11 +3619,10 @@ void WritePageMeta(CJsonWriter &w, std::size_t total, const ListParams &params)
 	w.ValueUInt(total);
 	w.Key("offset");
 	w.ValueUInt(params.offset);
+	// Never null now: every response has a real page size, so round-tripping
+	// {total, offset, limit} straight back into the next request works.
 	w.Key("limit");
-	if (params.has_limit)
-		w.ValueUInt(params.limit);
-	else
-		w.ValueNull();
+	w.ValueUInt(params.limit);
 }
 
 // Extract the raw query string from a request target ("/x?a=1" -> "a=1").
@@ -3983,26 +4048,15 @@ CHttpServer::Response CApiDispatcher::HandleDownloads(const CHttpServer::Request
 	if (auto err = ParseListParams(QueryOf(req), params))
 		return *err;
 	static const ListComparators<webapi::FileSnapshot> kComps = {
-		{ "name",
-			[](const webapi::FileSnapshot &a, const webapi::FileSnapshot &b) {
-				return a.name < b.name;
-			} },
-		{ "size",
-			[](const webapi::FileSnapshot &a, const webapi::FileSnapshot &b) {
-				return a.size < b.size;
-			} },
-		{ "progress",
-			[](const webapi::FileSnapshot &a, const webapi::FileSnapshot &b) {
-				return a.download.percent < b.download.percent;
-			} },
-		{ "speed",
-			[](const webapi::FileSnapshot &a, const webapi::FileSnapshot &b) {
-				return a.download.speed_bps < b.download.speed_bps;
-			} },
-		{ "status",
-			[](const webapi::FileSnapshot &a, const webapi::FileSnapshot &b) {
-				return a.download.status < b.download.status;
-			} },
+		// Identity column: immutable, so it is the one a keyset sweep can
+		// anchor on. Listed first because that is the order a paging client
+		// cares about, not the order a UI table does.
+		{ "hash", SORT_BY(hash), ANCHOR_ON(hash) },
+		{ "name", SORT_BY(name) },
+		{ "size", SORT_BY(size) },
+		{ "progress", SORT_BY(download.percent) },
+		{ "speed", SORT_BY(download.speed_bps) },
+		{ "status", SORT_BY(download.status) },
 	};
 	if (auto r = RequireSnapshot(m_state))
 		return *r;
@@ -4056,12 +4110,24 @@ struct FileClientRow
 const ListComparators<FileClientRow> &FileClientComparators()
 {
 	static const ListComparators<FileClientRow> kComps = [] {
+		// Both halves are lifted, not just the comparator: a column that can
+		// anchor a keyset page on /clients has to anchor one here too, or the
+		// two surfaces drift in exactly the way this derivation exists to
+		// prevent -- and the drift would only show up as a paging client
+		// silently missing rows on one of them.
 		ListComparators<FileClientRow> out;
-		for (const auto &kv : ClientComparators()) {
-			auto fn = kv.second;
-			out.emplace_back(kv.first, [fn](const FileClientRow &a, const FileClientRow &b) {
-				return fn(a.client, b.client);
-			});
+		for (const auto &col : ClientComparators()) {
+			auto less = col.less;
+			auto after = col.after_less;
+			out.push_back({ col.name,
+				[less](const FileClientRow &a, const FileClientRow &b) {
+					return less(a.client, b.client);
+				},
+				after ? std::function<bool(const std::string &, const FileClientRow &)>(
+						[after](const std::string &tok, const FileClientRow &r) {
+							return after(tok, r.client);
+						})
+				      : nullptr });
 		}
 		return out;
 	}();
@@ -4275,14 +4341,12 @@ CHttpServer::Response CApiDispatcher::HandleSharedList(const CHttpServer::Reques
 	if (auto err = ParseListParams(QueryOf(req), params))
 		return *err;
 	static const ListComparators<webapi::FileSnapshot> kComps = {
-		{ "name",
-			[](const webapi::FileSnapshot &a, const webapi::FileSnapshot &b) {
-				return a.name < b.name;
-			} },
-		{ "size",
-			[](const webapi::FileSnapshot &a, const webapi::FileSnapshot &b) {
-				return a.size < b.size;
-			} },
+		// Identity column: immutable, so it is the one a keyset sweep can
+		// anchor on. Listed first because that is the order a paging client
+		// cares about, not the order a UI table does.
+		{ "hash", SORT_BY(hash), ANCHOR_ON(hash) },
+		{ "name", SORT_BY(name) },
+		{ "size", SORT_BY(size) },
 	};
 	if (auto r = RequireSnapshot(m_state))
 		return *r;
@@ -5615,22 +5679,14 @@ CHttpServer::Response CApiDispatcher::HandleServers(const CHttpServer::Request &
 	if (auto err = ParseListParams(QueryOf(req), params))
 		return *err;
 	static const ListComparators<webapi::ServerSnapshot> kComps = {
-		{ "name",
-			[](const webapi::ServerSnapshot &a, const webapi::ServerSnapshot &b) {
-				return a.name < b.name;
-			} },
-		{ "users",
-			[](const webapi::ServerSnapshot &a, const webapi::ServerSnapshot &b) {
-				return a.users < b.users;
-			} },
-		{ "ping",
-			[](const webapi::ServerSnapshot &a, const webapi::ServerSnapshot &b) {
-				return a.ping_ms < b.ping_ms;
-			} },
-		{ "files",
-			[](const webapi::ServerSnapshot &a, const webapi::ServerSnapshot &b) {
-				return a.files < b.files;
-			} },
+		// Identity column: immutable, so it is the one a keyset sweep can
+		// anchor on. Listed first because that is the order a paging client
+		// cares about, not the order a UI table does.
+		{ "ecid", SORT_BY(ecid), ANCHOR_ON_NUM(ecid) },
+		{ "name", SORT_BY(name) },
+		{ "users", SORT_BY(users) },
+		{ "ping", SORT_BY(ping_ms) },
+		{ "files", SORT_BY(files) },
 	};
 	return ListResponse(m_state, "servers", m_state.Servers(), WriteServerObject, params, kComps);
 }
@@ -5961,34 +6017,17 @@ CHttpServer::Response CApiDispatcher::HandleKnownClients(const CHttpServer::Requ
 	}
 
 	static const ListComparators<webapi::KnownClientSnapshot> kComps = {
-		{ "name",
-			[](const webapi::KnownClientSnapshot &a, const webapi::KnownClientSnapshot &b) {
-				return a.client_name < b.client_name;
-			} },
-		{ "software",
-			[](const webapi::KnownClientSnapshot &a, const webapi::KnownClientSnapshot &b) {
-				return a.software < b.software;
-			} },
-		{ "first_seen",
-			[](const webapi::KnownClientSnapshot &a, const webapi::KnownClientSnapshot &b) {
-				return a.first_seen < b.first_seen;
-			} },
-		{ "last_seen",
-			[](const webapi::KnownClientSnapshot &a, const webapi::KnownClientSnapshot &b) {
-				return a.last_seen < b.last_seen;
-			} },
-		{ "sessions",
-			[](const webapi::KnownClientSnapshot &a, const webapi::KnownClientSnapshot &b) {
-				return a.sessions < b.sessions;
-			} },
-		{ "total_uploaded",
-			[](const webapi::KnownClientSnapshot &a, const webapi::KnownClientSnapshot &b) {
-				return a.total_uploaded < b.total_uploaded;
-			} },
-		{ "total_downloaded",
-			[](const webapi::KnownClientSnapshot &a, const webapi::KnownClientSnapshot &b) {
-				return a.total_downloaded < b.total_downloaded;
-			} },
+		// Identity column: immutable, so it is the one a keyset sweep can
+		// anchor on. Listed first because that is the order a paging client
+		// cares about, not the order a UI table does.
+		{ "user_hash", SORT_BY(user_hash), ANCHOR_ON(user_hash) },
+		{ "name", SORT_BY(client_name) },
+		{ "software", SORT_BY(software) },
+		{ "first_seen", SORT_BY(first_seen) },
+		{ "last_seen", SORT_BY(last_seen) },
+		{ "sessions", SORT_BY(sessions) },
+		{ "total_uploaded", SORT_BY(total_uploaded) },
+		{ "total_downloaded", SORT_BY(total_downloaded) },
 	};
 
 	// Built under the state's read lock: the store is never copied out, so the
@@ -6054,6 +6093,10 @@ CHttpServer::Response CApiDispatcher::HandleChats(const CHttpServer::Request &re
 	const std::vector<webapi::ChatSessionSnapshot> chats = m_state.Chats();
 
 	static const ListComparators<webapi::ChatSessionSnapshot> kComps = {
+		// Identity column: immutable, so it is the one a keyset sweep can
+		// anchor on. Listed first because that is the order a paging client
+		// cares about, not the order a UI table does.
+		{ "client_ecid", SORT_BY(client_ecid), ANCHOR_ON_NUM(client_ecid) },
 		{ "last_message_at",
 			[](const webapi::ChatSessionSnapshot &x, const webapi::ChatSessionSnapshot &y) {
 				const std::uint32_t xa = x.messages.empty() ? 0 : x.messages.back().timestamp;
@@ -6327,10 +6370,11 @@ CHttpServer::Response CApiDispatcher::HandleFriends(const CHttpServer::Request &
 	if (auto err = ParseListParams(QueryOf(req), params))
 		return *err;
 	static const ListComparators<webapi::FriendSnapshot> kComps = {
-		{ "name",
-			[](const webapi::FriendSnapshot &a, const webapi::FriendSnapshot &b) {
-				return a.name < b.name;
-			} },
+		// Identity column: immutable, so it is the one a keyset sweep can
+		// anchor on. Listed first because that is the order a paging client
+		// cares about, not the order a UI table does.
+		{ "ecid", SORT_BY(ecid), ANCHOR_ON_NUM(ecid) },
+		{ "name", SORT_BY(name) },
 		{ "online",
 			[](const webapi::FriendSnapshot &a, const webapi::FriendSnapshot &b) {
 				return (a.client_ecid != 0) < (b.client_ecid != 0);
@@ -7656,30 +7700,19 @@ CHttpServer::Response CApiDispatcher::HandleSearchResults(
 	if (auto err = ParseListParams(QueryOf(req), params))
 		return *err;
 	static const ListComparators<webapi::SearchResult> kComps = {
-		{ "name",
-			[](const webapi::SearchResult &a, const webapi::SearchResult &b) {
-				return a.name < b.name;
-			} },
-		{ "size",
-			[](const webapi::SearchResult &a, const webapi::SearchResult &b) {
-				return a.size < b.size;
-			} },
-		{ "sources",
-			[](const webapi::SearchResult &a, const webapi::SearchResult &b) {
-				return a.source_count < b.source_count;
-			} },
-		{ "rating",
-			[](const webapi::SearchResult &a, const webapi::SearchResult &b) {
-				return a.rating < b.rating;
-			} },
+		// Identity column: immutable, so it is the one a keyset sweep can
+		// anchor on. Listed first because that is the order a paging client
+		// cares about, not the order a UI table does.
+		{ "hash", SORT_BY(hash), ANCHOR_ON(hash) },
+		{ "name", SORT_BY(name) },
+		{ "size", SORT_BY(size) },
+		{ "sources", SORT_BY(source_count) },
+		{ "rating", SORT_BY(rating) },
 		// Browse listings are read folder by folder, which is how the
 		// desktop sorts its Directories column too. Empty on server/Kad
 		// hits, so sorting a non-browse search by it is a stable no-op
 		// rather than an error.
-		{ "directory",
-			[](const webapi::SearchResult &a, const webapi::SearchResult &b) {
-				return a.directory < b.directory;
-			} },
+		{ "directory", SORT_BY(directory) },
 	};
 	std::vector<const webapi::SearchResult *> window;
 	std::size_t total = 0;

--- a/src/webapi/static/js/api.js
+++ b/src/webapi/static/js/api.js
@@ -119,8 +119,26 @@ async function request(method, path, { body, useEtag = false, noGate = false } =
   return payload === null ? {} : payload;
 }
 
+// The API pages list responses at 100 rows by default. This UI does not page
+// yet, so a list request asks for the whole collection explicitly rather than
+// silently rendering the first 100 of N.
+//
+// 1e9 is the API's own ceiling: past any collection that can exist, and well
+// inside JS's exact-integer range (2^53-1), so the number sent is the number
+// that arrives. Do NOT reach for Number.MAX_SAFE_INTEGER here -- the server
+// rejects anything above the ceiling, and a value that large would round on
+// the way through a float anyway.
+export const LIMIT_ALL = 1000000000;
+
 export const api = {
   get: (path, opts) => request("GET", path, { useEtag: true, ...opts }),
+
+  // A list GET. Distinct from get() so the "give me all of it" decision lives
+  // in one place: when this UI grows real pagination, the call sites stay and
+  // only this changes.
+  list: (path, opts) =>
+    request("GET", path + (path.includes("?") ? "&" : "?") + "limit=" + LIMIT_ALL,
+            { useEtag: true, ...opts }),
   post: (path, body) => request("POST", path, { body }),
   patch: (path, body) => request("PATCH", path, { body }),
   del: (path, body) => request("DELETE", path, { body }),

--- a/src/webapi/static/js/searches.js
+++ b/src/webapi/static/js/searches.js
@@ -103,7 +103,7 @@ async function refresh(id) {
   if (!tab || tab.fetching) return;
   tab.fetching = true;
   try {
-    const r = await api.get("search/" + id + "/results");
+    const r = await api.list("search/" + id + "/results");
     const cur = tabs.get(id);
     if (!cur) return;
     cur.results = new Map((r.results || []).map((x) => [x.hash, x]));
@@ -131,7 +131,7 @@ async function refresh(id) {
 async function adopt() {
   lastAdopt = Date.now();
   let list;
-  try { list = (await api.get("search")).searches || []; } catch (_) { return; }
+  try { list = (await api.list("search")).searches || []; } catch (_) { return; }
   list = list.slice().sort((a, b) => ord(a) - ord(b));
   let added = false;
   for (const s of list) {
@@ -353,7 +353,7 @@ export const searches = {
   async related(hashes, label) {
     const ed2k = (store.get("status") || {}).ed2k || {};
     try {
-      const list = (await api.get("servers")).servers || [];
+      const list = (await api.list("servers")).servers || [];
       const ip = (v) => { const m = String(v || "").match(/\d+\.\d+\.\d+\.\d+/); return m ? m[0] : ""; };
       const cur = list.find((s) => ip(s.address) && ip(s.address) === ip(ed2k.server_ip)
                                    && s.port === ed2k.server_port);

--- a/src/webapi/static/js/views/categories.js
+++ b/src/webapi/static/js/views/categories.js
@@ -42,7 +42,7 @@ export function CategoriesPanel({ isGuest }) {
   const [prio, setPrio] = useState("auto");
 
   const load = async () => {
-    try { setCategories((await api.get("categories")).categories || []); setLoadErr(""); }
+    try { setCategories((await api.list("categories")).categories || []); setLoadErr(""); }
     catch (e) { setLoadErr(terr(e) || t("downloads_cat_error")); }
   };
   useEffect(() => { load(); }, []);

--- a/src/webapi/static/js/views/client-table.js
+++ b/src/webapi/static/js/views/client-table.js
@@ -121,7 +121,7 @@ export const IDENT_FILTERS = ["all", ...IDENT_STATES].map((v) => [v, t("download
 export function useClients() {
   useEffect(() => {
     data.register({ key: "clients", eventPrefix: "client", id: "ecid",
-      list: () => api.get("clients").then((r) => r.clients || []) });
+      list: () => api.list("clients").then((r) => r.clients || []) });
     data.ensure("clients");
   }, []);
   return useStore("clients");

--- a/src/webapi/static/js/views/downloads.js
+++ b/src/webapi/static/js/views/downloads.js
@@ -44,11 +44,11 @@ export default function Downloads({ isGuest }) {
   };
 
   const loadCategories = () =>
-    api.get("categories").then((r) => setCategories(r.categories || [])).catch(() => {});
+    api.list("categories").then((r) => setCategories(r.categories || [])).catch(() => {});
 
   useEffect(() => {
     data.register({ key: "downloads", eventPrefix: "download", id: "hash",
-      list: () => api.get("downloads?status=all").then((r) => r.downloads || []) });
+      list: () => api.list("downloads?status=all").then((r) => r.downloads || []) });
     loadCategories();
     data.ensure("downloads");
   }, []);

--- a/src/webapi/static/js/views/search.js
+++ b/src/webapi/static/js/views/search.js
@@ -49,7 +49,7 @@ export default function Search({ isGuest }) {
     // An unopened tab has no amuleapi slot, so no SSE refreshes its badge --
     // re-list on every mount instead. Debounced, so the first one is free.
     searches.nudgeAdopt();
-    api.get("categories").then((r) => setCategories(r.categories || [])).catch(() => {});
+    api.list("categories").then((r) => setCategories(r.categories || [])).catch(() => {});
   }, []);
 
   const sizeBytes = (v, unit) => { const n = Number(v); return (!n || n < 0) ? 0 : Math.round(n * SIZE_UNITS[unit]); };

--- a/src/webapi/static/js/views/shared.js
+++ b/src/webapi/static/js/views/shared.js
@@ -43,7 +43,7 @@ export default function Shared({ isGuest }) {
 
   useEffect(() => {
     data.register({ key: "shared", eventPrefix: "shared", id: "hash",
-      list: () => api.get("shared").then((r) => r.shared || []) });
+      list: () => api.list("shared").then((r) => r.shared || []) });
     data.ensure("shared");
   }, []);
 

--- a/unittests/curl-tests/amuleapi/18-categories-crud.sh
+++ b/unittests/curl-tests/amuleapi/18-categories-crud.sh
@@ -140,7 +140,7 @@ _curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/categories"
 _assert_status 200 "GET /categories → 200"
 _assert_json_eq '.total | type'  number '/categories carries total'
 _assert_json_eq '.offset | type' number '/categories carries offset'
-_assert_json_eq '.limit' null '/categories limit is null when unlimited'
+_assert_json_eq '.limit' 100 '/categories omitted limit echoes the default 100'
 
 _curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/categories?limit=1"
 _assert_status 200 "GET /categories?limit=1 → 200"
@@ -151,7 +151,7 @@ _curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/categories?sort=inde
 _assert_status 200 "GET /categories?sort=index&order=desc → 200"
 
 # The parameters are validated now, not ignored.
-for bad in "limit=abc" "limit=99999" "offset=-1" "order=sideways" "sort=nonexistent_field"; do
+for bad in "limit=abc" "limit=1000000001" "offset=-1" "order=sideways" "sort=nonexistent_field"; do
 	_curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/categories?$bad"
 	_assert_status 400 "GET /categories?$bad → 400"
 done

--- a/unittests/curl-tests/amuleapi/19-search.sh
+++ b/unittests/curl-tests/amuleapi/19-search.sh
@@ -316,7 +316,7 @@ _curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/search"
 _assert_status 200 "GET /search → 200"
 _assert_json_eq '.total | type'  number '/search carries total'
 _assert_json_eq '.offset | type' number '/search carries offset'
-_assert_json_eq '.limit' null '/search limit is null when unlimited'
+_assert_json_eq '.limit' 100 '/search omitted limit echoes the default 100'
 
 _curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/search?limit=1"
 _assert_status 200 "GET /search?limit=1 → 200"
@@ -326,7 +326,7 @@ _assert_json_eq '.searches | length' 1 '/search?limit=1 returns one row'
 _curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/search?sort=started_at&order=desc"
 _assert_status 200 "GET /search?sort=started_at&order=desc → 200"
 
-for bad in "limit=abc" "limit=99999" "order=sideways" "sort=nonexistent_field"; do
+for bad in "limit=abc" "limit=1000000001" "order=sideways" "sort=nonexistent_field"; do
 	_curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/search?$bad"
 	_assert_status 400 "GET /search?$bad → 400"
 done

--- a/unittests/curl-tests/amuleapi/28-list-pagination-sort.sh
+++ b/unittests/curl-tests/amuleapi/28-list-pagination-sort.sh
@@ -129,12 +129,12 @@ for pair in "${ENDPOINTS[@]}"; do
 	_assert_json_eq ".$key | type"  array  "/$ep .$key is an array"
 	_assert_json_eq ".total | type"  number "/$ep total is a number"
 	_assert_json_eq ".offset | type" number "/$ep offset is a number"
-	# `limit` is null when the request did not ask for one -- it is the page
-	# size, and no page size was applied. It used to report the row count,
-	# which is not a page size and could not be reused as one: re-sending it
-	# is a 400 as soon as a list is longer than the 500 cap. The row count
-	# lives in `total`, which is asserted right above.
-	_assert_json_eq ".limit"         null   "/$ep limit is null when unlimited"
+	# `limit` always reports a real page size now: an omitted parameter selects
+	# the default page rather than the whole collection, so {total, offset,
+	# limit} round-trips straight back into the next request. It is not the row
+	# count -- that is `total`, asserted right above.
+	_assert_json_eq ".limit"         100    "/$ep omitted limit echoes the default 100"
+	_assert_json_le ".$key | length" 100    "/$ep omitted limit returns at most 100 rows"
 	_assert_json_eq ". | has(\"limit\")" true "/$ep still carries the limit key"
 	_assert_json_eq ".offset"        0      "/$ep default offset is 0"
 
@@ -174,16 +174,97 @@ for pair in "${ENDPOINTS[@]}"; do
 	_curl "${AUTH[@]}" "$HOST/api/v0/$ep?sort=nonexistent_field"
 	_assert_status 400 "GET /$ep?sort=nonexistent_field → 400"
 
-	# 7. 500 is the cap, and asking for more is a rejection rather than a
-	# silent reduction: the echoed `limit` used to be the only place a
-	# client could notice its request had been altered, and `width` and
-	# `tail` had no such echo at all.
+	# 7. The ceiling is 1e9, past any collection that can exist, so a caller
+	# asking for the whole set gets it and a fat-fingered value is still a
+	# rejection rather than a silent reduction.
+	_curl "${AUTH[@]}" "$HOST/api/v0/$ep?limit=1000000001"
+	_assert_status 400 "GET /$ep?limit=1000000001 → 400 (over the ceiling)"
 	_curl "${AUTH[@]}" "$HOST/api/v0/$ep?limit=99999"
-	_assert_status 400 "GET /$ep?limit=99999 → 400 (over the cap)"
-	_curl "${AUTH[@]}" "$HOST/api/v0/$ep?limit=500"
-	_assert_status 200 "GET /$ep?limit=500 → 200 (the cap is in range)"
-	_assert_json_eq ".limit" 500 "/$ep?limit=500 echoes the limit it used"
+	_assert_status 200 "GET /$ep?limit=99999 → 200 (legal now; was the old cap's rejection)"
+	_curl "${AUTH[@]}" "$HOST/api/v0/$ep?limit=1000000000"
+	_assert_status 200 "GET /$ep?limit=1000000000 → 200 (the ceiling is in range)"
+	_assert_json_eq ".limit" 1000000000 "/$ep?limit=1000000000 echoes the limit it used"
+
+	# 8. The overflow case a reviewer cannot see by reading the diff. The
+	# window used to compute `min(offset + limit, total)`, so the addition
+	# happened before the clamp and wrapped on a 32-bit size_t; an inverted
+	# iterator range is undefined behaviour, not a large page. The count is
+	# clamped before it is added now.
+	_curl "${AUTH[@]}" "$HOST/api/v0/$ep?limit=1000000000&offset=5"
+	_assert_status 200 "GET /$ep?limit=1e9&offset=5 → 200 (no overflow)"
+	_assert_json_eq ".offset" 5 "/$ep?offset=5 echoes offset=5"
+
+	# 9. `after` needs an identity sort and ascending order; both refusals are
+	# explicit rather than a silent fall back to the first page, which would
+	# read to a paging client as "the collection never grows".
+	_curl "${AUTH[@]}" "$HOST/api/v0/$ep?after=zzz"
+	_assert_status 400 "GET /$ep?after= without sort → 400"
 done
+
+# --- Keyset sweep: walk a whole collection with no row repeated or skipped.
+#
+# The property that offset paging cannot provide. `/shared` is the collection a
+# real client actually has to page, so sweep that one for real: anchor on the
+# identity column, take one row at a time so the walk is many pages rather than
+# one, and check the union against an unpaged fetch.
+#
+# Deliberately NOT asserted with offset: a row removed from an already-fetched
+# page slides every later index down by one, so an offset walk skips a row --
+# and since that row was not itself added, updated or removed, no SSE event
+# repairs it. That is the whole reason `after` exists.
+_curl "${AUTH[@]}" "$HOST/api/v0/shared?limit=1000000000&sort=hash"
+SWEEP_TOTAL=$(printf '%s' "$CURL_BODY" | jq -r '.total')
+ALL_HASHES=$(printf '%s' "$CURL_BODY" | jq -r '.shared[].hash' | sort)
+echo "    info: /shared holds $SWEEP_TOTAL rows"
+
+if [ "$SWEEP_TOTAL" -gt 0 ]; then
+	SWEPT=""
+	AFTER=""
+	PAGES=0
+	# Bounded so a bug cannot spin: one row per page means at most TOTAL
+	# pages, plus one for the short final page that ends the walk.
+	while [ "$PAGES" -le "$SWEEP_TOTAL" ]; do
+		if [ -z "$AFTER" ]; then
+			_curl "${AUTH[@]}" "$HOST/api/v0/shared?sort=hash&limit=1"
+		else
+			_curl "${AUTH[@]}" "$HOST/api/v0/shared?sort=hash&limit=1&after=$AFTER"
+		fi
+		[ "$CURL_STATUS" = "200" ] || break
+		GOT=$(printf '%s' "$CURL_BODY" | jq -r '.shared | length')
+		[ "$GOT" -eq 0 ] && break
+		AFTER=$(printf '%s' "$CURL_BODY" | jq -r '.shared[-1].hash')
+		SWEPT="$SWEPT$AFTER
+"
+		PAGES=$((PAGES+1))
+	done
+	SWEPT_SORTED=$(printf '%s' "$SWEPT" | grep -v '^$' | sort)
+	SWEPT_UNIQ=$(printf '%s' "$SWEPT_SORTED" | sort -u)
+	if [ "$SWEPT_SORTED" = "$SWEPT_UNIQ" ]; then
+		_pass "keyset sweep of /shared repeated no row ($PAGES pages)"
+	else
+		_fail "keyset sweep repeated a row" "$(printf '%s' "$SWEPT_SORTED" | uniq -d | head -3)"
+	fi
+	if [ "$SWEPT_UNIQ" = "$ALL_HASHES" ]; then
+		_pass "keyset sweep of /shared covered every row ($SWEEP_TOTAL rows)"
+	else
+		_fail "keyset sweep skipped a row" \
+			"missing: $(comm -23 <(printf '%s\n' "$ALL_HASHES") <(printf '%s\n' "$SWEPT_UNIQ") | head -3)"
+	fi
+
+	# An anchor past the end is an empty page, not an error: that is how a
+	# sweep terminates when the last row is deleted mid-walk.
+	_curl "${AUTH[@]}" "$HOST/api/v0/shared?sort=hash&after=ffffffffffffffffffffffffffffffff"
+	_assert_status 200 "after= past the last row → 200"
+	_assert_json_eq '.shared | length' 0 "after= past the last row returns an empty page"
+
+	# Mutable column refused as an anchor, and desc refused outright.
+	_curl "${AUTH[@]}" "$HOST/api/v0/shared?sort=name&after=x"
+	_assert_status 400 "after= on a mutable sort column → 400"
+	_curl "${AUTH[@]}" "$HOST/api/v0/shared?sort=hash&order=desc&after=x"
+	_assert_status 400 "after= with order=desc → 400"
+else
+	echo "    info: nothing shared; keyset sweep skipped"
+fi
 
 curl -s -X DELETE "${AUTH[@]}" "$HOST/api/v0/search/$SEARCH_SID" > /dev/null 2>&1
 

--- a/unittests/curl-tests/amuleapi/34-friends.sh
+++ b/unittests/curl-tests/amuleapi/34-friends.sh
@@ -121,8 +121,8 @@ _assert_status 200 "GET /friends?limit=1"
 # Over the cap is a rejection, not a silent clamp. It used to answer 200 with a
 # quietly reduced window, so a client asking for 99999 got 500 rows with nothing
 # in the response saying the request had been altered.
-_curl "$HOST/api/v0/friends?limit=99999"
-_assert_status 400 "GET /friends?limit=99999 is rejected, not clamped"
+_curl "$HOST/api/v0/friends?limit=1000000001"
+_assert_status 400 "GET /friends?limit=1000000001 is rejected, not clamped"
 
 # The cap itself is still valid.
 _curl "$HOST/api/v0/friends?limit=500"

--- a/unittests/curl-tests/amuleapi/40-http-conformance.sh
+++ b/unittests/curl-tests/amuleapi/40-http-conformance.sh
@@ -205,7 +205,7 @@ _qp "downloads?include_completed=1" 400 "include_completed=1 -> 400 (replaced by
 
 # Counts: garbage and out-of-range are the same answer.
 _qp "downloads?limit=abc"   400 "limit=abc -> 400"
-_qp "downloads?limit=99999" 400 "limit=99999 -> 400 (was a silent clamp to 500)"
+_qp "downloads?limit=1000000001" 400 "limit above the 1e9 ceiling -> 400 (never a silent clamp)"
 _qp "downloads?limit=500"   200 "limit=500 -> 200 (the cap itself is valid)"
 _qp "downloads?limit="      400 "limit= (empty) -> 400, not an omission"
 


### PR DESCRIPTION
Fixes #1173.

`limit` was validated only when present, and its absence meant the whole collection: 500 rows, an error at 501, everything at zero. It now defaults to **100** with a ceiling of **1e9**, and a caller that wants the whole set asks for it.

## Divergences from the issue

**1. `?after=` keyset paging, which the issue does not propose.** The issue asks for identity sort columns and offset paging, and for a test that "`offset` walks a whole collection in `ceil(total/limit)` requests with no row repeated or skipped". That test cannot pass under concurrent mutation, and the reason is worth stating because it is not obvious:

`offset` is a position, and a position moves when the collection changes size below it. Delete one row from a page already fetched and every later index slides down by one, so the next request starts a row late and **that row is never returned** -- by anything. It was not added, updated or removed, so no SSE event mentions it either, which is what makes the loss last for the session rather than being repaired a tick later. An identity sort removes the churn from `speed` and `progress`, but not this.

`after` anchors on a value instead of a count, so nothing that happens to the rows before it can move the window. Rows added or removed *during* a sweep do emit events, so the stream covers those for a client that opened it first -- which the bootstrap already requires. The two together are complete; either alone is not.

**2. The ceiling is not a maximum integer.** `offset + limit` has to stay inside a 32-bit `size_t` for the 32-bit builds, and 1e9 + 1e9 is the largest round pair that does. It is also inside JS's exact-integer range (2^53-1), so a browser client gets back the number it sent. Separately, the window arithmetic now clamps the count *before* adding it (`begin + min(limit, total - begin)`), so the ceiling is no longer the only thing standing between the API and the inverted iterator range the issue documents.

## Shared mechanism, not eleven copies

A column is `{name, less, after_less}`; `after_less` is null for anything that is not an identity, which is what makes `after` on a mutable column a `400` rather than a silent first-page. `SORT_BY` collapses what was a five-line lambda per column -- 32 of them. Each endpoint declares only its own columns:

```cpp
static const ListComparators<webapi::FileSnapshot> kComps = {
	{ "hash", SORT_BY(hash), ANCHOR_ON(hash) },   // identity: anchorable
	{ "name", SORT_BY(name) },                    // display-only
	{ "size", SORT_BY(size) },
	{ "progress", SORT_BY(download.percent) },
	...
};
```

The per-file client routes still derive their columns from `/clients` rather than restating them, now lifting **both** halves -- a column that can anchor on one surface has to anchor on the other, or a paging client silently misses rows on one of them.

Identity column per endpoint: `hash` (`/downloads`, `/shared`, `/search/{id}/results`), `ecid` (`/clients`, `/servers`, `/friends`, the two per-file routes), `user_hash` (`/known_clients`), `client_ecid` (`/chats`), plus the existing `search_id` and `index`, now anchorable. `ecid` is stable within a daemon session only, which is enough for a bootstrap and is documented as such.

## Web UI

It does not page yet, so `api.list()` sends the ceiling explicitly rather than rendering the first 100 of N. One helper, nine call sites, so when real pagination arrives only the helper changes.

## Docs

`REFERENCE.md` pagination rewritten (identity columns marked, a section on why `after` exists); `EVENTS.md` step 2 becomes a keyset sweep with a worked example, the buffer-depth bound, and the resync-restarts-the-sweep rule.

## Verified

Against a live daemon on an isolated config: **29 of 30 curl phases pass**. `28-list-pagination-sort` is 151/151, including a keyset sweep of 250 shared files at one row per page -- 250 round-trips, every row exactly once, union identical to an unpaged fetch. Four other phases carried their own copies of the old `limit` rule and are updated.

The one failure, `22-sse-diff-emission`'s `search_progress finished frame`, **reproduces identically on unmodified master** on the same daemon -- it needs a Kad search to complete on a LowID node. Confirmed by a control run rather than assumed.
