### PR TITLE
fix(gui): name the two chunk-bar columns apart, and explain their colours

### DIFF
--- a/po/amule.pot
+++ b/po/amule.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-29 20:55+0200\n"
+"POT-Creation-Date: 2026-08-30 16:16+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -2678,21 +2678,39 @@ msgid ""
 msgstr ""
 
 #: src/GenericClientListCtrl.cpp
-msgid ""
-"One block per part of the file.\n"
-"Light grey: this source does not have the part.\n"
-"Green: this source has it and so do you.\n"
-"Amber: downloading this part from this source now.\n"
-"Pale yellow: the next part you will request from this source.\n"
-"Dark grey: this source has it and you still need it.\n"
-"The whole bar is dimmed while the download is stopped."
+msgid "This source does not have the part"
 msgstr ""
 
 #: src/GenericClientListCtrl.cpp
-msgid ""
-"One block per part of your shared file.\n"
-"Dark grey: this peer already has the part.\n"
-"Light grey: this peer does not have it."
+msgid "You and this source both have the part"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "Being downloaded from this source now"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "The next part that will be asked of this source"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "This source has the part and you still need it"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "This peer already has the part"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "This peer does not have the part"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "One block per part of the file being downloaded."
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "One block per part of the shared file."
 msgstr ""
 
 #: src/GenericClientListCtrl.cpp

--- a/po/amule.pot
+++ b/po/amule.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 19:01+0200\n"
+"POT-Creation-Date: 2026-08-29 20:55+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -2675,6 +2675,24 @@ msgstr ""
 msgid ""
 "You are not allowed to set more than one friendslot.\n"
 " Only one slot was assigned."
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid ""
+"One block per part of the file.\n"
+"Light grey: this source does not have the part.\n"
+"Green: this source has it and so do you.\n"
+"Amber: downloading this part from this source now.\n"
+"Pale yellow: the next part you will request from this source.\n"
+"Dark grey: this source has it and you still need it.\n"
+"The whole bar is dimmed while the download is stopped."
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid ""
+"One block per part of your shared file.\n"
+"Dark grey: this peer already has the part.\n"
+"Light grey: this peer does not have it."
 msgstr ""
 
 #: src/GenericClientListCtrl.cpp
@@ -7108,8 +7126,8 @@ msgstr[1] ""
 msgid "User Name"
 msgstr ""
 
-#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
-msgid "Available Parts"
+#: src/SharedFilePeersListCtrl.cpp
+msgid "Parts on Peer"
 msgstr ""
 
 #: src/SharedFilePeersListCtrl.cpp
@@ -7302,6 +7320,10 @@ msgstr ""
 #: src/SharedFilesReloadProgress.cpp
 #, c-format
 msgid "Reloading shared files: %u files scanned"
+msgstr ""
+
+#: src/SourceListCtrl.cpp
+msgid "Part Status"
 msgstr ""
 
 #: src/SourceListCtrl.cpp

--- a/po/amule.pot
+++ b/po/amule.pot
@@ -2714,6 +2714,10 @@ msgid "One block per part of the shared file."
 msgstr ""
 
 #: src/GenericClientListCtrl.cpp
+msgid "Colour legend"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
 #, c-format
 msgid "On Queue: %u (%i)"
 msgstr ""

--- a/po/ar.po
+++ b/po/ar.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 19:01+0200\n"
+"POT-Creation-Date: 2026-08-29 20:55+0200\n"
 "PO-Revision-Date: 2026-08-25 10:01+0000\n"
 "Last-Translator: saleh alhathal <hathalsal@hotmail.com>\n"
 "Language-Team: \n"
@@ -2719,6 +2719,24 @@ msgstr "هل انت متاكد من الغاء زحذف هذه الملفات ؟
 msgid ""
 "You are not allowed to set more than one friendslot.\n"
 " Only one slot was assigned."
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid ""
+"One block per part of the file.\n"
+"Light grey: this source does not have the part.\n"
+"Green: this source has it and so do you.\n"
+"Amber: downloading this part from this source now.\n"
+"Pale yellow: the next part you will request from this source.\n"
+"Dark grey: this source has it and you still need it.\n"
+"The whole bar is dimmed while the download is stopped."
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid ""
+"One block per part of your shared file.\n"
+"Dark grey: this peer already has the part.\n"
+"Light grey: this peer does not have it."
 msgstr ""
 
 #: src/GenericClientListCtrl.cpp
@@ -7234,10 +7252,9 @@ msgstr[1] "وجد %i ملف مشاركة معرف"
 msgid "User Name"
 msgstr "اسم مستخدم"
 
-#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
-#, fuzzy
-msgid "Available Parts"
-msgstr "متوفر :"
+#: src/SharedFilePeersListCtrl.cpp
+msgid "Parts on Peer"
+msgstr ""
 
 #: src/SharedFilePeersListCtrl.cpp
 #, fuzzy
@@ -7435,6 +7452,11 @@ msgstr "ملفات مشاركة (%i)"
 #, fuzzy, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "وجد %i ملف مشاركة معرف"
+
+#: src/SourceListCtrl.cpp
+#, fuzzy
+msgid "Part Status"
+msgstr "حالة"
 
 #: src/SourceListCtrl.cpp
 #, fuzzy
@@ -9071,6 +9093,10 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#, fuzzy
+#~ msgid "Available Parts"
+#~ msgstr "متوفر :"
 
 #, fuzzy, c-format
 #~ msgid "Found %i known shared file, %i unknown"

--- a/po/ar.po
+++ b/po/ar.po
@@ -2758,6 +2758,10 @@ msgid "One block per part of the shared file."
 msgstr ""
 
 #: src/GenericClientListCtrl.cpp
+msgid "Colour legend"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
 #, fuzzy, c-format
 msgid "On Queue: %u (%i)"
 msgstr "في اﻻنتظار"

--- a/po/ar.po
+++ b/po/ar.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-29 20:55+0200\n"
+"POT-Creation-Date: 2026-08-30 16:16+0200\n"
 "PO-Revision-Date: 2026-08-25 10:01+0000\n"
 "Last-Translator: saleh alhathal <hathalsal@hotmail.com>\n"
 "Language-Team: \n"
@@ -2722,21 +2722,39 @@ msgid ""
 msgstr ""
 
 #: src/GenericClientListCtrl.cpp
-msgid ""
-"One block per part of the file.\n"
-"Light grey: this source does not have the part.\n"
-"Green: this source has it and so do you.\n"
-"Amber: downloading this part from this source now.\n"
-"Pale yellow: the next part you will request from this source.\n"
-"Dark grey: this source has it and you still need it.\n"
-"The whole bar is dimmed while the download is stopped."
+msgid "This source does not have the part"
 msgstr ""
 
 #: src/GenericClientListCtrl.cpp
-msgid ""
-"One block per part of your shared file.\n"
-"Dark grey: this peer already has the part.\n"
-"Light grey: this peer does not have it."
+msgid "You and this source both have the part"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "Being downloaded from this source now"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "The next part that will be asked of this source"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "This source has the part and you still need it"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "This peer already has the part"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "This peer does not have the part"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "One block per part of the file being downloaded."
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "One block per part of the shared file."
 msgstr ""
 
 #: src/GenericClientListCtrl.cpp

--- a/po/ast.po
+++ b/po/ast.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 19:01+0200\n"
+"POT-Creation-Date: 2026-08-29 20:55+0200\n"
 "PO-Revision-Date: 2026-08-25 10:02+0000\n"
 "Last-Translator: astur <malditoastur@gmail.com>\n"
 "Language-Team: Language ast <malditoastur@gmail.com>\n"
@@ -2778,6 +2778,24 @@ msgid ""
 msgstr ""
 "Nun se-y permite asignar más d'ún puestu reserváu.\n"
 " Namái s'asignó un puestu reserváu."
+
+#: src/GenericClientListCtrl.cpp
+msgid ""
+"One block per part of the file.\n"
+"Light grey: this source does not have the part.\n"
+"Green: this source has it and so do you.\n"
+"Amber: downloading this part from this source now.\n"
+"Pale yellow: the next part you will request from this source.\n"
+"Dark grey: this source has it and you still need it.\n"
+"The whole bar is dimmed while the download is stopped."
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid ""
+"One block per part of your shared file.\n"
+"Dark grey: this peer already has the part.\n"
+"Light grey: this peer does not have it."
+msgstr ""
 
 #: src/GenericClientListCtrl.cpp
 #, fuzzy, c-format
@@ -7353,10 +7371,9 @@ msgstr[1] "Alcontráronse %i ficheros compartíos"
 msgid "User Name"
 msgstr "Nome usuariu:"
 
-#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
-#, fuzzy
-msgid "Available Parts"
-msgstr "Disponibles :"
+#: src/SharedFilePeersListCtrl.cpp
+msgid "Parts on Peer"
+msgstr ""
 
 #: src/SharedFilePeersListCtrl.cpp
 #, fuzzy
@@ -7554,6 +7571,11 @@ msgstr "Ficheros Compartíos (%i)"
 #, fuzzy, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "Recargar llista de ficheros compartíos."
+
+#: src/SourceListCtrl.cpp
+#, fuzzy
+msgid "Part Status"
+msgstr "Estáu"
 
 #: src/SourceListCtrl.cpp
 #, fuzzy
@@ -9262,6 +9284,10 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#, fuzzy
+#~ msgid "Available Parts"
+#~ msgstr "Disponibles :"
 
 #, c-format
 #~ msgid "Found %i known shared file, %i unknown"

--- a/po/ast.po
+++ b/po/ast.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-29 20:55+0200\n"
+"POT-Creation-Date: 2026-08-30 16:16+0200\n"
 "PO-Revision-Date: 2026-08-25 10:02+0000\n"
 "Last-Translator: astur <malditoastur@gmail.com>\n"
 "Language-Team: Language ast <malditoastur@gmail.com>\n"
@@ -2780,22 +2780,42 @@ msgstr ""
 " Namái s'asignó un puestu reserváu."
 
 #: src/GenericClientListCtrl.cpp
-msgid ""
-"One block per part of the file.\n"
-"Light grey: this source does not have the part.\n"
-"Green: this source has it and so do you.\n"
-"Amber: downloading this part from this source now.\n"
-"Pale yellow: the next part you will request from this source.\n"
-"Dark grey: this source has it and you still need it.\n"
-"The whole bar is dimmed while the download is stopped."
+#, fuzzy
+msgid "This source does not have the part"
+msgstr "Esti comandu nun tendría de tener dengún parámetru"
+
+#: src/GenericClientListCtrl.cpp
+msgid "You and this source both have the part"
 msgstr ""
 
 #: src/GenericClientListCtrl.cpp
-msgid ""
-"One block per part of your shared file.\n"
-"Dark grey: this peer already has the part.\n"
-"Light grey: this peer does not have it."
+msgid "Being downloaded from this source now"
 msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "The next part that will be asked of this source"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "This source has the part and you still need it"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "This peer already has the part"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "This peer does not have the part"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "One block per part of the file being downloaded."
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+#, fuzzy
+msgid "One block per part of the shared file."
+msgstr "Introduz el puertu del sirvidor"
 
 #: src/GenericClientListCtrl.cpp
 #, fuzzy, c-format

--- a/po/ast.po
+++ b/po/ast.po
@@ -2818,6 +2818,10 @@ msgid "One block per part of the shared file."
 msgstr "Introduz el puertu del sirvidor"
 
 #: src/GenericClientListCtrl.cpp
+msgid "Colour legend"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
 #, fuzzy, c-format
 msgid "On Queue: %u (%i)"
 msgstr "LC: %u (%i)"

--- a/po/bg.po
+++ b/po/bg.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 19:01+0200\n"
+"POT-Creation-Date: 2026-08-29 20:55+0200\n"
 "PO-Revision-Date: 2026-08-25 10:02+0000\n"
 "Last-Translator: Sebastiano Pistore <SebastianoPistore.info@protonmail.ch>\n"
 "Language-Team: Bulgarian <dict@linux.zonebg.com>\n"
@@ -2716,6 +2716,24 @@ msgstr "Сигурни ли сте,че желаете да откажете с�
 msgid ""
 "You are not allowed to set more than one friendslot.\n"
 " Only one slot was assigned."
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid ""
+"One block per part of the file.\n"
+"Light grey: this source does not have the part.\n"
+"Green: this source has it and so do you.\n"
+"Amber: downloading this part from this source now.\n"
+"Pale yellow: the next part you will request from this source.\n"
+"Dark grey: this source has it and you still need it.\n"
+"The whole bar is dimmed while the download is stopped."
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid ""
+"One block per part of your shared file.\n"
+"Dark grey: this peer already has the part.\n"
+"Light grey: this peer does not have it."
 msgstr ""
 
 #: src/GenericClientListCtrl.cpp
@@ -7207,10 +7225,9 @@ msgstr[1] "Известни са %i споделени файлове"
 msgid "User Name"
 msgstr "Потребителско име"
 
-#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
-#, fuzzy
-msgid "Available Parts"
-msgstr "Наличен"
+#: src/SharedFilePeersListCtrl.cpp
+msgid "Parts on Peer"
+msgstr ""
 
 #: src/SharedFilePeersListCtrl.cpp
 #, fuzzy
@@ -7408,6 +7425,11 @@ msgstr "Споделени файлове (%i)"
 #, fuzzy, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "Известни са %i споделени файлове"
+
+#: src/SourceListCtrl.cpp
+#, fuzzy
+msgid "Part Status"
+msgstr "Статус"
 
 #: src/SourceListCtrl.cpp
 #, fuzzy
@@ -9043,6 +9065,10 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#, fuzzy
+#~ msgid "Available Parts"
+#~ msgstr "Наличен"
 
 #, fuzzy, c-format
 #~ msgid "Found %i known shared file, %i unknown"

--- a/po/bg.po
+++ b/po/bg.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-29 20:55+0200\n"
+"POT-Creation-Date: 2026-08-30 16:16+0200\n"
 "PO-Revision-Date: 2026-08-25 10:02+0000\n"
 "Last-Translator: Sebastiano Pistore <SebastianoPistore.info@protonmail.ch>\n"
 "Language-Team: Bulgarian <dict@linux.zonebg.com>\n"
@@ -2719,21 +2719,39 @@ msgid ""
 msgstr ""
 
 #: src/GenericClientListCtrl.cpp
-msgid ""
-"One block per part of the file.\n"
-"Light grey: this source does not have the part.\n"
-"Green: this source has it and so do you.\n"
-"Amber: downloading this part from this source now.\n"
-"Pale yellow: the next part you will request from this source.\n"
-"Dark grey: this source has it and you still need it.\n"
-"The whole bar is dimmed while the download is stopped."
+msgid "This source does not have the part"
 msgstr ""
 
 #: src/GenericClientListCtrl.cpp
-msgid ""
-"One block per part of your shared file.\n"
-"Dark grey: this peer already has the part.\n"
-"Light grey: this peer does not have it."
+msgid "You and this source both have the part"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "Being downloaded from this source now"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "The next part that will be asked of this source"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "This source has the part and you still need it"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "This peer already has the part"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "This peer does not have the part"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "One block per part of the file being downloaded."
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "One block per part of the shared file."
 msgstr ""
 
 #: src/GenericClientListCtrl.cpp

--- a/po/bg.po
+++ b/po/bg.po
@@ -2755,6 +2755,10 @@ msgid "One block per part of the shared file."
 msgstr ""
 
 #: src/GenericClientListCtrl.cpp
+msgid "Colour legend"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
 #, fuzzy, c-format
 msgid "On Queue: %u (%i)"
 msgstr "На опашката"

--- a/po/bn.po
+++ b/po/bn.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-29 20:55+0200\n"
+"POT-Creation-Date: 2026-08-30 16:16+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -2677,21 +2677,39 @@ msgid ""
 msgstr ""
 
 #: src/GenericClientListCtrl.cpp
-msgid ""
-"One block per part of the file.\n"
-"Light grey: this source does not have the part.\n"
-"Green: this source has it and so do you.\n"
-"Amber: downloading this part from this source now.\n"
-"Pale yellow: the next part you will request from this source.\n"
-"Dark grey: this source has it and you still need it.\n"
-"The whole bar is dimmed while the download is stopped."
+msgid "This source does not have the part"
 msgstr ""
 
 #: src/GenericClientListCtrl.cpp
-msgid ""
-"One block per part of your shared file.\n"
-"Dark grey: this peer already has the part.\n"
-"Light grey: this peer does not have it."
+msgid "You and this source both have the part"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "Being downloaded from this source now"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "The next part that will be asked of this source"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "This source has the part and you still need it"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "This peer already has the part"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "This peer does not have the part"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "One block per part of the file being downloaded."
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "One block per part of the shared file."
 msgstr ""
 
 #: src/GenericClientListCtrl.cpp

--- a/po/bn.po
+++ b/po/bn.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 19:01+0200\n"
+"POT-Creation-Date: 2026-08-29 20:55+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -2674,6 +2674,24 @@ msgstr ""
 msgid ""
 "You are not allowed to set more than one friendslot.\n"
 " Only one slot was assigned."
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid ""
+"One block per part of the file.\n"
+"Light grey: this source does not have the part.\n"
+"Green: this source has it and so do you.\n"
+"Amber: downloading this part from this source now.\n"
+"Pale yellow: the next part you will request from this source.\n"
+"Dark grey: this source has it and you still need it.\n"
+"The whole bar is dimmed while the download is stopped."
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid ""
+"One block per part of your shared file.\n"
+"Dark grey: this peer already has the part.\n"
+"Light grey: this peer does not have it."
 msgstr ""
 
 #: src/GenericClientListCtrl.cpp
@@ -7107,8 +7125,8 @@ msgstr[1] ""
 msgid "User Name"
 msgstr ""
 
-#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
-msgid "Available Parts"
+#: src/SharedFilePeersListCtrl.cpp
+msgid "Parts on Peer"
 msgstr ""
 
 #: src/SharedFilePeersListCtrl.cpp
@@ -7301,6 +7319,10 @@ msgstr ""
 #: src/SharedFilesReloadProgress.cpp
 #, c-format
 msgid "Reloading shared files: %u files scanned"
+msgstr ""
+
+#: src/SourceListCtrl.cpp
+msgid "Part Status"
 msgstr ""
 
 #: src/SourceListCtrl.cpp

--- a/po/bn.po
+++ b/po/bn.po
@@ -2713,6 +2713,10 @@ msgid "One block per part of the shared file."
 msgstr ""
 
 #: src/GenericClientListCtrl.cpp
+msgid "Colour legend"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
 #, c-format
 msgid "On Queue: %u (%i)"
 msgstr ""

--- a/po/ca.po
+++ b/po/ca.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-29 20:55+0200\n"
+"POT-Creation-Date: 2026-08-30 16:16+0200\n"
 "PO-Revision-Date: 2026-08-25 10:03+0000\n"
 "Last-Translator: minterior <minterior@gmail.com>\n"
 "Language-Team: Català\n"
@@ -2773,22 +2773,42 @@ msgstr ""
 " Només s'ha assignat una posició."
 
 #: src/GenericClientListCtrl.cpp
-msgid ""
-"One block per part of the file.\n"
-"Light grey: this source does not have the part.\n"
-"Green: this source has it and so do you.\n"
-"Amber: downloading this part from this source now.\n"
-"Pale yellow: the next part you will request from this source.\n"
-"Dark grey: this source has it and you still need it.\n"
-"The whole bar is dimmed while the download is stopped."
+#, fuzzy
+msgid "This source does not have the part"
+msgstr "Aquesta ordre no hauria de tenir cap paràmetre."
+
+#: src/GenericClientListCtrl.cpp
+msgid "You and this source both have the part"
 msgstr ""
 
 #: src/GenericClientListCtrl.cpp
-msgid ""
-"One block per part of your shared file.\n"
-"Dark grey: this peer already has the part.\n"
-"Light grey: this peer does not have it."
+msgid "Being downloaded from this source now"
 msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "The next part that will be asked of this source"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "This source has the part and you still need it"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "This peer already has the part"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "This peer does not have the part"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "One block per part of the file being downloaded."
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+#, fuzzy
+msgid "One block per part of the shared file."
+msgstr "Introduïu el port del servidor."
 
 #: src/GenericClientListCtrl.cpp
 #, c-format

--- a/po/ca.po
+++ b/po/ca.po
@@ -2811,6 +2811,10 @@ msgid "One block per part of the shared file."
 msgstr "Introduïu el port del servidor."
 
 #: src/GenericClientListCtrl.cpp
+msgid "Colour legend"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
 #, c-format
 msgid "On Queue: %u (%i)"
 msgstr "En cua: %u (%i)"

--- a/po/ca.po
+++ b/po/ca.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 19:01+0200\n"
+"POT-Creation-Date: 2026-08-29 20:55+0200\n"
 "PO-Revision-Date: 2026-08-25 10:03+0000\n"
 "Last-Translator: minterior <minterior@gmail.com>\n"
 "Language-Team: Català\n"
@@ -2771,6 +2771,24 @@ msgid ""
 msgstr ""
 "No podeu establir més d'una posició d'amic.\n"
 " Només s'ha assignat una posició."
+
+#: src/GenericClientListCtrl.cpp
+msgid ""
+"One block per part of the file.\n"
+"Light grey: this source does not have the part.\n"
+"Green: this source has it and so do you.\n"
+"Amber: downloading this part from this source now.\n"
+"Pale yellow: the next part you will request from this source.\n"
+"Dark grey: this source has it and you still need it.\n"
+"The whole bar is dimmed while the download is stopped."
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid ""
+"One block per part of your shared file.\n"
+"Dark grey: this peer already has the part.\n"
+"Light grey: this peer does not have it."
+msgstr ""
 
 #: src/GenericClientListCtrl.cpp
 #, c-format
@@ -7319,9 +7337,9 @@ msgstr[1] "S'han trobat %i fitxers compartits"
 msgid "User Name"
 msgstr "Nom d'usuari"
 
-#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
-msgid "Available Parts"
-msgstr "Parts disponibles"
+#: src/SharedFilePeersListCtrl.cpp
+msgid "Parts on Peer"
+msgstr ""
 
 #: src/SharedFilePeersListCtrl.cpp
 msgid "Upload Status"
@@ -7515,6 +7533,11 @@ msgstr "Fitxers compartits (%i)"
 #, fuzzy, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "Recarrega la llista de fitxers compartits."
+
+#: src/SourceListCtrl.cpp
+#, fuzzy
+msgid "Part Status"
+msgstr "Estat"
 
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"
@@ -9207,6 +9230,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "Available Parts"
+#~ msgstr "Parts disponibles"
 
 #, c-format
 #~ msgid "Found %i known shared file, %i unknown"

--- a/po/cs.po
+++ b/po/cs.po
@@ -2813,6 +2813,10 @@ msgid "One block per part of the shared file."
 msgstr "Zadejte port serveru."
 
 #: src/GenericClientListCtrl.cpp
+msgid "Colour legend"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
 #, c-format
 msgid "On Queue: %u (%i)"
 msgstr "Ve frontě: %u (%i)"

--- a/po/cs.po
+++ b/po/cs.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-29 20:55+0200\n"
+"POT-Creation-Date: 2026-08-30 16:16+0200\n"
 "PO-Revision-Date: 2026-08-28 20:01+0000\n"
 "Last-Translator: David Watzke <david@watzke.cz>\n"
 "Language-Team: cs <cs@li.org>\n"
@@ -2775,22 +2775,42 @@ msgstr ""
 " Byl přidělen pouze jeden slot."
 
 #: src/GenericClientListCtrl.cpp
-msgid ""
-"One block per part of the file.\n"
-"Light grey: this source does not have the part.\n"
-"Green: this source has it and so do you.\n"
-"Amber: downloading this part from this source now.\n"
-"Pale yellow: the next part you will request from this source.\n"
-"Dark grey: this source has it and you still need it.\n"
-"The whole bar is dimmed while the download is stopped."
+#, fuzzy
+msgid "This source does not have the part"
+msgstr "Tento příkaz by neměl mít parametry."
+
+#: src/GenericClientListCtrl.cpp
+msgid "You and this source both have the part"
 msgstr ""
 
 #: src/GenericClientListCtrl.cpp
-msgid ""
-"One block per part of your shared file.\n"
-"Dark grey: this peer already has the part.\n"
-"Light grey: this peer does not have it."
+msgid "Being downloaded from this source now"
 msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "The next part that will be asked of this source"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "This source has the part and you still need it"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "This peer already has the part"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "This peer does not have the part"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "One block per part of the file being downloaded."
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+#, fuzzy
+msgid "One block per part of the shared file."
+msgstr "Zadejte port serveru."
 
 #: src/GenericClientListCtrl.cpp
 #, c-format

--- a/po/cs.po
+++ b/po/cs.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 19:01+0200\n"
+"POT-Creation-Date: 2026-08-29 20:55+0200\n"
 "PO-Revision-Date: 2026-08-28 20:01+0000\n"
 "Last-Translator: David Watzke <david@watzke.cz>\n"
 "Language-Team: cs <cs@li.org>\n"
@@ -2773,6 +2773,24 @@ msgid ""
 msgstr ""
 "Nemůžete založit více než jeden kamarádský slot.\n"
 " Byl přidělen pouze jeden slot."
+
+#: src/GenericClientListCtrl.cpp
+msgid ""
+"One block per part of the file.\n"
+"Light grey: this source does not have the part.\n"
+"Green: this source has it and so do you.\n"
+"Amber: downloading this part from this source now.\n"
+"Pale yellow: the next part you will request from this source.\n"
+"Dark grey: this source has it and you still need it.\n"
+"The whole bar is dimmed while the download is stopped."
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid ""
+"One block per part of your shared file.\n"
+"Dark grey: this peer already has the part.\n"
+"Light grey: this peer does not have it."
+msgstr ""
 
 #: src/GenericClientListCtrl.cpp
 #, c-format
@@ -7315,9 +7333,9 @@ msgstr[2] "Znovu načíst vaše sdílené soubory"
 msgid "User Name"
 msgstr "Uživatelské jméno"
 
-#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
-msgid "Available Parts"
-msgstr "Dostupné části"
+#: src/SharedFilePeersListCtrl.cpp
+msgid "Parts on Peer"
+msgstr ""
 
 #: src/SharedFilePeersListCtrl.cpp
 #, fuzzy
@@ -7522,6 +7540,11 @@ msgstr "Sdílené soubory (%i)"
 #, fuzzy, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "Znovu načte seznam sdílených souborů."
+
+#: src/SourceListCtrl.cpp
+#, fuzzy
+msgid "Part Status"
+msgstr "Stav"
 
 #: src/SourceListCtrl.cpp
 #, fuzzy
@@ -9187,6 +9210,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "Available Parts"
+#~ msgstr "Dostupné části"
 
 #, fuzzy, c-format
 #~ msgid "Found %i known shared file, %i unknown"

--- a/po/da.po
+++ b/po/da.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-29 20:55+0200\n"
+"POT-Creation-Date: 2026-08-30 16:16+0200\n"
 "PO-Revision-Date: 2026-08-25 10:03+0000\n"
 "Last-Translator: Alex Thomsen Leth <alexl@stofanet.dk>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -2728,21 +2728,39 @@ msgid ""
 msgstr ""
 
 #: src/GenericClientListCtrl.cpp
-msgid ""
-"One block per part of the file.\n"
-"Light grey: this source does not have the part.\n"
-"Green: this source has it and so do you.\n"
-"Amber: downloading this part from this source now.\n"
-"Pale yellow: the next part you will request from this source.\n"
-"Dark grey: this source has it and you still need it.\n"
-"The whole bar is dimmed while the download is stopped."
+msgid "This source does not have the part"
 msgstr ""
 
 #: src/GenericClientListCtrl.cpp
-msgid ""
-"One block per part of your shared file.\n"
-"Dark grey: this peer already has the part.\n"
-"Light grey: this peer does not have it."
+msgid "You and this source both have the part"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "Being downloaded from this source now"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "The next part that will be asked of this source"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "This source has the part and you still need it"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "This peer already has the part"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "This peer does not have the part"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "One block per part of the file being downloaded."
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "One block per part of the shared file."
 msgstr ""
 
 #: src/GenericClientListCtrl.cpp

--- a/po/da.po
+++ b/po/da.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 19:01+0200\n"
+"POT-Creation-Date: 2026-08-29 20:55+0200\n"
 "PO-Revision-Date: 2026-08-25 10:03+0000\n"
 "Last-Translator: Alex Thomsen Leth <alexl@stofanet.dk>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -2725,6 +2725,24 @@ msgstr "Er du sikker på at du ønsker at slette de(n) valgt(e) ven(ner)?"
 msgid ""
 "You are not allowed to set more than one friendslot.\n"
 " Only one slot was assigned."
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid ""
+"One block per part of the file.\n"
+"Light grey: this source does not have the part.\n"
+"Green: this source has it and so do you.\n"
+"Amber: downloading this part from this source now.\n"
+"Pale yellow: the next part you will request from this source.\n"
+"Dark grey: this source has it and you still need it.\n"
+"The whole bar is dimmed while the download is stopped."
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid ""
+"One block per part of your shared file.\n"
+"Dark grey: this peer already has the part.\n"
+"Light grey: this peer does not have it."
 msgstr ""
 
 #: src/GenericClientListCtrl.cpp
@@ -7254,10 +7272,9 @@ msgstr[1] "Fandt %i kendte delte filer"
 msgid "User Name"
 msgstr "Brugernavn"
 
