### PR TITLE
webapi: keep the search resync obligation until a replace discharges it

### DIFF
--- a/src/webapi/Refresher.cpp
+++ b/src/webapi/Refresher.cpp
@@ -2743,6 +2743,41 @@ void ApplySearchUnion(const CECPacket *resp,
 	}
 }
 
+void ApplySearchFullReply(const CECPacket *resp,
+	std::map<std::uint32_t, SearchSlot> &slots,
+	std::map<std::uint32_t, std::uint32_t> &owner,
+	std::uint32_t search_id,
+	bool replace)
+{
+	auto sit = slots.find(search_id);
+	if (sit == slots.end())
+		return;
+	if (replace) {
+		// Drop the old rows AND their index entries: the reply below re-adds
+		// an entry for every result it carries, so anything not re-added is a
+		// row the daemon no longer holds.
+		for (const auto &entry : sit->second.raw)
+			owner.erase(entry.first);
+		sit->second.raw.clear();
+	}
+	ApplySearchUnion(resp, slots, owner, search_id);
+	sit = slots.find(search_id);
+	if (sit == slots.end())
+		return;
+	// ApplySearchUnion only refolds slots it touched, and an empty reply
+	// touches nothing -- which is exactly the case where the stale fold has to
+	// be cleared rather than kept.
+	if (replace) {
+		RebuildFoldedResults(sit->second.raw, sit->second.results);
+		// Only a replace answers the question the flag asks. A merge re-reads
+		// every row the daemon still has, but it cannot remove one it has
+		// dropped -- the tombstones for those went out in the union reply that
+		// was lost, and the daemon will not mention them again. Clearing the
+		// flag here would leave those rows in place for the life of the slot.
+		sit->second.needs_resync = false;
+	}
+}
+
 // --- Search-progress, daemon-supplied lifecycle path -------------------
 //
 // Reads EC_TAG_SEARCH_LIFECYCLE_STATE from the EC_OP_SEARCH_PROGRESS

--- a/src/webapi/Refresher.h
+++ b/src/webapi/Refresher.h
@@ -294,6 +294,24 @@ void ApplySearchUnion(const CECPacket *resp,
 	std::map<std::uint32_t, std::uint32_t> &owner,
 	std::uint32_t default_sid = 0);
 
+// Apply one per-search EC_DETAIL_FULL reply to a single slot.
+//
+// `replace` swaps the slot's results for what the daemon reports now instead
+// of merging onto them, which is what a re-seed after a lost union reply
+// needs: a FULL reply carries no tombstones, so a merge cannot express a row
+// the daemon has dropped. It is also the only mode that discharges
+// SearchSlot::needs_resync -- a merge leaves exactly the rows the flag exists
+// to clear, so clearing it there would strand them permanently.
+//
+// Split out of FetchOneSearchFull so the bookkeeping is reachable from the
+// tests: RefresherTick.cpp is kept out of the test target for its CamuleapiApp
+// dependency, and this is where the resync contract actually lives.
+void ApplySearchFullReply(const CECPacket *resp,
+	std::map<std::uint32_t, SearchSlot> &slots,
+	std::map<std::uint32_t, std::uint32_t> &owner,
+	std::uint32_t search_id,
+	bool replace);
+
 // Search-progress derivation from the EC_TAG_SEARCH_LIFECYCLE_* tags.
 // `lifecycle_state` is the uint8 enum value (0=idle, 1=running,
 // 2=finished). `pct_now` is the EC_TAG_SEARCH_LIFECYCLE_PERCENT value —

