### PR TITLE
webapi: watch finished searches for expiry, not just active ones

### DIFF
--- a/src/webapi/RefresherTick.cpp
+++ b/src/webapi/RefresherTick.cpp
@@ -466,8 +466,8 @@ bool RefresherTick(CamuleapiApp &app, CState &state)
 	// only slots that are not active. Skipping the fetch when nobody is
 	// subscribed would hand that client frozen results.
 	//
-	// HasAnySearch() asks about OUR slots -- specifically the ones the daemon
-	// could still speak for, since a detached slot's search has already been
+	// The gate asks about OUR slots -- specifically the ones the daemon could
+	// still speak for, since a detached slot's search has already been
 	// evicted core-side and polling for it would never return anything. It
 	// does not ask about the daemon's searches, and the daemon never tells us
 	// about one unasked: a slot exists only because
@@ -494,7 +494,11 @@ bool RefresherTick(CamuleapiApp &app, CState &state)
 			return false;
 		}
 	}
-	if (state.HasAnySearch()) {
+	// The same set the progress union above asked about, reused rather than
+	// recomputed against a second spelling of the same !detached test. A slot
+	// an HTTP thread created since is missed for this one tick and picked up
+	// by the next, which is the poll interval either way.
+	if (!attached_sids.empty()) {
 		if (FetchSearchResults(app, state) == SearchFetchOutcome::EcFailed) {
 			// The daemon commits its differential state while building the
 			// reply, so what this one carried is already gone from its point

--- a/src/webapi/RefresherTick.cpp
+++ b/src/webapi/RefresherTick.cpp
@@ -37,6 +37,7 @@
 #include <ec/cpp/ECSpecialTags.h>
 #include <ec/cpp/ECPacket.h>
 
+#include <algorithm>
 #include <cstdint>
 #include <map>
 #include <memory>
@@ -332,14 +333,27 @@ bool RefresherTick(CamuleapiApp &app, CState &state)
 	std::map<std::uint32_t, std::pair<std::uint32_t, std::uint32_t>> union_progress;
 	bool have_union = false;
 	const std::vector<std::uint32_t> active_sids = state.ActiveSearchIds();
-	// Nothing active means nothing to ask about. Without this guard the union
-	// would cost a roundtrip every tick forever on an idle daemon, where the
-	// per-id loop below simply had nothing to iterate.
-	if (app.IsServerSearchProgressUnionActive() && !active_sids.empty()) {
+	// Every slot the daemon could still speak for, finished ones included.
+	// A finished search is never polled for progress -- there is none left to
+	// report -- but it still has to be watched for EXPIRY, because the ring
+	// evicting it is what tombstones its results, and a slot that is not
+	// detached by then has them erased by the union below. That is the whole
+	// point of detaching: keep the last-known results for late reads.
+	//
+	// Naming these ids is also what stops the eviction happening so soon.
+	// The daemon touches its LRU for exactly the ids a client names, so
+	// leaving finished searches out made them the least-recently-used and the
+	// first victims of anyone's next search -- amuleapi stopped refreshing
+	// precisely the searches it had decided to keep.
+	const std::vector<std::uint32_t> attached_sids = state.AttachedSearchIds();
+	// Nothing attached means nothing to ask about. Without this guard the
+	// union would cost a roundtrip every tick forever on an idle daemon,
+	// where the per-id loop below simply had nothing to iterate.
+	if (app.IsServerSearchProgressUnionActive() && !attached_sids.empty()) {
 		std::unique_ptr<CECPacket> req(new CECPacket(EC_OP_SEARCH_PROGRESS));
 		// Name the searches we track so the daemon bumps exactly those in its
 		// LRU, matching what the per-id poll did.
-		for (std::uint32_t sid : active_sids) {
+		for (std::uint32_t sid : attached_sids) {
 			req->AddTag(CECTag(EC_TAG_SEARCH_ID, sid));
 		}
 		const CECPacket *resp = app.SendRecvSerialized(req.get());
@@ -358,10 +372,16 @@ bool RefresherTick(CamuleapiApp &app, CState &state)
 	// roundtrip each against an older daemon). Runs BEFORE the results poll
 	// below so an eviction is seen, and the slot frozen, while its results
 	// are still there to keep -- see the `expired` branch.
-	for (std::uint32_t sid : active_sids) {
+	for (std::uint32_t sid : attached_sids) {
 		std::uint32_t percent = 0;
 		std::uint32_t lifecycle_state = 0;
 		bool expired = false;
+		// A finished slot is here for the expiry verdict only. Its progress
+		// is terminal and must not be re-derived: AdvanceSearchProgress reads
+		// a missing lifecycle tag as IDLE and would reset complete/percent
+		// back to 0, turning a finished search into an idle one.
+		const bool was_active =
+			std::find(active_sids.begin(), active_sids.end(), sid) != active_sids.end();
 		if (have_union) {
 			// Already fetched above; absent means the daemon dropped it.
 			const auto found = union_progress.find(sid);
@@ -371,7 +391,11 @@ bool RefresherTick(CamuleapiApp &app, CState &state)
 				percent = found->second.first;
 				lifecycle_state = found->second.second;
 			}
-		} else {
+		} else if (was_active) {
+			// No union on this daemon: fall back to one roundtrip per search,
+			// and only for the active ones. Paying a roundtrip per FINISHED
+			// slot every tick to learn about an eviction that may never come
+			// is the trade the union makes cheap and this form does not.
 			std::unique_ptr<CECPacket> req(new CECPacket(EC_OP_SEARCH_PROGRESS));
 			req->AddTag(CECTag(EC_TAG_SEARCH_ID, sid));
 			const CECPacket *resp = app.SendRecvSerialized(req.get());
@@ -413,6 +437,11 @@ bool RefresherTick(CamuleapiApp &app, CState &state)
 			fin.complete = true;
 			fin.percent = 100;
 			state.WriteSearchProgress(sid, fin);
+			continue;
+		}
+		if (!was_active) {
+			// Not expired, and not active: nothing to advance. Leaving the
+			// snapshot alone is what keeps a finished search finished.
 			continue;
 		}
 		const SearchProgressSnapshot next =

--- a/src/webapi/State.cpp
+++ b/src/webapi/State.cpp
@@ -266,6 +266,16 @@ std::vector<std::uint32_t> CState::ActiveSearchIds() const
 	return out;
 }
 
+std::vector<std::uint32_t> CState::AttachedSearchIds() const
+{
+	std::shared_lock<std::shared_timed_mutex> lock(m_mu);
+	std::vector<std::uint32_t> out;
+	for (const auto &kv : m_searches)
+		if (!kv.second.detached)
+			out.push_back(kv.first);
+	return out;
+}
+
 std::vector<std::uint32_t> CState::AllSearchIds() const
 {
 	std::shared_lock<std::shared_timed_mutex> lock(m_mu);

--- a/src/webapi/State.cpp
+++ b/src/webapi/State.cpp
@@ -286,21 +286,6 @@ std::vector<std::uint32_t> CState::AllSearchIds() const
 	return out;
 }
 
-bool CState::HasAnySearch() const
-{
-	std::shared_lock<std::shared_timed_mutex> lock(m_mu);
-	// Detached slots do not count. The daemon has already evicted those
-	// searches, so it has nothing left to send for them -- a session holding
-	// only detached slots would otherwise poll once a second forever with
-	// nothing on the other end, which is what a user who runs one search and
-	// never deletes it ends up with once the daemon's ring drops it.
-	return std::any_of(m_searches.begin(),
-		m_searches.end(),
-		[](const std::pair<const std::uint32_t, SearchSlot> &entry) {
-			return !entry.second.detached;
-		});
-}
-
 bool CState::FindSearchResultByHash(
 	const std::string &hash_hex, SearchResult &out, std::uint32_t *owner_search_id) const
 {

--- a/src/webapi/State.h
+++ b/src/webapi/State.h
@@ -1823,16 +1823,17 @@ public:
 	// the one whose results we are keeping. Naming them in the progress
 	// union also refreshes their LRU entry daemon-side, which is what the
 	// daemon means by "the searches a client still has open".
+	//
+	// Empty is also the gate for both union polls: with no attached slot
+	// there is nothing the daemon could answer about, and sending either
+	// request would be a roundtrip a second that can never return anything.
+	// This replaced a separate HasAnySearch() predicate -- the same
+	// !detached test spelled a second way, which is what drifts -- and the
+	// vector it was introduced to avoid is now built for the progress union
+	// regardless.
 	std::vector<std::uint32_t> AttachedSearchIds() const;
 	// Every live slot id, for the SSE per-search diff.
 	std::vector<std::uint32_t> AllSearchIds() const;
-	// Whether any slot the daemon could still speak for exists. The union poll
-	// asks for every search in one request, so it needs no id list -- only
-	// whether the request is worth sending. Detached slots are excluded: the
-	// daemon has evicted those, so polling on their behalf is a roundtrip a
-	// second that can never return anything. Separate from AllSearchIds() to
-	// avoid building and copying a vector once a second just to test it.
-	bool HasAnySearch() const;
 	// Find a result carrying this (already-lowercased) hash across ALL open
 	// searches — the hash-keyed comments endpoints are search-agnostic. The
 	// parent owns any fetched Kad notes, so it matches ahead of its children.

--- a/src/webapi/State.h
+++ b/src/webapi/State.h
@@ -1817,6 +1817,13 @@ public:
 	std::time_t SearchStartedAt(std::uint32_t search_id) const;
 	// Slots the refresher must still poll (progress.active).
 	std::vector<std::uint32_t> ActiveSearchIds() const;
+	// Every slot the daemon could still speak for: attached, active or not.
+	// The tick polls THIS set for expiry, not ActiveSearchIds(), because a
+	// finished search is exactly the one the daemon's ring drops first and
+	// the one whose results we are keeping. Naming them in the progress
+	// union also refreshes their LRU entry daemon-side, which is what the
+	// daemon means by "the searches a client still has open".
+	std::vector<std::uint32_t> AttachedSearchIds() const;
 	// Every live slot id, for the SSE per-search diff.
 	std::vector<std::uint32_t> AllSearchIds() const;
 	// Whether any slot the daemon could still speak for exists. The union poll

--- a/unittests/tests/StateTest.cpp
+++ b/unittests/tests/StateTest.cpp
@@ -1667,6 +1667,50 @@ TEST(State, EvictionNeverTakesTheSlotBeingSeeded)
 	ASSERT_TRUE(std::find(left.begin(), left.end(), 4242u) != left.end());
 }
 
+TEST(State, AttachedSearchIdsKeepsFinishedSlotsAndDropsDetachedOnes)
+{
+	// The tick polls THIS set for expiry. A finished search has to stay in it:
+	// it is the one the daemon's ring drops first, and the eviction tombstones
+	// its results, so a slot not detached by then has them erased -- which is
+	// exactly what detaching exists to prevent. A detached slot drops out
+	// because the daemon already has nothing to say about it.
+	CState state;
+	state.MarkSearchStarted(1, "global", "running");
+	SearchProgressSnapshot running;
+	running.active = true;
+	state.WriteSearchProgress(1, running);
+
+	state.MarkSearchStarted(2, "global", "finished");
+	SearchProgressSnapshot done;
+	done.active = false;
+	done.complete = true;
+	done.percent = 100;
+	state.WriteSearchProgress(2, done);
+
+	// Detached exactly the way the tick does it: the expiry branch detaches
+	// AND writes the terminal snapshot, so a detached slot is never left
+	// marked active. Detaching alone would be a state the product never
+	// produces, and asserting against it would prove nothing.
+	state.MarkSearchStarted(3, "global", "gone");
+	state.DetachSearch(3);
+	SearchProgressSnapshot retired;
+	retired.active = false;
+	retired.complete = true;
+	retired.percent = 100;
+	state.WriteSearchProgress(3, retired);
+
+	const std::vector<std::uint32_t> attached = state.AttachedSearchIds();
+	ASSERT_EQUALS(static_cast<size_t>(2), attached.size());
+	ASSERT_TRUE(std::find(attached.begin(), attached.end(), 1u) != attached.end());
+	ASSERT_TRUE(std::find(attached.begin(), attached.end(), 2u) != attached.end());
+	ASSERT_TRUE(std::find(attached.begin(), attached.end(), 3u) == attached.end());
+
+	// The active set is the narrower one the progress advance still uses.
+	const std::vector<std::uint32_t> active = state.ActiveSearchIds();
+	ASSERT_EQUALS(static_cast<size_t>(1), active.size());
+	ASSERT_EQUALS(1u, active[0]);
+}
+
 TEST(State, AFailedUnionFlagsEveryLiveSlotForResync)
 {
 	// The daemon commits its differential state while building a reply, so a

--- a/unittests/tests/StateTest.cpp
+++ b/unittests/tests/StateTest.cpp
@@ -1573,7 +1573,7 @@ TEST(State, ResetListsKeepsSearchSlots)
 
 	state.ResetLists();
 
-	ASSERT_TRUE(state.HasAnySearch());
+	ASSERT_TRUE(!state.AttachedSearchIds().empty());
 	ASSERT_EQUALS(static_cast<size_t>(1), state.Search(42).size());
 }
 
@@ -1612,15 +1612,15 @@ TEST(State, DetachedSlotsDoNotKeepTheUnionPollAlive)
 {
 	CState state;
 	state.MarkSearchStarted(42, "global", "ubuntu");
-	ASSERT_TRUE(state.HasAnySearch());
+	ASSERT_TRUE(!state.AttachedSearchIds().empty());
 
 	state.DetachSearch(42);
-	ASSERT_TRUE(!state.HasAnySearch());
+	ASSERT_TRUE(state.AttachedSearchIds().empty());
 
 	// A second, still-attached slot re-opens it: the poll covers every search
 	// in one request, so one live slot is reason enough to send it.
 	state.MarkSearchStarted(43, "kad", "debian");
-	ASSERT_TRUE(state.HasAnySearch());
+	ASSERT_TRUE(!state.AttachedSearchIds().empty());
 }
 
 // Slots are capped, or a long-lived process watching a busy GUI accumulates one


### PR DESCRIPTION
Found reviewing the search feature after #1196. A finished search's results are erased when the daemon's ring evicts it, which is the exact outcome `detached` exists to prevent.

### The bug

The tick's retirement loop iterated `ActiveSearchIds()`, and `DetachSearch` has exactly one caller, inside that loop. So a finished slot was never checked for expiry again and stayed attached forever. When the daemon evicted the search, the results union tombstoned every one of its ECIDs, `ApplySearchUnion` found a slot that was not detached, and erased the rows the slot existed to keep.

The slot then answers `200` with `"state": "finished"` and an empty `results` array, while `GET /search` no longer lists the search at all - two endpoints disagreeing about whether it exists. There is no way back: a re-read gets `EC_TAG_SEARCH_EXPIRED`, and `FetchOneSearchFull` defers that to a retirement path which never runs for a finished slot.

### Why it happens so readily

The daemon touches its LRU for exactly the ids a client names. `s_ecSearches` is global across all EC connections and capped at `kMaxEcSearches = 20`, and every new search *or browse* from any client evicts the tail. By naming only its active searches, amuleapi stopped refreshing precisely the ones it had decided to keep, making them the first victims of anyone's next search. Polling the attached set fixes the trigger as well as the handling.

### What the results are still good for

`POST /search/results/{hash}/download` does die with the search - amuled resolves that hash against its own search list. But a result carries `hash`, `name` and `size`, which is what an ed2k link is made of, and `POST /downloads` takes links without consulting the search list. So a kept result stays downloadable; an erased one is gone.

### Scope

A finished slot is polled for the expiry verdict only. Its progress is terminal and must not be re-derived: `AdvanceSearchProgress` reads a missing lifecycle tag as IDLE and would reset `complete` and `percent` to zero, turning a finished search into an idle one. The legacy per-id fallback stays on the active set, where one roundtrip per slot per tick is affordable; against a daemon with no progress union a finished slot is still not watched.

Cost: in the "searches all finished" state the progress union used to be skipped entirely, so the search surface cost one roundtrip per tick. It now costs two. That second request per second is what buys both the expiry detection and the LRU touch that stops the eviction happening so soon.

No API surface change, so no doc updates.

### Second commit: folding `HasAnySearch` into `AttachedSearchIds`

Widening the progress-union gate left the two union polls testing the same `!detached` predicate through two different functions - the kind of duplication that drifts when someone later changes what "attached" means in only one of them. The results-union gate now reuses the vector the progress union already built.

That left `HasAnySearch()` with no caller. It existed specifically to avoid building a vector once a second purely to test it, and the progress union now builds that vector regardless, so the reason for a second accessor went with it. Its tests move onto the predicate the tick actually uses, and three comments naming it are updated.

The one behavioural nuance: a slot created by an HTTP thread between the two gates is now missed for that single tick and picked up by the next, because the vector is a snapshot rather than a fresh read. That is the poll interval either way.

### Verification

- Rebased onto `e12edc5e6` after #1197 landed mid-work and touched the same files. The rebase was conflict-free and renamed none of the accessors used here, but everything below was re-run from a clean configure on the new base - the earlier green was against the old one.
- 43/43 ctest.
- `AttachedSearchIdsKeepsFinishedSlotsAndDropsDetachedOnes` fails when the accessor is reverted to active-only (`Expected '2' but got '1'`), and the suite is green again after restoring it.
- The test's first draft asserted against a slot detached *without* the deactivation the tick always pairs with it, and failed. The fixture now mirrors the expiry branch exactly, since asserting against a state the product never produces proves nothing.
- clang-format clean; clang-tidy Tier-1 and Tier-2 clean with 0 compiler errors.
- No live-daemon phases: reproducing this needs 20 searches registered against the daemon to force a ring eviction, which the curl suite has no fixture for. The detach-on-expiry path itself is tick orchestration and is not reachable from the unit tests - the same gap flagged on #1195. The new test pins the accessor, not the tick's use of it.
