### PR TITLE
kad: stop unassigned searches answering to the legacy EC search id

### DIFF
--- a/src/SearchList.cpp
+++ b/src/SearchList.cpp
@@ -548,8 +548,19 @@ std::vector<uint32_t> CSearchList::LoadSearches()
 		// started. Partitioned on the id's own high bit rather than the
 		// persisted `kind` byte: bit 31 is intrinsic to which counter owns
 		// the value, while `kind` is a separate field from the same record
-		// that could disagree with it if the file were corrupt.
-		if (entry.id & 0x80000000) {
+		// that could disagree with it if the file were corrupt. The one id
+		// that bit is wrong about is the legacy sentinel, handled first.
+		if (entry.id == 0xffffffff) {
+			// The legacy single-search bucket comes from neither counter:
+			// every EC client predating multi-search reuses this one id for
+			// all of its searches, so there is no allocation to advance past.
+			// It has to be excluded explicitly because the bit-31 test below
+			// would hand an ed2k search to the Kad counter -- and since this
+			// is the largest uint32 there is, ReserveSearchId would pin
+			// m_nextID at its maximum and the next Kad allocation
+			// (++m_nextID | SEARCH_ID_KAD_MASK) would wrap to the FIRST Kad
+			// id, which is the collision this reservation exists to prevent.
+		} else if (entry.id & 0x80000000) {
 			Kademlia::CSearchManager::ReserveSearchId(entry.id);
 		} else {
 			ReserveEd2kId(entry.id);

--- a/src/kademlia/kademlia/Search.cpp
+++ b/src/kademlia/kademlia/Search.cpp
@@ -75,6 +75,7 @@ CSearch::CSearch()
 	m_answers = 0;
 	m_totalRequestAnswers = 0;
 	m_searchID = (uint32_t)-1;
+	m_searchIDAssigned = false;
 	m_stopping = false;
 	m_totalLoad = 0;
 	m_totalLoadResponses = 0;

--- a/src/kademlia/kademlia/Search.h
+++ b/src/kademlia/kademlia/Search.h
@@ -59,7 +59,20 @@ class CSearch
 
 public:
 	uint32_t GetSearchID() const noexcept { return m_searchID; }
-	void SetSearchID(uint32_t id) noexcept { m_searchID = id; }
+	void SetSearchID(uint32_t id) noexcept
+	{
+		m_searchID = id;
+		m_searchIDAssigned = true;
+	}
+	// Whether this search was ever given an id. Only PrepareFindKeywords and
+	// PrepareLookup assign one; FindNode, FindNodeSpecial and
+	// FindNodeFWCheckUDP leave the constructor's default, which is the same
+	// value an EC client that predates multi-search uses for every search it
+	// runs (0xFFFFFFFF). An id lookup must not resolve to a search that never
+	// claimed one, or aMule's own node lookups answer for a legacy client's
+	// search. The value alone cannot say: a legacy Kad keyword search really
+	// does get 0xFFFFFFFF assigned, deliberately, in PrepareFindKeywords.
+	bool HasSearchID() const noexcept { return m_searchIDAssigned; }
 	uint32_t GetSearchTypes() const noexcept { return m_type; }
 	void SetSearchTypes(uint32_t val) noexcept { m_type = val; }
 	void SetTargetID(const CUInt128 &val) noexcept { m_target = val; }
@@ -174,6 +187,7 @@ private:
 	uint32_t m_lastResponse;
 
 	uint32_t m_searchID;
+	bool m_searchIDAssigned;
 	CUInt128 m_target;
 	uint32_t m_searchTermsDataSize;
 	uint8_t *m_searchTermsData;

--- a/src/kademlia/kademlia/SearchManager.cpp
+++ b/src/kademlia/kademlia/SearchManager.cpp
@@ -103,6 +103,19 @@ bool CSearchManager::RequestMoreResults(uint32_t searchID, bool *out_fired)
 bool CSearchManager::IsKadSearch(uint32_t searchID)
 {
 	for (SearchMap::const_iterator it = m_searches.begin(); it != m_searches.end(); ++it) {
+		// Skip searches that were never given an id. Their m_searchID is the
+		// constructor's 0xFFFFFFFF, which is also the single bucket every EC
+		// client predating multi-search reuses for all of its searches -- so
+		// without this an ordinary node lookup, buddy lookup or UDP firewall
+		// check answers "yes, that is a running Kad search" for a legacy
+		// client's ed2k search. The whole per-id lifecycle then follows: the
+		// search is reported as kind Kad, RUNNING, and its percent comes from
+		// the Kad time-ramp (pinned at 99) until the unrelated internal search
+		// happens to end. Only PrepareFindKeywords and PrepareLookup assign an
+		// id; the three FindNode* paths do not.
+		if (!it->second->HasSearchID()) {
+			continue;
+		}
 		if (it->second->GetSearchID() == searchID) {
 			return true;
 		}


### PR DESCRIPTION
A global ed2k search started by an EC client that predates multi-search is reported as a *running Kad search at 99%* in both amulegui and amuleapi, for a minute or two at a time, long after it has finished.

### Root cause

`CSearch`'s constructor leaves `m_searchID` at `0xFFFFFFFF`, and only `PrepareFindKeywords` and `PrepareLookup` overwrite it. `FindNode`, `FindNodeSpecial` and `FindNodeFWCheckUDP` do not - so every node lookup, buddy lookup and UDP firewall check carries that value. It is also the single bucket every pre-multi-search EC client reuses for all of its searches.

`IsKadSearch` matches on the id alone, so aMule's own housekeeping answers "yes, a Kad search with that id is running" whenever a legacy client has a search open. The per-id lifecycle follows:

| Function | Wrong answer | Why |
|---|---|---|
| `GetSearchLifecycleKindById` | `KadSearch` | `IsOrWasKadSearch` is tested first |
| `GetSearchLifecycleStateById` | `RUNNING` | returns at the `IsKadSearch` step, before the ed2k state |
| `GetSearchLifecyclePercentById` | `99` | Kad time-ramp, saturated, capped so it never claims completion |

Observed on a daemon driven by aMuTorrent: 498 results carrying ed2k **ratings**, which Kad results do not have, reported as kind `kad`, `running`, `99%`, stable across a 40 s sample. It clears when the unrelated internal search ends - after a restart that is Kad bootstrapping, matching the reported 60-120 s.

Modern clients are unaffected: their ids are allocated values no internal search ever carries.

### Fix 1: track assignment, not the value

`SetSearchID` now records that an id was claimed, and `IsKadSearch` skips searches that never claimed one. The value cannot answer the question: `PrepareFindKeywords` passes the sentinel through deliberately, so a legacy client's *real* Kad keyword search is legitimately `0xFFFFFFFF` and must keep matching.

Deliberately confined to `IsKadSearch`, whose only caller feeds lifecycle reporting and the monolithic "More" button. `StopSearch`, `RequestMoreResults` and `IsSearching` share the lookup and the flaw, but the first carries a side effect that deserves its own decision: `StartNewSearch` calls `StopSearch(0xffffffff, false)` on every legacy search start, so today each such search hard-deletes whatever internal Kad search is in flight. `IsSearching` has no callers at all.

### Fix 2: the legacy sentinel belongs to neither id counter

`LoadSearches` partitions restored ids between the two allocators on bit 31. That bit is intrinsic to which counter owns a *real* id, but the sentinel is an ed2k bucket with every bit set, so it was reserved against the Kad counter - pinning `m_nextID` at the maximum `uint32`, after which the next allocation `(++m_nextID | SEARCH_ID_KAD_MASK)` wraps to the **first** Kad id. A reservation whose purpose is to stop a restored search colliding with the next one started produced exactly that collision. It is now excluded, since it comes from neither counter.

### Verification

- Builds clean for monolithic, daemon and remote GUI; 47/47 ctest; clang-format and both clang-tidy tiers clean with 0 compiler errors.
- **Not covered by tests, and worth being explicit about.** Both paths are in the Kad layer: `CSearchManager` is static global state and `LoadSearches` needs a file fixture, so neither is reachable from the current unit tests, and standing that up is a larger change than either fix. This is verified by construction plus the live diagnosis above.
- The behavioural delta is bounded by inspection: the only searches that resolve differently are those that never called `SetSearchID`, and the only id affected by fix 2 is `0xFFFFFFFF`.
- **Confirmed on a production node built from this head**, driven by aMuTorrent:
  - a **global** search reports `type: global` with the ed2k sweep's own progress and reaches `finished`. Pre-fix it read `kad` / `running` / `99%` for a minute or more after completing.
  - restarting the core now shows that search `finished` rather than running.
  - a **Kad** search from the same legacy client still reports `type: kad` and completes correctly. This is the case fix 1 must not break: `PrepareFindKeywords` assigns the sentinel deliberately, so a legacy Kad keyword search owns `0xFFFFFFFF` legitimately and has to keep matching. 99% *during* a Kad search is correct, the ramp being capped so the cosmetic timer never claims completion early.
- One cosmetic residue is knowingly left: with every legacy search sharing the sentinel, an amulegui tab keeps the query it was created with. The daemon reports the current name correctly (`StartNewSearch` rewrites it) and a fresh amulegui shows it, but the tab label refresh derives the name from the existing page text rather than from the core, so it never updates in place. Search pages would need a name field of their own, as browse pages already have.