--- a/src/webapi/RefresherTick.cpp
+++ b/src/webapi/RefresherTick.cpp
@@ -136,24 +136,7 @@ SearchFetchOutcome FetchOneSearchFull(CamuleapiApp &app, CState &state, std::uin
 		// reply carries no EC_TAG_SEARCH_ID of its own, hence the explicit id.
 		state.MutateAllSearches([&](std::map<std::uint32_t, SearchSlot> &slots,
 						std::map<std::uint32_t, std::uint32_t> &owner) {
-			auto sit = slots.find(search_id);
-			if (sit == slots.end())
-				return;
-			if (replace) {
-				for (const auto &entry : sit->second.raw)
-					owner.erase(entry.first);
-				sit->second.raw.clear();
-			}
-			ApplySearchUnion(resp, slots, owner, search_id);
-			sit = slots.find(search_id);
-			if (sit == slots.end())
-				return;
-			// ApplySearchUnion only refolds slots it touched, and an empty
-			// reply touches nothing -- which is exactly the case where the
-			// stale fold has to be cleared rather than kept.
-			if (replace)
-				RebuildFoldedResults(sit->second.raw, sit->second.results);
-			sit->second.needs_resync = false;
+			ApplySearchFullReply(resp, slots, owner, search_id, replace);
 		});
 	}
 	if (outcome == SearchFetchOutcome::Expired) {
@@ -474,7 +457,9 @@ bool RefresherTick(CamuleapiApp &app, CState &state)
 	// Anything the last failed union reply covered is unrecoverable from the
 	// stream itself, so re-seed those slots in full before polling again.
 	// Ordered after the retirement loop so a slot the daemon has dropped is
-	// already detached and not asked for.
+	// already detached by the time this runs, and SearchesNeedingResync skips
+	// it: the ordering alone only makes the slot detached, it does not keep it
+	// out of the list.
 	for (std::uint32_t sid : state.SearchesNeedingResync()) {
 		if (FetchOneSearchFull(app, state, sid, /*replace=*/true) == SearchFetchOutcome::EcFailed) {
 			return false;

--- a/src/webapi/State.cpp
+++ b/src/webapi/State.cpp
@@ -409,7 +409,12 @@ std::vector<std::uint32_t> CState::SearchesNeedingResync() const
 	std::shared_lock<std::shared_timed_mutex> lock(m_mu);
 	std::vector<std::pair<std::uint64_t, std::uint32_t>> pending;
 	for (const auto &kv : m_searches) {
-		if (kv.second.needs_resync)
+		// Same exemption the flag's writer applies, and for the same reason:
+		// a slot detached after it was flagged has had its search dropped by
+		// the daemon, so a full re-read would only come back expired. Asking
+		// anyway costs a roundtrip per slot, and a replace-mode apply against
+		// a detached slot would clear the results the detach exists to keep.
+		if (kv.second.needs_resync && !kv.second.detached)
 			pending.emplace_back(kv.second.seq, kv.first);
 	}
 	std::sort(pending.begin(), pending.end());

--- a/src/webapi/State.h
+++ b/src/webapi/State.h
@@ -1983,6 +1983,8 @@ public:
 	// reply carried, and the daemon will not send it again.
 	void MarkAllSearchesNeedResync();
 	// Ids awaiting that re-seed, oldest slot first. Drained by the tick.
+	// Detached slots are excluded, matching MarkAllSearchesNeedResync: one
+	// detached after it was flagged has nothing left to re-seed.
 	std::vector<std::uint32_t> SearchesNeedingResync() const;
 	// Clears the flag for one slot without re-seeding it, for when the daemon
 	// answers that the search is gone.

--- a/unittests/tests/RefresherTest.cpp
+++ b/unittests/tests/RefresherTest.cpp
@@ -2972,6 +2972,91 @@ TEST(Refresher, SearchUnionStillIndexesAResultItAccepts)
 	ASSERT_EQUALS(std::string("kept.bin"), slots[kSid].results[73].name);
 }
 
+TEST(Refresher, AMergingFullReplyLeavesTheResyncFlagSet)
+{
+	// The flag says "a union reply was lost, so this slot may hold rows the
+	// daemon has already dropped". Only a replace answers that: a merge
+	// re-reads what the daemon still has and cannot remove what it does not.
+	// Clearing it on a merge strands those rows for the life of the slot --
+	// the tombstones went out in the reply that was lost, and the daemon
+	// never mentions them again. The HTTP refresh path (RefreshSearchIfStale)
+	// takes exactly this mode, and it serves the same non-active slots the
+	// flag is set on.
+	std::map<std::uint32_t, SearchSlot> slots;
+	std::map<std::uint32_t, std::uint32_t> owner;
+	SearchSlot &slot = slots[kSid];
+	slot.needs_resync = true;
+	slot.raw[80].ecid = 80;
+	slot.raw[80].name = "dropped-by-the-daemon.bin";
+	owner[80] = kSid;
+
+	// A FULL reply that no longer carries ECID 80. No tombstone: a FULL reply
+	// has none to carry.
+	CECPacket resp(EC_OP_SEARCH_RESULTS);
+	CECTag sf(EC_TAG_SEARCHFILE, static_cast<std::uint32_t>(81));
+	sf.AddTag(CECTag(EC_TAG_PARTFILE_NAME, std::string("still-here.bin")));
+	resp.AddTag(sf);
+	ApplySearchFullReply(&resp, slots, owner, kSid, /*replace=*/false);
+
+	// The stale row survives the merge, which is precisely why the obligation
+	// must survive with it.
+	ASSERT_TRUE(slots[kSid].raw.find(80) != slots[kSid].raw.end());
+	ASSERT_TRUE(slots[kSid].needs_resync);
+}
+
+TEST(Refresher, AReplacingFullReplyDropsStaleRowsAndClearsTheFlag)
+{
+	// The re-seed the tick issues. Swapping the rows wholesale is the only
+	// way to express a deletion from a reply that carries no tombstones, and
+	// having done it the slot is authoritative again.
+	std::map<std::uint32_t, SearchSlot> slots;
+	std::map<std::uint32_t, std::uint32_t> owner;
+	SearchSlot &slot = slots[kSid];
+	slot.needs_resync = true;
+	slot.raw[80].ecid = 80;
+	slot.raw[80].name = "dropped-by-the-daemon.bin";
+	slot.results = slot.raw;
+	owner[80] = kSid;
+
+	CECPacket resp(EC_OP_SEARCH_RESULTS);
+	CECTag sf(EC_TAG_SEARCHFILE, static_cast<std::uint32_t>(81));
+	sf.AddTag(CECTag(EC_TAG_PARTFILE_NAME, std::string("still-here.bin")));
+	resp.AddTag(sf);
+	ApplySearchFullReply(&resp, slots, owner, kSid, /*replace=*/true);
+
+	ASSERT_TRUE(slots[kSid].raw.find(80) == slots[kSid].raw.end());
+	ASSERT_TRUE(slots[kSid].results.find(80) == slots[kSid].results.end());
+	// The index entry goes with the row, or a later result reusing the ECID
+	// resolves through it.
+	ASSERT_TRUE(owner.find(80) == owner.end());
+	ASSERT_EQUALS(std::string("still-here.bin"), slots[kSid].results[81].name);
+	ASSERT_TRUE(!slots[kSid].needs_resync);
+}
+
+TEST(Refresher, AnEmptyReplacingReplyClearsTheFoldedView)
+{
+	// The daemon reporting nothing left is a real answer, and the one an
+	// empty-reply merge cannot express: ApplySearchUnion refolds only slots
+	// it touched, so without the unconditional refold the stale fold would
+	// outlive the rows it was built from.
+	std::map<std::uint32_t, SearchSlot> slots;
+	std::map<std::uint32_t, std::uint32_t> owner;
+	SearchSlot &slot = slots[kSid];
+	slot.needs_resync = true;
+	slot.raw[80].ecid = 80;
+	slot.raw[80].name = "gone.bin";
+	slot.results = slot.raw;
+	owner[80] = kSid;
+
+	CECPacket resp(EC_OP_SEARCH_RESULTS);
+	ApplySearchFullReply(&resp, slots, owner, kSid, /*replace=*/true);
+
+	ASSERT_TRUE(slots[kSid].raw.empty());
+	ASSERT_TRUE(slots[kSid].results.empty());
+	ASSERT_TRUE(owner.empty());
+	ASSERT_TRUE(!slots[kSid].needs_resync);
+}
+
 TEST(Refresher, SearchProgressUnionParsesEveryEntry)
 {
 	CECPacket resp(EC_OP_SEARCH_PROGRESS);

--- a/unittests/tests/StateTest.cpp
+++ b/unittests/tests/StateTest.cpp
@@ -1688,6 +1688,30 @@ TEST(State, AFailedUnionFlagsEveryLiveSlotForResync)
 	ASSERT_EQUALS(2u, pending[1]);
 }
 
+TEST(State, ADetachedSlotDropsOutOfTheResyncList)
+{
+	// MarkAllSearchesNeedResync skips detached slots; the drain has to apply
+	// the same rule, because a slot can be flagged first and detached later.
+	// That is the ordinary sequence: the union fails and flags every live
+	// slot, then the next tick's retirement loop detaches the ones the daemon
+	// has expired -- before the resync loop runs. Left in, each costs a
+	// roundtrip that can only come back expired, and a replace-mode apply
+	// against a detached slot clears the last-known results the detach exists
+	// to preserve.
+	CState state;
+	state.MarkSearchStarted(11, "global", "alpha");
+	state.MarkSearchStarted(12, "global", "beta");
+
+	state.MarkAllSearchesNeedResync();
+	ASSERT_EQUALS(static_cast<size_t>(2), state.SearchesNeedingResync().size());
+
+	state.DetachSearch(12);
+
+	const std::vector<std::uint32_t> pending = state.SearchesNeedingResync();
+	ASSERT_EQUALS(static_cast<size_t>(1), pending.size());
+	ASSERT_EQUALS(11u, pending[0]);
+}
+
 TEST(State, ClearingTheResyncFlagStopsItBeingRequestedAgain)
 {
 	// The daemon answering "expired" is a definitive answer. Left set, the id


### PR DESCRIPTION
Follow-up to #1191 and #1195, from reviewing the merged code. Two defects in the resync path #1195 added. No API surface change, so no doc updates.

### 1. A merging FULL fetch discharged the resync obligation

`FetchOneSearchFull` cleared `needs_resync` in both of its modes, but only a replace answers what the flag asks. A merge re-reads every row the daemon still holds and cannot remove one it has dropped: the tombstones for those went out in the union reply that was lost, and the daemon never mentions them again.

Both HTTP callers take the merging mode (the default), and `RefreshSearchIfStale` serves exactly the non-active slots the flag is set on. So: the union fails, every live slot is flagged, the tick bails. Within the second before the next tick a client GETs that search, `ClaimSearchRefresh` accepts it (it refuses only active slots), the merge applies and clears the flag. The next tick sees nothing pending, and the authoritative replace never runs.

The rows stranded that way are permanent. It surfaces as two searches merged under one id when the daemon reuses a search id, which is one of the cases it tombstones for: *"a closed or evicted search, or a results list replaced by a new search on the same ID"*. The whole-search eviction case was already covered, since retirement detaches the slot and keeps its results deliberately.

Fix: clear the flag only in replace mode. The bookkeeping moves out of the `MutateAllSearches` lambda into `ApplySearchFullReply` in `Refresher.cpp` so it is reachable from the tests, since `RefresherTick.cpp` is kept out of the test target for its `CamuleapiApp` dependency.

### 2. `SearchesNeedingResync` skipped the detached filter its writer applies

`MarkAllSearchesNeedResync` deliberately skips detached slots; the drain did not. A slot flagged by a failed union and then detached by the next tick's retirement loop, which runs ahead of the resync loop, was still asked for: one roundtrip per slot that can only come back expired. The comment claiming the ordering keeps it out of the list did not hold, since the ordering only makes the slot detached.

Benign today, because the daemon answers expired for exactly the searches that caused the detach. Were it reachable otherwise, the replace would clear `raw`, every tag would hit `ApplySearchUnion`'s detached guard, and the unconditional refold would write the empty map, dropping the last-known results the detach exists to preserve.

### Verification

- 43/43 ctest.
- Each fix is pinned by a test that fails without it, verified by reverting them one at a time: restoring the unconditional clear fails `AMergingFullReplyLeavesTheResyncFlagSet` (`Not true: slots[kSid].needs_resync`), and removing the detached filter fails `ADetachedSlotDropsOutOfTheResyncList` (`Expected '1' but got '2'`). Neither revert disturbs the other's test, and the suite is green again after restoring both.
- Two companion tests pin the replace semantics the fix leaves intact: stale rows and their index entries dropped, and an empty reply clearing the folded view.
- clang-format clean; clang-tidy Tier-1 and Tier-2 clean with 0 compiler errors.
- No live-daemon phases: neither defect is reachable without injecting a union roundtrip failure, so the curl suite cannot observe either, and the apply path both HTTP callers take is exercised directly by the unit tests above.
