### PR TITLE
fix(ec): reject an out-of-range category index instead of aborting the daemon

### DIFF
--- a/po/amule.pot
+++ b/po/amule.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-31 17:03+0200\n"
+"POT-Creation-Date: 2026-08-31 22:39+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -2160,6 +2160,10 @@ msgstr ""
 #: src/ExternalConn.cpp
 #, c-format
 msgid "Could not save the amuleapi password: %s"
+msgstr ""
+
+#: src/ExternalConn.cpp
+msgid "No such category."
 msgstr ""
 
 #: src/ExternalConn.cpp

--- a/po/ar.po
+++ b/po/ar.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-31 17:03+0200\n"
+"POT-Creation-Date: 2026-08-31 22:39+0200\n"
 "PO-Revision-Date: 2026-08-31 15:26+0000\n"
 "Last-Translator: saleh alhathal <hathalsal@hotmail.com>\n"
 "Language-Team: \n"
@@ -2202,6 +2202,11 @@ msgstr ""
 #, c-format
 msgid "Could not save the amuleapi password: %s"
 msgstr ""
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "No such category."
+msgstr "الغاء المجموعة"
 
 #: src/ExternalConn.cpp
 msgid "Missing chat session id"

--- a/po/ast.po
+++ b/po/ast.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-31 17:03+0200\n"
+"POT-Creation-Date: 2026-08-31 22:39+0200\n"
 "PO-Revision-Date: 2026-08-31 15:26+0000\n"
 "Last-Translator: astur <malditoastur@gmail.com>\n"
 "Language-Team: Language ast <malditoastur@gmail.com>\n"
@@ -2228,6 +2228,11 @@ msgstr ""
 #, c-format
 msgid "Could not save the amuleapi password: %s"
 msgstr ""
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "No such category."
+msgstr "Zarrar esta sesión de charra"
 
 #: src/ExternalConn.cpp
 #, fuzzy

--- a/po/bg.po
+++ b/po/bg.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-31 17:03+0200\n"
+"POT-Creation-Date: 2026-08-31 22:39+0200\n"
 "PO-Revision-Date: 2026-08-31 15:26+0000\n"
 "Last-Translator: Sebastiano Pistore <SebastianoPistore.info@protonmail.ch>\n"
 "Language-Team: Bulgarian <dict@linux.zonebg.com>\n"
@@ -2195,6 +2195,11 @@ msgstr ""
 #, c-format
 msgid "Could not save the amuleapi password: %s"
 msgstr ""
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "No such category."
+msgstr "Премахване на категория"
 
 #: src/ExternalConn.cpp
 msgid "Missing chat session id"

--- a/po/bn.po
+++ b/po/bn.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-31 17:03+0200\n"
+"POT-Creation-Date: 2026-08-31 22:39+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -2159,6 +2159,10 @@ msgstr ""
 #: src/ExternalConn.cpp
 #, c-format
 msgid "Could not save the amuleapi password: %s"
+msgstr ""
+
+#: src/ExternalConn.cpp
+msgid "No such category."
 msgstr ""
 
 #: src/ExternalConn.cpp

--- a/po/ca.po
+++ b/po/ca.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-31 17:03+0200\n"
+"POT-Creation-Date: 2026-08-31 22:39+0200\n"
 "PO-Revision-Date: 2026-08-31 15:27+0000\n"
 "Last-Translator: minterior <minterior@gmail.com>\n"
 "Language-Team: Català\n"
@@ -2221,6 +2221,11 @@ msgstr ""
 #, c-format
 msgid "Could not save the amuleapi password: %s"
 msgstr ""
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "No such category."
+msgstr "Tanca aquesta sessió de xat."
 
 #: src/ExternalConn.cpp
 #, fuzzy

--- a/po/cs.po
+++ b/po/cs.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-31 17:03+0200\n"
+"POT-Creation-Date: 2026-08-31 22:39+0200\n"
 "PO-Revision-Date: 2026-08-31 15:27+0000\n"
 "Last-Translator: David Watzke <david@watzke.cz>\n"
 "Language-Team: cs <cs@li.org>\n"
@@ -2214,6 +2214,11 @@ msgstr ""
 #, c-format
 msgid "Could not save the amuleapi password: %s"
 msgstr "Nepodařilo se uložit heslo amuleapi: %s"
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "No such category."
+msgstr "Zavře tento chat."
 
 #: src/ExternalConn.cpp
 #, fuzzy

