### PR TITLE
refactor(amuleapi): rename the clients resource per the naming rules

### DIFF
--- a/docs/api/EVENTS.md
+++ b/docs/api/EVENTS.md
@@ -478,7 +478,7 @@ Identical to the REST [`/api/v0/clients`](REFERENCE.md#get-apiv0clients) list-it
   "port":                   4662,
   "software":               "emule",
   "software_version":       "0.50a",
-  "os_info":                "Linux",
+  "reported_os":                "Linux",
   "upload_state":           "uploading",
   "download_state":         "idle",
   "ident_state":            "identified",
@@ -486,25 +486,23 @@ Identical to the REST [`/api/v0/clients`](REFERENCE.md#get-apiv0clients) list-it
   "download_file_hash":     "",
   "download_file_name":     "",
   "upload_file_name":       "example-distribution.iso",
-  "xfer": {
-    "up_session":   22000000,
-    "down_session": 0,
-    "up_total":     452000000,
-    "down_total":   189000000
-  },
+  "uploaded_bytes_session":   22000000,
+  "downloaded_bytes_session": 0,
+  "uploaded_bytes_total":     452000000,
+  "downloaded_bytes_total":   189000000,
   "upload_speed_bps":       22000,
   "download_speed_bps":     0,
-  "queue_waiting_position": 0,
-  "remote_queue_rank":      0,
-  "score":                  150,
-  "obfuscation_status":     "enabled",
+  "upload_queue_position": 0,
+  "remote_queue_position":      0,
+  "upload_queue_score":                  150,
+  "obfuscation_state":     "enabled",
   "friend_slot":            false,
   "part_progress_percent":  75.0
 }
 ```
-Carries the same field set as the [`/clients`](REFERENCE.md#get-apiv0clients) list row, including `source_origin`, `available_parts`, `mod_version` and `view_shared_disabled`.
+Carries the same field set as the [`/clients`](REFERENCE.md#get-apiv0clients) list row, including `source_origin`, `parts_offered_count`, `client_mod_name` and `shared_files_browsable`.
 
-`part_progress_percent` follows the same rule as on the REST row: it is how much of the file we are downloading **from** this peer the peer already holds, and it is `null` when there is no such file, rather than sent as a negative sentinel. It is derived from `available_parts` and the linked download's part count, so it moves when `available_parts` does, and goes back to `null` if that download goes away. The key is always present -- see [REFERENCE.md's unknown-value rule](REFERENCE.md#unknown-values), under which `null` means "no value" and an absent key means "not reported".
+`part_progress_percent` follows the same rule as on the REST row: it is how much of the file we are downloading **from** this peer the peer already holds, and it is `null` when there is no such file, rather than sent as a negative sentinel. It is derived from `parts_offered_count` and the linked download's part count, so it moves when `parts_offered_count` does, and goes back to `null` if that download goes away. The key is always present -- see [REFERENCE.md's unknown-value rule](REFERENCE.md#unknown-values), under which `null` means "no value" and an absent key means "not reported".
 
 It never carries a `parts` bitmap — those are opt-in on the per-file client routes only, being one boolean per chunk per peer.
 

--- a/docs/api/REFERENCE.md
+++ b/docs/api/REFERENCE.md
@@ -304,7 +304,7 @@ Rows added or removed *during* a sweep are not missed: both emit an SSE event, s
 | `GET /downloads`      | **`hash`** (id), `name`, `size_bytes`, `progress.percent`, `speed_bytes_per_second`, `status` |
 | `GET /clients`        | **`ecid`** (id), `name`, `software` |
 | `GET /downloads/{hash}/clients`<br>`GET /shared/{hash}/clients` | same keys as `/clients`, `after` included |
-| `GET /known_clients`  | **`user_hash`** (id), `name`, `software`, `first_seen`, `last_seen`, `sessions`, `total_uploaded`, `total_downloaded` |
+| `GET /known_clients`  | **`user_hash`** (id), `name`, `software`, `first_seen_at`, `last_seen_at`, `session_count`, `uploaded_bytes_total`, `downloaded_bytes_total` |
 | `GET /shared`         | **`hash`** (id), `name`, `size` |
 | `GET /servers`        | **`ecid`** (id), `name`, `users`, `ping`, `files` |
 | `GET /friends`        | **`ecid`** (id), `name`, `online` |
@@ -344,13 +344,13 @@ A malformed **request** (missing/empty `hashes`, an invalid patch field) is stil
 
 ### Unknown values
 
-A field whose value is not known is `null`, not a sentinel. `remaining_seconds` is `null` rather than `-1` when there is no ETA to compute; `last_upload`, `shared_since` and `last_seen_complete_at` are `null` rather than `0` when a file has never uploaded, has never been seen complete, or its `known.met` entry predates the field. On a peer row, `available_parts` is `null` when that peer has not reported its part map -- distinct from `0`, which is a real answer and what a fresh source looks like -- and `remote_queue_rank` is `null` when the peer's queue is full, which the daemon signals with a `65535` sentinel rather than a position.
+A field whose value is not known is `null`, not a sentinel. `remaining_seconds` is `null` rather than `-1` when there is no ETA to compute; `last_upload`, `shared_since` and `last_seen_complete_at` are `null` rather than `0` when a file has never uploaded, has never been seen complete, or its `known.met` entry predates the field. On a peer row, `parts_offered_count` is `null` when that peer has not reported its part map -- distinct from `0`, which is a real answer and what a fresh source looks like -- and `remote_queue_position` is `null` when the peer's queue is full, which the daemon signals with a `65535` sentinel rather than a position.
 
 A key is **omitted** only where absence itself is the meaning: something the daemon never reported, rather than something known to be absent. `started_at` on [`GET /search`](#get-apiv0search) is the example, missing for a search this process did not start, and `result_count` is missing when the daemon is too old to send it, which has to stay distinguishable from a search that found nothing.
 
 So: `null` means "no value", an absent key means "not reported", and neither is ever spelled `0` or `-1`.
 
-The rule now reaches the whole surface rather than just the download and shared objects. Keys that used to disappear and are `null` instead: `name`, `ip`, `port`, `kad_port`, `country_code`, `software`, `version`, `source_origin`, `obfuscation`, `first_seen` and `sessions` on [`GET /known_clients`](#get-apiv0known_clients); `part_progress_percent` and `available_parts` on the peer rows and the `client_*` events; `client_ecid` on [`GET /search`](#get-apiv0search); `last_message` on [`GET /chats`](#get-apiv0chats); `token`, `label_value` and `extra` on the statistics tree; and `media` everywhere it appears.
+The rule now reaches the whole surface rather than just the download and shared objects. Keys that used to disappear and are `null` instead: `name`, `ip`, `port`, `kad_port`, `country_code`, `software`, `version`, `source_origin`, `obfuscation`, `first_seen` and `sessions` on [`GET /known_clients`](#get-apiv0known_clients); `part_progress_percent` and `parts_offered_count` on the peer rows and the `client_*` events; `client_ecid` on [`GET /search`](#get-apiv0search); `last_message` on [`GET /chats`](#get-apiv0chats); `token`, `label_value` and `extra` on the statistics tree; and `media` everywhere it appears.
 
 `media` is the one place this reaches an **object** rather than a scalar, so a client tests `media === null` before reaching into it -- which it had to do regardless, since the object's own fields can be absent.
 
@@ -626,7 +626,7 @@ curl -s -H "Authorization: Bearer $TOKEN" http://$HOST/api/v0/status
 
 While disconnected `user_id` is `0`, `public_ip` is `""` and `high_id` is `false` — so read `high_id` **together with `state`**: `false` means "LowID" only once `state` is `"connected"`, and means "no id yet" otherwise. The transient `0xffffffff` the daemon sends mid-connect is normalized to `0` and never appears.
 
-**`ed2k.user_id` is not the same encoding as a peer's `user_id_hybrid`.** [`GET /api/v0/clients/{ecid}`](#get-apiv0clientsecid) reports `user_id_hybrid` for a remote peer, and the similar name invites the assumption that the two are interchangeable. They are not. Ours is stored exactly as the server sent it and is read least-significant-byte-first to produce `public_ip`; a peer's HighID is **byte-swapped** on the way in. A consumer that compares the two values, or feeds one through the other's IP decoder, gets a reversed address. The `>= 16777216` HighID threshold *is* common to both; the byte order is not.
+**`ed2k.user_id` is not the same encoding as a client's `ed2k_user_id`.** [`GET /api/v0/clients/{ecid}`](#get-apiv0clientsecid) reports `ed2k_user_id` for a remote client, and the similar name invites the assumption that the two are interchangeable. They are not. Ours is stored exactly as the server sent it and is read least-significant-byte-first to produce `public_ip`; a peer's HighID is **byte-swapped** on the way in. A consumer that compares the two values, or feeds one through the other's IP decoder, gets a reversed address. The `>= 16777216` HighID threshold *is* common to both; the byte order is not.
 
 **Overhead is additive.** `speeds.download_overhead_bps` / `upload_overhead_bps` are protocol and control traffic, counted **separately** from `download_bps` / `upload_bps` rather than being part of them — the desktop shows them as a second figure in parentheses. Both are `0` when the daemon reports nothing.
 
@@ -1224,7 +1224,7 @@ curl -s -H "Authorization: Bearer $TOKEN" \
       "port": 4662,
       "software": "emule",
       "software_version": "0.50a",
-      "os_info": "Linux",
+      "reported_os": "Linux",
       "upload_state": "uploading",
       "download_state": "idle",
       "ident_state": "identified",
@@ -1232,18 +1232,21 @@ curl -s -H "Authorization: Bearer $TOKEN" \
       "upload_file_name": "example-distribution.iso",
       "upload_file_hash": "8b54a3c20fae9e4b9f7e0c2c8c01b6b1",
       "download_file_hash": "",
-      "xfer": { "up_session": 22000000, "down_session": 0, "up_total": 452000000, "down_total": 189000000 },
+      "uploaded_bytes_session": 22000000,
+      "downloaded_bytes_session": 0,
+      "uploaded_bytes_total": 452000000,
+      "downloaded_bytes_total": 189000000,
       "upload_speed_bps": 22000,
       "download_speed_bps": 0,
-      "queue_waiting_position": 0,
-      "remote_queue_rank": 0,
+      "upload_queue_position": 0,
+      "remote_queue_position": 0,
       "score": 150,
-      "obfuscation_status": "enabled",
+      "obfuscation_state": "enabled",
       "friend_slot": false,
       "source_origin": "kad",
-      "available_parts": 42,
-      "mod_version": "",
-      "view_shared_disabled": false,
+      "parts_offered_count": 42,
+      "client_mod_name": "",
+      "shared_files_browsable": false,
       "part_progress_percent": 87.5
     }
   ]
@@ -1256,7 +1259,7 @@ The last five were originally detail-only and were promoted onto this row (and o
 
 `upload_file_hash` / `download_file_hash` are the 32-char MD4 hex hashes of the partfile or shared file the peer is currently transferring with — directly resolvable against [`/api/v0/downloads/{hash}`](#get-apiv0downloadshash) (in-progress) or the corresponding entry in [`/api/v0/shared`](#get-apiv0shared) by `.hash`. Either field can be empty when the peer is queued / idle in that direction. `download_file_name` is the filename the peer advertised in `OP_REQFILENAMEANSWER` and is populated only while we're actively downloading from them. `upload_file_name` is the partfile the peer is downloading **from us**, resolved locally against our own partfile list — present only while we're uploading to them.
 
-`software` and `software_version` are locale-independent, per the API's English-only contract. `software` is one of the tokens in the enumerated-fields table below; `software_version` is a free-form string. A peer the daemon could not identify reports `"software": "unknown"` and `"software_version": "unknown"` — a lowercase sentinel, never a daemon-localized string (the daemon's own version formatting is gettext-translated and is deliberately not surfaced here). `os_info` is the peer's *own* self-reported OS string (raw external data, not normalized by amuled) and is frequently empty, since most clients don't send it.
+`software` and `software_version` are locale-independent, per the API's English-only contract. `software` is one of the tokens in the enumerated-fields table below; `software_version` is a free-form string. A peer the daemon could not identify reports `"software": "unknown"` and `"software_version": "unknown"` — a lowercase sentinel, never a daemon-localized string (the daemon's own version formatting is gettext-translated and is deliberately not surfaced here). `reported_os` is the peer's *own* self-reported OS string (raw external data, not normalized by amuled) and is frequently empty, since most clients don't send it.
 
 `ident_state` is the peer's secure-identification (SecIdent) state, one of `"not_available"` (the peer does not support SecIdent, or this build has no crypto), `"id_needed"` (its public key is known but the signature exchange has not completed), `"identified"` (verified), `"id_failed"` (signature verification failed), `"bad_guy"` (verified earlier, but currently connecting from a *different* IP than the one it was verified on) or `"unknown"` (state not yet reported for a newly seen peer). `"bad_guy"` is also briefly reported for a legitimate peer that reconnected after an IP change and has not re-identified yet, so treat it as a hint rather than a verdict.
 
@@ -1267,11 +1270,11 @@ The last five were originally detail-only and were promoted onto this row (and o
 | `upload_state` | `uploading`, `queued`, `waitcallback`, `connecting`, `pending`, `lowtolowip`, `banned`, `error`, `idle`, `unknown` |
 | `download_state` | `downloading`, `onqueue`, `connected`, `connecting`, `waitcallback`, `waitcallbackkad`, `reqhashset`, `noneededparts`, `toomanyconns`, `toomanyconnskad`, `lowtolowip`, `banned`, `error`, `idle`, `remotequeuefull`, `unknown` |
 | `ident_state` | `not_available`, `id_needed`, `identified`, `id_failed`, `bad_guy`, `unknown` |
-| `obfuscation_status` | `undefined`, `enabled`, `supported`, `not_supported`, `disabled`, `unknown` |
+| `obfuscation_state` | `undefined`, `enabled`, `supported`, `not_supported`, `disabled`, `unknown` |
 | `software` | `emule`, `cdonkey`, `lxmule`, `amule`, `shareaza`, `emule_plus`, `hydranode`, `mldonkey`, `lphant`, `edonkey_hybrid`, `edonkey`, `old_emule`, `compat`, `unknown` |
 | `source_origin` | `server`, `kad`, `source_exchange`, `passive`, `link`, `source_seeds`, `search_result`, `unknown` |
 
-Every one of them falls back to `"unknown"` for a code the daemon does not map, so a client can treat `"unknown"` as its default branch and never has to handle an absent or unexpected token. Note the two distinct sentinels on `obfuscation_status`: `"undefined"` is *the peer has not told us yet*, `"unknown"` is *the daemon received a code it does not recognise*. The authoritative mappings are the `Client*Name()` / `SourceOriginName()` functions in `src/webapi/Refresher.cpp`.
+Every one of them falls back to `"unknown"` for a code the daemon does not map, so a client can treat `"unknown"` as its default branch and never has to handle an absent or unexpected token. Note the two distinct sentinels on `obfuscation_state`: `"undefined"` is *the peer has not told us yet*, `"unknown"` is *the daemon received a code it does not recognise*. The authoritative mappings are the `Client*Name()` / `SourceOriginName()` functions in `src/webapi/Refresher.cpp`.
 
 `country_code` is the peer's ISO 3166-1 alpha-2 country code (lowercase, e.g. `"de"`), resolved server-side from the peer IP by the daemon's GeoIP database. It is an empty string when GeoIP is disabled or unsupported by the build, or when the IP does not resolve — render the flag and localized country name client-side from the code. The flag image is served by [`GET /flags/{code}.png`](#get-flagscodepng); the localized name has no endpoint because the browser already has it (`Intl.DisplayNames` with `{ type: "region" }`).
 
@@ -1302,22 +1305,25 @@ curl -s -H "Authorization: Bearer $TOKEN" \
   "port": 4662,
   "software": "emule",
   "software_version": "0.50a",
-  "os_info": "Linux",
+  "reported_os": "Linux",
   "upload_state": "uploading",
   "download_state": "idle",
   "ident_state": "identified",
   "download_file_name": "",
   "upload_file_hash": "8b54a3c20fae9e4b9f7e0c2c8c01b6b1",
   "download_file_hash": "",
-  "xfer": { "up_session": 22000000, "down_session": 0, "up_total": 452000000, "down_total": 189000000 },
+  "uploaded_bytes_session": 22000000,
+      "downloaded_bytes_session": 0,
+      "uploaded_bytes_total": 452000000,
+      "downloaded_bytes_total": 189000000,
   "upload_speed_bps": 22000,
   "download_speed_bps": 0,
-  "queue_waiting_position": 0,
-  "remote_queue_rank": 0,
+  "upload_queue_position": 0,
+  "remote_queue_position": 0,
   "score": 150,
-  "obfuscation_status": "enabled",
+  "obfuscation_state": "enabled",
   "friend_slot": false,
-  "user_id_hybrid": 3232238090,
+  "ed2k_user_id": 3232238090,
   "high_id": true,
   "server_ip": "203.0.113.9",
   "server_port": 4242,
@@ -1325,18 +1331,18 @@ curl -s -H "Authorization: Bearer $TOKEN" \
   "kad_port": 4672,
   "source_origin": "kad",
   "upload_file_name": "example-distribution.iso",
-  "available_parts": 42,
-  "mod_version": "",
-  "view_shared_disabled": false,
-  "is_friend": false,
-  "dl_up_modifier": 1.0,
+  "parts_offered_count": 42,
+  "client_mod_name": "",
+  "shared_files_browsable": false,
+  "friend": false,
+  "credit_ratio": 1.0,
   "part_progress_percent": 87.5
 }
 ```
 
-The detail fields mirror the desktop "Client Details" modal. Five of the fields below — `source_origin`, `available_parts`, `mod_version`, `view_shared_disabled` and `part_progress_percent` — are **not** detail-only: they are on the [`GET /clients`](#get-apiv0clients) row and the SSE payload too, and are described here because this is where the rest of their neighbours live. `user_id_hybrid` is the peer's hybrid eD2k id; `high_id` is `true` for a HighID peer (id ≥ `16777216`, i.e. `0x1000000`) and `false` for LowID — the same threshold and the same spelling as `ed2k.high_id` on [`GET /status`](#get-apiv0status), so the value means the same thing on both ends of the API. `server_ip` / `server_port` / `server_name` describe the eD2k server the peer connects through (`server_ip` is `""` when unknown). `kad_port` is non-zero when the peer is reachable on Kad. `source_origin` is how the peer was discovered (values in the enumerated-fields table under [`GET /clients`](#get-apiv0clients)). (`upload_file_name` is part of the base field set — see [`GET /clients`](#get-apiv0clients) above.) `available_parts` is the count of parts the peer holds of the linked file, or `null` when the peer has not reported a part map (see [Unknown values](#unknown-values)); `mod_version` is the peer's client-mod string (often `""`); `view_shared_disabled` is `true` when the peer forbids browsing its shared files. `is_friend` is `true` when the peer is in your friends list (`CUpDownClient::IsFriend()`) — **distinct** from `friend_slot`, which is a *reserved upload slot* granted to a peer and can be set for non-friends. `dl_up_modifier` is the upload score modifier the GUI labels "DL/UP modifier" (`GetScoreRatio()`). `part_progress_percent` is the peer's completeness of the file we are downloading **from** them (`available_parts` over that file's part count) and is `null` when there is no linked download or the part count is unknown (see [Unknown values](#unknown-values)).
+The detail fields mirror the desktop "Client Details" modal. Five of the fields below — `source_origin`, `parts_offered_count`, `client_mod_name`, `shared_files_browsable` and `part_progress_percent` — are **not** detail-only: they are on the [`GET /clients`](#get-apiv0clients) row and the SSE payload too, and are described here because this is where the rest of their neighbours live. `ed2k_user_id` is the peer's hybrid eD2k id; `high_id` is `true` for a HighID peer (id ≥ `16777216`, i.e. `0x1000000`) and `false` for LowID — the same threshold and the same spelling as `ed2k.high_id` on [`GET /status`](#get-apiv0status), so the value means the same thing on both ends of the API. `server_ip` / `server_port` / `server_name` describe the eD2k server the peer connects through (`server_ip` is `""` when unknown). `kad_port` is non-zero when the peer is reachable on Kad. `source_origin` is how the peer was discovered (values in the enumerated-fields table under [`GET /clients`](#get-apiv0clients)). (`upload_file_name` is part of the base field set — see [`GET /clients`](#get-apiv0clients) above.) `parts_offered_count` is the count of parts the peer holds of the linked file, or `null` when the peer has not reported a part map (see [Unknown values](#unknown-values)); `client_mod_name` is the peer's client-mod string (often `""`); `shared_files_browsable` is `true` when the peer forbids browsing its shared files. `friend` is `true` when the peer is in your friends list (`CUpDownClient::IsFriend()`) — **distinct** from `friend_slot`, which is a *reserved upload slot* granted to a peer and can be set for non-friends. `credit_ratio` is the upload score modifier the GUI labels "DL/UP modifier" (`GetScoreRatio()`). `part_progress_percent` is the peer's completeness of the file we are downloading **from** them (`parts_offered_count` over that file's part count) and is `null` when there is no linked download or the part count is unknown (see [Unknown values](#unknown-values)).
 
-> `is_friend` and `dl_up_modifier` ride two EC tags added for this endpoint. A webapi built against a newer core talking to an **older** amuled that doesn't send them degrades gracefully — `is_friend` reads `false` and `dl_up_modifier` reads `0`.
+> `friend` and `credit_ratio` ride two EC tags added for this endpoint. A webapi built against a newer core talking to an **older** amuled that doesn't send them degrades gracefully — `friend` reads `false` and `credit_ratio` reads `0`.
 
 **Errors:** `400 bad_request` (`{ecid}` is not a non-negative integer), `404 not_found` (no peer with that ecid in the current snapshot), `405 method_not_allowed` (non-GET), `503 ec_unavailable`.
 
@@ -1421,8 +1427,8 @@ curl -s -H "Authorization: Bearer $TOKEN" \
       "version": "v2.3.1",
       "source_origin": "kad",
       "obfuscation": "supported",
-      "total_uploaded": 0,
-      "total_downloaded": 0,
+      "uploaded_bytes_total": 0,
+      "downloaded_bytes_total": 0,
       "last_seen": 1786652714,
       "first_seen": 1786652714,
       "sessions": 1,
@@ -1442,7 +1448,7 @@ curl -s -H "Authorization: Bearer $TOKEN" \
 | `software`, `version` | Same tokens `GET /clients` uses. Absent together. |
 | `source_origin` | How the peer was first found — `server`, `kad`, `source_exchange`, `passive`, … |
 | `obfuscation` | Protocol-obfuscation state as of the last session. |
-| `total_uploaded`, `total_downloaded` | Lifetime bytes, from the credit record. Always present. |
+| `uploaded_bytes_total`, `downloaded_bytes_total` | Lifetime bytes, from the credit record. Always present. |
 | `last_seen` | Unix seconds. Always present. For a peer that is connected this is *now* — it is being seen — so the connected records are the most recent in the store under `sort=last_seen&order=desc`. A peer that left during the current tick carries the same timestamp and ties with them; ties keep a stable order across requests. |
 | `first_seen`, `sessions` | Present together, and only for a record the daemon holds metadata for. |
 | `online` | Whether this peer is connected right now, correlated by `user_hash`. |
@@ -1452,7 +1458,7 @@ curl -s -H "Authorization: Bearer $TOKEN" \
 The store is read from the daemon **once**, on the first request, and maintained from there: every refresher tick folds the connected peers back in, so later requests never touch EC at all. That is sound rather than a shortcut — a record whose peer is not connected cannot change, since credit totals only move during a transfer and `last_seen` is written at disconnect. What the maintenance covers:
 
 - a peer that connects is added, with `first_seen` and `sessions` set to what the daemon recorded when it said hello;
-- a connected peer's `online`, `total_uploaded` and `total_downloaded` track the live client state;
+- a connected peer's `online`, `uploaded_bytes_total` and `downloaded_bytes_total` track the live client state;
 - a bare record gains its name, address, software and origin once its peer identifies;
 - a connected peer's `last_seen` is now, and a peer that leaves has `online` cleared with `last_seen` stamped at the moment it went.
 
@@ -1999,7 +2005,7 @@ The friends list amuled persists to `emfriends.met`. The daemon ships the whole 
 
 `client_ecid` is the live peer this friend is currently linked to, joinable against [`GET /api/v0/clients`](#get-apiv0clients), and `0` when the friend is offline — `online` is the convenience form of that test. `user_hash` is `""` for a friend added by address only, and `ip` is `""` for a zero address.
 
-`friend_slot` reads `false` against a daemon predating the tag that carries it, the same way `is_friend` and `dl_up_modifier` degrade on `/clients`.
+`friend_slot` reads `false` against a daemon predating the tag that carries it, the same way `friend` and `credit_ratio` degrade on `/clients`.
 
 **Errors:** `503 ec_unavailable`.
 

--- a/src/webapi/Api.cpp
+++ b/src/webapi/Api.cpp
@@ -2592,7 +2592,7 @@ CHttpServer::Response CApiDispatcher::HandleStatus(const CHttpServer::Request &r
 	// Our server-assigned id; a HighID (>= 16777216) is our public address
 	// packed LSB-first, which is where public_ip comes from. Both are 0 /
 	// empty while disconnected. Not the same encoding as the peer-side
-	// user_id_hybrid on /clients/{ecid}: that one byte-swaps a HighID, so
+	// ed2k_user_id on /clients/{ecid}: that one byte-swaps a HighID, so
 	// the two must not be compared or fed through each other's decoder.
 	w.Key("user_id");
 	w.ValueInt(static_cast<int64_t>(s.ed2k_user_id));
@@ -2967,14 +2967,13 @@ void WriteClientBaseFields(CJsonWriter &w, const webapi::ClientSnapshot &c)
 	w.Key("port");
 	w.ValueInt(static_cast<int64_t>(c.port));
 	// ISO 3166-1 alpha-2 (lowercase); "" when GeoIP is off/unresolved (#439).
-	w.Key("country_code");
-	w.ValueString(wxString::FromUTF8(c.country_code.c_str()));
+	WriteStringOrNull(w, "country_code", !c.country_code.empty(), c.country_code);
 	w.Key("software");
 	w.ValueString(wxString::FromUTF8(c.software.c_str()));
 	w.Key("software_version");
 	w.ValueString(wxString::FromUTF8(c.software_version.c_str()));
-	w.Key("os_info");
-	w.ValueString(wxString::FromUTF8(c.os_info.c_str()));
+	w.Key("reported_os");
+	w.ValueString(wxString::FromUTF8(c.reported_os.c_str()));
 	w.Key("upload_state");
 	w.ValueString(wxString::FromUTF8(c.upload_state.c_str()));
 	w.Key("download_state");
@@ -2989,36 +2988,37 @@ void WriteClientBaseFields(CJsonWriter &w, const webapi::ClientSnapshot &c)
 	w.ValueString(wxString::FromUTF8(c.upload_file_hash.c_str()));
 	w.Key("download_file_hash");
 	w.ValueString(wxString::FromUTF8(c.download_file_hash.c_str()));
-	w.Key("xfer");
-	w.BeginObject();
-	w.Key("up_session");
-	w.ValueInt(static_cast<int64_t>(c.xfer_up_session));
-	w.Key("down_session");
-	w.ValueInt(static_cast<int64_t>(c.xfer_down_session));
-	w.Key("up_total");
-	w.ValueInt(static_cast<int64_t>(c.xfer_up_total));
-	w.Key("down_total");
-	w.ValueInt(static_cast<int64_t>(c.xfer_down_total));
-	w.EndObject();
+	// R11: flattened out of the old `xfer` wrapper. A sub-object earns its
+	// place by grouping DIFFERENT quantities; this grouped one quantity split
+	// by time window, which belongs in the key. It also meant `xfer` named a
+	// 4-field up/down pair here and an upload-only pair on /shared.
+	w.Key("uploaded_bytes_session");
+	w.ValueInt(static_cast<int64_t>(c.uploaded_bytes_session));
+	w.Key("downloaded_bytes_session");
+	w.ValueInt(static_cast<int64_t>(c.downloaded_bytes_session));
+	w.Key("uploaded_bytes_total");
+	w.ValueInt(static_cast<int64_t>(c.uploaded_bytes_total));
+	w.Key("downloaded_bytes_total");
+	w.ValueInt(static_cast<int64_t>(c.downloaded_bytes_total));
 	w.Key("upload_speed_bps");
 	w.ValueInt(static_cast<int64_t>(c.upload_speed_bps));
 	w.Key("download_speed_bps");
 	w.ValueInt(static_cast<int64_t>(c.download_speed_bps));
-	w.Key("queue_waiting_position");
-	w.ValueInt(static_cast<int64_t>(c.queue_waiting_position));
+	w.Key("upload_queue_position");
+	w.ValueInt(static_cast<int64_t>(c.upload_queue_position));
 	// 0xffff is amuled's "that peer's queue is full" sentinel
 	// (ECSpecialCoreTags.cpp: IsRemoteQueueFull() ? 0xffff : rank), not a
 	// position. Relayed verbatim it renders as "position 65535", and a client
 	// sorting by queue position buries full queues at the far end as though
 	// they were merely very distant.
 	WriteIntOrNull(w,
-		"remote_queue_rank",
-		c.remote_queue_rank != webapi::kRemoteQueueFullSentinel,
-		static_cast<int64_t>(c.remote_queue_rank));
-	w.Key("score");
+		"remote_queue_position",
+		c.remote_queue_position != webapi::kRemoteQueueFullSentinel,
+		static_cast<int64_t>(c.remote_queue_position));
+	w.Key("upload_queue_score");
 	w.ValueInt(static_cast<int64_t>(c.score));
-	w.Key("obfuscation_status");
-	w.ValueString(wxString::FromUTF8(c.obfuscation_status.c_str()));
+	w.Key("obfuscation_state");
+	w.ValueString(wxString::FromUTF8(c.obfuscation_state.c_str()));
 	w.Key("friend_slot");
 	w.ValueBool(c.friend_slot);
 	// Promoted out of the detail object (issue #984): the desktop's per-file
@@ -3033,11 +3033,16 @@ void WriteClientBaseFields(CJsonWriter &w, const webapi::ClientSnapshot &c)
 	// indistinguishable from one reporting zero parts -- and zero is a real
 	// answer here, being what a fresh source looks like before its map turns
 	// up.
-	WriteIntOrNull(w, "available_parts", c.has_available_parts, static_cast<int64_t>(c.available_parts));
-	w.Key("mod_version");
-	w.ValueString(wxString::FromUTF8(c.mod_version.c_str()));
-	w.Key("view_shared_disabled");
-	w.ValueBool(c.view_shared_disabled);
+	WriteIntOrNull(w,
+		"parts_offered_count",
+		c.has_parts_offered_count,
+		static_cast<int64_t>(c.parts_offered_count));
+	w.Key("client_mod_name");
+	w.ValueString(wxString::FromUTF8(c.client_mod_name.c_str()));
+	// Inverted from the old `view_shared_disabled`: a negated boolean forces
+	// `=== false` at every call site, and R4 wants the positive form.
+	w.Key("shared_files_browsable");
+	w.ValueBool(!c.view_shared_disabled);
 	// null, not omitted, when there is no linked download to be a fraction
 	// of. -1 is the in-process sentinel and never reaches the wire.
 	w.Key("part_progress_percent");
@@ -3126,18 +3131,19 @@ void WriteKnownClientObject(CJsonWriter &w, const webapi::KnownClientSnapshot &c
 	WriteStringOrNull(w, "country_code", !c.country_code.empty(), c.country_code);
 	const bool has_software = !c.software.empty();
 	WriteStringOrNull(w, "software", has_software, c.software);
-	WriteStringOrNull(w, "version", has_software, c.version);
+	WriteStringOrNull(w, "software_version", has_software, c.version);
 	WriteStringOrNull(w, "source_origin", !c.source_origin.empty(), c.source_origin);
-	WriteStringOrNull(w, "obfuscation", !c.obfuscation.empty(), c.obfuscation);
-	w.Key("total_uploaded");
+	WriteStringOrNull(w, "obfuscation_state", !c.obfuscation.empty(), c.obfuscation);
+	// Same quantity as the live /clients row, so the same key (R6).
+	w.Key("uploaded_bytes_total");
 	w.ValueUInt(static_cast<uint64_t>(c.total_uploaded));
-	w.Key("total_downloaded");
+	w.Key("downloaded_bytes_total");
 	w.ValueUInt(static_cast<uint64_t>(c.total_downloaded));
-	w.Key("last_seen");
+	w.Key("last_seen_at");
 	w.ValueUInt(static_cast<uint64_t>(c.last_seen));
 	const bool has_first_seen = c.first_seen != 0;
-	WriteUIntOrNull(w, "first_seen", has_first_seen, static_cast<uint64_t>(c.first_seen));
-	WriteUIntOrNull(w, "sessions", has_first_seen, static_cast<uint64_t>(c.sessions));
+	WriteUIntOrNull(w, "first_seen_at", has_first_seen, static_cast<uint64_t>(c.first_seen));
+	WriteUIntOrNull(w, "session_count", has_first_seen, static_cast<uint64_t>(c.sessions));
 	// Correlate with /clients by user_hash to reach the live peer.
 	w.Key("online");
 	w.ValueBool(c.online);
@@ -3151,8 +3157,8 @@ void WriteClientDetailObject(CJsonWriter &w, const webapi::ClientSnapshot &c)
 {
 	w.BeginObject();
 	WriteClientBaseFields(w, c);
-	w.Key("user_id_hybrid");
-	w.ValueUInt(static_cast<uint64_t>(c.user_id_hybrid));
+	w.Key("ed2k_user_id");
+	w.ValueUInt(static_cast<uint64_t>(c.ed2k_user_id));
 	w.Key("high_id");
 	w.ValueBool(c.high_id);
 	w.Key("server_ip");
@@ -3163,13 +3169,17 @@ void WriteClientDetailObject(CJsonWriter &w, const webapi::ClientSnapshot &c)
 	w.ValueString(wxString::FromUTF8(c.server_name.c_str()));
 	w.Key("kad_port");
 	w.ValueInt(static_cast<int64_t>(c.kad_port));
-	// Friend status + DL/UP modifier (issue #423). is_friend is
-	// friends-list membership, distinct from the friend_slot reserved
+	// Friend status + the credit-system modifier (issue #423). `friend` is
+	// friends-list membership, distinct from the `friend_slot` reserved
 	// upload slot above.
-	w.Key("is_friend");
+	//
+	// The key drops the `is_` prefix per R4; the C++ member cannot follow it,
+	// because `friend` is a keyword. This is the one place on the surface
+	// where key and member deliberately differ.
+	w.Key("friend");
 	w.ValueBool(c.is_friend);
-	w.Key("dl_up_modifier");
-	w.ValueDouble(c.dl_up_modifier);
+	w.Key("credit_ratio");
+	w.ValueDouble(c.credit_ratio);
 	w.EndObject();
 }
 
@@ -4122,7 +4132,7 @@ namespace
 struct FileClientRow
 {
 	webapi::ClientSnapshot client;
-	std::string role; // "source" | "peer" | "both" | "none"
+	std::string role; // "downloading_from" | "uploading_to" | "both" | "none"
 	bool a4af = false;
 	std::vector<bool> parts;
 	bool has_parts = false;
@@ -4161,10 +4171,11 @@ void WriteFileClientRow(CJsonWriter &w, const FileClientRow &row)
 {
 	w.BeginObject();
 	WriteClientBaseFields(w, row.client);
-	// The peer's relation to THIS file, which the global /clients row cannot
-	// express: "source" serves it to us, "peer" pulls it from us, "both" does
-	// each way, "none" is a row that exists only because it is parked here as
-	// an A4AF source.
+	// This client's relation to THIS file, which the global /clients row
+	// cannot express: "downloading_from" means we pull the file from it,
+	// "uploading_to" means it pulls the file from us, "both" is each way, and
+	// "none" is a row that exists only because it is parked here as an A4AF
+	// source.
 	w.Key("role");
 	w.ValueString(wxString::FromUTF8(row.role.c_str()));
 	// Orthogonal to role on purpose: a peer can be parked on another file and
@@ -4260,8 +4271,13 @@ CHttpServer::Response CApiDispatcher::HandleFileClients(
 		}
 
 		FileClientRow row;
-		row.role =
-			is_source && is_peer ? "both" : (is_source ? "source" : (is_peer ? "peer" : "none"));
+		// R12: named by direction. The old pair was `source` / `peer`, which is
+		// not even one axis -- `source` names a relation to the file, `peer`
+		// names the entity -- and `peer` was the last contract-level use of that
+		// word outside /chats.
+		row.role = is_source && is_peer
+				   ? "both"
+				   : (is_source ? "downloading_from" : (is_peer ? "uploading_to" : "none"));
 		row.a4af = is_a4af;
 		ComputePartProgressPercent(m_state, client);
 		if (include_parts) {
@@ -6057,11 +6073,12 @@ CHttpServer::Response CApiDispatcher::HandleKnownClients(const CHttpServer::Requ
 		{ "user_hash", SORT_BY(user_hash), ANCHOR_ON(user_hash) },
 		{ "name", SORT_BY(client_name) },
 		{ "software", SORT_BY(software) },
-		{ "first_seen", SORT_BY(first_seen) },
-		{ "last_seen", SORT_BY(last_seen) },
-		{ "sessions", SORT_BY(sessions) },
-		{ "total_uploaded", SORT_BY(total_uploaded) },
-		{ "total_downloaded", SORT_BY(total_downloaded) },
+		// R7: each value is spelled exactly like the response key it orders by.
+		{ "first_seen_at", SORT_BY(first_seen) },
+		{ "last_seen_at", SORT_BY(last_seen) },
+		{ "session_count", SORT_BY(sessions) },
+		{ "uploaded_bytes_total", SORT_BY(total_uploaded) },
+		{ "downloaded_bytes_total", SORT_BY(total_downloaded) },
 	};
 
 	// Built under the state's read lock: the store is never copied out, so the

--- a/src/webapi/EventDiff.cpp
+++ b/src/webapi/EventDiff.cpp
@@ -261,32 +261,40 @@ std::string ToJson(const ClientSnapshot &c)
 	  << "\"ecid\":" << c.ecid << ",\"name\":\"" << EscJson(c.client_name) << "\""
 	  << ",\"user_hash\":\"" << EscJson(c.user_hash) << "\""
 	  << ",\"ip\":\"" << EscJson(c.ip) << "\""
-	  << ",\"country_code\":\"" << EscJson(c.country_code) << "\""
+	  << ",\"country_code\":"
+	  // null, not "", when the lookup has not resolved -- the REST row this
+	  // event promises key parity with emits null here.
+	  << (c.country_code.empty() ? std::string("null") : "\"" + EscJson(c.country_code) + "\"")
 	  << ",\"port\":" << c.port << ",\"software\":\"" << EscJson(c.software) << "\""
 	  << ",\"software_version\":\"" << EscJson(c.software_version) << "\""
-	  << ",\"os_info\":\"" << EscJson(c.os_info) << "\""
+	  << ",\"reported_os\":\"" << EscJson(c.reported_os) << "\""
 	  << ",\"upload_state\":\"" << EscJson(c.upload_state) << "\""
 	  << ",\"download_state\":\"" << EscJson(c.download_state) << "\""
 	  << ",\"ident_state\":\"" << EscJson(c.ident_state) << "\""
 	  << ",\"download_file_name\":\"" << EscJson(c.download_file_name) << "\""
 	  << ",\"upload_file_name\":\"" << EscJson(c.upload_file_name) << "\""
 	  << ",\"upload_file_hash\":\"" << EscJson(c.upload_file_hash) << "\""
-	  << ",\"download_file_hash\":\"" << EscJson(c.download_file_hash) << "\""
-	  << ",\"xfer\":{"
-	  << "\"up_session\":" << c.xfer_up_session << ",\"down_session\":" << c.xfer_down_session
-	  << ",\"up_total\":" << c.xfer_up_total << ",\"down_total\":" << c.xfer_down_total << "}"
+	  << ",\"download_file_hash\":\"" << EscJson(c.download_file_hash)
+	  << "\""
+	  // Flattened out of the old `xfer` wrapper (R11), same as the REST row
+	  // this payload promises key parity with.
+	  << ",\"uploaded_bytes_session\":" << c.uploaded_bytes_session
+	  << ",\"downloaded_bytes_session\":" << c.downloaded_bytes_session
+	  << ",\"uploaded_bytes_total\":" << c.uploaded_bytes_total
+	  << ",\"downloaded_bytes_total\":" << c.downloaded_bytes_total
 	  << ",\"upload_speed_bps\":" << c.upload_speed_bps
 	  << ",\"download_speed_bps\":" << c.download_speed_bps
-	  << ",\"queue_waiting_position\":" << c.queue_waiting_position << ",\"remote_queue_rank\":"
-	  << (c.remote_queue_rank == kRemoteQueueFullSentinel ? std::string("null")
-							      : std::to_string(c.remote_queue_rank))
-	  << ",\"score\":" << c.score << ",\"obfuscation_status\":\"" << EscJson(c.obfuscation_status) << "\""
+	  << ",\"upload_queue_position\":" << c.upload_queue_position << ",\"remote_queue_position\":"
+	  << (c.remote_queue_position == kRemoteQueueFullSentinel ? std::string("null")
+								  : std::to_string(c.remote_queue_position))
+	  << ",\"upload_queue_score\":" << c.score << ",\"obfuscation_state\":\""
+	  << EscJson(c.obfuscation_state) << "\""
 	  << ",\"friend_slot\":" << (c.friend_slot ? "true" : "false") << ",\"source_origin\":\""
 	  << EscJson(c.source_origin) << "\""
-	  << ",\"available_parts\":"
-	  << (c.has_available_parts ? std::to_string(c.available_parts) : std::string("null"))
-	  << ",\"mod_version\":\"" << EscJson(c.mod_version) << "\""
-	  << ",\"view_shared_disabled\":" << (c.view_shared_disabled ? "true" : "false");
+	  << ",\"parts_offered_count\":"
+	  << (c.has_parts_offered_count ? std::to_string(c.parts_offered_count) : std::string("null"))
+	  << ",\"client_mod_name\":\"" << EscJson(c.client_mod_name) << "\""
+	  << ",\"shared_files_browsable\":" << (c.view_shared_disabled ? "false" : "true");
 	// null, not omitted, matching the REST row: the field only means
 	// something for a peer we are downloading from, and -1 is the
 	// in-process sentinel that must never reach the wire. Formatted
@@ -480,23 +488,25 @@ bool Equal(const ClientSnapshot &a, const ClientSnapshot &b)
 {
 	return a.client_name == b.client_name && a.user_hash == b.user_hash && a.ip == b.ip &&
 	       a.country_code == b.country_code && a.port == b.port && a.software == b.software &&
-	       a.software_version == b.software_version && a.os_info == b.os_info &&
+	       a.software_version == b.software_version && a.reported_os == b.reported_os &&
 	       a.upload_state == b.upload_state && a.download_state == b.download_state &&
 	       a.ident_state == b.ident_state && a.download_file_name == b.download_file_name &&
 	       a.upload_file_name == b.upload_file_name && a.upload_file_hash == b.upload_file_hash &&
-	       a.download_file_hash == b.download_file_hash && a.xfer_up_session == b.xfer_up_session &&
-	       a.xfer_down_session == b.xfer_down_session && a.xfer_up_total == b.xfer_up_total &&
-	       a.xfer_down_total == b.xfer_down_total && a.upload_speed_bps == b.upload_speed_bps &&
-	       a.download_speed_bps == b.download_speed_bps &&
-	       a.queue_waiting_position == b.queue_waiting_position &&
-	       a.remote_queue_rank == b.remote_queue_rank && a.score == b.score &&
-	       a.obfuscation_status == b.obfuscation_status && a.friend_slot == b.friend_slot &&
-	       a.source_origin == b.source_origin && a.available_parts == b.available_parts &&
+	       a.download_file_hash == b.download_file_hash &&
+	       a.uploaded_bytes_session == b.uploaded_bytes_session &&
+	       a.downloaded_bytes_session == b.downloaded_bytes_session &&
+	       a.uploaded_bytes_total == b.uploaded_bytes_total &&
+	       a.downloaded_bytes_total == b.downloaded_bytes_total &&
+	       a.upload_speed_bps == b.upload_speed_bps && a.download_speed_bps == b.download_speed_bps &&
+	       a.upload_queue_position == b.upload_queue_position &&
+	       a.remote_queue_position == b.remote_queue_position && a.score == b.score &&
+	       a.obfuscation_state == b.obfuscation_state && a.friend_slot == b.friend_slot &&
+	       a.source_origin == b.source_origin && a.parts_offered_count == b.parts_offered_count &&
 	       // Without the flag, null -> 0 (the part map arriving and reporting
 	       // zero) compares equal and the row never updates.
-	       a.has_available_parts == b.has_available_parts && a.mod_version == b.mod_version &&
-	       a.view_shared_disabled == b.view_shared_disabled &&
-	       // Derived from available_parts and the linked file's part count,
+	       a.has_parts_offered_count == b.has_parts_offered_count &&
+	       a.client_mod_name == b.client_mod_name && a.view_shared_disabled == b.view_shared_disabled &&
+	       // Derived from parts_offered_count and the linked file's part count,
 	       // so it normally moves only when a compared field does. The case
 	       // that needs it in its own right is the file going away: the
 	       // percent drops back to its sentinel while every other field

--- a/src/webapi/Refresher.cpp
+++ b/src/webapi/Refresher.cpp
@@ -869,11 +869,11 @@ void MergeClientTag(const CEC_UpDownClient_Tag *c, ClientSnapshot &cs, bool is_n
 	if (cs.software_version.empty()) {
 		cs.software_version = "unknown";
 	}
-	// os_info is the peer's own self-reported OS string (raw external data,
+	// reported_os is the peer's own self-reported OS string (raw external data,
 	// not gettext-translated by our daemon), so it carries no locale-leak;
 	// it is frequently empty because most clients don't send it.
 	if (const CECTag *t = c->GetTagByName(EC_TAG_CLIENT_OS_INFO)) {
-		cs.os_info = std::string(t->GetStringData().utf8_str());
+		cs.reported_os = std::string(t->GetStringData().utf8_str());
 	}
 	{
 		std::uint8_t v = 0;
@@ -961,24 +961,24 @@ void MergeClientTag(const CEC_UpDownClient_Tag *c, ClientSnapshot &cs, bool is_n
 		}
 	}
 	{
-		std::uint64_t v = cs.xfer_up_session;
+		std::uint64_t v = cs.uploaded_bytes_session;
 		if (c->AssignIfExist(EC_TAG_CLIENT_UPLOAD_SESSION, v))
-			cs.xfer_up_session = v;
+			cs.uploaded_bytes_session = v;
 	}
 	{
-		std::uint64_t v = cs.xfer_down_session;
+		std::uint64_t v = cs.downloaded_bytes_session;
 		if (c->AssignIfExist(EC_TAG_PARTFILE_SIZE_XFER, v))
-			cs.xfer_down_session = v;
+			cs.downloaded_bytes_session = v;
 	}
 	{
-		std::uint64_t v = cs.xfer_up_total;
+		std::uint64_t v = cs.uploaded_bytes_total;
 		if (c->AssignIfExist(EC_TAG_CLIENT_UPLOAD_TOTAL, v))
-			cs.xfer_up_total = v;
+			cs.uploaded_bytes_total = v;
 	}
 	{
-		std::uint64_t v = cs.xfer_down_total;
+		std::uint64_t v = cs.downloaded_bytes_total;
 		if (c->AssignIfExist(EC_TAG_CLIENT_DOWNLOAD_TOTAL, v))
-			cs.xfer_down_total = v;
+			cs.downloaded_bytes_total = v;
 	}
 	{
 		std::uint32_t v = cs.upload_speed_bps;
@@ -996,14 +996,14 @@ void MergeClientTag(const CEC_UpDownClient_Tag *c, ClientSnapshot &cs, bool is_n
 		}
 	}
 	{
-		std::uint32_t v = cs.queue_waiting_position;
+		std::uint32_t v = cs.upload_queue_position;
 		if (c->AssignIfExist(EC_TAG_CLIENT_WAITING_POSITION, v))
-			cs.queue_waiting_position = v;
+			cs.upload_queue_position = v;
 	}
 	{
-		std::uint16_t v = cs.remote_queue_rank;
+		std::uint16_t v = cs.remote_queue_position;
 		if (c->AssignIfExist(EC_TAG_CLIENT_REMOTE_QUEUE_RANK, v))
-			cs.remote_queue_rank = v;
+			cs.remote_queue_position = v;
 	}
 	{
 		std::uint32_t v = cs.score;
@@ -1013,7 +1013,7 @@ void MergeClientTag(const CEC_UpDownClient_Tag *c, ClientSnapshot &cs, bool is_n
 	{
 		std::uint8_t v = 0;
 		if (c->AssignIfExist(EC_TAG_CLIENT_OBFUSCATION_STATUS, v)) {
-			cs.obfuscation_status = ClientObfuscationName(v);
+			cs.obfuscation_state = ClientObfuscationName(v);
 		}
 	}
 	{
@@ -1028,7 +1028,7 @@ void MergeClientTag(const CEC_UpDownClient_Tag *c, ClientSnapshot &cs, bool is_n
 	{
 		std::uint32_t v = 0;
 		if (c->AssignIfExist(EC_TAG_CLIENT_USER_ID, v)) {
-			cs.user_id_hybrid = v;
+			cs.ed2k_user_id = v;
 			// A LowID peer has a hybrid id below 0x1000000 (IsLowID(),
 			// NetworkFunctions.h); inline the ed2k-stable ceiling rather
 			// than drag the core header into the webapi decoder.
@@ -1095,12 +1095,12 @@ void MergeClientTag(const CEC_UpDownClient_Tag *c, ClientSnapshot &cs, bool is_n
 	{
 		std::uint32_t v = 0;
 		if (c->AssignIfExist(EC_TAG_CLIENT_AVAILABLE_PARTS, v)) {
-			cs.available_parts = v;
-			cs.has_available_parts = true;
+			cs.parts_offered_count = v;
+			cs.has_parts_offered_count = true;
 		}
 	}
 	if (const CECTag *t = c->GetTagByName(EC_TAG_CLIENT_MOD_VERSION)) {
-		cs.mod_version = std::string(t->GetStringData().utf8_str());
+		cs.client_mod_name = std::string(t->GetStringData().utf8_str());
 	}
 	{
 		bool v = false;
@@ -1118,7 +1118,7 @@ void MergeClientTag(const CEC_UpDownClient_Tag *c, ClientSnapshot &cs, bool is_n
 			cs.is_friend = v;
 	}
 	if (const CECTag *t = c->GetTagByName(EC_TAG_CLIENT_SCORE_RATIO)) {
-		cs.dl_up_modifier = t->GetDoubleData();
+		cs.credit_ratio = t->GetDoubleData();
 	}
 }
 

--- a/src/webapi/State.cpp
+++ b/src/webapi/State.cpp
@@ -57,7 +57,7 @@ std::uint16_t SharedHashingProgress(const FileSnapshot &f)
 // the field.
 void ComputePartProgressPercent(const CState &state, ClientSnapshot &cli)
 {
-	if (!cli.has_available_parts || cli.download_file_hash.empty()) {
+	if (!cli.has_parts_offered_count || cli.download_file_hash.empty()) {
 		return;
 	}
 	// DownloadPartCount, not FindDownload: this runs once per source per
@@ -69,7 +69,7 @@ void ComputePartProgressPercent(const CState &state, ClientSnapshot &cli)
 	if (part_count == 0) {
 		return;
 	}
-	double pct = 100.0 * static_cast<double>(cli.available_parts) / static_cast<double>(part_count);
+	double pct = 100.0 * static_cast<double>(cli.parts_offered_count) / static_cast<double>(part_count);
 	if (pct > 100.0)
 		pct = 100.0;
 	cli.part_progress_percent = pct;
@@ -744,8 +744,8 @@ void CState::ReconcileKnownClientsLocked()
 		// connected as last seen months ago, and now is what the core writes
 		// to the record at its own disconnect handling anyway.
 		k.last_seen = now;
-		k.total_uploaded = c.xfer_up_total;
-		k.total_downloaded = c.xfer_down_total;
+		k.total_uploaded = c.uploaded_bytes_total;
+		k.total_downloaded = c.downloaded_bytes_total;
 		// Identity, when the peer in front of us knows more than the record.
 		// A record only gains a name once the core writes its metadata, so a
 		// peer we have never finished a session with is otherwise nameless.
@@ -760,7 +760,7 @@ void CState::ReconcileKnownClientsLocked()
 			k.software = c.software;
 			k.version = c.software_version;
 			k.source_origin = c.source_origin;
-			k.obfuscation = c.obfuscation_status;
+			k.obfuscation = c.obfuscation_state;
 		}
 	}
 

--- a/src/webapi/State.h
+++ b/src/webapi/State.h
@@ -366,7 +366,7 @@ struct ClientSnapshot
 	// short label here so consumers don't need the lookup table.
 	std::string software;         // "amule" | "emule" | "edonkey" | "mldonkey" | ...
 	std::string software_version; // free-form string from EC_TAG_CLIENT_SOFT_VER_STR
-	std::string os_info;          // free-form (CLIENT_OS_INFO)
+	std::string reported_os;      // free-form (CLIENT_OS_INFO)
 
 	// State machine values. We decode the raw US_*/DS_*/IS_* ints
 	// into wire strings so consumers don't reach into amule's enums.
@@ -400,48 +400,48 @@ struct ClientSnapshot
 	// Per-session transfer stats. CLIENT_UPLOAD_SESSION = bytes
 	// uploaded TO this peer; PARTFILE_SIZE_XFER (when re-keyed on a
 	// CLIENT_* tag) = bytes downloaded FROM this peer.
-	std::uint64_t xfer_up_session = 0;
-	std::uint64_t xfer_down_session = 0;
-	std::uint64_t xfer_up_total = 0;
-	std::uint64_t xfer_down_total = 0;
+	std::uint64_t uploaded_bytes_session = 0;
+	std::uint64_t downloaded_bytes_session = 0;
+	std::uint64_t uploaded_bytes_total = 0;
+	std::uint64_t downloaded_bytes_total = 0;
 	std::uint32_t upload_speed_bps = 0;
 	std::uint32_t download_speed_bps = 0;
 
 	// Upload queue position (for peers in US_ONUPLOADQUEUE).
 	// 0 when not queued.
-	std::uint32_t queue_waiting_position = 0;
+	std::uint32_t upload_queue_position = 0;
 	// Remote queue rank — our position in THE PEER's upload queue
 	// (i.e. how many other ed2k clients they're going to upload to
 	// before us). 0xFFFF when their queue is full.
 	//! Carries amuled's queue-full sentinel as well as a real position; see
 	//! kRemoteQueueFullSentinel.
-	std::uint16_t remote_queue_rank = 0;
+	std::uint16_t remote_queue_position = 0;
 
 	std::uint32_t score = 0; // EC_TAG_CLIENT_SCORE
 	// Complete set, see ClientObfuscationName() in Refresher.cpp:
-	std::string obfuscation_status; // "undefined" | "enabled" | "supported" | "not_supported" |
-					// "disabled" | "unknown"
+	std::string obfuscation_state; // "undefined" | "enabled" | "supported" | "not_supported" |
+				       // "disabled" | "unknown"
 	bool friend_slot = false;
 
 	// --- Extra fields decoded off the INC_UPDATE wire (issue #422) ----
 	// Originally detail-only. Five of them -- source_origin,
-	// available_parts, mod_version, view_shared_disabled and the derived
+	// parts_offered_count, client_mod_name, view_shared_disabled and the derived
 	// part_progress_percent -- were since promoted to the /clients list row
 	// and the SSE client_* payloads (#995, #1015); the rest are still
 	// serialized only by GET /clients/{ecid}.
-	std::uint32_t user_id_hybrid = 0; // EC_TAG_CLIENT_USER_ID (hybrid eD2k id)
-	bool high_id = false;             // derived: !IsLowID(user_id_hybrid)
-	std::string server_ip;            // dotted-quad; "" when unknown/0
+	std::uint32_t ed2k_user_id = 0; // EC_TAG_CLIENT_USER_ID (hybrid eD2k id)
+	bool high_id = false;           // derived: !IsLowID(ed2k_user_id)
+	std::string server_ip;          // dotted-quad; "" when unknown/0
 	std::uint16_t server_port = 0;
 	std::string server_name;
-	std::uint16_t kad_port = 0;        // 0 => Kad not connected for this peer
-	std::string source_origin;         // "server" | "kad" | "source_exchange" | "passive" | "link" | ...
-	std::uint32_t available_parts = 0; // count of parts the peer has (EC_TAG_CLIENT_AVAILABLE_PARTS)
-	bool has_available_parts = false;  // false => tag absent, emitted as null
-	std::string mod_version;           // EC_TAG_CLIENT_MOD_VERSION
-	bool view_shared_disabled = false; // peer forbids viewing its shared files
+	std::uint16_t kad_port = 0; // 0 => Kad not connected for this peer
+	std::string source_origin;  // "server" | "kad" | "source_exchange" | "passive" | "link" | ...
+	std::uint32_t parts_offered_count = 0; // count of parts the peer has (EC_TAG_CLIENT_AVAILABLE_PARTS)
+	bool has_parts_offered_count = false;  // false => tag absent, emitted as null
+	std::string client_mod_name;           // EC_TAG_CLIENT_MOD_VERSION
+	bool view_shared_disabled = false;     // peer forbids viewing its shared files
 	// Completeness of the linked download for this peer, as a percent
-	// (available_parts / file part count). < 0 => not computable (no
+	// (parts_offered_count / file part count). < 0 => not computable (no
 	// linked file / no part count). Derived rather than decoded: filled in
 	// by ComputePartProgressPercent at every site that serializes a client
 	// -- the list, the per-file rows, the detail object and the SSE
@@ -480,8 +480,8 @@ struct ClientSnapshot
 	bool has_last_downloading_part = false;
 
 	// --- Detail-only fields (issue #423, new EC tags) ----------------
-	bool is_friend = false;      // CUpDownClient::IsFriend(); distinct from friend_slot
-	double dl_up_modifier = 0.0; // CUpDownClient::GetScoreRatio() ("DL/UP modifier")
+	bool is_friend = false;    // CUpDownClient::IsFriend(); distinct from friend_slot
+	double credit_ratio = 0.0; // CUpDownClient::GetScoreRatio() ("DL/UP modifier")
 };
 
 // One per eD2k server in the configured server list. Identity is
@@ -538,7 +538,7 @@ struct FriendSnapshot
 	std::uint32_t client_ecid = 0; // live peer this friend is linked to, 0 = offline
 	// Reported by cores that serialize EC_TAG_FRIEND_FRIENDSLOT. An older
 	// daemon omits the tag and this stays false, the same way is_friend and
-	// dl_up_modifier degrade on /clients.
+	// credit_ratio degrade on /clients.
 	bool friend_slot = false;
 };
 
@@ -1393,7 +1393,7 @@ struct StatusSnapshot
 	// Our eD2k id as assigned by the connected server. 0 when not
 	// connected; the 0xffffffff "connect in flight" sentinel is normalized
 	// to 0 rather than surfaced. Packed LSB-first, unlike the peer-side
-	// user_id_hybrid on CUpDownClient, which byte-swaps a HighID.
+	// ed2k_user_id on CUpDownClient, which byte-swaps a HighID.
 	std::uint32_t ed2k_user_id = 0;
 
 	// Our public IPv4 in dotted-quad form, derived from ed2k_user_id when that

--- a/src/webapi/static/js/views/client-table.js
+++ b/src/webapi/static/js/views/client-table.js
@@ -21,11 +21,11 @@ export const isUp = (c) => (c.upload_speed_bps || 0) > 0 || ACTIVE(c.upload_stat
 // picker and picks which ones start hidden (see ClientTable's defaultHidden),
 // so a column is always one click away instead of missing from a tab.
 const softLabel = (c) => [c.software ? t("downloads_peer_soft_" + c.software) : "", c.software === "unknown" ? "" : c.software_version].filter(Boolean).join(" ") || "—";
-// `remote_queue_rank` is null when the peer's queue is full (the API turns
+// `remote_queue_position` is null when the peer's queue is full (the API turns
 // amuled's 0xffff sentinel into null), and 0 when it reported no position at
 // all. Both are "not a position", so they sort together as 0.
-const rankLabel = (c) => c.remote_queue_rank === null ? t("downloads_peer_queue_full") : c.remote_queue_rank || "—";
-const bytesOf = (c, k) => formatBytes((c.xfer || {})[k]);
+const rankLabel = (c) => c.remote_queue_position === null ? t("downloads_peer_queue_full") : c.remote_queue_position || "—";
+const bytesOf = (c, k) => formatBytes(c[k]);
 // The "file" column is shared by both directions: download_file_name is the
 // peer-advertised name of what we're pulling FROM them; upload_file_name is
 // the partfile they're pulling FROM us. An upload-only peer has no
@@ -62,7 +62,7 @@ export const COLS = [
     sortVal: (c) => softLabel(c).toLowerCase(), cell: (c) => softLabel(c) },
   // The peer's own self-reported OS string -- frequently empty.
   { key: "os", th: "downloads_peer_col_os", width: "110px", sortable: true,
-    sortVal: (c) => (c.os_info || "").toLowerCase(), cell: (c) => c.os_info || "—" },
+    sortVal: (c) => (c.reported_os || "").toLowerCase(), cell: (c) => c.reported_os || "—" },
   { key: "file", th: "downloads_peer_col_file", cls: "name", sortable: true,
     sortVal: (c) => fileNameOf(c).toLowerCase(),
     cell: (c) => html`<span title=${fileNameOf(c)}>${fileNameOf(c) || "—"}</span>` },
@@ -72,24 +72,24 @@ export const COLS = [
   { key: "dl_speed", th: "downloads_peer_col_dl_speed", num: true, width: "100px", sortable: true,
     sortVal: (c) => c.download_speed_bps || 0, cell: (c) => formatSpeed(c.download_speed_bps) },
   { key: "downloaded", th: "downloads_peer_col_downloaded", num: true, width: "100px", sortable: true,
-    sortVal: (c) => (c.xfer && c.xfer.down_total) || 0, cell: (c) => bytesOf(c, "down_total") },
+    sortVal: (c) => c.downloaded_bytes_total || 0, cell: (c) => bytesOf(c, "downloaded_bytes_total") },
   { key: "dl_session", th: "downloads_peer_col_downloaded_session", num: true, width: "100px", sortable: true,
-    sortVal: (c) => (c.xfer && c.xfer.down_session) || 0, cell: (c) => bytesOf(c, "down_session") },
+    sortVal: (c) => c.downloaded_bytes_session || 0, cell: (c) => bytesOf(c, "downloaded_bytes_session") },
   { key: "remote_rank", th: "downloads_peer_col_remote_rank", num: true, width: "90px", sortable: true,
-    sortVal: (c) => c.remote_queue_rank || 0, cell: (c) => rankLabel(c) },
+    sortVal: (c) => c.remote_queue_position || 0, cell: (c) => rankLabel(c) },
 
   { key: "ul_state", th: "downloads_peer_col_ul_state", width: "120px", sortable: true,
     sortVal: (c) => c.upload_state || "", cell: (c) => stateBadge(c.upload_state) },
   { key: "ul_speed", th: "downloads_peer_col_ul_speed", num: true, width: "100px", sortable: true,
     sortVal: (c) => c.upload_speed_bps || 0, cell: (c) => formatSpeed(c.upload_speed_bps) },
   { key: "uploaded", th: "downloads_peer_col_uploaded", num: true, width: "100px", sortable: true,
-    sortVal: (c) => (c.xfer && c.xfer.up_total) || 0, cell: (c) => bytesOf(c, "up_total") },
+    sortVal: (c) => c.uploaded_bytes_total || 0, cell: (c) => bytesOf(c, "uploaded_bytes_total") },
   { key: "ul_session", th: "downloads_peer_col_uploaded_session", num: true, width: "100px", sortable: true,
-    sortVal: (c) => (c.xfer && c.xfer.up_session) || 0, cell: (c) => bytesOf(c, "up_session") },
+    sortVal: (c) => c.uploaded_bytes_session || 0, cell: (c) => bytesOf(c, "uploaded_bytes_session") },
   { key: "queue_pos", th: "downloads_peer_col_queue_pos", num: true, width: "90px", sortable: true,
-    sortVal: (c) => c.queue_waiting_position || 0, cell: (c) => c.queue_waiting_position || "—" },
+    sortVal: (c) => c.upload_queue_position || 0, cell: (c) => c.upload_queue_position || "—" },
   { key: "score", th: "downloads_peer_col_score", num: true, width: "80px", sortable: true,
-    sortVal: (c) => c.score || 0, cell: (c) => c.score || "—" },
+    sortVal: (c) => c.upload_queue_score || 0, cell: (c) => c.upload_queue_score || "—" },
 
   // "View files": browse this peer's share, the desktop's context-menu action.
   // A browse is an ordinary search on the API, so it opens as a tab in the
@@ -136,7 +136,7 @@ export function peerFlags(c) {
   // states are just an absence of SecIdent and earn no icon.
   if (c.ident_state === "identified") flags.push(["verified", identTip()]);
   else if (c.ident_state === "bad_guy" || c.ident_state === "id_failed") flags.push(["warning", identTip()]);
-  if (c.obfuscation_status === "enabled")
+  if (c.obfuscation_state === "enabled")
     flags.push(["lock", t("downloads_peer_obfuscation") + ": " + t("downloads_peer_enabled")]);
   if (c.friend_slot)
     flags.push(["star", t("downloads_peer_friend")]);

--- a/unittests/curl-tests/amuleapi/04-read-downloads-shared.sh
+++ b/unittests/curl-tests/amuleapi/04-read-downloads-shared.sh
@@ -287,7 +287,7 @@ if [ "$COUNT" -gt 0 ]; then
 	DLROWS=$(printf '%s' "$CURL_BODY" | jq '.clients | length')
 	echo "  --- /downloads/{hash}/clients returned $DLROWS row(s) ---"
 	if [ "$DLROWS" -gt 0 ]; then
-		_assert_json_eq '[.clients[] | select(.role as $r | ($r == null) or ((["source","peer","both","none"] | index($r)) == null))] | length' \
+		_assert_json_eq '[.clients[] | select(.role as $r | ($r == null) or ((["downloading_from","uploading_to","both","none"] | index($r)) == null))] | length' \
 			0 "every row has a valid role"
 		_assert_json_eq '[.clients[] | select(.a4af == null)] | length' 0 "every row has an a4af flag"
 		_assert_json_eq '[.clients[] | select(has("parts"))] | length' 0 "no parts bitmap without include_parts"
@@ -335,7 +335,7 @@ if [ "$COUNT" -gt 0 ]; then
 	# just the detail object — the desktop renders them as table columns.
 	_curl -H "Authorization: Bearer $TOKEN" "$HOST/api/v0/clients?limit=1"
 	if [ "$(echo "$CURL_BODY" | jq -r '.clients | length')" != "0" ]; then
-		for k in source_origin available_parts mod_version view_shared_disabled; do
+		for k in source_origin parts_offered_count client_mod_name shared_files_browsable; do
 			_assert_json_eq ".clients[0] | has(\"$k\")" true "/clients row carries $k"
 		done
 	fi
@@ -488,7 +488,7 @@ if [ "$SHCOUNT" -gt 0 ]; then
 	SHROWS=$(printf '%s' "$CURL_BODY" | jq '.clients | length')
 	echo "  --- /shared/{hash}/clients returned $SHROWS row(s) ---"
 	if [ "$SHROWS" -gt 0 ]; then
-		_assert_json_eq '[.clients[] | select(.role as $r | ($r == null) or ((["source","peer","both","none"] | index($r)) == null))] | length' \
+		_assert_json_eq '[.clients[] | select(.role as $r | ($r == null) or ((["downloading_from","uploading_to","both","none"] | index($r)) == null))] | length' \
 			0 "every shared-side row has a valid role"
 		_assert_json_eq '[.clients[] | select(.a4af == null)] | length' 0 \
 			"every shared-side row has an a4af flag"

--- a/unittests/curl-tests/amuleapi/10-refresher-lazy-ondemand.sh
+++ b/unittests/curl-tests/amuleapi/10-refresher-lazy-ondemand.sh
@@ -115,9 +115,10 @@ if [ "$CCOUNT" -gt 0 ]; then
 	# #439 peer country: always-present ISO 3166-1 alpha-2 string,
 	# empty when GeoIP is off/unresolved (never absent/null).
 	_assert_json_eq '.clients[0].country_code | type'   string   '/clients[0].country_code is string (#439)'
-	_assert_json_eq '.clients[0].xfer | type'           object   '/clients[0].xfer is object'
-	_assert_json_eq '.clients[0].xfer.up_session | type'   number '/clients[0].xfer.up_session is numeric'
-	_assert_json_eq '.clients[0].xfer.down_session | type' number '/clients[0].xfer.down_session is numeric'
+	# xfer was flattened (R11): the window belongs in the key, not a wrapper.
+	_assert_json_eq '.clients[0] | has("xfer")' false '/clients[0] no longer wraps counters in xfer'
+	_assert_json_eq '.clients[0].uploaded_bytes_session | type'   number '/clients[0].uploaded_bytes_session is numeric'
+	_assert_json_eq '.clients[0].downloaded_bytes_session | type' number '/clients[0].downloaded_bytes_session is numeric'
 
 	# State enum allowlists — any peer's upload_state must be one of
 	# the wire strings the walker emits. Catch silent regressions if

--- a/unittests/curl-tests/amuleapi/22-sse-diff-emission.sh
+++ b/unittests/curl-tests/amuleapi/22-sse-diff-emission.sh
@@ -446,9 +446,9 @@ CLIENT_JSON=$(grep -A2 -E "^event: client_(added|updated)$" "$SSE_OUT" \
 if [ -n "$CLIENT_JSON" ]; then
 	if echo "$CLIENT_JSON" | jq -e \
 		'(.source_origin|type=="string")
-		 and has("available_parts")
-		 and ((.available_parts|type)=="number" or (.available_parts|type)=="null")
-		 and (.mod_version|type=="string") and (.view_shared_disabled|type=="boolean")' \
+		 and has("parts_offered_count")
+		 and ((.parts_offered_count|type)=="number" or (.parts_offered_count|type)=="null")
+		 and (.client_mod_name|type=="string") and (.shared_files_browsable|type=="boolean")' \
 		>/dev/null 2>&1; then
 		_pass "client_added/updated carries the promoted peer fields (#984)"
 	else

--- a/unittests/curl-tests/amuleapi/26-rfc-followup-endpoints.sh
+++ b/unittests/curl-tests/amuleapi/26-rfc-followup-endpoints.sh
@@ -409,12 +409,12 @@ if [ -n "$FIRST_ECID" ]; then
 		(.ecid == $e)
 		and has("user_hash")
 		and has("upload_file_name") and has("download_file_name")
-		and has("user_id_hybrid") and has("high_id")
+		and has("ed2k_user_id") and has("high_id")
 		and has("server_ip") and has("server_port") and has("server_name")
 		and has("kad_port") and has("source_origin")
-		and has("available_parts") and has("mod_version")
-		and has("view_shared_disabled")
-		and has("is_friend") and has("dl_up_modifier")')
+		and has("parts_offered_count") and has("client_mod_name")
+		and has("shared_files_browsable")
+		and has("friend") and has("credit_ratio")')
 	if [ "$OK" = "true" ]; then
 		_pass "/clients/{ecid} returns detail superset (ecid=$FIRST_ECID)"
 	else

--- a/unittests/curl-tests/amuleapi/33-known-clients.sh
+++ b/unittests/curl-tests/amuleapi/33-known-clients.sh
@@ -17,7 +17,7 @@
 #   * every `sort` key the endpoint advertises is accepted and an
 #     unknown one is a 400,
 #   * each record carries the fields that are always recorded (user_hash,
-#     the totals, last_seen, online) and omits — rather than empties —
+#     the totals, last_seen_at, online) and omits — rather than empties —
 #     the ones a pre-metadata record has no value for,
 #   * `user_hash` is a 32-char lowercase MD4, so it correlates with
 #     /clients `user_hash` directly,
@@ -149,21 +149,21 @@ for bad in "limit=abc" "limit=99999999999" "offset=-1" "order=sideways"; do
 done
 
 # --- 3. Sort keys. -------------------------------------------------
-for key in name software first_seen last_seen sessions total_uploaded total_downloaded; do
+for key in name software first_seen_at last_seen_at session_count uploaded_bytes_total downloaded_bytes_total; do
 	_curl "$HOST/api/v0/known_clients?sort=$key&limit=1"
 	_assert_status 200 "sort=$key is accepted"
 done
 _curl "$HOST/api/v0/known_clients?sort=nonsense"
 _assert_status 400 "an unknown sort key is rejected"
 
-_curl "$HOST/api/v0/known_clients?sort=last_seen&order=desc&limit=1"
-_assert_status 200 "sort=last_seen&order=desc is accepted"
+_curl "$HOST/api/v0/known_clients?sort=last_seen_at&order=desc&limit=1"
+_assert_status 200 "sort=last_seen_at&order=desc is accepted"
 
 # --- 4. Record shape. ----------------------------------------------
 if [ "${TOTAL:-0}" -gt 0 ]; then
 	_curl "$HOST/api/v0/known_clients?limit=1"
 
-	for k in user_hash total_uploaded total_downloaded last_seen online; do
+	for k in user_hash uploaded_bytes_total downloaded_bytes_total last_seen_at online; do
 		if [ "$(_jq ".known_clients[0] | has(\"$k\")")" = "true" ]; then
 			_pass "record always carries $k"
 		else
@@ -194,11 +194,11 @@ if [ "${TOTAL:-0}" -gt 0 ]; then
 		_fail "optional fields" "$EMPTY_NAMES record(s) have name == \"\""
 	fi
 
-	# first_seen and sessions travel together — both come from the same
+	# first_seen_at and session_count travel together — both come from the same
 	# metadata block, so one without the other means a decode bug.
-	MISMATCH=$(_jq '[.known_clients[] | select(has("first_seen") != has("sessions"))] | length')
+	MISMATCH=$(_jq '[.known_clients[] | select(has("first_seen_at") != has("session_count"))] | length')
 	if [ "${MISMATCH:-0}" -eq 0 ]; then
-		_pass "first_seen and sessions are present or absent together"
+		_pass "first_seen_at and session_count are present or absent together"
 	else
 		_fail "metadata pairing" "$MISMATCH record(s) have one without the other"
 	fi
@@ -217,15 +217,15 @@ fi
 # Sorted, for the same reason as the row check below: an unsorted page of a
 # large store contains no online records at all, and the check would skip
 # itself forever while looking like it had run.
-_curl "$HOST/api/v0/known_clients?sort=last_seen&order=desc&limit=500"
+_curl "$HOST/api/v0/known_clients?sort=last_seen_at&order=desc&limit=500"
 ACTIVE_HASH=$(_jq '[.known_clients[] | select(.online)][0].user_hash')
 if [ -n "$ACTIVE_HASH" ] && [ "$ACTIVE_HASH" != "null" ]; then
 	BEFORE=$(_jq "[.known_clients[] | select(.user_hash == \"$ACTIVE_HASH\")][0]
-		| .total_downloaded + .total_uploaded")
+		| .downloaded_bytes_total + .uploaded_bytes_total")
 	sleep 4
-	_curl "$HOST/api/v0/known_clients?sort=last_seen&order=desc&limit=500"
+	_curl "$HOST/api/v0/known_clients?sort=last_seen_at&order=desc&limit=500"
 	AFTER=$(_jq "[.known_clients[] | select(.user_hash == \"$ACTIVE_HASH\")][0]
-		| .total_downloaded + .total_uploaded")
+		| .downloaded_bytes_total + .uploaded_bytes_total")
 	if [ "${AFTER:-0}" -gt "${BEFORE:-0}" ]; then
 		_pass "a connected peer's totals move without a refetch ($BEFORE -> $AFTER)"
 	else
@@ -243,7 +243,7 @@ fi
 # appear here -- if it does not, the maintenance has stopped and the endpoint
 # is quietly serving a frozen snapshot.
 #
-# Sorted by last_seen descending and read one page: a connected peer is last
+# Sorted by last_seen_at descending and read one page: a connected peer is last
 # seen *now*, so the online records are the newest in the store and cannot be
 # pushed off the first page by anything else. `limit` is clamped to 500 by the
 # shared parser, which is well above MaxConnections -- asking for the whole
@@ -259,7 +259,7 @@ LIVE_TOTAL=$(printf '%s' "$LIVE_CLIENTS_JSON" | jq -r '.clients | length' 2>/dev
 LIVE_HASHES=$(printf '%s' "$LIVE_CLIENTS_JSON" \
 	| jq -r '.clients[].user_hash // empty | select(. != "" and (test("^0+$") | not))' | sort -u)
 if [ -n "$LIVE_HASHES" ]; then
-	_curl "$HOST/api/v0/known_clients?sort=last_seen&order=desc&limit=500"
+	_curl "$HOST/api/v0/known_clients?sort=last_seen_at&order=desc&limit=500"
 	MISSING=0
 	CHECKED=0
 	for h in $LIVE_HASHES; do

--- a/unittests/tests/EventDiffTest.cpp
+++ b/unittests/tests/EventDiffTest.cpp
@@ -843,7 +843,7 @@ TEST(EventDiff, SearchClosedFiresOnceWhenTheSlotIsFreed)
 // resource: it is derived rather than refreshed (it needs the part count of
 // the linked download, which lives in a different snapshot), so the diff pass
 // never computed it and the payload silently lacked a key the REST row had.
-// #1159 section 1. ClientSnapshot carries has_available_parts precisely so a
+// #1159 section 1. ClientSnapshot carries has_parts_offered_count precisely so a
 // peer that never reported its part map can be told apart from one reporting
 // zero -- and zero is a real answer, being what a fresh source looks like
 // before its map arrives. The field was emitted unconditionally, so nothing
@@ -855,7 +855,7 @@ TEST(EventDiff, ClientEventEmitsNullAvailablePartsWhenTheMapIsUnreported)
 		ClientSnapshot c;
 		c.ecid = 71;
 		c.client_name = "no-map";
-		// has_available_parts stays false: the tag never arrived.
+		// has_parts_offered_count stays false: the tag never arrived.
 		clients.emplace(c.ecid, c);
 	});
 
@@ -869,7 +869,7 @@ TEST(EventDiff, ClientEventEmitsNullAvailablePartsWhenTheMapIsUnreported)
 			payload = e.data;
 	}
 	ASSERT_TRUE(!payload.empty());
-	ASSERT_TRUE(payload.find("\"available_parts\":null") != std::string::npos);
+	ASSERT_TRUE(payload.find("\"parts_offered_count\":null") != std::string::npos);
 }
 
 // ...and a peer that did report zero still says zero.
@@ -880,8 +880,8 @@ TEST(EventDiff, ClientEventEmitsZeroAvailablePartsWhenTheMapSaysZero)
 		ClientSnapshot c;
 		c.ecid = 72;
 		c.client_name = "empty-map";
-		c.available_parts = 0;
-		c.has_available_parts = true;
+		c.parts_offered_count = 0;
+		c.has_parts_offered_count = true;
 		clients.emplace(c.ecid, c);
 	});
 
@@ -895,8 +895,8 @@ TEST(EventDiff, ClientEventEmitsZeroAvailablePartsWhenTheMapSaysZero)
 			payload = e.data;
 	}
 	ASSERT_TRUE(!payload.empty());
-	ASSERT_TRUE(payload.find("\"available_parts\":0") != std::string::npos);
-	ASSERT_TRUE(payload.find("\"available_parts\":null") == std::string::npos);
+	ASSERT_TRUE(payload.find("\"parts_offered_count\":0") != std::string::npos);
+	ASSERT_TRUE(payload.find("\"parts_offered_count\":null") == std::string::npos);
 }
 
 // The comparator has to see the flag too. null -> 0 is a visible change; with
@@ -917,8 +917,8 @@ TEST(EventDiff, ClientUpdateFiresWhenThePartMapFinallyArrivesReportingZero)
 
 	state.MutateClients([](std::map<std::uint32_t, ClientSnapshot> &clients) {
 		auto it = clients.find(73);
-		it->second.available_parts = 0;
-		it->second.has_available_parts = true;
+		it->second.parts_offered_count = 0;
+		it->second.has_parts_offered_count = true;
 	});
 	EmitDiffsAndUpdate(bus, prev, state);
 
@@ -940,13 +940,13 @@ TEST(EventDiff, ClientEventEmitsNullRemoteQueueRankWhenTheQueueIsFull)
 		ClientSnapshot full;
 		full.ecid = 74;
 		full.client_name = "full-queue";
-		full.remote_queue_rank = kRemoteQueueFullSentinel;
+		full.remote_queue_position = kRemoteQueueFullSentinel;
 		clients.emplace(full.ecid, full);
 
 		ClientSnapshot ranked;
 		ranked.ecid = 75;
 		ranked.client_name = "ranked";
-		ranked.remote_queue_rank = 12;
+		ranked.remote_queue_position = 12;
 		clients.emplace(ranked.ecid, ranked);
 	});
 
@@ -964,10 +964,10 @@ TEST(EventDiff, ClientEventEmitsNullRemoteQueueRankWhenTheQueueIsFull)
 			ranked_payload = e.data;
 	}
 	ASSERT_TRUE(!full_payload.empty());
-	ASSERT_TRUE(full_payload.find("\"remote_queue_rank\":null") != std::string::npos);
+	ASSERT_TRUE(full_payload.find("\"remote_queue_position\":null") != std::string::npos);
 	// A real position is still a number.
 	ASSERT_TRUE(!ranked_payload.empty());
-	ASSERT_TRUE(ranked_payload.find("\"remote_queue_rank\":12") != std::string::npos);
+	ASSERT_TRUE(ranked_payload.find("\"remote_queue_position\":12") != std::string::npos);
 }
 
 TEST(EventDiff, ClientEventCarriesPartProgressPercent)
@@ -989,8 +989,8 @@ TEST(EventDiff, ClientEventCarriesPartProgressPercent)
 		c.ecid = 7;
 		c.client_name = "peer";
 		c.download_file_hash = "8b54a3c28b54a3c28b54a3c28b54a3c2";
-		c.available_parts = 3;
-		c.has_available_parts = true;
+		c.parts_offered_count = 3;
+		c.has_parts_offered_count = true;
 		clients.emplace(c.ecid, c);
 	});
 

--- a/unittests/tests/RefresherTest.cpp
+++ b/unittests/tests/RefresherTest.cpp
@@ -2207,7 +2207,7 @@ TEST(Refresher, ClientDetailFieldsDecode)
 	const auto it = cache.find(50);
 	ASSERT_TRUE(it != cache.end());
 	const ClientSnapshot &cs = it->second;
-	ASSERT_EQUALS(static_cast<std::uint32_t>(0x04030201), cs.user_id_hybrid);
+	ASSERT_EQUALS(static_cast<std::uint32_t>(0x04030201), cs.ed2k_user_id);
 	ASSERT_TRUE(cs.high_id);
 	ASSERT_EQUALS(std::string("127.0.0.1"), cs.server_ip);
 	ASSERT_EQUALS(static_cast<std::uint16_t>(4242), cs.server_port);
@@ -2216,20 +2216,20 @@ TEST(Refresher, ClientDetailFieldsDecode)
 	ASSERT_EQUALS(static_cast<std::uint16_t>(4672), cs.kad_port);
 	ASSERT_EQUALS(std::string("kad"), cs.source_origin);
 	ASSERT_EQUALS(std::string("upload.iso"), cs.upload_file_name);
-	ASSERT_TRUE(cs.has_available_parts);
-	ASSERT_EQUALS(static_cast<std::uint32_t>(7), cs.available_parts);
-	ASSERT_EQUALS(std::string("mod-x"), cs.mod_version);
+	ASSERT_TRUE(cs.has_parts_offered_count);
+	ASSERT_EQUALS(static_cast<std::uint32_t>(7), cs.parts_offered_count);
+	ASSERT_EQUALS(std::string("mod-x"), cs.client_mod_name);
 	ASSERT_TRUE(cs.view_shared_disabled);
 	ASSERT_TRUE(cs.is_friend);
-	ASSERT_TRUE(cs.dl_up_modifier > 2.4 && cs.dl_up_modifier < 2.6);
+	ASSERT_TRUE(cs.credit_ratio > 2.4 && cs.credit_ratio < 2.6);
 
 	const auto it2 = cache.find(51);
 	ASSERT_TRUE(it2 != cache.end());
 	ASSERT_TRUE(!it2->second.high_id);
-	ASSERT_TRUE(!it2->second.has_available_parts);
+	ASSERT_TRUE(!it2->second.has_parts_offered_count);
 	// #423 fields absent on the wire => defaults preserved.
 	ASSERT_TRUE(!it2->second.is_friend);
-	ASSERT_TRUE(it2->second.dl_up_modifier == 0.0);
+	ASSERT_TRUE(it2->second.credit_ratio == 0.0);
 }
 
 // --- #437: extended EC preference categories decode ------------------


