### PR TITLE
fix(web-ui): full server list on Networks, and close the #1173 paging gaps

### DIFF
--- a/docs/QUICKSTART-AMULEAPI.md
+++ b/docs/QUICKSTART-AMULEAPI.md
@@ -258,8 +258,10 @@ Everything under `/api/v0/`, with full details in
 - **Search** — start a search, read results, download one.
 - **Categories**, **preferences**, **logs** and **statistics**.
 
-Lists take `limit`, `offset`, `sort` and `order`. Bulk actions report each
-item's outcome separately rather than one overall result.
+Lists take `limit`, `offset`, `sort`, `order` and `after` (a keyset anchor for
+paging). `limit` defaults to 100, so a list request returns the first page
+unless it asks for more — see [`docs/api/REFERENCE.md`](api/REFERENCE.md). Bulk
+actions report each item's outcome separately rather than one overall result.
 
 `GET /api/v0/events` streams changes as they happen and can resume where it
 left off after a dropped connection — see

--- a/docs/api/EVENTS.md
+++ b/docs/api/EVENTS.md
@@ -46,34 +46,10 @@ const es = new EventSource("/api/v0/events", { withCredentials: true });
 for (const t of EVENT_TYPES) es.addEventListener(t, onEvent);
 es.addEventListener("resync", () => location.reload()); // simplest recovery
 
-// 2. Pull baseline snapshots in parallel.
-const [downloads, shared, clients, servers, status] = await Promise.all([
-  fetch("/api/v0/downloads").then((r) => r.json()),
-  fetch("/api/v0/shared").then((r) => r.json()),
-  fetch("/api/v0/clients").then((r) => r.json()),
-  fetch("/api/v0/servers").then((r) => r.json()),
-  fetch("/api/v0/status").then((r) => r.json()),
-]);
-
-// 3. Load each snapshot into the store, drain the buffer, flip the flag —
-//    single synchronous block so no event can fire between drain and flip.
-//    `loadSnapshot` is your store-specific "replace this collection" call,
-//    e.g. `store.set(name, payload)` or `collections.set(name, new Map(...))`.
-loadSnapshot("downloads", downloads);
-loadSnapshot("shared",    shared);
-loadSnapshot("clients",   clients);
-loadSnapshot("servers",   servers);
-loadSnapshot("status",    status);
-for (const ev of buffered) applyEvent(ev);
-buffered.length = 0;
-booting = false;
-```
-
-### Step 2 is a sweep, not a `GET`
-
-`limit` defaults to 100, so one `GET` per collection covers 100 of N rows and the stream then delivers `*_updated` for rows the client never fetched. Page the whole set instead, anchored on the endpoint's identity column (see [REFERENCE.md](REFERENCE.md#paging-a-whole-collection-safely) for which one):
-
-```js
+// Page one collection to completion on its identity column (`hash`, `ecid`,
+// ... — see REFERENCE.md). Anchored on `after`, not `offset`, so a row removed
+// mid-sweep cannot slide the window and hide another row. "Why step 2 sweeps"
+// below is why the whole sweep belongs inside step 2.
 async function sweep(collection, key, idField) {
   const out = [];
   let after = null;
@@ -85,7 +61,35 @@ async function sweep(collection, key, idField) {
     after = page[page.length - 1][idField];
   }
 }
