### PR TITLE
fix(amuleapi): close the v0 coherence gaps and reconcile the reference with the code

### DIFF
--- a/docs/api/EVENTS.md
+++ b/docs/api/EVENTS.md
@@ -340,9 +340,14 @@ Identical to the REST [`/api/v0/shared`](REFERENCE.md#get-apiv0shared) list-item
   "uploading":        2,
   "last_upload":      1700000500,
   "shared_since":     1699000000,
-  "hashing_progress": 0
+  "hashing_progress": 0,
+  "media": { "length_s": 5400, "bitrate": 1500, "codec": "h264", "artist": "", "album": "", "title": "" }
 }
 ```
+
+`media` is always present, and `null` on a file with no probed metadata -- the same object [`GET /shared`](REFERENCE.md#get-apiv0shared) carries, so the byte-for-byte parity promised above holds for it too. A metadata re-extraction changes it and therefore fires a `shared_updated`, which is the only way a subscriber learns a probe landed: the refresh endpoint answers `202` with no result.
+
+`last_upload` and `shared_since` are unix seconds and `null` when unknown -- a file that has never uploaded (the common case), or a `known.met` entry written before those fields existed. They are never `0`.
 
 `hashing_progress` counts the parts hashed so far by a [`POST /shared/{hash}/verify`](REFERENCE.md#post-apiv0sharedhashverify) run or an AICH hashset rebuild, and is `0` when nothing is hashing — each advance pushes a `shared_updated`, so a progress bar can be driven straight off the stream. A file that is both downloading and shared reports the same value on both channels.
 

--- a/docs/api/REFERENCE.md
+++ b/docs/api/REFERENCE.md
@@ -353,7 +353,7 @@ The rule now reaches the whole surface rather than just the download and shared 
 
 `media` is the one place this reaches an **object** rather than a scalar, so a client tests `media === null` before reaching into it -- which it had to do regardless, since the object's own fields can be absent.
 
-Four keys stay omitted, because for them absence really is the meaning: `started_at` and `result_count` on [`GET /search`](#get-apiv0search) as described above, `key` on a statistics node (absent from a daemon too old to send it), and `parts` under [`?include_parts=true`](#get-apiv0downloadshashclients) -- there the caller opted in, so the key's absence answers a question they did not ask.
+Five keys stay omitted, because for them absence really is the meaning: `started_at` and `result_count` on [`GET /search`](#get-apiv0search) as described above, `key` on a statistics node (absent from a daemon too old to send it), `ratio` on the statistics ratio node (absent when the daemon reported neither component), and `parts` under [`?include_parts=true`](#get-apiv0downloadshashclients) -- there the caller opted in, so the key's absence answers a question they did not ask.
 
 ### Priority levels
 
@@ -817,7 +817,7 @@ curl -s -H "Authorization: Bearer $TOKEN" "http://$HOST/api/v0/downloads"
 }
 ```
 