### PR DESCRIPTION
Second slice of #1189, covering §1.2. Same staging as #1197: serializer, snapshot struct, SSE payload **and** its `Equal` predicate, Web UI, curl tests and docs in one commit, so the tree works at every step and the UI never reads a key the API stopped emitting.

## The `xfer` wrapper is flattened

R11: a sub-object earns its place by grouping *different* quantities. `xfer` grouped one quantity split by time window, which belongs in the key. It also meant `xfer` named a four-field up/down pair on a client and an upload-only pair on `/shared`.

It becomes `uploaded_bytes_session`, `downloaded_bytes_session`, `uploaded_bytes_total`, `downloaded_bytes_total` -- and those last two are exactly what `/known_clients` now calls the same quantities, which it previously spelled `total_uploaded` / `total_downloaded` (R6).

## Renames

Names that hid which side of the transfer they described:

| current | new |
|---|---|
| `queue_waiting_position` | `upload_queue_position` (our queue) |
| `remote_queue_rank` | `remote_queue_position` (theirs; `rank` and `position` were two words for one thing) |
| `score` | `upload_queue_score` |

Names that were unguessable or promised more than they deliver: `dl_up_modifier` -> `credit_ratio`, `user_id_hybrid` -> `ed2k_user_id` (hybrid is an eDonkey encoding detail), `mod_version` -> `client_mod_name` (a mod string, not a version), `os_info` -> `reported_os` (untrusted, frequently empty), `available_parts` -> `parts_offered_count` -- deliberately **not** `parts_available_count`, which means something else on a download.