--- a/po/da.po
+++ b/po/da.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-31 17:03+0200\n"
+"POT-Creation-Date: 2026-08-31 22:39+0200\n"
 "PO-Revision-Date: 2026-08-31 15:27+0000\n"
 "Last-Translator: Alex Thomsen Leth <alexl@stofanet.dk>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -2207,6 +2207,11 @@ msgstr ""
 #, c-format
 msgid "Could not save the amuleapi password: %s"
 msgstr ""
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "No such category."
+msgstr "Fjern kategori"
 
 #: src/ExternalConn.cpp
 msgid "Missing chat session id"

--- a/po/de.po
+++ b/po/de.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-31 17:03+0200\n"
+"POT-Creation-Date: 2026-08-31 22:39+0200\n"
 "PO-Revision-Date: 2026-08-31 15:27+0000\n"
 "Last-Translator: Werner Mahr <werner@vollstreckernet.de>\n"
 "Language-Team: German <>\n"
@@ -2226,6 +2226,11 @@ msgstr ""
 #, c-format
 msgid "Could not save the amuleapi password: %s"
 msgstr ""
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "No such category."
+msgstr "Schließe diese Chat-Sitzung."
 
 #: src/ExternalConn.cpp
 #, fuzzy

--- a/po/el.po
+++ b/po/el.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-31 17:03+0200\n"
+"POT-Creation-Date: 2026-08-31 22:39+0200\n"
 "PO-Revision-Date: 2026-08-31 15:28+0000\n"
 "Last-Translator: Dimitris <dgalanak@yahoo.com>\n"
 "Language-Team: Greek\n"
@@ -2238,6 +2238,11 @@ msgstr ""
 #, c-format
 msgid "Could not save the amuleapi password: %s"
 msgstr ""
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "No such category."
+msgstr "Κλείσιμο της συνομιλίας."
 
 #: src/ExternalConn.cpp
 #, fuzzy

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-31 17:03+0200\n"
+"POT-Creation-Date: 2026-08-31 22:39+0200\n"
 "PO-Revision-Date: 2020-03-04 14:43+0100\n"
 "Last-Translator: Dévai Tamás <devait@vnet.hu>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -2160,6 +2160,10 @@ msgstr ""
 #: src/ExternalConn.cpp
 #, c-format
 msgid "Could not save the amuleapi password: %s"
+msgstr ""
+
+#: src/ExternalConn.cpp
+msgid "No such category."
 msgstr ""
 
 #: src/ExternalConn.cpp

--- a/po/es.po
+++ b/po/es.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-31 17:03+0200\n"
+"POT-Creation-Date: 2026-08-31 22:39+0200\n"
 "PO-Revision-Date: 2026-08-31 15:28+0000\n"
 "Last-Translator: Diego Heras <ngosang@hotmail.es>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/amule/amule-application/es/>\n"
@@ -2213,6 +2213,11 @@ msgstr "No se pudo reasignar el cliente a ese archivo."
 #, c-format
 msgid "Could not save the amuleapi password: %s"
 msgstr "No se pudo guardar la contraseña amuleapi: %s"
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "No such category."
+msgstr "Cerrar esta sesión de chat."
 
 #: src/ExternalConn.cpp
 #, fuzzy

--- a/po/et_EE.po
+++ b/po/et_EE.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-31 17:03+0200\n"
+"POT-Creation-Date: 2026-08-31 22:39+0200\n"
 "PO-Revision-Date: 2026-08-31 15:28+0000\n"
 "Last-Translator: \n"
 "Language-Team: Estonian <kde-i18n-doc@kde.org>\n"
@@ -2221,6 +2221,11 @@ msgstr ""
 #, c-format
 msgid "Could not save the amuleapi password: %s"
 msgstr ""
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "No such category."
+msgstr "Sulge see vestlus-seanss."
 
 #: src/ExternalConn.cpp
 #, fuzzy

--- a/po/eu.po
+++ b/po/eu.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-31 17:03+0200\n"
+"POT-Creation-Date: 2026-08-31 22:39+0200\n"
 "PO-Revision-Date: 2026-08-31 15:29+0000\n"
 "Last-Translator: Piarres Beobide <pi@beobide.net>\n"
 "Language-Team: Euskara <librezale@librezale.org>\n"
