### PR TITLE
feat(amulegui): show the connected core's version on the status bar

### DIFF
--- a/docs/api/REFERENCE.md
+++ b/docs/api/REFERENCE.md
@@ -527,8 +527,8 @@ curl -s http://$HOST/api/v0/version
 {
   "service": "amuleapi",
   "api_version": "v0",
-  "amuleapi_version": "2.4.0-29-g...",
-  "daemon_version": "2.4.0-29-g...",
+  "amuleapi_version": "GIT rev. 3.0.1-773-g500293ba3",
+  "daemon_version": "GIT rev. 3.0.1-773-g500293ba3",
   "update": {
     "check_enabled": true,
     "checked": true,
@@ -543,8 +543,8 @@ curl -s http://$HOST/api/v0/version
 | --- | --- |
 | `name` | Always `"amuleapi"`. |
 | `api_version` | REST contract version served on this path (`"v0"`). |
-| `amuleapi_version` | amuleapi's **own** build version. |
-| `daemon_version` | Version of the **connected amuled**, from the EC handshake. Empty string when EC is not (yet) connected, or when the daemon is old enough not to advertise it. Normally equal to `amuleapi_version` (both are built from the same source tree), but they can differ if a mismatched amuleapi is pointed at a different amuled. |
+| `amuleapi_version` | amuleapi's **own** build version. On a tagged release this is the release number (`"3.0.1"`); on a development build it is `"GIT"` followed by the revision (`"GIT rev. 3.0.1-773-g500293ba3"`), because `"GIT"` alone is the same string for every snapshot and identifies nothing. |
+| `daemon_version` | Version of the **connected amuled**, from the EC handshake, in the same spelling as `amuleapi_version` above. Empty string when EC is not (yet) connected, or when the daemon is old enough not to advertise it. Normally equal to `amuleapi_version` (both are built from the same source tree), but they can differ if a mismatched amuleapi is pointed at a different amuled. On development builds the revision makes that comparison meaningful, which bare `"GIT"` could not. |
 | `update` | Update-availability, **relayed from the connected daemon** — amuleapi never contacts GitHub itself. See the sub-table. |
 
 The `update` object:

--- a/po/amule.pot
+++ b/po/amule.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-30 16:16+0200\n"
+"POT-Creation-Date: 2026-08-31 17:03+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -726,6 +726,36 @@ msgid "Kad: Off"
 msgstr ""
 
 #: src/amuleDlg.cpp
+msgid "Core"
+msgstr ""
+
+#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp src/Statistics.cpp
+msgid "Version"
+msgstr ""
+
+#: src/amuleDlg.cpp
+msgid "The core and aMuleGUI are different versions."
+msgstr ""
+
+#: src/amuleDlg.cpp
+msgid "The core and aMuleGUI are the same version."
+msgstr ""
+
+#: src/amuleDlg.cpp src/ServerListCtrl.cpp
+msgid "Address"
+msgstr ""
+
+#: src/amuleDlg.cpp
+msgid "Encryption"
+msgstr ""
+
+#: src/amuleDlg.cpp
+msgid "aMuleGUI"
+msgstr ""
+
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr ""
@@ -925,6 +955,10 @@ msgstr ""
 
 #: src/amule-remote-gui.cpp
 msgid "Connection to the remote core was lost. Trying to reconnect..."
+msgstr ""
+
+#: src/amule-remote-gui.cpp src/ClientDetailDialog.cpp
+msgid "Disabled"
 msgstr ""
 
 #: src/amule-remote-gui.cpp
@@ -1236,10 +1270,6 @@ msgstr ""
 msgid "Not supported"
 msgstr ""
 
-#: src/ClientDetailDialog.cpp
-msgid "Disabled"
-msgstr ""
-
 #: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
 #: src/TextClient.cpp
 msgid "Connected"
@@ -1261,11 +1291,6 @@ msgstr ""
 
 #: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
 msgid "Software"
-msgstr ""
-
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/ServerListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp src/Statistics.cpp
-msgid "Version"
 msgstr ""
 
 #: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
@@ -6728,10 +6753,6 @@ msgstr ""
 
 #: src/ServerListCtrl.cpp
 msgid "Server Name"
-msgstr ""
-
-#: src/ServerListCtrl.cpp
-msgid "Address"
 msgstr ""
 
 #: src/ServerListCtrl.cpp

--- a/po/ar.po
+++ b/po/ar.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-30 16:16+0200\n"
+"POT-Creation-Date: 2026-08-31 17:03+0200\n"
 "PO-Revision-Date: 2026-08-31 09:52+0000\n"
 "Last-Translator: saleh alhathal <hathalsal@hotmail.com>\n"
 "Language-Team: \n"
@@ -740,6 +740,38 @@ msgid "Kad: Off"
 msgstr ""
 
 #: src/amuleDlg.cpp
+msgid "Core"
+msgstr ""
+
+#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp src/Statistics.cpp
+msgid "Version"
+msgstr "نسخة"
+
+#: src/amuleDlg.cpp
+msgid "The core and aMuleGUI are different versions."
+msgstr ""
+
+#: src/amuleDlg.cpp
+msgid "The core and aMuleGUI are the same version."
+msgstr ""
+
+#: src/amuleDlg.cpp src/ServerListCtrl.cpp
+msgid "Address"
+msgstr ""
+
+#: src/amuleDlg.cpp
+#, fuzzy
+msgid "Encryption"
+msgstr "وصف"
+
+#: src/amuleDlg.cpp
+#, fuzzy
+msgid "aMuleGUI"
+msgstr "سجل aMule"
+
+#: src/amuleDlg.cpp
 #, fuzzy, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "تحميل: %.1f(%.1f) | رفع: %.1f(%.1f)"
@@ -945,6 +977,10 @@ msgstr ""
 
 #: src/amule-remote-gui.cpp
 msgid "Connection to the remote core was lost. Trying to reconnect..."
+msgstr ""
+
+#: src/amule-remote-gui.cpp src/ClientDetailDialog.cpp
+msgid "Disabled"
 msgstr ""
 
 #: src/amule-remote-gui.cpp
@@ -1260,10 +1296,6 @@ msgstr ""
 msgid "Not supported"
 msgstr ""
 
-#: src/ClientDetailDialog.cpp
-msgid "Disabled"
-msgstr ""
-
 #: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
 #: src/TextClient.cpp
 msgid "Connected"
@@ -1287,11 +1319,6 @@ msgstr "اسم الملف"
 #: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
 msgid "Software"
 msgstr ""
-
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/ServerListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp src/Statistics.cpp
-msgid "Version"
-msgstr "نسخة"
 
 #: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
 #, fuzzy
@@ -6841,10 +6868,6 @@ msgstr ""
 #: src/ServerListCtrl.cpp
 msgid "Server Name"
 msgstr "إسم الخادم"
-
-#: src/ServerListCtrl.cpp
-msgid "Address"
-msgstr ""
 
 #: src/ServerListCtrl.cpp
 msgid "Port"

--- a/po/ast.po
+++ b/po/ast.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-30 16:16+0200\n"
+"POT-Creation-Date: 2026-08-31 17:03+0200\n"
 "PO-Revision-Date: 2026-08-31 09:53+0000\n"
 "Last-Translator: astur <malditoastur@gmail.com>\n"
 "Language-Team: Language ast <malditoastur@gmail.com>\n"
@@ -758,6 +758,38 @@ msgid "Kad: Off"
 msgstr "Kad: Apagada"
 
 #: src/amuleDlg.cpp
+msgid "Core"
+msgstr ""
+
+#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp src/Statistics.cpp
+msgid "Version"
+msgstr "Versión"
+
+#: src/amuleDlg.cpp
+msgid "The core and aMuleGUI are different versions."
+msgstr ""
+
+#: src/amuleDlg.cpp
+msgid "The core and aMuleGUI are the same version."
+msgstr ""
+
+#: src/amuleDlg.cpp src/ServerListCtrl.cpp
+msgid "Address"
+msgstr "Direición"
+
+#: src/amuleDlg.cpp
+#, fuzzy
+msgid "Encryption"
+msgstr "Descripción"
+
+#: src/amuleDlg.cpp
+#, fuzzy
+msgid "aMuleGUI"
+msgstr "Rexistru"
+
+#: src/amuleDlg.cpp
 #, fuzzy, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Xu: %.1f(%.1f) | Desc: %.1f(%.1f)"
@@ -962,6 +994,10 @@ msgstr ""
 #: src/amule-remote-gui.cpp
 msgid "Connection to the remote core was lost. Trying to reconnect..."
 msgstr ""
+
+#: src/amule-remote-gui.cpp src/ClientDetailDialog.cpp
+msgid "Disabled"
+msgstr "Deshabilitáu"
 
 #: src/amule-remote-gui.cpp
 #, fuzzy
@@ -1279,10 +1315,6 @@ msgstr "Sofitáu"
 msgid "Not supported"
 msgstr "Non sofitáu"
 
-#: src/ClientDetailDialog.cpp
-msgid "Disabled"
-msgstr "Deshabilitáu"
-
 #: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
 #: src/TextClient.cpp
 msgid "Connected"
@@ -1306,11 +1338,6 @@ msgstr "Nome:"
 #: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
 msgid "Software"
 msgstr ""
-
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/ServerListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp src/Statistics.cpp
-msgid "Version"
-msgstr "Versión"
 
 #: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
 #, fuzzy
@@ -6966,10 +6993,6 @@ msgstr "Sirvidor llocal ye fieltráu polos Fieltros IP, ¡coneutando a un sirvid
 #: src/ServerListCtrl.cpp
 msgid "Server Name"
 msgstr "Nome del Sirvidor"
-
-#: src/ServerListCtrl.cpp
-msgid "Address"
-msgstr "Direición"
 
 #: src/ServerListCtrl.cpp
 msgid "Port"

--- a/po/bg.po
+++ b/po/bg.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-30 16:16+0200\n"
+"POT-Creation-Date: 2026-08-31 17:03+0200\n"
 "PO-Revision-Date: 2026-08-31 09:55+0000\n"
 "Last-Translator: Sebastiano Pistore <SebastianoPistore.info@protonmail.ch>\n"
 "Language-Team: Bulgarian <dict@linux.zonebg.com>\n"
@@ -738,6 +738,37 @@ msgid "Kad: Off"
 msgstr ""
 
 #: src/amuleDlg.cpp
+msgid "Core"
+msgstr ""
+
+#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp src/Statistics.cpp
+msgid "Version"
+msgstr "версия"
+
+#: src/amuleDlg.cpp
+msgid "The core and aMuleGUI are different versions."
+msgstr ""
+
+#: src/amuleDlg.cpp
+msgid "The core and aMuleGUI are the same version."
+msgstr ""
+
+#: src/amuleDlg.cpp src/ServerListCtrl.cpp
+msgid "Address"
+msgstr "адрес"
+
+#: src/amuleDlg.cpp
+#, fuzzy
+msgid "Encryption"
+msgstr "Описание"
+
+#: src/amuleDlg.cpp
+msgid "aMuleGUI"
+msgstr ""
+
+#: src/amuleDlg.cpp
 #, fuzzy, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Кач.: %.1f(%.1f) | Свал.: %.1f(%.1f)"
@@ -943,6 +974,10 @@ msgstr ""
 #: src/amule-remote-gui.cpp
 msgid "Connection to the remote core was lost. Trying to reconnect..."
 msgstr ""
+
+#: src/amule-remote-gui.cpp src/ClientDetailDialog.cpp
+msgid "Disabled"
+msgstr "изваден от строя"
 
 #: src/amule-remote-gui.cpp
 msgid "Reconnected to the remote core."
@@ -1255,10 +1290,6 @@ msgstr ""
 msgid "Not supported"
 msgstr ""
 
-#: src/ClientDetailDialog.cpp
-msgid "Disabled"
-msgstr "изваден от строя"
-
 #: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
 #: src/TextClient.cpp
 msgid "Connected"
@@ -1282,11 +1313,6 @@ msgstr "Име:"
 #: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
 msgid "Software"
 msgstr ""
-
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/ServerListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp src/Statistics.cpp
-msgid "Version"
-msgstr "версия"
 
 #: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
 #, fuzzy
@@ -6815,10 +6841,6 @@ msgstr ""
 #: src/ServerListCtrl.cpp
 msgid "Server Name"
 msgstr "Име на сървър"
-
-#: src/ServerListCtrl.cpp
-msgid "Address"
-msgstr "адрес"
 
 #: src/ServerListCtrl.cpp
 msgid "Port"

--- a/po/bn.po
+++ b/po/bn.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-30 16:16+0200\n"
+"POT-Creation-Date: 2026-08-31 17:03+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -725,6 +725,36 @@ msgid "Kad: Off"
 msgstr ""
 
 #: src/amuleDlg.cpp
+msgid "Core"
+msgstr ""
+
+#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp src/Statistics.cpp
+msgid "Version"
+msgstr ""
+
+#: src/amuleDlg.cpp
+msgid "The core and aMuleGUI are different versions."
+msgstr ""
+
+#: src/amuleDlg.cpp
+msgid "The core and aMuleGUI are the same version."
+msgstr ""
+
+#: src/amuleDlg.cpp src/ServerListCtrl.cpp
+msgid "Address"
+msgstr ""
+
+#: src/amuleDlg.cpp
+msgid "Encryption"
+msgstr ""
+
+#: src/amuleDlg.cpp
+msgid "aMuleGUI"
+msgstr ""
+
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr ""
@@ -924,6 +954,10 @@ msgstr ""
 
 #: src/amule-remote-gui.cpp
 msgid "Connection to the remote core was lost. Trying to reconnect..."
+msgstr ""
+
+#: src/amule-remote-gui.cpp src/ClientDetailDialog.cpp
+msgid "Disabled"
 msgstr ""
 
 #: src/amule-remote-gui.cpp
@@ -1235,10 +1269,6 @@ msgstr ""
 msgid "Not supported"
 msgstr ""
 
-#: src/ClientDetailDialog.cpp
-msgid "Disabled"
-msgstr ""
-
 #: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
 #: src/TextClient.cpp
 msgid "Connected"
@@ -1260,11 +1290,6 @@ msgstr ""
 
 #: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
 msgid "Software"
-msgstr ""
-
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/ServerListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp src/Statistics.cpp
-msgid "Version"
 msgstr ""
 
 #: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
@@ -6727,10 +6752,6 @@ msgstr ""
 
 #: src/ServerListCtrl.cpp
 msgid "Server Name"
-msgstr ""
-
-#: src/ServerListCtrl.cpp
-msgid "Address"
 msgstr ""
 
 #: src/ServerListCtrl.cpp

--- a/po/ca.po
+++ b/po/ca.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-30 16:16+0200\n"
+"POT-Creation-Date: 2026-08-31 17:03+0200\n"
 "PO-Revision-Date: 2026-08-31 09:56+0000\n"
 "Last-Translator: minterior <minterior@gmail.com>\n"
 "Language-Team: Català\n"
@@ -758,6 +758,38 @@ msgid "Kad: Off"
 msgstr "Kad: Inativa"
 
 #: src/amuleDlg.cpp
+msgid "Core"
+msgstr ""
+
+#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp src/Statistics.cpp
+msgid "Version"
+msgstr "Versió"
+
+#: src/amuleDlg.cpp
+msgid "The core and aMuleGUI are different versions."
+msgstr ""
+
+#: src/amuleDlg.cpp
+msgid "The core and aMuleGUI are the same version."
+msgstr ""
+
+#: src/amuleDlg.cpp src/ServerListCtrl.cpp
+msgid "Address"
+msgstr "Adreça"
+
+#: src/amuleDlg.cpp
+#, fuzzy
+msgid "Encryption"
+msgstr "Descripció"
+
+#: src/amuleDlg.cpp
+#, fuzzy
+msgid "aMuleGUI"
+msgstr "Registre de l'aMule"
+
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "PU: %.1f%s (%.1f) | BA: %.1f%s (%.1f)"
@@ -961,6 +993,10 @@ msgstr ""
 #: src/amule-remote-gui.cpp
 msgid "Connection to the remote core was lost. Trying to reconnect..."
 msgstr ""
+
+#: src/amule-remote-gui.cpp src/ClientDetailDialog.cpp
+msgid "Disabled"
+msgstr "Inhabilitada"
 
 #: src/amule-remote-gui.cpp
 #, fuzzy
@@ -1277,10 +1313,6 @@ msgstr "Suportada"
 msgid "Not supported"
 msgstr "No suportada"
 
-#: src/ClientDetailDialog.cpp
-msgid "Disabled"
-msgstr "Inhabilitada"
-
 #: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
 #: src/TextClient.cpp
 msgid "Connected"
@@ -1304,11 +1336,6 @@ msgstr "Nom:"
 #: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
 msgid "Software"
 msgstr ""
-
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/ServerListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp src/Statistics.cpp
-msgid "Version"
-msgstr "Versió"
 
 #: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
 #, fuzzy
@@ -6935,10 +6962,6 @@ msgstr "El servidor local està filtrat pels filtres IP, s'està reconnectant a 
 #: src/ServerListCtrl.cpp
 msgid "Server Name"
 msgstr "Nom"
-
-#: src/ServerListCtrl.cpp
-msgid "Address"
-msgstr "Adreça"
 
 #: src/ServerListCtrl.cpp
 msgid "Port"

--- a/po/cs.po
+++ b/po/cs.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-30 16:16+0200\n"
+"POT-Creation-Date: 2026-08-31 17:03+0200\n"
 "PO-Revision-Date: 2026-08-31 09:57+0000\n"
 "Last-Translator: David Watzke <david@watzke.cz>\n"
 "Language-Team: cs <cs@li.org>\n"
@@ -760,6 +760,38 @@ msgid "Kad: Off"
 msgstr "Kad: vypnut"
 
 #: src/amuleDlg.cpp
+msgid "Core"
+msgstr ""
+
+#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp src/Statistics.cpp
+msgid "Version"
+msgstr "Verze"
+
+#: src/amuleDlg.cpp
+msgid "The core and aMuleGUI are different versions."
+msgstr ""
+
+#: src/amuleDlg.cpp
+msgid "The core and aMuleGUI are the same version."
+msgstr ""
+
+#: src/amuleDlg.cpp src/ServerListCtrl.cpp
+msgid "Address"
+msgstr "Adresa"
+
+#: src/amuleDlg.cpp
+#, fuzzy
+msgid "Encryption"
+msgstr "Popis"
+
+#: src/amuleDlg.cpp
+#, fuzzy
+msgid "aMuleGUI"
+msgstr "Log aMule"
+
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Odesílání: %.1f%s (%.1f) | Stahování: %.1f%s (%.1f)"
@@ -966,6 +998,10 @@ msgstr ""
 #: src/amule-remote-gui.cpp
 msgid "Connection to the remote core was lost. Trying to reconnect..."
 msgstr "Připojení ke vzdálenému jádru bylo ztraceno. Probíhá pokus o opětovné připojení..."
+
+#: src/amule-remote-gui.cpp src/ClientDetailDialog.cpp
+msgid "Disabled"
+msgstr "Zakázáno"
 
 #: src/amule-remote-gui.cpp
 msgid "Reconnected to the remote core."
@@ -1282,10 +1318,6 @@ msgstr "Podporováno"
 msgid "Not supported"
 msgstr "Nepodporováno"
 
-#: src/ClientDetailDialog.cpp
-msgid "Disabled"
-msgstr "Zakázáno"
-
 #: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
 #: src/TextClient.cpp
 msgid "Connected"
@@ -1308,11 +1340,6 @@ msgstr "Název"
 #: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
 msgid "Software"
 msgstr "Software"
-
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/ServerListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp src/Statistics.cpp
-msgid "Version"
-msgstr "Verze"
 
 #: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
 msgid "IP Address"
@@ -6918,10 +6945,6 @@ msgstr ""
 #: src/ServerListCtrl.cpp
 msgid "Server Name"
 msgstr "Název serveru"
-
-#: src/ServerListCtrl.cpp
-msgid "Address"
-msgstr "Adresa"
 
 #: src/ServerListCtrl.cpp
 msgid "Port"

--- a/po/da.po
+++ b/po/da.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-30 16:16+0200\n"
+"POT-Creation-Date: 2026-08-31 17:03+0200\n"
 "PO-Revision-Date: 2026-08-31 09:59+0000\n"
 "Last-Translator: Alex Thomsen Leth <alexl@stofanet.dk>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -743,6 +743,38 @@ msgid "Kad: Off"
 msgstr " Kad: "
 
 #: src/amuleDlg.cpp
+msgid "Core"
+msgstr ""
+
+#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp src/Statistics.cpp
+msgid "Version"
+msgstr ""
+
+#: src/amuleDlg.cpp
+msgid "The core and aMuleGUI are different versions."
+msgstr ""
+
+#: src/amuleDlg.cpp
+msgid "The core and aMuleGUI are the same version."
+msgstr ""
+
+#: src/amuleDlg.cpp src/ServerListCtrl.cpp
+msgid "Address"
+msgstr ""
+
+#: src/amuleDlg.cpp
+#, fuzzy
+msgid "Encryption"
+msgstr "Beskrivelse"
+
+#: src/amuleDlg.cpp
+#, fuzzy
+msgid "aMuleGUI"
+msgstr "aMule Log"
+
+#: src/amuleDlg.cpp
 #, fuzzy, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Up: %.1f(%.1f) | Down: %.1f(%.1f)"
@@ -948,6 +980,10 @@ msgstr ""
 
 #: src/amule-remote-gui.cpp
 msgid "Connection to the remote core was lost. Trying to reconnect..."
+msgstr ""
+
+#: src/amule-remote-gui.cpp src/ClientDetailDialog.cpp
+msgid "Disabled"
 msgstr ""
 
 #: src/amule-remote-gui.cpp
@@ -1263,10 +1299,6 @@ msgstr ""
 msgid "Not supported"
 msgstr ""
 
-#: src/ClientDetailDialog.cpp
-msgid "Disabled"
-msgstr ""
-
 #: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
 #: src/TextClient.cpp
 msgid "Connected"
@@ -1289,11 +1321,6 @@ msgstr "Fil Navn"
 
 #: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
 msgid "Software"
-msgstr ""
-
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/ServerListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp src/Statistics.cpp
-msgid "Version"
 msgstr ""
 
 #: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
@@ -6860,10 +6887,6 @@ msgstr ""
 #: src/ServerListCtrl.cpp
 msgid "Server Name"
 msgstr "Servernavn"
-
-#: src/ServerListCtrl.cpp
-msgid "Address"
-msgstr ""
 
 #: src/ServerListCtrl.cpp
 msgid "Port"

--- a/po/de.po
+++ b/po/de.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-30 16:16+0200\n"
+"POT-Creation-Date: 2026-08-31 17:03+0200\n"
 "PO-Revision-Date: 2026-08-31 10:00+0000\n"
 "Last-Translator: Werner Mahr <werner@vollstreckernet.de>\n"
 "Language-Team: German <>\n"
@@ -765,6 +765,38 @@ msgid "Kad: Off"
 msgstr "Kad: aus"
 
 #: src/amuleDlg.cpp
+msgid "Core"
+msgstr ""
+
+#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp src/Statistics.cpp
+msgid "Version"
+msgstr "Version"
+
+#: src/amuleDlg.cpp
+msgid "The core and aMuleGUI are different versions."
+msgstr ""
+
+#: src/amuleDlg.cpp
+msgid "The core and aMuleGUI are the same version."
+msgstr ""
+
+#: src/amuleDlg.cpp src/ServerListCtrl.cpp
+msgid "Address"
+msgstr "Adresse"
+
+#: src/amuleDlg.cpp
+#, fuzzy
+msgid "Encryption"
+msgstr "Beschreibung"
+
+#: src/amuleDlg.cpp
+#, fuzzy
+msgid "aMuleGUI"
+msgstr "aMule-Log"
+
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
@@ -970,6 +1002,10 @@ msgstr ""
 #: src/amule-remote-gui.cpp
 msgid "Connection to the remote core was lost. Trying to reconnect..."
 msgstr ""
+
+#: src/amule-remote-gui.cpp src/ClientDetailDialog.cpp
+msgid "Disabled"
+msgstr "Deaktiviert"
 
 #: src/amule-remote-gui.cpp
 #, fuzzy
@@ -1285,10 +1321,6 @@ msgstr "Unterstützt"
 msgid "Not supported"
 msgstr "Nicht Unterstützt"
 
-#: src/ClientDetailDialog.cpp
-msgid "Disabled"
-msgstr "Deaktiviert"
-
 #: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
 #: src/TextClient.cpp
 msgid "Connected"
@@ -1312,11 +1344,6 @@ msgstr "Name:"
 #: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
 msgid "Software"
 msgstr ""
-
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/ServerListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp src/Statistics.cpp
-msgid "Version"
-msgstr "Version"
 
 #: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
 #, fuzzy
@@ -6931,10 +6958,6 @@ msgstr "Lokaler Server ist gefiltert durch IPFilters, verbinde neu zu einem ande
 #: src/ServerListCtrl.cpp
 msgid "Server Name"
 msgstr "Servername"
-
-#: src/ServerListCtrl.cpp
-msgid "Address"
-msgstr "Adresse"
 
 #: src/ServerListCtrl.cpp
 msgid "Port"

--- a/po/el.po
+++ b/po/el.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-30 16:16+0200\n"
+"POT-Creation-Date: 2026-08-31 17:03+0200\n"
 "PO-Revision-Date: 2026-08-31 10:01+0000\n"
 "Last-Translator: Dimitris <dgalanak@yahoo.com>\n"
 "Language-Team: Greek\n"
@@ -763,6 +763,38 @@ msgid "Kad: Off"
 msgstr "Kad: Εκτός"
 
 #: src/amuleDlg.cpp
+msgid "Core"
+msgstr ""
+
+#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp src/Statistics.cpp
+msgid "Version"
+msgstr "Έκδοση"
+
+#: src/amuleDlg.cpp
+msgid "The core and aMuleGUI are different versions."
+msgstr ""
+
+#: src/amuleDlg.cpp
+msgid "The core and aMuleGUI are the same version."
+msgstr ""
+
+#: src/amuleDlg.cpp src/ServerListCtrl.cpp
+msgid "Address"
+msgstr "Διεύθυνση"
+
+#: src/amuleDlg.cpp
+#, fuzzy
+msgid "Encryption"
+msgstr "Περιγραφή"
+
+#: src/amuleDlg.cpp
+#, fuzzy
+msgid "aMuleGUI"
+msgstr "Αρχείο καταγραφής aMule"
+
+#: src/amuleDlg.cpp
 #, fuzzy, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Πάνω: %.1f(%.1f) | Κάτω: %.1f(%.1f)"
@@ -971,6 +1003,10 @@ msgstr ""
 #: src/amule-remote-gui.cpp
 msgid "Connection to the remote core was lost. Trying to reconnect..."
 msgstr ""
+
+#: src/amule-remote-gui.cpp src/ClientDetailDialog.cpp
+msgid "Disabled"
+msgstr "Απενεργοποιημένο"
 
 #: src/amule-remote-gui.cpp
 #, fuzzy
@@ -1288,10 +1324,6 @@ msgstr "Υποστηρίζεται"
 msgid "Not supported"
 msgstr "Δεν υποστηρίζεται"
 
-#: src/ClientDetailDialog.cpp
-msgid "Disabled"
-msgstr "Απενεργοποιημένο"
-
 #: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
 #: src/TextClient.cpp
 msgid "Connected"
@@ -1315,11 +1347,6 @@ msgstr "Όνομα:"
 #: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
 msgid "Software"
 msgstr ""
-
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/ServerListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp src/Statistics.cpp
-msgid "Version"
-msgstr "Έκδοση"
 
 #: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
 #, fuzzy
@@ -6978,10 +7005,6 @@ msgstr "Ο τοπικός διακομιστής είναι φιλτραρισμ
 #: src/ServerListCtrl.cpp
 msgid "Server Name"
 msgstr "Όνομα διακομιστή"
-
-#: src/ServerListCtrl.cpp
-msgid "Address"
-msgstr "Διεύθυνση"
 
 #: src/ServerListCtrl.cpp
 msgid "Port"

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-30 16:16+0200\n"
+"POT-Creation-Date: 2026-08-31 17:03+0200\n"
 "PO-Revision-Date: 2020-03-04 14:43+0100\n"
 "Last-Translator: Dévai Tamás <devait@vnet.hu>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -726,6 +726,36 @@ msgid "Kad: Off"
 msgstr ""
 
 #: src/amuleDlg.cpp
+msgid "Core"
+msgstr ""
+
+#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp src/Statistics.cpp
+msgid "Version"
+msgstr ""
+
+#: src/amuleDlg.cpp
+msgid "The core and aMuleGUI are different versions."
+msgstr ""
+
+#: src/amuleDlg.cpp
+msgid "The core and aMuleGUI are the same version."
+msgstr ""
+
+#: src/amuleDlg.cpp src/ServerListCtrl.cpp
+msgid "Address"
+msgstr ""
+
+#: src/amuleDlg.cpp
+msgid "Encryption"
+msgstr ""
+
+#: src/amuleDlg.cpp
+msgid "aMuleGUI"
+msgstr ""
+
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr ""
@@ -925,6 +955,10 @@ msgstr ""
 
 #: src/amule-remote-gui.cpp
 msgid "Connection to the remote core was lost. Trying to reconnect..."
+msgstr ""
+
+#: src/amule-remote-gui.cpp src/ClientDetailDialog.cpp
+msgid "Disabled"
 msgstr ""
 
 #: src/amule-remote-gui.cpp
@@ -1236,10 +1270,6 @@ msgstr ""
 msgid "Not supported"
 msgstr ""
 
-#: src/ClientDetailDialog.cpp
-msgid "Disabled"
-msgstr ""
-
 #: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
 #: src/TextClient.cpp
 msgid "Connected"
@@ -1261,11 +1291,6 @@ msgstr ""
 
 #: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
 msgid "Software"
-msgstr ""
-
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/ServerListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp src/Statistics.cpp
-msgid "Version"
 msgstr ""
 
 #: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
@@ -6728,10 +6753,6 @@ msgstr ""
 
 #: src/ServerListCtrl.cpp
 msgid "Server Name"
-msgstr ""
-
-#: src/ServerListCtrl.cpp
-msgid "Address"
 msgstr ""
 
 #: src/ServerListCtrl.cpp

--- a/po/es.po
+++ b/po/es.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-30 16:16+0200\n"
+"POT-Creation-Date: 2026-08-31 17:03+0200\n"
 "PO-Revision-Date: 2026-08-31 10:02+0000\n"
 "Last-Translator: Diego Heras <ngosang@hotmail.es>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/amule/amule-application/es/>\n"
@@ -766,6 +766,38 @@ msgid "Kad: Off"
 msgstr "Kad: apagado"
 
 #: src/amuleDlg.cpp
+msgid "Core"
+msgstr ""
+
+#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp src/Statistics.cpp
+msgid "Version"
+msgstr "Versión"
+
+#: src/amuleDlg.cpp
+msgid "The core and aMuleGUI are different versions."
+msgstr ""
+
+#: src/amuleDlg.cpp
+msgid "The core and aMuleGUI are the same version."
+msgstr ""
+
+#: src/amuleDlg.cpp src/ServerListCtrl.cpp
+msgid "Address"
+msgstr "Dirección"
+
+#: src/amuleDlg.cpp
+#, fuzzy
+msgid "Encryption"
+msgstr "Descripción"
+
+#: src/amuleDlg.cpp
+#, fuzzy
+msgid "aMuleGUI"
+msgstr "Registro de aMuleGUI"
+
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Su: %.1f%s (%.1f) | De: %.1f%s (%.1f)"
@@ -972,6 +1004,10 @@ msgstr ""
 #: src/amule-remote-gui.cpp
 msgid "Connection to the remote core was lost. Trying to reconnect..."
 msgstr "Se perdió la conexión con el núcleo remoto. Intentando reconectar..."
+
+#: src/amule-remote-gui.cpp src/ClientDetailDialog.cpp
+msgid "Disabled"
+msgstr "Deshabilitada"
 
 #: src/amule-remote-gui.cpp
 msgid "Reconnected to the remote core."
@@ -1284,10 +1320,6 @@ msgstr "Soportada"
 msgid "Not supported"
 msgstr "No soportada"
 
-#: src/ClientDetailDialog.cpp
-msgid "Disabled"
-msgstr "Deshabilitada"
-
 #: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
 #: src/TextClient.cpp
 msgid "Connected"
@@ -1310,11 +1342,6 @@ msgstr "Nombre"
 #: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
 msgid "Software"
 msgstr "Software"
-
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/ServerListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp src/Statistics.cpp
-msgid "Version"
-msgstr "Versión"
 
 #: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
 msgid "IP Address"
@@ -6883,10 +6910,6 @@ msgstr "El servidor local está filtrado por los filtros de IP, ¡conectando a u
 #: src/ServerListCtrl.cpp
 msgid "Server Name"
 msgstr "Nombre del servidor"
-
-#: src/ServerListCtrl.cpp
-msgid "Address"
-msgstr "Dirección"
 
 #: src/ServerListCtrl.cpp
 msgid "Port"

--- a/po/et_EE.po
+++ b/po/et_EE.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-30 16:16+0200\n"
+"POT-Creation-Date: 2026-08-31 17:03+0200\n"
 "PO-Revision-Date: 2026-08-31 10:03+0000\n"
 "Last-Translator: \n"
 "Language-Team: Estonian <kde-i18n-doc@kde.org>\n"
@@ -758,6 +758,38 @@ msgid "Kad: Off"
 msgstr "Kad: Väljas"
 
 #: src/amuleDlg.cpp
+msgid "Core"
+msgstr ""
+
+#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp src/Statistics.cpp
+msgid "Version"
+msgstr "Versioon"
+
+#: src/amuleDlg.cpp
+msgid "The core and aMuleGUI are different versions."
+msgstr ""
+
+#: src/amuleDlg.cpp
+msgid "The core and aMuleGUI are the same version."
+msgstr ""
+
+#: src/amuleDlg.cpp src/ServerListCtrl.cpp
+msgid "Address"
+msgstr "Aadress"
+
+#: src/amuleDlg.cpp
+#, fuzzy
+msgid "Encryption"
+msgstr "Kirjeldus"
+
+#: src/amuleDlg.cpp
+#, fuzzy
+msgid "aMuleGUI"
+msgstr "aMule Logi"
+
+#: src/amuleDlg.cpp
 #, fuzzy, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Üles: %.1f(%.1f) | Alla: %.1f(%.1f)"
@@ -961,6 +993,10 @@ msgstr ""
 #: src/amule-remote-gui.cpp
 msgid "Connection to the remote core was lost. Trying to reconnect..."
 msgstr ""
+
+#: src/amule-remote-gui.cpp src/ClientDetailDialog.cpp
+msgid "Disabled"
+msgstr "Keelatud"
 
 #: src/amule-remote-gui.cpp
 #, fuzzy
@@ -1277,10 +1313,6 @@ msgstr "Toetatud"
 msgid "Not supported"
 msgstr "Pole toetatud"
 
-#: src/ClientDetailDialog.cpp
-msgid "Disabled"
-msgstr "Keelatud"
-
 #: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
 #: src/TextClient.cpp
 msgid "Connected"
@@ -1304,11 +1336,6 @@ msgstr "Nimi:"
 #: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
 msgid "Software"
 msgstr ""
-
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/ServerListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp src/Statistics.cpp
-msgid "Version"
-msgstr "Versioon"
 
 #: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
 #, fuzzy
@@ -6940,10 +6967,6 @@ msgstr "Kohalik server on IPFiltri poolt väljafiltreeritud, ühendud teise serv
 #: src/ServerListCtrl.cpp
 msgid "Server Name"
 msgstr "Serveri nimi"
-
-#: src/ServerListCtrl.cpp
-msgid "Address"
-msgstr "Aadress"
 
 #: src/ServerListCtrl.cpp
 msgid "Port"

--- a/po/eu.po
+++ b/po/eu.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-30 16:16+0200\n"
+"POT-Creation-Date: 2026-08-31 17:03+0200\n"
 "PO-Revision-Date: 2026-08-31 10:04+0000\n"
 "Last-Translator: Piarres Beobide <pi@beobide.net>\n"
 "Language-Team: Euskara <librezale@librezale.org>\n"
@@ -759,6 +759,38 @@ msgid "Kad: Off"
 msgstr "Kad: Itzalia"
 
 #: src/amuleDlg.cpp
+msgid "Core"
+msgstr ""
+
+#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp src/Statistics.cpp
+msgid "Version"
+msgstr "Bertsioa"
+
+#: src/amuleDlg.cpp
+msgid "The core and aMuleGUI are different versions."
+msgstr ""
+
+#: src/amuleDlg.cpp
+msgid "The core and aMuleGUI are the same version."
+msgstr ""
+
+#: src/amuleDlg.cpp src/ServerListCtrl.cpp
+msgid "Address"
+msgstr "Helbidea"
+
+#: src/amuleDlg.cpp
+#, fuzzy
+msgid "Encryption"
+msgstr "Azalpena"
+
+#: src/amuleDlg.cpp
+#, fuzzy
+msgid "aMuleGUI"
+msgstr "aMule erregistroa"
+
+#: src/amuleDlg.cpp
 #, fuzzy, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Gora: %.1f(%.1f) | Behera: %.1f(%.1f)"
@@ -962,6 +994,10 @@ msgstr ""
 #: src/amule-remote-gui.cpp
 msgid "Connection to the remote core was lost. Trying to reconnect..."
 msgstr ""
+
+#: src/amule-remote-gui.cpp src/ClientDetailDialog.cpp
+msgid "Disabled"
+msgstr "Ezgaitua"
 
 #: src/amule-remote-gui.cpp
 #, fuzzy
@@ -1278,10 +1314,6 @@ msgstr "Onartua"
 msgid "Not supported"
 msgstr "Ez da onartzen"
 
-#: src/ClientDetailDialog.cpp
-msgid "Disabled"
-msgstr "Ezgaitua"
-
 #: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
 #: src/TextClient.cpp
 msgid "Connected"
@@ -1305,11 +1337,6 @@ msgstr "Izena:"
 #: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
 msgid "Software"
 msgstr ""
-
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/ServerListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp src/Statistics.cpp
-msgid "Version"
-msgstr "Bertsioa"
 
 #: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
 #, fuzzy
@@ -6938,10 +6965,6 @@ msgstr "Zerbitzari lokala IPIragazkiak iragazirik dago, beste zerbitzari batetar
 #: src/ServerListCtrl.cpp
 msgid "Server Name"
 msgstr "Zerbitzaria izena"
-
-#: src/ServerListCtrl.cpp
-msgid "Address"
-msgstr "Helbidea"
 
 #: src/ServerListCtrl.cpp
 msgid "Port"

--- a/po/fi.po
+++ b/po/fi.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-30 16:16+0200\n"
+"POT-Creation-Date: 2026-08-31 17:03+0200\n"
 "PO-Revision-Date: 2026-08-31 10:05+0000\n"
 "Last-Translator: Tapio Rantala <tapio.rantala@iki.fi>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -759,6 +759,38 @@ msgid "Kad: Off"
 msgstr "Kad: Pois päältä"
 
 #: src/amuleDlg.cpp
+msgid "Core"
+msgstr ""
+
+#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp src/Statistics.cpp
+msgid "Version"
+msgstr "Versio"
+
+#: src/amuleDlg.cpp
+msgid "The core and aMuleGUI are different versions."
+msgstr ""
+
+#: src/amuleDlg.cpp
+msgid "The core and aMuleGUI are the same version."
+msgstr ""
+
+#: src/amuleDlg.cpp src/ServerListCtrl.cpp
+msgid "Address"
+msgstr "Osoite"
+
+#: src/amuleDlg.cpp
+#, fuzzy
+msgid "Encryption"
+msgstr "Kuvaus"
+
+#: src/amuleDlg.cpp
+#, fuzzy
+msgid "aMuleGUI"
+msgstr "aMule loki"
+
+#: src/amuleDlg.cpp
 #, fuzzy, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Ylös: %.1f(%.1f) | Alas: %.1f(%.1f)"
@@ -962,6 +994,10 @@ msgstr ""
 #: src/amule-remote-gui.cpp
 msgid "Connection to the remote core was lost. Trying to reconnect..."
 msgstr ""
+
+#: src/amule-remote-gui.cpp src/ClientDetailDialog.cpp
+msgid "Disabled"
+msgstr "Poissa käytöstä"
 
 #: src/amule-remote-gui.cpp
 #, fuzzy
@@ -1278,10 +1314,6 @@ msgstr "Tuettu"
 msgid "Not supported"
 msgstr "Ei tuettu"
 
-#: src/ClientDetailDialog.cpp
-msgid "Disabled"
-msgstr "Poissa käytöstä"
-
 #: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
 #: src/TextClient.cpp
 msgid "Connected"
@@ -1305,11 +1337,6 @@ msgstr "Nimi:"
 #: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
 msgid "Software"
 msgstr ""
-
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/ServerListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp src/Statistics.cpp
-msgid "Version"
-msgstr "Versio"
 
 #: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
 #, fuzzy
@@ -6938,10 +6965,6 @@ msgstr "Paikallinen palvelin IP-suodatetaan, yhdistän toiselle palvelimelle!"
 #: src/ServerListCtrl.cpp
 msgid "Server Name"
 msgstr "Palvelimen nimi"
-
-#: src/ServerListCtrl.cpp
-msgid "Address"
-msgstr "Osoite"
 
 #: src/ServerListCtrl.cpp
 msgid "Port"

--- a/po/fr.po
+++ b/po/fr.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-30 16:16+0200\n"
+"POT-Creation-Date: 2026-08-31 17:03+0200\n"
 "PO-Revision-Date: 2026-08-31 10:05+0000\n"
 "Last-Translator: Dylan Aïssi <bob.dybian@gmail.com>\n"
 "Language-Team: Français\n"
@@ -765,6 +765,38 @@ msgid "Kad: Off"
 msgstr "Kad : Coupé"
 
 #: src/amuleDlg.cpp
+msgid "Core"
+msgstr ""
+
+#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp src/Statistics.cpp
+msgid "Version"
+msgstr "Version"
+
+#: src/amuleDlg.cpp
+msgid "The core and aMuleGUI are different versions."
+msgstr ""
+
+#: src/amuleDlg.cpp
+msgid "The core and aMuleGUI are the same version."
+msgstr ""
+
+#: src/amuleDlg.cpp src/ServerListCtrl.cpp
+msgid "Address"
+msgstr "Adresse"
+
+#: src/amuleDlg.cpp
+#, fuzzy
+msgid "Encryption"
+msgstr "Description"
+
+#: src/amuleDlg.cpp
+#, fuzzy
+msgid "aMuleGUI"
+msgstr "Journal d'aMuleGUI"
+
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "E : %.1f%s (%.1f) | R : %.1f%s (%.1f)"
@@ -971,6 +1003,10 @@ msgstr ""
 #: src/amule-remote-gui.cpp
 msgid "Connection to the remote core was lost. Trying to reconnect..."
 msgstr "La connexion au noyau distant a été perdue. Tentative de reconnexion…"
+
+#: src/amule-remote-gui.cpp src/ClientDetailDialog.cpp
+msgid "Disabled"
+msgstr "Désactivé"
 
 #: src/amule-remote-gui.cpp
 msgid "Reconnected to the remote core."
@@ -1283,10 +1319,6 @@ msgstr "Supporté"
 msgid "Not supported"
 msgstr "Non supporté"
 
-#: src/ClientDetailDialog.cpp
-msgid "Disabled"
-msgstr "Désactivé"
-
 #: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
 #: src/TextClient.cpp
 msgid "Connected"
@@ -1309,11 +1341,6 @@ msgstr "Nom"
 #: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
 msgid "Software"
 msgstr "Logiciel"
-
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/ServerListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp src/Statistics.cpp
-msgid "Version"
-msgstr "Version"
 
 #: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
 msgid "IP Address"
@@ -6875,10 +6902,6 @@ msgstr "Le serveur local est filtré par les filtres IP, reconnexion à un autre
 #: src/ServerListCtrl.cpp
 msgid "Server Name"
 msgstr "Nom du serveur"
-
-#: src/ServerListCtrl.cpp
-msgid "Address"
-msgstr "Adresse"
 
 #: src/ServerListCtrl.cpp
 msgid "Port"

--- a/po/gl.po
+++ b/po/gl.po
@@ -24,7 +24,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-30 16:16+0200\n"
+"POT-Creation-Date: 2026-08-31 17:03+0200\n"
 "PO-Revision-Date: 2026-08-31 10:06+0000\n"
 "Last-Translator: Pablo <parodper@gmail.com>\n"
 "Language-Team: http://forum.amule.org/index.php?topic=13883\n"
@@ -778,6 +778,38 @@ msgid "Kad: Off"
 msgstr "Kad: Apagado"
 
 #: src/amuleDlg.cpp
+msgid "Core"
+msgstr ""
+
+#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp src/Statistics.cpp
+msgid "Version"
+msgstr "Versión"
+
+#: src/amuleDlg.cpp
+msgid "The core and aMuleGUI are different versions."
+msgstr ""
+
+#: src/amuleDlg.cpp
+msgid "The core and aMuleGUI are the same version."
+msgstr ""
+
+#: src/amuleDlg.cpp src/ServerListCtrl.cpp
+msgid "Address"
+msgstr "Enderezo"
+
+#: src/amuleDlg.cpp
+#, fuzzy
+msgid "Encryption"
+msgstr "Descrición"
+
+#: src/amuleDlg.cpp
+#, fuzzy
+msgid "aMuleGUI"
+msgstr "Rexistro de aMule"
+
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Enviado: %.1f%s (%.1f) | Descargado: %.1f%s (%.1f)"
@@ -983,6 +1015,10 @@ msgstr ""
 #: src/amule-remote-gui.cpp
 msgid "Connection to the remote core was lost. Trying to reconnect..."
 msgstr ""
+
+#: src/amule-remote-gui.cpp src/ClientDetailDialog.cpp
+msgid "Disabled"
+msgstr "Deshabilitado"
 
 #: src/amule-remote-gui.cpp
 #, fuzzy
@@ -1298,10 +1334,6 @@ msgstr "Permitido"
 msgid "Not supported"
 msgstr "Non permitido"
 
-#: src/ClientDetailDialog.cpp
-msgid "Disabled"
-msgstr "Deshabilitado"
-
 #: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
 #: src/TextClient.cpp
 msgid "Connected"
@@ -1325,11 +1357,6 @@ msgstr "Nome:"
 #: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
 msgid "Software"
 msgstr ""
-
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/ServerListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp src/Statistics.cpp
-msgid "Version"
-msgstr "Versión"
 
 #: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
 #, fuzzy
@@ -6945,10 +6972,6 @@ msgstr "O servidor local está filtrado por IPFilters, conectando a un servidor 
 #: src/ServerListCtrl.cpp
 msgid "Server Name"
 msgstr "Nome do servidor"
-
-#: src/ServerListCtrl.cpp
-msgid "Address"
-msgstr "Enderezo"
 
 #: src/ServerListCtrl.cpp
 msgid "Port"

--- a/po/he.po
+++ b/po/he.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-30 16:16+0200\n"
+"POT-Creation-Date: 2026-08-31 17:03+0200\n"
 "PO-Revision-Date: 2026-08-31 10:06+0000\n"
 "Last-Translator: Peace Kramer <kpeace1@gmail.com>\n"
 "Language-Team: Hebrew\n"
@@ -745,6 +745,38 @@ msgid "Kad: Off"
 msgstr "קאד: מכובה"
 
 #: src/amuleDlg.cpp
+msgid "Core"
+msgstr ""
+
+#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp src/Statistics.cpp
+msgid "Version"
+msgstr "גירסא"
+
+#: src/amuleDlg.cpp
+msgid "The core and aMuleGUI are different versions."
+msgstr ""
+
+#: src/amuleDlg.cpp
+msgid "The core and aMuleGUI are the same version."
+msgstr ""
+
+#: src/amuleDlg.cpp src/ServerListCtrl.cpp
+msgid "Address"
+msgstr "כתובת"
+
+#: src/amuleDlg.cpp
+#, fuzzy
+msgid "Encryption"
+msgstr "תיאור"
+
+#: src/amuleDlg.cpp
+#, fuzzy
+msgid "aMuleGUI"
+msgstr "אֵימיול "
+
+#: src/amuleDlg.cpp
 #, fuzzy, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "מעלה: %.1f(%.1f) | מוריד: %.1f(%.1f)"
@@ -951,6 +983,10 @@ msgstr ""
 
 #: src/amule-remote-gui.cpp
 msgid "Connection to the remote core was lost. Trying to reconnect..."
+msgstr ""
+
+#: src/amule-remote-gui.cpp src/ClientDetailDialog.cpp
+msgid "Disabled"
 msgstr ""
 
 #: src/amule-remote-gui.cpp
@@ -1269,10 +1305,6 @@ msgstr ""
 msgid "Not supported"
 msgstr ""
 
-#: src/ClientDetailDialog.cpp
-msgid "Disabled"
-msgstr ""
-
 #: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
 #: src/TextClient.cpp
 msgid "Connected"
@@ -1296,11 +1328,6 @@ msgstr "שם:"
 #: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
 msgid "Software"
 msgstr ""
-
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/ServerListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp src/Statistics.cpp
-msgid "Version"
-msgstr "גירסא"
 
 #: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
 #, fuzzy
@@ -6900,10 +6927,6 @@ msgstr ""
 #: src/ServerListCtrl.cpp
 msgid "Server Name"
 msgstr "שם שרת"
-
-#: src/ServerListCtrl.cpp
-msgid "Address"
-msgstr "כתובת"
 
 #: src/ServerListCtrl.cpp
 msgid "Port"

--- a/po/hr.po
+++ b/po/hr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-30 16:16+0200\n"
+"POT-Creation-Date: 2026-08-31 17:03+0200\n"
 "PO-Revision-Date: 2026-08-31 10:07+0000\n"
 "Last-Translator: Sebastiano Pistore <sebastiano.pistore.info@aol.com>\n"
 "Language-Team: https://github.com/amule-org/amule <forum@aMule.org>\n"
@@ -745,6 +745,38 @@ msgid "Kad: Off"
 msgstr ""
 
 #: src/amuleDlg.cpp
+msgid "Core"
+msgstr ""
+
+#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp src/Statistics.cpp
+msgid "Version"
+msgstr "Verzija"
+
+#: src/amuleDlg.cpp
+msgid "The core and aMuleGUI are different versions."
+msgstr ""
+
+#: src/amuleDlg.cpp
+msgid "The core and aMuleGUI are the same version."
+msgstr ""
+
+#: src/amuleDlg.cpp src/ServerListCtrl.cpp
+msgid "Address"
+msgstr "Adresa"
+
+#: src/amuleDlg.cpp
+#, fuzzy
+msgid "Encryption"
+msgstr "Opis"
+
+#: src/amuleDlg.cpp
+#, fuzzy
+msgid "aMuleGUI"
+msgstr "aMule Log"
+
+#: src/amuleDlg.cpp
 #, fuzzy, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Gore: %.1f(%.1f) | Dole: %.1f(%.1f)"
@@ -951,6 +983,10 @@ msgstr ""
 #: src/amule-remote-gui.cpp
 msgid "Connection to the remote core was lost. Trying to reconnect..."
 msgstr ""
+
+#: src/amule-remote-gui.cpp src/ClientDetailDialog.cpp
+msgid "Disabled"
+msgstr "Onemogućeno"
 
 #: src/amule-remote-gui.cpp
 msgid "Reconnected to the remote core."
@@ -1268,10 +1304,6 @@ msgstr "Podržano"
 msgid "Not supported"
 msgstr "Nije podržano"
 
-#: src/ClientDetailDialog.cpp
-msgid "Disabled"
-msgstr "Onemogućeno"
-
 #: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
 #: src/TextClient.cpp
 msgid "Connected"
@@ -1295,11 +1327,6 @@ msgstr "Naziv:"
 #: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
 msgid "Software"
 msgstr ""
-
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/ServerListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp src/Statistics.cpp
-msgid "Version"
-msgstr "Verzija"
 
 #: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
 #, fuzzy
@@ -6891,10 +6918,6 @@ msgstr ""
 #: src/ServerListCtrl.cpp
 msgid "Server Name"
 msgstr "Ime servera"
-
-#: src/ServerListCtrl.cpp
-msgid "Address"
-msgstr "Adresa"
 
 #: src/ServerListCtrl.cpp
 msgid "Port"

--- a/po/hu.po
+++ b/po/hu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-30 16:16+0200\n"
+"POT-Creation-Date: 2026-08-31 17:03+0200\n"
 "PO-Revision-Date: 2026-08-31 10:07+0000\n"
 "Last-Translator: Dévai Tamás <gonosztopi@amule.org>\n"
 "Language-Team: Hungarian <hu@li.org>\n"
@@ -759,6 +759,38 @@ msgid "Kad: Off"
 msgstr "Kad: Nincs kapcsolat"
 
 #: src/amuleDlg.cpp
+msgid "Core"
+msgstr ""
+
+#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp src/Statistics.cpp
+msgid "Version"
+msgstr "Verzió"
+
+#: src/amuleDlg.cpp
+msgid "The core and aMuleGUI are different versions."
+msgstr ""
+
+#: src/amuleDlg.cpp
+msgid "The core and aMuleGUI are the same version."
+msgstr ""
+
+#: src/amuleDlg.cpp src/ServerListCtrl.cpp
+msgid "Address"
+msgstr "IP-cím"
+
+#: src/amuleDlg.cpp
+#, fuzzy
+msgid "Encryption"
+msgstr "Leírás"
+
+#: src/amuleDlg.cpp
+#, fuzzy
+msgid "aMuleGUI"
+msgstr "aMule Napló"
+
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Fel: %.1f%s (%.1f) | Le: %.1f%s (%.1f)"
@@ -964,6 +996,10 @@ msgstr ""
 #: src/amule-remote-gui.cpp
 msgid "Connection to the remote core was lost. Trying to reconnect..."
 msgstr ""
+
+#: src/amule-remote-gui.cpp src/ClientDetailDialog.cpp
+msgid "Disabled"
+msgstr "Letiltva"
 
 #: src/amule-remote-gui.cpp
 #, fuzzy
@@ -1275,10 +1311,6 @@ msgstr "Támogatott"
 msgid "Not supported"
 msgstr "Nem támogatott"
 
-#: src/ClientDetailDialog.cpp
-msgid "Disabled"
-msgstr "Letiltva"
-
 #: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
 #: src/TextClient.cpp
 msgid "Connected"
@@ -1302,11 +1334,6 @@ msgstr "Név:"
 #: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
 msgid "Software"
 msgstr ""
-
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/ServerListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp src/Statistics.cpp
-msgid "Version"
-msgstr "Verzió"
 
 #: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
 #, fuzzy
@@ -6904,10 +6931,6 @@ msgstr "A helyi kiszolgálót kiszűrte az IP-szűrő, újracsatlakozom egy más
 #: src/ServerListCtrl.cpp
 msgid "Server Name"
 msgstr "Kiszolgáló neve"
-
-#: src/ServerListCtrl.cpp
-msgid "Address"
-msgstr "IP-cím"
 
 #: src/ServerListCtrl.cpp
 msgid "Port"

--- a/po/it.po
+++ b/po/it.po
@@ -19,7 +19,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule 2.3.3\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-30 16:16+0200\n"
+"POT-Creation-Date: 2026-08-31 17:03+0200\n"
 "PO-Revision-Date: 2026-08-31 10:08+0000\n"
 "Last-Translator: got3nks <got3nks@users.noreply.github.com>\n"
 "Language-Team: SebastianoPistore.info@protonmail.ch\n"
@@ -772,6 +772,38 @@ msgid "Kad: Off"
 msgstr "Kad: Spento"
 
 #: src/amuleDlg.cpp
+msgid "Core"
+msgstr ""
+
+#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp src/Statistics.cpp
+msgid "Version"
+msgstr "Versione"
+
+#: src/amuleDlg.cpp
+msgid "The core and aMuleGUI are different versions."
+msgstr ""
+
+#: src/amuleDlg.cpp
+msgid "The core and aMuleGUI are the same version."
+msgstr ""
+
+#: src/amuleDlg.cpp src/ServerListCtrl.cpp
+msgid "Address"
+msgstr "Indirizzo"
+
+#: src/amuleDlg.cpp
+#, fuzzy
+msgid "Encryption"
+msgstr "Descrizione"
+
+#: src/amuleDlg.cpp
+#, fuzzy
+msgid "aMuleGUI"
+msgstr "log di aMuleGUI"
+
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
@@ -978,6 +1010,10 @@ msgstr ""
 #: src/amule-remote-gui.cpp
 msgid "Connection to the remote core was lost. Trying to reconnect..."
 msgstr "Connessione al core remoto persa. Tentativo di riconnessione..."
+
+#: src/amule-remote-gui.cpp src/ClientDetailDialog.cpp
+msgid "Disabled"
+msgstr "Disabilitato"
 
 #: src/amule-remote-gui.cpp
 msgid "Reconnected to the remote core."
@@ -1290,10 +1326,6 @@ msgstr "Supportato"
 msgid "Not supported"
 msgstr "Non supportato"
 
-#: src/ClientDetailDialog.cpp
-msgid "Disabled"
-msgstr "Disabilitato"
-
 #: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
 #: src/TextClient.cpp
 msgid "Connected"
@@ -1316,11 +1348,6 @@ msgstr "Nome"
 #: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
 msgid "Software"
 msgstr "Software"
-
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/ServerListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp src/Statistics.cpp
-msgid "Version"
-msgstr "Versione"
 
 #: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
 msgid "IP Address"
@@ -6882,10 +6909,6 @@ msgstr "Il server locale è filtrato dal filtro IP, mi connetto a un altro serve
 #: src/ServerListCtrl.cpp
 msgid "Server Name"
 msgstr "Nome server"
-
-#: src/ServerListCtrl.cpp
-msgid "Address"
-msgstr "Indirizzo"
 
 #: src/ServerListCtrl.cpp
 msgid "Port"

--- a/po/ja.po
+++ b/po/ja.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-30 16:16+0200\n"
+"POT-Creation-Date: 2026-08-31 17:03+0200\n"
 "PO-Revision-Date: 2026-08-31 10:08+0000\n"
 "Last-Translator: \n"
 "Language-Team: Japanese\n"
@@ -757,6 +757,38 @@ msgid "Kad: Off"
 msgstr "Kad: オフ"
 
 #: src/amuleDlg.cpp
+msgid "Core"
+msgstr ""
+
+#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp src/Statistics.cpp
+msgid "Version"
+msgstr "バージョン"
+
+#: src/amuleDlg.cpp
+msgid "The core and aMuleGUI are different versions."
+msgstr ""
+
+#: src/amuleDlg.cpp
+msgid "The core and aMuleGUI are the same version."
+msgstr ""
+
+#: src/amuleDlg.cpp src/ServerListCtrl.cpp
+msgid "Address"
+msgstr "アドレス"
+
+#: src/amuleDlg.cpp
+#, fuzzy
+msgid "Encryption"
+msgstr "説明"
+
+#: src/amuleDlg.cpp
+#, fuzzy
+msgid "aMuleGUI"
+msgstr "aMuleのログ"
+
+#: src/amuleDlg.cpp
 #, fuzzy, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "アップ： %.1f(%.1f) | ダウン： %.1f(%.1f)"
@@ -966,6 +998,10 @@ msgstr ""
 #: src/amule-remote-gui.cpp
 msgid "Connection to the remote core was lost. Trying to reconnect..."
 msgstr ""
+
+#: src/amule-remote-gui.cpp src/ClientDetailDialog.cpp
+msgid "Disabled"
+msgstr "無効"
 
 #: src/amule-remote-gui.cpp
 #, fuzzy
@@ -1277,10 +1313,6 @@ msgstr "サポート"
 msgid "Not supported"
 msgstr "非サポート"
 
-#: src/ClientDetailDialog.cpp
-msgid "Disabled"
-msgstr "無効"
-
 #: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
 #: src/TextClient.cpp
 msgid "Connected"
@@ -1304,11 +1336,6 @@ msgstr "名前："
 #: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
 msgid "Software"
 msgstr ""
-
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/ServerListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp src/Statistics.cpp
-msgid "Version"
-msgstr "バージョン"
 
 #: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
 #, fuzzy
@@ -6928,10 +6955,6 @@ msgstr "ローカル・サーバはIPFiltersにフィルタされているため
 #: src/ServerListCtrl.cpp
 msgid "Server Name"
 msgstr "サーバ名"
-
-#: src/ServerListCtrl.cpp
-msgid "Address"
-msgstr "アドレス"
 
 #: src/ServerListCtrl.cpp
 msgid "Port"

--- a/po/ko_KR.po
+++ b/po/ko_KR.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-30 16:16+0200\n"
+"POT-Creation-Date: 2026-08-31 17:03+0200\n"
 "PO-Revision-Date: 2026-08-31 10:08+0000\n"
 "Last-Translator: Hyunju Kang <rexington@gmail.com>\n"
 "Language-Team: Korean <hoenny@daum.net>\n"
@@ -760,6 +760,38 @@ msgid "Kad: Off"
 msgstr " Kad: "
 
 #: src/amuleDlg.cpp
+msgid "Core"
+msgstr ""
+
+#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp src/Statistics.cpp
+msgid "Version"
+msgstr "버젼"
+
+#: src/amuleDlg.cpp
+msgid "The core and aMuleGUI are different versions."
+msgstr ""
+
+#: src/amuleDlg.cpp
+msgid "The core and aMuleGUI are the same version."
+msgstr ""
+
+#: src/amuleDlg.cpp src/ServerListCtrl.cpp
+msgid "Address"
+msgstr "주소"
+
+#: src/amuleDlg.cpp
+#, fuzzy
+msgid "Encryption"
+msgstr "설명"
+
+#: src/amuleDlg.cpp
+#, fuzzy
+msgid "aMuleGUI"
+msgstr "어뮬 로그"
+
+#: src/amuleDlg.cpp
 #, fuzzy, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "올려주기: %.1f(%.1f) | 내려받기: %.1f(%.1f)"
@@ -968,6 +1000,10 @@ msgstr ""
 
 #: src/amule-remote-gui.cpp
 msgid "Connection to the remote core was lost. Trying to reconnect..."
+msgstr ""
+
+#: src/amule-remote-gui.cpp src/ClientDetailDialog.cpp
+msgid "Disabled"
 msgstr ""
 
 #: src/amule-remote-gui.cpp
@@ -1286,10 +1322,6 @@ msgstr ""
 msgid "Not supported"
 msgstr ""
 
-#: src/ClientDetailDialog.cpp
-msgid "Disabled"
-msgstr ""
-
 #: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
 #: src/TextClient.cpp
 msgid "Connected"
@@ -1313,11 +1345,6 @@ msgstr "이름:"
 #: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
 msgid "Software"
 msgstr ""
-
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/ServerListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp src/Statistics.cpp
-msgid "Version"
-msgstr "버젼"
 
 #: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
 #, fuzzy
@@ -6968,10 +6995,6 @@ msgstr "지역 서버가 IPFilter에 의해 차단되어, 다른 서버로 재�
 #: src/ServerListCtrl.cpp
 msgid "Server Name"
 msgstr "서버 이름"
-
-#: src/ServerListCtrl.cpp
-msgid "Address"
-msgstr "주소"
 
 #: src/ServerListCtrl.cpp
 msgid "Port"

--- a/po/lt.po
+++ b/po/lt.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-30 16:16+0200\n"
+"POT-Creation-Date: 2026-08-31 17:03+0200\n"
 "PO-Revision-Date: 2026-08-31 10:09+0000\n"
 "Last-Translator: Dovydas Sankauskas <laisve@gmail.com>\n"
 "Language-Team: Lithuanian <komp_lt@konf.lt>\n"
@@ -763,6 +763,38 @@ msgid "Kad: Off"
 msgstr "Kad: išjungta"
 
 #: src/amuleDlg.cpp
+msgid "Core"
+msgstr ""
+
+#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp src/Statistics.cpp
+msgid "Version"
+msgstr "Versija"
+
+#: src/amuleDlg.cpp
+msgid "The core and aMuleGUI are different versions."
+msgstr ""
+
+#: src/amuleDlg.cpp
+msgid "The core and aMuleGUI are the same version."
+msgstr ""
+
+#: src/amuleDlg.cpp src/ServerListCtrl.cpp
+msgid "Address"
+msgstr "Adresas"
+
+#: src/amuleDlg.cpp
+#, fuzzy
+msgid "Encryption"
+msgstr "Aprašymas"
+
+#: src/amuleDlg.cpp
+#, fuzzy
+msgid "aMuleGUI"
+msgstr "aMule žurnalas"
+
+#: src/amuleDlg.cpp
 #, fuzzy, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Išs.: %.1f(%.1f) | Ats.: %.1f(%.1f)"
@@ -971,6 +1003,10 @@ msgstr ""
 #: src/amule-remote-gui.cpp
 msgid "Connection to the remote core was lost. Trying to reconnect..."
 msgstr ""
+
+#: src/amule-remote-gui.cpp src/ClientDetailDialog.cpp
+msgid "Disabled"
+msgstr "Išjungta"
 
 #: src/amule-remote-gui.cpp
 #, fuzzy
@@ -1292,10 +1328,6 @@ msgstr "Palaikoma"
 msgid "Not supported"
 msgstr "Nepalaikoma"
 
-#: src/ClientDetailDialog.cpp
-msgid "Disabled"
-msgstr "Išjungta"
-
 #: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
 #: src/TextClient.cpp
 msgid "Connected"
@@ -1319,11 +1351,6 @@ msgstr "Pavadinimas:"
 #: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
 msgid "Software"
 msgstr ""
-
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/ServerListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp src/Statistics.cpp
-msgid "Version"
-msgstr "Versija"
 
 #: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
 #, fuzzy
@@ -7000,10 +7027,6 @@ msgstr "Vietinis serveris filtruojamas IP filtro, jungiamasi prie kito serverio!
 #: src/ServerListCtrl.cpp
 msgid "Server Name"
 msgstr "Serverio pavadinimas"
-
-#: src/ServerListCtrl.cpp
-msgid "Address"
-msgstr "Adresas"
 
 #: src/ServerListCtrl.cpp
 msgid "Port"

--- a/po/lv.po
+++ b/po/lv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-30 16:16+0200\n"
+"POT-Creation-Date: 2026-08-31 17:03+0200\n"
 "PO-Revision-Date: 2026-08-31 10:18+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -736,6 +736,38 @@ msgid "Kad: Off"
 msgstr "Kad: Izslēgts"
 
 #: src/amuleDlg.cpp
+msgid "Core"
+msgstr ""
+
+#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp src/Statistics.cpp
+msgid "Version"
+msgstr "Versija"
+
+#: src/amuleDlg.cpp
+msgid "The core and aMuleGUI are different versions."
+msgstr ""
+
+#: src/amuleDlg.cpp
+msgid "The core and aMuleGUI are the same version."
+msgstr ""
+
+#: src/amuleDlg.cpp src/ServerListCtrl.cpp
+msgid "Address"
+msgstr "Adrese"
+
+#: src/amuleDlg.cpp
+#, fuzzy
+msgid "Encryption"
+msgstr "Apraksts"
+
+#: src/amuleDlg.cpp
+#, fuzzy
+msgid "aMuleGUI"
+msgstr "aMuleGUI žurnāls"
+
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "↑ Augšup.: %.1f%s (%.1f) | ↓ Lejup.: %.1f%s (%.1f)"
@@ -937,6 +969,10 @@ msgstr ""
 #: src/amule-remote-gui.cpp
 msgid "Connection to the remote core was lost. Trying to reconnect..."
 msgstr ""
+
+#: src/amule-remote-gui.cpp src/ClientDetailDialog.cpp
+msgid "Disabled"
+msgstr "Atspējots"
 
 #: src/amule-remote-gui.cpp
 #, fuzzy
@@ -1248,10 +1284,6 @@ msgstr ""
 msgid "Not supported"
 msgstr ""
 
-#: src/ClientDetailDialog.cpp
-msgid "Disabled"
-msgstr "Atspējots"
-
 #: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
 #: src/TextClient.cpp
 msgid "Connected"
@@ -1274,11 +1306,6 @@ msgstr "Nosaukums"
 #: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
 msgid "Software"
 msgstr "Programma"
-
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/ServerListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp src/Statistics.cpp
-msgid "Version"
-msgstr "Versija"
 
 #: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
 msgid "IP Address"
@@ -6773,10 +6800,6 @@ msgstr ""
 #: src/ServerListCtrl.cpp
 msgid "Server Name"
 msgstr "Servera nosaukums"
-
-#: src/ServerListCtrl.cpp
-msgid "Address"
-msgstr "Adrese"
 
 #: src/ServerListCtrl.cpp
 msgid "Port"

--- a/po/nl.po
+++ b/po/nl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-30 16:16+0200\n"
+"POT-Creation-Date: 2026-08-31 17:03+0200\n"
 "PO-Revision-Date: 2026-08-31 10:10+0000\n"
 "Last-Translator: Marcel Pol <marcel@timelord.nl>\n"
 "Language-Team: Dutch <nl@li.org>\n"
@@ -761,6 +761,38 @@ msgid "Kad: Off"
 msgstr "Kad: Uitgeschakeld"
 
 #: src/amuleDlg.cpp
+msgid "Core"
+msgstr ""
+
+#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp src/Statistics.cpp
+msgid "Version"
+msgstr "Versie"
+
+#: src/amuleDlg.cpp
+msgid "The core and aMuleGUI are different versions."
+msgstr ""
+
+#: src/amuleDlg.cpp
+msgid "The core and aMuleGUI are the same version."
+msgstr ""
+
+#: src/amuleDlg.cpp src/ServerListCtrl.cpp
+msgid "Address"
+msgstr "Adres"
+
+#: src/amuleDlg.cpp
+#, fuzzy
+msgid "Encryption"
+msgstr "Beschrijving"
+
+#: src/amuleDlg.cpp
+#, fuzzy
+msgid "aMuleGUI"
+msgstr "aMuleGUI-log"
+
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Upload: %.1f%s (%.1f) | Download: %.1f%s (%.1f)"
@@ -967,6 +999,10 @@ msgstr ""
 #: src/amule-remote-gui.cpp
 msgid "Connection to the remote core was lost. Trying to reconnect..."
 msgstr "Verbinding met de externe kern is verloren. Opnieuw verbinden wordt geprobeerd..."
+
+#: src/amule-remote-gui.cpp src/ClientDetailDialog.cpp
+msgid "Disabled"
+msgstr "Uitgeschakeld"
 
 #: src/amule-remote-gui.cpp
 msgid "Reconnected to the remote core."
@@ -1279,10 +1315,6 @@ msgstr "Ondersteund"
 msgid "Not supported"
 msgstr "Niet ondersteund"
 
-#: src/ClientDetailDialog.cpp
-msgid "Disabled"
-msgstr "Uitgeschakeld"
-
 #: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
 #: src/TextClient.cpp
 msgid "Connected"
@@ -1305,11 +1337,6 @@ msgstr "Naam"
 #: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
 msgid "Software"
 msgstr "Software"
-
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/ServerListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp src/Statistics.cpp
-msgid "Version"
-msgstr "Versie"
 
 #: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
 msgid "IP Address"
@@ -6873,10 +6900,6 @@ msgstr "De lokale server wordt door de IP-filters weggefilterd, er wordt verbond
 #: src/ServerListCtrl.cpp
 msgid "Server Name"
 msgstr "Server-naam"
-
-#: src/ServerListCtrl.cpp
-msgid "Address"
-msgstr "Adres"
 
 #: src/ServerListCtrl.cpp
 msgid "Port"

--- a/po/nn.po
+++ b/po/nn.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-30 16:16+0200\n"
+"POT-Creation-Date: 2026-08-31 17:03+0200\n"
 "PO-Revision-Date: 2026-08-31 10:10+0000\n"
 "Last-Translator: Hallvor Brunstad <Hallvor_1976@yahoo.com>\n"
 "Language-Team: <i18n-nn@lister.ping.uio.no>\n"
@@ -761,6 +761,38 @@ msgid "Kad: Off"
 msgstr "Kad: Av"
 
 #: src/amuleDlg.cpp
+msgid "Core"
+msgstr ""
+
+#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp src/Statistics.cpp
+msgid "Version"
+msgstr "Utgåve"
+
+#: src/amuleDlg.cpp
+msgid "The core and aMuleGUI are different versions."
+msgstr ""
+
+#: src/amuleDlg.cpp
+msgid "The core and aMuleGUI are the same version."
+msgstr ""
+
+#: src/amuleDlg.cpp src/ServerListCtrl.cpp
+msgid "Address"
+msgstr "Addresse"
+
+#: src/amuleDlg.cpp
+#, fuzzy
+msgid "Encryption"
+msgstr "Skildring"
+
+#: src/amuleDlg.cpp
+#, fuzzy
+msgid "aMuleGUI"
+msgstr "aMulelogg"
+
+#: src/amuleDlg.cpp
 #, fuzzy, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Opp:·%.1f(%.1f)·|·Ned:·%.1f(%.1f)"
@@ -969,6 +1001,10 @@ msgstr ""
 #: src/amule-remote-gui.cpp
 msgid "Connection to the remote core was lost. Trying to reconnect..."
 msgstr ""
+
+#: src/amule-remote-gui.cpp src/ClientDetailDialog.cpp
+msgid "Disabled"
+msgstr "Deaktivert"
 
 #: src/amule-remote-gui.cpp
 #, fuzzy
@@ -1286,10 +1322,6 @@ msgstr "Støtta"
 msgid "Not supported"
 msgstr "Ikkje støtta"
 
-#: src/ClientDetailDialog.cpp
-msgid "Disabled"
-msgstr "Deaktivert"
-
 #: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
 #: src/TextClient.cpp
 msgid "Connected"
@@ -1313,11 +1345,6 @@ msgstr "Namn:"
 #: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
 msgid "Software"
 msgstr ""
-
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/ServerListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp src/Statistics.cpp
-msgid "Version"
-msgstr "Utgåve"
 
 #: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
 #, fuzzy
@@ -6970,10 +6997,6 @@ msgstr "Lokal tenar er filtrert av ipfiltra - koplar til ein anna tenar!"
 #: src/ServerListCtrl.cpp
 msgid "Server Name"
 msgstr "Tenarnamn"
-
-#: src/ServerListCtrl.cpp
-msgid "Address"
-msgstr "Addresse"
 
 #: src/ServerListCtrl.cpp
 msgid "Port"

--- a/po/pl.po
+++ b/po/pl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-30 16:16+0200\n"
+"POT-Creation-Date: 2026-08-31 17:03+0200\n"
 "PO-Revision-Date: 2026-08-31 10:10+0000\n"
 "Last-Translator: Michał Trzebiatowski <hippie_1968@hotmail.com>\n"
 "Language-Team: translationproject.org/team/pl.html <translation-team-pl@lists.sourceforge.net>\n"
@@ -761,6 +761,38 @@ msgid "Kad: Off"
 msgstr "Kad: Wyłączony"
 
 #: src/amuleDlg.cpp
+msgid "Core"
+msgstr ""
+
+#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp src/Statistics.cpp
+msgid "Version"
+msgstr "Wersja"
+
+#: src/amuleDlg.cpp
+msgid "The core and aMuleGUI are different versions."
+msgstr ""
+
+#: src/amuleDlg.cpp
+msgid "The core and aMuleGUI are the same version."
+msgstr ""
+
+#: src/amuleDlg.cpp src/ServerListCtrl.cpp
+msgid "Address"
+msgstr "Adres"
+
+#: src/amuleDlg.cpp
+#, fuzzy
+msgid "Encryption"
+msgstr "Opis"
+
+#: src/amuleDlg.cpp
+#, fuzzy
+msgid "aMuleGUI"
+msgstr "Logi aMule"
+
+#: src/amuleDlg.cpp
 #, fuzzy, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Wysł: %.1f(%.1f) | Pobr: %.1f(%.1f)"
@@ -964,6 +996,10 @@ msgstr ""
 #: src/amule-remote-gui.cpp
 msgid "Connection to the remote core was lost. Trying to reconnect..."
 msgstr ""
+
+#: src/amule-remote-gui.cpp src/ClientDetailDialog.cpp
+msgid "Disabled"
+msgstr "Wyłączony"
 
 #: src/amule-remote-gui.cpp
 #, fuzzy
@@ -1284,10 +1320,6 @@ msgstr "Obsługiwany"
 msgid "Not supported"
 msgstr "Nieobsługiwany"
 
-#: src/ClientDetailDialog.cpp
-msgid "Disabled"
-msgstr "Wyłączony"
-
 #: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
 #: src/TextClient.cpp
 msgid "Connected"
@@ -1311,11 +1343,6 @@ msgstr "Nazwa:"
 #: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
 msgid "Software"
 msgstr ""
-
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/ServerListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp src/Statistics.cpp
-msgid "Version"
-msgstr "Wersja"
 
 #: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
 #, fuzzy
@@ -6980,10 +7007,6 @@ msgstr "Serwer lokalny jest filtrowany przez IPFilters, podłączam ponownie do 
 #: src/ServerListCtrl.cpp
 msgid "Server Name"
 msgstr "Nazwa serwera"
-
-#: src/ServerListCtrl.cpp
-msgid "Address"
-msgstr "Adres"
 
 #: src/ServerListCtrl.cpp
 msgid "Port"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-30 16:16+0200\n"
+"POT-Creation-Date: 2026-08-31 17:03+0200\n"
 "PO-Revision-Date: 2026-08-31 10:11+0000\n"
 "Last-Translator: Marcelo Jimenez <mroberto@users.sourceforge.com>\n"
 "Language-Team: Português (Brasileiro) <pt@li.org>\n"
@@ -766,6 +766,38 @@ msgid "Kad: Off"
 msgstr "Kad: Desligado"
 
 #: src/amuleDlg.cpp
+msgid "Core"
+msgstr ""
+
+#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp src/Statistics.cpp
+msgid "Version"
+msgstr "Versão"
+
+#: src/amuleDlg.cpp
+msgid "The core and aMuleGUI are different versions."
+msgstr ""
+
+#: src/amuleDlg.cpp
+msgid "The core and aMuleGUI are the same version."
+msgstr ""
+
+#: src/amuleDlg.cpp src/ServerListCtrl.cpp
+msgid "Address"
+msgstr "Endereço"
+
+#: src/amuleDlg.cpp
+#, fuzzy
+msgid "Encryption"
+msgstr "Descrição"
+
+#: src/amuleDlg.cpp
+#, fuzzy
+msgid "aMuleGUI"
+msgstr "Log do aMuleGUI"
+
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
@@ -972,6 +1004,10 @@ msgstr ""
 #: src/amule-remote-gui.cpp
 msgid "Connection to the remote core was lost. Trying to reconnect..."
 msgstr "A conexão com o núcleo remoto foi perdida. Tentando reconectar..."
+
+#: src/amule-remote-gui.cpp src/ClientDetailDialog.cpp
+msgid "Disabled"
+msgstr "Desabilitado"
 
 #: src/amule-remote-gui.cpp
 msgid "Reconnected to the remote core."
@@ -1284,10 +1320,6 @@ msgstr "Suportado"
 msgid "Not supported"
 msgstr "Não suportado"
 
-#: src/ClientDetailDialog.cpp
-msgid "Disabled"
-msgstr "Desabilitado"
-
 #: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
 #: src/TextClient.cpp
 msgid "Connected"
@@ -1310,11 +1342,6 @@ msgstr "Nome"
 #: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
 msgid "Software"
 msgstr "Software"
-
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/ServerListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp src/Statistics.cpp
-msgid "Version"
-msgstr "Versão"
 
 #: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
 msgid "IP Address"
@@ -6876,10 +6903,6 @@ msgstr "Servidor local é filtrado pelo IPFilters, reconectando em um servidor d
 #: src/ServerListCtrl.cpp
 msgid "Server Name"
 msgstr "Nome do Servidor"
-
-#: src/ServerListCtrl.cpp
-msgid "Address"
-msgstr "Endereço"
 
 #: src/ServerListCtrl.cpp
 msgid "Port"

--- a/po/pt_PT.po
+++ b/po/pt_PT.po
@@ -17,7 +17,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-30 16:16+0200\n"
+"POT-Creation-Date: 2026-08-31 17:03+0200\n"
 "PO-Revision-Date: 2026-08-31 10:12+0000\n"
 "Last-Translator: Luís Picciochi Oliveira <Pitxyoki@Gmail.com>\n"
 "Language-Team: Portuguese <traduz@debianpt.org>\n"
@@ -765,6 +765,38 @@ msgid "Kad: Off"
 msgstr "Kad: Desligado"
 
 #: src/amuleDlg.cpp
+msgid "Core"
+msgstr ""
+
+#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp src/Statistics.cpp
+msgid "Version"
+msgstr "Versão"
+
+#: src/amuleDlg.cpp
+msgid "The core and aMuleGUI are different versions."
+msgstr ""
+
+#: src/amuleDlg.cpp
+msgid "The core and aMuleGUI are the same version."
+msgstr ""
+
+#: src/amuleDlg.cpp src/ServerListCtrl.cpp
+msgid "Address"
+msgstr "Endereço"
+
+#: src/amuleDlg.cpp
+#, fuzzy
+msgid "Encryption"
+msgstr "Descrição"
+
+#: src/amuleDlg.cpp
+#, fuzzy
+msgid "aMuleGUI"
+msgstr "Relatório"
+
+#: src/amuleDlg.cpp
 #, fuzzy, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Up: %.1f(%.1f) | Down: %.1f(%.1f)"
@@ -968,6 +1000,10 @@ msgstr ""
 #: src/amule-remote-gui.cpp
 msgid "Connection to the remote core was lost. Trying to reconnect..."
 msgstr ""
+
+#: src/amule-remote-gui.cpp src/ClientDetailDialog.cpp
+msgid "Disabled"
+msgstr "Desactivado"
 
 #: src/amule-remote-gui.cpp
 #, fuzzy
@@ -1284,10 +1320,6 @@ msgstr "Suportado"
 msgid "Not supported"
 msgstr "Não suportado"
 
-#: src/ClientDetailDialog.cpp
-msgid "Disabled"
-msgstr "Desactivado"
-
 #: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
 #: src/TextClient.cpp
 msgid "Connected"
@@ -1311,11 +1343,6 @@ msgstr "Nome:"
 #: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
 msgid "Software"
 msgstr ""
-
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/ServerListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp src/Statistics.cpp
-msgid "Version"
-msgstr "Versão"
 
 #: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
 #, fuzzy
@@ -6946,10 +6973,6 @@ msgstr "Servidor local filtrado pelo Filtro de IPs, a ligar a um servidor difere
 #: src/ServerListCtrl.cpp
 msgid "Server Name"
 msgstr "Nome do Servidor"
-
-#: src/ServerListCtrl.cpp
-msgid "Address"
-msgstr "Endereço"
 
 #: src/ServerListCtrl.cpp
 msgid "Port"

--- a/po/ro.po
+++ b/po/ro.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-30 16:16+0200\n"
+"POT-Creation-Date: 2026-08-31 17:03+0200\n"
 "PO-Revision-Date: 2026-08-31 10:12+0000\n"
 "Last-Translator: Angelescu Constantin <titus0818@yahoo.com>\n"
 "Language-Team: English <kde-i18n-doc@kde.org>\n"
@@ -758,6 +758,38 @@ msgid "Kad: Off"
 msgstr "Kad: Închis"
 
 #: src/amuleDlg.cpp
+msgid "Core"
+msgstr ""
+
+#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp src/Statistics.cpp
+msgid "Version"
+msgstr "Versiune"
+
+#: src/amuleDlg.cpp
+msgid "The core and aMuleGUI are different versions."
+msgstr ""
+
+#: src/amuleDlg.cpp
+msgid "The core and aMuleGUI are the same version."
+msgstr ""
+
+#: src/amuleDlg.cpp src/ServerListCtrl.cpp
+msgid "Address"
+msgstr "Adresă"
+
+#: src/amuleDlg.cpp
+#, fuzzy
+msgid "Encryption"
+msgstr "Descriere"
+
+#: src/amuleDlg.cpp
+#, fuzzy
+msgid "aMuleGUI"
+msgstr "Jurnal aMule"
+
+#: src/amuleDlg.cpp
 #, fuzzy, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "În: %.1f(%.1f) | Desc: %.1f(%.1f)"
@@ -961,6 +993,10 @@ msgstr ""
 #: src/amule-remote-gui.cpp
 msgid "Connection to the remote core was lost. Trying to reconnect..."
 msgstr ""
+
+#: src/amule-remote-gui.cpp src/ClientDetailDialog.cpp
+msgid "Disabled"
+msgstr "Dezactivat"
 
 #: src/amule-remote-gui.cpp
 #, fuzzy
@@ -1281,10 +1317,6 @@ msgstr "Susținut"
 msgid "Not supported"
 msgstr "Nu este susținut"
 
-#: src/ClientDetailDialog.cpp
-msgid "Disabled"
-msgstr "Dezactivat"
-
 #: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
 #: src/TextClient.cpp
 msgid "Connected"
@@ -1308,11 +1340,6 @@ msgstr "Name:"
 #: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
 msgid "Software"
 msgstr ""
-
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/ServerListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp src/Statistics.cpp
-msgid "Version"
-msgstr "Versiune"
 
 #: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
 #, fuzzy
@@ -6961,10 +6988,6 @@ msgstr "Serverul local este filtrat de filtrele IP, reconectați la un server di
 #: src/ServerListCtrl.cpp
 msgid "Server Name"
 msgstr "Nume server"
-
-#: src/ServerListCtrl.cpp
-msgid "Address"
-msgstr "Adresă"
 
 #: src/ServerListCtrl.cpp
 msgid "Port"

--- a/po/ru.po
+++ b/po/ru.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-30 16:16+0200\n"
+"POT-Creation-Date: 2026-08-31 17:03+0200\n"
 "PO-Revision-Date: 2026-08-31 10:13+0000\n"
 "Last-Translator: Radist Morse <radist.morse@gmail.com>\n"
 "Language-Team: Russian <kde-russian@lists.kde.ru>\n"
@@ -770,6 +770,38 @@ msgid "Kad: Off"
 msgstr "Kad: отключён"
 
 #: src/amuleDlg.cpp
+msgid "Core"
+msgstr ""
+
+#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp src/Statistics.cpp
+msgid "Version"
+msgstr "Версия"
+
+#: src/amuleDlg.cpp
+msgid "The core and aMuleGUI are different versions."
+msgstr ""
+
+#: src/amuleDlg.cpp
+msgid "The core and aMuleGUI are the same version."
+msgstr ""
+
+#: src/amuleDlg.cpp src/ServerListCtrl.cpp
+msgid "Address"
+msgstr "Адрес"
+
+#: src/amuleDlg.cpp
+#, fuzzy
+msgid "Encryption"
+msgstr "Описание"
+
+#: src/amuleDlg.cpp
+#, fuzzy
+msgid "aMuleGUI"
+msgstr "Журнал aMuleGUI"
+
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Отд: %.1f%s (%.1f) | Заг: %.1f%s (%.1f)"
@@ -976,6 +1008,10 @@ msgstr ""
 #: src/amule-remote-gui.cpp
 msgid "Connection to the remote core was lost. Trying to reconnect..."
 msgstr "Подключение к удалённому ядру потеряно. Попытка переподключения…"
+
+#: src/amule-remote-gui.cpp src/ClientDetailDialog.cpp
+msgid "Disabled"
+msgstr "Запрещено"
 
 #: src/amule-remote-gui.cpp
 msgid "Reconnected to the remote core."
@@ -1292,10 +1328,6 @@ msgstr "Поддерживается"
 msgid "Not supported"
 msgstr "Не поддерживается"
 
-#: src/ClientDetailDialog.cpp
-msgid "Disabled"
-msgstr "Запрещено"
-
 #: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
 #: src/TextClient.cpp
 msgid "Connected"
@@ -1318,11 +1350,6 @@ msgstr "Имя"
 #: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
 msgid "Software"
 msgstr "ПО"
-
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/ServerListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp src/Statistics.cpp
-msgid "Version"
-msgstr "Версия"
 
 #: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
 msgid "IP Address"
@@ -6932,10 +6959,6 @@ msgstr "Локальный сервер отфильтрован IP-фильтр
 #: src/ServerListCtrl.cpp
 msgid "Server Name"
 msgstr "Имя сервера"
-
-#: src/ServerListCtrl.cpp
-msgid "Address"
-msgstr "Адрес"
 
 #: src/ServerListCtrl.cpp
 msgid "Port"

--- a/po/sl.po
+++ b/po/sl.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-30 16:16+0200\n"
+"POT-Creation-Date: 2026-08-31 17:03+0200\n"
 "PO-Revision-Date: 2026-08-31 10:13+0000\n"
 "Last-Translator: Jure Repinc <jlp@holodeck1.com>\n"
 "Language-Team: Slovenian\n"
@@ -764,6 +764,38 @@ msgid "Kad: Off"
 msgstr "Kad: izklopljen"
 
 #: src/amuleDlg.cpp
+msgid "Core"
+msgstr ""
+
+#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp src/Statistics.cpp
+msgid "Version"
+msgstr "Različica"
+
+#: src/amuleDlg.cpp
+msgid "The core and aMuleGUI are different versions."
+msgstr ""
+
+#: src/amuleDlg.cpp
+msgid "The core and aMuleGUI are the same version."
+msgstr ""
+
+#: src/amuleDlg.cpp src/ServerListCtrl.cpp
+msgid "Address"
+msgstr "Naslov"
+
+#: src/amuleDlg.cpp
+#, fuzzy
+msgid "Encryption"
+msgstr "Opis"
+
+#: src/amuleDlg.cpp
+#, fuzzy
+msgid "aMuleGUI"
+msgstr "aMule dnevnik"
+
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Gor: %.1f%s (%.1f) | Dol: %.1f%s (%.1f)"
@@ -967,6 +999,10 @@ msgstr ""
 #: src/amule-remote-gui.cpp
 msgid "Connection to the remote core was lost. Trying to reconnect..."
 msgstr ""
+
+#: src/amule-remote-gui.cpp src/ClientDetailDialog.cpp
+msgid "Disabled"
+msgstr "Onemogočeno"
 
 #: src/amule-remote-gui.cpp
 #, fuzzy
@@ -1291,10 +1327,6 @@ msgstr "Podprto"
 msgid "Not supported"
 msgstr "Ni podprto"
 
-#: src/ClientDetailDialog.cpp
-msgid "Disabled"
-msgstr "Onemogočeno"
-
 #: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
 #: src/TextClient.cpp
 msgid "Connected"
@@ -1318,11 +1350,6 @@ msgstr "Ime:"
 #: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
 msgid "Software"
 msgstr ""
-
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/ServerListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp src/Statistics.cpp
-msgid "Version"
-msgstr "Različica"
 
 #: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
 #, fuzzy
@@ -7003,10 +7030,6 @@ msgstr "IP Filter je filtriral krajevni strežnik. Povezovanje z drugim strežni
 #: src/ServerListCtrl.cpp
 msgid "Server Name"
 msgstr "Ime strežnika"
-
-#: src/ServerListCtrl.cpp
-msgid "Address"
-msgstr "Naslov"
 
 #: src/ServerListCtrl.cpp
 msgid "Port"

--- a/po/sq.po
+++ b/po/sq.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-30 16:16+0200\n"
+"POT-Creation-Date: 2026-08-31 17:03+0200\n"
 "PO-Revision-Date: 2026-08-31 10:14+0000\n"
 "Last-Translator: Fation <dj_barthezz@linuxmail.org lushnja_corps@hotmail.Language-Team:\n"
 "Language: sq\n"
@@ -758,6 +758,38 @@ msgid "Kad: Off"
 msgstr "Kad: Fikur"
 
 #: src/amuleDlg.cpp
+msgid "Core"
+msgstr ""
+
+#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp src/Statistics.cpp
+msgid "Version"
+msgstr "Versioni"
+
+#: src/amuleDlg.cpp
+msgid "The core and aMuleGUI are different versions."
+msgstr ""
+
+#: src/amuleDlg.cpp
+msgid "The core and aMuleGUI are the same version."
+msgstr ""
+
+#: src/amuleDlg.cpp src/ServerListCtrl.cpp
+msgid "Address"
+msgstr "Adresa"
+
+#: src/amuleDlg.cpp
+#, fuzzy
+msgid "Encryption"
+msgstr "Pershkrimi"
+
+#: src/amuleDlg.cpp
+#, fuzzy
+msgid "aMuleGUI"
+msgstr "Log i aMule"
+
+#: src/amuleDlg.cpp
 #, fuzzy, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Larte: %.1f(%.1f) | Poshte: %.1f(%.1f)"
@@ -965,6 +997,10 @@ msgstr ""
 
 #: src/amule-remote-gui.cpp
 msgid "Connection to the remote core was lost. Trying to reconnect..."
+msgstr ""
+
+#: src/amule-remote-gui.cpp src/ClientDetailDialog.cpp
+msgid "Disabled"
 msgstr ""
 
 #: src/amule-remote-gui.cpp
@@ -1283,10 +1319,6 @@ msgstr ""
 msgid "Not supported"
 msgstr ""
 
-#: src/ClientDetailDialog.cpp
-msgid "Disabled"
-msgstr ""
-
 #: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
 #: src/TextClient.cpp
 msgid "Connected"
@@ -1310,11 +1342,6 @@ msgstr "Emri:"
 #: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
 msgid "Software"
 msgstr ""
-
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/ServerListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp src/Statistics.cpp
-msgid "Version"
-msgstr "Versioni"
 
 #: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
 #, fuzzy
@@ -6960,10 +6987,6 @@ msgstr "Serverat lokale jane te filtruara nga IPFilters, duke u rilidhur ne nje 
 #: src/ServerListCtrl.cpp
 msgid "Server Name"
 msgstr "Emri i serverit"
-
-#: src/ServerListCtrl.cpp
-msgid "Address"
-msgstr "Adresa"
 
 #: src/ServerListCtrl.cpp
 msgid "Port"

--- a/po/sv.po
+++ b/po/sv.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-30 16:16+0200\n"
+"POT-Creation-Date: 2026-08-31 17:03+0200\n"
 "PO-Revision-Date: 2026-08-31 10:14+0000\n"
 "Last-Translator: raffe <raffe@localhost.se>\n"
 "Language-Team: Swedish <tp-sv@listor.tp-sv.se>\n"
@@ -757,6 +757,38 @@ msgid "Kad: Off"
 msgstr "Kad: Av"
 
 #: src/amuleDlg.cpp
+msgid "Core"
+msgstr ""
+
+#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp src/Statistics.cpp
+msgid "Version"
+msgstr "Version"
+
+#: src/amuleDlg.cpp
+msgid "The core and aMuleGUI are different versions."
+msgstr ""
+
+#: src/amuleDlg.cpp
+msgid "The core and aMuleGUI are the same version."
+msgstr ""
+
+#: src/amuleDlg.cpp src/ServerListCtrl.cpp
+msgid "Address"
+msgstr "Adress"
+
+#: src/amuleDlg.cpp
+#, fuzzy
+msgid "Encryption"
+msgstr "Beskrivning"
+
+#: src/amuleDlg.cpp
+#, fuzzy
+msgid "aMuleGUI"
+msgstr "aMule-logg"
+
+#: src/amuleDlg.cpp
 #, fuzzy, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Upp: %.1f(%.1f) | Ner: %.1f(%.1f)"
@@ -960,6 +992,10 @@ msgstr ""
 #: src/amule-remote-gui.cpp
 msgid "Connection to the remote core was lost. Trying to reconnect..."
 msgstr ""
+
+#: src/amule-remote-gui.cpp src/ClientDetailDialog.cpp
+msgid "Disabled"
+msgstr "Inaktiverad"
 
 #: src/amule-remote-gui.cpp
 #, fuzzy
@@ -1276,10 +1312,6 @@ msgstr "Stöds"
 msgid "Not supported"
 msgstr "Stöds inte"
 
-#: src/ClientDetailDialog.cpp
-msgid "Disabled"
-msgstr "Inaktiverad"
-
 #: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
 #: src/TextClient.cpp
 msgid "Connected"
@@ -1303,11 +1335,6 @@ msgstr "Namn:"
 #: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
 msgid "Software"
 msgstr ""
-
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/ServerListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp src/Statistics.cpp
-msgid "Version"
-msgstr "Version"
 
 #: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
 #, fuzzy
@@ -6934,10 +6961,6 @@ msgstr "Lokal server filtreras av IPFilters, återansluter till en annan server!
 #: src/ServerListCtrl.cpp
 msgid "Server Name"
 msgstr "Servernamn"
-
-#: src/ServerListCtrl.cpp
-msgid "Address"
-msgstr "Adress"
 
 #: src/ServerListCtrl.cpp
 msgid "Port"

--- a/po/ta.po
+++ b/po/ta.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-30 16:16+0200\n"
+"POT-Creation-Date: 2026-08-31 17:03+0200\n"
 "PO-Revision-Date: 2026-08-31 10:18+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -725,6 +725,36 @@ msgid "Kad: Off"
 msgstr ""
 
 #: src/amuleDlg.cpp
+msgid "Core"
+msgstr ""
+
+#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp src/Statistics.cpp
+msgid "Version"
+msgstr ""
+
+#: src/amuleDlg.cpp
+msgid "The core and aMuleGUI are different versions."
+msgstr ""
+
+#: src/amuleDlg.cpp
+msgid "The core and aMuleGUI are the same version."
+msgstr ""
+
+#: src/amuleDlg.cpp src/ServerListCtrl.cpp
+msgid "Address"
+msgstr ""
+
+#: src/amuleDlg.cpp
+msgid "Encryption"
+msgstr ""
+
+#: src/amuleDlg.cpp
+msgid "aMuleGUI"
+msgstr ""
+
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr ""
@@ -924,6 +954,10 @@ msgstr ""
 
 #: src/amule-remote-gui.cpp
 msgid "Connection to the remote core was lost. Trying to reconnect..."
+msgstr ""
+
+#: src/amule-remote-gui.cpp src/ClientDetailDialog.cpp
+msgid "Disabled"
 msgstr ""
 
 #: src/amule-remote-gui.cpp
@@ -1235,10 +1269,6 @@ msgstr ""
 msgid "Not supported"
 msgstr ""
 
-#: src/ClientDetailDialog.cpp
-msgid "Disabled"
-msgstr ""
-
 #: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
 #: src/TextClient.cpp
 msgid "Connected"
@@ -1260,11 +1290,6 @@ msgstr ""
 
 #: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
 msgid "Software"
-msgstr ""
-
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/ServerListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp src/Statistics.cpp
-msgid "Version"
 msgstr ""
 
 #: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
@@ -6727,10 +6752,6 @@ msgstr ""
 
 #: src/ServerListCtrl.cpp
 msgid "Server Name"
-msgstr ""
-
-#: src/ServerListCtrl.cpp
-msgid "Address"
 msgstr ""
 
 #: src/ServerListCtrl.cpp

--- a/po/tr.po
+++ b/po/tr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-30 16:16+0200\n"
+"POT-Creation-Date: 2026-08-31 17:03+0200\n"
 "PO-Revision-Date: 2026-08-31 10:15+0000\n"
 "Last-Translator: \n"
 "Language-Team: Turkish <li@li.org>\n"
@@ -758,6 +758,38 @@ msgid "Kad: Off"
 msgstr "Kad: Kapalı"
 
 #: src/amuleDlg.cpp
+msgid "Core"
+msgstr ""
+
+#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp src/Statistics.cpp
+msgid "Version"
+msgstr "Sürüm"
+
+#: src/amuleDlg.cpp
+msgid "The core and aMuleGUI are different versions."
+msgstr ""
+
+#: src/amuleDlg.cpp
+msgid "The core and aMuleGUI are the same version."
+msgstr ""
+
+#: src/amuleDlg.cpp src/ServerListCtrl.cpp
+msgid "Address"
+msgstr "Adres"
+
+#: src/amuleDlg.cpp
+#, fuzzy
+msgid "Encryption"
+msgstr "Açıklama"
+
+#: src/amuleDlg.cpp
+#, fuzzy
+msgid "aMuleGUI"
+msgstr "aMuleGUI Günlüğü"
+
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Gön: %.1f%s (%.1f) | İnd: %.1f%s (%.1f)"
@@ -964,6 +996,10 @@ msgstr ""
 #: src/amule-remote-gui.cpp
 msgid "Connection to the remote core was lost. Trying to reconnect..."
 msgstr "Uzaktaki çekirdekle kurulan bağlantı koptu. Tekrar bağlanma deneniyor…"
+
+#: src/amule-remote-gui.cpp src/ClientDetailDialog.cpp
+msgid "Disabled"
+msgstr "Devre dışı"
 
 #: src/amule-remote-gui.cpp
 msgid "Reconnected to the remote core."
@@ -1276,10 +1312,6 @@ msgstr "Destekleniyor"
 msgid "Not supported"
 msgstr "Desteklenmiyor"
 
-#: src/ClientDetailDialog.cpp
-msgid "Disabled"
-msgstr "Devre dışı"
-
 #: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
 #: src/TextClient.cpp
 msgid "Connected"
@@ -1302,11 +1334,6 @@ msgstr "Ad"
 #: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
 msgid "Software"
 msgstr "Yazılım"
-
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/ServerListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp src/Statistics.cpp
-msgid "Version"
-msgstr "Sürüm"
 
 #: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
 msgid "IP Address"
@@ -6868,10 +6895,6 @@ msgstr "Yerel sunucu IP Süzgeci tarafından engellendi, başka bir sunucuya ba�
 #: src/ServerListCtrl.cpp
 msgid "Server Name"
 msgstr "Sunucu Adı"
-
-#: src/ServerListCtrl.cpp
-msgid "Address"
-msgstr "Adres"
 
 #: src/ServerListCtrl.cpp
 msgid "Port"

--- a/po/uk.po
+++ b/po/uk.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-30 16:16+0200\n"
+"POT-Creation-Date: 2026-08-31 17:03+0200\n"
 "PO-Revision-Date: 2026-08-31 10:15+0000\n"
 "Last-Translator: Oleksandr Kovalenko <alx.kovalenko@gmail.com>\n"
 "Language-Team: Ukrainian <translation@linux.org.ua>\n"
@@ -758,6 +758,38 @@ msgid "Kad: Off"
 msgstr "Kad: вимкнена"
 
 #: src/amuleDlg.cpp
+msgid "Core"
+msgstr ""
+
+#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp src/Statistics.cpp
+msgid "Version"
+msgstr "Версія"
+
+#: src/amuleDlg.cpp
+msgid "The core and aMuleGUI are different versions."
+msgstr ""
+
+#: src/amuleDlg.cpp
+msgid "The core and aMuleGUI are the same version."
+msgstr ""
+
+#: src/amuleDlg.cpp src/ServerListCtrl.cpp
+msgid "Address"
+msgstr "Адреса"
+
+#: src/amuleDlg.cpp
+#, fuzzy
+msgid "Encryption"
+msgstr "Опис"
+
+#: src/amuleDlg.cpp
+#, fuzzy
+msgid "aMuleGUI"
+msgstr "Часопис aMule"
+
+#: src/amuleDlg.cpp
 #, fuzzy, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "Вивантаження: %.1f(%.1f) | Звантаження: %.1f(%.1f)"
@@ -962,6 +994,10 @@ msgstr ""
 #: src/amule-remote-gui.cpp
 msgid "Connection to the remote core was lost. Trying to reconnect..."
 msgstr ""
+
+#: src/amule-remote-gui.cpp src/ClientDetailDialog.cpp
+msgid "Disabled"
+msgstr "Вимкнено"
 
 #: src/amule-remote-gui.cpp
 #, fuzzy
@@ -1283,10 +1319,6 @@ msgstr "Підтримується"
 msgid "Not supported"
 msgstr "Не підтримується"
 
-#: src/ClientDetailDialog.cpp
-msgid "Disabled"
-msgstr "Вимкнено"
-
 #: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
 #: src/TextClient.cpp
 msgid "Connected"
@@ -1310,11 +1342,6 @@ msgstr "Назва:"
 #: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
 msgid "Software"
 msgstr ""
-
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/ServerListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp src/Statistics.cpp
-msgid "Version"
-msgstr "Версія"
 
 #: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
 #, fuzzy
@@ -7005,10 +7032,6 @@ msgstr "Місцевий сервер відфільтрований IPFilters, 
 #: src/ServerListCtrl.cpp
 msgid "Server Name"
 msgstr "Назва сервера"
-
-#: src/ServerListCtrl.cpp
-msgid "Address"
-msgstr "Адреса"
 
 #: src/ServerListCtrl.cpp
 msgid "Port"

--- a/po/vi.po
+++ b/po/vi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-30 16:16+0200\n"
+"POT-Creation-Date: 2026-08-31 17:03+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -724,6 +724,36 @@ msgid "Kad: Off"
 msgstr ""
 
 #: src/amuleDlg.cpp
+msgid "Core"
+msgstr ""
+
+#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp src/Statistics.cpp
+msgid "Version"
+msgstr ""
+
+#: src/amuleDlg.cpp
+msgid "The core and aMuleGUI are different versions."
+msgstr ""
+
+#: src/amuleDlg.cpp
+msgid "The core and aMuleGUI are the same version."
+msgstr ""
+
+#: src/amuleDlg.cpp src/ServerListCtrl.cpp
+msgid "Address"
+msgstr ""
+
+#: src/amuleDlg.cpp
+msgid "Encryption"
+msgstr ""
+
+#: src/amuleDlg.cpp
+msgid "aMuleGUI"
+msgstr ""
+
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr ""
@@ -923,6 +953,10 @@ msgstr ""
 
 #: src/amule-remote-gui.cpp
 msgid "Connection to the remote core was lost. Trying to reconnect..."
+msgstr ""
+
+#: src/amule-remote-gui.cpp src/ClientDetailDialog.cpp
+msgid "Disabled"
 msgstr ""
 
 #: src/amule-remote-gui.cpp
@@ -1234,10 +1268,6 @@ msgstr ""
 msgid "Not supported"
 msgstr ""
 
-#: src/ClientDetailDialog.cpp
-msgid "Disabled"
-msgstr ""
-
 #: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
 #: src/TextClient.cpp
 msgid "Connected"
@@ -1259,11 +1289,6 @@ msgstr ""
 
 #: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
 msgid "Software"
-msgstr ""
-
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/ServerListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp src/Statistics.cpp
-msgid "Version"
 msgstr ""
 
 #: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
@@ -6722,10 +6747,6 @@ msgstr ""
 
 #: src/ServerListCtrl.cpp
 msgid "Server Name"
-msgstr ""
-
-#: src/ServerListCtrl.cpp
-msgid "Address"
 msgstr ""
 
 #: src/ServerListCtrl.cpp

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-30 16:16+0200\n"
+"POT-Creation-Date: 2026-08-31 17:03+0200\n"
 "PO-Revision-Date: 2026-08-31 10:16+0000\n"
 "Last-Translator: Mike Akiba <mike2718@gmail.com>\n"
 "Language-Team: Chinese Simplified <kde-i18n-doc@kde.org>\n"
@@ -762,6 +762,38 @@ msgid "Kad: Off"
 msgstr "Kad: 关闭"
 
 #: src/amuleDlg.cpp
+msgid "Core"
+msgstr ""
+
+#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp src/Statistics.cpp
+msgid "Version"
+msgstr "版本"
+
+#: src/amuleDlg.cpp
+msgid "The core and aMuleGUI are different versions."
+msgstr ""
+
+#: src/amuleDlg.cpp
+msgid "The core and aMuleGUI are the same version."
+msgstr ""
+
+#: src/amuleDlg.cpp src/ServerListCtrl.cpp
+msgid "Address"
+msgstr "地址"
+
+#: src/amuleDlg.cpp
+#, fuzzy
+msgid "Encryption"
+msgstr "描述"
+
+#: src/amuleDlg.cpp
+#, fuzzy
+msgid "aMuleGUI"
+msgstr "aMule图形用户界面日志"
+
+#: src/amuleDlg.cpp
 #, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "上传: %.1f%s（%.1f） | 下载: %.1f%s（%.1f）"
@@ -968,6 +1000,10 @@ msgstr ""
 #: src/amule-remote-gui.cpp
 msgid "Connection to the remote core was lost. Trying to reconnect..."
 msgstr "到远程核心的连接丢失。正尝试重新连接…"
+
+#: src/amule-remote-gui.cpp src/ClientDetailDialog.cpp
+msgid "Disabled"
+msgstr "已禁用"
 
 #: src/amule-remote-gui.cpp
 msgid "Reconnected to the remote core."
@@ -1280,10 +1316,6 @@ msgstr "已支持"
 msgid "Not supported"
 msgstr "不支持"
 
-#: src/ClientDetailDialog.cpp
-msgid "Disabled"
-msgstr "已禁用"
-
 #: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
 #: src/TextClient.cpp
 msgid "Connected"
@@ -1306,11 +1338,6 @@ msgstr "名称"
 #: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
 msgid "Software"
 msgstr "软件"
-
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/ServerListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp src/Statistics.cpp
-msgid "Version"
-msgstr "版本"
 
 #: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
 msgid "IP Address"
@@ -6872,10 +6899,6 @@ msgstr "本地服务器被IP过滤器过滤掉了，正在重新连接至其他�
 #: src/ServerListCtrl.cpp
 msgid "Server Name"
 msgstr "服务器名称"
-
-#: src/ServerListCtrl.cpp
-msgid "Address"
-msgstr "地址"
 
 #: src/ServerListCtrl.cpp
 msgid "Port"

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-30 16:16+0200\n"
+"POT-Creation-Date: 2026-08-31 17:03+0200\n"
 "PO-Revision-Date: 2026-08-31 10:16+0000\n"
 "Last-Translator: Wayne Su <mstarmstar@gmail.com>\n"
 "Language-Team: \n"
@@ -762,6 +762,38 @@ msgid "Kad: Off"
 msgstr "Kad：關閉"
 
 #: src/amuleDlg.cpp
+msgid "Core"
+msgstr ""
+
+#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp src/Statistics.cpp
+msgid "Version"
+msgstr "版本"
+
+#: src/amuleDlg.cpp
+msgid "The core and aMuleGUI are different versions."
+msgstr ""
+
+#: src/amuleDlg.cpp
+msgid "The core and aMuleGUI are the same version."
+msgstr ""
+
+#: src/amuleDlg.cpp src/ServerListCtrl.cpp
+msgid "Address"
+msgstr "位址"
+
+#: src/amuleDlg.cpp
+#, fuzzy
+msgid "Encryption"
+msgstr "說明"
+
+#: src/amuleDlg.cpp
+#, fuzzy
+msgid "aMuleGUI"
+msgstr "aMule 記錄"
+
+#: src/amuleDlg.cpp
 #, fuzzy, c-format
 msgid "Up: %.1f%s (%.1f) | Down: %.1f%s (%.1f)"
 msgstr "上傳：%.1f (%.1f) | 下載：%.1f (%.1f)"
@@ -965,6 +997,10 @@ msgstr ""
 #: src/amule-remote-gui.cpp
 msgid "Connection to the remote core was lost. Trying to reconnect..."
 msgstr ""
+
+#: src/amule-remote-gui.cpp src/ClientDetailDialog.cpp
+msgid "Disabled"
+msgstr "已停用"
 
 #: src/amule-remote-gui.cpp
 #, fuzzy
@@ -1277,10 +1313,6 @@ msgstr "已支援"
 msgid "Not supported"
 msgstr "不支援"
 
-#: src/ClientDetailDialog.cpp
-msgid "Disabled"
-msgstr "已停用"
-
 #: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
 #: src/TextClient.cpp
 msgid "Connected"
@@ -1304,11 +1336,6 @@ msgstr "名稱："
 #: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
 msgid "Software"
 msgstr ""
-
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/ServerListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp src/Statistics.cpp
-msgid "Version"
-msgstr "版本"
 
 #: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
 #, fuzzy
@@ -6913,10 +6940,6 @@ msgstr "本地伺服器被 IP 過濾器過濾掉了，正在重新連線到其�
 #: src/ServerListCtrl.cpp
 msgid "Server Name"
 msgstr "伺服器名稱"
-
-#: src/ServerListCtrl.cpp
-msgid "Address"
-msgstr "位址"
 
 #: src/ServerListCtrl.cpp
 msgid "Port"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -961,6 +961,7 @@ if (NEED_LIB_MULEAPPGUI)
 		ColorFrameCtrl.cpp
 		EditServerListDlg.cpp
 		FileDetailListCtrl.cpp
+		InfoGridDialog.cpp
 		ListColumnStore.cpp
 		MuleBarRenderer.cpp
 		MuleIconTextRenderer.cpp

--- a/src/ExternalConn.cpp
+++ b/src/ExternalConn.cpp
@@ -52,6 +52,7 @@
 #include "amule.h"      // Needed for theApp
 #include "SearchList.h" // Needed for GetSearchResults
 #include "ClientVersionString.h"
+#include "MuleVersion.h" // Needed for GetShortMuleVersion()
 #include "ClientList.h"
 #include "ChatSessionStore.h"
 #include "ClientCreditsList.h" // Needed for CClientCreditsList
@@ -1379,7 +1380,12 @@ const CECPacket *CECServerSocket::Authenticate(const CECPacket *request)
 				const std::vector<uint8_t> serverConfirm = ServerConfirm(authSecret);
 				ActivateAEAD();
 				response = new CECPacket(EC_OP_AUTH_OK);
-				response->AddTag(CECTag(EC_TAG_SERVER_VERSION, VERSION));
+				// Short form rather than bare VERSION: on a development
+				// build VERSION is the literal "GIT", so every snapshot
+				// would identify itself identically and a client could
+				// not tell which revision it is talking to. No change on
+				// a tagged release, where GITDATE is undefined.
+				response->AddTag(CECTag(EC_TAG_SERVER_VERSION, GetShortMuleVersion()));
 				// Our half of the proof. Travels inside the now-sealed
 				// AUTH_OK, so the client learns both that we hold the
 				// credential and that we hold the key, from one packet.
@@ -4436,7 +4442,9 @@ CECPacket *CECServerSocket::ProcessRequest2(const CECPacket *request)
 			delete tree;
 		}
 		if (request->GetDetailLevel() == EC_DETAIL_WEB) {
-			response->AddTag(CECTag(EC_TAG_SERVER_VERSION, VERSION));
+			// Same short form as the AUTH_OK handshake above, so amuleweb
+			// and the GUI never see two spellings of one build.
+			response->AddTag(CECTag(EC_TAG_SERVER_VERSION, GetShortMuleVersion()));
 			response->AddTag(CECTag(EC_TAG_USER_NICK, thePrefs::GetUserNick()));
 		}
 		break;

--- a/src/GenericClientListCtrl.cpp
+++ b/src/GenericClientListCtrl.cpp
@@ -40,6 +40,7 @@
 #include "DataToText.h"           // Needed for PriorityToStr
 #include "FileDetailDialog.h"     // Needed for CFileDetailDialog
 #include "GuiEvents.h"            // Needed for CoreNotify_*
+#include "InfoGridDialog.h"       // Needed for ShowInfoGridDialog
 #ifdef GEOIP_GUI
 #include "CountryFlags.h"   // Needed for CCountryFlags (flag bitmaps)
 #include "CountryDisplay.h" // Needed for GetDisplayCountryCode
@@ -711,39 +712,29 @@ void CGenericClientListCtrl::ShowBarLegend(partbar::BarLegendKind kind, const wx
 	// fills the bar from, under the bar preference in force right now: a
 	// swatch cannot disagree with the pixels it explains.
 	const bool bFlat = thePrefs::UseFlatBar();
+	const bool sourceKind = (kind == partbar::BarLegendKind::SourceParts);
 
-	wxDialog dialog(this, wxID_ANY, columnTitle);
-	wxFlexGridSizer *grid = new wxFlexGridSizer(2, wxSize(8, 6));
-
-	wxString intro;
-	if (kind == partbar::BarLegendKind::SourceParts) {
-		intro = _("One block per part of the file being downloaded.");
-		for (const partbar::SourcePartState state : partbar::kSourceLegendOrder) {
-			AddLegendRow(&dialog,
-				grid,
-				partbar::SourcePartColour(state, bFlat),
-				SourcePartStateLabel(state));
-		}
-	} else {
-		intro = _("One block per part of the shared file.");
-		for (const partbar::PeerPartState state : partbar::kPeerLegendOrder) {
-			AddLegendRow(&dialog,
-				grid,
-				partbar::PeerPartColour(state, bFlat),
-				PeerPartStateLabel(state));
-		}
-	}
-
-	wxBoxSizer *top = new wxBoxSizer(wxVERTICAL);
-	top->Add(new wxStaticText(&dialog, wxID_ANY, intro), 0, wxALL, 10);
-	top->Add(grid, 0, wxLEFT | wxRIGHT | wxBOTTOM, 10);
-	if (wxSizer *buttons = dialog.CreateButtonSizer(wxOK)) {
-		top->Add(buttons, 0, wxALIGN_RIGHT | wxLEFT | wxRIGHT | wxBOTTOM, 10);
-	}
-
-	dialog.SetSizerAndFit(top);
-	dialog.CentreOnParent();
-	dialog.ShowModal();
+	ShowInfoGridDialog(this,
+		columnTitle,
+		sourceKind ? _("One block per part of the file being downloaded.")
+			   : _("One block per part of the shared file."),
+		[bFlat, sourceKind](wxWindow *dlg, wxSizer *grid) {
+			if (sourceKind) {
+				for (const partbar::SourcePartState state : partbar::kSourceLegendOrder) {
+					AddLegendRow(dlg,
+						grid,
+						partbar::SourcePartColour(state, bFlat),
+						SourcePartStateLabel(state));
+				}
+			} else {
+				for (const partbar::PeerPartState state : partbar::kPeerLegendOrder) {
+					AddLegendRow(dlg,
+						grid,
+						partbar::PeerPartColour(state, bFlat),
+						PeerPartStateLabel(state));
+				}
+			}
+		});
 }
 
 void CGenericClientListCtrl::OnShowBarLegend(wxCommandEvent &WXUNUSED(event))

--- a/src/InfoGridDialog.cpp
+++ b/src/InfoGridDialog.cpp
@@ -1,0 +1,101 @@
+//
+// This file is part of the aMule Project.
+//
+// Copyright (c) 2003-2026 aMule Team ( https://amule-org.github.io )
+//
+// Any parts of this program derived from the xMule, lMule or eMule project,
+// or contributed by third-party developers are copyrighted by their
+// respective authors.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301, USA
+//
+
+#include "InfoGridDialog.h" // Interface declarations
+
+#include <wx/artprov.h>
+#include <wx/bmpbndl.h>
+#include <wx/dialog.h>
+#include <wx/sizer.h>
+#include <wx/statbmp.h>
+#include <wx/stattext.h>
+#include <wx/string.h>
+#include <wx/window.h>
+
+namespace
+{
+// GUI thread only. ShowModal() does not stop a click reaching the control that
+// opened the dialog: the event is queued and delivered once ShowModal()
+// returns, so without this each click made while the dialog was up opens
+// another one on close.
+bool g_dialogOpen = false;
+} // namespace
+
+void ShowInfoGridDialog(wxWindow *parent,
+	const wxString &title,
+	const wxString &intro,
+	const std::function<void(wxWindow *, wxSizer *)> &fillGrid,
+	const wxString &introArt,
+	const wxColour &introColour)
+{
+	if (g_dialogOpen) {
+		return;
+	}
+	g_dialogOpen = true;
+
+	wxDialog dialog(parent, wxID_ANY, title);
+	wxFlexGridSizer *grid = new wxFlexGridSizer(2, wxSize(8, 6));
+	fillGrid(&dialog, grid);
+
+	wxBoxSizer *top = new wxBoxSizer(wxVERTICAL);
+	if (!intro.IsEmpty()) {
+		// A stock id can exist without the platform's provider supplying art
+		// for it, so fall back to the bare line rather than leaving a gap.
+		const wxBitmapBundle introBmp =
+			introArt.IsEmpty()
+				? wxBitmapBundle()
+				: wxArtProvider::GetBitmapBundle(introArt, wxART_MESSAGE_BOX, wxSize(16, 16));
+		wxStaticText *introText = new wxStaticText(&dialog, wxID_ANY, intro);
+		if (introColour.IsOk()) {
+			introText->SetForegroundColour(introColour);
+		}
+		if (!introBmp.IsOk()) {
+			top->Add(introText, 0, wxALL, 10);
+		} else {
+			wxBoxSizer *introRow = new wxBoxSizer(wxHORIZONTAL);
+			introRow->Add(new wxStaticBitmap(&dialog, wxID_ANY, introBmp),
+				0,
+				wxALIGN_CENTRE_VERTICAL | wxRIGHT,
+				6);
+			introRow->Add(introText, 0, wxALIGN_CENTRE_VERTICAL);
+			top->Add(introRow, 0, wxALL, 10);
+		}
+	}
+	top->Add(grid, 0, wxLEFT | wxRIGHT | wxBOTTOM, 10);
+	if (wxSizer *buttons = dialog.CreateButtonSizer(wxOK)) {
+		top->Add(buttons, 0, wxALIGN_RIGHT | wxLEFT | wxRIGHT | wxBOTTOM, 10);
+	}
+
+	dialog.SetSizerAndFit(top);
+	dialog.CentreOnParent();
+	dialog.ShowModal();
+
+	// Cleared behind the queued clicks rather than here, so they are dispatched
+	// -- and rejected above -- before the flag drops.
+	if (parent) {
+		parent->CallAfter([] { g_dialogOpen = false; });
+	} else {
+		g_dialogOpen = false;
+	}
+}

--- a/src/InfoGridDialog.h
+++ b/src/InfoGridDialog.h
@@ -1,0 +1,55 @@
+//
+// This file is part of the aMule Project.
+//
+// Copyright (c) 2003-2026 aMule Team ( https://amule-org.github.io )
+//
+// Any parts of this program derived from the xMule, lMule or eMule project,
+// or contributed by third-party developers are copyrighted by their
+// respective authors.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301, USA
+//
+
+#ifndef INFOGRIDDIALOG_H
+#define INFOGRIDDIALOG_H
+
+#include <functional>
+
+#include <wx/colour.h>
+#include <wx/string.h>
+
+class wxWindow;
+class wxSizer;
+
+/**
+ * Show a small modal dialog: an optional intro line, a two-column grid the
+ * caller fills, and an OK button.
+ *
+ * Shared so the part-bar legends and the status-bar core-version details do
+ * not each carry a copy of the same scaffolding. `fillGrid` receives the
+ * dialog to parent widgets to, and the grid to add them to.
+ *
+ * `introArt` is an optional wxArtProvider id (wxART_WARNING, wxART_TICK_MARK,
+ * ...) drawn left of the intro line. Stock art, so it matches the platform and
+ * needs no bundled asset.
+ */
+void ShowInfoGridDialog(wxWindow *parent,
+	const wxString &title,
+	const wxString &intro,
+	const std::function<void(wxWindow *, wxSizer *)> &fillGrid,
+	const wxString &introArt = wxString(),
+	const wxColour &introColour = wxColour());
+
+#endif // INFOGRIDDIALOG_H

--- a/src/MuleVersion.h
+++ b/src/MuleVersion.h
@@ -42,6 +42,34 @@
 extern wxString MuleBoostVersion;
 
 /**
+ * The build's version in the short form exchanged over EC and shown in the UI.
+ *
+ * `VERSION` alone is not enough to identify a development build: on any
+ * untagged build it is the literal string "GIT", so every snapshot reports the
+ * same value and two different revisions look identical. The revision lives in
+ * GITDATE, which CMake sets from `git describe`.
+ *
+ * On a tagged release CMake unsets GITDATE (config.h.cm renders `#undef
+ * GITDATE`), so this returns exactly VERSION -- e.g. "3.0.1" -- and the
+ * appended part compiles away entirely. Only development builds gain the
+ * suffix, e.g. "GIT rev. 3.0.1-773-g500293ba3".
+ *
+ * Deliberately shorter than GetMuleVersion(): that one describes the whole
+ * build for debugging (wx toolkit, Boost, debug flag) and is far too long for
+ * a status-bar field or a protocol tag. Both the core that reports this over
+ * EC and the client that compares it against its own build call this, so the
+ * two can never disagree about how the string is spelled.
+ */
+inline wxString GetShortMuleVersion()
+{
+	return wxString(VERSION)
+#ifdef GITDATE
+	       + " " GITDATE
+#endif
+		;
+}
+
+/**
  * Returns a description of the version of aMule being used.
  *
  * @return A detailed description of the aMule version, including wx information.

--- a/src/ServerWnd.cpp
+++ b/src/ServerWnd.cpp
@@ -113,9 +113,8 @@ CServerWnd::CServerWnd(wxWindow *pParent /*=NULL*/, int splitter_pos)
 
 #ifdef CLIENT_GUI
 	// amulegui only: "aMule Log" carries the daemon/core log forwarded over EC,
