### PR TITLE
fix(ec+amuleapi): make search results incremental for every EC client

### DIFF
--- a/docs/api/EVENTS.md
+++ b/docs/api/EVENTS.md
@@ -572,6 +572,8 @@ Driven by the refresher state machine that owns the `POST /search` → completio
 
 Emitted per new result that appears in the results map between refresher ticks.
 
+**Add-only.** There is no `search_result_updated`, so a result's mutable fields (`sources`, `status`, `already_have`, `children[]`, `comments[]`) do not push after the row first arrives. While a search runs, [`search_progress`](#search_progress) fires on every advance and is the cue to re-read [`GET /search/{id}/results`](REFERENCE.md#get-apiv0searchidresults); once it finishes, that endpoint refreshes on read. The daemon is polled for every search it holds, finished ones included, so a re-read is current -- but the stream will not tell you when to make one.
+
 ```json
 {
   "search_id": 42,

--- a/docs/api/REFERENCE.md
+++ b/docs/api/REFERENCE.md
@@ -2753,7 +2753,9 @@ Returns one search's results buffer at the moment of the call PLUS a progress en
 
 This endpoint does NOT busy-wait — it returns whatever amuled has in its result buffer right now. A client that wants to wait for completion should poll while `progress.state == "running"`. While a search is **running** the refresher polls amuled (`EC_OP_SEARCH_RESULTS` + `EC_OP_SEARCH_PROGRESS`, addressed by `search_id`) every tick, so this GET reads straight from that snapshot and successive polls see the growing result set with no extra EC roundtrip.
 
-Once a search is **finished** the refresher stops polling it, so this endpoint refreshes it **on read** instead, coalesced by a ~1 s TTL. That is what keeps a finished search's results live rather than frozen at the moment it completed: a Kad notes lookup started on one of its hits reports back, and a hit you download from it starts reading `status: "downloaded"` / `already_have: true`. Repeated polling of a finished search costs at most one EC roundtrip per second, not one per request.
+A finished search keeps being refreshed. The daemon is polled for every search it holds in one incremental request per tick, so a search that has completed costs nothing to keep current and is not dropped from the poll set: a hit you download from it starts reading `status: "downloaded"` / `already_have: true` without anyone having to ask.
+
+This endpoint additionally refreshes on read, coalesced by a ~1 s TTL, which covers the sub-tick window: a client that starts a Kad notes lookup and immediately re-reads sees the flag without waiting for the next tick. Repeated polling costs at most one EC roundtrip per second, not one per request.
 
 `POST /search` is one way a search becomes readable; an unknown `search_id` (one this session never started) triggers a one-off `EC_OP_SEARCH_LIST` check before the `404`, and once confirmed it is polled every tick from there — so a search another client (or the monolithic GUI) started is readable here too, not just listable via [`GET /search`](#get-apiv0search).
 

--- a/docs/api/REFERENCE.md
+++ b/docs/api/REFERENCE.md
@@ -2757,7 +2757,7 @@ A finished search keeps being refreshed. The daemon is polled for every search i
 
 This endpoint additionally refreshes on read, coalesced by a ~1 s TTL, which covers the sub-tick window: a client that starts a Kad notes lookup and immediately re-reads sees the flag without waiting for the next tick. Repeated polling costs at most one EC roundtrip per second, not one per request.
 
-`POST /search` is one way a search becomes readable; an unknown `search_id` (one this session never started) triggers a one-off `EC_OP_SEARCH_LIST` check before the `404`, and once confirmed it is polled every tick from there — so a search another client (or the monolithic GUI) started is readable here too, not just listable via [`GET /search`](#get-apiv0search).
+`POST /search` is one way a search becomes readable; an unknown `search_id` (one this session never started) triggers a one-off `EC_OP_SEARCH_LIST` check before the `404`. Once confirmed, that same request reads the search in full, so the first response already carries its whole result set rather than an empty one that fills in over the following ticks; it is then polled every tick like any other. A search another client (or the monolithic GUI) started is therefore readable here too, not just listable via [`GET /search`](#get-apiv0search).
 
 amuled keeps a bounded ring of recent searches (20). A search evicted from that ring (because 20 newer searches were started) is reported to amuleapi as expired: its slot is retired as `finished` and reads with its `search_id` then return `404`.
 

--- a/src/ECSpecialCoreTags.cpp
+++ b/src/ECSpecialCoreTags.cpp
@@ -569,20 +569,36 @@ CEC_SearchFile_Tag::CEC_SearchFile_Tag(
 	// and an empty container never clears the remote list.
 	FileRatingList list;
 	file->GetRatingAndComments(list);
-	if (file->IsKadCommentSearchRunning() || !list.empty()) {
-		AddTag(EC_TAG_PARTFILE_KAD_COMMENT_SEARCHING,
-			(uint64)(file->IsKadCommentSearchRunning() ? 1 : 0));
-		if (!list.empty()) {
-			CECEmptyTag sc(EC_TAG_PARTFILE_COMMENTS);
-			for (FileRatingList::const_iterator it = list.begin(); it != list.end(); ++it) {
-				// Tag children are evaluated by index, not by name.
-				sc.AddTag(CECTag(EC_TAG_PARTFILE_COMMENTS, it->UserName));
-				sc.AddTag(CECTag(EC_TAG_PARTFILE_COMMENTS, it->FileName));
-				sc.AddTag(CECTag(EC_TAG_PARTFILE_COMMENTS, (uint64)it->Rating));
-				sc.AddTag(CECTag(EC_TAG_PARTFILE_COMMENTS, it->Comment));
-			}
-			AddTag(sc);
+	// Always emitted, and through the valuemap -- the same shape the download
+	// side has always used for this tag (CEC_PartFile_Tag above).
+	//
+	// It used to be emitted only while the lookup was running or had notes to
+	// show, so "finished, found nothing" was signalled by the tag going away.
+	// That cannot survive the incremental union: a result whose only change is
+	// a tag no longer being built produces a tag with no children, which
+	// Get_EC_Response_Search_Results_Union drops as unchanged. The transition
+	// was therefore invisible to every incremental client -- amulegui latched
+	// the flag on, and so did amuleapi -- and only a full re-read cleared it.
+	//
+	// Through the valuemap the 1 -> 0 transition is itself a child tag, so the
+	// result is not elided and every client sees the lookup end. A steady
+	// state still costs nothing: unchanged, it is diffed away as before.
+	AddTag(EC_TAG_PARTFILE_KAD_COMMENT_SEARCHING,
+		(uint64)(file->IsKadCommentSearchRunning() ? 1 : 0),
+		valuemap);
+	// The container itself stays gated on there being notes, and stays off the
+	// valuemap: an empty one must never be sent, because a client reads its
+	// absence as "no notes" rather than as "unchanged".
+	if (!list.empty()) {
+		CECEmptyTag sc(EC_TAG_PARTFILE_COMMENTS);
+		for (FileRatingList::const_iterator it = list.begin(); it != list.end(); ++it) {
+			// Tag children are evaluated by index, not by name.
+			sc.AddTag(CECTag(EC_TAG_PARTFILE_COMMENTS, it->UserName));
+			sc.AddTag(CECTag(EC_TAG_PARTFILE_COMMENTS, it->FileName));
+			sc.AddTag(CECTag(EC_TAG_PARTFILE_COMMENTS, (uint64)it->Rating));
+			sc.AddTag(CECTag(EC_TAG_PARTFILE_COMMENTS, it->Comment));
 		}
+		AddTag(sc);
 	}
 
 	if (detail_level == EC_DETAIL_UPDATE) {

--- a/src/ECSpecialCoreTags.cpp
+++ b/src/ECSpecialCoreTags.cpp
@@ -589,6 +589,13 @@ CEC_SearchFile_Tag::CEC_SearchFile_Tag(
 	// The container itself stays gated on there being notes, and stays off the
 	// valuemap: an empty one must never be sent, because a client reads its
 	// absence as "no notes" rather than as "unchanged".
+	//
+	// One consequence worth naming, since it looks like a bug from the other
+	// end: a result that HAS notes is never elided by the multi-search union.
+	// The union skips a result whose tag came out childless, and this
+	// container is a child that off-valuemap means it is re-emitted on every
+	// poll, unchanged or not. That is the correct trade -- the alternative
+	// silently drops notes -- and it is bounded by how few results carry any.
 	if (!list.empty()) {
 		CECEmptyTag sc(EC_TAG_PARTFILE_COMMENTS);
 		for (FileRatingList::const_iterator it = list.begin(); it != list.end(); ++it) {

--- a/src/webapi/Api.cpp
+++ b/src/webapi/Api.cpp
@@ -7795,16 +7795,20 @@ void CApiDispatcher::RefreshSearchIfStale(std::uint32_t search_id)
 	// perfectly good answer. An expiry is left to the tick's own retirement
 	// path rather than duplicated here.
 	//
-	// The fetch is the multi-search union, so it refreshes every search rather
-	// than just this one. The claim above stays per-search on purpose: it is
-	// what bounds how often a read can trigger a roundtrip, and the union
-	// costs the same whether one search is stale or all of them are.
+	// Deliberately the per-search FULL fetch and not the union, even though
+	// the union would refresh every stale search in one roundtrip. The union
+	// is a differential stream keyed on what the daemon has already sent this
+	// connection, so it tolerates exactly one issuer: with the refresher
+	// thread issuing it every tick, a second issuer here could have its reply
+	// applied out of order and leave a row no later poll can correct, because
+	// by then the daemon considers every field of it unchanged. A FULL reply
+	// carries the whole search and is idempotent, so it races nothing.
 	//
 	// Kept even though the tick now polls finished searches too: this covers
 	// the sub-tick window a client hits when it GETs immediately after
 	// starting a Kad notes lookup, which is what the poll-until-false loop in
 	// the reference does.
-	(void)webapi::FetchSearchResults(m_app, m_state);
+	(void)webapi::FetchOneSearchFull(m_app, m_state, search_id);
 }
 
 // See the declaration in Api.h for why this is shared rather than inlined
@@ -7851,6 +7855,15 @@ bool CApiDispatcher::DiscoverSearchIfHeldByCore(std::uint32_t search_id)
 		break;
 	}
 	delete ec_resp;
+	if (found) {
+		// Seed the slot's results immediately, at EC_DETAIL_FULL. Waiting for
+		// the next union poll would leave it permanently empty: the union
+		// responder walks every search the core holds, so it has very likely
+		// already offered this search's results to this connection, found no
+		// slot for them, and dropped them -- and having sent them once, it
+		// will elide them from here on. This is the only chance to read them.
+		(void)webapi::FetchOneSearchFull(m_app, m_state, search_id);
+	}
 	return found;
 }
 

--- a/src/webapi/Api.cpp
+++ b/src/webapi/Api.cpp
@@ -7794,7 +7794,17 @@ void CApiDispatcher::RefreshSearchIfStale(std::uint32_t search_id)
 	// previous set is strictly better than failing a read that has a
 	// perfectly good answer. An expiry is left to the tick's own retirement
 	// path rather than duplicated here.
-	(void)webapi::FetchSearchResults(m_app, m_state, search_id);
+	//
+	// The fetch is the multi-search union, so it refreshes every search rather
+	// than just this one. The claim above stays per-search on purpose: it is
+	// what bounds how often a read can trigger a roundtrip, and the union
+	// costs the same whether one search is stale or all of them are.
+	//
+	// Kept even though the tick now polls finished searches too: this covers
+	// the sub-tick window a client hits when it GETs immediately after
+	// starting a Kad notes lookup, which is what the poll-until-false loop in
+	// the reference does.
+	(void)webapi::FetchSearchResults(m_app, m_state);
 }
 
 // See the declaration in Api.h for why this is shared rather than inlined

--- a/src/webapi/Refresher.cpp
+++ b/src/webapi/Refresher.cpp
@@ -2407,145 +2407,189 @@ std::string FileTypeToken(const std::string &name)
 	return s;
 }
 
-void ApplySearchFull(const CECPacket *resp, std::map<std::uint32_t, SearchResult> &cache)
+// Merge one EC_TAG_SEARCHFILE onto a result, writing only the fields the tag
+// actually carries.
+//
+// This is the whole contract of the incremental union poll: the daemon diffs a
+// result against what it last sent us and emits only what moved, so an absent
+// field means "unchanged", never "cleared". Every write below is therefore
+// guarded on its tag being present -- including the ones a full fetch could
+// take unconditionally, because their accessors go through GetTagByNameSafe
+// and answer 0 / "" for a tag that is not there.
+void MergeSearchResultTag(const CEC_SearchFile_Tag *sf, SearchResult &r)
 {
-	cache.clear();
-	if (!resp)
-		return;
-	for (CECPacket::const_iterator it = resp->begin(); it != resp->end(); ++it) {
-		const CECTag *t = &*it;
-		if (t->GetTagName() != EC_TAG_SEARCHFILE)
-			continue;
-		const CEC_SearchFile_Tag *sf = static_cast<const CEC_SearchFile_Tag *>(t);
-		SearchResult r;
-		r.ecid = sf->ID();
-		{
-			std::string h(sf->FileHashString().utf8_str());
-			std::transform(h.begin(), h.end(), h.begin(), [](unsigned char c) {
-				return std::tolower(c);
-			});
-			r.hash = std::move(h);
-		}
-		r.name = std::string(sf->FileName().utf8_str());
-		r.size = sf->SizeFull();
-		{
-			std::uint32_t v = 0;
-			if (sf->AssignIfExist(EC_TAG_PARTFILE_SOURCE_COUNT, v))
-				r.source_count = v;
-		}
-		{
-			std::uint32_t v = 0;
-			if (sf->AssignIfExist(EC_TAG_PARTFILE_SOURCE_COUNT_XFER, v))
-				r.complete_source_count = v;
-		}
-		r.already_have = sf->AlreadyHave();
-		// Grouping (issue #431): a child hit carries its parent's ECID in
-		// EC_TAG_SEARCH_PARENT. Recorded here; folded into the parent's
-		// children[] in the second pass below.
-		{
-			std::uint32_t v = 0;
-			if (sf->AssignIfExist(EC_TAG_SEARCH_PARENT, v)) {
-				r.parent_ecid = v;
-				r.has_parent = true;
-			}
-		}
-		{
-			std::uint8_t v = 0;
-			if (sf->AssignIfExist(EC_TAG_KNOWNFILE_RATING, v))
-				r.rating = v;
-		}
-		// Download status (issue #429): amuled packs the CSearchFile
-		// status in EC_TAG_PARTFILE_STATUS on every search-result tag.
-		{
-			std::uint32_t v = 0;
-			r.status = SearchStatusName(sf->AssignIfExist(EC_TAG_PARTFILE_STATUS, v) ? v : 0);
-		}
-		// File type, computed from the filename (no EC data needed).
-		r.type = FileTypeToken(r.name);
-		// Browse-only: the folder this file sits in inside the peer's
-		// share. The core attaches it to results filed from a shared-file
-		// listing and to nothing else, so an ordinary server/Kad hit
-		// simply leaves it empty.
-		if (const CECTag *x = sf->GetTagByName(EC_TAG_SEARCHFILE_DIRECTORY)) {
-			r.directory = std::string(x->GetStringData().utf8_str());
-		}
-		// Media metadata (issue #430): present when the hit carried
-		// FT_MEDIA_* tags. On a locally known/probed file those are our
-		// own probe's values; on a remote hit they are whatever the
-		// responding server advertised, which is not validated anywhere
-		// and can contradict the file (a .pdf with a runtime and an xvid
-		// codec is a real observed result). Passed through as sent -- the
-		// API documents the search-result `media` as unverified rather
-		// than second-guessing the server. Any present tag marks
-		// has_media so the API emits the `media` object.
-		{
-			std::uint32_t v = 0;
-			if (sf->AssignIfExist(EC_TAG_KNOWNFILE_MEDIA_LENGTH, v)) {
-				r.media.length_s = v;
-			}
-			if (sf->AssignIfExist(EC_TAG_KNOWNFILE_MEDIA_BITRATE, v)) {
-				r.media.bitrate = v;
-			}
-		}
-		if (const CECTag *x = sf->GetTagByName(EC_TAG_KNOWNFILE_MEDIA_CODEC)) {
-			r.media.codec = std::string(x->GetStringData().utf8_str());
-		}
-		if (const CECTag *x = sf->GetTagByName(EC_TAG_KNOWNFILE_MEDIA_ARTIST)) {
-			r.media.artist = std::string(x->GetStringData().utf8_str());
-		}
-		if (const CECTag *x = sf->GetTagByName(EC_TAG_KNOWNFILE_MEDIA_ALBUM)) {
-			r.media.album = std::string(x->GetStringData().utf8_str());
-		}
-		if (const CECTag *x = sf->GetTagByName(EC_TAG_KNOWNFILE_MEDIA_TITLE)) {
-			r.media.title = std::string(x->GetStringData().utf8_str());
-		}
-		// Derived from the fields, exactly as MergeKnownFileDetail does for a
-		// shared file. Both paths share AddMediaTagsPresent on the daemon
-		// side, so either can be sent a zero / empty "this field is gone" tag
-		// -- latching on any tag being present would mark a result as having
-		// media with every field blank.
-		r.has_media = r.media.length_s != 0 || r.media.bitrate != 0 || !r.media.codec.empty() ||
-			      !r.media.artist.empty() || !r.media.album.empty() || !r.media.title.empty();
-		// On-demand Kad community ratings/comments (issue #434). Same
-		// 4-children-per-entry positional container the download side uses
-		// (username, filename, rating, comment); a search hit's comments are
-		// purely Kad notes.
-		if (const CECTag *cont = sf->GetTagByName(EC_TAG_PARTFILE_COMMENTS)) {
-			std::vector<const CECTag *> kids;
-			for (const CECTag &kid : *cont)
-				kids.push_back(&kid);
-			for (std::size_t i = 0; i + 3 < kids.size(); i += 4) {
-				SearchResult::Comment c;
-				c.username = std::string(kids[i]->GetStringData().utf8_str());
-				c.filename = std::string(kids[i + 1]->GetStringData().utf8_str());
-				c.rating = static_cast<std::int32_t>(
-					static_cast<std::int64_t>(kids[i + 2]->GetInt()));
-				c.comment = std::string(kids[i + 3]->GetStringData().utf8_str());
-				r.comments.push_back(std::move(c));
-			}
-		}
-		{
-			std::uint32_t v = 0;
-			if (sf->AssignIfExist(EC_TAG_PARTFILE_KAD_COMMENT_SEARCHING, v))
-				r.kad_comment_searching = v != 0;
-		}
-		cache.emplace(r.ecid, std::move(r));
+	r.ecid = sf->ID();
+	// Identity and the immutable descriptors. Under INC_UPDATE these
+	// travel once and are diffed away afterwards, and the accessors
+	// answer through GetTagByNameSafe -- an absent tag reads as an empty
+	// string or 0, which would wipe the field rather than leave it. So
+	// each one is written only when its tag is actually on this packet.
+	if (sf->GetTagByName(EC_TAG_PARTFILE_HASH)) {
+		std::string h(sf->FileHashString().utf8_str());
+		std::transform(
+			h.begin(), h.end(), h.begin(), [](unsigned char c) { return std::tolower(c); });
+		r.hash = std::move(h);
 	}
+	if (sf->GetTagByName(EC_TAG_PARTFILE_NAME)) {
+		r.name = std::string(sf->FileName().utf8_str());
+	}
+	if (sf->GetTagByName(EC_TAG_PARTFILE_SIZE_FULL)) {
+		r.size = sf->SizeFull();
+	}
+	{
+		std::uint32_t v = 0;
+		if (sf->AssignIfExist(EC_TAG_PARTFILE_SOURCE_COUNT, v))
+			r.source_count = v;
+	}
+	{
+		std::uint32_t v = 0;
+		if (sf->AssignIfExist(EC_TAG_PARTFILE_SOURCE_COUNT_XFER, v))
+			r.complete_source_count = v;
+	}
+	// Grouping (issue #431): a child hit carries its parent's ECID in
+	// EC_TAG_SEARCH_PARENT. Recorded here; folded into the parent's
+	// children[] in the second pass below.
+	{
+		std::uint32_t v = 0;
+		if (sf->AssignIfExist(EC_TAG_SEARCH_PARENT, v)) {
+			r.parent_ecid = v;
+			r.has_parent = true;
+		}
+	}
+	{
+		std::uint8_t v = 0;
+		if (sf->AssignIfExist(EC_TAG_KNOWNFILE_RATING, v))
+			r.rating = v;
+	}
+	// Download status (issue #429): amuled packs the CSearchFile
+	// status in EC_TAG_PARTFILE_STATUS on every search-result tag.
+	// Download status (issue #429): amuled packs the CSearchFile status
+	// in EC_TAG_PARTFILE_STATUS. `already_have` is not its own field on
+	// the wire -- AlreadyHave() reads the same tag -- so both move
+	// together, and both are left alone when the tag is diffed away.
+	// Writing the absent case as status 0 would report every unchanged
+	// result as "new" on the very polls that say nothing changed.
+	{
+		std::uint32_t v = 0;
+		if (sf->AssignIfExist(EC_TAG_PARTFILE_STATUS, v)) {
+			r.status = SearchStatusName(v);
+			r.already_have = sf->AlreadyHave();
+		}
+	}
+	// File type, computed from the filename (no EC data needed).
+	// Derived from the filename, so it is recomputed whenever the name is.
+	if (!r.name.empty()) {
+		r.type = FileTypeToken(r.name);
+	}
+	// Browse-only: the folder this file sits in inside the peer's
+	// share. The core attaches it to results filed from a shared-file
+	// listing and to nothing else, so an ordinary server/Kad hit
+	// simply leaves it empty.
+	if (const CECTag *x = sf->GetTagByName(EC_TAG_SEARCHFILE_DIRECTORY)) {
+		r.directory = std::string(x->GetStringData().utf8_str());
+	}
+	// Media metadata (issue #430): present when the hit carried
+	// FT_MEDIA_* tags. On a locally known/probed file those are our
+	// own probe's values; on a remote hit they are whatever the
+	// responding server advertised, which is not validated anywhere
+	// and can contradict the file (a .pdf with a runtime and an xvid
+	// codec is a real observed result). Passed through as sent -- the
+	// API documents the search-result `media` as unverified rather
+	// than second-guessing the server. Any present tag marks
+	// has_media so the API emits the `media` object.
+	{
+		std::uint32_t v = 0;
+		if (sf->AssignIfExist(EC_TAG_KNOWNFILE_MEDIA_LENGTH, v)) {
+			r.media.length_s = v;
+		}
+		if (sf->AssignIfExist(EC_TAG_KNOWNFILE_MEDIA_BITRATE, v)) {
+			r.media.bitrate = v;
+		}
+	}
+	if (const CECTag *x = sf->GetTagByName(EC_TAG_KNOWNFILE_MEDIA_CODEC)) {
+		r.media.codec = std::string(x->GetStringData().utf8_str());
+	}
+	if (const CECTag *x = sf->GetTagByName(EC_TAG_KNOWNFILE_MEDIA_ARTIST)) {
+		r.media.artist = std::string(x->GetStringData().utf8_str());
+	}
+	if (const CECTag *x = sf->GetTagByName(EC_TAG_KNOWNFILE_MEDIA_ALBUM)) {
+		r.media.album = std::string(x->GetStringData().utf8_str());
+	}
+	if (const CECTag *x = sf->GetTagByName(EC_TAG_KNOWNFILE_MEDIA_TITLE)) {
+		r.media.title = std::string(x->GetStringData().utf8_str());
+	}
+	// Derived from the fields, exactly as MergeKnownFileDetail does for a
+	// shared file. Both paths share AddMediaTagsPresent on the daemon
+	// side, so either can be sent a zero / empty "this field is gone" tag
+	// -- latching on any tag being present would mark a result as having
+	// media with every field blank.
+	r.has_media = r.media.length_s != 0 || r.media.bitrate != 0 || !r.media.codec.empty() ||
+		      !r.media.artist.empty() || !r.media.album.empty() || !r.media.title.empty();
+	// On-demand Kad community ratings/comments (issue #434). Same
+	// 4-children-per-entry positional container the download side uses
+	// (username, filename, rating, comment); a search hit's comments are
+	// purely Kad notes.
+	// The comments container is the one field where absence is a value,
+	// not silence: it is built only when there are notes and is added
+	// without the valuemap, so it is never diffed away. An absent one
+	// therefore means "no notes", and a present one replaces the set
+	// rather than appending to it.
+	//
+	// The searching flag beside it is NOT in that category -- it goes
+	// through the valuemap like every other field, so it follows the
+	// ordinary absent-means-unchanged rule below.
+	r.comments.clear();
+	if (const CECTag *cont = sf->GetTagByName(EC_TAG_PARTFILE_COMMENTS)) {
+		std::vector<const CECTag *> kids;
+		for (const CECTag &kid : *cont)
+			kids.push_back(&kid);
+		for (std::size_t i = 0; i + 3 < kids.size(); i += 4) {
+			SearchResult::Comment c;
+			c.username = std::string(kids[i]->GetStringData().utf8_str());
+			c.filename = std::string(kids[i + 1]->GetStringData().utf8_str());
+			c.rating =
+				static_cast<std::int32_t>(static_cast<std::int64_t>(kids[i + 2]->GetInt()));
+			c.comment = std::string(kids[i + 3]->GetStringData().utf8_str());
+			r.comments.push_back(std::move(c));
+		}
+	}
+	{
+		std::uint32_t v = 0;
+		if (sf->AssignIfExist(EC_TAG_PARTFILE_KAD_COMMENT_SEARCHING, v))
+			r.kad_comment_searching = v != 0;
+	}
+}
 
-	// Second pass (issue #431): fold each child into its parent's
-	// children[] and drop it from the top-level set, so the API serves
-	// one parent row per hash+size with the alternative filenames nested.
-	// A child whose parent isn't in the set (shouldn't happen — the core
-	// emits the parent before its children) is left as a top-level row so
-	// nothing is silently lost.
-	std::vector<std::uint32_t> folded;
-	for (auto &kv : cache) {
-		SearchResult &child = kv.second;
+// Rebuild the folded view (`results`) from the flat merge target (`raw`).
+//
+// Kept as a pass over `raw` rather than merged into directly: a grouped child
+// is addressable by its own ECID on the wire and gets diffed tags of its own,
+// so it has to stay in `raw`, while every reader wants it nested in its
+// parent. Rebuilding is O(n) in one search's results and runs only when that
+// search actually changed.
+void RebuildFoldedResults(
+	const std::map<std::uint32_t, SearchResult> &raw, std::map<std::uint32_t, SearchResult> &out)
+{
+	out.clear();
+	// Parents first, so a child always finds its parent already present.
+	for (const auto &kv : raw) {
+		if (!kv.second.has_parent)
+			out.emplace(kv.first, kv.second);
+	}
+	// Then fold each child into its parent's children[] (issue #431), so the
+	// API serves one row per hash+size with the alternative filenames nested.
+	// A child whose parent is not in the set -- which should not happen, the
+	// core emits the parent first -- is promoted to a top-level row instead,
+	// so nothing is silently lost.
+	for (const auto &kv : raw) {
+		const SearchResult &child = kv.second;
 		if (!child.has_parent)
 			continue;
-		auto pit = cache.find(child.parent_ecid);
-		if (pit == cache.end())
+		auto pit = out.find(child.parent_ecid);
+		if (pit == out.end()) {
+			out.emplace(kv.first, child);
 			continue;
+		}
 		SearchResult::Child c;
 		c.ecid = child.ecid;
 		c.name = child.name;
@@ -2554,10 +2598,112 @@ void ApplySearchFull(const CECPacket *resp, std::map<std::uint32_t, SearchResult
 		c.complete_source_count = child.complete_source_count;
 		c.directory = child.directory;
 		pit->second.children.push_back(std::move(c));
-		folded.push_back(kv.first);
 	}
-	for (std::uint32_t ecid : folded) {
-		cache.erase(ecid);
+}
+
+// Apply one incremental multi-search union reply across every search slot.
+//
+// The reply is not per-search: it carries every result of every search the
+// daemon holds, and it carries them incrementally. Two consequences drive the
+// shape here.
+//
+// First, EC_TAG_SEARCH_ID travels only the first time the daemon tells us
+// about a result -- after that the tag is diffed away, because a result never
+// changes owner. So a tag without one is attributed through `owner`, the index
+// this function is responsible for keeping in step with the slots.
+//
+// Second, absence no longer means deletion. A result the daemon still holds
+// but has nothing new to say about is omitted entirely; removal is explicit,
+// as one EC_TAG_FILE_REMOVED per gone ECID. Sweeping "anything missing is
+// gone" here would delete the whole result set on the first quiet poll.
+void ApplySearchUnion(const CECPacket *resp,
+	std::map<std::uint32_t, SearchSlot> &slots,
+	std::map<std::uint32_t, std::uint32_t> &owner,
+	std::uint32_t default_sid)
+{
+	if (!resp)
+		return;
+	// Slots that actually took a change, so the fold below only re-runs for
+	// those rather than for every open search on every poll.
+	std::set<std::uint32_t> touched;
+
+	for (const CECTag &tag : *resp) {
+		const CECTag *t = &tag;
+
+		if (t->GetTagName() == EC_TAG_FILE_REMOVED) {
+			const std::uint32_t ecid = static_cast<std::uint32_t>(t->GetInt());
+			const auto oit = owner.find(ecid);
+			if (oit == owner.end())
+				continue;
+			const auto sit = slots.find(oit->second);
+			if (sit != slots.end() && sit->second.raw.erase(ecid) != 0)
+				touched.insert(oit->second);
+			owner.erase(oit);
+			continue;
+		}
+
+		if (t->GetTagName() != EC_TAG_SEARCHFILE)
+			continue;
+		const CEC_SearchFile_Tag *sf = static_cast<const CEC_SearchFile_Tag *>(t);
+		const std::uint32_t ecid = sf->ID();
+
+		// Present on a result's first appearance, diffed away afterwards.
+		std::uint32_t sid = 0;
+		if (const CECTag *x = sf->GetTagByName(EC_TAG_SEARCH_ID)) {
+			sid = static_cast<std::uint32_t>(x->GetInt());
+			owner[ecid] = sid;
+		} else if (default_sid != 0) {
+			// A per-search reply: every tag in it belongs to the search the
+			// caller asked for, and that form carries no id of its own.
+			sid = default_sid;
+			owner[ecid] = sid;
+		} else {
+			const auto oit = owner.find(ecid);
+			if (oit == owner.end()) {
+				// A diffed tag for a result we have no record of. Only
+				// reachable if our slot went away while the daemon still
+				// believed we held it -- there is nothing to apply it to,
+				// and inventing a slot would produce a search with no
+				// lifecycle state behind it.
+				continue;
+			}
+			sid = oit->second;
+		}
+
+		const auto sit = slots.find(sid);
+		if (sit == slots.end()) {
+			// Results for a search this session has no slot for. Dropped
+			// rather than auto-created: MarkSearchStarted / discovery own
+			// slot creation, and they also set the lifecycle state that
+			// GET /search reports.
+			owner.erase(ecid);
+			continue;
+		}
+		auto &slot_results = sit->second.raw;
+		const auto existing = slot_results.find(ecid);
+		if (existing == slot_results.end()) {
+			// First sight of this result. Seed the fields whose "absent"
+			// reading differs between a fresh row and a diff: status has no
+			// sensible empty value, and the daemon's own default for a hit
+			// it has said nothing about is the zero code. Merging onto a
+			// default-constructed SearchResult would leave it "", which is
+			// not a state any consumer knows.
+			SearchResult fresh;
+			fresh.ecid = ecid;
+			fresh.status = SearchStatusName(0);
+			MergeSearchResultTag(sf, fresh);
+			slot_results.emplace(ecid, std::move(fresh));
+		} else {
+			MergeSearchResultTag(sf, existing->second);
+			existing->second.ecid = ecid;
+		}
+		touched.insert(sid);
+	}
+
+	for (std::uint32_t sid : touched) {
+		const auto sit = slots.find(sid);
+		if (sit != slots.end())
+			RebuildFoldedResults(sit->second.raw, sit->second.results);
 	}
 }
 

--- a/src/webapi/Refresher.cpp
+++ b/src/webapi/Refresher.cpp
@@ -2636,7 +2636,19 @@ void ApplySearchUnion(const CECPacket *resp,
 			if (oit == owner.end())
 				continue;
 			const auto sit = slots.find(oit->second);
-			if (sit != slots.end() && sit->second.raw.erase(ecid) != 0)
+			if (sit == slots.end()) {
+				owner.erase(oit);
+				continue;
+			}
+			if (sit->second.detached) {
+				// The daemon evicted this whole search and is tombstoning
+				// its results on the way out. Retirement deliberately keeps
+				// them for late reads, so the removals are ignored -- and
+				// the index entries with them, since nothing else will
+				// re-establish them.
+				continue;
+			}
+			if (sit->second.raw.erase(ecid) != 0)
 				touched.insert(oit->second);
 			owner.erase(oit);
 			continue;
@@ -2672,11 +2684,25 @@ void ApplySearchUnion(const CECPacket *resp,
 
 		const auto sit = slots.find(sid);
 		if (sit == slots.end()) {
-			// Results for a search this session has no slot for. Dropped
-			// rather than auto-created: MarkSearchStarted / discovery own
-			// slot creation, and they also set the lifecycle state that
+			// Results for a search this session has no slot for -- one
+			// started in amulegui or the monolithic GUI, since the union
+			// responder walks every search the core holds. Dropped rather
+			// than auto-created: MarkSearchStarted / discovery own slot
+			// creation, and they also set the lifecycle state that
 			// GET /search reports.
+			//
+			// The drop is not the loss it would otherwise be, because the
+			// daemon has now marked these ECIDs sent and will elide them
+			// from every later poll. Whoever creates the slot re-reads the
+			// search in full instead: DiscoverSearchIfHeldByCore seeds it
+			// via FetchOneSearchFull, which bypasses the differential
+			// stream entirely.
 			owner.erase(ecid);
+			continue;
+		}
+		if (sit->second.detached) {
+			// Frozen: the daemon no longer holds this search, so anything
+			// arriving for it is the tail of an eviction, not an update.
 			continue;
 		}
 		auto &slot_results = sit->second.raw;

--- a/src/webapi/Refresher.h
+++ b/src/webapi/Refresher.h
@@ -32,6 +32,7 @@
 #include <vector>
 
 class CECPacket;
+class CEC_SearchFile_Tag;
 class CamuleapiApp;
 class PartFileEncoderData;
 
@@ -70,7 +71,7 @@ enum class SearchFetchOutcome
 // identical request (EC_DETAIL_FULL plus the EC_TAG_SEARCH_PARENT grouping
 // flag) and feed the identical applier — a results list read through either
 // route has the same shape.
-SearchFetchOutcome FetchSearchResults(CamuleapiApp &app, CState &state, std::uint32_t search_id);
+SearchFetchOutcome FetchSearchResults(CamuleapiApp &app, CState &state);
 
 // Single-threaded SSE diff emission. Called ONLY from the wxApp
 // refresher loop after a successful RefresherTick so that the
@@ -263,7 +264,28 @@ void ParseGraphsFromPacket(const CECPacket *resp, StatsGraphs &out);
 // Cache is keyed by ECID; cleared on each refresher tick before
 // applying.
 struct SearchResult;
-void ApplySearchFull(const CECPacket *resp, std::map<std::uint32_t, SearchResult> &cache);
+struct SearchSlot;
+// Merge one EC_TAG_SEARCHFILE onto a result, writing only the fields the tag
+// carries. Exposed for the unit tests, which drive it directly to pin the
+// absent-means-unchanged contract field by field.
+void MergeSearchResultTag(const CEC_SearchFile_Tag *sf, SearchResult &r);
+
+// Rebuild the folded view from the flat merge target: children nested into
+// their parents, orphans promoted.
+void RebuildFoldedResults(
+	const std::map<std::uint32_t, SearchResult> &raw, std::map<std::uint32_t, SearchResult> &out);
+
+// Apply one incremental multi-search union reply across every slot, keeping
+// the ECID -> search_id index in step. See the definition for why absence
+// cannot mean deletion here.
+// `default_sid` attributes tags that carry no EC_TAG_SEARCH_ID of their own.
+// Zero for the union reply, where a missing id means "already known" and the
+// index answers it; set for a per-search reply, where the whole packet belongs
+// to one search and the responder never stamps an id.
+void ApplySearchUnion(const CECPacket *resp,
+	std::map<std::uint32_t, SearchSlot> &slots,
+	std::map<std::uint32_t, std::uint32_t> &owner,
+	std::uint32_t default_sid = 0);
 
 // Search-progress derivation from the EC_TAG_SEARCH_LIFECYCLE_* tags.
 // `lifecycle_state` is the uint8 enum value (0=idle, 1=running,

--- a/src/webapi/Refresher.h
+++ b/src/webapi/Refresher.h
@@ -73,6 +73,12 @@ enum class SearchFetchOutcome
 // route has the same shape.
 SearchFetchOutcome FetchSearchResults(CamuleapiApp &app, CState &state);
 
+// Re-fetch one search at EC_DETAIL_FULL. The union has no resync opcode, so
+// this is how a newly discovered slot is filled and how a request handler
+// refreshes without becoming a second issuer of the stateful stream. See the
+// definition.
+SearchFetchOutcome FetchOneSearchFull(CamuleapiApp &app, CState &state, std::uint32_t search_id);
+
 // Single-threaded SSE diff emission. Called ONLY from the wxApp
 // refresher loop after a successful RefresherTick so that the
 // LastSeenState walk (which mutates app.LastSeenForEvents()) is

--- a/src/webapi/RefresherTick.cpp
+++ b/src/webapi/RefresherTick.cpp
@@ -78,6 +78,51 @@ SearchFetchOutcome FetchSearchResults(CamuleapiApp &app, CState &state)
 	return SearchFetchOutcome::Updated;
 }
 
+// Re-fetch ONE search at EC_DETAIL_FULL, bypassing the union entirely.
+//
+// The union is a stateful differential stream: the daemon records what it has
+// sent this connection and then sends only changes, with no opcode for "send
+// it all again". That makes it the wrong tool twice over, and this is the
+// escape hatch for both.
+//
+// Seeding a newly discovered slot. The union responder walks
+// GetKnownSearchIds() -- every search the core holds, including ones started
+// in amulegui or the monolithic GUI. ApplySearchUnion drops results for a
+// search it has no slot for, but the daemon has already marked those ECIDs
+// delivered and seeded its valuemap, so on the next poll they are unchanged
+// and elided: dropped once means dropped forever. A slot created later by
+// discovery would stay empty. This fetch is what fills it.
+//
+// Serving the HTTP thread. The union must have exactly one issuer, or two
+// replies can be applied out of order and leave a ghost row no later poll can
+// clear -- SendRecvSerialized serialises the roundtrip, not the roundtrip plus
+// the apply. A FULL reply is self-contained and idempotent, so issuing this
+// from a request handler races nothing.
+SearchFetchOutcome FetchOneSearchFull(CamuleapiApp &app, CState &state, std::uint32_t search_id)
+{
+	std::unique_ptr<CECPacket> req(new CECPacket(EC_OP_SEARCH_RESULTS, EC_DETAIL_FULL));
+	req->AddTag(CECEmptyTag(EC_TAG_SEARCH_PARENT));
+	req->AddTag(CECTag(EC_TAG_SEARCH_ID, search_id));
+	const CECPacket *resp = app.SendRecvSerialized(req.get());
+	if (!resp)
+		return SearchFetchOutcome::EcFailed;
+	SearchFetchOutcome outcome = SearchFetchOutcome::Updated;
+	if (resp->GetTagByName(EC_TAG_SEARCH_EXPIRED)) {
+		outcome = SearchFetchOutcome::Expired;
+	} else {
+		// Same merge the union uses. The per-search responder builds its tags
+		// without a valuemap, so every field of every result is present and
+		// the merge's absent-means-unchanged rule simply never fires. The
+		// reply carries no EC_TAG_SEARCH_ID of its own, hence the explicit id.
+		state.MutateAllSearches([&](std::map<std::uint32_t, SearchSlot> &slots,
+						std::map<std::uint32_t, std::uint32_t> &owner) {
+			ApplySearchUnion(resp, slots, owner, search_id);
+		});
+	}
+	delete resp;
+	return outcome;
+}
+
 bool RefresherTick(CamuleapiApp &app, CState &state)
 {
 	// Per-tick budget: a few EC ops via SendRecvSerialized
@@ -283,41 +328,10 @@ bool RefresherTick(CamuleapiApp &app, CState &state)
 		delete resp;
 	}
 
-	// Results for every search in one roundtrip, before the per-search
-	// progress loop below.
-	//
-	// Gated on there being any search at all, not on which ones are active. A
-	// finished search still changes -- a hit gets downloaded, a Kad notes
-	// lookup lands -- and now costs nothing to keep polling, which is what
-	// lets those changes be seen rather than only appearing on a client's
-	// next read. What is not worth paying for is the empty case: a daemon
-	// holding no searches would otherwise take a roundtrip a second forever
-	// to be told so.
-	//
-	// Deliberately NOT gated on SSE subscribers. The diff walk is (see
-	// CEventBus's subscriber accounting), but the fetch cannot be: a REST
-	// client polling GET /search/{id}/results reads this cache, and for an
-	// active search nothing else refreshes it -- ClaimSearchRefresh covers
-	// only slots that are not active. Skipping the fetch when nobody is
-	// subscribed would hand that client frozen results.
-	//
-	// HasAnySearch() asks about OUR slots, not the daemon's searches, and the
-	// daemon never tells us about one unasked: a slot exists only because
-	// this process started the search or because a read discovered it
-	// (RequireSearch -> DiscoverSearchIfHeldByCore, a one-off
-	// EC_OP_SEARCH_LIST on a cache miss). A search begun in amulegui or the
-	// monolithic GUI therefore leaves this false, and the union is not sent.
-	//
-	// That costs nothing, because ApplySearchUnion drops results for a search
-	// with no slot anyway -- polling on an empty map would fetch them only to
-	// discard them. Neither discovery route runs through here: GET /search
-	// goes straight to EC_OP_SEARCH_LIST every call, and a by-id read seeds
-	// the slot itself, after which this opens.
-	if (state.HasAnySearch() && FetchSearchResults(app, state) == SearchFetchOutcome::EcFailed) {
-		// Same rule as every other step in the tick: a failed roundtrip bails
-		// the whole tick rather than exposing a half-refreshed cache.
-		return false;
-	}
+	// Per-search lifecycle, off the progress union fetched above (or one
+	// roundtrip each against an older daemon). Runs BEFORE the results poll
+	// below so an eviction is seen, and the slot frozen, while its results
+	// are still there to keep -- see the `expired` branch.
 	for (std::uint32_t sid : active_sids) {
 		std::uint32_t percent = 0;
 		std::uint32_t lifecycle_state = 0;
@@ -358,6 +372,16 @@ bool RefresherTick(CamuleapiApp &app, CState &state)
 			// slot as finished + inactive so we stop polling it but keep the
 			// last-known results for late reads; the terminal state also drives
 			// a final search_progress SSE frame for subscribers.
+			//
+			// Detaching is what makes "keep the last-known results" true. The
+			// same eviction makes the union emit an EC_TAG_FILE_REMOVED for
+			// every one of this search's results, which would erase precisely
+			// what is being kept -- so the slot is frozen here, before the
+			// union below is fetched, and ApplySearchUnion then leaves it be.
+			// Hence this loop running ahead of the results poll: the progress
+			// union it reads was fetched separately, above, so the order is
+			// free.
+			state.DetachSearch(sid);
 			SearchProgressSnapshot fin = state.SearchProgress(sid);
 			fin.active = false;
 			fin.complete = true;
@@ -368,6 +392,43 @@ bool RefresherTick(CamuleapiApp &app, CState &state)
 		const SearchProgressSnapshot next =
 			AdvanceSearchProgress(state.SearchProgress(sid), lifecycle_state, percent);
 		state.WriteSearchProgress(sid, next);
+	}
+
+	// Results for every search in one roundtrip.
+	//
+	// Gated on there being any search at all, not on which ones are active. A
+	// finished search still changes -- a hit gets downloaded, a Kad notes
+	// lookup lands -- and now costs nothing to keep polling, which is what
+	// lets those changes be seen rather than only appearing on a client's
+	// next read. What is not worth paying for is the empty case: a daemon
+	// holding no searches would otherwise take a roundtrip a second forever
+	// to be told so.
+	//
+	// Deliberately NOT gated on SSE subscribers. The diff walk is (see
+	// CEventBus's subscriber accounting), but the fetch cannot be: a REST
+	// client polling GET /search/{id}/results reads this cache, and for an
+	// active search nothing else refreshes it -- ClaimSearchRefresh covers
+	// only slots that are not active. Skipping the fetch when nobody is
+	// subscribed would hand that client frozen results.
+	//
+	// HasAnySearch() asks about OUR slots, not the daemon's searches, and the
+	// daemon never tells us about one unasked: a slot exists only because
+	// this process started the search or because a read discovered it
+	// (RequireSearch -> DiscoverSearchIfHeldByCore, a one-off
+	// EC_OP_SEARCH_LIST on a cache miss). A search begun in amulegui or the
+	// monolithic GUI therefore leaves this false, and the union is not sent.
+	//
+	// Skipping the poll is not merely an optimisation there, it is the point.
+	// ApplySearchUnion drops results for a search it has no slot for, and the
+	// daemon marks them sent regardless, so polling with nothing to apply
+	// them to would burn through a foreign search's results once and elide
+	// them forever after. Neither discovery route runs through here:
+	// GET /search goes straight to EC_OP_SEARCH_LIST every call, and a by-id
+	// read seeds the slot in full via FetchOneSearchFull before this opens.
+	if (state.HasAnySearch() && FetchSearchResults(app, state) == SearchFetchOutcome::EcFailed) {
+		// Same rule as every other step in the tick: a failed roundtrip bails
+		// the whole tick rather than exposing a half-refreshed cache.
+		return false;
 	}
 
 	// /preferences + /categories — one EC roundtrip populates both.

--- a/src/webapi/RefresherTick.cpp
+++ b/src/webapi/RefresherTick.cpp
@@ -411,8 +411,11 @@ bool RefresherTick(CamuleapiApp &app, CState &state)
 	// only slots that are not active. Skipping the fetch when nobody is
 	// subscribed would hand that client frozen results.
 	//
-	// HasAnySearch() asks about OUR slots, not the daemon's searches, and the
-	// daemon never tells us about one unasked: a slot exists only because
+	// HasAnySearch() asks about OUR slots -- specifically the ones the daemon
+	// could still speak for, since a detached slot's search has already been
+	// evicted core-side and polling for it would never return anything. It
+	// does not ask about the daemon's searches, and the daemon never tells us
+	// about one unasked: a slot exists only because
 	// this process started the search or because a read discovered it
 	// (RequireSearch -> DiscoverSearchIfHeldByCore, a one-off
 	// EC_OP_SEARCH_LIST on a cache miss). A search begun in amulegui or the

--- a/src/webapi/RefresherTick.cpp
+++ b/src/webapi/RefresherTick.cpp
@@ -45,26 +45,37 @@
 namespace webapi
 {
 
-SearchFetchOutcome FetchSearchResults(CamuleapiApp &app, CState &state, std::uint32_t search_id)
+// One id-less EC_OP_SEARCH_RESULTS at EC_DETAIL_INC_UPDATE: the daemon answers
+// with every result of every search it holds, incrementally.
+//
+// This replaced one EC_DETAIL_FULL roundtrip per active search, each carrying
+// that search's whole result set on every tick whether or not anything had
+// changed. With eliding, an unchanged result costs nothing on the wire and an
+// idle or finished search costs nothing at all -- which is what makes polling
+// finished searches affordable, and is why the caller no longer filters on
+// ActiveSearchIds().
+//
+// No single-search fallback: amuleapi already advertises multi-search
+// unconditionally and never checks whether the daemon supports it (App.cpp),
+// so it has always required a matching daemon for search. EC_TAG_CAN_PARTIAL_SEARCH
+// is advertised for every client of CRemoteConnect, so the daemon is already
+// eliding for this connection.
+SearchFetchOutcome FetchSearchResults(CamuleapiApp &app, CState &state)
 {
-	std::unique_ptr<CECPacket> req(new CECPacket(EC_OP_SEARCH_RESULTS, EC_DETAIL_FULL));
+	std::unique_ptr<CECPacket> req(new CECPacket(EC_OP_SEARCH_RESULTS, EC_DETAIL_INC_UPDATE));
 	// Opt into result grouping (issue #431): the empty EC_TAG_SEARCH_PARENT
-	// flag tells the FULL responder to also emit each same-hash/different-name
+	// flag tells the responder to also emit each same-hash/different-name
 	// child so the results list can nest them.
 	req->AddTag(CECEmptyTag(EC_TAG_SEARCH_PARENT));
-	req->AddTag(CECTag(EC_TAG_SEARCH_ID, search_id));
 	const CECPacket *resp = app.SendRecvSerialized(req.get());
 	if (!resp)
 		return SearchFetchOutcome::EcFailed;
-	SearchFetchOutcome outcome = SearchFetchOutcome::Updated;
-	if (resp->GetTagByName(EC_TAG_SEARCH_EXPIRED)) {
-		outcome = SearchFetchOutcome::Expired;
-	} else {
-		state.MutateSearch(search_id,
-			[&](std::map<std::uint32_t, SearchResult> &cache) { ApplySearchFull(resp, cache); });
-	}
+	state.MutateAllSearches([&](std::map<std::uint32_t, SearchSlot> &slots,
+					std::map<std::uint32_t, std::uint32_t> &owner) {
+		ApplySearchUnion(resp, slots, owner);
+	});
 	delete resp;
-	return outcome;
+	return SearchFetchOutcome::Updated;
 }
 
 bool RefresherTick(CamuleapiApp &app, CState &state)
@@ -272,22 +283,21 @@ bool RefresherTick(CamuleapiApp &app, CState &state)
 		delete resp;
 	}
 
+	// Results for every search in one roundtrip, before the per-search
+	// progress loop below. Not gated on active_sids: a finished search still
+	// changes (a hit gets downloaded, a Kad notes lookup lands) and now costs
+	// nothing to keep polling, which is what lets those changes be observed
+	// at all rather than only on a client's next read.
+	if (FetchSearchResults(app, state) == SearchFetchOutcome::EcFailed) {
+		// Same rule as every other step in the tick: a failed roundtrip bails
+		// the whole tick rather than exposing a half-refreshed cache.
+		return false;
+	}
 	for (std::uint32_t sid : active_sids) {
 		std::uint32_t percent = 0;
 		std::uint32_t lifecycle_state = 0;
 		bool expired = false;
-		switch (FetchSearchResults(app, state, sid)) {
-		case SearchFetchOutcome::EcFailed:
-			// Same rule as every other step in the tick: a failed roundtrip
-			// bails the whole tick rather than exposing a half-refreshed cache.
-			return false;
-		case SearchFetchOutcome::Expired:
-			expired = true;
-			break;
-		case SearchFetchOutcome::Updated:
-			break;
-		}
-		if (!expired && have_union) {
+		if (have_union) {
 			// Already fetched above; absent means the daemon dropped it.
 			const auto found = union_progress.find(sid);
 			if (found == union_progress.end()) {
@@ -296,7 +306,7 @@ bool RefresherTick(CamuleapiApp &app, CState &state)
 				percent = found->second.first;
 				lifecycle_state = found->second.second;
 			}
-		} else if (!expired) {
+		} else {
 			std::unique_ptr<CECPacket> req(new CECPacket(EC_OP_SEARCH_PROGRESS));
 			req->AddTag(CECTag(EC_TAG_SEARCH_ID, sid));
 			const CECPacket *resp = app.SendRecvSerialized(req.get());

--- a/src/webapi/RefresherTick.cpp
+++ b/src/webapi/RefresherTick.cpp
@@ -284,11 +284,36 @@ bool RefresherTick(CamuleapiApp &app, CState &state)
 	}
 
 	// Results for every search in one roundtrip, before the per-search
-	// progress loop below. Not gated on active_sids: a finished search still
-	// changes (a hit gets downloaded, a Kad notes lookup lands) and now costs
-	// nothing to keep polling, which is what lets those changes be observed
-	// at all rather than only on a client's next read.
-	if (FetchSearchResults(app, state) == SearchFetchOutcome::EcFailed) {
+	// progress loop below.
+	//
+	// Gated on there being any search at all, not on which ones are active. A
+	// finished search still changes -- a hit gets downloaded, a Kad notes
+	// lookup lands -- and now costs nothing to keep polling, which is what
+	// lets those changes be seen rather than only appearing on a client's
+	// next read. What is not worth paying for is the empty case: a daemon
+	// holding no searches would otherwise take a roundtrip a second forever
+	// to be told so.
+	//
+	// Deliberately NOT gated on SSE subscribers. The diff walk is (see
+	// CEventBus's subscriber accounting), but the fetch cannot be: a REST
+	// client polling GET /search/{id}/results reads this cache, and for an
+	// active search nothing else refreshes it -- ClaimSearchRefresh covers
+	// only slots that are not active. Skipping the fetch when nobody is
+	// subscribed would hand that client frozen results.
+	//
+	// HasAnySearch() asks about OUR slots, not the daemon's searches, and the
+	// daemon never tells us about one unasked: a slot exists only because
+	// this process started the search or because a read discovered it
+	// (RequireSearch -> DiscoverSearchIfHeldByCore, a one-off
+	// EC_OP_SEARCH_LIST on a cache miss). A search begun in amulegui or the
+	// monolithic GUI therefore leaves this false, and the union is not sent.
+	//
+	// That costs nothing, because ApplySearchUnion drops results for a search
+	// with no slot anyway -- polling on an empty map would fetch them only to
+	// discard them. Neither discovery route runs through here: GET /search
+	// goes straight to EC_OP_SEARCH_LIST every call, and a by-id read seeds
+	// the slot itself, after which this opens.
+	if (state.HasAnySearch() && FetchSearchResults(app, state) == SearchFetchOutcome::EcFailed) {
 		// Same rule as every other step in the tick: a failed roundtrip bails
 		// the whole tick rather than exposing a half-refreshed cache.
 		return false;

--- a/src/webapi/State.cpp
+++ b/src/webapi/State.cpp
@@ -275,6 +275,12 @@ std::vector<std::uint32_t> CState::AllSearchIds() const
 	return out;
 }
 
+bool CState::HasAnySearch() const
+{
+	std::shared_lock<std::shared_timed_mutex> lock(m_mu);
+	return !m_searches.empty();
+}
+
 bool CState::FindSearchResultByHash(
 	const std::string &hash_hex, SearchResult &out, std::uint32_t *owner_search_id) const
 {

--- a/src/webapi/State.cpp
+++ b/src/webapi/State.cpp
@@ -292,29 +292,6 @@ bool CState::FindSearchResultByHash(
 	return false;
 }
 
-void CState::EvictSurplusSearchSlotsLocked()
-{
-	// Bound the retained slots: a client that never frees its searches would
-	// otherwise accumulate one slot (with its result map) per search for the
-	// whole process lifetime. Evict oldest-first, never an active
-	// (still-polling) one — the surplus is always finished slots.
-	while (m_searches.size() > kMaxSearchSlots) {
-		auto victim = m_searches.end();
-		for (auto it = m_searches.begin(); it != m_searches.end(); ++it) {
-			if (it->second.progress.active) {
-				continue;
-			}
-			if (victim == m_searches.end() || it->second.seq < victim->second.seq) {
-				victim = it;
-			}
-		}
-		if (victim == m_searches.end()) {
-			break; // every remaining slot is still active — nothing to evict
-		}
-		m_searches.erase(victim);
-	}
-}
-
 void CState::MarkSearchStarted(std::uint32_t search_id, const std::string &kind, const std::string &query)
 {
 	std::unique_lock<std::shared_timed_mutex> lock(m_mu);
@@ -328,10 +305,8 @@ void CState::MarkSearchStarted(std::uint32_t search_id, const std::string &kind,
 	slot.progress.kind = kind;
 	slot.progress.generation = next_generation;
 	slot.query = query;
-	slot.seq = ++m_search_seq;
 	slot.started_at = std::time(nullptr);
 	slot.last_fetch = {};
-	EvictSurplusSearchSlotsLocked();
 }
 
 void CState::MarkSearchDiscovered(std::uint32_t search_id,
@@ -377,8 +352,6 @@ void CState::MarkSearchDiscovered(std::uint32_t search_id,
 		reported_percent >= 0 ? static_cast<std::uint32_t>(reported_percent) : (complete ? 100u : 0u);
 	slot.progress.kind = kind;
 	slot.query = query;
-	slot.seq = ++m_search_seq;
-	EvictSurplusSearchSlotsLocked();
 }
 
 void CState::WriteSearchProgress(std::uint32_t search_id, SearchProgressSnapshot s)
@@ -389,10 +362,27 @@ void CState::WriteSearchProgress(std::uint32_t search_id, SearchProgressSnapshot
 		it->second.progress = std::move(s);
 }
 
+void CState::MutateAllSearches(const std::function<void(
+		std::map<std::uint32_t, SearchSlot> &, std::map<std::uint32_t, std::uint32_t> &)> &fn)
+{
+	const ReentryGuard guard(this);
+	std::unique_lock<std::shared_timed_mutex> lock(m_mu);
+	fn(m_searches, m_resultOwner);
+}
+
 void CState::CloseSearch(std::uint32_t search_id)
 {
 	std::unique_lock<std::shared_timed_mutex> lock(m_mu);
-	m_searches.erase(search_id);
+	const auto it = m_searches.find(search_id);
+	if (it == m_searches.end())
+		return;
+	// The index mirrors this slot's result map, so it has to lose the same
+	// ECIDs in the same locked step. Walking the slot's own results is what
+	// keeps that exact: erasing by value over the whole index would be O(n)
+	// in every search rather than this one.
+	for (const auto &kv : it->second.raw)
+		m_resultOwner.erase(kv.first);
+	m_searches.erase(it);
 }
 
 void CState::WriteStatsTree(StatsTreeNode t)
@@ -812,6 +802,11 @@ void CState::ResetLists()
 	// re-baselines its per-search state when a slot it was tracking
 	// disappears, so no generation carry-over is needed here.)
 	m_searches.clear();
+	// The ECID->search_id index mirrors those slots, and the daemon's
+	// per-connection diff state died with the same socket, so it re-sends
+	// every result in full on the new one. Keeping stale entries here would
+	// attribute a reused ECID to a search that no longer exists.
+	m_resultOwner.clear();
 	// The credit store deliberately does NOT go with them. This runs when a
 	// tick failed against a socket that is still up, and dropping the store
 	// there would refetch the whole thing after one null tick -- the cost this

--- a/src/webapi/State.cpp
+++ b/src/webapi/State.cpp
@@ -302,10 +302,22 @@ void CState::MarkSearchStarted(std::uint32_t search_id, const std::string &kind,
 {
 	std::unique_lock<std::shared_timed_mutex> lock(m_mu);
 	SearchSlot &slot = m_searches[search_id];
+	if (slot.seq == 0)
+		slot.seq = ++m_search_seq;
 	// generation is per-slot and monotonic: a restart of the same id (rare —
 	// the daemon allocates fresh ids) keeps it climbing so EventDiff still fires.
 	const auto next_generation = slot.progress.generation + 1;
+	// Both maps, and the ECID index that points at them. `raw` is the merge
+	// target the union applies diffed tags to, so a stale entry left here
+	// would have the previous search's fields show through wherever the new
+	// one's tag happens not to carry that field -- and RebuildFoldedResults
+	// would then put the ghost straight back into `results`, however many
+	// times that gets cleared.
+	for (const auto &entry : slot.raw)
+		m_resultOwner.erase(entry.first);
+	slot.raw.clear();
 	slot.results.clear();
+	slot.detached = false;
 	slot.progress = SearchProgressSnapshot{};
 	slot.progress.active = true;
 	slot.progress.kind = kind;
@@ -313,6 +325,7 @@ void CState::MarkSearchStarted(std::uint32_t search_id, const std::string &kind,
 	slot.query = query;
 	slot.started_at = std::time(nullptr);
 	slot.last_fetch = {};
+	EvictSurplusSearchSlotsLocked();
 }
 
 void CState::MarkSearchDiscovered(std::uint32_t search_id,
@@ -328,7 +341,7 @@ void CState::MarkSearchDiscovered(std::uint32_t search_id,
 		// Already known (self-started, or discovered on an earlier
 		// cache-miss check): leave its accumulated results/progress
 		// alone. Re-seeding here would stomp whatever
-		// WriteSearchProgress/ApplySearchFull already recorded for it
+		// WriteSearchProgress/ApplySearchUnion already recorded for it
 		// this session. The query is the one exception — a slot seeded
 		// before the daemon reported a name has an empty one, and
 		// filling it in loses nothing.
@@ -337,6 +350,7 @@ void CState::MarkSearchDiscovered(std::uint32_t search_id,
 		return;
 	}
 	SearchSlot &slot = m_searches[search_id];
+	slot.seq = ++m_search_seq;
 	// The daemon's own lifecycle state for this search, not an assumption.
 	// A finished search seeded as active reads as running until the next
 	// tick corrects it, and POST /search/{id}/more gates on exactly that.
@@ -358,6 +372,43 @@ void CState::MarkSearchDiscovered(std::uint32_t search_id,
 		reported_percent >= 0 ? static_cast<std::uint32_t>(reported_percent) : (complete ? 100u : 0u);
 	slot.progress.kind = kind;
 	slot.query = query;
+	EvictSurplusSearchSlotsLocked();
+}
+
+void CState::DetachSearch(std::uint32_t search_id)
+{
+	std::unique_lock<std::shared_timed_mutex> lock(m_mu);
+	auto it = m_searches.find(search_id);
+	if (it != m_searches.end())
+		it->second.detached = true;
+}
+
+void CState::EvictSurplusSearchSlotsLocked()
+{
+	while (m_searches.size() > kMaxSearchSlots) {
+		auto victim = m_searches.end();
+		for (auto it = m_searches.begin(); it != m_searches.end(); ++it) {
+			// Never an active one: it is still being polled, and the surplus
+			// is always made of slots that have stopped moving.
+			if (it->second.progress.active)
+				continue;
+			// A detached slot always outranks an attached one, however much
+			// younger: the daemon no longer holds it, so evicting it drops
+			// nothing that could still be re-read.
+			if (victim == m_searches.end() || (it->second.detached && !victim->second.detached) ||
+				(it->second.detached == victim->second.detached &&
+					it->second.seq < victim->second.seq)) {
+				victim = it;
+			}
+		}
+		if (victim == m_searches.end())
+			break; // every remaining slot is still active — nothing to evict
+		// The index has to go with the slot, or a later result reusing one of
+		// these ECIDs would be attributed to a search that is no longer here.
+		for (const auto &entry : victim->second.raw)
+			m_resultOwner.erase(entry.first);
+		m_searches.erase(victim);
+	}
 }
 
 void CState::WriteSearchProgress(std::uint32_t search_id, SearchProgressSnapshot s)
@@ -794,7 +845,7 @@ void CState::MutateClientsWithFiles(
 void CState::ResetLists()
 {
 	std::unique_lock<std::shared_timed_mutex> lock(m_mu);
-	// A wholesale wipe on EC reconnect is as much a body change as any
+	// A wholesale wipe on a failed tick is as much a body change as any
 	// mutation, and it runs on the failure path -- exactly where the key
 	// used to freeze while the bodies moved underneath it.
 	++m_snapshot_rev;
@@ -802,23 +853,25 @@ void CState::ResetLists()
 	m_clients.clear();
 	m_servers.clear();
 	m_categories.clear();
-	// Drop all search slots on an EC reconnect: the daemon's per-connection
-	// search registry is gone with the old connection, so every cached
-	// search_id is stale; the next POST /search re-seeds. (EventDiff
-	// re-baselines its per-search state when a slot it was tracking
-	// disappears, so no generation carry-over is needed here.)
-	m_searches.clear();
-	// The ECID->search_id index mirrors those slots, and the daemon's
-	// per-connection diff state died with the same socket, so it re-sends
-	// every result in full on the new one. Keeping stale entries here would
-	// attribute a reused ECID to a search that no longer exists.
-	m_resultOwner.clear();
-	// The credit store deliberately does NOT go with them. This runs when a
-	// tick failed against a socket that is still up, and dropping the store
-	// there would refetch the whole thing after one null tick -- the cost this
-	// endpoint exists to avoid. It cannot go stale across a daemon restart
-	// either: HandleEcConnectionLost() shuts amuleapi down the moment the
-	// socket drops, so the process never attaches to a second core.
+	// Search slots and the ECID->search_id index that mirrors them are
+	// deliberately NOT cleared, for the same reason as the credit store
+	// below and then some. This runs when a tick failed against a socket
+	// that is still up -- an actual dropped connection sets
+	// g_shutdownRequested via HandleEcConnectionLost() and this loop exits
+	// instead -- so the daemon's per-connection search registry is very much
+	// alive, along with its record of which results it has already sent us
+	// and the valuemap it diffs against. Wiping our side of that would not
+	// resync anything: results the daemon considers delivered are elided from
+	// then on, so every search would come back permanently short by whatever
+	// it held at the moment one tick returned null. The collections above are
+	// safe to wipe precisely because their EC_DETAIL_UPDATE streams resend in
+	// full; this one does not.
+	//
+	// The credit store is dropped for the same reason -- refetching the whole
+	// thing after one null tick is the cost this endpoint exists to avoid. It
+	// cannot go stale across a daemon restart either: amuleapi shuts down the
+	// moment the socket drops, so the process never attaches to a second
+	// core.
 	// Logs + stats_tree + graphs survive EC reconnects on purpose —
 	// operator can see "EC disconnected at HH:MM" alongside earlier
 	// graph traffic; stats_tree's counters are amuled-uptime not

--- a/src/webapi/State.cpp
+++ b/src/webapi/State.cpp
@@ -27,6 +27,7 @@
 #include <cstdlib>  // std::abort
 #include <iostream> // std::cerr
 
+#include <algorithm>
 #include <cstdio>
 #include <ctime>
 
@@ -278,7 +279,16 @@ std::vector<std::uint32_t> CState::AllSearchIds() const
 bool CState::HasAnySearch() const
 {
 	std::shared_lock<std::shared_timed_mutex> lock(m_mu);
-	return !m_searches.empty();
+	// Detached slots do not count. The daemon has already evicted those
+	// searches, so it has nothing left to send for them -- a session holding
+	// only detached slots would otherwise poll once a second forever with
+	// nothing on the other end, which is what a user who runs one search and
+	// never deletes it ends up with once the daemon's ring drops it.
+	return std::any_of(m_searches.begin(),
+		m_searches.end(),
+		[](const std::pair<const std::uint32_t, SearchSlot> &entry) {
+			return !entry.second.detached;
+		});
 }
 
 bool CState::FindSearchResultByHash(

--- a/src/webapi/State.h
+++ b/src/webapi/State.h
@@ -1807,10 +1807,12 @@ public:
 	std::vector<std::uint32_t> ActiveSearchIds() const;
 	// Every live slot id, for the SSE per-search diff.
 	std::vector<std::uint32_t> AllSearchIds() const;
-	// Whether any slot exists at all. The union poll asks for every search in
-	// one request, so it needs no id list -- only whether the request is worth
-	// sending. Separate from AllSearchIds() to avoid building and copying a
-	// vector once a second just to test it for emptiness.
+	// Whether any slot the daemon could still speak for exists. The union poll
+	// asks for every search in one request, so it needs no id list -- only
+	// whether the request is worth sending. Detached slots are excluded: the
+	// daemon has evicted those, so polling on their behalf is a roundtrip a
+	// second that can never return anything. Separate from AllSearchIds() to
+	// avoid building and copying a vector once a second just to test it.
 	bool HasAnySearch() const;
 	// Find a result carrying this (already-lowercased) hash across ALL open
 	// searches — the hash-keyed comments endpoints are search-agnostic. The

--- a/src/webapi/State.h
+++ b/src/webapi/State.h
@@ -1020,6 +1020,18 @@ void ComputePartProgressPercent(const CState &state, ClientSnapshot &cli);
 // daemon-allocated search_id (see m_searches).
 struct SearchSlot
 {
+	// What the daemon last told us, flat: every result ECID it has sent for
+	// this search, parents and grouped children alike, exactly as they
+	// arrived. This is the merge target for the incremental union poll --
+	// a diffed tag names one ECID and carries only the fields that moved, so
+	// there has to be somewhere addressable by ECID to apply it to.
+	std::map<std::uint32_t, SearchResult> raw;
+	// The view every reader uses: `raw` with each child folded into its
+	// parent's children[] and dropped from the top level, so the API serves
+	// one row per hash+size. Rebuilt from `raw` after each merge rather than
+	// merged into directly, which keeps every consumer (Search(),
+	// FindSearchResultByHash, EventDiff) on exactly the shape it had before
+	// incremental polling existed.
 	std::map<std::uint32_t, SearchResult> results;
 	SearchProgressSnapshot progress;
 	// What was searched for, so a consumer reading one search's results
@@ -1028,10 +1040,6 @@ struct SearchSlot
 	// nickname, not a query. Empty only for a slot seeded by discovery
 	// before its name was observed.
 	std::string query;
-	// Monotonic insertion order, used to evict the oldest slots when the map
-	// exceeds its cap (a client that starts many searches without closing them
-	// would otherwise accumulate slots for the whole process lifetime).
-	std::uint64_t seq = 0;
 	// Wall-clock second this session started the search, for ranking the
 	// entries GET /search returns: that listing comes straight off
 	// EC_OP_SEARCH_LIST, which walks a std::map keyed by search_id and
@@ -1867,6 +1875,13 @@ public:
 	// overwrite). No-op if the id names no live slot.
 	void MutateSearch(std::uint32_t search_id,
 		const std::function<void(std::map<std::uint32_t, SearchResult> &)> &fn);
+	// Mutate every search slot and the ECID->search_id index together, under
+	// one exclusive lock. The incremental union poll needs both: a diffed tag
+	// names no search, so the index resolves it, and a result that moves or
+	// disappears has to leave the map and the index in step. Handing out both
+	// halves to one callback is what makes that atomic.
+	void MutateAllSearches(const std::function<void(std::map<std::uint32_t, SearchSlot> &,
+			std::map<std::uint32_t, std::uint32_t> &)> &fn);
 
 	// Wholesale reset paths. Called by the refresher after a
 	// MarkTickFailure → MarkTickSuccess transition (the server's
@@ -2002,18 +2017,15 @@ private:
 	// the REST surface by its daemon-allocated search_id. One slot per search
 	// holds that search's results (by result ECID) and its lifecycle progress.
 	std::map<std::uint32_t, SearchSlot> m_searches;
-	// Ever-increasing sequence stamped on each new slot for oldest-first
-	// eviction. Never wraps in practice (one bump per POST /search).
-	std::uint64_t m_search_seq = 0;
-	// Hard cap on retained slots. Comfortably above the daemon's 20-search
-	// ring so every live search always fits; excess is finished slots a
-	// client never closed, evicted oldest-first.
-	static constexpr std::size_t kMaxSearchSlots = 64;
-
-	// Trim m_searches back to kMaxSearchSlots, dropping the oldest slot that
-	// is not still being polled. Shared by both slot-creating paths, which
-	// need the identical rule. MUST be called with m_mu held exclusively.
-	void EvictSurplusSearchSlotsLocked();
+	// Result ECID -> owning search_id, mirroring m_searches' result maps.
+	//
+	// Required by the incremental union poll: the daemon sends
+	// EC_TAG_SEARCH_ID only the first time it tells us about a result, and
+	// EC_TAG_FILE_REMOVED carries the bare ECID, so every later tag has to be
+	// attributed from here. Maintained inside the same locked mutation that
+	// writes the result maps -- an index that can drift from the map it
+	// mirrors is how #1028 leaked keys a reload could not heal.
+	std::map<std::uint32_t, std::uint32_t> m_resultOwner;
 };
 
 } // namespace webapi

--- a/src/webapi/State.h
+++ b/src/webapi/State.h
@@ -1055,6 +1055,22 @@ struct SearchSlot
 	// this stamp. Default-constructed (epoch) means "never fetched", which
 	// is always stale.
 	std::chrono::steady_clock::time_point last_fetch{};
+	// The daemon no longer holds this search: its EC ring evicted it, or it
+	// was closed core-side. Set by the tick when EC_OP_SEARCH_PROGRESS comes
+	// back expired, before that same tick applies the results union -- which
+	// would otherwise tombstone away exactly the results the retirement path
+	// means to keep for late reads, since the union emits EC_TAG_FILE_REMOVED
+	// for every result of an evicted search.
+	//
+	// A detached slot is frozen: ApplySearchUnion skips it for merges and
+	// tombstones alike, since nothing about it can change any more. It is
+	// also the preferred eviction victim, because it is the only kind whose
+	// eviction costs nothing -- the daemon has nothing left to re-send.
+	bool detached = false;
+	// Insertion order, for oldest-first eviction. Not started_at: that is 0
+	// for a discovered slot, which would make every adopted search tie for
+	// oldest and evict in map order.
+	std::uint64_t seq = 0;
 };
 
 // `m_amule_log_lines` in CState caches /logs/amule. amule's EC
@@ -1941,6 +1957,11 @@ public:
 	// derived: 100 for a finished search (true by definition), 0 for a
 	// running one (the tick corrects it within a second, and inventing a
 	// number would flash a wrong one meanwhile).
+	/**
+	 * Mark a slot as no longer backed by the daemon. Freezes its results:
+	 * see SearchSlot::detached. Idempotent; a no-op for an unknown id.
+	 */
+	void DetachSearch(std::uint32_t search_id);
 	void MarkSearchDiscovered(std::uint32_t search_id,
 		const std::string &kind,
 		const std::string &query,
@@ -2031,6 +2052,23 @@ private:
 	// writes the result maps -- an index that can drift from the map it
 	// mirrors is how #1028 leaked keys a reload could not heal.
 	std::map<std::uint32_t, std::uint32_t> m_resultOwner;
+	//! Monotonic source for SearchSlot::seq.
+	std::uint64_t m_search_seq = 0;
+	// Ceiling on retained slots. A client that never DELETEs its searches,
+	// or one watching a busy monolithic GUI, would otherwise accumulate a
+	// slot and its whole result map per search for the life of the process:
+	// the daemon's own kMaxEcSearches bounds only the searches it holds for
+	// *this* connection, and detached slots outlive even those.
+	//
+	// Eviction is recoverable, which is why a cap is affordable at all: a
+	// later read of an evicted id misses the cache, re-discovers it via
+	// EC_OP_SEARCH_LIST and re-seeds it in full through FetchOneSearchFull.
+	// Detached slots are preferred as victims anyway, since for those the
+	// daemon has nothing left to re-send and nothing is lost.
+	static constexpr std::size_t kMaxSearchSlots = 64;
+	// Trim m_searches back to kMaxSearchSlots, and drop the evicted slots'
+	// entries from m_resultOwner with them. Caller holds the write lock.
+	void EvictSurplusSearchSlotsLocked();
 };
 
 } // namespace webapi

--- a/src/webapi/State.h
+++ b/src/webapi/State.h
@@ -1791,6 +1791,11 @@ public:
 	std::vector<std::uint32_t> ActiveSearchIds() const;
 	// Every live slot id, for the SSE per-search diff.
 	std::vector<std::uint32_t> AllSearchIds() const;
+	// Whether any slot exists at all. The union poll asks for every search in
+	// one request, so it needs no id list -- only whether the request is worth
+	// sending. Separate from AllSearchIds() to avoid building and copying a
+	// vector once a second just to test it for emptiness.
+	bool HasAnySearch() const;
 	// Find a result carrying this (already-lowercased) hash across ALL open
 	// searches — the hash-keyed comments endpoints are search-agnostic. The
 	// parent owns any fetched Kad notes, so it matches ahead of its children.

--- a/unittests/curl-tests/amuleapi/19-search.sh
+++ b/unittests/curl-tests/amuleapi/19-search.sh
@@ -943,20 +943,40 @@ if [ -n "$SID_G" ] && [ -n "$SID_K" ] && [ "$SID_G" != "null" ] && [ "$SID_K" !=
 		_curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/search/$SID_G/results"
 		_assert_status 200 "union: GET /search/{global}/results after repeated polls → 200"
 		_assert_json_eq '.search_id' "$SID_G" 'union: the global search still reports its own id'
-		G_HASHES=$(printf '%s' "$CURL_BODY" | jq -r '[.results[].hash] | sort | join(",")')
+		G_TOTAL=$(printf '%s' "$CURL_BODY" | jq -r '.total')
 
 		_curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/search/$SID_K/results"
 		_assert_status 200 "union: GET /search/{kad}/results after repeated polls → 200"
 		_assert_json_eq '.search_id' "$SID_K" 'union: the kad search still reports its own id'
-		K_HASHES=$(printf '%s' "$CURL_BODY" | jq -r '[.results[].hash] | sort | join(",")')
+		K_TOTAL=$(printf '%s' "$CURL_BODY" | jq -r '.total')
 
-		# Results must not migrate between searches. Identical non-empty sets would
-		# mean the index attributed one search's diffed tags to the other.
-		if [ -n "$G_HASHES" ] && [ "$G_HASHES" = "$K_HASHES" ]; then
-			_fail "union: two searches hold an identical result set" \
-				"the ECID index may be cross-wiring diffed tags"
+		# Results must not migrate between searches. Checked against the daemon's own
+		# per-search count from GET /search, which comes from EC_OP_SEARCH_LIST and so
+		# is independent of the cache the union maintains -- comparing the two searches
+		# to each other proves nothing, since a global and a Kad search for the same
+		# query may legitimately return the same files.
+		#
+		# One-sided on purpose: the cached total is the FOLDED view (children counted
+		# inside their parent) while the daemon counts what it holds, so it may
+		# legitimately be lower. It can only ever exceed the daemon's count by holding
+		# results that belong to another search, which is exactly the cross-wiring
+		# this is looking for.
+		_curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/search"
+		if [ "$(printf '%s' "$CURL_BODY" | jq --argjson g "$SID_G" --argjson k "$SID_K" \
+			'[.searches[] | select(.search_id == $g or .search_id == $k) | select(has("result_count"))] | length')" -eq 2 ]; then
+			for _pair in "$SID_G:$G_TOTAL:global" "$SID_K:$K_TOTAL:kad"; do
+				_sid=${_pair%%:*}; _rest=${_pair#*:}; _cached=${_rest%%:*}; _label=${_rest#*:}
+				_held=$(printf '%s' "$CURL_BODY" | jq -r --argjson s "$_sid" \
+					'.searches[] | select(.search_id == $s) | .result_count')
+				if [ "$_cached" -gt "$_held" ]; then
+					_fail "union: the $_label search holds more results than the daemon has for it" \
+						"cached $_cached > daemon $_held; the ECID index is cross-wiring diffed tags"
+				else
+					_pass "union: the $_label search holds no results the daemon attributes elsewhere"
+				fi
+			done
 		else
-			_pass "union: the two searches keep distinct result sets"
+			echo "    info: daemon reported no result_count for one of the searches; cross-wiring check skipped"
 		fi
 
 		# Every row still carries the fields that only travel on a result's FIRST

--- a/unittests/curl-tests/amuleapi/19-search.sh
+++ b/unittests/curl-tests/amuleapi/19-search.sh
@@ -923,6 +923,64 @@ if [ -n "$SID_G" ] && [ -n "$SID_K" ] && [ "$SID_G" != "null" ] && [ "$SID_K" !=
 		echo "    info: global search returned 0 alongside Kad — daemon may lack ed2k hits for '$TEST_QUERY'"
 	fi
 
+	# --- 11.1 Two searches stay separate across the incremental union poll. ---
+	#
+	# The refresher now fetches every search's results in ONE id-less
+	# EC_OP_SEARCH_RESULTS at EC_DETAIL_INC_UPDATE, so all searches share a reply
+	# and the daemon stops repeating a result it has already sent. Attribution then
+	# rests on amuleapi's own ECID -> search_id index rather than on a tag in the
+	# packet, which is the thing that can silently cross-wire two searches.
+	#
+	# Poll both several times: the first pass populates, later ones are the diffed
+	# ones where the search id is no longer on the wire.
+	if [ -n "$SID_G" ] && [ -n "$SID_K" ] && [ "$SID_G" != "$SID_K" ]; then
+		for _ in 1 2 3 4 5; do
+			sleep 1
+			_curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/search/$SID_G/results"
+			_curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/search/$SID_K/results"
+		done
+
+		_curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/search/$SID_G/results"
+		_assert_status 200 "union: GET /search/{global}/results after repeated polls → 200"
+		_assert_json_eq '.search_id' "$SID_G" 'union: the global search still reports its own id'
+		G_HASHES=$(printf '%s' "$CURL_BODY" | jq -r '[.results[].hash] | sort | join(",")')
+
+		_curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/search/$SID_K/results"
+		_assert_status 200 "union: GET /search/{kad}/results after repeated polls → 200"
+		_assert_json_eq '.search_id' "$SID_K" 'union: the kad search still reports its own id'
+		K_HASHES=$(printf '%s' "$CURL_BODY" | jq -r '[.results[].hash] | sort | join(",")')
+
+		# Results must not migrate between searches. Identical non-empty sets would
+		# mean the index attributed one search's diffed tags to the other.
+		if [ -n "$G_HASHES" ] && [ "$G_HASHES" = "$K_HASHES" ]; then
+			_fail "union: two searches hold an identical result set" \
+				"the ECID index may be cross-wiring diffed tags"
+		else
+			_pass "union: the two searches keep distinct result sets"
+		fi
+
+		# Every row still carries the fields that only travel on a result's FIRST
+		# appearance. A merge that dropped a guard would blank these on the first
+		# diffed poll, which is the failure mode with no other symptom.
+		_curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/search/$SID_G/results"
+		if [ "$(printf '%s' "$CURL_BODY" | jq '.results | length')" -gt 0 ]; then
+			_assert_json_eq '[.results[] | select(.name == "" or .name == null)] | length' 0 \
+				'union: no result lost its name across diffed polls'
+			_assert_json_eq '[.results[] | select(.size == 0 or .size == null)] | length' 0 \
+				'union: no result lost its size across diffed polls'
+			_assert_json_eq '[.results[] | select(.hash == "" or .hash == null)] | length' 0 \
+				'union: no result lost its hash across diffed polls'
+			_assert_json_eq '[.results[] | select(.status == "" or .status == null)] | length' 0 \
+				'union: no result lost its status across diffed polls'
+			_assert_json_eq '[.results[] | select(.type == "" or .type == null)] | length' 0 \
+				'union: no result lost its type across diffed polls'
+		else
+			echo "    info: global search returned no rows; per-field retention checks skipped"
+		fi
+	else
+		echo "    info: no two distinct searches available; union separation check skipped"
+	fi
+
 	# DELETE the global search: its slot is freed (404), the Kad search
 	# is untouched (still 200). Freeing one from one tab must never take
 	# a sibling with it.
@@ -941,6 +999,41 @@ if [ -n "$SID_G" ] && [ -n "$SID_K" ] && [ "$SID_G" != "null" ] && [ "$SID_K" !=
 		"$HOST/api/v0/search/$SID_K" >/dev/null 2>&1
 else
 	_fail "Multi-search setup" "POST /search did not return search_ids (G=$SID_G K=$SID_K)"
+fi
+
+# --- 11.2 A finished search keeps being refreshed. -----------------
+#
+# The tick used to poll only searches with progress.active, so once a search
+# finished nothing re-read it and a hit downloaded afterwards kept reporting
+# already_have=false forever. Eliding made polling finished searches free, so
+# they stay in the poll set -- this pins that the row is still being maintained
+# rather than frozen at the moment the search completed.
+_curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/search/$FIRST_SID/results"
+if [ "$CURL_STATUS" = "200" ]; then
+	FIN_STATE=$(printf '%s' "$CURL_BODY" | jq -r '.progress.state')
+	FIN_N=$(printf '%s' "$CURL_BODY" | jq '.results | length')
+	echo "    info: search $FIRST_SID is $FIN_STATE with $FIN_N result(s)"
+	if [ "$FIN_STATE" = "finished" ] && [ "$FIN_N" -gt 0 ]; then
+		# Two reads a couple of ticks apart: the row must still be there and
+		# still complete. A finished search dropped from the poll set would
+		# have kept whatever it had, so this is a regression guard on the
+		# merge rather than a liveness assertion about values that may not
+		# change on an idle daemon.
+		BEFORE_N=$FIN_N
+		sleep 3
+		_curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/search/$FIRST_SID/results"
+		_assert_status 200 "union: a finished search is still readable after further ticks"
+		_assert_json_eq '.results | length' "$BEFORE_N" \
+			'union: a finished search keeps its results across ticks'
+		_assert_json_eq '[.results[] | select(.name == "" or .name == null)] | length' 0 \
+			'union: a finished search keeps its result names across ticks'
+		_assert_json_eq '[.results[] | select(.already_have | type != "boolean")] | length' 0 \
+			'union: a finished search still reports already_have as a boolean'
+	else
+		echo "    info: search $FIRST_SID not finished-with-results; finished-poll check skipped"
+	fi
+else
+	echo "    info: search $FIRST_SID no longer readable; finished-poll check skipped"
 fi
 
 # --- 12. Close actually frees the search on the daemon. ------------

--- a/unittests/curl-tests/amuleapi/19-search.sh
+++ b/unittests/curl-tests/amuleapi/19-search.sh
@@ -1567,10 +1567,111 @@ _curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/servers"
 _assert_json_eq '[.servers[]? | .tcp_flags | has("related_search")] | all' true \
 	'every server advertises its related_search capability in tcp_flags'
 
+# --- 13. A foreign search discovered AFTER the union has been polling. -----
+# Section 3.2 covers the easy ordering: a second instance that has never POSTed
+# anything reads a search it did not start. That one cannot regress, because an
+# instance with no slots of its own never sends the union at all.
+#
+# The ordering that DID break is this one. Once a session holds any slot, its
+# tick polls the multi-search union, and the union responder walks every search
+# the core holds -- so it hands over a foreign search's results to a session
+# with no slot to put them in. They are dropped, but the daemon has marked them
+# sent and seeds its valuemap, so every later poll elides them. Discovering that
+# search afterwards used to yield a permanently empty result set that no number
+# of ticks would fill.
+#
+# Deliberately the LAST section in this file: it starts two extra searches on
+# the shared daemon, and doing that earlier reorders what the sections above see.
+if [ "$HAVE_SECOND_INSTANCE" -eq 1 ]; then
+	THIRD_HOST="localhost:4715"
+	THIRD_CONFIG_DIR=$(mktemp -d -t amuleapi_19_search_third.XXXXXX)
+	THIRD_LOG=$(mktemp -t amuleapi_19_search_third_log.XXXXXX)
+	"$AMULEAPI_BIN" --config-dir="$THIRD_CONFIG_DIR" \
+		--host="$EC_HOST" --port="$EC_PORT" \
+		--set-admin-pass="$ADMIN_PASS" >/dev/null 2>&1
+	sed -i'.bak' "s|^Password=.*|Password=$EC_PASSWORD|" "$THIRD_CONFIG_DIR/amuleapi.conf"
+	rm -f "$THIRD_CONFIG_DIR/amuleapi.conf.bak"
+	"$AMULEAPI_BIN" --config-dir="$THIRD_CONFIG_DIR" \
+		--host="$EC_HOST" --port="$EC_PORT" \
+		--http-port=4715 >"$THIRD_LOG" 2>&1 &
+	THIRD_PID=$!
+	for i in 1 2 3 4 5 6 7 8 9 10 11 12; do
+		curl -s -o /dev/null --max-time 1 "http://$THIRD_HOST/api/v0/health" 2>/dev/null && break
+		sleep 0.5
+	done
+	sleep 3
+
+	THIRD_TOKEN=$(curl -s -X POST -H "Content-Type: application/json" \
+		-d "{\"password\":\"$ADMIN_PASS\"}" "http://$THIRD_HOST/api/v0/auth/login?type=bearer" \
+		| jq -r .token)
+
+	if [ -n "$THIRD_TOKEN" ] && [ "$THIRD_TOKEN" != "null" ]; then
+		# Give the third instance a slot of its own. From here its tick sends the
+		# union every second, which is the precondition for the bug.
+		OWN_SID=$(curl -s -X POST -H "Authorization: Bearer $THIRD_TOKEN" \
+			-H "Content-Type: application/json" \
+			-d "{\"query\":\"$TEST_QUERY\"}" "http://$THIRD_HOST/api/v0/search" \
+			| jq -r '.search_id // empty')
+		sleep 3
+
+		# NOW start a search it knows nothing about, and let its union poll run
+		# over the results several times. Every one of those polls offers this
+		# search's results to a session with no slot for them.
+		_curl -X POST -H "Authorization: Bearer $ADMIN_TOKEN" \
+			-H "Content-Type: application/json" \
+			-d "{\"query\":\"$TEST_QUERY\"}" "$HOST/api/v0/search"
+		_assert_status 202 'late-discovery: first instance starts a search the third has never seen'
+		LATE_SID=$(printf '%s' "$CURL_BODY" | jq -r '.search_id // empty')
+		sleep 12
+
+		if [ -n "$LATE_SID" ]; then
+			# What the daemon actually holds, so an empty read is distinguishable
+			# from a search that genuinely found nothing.
+			_curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/search"
+			LATE_HELD=$(printf '%s' "$CURL_BODY" \
+				| jq -r "[.searches[] | select(.search_id == $LATE_SID)][0].result_count // 0")
+			if [ "$LATE_HELD" -gt 0 ]; then
+				# First read by the third instance: discovery has to seed the slot in
+				# full here, because the differential stream has nothing left to send.
+				_curl -H "Authorization: Bearer $THIRD_TOKEN" \
+					"http://$THIRD_HOST/api/v0/search/$LATE_SID/results"
+				_assert_status 200 'late-discovery: third instance reads the late search → 200'
+				_assert_json_eq '.search_id' "$LATE_SID" 'late-discovery: it echoes the discovered id'
+				_assert_json_eq '[.results[]] | length > 0' true \
+					"late-discovery: the discovered search is seeded (daemon holds $LATE_HELD)"
+				# And it stays: a seed that only survived until the next union poll
+				# would be worse than none.
+				sleep 3
+				_curl -H "Authorization: Bearer $THIRD_TOKEN" \
+					"http://$THIRD_HOST/api/v0/search/$LATE_SID/results"
+				_assert_json_eq '[.results[]] | length > 0' true \
+					'late-discovery: the seeded results survive the next union polls'
+			else
+				_skip "late-discovery: the daemon holds no results for the late search"
+			fi
+			curl -s -X DELETE -H "Authorization: Bearer $ADMIN_TOKEN" \
+				"$HOST/api/v0/search/$LATE_SID" >/dev/null 2>&1
+		else
+			_skip 'late-discovery: no search id returned for the late search'
+		fi
+		[ -n "$OWN_SID" ] && curl -s -X DELETE -H "Authorization: Bearer $THIRD_TOKEN" \
+			"http://$THIRD_HOST/api/v0/search/$OWN_SID" >/dev/null 2>&1
+	else
+		_fail "late-discovery: third amuleapi instance admin login" \
+			"could not obtain a token; log: $(tail -c 300 "$THIRD_LOG")"
+	fi
+
+	kill "$THIRD_PID" >/dev/null 2>&1
+	wait "$THIRD_PID" 2>/dev/null
+	rm -rf "$THIRD_CONFIG_DIR" "$THIRD_LOG"
+else
+	_skip 'late-discovery: no amuleapi binary to start a third instance'
+fi
+
 # --- Summary. -----------------------------------------------------
 echo
 SKIP_NOTE=""
-[ "$SKIP_COUNT" -gt 0 ] && SKIP_NOTE=" ($SKIP_COUNT section(s) skipped: no second amuleapi instance)"
+[ "$SKIP_COUNT" -gt 0 ] && SKIP_NOTE=" ($SKIP_COUNT check(s) skipped -- see the SKIP lines above for why)"
 if [ "$FAIL_COUNT" -eq 0 ]; then
 	echo "OK: $TEST_COUNT/$TEST_COUNT passed$SKIP_NOTE"
 	exit 0

--- a/unittests/tests/RefresherTest.cpp
+++ b/unittests/tests/RefresherTest.cpp
@@ -2854,6 +2854,81 @@ TEST(Refresher, SearchUnionIgnoresResultsForAnUnknownSearch)
 	ASSERT_TRUE(owner.find(70) == owner.end());
 }
 
+TEST(Refresher, SearchUnionLeavesADetachedSlotAlone)
+{
+	// The daemon evicted the search from its ring. That makes it emit an
+	// EC_TAG_FILE_REMOVED for every result it had sent us -- but the tick has
+	// already detached the slot, precisely so those tombstones do not erase
+	// the results the retirement path means to keep for late reads.
+	std::map<std::uint32_t, SearchSlot> slots;
+	std::map<std::uint32_t, std::uint32_t> owner;
+	SearchSlot &slot = slots[kSid];
+	SearchResult keep;
+	keep.name = "kept.bin";
+	keep.status = "new";
+	slot.raw[70] = keep;
+	slot.results[70] = keep;
+	slot.detached = true;
+	owner[70] = kSid;
+
+	CECPacket resp(EC_OP_SEARCH_RESULTS);
+	resp.AddTag(CECTag(EC_TAG_FILE_REMOVED, static_cast<std::uint32_t>(70)));
+	ApplySearchUnion(&resp, slots, owner);
+
+	ASSERT_EQUALS(static_cast<size_t>(1), slots[kSid].raw.size());
+	ASSERT_EQUALS(static_cast<size_t>(1), slots[kSid].results.size());
+	ASSERT_EQUALS(std::string("kept.bin"), slots[kSid].results[70].name);
+	// The index entry stays too: nothing will re-establish it, and dropping
+	// it would strand the result it points at.
+	ASSERT_TRUE(owner.find(70) != owner.end());
+}
+
+TEST(Refresher, SearchUnionDoesNotUpdateADetachedSlot)
+{
+	// Same freeze in the other direction. A diffed tag arriving for a search
+	// the daemon no longer holds is the tail of an eviction, not news.
+	std::map<std::uint32_t, SearchSlot> slots;
+	std::map<std::uint32_t, std::uint32_t> owner;
+	SearchSlot &slot = slots[kSid];
+	SearchResult keep;
+	keep.name = "kept.bin";
+	keep.source_count = 3;
+	slot.raw[70] = keep;
+	slot.results[70] = keep;
+	slot.detached = true;
+	owner[70] = kSid;
+
+	CECPacket resp(EC_OP_SEARCH_RESULTS);
+	CECTag sf(EC_TAG_SEARCHFILE, static_cast<std::uint32_t>(70));
+	sf.AddTag(CECTag(EC_TAG_SEARCH_ID, kSid));
+	sf.AddTag(CECTag(EC_TAG_PARTFILE_SOURCE_COUNT, static_cast<uint32>(99)));
+	resp.AddTag(sf);
+	ApplySearchUnion(&resp, slots, owner);
+
+	ASSERT_EQUALS(static_cast<std::uint32_t>(3), slots[kSid].results[70].source_count);
+}
+
+TEST(Refresher, SearchUnionDefaultSidAdoptsAnIdLessReply)
+{
+	// The per-search EC_DETAIL_FULL fetch -- the resync path the differential
+	// union has no opcode for. Its reply carries no EC_TAG_SEARCH_ID at all,
+	// so every tag in it has to be attributed to the search that was asked
+	// for, and the ECID index built from that.
+	std::map<std::uint32_t, SearchSlot> slots;
+	std::map<std::uint32_t, std::uint32_t> owner;
+	slots[kSid];
+
+	CECPacket resp(EC_OP_SEARCH_RESULTS);
+	CECTag sf(EC_TAG_SEARCHFILE, static_cast<std::uint32_t>(71));
+	sf.AddTag(CECTag(EC_TAG_PARTFILE_NAME, std::string("seeded.bin")));
+	resp.AddTag(sf);
+	ApplySearchUnion(&resp, slots, owner, kSid);
+
+	ASSERT_EQUALS(static_cast<size_t>(1), slots[kSid].results.size());
+	ASSERT_EQUALS(std::string("seeded.bin"), slots[kSid].results[71].name);
+	ASSERT_EQUALS(kSid, owner[71]);
+}
+
 TEST(Refresher, SearchProgressUnionParsesEveryEntry)
 {
 	CECPacket resp(EC_OP_SEARCH_PROGRESS);

--- a/unittests/tests/RefresherTest.cpp
+++ b/unittests/tests/RefresherTest.cpp
@@ -1660,22 +1660,34 @@ constexpr std::uint32_t LIFECYCLE_FINISHED = 2;
 
 // Search result status + type (issue #429): EC_TAG_PARTFILE_STATUS decodes
 // to the lowercase status string, and `type` is derived from the filename.
+// The union reply is not per-search: every result carries EC_TAG_SEARCH_ID the
+// first time the daemon mentions it, and the applier attributes later diffed
+// tags through the ECID -> search_id index. These fixtures therefore stamp one
+// search id on every result tag and pre-create its slot, which is what the
+// refresher does via MarkSearchStarted before any poll runs.
+static constexpr std::uint32_t kSid = 4242;
+
 TEST(Refresher, SearchResultStatusAndTypeDecode)
 {
-	std::map<std::uint32_t, SearchResult> cache;
+	std::map<std::uint32_t, SearchSlot> slots;
+	std::map<std::uint32_t, std::uint32_t> owner;
+	slots[kSid];
+	std::map<std::uint32_t, SearchResult> &cache = slots[kSid].results;
 	CECPacket resp(EC_OP_SEARCH_RESULTS);
 	CECTag sf(EC_TAG_SEARCHFILE, static_cast<std::uint32_t>(70));
+	sf.AddTag(CECTag(EC_TAG_SEARCH_ID, kSid));
 	sf.AddTag(CECTag(EC_TAG_PARTFILE_NAME, std::string("cool.movie.mkv")));
 	sf.AddTag(CECTag(EC_TAG_PARTFILE_SIZE_FULL, static_cast<std::uint64_t>(123)));
 	sf.AddTag(CECTag(EC_TAG_PARTFILE_STATUS, static_cast<std::uint32_t>(2))); // QUEUED
 	resp.AddTag(sf);
 	// A second result with no status tag defaults to "new"; a .mp3 → audio.
 	CECTag sf2(EC_TAG_SEARCHFILE, static_cast<std::uint32_t>(71));
+	sf2.AddTag(CECTag(EC_TAG_SEARCH_ID, kSid));
 	sf2.AddTag(CECTag(EC_TAG_PARTFILE_NAME, std::string("song.mp3")));
 	sf2.AddTag(CECTag(EC_TAG_PARTFILE_SIZE_FULL, static_cast<std::uint64_t>(4)));
 	resp.AddTag(sf2);
 
-	ApplySearchFull(&resp, cache);
+	ApplySearchUnion(&resp, slots, owner);
 
 	const auto it = cache.find(70);
 	ASSERT_TRUE(it != cache.end());
@@ -1751,9 +1763,13 @@ TEST(Refresher, SearchProgressIdleZeroesOutGracefully)
 // has_media=false so the API omits the `media` object.
 TEST(Refresher, SearchResultMediaDecode)
 {
-	std::map<std::uint32_t, SearchResult> cache;
+	std::map<std::uint32_t, SearchSlot> slots;
+	std::map<std::uint32_t, std::uint32_t> owner;
+	slots[kSid];
+	std::map<std::uint32_t, SearchResult> &cache = slots[kSid].results;
 	CECPacket resp(EC_OP_SEARCH_RESULTS);
 	CECTag sf(EC_TAG_SEARCHFILE, static_cast<std::uint32_t>(80));
+	sf.AddTag(CECTag(EC_TAG_SEARCH_ID, kSid));
 	sf.AddTag(CECTag(EC_TAG_PARTFILE_NAME, std::string("show.s01e01.mkv")));
 	sf.AddTag(CECTag(EC_TAG_PARTFILE_SIZE_FULL, static_cast<std::uint64_t>(999)));
 	sf.AddTag(CECTag(EC_TAG_KNOWNFILE_MEDIA_LENGTH, static_cast<std::uint32_t>(1320)));
@@ -1762,11 +1778,12 @@ TEST(Refresher, SearchResultMediaDecode)
 	resp.AddTag(sf);
 	// A second hit with no media tags stays has_media=false.
 	CECTag sf2(EC_TAG_SEARCHFILE, static_cast<std::uint32_t>(81));
+	sf2.AddTag(CECTag(EC_TAG_SEARCH_ID, kSid));
 	sf2.AddTag(CECTag(EC_TAG_PARTFILE_NAME, std::string("nomedia.bin")));
 	sf2.AddTag(CECTag(EC_TAG_PARTFILE_SIZE_FULL, static_cast<std::uint64_t>(4)));
 	resp.AddTag(sf2);
 
-	ApplySearchFull(&resp, cache);
+	ApplySearchUnion(&resp, slots, owner);
 
 	const auto it = cache.find(80);
 	ASSERT_TRUE(it != cache.end());
@@ -1787,16 +1804,21 @@ TEST(Refresher, SearchResultMediaDecode)
 // nested in children[]; the child ECIDs must not remain top-level.
 TEST(Refresher, SearchResultGroupingFoldsChildren)
 {
-	std::map<std::uint32_t, SearchResult> cache;
+	std::map<std::uint32_t, SearchSlot> slots;
+	std::map<std::uint32_t, std::uint32_t> owner;
+	slots[kSid];
+	std::map<std::uint32_t, SearchResult> &cache = slots[kSid].results;
 	CECPacket resp(EC_OP_SEARCH_RESULTS);
 
 	CECTag parent(EC_TAG_SEARCHFILE, static_cast<std::uint32_t>(100));
+	parent.AddTag(CECTag(EC_TAG_SEARCH_ID, kSid));
 	parent.AddTag(CECTag(EC_TAG_PARTFILE_NAME, std::string("best.mkv")));
 	parent.AddTag(CECTag(EC_TAG_PARTFILE_SIZE_FULL, static_cast<std::uint64_t>(123)));
 	parent.AddTag(CECTag(EC_TAG_PARTFILE_SOURCE_COUNT, static_cast<std::uint32_t>(30)));
 	resp.AddTag(parent);
 
 	CECTag c1(EC_TAG_SEARCHFILE, static_cast<std::uint32_t>(101));
+	c1.AddTag(CECTag(EC_TAG_SEARCH_ID, kSid));
 	c1.AddTag(CECTag(EC_TAG_PARTFILE_NAME, std::string("alt.name.mkv")));
 	c1.AddTag(CECTag(EC_TAG_PARTFILE_SIZE_FULL, static_cast<std::uint64_t>(123)));
 	c1.AddTag(CECTag(EC_TAG_PARTFILE_SOURCE_COUNT, static_cast<std::uint32_t>(10)));
@@ -1804,12 +1826,13 @@ TEST(Refresher, SearchResultGroupingFoldsChildren)
 	resp.AddTag(c1);
 
 	CECTag c2(EC_TAG_SEARCHFILE, static_cast<std::uint32_t>(102));
+	c2.AddTag(CECTag(EC_TAG_SEARCH_ID, kSid));
 	c2.AddTag(CECTag(EC_TAG_PARTFILE_NAME, std::string("third.mkv")));
 	c2.AddTag(CECTag(EC_TAG_PARTFILE_SIZE_FULL, static_cast<std::uint64_t>(123)));
 	c2.AddTag(CECTag(EC_TAG_SEARCH_PARENT, static_cast<std::uint32_t>(100)));
 	resp.AddTag(c2);
 
-	ApplySearchFull(&resp, cache);
+	ApplySearchUnion(&resp, slots, owner);
 
 	ASSERT_EQUALS(static_cast<size_t>(1), cache.size());
 	const auto it = cache.find(100);
@@ -1833,23 +1856,28 @@ TEST(Refresher, SearchResultGroupingFoldsChildren)
 // single parent and each must keep its own folder.
 TEST(Refresher, SearchResultDirectoryDecodesAndRidesEachChild)
 {
-	std::map<std::uint32_t, SearchResult> cache;
+	std::map<std::uint32_t, SearchSlot> slots;
+	std::map<std::uint32_t, std::uint32_t> owner;
+	slots[kSid];
+	std::map<std::uint32_t, SearchResult> &cache = slots[kSid].results;
 	CECPacket resp(EC_OP_SEARCH_RESULTS);
 
 	CECTag parent(EC_TAG_SEARCHFILE, static_cast<std::uint32_t>(200));
+	parent.AddTag(CECTag(EC_TAG_SEARCH_ID, kSid));
 	parent.AddTag(CECTag(EC_TAG_PARTFILE_NAME, std::string("shared.iso")));
 	parent.AddTag(CECTag(EC_TAG_PARTFILE_SIZE_FULL, static_cast<std::uint64_t>(4096)));
 	parent.AddTag(CECTag(EC_TAG_SEARCHFILE_DIRECTORY, std::string("Incoming/ISOs")));
 	resp.AddTag(parent);
 
 	CECTag child(EC_TAG_SEARCHFILE, static_cast<std::uint32_t>(201));
+	child.AddTag(CECTag(EC_TAG_SEARCH_ID, kSid));
 	child.AddTag(CECTag(EC_TAG_PARTFILE_NAME, std::string("shared-copy.iso")));
 	child.AddTag(CECTag(EC_TAG_PARTFILE_SIZE_FULL, static_cast<std::uint64_t>(4096)));
 	child.AddTag(CECTag(EC_TAG_SEARCH_PARENT, static_cast<std::uint32_t>(200)));
 	child.AddTag(CECTag(EC_TAG_SEARCHFILE_DIRECTORY, std::string("Backup/ISOs")));
 	resp.AddTag(child);
 
-	ApplySearchFull(&resp, cache);
+	ApplySearchUnion(&resp, slots, owner);
 
 	const auto it = cache.find(200);
 	ASSERT_TRUE(it != cache.end());
@@ -1863,13 +1891,17 @@ TEST(Refresher, SearchResultDirectoryEmptyOnOrdinaryHit)
 {
 	// A server/Kad hit never carries the tag, and must report an empty
 	// string rather than anything that could read as a real folder.
-	std::map<std::uint32_t, SearchResult> cache;
+	std::map<std::uint32_t, SearchSlot> slots;
+	std::map<std::uint32_t, std::uint32_t> owner;
+	slots[kSid];
+	std::map<std::uint32_t, SearchResult> &cache = slots[kSid].results;
 	CECPacket resp(EC_OP_SEARCH_RESULTS);
 	CECTag hit(EC_TAG_SEARCHFILE, static_cast<std::uint32_t>(300));
+	hit.AddTag(CECTag(EC_TAG_SEARCH_ID, kSid));
 	hit.AddTag(CECTag(EC_TAG_PARTFILE_NAME, std::string("remote.iso")));
 	resp.AddTag(hit);
 
-	ApplySearchFull(&resp, cache);
+	ApplySearchUnion(&resp, slots, owner);
 
 	const auto it = cache.find(300);
 	ASSERT_TRUE(it != cache.end());
@@ -2540,6 +2572,287 @@ TEST(Refresher, ServerPriorityMapsBothWays)
 // parser's return value is load-bearing: a reply it could not parse must be
 // rejected outright rather than handed back as an empty union, which the
 // caller would read as "every tracked search is gone" and retire in one pass.
+
+// --- The incremental contract -------------------------------------------
+//
+// Under EC_DETAIL_INC_UPDATE the daemon sends only what moved, so an absent
+// field means "unchanged". These pin that per field, because the failure mode
+// is silent: a guard forgotten on one field reverts it to its default on the
+// first quiet poll and nothing else notices.
+
+TEST(Refresher, SearchUnionSecondPollKeepsFieldsTheDiffOmits)
+{
+	std::map<std::uint32_t, SearchSlot> slots;
+	std::map<std::uint32_t, std::uint32_t> owner;
+	slots[kSid];
+
+	CECPacket first(EC_OP_SEARCH_RESULTS);
+	CECTag sf(EC_TAG_SEARCHFILE, static_cast<std::uint32_t>(70));
+	sf.AddTag(CECTag(EC_TAG_SEARCH_ID, kSid));
+	sf.AddTag(CECTag(EC_TAG_PARTFILE_NAME, std::string("cool.movie.mkv")));
+	sf.AddTag(CECTag(EC_TAG_PARTFILE_SIZE_FULL, static_cast<std::uint64_t>(123)));
+	sf.AddTag(CECTag(EC_TAG_PARTFILE_STATUS, static_cast<std::uint32_t>(2))); // QUEUED
+	sf.AddTag(CECTag(EC_TAG_PARTFILE_SOURCE_COUNT, static_cast<std::uint32_t>(9)));
+	first.AddTag(sf);
+	ApplySearchUnion(&first, slots, owner);
+
+	// A diff that moves only the source count. Everything else is absent,
+	// which is the daemon saying "unchanged", not "cleared".
+	CECPacket second(EC_OP_SEARCH_RESULTS);
+	CECTag d(EC_TAG_SEARCHFILE, static_cast<std::uint32_t>(70));
+	d.AddTag(CECTag(EC_TAG_PARTFILE_SOURCE_COUNT, static_cast<std::uint32_t>(11)));
+	second.AddTag(d);
+	ApplySearchUnion(&second, slots, owner);
+
+	const auto it = slots[kSid].results.find(70);
+	ASSERT_TRUE(it != slots[kSid].results.end());
+	ASSERT_EQUALS(static_cast<std::uint32_t>(11), it->second.source_count);
+	// The fields the diff said nothing about.
+	ASSERT_EQUALS(std::string("cool.movie.mkv"), it->second.name);
+	ASSERT_EQUALS(static_cast<std::uint64_t>(123), it->second.size);
+	ASSERT_EQUALS(std::string("queued"), it->second.status);
+	ASSERT_TRUE(it->second.already_have);
+	ASSERT_EQUALS(std::string("videos"), it->second.type);
+}
+
+TEST(Refresher, SearchUnionAppliesAStatusChangeOnAFinishedSearch)
+{
+	// The case #1187 section 2 is about: a hit gets downloaded after its
+	// search finished. Nothing here knows or cares that the search is over --
+	// which is the point, since the union polls it either way.
+	std::map<std::uint32_t, SearchSlot> slots;
+	std::map<std::uint32_t, std::uint32_t> owner;
+	slots[kSid];
+
+	CECPacket first(EC_OP_SEARCH_RESULTS);
+	CECTag sf(EC_TAG_SEARCHFILE, static_cast<std::uint32_t>(70));
+	sf.AddTag(CECTag(EC_TAG_SEARCH_ID, kSid));
+	sf.AddTag(CECTag(EC_TAG_PARTFILE_NAME, std::string("iso.img")));
+	sf.AddTag(CECTag(EC_TAG_PARTFILE_STATUS, static_cast<std::uint32_t>(0))); // NEW
+	first.AddTag(sf);
+	ApplySearchUnion(&first, slots, owner);
+	ASSERT_TRUE(!slots[kSid].results.find(70)->second.already_have);
+
+	CECPacket second(EC_OP_SEARCH_RESULTS);
+	CECTag d(EC_TAG_SEARCHFILE, static_cast<std::uint32_t>(70));
+	d.AddTag(CECTag(EC_TAG_PARTFILE_STATUS, static_cast<std::uint32_t>(1))); // DOWNLOADED
+	second.AddTag(d);
+	ApplySearchUnion(&second, slots, owner);
+
+	const auto &r = slots[kSid].results.find(70)->second;
+	ASSERT_EQUALS(std::string("downloaded"), r.status);
+	ASSERT_TRUE(r.already_have);
+}
+
+TEST(Refresher, SearchUnionQuietPollRemovesNothing)
+{
+	// Absence stopped meaning deletion: a poll that mentions a search not at
+	// all must leave its results alone. Sweeping here would empty every
+	// result set on the first tick where nothing changed.
+	std::map<std::uint32_t, SearchSlot> slots;
+	std::map<std::uint32_t, std::uint32_t> owner;
+	slots[kSid];
+
+	CECPacket first(EC_OP_SEARCH_RESULTS);
+	CECTag sf(EC_TAG_SEARCHFILE, static_cast<std::uint32_t>(70));
+	sf.AddTag(CECTag(EC_TAG_SEARCH_ID, kSid));
+	sf.AddTag(CECTag(EC_TAG_PARTFILE_NAME, std::string("still.here.bin")));
+	first.AddTag(sf);
+	ApplySearchUnion(&first, slots, owner);
+	ASSERT_EQUALS(static_cast<std::size_t>(1), slots[kSid].results.size());
+
+	const CECPacket quiet(EC_OP_SEARCH_RESULTS);
+	ApplySearchUnion(&quiet, slots, owner);
+	ASSERT_EQUALS(static_cast<std::size_t>(1), slots[kSid].results.size());
+	ASSERT_EQUALS(std::string("still.here.bin"), slots[kSid].results.find(70)->second.name);
+}
+
+TEST(Refresher, SearchUnionRemovesOnlyOnTheExplicitTombstone)
+{
+	std::map<std::uint32_t, SearchSlot> slots;
+	std::map<std::uint32_t, std::uint32_t> owner;
+	slots[kSid];
+
+	CECPacket first(EC_OP_SEARCH_RESULTS);
+	for (std::uint32_t ecid : { 70u, 71u }) {
+		CECTag sf(EC_TAG_SEARCHFILE, ecid);
+		sf.AddTag(CECTag(EC_TAG_SEARCH_ID, kSid));
+		sf.AddTag(CECTag(EC_TAG_PARTFILE_NAME, std::string("f.bin")));
+		first.AddTag(sf);
+	}
+	ApplySearchUnion(&first, slots, owner);
+	ASSERT_EQUALS(static_cast<std::size_t>(2), slots[kSid].results.size());
+
+	CECPacket second(EC_OP_SEARCH_RESULTS);
+	second.AddTag(CECTag(EC_TAG_FILE_REMOVED, static_cast<std::uint32_t>(71)));
+	ApplySearchUnion(&second, slots, owner);
+	ASSERT_EQUALS(static_cast<std::size_t>(1), slots[kSid].results.size());
+	ASSERT_TRUE(slots[kSid].results.find(70) != slots[kSid].results.end());
+	// The index loses it with the map, or a later reuse of the ECID would be
+	// attributed to a search that no longer holds it.
+	ASSERT_TRUE(owner.find(71) == owner.end());
+	ASSERT_TRUE(owner.find(70) != owner.end());
+}
+
+TEST(Refresher, SearchUnionAttributesDiffedTagsAcrossTwoSearches)
+{
+	// The index earns its keep here: the second poll carries no search id on
+	// either result, so both can only be placed by remembering who owns them.
+	const std::uint32_t sid_a = 1;
+	const std::uint32_t sid_b = 2 | 0x80000000u; // Kad ids carry the mask
+	std::map<std::uint32_t, SearchSlot> slots;
+	std::map<std::uint32_t, std::uint32_t> owner;
+	slots[sid_a];
+	slots[sid_b];
+
+	CECPacket first(EC_OP_SEARCH_RESULTS);
+	CECTag a(EC_TAG_SEARCHFILE, static_cast<std::uint32_t>(10));
+	a.AddTag(CECTag(EC_TAG_SEARCH_ID, sid_a));
+	a.AddTag(CECTag(EC_TAG_PARTFILE_NAME, std::string("a.bin")));
+	first.AddTag(a);
+	CECTag b(EC_TAG_SEARCHFILE, static_cast<std::uint32_t>(20));
+	b.AddTag(CECTag(EC_TAG_SEARCH_ID, sid_b));
+	b.AddTag(CECTag(EC_TAG_PARTFILE_NAME, std::string("b.bin")));
+	first.AddTag(b);
+	ApplySearchUnion(&first, slots, owner);
+
+	CECPacket second(EC_OP_SEARCH_RESULTS);
+	CECTag da(EC_TAG_SEARCHFILE, static_cast<std::uint32_t>(10));
+	da.AddTag(CECTag(EC_TAG_PARTFILE_SOURCE_COUNT, static_cast<std::uint32_t>(5)));
+	second.AddTag(da);
+	CECTag db(EC_TAG_SEARCHFILE, static_cast<std::uint32_t>(20));
+	db.AddTag(CECTag(EC_TAG_PARTFILE_SOURCE_COUNT, static_cast<std::uint32_t>(7)));
+	second.AddTag(db);
+	ApplySearchUnion(&second, slots, owner);
+
+	ASSERT_EQUALS(static_cast<std::uint32_t>(5), slots[sid_a].results.find(10)->second.source_count);
+	ASSERT_EQUALS(static_cast<std::uint32_t>(7), slots[sid_b].results.find(20)->second.source_count);
+	// And neither leaked into the other.
+	ASSERT_EQUALS(static_cast<std::size_t>(1), slots[sid_a].results.size());
+	ASSERT_EQUALS(static_cast<std::size_t>(1), slots[sid_b].results.size());
+}
+
+TEST(Refresher, SearchUnionDiffedChildStaysFoldedIntoItsParent)
+{
+	// A grouped child is addressable by its own ECID on the wire, so it gets
+	// diffed tags of its own -- which is why `raw` keeps children and the
+	// folded view is rebuilt from it rather than merged into.
+	std::map<std::uint32_t, SearchSlot> slots;
+	std::map<std::uint32_t, std::uint32_t> owner;
+	slots[kSid];
+
+	CECPacket first(EC_OP_SEARCH_RESULTS);
+	CECTag parent(EC_TAG_SEARCHFILE, static_cast<std::uint32_t>(100));
+	parent.AddTag(CECTag(EC_TAG_SEARCH_ID, kSid));
+	parent.AddTag(CECTag(EC_TAG_PARTFILE_NAME, std::string("movie.mkv")));
+	first.AddTag(parent);
+	CECTag child(EC_TAG_SEARCHFILE, static_cast<std::uint32_t>(101));
+	child.AddTag(CECTag(EC_TAG_SEARCH_ID, kSid));
+	child.AddTag(CECTag(EC_TAG_PARTFILE_NAME, std::string("movie.alt.mkv")));
+	child.AddTag(CECTag(EC_TAG_SEARCH_PARENT, static_cast<std::uint32_t>(100)));
+	first.AddTag(child);
+	ApplySearchUnion(&first, slots, owner);
+	ASSERT_EQUALS(static_cast<std::size_t>(1), slots[kSid].results.size());
+	ASSERT_EQUALS(static_cast<std::size_t>(1), slots[kSid].results.find(100)->second.children.size());
+
+	// The child's source count moves; it must still be nested, not promoted.
+	CECPacket second(EC_OP_SEARCH_RESULTS);
+	CECTag dc(EC_TAG_SEARCHFILE, static_cast<std::uint32_t>(101));
+	dc.AddTag(CECTag(EC_TAG_PARTFILE_SOURCE_COUNT, static_cast<std::uint32_t>(3)));
+	second.AddTag(dc);
+	ApplySearchUnion(&second, slots, owner);
+
+	ASSERT_EQUALS(static_cast<std::size_t>(1), slots[kSid].results.size());
+	const auto &kids = slots[kSid].results.find(100)->second.children;
+	ASSERT_EQUALS(static_cast<std::size_t>(1), kids.size());
+	ASSERT_EQUALS(static_cast<std::uint32_t>(3), kids[0].source_count);
+	ASSERT_EQUALS(std::string("movie.alt.mkv"), kids[0].name);
+}
+
+TEST(Refresher, SearchUnionSeesTheKadLookupEnd)
+{
+	// The daemon now always sends EC_TAG_PARTFILE_KAD_COMMENT_SEARCHING, and
+	// sends it through the valuemap, so the 1 -> 0 transition is itself a
+	// child tag and the result carrying it is not elided as unchanged. It
+	// used to be emitted only while the lookup ran or had notes, which made
+	// "finished, found nothing" a tag that simply stopped appearing -- and an
+	// incremental client cannot tell that from silence.
+	std::map<std::uint32_t, SearchSlot> slots;
+	std::map<std::uint32_t, std::uint32_t> owner;
+	slots[kSid];
+
+	CECPacket running(EC_OP_SEARCH_RESULTS);
+	CECTag sf(EC_TAG_SEARCHFILE, static_cast<std::uint32_t>(70));
+	sf.AddTag(CECTag(EC_TAG_SEARCH_ID, kSid));
+	sf.AddTag(CECTag(EC_TAG_PARTFILE_NAME, std::string("noted.bin")));
+	sf.AddTag(CECTag(EC_TAG_PARTFILE_KAD_COMMENT_SEARCHING, static_cast<std::uint64_t>(1)));
+	running.AddTag(sf);
+	ApplySearchUnion(&running, slots, owner);
+	ASSERT_TRUE(slots[kSid].results.find(70)->second.kad_comment_searching);
+
+	CECPacket done(EC_OP_SEARCH_RESULTS);
+	CECTag d(EC_TAG_SEARCHFILE, static_cast<std::uint32_t>(70));
+	d.AddTag(CECTag(EC_TAG_PARTFILE_KAD_COMMENT_SEARCHING, static_cast<std::uint64_t>(0)));
+	done.AddTag(d);
+	ApplySearchUnion(&done, slots, owner);
+
+	const auto &r = slots[kSid].results.find(70)->second;
+	ASSERT_TRUE(!r.kad_comment_searching);
+	// ...and the poll that carried it touched nothing else.
+	ASSERT_EQUALS(std::string("noted.bin"), r.name);
+}
+
+TEST(Refresher, SearchUnionCommentsAbsenceMeansNoNotes)
+{
+	// The comments container is the one field where absence is a value: it is
+	// built only when there are notes and added without the valuemap, so it is
+	// never diffed away. A poll that omits it is saying "no notes", not
+	// "unchanged" -- otherwise a note set could never shrink to empty.
+	std::map<std::uint32_t, SearchSlot> slots;
+	std::map<std::uint32_t, std::uint32_t> owner;
+	slots[kSid];
+
+	CECPacket withNotes(EC_OP_SEARCH_RESULTS);
+	CECTag sf(EC_TAG_SEARCHFILE, static_cast<std::uint32_t>(70));
+	sf.AddTag(CECTag(EC_TAG_SEARCH_ID, kSid));
+	sf.AddTag(CECTag(EC_TAG_PARTFILE_NAME, std::string("noted.bin")));
+	CECEmptyTag cont(EC_TAG_PARTFILE_COMMENTS);
+	cont.AddTag(CECTag(EC_TAG_PARTFILE_COMMENTS, std::string("someone")));
+	cont.AddTag(CECTag(EC_TAG_PARTFILE_COMMENTS, std::string("noted.bin")));
+	cont.AddTag(CECTag(EC_TAG_PARTFILE_COMMENTS, static_cast<std::uint64_t>(4)));
+	cont.AddTag(CECTag(EC_TAG_PARTFILE_COMMENTS, std::string("good file")));
+	sf.AddTag(cont);
+	withNotes.AddTag(sf);
+	ApplySearchUnion(&withNotes, slots, owner);
+	ASSERT_EQUALS(static_cast<std::size_t>(1), slots[kSid].results.find(70)->second.comments.size());
+
+	CECPacket without(EC_OP_SEARCH_RESULTS);
+	CECTag d(EC_TAG_SEARCHFILE, static_cast<std::uint32_t>(70));
+	d.AddTag(CECTag(EC_TAG_PARTFILE_SOURCE_COUNT, static_cast<std::uint32_t>(2)));
+	without.AddTag(d);
+	ApplySearchUnion(&without, slots, owner);
+	ASSERT_EQUALS(static_cast<std::size_t>(0), slots[kSid].results.find(70)->second.comments.size());
+}
+
+TEST(Refresher, SearchUnionIgnoresResultsForAnUnknownSearch)
+{
+	// Slot creation belongs to MarkSearchStarted / discovery, which also set
+	// the lifecycle state GET /search reports. Auto-creating one here would
+	// produce a search with results and no state behind it.
+	std::map<std::uint32_t, SearchSlot> slots;
+	std::map<std::uint32_t, std::uint32_t> owner;
+
+	CECPacket resp(EC_OP_SEARCH_RESULTS);
+	CECTag sf(EC_TAG_SEARCHFILE, static_cast<std::uint32_t>(70));
+	sf.AddTag(CECTag(EC_TAG_SEARCH_ID, static_cast<std::uint32_t>(999)));
+	sf.AddTag(CECTag(EC_TAG_PARTFILE_NAME, std::string("orphan.bin")));
+	resp.AddTag(sf);
+	ApplySearchUnion(&resp, slots, owner);
+
+	ASSERT_TRUE(slots.empty());
+	// And it is not left in the index pointing at a slot that never existed.
+	ASSERT_TRUE(owner.find(70) == owner.end());
+}
 
 TEST(Refresher, SearchProgressUnionParsesEveryEntry)
 {

--- a/unittests/tests/StateTest.cpp
+++ b/unittests/tests/StateTest.cpp
@@ -1552,6 +1552,81 @@ TEST(State, ResetListsAdvancesTheRevision)
 // MarkTickSuccess stamps the timestamp; it deliberately does NOT advance the
 // revision, because RefresherTick owns that and the background loop calls
 // both. Pinning it so a future edit does not quietly double-count.
+// ResetLists fires when the PREVIOUS tick returned null against a socket that
+// is still up -- an actual dropped connection shuts amuleapi down instead. The
+// daemon's search registry is therefore alive, along with its record of what it
+// has already sent us, and the multi-search union has no resync opcode. Wiping
+// our side would leave every search permanently short by whatever it held when
+// one tick happened to fail.
+TEST(State, ResetListsKeepsSearchSlots)
+{
+	CState state;
+	state.MarkSearchStarted(42, "global", "ubuntu");
+	state.MutateAllSearches([](std::map<std::uint32_t, SearchSlot> &slots,
+					std::map<std::uint32_t, std::uint32_t> &owner) {
+		SearchResult r;
+		r.name = "ubuntu.iso";
+		slots[42].raw[70] = r;
+		slots[42].results[70] = r;
+		owner[70] = 42;
+	});
+
+	state.ResetLists();
+
+	ASSERT_TRUE(state.HasAnySearch());
+	ASSERT_EQUALS(static_cast<size_t>(1), state.Search(42).size());
+}
+
+// A restarted search must not show the previous one's hits through the gaps in
+// a diffed tag. `results` alone is not enough: `raw` is what the union merges
+// into, and RebuildFoldedResults would put any survivor straight back.
+TEST(State, MarkSearchStartedClearsTheRawResultsAndTheIndex)
+{
+	CState state;
+	state.MarkSearchStarted(42, "global", "ubuntu");
+	state.MutateAllSearches([](std::map<std::uint32_t, SearchSlot> &slots,
+					std::map<std::uint32_t, std::uint32_t> &owner) {
+		SearchResult r;
+		r.name = "stale.iso";
+		slots[42].raw[70] = r;
+		slots[42].results[70] = r;
+		owner[70] = 42;
+	});
+
+	state.MarkSearchStarted(42, "global", "debian");
+
+	state.MutateAllSearches([](std::map<std::uint32_t, SearchSlot> &slots,
+					std::map<std::uint32_t, std::uint32_t> &owner) {
+		ASSERT_TRUE(slots[42].raw.empty());
+		ASSERT_TRUE(slots[42].results.empty());
+		ASSERT_TRUE(owner.find(70) == owner.end());
+	});
+}
+
+// Slots are capped, or a long-lived process watching a busy GUI accumulates one
+// result map per search forever. Active searches are never the victim, and a
+// detached one -- the daemon no longer holds it, so nothing is lost -- outranks
+// an attached one however much younger.
+TEST(State, SurplusSearchSlotsAreEvictedDetachedFirst)
+{
+	CState state;
+	// Two finished slots, oldest first, then fill well past the cap.
+	state.MarkSearchStarted(1, "global", "oldest-attached");
+	state.MarkSearchStarted(2, "global", "younger-detached");
+	state.WriteSearchProgress(1, SearchProgressSnapshot{});
+	state.WriteSearchProgress(2, SearchProgressSnapshot{});
+	state.DetachSearch(2);
+	for (std::uint32_t sid = 100; sid < 100 + 70; ++sid) {
+		state.MarkSearchStarted(sid, "global", "filler");
+		state.WriteSearchProgress(sid, SearchProgressSnapshot{});
+	}
+
+	const std::vector<std::uint32_t> left = state.AllSearchIds();
+	ASSERT_TRUE(left.size() <= 64);
+	// The detached one went even though slot 1 is older.
+	ASSERT_TRUE(std::find(left.begin(), left.end(), 2u) == left.end());
+}
+
 TEST(State, MarkTickSuccessDoesNotAdvanceTheRevision)
 {
 	CState state;

--- a/unittests/tests/StateTest.cpp
+++ b/unittests/tests/StateTest.cpp
@@ -1603,6 +1603,26 @@ TEST(State, MarkSearchStartedClearsTheRawResultsAndTheIndex)
 	});
 }
 
+// The union poll is gated on there being a slot the daemon could still speak
+// for. A detached slot is not one: its search is gone core-side, so polling on
+// its behalf is a roundtrip a second that can never return anything. Without
+// this, a user who runs one search and never deletes it keeps amuleapi polling
+// forever once the daemon's ring drops it.
+TEST(State, DetachedSlotsDoNotKeepTheUnionPollAlive)
+{
+	CState state;
+	state.MarkSearchStarted(42, "global", "ubuntu");
+	ASSERT_TRUE(state.HasAnySearch());
+
+	state.DetachSearch(42);
+	ASSERT_TRUE(!state.HasAnySearch());
+
+	// A second, still-attached slot re-opens it: the poll covers every search
+	// in one request, so one live slot is reason enough to send it.
+	state.MarkSearchStarted(43, "kad", "debian");
+	ASSERT_TRUE(state.HasAnySearch());
+}
+
 // Slots are capped, or a long-lived process watching a busy GUI accumulates one
 // result map per search forever. Active searches are never the victim, and a
 // detached one -- the daemon no longer holds it, so nothing is lost -- outranks


### PR DESCRIPTION
Search results now travel incrementally to every EC client. Two halves of one problem: the daemon could not express one transition incrementally, and amuleapi never adopted the incremental path at all.

Related to #1187 section 2, but not framed as that fix. Section 2 asks whether the search channel should push updates; this makes the data current for every client that polls it, which is the thing that has to be true first either way.

## Core: one tag the incremental encoder could not express

`CEC_SearchFile_Tag` built `EC_TAG_PARTFILE_KAD_COMMENT_SEARCHING` only while a Kad notes lookup was running or had notes to show, and built it without the valuemap. So "lookup finished, found nothing" was signalled by the tag ceasing to appear.

That cannot survive incremental encoding. A result whose only change is a tag no longer being built yields a tag with no children, and `Get_EC_Response_Search_Results_Union` drops exactly that as unchanged. The transition was invisible to every incremental client: **amulegui latched the flag on, and so did amuleapi**, and only a full re-read ever cleared it.

The fix is to emit it unconditionally and through the valuemap, which is what `CEC_PartFile_Tag` twenty lines above has always done for the same tag. The `1 -> 0` transition then is a child tag, the result is not elided, and every client sees the lookup end. A steady state still costs nothing: unchanged, it is diffed away as before.

**amulegui needs no code change.** Its reader was already correct; the encoder was the bug. The comments container stays gated and off the valuemap, because a client reads its absence as "no notes" rather than as "unchanged". One consequence of that is now noted in the code, since it looks like a bug from the other end: a result that has notes is never elided, because the container is a child tag that reappears on every poll.

## amuleapi: adopt the union the core already offered it

The refresher polled one `EC_OP_SEARCH_RESULTS` at `EC_DETAIL_FULL` **per active search**, each carrying that search's whole result set every tick whether or not anything had changed, then did `cache.clear()` and rebuilt. It now sends one id-less request at `EC_DETAIL_INC_UPDATE` for all searches at once.

amuleapi already advertised `EC_TAG_CAN_PARTIAL_SEARCH` and `EC_TAG_CAN_MULTI_SEARCH` unconditionally, so the daemon was already prepared to serve it this way and was eliding for this connection all along. No single-search fallback, matching the existing stance that amuleapi always pairs with a matching daemon.

For scale, #723 measured what the eliding is worth on the amulegui side: two finished searches with ~900 results were re-sending 12.3 KB every 3 s with not one changed field.

Three consequences shaped the code:

- **A diffed tag carries no `EC_TAG_SEARCH_ID`** (the daemon sends it once per result), and `EC_TAG_FILE_REMOVED` carries only an ECID. `CState` gains an ECID -> search_id index, maintained inside the same locked mutation that writes the result maps -- an index that can drift from the map it mirrors is how #1028 leaked keys a reload could not heal.
- **A grouped child is addressable by its own ECID** and gets diffed tags of its own, so it cannot be folded away at parse time. `SearchSlot` keeps a flat `raw` merge target and rebuilds the folded `results` view from it, which leaves `Search()`, `FindSearchResultByHash` and `EventDiff` on exactly the shape they already had.
- **Absence stopped meaning deletion**, so nothing but the daemon may remove a result -- the invariant amulegui already keeps.

Finished searches are no longer filtered out of the poll set. Keeping them polled costs nothing once an idle search elides to nothing, and it is what makes a hit downloaded after its search completed report `status` / `already_have` without anyone re-reading it.

## Second pass: the stream needed a resync path

Review of the above found eight defects sharing one root cause I had not named: the union is a **stateful differential stream with no opcode for "send it again"**. Every place the client dropped state the daemon still believed it held was therefore permanent loss, where under `EC_DETAIL_FULL` it self-healed on the next tick. One of them contradicts a claim in the first version of this description, and another contradicts a comment I wrote in the code asserting the gap cost nothing; both are retracted below rather than quietly edited out.

`FetchOneSearchFull` is the missing resync: one search, `EC_DETAIL_FULL`, outside the stream. Two callers need it.

**Foreign searches were lost permanently, not merely skipped.** This one is a regression introduced by the commit above and fixed in the same PR, so it is worth being precise about what changed rather than filing it as a pre-existing bug.

On master there was nothing to lose. amuleapi asked per search, `EC_DETAIL_FULL` with an `EC_TAG_SEARCH_ID`, so a search it did not know about was simply never requested. The dispatch in `ExternalConn.cpp` routes that to the per-search responder; the union responder was never reached.

Making the request id-less is what removes that protection. The union branch is selected on `m_multiSearchActive && incUpdate` and never reads `EC_TAG_SEARCH_ID` at all, so the request cannot be scoped to known searches by construction: the daemon answers for every search it holds, `GetKnownSearchIds()` included, which covers ones started in amulegui or the monolithic GUI. "We only ask once the tab is loaded" stops being available as a defence, because there is no longer a per-search ask.

`ApplySearchUnion` drops what it has no slot for, but the daemon has marked those ECIDs sent and seeded its valuemap, so every later poll elides them. A slot created afterwards stayed empty forever. The code comment on the poll gate said skipping the poll "costs nothing, because ApplySearchUnion drops results for a search with no slot anyway" -- true only at zero slots, which is the one case where the union is not sent at all. Discovery now seeds the slot in full instead.

Measured against a live amuled, second amuleapi instance, first-ever read of a search it never started:

| | `GET /search/{id}/results` | after 5 more ticks |
|---|---|---|
| before | `total: 0` | `total: 0` |
| after | `total: 274` | `total: 274` |

**The slot cap should not have been removed.** The first version argued retention was "bounded by the daemon's own eviction". `CEcSearchRegistry` does bound searches *started through EC* to `kMaxEcSearches` (20, global, LRU) -- but that is not a bound on our slots. It does not cover searches started in the monolithic GUI or amulegui, which `SearchList.h` says in as many words are not EC-bounded, and amuleapi holds a slot for any of those it has been asked to read. Nor does it cover a detached slot, whose daemon-side counterpart has already been evicted and so is not in that registry to be counted.

The cap is back at 64, and is affordable now precisely because eviction is recoverable -- a later read re-discovers the id and re-seeds it in full. Detached slots are preferred as victims, since for those the daemon has nothing left to re-send.

The rest:

- **Two threads issued the stream.** `RefreshSearchIfStale` issued the union from the HTTP thread while the tick issued it from its own. `SendRecvSerialized` serialises the roundtrip, not the roundtrip plus the apply, so two replies could land out of order and leave a row no later poll could correct. It takes the per-search FULL fetch instead -- idempotent, races nothing -- leaving the union with exactly one issuer.
- **`ResetLists` wiped state the daemon still held.** Its comment claimed an EC reconnect; it actually runs when the *previous tick returned null* against a socket that is still up, since a real drop shuts amuleapi down. The registry and diff state are alive, so clearing ours left every search short by whatever it held at that moment. Search slots and the index now survive it, for the same reason the credit store already did.
- **Ring eviction erased what retirement meant to keep.** The union ran before the expiry loop, so the tombstones an evicted search emits deleted its results before the retirement path tried to preserve them. `SearchSlot::detached` freezes such a slot, and the per-search progress loop moved above the results poll so the freeze happens first -- it reads the progress union fetched separately, so the order was free.
- **`MarkSearchStarted` cleared `results` but not `raw`.** A stale `raw` entry shows the previous search's fields through the gaps in a diffed tag, and `RebuildFoldedResults` puts it back however often `results` is cleared. It now clears both and the matching index entries.

## A ninth, found while answering a question about the gate

Not from the review. Asked plainly when amuleapi actually sends the union, I went back to the code and found the gate was wrong in a way none of the tests would ever have shown.

`HasAnySearch()` counted every slot, detached ones included. A detached slot's search is gone core-side, so the union can never return anything for it -- and the gate is all-or-nothing, so a session holding only detached slots kept sending one roundtrip a second forever. A user who runs a single search, lets it finish and never calls `DELETE` lands there the moment the daemon's ring drops it: the slot is retired and detached, nothing else is tracked, and the poll runs in perpetuity against a search that no longer exists. It stopped only if they deleted the search or started 64 more.

The gate now asks for any slot the daemon could still speak for, which is one `any_of` over a map capped at 64. Reads of a detached search are unaffected: its results are deliberately kept for late reads, and a read still refreshes on demand through `FetchOneSearchFull`, which the daemon answers with `EC_TAG_SEARCH_EXPIRED` and which leaves the kept results alone.

For anyone reviewing the gate, the trigger is narrower than it looks. A slot is created only by `POST /search` (or a browse) and by a **by-id** read that discovers one -- `GET /search/{id}/results`, `stop`, `close`, `more`. `GET /search`, the listing, goes straight to `EC_OP_SEARCH_LIST` and creates nothing, so listing searches never starts the poll.

## Docs

`REFERENCE.md` on `GET /search/{id}/results`: a finished search is no longer dropped from the poll set, so the paragraph saying the refresher stops polling it is replaced by what actually happens now. The on-read refresh is still documented, since it still exists and is what covers the sub-tick window. The discovery paragraph now says the confirming request also reads the search in full, so a client's first response carries the whole result set rather than an empty one that fills in over later ticks -- observable behaviour a caller can depend on, and the user-visible half of the foreign-search fix.

`EVENTS.md` on `search_result_added`: spells out that the channel is add-only. There is no `search_result_updated`, so a result's mutable fields do not push after the row first arrives; `search_progress` is the cue to re-read while a search runs, and the endpoint refreshes on read once it finishes. The daemon is polled for every search it holds, so a re-read is current -- the stream just will not tell you when to make one.

## Tests

The five existing search tests now drive the incremental applier rather than the full-replace one. Nine cases pin the merge contract, which is where the risk is concentrated: absent field survives, status change on a finished search, quiet poll removes nothing, removal only on the explicit tombstone, cross-search attribution through the index, a diffed child stays folded, results for an unknown search are ignored, the Kad lookup end is seen, and comments absence means no notes.

Seven more cover the second pass: a detached slot ignores tombstones, a detached slot ignores updates, an id-less reply is attributed to the search that was asked for, `ResetLists` keeps its slots, `MarkSearchStarted` clears `raw` and the index, surplus slots evict detached-first, and detached slots do not hold the union poll open.

The curl phase covers that two searches keep distinct result sets across repeated (and therefore diffed) polls, that no result loses a field that only travels on first appearance, and that a finished search is still maintained.

It also gains the regression test for the foreign-search loss, which had no automated coverage at all. The existing cross-session section reads a search the instance did not start, but from one that has never POSTed anything -- and that cannot regress, because a session with no slots never sends the union. The new section gives the second instance a slot first, then starts a search it has never seen and lets several union polls run over it before reading. Confirmed to be a real gate rather than a vacuous one: driving the pre-fix binary with this script fails both new assertions and exits 1.

Worth saying plainly, twice over. The Kad-notes bug was found by the curl suite, not by the unit tests, and only against a live daemon. And the cross-wiring check in the first version compared the two searches' *hash sets*, which a global and a Kad search for the same query may legitimately share -- an unsound discriminator. It now compares each search's cached total against the daemon's own `result_count` from `EC_OP_SEARCH_LIST`, an independent source, one-sided: the folded view may legitimately be smaller, but can only exceed it by holding another search's results.

## Verification

Against a live amuled on macOS:

- Full curl-smoke suite: **40/40 phases, 1614/1614 assertions**.
- Unit tests: **43/43**, including a new case pinning that a detached slot does not hold the poll open.
- Before/after control run for the foreign-search loss, on binaries built from this branch and its parent commit (table above).
- `clang-format` on the diff: clean.
- `clang-tidy` Tier-1 and Tier-2 on the diff: 0 findings, 0 compiler errors.
- `scripts/check-potfiles.sh`: clean, no new translatable strings.

## Two things reasoned about rather than observed

Recording these plainly so they are not later mistaken for verified.

- **amuleweb reads the same tag.** The change is additive -- a tag that was sometimes absent is now always present -- so it should be safe, but only amuleapi was exercised against a live daemon; the other consumers were reasoned about from their readers.
- **amulegui gets the fix without a code change.** That is an argument from reading its reader, not an observation. Someone starting a Kad notes lookup on a search result in the remote GUI and watching the flag clear would settle it.

