### PR TITLE
feat(amuleapi): carry the A4AF source membership on the download object

### DIFF
--- a/docs/api/EVENTS.md
+++ b/docs/api/EVENTS.md
@@ -268,7 +268,7 @@ Every event the bus publishes. The `_added` and `_updated` payloads are BYTE-FOR
 
 #### `download_added` / `download_updated`
 
-Identical to the REST [`/api/v0/downloads`](REFERENCE.md#get-apiv0downloads) list-item shape. `_updated` fires on any field-level change including `completed_bytes`, `transferred_bytes`, `speed_bytes_per_second`, the source counters, `kad_comment_lookup_running` and `hashed_part_count` — clients see live progress (and the Kad-notes lookup start → finish edge, and a running hash) without polling.
+Identical to the REST [`/api/v0/downloads`](REFERENCE.md#get-apiv0downloads) list-item shape. `_updated` fires on any field-level change including `completed_bytes`, `transferred_bytes`, `speed_bytes_per_second`, the source counters, `kad_comment_lookup_running`, `hashed_part_count` and `source_ecids` — clients see live progress (and the Kad-notes lookup start → finish edge, and a running hash) without polling.
 
 ```json
 {
@@ -287,9 +287,12 @@ Identical to the REST [`/api/v0/downloads`](REFERENCE.md#get-apiv0downloads) lis
   "progress": { "percent": 29.85 },
   "kad_comment_lookup_running": false,
   "hashed_part_count":  0,
-  "parts_total_count":  411
+  "parts_total_count":  411,
+  "source_ecids":  [ 1234, 5678 ]
 }
 ```
+
+`source_ecids` is the A4AF membership: the ECIDs of the clients parked on this file while pulling another. It is compared as a list, not through the `sources.a4af` count beside it, so a swap that moves one client out and another in still fires `download_updated`. Join it against the `clients` channel to shade the A4AF rows of a per-file client list without polling [`GET /downloads/{hash}/clients`](REFERENCE.md#get-apiv0downloadshashclients--get-apiv0sharedhashclients) — A4AF is a client-to-*file* relation, so it is the one such row attribute the client object cannot carry.
 
 A `POST /downloads/{hash}/comments` flips `kad_comment_lookup_running` to `true`, producing a `download_updated`; when the Kad lookup finishes (typically ~45 s, or sooner) it flips back to `false`, producing another. Retrieved notes are then read via `GET /downloads/{hash}/comments`.
 

--- a/docs/api/REFERENCE.md
+++ b/docs/api/REFERENCE.md
@@ -843,7 +843,9 @@ curl -s -H "Authorization: Bearer $TOKEN" "http://$HOST/api/v0/downloads"
       "sources":  { "total": 217, "unavailable": 23, "transferring": 8, "a4af": 4 },
       "progress": { "percent": 29.85 },
       "kad_comment_lookup_running": false,
-      "hashed_part_count": 0
+      "hashed_part_count": 0,
+      "parts_total_count": 394,
+      "source_ecids": [ 1234, 5678 ]
     }
   ]
 }