-#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
-#, fuzzy
-msgid "Available Parts"
-msgstr "Tilgængelig :"
+#: src/SharedFilePeersListCtrl.cpp
+msgid "Parts on Peer"
+msgstr ""
 
 #: src/SharedFilePeersListCtrl.cpp
 #, fuzzy
@@ -7456,6 +7473,11 @@ msgstr "Delte Filer (%i)"
 #, fuzzy, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "Fandt %i kendte delte filer"
+
+#: src/SourceListCtrl.cpp
+#, fuzzy
+msgid "Part Status"
+msgstr "Status"
 
 #: src/SourceListCtrl.cpp
 #, fuzzy
@@ -9102,6 +9124,10 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#, fuzzy
+#~ msgid "Available Parts"
+#~ msgstr "Tilgængelig :"
 
 #, fuzzy, c-format
 #~ msgid "Found %i known shared file, %i unknown"

--- a/po/da.po
+++ b/po/da.po
@@ -2764,6 +2764,10 @@ msgid "One block per part of the shared file."
 msgstr ""
 
 #: src/GenericClientListCtrl.cpp
+msgid "Colour legend"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
 #, fuzzy, c-format
 msgid "On Queue: %u (%i)"
 msgstr "I Kø"

--- a/po/de.po
+++ b/po/de.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 19:01+0200\n"
+"POT-Creation-Date: 2026-08-29 20:55+0200\n"
 "PO-Revision-Date: 2026-08-25 10:04+0000\n"
 "Last-Translator: Werner Mahr <werner@vollstreckernet.de>\n"
 "Language-Team: German <>\n"
@@ -2776,6 +2776,24 @@ msgid ""
 msgstr ""
 "Du darfst nicht mehr als einen Friendslot vergeben.\n"
 " Nur ein Slot wurde vergeben."
+
+#: src/GenericClientListCtrl.cpp
+msgid ""
+"One block per part of the file.\n"
+"Light grey: this source does not have the part.\n"
+"Green: this source has it and so do you.\n"
+"Amber: downloading this part from this source now.\n"
+"Pale yellow: the next part you will request from this source.\n"
+"Dark grey: this source has it and you still need it.\n"
+"The whole bar is dimmed while the download is stopped."
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid ""
+"One block per part of your shared file.\n"
+"Dark grey: this peer already has the part.\n"
+"Light grey: this peer does not have it."
+msgstr ""
 
 #: src/GenericClientListCtrl.cpp
 #, c-format
@@ -7314,9 +7332,9 @@ msgstr[1] "%i bekannte freigegebene Dateien gefunden"
 msgid "User Name"
 msgstr "Benutzername"
 
-#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
-msgid "Available Parts"
-msgstr "Verfügbare Teile"
+#: src/SharedFilePeersListCtrl.cpp
+msgid "Parts on Peer"
+msgstr ""
 
 #: src/SharedFilePeersListCtrl.cpp
 msgid "Upload Status"
@@ -7510,6 +7528,11 @@ msgstr "Freigegebene Dateien (%i)"
 #, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "Liste freigegebener Dateien neu laden: %u Dateien gelesen"
+
+#: src/SourceListCtrl.cpp
+#, fuzzy
+msgid "Part Status"
+msgstr "Status"
 
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"
@@ -9221,6 +9244,9 @@ msgstr "aMule scheint zu laufen. Bitte schließen und das Entfernprogram erneut 
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "Entferne Benutzerdaten von $APPDATA\\aMule..."
+
+#~ msgid "Available Parts"
+#~ msgstr "Verfügbare Teile"
 
 #, c-format
 #~ msgid "Found %i known shared file, %i unknown"

--- a/po/de.po
+++ b/po/de.po
@@ -2816,6 +2816,10 @@ msgid "One block per part of the shared file."
 msgstr "Hier den Serverport eingeben."
 
 #: src/GenericClientListCtrl.cpp
+msgid "Colour legend"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
 #, c-format
 msgid "On Queue: %u (%i)"
 msgstr "In Warteschlange: %u (%i)"

--- a/po/de.po
+++ b/po/de.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-29 20:55+0200\n"
+"POT-Creation-Date: 2026-08-30 16:16+0200\n"
 "PO-Revision-Date: 2026-08-25 10:04+0000\n"
 "Last-Translator: Werner Mahr <werner@vollstreckernet.de>\n"
 "Language-Team: German <>\n"
@@ -2778,22 +2778,42 @@ msgstr ""
 " Nur ein Slot wurde vergeben."
 
 #: src/GenericClientListCtrl.cpp
-msgid ""
-"One block per part of the file.\n"
-"Light grey: this source does not have the part.\n"
-"Green: this source has it and so do you.\n"
-"Amber: downloading this part from this source now.\n"
-"Pale yellow: the next part you will request from this source.\n"
-"Dark grey: this source has it and you still need it.\n"
-"The whole bar is dimmed while the download is stopped."
+#, fuzzy
+msgid "This source does not have the part"
+msgstr "Dieser Befehl sollte keine Parameter haben."
+
+#: src/GenericClientListCtrl.cpp
+msgid "You and this source both have the part"
 msgstr ""
 
 #: src/GenericClientListCtrl.cpp
-msgid ""
-"One block per part of your shared file.\n"
-"Dark grey: this peer already has the part.\n"
-"Light grey: this peer does not have it."
+msgid "Being downloaded from this source now"
 msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "The next part that will be asked of this source"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "This source has the part and you still need it"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "This peer already has the part"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "This peer does not have the part"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "One block per part of the file being downloaded."
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+#, fuzzy
+msgid "One block per part of the shared file."
+msgstr "Hier den Serverport eingeben."
 
 #: src/GenericClientListCtrl.cpp
 #, c-format

--- a/po/el.po
+++ b/po/el.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-29 20:55+0200\n"
+"POT-Creation-Date: 2026-08-30 16:16+0200\n"
 "PO-Revision-Date: 2026-08-25 10:05+0000\n"
 "Last-Translator: Dimitris <dgalanak@yahoo.com>\n"
 "Language-Team: Greek\n"
@@ -2789,22 +2789,42 @@ msgstr ""
 " Γι αυτό μόνο μία ανατέθηκε."
 
 #: src/GenericClientListCtrl.cpp
-msgid ""
-"One block per part of the file.\n"
-"Light grey: this source does not have the part.\n"
-"Green: this source has it and so do you.\n"
-"Amber: downloading this part from this source now.\n"
-"Pale yellow: the next part you will request from this source.\n"
-"Dark grey: this source has it and you still need it.\n"
-"The whole bar is dimmed while the download is stopped."
+#, fuzzy
+msgid "This source does not have the part"
+msgstr "Αυτή η εντολή δεν πρέπει να έχει παραμέτρους."
+
+#: src/GenericClientListCtrl.cpp
+msgid "You and this source both have the part"
 msgstr ""
 
 #: src/GenericClientListCtrl.cpp
-msgid ""
-"One block per part of your shared file.\n"
-"Dark grey: this peer already has the part.\n"
-"Light grey: this peer does not have it."
+msgid "Being downloaded from this source now"
 msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "The next part that will be asked of this source"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "This source has the part and you still need it"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "This peer already has the part"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "This peer does not have the part"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "One block per part of the file being downloaded."
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+#, fuzzy
+msgid "One block per part of the shared file."
+msgstr "Γράψτε την θύρα του διακομιστή εδώ."
 
 #: src/GenericClientListCtrl.cpp
 #, fuzzy, c-format

--- a/po/el.po
+++ b/po/el.po
@@ -2827,6 +2827,10 @@ msgid "One block per part of the shared file."
 msgstr "Γράψτε την θύρα του διακομιστή εδώ."
 
 #: src/GenericClientListCtrl.cpp
+msgid "Colour legend"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
 #, fuzzy, c-format
 msgid "On Queue: %u (%i)"
 msgstr "QR: %u (%i)"

--- a/po/el.po
+++ b/po/el.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 19:01+0200\n"
+"POT-Creation-Date: 2026-08-29 20:55+0200\n"
 "PO-Revision-Date: 2026-08-25 10:05+0000\n"
 "Last-Translator: Dimitris <dgalanak@yahoo.com>\n"
 "Language-Team: Greek\n"
@@ -2787,6 +2787,24 @@ msgid ""
 msgstr ""
 "Δεν επιτρέπεται να θέσεις μόνο πανω από μία φιλική θυρίδα. \n"
 " Γι αυτό μόνο μία ανατέθηκε."
+
+#: src/GenericClientListCtrl.cpp
+msgid ""
+"One block per part of the file.\n"
+"Light grey: this source does not have the part.\n"
+"Green: this source has it and so do you.\n"
+"Amber: downloading this part from this source now.\n"
+"Pale yellow: the next part you will request from this source.\n"
+"Dark grey: this source has it and you still need it.\n"
+"The whole bar is dimmed while the download is stopped."
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid ""
+"One block per part of your shared file.\n"
+"Dark grey: this peer already has the part.\n"
+"Light grey: this peer does not have it."
+msgstr ""
 
 #: src/GenericClientListCtrl.cpp
 #, fuzzy, c-format
@@ -7369,10 +7387,9 @@ msgstr[1] "Βρέθηκαν %i γνωστά κοινόχρηστα αρχεία"
 msgid "User Name"
 msgstr "Όνομα χρήστη"
 
-#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
-#, fuzzy
-msgid "Available Parts"
-msgstr "Διαθέσιμα:"
+#: src/SharedFilePeersListCtrl.cpp
+msgid "Parts on Peer"
+msgstr ""
 
 #: src/SharedFilePeersListCtrl.cpp
 #, fuzzy
@@ -7570,6 +7587,11 @@ msgstr "Κοινόχρηστα αρχεία (%i)"
 #, fuzzy, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "Επαναφορτώνει τη λίστα κοινοχρήστων αρχείων."
+
+#: src/SourceListCtrl.cpp
+#, fuzzy
+msgid "Part Status"
+msgstr "Κατάσταση"
 
 #: src/SourceListCtrl.cpp
 #, fuzzy
@@ -9280,6 +9302,10 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#, fuzzy
+#~ msgid "Available Parts"
+#~ msgstr "Διαθέσιμα:"
 
 #, c-format
 #~ msgid "Found %i known shared file, %i unknown"

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 19:01+0200\n"
+"POT-Creation-Date: 2026-08-29 20:55+0200\n"
 "PO-Revision-Date: 2020-03-04 14:43+0100\n"
 "Last-Translator: Dévai Tamás <devait@vnet.hu>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -2675,6 +2675,24 @@ msgstr ""
 msgid ""
 "You are not allowed to set more than one friendslot.\n"
 " Only one slot was assigned."
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid ""
+"One block per part of the file.\n"
+"Light grey: this source does not have the part.\n"
+"Green: this source has it and so do you.\n"
+"Amber: downloading this part from this source now.\n"
+"Pale yellow: the next part you will request from this source.\n"
+"Dark grey: this source has it and you still need it.\n"
+"The whole bar is dimmed while the download is stopped."
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid ""
+"One block per part of your shared file.\n"
+"Dark grey: this peer already has the part.\n"
+"Light grey: this peer does not have it."
 msgstr ""
 
 #: src/GenericClientListCtrl.cpp
@@ -7108,8 +7126,8 @@ msgstr[1] ""
 msgid "User Name"
 msgstr ""
 
-#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
-msgid "Available Parts"
+#: src/SharedFilePeersListCtrl.cpp
+msgid "Parts on Peer"
 msgstr ""
 
 #: src/SharedFilePeersListCtrl.cpp
@@ -7302,6 +7320,10 @@ msgstr ""
 #: src/SharedFilesReloadProgress.cpp
 #, c-format
 msgid "Reloading shared files: %u files scanned"
+msgstr ""
+
+#: src/SourceListCtrl.cpp
+msgid "Part Status"
 msgstr ""
 
 #: src/SourceListCtrl.cpp

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-29 20:55+0200\n"
+"POT-Creation-Date: 2026-08-30 16:16+0200\n"
 "PO-Revision-Date: 2020-03-04 14:43+0100\n"
 "Last-Translator: Dévai Tamás <devait@vnet.hu>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -2678,21 +2678,39 @@ msgid ""
 msgstr ""
 
 #: src/GenericClientListCtrl.cpp
-msgid ""
-"One block per part of the file.\n"
-"Light grey: this source does not have the part.\n"
-"Green: this source has it and so do you.\n"
-"Amber: downloading this part from this source now.\n"
-"Pale yellow: the next part you will request from this source.\n"
-"Dark grey: this source has it and you still need it.\n"
-"The whole bar is dimmed while the download is stopped."
+msgid "This source does not have the part"
 msgstr ""
 
 #: src/GenericClientListCtrl.cpp
-msgid ""
-"One block per part of your shared file.\n"
-"Dark grey: this peer already has the part.\n"
-"Light grey: this peer does not have it."
+msgid "You and this source both have the part"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "Being downloaded from this source now"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "The next part that will be asked of this source"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "This source has the part and you still need it"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "This peer already has the part"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "This peer does not have the part"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "One block per part of the file being downloaded."
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "One block per part of the shared file."
 msgstr ""
 
 #: src/GenericClientListCtrl.cpp

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -2714,6 +2714,10 @@ msgid "One block per part of the shared file."
 msgstr ""
 
 #: src/GenericClientListCtrl.cpp
+msgid "Colour legend"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
 #, c-format
 msgid "On Queue: %u (%i)"
 msgstr ""

--- a/po/es.po
+++ b/po/es.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 19:01+0200\n"
+"POT-Creation-Date: 2026-08-29 20:55+0200\n"
 "PO-Revision-Date: 2026-08-25 10:05+0000\n"
 "Last-Translator: Diego Heras <ngosang@hotmail.es>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/amule/amule-application/es/>\n"
@@ -2772,6 +2772,24 @@ msgid ""
 msgstr ""
 "No se le permite asignar más de un puesto reservado.\n"
 " Solo se ha asignado uno."
+
+#: src/GenericClientListCtrl.cpp
+msgid ""
+"One block per part of the file.\n"
+"Light grey: this source does not have the part.\n"
+"Green: this source has it and so do you.\n"
+"Amber: downloading this part from this source now.\n"
+"Pale yellow: the next part you will request from this source.\n"
+"Dark grey: this source has it and you still need it.\n"
+"The whole bar is dimmed while the download is stopped."
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid ""
+"One block per part of your shared file.\n"
+"Dark grey: this peer already has the part.\n"
+"Light grey: this peer does not have it."
+msgstr ""
 
 #: src/GenericClientListCtrl.cpp
 #, c-format
@@ -7261,9 +7279,9 @@ msgstr[1] "Encontrados %i archivos compartidos"
 msgid "User Name"
 msgstr "Nombre de usuario"
 
-#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
-msgid "Available Parts"
-msgstr "Partes disponibles"
+#: src/SharedFilePeersListCtrl.cpp
+msgid "Parts on Peer"
+msgstr ""
 
 #: src/SharedFilePeersListCtrl.cpp
 msgid "Upload Status"
@@ -7456,6 +7474,11 @@ msgstr "Archivos compartidos (%i)"
 #, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "Recargando archivos compartidos: %u archivos escaneados"
+
+#: src/SourceListCtrl.cpp
+#, fuzzy
+msgid "Part Status"
+msgstr "Estado"
 
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"
@@ -9166,6 +9189,9 @@ msgstr "aMule parece estar en ejecución. Por favor, ciérrelo y vuelva a ejecut
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "Eliminando los datos de usuario en $APPDATA\\aMule..."
+
+#~ msgid "Available Parts"
+#~ msgstr "Partes disponibles"
 
 #, c-format
 #~ msgid "Found %i known shared file, %i unknown"

--- a/po/es.po
+++ b/po/es.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-29 20:55+0200\n"
+"POT-Creation-Date: 2026-08-30 16:16+0200\n"
 "PO-Revision-Date: 2026-08-25 10:05+0000\n"
 "Last-Translator: Diego Heras <ngosang@hotmail.es>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/amule/amule-application/es/>\n"
@@ -2774,22 +2774,42 @@ msgstr ""
 " Solo se ha asignado uno."
 
 #: src/GenericClientListCtrl.cpp
-msgid ""
-"One block per part of the file.\n"
-"Light grey: this source does not have the part.\n"
-"Green: this source has it and so do you.\n"
-"Amber: downloading this part from this source now.\n"
-"Pale yellow: the next part you will request from this source.\n"
-"Dark grey: this source has it and you still need it.\n"
-"The whole bar is dimmed while the download is stopped."
+#, fuzzy
+msgid "This source does not have the part"
+msgstr "El comando no debe tener ningún parámetro."
+
+#: src/GenericClientListCtrl.cpp
+msgid "You and this source both have the part"
 msgstr ""
 
 #: src/GenericClientListCtrl.cpp
-msgid ""
-"One block per part of your shared file.\n"
-"Dark grey: this peer already has the part.\n"
-"Light grey: this peer does not have it."
+msgid "Being downloaded from this source now"
 msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "The next part that will be asked of this source"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "This source has the part and you still need it"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "This peer already has the part"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "This peer does not have the part"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "One block per part of the file being downloaded."
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+#, fuzzy
+msgid "One block per part of the shared file."
+msgstr "Introduzca el puerto del servidor."
 
 #: src/GenericClientListCtrl.cpp
 #, c-format

--- a/po/es.po
+++ b/po/es.po
@@ -2812,6 +2812,10 @@ msgid "One block per part of the shared file."
 msgstr "Introduzca el puerto del servidor."
 
 #: src/GenericClientListCtrl.cpp
+msgid "Colour legend"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
 #, c-format
 msgid "On Queue: %u (%i)"
 msgstr "En la cola: %u (%i)"

--- a/po/et_EE.po
+++ b/po/et_EE.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-29 20:55+0200\n"
+"POT-Creation-Date: 2026-08-30 16:16+0200\n"
 "PO-Revision-Date: 2026-08-25 10:06+0000\n"
 "Last-Translator: \n"
 "Language-Team: Estonian <kde-i18n-doc@kde.org>\n"
@@ -2773,22 +2773,42 @@ msgstr ""
 "Määrati ainult üks slott."
 
 #: src/GenericClientListCtrl.cpp
-msgid ""
-"One block per part of the file.\n"
-"Light grey: this source does not have the part.\n"
-"Green: this source has it and so do you.\n"
-"Amber: downloading this part from this source now.\n"
-"Pale yellow: the next part you will request from this source.\n"
-"Dark grey: this source has it and you still need it.\n"
-"The whole bar is dimmed while the download is stopped."
+#, fuzzy
+msgid "This source does not have the part"
+msgstr "Sellel käsul ei tohiks olla ühtegi parameetrit."
+
+#: src/GenericClientListCtrl.cpp
+msgid "You and this source both have the part"
 msgstr ""
 
 #: src/GenericClientListCtrl.cpp
-msgid ""
-"One block per part of your shared file.\n"
-"Dark grey: this peer already has the part.\n"
-"Light grey: this peer does not have it."
+msgid "Being downloaded from this source now"
 msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "The next part that will be asked of this source"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "This source has the part and you still need it"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "This peer already has the part"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "This peer does not have the part"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "One block per part of the file being downloaded."
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+#, fuzzy
+msgid "One block per part of the shared file."
+msgstr "Sisesta siia serveri port."
 
 #: src/GenericClientListCtrl.cpp
 #, c-format

--- a/po/et_EE.po
+++ b/po/et_EE.po
@@ -2811,6 +2811,10 @@ msgid "One block per part of the shared file."
 msgstr "Sisesta siia serveri port."
 
 #: src/GenericClientListCtrl.cpp
+msgid "Colour legend"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
 #, c-format
 msgid "On Queue: %u (%i)"
 msgstr "JK: %u (%i)"

--- a/po/et_EE.po
+++ b/po/et_EE.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 19:01+0200\n"
+"POT-Creation-Date: 2026-08-29 20:55+0200\n"
 "PO-Revision-Date: 2026-08-25 10:06+0000\n"
 "Last-Translator: \n"
 "Language-Team: Estonian <kde-i18n-doc@kde.org>\n"
@@ -2771,6 +2771,24 @@ msgid ""
 msgstr ""
 "Sul pole lubatud määrata rohkem kui üks sõbraslot.\n"
 "Määrati ainult üks slott."
+
+#: src/GenericClientListCtrl.cpp
+msgid ""
+"One block per part of the file.\n"
+"Light grey: this source does not have the part.\n"
+"Green: this source has it and so do you.\n"
+"Amber: downloading this part from this source now.\n"
+"Pale yellow: the next part you will request from this source.\n"
+"Dark grey: this source has it and you still need it.\n"
+"The whole bar is dimmed while the download is stopped."
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid ""
+"One block per part of your shared file.\n"
+"Dark grey: this peer already has the part.\n"
+"Light grey: this peer does not have it."
+msgstr ""
 
 #: src/GenericClientListCtrl.cpp
 #, c-format
@@ -7325,9 +7343,9 @@ msgstr[1] "Leitud %i tuntud ja jagatud faili."
 msgid "User Name"
 msgstr "Kasutaja nimi"
 
-#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
-msgid "Available Parts"
-msgstr "Saadaval osi"
+#: src/SharedFilePeersListCtrl.cpp
+msgid "Parts on Peer"
+msgstr ""
 
 #: src/SharedFilePeersListCtrl.cpp
 #, fuzzy
@@ -7524,6 +7542,11 @@ msgstr "Jagatud failid (%i)"
 #, fuzzy, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "Jagatud failide loetelu taaslaadimine."
+
+#: src/SourceListCtrl.cpp
+#, fuzzy
+msgid "Part Status"
+msgstr "Olek"
 
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"
@@ -9209,6 +9232,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "Available Parts"
+#~ msgstr "Saadaval osi"
 
 #, c-format
 #~ msgid "Found %i known shared file, %i unknown"

--- a/po/eu.po
+++ b/po/eu.po
@@ -2812,6 +2812,10 @@ msgid "One block per part of the shared file."
 msgstr "Idatzi zerbitzariaren ataka hemen."
 
 #: src/GenericClientListCtrl.cpp
+msgid "Colour legend"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
 #, c-format
 msgid "On Queue: %u (%i)"
 msgstr "Ilaran: %u (%i)"

--- a/po/eu.po
+++ b/po/eu.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 19:01+0200\n"
+"POT-Creation-Date: 2026-08-29 20:55+0200\n"
 "PO-Revision-Date: 2026-08-25 10:07+0000\n"
 "Last-Translator: Piarres Beobide <pi@beobide.net>\n"
 "Language-Team: Euskara <librezale@librezale.org>\n"
@@ -2772,6 +2772,24 @@ msgid ""
 msgstr ""
 "Ez duzu lagun-ataka bat baino gehiago ezartzeko baimenik.\n"
 " Ataka bat bakarrik dago sinaturik."
+
+#: src/GenericClientListCtrl.cpp
+msgid ""
+"One block per part of the file.\n"
+"Light grey: this source does not have the part.\n"
+"Green: this source has it and so do you.\n"
+"Amber: downloading this part from this source now.\n"
+"Pale yellow: the next part you will request from this source.\n"
+"Dark grey: this source has it and you still need it.\n"
+"The whole bar is dimmed while the download is stopped."
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid ""
+"One block per part of your shared file.\n"
+"Dark grey: this peer already has the part.\n"
+"Light grey: this peer does not have it."
+msgstr ""
 
 #: src/GenericClientListCtrl.cpp
 #, c-format
@@ -7323,9 +7341,9 @@ msgstr[1] "%i ezagututako partekatutako fitxategi aurkiturik"
 msgid "User Name"
 msgstr "Erabiltzaile izena"
 
-#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
-msgid "Available Parts"
-msgstr "Zati eskuragarriak"
+#: src/SharedFilePeersListCtrl.cpp
+msgid "Parts on Peer"
+msgstr ""
 
 #: src/SharedFilePeersListCtrl.cpp
 msgid "Upload Status"
@@ -7520,6 +7538,11 @@ msgstr "Partekatutako fitxategiak (%i)"
 #, fuzzy, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "Partekatutako fitxategi zerrenda birkargatu."
+
+#: src/SourceListCtrl.cpp
+#, fuzzy
+msgid "Part Status"
+msgstr "Egoera"
 
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"
@@ -9209,6 +9232,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "Available Parts"
+#~ msgstr "Zati eskuragarriak"
 
 #, c-format
 #~ msgid "Found %i known shared file, %i unknown"

--- a/po/eu.po
+++ b/po/eu.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-29 20:55+0200\n"
+"POT-Creation-Date: 2026-08-30 16:16+0200\n"
 "PO-Revision-Date: 2026-08-25 10:07+0000\n"
 "Last-Translator: Piarres Beobide <pi@beobide.net>\n"
 "Language-Team: Euskara <librezale@librezale.org>\n"
@@ -2774,22 +2774,42 @@ msgstr ""
 " Ataka bat bakarrik dago sinaturik."
 
 #: src/GenericClientListCtrl.cpp
-msgid ""
-"One block per part of the file.\n"
-"Light grey: this source does not have the part.\n"
-"Green: this source has it and so do you.\n"
-"Amber: downloading this part from this source now.\n"
-"Pale yellow: the next part you will request from this source.\n"
-"Dark grey: this source has it and you still need it.\n"
-"The whole bar is dimmed while the download is stopped."
+#, fuzzy
+msgid "This source does not have the part"
+msgstr "Komando honek ez luke parametrorik eduki beharko."
+
+#: src/GenericClientListCtrl.cpp
+msgid "You and this source both have the part"
 msgstr ""
 
 #: src/GenericClientListCtrl.cpp
-msgid ""
-"One block per part of your shared file.\n"
-"Dark grey: this peer already has the part.\n"
-"Light grey: this peer does not have it."
+msgid "Being downloaded from this source now"
 msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "The next part that will be asked of this source"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "This source has the part and you still need it"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "This peer already has the part"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "This peer does not have the part"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "One block per part of the file being downloaded."
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+#, fuzzy
+msgid "One block per part of the shared file."
+msgstr "Idatzi zerbitzariaren ataka hemen."
 
 #: src/GenericClientListCtrl.cpp
 #, c-format

--- a/po/fi.po
+++ b/po/fi.po
@@ -2812,6 +2812,10 @@ msgid "One block per part of the shared file."
 msgstr "Syötä palvelimen portti tähän."
 
 #: src/GenericClientListCtrl.cpp
+msgid "Colour legend"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
 #, c-format
 msgid "On Queue: %u (%i)"
 msgstr "Jonossa: %u (%i)"

--- a/po/fi.po
+++ b/po/fi.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-29 20:55+0200\n"
+"POT-Creation-Date: 2026-08-30 16:16+0200\n"
 "PO-Revision-Date: 2026-08-25 10:07+0000\n"
 "Last-Translator: Tapio Rantala <tapio.rantala@iki.fi>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -2774,22 +2774,42 @@ msgstr ""
 " Asetettiin yksi paikka."
 
 #: src/GenericClientListCtrl.cpp
-msgid ""
-"One block per part of the file.\n"
-"Light grey: this source does not have the part.\n"
-"Green: this source has it and so do you.\n"
-"Amber: downloading this part from this source now.\n"
-"Pale yellow: the next part you will request from this source.\n"
-"Dark grey: this source has it and you still need it.\n"
-"The whole bar is dimmed while the download is stopped."
+#, fuzzy
+msgid "This source does not have the part"
+msgstr "Tämä komento ei tarvitse parametreja."
+
+#: src/GenericClientListCtrl.cpp
+msgid "You and this source both have the part"
 msgstr ""
 
 #: src/GenericClientListCtrl.cpp
-msgid ""
-"One block per part of your shared file.\n"
-"Dark grey: this peer already has the part.\n"
-"Light grey: this peer does not have it."
+msgid "Being downloaded from this source now"
 msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "The next part that will be asked of this source"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "This source has the part and you still need it"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "This peer already has the part"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "This peer does not have the part"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "One block per part of the file being downloaded."
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+#, fuzzy
+msgid "One block per part of the shared file."
+msgstr "Syötä palvelimen portti tähän."
 
 #: src/GenericClientListCtrl.cpp
 #, c-format

--- a/po/fi.po
+++ b/po/fi.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 19:01+0200\n"
+"POT-Creation-Date: 2026-08-29 20:55+0200\n"
 "PO-Revision-Date: 2026-08-25 10:07+0000\n"
 "Last-Translator: Tapio Rantala <tapio.rantala@iki.fi>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -2772,6 +2772,24 @@ msgid ""
 msgstr ""
 "Et voi asettaa enempää kuin yhden kaveripaikan.\n"
 " Asetettiin yksi paikka."
+
+#: src/GenericClientListCtrl.cpp
+msgid ""
+"One block per part of the file.\n"
+"Light grey: this source does not have the part.\n"
+"Green: this source has it and so do you.\n"
+"Amber: downloading this part from this source now.\n"
+"Pale yellow: the next part you will request from this source.\n"
+"Dark grey: this source has it and you still need it.\n"
+"The whole bar is dimmed while the download is stopped."
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid ""
+"One block per part of your shared file.\n"
+"Dark grey: this peer already has the part.\n"
+"Light grey: this peer does not have it."
+msgstr ""
 
 #: src/GenericClientListCtrl.cpp
 #, c-format
@@ -7323,9 +7341,9 @@ msgstr[1] "Löydetty %i tunnettua jaettua tiedostoa"
 msgid "User Name"
 msgstr "Käyttäjänimi"
 
-#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
-msgid "Available Parts"
-msgstr "Saatavilla olevat osat"
+#: src/SharedFilePeersListCtrl.cpp
+msgid "Parts on Peer"
+msgstr ""
 
 #: src/SharedFilePeersListCtrl.cpp
 msgid "Upload Status"