@@ -2222,6 +2222,11 @@ msgstr ""
 #, c-format
 msgid "Could not save the amuleapi password: %s"
 msgstr ""
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "No such category."
+msgstr "Itxi elkarrizketa saio hau."
 
 #: src/ExternalConn.cpp
 #, fuzzy

--- a/po/fi.po
+++ b/po/fi.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-31 17:03+0200\n"
+"POT-Creation-Date: 2026-08-31 22:39+0200\n"
 "PO-Revision-Date: 2026-08-31 15:29+0000\n"
 "Last-Translator: Tapio Rantala <tapio.rantala@iki.fi>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -2222,6 +2222,11 @@ msgstr ""
 #, c-format
 msgid "Could not save the amuleapi password: %s"
 msgstr ""
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "No such category."
+msgstr "Sulje tämä keskustelu."
 
 #: src/ExternalConn.cpp
 #, fuzzy

--- a/po/fr.po
+++ b/po/fr.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-31 17:03+0200\n"
+"POT-Creation-Date: 2026-08-31 22:39+0200\n"
 "PO-Revision-Date: 2026-08-31 15:30+0000\n"
 "Last-Translator: Dylan Aïssi <bob.dybian@gmail.com>\n"
 "Language-Team: Français\n"
@@ -2212,6 +2212,11 @@ msgstr "Impossible de basculer le client vers ce fichier."
 #, c-format
 msgid "Could not save the amuleapi password: %s"
 msgstr "Impossible d’enregistrer le mot de passe d’amuleapi : %s"
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "No such category."
+msgstr "Discussion introuvable"
 
 #: src/ExternalConn.cpp
 msgid "Missing chat session id"

--- a/po/gl.po
+++ b/po/gl.po
@@ -24,7 +24,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-31 17:03+0200\n"
+"POT-Creation-Date: 2026-08-31 22:39+0200\n"
 "PO-Revision-Date: 2026-08-31 15:30+0000\n"
 "Last-Translator: Pablo <parodper@gmail.com>\n"
 "Language-Team: http://forum.amule.org/index.php?topic=13883\n"
@@ -2239,6 +2239,11 @@ msgstr ""
 #, c-format
 msgid "Could not save the amuleapi password: %s"
 msgstr ""
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "No such category."
+msgstr "Pechar esta conversa."
 
 #: src/ExternalConn.cpp
 #, fuzzy

--- a/po/he.po
+++ b/po/he.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-31 17:03+0200\n"
+"POT-Creation-Date: 2026-08-31 22:39+0200\n"
 "PO-Revision-Date: 2026-08-31 15:30+0000\n"
 "Last-Translator: Peace Kramer <kpeace1@gmail.com>\n"
 "Language-Team: Hebrew\n"
@@ -2217,6 +2217,11 @@ msgstr ""
 #, c-format
 msgid "Could not save the amuleapi password: %s"
 msgstr ""
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "No such category."
+msgstr "סגור את הצ'אט הנוכחי."
 
 #: src/ExternalConn.cpp
 #, fuzzy

--- a/po/hr.po
+++ b/po/hr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-31 17:03+0200\n"
+"POT-Creation-Date: 2026-08-31 22:39+0200\n"
 "PO-Revision-Date: 2026-08-31 15:30+0000\n"
 "Last-Translator: Sebastiano Pistore <sebastiano.pistore.info@aol.com>\n"
 "Language-Team: https://github.com/amule-org/amule <forum@aMule.org>\n"
@@ -2215,6 +2215,11 @@ msgstr ""
 #, c-format
 msgid "Could not save the amuleapi password: %s"
 msgstr ""
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "No such category."
+msgstr "Odstrani kategoriju"
 
 #: src/ExternalConn.cpp
 msgid "Missing chat session id"

--- a/po/hu.po
+++ b/po/hu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-31 17:03+0200\n"
+"POT-Creation-Date: 2026-08-31 22:39+0200\n"
 "PO-Revision-Date: 2026-08-31 15:31+0000\n"
 "Last-Translator: Dévai Tamás <gonosztopi@amule.org>\n"
 "Language-Team: Hungarian <hu@li.org>\n"
@@ -2213,6 +2213,11 @@ msgstr ""
 #, c-format
 msgid "Could not save the amuleapi password: %s"
 msgstr ""
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "No such category."
+msgstr "Csevegési folyamat bezárása."
 
 #: src/ExternalConn.cpp
 #, fuzzy