-	// so give the GUI client's own messages a second tab. Inserted here rather
-	// than in serverListDlg() because muuli_wdr is compiled into a shared
-	// library without CLIENT_GUI and cannot tell the two builds apart.
+	// so give the GUI client's own messages a second tab. Inserted after the
+	// notebook is built rather than inside serverListDlg().
 	wxNotebook *srvLogNotebook = CastChild(ID_SRVLOG_NOTEBOOK, wxNotebook);
 	if (srvLogNotebook) {
 		wxPanel *guiLogPanel = new wxPanel(srvLogNotebook, -1);

--- a/src/amule-remote-gui.cpp
+++ b/src/amule-remote-gui.cpp
@@ -22,7 +22,8 @@
 // Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301, USA
 //
 
-#include <algorithm> // Needed for std::min
+#include <algorithm>             // Needed for std::min
+#include "libs/ec/cpp/ECCrypt.h" // Needed for ECCrypt::CipherName
 
 #include <wx/ipc.h>
 #include <wx/cmdline.h>  // Needed for wxCmdLineParser
@@ -925,6 +926,26 @@ void CamuleRemoteGuiApp::ShowReconnectDialog()
 	FinishReconnect(result);
 }
 
+void CamuleRemoteGuiApp::UpdateCoreVersionIndicator()
+{
+	if (!amuledlg || !m_connect) {
+		return;
+	}
+	// Cipher names are protocol identifiers ("AES-128-GCM"), not prose, so
+	// only the not-encrypted case needs the catalog.
+	const bool encrypted = m_connect->IsAEADEnabled();
+	const wxString encryption =
+		encrypted ? wxString::FromAscii(ECCrypt::CipherName(m_connect->GetAEADCipher()))
+			  : _("Disabled");
+
+	// Empty against a daemon too old to send EC_TAG_SERVER_VERSION; the
+	// dialog hides the field in that case rather than showing a blank.
+	amuledlg->ShowCoreVersion(m_connect->GetServerVersion(),
+		CFormat(wxT("%s:%d")) % m_ecHost % m_ecPort,
+		encryption,
+		encrypted);
+}
+
 void CamuleRemoteGuiApp::FinishReconnect(int result)
 {
 	m_reconnecting = false;
@@ -937,6 +958,10 @@ void CamuleRemoteGuiApp::FinishReconnect(int result)
 
 	if (result == wxID_OK) {
 		AddLogLineCS(_("Reconnected to the remote core."));
+
+		// The daemon may have been upgraded while we were away, so re-read
+		// the version rather than leaving the pre-drop one on screen.
+		UpdateCoreVersionIndicator();
 
 		// Everything we hold is keyed by ECID, and an ECID only means
 		// something within one daemon process: CECID hands them out from a
@@ -1195,6 +1220,10 @@ void CamuleRemoteGuiApp::Startup()
 
 	// Create main dialog
 	InitGui(m_geometryEnabled, m_geometryString);
+
+	// Needs the dialog to exist, so it cannot happen with the rest of the
+	// handshake bookkeeping above.
+	UpdateCoreVersionIndicator();
 
 	// Forward wxLog events to CLogger
 	wxLog::SetActiveTarget(new CLoggerTarget);

--- a/src/amule-remote-gui.h
+++ b/src/amule-remote-gui.h
@@ -1030,6 +1030,11 @@ class CamuleRemoteGuiApp : public wxApp, public CamuleGuiBase, public CamuleAppC
 	/// dialog was ever shown -- reconnecting behind a minimised window
 	/// finishes without one.
 	void FinishReconnect(int result);
+	// Push the connected core's version and endpoint to the status bar.
+	// Called on first connect and again after every reconnect: a
+	// reconnect may have reached a daemon that was upgraded and
+	// restarted meanwhile, so the version on screen can go stale.
+	void UpdateCoreVersionIndicator();
 
 	virtual int InitGui(bool geometry_enable, wxString &geometry_string);
 

--- a/src/amuleDlg.cpp
+++ b/src/amuleDlg.cpp
@@ -90,7 +90,8 @@
 #include <wx/iconbndl.h> // Needed for wxIconBundle // Needed for wxArtProvider::GetIcon
 
 #include "kademlia/kademlia/Kademlia.h"
-#include "MuleVersion.h" // Needed for GetMuleVersion()
+#include "MuleVersion.h"    // Needed for GetMuleVersion(), GetShortMuleVersion()
+#include "InfoGridDialog.h" // Needed for ShowInfoGridDialog
 
 #ifdef ENABLE_IP2COUNTRY
 #include "IP2Country.h" // Needed for IP2Country
@@ -355,6 +356,15 @@ CamuleDlg::CamuleDlg(wxWindow *pParent, const wxString &title, wxPoint where, wx
 	m_chatwnd = new CChatWnd(p_cnt);
 	m_clientswnd = new CClientsWnd(p_cnt);
 	m_kademliawnd = CastChild("kadWnd", CKadDlg);
+
+	// Status-bar core-version field opens its details dialog on click. Null in
+	// monolithic aMule, which does not build it.
+	if (wxWindow *coreVerLabel = CastChild("coreVersionLabel", wxWindow)) {
+		coreVerLabel->Bind(wxEVT_LEFT_UP, &CamuleDlg::OnCoreVersionClicked, this);
+	}
+	if (wxWindow *coreVerIcon = CastChild("coreVersionImage", wxWindow)) {
+		coreVerIcon->Bind(wxEVT_LEFT_UP, &CamuleDlg::OnCoreVersionClicked, this);
+	}
 
 	m_serverwnd->Show(false);
 	m_searchwnd->Show(false);
@@ -1395,6 +1405,103 @@ void CamuleDlg::ShowConnectionState()
 
 		connBitmap->SetBitmap(statusIcon);
 	}
+}
+
+void CamuleDlg::ShowCoreVersion(
+	const wxString &coreVersion, const wxString &endpoint, const wxString &encryption, bool encrypted)
+{
+	wxStaticText *label = CastChild("coreVersionLabel", wxStaticText);
+	wxStaticBitmap *icon = CastChild("coreVersionImage", wxStaticBitmap);
+	wxWindow *sep = CastChild("coreVersionSep", wxWindow);
+	// Absent in monolithic aMule, which never builds them.
+	if (!label || !icon || !sep) {
+		return;
+	}
+
+	// Empty before the handshake, and from a core too old to send
+	// EC_TAG_SERVER_VERSION. Hide rather than show a blank.
+	if (coreVersion.IsEmpty()) {
+		label->Show(false);
+		icon->Show(false);
+		sep->Show(false);
+		return;
+	}
+
+	m_coreVersion = coreVersion;
+	m_coreEndpoint = endpoint;
+	m_coreEncryption = encryption;
+	m_coreEncrypted = encrypted;
+
+	// Exact inequality: a dev build reports "GIT rev. <describe>", which has no
+	// ordering against a release number, so "newer" is unanswerable.
+	const bool differs = (coreVersion != GetShortMuleVersion());
+
+	label->Show(true);
+	icon->Show(true);
+	sep->Show(true);
+
+	// "%s: %s" is punctuation, so only the word needs translating.
+	UpdateStatusLabel(label, CFormat(wxT("%s: %s")) % _("Core") % coreVersion);
+
+	// Same idiom as SetFreeSpaceLabel above: recolour only on a real change.
+	const wxColour colour = differs ? *wxRED : wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOWTEXT);
+	if (label->GetForegroundColour() != colour) {
+		label->SetForegroundColour(colour);
+		label->Refresh();
+	}
+}
+
+void CamuleDlg::OnCoreVersionClicked(wxMouseEvent &WXUNUSED(event))
+{
+	if (m_coreVersion.IsEmpty()) {
+		return;
+	}
+	const wxString ownVersion = GetShortMuleVersion();
+	const wxString endpoint = m_coreEndpoint;
+	const wxString encryption = m_coreEncryption;
+	const bool encrypted = m_coreEncrypted;
+	const wxString coreVersion = m_coreVersion;
+
+	const bool differs = (coreVersion != ownVersion);
+
+	// Our own client_red / client_green rather than stock wx art: on macOS the
+	// stock glyphs are template symbols that take the system label colour, so
+	// they render grey and ignore a tint, and tinting is not portable either --
+	// GTK's error icon is already a red disc with a white cross, which a blanket
+	// recolour would flatten. These two are a matched pair from one set, so the
+	// states differ only in colour.
+	ShowInfoGridDialog(
+		this,
+		_("Version"),
+		differs ? _("The core and aMuleGUI are different versions.")
+			: _("The core and aMuleGUI are the same version."),
+		[&](wxWindow *dlg, wxSizer *grid) {
+			const struct
+			{
+				wxString label;
+				wxString value;
+				wxColour colour;
+			} rows[] = {
+				{ _("Address"), endpoint, wxNullColour },
+				// Red only when off: an encrypted link is the expected
+				// state and needs no colour to say so.
+				{ _("Encryption"), encryption, encrypted ? wxNullColour : *wxRED },
+				{ _("Core"), coreVersion, wxNullColour },
+				{ _("aMuleGUI"), ownVersion, wxNullColour },
+			};
+			for (const auto &row : rows) {
+				grid->Add(new wxStaticText(dlg, wxID_ANY, row.label),
+					0,
+					wxALIGN_CENTRE_VERTICAL);
+				wxStaticText *value = new wxStaticText(dlg, wxID_ANY, row.value);
+				if (row.colour.IsOk()) {
+					value->SetForegroundColour(row.colour);
+				}
+				grid->Add(value, 0, wxALIGN_CENTRE_VERTICAL);
+			}
+		},
+		differs ? wxString("amule:client_red") : wxString("amule:client_green"),
+		differs ? *wxRED : wxNullColour);
 }
 
 void CamuleDlg::ShowUserCount(const wxString &info)