@@ -7520,6 +7538,11 @@ msgstr "Jaetut tiedostot (%i)"
 #, fuzzy, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "Lataa uudelleen lista jaetuista tiedostoista."
+
+#: src/SourceListCtrl.cpp
+#, fuzzy
+msgid "Part Status"
+msgstr "Tila"
 
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"
@@ -9209,6 +9232,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "Available Parts"
+#~ msgstr "Saatavilla olevat osat"
 
 #, c-format
 #~ msgid "Found %i known shared file, %i unknown"

--- a/po/fr.po
+++ b/po/fr.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 19:01+0200\n"
+"POT-Creation-Date: 2026-08-29 20:55+0200\n"
 "PO-Revision-Date: 2026-08-25 10:08+0000\n"
 "Last-Translator: Dylan Aïssi <bob.dybian@gmail.com>\n"
 "Language-Team: Français\n"
@@ -2767,6 +2767,24 @@ msgid ""
 msgstr ""
 "Vous n'êtes pas autorisé à établir plus d'un slot ami.\n"
 " Seul un slot a été attribué."
+
+#: src/GenericClientListCtrl.cpp
+msgid ""
+"One block per part of the file.\n"
+"Light grey: this source does not have the part.\n"
+"Green: this source has it and so do you.\n"
+"Amber: downloading this part from this source now.\n"
+"Pale yellow: the next part you will request from this source.\n"
+"Dark grey: this source has it and you still need it.\n"
+"The whole bar is dimmed while the download is stopped."
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid ""
+"One block per part of your shared file.\n"
+"Dark grey: this peer already has the part.\n"
+"Light grey: this peer does not have it."
+msgstr ""
 
 #: src/GenericClientListCtrl.cpp
 #, c-format
@@ -7252,9 +7270,9 @@ msgstr[1] "%u nouveaux fichiers partagés découverts"
 msgid "User Name"
 msgstr "Nom d'Utilisateur"
 
-#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
-msgid "Available Parts"
-msgstr "Parties Disponibles"
+#: src/SharedFilePeersListCtrl.cpp
+msgid "Parts on Peer"
+msgstr ""
 
 #: src/SharedFilePeersListCtrl.cpp
 msgid "Upload Status"
@@ -7447,6 +7465,11 @@ msgstr "Fichiers partagés (%i)"
 #, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "Rechargement des fichiers partagés : %u fichiers analysés"
+
+#: src/SourceListCtrl.cpp
+#, fuzzy
+msgid "Part Status"
+msgstr "Statut"
 
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"
@@ -9157,6 +9180,9 @@ msgstr "aMule semble être en cours d'exécution. Veuillez le fermer et relancer
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "Suppression des données d'utilisateur sur $APPDATA\\aMule…"
+
+#~ msgid "Available Parts"
+#~ msgstr "Parties Disponibles"
 
 #, c-format
 #~ msgid "Found %i known shared file, %i unknown"

--- a/po/fr.po
+++ b/po/fr.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-29 20:55+0200\n"
+"POT-Creation-Date: 2026-08-30 16:16+0200\n"
 "PO-Revision-Date: 2026-08-25 10:08+0000\n"
 "Last-Translator: Dylan Aïssi <bob.dybian@gmail.com>\n"
 "Language-Team: Français\n"
@@ -2769,22 +2769,42 @@ msgstr ""
 " Seul un slot a été attribué."
 
 #: src/GenericClientListCtrl.cpp
-msgid ""
-"One block per part of the file.\n"
-"Light grey: this source does not have the part.\n"
-"Green: this source has it and so do you.\n"
-"Amber: downloading this part from this source now.\n"
-"Pale yellow: the next part you will request from this source.\n"
-"Dark grey: this source has it and you still need it.\n"
-"The whole bar is dimmed while the download is stopped."
+#, fuzzy
+msgid "This source does not have the part"
+msgstr "Cette commande ne devrait pas avoir de paramètres."
+
+#: src/GenericClientListCtrl.cpp
+msgid "You and this source both have the part"
 msgstr ""
 
 #: src/GenericClientListCtrl.cpp
-msgid ""
-"One block per part of your shared file.\n"
-"Dark grey: this peer already has the part.\n"
-"Light grey: this peer does not have it."
+msgid "Being downloaded from this source now"
 msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "The next part that will be asked of this source"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "This source has the part and you still need it"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "This peer already has the part"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "This peer does not have the part"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "One block per part of the file being downloaded."
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+#, fuzzy
+msgid "One block per part of the shared file."
+msgstr "Entrer ici le port du serveur."
 
 #: src/GenericClientListCtrl.cpp
 #, c-format

--- a/po/fr.po
+++ b/po/fr.po
@@ -2807,6 +2807,10 @@ msgid "One block per part of the shared file."
 msgstr "Entrer ici le port du serveur."
 
 #: src/GenericClientListCtrl.cpp
+msgid "Colour legend"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
 #, c-format
 msgid "On Queue: %u (%i)"
 msgstr "En attente : %u (%i)"

--- a/po/gl.po
+++ b/po/gl.po
@@ -2829,6 +2829,10 @@ msgid "One block per part of the shared file."
 msgstr "Introduza o porto do servidor aquí."
 
 #: src/GenericClientListCtrl.cpp
+msgid "Colour legend"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
 #, c-format
 msgid "On Queue: %u (%i)"
 msgstr "En lista de espera: %u (%i)"

--- a/po/gl.po
+++ b/po/gl.po
@@ -24,7 +24,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-29 20:55+0200\n"
+"POT-Creation-Date: 2026-08-30 16:16+0200\n"
 "PO-Revision-Date: 2026-08-25 10:08+0000\n"
 "Last-Translator: Pablo <parodper@gmail.com>\n"
 "Language-Team: http://forum.amule.org/index.php?topic=13883\n"
@@ -2791,22 +2791,42 @@ msgstr ""
 " Só se asignou un espazo."
 
 #: src/GenericClientListCtrl.cpp
-msgid ""
-"One block per part of the file.\n"
-"Light grey: this source does not have the part.\n"
-"Green: this source has it and so do you.\n"
-"Amber: downloading this part from this source now.\n"
-"Pale yellow: the next part you will request from this source.\n"
-"Dark grey: this source has it and you still need it.\n"
-"The whole bar is dimmed while the download is stopped."
+#, fuzzy
+msgid "This source does not have the part"
+msgstr "Esta orde non debería ter ningún parámetro."
+
+#: src/GenericClientListCtrl.cpp
+msgid "You and this source both have the part"
 msgstr ""
 
 #: src/GenericClientListCtrl.cpp
-msgid ""
-"One block per part of your shared file.\n"
-"Dark grey: this peer already has the part.\n"
-"Light grey: this peer does not have it."
+msgid "Being downloaded from this source now"
 msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "The next part that will be asked of this source"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "This source has the part and you still need it"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "This peer already has the part"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "This peer does not have the part"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "One block per part of the file being downloaded."
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+#, fuzzy
+msgid "One block per part of the shared file."
+msgstr "Introduza o porto do servidor aquí."
 
 #: src/GenericClientListCtrl.cpp
 #, c-format

--- a/po/gl.po
+++ b/po/gl.po
@@ -24,7 +24,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 19:01+0200\n"
+"POT-Creation-Date: 2026-08-29 20:55+0200\n"
 "PO-Revision-Date: 2026-08-25 10:08+0000\n"
 "Last-Translator: Pablo <parodper@gmail.com>\n"
 "Language-Team: http://forum.amule.org/index.php?topic=13883\n"
@@ -2789,6 +2789,24 @@ msgid ""
 msgstr ""
 "Non está permitindo establecer máis dun espazo de amigo.\n"
 " Só se asignou un espazo."
+
+#: src/GenericClientListCtrl.cpp
+msgid ""
+"One block per part of the file.\n"
+"Light grey: this source does not have the part.\n"
+"Green: this source has it and so do you.\n"
+"Amber: downloading this part from this source now.\n"
+"Pale yellow: the next part you will request from this source.\n"
+"Dark grey: this source has it and you still need it.\n"
+"The whole bar is dimmed while the download is stopped."
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid ""
+"One block per part of your shared file.\n"
+"Dark grey: this peer already has the part.\n"
+"Light grey: this peer does not have it."
+msgstr ""
 
 #: src/GenericClientListCtrl.cpp
 #, c-format
@@ -7329,9 +7347,9 @@ msgstr[1] "Atopados %i ficheiros compartidos"
 msgid "User Name"
 msgstr "Nome de usuario"
 
-#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
-msgid "Available Parts"
-msgstr "Partes dispoñibles"
+#: src/SharedFilePeersListCtrl.cpp
+msgid "Parts on Peer"
+msgstr ""
 
 #: src/SharedFilePeersListCtrl.cpp
 msgid "Upload Status"
@@ -7525,6 +7543,11 @@ msgstr "Ficheiros compartidos (%i)"
 #, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "Recargouse a lista de ficheiros compartidos: atopáronse %u ficheiros"
+
+#: src/SourceListCtrl.cpp
+#, fuzzy
+msgid "Part Status"
+msgstr "Estado"
 
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"
@@ -9231,6 +9254,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "Available Parts"
+#~ msgstr "Partes dispoñibles"
 
 #, c-format
 #~ msgid "Found %i known shared file, %i unknown"

--- a/po/he.po
+++ b/po/he.po
@@ -2780,6 +2780,10 @@ msgid "One block per part of the shared file."
 msgstr ""
 
 #: src/GenericClientListCtrl.cpp
+msgid "Colour legend"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
 #, fuzzy, c-format
 msgid "On Queue: %u (%i)"
 msgstr "QR:·%u·(%i)"

--- a/po/he.po
+++ b/po/he.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-29 20:55+0200\n"
+"POT-Creation-Date: 2026-08-30 16:16+0200\n"
 "PO-Revision-Date: 2026-08-25 10:09+0000\n"
 "Last-Translator: Peace Kramer <kpeace1@gmail.com>\n"
 "Language-Team: Hebrew\n"
@@ -2744,21 +2744,39 @@ msgstr ""
 "רק משבצת אחת הוגדרה."
 
 #: src/GenericClientListCtrl.cpp
-msgid ""
-"One block per part of the file.\n"
-"Light grey: this source does not have the part.\n"
-"Green: this source has it and so do you.\n"
-"Amber: downloading this part from this source now.\n"
-"Pale yellow: the next part you will request from this source.\n"
-"Dark grey: this source has it and you still need it.\n"
-"The whole bar is dimmed while the download is stopped."
+msgid "This source does not have the part"
 msgstr ""
 
 #: src/GenericClientListCtrl.cpp
-msgid ""
-"One block per part of your shared file.\n"
-"Dark grey: this peer already has the part.\n"
-"Light grey: this peer does not have it."
+msgid "You and this source both have the part"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "Being downloaded from this source now"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "The next part that will be asked of this source"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "This source has the part and you still need it"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "This peer already has the part"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "This peer does not have the part"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "One block per part of the file being downloaded."
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "One block per part of the shared file."
 msgstr ""
 
 #: src/GenericClientListCtrl.cpp

--- a/po/he.po
+++ b/po/he.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 19:01+0200\n"
+"POT-Creation-Date: 2026-08-29 20:55+0200\n"
 "PO-Revision-Date: 2026-08-25 10:09+0000\n"
 "Last-Translator: Peace Kramer <kpeace1@gmail.com>\n"
 "Language-Team: Hebrew\n"
@@ -2742,6 +2742,24 @@ msgid ""
 msgstr ""
 "אתה לא רשאי להגידר יותר ממשצת \"חבר\" אחת.\n"
 "רק משבצת אחת הוגדרה."
+
+#: src/GenericClientListCtrl.cpp
+msgid ""
+"One block per part of the file.\n"
+"Light grey: this source does not have the part.\n"
+"Green: this source has it and so do you.\n"
+"Amber: downloading this part from this source now.\n"
+"Pale yellow: the next part you will request from this source.\n"
+"Dark grey: this source has it and you still need it.\n"
+"The whole bar is dimmed while the download is stopped."
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid ""
+"One block per part of your shared file.\n"
+"Dark grey: this peer already has the part.\n"
+"Light grey: this peer does not have it."
+msgstr ""
 
 #: src/GenericClientListCtrl.cpp
 #, fuzzy, c-format
@@ -7293,10 +7311,9 @@ msgstr[1] "נמצא %i קובץ משותף מוכר"
 msgid "User Name"
 msgstr "שם משתמש"
 
-#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
-#, fuzzy
-msgid "Available Parts"
-msgstr "זמין :"
+#: src/SharedFilePeersListCtrl.cpp
+msgid "Parts on Peer"
+msgstr ""
 
 #: src/SharedFilePeersListCtrl.cpp
 #, fuzzy
@@ -7495,6 +7512,11 @@ msgstr "קבצים משותפים (%i)"
 #, fuzzy, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "טוען מחדש את רשימת הקבצים המשותפים."
+
+#: src/SourceListCtrl.cpp
+#, fuzzy
+msgid "Part Status"
+msgstr "מצב"
 
 #: src/SourceListCtrl.cpp
 #, fuzzy
@@ -9181,6 +9203,10 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#, fuzzy
+#~ msgid "Available Parts"
+#~ msgstr "זמין :"
 
 #, fuzzy, c-format
 #~ msgid "Found %i known shared file, %i unknown"

--- a/po/hr.po
+++ b/po/hr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 19:01+0200\n"
+"POT-Creation-Date: 2026-08-29 20:55+0200\n"
 "PO-Revision-Date: 2026-08-25 10:09+0000\n"
 "Last-Translator: Sebastiano Pistore <sebastiano.pistore.info@aol.com>\n"
 "Language-Team: https://github.com/amule-org/amule <forum@aMule.org>\n"
@@ -2733,6 +2733,24 @@ msgstr "Da li zaist zelis otkazati i obrisati ove fajlove ?\n"
 msgid ""
 "You are not allowed to set more than one friendslot.\n"
 " Only one slot was assigned."
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid ""
+"One block per part of the file.\n"
+"Light grey: this source does not have the part.\n"
+"Green: this source has it and so do you.\n"
+"Amber: downloading this part from this source now.\n"
+"Pale yellow: the next part you will request from this source.\n"
+"Dark grey: this source has it and you still need it.\n"
+"The whole bar is dimmed while the download is stopped."
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid ""
+"One block per part of your shared file.\n"
+"Dark grey: this peer already has the part.\n"
+"Light grey: this peer does not have it."
 msgstr ""
 
 #: src/GenericClientListCtrl.cpp
@@ -7292,10 +7310,9 @@ msgstr[2] ""
 msgid "User Name"
 msgstr "Ime korisnika"
 
-#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
-#, fuzzy
-msgid "Available Parts"
-msgstr "Dostupnost :"
+#: src/SharedFilePeersListCtrl.cpp
+msgid "Parts on Peer"
+msgstr ""
 
 #: src/SharedFilePeersListCtrl.cpp
 #, fuzzy
@@ -7500,6 +7517,11 @@ msgstr "Dijeljeni fajlovi (%i)"
 #, fuzzy, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "Pronadjeno %i poznatih dijeljenih fajlova"
+
+#: src/SourceListCtrl.cpp
+#, fuzzy
+msgid "Part Status"
+msgstr "Status"
 
 #: src/SourceListCtrl.cpp
 #, fuzzy
@@ -9136,6 +9158,10 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#, fuzzy
+#~ msgid "Available Parts"
+#~ msgstr "Dostupnost :"
 
 #, fuzzy, c-format
 #~ msgid "Found %i known shared file, %i unknown"

--- a/po/hr.po
+++ b/po/hr.po
@@ -2772,6 +2772,10 @@ msgid "One block per part of the shared file."
 msgstr ""
 
 #: src/GenericClientListCtrl.cpp
+msgid "Colour legend"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
 #, fuzzy, c-format
 msgid "On Queue: %u (%i)"
 msgstr "U redu cekanja"

--- a/po/hr.po
+++ b/po/hr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-29 20:55+0200\n"
+"POT-Creation-Date: 2026-08-30 16:16+0200\n"
 "PO-Revision-Date: 2026-08-25 10:09+0000\n"
 "Last-Translator: Sebastiano Pistore <sebastiano.pistore.info@aol.com>\n"
 "Language-Team: https://github.com/amule-org/amule <forum@aMule.org>\n"
@@ -2736,21 +2736,39 @@ msgid ""
 msgstr ""
 
 #: src/GenericClientListCtrl.cpp
-msgid ""
-"One block per part of the file.\n"
-"Light grey: this source does not have the part.\n"
-"Green: this source has it and so do you.\n"
-"Amber: downloading this part from this source now.\n"
-"Pale yellow: the next part you will request from this source.\n"
-"Dark grey: this source has it and you still need it.\n"
-"The whole bar is dimmed while the download is stopped."
+msgid "This source does not have the part"
 msgstr ""
 
 #: src/GenericClientListCtrl.cpp
-msgid ""
-"One block per part of your shared file.\n"
-"Dark grey: this peer already has the part.\n"
-"Light grey: this peer does not have it."
+msgid "You and this source both have the part"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "Being downloaded from this source now"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "The next part that will be asked of this source"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "This source has the part and you still need it"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "This peer already has the part"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "This peer does not have the part"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "One block per part of the file being downloaded."
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "One block per part of the shared file."
 msgstr ""
 
 #: src/GenericClientListCtrl.cpp

--- a/po/hu.po
+++ b/po/hu.po
@@ -2803,6 +2803,10 @@ msgid "One block per part of the shared file."
 msgstr "Add meg a kiszolgáló portját."
 
 #: src/GenericClientListCtrl.cpp
+msgid "Colour legend"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
 #, c-format
 msgid "On Queue: %u (%i)"
 msgstr "Várólistán: %u (%i)"

--- a/po/hu.po
+++ b/po/hu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-29 20:55+0200\n"
+"POT-Creation-Date: 2026-08-30 16:16+0200\n"
 "PO-Revision-Date: 2026-08-25 10:09+0000\n"
 "Last-Translator: Dévai Tamás <gonosztopi@amule.org>\n"
 "Language-Team: Hungarian <hu@li.org>\n"
@@ -2765,22 +2765,42 @@ msgstr ""
 "Csak egy slot lett hozzárendelve."
 
 #: src/GenericClientListCtrl.cpp
-msgid ""
-"One block per part of the file.\n"
-"Light grey: this source does not have the part.\n"
-"Green: this source has it and so do you.\n"
-"Amber: downloading this part from this source now.\n"
-"Pale yellow: the next part you will request from this source.\n"
-"Dark grey: this source has it and you still need it.\n"
-"The whole bar is dimmed while the download is stopped."
+#, fuzzy
+msgid "This source does not have the part"
+msgstr "Ennek a parancsnak nem kellene paraméterének lennie."
+
+#: src/GenericClientListCtrl.cpp
+msgid "You and this source both have the part"
 msgstr ""
 
 #: src/GenericClientListCtrl.cpp
-msgid ""
-"One block per part of your shared file.\n"
-"Dark grey: this peer already has the part.\n"
-"Light grey: this peer does not have it."
+msgid "Being downloaded from this source now"
 msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "The next part that will be asked of this source"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "This source has the part and you still need it"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "This peer already has the part"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "This peer does not have the part"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "One block per part of the file being downloaded."
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+#, fuzzy
+msgid "One block per part of the shared file."
+msgstr "Add meg a kiszolgáló portját."
 
 #: src/GenericClientListCtrl.cpp
 #, c-format

--- a/po/hu.po
+++ b/po/hu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 19:01+0200\n"
+"POT-Creation-Date: 2026-08-29 20:55+0200\n"
 "PO-Revision-Date: 2026-08-25 10:09+0000\n"
 "Last-Translator: Dévai Tamás <gonosztopi@amule.org>\n"
 "Language-Team: Hungarian <hu@li.org>\n"
@@ -2763,6 +2763,24 @@ msgid ""
 msgstr ""
 "Nem lehet egynél több barát slot-ot létrehozni.\n"
 "Csak egy slot lett hozzárendelve."
+
+#: src/GenericClientListCtrl.cpp
+msgid ""
+"One block per part of the file.\n"
+"Light grey: this source does not have the part.\n"
+"Green: this source has it and so do you.\n"
+"Amber: downloading this part from this source now.\n"
+"Pale yellow: the next part you will request from this source.\n"
+"Dark grey: this source has it and you still need it.\n"
+"The whole bar is dimmed while the download is stopped."
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid ""
+"One block per part of your shared file.\n"
+"Dark grey: this peer already has the part.\n"
+"Light grey: this peer does not have it."
+msgstr ""
 
 #: src/GenericClientListCtrl.cpp
 #, c-format
@@ -7280,9 +7298,9 @@ msgstr[0] "%i ismert megosztott fájlt találtam"
 msgid "User Name"
 msgstr "Felhasználói név"
 
-#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
-msgid "Available Parts"
-msgstr "Elérhető részek"
+#: src/SharedFilePeersListCtrl.cpp
+msgid "Parts on Peer"
+msgstr ""
 
 #: src/SharedFilePeersListCtrl.cpp
 msgid "Upload Status"
@@ -7469,6 +7487,11 @@ msgstr "Megosztott fájlok (%i)"
 #, fuzzy, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "A megosztott fájlok listájának újratöltése."
+
+#: src/SourceListCtrl.cpp
+#, fuzzy
+msgid "Part Status"
+msgstr "Állapot"
 
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"
@@ -9163,6 +9186,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "Available Parts"
+#~ msgstr "Elérhető részek"
 
 #, c-format
 #~ msgid "Found %i known shared file, %i unknown"

--- a/po/it.po
+++ b/po/it.po
@@ -2814,6 +2814,10 @@ msgid "One block per part of the shared file."
 msgstr "Inserisci qui la porta del server."
 
 #: src/GenericClientListCtrl.cpp
+msgid "Colour legend"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
 #, c-format
 msgid "On Queue: %u (%i)"
 msgstr "In coda: %u (%i)"

--- a/po/it.po
+++ b/po/it.po
@@ -19,7 +19,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule 2.3.3\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 19:01+0200\n"
+"POT-Creation-Date: 2026-08-29 20:55+0200\n"
 "PO-Revision-Date: 2026-08-25 10:10+0000\n"
 "Last-Translator: got3nks <got3nks@users.noreply.github.com>\n"
 "Language-Team: SebastianoPistore.info@protonmail.ch\n"
@@ -2774,6 +2774,24 @@ msgid ""
 msgstr ""
 "Non puoi assegnare più di uno slot amico.\n"
 "Assegnato un solo slot."
+
+#: src/GenericClientListCtrl.cpp
+msgid ""
+"One block per part of the file.\n"
+"Light grey: this source does not have the part.\n"
+"Green: this source has it and so do you.\n"
+"Amber: downloading this part from this source now.\n"
+"Pale yellow: the next part you will request from this source.\n"
+"Dark grey: this source has it and you still need it.\n"
+"The whole bar is dimmed while the download is stopped."
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid ""
+"One block per part of your shared file.\n"
+"Dark grey: this peer already has the part.\n"
+"Light grey: this peer does not have it."
+msgstr ""
 
 #: src/GenericClientListCtrl.cpp
 #, c-format
@@ -7259,9 +7277,9 @@ msgstr[1] "Rilevati %u nuovi file condivisi"
 msgid "User Name"
 msgstr "Nome utente"
 
-#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
-msgid "Available Parts"
-msgstr "Parti disponibili"
+#: src/SharedFilePeersListCtrl.cpp
+msgid "Parts on Peer"
+msgstr ""
 
 #: src/SharedFilePeersListCtrl.cpp
 msgid "Upload Status"
@@ -7454,6 +7472,11 @@ msgstr "File condivisi (%i)"
 #, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "Ricarica file condivisi: %u file analizzati"
+
+#: src/SourceListCtrl.cpp
+#, fuzzy
+msgid "Part Status"
+msgstr "Stato"
 
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"
@@ -9164,6 +9187,9 @@ msgstr "Sembra che aMule sia in esecuzione. Chiudilo e riavvia il programma di d
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "Rimozione dei dati utente in $APPDATA\\aMule..."
+
+#~ msgid "Available Parts"
+#~ msgstr "Parti disponibili"
 
 #, c-format
 #~ msgid "Found %i known shared file, %i unknown"

--- a/po/it.po
+++ b/po/it.po
@@ -19,7 +19,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule 2.3.3\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-29 20:55+0200\n"
+"POT-Creation-Date: 2026-08-30 16:16+0200\n"
 "PO-Revision-Date: 2026-08-25 10:10+0000\n"
 "Last-Translator: got3nks <got3nks@users.noreply.github.com>\n"
 "Language-Team: SebastianoPistore.info@protonmail.ch\n"
@@ -2776,22 +2776,42 @@ msgstr ""
 "Assegnato un solo slot."
 
 #: src/GenericClientListCtrl.cpp
-msgid ""
-"One block per part of the file.\n"
-"Light grey: this source does not have the part.\n"
-"Green: this source has it and so do you.\n"
-"Amber: downloading this part from this source now.\n"
-"Pale yellow: the next part you will request from this source.\n"
-"Dark grey: this source has it and you still need it.\n"
-"The whole bar is dimmed while the download is stopped."
+#, fuzzy
+msgid "This source does not have the part"
+msgstr "Questo comando non deve avere parametri."
+
+#: src/GenericClientListCtrl.cpp
+msgid "You and this source both have the part"
 msgstr ""
 
 #: src/GenericClientListCtrl.cpp
-msgid ""
-"One block per part of your shared file.\n"
-"Dark grey: this peer already has the part.\n"
-"Light grey: this peer does not have it."
+msgid "Being downloaded from this source now"
 msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "The next part that will be asked of this source"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "This source has the part and you still need it"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "This peer already has the part"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "This peer does not have the part"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "One block per part of the file being downloaded."
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+#, fuzzy
+msgid "One block per part of the shared file."
+msgstr "Inserisci qui la porta del server."
 
 #: src/GenericClientListCtrl.cpp
 #, c-format

--- a/po/ja.po
+++ b/po/ja.po
@@ -2812,6 +2812,10 @@ msgid "One block per part of the shared file."
 msgstr "サーバのポートをここに入力してください。"
 
 #: src/GenericClientListCtrl.cpp
+msgid "Colour legend"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
 #, fuzzy, c-format
 msgid "On Queue: %u (%i)"
 msgstr "QR: %u (%i)"

--- a/po/ja.po
+++ b/po/ja.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-29 20:55+0200\n"
+"POT-Creation-Date: 2026-08-30 16:16+0200\n"
 "PO-Revision-Date: 2026-08-25 10:11+0000\n"
 "Last-Translator: \n"
 "Language-Team: Japanese\n"
@@ -2774,22 +2774,42 @@ msgid ""
 msgstr "スロットが一つのみ提供されました。"
 
 #: src/GenericClientListCtrl.cpp
-msgid ""
-"One block per part of the file.\n"
-"Light grey: this source does not have the part.\n"
-"Green: this source has it and so do you.\n"
-"Amber: downloading this part from this source now.\n"
-"Pale yellow: the next part you will request from this source.\n"
-"Dark grey: this source has it and you still need it.\n"
-"The whole bar is dimmed while the download is stopped."
+#, fuzzy
+msgid "This source does not have the part"
+msgstr "このコマンドには引数が認められていません。"
+
+#: src/GenericClientListCtrl.cpp
+msgid "You and this source both have the part"
 msgstr ""
 
 #: src/GenericClientListCtrl.cpp
-msgid ""
-"One block per part of your shared file.\n"
-"Dark grey: this peer already has the part.\n"
-"Light grey: this peer does not have it."
+msgid "Being downloaded from this source now"
 msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "The next part that will be asked of this source"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "This source has the part and you still need it"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "This peer already has the part"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "This peer does not have the part"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "One block per part of the file being downloaded."
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+#, fuzzy
+msgid "One block per part of the shared file."
+msgstr "サーバのポートをここに入力してください。"
 
 #: src/GenericClientListCtrl.cpp
 #, fuzzy, c-format

--- a/po/ja.po
+++ b/po/ja.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 19:01+0200\n"
+"POT-Creation-Date: 2026-08-29 20:55+0200\n"
 "PO-Revision-Date: 2026-08-25 10:11+0000\n"
 "Last-Translator: \n"
 "Language-Team: Japanese\n"
@@ -2772,6 +2772,24 @@ msgid ""
 "You are not allowed to set more than one friendslot.\n"
 " Only one slot was assigned."
 msgstr "スロットが一つのみ提供されました。"
+
+#: src/GenericClientListCtrl.cpp
+msgid ""
+"One block per part of the file.\n"
+"Light grey: this source does not have the part.\n"
+"Green: this source has it and so do you.\n"
+"Amber: downloading this part from this source now.\n"
+"Pale yellow: the next part you will request from this source.\n"
+"Dark grey: this source has it and you still need it.\n"
+"The whole bar is dimmed while the download is stopped."
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid ""
+"One block per part of your shared file.\n"
+"Dark grey: this peer already has the part.\n"
+"Light grey: this peer does not have it."
+msgstr ""
 
 #: src/GenericClientListCtrl.cpp
 #, fuzzy, c-format
@@ -7311,10 +7329,9 @@ msgstr[0] "%i個の既知の共有ファイルが見つかりました"
 msgid "User Name"
 msgstr "ユーザ名"
 
-#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
-#, fuzzy
-msgid "Available Parts"
-msgstr "入手可能数："
+#: src/SharedFilePeersListCtrl.cpp
+msgid "Parts on Peer"
+msgstr ""
 
 #: src/SharedFilePeersListCtrl.cpp
 #, fuzzy