--- a/po/it.po
+++ b/po/it.po
@@ -19,7 +19,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule 2.3.3\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-31 17:03+0200\n"
+"POT-Creation-Date: 2026-08-31 22:39+0200\n"
 "PO-Revision-Date: 2026-08-31 15:31+0000\n"
 "Last-Translator: got3nks <got3nks@users.noreply.github.com>\n"
 "Language-Team: SebastianoPistore.info@protonmail.ch\n"
@@ -2219,6 +2219,11 @@ msgstr "Non è stato possibile spostare il client su quel file."
 #, c-format
 msgid "Could not save the amuleapi password: %s"
 msgstr "Impossibile salvare la password di amuleapi: %s"
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "No such category."
+msgstr "Sessione di chat inesistente"
 
 #: src/ExternalConn.cpp
 msgid "Missing chat session id"

--- a/po/ja.po
+++ b/po/ja.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-31 17:03+0200\n"
+"POT-Creation-Date: 2026-08-31 22:39+0200\n"
 "PO-Revision-Date: 2026-08-31 15:31+0000\n"
 "Last-Translator: \n"
 "Language-Team: Japanese\n"
@@ -2224,6 +2224,11 @@ msgstr ""
 #, c-format
 msgid "Could not save the amuleapi password: %s"
 msgstr ""
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "No such category."
+msgstr "チャット・セションを閉じます。"
 
 #: src/ExternalConn.cpp
 #, fuzzy

--- a/po/ko_KR.po
+++ b/po/ko_KR.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-31 17:03+0200\n"
+"POT-Creation-Date: 2026-08-31 22:39+0200\n"
 "PO-Revision-Date: 2026-08-31 15:32+0000\n"
 "Last-Translator: Hyunju Kang <rexington@gmail.com>\n"
 "Language-Team: Korean <hoenny@daum.net>\n"
@@ -2235,6 +2235,11 @@ msgstr ""
 #, c-format
 msgid "Could not save the amuleapi password: %s"
 msgstr ""
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "No such category."
+msgstr "이 채팅세션을 닫습니다."
 
 #: src/ExternalConn.cpp
 #, fuzzy

--- a/po/lt.po
+++ b/po/lt.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-31 17:03+0200\n"
+"POT-Creation-Date: 2026-08-31 22:39+0200\n"
 "PO-Revision-Date: 2026-08-31 15:32+0000\n"
 "Last-Translator: Dovydas Sankauskas <laisve@gmail.com>\n"
 "Language-Team: Lithuanian <komp_lt@konf.lt>\n"
@@ -2245,6 +2245,11 @@ msgstr ""
 #, c-format
 msgid "Could not save the amuleapi password: %s"
 msgstr ""
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "No such category."
+msgstr "Baigti pokalbį ir užverti pokalbio kortelę."
 
 #: src/ExternalConn.cpp
 #, fuzzy

--- a/po/lv.po
+++ b/po/lv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-31 17:03+0200\n"
+"POT-Creation-Date: 2026-08-31 22:39+0200\n"
 "PO-Revision-Date: 2026-08-31 15:38+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -2181,6 +2181,11 @@ msgstr ""
 #, c-format
 msgid "Could not save the amuleapi password: %s"
 msgstr ""
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "No such category."
+msgstr "Šāda ziņojumapmaiņas sesija nepastāv"
 
 #: src/ExternalConn.cpp
 msgid "Missing chat session id"

--- a/po/nl.po
+++ b/po/nl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-31 17:03+0200\n"
+"POT-Creation-Date: 2026-08-31 22:39+0200\n"
 "PO-Revision-Date: 2026-08-31 15:32+0000\n"
 "Last-Translator: Marcel Pol <marcel@timelord.nl>\n"
 "Language-Team: Dutch <nl@li.org>\n"
@@ -2209,6 +2209,11 @@ msgstr "Kan de client niet naar dat bestand overschakelen."
 #, c-format
 msgid "Could not save the amuleapi password: %s"
 msgstr "Kon het amuleapi-wachtwoord niet opslaan: %s"
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "No such category."
+msgstr "Chatsessie onvindbaar"
 
 #: src/ExternalConn.cpp
 msgid "Missing chat session id"

--- a/po/nn.po
+++ b/po/nn.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-31 17:03+0200\n"
+"POT-Creation-Date: 2026-08-31 22:39+0200\n"
 "PO-Revision-Date: 2026-08-31 15:33+0000\n"
 "Last-Translator: Hallvor Brunstad <Hallvor_1976@yahoo.com>\n"
 "Language-Team: <i18n-nn@lister.ping.uio.no>\n"
