### PR TITLE
fix(web-ui): show "—" not "0" for Kad indexed counters while disconnected

### DIFF
--- a/src/webapi/static/js/views/networks.js
+++ b/src/webapi/static/js/views/networks.js
@@ -558,10 +558,10 @@ function KadInfoPanel() {
         statRow("networks_kad_contacts_nodes", connected ? formatInt(net.nodes) : "—"),
       ], "networks_kad_group_network")}
       ${Section([
-        statRow("networks_kad_indexed_sources", formatInt(idx.sources)),
-        statRow("networks_kad_indexed_keywords", formatInt(idx.keywords)),
-        statRow("networks_kad_indexed_notes", formatInt(idx.notes)),
-        statRow("networks_kad_indexed_load", formatInt(idx.load)),
+        statRow("networks_kad_indexed_sources", connected ? formatInt(idx.sources) : "—"),
+        statRow("networks_kad_indexed_keywords", connected ? formatInt(idx.keywords) : "—"),
+        statRow("networks_kad_indexed_notes", connected ? formatInt(idx.notes) : "—"),
+        statRow("networks_kad_indexed_load", connected ? formatInt(idx.load) : "—"),
       ], "networks_kad_group_index")}
     </div>`;
 }


### PR DESCRIPTION
The indexed sources/keywords/notes/load rows in KadInfoPanel were the only group not gated on `connected`. With #1184 the API now returns `null` for these while Kad is down, and formatInt(null) renders "0" — the same misleading value the API fix set out to remove. Gate them on `connected` like every sibling row, so they read "—".

Refs #1181, #1184.