@@ -7505,6 +7522,11 @@ msgstr "共有ファイル（%i）"
 #, fuzzy, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "共有ファイル・リストを再ロードします。"
+
+#: src/SourceListCtrl.cpp
+#, fuzzy
+msgid "Part Status"
+msgstr "ステータス"
 
 #: src/SourceListCtrl.cpp
 #, fuzzy
@@ -9196,6 +9218,10 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#, fuzzy
+#~ msgid "Available Parts"
+#~ msgstr "入手可能数："
 
 #, c-format
 #~ msgid "Found %i known shared file, %i unknown"

--- a/po/ko_KR.po
+++ b/po/ko_KR.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-29 20:55+0200\n"
+"POT-Creation-Date: 2026-08-30 16:16+0200\n"
 "PO-Revision-Date: 2026-08-25 10:12+0000\n"
 "Last-Translator: Hyunju Kang <rexington@gmail.com>\n"
 "Language-Team: Korean <hoenny@daum.net>\n"
@@ -2789,22 +2789,42 @@ msgstr ""
 "단지 하나의 칸만 가능합니다."
 
 #: src/GenericClientListCtrl.cpp
-msgid ""
-"One block per part of the file.\n"
-"Light grey: this source does not have the part.\n"
-"Green: this source has it and so do you.\n"
-"Amber: downloading this part from this source now.\n"
-"Pale yellow: the next part you will request from this source.\n"
-"Dark grey: this source has it and you still need it.\n"
-"The whole bar is dimmed while the download is stopped."
+#, fuzzy
+msgid "This source does not have the part"
+msgstr "이 명령은 어떤 변수도 필요하지 않습니다."
+
+#: src/GenericClientListCtrl.cpp
+msgid "You and this source both have the part"
 msgstr ""
 
 #: src/GenericClientListCtrl.cpp
-msgid ""
-"One block per part of your shared file.\n"
-"Dark grey: this peer already has the part.\n"
-"Light grey: this peer does not have it."
+msgid "Being downloaded from this source now"
 msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "The next part that will be asked of this source"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "This source has the part and you still need it"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "This peer already has the part"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "This peer does not have the part"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "One block per part of the file being downloaded."
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+#, fuzzy
+msgid "One block per part of the shared file."
+msgstr "서버의 포트를 이곳에 입력하세요."
 
 #: src/GenericClientListCtrl.cpp
 #, fuzzy, c-format

--- a/po/ko_KR.po
+++ b/po/ko_KR.po
@@ -2827,6 +2827,10 @@ msgid "One block per part of the shared file."
 msgstr "서버의 포트를 이곳에 입력하세요."
 
 #: src/GenericClientListCtrl.cpp
+msgid "Colour legend"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
 #, fuzzy, c-format
 msgid "On Queue: %u (%i)"
 msgstr "QR: %u (%i)"

--- a/po/ko_KR.po
+++ b/po/ko_KR.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 19:01+0200\n"
+"POT-Creation-Date: 2026-08-29 20:55+0200\n"
 "PO-Revision-Date: 2026-08-25 10:12+0000\n"
 "Last-Translator: Hyunju Kang <rexington@gmail.com>\n"
 "Language-Team: Korean <hoenny@daum.net>\n"
@@ -2787,6 +2787,24 @@ msgid ""
 msgstr ""
 "하나 이상의 친구칸으로 설정이 허락되지않습니다\n"
 "단지 하나의 칸만 가능합니다."
+
+#: src/GenericClientListCtrl.cpp
+msgid ""
+"One block per part of the file.\n"
+"Light grey: this source does not have the part.\n"
+"Green: this source has it and so do you.\n"
+"Amber: downloading this part from this source now.\n"
+"Pale yellow: the next part you will request from this source.\n"
+"Dark grey: this source has it and you still need it.\n"
+"The whole bar is dimmed while the download is stopped."
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid ""
+"One block per part of your shared file.\n"
+"Dark grey: this peer already has the part.\n"
+"Light grey: this peer does not have it."
+msgstr ""
 
 #: src/GenericClientListCtrl.cpp
 #, fuzzy, c-format
@@ -7367,10 +7385,9 @@ msgstr[1] "알려진 공유 파일 %i개를 찾았음"
 msgid "User Name"
 msgstr "사용자이름"
 
-#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
-#, fuzzy
-msgid "Available Parts"
-msgstr "가능함 :"
+#: src/SharedFilePeersListCtrl.cpp
+msgid "Parts on Peer"
+msgstr ""
 
 #: src/SharedFilePeersListCtrl.cpp
 #, fuzzy
@@ -7567,6 +7584,11 @@ msgstr "공유된 파일(%i)"
 #, fuzzy, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "공유된 파일 목록을 다시 읽어들입니다."
+
+#: src/SourceListCtrl.cpp
+#, fuzzy
+msgid "Part Status"
+msgstr "상태"
 
 #: src/SourceListCtrl.cpp
 #, fuzzy
@@ -9260,6 +9282,10 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#, fuzzy
+#~ msgid "Available Parts"
+#~ msgstr "가능함 :"
 
 #, fuzzy, c-format
 #~ msgid "Found %i known shared file, %i unknown"

--- a/po/lt.po
+++ b/po/lt.po
@@ -2835,6 +2835,10 @@ msgid "One block per part of the shared file."
 msgstr "Įrašykite serverio prievadą."
 
 #: src/GenericClientListCtrl.cpp
+msgid "Colour legend"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
 #, fuzzy, c-format
 msgid "On Queue: %u (%i)"
 msgstr "Reitingas: %u (%i)"

--- a/po/lt.po
+++ b/po/lt.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-29 20:55+0200\n"
+"POT-Creation-Date: 2026-08-30 16:16+0200\n"
 "PO-Revision-Date: 2026-08-25 10:13+0000\n"
 "Last-Translator: Dovydas Sankauskas <laisve@gmail.com>\n"
 "Language-Team: Lithuanian <komp_lt@konf.lt>\n"
@@ -2797,22 +2797,42 @@ msgstr ""
 "Buvo sukurtas tik vienas kanalas."
 
 #: src/GenericClientListCtrl.cpp
-msgid ""
-"One block per part of the file.\n"
-"Light grey: this source does not have the part.\n"
-"Green: this source has it and so do you.\n"
-"Amber: downloading this part from this source now.\n"
-"Pale yellow: the next part you will request from this source.\n"
-"Dark grey: this source has it and you still need it.\n"
-"The whole bar is dimmed while the download is stopped."
+#, fuzzy
+msgid "This source does not have the part"
+msgstr "Ši komanda negali turėti parametrų."
+
+#: src/GenericClientListCtrl.cpp
+msgid "You and this source both have the part"
 msgstr ""
 
 #: src/GenericClientListCtrl.cpp
-msgid ""
-"One block per part of your shared file.\n"
-"Dark grey: this peer already has the part.\n"
-"Light grey: this peer does not have it."
+msgid "Being downloaded from this source now"
 msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "The next part that will be asked of this source"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "This source has the part and you still need it"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "This peer already has the part"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "This peer does not have the part"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "One block per part of the file being downloaded."
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+#, fuzzy
+msgid "One block per part of the shared file."
+msgstr "Įrašykite serverio prievadą."
 
 #: src/GenericClientListCtrl.cpp
 #, fuzzy, c-format

--- a/po/lt.po
+++ b/po/lt.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 19:01+0200\n"
+"POT-Creation-Date: 2026-08-29 20:55+0200\n"
 "PO-Revision-Date: 2026-08-25 10:13+0000\n"
 "Last-Translator: Dovydas Sankauskas <laisve@gmail.com>\n"
 "Language-Team: Lithuanian <komp_lt@konf.lt>\n"
@@ -2795,6 +2795,24 @@ msgid ""
 msgstr ""
 "Neleidžiama sukurti daugiau nei vieną siuntimo kanalą draugui.\n"
 "Buvo sukurtas tik vienas kanalas."
+
+#: src/GenericClientListCtrl.cpp
+msgid ""
+"One block per part of the file.\n"
+"Light grey: this source does not have the part.\n"
+"Green: this source has it and so do you.\n"
+"Amber: downloading this part from this source now.\n"
+"Pale yellow: the next part you will request from this source.\n"
+"Dark grey: this source has it and you still need it.\n"
+"The whole bar is dimmed while the download is stopped."
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid ""
+"One block per part of your shared file.\n"
+"Dark grey: this peer already has the part.\n"
+"Light grey: this peer does not have it."
+msgstr ""
 
 #: src/GenericClientListCtrl.cpp
 #, fuzzy, c-format
@@ -7399,10 +7417,9 @@ msgstr[2] "Aptikta %i dalinamų failų"
 msgid "User Name"
 msgstr "Naudotojo vardas"
 
-#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
-#, fuzzy
-msgid "Available Parts"
-msgstr "Pasiekiamos dalys:"
+#: src/SharedFilePeersListCtrl.cpp
+msgid "Parts on Peer"
+msgstr ""
 
 #: src/SharedFilePeersListCtrl.cpp
 #, fuzzy
@@ -7607,6 +7624,11 @@ msgstr "Dalinami failai (%i)"
 #, fuzzy, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "Atnaujinti dalinamų failų sąrašą."
+
+#: src/SourceListCtrl.cpp
+#, fuzzy
+msgid "Part Status"
+msgstr "Būsena"
 
 #: src/SourceListCtrl.cpp
 #, fuzzy
@@ -9313,6 +9335,10 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#, fuzzy
+#~ msgid "Available Parts"
+#~ msgstr "Pasiekiamos dalys:"
 
 #, c-format
 #~ msgid "Found %i known shared file, %i unknown"

--- a/po/lv.po
+++ b/po/lv.po
@@ -2733,6 +2733,10 @@ msgid "One block per part of the shared file."
 msgstr ""
 
 #: src/GenericClientListCtrl.cpp
+msgid "Colour legend"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
 #, c-format
 msgid "On Queue: %u (%i)"
 msgstr ""

--- a/po/lv.po
+++ b/po/lv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 19:01+0200\n"
+"POT-Creation-Date: 2026-08-29 20:55+0200\n"
 "PO-Revision-Date: 2026-08-25 10:23+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -2694,6 +2694,24 @@ msgstr "Vai tiešām vēlaties dzēst atlasītos draugus?"
 msgid ""
 "You are not allowed to set more than one friendslot.\n"
 " Only one slot was assigned."
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid ""
+"One block per part of the file.\n"
+"Light grey: this source does not have the part.\n"
+"Green: this source has it and so do you.\n"
+"Amber: downloading this part from this source now.\n"
+"Pale yellow: the next part you will request from this source.\n"
+"Dark grey: this source has it and you still need it.\n"
+"The whole bar is dimmed while the download is stopped."
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid ""
+"One block per part of your shared file.\n"
+"Dark grey: this peer already has the part.\n"
+"Light grey: this peer does not have it."
 msgstr ""
 
 #: src/GenericClientListCtrl.cpp
@@ -7161,8 +7179,8 @@ msgstr[2] "Atrada %u jaunas kopīgotas datnes"
 msgid "User Name"
 msgstr "Dalībniekvārds"
 
-#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
-msgid "Available Parts"
+#: src/SharedFilePeersListCtrl.cpp
+msgid "Parts on Peer"
 msgstr ""
 
 #: src/SharedFilePeersListCtrl.cpp
@@ -7363,6 +7381,11 @@ msgstr "Kopīgotās datnes (%i)"
 #, fuzzy, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "Ielādē kopīgotās datnes (%u)"
+
+#: src/SourceListCtrl.cpp
+#, fuzzy
+msgid "Part Status"
+msgstr "Statuss"
 
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"

--- a/po/lv.po
+++ b/po/lv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-29 20:55+0200\n"
+"POT-Creation-Date: 2026-08-30 16:16+0200\n"
 "PO-Revision-Date: 2026-08-25 10:23+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -2697,21 +2697,39 @@ msgid ""
 msgstr ""
 
 #: src/GenericClientListCtrl.cpp
-msgid ""
-"One block per part of the file.\n"
-"Light grey: this source does not have the part.\n"
-"Green: this source has it and so do you.\n"
-"Amber: downloading this part from this source now.\n"
-"Pale yellow: the next part you will request from this source.\n"
-"Dark grey: this source has it and you still need it.\n"
-"The whole bar is dimmed while the download is stopped."
+msgid "This source does not have the part"
 msgstr ""
 
 #: src/GenericClientListCtrl.cpp
-msgid ""
-"One block per part of your shared file.\n"
-"Dark grey: this peer already has the part.\n"
-"Light grey: this peer does not have it."
+msgid "You and this source both have the part"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "Being downloaded from this source now"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "The next part that will be asked of this source"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "This source has the part and you still need it"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "This peer already has the part"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "This peer does not have the part"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "One block per part of the file being downloaded."
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "One block per part of the shared file."
 msgstr ""
 
 #: src/GenericClientListCtrl.cpp

--- a/po/nl.po
+++ b/po/nl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-29 20:55+0200\n"
+"POT-Creation-Date: 2026-08-30 16:16+0200\n"
 "PO-Revision-Date: 2026-08-26 20:30+0000\n"
 "Last-Translator: Marcel Pol <marcel@timelord.nl>\n"
 "Language-Team: Dutch <nl@li.org>\n"
@@ -2766,22 +2766,42 @@ msgstr ""
 " Slechts één slot is toegekend."
 
 #: src/GenericClientListCtrl.cpp
-msgid ""
-"One block per part of the file.\n"
-"Light grey: this source does not have the part.\n"
-"Green: this source has it and so do you.\n"
-"Amber: downloading this part from this source now.\n"
-"Pale yellow: the next part you will request from this source.\n"
-"Dark grey: this source has it and you still need it.\n"
-"The whole bar is dimmed while the download is stopped."
+#, fuzzy
+msgid "This source does not have the part"
+msgstr "Dit commando heeft geen parameters."
+
+#: src/GenericClientListCtrl.cpp
+msgid "You and this source both have the part"
 msgstr ""
 
 #: src/GenericClientListCtrl.cpp
-msgid ""
-"One block per part of your shared file.\n"
-"Dark grey: this peer already has the part.\n"
-"Light grey: this peer does not have it."
+msgid "Being downloaded from this source now"
 msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "The next part that will be asked of this source"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "This source has the part and you still need it"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "This peer already has the part"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "This peer does not have the part"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "One block per part of the file being downloaded."
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+#, fuzzy
+msgid "One block per part of the shared file."
+msgstr "Voer hier de poort van de server in."
 
 #: src/GenericClientListCtrl.cpp
 #, c-format

--- a/po/nl.po
+++ b/po/nl.po
@@ -2804,6 +2804,10 @@ msgid "One block per part of the shared file."
 msgstr "Voer hier de poort van de server in."
 
 #: src/GenericClientListCtrl.cpp
+msgid "Colour legend"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
 #, c-format
 msgid "On Queue: %u (%i)"
 msgstr "In wachtrij: %u (%i)"

--- a/po/nl.po
+++ b/po/nl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 19:01+0200\n"
+"POT-Creation-Date: 2026-08-29 20:55+0200\n"
 "PO-Revision-Date: 2026-08-26 20:30+0000\n"
 "Last-Translator: Marcel Pol <marcel@timelord.nl>\n"
 "Language-Team: Dutch <nl@li.org>\n"
@@ -2764,6 +2764,24 @@ msgid ""
 msgstr ""
 "U kunt maximaal één vriendenslot instellen.\n"
 " Slechts één slot is toegekend."
+
+#: src/GenericClientListCtrl.cpp
+msgid ""
+"One block per part of the file.\n"
+"Light grey: this source does not have the part.\n"
+"Green: this source has it and so do you.\n"
+"Amber: downloading this part from this source now.\n"
+"Pale yellow: the next part you will request from this source.\n"
+"Dark grey: this source has it and you still need it.\n"
+"The whole bar is dimmed while the download is stopped."
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid ""
+"One block per part of your shared file.\n"
+"Dark grey: this peer already has the part.\n"
+"Light grey: this peer does not have it."
+msgstr ""
 
 #: src/GenericClientListCtrl.cpp
 #, c-format
@@ -7250,9 +7268,9 @@ msgstr[1] "%u nieuwe gedeelde bestanden ontdekt"
 msgid "User Name"
 msgstr "Gebruikersnaam"
 
-#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
-msgid "Available Parts"
-msgstr "Beschikbare delen"
+#: src/SharedFilePeersListCtrl.cpp
+msgid "Parts on Peer"
+msgstr ""
 
 #: src/SharedFilePeersListCtrl.cpp
 msgid "Upload Status"
@@ -7445,6 +7463,11 @@ msgstr "Gedeelde bestanden (%i)"
 #, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "Gedeelde bestanden opnieuw laden: %u bestanden gescand"
+
+#: src/SourceListCtrl.cpp
+#, fuzzy
+msgid "Part Status"
+msgstr "Status"
 
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"
@@ -9159,6 +9182,9 @@ msgstr "aMule lijkt te worden uitgevoerd. Sluit het en voer het verwijderprogram
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "Gebruikersgegevens op $APPDATA\\aMule worden verwijderd..."
+
+#~ msgid "Available Parts"
+#~ msgstr "Beschikbare delen"
 
 #, c-format
 #~ msgid "Found %i known shared file, %i unknown"

--- a/po/nn.po
+++ b/po/nn.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-29 20:55+0200\n"
+"POT-Creation-Date: 2026-08-30 16:16+0200\n"
 "PO-Revision-Date: 2026-08-25 10:14+0000\n"
 "Last-Translator: Hallvor Brunstad <Hallvor_1976@yahoo.com>\n"
 "Language-Team: <i18n-nn@lister.ping.uio.no>\n"
@@ -2788,22 +2788,42 @@ msgstr ""
 " Berre ei venekopling vart oppretta."
 
 #: src/GenericClientListCtrl.cpp
-msgid ""
-"One block per part of the file.\n"
-"Light grey: this source does not have the part.\n"
-"Green: this source has it and so do you.\n"
-"Amber: downloading this part from this source now.\n"
-"Pale yellow: the next part you will request from this source.\n"
-"Dark grey: this source has it and you still need it.\n"
-"The whole bar is dimmed while the download is stopped."
+#, fuzzy
+msgid "This source does not have the part"
+msgstr "Denne kommandoen skulle ikkje ha nokon parameter."
+
+#: src/GenericClientListCtrl.cpp
+msgid "You and this source both have the part"
 msgstr ""
 
 #: src/GenericClientListCtrl.cpp
-msgid ""
-"One block per part of your shared file.\n"
-"Dark grey: this peer already has the part.\n"
-"Light grey: this peer does not have it."
+msgid "Being downloaded from this source now"
 msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "The next part that will be asked of this source"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "This source has the part and you still need it"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "This peer already has the part"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "This peer does not have the part"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "One block per part of the file being downloaded."
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+#, fuzzy
+msgid "One block per part of the shared file."
+msgstr "Skriv inn porten til tenaren her."
 
 #: src/GenericClientListCtrl.cpp
 #, fuzzy, c-format

--- a/po/nn.po
+++ b/po/nn.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 19:01+0200\n"
+"POT-Creation-Date: 2026-08-29 20:55+0200\n"
 "PO-Revision-Date: 2026-08-25 10:14+0000\n"
 "Last-Translator: Hallvor Brunstad <Hallvor_1976@yahoo.com>\n"
 "Language-Team: <i18n-nn@lister.ping.uio.no>\n"
@@ -2786,6 +2786,24 @@ msgid ""
 msgstr ""
 "Det er ikkje tillate å opprette meir enn ei venekopling.\n"
 " Berre ei venekopling vart oppretta."
+
+#: src/GenericClientListCtrl.cpp
+msgid ""
+"One block per part of the file.\n"
+"Light grey: this source does not have the part.\n"
+"Green: this source has it and so do you.\n"
+"Amber: downloading this part from this source now.\n"
+"Pale yellow: the next part you will request from this source.\n"
+"Dark grey: this source has it and you still need it.\n"
+"The whole bar is dimmed while the download is stopped."
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid ""
+"One block per part of your shared file.\n"
+"Dark grey: this peer already has the part.\n"
+"Light grey: this peer does not have it."
+msgstr ""
 
 #: src/GenericClientListCtrl.cpp
 #, fuzzy, c-format
@@ -7361,10 +7379,9 @@ msgstr[1] "Fann %i kjende delte filer"
 msgid "User Name"
 msgstr "Brukarnamn"
 
-#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
-#, fuzzy
-msgid "Available Parts"
-msgstr "Tilgjengeleg:"
+#: src/SharedFilePeersListCtrl.cpp
+msgid "Parts on Peer"
+msgstr ""
 
 #: src/SharedFilePeersListCtrl.cpp
 #, fuzzy
@@ -7562,6 +7579,11 @@ msgstr "Delte filer (%i)"
 #, fuzzy, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "Lastar inn att lista over delte filer."
+
+#: src/SourceListCtrl.cpp
+#, fuzzy
+msgid "Part Status"
+msgstr "Status"
 
 #: src/SourceListCtrl.cpp
 #, fuzzy
@@ -9270,6 +9292,10 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#, fuzzy
+#~ msgid "Available Parts"
+#~ msgstr "Tilgjengeleg:"
 
 #, c-format
 #~ msgid "Found %i known shared file, %i unknown"

--- a/po/nn.po
+++ b/po/nn.po
@@ -2826,6 +2826,10 @@ msgid "One block per part of the shared file."
 msgstr "Skriv inn porten til tenaren her."
 
 #: src/GenericClientListCtrl.cpp
+msgid "Colour legend"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
 #, fuzzy, c-format
 msgid "On Queue: %u (%i)"
 msgstr "QR:·%u·(%i)"

--- a/po/pl.po
+++ b/po/pl.po
@@ -2821,6 +2821,10 @@ msgid "One block per part of the shared file."
 msgstr "Wpisz tu port serwera."
 
 #: src/GenericClientListCtrl.cpp
+msgid "Colour legend"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
 #, fuzzy, c-format
 msgid "On Queue: %u (%i)"
 msgstr "QR: %u (%i)"

--- a/po/pl.po
+++ b/po/pl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-29 20:55+0200\n"
+"POT-Creation-Date: 2026-08-30 16:16+0200\n"
 "PO-Revision-Date: 2026-08-25 10:15+0000\n"
 "Last-Translator: Michał Trzebiatowski <hippie_1968@hotmail.com>\n"
 "Language-Team: translationproject.org/team/pl.html <translation-team-pl@lists.sourceforge.net>\n"
@@ -2783,22 +2783,42 @@ msgstr ""
 "Przydzielono tylko jeden slot."
 
 #: src/GenericClientListCtrl.cpp
-msgid ""
-"One block per part of the file.\n"
-"Light grey: this source does not have the part.\n"
-"Green: this source has it and so do you.\n"
-"Amber: downloading this part from this source now.\n"
-"Pale yellow: the next part you will request from this source.\n"
-"Dark grey: this source has it and you still need it.\n"
-"The whole bar is dimmed while the download is stopped."
+#, fuzzy
+msgid "This source does not have the part"
+msgstr "Ta komenda nie powinna posiadać żadnego parametru."
+
+#: src/GenericClientListCtrl.cpp
+msgid "You and this source both have the part"
 msgstr ""
 
 #: src/GenericClientListCtrl.cpp
-msgid ""
-"One block per part of your shared file.\n"
-"Dark grey: this peer already has the part.\n"
-"Light grey: this peer does not have it."
+msgid "Being downloaded from this source now"
 msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "The next part that will be asked of this source"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "This source has the part and you still need it"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "This peer already has the part"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "This peer does not have the part"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "One block per part of the file being downloaded."
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+#, fuzzy
+msgid "One block per part of the shared file."
+msgstr "Wpisz tu port serwera."
 
 #: src/GenericClientListCtrl.cpp
 #, fuzzy, c-format

--- a/po/pl.po
+++ b/po/pl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 19:01+0200\n"
+"POT-Creation-Date: 2026-08-29 20:55+0200\n"
 "PO-Revision-Date: 2026-08-25 10:15+0000\n"
 "Last-Translator: Michał Trzebiatowski <hippie_1968@hotmail.com>\n"
 "Language-Team: translationproject.org/team/pl.html <translation-team-pl@lists.sourceforge.net>\n"
@@ -2781,6 +2781,24 @@ msgid ""
 msgstr ""
 "Nie możesz ustanowić więcej niż jeden slot dla znajomego.\n"
 "Przydzielono tylko jeden slot."
+
+#: src/GenericClientListCtrl.cpp
+msgid ""
+"One block per part of the file.\n"
+"Light grey: this source does not have the part.\n"
+"Green: this source has it and so do you.\n"
+"Amber: downloading this part from this source now.\n"
+"Pale yellow: the next part you will request from this source.\n"
+"Dark grey: this source has it and you still need it.\n"
+"The whole bar is dimmed while the download is stopped."
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid ""
+"One block per part of your shared file.\n"
+"Dark grey: this peer already has the part.\n"
+"Light grey: this peer does not have it."
+msgstr ""
 
 #: src/GenericClientListCtrl.cpp
 #, fuzzy, c-format
@@ -7374,9 +7392,9 @@ msgstr[2] "Znaleziono %i znanych udostępnionych plików"
 msgid "User Name"
 msgstr "Nazwa uzytkownika"
 
-#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
-msgid "Available Parts"
-msgstr "Dostępne części"
+#: src/SharedFilePeersListCtrl.cpp
+msgid "Parts on Peer"
+msgstr ""
 
 #: src/SharedFilePeersListCtrl.cpp
 #, fuzzy
@@ -7580,6 +7598,11 @@ msgstr "Udostępnione pliki (%i)"
 #, fuzzy, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "Przeładowuje listę udostępnionych plików."
+
+#: src/SourceListCtrl.cpp
+#, fuzzy
+msgid "Part Status"
+msgstr "Status"
 
 #: src/SourceListCtrl.cpp
 #, fuzzy
@@ -9271,6 +9294,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "Available Parts"
+#~ msgstr "Dostępne części"
 
 #, c-format
 #~ msgid "Found %i known shared file, %i unknown"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-29 20:55+0200\n"
+"POT-Creation-Date: 2026-08-30 16:16+0200\n"
 "PO-Revision-Date: 2026-08-25 10:15+0000\n"
 "Last-Translator: Marcelo Jimenez <mroberto@users.sourceforge.com>\n"
 "Language-Team: Português (Brasileiro) <pt@li.org>\n"
@@ -2770,22 +2770,42 @@ msgstr ""
 " Apenas um foi definido."
 
 #: src/GenericClientListCtrl.cpp
-msgid ""
-"One block per part of the file.\n"
-"Light grey: this source does not have the part.\n"
-"Green: this source has it and so do you.\n"
-"Amber: downloading this part from this source now.\n"
-"Pale yellow: the next part you will request from this source.\n"
-"Dark grey: this source has it and you still need it.\n"
-"The whole bar is dimmed while the download is stopped."
+#, fuzzy
+msgid "This source does not have the part"
+msgstr "Este comando não precisa de parâmetros."
+
+#: src/GenericClientListCtrl.cpp
+msgid "You and this source both have the part"
 msgstr ""
 
 #: src/GenericClientListCtrl.cpp
-msgid ""
-"One block per part of your shared file.\n"
-"Dark grey: this peer already has the part.\n"
-"Light grey: this peer does not have it."
+msgid "Being downloaded from this source now"
 msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "The next part that will be asked of this source"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "This source has the part and you still need it"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "This peer already has the part"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "This peer does not have the part"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "One block per part of the file being downloaded."
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+#, fuzzy
+msgid "One block per part of the shared file."
+msgstr "Informe a porta do servidor aqui."
 
 #: src/GenericClientListCtrl.cpp
 #, c-format

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 19:01+0200\n"
+"POT-Creation-Date: 2026-08-29 20:55+0200\n"
 "PO-Revision-Date: 2026-08-25 10:15+0000\n"
 "Last-Translator: Marcelo Jimenez <mroberto@users.sourceforge.com>\n"
 "Language-Team: Português (Brasileiro) <pt@li.org>\n"
@@ -2768,6 +2768,24 @@ msgid ""
 msgstr ""
 "Você não pode definir mais de um slot para amigos.\n"
 " Apenas um foi definido."
+
+#: src/GenericClientListCtrl.cpp
+msgid ""
+"One block per part of the file.\n"
+"Light grey: this source does not have the part.\n"
+"Green: this source has it and so do you.\n"
+"Amber: downloading this part from this source now.\n"
+"Pale yellow: the next part you will request from this source.\n"
+"Dark grey: this source has it and you still need it.\n"
+"The whole bar is dimmed while the download is stopped."
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid ""
+"One block per part of your shared file.\n"
+"Dark grey: this peer already has the part.\n"
+"Light grey: this peer does not have it."
+msgstr ""
 
 #: src/GenericClientListCtrl.cpp
 #, c-format
@@ -7253,9 +7271,9 @@ msgstr[1] "Encontrados %u novos arquivos compartilhados"
 msgid "User Name"
 msgstr "Nome de Usuário"
 
-#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
-msgid "Available Parts"
-msgstr "Partes Disponíveis"
+#: src/SharedFilePeersListCtrl.cpp
+msgid "Parts on Peer"
+msgstr ""
 
 #: src/SharedFilePeersListCtrl.cpp
 msgid "Upload Status"
@@ -7448,6 +7466,11 @@ msgstr "Arquivos Compartilhados (%i)"
 #, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "Recarregando arquivos compartilhados: %u arquivos encontrados"