`view_shared_disabled` -> `shared_files_browsable`, **inverted**: a negated boolean forces `=== false` at every call site.

`country_code` emits `null` rather than `""` when the lookup has not resolved, on REST and on the SSE payload that promises key parity with it.

R7 reaches `/known_clients`: its sort values become `first_seen_at`, `last_seen_at`, `session_count`, `uploaded_bytes_total`, `downloaded_bytes_total`.

## The `role` enum, and the last `peer`

`role` was `source` / `peer` / `both` / `none`. Those are not one axis -- `source` names a relation to the file, `peer` names the entity -- and paired together they say less than either would alone. It becomes `downloading_from` / `uploading_to` / `both` / `none`, naming both by direction.

That also removes the **last contract-level use of `peer`** outside `/chats` (R12).

## Two notes against the issue

**`is_friend` -> `friend` cannot be symmetric.** `friend` is a C++ reserved keyword, so the JSON key takes it but the member must stay `is_friend`. This is the one place on the surface where key and member deliberately differ, and it is commented at the source. The issue anticipated this class of problem for `static` but not for this one.

**The R10 fix for `/known_clients` is already done.** The issue asks it to stop omitting eleven keys behind seven guards; they already route through `WriteStringOrNull` / `WriteIntOrNull`, with a comment explaining why. Stale claim, no work needed.

## Verification

Against a live amuled on macOS, rebased onto `2ae8c09e1` (#1198):

- Full curl-smoke suite: **40/40 phases, 1526 assertions, zero failures on the first run** -- no rename misses this time, unlike #1197. That run predates the rebase onto #1198, so the seven phases either change can reach were re-run afterwards on the rebased tree and are green: 04 (132/132), 07 (84/84), 10 (37/37), 19 (179/179), 22 (29/29), 26 (39/39), 33.
- #1198 is an ancestor of this branch, and this diff touches neither `RefresherTick.cpp` nor `StateTest.cpp` -- the two files its change centres on.
- Unit tests: **43/43**.
- `clang-format` 18: diff clean, and the whole of `src/` + `unittests/` re-checked (634 files, 0 violations) since CI's gate is whole-file.
- `clang-tidy` Tier-1 and Tier-2 on the diff: 0 findings, 0 compiler errors.
- `scripts/check-potfiles.sh`: clean, no new translatable strings.

#1189 stays open after this: nine resources and the query-parameter renames remain.
