### PR TITLE
feat(gui): open the main window on a left-click of the Linux tray icon

### DIFF
--- a/packaging/linux/appimage/Dockerfile
+++ b/packaging/linux/appimage/Dockerfile
@@ -12,6 +12,9 @@ ARG LINUXDEPLOY_GTK_SHA
 ARG LIBUPNP_VERSION
 ARG LIBUPNP_TARBALL_URL
 ARG LIBUPNP_SHA256
+ARG APPINDICATOR_VERSION
+ARG APPINDICATOR_TARBALL_URL
+ARG APPINDICATOR_SHA256
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV TZ=Etc/UTC
@@ -50,13 +53,22 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         # GTK3 dev headers (linker target for wx) + Wayland/X11 client headers
         libgtk-3-dev \
         libwayland-dev \
-        # libayatana-appindicator3: enables the StatusNotifierItem (SNI)
-        # tray-icon backend in MuleTrayIcon. Without it the tray falls
+        # Build deps for libayatana-appindicator, which is built from source
+        # below rather than taken from the archive -- see the RUN block for
+        # why. The library itself enables the StatusNotifierItem (SNI)
+        # tray-icon backend in MuleTrayIcon; without it the tray falls
         # back to wxTaskBarIcon → legacy GtkStatusIcon, which GNOME
         # dropped in 3.26 and wlroots compositors never implemented.
         # Ubuntu's GNOME Shell extension renders both, but Fedora /
         # vanilla GNOME / Sway need the SNI path to see the icon at all.
-        libayatana-appindicator3-dev \
+        libayatana-indicator3-dev \
+        libdbusmenu-gtk3-dev \
+        # g-ir-scanner. appindicator calls find_package(GObjectIntrospection
+        # REQUIRED) but the find module does not fail configure when the
+        # scanner is missing -- it leaves INTROSPECTION_SCANNER empty and the
+        # .gir rule then runs its own first argument as the command, failing
+        # with "app-indicator.c: not found" at build time instead.
+        libgirepository1.0-dev \
         # AppImage runtime / linuxdeploy-plugin-gtk deps
         libglib2.0-bin \
         libgdk-pixbuf-2.0-0 \
@@ -77,6 +89,24 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # the AppImage). pupnp 22.x is CMake-only. CMAKE_INSTALL_LIBDIR=lib keeps
 # libupnp.pc / .so / the UPNP CMake config out of lib64 where pkg-config, cmake
 # and ldconfig wouldn't find them.
+# libayatana-appindicator from source: 22.04 ships 0.5.90, and only 0.6.0
+# answers the StatusNotifierItem Activate D-Bus method, which is what a host
+# sends on left-click. On anything older the tray icon can only open its menu,
+# so left-click and right-click do the same thing (discussion #1115). Shared,
+# so linuxdeploy bundles the .so into the AppImage. Its own dependencies
+# (ayatana-indicator3 >= 0.8.4, dbusmenu-gtk3, GTK >= 3.24) are satisfied by
+# the archive packages installed above, so nothing else needs building.
+RUN wget -qO /tmp/appindicator.tar.gz "${APPINDICATOR_TARBALL_URL}" \
+    && echo "${APPINDICATOR_SHA256}  /tmp/appindicator.tar.gz" | sha256sum -c - \
+    && mkdir -p /tmp/appindicator && tar -xf /tmp/appindicator.tar.gz -C /tmp/appindicator --strip-components=1 \
+    && cmake -S /tmp/appindicator -B /tmp/appindicator/build -G Ninja -DCMAKE_BUILD_TYPE=Release \
+        -DFLAVOUR_GTK3=ON -DENABLE_BINDINGS_MONO=OFF -DENABLE_BINDINGS_VALA=OFF \
+        -DENABLE_TESTS=OFF -DENABLE_GTKDOC=OFF \
+        -DCMAKE_INSTALL_PREFIX=/usr/local -DCMAKE_INSTALL_LIBDIR=lib \
+    && cmake --build /tmp/appindicator/build && cmake --install /tmp/appindicator/build \
+    && ldconfig \
+    && rm -rf /tmp/appindicator /tmp/appindicator.tar.gz
+
 RUN wget -qO /tmp/libupnp.tar.gz "${LIBUPNP_TARBALL_URL}" \
     && echo "${LIBUPNP_SHA256}  /tmp/libupnp.tar.gz" | sha256sum -c - \
     && mkdir -p /tmp/libupnp && tar -xf /tmp/libupnp.tar.gz -C /tmp/libupnp --strip-components=1 \