+
+#: src/SourceListCtrl.cpp
+#, fuzzy
+msgid "Part Status"
+msgstr "Status"
 
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"
@@ -9158,6 +9181,9 @@ msgstr "O aMule parece estar rodando. Por favor, feche-o e rode o desinstalador 
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "Removendo os dados do usuário em $APPDATA\\aMule..."
+
+#~ msgid "Available Parts"
+#~ msgstr "Partes Disponíveis"
 
 #, c-format
 #~ msgid "Found %i known shared file, %i unknown"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -2808,6 +2808,10 @@ msgid "One block per part of the shared file."
 msgstr "Informe a porta do servidor aqui."
 
 #: src/GenericClientListCtrl.cpp
+msgid "Colour legend"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
 #, c-format
 msgid "On Queue: %u (%i)"
 msgstr "Em Fila: %u (%i)"

--- a/po/pt_PT.po
+++ b/po/pt_PT.po
@@ -17,7 +17,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 19:01+0200\n"
+"POT-Creation-Date: 2026-08-29 20:55+0200\n"
 "PO-Revision-Date: 2026-08-25 10:16+0000\n"
 "Last-Translator: Luís Picciochi Oliveira <Pitxyoki@Gmail.com>\n"
 "Language-Team: Portuguese <traduz@debianpt.org>\n"
@@ -2778,6 +2778,24 @@ msgid ""
 msgstr ""
 "Não lhe é permitido definir mais do que uma ligação de amigo.\n"
 " Apenas uma ligação foi atribuída."
+
+#: src/GenericClientListCtrl.cpp
+msgid ""
+"One block per part of the file.\n"
+"Light grey: this source does not have the part.\n"
+"Green: this source has it and so do you.\n"
+"Amber: downloading this part from this source now.\n"
+"Pale yellow: the next part you will request from this source.\n"
+"Dark grey: this source has it and you still need it.\n"
+"The whole bar is dimmed while the download is stopped."
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid ""
+"One block per part of your shared file.\n"
+"Dark grey: this peer already has the part.\n"
+"Light grey: this peer does not have it."
+msgstr ""
 
 #: src/GenericClientListCtrl.cpp
 #, c-format
@@ -7331,9 +7349,9 @@ msgstr[1] "Encontrados %i ficheiros partilhados conhecidos"
 msgid "User Name"
 msgstr "Nome de Utilizador"
 
-#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
-msgid "Available Parts"
-msgstr "Partes Disponíveis"
+#: src/SharedFilePeersListCtrl.cpp
+msgid "Parts on Peer"
+msgstr ""
 
 #: src/SharedFilePeersListCtrl.cpp
 msgid "Upload Status"
@@ -7528,6 +7546,11 @@ msgstr "Ficheiros Partilhados (%i)"
 #, fuzzy, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "Recarrega a lista de ficheiros partilhados."
+
+#: src/SourceListCtrl.cpp
+#, fuzzy
+msgid "Part Status"
+msgstr "Estado"
 
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"
@@ -9218,6 +9241,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "Available Parts"
+#~ msgstr "Partes Disponíveis"
 
 #, c-format
 #~ msgid "Found %i known shared file, %i unknown"

--- a/po/pt_PT.po
+++ b/po/pt_PT.po
@@ -17,7 +17,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-29 20:55+0200\n"
+"POT-Creation-Date: 2026-08-30 16:16+0200\n"
 "PO-Revision-Date: 2026-08-25 10:16+0000\n"
 "Last-Translator: Luís Picciochi Oliveira <Pitxyoki@Gmail.com>\n"
 "Language-Team: Portuguese <traduz@debianpt.org>\n"
@@ -2780,22 +2780,42 @@ msgstr ""
 " Apenas uma ligação foi atribuída."
 
 #: src/GenericClientListCtrl.cpp
-msgid ""
-"One block per part of the file.\n"
-"Light grey: this source does not have the part.\n"
-"Green: this source has it and so do you.\n"
-"Amber: downloading this part from this source now.\n"
-"Pale yellow: the next part you will request from this source.\n"
-"Dark grey: this source has it and you still need it.\n"
-"The whole bar is dimmed while the download is stopped."
+#, fuzzy
+msgid "This source does not have the part"
+msgstr "Este comando não deveria ter quaisquer parâmetros."
+
+#: src/GenericClientListCtrl.cpp
+msgid "You and this source both have the part"
 msgstr ""
 
 #: src/GenericClientListCtrl.cpp
-msgid ""
-"One block per part of your shared file.\n"
-"Dark grey: this peer already has the part.\n"
-"Light grey: this peer does not have it."
+msgid "Being downloaded from this source now"
 msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "The next part that will be asked of this source"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "This source has the part and you still need it"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "This peer already has the part"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "This peer does not have the part"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "One block per part of the file being downloaded."
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+#, fuzzy
+msgid "One block per part of the shared file."
+msgstr "Insira o porto do servidor."
 
 #: src/GenericClientListCtrl.cpp
 #, c-format

--- a/po/pt_PT.po
+++ b/po/pt_PT.po
@@ -2818,6 +2818,10 @@ msgid "One block per part of the shared file."
 msgstr "Insira o porto do servidor."
 
 #: src/GenericClientListCtrl.cpp
+msgid "Colour legend"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
 #, c-format
 msgid "On Queue: %u (%i)"
 msgstr "Na Fila: %u (%i)"

--- a/po/ro.po
+++ b/po/ro.po
@@ -2816,6 +2816,10 @@ msgid "One block per part of the shared file."
 msgstr "Introduceți aici portul serverului."
 
 #: src/GenericClientListCtrl.cpp
+msgid "Colour legend"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
 #, c-format
 msgid "On Queue: %u (%i)"
 msgstr "În coadă: %u (%i)"

--- a/po/ro.po
+++ b/po/ro.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-29 20:55+0200\n"
+"POT-Creation-Date: 2026-08-30 16:16+0200\n"
 "PO-Revision-Date: 2026-08-25 10:17+0000\n"
 "Last-Translator: Angelescu Constantin <titus0818@yahoo.com>\n"
 "Language-Team: English <kde-i18n-doc@kde.org>\n"
@@ -2778,22 +2778,42 @@ msgstr ""
 "A fost alocat numai un singur slot."
 
 #: src/GenericClientListCtrl.cpp
-msgid ""
-"One block per part of the file.\n"
-"Light grey: this source does not have the part.\n"
-"Green: this source has it and so do you.\n"
-"Amber: downloading this part from this source now.\n"
-"Pale yellow: the next part you will request from this source.\n"
-"Dark grey: this source has it and you still need it.\n"
-"The whole bar is dimmed while the download is stopped."
+#, fuzzy
+msgid "This source does not have the part"
+msgstr "Această comandă nu ar trebui să aibă niciun parametru."
+
+#: src/GenericClientListCtrl.cpp
+msgid "You and this source both have the part"
 msgstr ""
 
 #: src/GenericClientListCtrl.cpp
-msgid ""
-"One block per part of your shared file.\n"
-"Dark grey: this peer already has the part.\n"
-"Light grey: this peer does not have it."
+msgid "Being downloaded from this source now"
 msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "The next part that will be asked of this source"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "This source has the part and you still need it"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "This peer already has the part"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "This peer does not have the part"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "One block per part of the file being downloaded."
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+#, fuzzy
+msgid "One block per part of the shared file."
+msgstr "Introduceți aici portul serverului."
 
 #: src/GenericClientListCtrl.cpp
 #, c-format

--- a/po/ro.po
+++ b/po/ro.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 19:01+0200\n"
+"POT-Creation-Date: 2026-08-29 20:55+0200\n"
 "PO-Revision-Date: 2026-08-25 10:17+0000\n"
 "Last-Translator: Angelescu Constantin <titus0818@yahoo.com>\n"
 "Language-Team: English <kde-i18n-doc@kde.org>\n"
@@ -2776,6 +2776,24 @@ msgid ""
 msgstr ""
 "Nu vă este permis să configurați mai mult de un slot prieten.\n"
 "A fost alocat numai un singur slot."
+
+#: src/GenericClientListCtrl.cpp
+msgid ""
+"One block per part of the file.\n"
+"Light grey: this source does not have the part.\n"
+"Green: this source has it and so do you.\n"
+"Amber: downloading this part from this source now.\n"
+"Pale yellow: the next part you will request from this source.\n"
+"Dark grey: this source has it and you still need it.\n"
+"The whole bar is dimmed while the download is stopped."
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid ""
+"One block per part of your shared file.\n"
+"Dark grey: this peer already has the part.\n"
+"Light grey: this peer does not have it."
+msgstr ""
 
 #: src/GenericClientListCtrl.cpp
 #, c-format
@@ -7354,9 +7372,9 @@ msgstr[2] "S-au găsit %i de fișiere partajate cunoscute"
 msgid "User Name"
 msgstr "Nume utilizator"
 
-#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
-msgid "Available Parts"
-msgstr "Părți disponibile"
+#: src/SharedFilePeersListCtrl.cpp
+msgid "Parts on Peer"
+msgstr ""
 
 #: src/SharedFilePeersListCtrl.cpp
 msgid "Upload Status"
@@ -7557,6 +7575,11 @@ msgstr "Fișiere partajate (%i)"
 #, fuzzy, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "Reîncarcă lista fișierelor partajate."
+
+#: src/SourceListCtrl.cpp
+#, fuzzy
+msgid "Part Status"
+msgstr "Stare"
 
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"
@@ -9249,6 +9272,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "Available Parts"
+#~ msgstr "Părți disponibile"
 
 #, c-format
 #~ msgid "Found %i known shared file, %i unknown"

--- a/po/ru.po
+++ b/po/ru.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 19:01+0200\n"
+"POT-Creation-Date: 2026-08-29 20:55+0200\n"
 "PO-Revision-Date: 2026-08-26 20:30+0000\n"
 "Last-Translator: Radist Morse <radist.morse@gmail.com>\n"
 "Language-Team: Russian <kde-russian@lists.kde.ru>\n"
@@ -2784,6 +2784,24 @@ msgid ""
 msgstr ""
 "Устанавка более одного слота для друзей запрещена.\n"
 " Был выделен только один слот."
+
+#: src/GenericClientListCtrl.cpp
+msgid ""
+"One block per part of the file.\n"
+"Light grey: this source does not have the part.\n"
+"Green: this source has it and so do you.\n"
+"Amber: downloading this part from this source now.\n"
+"Pale yellow: the next part you will request from this source.\n"
+"Dark grey: this source has it and you still need it.\n"
+"The whole bar is dimmed while the download is stopped."
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid ""
+"One block per part of your shared file.\n"
+"Dark grey: this peer already has the part.\n"
+"Light grey: this peer does not have it."
+msgstr ""
 
 #: src/GenericClientListCtrl.cpp
 #, c-format
@@ -7319,9 +7337,9 @@ msgstr[2] "Обнаружено %u новых публикуемых файло�
 msgid "User Name"
 msgstr "Имя пользователя"
 
-#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
-msgid "Available Parts"
-msgstr "Доступные части"
+#: src/SharedFilePeersListCtrl.cpp
+msgid "Parts on Peer"
+msgstr ""
 
 #: src/SharedFilePeersListCtrl.cpp
 msgid "Upload Status"
@@ -7523,6 +7541,11 @@ msgstr "Общие файлы (%i)"
 #, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "Переподгрузка общих файлов: просканировано файлов — %u"
+
+#: src/SourceListCtrl.cpp
+#, fuzzy
+msgid "Part Status"
+msgstr "Состояние"
 
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"
@@ -9237,6 +9260,9 @@ msgstr "Похоже, что aMule запущен. Закройте его и п
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "Удаление пользовательских данных в $APPDATA\\aMule…"
+
+#~ msgid "Available Parts"
+#~ msgstr "Доступные части"
 
 #, c-format
 #~ msgid "Found %i known shared file, %i unknown"

--- a/po/ru.po
+++ b/po/ru.po
@@ -2824,6 +2824,10 @@ msgid "One block per part of the shared file."
 msgstr "Введите здесь порт сервера."
 
 #: src/GenericClientListCtrl.cpp
+msgid "Colour legend"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
 #, c-format
 msgid "On Queue: %u (%i)"
 msgstr "В очереди: %u (%i)"

--- a/po/ru.po
+++ b/po/ru.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-29 20:55+0200\n"
+"POT-Creation-Date: 2026-08-30 16:16+0200\n"
 "PO-Revision-Date: 2026-08-26 20:30+0000\n"
 "Last-Translator: Radist Morse <radist.morse@gmail.com>\n"
 "Language-Team: Russian <kde-russian@lists.kde.ru>\n"
@@ -2786,22 +2786,42 @@ msgstr ""
 " Был выделен только один слот."
 
 #: src/GenericClientListCtrl.cpp
-msgid ""
-"One block per part of the file.\n"
-"Light grey: this source does not have the part.\n"
-"Green: this source has it and so do you.\n"
-"Amber: downloading this part from this source now.\n"
-"Pale yellow: the next part you will request from this source.\n"
-"Dark grey: this source has it and you still need it.\n"
-"The whole bar is dimmed while the download is stopped."
+#, fuzzy
+msgid "This source does not have the part"
+msgstr "У этой команды не должно быть параметров."
+
+#: src/GenericClientListCtrl.cpp
+msgid "You and this source both have the part"
 msgstr ""
 
 #: src/GenericClientListCtrl.cpp
-msgid ""
-"One block per part of your shared file.\n"
-"Dark grey: this peer already has the part.\n"
-"Light grey: this peer does not have it."
+msgid "Being downloaded from this source now"
 msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "The next part that will be asked of this source"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "This source has the part and you still need it"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "This peer already has the part"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "This peer does not have the part"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "One block per part of the file being downloaded."
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+#, fuzzy
+msgid "One block per part of the shared file."
+msgstr "Введите здесь порт сервера."
 
 #: src/GenericClientListCtrl.cpp
 #, c-format

--- a/po/sl.po
+++ b/po/sl.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 19:01+0200\n"
+"POT-Creation-Date: 2026-08-29 20:55+0200\n"
 "PO-Revision-Date: 2026-08-25 10:18+0000\n"
 "Last-Translator: Jure Repinc <jlp@holodeck1.com>\n"
 "Language-Team: Slovenian\n"
@@ -2792,6 +2792,24 @@ msgid ""
 msgstr ""
 "Ne morete dodeliti več kot enega mesta za prijatelja.\n"
 "Samo eno mesto je bilo dodeljeno."
+
+#: src/GenericClientListCtrl.cpp
+msgid ""
+"One block per part of the file.\n"
+"Light grey: this source does not have the part.\n"
+"Green: this source has it and so do you.\n"
+"Amber: downloading this part from this source now.\n"
+"Pale yellow: the next part you will request from this source.\n"
+"Dark grey: this source has it and you still need it.\n"
+"The whole bar is dimmed while the download is stopped."
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid ""
+"One block per part of your shared file.\n"
+"Dark grey: this peer already has the part.\n"
+"Light grey: this peer does not have it."
+msgstr ""
 
 #: src/GenericClientListCtrl.cpp
 #, c-format
@@ -7404,9 +7422,9 @@ msgstr[3] "Najdene %i znane deljene datoteke"
 msgid "User Name"
 msgstr "Uporabniško ime"
 
-#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
-msgid "Available Parts"
-msgstr "Razpoložljivi deli"
+#: src/SharedFilePeersListCtrl.cpp
+msgid "Parts on Peer"
+msgstr ""
 
 #: src/SharedFilePeersListCtrl.cpp
 msgid "Upload Status"
@@ -7614,6 +7632,11 @@ msgstr "Deljene datoteke (%i)"
 #, fuzzy, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "Ponovno naloži seznam deljenih datotek."
+
+#: src/SourceListCtrl.cpp
+#, fuzzy
+msgid "Part Status"
+msgstr "Stanje"
 
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"
@@ -9302,6 +9325,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "Available Parts"
+#~ msgstr "Razpoložljivi deli"
 
 #, c-format
 #~ msgid "Found %i known shared file, %i unknown"

--- a/po/sl.po
+++ b/po/sl.po
@@ -2832,6 +2832,10 @@ msgid "One block per part of the shared file."
 msgstr "Sem vnesite vrata strežnika."
 
 #: src/GenericClientListCtrl.cpp
+msgid "Colour legend"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
 #, c-format
 msgid "On Queue: %u (%i)"
 msgstr "V vrsti: %u (%i)"

--- a/po/sl.po
+++ b/po/sl.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-29 20:55+0200\n"
+"POT-Creation-Date: 2026-08-30 16:16+0200\n"
 "PO-Revision-Date: 2026-08-25 10:18+0000\n"
 "Last-Translator: Jure Repinc <jlp@holodeck1.com>\n"
 "Language-Team: Slovenian\n"
@@ -2794,22 +2794,42 @@ msgstr ""
 "Samo eno mesto je bilo dodeljeno."
 
 #: src/GenericClientListCtrl.cpp
-msgid ""
-"One block per part of the file.\n"
-"Light grey: this source does not have the part.\n"
-"Green: this source has it and so do you.\n"
-"Amber: downloading this part from this source now.\n"
-"Pale yellow: the next part you will request from this source.\n"
-"Dark grey: this source has it and you still need it.\n"
-"The whole bar is dimmed while the download is stopped."
+#, fuzzy
+msgid "This source does not have the part"
+msgstr "Ta ukaz ne sme imeti parametrov."
+
+#: src/GenericClientListCtrl.cpp
+msgid "You and this source both have the part"
 msgstr ""
 
 #: src/GenericClientListCtrl.cpp
-msgid ""
-"One block per part of your shared file.\n"
-"Dark grey: this peer already has the part.\n"
-"Light grey: this peer does not have it."
+msgid "Being downloaded from this source now"
 msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "The next part that will be asked of this source"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "This source has the part and you still need it"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "This peer already has the part"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "This peer does not have the part"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "One block per part of the file being downloaded."
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+#, fuzzy
+msgid "One block per part of the shared file."
+msgstr "Sem vnesite vrata strežnika."
 
 #: src/GenericClientListCtrl.cpp
 #, c-format

--- a/po/sq.po
+++ b/po/sq.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-29 20:55+0200\n"
+"POT-Creation-Date: 2026-08-30 16:16+0200\n"
 "PO-Revision-Date: 2026-08-25 10:18+0000\n"
 "Last-Translator: Fation <dj_barthezz@linuxmail.org lushnja_corps@hotmail.Language-Team:\n"
 "Language: sq\n"
@@ -2782,22 +2782,42 @@ msgstr ""
 " Vetem nje slot i vetem u vendos."
 
 #: src/GenericClientListCtrl.cpp
-msgid ""
-"One block per part of the file.\n"
-"Light grey: this source does not have the part.\n"
-"Green: this source has it and so do you.\n"
-"Amber: downloading this part from this source now.\n"
-"Pale yellow: the next part you will request from this source.\n"
-"Dark grey: this source has it and you still need it.\n"
-"The whole bar is dimmed while the download is stopped."
+#, fuzzy
+msgid "This source does not have the part"
+msgstr "Kjo komande nuk duhet te kete parametra."
+
+#: src/GenericClientListCtrl.cpp
+msgid "You and this source both have the part"
 msgstr ""
 
 #: src/GenericClientListCtrl.cpp
-msgid ""
-"One block per part of your shared file.\n"
-"Dark grey: this peer already has the part.\n"
-"Light grey: this peer does not have it."
+msgid "Being downloaded from this source now"
 msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "The next part that will be asked of this source"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "This source has the part and you still need it"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "This peer already has the part"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "This peer does not have the part"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "One block per part of the file being downloaded."
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+#, fuzzy
+msgid "One block per part of the shared file."
+msgstr "Futni porten e serverit ketu."
 
 #: src/GenericClientListCtrl.cpp
 #, fuzzy, c-format

--- a/po/sq.po
+++ b/po/sq.po
@@ -2820,6 +2820,10 @@ msgid "One block per part of the shared file."
 msgstr "Futni porten e serverit ketu."
 
 #: src/GenericClientListCtrl.cpp
+msgid "Colour legend"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
 #, fuzzy, c-format
 msgid "On Queue: %u (%i)"
 msgstr "QR: %u (%i)"

--- a/po/sq.po
+++ b/po/sq.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 19:01+0200\n"
+"POT-Creation-Date: 2026-08-29 20:55+0200\n"
 "PO-Revision-Date: 2026-08-25 10:18+0000\n"
 "Last-Translator: Fation <dj_barthezz@linuxmail.org lushnja_corps@hotmail.Language-Team:\n"
 "Language: sq\n"
@@ -2780,6 +2780,24 @@ msgid ""
 msgstr ""
 "Ju nuk lejoheni qe te vendosni me shume se nje slot per shoket.\n"
 " Vetem nje slot i vetem u vendos."
+
+#: src/GenericClientListCtrl.cpp
+msgid ""
+"One block per part of the file.\n"
+"Light grey: this source does not have the part.\n"
+"Green: this source has it and so do you.\n"
+"Amber: downloading this part from this source now.\n"
+"Pale yellow: the next part you will request from this source.\n"
+"Dark grey: this source has it and you still need it.\n"
+"The whole bar is dimmed while the download is stopped."
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid ""
+"One block per part of your shared file.\n"
+"Dark grey: this peer already has the part.\n"
+"Light grey: this peer does not have it."
+msgstr ""
 
 #: src/GenericClientListCtrl.cpp
 #, fuzzy, c-format
@@ -7351,10 +7369,9 @@ msgstr[1] "U gjenden %i faile te njohura te ndara"
 msgid "User Name"
 msgstr "Emri i Perdoruesit"
 
-#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
-#, fuzzy
-msgid "Available Parts"
-msgstr "Te disponueshem :"
+#: src/SharedFilePeersListCtrl.cpp
+msgid "Parts on Peer"
+msgstr ""
 
 #: src/SharedFilePeersListCtrl.cpp
 #, fuzzy
@@ -7552,6 +7569,11 @@ msgstr "Faile te ndara (%i)"
 #, fuzzy, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "Ringarko listen e faileve te ndara."
+
+#: src/SourceListCtrl.cpp
+#, fuzzy
+msgid "Part Status"
+msgstr "Gjendja"
 
 #: src/SourceListCtrl.cpp
 #, fuzzy
@@ -9241,6 +9263,10 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#, fuzzy
+#~ msgid "Available Parts"
+#~ msgstr "Te disponueshem :"
 
 #, c-format
 #~ msgid "Found %i known shared file, %i unknown"

--- a/po/sv.po
+++ b/po/sv.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 19:01+0200\n"
+"POT-Creation-Date: 2026-08-29 20:55+0200\n"
 "PO-Revision-Date: 2026-08-25 10:19+0000\n"
 "Last-Translator: raffe <raffe@localhost.se>\n"
 "Language-Team: Swedish <tp-sv@listor.tp-sv.se>\n"
@@ -2770,6 +2770,24 @@ msgid ""
 msgstr ""
 "Du kan endast ha ett vän-spår.\n"
 " Endast ett spår tilldelades. "
+
+#: src/GenericClientListCtrl.cpp
+msgid ""
+"One block per part of the file.\n"
+"Light grey: this source does not have the part.\n"
+"Green: this source has it and so do you.\n"
+"Amber: downloading this part from this source now.\n"
+"Pale yellow: the next part you will request from this source.\n"
+"Dark grey: this source has it and you still need it.\n"
+"The whole bar is dimmed while the download is stopped."
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid ""
+"One block per part of your shared file.\n"
+"Dark grey: this peer already has the part.\n"
+"Light grey: this peer does not have it."
+msgstr ""
 
 #: src/GenericClientListCtrl.cpp
 #, c-format
@@ -7318,9 +7336,9 @@ msgstr[1] "Hittade %i kända delad filer"
 msgid "User Name"
 msgstr "Användarnamn"
 
-#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
-msgid "Available Parts"
-msgstr "Tillgängliga delar"
+#: src/SharedFilePeersListCtrl.cpp
+msgid "Parts on Peer"
+msgstr ""
 
 #: src/SharedFilePeersListCtrl.cpp
 msgid "Upload Status"
@@ -7514,6 +7532,11 @@ msgstr "Utdelade filer (%i)"
 #, fuzzy, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "Ladda om listan med delade filer."
+
+#: src/SourceListCtrl.cpp
+#, fuzzy
+msgid "Part Status"
+msgstr "Status"
 
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"
@@ -9206,6 +9229,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "Available Parts"
+#~ msgstr "Tillgängliga delar"
 
 #, c-format
 #~ msgid "Found %i known shared file, %i unknown"

--- a/po/sv.po
+++ b/po/sv.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-29 20:55+0200\n"
+"POT-Creation-Date: 2026-08-30 16:16+0200\n"
 "PO-Revision-Date: 2026-08-25 10:19+0000\n"
 "Last-Translator: raffe <raffe@localhost.se>\n"
 "Language-Team: Swedish <tp-sv@listor.tp-sv.se>\n"
@@ -2772,22 +2772,42 @@ msgstr ""
 " Endast ett spår tilldelades. "
 
 #: src/GenericClientListCtrl.cpp
-msgid ""
-"One block per part of the file.\n"
-"Light grey: this source does not have the part.\n"
-"Green: this source has it and so do you.\n"
-"Amber: downloading this part from this source now.\n"
-"Pale yellow: the next part you will request from this source.\n"
-"Dark grey: this source has it and you still need it.\n"
-"The whole bar is dimmed while the download is stopped."
+#, fuzzy
+msgid "This source does not have the part"
+msgstr "Det här kommandot ska inte ha några parametrar."
+
+#: src/GenericClientListCtrl.cpp
+msgid "You and this source both have the part"
 msgstr ""
 
 #: src/GenericClientListCtrl.cpp
-msgid ""
-"One block per part of your shared file.\n"
-"Dark grey: this peer already has the part.\n"
-"Light grey: this peer does not have it."
+msgid "Being downloaded from this source now"
 msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "The next part that will be asked of this source"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "This source has the part and you still need it"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "This peer already has the part"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "This peer does not have the part"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "One block per part of the file being downloaded."
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+#, fuzzy
+msgid "One block per part of the shared file."
+msgstr "Ange porten på servern här."
 
 #: src/GenericClientListCtrl.cpp
 #, c-format

--- a/po/sv.po
+++ b/po/sv.po
@@ -2810,6 +2810,10 @@ msgid "One block per part of the shared file."
 msgstr "Ange porten på servern här."
 
 #: src/GenericClientListCtrl.cpp
+msgid "Colour legend"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
 #, c-format
 msgid "On Queue: %u (%i)"
 msgstr "På kö: %u (%i)"

--- a/po/ta.po
+++ b/po/ta.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-29 20:55+0200\n"
+"POT-Creation-Date: 2026-08-30 16:16+0200\n"
 "PO-Revision-Date: 2026-08-25 10:23+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -2677,21 +2677,39 @@ msgid ""
 msgstr ""
 
 #: src/GenericClientListCtrl.cpp
-msgid ""
-"One block per part of the file.\n"
-"Light grey: this source does not have the part.\n"
-"Green: this source has it and so do you.\n"
-"Amber: downloading this part from this source now.\n"
-"Pale yellow: the next part you will request from this source.\n"
-"Dark grey: this source has it and you still need it.\n"
-"The whole bar is dimmed while the download is stopped."
+msgid "This source does not have the part"
 msgstr ""
 
 #: src/GenericClientListCtrl.cpp
-msgid ""
-"One block per part of your shared file.\n"
-"Dark grey: this peer already has the part.\n"
-"Light grey: this peer does not have it."
+msgid "You and this source both have the part"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "Being downloaded from this source now"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "The next part that will be asked of this source"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "This source has the part and you still need it"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "This peer already has the part"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "This peer does not have the part"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "One block per part of the file being downloaded."
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "One block per part of the shared file."
 msgstr ""
 
 #: src/GenericClientListCtrl.cpp

--- a/po/ta.po
+++ b/po/ta.po
@@ -2713,6 +2713,10 @@ msgid "One block per part of the shared file."
 msgstr ""
 
 #: src/GenericClientListCtrl.cpp
+msgid "Colour legend"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
 #, c-format
 msgid "On Queue: %u (%i)"
 msgstr ""

--- a/po/ta.po
+++ b/po/ta.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 19:01+0200\n"
+"POT-Creation-Date: 2026-08-29 20:55+0200\n"
 "PO-Revision-Date: 2026-08-25 10:23+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -2674,6 +2674,24 @@ msgstr ""
 msgid ""
 "You are not allowed to set more than one friendslot.\n"
 " Only one slot was assigned."
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid ""
+"One block per part of the file.\n"
+"Light grey: this source does not have the part.\n"
+"Green: this source has it and so do you.\n"
+"Amber: downloading this part from this source now.\n"
+"Pale yellow: the next part you will request from this source.\n"
+"Dark grey: this source has it and you still need it.\n"
+"The whole bar is dimmed while the download is stopped."
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid ""
+"One block per part of your shared file.\n"
+"Dark grey: this peer already has the part.\n"
+"Light grey: this peer does not have it."
 msgstr ""
 
 #: src/GenericClientListCtrl.cpp
@@ -7107,8 +7125,8 @@ msgstr[1] "பயனர் %s (%u) பகிர்ந்த கோப்பக�
 msgid "User Name"
 msgstr ""
 
-#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
-msgid "Available Parts"
+#: src/SharedFilePeersListCtrl.cpp
+msgid "Parts on Peer"
 msgstr ""
 
 #: src/SharedFilePeersListCtrl.cpp
@@ -7301,6 +7319,10 @@ msgstr ""
 #: src/SharedFilesReloadProgress.cpp
 #, c-format
 msgid "Reloading shared files: %u files scanned"
