### PR TITLE
fix(web-ui): cap upload_slot_kbps at the API max, and assert the 400 messages (#1174)

### DIFF
--- a/src/webapi/static/js/views/preferences.js
+++ b/src/webapi/static/js/views/preferences.js
@@ -65,7 +65,7 @@ const TABS = [
     { legendKey: "prefs_group_bandwidth", fields: [
       { key: "max_download_kbps", type: "int", min: 0, max: 1000000 },
       { key: "max_upload_kbps", type: "int", min: 0, max: 1000000 },
-      { key: "upload_slot_kbps", type: "int", min: 1, max: 100000 },
+      { key: "upload_slot_kbps", type: "int", min: 1, max: 65535 },
     ] },
     { legendKey: "prefs_group_ports", fields: [
       // 65532, not 65535: the server UDP socket is TCP+3, and the core

--- a/unittests/curl-tests/amuleapi/15-preferences-patch.sh
+++ b/unittests/curl-tests/amuleapi/15-preferences-patch.sh
@@ -592,6 +592,20 @@ for CASE in \
 	_assert_status 400 "PATCH $1.$2=$3 -> 400 (was silently $4)"
 done
 
+# The 400 body names which bound was hit and by what unit -- "out of range"
+# alone leaves a caller guessing which end and, for a step, why an in-range
+# value was refused. Assert the message for one range case and one step case.
+_curl -X PATCH -H "Authorization: Bearer $ADMIN_TOKEN" \
+	-H "Content-Type: application/json" \
+	-d '{"connection":{"tcp_port":99999}}' "$HOST/api/v0/preferences"
+_assert_json_eq '.error.message | contains("(1-65532)")' true \
+	"tcp_port 400 names the range in the message"
+_curl -X PATCH -H "Authorization: Bearer $ADMIN_TOKEN" \
+	-H "Content-Type: application/json" \
+	-d '{"core_tweaks":{"file_buffer_bytes":20000}}' "$HOST/api/v0/preferences"
+_assert_json_eq '.error.message | contains("multiple of 15000")' true \
+	"file_buffer_bytes 400 names the step in the message"
+
 # accept: the domain's own endpoints, which must round-trip untouched. A bound
 # that rejects its own boundary is the failure mode this half guards.
 for CASE in \


### PR DESCRIPTION
Two loose ends from the #1176 preference-bounds pass:

- upload_slot_kbps let the Web UI form accept up to 100000 while the API caps it at its uint16 max of 65535, so a value in between was the same form-collects-a-400 mismatch #1176 removed for the eight core_tweaks and connection fields. Align the form's max to the schema.

- 15-preferences-patch.sh asserted only the 400 status of a rejected write, never that the body names which bound was hit. The pass added messages that name the range and the step precisely so a caller is not left guessing; assert one range case and one step case so that text has a test.