### PR TITLE
feat(amuleapi): surface the two part indices the source bar needs

### DIFF
--- a/docs/api/REFERENCE.md
+++ b/docs/api/REFERENCE.md
@@ -362,6 +362,8 @@ The rule now reaches the whole surface rather than just the download and shared 
 
 Five keys stay omitted, because for them absence really is the meaning: `started_at` and `result_count` on [`GET /search`](#get-apiv0search) as described above, `key` on a statistics node (absent from a daemon too old to send it), `ratio` on the statistics ratio node (absent when the daemon reported neither component), and `parts` under [`?include_parts=true`](#get-apiv0downloadshashclients--get-apiv0sharedhashclients) -- there the caller opted in, so the key's absence answers a question they did not ask.
 
+Opting out is not one of them. `parts`, `next_requested_part_index` and `downloading_part_index` are all absent from a client row unless `?include_parts=true` was asked for, but that absence is a property of the request, not a fact about the client, so it is not what the null-versus-absent rule above is about. Under the flag the two index keys are *always* present — `null`, never absent, wherever the index does not apply — which is why only `parts` is in the list above.
+
 ### Priority levels
 
 `priority` appears on four resources and accepts three different sets. The differences are deliberate rather than drift, and they reflect what the daemon can actually store:
@@ -1003,19 +1005,23 @@ curl -s -H "Authorization: Bearer $TOKEN" \
 
 The clients of one file: sources serving it to us, clients pulling it from us, and — on the downloads side — A4AF sources parked on another file. Replaces the client-side join of the global `/clients` list against `download_file_hash` / `upload_file_hash`, which could never produce the A4AF rows.
 
-Each entry is the [`/clients`](#get-apiv0clients) list object plus three keys:
+Each entry is the [`/clients`](#get-apiv0clients) list object plus five keys:
 
 | Key | Meaning |
 |---|---|
 | `role` | which direction this row moves the file: `"downloading_from"` — we pull the file from it (including queued); `"uploading_to"` — it pulls the file from us; `"both"`; `"none"` |
 | `a4af` | `true` for a source parked on another file — the desktop's A4AF row |
 | `parts` | the client's per-part bitmap, **only** when `?include_parts=true` |
+| `next_requested_part_index` | index of the chunk queued next from this client, or `null`; **only** when `?include_parts=true` |
+| `downloading_part_index` | index of the chunk currently in flight from this client, or `null`; **only** when `?include_parts=true` |
 
 `role` and `a4af` are orthogonal: a pure A4AF row is `role: "none"`, `a4af: true`, but a client can be parked on another file *and* be pulling this one from us (`role: "uploading_to"`, `a4af: true`).
 
 `parts` is opt-in because it is one boolean per chunk per client — a multi-TiB file is 100k+ entries each. It is exactly `parts_total_count` entries, and it describes the file this row is about: the download bitmap for a `"downloading_from"` row, the upload bitmap for an `"uploading_to"` one. A client the core reports as holding every part comes back all-`true`. A pure A4AF row has no bitmap for this file and omits the key. **`parts` never appears in SSE payloads.**
 
-The file's own three-state part view is on [`GET /downloads/{hash}`](#get-apiv0downloadshash); combine it with this bitmap to render the desktop's per-source bar.
+`next_requested_part_index` and `downloading_part_index` are the two extra states the desktop paints on top of that bitmap — the chunk in flight in amber, the one queued behind it in pale yellow — turning a three-state bar into the desktop's five-state one. Both are `0`-based indices into `parts`, and both ride `include_parts` for the same reason: an index is meaningless without the bitmap it indexes, and a caller that did not ask for `parts` does not know the file's `parts_total_count`. Under the flag both keys are always present, `null` rather than omitted whenever the index does not apply, so one query returns one row shape. `null` covers every such case: the client never reported the value, it reported the `0xffff` "nothing pending" sentinel, the index does not address a chunk of this file, the row is not a source for this file at all (`role: "uploading_to"` or a pure A4AF row, whose indices belong to whatever else that client is downloading), or the row carries no `parts` bitmap for the index to point into. `downloading_part_index` carries one further rule: it is `null` unless the client's `download_state` is `"downloading"`, because the daemon reports a stale `0` for a source that is merely connected or queued — treat a number here as "this chunk is arriving right now", which is what makes it safe to paint, and which is why it is named for the present tense rather than for a previous part. Note that `0` is a real chunk index, never a stand-in for unknown — see [`Unknown values`](#unknown-values). Neither key ever appears in SSE payloads.
+
+The file's own three-state part view (`complete` / `incomplete` / `missing`) is on [`GET /downloads/{hash}`](#get-apiv0downloadshash); combine it with this bitmap and the two indices above to render the desktop's five-state per-source bar.
 
 Both routes accept `limit` / `offset` / `sort` / `order` exactly as `/clients` does. A partfile with at least one completed chunk is both a download and a shared file, and then **both routes return the same body** — they differ only in which collection the hash must belong to, which is what the `404` checks.
 

--- a/src/webapi/Api.cpp
+++ b/src/webapi/Api.cpp
@@ -43,6 +43,7 @@
 #include "Refresher.h"     // ParseStatsTreeFromPacket / ParseGraphsFromPacket / ApplySearchFull
 #include "StaticFs.h"      // IsDir, ResolveWithinRoot
 #include "SharedContent.h" // /shared/{hash}/content: path resolution, Range, disposition
+#include "PartIndex.h"     // UsablePartIndex / UsableLastDownloadingPart, unit-tested standalone
 #include <cstring>
 #include <map>
 
@@ -4230,6 +4231,13 @@ struct FileClientRow
 	bool a4af = false;
 	std::vector<bool> parts;
 	bool has_parts = false;
+	// Whether each index actually addresses a chunk of THIS file that this
+	// row also carries a bitmap for. Resolved in the handler, which is the
+	// only place that knows part_count; false here means the key goes out as
+	// null. Not a copy of `include_parts` -- that is the same on every row,
+	// so it is passed to WriteFileClientRow rather than stored per row.
+	bool next_requested_part_known = false;
+	bool last_downloading_part_known = false;
 };
 
 // Sort keys, derived from the /clients set rather than restated, so the two
@@ -4261,7 +4269,7 @@ const ListComparators<FileClientRow> &FileClientComparators()
 	return kComps;
 }
 
-void WriteFileClientRow(CJsonWriter &w, const FileClientRow &row)
+void WriteFileClientRow(CJsonWriter &w, const FileClientRow &row, bool include_parts)
 {
 	w.BeginObject();
 	WriteClientBaseFields(w, row.client);
@@ -4284,6 +4292,31 @@ void WriteFileClientRow(CJsonWriter &w, const FileClientRow &row)
 			w.ValueBool(b);
 		}
 		w.EndArray();
+	}
+	// The two chunks the desktop's source bar paints on top of the bitmap:
+	// the one in flight and the one queued behind it
+	// (GenericClientListCtrl.cpp: crPending and crNextPending). They live on
+	// the row rather than in WriteClientBaseFields for the same reason
+	// `parts` does -- they describe a peer's relation to ONE file, not the
+	// peer -- which also keeps them out of the shared SSE client payload,
+	// where a value that moves every tick would be noise no listener renders.
+	//
+	// Gated on include_parts because an index is meaningless without the
+	// bitmap it indexes: a caller that did not ask for `parts` does not know
+	// the file's part count and has no bar to paint the stripe on. Under the
+	// flag both keys are always present -- null, never omitted, on a row
+	// where the index does not apply -- so one query yields one row shape.
+	// Unlike `parts`, whose absence is the only way to say "no bitmap of the
+	// right length exists", these have a null to say it with.
+	if (include_parts) {
+		WriteIntOrNull(w,
+			"next_requested_part_index",
+			row.next_requested_part_known,
+			static_cast<int64_t>(row.client.next_requested_part));
+		WriteIntOrNull(w,
+			"downloading_part_index",
+			row.last_downloading_part_known,
+			static_cast<int64_t>(row.client.last_downloading_part));
 	}
 	w.EndObject();
 }