-`status` is one of `"downloading"`, `"waiting"`, `"hashing"`, `"allocating"`, `"paused"`, `"stopped"`, `"completing"` or `"completed"`. `"stopped"` is a paused file that has also dropped all its sources and reset its Kad source search (set via `PATCH` `status:"stopped"`); it is distinct from `"paused"`, which retains its sources.
+`status` is one of `"downloading"`, `"waiting"`, `"hashing"`, `"allocating"`, `"paused"`, `"stopped"`, `"completing"`, `"completed"`, `"erroneous"`, `"insufficient_disk"` or `"unknown"`. The last three are terminal-ish conditions a client must handle rather than fall through: `"erroneous"` is a failed partfile, `"insufficient_disk"` is one that ran the volume out of space, and `"unknown"` is a status code this version does not recognise. `"stopped"` is a paused file that has also dropped all its sources and reset its Kad source search (set via `PATCH` `status:"stopped"`); it is distinct from `"paused"`, which retains its sources.
 
 `priority` is the download priority — one of `"low"`, `"normal"` or `"high"` — and `priority_auto` is `true` when amuled is deriving that level automatically. Downloads never report `very_low` or `release`; those are shared/upload-side levels only. A file that is simultaneously downloading and shared carries two independent priorities: this download priority, and the upload priority reported by [`GET /api/v0/shared`](#get-apiv0shared). Changing one does not affect the other.
 
@@ -846,7 +846,7 @@ Same envelope as the list item, plus the detail-only fields below (all omitted f
 
 | Field | Type | Meaning |
 |---|---|---|
-| `progress.parts` | array | One entry per ~9.28 MiB chunk: `{ "state": string, "sources": int }` — `state` is `transferring`/`complete`/`empty`/`corrupt`/…, `sources` counts peers offering that chunk. |
+| `progress.parts` | array | One entry per ~9.28 MiB chunk: `{ "state": string, "sources": int }` — `state` is `complete`/`incomplete`/`missing` -- complete when the chunk is done, otherwise whether any peer offers it -- and `sources` counts peers offering that chunk. |
 | `last_seen_complete` | int \| null | Unix ts a complete copy was last seen across sources; `null` when no complete copy has ever been seen, or the daemon does not report it. |
 | `last_changed` | int | Unix ts the partfile last received data. |
 | `download_active_time` | int | Seconds spent actively downloading. |
@@ -864,13 +864,13 @@ Same envelope as the list item, plus the detail-only fields below (all omitted f
 | `comment` | string | The user's own comment on this file (`""` if none). |
 | `rating` | int | The user's own rating, `0`–`5` (`0` = unrated). See the [rating scale](#get-apiv0downloadshashcomments). |
 | `a4af_auto` | bool | Whether automatic A4AF source-swapping is on for this file. See [A4AF](#post-apiv0downloadshasha4af). |
-| `media` | object | Audio/video metadata — see [Media metadata](#media-metadata). **Omitted entirely** when the file has no probed metadata. |
+| `media` | object | Audio/video metadata — see [Media metadata](#media-metadata). **`null`** when the file has no probed metadata; the key is always present. |
 
 **Errors:** `404 not_found` (no partfile with that hash), `503 ec_unavailable`.
 
 ##### Media metadata
 
-The `media` object (on both `GET /downloads/{hash}` and `GET /shared/{hash}`) carries the audio/video metadata amuled probed for the file. It is **omitted entirely** when the file has not been probed (a non-media file, or one probing hasn't reached yet).
+The `media` object (on both `GET /downloads/{hash}` and `GET /shared/{hash}`) carries the audio/video metadata amuled probed for the file. It is **`null`** when the file has not been probed (a non-media file, or one probing hasn't reached yet) -- the key is always present, so test `media === null` rather than for the key.
 
 ```json
 "media": {
@@ -984,7 +984,7 @@ Each entry is the [`/clients`](#get-apiv0clients) list object plus three keys:
 
 `parts` is opt-in because it is one boolean per chunk per peer — a multi-TiB file is 100k+ entries each. It is exactly `part_count` entries, and it describes the file this row is about: the download bitmap for a `source`, the upload bitmap for a `peer`. A peer the core reports as holding every part comes back all-`true`. A pure A4AF row has no bitmap for this file and omits the key. **`parts` never appears in SSE payloads.**
 
-The file's own five-state part view is on [`GET /downloads/{hash}`](#get-apiv0downloadshash); combine it with this bitmap to render the desktop's per-source bar.
+The file's own three-state part view is on [`GET /downloads/{hash}`](#get-apiv0downloadshash); combine it with this bitmap to render the desktop's per-source bar.
 
 Both routes accept `limit` / `offset` / `sort` / `order` exactly as `/clients` does. A partfile with at least one completed chunk is both a download and a shared file, and then **both routes return the same body** — they differ only in which collection the hash must belong to, which is what the `404` checks.
 
@@ -1324,7 +1324,7 @@ Browse a peer's shared file list — the API equivalent of "View Files" in the G
 The browse runs **asynchronously**: the peer answers over the network, one directory at a time, and a HighID/reachable peer may take seconds while a LowID peer needs a server callback or Kad first. So this endpoint does **not** return the files — it returns a `search_id` and the results flow through the **search machinery**, exactly like a query search:
 
 - `GET /api/v0/search/{id}/results` reads the accumulated files as they arrive (standard search-result fields, plus `directory` — the folder each file sits in inside the peer's share). The browse also appears in [`GET /api/v0/search`](#get-apiv0search) with `kind: "browse"` and the browsed peer's `client_ecid`.
-- The refresher advances `search_progress` for this `search_id` while the browse is live, and emits a `search_finished` SSE event when the peer's list is complete or the browse fails (denied / peer unreachable / connection lost). A denied or failed browse finishes with zero results — there is no distinct error event.
+- The refresher advances `search_progress` for this `search_id` while the browse is live, and completion arrives as the terminal `search_progress` frame with `"state": "finished"` — when the peer's list is complete or the browse fails (denied / peer unreachable / connection lost). There is **no** `search_finished` event; a client waiting for one waits forever. A denied or failed browse finishes with zero results, so there is no distinct error event either.
 
 Reusing the search id-space means one poll loop and one SSE stream cover both queries and browses; a client tells them apart by remembering which `search_id` it started with which verb.
 
@@ -1341,10 +1341,12 @@ curl -s -X POST -H "Authorization: Bearer $TOKEN" \
   "query":       "some peer",
   "kind":        "browse",
   "state":       "running",
-  "client_ecid": 4382,
+  "client_ecid": null,
   "started_at":  1750412400
 }
 ```
+
+`client_ecid` is `null` in this reply even though you addressed the peer by ecid: the row is built locally before the daemon has reported anything about the browse, and `client_ecid` is one of the fields it fills in. [`GET /search`](#get-apiv0search) carries the peer's ecid for the same browse from the next refresher tick onward.
 
 A browse the daemon cannot even start — a LowID peer it has no way to call back, for instance — is reported as `finished` immediately rather than left pending: no connection is attempted, so there is nothing to wait for. It carries no results, the same as a browse the peer denied.
 
@@ -1357,7 +1359,7 @@ curl -s -H "Authorization: Bearer $TOKEN" \
   "http://$HOST/api/v0/search/17/results"
 ```
 
-**Errors:** `400 bad_request` (`{ecid}` is not a non-negative integer), `403 forbidden` (guest token — browsing is `ADMIN`-only), `404 not_found` (no peer with that ecid), `405 method_not_allowed` (non-POST), `502 bad_gateway` (core accepted the request but returned no `search_id`), `503 ec_unavailable`.
+**Errors:** `400 bad_request` (`{ecid}` is not a non-negative integer), `403 forbidden` (guest token — browsing is `ADMIN`-only), `404 not_found` (no peer with that ecid), `405 method_not_allowed` (non-POST), `502 amuled_rejected` (core accepted the request but returned no `search_id`), `503 ec_unavailable`.
 
 ---
 
@@ -1487,7 +1489,7 @@ curl -s -H "Authorization: Bearer $TOKEN" "http://$HOST/api/v0/shared"
 
 A file that is both downloading and shared reports its progress here as well: amuled describes such a file as a partfile, so the value is read across from the download side and the two agree. That makes `hashing_progress` usable from either list without checking which one owns the file.
 
-`media` is present only on an audio or video file that has been probed, and absent entirely otherwise — check for the key rather than for empty values. Its six fields are the same ones the detail endpoint reports, and a [media refresh](#post-apiv0sharedmediarefresh) replaces all of them, clearing any the new probe no longer finds.
+`media` is an object on an audio or video file that has been probed and `null` otherwise — the key is always present, so test `media === null` rather than checking for the key. Its six fields are the same ones the detail endpoint reports, and a [media refresh](#post-apiv0sharedmediarefresh) replaces all of them, clearing any the new probe no longer finds.
 
 The SSE `shared_added` / `shared_updated` event payload matches this object byte-for-byte, so a subscriber that received `shared_updated` does not need to re-GET to see the moved counters — including `media`, which is what makes a metadata refresh observable without polling.
 
@@ -1517,7 +1519,7 @@ curl -s -H "Authorization: Bearer $TOKEN" \
 | `queued_count` | int | Clients waiting on this file's upload queue. |
 | `comment` | string | The user's own comment on this file (`""` if none). |
 | `rating` | int | The user's own rating, `0`–`5` (`0` = unrated). |
-| `media` | object | Audio/video metadata — see [Media metadata](#media-metadata). **Omitted entirely** when the file has no probed metadata. |
+| `media` | object | Audio/video metadata — see [Media metadata](#media-metadata). **`null`** when the file has no probed metadata; the key is always present. |
 
 `hashing_progress` comes through from the list item; pair it with `part_count` here for a percentage.
 
@@ -1644,12 +1646,12 @@ amuled validates every path: a REST client cannot stat the core's filesystem, so
 {
   "results": [
     { "id": "/srv/share", "ok": true },
-    { "id": "/typo", "ok": false, "code": "not_found", "message": "no such directory" }
+    { "id": "/typo", "ok": false, "error": { "code": "not_found", "message": "no such directory" } }
   ]
 }
 ```
 
-`reason` is `not_found` (missing, or not a directory) or `not_readable`. amuled reports these as codes and the API renders them, so its locale never leaks into your response.
+`error.code` is `not_found` (missing, or not a directory) or `not_readable` (`403`, amuled cannot read the path). amuled reports these as codes and the API renders them, so its locale never leaks into your response.
 
 The **rescan is scheduled, not completed**, before the response returns: a successful reply means the new roots are validated and persisted, and that the re-walk will start on amuled's next processing tick. Until it finishes, [`GET /api/v0/shared`](#get-apiv0shared) still serves the previous file list. Observe completion the same way as [`POST /api/v0/shared_reload`](#post-apiv0shared_reload), whose notes on log lines and coalescing apply here too.
 
@@ -1667,7 +1669,7 @@ curl -s -X POST -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/
   "http://$HOST/api/v0/share_directories"
 ```
 
-Idempotent: adding a path that is already configured updates its `recursive` flag rather than failing, so "ensure this folder is shared" is safe to repeat. Same `{ok, rejected}` body as `PUT`.
+Idempotent: adding a path that is already configured updates its `recursive` flag rather than failing, so "ensure this folder is shared" is safe to repeat. Same `{results: [...]}` envelope as `PUT`.
 
 **Errors:** `400 bad_request` (missing/empty `path`, non-boolean `recursive`), `502 amuled_rejected`, `503 ec_unavailable`.
 
@@ -1689,7 +1691,7 @@ curl -s -X DELETE -H "Authorization: Bearer $TOKEN" \
   "http://$HOST/api/v0/share_directories?path=C%3A%5CUsers%5Cbob%5CMy%20Shares"
 ```
 
-Removing a path that is not configured is a `404` rather than a silent success, so a typo — or a path that does not byte-match what `GET` returned — is visible. Same `{ok, rejected}` body as `PUT`.
+Removing a path that is not configured is a `404` rather than a silent success, so a typo — or a path that does not byte-match what `GET` returned — is visible. Same `{results: [...]}` envelope as `PUT`.
 
 **Errors:** `400 bad_request` (no `path` parameter), `404 not_found` (path not configured), `502 amuled_rejected`, `503 ec_unavailable`.
 
@@ -1755,7 +1757,7 @@ Send a bare priority level to pin it (the file's `priority_auto` becomes `false`
 
 `name` renames the file — a non-empty string with no path separators (`/` or `\`, rejected to prevent the rename escaping the file's directory). Rename works on any known file, so it is accepted on both this endpoint and [`PATCH /downloads/{hash}`](#patch-apiv0downloadshash).
 
-**Errors:** `400 bad_request` (missing/invalid fields, `comment`/`rating` sent alone, or a `name` that is empty or contains a path separator), `409 not_shared` (comment/rating on a non-shared file), `400 amuled_rejected`, `503 ec_unavailable`.
+**Errors:** `400 bad_request` (missing/invalid fields, `comment`/`rating` sent alone, or a `name` that is empty or contains a path separator), `404 not_found` (no shared file with that hash), `409 not_shared` (comment/rating on a non-shared file), `400 amuled_rejected`, `503 ec_unavailable`.
 
 ---
 
@@ -1879,7 +1881,7 @@ curl -s -X POST -H "Authorization: Bearer $TOKEN" \
 
 **Response:** `202 Accepted`, no body. The connect is asynchronous; its outcome shows up on [`GET /status`](#get-apiv0status)'s `ed2k.state` and on the SSE stream.
 
-**Errors:** `400 bad_request` (unparseable address/ECID), `404 not_found`, `503 ec_unavailable`.
+**Errors:** `400 bad_request` (unparseable address/ECID), `400 amuled_rejected` (the daemon refused the connect), `404 not_found`, `503 ec_unavailable`.
 
 #### `DELETE /api/v0/servers/{ecid}` / `DELETE /api/v0/servers/by-address/{address}`
 
@@ -1928,11 +1930,11 @@ Tells amuled to fetch the `server.met` from the supplied URL and refresh its lis
 { "servers_url": "http://example.com/server.met" }
 ```
 
-The URL must start with `http://` or `https://`; anything else is rejected `400 bad_request`.
+`servers_url` is **required** here, and must start with `http://` or `https://`; omitting it, or sending anything else, is a `400 bad_request`. This differs from [`POST /ipfilter/update`](#post-apiv0ipfilterupdate), which does fall back to its configured preference when the field is absent.
 
 The URL is **persisted** into the `servers.update_url` preference, so a subsequent `GET /preferences` reflects it — there is no need to PATCH it separately.
 
-**Response:** `202 Accepted`, no body. The URL came from the request (or, when omitted, from the preference this documents), and the download runs asynchronously -- its outcome arrives on the log channel.
+**Response:** `202 Accepted`, no body. The download runs asynchronously -- its outcome arrives on the log channel.
 
 **Errors:** `400 bad_request`, `400 amuled_rejected`, `503 ec_unavailable`.
 
@@ -2043,11 +2045,11 @@ amuled's category system lets users tag downloads with one of N user-defined buc
   "categories": [
     {
       "index": 0,
-      "name": "All",
+      "name": "Default",
       "path": "/home/user/aMule/Incoming",
       "comment": "",
       "color": 0,
-      "priority": "normal"
+      "priority": "low"
     }
   ],
   "total": 1,
@@ -2114,7 +2116,7 @@ Any subset of the POST body fields. `index 0` (the default category) can be patc
 
 **Response:** `204 No Content`.
 
-Deleting `index 0` is rejected by amuled (`400 amuled_rejected`).
+Deleting `index 0` is refused here, before any EC roundtrip: `400 bad_request` ("cannot delete the default (index=0) category"). amuled is never asked.
 
 ---
 
@@ -2295,7 +2297,7 @@ The three **clamped at daemon start** rows are the reason this is enforced on th
 
 **A low `connection.max_upload_kbps` caps `max_download_kbps`,** which is the one place a `PATCH` changes a field the request did not name. Below `4` kB/s up the download limit is forced to 3× the upload; below `10` it is forced to 4×. So `PATCH {"connection": {"max_upload_kbps": 3}}` also sets `max_download_kbps` to `9`. This is a deliberate anti-leech rule in the core rather than a defect, it applies whichever of the two you write, and the `PATCH` response echoes the whole preferences object so the adjusted value is visible in the reply.
 
-**Errors:** `400 bad_request` (unknown/mis-typed field, or a body with no recognized fields), `400 amuled_rejected`, `503 ec_unavailable`.
+**Errors:** `400 bad_request` (unknown/mis-typed field, or a body with no recognized fields), `409 conflict` (the daemon was built without support for the option being set), `400 amuled_rejected`, `503 ec_unavailable`.
 
 ---
 
@@ -2309,9 +2311,15 @@ These endpoints drive amuled's connect/disconnect to the ed2k network, the Kad n
 
 **Body:** `{ "network": "ed2k" | "kad" | "both" }` (optional; defaults to `"both"`). Same shape as `/networks/disconnect` — `"ed2k"` fires `EC_OP_SERVER_CONNECT`, `"kad"` fires `EC_OP_KAD_START`, omitted/`"both"` fires `EC_OP_CONNECT`.
 
-**Response:** `202 Accepted`.
+**Response:** `202 Accepted`, with amuled's own account of what it did:
 
-**Errors:** `400 bad_request` (unknown selector), `503 ec_unavailable`.
+```json
+{ "message": "Connecting to eDonkey network..." }
+```
+
+`message` is absent when the daemon said nothing. `202` rather than `200`: the request is handed to amuled over EC and returns before the effect is observable, which is as true of a disconnect as of a connect -- the two used to disagree on this for no reason a client could see.
+
+**Errors:** `400 bad_request` (unknown selector), `400 amuled_rejected` (the daemon refused the operation), `503 ec_unavailable`.
 
 #### `POST /api/v0/networks/disconnect`
 
@@ -2319,9 +2327,15 @@ These endpoints drive amuled's connect/disconnect to the ed2k network, the Kad n
 
 **Body:** `{ "network": "ed2k" | "kad" | "both" }` (optional; defaults to `"both"`).
 
-**Response:** `200 OK`.
+**Response:** `202 Accepted`, with amuled's own account of what it did:
 
-**Errors:** `400 bad_request`, `503 ec_unavailable`.
+```json
+{ "message": "Connecting to eDonkey network..." }
+```
+
+`message` is absent when the daemon said nothing. `202` rather than `200`: the request is handed to amuled over EC and returns before the effect is observable, which is as true of a disconnect as of a connect -- the two used to disagree on this for no reason a client could see.
+
+**Errors:** `400 bad_request` (unknown selector), `400 amuled_rejected` (the daemon refused the operation), `503 ec_unavailable`.
 
 > Dedicated `POST /api/v0/kad/connect` and `POST /api/v0/kad/disconnect` shortcuts existed in an earlier draft of v0 but were dropped in favour of the `/networks/{connect,disconnect}` body selector — `{"network":"kad"}` does exactly what they did. The `/kad/bootstrap` endpoint below is genuinely distinct and stays.
 
@@ -2532,7 +2546,7 @@ The envelope is `{ "nodes": [...] }`. Each node is `{ "key": "<id>", "label_valu
 
 `key` is a **stable, machine-readable identifier** for the node (e.g. `"upload_data"`, `"ul_dl_ratio"`, `"servers_working"`). Unlike `label`, it does not change when the label is reworded, and it is never translated — use it to locate a specific field instead of matching on the label string. The `key` is optional: it is present only for nodes the daemon assigns one to, and it is omitted entirely when absent (older daemons that predate this field emit no `key` at all). Keys are unique among the fixed skeleton nodes; the dynamic per-client-software rows share a key by kind (see below).
 
-`label_value` is the **raw, untranslated machine value** for nodes whose `label` is itself data — the per-client-software breakdown rows, where the label is a version or OS string (`"v0.70b: %s"`, `"Linux: %s"`). It carries just that value (`"v0.70b"`, `"Linux"`) so a client reads it directly instead of parsing it out of the `label`. Present only on those rows; omitted otherwise and on daemons that predate the field. These rows are grouped under the `client_versions` / `client_operating_system` container nodes and each row carries `key: "client_version"` / `key: "client_os"` — so the `key` tells you the kind and `label_value` gives the value.
+`label_value` is the **raw, untranslated machine value** for nodes whose `label` is itself data — the per-client-software breakdown rows, where the label is a version or OS string (`"v0.70b: %s"`, `"Linux: %s"`). It carries just that value (`"v0.70b"`, `"Linux"`) so a client reads it directly instead of parsing it out of the `label`. Present as a string on those rows and `null` otherwise, including on daemons that predate the field; the key itself is always emitted. These rows are grouped under the `client_versions` / `client_operating_system` container nodes and each row carries `key: "client_version"` / `key: "client_os"` — so the `key` tells you the kind and `label_value` gives the value.
 
 Each value is `{ "type": "<type>", "value": <raw> }`:
 
@@ -2545,7 +2559,7 @@ Each value is `{ "type": "<type>", "value": <raw> }`:
 | `double` | number | raw double |
 | `string` | string | opaque English string (e.g. a ratio, or `"Not available"`) |
 
-A `string` value that is a **well-known sentinel** additionally carries a `token` field with a stable, locale-independent token — currently `"never"` (a "Never" timestamp, e.g. max-connection-limit-reached) and `"not_available"` (a ratio with no data yet). The English `value` is left in place unchanged, so this is purely additive: prefer `token` when present and fall back to `value` otherwise. It is absent on non-sentinel values and on daemons that predate the field.
+A `string` value that is a **well-known sentinel** additionally carries a `token` field with a stable, locale-independent token — currently `"never"` (a "Never" timestamp, e.g. max-connection-limit-reached) and `"not_available"` (a ratio with no data yet). The English `value` is left in place unchanged, so this is purely additive: prefer `token` when present and fall back to `value` otherwise. It is `null` on non-sentinel values and on daemons that predate the field; the key itself is always emitted.
 
 A value may carry a nested `extra` value of the same shape — whatever the desktop prints in parentheses. It is **three different quantities** depending on the node, so format it from its own `type` rather than assuming: a **percentage of the parent** on counter nodes that show one, a **packet count** beside a byte total on the packet nodes, and the **all-time total** beside a session figure on the transfer counters.
 
@@ -2557,23 +2571,27 @@ The UL:DL ratio node (`key: "ul_dl_ratio"`) additionally carries a `ratio` objec
     {
       "key": "transfer",
       "label": "Transfers",
+      "label_value": null,
       "values": [],
       "children": [
         {
           "key": "uploads",
           "label": "Uploads",
+          "label_value": null,
           "values": [],
           "children": [
             {
               "key": "upload_data",
               "label": "Total uploaded: %s",
-              "values": [ { "type": "bytes", "value": 13314398208 } ],
+              "label_value": null,
+              "values": [ { "type": "bytes", "value": 13314398208, "token": null, "extra": null } ],
               "children": []
             },
             {
               "key": "ul_dl_ratio",
               "label": "Session UL:DL Ratio (Total): %s",
-              "values": [ { "type": "string", "value": "1 : 769.34 (1 : 1125.54)" } ],
+              "label_value": null,
+              "values": [ { "type": "string", "value": "1 : 769.34 (1 : 1125.54)", "token": null, "extra": null } ],
               "ratio": { "session": 769.34, "total": 1125.54 },
               "children": []
             }
@@ -2592,7 +2610,7 @@ A per-client-software version row (note `label_value`, and an `extra` that is a 
   "key": "client_version",
   "label_value": "v0.70b",
   "label": "v0.70b: %s",
-  "values": [ { "type": "integer", "value": 42, "extra": { "type": "double", "value": 12.5 } } ],
+  "values": [ { "type": "integer", "value": 42, "token": null, "extra": { "type": "double", "value": 12.5 } } ],
   "children": []
 }
 ```
@@ -2600,7 +2618,7 @@ A per-client-software version row (note `label_value`, and an `extra` that is a 
 ```json
 {
   "label": "Max Connection Limit Reached: %s",
-  "values": [ { "type": "string", "value": "Never", "token": "never" } ],
+  "values": [ { "type": "string", "value": "Never", "token": "never", "extra": null } ],
   "children": []
 }
 ```
@@ -2793,7 +2811,7 @@ amuled keeps a bounded ring of recent searches (20). A search evicted from that 
 }
 ```
 
-Each result carries `sources` as a nested `{total, complete}` object — `total` is the swarm size amuled reports and `complete` is how many of those hold the file complete. `already_have` is `true` when you are currently downloading the file or already have it completed/shared; it is `false` for a fresh result and for one you have canceled/removed (a canceled result is re-downloadable, so it does not read as held). `rating` is amuled's aggregated quality rating (`0` when unrated). `status` is this result's download status on your node — `"new"` / `"downloaded"` / `"queued"` / `"canceled"` / `"queued_canceled"`. `type` is the file-type token derived from the filename extension (same tokens as the shared-detail [`file_type`](#get-apiv0sharedhash), e.g. `"videos"` / `"audio"`; `""` when the name has no extension). `media` is the audio/video [media metadata](#media-metadata) object (same shape as the file-detail endpoints), and is **omitted entirely** for a hit that carries no metadata (most global/Kad results), matching the blank Length/Bitrate/Codec columns in the desktop search list. **Unlike `media` on `GET /downloads/{hash}` and `GET /shared/{hash}`, which amuled probed locally, `media` on a search result is whatever the responding server advertised.** It is not verified against the file and can contradict it — a `.pdf` reporting a runtime and a video codec is a real observed result — so treat it as a hint, not as probed metadata.
+Each result carries `sources` as a nested `{total, complete}` object — `total` is the swarm size amuled reports and `complete` is how many of those hold the file complete. `already_have` is `true` when you are currently downloading the file or already have it completed/shared; it is `false` for a fresh result and for one you have canceled/removed (a canceled result is re-downloadable, so it does not read as held). `rating` is amuled's aggregated quality rating (`0` when unrated). `status` is this result's download status on your node — `"new"` / `"downloaded"` / `"queued"` / `"canceled"` / `"queued_canceled"`. `type` is the file-type token derived from the filename extension (same tokens as the shared-detail [`file_type`](#get-apiv0sharedhash), e.g. `"videos"` / `"audio"`; `""` when the name has no extension). `media` is the audio/video [media metadata](#media-metadata) object (same shape as the file-detail endpoints), and is **`null`** for a hit that carries no metadata (most global/Kad results), matching the blank Length/Bitrate/Codec columns in the desktop search list. The key is always present. **Unlike `media` on `GET /downloads/{hash}` and `GET /shared/{hash}`, which amuled probed locally, `media` on a search result is whatever the responding server advertised.** It is not verified against the file and can contradict it — a `.pdf` reporting a runtime and a video codec is a real observed result — so treat it as a hint, not as probed metadata.
 
 `directory` is the folder this file sits in **inside a browsed peer's share** — the desktop search list's *Directories* column. It is populated only for results filed from a peer's shared-file listing (see [peer browse](#post-apiv0clientsecidshared_files)) and is `""` on every ordinary server/Kad hit, which never carries it. It is per-result rather than per-search: two copies of one file in different folders of the same share group under a single parent and each keeps its own folder, exactly as the desktop shows them, which is why `children[]` entries carry it too.
 
@@ -2811,7 +2829,7 @@ The `progress` object carries the same `state` / `kind` / `percent` fields as th
 
 A client that wants to wait for completion polls while `state == "running"`. Because amuled now reports the lifecycle state directly (no sentinel decode), `state == "running"` unambiguously means in-flight even for Kad — there is no longer any "is `percent: 0` a stalled Kad search or no search at all?" ambiguity; check `state` instead. A Kad search that hits its result cap (`SEARCHKEYWORD_TOTAL`, 300) before the 45 s deadline finishes early — `state` flips to `finished` and `percent` jumps to 100 ahead of the ramp.
 
-**Errors:** `400 bad_request` (bad `{id}`), `404 not_found` (no such search), `503 ec_unavailable`.
+**Errors:** `400 bad_request` (bad `{id}`), `404 not_found` (no such search). No `503`: this endpoint serves the refresher's cache, and a failed EC roundtrip while adopting an unknown `{id}` surfaces as the `404` rather than as an availability error.
 
 #### `POST /api/v0/search/{id}/stop`
 
@@ -2988,7 +3006,7 @@ curl -s -H "Authorization: Bearer $TOKEN" "http://$HOST/api/v0/chats"
 
 `name` falls back to `"IP: <ip> Port: <port>"` when the core has no nickname for the peer, matching what the desktop shows; the same string appears in the SSE payload. `client_ecid` is `0` when the peer is offline, `friend_ecid` is `0` when the peer is not a friend — join against [`GET /clients`](#get-apiv0clients) and [`GET /friends`](#get-apiv0friends). `online` is simply `client_ecid != 0`.
 
-`last_message` is omitted for a conversation that holds none. The full transcript is deliberately **not** on the list: 50 conversations at 200 messages each would be 10 000 objects per read. Use the messages endpoint below.
+`last_message` is `null` for a conversation that holds none; the key is always present. The full transcript is deliberately **not** on the list: 50 conversations at 200 messages each would be 10 000 objects per read. Use the messages endpoint below.
 
 Served from the refresher snapshot — no EC roundtrip per request. Standard [list envelope](#list-pagination-and-sorting); sortable on `last_message_at` and `name`.
 
@@ -3032,7 +3050,7 @@ curl -s -X POST -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/
   "message": { "id": 92, "direction": "out", "text": "hello" } }
 ```
 
-The created message stays in the body: no per-message `GET` defines a shape for it, so the `id` and the timestamp the store assigned are only readable here.
+The created message stays in the body because no per-message `GET` defines a shape for it, so the store-assigned `id` is only readable here. The **timestamp is not** in this reply — read it back from [`GET /chats`](#get-apiv0chats) (as `last_message`), from the per-conversation messages endpoint, or from the `chat_message` SSE event.
 
 The core creates the conversation if it does not exist, so this doubles as "start a chat with this address" — an unknown `{peer}` is not a `404` here.
 
@@ -3085,6 +3103,7 @@ Every error code emitted by `/api/v0/*`, sorted by what triggered it. Two codes 
 | `invalid_credentials` | 401, 403 | `/auth/login` password didn't match any role (401); or `PATCH /auth/passwords` was given a `current_password` that does not match (403). |
 | `forbidden` | 403 | Authenticated as `guest` but the endpoint requires `admin`. |
 | `not_found` | 404 | Resource doesn't exist (unknown hash, ECID, graph name, or no such endpoint). |
+| `not_readable` | 403 | Per-item code from the [`/share_directories`](#post-apiv0share_directories) bulk envelope: amuled cannot read that path. Only ever appears inside a `results[].error`, never as a whole-response error. |
 | `method_not_allowed` | 405 | Wrong HTTP verb for the route. The response carries an `Allow` header listing the methods this resource does support. |
 | `conflict` | 409 | The request is valid but the daemon cannot serve it as asked: it was built without support for the option being set, or the client named on an A4AF request is not an A4AF source of that download. |
 | `partfile_unsupported` | 409 | Verify Local Data requested on a file that is still an incomplete partfile. |

--- a/src/webapi/Api.cpp
+++ b/src/webapi/Api.cpp
@@ -5245,7 +5245,9 @@ CHttpServer::Response CApiDispatcher::HandleDownloadPatch(
 		}
 	}
 
-	// priority: "very_low"|"low"|"normal"|"high"|"release"|"auto"
+	// priority: "low"|"normal"|"high"|"auto" -- the kPrioDownload domain.
+	// "very_low" and "release" are upload-side only (kPrioShared) and are
+	// refused here with a 400, by design; see kFilePriorities.
 	{
 		const auto it = obj.find("priority");
 		if (it != obj.end()) {
@@ -5670,10 +5672,12 @@ void WriteFriendObject(CJsonWriter &w, const webapi::FriendSnapshot &f)
 	w.ValueString(wxString::FromUTF8(f.ip.c_str()));
 	w.Key("port");
 	w.ValueInt(static_cast<int64_t>(f.port));
-	// The live peer this friend is linked to, joinable against /clients. 0
-	// when the friend is not connected, which is what `online` reports.
-	w.Key("client_ecid");
-	w.ValueInt(static_cast<int64_t>(f.client_ecid));
+	// The live peer this friend is linked to, joinable against /clients. null
+	// when the friend is not connected, which is the common case and which
+	// `online` also reports. Deliberately not the 0 it used to be: the surface
+	// spells "no value" as null and never as 0 or -1, and a client joining
+	// naively on the raw value was building GET /clients/0 and taking a 404.
+	WriteIntOrNull(w, "client_ecid", f.client_ecid != 0, static_cast<int64_t>(f.client_ecid));
 	w.Key("online");
 	w.ValueBool(f.client_ecid != 0);
 	w.Key("friend_slot");
@@ -5929,10 +5933,11 @@ void WriteChatObject(CJsonWriter &w, const webapi::ChatSessionSnapshot &s)
 	w.ValueInt(static_cast<int64_t>(s.port));
 	w.Key("name");
 	w.ValueString(wxString::FromUTF8(s.DisplayName().c_str()));
-	w.Key("client_ecid");
-	w.ValueInt(static_cast<int64_t>(s.client_ecid));
-	w.Key("friend_ecid");
-	w.ValueInt(static_cast<int64_t>(s.friend_ecid));
+	// null rather than 0 for "no live connection" / "not a friend", for the
+	// same reason as the /friends row above: 0 is not how this surface spells
+	// absence, and /clients/0 is a 404 waiting to happen.
+	WriteIntOrNull(w, "client_ecid", s.client_ecid != 0, static_cast<int64_t>(s.client_ecid));
+	WriteIntOrNull(w, "friend_ecid", s.friend_ecid != 0, static_cast<int64_t>(s.friend_ecid));
 	w.Key("online");
 	w.ValueBool(s.client_ecid != 0);
 	w.Key("message_count");
@@ -8692,9 +8697,15 @@ namespace
 {
 
 // Issue a single-shot mutation EC packet (no body), check the
-// response, run RefresherTick inline, return a standard
-// `{ok: true, message?: "..."}` response. Used by every connection-
-// control endpoint where the EC op is parameterless.
+// response, run RefresherTick inline, return `{message?: "..."}` -- the
+// daemon's own account of what it did, and nothing else. (`ok` was dropped
+// when mutation responses collapsed onto the status code; see the body
+// below.) Used by every connection-control endpoint where the EC op is
+// parameterless.
+//
+// Callers pass 202, not 200: the request is handed to the daemon over EC and
+// returns before the effect is observable, which is as true of a disconnect
+// as of a connect.
 CHttpServer::Response SimpleConnControlOp(
 	CamuleapiApp &app, webapi::CState &state, ec_opcode_t op, unsigned http_status)
 {
@@ -8827,14 +8838,14 @@ CHttpServer::Response CApiDispatcher::HandleNetworksDisconnect(const CHttpServer
 	}
 
 	if (network == "ed2k") {
-		return SimpleConnControlOp(m_app, m_state, EC_OP_SERVER_DISCONNECT, 200);
+		return SimpleConnControlOp(m_app, m_state, EC_OP_SERVER_DISCONNECT, 202);
 	}
 	if (network == "kad") {
-		return SimpleConnControlOp(m_app, m_state, EC_OP_KAD_STOP, 200);
+		return SimpleConnControlOp(m_app, m_state, EC_OP_KAD_STOP, 202);
 	}
 	// "both": amuled's EC_OP_DISCONNECT short-circuits to both
 	// SERVER_DISCONNECT and KAD_STOP in one EC roundtrip.
-	return SimpleConnControlOp(m_app, m_state, EC_OP_DISCONNECT, 200);
+	return SimpleConnControlOp(m_app, m_state, EC_OP_DISCONNECT, 202);
 }
 
 // HandleKadConnect / HandleKadDisconnect were removed — strict

--- a/src/webapi/EventDiff.cpp
+++ b/src/webapi/EventDiff.cpp
@@ -175,10 +175,26 @@ std::string ToJsonSharedEvent(const FileSnapshot &f)
 	  << ",\"total\":" << f.shared.requests_total << "}"
 	  << ",\"accepts\":{\"session\":" << f.shared.accepts_session
 	  << ",\"total\":" << f.shared.accepts_total << "}"
-	  << ",\"upload_speed_bps\":" << f.shared.upload_speed_bps
-	  << ",\"uploading\":" << f.shared.uploading_count << ",\"last_upload\":" << f.shared.last_upload
-	  << ",\"shared_since\":" << f.shared.shared_since
-	  << ",\"hashing_progress\":" << SharedHashingProgress(f);
+	  << ",\"upload_speed_bps\":" << f.shared.upload_speed_bps << ",\"uploading\":"
+	  << f.shared.uploading_count
+	  // Unix seconds, null when unknown -- never uploaded, or a known.met entry
+	  // that predates the field. 0 reads as 1970 rather than "no idea", and the
+	  // REST row this event promises key parity with has always sent null here
+	  // (WriteIntOrNull in the shared list writer). A subscriber that hydrates
+	  // from REST and live-updates from this saw its null flip to 0 on the
+	  // first tick the file changed. Never-uploaded is the common case, so this
+	  // was the routine reading, not an edge one.
+	  << ",\"last_upload\":";
+	if (f.shared.last_upload != 0)
+		o << f.shared.last_upload;
+	else
+		o << "null";
+	o << ",\"shared_since\":";
+	if (f.shared.shared_since != 0)
+		o << f.shared.shared_since;
+	else
+		o << "null";
+	o << ",\"hashing_progress\":" << SharedHashingProgress(f);
 	// Media metadata rides the event because a metadata re-extraction is
 	// otherwise invisible to a subscriber: the refresh endpoints answer 202
 	// with no result, so this is how a client learns a probe landed. Six

--- a/unittests/curl-tests/amuleapi/16-networks-connect.sh
+++ b/unittests/curl-tests/amuleapi/16-networks-connect.sh
@@ -101,10 +101,11 @@ if [ "$HAVE_GUEST" = "1" ]; then
 	_assert_status 403 "POST /networks/disconnect (guest) → 403"
 fi
 
-# --- 2. networks/disconnect → 200 + message. -----------------------
+# --- 2. networks/disconnect → 202 + message. -----------------------
 _curl -X POST -H "Authorization: Bearer $ADMIN_TOKEN" \
 	"$HOST/api/v0/networks/disconnect"
-_assert_status 200 "POST /networks/disconnect → 200"
+_assert_status 202 "POST /networks/disconnect → 202"
+_assert_json_eq '.message | type' string 'disconnect response carries .message'
 _assert_json_eq '. | has("ok")' false 'disconnect response has no constant ok field'
 
 # --- 3. networks/connect → 202 + message. --------------------------
@@ -121,7 +122,7 @@ _curl -X POST -H "Authorization: Bearer $ADMIN_TOKEN" \
 	-H "Content-Type: application/json" \
 	-d '{"network":"kad"}' \
 	"$HOST/api/v0/networks/disconnect"
-_assert_status 200 "POST /networks/disconnect {network:kad} → 200"
+_assert_status 202 "POST /networks/disconnect {network:kad} → 202"
 _assert_json_eq '. | has("ok")' false \
 	'networks/disconnect(kad) response has no constant ok field'
 

--- a/unittests/curl-tests/amuleapi/22-sse-diff-emission.sh
+++ b/unittests/curl-tests/amuleapi/22-sse-diff-emission.sh
@@ -576,6 +576,26 @@ if [ -n "$SHARED_JSON" ]; then
 		else
 			_fail "shared event / GET /shared key parity" "$DIFF"
 		fi
+		# Key parity is not value parity, and this pair disagreed on VALUES
+		# while the key sets matched: the SSE writer emitted a raw 0 for a
+		# never-uploaded file where REST sent null, so a subscriber that
+		# hydrated from REST watched null flip to 0 on the first frame and a
+		# renderer drew 1970-01-01. Compare the two timestamps directly.
+		VAL_DIFF=$(jq -n --argjson a "$REST_ITEM" --argjson b "$SHARED_JSON" \
+			'[ {k:"last_upload",  rest:$a.last_upload,  sse:$b.last_upload},
+			   {k:"shared_since", rest:$a.shared_since, sse:$b.shared_since} ]
+			 | map(select(.rest != .sse))')
+		if [ "$(echo "$VAL_DIFF" | jq -c '.')" = "[]" ]; then
+			_pass "shared event timestamps match GET /shared by value, not just by key"
+		else
+			_fail "shared event / GET /shared timestamp values" "$VAL_DIFF"
+		fi
+		# And the specific reading the fix is about: never-uploaded is null.
+		if [ "$(echo "$SHARED_JSON" | jq -r '.last_upload')" = "null" ]; then
+			_pass "a never-uploaded file arrives over SSE with last_upload null, not 0"
+		else
+			_pass "file has uploaded before; null-for-zero case not exercised this run"
+		fi
 	fi
 else
 	_fail "shared event parity" "no shared_added/updated frame for $PARITY_HASH after a priority PATCH"

--- a/unittests/curl-tests/amuleapi/26-rfc-followup-endpoints.sh
+++ b/unittests/curl-tests/amuleapi/26-rfc-followup-endpoints.sh
@@ -276,7 +276,7 @@ for BODY in \
 	fi
 done
 if jq -e '.error.message | test("`links`")' /tmp/p11_dl_alias.json >/dev/null 2>&1; then
-	_pass "the ed2k_link 400 names `links` as the replacement"
+	_pass 'the ed2k_link 400 names `links` as the replacement'
 else
 	_fail "ed2k_link 400 message" "$(cat /tmp/p11_dl_alias.json)"
 fi
@@ -285,30 +285,30 @@ fi
 # Default (no body) = both
 RC=$(curl -s -o /tmp/p11_nd.json -w "%{http_code}" -X POST "${H_AUTH[@]}" \
 	"$HOST/api/v0/networks/disconnect")
-if [ "$RC" = "200" ]; then
-	_pass "POST /networks/disconnect (no body) → 200 default=both"
+if [ "$RC" = "202" ]; then
+	_pass "POST /networks/disconnect (no body) → 202 default=both"
 else
-	_fail "networks disconnect no-body" "expected 200, got $RC"
+	_fail "networks disconnect no-body" "expected 202, got $RC"
 fi
 sleep 2
 # selector=ed2k
 RC=$(curl -s -o /dev/null -w "%{http_code}" -X POST "${H_AUTH[@]}" \
 	-H "Content-Type: application/json" \
 	-d '{"network":"ed2k"}' "$HOST/api/v0/networks/disconnect")
-if [ "$RC" = "200" ]; then
-	_pass "POST /networks/disconnect {\"network\":\"ed2k\"} → 200"
+if [ "$RC" = "202" ]; then
+	_pass "POST /networks/disconnect {\"network\":\"ed2k\"} → 202"
 else
-	_fail "networks disconnect ed2k" "expected 200, got $RC"
+	_fail "networks disconnect ed2k" "expected 202, got $RC"
 fi
 sleep 1
 # selector=kad
 RC=$(curl -s -o /dev/null -w "%{http_code}" -X POST "${H_AUTH[@]}" \
 	-H "Content-Type: application/json" \
 	-d '{"network":"kad"}' "$HOST/api/v0/networks/disconnect")
-if [ "$RC" = "200" ]; then
-	_pass "POST /networks/disconnect {\"network\":\"kad\"} → 200"
+if [ "$RC" = "202" ]; then
+	_pass "POST /networks/disconnect {\"network\":\"kad\"} → 202"
 else
-	_fail "networks disconnect kad" "expected 200, got $RC"
+	_fail "networks disconnect kad" "expected 202, got $RC"
 fi
 # Invalid selector
 RC=$(curl -s -o /dev/null -w "%{http_code}" -X POST "${H_AUTH[@]}" \

--- a/unittests/curl-tests/amuleapi/34-friends.sh
+++ b/unittests/curl-tests/amuleapi/34-friends.sh
@@ -178,6 +178,12 @@ NEW=$(echo "$CURL_BODY" | jq -r --argjson e "$NEW_ECID" \
 [ "$(echo "$NEW" | jq -r .online)" = "false" ] \
 	&& _pass "a friend with no linked peer is offline" \
 	|| _fail "online" "expected false, got $(echo "$NEW" | jq -r .online)"
+# ...and reports that as null, not as the 0 sentinel it used to send. 0 is not
+# how this surface spells "no value" anywhere else, and a client joining
+# naively on the raw number was building GET /clients/0 and taking a 404.
+[ "$(echo "$NEW" | jq -r '.client_ecid')" = "null" ] \
+	&& _pass "an offline friend reports client_ecid null, not a 0 sentinel" \
+	|| _fail "client_ecid" "expected null, got $(echo "$NEW" | jq -r .client_ecid)"
 if [ "$AFTER" -gt "$BEFORE" ] 2>/dev/null; then
 	_pass "the list grew ($BEFORE -> $AFTER)"
 else

--- a/unittests/curl-tests/amuleapi/38-chat.sh
+++ b/unittests/curl-tests/amuleapi/38-chat.sh
@@ -154,7 +154,8 @@ printf '%s' "$ROW" > "$CURL_BODY_FILE"; CURL_BODY=$ROW
 _assert_json_eq '.ip'                 "$PEER_IP"   'row carries the split ip'
 _assert_json_eq '.port'               "$PEER_PORT" 'row carries the split port'
 _assert_json_eq '.online'             false        'unrouted peer is offline'
-_assert_json_eq '.client_ecid'        0            'offline peer has client_ecid 0'
+_assert_json_eq '.client_ecid'        null         'offline peer has client_ecid null, not a 0 sentinel'
+_assert_json_eq '.friend_ecid'        null         'a non-friend peer has friend_ecid null, not a 0 sentinel'
 _assert_json_eq '.last_message.text'  "curl-test hello" 'row carries last_message'
 # The core has no nickname for a peer that never answered, so the row must
 # fall back to the desktop's own rendering rather than an empty string.


### PR DESCRIPTION
Closes #1188, and addresses every part of #1187 except its §2: three wire-visible inconsistencies, two stale code comments, and the documentation drift behind them. #1187 stays open for §2 alone, which gets its own PR (see the end). One PR rather than the two-way split I sketched on #1187 -- the doc sweep turned out to be inseparable from the wire changes, since several of the sites it corrects are the ones those changes create.

`/api/v0` has no consumers outside this repository, so where a writer and the documented rule disagreed, the writer moved.

## Wire-visible

**SSE emitted `last_upload` / `shared_since` as a raw `0` where REST sent `null`.** The shared event promises byte-for-byte parity with the REST list item, and both documents state the `null`. A subscriber that hydrated from REST watched its `null` flip to `0` on the first tick the file changed, and a renderer treating the number as a timestamp drew 1970-01-01. Never-uploaded is the common case, so this was the routine reading rather than an edge one.

The existing parity test compared **key paths**, which matched while the values disagreed -- which is why it never caught this. It now also compares the two timestamps by value, plus asserts the specific never-uploaded reading.

**`client_ecid` was `null` on `/search` and a `0` sentinel on `/friends` and `/chats`**, where `friend_ecid` did the same. The documented rule is that `null` means "no value" and that the surface never spells it `0` or `-1`. Both writers now go through `WriteIntOrNull`. The naive `GET /clients/${friend.client_ecid}` this invited was a `404`.

**`POST /networks/disconnect` answered `200`** where every other `SimpleConnControlOp` route answers `202`. Nothing observable justified it: both hand the request to the daemon over EC and return before the effect is visible. Correction to the issue -- this is **three** call sites, not one: `EC_OP_SERVER_DISCONNECT`, `EC_OP_KAD_STOP` and `EC_OP_DISCONNECT`.

## Code comments

`SimpleConnControlOp` still documented the `ok` field that was dropped when mutation responses collapsed onto the status code -- contradicted by the body twelve lines down, which explains the removal. And the download `PATCH` comment listed `very_low` and `release`, which are `kPrioShared`-only and rejected with a `400` on a download. The shared `PATCH` block that legitimately lists both is unchanged.

## Reference sweep

Roughly twenty-five sites, verified individually against the writers rather than applied from the issue -- it was written before #1191 landed and several line references had moved.

- **Keys the omitted-vs-null pass made always-present** that per-endpoint prose still called omitted: `media` in three places, `last_message`, `label_value`, `token`. Plus `media`, which `ToJsonSharedEvent` always emits, missing entirely from the `shared_added` / `shared_updated` payload in EVENTS.md.
- **Enum lists that never matched the writers.** `progress.parts[].state` documented four tokens of which only one exists (the writer emits `complete` / `incomplete` / `missing`), and download `status` listed eight of eleven, omitting `erroneous`, `insufficient_disk` and `unknown` -- so a client switching on it mishandled a partfile that errors or fills the disk. A stray "five-state part view" cross-reference went with them.
- **A documented `search_finished` SSE event that is never emitted**, and that EVENTS.md already denies in as many words. A client waiting for it waits forever.
- **Seven wrong or missing error codes**, including `502 bad_gateway` for a browse that actually answers `502 amuled_rejected`, and `DELETE /categories/0`, which is refused locally as `400 bad_request` before any EC roundtrip rather than by amuled.
- **Worked examples the writers contradict**, including the categories example still showing the pre-#1166 `All` / `normal`, the `/share_directories` flat `{code, message}` failures that are really the bulk `{results:[{id, ok, error}]}` envelope, and `servers_url` documented as optional when it is required.

Two claims needed correcting rather than applying:

- The issue reads the chat-send reply as carrying only `id` / `direction` / `text`. It does return `202` with that body -- what it actually omits is the **timestamp**, which the prose promised was readable there. I had this wrong mid-review too, and briefly documented the endpoint as `204`; the `204` belongs to `HandleChatClose`. The existing `38-chat.sh` assertion of `202` is what flagged it.
- `ratio` joins the deliberately-omitted list, which meant changing its count from "Four keys" to "Five", not just appending.

## Tests

Two assertions had to change because the behaviour did: the chats row's `client_ecid` `0` becomes `null`, and `16-networks-connect.sh` expects `202`. Four are new: the SSE timestamp value-parity pair, the never-uploaded `null`, the offline friend's `null` `client_ecid`, and the non-friend's `null` `friend_ecid`.

The status-code change also had three stale assertions in a phase that does not own the endpoint (`26-rfc-followup-endpoints.sh`), which is the argument for running the whole suite rather than the files touched. While there, a latent bug in that file unrelated to this change: an assertion name used backticks inside double quotes, so the shell ran `links` as a command and printed the name empty.

## Verification

Against a live amuled on macOS:

- Full curl-smoke suite, all 40 phases. Every phase passed except `26-rfc-followup-endpoints.sh`, whose 3 failures were stale expectations of the `200` this PR changes to `202`. Those were updated and that phase re-ran **41/41**; no source changed between the two runs, so the rest of the suite's result stands as measured.
- Unit tests: **43/43**.
- `clang-format` on the diff: clean.
- `clang-tidy` Tier-1 and Tier-2 on the diff: 0 findings, 0 compiler errors.
- `scripts/check-potfiles.sh`: clean, no new translatable strings.
- Every JSON block in `REFERENCE.md` re-parsed after editing; the one that does not parse is the intentional `"a" | "b"` schema notation.

#1187 §2 (`search_result_added` is add-only) is deliberately **not** here. #1191 unblocked it -- the union now polls finished searches every tick, so the comparator I described on the issue can actually fire -- but it adds an event type and carries a design choice of its own, so it gets its own PR.
