### PR TITLE
refactor(amuleapi): rename the search, chats and status resources

### DIFF
--- a/docs/api/EVENTS.md
+++ b/docs/api/EVENTS.md
@@ -444,27 +444,27 @@ One event per message, **inbound and outbound alike**. An outbound one is how a 
 
 ```json
 {
-  "peer":        "203.0.113.42:4662",
+  "client_address": "203.0.113.42:4662",
   "ip":          "203.0.113.42",
   "port":        4662,
   "name":        "alice",
   "client_ecid": 4382,
   "friend_ecid": 12,
-  "message":     { "id": 91, "direction": "in", "text": "thanks!", "timestamp": 1786652714 }
+  "message":     { "id": 91, "direction": "in", "text": "thanks!", "sent_at": 1786652714 }
 }
 ```
 
-`message` is identical to a `messages[]` entry on [`GET /api/v0/chats/{peer}/messages`](REFERENCE.md#get-apiv0chatspeermessages), and `name` uses the same `"IP: <ip> Port: <port>"` fallback the REST list does.
+`message` is identical to a `messages[]` entry on [`GET /api/v0/chats/{client_address}/messages`](REFERENCE.md#get-apiv0chatsclient_addressmessages), and `name` uses the same `"IP: <ip> Port: <port>"` fallback the REST list does.
 
-There is no separate "conversation started" event: a conversation that did not exist yet is implied by the first message carrying its `peer`.
+There is no separate "conversation started" event: a conversation that did not exist yet is implied by the first message carrying its `client_address`.
 
 #### `chat_session_closed`
 
 ```json
-{ "peer": "203.0.113.42:4662" }
+{ "client_address": "203.0.113.42:4662" }
 ```
 
-Closing is global — see [`DELETE /api/v0/chats/{peer}`](REFERENCE.md#delete-apiv0chatspeer). This fires whichever client closed it, including the desktop GUI, so a viewer should drop the conversation rather than assume it still exists.
+Closing is global — see [`DELETE /api/v0/chats/{client_address}`](REFERENCE.md#delete-apiv0chatsclient_address). This fires whichever client closed it, including the desktop GUI, so a viewer should drop the conversation rather than assume it still exists.
 
 ### `clients` channel
 

--- a/docs/api/EVENTS.md
+++ b/docs/api/EVENTS.md
@@ -580,49 +580,49 @@ Driven by the refresher state machine that owns the `POST /search` → completio
 
 `_added` fires per new result that appears in the results map between refresher ticks. `_updated` fires when a result you already hold changes in one of the fields below. Both carry the identical payload, so a subscriber can handle them with one function keyed by `(search_id, hash)`; they are separate names so that a consumer written against the add-only channel keeps its existing behaviour instead of silently acquiring upsert semantics.
 
-**What `_updated` covers, and what it deliberately does not.** It fires on `status`, `already_have`, `comments[]`, `kad_comment_lookup_running` and `rating` (which aggregates from the comments). Those are the fields that can change *after* a search finishes, which is the window where nothing else tells you: `search_progress` has stopped, so a hit you download from a finished search would otherwise read `already_have: false` forever, and a Kad notes lookup that lands afterwards would be invisible until someone re-read the endpoint.
+**What `_updated` covers, and what it deliberately does not.** It fires on `status`, `already_downloaded`, `comments[]`, `kad_comment_lookup_running` and `rating` (which aggregates from the comments). Those are the fields that can change *after* a search finishes, which is the window where nothing else tells you: `search_progress` has stopped, so a hit you download from a finished search would otherwise read `already_have: false` forever, and a Kad notes lookup that lands afterwards would be invisible until someone re-read the endpoint.
 
-It does **not** fire on `sources` or `children[]`. Those churn on essentially every tick of a running search, and [`search_progress`](#search_progress) already fires on every advance there and is the cue to re-read [`GET /search/{id}/results`](REFERENCE.md#get-apiv0searchidresults). Pushing them per result would duplicate an existing signal on the noisiest fields on the surface. The identity fields (`hash`, `name`, `size`, `type`, `directory`, `media`) never change for a given result, so there is nothing to push.
+It does **not** fire on `sources` or `alternate_names[]`. Those churn on essentially every tick of a running search, and [`search_progress`](#search_progress) already fires on every advance there and is the cue to re-read [`GET /search/{id}/results`](REFERENCE.md#get-apiv0searchidresults). Pushing them per result would duplicate an existing signal on the noisiest fields on the surface. The identity fields (`hash`, `name`, `size`, `type`, `directory`, `media`) never change for a given result, so there is nothing to push.
 
 ```json
 {
   "search_id": 42,
   "hash": "0123456789abcdef0123456789abcdef",
   "name": "ubuntu-24.04-desktop-amd64.iso",
-  "size": 5765873664,
+  "size_bytes": 5765873664,
   "sources": { "total": 12, "complete": 7 },
-  "already_have": false,
+  "already_downloaded": false,
   "rating": 0,
   "status": "new",
   "type": "videos",
   "media": { "duration_seconds": 5400, "bitrate_kilobits_per_second": 1500, "codec": "h264", "artist": "", "album": "", "title": "" },
-  "children": []
+  "alternate_names": []
 }
 ```
 
-`search_id` routes the result to the search that produced it — amuleapi runs several searches at once (see [REFERENCE.md](REFERENCE.md#post-apiv0search)), so demux on it. Key results by `(search_id, hash)`. Aside from the leading `search_id`, the payload is byte-for-byte identical to a `/search/{id}/results` array entry — the two are emitted by the same writer, so the promise holds by construction. That includes `status`, `type`, `directory` (the folder inside a browsed peer's share, `""` on ordinary hits), `kad_comment_lookup_running`, `comments[]` and the `children[]` grouping array — see [REFERENCE.md](REFERENCE.md#get-apiv0searchidresults); `sources` is the nested `{total, complete}` object, `media` — the audio/video metadata object — is present for locally-known/probed hits and `null` otherwise (the one place the unknown-value rule reaches an object rather than a scalar, so test `media === null` before reaching into it), and `children` holds the same-hash/different-name alternatives (empty for a single-name hit), same as the REST endpoint. Only parent results fire these events — children are folded into their parent's `children[]`, never emitted on their own. A change to a child therefore surfaces as a `search_result_updated` for its parent. Each `search_id` is an independent result space — a new `POST /search` starts a fresh one without disturbing the others.
+`search_id` routes the result to the search that produced it — amuleapi runs several searches at once (see [REFERENCE.md](REFERENCE.md#post-apiv0search)), so demux on it. Key results by `(search_id, hash)`. Aside from the leading `search_id`, the payload is byte-for-byte identical to a `/search/{id}/results` array entry — the two are emitted by the same writer, so the promise holds by construction. That includes `status`, `type`, `directory` (the folder inside a browsed peer's share, `""` on ordinary hits), `kad_comment_lookup_running`, `comments[]` and the `alternate_names[]` grouping array — see [REFERENCE.md](REFERENCE.md#get-apiv0searchidresults); `sources` is the nested `{total, complete}` object, `media` — the audio/video metadata object — is present for locally-known/probed hits and `null` otherwise (the one place the unknown-value rule reaches an object rather than a scalar, so test `media === null` before reaching into it), and `alternate_names` holds the same-hash/different-name alternatives (empty for a single-name hit), same as the REST endpoint. Only parent results fire these events — children are folded into their parent's `alternate_names[]`, never emitted on their own. A change to a child therefore surfaces as a `search_result_updated` for its parent. Each `search_id` is an independent result space — a new `POST /search` starts a fresh one without disturbing the others.
 
 #### `search_progress`
 
 Emitted whenever a search's completion advances and once more on its completion; every frame carries the `search_id` it refers to. Two triggers, both off the daemon's unambiguous `EC_TAG_SEARCH_LIFECYCLE_*` tags (see [REFERENCE.md](REFERENCE.md#get-apiv0searchidresults)): the `percent` changing between refresher ticks while the search runs, and the lifecycle flipping to finished (the `state` `running` → `finished` edge). A newly-started search also emits its initial `running` frame. The completion frame is just the terminal `search_progress` with `"state": "finished"` — there is **no** separate `search_finished` event.
 
 ```json
-{ "search_id": 42, "state": "running", "percent": 47, "results": 88, "kind": "kad" }
+{ "search_id": 42, "state": "running", "percent": 47, "result_count": 88, "type": "kad" }
 ```
 
 ```json
-{ "search_id": 42, "state": "finished", "percent": 100, "results": 153, "kind": "local" }
+{ "search_id": 42, "state": "finished", "percent": 100, "result_count": 153, "type": "local" }
 ```
 
 - `search_id` — which search this frame is about.
 - `state` — `"running"` while the search is in flight, `"finished"` on the terminal frame.
 - `percent` — `0..100`, daemon-computed for every search kind. For **global** it is the real server-queue progress. For **Kad**, which has no measurable progress, it is a cosmetic time-ramp derived from the fixed 45 s keyword-search lifetime (capped at 99 until the daemon authoritatively reports completion, then 100); see [REFERENCE.md](REFERENCE.md#get-apiv0searchidresults). Treat the Kad value as a liveliness indicator, not an accurate completion estimate.
 - `kind` — the originally-requested search type (`"local"` | `"global"` | `"kad"` | `"browse"`).
-- `results` — the current results-map size; subscribers can reconcile against any `search_result_added` / `search_result_updated` they may have missed via `GET /search/{id}/results`.
+- `result_count` — the current results-map size; subscribers can reconcile against any `search_result_added` / `search_result_updated` they may have missed via `GET /search/{id}/results`.
 
 A Kad search hitting its result cap (`SEARCHKEYWORD_TOTAL`, 300) before the 45 s deadline finishes early — the lifecycle flips to `finished` and `percent` jumps straight to 100 ahead of the ramp.
 
-A **browse** started via [`POST /clients/{ecid}/shared_files`](REFERENCE.md#post-apiv0clientsecidshared_files) rides this same channel: its `search_id` fires `search_result_added` per file the peer returns and `search_progress` frames with `"kind": "browse"`, where `percent` tracks the directories received so far. A denied / unreachable / lost browse flips to `finished` with the results it managed to collect (often zero) — same terminal frame as a completed one, no distinct failure event.
+A **browse** started via [`POST /clients/{ecid}/shared_files`](REFERENCE.md#post-apiv0clientsecidshared_files) rides this same channel: its `search_id` fires `search_result_added` per file the peer returns and `search_progress` frames with `"type": "browse"`, where `percent` tracks the directories received so far. A denied / unreachable / lost browse flips to `finished` with the results it managed to collect (often zero) — same terminal frame as a completed one, no distinct failure event.
 
 #### `search_closed`
 

--- a/docs/api/EVENTS.md
+++ b/docs/api/EVENTS.md
@@ -535,17 +535,17 @@ Rate impact is small: the overhead rates move about as often as the speeds alrea
     "high_id":     true,
     "user_id":     1234567890,
     "public_ip":   "210.2.150.73",
-    "connected_since": 1751000000,
+    "connected_since_at": 1751000000,
     "server_name": "eMule Server",
     "server_ip":   "203.0.113.5",
     "server_port": 4242,
-    "network":     { "users": 312000, "files": 75000000 }
+    "network":     { "user_count": 312000, "file_count": 75000000 }
   },
   "kad": {
     "state":      "connected",
     "firewalled_tcp": false,
-    "connected_since": 1751000000,
-    "network":    { "users": 5400000, "files": 1400000000, "nodes": 2400 }
+    "connected_since_at": 1751000000,
+    "network":    { "user_count": 5400000, "file_count": 1400000000, "node_count": 2400 }
   },
   "speeds": {
     "download_bps": 4500000, "upload_bps": 50000,

--- a/docs/api/REFERENCE.md
+++ b/docs/api/REFERENCE.md
@@ -309,8 +309,8 @@ Rows added or removed *during* a sweep are not missed: both emit an SSE event, s
 | `GET /servers`        | **`ecid`** (id), `name`, `user_count`, `ping_ms`, `file_count` |
 | `GET /friends`        | **`ecid`** (id), `name`, `online` |
 | `GET /chats`          | **`client_ecid`** (id), `last_message_at`, `name` |
-| `GET /search/{id}/results` | **`hash`** (id), `name`, `size`, `sources`, `rating`, `directory` |
-| `GET /search`         | **`search_id`** (id), `query`, `started_at`, `result_count` |
+| `GET /search/{id}/results` | **`hash`** (id), `name`, `size_bytes`, `sources.total`, `rating`, `directory` |
+| `GET /search`         | **`id`** (id), `query`, `started_at`, `result_count` |
 | `GET /categories`     | **`index`** (id), `name` |
 
 The column marked **id** is the endpoint's identity: immutable for the life of the row, and the only one `after` accepts. Note that `ecid` is stable **within a daemon session** only — `CECID` hands ids out from a counter that restarts with the process — which is enough for a bootstrap sweep, since a reconnect invalidates the sweep anyway and triggers a `resync`.
@@ -2733,9 +2733,9 @@ Lists every search amuled currently holds — including ones started by a **diff
 ```json
 {
   "searches": [
-    { "search_id": 42, "query": "ubuntu desktop iso", "kind": "global", "state": "finished", "started_at": 1751000000, "result_count": 182 },
-    { "search_id": 43, "query": "debian",             "kind": "kad",    "state": "running",  "started_at": 1751000042, "result_count": 57  },
-    { "search_id": 44, "query": "SomePeerNick",       "kind": "browse", "state": "running",  "client_ecid": 621,       "result_count": 237 }
+    { "id": 42, "query": "ubuntu desktop iso", "type": "global", "state": "finished", "started_at": 1751000000, "result_count": 182 },
+    { "id": 43, "query": "debian",             "type": "kad",    "state": "running",  "started_at": 1751000042, "result_count": 57  },
+    { "id": 44, "query": "SomePeerNick",       "type": "browse", "state": "running",  "client_ecid": 621,       "result_count": 237 }
   ],
   "total": 3,
   "offset": 0,
@@ -2745,7 +2745,7 @@ Lists every search amuled currently holds — including ones started by a **diff
 
 This is a list endpoint like the others: it takes `?limit`, `?offset`, `?sort` and `?order`, and carries the same `total` / `offset` / `limit` trio. See [List pagination and sorting](#list-pagination-and-sorting); the sort keys are `search_id`, `query`, `started_at` and `result_count`.
 
-`search_id` is the value that fills `{id}` on every search-scoped path: [`GET /search/{id}/results`](#get-apiv0searchidresults) to read its hits, [`POST /search/{id}/stop`](#post-apiv0searchidstop) to stop it, [`DELETE /search/{id}`](#delete-apiv0searchid) to free it. `kind` is `"local"` | `"global"` | `"kad"` | `"browse"`. The first three are the vocabulary `POST /search`'s `type` accepts; `"browse"` is reported only, for a "View Files" listing of one peer's share, which is started through the client endpoints rather than by a query. `state` is `"running"` | `"finished"` | `"idle"`, same vocabulary and meaning as `GET /search/{id}/results`'s `progress.state`.
+`id` is the value that fills `{id}` on every search-scoped path: [`GET /search/{id}/results`](#get-apiv0searchidresults) to read its hits, [`POST /search/{id}/stop`](#post-apiv0searchidstop) to stop it, [`DELETE /search/{id}`](#delete-apiv0searchid) to free it. `kind` is `"local"` | `"global"` | `"kad"` | `"browse"`. The first three are the vocabulary `POST /search`'s `type` accepts; `"browse"` is reported only, for a "View Files" listing of one peer's share, which is started through the client endpoints rather than by a query. `state` is `"running"` | `"finished"` | `"idle"`, same vocabulary and meaning as `GET /search/{id}/results`'s `progress.state`.
 
 For a `"browse"` entry, `state` and the results endpoint's `progress.percent` come from the browse's own lifecycle rather than from a query's: the request being sent is `"running"`, and the peer having answered, denied the request, or disconnected mid-list is `"finished"` — a browse is never reported as `"idle"`. `percent` is the share of the peer's directory list received so far, so it climbs while the listing streams in rather than jumping straight from `0` to `100`.
 
@@ -2779,9 +2779,9 @@ Kicks off a new search. amuleapi supports **several concurrent searches** — a 
   "type":      "global",
   "file_type": "iso",
   "extension": "iso",
-  "min_size":  1000000000,
-  "max_size":  5000000000,
-  "min_avail": 5
+  "min_size_bytes":  1000000000,
+  "max_size_bytes":  5000000000,
+  "min_source_count": 5
 }
 ```
 
@@ -2791,16 +2791,16 @@ Only `query` is required. `type` defaults to `"global"`; valid values are `"loca
 
 ```json
 {
-  "search_id":   42,
+  "id":         42,
   "query":       "ubuntu desktop iso",
-  "kind":        "global",
+  "type":        "global",
   "state":       "running",
   "client_ecid": null,
   "started_at":  1750412400
 }
 ```
 
-Keep the `search_id` to read this search's results/progress or to stop it. This is one of the two creations that answer with the resource, because `EC_OP_SEARCH_START` really does hand one back; the ones whose EC op answers success or failure and nothing more are a bare `202` with no body.
+Keep the `id` to read this search's results/progress or to stop it. This is one of the two creations that answer with the resource, because `EC_OP_SEARCH_START` really does hand one back; the ones whose EC op answers success or failure and nothing more are a bare `202` with no body.
 
 **Errors:** `502 amuled_rejected` (daemon returned no search_id), `503 ec_unavailable`.
 
@@ -2830,13 +2830,13 @@ amuled keeps a bounded ring of recent searches (20). A search evicted from that 
       "name":         "example-distribution-26.04-amd64.iso",
       "size":         3825205248,
       "sources":      { "total": 217, "complete": 142 },
-      "already_have": false,
+      "already_downloaded": false,
       "rating":       0,
       "status":       "new",
       "type":         "videos",
       "directory":    "",
       "media":        { "duration_seconds": 5400, "bitrate": 1500, "codec": "h264", "artist": "", "album": "", "title": "" },
-      "children": [
+      "alternate_names": [
         { "ecid": 621, "name": "example-distribution-26.04.iso", "hash": "8b54a3c2...", "sources": { "total": 40, "complete": 22 }, "directory": "" },
         { "ecid": 622, "name": "example_distro_2604_amd64.iso",  "hash": "8b54a3c2...", "sources": { "total": 10, "complete":  3 }, "directory": "" }
       ],
@@ -2844,23 +2844,23 @@ amuled keeps a bounded ring of recent searches (20). A search evicted from that 
       "comments": []
     }
   ],
-  "search_id": 42,
+  "id":         42,
   "query": "ubuntu desktop iso",
   "progress": {
     "state":    "running",
-    "kind":     "kad",
+    "type":     "kad",
     "percent":  67
   }
 }
 ```
 
-Each result carries `sources` as a nested `{total, complete}` object — `total` is the swarm size amuled reports and `complete` is how many of those hold the file complete. `already_have` is `true` when you are currently downloading the file or already have it completed/shared; it is `false` for a fresh result and for one you have canceled/removed (a canceled result is re-downloadable, so it does not read as held). `rating` is amuled's aggregated quality rating (`0` when unrated). `status` is this result's download status on your node — `"new"` / `"downloaded"` / `"queued"` / `"canceled"` / `"queued_canceled"`. `type` is the file-type token derived from the filename extension (same tokens as the shared-detail [`file_type`](#get-apiv0sharedhash), e.g. `"videos"` / `"audio"`; `""` when the name has no extension). `media` is the audio/video [media metadata](#media-metadata) object (same shape as the file-detail endpoints), and is **`null`** for a hit that carries no metadata (most global/Kad results), matching the blank Length/Bitrate/Codec columns in the desktop search list. The key is always present. **Unlike `media` on `GET /downloads/{hash}` and `GET /shared/{hash}`, which amuled probed locally, `media` on a search result is whatever the responding server advertised.** It is not verified against the file and can contradict it — a `.pdf` reporting a runtime and a video codec is a real observed result — so treat it as a hint, not as probed metadata.
+Each result carries `sources` as a nested `{total, complete}` object — `total` is the swarm size amuled reports and `complete` is how many of those hold the file complete. `already_downloaded` is `true` when you are currently downloading the file or already have it completed/shared; it is `false` for a fresh result and for one you have canceled/removed (a canceled result is re-downloadable, so it does not read as held). `rating` is amuled's aggregated quality rating (`0` when unrated). `status` is this result's download status on your node — `"new"` / `"downloaded"` / `"queued"` / `"canceled"` / `"queued_canceled"`. `type` is the file-type token derived from the filename extension (same tokens as the shared-detail [`file_type`](#get-apiv0sharedhash), e.g. `"videos"` / `"audio"`; `""` when the name has no extension). `media` is the audio/video [media metadata](#media-metadata) object (same shape as the file-detail endpoints), and is **`null`** for a hit that carries no metadata (most global/Kad results), matching the blank Length/Bitrate/Codec columns in the desktop search list. The key is always present. **Unlike `media` on `GET /downloads/{hash}` and `GET /shared/{hash}`, which amuled probed locally, `media` on a search result is whatever the responding server advertised.** It is not verified against the file and can contradict it — a `.pdf` reporting a runtime and a video codec is a real observed result — so treat it as a hint, not as probed metadata.
 
 `directory` is the folder this file sits in **inside a browsed peer's share** — the desktop search list's *Directories* column. It is populated only for results filed from a peer's shared-file listing (see [peer browse](#post-apiv0clientsecidshared_files)) and is `""` on every ordinary server/Kad hit, which never carries it. It is per-result rather than per-search: two copies of one file in different folders of the same share group under a single parent and each keeps its own folder, exactly as the desktop shows them, which is why `children[]` entries carry it too.
 
 `search_id` and `query` identify the search these results belong to. `search_id` echoes the path so clients can key a view on the response alone; `query` is what the search was started with, so a client that adopted an id from [`GET /search`](#get-apiv0search) can label it without a second call. For a **browse**, `query` is the peer's nickname rather than a query string. `query` is `""` only for a search discovered before amuled reported a name for it.
 
-`children` is the result-grouping tree: amuled collapses hits that are the **same file** (same ed2k hash **and** size) but advertised under **different filenames** into one parent row, and `children[]` holds the alternative names. Each child carries the parent's `hash` (that's why they group), its own `sources`, and a distinct `ecid` — pass that `ecid` to [`POST /search/results/{hash}/download`](#post-apiv0searchresultshashdownload) to download the file **under that chosen filename**. `children` is always present and is an empty array for a hit seen under a single name. The top-level `results[]` contains parents only — a child never appears as its own top-level entry.
+`alternate_names` is the result-grouping tree: amuled collapses hits that are the **same file** (same ed2k hash **and** size) but advertised under **different filenames** into one parent row, and `children[]` holds the alternative names. Each child carries the parent's `hash` (that's why they group), its own `sources`, and a distinct `ecid` — pass that `ecid` to [`POST /search/results/{hash}/download`](#post-apiv0searchresultshashdownload) to download the file **under that chosen filename**. `alternate_names` is always present and is an empty array for a hit seen under a single name. The top-level `results[]` contains parents only — a child never appears as its own top-level entry.
 
 `kad_comment_lookup_running` and `comments` carry the file's community ratings/comments fetched from Kad. Unlike a download — whose comments come from connected sources — a search result has no sources, so `comments` is populated purely by an on-demand Kad notes lookup you start with [`POST /search/results/{hash}/comments`](#post-apiv0searchresultshashcomments). `kad_comment_lookup_running` is `true` while that lookup is in flight and flips back to `false` when it finishes; `comments` is an empty array until notes arrive, each entry shaped like a download comment (`username` / `filename` / `rating` / `comment`, with `username` the responding node's IP or `Kad user`). Both fields are always present.
 

--- a/docs/api/REFERENCE.md
+++ b/docs/api/REFERENCE.md
@@ -591,17 +591,17 @@ curl -s -H "Authorization: Bearer $TOKEN" http://$HOST/api/v0/status
     "high_id": true,
     "user_id": 1234567890,
     "public_ip": "210.2.150.73",
-    "connected_since": 1751000000,
+    "connected_since_at": 1751000000,
     "server_name": "eMule Server",
     "server_ip": "203.0.113.5",
     "server_port": 4242,
-    "network": { "users": 312000, "files": 75000000 }
+    "network": { "user_count": 312000, "file_count": 75000000 }
   },
   "kad": {
     "state": "connected",
     "firewalled_tcp": false,
-    "connected_since": 1751000000,
-    "network": { "users": 5400000, "files": 1400000000, "nodes": 2400 }
+    "connected_since_at": 1751000000,
+    "network": { "user_count": 5400000, "file_count": 1400000000, "node_count": 2400 }
   },
   "speeds": {
     "download_bps": 4500000,
@@ -2214,7 +2214,7 @@ Returns every preference category amuled carries over EC. The `general` and `con
     "exclude_patterns": "",
     "exclude_patterns_use_regex": false
   },
-  "files": {
+  "file_count": {
     "ich_enabled": true, "aich_trust_every_hash": false,
     "add_new_downloads_paused": false, "new_downloads_auto_priority": false,
     "new_shared_files_auto_priority": false,
@@ -2307,7 +2307,7 @@ Read-only fields are **ignored rather than rejected** when they arrive alongside
 Body shape mirrors the GET; every sub-object and every field is optional, and fields not present are left unchanged. Subset example:
 
 ```json
-{ "files": { "add_new_downloads_paused": true }, "servers": { "dead_server_retries": 5 } }
+{ "file_count": { "add_new_downloads_paused": true }, "servers": { "dead_server_retries": 5 } }
 ```
 
 `remote_controls` nests its two independent subsystems as `remote_controls.webserver` and `remote_controls.amuleapi` rather than prefixing every field. It reports amuleapi's `enabled` / `port` / `bind_address`, but **not** whether its admin or guest password is set. Those live in `amuleapi-passwords`, which amuleapi owns and which may sit on a different host from amuled — so the daemon's view of that file can be the wrong one. Ask the API that actually reads it: [`GET /auth/passwords`](#get-apiv0authpasswords), which is admin-only, whereas this endpoint is readable by any authenticated role. `webserver.guest_enabled` is reported because it is a genuine amuled preference rather than a fact about another process's file.
@@ -2441,10 +2441,10 @@ Standalone view of the Kad subtree from `/status`, plus the detail fields the st
   "firewalled_tcp": false,
   "firewalled_udp": false,
   "lan_mode": false,
-  "connected_since": 1751000000,
+  "connected_since_at": 1751000000,
   "public_ip": "203.0.113.5",
-  "network": { "users": 5400000, "files": 1400000000, "nodes": 2400 },
-  "indexed": { "sources": 12000, "keywords": 8500, "notes": 0, "load": 14 },
+  "network": { "user_count": 5400000, "file_count": 1400000000, "node_count": 2400 },
+  "indexed": { "sources": 12000, "keywords": 8500, "notes": 0, "load_percent": 14 },
   "buddy": { "status": "connected", "ip": "203.0.113.9", "port": 4672 }
 }
 ```
@@ -2453,16 +2453,16 @@ Standalone view of the Kad subtree from `/status`, plus the detail fields the st
 |---|---|---|
 | `state` | string | `disabled` / `connecting` / `connected`. `disabled` means Kad is not running at all, which is the condition several fields below key their "no measurement" value on. The same value `GET /api/v0/status` reports as `kad.state`. |
 | `node_id` | string | This node's own 128-bit Kademlia id, 32 lowercase hex characters (the desktop panel shows the same value uppercase). `""` while Kad is not running, which is exactly when `state` is `disabled`. Persisted by the daemon, so unlike the session-scoped ECIDs and the server-assigned eD2k id it is stable across restarts — the one identifier for the local node a consumer can key on. It is a DHT routing key, not a credential: every Kad contact the daemon talks to learns it. |
-| `connected_since` | int | Unix seconds of the most recent Kad connect, the same value `GET /api/v0/status` reports as `kad.connected_since`. `0` when not connected, so gate on `state` rather than trusting a `0`. |
+| `connected_since_at` | int | Unix seconds of the most recent Kad connect, the same value `GET /api/v0/status` reports as `kad.connected_since`. `0` when not connected, so gate on `state` rather than trusting a `0`. |
 | `public_ip` | string | This node's externally-visible IPv4, as a remote Kad contact reported it back. Two "not known" cases, both matching what the desktop panel's *IP address* row shows: `""` while Kad is not connected (the daemon sends the field only then), and `0.0.0.0` while connected but not yet told its own address by any contact. **Two distinct "unknown" sentinels, one of them a syntactically valid address**: a consumer that only checks for `""` will treat `0.0.0.0` as a real IP. Distinct from `preferences.connection.bind_address`, which is the local interface the daemon binds to. Named `public_ip` rather than `ip` because `buddy.ip` in the same payload belongs to somebody else. |
 | `firewalled_tcp` | bool \| null | Whether this node is firewalled for **TCP**. The verdict is a **vote**: two distinct peers must confirm reachability by opening an incoming TCP connection carrying `OP_KAD_FWTCPCHECK_ACK` before it clears to `false`. With no verdict yet it reads **`true`**, the conservative assumption. During an IP recheck it freezes at its previous value rather than momentarily reporting a false LowID. **`null` unless `state` is `connected`** - the underlying bit outlives a disconnect, so this used to report a reachability verdict for a network the daemon was not on. Named for the transport because it is one half of a pair, not an overall verdict that `firewalled_udp` refines. |
 | `firewalled_udp` | bool \| null | Whether this node is firewalled for **UDP**, measured by an entirely different mechanism: a directed test with its own state, which can also declare firewalled **by timeout** after six minutes. **`null` unless `state` is `connected`.** It previously read `false` while Kad was down, which was the absence of a measurement dressed as "UDP is open" - the asymmetry with `firewalled_tcp`'s `true` made the pair actively misleading. Both are `null` now, so there is nothing to misread. |
 | `lan_mode` | bool \| null | `true` when the daemon is running Kad in LAN mode. It **forces both firewalled fields to `false`** regardless of any measurement, which is why it belongs beside them: a `false` on either flag is only meaningful once you have checked this one. `null` unless `state` is `connected`. |
-| `network.users` / `.files` | int \| null | Network-wide estimates for the whole Kad network, not counts belonging to this node. The same values `GET /api/v0/status` reports under `kad.network`. **`null` unless `state` is `connected`** - they used to keep their last estimate through a disconnect, indistinguishable from a live reading. |
-| `network.nodes` | int \| null | **This node's own routing table size** - how many Kad contacts it currently holds - *not* a network-wide figure like the two above. Saturates at 65535 (the daemon counts it in a `uint16`). **`null` unless `state` is `connected`**: routing contacts outlive the disconnect, so this was measured at `2` on a fully stopped Kad. |
+| `network.user_count` / `.files` | int \| null | Network-wide estimates for the whole Kad network, not counts belonging to this node. The same values `GET /api/v0/status` reports under `kad.network`. **`null` unless `state` is `connected`** - they used to keep their last estimate through a disconnect, indistinguishable from a live reading. |
+| `network.node_count` | int \| null | **This node's own routing table size** - how many Kad contacts it currently holds - *not* a network-wide figure like the two above. Saturates at 65535 (the daemon counts it in a `uint16`). **`null` unless `state` is `connected`**: routing contacts outlive the disconnect, so this was measured at `2` on a fully stopped Kad. |
 | `indexed.sources` / `.keywords` / `.notes` | int \| null | Kad-store counters: how many entries this node is holding for the network as a DHT participant. `null` unless `state` is `connected` - they previously read `0`, which is a real count and indistinguishable from an idle but connected node. |
-| `indexed.load` | int \| null | A **load figure, not a count**, despite sitting beside three counts: it is the Kad store's fill level. `null` unless `state` is `connected`, on the same gate as the three counters above. |
-| `buddy.status` | string \| null | LowID-buddy state for NAT-traversal peers: `no_buddy` / `connecting` / `connected` (`unknown` only if the daemon ever ships a value outside its own enum). **`null` unless `state` is `connected`**, along with `buddy.ip` / `buddy.port`; it previously read `no_buddy`, which is a real state rather than the absence of one. While connected with no buddy, `ip` / `port` are `0.0.0.0` / `0`. |
+| `indexed.load_percent` | int \| null | A **load figure, not a count**, despite sitting beside three counts: it is the Kad store's fill level. `null` unless `state` is `connected`, on the same gate as the three counters above. |
+| `buddy.state` | string \| null | LowID-buddy state for NAT-traversal peers: `no_buddy` / `connecting` / `connected` (`unknown` only if the daemon ever ships a value outside its own enum). **`null` unless `state` is `connected`**, along with `buddy.ip` / `buddy.port`; it previously read `no_buddy`, which is a real state rather than the absence of one. While connected with no buddy, `ip` / `port` are `0.0.0.0` / `0`. |
 
 ---
 
@@ -2690,8 +2690,8 @@ Time-series points behind the desktop Statistics graphs.
   "interval_seconds": 1,
   "max_points": 1800,
   "points": [
-    { "t": "2026-06-14T09:40:00Z", "t_unix": 1781430000, "value": 42, "active_downloads": 7, "active_uploads": 4 },
-    { "t": "2026-06-14T09:40:01Z", "t_unix": 1781430001, "value": 44, "active_downloads": 8, "active_uploads": 4 }
+    { "at": 1781430000, "value": 42, "active_downloads": 7, "active_uploads": 4 },
+    { "at": 1781430001, "value": 44, "active_downloads": 8, "active_uploads": 4 }
   ],
   "session": {
     "download_bytes": 12400000000,
@@ -2702,7 +2702,7 @@ Time-series points behind the desktop Statistics graphs.
 }
 ```
 
-Each point has `t` (ISO-8601 UTC), `t_unix` (unix seconds) and `value`, spaced by `interval_seconds`. `unit` is `"bytes_per_second"` for the two speed graphs and `"count"` for the other two.
+Each point has `t` (ISO-8601 UTC), `at` (unix seconds) and `value`, spaced by `interval_seconds`. `unit` is `"bytes_per_second"` for the two speed graphs and `"count"` for the other two.
 
 `max_points` is how many points this daemon can answer with before it starts repeating records; `points` is never longer than it. It is not a constant across daemons, so a client that wants the deepest window available should read it rather than assume 1800.
 

--- a/docs/api/REFERENCE.md
+++ b/docs/api/REFERENCE.md
@@ -76,9 +76,9 @@ The API is versioned in the path. **`/api/v0/` is the pre-release surface and is
 - [`POST /api/v0/friends/{ecid}/shared_files`](#post-apiv0friendsecidshared_files) — browse a friend's shared files
 - [`POST /api/v0/friends/{ecid}/messages`](#post-apiv0friendsecidmessages) — message a friend, online or offline
 - [`GET /api/v0/chats`](#get-apiv0chats) — list chat conversations
-- [`GET /api/v0/chats/{peer}/messages`](#get-apiv0chatspeermessages) — read a conversation's history
-- [`POST /api/v0/chats/{peer}/messages`](#post-apiv0chatspeermessages) — send a message to a peer address
-- [`DELETE /api/v0/chats/{peer}`](#delete-apiv0chatspeer) — close a conversation
+- [`GET /api/v0/chats/{client_address}/messages`](#get-apiv0chatsclient_addressmessages) — read a conversation's history
+- [`POST /api/v0/chats/{client_address}/messages`](#post-apiv0chatsclient_addressmessages) — send a message to a peer address
+- [`DELETE /api/v0/chats/{client_address}`](#delete-apiv0chatsclient_address) — close a conversation
 - [`POST /api/v0/clients/{ecid}/messages`](#post-apiv0clientsecidmessages) — message a connected peer
 
 **Categories**
@@ -247,7 +247,7 @@ The conversion to and from the host-order integers EC carries happens inside amu
 One rule, everywhere: **a query parameter the server does not understand is a `400 bad_request`, never a silent default.** That covers both halves of "does not understand": a value that will not parse, and a value outside the parameter's documented range.
 
 - Booleans (`include_parts`) accept `1`/`0`, `true`/`false` and `yes`/`no`. Anything else is a `400`.
-- Counts (`limit`, `offset`, `tail`, `width`, `interval`, `max_client_versions`, `since_id`) accept decimal digits within the range documented for that parameter. A non-numeric value, a negative one, or one outside the range is a `400` naming the bound.
+- Counts (`limit`, `offset`, `tail`, `width`, `interval`, `max_client_versions`, `since_message_id`) accept decimal digits within the range documented for that parameter. A non-numeric value, a negative one, or one outside the range is a `400` naming the bound.
 - An omitted parameter takes the documented default. Only omission does that; an empty value (`?limit=`) is a `400`, not an omission.
 
 Nothing clamps. A count above its cap used to be quietly reduced on some endpoints, so a count over the cap returned a full page with nothing in the response saying the request had been altered; it is now a rejection, which is the same answer the other endpoints already gave.
@@ -462,7 +462,7 @@ Every path segment, query parameter and JSON key on this surface follows the rul
 | **R9** | **A writable field accepts the values the same field returns.** Where a write is really a command it belongs in a differently-named key (`action`), not in the read field's name. |
 | **R10** | **Always emit the key.** An unknown value is `null`, never an omitted key and never a `0`/`-1` sentinel. The few deliberate exceptions are enumerated under [Response model](#response-model). |
 | **R11** | **Group by quantity, not by scope.** A sub-object earns its place when it groups *different* quantities (`sources`, `progress`, `media`). One quantity split by time window does not — the window belongs in the key, not in a wrapper. |
-| **R12** | **One word for the remote party: `client`.** `peer` is not used in a key, a path or an enum value. `source` is not a synonym: a source is a client *in a role with respect to one file*, so it survives only where that relation is what is being described (`sources.total`, `source_origin`). |
+| **R12** | **One word for the remote party: `client`.** `client_address` is not used in a key, a path or an enum value. `source` is not a synonym: a source is a client *in a role with respect to one file*, so it survives only where that relation is what is being described (`sources.total`, `source_origin`). |
 
 ### Why rates are spelled out
 
@@ -1009,7 +1009,7 @@ Each entry is the [`/clients`](#get-apiv0clients) list object plus three keys:
 
 `role` and `a4af` are orthogonal: a pure A4AF row is `role: "none"`, `a4af: true`, but a peer can be parked on another file *and* be pulling this one from us (`role: "peer"`, `a4af: true`).
 
-`parts` is opt-in because it is one boolean per chunk per peer — a multi-TiB file is 100k+ entries each. It is exactly `parts_total_count` entries, and it describes the file this row is about: the download bitmap for a `source`, the upload bitmap for a `peer`. A peer the core reports as holding every part comes back all-`true`. A pure A4AF row has no bitmap for this file and omits the key. **`parts` never appears in SSE payloads.**
+`parts` is opt-in because it is one boolean per chunk per peer — a multi-TiB file is 100k+ entries each. It is exactly `parts_total_count` entries, and it describes the file this row is about: the download bitmap for a `source`, the upload bitmap for a `client_address`. A peer the core reports as holding every part comes back all-`true`. A pure A4AF row has no bitmap for this file and omits the key. **`parts` never appears in SSE payloads.**
 
 The file's own three-state part view is on [`GET /downloads/{hash}`](#get-apiv0downloadshash); combine it with this bitmap to render the desktop's per-source bar.
 
@@ -3010,11 +3010,11 @@ Peers whose country could not be resolved — GeoIP disabled, unsupported by the
 
 Conversations with peers, backed by the chat session store in `amuled`. The store is shared: a message sent from the desktop GUI, from amulegui or through this API lands in the same transcript, and every client sees the same conversation.
 
-A conversation is keyed on `{peer}` = `"<ip>:<port>"` (for example `203.0.113.42:4662`). That is the readable form of the internal id the EC wire already uses, it is stable across peer reconnects — unlike an ECID — and it needs no identifier of its own. A `{peer}` that is not four dotted octets plus a port is a `400`.
+A conversation is keyed on `{client_address}` = `"<ip>:<port>"` (for example `203.0.113.42:4662`). That is the readable form of the internal id the EC wire already uses, it is stable across peer reconnects — unlike an ECID — and it needs no identifier of its own. A `{client_address}` that is not four dotted octets plus a port is a `400`.
 
 The store is **in memory**: an `amuled` restart empties every conversation, exactly as the desktop's own transcript dies with its notebook tab. Retention is bounded at 200 messages per conversation and 50 conversations, evicting the least recently active first.
 
-Message `id` is monotonic per `amuled` process and never reused, which makes it a safe polling cursor: `since_id` never returns a duplicate and never skips a message. It resets when the daemon restarts, which also empties the store.
+Message `id` is monotonic per `amuled` process and never reused, which makes it a safe polling cursor: `since_message_id` never returns a duplicate and never skips a message. It resets when the daemon restarts, which also empties the store.
 
 Every endpoint here answers `503 ec_unsupported` when the connected `amuled` does not serve chat.
 
@@ -3030,7 +3030,7 @@ curl -s -H "Authorization: Bearer $TOKEN" "http://$HOST/api/v0/chats"
 {
   "chats": [
     {
-      "peer":            "203.0.113.42:4662",
+      "client_address":            "203.0.113.42:4662",
       "ip":              "203.0.113.42",
       "port":            4662,
       "name":            "alice",
@@ -3038,9 +3038,9 @@ curl -s -H "Authorization: Bearer $TOKEN" "http://$HOST/api/v0/chats"
       "friend_ecid":     12,
       "online":          true,
       "message_count":   14,
-      "last_msg_id":     91,
+      "last_message_id":     91,
       "last_message_at": 1786652714,
-      "last_message":    { "id": 91, "direction": "in", "text": "thanks!", "timestamp": 1786652714 }
+      "last_message":    { "id": 91, "direction": "in", "text": "thanks!", "sent_at": 1786652714 }
     }
   ],
   "total": 1, "offset": 0, "limit": 1
@@ -3055,29 +3055,29 @@ Served from the refresher snapshot — no EC roundtrip per request. Standard [li
 
 **Errors:** `503 ec_unsupported`, `503 ec_unavailable`.
 
-#### `GET /api/v0/chats/{peer}/messages`
+#### `GET /api/v0/chats/{client_address}/messages`
 
 **Auth:** `GUEST`
 
-**Query:** `since_id=N` (only messages with `id > N`), `tail=N` (the last N of that window, max `100000`). This selects a tail rather than a page, which is why it is not called `limit`: on the list endpoints `limit` is a window paired with `offset`, and one word meaning two things is a rule a client has to learn twice.
+**Query:** `since_message_id=N` (only messages with `id > N`), `tail=N` (the last N of that window, max `100000`). This selects a tail rather than a page, which is why it is not called `limit`: on the list endpoints `limit` is a window paired with `offset`, and one word meaning two things is a rule a client has to learn twice.
 
 ```json
 {
-  "peer": "203.0.113.42:4662",
+  "client_address": "203.0.113.42:4662",
   "messages": [
-    { "id": 90, "direction": "out", "text": "hi",      "timestamp": 1786652700 },
-    { "id": 91, "direction": "in",  "text": "thanks!", "timestamp": 1786652714 }
+    { "id": 90, "direction": "out", "text": "hi",      "sent_at": 1786652700 },
+    { "id": 91, "direction": "in",  "text": "thanks!", "sent_at": 1786652714 }
   ],
   "total": 14,
-  "last_msg_id": 91
+  "last_message_id": 91
 }
 ```
 
-`direction` is `"in"` (from the peer) or `"out"` (sent by us — from **any** client: this API, amulegui, or the desktop GUI). `timestamp` is stamped by the core when the message was received or sent. `total` counts everything the store holds for this conversation, not the returned window.
+`direction` is `"in"` (from the peer) or `"out"` (sent by us — from **any** client: this API, amulegui, or the desktop GUI). `sent_at` is stamped by the core when the message was received or sent. `total` counts everything the store holds for this conversation, not the returned window.
 
-**Errors:** `404 not_found` (no such conversation), `400 bad_request` (malformed `{peer}` or query), `503 ec_unsupported`, `503 ec_unavailable`.
+**Errors:** `404 not_found` (no such conversation), `400 bad_request` (malformed `{client_address}` or query), `503 ec_unsupported`, `503 ec_unavailable`.
 
-#### `POST /api/v0/chats/{peer}/messages`
+#### `POST /api/v0/chats/{client_address}/messages`
 
 **Auth:** `ADMIN`
 
@@ -3089,13 +3089,13 @@ curl -s -X POST -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/
 ```
 
 ```json
-{ "peer": "203.0.113.42:4662",
+{ "client_address": "203.0.113.42:4662",
   "message": { "id": 92, "direction": "out", "text": "hello" } }
 ```
 
 The created message stays in the body because no per-message `GET` defines a shape for it, so the store-assigned `id` is only readable here. The **timestamp is not** in this reply — read it back from [`GET /chats`](#get-apiv0chats) (as `last_message`), from the per-conversation messages endpoint, or from the `chat_message` SSE event.
 
-The core creates the conversation if it does not exist, so this doubles as "start a chat with this address" — an unknown `{peer}` is not a `404` here.
+The core creates the conversation if it does not exist, so this doubles as "start a chat with this address" — an unknown `{client_address}` is not a `404` here.
 
 Returns `202 Accepted`, not `200`: the core acknowledges that it queued the message on the peer connection, not that the peer received it. An unreachable peer is not an error — the desktop behaves the same, optimistically showing `*** Connecting to Client ***`.
 
@@ -3109,7 +3109,7 @@ Message a friend by friend ECID. This is the form that reaches an **offline** fr
 
 **Body:** `{ "text": "hello" }`
 
-**Response:** `202 Accepted` → `{ "peer": "203.0.113.42:4662", "message": { … } }`, so the caller learns the conversation key to read back.
+**Response:** `202 Accepted` → `{ "client_address": "203.0.113.42:4662", "message": { … } }`, so the caller learns the conversation key to read back.
 
 **Errors:** `404 not_found` (no friend with that ECID), plus the set above.
 
@@ -3121,7 +3121,7 @@ The peer-addressed form, for a caller holding a peer row that should not have to
 
 **Errors:** `404 not_found` (no live peer with that ECID), plus the set above.
 
-#### `DELETE /api/v0/chats/{peer}`
+#### `DELETE /api/v0/chats/{client_address}`
 
 **Auth:** `ADMIN`
 

--- a/src/webapi/Api.cpp
+++ b/src/webapi/Api.cpp
@@ -3413,11 +3413,14 @@ struct SearchListRow
 void WriteSearchListRow(CJsonWriter &w, const SearchListRow &row)
 {
 	w.BeginObject();
-	w.Key("search_id");
+	// `id`, not `search_id`: the object would be prefixing its own key with
+	// its own type. References from OUTSIDE keep the prefix -- the SSE
+	// payloads and the results envelope point into this object.
+	w.Key("id");
 	w.ValueInt(static_cast<int64_t>(row.search_id));
 	w.Key("query");
 	w.ValueString(row.query);
-	w.Key("kind");
+	w.Key("type");
 	w.ValueString(wxString::FromUTF8(row.kind.c_str()));
 	w.Key("state");
 	w.ValueString(wxString::FromUTF8(row.state.c_str()));
@@ -3439,7 +3442,7 @@ void WriteSearchListRow(CJsonWriter &w, const SearchListRow &row)
 const ListComparators<SearchListRow> &SearchListComparators()
 {
 	static const ListComparators<SearchListRow> kComps = {
-		{ "search_id", SORT_BY(search_id), ANCHOR_ON_NUM(search_id) },
+		{ "id", SORT_BY(search_id), ANCHOR_ON_NUM(search_id) },
 		{ "query", SORT_BY(query) },
 		{ "started_at", SORT_BY(started_at) },
 		{ "result_count", SORT_BY(result_count) },
@@ -7788,8 +7791,9 @@ CHttpServer::Response CApiDispatcher::HandleSearchResults(
 		// cares about, not the order a UI table does.
 		{ "hash", SORT_BY(hash), ANCHOR_ON(hash) },
 		{ "name", SORT_BY(name) },
-		{ "size", SORT_BY(size) },
-		{ "sources", SORT_BY(source_count) },
+		// R7: spelled like the response keys they order by.
+		{ "size_bytes", SORT_BY(size) },
+		{ "sources.total", SORT_BY(source_count) },
 		{ "rating", SORT_BY(rating) },
 		// Browse listings are read folder by folder, which is how the
 		// desktop sorts its Directories column too. Empty on server/Kad
@@ -7832,7 +7836,8 @@ CHttpServer::Response CApiDispatcher::HandleSearchResults(
 	w.BeginObject();
 	w.Key("state");
 	w.ValueString(SearchLifecycleStateToString(progress.complete ? 2 : progress.active ? 1 : 0));
-	w.Key("kind");
+	// `type`, matching POST /search's body field and the searches[] row (R6).
+	w.Key("type");
 	w.ValueString(wxString::FromUTF8(progress.kind.c_str()));
 	w.Key("percent");
 	w.ValueInt(static_cast<int64_t>(progress.percent));
@@ -10599,43 +10604,45 @@ CHttpServer::Response CApiDispatcher::HandleSearchStart(const CHttpServer::Reque
 	std::uint64_t max_size = 0;
 	std::uint32_t min_avail = 0;
 	{
-		const auto it = obj.find("min_size");
+		const auto it = obj.find("min_size_bytes");
 		if (it != obj.end()) {
 			if (!it->second.is<double>()) {
 				return ErrorResponse(400,
 					"bad_request",
-					"`min_size` must be a non-negative integer (bytes)");
+					"`min_size_bytes` must be a non-negative integer (bytes)");
 			}
 			const double v = it->second.get<double>();
 			if (v < 0)
-				return ErrorResponse(400, "bad_request", "`min_size` must be >= 0");
+				return ErrorResponse(400, "bad_request", "`min_size_bytes` must be >= 0");
 			min_size = static_cast<std::uint64_t>(v);
 		}
 	}
 	{
-		const auto it = obj.find("max_size");
+		const auto it = obj.find("max_size_bytes");
 		if (it != obj.end()) {
 			if (!it->second.is<double>()) {
 				return ErrorResponse(400,
 					"bad_request",
-					"`max_size` must be a non-negative integer (bytes; 0 = no cap)");
+					"`max_size_bytes` must be a non-negative integer (bytes; 0 = no "
+					"cap)");
 			}
 			const double v = it->second.get<double>();
 			if (v < 0)
-				return ErrorResponse(400, "bad_request", "`max_size` must be >= 0");
+				return ErrorResponse(400, "bad_request", "`max_size_bytes` must be >= 0");
 			max_size = static_cast<std::uint64_t>(v);
 		}
 	}
 	{
-		const auto it = obj.find("min_avail");
+		const auto it = obj.find("min_source_count");
 		if (it != obj.end()) {
 			if (!it->second.is<double>()) {
-				return ErrorResponse(
-					400, "bad_request", "`min_avail` must be a non-negative integer");
+				return ErrorResponse(400,
+					"bad_request",
+					"`min_source_count` must be a non-negative integer");
 			}
 			const double v = it->second.get<double>();
 			if (v < 0 || v > 4294967295.0) {
-				return ErrorResponse(400, "bad_request", "`min_avail` out of range");
+				return ErrorResponse(400, "bad_request", "`min_source_count` out of range");
 			}
 			min_avail = static_cast<std::uint32_t>(v);
 		}

--- a/src/webapi/Api.cpp
+++ b/src/webapi/Api.cpp
@@ -1241,25 +1241,26 @@ CHttpServer::Response CApiDispatcher::DispatchToHandler(const CHttpServer::Reque
 	// matched first, same ordering rationale as the server / friend routes:
 	// the longer pattern would otherwise be shadowed.
 	{
-		static const auto chat_messages = web_api_path::ParsePattern("/api/v0/chats/{peer}/messages");
-		static const auto chat_one = web_api_path::ParsePattern("/api/v0/chats/{peer}");
+		static const auto chat_messages =
+			web_api_path::ParsePattern("/api/v0/chats/{client_address}/messages");
+		static const auto chat_one = web_api_path::ParsePattern("/api/v0/chats/{client_address}");
 		const auto path_segs = web_api_path::SplitPath(path);
 		std::map<std::string, std::string> caps;
 		if (web_api_path::Match(chat_messages, path_segs, caps)) {
 			if (req.method == "GET" || req.method == "HEAD") {
-				return HandleChatMessages(req, caps["peer"]);
+				return HandleChatMessages(req, caps["client_address"]);
 			}
 			if (req.method == "POST") {
-				return HandleChatSend(req, caps["peer"]);
+				return HandleChatSend(req, caps["client_address"]);
 			}
-			return MethodNotAllowed(
-				"GET, HEAD, POST", "only GET / HEAD / POST on /chats/{peer}/messages");
+			return MethodNotAllowed("GET, HEAD, POST",
+				"only GET / HEAD / POST on /chats/{client_address}/messages");
 		}
 		if (web_api_path::Match(chat_one, path_segs, caps)) {
 			if (req.method == "DELETE") {
-				return HandleChatClose(req, caps["peer"]);
+				return HandleChatClose(req, caps["client_address"]);
 			}
-			return MethodNotAllowed("DELETE", "only DELETE on /chats/{peer}");
+			return MethodNotAllowed("DELETE", "only DELETE on /chats/{client_address}");
 		}
 	}
 
@@ -5739,8 +5740,8 @@ void WriteFriendObject(CJsonWriter &w, const webapi::FriendSnapshot &f)
 	w.ValueString(wxString::FromUTF8(f.name.c_str()));
 	w.Key("user_hash");
 	w.ValueString(wxString::FromUTF8(f.user_hash.c_str()));
-	w.Key("ip");
-	w.ValueString(wxString::FromUTF8(f.ip.c_str()));
+	// null rather than "" when the daemon has not reported an address (R10).
+	WriteStringOrNull(w, "ip", !f.ip.empty(), f.ip);
 	w.Key("port");
 	w.ValueInt(static_cast<int64_t>(f.port));
 	// The live peer this friend is linked to, joinable against /clients. null
@@ -5989,7 +5990,7 @@ void WriteChatMessageObject(CJsonWriter &w, const webapi::ChatMessageSnapshot &m
 	w.ValueString(wxString::FromAscii(m.outgoing ? "out" : "in"));
 	w.Key("text");
 	w.ValueString(wxString::FromUTF8(m.text.c_str()));
-	w.Key("timestamp");
+	w.Key("sent_at");
 	w.ValueInt(static_cast<int64_t>(m.timestamp));
 	w.EndObject();
 }
@@ -5997,7 +5998,7 @@ void WriteChatMessageObject(CJsonWriter &w, const webapi::ChatMessageSnapshot &m
 void WriteChatObject(CJsonWriter &w, const webapi::ChatSessionSnapshot &s)
 {
 	w.BeginObject();
-	w.Key("peer");
+	w.Key("client_address");
 	w.ValueString(wxString::FromUTF8(s.PeerKey().c_str()));
 	w.Key("ip");
 	w.ValueString(wxString::FromUTF8(s.ip.c_str()));
@@ -6014,10 +6015,14 @@ void WriteChatObject(CJsonWriter &w, const webapi::ChatSessionSnapshot &s)
 	w.ValueBool(s.client_ecid != 0);
 	w.Key("message_count");
 	w.ValueInt(static_cast<int64_t>(s.messages.size()));
-	w.Key("last_msg_id");
+	w.Key("last_message_id");
 	w.ValueInt(static_cast<int64_t>(s.LastMsgId()));
-	w.Key("last_message_at");
-	w.ValueInt(static_cast<int64_t>(s.messages.empty() ? 0 : s.messages.back().timestamp));
+	// null, not 0: a session with no messages has no last-message time, and
+	// 0 reads as 1970 (R10).
+	WriteIntOrNull(w,
+		"last_message_at",
+		!s.messages.empty(),
+		static_cast<int64_t>(s.messages.empty() ? 0 : s.messages.back().timestamp));
 	// The transcript itself is deliberately NOT on the list: a 50-session
 	// store at 200 messages each would be 10 000 objects per list read.
 	// null, not omitted: a session with no messages yet has no last message,
@@ -6216,7 +6221,7 @@ CHttpServer::Response CApiDispatcher::HandleChatMessages(
 
 	std::uint64_t gui_id = 0;
 	if (!ParseChatPeerKey(peer, gui_id)) {
-		return ErrorResponse(400, "bad_request", "path `{peer}` must be `<ip>:<port>`");
+		return ErrorResponse(400, "bad_request", "path `{client_address}` must be `<ip>:<port>`");
 	}
 
 	const std::vector<webapi::ChatSessionSnapshot> chats = m_state.Chats();
@@ -6225,7 +6230,7 @@ CHttpServer::Response CApiDispatcher::HandleChatMessages(
 		return ErrorResponse(404, "not_found", "no chat session with that peer");
 	}
 
-	// `since_id` is a safe polling cursor: ids are monotonic per daemon
+	// `since_message_id` is a safe polling cursor: ids are monotonic per daemon
 	// process, so a client never sees a duplicate and never skips one. They
 	// reset when the daemon restarts, which also empties the store.
 	std::uint32_t since_id = 0;
@@ -6233,7 +6238,7 @@ CHttpServer::Response CApiDispatcher::HandleChatMessages(
 	const auto qmap = web_api_path::ParseQuery(QueryOf(req));
 	{
 		std::uint64_t v = since_id;
-		if (auto r = ParseUintParam(qmap, "since_id", 0, 0xFFFFFFFFull, v))
+		if (auto r = ParseUintParam(qmap, "since_message_id", 0, 0xFFFFFFFFull, v))
 			return *r;
 		since_id = static_cast<std::uint32_t>(v);
 	}
@@ -6263,7 +6268,7 @@ CHttpServer::Response CApiDispatcher::HandleChatMessages(
 
 	CJsonWriter w;
 	w.BeginObject();
-	w.Key("peer");
+	w.Key("client_address");
 	w.ValueString(wxString::FromUTF8(session->PeerKey().c_str()));
 	w.Key("messages");
 	w.BeginArray();
@@ -6272,7 +6277,7 @@ CHttpServer::Response CApiDispatcher::HandleChatMessages(
 	w.EndArray();
 	w.Key("total");
 	w.ValueInt(static_cast<int64_t>(session->messages.size()));
-	w.Key("last_msg_id");
+	w.Key("last_message_id");
 	w.ValueInt(static_cast<int64_t>(session->LastMsgId()));
 	w.EndObject();
 	CHttpServer::Response r;
@@ -6337,7 +6342,7 @@ CHttpServer::Response CApiDispatcher::SendChatMessageTo(const CHttpServer::Reque
 	// `ok` dropped. The nested `message` object stays: it is the created
 	// resource, carrying the id and direction the daemon assigned, and there
 	// is no per-message GET route whose shape it could mirror instead.
-	w.Key("peer");
+	w.Key("client_address");
 	w.ValueString(wxString::FromUTF8(webapi::ChatPeerKeyFromGuiId(gui_id).c_str()));
 	w.Key("message");
 	w.BeginObject();
@@ -6369,7 +6374,7 @@ CHttpServer::Response CApiDispatcher::HandleChatSend(const CHttpServer::Request 
 	}
 	std::uint64_t gui_id = 0;
 	if (!ParseChatPeerKey(peer, gui_id)) {
-		return ErrorResponse(400, "bad_request", "path `{peer}` must be `<ip>:<port>`");
+		return ErrorResponse(400, "bad_request", "path `{client_address}` must be `<ip>:<port>`");
 	}
 	// No 404 for an unknown peer here: the core creates the session if it does
 	// not exist, so this doubles as "start a chat with this address".
@@ -6426,7 +6431,7 @@ CHttpServer::Response CApiDispatcher::HandleChatClose(
 	}
 	std::uint64_t gui_id = 0;
 	if (!ParseChatPeerKey(peer, gui_id)) {
-		return ErrorResponse(400, "bad_request", "path `{peer}` must be `<ip>:<port>`");
+		return ErrorResponse(400, "bad_request", "path `{client_address}` must be `<ip>:<port>`");
 	}
 
 	std::unique_ptr<CECPacket> ec_req(new CECPacket(EC_OP_CHAT_CLOSE_SESSION));

--- a/src/webapi/Api.cpp
+++ b/src/webapi/Api.cpp
@@ -725,13 +725,14 @@ void WriteKadNetworkObject(CJsonWriter &w, const webapi::KadSnapshot &k)
 {
 	w.Key("network");
 	w.BeginObject();
-	// null unless Kad is connected. `users`/`files` are the last estimate and
-	// survive into `connecting`; `nodes` is our own routing-table size and was
+	// null unless Kad is connected. `user_count`/`file_count` are the last
+	// estimate and survive into `connecting`; `node_count` is our own
+	// routing-table size and was
 	// measured at 2 with Kad fully stopped, so not even the terminal state
 	// reaches 0. A number here would be a claim about a network we are not on.
-	WriteIntOrNull(w, "users", k.has_network, static_cast<int64_t>(k.users));
-	WriteIntOrNull(w, "files", k.has_network, static_cast<int64_t>(k.files));
-	WriteIntOrNull(w, "nodes", k.has_network, static_cast<int64_t>(k.nodes));
+	WriteIntOrNull(w, "user_count", k.has_network, static_cast<int64_t>(k.users));
+	WriteIntOrNull(w, "file_count", k.has_network, static_cast<int64_t>(k.files));
+	WriteIntOrNull(w, "node_count", k.has_network, static_cast<int64_t>(k.nodes));
 	w.EndObject();
 }
 
@@ -2600,7 +2601,7 @@ CHttpServer::Response CApiDispatcher::HandleStatus(const CHttpServer::Request &r
 	w.Key("public_ip");
 	w.ValueString(wxString::FromUTF8(s.ed2k_public_ip.c_str()));
 	// 0 when not connected -- gate on ed2k.state, not on this being nonzero.
-	w.Key("connected_since");
+	w.Key("connected_since_at");
 	w.ValueInt(static_cast<int64_t>(s.ed2k_connected_since));
 	w.Key("server_name");
 	w.ValueString(wxString::FromUTF8(s.server_name.c_str()));
@@ -2616,8 +2617,8 @@ CHttpServer::Response CApiDispatcher::HandleStatus(const CHttpServer::Request &r
 	w.BeginObject();
 	// null unless eD2k is connected: these sum the whole known server list, not
 	// the server we are attached to, and nothing zeroes them on disconnect.
-	WriteIntOrNull(w, "users", s.has_ed2k_network, static_cast<int64_t>(s.ed2k_users));
-	WriteIntOrNull(w, "files", s.has_ed2k_network, static_cast<int64_t>(s.ed2k_files));
+	WriteIntOrNull(w, "user_count", s.has_ed2k_network, static_cast<int64_t>(s.ed2k_users));
+	WriteIntOrNull(w, "file_count", s.has_ed2k_network, static_cast<int64_t>(s.ed2k_files));
 	w.EndObject();
 	w.EndObject();
 
@@ -2630,7 +2631,7 @@ CHttpServer::Response CApiDispatcher::HandleStatus(const CHttpServer::Request &r
 	// measurement rather than a refinement of this one.
 	WriteBoolOrNull(w, "firewalled_tcp", s.has_kad_firewalled_tcp, s.kad_firewalled_tcp);
 	// 0 when not connected -- gate on kad.state, not on this being nonzero.
-	w.Key("connected_since");
+	w.Key("connected_since_at");
 	w.ValueInt(static_cast<int64_t>(s.kad_connected_since));
 	// Network rollup — same numbers GET /kad serves under
 	// `network.{users,files,nodes}`, written by the same helper so
@@ -7244,7 +7245,7 @@ CHttpServer::Response CApiDispatcher::HandleKad(const CHttpServer::Request &req)
 	WriteBoolOrNull(w, "lan_mode", k.has_lan_mode, k.lan_mode);
 	// Same value GET /status reports as kad.connected_since; 0 when
 	// not connected, so gate on `state` rather than on a nonzero.
-	w.Key("connected_since");
+	w.Key("connected_since_at");
 	w.ValueInt(static_cast<int64_t>(d.status.kad_connected_since));
 	// Ours, as opposed to `buddy.ip` below — which is why this one
 	// is not called plain `ip`.
@@ -7259,11 +7260,11 @@ CHttpServer::Response CApiDispatcher::HandleKad(const CHttpServer::Request &req)
 	WriteIntOrNull(w, "sources", k.has_indexed, static_cast<int64_t>(k.indexed_sources));
 	WriteIntOrNull(w, "keywords", k.has_indexed, static_cast<int64_t>(k.indexed_keywords));
 	WriteIntOrNull(w, "notes", k.has_indexed, static_cast<int64_t>(k.indexed_notes));
-	WriteIntOrNull(w, "load", k.has_indexed, static_cast<int64_t>(k.indexed_load));
+	WriteIntOrNull(w, "load_percent", k.has_indexed, static_cast<int64_t>(k.indexed_load));
 	w.EndObject();
 	w.Key("buddy");
 	w.BeginObject();
-	WriteStringOrNull(w, "status", k.has_buddy, k.buddy_status);
+	WriteStringOrNull(w, "state", k.has_buddy, k.buddy_status);
 	WriteStringOrNull(w, "ip", k.has_buddy, k.buddy_ip);
 	WriteIntOrNull(w, "port", k.has_buddy, static_cast<int64_t>(k.buddy_port));
 	w.EndObject();
@@ -7449,9 +7450,11 @@ void WritePointArray(CJsonWriter &w,
 		const std::time_t t =
 			snapshot_at - static_cast<std::time_t>((samples.size() - 1 - i) * interval);
 		w.BeginObject();
-		w.Key("t");
-		w.ValueString(wxString::FromUTF8(webapi::FormatIso8601Utc(t).c_str()));
-		w.Key("t_unix");
+		// One representation, unix seconds, named `_at` like every other time
+		// on the surface (R3). The ISO twin is dropped: formatting is a client
+		// concern, and it cost a key plus ~22 bytes on every point of an array
+		// that runs to max_points.
+		w.Key("at");
 		w.ValueInt(static_cast<int64_t>(t));
 		w.Key("value");
 		w.ValueInt(static_cast<int64_t>(samples[i]));

--- a/src/webapi/EventDiff.cpp
+++ b/src/webapi/EventDiff.cpp
@@ -352,7 +352,7 @@ std::string JsonBoolOrNull(bool known, bool v)
 
 // Mirrors HandleStatus key for key -- EVENTS.md promises this payload is
 // identical to the REST /status envelope, and 22-sse-diff-emission.sh asserts
-// it. Both connected_since values are 0 while not connected, same rule as
+// it. Both connected_since_at values are 0 while not connected, same rule as
 // there: gate on state rather than trusting a 0 timestamp.
 std::string ToJsonStatusEvent(const StatusSnapshot &s, const KadSnapshot &k, bool ec_connected)
 {
@@ -362,19 +362,19 @@ std::string ToJsonStatusEvent(const StatusSnapshot &s, const KadSnapshot &k, boo
 	  << "\"state\":\"" << EscJson(s.ed2k_state) << "\""
 	  << ",\"high_id\":" << (s.ed2k_high_id ? "true" : "false") << ",\"user_id\":" << s.ed2k_user_id
 	  << ",\"public_ip\":\"" << EscJson(s.ed2k_public_ip) << "\""
-	  << ",\"connected_since\":" << s.ed2k_connected_since << ",\"server_name\":\""
+	  << ",\"connected_since_at\":" << s.ed2k_connected_since << ",\"server_name\":\""
 	  << EscJson(s.server_name) << "\""
 	  << ",\"server_ip\":\"" << EscJson(s.server_ip) << "\""
 	  << ",\"server_port\":" << s.server_port << ",\"network\":{"
-	  << "\"users\":" << JsonNumOrNull(s.has_ed2k_network, s.ed2k_users)
-	  << ",\"files\":" << JsonNumOrNull(s.has_ed2k_network, s.ed2k_files) << "}}"
+	  << "\"user_count\":" << JsonNumOrNull(s.has_ed2k_network, s.ed2k_users)
+	  << ",\"file_count\":" << JsonNumOrNull(s.has_ed2k_network, s.ed2k_files) << "}}"
 	  << ",\"kad\":{"
 	  << "\"state\":\"" << EscJson(s.kad_state) << "\""
 	  << ",\"firewalled_tcp\":" << JsonBoolOrNull(s.has_kad_firewalled_tcp, s.kad_firewalled_tcp)
-	  << ",\"connected_since\":" << s.kad_connected_since << ",\"network\":{"
-	  << "\"users\":" << JsonNumOrNull(k.has_network, k.users)
-	  << ",\"files\":" << JsonNumOrNull(k.has_network, k.files)
-	  << ",\"nodes\":" << JsonNumOrNull(k.has_network, k.nodes) << "}"
+	  << ",\"connected_since_at\":" << s.kad_connected_since << ",\"network\":{"
+	  << "\"user_count\":" << JsonNumOrNull(k.has_network, k.users)
+	  << ",\"file_count\":" << JsonNumOrNull(k.has_network, k.files)
+	  << ",\"node_count\":" << JsonNumOrNull(k.has_network, k.nodes) << "}"
 	  << "}"
 	  << ",\"speeds\":{"
 	  << "\"download_bps\":" << s.download_bps << ",\"upload_bps\":" << s.upload_bps

--- a/src/webapi/EventDiff.cpp
+++ b/src/webapi/EventDiff.cpp
@@ -685,14 +685,13 @@ void EnforceSinglePublisher()
 } // namespace
 
 // One chat message as the `message` object both the SSE payload and
-// GET /chats/{peer}/messages expose. Written here in the same string-building
+// GET /chats/{client_address}/messages expose. Written here in the same string-building
 // style as the other event payloads in this file; the REST side renders the
 // identical shape through CJsonWriter.
 std::string ChatMessageJson(const ChatMessageSnapshot &msg)
 {
 	return "{\"id\":" + std::to_string(msg.id) + ",\"direction\":\"" + (msg.outgoing ? "out" : "in") +
-	       "\",\"text\":\"" + EscJson(msg.text) + "\",\"timestamp\":" + std::to_string(msg.timestamp) +
-	       "}";
+	       "\",\"text\":\"" + EscJson(msg.text) + "\",\"sent_at\":" + std::to_string(msg.timestamp) + "}";
 }
 
 void PublishChatEvents(CEventBus &bus,
@@ -706,19 +705,25 @@ void PublishChatEvents(CEventBus &bus,
 	for (const ChatSessionSnapshot &session : new_messages) {
 		const std::string peer = session.PeerKey();
 		for (const ChatMessageSnapshot &msg : session.messages) {
-			std::string payload = "{\"peer\":\"" + EscJson(peer) + "\",\"ip\":\"" +
+			std::string payload = "{\"client_address\":\"" + EscJson(peer) + "\",\"ip\":\"" +
 					      EscJson(session.ip) +
 					      "\",\"port\":" + std::to_string(session.port) + ",\"name\":\"" +
 					      EscJson(session.DisplayName()) +
-					      "\",\"client_ecid\":" + std::to_string(session.client_ecid) +
-					      ",\"friend_ecid\":" + std::to_string(session.friend_ecid) +
+					      // client_ecid / friend_ecid are null rather than the 0
+					      // sentinel, matching the REST row (R10).
+					      "\",\"client_ecid\":" +
+					      (session.client_ecid ? std::to_string(session.client_ecid)
+								   : std::string("null")) +
+					      ",\"friend_ecid\":" +
+					      (session.friend_ecid ? std::to_string(session.friend_ecid)
+								   : std::string("null")) +
 					      ",\"message\":" + ChatMessageJson(msg) + "}";
 			batch.emplace_back("chat_message", std::move(payload));
 		}
 	}
 	for (std::uint64_t gui_id : closed) {
 		const std::string peer = ChatPeerKeyFromGuiId(gui_id);
-		batch.emplace_back("chat_session_closed", "{\"peer\":\"" + EscJson(peer) + "\"}");
+		batch.emplace_back("chat_session_closed", "{\"client_address\":\"" + EscJson(peer) + "\"}");
 	}
 	bus.PublishBatch(batch);
 }

--- a/src/webapi/EventDiff.cpp
+++ b/src/webapi/EventDiff.cpp
@@ -947,13 +947,13 @@ void EmitDiffsAndUpdate(CEventBus &bus, LastSeenState &prev, const CState &state
 	// while the search runs -- where `search_progress` is already the re-read
 	// cue. What is left is the set that can change AFTER a search finishes,
 	// when no other signal exists: download state (`status` /
-	// `already_have`), and the Kad-notes cluster (`comments[]`, the
+	// `already_downloaded`), and the Kad-notes cluster (`comments[]`, the
 	// in-flight flag, and `rating`, which aggregates from the comments).
 	// Comparing only these keeps the search channel quiet on a running
 	// search instead of firing per-result frames on source-count churn.
 	const auto result_mutated = [](const SearchResult &a, const SearchResult &b) {
-		if (a.status != b.status || a.already_have != b.already_have || a.rating != b.rating ||
-			a.kad_comment_searching != b.kad_comment_searching ||
+		if (a.status != b.status || a.already_downloaded != b.already_downloaded ||
+			a.rating != b.rating || a.kad_comment_searching != b.kad_comment_searching ||
 			a.comments.size() != b.comments.size())
 			return true;
 		for (std::size_t i = 0; i < a.comments.size(); ++i) {
@@ -1021,7 +1021,7 @@ void EmitDiffsAndUpdate(CEventBus &bus, LastSeenState &prev, const CState &state
 				// live rows opts in by handling the new event. It is the
 				// close of the one window where a client could not know:
 				// a finished search stops emitting search_progress, yet a
-				// hit downloaded from it flips status / already_have, and
+				// hit downloaded from it flips status / already_downloaded, and
 				// a Kad notes lookup lands comments / rating after the
 				// fact. (Those fields are polled at all because the union
 				// keeps finished searches in the per-tick poll set.)
@@ -1048,8 +1048,12 @@ void EmitDiffsAndUpdate(CEventBus &bus, LastSeenState &prev, const CState &state
 				std::ostringstream payload;
 				payload << "{\"search_id\":" << sid << ",\"state\":\""
 					<< (progress_now.complete ? "finished" : "running") << "\""
-					<< ",\"percent\":" << progress_now.percent
-					<< ",\"results\":" << search_now.size() << ",\"kind\":\""
+					<< ",\"percent\":"
+					<< progress_now.percent
+					// `result_count`: a plural key held an integer while `results` is an
+					// array everywhere else, and GET /search already calls this number
+					// result_count.
+					<< ",\"result_count\":" << search_now.size() << ",\"type\":\""
 					<< EscJson(progress_now.kind) << "\""
 					<< "}";
 				bus.Publish("search_progress", payload.str());

--- a/src/webapi/Refresher.cpp
+++ b/src/webapi/Refresher.cpp
@@ -2480,7 +2480,7 @@ void MergeSearchResultTag(const CEC_SearchFile_Tag *sf, SearchResult &r)
 	// Download status (issue #429): amuled packs the CSearchFile
 	// status in EC_TAG_PARTFILE_STATUS on every search-result tag.
 	// Download status (issue #429): amuled packs the CSearchFile status
-	// in EC_TAG_PARTFILE_STATUS. `already_have` is not its own field on
+	// in EC_TAG_PARTFILE_STATUS. `already_downloaded` is not its own field on
 	// the wire -- AlreadyHave() reads the same tag -- so both move
 	// together, and both are left alone when the tag is diffed away.
 	// Writing the absent case as status 0 would report every unchanged
@@ -2489,7 +2489,7 @@ void MergeSearchResultTag(const CEC_SearchFile_Tag *sf, SearchResult &r)
 		std::uint32_t v = 0;
 		if (sf->AssignIfExist(EC_TAG_PARTFILE_STATUS, v)) {
 			r.status = SearchStatusName(v);
-			r.already_have = sf->AlreadyHave();
+			r.already_downloaded = sf->AlreadyHave();
 		}
 	}
 	// File type, computed from the filename (no EC data needed).

--- a/src/webapi/SearchJson.cpp
+++ b/src/webapi/SearchJson.cpp
@@ -39,7 +39,7 @@ void WriteSearchResultFields(CJsonWriter &w, const SearchResult &r)
 	w.ValueString(wxString::FromUTF8(r.hash.c_str()));
 	w.Key("name");
 	w.ValueString(wxString::FromUTF8(r.name.c_str()));
-	w.Key("size");
+	w.Key("size_bytes");
 	w.ValueInt(static_cast<int64_t>(r.size));
 	w.Key("sources");
 	w.BeginObject();
@@ -48,13 +48,17 @@ void WriteSearchResultFields(CJsonWriter &w, const SearchResult &r)
 	w.Key("complete");
 	w.ValueInt(static_cast<int64_t>(r.complete_source_count));
 	w.EndObject();
-	w.Key("already_have");
-	w.ValueBool(r.already_have);
+	// `have` reads as the wire verb; `downloaded` is the state (R4: no prefix).
+	w.Key("already_downloaded");
+	w.ValueBool(r.already_downloaded);
 	w.Key("rating");
 	w.ValueInt(static_cast<int64_t>(r.rating));
 	w.Key("status");
 	w.ValueString(wxString::FromUTF8(r.status.c_str()));
-	w.Key("type");
+	// `file_type`, matching POST /search's own filter field and the key
+	// /shared/{hash} derives from the same helper. Next to a `media` object a
+	// bare `type` also reads as a MIME type.
+	w.Key("file_type");
 	w.ValueString(wxString::FromUTF8(r.type.c_str()));
 	// Browse-only (the folder inside the peer's share). Always present so
 	// clients need no presence check; empty on every server/Kad hit, which
@@ -92,7 +96,9 @@ void WriteSearchResultFields(CJsonWriter &w, const SearchResult &r)
 	// without a presence check. Each child shares the parent's `hash`; the
 	// distinct `ecid` selects it for download-under-that-name (see
 	// POST /search/results/{hash}/download).
-	w.Key("children");
+	// Not `children`: there is no hierarchy, only one file advertised under
+	// several names. Each entry's hash is by construction this result's.
+	w.Key("alternate_names");
 	w.BeginArray();
 	for (const auto &c : r.children) {
 		w.BeginObject();
@@ -100,8 +106,6 @@ void WriteSearchResultFields(CJsonWriter &w, const SearchResult &r)
 		w.ValueInt(static_cast<int64_t>(c.ecid));
 		w.Key("name");
 		w.ValueString(wxString::FromUTF8(c.name.c_str()));
-		w.Key("hash");
-		w.ValueString(wxString::FromUTF8(c.hash.c_str()));
 		w.Key("sources");
 		w.BeginObject();
 		w.Key("total");

--- a/src/webapi/State.h
+++ b/src/webapi/State.h
@@ -870,7 +870,7 @@ struct SearchResult
 	std::uint64_t size = 0;
 	std::uint32_t source_count = 0;
 	std::uint32_t complete_source_count = 0;
-	bool already_have = false;
+	bool already_downloaded = false;
 	std::uint8_t rating = 0;
 	// Download status of the result on this node (issue #429), a lowercase
 	// string from the CSearchFile enum: "new" | "downloaded" | "queued" |

--- a/src/webapi/static/js/app.js
+++ b/src/webapi/static/js/app.js
@@ -285,8 +285,8 @@ function StatusBar() {
 
   const kNet = (status && status.kad && status.kad.network) || {};
   const eNet = (status && status.ed2k && status.ed2k.network) || {};
-  const hasNet = kNet.users != null || kNet.files != null
-              || eNet.users != null || eNet.files != null;
+  const hasNet = kNet.user_count != null || kNet.file_count != null
+              || eNet.user_count != null || eNet.file_count != null;
 
   const groups = [
     hasNet ? html`<${NetworkInfo} status=${status} />` : null,
@@ -344,18 +344,18 @@ function ConnectionStatus({ status }) {
 function NetworkInfo({ status }) {
   const e = (status && status.ed2k && status.ed2k.network) || null;
   const k = (status && status.kad && status.kad.network) || null;
-  const eHas = e && (e.users != null || e.files != null);
-  const kHas = k && (k.users != null || k.files != null);
+  const eHas = e && (e.user_count != null || e.file_count != null);
+  const kHas = k && (k.user_count != null || k.file_count != null);
   if (!eHas && !kHas) return null;
 
   const both = eHas && kHas;
   const net = eHas ? e : k;
   const usersVal = both
-    ? html`<b>E:</b> ${formatInt(e.users)} <b>K:</b> ${formatInt(k.users)}`
-    : html`${formatInt(net.users)}`;
+    ? html`<b>E:</b> ${formatInt(e.user_count)} <b>K:</b> ${formatInt(k.user_count)}`
+    : html`${formatInt(net.user_count)}`;
   const filesVal = both
-    ? html`<b>E:</b> ${formatInt(e.files)} <b>K:</b> ${formatInt(k.files)}`
-    : html`${formatInt(net.files)}`;
+    ? html`<b>E:</b> ${formatInt(e.file_count)} <b>K:</b> ${formatInt(k.file_count)}`
+    : html`${formatInt(net.file_count)}`;
 
   return html`
     <span class="status-item status-extra">

--- a/src/webapi/static/js/searches.js
+++ b/src/webapi/static/js/searches.js
@@ -112,7 +112,7 @@ async function refresh(id) {
     if (r.query && !cur.label) cur.label = r.query;
     const pr = r.progress || {};
     if (pr.state) cur.state = pr.state;
-    if (pr.kind) cur.kind = pr.kind;
+    if (pr.type) cur.kind = pr.type;
     cur.percent = pr.percent || 0;
     publishTabs();
     publishResults(id);
@@ -135,7 +135,7 @@ async function adopt() {
   list = list.slice().sort((a, b) => ord(a) - ord(b));
   let added = false;
   for (const s of list) {
-    const known = tabs.get(s.search_id);
+    const known = tabs.get(s.id);
     if (known) {
       if (!known.query && s.query) { known.query = s.query; known.label = known.label || s.query; }
       // Keep an unopened tab's badge current. Only while it holds no results
@@ -151,8 +151,8 @@ async function adopt() {
     // result_count is what makes an unopened tab show a real badge instead of
     // 0 after a reload; it is omitted by a daemon that does not report counts,
     // in which case the badge stays 0 until the tab is opened and fetched.
-    tabs.set(s.search_id, newTab({
-      id: s.search_id, query: s.query || "", kind: s.kind || "global",
+    tabs.set(s.id, newTab({
+      id: s.id, query: s.query || "", kind: s.type || "global",
       state: s.state || "finished", startedAt: s.started_at || 0,
       count: typeof s.result_count === "number" ? s.result_count : 0,
     }));
@@ -161,7 +161,7 @@ async function adopt() {
   if (!tabs.has(activeId)) {
     const running = list.filter((s) => s.state === "running");
     const pick = (running.length ? running : list).slice(-1)[0];
-    if (pick) { setActive(pick.search_id); return; }
+    if (pick) { setActive(pick.id); return; }
     activeId = 0;
   }
   if (added) publishTabs();
@@ -216,11 +216,11 @@ function onProgress(p) {
   if (!tab) { nudgeAdopt(); return; }
   const wasRunning = tab.state === "running";
   if (p.state) tab.state = p.state;
-  if (p.kind) tab.kind = p.kind;
+  if (p.type) tab.kind = p.type;
   tab.percent = p.percent || 0;
   // The event's count is the backend's own map size and may legitimately run
   // ahead of the upserts seen so far.
-  if (typeof p.results === "number") tab.count = p.results;
+  if (typeof p.result_count === "number") tab.count = p.result_count;
   publishTabsSoon();
   // Terminal frame: reconcile once against REST to pick up anything the
   // stream dropped, and to land the final status/children of every row.
@@ -306,10 +306,10 @@ export const searches = {
     // from what we asked for -- `kind` and `startedAt` in particular, which
     // the request only implies.
     const r = await api.post("search", body);
-    const id = r.search_id;
+    const id = r.id;
     tabs.set(id, newTab({
       id, query: r.query || body.query || "", label: label || "",
-      kind: r.kind || body.type || "global",
+      kind: r.type || body.type || "global",
       state: r.state || "running",
       startedAt: r.started_at || nowSec(),
     }));
@@ -327,7 +327,7 @@ export const searches = {
   // filter, per-row category) for a browse that never restarted.
   async browse(ecid, name) {
     const r = await api.post("clients/" + ecid + "/shared_files");
-    const id = r.search_id;
+    const id = r.id;
     const open = tabs.get(id);
     if (open) {
       if (name) { open.query = name; open.label = name; }

--- a/src/webapi/static/js/views/networks.js
+++ b/src/webapi/static/js/views/networks.js
@@ -296,7 +296,7 @@ function KadPanel() {
       try {
         const r = await api.get("stats/graphs/" + KAD_GRAPH.name + "?width=" + GRAPH_WIDTH);
         const pts = r.points || [];
-        if (alive) setGraphData([pts.map((p) => p.t_unix), pts.map((p) => p.value)]);
+        if (alive) setGraphData([pts.map((p) => p.at), pts.map((p) => p.value)]);
       } catch (_) { /* leave previous data */ }
     };
     tick();
@@ -443,7 +443,7 @@ function yesno(b) { return html`<span class=${"status-chip " + (b ? "warn" : "ok
 // with are stale, so the row goes blank instead (the desktop hides it outright).
 function buddyText(kad_state, buddy, firewalled_tcp, firewalled_udp) {
   if (kad_state !== "connected") return "—";
-  switch (buddy.status) {
+  switch (buddy.state) {
     case "connected": return t("networks_kad_buddy_at", { addr: buddy.ip + ":" + buddy.port });
     case "connecting": return t("networks_kad_buddy_connecting");
     case "no_buddy":
@@ -496,7 +496,7 @@ function Ed2kInfoPanel() {
           connected
             ? html`<span class=${"status-chip " + (ed2k.high_id ? "ok" : "warn")}>${ed2k.high_id ? t("networks_ed2k_high_id") : t("networks_ed2k_low_id")}</span>`
             : "—"),
-        statRow("networks_ed2k_connected_since", formatTimestamp(ed2k.connected_since)),
+        statRow("networks_ed2k_connected_since", formatTimestamp(ed2k.connected_since_at)),
       ], "networks_ed2k_group_connection")}
       ${Section([
         // An identifier, not a quantity -- no thousands separators.
@@ -504,8 +504,8 @@ function Ed2kInfoPanel() {
         statRow("networks_ed2k_ip_port", ipPort),
       ], "networks_ed2k_group_identity")}
       ${Section([
-        statRow("networks_ed2k_users", connected ? formatInt(net.users) : "—"),
-        statRow("networks_ed2k_files", connected ? formatInt(net.files) : "—"),
+        statRow("networks_ed2k_users", connected ? formatInt(net.user_count) : "—"),
+        statRow("networks_ed2k_files", connected ? formatInt(net.file_count) : "—"),
       ], "networks_ed2k_group_network")}
     </div>`;
 }
@@ -545,7 +545,7 @@ function KadInfoPanel() {
         statRow("networks_kad_firewalled_tcp", connected ? yesno(kad.firewalled_tcp) : "—"),
         statRow("networks_kad_firewalled_udp", connected ? yesno(d.firewalled_udp) : "—"),
         statRow("networks_kad_in_lan_mode", connected ? yesno(d.lan_mode) : "—"),
-        statRow("networks_kad_connected_since", connected ? formatTimestamp(d.connected_since) : "—"),
+        statRow("networks_kad_connected_since", connected ? formatTimestamp(d.connected_since_at) : "—"),
       ], "networks_kad_group_connection")}
       ${Section([
         statRow("networks_kad_node_id", d.node_id || "—"),
@@ -553,15 +553,15 @@ function KadInfoPanel() {
         statRow("networks_kad_buddy", buddyText(kad.state, buddy, kad.firewalled_tcp, d.firewalled_udp)),
       ], "networks_kad_group_identity")}
       ${Section([
-        statRow("networks_kad_users", connected ? formatInt(net.users) : "—"),
-        statRow("networks_kad_files", connected ? formatInt(net.files) : "—"),
-        statRow("networks_kad_contacts_nodes", connected ? formatInt(net.nodes) : "—"),
+        statRow("networks_kad_users", connected ? formatInt(net.user_count) : "—"),
+        statRow("networks_kad_files", connected ? formatInt(net.file_count) : "—"),
+        statRow("networks_kad_contacts_nodes", connected ? formatInt(net.node_count) : "—"),
       ], "networks_kad_group_network")}
       ${Section([
         statRow("networks_kad_indexed_sources", connected ? formatInt(idx.sources) : "—"),
         statRow("networks_kad_indexed_keywords", connected ? formatInt(idx.keywords) : "—"),
         statRow("networks_kad_indexed_notes", connected ? formatInt(idx.notes) : "—"),
-        statRow("networks_kad_indexed_load", connected ? formatInt(idx.load) : "—"),
+        statRow("networks_kad_indexed_load", connected ? formatInt(idx.load_percent) : "—"),
       ], "networks_kad_group_index")}
     </div>`;
 }

--- a/src/webapi/static/js/views/search.js
+++ b/src/webapi/static/js/views/search.js
@@ -156,7 +156,7 @@ function ResultsPane({ tab, categories }) {
   const visible = (all, filter, filterHave) => {
     const m = textMatcher(filter);
     let out = filter ? all.filter((r) => m(r.name)) : all;
-    if (filterHave !== "all") out = out.filter((r) => (filterHave === "have") === !!r.already_have);
+    if (filterHave !== "all") out = out.filter((r) => (filterHave === "have") === !!r.already_downloaded);
     return out;
   };
   const filtered = visible(rows, ui.filter, ui.filterHave);
@@ -236,7 +236,7 @@ function ResultsPane({ tab, categories }) {
         // The core names a group after its most-sourced child
         // (CSearchFile::UpdateParent), so one child always repeats the parent's
         // name; the default option below already IS that name.
-        const kids = (r.children || []).filter((c) => c.name !== r.name);
+        const kids = (r.alternate_names || []).filter((c) => c.name !== r.name);
         if (!kids.length) return r.name;
         return html`
           <select class="input input-sm name-select" title=${t("search_alt_names_title")}
@@ -247,7 +247,7 @@ function ResultsPane({ tab, categories }) {
           </select>`;
       } },
     { key: "size", label: t("search_size"), num: true, width: "110px", sortable: true,
-      sortVal: (r) => r.size || 0, cell: (r) => formatBytes(r.size) },
+      sortVal: (r) => r.size_bytes || 0, cell: (r) => formatBytes(r.size_bytes) },
     { key: "sources", label: t("search_sources"), num: true, width: "120px", sortable: true,
       sortVal: (r) => (r.sources && r.sources.total) || 0,
       // Total, plus the complete count in parentheses only when there IS one,
@@ -269,7 +269,7 @@ function ResultsPane({ tab, categories }) {
       // rating only ever surfaces per-comment in the ratings dialog.
       cell: (r) => (r.rating ? html`<span title=${ratingLabel(r.rating)}>${r.rating}</span>` : "—") },
     { key: "type", label: t("search_type"), width: "100px", sortable: true,
-      sortVal: (r) => r.type || "", cell: (r) => typeLabel(r.type) },
+      sortVal: (r) => r.file_type || "", cell: (r) => typeLabel(r.file_type) },
     { key: "status", label: t("downloads_status_label"), width: "120px", sortable: true,
       sortVal: (r) => r.status || "", cell: (r) => searchStatusBadge(r.status) },
     // Browse-only: the folder inside the peer's share, empty on every
@@ -308,7 +308,7 @@ function ResultsPane({ tab, categories }) {
   const rowClass = (r) => {
     const c = [];
     if (ui.selection.has(r.hash)) c.push("row-selected");
-    if (r.already_have) c.push("row-have");
+    if (r.already_downloaded) c.push("row-have");
     return c.join(" ");
   };
 

--- a/src/webapi/static/js/views/stats.js
+++ b/src/webapi/static/js/views/stats.js
@@ -70,7 +70,7 @@ export default function Stats() {
           : pts.length && pts[0].active_downloads !== undefined
             ? [pts.map((p) => p.active_downloads), pts.map((p) => p.active_uploads)]
             : [];
-        if (alive) setGraphData((d) => ({ ...d, [g.name]: [pts.map((p) => p.t_unix), ys, ...rest] }));
+        if (alive) setGraphData((d) => ({ ...d, [g.name]: [pts.map((p) => p.at), ys, ...rest] }));
       } catch (_) { /* leave previous data */ }
     };
     const loadTree = async () => {

--- a/unittests/curl-tests/amuleapi/03-read-status.sh
+++ b/unittests/curl-tests/amuleapi/03-read-status.sh
@@ -159,7 +159,7 @@ _assert_json_eq '(.kad.state != "connected") or ((.kad.firewalled_tcp | type) ==
 # The network rollups, both sides. ed2k's summed the whole known SERVER LIST
 # rather than the attached server and nothing zeroed them, so a disconnected
 # daemon repeated its connected figures verbatim and indefinitely.
-for P in "ed2k users" "ed2k files" "kad users" "kad files" "kad nodes"; do
+for P in "ed2k user_count" "ed2k file_count" "kad user_count" "kad file_count" "kad node_count"; do
 	set -- $P
 	_assert_json_eq "(.$1.state == \"connected\") or (.$1.network.$2 == null)" true \
 		"$1.network.$2 is null while $1 is not connected"

--- a/unittests/curl-tests/amuleapi/05-read-servers-kad-categories-prefs.sh
+++ b/unittests/curl-tests/amuleapi/05-read-servers-kad-categories-prefs.sh
@@ -168,7 +168,7 @@ _assert_json_eq '(.lan_mode | not) or ((.firewalled_tcp | not) and (.firewalled_
 # side defaults the other way: true until two peers vouch for us.
 # Was: "reads false while not connected". That false was the absence of a
 # measurement wearing the costume of one, and it is null now.
-_assert_json_eq '.connected_since  | type' number  '/kad.connected_since is numeric'
+_assert_json_eq '.connected_since_at | type' number  '/kad.connected_since_ate is numeric'
 # Ours. Named apart from the buddy's address, which the rename must not touch.
 _assert_json_eq '.public_ip        | type' string  '/kad.public_ip is string'
 _assert_json_eq '.ip               | type' null    '/kad has no bare top-level ip'
@@ -182,14 +182,14 @@ _assert_json_eq '(.state != "disabled") or (.node_id == "")' \
 # `nodes` is the sharp one: it is this node's OWN routing-table size, and
 # contacts outlive a disconnect, so it was measured at 2 on a fully stopped Kad
 # -- a non-zero figure for a network the daemon was not on.
-for F in network.users network.files network.nodes \
-	indexed.sources indexed.keywords indexed.notes indexed.load; do
+for F in network.user_count network.file_count network.node_count \
+	indexed.sources indexed.keywords indexed.notes indexed.load_percent; do
 	_assert_json_eq "(.state == \"connected\") or (.$F == null)" true \
 		"/kad.$F is null while Kad is not connected"
 	_assert_json_eq "(.state != \"connected\") or ((.$F | type) == \"number\")" true \
 		"/kad.$F is numeric while Kad is connected"
 done
-# indexed.load is a load figure rather than a count, despite sitting beside
+# indexed.load_percent is a load figure rather than a count, despite sitting beside
 # three counts -- covered by the loop above.
 # Two distinct "unknown" sentinels: "" while Kad is not connected, and a
 # syntactically valid 0.0.0.0 while connected but not yet told our address.
@@ -198,7 +198,7 @@ _assert_json_eq '(.state == "connected") or (.public_ip == "")' \
 # Gated with the rest: `no_buddy` is a real state, so reporting it on a stopped
 # Kad claimed we had looked and found none. Null when not connected; the enum
 # and the types still hold while connected.
-for F in buddy.status buddy.ip buddy.port; do
+for F in buddy.state buddy.ip buddy.port; do
 	_assert_json_eq "(.state == \"connected\") or (.$F == null)" true \
 		"/kad.$F is null while Kad is not connected"
 done
@@ -206,8 +206,8 @@ _assert_json_eq '(.state != "connected") or ((.buddy.port | type) == "number")' 
 	true '/kad.buddy.port is numeric while Kad is connected'
 _assert_json_eq '(.state != "connected") or ((.buddy.ip | type) == "string")' \
 	true '/kad.buddy.ip survives the ip rename'
-_assert_json_eq '(.state != "connected") or (.buddy.status | test("^(no_buddy|connecting|connected|unknown)$"))' \
-	true '/kad.buddy.status is a known enum value while Kad is connected'
+_assert_json_eq '(.state != "connected") or (.buddy.state | test("^(no_buddy|connecting|connected|unknown)$"))' \
+	true '/kad.buddy.state is a known enum value while Kad is connected'
 
 # --- 3. /categories -----------------------------------------------
 _curl "$HOST/api/v0/categories"

--- a/unittests/curl-tests/amuleapi/07-read-stats-and-search-results.sh
+++ b/unittests/curl-tests/amuleapi/07-read-stats-and-search-results.sh
@@ -78,7 +78,7 @@ sleep 4
 # script starts one rather than relying on a removed implicit default.
 _curl -X POST -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' \
 	-d '{"query":"amuleapi-phase07","type":"local"}' "$HOST/api/v0/search"
-SID=$(printf '%s' "$CURL_BODY" | jq -r '.search_id // empty')
+SID=$(printf '%s' "$CURL_BODY" | jq -r '.id // empty')
 [ -n "$SID" ] || _die "POST /search returned no search_id"
 
 # --- 1. Auth gate. -------------------------------------------------

--- a/unittests/curl-tests/amuleapi/07-read-stats-and-search-results.sh
+++ b/unittests/curl-tests/amuleapi/07-read-stats-and-search-results.sh
@@ -214,12 +214,14 @@ _curl -H "Authorization: Bearer $TOKEN" "$HOST/api/v0/stats/graphs/download_spee
 _assert_status 200 "GET /stats/graphs/download_speed?width=5 → 200"
 _assert_json_eq '.points | length <= 5' true \
 	'/stats/graphs/download_speed?width=5 returns ≤5 points'
-# When a point exists, it must carry both t (ISO-8601) and t_unix.
+# One timestamp per point, unix seconds, named `at` (R3). The ISO-8601 twin
+# was dropped: formatting is a client concern, and it cost a key plus its
+# value on every point of an array that runs to max_points.
 if [ "$(printf '%s' "$CURL_BODY" | jq '.points | length')" -gt 0 ]; then
-	_assert_json_eq '.points[0].t | length' 20 \
-		'/stats/graphs/download_speed point.t is 20-char ISO-8601'
-	_assert_json_eq '.points[0].t_unix | type' number \
-		'/stats/graphs/download_speed point.t_unix is numeric'
+	_assert_json_eq '.points[0].at | type' number \
+		'/stats/graphs/download_speed point.at is numeric (unix seconds)'
+	_assert_json_eq '.points[0] | has("t")' false \
+		'/stats/graphs point no longer carries the ISO-8601 twin'
 	_assert_json_eq '.points[0].value | type' number \
 		'/stats/graphs/download_speed point.value is numeric'
 fi

--- a/unittests/curl-tests/amuleapi/10-refresher-lazy-ondemand.sh
+++ b/unittests/curl-tests/amuleapi/10-refresher-lazy-ondemand.sh
@@ -189,7 +189,7 @@ _assert_status 404 "GET /stats/graphs/bogus → 404 (still validated)"
 # which is the lazy-fetch behaviour this phase is about.
 _curl -X POST -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' \
 	-d '{"query":"amuleapi-phase10","type":"local"}' "$HOST/api/v0/search"
-SID=$(printf '%s' "$CURL_BODY" | jq -r '.search_id // empty')
+SID=$(printf '%s' "$CURL_BODY" | jq -r '.id // empty')
 [ -n "$SID" ] || _die "POST /search returned no search_id"
 
 _curl -H "Authorization: Bearer $TOKEN" "$HOST/api/v0/search/$SID/results"

--- a/unittests/curl-tests/amuleapi/19-search.sh
+++ b/unittests/curl-tests/amuleapi/19-search.sh
@@ -481,13 +481,15 @@ if [ -n "$RESULT_HASH" ]; then
 		true '/search/{id}/results[0].media is an object or absent'
 	# Result grouping (issue #431): every result carries a children[]
 	# array (empty when the hit was seen under a single name). No result
-	# is itself a child (children are folded into their parent), and each
-	# child object has ecid + name + hash + sources.
+	# is itself an alternate name (they are folded into their parent), and
+	# each entry has ecid + name + sources.
 	_assert_json_eq '.results[0].alternate_names | type' array '/search/{id}/results[0].alternate_names is an array'
-	_assert_json_eq '[.results[].alternate_names[]?] | all(has("ecid") and has("name") and has("hash") and has("sources"))' \
-		true 'every child has ecid/name/hash/sources'
-	_assert_json_eq '[.results[].alternate_names[]?.hash | length] | all(. == 32)' \
-		true 'every child hash is 32-char hex (shared with its parent)'
+	_assert_json_eq '[.results[].alternate_names[]?] | all(has("ecid") and has("name") and has("sources"))' \
+		true 'every alternate name has ecid/name/sources'
+	# `hash` was dropped from the entries: it is by construction the parent's,
+	# so repeating it per entry said nothing.
+	_assert_json_eq '[.results[].alternate_names[]?] | all(has("hash") | not)' \
+		true 'alternate names no longer repeat the parent hash'
 	_assert_json_eq '[.results[].alternate_names[]?] | all(has("directory"))' \
 		true 'every child carries its own directory (per-result, not per-search)'
 
@@ -536,7 +538,7 @@ _curl -X POST -H "Authorization: Bearer $ADMIN_TOKEN" \
 	-H "Content-Type: application/json" \
 	-d "{\"query\":\"${TEST_QUERY}more\",\"type\":\"kad\"}" "$HOST/api/v0/search"
 if [ "$CURL_STATUS" = "202" ]; then
-	KAD_SID=$(printf '%s' "$CURL_BODY" | jq -r '.search_id')
+	KAD_SID=$(printf '%s' "$CURL_BODY" | jq -r '.id')
 	_curl -X POST -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/search/$KAD_SID/more"
 	_assert_status 202 "POST /search/{id}/more on a running Kad search → 202"
 	_assert_body_empty 'more sends no body'
@@ -677,13 +679,13 @@ _curl -X POST -H "Authorization: Bearer $ADMIN_TOKEN" \
 	-H "Content-Type: application/json" \
 	-d "{\"query\":\"$TEST_QUERY\",\"type\":\"kad\"}" "$HOST/api/v0/search"
 _assert_status 202 "POST /search type=kad → 202"
-RAMP_SID=$(printf '%s' "$CURL_BODY" | jq -r '.search_id')
+RAMP_SID=$(printf '%s' "$CURL_BODY" | jq -r '.id')
 
 KAD_STATES=""; KAD_PCTS=""; SAW_RUNNING_KAD=0
 for _ in 1 2 3 4 5 6; do
 	_curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/search/$RAMP_SID/results"
 	ST=$(printf '%s' "$CURL_BODY" | jq -r '.progress.state')
-	KD=$(printf '%s' "$CURL_BODY" | jq -r '.progress.kind')
+	KD=$(printf '%s' "$CURL_BODY" | jq -r '.progress.type')
 	PC=$(printf '%s' "$CURL_BODY" | jq -r '.progress.percent')
 	KAD_STATES="$KAD_STATES $ST"; KAD_PCTS="$KAD_PCTS $PC"
 	if [ "$ST" = "running" ] && [ "$KD" = "kad" ]; then SAW_RUNNING_KAD=1; fi
@@ -876,7 +878,7 @@ fi
 G=$(curl -s -X POST -H "Authorization: Bearer $ADMIN_TOKEN" \
 	-H "Content-Type: application/json" \
 	-d "{\"query\":\"$TEST_QUERY\",\"type\":\"global\"}" "$HOST/api/v0/search")
-SID_G=$(printf '%s' "$G" | jq -r '.search_id')
+SID_G=$(printf '%s' "$G" | jq -r '.id')
 # Distinct Kad keyword again: amuled keeps a keyword on its Kademlia
 # search list for the search's lifetime and refuses a second search for
 # the same one, so reusing $TEST_QUERY here would couple this section to
@@ -884,7 +886,7 @@ SID_G=$(printf '%s' "$G" | jq -r '.search_id')
 K=$(curl -s -X POST -H "Authorization: Bearer $ADMIN_TOKEN" \
 	-H "Content-Type: application/json" \
 	-d "{\"query\":\"${TEST_QUERY}multi\",\"type\":\"kad\"}" "$HOST/api/v0/search")
-SID_K=$(printf '%s' "$K" | jq -r '.search_id')
+SID_K=$(printf '%s' "$K" | jq -r '.id')
 
 if [ -n "$SID_G" ] && [ -n "$SID_K" ] && [ "$SID_G" != "null" ] && [ "$SID_K" != "null" ]; then
 	if [ "$SID_G" != "$SID_K" ]; then
@@ -897,11 +899,11 @@ if [ -n "$SID_G" ] && [ -n "$SID_K" ] && [ "$SID_G" != "null" ] && [ "$SID_K" !=
 	_curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/search/$SID_G/results"
 	_assert_status 200 "GET /search/{global}/results → 200"
 	_assert_json_eq '.search_id'      "$SID_G" 'global search echoes its search_id'
-	_assert_json_eq '.progress.kind'  global   'global search progress.kind==global'
+	_assert_json_eq '.progress.type'  global   'global search progress.type==global'
 	_curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/search/$SID_K/results"
 	_assert_status 200 "GET /search/{kad}/results → 200"
 	_assert_json_eq '.search_id'      "$SID_K" 'kad search echoes its search_id'
-	_assert_json_eq '.progress.kind'  kad      'kad search progress.kind==kad'
+	_assert_json_eq '.progress.type'  kad      'kad search progress.type==kad'
 
 	# Unknown / never-started id → 404 (distinct from known-but-empty).
 	_curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/search/4293000111/results"
@@ -963,7 +965,7 @@ if [ -n "$SID_G" ] && [ -n "$SID_K" ] && [ "$SID_G" != "null" ] && [ "$SID_K" !=
 		# this is looking for.
 		_curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/search"
 		if [ "$(printf '%s' "$CURL_BODY" | jq --argjson g "$SID_G" --argjson k "$SID_K" \
-			'[.searches[] | select(.id == $g or .search_id == $k) | select(has("result_count"))] | length')" -eq 2 ]; then
+			'[.searches[] | select(.id == $g or .id == $k) | select(has("result_count"))] | length')" -eq 2 ]; then
 			for _pair in "$SID_G:$G_TOTAL:global" "$SID_K:$K_TOTAL:kad"; do
 				_sid=${_pair%%:*}; _rest=${_pair#*:}; _cached=${_rest%%:*}; _label=${_rest#*:}
 				_held=$(printf '%s' "$CURL_BODY" | jq -r --argjson s "$_sid" \
@@ -986,14 +988,14 @@ if [ -n "$SID_G" ] && [ -n "$SID_K" ] && [ "$SID_G" != "null" ] && [ "$SID_K" !=
 		if [ "$(printf '%s' "$CURL_BODY" | jq '.results | length')" -gt 0 ]; then
 			_assert_json_eq '[.results[] | select(.name == "" or .name == null)] | length' 0 \
 				'union: no result lost its name across diffed polls'
-			_assert_json_eq '[.results[] | select(.size == 0 or .size == null)] | length' 0 \
-				'union: no result lost its size across diffed polls'
+			_assert_json_eq '[.results[] | select(.size_bytes == 0 or .size_bytes == null)] | length' 0 \
+				'union: no result lost its size_bytes across diffed polls'
 			_assert_json_eq '[.results[] | select(.hash == "" or .hash == null)] | length' 0 \
 				'union: no result lost its hash across diffed polls'
 			_assert_json_eq '[.results[] | select(.status == "" or .status == null)] | length' 0 \
 				'union: no result lost its status across diffed polls'
-			_assert_json_eq '[.results[] | select(.type == "" or .type == null)] | length' 0 \
-				'union: no result lost its type across diffed polls'
+			_assert_json_eq '[.results[] | select(.file_type == "" or .file_type == null)] | length' 0 \
+				'union: no result lost its file_type across diffed polls'
 		else
 			echo "    info: global search returned no rows; per-field retention checks skipped"
 		fi
@@ -1075,7 +1077,7 @@ fi
 CLOSE_RES=$(curl -s -X POST -H "Authorization: Bearer $ADMIN_TOKEN" \
 	-H "Content-Type: application/json" \
 	-d "{\"query\":\"$TEST_QUERY\",\"type\":\"global\"}" "$HOST/api/v0/search")
-SID_CLOSE=$(printf '%s' "$CLOSE_RES" | jq -r '.search_id')
+SID_CLOSE=$(printf '%s' "$CLOSE_RES" | jq -r '.id')
 
 if [ -n "$SID_CLOSE" ] && [ "$SID_CLOSE" != "null" ]; then
 	# Precondition: the daemon holds it. Without this the "gone" assertion
@@ -1190,7 +1192,7 @@ if [ -n "$FOREIGN_TOKEN" ] && [ "$FOREIGN_TOKEN" != "null" ]; then
 		-H "Content-Type: application/json" \
 		-d "{\"query\":\"$TEST_QUERY\",\"type\":\"global\"}" \
 		"http://localhost:4716/api/v0/search")
-	SID_FOREIGN=$(printf '%s' "$FOREIGN_RES" | jq -r '.search_id')
+	SID_FOREIGN=$(printf '%s' "$FOREIGN_RES" | jq -r '.id')
 
 	if [ -n "$SID_FOREIGN" ] && [ "$SID_FOREIGN" != "null" ]; then
 		# The primary session can SEE it (this already worked).
@@ -1244,7 +1246,7 @@ _assert_json_eq '.searches | type' array 'failed start: /search still enumerable
 AFTER_BAD=$(curl -s -X POST -H "Authorization: Bearer $ADMIN_TOKEN" \
 	-H "Content-Type: application/json" \
 	-d "{\"query\":\"$TEST_QUERY\",\"type\":\"global\"}" "$HOST/api/v0/search")
-SID_AFTER=$(printf '%s' "$AFTER_BAD" | jq -r '.search_id')
+SID_AFTER=$(printf '%s' "$AFTER_BAD" | jq -r '.id')
 if [ -n "$SID_AFTER" ] && [ "$SID_AFTER" != "null" ] && [ "$SID_AFTER" != "0" ]; then
 	_pass "failed start: a subsequent search still starts (id $SID_AFTER)"
 	_curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/search"
@@ -1275,13 +1277,13 @@ _curl -X POST -H "Authorization: Bearer $ADMIN_TOKEN" \
 	-H "Content-Type: application/json" \
 	-d "{\"query\":\"$ZERO_QUERY\",\"type\":\"global\"}" "$HOST/api/v0/search"
 _assert_status 202 "POST /search (zero-result probe) → 202"
-ZERO_SID=$(printf '%s' "$CURL_BODY" | jq -r '.search_id')
+ZERO_SID=$(printf '%s' "$CURL_BODY" | jq -r '.id')
 
 _curl -X POST -H "Authorization: Bearer $ADMIN_TOKEN" \
 	-H "Content-Type: application/json" \
 	-d "{\"query\":\"${ZERO_QUERY}b\",\"type\":\"global\"}" "$HOST/api/v0/search"
 _assert_status 202 "POST /search (demotes the zero-result probe) → 202"
-DEMOTER_SID=$(printf '%s' "$CURL_BODY" | jq -r '.search_id')
+DEMOTER_SID=$(printf '%s' "$CURL_BODY" | jq -r '.id')
 
 _curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/search"
 _assert_status 200 "GET /search → 200 (after the zero-result probe)"
@@ -1343,7 +1345,7 @@ if [ -n "$PEER_ECID" ]; then
 	_curl -X POST -H "Authorization: Bearer $ADMIN_TOKEN" \
 		"$HOST/api/v0/clients/$PEER_ECID/shared_files"
 	if [ "$CURL_STATUS" = "202" ]; then
-		BROWSE_SID=$(printf '%s' "$CURL_BODY" | jq -r '.search_id')
+		BROWSE_SID=$(printf '%s' "$CURL_BODY" | jq -r '.id')
 		_pass "POST /clients/{ecid}/shared_files (live peer) → 202 (search_id $BROWSE_SID)"
 
 		_curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/search"
@@ -1414,16 +1416,16 @@ if [ -n "$PEER_ECID" ]; then
 		# legitimately shows more than one entry for it.
 		_curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/search"
 		BROWSE_COUNT_BEFORE=$(printf '%s' "$CURL_BODY" | \
-			jq "[.searches[] | select(.kind == \"browse\")] | length")
+			jq "[.searches[] | select(.type == \"browse\")] | length")
 		_curl -X POST -H "Authorization: Bearer $ADMIN_TOKEN" \
 			"$HOST/api/v0/clients/$PEER_ECID/shared_files"
 		_assert_status 202 "POST /clients/{ecid}/shared_files (duplicate) → 202"
-		DUP_SID=$(printf '%s' "$CURL_BODY" | jq -r '.search_id')
+		DUP_SID=$(printf '%s' "$CURL_BODY" | jq -r '.id')
 		_curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/search"
 		FIRST_STATE=$(printf '%s' "$CURL_BODY" | \
 			jq -r "[.searches[] | select(.id == $BROWSE_SID)][0].state")
 		BROWSE_COUNT_AFTER=$(printf '%s' "$CURL_BODY" | \
-			jq "[.searches[] | select(.kind == \"browse\")] | length")
+			jq "[.searches[] | select(.type == \"browse\")] | length")
 		if [ "$DUP_SID" = "$BROWSE_SID" ]; then
 			_pass "a duplicate browse returns the id already in flight ($BROWSE_SID)"
 			# ...so it added no entry to the listing.
@@ -1502,7 +1504,7 @@ if [ -n "$UNREACHABLE_ECID" ]; then
 	_curl -X POST -H "Authorization: Bearer $ADMIN_TOKEN" \
 		"$HOST/api/v0/clients/$UNREACHABLE_ECID/shared_files"
 	if [ "$CURL_STATUS" = "202" ]; then
-		DEAD_SID=$(printf '%s' "$CURL_BODY" | jq -r '.search_id')
+		DEAD_SID=$(printf '%s' "$CURL_BODY" | jq -r '.id')
 		# No peer round trip is involved -- the daemon decides not to contact
 		# it and fails the browse in the same call -- so a short settle is
 		# enough. Poll rather than sleep blindly, to keep it quick when it
@@ -1530,7 +1532,7 @@ if [ -n "$UNREACHABLE_ECID" ]; then
 		# is still browsable rather than joined to a dead browse for good.
 		_curl -X POST -H "Authorization: Bearer $ADMIN_TOKEN" \
 			"$HOST/api/v0/clients/$UNREACHABLE_ECID/shared_files"
-		RETRY_SID=$(printf '%s' "$CURL_BODY" | jq -r '.search_id')
+		RETRY_SID=$(printf '%s' "$CURL_BODY" | jq -r '.id')
 		if [ "$RETRY_SID" != "$DEAD_SID" ]; then
 			_pass "a later browse of that peer starts fresh ($RETRY_SID), not the dead id"
 		else

--- a/unittests/curl-tests/amuleapi/19-search.sh
+++ b/unittests/curl-tests/amuleapi/19-search.sh
@@ -6,7 +6,7 @@
 #   GET  /api/v0/search                                    — EC_OP_SEARCH_LIST
 #   POST /api/v0/search                                   — EC_OP_SEARCH_START
 #       body: {query, type?, file_type?, extension?,
-#              min_size?, max_size?, min_avail?}
+#              min_size_bytes?, max_size_bytes?, min_source_count?}
 #   POST /api/v0/search/{id}/stop                          — EC_OP_SEARCH_STOP
 #   POST /api/v0/search/{id}/more                          — EC_OP_SEARCH_REQUEST_MORE
 #   DELETE /api/v0/search/{id}                             — stop + free
@@ -214,8 +214,8 @@ _assert_status 400 "POST /search (bad type enum) → 400"
 
 _curl -X POST -H "Authorization: Bearer $ADMIN_TOKEN" \
 	-H "Content-Type: application/json" \
-	-d "{\"query\":\"$TEST_QUERY\",\"min_size\":-1}" "$HOST/api/v0/search"
-_assert_status 400 "POST /search (negative min_size) → 400"
+	-d "{\"query\":\"$TEST_QUERY\",\"min_size_bytes\":-1}" "$HOST/api/v0/search"
+_assert_status 400 "POST /search (negative min_size_bytes) → 400"
 
 _curl -X POST -H "Authorization: Bearer $ADMIN_TOKEN" \
 	-H "Content-Type: application/json" \
@@ -250,11 +250,11 @@ _assert_status 202 "POST /search (query=$TEST_QUERY, type=global) → 202"
 # carried it.
 _assert_json_eq '. | has("ok")' false 'POST /search response has no constant ok field'
 _assert_json_eq '.query' "$TEST_QUERY" 'POST /search echoes query'
-_assert_json_eq '.search_id | type' number 'POST /search returns a numeric search_id'
-_assert_json_eq '.kind'  global       'POST /search response reports kind=global'
+_assert_json_eq '.id | type' number 'POST /search returns a numeric id'
+_assert_json_eq '.type'  global       'POST /search response reports type=global'
 _assert_json_eq '.state' running      'POST /search response reports state=running'
 _assert_json_eq '.started_at | type' number 'POST /search response stamps started_at'
-FIRST_SID=$(printf '%s' "$CURL_BODY" | jq -r '.search_id')
+FIRST_SID=$(printf '%s' "$CURL_BODY" | jq -r '.id')
 # ...and a Location naming where the resource now lives, so a client that
 # ignores the body still knows the id it was given.
 _assert_header_contains "location: /api/v0/search/$FIRST_SID" \
@@ -282,25 +282,25 @@ _assert_status 404 "GET /search/{unknown}/results → 404"
 _curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/search"
 _assert_status 200 "GET /search → 200"
 _assert_json_eq '.searches | type' array 'GET /search .searches is an array'
-_assert_json_eq "[.searches[] | select(.search_id == $FIRST_SID)] | length" 1 \
+_assert_json_eq "[.searches[] | select(.id == $FIRST_SID)] | length" 1 \
 	'GET /search lists the search just started via POST /search'
-_assert_json_eq "[.searches[] | select(.search_id == $FIRST_SID)][0].query" "$TEST_QUERY" \
+_assert_json_eq "[.searches[] | select(.id == $FIRST_SID)][0].query" "$TEST_QUERY" \
 	'GET /search entry echoes the query'
-_assert_json_eq "[.searches[] | select(.search_id == $FIRST_SID)][0].kind" global \
+_assert_json_eq "[.searches[] | select(.id == $FIRST_SID)][0].type" global \
 	'GET /search entry reports kind==global'
-_assert_json_eq "[[.searches[] | select(.search_id == $FIRST_SID)][0].state] | inside([\"running\",\"finished\"])" \
+_assert_json_eq "[[.searches[] | select(.id == $FIRST_SID)][0].state] | inside([\"running\",\"finished\"])" \
 	true 'GET /search entry state is running or finished (never idle for an active search)'
 # started_at is the list's only recency signal: entries arrive id-ascending
 # and id order is not start order (Kad ids carry a high-bit mask and sort
 # above ed2k ones), so a client that wants "the newest search" sorts on this.
 # Present because THIS amuleapi started the search.
-_assert_json_eq "[.searches[] | select(.search_id == $FIRST_SID)][0].started_at | type" number \
+_assert_json_eq "[.searches[] | select(.id == $FIRST_SID)][0].started_at | type" number \
 	'GET /search stamps started_at on a search this session started'
-_assert_json_eq "[.searches[] | select(.search_id == $FIRST_SID)][0].started_at > 1700000000" \
+_assert_json_eq "[.searches[] | select(.id == $FIRST_SID)][0].started_at > 1700000000" \
 	true 'started_at is a plausible recent unix second, not 0'
 # result_count lets a client label a tab it has not opened yet, instead of
 # fetching every search's results just to learn one integer each.
-_assert_json_eq "[.searches[] | select(.search_id == $FIRST_SID)][0].result_count | type" number \
+_assert_json_eq "[.searches[] | select(.id == $FIRST_SID)][0].result_count | type" number \
 	'GET /search entry carries a numeric result_count'
 # ...and it agrees with what the results endpoint reports as `total` -- but only
 # once the search has settled. While it runs, result_count is the daemon's live
@@ -333,9 +333,9 @@ done
 
 # legitimately differ by a fetch.
 LIST_COUNT=$(printf '%s' "$CURL_BODY" \
-	| jq -r "[.searches[] | select(.search_id == $FIRST_SID)][0].result_count")
+	| jq -r "[.searches[] | select(.id == $FIRST_SID)][0].result_count")
 LIST_STATE=$(printf '%s' "$CURL_BODY" \
-	| jq -r "[.searches[] | select(.search_id == $FIRST_SID)][0].state")
+	| jq -r "[.searches[] | select(.id == $FIRST_SID)][0].state")
 if [ "$LIST_STATE" = "finished" ]; then
 	_curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/search/$FIRST_SID/results"
 	_assert_json_eq '.total' "$LIST_COUNT" \
@@ -387,11 +387,11 @@ SECOND_TOKEN=$(curl -s -X POST -H "Content-Type: application/json" \
 if [ -n "$SECOND_TOKEN" ] && [ "$SECOND_TOKEN" != "null" ]; then
 	_curl -H "Authorization: Bearer $SECOND_TOKEN" "http://$SECOND_HOST/api/v0/search"
 	_assert_status 200 "second amuleapi instance: GET /search → 200"
-	_assert_json_eq "[.searches[] | select(.search_id == $FIRST_SID)] | length" 1 \
+	_assert_json_eq "[.searches[] | select(.id == $FIRST_SID)] | length" 1 \
 		'second amuleapi instance (never POSTed) still lists the first instance'"'"'s search'
 	# ...but cannot stamp it: that instance did not start the search and the
 	# daemon ships no timestamp, so the key is omitted rather than zeroed.
-	_assert_json_eq "[.searches[] | select(.search_id == $FIRST_SID)][0] | has(\"started_at\")" \
+	_assert_json_eq "[.searches[] | select(.id == $FIRST_SID)][0] | has(\"started_at\")" \
 		false 'a foreign search carries no started_at (unknown, not 1970)'
 
 	_curl -H "Authorization: Bearer $SECOND_TOKEN" \
@@ -444,7 +444,7 @@ else
 		"got state=$EARLY_STATE with ${EARLY_RESULTS:-0} results" \
 		"amuled's queue-empty-at-start raw=100 is leaking through unmasked"
 fi
-_assert_json_eq '.progress.kind | type' string 'progress.kind is a string'
+_assert_json_eq '.progress.type | type' string 'progress.type is a string'
 
 # --- 4. Poll /search/{id}/results until we get hits (max ~10 s). --
 RESULT_HASH=""
@@ -465,7 +465,7 @@ if [ -n "$RESULT_HASH" ]; then
 	_curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/search/$FIRST_SID/results"
 	_assert_json_eq '.results[0].hash | length' 32     '/search/{id}/results[0].hash is 32-char hex'
 	_assert_json_eq '.results[0].name | type'   string '/search/{id}/results[0].name is string'
-	_assert_json_eq '.results[0].size | type'   number '/search/{id}/results[0].size is numeric'
+	_assert_json_eq '.results[0].size_bytes | type'   number '/search/{id}/results[0].size_bytes is numeric'
 	# Browse-only folder. Always present, empty on a server/Kad hit.
 	_assert_json_eq '.results[0].directory | type' string \
 		'/search/{id}/results[0].directory is a string'
@@ -474,7 +474,7 @@ if [ -n "$RESULT_HASH" ]; then
 	# Download status + file type (issue #429).
 	_assert_json_eq '[.results[0].status] | inside(["new","downloaded","queued","canceled","queued_canceled"])' \
 		true '/search/results[0].status is a known enum value'
-	_assert_json_eq '.results[0].type | type'   string '/search/{id}/results[0].type is string'
+	_assert_json_eq '.results[0].file_type | type'   string '/search/{id}/results[0].file_type is string'
 	# Media metadata (issue #430): an object when the hit is locally
 	# known/probed, absent otherwise — both are valid.
 	_assert_json_eq '.results[0].media | type | test("^(object|null)$")' \
@@ -483,12 +483,12 @@ if [ -n "$RESULT_HASH" ]; then
 	# array (empty when the hit was seen under a single name). No result
 	# is itself a child (children are folded into their parent), and each
 	# child object has ecid + name + hash + sources.
-	_assert_json_eq '.results[0].children | type' array '/search/{id}/results[0].children is an array'
-	_assert_json_eq '[.results[].children[]?] | all(has("ecid") and has("name") and has("hash") and has("sources"))' \
+	_assert_json_eq '.results[0].alternate_names | type' array '/search/{id}/results[0].alternate_names is an array'
+	_assert_json_eq '[.results[].alternate_names[]?] | all(has("ecid") and has("name") and has("hash") and has("sources"))' \
 		true 'every child has ecid/name/hash/sources'
-	_assert_json_eq '[.results[].children[]?.hash | length] | all(. == 32)' \
+	_assert_json_eq '[.results[].alternate_names[]?.hash | length] | all(. == 32)' \
 		true 'every child hash is 32-char hex (shared with its parent)'
-	_assert_json_eq '[.results[].children[]?] | all(has("directory"))' \
+	_assert_json_eq '[.results[].alternate_names[]?] | all(has("directory"))' \
 		true 'every child carries its own directory (per-result, not per-search)'
 
 	# sort=directory is accepted (browse listings are read folder by
@@ -778,7 +778,7 @@ _assert_status 405 "PATCH search comments → 405"
 _curl -X POST -H "Authorization: Bearer $ADMIN_TOKEN" \
 	-H "Content-Type: application/json" \
 	-d "{\"query\":\"$TEST_QUERY\",\"type\":\"global\"}" "$HOST/api/v0/search"
-CMT_SID=$(printf '%s' "$CURL_BODY" | jq -r '.search_id // empty')
+CMT_SID=$(printf '%s' "$CURL_BODY" | jq -r '.id // empty')
 CMT_HASH=""
 for _ in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20; do
 	_curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/search/$CMT_SID/results"
@@ -963,11 +963,11 @@ if [ -n "$SID_G" ] && [ -n "$SID_K" ] && [ "$SID_G" != "null" ] && [ "$SID_K" !=
 		# this is looking for.
 		_curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/search"
 		if [ "$(printf '%s' "$CURL_BODY" | jq --argjson g "$SID_G" --argjson k "$SID_K" \
-			'[.searches[] | select(.search_id == $g or .search_id == $k) | select(has("result_count"))] | length')" -eq 2 ]; then
+			'[.searches[] | select(.id == $g or .search_id == $k) | select(has("result_count"))] | length')" -eq 2 ]; then
 			for _pair in "$SID_G:$G_TOTAL:global" "$SID_K:$K_TOTAL:kad"; do
 				_sid=${_pair%%:*}; _rest=${_pair#*:}; _cached=${_rest%%:*}; _label=${_rest#*:}
 				_held=$(printf '%s' "$CURL_BODY" | jq -r --argjson s "$_sid" \
-					'.searches[] | select(.search_id == $s) | .result_count')
+					'.searches[] | select(.id == $s) | .result_count')
 				if [ "$_cached" -gt "$_held" ]; then
 					_fail "union: the $_label search holds more results than the daemon has for it" \
 						"cached $_cached > daemon $_held; the ECID index is cross-wiring diffed tags"
@@ -1025,7 +1025,7 @@ fi
 #
 # The tick used to poll only searches with progress.active, so once a search
 # finished nothing re-read it and a hit downloaded afterwards kept reporting
-# already_have=false forever. Eliding made polling finished searches free, so
+# already_downloaded=false forever. Eliding made polling finished searches free, so
 # they stay in the poll set -- this pins that the row is still being maintained
 # rather than frozen at the moment the search completed.
 _curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/search/$FIRST_SID/results"
@@ -1047,8 +1047,8 @@ if [ "$CURL_STATUS" = "200" ]; then
 			'union: a finished search keeps its results across ticks'
 		_assert_json_eq '[.results[] | select(.name == "" or .name == null)] | length' 0 \
 			'union: a finished search keeps its result names across ticks'
-		_assert_json_eq '[.results[] | select(.already_have | type != "boolean")] | length' 0 \
-			'union: a finished search still reports already_have as a boolean'
+		_assert_json_eq '[.results[] | select(.already_downloaded | type != "boolean")] | length' 0 \
+			'union: a finished search still reports already_downloaded as a boolean'
 	else
 		echo "    info: search $FIRST_SID not finished-with-results; finished-poll check skipped"
 	fi
@@ -1081,7 +1081,7 @@ if [ -n "$SID_CLOSE" ] && [ "$SID_CLOSE" != "null" ]; then
 	# Precondition: the daemon holds it. Without this the "gone" assertion
 	# below would also pass against a search that was never there.
 	_curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/search"
-	_assert_json_eq "[.searches[] | select(.search_id == $SID_CLOSE)] | length" 1 \
+	_assert_json_eq "[.searches[] | select(.id == $SID_CLOSE)] | length" 1 \
 		'close: daemon lists the search before the close'
 
 	# A plain stop (no close) halts activity but must KEEP the search --
@@ -1090,7 +1090,7 @@ if [ -n "$SID_CLOSE" ] && [ "$SID_CLOSE" != "null" ]; then
 	curl -s -X POST -H "Authorization: Bearer $ADMIN_TOKEN" \
 		"$HOST/api/v0/search/$SID_CLOSE/stop" >/dev/null 2>&1
 	_curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/search"
-	_assert_json_eq "[.searches[] | select(.search_id == $SID_CLOSE)] | length" 1 \
+	_assert_json_eq "[.searches[] | select(.id == $SID_CLOSE)] | length" 1 \
 		'close: a plain stop leaves the search on the daemon'
 
 	# Now free it, and assert it is GONE from the daemon's own list.
@@ -1098,7 +1098,7 @@ if [ -n "$SID_CLOSE" ] && [ "$SID_CLOSE" != "null" ]; then
 		"$HOST/api/v0/search/$SID_CLOSE" >/dev/null 2>&1
 	_curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/search"
 	_assert_status 200 'close: GET /search after close → 200'
-	_assert_json_eq "[.searches[] | select(.search_id == $SID_CLOSE)] | length" 0 \
+	_assert_json_eq "[.searches[] | select(.id == $SID_CLOSE)] | length" 0 \
 		'close: the closed search is GONE from the daemon list'
 
 	# And it is gone for everyone, not just the session that closed it --
@@ -1129,7 +1129,7 @@ if [ -n "$SID_CLOSE" ] && [ "$SID_CLOSE" != "null" ]; then
 		"http://localhost:4715/api/v0/auth/login?type=bearer" | jq -r .token)
 	if [ -n "$SECOND2_TOKEN" ] && [ "$SECOND2_TOKEN" != "null" ]; then
 		_curl -H "Authorization: Bearer $SECOND2_TOKEN" "http://localhost:4715/api/v0/search"
-		_assert_json_eq "[.searches[] | select(.search_id == $SID_CLOSE)] | length" 0 \
+		_assert_json_eq "[.searches[] | select(.id == $SID_CLOSE)] | length" 0 \
 			'close: a second session also no longer sees the closed search'
 	else
 		_fail "close: second instance login" "no token; log: $(tail -c 300 "$SECOND2_LOG")"
@@ -1195,7 +1195,7 @@ if [ -n "$FOREIGN_TOKEN" ] && [ "$FOREIGN_TOKEN" != "null" ]; then
 	if [ -n "$SID_FOREIGN" ] && [ "$SID_FOREIGN" != "null" ]; then
 		# The primary session can SEE it (this already worked).
 		_curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/search"
-		_assert_json_eq "[.searches[] | select(.search_id == $SID_FOREIGN)] | length" 1 \
+		_assert_json_eq "[.searches[] | select(.id == $SID_FOREIGN)] | length" 1 \
 			'foreign stop: primary session lists the foreign search'
 
 		# ...and can also FREE it. This is the assertion that was 404ing.
@@ -1204,7 +1204,7 @@ if [ -n "$FOREIGN_TOKEN" ] && [ "$FOREIGN_TOKEN" != "null" ]; then
 		_assert_status 204 'foreign stop: freeing a foreign search → 204 (not 404)'
 
 		_curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/search"
-		_assert_json_eq "[.searches[] | select(.search_id == $SID_FOREIGN)] | length" 0 \
+		_assert_json_eq "[.searches[] | select(.id == $SID_FOREIGN)] | length" 0 \
 			'foreign stop: the foreign search is actually gone afterwards'
 	else
 		_fail "foreign stop setup" "second instance POST /search returned no id ($FOREIGN_RES)"
@@ -1248,7 +1248,7 @@ SID_AFTER=$(printf '%s' "$AFTER_BAD" | jq -r '.search_id')
 if [ -n "$SID_AFTER" ] && [ "$SID_AFTER" != "null" ] && [ "$SID_AFTER" != "0" ]; then
 	_pass "failed start: a subsequent search still starts (id $SID_AFTER)"
 	_curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/search"
-	_assert_json_eq "[.searches[] | select(.search_id == $SID_AFTER)] | length" 1 \
+	_assert_json_eq "[.searches[] | select(.id == $SID_AFTER)] | length" 1 \
 		'failed start: the subsequent search is discoverable'
 	curl -s -X DELETE -H "Authorization: Bearer $ADMIN_TOKEN" \
 		"$HOST/api/v0/search/$SID_AFTER" >/dev/null 2>&1
@@ -1286,12 +1286,12 @@ DEMOTER_SID=$(printf '%s' "$CURL_BODY" | jq -r '.search_id')
 _curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/search"
 _assert_status 200 "GET /search → 200 (after the zero-result probe)"
 ZERO_COUNT=$(printf '%s' "$CURL_BODY" \
-	| jq -r "[.searches[] | select(.search_id == $ZERO_SID)][0].result_count // empty")
+	| jq -r "[.searches[] | select(.id == $ZERO_SID)][0].result_count // empty")
 # Guarded on the probe actually having retained nothing: on a daemon where the
 # nonsense keyword somehow matched, this assertion would pass through the
 # results-retained branch and prove nothing.
 if [ "$ZERO_COUNT" = "0" ]; then
-	_assert_json_eq "[.searches[] | select(.search_id == $ZERO_SID)][0].state" finished \
+	_assert_json_eq "[.searches[] | select(.id == $ZERO_SID)][0].state" finished \
 		'a demoted search that retained no results reports finished, not idle'
 else
 	_skip "zero-result lifecycle: probe retained ${ZERO_COUNT:-no} result(s), not 0"
@@ -1347,13 +1347,13 @@ if [ -n "$PEER_ECID" ]; then
 		_pass "POST /clients/{ecid}/shared_files (live peer) → 202 (search_id $BROWSE_SID)"
 
 		_curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/search"
-		_assert_json_eq "[.searches[] | select(.search_id == $BROWSE_SID)][0].kind" browse \
+		_assert_json_eq "[.searches[] | select(.id == $BROWSE_SID)][0].type" browse \
 			'GET /search reports the browse with kind=browse'
-		_assert_json_eq "[.searches[] | select(.search_id == $BROWSE_SID)][0].client_ecid" \
+		_assert_json_eq "[.searches[] | select(.id == $BROWSE_SID)][0].client_ecid" \
 			"$PEER_ECID" 'GET /search reports the browsed peer as client_ecid'
 		# Files received from the peer so far -- no total comparison, a browse
 		# is still running here.
-		_assert_json_eq "[.searches[] | select(.search_id == $BROWSE_SID)][0].result_count | type" \
+		_assert_json_eq "[.searches[] | select(.id == $BROWSE_SID)][0].result_count | type" \
 			number 'GET /search carries a numeric result_count on the browse'
 
 		# A browse must never report `idle` on the listing
@@ -1367,7 +1367,7 @@ if [ -n "$PEER_ECID" ]; then
 		# request is sent, but a peer that denies instantly can terminalize
 		# the browse before this round trip completes. `idle` is the failure.
 		LIST_STATE=$(printf '%s' "$CURL_BODY" | \
-			jq -r "[.searches[] | select(.search_id == $BROWSE_SID)][0].state")
+			jq -r "[.searches[] | select(.id == $BROWSE_SID)][0].state")
 		case "$LIST_STATE" in
 		running | finished)
 			_pass "GET /search reports the browse as $LIST_STATE, never idle"
@@ -1421,7 +1421,7 @@ if [ -n "$PEER_ECID" ]; then
 		DUP_SID=$(printf '%s' "$CURL_BODY" | jq -r '.search_id')
 		_curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/search"
 		FIRST_STATE=$(printf '%s' "$CURL_BODY" | \
-			jq -r "[.searches[] | select(.search_id == $BROWSE_SID)][0].state")
+			jq -r "[.searches[] | select(.id == $BROWSE_SID)][0].state")
 		BROWSE_COUNT_AFTER=$(printf '%s' "$CURL_BODY" | \
 			jq "[.searches[] | select(.kind == \"browse\")] | length")
 		if [ "$DUP_SID" = "$BROWSE_SID" ]; then
@@ -1468,7 +1468,7 @@ if [ -n "$PEER_ECID" ]; then
 		# `running` is still legitimate for a peer genuinely still streaming.
 		_curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/search"
 		LIST_STATE=$(printf '%s' "$CURL_BODY" | \
-			jq -r "[.searches[] | select(.search_id == $BROWSE_SID)][0].state")
+			jq -r "[.searches[] | select(.id == $BROWSE_SID)][0].state")
 		if [ "$LIST_STATE" = "finished" ] || [ "$LIST_STATE" = "running" ]; then
 			_pass "browse listing state is $LIST_STATE after settling (never idle)"
 		else
@@ -1511,7 +1511,7 @@ if [ -n "$UNREACHABLE_ECID" ]; then
 		for _ in 1 2 3 4 5 6 7 8 9 10; do
 			_curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/search"
 			DEAD_STATE=$(printf '%s' "$CURL_BODY" | \
-				jq -r "[.searches[] | select(.search_id == $DEAD_SID)][0].state")
+				jq -r "[.searches[] | select(.id == $DEAD_SID)][0].state")
 			[ "$DEAD_STATE" = "finished" ] && break
 			sleep 1
 		done
@@ -1558,7 +1558,7 @@ _curl -X POST -H "Authorization: Bearer $ADMIN_TOKEN" \
 	-d '{"query":"related::baadbaadbaadbaadbaadbaadbaadbaad","type":"local"}' \
 	"$HOST/api/v0/search"
 _assert_status 202 'POST /search with a related:: query → 202 (no dedicated endpoint needed)'
-REL_SID=$(printf '%s' "$CURL_BODY" | jq -r '.search_id // empty')
+REL_SID=$(printf '%s' "$CURL_BODY" | jq -r '.id // empty')
 [ -n "$REL_SID" ] && curl -s -X DELETE -H "Authorization: Bearer $ADMIN_TOKEN" \
 	"$HOST/api/v0/search/$REL_SID" >/dev/null 2>&1
 # The capability a client should check before reading "no hits" as
@@ -1611,7 +1611,7 @@ if [ "$HAVE_SECOND_INSTANCE" -eq 1 ]; then
 		OWN_SID=$(curl -s -X POST -H "Authorization: Bearer $THIRD_TOKEN" \
 			-H "Content-Type: application/json" \
 			-d "{\"query\":\"$TEST_QUERY\"}" "http://$THIRD_HOST/api/v0/search" \
-			| jq -r '.search_id // empty')
+			| jq -r '.id // empty')
 		sleep 3
 
 		# NOW start a search it knows nothing about, and let its union poll run
@@ -1621,7 +1621,7 @@ if [ "$HAVE_SECOND_INSTANCE" -eq 1 ]; then
 			-H "Content-Type: application/json" \
 			-d "{\"query\":\"$TEST_QUERY\"}" "$HOST/api/v0/search"
 		_assert_status 202 'late-discovery: first instance starts a search the third has never seen'
-		LATE_SID=$(printf '%s' "$CURL_BODY" | jq -r '.search_id // empty')
+		LATE_SID=$(printf '%s' "$CURL_BODY" | jq -r '.id // empty')
 		sleep 12
 
 		if [ -n "$LATE_SID" ]; then
@@ -1629,7 +1629,7 @@ if [ "$HAVE_SECOND_INSTANCE" -eq 1 ]; then
 			# from a search that genuinely found nothing.
 			_curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/search"
 			LATE_HELD=$(printf '%s' "$CURL_BODY" \
-				| jq -r "[.searches[] | select(.search_id == $LATE_SID)][0].result_count // 0")
+				| jq -r "[.searches[] | select(.id == $LATE_SID)][0].result_count // 0")
 			if [ "$LATE_HELD" -gt 0 ]; then
 				# First read by the third instance: discovery has to seed the slot in
 				# full here, because the differential stream has nothing left to send.

--- a/unittests/curl-tests/amuleapi/20-etag-conditional-get.sh
+++ b/unittests/curl-tests/amuleapi/20-etag-conditional-get.sh
@@ -255,7 +255,7 @@ fi
 
 # Free the search to leave the daemon clean. The id comes from the start
 # reply -- there is no unaddressed stop to fall back on.
-SID=$(printf '%s' "$CURL_BODY" | jq -r '.search_id // empty')
+SID=$(printf '%s' "$CURL_BODY" | jq -r '.id // empty')
 if [ -n "$SID" ]; then
 	curl -s -X DELETE -H "Authorization: Bearer $ADMIN_TOKEN" \
 		"$HOST/api/v0/search/$SID" > /dev/null

--- a/unittests/curl-tests/amuleapi/22-sse-diff-emission.sh
+++ b/unittests/curl-tests/amuleapi/22-sse-diff-emission.sh
@@ -272,7 +272,7 @@ SSE_SEARCH=$(curl -s -X POST -H "Authorization: Bearer $ADMIN_TOKEN" \
 	-H "Content-Type: application/json" \
 	-d "{\"query\":\"$SEARCH_QUERY\",\"type\":\"local\"}" \
 	"$HOST/api/v0/search")
-SSE_SID=$(printf '%s' "$SSE_SEARCH" | jq -r '.search_id // empty')
+SSE_SID=$(printf '%s' "$SSE_SEARCH" | jq -r '.id // empty')
 SEARCH_FINISHED=""
 for _ in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 \
          21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40; do
@@ -297,26 +297,26 @@ if [ -n "$SEARCH_FINISHED" ]; then
 	else
 		_fail "search_progress .data.state" "expected 'finished' in $JSON"
 	fi
-	if echo "$JSON" | jq -e '.kind == "local"' >/dev/null 2>&1; then
-		_pass "search_progress .data.kind == 'local'"
+	if echo "$JSON" | jq -e '.type == "local"' >/dev/null 2>&1; then
+		_pass "search_progress .data.type == 'local'"
 	else
-		_fail "search_progress .data.kind" "expected 'local' in $JSON"
+		_fail "search_progress .data.type" "expected 'local' in $JSON"
 	fi
 	if echo "$JSON" | jq -e '.percent | type == "number"' >/dev/null 2>&1; then
 		_pass "search_progress .data.percent is numeric"
 	else
 		_fail "search_progress .data.percent" "missing/non-numeric in $JSON"
 	fi
-	if echo "$JSON" | jq -e '.results | type == "number"' >/dev/null 2>&1; then
-		_pass "search_progress .data.results is numeric"
+	if echo "$JSON" | jq -e '.result_count | type == "number"' >/dev/null 2>&1; then
+		_pass "search_progress .data.result_count is numeric"
 	else
-		_fail "search_progress .data.results" "missing/non-numeric in $JSON"
+		_fail "search_progress .data.result_count" "missing/non-numeric in $JSON"
 	fi
 	# search_result_added is content-dependent — only assert it
 	# fired if the local search produced any hits. On a fully-
 	# disconnected daemon it won't fire, and that's correct.
 	N_ADDED=$(grep -c "^event: search_result_added$" "$SSE_OUT" || true)
-	RESULTS_TOTAL=$(echo "$JSON" | jq '.results')
+	RESULTS_TOTAL=$(echo "$JSON" | jq '.result_count')
 	if [ "$RESULTS_TOTAL" -gt 0 ] 2>/dev/null; then
 		if [ "$N_ADDED" -ge 1 ]; then
 			_pass "search_result_added fired ($N_ADDED times; finished reports $RESULTS_TOTAL results)"
@@ -613,7 +613,7 @@ fi
 # The window this closes: once a search finishes, search_progress stops, so a
 # subscriber holding its rows has no signal for the fields that can still
 # change. Driven here by starting a download of one hit, which flips
-# already_have / status on the matching search result.
+# already_downloaded / status on the matching search result.
 #
 # Last section in the file: it starts a search on the shared daemon.
 #
@@ -621,7 +621,7 @@ fi
 # curl directly, same as every section above.
 SSE_SEARCH_SID=$(curl -s -X POST -H "Authorization: Bearer $ADMIN_TOKEN" \
 	-H "Content-Type: application/json" \
-	-d '{"query":"ubuntu"}' "$HOST/api/v0/search" | jq -r '.search_id // empty')
+	-d '{"query":"ubuntu"}' "$HOST/api/v0/search" | jq -r '.id // empty')
 UPD_HASH=""
 UPD_NAME=""
 UPD_SIZE=""
@@ -631,7 +631,7 @@ if [ -n "$SSE_SEARCH_SID" ]; then
 		sleep 1
 		UPD_ROW=$(curl -s -H "Authorization: Bearer $ADMIN_TOKEN" \
 			"$HOST/api/v0/search/$SSE_SEARCH_SID/results" \
-			| jq -c '[.results[] | select(.already_have == false)] | first // empty')
+			| jq -c '[.results[] | select(.already_downloaded == false)] | first // empty')
 		UPD_HASH=$(printf '%s' "$UPD_ROW" | jq -r '.hash // empty')
 		UPD_NAME=$(printf '%s' "$UPD_ROW" | jq -r '.name // empty' | sed 's/|/_/g')
 		UPD_SIZE=$(printf '%s' "$UPD_ROW" | jq -r '.size // empty')
@@ -652,7 +652,7 @@ if [ -n "$UPD_HASH" ]; then
 		sleep 0.25
 	done
 	# Provoke the change by starting a download of the hit. That flips
-	# already_have / status on the search result deterministically and
+	# already_downloaded / status on the search result deterministically and
 	# locally -- the partfile is created on the spot, no peer needed. A Kad
 	# NOTES lookup moves the other half of the comparator but depends on Kad
 	# actually answering, which would make a missing frame ambiguous between
@@ -687,10 +687,10 @@ if [ -n "$UPD_HASH" ]; then
 			_fail "search_result_updated shape" "$UPD_FRAME"
 		fi
 		# The point of the event: the row now reads as held.
-		if echo "$UPD_FRAME" | jq -e '.already_have == true' >/dev/null 2>&1; then
-			_pass "search_result_updated reports the hit as already_have after the download starts"
+		if echo "$UPD_FRAME" | jq -e '.already_downloaded == true' >/dev/null 2>&1; then
+			_pass "search_result_updated reports the hit as already_downloaded after the download starts"
 		else
-			_fail "search_result_updated .already_have" "expected true in $UPD_FRAME"
+			_fail "search_result_updated .already_downloaded" "expected true in $UPD_FRAME"
 		fi
 	else
 		_fail "search_result_updated" \

--- a/unittests/curl-tests/amuleapi/22-sse-diff-emission.sh
+++ b/unittests/curl-tests/amuleapi/22-sse-diff-emission.sh
@@ -634,7 +634,7 @@ if [ -n "$SSE_SEARCH_SID" ]; then
 			| jq -c '[.results[] | select(.already_downloaded == false)] | first // empty')
 		UPD_HASH=$(printf '%s' "$UPD_ROW" | jq -r '.hash // empty')
 		UPD_NAME=$(printf '%s' "$UPD_ROW" | jq -r '.name // empty' | sed 's/|/_/g')
-		UPD_SIZE=$(printf '%s' "$UPD_ROW" | jq -r '.size // empty')
+		UPD_SIZE=$(printf '%s' "$UPD_ROW" | jq -r '.size_bytes // empty')
 		[ -n "$UPD_HASH" ] && break
 	done
 fi
@@ -681,7 +681,7 @@ if [ -n "$UPD_HASH" ]; then
 		fi
 		# Same writer as _added and as the REST entry, so the whole row is
 		# there rather than a delta a client would have to merge blindly.
-		if echo "$UPD_FRAME" | jq -e 'has("name") and has("size") and has("status") and has("kad_comment_lookup_running")' >/dev/null 2>&1; then
+		if echo "$UPD_FRAME" | jq -e 'has("name") and has("size_bytes") and has("status") and has("kad_comment_lookup_running")' >/dev/null 2>&1; then
 			_pass "search_result_updated carries the full results-entry shape"
 		else
 			_fail "search_result_updated shape" "$UPD_FRAME"

--- a/unittests/curl-tests/amuleapi/26-rfc-followup-endpoints.sh
+++ b/unittests/curl-tests/amuleapi/26-rfc-followup-endpoints.sh
@@ -3,7 +3,7 @@
 # amuleapi 26-rfc-followup-endpoints — endpoints added to align with the RFC PR #132
 # review:
 #
-#   * GET    /status                       — `kad.network: {users,files,nodes}` rollup
+#   * GET    /status                       — `kad.network: {user_count,file_count,node_count}` rollup
 #   * POST   /shared_reload                — rescan share roots
 #   * POST   /servers_update               — refresh server list from server.met URL
 #   * POST   /servers/by-address/<ip>:<port>/connect — address-keyed route
@@ -76,7 +76,7 @@ if echo "$STATUS" | jq -e '.kad.network | type == "object"' >/dev/null 2>&1; the
 else
 	_fail "/status kad.network" "missing: $(echo "$STATUS" | jq -c .kad)"
 fi
-for f in users files nodes; do
+for f in user_count file_count node_count; do
 	if echo "$STATUS" | jq -e ".kad.network.$f | type == \"number\"" >/dev/null 2>&1; then
 		_pass "/status .kad.network.$f is a number"
 	else

--- a/unittests/curl-tests/amuleapi/28-list-pagination-sort.sh
+++ b/unittests/curl-tests/amuleapi/28-list-pagination-sort.sh
@@ -121,7 +121,7 @@ AUTH=(-H "Authorization: Bearer $TOKEN")
 # rather than relying on a removed implicit default.
 SEARCH_SID=$(curl -s -X POST "${AUTH[@]}" -H "Content-Type: application/json" \
 	-d '{"query":"amuleapi-phase28","type":"local"}' "$HOST/api/v0/search" \
-	| jq -r '.search_id // empty')
+	| jq -r '.id // empty')
 [ -n "$SEARCH_SID" ] || _die "POST /search returned no search_id"
 
 # endpoint:array-key pairs. The search results list wraps under "results".
@@ -295,7 +295,7 @@ fi
 _curl "${AUTH[@]}" "$HOST/api/v0/categories?limit=1000000000&sort=index"
 BEFORE_IDX=$(printf '%s' "$CURL_BODY" | jq -c '[.categories[].index]')
 curl -s -X POST "${AUTH[@]}" -H "Content-Type: application/json" \
-	-d '{"name":"phase28-cat","path":"/tmp/28-cat-sweep"}' \
+	-d '{"name":"phase28-cat","save_path":"/tmp/28-cat-sweep"}' \
 	"$HOST/api/v0/categories" > /dev/null 2>&1
 _curl "${AUTH[@]}" "$HOST/api/v0/categories?limit=1000000000&sort=index"
 _assert_json_ge '.total' 2 '/categories seeded a row to step past'

--- a/unittests/curl-tests/amuleapi/38-chat.sh
+++ b/unittests/curl-tests/amuleapi/38-chat.sh
@@ -168,11 +168,11 @@ _assert_json_eq '.client_address'            "$PEER" 'messages echo the conversa
 _assert_json_eq '.messages | type' array   'messages is an array'
 _assert_json_eq '.messages[0].direction' out 'first message is direction=out'
 
-# Every message object is exactly {id, direction, text, timestamp}.
+# Every message object is exactly {id, direction, text, sent_at}.
 WRONG=$(printf '%s' "$CURL_BODY" | jq \
-	'[.messages[] | select((keys | sort) != ["direction","id","text","timestamp"])] | length')
+	'[.messages[] | select((keys | sort) != ["direction","id","sent_at","text"])] | length')
 if [ "$WRONG" = "0" ]; then
-	_pass "every message object is {id, direction, text, timestamp}"
+	_pass "every message object is {id, direction, text, sent_at}"
 else
 	_fail "message object shape" "$WRONG messages carry unexpected keys"
 fi

--- a/unittests/curl-tests/amuleapi/38-chat.sh
+++ b/unittests/curl-tests/amuleapi/38-chat.sh
@@ -8,9 +8,9 @@
 #
 # Wire contract:
 #   GET    /chats                   → list envelope of conversations
-#   GET    /chats/{peer}/messages   → { peer, messages[], total, last_msg_id }
-#   POST   /chats/{peer}/messages   → 202 + the created message
-#   DELETE /chats/{peer}            → 204, no body
+#   GET    /chats/{client_address}/messages   → { peer, messages[], total, last_message_id }
+#   POST   /chats/{client_address}/messages   → 202 + the created message
+#   DELETE /chats/{client_address}            → 204, no body
 #   POST   /friends/{ecid}/messages → 202 (reaches an OFFLINE friend)
 #   POST   /clients/{ecid}/messages → 202
 #
@@ -126,12 +126,12 @@ _assert_json_eq '.chats | type' array '/chats .chats is array'
 # doubles as "start a chat with this address".
 _curl -X POST -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
 	-d '{"text":"curl-test hello"}' "$HOST/api/v0/chats/$PEER/messages"
-_assert_status 202 "POST /chats/{peer}/messages → 202 Accepted"
+_assert_status 202 "POST /chats/{client_address}/messages → 202 Accepted"
 # The created message stays in the body: no per-message GET defines a shape
 # for it, so the id and the timestamp the store assigned are only readable
 # here. `ok` is gone; the 202 already carried it.
 _assert_json_eq '. | has("ok")' false 'send response has no constant ok field'
-_assert_json_eq '.peer'                "$PEER" 'send echoes the conversation key'
+_assert_json_eq '.client_address'                "$PEER" 'send echoes the conversation key'
 _assert_json_eq '.message.direction'   out     'sent message is direction=out'
 _assert_json_eq '.message.text'        "curl-test hello" 'send echoes the text'
 FIRST_ID=$(printf '%s' "$CURL_BODY" | jq -r '.message.id')
@@ -142,14 +142,14 @@ sleep 3
 # --- 3. The conversation is now on the list. ----------------------
 _curl -H "Authorization: Bearer $TOKEN" "$HOST/api/v0/chats"
 _assert_status 200 "GET /chats → 200 after send"
-FOUND=$(printf '%s' "$CURL_BODY" | jq --arg p "$PEER" '[.chats[] | select(.peer == $p)] | length')
+FOUND=$(printf '%s' "$CURL_BODY" | jq --arg p "$PEER" '[.chats[] | select(.client_address == $p)] | length')
 if [ "$FOUND" = "1" ]; then
 	_pass "/chats lists the new conversation"
 else
 	_fail "/chats conversation presence" "expected exactly 1 row for $PEER, got $FOUND"
 fi
 # Narrow the body to just this conversation's row for the field checks.
-ROW=$(printf '%s' "$CURL_BODY" | jq --arg p "$PEER" -c '.chats[] | select(.peer == $p)')
+ROW=$(printf '%s' "$CURL_BODY" | jq --arg p "$PEER" -c '.chats[] | select(.client_address == $p)')
 printf '%s' "$ROW" > "$CURL_BODY_FILE"; CURL_BODY=$ROW
 _assert_json_eq '.ip'                 "$PEER_IP"   'row carries the split ip'
 _assert_json_eq '.port'               "$PEER_PORT" 'row carries the split port'
@@ -163,8 +163,8 @@ _assert_json_eq '.name' "IP: $PEER_IP Port: $PEER_PORT" 'name falls back to the 
 
 # --- 4. Reading the transcript. -----------------------------------
 _curl -H "Authorization: Bearer $TOKEN" "$HOST/api/v0/chats/$PEER/messages"
-_assert_status 200 "GET /chats/{peer}/messages → 200"
-_assert_json_eq '.peer'            "$PEER" 'messages echo the conversation key'
+_assert_status 200 "GET /chats/{client_address}/messages → 200"
+_assert_json_eq '.client_address'            "$PEER" 'messages echo the conversation key'
 _assert_json_eq '.messages | type' array   'messages is an array'
 _assert_json_eq '.messages[0].direction' out 'first message is direction=out'
 
@@ -177,23 +177,23 @@ else
 	_fail "message object shape" "$WRONG messages carry unexpected keys"
 fi
 
-# --- 5. since_id is a safe cursor. --------------------------------
+# --- 5. since_message_id is a safe cursor. --------------------------------
 #
 # ids are monotonic per daemon process, so a client polling with the
 # highest id it holds must never see a duplicate and never skip one.
 _curl -H "Authorization: Bearer $TOKEN" \
-	"$HOST/api/v0/chats/$PEER/messages?since_id=$FIRST_ID"
-_assert_status 200 "GET messages?since_id → 200"
-_assert_json_eq '.messages | length' 0 'since_id at the head returns nothing new'
+	"$HOST/api/v0/chats/$PEER/messages?since_message_id=$FIRST_ID"
+_assert_status 200 "GET messages?since_message_id → 200"
+_assert_json_eq '.messages | length' 0 'since_message_id at the head returns nothing new'
 
 _curl -X POST -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
 	-d '{"text":"second message"}' "$HOST/api/v0/chats/$PEER/messages"
 _assert_status 202 "POST second message → 202"
 sleep 3
 _curl -H "Authorization: Bearer $TOKEN" \
-	"$HOST/api/v0/chats/$PEER/messages?since_id=$FIRST_ID"
-_assert_json_eq '.messages | length'   1                'since_id returns exactly the new message'
-_assert_json_eq '.messages[0].text'    "second message" 'since_id returns the right message'
+	"$HOST/api/v0/chats/$PEER/messages?since_message_id=$FIRST_ID"
+_assert_json_eq '.messages | length'   1                'since_message_id returns exactly the new message'
+_assert_json_eq '.messages[0].text'    "second message" 'since_message_id returns the right message'
 
 # --- 5b. `tail`, not `limit`. --------------------------------------
 #
@@ -243,7 +243,7 @@ _assert_status 404 "POST to an unknown friend ECID → 404"
 _curl -X PUT -H "Authorization: Bearer $TOKEN" "$HOST/api/v0/chats"
 _assert_status 405 "PUT /chats → 405"
 _curl -X PATCH -H "Authorization: Bearer $TOKEN" "$HOST/api/v0/chats/$PEER"
-_assert_status 405 "PATCH /chats/{peer} → 405"
+_assert_status 405 "PATCH /chats/{client_address} → 405"
 
 # --- 8. Guests read but do not write. -----------------------------
 GUEST_TOKEN=$(curl -s -X POST -H "Content-Type: application/json" \
@@ -264,11 +264,11 @@ fi
 # --- 9. Closing is global and actually removes it. ----------------
 _curl -X DELETE -H "Authorization: Bearer $TOKEN" "$HOST/api/v0/chats/$PEER"
 # 204, no body: `peer` came from the URL and `ok` restated the status code.
-_assert_status 204 "DELETE /chats/{peer} → 204"
+_assert_status 204 "DELETE /chats/{client_address} → 204"
 _assert_body_empty 'close sends no body'
 sleep 3
 _curl -H "Authorization: Bearer $TOKEN" "$HOST/api/v0/chats"
-GONE=$(printf '%s' "$CURL_BODY" | jq --arg p "$PEER" '[.chats[] | select(.peer == $p)] | length')
+GONE=$(printf '%s' "$CURL_BODY" | jq --arg p "$PEER" '[.chats[] | select(.client_address == $p)] | length')
 if [ "$GONE" = "0" ]; then
 	_pass "closed conversation is gone from /chats"
 else

--- a/unittests/tests/EventDiffTest.cpp
+++ b/unittests/tests/EventDiffTest.cpp
@@ -652,7 +652,7 @@ TEST(EventDiff, SearchResultUpdatedFiresWhenADownloadStateChanges)
 	// ever tell a subscriber this.
 	state.MutateSearch(42, [](std::map<std::uint32_t, SearchResult> &cache) {
 		cache[7].status = "downloaded";
-		cache[7].already_have = true;
+		cache[7].already_downloaded = true;
 	});
 	EmitDiffsAndUpdate(bus, prev, state);
 
@@ -667,7 +667,7 @@ TEST(EventDiff, SearchResultUpdatedFiresWhenADownloadStateChanges)
 	// Same shape as _added, search_id first, carrying the new values.
 	ASSERT_TRUE(payload.compare(0, 15, "{\"search_id\":42") == 0);
 	ASSERT_TRUE(payload.find("\"status\":\"downloaded\"") != std::string::npos);
-	ASSERT_TRUE(payload.find("\"already_have\":true") != std::string::npos);
+	ASSERT_TRUE(payload.find("\"already_downloaded\":true") != std::string::npos);
 }
 
 TEST(EventDiff, SearchResultUpdatedFiresWhenKadNotesLand)

--- a/unittests/tests/EventDiffTest.cpp
+++ b/unittests/tests/EventDiffTest.cpp
@@ -377,8 +377,8 @@ TEST(EventDiff, StatusEventFiresWhenTheKadNetworkFiguresBecomeUnknown)
 	}
 
 	ASSERT_TRUE(!payload.empty());
-	ASSERT_TRUE(payload.find("\"nodes\":null") != std::string::npos);
-	ASSERT_TRUE(payload.find("\"nodes\":499") == std::string::npos);
+	ASSERT_TRUE(payload.find("\"node_count\":null") != std::string::npos);
+	ASSERT_TRUE(payload.find("\"node_count\":499") == std::string::npos);
 }
 
 // A tick where only the overhead moved still has to fire: the field is in the
@@ -409,8 +409,8 @@ TEST(EventDiff, StatusEventCarriesBothConnectedSince)
 
 	const std::string payload = EmitStatusAndGetPayload(s);
 
-	ASSERT_TRUE(payload.find("\"connected_since\":1751000000") != std::string::npos);
-	ASSERT_TRUE(payload.find("\"connected_since\":1751000042") != std::string::npos);
+	ASSERT_TRUE(payload.find("\"connected_since_at\":1751000000") != std::string::npos);
+	ASSERT_TRUE(payload.find("\"connected_since_at\":1751000042") != std::string::npos);
 }
 
 // A reconnect can leave every other field identical -- same server, same id,
@@ -424,7 +424,7 @@ TEST(EventDiff, StatusEventFiresWhenOnlyConnectedSinceMoved)
 	const std::string payload = EmitStatusAndGetPayload(s);
 
 	ASSERT_TRUE(!payload.empty());
-	ASSERT_TRUE(payload.find("\"connected_since\":1751000000") != std::string::npos);
+	ASSERT_TRUE(payload.find("\"connected_since_at\":1751000000") != std::string::npos);
 }
 
 TEST(EventDiff, ClientAddedCarriesUploadFileName)

--- a/unittests/tests/RefresherTest.cpp
+++ b/unittests/tests/RefresherTest.cpp
@@ -2614,7 +2614,7 @@ TEST(Refresher, SearchUnionSecondPollKeepsFieldsTheDiffOmits)
 	ASSERT_EQUALS(std::string("cool.movie.mkv"), it->second.name);
 	ASSERT_EQUALS(static_cast<std::uint64_t>(123), it->second.size);
 	ASSERT_EQUALS(std::string("queued"), it->second.status);
-	ASSERT_TRUE(it->second.already_have);
+	ASSERT_TRUE(it->second.already_downloaded);
 	ASSERT_EQUALS(std::string("video"), it->second.type);
 }
 
@@ -2634,7 +2634,7 @@ TEST(Refresher, SearchUnionAppliesAStatusChangeOnAFinishedSearch)
 	sf.AddTag(CECTag(EC_TAG_PARTFILE_STATUS, static_cast<std::uint32_t>(0))); // NEW
 	first.AddTag(sf);
 	ApplySearchUnion(&first, slots, owner);
-	ASSERT_TRUE(!slots[kSid].results.find(70)->second.already_have);
+	ASSERT_TRUE(!slots[kSid].results.find(70)->second.already_downloaded);
 
 	CECPacket second(EC_OP_SEARCH_RESULTS);
 	CECTag d(EC_TAG_SEARCHFILE, static_cast<std::uint32_t>(70));
@@ -2644,7 +2644,7 @@ TEST(Refresher, SearchUnionAppliesAStatusChangeOnAFinishedSearch)
 
 	const auto &r = slots[kSid].results.find(70)->second;
 	ASSERT_EQUALS(std::string("downloaded"), r.status);
-	ASSERT_TRUE(r.already_have);
+	ASSERT_TRUE(r.already_downloaded);
 }
 
 TEST(Refresher, SearchUnionQuietPollRemovesNothing)

--- a/unittests/tests/StateTest.cpp
+++ b/unittests/tests/StateTest.cpp
@@ -934,7 +934,7 @@ TEST(State, SearchResultsRoundtripAndOrderByEcid)
 		b.name = "first-by-ecid.iso";
 		b.size = 7000;
 		b.complete_source_count = 5;
-		b.already_have = true;
+		b.already_downloaded = true;
 		cache.emplace(b.ecid, b);
 	});
 
@@ -943,8 +943,8 @@ TEST(State, SearchResultsRoundtripAndOrderByEcid)
 	ASSERT_EQUALS(static_cast<size_t>(2), out.size());
 	ASSERT_EQUALS(std::string("first-by-ecid.iso"), out[0].name);
 	ASSERT_EQUALS(std::string("ascii-name.iso"), out[1].name);
-	ASSERT_TRUE(out[0].already_have);
-	ASSERT_FALSE(out[1].already_have);
+	ASSERT_TRUE(out[0].already_downloaded);
+	ASSERT_FALSE(out[1].already_downloaded);
 	// The query rides on the slot, so a results read can report what was
 	// searched for without a second lookup.
 	ASSERT_EQUALS(std::string("ubuntu"), s.SearchQuery(sid));


### PR DESCRIPTION
Batch B of the remaining #1189 work: §1.6 search, §1.7 friends/chats, §1.8 status/Kad/stats, one commit each.

## §1.6 search

`searches[].search_id` becomes `id`. The object was prefixing its own key with its own type -- the same rule that gave the client object a bare `ecid`. References from **outside** keep the prefix: the `search_result_added` / `search_progress` SSE payloads and the results envelope point *into* this object rather than being it.

`kind` becomes `type` on the row and on `progress`, matching what `POST /search` has always called the same concept in its body (R6).

On results: `size` -> `size_bytes`; `already_have` -> `already_downloaded`, since "have" reads as the wire verb while "downloaded" is the state; `type` -> `file_type`, aligning with `POST /search`'s own filter field and with the key `/shared/{hash}` derives from the same helper -- and next to a `media` object a bare `type` reads as a MIME type.

`children` becomes **`alternate_names`**. There is no hierarchy: these are same-hash, same-size hits advertised under different filenames. Each entry's `hash` was by construction the parent's, so it is dropped.

Request body: `min_size` / `max_size` -> `min_size_bytes` / `max_size_bytes`, and `min_avail` -> `min_source_count` -- the desktop's "availability" row is a minimum source count, and `avail` is not a word.

The `search_progress` frame called its integer `results`, while `results` is an array everywhere else and `GET /search` already calls the same number `result_count`.

## §1.7 friends and chats

The chat resource called the remote party a **`peer`** -- in the object key, the path segment, and two SSE payloads. That was the third word for what the API calls a client, and **the last contract-level use of it anywhere** (R12).

It becomes `client_address`, because that is what it is: the address form, which a chat needs since it can address a client that is offline and has no ECID. `client_ecid` sits beside it for the online case. Six key sites plus the `{peer}` path segment on three routes.

`last_msg_id` -> `last_message_id` (the same object spells the word out three times over and abbreviated only the id), with the matching query parameter `since_id` -> `since_message_id`. `messages[].timestamp` -> `sent_at` (R3).

R10 on the remaining sentinels: a friend's `ip` is `null` rather than `""`, and `last_message_at` is `null` rather than `0` for a session with no messages, where `0` reads as 1970. The `chat_message` SSE payload still emitted the `0` ECID sentinel the REST rows lost in #1199, and now matches.

## §1.8 status, Kad and stats

`network.users` / `.files` / `.nodes` -> `user_count` / `file_count` / `node_count` on both `/status` and `/kad` (R5/R6): `network` names the scope, not the thing counted, so the parent-carries-it carve-out does not apply, and `/servers` already reports the same two quantities under those names.

`indexed.load` -> `indexed.load_percent` (R2). `buddy.status` -> `buddy.state`, since every other connection enum on the surface is `state`. `connected_since` -> `connected_since_at` (R3).

`/stats/graphs` points carried both `t` (ISO-8601) and `t_unix`; they collapse to a single **`at`** in unix seconds. Formatting is a client concern, and the twin cost a key plus its value on every point of an array that runs to `max_points`.

## Two items inverted by the R2 decision

The issue asks for the graph `unit` token to become `"bps"`, and for the media bitrate to be `_kbits`, both on the grounds that `_bps` is this API's word for bytes per second. Since #1197 spells rates out instead, `unit` already reads `bytes_per_second` and stays as it is. Recorded in the commits so the divergence is not mistaken for an oversight.

## Three near-misses worth recording

Mechanical renames on a surface this size fail in ways a build does not catch, so each of these was found by reading the diff rather than by the compiler:

- A `since_id` regex hit the **SSE Last-Event-ID resync cursor**, an unrelated concept in the same file. Reverted to the chat query parameter alone.
- A `nodes` doc rename hit the **`/stats/tree` array envelope**, which keeps its name -- only the Kad node *count* moved. `children` on that same tree also stays, being a real hierarchy.
- A string substitution injected a comment *inside* a C++ string literal in the chat SSE builder. That one the build did catch.

## Verification

Against a live amuled on macOS:

- Unit tests: **43/43**.
- `clang-format` 18: diff clean, whole tree re-checked (634 files, 0 violations).
- `clang-tidy` Tier-1 and Tier-2 on the diff: 0 findings, 0 compiler errors.
- `scripts/check-potfiles.sh`: clean.
- Every JSON block in `REFERENCE.md` and `EVENTS.md` re-parsed after editing.
- Doc anchors verified: the two unresolved ones are identical to master, so nothing broke.
- Full curl-smoke suite: **40/40 phases, 1663 assertions, zero failures**.

The first run of that suite failed 15 assertions, and two of them were real code gaps rather than stale tests -- worth recording, since both are the kind a build cannot catch:

- **The SSE `/status` payload was not renamed alongside REST** (`connected_since`, the network counts). That breaks the key-parity promise `status_changed` makes with `GET /status`, and the parity test is what caught it.
- **The ed2k network object is a separate writer** from `WriteKadNetworkObject`. The issue notes that one helper serves `/status` and `/kad` so the Kad triplet is a single edit -- true for Kad, but ed2k's `users` / `files` are written inline and were left behind.

One of the 15 was not from this batch at all: `28-list-pagination-sort.sh` seeds a category with `path`, which **#1201** renamed to `save_path`. It passed in that PR's own run only because a leftover `phase28-cat` from an earlier run satisfied the assertion; deleting that leftover during cleanup is what exposed it. Fixed here. The lesson generalises: an assertion satisfied by residue from a previous run is not evidence.

#1189 stays open after this: §1.9 preferences (Batch C), §1.10-1.12 with the §2 query parameters and the R12 prose sweep (Batch D), then the `v1` flip.