--- a/src/amuleDlg.h
+++ b/src/amuleDlg.h
@@ -148,7 +148,25 @@ public:
 	void BeginLogBatch();
 	void EndLogBatch();
 
+	// Last values pushed by ShowCoreVersion, so the click handler can build
+	// the dialog without re-reading the EC connection.
+	wxString m_coreVersion;
+	wxString m_coreEndpoint;
+	wxString m_coreEncryption;
+	bool m_coreEncrypted = false;
+
 	void ShowUserCount(const wxString &info = "");
+	// Reveal and populate the status-bar core-version field. `coreVersion`
+	// is what the core reported over EC; `endpoint` is the host:port it
+	// was reached on. amulegui only.
+	void ShowCoreVersion(const wxString &coreVersion,
+		const wxString &endpoint,
+		const wxString &encryption,
+		bool encrypted);
+	// Details dialog for the status-bar core-version field. A dialog rather
+	// than a tooltip: the bar shifts sideways whenever the speed text
+	// changes width, which cancels a hover before it can fire.
+	void OnCoreVersionClicked(wxMouseEvent &event);
 	void ShowConnectionState();
 	void ShowTransferRate();
 

--- a/src/muuli_wdr.cpp
+++ b/src/muuli_wdr.cpp
@@ -123,6 +123,33 @@ wxSizer *muleDlg( wxWindow *parent, bool call_fit, bool set_sizer )
     wxStaticLine *item9 = new wxStaticLine( parent, -1, wxDefaultPosition, wxSize(-1,20), wxLI_VERTICAL );
     item6->Add( item9, wxSizerFlags().Center().Border(wxLEFT, 5) );
 
