### PR TITLE
refactor(amuleapi): spell out the six byte rates still named _bps

### DIFF
--- a/docs/api/EVENTS.md
+++ b/docs/api/EVENTS.md
@@ -340,7 +340,7 @@ Identical to the REST [`/api/v0/shared`](REFERENCE.md#get-apiv0shared) list-item
   "request_count_total":            1837,
   "accepted_request_count_session": 18,
   "accepted_request_count_total":   921,
-  "upload_speed_bps": 51200,
+  "upload_speed_bytes_per_second": 51200,
   "uploading_client_count": 2,
   "last_upload_at":   1700000500,
   "shared_since_at":  1699000000,
@@ -494,8 +494,8 @@ Identical to the REST [`/api/v0/clients`](REFERENCE.md#get-apiv0clients) list-it
   "downloaded_bytes_session": 0,
   "uploaded_bytes_total":     452000000,
   "downloaded_bytes_total":   189000000,
-  "upload_speed_bps":       22000,
-  "download_speed_bps":     0,
+  "upload_speed_bytes_per_second":       22000,
+  "download_speed_bytes_per_second":     0,
   "upload_queue_position": 0,
   "remote_queue_position":      0,
   "upload_queue_score":                  150,
@@ -548,8 +548,8 @@ Rate impact is small: the overhead rates move about as often as the speeds alrea
     "network":    { "user_count": 5400000, "file_count": 1400000000, "node_count": 2400 }
   },
   "speeds": {
-    "download_bps": 4500000, "upload_bps": 50000,
-    "download_overhead_bps": 8700, "upload_overhead_bps": 1100
+    "download_bytes_per_second": 4500000, "upload_bytes_per_second": 50000,
+    "download_overhead_bytes_per_second": 8700, "upload_overhead_bytes_per_second": 1100
   },
   "disk":   { "temp_free_bytes": 48318382080, "incoming_free_bytes": 48318382080 },
   "queue":  { "upload_clients_waiting": 12, "download_sources_total": 1843 }

--- a/docs/api/REFERENCE.md
+++ b/docs/api/REFERENCE.md
@@ -609,10 +609,10 @@ curl -s -H "Authorization: Bearer $TOKEN" http://$HOST/api/v0/status
     "network": { "user_count": 5400000, "file_count": 1400000000, "node_count": 2400 }
   },
   "speeds": {
-    "download_bps": 4500000,
-    "upload_bps": 50000,
-    "download_overhead_bps": 8700,
-    "upload_overhead_bps": 1100
+    "download_bytes_per_second": 4500000,
+    "upload_bytes_per_second": 50000,
+    "download_overhead_bytes_per_second": 8700,
+    "upload_overhead_bytes_per_second": 1100
   },
   "disk": { "temp_free_bytes": 48318382080, "incoming_free_bytes": 48318382080 },
   "queue": { "upload_clients_waiting": 12, "download_sources_total": 1843 }
