### PR TITLE
refactor(amuleapi): rename the routes, auth, error codes and query parameters

### DIFF
--- a/docs/QUICKSTART-AMULEAPI.md
+++ b/docs/QUICKSTART-AMULEAPI.md
@@ -118,7 +118,7 @@ All are readable only by you.
 curl -s http://127.0.0.1:4713/api/v0/health
 
 # Log in, then use the token.
-TOKEN=$(curl -s -X POST "http://127.0.0.1:4713/api/v0/auth/login?type=bearer" \
+TOKEN=$(curl -s -X POST "http://127.0.0.1:4713/api/v0/auth/login?include_token=true" \
     -H 'Content-Type: application/json' \
     -d '{"password":"mySecret123"}' | jq -r .token)
 
@@ -129,7 +129,7 @@ curl -s -H "Authorization: Bearer $TOKEN" http://127.0.0.1:4713/api/v0/status
 curl -s -H "Authorization: Bearer $TOKEN" http://127.0.0.1:4713/api/v0/version
 ```
 
-Browsers should call `/auth/login` *without* `?type=bearer` — they get a
+Browsers should call `/auth/login` *without* `?include_token=true` — they get a
 cookie instead, which keeps the token out of reach of page scripts.
 
 ## Reaching it from another machine

--- a/docs/QUICKSTART-AMULEAPI.md
+++ b/docs/QUICKSTART-AMULEAPI.md
@@ -252,7 +252,7 @@ Everything under `/api/v0/`, with full details in
 - **Downloads** — the queue: add, pause, cancel, clear completed, plus
   comments, filenames and alternate sources.
 - **Shared files** — list, verify, and the shared folders.
-- **Peers** — who you are connected to, and browsing their shared files.
+- **Clients** — who you are connected to, and browsing their shared files.
 - **Servers** — the ed2k server list, connecting, and refreshing it.
 - **Network** — connect and disconnect ed2k and Kad.
 - **Search** — start a search, read results, download one.

--- a/docs/api/EVENTS.md
+++ b/docs/api/EVENTS.md
@@ -110,7 +110,7 @@ If the daemon restarts between steps 1 and 2, or the ring buffer overflows on a 
 ```sh
 TOKEN=$(curl -s -X POST -H "Content-Type: application/json" \
   -d '{"password":"adminpass"}' \
-  "http://$HOST/api/v0/auth/login?type=bearer" | jq -r .token)
+  "http://$HOST/api/v0/auth/login?include_token=true" | jq -r .token)
 
 curl -N -H "Authorization: Bearer $TOKEN" http://$HOST/api/v0/events
 ```
@@ -191,7 +191,7 @@ Every event belongs to a single channel. The full set, prefix-mapped from the ev
 | `clients` | `client_*` | Peers we're exchanging with |
 | `friends` | `friend_*` | The friends list, and whether each one is online |
 | `status` | `status_*` | Connection state + headline counters |
-| `logs` | `log_*` | amuled log buffer (live tail; serverinfo is poll-only) |
+| `logs` | `log_*` | amuled log buffer (live tail; server_info is poll-only) |
 | `search` | `search_*` | Result deltas, completion, and the freeing of a search |
 | `chats` | `chat_*` | Peer chat messages, and conversations being closed |
 | `comments` | `comments_*` | Comment/rating lists on a download |
@@ -570,7 +570,7 @@ Emitted when the amuled log buffer appends new lines.
 { "lines": ["2026-06-19 11:00:00: line one", "2026-06-19 11:00:01: line two"] }
 ```
 