+#ifdef CLIENT_GUI
+    // Connected core's version, left of the counters it heads. amulegui only:
+    // this file is compiled per-executable, so CLIENT_GUI is the consuming
+    // target's and monolithic aMule never builds it. Hidden until the EC
+    // handshake reports a version. Clickable, so it gets the hand cursor.
+    //
+    // 16x16 explicitly: with no size the bundle defaults to the icon's PNG
+    // twin, 256x256 for the logo. The size is logical, so it still renders
+    // from the SVG at the display's scale.
+    wxStaticBitmap *coreVerIcon = new wxStaticBitmap( parent, -1, wxArtProvider::GetBitmapBundle( "amule:amule", wxART_OTHER, wxSize(16, 16) ), wxDefaultPosition, wxDefaultSize );
+    coreVerIcon->SetName( "coreVersionImage" );
+    coreVerIcon->SetCursor( wxCursor( wxCURSOR_HAND ) );
+    coreVerIcon->Show( false );
+    item6->Add( coreVerIcon, wxSizerFlags().Center().Border(wxLEFT|wxRIGHT, 5) );
+
+    wxStaticText *coreVerLabel = new wxStaticText( parent, -1, wxEmptyString, wxDefaultPosition, wxDefaultSize, 0 );
+    coreVerLabel->SetName( "coreVersionLabel" );
+    coreVerLabel->SetCursor( wxCursor( wxCURSOR_HAND ) );
+    coreVerLabel->Show( false );
+    item6->Add( coreVerLabel, wxSizerFlags().Center().Border(wxRIGHT, 5) );
+
+    wxStaticLine *coreVerSep = new wxStaticLine( parent, -1, wxDefaultPosition, wxSize(-1,20), wxLI_VERTICAL );
+    coreVerSep->SetName( "coreVersionSep" );
+    coreVerSep->Show( false );
+    item6->Add( coreVerSep, wxSizerFlags().Center().Border(wxLEFT, 5) );
+#endif // CLIENT_GUI
+
     wxStaticBitmap *item10 = new wxStaticBitmap( parent, -1, wxArtProvider::GetBitmapBundle( "amule:status_users" ), wxDefaultPosition, wxDefaultSize );
     item10->SetToolTip( _("Number of users on the server you are connected to ...") );
     item6->Add( item10, wxSizerFlags().Center().Border(wxLEFT|wxRIGHT, 5) );