+
+// 2. Pull baseline snapshots in parallel. `limit` defaults to 100, so a list
+//    collection is *swept* page by page; /status is a singleton GET.
+const [downloads, shared, clients, servers, status] = await Promise.all([
+  sweep("downloads", "downloads", "hash"),
+  sweep("shared",    "shared",    "hash"),
+  sweep("clients",   "clients",   "ecid"),
+  sweep("servers",   "servers",   "ecid"),
+  fetch("/api/v0/status").then((r) => r.json()),
+]);
+
+// 3. Load each snapshot into the store, drain the buffer, flip the flag —
+//    single synchronous block so no event can fire between drain and flip.
+//    `loadSnapshot` is your store-specific "replace this collection" call,
+//    e.g. `store.set(name, rows)` or `collections.set(name, new Map(...))`.
+//    The swept collections are arrays of rows; /status is its envelope.
+loadSnapshot("downloads", downloads);
+loadSnapshot("shared",    shared);
+loadSnapshot("clients",   clients);
+loadSnapshot("servers",   servers);
+loadSnapshot("status",    status);
+for (const ev of buffered) applyEvent(ev);
+buffered.length = 0;
+booting = false;
 ```
+
+### Why step 2 sweeps
+
+`limit` defaults to 100, so a single `GET` per collection would cover only 100 of N rows and the stream would then deliver `*_updated` for rows the client never fetched. The `sweep()` helper in step 2 above pages the whole set instead, anchored on the endpoint's identity column (see [REFERENCE.md](REFERENCE.md#paging-a-whole-collection-safely) for which one).
 
 Three rules go with it:
 

--- a/src/webapi/static/js/views/networks.js
+++ b/src/webapi/static/js/views/networks.js
@@ -141,7 +141,7 @@ function ServersPanel({ isGuest }) {
 
   useEffect(() => {
     data.register({ key: "servers", eventPrefix: "server", id: "ecid",
-      list: () => api.get("servers").then((r) => r.servers || []) });
+      list: () => api.list("servers").then((r) => r.servers || []) });
     data.ensure("servers");
   }, []);
 

--- a/unittests/curl-tests/amuleapi/28-list-pagination-sort.sh
+++ b/unittests/curl-tests/amuleapi/28-list-pagination-sort.sh
@@ -1,15 +1,17 @@
 #!/usr/bin/env bash
 #
-# amuleapi list pagination + sorting (issue #357). Exercises the shared
-# ?limit/&offset/&sort/&order machinery across every list endpoint:
-# /downloads, /shared, /servers, /clients and /search/{id}/results.
+# amuleapi list pagination + sorting (issue #357, keyset paging #1173).
+# Exercises the shared ?limit/&offset/&sort/&order/&after machinery across the
+# list endpoints: /downloads, /shared, /servers, /clients, /categories,
+# /friends, /known_clients, /chats and /search/{id}/results.
 #
 # Data-tolerant like the other read smokes — it asserts the pagination
-# metadata (`total`/`offset`/`limit`), that `limit` bounds the array
-# length, that omitting params preserves the array, and that malformed
-# params are rejected with 400. Ordering correctness needs >= 2 items to
-# observe and is left to the live test / unit layer; here `sort` is only
-# asserted to be accepted (valid field) or rejected (unknown field).
+# metadata (`total`/`offset`/`limit`), that `limit` bounds the array length,
+# that an omitted `limit` selects the default page of 100, and that malformed
+# params are rejected with 400. Per-endpoint `sort` is only asserted accepted
+# (valid field) or rejected (unknown field); the two keyset sweeps below do
+# check coverage against real data (a string `hash` anchor on /shared, a
+# numeric `index` anchor on /categories).
 #
 # Bring-up convention (see run-all.sh / 04-read-downloads-shared.sh):
 #   amuleapi --config-dir=/tmp/... --host=127.0.0.1 --port=4712 \
@@ -82,6 +84,19 @@ _assert_json_le() {
 	fi
 }
 
+# jq expr must evaluate to a number; assert it is >= bound. A non-numeric
+# result (a failed GET yields the string "null") fails rather than skips.
+_assert_json_ge() {
+	local expr=$1 bound=$2 label=$3
+	local actual
+	actual=$(printf '%s' "$CURL_BODY" | jq -r "$expr" 2>/dev/null)
+	if [ -n "$actual" ] && [ "$actual" != "null" ] && [ "$actual" -ge "$bound" ] 2>/dev/null; then
+		_pass "$label ($actual >= $bound)"
+	else
+		_fail "$label" "expected >= $bound, got $actual" "body: $CURL_BODY"
+	fi
+}
+
 if ! command -v jq >/dev/null 2>&1; then
 	_die "jq is required. brew install jq."
 fi
@@ -115,6 +130,10 @@ ENDPOINTS=(
 	"shared:shared"
 	"servers:servers"
 	"clients:clients"
+	"categories:categories"
+	"friends:friends"
+	"known_clients:known_clients"
+	"chats:chats"
 	"search/$SEARCH_SID/results:results"
 )
 
@@ -144,8 +163,8 @@ for pair in "${ENDPOINTS[@]}"; do
 	_assert_json_le ".$key | length" 1 "/$ep?limit=1 returns <= 1 item"
 	_assert_json_eq ".limit" 1 "/$ep?limit=1 echoes limit=1"
 
-	# ...and a limit the caller did choose is echoed as a number, so null
-	# above is "no window", not "the field went away".
+	# ...and it comes back as a number, confirming the default 100 asserted
+	# above is a real page size (#1179 dropped the old null "no window" echo).
 	_assert_json_eq ".limit | type" number "/$ep?limit=1 limit is a number"
 
 	# 3. limit=0 → empty window, total still reported.
@@ -265,6 +284,44 @@ if [ "$SWEEP_TOTAL" -gt 0 ]; then
 else
 	echo "    info: nothing shared; keyset sweep skipped"
 fi
+
+# --- Numeric identity anchor. /shared above walks a string `hash`; a numeric
+# column (index/ecid/search_id) goes through ANCHOR_ON_NUM, which strtoull's the
+# token instead. The window arithmetic is the same shared code /shared already
+# exercises, so this only has to prove the numeric comparator seeks in the right
+# direction. A stock daemon holds only category 0, so seed one row to step past
+# and delete it after. Assert the precondition rather than assume it: a failed
+# GET yields total="null", which must fail loudly, not skip and pass empty.
+_curl "${AUTH[@]}" "$HOST/api/v0/categories?limit=1000000000&sort=index"
+BEFORE_IDX=$(printf '%s' "$CURL_BODY" | jq -c '[.categories[].index]')
+curl -s -X POST "${AUTH[@]}" -H "Content-Type: application/json" \
+	-d '{"name":"phase28-cat","path":"/tmp/28-cat-sweep"}' \
+	"$HOST/api/v0/categories" > /dev/null 2>&1
+_curl "${AUTH[@]}" "$HOST/api/v0/categories?limit=1000000000&sort=index"
+_assert_json_ge '.total' 2 '/categories seeded a row to step past'
+NEW_IDX=$(printf '%s' "$CURL_BODY" \
+	| jq -r --argjson b "$BEFORE_IDX" '[.categories[].index] - $b | first // empty')
+
+# after=0 seeks past category 0 and returns the rest -- a real numeric advance,
+# not just a parse edge. A reversed comparator would return nothing here.
+_curl "${AUTH[@]}" "$HOST/api/v0/categories?sort=index&after=0"
+_assert_status 200 "after=0 (numeric) → 200"
+_assert_json_ge ".categories | length" 1 "after=0 returns the rows past index 0"
+_assert_json_eq "[.categories[].index] | any(. == 0)" false "after=0 excludes index 0"
+
+# A non-numeric token sorts before everything -> first page (the strtoull-failed
+# branch), the same shape as an out-of-range offset.
+_curl "${AUTH[@]}" "$HOST/api/v0/categories?sort=index&after=notanumber"
+_assert_status 200 "after=<non-numeric> on a numeric anchor → 200 (first page)"
+_assert_json_eq ".categories[0].index" 0 "after=<non-numeric> falls back to the first page"
+
+# A parsed token past every index -> empty page, not an error.
+_curl "${AUTH[@]}" "$HOST/api/v0/categories?sort=index&after=1000000000"
+_assert_status 200 "after= past the last index → 200"
+_assert_json_eq ".categories | length" 0 "after= past the last index returns an empty page"
+
+# Delete the seeded row (a single row, so no index-renumber concern).
+[ -n "$NEW_IDX" ] && curl -s -X DELETE "${AUTH[@]}" "$HOST/api/v0/categories/$NEW_IDX" > /dev/null 2>&1
 
 curl -s -X DELETE "${AUTH[@]}" "$HOST/api/v0/search/$SEARCH_SID" > /dev/null 2>&1
 


### PR DESCRIPTION
Follow-up to the amuleapi list-paging change (#1173 / #1179), fixing the gaps it left behind.

Web UI: the Networks servers table bootstrapped via api.get("servers"), which since #1173 defaults limit to 100 -- so a node with more than 100 servers rendered only the first 100 and the SSE server_* stream never backfilled the rest for the life of the session. Use api.list() like the other live tables (downloads, shared, clients), which sends the 1e9 ceiling explicitly.

Docs: the EVENTS.md bootstrap example still did one GET per collection, which now returns only the first 100 rows and contradicts the "Step 2 is a sweep" section right below it. Fold the sweep() helper into the worked example so step 2 pages each list to completion; drop the now-duplicate helper and retitle the section. QUICKSTART gains the after parameter and the default-100 note.

Tests: the pagination curl test only iterated 5 of the list endpoints; add categories, friends, known_clients and chats (categories in particular went from parsing no list params to full paging in #1173 and had no coverage). Add a numeric-identity keyset sweep on /categories?sort=index to exercise the ANCHOR_ON_NUM path the string-hash /shared sweep does not.