### PR TITLE
fix(amuleapi): a refused category path is a partial success, not a failure

### DIFF
--- a/docs/api/REFERENCE.md
+++ b/docs/api/REFERENCE.md
@@ -2138,6 +2138,8 @@ it as `0x00BBGGRR` with **red in the low byte**, so a naive hex print of the
 integer comes out reversed. Anything that is not `#` followed by six hex
 digits is a `400 bad_request`. `priority` accepts the same six levels the category read side can return — `"very_low"` / `"low"` / `"normal"` / `"high"` / `"release"` / `"auto"` — so a read-modify-write round-trip always succeeds (R9). It is applied to the category's member files as a download priority.
 
+**`save_path` is resolved on the daemon's filesystem, not yours,** so it is accepted without being checked here. Omit it and the category is created on the incoming directory, which is amuled's own default. Give a path amuled cannot use — it does not exist and cannot be created — and the category is still created, on the incoming directory again. Either way this is a success, and [`GET /categories/{index}`](#get-apiv0categoriesindex) reports the path that was actually stored. Compare it with what you sent if it matters to you; a `save_path` that comes back different is the daemon saying it could not use yours.
+
 **Response:** `202 Accepted`, no body. `EC_OP_CREATE_CATEGORY` answers success or failure and never returns the index it assigned, so naming the new category here meant scanning the snapshot for one with a matching name and falling back to a bodiless `201` when the scan came up short. Re-read [`GET /categories`](#get-apiv0categories) for the assigned index.
 
 **Errors:** `400 bad_request`, `400 amuled_rejected`, `503 ec_unavailable`.
@@ -2157,6 +2159,12 @@ Returns the single category object, the same shape [`PATCH`](#patch-apiv0categor
 **Auth:** `ADMIN`
 
 Any subset of the POST body fields. `index 0` (the default category) can be patched but not deleted.
+
+**Response:** `200 OK` with the category object as stored, the same shape [`GET /categories/{index}`](#get-apiv0categoriesindex) returns, so a client can see what landed without a follow-up read.
+
+`save_path` follows the same rule as on create: amuled resolves it on its own filesystem, and when it cannot use the path it keeps the one the category already had. The rest of the request still applies — `name`, `comment`, `color` and `priority` all land — and the echoed object reports the path that was kept. That is the one case where a field you sent is not the field you get back, which is why the response echoes the object rather than answering `204`.
+
+**Errors:** `400 bad_request` (non-numeric or out-of-range `{index}`, malformed `color`, unknown `priority`), `404 not_found` (no category at that index), `400 amuled_rejected`, `503 ec_unavailable`.
 
 #### `DELETE /api/v0/categories/{index}`
 

--- a/src/webapi/Api.cpp
+++ b/src/webapi/Api.cpp
@@ -3848,6 +3848,32 @@ bool IsEcFailedResponse(const CECPacket *resp, std::string &out_msg)
 	return true;
 }
 
+// The two category ops answer EC_OP_FAILED for a *partial success*, not a
+// failure: amuled created or updated the category and then found it could not
+// use the path, so it kept another one -- the incoming directory for a create,
+// the previous path for an update -- and returns that path in
+// EC_TAG_CATEGORY_PATH beside the category index (ExternalConn.cpp,
+// EC_OP_CREATE_CATEGORY / EC_OP_UPDATE_CATEGORY, and the rewrite in
+// CEC_Category_Tag::Create / ::Apply). An update keeps name, comment, colour
+// and priority in that case; only the path is refused.
+//
+// The desktop reads exactly this: CCatHandler::HandlePacket corrects its local
+// copy from the tag and tells the user "keeping directory ...". Relaying it as
+// a 400 instead says the request failed while the category exists, and throws
+// away the one field that says what happened.
+//
+// A reply carrying no such tag is a genuine failure.
+bool EcCategoryPathKept(const CECPacket *resp, std::string &kept_path)
+{
+	if (!resp || resp->GetOpCode() != EC_OP_FAILED)
+		return false;
+	const CECTag *t = resp->GetTagByName(EC_TAG_CATEGORY_PATH);
+	if (!t)
+		return false;
+	kept_path = std::string(t->GetStringData().utf8_str());
+	return true;
+}
+
 // Map our wire-string priorities back to amule's PR_* encoding -- the inverse of
 // PriorityName in Refresher.cpp, which is likewise one function for all three
 // resources. PR_AUTO=5 is the magic value stored as High plus the auto flag.
@@ -10283,10 +10309,18 @@ CHttpServer::Response CApiDispatcher::HandleCategoryCreate(const CHttpServer::Re
 	}
 	std::string ec_err_msg;
 	if (IsEcFailedResponse(ec_resp, ec_err_msg)) {
+		// A kept-path reply means the category exists; only the path was
+		// refused, and `save_path` on the follow-up read is the truthful
+		// answer. Anything else is a real failure.
+		std::string kept_path;
+		const bool kept = EcCategoryPathKept(ec_resp, kept_path);
 		delete ec_resp;
-		return ErrorResponse(400, "amuled_rejected", ec_err_msg.c_str());
+		if (!kept) {
+			return ErrorResponse(400, "amuled_rejected", ec_err_msg.c_str());
+		}
+	} else {
+		delete ec_resp;
 	}
-	delete ec_resp;
 
 	// Tick so the new category is in the snapshot the caller's follow-up GET
 	// reads, even though this response does not carry it.
@@ -10397,10 +10431,18 @@ CHttpServer::Response CApiDispatcher::HandleCategoryUpdate(
 	}
 	std::string ec_err_msg;
 	if (IsEcFailedResponse(ec_resp, ec_err_msg)) {
+		// As on create: a kept-path reply is a partial success. The name,
+		// comment, colour and priority in this request all landed, and the
+		// echoed object below reports the path that was actually kept.
+		std::string kept_path;
+		const bool kept = EcCategoryPathKept(ec_resp, kept_path);
 		delete ec_resp;
-		return ErrorResponse(400, "amuled_rejected", ec_err_msg.c_str());
+		if (!kept) {
+			return ErrorResponse(400, "amuled_rejected", ec_err_msg.c_str());
+		}
+	} else {
+		delete ec_resp;
 	}
-	delete ec_resp;
 
 	(void)RefresherTick(m_app, m_state);
 

--- a/unittests/curl-tests/amuleapi/18-categories-crud.sh
+++ b/unittests/curl-tests/amuleapi/18-categories-crud.sh
@@ -349,6 +349,77 @@ _curl -X DELETE -H "Authorization: Bearer $ADMIN_TOKEN" \
 	"$HOST/api/v0/categories/$NEW_IDX"
 _assert_status 404 "DELETE same index twice → 404"
 
+# --- 8. The path-substitution contract (partial success, not failure). ---
+#
+# amuled answers EC_OP_FAILED for these two ops when it created or updated the
+# category but could not use the path, keeping another one and returning it in
+# EC_TAG_CATEGORY_PATH. The category exists either way, so the API reports
+# success and `save_path` carries the path that was actually kept. Relaying it
+# as a 400 used to claim the request failed while the category was sitting in
+# the list.
+#
+# Placed last because each case creates a category; each cleans up its own.
+
+# 8a. No save_path at all. The daemon's documented default is the incoming
+#     directory, so this is an ordinary create, not an error.
+_curl -X POST -H "Authorization: Bearer $ADMIN_TOKEN" \
+	-H "Content-Type: application/json" \
+	-d '{"name":"18-cat-nopath"}' "$HOST/api/v0/categories"
+_assert_status 202 "POST /categories with no save_path -> 202 (defaults to incoming)"
+_curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/categories"
+NOPATH_IDX=$(printf '%s' "$CURL_BODY" \
+	| jq -r '[.categories[] | select(.name == "18-cat-nopath")][0].index // empty')
+if [ -n "$NOPATH_IDX" ]; then
+	_pass "the category created without save_path is in the list (index=$NOPATH_IDX)"
+	_assert_json_eq '[.categories[] | select(.name == "18-cat-nopath")][0].save_path' \
+		"$INCOMING" 'a create with no save_path lands on directories.incoming_path'
+	_curl -X DELETE -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/categories/$NOPATH_IDX"
+	_assert_status 204 "cleanup: DELETE /categories/$NOPATH_IDX -> 204"
+else
+	_fail "create without save_path" "202 returned but no such category in /categories"
+fi
+
+# 8b. A save_path the daemon cannot create. It keeps the incoming directory and
+#     the category still exists. Running as root the mkdir would succeed, so the
+#     assertion is guarded on the substitution actually having happened.
+UNUSABLE=/18-cat-unusable-$$/sub
+_curl -X POST -H "Authorization: Bearer $ADMIN_TOKEN" \
+	-H "Content-Type: application/json" \
+	-d "{\"name\":\"18-cat-badpath\",\"save_path\":\"$UNUSABLE\"}" "$HOST/api/v0/categories"
+_assert_status 202 "POST /categories with an uncreatable save_path -> 202 (path substituted)"
+_curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/categories"
+BAD_IDX=$(printf '%s' "$CURL_BODY" \
+	| jq -r '[.categories[] | select(.name == "18-cat-badpath")][0].index // empty')
+if [ -n "$BAD_IDX" ]; then
+	_pass "the category survives an uncreatable save_path (index=$BAD_IDX)"
+	BAD_PATH=$(printf '%s' "$CURL_BODY" \
+		| jq -r '[.categories[] | select(.name == "18-cat-badpath")][0].save_path')
+	if [ "$BAD_PATH" = "$UNUSABLE" ]; then
+		_skip "path-substitution check: the daemon could create $UNUSABLE (running as root?)"
+	else
+		_assert_json_eq '[.categories[] | select(.name == "18-cat-badpath")][0].save_path' \
+			"$INCOMING" 'the refused path is replaced by directories.incoming_path, not stored'
+	fi
+
+	# 8c. The same contract on PATCH: an update whose path is refused still
+	#     applies every other field, and the echoed object reports the path
+	#     that was kept rather than the one that was asked for.
+	_curl -X PATCH -H "Authorization: Bearer $ADMIN_TOKEN" \
+		-H "Content-Type: application/json" \
+		-d "{\"name\":\"18-cat-badpath-renamed\",\"save_path\":\"$UNUSABLE\"}" \
+		"$HOST/api/v0/categories/$BAD_IDX"
+	_assert_status 200 "PATCH /categories/$BAD_IDX with an uncreatable save_path -> 200"
+	_assert_json_eq '.name' '18-cat-badpath-renamed' \
+		'the rest of the PATCH lands even when the path is refused'
+	_assert_json_eq "(.save_path == \"$UNUSABLE\")" false \
+		'the echoed save_path is the kept one, not the refused one'
+
+	_curl -X DELETE -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/categories/$BAD_IDX"
+	_assert_status 204 "cleanup: DELETE /categories/$BAD_IDX -> 204"
+else
+	_fail "create with an uncreatable save_path" "202 returned but no such category in /categories"
+fi
+
 # --- Summary. -----------------------------------------------------
 echo
 if [ "$FAIL_COUNT" -eq 0 ]; then


### PR DESCRIPTION
`POST /categories` and `PATCH /categories/{index}` answered `400 amuled_rejected` whenever amuled could not use the `save_path` - **including the ordinary case of not sending one at all**. The category was created or updated regardless, so the client was told its request failed while the result sat in the list.

### `EC_OP_FAILED` does not mean failure for these two ops

amuled creates or updates the category, finds the path unusable, keeps another one, and returns it:

- `CEC_Category_Tag::Create()` / `::Apply()` rewrite `EC_TAG_CATEGORY_PATH` to the path actually kept when the update returns false (`ECSpecialMuleTags.cpp:65-88`)
- `ExternalConn.cpp:4189-4220` sends `EC_OP_FAILED` carrying that tag plus `EC_TAG_CATEGORY` - and no `EC_TAG_STRING`, which is why the old 400 also had nothing useful to say
- for a create the kept path is the incoming directory; for an update it is the path the category already had, and **name, comment, colour and priority still land** (`CPreferences::UpdateCategory` applies them before returning false)

**The desktop already reads it this way.** `CCatHandler::HandlePacket` takes the path out of that reply, corrects its local copy, refreshes the transfer window and tells the user *"Can't create directory '%s' for category '%s', keeping directory '%s'."* The monolithic GUI never reaches the case at all, because `CCatDialog::OnBnClickedOk` validates the path before sending - which neither amulegui nor amuleapi can do, since the path lives on the daemon's filesystem. amulegui says so in a comment: *"Pass path unchecked (and don't try to create it on the wrong machine...). It will be checked on the server."*

So amuleapi was the only one of the three treating a partial success as a failure, and the only one throwing away the field that says what happened.

### The fix

Both handlers check for the kept-path tag and, when it is present, answer as they do on success. A reply without it is still a real failure and still a `400`.

**No response shape changes.** A create stays `202` with no body; a patch stays `200` with the category object. `save_path` on that object is the honest answer in both cases - more useful to a client than a message it would have to parse, and it avoids a key that exists on only one code path.

### Verification

Build clean, 43/43 unit tests.

Phase 18 extended with the contract, **66/66** including 11 new assertions:

- `POST` with no `save_path` -> `202`, category present, lands on `directories.incoming_path`
- `POST` with an uncreatable `save_path` -> `202`, category present, path substituted rather than stored
- `PATCH` with an uncreatable `save_path` -> `200`, the `name` change lands, echoed `save_path` is the kept one
- each case deletes the category it created

The substitution assertions are guarded: if the daemon manages to create the directory (running as root) the test `_skip`s rather than asserting a substitution that did not happen.

clang-format 18 whole-file, clang-tidy Tier-1 and Tier-2 on the diff: clean, 0 fatal errors.

### Docs

`POST` now states that `save_path` is resolved on the daemon's filesystem and what happens when it cannot be used. `PATCH` gained a **Response** and **Errors** section it never had, including the one case where a field you send is not the field you get back - which is why that endpoint echoes the object instead of answering `204`.