@@ -860,6 +862,8 @@ The list shape omits `progress.parts` to keep large libraries compact. Use the d
 `kad_comment_lookup_running` is `true` while an on-demand Kad notes lookup is in flight for the file (started by [`POST /downloads/{hash}/comments`](#post-apiv0downloadshashcomments)); it flips back to `false` when the lookup finishes. Because it lives on the download object, a client can watch the `download_updated` SSE event for the start → finish transition instead of polling.
 
 `hashed_part_count` is the number of parts hashed so far by a pass running over the file — a `hashing` status, an [`AICH`](#post-apiv0sharedhashverify) hashset rebuild — and `0` when nothing is hashing. It is a count of completed parts, not the index of the part in flight, so it runs `0` → `parts_total_count`; divide by `parts_total_count` (from the detail endpoint, or `ceil(size / 9728000)`) for a percentage.
+
+`source_ecids` are the ECIDs of the clients holding this file as an A4AF source — the same array, under the same name, that [`POST /downloads/{hash}/a4af`](#post-apiv0downloadshasha4af) returns, and `[]` when there are none. It is the one thing a per-file client list needs that [`GET /api/v0/clients`](#get-apiv0clients) and the `clients` SSE channel cannot say: A4AF is a relation between a client and a *file*, so it does not live on the client object. With it on the download event, a Clients panel driven by the `downloads` and `clients` channels can shade its A4AF rows from the stream instead of polling [`GET /downloads/{hash}/clients`](#get-apiv0downloadshashclients--get-apiv0sharedhashclients). Note the name is scoped to A4AF, not to sources at large — the count of *all* sources is `sources.total`.
 
 The SSE `download_added` / `download_updated` event payload matches this object byte-for-byte.
 
@@ -1059,7 +1063,7 @@ The swap moves the client between two files' source lists, so an SSE subscriber 
 { "a4af_auto": false, "source_ecids": [ 1234, 5678 ] }
 ```
 
-`source_ecids` are the ECIDs of the clients holding this file as an A4AF source, joinable against [`GET /api/v0/clients`](#get-apiv0clients). The array is the post-action state, so a `swap_this` naming a single client shows up as that ECID having left it. The same clients appear as rows with `"a4af": true` on [`GET /api/v0/downloads/{hash}/clients`](#get-apiv0downloadshashclients--get-apiv0sharedhashclients), which carries the whole client object rather than a bare ECID.
+`source_ecids` are the ECIDs of the clients holding this file as an A4AF source, joinable against [`GET /api/v0/clients`](#get-apiv0clients). The same array, under the same name, rides the download object and its `download_updated` SSE event, so a subscriber does not have to POST here to keep it current. The array is the post-action state, so a `swap_this` naming a single client shows up as that ECID having left it. The same clients appear as rows with `"a4af": true` on [`GET /api/v0/downloads/{hash}/clients`](#get-apiv0downloadshashclients--get-apiv0sharedhashclients), which carries the whole client object rather than a bare ECID.
 
 **Errors:** `400 bad_request` (missing or unknown `action`; `swap_this_auto`, which moved to `PATCH`; a non-integer `client_ecid`; `client_ecid` with the wrong action), `400 amuled_rejected` (the daemon refused the swap — most commonly because the client is actively sending data, which it will not be swapped away from), `404 not_found` (no download with that hash, or no client with that ECID), `409 conflict` (that client is not an A4AF source of this download), `503 ec_unavailable`.
 

--- a/src/webapi/Api.cpp
+++ b/src/webapi/Api.cpp
@@ -2935,6 +2935,16 @@ void WriteDownloadObject(
 	const std::int64_t parts_total_count = static_cast<std::int64_t>(webapi::PartCountForSize(f.size));
 	w.Key("parts_total_count");
 	w.ValueInt(parts_total_count);
+	// On the list, not detail-only, so the SSE download event carries it:
+	// A4AF is a client-to-file relation, the one thing a per-file client
+	// list needs that the `clients` channel cannot say. Same spelling as on
+	// POST /downloads/{hash}/a4af (R6).
+	w.Key("source_ecids");
+	w.BeginArray();
+	for (const std::uint32_t ecid : f.download.a4af_sources) {
+		w.ValueInt(static_cast<int64_t>(ecid));
+	}
+	w.EndArray();
 	if (detail) {
 		// Detail-only fields (GET /downloads/{hash}); omitted from the
 		// list. `remaining_seconds` is computed here from the snapshot --

--- a/src/webapi/EventDiff.cpp
+++ b/src/webapi/EventDiff.cpp
@@ -32,6 +32,7 @@
 
 #include <algorithm>
 #include <atomic>
+#include <cstdint>
 #include <cstdlib>
 #include <iostream>
 #include <sstream>
@@ -126,7 +127,15 @@ std::string ToJsonDownloadEvent(const FileSnapshot &f)
 	  << ",\"progress\":{\"percent\":" << JsonDoubleToString(f.download.percent) << "}"
 	  << ",\"kad_comment_lookup_running\":" << (f.download.kad_comment_searching ? "true" : "false")
 	  << ",\"hashed_part_count\":" << f.download.hashed_part_count
-	  << ",\"parts_total_count\":" << webapi::PartCountForSize(f.size) << "}";
+	  << ",\"parts_total_count\":" << webapi::PartCountForSize(f.size) << ",\"source_ecids\":[";
+	bool first_a4af = true;
+	for (const std::uint32_t ecid : f.download.a4af_sources) {
+		if (!first_a4af)
+			o << ",";
+		first_a4af = false;
+		o << ecid;
+	}
+	o << "]}";
 	return o.str();
 }
 
@@ -426,7 +435,11 @@ bool EqualDownload(const FileSnapshot &a, const FileSnapshot &b)
 	       a.download.sources_a4af == b.download.sources_a4af &&
 	       a.download.percent == b.download.percent &&
 	       a.download.kad_comment_searching == b.download.kad_comment_searching &&
-	       a.download.hashed_part_count == b.download.hashed_part_count;
+	       a.download.hashed_part_count == b.download.hashed_part_count &&
+	       // The membership, not the `sources_a4af` count beside it: a swap
+	       // moves one client out and another in, so the count never budges
+	       // and comparing it would publish nothing.
+	       a.download.a4af_sources == b.download.a4af_sources;
 }
 
 // Comment list equality (deliberately NOT part of EqualDownload — a comment

--- a/unittests/curl-tests/amuleapi/04-read-downloads-shared.sh
+++ b/unittests/curl-tests/amuleapi/04-read-downloads-shared.sh
@@ -141,6 +141,12 @@ if [ "$COUNT" -gt 0 ]; then
 	# left a list-driven client with no way to see a hash running.
 	_assert_json_eq '.downloads[0].hashed_part_count | type' number \
 		'/downloads[0].hashed_part_count is numeric (#1054)'
+	# A4AF membership on the list, so the SSE download event carries it and a
+	# per-file Clients panel stops polling /downloads/{hash}/clients for it.
+	_assert_json_eq '.downloads[0].source_ecids | type' array \
+		'/downloads[0].source_ecids is an array'
+	_assert_json_eq '[.downloads[0].source_ecids[] | type] | all(. == "number")' true \
+		'/downloads[0].source_ecids holds only numeric ECIDs'
 
 	# --- 4. /downloads/{hash} bare-object detail. -----------------
 	HASH=$(printf '%s' "$CURL_BODY" | jq -r '.downloads[0].hash')
@@ -183,6 +189,8 @@ if [ "$COUNT" -gt 0 ]; then
 		'/downloads/{hash} carries my_rating (yours, not comments[].rating)'
 	_assert_json_eq '.a4af_auto | type' boolean \
 		'/downloads/{hash} carries a4af_auto'
+	_assert_json_eq '.source_ecids | type' array \
+		'/downloads/{hash} carries source_ecids (same key as POST .../a4af)'
 
 	# Per-source comments sub-resource (issue #419).
 	_curl -H "Authorization: Bearer $TOKEN" "$HOST/api/v0/downloads/$HASH/comments"

--- a/unittests/curl-tests/amuleapi/22-sse-diff-emission.sh
+++ b/unittests/curl-tests/amuleapi/22-sse-diff-emission.sh
@@ -166,6 +166,20 @@ if [ -n "$ADDED" ]; then
 	else
 		_fail "download_added .data.hashed_part_count" "not a number in $JSON"
 	fi
+	# A4AF membership rides the download event: it is the only per-file
+	# client relation the `clients` channel cannot carry, and a per-file
+	# Clients panel polled /downloads/{hash}/clients purely to get it.
+	# Always an array, never absent (R10) — empty for a fresh download.
+	if echo "$JSON" | jq -e '.source_ecids | type == "array"' >/dev/null 2>&1; then
+		_pass "download_added .data.source_ecids is an array"
+	else
+		_fail "download_added .data.source_ecids" "not an array in $JSON"
+	fi
+	if echo "$JSON" | jq -e '[.source_ecids[] | type] | all(. == "number")' >/dev/null 2>&1; then
+		_pass "download_added .data.source_ecids holds only numeric ECIDs"
+	else
+		_fail "download_added .data.source_ecids" "non-numeric entry in $JSON"
+	fi
 else
 	_fail "download_added missing" \
 		"no event with the Ubuntu ISO hash within 12 s; stream sample: $(head -30 "$SSE_OUT")"

--- a/unittests/tests/EventDiffTest.cpp
+++ b/unittests/tests/EventDiffTest.cpp
@@ -1234,6 +1234,71 @@ TEST(EventDiff, DownloadUpdatedFiresWhenOnlyHashingProgressMoved)
 	ASSERT_TRUE(payload.find("\"hashed_part_count\":5") != std::string::npos);
 }
 
+// The A4AF membership rides download_updated, and the predicate compares the
+// list rather than the count that summarises it. A swap moves one client out
+// and another in, so `sources_a4af` never moves -- comparing only the count
+// left the panel showing the client that had already left.
+TEST(EventDiff, DownloadUpdatedFiresWhenTheA4afSourceSetSwapsAtAConstantCount)
+{
+	CState state;
+	state.MutateDownloads([](FileMap &files) {
+		FileSnapshot f;
+		f.ecid = 15;
+		f.hash = "5555555555555555555555555555eeee";
+		f.name = "parked.iso";
+		f.size = kPartSizeBytes * 2;
+		f.is_downloading = true;
+		f.download.sources_a4af = 2;
+		f.download.a4af_sources = { 7, 9 };
+		files.emplace(f.ecid, f);
+	});
+
+	CEventBus bus;
+	LastSeenState prev;
+	EmitDiffsAndUpdate(bus, prev, state);
+	DrainAll(bus);
+
+	state.MutateDownloads(
+		[](FileMap &files) { files.find(15)->second.download.a4af_sources = { 7, 11 }; });
+	EmitDiffsAndUpdate(bus, prev, state);
+
+	std::string payload;
+	for (const auto &e : DrainAll(bus)) {
+		if (e.name == "download_updated")
+			payload = e.data;
+	}
+	ASSERT_TRUE(!payload.empty());
+	ASSERT_TRUE(payload.find("\"source_ecids\":[7,11]") != std::string::npos);
+}
+
+// R10: the key is always there. A download with no A4AF sources reports an
+// empty array, so a client can index it without first testing for the key.
+TEST(EventDiff, DownloadEventCarriesAnEmptySourceEcidsArrayWithNoA4afSources)
+{
+	CState state;
+	state.MutateDownloads([](FileMap &files) {
+		FileSnapshot f;
+		f.ecid = 16;
+		f.hash = "6666666666666666666666666666ffff";
+		f.name = "lonely.iso";
+		f.size = kPartSizeBytes;
+		f.is_downloading = true;
+		files.emplace(f.ecid, f);
+	});
+
+	CEventBus bus;
+	LastSeenState prev;
+	EmitDiffsAndUpdate(bus, prev, state);
+
+	std::string payload;
+	for (const auto &e : DrainAll(bus)) {
+		if (e.name == "download_added")
+			payload = e.data;
+	}
+	ASSERT_TRUE(!payload.empty());
+	ASSERT_TRUE(payload.find("\"source_ecids\":[]") != std::string::npos);
+}
+
 // A file leaving the map fires download_removed carrying its hash, and drops
 // out of the baseline — the `gone` erase. Without it the baseline would grow
 // without bound across a session and keep re-firing the removal every tick.


### PR DESCRIPTION
Opened at @got3nks's request in #1215, where he asked for this as its own PR rather than in the Web UI diff. **Generated with AI**, flagged up front per #1177.

## Why

The per-file Clients panel in #1215 polls `GET /downloads/{hash}/clients` every 5 s. The `clients` SSE channel already carries everything that panel shows — `download_file_hash`, `upload_file_hash`, `source_origin`, `shared_files_browsable`. The **one** thing it cannot express is the A4AF relation: which clients are parked on this file having asked for another. One boolean per row is the entire reason the poll exists.

`a4af_sources` is already built every refresh tick (`Refresher.cpp:672`) on the download snapshot. It was simply never emitted outside the `POST /downloads/{hash}/a4af` response.

## What

`source_ecids`, an array of EC ids, on the download object. Placed **before** the `if (detail)` block so it rides the list and therefore the `download_added` / `download_updated` SSE payloads, which is the whole point — a detail-only field would not remove any polling. The name is the spelling already used on `POST /downloads/{hash}/a4af`, so the same concept keeps one name across the surface.

**And the membership in `EqualDownload`**, which is the half that matters:

```cpp
a.download.a4af_sources == b.download.a4af_sources
```

`EqualDownload` compared `sources_a4af`, the count. A swap moves one client out and another in at a constant count, so comparing the summary instead of the thing it summarises would emit nothing and fail in a way nobody would ever notice. @got3nks named this before a line was written; it is his catch, not mine.

## Cost

@got3nks measured it in #1215 and I am not restating his numbers as if they were mine: **+18 bytes on a 623-byte payload (2.9%)** empty, **+32 (5.1%)** with three sources, and **no additional events** — `EqualDownload` already compares `speed_bytes_per_second` and `completed_bytes`, which move every tick for anything transferring, so these frames are in flight regardless. It is the `downloads` channel, the active queue, not `shared` — so @ngosang's 20k-shared-file phone is untouched.

Two things I checked independently, because both could have turned a cheap change into a per-tick storm and neither is visible from the diff:

- **Ordering cannot publish spuriously.** `a4af_sources` is a `std::vector`, so `==` is order-sensitive. It is filled from `CKnownFile::GetA4AFList()`, which is a `std::set<CClientRef>` — deterministic iteration, so equal membership always compares equal. Had it been a hash container this predicate would have republished on most ticks.
- **The tag actually travels on the update path.** `ECSpecialCoreTags.cpp:246` returns *before* emitting the A4AF sources when `detail_level == EC_DETAIL_UPDATE`. The periodic tick uses `EC_OP_GET_UPDATE` at `EC_DETAIL_INC_UPDATE` (`RefresherTick.cpp:210`), which does not hit that return. Had it used `EC_DETAIL_UPDATE`, the field would have gone stale permanently and the Web UI would have dropped its poll to never learn of a change again.

## Test plan

- **`EventDiffTest`: registered, compiled, ran, passed by name** — `34/46 Test #34: EventDiffTest ... Passed`. Two cases added to the existing file, and I ran the binary directly to confirm they execute rather than merely compile:
  - `DownloadUpdatedFiresWhenTheA4afSourceSetSwapsAtAConstantCount` — the swap-at-constant-count case, i.e. the defect the `EqualDownload` change exists to prevent.
  - `DownloadEventCarriesAnEmptySourceEcidsArrayWithNoA4afSources` — `[]`, not omitted.
- **Full suite: `100% tests passed, 0 tests failed out of 46`.** Results identified by name throughout.
- **Build: exit 0, 644/644 targets**, all six binaries linked, Linux aarch64.

**What is NOT verified, plainly:** the two curl scripts this touches (`04-read-downloads-shared.sh` +8, `22-sse-diff-emission.sh` +14) **were not run** — they need a live `amuled` + `amuleapi` and I did not start a daemon. So the end-to-end wire behaviour is covered by reasoning and by the unit test at the JSON-shape and `EqualDownload` level, but those added assertions have never executed. I would rather say that than let an edited assertion read as a passing one. Also: Linux only, no macOS or Windows build.

## Follow-up

Once this is on master, #1215 drops its 5 s interval entirely and takes the rows from the `clients` store joined on this array — no polling at all.
