### PR TITLE
fix(core): stop redefining an Asio ABI macro in one translation unit

### DIFF
--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -253,6 +253,21 @@ endif()
 
 add_compile_definitions ($<$<CONFIG:DEBUG>:__DEBUG__>)
 
+# Refuse deprecated Boost.Asio APIs. Set for EVERY target on purpose, never in
+# a single source file: the macro does not only hide deprecated names, it
+# switches BOOST_ASIO_SYNC_OP_VOID between void and error_code, which changes
+# the return type of basic_socket::close() and its siblings. Those are weak
+# inline templates, so a translation unit that disagrees with the rest still
+# links -- against whichever definition the linker happened to keep -- and the
+# caller then sets up the wrong ABI for the call. Defined in one .cpp, it made
+# amuleapi write a returned error_code over a live socket object and abort with
+# bad_weak_ptr on shutdown (issue #1214).
+#
+# Safe only while Asio is header-only, which it is here: nothing links a
+# prebuilt Boost. If that ever changes, this has to match how that Boost was
+# built, or the same mismatch returns at the library boundary.
+add_compile_definitions (BOOST_ASIO_NO_DEPRECATED)
+
 if (WIN32)
 	add_compile_definitions ($<$<CONFIG:DEBUG>:wxDEBUG_LEVEL=0>)
 endif (WIN32)

--- a/src/LibSocketAsio.cpp
+++ b/src/LibSocketAsio.cpp
@@ -48,8 +48,6 @@
 #include <poll.h> // Bounded readability wait for the sync-read no-progress timeout
 #endif
 
-// Trip the compile if we accidentally pull a deprecated Asio API back in.
-#define BOOST_ASIO_NO_DEPRECATED
 // Boost 1.92's asio declares several exception types with a user-provided
 // destructor and no matching copy constructor, which is the P0806 deprecation
 // -Wdeprecated-copy-with-user-provided-dtor reports. The build promotes it to


### PR DESCRIPTION
Closes #1214.

`amuleapi` aborted with `bad_weak_ptr` on SIGTERM, exit 255. The throw came from `shared_from_this()` in `CAsioSocketImpl::Destroy`, but the object's lifetime was never the problem: a watchpoint on the impl caught its `enable_shared_from_this` member being overwritten from inside `boost::asio::basic_socket::close()`, while the object was alive with a use count of 1 and its destructor still to come.

## What was actually happening

`LibSocketAsio.cpp` defined `BOOST_ASIO_NO_DEPRECATED` before including Asio, as a lint against accidentally using deprecated APIs. That macro also switches `BOOST_ASIO_SYNC_OP_VOID` between `boost::system::error_code` and `void`, which changes the **return type** of `basic_socket::close()` and its siblings.

Defined in one translation unit, it gave that file a different view of those functions than `webapi/HttpServer.cpp`, which includes Asio too. `basic_socket::close` is a weak inline template, so the linker keeps one definition. It kept the `error_code`-returning one. `DispatchClose`, compiled believing the call returned `void`, never set up the AArch64 indirect-result register, and the callee wrote its 24-byte return value through whatever that register happened to hold. It held `this`, so the write landed on `__weak_this_` and the next `shared_from_this()` threw.

The disassembly at the watchpoint, immediately after the inner service call returns:

```
bl   reactive_socket_service_base::close(...)
ldr  x9, [sp, #0x10]        ; hidden return-value pointer
ldur x8, [x29, #-0x10]      ; &ec
ldr  q0, [x8] / str q0, [x9]                 ; 16 bytes
ldr  x8, [x8, #0x10] / str x8, [x9, #0x10]   ; the remaining 8
```

`x9` is the impl. That is a 24-byte `error_code` returned by value into an object that never asked for one.

## The fix

The macro moves to `cmake/options.cmake` and applies to every target, rather than being dropped. It was doing a useful job, the tree has no deprecated Asio usage, and this keeps it that way. The bug was *where* it was defined, not *that* it was defined.

That is safe here because Asio is header-only in this build: nothing links a prebuilt Boost, so our own translation units are the only parties that have to agree. The comment at the definition site says so, because linking a distro Boost later would reintroduce the same mismatch at that boundary, and this is not the kind of bug anyone wants to diagnose twice.

## Why this shape of bug

- Every lifetime-based explanation fails, because it is not a lifetime bug. Holding a `shared_ptr` across the call cannot stop a stray struct copy.
- `amulecmd` runs the identical teardown and has always exited cleanly: it does not link `webapi/HttpServer.cpp`, so there is no second instantiation and no mismatch. `amuleapi` links both.
- ASan is clean, because the write goes to valid, live memory, just the wrong object.
- Linux never showed the symptom: GCC inlined `close()` locally rather than calling the shared symbol, so no ABI boundary was crossed. Same latent defect, no crash.

## Verification

Three runs per platform, same teardown path, before and after.

| platform | before | after |
|---|---|---|
| macOS arm64 | `bad_weak_ptr`, exit 255 | clean, exit 0 |
| Linux aarch64 | clean, exit 0 | clean, exit 0 |
| Windows ARM64 | `bad_weak_ptr`, exit 255 | clean, exit 1 |

Windows cannot receive an external SIGTERM as a native binary, so that leg drops amuled and lets the EC-loss path request the same shutdown; exit 1 is that path's normal result, replacing the abort. Linux is a no-regression check, since it never showed the symptom.

Full build clean on all three, 43/43 tests, clang-format and Tier-2 clang-tidy clean. Confirmed the define reaches every Asio translation unit, including `LibSocketAsio.cpp`, which is `#include`d into `LibSocket.cpp` rather than compiled directly.