+msgstr ""
+
+#: src/SourceListCtrl.cpp
+msgid "Part Status"
 msgstr ""
 
 #: src/SourceListCtrl.cpp

--- a/po/tr.po
+++ b/po/tr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-29 20:55+0200\n"
+"POT-Creation-Date: 2026-08-30 16:16+0200\n"
 "PO-Revision-Date: 2026-08-25 10:19+0000\n"
 "Last-Translator: \n"
 "Language-Team: Turkish <li@li.org>\n"
@@ -2762,22 +2762,42 @@ msgstr ""
 "Sadece bir slot kuruldu."
 
 #: src/GenericClientListCtrl.cpp
-msgid ""
-"One block per part of the file.\n"
-"Light grey: this source does not have the part.\n"
-"Green: this source has it and so do you.\n"
-"Amber: downloading this part from this source now.\n"
-"Pale yellow: the next part you will request from this source.\n"
-"Dark grey: this source has it and you still need it.\n"
-"The whole bar is dimmed while the download is stopped."
+#, fuzzy
+msgid "This source does not have the part"
+msgstr "Bu komut herhangi bir parametre içermemeli."
+
+#: src/GenericClientListCtrl.cpp
+msgid "You and this source both have the part"
 msgstr ""
 
 #: src/GenericClientListCtrl.cpp
-msgid ""
-"One block per part of your shared file.\n"
-"Dark grey: this peer already has the part.\n"
-"Light grey: this peer does not have it."
+msgid "Being downloaded from this source now"
 msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "The next part that will be asked of this source"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "This source has the part and you still need it"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "This peer already has the part"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "This peer does not have the part"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "One block per part of the file being downloaded."
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+#, fuzzy
+msgid "One block per part of the shared file."
+msgstr "Sunucunu portunu buraya giriniz."
 
 #: src/GenericClientListCtrl.cpp
 #, c-format

--- a/po/tr.po
+++ b/po/tr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 19:01+0200\n"
+"POT-Creation-Date: 2026-08-29 20:55+0200\n"
 "PO-Revision-Date: 2026-08-25 10:19+0000\n"
 "Last-Translator: \n"
 "Language-Team: Turkish <li@li.org>\n"
@@ -2760,6 +2760,24 @@ msgid ""
 msgstr ""
 "Birden fazla arkadaş slotu kuramazsınız.\n"
 "Sadece bir slot kuruldu."
+
+#: src/GenericClientListCtrl.cpp
+msgid ""
+"One block per part of the file.\n"
+"Light grey: this source does not have the part.\n"
+"Green: this source has it and so do you.\n"
+"Amber: downloading this part from this source now.\n"
+"Pale yellow: the next part you will request from this source.\n"
+"Dark grey: this source has it and you still need it.\n"
+"The whole bar is dimmed while the download is stopped."
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid ""
+"One block per part of your shared file.\n"
+"Dark grey: this peer already has the part.\n"
+"Light grey: this peer does not have it."
+msgstr ""
 
 #: src/GenericClientListCtrl.cpp
 #, c-format
@@ -7245,9 +7263,9 @@ msgstr[1] "Yeni paylaşılan %u dosya bulundu"
 msgid "User Name"
 msgstr "Kullanıcı Adı"
 
-#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
-msgid "Available Parts"
-msgstr "Erişilebilir Parçalar"
+#: src/SharedFilePeersListCtrl.cpp
+msgid "Parts on Peer"
+msgstr ""
 
 #: src/SharedFilePeersListCtrl.cpp
 msgid "Upload Status"
@@ -7440,6 +7458,11 @@ msgstr "Paylaşılan Dosyalar (%i)"
 #, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "Paylaşılmış dosyalar yeniden yükleniyor: %u dosya tarandı"
+
+#: src/SourceListCtrl.cpp
+#, fuzzy
+msgid "Part Status"
+msgstr "Durum"
 
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"
@@ -9150,6 +9173,9 @@ msgstr "aMule çalışmakta gibi görünüyor. Lütfen onu kapatıp kurulum prog
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "Kullanıcı verileri $APPDATA\\aMule konumunda kaldırılıyor…"
+
+#~ msgid "Available Parts"
+#~ msgstr "Erişilebilir Parçalar"
 
 #, c-format
 #~ msgid "Found %i known shared file, %i unknown"

--- a/po/tr.po
+++ b/po/tr.po
@@ -2800,6 +2800,10 @@ msgid "One block per part of the shared file."
 msgstr "Sunucunu portunu buraya giriniz."
 
 #: src/GenericClientListCtrl.cpp
+msgid "Colour legend"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
 #, c-format
 msgid "On Queue: %u (%i)"
 msgstr "Sırada: %u (%i)"

--- a/po/uk.po
+++ b/po/uk.po
@@ -2830,6 +2830,10 @@ msgid "One block per part of the shared file."
 msgstr "Введіть тут порт сервера."
 
 #: src/GenericClientListCtrl.cpp
+msgid "Colour legend"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
 #, fuzzy, c-format
 msgid "On Queue: %u (%i)"
 msgstr "QR: %u (%i)"

--- a/po/uk.po
+++ b/po/uk.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 19:01+0200\n"
+"POT-Creation-Date: 2026-08-29 20:55+0200\n"
 "PO-Revision-Date: 2026-08-25 10:20+0000\n"
 "Last-Translator: Oleksandr Kovalenko <alx.kovalenko@gmail.com>\n"
 "Language-Team: Ukrainian <translation@linux.org.ua>\n"
@@ -2790,6 +2790,24 @@ msgid ""
 msgstr ""
 "Встановлення більш ніж одного шматка для друга не дозволено.\n"
 "Був виділений тільки один слот."
+
+#: src/GenericClientListCtrl.cpp
+msgid ""
+"One block per part of the file.\n"
+"Light grey: this source does not have the part.\n"
+"Green: this source has it and so do you.\n"
+"Amber: downloading this part from this source now.\n"
+"Pale yellow: the next part you will request from this source.\n"
+"Dark grey: this source has it and you still need it.\n"
+"The whole bar is dimmed while the download is stopped."
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid ""
+"One block per part of your shared file.\n"
+"Dark grey: this peer already has the part.\n"
+"Light grey: this peer does not have it."
+msgstr ""
 
 #: src/GenericClientListCtrl.cpp
 #, fuzzy, c-format
@@ -7400,10 +7418,9 @@ msgstr[2] "Знайдено %i нових спільних файлів"
 msgid "User Name"
 msgstr "Ім'я користувача"
 
-#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
-#, fuzzy
-msgid "Available Parts"
-msgstr "Наявні:"
+#: src/SharedFilePeersListCtrl.cpp
+msgid "Parts on Peer"
+msgstr ""
 
 #: src/SharedFilePeersListCtrl.cpp
 #, fuzzy
@@ -7608,6 +7625,11 @@ msgstr "Спільні файли (%i)"
 #, fuzzy, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "Перезавантажується перелік спільних файлів."
+
+#: src/SourceListCtrl.cpp
+#, fuzzy
+msgid "Part Status"
+msgstr "Стан"
 
 #: src/SourceListCtrl.cpp
 #, fuzzy
@@ -9318,6 +9340,10 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#, fuzzy
+#~ msgid "Available Parts"
+#~ msgstr "Наявні:"
 
 #, c-format
 #~ msgid "Found %i known shared file, %i unknown"

--- a/po/uk.po
+++ b/po/uk.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-29 20:55+0200\n"
+"POT-Creation-Date: 2026-08-30 16:16+0200\n"
 "PO-Revision-Date: 2026-08-25 10:20+0000\n"
 "Last-Translator: Oleksandr Kovalenko <alx.kovalenko@gmail.com>\n"
 "Language-Team: Ukrainian <translation@linux.org.ua>\n"
@@ -2792,22 +2792,42 @@ msgstr ""
 "Був виділений тільки один слот."
 
 #: src/GenericClientListCtrl.cpp
-msgid ""
-"One block per part of the file.\n"
-"Light grey: this source does not have the part.\n"
-"Green: this source has it and so do you.\n"
-"Amber: downloading this part from this source now.\n"
-"Pale yellow: the next part you will request from this source.\n"
-"Dark grey: this source has it and you still need it.\n"
-"The whole bar is dimmed while the download is stopped."
+#, fuzzy
+msgid "This source does not have the part"
+msgstr "Ця команда не повинна мати жодного параметру."
+
+#: src/GenericClientListCtrl.cpp
+msgid "You and this source both have the part"
 msgstr ""
 
 #: src/GenericClientListCtrl.cpp
-msgid ""
-"One block per part of your shared file.\n"
-"Dark grey: this peer already has the part.\n"
-"Light grey: this peer does not have it."
+msgid "Being downloaded from this source now"
 msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "The next part that will be asked of this source"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "This source has the part and you still need it"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "This peer already has the part"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "This peer does not have the part"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "One block per part of the file being downloaded."
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+#, fuzzy
+msgid "One block per part of the shared file."
+msgstr "Введіть тут порт сервера."
 
 #: src/GenericClientListCtrl.cpp
 #, fuzzy, c-format

--- a/po/vi.po
+++ b/po/vi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-29 20:55+0200\n"
+"POT-Creation-Date: 2026-08-30 16:16+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -2676,21 +2676,39 @@ msgid ""
 msgstr ""
 
 #: src/GenericClientListCtrl.cpp
-msgid ""
-"One block per part of the file.\n"
-"Light grey: this source does not have the part.\n"
-"Green: this source has it and so do you.\n"
-"Amber: downloading this part from this source now.\n"
-"Pale yellow: the next part you will request from this source.\n"
-"Dark grey: this source has it and you still need it.\n"
-"The whole bar is dimmed while the download is stopped."
+msgid "This source does not have the part"
 msgstr ""
 
 #: src/GenericClientListCtrl.cpp
-msgid ""
-"One block per part of your shared file.\n"
-"Dark grey: this peer already has the part.\n"
-"Light grey: this peer does not have it."
+msgid "You and this source both have the part"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "Being downloaded from this source now"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "The next part that will be asked of this source"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "This source has the part and you still need it"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "This peer already has the part"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "This peer does not have the part"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "One block per part of the file being downloaded."
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "One block per part of the shared file."
 msgstr ""
 
 #: src/GenericClientListCtrl.cpp

--- a/po/vi.po
+++ b/po/vi.po
@@ -2712,6 +2712,10 @@ msgid "One block per part of the shared file."
 msgstr ""
 
 #: src/GenericClientListCtrl.cpp
+msgid "Colour legend"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
 #, c-format
 msgid "On Queue: %u (%i)"
 msgstr ""

--- a/po/vi.po
+++ b/po/vi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 19:01+0200\n"
+"POT-Creation-Date: 2026-08-29 20:55+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -2673,6 +2673,24 @@ msgstr ""
 msgid ""
 "You are not allowed to set more than one friendslot.\n"
 " Only one slot was assigned."
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid ""
+"One block per part of the file.\n"
+"Light grey: this source does not have the part.\n"
+"Green: this source has it and so do you.\n"
+"Amber: downloading this part from this source now.\n"
+"Pale yellow: the next part you will request from this source.\n"
+"Dark grey: this source has it and you still need it.\n"
+"The whole bar is dimmed while the download is stopped."
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid ""
+"One block per part of your shared file.\n"
+"Dark grey: this peer already has the part.\n"
+"Light grey: this peer does not have it."
 msgstr ""
 
 #: src/GenericClientListCtrl.cpp
@@ -7097,8 +7115,8 @@ msgstr[0] ""
 msgid "User Name"
 msgstr ""
 
-#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
-msgid "Available Parts"
+#: src/SharedFilePeersListCtrl.cpp
+msgid "Parts on Peer"
 msgstr ""
 
 #: src/SharedFilePeersListCtrl.cpp
@@ -7284,6 +7302,10 @@ msgstr ""
 #: src/SharedFilesReloadProgress.cpp
 #, c-format
 msgid "Reloading shared files: %u files scanned"
+msgstr ""
+
+#: src/SourceListCtrl.cpp
+msgid "Part Status"
 msgstr ""
 
 #: src/SourceListCtrl.cpp

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-29 20:55+0200\n"
+"POT-Creation-Date: 2026-08-30 16:16+0200\n"
 "PO-Revision-Date: 2026-08-26 20:31+0000\n"
 "Last-Translator: Mike Akiba <mike2718@gmail.com>\n"
 "Language-Team: Chinese Simplified <kde-i18n-doc@kde.org>\n"
@@ -2766,22 +2766,42 @@ msgstr ""
 " 只能指定一个通道。"
 
 #: src/GenericClientListCtrl.cpp
-msgid ""
-"One block per part of the file.\n"
-"Light grey: this source does not have the part.\n"
-"Green: this source has it and so do you.\n"
-"Amber: downloading this part from this source now.\n"
-"Pale yellow: the next part you will request from this source.\n"
-"Dark grey: this source has it and you still need it.\n"
-"The whole bar is dimmed while the download is stopped."
+#, fuzzy
+msgid "This source does not have the part"
+msgstr "此命令不需要任何参数。"
+
+#: src/GenericClientListCtrl.cpp
+msgid "You and this source both have the part"
 msgstr ""
 
 #: src/GenericClientListCtrl.cpp
-msgid ""
-"One block per part of your shared file.\n"
-"Dark grey: this peer already has the part.\n"
-"Light grey: this peer does not have it."
+msgid "Being downloaded from this source now"
 msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "The next part that will be asked of this source"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "This source has the part and you still need it"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "This peer already has the part"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "This peer does not have the part"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "One block per part of the file being downloaded."
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+#, fuzzy
+msgid "One block per part of the shared file."
+msgstr "在此请输入服务器端口。"
 
 #: src/GenericClientListCtrl.cpp
 #, c-format

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -2804,6 +2804,10 @@ msgid "One block per part of the shared file."
 msgstr "在此请输入服务器端口。"
 
 #: src/GenericClientListCtrl.cpp
+msgid "Colour legend"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
 #, c-format
 msgid "On Queue: %u (%i)"
 msgstr "在队列中: %u (%i)"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 19:01+0200\n"
+"POT-Creation-Date: 2026-08-29 20:55+0200\n"
 "PO-Revision-Date: 2026-08-26 20:31+0000\n"
 "Last-Translator: Mike Akiba <mike2718@gmail.com>\n"
 "Language-Team: Chinese Simplified <kde-i18n-doc@kde.org>\n"
@@ -2764,6 +2764,24 @@ msgid ""
 msgstr ""
 "不允许设置超过一个好友通道。\n"
 " 只能指定一个通道。"
+
+#: src/GenericClientListCtrl.cpp
+msgid ""
+"One block per part of the file.\n"
+"Light grey: this source does not have the part.\n"
+"Green: this source has it and so do you.\n"
+"Amber: downloading this part from this source now.\n"
+"Pale yellow: the next part you will request from this source.\n"
+"Dark grey: this source has it and you still need it.\n"
+"The whole bar is dimmed while the download is stopped."
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid ""
+"One block per part of your shared file.\n"
+"Dark grey: this peer already has the part.\n"
+"Light grey: this peer does not have it."
+msgstr ""
 
 #: src/GenericClientListCtrl.cpp
 #, c-format
@@ -7249,9 +7267,9 @@ msgstr[1] "发现了 %u 个新的共享文件"
 msgid "User Name"
 msgstr "用户名"
 
-#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
-msgid "Available Parts"
-msgstr "可用分块"
+#: src/SharedFilePeersListCtrl.cpp
+msgid "Parts on Peer"
+msgstr ""
 
 #: src/SharedFilePeersListCtrl.cpp
 msgid "Upload Status"
@@ -7444,6 +7462,11 @@ msgstr "共享文件 (%i)"
 #, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "正重新加载共享文件：扫描了 %u 个文件"
+
+#: src/SourceListCtrl.cpp
+#, fuzzy
+msgid "Part Status"
+msgstr "状态"
 
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"
@@ -9151,6 +9174,9 @@ msgstr "aMule 似乎正在运行。请将其关闭并重新运行卸载程序。
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "正在删除 $APPDATA\\aMule 中的用户数据..."
+
+#~ msgid "Available Parts"
+#~ msgstr "可用分块"
 
 #, c-format
 #~ msgid "Found %i known shared file, %i unknown"

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-29 20:55+0200\n"
+"POT-Creation-Date: 2026-08-30 16:16+0200\n"
 "PO-Revision-Date: 2026-08-25 10:21+0000\n"
 "Last-Translator: Wayne Su <mstarmstar@gmail.com>\n"
 "Language-Team: \n"
@@ -2770,22 +2770,42 @@ msgstr ""
 " 只設定了一個位置。"
 
 #: src/GenericClientListCtrl.cpp
-msgid ""
-"One block per part of the file.\n"
-"Light grey: this source does not have the part.\n"
-"Green: this source has it and so do you.\n"
-"Amber: downloading this part from this source now.\n"
-"Pale yellow: the next part you will request from this source.\n"
-"Dark grey: this source has it and you still need it.\n"
-"The whole bar is dimmed while the download is stopped."
+#, fuzzy
+msgid "This source does not have the part"
+msgstr "這個指令不能有參數。"
+
+#: src/GenericClientListCtrl.cpp
+msgid "You and this source both have the part"
 msgstr ""
 
 #: src/GenericClientListCtrl.cpp
-msgid ""
-"One block per part of your shared file.\n"
-"Dark grey: this peer already has the part.\n"
-"Light grey: this peer does not have it."
+msgid "Being downloaded from this source now"
 msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "The next part that will be asked of this source"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "This source has the part and you still need it"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "This peer already has the part"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "This peer does not have the part"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "One block per part of the file being downloaded."
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+#, fuzzy
+msgid "One block per part of the shared file."
+msgstr "輸入伺服器的通訊埠。"
 
 #: src/GenericClientListCtrl.cpp
 #, c-format

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -2808,6 +2808,10 @@ msgid "One block per part of the shared file."
 msgstr "輸入伺服器的通訊埠。"
 
 #: src/GenericClientListCtrl.cpp
+msgid "Colour legend"
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
 #, c-format
 msgid "On Queue: %u (%i)"
 msgstr "QR：%u (%i)"

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-24 19:01+0200\n"
+"POT-Creation-Date: 2026-08-29 20:55+0200\n"
 "PO-Revision-Date: 2026-08-25 10:21+0000\n"
 "Last-Translator: Wayne Su <mstarmstar@gmail.com>\n"
 "Language-Team: \n"
@@ -2768,6 +2768,24 @@ msgid ""
 msgstr ""
 "不允許設定超過一個好友位置。\n"
 " 只設定了一個位置。"
+
+#: src/GenericClientListCtrl.cpp
+msgid ""
+"One block per part of the file.\n"
+"Light grey: this source does not have the part.\n"
+"Green: this source has it and so do you.\n"
+"Amber: downloading this part from this source now.\n"
+"Pale yellow: the next part you will request from this source.\n"
+"Dark grey: this source has it and you still need it.\n"
+"The whole bar is dimmed while the download is stopped."
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid ""
+"One block per part of your shared file.\n"
+"Dark grey: this peer already has the part.\n"
+"Light grey: this peer does not have it."
+msgstr ""
 
 #: src/GenericClientListCtrl.cpp
 #, c-format
@@ -7290,9 +7308,9 @@ msgstr[0] "找到 %i 個已知的分享檔案"
 msgid "User Name"
 msgstr "使用者名稱"
 
-#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
-msgid "Available Parts"
-msgstr "可取得的部份"
+#: src/SharedFilePeersListCtrl.cpp
+msgid "Parts on Peer"
+msgstr ""
 
 #: src/SharedFilePeersListCtrl.cpp
 msgid "Upload Status"
@@ -7480,6 +7498,11 @@ msgstr "分享檔案 (%i)"
 #, fuzzy, c-format
 msgid "Reloading shared files: %u files scanned"
 msgstr "重新載入分享檔案清單。"
+
+#: src/SourceListCtrl.cpp
+#, fuzzy
+msgid "Part Status"
+msgstr "狀態"
 
 #: src/SourceListCtrl.cpp
 msgid "Remote File Name"
@@ -9168,6 +9191,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "Available Parts"
+#~ msgstr "可取得的部份"
 
 #, c-format
 #~ msgid "Found %i known shared file, %i unknown"

--- a/src/ClientListColumns.h
+++ b/src/ClientListColumns.h
@@ -1,0 +1,54 @@
+//
+// This file is part of the aMule Project.
+//
+// Copyright (c) 2003-2026 aMule Team ( https://amule-org.github.io )
+//
+// Any parts of this program derived from the xMule, lMule or eMule project,
+// or contributed by third-party developers are copyrighted by their
+// respective authors.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301, USA
+//
+
+#ifndef CLIENTLISTCOLUMNS_H
+#define CLIENTLISTCOLUMNS_H
+
+// The column ids every CGenericClientListCtrl subclass builds its column table
+// from. They used to live in GenericClientListCtrl.h, which cannot be included
+// without wx; they were split out so the pure decisions keyed on a column id --
+// currently PartBarLegend.h's column-to-legend mapping -- can be compiled and
+// tested without a GUI toolkit or a display. Nothing else moved with them.
+
+enum GenericColumnEnum
+{
+	ColumnUserName = 0,
+	ColumnUserDownloaded,
+	ColumnUserUploaded,
+	ColumnUserSpeedDown,
+	ColumnUserSpeedUp,
+	ColumnUserProgress,
+	ColumnUserAvailable,
+	ColumnUserVersion,
+	ColumnUserQueueRankLocal,
+	ColumnUserQueueRankRemote,
+	ColumnUserOrigin,
+	ColumnUserFileNameDownload,
+	ColumnUserFileNameUpload,
+	ColumnUserFileNameDownloadRemote,
+	ColumnUserSharedFiles,
+	ColumnInvalid
+};
+
+#endif // CLIENTLISTCOLUMNS_H

--- a/src/GenericClientListCtrl.cpp
+++ b/src/GenericClientListCtrl.cpp
@@ -62,6 +62,12 @@
 #endif
 #include "FriendList.h"
 
+#include <wx/dcmemory.h> // Needed for wxMemoryDC (legend swatches)
+#include <wx/dialog.h>   // Needed for wxDialog (legend)
+#include <wx/sizer.h>    // Needed for wxBoxSizer, wxFlexGridSizer
+#include <wx/statbmp.h>  // Needed for wxStaticBitmap
+#include <wx/stattext.h> // Needed for wxStaticText
+
 namespace
 {
 /**
@@ -96,6 +102,64 @@ public:
 		return true;
 	}
 };
+
+//! Appended to the header of a column that has a colour legend, and clicked to
+//! open it. Not translated: it is punctuation, and the click handler resolves
+//! it by its rendered width, so the two have to stay the same string. A plain
+//! literal rather than a wxString, which at namespace scope would be built
+//! before the app is.
+const char kLegendMarker[] = "  (?)";
+
+/**
+ * A 16x16 swatch of one bar colour, drawn the way CCatDialog::MakeBitmap()
+ * draws the category colour: a wxMemoryDC over a wxBitmap, default pen, so the
+ * fill keeps a border and the two pale greys stay visible on a light dialog.
+ */
+wxBitmap MakeLegendSwatch(const partbar::BarColour &colour)
+{
+	wxBitmap bitmap(16, 16);
+	wxMemoryDC dc(bitmap);
+
+	dc.SetBrush(CMuleColour(colour.red, colour.green, colour.blue).GetBrush());
+	dc.DrawRectangle(0, 0, 16, 16);
+
+	return bitmap;
+}
+
+wxString SourcePartStateLabel(partbar::SourcePartState state)
+{
+	switch (state) {
+	case partbar::SourcePartState::Missing:
+		return _("This source does not have the part");
+	case partbar::SourcePartState::Complete:
+		return _("You and this source both have the part");
+	case partbar::SourcePartState::Downloading:
+		return _("Being downloaded from this source now");
+	case partbar::SourcePartState::NextRequested:
+		return _("The next part that will be asked of this source");
+	case partbar::SourcePartState::Needed:
+		return _("This source has the part and you still need it");
+	}
+	return wxEmptyString;
+}
+
+wxString PeerPartStateLabel(partbar::PeerPartState state)
+{
+	switch (state) {
+	case partbar::PeerPartState::Present:
+		return _("This peer already has the part");
+	case partbar::PeerPartState::Missing:
+		return _("This peer does not have the part");
+	}
+	return wxEmptyString;
+}
+
+//! One swatch-and-text row of a legend.
+void AddLegendRow(wxWindow *parent, wxSizer *grid, const partbar::BarColour &colour, const wxString &label)
+{
+	grid->Add(new wxStaticBitmap(parent, wxID_ANY, MakeLegendSwatch(colour)), 0, wxALIGN_CENTRE_VERTICAL);
+	grid->Add(new wxStaticText(parent, wxID_ANY, label), 0, wxALIGN_CENTRE_VERTICAL);
+}
 } // namespace
 
 #define m_ImageList theApp->amuledlg->m_imagelist
@@ -104,7 +168,9 @@ wxBEGIN_EVENT_TABLE(CGenericClientListCtrl, CMuleVirtualDataViewCtrl)
 	EVT_DATAVIEW_ITEM_ACTIVATED(wxID_ANY, CGenericClientListCtrl::OnItemActivated)
 	EVT_DATAVIEW_ITEM_CONTEXT_MENU(wxID_ANY, CGenericClientListCtrl::OnItemRightClicked)
 	EVT_MIDDLE_DOWN(CGenericClientListCtrl::OnMouseMiddleClick)
-	EVT_MOTION(CGenericClientListCtrl::OnMouseMotion)
+	// Ahead of the base class's own binding, which sorts: this one sorts too,
+	// unless the click landed on a bar column's "?" marker.
+	EVT_DATAVIEW_COLUMN_HEADER_CLICK(wxID_ANY, CGenericClientListCtrl::OnColumnHeaderClick)
 
 	EVT_MENU(MP_CHANGE2FILE, CGenericClientListCtrl::OnSwapSource)
 	EVT_MENU(MP_SHOWLIST, CGenericClientListCtrl::OnViewFiles)
@@ -223,7 +289,11 @@ void CGenericClientListCtrl::InitColumnData()
 
 	for (int i = 0; i < m_columndata.n_columns; ++i) {
 		const GenericColumnEnum cid = m_columndata.columns[i].cid;
-		const wxString title = wxGetTranslation(m_columndata.columns[i].title);
+		// The two chunk-bar columns carry a "?" that opens their colour
+		// legend -- see OnColumnHeaderClick().
+		const bool hasLegend = partbar::LegendForColumn(cid) != partbar::BarLegendKind::None;
+		const wxString title =
+			wxGetTranslation(m_columndata.columns[i].title) + (hasLegend ? kLegendMarker : "");
 		const wxString key = TranslateCIDToName(cid);
 		const int width = m_columndata.columns[i].width;
 
@@ -632,63 +702,101 @@ void CGenericClientListCtrl::OnMouseMiddleClick(wxMouseEvent &event)
 	CClientDetailDialog(this, reinterpret_cast<ClientCtrlItem_Struct *>(data)->GetSource()).ShowModal();
 }
 