-Only the amuled log has a live channel; the serverinfo buffer has no SSE feed and is fetched by polling [`GET /logs/serverinfo`](REFERENCE.md#get-apiv0logsserverinfo). Multiple lines may be batched into a single event when the buffer landed several lines between refresher ticks. The [Bootstrap example](#bootstrap-snapshot--stream) doesn't pull `/logs/amule` — fetch it in step 2 if your UI shows historical log lines, otherwise treat `log_appended` as a live-only feed.
+Only the amuled log has a live channel; the server_info buffer has no SSE feed and is fetched by polling [`GET /logs/serverinfo`](REFERENCE.md#get-apiv0logsserverinfo). Multiple lines may be batched into a single event when the buffer landed several lines between refresher ticks. The [Bootstrap example](#bootstrap-snapshot--stream) doesn't pull `/logs/amule` — fetch it in step 2 if your UI shows historical log lines, otherwise treat `log_appended` as a live-only feed.
 
 ### `search` channel
 

--- a/docs/api/EVENTS.md
+++ b/docs/api/EVENTS.md
@@ -103,7 +103,7 @@ If the daemon restarts between steps 1 and 2, or the ring buffer overflows on a 
 
 ## Connecting
 
-`GET /api/v0/events` opens the stream. Auth runs synchronously BEFORE the worker thread is spawned and before the 32-slot streaming budget is touched, so an unauthenticated peer can't tie up a slot for the read-timeout window.
+`GET /api/v0/events` opens the stream. Auth runs synchronously BEFORE the worker thread is spawned and before the 32-slot streaming budget is touched, so an unauthenticated client can't tie up a slot for the read-timeout window.
 
 `HEAD` returns the stream's headers and no body. Any other method is `405` with `Allow: GET, HEAD`, like every other route — it used to be a `404` here, which read as "the endpoint does not exist" to a client probing the surface. A trailing slash is stripped first, so `/api/v0/events/` opens the same stream.
 
@@ -188,12 +188,12 @@ Every event belongs to a single channel. The full set, prefix-mapped from the ev
 | `downloads` | `download_*` | Transfers in the active queue |
 | `shared` | `shared_*` | Shared file list |
 | `servers` | `server_*` | Known ed2k servers |
-| `clients` | `client_*` | Peers we're exchanging with |
+| `clients` | `client_*` | Clients we're exchanging with |
 | `friends` | `friend_*` | The friends list, and whether each one is online |
 | `status` | `status_*` | Connection state + headline counters |
 | `logs` | `log_*` | amuled log buffer (live tail; server_info is poll-only) |
 | `search` | `search_*` | Result deltas, completion, and the freeing of a search |
-| `chats` | `chat_*` | Peer chat messages, and conversations being closed |
+| `chats` | `chat_*` | Client chat messages, and conversations being closed |
 | `comments` | `comments_*` | Comment/rating lists on a download |
 
 By default every channel is delivered. To subscribe to a subset, pass `?channels=` with a comma-separated list:
@@ -424,7 +424,7 @@ Identical to the REST [`/api/v0/friends`](REFERENCE.md#get-apiv0friends) list-it
 }
 ```
 
-`friend_updated` fires on any observable change, including a friend coming online or going offline — that transition is `client_ecid` moving between a live peer's ECID and `0`, which is what drives the connected indicator in the desktop client.
+`friend_updated` fires on any observable change, including a friend coming online or going offline — that transition is `client_ecid` moving between a live client's ECID and `0`, which is what drives the connected indicator in the desktop client.
 
 One `PATCH /api/v0/friends/{ecid}` can produce **two** `friend_updated` events. Only one friend may hold the friend slot, so granting it to one clears it on whoever held it before, and both records change.
 
@@ -506,12 +506,12 @@ Identical to the REST [`/api/v0/clients`](REFERENCE.md#get-apiv0clients) list-it
 ```
 Carries the same field set as the [`/clients`](REFERENCE.md#get-apiv0clients) list row, including `source_origin`, `parts_offered_count`, `client_mod_name` and `shared_files_browsable`.
 
-`part_progress_percent` follows the same rule as on the REST row: it is how much of the file we are downloading **from** this peer the peer already holds, and it is `null` when there is no such file, rather than sent as a negative sentinel. It is derived from `parts_offered_count` and the linked download's part count, so it moves when `parts_offered_count` does, and goes back to `null` if that download goes away. The key is always present -- see [REFERENCE.md's unknown-value rule](REFERENCE.md#unknown-values), under which `null` means "no value" and an absent key means "not reported".
+`part_progress_percent` follows the same rule as on the REST row: it is how much of the file we are downloading **from** this client the client already holds, and it is `null` when there is no such file, rather than sent as a negative sentinel. It is derived from `parts_offered_count` and the linked download's part count, so it moves when `parts_offered_count` does, and goes back to `null` if that download goes away. The key is always present -- see [REFERENCE.md's unknown-value rule](REFERENCE.md#unknown-values), under which `null` means "no value" and an absent key means "not reported".
 
-It never carries a `parts` bitmap — those are opt-in on the per-file client routes only, being one boolean per chunk per peer.
+It never carries a `parts` bitmap — those are opt-in on the per-file client routes only, being one boolean per chunk per client.
 
 
-`upload_file_hash` (file we're uploading TO this peer) and `download_file_hash` (file we're downloading FROM this peer) are 32-char MD4 hex hashes — directly resolvable against [`/api/v0/downloads/{hash}`](REFERENCE.md#get-apiv0downloadshash) (in-progress) or the corresponding entry in [`/api/v0/shared`](REFERENCE.md#get-apiv0shared) by `.hash`. Either field can be empty when the peer is queued / idle in that direction. `download_file_name` is the filename the peer advertised while we download from them; `upload_file_name` is the partfile they're downloading from us, resolved locally — see [`GET /clients`](REFERENCE.md#get-apiv0clients) for details.
+`upload_file_hash` (file we're uploading TO this client) and `download_file_hash` (file we're downloading FROM this client) are 32-char MD4 hex hashes — directly resolvable against [`/api/v0/downloads/{hash}`](REFERENCE.md#get-apiv0downloadshash) (in-progress) or the corresponding entry in [`/api/v0/shared`](REFERENCE.md#get-apiv0shared) by `.hash`. Either field can be empty when the client is queued / idle in that direction. `download_file_name` is the filename the client advertised while we download from them; `upload_file_name` is the partfile they're downloading from us, resolved locally — see [`GET /clients`](REFERENCE.md#get-apiv0clients) for details.
 
 #### `client_removed`
 
@@ -600,7 +600,7 @@ It does **not** fire on `sources` or `alternate_names[]`. Those churn on essenti
 }
 ```
 
-`search_id` routes the result to the search that produced it — amuleapi runs several searches at once (see [REFERENCE.md](REFERENCE.md#post-apiv0search)), so demux on it. Key results by `(search_id, hash)`. Aside from the leading `search_id`, the payload is byte-for-byte identical to a `/search/{id}/results` array entry — the two are emitted by the same writer, so the promise holds by construction. That includes `status`, `type`, `directory` (the folder inside a browsed peer's share, `""` on ordinary hits), `kad_comment_lookup_running`, `comments[]` and the `alternate_names[]` grouping array — see [REFERENCE.md](REFERENCE.md#get-apiv0searchidresults); `sources` is the nested `{total, complete}` object, `media` — the audio/video metadata object — is present for locally-known/probed hits and `null` otherwise (the one place the unknown-value rule reaches an object rather than a scalar, so test `media === null` before reaching into it), and `alternate_names` holds the same-hash/different-name alternatives (empty for a single-name hit), same as the REST endpoint. Only parent results fire these events — children are folded into their parent's `alternate_names[]`, never emitted on their own. A change to a child therefore surfaces as a `search_result_updated` for its parent. Each `search_id` is an independent result space — a new `POST /search` starts a fresh one without disturbing the others.
+`search_id` routes the result to the search that produced it — amuleapi runs several searches at once (see [REFERENCE.md](REFERENCE.md#post-apiv0search)), so demux on it. Key results by `(search_id, hash)`. Aside from the leading `search_id`, the payload is byte-for-byte identical to a `/search/{id}/results` array entry — the two are emitted by the same writer, so the promise holds by construction. That includes `status`, `type`, `directory` (the folder inside a browsed client's share, `""` on ordinary hits), `kad_comment_lookup_running`, `comments[]` and the `alternate_names[]` grouping array — see [REFERENCE.md](REFERENCE.md#get-apiv0searchidresults); `sources` is the nested `{total, complete}` object, `media` — the audio/video metadata object — is present for locally-known/probed hits and `null` otherwise (the one place the unknown-value rule reaches an object rather than a scalar, so test `media === null` before reaching into it), and `alternate_names` holds the same-hash/different-name alternatives (empty for a single-name hit), same as the REST endpoint. Only parent results fire these events — children are folded into their parent's `alternate_names[]`, never emitted on their own. A change to a child therefore surfaces as a `search_result_updated` for its parent. Each `search_id` is an independent result space — a new `POST /search` starts a fresh one without disturbing the others.
 
 #### `search_progress`
 
@@ -622,7 +622,7 @@ Emitted whenever a search's completion advances and once more on its completion;
 
 A Kad search hitting its result cap (`SEARCHKEYWORD_TOTAL`, 300) before the 45 s deadline finishes early — the lifecycle flips to `finished` and `percent` jumps straight to 100 ahead of the ramp.
 
-A **browse** started via [`POST /clients/{ecid}/shared_files`](REFERENCE.md#post-apiv0clientsecidshared_files) rides this same channel: its `search_id` fires `search_result_added` per file the peer returns and `search_progress` frames with `"type": "browse"`, where `percent` tracks the directories received so far. A denied / unreachable / lost browse flips to `finished` with the results it managed to collect (often zero) — same terminal frame as a completed one, no distinct failure event.
+A **browse** started via [`POST /clients/{ecid}/shared_files`](REFERENCE.md#post-apiv0clientsecidshared_files) rides this same channel: its `search_id` fires `search_result_added` per file the client returns and `search_progress` frames with `"type": "browse"`, where `percent` tracks the directories received so far. A denied / unreachable / lost browse flips to `finished` with the results it managed to collect (often zero) — same terminal frame as a completed one, no distinct failure event.
 
 #### `search_closed`
 

--- a/docs/api/REFERENCE.md
+++ b/docs/api/REFERENCE.md
@@ -107,8 +107,8 @@ The API is versioned in the path. **`/api/v0/` is the pre-release surface and is
 **Logs**
 - [`GET /api/v0/logs/amule`](#get-apiv0logsamule) — amule log buffer
 - [`DELETE /api/v0/logs/amule`](#delete-apiv0logsamule) — clear amule buffer
-- [`GET /api/v0/logs/serverinfo`](#get-apiv0logsserverinfo--delete-apiv0logsserverinfo) — server-info log buffer
-- [`DELETE /api/v0/logs/serverinfo`](#get-apiv0logsserverinfo--delete-apiv0logsserverinfo) — clear server-info buffer
+- [`GET /api/v0/logs/server_info`](#get-apiv0logsserver_info--delete-apiv0logsserver_info) — server-info log buffer
+- [`DELETE /api/v0/logs/server_info`](#get-apiv0logsserver_info--delete-apiv0logsserver_info) — clear server-info buffer
 
 **Statistics**
 - [`GET /api/v0/stats/tree`](#get-apiv0statstree) — full statistics tree
@@ -147,13 +147,17 @@ If both arrive on the same request, the bearer header wins. The cookie attribute
 
 The JSON body of `POST /auth/login` deliberately omits the token by default — XSS that can `fetch('/auth/login', ...)` and read the body would defeat the HttpOnly protection. Browser clients work entirely off the Set-Cookie attached to the response. SDK clients that need the token in the body opt in via either:
 
-- `?type=bearer` query string, or
+- `?include_token=true` query string, or
 - `Accept: application/jwt` request header.
+
+The two are equivalent.
 
 | Mode | Body keys | Set-Cookie |
 |------|-----------|------------|
-| Default (cookie) | `role`, `expires_at`, `expires_at_unix` | yes |
-| Bearer opt-in | `token`, `role`, `expires_at`, `expires_at_unix`, `jti` | yes (cookie also goes out so a hybrid client can use either) |
+| Default (cookie) | `role`, `expires_at`, `session_id` | yes |
+| Token opt-in | `token`, `role`, `expires_at`, `session_id` | yes (cookie also goes out so a hybrid client can use either) |
+
+`include_token` adds exactly the one key it names: `session_id` and `expires_at` are unconditional, so a cookie client can identify and expire its own session without asking for a token it will not use.
 
 ### Role model
 
@@ -355,7 +359,7 @@ The rule now reaches the whole surface rather than just the download and shared 
 
 `media` is the one place this reaches an **object** rather than a scalar, so a client tests `media === null` before reaching into it -- which it had to do regardless, since the object's own fields can be absent.
 
-Five keys stay omitted, because for them absence really is the meaning: `started_at` and `result_count` on [`GET /search`](#get-apiv0search) as described above, `key` on a statistics node (absent from a daemon too old to send it), `ratio` on the statistics ratio node (absent when the daemon reported neither component), and `parts` under [`?include_parts=true`](#get-apiv0downloadshashclients) -- there the caller opted in, so the key's absence answers a question they did not ask.
+Five keys stay omitted, because for them absence really is the meaning: `started_at` and `result_count` on [`GET /search`](#get-apiv0search) as described above, `key` on a statistics node (absent from a daemon too old to send it), `ratio` on the statistics ratio node (absent when the daemon reported neither component), and `parts` under [`?include_parts=true`](#get-apiv0downloadshashclients--get-apiv0sharedhashclients) -- there the caller opted in, so the key's absence answers a question they did not ask.
 
 ### Priority levels
 
@@ -518,16 +522,16 @@ curl -s http://$HOST/api/v0/version
 
 ```json
 {
-  "name": "amuleapi",
+  "service": "amuleapi",
   "api_version": "v0",
-  "amule_version": "2.4.0-29-g...",
+  "amuleapi_version": "2.4.0-29-g...",
   "daemon_version": "2.4.0-29-g...",
   "update": {
     "check_enabled": true,
     "checked": true,
     "latest_version": "3.0.1",
-    "update_available": false,
-    "last_checked": 1783675590
+    "available": false,
+    "last_checked_at": 1783675590
   }
 }
 ```
@@ -536,7 +540,7 @@ curl -s http://$HOST/api/v0/version
 | --- | --- |
 | `name` | Always `"amuleapi"`. |
 | `api_version` | REST contract version served on this path (`"v0"`). |
-| `amule_version` | amuleapi's **own** build version. |
+| `amuleapi_version` | amuleapi's **own** build version. |
 | `daemon_version` | Version of the **connected amuled**, from the EC handshake. Empty string when EC is not (yet) connected, or when the daemon is old enough not to advertise it. Normally equal to `amule_version` (both are built from the same source tree), but they can differ if a mismatched amuleapi is pointed at a different amuled. |
 | `update` | Update-availability, **relayed from the connected daemon** — amuleapi never contacts GitHub itself. See the sub-table. |
 
@@ -547,8 +551,8 @@ The `update` object:
 | `check_enabled` | `true` only when the daemon can check **and** is configured to: built with `ENABLE_VERSION_CHECK` **and** its `NewVersionCheck` preference on. `false` for OS-package builds, the preference off, or a pre-3.1 daemon. When `false`, a client should show nothing. |
 | `checked` | `true` once the daemon has completed at least one check this session (so `latest_version` is known). The daemon checks at startup; use `POST /api/v0/version/check` to trigger a fresh one. |
 | `latest_version` | Latest release string (e.g. `"3.0.1"`); empty string when not yet checked or unavailable. |
-| `update_available` | `true` when a newer release exists, `false` when up to date, `null` when unknown (not yet checked or disabled). |
-| `last_checked` | Unix time (seconds) the last check completed; `null` when never checked. Useful because checks are startup-only unless re-triggered. |
+| `available` | `true` when a newer release exists, `false` when up to date, `null` when unknown (not yet checked or disabled). |
+| `last_checked_at` | Unix time (seconds) the last check completed; `null` when never checked. Useful because checks are startup-only unless re-triggered. |
 
 #### `POST /api/v0/version/check`
 
@@ -649,7 +653,7 @@ To reproduce the desktop's low-space warning, compare `temp_free_bytes` against 
 
 Mints a JWT for the role that matched the supplied password.
 
-**Query parameters:** `?type=bearer` (optional) — opt into the bearer body response shape. Equivalent to sending `Accept: application/jwt`.
+**Query parameters:** `?include_token=true` (optional) — also return the token in the body. Equivalent to sending `Accept: application/jwt`.
 
 **Body:**
 
@@ -670,13 +674,13 @@ HTTP/1.1 200 OK
 Set-Cookie: amuleapi_token=eyJhbGciOi...; HttpOnly; SameSite=Strict; Path=/api/v0; Max-Age=86400
 Content-Type: application/json
 
-{"role":"admin","expires_at":"2026-06-20T11:00:00Z","expires_at_unix":1781434800}
+{"role":"admin","expires_at":1781434800,"session_id":"b3iY9oA1tUW2pK..."}
 ```
 
-**Bearer opt-in request:**
+**Token opt-in request:**
 
 ```sh
-curl -s -X POST "http://$HOST/api/v0/auth/login?type=bearer" \
+curl -s -X POST "http://$HOST/api/v0/auth/login?include_token=true" \
   -H 'Content-Type: application/json' \
   -d '{"password":"adminpass"}'
 ```
@@ -685,11 +689,12 @@ curl -s -X POST "http://$HOST/api/v0/auth/login?type=bearer" \
 {
   "token": "eyJhbGciOi...",
   "role": "admin",
-  "expires_at": "2026-06-20T11:00:00Z",
-  "expires_at_unix": 1781434800,
-  "jti": "b3iY9oA1tUW2pK..."
+  "expires_at": 1781434800,
+  "session_id": "b3iY9oA1tUW2pK..."
 }
 ```
+
+`expires_at` is unix seconds, like every other `_at` key on this surface.
 
 **Errors:**
 
@@ -725,9 +730,8 @@ curl -s -H "Authorization: Bearer $TOKEN" http://$HOST/api/v0/auth/session
 ```json
 {
   "role": "admin",
-  "exp": "2026-06-20T11:00:00Z",
-  "exp_unix": 1781434800,
-  "jti": "b3iY9oA1tUW2pK..."
+  "session_id": "b3iY9oA1tUW2pK...",
+  "expires_at": 1781434800
 }
 ```
 
@@ -745,12 +749,12 @@ curl -s -H "Authorization: Bearer $TOKEN" http://$HOST/api/v0/auth/passwords
 
 ```json
 {
-  "admin_set": true,
-  "guest_enabled": false
+  "admin_password_set": true,
+  "guest_access_enabled": false
 }
 ```
 
-`guest_enabled` is simply whether a guest password exists.
+`guest_access_enabled` is simply whether a guest password exists.
 
 ---
 
@@ -764,8 +768,8 @@ Changes the admin password, and turns guest access on or off or changes its pass
 |-------|------|---------|
 | `current_password` | string | **Required.** The admin password as it is now. |
 | `admin_password` | string | New admin password. Omit to leave it unchanged. |
-| `guest_password` | string | New guest password. Implies `guest_enabled: true` unless that field says otherwise. Omit to leave it unchanged. |
-| `guest_enabled` | bool | `false` clears the guest password, turning guest access off. Omit to leave the current state. |
+| `guest_password` | string | New guest password. Implies `guest_access_enabled: true` unless that field says otherwise. Omit to leave it unchanged. |
+| `guest_access_enabled` | bool | `false` clears the guest password, turning guest access off. Omit to leave the current state. |
 
 Omitting a field means "leave it alone" — the same rule every other interface follows, and a necessary one, because a client cannot read a stored password back in order to resend it.
 
@@ -775,23 +779,21 @@ Omitting a field means "leave it alone" — the same rule every other interface 
 curl -s -X PATCH -H "Authorization: Bearer $TOKEN" \
     -H 'Content-Type: application/json' \
     -d '{"current_password":"old-secret","admin_password":"new-secret"}' \
-    "http://$HOST/api/v0/auth/passwords?type=bearer"
+    "http://$HOST/api/v0/auth/passwords?include_token=true"
 ```
 
 ```json
 {
-  "admin_set": true,
-  "guest_enabled": false,
-  "other_sessions_revoked": true,
+  "admin_password_set": true,
+  "guest_access_enabled": false,
   "token": "eyJhbGciOiJIUzI1NiIs...",
   "role": "admin",
-  "expires_at": "2026-06-21T11:00:00Z",
-  "expires_at_unix": 1781521200,
-  "jti": "9pQ2xR7mLk4vTn..."
+  "expires_at": 1781521200,
+  "session_id": "9pQ2xR7mLk4vTn..."
 }
 ```
 
-The response re-issues the caller's session — same shape and same `?type=bearer` / `Accept: application/jwt` opt-in as `/auth/login`, cookie included. Every *other* session is now invalid, which is what `other_sessions_revoked` reports. Clients that ignore the new token will get `401 unauthorized` on their next request.
+The response re-issues the caller's session — same shape and same `?include_token=true` / `Accept: application/jwt` opt-in as `/auth/login`, cookie included. Every *other* session is now invalid — unconditionally, which is why the body carries no key for it. Clients that ignore the new token will get `401 unauthorized` on their next request.
 
 **Errors**
 
@@ -1604,7 +1606,7 @@ curl -s -X POST -H "Authorization: Bearer $TOKEN" \
 ```
 
 ```json
-{ "scope": "all", "queued": 812 }
+{ "scope": "all", "queued_file_count": 812 }
 ```
 
 Returns `202 Accepted`. `queued` is how many files were **accepted for probing**, not how many produced metadata — files the scheduler drops (not audio/video by extension, an incomplete download, missing on disk) are not counted, and nothing has been extracted yet when the response returns.
@@ -1630,7 +1632,7 @@ Cost is roughly 13 ms per file — a probe reads the container header, not the f
 The same operation for a single file, which is the quickest way to check a fix on one file rather than a whole library.
 
 ```json
-{ "scope": "file", "queued": 1 }
+{ "scope": "file", "queued_file_count": 1 }
 ```
 
 **Errors:** `404 not_found` (no shared file with that hash), `409 partfile_unsupported` (an incomplete download has no complete file to read), `400 amuled_rejected` (media metadata extraction is disabled, or the file is not eligible: not audio/video, or an incomplete download), `503 ec_unsupported`, `503 ec_unavailable`.
@@ -2319,7 +2321,7 @@ amuleapi's own `admin` and `guest` passwords are **not** settable here; `remote_
 
 **`geoip`** accepts `enabled`, `source` (`"dbip"` / `"maxmind"` / `"custom"` — any other value is a `400`), `custom_update_url`, `maxmind_license`, and `auto_update`. `supported` and the read-only status fields (`loaded_source`, `db_path`, `db_loaded`, `download_in_progress`, `last_update_status`) are ignored if sent.
 
-Downloading a database **now** is [`POST /geoip/update`](#post-apiv0geoipupdate), not a field here. It used to be a write-only `geoip.update_now` boolean; sending that key is now a `400` naming the endpoint. It is an action, not a setting — nothing read it back, and writing `false` meant nothing.
+Downloading a database **now** is [`POST /geoip/update`](#post-apiv0geoipupdate), not a field here: it is an action, not a setting. Sending `geoip.update_now` in this body is a `400` naming that endpoint.
 
 > **Note:** these are the daemon's live settings — the same ones the desktop GUI edits. Some are self-affecting: changing `remote_controls.amuleapi.port` / `.bind_address`, or `directories.incoming_path` / `temp_path`, alters the very daemon you are talking to. A port/bind change only takes effect on the next amuled restart, so it will not drop your current connection mid-request.
 
@@ -2569,12 +2571,12 @@ amuled's general log buffer.
 ```json
 {
   "lines": ["2026-06-19 11:00:00: line one", "...line two"],
-  "total_cached": 1024,
-  "returned": 2
+  "total_lines": 1024,
+  "returned_lines": 2
 }
 ```
 
-`lines` is the array of log lines; `total_cached` is how many lines are held in the buffer and `returned` how many this response carried (≤ `tail`).
+`lines` is the array of log lines; `total_lines` is how many lines are held in the buffer and `returned_lines` how many this response carried (≤ `tail`).
 
 #### `DELETE /api/v0/logs/amule`
 
@@ -2584,7 +2586,7 @@ Clears the buffer.
 
 **Response:** `204 No Content`, with no body -- a pure action with nothing to report.
 
-#### `GET /api/v0/logs/serverinfo` / `DELETE /api/v0/logs/serverinfo`
+#### `GET /api/v0/logs/server_info` / `DELETE /api/v0/logs/server_info`
 
 **Auth:** `GUEST` / `ADMIN`
 
@@ -2598,7 +2600,7 @@ The ed2k server-info log buffer. Unlike `/logs/amule`, amuled ships this one as 
 }
 ```
 
-`DELETE /api/v0/logs/serverinfo` clears the buffer and answers `204 No Content` with no body.
+`DELETE /api/v0/logs/server_info` clears the buffer and answers `204 No Content` with no body.
 
 ---
 
@@ -3213,4 +3215,4 @@ What that means in practice, until the freeze:
 
 **`/api/v1/` is where the guarantee starts.** It is cut once the naming rules below hold across the whole surface and the result has been exercised end to end. From that point the additive-only discipline applies: anything that could break a conformant client is deferred to the next version rather than applied in place.
 
-`POST /api/v0/auth/login`'s default body shape (no token unless `?type=bearer`) IS a change from the very first amuleapi cuts; the legacy "token always in body" behaviour is reachable only via the opt-in. This is documented and committed.
+`POST /api/v0/auth/login`'s default body shape (no token unless `?include_token=true`) IS a change from the very first amuleapi cuts; the legacy "token always in body" behaviour is reachable only via the opt-in. This is documented and committed.

--- a/docs/api/REFERENCE.md
+++ b/docs/api/REFERENCE.md
@@ -42,15 +42,15 @@ The API is versioned in the path. **`/api/v0/` is the pre-release surface and is
 - [`DELETE /api/v0/downloads/{hash}`](#delete-apiv0downloadshash) — cancel + remove
 - [`POST /api/v0/downloads_clear_completed`](#post-apiv0downloads_clear_completed) — bulk-clear completed staging buffer
 
-**Clients (peers)**
-- [`GET /api/v0/clients`](#get-apiv0clients) — list peers, optional filter
-- [`GET /api/v0/clients/{ecid}`](#get-apiv0clientsecid) — full detail for one peer
-- [`POST /api/v0/clients/{ecid}/shared_files`](#post-apiv0clientsecidshared_files) — browse a peer's shared files ("View Files"), returns a `search_id`
+**Clients**
+- [`GET /api/v0/clients`](#get-apiv0clients) — list clients, optional filter
+- [`GET /api/v0/clients/{ecid}`](#get-apiv0clientsecid) — full detail for one client
+- [`POST /api/v0/clients/{ecid}/shared_files`](#post-apiv0clientsecidshared_files) — browse a client's shared files ("View Files"), returns a `search_id`
 
 **Shared files**
 - [`GET /api/v0/shared`](#get-apiv0shared) — list shared files
 - [`GET /api/v0/shared/{hash}`](#get-apiv0sharedhash) — detail view; every list field plus shared-detail fields
-- [`GET /api/v0/shared/{hash}/clients`](#get-apiv0downloadshashclients--get-apiv0sharedhashclients) — peers of one shared file
+- [`GET /api/v0/shared/{hash}/clients`](#get-apiv0downloadshashclients--get-apiv0sharedhashclients) — clients of one shared file
 - [`POST /api/v0/shared_reload`](#post-apiv0shared_reload) — re-walk shared directories
 - [`POST /api/v0/shared/media/refresh`](#post-apiv0sharedmediarefresh) — re-extract media metadata for the whole share
 - [`POST /api/v0/shared/{hash}/media/refresh`](#post-apiv0sharedhashmediarefresh) — re-extract it for one file
@@ -70,16 +70,16 @@ The API is versioned in the path. **`/api/v0/` is the pre-release surface and is
 - [`PATCH /api/v0/servers/{ecid}`](#patch-apiv0serversecid--patch-apiv0serversby-addressaddress) — set server priority / static flag (by ECID, or by `ip:port` under `by-address`)
 - [`POST /api/v0/servers_update`](#post-apiv0servers_update) — refresh from `server.met` URL
 - [`GET /api/v0/friends`](#get-apiv0friends) — list the friends list
-- [`POST /api/v0/friends`](#post-apiv0friends) — add a friend, by connected peer or by address
+- [`POST /api/v0/friends`](#post-apiv0friends) — add a friend, by connected client or by address
 - [`DELETE /api/v0/friends/{ecid}`](#delete-apiv0friendsecid) — remove a friend
 - [`PATCH /api/v0/friends/{ecid}`](#patch-apiv0friendsecid) — grant or clear the friend slot
 - [`POST /api/v0/friends/{ecid}/shared_files`](#post-apiv0friendsecidshared_files) — browse a friend's shared files
 - [`POST /api/v0/friends/{ecid}/messages`](#post-apiv0friendsecidmessages) — message a friend, online or offline
 - [`GET /api/v0/chats`](#get-apiv0chats) — list chat conversations
 - [`GET /api/v0/chats/{client_address}/messages`](#get-apiv0chatsclient_addressmessages) — read a conversation's history
-- [`POST /api/v0/chats/{client_address}/messages`](#post-apiv0chatsclient_addressmessages) — send a message to a peer address
+- [`POST /api/v0/chats/{client_address}/messages`](#post-apiv0chatsclient_addressmessages) — send a message to a client address
 - [`DELETE /api/v0/chats/{client_address}`](#delete-apiv0chatsclient_address) — close a conversation
-- [`POST /api/v0/clients/{ecid}/messages`](#post-apiv0clientsecidmessages) — message a connected peer
+- [`POST /api/v0/clients/{ecid}/messages`](#post-apiv0clientsecidmessages) — message a connected client
 
 **Categories**
 - [`GET /api/v0/categories`](#get-apiv0categories) — list categories
@@ -279,7 +279,7 @@ Sorting is applied to the full filtered set **before** slicing, so pagination is
 { "shared": [ ... ], "total": 8431, "offset": 100, "limit": 50 }
 ```
 
-- `total` — item count after any endpoint-specific filter (e.g. `/clients?filter=`), before slicing.
+- `total` — item count after any endpoint-specific filter (e.g. `/clients?activity=`), before slicing.
 - `offset` — the offset applied.
 - `limit` — the page size applied. Never `null`: every response has a real page size, so `{total, offset, limit}` round-trips straight back into the next request. It is not the row count — that is `total`.
 
@@ -349,13 +349,13 @@ A malformed **request** (missing/empty `hashes`, an invalid patch field) is stil
 
 ### Unknown values
 
-A field whose value is not known is `null`, not a sentinel. `remaining_seconds` is `null` rather than `-1` when there is no ETA to compute; `last_upload`, `shared_since` and `last_seen_complete_at` are `null` rather than `0` when a file has never uploaded, has never been seen complete, or its `known.met` entry predates the field. On a peer row, `parts_offered_count` is `null` when that peer has not reported its part map -- distinct from `0`, which is a real answer and what a fresh source looks like -- and `remote_queue_position` is `null` when the peer's queue is full, which the daemon signals with a `65535` sentinel rather than a position.
+A field whose value is not known is `null`, not a sentinel. `remaining_seconds` is `null` rather than `-1` when there is no ETA to compute; `last_upload`, `shared_since` and `last_seen_complete_at` are `null` rather than `0` when a file has never uploaded, has never been seen complete, or its `known.met` entry predates the field. On a client row, `parts_offered_count` is `null` when that client has not reported its part map -- distinct from `0`, which is a real answer and what a fresh source looks like -- and `remote_queue_position` is `null` when the client's queue is full, which the daemon signals with a `65535` sentinel rather than a position.
 
 A key is **omitted** only where absence itself is the meaning: something the daemon never reported, rather than something known to be absent. `started_at` on [`GET /search`](#get-apiv0search) is the example, missing for a search this process did not start, and `result_count` is missing when the daemon is too old to send it, which has to stay distinguishable from a search that found nothing.
 
 So: `null` means "no value", an absent key means "not reported", and neither is ever spelled `0` or `-1`.
 
-The rule now reaches the whole surface rather than just the download and shared objects. Keys that used to disappear and are `null` instead: `name`, `ip`, `port`, `kad_port`, `country_code`, `software`, `version`, `source_origin`, `obfuscation`, `first_seen` and `sessions` on [`GET /known_clients`](#get-apiv0known_clients); `part_progress_percent` and `parts_offered_count` on the peer rows and the `client_*` events; `client_ecid` on [`GET /search`](#get-apiv0search); `last_message` on [`GET /chats`](#get-apiv0chats); `token`, `label_value` and `extra` on the statistics tree; and `media` everywhere it appears.
+The rule now reaches the whole surface rather than just the download and shared objects. Keys that used to disappear and are `null` instead: `name`, `ip`, `port`, `kad_port`, `country_code`, `software`, `version`, `source_origin`, `obfuscation`, `first_seen` and `sessions` on [`GET /known_clients`](#get-apiv0known_clients); `part_progress_percent` and `parts_offered_count` on the client rows and the `client_*` events; `client_ecid` on [`GET /search`](#get-apiv0search); `last_message` on [`GET /chats`](#get-apiv0chats); `token`, `label_value` and `extra` on the statistics tree; and `media` everywhere it appears.
 
 `media` is the one place this reaches an **object** rather than a scalar, so a client tests `media === null` before reaching into it -- which it had to do regardless, since the object's own fields can be absent.
 
@@ -420,7 +420,7 @@ A validator names one representation, not one URL. When a response is compressed
 
 There is no freshness lifetime on them because these filenames carry no content hash: `index.html`, `app.js` and `app.css` keep their names across a rebuild, so a `max-age` would let an upgraded daemon keep serving the old shell until the entry expired, and -- since each asset expires on its own clock -- pair a new shell with an old bundle. `must-revalidate` would not prevent that: it governs what a cache may do once an entry is *already* stale (RFC 9111 §5.2.2.2), not whether it may be used while fresh.
 
-The [country flags](#get-flagscodepng) take the opposite trade and keep `public, max-age=86400`. That artwork is compiled into the daemon, so it changes only with a new build, and a peer list is a page full of `<img>` tags: a day of freshness turns those into cache hits instead of one conditional request per distinct country per reload. The `max-age` is what bounds how long an upgraded daemon can keep serving the old art -- a day, not forever.
+The [country flags](#get-flagscodepng) take the opposite trade and keep `public, max-age=86400`. That artwork is compiled into the daemon, so it changes only with a new build, and a client list is a page full of `<img>` tags: a day of freshness turns those into cache hits instead of one conditional request per distinct country per reload. The `max-age` is what bounds how long an upgraded daemon can keep serving the old art -- a day, not forever.
 
 Mutations (`POST`/`PATCH`/`DELETE`) and error responses are never ETag-stamped; the body always ships.
 
@@ -541,7 +541,7 @@ curl -s http://$HOST/api/v0/version
 | `name` | Always `"amuleapi"`. |
 | `api_version` | REST contract version served on this path (`"v0"`). |
 | `amuleapi_version` | amuleapi's **own** build version. |
-| `daemon_version` | Version of the **connected amuled**, from the EC handshake. Empty string when EC is not (yet) connected, or when the daemon is old enough not to advertise it. Normally equal to `amule_version` (both are built from the same source tree), but they can differ if a mismatched amuleapi is pointed at a different amuled. |
+| `daemon_version` | Version of the **connected amuled**, from the EC handshake. Empty string when EC is not (yet) connected, or when the daemon is old enough not to advertise it. Normally equal to `amuleapi_version` (both are built from the same source tree), but they can differ if a mismatched amuleapi is pointed at a different amuled. |
 | `update` | Update-availability, **relayed from the connected daemon** — amuleapi never contacts GitHub itself. See the sub-table. |
 
 The `update` object:
@@ -627,11 +627,11 @@ curl -s -H "Authorization: Bearer $TOKEN" http://$HOST/api/v0/status
 
 **`kad.firewalled_tcp` is named for its transport.** It is the TCP half of a pair; [`GET /api/v0/kad`](#get-apiv0kad) reports `firewalled_udp` alongside it. The two are independent measurements taken by different mechanisms, not a verdict and a refinement of it. See the `/kad` field table for what each one measures and how their defaults differ.
 
-**Our eD2k identity.** `ed2k.user_id` is the id the connected server assigned us, and `ed2k.high_id` is `true` when it is a HighID — an id `>= 16777216`, the same threshold the peer-side `high_id` on [`GET /clients/{ecid}`](#get-apiv0clientsecid) uses. A HighID **is** our public IPv4 packed into that integer, which is where `ed2k.public_ip` comes from; a LowID is a small number the server picked for a firewalled client and carries no address, so `public_ip` is `""` there.
+**Our eD2k identity.** `ed2k.user_id` is the id the connected server assigned us, and `ed2k.high_id` is `true` when it is a HighID — an id `>= 16777216`, the same threshold the client-side `high_id` on [`GET /clients/{ecid}`](#get-apiv0clientsecid) uses. A HighID **is** our public IPv4 packed into that integer, which is where `ed2k.public_ip` comes from; a LowID is a small number the server picked for a firewalled client and carries no address, so `public_ip` is `""` there.
 
 While disconnected `user_id` is `0`, `public_ip` is `""` and `high_id` is `false` — so read `high_id` **together with `state`**: `false` means "LowID" only once `state` is `"connected"`, and means "no id yet" otherwise. The transient `0xffffffff` the daemon sends mid-connect is normalized to `0` and never appears.
 
-**`ed2k.user_id` is not the same encoding as a client's `ed2k_user_id`.** [`GET /api/v0/clients/{ecid}`](#get-apiv0clientsecid) reports `ed2k_user_id` for a remote client, and the similar name invites the assumption that the two are interchangeable. They are not. Ours is stored exactly as the server sent it and is read least-significant-byte-first to produce `public_ip`; a peer's HighID is **byte-swapped** on the way in. A consumer that compares the two values, or feeds one through the other's IP decoder, gets a reversed address. The `>= 16777216` HighID threshold *is* common to both; the byte order is not.
+**`ed2k.user_id` is not the same encoding as a client's `ed2k_user_id`.** [`GET /api/v0/clients/{ecid}`](#get-apiv0clientsecid) reports `ed2k_user_id` for a remote client, and the similar name invites the assumption that the two are interchangeable. They are not. Ours is stored exactly as the server sent it and is read least-significant-byte-first to produce `public_ip`; a client's HighID is **byte-swapped** on the way in. A consumer that compares the two values, or feeds one through the other's IP decoder, gets a reversed address. The `>= 16777216` HighID threshold *is* common to both; the byte order is not.
 
 **Overhead is additive.** `speeds.download_overhead_bps` / `upload_overhead_bps` are protocol and control traffic, counted **separately** from `download_bps` / `upload_bps` rather than being part of them — the desktop shows them as a second figure in parentheses. Both are `0` when the daemon reports nothing.
 
@@ -877,7 +877,7 @@ Same envelope as the list item, plus the detail-only fields below (all omitted f
 
 | Field | Type | Meaning |
 |---|---|---|
-| `progress.parts` | array | One entry per ~9.28 MiB chunk: `{ "state": string, "sources": int }` — `state` is `complete`/`incomplete`/`missing` -- complete when the chunk is done, otherwise whether any peer offers it -- and `sources` counts peers offering that chunk. |
+| `progress.parts` | array | One entry per ~9.28 MiB chunk: `{ "state": string, "sources": int }` — `state` is `complete`/`incomplete`/`missing` -- complete when the chunk is done, otherwise whether any client offers it -- and `sources` counts clients offering that chunk. |
 | `last_seen_complete_at` | int \| null | Unix ts a complete copy was last seen across sources; `null` when no complete copy has ever been seen, or the daemon does not report it. |
 | `last_received_at` | int | Unix ts the partfile last received data. |
 | `active_seconds` | int | Seconds spent actively downloading. |
@@ -1000,19 +1000,19 @@ curl -s -H "Authorization: Bearer $TOKEN" \
 
 **Auth:** `GUEST`
 
-The peers of one file: sources serving it to us, peers pulling it from us, and — on the downloads side — A4AF sources parked on another file. Replaces the client-side join of the global `/clients` list against `download_file_hash` / `upload_file_hash`, which could never produce the A4AF rows.
+The clients of one file: sources serving it to us, clients pulling it from us, and — on the downloads side — A4AF sources parked on another file. Replaces the client-side join of the global `/clients` list against `download_file_hash` / `upload_file_hash`, which could never produce the A4AF rows.
 
 Each entry is the [`/clients`](#get-apiv0clients) list object plus three keys:
 
 | Key | Meaning |
 |---|---|
-| `role` | this peer's live relation to **this** file: `"source"` (serves it to us, including queued), `"peer"` (pulls it from us), `"both"`, `"none"` |
+| `role` | which direction this row moves the file: `"source"` — it serves the file to us (including queued); `"client"` — it pulls the file from us; `"both"`; `"none"` |
 | `a4af` | `true` for a source parked on another file — the desktop's A4AF row |
-| `parts` | the peer's per-part bitmap, **only** when `?include_parts=true` |
+| `parts` | the client's per-part bitmap, **only** when `?include_parts=true` |
 
-`role` and `a4af` are orthogonal: a pure A4AF row is `role: "none"`, `a4af: true`, but a peer can be parked on another file *and* be pulling this one from us (`role: "peer"`, `a4af: true`).
+`role` and `a4af` are orthogonal: a pure A4AF row is `role: "none"`, `a4af: true`, but a client can be parked on another file *and* be pulling this one from us (`role: "client"`, `a4af: true`).
 
-`parts` is opt-in because it is one boolean per chunk per peer — a multi-TiB file is 100k+ entries each. It is exactly `parts_total_count` entries, and it describes the file this row is about: the download bitmap for a `source`, the upload bitmap for a `client_address`. A peer the core reports as holding every part comes back all-`true`. A pure A4AF row has no bitmap for this file and omits the key. **`parts` never appears in SSE payloads.**
+`parts` is opt-in because it is one boolean per chunk per client — a multi-TiB file is 100k+ entries each. It is exactly `parts_total_count` entries, and it describes the file this row is about: the download bitmap for a `source`, the upload bitmap for a `client_address`. A client the core reports as holding every part comes back all-`true`. A pure A4AF row has no bitmap for this file and omits the key. **`parts` never appears in SSE payloads.**
 
 The file's own three-state part view is on [`GET /downloads/{hash}`](#get-apiv0downloadshash); combine it with this bitmap to render the desktop's per-source bar.
 
@@ -1029,7 +1029,7 @@ curl -H "Authorization: Bearer $TOKEN" \
 
 **Auth:** `ADMIN`
 
-> `POST` only; a `GET` here answers `405`. A4AF sources are rows of [`GET /downloads/{hash}/clients`](#get-apiv0downloadshashclients--get-apiv0sharedhashclients), carrying the whole peer object rather than a bare ECID, and `a4af_auto` is on the download detail object.
+> `POST` only; a `GET` here answers `405`. A4AF sources are rows of [`GET /downloads/{hash}/clients`](#get-apiv0downloadshashclients--get-apiv0sharedhashclients), carrying the whole client object rather than a bare ECID, and `a4af_auto` is on the download detail object.
 
 Force A4AF source-swapping for this download. Downloads-only.
 
@@ -1042,9 +1042,9 @@ Force A4AF source-swapping for this download. Downloads-only.
 
 Both move sources one way. A third action, `swap_this_auto`, flipped the `a4af_auto` flag and is gone: a flip cannot be retried safely, and it set a field the download object already reports. Set it with [`PATCH /downloads/{hash}`](#patch-apiv0downloadshash) and `{"a4af_auto": true|false}` instead. Sending `swap_this_auto` here is a `400` naming the replacement.
 
-`client_ecid` is optional and valid **only with `swap_this`**, where it narrows the action from every A4AF source of this file to the single named one — the per-peer "Swap to this file" of the desktop client. It must name a client in the current snapshot that is an A4AF source of *this* download; pairing it with `swap_others` is a `400`, because the core has no per-source form of it.
+`client_ecid` is optional and valid **only with `swap_this`**, where it narrows the action from every A4AF source of this file to the single named one — the per-client "Swap to this file" of the desktop client. It must name a client in the current snapshot that is an A4AF source of *this* download; pairing it with `swap_others` is a `400`, because the core has no per-source form of it.
 
-The swap moves the peer between two files' source lists, so an SSE subscriber sees `download_updated` for **both** the peer's former download and this one, plus `client_updated` for the peer itself.
+The swap moves the client between two files' source lists, so an SSE subscriber sees `download_updated` for **both** the client's former download and this one, plus `client_updated` for the client itself.
 
 **Response:** `200 OK` — the post-action A4AF view of this download:
 
@@ -1052,9 +1052,9 @@ The swap moves the peer between two files' source lists, so an SSE subscriber se
 { "a4af_auto": false, "source_ecids": [ 1234, 5678 ] }
 ```
 
-`source_ecids` are the ECIDs of the peers holding this file as an A4AF source, joinable against [`GET /api/v0/clients`](#get-apiv0clients). The array is the post-action state, so a `swap_this` naming a single peer shows up as that ECID having left it. The same peers appear as rows with `"a4af": true` on [`GET /api/v0/downloads/{hash}/clients`](#get-apiv0downloadshashclients--get-apiv0sharedhashclients), which carries the whole peer object rather than a bare ECID.
+`source_ecids` are the ECIDs of the clients holding this file as an A4AF source, joinable against [`GET /api/v0/clients`](#get-apiv0clients). The array is the post-action state, so a `swap_this` naming a single client shows up as that ECID having left it. The same clients appear as rows with `"a4af": true` on [`GET /api/v0/downloads/{hash}/clients`](#get-apiv0downloadshashclients--get-apiv0sharedhashclients), which carries the whole client object rather than a bare ECID.
 
-**Errors:** `400 bad_request` (missing or unknown `action`; `swap_this_auto`, which moved to `PATCH`; a non-integer `client_ecid`; `client_ecid` with the wrong action), `400 amuled_rejected` (the daemon refused the swap — most commonly because the peer is actively sending data, which it will not be swapped away from), `404 not_found` (no download with that hash, or no client with that ECID), `409 conflict` (that client is not an A4AF source of this download), `503 ec_unavailable`.
+**Errors:** `400 bad_request` (missing or unknown `action`; `swap_this_auto`, which moved to `PATCH`; a non-integer `client_ecid`; `client_ecid` with the wrong action), `400 amuled_rejected` (the daemon refused the swap — most commonly because the client is actively sending data, which it will not be swapped away from), `404 not_found` (no download with that hash, or no client with that ECID), `409 conflict` (that client is not an A4AF source of this download), `503 ec_unavailable`.
 
 #### `POST /api/v0/downloads`
 
@@ -1195,24 +1195,26 @@ One entry per cleared hash, in the shared [`results` envelope](#bulk-mutations-a
 
 ---
 
-### Clients (peers)
+### Clients
 
 #### `GET /api/v0/clients`
 
 **Auth:** `GUEST`
 
-Lists the peers amuled is currently exchanging with.
+Lists the clients amuled is currently exchanging with.
 
 **Query parameters:**
 
-- `filter=uploads` — peers we are currently uploading to (`upload_state == "uploading"`).
-- `filter=downloads` — peers we are currently downloading from (`download_state == "downloading"`).
-- `filter=active` — peers that are either uploading or downloading right now.
-- Default (no filter) — every known peer, including queued.
+- `activity=uploading` — clients we are currently uploading to (`upload_state == "uploading"`).
+- `activity=downloading` — clients we are currently downloading from (`download_state == "downloading"`).
+- `activity=active` — clients that are either uploading or downloading right now.
+- Default (no `activity`) — every known client, including queued.
+
+The values are spelled the way `upload_state` / `download_state` spell them, so the parameter and the field it selects on read alike. Any other value is a `400 bad_request`.
 
 ```sh
 curl -s -H "Authorization: Bearer $TOKEN" \
-  "http://$HOST/api/v0/clients?filter=active"
+  "http://$HOST/api/v0/clients?activity=active"
 ```
 
 ```json
@@ -1256,17 +1258,17 @@ curl -s -H "Authorization: Bearer $TOKEN" \
 }
 ```
 
-The last five were originally detail-only and were promoted onto this row (and onto the `client_added` / `client_updated` SSE payloads) so a client rendering a peer list does not have to fan out a detail request per row. `part_progress_percent` is `null`, not a sentinel, when the peer is not a source for anything we are downloading — see the detail section below for what all five mean.
+The last five were originally detail-only and were promoted onto this row (and onto the `client_added` / `client_updated` SSE payloads) so a client rendering a client list does not have to fan out a detail request per row. `part_progress_percent` is `null`, not a sentinel, when the client is not a source for anything we are downloading — see the detail section below for what all five mean.
 
-`ecid` identifies the remote *peer*, not a file — it's the URL key for [`GET /api/v0/clients/{ecid}`](#get-apiv0clientsecid) and the identity carried in `client_removed` SSE payloads. `user_hash` is the peer's stable identity *when published* (peers without SecIdent or in their first session don't have one), so `ecid` is the always-populated handle.
+`ecid` identifies the remote *client*, not a file — it's the URL key for [`GET /api/v0/clients/{ecid}`](#get-apiv0clientsecid) and the identity carried in `client_removed` SSE payloads. `user_hash` is the client's stable identity *when published* (clients without SecIdent or in their first session don't have one), so `ecid` is the always-populated handle.
 
-`upload_file_hash` / `download_file_hash` are the 32-char MD4 hex hashes of the partfile or shared file the peer is currently transferring with — directly resolvable against [`/api/v0/downloads/{hash}`](#get-apiv0downloadshash) (in-progress) or the corresponding entry in [`/api/v0/shared`](#get-apiv0shared) by `.hash`. Either field can be empty when the peer is queued / idle in that direction. `download_file_name` is the filename the peer advertised in `OP_REQFILENAMEANSWER` and is populated only while we're actively downloading from them. `upload_file_name` is the partfile the peer is downloading **from us**, resolved locally against our own partfile list — present only while we're uploading to them.
+`upload_file_hash` / `download_file_hash` are the 32-char MD4 hex hashes of the partfile or shared file the client is currently transferring with — directly resolvable against [`/api/v0/downloads/{hash}`](#get-apiv0downloadshash) (in-progress) or the corresponding entry in [`/api/v0/shared`](#get-apiv0shared) by `.hash`. Either field can be empty when the client is queued / idle in that direction. `download_file_name` is the filename the client advertised in `OP_REQFILENAMEANSWER` and is populated only while we're actively downloading from them. `upload_file_name` is the partfile the client is downloading **from us**, resolved locally against our own partfile list — present only while we're uploading to them.
 
-`software` and `software_version` are locale-independent, per the API's English-only contract. `software` is one of the tokens in the enumerated-fields table below; `software_version` is a free-form string. A peer the daemon could not identify reports `"software": "unknown"` and `"software_version": "unknown"` — a lowercase sentinel, never a daemon-localized string (the daemon's own version formatting is gettext-translated and is deliberately not surfaced here). `reported_os` is the peer's *own* self-reported OS string (raw external data, not normalized by amuled) and is frequently empty, since most clients don't send it.
+`software` and `software_version` are locale-independent, per the API's English-only contract. `software` is one of the tokens in the enumerated-fields table below; `software_version` is a free-form string. A client the daemon could not identify reports `"software": "unknown"` and `"software_version": "unknown"` — a lowercase sentinel, never a daemon-localized string (the daemon's own version formatting is gettext-translated and is deliberately not surfaced here). `reported_os` is the client's *own* self-reported OS string (raw external data, not normalized by amuled) and is frequently empty, since most clients don't send it.
 
-`ident_state` is the peer's secure-identification (SecIdent) state, one of `"not_available"` (the peer does not support SecIdent, or this build has no crypto), `"id_needed"` (its public key is known but the signature exchange has not completed), `"identified"` (verified), `"id_failed"` (signature verification failed), `"bad_guy"` (verified earlier, but currently connecting from a *different* IP than the one it was verified on) or `"unknown"` (state not yet reported for a newly seen peer). `"bad_guy"` is also briefly reported for a legitimate peer that reconnected after an IP change and has not re-identified yet, so treat it as a hint rather than a verdict.
+`ident_state` is the client's secure-identification (SecIdent) state, one of `"not_available"` (the client does not support SecIdent, or this build has no crypto), `"id_needed"` (its public key is known but the signature exchange has not completed), `"identified"` (verified), `"id_failed"` (signature verification failed), `"bad_guy"` (verified earlier, but currently connecting from a *different* IP than the one it was verified on) or `"unknown"` (state not yet reported for a newly seen client). `"bad_guy"` is also briefly reported for a legitimate client that reconnected after an IP change and has not re-identified yet, so treat it as a hint rather than a verdict.
 
-**Enumerated string fields.** Every peer field below carries one of a fixed set of lowercase, locale-independent tokens — the daemon decodes amuled's internal enums server-side so consumers never need the lookup tables. The complete sets:
+**Enumerated string fields.** Every client field below carries one of a fixed set of lowercase, locale-independent tokens — the daemon decodes amuled's internal enums server-side so consumers never need the lookup tables. The complete sets:
 
 | Field | Values |
 |---|---|
@@ -1277,9 +1279,9 @@ The last five were originally detail-only and were promoted onto this row (and o
 | `software` | `emule`, `cdonkey`, `lxmule`, `amule`, `shareaza`, `emule_plus`, `hydranode`, `mldonkey`, `lphant`, `edonkey_hybrid`, `edonkey`, `old_emule`, `compat`, `unknown` |
 | `source_origin` | `server`, `kad`, `source_exchange`, `passive`, `link`, `source_seeds`, `search_result`, `unknown` |
 
-Every one of them falls back to `"unknown"` for a code the daemon does not map, so a client can treat `"unknown"` as its default branch and never has to handle an absent or unexpected token. Note the two distinct sentinels on `obfuscation_state`: `"undefined"` is *the peer has not told us yet*, `"unknown"` is *the daemon received a code it does not recognise*. The authoritative mappings are the `Client*Name()` / `SourceOriginName()` functions in `src/webapi/Refresher.cpp`.
+Every one of them falls back to `"unknown"` for a code the daemon does not map, so a client can treat `"unknown"` as its default branch and never has to handle an absent or unexpected token. Note the two distinct sentinels on `obfuscation_state`: `"undefined"` is *the client has not told us yet*, `"unknown"` is *the daemon received a code it does not recognise*. The authoritative mappings are the `Client*Name()` / `SourceOriginName()` functions in `src/webapi/Refresher.cpp`.
 
-`country_code` is the peer's ISO 3166-1 alpha-2 country code (lowercase, e.g. `"de"`), resolved server-side from the peer IP by the daemon's GeoIP database. It is an empty string when GeoIP is disabled or unsupported by the build, or when the IP does not resolve — render the flag and localized country name client-side from the code. The flag image is served by [`GET /flags/{code}.png`](#get-flagscodepng); the localized name has no endpoint because the browser already has it (`Intl.DisplayNames` with `{ type: "region" }`).
+`country_code` is the client's ISO 3166-1 alpha-2 country code (lowercase, e.g. `"de"`), resolved server-side from the client IP by the daemon's GeoIP database. It is an empty string when GeoIP is disabled or unsupported by the build, or when the IP does not resolve — render the flag and localized country name client-side from the code. The flag image is served by [`GET /flags/{code}.png`](#get-flagscodepng); the localized name has no endpoint because the browser already has it (`Intl.DisplayNames` with `{ type: "region" }`).
 
 **Errors:** `400 bad_request` (unknown filter token), `503 ec_unavailable`.
 
@@ -1289,9 +1291,9 @@ Every one of them falls back to `"unknown"` for a code the daemon does not map, 
 
 **Auth:** `GUEST`
 
-Returns the full detail object for a single peer — every field [`GET /clients`](#get-apiv0clients) returns for that peer, **plus** the detail-only fields below. `{ecid}` is the peer's `ecid` (the EC connection id). Bare object, no list envelope.
+Returns the full detail object for a single client — every field [`GET /clients`](#get-apiv0clients) returns for that client, **plus** the detail-only fields below. `{ecid}` is the client's `ecid` (the EC connection id). Bare object, no list envelope.
 
-`ecid`, not `user_hash`, is the resource key: not every peer has a hash (unidentified / some LowID / eDonkey peers expose an empty one), a hash is not unique among a peer's simultaneous connections, and it is unauthenticated unless the peer uses Secure Identification. `ecid` is always present and unique per live connection. Trade-off: `ecid` is reassigned when amuled restarts, so a detail URL is **not** stable across restarts — use the `user_hash` field for a durable reference.
+`ecid`, not `user_hash`, is the resource key: not every client has a hash (unidentified / some LowID / eDonkey clients expose an empty one), a hash is not unique among a client's simultaneous connections, and it is unauthenticated unless the client uses Secure Identification. `ecid` is always present and unique per live connection. Trade-off: `ecid` is reassigned when amuled restarts, so a detail URL is **not** stable across restarts — use the `user_hash` field for a durable reference.
 
 ```sh
 curl -s -H "Authorization: Bearer $TOKEN" \
@@ -1343,11 +1345,11 @@ curl -s -H "Authorization: Bearer $TOKEN" \
 }
 ```
 
-The detail fields mirror the desktop "Client Details" modal. Five of the fields below — `source_origin`, `parts_offered_count`, `client_mod_name`, `shared_files_browsable` and `part_progress_percent` — are **not** detail-only: they are on the [`GET /clients`](#get-apiv0clients) row and the SSE payload too, and are described here because this is where the rest of their neighbours live. `ed2k_user_id` is the peer's hybrid eD2k id; `high_id` is `true` for a HighID peer (id ≥ `16777216`, i.e. `0x1000000`) and `false` for LowID — the same threshold and the same spelling as `ed2k.high_id` on [`GET /status`](#get-apiv0status), so the value means the same thing on both ends of the API. `server_ip` / `server_port` / `server_name` describe the eD2k server the peer connects through (`server_ip` is `""` when unknown). `kad_port` is non-zero when the peer is reachable on Kad. `source_origin` is how the peer was discovered (values in the enumerated-fields table under [`GET /clients`](#get-apiv0clients)). (`upload_file_name` is part of the base field set — see [`GET /clients`](#get-apiv0clients) above.) `parts_offered_count` is the count of parts the peer holds of the linked file, or `null` when the peer has not reported a part map (see [Unknown values](#unknown-values)); `client_mod_name` is the peer's client-mod string (often `""`); `shared_files_browsable` is `true` when the peer forbids browsing its shared files. `friend` is `true` when the peer is in your friends list (`CUpDownClient::IsFriend()`) — **distinct** from `friend_slot`, which is a *reserved upload slot* granted to a peer and can be set for non-friends. `credit_ratio` is the upload score modifier the GUI labels "DL/UP modifier" (`GetScoreRatio()`). `part_progress_percent` is the peer's completeness of the file we are downloading **from** them (`parts_offered_count` over that file's part count) and is `null` when there is no linked download or the part count is unknown (see [Unknown values](#unknown-values)).
+The detail fields mirror the desktop "Client Details" modal. Five of the fields below — `source_origin`, `parts_offered_count`, `client_mod_name`, `shared_files_browsable` and `part_progress_percent` — are **not** detail-only: they are on the [`GET /clients`](#get-apiv0clients) row and the SSE payload too, and are described here because this is where the rest of their neighbours live. `ed2k_user_id` is the client's hybrid eD2k id; `high_id` is `true` for a HighID client (id ≥ `16777216`, i.e. `0x1000000`) and `false` for LowID — the same threshold and the same spelling as `ed2k.high_id` on [`GET /status`](#get-apiv0status), so the value means the same thing on both ends of the API. `server_ip` / `server_port` / `server_name` describe the eD2k server the client connects through (`server_ip` is `""` when unknown). `kad_port` is non-zero when the client is reachable on Kad. `source_origin` is how the client was discovered (values in the enumerated-fields table under [`GET /clients`](#get-apiv0clients)). (`upload_file_name` is part of the base field set — see [`GET /clients`](#get-apiv0clients) above.) `parts_offered_count` is the count of parts the client holds of the linked file, or `null` when the client has not reported a part map (see [Unknown values](#unknown-values)); `client_mod_name` is the client's client-mod string (often `""`); `shared_files_browsable` is `true` when the client forbids browsing its shared files. `friend` is `true` when the client is in your friends list (`CUpDownClient::IsFriend()`) — **distinct** from `friend_slot`, which is a *reserved upload slot* granted to a client and can be set for non-friends. `credit_ratio` is the upload score modifier the GUI labels "DL/UP modifier" (`GetScoreRatio()`). `part_progress_percent` is the client's completeness of the file we are downloading **from** them (`parts_offered_count` over that file's part count) and is `null` when there is no linked download or the part count is unknown (see [Unknown values](#unknown-values)).
 
 > `friend` and `credit_ratio` ride two EC tags added for this endpoint. A webapi built against a newer core talking to an **older** amuled that doesn't send them degrades gracefully — `friend` reads `false` and `credit_ratio` reads `0`.
 
-**Errors:** `400 bad_request` (`{ecid}` is not a non-negative integer), `404 not_found` (no peer with that ecid in the current snapshot), `405 method_not_allowed` (non-GET), `503 ec_unavailable`.
+**Errors:** `400 bad_request` (`{ecid}` is not a non-negative integer), `404 not_found` (no client with that ecid in the current snapshot), `405 method_not_allowed` (non-GET), `503 ec_unavailable`.
 
 ---
 
@@ -1355,12 +1357,12 @@ The detail fields mirror the desktop "Client Details" modal. Five of the fields 
 
 **Auth:** `ADMIN`
 
-Browse a peer's shared file list — the API equivalent of "View Files" in the GUI. `{ecid}` is the peer's `ecid`. amuled opens (or reuses) a direct client-to-client connection to that peer and asks it to enumerate its shared directories and files.
+Browse a client's shared file list — the API equivalent of "View Files" in the GUI. `{ecid}` is the client's `ecid`. amuled opens (or reuses) a direct client-to-client connection to that client and asks it to enumerate its shared directories and files.
 
-The browse runs **asynchronously**: the peer answers over the network, one directory at a time, and a HighID/reachable peer may take seconds while a LowID peer needs a server callback or Kad first. So this endpoint does **not** return the files — it returns a `search_id` and the results flow through the **search machinery**, exactly like a query search:
+The browse runs **asynchronously**: the client answers over the network, one directory at a time, and a HighID/reachable client may take seconds while a LowID client needs a server callback or Kad first. So this endpoint does **not** return the files — it returns a `search_id` and the results flow through the **search machinery**, exactly like a query search:
 
-- `GET /api/v0/search/{id}/results` reads the accumulated files as they arrive (standard search-result fields, plus `directory` — the folder each file sits in inside the peer's share). The browse also appears in [`GET /api/v0/search`](#get-apiv0search) with `kind: "browse"` and the browsed peer's `client_ecid`.
-- The refresher advances `search_progress` for this `search_id` while the browse is live, and completion arrives as the terminal `search_progress` frame with `"state": "finished"` — when the peer's list is complete or the browse fails (denied / peer unreachable / connection lost). There is **no** `search_finished` event; a client waiting for one waits forever. A denied or failed browse finishes with zero results, so there is no distinct error event either.
+- `GET /api/v0/search/{id}/results` reads the accumulated files as they arrive (standard search-result fields, plus `directory` — the folder each file sits in inside the client's share). The browse also appears in [`GET /api/v0/search`](#get-apiv0search) with `kind: "browse"` and the browsed client's `client_ecid`.
+- The refresher advances `search_progress` for this `search_id` while the browse is live, and completion arrives as the terminal `search_progress` frame with `"state": "finished"` — when the client's list is complete or the browse fails (denied / client unreachable / connection lost). There is **no** `search_finished` event; a client waiting for one waits forever. A denied or failed browse finishes with zero results, so there is no distinct error event either.
 
 Reusing the search id-space means one poll loop and one SSE stream cover both queries and browses; a client tells them apart by remembering which `search_id` it started with which verb.
 
@@ -1369,12 +1371,12 @@ curl -s -X POST -H "Authorization: Bearer $TOKEN" \
   "http://$HOST/api/v0/clients/4382/shared_files"
 ```
 
-**Response:** `202 Accepted`, with a `Location: /api/v0/search/{search_id}` header and the browse as the body -- the same row [`GET /search`](#get-apiv0search) lists, with `kind: "browse"` and `query` holding the peer's name:
+**Response:** `202 Accepted`, with a `Location: /api/v0/search/{search_id}` header and the browse as the body -- the same row [`GET /search`](#get-apiv0search) lists, with `kind: "browse"` and `query` holding the client's name:
 
 ```json
 {
   "search_id":   17,
-  "query":       "some peer",
+  "query":       "some client",
   "kind":        "browse",
   "state":       "running",
   "client_ecid": null,
@@ -1382,11 +1384,11 @@ curl -s -X POST -H "Authorization: Bearer $TOKEN" \
 }
 ```
 
-`client_ecid` is `null` in this reply even though you addressed the peer by ecid: the row is built locally before the daemon has reported anything about the browse, and `client_ecid` is one of the fields it fills in. [`GET /search`](#get-apiv0search) carries the peer's ecid for the same browse from the next refresher tick onward.
+`client_ecid` is `null` in this reply even though you addressed the client by ecid: the row is built locally before the daemon has reported anything about the browse, and `client_ecid` is one of the fields it fills in. [`GET /search`](#get-apiv0search) carries the client's ecid for the same browse from the next refresher tick onward.
 
-A browse the daemon cannot even start — a LowID peer it has no way to call back, for instance — is reported as `finished` immediately rather than left pending: no connection is attempted, so there is nothing to wait for. It carries no results, the same as a browse the peer denied.
+A browse the daemon cannot even start — a LowID client it has no way to call back, for instance — is reported as `finished` immediately rather than left pending: no connection is attempted, so there is nothing to wait for. It carries no results, the same as a browse the client denied.
 
-**Idempotent while a browse is running.** Asking again for a peer that is already being browsed returns **the same `search_id`** rather than starting a second browse — amuled will not re-ask a peer that is still answering, so a second id would name a browse that never happens. Two clicks therefore leave one browse, one id and one entry on [`GET /api/v0/search`](#get-apiv0search). Once that browse has settled, a fresh request starts a new one with a new id.
+**Idempotent while a browse is running.** Asking again for a client that is already being browsed returns **the same `search_id`** rather than starting a second browse — amuled will not re-ask a client that is still answering, so a second id would name a browse that never happens. Two clicks therefore leave one browse, one id and one entry on [`GET /api/v0/search`](#get-apiv0search). Once that browse has settled, a fresh request starts a new one with a new id.
 
 Status `202 Accepted` — the browse was started, not completed. Then poll:
 
@@ -1395,7 +1397,7 @@ curl -s -H "Authorization: Bearer $TOKEN" \
   "http://$HOST/api/v0/search/17/results"
 ```
 
-**Errors:** `400 bad_request` (`{ecid}` is not a non-negative integer), `403 forbidden` (guest token — browsing is `ADMIN`-only), `404 not_found` (no peer with that ecid), `405 method_not_allowed` (non-POST), `502 amuled_rejected` (core accepted the request but returned no `search_id`), `503 ec_unavailable`.
+**Errors:** `400 bad_request` (`{ecid}` is not a non-negative integer), `403 forbidden` (guest token — browsing is `ADMIN`-only), `404 not_found` (no client with that ecid), `405 method_not_allowed` (non-POST), `502 amuled_rejected` (core accepted the request but returned no `search_id`), `503 ec_unavailable`.
 
 ---
 
@@ -1405,9 +1407,9 @@ curl -s -H "Authorization: Bearer $TOKEN" \
 
 **Auth:** `GUEST`
 
-Lists every peer the daemon has ever exchanged data with, from its credit store.
+Lists every client the daemon has ever exchanged data with, from its credit store.
 
-Distinct from [`GET /clients`](#get-apiv0clients), which lists the peers connected **right now**. The two differ in identity as well as content: a live client is keyed by `ecid`, which is meaningful only within one daemon process, while a known client is keyed by `user_hash` and survives daemon restarts. Correlate the two on `user_hash`; the `online` field says whether a given record has a live counterpart at this moment.
+Distinct from [`GET /clients`](#get-apiv0clients), which lists the clients connected **right now**. The two differ in identity as well as content: a live client is keyed by `ecid`, which is meaningful only within one daemon process, while a known client is keyed by `user_hash` and survives daemon restarts. Correlate the two on `user_hash`; the `online` field says whether a given record has a live counterpart at this moment.
 
 Standard [list envelope](#list-pagination-and-sorting) under the `known_clients` key, with `limit` / `offset` / `sort` / `order`.
 
@@ -1421,7 +1423,7 @@ curl -s -H "Authorization: Bearer $TOKEN" \
   "known_clients": [
     {
       "user_hash": "a1b2c3d4e5060e708090a0b0c0d06f00",
-      "name": "example-peer",
+      "name": "example-client",
       "ip": "192.0.2.10",
       "port": 4665,
       "kad_port": 4675,
@@ -1445,25 +1447,25 @@ curl -s -H "Authorization: Bearer $TOKEN" \
 | Field | Notes |
 |---|---|
 | `user_hash` | 32-char lowercase MD4. The identity; join with `/clients`. |
-| `name` | Peer-chosen name. Absent when never recorded. |
-| `ip`, `port`, `kad_port` | Last address the peer was seen at. Absent together. |
+| `name` | Client-chosen name. Absent when never recorded. |
+| `ip`, `port`, `kad_port` | Last address the client was seen at. Absent together. |
 | `country_code` | ISO 3166-1 alpha-2, lowercase, resolved by the daemon's GeoIP. Absent when GeoIP is off or the address does not resolve. Artwork: [`GET /flags/{code}.png`](#get-flagscodepng). |
 | `software`, `version` | Same tokens `GET /clients` uses. Absent together. |
-| `source_origin` | How the peer was first found — `server`, `kad`, `source_exchange`, `passive`, … |
+| `source_origin` | How the client was first found — `server`, `kad`, `source_exchange`, `passive`, … |
 | `obfuscation` | Protocol-obfuscation state as of the last session. |
 | `uploaded_bytes_total`, `downloaded_bytes_total` | Lifetime bytes, from the credit record. Always present. |
-| `last_seen` | Unix seconds. Always present. For a peer that is connected this is *now* — it is being seen — so the connected records are the most recent in the store under `sort=last_seen&order=desc`. A peer that left during the current tick carries the same timestamp and ties with them; ties keep a stable order across requests. |
+| `last_seen` | Unix seconds. Always present. For a client that is connected this is *now* — it is being seen — so the connected records are the most recent in the store under `sort=last_seen&order=desc`. A client that left during the current tick carries the same timestamp and ties with them; ties keep a stable order across requests. |
 | `first_seen`, `sessions` | Present together, and only for a record the daemon holds metadata for. |
-| `online` | Whether this peer is connected right now, correlated by `user_hash`. |
+| `online` | Whether this client is connected right now, correlated by `user_hash`. |
 
-**Optional fields are omitted, never emitted empty.** A record written before the daemon kept per-peer metadata carries only the hash, the totals and `last_seen`; the rest are absent so a consumer can tell "never recorded" from "recorded as empty". On a long-lived node most records are of that kind.
+**Optional fields are omitted, never emitted empty.** A record written before the daemon kept per-client metadata carries only the hash, the totals and `last_seen`; the rest are absent so a consumer can tell "never recorded" from "recorded as empty". On a long-lived node most records are of that kind.
 
-The store is read from the daemon **once**, on the first request, and maintained from there: every refresher tick folds the connected peers back in, so later requests never touch EC at all. That is sound rather than a shortcut — a record whose peer is not connected cannot change, since credit totals only move during a transfer and `last_seen` is written at disconnect. What the maintenance covers:
+The store is read from the daemon **once**, on the first request, and maintained from there: every refresher tick folds the connected clients back in, so later requests never touch EC at all. That is sound rather than a shortcut — a record whose client is not connected cannot change, since credit totals only move during a transfer and `last_seen` is written at disconnect. What the maintenance covers:
 
-- a peer that connects is added, with `first_seen` and `sessions` set to what the daemon recorded when it said hello;
-- a connected peer's `online`, `uploaded_bytes_total` and `downloaded_bytes_total` track the live client state;
-- a bare record gains its name, address, software and origin once its peer identifies;
-- a connected peer's `last_seen` is now, and a peer that leaves has `online` cleared with `last_seen` stamped at the moment it went.
+- a client that connects is added, with `first_seen` and `sessions` set to what the daemon recorded when it said hello;
+- a connected client's `online`, `uploaded_bytes_total` and `downloaded_bytes_total` track the live client state;
+- a bare record gains its name, address, software and origin once its client identifies;
+- a connected client's `last_seen` is now, and a client that leaves has `online` cleared with `last_seen` stamped at the moment it went.
 
 The cost is one EC roundtrip per amuleapi process, and the store stays resident from first use.
 
@@ -1477,7 +1479,7 @@ The cost is one EC roundtrip per amuleapi process, and the store stays resident 
 
 **Auth:** `GUEST`
 
-Lists every file the local node is sharing. The `sources.complete` counter is amuled's estimate of how many peers in the swarm hold the file complete.
+Lists every file the local node is sharing. The `sources.complete` counter is amuled's estimate of how many clients in the swarm hold the file complete.
 
 ```sh
 curl -s -H "Authorization: Bearer $TOKEN" "http://$HOST/api/v0/shared"
@@ -1518,9 +1520,9 @@ curl -s -H "Authorization: Bearer $TOKEN" "http://$HOST/api/v0/shared"
 }
 ```
 
-`uploaded_bytes_session` / `uploaded_bytes_total` are bytes uploaded during the current amuled process vs over the file's lifetime. `requests` counts how many peers have asked for the file; `accepts` counts how many of those requests were granted an upload slot. The `session` counters reset on amuled restart; `total` is persisted in `known.met`.
+`uploaded_bytes_session` / `uploaded_bytes_total` are bytes uploaded during the current amuled process vs over the file's lifetime. `requests` counts how many clients have asked for the file; `accepts` counts how many of those requests were granted an upload slot. The `session` counters reset on amuled restart; `total` is persisted in `known.met`.
 
-`upload_speed_bps` is the file's current combined upload rate in bytes/sec (summed over the peers it is uploading to), and `uploading_client_count` is how many peers it is actively uploading to right now — together the "is this file being seeded" signal, the upload-side analogue of the `/downloads` speed + transferring-source counts. Subtract `uploading_client_count` from the queued-client count (`upload_queue_count`, on the detail view) to show `uploading / queued`. Both are live and refresh every tick. `last_upload_at` is the unix timestamp of the last time data was sent for the file, and `shared_since_at` is when the file was completed or first shared; both are persisted in `known.met` and are `null` when unknown: a file that has never uploaded, or a `known.met` entry written before these fields existed.
+`upload_speed_bps` is the file's current combined upload rate in bytes/sec (summed over the clients it is uploading to), and `uploading_client_count` is how many clients it is actively uploading to right now — together the "is this file being seeded" signal, the upload-side analogue of the `/downloads` speed + transferring-source counts. Subtract `uploading_client_count` from the queued-client count (`upload_queue_count`, on the detail view) to show `uploading / queued`. Both are live and refresh every tick. `last_upload_at` is the unix timestamp of the last time data was sent for the file, and `shared_since_at` is when the file was completed or first shared; both are persisted in `known.met` and are `null` when unknown: a file that has never uploaded, or a `known.met` entry written before these fields existed.
 
 `priority` is the upload priority — `"very_low"` / `"low"` / `"normal"` / `"high"` / `"release"` — and `priority_auto` is `true` when amuled is deriving that level automatically from the upload queue. This mirrors the `/downloads` shape (base `priority` + separate `priority_auto` flag); on an auto file `priority` reports the current derived level, not the literal string `"auto"`. For a file that is both downloading and shared this upload priority is independent of the download priority reported by [`GET /api/v0/downloads`](#get-apiv0downloads).
 
@@ -1562,7 +1564,7 @@ curl -s -H "Authorization: Bearer $TOKEN" \
 
 `hashed_part_count` comes through from the list item; pair it with `parts_total_count` here for a percentage.
 
-`parts[].sources` is how many peers currently requesting this file hold that part — an **availability** measure, not a progress one. A shared file is fully local by definition, so a part with `"sources": 0` means no other peer has it and you are its only source. Counts saturate at `255`.
+`parts[].sources` is how many clients currently requesting this file hold that part — an **availability** measure, not a progress one. A shared file is fully local by definition, so a part with `"sources": 0` means no other client has it and you are its only source. Counts saturate at `255`.
 
 This is deliberately detail-only. A 100 GB file has ~10 800 parts, so carrying the array on [`GET /shared`](#get-apiv0shared) or in `shared_updated` SSE events would multiply that across the whole share on every tick — the same reason `progress.parts` is absent from the downloads list. `shared_updated` events are unaffected by source-count changes.
 
@@ -1852,7 +1854,7 @@ Send a bare priority level to pin it (the file's `priority_auto` becomes `false`
 }
 ```
 
-`country_code` is the ISO 3166-1 alpha-2 code (lowercase, e.g. `"de"`) of the server host, resolved server-side from the server IP by the daemon's GeoIP database — same semantics and empty-string fallback as the peer `country_code` on `/clients`, and the same artwork route, [`GET /flags/{code}.png`](#get-flagscodepng).
+`country_code` is the ISO 3166-1 alpha-2 code (lowercase, e.g. `"de"`) of the server host, resolved server-side from the server IP by the daemon's GeoIP database — same semantics and empty-string fallback as the client `country_code` on `/clients`, and the same artwork route, [`GET /flags/{code}.png`](#get-flagscodepng).
 
 `file_count` is how many files the server indexes. `soft_file_limit` and `hard_file_limit` are something else entirely: the per-user publishing limits the server advertises. Below the soft limit a client may publish every file it shares, between soft and hard only its rarest, above the hard limit nothing. Both arrive only once the server has answered a UDP status request, so **`0` means "not reported yet", not "the limit is zero"** — render it blank rather than as a number, the way the desktop's Soft Files / Hard Files columns do. `user_count`, `max_user_count` and `file_count` share that sentinel.
 
@@ -1985,7 +1987,7 @@ The URL is **persisted** into the `servers.update_url` preference, so a subseque
 
 The friends list amuled persists to `emfriends.met`. The daemon ships the whole list inside the update every client already receives, so `GET /friends` costs no roundtrip of its own.
 
-`{ecid}` is the friend's own id, distinct from the peer ECIDs on `/clients`. Like every ECID it does **not** survive an `amuled` restart — use `user_hash` as the durable reference where a friend has one. A friend added by address alone has no hash.
+`{ecid}` is the friend's own id, distinct from the client ECIDs on `/clients`. Like every ECID it does **not** survive an `amuled` restart — use `user_hash` as the durable reference where a friend has one. A friend added by address alone has no hash.
 
 #### `GET /api/v0/friends`
 
@@ -2011,7 +2013,7 @@ The friends list amuled persists to `emfriends.met`. The daemon ships the whole 
 }
 ```
 
-`client_ecid` is the live peer this friend is currently linked to, joinable against [`GET /api/v0/clients`](#get-apiv0clients), and `0` when the friend is offline — `online` is the convenience form of that test. `user_hash` is `""` for a friend added by address only, and `ip` is `""` for a zero address.
+`client_ecid` is the live client this friend is currently linked to, joinable against [`GET /api/v0/clients`](#get-apiv0clients), and `0` when the friend is offline — `online` is the convenience form of that test. `user_hash` is `""` for a friend added by address only, and `ip` is `""` for a zero address.
 
 `friend_slot` reads `false` against a daemon predating the tag that carries it, the same way `friend` and `credit_ratio` degrade on `/clients`.
 
@@ -2023,7 +2025,7 @@ The friends list amuled persists to `emfriends.met`. The daemon ships the whole 
 
 Two mutually exclusive body forms.
 
-Promote a connected peer:
+Promote a connected client:
 
 ```json
 { "client_ecid": 4382 }
@@ -2069,7 +2071,7 @@ Only one friend can hold the slot at a time, so granting it clears it on whoever
 
 Browse a friend's shared files. The friend-addressed twin of [`POST /api/v0/clients/{ecid}/shared_files`](#post-apiv0clientsecidshared_files), and more capable: a friend record carries a stored address, so the daemon can browse a friend who is **not currently connected**, which the clients route cannot do.
 
-**Response:** `202 Accepted`, with a `Location` header and the browse row as the body, exactly as on the clients route. Poll [`GET /api/v0/search/{id}/results`](#get-apiv0searchidresults) with the `search_id` it carries. Idempotent while a browse of that peer is running, exactly as on the clients route.
+**Response:** `202 Accepted`, with a `Location` header and the browse row as the body, exactly as on the clients route. Poll [`GET /api/v0/search/{id}/results`](#get-apiv0searchidresults) with the `search_id` it carries. Idempotent while a browse of that client is running, exactly as on the clients route.
 
 **Errors:** `403 forbidden`, `404 not_found`, `502 amuled_rejected`, `503 ec_unavailable`.
 
@@ -2438,7 +2440,7 @@ Two side effects are worth planning for. The URL is **persisted** into the `kad.
 
 **Auth:** `GUEST`
 
-Standalone view of the Kad subtree from `/status`, plus the detail fields the status rollup omits (`node_id`, `firewalled_udp`, `lan_mode`, your `public_ip`, the `indexed` Kad-store counters, and `buddy` contact info for low-ID peers). Together with `GET /api/v0/preferences` (for the TCP/UDP port numbers the firewalled messages quote) this covers every row of the desktop client's **Networks → Kad Info** panel.
+Standalone view of the Kad subtree from `/status`, plus the detail fields the status rollup omits (`node_id`, `firewalled_udp`, `lan_mode`, your `public_ip`, the `indexed` Kad-store counters, and `buddy` contact info for low-ID clients). Together with `GET /api/v0/preferences` (for the TCP/UDP port numbers the firewalled messages quote) this covers every row of the desktop client's **Networks → Kad Info** panel.
 
 ```json
 {
@@ -2461,14 +2463,14 @@ Standalone view of the Kad subtree from `/status`, plus the detail fields the st
 | `node_id` | string | This node's own 128-bit Kademlia id, 32 lowercase hex characters (the desktop panel shows the same value uppercase). `""` while Kad is not running, which is exactly when `state` is `disabled`. Persisted by the daemon, so unlike the session-scoped ECIDs and the server-assigned eD2k id it is stable across restarts — the one identifier for the local node a consumer can key on. It is a DHT routing key, not a credential: every Kad contact the daemon talks to learns it. |
 | `connected_since_at` | int | Unix seconds of the most recent Kad connect, the same value `GET /api/v0/status` reports as `kad.connected_since`. `0` when not connected, so gate on `state` rather than trusting a `0`. |
 | `public_ip` | string | This node's externally-visible IPv4, as a remote Kad contact reported it back. Two "not known" cases, both matching what the desktop panel's *IP address* row shows: `""` while Kad is not connected (the daemon sends the field only then), and `0.0.0.0` while connected but not yet told its own address by any contact. **Two distinct "unknown" sentinels, one of them a syntactically valid address**: a consumer that only checks for `""` will treat `0.0.0.0` as a real IP. Distinct from `preferences.connection.bind_address`, which is the local interface the daemon binds to. Named `public_ip` rather than `ip` because `buddy.ip` in the same payload belongs to somebody else. |
-| `firewalled_tcp` | bool \| null | Whether this node is firewalled for **TCP**. The verdict is a **vote**: two distinct peers must confirm reachability by opening an incoming TCP connection carrying `OP_KAD_FWTCPCHECK_ACK` before it clears to `false`. With no verdict yet it reads **`true`**, the conservative assumption. During an IP recheck it freezes at its previous value rather than momentarily reporting a false LowID. **`null` unless `state` is `connected`** - the underlying bit outlives a disconnect, so this used to report a reachability verdict for a network the daemon was not on. Named for the transport because it is one half of a pair, not an overall verdict that `firewalled_udp` refines. |
+| `firewalled_tcp` | bool \| null | Whether this node is firewalled for **TCP**. The verdict is a **vote**: two distinct clients must confirm reachability by opening an incoming TCP connection carrying `OP_KAD_FWTCPCHECK_ACK` before it clears to `false`. With no verdict yet it reads **`true`**, the conservative assumption. During an IP recheck it freezes at its previous value rather than momentarily reporting a false LowID. **`null` unless `state` is `connected`** - the underlying bit outlives a disconnect, so this used to report a reachability verdict for a network the daemon was not on. Named for the transport because it is one half of a pair, not an overall verdict that `firewalled_udp` refines. |
 | `firewalled_udp` | bool \| null | Whether this node is firewalled for **UDP**, measured by an entirely different mechanism: a directed test with its own state, which can also declare firewalled **by timeout** after six minutes. **`null` unless `state` is `connected`.** It previously read `false` while Kad was down, which was the absence of a measurement dressed as "UDP is open" - the asymmetry with `firewalled_tcp`'s `true` made the pair actively misleading. Both are `null` now, so there is nothing to misread. |
 | `lan_mode` | bool \| null | `true` when the daemon is running Kad in LAN mode. It **forces both firewalled fields to `false`** regardless of any measurement, which is why it belongs beside them: a `false` on either flag is only meaningful once you have checked this one. `null` unless `state` is `connected`. |
 | `network.user_count` / `.files` | int \| null | Network-wide estimates for the whole Kad network, not counts belonging to this node. The same values `GET /api/v0/status` reports under `kad.network`. **`null` unless `state` is `connected`** - they used to keep their last estimate through a disconnect, indistinguishable from a live reading. |
 | `network.node_count` | int \| null | **This node's own routing table size** - how many Kad contacts it currently holds - *not* a network-wide figure like the two above. Saturates at 65535 (the daemon counts it in a `uint16`). **`null` unless `state` is `connected`**: routing contacts outlive the disconnect, so this was measured at `2` on a fully stopped Kad. |
 | `indexed.sources` / `.keywords` / `.notes` | int \| null | Kad-store counters: how many entries this node is holding for the network as a DHT participant. `null` unless `state` is `connected` - they previously read `0`, which is a real count and indistinguishable from an idle but connected node. |
 | `indexed.load_percent` | int \| null | A **load figure, not a count**, despite sitting beside three counts: it is the Kad store's fill level. `null` unless `state` is `connected`, on the same gate as the three counters above. |
-| `buddy.state` | string \| null | LowID-buddy state for NAT-traversal peers: `no_buddy` / `connecting` / `connected` (`unknown` only if the daemon ever ships a value outside its own enum). **`null` unless `state` is `connected`**, along with `buddy.ip` / `buddy.port`; it previously read `no_buddy`, which is a real state rather than the absence of one. While connected with no buddy, `ip` / `port` are `0.0.0.0` / `0`. |
+| `buddy.state` | string \| null | LowID-buddy state for NAT-traversal clients: `no_buddy` / `connecting` / `connected` (`unknown` only if the daemon ever ships a value outside its own enum). **`null` unless `state` is `connected`**, along with `buddy.ip` / `buddy.port`; it previously read `no_buddy`, which is a real state rather than the absence of one. While connected with no buddy, `ip` / `port` are `0.0.0.0` / `0`. |
 
 ---
 
@@ -2737,7 +2739,7 @@ Each point has `t` (ISO-8601 UTC), `at` (unix seconds) and `value`, spaced by `i
 
 `max_points` is how many points this daemon can answer with before it starts repeating records; `points` is never longer than it. It is not a constant across daemons, so a client that wants the deepest window available should read it rather than assume 1800.
 
-**`connections` only:** each point also carries `active_downloads` (peers being pulled from) and `active_uploads` (peers being pushed to), alongside `value`, which stays the total connection count. Against an amuled that does not report them the two keys are **omitted entirely** rather than sent as `0`, so "not reported" is distinguishable from "nothing was transferring". They are all-or-nothing: either every point in a response has them or none does.
+**`connections` only:** each point also carries `active_downloads` (clients being pulled from) and `active_uploads` (clients being pushed to), alongside `value`, which stays the total connection count. Against an amuled that does not report them the two keys are **omitted entirely** rather than sent as `0`, so "not reported" is distinguishable from "nothing was transferring". They are all-or-nothing: either every point in a response has them or none does.
 
 **`session`** carries this-session figures so a client doesn't need a separate roundtrip:
 
@@ -2776,19 +2778,19 @@ Lists every search amuled currently holds — including ones started by a **diff
 
 This is a list endpoint like the others: it takes `?limit`, `?offset`, `?sort` and `?order`, and carries the same `total` / `offset` / `limit` trio. See [List pagination and sorting](#list-pagination-and-sorting); the sort keys are `search_id`, `query`, `started_at` and `result_count`.
 
-`id` is the value that fills `{id}` on every search-scoped path: [`GET /search/{id}/results`](#get-apiv0searchidresults) to read its hits, [`POST /search/{id}/stop`](#post-apiv0searchidstop) to stop it, [`DELETE /search/{id}`](#delete-apiv0searchid) to free it. `kind` is `"local"` | `"global"` | `"kad"` | `"browse"`. The first three are the vocabulary `POST /search`'s `type` accepts; `"browse"` is reported only, for a "View Files" listing of one peer's share, which is started through the client endpoints rather than by a query. `state` is `"running"` | `"finished"` | `"idle"`, same vocabulary and meaning as `GET /search/{id}/results`'s `progress.state`.
+`id` is the value that fills `{id}` on every search-scoped path: [`GET /search/{id}/results`](#get-apiv0searchidresults) to read its hits, [`POST /search/{id}/stop`](#post-apiv0searchidstop) to stop it, [`DELETE /search/{id}`](#delete-apiv0searchid) to free it. `kind` is `"local"` | `"global"` | `"kad"` | `"browse"`. The first three are the vocabulary `POST /search`'s `type` accepts; `"browse"` is reported only, for a "View Files" listing of one client's share, which is started through the client endpoints rather than by a query. `state` is `"running"` | `"finished"` | `"idle"`, same vocabulary and meaning as `GET /search/{id}/results`'s `progress.state`.
 
-For a `"browse"` entry, `state` and the results endpoint's `progress.percent` come from the browse's own lifecycle rather than from a query's: the request being sent is `"running"`, and the peer having answered, denied the request, or disconnected mid-list is `"finished"` — a browse is never reported as `"idle"`. `percent` is the share of the peer's directory list received so far, so it climbs while the listing streams in rather than jumping straight from `0` to `100`.
+For a `"browse"` entry, `state` and the results endpoint's `progress.percent` come from the browse's own lifecycle rather than from a query's: the request being sent is `"running"`, and the client having answered, denied the request, or disconnected mid-list is `"finished"` — a browse is never reported as `"idle"`. `percent` is the share of the client's directory list received so far, so it climbs while the listing streams in rather than jumping straight from `0` to `100`.
 
-Browsing a peer that is **already being browsed** returns the id already in flight rather than starting a second one, so this list holds one entry per browsed peer, not one per request.
+Browsing a client that is **already being browsed** returns the id already in flight rather than starting a second one, so this list holds one entry per browsed client, not one per request.
 
-`query` is the daemon's name for the search. For a `"browse"` that is **the peer's nickname**, not a query string — a browse has no query. `client_ecid` is the browsed peer's ecid and is present **only** on browse entries, so a consumer can tell whose share is being listed and cross-reference [`GET /clients`](#get-apiv0clients); it is omitted entirely on an ordinary search.
+`query` is the daemon's name for the search. For a `"browse"` that is **the client's nickname**, not a query string — a browse has no query. `client_ecid` is the browsed client's ecid and is present **only** on browse entries, so a consumer can tell whose share is being listed and cross-reference [`GET /clients`](#get-apiv0clients); it is omitted entirely on an ordinary search.
 
 `started_at` is the Unix second amuleapi started the search, and it is the **only recency signal on this list**: entries arrive ordered by `search_id`, and id order is not start order, because Kad search ids carry a high-bit mask and therefore always sort above eD2k ones. Ask for `?sort=started_at&order=desc` when you need "the newest search".
 
 It is **omitted** for any search this `amuleapi` process did not start itself — one begun by another client, by the desktop GUI, or restored from the daemon's on-disk ring after a restart. The daemon ships no timestamp of its own, so there is nothing to report for those; treat a missing `started_at` as *unknown*, not as oldest.
 
-`result_count` is how many results the daemon currently holds for that search. It matches the `total` that [`GET /search/{id}/results`](#get-apiv0searchidresults) reports for the same id once the search has finished; while one is still running the two can differ by a fetch, because this number comes straight off the daemon's live index and `total` counts what amuleapi last pulled into its cache. It counts top-level hits only: grouped alternative filenames ride their parent's `children[]` and are not counted separately. On a `"browse"` entry it is the files received from the peer so far. Like every other field on this listing it is a snapshot at request time, so a running search's count climbs between calls.
+`result_count` is how many results the daemon currently holds for that search. It matches the `total` that [`GET /search/{id}/results`](#get-apiv0searchidresults) reports for the same id once the search has finished; while one is still running the two can differ by a fetch, because this number comes straight off the daemon's live index and `total` counts what amuleapi last pulled into its cache. It counts top-level hits only: grouped alternative filenames ride their parent's `children[]` and are not counted separately. On a `"browse"` entry it is the files received from the client so far. Like every other field on this listing it is a snapshot at request time, so a running search's count climbs between calls.
 
 It exists so a client that adopts the whole list and fetches each search's results lazily — on first activation of a tab, rather than all at once at load — has a number to label an unopened tab with. It is **omitted**, not zeroed, when the daemon does not report it: a daemon older than this field sends nothing, and "does not report counts" has to stay distinguishable from "this search found nothing". Same rule as `client_ecid` and `started_at` above.
 
@@ -2887,9 +2889,9 @@ amuled keeps a bounded ring of recent searches (20). A search evicted from that 
 
 Each result carries `sources` as a nested `{total, complete}` object — `total` is the swarm size amuled reports and `complete` is how many of those hold the file complete. `already_downloaded` is `true` when you are currently downloading the file or already have it completed/shared; it is `false` for a fresh result and for one you have canceled/removed (a canceled result is re-downloadable, so it does not read as held). `rating` is amuled's aggregated quality rating (`0` when unrated). `status` is this result's download status on your node — `"new"` / `"downloaded"` / `"queued"` / `"canceled"` / `"queued_canceled"`. `type` is the file-type token derived from the filename extension (same tokens as the shared-detail [`file_type`](#get-apiv0sharedhash), e.g. `"videos"` / `"audio"`; `""` when the name has no extension). `media` is the audio/video [media metadata](#media-metadata) object (same shape as the file-detail endpoints), and is **`null`** for a hit that carries no metadata (most global/Kad results), matching the blank Length/Bitrate/Codec columns in the desktop search list. The key is always present. **Unlike `media` on `GET /downloads/{hash}` and `GET /shared/{hash}`, which amuled probed locally, `media` on a search result is whatever the responding server advertised.** It is not verified against the file and can contradict it — a `.pdf` reporting a runtime and a video codec is a real observed result — so treat it as a hint, not as probed metadata.
 
-`directory` is the folder this file sits in **inside a browsed peer's share** — the desktop search list's *Directories* column. It is populated only for results filed from a peer's shared-file listing (see [peer browse](#post-apiv0clientsecidshared_files)) and is `""` on every ordinary server/Kad hit, which never carries it. It is per-result rather than per-search: two copies of one file in different folders of the same share group under a single parent and each keeps its own folder, exactly as the desktop shows them, which is why `children[]` entries carry it too.
+`directory` is the folder this file sits in **inside a browsed client's share** — the desktop search list's *Directories* column. It is populated only for results filed from a client's shared-file listing (see [client browse](#post-apiv0clientsecidshared_files)) and is `""` on every ordinary server/Kad hit, which never carries it. It is per-result rather than per-search: two copies of one file in different folders of the same share group under a single parent and each keeps its own folder, exactly as the desktop shows them, which is why `children[]` entries carry it too.
 
-`search_id` and `query` identify the search these results belong to. `search_id` echoes the path so clients can key a view on the response alone; `query` is what the search was started with, so a client that adopted an id from [`GET /search`](#get-apiv0search) can label it without a second call. For a **browse**, `query` is the peer's nickname rather than a query string. `query` is `""` only for a search discovered before amuled reported a name for it.
+`search_id` and `query` identify the search these results belong to. `search_id` echoes the path so clients can key a view on the response alone; `query` is what the search was started with, so a client that adopted an id from [`GET /search`](#get-apiv0search) can label it without a second call. For a **browse**, `query` is the client's nickname rather than a query string. `query` is `""` only for a search discovered before amuled reported a name for it.
 
 `alternate_names` is the result-grouping tree: amuled collapses hits that are the **same file** (same ed2k hash **and** size) but advertised under **different filenames** into one parent row, and `children[]` holds the alternative names. Each child carries the parent's `hash` (that's why they group), its own `sources`, and a distinct `ecid` — pass that `ecid` to [`POST /search/results/{hash}/download`](#post-apiv0searchresultshashdownload) to download the file **under that chosen filename**. `alternate_names` is always present and is an empty array for a hit seen under a single name. The top-level `results[]` contains parents only — a child never appears as its own top-level entry.
 
@@ -2931,7 +2933,7 @@ Freeing a search delivers a [`search_closed`](EVENTS.md#search_closed) event to 
 
 **Auth:** `ADMIN`
 
-Widens a running **Kad** search — the desktop's **"More"** button. It re-asks the Kad peers already queried for a wider result frontier. No body.
+Widens a running **Kad** search — the desktop's **"More"** button. It re-asks the Kad clients already queried for a wider result frontier. No body.
 
 Kad-only and running-only, matching what the desktop button allows rather than what the core tolerates: amuled turns a `more` on a non-Kad or finished search into a silent no-op, so both are rejected here instead of being answered with a misleading `202`.
 
@@ -2939,7 +2941,7 @@ Kad-only and running-only, matching what the desktop button allows rather than w
 
 **When it can no longer be widened:** `409 Conflict`, code `kad_more_exhausted`. Kad allows at most **4** reasks per search, and stops accepting them entirely once the search enters its stopping window — which begins 20 s before a keyword search's 45 s life ends, or as soon as it has collected 300 answers. In practice that means `more` only does something during roughly the first half of a search; past that, this is the answer. Disable the control for that search when you see it: nothing about that search will make it widenable again, and re-running the query is the way to get more (a fresh `POST /search` succeeds immediately and returns a new `search_id`).
 
-A `202` does **not** promise a reask went out. A press made while no already-responded peer is left un-reasked also answers `202`, because that clears the moment another peer answers and retrying is the right next action. The distinction the status carries is *terminal* versus *not terminal*, which is what a UI acts on; the daemon's log line distinguishes all the individual outcomes for anyone debugging.
+A `202` does **not** promise a reask went out. A press made while no already-responded client is left un-reasked also answers `202`, because that clears the moment another client answers and retrying is the right next action. The distinction the status carries is *terminal* versus *not terminal*, which is what a UI acts on; the daemon's log line distinguishes all the individual outcomes for anyone debugging.
 
 Note that a successful reask changes neither `progress.percent` nor `progress.state` — the Kad percent is a wall-clock ramp off the search's own start time. The response is the only signal; do not try to infer the outcome from the progress envelope.
 
@@ -3027,21 +3029,21 @@ curl -s http://$HOST/flags/unknown.png -o unknown.png
 
 **Response:** `200 OK`, `Content-Type: image/png`, `Cache-Control: public, max-age=86400`.
 
-Responses carry an `ETag` and honour `If-None-Match` with `304 Not Modified` like every other `GET` (see [ETag and conditional GET](#etag-and-conditional-get)). The `max-age` is what keeps a peer list full of `<img>` tags from issuing one conditional request per country on every reload; the artwork can only change with a new daemon build, and a day bounds how long an upgraded daemon keeps serving the old image.
+Responses carry an `ETag` and honour `If-None-Match` with `304 Not Modified` like every other `GET` (see [ETag and conditional GET](#etag-and-conditional-get)). The `max-age` is what keeps a client list full of `<img>` tags from issuing one conditional request per country on every reload; the artwork can only change with a new daemon build, and a day bounds how long an upgraded daemon keeps serving the old image.
 
 The response is never `Content-Encoding: gzip` — a PNG is already entropy-coded, so the server skips compression for it.
 
 **Errors:** `404 not_found` for anything that is neither two lowercase letters nor `unknown` (uppercase, wrong length, digits, another extension), and for a well-formed code the famfamfam set has no artwork for — it covers 248 of the assignable alpha-2 codes, so a resolvable country can legitimately have no flag. Render the code as text, or fall back to `unknown.png`, in that case. `400 bad_request` for paths carrying traversal tokens, per [Path validation](#path-validation).
 
-Peers whose country could not be resolved — GeoIP disabled, unsupported by the build, or a private/unmatched address — come back with `country_code: ""`. There is no per-country image to request in that case; draw nothing, or `unknown.png` for parity with the desktop list.
+Clients whose country could not be resolved — GeoIP disabled, unsupported by the build, or a private/unmatched address — come back with `country_code: ""`. There is no per-country image to request in that case; draw nothing, or `unknown.png` for parity with the desktop list.
 
 ---
 
 ### Chat
 
-Conversations with peers, backed by the chat session store in `amuled`. The store is shared: a message sent from the desktop GUI, from amulegui or through this API lands in the same transcript, and every client sees the same conversation.
+Conversations with clients, backed by the chat session store in `amuled`. The store is shared: a message sent from the desktop GUI, from amulegui or through this API lands in the same transcript, and every client sees the same conversation.
 
-A conversation is keyed on `{client_address}` = `"<ip>:<port>"` (for example `203.0.113.42:4662`). That is the readable form of the internal id the EC wire already uses, it is stable across peer reconnects — unlike an ECID — and it needs no identifier of its own. A `{client_address}` that is not four dotted octets plus a port is a `400`.
+A conversation is keyed on `{client_address}` = `"<ip>:<port>"` (for example `203.0.113.42:4662`). That is the readable form of the internal id the EC wire already uses, it is stable across client reconnects — unlike an ECID — and it needs no identifier of its own. A `{client_address}` that is not four dotted octets plus a port is a `400`.
 
 The store is **in memory**: an `amuled` restart empties every conversation, exactly as the desktop's own transcript dies with its notebook tab. Retention is bounded at 200 messages per conversation and 50 conversations, evicting the least recently active first.
 
@@ -3078,7 +3080,7 @@ curl -s -H "Authorization: Bearer $TOKEN" "http://$HOST/api/v0/chats"
 }
 ```
 
-`name` falls back to `"IP: <ip> Port: <port>"` when the core has no nickname for the peer, matching what the desktop shows; the same string appears in the SSE payload. `client_ecid` is `0` when the peer is offline, `friend_ecid` is `0` when the peer is not a friend — join against [`GET /clients`](#get-apiv0clients) and [`GET /friends`](#get-apiv0friends). `online` is simply `client_ecid != 0`.
+`name` falls back to `"IP: <ip> Port: <port>"` when the core has no nickname for the client, matching what the desktop shows; the same string appears in the SSE payload. `client_ecid` is `null` when the client is offline and `friend_ecid` is `null` when the client is not a friend — join either against [`GET /clients`](#get-apiv0clients) and [`GET /friends`](#get-apiv0friends). `online` is the same fact as a non-null `client_ecid`, in the readable form.
 
 `last_message` is `null` for a conversation that holds none; the key is always present. The full transcript is deliberately **not** on the list: 50 conversations at 200 messages each would be 10 000 objects per read. Use the messages endpoint below.
 
@@ -3104,7 +3106,7 @@ Served from the refresher snapshot — no EC roundtrip per request. Standard [li
 }
 ```
 
-`direction` is `"in"` (from the peer) or `"out"` (sent by us — from **any** client: this API, amulegui, or the desktop GUI). `sent_at` is stamped by the core when the message was received or sent. `total` counts everything the store holds for this conversation, not the returned window.
+`direction` is `"in"` (from the client) or `"out"` (sent by us — from **any** client: this API, amulegui, or the desktop GUI). `sent_at` is stamped by the core when the message was received or sent. `total` counts everything the store holds for this conversation, not the returned window.
 
 **Errors:** `404 not_found` (no such conversation), `400 bad_request` (malformed `{client_address}` or query), `503 ec_unsupported`, `503 ec_unavailable`.
 
@@ -3128,7 +3130,7 @@ The created message stays in the body because no per-message `GET` defines a sha
 
 The core creates the conversation if it does not exist, so this doubles as "start a chat with this address" — an unknown `{client_address}` is not a `404` here.
 
-Returns `202 Accepted`, not `200`: the core acknowledges that it queued the message on the peer connection, not that the peer received it. An unreachable peer is not an error — the desktop behaves the same, optimistically showing `*** Connecting to Client ***`.
+Returns `202 Accepted`, not `200`: the core acknowledges that it queued the message on the client connection, not that the client received it. An unreachable client is not an error — the desktop behaves the same, optimistically showing `*** Connecting to Client ***`.
 
 **Errors:** `400 bad_request`, `503 ec_unsupported`, `503 ec_unavailable`.
 
@@ -3148,15 +3150,15 @@ Message a friend by friend ECID. This is the form that reaches an **offline** fr
 
 **Auth:** `ADMIN`
 
-The peer-addressed form, for a caller holding a peer row that should not have to compose an `ip:port` key. Same body and response as above.
+The client-addressed form, for a caller holding a client row that should not have to compose an `ip:port` key. Same body and response as above.
 
-**Errors:** `404 not_found` (no live peer with that ECID), plus the set above.
+**Errors:** `404 not_found` (no live client with that ECID), plus the set above.
 
 #### `DELETE /api/v0/chats/{client_address}`
 
 **Auth:** `ADMIN`
 
-Closes the conversation: drops it from the core store and resets the peer's chat state.
+Closes the conversation: drops it from the core store and resets the client's chat state.
 
 **Response:** `204 No Content`.
 

--- a/docs/api/REFERENCE.md
+++ b/docs/api/REFERENCE.md
@@ -571,7 +571,7 @@ curl -s -X POST -H "Authorization: Bearer $TOKEN" http://$HOST/api/v0/version/ch
 | Status | `error.code` | When |
 | --- | --- | --- |
 | `409` | `update_check_unavailable` | The daemon can't check (`update.check_enabled` is `false`). |
-| `429` | `update_check_throttled` | A check ran too recently; retry shortly. |
+| `429` | `rate_limited` | A check ran too recently; retry shortly. |
 | `503` | `ec_unavailable` | The EC round-trip to amuled failed, or the first snapshot has not landed yet. |
 
 The snapshot gate matters at startup: `version_check_available` defaults to false, so before the first EC tick this route used to answer `409 update_check_unavailable`, blaming the daemon's configuration for amuleapi not having read it yet. It answers `503` there now, which is the condition a client can retry.
@@ -1114,11 +1114,11 @@ curl -s -X PATCH -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application
 
 **Auth:** `ADMIN`
 
-Bulk cancel + remove of active downloads (deletes each `.part`/`.met` from disk). A completed entry is rejected per-item with `completed_use_clear_completed` — clear those via `POST /downloads_clear_completed`.
+Bulk cancel + remove of active downloads (deletes each `.part`/`.met` from disk). A completed entry is rejected per-item with `download_completed` — clear those via `POST /downloads_clear_completed`.
 
 **Body:** `{ "hashes": ["<md4>", …] }` (non-empty, max 500).
 
-**Response:** the [bulk `results` envelope](#bulk-mutations-and-the-results-envelope), keyed by hash. Per-item `error.code` is `not_found`, `completed_use_clear_completed`, `amuled_rejected`, or `ec_unavailable`.
+**Response:** the [bulk `results` envelope](#bulk-mutations-and-the-results-envelope), keyed by hash. Per-item `error.code` is `not_found`, `download_completed`, `amuled_rejected`, or `ec_unavailable`.
 
 **Errors:** `400 bad_request` (missing/empty `hashes`), `503 ec_unavailable`.
 
@@ -1161,7 +1161,7 @@ curl -s -X DELETE -H "Authorization: Bearer $TOKEN" \
 
 **Response:** `204 No Content`.
 
-**Errors:** `400 amuled_rejected`, `404 not_found`, `409 completed_use_clear_completed`, `503 ec_unavailable`.
+**Errors:** `400 amuled_rejected`, `404 not_found`, `409 download_completed`, `503 ec_unavailable`.
 
 #### `POST /api/v0/downloads_clear_completed`
 
@@ -2284,7 +2284,7 @@ Booleans are plain JSON `true`/`false` regardless of how amuled encodes them on 
 
 `files.media_metadata_enabled` / `files.ffprobe_path` control media-metadata extraction: when enabled, the daemon probes shared audio/video with `ffprobe` to advertise length, bitrate, codec, artist, album and title. `ffprobe_path` is a **daemon-side** path — an empty string means the daemon auto-detects the binary, trying `ffprobe` on its `PATH` and then a per-platform list of well-known install locations. The detected path is deliberately **not** written back: it describes the daemon's machine rather than a choice you made, so `ffprobe_path` keeps reading as `""` while extraction works, and a daemon that moves to a host with ffmpeg somewhere else re-detects on its own. Set the field explicitly to pin one binary and override detection. When nothing is found the daemon logs one line saying so — visible on [`GET /api/v0/logs/amule`](#get-apiv0logsamule) — and extraction stays inert until ffmpeg is installed or the path is set. `connection.bind_address` (empty = bind to any local IP), `connection.bind_interface` (a daemon-side interface name such as `eth0` / `en0` / `tun0`; empty = any), and `online_signature.directory` are likewise daemon-side paths/addresses. These, together with `files.on_finished_start_next_alphabetically`, `security.reject_spoofed_source_ips`, `security.system_ipfilter_enabled`, and `online_signature.update_frequency_seconds`, are ordinary daemon settings; a `bind_address` change takes effect on the next amuled restart.
 
-`files.mmap_supported` is **read-only** — the daemon advertises whether it was built with memory-mapped file I/O (`false` on a core without mmap support, e.g. Windows or a build with `-DENABLE_MMAP=OFF`); it is ignored if sent on PATCH. `files.mmap_enabled` is the runtime toggle for memory-mapped block I/O — download writes to part files, upload reads of both shared (completed) and partial files, and hashing (lower per-process memory use, at some write-path cost; best for upload-heavy or memory-constrained hosts). It is **capability-gated**: a PATCH that sets `files.mmap_enabled` is rejected with **409 `conflict`** when `files.mmap_supported` is `false`, so the option is only writable against a daemon that can actually use it. Safe to toggle with active transfers.
+`files.mmap_supported` is **read-only** — the daemon advertises whether it was built with memory-mapped file I/O (`false` on a core without mmap support, e.g. Windows or a build with `-DENABLE_MMAP=OFF`); it is ignored if sent on PATCH. `files.mmap_enabled` is the runtime toggle for memory-mapped block I/O — download writes to part files, upload reads of both shared (completed) and partial files, and hashing (lower per-process memory use, at some write-path cost; best for upload-heavy or memory-constrained hosts). It is **capability-gated**: a PATCH that sets `files.mmap_enabled` is rejected with **409 `option_not_supported`** when `files.mmap_supported` is `false`, so the option is only writable against a daemon that can actually use it. Safe to toggle with active transfers.
 
 `connection.upnp_enabled` toggles UPnP router forwarding of the daemon's P2P ports — the ports themselves are `connection.tcp_port` (ed2k TCP) and `connection.udp_port` (ed2k/Kad UDP). `connection.upnp_control_point_port` is a separate optional knob: the fixed local port the UPnP control point (libupnp) binds to for the router's callbacks, `0` meaning auto-assign — **not** a forwarded port. `connection.upnp_supported` is **read-only** — the daemon advertises whether it was built with UPnP (`false` on a core built `-DENABLE_UPNP=OFF`, where `upnp_enabled` has no effect); it is ignored if sent on PATCH. (Web-server and EC-port UPnP are intentionally not exposed — amuleweb is deprecated and the EC port is not a P2P port.)
 
@@ -3179,24 +3179,23 @@ Every error code emitted by `/api/v0/*`, sorted by what triggered it. Two codes 
 | `not_found` | 404 | Resource doesn't exist (unknown hash, ECID, graph name, or no such endpoint). |
 | `not_readable` | 403 | Per-item code from the [`/share_directories`](#post-apiv0share_directories) bulk envelope: amuled cannot read that path. Only ever appears inside a `results[].error`, never as a whole-response error. |
 | `method_not_allowed` | 405 | Wrong HTTP verb for the route. The response carries an `Allow` header listing the methods this resource does support. |
-| `conflict` | 409 | The request is valid but the daemon cannot serve it as asked: it was built without support for the option being set, or the client named on an A4AF request is not an A4AF source of that download. |
+| `option_not_supported` | 409 | `PATCH /preferences` set an option the connected daemon was built without. |
+| `not_a4af_source` | 409 | The client named on a `POST /downloads/{hash}/a4af` request is not an A4AF source of that download. |
 | `partfile_unsupported` | 409 | Verify Local Data requested on a file that is still an incomplete partfile. |
 | `not_shared` | 409 | A comment or rating was posted against a file that is not shared. |
 | `not_completed` | 409 | `clear_completed` named a `hash` that is not a completed download. |
-| `completed_use_clear_completed` | 409 | A bulk `DELETE /downloads` matched a completed download; use `clear_completed` for those. |
+| `download_completed` | 409 | A `DELETE /downloads` matched a completed download; use `clear_completed` for those. |
 | `kad_more_exhausted` | 409 | `POST /search/{id}/more` on a Kad search that can no longer be widened — its 4-reask budget is spent, or it has entered the stopping window Kad begins 20 s before a keyword search ends. Terminal for that search; re-run the query for more. |
 | `update_check_unavailable` | 409 | `POST /version/check` cannot run — the daemon has no update-check capability. |
 | `payload_too_large` | 413 | Request body exceeds the 1 MiB limit. The connection closes after the response. |
-| `rate_limited` | 429 | Per-IP failure bucket full. `Retry-After: <seconds>` accompanies the response. |
-| `update_check_throttled` | 429 | `POST /version/check` was throttled by the daemon; try again shortly. |
+| `rate_limited` | 429 | Too many requests: the per-IP auth-failure bucket is full, or `POST /version/check` was throttled by the daemon. `Retry-After: <seconds>` accompanies the auth case. |
 | `headers_too_large` | 431 | Request headers exceed the 16 KiB limit. The connection closes after the response. |
-| `internal_error` | 500 | A handler failed internally — hash decode or serialization. The body is generic; details land in the daemon's stderr. |
-| `internal` | 500 | A handler threw. Raised by the HTTP layer's catch-all rather than by a handler, so it is distinct from `internal_error` above; a client that wants every server-side failure must match both. |
-| `bad_gateway` | 502 | amuled returned an EC payload this endpoint could not decode. |
+| `internal_error` | 500 | A server-side failure: a handler failed internally (hash decode, serialization) or threw and was caught by the HTTP layer. The body is generic; details land in the daemon's stderr. |
+| `amuled_response_invalid` | 502 | amuled returned an EC payload this endpoint could not decode. |
 | `ec_unavailable` | 503 | EC connection not ready yet (cold start, transient amuled restart). |
 | `ec_unsupported` | 503 | The connected amuled is too old to serve this route — the chat endpoints and `/known_clients`. |
 | `login_disabled` | 503 | `/auth/login` reached but no admin AND no guest password configured. |
-| `sessions_exhausted` | 503 | Too many concurrent streaming sessions. `Retry-After` accompanies the response. |
+| `too_many_streams` | 503 | Too many concurrent SSE streams. `Retry-After` accompanies the response. |
 
 `message` is human-readable and may change between releases. Pin on `code`.
 

--- a/src/webapi/Api.cpp
+++ b/src/webapi/Api.cpp
@@ -1520,14 +1520,14 @@ CHttpServer::Response CApiDispatcher::DispatchToHandler(const CHttpServer::Reque
 		return MethodNotAllowed("GET, HEAD, DELETE", "only GET / HEAD / DELETE on /logs/amule");
 	}
 
-	if (path == "/api/v0/logs/serverinfo") {
+	if (path == "/api/v0/logs/server_info") {
 		if (req.method == "GET" || req.method == "HEAD") {
 			return HandleLogServerinfo(req);
 		}
 		if (req.method == "DELETE") {
 			return HandleLogServerinfoReset(req);
 		}
-		return MethodNotAllowed("GET, HEAD, DELETE", "only GET / HEAD / DELETE on /logs/serverinfo");
+		return MethodNotAllowed("GET, HEAD, DELETE", "only GET / HEAD / DELETE on /logs/server_info");
 	}
 
 	if (path == "/api/v0/stats/tree") {
@@ -2057,15 +2057,20 @@ CHttpServer::Response CApiDispatcher::HandleVersion(const CHttpServer::Request &
 	r.content_type = "application/json";
 	CJsonWriter w;
 	w.BeginObject();
-	w.Key("name");
+	// `service`, not `name`: "name" of what? The value is the constant
+	// "amuleapi", so the key should say which thing it names.
+	w.Key("service");
 	w.ValueString(wxT("amuleapi"));
 	w.Key("api_version");
 	w.ValueString(wxT("v0"));
-	w.Key("amule_version");
+	// `amuleapi_version`, not `amule_version`: this is the VERSION the
+	// amuleapi binary was built from, which need not match the aMule daemon
+	// it is talking to. The old name said the opposite of what it holds.
+	w.Key("amuleapi_version");
 	w.ValueString(wxString::FromAscii(VERSION));
 	// Version of the connected amuled, from the EC handshake. Empty
 	// string when EC is not (yet) connected or the daemon predates the
-	// EC_TAG_SERVER_VERSION tag. Distinct from amule_version above,
+	// EC_TAG_SERVER_VERSION tag. Distinct from amuleapi_version above,
 	// which is amuleapi's own build version.
 	w.Key("daemon_version");
 	w.ValueString(m_app.GetDaemonVersion());
@@ -2075,8 +2080,8 @@ CHttpServer::Response CApiDispatcher::HandleVersion(const CHttpServer::Request &
 	// contract. When the daemon can't check -- built without
 	// ENABLE_VERSION_CHECK, the check_new_version pref off, or a pre-3.1
 	// daemon that emits none of these tags -- check_enabled is false and a
-	// client should show nothing. update_available / last_checked are null
-	// until a check has completed.
+	// client should show nothing. `available`, `latest_version` and
+	// `last_checked_at` are null until a check has completed.
 	if (auth.ok) {
 		const auto prefs = m_state.Preferences();
 		const auto status = m_state.Status();
@@ -2088,16 +2093,22 @@ CHttpServer::Response CApiDispatcher::HandleVersion(const CHttpServer::Request &
 		w.ValueBool(check_enabled);
 		w.Key("checked");
 		w.ValueBool(checked);
-		w.Key("latest_version");
-		w.ValueString(wxString::FromUTF8(status.version_check_latest.c_str()));
-		w.Key("update_available");
+		// null rather than "" before a check completes: R10, and its two
+		// siblings on this object already answer that way.
+		WriteStringOrNull(w,
+			"latest_version",
+			checked && !status.version_check_latest.empty(),
+			status.version_check_latest);
+		// `available`, not `update_available`: it stutters inside its own
+		// `update` object.
+		w.Key("available");
 		if (checked) {
 			w.ValueBool(status.version_check_outdated);
 		} else {
 			w.ValueNull();
 		}
 		WriteIntOrNull(w,
-			"last_checked",
+			"last_checked_at",
 			checked && status.version_check_timestamp > 0,
 			static_cast<std::int64_t>(status.version_check_timestamp));
 		w.EndObject();
@@ -2210,10 +2221,11 @@ void CApiDispatcher::BeginSession(
 	// the body and exfiltrate the bearer. So the default response is
 	// deliberately token-less.
 	//
-	// Bearer opt-in (SDK / curl / no cookie jar): client passes
-	// `Accept: application/jwt` or `?type=bearer` to get the bearer
-	// shape — `token`, `expires_at`, `expires_at_unix`, `jti`. The
-	// cookie still ships; bearer clients can ignore it.
+	// Token opt-in (SDK / curl / no cookie jar): client passes
+	// `Accept: application/jwt` or `?include_token=true` to get `token` in
+	// the body as well. The cookie still ships; token clients can ignore it.
+	// Everything else on this response is unconditional -- `include_token`
+	// adds the one key it names and nothing else.
 	bool wants_bearer = false;
 	{
 		const std::string accept = FindHeaderCaseInsensitive(req.headers, "Accept");
@@ -2226,8 +2238,10 @@ void CApiDispatcher::BeginSession(
 			if (qpos != std::string::npos)
 				q = req.target.substr(qpos + 1);
 			const auto qmap = web_api_path::ParseQuery(q);
-			const auto it = qmap.find("type");
-			if (it != qmap.end() && it->second == "bearer") {
+			// `include_token=true`, not `type=bearer`: "type" named no
+			// axis, and the parameter only ever added one key.
+			const auto it = qmap.find("include_token");
+			if (it != qmap.end() && it->second == "true") {
 				wants_bearer = true;
 			}
 		}
@@ -2239,14 +2253,15 @@ void CApiDispatcher::BeginSession(
 	}
 	w.Key("role");
 	w.ValueString(role == Role::ADMIN ? wxT("admin") : wxT("guest"));
+	// One `expires_at`, unix seconds, like every other `_at` on the surface.
+	// It used to ship twice -- ISO here and unix as `expires_at_unix`.
 	w.Key("expires_at");
-	w.ValueString(wxString::FromUTF8(webapi::FormatIso8601Utc(issued.expires_at).c_str()));
-	w.Key("expires_at_unix");
 	w.ValueInt(static_cast<int64_t>(issued.expires_at));
-	if (wants_bearer) {
-		w.Key("jti");
-		w.ValueString(wxString::FromUTF8(issued.jti.c_str()));
-	}
+	// `session_id`, not `jti` (a JWT internal), and emitted unconditionally:
+	// it used to appear only in the token shape, so every cookie-auth login
+	// lacked the id that /auth/session returns for the same session.
+	w.Key("session_id");
+	w.ValueString(wxString::FromUTF8(issued.jti.c_str()));
 }
 
 CHttpServer::Response CApiDispatcher::HandleLogout(const CHttpServer::Request &req)
@@ -2360,11 +2375,9 @@ CHttpServer::Response CApiDispatcher::HandleSession(const CHttpServer::Request &
 	w.BeginObject();
 	w.Key("role");
 	w.ValueString(a.verified.role == Role::ADMIN ? wxT("admin") : wxT("guest"));
-	w.Key("jti");
+	w.Key("session_id");
 	w.ValueString(wxString::FromUTF8(a.verified.jti.c_str()));
-	w.Key("exp");
-	w.ValueString(wxString::FromUTF8(webapi::FormatIso8601Utc(a.verified.exp).c_str()));
-	w.Key("exp_unix");
+	w.Key("expires_at");
 	w.ValueInt(static_cast<int64_t>(a.verified.exp));
 	w.EndObject();
 	// Per-principal document: a shared cache must not hand one caller
@@ -2392,9 +2405,9 @@ CHttpServer::Response CApiDispatcher::HandleAuthPasswords(const CHttpServer::Req
 
 	CJsonWriter w;
 	w.BeginObject();
-	w.Key("admin_set");
+	w.Key("admin_password_set");
 	w.ValueBool(!m_config.AdminCredential().empty());
-	w.Key("guest_enabled");
+	w.Key("guest_access_enabled");
 	w.ValueBool(!m_config.GuestCredential().empty());
 	w.EndObject();
 	FinalizeJsonBody(w, r);
@@ -2462,31 +2475,31 @@ CHttpServer::Response CApiDispatcher::HandleAuthPasswordsPatch(const CHttpServer
 		return ErrorResponse(400, "bad_request", "`current_password` is required");
 	}
 
-	bool guest_enabled = !m_config.GuestCredential().empty();
-	bool has_guest_enabled = false;
+	bool guest_access_enabled = !m_config.GuestCredential().empty();
+	bool has_guest_access_enabled = false;
 	{
-		auto it = obj.find("guest_enabled");
-		has_guest_enabled = (it != obj.end());
-		if (has_guest_enabled) {
+		auto it = obj.find("guest_access_enabled");
+		has_guest_access_enabled = (it != obj.end());
+		if (has_guest_access_enabled) {
 			if (!it->second.is<bool>()) {
-				return ErrorResponse(400, "bad_request", "`guest_enabled` must be a boolean");
+				return ErrorResponse(400, "bad_request", "`guest_access_enabled` must be a boolean");
 			}
-			guest_enabled = it->second.get<bool>();
+			guest_access_enabled = it->second.get<bool>();
 		}
 	}
 	// Setting a guest password while switching the role off is
 	// contradictory; guessing at which half was meant would silently do
 	// the wrong one.
-	if (has_guest && !guest_new.empty() && has_guest_enabled && !guest_enabled) {
+	if (has_guest && !guest_new.empty() && has_guest_access_enabled && !guest_access_enabled) {
 		return ErrorResponse(400,
 			"bad_request",
-			"`guest_password` cannot be set together with `guest_enabled: false`");
+			"`guest_password` cannot be set together with `guest_access_enabled: false`");
 	}
 	// A guest password on its own means "turn guest on with this".
-	if (has_guest && !guest_new.empty() && !has_guest_enabled) {
-		guest_enabled = true;
+	if (has_guest && !guest_new.empty() && !has_guest_access_enabled) {
+		guest_access_enabled = true;
 	}
-	if (!has_admin && !has_guest && !has_guest_enabled) {
+	if (!has_admin && !has_guest && !has_guest_access_enabled) {
 		return ErrorResponse(400, "bad_request", "nothing to change");
 	}
 	// There is no way to clear the admin password; an admin-less daemon
@@ -2507,7 +2520,9 @@ CHttpServer::Response CApiDispatcher::HandleAuthPasswordsPatch(const CHttpServer
 	m_rateLimiter.NoteSuccess(ip);
 
 	webcommon::CredentialChange change;
-	change.guest_enabled = guest_enabled;
+	// `change` belongs to libwebcommon's credential file format, shared with
+	// amuleweb, so its member keeps the name the file uses.
+	change.guest_enabled = guest_access_enabled;
 	if (has_admin) {
 		change.admin_md5 = std::string(
 			MD5Sum(wxString::FromUTF8(admin_new.c_str())).GetHash().Lower().utf8_str());
@@ -2533,16 +2548,16 @@ CHttpServer::Response CApiDispatcher::HandleAuthPasswordsPatch(const CHttpServer
 
 	CJsonWriter w;
 	w.BeginObject();
-	w.Key("admin_set");
+	w.Key("admin_password_set");
 	w.ValueBool(!m_config.AdminCredential().empty());
-	w.Key("guest_enabled");
+	w.Key("guest_access_enabled");
 	w.ValueBool(!m_config.GuestCredential().empty());
 	// Writing the file invalidated every token issued before it, this
 	// caller's included. Re-issue theirs in the same response so the
 	// operator who changed the password stays signed in while everyone
-	// else is signed out — which is the point of changing it.
-	w.Key("other_sessions_revoked");
-	w.ValueBool(true);
+	// else is signed out — which is the point of changing it. That is
+	// unconditional, so it carried no information as a key and the
+	// always-true `other_sessions_revoked` is gone; the reference says it.
 	BeginSession(req, Role::ADMIN, r, w);
 	w.EndObject();
 	FinalizeJsonBody(w, r);
@@ -4941,7 +4956,7 @@ CHttpServer::Response CApiDispatcher::HandleVersionCheck(const CHttpServer::Requ
 	}
 
 	// Accepted. The check runs asynchronously on the daemon; the result
-	// (latest_version / update_available / last_checked) appears on a
+	// (latest_version / available / last_checked_at) appears on a
 	// subsequent GET /api/v0/version once it completes.
 	CHttpServer::Response r;
 	// 202 with no body; see the comment on the comments routes. "started" is
@@ -7312,7 +7327,7 @@ std::vector<std::string> SliceTail(const std::vector<std::string> &all, std::siz
 	return std::vector<std::string>(all.begin() + (all.size() - tail), all.end());
 }
 
-// For a single-string log (e.g. /logs/serverinfo), `?tail=N` slices
+// For a single-string log (e.g. /logs/server_info), `?tail=N` slices
 // at line boundaries from the END so the first line of the response
 // is always whole. tail=0 returns the input verbatim.
 std::string TailString(const std::string &text, std::size_t tail_lines)
@@ -8058,9 +8073,9 @@ CHttpServer::Response CApiDispatcher::HandleLogAmule(const CHttpServer::Request 
 	w.EndArray();
 	// Operator-debug metadata: total cached + how many we returned.
 	// Lets a client paging through history know what it missed.
-	w.Key("total_cached");
+	w.Key("total_lines");
 	w.ValueInt(static_cast<int64_t>(all.size()));
-	w.Key("returned");
+	w.Key("returned_lines");
 	w.ValueInt(static_cast<int64_t>(sliced.size()));
 	w.EndObject();
 	FinalizeJsonBody(w, r);
@@ -8183,7 +8198,7 @@ CHttpServer::Response CApiDispatcher::HandleLogServerinfoReset(const CHttpServer
 	}
 	delete ec_resp;
 
-	// Lazy cache for /logs/serverinfo would otherwise return stale
+	// Lazy cache for /logs/server_info would otherwise return stale
 	// text until its 1 s TTL expires; force the next GET to re-fetch.
 	m_server_info_cache.Invalidate();
 
@@ -10000,11 +10015,11 @@ CHttpServer::Response SendMediaRefresh(CamuleapiApp &app, const CECTag *hashTag,
 	r.content_type = "application/json";
 	CJsonWriter w;
 	w.BeginObject();
-	// `ok` dropped; `scope` and `queued` stay -- `queued` is a real count of
-	// the rescans this triggered.
+	// `ok` dropped; `scope` and the count stay -- the count is a real number
+	// of rescans this triggered, so R5 spells it out.
 	w.Key("scope");
 	w.ValueString(wxString::FromAscii(what));
-	w.Key("queued");
+	w.Key("queued_file_count");
 	w.ValueInt(static_cast<int64_t>(queued));
 	w.EndObject();
 	FinalizeJsonBody(w, r);

--- a/src/webapi/Api.cpp
+++ b/src/webapi/Api.cpp
@@ -4759,7 +4759,7 @@ CHttpServer::Response CApiDispatcher::HandleDownloadA4afAction(
 		const auto &srcs = d.download.a4af_sources;
 		if (std::find(srcs.begin(), srcs.end(), client_ecid) == srcs.end()) {
 			return ErrorResponse(
-				409, "conflict", "that client is not an A4AF source of this download");
+				409, "not_a4af_source", "that client is not an A4AF source of this download");
 		}
 	}
 
@@ -4951,7 +4951,7 @@ CHttpServer::Response CApiDispatcher::HandleVersionCheck(const CHttpServer::Requ
 		// The only expected failure past the gate above is the daemon's
 		// throttle. Report an English code; the daemon's message is not relayed.
 		return ErrorResponse(429,
-			"update_check_throttled",
+			"rate_limited",
 			"version check was throttled by the daemon; try again shortly");
 	}
 
@@ -5486,7 +5486,7 @@ CHttpServer::Response CApiDispatcher::HandleDownloadDelete(
 	// so the verb-vs-disk-semantic mapping stays unambiguous.
 	if (d.download.status == "completed") {
 		return ErrorResponse(409,
-			"completed_use_clear_completed",
+			"download_completed",
 			"DELETE only removes active downloads (deletes .part/.met "
 			"files from disk). Use POST /downloads_clear_completed "
 			"with optional {\"hash\":\"...\"} body to clear a completed "
@@ -6130,7 +6130,7 @@ CHttpServer::Response CApiDispatcher::HandleKnownClients(const CHttpServer::Requ
 			// and older ones are refused above -- but the cost of being wrong
 			// is permanent, and retrying next request is free.
 			return ErrorResponse(502,
-				"bad_gateway",
+				"amuled_response_invalid",
 				"the core answered the history request with an unknown reply");
 		}
 		m_state.SetKnownClients(std::move(rows));
@@ -8685,7 +8685,7 @@ CHttpServer::Response CApiDispatcher::HandlePreferencesPatch(const CHttpServer::
 			}
 			if (!ok) {
 				return ErrorResponse(409,
-					"conflict",
+					"option_not_supported",
 					"this daemon was built without support for that option");
 			}
 		}
@@ -9499,7 +9499,7 @@ CHttpServer::Response CApiDispatcher::HandleDownloadsBulkDelete(const CHttpServe
 		if (d.download.status == "completed") {
 			results.push_back(BulkErr(raw,
 				409,
-				"completed_use_clear_completed",
+				"download_completed",
 				"DELETE only removes active downloads; use POST "
 				"/downloads_clear_completed to clear a completed entry"));
 			continue;

--- a/src/webapi/Api.cpp
+++ b/src/webapi/Api.cpp
@@ -2482,7 +2482,8 @@ CHttpServer::Response CApiDispatcher::HandleAuthPasswordsPatch(const CHttpServer
 		has_guest_access_enabled = (it != obj.end());
 		if (has_guest_access_enabled) {
 			if (!it->second.is<bool>()) {
-				return ErrorResponse(400, "bad_request", "`guest_access_enabled` must be a boolean");
+				return ErrorResponse(
+					400, "bad_request", "`guest_access_enabled` must be a boolean");
 			}
 			guest_access_enabled = it->second.get<bool>();
 		}
@@ -4362,40 +4363,46 @@ CHttpServer::Response CApiDispatcher::HandleClients(const CHttpServer::Request &
 	if (!a.ok)
 		return a.rejection;
 
-	// Optional `?filter=uploads | downloads | active` query parameter.
-	// `uploads`   → peers actively transferring TO us (upload_state ==
-	//              "uploading"). Subset that maps to the legacy
-	//              amuleweb "Uploads" page.
-	// `downloads` → peers we're actively pulling FROM (download_state
-	//              == "downloading").
-	// `active`    → union of the two; everything currently moving
-	//              bytes either direction.
-	// No filter → every peer the daemon knows about (default, v0.1
-	// shape).
-	std::string filter;
+	// Optional `?activity=uploading | downloading | active` query parameter.
+	// `activity`, not `filter`: "filter" named the mechanism rather than the
+	// axis being filtered on, and every list endpoint filters somehow. The
+	// values are client states, so they are spelled the way the client's own
+	// `upload_state` / `download_state` spell them rather than as plural
+	// nouns for the transfers.
+	// `uploading`   → clients actively transferring TO us (upload_state ==
+	//                "uploading"). Subset that maps to the legacy
+	//                amuleweb "Uploads" page.
+	// `downloading` → clients we're actively pulling FROM (download_state
+	//                == "downloading").
+	// `active`      → union of the two; everything currently moving
+	//                bytes either direction.
+	// No activity → every client the daemon knows about (the default).
+	std::string activity;
 	{
 		std::string query;
 		const std::size_t q = req.target.find('?');
 		if (q != std::string::npos)
 			query = req.target.substr(q + 1);
 		const auto qmap = web_api_path::ParseQuery(query);
-		const auto it = qmap.find("filter");
+		const auto it = qmap.find("activity");
 		if (it != qmap.end())
-			filter = it->second;
+			activity = it->second;
 	}
-	if (!filter.empty() && filter != "uploads" && filter != "downloads" && filter != "active") {
-		return ErrorResponse(
-			400, "bad_request", "`filter` must be one of \"uploads\", \"downloads\", \"active\"");
+	if (!activity.empty() && activity != "uploading" && activity != "downloading" &&
+		activity != "active") {
+		return ErrorResponse(400,
+			"bad_request",
+			"`activity` must be one of \"uploading\", \"downloading\", \"active\"");
 	}
 
 	auto clients = m_state.Clients();
-	if (!filter.empty()) {
+	if (!activity.empty()) {
 		auto matches = [&](const webapi::ClientSnapshot &c) {
 			const bool up = (c.upload_state == "uploading");
 			const bool down = (c.download_state == "downloading");
-			if (filter == "uploads")
+			if (activity == "uploading")
 				return up;
-			if (filter == "downloads")
+			if (activity == "downloading")
 				return down;
 			/* active */ return up || down;
 		};
@@ -4950,9 +4957,8 @@ CHttpServer::Response CApiDispatcher::HandleVersionCheck(const CHttpServer::Requ
 	if (failed) {
 		// The only expected failure past the gate above is the daemon's
 		// throttle. Report an English code; the daemon's message is not relayed.
-		return ErrorResponse(429,
-			"rate_limited",
-			"version check was throttled by the daemon; try again shortly");
+		return ErrorResponse(
+			429, "rate_limited", "version check was throttled by the daemon; try again shortly");
 	}
 
 	// Accepted. The check runs asynchronously on the daemon; the result

--- a/src/webapi/Auth.cpp
+++ b/src/webapi/Auth.cpp
@@ -133,32 +133,4 @@ std::string ExtractCookieValue(const std::string &cookie_header, const std::stri
 	return std::string(v.first, v.second);
 }
 
-// ---------- ISO-8601 ---------------------------------------------
-
-std::string FormatIso8601Utc(std::time_t t)
-{
-	std::tm out{};
-#ifdef _WIN32
-	gmtime_s(&out, &t);
-#else
-	gmtime_r(&t, &out);
-#endif
-	char buf[32];
-	const int n = std::snprintf(buf,
-		sizeof(buf),
-		"%04d-%02d-%02dT%02d:%02d:%02dZ",
-		out.tm_year + 1900,
-		out.tm_mon + 1,
-		out.tm_mday,
-		out.tm_hour,
-		out.tm_min,
-		out.tm_sec);
-	// snprintf's return is the bytes that *would* have been written.
-	// Our format produces exactly 20 chars + NUL, so anything else
-	// is a libc bug — return whatever we got rather than crashing.
-	if (n < 0)
-		return std::string();
-	return std::string(buf, std::min<size_t>(n, sizeof(buf) - 1));
-}
-
 } // namespace webapi

--- a/src/webapi/Auth.h
+++ b/src/webapi/Auth.h
@@ -96,10 +96,6 @@ std::string ExtractBearerToken(const std::string &authorization_header);
 // empty string on miss.
 std::string ExtractCookieValue(const std::string &cookie_header, const std::string &cookie_name);
 
-// ISO-8601 / RFC 3339 in UTC: "2026-06-19T11:00:00Z". 20-char fixed
-// length; clients can `Date.parse(...)` it.
-std::string FormatIso8601Utc(std::time_t t);
-
 } // namespace webapi
 
 #endif // WEBAPI_AUTH_H

--- a/src/webapi/HttpServer.cpp
+++ b/src/webapi/HttpServer.cpp
@@ -659,7 +659,7 @@ private:
 				std::cerr << "amuleapi: 500 from handler: " << e.what() << "\n";
 				resp.status = 500;
 				resp.content_type = "application/json";
-				resp.body = "{\"error\":{\"code\":\"internal\","
+				resp.body = "{\"error\":{\"code\":\"internal_error\","
 					    "\"message\":\"internal server error\"}}";
 				// The dispatcher's CORS pass died with the handler,
 				// so stamp it here: a cross-origin client should be
@@ -695,7 +695,7 @@ private:
 		if (m_cors_stamper) {
 			m_cors_stamper(refused.headers, FindHeaderCaseInsensitiveRaw("Origin"));
 		}
-		refused.body = "{\"error\":{\"code\":\"sessions_exhausted\","
+		refused.body = "{\"error\":{\"code\":\"too_many_streams\","
 			       "\"message\":\"too many concurrent streaming sessions; "
 			       "retry in a few seconds\"}}";
 		WriteResponse(std::move(refused));

--- a/src/webapi/RefresherTick.cpp
+++ b/src/webapi/RefresherTick.cpp
@@ -302,7 +302,7 @@ bool RefresherTick(CamuleapiApp &app, CState &state)
 		PublishChatEvents(app.EventBus(), new_messages, closed);
 	}
 
-	// /logs/serverinfo, /stats/tree, /stats/graphs/{graph} are NOT
+	// /logs/server_info, /stats/tree, /stats/graphs/{graph} are NOT
 	// fetched per-tick — they're lazy-fetched on first GET via
 	// CTtlCache (1 s TTL coalesces burst reads). HTTP handlers in
 	// Api.cpp drive their own EC roundtrips under m_ec_mtx. Per-tick

--- a/src/webapi/State.h
+++ b/src/webapi/State.h
@@ -1096,7 +1096,7 @@ struct SearchSlot
 // in memory until amuleapi restarts; log volume is bounded by
 // operator habits (idle ~tens of KB/day; busy ~hundreds).
 
-// /logs/serverinfo. amule has no incremental EC op for this log
+// /logs/server_info. amule has no incremental EC op for this log
 // (no equivalent of CLoggerAccess for ServerInfoLog), so the
 // refresher fetches the entire string via EC_OP_GET_SERVERINFO each
 // tick and the cache stores the latest snapshot. Server-info logs

--- a/src/webapi/TtlCache.h
+++ b/src/webapi/TtlCache.h
@@ -34,7 +34,7 @@ namespace webapi
 {
 
 // Single-flight TTL cache for lazy-fetched endpoints
-// (/logs/serverinfo, /stats/tree, /stats/graphs/{graph},
+// (/logs/server_info, /stats/tree, /stats/graphs/{graph},
 // /search/results). HTTP handlers drive their own EC fetches on
 // demand, coalescing burst reads via a 1 s TTL.
 //

--- a/src/webapi/static/js/app.js
+++ b/src/webapi/static/js/app.js
@@ -100,10 +100,10 @@ function Shell({ role, onLogout }) {
 }
 
 // Persistent alerts from the one-shot GET /version fetch, both linking to About:
-//   - version mismatch: amuleapi's build (amule_version) differs from the
+//   - version mismatch: amuleapi's build (amuleapi_version) differs from the
 //     connected amuled (daemon_version) — a config mismatch a toast would miss.
 //   - update available: the daemon's version check found a newer release
-//     (update.check_enabled && update.update_available).
+//     (update.check_enabled && update.available).
 // Lives in Shell so a dismiss sticks for the session; each row dismisses on its
 // own. daemon_version is empty when EC isn't connected; skip mismatch then.
 function VersionBanner() {
@@ -117,10 +117,10 @@ function VersionBanner() {
     api.get("version")
       .then((v) => {
         if (!alive) return;
-        if (v.daemon_version && v.amule_version !== v.daemon_version) {
-          setMismatch({ ui: v.amule_version, daemon: v.daemon_version });
+        if (v.daemon_version && v.amuleapi_version !== v.daemon_version) {
+          setMismatch({ ui: v.amuleapi_version, daemon: v.daemon_version });
         }
-        if (v.update && v.update.check_enabled && v.update.update_available === true) {
+        if (v.update && v.update.check_enabled && v.update.available === true) {
           setUpdate({ version: v.update.latest_version });
         }
       })

--- a/src/webapi/static/js/views/about.js
+++ b/src/webapi/static/js/views/about.js
@@ -55,7 +55,7 @@ export default function About() {
     <div class="card">
       <h3>aMule Web</h3>
       <div class="form-grid form-grid-2">
-        <div class="field"><label>${t("about_amuleapi_version")}</label><span>${info.amule_version}</span></div>
+        <div class="field"><label>${t("about_amuleapi_version")}</label><span>${info.amuleapi_version}</span></div>
         <div class="field"><label>${t("about_daemon_version")}</label><span>${daemon}</span></div>
         <div class="field"><label>${t("about_api_version")}</label><span>${info.api_version}</span></div>
       </div>
@@ -66,17 +66,17 @@ export default function About() {
       <div class="form-grid form-grid-2">
         <div class="field">
           <label>${t("about_update_status")}</label>
-          <span class=${"update-status" + (u.update_available ? " available" : "")}>
+          <span class=${"update-status" + (u.available ? " available" : "")}>
             ${!u.checked ? t("about_update_not_checked")
-              : u.update_available ? t("about_update_available") : t("about_update_uptodate")}
+              : u.available ? t("about_update_available") : t("about_update_uptodate")}
           </span>
         </div>
         ${u.checked && u.latest_version ? html`
         <div class="field"><label>${t("about_update_latest")}</label><span>${u.latest_version}</span></div>` : null}
-        ${u.last_checked ? html`
+        ${u.last_checked_at ? html`
         <div class="field">
           <label>${t("about_update_last_checked")}</label>
-          <span>${new Date(u.last_checked * 1000).toLocaleString()}</span>
+          <span>${new Date(u.last_checked_at * 1000).toLocaleString()}</span>
         </div>` : null}
       </div>
       <div class="toolbar update-actions">

--- a/src/webapi/static/js/views/download-detail.js
+++ b/src/webapi/static/js/views/download-detail.js
@@ -171,7 +171,7 @@ export function DownloadDetail({ hash, isGuest, categories = [], onPatch, onDele
 function DetailActions({ d, isGuest, categories, onPatch, onDelete, onClear }) {
   const inactive = d.status === "paused" || d.status === "stopped";
   const canStop = d.status !== "stopped" && d.status !== "completed" && d.status !== "completing";
-  // Completed rejects DELETE (409 completed_use_clear_completed): offer Clear.
+  // Completed rejects DELETE (409 download_completed): offer Clear.
   const done = d.status === "completed";
 
   const clear = async () => {

--- a/src/webapi/static/js/views/networks.js
+++ b/src/webapi/static/js/views/networks.js
@@ -407,7 +407,7 @@ function ServerInfoPanel() {
 
   const load = async () => {
     try {
-      const r = await api.get("logs/serverinfo");
+      const r = await api.get("logs/server_info");
       if (!boxRef.current) return;
       setText(boxRef.current, r.text || "");
       boxRef.current.scrollTop = boxRef.current.scrollHeight;
@@ -415,11 +415,11 @@ function ServerInfoPanel() {
   };
   const clear = async () => {
     if (!(await confirmDialog(t("networks_log_confirm_clear_serverinfo")))) return;
-    try { await api.del("logs/serverinfo"); if (boxRef.current) setText(boxRef.current, ""); toast(t("networks_log_toast_cleared"), "success"); }
+    try { await api.del("logs/server_info"); if (boxRef.current) setText(boxRef.current, ""); toast(t("networks_log_toast_cleared"), "success"); }
     catch (e) { toast(terr(e) || t("networks_log_error"), "error"); }
   };
   const save = async () => {
-    try { const r = await api.get("logs/serverinfo"); saveText("server-info.txt", r.text || ""); }
+    try { const r = await api.get("logs/server_info"); saveText("server-info.txt", r.text || ""); }
     catch (e) { toast(terr(e) || t("networks_log_error"), "error"); }
   };
 

--- a/src/webapi/static/js/views/preferences.js
+++ b/src/webapi/static/js/views/preferences.js
@@ -321,15 +321,15 @@ function AmuleApiCredentials({ isGuest }) {
   useEffect(() => {
     if (isGuest) return; // admin-only endpoint
     api.get("auth/passwords")
-      .then((s) => { setKnown(s); setGuestOn(!!s.guest_enabled); })
-      // Stay hidden rather than guess: sending guest_enabled without knowing
+      .then((s) => { setKnown(s); setGuestOn(!!s.guest_access_enabled); })
+      // Stay hidden rather than guess: sending guest_access_enabled without knowing
       // the stored state would clear a password nobody can read back.
       .catch(() => {});
   }, [isGuest]);
 
   if (isGuest || !known) return null;
 
-  const wasGuestOn = !!known.guest_enabled;
+  const wasGuestOn = !!known.guest_access_enabled;
   const settingGuestPw = guestOn && guestPw !== "";
   // Ticked guest, nothing typed, nothing stored: "keep the current" has
   // nothing to keep.
@@ -342,13 +342,13 @@ function AmuleApiCredentials({ isGuest }) {
     // back to resend it.
     const body = { current_password: current };
     if (admin !== "") body.admin_password = admin;
-    if (guestOn !== wasGuestOn) body.guest_enabled = guestOn;
+    if (guestOn !== wasGuestOn) body.guest_access_enabled = guestOn;
     if (settingGuestPw) body.guest_password = guestPw;
     setBusy(true);
     try {
       const res = await api.patch("auth/passwords", body);
       setKnown(res);
-      setGuestOn(!!res.guest_enabled);
+      setGuestOn(!!res.guest_access_enabled);
       setCurrent(""); setAdmin(""); setGuestPw("");
       toast(t("prefs_creds_saved"), "success");
     } catch (err) {

--- a/src/webapi/static/js/views/shared.js
+++ b/src/webapi/static/js/views/shared.js
@@ -116,7 +116,7 @@ export default function Shared({ isGuest }) {
     if (!(await confirmDialog(t("shared_media_refresh_all_confirm")))) return;
     try {
       const r = await api.post("shared/media/refresh");
-      toast(tn("shared_media_refresh_all_started", (r && r.queued) || 0), "info");
+      toast(tn("shared_media_refresh_all_started", (r && r.queued_file_count) || 0), "info");
     } catch (e) { toast(terr(e) || t("shared_error"), "error"); }
   };
 

--- a/unittests/curl-tests/amuleapi/01-version-and-errors.sh
+++ b/unittests/curl-tests/amuleapi/01-version-and-errors.sh
@@ -76,20 +76,20 @@ echo "amuleapi 01-version-and-errors smoke @ $HOST"
 # 1. GET /api/v0/version → 200 + JSON with name=amuleapi, api_version=v0.
 _curl "$HOST/api/v0/version"
 _assert_status 200 "GET /api/v0/version returns 200"
-_assert_json_eq '.name'        amuleapi '/api/v0/version reports name=amuleapi'
+_assert_json_eq '.service'     amuleapi '/api/v0/version reports service=amuleapi'
 _assert_json_eq '.api_version' v0       '/api/v0/version reports api_version=v0'
 
-# 2. amule_version field — non-empty. On release builds it's
+# 2. amuleapi_version field — non-empty. On release builds it's
 #    e.g. "3.0.1"; on the `master` line it's the literal "GIT"
 #    (PACKAGE_VERSION default in the top-level CMakeLists.txt).
 #    Pinning a shape would force the smoke to know which kind of
 #    build it's poking at, so just assert the field is populated.
-_assert_json_eq '.amule_version | length > 0' \
-	true '/api/v0/version reports a non-empty amule_version'
+_assert_json_eq '.amuleapi_version | length > 0' \
+	true '/api/v0/version reports a non-empty amuleapi_version'
 
 # 2b. daemon_version field — the connected amuled's version, taken from
 #     the EC_TAG_SERVER_VERSION handshake tag. Distinct from
-#     amule_version (which is amuleapi's own build). The regression
+#     amuleapi_version (which is amuleapi's own build). The regression
 #     amuled is a live modern build that always advertises the tag, so
 #     assert it's populated. (Against a daemon old enough to omit the
 #     tag, or before EC connects, this field is legitimately empty.)
@@ -126,9 +126,12 @@ _assert_status 200 "GET /api/v0/version (authenticated) returns 200"
 _assert_json_eq '.update | type' object '/api/v0/version has an update object when authenticated'
 _assert_json_eq '.update.check_enabled | type' boolean 'update.check_enabled is boolean'
 _assert_json_eq '.update.checked | type' boolean 'update.checked is boolean'
-_assert_json_eq '.update.latest_version | type' string 'update.latest_version is string'
-_assert_json_eq '.update | has("update_available")' true 'update has update_available'
-_assert_json_eq '.update | has("last_checked")' true 'update has last_checked'
+# latest_version is null until a check completes (R10), so it is string-or-null
+# rather than always-string -- the same shape as its two siblings.
+_assert_json_eq '(.update.latest_version | type) as $t | $t == "string" or $t == "null"' \
+	true 'update.latest_version is string or null'
+_assert_json_eq '.update | has("available")' true 'update has available'
+_assert_json_eq '.update | has("last_checked_at")' true 'update has last_checked_at'
 
 # 2d. /health — the liveness probe. The surface had none, so /version was being
 #     used as one: a document whose body changes over time and whose name says

--- a/unittests/curl-tests/amuleapi/02-auth.sh
+++ b/unittests/curl-tests/amuleapi/02-auth.sh
@@ -108,7 +108,7 @@ echo "amuleapi 02-auth smoke @ $HOST"
 # --- 1. Login with wrong password → 401 invalid_credentials. -------
 _curl -X POST -H "Content-Type: application/json" \
 	-d '{"password":"wrong-password"}' \
-	"$HOST/api/v0/auth/login?type=bearer"
+	"$HOST/api/v0/auth/login?include_token=true"
 _assert_status 401 "POST /auth/login with wrong password → 401"
 _assert_json_eq '.error.code' invalid_credentials \
 	'401 carries error.code=invalid_credentials'
@@ -116,13 +116,14 @@ _assert_json_eq '.error.code' invalid_credentials \
 # --- 2. Login with right password → 200 + JWT + Set-Cookie. --------
 _curl -X POST -H "Content-Type: application/json" \
 	-d "{\"password\":\"$ADMIN_PASS\"}" \
-	"$HOST/api/v0/auth/login?type=bearer"
+	"$HOST/api/v0/auth/login?include_token=true"
 _assert_status 200 "POST /auth/login with admin password → 200"
 _assert_json_eq '.role'                    admin    'login response role=admin'
 _assert_json_eq '.token | length > 100'    true     'login response carries a real JWT (>100 chars)'
-_assert_json_eq '.expires_at | length'     20       'expires_at is 20-char ISO-8601'
-_assert_json_eq '.expires_at_unix | type'  number   'expires_at_unix is numeric'
-_assert_json_eq '.jti | length'            22       'jti is 22-char base64url'
+_assert_json_eq '.expires_at | type'       number   'expires_at is unix seconds'
+_assert_json_eq '.session_id | length'     22       'session_id is 22-char base64url'
+# The two keys above are unconditional; only `token` rides include_token.
+_assert_json_eq '. | has("expires_at_unix")' false 'expires_at ships once, not also as expires_at_unix'
 _assert_header_contains 'set-cookie: amuleapi_token=' \
 	'login sets the amuleapi_token cookie'
 _assert_header_contains 'HttpOnly' \
@@ -135,12 +136,12 @@ TOKEN=$(printf '%s' "$CURL_BODY" | jq -r .token)
 [ -n "$TOKEN" ] && [ "$TOKEN" != "null" ] \
 	|| _die "couldn't extract token from login response: $CURL_BODY"
 
-# --- 3. /auth/session with bearer → 200 + role/jti/exp. ------------
+# --- 3. /auth/session with bearer → 200 + role/session_id/expires_at. -
 _curl -H "Authorization: Bearer $TOKEN" "$HOST/api/v0/auth/session"
 _assert_status 200 "GET /auth/session (bearer) → 200"
 _assert_json_eq '.role' admin 'session.role=admin (bearer)'
-_assert_json_eq '.jti  | length' 22 'session.jti is 22-char (bearer)'
-_assert_json_eq '.exp  | length' 20 'session.exp is 20-char ISO-8601 (bearer)'
+_assert_json_eq '.session_id | length' 22 'session.session_id is 22-char (bearer)'
+_assert_json_eq '.expires_at | type' number 'session.expires_at is unix seconds (bearer)'
 
 # --- 4. /auth/session with cookie → same. --------------------------
 # Use the cookie jar populated by curl above by re-sending the same
@@ -175,7 +176,7 @@ _assert_json_eq '.error.code' unauthorized \
 	'revoked bearer 401 carries error.code=unauthorized'
 
 # --- 9. Method gate. ----------------------------------------------
-_curl -X GET "$HOST/api/v0/auth/login?type=bearer"
+_curl -X GET "$HOST/api/v0/auth/login?include_token=true"
 _assert_status 405 "GET /auth/login → 405 method_not_allowed"
 _curl -X GET "$HOST/api/v0/auth/logout"
 _assert_status 405 "GET /auth/logout → 405 method_not_allowed"
@@ -183,7 +184,7 @@ _assert_status 405 "GET /auth/logout → 405 method_not_allowed"
 # --- 10. Bad JSON body on login → 400 bad_request. -----------------
 _curl -X POST -H "Content-Type: application/json" \
 	-d 'not-even-json' \
-	"$HOST/api/v0/auth/login?type=bearer"
+	"$HOST/api/v0/auth/login?include_token=true"
 _assert_status 400 "POST /auth/login (bad JSON) → 400"
 _assert_json_eq '.error.code' bad_request \
 	'bad-JSON 400 carries error.code=bad_request'
@@ -198,7 +199,7 @@ _assert_json_eq '.error.code' bad_request \
 # amuleapi and every later script logs in with it.
 _curl -X POST -H "Content-Type: application/json" \
 	-d "{\"password\":\"$ADMIN_PASS\"}" \
-	"$HOST/api/v0/auth/login?type=bearer"
+	"$HOST/api/v0/auth/login?include_token=true"
 _assert_status 200 "re-login for the credential block → 200"
 PW_TOKEN=$(printf '%s' "$CURL_BODY" | jq -r .token)
 [ -n "$PW_TOKEN" ] && [ "$PW_TOKEN" != "null" ] \
@@ -206,11 +207,11 @@ PW_TOKEN=$(printf '%s' "$CURL_BODY" | jq -r .token)
 
 _curl -H "Authorization: Bearer $PW_TOKEN" "$HOST/api/v0/auth/passwords"
 _assert_status 200 "GET /auth/passwords (admin) → 200"
-_assert_json_eq '.admin_set'          true    'admin_set=true'
+_assert_json_eq '.admin_password_set'          true    'admin_password_set=true'
 # Not asserting the initial guest state: run-all.sh sets a guest password
 # during bring-up, a bare manual run does not. The transitions below are
 # what matter, and each asserts the state it just produced.
-_assert_json_eq '.guest_enabled | type' boolean 'guest_enabled is a boolean'
+_assert_json_eq '.guest_access_enabled | type' boolean 'guest_access_enabled is a boolean'
 
 # The stored form is irreversible, so no digest may appear in the body.
 _assert_json_eq 'has("admin_password") or has("guest_password")' false \
@@ -238,9 +239,9 @@ _assert_status 400 "PATCH /auth/passwords cannot clear the admin password → 40
 
 _curl -X PATCH -H "Authorization: Bearer $PW_TOKEN" \
 	-H "Content-Type: application/json" \
-	-d "{\"current_password\":\"$ADMIN_PASS\",\"guest_password\":\"g\",\"guest_enabled\":false}" \
+	-d "{\"current_password\":\"$ADMIN_PASS\",\"guest_password\":\"g\",\"guest_access_enabled\":false}" \
 	"$HOST/api/v0/auth/passwords"
-_assert_status 400 "PATCH /auth/passwords rejects guest_password with guest_enabled:false → 400"
+_assert_status 400 "PATCH /auth/passwords rejects guest_password with guest_access_enabled:false → 400"
 
 # The revocation cutoff is the credential file's mtime, which has
 # one-second resolution: a token minted in the same second as the write
@@ -254,9 +255,13 @@ _curl -X PATCH -H "Authorization: Bearer $PW_TOKEN" \
 	-d "{\"current_password\":\"$ADMIN_PASS\",\"guest_password\":\"guestpass\"}" \
 	"$HOST/api/v0/auth/passwords"
 _assert_status 200 "PATCH /auth/passwords enabling guest → 200"
-_assert_json_eq '.admin_set'              true 'admin_set still true after enabling guest'
-_assert_json_eq '.guest_enabled'          true 'guest_enabled=true after setting a guest password'
-_assert_json_eq '.other_sessions_revoked' true 'password change reports other sessions revoked'
+_assert_json_eq '.admin_password_set'              true 'admin_password_set still true after enabling guest'
+_assert_json_eq '.guest_access_enabled'          true 'guest_access_enabled=true after setting a guest password'
+# The old always-true `other_sessions_revoked` carried no information and is
+# gone; revocation is unconditional and the re-issued token below is the
+# observable half.
+_assert_json_eq '. | has("other_sessions_revoked")' false \
+	'no always-true other_sessions_revoked key'
 _assert_json_eq '.token | length > 100'   true 'password change re-issues the caller a token'
 NEW_TOKEN=$(printf '%s' "$CURL_BODY" | jq -r .token)
 
@@ -268,7 +273,7 @@ _assert_status 401 "token issued before the change → 401"
 
 # The new guest password works, and guest may not read the credential state.
 _curl -X POST -H "Content-Type: application/json" \
-	-d '{"password":"guestpass"}' "$HOST/api/v0/auth/login?type=bearer"
+	-d '{"password":"guestpass"}' "$HOST/api/v0/auth/login?include_token=true"
 _assert_status 200 "guest can log in with the password just set → 200"
 _assert_json_eq '.role' guest 'guest login yields role=guest'
 GUEST_TOKEN=$(printf '%s' "$CURL_BODY" | jq -r .token)
@@ -285,14 +290,14 @@ sleep 1
 _curl -X PATCH -H "Authorization: Bearer $NEW_TOKEN" \
 	-H "Content-Type: application/json" \
 	-H "Accept: application/jwt" \
-	-d "{\"current_password\":\"$ADMIN_PASS\",\"guest_enabled\":false}" \
+	-d "{\"current_password\":\"$ADMIN_PASS\",\"guest_access_enabled\":false}" \
 	"$HOST/api/v0/auth/passwords"
 _assert_status 200 "PATCH /auth/passwords disabling guest → 200"
-_assert_json_eq '.guest_enabled' false 'guest_enabled=false after disabling'
-_assert_json_eq '.admin_set'     true  'disabling guest leaves the admin password alone'
+_assert_json_eq '.guest_access_enabled' false 'guest_access_enabled=false after disabling'
+_assert_json_eq '.admin_password_set'     true  'disabling guest leaves the admin password alone'
 NEW_TOKEN=$(printf '%s' "$CURL_BODY" | jq -r .token)
 _curl -X POST -H "Content-Type: application/json" \
-	-d '{"password":"guestpass"}' "$HOST/api/v0/auth/login?type=bearer"
+	-d '{"password":"guestpass"}' "$HOST/api/v0/auth/login?include_token=true"
 _assert_status 401 "the cleared guest password no longer logs in → 401"
 
 # Rotate the admin password and rotate it straight back, so the rest of
@@ -306,10 +311,10 @@ _curl -X PATCH -H "Authorization: Bearer $NEW_TOKEN" \
 _assert_status 200 "PATCH /auth/passwords rotating the admin password → 200"
 NEW_TOKEN=$(printf '%s' "$CURL_BODY" | jq -r .token)
 _curl -X POST -H "Content-Type: application/json" \
-	-d "{\"password\":\"$ADMIN_PASS\"}" "$HOST/api/v0/auth/login?type=bearer"
+	-d "{\"password\":\"$ADMIN_PASS\"}" "$HOST/api/v0/auth/login?include_token=true"
 _assert_status 401 "the replaced admin password no longer logs in → 401"
 _curl -X POST -H "Content-Type: application/json" \
-	-d '{"password":"rotated-pass"}' "$HOST/api/v0/auth/login?type=bearer"
+	-d '{"password":"rotated-pass"}' "$HOST/api/v0/auth/login?include_token=true"
 _assert_status 200 "the new admin password logs in → 200"
 
 sleep 1
@@ -319,7 +324,7 @@ _curl -X PATCH -H "Authorization: Bearer $NEW_TOKEN" \
 	"$HOST/api/v0/auth/passwords"
 _assert_status 200 "PATCH /auth/passwords restoring the admin password → 200"
 _curl -X POST -H "Content-Type: application/json" \
-	-d "{\"password\":\"$ADMIN_PASS\"}" "$HOST/api/v0/auth/login?type=bearer"
+	-d "{\"password\":\"$ADMIN_PASS\"}" "$HOST/api/v0/auth/login?include_token=true"
 _assert_status 200 "ADMIN_PASS restored for the rest of the suite → 200"
 
 _curl -X POST "$HOST/api/v0/auth/passwords"
@@ -341,17 +346,17 @@ _assert_status 405 "POST /auth/passwords → 405 method_not_allowed"
 for i in 1 2 3 4; do
 	_curl -X POST -H "Content-Type: application/json" \
 		-d '{"password":"wrong"}' \
-		"$HOST/api/v0/auth/login?type=bearer" > /dev/null
+		"$HOST/api/v0/auth/login?include_token=true" > /dev/null
 done
 # Attempt 5: NoteFailure() arms the lockout AFTER returning 401.
 _curl -X POST -H "Content-Type: application/json" \
 	-d '{"password":"wrong"}' \
-	"$HOST/api/v0/auth/login?type=bearer"
+	"$HOST/api/v0/auth/login?include_token=true"
 _assert_status 401 "POST /auth/login: 5th failure arms but still returns 401"
 # Attempt 6: Check() sees the armed lockout → 429.
 _curl -X POST -H "Content-Type: application/json" \
 	-d '{"password":"wrong"}' \
-	"$HOST/api/v0/auth/login?type=bearer"
+	"$HOST/api/v0/auth/login?include_token=true"
 _assert_status 429 "POST /auth/login: 6th attempt is the first 429"
 _assert_json_eq '.error.code' rate_limited \
 	'6th-attempt lockout carries error.code=rate_limited'
@@ -359,11 +364,11 @@ _assert_json_eq '.error.code' rate_limited \
 # Attempt 7 stays locked.
 _curl -X POST -H "Content-Type: application/json" \
 	-d '{"password":"wrong"}' \
-	"$HOST/api/v0/auth/login?type=bearer" > /dev/null
+	"$HOST/api/v0/auth/login?include_token=true" > /dev/null
 # The 8th attempt also remains locked.
 _curl -X POST -H "Content-Type: application/json" \
 	-d '{"password":"wrong"}' \
-	"$HOST/api/v0/auth/login?type=bearer"
+	"$HOST/api/v0/auth/login?include_token=true"
 _assert_status 429 "POST /auth/login after many failures → 429"
 _assert_json_eq '.error.code' rate_limited \
 	'lockout carries error.code=rate_limited'

--- a/unittests/curl-tests/amuleapi/03-read-status.sh
+++ b/unittests/curl-tests/amuleapi/03-read-status.sh
@@ -3,7 +3,7 @@
 # amuleapi 03-read-status — read endpoints, /status only. Validates the
 # refresher → state cache → handler chain end-to-end against a live
 # amuled. The remaining 12 endpoints (downloads, uploads, shared,
-# servers, kad, categories, logs/amule, logs/serverinfo, preferences,
+# servers, kad, categories, logs/amule, logs/server_info, preferences,
 # stats/tree, stats/graphs, search/results) land in subsequent
 # sub-phases (4b/4c/4d); their phase scripts share this directory.
 #
@@ -96,7 +96,7 @@ _assert_json_eq '.error.code' unauthorized \
 # --- 2. Log in as admin and capture the bearer. --------------------
 TOKEN=$(curl -s -X POST -H "Content-Type: application/json" \
 	-d "{\"password\":\"$ADMIN_PASS\"}" \
-	"$HOST/api/v0/auth/login?type=bearer" | jq -r .token)
+	"$HOST/api/v0/auth/login?include_token=true" | jq -r .token)
 [ -n "$TOKEN" ] && [ "$TOKEN" != "null" ] \
 	|| _die "could not log in for /status tests"
 
@@ -201,7 +201,7 @@ _assert_json_eq '[paths | join(".")] | map(select(test("low_id|upload_queue_leng
 # --- 4. /status with guest bearer also works (any-role read gate). --
 GUEST_TOKEN=$(curl -s -X POST -H "Content-Type: application/json" \
 	-d "{\"password\":\"$GUEST_PASS\"}" \
-	"$HOST/api/v0/auth/login?type=bearer" | jq -r .token)
+	"$HOST/api/v0/auth/login?include_token=true" | jq -r .token)
 if [ -n "$GUEST_TOKEN" ] && [ "$GUEST_TOKEN" != "null" ]; then
 	_curl -H "Authorization: Bearer $GUEST_TOKEN" "$HOST/api/v0/status"
 	_assert_status 200 "GET /api/v0/status (guest bearer) → 200"

--- a/unittests/curl-tests/amuleapi/04-read-downloads-shared.sh
+++ b/unittests/curl-tests/amuleapi/04-read-downloads-shared.sh
@@ -90,7 +90,7 @@ echo "amuleapi 04-read-downloads-shared smoke @ $HOST"
 # --- 0. Log in. ----------------------------------------------------
 TOKEN=$(curl -s -X POST -H "Content-Type: application/json" \
 	-d "{\"password\":\"$ADMIN_PASS\"}" \
-	"$HOST/api/v0/auth/login?type=bearer" | jq -r .token)
+	"$HOST/api/v0/auth/login?include_token=true" | jq -r .token)
 [ -n "$TOKEN" ] && [ "$TOKEN" != "null" ] \
 	|| _die "could not log in for phase 4b tests"
 

--- a/unittests/curl-tests/amuleapi/04-read-downloads-shared.sh
+++ b/unittests/curl-tests/amuleapi/04-read-downloads-shared.sh
@@ -347,7 +347,7 @@ if [ "$COUNT" -gt 0 ]; then
 
 	# Per-source swap (issue #983): `client_ecid` narrows swap_this to one
 	# source. Validation is asserted here rather than the swap itself — a
-	# regtest daemon has no A4AF source to move, and the conflict/not-found
+	# regtest daemon has no A4AF source to move, and the rejection/not-found
 	# paths are the ones that must never silently succeed.
 	_curl -X POST -H "Authorization: Bearer $TOKEN" \
 		-H "Content-Type: application/json" \
@@ -369,7 +369,7 @@ if [ "$COUNT" -gt 0 ]; then
 		-d '{"action":"swap_this","client_ecid":4294967290}' "$HOST/api/v0/downloads/$HASH/a4af"
 	_assert_status 404 "POST a4af naming an unknown client_ecid → 404"
 
-	# A live peer that is not an A4AF source of this file is a conflict, not a
+	# A live client that is not an A4AF source of this file is a rejection, not a
 	# no-op: pick any client from /clients and ensure it is absent from the
 	# A4AF list before asserting.
 	OTHER_ECID=$(curl -s -H "Authorization: Bearer $TOKEN" "$HOST/api/v0/clients?limit=1" \
@@ -384,6 +384,8 @@ if [ "$COUNT" -gt 0 ]; then
 				-d "{\"action\":\"swap_this\",\"client_ecid\":$OTHER_ECID}" \
 				"$HOST/api/v0/downloads/$HASH/a4af"
 			_assert_status 409 "POST a4af for a non-A4AF client → 409"
+			_assert_json_eq '.error.code' not_a4af_source \
+				'the 409 names not_a4af_source, not a bare conflict'
 		fi
 	fi
 

--- a/unittests/curl-tests/amuleapi/05-read-servers-kad-categories-prefs.sh
+++ b/unittests/curl-tests/amuleapi/05-read-servers-kad-categories-prefs.sh
@@ -76,7 +76,7 @@ echo "amuleapi 05-read-servers-kad-categories-prefs smoke @ $HOST"
 # Log in.
 TOKEN=$(curl -s -X POST -H "Content-Type: application/json" \
 	-d "{\"password\":\"$ADMIN_PASS\"}" \
-	"$HOST/api/v0/auth/login?type=bearer" | jq -r .token)
+	"$HOST/api/v0/auth/login?include_token=true" | jq -r .token)
 [ -n "$TOKEN" ] && [ "$TOKEN" != "null" ] || _die "login failed"
 
 # Wait for the first full refresher tick (servers + prefs land at the

--- a/unittests/curl-tests/amuleapi/06-read-logs.sh
+++ b/unittests/curl-tests/amuleapi/06-read-logs.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# amuleapi 06-read-logs — /logs/amule + /logs/serverinfo. amule log
+# amuleapi 06-read-logs — /logs/amule + /logs/server_info. amule log
 # rides on STAT_REQ's `EC_TAG_STATS_LOGGER_MESSAGE` channel (per-EC-
 # connection cursor, incremental); server-info log is full-snapshot
 # via `EC_OP_GET_SERVERINFO`.
@@ -71,7 +71,7 @@ echo "amuleapi 06-read-logs smoke @ $HOST"
 
 TOKEN=$(curl -s -X POST -H "Content-Type: application/json" \
 	-d "{\"password\":\"$ADMIN_PASS\"}" \
-	"$HOST/api/v0/auth/login?type=bearer" | jq -r .token)
+	"$HOST/api/v0/auth/login?include_token=true" | jq -r .token)
 [ -n "$TOKEN" ] && [ "$TOKEN" != "null" ] || _die "login failed"
 
 # Give the refresher a few seconds to drain the initial log baseline
@@ -82,34 +82,34 @@ sleep 5
 # --- 1. Auth gate. -------------------------------------------------
 _curl "$HOST/api/v0/logs/amule"
 _assert_status 401 "GET /logs/amule (no creds) → 401"
-_curl "$HOST/api/v0/logs/serverinfo"
-_assert_status 401 "GET /logs/serverinfo (no creds) → 401"
+_curl "$HOST/api/v0/logs/server_info"
+_assert_status 401 "GET /logs/server_info (no creds) → 401"
 
 # --- 2. /logs/amule full response shape. ---------------------------
 _curl -H "Authorization: Bearer $TOKEN" "$HOST/api/v0/logs/amule"
 _assert_status 200 "GET /logs/amule → 200"
 _assert_json_eq '.lines | type'         array  '/logs/amule.lines is an array'
-_assert_json_eq '.total_cached | type'  number '/logs/amule.total_cached is numeric'
-_assert_json_eq '.returned | type'      number '/logs/amule.returned is numeric'
+_assert_json_eq '.total_lines | type'  number '/logs/amule.total_lines is numeric'
+_assert_json_eq '.returned_lines | type'      number '/logs/amule.returned_lines is numeric'
 _assert_json_eq '.lines | length > 0'   true   '/logs/amule.lines is non-empty (amule emits a banner on connect)'
-# When no tail is given, returned == total_cached.
-_assert_json_eq '(.returned == .total_cached)' true \
-	'/logs/amule: returned == total_cached when no ?tail given'
+# When no tail is given, returned_lines == total_lines.
+_assert_json_eq '(.returned_lines == .total_lines)' true \
+	'/logs/amule: returned_lines == total_lines when no ?tail given'
 
-TOTAL=$(printf '%s' "$CURL_BODY" | jq '.total_cached')
+TOTAL=$(printf '%s' "$CURL_BODY" | jq '.total_lines')
 
 # --- 3. /logs/amule?tail=N. ----------------------------------------
 _curl -H "Authorization: Bearer $TOKEN" "$HOST/api/v0/logs/amule?tail=2"
 _assert_status 200 "GET /logs/amule?tail=2 → 200"
-_assert_json_eq '.returned'           2      '/logs/amule?tail=2 returns 2 lines'
+_assert_json_eq '.returned_lines'           2      '/logs/amule?tail=2 returns 2 lines'
 _assert_json_eq '.lines | length'     2      '/logs/amule?tail=2 array length is 2'
-_assert_json_eq '.total_cached'       "$TOTAL" '/logs/amule?tail=2 still reports full cached count'
+_assert_json_eq '.total_lines'       "$TOTAL" '/logs/amule?tail=2 still reports the full line count'
 
 # tail=0 means "no tailing" → all lines. The wire contract makes 0
 # the inert default (matches the helper's behaviour: 0 = unbounded).
 _curl -H "Authorization: Bearer $TOKEN" "$HOST/api/v0/logs/amule?tail=0"
 _assert_status 200 "GET /logs/amule?tail=0 → 200"
-_assert_json_eq '(.returned == .total_cached)' true \
+_assert_json_eq '(.returned_lines == .total_lines)' true \
 	'/logs/amule?tail=0 returns all (tail=0 is "no tailing")'
 
 # A non-numeric tail is a 400, not a silent "return all". It used to parse as
@@ -122,29 +122,29 @@ _assert_status 400 "GET /logs/amule?tail=notanumber → 400"
 _curl -H "Authorization: Bearer $TOKEN" "$HOST/api/v0/logs/amule?tail=999999"
 _assert_status 400 "GET /logs/amule?tail=999999 → 400"
 
-# --- 4. /logs/serverinfo shape. ------------------------------------
-_curl -H "Authorization: Bearer $TOKEN" "$HOST/api/v0/logs/serverinfo"
-_assert_status 200 "GET /logs/serverinfo → 200"
-_assert_json_eq '.text | type'           string '/logs/serverinfo.text is string'
-_assert_json_eq '.total_bytes | type'    number '/logs/serverinfo.total_bytes is numeric'
-_assert_json_eq '.returned_bytes | type' number '/logs/serverinfo.returned_bytes is numeric'
+# --- 4. /logs/server_info shape. ------------------------------------
+_curl -H "Authorization: Bearer $TOKEN" "$HOST/api/v0/logs/server_info"
+_assert_status 200 "GET /logs/server_info → 200"
+_assert_json_eq '.text | type'           string '/logs/server_info.text is string'
+_assert_json_eq '.total_bytes | type'    number '/logs/server_info.total_bytes is numeric'
+_assert_json_eq '.returned_bytes | type' number '/logs/server_info.returned_bytes is numeric'
 _assert_json_eq '(.returned_bytes == .total_bytes)' true \
-	'/logs/serverinfo: returned_bytes == total_bytes when no ?tail given'
+	'/logs/server_info: returned_bytes == total_bytes when no ?tail given'
 
 TOTAL_BYTES=$(printf '%s' "$CURL_BODY" | jq '.total_bytes')
 
-# --- 5. /logs/serverinfo?tail=3 — line-boundary slicing. -----------
-_curl -H "Authorization: Bearer $TOKEN" "$HOST/api/v0/logs/serverinfo?tail=3"
-_assert_status 200 "GET /logs/serverinfo?tail=3 → 200"
+# --- 5. /logs/server_info?tail=3 — line-boundary slicing. -----------
+_curl -H "Authorization: Bearer $TOKEN" "$HOST/api/v0/logs/server_info?tail=3"
+_assert_status 200 "GET /logs/server_info?tail=3 → 200"
 _assert_json_eq '(.returned_bytes <= .total_bytes)' true \
-	'/logs/serverinfo?tail=3: returned_bytes <= total_bytes'
+	'/logs/server_info?tail=3: returned_bytes <= total_bytes'
 _assert_json_eq '.total_bytes' "$TOTAL_BYTES" \
-	'/logs/serverinfo?tail=3 reports the same total_bytes'
+	'/logs/server_info?tail=3 reports the same total_bytes'
 
 # --- 6. Method gate. -----------------------------------------------
 # DELETE on /logs/{amule,serverinfo} clears the buffer. PATCH is a 405:
 # the logs are read+reset only, never partially mutable.
-for ep in logs/amule logs/serverinfo; do
+for ep in logs/amule logs/server_info; do
 	_curl -X PATCH -H "Authorization: Bearer $TOKEN" "$HOST/api/v0/$ep"
 	_assert_status 405 "PATCH /api/v0/$ep → 405"
 done

--- a/unittests/curl-tests/amuleapi/07-read-stats-and-search-results.sh
+++ b/unittests/curl-tests/amuleapi/07-read-stats-and-search-results.sh
@@ -67,7 +67,7 @@ echo "amuleapi 07-read-stats-and-search-results smoke @ $HOST"
 
 TOKEN=$(curl -s -X POST -H "Content-Type: application/json" \
 	-d "{\"password\":\"$ADMIN_PASS\"}" \
-	"$HOST/api/v0/auth/login?type=bearer" | jq -r .token)
+	"$HOST/api/v0/auth/login?include_token=true" | jq -r .token)
 [ -n "$TOKEN" ] && [ "$TOKEN" != "null" ] || _die "login failed"
 
 # Wait for the refresher to populate the cache (3 new EC roundtrips

--- a/unittests/curl-tests/amuleapi/08-read-download-parts.sh
+++ b/unittests/curl-tests/amuleapi/08-read-download-parts.sh
@@ -84,7 +84,7 @@ echo "amuleapi 08-read-download-parts smoke @ $HOST"
 
 TOKEN=$(curl -s -X POST -H "Content-Type: application/json" \
 	-d "{\"password\":\"$ADMIN_PASS\"}" \
-	"$HOST/api/v0/auth/login?type=bearer" | jq -r .token)
+	"$HOST/api/v0/auth/login?include_token=true" | jq -r .token)
 [ -n "$TOKEN" ] && [ "$TOKEN" != "null" ] || _die "login failed"
 
 # Refresher needs at least 2 ticks for the two-phase INC protocol to

--- a/unittests/curl-tests/amuleapi/09-refresher-consolidation.sh
+++ b/unittests/curl-tests/amuleapi/09-refresher-consolidation.sh
@@ -91,7 +91,7 @@ echo "amuleapi 09-refresher-consolidation smoke @ $HOST"
 
 TOKEN=$(curl -s -X POST -H "Content-Type: application/json" \
 	-d "{\"password\":\"$ADMIN_PASS\"}" \
-	"$HOST/api/v0/auth/login?type=bearer" | jq -r .token)
+	"$HOST/api/v0/auth/login?include_token=true" | jq -r .token)
 [ -n "$TOKEN" ] && [ "$TOKEN" != "null" ] || _die "login failed"
 
 # Let the refresher complete at least one full tick after auth so the

--- a/unittests/curl-tests/amuleapi/10-refresher-lazy-ondemand.sh
+++ b/unittests/curl-tests/amuleapi/10-refresher-lazy-ondemand.sh
@@ -10,7 +10,7 @@
 #   3. EC_OP_GET_PREFERENCES                → /preferences + /categories
 #
 # Four endpoints lazy-fetched on first GET, coalesced via 1 s TTL:
-#   * /logs/serverinfo  (EC_OP_GET_SERVERINFO)
+#   * /logs/server_info  (EC_OP_GET_SERVERINFO)
 #   * /stats/tree       (EC_OP_GET_STATSTREE)
 #   * /stats/graphs/{X} (EC_OP_GET_STATSGRAPHS — one fetch serves all 4)
 #   * /search/{id}/results (EC_OP_SEARCH_RESULTS, on a finished search)
@@ -84,7 +84,7 @@ echo "amuleapi 10-refresher-lazy-ondemand smoke @ $HOST"
 
 TOKEN=$(curl -s -X POST -H "Content-Type: application/json" \
 	-d "{\"password\":\"$ADMIN_PASS\"}" \
-	"$HOST/api/v0/auth/login?type=bearer" | jq -r .token)
+	"$HOST/api/v0/auth/login?include_token=true" | jq -r .token)
 [ -n "$TOKEN" ] && [ "$TOKEN" != "null" ] || _die "login failed"
 
 # Refresher has 3 ops/tick now (STAT_REQ + GET_UPDATE + PREFERENCES).
@@ -148,7 +148,7 @@ fi
 # --- 3. Lazy-fetch endpoints — fresh per-endpoint snapshot_at. -----
 #
 # Per Phase 4g, /stats/tree, /stats/graphs/{X}, /search/{id}/results, and
-# /logs/serverinfo no longer ride the refresher tick. Each handler
+# /logs/server_info no longer ride the refresher tick. Each handler
 # drives its own EC roundtrip on first call, coalesced via 1 s TTL.
 # The `snapshot_at` field on each reflects the per-endpoint fetch
 # time, not the refresher tick.
@@ -200,10 +200,10 @@ _assert_json_eq '.results | type' array '/search/{id}/results .results is array'
 _curl -H "Authorization: Bearer $TOKEN" "$HOST/api/v0/search/4294967290/results"
 _assert_status 404 "GET /search/{unknown}/results → 404 (no implicit fallback)"
 
-_curl -H "Authorization: Bearer $TOKEN" "$HOST/api/v0/logs/serverinfo"
-_assert_status 200 "GET /logs/serverinfo → 200 (lazy fetch)"
-_assert_json_eq '.text | type' string '/logs/serverinfo .text is string'
-_assert_json_eq '.total_bytes | type' number '/logs/serverinfo .total_bytes is numeric'
+_curl -H "Authorization: Bearer $TOKEN" "$HOST/api/v0/logs/server_info"
+_assert_status 200 "GET /logs/server_info → 200 (lazy fetch)"
+_assert_json_eq '.text | type' string '/logs/server_info .text is string'
+_assert_json_eq '.total_bytes | type' number '/logs/server_info .total_bytes is numeric'
 
 # --- 4. Per-tick endpoints still fresh from the refresher. ---------
 #

--- a/unittests/curl-tests/amuleapi/11-downloads-default-filter.sh
+++ b/unittests/curl-tests/amuleapi/11-downloads-default-filter.sh
@@ -90,7 +90,7 @@ echo "amuleapi 11-downloads-default-filter smoke @ $HOST"
 
 TOKEN=$(curl -s -X POST -H "Content-Type: application/json" \
 	-d "{\"password\":\"$ADMIN_PASS\"}" \
-	"$HOST/api/v0/auth/login?type=bearer" | jq -r .token)
+	"$HOST/api/v0/auth/login?include_token=true" | jq -r .token)
 [ -n "$TOKEN" ] && [ "$TOKEN" != "null" ] || _die "login failed"
 sleep 4
 

--- a/unittests/curl-tests/amuleapi/12-downloads-add-patch.sh
+++ b/unittests/curl-tests/amuleapi/12-downloads-add-patch.sh
@@ -99,13 +99,13 @@ echo "amuleapi 12-downloads-add-patch smoke @ $HOST"
 
 ADMIN_TOKEN=$(curl -s -X POST -H "Content-Type: application/json" \
 	-d "{\"password\":\"$ADMIN_PASS\"}" \
-	"$HOST/api/v0/auth/login?type=bearer" | jq -r .token)
+	"$HOST/api/v0/auth/login?include_token=true" | jq -r .token)
 [ -n "$ADMIN_TOKEN" ] && [ "$ADMIN_TOKEN" != "null" ] \
 	|| _die "admin login failed (need --set-admin-pass=$ADMIN_PASS on the daemon)"
 
 GUEST_TOKEN=$(curl -s -X POST -H "Content-Type: application/json" \
 	-d "{\"password\":\"$GUEST_PASS\"}" \
-	"$HOST/api/v0/auth/login?type=bearer" | jq -r .token)
+	"$HOST/api/v0/auth/login?include_token=true" | jq -r .token)
 HAVE_GUEST=0
 if [ -n "$GUEST_TOKEN" ] && [ "$GUEST_TOKEN" != "null" ]; then
 	HAVE_GUEST=1

--- a/unittests/curl-tests/amuleapi/13-downloads-delete-clear.sh
+++ b/unittests/curl-tests/amuleapi/13-downloads-delete-clear.sh
@@ -98,11 +98,11 @@ fi
 echo "amuleapi 13-downloads-delete-clear smoke @ $HOST"
 
 ADMIN_TOKEN=$(curl -s -X POST -H "Content-Type: application/json" \
-	-d "{\"password\":\"$ADMIN_PASS\"}" "$HOST/api/v0/auth/login?type=bearer" | jq -r .token)
+	-d "{\"password\":\"$ADMIN_PASS\"}" "$HOST/api/v0/auth/login?include_token=true" | jq -r .token)
 [ -n "$ADMIN_TOKEN" ] && [ "$ADMIN_TOKEN" != "null" ] || _die "admin login failed"
 
 GUEST_TOKEN=$(curl -s -X POST -H "Content-Type: application/json" \
-	-d "{\"password\":\"$GUEST_PASS\"}" "$HOST/api/v0/auth/login?type=bearer" | jq -r .token)
+	-d "{\"password\":\"$GUEST_PASS\"}" "$HOST/api/v0/auth/login?include_token=true" | jq -r .token)
 HAVE_GUEST=0
 [ -n "$GUEST_TOKEN" ] && [ "$GUEST_TOKEN" != "null" ] && HAVE_GUEST=1
 

--- a/unittests/curl-tests/amuleapi/13-downloads-delete-clear.sh
+++ b/unittests/curl-tests/amuleapi/13-downloads-delete-clear.sh
@@ -277,8 +277,8 @@ if [ -n "$COMPLETED_HASH" ]; then
 	_curl -X DELETE -H "Authorization: Bearer $ADMIN_TOKEN" \
 		"$HOST/api/v0/downloads/$COMPLETED_HASH"
 	_assert_status 409 "DELETE /downloads/{completed} → 409"
-	_assert_json_eq '.error.code' completed_use_clear_completed \
-		'DELETE on completed .error.code == completed_use_clear_completed'
+	_assert_json_eq '.error.code' download_completed \
+		'DELETE on completed .error.code == download_completed'
 
 	# clear_completed {hash:completed} → 200, exactly 1 cleared.
 	_curl -X POST -H "Authorization: Bearer $ADMIN_TOKEN" \

--- a/unittests/curl-tests/amuleapi/14-servers-mutations.sh
+++ b/unittests/curl-tests/amuleapi/14-servers-mutations.sh
@@ -97,11 +97,11 @@ fi
 echo "amuleapi 14-servers-mutations smoke @ $HOST"
 
 ADMIN_TOKEN=$(curl -s -X POST -H "Content-Type: application/json" \
-	-d "{\"password\":\"$ADMIN_PASS\"}" "$HOST/api/v0/auth/login?type=bearer" | jq -r .token)
+	-d "{\"password\":\"$ADMIN_PASS\"}" "$HOST/api/v0/auth/login?include_token=true" | jq -r .token)
 [ -n "$ADMIN_TOKEN" ] && [ "$ADMIN_TOKEN" != "null" ] || _die "admin login failed"
 
 GUEST_TOKEN=$(curl -s -X POST -H "Content-Type: application/json" \
-	-d "{\"password\":\"$GUEST_PASS\"}" "$HOST/api/v0/auth/login?type=bearer" | jq -r .token)
+	-d "{\"password\":\"$GUEST_PASS\"}" "$HOST/api/v0/auth/login?include_token=true" | jq -r .token)
 HAVE_GUEST=0
 [ -n "$GUEST_TOKEN" ] && [ "$GUEST_TOKEN" != "null" ] && HAVE_GUEST=1
 

--- a/unittests/curl-tests/amuleapi/15-preferences-patch.sh
+++ b/unittests/curl-tests/amuleapi/15-preferences-patch.sh
@@ -348,7 +348,9 @@ else
 	echo "    info: daemon built without mmap — exercising the 409 capability gate"
 	_curl -X PATCH -H "Authorization: Bearer $ADMIN_TOKEN" -H "Content-Type: application/json" \
 		-d '{"files":{"mmap_enabled":true}}' "$HOST/api/v0/preferences"
-	_assert_status 409 "PATCH files.mmap_enabled on non-mmap daemon → 409 conflict"
+	_assert_status 409 "PATCH files.mmap_enabled on non-mmap daemon → 409"
+	_assert_json_eq '.error.code' option_not_supported \
+		'the 409 names option_not_supported, not a bare conflict'
 fi
 
 # --- Proxy: readable fields present, round-trip, write-only password. -----

--- a/unittests/curl-tests/amuleapi/15-preferences-patch.sh
+++ b/unittests/curl-tests/amuleapi/15-preferences-patch.sh
@@ -83,11 +83,11 @@ fi
 echo "amuleapi 15-preferences-patch smoke @ $HOST"
 
 ADMIN_TOKEN=$(curl -s -X POST -H "Content-Type: application/json" \
-	-d "{\"password\":\"$ADMIN_PASS\"}" "$HOST/api/v0/auth/login?type=bearer" | jq -r .token)
+	-d "{\"password\":\"$ADMIN_PASS\"}" "$HOST/api/v0/auth/login?include_token=true" | jq -r .token)
 [ -n "$ADMIN_TOKEN" ] && [ "$ADMIN_TOKEN" != "null" ] || _die "admin login failed"
 
 GUEST_TOKEN=$(curl -s -X POST -H "Content-Type: application/json" \
-	-d "{\"password\":\"$GUEST_PASS\"}" "$HOST/api/v0/auth/login?type=bearer" | jq -r .token)
+	-d "{\"password\":\"$GUEST_PASS\"}" "$HOST/api/v0/auth/login?include_token=true" | jq -r .token)
 HAVE_GUEST=0
 [ -n "$GUEST_TOKEN" ] && [ "$GUEST_TOKEN" != "null" ] && HAVE_GUEST=1
 

--- a/unittests/curl-tests/amuleapi/16-networks-connect.sh
+++ b/unittests/curl-tests/amuleapi/16-networks-connect.sh
@@ -81,11 +81,11 @@ fi
 echo "amuleapi 16-networks-connect smoke @ $HOST"
 
 ADMIN_TOKEN=$(curl -s -X POST -H "Content-Type: application/json" \
-	-d "{\"password\":\"$ADMIN_PASS\"}" "$HOST/api/v0/auth/login?type=bearer" | jq -r .token)
+	-d "{\"password\":\"$ADMIN_PASS\"}" "$HOST/api/v0/auth/login?include_token=true" | jq -r .token)
 [ -n "$ADMIN_TOKEN" ] && [ "$ADMIN_TOKEN" != "null" ] || _die "admin login failed"
 
 GUEST_TOKEN=$(curl -s -X POST -H "Content-Type: application/json" \
-	-d "{\"password\":\"$GUEST_PASS\"}" "$HOST/api/v0/auth/login?type=bearer" | jq -r .token)
+	-d "{\"password\":\"$GUEST_PASS\"}" "$HOST/api/v0/auth/login?include_token=true" | jq -r .token)
 HAVE_GUEST=0
 [ -n "$GUEST_TOKEN" ] && [ "$GUEST_TOKEN" != "null" ] && HAVE_GUEST=1
 

--- a/unittests/curl-tests/amuleapi/17-shared-priority-patch.sh
+++ b/unittests/curl-tests/amuleapi/17-shared-priority-patch.sh
@@ -74,11 +74,11 @@ fi
 echo "amuleapi 17-shared-priority-patch smoke @ $HOST"
 
 ADMIN_TOKEN=$(curl -s -X POST -H "Content-Type: application/json" \
-	-d "{\"password\":\"$ADMIN_PASS\"}" "$HOST/api/v0/auth/login?type=bearer" | jq -r .token)
+	-d "{\"password\":\"$ADMIN_PASS\"}" "$HOST/api/v0/auth/login?include_token=true" | jq -r .token)
 [ -n "$ADMIN_TOKEN" ] && [ "$ADMIN_TOKEN" != "null" ] || _die "admin login failed"
 
 GUEST_TOKEN=$(curl -s -X POST -H "Content-Type: application/json" \
-	-d "{\"password\":\"$GUEST_PASS\"}" "$HOST/api/v0/auth/login?type=bearer" | jq -r .token)
+	-d "{\"password\":\"$GUEST_PASS\"}" "$HOST/api/v0/auth/login?include_token=true" | jq -r .token)
 HAVE_GUEST=0
 [ -n "$GUEST_TOKEN" ] && [ "$GUEST_TOKEN" != "null" ] && HAVE_GUEST=1
 

--- a/unittests/curl-tests/amuleapi/18-categories-crud.sh
+++ b/unittests/curl-tests/amuleapi/18-categories-crud.sh
@@ -86,11 +86,11 @@ mkdir -p "$TEST_PATH"
 echo "amuleapi 18-categories-crud smoke @ $HOST"
 
 ADMIN_TOKEN=$(curl -s -X POST -H "Content-Type: application/json" \
-	-d "{\"password\":\"$ADMIN_PASS\"}" "$HOST/api/v0/auth/login?type=bearer" | jq -r .token)
+	-d "{\"password\":\"$ADMIN_PASS\"}" "$HOST/api/v0/auth/login?include_token=true" | jq -r .token)
 [ -n "$ADMIN_TOKEN" ] && [ "$ADMIN_TOKEN" != "null" ] || _die "admin login failed"
 
 GUEST_TOKEN=$(curl -s -X POST -H "Content-Type: application/json" \
-	-d "{\"password\":\"$GUEST_PASS\"}" "$HOST/api/v0/auth/login?type=bearer" | jq -r .token)
+	-d "{\"password\":\"$GUEST_PASS\"}" "$HOST/api/v0/auth/login?include_token=true" | jq -r .token)
 HAVE_GUEST=0
 [ -n "$GUEST_TOKEN" ] && [ "$GUEST_TOKEN" != "null" ] && HAVE_GUEST=1
 

--- a/unittests/curl-tests/amuleapi/19-search.sh
+++ b/unittests/curl-tests/amuleapi/19-search.sh
@@ -165,11 +165,11 @@ fi
 echo "amuleapi 19-search smoke @ $HOST"
 
 ADMIN_TOKEN=$(curl -s -X POST -H "Content-Type: application/json" \
-	-d "{\"password\":\"$ADMIN_PASS\"}" "$HOST/api/v0/auth/login?type=bearer" | jq -r .token)
+	-d "{\"password\":\"$ADMIN_PASS\"}" "$HOST/api/v0/auth/login?include_token=true" | jq -r .token)
 [ -n "$ADMIN_TOKEN" ] && [ "$ADMIN_TOKEN" != "null" ] || _die "admin login failed"
 
 GUEST_TOKEN=$(curl -s -X POST -H "Content-Type: application/json" \
-	-d "{\"password\":\"$GUEST_PASS\"}" "$HOST/api/v0/auth/login?type=bearer" | jq -r .token)
+	-d "{\"password\":\"$GUEST_PASS\"}" "$HOST/api/v0/auth/login?include_token=true" | jq -r .token)
 HAVE_GUEST=0
 [ -n "$GUEST_TOKEN" ] && [ "$GUEST_TOKEN" != "null" ] && HAVE_GUEST=1
 
@@ -381,7 +381,7 @@ done
 sleep 4
 
 SECOND_TOKEN=$(curl -s -X POST -H "Content-Type: application/json" \
-	-d "{\"password\":\"$ADMIN_PASS\"}" "http://$SECOND_HOST/api/v0/auth/login?type=bearer" \
+	-d "{\"password\":\"$ADMIN_PASS\"}" "http://$SECOND_HOST/api/v0/auth/login?include_token=true" \
 	| jq -r .token)
 
 if [ -n "$SECOND_TOKEN" ] && [ "$SECOND_TOKEN" != "null" ]; then
@@ -1128,7 +1128,7 @@ if [ -n "$SID_CLOSE" ] && [ "$SID_CLOSE" != "null" ]; then
 	sleep 2
 	SECOND2_TOKEN=$(curl -s -X POST -H "Content-Type: application/json" \
 		-d "{\"password\":\"$ADMIN_PASS\"}" \
-		"http://localhost:4715/api/v0/auth/login?type=bearer" | jq -r .token)
+		"http://localhost:4715/api/v0/auth/login?include_token=true" | jq -r .token)
 	if [ -n "$SECOND2_TOKEN" ] && [ "$SECOND2_TOKEN" != "null" ]; then
 		_curl -H "Authorization: Bearer $SECOND2_TOKEN" "http://localhost:4715/api/v0/search"
 		_assert_json_eq "[.searches[] | select(.id == $SID_CLOSE)] | length" 0 \
@@ -1185,7 +1185,7 @@ done
 sleep 2
 FOREIGN_TOKEN=$(curl -s -X POST -H "Content-Type: application/json" \
 	-d "{\"password\":\"$ADMIN_PASS\"}" \
-	"http://localhost:4716/api/v0/auth/login?type=bearer" | jq -r .token)
+	"http://localhost:4716/api/v0/auth/login?include_token=true" | jq -r .token)
 
 if [ -n "$FOREIGN_TOKEN" ] && [ "$FOREIGN_TOKEN" != "null" ]; then
 	FOREIGN_RES=$(curl -s -X POST -H "Authorization: Bearer $FOREIGN_TOKEN" \
@@ -1604,7 +1604,7 @@ if [ "$HAVE_SECOND_INSTANCE" -eq 1 ]; then
 	sleep 3
 
 	THIRD_TOKEN=$(curl -s -X POST -H "Content-Type: application/json" \
-		-d "{\"password\":\"$ADMIN_PASS\"}" "http://$THIRD_HOST/api/v0/auth/login?type=bearer" \
+		-d "{\"password\":\"$ADMIN_PASS\"}" "http://$THIRD_HOST/api/v0/auth/login?include_token=true" \
 		| jq -r .token)
 
 	if [ -n "$THIRD_TOKEN" ] && [ "$THIRD_TOKEN" != "null" ]; then

--- a/unittests/curl-tests/amuleapi/20-etag-conditional-get.sh
+++ b/unittests/curl-tests/amuleapi/20-etag-conditional-get.sh
@@ -89,7 +89,7 @@ fi
 echo "amuleapi 20-etag-conditional-get smoke @ $HOST"
 
 ADMIN_TOKEN=$(curl -s -X POST -H "Content-Type: application/json" \
-	-d "{\"password\":\"$ADMIN_PASS\"}" "$HOST/api/v0/auth/login?type=bearer" | jq -r .token)
+	-d "{\"password\":\"$ADMIN_PASS\"}" "$HOST/api/v0/auth/login?include_token=true" | jq -r .token)
 [ -n "$ADMIN_TOKEN" ] && [ "$ADMIN_TOKEN" != "null" ] || _die "admin login failed"
 
 sleep 4

--- a/unittests/curl-tests/amuleapi/21-sse-heartbeat.sh
+++ b/unittests/curl-tests/amuleapi/21-sse-heartbeat.sh
@@ -66,7 +66,7 @@ fi
 echo "amuleapi 21-sse-heartbeat smoke @ $HOST"
 
 ADMIN_TOKEN=$(curl -s -X POST -H "Content-Type: application/json" \
-	-d "{\"password\":\"$ADMIN_PASS\"}" "$HOST/api/v0/auth/login?type=bearer" | jq -r .token)
+	-d "{\"password\":\"$ADMIN_PASS\"}" "$HOST/api/v0/auth/login?include_token=true" | jq -r .token)
 [ -n "$ADMIN_TOKEN" ] && [ "$ADMIN_TOKEN" != "null" ] || _die "admin login failed"
 
 # --- 1. Auth gate. -------------------------------------------------

--- a/unittests/curl-tests/amuleapi/22-sse-diff-emission.sh
+++ b/unittests/curl-tests/amuleapi/22-sse-diff-emission.sh
@@ -65,7 +65,7 @@ fi
 echo "amuleapi 22-sse-diff-emission smoke @ $HOST"
 
 ADMIN_TOKEN=$(curl -s -X POST -H "Content-Type: application/json" \
-	-d "{\"password\":\"$ADMIN_PASS\"}" "$HOST/api/v0/auth/login?type=bearer" | jq -r .token)
+	-d "{\"password\":\"$ADMIN_PASS\"}" "$HOST/api/v0/auth/login?include_token=true" | jq -r .token)
 [ -n "$ADMIN_TOKEN" ] && [ "$ADMIN_TOKEN" != "null" ] || _die "admin login failed"
 
 sleep 4

--- a/unittests/curl-tests/amuleapi/23-sse-replay.sh
+++ b/unittests/curl-tests/amuleapi/23-sse-replay.sh
@@ -53,7 +53,7 @@ fi
 echo "amuleapi 23-sse-replay smoke @ $HOST"
 
 ADMIN_TOKEN=$(curl -s -X POST -H "Content-Type: application/json" \
-	-d "{\"password\":\"$ADMIN_PASS\"}" "$HOST/api/v0/auth/login?type=bearer" | jq -r .token)
+	-d "{\"password\":\"$ADMIN_PASS\"}" "$HOST/api/v0/auth/login?include_token=true" | jq -r .token)
 [ -n "$ADMIN_TOKEN" ] && [ "$ADMIN_TOKEN" != "null" ] || _die "admin login failed"
 
 sleep 4

--- a/unittests/curl-tests/amuleapi/24-sse-resync.sh
+++ b/unittests/curl-tests/amuleapi/24-sse-resync.sh
@@ -105,7 +105,7 @@ done
 # token from before the bounce is unrelated (its rate-limit bucket
 # is empty too).
 ADMIN_TOKEN=$(curl -s -X POST -H "Content-Type: application/json" \
-	-d "{\"password\":\"$ADMIN_PASS\"}" "$HOST/api/v0/auth/login?type=bearer" | jq -r .token)
+	-d "{\"password\":\"$ADMIN_PASS\"}" "$HOST/api/v0/auth/login?include_token=true" | jq -r .token)
 [ -n "$ADMIN_TOKEN" ] && [ "$ADMIN_TOKEN" != "null" ] || _die "admin login failed after bounce"
 
 # Deterministically rotate the ring past id 1 instead of hoping the

--- a/unittests/curl-tests/amuleapi/25-cors.sh
+++ b/unittests/curl-tests/amuleapi/25-cors.sh
@@ -380,7 +380,7 @@ fi
 # HEAD doesn't trigger the streaming handler, so we do a short -m 2.
 : > "$HDR"; : > "$SSE"
 ADMIN_TOKEN=$(curl -s -X POST -H "Content-Type: application/json" \
-	-d "{\"password\":\"$ADMIN_PASS\"}" "$HOST/api/v0/auth/login?type=bearer" | jq -r .token)
+	-d "{\"password\":\"$ADMIN_PASS\"}" "$HOST/api/v0/auth/login?include_token=true" | jq -r .token)
 [ -n "$ADMIN_TOKEN" ] && [ "$ADMIN_TOKEN" != "null" ] || _die "admin login failed"
 curl -sS -m 2 -D "$HDR" -o "$SSE" \
 	-H "Origin: https://allowed.example.com" \

--- a/unittests/curl-tests/amuleapi/26-rfc-followup-endpoints.sh
+++ b/unittests/curl-tests/amuleapi/26-rfc-followup-endpoints.sh
@@ -12,7 +12,7 @@
 #   * DELETE /logs/server_info              — clear MOTD log + invalidate lazy cache
 #   * POST   /downloads {"links":[...]}    — array body, the only spelling
 #   * POST   /networks/disconnect          — `{"network":"ed2k"|"kad"|"both"}` selector
-#   * GET    /clients?filter=uploads|downloads|active
+#   * GET    /clients?activity=uploading|downloading|active
 #   * GET    /events?channels=<csv>        — subscribe to a subset of event types
 #
 # All log-mutating tests verify that a *fast* GET immediately after the
@@ -324,54 +324,54 @@ fi
 # Get baseline first
 TOTAL_CLIENTS=$(curl -s "${H_AUTH[@]}" "$HOST/api/v0/clients" \
 	| jq '.clients | length')
-UP_CLIENTS=$(curl -s "${H_AUTH[@]}" "$HOST/api/v0/clients?filter=uploads" \
+UP_CLIENTS=$(curl -s "${H_AUTH[@]}" "$HOST/api/v0/clients?activity=uploading" \
 	| jq '.clients | length')
-DOWN_CLIENTS=$(curl -s "${H_AUTH[@]}" "$HOST/api/v0/clients?filter=downloads" \
+DOWN_CLIENTS=$(curl -s "${H_AUTH[@]}" "$HOST/api/v0/clients?activity=downloading" \
 	| jq '.clients | length')
-ACTIVE_CLIENTS=$(curl -s "${H_AUTH[@]}" "$HOST/api/v0/clients?filter=active" \
+ACTIVE_CLIENTS=$(curl -s "${H_AUTH[@]}" "$HOST/api/v0/clients?activity=active" \
 	| jq '.clients | length')
 if [ "$UP_CLIENTS" -le "$TOTAL_CLIENTS" ] 2>/dev/null \
    && [ "$DOWN_CLIENTS" -le "$TOTAL_CLIENTS" ] 2>/dev/null \
    && [ "$ACTIVE_CLIENTS" -le "$TOTAL_CLIENTS" ] 2>/dev/null; then
-	_pass "/clients filters: total=$TOTAL_CLIENTS up=$UP_CLIENTS down=$DOWN_CLIENTS active=$ACTIVE_CLIENTS (each ≤ total)"
+	_pass "/clients activity: total=$TOTAL_CLIENTS up=$UP_CLIENTS down=$DOWN_CLIENTS active=$ACTIVE_CLIENTS (each ≤ total)"
 else
-	_fail "clients filter sizing" \
+	_fail "clients activity sizing" \
 		"total=$TOTAL_CLIENTS up=$UP_CLIENTS down=$DOWN_CLIENTS active=$ACTIVE_CLIENTS"
 fi
-# `active` = |uploads ∪ downloads|, so it sits in
+# `active` = |uploading ∪ downloading|, so it sits in
 # [max(up, down), up+down]. The lower bound holds because every
-# uploads-or-downloads-only peer is in active; the upper bound holds
-# because a peer simultaneously in both states (upload_state=uploading
+# uploading-or-downloading-only client is in active; the upper bound holds
+# because a client simultaneously in both states (upload_state=uploading
 # AND download_state=downloading) gets counted once in active but
 # twice in (up + down). Exact equality is intentionally not asserted
-# because the intersection count is unobservable from filter results
+# because the intersection count is unobservable from activity results
 # alone.
 EXP_UPPER=$((UP_CLIENTS + DOWN_CLIENTS))
 if [ "$ACTIVE_CLIENTS" -ge "$UP_CLIENTS" ] 2>/dev/null \
    && [ "$ACTIVE_CLIENTS" -ge "$DOWN_CLIENTS" ] 2>/dev/null \
    && [ "$ACTIVE_CLIENTS" -le "$EXP_UPPER" ] 2>/dev/null; then
-	_pass "/clients?filter=active sits in [max(up,down), up+down]"
+	_pass "/clients?activity=active sits in [max(up,down), up+down]"
 else
 	_fail "clients active span" \
 		"active=$ACTIVE_CLIENTS up=$UP_CLIENTS down=$DOWN_CLIENTS (expected max..sum)"
 fi
-# Verify every entry in /clients?filter=uploads truly has upload_state=uploading
-BAD=$(curl -s "${H_AUTH[@]}" "$HOST/api/v0/clients?filter=uploads" \
+# Verify every entry in /clients?activity=uploading truly has upload_state=uploading
+BAD=$(curl -s "${H_AUTH[@]}" "$HOST/api/v0/clients?activity=uploading" \
 	| jq -r '.clients[] | select(.upload_state != "uploading") | .ecid' \
 	| head -1)
 if [ -z "$BAD" ]; then
-	_pass "/clients?filter=uploads only returns upload_state=uploading peers"
+	_pass "/clients?activity=uploading only returns upload_state=uploading clients"
 else
-	_fail "clients uploads filter content" \
+	_fail "clients activity=uploading content" \
 		"client_ecid $BAD has wrong upload_state"
 fi
 # Bogus filter → 400
 RC=$(curl -s -o /dev/null -w "%{http_code}" "${H_AUTH[@]}" \
-	"$HOST/api/v0/clients?filter=alphabetical")
+	"$HOST/api/v0/clients?activity=alphabetical")
 if [ "$RC" = "400" ]; then
-	_pass "/clients?filter=<bogus> → 400"
+	_pass "/clients?activity=<bogus> → 400"
 else
-	_fail "clients bogus filter" "expected 400, got $RC"
+	_fail "clients bogus activity" "expected 400, got $RC"
 fi
 
 # --- 9a-bis. Base transfer-filename fields on the LIST object -----

--- a/unittests/curl-tests/amuleapi/26-rfc-followup-endpoints.sh
+++ b/unittests/curl-tests/amuleapi/26-rfc-followup-endpoints.sh
@@ -9,7 +9,7 @@
 #   * POST   /servers/by-address/<ip>:<port>/connect — address-keyed route
 #   * DELETE /servers/by-address/<ip>:<port>         — address-keyed route
 #   * DELETE /logs/amule                   — clear amule log + in-process cache
-#   * DELETE /logs/serverinfo              — clear MOTD log + invalidate lazy cache
+#   * DELETE /logs/server_info              — clear MOTD log + invalidate lazy cache
 #   * POST   /downloads {"links":[...]}    — array body, the only spelling
 #   * POST   /networks/disconnect          — `{"network":"ed2k"|"kad"|"both"}` selector
 #   * GET    /clients?filter=uploads|downloads|active
@@ -64,7 +64,7 @@ fi
 echo "amuleapi 26-rfc-followup-endpoints smoke @ $HOST"
 
 ADMIN_TOKEN=$(curl -s -X POST -H "Content-Type: application/json" \
-	-d "{\"password\":\"$ADMIN_PASS\"}" "$HOST/api/v0/auth/login?type=bearer" | jq -r .token)
+	-d "{\"password\":\"$ADMIN_PASS\"}" "$HOST/api/v0/auth/login?include_token=true" | jq -r .token)
 [ -n "$ADMIN_TOKEN" ] && [ "$ADMIN_TOKEN" != "null" ] || _die "admin login failed"
 H_AUTH=(-H "Authorization: Bearer $ADMIN_TOKEN")
 sleep 4
@@ -199,7 +199,7 @@ fi
 # Fast GET immediately after — must show empty / post-reset state.
 GET_BODY=$(curl -s "${H_AUTH[@]}" "$HOST/api/v0/logs/amule")
 LINES=$(echo "$GET_BODY" | jq -r '.lines | length' 2>/dev/null)
-TOTAL=$(echo "$GET_BODY" | jq -r '.total_cached' 2>/dev/null)
+TOTAL=$(echo "$GET_BODY" | jq -r '.total_lines' 2>/dev/null)
 if [ "$LINES" = "0" ] && [ "$TOTAL" = "0" ]; then
 	_pass "GET /logs/amule immediately after DELETE returns empty (no stale cache)"
 else
@@ -207,21 +207,21 @@ else
 		"lines=$LINES total=$TOTAL — expected 0/0"
 fi
 
-# --- 6. DELETE /logs/serverinfo + freshness (lazy cache!). -------
+# --- 6. DELETE /logs/server_info + freshness (lazy cache!). -------
 RC=$(curl -s -o /dev/null -w "%{http_code}" -X DELETE "${H_AUTH[@]}" \
-	"$HOST/api/v0/logs/serverinfo")
+	"$HOST/api/v0/logs/server_info")
 if [ "$RC" = "204" ]; then
-	_pass "DELETE /logs/serverinfo → 204"
+	_pass "DELETE /logs/server_info → 204"
 else
-	_fail "logs/serverinfo DELETE" "expected 204, got $RC"
+	_fail "logs/server_info DELETE" "expected 204, got $RC"
 fi
 # Fast GET immediately after — must show empty / post-reset.
-GET_BODY=$(curl -s "${H_AUTH[@]}" "$HOST/api/v0/logs/serverinfo")
+GET_BODY=$(curl -s "${H_AUTH[@]}" "$HOST/api/v0/logs/server_info")
 BYTES=$(echo "$GET_BODY" | jq -r '.total_bytes' 2>/dev/null)
 if [ "$BYTES" = "0" ]; then
-	_pass "GET /logs/serverinfo immediately after DELETE returns empty (lazy cache invalidated)"
+	_pass "GET /logs/server_info immediately after DELETE returns empty (lazy cache invalidated)"
 else
-	_fail "logs/serverinfo post-DELETE freshness" \
+	_fail "logs/server_info post-DELETE freshness" \
 		"total_bytes=$BYTES — expected 0"
 fi
 

--- a/unittests/curl-tests/amuleapi/28-list-pagination-sort.sh
+++ b/unittests/curl-tests/amuleapi/28-list-pagination-sort.sh
@@ -109,7 +109,7 @@ echo "amuleapi 28-list-pagination-sort smoke @ $HOST"
 # --- 0. Log in. ----------------------------------------------------
 TOKEN=$(curl -s -X POST -H "Content-Type: application/json" \
 	-d "{\"password\":\"$ADMIN_PASS\"}" \
-	"$HOST/api/v0/auth/login?type=bearer" | jq -r .token)
+	"$HOST/api/v0/auth/login?include_token=true" | jq -r .token)
 [ -n "$TOKEN" ] && [ "$TOKEN" != "null" ] \
 	|| _die "could not log in for pagination tests"
 

--- a/unittests/curl-tests/amuleapi/29-bulk-mutations.sh
+++ b/unittests/curl-tests/amuleapi/29-bulk-mutations.sh
@@ -45,7 +45,7 @@ curl -s -o /dev/null --max-time 2 "$HOST/api/v0/health" || _die "amuleapi at $HO
 
 echo "amuleapi 29-bulk-mutations @ $HOST"
 TOKEN=$(curl -s -X POST -H "Content-Type: application/json" -d "{\"password\":\"$ADMIN_PASS\"}" \
-	"$HOST/api/v0/auth/login?type=bearer" | jq -r .token)
+	"$HOST/api/v0/auth/login?include_token=true" | jq -r .token)
 [ -n "$TOKEN" ] && [ "$TOKEN" != "null" ] || _die "login failed"
 sleep 2
 

--- a/unittests/curl-tests/amuleapi/30-shared-verify.sh
+++ b/unittests/curl-tests/amuleapi/30-shared-verify.sh
@@ -87,11 +87,11 @@ fi
 echo "amuleapi 30-shared-verify smoke @ $HOST"
 
 ADMIN_TOKEN=$(curl -s -X POST -H "Content-Type: application/json" \
-	-d "{\"password\":\"$ADMIN_PASS\"}" "$HOST/api/v0/auth/login?type=bearer" | jq -r .token)
+	-d "{\"password\":\"$ADMIN_PASS\"}" "$HOST/api/v0/auth/login?include_token=true" | jq -r .token)
 [ -n "$ADMIN_TOKEN" ] && [ "$ADMIN_TOKEN" != "null" ] || _die "admin login failed"
 
 GUEST_TOKEN=$(curl -s -X POST -H "Content-Type: application/json" \
-	-d "{\"password\":\"$GUEST_PASS\"}" "$HOST/api/v0/auth/login?type=bearer" | jq -r .token)
+	-d "{\"password\":\"$GUEST_PASS\"}" "$HOST/api/v0/auth/login?include_token=true" | jq -r .token)
 HAVE_GUEST=0
 [ -n "$GUEST_TOKEN" ] && [ "$GUEST_TOKEN" != "null" ] && HAVE_GUEST=1
 

--- a/unittests/curl-tests/amuleapi/31-shared-directories.sh
+++ b/unittests/curl-tests/amuleapi/31-shared-directories.sh
@@ -96,11 +96,11 @@ fi
 echo "amuleapi 31-shared-directories smoke @ $HOST"
 
 ADMIN_TOKEN=$(curl -s -X POST -H "Content-Type: application/json" \
-	-d "{\"password\":\"$ADMIN_PASS\"}" "$HOST/api/v0/auth/login?type=bearer" | jq -r .token)
+	-d "{\"password\":\"$ADMIN_PASS\"}" "$HOST/api/v0/auth/login?include_token=true" | jq -r .token)
 [ -n "$ADMIN_TOKEN" ] && [ "$ADMIN_TOKEN" != "null" ] || _die "admin login failed"
 
 GUEST_TOKEN=$(curl -s -X POST -H "Content-Type: application/json" \
-	-d "{\"password\":\"$GUEST_PASS\"}" "$HOST/api/v0/auth/login?type=bearer" | jq -r .token)
+	-d "{\"password\":\"$GUEST_PASS\"}" "$HOST/api/v0/auth/login?include_token=true" | jq -r .token)
 HAVE_GUEST=0
 [ -n "$GUEST_TOKEN" ] && [ "$GUEST_TOKEN" != "null" ] && HAVE_GUEST=1
 

--- a/unittests/curl-tests/amuleapi/33-known-clients.sh
+++ b/unittests/curl-tests/amuleapi/33-known-clients.sh
@@ -98,7 +98,7 @@ echo "amuleapi 33-known-clients @ $HOST"
 # --- 0. Log in. ----------------------------------------------------
 TOKEN=$(curl -s -X POST -H "Content-Type: application/json" \
 	-d "{\"password\":\"$ADMIN_PASS\"}" \
-	"$HOST/api/v0/auth/login?type=bearer" | jq -r .token)
+	"$HOST/api/v0/auth/login?include_token=true" | jq -r .token)
 [ -n "$TOKEN" ] && [ "$TOKEN" != "null" ] \
 	|| _die "could not log in for known-clients tests"
 AUTH=(-H "Authorization: Bearer $TOKEN")

--- a/unittests/curl-tests/amuleapi/34-friends.sh
+++ b/unittests/curl-tests/amuleapi/34-friends.sh
@@ -88,7 +88,7 @@ echo "amuleapi 34-friends @ $HOST"
 # --- 0. Log in. ----------------------------------------------------
 TOKEN=$(curl -s -X POST -H "Content-Type: application/json" \
 	-d "{\"password\":\"$ADMIN_PASS\"}" \
-	"$HOST/api/v0/auth/login?type=bearer" | jq -r .token)
+	"$HOST/api/v0/auth/login?include_token=true" | jq -r .token)
 [ -n "$TOKEN" ] && [ "$TOKEN" != "null" ] || _die "could not log in for friends tests"
 AUTH=(-H "Authorization: Bearer $TOKEN")
 
@@ -252,7 +252,7 @@ _assert_status 405 "POST /friends/{ecid} is 405"
 # --- 7. Guests read but cannot mutate. ------------------------------
 GUEST_TOKEN=$(curl -s -X POST -H "Content-Type: application/json" \
 	-d "{\"password\":\"$GUEST_PASS\"}" \
-	"$HOST/api/v0/auth/login?type=bearer" | jq -r .token)
+	"$HOST/api/v0/auth/login?include_token=true" | jq -r .token)
 if [ -n "$GUEST_TOKEN" ] && [ "$GUEST_TOKEN" != "null" ]; then
 	SAVED=("${AUTH[@]}")
 	AUTH=(-H "Authorization: Bearer $GUEST_TOKEN")

--- a/unittests/curl-tests/amuleapi/35-ipfilter-actions.sh
+++ b/unittests/curl-tests/amuleapi/35-ipfilter-actions.sh
@@ -122,11 +122,11 @@ fi
 echo "amuleapi 35-ipfilter-actions smoke @ $HOST"
 
 ADMIN_TOKEN=$(curl -s -X POST -H "Content-Type: application/json" \
-	-d "{\"password\":\"$ADMIN_PASS\"}" "$HOST/api/v0/auth/login?type=bearer" | jq -r .token)
+	-d "{\"password\":\"$ADMIN_PASS\"}" "$HOST/api/v0/auth/login?include_token=true" | jq -r .token)
 [ -n "$ADMIN_TOKEN" ] && [ "$ADMIN_TOKEN" != "null" ] || _die "admin login failed"
 
 GUEST_TOKEN=$(curl -s -X POST -H "Content-Type: application/json" \
-	-d "{\"password\":\"$GUEST_PASS\"}" "$HOST/api/v0/auth/login?type=bearer" | jq -r .token)
+	-d "{\"password\":\"$GUEST_PASS\"}" "$HOST/api/v0/auth/login?include_token=true" | jq -r .token)
 HAVE_GUEST=0
 [ -n "$GUEST_TOKEN" ] && [ "$GUEST_TOKEN" != "null" ] && HAVE_GUEST=1
 

--- a/unittests/curl-tests/amuleapi/36-shared-reload.sh
+++ b/unittests/curl-tests/amuleapi/36-shared-reload.sh
@@ -90,11 +90,11 @@ fi
 echo "amuleapi 36-shared-reload smoke @ $HOST"
 
 ADMIN_TOKEN=$(curl -s -X POST -H "Content-Type: application/json" \
-	-d "{\"password\":\"$ADMIN_PASS\"}" "$HOST/api/v0/auth/login?type=bearer" | jq -r .token)
+	-d "{\"password\":\"$ADMIN_PASS\"}" "$HOST/api/v0/auth/login?include_token=true" | jq -r .token)
 [ -n "$ADMIN_TOKEN" ] && [ "$ADMIN_TOKEN" != "null" ] || _die "admin login failed"
 
 GUEST_TOKEN=$(curl -s -X POST -H "Content-Type: application/json" \
-	-d "{\"password\":\"$GUEST_PASS\"}" "$HOST/api/v0/auth/login?type=bearer" | jq -r .token)
+	-d "{\"password\":\"$GUEST_PASS\"}" "$HOST/api/v0/auth/login?include_token=true" | jq -r .token)
 HAVE_GUEST=0
 [ -n "$GUEST_TOKEN" ] && [ "$GUEST_TOKEN" != "null" ] && HAVE_GUEST=1
 

--- a/unittests/curl-tests/amuleapi/37-shared-availability-parts.sh
+++ b/unittests/curl-tests/amuleapi/37-shared-availability-parts.sh
@@ -85,7 +85,7 @@ echo "amuleapi 37-shared-availability-parts smoke @ $HOST"
 
 TOKEN=$(curl -s -X POST -H "Content-Type: application/json" \
 	-d "{\"password\":\"$ADMIN_PASS\"}" \
-	"$HOST/api/v0/auth/login?type=bearer" | jq -r .token)
+	"$HOST/api/v0/auth/login?include_token=true" | jq -r .token)
 [ -n "$TOKEN" ] && [ "$TOKEN" != "null" ] || _die "login failed"
 
 # The RLE decoder needs the first EC_TAG_KNOWNFILE frame to seed itself
@@ -204,7 +204,7 @@ if [ "$COUNT" -gt 0 ]; then
 	# --- 8. Guest sessions see the bar too (read-only data). -------
 	GUEST_TOKEN=$(curl -s -X POST -H "Content-Type: application/json" \
 		-d "{\"password\":\"${GUEST_PASS:-guestpass}\"}" \
-		"$HOST/api/v0/auth/login?type=bearer" | jq -r .token)
+		"$HOST/api/v0/auth/login?include_token=true" | jq -r .token)
 	if [ -n "$GUEST_TOKEN" ] && [ "$GUEST_TOKEN" != "null" ]; then
 		_curl -H "Authorization: Bearer $GUEST_TOKEN" "$HOST/api/v0/shared/$FIRST_HASH"
 		_assert_status 200 "GET /shared/{hash} as guest → 200"

--- a/unittests/curl-tests/amuleapi/38-chat.sh
+++ b/unittests/curl-tests/amuleapi/38-chat.sh
@@ -97,7 +97,7 @@ echo "amuleapi 38-chat smoke @ $HOST"
 
 TOKEN=$(curl -s -X POST -H "Content-Type: application/json" \
 	-d "{\"password\":\"$ADMIN_PASS\"}" \
-	"$HOST/api/v0/auth/login?type=bearer" | jq -r .token)
+	"$HOST/api/v0/auth/login?include_token=true" | jq -r .token)
 [ -n "$TOKEN" ] && [ "$TOKEN" != "null" ] || _die "login failed"
 
 # --- 1. Capability gate. ------------------------------------------
@@ -248,7 +248,7 @@ _assert_status 405 "PATCH /chats/{client_address} → 405"
 # --- 8. Guests read but do not write. -----------------------------
 GUEST_TOKEN=$(curl -s -X POST -H "Content-Type: application/json" \
 	-d "{\"password\":\"$GUEST_PASS\"}" \
-	"$HOST/api/v0/auth/login?type=bearer" | jq -r .token)
+	"$HOST/api/v0/auth/login?include_token=true" | jq -r .token)
 if [ -n "$GUEST_TOKEN" ] && [ "$GUEST_TOKEN" != "null" ]; then
 	_curl -H "Authorization: Bearer $GUEST_TOKEN" "$HOST/api/v0/chats"
 	_assert_status 200 "GET /chats as guest → 200 (read-only data)"

--- a/unittests/curl-tests/amuleapi/39-shared-media-refresh.sh
+++ b/unittests/curl-tests/amuleapi/39-shared-media-refresh.sh
@@ -3,10 +3,10 @@
 # amuleapi 39-shared-media-refresh — re-extracting media metadata (issue #1079).
 #
 # Wire contract:
-#   POST /shared/media/refresh          → 202 { scope:"all",  queued }
-#   POST /shared/{hash}/media/refresh   → 202 { scope:"file", queued }
+#   POST /shared/media/refresh          → 202 { scope:"all",  queued_file_count }
+#   POST /shared/{hash}/media/refresh   → 202 { scope:"file", queued_file_count }
 #
-# `queued` counts files ACCEPTED for probing, not files that produced
+# `queued_file_count` counts files ACCEPTED for probing, not files that produced
 # metadata: the scheduler drops anything that is not audio/video by
 # extension, is an incomplete download, or is missing on disk. Nothing has
 # been extracted when the response returns -- the probes run on amuled's
@@ -68,7 +68,7 @@ echo "amuleapi 39-shared-media-refresh smoke @ $HOST"
 
 TOKEN=$(curl -s -X POST -H "Content-Type: application/json" \
 	-d "{\"password\":\"$ADMIN_PASS\"}" \
-	"$HOST/api/v0/auth/login?type=bearer" | jq -r .token)
+	"$HOST/api/v0/auth/login?include_token=true" | jq -r .token)
 [ -n "$TOKEN" ] && [ "$TOKEN" != "null" ] || _die "login failed"
 
 # --- 1. Whole-share refresh. ---------------------------------------
@@ -98,11 +98,11 @@ if [ "$CURL_STATUS" = "503" ]; then
 	exit 1
 fi
 _assert_status 202 "POST /shared/media/refresh → 202 Accepted"
-# `scope` and `queued` stay: `queued` is a real count of what the scheduler
+# `scope` and the count stay: it is a real count of what the scheduler
 # accepted, which no later read reports. `ok` is gone; the 202 carried it.
 _assert_json_eq '. | has("ok")' false 'whole-share refresh has no constant ok field'
 _assert_json_eq '.scope'         all   'whole-share refresh reports scope=all'
-_assert_json_eq '.queued | type' number 'queued is numeric'
+_assert_json_eq '.queued_file_count | type' number 'queued_file_count is numeric'
 
 # --- 2. Method + auth gating. --------------------------------------
 _curl -H "Authorization: Bearer $TOKEN" "$HOST/api/v0/shared/media/refresh"
@@ -112,7 +112,7 @@ _assert_status 401 "POST without a token → 401"
 
 GUEST_TOKEN=$(curl -s -X POST -H "Content-Type: application/json" \
 	-d "{\"password\":\"${GUEST_PASS}\"}" \
-	"$HOST/api/v0/auth/login?type=bearer" | jq -r .token)
+	"$HOST/api/v0/auth/login?include_token=true" | jq -r .token)
 if [ -n "$GUEST_TOKEN" ] && [ "$GUEST_TOKEN" != "null" ]; then
 	_curl -X POST -H "Authorization: Bearer $GUEST_TOKEN" "$HOST/api/v0/shared/media/refresh"
 	_assert_status 403 "POST as guest → 403 (refresh is admin-only)"

--- a/unittests/curl-tests/amuleapi/40-http-conformance.sh
+++ b/unittests/curl-tests/amuleapi/40-http-conformance.sh
@@ -81,7 +81,7 @@ if ! curl -s -o /dev/null --max-time 2 "$HOST/api/v0/health" 2>/dev/null; then
 fi
 
 TOKEN=$(curl -s -X POST -H "Content-Type: application/json" \
-	-d "{\"password\":\"$ADMIN_PASS\"}" "$HOST/api/v0/auth/login?type=bearer" | jq -r .token)
+	-d "{\"password\":\"$ADMIN_PASS\"}" "$HOST/api/v0/auth/login?include_token=true" | jq -r .token)
 [ -n "$TOKEN" ] && [ "$TOKEN" != "null" ] || _die "admin login failed"
 AUTH=(-H "Authorization: Bearer $TOKEN")
 
@@ -810,7 +810,7 @@ fi
 # different documents, and the second was answered 304 against the first's.
 GUEST_TOKEN=$(curl -s -X POST -H "Content-Type: application/json" \
 	-d "{\"password\":\"${GUEST_PASS:-guestpass}\"}" \
-	"$HOST/api/v0/auth/login?type=bearer" 2>/dev/null | jq -r .token)
+	"$HOST/api/v0/auth/login?include_token=true" 2>/dev/null | jq -r .token)
 if [ -z "$GUEST_TOKEN" ] || [ "$GUEST_TOKEN" = "null" ]; then
 	_skip "per-principal ETag check (no guest password configured)"
 else

--- a/unittests/tests/AuthTest.cpp
+++ b/unittests/tests/AuthTest.cpp
@@ -272,27 +272,3 @@ TEST(Auth, ExtractCookieValue_MissingReturnsEmpty)
 	ASSERT_TRUE(ExtractCookieValue("foo=1; bar=2", "amuleapi_token").empty());
 	ASSERT_TRUE(ExtractCookieValue("", "amuleapi_token").empty());
 }
-
-// ---------- ISO-8601 ---------------------------------------------
-
-TEST(Auth, FormatIso8601Utc_KnownTimestamp)
-{
-	// 1768523696 = 2026-01-16T00:34:56Z (verified via
-	// `date -r 1768523696 -u`); a single point exercises the standard
-	// year/month/day/hour/min/sec formatting path.
-	const std::time_t t = 1768523696;
-	ASSERT_EQUALS(std::string("2026-01-16T00:34:56Z"), FormatIso8601Utc(t));
-}
-
-TEST(Auth, FormatIso8601Utc_FixedWidth)
-{
-	// 1735734005 = 2025-01-01T12:20:05Z (verified via
-	// `date -r 1735734005 -u`). Single-digit month / day / second
-	// here all need leading zeros — pinning length=20 + trailing
-	// 'Z' catches any %d → %2d regression.
-	const std::time_t t = 1735734005;
-	const std::string s = FormatIso8601Utc(t);
-	ASSERT_EQUALS(static_cast<size_t>(20), s.size());
-	ASSERT_EQUALS('Z', s.back());
-	ASSERT_EQUALS(std::string("2025-01-01T12:20:05Z"), s);
-}

--- a/unittests/tests/StateTest.cpp
+++ b/unittests/tests/StateTest.cpp
@@ -1441,7 +1441,7 @@ TEST(State, MemoizableTargetExcludesEverythingElse)
 	ASSERT_TRUE(!MemoizableTarget("/api/v0/stats/tree"));
 	ASSERT_TRUE(!MemoizableTarget("/api/v0/stats/graphs/download_speed?width=3"));
 	ASSERT_TRUE(!MemoizableTarget("/api/v0/logs/amule"));
-	ASSERT_TRUE(!MemoizableTarget("/api/v0/logs/serverinfo"));
+	ASSERT_TRUE(!MemoizableTarget("/api/v0/logs/server_info"));
 	ASSERT_TRUE(!MemoizableTarget("/api/v0/search/7/results"));
 	// live EC roundtrip per read, and the bare collection a trailing-slash
 	// prefix could never match


### PR DESCRIPTION
Batch 4 of #1189, the last of the rename work: §1.10, §1.11, §1.12 and §2, plus the R12 prose sweep. Three commits, one per area.

### §1.10 + §1.11 - routes, auth, version, logs

`/logs/serverinfo` → `/logs/server_info`, the last non-snake_case path segment on the surface.

`/logs/amule` counted lines but named its counters after amuleapi's mirror: `total_cached` → `total_lines`, `returned` → `returned_lines`. Its sibling ships one blob and keeps `total_bytes` / `returned_bytes`, which is the model these now follow.

`/version` said `name` for the constant `"amuleapi"` (→ `service`) and `amule_version` for the version of the *amuleapi binary* (→ `amuleapi_version`), which read as the daemon's version with `daemon_version` sitting right beside it. Inside `update`: `update_available` → `available` (it stuttered inside its own object), `last_checked` → `last_checked_at`, and `latest_version` answers `null` before a check instead of `""`, matching its two siblings.

`/auth` carried JWT internals in the public contract:

| current | new |
|---|---|
| `jti` | `session_id`, now emitted on **every** login, not only the token shape |
| `exp` / `exp_unix` / ISO `expires_at` | one `expires_at`, unix seconds |
| `admin_set` | `admin_password_set` |
| `guest_enabled` | `guest_access_enabled` (read and write) |
| `other_sessions_revoked` | dropped - always `true` |
| `?type=bearer` | `?include_token=true` |

`Accept: application/jwt` is unchanged. `POST /shared/media/refresh`'s `queued` → `queued_file_count`.

### §1.12 - error codes

Six of the 27 were something other than a stable machine-readable token:

- `internal` → `internal_error`. Two codes for one condition, and being a raw JSON literal in the transport it did not grep like the rest. **The Web UI gets a fix for free:** `terr()` looks up `common_err_<code>`, so `internal` fell through to the raw English message while `common_err_internal_error` sat unused.
- `completed_use_clear_completed` → `download_completed`. The instruction was already in `message`.
- `conflict` **split** into `option_not_supported` and `not_a4af_source`. It restated the HTTP status and carried two unrelated meanings on two endpoints; both are now asserted by name in the curl suite rather than only by status.
- `sessions_exhausted` → `too_many_streams` ("sessions" meant SSE streams, not logins).
- `update_check_throttled` → `rate_limited` (two codes, one concept, same status).
- `bad_gateway` → `amuled_response_invalid` (an HTTP status name used as a code).

Catalog and binary are cross-checked: **25 codes in `src/webapi/*.cpp`, 25 rows in the reference, sets equal.**

### §2 - query parameters

`GET /clients?filter=uploads|downloads|active` → `?activity=uploading|downloading|active`. "filter" named the mechanism, not the axis - every list endpoint filters somehow - and the values are client states, so they are now spelled the way `upload_state` / `download_state` spell them.

The `sort=` half (R7) already landed with the per-resource batches; verified here: **all 26 sort tokens are exactly the response key they order by.**

### R12 - prose sweep

The contract never said "peer" in a key, path or enum value, but the reference prose said it 159 times for the thing the contract calls a client. Swept across the three API docs (173 replacements). Sample data values (`"AnonymousPeer"` as a nickname) are values, not vocabulary, and stay.

**Web UI labels deliberately stay "Peers"** - R12 exempts them so they can mirror the desktop, whose Shared Files panel is called *Peers*.

Two spots needed judgment rather than substitution: the `Clients (peers)` headings existed only to gloss the word and are now just `Clients`; and the per-file `role` row read badly once its subject and its `"client"` enum value were the same word, so it names the direction instead.

### Found in passing

Three pre-existing bugs, fixed here:

1. A **broken doc anchor** - four links to the compound `/downloads/{hash}/clients` heading used its full id, one used a bare prefix matching no heading.
2. **Stale `/friends` + `/chats` docs** still promising `client_ecid` / `friend_ecid` as `0`; those writers moved to `null` in #1193.
3. A stale `amule_version` cross-reference in the `daemon_version` row.

Also removed `FormatIso8601Utc` and its two tests - the two auth timestamps were its only callers.

### Verification

Build clean, 43/43 unit tests.

**Full curl suite: 40/40 phases, ~1650 assertions.** Two phases (19, 22) failed the first run against a daemon connected to *eMule Sunrise*, a server that connects but answers no searches; both pass on *Sharing-Devils No.2* (19 then runs 189 assertions instead of 176, since the search paths stop skipping). Neither failure touches a renamed key.

clang-format 18 whole-file (9 files), clang-tidy Tier-1 and Tier-2 on the diff: clean, 0 fatal errors.

Acceptance criteria re-checked mechanically: no `is_`/`has_`/`can_` prefix anywhere; every sort token is a response key; no `internal` distinct from `internal_error`; no `peer` in key position.

This closes the rename work in #1189. What remains on the issue is the `v0` → `v1` flip, held until everything is exercised end to end.