@@ -2236,6 +2236,11 @@ msgstr ""
 #, c-format
 msgid "Could not save the amuleapi password: %s"
 msgstr ""
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "No such category."
+msgstr "Stengje denne lynmeldingsøkta."
 
 #: src/ExternalConn.cpp
 #, fuzzy

--- a/po/pl.po
+++ b/po/pl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-31 17:03+0200\n"
+"POT-Creation-Date: 2026-08-31 22:39+0200\n"
 "PO-Revision-Date: 2026-08-31 15:33+0000\n"
 "Last-Translator: Michał Trzebiatowski <hippie_1968@hotmail.com>\n"
 "Language-Team: translationproject.org/team/pl.html <translation-team-pl@lists.sourceforge.net>\n"
@@ -2231,6 +2231,11 @@ msgstr ""
 #, c-format
 msgid "Could not save the amuleapi password: %s"
 msgstr ""
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "No such category."
+msgstr "Zamknij tę sesję czata."
 
 #: src/ExternalConn.cpp
 #, fuzzy

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-31 17:03+0200\n"
+"POT-Creation-Date: 2026-08-31 22:39+0200\n"
 "PO-Revision-Date: 2026-08-31 15:33+0000\n"
 "Last-Translator: Marcelo Jimenez <mroberto@users.sourceforge.com>\n"
 "Language-Team: Português (Brasileiro) <pt@li.org>\n"
@@ -2213,6 +2213,11 @@ msgstr "O cliente não pode ser trocado para este arquivo."
 #, c-format
 msgid "Could not save the amuleapi password: %s"
 msgstr "Não foi possível salvar a senha da amuleapi: %s"
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "No such category."
+msgstr "Esta sessão de chat não existe"
 
 #: src/ExternalConn.cpp
 msgid "Missing chat session id"

--- a/po/pt_PT.po
+++ b/po/pt_PT.po
@@ -17,7 +17,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-31 17:03+0200\n"
+"POT-Creation-Date: 2026-08-31 22:39+0200\n"
 "PO-Revision-Date: 2026-08-31 15:34+0000\n"
 "Last-Translator: Luís Picciochi Oliveira <Pitxyoki@Gmail.com>\n"
 "Language-Team: Portuguese <traduz@debianpt.org>\n"
@@ -2228,6 +2228,11 @@ msgstr ""
 #, c-format
 msgid "Could not save the amuleapi password: %s"
 msgstr ""
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "No such category."
+msgstr "Fechar esta conversa."
 
 #: src/ExternalConn.cpp
 #, fuzzy

--- a/po/ro.po
+++ b/po/ro.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-31 17:03+0200\n"
+"POT-Creation-Date: 2026-08-31 22:39+0200\n"
 "PO-Revision-Date: 2026-08-31 15:34+0000\n"
 "Last-Translator: Angelescu Constantin <titus0818@yahoo.com>\n"
 "Language-Team: English <kde-i18n-doc@kde.org>\n"
@@ -2228,6 +2228,11 @@ msgstr ""
 #, c-format
 msgid "Could not save the amuleapi password: %s"
 msgstr ""
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "No such category."
+msgstr "Închide această sesiune de chat."
 
 #: src/ExternalConn.cpp
 #, fuzzy

--- a/po/ru.po
+++ b/po/ru.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-31 17:03+0200\n"
+"POT-Creation-Date: 2026-08-31 22:39+0200\n"
 "PO-Revision-Date: 2026-08-31 15:34+0000\n"
 "Last-Translator: Radist Morse <radist.morse@gmail.com>\n"
 "Language-Team: Russian <kde-russian@lists.kde.ru>\n"
@@ -2229,6 +2229,11 @@ msgstr "Не удалось переключить клиента на этот 
 #, c-format
 msgid "Could not save the amuleapi password: %s"
 msgstr "Не удалось сохранить пароль amuleapi: %s"
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "No such category."
+msgstr "Такой беседы нет"
 
 #: src/ExternalConn.cpp
 msgid "Missing chat session id"

--- a/po/sl.po
+++ b/po/sl.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-31 17:03+0200\n"
+"POT-Creation-Date: 2026-08-31 22:39+0200\n"
 "PO-Revision-Date: 2026-08-31 15:35+0000\n"
 "Last-Translator: Jure Repinc <jlp@holodeck1.com>\n"
 "Language-Team: Slovenian\n"