-namespace
+int CGenericClientListCtrl::GetColumnLeft(unsigned column) const
 {
-/**
- * Colour legend of a chunk-bar column, or an empty string for any other
- * column. The two bar columns share one renderer but not one palette, so
- * each gets its own text -- which is also why they no longer share one
- * header label (issue #1192).
- */
-wxString BarColumnTooltip(GenericColumnEnum cid)
-{
-	switch (cid) {
-	case ColumnUserProgress:
-		// Five states, in the order GetItemBarFill() tests them.
-		return _("One block per part of the file.\n"
-			 "Light grey: this source does not have the part.\n"
-			 "Green: this source has it and so do you.\n"
-			 "Amber: downloading this part from this source now.\n"
-			 "Pale yellow: the next part you will request from this source.\n"
-			 "Dark grey: this source has it and you still need it.\n"
-			 "The whole bar is dimmed while the download is stopped.");
-	case ColumnUserAvailable:
-		return _("One block per part of your shared file.\n"
-			 "Dark grey: this peer already has the part.\n"
-			 "Light grey: this peer does not have it.");
-	default:
-		return wxEmptyString;
+	const unsigned columns = GetColumnCount();
+	if (column >= columns) {
+		return -1;
 	}
+	// Model column and view index coincide here -- CMuleDataViewCtrl asserts
+	// as much when it appends its columns -- so summing the widths of the
+	// preceding, visible columns gives the logical left edge.
+	int left = 0;
+	for (unsigned i = 0; i < column; ++i) {
+		const wxDataViewColumn *col = GetColumn(i);
+		if (col == nullptr) {
+			return -1;
+		}
+		if (!col->IsHidden()) {
+			left += col->GetWidth();
+		}
+	}
+	return left;
 }
-} // namespace
 
-void CGenericClientListCtrl::OnMouseMotion(wxMouseEvent &event)
+void CGenericClientListCtrl::ShowBarLegend(partbar::BarLegendKind kind, const wxString &columnTitle)
 {
-	// The base class and the platform both still need this event (hover
-	// highlight, drag tracking); the tooltip is purely additive.
-	event.Skip();
+	// Both legends read their colours from the functions GetItemBarFill()
+	// fills the bar from, under the bar preference in force right now: a
+	// swatch cannot disagree with the pixels it explains.
+	const bool bFlat = thePrefs::UseFlatBar();
 
-	wxDataViewItem hitItem;
-	wxDataViewColumn *hitColumn = nullptr;
-	HitTest(event.GetPosition(), hitItem, hitColumn);
+	wxDialog dialog(this, wxID_ANY, columnTitle);
+	wxFlexGridSizer *grid = new wxFlexGridSizer(2, wxSize(8, 6));
 
-	wxString tip;
-	if (hitColumn) {
-		const unsigned column = hitColumn->GetModelColumn();
-		if (column < static_cast<unsigned>(m_columndata.n_columns)) {
-			tip = BarColumnTooltip(m_columndata.columns[column].cid);
+	wxString intro;
+	if (kind == partbar::BarLegendKind::SourceParts) {
+		intro = _("One block per part of the file being downloaded.");
+		for (std::size_t i = 0; i < partbar::kSourceLegendSize; ++i) {
+			const partbar::SourcePartState state = partbar::kSourceLegendOrder[i];
+			AddLegendRow(&dialog,
+				grid,
+				partbar::SourcePartColour(state, bFlat),
+				SourcePartStateLabel(state));
+		}
+	} else {
+		intro = _("One block per part of the shared file.");
+		for (std::size_t i = 0; i < partbar::kPeerLegendSize; ++i) {
+			const partbar::PeerPartState state = partbar::kPeerLegendOrder[i];
+			AddLegendRow(&dialog,
+				grid,
+				partbar::PeerPartColour(state, bFlat),
+				PeerPartStateLabel(state));
 		}
 	}
 
-	if (tip == m_tooltipText) {
-		return;
+	wxBoxSizer *top = new wxBoxSizer(wxVERTICAL);
+	top->Add(new wxStaticText(&dialog, wxID_ANY, intro), 0, wxALL, 10);
+	top->Add(grid, 0, wxLEFT | wxRIGHT | wxBOTTOM, 10);
+	if (wxSizer *buttons = dialog.CreateButtonSizer(wxOK)) {
+		top->Add(buttons, 0, wxALIGN_RIGHT | wxLEFT | wxRIGHT | wxBOTTOM, 10);
 	}
-	m_tooltipText = tip;
-	if (tip.IsEmpty()) {
-		UnsetToolTip();
-	} else {
-		SetToolTip(tip);
+
+	dialog.SetSizerAndFit(top);
+	dialog.CentreOnParent();
+	dialog.ShowModal();
+}
+
+void CGenericClientListCtrl::OnColumnHeaderClick(wxDataViewEvent &event)
+{
+	wxDataViewColumn *col = event.GetDataViewColumn();
+	if (col != nullptr) {
+		const unsigned column = static_cast<unsigned>(col->GetModelColumn());
+		if (column < static_cast<unsigned>(m_columndata.n_columns)) {
+			const partbar::BarLegendKind kind =
+				partbar::LegendForColumn(m_columndata.columns[column].cid);
+			const int left = GetColumnLeft(column);
+			// A header click carries no position of its own, so the
+			// pointer is read back: it cannot have moved between the
+			// click and this handler. Both x values are shifted into the
+			// header's own, unscrolled space before they are compared.
+			const int clickX =
+				ScreenToClient(wxGetMousePosition()).x + GetScrollPos(wxHORIZONTAL);
+			if (kind != partbar::BarLegendKind::None && left >= 0 &&
+				partbar::InLegendMarker(clickX,
+					left,
+					col->GetWidth(),
+					GetTextExtent(kLegendMarker).GetWidth())) {
+				ShowBarLegend(kind, wxGetTranslation(m_columndata.columns[column].title));
+				return;
+			}
+		}
 	}
+
+	// Everything else -- a column with no legend, a click beside the marker,
+	// a geometry that could not be resolved -- is an ordinary header click.
+	// Sorting must not depend on the marker being placed correctly.
+	CMuleDataViewCtrl::OnColumnHeaderClick(event);
 }
 
 void CGenericClientListCtrl::OnItemRightClicked(wxDataViewEvent &event)
@@ -891,23 +999,12 @@ bool CGenericClientListCtrl::GetItemAttr(wxUIntPtr data, unsigned column, wxData
 
 namespace
 {
-const CMuleColour crBoth(0, 192, 0);
-const CMuleColour crFlatBoth(0, 150, 0);
-
-const CMuleColour crNeither(240, 240, 240);
-const CMuleColour crFlatNeither(224, 224, 224);
-
-const CMuleColour crClientOnly(104, 104, 104);
-const CMuleColour crFlatClientOnly(0, 0, 0);
-
-const CMuleColour crPending(255, 208, 0);
-const CMuleColour crNextPending(255, 255, 100);
-
-const CMuleColour crUnavailable(240, 240, 240);
-const CMuleColour crFlatUnavailable(224, 224, 224);
-
-const CMuleColour crAvailable(104, 104, 104);
-const CMuleColour crFlatAvailable(0, 0, 0);
+//! The bar palette lives in PartBarLegend.h, where the legend reads the same
+//! values -- see the header comment for why they cannot be kept in two places.
+inline CMuleColour ToMuleColour(const partbar::BarColour &colour)
+{
+	return CMuleColour(colour.red, colour.green, colour.blue);
+}
 } // namespace
 
 void CGenericClientListCtrl::GetItemBarFill(wxUIntPtr data, unsigned column, CBarFillSpec &out) const
@@ -951,25 +1048,34 @@ void CGenericClientListCtrl::GetItemBarFill(wxUIntPtr data, unsigned column, CBa
 				const uint64 uStart = PARTSIZE * i;
 				const uint64 uEnd = uStart + reqfile->GetPartSize(static_cast<uint16>(i)) - 1;
 
-				CMuleColour colour;
+				// The order of these tests is the order the legend
+				// lists the states in (partbar::kSourceLegendOrder).
+				partbar::SourcePartState state;
 				if (!partStatus.get(i)) {
-					colour = bFlat ? crFlatNeither : crNeither;
+					state = partbar::SourcePartState::Missing;
 				} else if (reqfile->IsComplete(static_cast<uint16>(i))) {
-					colour = bFlat ? crFlatBoth : crBoth;
+					state = partbar::SourcePartState::Complete;
 				} else if (lastDownloadingPart == static_cast<uint16>(i)) {
-					colour = crPending;
+					state = partbar::SourcePartState::Downloading;
 				} else if (nextRequestedPart == static_cast<uint16>(i)) {
-					colour = crNextPending;
+					state = partbar::SourcePartState::NextRequested;
 				} else {
-					colour = bFlat ? crFlatClientOnly : crClientOnly;
+					state = partbar::SourcePartState::Needed;
 				}
+				CMuleColour colour = ToMuleColour(partbar::SourcePartColour(state, bFlat));
 				if (stopped) {
+					// Not in the legend: a dimmed swatch out of
+					// context reads as a sixth state rather than as
+					// the same five turned down.
 					colour.Blend(50);
 				}
 				spans.push_back({ uStart, uEnd, colour });
 			}
 		} else {
-			spans.push_back({ 0, 1, bFlat ? crFlatNeither : crNeither });
+			spans.push_back({ 0,
+				1,
+				ToMuleColour(partbar::SourcePartColour(
+					partbar::SourcePartState::Missing, bFlat)) });
 		}
 
 		out = CBarFillSpec(data, fileSize, std::move(spans));
@@ -992,8 +1098,10 @@ void CGenericClientListCtrl::GetItemBarFill(wxUIntPtr data, unsigned column, CBa
 			const uint64 uEnd = uStart + PARTSIZE - 1;
 			spans.push_back({ uStart,
 				uEnd,
-				client.IsUpPartAvailable(i) ? (bFlat ? crFlatAvailable : crAvailable)
-							    : (bFlat ? crFlatUnavailable : crUnavailable) });
+				ToMuleColour(partbar::PeerPartColour(
+					client.IsUpPartAvailable(i) ? partbar::PeerPartState::Present
+								    : partbar::PeerPartState::Missing,
+					bFlat)) });
 		}
 		out = CBarFillSpec(data, static_cast<uint64>(partCount) * PARTSIZE, std::move(spans));
 		return;

--- a/src/GenericClientListCtrl.cpp
+++ b/src/GenericClientListCtrl.cpp
@@ -103,13 +103,6 @@ public:
 	}
 };
 
-//! Appended to the header of a column that has a colour legend, and clicked to
-//! open it. Not translated: it is punctuation, and the click handler resolves
-//! it by its rendered width, so the two have to stay the same string. A plain
-//! literal rather than a wxString, which at namespace scope would be built
-//! before the app is.
-const char kLegendMarker[] = "  (?)";
-
 /**
  * A 16x16 swatch of one bar colour, drawn the way CCatDialog::MakeBitmap()
  * draws the category colour: a wxMemoryDC over a wxBitmap, default pen, so the
@@ -168,9 +161,6 @@ wxBEGIN_EVENT_TABLE(CGenericClientListCtrl, CMuleVirtualDataViewCtrl)
 	EVT_DATAVIEW_ITEM_ACTIVATED(wxID_ANY, CGenericClientListCtrl::OnItemActivated)
 	EVT_DATAVIEW_ITEM_CONTEXT_MENU(wxID_ANY, CGenericClientListCtrl::OnItemRightClicked)
 	EVT_MIDDLE_DOWN(CGenericClientListCtrl::OnMouseMiddleClick)
-	// Ahead of the base class's own binding, which sorts: this one sorts too,
-	// unless the click landed on a bar column's "?" marker.
-	EVT_DATAVIEW_COLUMN_HEADER_CLICK(wxID_ANY, CGenericClientListCtrl::OnColumnHeaderClick)
 
 	EVT_MENU(MP_CHANGE2FILE, CGenericClientListCtrl::OnSwapSource)
 	EVT_MENU(MP_SHOWLIST, CGenericClientListCtrl::OnViewFiles)
@@ -178,6 +168,7 @@ wxBEGIN_EVENT_TABLE(CGenericClientListCtrl, CMuleVirtualDataViewCtrl)
 	EVT_MENU(MP_FRIENDSLOT, CGenericClientListCtrl::OnSetFriendslot)
 	EVT_MENU(MP_SENDMESSAGE, CGenericClientListCtrl::OnSendMessage)
 	EVT_MENU(MP_DETAIL, CGenericClientListCtrl::OnViewClientInfo)
+	EVT_MENU(MP_BARLEGEND, CGenericClientListCtrl::OnShowBarLegend)
 wxEND_EVENT_TABLE()
 
 CGenericClientListCtrl::CGenericClientListCtrl(const wxString &tablename,
@@ -289,11 +280,7 @@ void CGenericClientListCtrl::InitColumnData()
 
 	for (int i = 0; i < m_columndata.n_columns; ++i) {
 		const GenericColumnEnum cid = m_columndata.columns[i].cid;
-		// The two chunk-bar columns carry a "?" that opens their colour
-		// legend -- see OnColumnHeaderClick().
-		const bool hasLegend = partbar::LegendForColumn(cid) != partbar::BarLegendKind::None;
-		const wxString title =
-			wxGetTranslation(m_columndata.columns[i].title) + (hasLegend ? kLegendMarker : "");
+		const wxString title = wxGetTranslation(m_columndata.columns[i].title);
 		const wxString key = TranslateCIDToName(cid);
 		const int width = m_columndata.columns[i].width;
 
@@ -702,26 +689,20 @@ void CGenericClientListCtrl::OnMouseMiddleClick(wxMouseEvent &event)
 	CClientDetailDialog(this, reinterpret_cast<ClientCtrlItem_Struct *>(data)->GetSource()).ShowModal();
 }
 
-int CGenericClientListCtrl::GetColumnLeft(unsigned column) const
+int CGenericClientListCtrl::FindBarLegendColumn() const
 {
-	const unsigned columns = GetColumnCount();
-	if (column >= columns) {
-		return -1;
-	}
-	// Model column and view index coincide here -- CMuleDataViewCtrl asserts
-	// as much when it appends its columns -- so summing the widths of the
-	// preceding, visible columns gives the logical left edge.
-	int left = 0;
-	for (unsigned i = 0; i < column; ++i) {
-		const wxDataViewColumn *col = GetColumn(i);
-		if (col == nullptr) {
-			return -1;
+	for (int i = 0; i < m_columndata.n_columns; ++i) {
+		if (partbar::LegendForColumn(m_columndata.columns[i].cid) == partbar::BarLegendKind::None) {
+			continue;
 		}
-		if (!col->IsHidden()) {
-			left += col->GetWidth();
+		// A bar the user has hidden is not on screen to be explained. Model
+		// id and view position coincide here -- InitColumnState() requires
+		// it -- so one index answers both.
+		if (!IsColumnHidden(i)) {
+			return i;
 		}
 	}
-	return left;
+	return -1;
 }
 
 void CGenericClientListCtrl::ShowBarLegend(partbar::BarLegendKind kind, const wxString &columnTitle)
@@ -765,36 +746,17 @@ void CGenericClientListCtrl::ShowBarLegend(partbar::BarLegendKind kind, const wx
 	dialog.ShowModal();
 }
 
-void CGenericClientListCtrl::OnColumnHeaderClick(wxDataViewEvent &event)
+void CGenericClientListCtrl::OnShowBarLegend(wxCommandEvent &WXUNUSED(event))
 {
-	wxDataViewColumn *col = event.GetDataViewColumn();
-	if (col != nullptr) {
-		const unsigned column = static_cast<unsigned>(col->GetModelColumn());
-		if (column < static_cast<unsigned>(m_columndata.n_columns)) {
-			const partbar::BarLegendKind kind =
-				partbar::LegendForColumn(m_columndata.columns[column].cid);
-			const int left = GetColumnLeft(column);
-			// A header click carries no position of its own, so the
-			// pointer is read back: it cannot have moved between the
-			// click and this handler. Both x values are shifted into the
-			// header's own, unscrolled space before they are compared.
-			const int clickX =
-				ScreenToClient(wxGetMousePosition()).x + GetScrollPos(wxHORIZONTAL);
-			if (kind != partbar::BarLegendKind::None && left >= 0 &&
-				partbar::InLegendMarker(clickX,
-					left,
-					col->GetWidth(),
-					GetTextExtent(kLegendMarker).GetWidth())) {
-				ShowBarLegend(kind, wxGetTranslation(m_columndata.columns[column].title));
-				return;
-			}
-		}
+	// Resolved again rather than remembered from when the menu was built: the
+	// entry only exists on menus built while a bar column was on screen, and
+	// re-asking costs a walk over at most a couple of dozen columns.
+	const int column = FindBarLegendColumn();
+	if (column < 0) {
+		return;
 	}
-
-	// Everything else -- a column with no legend, a click beside the marker,
-	// a geometry that could not be resolved -- is an ordinary header click.
-	// Sorting must not depend on the marker being placed correctly.
-	CMuleDataViewCtrl::OnColumnHeaderClick(event);
+	ShowBarLegend(partbar::LegendForColumn(m_columndata.columns[column].cid),
+		wxGetTranslation(m_columndata.columns[column].title));
 }
 
 void CGenericClientListCtrl::OnItemRightClicked(wxDataViewEvent &event)
@@ -820,6 +782,16 @@ void CGenericClientListCtrl::OnItemRightClicked(wxDataViewEvent &event)
 	// Same menu the global clients list offers; "Swap to this file" is the one
 	// entry only a per-file list can act on.
 	m_menu = BuildClientContextMenu(client, item->GetType() == A4AF_SOURCE);
+
+	// Appended here rather than inside BuildClientContextMenu(): that builder
+	// is shared with CClientRowListCtrl, the Clients tab, which draws no chunk
+	// bar and so must not offer to explain one. Asking the list which of its
+	// own columns has a legend keeps that true for any future subclass without
+	// naming one here.
+	if (FindBarLegendColumn() >= 0) {
+		m_menu->AppendSeparator();
+		m_menu->Append(MP_BARLEGEND, _("Colour legend"));
+	}
 
 	PopupMenu(m_menu, event.GetPosition());
 

--- a/src/GenericClientListCtrl.cpp
+++ b/src/GenericClientListCtrl.cpp
@@ -737,8 +737,7 @@ void CGenericClientListCtrl::ShowBarLegend(partbar::BarLegendKind kind, const wx
 	wxString intro;
 	if (kind == partbar::BarLegendKind::SourceParts) {
 		intro = _("One block per part of the file being downloaded.");
-		for (std::size_t i = 0; i < partbar::kSourceLegendSize; ++i) {
-			const partbar::SourcePartState state = partbar::kSourceLegendOrder[i];
+		for (const partbar::SourcePartState state : partbar::kSourceLegendOrder) {
 			AddLegendRow(&dialog,
 				grid,
 				partbar::SourcePartColour(state, bFlat),
@@ -746,8 +745,7 @@ void CGenericClientListCtrl::ShowBarLegend(partbar::BarLegendKind kind, const wx
 		}
 	} else {
 		intro = _("One block per part of the shared file.");
-		for (std::size_t i = 0; i < partbar::kPeerLegendSize; ++i) {
-			const partbar::PeerPartState state = partbar::kPeerLegendOrder[i];
+		for (const partbar::PeerPartState state : partbar::kPeerLegendOrder) {
 			AddLegendRow(&dialog,
 				grid,
 				partbar::PeerPartColour(state, bFlat),

--- a/src/GenericClientListCtrl.cpp
+++ b/src/GenericClientListCtrl.cpp
@@ -104,6 +104,7 @@ wxBEGIN_EVENT_TABLE(CGenericClientListCtrl, CMuleVirtualDataViewCtrl)
 	EVT_DATAVIEW_ITEM_ACTIVATED(wxID_ANY, CGenericClientListCtrl::OnItemActivated)
 	EVT_DATAVIEW_ITEM_CONTEXT_MENU(wxID_ANY, CGenericClientListCtrl::OnItemRightClicked)
 	EVT_MIDDLE_DOWN(CGenericClientListCtrl::OnMouseMiddleClick)
+	EVT_MOTION(CGenericClientListCtrl::OnMouseMotion)
 
 	EVT_MENU(MP_CHANGE2FILE, CGenericClientListCtrl::OnSwapSource)
 	EVT_MENU(MP_SHOWLIST, CGenericClientListCtrl::OnViewFiles)
@@ -629,6 +630,65 @@ void CGenericClientListCtrl::OnMouseMiddleClick(wxMouseEvent &event)
 		return;
 	}
 	CClientDetailDialog(this, reinterpret_cast<ClientCtrlItem_Struct *>(data)->GetSource()).ShowModal();
+}
+
+namespace
+{
+/**
+ * Colour legend of a chunk-bar column, or an empty string for any other
+ * column. The two bar columns share one renderer but not one palette, so
+ * each gets its own text -- which is also why they no longer share one
+ * header label (issue #1192).
+ */
+wxString BarColumnTooltip(GenericColumnEnum cid)
+{
+	switch (cid) {
+	case ColumnUserProgress:
+		// Five states, in the order GetItemBarFill() tests them.
+		return _("One block per part of the file.\n"
+			 "Light grey: this source does not have the part.\n"
+			 "Green: this source has it and so do you.\n"
+			 "Amber: downloading this part from this source now.\n"
+			 "Pale yellow: the next part you will request from this source.\n"
+			 "Dark grey: this source has it and you still need it.\n"
+			 "The whole bar is dimmed while the download is stopped.");
+	case ColumnUserAvailable:
+		return _("One block per part of your shared file.\n"
+			 "Dark grey: this peer already has the part.\n"
+			 "Light grey: this peer does not have it.");
+	default:
+		return wxEmptyString;
+	}
+}
+} // namespace
+
+void CGenericClientListCtrl::OnMouseMotion(wxMouseEvent &event)
+{
+	// The base class and the platform both still need this event (hover
+	// highlight, drag tracking); the tooltip is purely additive.
+	event.Skip();
+
+	wxDataViewItem hitItem;
+	wxDataViewColumn *hitColumn = nullptr;
+	HitTest(event.GetPosition(), hitItem, hitColumn);
+
+	wxString tip;
+	if (hitColumn) {
+		const unsigned column = hitColumn->GetModelColumn();
+		if (column < static_cast<unsigned>(m_columndata.n_columns)) {
+			tip = BarColumnTooltip(m_columndata.columns[column].cid);
+		}
+	}
+
+	if (tip == m_tooltipText) {
+		return;
+	}
+	m_tooltipText = tip;
+	if (tip.IsEmpty()) {
+		UnsetToolTip();
+	} else {
+		SetToolTip(tip);
+	}
 }
 
 void CGenericClientListCtrl::OnItemRightClicked(wxDataViewEvent &event)

--- a/src/GenericClientListCtrl.h
+++ b/src/GenericClientListCtrl.h
@@ -32,6 +32,7 @@
 #include "Constants.h"               // Needed for DownloadItemType
 #include "ClientRef.h"               // Needed for CClientRef (stored by value below)
 #include "MuleVirtualDataViewCtrl.h" // Needed for CMuleVirtualDataViewCtrl
+#include "PartBarLegend.h"           // Needed for GenericColumnEnum, partbar::BarLegendKind
 #include "amuleDlg.h"                // Needed for CamuleDlg::DialogType
 
 class CPartFile;
@@ -75,26 +76,6 @@ private:
 	CKnownFile *m_owner;
 	CClientRef m_sourceValue;
 	SourceItemType m_type;
-};
-
-enum GenericColumnEnum
-{
-	ColumnUserName = 0,
-	ColumnUserDownloaded,
-	ColumnUserUploaded,
-	ColumnUserSpeedDown,
-	ColumnUserSpeedUp,
-	ColumnUserProgress,
-	ColumnUserAvailable,
-	ColumnUserVersion,
-	ColumnUserQueueRankLocal,
-	ColumnUserQueueRankRemote,
-	ColumnUserOrigin,
-	ColumnUserFileNameDownload,
-	ColumnUserFileNameUpload,
-	ColumnUserFileNameDownloadRemote,
-	ColumnUserSharedFiles,
-	ColumnInvalid
 };
 
 struct CGenericClientListCtrlColumn
@@ -292,19 +273,25 @@ private:
 	void OnMouseMiddleClick(wxMouseEvent &event);
 
 	/**
-	 * Shows the colour legend of the chunk-bar column as a tooltip while the
-	 * pointer is over it, and clears it elsewhere. The bar has no other
-	 * explanation of what its colours mean (issue #1192), and the two
+	 * Opens the colour legend when the click landed on the "?" marker of a
+	 * chunk-bar column header, and sorts as usual otherwise. The bar has no
+	 * other explanation of what its colours mean (issue #1192), and the two
 	 * variants of the column -- ColumnUserProgress for Sources,
-	 * ColumnUserAvailable for Peers -- have different palettes, so the text
-	 * is chosen per cid.
+	 * ColumnUserAvailable for Peers -- have different palettes, so the
+	 * legend is chosen per cid (partbar::LegendForColumn).
 	 */
-	void OnMouseMotion(wxMouseEvent &event);
+	void OnColumnHeaderClick(wxDataViewEvent &event);
 
-	//! Tooltip text currently set on the control, so a motion event that does
-	//! not change it does not re-set it: re-setting on every move makes the
-	//! tooltip flicker and re-pop on GTK and MSW.
-	wxString m_tooltipText;
+	//! Left edge of a column in the header's own coordinates, horizontal
+	//! scroll already applied, or -1 when it cannot be resolved. Hidden
+	//! columns take up no width. Separate from the click handler only
+	//! because it is the half that needs the live control.
+	int GetColumnLeft(unsigned column) const;
+
+	//! Pops up the legend of @a kind, titled with @a columnTitle. Swatches
+	//! are filled from partbar::SourcePartColour()/PeerPartColour(), the same
+	//! functions GetItemBarFill() fills the bar itself from.
+	void ShowBarLegend(partbar::BarLegendKind kind, const wxString &columnTitle);
 
 	/**
 	 * The item the context menu was built for, by identity rather than row —

--- a/src/GenericClientListCtrl.h
+++ b/src/GenericClientListCtrl.h
@@ -258,6 +258,14 @@ private:
 	void OnSetFriendslot(wxCommandEvent &event);
 	void OnSendMessage(wxCommandEvent &event);
 	void OnViewClientInfo(wxCommandEvent &event);
+	/**
+	 * Opens the colour legend for this list's chunk-bar column. The bar has no
+	 * other explanation of what its colours mean (issue #1192), and the two
+	 * variants of the column -- ColumnUserProgress for Sources,
+	 * ColumnUserAvailable for Peers -- have different palettes, so the legend
+	 * is chosen per cid (partbar::LegendForColumn).
+	 */
+	void OnShowBarLegend(wxCommandEvent &event);
 
 	// Misc event-handlers
 	void OnItemActivated(wxDataViewEvent &event);
@@ -273,20 +281,14 @@ private:
 	void OnMouseMiddleClick(wxMouseEvent &event);
 
 	/**
-	 * Opens the colour legend when the click landed on the "?" marker of a
-	 * chunk-bar column header, and sorts as usual otherwise. The bar has no
-	 * other explanation of what its colours mean (issue #1192), and the two
-	 * variants of the column -- ColumnUserProgress for Sources,
-	 * ColumnUserAvailable for Peers -- have different palettes, so the
-	 * legend is chosen per cid (partbar::LegendForColumn).
+	 * Index in m_columndata of the chunk-bar column this list shows, or -1
+	 * when there is none on screen -- either the subclass declares no bar
+	 * column, or the user has hidden the one it declares. Found by asking
+	 * partbar::LegendForColumn() about the list's own columns rather than by
+	 * naming cids here, so a subclass that gains or loses a bar column needs
+	 * nothing changed in this class.
 	 */
-	void OnColumnHeaderClick(wxDataViewEvent &event);
-
-	//! Left edge of a column in the header's own coordinates, horizontal
-	//! scroll already applied, or -1 when it cannot be resolved. Hidden
-	//! columns take up no width. Separate from the click handler only
-	//! because it is the half that needs the live control.
-	int GetColumnLeft(unsigned column) const;
+	int FindBarLegendColumn() const;
 
 	//! Pops up the legend of @a kind, titled with @a columnTitle. Swatches
 	//! are filled from partbar::SourcePartColour()/PeerPartColour(), the same