@@ -4386,6 +4419,32 @@ CHttpServer::Response CApiDispatcher::HandleFileClients(
 					client.has_part_status,
 					part_count,
 					row.parts);
+				// The two part indices are indices into that download
+				// map, so they address this file only on a source row.
+				// On a pure "peer" or A4AF row they belong to whatever
+				// else the peer is pulling and must not be relayed as
+				// though they described this one -- left false, they go
+				// out as null.
+				//
+				// `row.has_parts` is part of the test, not just the
+				// role: ResolvePartBitmap declines a source that has
+				// sent no part status yet, and one whose decoded bitmap
+				// cannot cover the file. Either way the row ships no
+				// `parts`, and a stripe coordinate with no bar to paint
+				// it on is the exact thing the gating exists to prevent.
+				// Ordering matters -- both reads happen after the
+				// ResolvePartBitmap call above has set it.
+				row.next_requested_part_known =
+					row.has_parts &&
+					webapi::UsablePartIndex(client.has_next_requested_part,
+						client.next_requested_part,
+						part_count);
+				row.last_downloading_part_known =
+					row.has_parts &&
+					webapi::UsableLastDownloadingPart(client.download_state,
+						client.has_last_downloading_part,
+						client.last_downloading_part,
+						part_count);
 			} else if (is_peer) {
 				row.has_parts = ResolvePartBitmap(client.upload_part_status,
 					client.upload_part_status_all,
@@ -4398,7 +4457,15 @@ CHttpServer::Response CApiDispatcher::HandleFileClients(
 		rows.push_back(std::move(row));
 	}
 
-	return ListResponse(m_state, "clients", rows, WriteFileClientRow, params, FileClientComparators());
+	return ListResponse(
+		m_state,
+		"clients",
+		rows,
+		[include_parts](CJsonWriter &w, const FileClientRow &row) {
+			WriteFileClientRow(w, row, include_parts);
+		},
+		params,
+		FileClientComparators());
 }
 
 CHttpServer::Response CApiDispatcher::HandleClients(const CHttpServer::Request &req)
@@ -4443,7 +4510,7 @@ CHttpServer::Response CApiDispatcher::HandleClients(const CHttpServer::Request &
 	if (!activity.empty()) {
 		auto matches = [&](const webapi::ClientSnapshot &c) {
 			const bool up = (c.upload_state == "uploading");
-			const bool down = (c.download_state == "downloading");
+			const bool down = (c.download_state == webapi::kDownloadStateDownloading);
 			if (activity == "uploading")
 				return up;
 			if (activity == "downloading")

--- a/src/webapi/PartIndex.h
+++ b/src/webapi/PartIndex.h
@@ -1,0 +1,93 @@
+//
+// This file is part of the aMule Project.
+//
+// Copyright (c) 2003-2026 aMule Team ( https://amule-org.github.io )
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+
+// Whether a part index amuled reported about a peer may be relayed as an
+// index into a given file's part bitmap.
+//
+// Both predicates are pure and their inputs are all reachable from a crafted
+// EC frame, but the values that make them interesting -- the 0xffff sentinel,
+// the boundary at part_count, a file with more than 65535 parts, a source
+// whose state flips to "downloading" -- are not values a live peer hands out
+// on request. So they live here, in a header that pulls in nothing but <string>
+// and <cstdint>: no wx, no Boost.Beast, no EC. Same rationale as
+// SharedContent.h and CompleteSourcesThrottle.h, and the same reason
+// PartIndexTest can drive every branch without a daemon.
+//
+// The serializing half (which key gets written, and as what) stays in Api.cpp.
+
+#ifndef AMULE_WEBAPI_PARTINDEX_H
+#define AMULE_WEBAPI_PARTINDEX_H
+
+#include <cstdint>
+#include <string>
+
+namespace webapi
+{
+
+//! The core answers 0xffff for "no block pending" (DownloadClient.cpp:
+//! `GetNextRequestedPart`), and the desktop substitutes it for the downloading
+//! part on a source that is not transferring (GenericClientListCtrl.cpp). It is
+//! a sentinel, not a part number, and it has to be tested for by name rather
+//! than left to fall out of a bounds check -- see UsablePartIndex.
+constexpr std::uint16_t kNoPartPendingSentinel = 0xffffu;
+
+//! The one `download_state` value that means bytes are moving from the peer to
+//! us right now (Refresher.cpp: ClientDownloadStateName, mapping
+//! DS_DOWNLOADING). Two unrelated places test for it -- the
+//! `?activity=downloading` filter in Api.cpp and UsableLastDownloadingPart
+//! below -- and they have to agree, so the spelling lives here once.
+constexpr const char *kDownloadStateDownloading = "downloading";
+
+//! True when a reported part index can actually address a chunk of a file with
+//! `part_count` chunks. Three things make it unusable: the peer never reported
+//! one (`present` false), kNoPartPendingSentinel, and any index left over from
+//! a peer whose request file is not this one. Relayed raw, either of the last
+//! two would draw a stripe on a chunk nothing is happening to.
+//!
+//! The sentinel is tested by name rather than left to fall out of the bounds
+//! check, which only filters it while `part_count <= 0xffff`. Above that -- a
+//! file larger than 65535 * kPartSizeBytes, about 637 GB -- 65535 is a real
+//! chunk, so the bound alone would pass the sentinel through as an index on
+//! exactly the files a source bar is most useful on. Part 65535 of such a file
+//! is then unreportable, which is what the desktop already accepts.
+inline bool UsablePartIndex(bool present, std::uint16_t part, std::uint64_t part_count)
+{
+	return present && part != kNoPartPendingSentinel && static_cast<std::uint64_t>(part) < part_count;
+}
+
+//! The same test for `last_downloading_part`, plus the download-state guard the
+//! bounds check cannot supply: the core initialises m_lastDownloadingPart to 0
+//! (BaseClient.cpp: CUpDownClient::Init) and ECSpecialCoreTags.cpp ships it with
+//! AddTag rather than AddDiffTag, so it arrives on every frame whether or not
+//! the peer is transferring. A connected-but-queued source therefore reports a
+//! perfectly in-range 0, indistinguishable from one actually feeding chunk 0 --
+//! and since most sources in a list are queued rather than transferring, a
+//! renderer would mark chunk 0 as "downloading now" on nearly every row. The
+//! desktop guards it the same way (GenericClientListCtrl.cpp: lastDownloadingPart
+//! is forced to 0xffff unless GetDownloadState() == DS_DOWNLOADING); doing it in
+//! the serializer instead means every API client gets it right once rather than
+//! each rediscovering the rule.
+//!
+//! Takes the state string and the two scalars rather than a ClientSnapshot, so
+//! this header needs neither State.h nor anything State.h reaches.
+//!
+//! Deliberately NOT applied to next_requested_part, exactly as the desktop does
+//! not apply it either: 0xffff is that field's own "no block pending" answer, so
+//! an idle peer already falls out through UsablePartIndex.
+inline bool UsableLastDownloadingPart(
+	const std::string &download_state, bool present, std::uint16_t part, std::uint64_t part_count)
+{
+	return download_state == kDownloadStateDownloading && UsablePartIndex(present, part, part_count);
+}
+
+} // namespace webapi
+
+#endif // AMULE_WEBAPI_PARTINDEX_H

--- a/src/webapi/State.h
+++ b/src/webapi/State.h
@@ -36,6 +36,13 @@
 #include <unordered_map>
 #include <vector>
 
+// kNoPartPendingSentinel: the same shape of sentinel as
+// kRemoteQueueFullSentinel below, for the two part indices on ClientSnapshot.
+// It lives in that header rather than here because the predicates that test it
+// are unit-tested standalone, and a constant defined twice is a constant that
+// drifts.
+#include "PartIndex.h"
+
 // Cached snapshot of amuled state. One instance lives inside
 // CamuleapiApp for the whole process; the refresher (wxApp thread)
 // writes; the HTTP server (Boost.Asio thread) reads.
@@ -468,12 +475,20 @@ struct ClientSnapshot
 	// Indices into the download bitmap; absent from the wire means unchanged,
 	// so the has_ flags distinguish "never reported" from "reported as 0".
 	//
-	// Decoded but not yet surfaced: no endpoint serializes these and no
-	// comparator sorts on them. Kept because the decode is already paid for
-	// on every INC_UPDATE tick and they are the natural companions of the
-	// bitmaps above -- a client wanting to show which chunk a peer is
-	// feeding needs them. Delete them rather than leave them rotting if
-	// that never materialises.
+	// Both are indices into the *download* bitmap of the peer's request
+	// file (ECSpecialCoreTags.cpp emits them inside the `pfile` guard, next
+	// to EC_TAG_CLIENT_PART_STATUS), so they address one file, not the peer
+	// as a whole. Surfaced by the per-file client rows only --
+	// `next_requested_part_index` / `downloading_part_index` on
+	// GET /downloads/{hash}/clients under `include_parts` -- which is why
+	// no comparator sorts on them and no SSE payload carries them. Values
+	// are relayed raw and validated by the serializer rather than here,
+	// because only the endpoint knows the file: kNoPartPendingSentinel is
+	// the core's "nothing pending" answer, any index past the file's part
+	// count is unusable, the row needs the bitmap the index indexes, and
+	// last_downloading_part is a stale 0 (BaseClient.cpp inits it so, and
+	// the tag is sent unconditionally) unless download_state is
+	// "downloading" -- all of which come out as null.
 	std::uint16_t next_requested_part = 0;
 	std::uint16_t last_downloading_part = 0;
 	bool has_next_requested_part = false;

--- a/unittests/curl-tests/amuleapi/04-read-downloads-shared.sh
+++ b/unittests/curl-tests/amuleapi/04-read-downloads-shared.sh
@@ -291,6 +291,11 @@ if [ "$COUNT" -gt 0 ]; then
 			0 "every row has a valid role"
 		_assert_json_eq '[.clients[] | select(.a4af == null)] | length' 0 "every row has an a4af flag"
 		_assert_json_eq '[.clients[] | select(has("parts"))] | length' 0 "no parts bitmap without include_parts"
+		# The two part indices ride include_parts with the bitmap: an
+		# index into a bitmap the caller did not ask for is unreadable,
+		# so neither key may appear here either.
+		_assert_json_eq '[.clients[] | select(has("next_requested_part_index") or has("downloading_part_index"))] | length' \
+			0 "no part indices without include_parts"
 	else
 		_skip "row-shape checks: no peer is connected to the download"
 	fi
@@ -318,6 +323,69 @@ if [ "$COUNT" -gt 0 ]; then
 		_curl -H "Authorization: Bearer $TOKEN" "$HOST/api/v0/downloads?sort=$_sk&limit=1"
 		_assert_status 400 "/downloads?sort=$_sk (pre-rename spelling) → 400"
 	done
+	# The two part indices the desktop's source bar paints over the bitmap.
+	# Under include_parts both keys are ALWAYS present on every row, null
+	# rather than omitted when the index does not apply, so one query yields
+	# one row shape -- assert presence separately from type, or a missing key
+	# and a null one both read as `null` and the test proves nothing.
+	#
+	# Re-issued rather than reusing the include_parts body fetched above: the
+	# sort loops in between have each overwritten $CURL_BODY, and the last of
+	# them left a 400 error envelope there. `.clients` on that is null, `null
+	# | length` is 0, and the whole block below would have skipped itself on
+	# every run while reporting "no peer is connected".
+	_curl -H "Authorization: Bearer $TOKEN" "$HOST/api/v0/downloads/$HASH/clients?include_parts=true"
+	_assert_status 200 "GET /downloads/{hash}/clients?include_parts=true (part-index block) → 200"
+	DLIDXROWS=$(printf '%s' "$CURL_BODY" | jq '.clients | length')
+	echo "  --- part-index block sees $DLIDXROWS row(s) ---"
+	if [ "$DLIDXROWS" -gt 0 ]; then
+		for k in next_requested_part_index downloading_part_index; do
+			_assert_json_eq "[.clients[] | select(has(\"$k\") | not)] | length" 0 \
+				"every row carries $k under include_parts"
+			# Number or null, never a string and never a bool: null is
+			# how "the peer never reported it", the 0xffff "nothing
+			# pending" sentinel, and a non-source row are all spelled.
+			_assert_json_eq "[.clients[] | select((.$k | type) as \$t | \$t != \"number\" and \$t != \"null\")] | length" \
+				0 "$k is a number or null on every row"
+			# 0 is a real chunk index, so an unknown value must be a
+			# JSON null and not a 0 standing in for one; and a known
+			# value must address a chunk of THIS file.
+			_assert_json_eq "[.clients[] | select(.$k != null) | select(.$k < 0 or .$k >= $PARTCOUNT)] | length" \
+				0 "$k, when not null, is an index inside [0, part_count)"
+		done
+		# A row that is not a source for this file has no download bitmap,
+		# so its indices belong to some other file: both must be null.
+		_assert_json_eq '[.clients[] | select(.role == "uploading_to" or .role == "none") | select(.next_requested_part_index != null or .downloading_part_index != null)] | length' \
+			0 "non-source rows report both part indices as null"
+		# An index is only meaningful against the bitmap it indexes, and
+		# role alone does not guarantee one: a source that has sent no
+		# part status yet, or whose decoded bitmap cannot cover the file,
+		# ships no `parts` key at all. Such a row is a stripe coordinate
+		# with no bar to paint it on, so both indices must be null there
+		# too. Count the rows that actually exercised it, so a green run
+		# with no such row cannot be read as having proved the gate.
+		DLNOBITS=$(printf '%s' "$CURL_BODY" | jq '[.clients[] | select(has("parts") | not)] | length')
+		_assert_json_eq '[.clients[] | select(has("parts") | not) | select(.next_requested_part_index != null or .downloading_part_index != null)] | length' \
+			0 "a row without a parts bitmap reports both part indices as null ($DLNOBITS such row(s))"
+		# The state guard: the daemon reports downloading_part_index as a
+		# stale 0 for a source that is merely connected or queued, which
+		# would have a renderer paint "downloading now" on chunk 0 of
+		# every idle row. Anything but download_state "downloading" must
+		# come back null -- and null, not 0, is what distinguishes it
+		# from a peer genuinely feeding chunk 0.
+		DLIDLE=$(printf '%s' "$CURL_BODY" | jq '[.clients[] | select(.role == "downloading_from" or .role == "both") | select(.download_state != "downloading")] | length')
+		if [ "$DLIDLE" -gt 0 ]; then
+			_assert_json_eq '[.clients[] | select(.role == "downloading_from" or .role == "both") | select(.download_state != "downloading") | select(.downloading_part_index != null)] | length' \
+				0 "a source that is not downloading reports downloading_part_index null, not 0 ($DLIDLE such row(s))"
+		else
+			_skip "idle-source downloading_part_index check: every source row is actively downloading"
+		fi
+		# Report which path the run actually exercised, so a green run
+		# cannot be read as having seen a live peer feeding a chunk.
+		echo "  --- non-null part indices observed: next=$(printf '%s' "$CURL_BODY" | jq '[.clients[] | select(.next_requested_part_index != null)] | length') last=$(printf '%s' "$CURL_BODY" | jq '[.clients[] | select(.downloading_part_index != null)] | length') of $DLIDXROWS row(s) ---"
+	else
+		_skip "part-index checks: no peer is connected to the download"
+	fi
 
 	_curl -H "Authorization: Bearer $TOKEN" "$HOST/api/v0/downloads/$HASH/clients?include_parts=maybe"
 	_assert_status 400 "include_parts must be true/false"
@@ -497,8 +565,49 @@ if [ "$SHCOUNT" -gt 0 ]; then
 			"every shared-side row has an a4af flag"
 		_assert_json_eq '[.clients[] | select(has("parts"))] | length' 0 \
 			"no parts bitmap on the shared route without include_parts"
+		_assert_json_eq '[.clients[] | select(has("next_requested_part_index") or has("downloading_part_index"))] | length' \
+			0 "no part indices on the shared route without include_parts"
 	else
 		_skip "shared-side row-shape checks: no peer is downloading the shared file"
+	fi
+
+	# Same two keys on the shared route, which is the same handler. A shared
+	# file's rows are overwhelmingly role "uploading_to" -- someone pulling from us --
+	# and a peer's download indices describe whatever IT is downloading, not
+	# this file, so the interesting case here is that they come back null.
+	_curl -H "Authorization: Bearer $TOKEN" "$HOST/api/v0/shared/$SHASH/clients?include_parts=true"
+	_assert_status 200 "GET /shared/{hash}/clients?include_parts=true → 200"
+	SHIDXROWS=$(printf '%s' "$CURL_BODY" | jq '.clients | length')
+	if [ "$SHIDXROWS" -gt 0 ]; then
+		for k in next_requested_part_index downloading_part_index; do
+			_assert_json_eq "[.clients[] | select(has(\"$k\") | not)] | length" 0 \
+				"every shared-side row carries $k under include_parts"
+			_assert_json_eq "[.clients[] | select((.$k | type) as \$t | \$t != \"number\" and \$t != \"null\")] | length" \
+				0 "$k is a number or null on every shared-side row"
+			_assert_json_eq "[.clients[] | select(.$k != null) | select(.$k < 0 or .$k >= $SHPARTCOUNT)] | length" \
+				0 "$k, when not null, indexes a chunk of the shared file"
+		done
+		_assert_json_eq '[.clients[] | select(.role == "uploading_to" or .role == "none") | select(.next_requested_part_index != null or .downloading_part_index != null)] | length' \
+			0 "shared-side non-source rows report both part indices as null"
+		# An index is only meaningful against the bitmap it indexes, and
+		# role alone does not guarantee one: a source that has sent no
+		# part status yet, or whose decoded bitmap cannot cover the file,
+		# ships no `parts` key at all. Such a row is a stripe coordinate
+		# with no bar to paint it on, so both indices must be null there
+		# too. Count the rows that actually exercised it, so a green run
+		# with no such row cannot be read as having proved the gate.
+		SHNOBITS=$(printf '%s' "$CURL_BODY" | jq '[.clients[] | select(has("parts") | not)] | length')
+		_assert_json_eq '[.clients[] | select(has("parts") | not) | select(.next_requested_part_index != null or .downloading_part_index != null)] | length' \
+			0 "a shared-side row without a parts bitmap reports both part indices as null ($SHNOBITS such row(s))"
+		SHIDLE=$(printf '%s' "$CURL_BODY" | jq '[.clients[] | select(.role == "downloading_from" or .role == "both") | select(.download_state != "downloading")] | length')
+		if [ "$SHIDLE" -gt 0 ]; then
+			_assert_json_eq '[.clients[] | select(.role == "downloading_from" or .role == "both") | select(.download_state != "downloading") | select(.downloading_part_index != null)] | length' \
+				0 "a shared-side source that is not downloading reports downloading_part_index null ($SHIDLE such row(s))"
+		else
+			_skip "shared-side idle-source downloading_part_index check: no idle source row"
+		fi
+	else
+		_skip "shared-side part-index checks: no peer is downloading the shared file"
 	fi
 
 	_curl -H "Authorization: Bearer $TOKEN" "$HOST/api/v0/shared/$SHASH/clients?include_parts=true"

--- a/unittests/tests/CMakeLists.txt
+++ b/unittests/tests/CMakeLists.txt
@@ -966,3 +966,29 @@ target_link_libraries (RangeFileBodyTest
 	mulecommon
 	${Boost_LIBRARIES}
 )
+
+# The two part-index predicates behind `next_requested_part_index` /
+# `downloading_part_index` on the per-file client rows. Every branch that
+# matters turns on a value a live peer will not produce on request -- the
+# 0xffff sentinel, the boundary at part_count, a file with more than 65535
+# parts, a source whose state flips to "downloading" -- so PartIndex.h is
+# header-only and free of wx, Beast and EC, and the test needs nothing but
+# the harness.
+add_executable (PartIndexTest
+	PartIndexTest.cpp
+)
+
+add_test (NAME PartIndexTest
+	COMMAND PartIndexTest
+)
+
+target_include_directories (PartIndexTest
+	PRIVATE ${CMAKE_SOURCE_DIR}/src/webapi
+)
+
+# mulecommon even though the header is inline-only: macOS links without it,
+# GNU ld and mingw do not (see JsonDepthScanTest).
+target_link_libraries (PartIndexTest
+	muleunit
+	mulecommon
+)

--- a/unittests/tests/PartIndexTest.cpp
+++ b/unittests/tests/PartIndexTest.cpp
@@ -1,0 +1,185 @@
+//
+// This file is part of the aMule Project.
+//
+// Copyright (c) 2003-2026 aMule Team ( https://amule-org.github.io )
+//
+// Any parts of this program derived from the xMule, lMule or eMule project,
+// or contributed by third-party developers are copyrighted by their
+// respective authors.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301, USA
+//
+
+// The two predicates behind `next_requested_part_index` and
+// `downloading_part_index` on GET /{downloads,shared}/{hash}/clients.
+//
+// Every branch here is decided by a value amuled reports about a peer, and the
+// ones that matter are the ones no live peer will hand over on request: the
+// 0xffff "no block pending" sentinel, the boundary at part_count, a file with
+// more than 65535 parts (~637 GB, where 0xffff is a legitimate chunk and the
+// sentinel is therefore indistinguishable from real data by range alone), and a
+// source whose download_state flips to "downloading". Waiting for a daemon to
+// produce those is waiting forever, which is why the predicates live in a
+// header of their own -- no wx, no Boost.Beast, no EC -- and are driven here.
+
+#include <muleunit/test.h>
+
+#include "PartIndex.h"
+
+#include <cstdint>
+#include <string>
+
+using namespace muleunit;
+using namespace webapi;
+
+namespace
+{
+
+// A file with more than 65535 parts: 65536 * 9.28 MB is about 608 GiB, so this
+// is a real size a real user reaches, not a synthetic extreme. Named because
+// every "large file" case below turns on it being > kNoPartPendingSentinel.
+constexpr std::uint64_t kPartCountAbove16Bit = 200000u;
+
+} // namespace
+
+DECLARE_SIMPLE(PartIndex)
+
+TEST(PartIndex, SentinelIsTheValueTheCoreActuallySends)
+{
+	// Pinned rather than assumed: the whole point of testing the sentinel by
+	// name is that the name and the wire value agree.
+	ASSERT_EQUALS(0xffffu, (unsigned)kNoPartPendingSentinel);
+	ASSERT_TRUE(std::string("downloading") == kDownloadStateDownloading);
+}
+
+// --- UsablePartIndex ----------------------------------------------------
+
+TEST(PartIndex, AnUnreportedIndexIsUnusable)
+{
+	// The has_* flag false: the peer never sent the tag at all. Nothing else
+	// in the call can rescue it -- not an in-range value, not part 0.
+	ASSERT_FALSE(UsablePartIndex(false, 0, 100));
+	ASSERT_FALSE(UsablePartIndex(false, 7, 100));
+	ASSERT_FALSE(UsablePartIndex(false, kNoPartPendingSentinel, 100));
+}
+
+TEST(PartIndex, AnInRangeIndexIsUsable)
+{
+	// The positive path, including part 0 -- a real and common chunk index,
+	// never a stand-in for "unknown".
+	ASSERT_TRUE(UsablePartIndex(true, 0, 1));
+	ASSERT_TRUE(UsablePartIndex(true, 0, 100));
+	ASSERT_TRUE(UsablePartIndex(true, 42, 100));
+}
+
+TEST(PartIndex, PartCountMinusOneIsInsideAndPartCountIsNot)
+{
+	// The boundary. part_count is a count, the index is 0-based, so the last
+	// addressable chunk is part_count - 1 and part_count itself is the first
+	// value that must be refused.
+	ASSERT_TRUE(UsablePartIndex(true, 9, 10));
+	ASSERT_FALSE(UsablePartIndex(true, 10, 10));
+	ASSERT_FALSE(UsablePartIndex(true, 11, 10));
+}
+
+TEST(PartIndex, AFileWithNoPartsAddressesNothing)
+{
+	// part_count 0: `0 < 0` is false, so even index 0 is refused. This is the
+	// shape a row whose bitmap could not be resolved arrives in.
+	ASSERT_FALSE(UsablePartIndex(true, 0, 0));
+	ASSERT_FALSE(UsablePartIndex(true, 1, 0));
+	ASSERT_FALSE(UsablePartIndex(true, kNoPartPendingSentinel, 0));
+}
+
+TEST(PartIndex, TheSentinelIsRefusedOnAnOrdinaryFile)
+{
+	// Here the bounds check would have caught it anyway (65535 >= 100). The
+	// next test is the one that proves the by-name test is load-bearing.
+	ASSERT_FALSE(UsablePartIndex(true, kNoPartPendingSentinel, 100));
+	ASSERT_FALSE(UsablePartIndex(true, kNoPartPendingSentinel, 65535));
+}
+
+TEST(PartIndex, TheSentinelIsRefusedEvenWhere65535IsARealChunk)
+{
+	// The 637 GB case, and the entire reason UsablePartIndex names the
+	// sentinel instead of leaving it to the bound: with 200000 parts, 65535
+	// is squarely in range, so a bounds check alone would relay "no block
+	// pending" as an index and paint a stripe on chunk 65535 of exactly the
+	// files a per-source bar is most useful on.
+	ASSERT_TRUE(65535u < kPartCountAbove16Bit); // the bound would have passed it
+	ASSERT_FALSE(UsablePartIndex(true, kNoPartPendingSentinel, kPartCountAbove16Bit));
+
+	// Only the sentinel value is special, not its neighbourhood: 65534 on the
+	// same file is an ordinary chunk and must still come through.
+	ASSERT_TRUE(UsablePartIndex(true, 65534, kPartCountAbove16Bit));
+
+	// And part_count exactly 65536, the smallest file on which the sentinel is
+	// in range at all -- the first size where the by-name test starts mattering.
+	ASSERT_FALSE(UsablePartIndex(true, kNoPartPendingSentinel, 65536));
+	ASSERT_TRUE(UsablePartIndex(true, 65534, 65536));
+}
+
+// --- UsableLastDownloadingPart ------------------------------------------
+
+TEST(PartIndex, LastDownloadingPartNeedsTheDownloadingState)
+{
+	// The defect the guard exists for. The core initialises the field to 0 and
+	// ships it unconditionally, so a source that is merely connected or queued
+	// reports a perfectly in-range 0 -- and since most sources in a list are
+	// queued, relaying it would mark chunk 0 as "downloading now" on nearly
+	// every row. Only the exact state string opens the gate.
+	ASSERT_TRUE(UsableLastDownloadingPart("downloading", true, 0, 100));
+
+	ASSERT_FALSE(UsableLastDownloadingPart("onqueue", true, 0, 100));
+	ASSERT_FALSE(UsableLastDownloadingPart("connecting", true, 0, 100));
+	ASSERT_FALSE(UsableLastDownloadingPart("connected", true, 0, 100));
+	ASSERT_FALSE(UsableLastDownloadingPart("", true, 0, 100));
+
+	// Not just the stale 0: a genuinely in-range value is still refused while
+	// the peer is not transferring, because it describes a chunk that finished
+	// arriving at some point in the past.
+	ASSERT_FALSE(UsableLastDownloadingPart("onqueue", true, 42, 100));
+	ASSERT_FALSE(UsableLastDownloadingPart("toomanyconns", true, 42, 100));
+}
+
+TEST(PartIndex, TheStateComparisonIsExact)
+{
+	// The state string comes from one enum-to-token mapping (Refresher.cpp:
+	// ClientDownloadStateName) and is compared verbatim, so nothing that merely
+	// contains or resembles the token opens the gate.
+	ASSERT_FALSE(UsableLastDownloadingPart("Downloading", true, 5, 100));
+	ASSERT_FALSE(UsableLastDownloadingPart("downloading ", true, 5, 100));
+	ASSERT_FALSE(UsableLastDownloadingPart("notdownloading", true, 5, 100));
+	ASSERT_FALSE(UsableLastDownloadingPart("downloading_from", true, 5, 100));
+}
+
+TEST(PartIndex, TheStateGuardDoesNotReplaceTheRangeChecks)
+{
+	// "downloading" is necessary, never sufficient: every UsablePartIndex
+	// branch still applies underneath it.
+	ASSERT_FALSE(UsableLastDownloadingPart("downloading", false, 5, 100));
+	ASSERT_FALSE(UsableLastDownloadingPart("downloading", true, kNoPartPendingSentinel, 100));
+	ASSERT_FALSE(UsableLastDownloadingPart("downloading", true, 100, 100));
+	ASSERT_FALSE(UsableLastDownloadingPart("downloading", true, 0, 0));
+
+	// Including on the large file, where the sentinel is in range: a
+	// transferring peer does not make 0xffff mean chunk 65535.
+	ASSERT_FALSE(
+		UsableLastDownloadingPart("downloading", true, kNoPartPendingSentinel, kPartCountAbove16Bit));
+	ASSERT_TRUE(UsableLastDownloadingPart("downloading", true, 65534, kPartCountAbove16Bit));
+
+	// And the boundary once more through this entry point.
+	ASSERT_TRUE(UsableLastDownloadingPart("downloading", true, 99, 100));
+}


### PR DESCRIPTION
## Summary

The two part indices the desktop's per-source bar paints on top of the availability bitmap: the chunk currently in flight, and the one queued behind it. Without them a client can draw three of the desktop's five states.

This is a gap in #995 rather than §4 of #984 — it is amuleapi-side and stands on its own, which is why it is its own PR. The Web UI that consumes it follows separately.

**Generated with AI**, flagged up front per the terms in #1177.

The decode already existed: `Refresher.cpp` has been reading `EC_TAG_CLIENT_NEXT_REQUESTED_PART` and `EC_TAG_CLIENT_LAST_DOWNLOADING_PART` on every tick, and `ClientSnapshot` has been holding them. The comment above them said, verbatim, *"Decoded but not yet surfaced… a client wanting to show which chunk a peer is feeding needs them. Delete them rather than leave them rotting if that never materialises."* Something needs them now.

They go on the per-file client row rather than the base fields, for the same reason `parts` does: they describe a peer's relation to **one** file, not the peer. That also keeps them out of the SSE client payload, where a value that moves every tick would be noise no listener renders. Both are gated on `include_parts`, because an index is meaningless without the bitmap it indexes.

Under the flag both keys are always present — `null` rather than omitted wherever they do not apply, so one query yields one row shape. Three things make an index not apply: `0xffff`, which is the core's "no block pending" answer and not part 65535; an index past the file's part count, left over from a peer whose request file is not this one; and a row that is not a source for this file at all, where the indices belong to whatever else that peer is pulling.

**`last_downloading_part` needs one guard more, which the bounds check cannot give it.** The core initialises `m_lastDownloadingPart` to `0` and `ECSpecialCoreTags.cpp` ships it with `AddTag` rather than `AddDiffTag`, so it arrives on every frame whether or not the peer is transferring. A connected-but-queued source therefore reports a perfectly in-range `0`, indistinguishable from one actually feeding chunk 0 — and since most sources in a list are queued rather than transferring, a renderer would mark chunk 0 as "downloading now" on nearly every row. `GenericClientListCtrl.cpp` guards it the same way, forcing `0xffff` unless the state is `DS_DOWNLOADING`; doing it in the serializer means every API client gets it right once instead of each rediscovering the rule. Deliberately **not** applied to `next_requested_part`, exactly as the desktop does not apply it either: `0xffff` is that field's own "nothing pending" answer, so an idle peer already falls out through the bounds check.

## Test plan

- **`unittests/curl-tests/amuleapi/04-read-downloads-shared.sh`**, extended in place next to the existing `include_parts` assertions: both keys present on every row under the flag (asserted separately from type, or a missing key and a null one both read as `null` and prove nothing); number-or-null on every row, never a string or a bool; when not null, an index inside `[0, parts_total_count)`; both null on non-source rows; and `last_downloading_part` null rather than `0` on a source whose `download_state` is not `"downloading"`. The run prints how many non-null indices it actually observed, so a green run cannot be misread as having seen a live peer feeding a chunk. **46/46**.
- ctest **43/43**; zero new compiler warnings (the three `-Wc++17-extensions` in `Api.cpp` are pre-existing); clang-format 18 clean on the changed ranges.
- Rebased onto `9722a68`. `REFERENCE.md` and the curl suite both conflicted with the resource renames and were resolved against the new spelling — `parts_total_count`, not `part_count`.

**Naming.** These two keys predate the #1189 pass on this resource, and `parts_total_count` / `parts_offered_count` landed since. If they should be spelled differently under the new rules, say so and I will rename rather than leave the surface inconsistent.

**Honest limit:** I could not get a live peer to report a non-null value on demand — a source has to be actively feeding a chunk at the moment of the request. The null paths, the bounds rejection and the state guard are all covered; the "a real number arrives and is in range" path is covered by the assertions but was exercised against null-valued rows.