@@ -2242,6 +2242,11 @@ msgstr ""
 #, c-format
 msgid "Could not save the amuleapi password: %s"
 msgstr ""
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "No such category."
+msgstr "Zapri to pogovorno sejo."
 
 #: src/ExternalConn.cpp
 #, fuzzy

--- a/po/sq.po
+++ b/po/sq.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-31 17:03+0200\n"
+"POT-Creation-Date: 2026-08-31 22:39+0200\n"
 "PO-Revision-Date: 2026-08-31 15:35+0000\n"
 "Last-Translator: Fation <dj_barthezz@linuxmail.org lushnja_corps@hotmail.Language-Team:\n"
 "Language: sq\n"
@@ -2231,6 +2231,11 @@ msgstr ""
 #, c-format
 msgid "Could not save the amuleapi password: %s"
 msgstr ""
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "No such category."
+msgstr "Mbylle kete sesion chati."
 
 #: src/ExternalConn.cpp
 #, fuzzy

--- a/po/sv.po
+++ b/po/sv.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-31 17:03+0200\n"
+"POT-Creation-Date: 2026-08-31 22:39+0200\n"
 "PO-Revision-Date: 2026-08-31 15:35+0000\n"
 "Last-Translator: raffe <raffe@localhost.se>\n"
 "Language-Team: Swedish <tp-sv@listor.tp-sv.se>\n"
@@ -2220,6 +2220,11 @@ msgstr ""
 #, c-format
 msgid "Could not save the amuleapi password: %s"
 msgstr ""
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "No such category."
+msgstr "Stäng denna chat-session."
 
 #: src/ExternalConn.cpp
 #, fuzzy

--- a/po/ta.po
+++ b/po/ta.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-31 17:03+0200\n"
+"POT-Creation-Date: 2026-08-31 22:39+0200\n"
 "PO-Revision-Date: 2026-08-31 15:38+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -2159,6 +2159,10 @@ msgstr ""
 #: src/ExternalConn.cpp
 #, c-format
 msgid "Could not save the amuleapi password: %s"
+msgstr ""
+
+#: src/ExternalConn.cpp
+msgid "No such category."
 msgstr ""
 
 #: src/ExternalConn.cpp

--- a/po/tr.po
+++ b/po/tr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-31 17:03+0200\n"
+"POT-Creation-Date: 2026-08-31 22:39+0200\n"
 "PO-Revision-Date: 2026-08-31 15:36+0000\n"
 "Last-Translator: \n"
 "Language-Team: Turkish <li@li.org>\n"
@@ -2205,6 +2205,11 @@ msgstr "İstemci bu dosyaya geçirilemedi."
 #, c-format
 msgid "Could not save the amuleapi password: %s"
 msgstr "amuleapi parolası kaydedilemedi: %s"
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "No such category."
+msgstr "Böyle bir sohbet oturumu yok"
 
 #: src/ExternalConn.cpp
 msgid "Missing chat session id"

--- a/po/uk.po
+++ b/po/uk.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-31 17:03+0200\n"
+"POT-Creation-Date: 2026-08-31 22:39+0200\n"
 "PO-Revision-Date: 2026-08-31 15:36+0000\n"
 "Last-Translator: Oleksandr Kovalenko <alx.kovalenko@gmail.com>\n"
 "Language-Team: Ukrainian <translation@linux.org.ua>\n"
@@ -2241,6 +2241,11 @@ msgstr ""
 #, c-format
 msgid "Could not save the amuleapi password: %s"
 msgstr ""
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "No such category."
+msgstr "Закрити цю розмову."
 
 #: src/ExternalConn.cpp
 #, fuzzy

--- a/po/vi.po
+++ b/po/vi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-31 17:03+0200\n"
+"POT-Creation-Date: 2026-08-31 22:39+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -2158,6 +2158,10 @@ msgstr ""
 #: src/ExternalConn.cpp
 #, c-format
 msgid "Could not save the amuleapi password: %s"
+msgstr ""
+
+#: src/ExternalConn.cpp
+msgid "No such category."
 msgstr ""
 
 #: src/ExternalConn.cpp

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-31 17:03+0200\n"
+"POT-Creation-Date: 2026-08-31 22:39+0200\n"
 "PO-Revision-Date: 2026-08-31 15:36+0000\n"
 "Last-Translator: Mike Akiba <mike2718@gmail.com>\n"
 "Language-Team: Chinese Simplified <kde-i18n-doc@kde.org>\n"