--- a/src/GenericClientListCtrl.h
+++ b/src/GenericClientListCtrl.h
@@ -292,6 +292,21 @@ private:
 	void OnMouseMiddleClick(wxMouseEvent &event);
 
 	/**
+	 * Shows the colour legend of the chunk-bar column as a tooltip while the
+	 * pointer is over it, and clears it elsewhere. The bar has no other
+	 * explanation of what its colours mean (issue #1192), and the two
+	 * variants of the column -- ColumnUserProgress for Sources,
+	 * ColumnUserAvailable for Peers -- have different palettes, so the text
+	 * is chosen per cid.
+	 */
+	void OnMouseMotion(wxMouseEvent &event);
+
+	//! Tooltip text currently set on the control, so a motion event that does
+	//! not change it does not re-set it: re-setting on every move makes the
+	//! tooltip flicker and re-pop on GTK and MSW.
+	wxString m_tooltipText;
+
+	/**
 	 * The item the context menu was built for, by identity rather than row —
 	 * see the identical field on CDownloadListCtrl for why (PopupMenu runs a
 	 * nested event loop, so a row index would not survive it).

--- a/src/PartBarLegend.h
+++ b/src/PartBarLegend.h
@@ -1,0 +1,194 @@
+//
+// This file is part of the aMule Project.
+//
+// Copyright (c) 2003-2026 aMule Team ( https://amule-org.github.io )
+//
+// Any parts of this program derived from the xMule, lMule or eMule project,
+// or contributed by third-party developers are copyrighted by their
+// respective authors.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301, USA
+//
+
+#ifndef PARTBARLEGEND_H
+#define PARTBARLEGEND_H
+
+// The palette of the two chunk-bar columns of the client lists, and the legend
+// the "?" beside their headers opens.
+//
+// The point of this header is that there is exactly one copy of each colour.
+// A legend that restated the palette -- in words, or in swatches filled from a
+// second set of constants -- would be free to drift away from the pixels it
+// claims to explain, and nothing would fail when it did. Here the renderer
+// (CGenericClientListCtrl::GetItemBarFill) and the legend both read
+// SourcePartColour()/PeerPartColour(), so a colour can only change for both at
+// once.
+//
+// It pulls in nothing but <cstddef>/<cstdint> and ClientListColumns.h, so the
+// part of the feature worth checking -- which states a legend lists, in which
+// order, in which colour, and which legend a column gets -- is reachable from
+// a unit test with no wx, no app and no display session. Same rationale as
+// webapi/PartIndex.h. What is left needing a display is the drawing itself.
+
+#include <cstddef>
+#include <cstdint>
+
+#include "ClientListColumns.h" // Needed for GenericColumnEnum
+
+namespace partbar
+{
+
+//! One bar colour, as plain components. Deliberately not CMuleColour, which
+//! cannot be constructed without wx; the GUI converts on use.
+struct BarColour
+{
+	std::uint8_t red;
+	std::uint8_t green;
+	std::uint8_t blue;
+};
+
+constexpr bool operator==(const BarColour &a, const BarColour &b)
+{
+	return a.red == b.red && a.green == b.green && a.blue == b.blue;
+}
+
+constexpr bool operator!=(const BarColour &a, const BarColour &b)
+{
+	return !(a == b);
+}
+
+// The palette itself. Two variants of each fill: the flat one is used when
+// thePrefs::UseFlatBar() is set, which drops the gradient the shaded bar draws
+// and so needs its own, more contrasty values.
+constexpr BarColour kBoth{ 0, 192, 0 };
+constexpr BarColour kFlatBoth{ 0, 150, 0 };
+
+constexpr BarColour kNeither{ 240, 240, 240 };
+constexpr BarColour kFlatNeither{ 224, 224, 224 };
+
+constexpr BarColour kClientOnly{ 104, 104, 104 };
+constexpr BarColour kFlatClientOnly{ 0, 0, 0 };
+
+// The two request cues have no flat variant: they are already flat colours,
+// and the shaded bar draws them unshaded too.
+constexpr BarColour kPending{ 255, 208, 0 };
+constexpr BarColour kNextPending{ 255, 255, 100 };
+
+constexpr BarColour kUnavailable{ 240, 240, 240 };
+constexpr BarColour kFlatUnavailable{ 224, 224, 224 };
+
+constexpr BarColour kAvailable{ 104, 104, 104 };
+constexpr BarColour kFlatAvailable{ 0, 0, 0 };
+
+/**
+ * The five fills the Sources bar (ColumnUserProgress) distinguishes, in the
+ * order GetItemBarFill() tests them -- which is also the order the legend
+ * lists them in, so a reader can follow one against the other.
+ */
+enum class SourcePartState
+{
+	Missing = 0,   //!< the source does not have this part
+	Complete,      //!< the source has it and the file is complete here
+	Downloading,   //!< being downloaded from this source right now
+	NextRequested, //!< the next part that will be asked of this source
+	Needed         //!< the source has it and it is still missing here
+};
+
+/**
+ * The two fills the Peers bar (ColumnUserAvailable) distinguishes. A peer of
+ * one of our shared files is either holding a part or not; none of the
+ * request-state cues above apply, which is why the two columns cannot share
+ * one legend and, since #1192, no longer share one header label either.
+ */
+enum class PeerPartState
+{
+	Present = 0, //!< this peer already has the part
+	Missing      //!< this peer does not have it
+};
+
+//! Colour the Sources bar fills a part with, given its state and whether the
+//! flat-bar preference is on. The renderer calls this; so does the legend.
+constexpr BarColour SourcePartColour(SourcePartState state, bool flat)
+{
+	return state == SourcePartState::Missing         ? (flat ? kFlatNeither : kNeither)
+	       : state == SourcePartState::Complete      ? (flat ? kFlatBoth : kBoth)
+	       : state == SourcePartState::Downloading   ? kPending
+	       : state == SourcePartState::NextRequested ? kNextPending
+							 : (flat ? kFlatClientOnly : kClientOnly);
+}
+
+//! Colour the Peers bar fills a part with. Same contract as above.
+constexpr BarColour PeerPartColour(PeerPartState state, bool flat)
+{
+	return state == PeerPartState::Present ? (flat ? kFlatAvailable : kAvailable)
+					       : (flat ? kFlatUnavailable : kUnavailable);
+}
+
+//! Which legend, if any, belongs behind a column's header.
+enum class BarLegendKind
+{
+	None = 0,    //!< the column draws no chunk bar
+	SourceParts, //!< ColumnUserProgress, five states
+	PeerParts    //!< ColumnUserAvailable, two states
+};
+
+//! The legend the "?" beside a column header opens. BarLegendKind::None means
+//! the header carries no "?" at all.
+constexpr BarLegendKind LegendForColumn(GenericColumnEnum cid)
+{
+	return cid == ColumnUserProgress    ? BarLegendKind::SourceParts
+	       : cid == ColumnUserAvailable ? BarLegendKind::PeerParts
+					    : BarLegendKind::None;
+}
+
+//! Rows of the Sources legend, top to bottom.
+constexpr SourcePartState kSourceLegendOrder[] = { SourcePartState::Missing,
+	SourcePartState::Complete,
+	SourcePartState::Downloading,
+	SourcePartState::NextRequested,
+	SourcePartState::Needed };
+
+constexpr std::size_t kSourceLegendSize = sizeof(kSourceLegendOrder) / sizeof(kSourceLegendOrder[0]);
+
+//! Rows of the Peers legend, top to bottom.
+constexpr PeerPartState kPeerLegendOrder[] = { PeerPartState::Present, PeerPartState::Missing };
+
+constexpr std::size_t kPeerLegendSize = sizeof(kPeerLegendOrder) / sizeof(kPeerLegendOrder[0]);
+
+/**
+ * True when a header click at @a clickX landed on the "?" marker of a column
+ * spanning [@a columnLeft, columnLeft + @a columnWidth), whose marker occupies
+ * the trailing @a markerWidth pixels.
+ *
+ * Split out from the click handler because it is the only part of the
+ * affordance that can be got wrong silently: everything else either draws or
+ * does not. All four values are in the same horizontal coordinate space; the
+ * caller is responsible for having applied the horizontal scroll offset to
+ * both @a clickX and @a columnLeft.
+ *
+ * A marker wider than the column (a column dragged narrower than its own
+ * header text) claims the whole column rather than a negative span, which is
+ * the harmless end of that trade: the column is then too narrow to sort by
+ * clicking anyway.
+ */
+constexpr bool InLegendMarker(int clickX, int columnLeft, int columnWidth, int markerWidth)
+{
+	return columnWidth > 0 && markerWidth > 0 && clickX < columnLeft + columnWidth &&
+	       clickX >= columnLeft + (markerWidth >= columnWidth ? 0 : columnWidth - markerWidth);
+}
+
+} // namespace partbar
+
+#endif // PARTBARLEGEND_H

--- a/src/PartBarLegend.h
+++ b/src/PartBarLegend.h
@@ -26,7 +26,7 @@
 #define PARTBARLEGEND_H
 
 // The palette of the two chunk-bar columns of the client lists, and the legend
-// the "?" beside their headers opens.
+// the row context menu opens to explain it.
 //
 // The point of this header is that there is exactly one copy of each colour.
 // A legend that restated the palette -- in words, or in swatches filled from a
@@ -136,7 +136,7 @@ constexpr BarColour PeerPartColour(PeerPartState state, bool flat)
 					       : (flat ? kFlatUnavailable : kUnavailable);
 }
 
-//! Which legend, if any, belongs behind a column's header.
+//! Which legend, if any, explains a column's cells.
 enum class BarLegendKind
 {
 	None = 0,    //!< the column draws no chunk bar
@@ -144,8 +144,9 @@ enum class BarLegendKind
 	PeerParts    //!< ColumnUserAvailable, two states
 };
 
-//! The legend the "?" beside a column header opens. BarLegendKind::None means
-//! the header carries no "?" at all.
+//! The legend a column's colours are explained by. BarLegendKind::None means
+//! the column draws no bar, so a list showing only such columns offers no
+//! legend at all.
 constexpr BarLegendKind LegendForColumn(GenericColumnEnum cid)
 {
 	return cid == ColumnUserProgress    ? BarLegendKind::SourceParts
@@ -166,28 +167,6 @@ constexpr std::size_t kSourceLegendSize = sizeof(kSourceLegendOrder) / sizeof(kS
 constexpr PeerPartState kPeerLegendOrder[] = { PeerPartState::Present, PeerPartState::Missing };
 
 constexpr std::size_t kPeerLegendSize = sizeof(kPeerLegendOrder) / sizeof(kPeerLegendOrder[0]);
-
-/**
- * True when a header click at @a clickX landed on the "?" marker of a column
- * spanning [@a columnLeft, columnLeft + @a columnWidth), whose marker occupies
- * the trailing @a markerWidth pixels.
- *
- * Split out from the click handler because it is the only part of the
- * affordance that can be got wrong silently: everything else either draws or
- * does not. All four values are in the same horizontal coordinate space; the
- * caller is responsible for having applied the horizontal scroll offset to
- * both @a clickX and @a columnLeft.
- *
- * A marker wider than the column (a column dragged narrower than its own
- * header text) claims the whole column rather than a negative span, which is
- * the harmless end of that trade: the column is then too narrow to sort by
- * clicking anyway.
- */
-constexpr bool InLegendMarker(int clickX, int columnLeft, int columnWidth, int markerWidth)
-{
-	return columnWidth > 0 && markerWidth > 0 && clickX < columnLeft + columnWidth &&
-	       clickX >= columnLeft + (markerWidth >= columnWidth ? 0 : columnWidth - markerWidth);
-}
 
 } // namespace partbar
 

--- a/src/SharedFilePeersListCtrl.cpp
+++ b/src/SharedFilePeersListCtrl.cpp
@@ -31,7 +31,7 @@ CGenericClientListCtrlColumn s_sources_column_info[] = { { ColumnUserName, wxTRA
 	{ ColumnUserSpeedDown, wxTRANSLATE("Download Speed"), 65 },
 	{ ColumnUserUploaded, wxTRANSLATE("Uploaded"), 65 },
 	{ ColumnUserSpeedUp, wxTRANSLATE("Upload Speed"), 65 },
-	{ ColumnUserAvailable, wxTRANSLATE("Available Parts"), 170 },
+	{ ColumnUserAvailable, wxTRANSLATE("Parts on Peer"), 170 },
 	{ ColumnUserVersion, wxTRANSLATE("Version"), 50 },
 	{ ColumnUserQueueRankLocal, wxTRANSLATE("Upload Status"), 70 },
 	{ ColumnUserQueueRankRemote, wxTRANSLATE("Download Status"), 70 },

--- a/src/SourceListCtrl.cpp
+++ b/src/SourceListCtrl.cpp
@@ -38,7 +38,7 @@ static CGenericClientListCtrlColumn s_sources_column_info[] = {
 	{ ColumnUserDownloaded, wxTRANSLATE("Downloaded"), 65 },
 	{ ColumnUserSpeedDown, wxTRANSLATE("Speed"), 65 },
 	{ ColumnUserUploaded, wxTRANSLATE("Uploaded"), 65 },
-	{ ColumnUserProgress, wxTRANSLATE("Available Parts"), 170 },
+	{ ColumnUserProgress, wxTRANSLATE("Part Status"), 170 },
 	{ ColumnUserVersion, wxTRANSLATE("Version"), 50 },
 	{ ColumnUserQueueRankRemote, wxTRANSLATE("Download Status"), 55 },
 	{ ColumnUserOrigin, wxTRANSLATE("Origin"), 110 },

--- a/src/include/common/MenuIDs.h
+++ b/src/include/common/MenuIDs.h
@@ -37,6 +37,9 @@ enum
 	MP_SHOWLIST,
 	MP_FRIENDSLOT,
 	MP_CHANGE2FILE,
+	// Explains the colours of a chunk-bar column. Only the client lists that
+	// actually draw one offer it -- see CGenericClientListCtrl.
+	MP_BARLEGEND,
 	MP_CANCEL,
 	MP_STOP,
 	MP_RESUME,

--- a/unittests/tests/CMakeLists.txt
+++ b/unittests/tests/CMakeLists.txt
@@ -974,6 +974,30 @@ target_link_libraries (RangeFileBodyTest
 # parts, a source whose state flips to "downloading" -- so PartIndex.h is
 # header-only and free of wx, Beast and EC, and the test needs nothing but
 # the harness.
+# The chunk-bar palette and the two legends the "?" beside the bar column
+# headers opens. Header-only and wx-free on purpose (see PartBarLegend.h): the
+# colours, the rows of each legend, which legend a column gets and where the "?"
+# is clickable are all decided without a toolkit, so a headless run can check
+# the half of the feature that can drift silently. Needs no app and no daemon.
+add_executable (PartBarLegendTest
+	PartBarLegendTest.cpp
+)
+
+add_test (NAME PartBarLegendTest
+	COMMAND PartBarLegendTest
+)
+
+target_include_directories (PartBarLegendTest
+	PRIVATE ${CMAKE_SOURCE_DIR}/src
+)
+
+# mulecommon even though the header is inline-only: macOS links without it,
+# GNU ld and mingw do not (see JsonDepthScanTest).
+target_link_libraries (PartBarLegendTest
+	muleunit
+	mulecommon
+)
+
 add_executable (PartIndexTest
 	PartIndexTest.cpp
 )

--- a/unittests/tests/PartBarLegendTest.cpp
+++ b/unittests/tests/PartBarLegendTest.cpp
@@ -22,8 +22,8 @@
 // Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301, USA
 //
 
-// The chunk-bar palette and the legend the "?" beside the two bar column
-// headers opens (issue #1192).
+// The chunk-bar palette and the legend the row context menu opens to explain
+// it (issue #1192).
 //
 // A legend explaining colours is only worth anything while it agrees with the
 // bar, and the way that agreement dies is silent: someone changes a colour in
@@ -38,8 +38,8 @@
 //
 // It links no wx and opens no display session, which is the point: this is the
 // half of the feature that a headless CI run can actually check. The drawing
-// (16x16 swatches through a wxMemoryDC, the "?" hit region in real pixels) is
-// not reachable from here.
+// (16x16 swatches through a wxMemoryDC) and the context-menu entry that opens
+// the dialog are not reachable from here.
 
 #include <muleunit/test.h>
 
@@ -173,52 +173,12 @@ TEST(PartBarLegend, OnlyTheTwoBarColumnsHaveALegend)
 	ASSERT_TRUE(BarLegendKind::SourceParts == LegendForColumn(ColumnUserProgress));
 	ASSERT_TRUE(BarLegendKind::PeerParts == LegendForColumn(ColumnUserAvailable));
 
-	// Every other column, exhaustively: a "?" on a text column would open a
-	// legend for a bar that is not there.
+	// Every other column, exhaustively: a legend offered for a text column
+	// would explain a bar that is not there.
 	for (std::size_t i = 0; i < kAllColumnsSize; ++i) {
 		if (kAllColumns[i] == ColumnUserProgress || kAllColumns[i] == ColumnUserAvailable) {
 			continue;
 		}
 		ASSERT_TRUE(BarLegendKind::None == LegendForColumn(kAllColumns[i]));
 	}
-}
-
-// --- the "?" hit region -------------------------------------------------
-
-TEST(PartBarLegend, TheMarkerClaimsTheTrailingPixelsOfItsOwnColumn)
-{
-	// A 170-wide column starting at 300, with a 24px marker: the marker owns
-	// [446, 470) and nothing else.
-	ASSERT_TRUE(InLegendMarker(446, 300, 170, 24));
-	ASSERT_TRUE(InLegendMarker(469, 300, 170, 24));
-	ASSERT_FALSE(InLegendMarker(445, 300, 170, 24));
-	ASSERT_FALSE(InLegendMarker(300, 300, 170, 24));
-
-	// The right edge belongs to the next column, not to this marker.
-	ASSERT_FALSE(InLegendMarker(470, 300, 170, 24));
-	ASSERT_FALSE(InLegendMarker(600, 300, 170, 24));
-
-	// Nor does anything to the left of the column.
-	ASSERT_FALSE(InLegendMarker(299, 300, 170, 24));
-	ASSERT_FALSE(InLegendMarker(0, 300, 170, 24));
-}
-
-TEST(PartBarLegend, AColumnNarrowerThanItsMarkerIsAllMarker)
-{
-	// Dragged down to less than the marker's own width, the column has no
-	// room left for a non-marker part; the alternative arithmetic would give
-	// the marker a left edge outside the column.
-	ASSERT_TRUE(InLegendMarker(300, 300, 20, 24));
-	ASSERT_TRUE(InLegendMarker(319, 300, 20, 24));
-	ASSERT_FALSE(InLegendMarker(320, 300, 20, 24));
-	ASSERT_FALSE(InLegendMarker(299, 300, 20, 24));
-}
-
-TEST(PartBarLegend, AHiddenOrUnmeasurableColumnHasNoMarker)
-{
-	// Zero width is a hidden column; a zero-width marker means the text
-	// could not be measured. Either way there is nothing to click, and the
-	// click has to fall through to sorting rather than open a legend.
-	ASSERT_FALSE(InLegendMarker(300, 300, 0, 24));
-	ASSERT_FALSE(InLegendMarker(300, 300, 170, 0));
 }

--- a/unittests/tests/PartBarLegendTest.cpp
+++ b/unittests/tests/PartBarLegendTest.cpp
@@ -1,0 +1,224 @@
+//
+// This file is part of the aMule Project.
+//
+// Copyright (c) 2003-2026 aMule Team ( https://amule-org.github.io )
+//
+// Any parts of this program derived from the xMule, lMule or eMule project,
+// or contributed by third-party developers are copyrighted by their
+// respective authors.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301, USA
+//
+
+// The chunk-bar palette and the legend the "?" beside the two bar column
+// headers opens (issue #1192).
+//
+// A legend explaining colours is only worth anything while it agrees with the
+// bar, and the way that agreement dies is silent: someone changes a colour in
+// the renderer and the explanation, wherever it lives, keeps saying the old
+// thing. PartBarLegend.h answers that by having exactly one copy of each
+// colour, which both the renderer and the legend read. This suite is the other
+// half: it pins the values themselves against what the bar drew before they
+// were lifted out of GenericClientListCtrl.cpp, so a colour cannot be edited on
+// the way past without a test saying so, and it pins the properties a legend
+// needs in order to be readable at all -- one row per state the bar can draw,
+// in the order the renderer decides them, no two rows the same colour.
+//
+// It links no wx and opens no display session, which is the point: this is the
+// half of the feature that a headless CI run can actually check. The drawing
+// (16x16 swatches through a wxMemoryDC, the "?" hit region in real pixels) is
+// not reachable from here.
+
+#include <muleunit/test.h>
+
+#include "PartBarLegend.h"
+
+#include <cstddef>
+
+using namespace muleunit;
+using namespace partbar;
+
+namespace
+{
+
+//! Spelled out rather than compared to the constants in the header: a test
+//! that read the palette from the same place the renderer does would pass no
+//! matter what either said.
+constexpr BarColour kExpectedNeither{ 240, 240, 240 };
+constexpr BarColour kExpectedFlatNeither{ 224, 224, 224 };
+constexpr BarColour kExpectedBoth{ 0, 192, 0 };
+constexpr BarColour kExpectedFlatBoth{ 0, 150, 0 };
+constexpr BarColour kExpectedClientOnly{ 104, 104, 104 };
+constexpr BarColour kExpectedFlatClientOnly{ 0, 0, 0 };
+constexpr BarColour kExpectedPending{ 255, 208, 0 };
+constexpr BarColour kExpectedNextPending{ 255, 255, 100 };
+
+//! Every column id, so the legend mapping can be checked exhaustively rather
+//! than on the two interesting cases alone.
+constexpr GenericColumnEnum kAllColumns[] = { ColumnUserName,
+	ColumnUserDownloaded,
+	ColumnUserUploaded,
+	ColumnUserSpeedDown,
+	ColumnUserSpeedUp,
+	ColumnUserProgress,
+	ColumnUserAvailable,
+	ColumnUserVersion,
+	ColumnUserQueueRankLocal,
+	ColumnUserQueueRankRemote,
+	ColumnUserOrigin,
+	ColumnUserFileNameDownload,
+	ColumnUserFileNameUpload,
+	ColumnUserFileNameDownloadRemote,
+	ColumnUserSharedFiles,
+	ColumnInvalid };
+
+constexpr std::size_t kAllColumnsSize = sizeof(kAllColumns) / sizeof(kAllColumns[0]);
+
+} // namespace
+
+DECLARE_SIMPLE(PartBarLegend)
+
+// --- the palette itself -------------------------------------------------
+
+TEST(PartBarLegend, SourceColoursAreTheOnesTheBarDrew)
+{
+	// The five shaded-bar fills, in the order GetItemBarFill() tests them.
+	ASSERT_TRUE(kExpectedNeither == SourcePartColour(SourcePartState::Missing, false));
+	ASSERT_TRUE(kExpectedBoth == SourcePartColour(SourcePartState::Complete, false));
+	ASSERT_TRUE(kExpectedPending == SourcePartColour(SourcePartState::Downloading, false));
+	ASSERT_TRUE(kExpectedNextPending == SourcePartColour(SourcePartState::NextRequested, false));
+	ASSERT_TRUE(kExpectedClientOnly == SourcePartColour(SourcePartState::Needed, false));
+}
+
+TEST(PartBarLegend, SourceColoursHaveTheirOwnFlatBarValues)
+{
+	ASSERT_TRUE(kExpectedFlatNeither == SourcePartColour(SourcePartState::Missing, true));
+	ASSERT_TRUE(kExpectedFlatBoth == SourcePartColour(SourcePartState::Complete, true));
+	ASSERT_TRUE(kExpectedFlatClientOnly == SourcePartColour(SourcePartState::Needed, true));
+
+	// The two request cues are the exception: flat and shaded draw them the
+	// same, which is why neither has a crFlat* counterpart to drift from.
+	ASSERT_TRUE(kExpectedPending == SourcePartColour(SourcePartState::Downloading, true));
+	ASSERT_TRUE(kExpectedNextPending == SourcePartColour(SourcePartState::NextRequested, true));
+}
+
+TEST(PartBarLegend, PeerColoursAreTheOnesTheBarDrew)
+{
+	// The peers bar reuses the greys of the sources bar, but for its own two
+	// states -- has / has not -- with no request cues in between.
+	ASSERT_TRUE(kExpectedClientOnly == PeerPartColour(PeerPartState::Present, false));
+	ASSERT_TRUE(kExpectedNeither == PeerPartColour(PeerPartState::Missing, false));
+	ASSERT_TRUE(kExpectedFlatClientOnly == PeerPartColour(PeerPartState::Present, true));
+	ASSERT_TRUE(kExpectedFlatNeither == PeerPartColour(PeerPartState::Missing, true));
+}
+
+// --- the legends --------------------------------------------------------
+
+TEST(PartBarLegend, TheSourceLegendListsEveryStateOnceInRendererOrder)
+{
+	// One row per fill the sources bar can draw: a state the renderer knows
+	// and the legend does not is a colour with no explanation, which is the
+	// bug the legend exists to fix.
+	ASSERT_EQUALS((std::size_t)5, kSourceLegendSize);
+	ASSERT_TRUE(SourcePartState::Missing == kSourceLegendOrder[0]);
+	ASSERT_TRUE(SourcePartState::Complete == kSourceLegendOrder[1]);
+	ASSERT_TRUE(SourcePartState::Downloading == kSourceLegendOrder[2]);
+	ASSERT_TRUE(SourcePartState::NextRequested == kSourceLegendOrder[3]);
+	ASSERT_TRUE(SourcePartState::Needed == kSourceLegendOrder[4]);
+}
+
+TEST(PartBarLegend, ThePeerLegendListsItsTwoStates)
+{
+	// Two, not five: the asymmetry between the two bar columns is the reason
+	// they were named apart, so collapsing them into one legend would undo
+	// the change it belongs to.
+	ASSERT_EQUALS((std::size_t)2, kPeerLegendSize);
+	ASSERT_TRUE(PeerPartState::Present == kPeerLegendOrder[0]);
+	ASSERT_TRUE(PeerPartState::Missing == kPeerLegendOrder[1]);
+}
+
+TEST(PartBarLegend, NoTwoRowsOfALegendShareAColour)
+{
+	// Two rows of one swatch cannot be told apart on screen, so the legend
+	// would be explaining a distinction the bar does not draw. Checked under
+	// both bar styles, since each has its own values.
+	for (int flat = 0; flat <= 1; ++flat) {
+		for (std::size_t i = 0; i < kSourceLegendSize; ++i) {
+			for (std::size_t j = i + 1; j < kSourceLegendSize; ++j) {
+				ASSERT_TRUE(SourcePartColour(kSourceLegendOrder[i], flat != 0) !=
+					    SourcePartColour(kSourceLegendOrder[j], flat != 0));
+			}
+		}
+		ASSERT_TRUE(PeerPartColour(kPeerLegendOrder[0], flat != 0) !=
+			    PeerPartColour(kPeerLegendOrder[1], flat != 0));
+	}
+}
+
+// --- which legend a column gets -----------------------------------------
+
+TEST(PartBarLegend, OnlyTheTwoBarColumnsHaveALegend)
+{
+	ASSERT_TRUE(BarLegendKind::SourceParts == LegendForColumn(ColumnUserProgress));
+	ASSERT_TRUE(BarLegendKind::PeerParts == LegendForColumn(ColumnUserAvailable));
+
+	// Every other column, exhaustively: a "?" on a text column would open a
+	// legend for a bar that is not there.
+	for (std::size_t i = 0; i < kAllColumnsSize; ++i) {
+		if (kAllColumns[i] == ColumnUserProgress || kAllColumns[i] == ColumnUserAvailable) {
+			continue;
+		}
+		ASSERT_TRUE(BarLegendKind::None == LegendForColumn(kAllColumns[i]));
+	}
+}
+
+// --- the "?" hit region -------------------------------------------------
+
+TEST(PartBarLegend, TheMarkerClaimsTheTrailingPixelsOfItsOwnColumn)
+{
+	// A 170-wide column starting at 300, with a 24px marker: the marker owns
+	// [446, 470) and nothing else.
+	ASSERT_TRUE(InLegendMarker(446, 300, 170, 24));
+	ASSERT_TRUE(InLegendMarker(469, 300, 170, 24));
+	ASSERT_FALSE(InLegendMarker(445, 300, 170, 24));
+	ASSERT_FALSE(InLegendMarker(300, 300, 170, 24));
+
+	// The right edge belongs to the next column, not to this marker.
+	ASSERT_FALSE(InLegendMarker(470, 300, 170, 24));
+	ASSERT_FALSE(InLegendMarker(600, 300, 170, 24));
+
+	// Nor does anything to the left of the column.
+	ASSERT_FALSE(InLegendMarker(299, 300, 170, 24));
+	ASSERT_FALSE(InLegendMarker(0, 300, 170, 24));
+}
+
+TEST(PartBarLegend, AColumnNarrowerThanItsMarkerIsAllMarker)
+{
+	// Dragged down to less than the marker's own width, the column has no
+	// room left for a non-marker part; the alternative arithmetic would give
+	// the marker a left edge outside the column.
+	ASSERT_TRUE(InLegendMarker(300, 300, 20, 24));
+	ASSERT_TRUE(InLegendMarker(319, 300, 20, 24));
+	ASSERT_FALSE(InLegendMarker(320, 300, 20, 24));
+	ASSERT_FALSE(InLegendMarker(299, 300, 20, 24));
+}
+
+TEST(PartBarLegend, AHiddenOrUnmeasurableColumnHasNoMarker)
+{
+	// Zero width is a hidden column; a zero-width marker means the text
+	// could not be measured. Either way there is nothing to click, and the
+	// click has to fall through to sorting rather than open a legend.
+	ASSERT_FALSE(InLegendMarker(300, 300, 0, 24));
+	ASSERT_FALSE(InLegendMarker(300, 300, 170, 0));
+}


### PR DESCRIPTION
## Summary

Closes #1192. **Generated with AI**, flagged up front per the terms in #1177.

@slrslr asks whether "Available Parts" means available locally or remotely. On the Downloads side the answer is *neither*, which is why the label could not be repaired in place — and looking at it turned up a second problem he could not have seen from the UI: **the same translatable string labels two different columns.**

```
src/SourceListCtrl.cpp:41            ColumnUserProgress    wxTRANSLATE("Available Parts")
src/SharedFilePeersListCtrl.cpp:34   ColumnUserAvailable   wxTRANSLATE("Available Parts")
```

They share `GetItemBarFill` but not a palette, so Weblate hands a translator one source string for two concepts with no way to tell them apart.

### What each bar actually shows

**Downloads → sources** is the intersection of remote and local: the *source's* parts, coloured by *our* completion. Five states, first match wins:

| condition | colour | meaning |
|---|---|---|
| `!partStatus.get(i)` | light grey | the source does not have this part |
| `reqfile->IsComplete(i)` | green | the source has it and so do we |
| `lastDownloadingPart == i` | amber | arriving from this source now |
| `nextRequestedPart == i` | pale yellow | the next part we will request |
| otherwise | dark grey | the source has it and we still need it |

plus the whole bar dimmed while the file is stopped. Only the first row is about availability, so `Downloaded parts` would be wrong and `Remote availability` would be too — hence **"Part Status"**.

**Shared Files → peers** genuinely is one peer's holdings: two states from `IsUpPartAvailable`. **"Parts on Peer"**, matching the panel it sits in.

**Both names are proposals and I have no attachment to them.** The one I weighed and rejected for the downloads column was `Source Parts`, which reads well but implies the bar is about the source alone and loses the green and amber states. For the shared column I rejected `Parts Held`, which is accurate but does not say *whose*. Say the word and I will change either.

### The tooltip

There was none — no `SetToolTip` anywhere in `SourceListCtrl.cpp` or `GenericClientListCtrl.cpp` — so the colours were undocumented in the UI entirely, which is @slrslr's first complaint. An `EVT_MOTION` handler now shows a per-column legend while the pointer is over a bar, using the `HitTest(pos, item, column)` the middle-click handler already relies on. Set only when the text changes, since setting a tooltip on every motion event flickers; `UnsetToolTip` on leaving the column; `event.Skip()` so hover highlight and drag tracking still work.

No renderer, palette or behaviour change.

## Test plan

- **Builds clean**: monolithic GUI, wxWidgets 3.3.3, macOS/arm64 — zero errors, zero new warnings in the three touched files.
- **`scripts/check-potfiles.sh`** passes.
- **Catalogues regenerated** with `scripts/update-po.sh`, as the I18n CI failure message instructs. Verified **idempotent**: re-running the script afterwards changes zero files under the workflow's own drift comparison (`msgcat --no-wrap`, metadata and `#:` lines stripped), so the "no real content drift" step should pass.
- clang-format 18 clean on all four changed files.

**What I could not verify, stated plainly:** I could not launch the GUI — this was built and checked in a headless automation context with no display session. So **the tooltip is unverified at runtime**: that it appears, that it appears over the right column and not its neighbours, that `UnsetToolTip` clears it on leaving, and that it does not flicker are all reasoned from the code and from the existing `HitTest` usage, not observed. Anyone with a desktop session can settle it in ten seconds, and I would rather say so than let a build-only check read as more than it is.
