### PR TITLE
refactor(amuleapi): align KnownClientSnapshot members with their keys

### DIFF
--- a/src/webapi/Api.cpp
+++ b/src/webapi/Api.cpp
@@ -3106,15 +3106,15 @@ webapi::KnownClientSnapshot DecodeKnownClient(const CECTag &entry)
 	c.user_hash = std::string(entry.GetMD4Data().Encode().Lower().utf8_str());
 
 	if (const CECTag *t = entry.GetTagByName(EC_TAG_CLIENT_UPLOAD_TOTAL))
-		c.total_uploaded = t->GetInt();
+		c.uploaded_bytes_total = t->GetInt();
 	if (const CECTag *t = entry.GetTagByName(EC_TAG_CLIENT_DOWNLOAD_TOTAL))
-		c.total_downloaded = t->GetInt();
+		c.downloaded_bytes_total = t->GetInt();
 	if (const CECTag *t = entry.GetTagByName(EC_TAG_CLIENT_LAST_SEEN))
-		c.last_seen = static_cast<std::time_t>(t->GetInt());
+		c.last_seen_at = static_cast<std::time_t>(t->GetInt());
 	if (const CECTag *t = entry.GetTagByName(EC_TAG_CLIENT_FIRST_SEEN))
-		c.first_seen = static_cast<std::time_t>(t->GetInt());
+		c.first_seen_at = static_cast<std::time_t>(t->GetInt());
 	if (const CECTag *t = entry.GetTagByName(EC_TAG_CLIENT_SESSIONS))
-		c.sessions = static_cast<std::uint32_t>(t->GetInt());
+		c.session_count = static_cast<std::uint32_t>(t->GetInt());
 	if (const CECTag *t = entry.GetTagByName(EC_TAG_CLIENT_NAME))
 		c.client_name = std::string(t->GetStringData().utf8_str());
 	if (const CECTag *t = entry.GetTagByName(EC_TAG_CLIENT_USER_IP)) {
@@ -3131,11 +3131,11 @@ webapi::KnownClientSnapshot DecodeKnownClient(const CECTag &entry)
 	if (const CECTag *t = entry.GetTagByName(EC_TAG_CLIENT_SOFTWARE))
 		c.software = webapi::ClientSoftwareName(static_cast<std::uint32_t>(t->GetInt()));
 	if (const CECTag *t = entry.GetTagByName(EC_TAG_CLIENT_SOFT_VER_STR))
-		c.version = std::string(t->GetStringData().utf8_str());
+		c.software_version = std::string(t->GetStringData().utf8_str());
 	if (const CECTag *t = entry.GetTagByName(EC_TAG_CLIENT_FROM))
 		c.source_origin = webapi::SourceOriginName(static_cast<std::uint32_t>(t->GetInt()));
 	if (const CECTag *t = entry.GetTagByName(EC_TAG_CLIENT_OBFUSCATION_STATUS))
-		c.obfuscation = webapi::ClientObfuscationName(static_cast<std::uint8_t>(t->GetInt()));
+		c.obfuscation_state = webapi::ClientObfuscationName(static_cast<std::uint8_t>(t->GetInt()));
 	return c;
 }
 