--- a/packaging/linux/build.sh
+++ b/packaging/linux/build.sh
@@ -103,6 +103,9 @@ build_appimage() {
         --build-arg "LIBUPNP_VERSION=${LIBUPNP_VERSION}" \
         --build-arg "LIBUPNP_TARBALL_URL=${LIBUPNP_TARBALL_URL}" \
         --build-arg "LIBUPNP_SHA256=${LIBUPNP_SHA256}" \
+        --build-arg "APPINDICATOR_VERSION=${APPINDICATOR_VERSION}" \
+        --build-arg "APPINDICATOR_TARBALL_URL=${APPINDICATOR_TARBALL_URL}" \
+        --build-arg "APPINDICATOR_SHA256=${APPINDICATOR_SHA256}" \
         -t "${image_tag}" \
         "${SCRIPT_DIR}/appimage"
 
@@ -281,6 +284,9 @@ build_static() {
         --build-arg "LIBUPNP_VERSION=${LIBUPNP_VERSION}" \
         --build-arg "LIBUPNP_TARBALL_URL=${LIBUPNP_TARBALL_URL}" \
         --build-arg "LIBUPNP_SHA256=${LIBUPNP_SHA256}" \
+        --build-arg "APPINDICATOR_VERSION=${APPINDICATOR_VERSION}" \
+        --build-arg "APPINDICATOR_TARBALL_URL=${APPINDICATOR_TARBALL_URL}" \
+        --build-arg "APPINDICATOR_SHA256=${APPINDICATOR_SHA256}" \
         "${cache_args[@]}" \
         --output "type=local,dest=${outdir}" \
         "${REPO_ROOT}"

--- a/packaging/linux/flatpak/org.amule.aMule.yaml.in
+++ b/packaging/linux/flatpak/org.amule.aMule.yaml.in
@@ -289,8 +289,11 @@ modules:
       - -DENABLE_GTKDOC=OFF
     sources:
       - type: archive
-        url: https://github.com/AyatanaIndicators/libayatana-appindicator/archive/refs/tags/0.5.94.tar.gz
-        sha256: 884a6bc77994c0b58c961613ca4c4b974dc91aa0f804e70e92f38a542d0d0f90
+        # 0.6.0, not 0.5.94: 0.6.0 is the first release that answers the
+        # StatusNotifierItem Activate D-Bus call, which is what a host sends
+        # on left-click. Without it the tray can only ever show its menu.
+        url: https://github.com/AyatanaIndicators/libayatana-appindicator/archive/refs/tags/0.6.0.tar.gz
+        sha256: 23be92ad8eb9625ce93b23b14f82f3cf88a4970c31d48581945ddfbac0441d06
 
   # libmaxminddb — enables aMule's IP2Country feature (country flag
   # lookup in client lists / search results / transfers). The matching

--- a/packaging/linux/versions.env
+++ b/packaging/linux/versions.env
@@ -59,6 +59,16 @@ LIBUPNP_VERSION=22.0.4
 LIBUPNP_TARBALL_URL=https://github.com/pupnp/pupnp/archive/refs/tags/release-${LIBUPNP_VERSION}.tar.gz
 LIBUPNP_SHA256=7028d2a151372ff8a34341e0a269f516676c1af95b0a2ba811a2f0a2fe91ea36
 
+# libayatana-appindicator from source: 22.04 packages 0.5.90, and the
+# StatusNotifierItem Activate D-Bus call -- what a host sends on left-click --
+# is only answered from 0.6.0. Without it the tray icon can only ever open its
+# menu, never the main window. 0.6.0's own deps (ayatana-indicator3 >= 0.8.4,
+# dbusmenu-gtk3, GTK >= 3.24) are all satisfied by 22.04's archive, so only
+# this one library is built from source.
+APPINDICATOR_VERSION=0.6.0
+APPINDICATOR_TARBALL_URL=https://github.com/AyatanaIndicators/libayatana-appindicator/archive/refs/tags/${APPINDICATOR_VERSION}.tar.gz
+APPINDICATOR_SHA256=23be92ad8eb9625ce93b23b14f82f3cf88a4970c31d48581945ddfbac0441d06
+
 LIBGD_VERSION=2.3.3
 LIBGD_TARBALL_URL=https://github.com/libgd/libgd/releases/download/gd-${LIBGD_VERSION}/libgd-${LIBGD_VERSION}.tar.xz
 LIBGD_SHA256=3fe822ece20796060af63b7c60acb151e5844204d289da0ce08f8fdf131e5a61

--- a/src/MuleTrayIcon.cpp
+++ b/src/MuleTrayIcon.cpp
@@ -236,6 +236,20 @@ enum TrayAction
 	TRAY_ACTION_SET_DOWNLOAD_LIMIT,
 };
 
+// Left-click on the indicator. SNI hosts (KDE Plasma, and GNOME via the
+// AppIndicator extension) call org.kde.StatusNotifierItem.Activate for the
+// primary button; libayatana-appindicator forwards that as this signal.
+//
+// Signature comes from AppIndicatorClass::activate_event: the x/y of the
+// click, which we do not need -- the window goes wherever it already was.
+void on_indicator_activate(AppIndicator *, gint, gint, gpointer user_data)
+{
+	CMuleTrayIcon *tray = static_cast<CMuleTrayIcon *>(user_data);
+	// Toggle rather than always-show, matching the Windows tray, where a
+	// single left click has flipped show/hide since 3.0.1.
+	tray->DoShowHide();
+}
+
 void on_menu_item_activated(GtkMenuItem *item, gpointer user_data)
 {
 	CMuleTrayIcon *tray = static_cast<CMuleTrayIcon *>(user_data);
@@ -340,6 +354,30 @@ CMuleTrayIcon::CMuleTrayIcon()
 	// without it some SNI hosts render the indicator as invisible.)
 	app_indicator_set_status(m_indicator, APP_INDICATOR_STATUS_ACTIVE);
 	app_indicator_set_title(m_indicator, "aMule");
+
+	// Left-click opens the main window instead of the menu, where the
+	// installed library can tell us about it. libayatana-appindicator only
+	// grew an Activate handler in 0.6.0; before that the primary click was
+	// not exposed at all, which is why the tray has behaved this way on Linux
+	// since the SNI backend landed (discussion #1115).
+	//
+	// Looked up at RUNTIME rather than behind a build-time version check,
+	// because the two genuinely differ: a distro may ship a newer library
+	// than we built against, and our AppImage and Flatpak bundle their own.
+	// On an older library the lookup returns 0, nothing is connected, and the
+	// panel keeps opening the menu exactly as it does today. The library
+	// handles that direction too, answering the Activate D-Bus call with an
+	// error when no handler is connected so the host falls back to the menu.
+	// Nothing is logged in that case: a debug line compiles out of release
+	// builds, which is precisely where this would matter.
+	//
+	// APP_INDICATOR_TYPE, not G_OBJECT_TYPE(m_indicator): the latter is a raw
+	// dereference and app_indicator_new can return NULL. The GObject setters
+	// above only warn on NULL, so this must not be the line that crashes.
+	g_type_class_ref(APP_INDICATOR_TYPE);
+	if (m_indicator && g_signal_lookup("activate", APP_INDICATOR_TYPE)) {
+		g_signal_connect(m_indicator, "activate", G_CALLBACK(on_indicator_activate), this);
+	}
 
 	RebuildMenu();
 }


### PR DESCRIPTION
Addresses the report in #1115.

On Linux the tray icon opens its menu for both mouse buttons, so showing the window takes two clicks, or three from a cold start. Windows has toggled show/hide on left-click since 3.0.1 and macOS opens the menu by platform convention, so Linux was the odd one out.

## Why it was not a missing binding

With libayatana-appindicator present, `CMuleTrayIcon` is a StatusNotifierItem and not a `wxTaskBarIcon` at all, so the wx click bindings do not exist on that path. The library also had no way to report a primary click: before **0.6.0** the SNI `Activate` D-Bus method was unimplemented, so a host had nothing to call and fell back to showing the menu. That is also why so many GTK apps behave this way; it is the library, not a toolkit convention.

## The fix

0.6.0 implements `Activate` and forwards it as an `"activate"` GObject signal. Connecting it is enough.

The lookup is done at **runtime** rather than behind a build-time version check, because the two genuinely differ: a distro may ship a newer library than we built against, and our AppImage and Flatpak bundle their own. On an older library the lookup returns 0, nothing is connected, and the panel keeps opening the menu exactly as today.

`APP_INDICATOR_TYPE` rather than `G_OBJECT_TYPE(m_indicator)` for the lookup: the latter is a raw dereference and `app_indicator_new` can return NULL, whereas the GObject setters around it only warn.

## Getting a new enough library to users

| Channel | Was | Now |
|---|---|---|
| Flatpak | 0.5.94, already built from source | pin moved to 0.6.0 |
| AppImage | 0.5.90 from Ubuntu 22.04 apt | built from source, following the libupnp precedent |
| Distro packages | 0.5.93 on Ubuntu 24.04 LTS | unchanged, picks this up when the distro does |

The AppImage also needs `g-ir-scanner`: appindicator calls `find_package(GObjectIntrospection REQUIRED)` but does **not** fail configure without it, and instead emits a `.gir` rule that runs its own first argument as a command and dies mid-build with `app-indicator.c: not found`.

## Verification

- Built libayatana-appindicator 0.6.0 in a real `ubuntu:22.04` container with only the deps this PR adds: configures, builds, installs, and 22.04 satisfies its requirements (`ayatana-indicator3 >= 0.8.4` gives 0.9.1, `dbusmenu-gtk3`, GTK 3.24.33). Nothing else needs building from source.
- The runtime guard checked against both real libraries: 0.5.90 returns a lookup of 0, so nothing connects; 0.6.0 connects.
- `MuleTrayIcon.cpp` compiles on Linux against 0.5.94, confirming no build-time gate is needed and current distro builds are unaffected.

Not yet click-tested on a desktop running 0.6.0, since no distro packages it yet, and the full AppImage build has not been run end to end: the appindicator stage was verified in isolation.
