### PR TITLE
feat(amuleapi): push search-result changes over SSE with search_result_updated

### DIFF
--- a/docs/api/EVENTS.md
+++ b/docs/api/EVENTS.md
@@ -39,7 +39,7 @@ const EVENT_TYPES = [
   "server_added",   "server_updated",   "server_removed",
   "friend_added",   "friend_updated",   "friend_removed",
   "status_changed", "log_appended",
-  "search_result_added", "search_progress", "search_closed",
+  "search_result_added", "search_result_updated", "search_progress", "search_closed",
   "comments_updated",
 ];
 const es = new EventSource("/api/v0/events", { withCredentials: true });
@@ -573,11 +573,13 @@ Only the amuled log has a live channel; the serverinfo buffer has no SSE feed an
 
 Driven by the refresher state machine that owns the `POST /search` → completion lifecycle (see [REFERENCE.md](REFERENCE.md#search)). Result and progress events only fire while a search is active; the channel is otherwise silent apart from `search_closed`. The [Bootstrap example](#bootstrap-snapshot--stream) omits the search endpoints because searches are normally client-initiated post-boot; if your UI persists a "search-in-progress" state across reloads, list them with `GET /search` and fetch `GET /search/{id}/results` in step 2 too.
 
-#### `search_result_added`
+#### `search_result_added` / `search_result_updated`
 
-Emitted per new result that appears in the results map between refresher ticks.
+`_added` fires per new result that appears in the results map between refresher ticks. `_updated` fires when a result you already hold changes in one of the fields below. Both carry the identical payload, so a subscriber can handle them with one function keyed by `(search_id, hash)`; they are separate names so that a consumer written against the add-only channel keeps its existing behaviour instead of silently acquiring upsert semantics.
 
-**Add-only.** There is no `search_result_updated`, so a result's mutable fields (`sources`, `status`, `already_have`, `children[]`, `comments[]`) do not push after the row first arrives. While a search runs, [`search_progress`](#search_progress) fires on every advance and is the cue to re-read [`GET /search/{id}/results`](REFERENCE.md#get-apiv0searchidresults); once it finishes, that endpoint refreshes on read. The daemon is polled for every search it holds, finished ones included, so a re-read is current -- but the stream will not tell you when to make one.
+**What `_updated` covers, and what it deliberately does not.** It fires on `status`, `already_have`, `comments[]`, `kad_comment_search_running` and `rating` (which aggregates from the comments). Those are the fields that can change *after* a search finishes, which is the window where nothing else tells you: `search_progress` has stopped, so a hit you download from a finished search would otherwise read `already_have: false` forever, and a Kad notes lookup that lands afterwards would be invisible until someone re-read the endpoint.
+
+It does **not** fire on `sources` or `children[]`. Those churn on essentially every tick of a running search, and [`search_progress`](#search_progress) already fires on every advance there and is the cue to re-read [`GET /search/{id}/results`](REFERENCE.md#get-apiv0searchidresults). Pushing them per result would duplicate an existing signal on the noisiest fields on the surface. The identity fields (`hash`, `name`, `size`, `type`, `directory`, `media`) never change for a given result, so there is nothing to push.
 
 ```json
 {
@@ -595,7 +597,7 @@ Emitted per new result that appears in the results map between refresher ticks.
 }
 ```
 
-`search_id` routes the result to the search that produced it — amuleapi runs several searches at once (see [REFERENCE.md](REFERENCE.md#post-apiv0search)), so demux on it. Key results by `(search_id, hash)`. Aside from the leading `search_id`, the payload is byte-for-byte identical to a `/search/{id}/results` array entry — the two are emitted by the same writer, so the promise holds by construction. That includes `status`, `type`, `directory` (the folder inside a browsed peer's share, `""` on ordinary hits), `kad_comment_search_running`, `comments[]` and the `children[]` grouping array — see [REFERENCE.md](REFERENCE.md#get-apiv0searchidresults); `sources` is the nested `{total, complete}` object, `media` — the audio/video metadata object — is present for locally-known/probed hits and `null` otherwise (the one place the unknown-value rule reaches an object rather than a scalar, so test `media === null` before reaching into it), and `children` holds the same-hash/different-name alternatives (empty for a single-name hit), same as the REST endpoint. Only parent results fire this event — children are folded into their parent's `children[]`, never emitted as their own `search_result_added`. Each `search_id` is an independent result space — a new `POST /search` starts a fresh one without disturbing the others.
+`search_id` routes the result to the search that produced it — amuleapi runs several searches at once (see [REFERENCE.md](REFERENCE.md#post-apiv0search)), so demux on it. Key results by `(search_id, hash)`. Aside from the leading `search_id`, the payload is byte-for-byte identical to a `/search/{id}/results` array entry — the two are emitted by the same writer, so the promise holds by construction. That includes `status`, `type`, `directory` (the folder inside a browsed peer's share, `""` on ordinary hits), `kad_comment_search_running`, `comments[]` and the `children[]` grouping array — see [REFERENCE.md](REFERENCE.md#get-apiv0searchidresults); `sources` is the nested `{total, complete}` object, `media` — the audio/video metadata object — is present for locally-known/probed hits and `null` otherwise (the one place the unknown-value rule reaches an object rather than a scalar, so test `media === null` before reaching into it), and `children` holds the same-hash/different-name alternatives (empty for a single-name hit), same as the REST endpoint. Only parent results fire these events — children are folded into their parent's `children[]`, never emitted on their own. A change to a child therefore surfaces as a `search_result_updated` for its parent. Each `search_id` is an independent result space — a new `POST /search` starts a fresh one without disturbing the others.
 
 #### `search_progress`
 
@@ -613,7 +615,7 @@ Emitted whenever a search's completion advances and once more on its completion;
 - `state` — `"running"` while the search is in flight, `"finished"` on the terminal frame.
 - `percent` — `0..100`, daemon-computed for every search kind. For **global** it is the real server-queue progress. For **Kad**, which has no measurable progress, it is a cosmetic time-ramp derived from the fixed 45 s keyword-search lifetime (capped at 99 until the daemon authoritatively reports completion, then 100); see [REFERENCE.md](REFERENCE.md#get-apiv0searchidresults). Treat the Kad value as a liveliness indicator, not an accurate completion estimate.
 - `kind` — the originally-requested search type (`"local"` | `"global"` | `"kad"` | `"browse"`).
-- `results` — the current results-map size; subscribers can reconcile against any `search_result_added` they may have missed via `GET /search/{id}/results`.
+- `results` — the current results-map size; subscribers can reconcile against any `search_result_added` / `search_result_updated` they may have missed via `GET /search/{id}/results`.
 
 A Kad search hitting its result cap (`SEARCHKEYWORD_TOTAL`, 300) before the 45 s deadline finishes early — the lifecycle flips to `finished` and `percent` jumps straight to 100 ahead of the ramp.
 

--- a/src/webapi/EventDiff.cpp
+++ b/src/webapi/EventDiff.cpp
@@ -913,8 +913,35 @@ void EmitDiffsAndUpdate(CEventBus &bus, LastSeenState &prev, const CState &state
 	prev.kad = new_kad;
 	prev.ec_connected = new_ec;
 
+	// The stable-but-mutable field set for `search_result_updated`. A hit's
+	// identity fields (hash, name, size, type, directory, media, children)
+	// never change for a given ECID, and its source counts churn every tick
+	// while the search runs -- where `search_progress` is already the re-read
+	// cue. What is left is the set that can change AFTER a search finishes,
+	// when no other signal exists: download state (`status` /
+	// `already_have`), and the Kad-notes cluster (`comments[]`, the
+	// in-flight flag, and `rating`, which aggregates from the comments).
+	// Comparing only these keeps the search channel quiet on a running
+	// search instead of firing per-result frames on source-count churn.
+	const auto result_mutated = [](const SearchResult &a, const SearchResult &b) {
+		if (a.status != b.status || a.already_have != b.already_have || a.rating != b.rating ||
+			a.kad_comment_searching != b.kad_comment_searching ||
+			a.comments.size() != b.comments.size())
+			return true;
+		for (std::size_t i = 0; i < a.comments.size(); ++i) {
+			const auto &ca = a.comments[i];
+			const auto &cb = b.comments[i];
+			if (ca.username != cb.username || ca.filename != cb.filename ||
+				ca.rating != cb.rating || ca.comment != cb.comment)
+				return true;
+		}
+		return false;
+	};
+
 	// Search events. `search_result_added` per new ECID in the results
-	// map; `search_progress` on any percent change while running and on
+	// map; `search_result_updated` when one of a held result's
+	// stable-but-mutable fields changes (see result_mutated above);
+	// `search_progress` on any percent change while running and on
 	// the running→finished edge. The finished frame (state="finished",
 	// percent=100) is just the terminal search_progress — there is no
 	// separate search_finished event. The refresher's state machine
@@ -946,23 +973,38 @@ void EmitDiffsAndUpdate(CEventBus &bus, LastSeenState &prev, const CState &state
 			}
 
 			auto &pstate = prev.searches[sid];
-			// New result entries for this search.
+			// New and mutated result entries for this search.
 			for (const auto &kv : search_now) {
-				if (pstate.results.find(kv.first) == pstate.results.end()) {
-					// `search_id` routes the event to a tab/view; every
-					// field after it comes from the same writer
-					// GET /search/{id}/results uses, which is what makes
-					// the documented "byte-for-byte identical to a
-					// results-list entry" promise hold by construction
-					// rather than by review.
-					CJsonWriter w;
-					w.BeginObject();
-					w.Key("search_id");
-					w.ValueInt(static_cast<int64_t>(sid));
-					WriteSearchResultFields(w, kv.second);
-					w.EndObject();
-					bus.Publish("search_result_added", w.TakeBuffer());
-				}
+				const auto pit = pstate.results.find(kv.first);
+				const bool is_new = pit == pstate.results.end();
+				if (!is_new && !result_mutated(pit->second, kv.second))
+					continue;
+				// `search_id` routes the event to a tab/view; every
+				// field after it comes from the same writer
+				// GET /search/{id}/results uses, which is what makes
+				// the documented "byte-for-byte identical to a
+				// results-list entry" promise hold by construction
+				// rather than by review.
+				//
+				// `search_result_updated` carries the identical payload
+				// under its own name, rather than re-firing _added with
+				// upsert semantics: a consumer that only handles _added
+				// keeps exactly the behaviour it had, and one that wants
+				// live rows opts in by handling the new event. It is the
+				// close of the one window where a client could not know:
+				// a finished search stops emitting search_progress, yet a
+				// hit downloaded from it flips status / already_have, and
+				// a Kad notes lookup lands comments / rating after the
+				// fact. (Those fields are polled at all because the union
+				// keeps finished searches in the per-tick poll set.)
+				CJsonWriter w;
+				w.BeginObject();
+				w.Key("search_id");
+				w.ValueInt(static_cast<int64_t>(sid));
+				WriteSearchResultFields(w, kv.second);
+				w.EndObject();
+				bus.Publish(is_new ? "search_result_added" : "search_result_updated",
+					w.TakeBuffer());
 			}
 			// search_progress: a percent change while running, the
 			// running→finished edge (complete false→true), or a

--- a/src/webapi/static/js/events.js
+++ b/src/webapi/static/js/events.js
@@ -176,9 +176,18 @@ function openSse() {
   // by hash, nested sources {total, complete}); search_progress carries
   // {state, percent, results, kind} and its terminal frame (state:
   // "finished") is the completion signal. Inert unless a search is active.
-  es.addEventListener("search_result_added", (ev) => {
+  //
+  // search_result_updated carries the identical payload for a row that
+  // changed after it arrived -- a hit you started downloading, or a Kad note
+  // that landed. Both land on the same store key because the view keys by
+  // hash and overwrites, which is exactly the upsert the two events describe
+  // between them; they stay distinct on the wire so a consumer that only
+  // wants additions is not silently given updates too.
+  const onSearchResult = (ev) => {
     try { store.set("search:result", JSON.parse(ev.data)); } catch (_) {}
-  });
+  };
+  es.addEventListener("search_result_added", onSearchResult);
+  es.addEventListener("search_result_updated", onSearchResult);
   es.addEventListener("search_progress", (ev) => {
     try { store.set("search:progress", JSON.parse(ev.data)); } catch (_) {}
   });

--- a/unittests/curl-tests/amuleapi/22-sse-diff-emission.sh
+++ b/unittests/curl-tests/amuleapi/22-sse-diff-emission.sh
@@ -609,6 +609,102 @@ curl -s -o /dev/null -X PATCH -H "Authorization: Bearer $ADMIN_TOKEN" \
 	"$HOST/api/v0/shared/$PARITY_HASH"
 fi
 
+# --- search_result_updated fires on a held result's mutable fields. -----
+# The window this closes: once a search finishes, search_progress stops, so a
+# subscriber holding its rows has no signal for the fields that can still
+# change. Driven here by starting a download of one hit, which flips
+# already_have / status on the matching search result.
+#
+# Last section in the file: it starts a search on the shared daemon.
+#
+# This file predates the _curl wrapper the other phases use, so it drives
+# curl directly, same as every section above.
+SSE_SEARCH_SID=$(curl -s -X POST -H "Authorization: Bearer $ADMIN_TOKEN" \
+	-H "Content-Type: application/json" \
+	-d '{"query":"ubuntu"}' "$HOST/api/v0/search" | jq -r '.search_id // empty')
+UPD_HASH=""
+UPD_NAME=""
+UPD_SIZE=""
+UPD_ROW=""
+if [ -n "$SSE_SEARCH_SID" ]; then
+	for _ in $(seq 1 30); do
+		sleep 1
+		UPD_ROW=$(curl -s -H "Authorization: Bearer $ADMIN_TOKEN" \
+			"$HOST/api/v0/search/$SSE_SEARCH_SID/results" \
+			| jq -c '[.results[] | select(.already_have == false)] | first // empty')
+		UPD_HASH=$(printf '%s' "$UPD_ROW" | jq -r '.hash // empty')
+		UPD_NAME=$(printf '%s' "$UPD_ROW" | jq -r '.name // empty' | sed 's/|/_/g')
+		UPD_SIZE=$(printf '%s' "$UPD_ROW" | jq -r '.size // empty')
+		[ -n "$UPD_HASH" ] && break
+	done
+fi
+if [ -n "$UPD_HASH" ]; then
+	# Subscribe to the search channel only, which also pins that the new event
+	# routes there rather than needing its own channel name.
+	: > "$SSE_OUT"
+	(curl -s -m 20 -N -H "Authorization: Bearer $ADMIN_TOKEN" \
+		"$HOST/api/v0/events?channels=search" >> "$SSE_OUT" 2>&1) &
+	UPD_PID=$!
+	# Wait for the stream to actually be up before provoking the change, or
+	# the frame lands before the subscription and the section flakes.
+	for _ in $(seq 1 60); do
+		[ -s "$SSE_OUT" ] && break
+		sleep 0.25
+	done
+	# Provoke the change by starting a download of the hit. That flips
+	# already_have / status on the search result deterministically and
+	# locally -- the partfile is created on the spot, no peer needed. A Kad
+	# NOTES lookup moves the other half of the comparator but depends on Kad
+	# actually answering, which would make a missing frame ambiguous between
+	# "the event is broken" and "Kad was quiet". This way a missing frame can
+	# only mean the former, so the check below is a real gate.
+	curl -s -o /dev/null -X POST -H "Authorization: Bearer $ADMIN_TOKEN" \
+		-H "Content-Type: application/json" \
+		-d "{\"links\":[\"ed2k://|file|$UPD_NAME|$UPD_SIZE|$UPD_HASH|/\"]}" \
+		"$HOST/api/v0/downloads"
+	UPD_FRAME=""
+	for _ in $(seq 1 60); do
+		UPD_FRAME=$(grep -A2 "^event: search_result_updated$" "$SSE_OUT" 2>/dev/null \
+			| grep "^data: " | sed 's/^data: //' \
+			| jq -c --arg h "$UPD_HASH" 'select(.hash == $h)' 2>/dev/null | head -1)
+		[ -n "$UPD_FRAME" ] && break
+		sleep 0.25
+	done
+	kill $UPD_PID 2>/dev/null
+	wait $UPD_PID 2>/dev/null
+	if [ -n "$UPD_FRAME" ]; then
+		_pass "search_result_updated fires for a held result whose download state changed"
+		if echo "$UPD_FRAME" | jq -e --argjson s "$SSE_SEARCH_SID" '.search_id == $s' >/dev/null 2>&1; then
+			_pass "search_result_updated carries its own search_id"
+		else
+			_fail "search_result_updated .search_id" "expected $SSE_SEARCH_SID in $UPD_FRAME"
+		fi
+		# Same writer as _added and as the REST entry, so the whole row is
+		# there rather than a delta a client would have to merge blindly.
+		if echo "$UPD_FRAME" | jq -e 'has("name") and has("size") and has("status") and has("kad_comment_search_running")' >/dev/null 2>&1; then
+			_pass "search_result_updated carries the full results-entry shape"
+		else
+			_fail "search_result_updated shape" "$UPD_FRAME"
+		fi
+		# The point of the event: the row now reads as held.
+		if echo "$UPD_FRAME" | jq -e '.already_have == true' >/dev/null 2>&1; then
+			_pass "search_result_updated reports the hit as already_have after the download starts"
+		else
+			_fail "search_result_updated .already_have" "expected true in $UPD_FRAME"
+		fi
+	else
+		_fail "search_result_updated" \
+			"no frame for $UPD_HASH within 15 s of starting a download of it"
+	fi
+	# Leave the daemon as we found it: drop the partfile we planted.
+	curl -s -o /dev/null -X DELETE -H "Authorization: Bearer $ADMIN_TOKEN" \
+		"$HOST/api/v0/downloads/$UPD_HASH" 2>/dev/null
+	curl -s -o /dev/null -X DELETE -H "Authorization: Bearer $ADMIN_TOKEN" \
+		"$HOST/api/v0/search/$SSE_SEARCH_SID" 2>/dev/null
+else
+	echo "    info: no search results available; search_result_updated check skipped"
+fi
+
 # --- Summary. -----------------------------------------------------
 echo
 if [ "$FAIL_COUNT" -eq 0 ]; then

--- a/unittests/tests/EventDiffTest.cpp
+++ b/unittests/tests/EventDiffTest.cpp
@@ -604,6 +604,136 @@ TEST(EventDiff, ServerFlagsJsonShape)
 	ASSERT_TRUE(webapi::ServerUdpFlagsJson(0x8000u).find("\"bitmask\":32768") != std::string::npos);
 }
 
+// --- search_result_updated: the fields that change after the search ends ---
+//
+// The window this closes: a finished search stops emitting search_progress,
+// so a hit downloaded from it, or a Kad notes lookup that lands afterwards,
+// used to be invisible until someone re-read the endpoint.
+namespace
+{
+// Seed one result and baseline it, so each case below starts from "the
+// subscriber already holds this row".
+void SeedOneResult(CState &state, CEventBus &bus, LastSeenState &prev)
+{
+	state.MarkSearchStarted(42, "global", "ubuntu");
+	EmitDiffsAndUpdate(bus, prev, state); // cold-start baseline
+	state.MutateSearch(42, [](std::map<std::uint32_t, SearchResult> &cache) {
+		SearchResult r;
+		r.ecid = 7;
+		r.hash = "8b54a3c28b54a3c28b54a3c28b54a3c2";
+		r.name = "ubuntu.iso";
+		r.size = 4096;
+		r.status = "new";
+		cache.emplace(r.ecid, r);
+	});
+	EmitDiffsAndUpdate(bus, prev, state); // the _added
+}
+
+std::size_t CountEvent(CEventBus &bus, const char *name)
+{
+	std::size_t n = 0;
+	for (const auto &e : DrainAll(bus))
+		if (e.name == name)
+			++n;
+	return n;
+}
+} // namespace
+
+TEST(EventDiff, SearchResultUpdatedFiresWhenADownloadStateChanges)
+{
+	CState state;
+	CEventBus bus;
+	LastSeenState prev;
+	SeedOneResult(state, bus, prev);
+	ASSERT_EQUALS(static_cast<size_t>(1), CountEvent(bus, "search_result_added"));
+	ASSERT_EQUALS(static_cast<size_t>(0), CountEvent(bus, "search_result_updated"));
+
+	// You start downloading the hit. On a finished search nothing else would
+	// ever tell a subscriber this.
+	state.MutateSearch(42, [](std::map<std::uint32_t, SearchResult> &cache) {
+		cache[7].status = "downloaded";
+		cache[7].already_have = true;
+	});
+	EmitDiffsAndUpdate(bus, prev, state);
+
+	ASSERT_EQUALS(static_cast<size_t>(1), CountEvent(bus, "search_result_updated"));
+	// Still exactly one _added: the row was not re-announced as new.
+	ASSERT_EQUALS(static_cast<size_t>(1), CountEvent(bus, "search_result_added"));
+
+	std::string payload;
+	for (const auto &e : DrainAll(bus))
+		if (e.name == "search_result_updated")
+			payload = e.data;
+	// Same shape as _added, search_id first, carrying the new values.
+	ASSERT_TRUE(payload.compare(0, 15, "{\"search_id\":42") == 0);
+	ASSERT_TRUE(payload.find("\"status\":\"downloaded\"") != std::string::npos);
+	ASSERT_TRUE(payload.find("\"already_have\":true") != std::string::npos);
+}
+
+TEST(EventDiff, SearchResultUpdatedFiresWhenKadNotesLand)
+{
+	CState state;
+	CEventBus bus;
+	LastSeenState prev;
+	SeedOneResult(state, bus, prev);
+
+	// The lookup starts...
+	state.MutateSearch(42,
+		[](std::map<std::uint32_t, SearchResult> &cache) { cache[7].kad_comment_searching = true; });
+	EmitDiffsAndUpdate(bus, prev, state);
+	ASSERT_EQUALS(static_cast<size_t>(1), CountEvent(bus, "search_result_updated"));
+
+	// ...and lands, bringing a note and the rating it aggregates into.
+	state.MutateSearch(42, [](std::map<std::uint32_t, SearchResult> &cache) {
+		cache[7].kad_comment_searching = false;
+		cache[7].rating = 4;
+		SearchResult::Comment c;
+		c.username = "alice";
+		c.filename = "ubuntu.iso";
+		c.rating = 4;
+		c.comment = "good";
+		cache[7].comments.push_back(c);
+	});
+	EmitDiffsAndUpdate(bus, prev, state);
+	ASSERT_EQUALS(static_cast<size_t>(2), CountEvent(bus, "search_result_updated"));
+}
+
+// The reason this is a restricted comparator rather than a full struct
+// compare: source counts move on essentially every tick of a running search,
+// and search_progress is already the re-read cue for them. Pushing them per
+// result would make this the loudest channel on the bus.
+TEST(EventDiff, SearchResultUpdatedIgnoresSourceCountChurn)
+{
+	CState state;
+	CEventBus bus;
+	LastSeenState prev;
+	SeedOneResult(state, bus, prev);
+
+	state.MutateSearch(42, [](std::map<std::uint32_t, SearchResult> &cache) {
+		cache[7].source_count = 99;
+		cache[7].complete_source_count = 42;
+	});
+	EmitDiffsAndUpdate(bus, prev, state);
+
+	ASSERT_EQUALS(static_cast<size_t>(0), CountEvent(bus, "search_result_updated"));
+}
+
+// A quiet tick must not emit: the comparator has to be a real comparison, not
+// "we saw this row again".
+TEST(EventDiff, SearchResultUpdatedStaysSilentOnAnUnchangedResult)
+{
+	CState state;
+	CEventBus bus;
+	LastSeenState prev;
+	SeedOneResult(state, bus, prev);
+
+	EmitDiffsAndUpdate(bus, prev, state);
+	EmitDiffsAndUpdate(bus, prev, state);
+
+	ASSERT_EQUALS(static_cast<size_t>(0), CountEvent(bus, "search_result_updated"));
+	ASSERT_EQUALS(static_cast<size_t>(1), CountEvent(bus, "search_result_added"));
+}
+
 // --- search_result_added is the results-list entry, verbatim ---------
 //
 // EVENTS.md promises the payload is byte-for-byte a


### PR DESCRIPTION
Closes #1187, whose §2 is the last part still open: the search channel was add-only, so once a result arrived nothing pushed for it again.

## The gap, and why it is narrower than "results do not update"

While a search **runs**, this is already covered. `sources`, `children[]` and `rating` churn every tick, and `search_progress` fires on every advance -- EVENTS.md already names it the cue to re-read. Pushing per-result frames there would duplicate an existing signal on the noisiest fields on the surface.

The gap is what happens **after it finishes**. `search_progress` stops, and two things still change:

- `status` / `already_have`, when you download a hit from that search. The stream said `already_have: false` forever.
- `comments[]` / `kad_comment_search_running` / `rating`, when a Kad notes lookup lands afterwards.

So the fix is a comparator restricted to exactly those fields, not a general "result changed" event.

**This could not be built before #1191.** My own follow-up on the issue had to retract the first version of this proposal: `ActiveSearchIds()` filtered finished searches out of the poll set, so their state never moved and a comparator over it could never have fired. The union now polls every search the daemon holds, finished ones included, which is what turns this into a diff rather than a new fetch path.

## Shape

`search_result_updated` carries the **identical payload** to `search_result_added`, through the same `WriteSearchResultFields` writer, so the documented byte-for-byte parity with a `/search/{id}/results` entry holds for both. A subscriber can handle them with one function keyed by `(search_id, hash)`.

Separate event names rather than re-firing `_added` with upsert semantics: a consumer written against the add-only channel keeps exactly the behaviour it has, instead of silently starting to receive rows it already holds. Channel routing needed no change -- the prefix before the first underscore already maps `search_*` to the `search` channel, which the curl case pins by subscribing with `?channels=search`.

The bundled web UI now listens for both names on one handler, since its search view keys by hash and overwrites -- which is the upsert the two events describe between them.

## Tests

Four unit cases: the download-state change fires it, a Kad notes lookup fires it, source-count churn does **not** (the restriction is the design, so it is pinned), and a quiet tick stays silent (the comparator has to be a real comparison, not "we saw this row again").

The curl case drives the change by **starting a download** of one hit rather than by a Kad notes lookup. Both move the comparator, but Kad may simply be quiet, which would leave a missing frame ambiguous between a broken event and a quiet network; a download flips `already_have` locally and immediately, so a missing frame can only mean the event is broken.

That matters because the first version of this check was a vacuous gate: it treated a missing frame as an informational skip, which on master -- where the event does not exist -- is a pass. Confirmed to be a real gate now: the same script against a master-built `amuleapi` fails and exits 1.

## Verification

Against a live amuled on macOS:

- Full curl-smoke suite: **40/40 phases**, 0 failures.
- Unit tests: **43/43**.
- Before/after control run for the new curl case (fails on master, passes here).
- `clang-format` 18: clean, and the whole of `src/` + `unittests/` re-checked (634 files, 0 violations) since CI's gate is whole-file.
- `clang-tidy` Tier-1 and Tier-2 on the diff: 0 findings, 0 compiler errors.
- `scripts/check-potfiles.sh`: clean, no new translatable strings.
