### PR TITLE
webapi: recover the search union after a lost reply, and order its two issuers

### DIFF
--- a/src/webapi/Refresher.cpp
+++ b/src/webapi/Refresher.cpp
@@ -2660,15 +2660,23 @@ void ApplySearchUnion(const CECPacket *resp,
 		const std::uint32_t ecid = sf->ID();
 
 		// Present on a result's first appearance, diffed away afterwards.
+		//
+		// The index is written only once this tag is known to be applicable,
+		// below: a slot that turns out to be missing or detached takes an
+		// early exit, and an entry written ahead of those would outlive the
+		// slot it points at -- eviction drops index entries by walking the
+		// slot's own results, so one that never made it there is never
+		// cleaned up.
 		std::uint32_t sid = 0;
+		bool sid_is_new = false;
 		if (const CECTag *x = sf->GetTagByName(EC_TAG_SEARCH_ID)) {
 			sid = static_cast<std::uint32_t>(x->GetInt());
-			owner[ecid] = sid;
+			sid_is_new = true;
 		} else if (default_sid != 0) {
 			// A per-search reply: every tag in it belongs to the search the
 			// caller asked for, and that form carries no id of its own.
 			sid = default_sid;
-			owner[ecid] = sid;
+			sid_is_new = true;
 		} else {
 			const auto oit = owner.find(ecid);
 			if (oit == owner.end()) {
@@ -2705,6 +2713,8 @@ void ApplySearchUnion(const CECPacket *resp,
 			// arriving for it is the tail of an eviction, not an update.
 			continue;
 		}
+		if (sid_is_new)
+			owner[ecid] = sid;
 		auto &slot_results = sit->second.raw;
 		const auto existing = slot_results.find(ecid);
 		if (existing == slot_results.end()) {

--- a/src/webapi/Refresher.h
+++ b/src/webapi/Refresher.h
@@ -77,7 +77,8 @@ SearchFetchOutcome FetchSearchResults(CamuleapiApp &app, CState &state);
 // this is how a newly discovered slot is filled and how a request handler
 // refreshes without becoming a second issuer of the stateful stream. See the
 // definition.
-SearchFetchOutcome FetchOneSearchFull(CamuleapiApp &app, CState &state, std::uint32_t search_id);
+SearchFetchOutcome FetchOneSearchFull(
+	CamuleapiApp &app, CState &state, std::uint32_t search_id, bool replace = false);
 
 // Single-threaded SSE diff emission. Called ONLY from the wxApp
 // refresher loop after a successful RefresherTick so that the

--- a/src/webapi/RefresherTick.cpp
+++ b/src/webapi/RefresherTick.cpp
@@ -40,7 +40,9 @@
 #include <cstdint>
 #include <map>
 #include <memory>
+#include <mutex>
 #include <set>
+#include <vector>
 
 namespace webapi
 {
@@ -60,8 +62,20 @@ namespace webapi
 // so it has always required a matching daemon for search. EC_TAG_CAN_PARTIAL_SEARCH
 // is advertised for every client of CRemoteConnect, so the daemon is already
 // eliding for this connection.
+// Serialises the two issuers of the search stream across the roundtrip AND the
+// apply. SendRecvSerialized only orders the roundtrips: both callers then take
+// the State lock separately, so a union reply and a FULL reply can still be
+// applied in the opposite order to the one they were fetched in. That matters
+// because the union's tombstones are one-shot -- the daemon drops an ECID from
+// io_lastSentResultIds as it emits EC_TAG_FILE_REMOVED for it -- so a stale
+// FULL landing after a tombstone re-inserts a row nothing will ever remove
+// again. Held across the EC call, which is the same wait the EC worker already
+// imposes; the State lock is always taken inside this one, never the reverse.
+std::mutex g_search_stream_mtx;
+
 SearchFetchOutcome FetchSearchResults(CamuleapiApp &app, CState &state)
 {
+	std::lock_guard<std::mutex> stream_lock(g_search_stream_mtx);
 	std::unique_ptr<CECPacket> req(new CECPacket(EC_OP_SEARCH_RESULTS, EC_DETAIL_INC_UPDATE));
 	// Opt into result grouping (issue #431): the empty EC_TAG_SEARCH_PARENT
 	// flag tells the responder to also emit each same-hash/different-name
@@ -95,11 +109,17 @@ SearchFetchOutcome FetchSearchResults(CamuleapiApp &app, CState &state)
 //
 // Serving the HTTP thread. The union must have exactly one issuer, or two
 // replies can be applied out of order and leave a ghost row no later poll can
-// clear -- SendRecvSerialized serialises the roundtrip, not the roundtrip plus
-// the apply. A FULL reply is self-contained and idempotent, so issuing this
-// from a request handler races nothing.
-SearchFetchOutcome FetchOneSearchFull(CamuleapiApp &app, CState &state, std::uint32_t search_id)
+// clear. A FULL reply is self-contained, but it is not ordered against the
+// union's one-shot tombstones, so this shares g_search_stream_mtx with the
+// union rather than relying on idempotence alone.
+//
+// Re-seeding after a lost union reply, with `replace`. A merge cannot express
+// a deletion, and a FULL reply carries no tombstones, so a plain merge would
+// leave behind rows the daemon has since dropped. In replace mode the slot's
+// results are swapped wholesale for what the daemon reports now.
+SearchFetchOutcome FetchOneSearchFull(CamuleapiApp &app, CState &state, std::uint32_t search_id, bool replace)
 {
+	std::lock_guard<std::mutex> stream_lock(g_search_stream_mtx);
 	std::unique_ptr<CECPacket> req(new CECPacket(EC_OP_SEARCH_RESULTS, EC_DETAIL_FULL));
 	req->AddTag(CECEmptyTag(EC_TAG_SEARCH_PARENT));
 	req->AddTag(CECTag(EC_TAG_SEARCH_ID, search_id));
@@ -116,8 +136,31 @@ SearchFetchOutcome FetchOneSearchFull(CamuleapiApp &app, CState &state, std::uin
 		// reply carries no EC_TAG_SEARCH_ID of its own, hence the explicit id.
 		state.MutateAllSearches([&](std::map<std::uint32_t, SearchSlot> &slots,
 						std::map<std::uint32_t, std::uint32_t> &owner) {
+			auto sit = slots.find(search_id);
+			if (sit == slots.end())
+				return;
+			if (replace) {
+				for (const auto &entry : sit->second.raw)
+					owner.erase(entry.first);
+				sit->second.raw.clear();
+			}
 			ApplySearchUnion(resp, slots, owner, search_id);
+			sit = slots.find(search_id);
+			if (sit == slots.end())
+				return;
+			// ApplySearchUnion only refolds slots it touched, and an empty
+			// reply touches nothing -- which is exactly the case where the
+			// stale fold has to be cleared rather than kept.
+			if (replace)
+				RebuildFoldedResults(sit->second.raw, sit->second.results);
+			sit->second.needs_resync = false;
 		});
+	}
+	if (outcome == SearchFetchOutcome::Expired) {
+		// Definitive answer, just not a useful one: the daemon no longer has
+		// this search, so retirement owns the slot from here. Clearing the
+		// flag stops it being re-requested every tick forever.
+		state.ClearSearchResyncFlag(search_id);
 	}
 	delete resp;
 	return outcome;
@@ -428,10 +471,28 @@ bool RefresherTick(CamuleapiApp &app, CState &state)
 	// them forever after. Neither discovery route runs through here:
 	// GET /search goes straight to EC_OP_SEARCH_LIST every call, and a by-id
 	// read seeds the slot in full via FetchOneSearchFull before this opens.
-	if (state.HasAnySearch() && FetchSearchResults(app, state) == SearchFetchOutcome::EcFailed) {
-		// Same rule as every other step in the tick: a failed roundtrip bails
-		// the whole tick rather than exposing a half-refreshed cache.
-		return false;
+	// Anything the last failed union reply covered is unrecoverable from the
+	// stream itself, so re-seed those slots in full before polling again.
+	// Ordered after the retirement loop so a slot the daemon has dropped is
+	// already detached and not asked for.
+	for (std::uint32_t sid : state.SearchesNeedingResync()) {
+		if (FetchOneSearchFull(app, state, sid, /*replace=*/true) == SearchFetchOutcome::EcFailed) {
+			return false;
+		}
+	}
+	if (state.HasAnySearch()) {
+		if (FetchSearchResults(app, state) == SearchFetchOutcome::EcFailed) {
+			// The daemon commits its differential state while building the
+			// reply, so what this one carried is already gone from its point
+			// of view. Flag the slots for a full re-seed above on the next
+			// tick; without it every result that reply covered would be
+			// elided from every later poll.
+			state.MarkAllSearchesNeedResync();
+			// Same rule as every other step in the tick: a failed roundtrip
+			// bails the whole tick rather than exposing a half-refreshed
+			// cache.
+			return false;
+		}
 	}
 
 	// /preferences + /categories — one EC roundtrip populates both.

--- a/src/webapi/State.cpp
+++ b/src/webapi/State.cpp
@@ -335,7 +335,7 @@ void CState::MarkSearchStarted(std::uint32_t search_id, const std::string &kind,
 	slot.query = query;
 	slot.started_at = std::time(nullptr);
 	slot.last_fetch = {};
-	EvictSurplusSearchSlotsLocked();
+	EvictSurplusSearchSlotsLocked(search_id);
 }
 
 void CState::MarkSearchDiscovered(std::uint32_t search_id,
@@ -382,7 +382,7 @@ void CState::MarkSearchDiscovered(std::uint32_t search_id,
 		reported_percent >= 0 ? static_cast<std::uint32_t>(reported_percent) : (complete ? 100u : 0u);
 	slot.progress.kind = kind;
 	slot.query = query;
-	EvictSurplusSearchSlotsLocked();
+	EvictSurplusSearchSlotsLocked(search_id);
 }
 
 void CState::DetachSearch(std::uint32_t search_id)
@@ -393,7 +393,42 @@ void CState::DetachSearch(std::uint32_t search_id)
 		it->second.detached = true;
 }
 
-void CState::EvictSurplusSearchSlotsLocked()
+void CState::MarkAllSearchesNeedResync()
+{
+	std::unique_lock<std::shared_timed_mutex> lock(m_mu);
+	for (auto &kv : m_searches) {
+		// A detached slot is frozen and the daemon holds nothing for it, so
+		// there is nothing to re-seed and the FULL would come back expired.
+		if (!kv.second.detached)
+			kv.second.needs_resync = true;
+	}
+}
+
+std::vector<std::uint32_t> CState::SearchesNeedingResync() const
+{
+	std::shared_lock<std::shared_timed_mutex> lock(m_mu);
+	std::vector<std::pair<std::uint64_t, std::uint32_t>> pending;
+	for (const auto &kv : m_searches) {
+		if (kv.second.needs_resync)
+			pending.emplace_back(kv.second.seq, kv.first);
+	}
+	std::sort(pending.begin(), pending.end());
+	std::vector<std::uint32_t> out;
+	out.reserve(pending.size());
+	for (const auto &p : pending)
+		out.push_back(p.second);
+	return out;
+}
+
+void CState::ClearSearchResyncFlag(std::uint32_t search_id)
+{
+	std::unique_lock<std::shared_timed_mutex> lock(m_mu);
+	auto it = m_searches.find(search_id);
+	if (it != m_searches.end())
+		it->second.needs_resync = false;
+}
+
+void CState::EvictSurplusSearchSlotsLocked(std::uint32_t exempt_id)
 {
 	while (m_searches.size() > kMaxSearchSlots) {
 		auto victim = m_searches.end();
@@ -401,6 +436,9 @@ void CState::EvictSurplusSearchSlotsLocked()
 			// Never an active one: it is still being polled, and the surplus
 			// is always made of slots that have stopped moving.
 			if (it->second.progress.active)
+				continue;
+			// Never the slot the caller is in the middle of seeding.
+			if (exempt_id != 0 && it->first == exempt_id)
 				continue;
 			// A detached slot always outranks an attached one, however much
 			// younger: the daemon no longer holds it, so evicting it drops

--- a/src/webapi/State.h
+++ b/src/webapi/State.h
@@ -1067,6 +1067,19 @@ struct SearchSlot
 	// also the preferred eviction victim, because it is the only kind whose
 	// eviction costs nothing -- the daemon has nothing left to re-send.
 	bool detached = false;
+	// Set when a union roundtrip failed against a live socket, and cleared
+	// once this slot has been re-seeded in full.
+	//
+	// The daemon commits its differential state while BUILDING the reply --
+	// Get_EC_Response_Search_Results_Union swaps io_lastSentResultIds and
+	// writes the valuemap before the packet reaches the socket -- so a reply
+	// we never apply is not re-sent, it is lost. Every later poll elides the
+	// results it covered. Nothing else recovers them: ResetLists deliberately
+	// keeps the search state (wiping it would resync nothing), and
+	// ClaimSearchRefresh refuses an active slot because the tick is supposed
+	// to be covering it. This flag is what turns that dead end into one FULL
+	// re-seed on the next tick.
+	bool needs_resync = false;
 	// Insertion order, for oldest-first eviction. Not started_at: that is 0
 	// for a discovered slot, which would make every adopted search tie for
 	// oldest and evict in map order.
@@ -1964,6 +1977,17 @@ public:
 	 * see SearchSlot::detached. Idempotent; a no-op for an unknown id.
 	 */
 	void DetachSearch(std::uint32_t search_id);
+
+	// Flag every slot the daemon could still speak for as needing a full
+	// re-seed. Called when a union roundtrip failed: we cannot know what that
+	// reply carried, and the daemon will not send it again.
+	void MarkAllSearchesNeedResync();
+	// Ids awaiting that re-seed, oldest slot first. Drained by the tick.
+	std::vector<std::uint32_t> SearchesNeedingResync() const;
+	// Clears the flag for one slot without re-seeding it, for when the daemon
+	// answers that the search is gone.
+	void ClearSearchResyncFlag(std::uint32_t search_id);
+
 	void MarkSearchDiscovered(std::uint32_t search_id,
 		const std::string &kind,
 		const std::string &query,
@@ -2067,10 +2091,19 @@ private:
 	// EC_OP_SEARCH_LIST and re-seeds it in full through FetchOneSearchFull.
 	// Detached slots are preferred as victims anyway, since for those the
 	// daemon has nothing left to re-send and nothing is lost.
+	//
+	// A soft cap, not a hard bound: an active slot is never a victim, so a
+	// burst of more than this many concurrent searches sits above the cap
+	// until they finish. That is deliberate -- evicting a search still being
+	// polled would drop results the daemon has already marked delivered.
 	static constexpr std::size_t kMaxSearchSlots = 64;
 	// Trim m_searches back to kMaxSearchSlots, and drop the evicted slots'
 	// entries from m_resultOwner with them. Caller holds the write lock.
-	void EvictSurplusSearchSlotsLocked();
+	//
+	// `exempt_id` is never chosen as a victim: callers evict straight after
+	// inserting, and with every other slot active the freshly-inserted one is
+	// the only eligible victim, so it would evict what it just seeded.
+	void EvictSurplusSearchSlotsLocked(std::uint32_t exempt_id = 0);
 };
 
 } // namespace webapi

--- a/unittests/tests/RefresherTest.cpp
+++ b/unittests/tests/RefresherTest.cpp
@@ -2929,6 +2929,49 @@ TEST(Refresher, SearchUnionDefaultSidAdoptsAnIdLessReply)
 	ASSERT_EQUALS(kSid, owner[71]);
 }
 
+TEST(Refresher, SearchUnionLeavesNoIndexEntryForADetachedSlot)
+{
+	// The index is what eviction walks to clean up after a slot, and it walks
+	// it via the slot's own results. An entry written for a result that was
+	// then dropped on the detached guard is in neither place, so nothing ever
+	// removes it -- and a reused ECID would resolve through it to a search
+	// that is gone.
+	std::map<std::uint32_t, SearchSlot> slots;
+	std::map<std::uint32_t, std::uint32_t> owner;
+	SearchSlot &slot = slots[kSid];
+	slot.detached = true;
+
+	CECPacket resp(EC_OP_SEARCH_RESULTS);
+	CECTag sf(EC_TAG_SEARCHFILE, static_cast<std::uint32_t>(72));
+	sf.AddTag(CECTag(EC_TAG_SEARCH_ID, kSid));
+	sf.AddTag(CECTag(EC_TAG_PARTFILE_NAME, std::string("late.bin")));
+	resp.AddTag(sf);
+	ApplySearchUnion(&resp, slots, owner);
+
+	// Not merged, and no index entry left pointing at the slot that refused it.
+	ASSERT_TRUE(slots[kSid].raw.empty());
+	ASSERT_TRUE(owner.find(72) == owner.end());
+}
+
+TEST(Refresher, SearchUnionStillIndexesAResultItAccepts)
+{
+	// The guard above must not cost the normal path its index entry: that is
+	// what attributes every later diffed tag, which carries no search id.
+	std::map<std::uint32_t, SearchSlot> slots;
+	std::map<std::uint32_t, std::uint32_t> owner;
+	slots[kSid];
+
+	CECPacket resp(EC_OP_SEARCH_RESULTS);
+	CECTag sf(EC_TAG_SEARCHFILE, static_cast<std::uint32_t>(73));
+	sf.AddTag(CECTag(EC_TAG_SEARCH_ID, kSid));
+	sf.AddTag(CECTag(EC_TAG_PARTFILE_NAME, std::string("kept.bin")));
+	resp.AddTag(sf);
+	ApplySearchUnion(&resp, slots, owner);
+
+	ASSERT_EQUALS(kSid, owner[73]);
+	ASSERT_EQUALS(std::string("kept.bin"), slots[kSid].results[73].name);
+}
+
 TEST(Refresher, SearchProgressUnionParsesEveryEntry)
 {
 	CECPacket resp(EC_OP_SEARCH_PROGRESS);

--- a/unittests/tests/StateTest.cpp
+++ b/unittests/tests/StateTest.cpp
@@ -1647,6 +1647,61 @@ TEST(State, SurplusSearchSlotsAreEvictedDetachedFirst)
 	ASSERT_TRUE(std::find(left.begin(), left.end(), 2u) == left.end());
 }
 
+TEST(State, EvictionNeverTakesTheSlotBeingSeeded)
+{
+	// Eviction runs straight after the insert. With every other slot active
+	// -- never a victim -- the slot just created is the only eligible one, so
+	// without an exemption the seed evicts itself and the caller then applies
+	// a full re-read to a slot that is no longer there.
+	CState state;
+	for (std::uint32_t sid = 100; sid < 100 + 64; ++sid) {
+		SearchProgressSnapshot running;
+		running.active = true;
+		state.MarkSearchStarted(sid, "global", "busy");
+		state.WriteSearchProgress(sid, running);
+	}
+	// Discovered as finished, so it is the one slot that is not active.
+	state.MarkSearchDiscovered(4242, "global", "adopted", false, true, 100);
+
+	const std::vector<std::uint32_t> left = state.AllSearchIds();
+	ASSERT_TRUE(std::find(left.begin(), left.end(), 4242u) != left.end());
+}
+
+TEST(State, AFailedUnionFlagsEveryLiveSlotForResync)
+{
+	// The daemon commits its differential state while building a reply, so a
+	// reply we never applied is gone rather than repeated. Every slot it could
+	// have covered has to be re-seeded in full.
+	CState state;
+	state.MarkSearchStarted(1, "global", "alpha");
+	state.MarkSearchStarted(2, "kad", "beta");
+	state.MarkSearchStarted(3, "global", "gone");
+	state.DetachSearch(3);
+
+	state.MarkAllSearchesNeedResync();
+	const std::vector<std::uint32_t> pending = state.SearchesNeedingResync();
+
+	ASSERT_EQUALS(static_cast<size_t>(2), pending.size());
+	// Oldest slot first, and the detached one is skipped: the daemon holds
+	// nothing for it, so a full re-read would only come back expired.
+	ASSERT_EQUALS(1u, pending[0]);
+	ASSERT_EQUALS(2u, pending[1]);
+}
+
+TEST(State, ClearingTheResyncFlagStopsItBeingRequestedAgain)
+{
+	// The daemon answering "expired" is a definitive answer. Left set, the id
+	// would be re-requested on every tick for the life of the slot.
+	CState state;
+	state.MarkSearchStarted(7, "global", "alpha");
+	state.MarkAllSearchesNeedResync();
+	ASSERT_EQUALS(static_cast<size_t>(1), state.SearchesNeedingResync().size());
+
+	state.ClearSearchResyncFlag(7);
+
+	ASSERT_TRUE(state.SearchesNeedingResync().empty());
+}
+
 TEST(State, MarkTickSuccessDoesNotAdvanceTheRevision)
 {
 	CState state;


### PR DESCRIPTION
Follow-up to #1191. Five gaps in the differential search stream, found reviewing the merged code. No API surface change, so no doc updates.

### 1. A lost union reply was unrecoverable

The daemon commits its per-connection diff state while **building** a union reply: `Get_EC_Response_Search_Results_Union` swaps `io_lastSentResultIds` and writes the valuemap before the packet reaches the socket. A reply the client never applies is therefore not re-sent, it is lost, and every later poll elides what it covered.

Nothing recovered it. The tick bails on a failed roundtrip without applying, `ResetLists` deliberately keeps the search state (#1191 got that right - wiping it would resync nothing), and `ClaimSearchRefresh` refuses an active slot because the tick is meant to be covering it. That is the "tick failed against a socket that is still up" path the code documents elsewhere, so it is reachable.

Now a failed union flags every live slot, and the next tick re-seeds them with one `FetchOneSearchFull`. The re-seed **replaces** rather than merges: a FULL reply carries no tombstones, so a merge cannot express a row the daemon has dropped.

### 2. The union and the FULL fetch had no ordering against each other

`SendRecvSerialized` orders the roundtrips, not the roundtrip plus the apply - each caller then takes the State lock separately. So a FULL reply fetched before a tombstone could be applied after it, re-inserting a row that nothing removes again, because the tombstones are one-shot: the daemon drops an ECID from `io_lastSentResultIds` as it emits `EC_TAG_FILE_REMOVED` for it. Both paths run for the same non-active slot (the tick polls finished searches, and `ClaimSearchRefresh` serves exactly those), so this was live.

Both now take one mutex across roundtrip and apply, in a fixed order with the State lock always taken inside it.

### 3. `ApplySearchUnion` left index entries behind

The ECID index entry was written before the checks that can reject the tag, so a result arriving for a detached slot left an entry with no result behind it. Eviction cleans the index by walking the slot's own results, so such an entry was never removed - and the index is what attributes every later diffed tag.

### 4. Eviction could take the slot just seeded

`EvictSurplusSearchSlotsLocked` runs straight after the insert. An active slot is never a victim, so with every other slot active the freshly-inserted one is the only candidate. Discovery then reported success for a slot that was gone, and the FULL re-read applied to nothing.

### 5. `kMaxSearchSlots` is a soft cap

Documented as such: an active slot is never evicted, so a burst above the cap persists until those searches finish. Deliberate - evicting a search still being polled would drop results the daemon has already marked delivered.

### Verification

- 43/43 ctest.
- Curl phases 07, 09, 10, 19, 20, 22, 26, 28 - every phase that touches `/search` or `/browse`, plus 09 because this adds a conditional roundtrip to the tick it covers. 682 assertions passed, 19-search 180/180, 2 skips both unrelated (no peers connected). Run against a daemon connected to eD2k (Sharing-Devils No.4, LowID) and Kad (connected, firewalled), so the searches returned real hits.
- clang-format clean; clang-tidy Tier-1 and Tier-2 clean with 0 compiler errors.

The two structural fixes are pinned by tests that fail without them - reverting each one fails exactly its own test (`owner.find(72) == owner.end()` for the index, the missing slot for the eviction), while the companion test that the normal path still indexes its results keeps passing. The three resync tests exercise new API, so they are characterization rather than regression guards, and the ordering fix in 2 is verified by construction: a deterministic test would need injectable EC timing that does not exist here.
