### PR TITLE
fix(amuleapi): give the version-check throttle its own error code

### DIFF
--- a/docs/api/REFERENCE.md
+++ b/docs/api/REFERENCE.md
@@ -574,7 +574,7 @@ curl -s -X POST -H "Authorization: Bearer $TOKEN" http://$HOST/api/v0/version/ch
 | Status | `error.code` | When |
 | --- | --- | --- |
 | `409` | `update_check_unavailable` | The daemon can't check (`update.check_enabled` is `false`). |
-| `429` | `rate_limited` | A check ran too recently; retry shortly. |
+| `429` | `version_check_throttled` | A check ran too recently; retry shortly. Distinct from the auth limiter's `rate_limited`, which also answers `429` but ends the session. |
 | `503` | `ec_unavailable` | The EC round-trip to amuled failed, or the first snapshot has not landed yet. |
 
 The snapshot gate matters at startup: `version_check_available` defaults to false, so before the first EC tick this route used to answer `409 update_check_unavailable`, blaming the daemon's configuration for amuleapi not having read it yet. It answers `503` there now, which is the condition a client can retry.
@@ -3263,7 +3263,8 @@ Every error code emitted by `/api/v0/*`, sorted by what triggered it. Two codes 
 | `update_check_unavailable` | 409 | `POST /version/check` cannot run — the daemon has no update-check capability. |
 | `payload_too_large` | 413 | Request body exceeds the 1 MiB limit. The connection closes after the response. |
 | `range_not_satisfiable` | 416 | A `Range` on [`GET /shared/{hash}/content`](#get-apiv0sharedhashcontent) starts at or past EOF. `Content-Range: bytes */<size>` accompanies the response. |
-| `rate_limited` | 429 | Too many requests: the per-IP auth-failure bucket is full, or `POST /version/check` was throttled by the daemon. `Retry-After: <seconds>` accompanies the auth case. |
+| `rate_limited` | 429 | The per-IP auth-failure bucket is full, so the address is locked out of every authenticated route. `Retry-After: <seconds>` accompanies it. A client should treat this as the session ending. |
+| `version_check_throttled` | 429 | [`POST /version/check`](#post-apiv0versioncheck) arrived inside the daemon's 60 s cooldown. Affects that route only, so a client must not read it as a lost session. |
 | `headers_too_large` | 431 | Request headers exceed the 16 KiB limit. The connection closes after the response. |
 | `internal_error` | 500 | A server-side failure: a handler failed internally (hash decode, serialization) or threw and was caught by the HTTP layer. The body is generic; details land in the daemon's stderr. |
 | `amuled_response_invalid` | 502 | amuled returned an EC payload this endpoint could not decode. |

--- a/src/webapi/Api.cpp
+++ b/src/webapi/Api.cpp
@@ -5083,8 +5083,14 @@ CHttpServer::Response CApiDispatcher::HandleVersionCheck(const CHttpServer::Requ
 	if (failed) {
 		// The only expected failure past the gate above is the daemon's
 		// throttle. Report an English code; the daemon's message is not relayed.
-		return ErrorResponse(
-			429, "rate_limited", "version check was throttled by the daemon; try again shortly");
+		//
+		// Its own code, not the auth limiter's `rate_limited`: both answer 429,
+		// and a client that cannot tell them apart has to treat a throttled
+		// update check as a lost session. The Web UI did exactly that and logged
+		// the user out on "Check now".
+		return ErrorResponse(429,
+			"version_check_throttled",
+			"version check was throttled by the daemon; try again shortly");
 	}
 
 	// Accepted. The check runs asynchronously on the daemon; the result

--- a/src/webapi/static/js/api.js
+++ b/src/webapi/static/js/api.js
@@ -103,8 +103,9 @@ async function request(method, path, { body, useEtag = false, noGate = false } =
     const err = payload && payload.error ? payload.error : {};
     // 401 (cookie gone / expired / revoked) and the auth limiter's own 429
     // are terminal for this session. Match 429 on the code, not the status:
-    // other endpoints answer 429 for their own throttles (the daemon's
-    // update check, say) and those must not log the user out.
+    // other endpoints answer 429 for their own throttles and must not log the
+    // user out. POST /version/check is the one that bit -- it answered
+    // `rate_limited` too, so "Check now" ended the session.
     if (!noGate && (resp.status === 401 || (resp.status === 429 && err.code === "rate_limited"))) {
       markSessionDead(resp.status === 429 ? "rate_limited" : "unauthorized");
     }

--- a/unittests/curl-tests/amuleapi/01-version-and-errors.sh
+++ b/unittests/curl-tests/amuleapi/01-version-and-errors.sh
@@ -181,6 +181,23 @@ _assert_status 200 "HEAD /api/v0/version returns 200"
 _curl -X POST "$HOST/api/v0/version/check"
 _assert_status 401 "POST /api/v0/version/check without auth yields 401"
 
+# 6b. The throttled check answers its own code, not the auth limiter's.
+#     Both are 429, and a client that cannot tell them apart has to read a
+#     throttled update check as a lost session -- which is exactly what the Web
+#     UI did, logging the user out on "Check now".
+#
+#     Two POSTs back to back: the daemon's cooldown is 60 s and its startup
+#     check already consumed one attempt, so whichever way the first lands, the
+#     second is inside the window. Deterministic regardless of daemon uptime.
+_curl "${AUTH[@]}" -X POST "$HOST/api/v0/version/check"
+_curl "${AUTH[@]}" -X POST "$HOST/api/v0/version/check"
+_assert_status 429 "second POST /version/check inside the cooldown yields 429"
+# Asserted as the exact code rather than "not rate_limited": the negative form
+# also passes on an `unauthorized` body, so it would go green on a broken
+# request instead of catching it.
+_assert_json_eq '.error.code' version_check_throttled \
+	'throttled /version/check carries error.code=version_check_throttled'
+
 # 7. GET /api/v0/version/check → 405 (POST only).
 _curl "$HOST/api/v0/version/check"
 _assert_status 405 "GET /api/v0/version/check yields 405"


### PR DESCRIPTION
Clicking **Check now** on the Web UI's About panel logged the user out.

The session was never actually invalid -- reloading the page restored it. That is the tell: the log-out is a client-side latch, not a server decision.

## Cause

Two unrelated conditions answered `429` with the same `error.code`:

| condition | scope |
|---|---|
| the auth limiter, when the per-IP failure bucket fills | **terminal** -- the address is locked out of every authenticated route |
| `POST /version/check`, inside the daemon's 60 s cooldown | that one route, nothing else |

[`api.js`](src/webapi/static/js/api.js) latches the session dead on `429 && code === "rate_limited"`. Its own comment says in as many words that other endpoints' throttles *"must not log the user out"*, and even names the daemon's update check as the example. **The client rule was right; the server made it undecidable** by spelling both conditions the same way.

`REFERENCE.md` documented the collision outright -- *"the per-IP auth-failure bucket is full, **or** `POST /version/check` was throttled by the daemon"* -- which is a code no client can act on.

## Fix

The throttle answers `version_check_throttled`. `rate_limited` now means the auth limiter and nothing else.

**No frontend logic change is needed** -- the existing discriminator starts working once the codes differ. Only its comment is updated, to name the endpoint that actually bit.

Both `REFERENCE.md` tables are split accordingly: the endpoint's own error table, and the global error-code list, which now says of `version_check_throttled` that it "affects that route only, so a client must not read it as a lost session".

## Test

The regression test posts twice in a row. The daemon's startup check already consumes one attempt, so whichever way the first POST lands the second is inside the cooldown -- deterministic regardless of daemon uptime.

It asserts the **exact** code rather than `!= "rate_limited"`. The negative form also passes on an `unauthorized` body, so it would go green on a request that never reached the endpoint. That is not hypothetical: the first cut of this test used a hand-written bearer header instead of the file's `AUTH` array, got `unauthorized`, and the negative assertion passed anyway while the real ones failed.

## Verification

Against a live amuled on macOS:

- Curl phase `01-version-and-errors.sh`: **32/32 passed**, both new assertions green.
- Unit tests: **47/47**.
- Reproduced end to end before and after: the throttled check returns `429 version_check_throttled`, and `GET /auth/session` and `GET /status` both answer **200** straight afterwards -- the session survives, which is the bug.
- `clang-format` 18 whole-file on the changed file: clean.
- `clang-tidy` Tier-1 and Tier-2 on the diff: 0 findings, 0 compiler errors.
- `node --check` on `api.js`: clean.