@@ -3163,19 +3163,19 @@ void WriteKnownClientObject(CJsonWriter &w, const webapi::KnownClientSnapshot &c
 	WriteStringOrNull(w, "country_code", !c.country_code.empty(), c.country_code);
 	const bool has_software = !c.software.empty();
 	WriteStringOrNull(w, "software", has_software, c.software);
-	WriteStringOrNull(w, "software_version", has_software, c.version);
+	WriteStringOrNull(w, "software_version", has_software, c.software_version);
 	WriteStringOrNull(w, "source_origin", !c.source_origin.empty(), c.source_origin);
-	WriteStringOrNull(w, "obfuscation_state", !c.obfuscation.empty(), c.obfuscation);
+	WriteStringOrNull(w, "obfuscation_state", !c.obfuscation_state.empty(), c.obfuscation_state);
 	// Same quantity as the live /clients row, so the same key (R6).
 	w.Key("uploaded_bytes_total");
-	w.ValueUInt(static_cast<uint64_t>(c.total_uploaded));
+	w.ValueUInt(static_cast<uint64_t>(c.uploaded_bytes_total));
 	w.Key("downloaded_bytes_total");
-	w.ValueUInt(static_cast<uint64_t>(c.total_downloaded));
+	w.ValueUInt(static_cast<uint64_t>(c.downloaded_bytes_total));
 	w.Key("last_seen_at");
-	w.ValueUInt(static_cast<uint64_t>(c.last_seen));
-	const bool has_first_seen = c.first_seen != 0;
-	WriteUIntOrNull(w, "first_seen_at", has_first_seen, static_cast<uint64_t>(c.first_seen));
-	WriteUIntOrNull(w, "session_count", has_first_seen, static_cast<uint64_t>(c.sessions));
+	w.ValueUInt(static_cast<uint64_t>(c.last_seen_at));
+	const bool has_first_seen = c.first_seen_at != 0;
+	WriteUIntOrNull(w, "first_seen_at", has_first_seen, static_cast<uint64_t>(c.first_seen_at));
+	WriteUIntOrNull(w, "session_count", has_first_seen, static_cast<uint64_t>(c.session_count));
 	// Correlate with /clients by user_hash to reach the live peer.
 	w.Key("online");
 	w.ValueBool(c.online);
@@ -6150,11 +6150,11 @@ CHttpServer::Response CApiDispatcher::HandleKnownClients(const CHttpServer::Requ
 		{ "name", SORT_BY(client_name) },
 		{ "software", SORT_BY(software) },
 		// R7: each value is spelled exactly like the response key it orders by.
-		{ "first_seen_at", SORT_BY(first_seen) },
-		{ "last_seen_at", SORT_BY(last_seen) },
-		{ "session_count", SORT_BY(sessions) },
-		{ "uploaded_bytes_total", SORT_BY(total_uploaded) },
-		{ "downloaded_bytes_total", SORT_BY(total_downloaded) },
+		{ "first_seen_at", SORT_BY(first_seen_at) },
+		{ "last_seen_at", SORT_BY(last_seen_at) },
+		{ "session_count", SORT_BY(session_count) },
+		{ "uploaded_bytes_total", SORT_BY(uploaded_bytes_total) },
+		{ "downloaded_bytes_total", SORT_BY(downloaded_bytes_total) },
 	};
 
 	// Built under the state's read lock: the store is never copied out, so the

--- a/src/webapi/State.cpp
+++ b/src/webapi/State.cpp
@@ -720,8 +720,8 @@ void CState::ReconcileKnownClientsLocked()
 			// same arrival twice.
 			KnownClientSnapshot k;
 			k.user_hash = c.user_hash;
-			k.first_seen = now;
-			k.last_seen = now;
+			k.first_seen_at = now;
+			k.last_seen_at = now;
 			m_known_clients.push_back(std::move(k));
 			it = m_known_of_hash.emplace(c.user_hash, m_known_clients.size() - 1).first;
 		}
@@ -737,15 +737,15 @@ void CState::ReconcileKnownClientsLocked()
 		// daemon's own figure replaces this at the next fetch, so any drift
 		// lives no longer than the connection to that core.
 		if (!k.online)
-			k.sessions++;
+			k.session_count++;
 		k.online = true;
 		// A peer in front of us was last seen now, not whenever it previously
 		// disconnected. Leaving the stored value would report a peer that is
 		// connected as last seen months ago, and now is what the core writes
 		// to the record at its own disconnect handling anyway.
-		k.last_seen = now;
-		k.total_uploaded = c.uploaded_bytes_total;
-		k.total_downloaded = c.downloaded_bytes_total;
+		k.last_seen_at = now;
+		k.uploaded_bytes_total = c.uploaded_bytes_total;
+		k.downloaded_bytes_total = c.downloaded_bytes_total;
 		// Identity, when the peer in front of us knows more than the record.
 		// A record only gains a name once the core writes its metadata, so a
 		// peer we have never finished a session with is otherwise nameless.