@@ -2684,8 +2711,7 @@ wxSizer *serverListDlgDown( wxWindow *parent, bool call_fit, bool set_sizer )
     item3->AddPage( item4, _("aMule Log") );
 
     // NB: the amulegui-only "aMuleGUI Log" page is inserted here at runtime by
-    // CServerWnd -- this file (muuli_wdr) is compiled into a shared library
-    // without CLIENT_GUI, so it cannot make the distinction itself.
+    // CServerWnd, under its own CLIENT_GUI guard.
 
     wxPanel *item5 = new wxPanel( item3, -1 );
     ServerInfoLog( item5, FALSE );

--- a/src/webapi/Api.cpp
+++ b/src/webapi/Api.cpp
@@ -89,7 +89,8 @@
 
 #include "PicoJson_Inc.h"
 
-#include "config.h" // VERSION
+#include "config.h"      // VERSION
+#include "MuleVersion.h" // Needed for GetShortMuleVersion()
 
 #include "Types.h" // uint8 (required by libs/common/MD5Sum.h)
 #include <common/MD5Sum.h>
@@ -2086,7 +2087,11 @@ CHttpServer::Response CApiDispatcher::HandleVersion(const CHttpServer::Request &
 	// amuleapi binary was built from, which need not match the aMule daemon
 	// it is talking to. The old name said the opposite of what it holds.
 	w.Key("amuleapi_version");
-	w.ValueString(wxString::FromAscii(VERSION));
+	// Same short form the daemon reports for itself, so the two stay
+	// comparable: bare VERSION is the literal "GIT" on a development
+	// build, which would make this differ from daemon_version on every
+	// such build even when both come from the same tree.
+	w.ValueString(GetShortMuleVersion());
 	// Version of the connected amuled, from the EC handshake. Empty
 	// string when EC is not (yet) connected or the daemon predates the
 	// EC_TAG_SERVER_VERSION tag. Distinct from amuleapi_version above,


### PR DESCRIPTION
amulegui could not say which core it was driving. A GUI left running against a daemon that had since been upgraded looked no different from one in step with it.

The version already crosses the wire: amuled puts it in `EC_TAG_SERVER_VERSION` on the `AUTH_OK` handshake and `CRemoteConnect` stores it. Nothing displayed it.

## What it looks like

The status bar gains a field immediately left of the network counters, which is where it belongs: those counters describe what the core reports, so naming the core heads that group.

Clicking it opens a details dialog. It leads with the verdict -- a green dot and *"The core and aMuleGUI are the same version."*, or a red dot and *"The core and aMuleGUI are different versions."* in red -- over the detail:

| Field | Value |
|---|---|
| **Address** | `127.0.0.1:4712` |
| **Encryption** | `AES-128-GCM`, or **Disabled** in red |
| **Core** | `GIT rev. 3.0.1-773-g500293ba3` |
| **aMuleGUI** | `GIT rev. 3.0.1-773-g500293ba3` |

A dialog rather than a tooltip because the bar shifts sideways whenever the speed text changes width, and that cancels a hover before it can fire. The label carries a hand cursor.

## Development builds could not be compared at all

`VERSION` is the literal string `"GIT"` on any untagged build, so every snapshot identified itself the same way and two unrelated revisions compared **equal** -- a worse failure than a false mismatch, because nothing looked wrong. The revision lives in `GITDATE`, which was never sent.

`GetShortMuleVersion()` appends it. Both the core reporting the version and the client comparing it call that one function, so they cannot disagree about spelling. **On a tagged release CMake unsets `GITDATE`**, so the appended part compiles away entirely and the tag alone is sent, byte for byte as before -- only development builds change.

Only the `AUTH_OK` and `EC_DETAIL_WEB` sites are touched. The two `ECSpecialCoreTags` sites carry an **ed2k server's** version under the same tag id and are deliberately left alone.

## Comparison rule

Exact inequality. Parsing the two would have to answer which is newer and cannot: `GIT rev. <describe>` has no ordering against a release number. A mismatch shows red in the bar and in the dialog. It is a *notice*, not an error -- running a GUI against a core of another version is supported, since the handshake negotiates capabilities per feature (`EC_TAG_CAN_*`) -- but it is worth noticing.

## amuleapi kept consistent

`amuleapi_version` moves to the same helper. `REFERENCE.md` documents it and `daemon_version` as normally equal, and adding the revision to only the daemon side would have made them differ on every development build. Verified live: both now report the same string.

## Shared, not copied

`ShowInfoGridDialog()` takes an intro line, an optional icon and colour, and a callback that fills a two-column grid.

**`CGenericClientListCtrl::ShowBarLegend()` was refactored onto it**, which is the bulk of the change to that file. That one dialog serves both part-bar legends -- **Part Status** (`ColumnUserProgress`, on a download's sources list) and **Parts on Peer** (`ColumnUserAvailable`, on a shared file's peers list) -- so both now share the scaffolding with the new dialog instead of a third copy being added.

That refactor is behaviour-preserving: the two legends keep their own state sets, palettes and row order from `PartBarLegend.h` (five states vs two), and only the surrounding dialog construction moved. `DownloadListCtrl` has no legend of its own and is untouched.

It lives in `muleappgui`, which only the two GUI binaries link. `OtherFunctions` would have dragged `wxDialog` into **amulecmd**, which links wxBase alone -- the build rejected that immediately.

The re-entry guard sits there too, so every consumer is covered. `ShowModal()` does not stop a click reaching the control that opened it, and those clicks arrive *after* the modal returns, so the flag is cleared behind them via `CallAfter`.

## Icons

The match and mismatch icons are the existing `client_green` / `client_red` rather than stock wx art. On macOS the stock glyphs are template symbols that take the system label colour, so they render grey and ignore a tint; tinting is not portable either, since GTK's error icon is a red disc with a white cross that a blanket recolour would flatten. No new assets, so `icon_data.c` is untouched.

## Monolithic aMule

Widgets are built under `CLIENT_GUI`, so monolithic aMule -- which has no separate core -- does not carry them. Confirmed by object: `muuli_wdr.cpp.o` has zero occurrences of the widget names for the `amule` target and one for `amulegui`.

Two comments claiming `muuli_wdr` is "compiled into a shared library without CLIENT_GUI" are corrected. It is compiled per-executable and does see the define; that stale claim is what made an earlier cut of this hide the field at runtime instead.

## Strings

Five new. `Version` and `Address` reuse existing entries, the encryption row reuses `Disabled`, and cipher names are protocol identifiers rather than prose. Catalogs regenerated with `scripts/update-po.sh`.

## Verification

- Unit tests: **47/47**.
- `clang-format` 18 whole-file over all 12 changed C++ files: **0 violations**.
- `clang-tidy` Tier-1 and Tier-2 on the diff: **0 findings, 0 compiler errors**.
- `scripts/check-potfiles.sh`: clean.
- Live against amuled: version, endpoint and cipher render correctly; repeated clicking opens exactly one dialog; `wxART` ids confirmed present at the **wx 3.2** floor before use, not just on the local 3.3.