@@ -2209,6 +2209,11 @@ msgstr "无法交换客户端到那个文件。"
 #, c-format
 msgid "Could not save the amuleapi password: %s"
 msgstr "无法保存 amuleapi 密码：%s"
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "No such category."
+msgstr "没有这样的聊天会话"
 
 #: src/ExternalConn.cpp
 msgid "Missing chat session id"

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-31 17:03+0200\n"
+"POT-Creation-Date: 2026-08-31 22:39+0200\n"
 "PO-Revision-Date: 2026-08-31 15:37+0000\n"
 "Last-Translator: Wayne Su <mstarmstar@gmail.com>\n"
 "Language-Team: \n"
@@ -2218,6 +2218,11 @@ msgstr ""
 #, c-format
 msgid "Could not save the amuleapi password: %s"
 msgstr ""
+
+#: src/ExternalConn.cpp
+#, fuzzy
+msgid "No such category."
+msgstr "結束本次交談。"
 
 #: src/ExternalConn.cpp
 #, fuzzy

--- a/src/ECSpecialMuleTags.cpp
+++ b/src/ECSpecialMuleTags.cpp
@@ -64,6 +64,21 @@ CEC_Category_Tag::CEC_Category_Tag(
 
 bool CEC_Category_Tag::Apply()
 {
+	// The index arrives from an EC client and the protocol does not constrain
+	// it: the tag admits any uint8 while only GetCatCount() categories exist.
+	// Refusing here rather than only inside UpdateCategory, because BOTH calls
+	// below index with this value -- the failure branch reads GetCatPath(),
+	// which is guarded by a wxASSERT that aborts a debug build and vanishes in
+	// a release one. Left unchecked, UpdateCategory indexed m_CatList (a
+	// std::vector) out of range and dereferenced the result comparing paths,
+	// which took the daemon down with SIGABRT and every transfer with it
+	// (amule-org/amule#1227).
+	if (GetInt() >= theApp->glob_prefs->GetCatCount()) {
+		// The EC_OP_UPDATE_CATEGORY handler turns false into EC_OP_FAILED
+		// carrying the category and the client's own path, which is the
+		// rejection this case wants -- no new protocol surface needed.
+		return false;
+	}
 	bool ret = theApp->glob_prefs->UpdateCategory(
 		GetInt(), Name(), CPath(Path()), Comment(), Color(), Prio());
 	if (!ret) {

--- a/src/ExternalConn.cpp
+++ b/src/ExternalConn.cpp
@@ -4213,6 +4213,22 @@ CECPacket *CECServerSocket::ProcessRequest2(const CECPacket *request)
 		if (request->GetTagCount() == 1) {
 			CEC_Category_Tag tag(
 				*static_cast<const CEC_Category_Tag *>(request->GetFirstTagSafe()));
+			if (tag.GetInt() >= theApp->glob_prefs->GetCatCount()) {
+				// No such category. Deliberately WITHOUT
+				// EC_TAG_CATEGORY_PATH: on a failed update that tag means
+				// "everything but the path was applied, and here is the
+				// path kept instead", which clients answer as a success
+				// (amule-org/amule#1213). Emitting it here would report a
+				// category that does not exist as updated. The index is
+				// whatever the client sent -- it used to be indexed
+				// straight into m_CatList (amule-org/amule#1227).
+				response = new CECPacket(EC_OP_FAILED);
+				response->AddTag(CECTag(EC_TAG_CATEGORY, tag.GetInt()));
+				response->AddTag(CECTag(EC_TAG_STRING, wxTRANSLATE("No such category.")));
+				// No Notify either: there is nothing to refresh, and the
+				// monolithic handler would index on this same value.
+				break;
+			}
 			if (tag.Apply()) {
 				response = new CECPacket(EC_OP_NOOP);
 			} else {

--- a/src/Preferences.cpp
+++ b/src/Preferences.cpp
@@ -2518,6 +2518,16 @@ bool CPreferences::CreateCategory(Category_Struct *&category,
 bool CPreferences::UpdateCategory(
 	uint8 cat, const wxString &name, const CPath &path, const wxString &comment, uint32 color, uint8 prio)
 {
+	// Backstop for the index. CreateCategory and the category dialog both pass
+	// one that is valid by construction; the EC handler does not, and its
+	// value comes straight off the wire. Returning false rather than indexing
+	// keeps an out-of-range id from reaching m_CatList, which is a std::vector
+	// -- operator[] past the end is undefined, and what it actually did was
+	// hand back a garbage pointer that the path comparison below dereferenced
+	// (amule-org/amule#1227). Callers already treat false as "not applied".
+	if (cat >= m_CatList.size()) {
+		return false;
+	}
 	Category_Struct *category = m_CatList[cat];
 
 	// return true if path is ok, false if not


### PR DESCRIPTION
Fixes the SIGABRT reported in #1227. The crash turns out to be reachable through amuleapi as well as through a legacy EC client, so it is a REST-triggerable daemon abort for any authenticated admin, not only an EC-client one.

### Root cause

`EC_OP_UPDATE_CATEGORY` carries a category index the protocol does not constrain: the tag admits any `uint8` while only `GetCatCount()` categories exist. `CEC_Category_Tag::Apply` passed it straight to `CPreferences::UpdateCategory`, which indexed `m_CatList` (a `std::vector<Category_Struct *>`) with no check of any kind, then dereferenced the result comparing paths:

```cpp
Category_Struct *category = m_CatList[cat];   // no bounds check
...
} else if (category->path != path) {          // deref of garbage
```

An EC client sending an index past the end therefore took the daemon down with `SIGABRT` and every transfer with it. Reported against 3.0.1 with 5 categories and an index of 28, and present unchanged on master.

### Why the check goes in `Apply`, not only in `UpdateCategory`

Both calls there index with the same value. The failure branch reads `GetCatPath()`, whose only guard is a `wxASSERT` - an abort in a debug build, nothing at all in a release one. A fix confined to `UpdateCategory` would have moved the crash rather than removed it.

`UpdateCategory` still gets a bounds check of its own as a backstop. Its other two callers, `CreateCategory` and the category dialog, pass an index that is valid by construction, so this only changes behaviour for a caller that would otherwise have indexed out of range. Its siblings `GetCategory` and `GetCatPath` already guard, if only with `wxASSERT`; this one had nothing.

### The reply has to stay distinguishable from a kept path

#1213 established that `EC_OP_FAILED` carrying `EC_TAG_CATEGORY_PATH` means "the category was applied and only the path was refused", which clients answer as a success. The update handler emitted that tag on *every* failure, so simply returning `false` for an unknown index would have reported a category that does not exist as updated - amuleapi answers `200` with the object echoed.

The handler now answers an unknown index with `EC_OP_FAILED` + `EC_TAG_STRING` and **no** path tag, so amuleapi returns `400 amuled_rejected` and the desktop's `CCatHandler` does not print a "keeping directory" correction for a category that was never touched. `Notify_CategoryUpdate` is skipped too, since the monolithic handler would index on the same value.

### amuleapi is a route into this

`HandleCategoryUpdate` resolves the index against its snapshot and answers `404` for an unknown one, but that check runs before the EC roundtrip is serialized. A `DELETE` and a `PATCH` of the same index issued **concurrently** can validate against the pre-delete snapshot and still be forwarded after the delete lands. A sequential pair cannot: `HandleCategoryDelete` forces a `RefresherTick` before it replies.

### Both consumers checked against the new shape

| Consumer | Behaviour on the new reply |
|---|---|
| amuleapi | `400 amuled_rejected` carrying the daemon's message - verified live: `{"error":{"code":"amuled_rejected","message":"No such category."}}` |
| amulegui | ignores it. `CCatHandler::HandlePacket` already required **both** the category and path tags *and* bounds-checked the index before using it, so a reply without the path tag is skipped rather than mishandled - it had the guard the daemon lacked |

### Verification

Repro against a throwaway daemon with amuleapi in front of it - create a category, then issue `DELETE /categories/1` and `PATCH /categories/1` concurrently, in a loop:

| Build | Result |
|---|---|
| pre-fix | daemon dead at **iteration 2** (`SIGABRT`) |
| post-fix | **40 iterations**, still running |

- Valid path unaffected: curl phases `18-categories-crud` and `05-read-servers-kad-categories-prefs` pass **165 assertions, 0 failures**, including the real `POST` / `PATCH` / `DELETE` round trips that go through this code.
- 47/47 ctest; clang-format and both clang-tidy tiers clean with 0 compiler errors.

Closes #1227.