@@ -633,7 +633,7 @@ While disconnected `user_id` is `0`, `public_ip` is `""` and `high_id` is `false
 
 **`ed2k.user_id` is not the same encoding as a client's `ed2k_user_id`.** [`GET /api/v0/clients/{ecid}`](#get-apiv0clientsecid) reports `ed2k_user_id` for a remote client, and the similar name invites the assumption that the two are interchangeable. They are not. Ours is stored exactly as the server sent it and is read least-significant-byte-first to produce `public_ip`; a client's HighID is **byte-swapped** on the way in. A consumer that compares the two values, or feeds one through the other's IP decoder, gets a reversed address. The `>= 16777216` HighID threshold *is* common to both; the byte order is not.
 
-**Overhead is additive.** `speeds.download_overhead_bps` / `upload_overhead_bps` are protocol and control traffic, counted **separately** from `download_bps` / `upload_bps` rather than being part of them — the desktop shows them as a second figure in parentheses. Both are `0` when the daemon reports nothing.
+**Overhead is additive.** `speeds.download_overhead_bytes_per_second` / `upload_overhead_bytes_per_second` are protocol and control traffic, counted **separately** from `download_bytes_per_second` / `upload_bytes_per_second` rather than being part of them — the desktop shows them as a second figure in parentheses. Both are `0` when the daemon reports nothing.
 
 **Disk figures may be `null`.** `disk.temp_free_bytes` is free space on the filesystem holding the part files, `disk.incoming_free_bytes` where finished downloads land. Either is `null` when the daemon has no figure — the first seconds after startup, or a directory it cannot stat, such as an unreachable network mount. `null` rather than `0`, because `0` would read as a full disk.
 
@@ -1241,8 +1241,8 @@ curl -s -H "Authorization: Bearer $TOKEN" \
       "downloaded_bytes_session": 0,
       "uploaded_bytes_total": 452000000,
       "downloaded_bytes_total": 189000000,
-      "upload_speed_bps": 22000,
-      "download_speed_bps": 0,
+      "upload_speed_bytes_per_second": 22000,
+      "download_speed_bytes_per_second": 0,
       "upload_queue_position": 0,
       "remote_queue_position": 0,
       "score": 150,
@@ -1321,8 +1321,8 @@ curl -s -H "Authorization: Bearer $TOKEN" \
       "downloaded_bytes_session": 0,
       "uploaded_bytes_total": 452000000,
       "downloaded_bytes_total": 189000000,
-  "upload_speed_bps": 22000,
-  "download_speed_bps": 0,
+  "upload_speed_bytes_per_second": 22000,
+  "download_speed_bytes_per_second": 0,
   "upload_queue_position": 0,
   "remote_queue_position": 0,
   "score": 150,
@@ -1502,7 +1502,7 @@ curl -s -H "Authorization: Bearer $TOKEN" "http://$HOST/api/v0/shared"
       "request_count_total":            1837,
       "accepted_request_count_session": 18,
       "accepted_request_count_total":   921,
-      "upload_speed_bps": 51200,
+      "upload_speed_bytes_per_second": 51200,
       "uploading_client_count": 2,
       "last_upload_at":      1700000500,
       "shared_since_at":     1699000000,
@@ -1522,7 +1522,7 @@ curl -s -H "Authorization: Bearer $TOKEN" "http://$HOST/api/v0/shared"
 
 `uploaded_bytes_session` / `uploaded_bytes_total` are bytes uploaded during the current amuled process vs over the file's lifetime. `requests` counts how many clients have asked for the file; `accepts` counts how many of those requests were granted an upload slot. The `session` counters reset on amuled restart; `total` is persisted in `known.met`.
 
-`upload_speed_bps` is the file's current combined upload rate in bytes/sec (summed over the clients it is uploading to), and `uploading_client_count` is how many clients it is actively uploading to right now — together the "is this file being seeded" signal, the upload-side analogue of the `/downloads` speed + transferring-source counts. Subtract `uploading_client_count` from the queued-client count (`upload_queue_count`, on the detail view) to show `uploading / queued`. Both are live and refresh every tick. `last_upload_at` is the unix timestamp of the last time data was sent for the file, and `shared_since_at` is when the file was completed or first shared; both are persisted in `known.met` and are `null` when unknown: a file that has never uploaded, or a `known.met` entry written before these fields existed.
+`upload_speed_bytes_per_second` is the file's current combined upload rate in bytes/sec (summed over the clients it is uploading to), and `uploading_client_count` is how many clients it is actively uploading to right now — together the "is this file being seeded" signal, the upload-side analogue of the `/downloads` speed + transferring-source counts. Subtract `uploading_client_count` from the queued-client count (`upload_queue_count`, on the detail view) to show `uploading / queued`. Both are live and refresh every tick. `last_upload_at` is the unix timestamp of the last time data was sent for the file, and `shared_since_at` is when the file was completed or first shared; both are persisted in `known.met` and are `null` when unknown: a file that has never uploaded, or a `known.met` entry written before these fields existed.
 
 `priority` is the upload priority — `"very_low"` / `"low"` / `"normal"` / `"high"` / `"release"` — and `priority_auto` is `true` when amuled is deriving that level automatically from the upload queue. This mirrors the `/downloads` shape (base `priority` + separate `priority_auto` flag); on an auto file `priority` reports the current derived level, not the literal string `"auto"`. For a file that is both downloading and shared this upload priority is independent of the download priority reported by [`GET /api/v0/downloads`](#get-apiv0downloads).
 

--- a/src/webapi/Api.cpp
+++ b/src/webapi/Api.cpp
@@ -2673,16 +2673,16 @@ CHttpServer::Response CApiDispatcher::HandleStatus(const CHttpServer::Request &r
 
 	w.Key("speeds");
 	w.BeginObject();
-	w.Key("download_bps");
-	w.ValueInt(static_cast<int64_t>(s.download_bps));
-	w.Key("upload_bps");
-	w.ValueInt(static_cast<int64_t>(s.upload_bps));
+	w.Key("download_bytes_per_second");
+	w.ValueInt(static_cast<int64_t>(s.download_bytes_per_second));
+	w.Key("upload_bytes_per_second");
+	w.ValueInt(static_cast<int64_t>(s.upload_bytes_per_second));
 	// Additive to the two above, not a subset: amuled counts protocol
 	// overhead separately from payload.
-	w.Key("download_overhead_bps");
-	w.ValueInt(static_cast<int64_t>(s.download_overhead_bps));
-	w.Key("upload_overhead_bps");
-	w.ValueInt(static_cast<int64_t>(s.upload_overhead_bps));
+	w.Key("download_overhead_bytes_per_second");
+	w.ValueInt(static_cast<int64_t>(s.download_overhead_bytes_per_second));
+	w.Key("upload_overhead_bytes_per_second");
+	w.ValueInt(static_cast<int64_t>(s.upload_overhead_bytes_per_second));
 	w.EndObject();
 
 	// null rather than a number when the daemon has no figure. Emitting the
@@ -3032,10 +3032,10 @@ void WriteClientBaseFields(CJsonWriter &w, const webapi::ClientSnapshot &c)
 	w.ValueInt(static_cast<int64_t>(c.uploaded_bytes_total));
 	w.Key("downloaded_bytes_total");
 	w.ValueInt(static_cast<int64_t>(c.downloaded_bytes_total));
-	w.Key("upload_speed_bps");
-	w.ValueInt(static_cast<int64_t>(c.upload_speed_bps));
-	w.Key("download_speed_bps");
-	w.ValueInt(static_cast<int64_t>(c.download_speed_bps));
+	w.Key("upload_speed_bytes_per_second");
+	w.ValueInt(static_cast<int64_t>(c.upload_speed_bytes_per_second));
+	w.Key("download_speed_bytes_per_second");
+	w.ValueInt(static_cast<int64_t>(c.download_speed_bytes_per_second));
 	w.Key("upload_queue_position");
 	w.ValueInt(static_cast<int64_t>(c.upload_queue_position));
 	// 0xffff is amuled's "that peer's queue is full" sentinel
@@ -3268,12 +3268,12 @@ void WriteSharedBaseFields(CJsonWriter &w, const webapi::FileSnapshot &f, bool d
 	w.ValueInt(static_cast<int64_t>(f.shared.accepted_request_count_session));
 	w.Key("accepted_request_count_total");
 	w.ValueInt(static_cast<int64_t>(f.shared.accepted_request_count_total));
-	// Live upload activity (issue #466). `upload_speed_bps` + `uploading`
+	// Live upload activity (issue #466). `upload_speed_bytes_per_second` + `uploading`
 	// refresh every tick; `last_upload` / `shared_since` are unix seconds,
 	// null when unknown -- never uploaded, or a known.met entry that predates
 	// the field. They were 0, which reads as 1970 rather than "no idea".
-	w.Key("upload_speed_bps");
-	w.ValueInt(static_cast<int64_t>(f.shared.upload_speed_bps));
+	w.Key("upload_speed_bytes_per_second");
+	w.ValueInt(static_cast<int64_t>(f.shared.upload_speed_bytes_per_second));
 	// Read as a boolean, held an integer.
 	w.Key("uploading_client_count");
 	w.ValueInt(static_cast<int64_t>(f.shared.uploading_client_count));
@@ -7714,9 +7714,9 @@ CHttpServer::Response CApiDispatcher::HandleStatsGraph(
 	const webapi::StatsGraphs &g = pair.first;
 	const std::vector<std::uint32_t> *series = nullptr;
 	if (graph == "download_speed") {
-		series = &g.download_bps;
+		series = &g.download_bytes_per_second;
 	} else if (graph == "upload_speed") {
-		series = &g.upload_bps;
+		series = &g.upload_bytes_per_second;
 	} else if (graph == "connections") {
 		series = &g.connections;
 	} else /* kad_nodes */ {

--- a/src/webapi/EventDiff.cpp
+++ b/src/webapi/EventDiff.cpp
@@ -185,7 +185,8 @@ std::string ToJsonSharedEvent(const FileSnapshot &f)
 	  << ",\"request_count_total\":" << f.shared.request_count_total
 	  << ",\"accepted_request_count_session\":" << f.shared.accepted_request_count_session
 	  << ",\"accepted_request_count_total\":" << f.shared.accepted_request_count_total
-	  << ",\"upload_speed_bps\":" << f.shared.upload_speed_bps << ",\"uploading_client_count\":"
+	  << ",\"upload_speed_bytes_per_second\":" << f.shared.upload_speed_bytes_per_second
+	  << ",\"uploading_client_count\":"
 	  << f.shared.uploading_client_count
 	  // Unix seconds, null when unknown -- never uploaded, or a known.met entry
 	  // that predates the field. 0 reads as 1970 rather than "no idea", and the
@@ -294,8 +295,8 @@ std::string ToJson(const ClientSnapshot &c)
 	  << ",\"downloaded_bytes_session\":" << c.downloaded_bytes_session
 	  << ",\"uploaded_bytes_total\":" << c.uploaded_bytes_total
 	  << ",\"downloaded_bytes_total\":" << c.downloaded_bytes_total
-	  << ",\"upload_speed_bps\":" << c.upload_speed_bps
-	  << ",\"download_speed_bps\":" << c.download_speed_bps
+	  << ",\"upload_speed_bytes_per_second\":" << c.upload_speed_bytes_per_second
+	  << ",\"download_speed_bytes_per_second\":" << c.download_speed_bytes_per_second
 	  << ",\"upload_queue_position\":" << c.upload_queue_position << ",\"remote_queue_position\":"
 	  << (c.remote_queue_position == kRemoteQueueFullSentinel ? std::string("null")
 								  : std::to_string(c.remote_queue_position))
@@ -377,9 +378,10 @@ std::string ToJsonStatusEvent(const StatusSnapshot &s, const KadSnapshot &k, boo
 	  << ",\"node_count\":" << JsonNumOrNull(k.has_network, k.nodes) << "}"
 	  << "}"
 	  << ",\"speeds\":{"
-	  << "\"download_bps\":" << s.download_bps << ",\"upload_bps\":" << s.upload_bps
-	  << ",\"download_overhead_bps\":" << s.download_overhead_bps
-	  << ",\"upload_overhead_bps\":" << s.upload_overhead_bps << "}"
+	  << "\"download_bytes_per_second\":" << s.download_bytes_per_second
+	  << ",\"upload_bytes_per_second\":" << s.upload_bytes_per_second
+	  << ",\"download_overhead_bytes_per_second\":" << s.download_overhead_bytes_per_second
+	  << ",\"upload_overhead_bytes_per_second\":" << s.upload_overhead_bytes_per_second << "}"
 	  << ",\"disk\":{"
 	  // null, not the -1 sentinel and not 0 -- same reasoning as the REST body.
 	  << "\"temp_free_bytes\":" << JsonFreeSpace(s.temp_free_bytes)
@@ -461,7 +463,7 @@ bool EqualShared(const FileSnapshot &a, const FileSnapshot &b)
 	       a.shared.request_count_total == b.shared.request_count_total &&
 	       a.shared.accepted_request_count_session == b.shared.accepted_request_count_session &&
 	       a.shared.accepted_request_count_total == b.shared.accepted_request_count_total &&
-	       a.shared.upload_speed_bps == b.shared.upload_speed_bps &&
+	       a.shared.upload_speed_bytes_per_second == b.shared.upload_speed_bytes_per_second &&
 	       a.shared.uploading_client_count == b.shared.uploading_client_count &&
 	       a.shared.last_upload == b.shared.last_upload &&
 	       a.shared.shared_since == b.shared.shared_since &&
@@ -510,7 +512,8 @@ bool Equal(const ClientSnapshot &a, const ClientSnapshot &b)
 	       a.downloaded_bytes_session == b.downloaded_bytes_session &&
 	       a.uploaded_bytes_total == b.uploaded_bytes_total &&
 	       a.downloaded_bytes_total == b.downloaded_bytes_total &&
-	       a.upload_speed_bps == b.upload_speed_bps && a.download_speed_bps == b.download_speed_bps &&
+	       a.upload_speed_bytes_per_second == b.upload_speed_bytes_per_second &&
+	       a.download_speed_bytes_per_second == b.download_speed_bytes_per_second &&
 	       a.upload_queue_position == b.upload_queue_position &&
 	       a.remote_queue_position == b.remote_queue_position && a.score == b.score &&
 	       a.obfuscation_state == b.obfuscation_state && a.friend_slot == b.friend_slot &&
@@ -535,11 +538,12 @@ bool Equal(const StatusSnapshot &a, const StatusSnapshot &b)
 	       a.kad_connected_since == b.kad_connected_since &&
 	       a.kad_firewalled_tcp == b.kad_firewalled_tcp && a.server_name == b.server_name &&
 	       a.server_ip == b.server_ip && a.server_port == b.server_port &&
-	       a.download_bps == b.download_bps && a.upload_bps == b.upload_bps &&
-	       a.download_overhead_bps == b.download_overhead_bps &&
-	       a.upload_overhead_bps == b.upload_overhead_bps && a.temp_free_bytes == b.temp_free_bytes &&
-	       a.incoming_free_bytes == b.incoming_free_bytes && a.ul_queue_len == b.ul_queue_len &&
-	       a.total_src_count == b.total_src_count &&
+	       a.download_bytes_per_second == b.download_bytes_per_second &&
+	       a.upload_bytes_per_second == b.upload_bytes_per_second &&
+	       a.download_overhead_bytes_per_second == b.download_overhead_bytes_per_second &&
+	       a.upload_overhead_bytes_per_second == b.upload_overhead_bytes_per_second &&
+	       a.temp_free_bytes == b.temp_free_bytes && a.incoming_free_bytes == b.incoming_free_bytes &&
+	       a.ul_queue_len == b.ul_queue_len && a.total_src_count == b.total_src_count &&
 	       // The has_ flags are part of the comparison, not just the values: a
 	       // disconnect flips these to null while the underlying ints keep
 	       // their last reading, so comparing the ints alone would miss the

--- a/src/webapi/Refresher.cpp
+++ b/src/webapi/Refresher.cpp
@@ -251,20 +251,20 @@ void ParseStatusFromPacket(const CECPacket *resp, StatusSnapshot &out)
 	}
 
 	if (const CECTag *t = resp->GetTagByName(EC_TAG_STATS_DL_SPEED)) {
-		out.download_bps = static_cast<std::uint64_t>(t->GetInt());
+		out.download_bytes_per_second = static_cast<std::uint64_t>(t->GetInt());
 	}
 	if (const CECTag *t = resp->GetTagByName(EC_TAG_STATS_UL_SPEED)) {
-		out.upload_bps = static_cast<std::uint64_t>(t->GetInt());
+		out.upload_bytes_per_second = static_cast<std::uint64_t>(t->GetInt());
 	}
 	// Overhead rates and free space ride the same EC_DETAIL_FULL response.
 	// The two disk figures are cast through int64 on purpose: amuled's
 	// FREE_SPACE_UNKNOWN is -1 and the serializer casts it to uint64, so an
 	// unsigned read would turn "unknown" into 18446744073709551615.
 	if (const CECTag *t = resp->GetTagByName(EC_TAG_STATS_UP_OVERHEAD)) {
-		out.upload_overhead_bps = static_cast<std::uint64_t>(t->GetInt());
+		out.upload_overhead_bytes_per_second = static_cast<std::uint64_t>(t->GetInt());
 	}
 	if (const CECTag *t = resp->GetTagByName(EC_TAG_STATS_DOWN_OVERHEAD)) {
-		out.download_overhead_bps = static_cast<std::uint64_t>(t->GetInt());
+		out.download_overhead_bytes_per_second = static_cast<std::uint64_t>(t->GetInt());
 	}
 	if (const CECTag *t = resp->GetTagByName(EC_TAG_STATS_TEMP_FREE_SPACE)) {
 		out.temp_free_bytes = static_cast<std::int64_t>(t->GetInt());
@@ -982,9 +982,9 @@ void MergeClientTag(const CEC_UpDownClient_Tag *c, ClientSnapshot &cs, bool is_n
 			cs.downloaded_bytes_total = v;
 	}
 	{
-		std::uint32_t v = cs.upload_speed_bps;
+		std::uint32_t v = cs.upload_speed_bytes_per_second;
 		if (c->AssignIfExist(EC_TAG_CLIENT_UP_SPEED, v))
-			cs.upload_speed_bps = v;
+			cs.upload_speed_bytes_per_second = v;
 	}
 	{
 		// EC_TAG_CLIENT_DOWN_SPEED is emitted as a double-encoded
@@ -993,7 +993,7 @@ void MergeClientTag(const CEC_UpDownClient_Tag *c, ClientSnapshot &cs, bool is_n
 		// extract via the typed read and convert.
 		if (const CECTag *t = c->GetTagByName(EC_TAG_CLIENT_DOWN_SPEED)) {
 			const double kBps = t->GetDoubleData();
-			cs.download_speed_bps = static_cast<std::uint32_t>(kBps * 1024.0);
+			cs.download_speed_bytes_per_second = static_cast<std::uint32_t>(kBps * 1024.0);
 		}
 	}
 	{
@@ -1198,9 +1198,9 @@ void MergeSharedTag(const CEC_SharedFile_Tag *sf, FileSnapshot &f)
 	}
 	// Live upload activity + timestamps (issue #466).
 	{
-		std::uint32_t v = f.shared.upload_speed_bps;
+		std::uint32_t v = f.shared.upload_speed_bytes_per_second;
 		if (sf->AssignIfExist(EC_TAG_KNOWNFILE_UPLOAD_SPEED, v))
-			f.shared.upload_speed_bps = v;
+			f.shared.upload_speed_bytes_per_second = v;
 	}
 	{
 		std::uint16_t v = f.shared.uploading_client_count;
@@ -2305,8 +2305,8 @@ void ParseGraphsFromPacket(const CECPacket *resp, StatsGraphs &out)
 			/*num_channels=*/4,
 			channels);
 		if (channels.size() >= 4) {
-			out.download_bps = std::move(channels[0]);
-			out.upload_bps = std::move(channels[1]);
+			out.download_bytes_per_second = std::move(channels[0]);
+			out.upload_bytes_per_second = std::move(channels[1]);
 			out.connections = std::move(channels[2]);
 			out.kad_nodes = std::move(channels[3]);
 		}
@@ -2359,8 +2359,8 @@ void ParseGraphsFromPacket(const CECPacket *resp, StatsGraphs &out)
 	// those draws them as distinct samples -- silently compressing time
 	// across the older part of the plot. A no-op where the request width
 	// and the reported depth agree, which is the current-build case.
-	TruncateToLast(out.download_bps, out.max_points);
-	TruncateToLast(out.upload_bps, out.max_points);
+	TruncateToLast(out.download_bytes_per_second, out.max_points);
+	TruncateToLast(out.upload_bytes_per_second, out.max_points);
 	TruncateToLast(out.connections, out.max_points);
 	TruncateToLast(out.kad_nodes, out.max_points);
 	TruncateToLast(out.active_uploads, out.max_points);

--- a/src/webapi/State.h
+++ b/src/webapi/State.h
@@ -271,11 +271,11 @@ struct FileSnapshot
 		std::uint16_t hashing_progress = 0;
 
 		// Live upload activity (issue #466), the upload-side analogue of
-		// the download stats. `upload_speed_bps` + `uploading_client_count` are
+		// the download stats. `upload_speed_bytes_per_second` + `uploading_client_count` are
 		// live (refresh every tick); `last_upload` / `shared_since` are
 		// unix timestamps, 0 = unknown (a file that has never uploaded, or
 		// a known.met entry that predates the feature).
-		std::uint32_t upload_speed_bps = 0;
+		std::uint32_t upload_speed_bytes_per_second = 0;
 		std::uint16_t uploading_client_count = 0;
 		std::uint32_t last_upload = 0;
 		std::uint32_t shared_since = 0;
@@ -404,8 +404,8 @@ struct ClientSnapshot
 	std::uint64_t downloaded_bytes_session = 0;
 	std::uint64_t uploaded_bytes_total = 0;
 	std::uint64_t downloaded_bytes_total = 0;
-	std::uint32_t upload_speed_bps = 0;
-	std::uint32_t download_speed_bps = 0;
+	std::uint32_t upload_speed_bytes_per_second = 0;
+	std::uint32_t download_speed_bytes_per_second = 0;
 
 	// Upload queue position (for peers in US_ONUPLOADQUEUE).
 	// 0 when not queued.
@@ -819,8 +819,8 @@ struct StatsGraphs
 	// entry fetched at one interval must not answer a request for another.
 	std::uint32_t interval_seconds = 1;
 
-	std::vector<std::uint32_t> download_bps;
-	std::vector<std::uint32_t> upload_bps;
+	std::vector<std::uint32_t> download_bytes_per_second;
+	std::vector<std::uint32_t> upload_bytes_per_second;
 	std::vector<std::uint32_t> connections;
 	std::vector<std::uint32_t> kad_nodes;
 
@@ -1418,15 +1418,15 @@ struct StatusSnapshot
 
 	// Bytes per second (NOT kB) so the field name matches the wire
 	// units throughout. Clients that want kB/s do the divide.
-	std::uint64_t download_bps = 0;
-	std::uint64_t upload_bps = 0;
+	std::uint64_t download_bytes_per_second = 0;
+	std::uint64_t upload_bytes_per_second = 0;
 
 	// Protocol/control-traffic overhead, bytes/second. ADDITIVE to the two
 	// rates above rather than a subset of them -- amuled keeps them as
 	// separate counters and the desktop renders them as a second figure in
 	// parentheses. 0 when the daemon reports nothing.
-	std::uint64_t download_overhead_bps = 0;
-	std::uint64_t upload_overhead_bps = 0;
+	std::uint64_t download_overhead_bytes_per_second = 0;
+	std::uint64_t upload_overhead_bytes_per_second = 0;
 
 	// Aggregate counts pulled by the same EC_OP_STATS round-trip.
 	std::uint32_t ul_queue_len = 0;

--- a/src/webapi/static/js/app.js
+++ b/src/webapi/static/js/app.js
@@ -369,8 +369,8 @@ function Speeds({ status }) {
   const sp = (status && status.speeds) || {};
   return html`
     <span class="status-item speeds">