@@ -758,9 +758,9 @@ void CState::ReconcileKnownClientsLocked()
 			k.kad_port = c.kad_port;
 			k.country_code = c.country_code;
 			k.software = c.software;
-			k.version = c.software_version;
+			k.software_version = c.software_version;
 			k.source_origin = c.source_origin;
-			k.obfuscation = c.obfuscation_state;
+			k.obfuscation_state = c.obfuscation_state;
 		}
 	}
 
@@ -775,7 +775,7 @@ void CState::ReconcileKnownClientsLocked()
 		// at its own disconnect handling. The stored value is the *previous*
 		// disconnect, so leaving it would show a peer that was here a second
 		// ago as last seen months back.
-		m_known_clients[idx].last_seen = now;
+		m_known_clients[idx].last_seen_at = now;
 	}
 	m_known_online.swap(still_online);
 }

--- a/src/webapi/State.h
+++ b/src/webapi/State.h
@@ -327,16 +327,16 @@ struct KnownClientSnapshot
 	std::string ip; // dotted-quad; "" when the record predates metadata
 	std::uint16_t port = 0;
 	std::uint16_t kad_port = 0;
-	std::string country_code; // ISO 3166-1 alpha-2, resolved daemon-side
-	std::string software;     // resolved name, e.g. "eMule"
-	std::string version;      // "v0.50.0"
+	std::string country_code;     // ISO 3166-1 alpha-2, resolved daemon-side
+	std::string software;         // resolved name, e.g. "eMule"
+	std::string software_version; // "v0.50.0"
 	std::string source_origin;
-	std::string obfuscation;
-	std::uint64_t total_uploaded = 0;
-	std::uint64_t total_downloaded = 0;
-	std::time_t first_seen = 0; // 0 when the record carries no metadata
-	std::time_t last_seen = 0;
-	std::uint32_t sessions = 0;
+	std::string obfuscation_state;
+	std::uint64_t uploaded_bytes_total = 0;
+	std::uint64_t downloaded_bytes_total = 0;
+	std::time_t first_seen_at = 0; // 0 when the record carries no metadata
+	std::time_t last_seen_at = 0;
+	std::uint32_t session_count = 0;
 	//! This peer is connected right now, correlated by user hash against the
 	//! live client list. Never by ECID: those mean nothing across daemon
 	//! restarts, while the hash is what the credit store is keyed on.


### PR DESCRIPTION
Closes the last gap in #1189's first acceptance criterion, which asks for each key to be renamed "in the serializer, **in the snapshot struct**, in the SSE payload, in the Web UI and in the docs".

The `/known_clients` keys were renamed in #1199, but `KnownClientSnapshot` was missed. Seven members kept their pre-rename names while emitting the new keys:

| member | key it emits |
|---|---|
| `total_uploaded` | `uploaded_bytes_total` |
| `total_downloaded` | `downloaded_bytes_total` |
| `first_seen` | `first_seen_at` |
| `last_seen` | `last_seen_at` |
| `sessions` | `session_count` |
| `version` | `software_version` |
| `obfuscation` | `obfuscation_state` |

Every other resource had its members moved with its keys, which is what makes a key greppable to the field that produces it. This does the same for this one.

`client_name` stays: it maps to `name` on `ClientSnapshot` too (`SORT_BY(client_name)` at both sort tables), so it is the existing convention rather than a leftover.

### No contract change

This renames only the C++ that reads the fields. Every JSON key string in the diff appears **identically on both sides** — checked per key: `session_count` 2/2, `first_seen_at` 2/2, `uploaded_bytes_total` 1/1, `software_version` 1/1, `obfuscation_state` 1/1, `last_seen_at` 1/1, `downloaded_bytes_total` 1/1. The struct's members and its writer's keys are now in exact agreement apart from that one documented convention.

### Verification

Build clean, 43/43 unit tests. Curl phases 33 (known-clients) and 28 (pagination/sort, which exercises the `/known_clients` sort table these members back) both pass.

clang-format 18 whole-file, clang-tidy Tier-1 and Tier-2 on the diff: clean, 0 fatal errors. The longer `software_version` widened the trailing-comment alignment block in `State.h`, so its two neighbours re-align with it.