-      <span class="speed dl"><${Icon} name="down" /> ${formatSpeed(sp.download_bps)}</span>
-      <span class="speed ul"><${Icon} name="up" /> ${formatSpeed(sp.upload_bps)}</span>
+      <span class="speed dl"><${Icon} name="down" /> ${formatSpeed(sp.download_bytes_per_second)}</span>
+      <span class="speed ul"><${Icon} name="up" /> ${formatSpeed(sp.upload_bytes_per_second)}</span>
     </span>`;
 }
 

--- a/src/webapi/static/js/views/client-table.js
+++ b/src/webapi/static/js/views/client-table.js
@@ -14,8 +14,8 @@ import { Icon } from "../icons.js";
 import { t, terr } from "../i18n.js";
 
 const ACTIVE = (s) => s && s !== "idle" && s !== "unknown";
-export const isDown = (c) => (c.download_speed_bps || 0) > 0 || ACTIVE(c.download_state);
-export const isUp = (c) => (c.upload_speed_bps || 0) > 0 || ACTIVE(c.upload_state);
+export const isDown = (c) => (c.download_speed_bytes_per_second || 0) > 0 || ACTIVE(c.download_state);
+export const isUp = (c) => (c.upload_speed_bytes_per_second || 0) > 0 || ACTIVE(c.upload_state);
 
 // Column set, declared once. Every consumer offers all of them in the column
 // picker and picks which ones start hidden (see ClientTable's defaultHidden),
@@ -35,8 +35,8 @@ export const fileNameOf = (c) => c.download_file_name || c.upload_file_name || "
 
 // Default order when no column sort is chosen: busiest peers first.
 export const bySpeed = (a, b) =>
-  ((b.download_speed_bps || 0) + (b.upload_speed_bps || 0)) -
-  ((a.download_speed_bps || 0) + (a.upload_speed_bps || 0));
+  ((b.download_speed_bytes_per_second || 0) + (b.upload_speed_bytes_per_second || 0)) -
+  ((a.download_speed_bytes_per_second || 0) + (a.upload_speed_bytes_per_second || 0));
 
 // Each column carries key + sortVal so the header is clickable-to-sort (the
 // flags column has no key → stays non-sortable).
@@ -70,7 +70,7 @@ export const COLS = [
   { key: "dl_state", th: "downloads_peer_col_dl_state", width: "120px", sortable: true,
     sortVal: (c) => c.download_state || "", cell: (c) => stateBadge(c.download_state) },
   { key: "dl_speed", th: "downloads_peer_col_dl_speed", num: true, width: "100px", sortable: true,
-    sortVal: (c) => c.download_speed_bps || 0, cell: (c) => formatSpeed(c.download_speed_bps) },
+    sortVal: (c) => c.download_speed_bytes_per_second || 0, cell: (c) => formatSpeed(c.download_speed_bytes_per_second) },
   { key: "downloaded", th: "downloads_peer_col_downloaded", num: true, width: "100px", sortable: true,
     sortVal: (c) => c.downloaded_bytes_total || 0, cell: (c) => bytesOf(c, "downloaded_bytes_total") },
   { key: "dl_session", th: "downloads_peer_col_downloaded_session", num: true, width: "100px", sortable: true,
@@ -81,7 +81,7 @@ export const COLS = [
   { key: "ul_state", th: "downloads_peer_col_ul_state", width: "120px", sortable: true,
     sortVal: (c) => c.upload_state || "", cell: (c) => stateBadge(c.upload_state) },
   { key: "ul_speed", th: "downloads_peer_col_ul_speed", num: true, width: "100px", sortable: true,
-    sortVal: (c) => c.upload_speed_bps || 0, cell: (c) => formatSpeed(c.upload_speed_bps) },
+    sortVal: (c) => c.upload_speed_bytes_per_second || 0, cell: (c) => formatSpeed(c.upload_speed_bytes_per_second) },
   { key: "uploaded", th: "downloads_peer_col_uploaded", num: true, width: "100px", sortable: true,
     sortVal: (c) => c.uploaded_bytes_total || 0, cell: (c) => bytesOf(c, "uploaded_bytes_total") },
   { key: "ul_session", th: "downloads_peer_col_uploaded_session", num: true, width: "100px", sortable: true,

--- a/src/webapi/static/js/views/shared-detail.js
+++ b/src/webapi/static/js/views/shared-detail.js
@@ -133,7 +133,7 @@ export function SharedDetail({ hash }) {
         ${Section([
           statRow("shared_size", formatBytes(s.size_bytes), "shared_detail_tip_size"),
           statRow("shared_detail_uploaded", twin(s, "uploaded_bytes_session", "uploaded_bytes_total", formatBytes), "shared_detail_tip_uploaded"),
-          statRow("shared_detail_upload_speed", formatSpeed(s.upload_speed_bps), "shared_detail_tip_upload_speed"),
+          statRow("shared_detail_upload_speed", formatSpeed(s.upload_speed_bytes_per_second), "shared_detail_tip_upload_speed"),
           statRow("shared_detail_uploading", formatInt(s.uploading_client_count), "shared_detail_tip_uploading"),
           statRow("shared_detail_last_upload", formatTimestamp(s.last_upload_at), "shared_detail_tip_last_upload"),
           statRow("shared_detail_shared_since", formatTimestamp(s.shared_since_at), "shared_detail_tip_shared_since"),

--- a/src/webapi/static/js/views/shared.js
+++ b/src/webapi/static/js/views/shared.js
@@ -159,7 +159,7 @@ export default function Shared({ isGuest }) {
     { key: "sources", label: t("shared_complete_src"), num: true, width: "90px", sortable: true,
       sortVal: (s) => (s.sources && s.sources.complete) || 0, cell: (s) => formatInt((s.sources && s.sources.complete) || 0) },
     { key: "upspeed", label: t("shared_upload_speed"), num: true, width: "100px", sortable: true,
-      sortVal: (s) => s.upload_speed_bps || 0, cell: (s) => formatSpeed(s.upload_speed_bps) },
+      sortVal: (s) => s.upload_speed_bytes_per_second || 0, cell: (s) => formatSpeed(s.upload_speed_bytes_per_second) },
     { key: "uploading", label: t("shared_upload_clients"), num: true, width: "90px", sortable: true,
       sortVal: (s) => s.uploading_client_count || 0, cell: (s) => formatInt(s.uploading_client_count) },
     { key: "last_upload", label: t("shared_last_upload"), width: "160px", sortable: true,
@@ -186,7 +186,7 @@ export default function Shared({ isGuest }) {
     size += s.size_bytes || 0;
     xs += s.uploaded_bytes_session || 0;
     xt += s.uploaded_bytes_total || 0;
-    up += s.upload_speed_bps || 0;
+    up += s.upload_speed_bytes_per_second || 0;
   }
 
   const freeSpace = formatFreeSpace(disk.temp_free_bytes, disk.incoming_free_bytes);

--- a/unittests/curl-tests/amuleapi/03-read-status.sh
+++ b/unittests/curl-tests/amuleapi/03-read-status.sh
@@ -170,14 +170,14 @@ _assert_json_eq '.kad | has("firewalled")' false \
 	'kad.firewalled is gone, replaced by kad.firewalled_tcp'
 
 # speeds + queue subtrees.
-_assert_json_eq '.speeds.download_bps | type' number \
-	'speeds.download_bps is numeric'
-_assert_json_eq '.speeds.upload_bps | type' number \
-	'speeds.upload_bps is numeric'
-_assert_json_eq '.speeds.download_overhead_bps | type' number \
-	'speeds.download_overhead_bps is numeric'
-_assert_json_eq '.speeds.upload_overhead_bps | type' number \
-	'speeds.upload_overhead_bps is numeric'
+_assert_json_eq '.speeds.download_bytes_per_second | type' number \
+	'speeds.download_bytes_per_second is numeric'
+_assert_json_eq '.speeds.upload_bytes_per_second | type' number \
+	'speeds.upload_bytes_per_second is numeric'
+_assert_json_eq '.speeds.download_overhead_bytes_per_second | type' number \
+	'speeds.download_overhead_bytes_per_second is numeric'
+_assert_json_eq '.speeds.upload_overhead_bytes_per_second | type' number \
+	'speeds.upload_overhead_bytes_per_second is numeric'
 _assert_json_eq '.queue.upload_clients_waiting | type' number \
 	'queue.upload_clients_waiting is numeric'
 _assert_json_eq '.queue.download_sources_total | type' number \

--- a/unittests/curl-tests/amuleapi/04-read-downloads-shared.sh
+++ b/unittests/curl-tests/amuleapi/04-read-downloads-shared.sh
@@ -432,8 +432,8 @@ if [ "$SHCOUNT" -gt 0 ]; then
 	_assert_json_eq '.shared[0].priority_auto | type' boolean \
 		'/shared[0].priority_auto is boolean'
 	# Live upload activity (issue #466).
-	_assert_json_eq '.shared[0].upload_speed_bps | type' number \
-		'/shared[0].upload_speed_bps is numeric (#466)'
+	_assert_json_eq '.shared[0].upload_speed_bytes_per_second | type' number \
+		'/shared[0].upload_speed_bytes_per_second is numeric (#466)'
 	_assert_json_eq '.shared[0].uploading_client_count | type' number \
 		'/shared[0].uploading_client_count is numeric (#466)'
 	# null when never uploaded, or on a known.met entry predating the field.

--- a/unittests/tests/EventDiffTest.cpp
+++ b/unittests/tests/EventDiffTest.cpp
@@ -269,14 +269,14 @@ TEST(EventDiff, StatusEventCarriesIdentityFields)
 	s.ed2k_high_id = true;
 	s.ed2k_user_id = 1234567890u;
 	s.ed2k_public_ip = "210.2.150.73";
-	s.download_overhead_bps = 8700;
+	s.download_overhead_bytes_per_second = 8700;
 
 	const std::string payload = EmitStatusAndGetPayload(s);
 
 	ASSERT_TRUE(payload.find("\"high_id\":true") != std::string::npos);
 	ASSERT_TRUE(payload.find("\"user_id\":1234567890") != std::string::npos);
 	ASSERT_TRUE(payload.find("\"public_ip\":\"210.2.150.73\"") != std::string::npos);
-	ASSERT_TRUE(payload.find("\"download_overhead_bps\":8700") != std::string::npos);
+	ASSERT_TRUE(payload.find("\"download_overhead_bytes_per_second\":8700") != std::string::npos);
 	// The retired spellings must not linger anywhere in the payload. A bare
 	// "id" would also match inside "user_id", so the quoted key is the test.
 	ASSERT_TRUE(payload.find("low_id") == std::string::npos);
@@ -387,12 +387,12 @@ TEST(EventDiff, StatusEventFiresWhenTheKadNetworkFiguresBecomeUnknown)
 TEST(EventDiff, StatusEventFiresWhenOnlyOverheadMoved)
 {
 	StatusSnapshot s;
-	s.download_overhead_bps = 8700;
+	s.download_overhead_bytes_per_second = 8700;
 
 	const std::string payload = EmitStatusAndGetPayload(s);
 
 	ASSERT_TRUE(!payload.empty());
-	ASSERT_TRUE(payload.find("\"download_overhead_bps\":8700") != std::string::npos);
+	ASSERT_TRUE(payload.find("\"download_overhead_bytes_per_second\":8700") != std::string::npos);
 }
 
 // EVENTS.md promises this payload is "identical to the REST /status envelope",

--- a/unittests/tests/RefresherTest.cpp
+++ b/unittests/tests/RefresherTest.cpp
@@ -910,7 +910,7 @@ TEST(Refresher, SharedDetailTagsDecodeIntoSnapshot)
 	// (the write layer reports it verbatim, with `incomplete` alongside).
 	ASSERT_EQUALS(std::string("/home/me/Incoming"), s.on_disk_dir);
 	// Upload activity (issue #466) decodes into the shared sub-block.
-	ASSERT_EQUALS(static_cast<std::uint32_t>(51200), s.shared.upload_speed_bps);
+	ASSERT_EQUALS(static_cast<std::uint32_t>(51200), s.shared.upload_speed_bytes_per_second);
 	ASSERT_EQUALS(static_cast<std::uint16_t>(3), s.shared.uploading_client_count);
 	ASSERT_EQUALS(static_cast<std::uint32_t>(1700000500), s.shared.last_upload);
 	ASSERT_EQUALS(static_cast<std::uint16_t>(4), s.shared.hashing_progress);
@@ -3306,8 +3306,8 @@ TEST(Refresher, StatusOverheadAndFreeSpaceTagsDecode)
 	StatusSnapshot out;
 	ParseStatusFromPacket(&resp, out);
 
-	ASSERT_EQUALS(static_cast<std::uint64_t>(8700), out.download_overhead_bps);
-	ASSERT_EQUALS(static_cast<std::uint64_t>(1100), out.upload_overhead_bps);
+	ASSERT_EQUALS(static_cast<std::uint64_t>(8700), out.download_overhead_bytes_per_second);
+	ASSERT_EQUALS(static_cast<std::uint64_t>(1100), out.upload_overhead_bytes_per_second);
 	ASSERT_EQUALS(static_cast<std::int64_t>(48318382080LL), out.temp_free_bytes);
 	ASSERT_EQUALS(static_cast<std::int64_t>(24159191040LL), out.incoming_free_bytes);
 }
@@ -3343,8 +3343,8 @@ TEST(Refresher, StatusWithoutStatsTagsKeepsZeroOverheadAndUnknownDisk)
 	StatusSnapshot out;
 	ParseStatusFromPacket(&resp, out);
 
-	ASSERT_EQUALS(static_cast<std::uint64_t>(0), out.download_overhead_bps);
-	ASSERT_EQUALS(static_cast<std::uint64_t>(0), out.upload_overhead_bps);
+	ASSERT_EQUALS(static_cast<std::uint64_t>(0), out.download_overhead_bytes_per_second);
+	ASSERT_EQUALS(static_cast<std::uint64_t>(0), out.upload_overhead_bytes_per_second);
 	ASSERT_EQUALS(static_cast<std::int64_t>(-1), out.temp_free_bytes);
 	ASSERT_EQUALS(static_cast<std::int64_t>(-1), out.incoming_free_bytes);
 }

--- a/unittests/tests/StateTest.cpp
+++ b/unittests/tests/StateTest.cpp
@@ -114,16 +114,16 @@ TEST(State, WriteStatusRoundtrip)
 	in.ed2k_high_id = true;
 	in.ed2k_user_id = 1234567890u; // 210.2.150.73 packed LSB-first
 	in.ed2k_public_ip = "210.2.150.73";
-	in.download_overhead_bps = 8700;
-	in.upload_overhead_bps = 1100;
+	in.download_overhead_bytes_per_second = 8700;
+	in.upload_overhead_bytes_per_second = 1100;
 	in.temp_free_bytes = 48318382080LL;
 	in.incoming_free_bytes = -1; // unknown
 	in.kad_firewalled_tcp = false;
 	in.server_name = "Some Server";
 	in.server_ip = "192.0.2.42";
 	in.server_port = 4242;
-	in.download_bps = 12345;
-	in.upload_bps = 6789;
+	in.download_bytes_per_second = 12345;
+	in.upload_bytes_per_second = 6789;
 	in.ul_queue_len = 3;
 	in.total_src_count = 17;
 	s.WriteStatus(in);
@@ -134,8 +134,8 @@ TEST(State, WriteStatusRoundtrip)
 	ASSERT_TRUE(out.ed2k_high_id);
 	ASSERT_EQUALS(static_cast<std::uint32_t>(1234567890u), out.ed2k_user_id);
 	ASSERT_EQUALS(std::string("210.2.150.73"), out.ed2k_public_ip);
-	ASSERT_EQUALS(static_cast<std::uint64_t>(8700), out.download_overhead_bps);
-	ASSERT_EQUALS(static_cast<std::uint64_t>(1100), out.upload_overhead_bps);
+	ASSERT_EQUALS(static_cast<std::uint64_t>(8700), out.download_overhead_bytes_per_second);
+	ASSERT_EQUALS(static_cast<std::uint64_t>(1100), out.upload_overhead_bytes_per_second);
 	ASSERT_EQUALS(static_cast<std::int64_t>(48318382080LL), out.temp_free_bytes);
 	// -1 must survive the round trip as -1: it is what the handler turns
 	// into JSON null, and an unsigned slot would make it 1.8e19.
@@ -144,8 +144,8 @@ TEST(State, WriteStatusRoundtrip)
 	ASSERT_EQUALS(std::string("Some Server"), out.server_name);
 	ASSERT_EQUALS(std::string("192.0.2.42"), out.server_ip);
 	ASSERT_EQUALS(static_cast<std::uint32_t>(4242), out.server_port);
-	ASSERT_EQUALS(static_cast<std::uint64_t>(12345), out.download_bps);
-	ASSERT_EQUALS(static_cast<std::uint64_t>(6789), out.upload_bps);
+	ASSERT_EQUALS(static_cast<std::uint64_t>(12345), out.download_bytes_per_second);
+	ASSERT_EQUALS(static_cast<std::uint64_t>(6789), out.upload_bytes_per_second);
 	ASSERT_EQUALS(static_cast<std::uint32_t>(3), out.ul_queue_len);
 	ASSERT_EQUALS(static_cast<std::uint32_t>(17), out.total_src_count);
 }
@@ -607,7 +607,7 @@ TEST(State, MutateClientsAndSharedRoundtrip)
 		c.ecid = 10;
 		c.client_name = "peer-1";
 		c.upload_state = "uploading";
-		c.upload_speed_bps = 1234;
+		c.upload_speed_bytes_per_second = 1234;
 		cache.emplace(c.ecid, c);
 	});
 	ASSERT_EQUALS(static_cast<size_t>(1), s.Clients().size());
@@ -867,8 +867,8 @@ TEST(State, WriteGraphsRoundtripAllSeries)
 	CState s;
 	StatsGraphs g;
 	g.interval_seconds = 1;
-	g.download_bps = { 100, 200, 300 };
-	g.upload_bps = { 10, 20, 30 };
+	g.download_bytes_per_second = { 100, 200, 300 };
+	g.upload_bytes_per_second = { 10, 20, 30 };
 	g.connections = { 1, 2, 3 };
 	g.kad_nodes = { 500, 600, 700 };
 	g.active_uploads = { 4, 5, 6 };
@@ -882,8 +882,8 @@ TEST(State, WriteGraphsRoundtripAllSeries)
 
 	const StatsGraphs out = s.Graphs();
 	ASSERT_EQUALS(static_cast<std::uint32_t>(1), out.interval_seconds);
-	ASSERT_EQUALS(static_cast<size_t>(3), out.download_bps.size());
-	ASSERT_EQUALS(static_cast<std::uint32_t>(300), out.download_bps[2]);
+	ASSERT_EQUALS(static_cast<size_t>(3), out.download_bytes_per_second.size());
+	ASSERT_EQUALS(static_cast<std::uint32_t>(300), out.download_bytes_per_second[2]);
 	ASSERT_EQUALS(static_cast<std::uint32_t>(700), out.kad_nodes[2]);
 	// The second data blob rides along point-aligned with the first.
 	ASSERT_EQUALS(static_cast<size_t>(3), out.active_uploads.size());
@@ -903,7 +903,7 @@ TEST(State, WriteGraphsWithoutConnBlobLeavesExtraSeriesEmpty)
 {
 	CState s;
 	StatsGraphs g;
-	g.download_bps = { 100, 200, 300 };
+	g.download_bytes_per_second = { 100, 200, 300 };
 	g.connections = { 1, 2, 3 };
 	s.WriteGraphs(g);
 
@@ -1298,7 +1298,7 @@ TEST(State, ConcurrentReadersDontTearSnapshot)
 	// a *self-consistent* snapshot (the four numeric fields below
 	// are written under one unique_lock, so a shared_lock reader
 	// must see them all from the same generation). A teared read
-	// would manifest as a mismatched (download_bps, upload_bps)
+	// would manifest as a mismatched (download_bytes_per_second, upload_bytes_per_second)
 	// pair, which we then assert against.
 
 	CState s;
@@ -1310,8 +1310,8 @@ TEST(State, ConcurrentReadersDontTearSnapshot)
 		std::uint64_t gen = 1;
 		while (!stop.load()) {
 			StatusSnapshot v;
-			v.download_bps = gen;
-			v.upload_bps = gen * 2;
+			v.download_bytes_per_second = gen;
+			v.upload_bytes_per_second = gen * 2;
 			v.ul_queue_len = static_cast<std::uint32_t>(gen & 0xffffffff);
 			v.total_src_count = static_cast<std::uint32_t>(gen & 0xffffffff);
 			s.WriteStatus(v);
@@ -1326,9 +1326,9 @@ TEST(State, ConcurrentReadersDontTearSnapshot)
 				StatusSnapshot r = s.Status();
 				observed.fetch_add(1);
 				// Invariants enforced by the writer's single
-				// unique_lock acquisition: upload_bps == 2 *
-				// download_bps; ul_queue_len == total_src_count.
-				if (r.upload_bps != 2 * r.download_bps)
+				// unique_lock acquisition: upload_bytes_per_second == 2 *
+				// download_bytes_per_second; ul_queue_len == total_src_count.
+				if (r.upload_bytes_per_second != 2 * r.download_bytes_per_second)
 					torn.fetch_add(1);
 				if (r.ul_queue_len != r.total_src_count)
 					torn.fetch_add(1);


### PR DESCRIPTION
R2 says a byte rate is `_bytes_per_second`, and `REFERENCE.md` has said so since #1197. Six keys never got the memo, so `/api/v0` has been shipping two spellings for one unit:

| Endpoint | Was | Now |
|---|---|---|
| `/status` | `download_bps`, `upload_bps` | `download_bytes_per_second`, `upload_bytes_per_second` |
| `/status` | `download_overhead_bps`, `upload_overhead_bps` | `download_overhead_bytes_per_second`, `upload_overhead_bytes_per_second` |
| `/clients` | `download_speed_bps`, `upload_speed_bps` | `download_speed_bytes_per_second`, `upload_speed_bytes_per_second` |
| `/shared` | `upload_speed_bps` | `upload_speed_bytes_per_second` |

while `/downloads` already returned `speed_bytes_per_second` and the graph `unit` token already read `"bytes_per_second"`.

### Why they were missed

#1189 listed them as *"keep - rule-compliant"* under **its** R2, where `_bps` was defined as bytes per second. Spelling rates out was a deliberate deviation from that (#1197), and the deviation was applied to the keys the issue asked to **rename** without being carried to the keys it asked to **keep**. The reasoning holds identically for both: in networking `bps` is bits, every rate on this surface is bytes, and a factor of 8 is invisible where a long name is not. The reference already states exactly this at the `Naming rules` section - the surface simply had not caught up with its own documentation.

`_kbps` is untouched. It is KiB/s, it is what the user types and what the desktop shows, and R2 keeps it. The only `_bps` left in the tree is the sentence in `REFERENCE.md` explaining why the abbreviation is not used.

### Scope

Members move with their keys, per the convention the rest of the rename series follows, so this touches the serializers, the snapshot structs, the SSE payloads **and their `Equal` predicates**, the Web UI reads, and both test suites together. 146 replacements across 15 files.

### Verification

Build clean, 43/43 unit tests.

Curl phases 03 (status), 04 (downloads/shared), 22 (SSE diff emission - the payloads and `Equal` predicates) and 28 (pagination/sort): **all pass**, 39/39, 130/130, 29/29.

R7 re-checked after the rename: all 26 sort tokens still equal the response key they order by, and the only rate-bearing one is `speed_bytes_per_second`.

clang-format 18 whole-file (7 files), clang-tidy Tier-1 and Tier-2 on the diff: clean, 0 fatal errors. `check-potfiles.sh` clean, en/es dictionary parity intact. The longer names rewrapped four `ostringstream` chains and two `Equal` predicates in `EventDiff.cpp`; that is the whole of the format delta.
