### PR TITLE
fix(ec): report deletes that EC_OP_DELETE_CATEGORY discards

### DIFF
--- a/po/amule.pot
+++ b/po/amule.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-31 22:39+0200\n"
+"POT-Creation-Date: 2026-09-01 11:32+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1001,6 +1001,15 @@ msgstr ""
 
 #: src/amule-remote-gui.cpp src/ExternalConn.cpp
 msgid "Invalid link or already on list."
+msgstr ""
+
+#: src/amule-remote-gui.cpp
+msgid "The daemon refused the request."
+msgstr ""
+
+#: src/amule-remote-gui.cpp
+#, c-format
+msgid "Could not delete the category: %s"
 msgstr ""
 
 #: src/amule-remote-gui.cpp
@@ -2164,6 +2173,14 @@ msgstr ""
 
 #: src/ExternalConn.cpp
 msgid "No such category."
+msgstr ""
+
+#: src/ExternalConn.cpp
+msgid "Malformed category request."
+msgstr ""
+
+#: src/ExternalConn.cpp
+msgid "The default category cannot be deleted."
 msgstr ""
 
 #: src/ExternalConn.cpp

--- a/po/ar.po
+++ b/po/ar.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-31 22:39+0200\n"
+"POT-Creation-Date: 2026-09-01 11:32+0200\n"
 "PO-Revision-Date: 2026-08-31 15:26+0000\n"
 "Last-Translator: saleh alhathal <hathalsal@hotmail.com>\n"
 "Language-Team: \n"
@@ -1027,6 +1027,15 @@ msgstr ""
 #: src/amule-remote-gui.cpp src/ExternalConn.cpp
 msgid "Invalid link or already on list."
 msgstr ""
+
+#: src/amule-remote-gui.cpp
+msgid "The daemon refused the request."
+msgstr ""
+
+#: src/amule-remote-gui.cpp
+#, fuzzy, c-format
+msgid "Could not delete the category: %s"
+msgstr "قمت بمحاولت تحميل الملف مسبقا %s"
 
 #: src/amule-remote-gui.cpp
 #, c-format
@@ -2207,6 +2216,14 @@ msgstr ""
 #, fuzzy
 msgid "No such category."
 msgstr "الغاء المجموعة"
+
+#: src/ExternalConn.cpp
+msgid "Malformed category request."
+msgstr ""
+
+#: src/ExternalConn.cpp
+msgid "The default category cannot be deleted."
+msgstr ""
 
 #: src/ExternalConn.cpp
 msgid "Missing chat session id"

--- a/po/ast.po
+++ b/po/ast.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-31 22:39+0200\n"
+"POT-Creation-Date: 2026-09-01 11:32+0200\n"
 "PO-Revision-Date: 2026-08-31 15:26+0000\n"
 "Last-Translator: astur <malditoastur@gmail.com>\n"
 "Language-Team: Language ast <malditoastur@gmail.com>\n"
@@ -1043,6 +1043,15 @@ msgstr ""
 #: src/amule-remote-gui.cpp src/ExternalConn.cpp
 msgid "Invalid link or already on list."
 msgstr "Enllaz non válidu o yá ta na llista."
+
+#: src/amule-remote-gui.cpp
+msgid "The daemon refused the request."
+msgstr ""
+
+#: src/amule-remote-gui.cpp
+#, fuzzy, c-format
+msgid "Could not delete the category: %s"
+msgstr "Carpeta pa los ficheros temporales de descargues"
 
 #: src/amule-remote-gui.cpp
 #, c-format
@@ -2233,6 +2242,14 @@ msgstr ""
 #, fuzzy
 msgid "No such category."
 msgstr "Zarrar esta sesión de charra"
+
+#: src/ExternalConn.cpp
+msgid "Malformed category request."
+msgstr ""
+
+#: src/ExternalConn.cpp
+msgid "The default category cannot be deleted."
+msgstr ""
 
 #: src/ExternalConn.cpp
 #, fuzzy

--- a/po/bg.po
+++ b/po/bg.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-31 22:39+0200\n"
+"POT-Creation-Date: 2026-09-01 11:32+0200\n"
 "PO-Revision-Date: 2026-08-31 15:26+0000\n"
 "Last-Translator: Sebastiano Pistore <SebastianoPistore.info@protonmail.ch>\n"
 "Language-Team: Bulgarian <dict@linux.zonebg.com>\n"
@@ -1021,6 +1021,15 @@ msgstr ""
 #: src/amule-remote-gui.cpp src/ExternalConn.cpp
 msgid "Invalid link or already on list."
 msgstr ""
+
+#: src/amule-remote-gui.cpp
+msgid "The daemon refused the request."
+msgstr ""
+
+#: src/amule-remote-gui.cpp
+#, fuzzy, c-format
+msgid "Could not delete the category: %s"
+msgstr "Вие вече опитвате да свалите файла %s"
 
 #: src/amule-remote-gui.cpp
 #, c-format
@@ -2200,6 +2209,14 @@ msgstr ""
 #, fuzzy
 msgid "No such category."
 msgstr "Премахване на категория"
+
+#: src/ExternalConn.cpp
+msgid "Malformed category request."
+msgstr ""
+
+#: src/ExternalConn.cpp
+msgid "The default category cannot be deleted."
+msgstr ""
 
 #: src/ExternalConn.cpp
 msgid "Missing chat session id"

--- a/po/bn.po
+++ b/po/bn.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-31 22:39+0200\n"
+"POT-Creation-Date: 2026-09-01 11:32+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -1000,6 +1000,15 @@ msgstr ""
 
 #: src/amule-remote-gui.cpp src/ExternalConn.cpp
 msgid "Invalid link or already on list."
+msgstr ""
+
+#: src/amule-remote-gui.cpp
+msgid "The daemon refused the request."
+msgstr ""
+
+#: src/amule-remote-gui.cpp
+#, c-format
+msgid "Could not delete the category: %s"
 msgstr ""
 
 #: src/amule-remote-gui.cpp
@@ -2163,6 +2172,14 @@ msgstr ""
 
 #: src/ExternalConn.cpp
 msgid "No such category."
+msgstr ""
+
+#: src/ExternalConn.cpp
+msgid "Malformed category request."
+msgstr ""
+
+#: src/ExternalConn.cpp
+msgid "The default category cannot be deleted."
 msgstr ""
 
 #: src/ExternalConn.cpp

--- a/po/ca.po
+++ b/po/ca.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-31 22:39+0200\n"
+"POT-Creation-Date: 2026-09-01 11:32+0200\n"
 "PO-Revision-Date: 2026-08-31 15:27+0000\n"
 "Last-Translator: minterior <minterior@gmail.com>\n"
 "Language-Team: Català\n"
@@ -1042,6 +1042,15 @@ msgstr ""
 #: src/amule-remote-gui.cpp src/ExternalConn.cpp
 msgid "Invalid link or already on list."
 msgstr "L'enllaç és invàlid o ja és present a la llista."
+
+#: src/amule-remote-gui.cpp
+msgid "The daemon refused the request."
+msgstr ""
+
+#: src/amule-remote-gui.cpp
+#, fuzzy, c-format
+msgid "Could not delete the category: %s"
+msgstr "Carpeta on desar les descàrregues temporals"
 
 #: src/amule-remote-gui.cpp
 #, c-format
@@ -2226,6 +2235,14 @@ msgstr ""
 #, fuzzy
 msgid "No such category."
 msgstr "Tanca aquesta sessió de xat."
+
+#: src/ExternalConn.cpp
+msgid "Malformed category request."
+msgstr ""
+
+#: src/ExternalConn.cpp
+msgid "The default category cannot be deleted."
+msgstr ""
 
 #: src/ExternalConn.cpp
 #, fuzzy

--- a/po/cs.po
+++ b/po/cs.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-31 22:39+0200\n"
+"POT-Creation-Date: 2026-09-01 11:32+0200\n"
 "PO-Revision-Date: 2026-08-31 15:27+0000\n"
 "Last-Translator: David Watzke <david@watzke.cz>\n"
 "Language-Team: cs <cs@li.org>\n"
@@ -1044,6 +1044,15 @@ msgstr "Jádro odmítlo tyto sdílené složky:%s"
 #: src/amule-remote-gui.cpp src/ExternalConn.cpp
 msgid "Invalid link or already on list."
 msgstr "Neplatný odkaz, nebo je již v seznamu."
+
+#: src/amule-remote-gui.cpp
+msgid "The daemon refused the request."
+msgstr ""
+
+#: src/amule-remote-gui.cpp
+#, fuzzy, c-format
+msgid "Could not delete the category: %s"
+msgstr "Nepodařilo se uložit heslo amuleapi: %s"
 
 #: src/amule-remote-gui.cpp
 #, c-format
@@ -2219,6 +2228,14 @@ msgstr "Nepodařilo se uložit heslo amuleapi: %s"
 #, fuzzy
 msgid "No such category."
 msgstr "Zavře tento chat."
+
+#: src/ExternalConn.cpp
+msgid "Malformed category request."
+msgstr ""
+
+#: src/ExternalConn.cpp
+msgid "The default category cannot be deleted."
+msgstr ""
 
 #: src/ExternalConn.cpp
 #, fuzzy

--- a/po/da.po
+++ b/po/da.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-31 22:39+0200\n"
+"POT-Creation-Date: 2026-09-01 11:32+0200\n"
 "PO-Revision-Date: 2026-08-31 15:27+0000\n"
 "Last-Translator: Alex Thomsen Leth <alexl@stofanet.dk>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -1030,6 +1030,15 @@ msgstr ""
 #: src/amule-remote-gui.cpp src/ExternalConn.cpp
 msgid "Invalid link or already on list."
 msgstr ""
+
+#: src/amule-remote-gui.cpp
+msgid "The daemon refused the request."
+msgstr ""
+
+#: src/amule-remote-gui.cpp
+#, fuzzy, c-format
+msgid "Could not delete the category: %s"
+msgstr "Du prøver allerede at downloade denne fil %s"
 
 #: src/amule-remote-gui.cpp
 #, c-format
@@ -2212,6 +2221,14 @@ msgstr ""
 #, fuzzy
 msgid "No such category."
 msgstr "Fjern kategori"
+
+#: src/ExternalConn.cpp
+msgid "Malformed category request."
+msgstr ""
+
+#: src/ExternalConn.cpp
+msgid "The default category cannot be deleted."
+msgstr ""
 
 #: src/ExternalConn.cpp
 msgid "Missing chat session id"

--- a/po/de.po
+++ b/po/de.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-31 22:39+0200\n"
+"POT-Creation-Date: 2026-09-01 11:32+0200\n"
 "PO-Revision-Date: 2026-08-31 15:27+0000\n"
 "Last-Translator: Werner Mahr <werner@vollstreckernet.de>\n"
 "Language-Team: German <>\n"
@@ -1051,6 +1051,15 @@ msgstr ""
 #: src/amule-remote-gui.cpp src/ExternalConn.cpp
 msgid "Invalid link or already on list."
 msgstr "Ungültiger Verweis oder schon auf der Liste"
+
+#: src/amule-remote-gui.cpp
+msgid "The daemon refused the request."
+msgstr ""
+
+#: src/amule-remote-gui.cpp
+#, fuzzy, c-format
+msgid "Could not delete the category: %s"
+msgstr "Konnte heruntergeladene Datei nicht nach %s verschieben"
 
 #: src/amule-remote-gui.cpp
 #, c-format
@@ -2231,6 +2240,14 @@ msgstr ""
 #, fuzzy
 msgid "No such category."
 msgstr "Schließe diese Chat-Sitzung."
+
+#: src/ExternalConn.cpp
+msgid "Malformed category request."
+msgstr ""
+
+#: src/ExternalConn.cpp
+msgid "The default category cannot be deleted."
+msgstr ""
 
 #: src/ExternalConn.cpp
 #, fuzzy

--- a/po/el.po
+++ b/po/el.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-31 22:39+0200\n"
+"POT-Creation-Date: 2026-09-01 11:32+0200\n"
 "PO-Revision-Date: 2026-08-31 15:28+0000\n"
 "Last-Translator: Dimitris <dgalanak@yahoo.com>\n"
 "Language-Team: Greek\n"
@@ -1052,6 +1052,15 @@ msgstr ""
 #: src/amule-remote-gui.cpp src/ExternalConn.cpp
 msgid "Invalid link or already on list."
 msgstr "Άκυρος σύνδεσμο ή ήδη στην λίστα."
+
+#: src/amule-remote-gui.cpp
+msgid "The daemon refused the request."
+msgstr ""
+
+#: src/amule-remote-gui.cpp
+#, fuzzy, c-format
+msgid "Could not delete the category: %s"
+msgstr "Κατάλογος για τα προσωρινά αρχεία"
 
 #: src/amule-remote-gui.cpp
 #, c-format
@@ -2243,6 +2252,14 @@ msgstr ""
 #, fuzzy
 msgid "No such category."
 msgstr "Κλείσιμο της συνομιλίας."
+
+#: src/ExternalConn.cpp
+msgid "Malformed category request."
+msgstr ""
+
+#: src/ExternalConn.cpp
+msgid "The default category cannot be deleted."
+msgstr ""
 
 #: src/ExternalConn.cpp
 #, fuzzy

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-31 22:39+0200\n"
+"POT-Creation-Date: 2026-09-01 11:32+0200\n"
 "PO-Revision-Date: 2020-03-04 14:43+0100\n"
 "Last-Translator: Dévai Tamás <devait@vnet.hu>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -1001,6 +1001,15 @@ msgstr ""
 
 #: src/amule-remote-gui.cpp src/ExternalConn.cpp
 msgid "Invalid link or already on list."
+msgstr ""
+
+#: src/amule-remote-gui.cpp
+msgid "The daemon refused the request."
+msgstr ""
+
+#: src/amule-remote-gui.cpp
+#, c-format
+msgid "Could not delete the category: %s"
 msgstr ""
 
 #: src/amule-remote-gui.cpp
@@ -2164,6 +2173,14 @@ msgstr ""
 
 #: src/ExternalConn.cpp
 msgid "No such category."
+msgstr ""
+
+#: src/ExternalConn.cpp
+msgid "Malformed category request."
+msgstr ""
+
+#: src/ExternalConn.cpp
+msgid "The default category cannot be deleted."
 msgstr ""
 
 #: src/ExternalConn.cpp

--- a/po/es.po
+++ b/po/es.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-31 22:39+0200\n"
+"POT-Creation-Date: 2026-09-01 11:32+0200\n"
 "PO-Revision-Date: 2026-08-31 15:28+0000\n"
 "Last-Translator: Diego Heras <ngosang@hotmail.es>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/amule/amule-application/es/>\n"
@@ -1050,6 +1050,15 @@ msgstr "El núcleo rechazó estas carpetas compartidas: %s"
 #: src/amule-remote-gui.cpp src/ExternalConn.cpp
 msgid "Invalid link or already on list."
 msgstr "El enlace no es válido o ya está en la lista."
+
+#: src/amule-remote-gui.cpp
+msgid "The daemon refused the request."
+msgstr ""
+
+#: src/amule-remote-gui.cpp
+#, fuzzy, c-format
+msgid "Could not delete the category: %s"
+msgstr "No se pudo guardar la contraseña amuleapi: %s"
 
 #: src/amule-remote-gui.cpp
 #, c-format
@@ -2218,6 +2227,14 @@ msgstr "No se pudo guardar la contraseña amuleapi: %s"
 #, fuzzy
 msgid "No such category."
 msgstr "Cerrar esta sesión de chat."
+
+#: src/ExternalConn.cpp
+msgid "Malformed category request."
+msgstr ""
+
+#: src/ExternalConn.cpp
+msgid "The default category cannot be deleted."
+msgstr ""
 
 #: src/ExternalConn.cpp
 #, fuzzy

--- a/po/et_EE.po
+++ b/po/et_EE.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-31 22:39+0200\n"
+"POT-Creation-Date: 2026-09-01 11:32+0200\n"
 "PO-Revision-Date: 2026-08-31 15:28+0000\n"
 "Last-Translator: \n"
 "Language-Team: Estonian <kde-i18n-doc@kde.org>\n"
@@ -1042,6 +1042,15 @@ msgstr ""
 #: src/amule-remote-gui.cpp src/ExternalConn.cpp
 msgid "Invalid link or already on list."
 msgstr "Vigane link või on juba loetelus."
+
+#: src/amule-remote-gui.cpp
+msgid "The daemon refused the request."
+msgstr ""
+
+#: src/amule-remote-gui.cpp
+#, fuzzy, c-format
+msgid "Could not delete the category: %s"
+msgstr "Ajutiste tõmmatavate failide kataloog"
 
 #: src/amule-remote-gui.cpp
 #, c-format
@@ -2226,6 +2235,14 @@ msgstr ""
 #, fuzzy
 msgid "No such category."
 msgstr "Sulge see vestlus-seanss."
+
+#: src/ExternalConn.cpp
+msgid "Malformed category request."
+msgstr ""
+
+#: src/ExternalConn.cpp
+msgid "The default category cannot be deleted."
+msgstr ""
 
 #: src/ExternalConn.cpp
 #, fuzzy

--- a/po/eu.po
+++ b/po/eu.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-31 22:39+0200\n"
+"POT-Creation-Date: 2026-09-01 11:32+0200\n"
 "PO-Revision-Date: 2026-08-31 15:29+0000\n"
 "Last-Translator: Piarres Beobide <pi@beobide.net>\n"
 "Language-Team: Euskara <librezale@librezale.org>\n"
@@ -1043,6 +1043,15 @@ msgstr ""
 #: src/amule-remote-gui.cpp src/ExternalConn.cpp
 msgid "Invalid link or already on list."
 msgstr "Lotura baliogabea edo zerrendan dagoeneko."
+
+#: src/amule-remote-gui.cpp
+msgid "The daemon refused the request."
+msgstr ""
+
+#: src/amule-remote-gui.cpp
+#, fuzzy, c-format
+msgid "Could not delete the category: %s"
+msgstr "Aldiroko deskarga fitxategientzat karpeta"
 
 #: src/amule-remote-gui.cpp
 #, c-format
@@ -2227,6 +2236,14 @@ msgstr ""
 #, fuzzy
 msgid "No such category."
 msgstr "Itxi elkarrizketa saio hau."
+
+#: src/ExternalConn.cpp
+msgid "Malformed category request."
+msgstr ""
+
+#: src/ExternalConn.cpp
+msgid "The default category cannot be deleted."
+msgstr ""
 
 #: src/ExternalConn.cpp
 #, fuzzy

--- a/po/fi.po
+++ b/po/fi.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-31 22:39+0200\n"
+"POT-Creation-Date: 2026-09-01 11:32+0200\n"
 "PO-Revision-Date: 2026-08-31 15:29+0000\n"
 "Last-Translator: Tapio Rantala <tapio.rantala@iki.fi>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -1043,6 +1043,15 @@ msgstr ""
 #: src/amule-remote-gui.cpp src/ExternalConn.cpp
 msgid "Invalid link or already on list."
 msgstr "Virheellinen linkki tai se on jo listalla."
+
+#: src/amule-remote-gui.cpp
+msgid "The daemon refused the request."
+msgstr ""
+
+#: src/amule-remote-gui.cpp
+#, fuzzy, c-format
+msgid "Could not delete the category: %s"
+msgstr "Kansio latauksen väliaikaisille tiedostoille"
 
 #: src/amule-remote-gui.cpp
 #, c-format
@@ -2227,6 +2236,14 @@ msgstr ""
 #, fuzzy
 msgid "No such category."
 msgstr "Sulje tämä keskustelu."
+
+#: src/ExternalConn.cpp
+msgid "Malformed category request."
+msgstr ""
+
+#: src/ExternalConn.cpp
+msgid "The default category cannot be deleted."
+msgstr ""
 
 #: src/ExternalConn.cpp
 #, fuzzy

--- a/po/fr.po
+++ b/po/fr.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-31 22:39+0200\n"
+"POT-Creation-Date: 2026-09-01 11:32+0200\n"
 "PO-Revision-Date: 2026-08-31 15:30+0000\n"
 "Last-Translator: Dylan Aïssi <bob.dybian@gmail.com>\n"
 "Language-Team: Français\n"
@@ -1049,6 +1049,15 @@ msgstr "Le noyau a rejeté ces répertoires partagés : %s"
 #: src/amule-remote-gui.cpp src/ExternalConn.cpp
 msgid "Invalid link or already on list."
 msgstr "Lien invalide ou déjà dans la liste."
+
+#: src/amule-remote-gui.cpp
+msgid "The daemon refused the request."
+msgstr ""
+
+#: src/amule-remote-gui.cpp
+#, fuzzy, c-format
+msgid "Could not delete the category: %s"
+msgstr "Impossible d’enregistrer le mot de passe d’amuleapi : %s"
 
 #: src/amule-remote-gui.cpp
 #, c-format
@@ -2217,6 +2226,14 @@ msgstr "Impossible d’enregistrer le mot de passe d’amuleapi : %s"
 #, fuzzy
 msgid "No such category."
 msgstr "Discussion introuvable"
+
+#: src/ExternalConn.cpp
+msgid "Malformed category request."
+msgstr ""
+
+#: src/ExternalConn.cpp
+msgid "The default category cannot be deleted."
+msgstr ""
 
 #: src/ExternalConn.cpp
 msgid "Missing chat session id"

--- a/po/gl.po
+++ b/po/gl.po
@@ -24,7 +24,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-31 22:39+0200\n"
+"POT-Creation-Date: 2026-09-01 11:32+0200\n"
 "PO-Revision-Date: 2026-08-31 15:30+0000\n"
 "Last-Translator: Pablo <parodper@gmail.com>\n"
 "Language-Team: http://forum.amule.org/index.php?topic=13883\n"
@@ -1064,6 +1064,15 @@ msgstr ""
 #: src/amule-remote-gui.cpp src/ExternalConn.cpp
 msgid "Invalid link or already on list."
 msgstr "Ligazón inválida ou xa presente na lista."
+
+#: src/amule-remote-gui.cpp
+msgid "The daemon refused the request."
+msgstr ""
+
+#: src/amule-remote-gui.cpp
+#, fuzzy, c-format
+msgid "Could not delete the category: %s"
+msgstr "Non se puido mover o ficheiro descargado a %s"
 
 #: src/amule-remote-gui.cpp
 #, c-format
@@ -2244,6 +2253,14 @@ msgstr ""
 #, fuzzy
 msgid "No such category."
 msgstr "Pechar esta conversa."
+
+#: src/ExternalConn.cpp
+msgid "Malformed category request."
+msgstr ""
+
+#: src/ExternalConn.cpp
+msgid "The default category cannot be deleted."
+msgstr ""
 
 #: src/ExternalConn.cpp
 #, fuzzy

--- a/po/he.po
+++ b/po/he.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-31 22:39+0200\n"
+"POT-Creation-Date: 2026-09-01 11:32+0200\n"
 "PO-Revision-Date: 2026-08-31 15:30+0000\n"
 "Last-Translator: Peace Kramer <kpeace1@gmail.com>\n"
 "Language-Team: Hebrew\n"
@@ -1033,6 +1033,15 @@ msgstr ""
 #: src/amule-remote-gui.cpp src/ExternalConn.cpp
 msgid "Invalid link or already on list."
 msgstr "קישור לא תקף או שכבר נמצא ברשימה."
+
+#: src/amule-remote-gui.cpp
+msgid "The daemon refused the request."
+msgstr ""
+
+#: src/amule-remote-gui.cpp
+#, fuzzy, c-format
+msgid "Could not delete the category: %s"
+msgstr "אתה כבר מנסה להוריד את הקובץ %s"
 
 #: src/amule-remote-gui.cpp
 #, c-format
@@ -2222,6 +2231,14 @@ msgstr ""
 #, fuzzy
 msgid "No such category."
 msgstr "סגור את הצ'אט הנוכחי."
+
+#: src/ExternalConn.cpp
+msgid "Malformed category request."
+msgstr ""
+
+#: src/ExternalConn.cpp
+msgid "The default category cannot be deleted."
+msgstr ""
 
 #: src/ExternalConn.cpp
 #, fuzzy

--- a/po/hr.po
+++ b/po/hr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-31 22:39+0200\n"
+"POT-Creation-Date: 2026-09-01 11:32+0200\n"
 "PO-Revision-Date: 2026-08-31 15:30+0000\n"
 "Last-Translator: Sebastiano Pistore <sebastiano.pistore.info@aol.com>\n"
 "Language-Team: https://github.com/amule-org/amule <forum@aMule.org>\n"
@@ -1031,6 +1031,15 @@ msgstr ""
 #: src/amule-remote-gui.cpp src/ExternalConn.cpp
 msgid "Invalid link or already on list."
 msgstr ""
+
+#: src/amule-remote-gui.cpp
+msgid "The daemon refused the request."
+msgstr ""
+
+#: src/amule-remote-gui.cpp
+#, fuzzy, c-format
+msgid "Could not delete the category: %s"
+msgstr "Vec pokusavate downloadovati fajl %s"
 
 #: src/amule-remote-gui.cpp
 #, c-format
@@ -2220,6 +2229,14 @@ msgstr ""
 #, fuzzy
 msgid "No such category."
 msgstr "Odstrani kategoriju"
+
+#: src/ExternalConn.cpp
+msgid "Malformed category request."
+msgstr ""
+
+#: src/ExternalConn.cpp
+msgid "The default category cannot be deleted."
+msgstr ""
 
 #: src/ExternalConn.cpp
 msgid "Missing chat session id"

--- a/po/hu.po
+++ b/po/hu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-31 22:39+0200\n"
+"POT-Creation-Date: 2026-09-01 11:32+0200\n"
 "PO-Revision-Date: 2026-08-31 15:31+0000\n"
 "Last-Translator: Dévai Tamás <gonosztopi@amule.org>\n"
 "Language-Team: Hungarian <hu@li.org>\n"
@@ -1045,6 +1045,15 @@ msgstr ""
 #: src/amule-remote-gui.cpp src/ExternalConn.cpp
 msgid "Invalid link or already on list."
 msgstr "Érvénytelen hivatkozás, vagy már rajta van a listán."
+
+#: src/amule-remote-gui.cpp
+msgid "The daemon refused the request."
+msgstr ""
+
+#: src/amule-remote-gui.cpp
+#, fuzzy, c-format
+msgid "Could not delete the category: %s"
+msgstr "A letöltött fájlok eltolása %s helyre sikertelen"
 
 #: src/amule-remote-gui.cpp
 #, c-format
@@ -2218,6 +2227,14 @@ msgstr ""
 #, fuzzy
 msgid "No such category."
 msgstr "Csevegési folyamat bezárása."
+
+#: src/ExternalConn.cpp
+msgid "Malformed category request."
+msgstr ""
+
+#: src/ExternalConn.cpp
+msgid "The default category cannot be deleted."
+msgstr ""
 
 #: src/ExternalConn.cpp
 #, fuzzy

--- a/po/it.po
+++ b/po/it.po
@@ -19,7 +19,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule 2.3.3\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-31 22:39+0200\n"
+"POT-Creation-Date: 2026-09-01 11:32+0200\n"
 "PO-Revision-Date: 2026-08-31 15:31+0000\n"
 "Last-Translator: got3nks <got3nks@users.noreply.github.com>\n"
 "Language-Team: SebastianoPistore.info@protonmail.ch\n"
@@ -1056,6 +1056,15 @@ msgstr "Il core ha rifiutato queste cartelle condivise:%s"
 #: src/amule-remote-gui.cpp src/ExternalConn.cpp
 msgid "Invalid link or already on list."
 msgstr "Collegamento non valido o già nella lista."
+
+#: src/amule-remote-gui.cpp
+msgid "The daemon refused the request."
+msgstr ""
+
+#: src/amule-remote-gui.cpp
+#, fuzzy, c-format
+msgid "Could not delete the category: %s"
+msgstr "Impossibile salvare la password di amuleapi: %s"
 
 #: src/amule-remote-gui.cpp
 #, c-format
@@ -2224,6 +2233,14 @@ msgstr "Impossibile salvare la password di amuleapi: %s"
 #, fuzzy
 msgid "No such category."
 msgstr "Sessione di chat inesistente"
+
+#: src/ExternalConn.cpp
+msgid "Malformed category request."
+msgstr ""
+
+#: src/ExternalConn.cpp
+msgid "The default category cannot be deleted."
+msgstr ""
 
 #: src/ExternalConn.cpp
 msgid "Missing chat session id"

--- a/po/ja.po
+++ b/po/ja.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-31 22:39+0200\n"
+"POT-Creation-Date: 2026-09-01 11:32+0200\n"
 "PO-Revision-Date: 2026-08-31 15:31+0000\n"
 "Last-Translator: \n"
 "Language-Team: Japanese\n"
@@ -1047,6 +1047,15 @@ msgstr ""
 #: src/amule-remote-gui.cpp src/ExternalConn.cpp
 msgid "Invalid link or already on list."
 msgstr "不正なリンク、またはリンクがすでにリストに入っています。"
+
+#: src/amule-remote-gui.cpp
+msgid "The daemon refused the request."
+msgstr ""
+
+#: src/amule-remote-gui.cpp
+#, fuzzy, c-format
+msgid "Could not delete the category: %s"
+msgstr "あなたはすでにファイル%sをダウンロードしようとしています"
 
 #: src/amule-remote-gui.cpp
 #, c-format
@@ -2229,6 +2238,14 @@ msgstr ""
 #, fuzzy
 msgid "No such category."
 msgstr "チャット・セションを閉じます。"
+
+#: src/ExternalConn.cpp
+msgid "Malformed category request."
+msgstr ""
+
+#: src/ExternalConn.cpp
+msgid "The default category cannot be deleted."
+msgstr ""
 
 #: src/ExternalConn.cpp
 #, fuzzy

--- a/po/ko_KR.po
+++ b/po/ko_KR.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-31 22:39+0200\n"
+"POT-Creation-Date: 2026-09-01 11:32+0200\n"
 "PO-Revision-Date: 2026-08-31 15:32+0000\n"
 "Last-Translator: Hyunju Kang <rexington@gmail.com>\n"
 "Language-Team: Korean <hoenny@daum.net>\n"
@@ -1050,6 +1050,15 @@ msgstr ""
 #: src/amule-remote-gui.cpp src/ExternalConn.cpp
 msgid "Invalid link or already on list."
 msgstr "유효하지 않은 링크거나 이미 목록에 존재합니다."
+
+#: src/amule-remote-gui.cpp
+msgid "The daemon refused the request."
+msgstr ""
+
+#: src/amule-remote-gui.cpp
+#, fuzzy, c-format
+msgid "Could not delete the category: %s"
+msgstr "이미 %s 파일을 내려받으려고 하고있음"
 
 #: src/amule-remote-gui.cpp
 #, c-format
@@ -2240,6 +2249,14 @@ msgstr ""
 #, fuzzy
 msgid "No such category."
 msgstr "이 채팅세션을 닫습니다."
+
+#: src/ExternalConn.cpp
+msgid "Malformed category request."
+msgstr ""
+
+#: src/ExternalConn.cpp
+msgid "The default category cannot be deleted."
+msgstr ""
 
 #: src/ExternalConn.cpp
 #, fuzzy

--- a/po/lt.po
+++ b/po/lt.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-31 22:39+0200\n"
+"POT-Creation-Date: 2026-09-01 11:32+0200\n"
 "PO-Revision-Date: 2026-08-31 15:32+0000\n"
 "Last-Translator: Dovydas Sankauskas <laisve@gmail.com>\n"
 "Language-Team: Lithuanian <komp_lt@konf.lt>\n"
@@ -1052,6 +1052,15 @@ msgstr ""
 #: src/amule-remote-gui.cpp src/ExternalConn.cpp
 msgid "Invalid link or already on list."
 msgstr "Klaidinga nuoroda arba failas sąraše jau yra."
+
+#: src/amule-remote-gui.cpp
+msgid "The daemon refused the request."
+msgstr ""
+
+#: src/amule-remote-gui.cpp
+#, fuzzy, c-format
+msgid "Could not delete the category: %s"
+msgstr "Failas %s jau yra atsiunčiamų failų sąraše"
 
 #: src/amule-remote-gui.cpp
 #, c-format
@@ -2250,6 +2259,14 @@ msgstr ""
 #, fuzzy
 msgid "No such category."
 msgstr "Baigti pokalbį ir užverti pokalbio kortelę."
+
+#: src/ExternalConn.cpp
+msgid "Malformed category request."
+msgstr ""
+
+#: src/ExternalConn.cpp
+msgid "The default category cannot be deleted."
+msgstr ""
 
 #: src/ExternalConn.cpp
 #, fuzzy

--- a/po/lv.po
+++ b/po/lv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-31 22:39+0200\n"
+"POT-Creation-Date: 2026-09-01 11:32+0200\n"
 "PO-Revision-Date: 2026-08-31 15:38+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -1016,6 +1016,15 @@ msgstr ""
 #: src/amule-remote-gui.cpp src/ExternalConn.cpp
 msgid "Invalid link or already on list."
 msgstr "Nederīga saite vai jau ir sarakstā."
+
+#: src/amule-remote-gui.cpp
+msgid "The daemon refused the request."
+msgstr ""
+
+#: src/amule-remote-gui.cpp
+#, c-format
+msgid "Could not delete the category: %s"
+msgstr ""
 
 #: src/amule-remote-gui.cpp
 #, c-format
@@ -2186,6 +2195,14 @@ msgstr ""
 #, fuzzy
 msgid "No such category."
 msgstr "Šāda ziņojumapmaiņas sesija nepastāv"
+
+#: src/ExternalConn.cpp
+msgid "Malformed category request."
+msgstr ""
+
+#: src/ExternalConn.cpp
+msgid "The default category cannot be deleted."
+msgstr ""
 
 #: src/ExternalConn.cpp
 msgid "Missing chat session id"

--- a/po/nl.po
+++ b/po/nl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-31 22:39+0200\n"
+"POT-Creation-Date: 2026-09-01 11:32+0200\n"
 "PO-Revision-Date: 2026-08-31 15:32+0000\n"
 "Last-Translator: Marcel Pol <marcel@timelord.nl>\n"
 "Language-Team: Dutch <nl@li.org>\n"
@@ -1045,6 +1045,15 @@ msgstr "De kern heeft deze gedeelde mappen geweigerd:%s"
 #: src/amule-remote-gui.cpp src/ExternalConn.cpp
 msgid "Invalid link or already on list."
 msgstr "Ongeldige link of al op de lijst."
+
+#: src/amule-remote-gui.cpp
+msgid "The daemon refused the request."
+msgstr ""
+
+#: src/amule-remote-gui.cpp
+#, fuzzy, c-format
+msgid "Could not delete the category: %s"
+msgstr "Kon het amuleapi-wachtwoord niet opslaan: %s"
 
 #: src/amule-remote-gui.cpp
 #, c-format
@@ -2214,6 +2223,14 @@ msgstr "Kon het amuleapi-wachtwoord niet opslaan: %s"
 #, fuzzy
 msgid "No such category."
 msgstr "Chatsessie onvindbaar"
+
+#: src/ExternalConn.cpp
+msgid "Malformed category request."
+msgstr ""
+
+#: src/ExternalConn.cpp
+msgid "The default category cannot be deleted."
+msgstr ""
 
 #: src/ExternalConn.cpp
 msgid "Missing chat session id"

--- a/po/nn.po
+++ b/po/nn.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-31 22:39+0200\n"
+"POT-Creation-Date: 2026-09-01 11:32+0200\n"
 "PO-Revision-Date: 2026-08-31 15:33+0000\n"
 "Last-Translator: Hallvor Brunstad <Hallvor_1976@yahoo.com>\n"
 "Language-Team: <i18n-nn@lister.ping.uio.no>\n"
@@ -1050,6 +1050,15 @@ msgstr ""
 #: src/amule-remote-gui.cpp src/ExternalConn.cpp
 msgid "Invalid link or already on list."
 msgstr "Ikkje gangbar lenkje eller lenka allereie på lista."
+
+#: src/amule-remote-gui.cpp
+msgid "The daemon refused the request."
+msgstr ""
+
+#: src/amule-remote-gui.cpp
+#, fuzzy, c-format
+msgid "Could not delete the category: %s"
+msgstr "Du freistar allereie nedlasting av fila %s"
 
 #: src/amule-remote-gui.cpp
 #, c-format
@@ -2241,6 +2250,14 @@ msgstr ""
 #, fuzzy
 msgid "No such category."
 msgstr "Stengje denne lynmeldingsøkta."
+
+#: src/ExternalConn.cpp
+msgid "Malformed category request."
+msgstr ""
+
+#: src/ExternalConn.cpp
+msgid "The default category cannot be deleted."
+msgstr ""
 
 #: src/ExternalConn.cpp
 #, fuzzy

--- a/po/pl.po
+++ b/po/pl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-31 22:39+0200\n"
+"POT-Creation-Date: 2026-09-01 11:32+0200\n"
 "PO-Revision-Date: 2026-08-31 15:33+0000\n"
 "Last-Translator: Michał Trzebiatowski <hippie_1968@hotmail.com>\n"
 "Language-Team: translationproject.org/team/pl.html <translation-team-pl@lists.sourceforge.net>\n"
@@ -1045,6 +1045,15 @@ msgstr ""
 #: src/amule-remote-gui.cpp src/ExternalConn.cpp
 msgid "Invalid link or already on list."
 msgstr "Nieprawidłowy lub znajdujący się już na liście link."
+
+#: src/amule-remote-gui.cpp
+msgid "The daemon refused the request."
+msgstr ""
+
+#: src/amule-remote-gui.cpp
+#, fuzzy, c-format
+msgid "Could not delete the category: %s"
+msgstr "Folder dla pobranych plików tymczasowych"
 
 #: src/amule-remote-gui.cpp
 #, c-format
@@ -2236,6 +2245,14 @@ msgstr ""
 #, fuzzy
 msgid "No such category."
 msgstr "Zamknij tę sesję czata."
+
+#: src/ExternalConn.cpp
+msgid "Malformed category request."
+msgstr ""
+
+#: src/ExternalConn.cpp
+msgid "The default category cannot be deleted."
+msgstr ""
 
 #: src/ExternalConn.cpp
 #, fuzzy

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-31 22:39+0200\n"
+"POT-Creation-Date: 2026-09-01 11:32+0200\n"
 "PO-Revision-Date: 2026-08-31 15:33+0000\n"
 "Last-Translator: Marcelo Jimenez <mroberto@users.sourceforge.com>\n"
 "Language-Team: Português (Brasileiro) <pt@li.org>\n"
@@ -1050,6 +1050,15 @@ msgstr "O núcleo rejeitou as seguintes pastas compartilhadas: %s"
 #: src/amule-remote-gui.cpp src/ExternalConn.cpp
 msgid "Invalid link or already on list."
 msgstr "Link inválido ou já está na lista."
+
+#: src/amule-remote-gui.cpp
+msgid "The daemon refused the request."
+msgstr ""
+
+#: src/amule-remote-gui.cpp
+#, fuzzy, c-format
+msgid "Could not delete the category: %s"
+msgstr "Não foi possível salvar a senha da amuleapi: %s"
 
 #: src/amule-remote-gui.cpp
 #, c-format
@@ -2218,6 +2227,14 @@ msgstr "Não foi possível salvar a senha da amuleapi: %s"
 #, fuzzy
 msgid "No such category."
 msgstr "Esta sessão de chat não existe"
+
+#: src/ExternalConn.cpp
+msgid "Malformed category request."
+msgstr ""
+
+#: src/ExternalConn.cpp
+msgid "The default category cannot be deleted."
+msgstr ""
 
 #: src/ExternalConn.cpp
 msgid "Missing chat session id"

--- a/po/pt_PT.po
+++ b/po/pt_PT.po
@@ -17,7 +17,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-31 22:39+0200\n"
+"POT-Creation-Date: 2026-09-01 11:32+0200\n"
 "PO-Revision-Date: 2026-08-31 15:34+0000\n"
 "Last-Translator: Luís Picciochi Oliveira <Pitxyoki@Gmail.com>\n"
 "Language-Team: Portuguese <traduz@debianpt.org>\n"
@@ -1049,6 +1049,15 @@ msgstr ""
 #: src/amule-remote-gui.cpp src/ExternalConn.cpp
 msgid "Invalid link or already on list."
 msgstr "Ligação inválida ou já na lista."
+
+#: src/amule-remote-gui.cpp
+msgid "The daemon refused the request."
+msgstr ""
+
+#: src/amule-remote-gui.cpp
+#, fuzzy, c-format
+msgid "Could not delete the category: %s"
+msgstr "Pasta para ficheiros temporários"
 
 #: src/amule-remote-gui.cpp
 #, c-format
@@ -2233,6 +2242,14 @@ msgstr ""
 #, fuzzy
 msgid "No such category."
 msgstr "Fechar esta conversa."
+
+#: src/ExternalConn.cpp
+msgid "Malformed category request."
+msgstr ""
+
+#: src/ExternalConn.cpp
+msgid "The default category cannot be deleted."
+msgstr ""
 
 #: src/ExternalConn.cpp
 #, fuzzy

--- a/po/ro.po
+++ b/po/ro.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-31 22:39+0200\n"
+"POT-Creation-Date: 2026-09-01 11:32+0200\n"
 "PO-Revision-Date: 2026-08-31 15:34+0000\n"
 "Last-Translator: Angelescu Constantin <titus0818@yahoo.com>\n"
 "Language-Team: English <kde-i18n-doc@kde.org>\n"
@@ -1042,6 +1042,15 @@ msgstr ""
 #: src/amule-remote-gui.cpp src/ExternalConn.cpp
 msgid "Invalid link or already on list."
 msgstr "Legătură nevalidă sau care este deja în listă."
+
+#: src/amule-remote-gui.cpp
+msgid "The daemon refused the request."
+msgstr ""
+
+#: src/amule-remote-gui.cpp
+#, fuzzy, c-format
+msgid "Could not delete the category: %s"
+msgstr "Dosar pentru fișiere descărcate temporar"
 
 #: src/amule-remote-gui.cpp
 #, c-format
@@ -2233,6 +2242,14 @@ msgstr ""
 #, fuzzy
 msgid "No such category."
 msgstr "Închide această sesiune de chat."
+
+#: src/ExternalConn.cpp
+msgid "Malformed category request."
+msgstr ""
+
+#: src/ExternalConn.cpp
+msgid "The default category cannot be deleted."
+msgstr ""
 
 #: src/ExternalConn.cpp
 #, fuzzy

--- a/po/ru.po
+++ b/po/ru.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-31 22:39+0200\n"
+"POT-Creation-Date: 2026-09-01 11:32+0200\n"
 "PO-Revision-Date: 2026-08-31 15:34+0000\n"
 "Last-Translator: Radist Morse <radist.morse@gmail.com>\n"
 "Language-Team: Russian <kde-russian@lists.kde.ru>\n"
@@ -1054,6 +1054,15 @@ msgstr "Ядро отклонило следующие общие папки:%s"
 #: src/amule-remote-gui.cpp src/ExternalConn.cpp
 msgid "Invalid link or already on list."
 msgstr "Ссылка неверна или уже в списке."
+
+#: src/amule-remote-gui.cpp
+msgid "The daemon refused the request."
+msgstr ""
+
+#: src/amule-remote-gui.cpp
+#, fuzzy, c-format
+msgid "Could not delete the category: %s"
+msgstr "Не удалось сохранить пароль amuleapi: %s"
 
 #: src/amule-remote-gui.cpp
 #, c-format
@@ -2234,6 +2243,14 @@ msgstr "Не удалось сохранить пароль amuleapi: %s"
 #, fuzzy
 msgid "No such category."
 msgstr "Такой беседы нет"
+
+#: src/ExternalConn.cpp
+msgid "Malformed category request."
+msgstr ""
+
+#: src/ExternalConn.cpp
+msgid "The default category cannot be deleted."
+msgstr ""
 
 #: src/ExternalConn.cpp
 msgid "Missing chat session id"

--- a/po/sl.po
+++ b/po/sl.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-31 22:39+0200\n"
+"POT-Creation-Date: 2026-09-01 11:32+0200\n"
 "PO-Revision-Date: 2026-08-31 15:35+0000\n"
 "Last-Translator: Jure Repinc <jlp@holodeck1.com>\n"
 "Language-Team: Slovenian\n"
@@ -1048,6 +1048,15 @@ msgstr ""
 #: src/amule-remote-gui.cpp src/ExternalConn.cpp
 msgid "Invalid link or already on list."
 msgstr "Neveljavna povezava oz. je že na seznamu."
+
+#: src/amule-remote-gui.cpp
+msgid "The daemon refused the request."
+msgstr ""
+
+#: src/amule-remote-gui.cpp
+#, fuzzy, c-format
+msgid "Could not delete the category: %s"
+msgstr "Mapa za začasne datoteke prejemanj"
 
 #: src/amule-remote-gui.cpp
 #, c-format
@@ -2247,6 +2256,14 @@ msgstr ""
 #, fuzzy
 msgid "No such category."
 msgstr "Zapri to pogovorno sejo."
+
+#: src/ExternalConn.cpp
+msgid "Malformed category request."
+msgstr ""
+
+#: src/ExternalConn.cpp
+msgid "The default category cannot be deleted."
+msgstr ""
 
 #: src/ExternalConn.cpp
 #, fuzzy

--- a/po/sq.po
+++ b/po/sq.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-31 22:39+0200\n"
+"POT-Creation-Date: 2026-09-01 11:32+0200\n"
 "PO-Revision-Date: 2026-08-31 15:35+0000\n"
 "Last-Translator: Fation <dj_barthezz@linuxmail.org lushnja_corps@hotmail.Language-Team:\n"
 "Language: sq\n"
@@ -1047,6 +1047,15 @@ msgstr ""
 #: src/amule-remote-gui.cpp src/ExternalConn.cpp
 msgid "Invalid link or already on list."
 msgstr "Link i pavlere ose qe eshte ne liste."
+
+#: src/amule-remote-gui.cpp
+msgid "The daemon refused the request."
+msgstr ""
+
+#: src/amule-remote-gui.cpp
+#, fuzzy, c-format
+msgid "Could not delete the category: %s"
+msgstr "Jeni duke u perpjekur te shkarkoni edhe njehere tjeter kete fail %s"
 
 #: src/amule-remote-gui.cpp
 #, c-format
@@ -2236,6 +2245,14 @@ msgstr ""
 #, fuzzy
 msgid "No such category."
 msgstr "Mbylle kete sesion chati."
+
+#: src/ExternalConn.cpp
+msgid "Malformed category request."
+msgstr ""
+
+#: src/ExternalConn.cpp
+msgid "The default category cannot be deleted."
+msgstr ""
 
 #: src/ExternalConn.cpp
 #, fuzzy

--- a/po/sv.po
+++ b/po/sv.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-31 22:39+0200\n"
+"POT-Creation-Date: 2026-09-01 11:32+0200\n"
 "PO-Revision-Date: 2026-08-31 15:35+0000\n"
 "Last-Translator: raffe <raffe@localhost.se>\n"
 "Language-Team: Swedish <tp-sv@listor.tp-sv.se>\n"
@@ -1041,6 +1041,15 @@ msgstr ""
 #: src/amule-remote-gui.cpp src/ExternalConn.cpp
 msgid "Invalid link or already on list."
 msgstr "Felaktig länk eller redan i listan."
+
+#: src/amule-remote-gui.cpp
+msgid "The daemon refused the request."
+msgstr ""
+
+#: src/amule-remote-gui.cpp
+#, fuzzy, c-format
+msgid "Could not delete the category: %s"
+msgstr "Mapp för temporära nerladdningsfiler"
 
 #: src/amule-remote-gui.cpp
 #, c-format
@@ -2225,6 +2234,14 @@ msgstr ""
 #, fuzzy
 msgid "No such category."
 msgstr "Stäng denna chat-session."
+
+#: src/ExternalConn.cpp
+msgid "Malformed category request."
+msgstr ""
+
+#: src/ExternalConn.cpp
+msgid "The default category cannot be deleted."
+msgstr ""
 
 #: src/ExternalConn.cpp
 #, fuzzy

--- a/po/ta.po
+++ b/po/ta.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-31 22:39+0200\n"
+"POT-Creation-Date: 2026-09-01 11:32+0200\n"
 "PO-Revision-Date: 2026-08-31 15:38+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -1000,6 +1000,15 @@ msgstr ""
 
 #: src/amule-remote-gui.cpp src/ExternalConn.cpp
 msgid "Invalid link or already on list."
+msgstr ""
+
+#: src/amule-remote-gui.cpp
+msgid "The daemon refused the request."
+msgstr ""
+
+#: src/amule-remote-gui.cpp
+#, c-format
+msgid "Could not delete the category: %s"
 msgstr ""
 
 #: src/amule-remote-gui.cpp
@@ -2163,6 +2172,14 @@ msgstr ""
 
 #: src/ExternalConn.cpp
 msgid "No such category."
+msgstr ""
+
+#: src/ExternalConn.cpp
+msgid "Malformed category request."
+msgstr ""
+
+#: src/ExternalConn.cpp
+msgid "The default category cannot be deleted."
 msgstr ""
 
 #: src/ExternalConn.cpp

--- a/po/tr.po
+++ b/po/tr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-31 22:39+0200\n"
+"POT-Creation-Date: 2026-09-01 11:32+0200\n"
 "PO-Revision-Date: 2026-08-31 15:36+0000\n"
 "Last-Translator: \n"
 "Language-Team: Turkish <li@li.org>\n"
@@ -1042,6 +1042,15 @@ msgstr "Çekirdek şu paylaşılan dizinleri reddetti: %s"
 #: src/amule-remote-gui.cpp src/ExternalConn.cpp
 msgid "Invalid link or already on list."
 msgstr "Geçersiz bağlantı veya zaten listede mevcut."
+
+#: src/amule-remote-gui.cpp
+msgid "The daemon refused the request."
+msgstr ""
+
+#: src/amule-remote-gui.cpp
+#, fuzzy, c-format
+msgid "Could not delete the category: %s"
+msgstr "amuleapi parolası kaydedilemedi: %s"
 
 #: src/amule-remote-gui.cpp
 #, c-format
@@ -2210,6 +2219,14 @@ msgstr "amuleapi parolası kaydedilemedi: %s"
 #, fuzzy
 msgid "No such category."
 msgstr "Böyle bir sohbet oturumu yok"
+
+#: src/ExternalConn.cpp
+msgid "Malformed category request."
+msgstr ""
+
+#: src/ExternalConn.cpp
+msgid "The default category cannot be deleted."
+msgstr ""
 
 #: src/ExternalConn.cpp
 msgid "Missing chat session id"

--- a/po/uk.po
+++ b/po/uk.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-31 22:39+0200\n"
+"POT-Creation-Date: 2026-09-01 11:32+0200\n"
 "PO-Revision-Date: 2026-08-31 15:36+0000\n"
 "Last-Translator: Oleksandr Kovalenko <alx.kovalenko@gmail.com>\n"
 "Language-Team: Ukrainian <translation@linux.org.ua>\n"
@@ -1043,6 +1043,15 @@ msgstr ""
 #: src/amule-remote-gui.cpp src/ExternalConn.cpp
 msgid "Invalid link or already on list."
 msgstr "Недопустиме посилання або вже в переліку."
+
+#: src/amule-remote-gui.cpp
+msgid "The daemon refused the request."
+msgstr ""
+
+#: src/amule-remote-gui.cpp
+#, fuzzy, c-format
+msgid "Could not delete the category: %s"
+msgstr "Тека для тимчасових звантажуваних файлів"
 
 #: src/amule-remote-gui.cpp
 #, c-format
@@ -2246,6 +2255,14 @@ msgstr ""
 #, fuzzy
 msgid "No such category."
 msgstr "Закрити цю розмову."
+
+#: src/ExternalConn.cpp
+msgid "Malformed category request."
+msgstr ""
+
+#: src/ExternalConn.cpp
+msgid "The default category cannot be deleted."
+msgstr ""
 
 #: src/ExternalConn.cpp
 #, fuzzy

--- a/po/vi.po
+++ b/po/vi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-31 22:39+0200\n"
+"POT-Creation-Date: 2026-09-01 11:32+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -999,6 +999,15 @@ msgstr ""
 
 #: src/amule-remote-gui.cpp src/ExternalConn.cpp
 msgid "Invalid link or already on list."
+msgstr ""
+
+#: src/amule-remote-gui.cpp
+msgid "The daemon refused the request."
+msgstr ""
+
+#: src/amule-remote-gui.cpp
+#, c-format
+msgid "Could not delete the category: %s"
 msgstr ""
 
 #: src/amule-remote-gui.cpp
@@ -2162,6 +2171,14 @@ msgstr ""
 
 #: src/ExternalConn.cpp
 msgid "No such category."
+msgstr ""
+
+#: src/ExternalConn.cpp
+msgid "Malformed category request."
+msgstr ""
+
+#: src/ExternalConn.cpp
+msgid "The default category cannot be deleted."
 msgstr ""
 
 #: src/ExternalConn.cpp

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-31 22:39+0200\n"
+"POT-Creation-Date: 2026-09-01 11:32+0200\n"
 "PO-Revision-Date: 2026-08-31 15:36+0000\n"
 "Last-Translator: Mike Akiba <mike2718@gmail.com>\n"
 "Language-Team: Chinese Simplified <kde-i18n-doc@kde.org>\n"
@@ -1046,6 +1046,15 @@ msgstr "核心拒绝了这些共享的文件夹：%s"
 #: src/amule-remote-gui.cpp src/ExternalConn.cpp
 msgid "Invalid link or already on list."
 msgstr "非法链接或已经存在列表中。"
+
+#: src/amule-remote-gui.cpp
+msgid "The daemon refused the request."
+msgstr ""
+
+#: src/amule-remote-gui.cpp
+#, fuzzy, c-format
+msgid "Could not delete the category: %s"
+msgstr "无法保存 amuleapi 密码：%s"
 
 #: src/amule-remote-gui.cpp
 #, c-format
@@ -2214,6 +2223,14 @@ msgstr "无法保存 amuleapi 密码：%s"
 #, fuzzy
 msgid "No such category."
 msgstr "没有这样的聊天会话"
+
+#: src/ExternalConn.cpp
+msgid "Malformed category request."
+msgstr ""
+
+#: src/ExternalConn.cpp
+msgid "The default category cannot be deleted."
+msgstr ""
 
 #: src/ExternalConn.cpp
 msgid "Missing chat session id"

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-08-31 22:39+0200\n"
+"POT-Creation-Date: 2026-09-01 11:32+0200\n"
 "PO-Revision-Date: 2026-08-31 15:37+0000\n"
 "Last-Translator: Wayne Su <mstarmstar@gmail.com>\n"
 "Language-Team: \n"
@@ -1046,6 +1046,15 @@ msgstr ""
 #: src/amule-remote-gui.cpp src/ExternalConn.cpp
 msgid "Invalid link or already on list."
 msgstr "無效連結或已在清單中。"
+
+#: src/amule-remote-gui.cpp
+msgid "The daemon refused the request."
+msgstr ""
+
+#: src/amule-remote-gui.cpp
+#, fuzzy, c-format
+msgid "Could not delete the category: %s"
+msgstr "暫存資料夾"
 
 #: src/amule-remote-gui.cpp
 #, c-format
@@ -2223,6 +2232,14 @@ msgstr ""
 #, fuzzy
 msgid "No such category."
 msgstr "結束本次交談。"
+
+#: src/ExternalConn.cpp
+msgid "Malformed category request."
+msgstr ""
+
+#: src/ExternalConn.cpp
+msgid "The default category cannot be deleted."
+msgstr ""
 
 #: src/ExternalConn.cpp
 #, fuzzy

--- a/src/ExternalConn.cpp
+++ b/src/ExternalConn.cpp
@@ -4242,12 +4242,32 @@ CECPacket *CECServerSocket::ProcessRequest2(const CECPacket *request)
 		}
 		break;
 	case EC_OP_DELETE_CATEGORY:
-		if (request->GetTagCount() == 1) {
-			uint32 cat = request->GetFirstTagSafe()->GetInt();
-			// this does not only update the gui, but actually deletes the cat
-			Notify_CategoryDelete(cat);
+		// Rejections answer EC_OP_FAILED, not the blanket EC_OP_NOOP this used
+		// to send: the guards downstream discard these silently, so a client
+		// could not tell a completed delete from a discarded one
+		// (amule-org/amule#1231). Never attach EC_TAG_CATEGORY_PATH -- on a
+		// failed category command clients read it as success (#1213).
+		if (request->GetTagCount() != 1) {
+			response = new CECPacket(EC_OP_FAILED);
+			response->AddTag(CECTag(EC_TAG_STRING, wxTRANSLATE("Malformed category request.")));
+		} else {
+			const uint32 cat = request->GetFirstTagSafe()->GetInt();
+			if (cat == 0) {
+				// The "all downloads" bucket, which CategoryDelete refuses.
+				response = new CECPacket(EC_OP_FAILED);
+				response->AddTag(CECTag(EC_TAG_CATEGORY, cat));
+				response->AddTag(CECTag(EC_TAG_STRING,
+					wxTRANSLATE("The default category cannot be deleted.")));
+			} else if (cat >= theApp->glob_prefs->GetCatCount()) {
+				response = new CECPacket(EC_OP_FAILED);
+				response->AddTag(CECTag(EC_TAG_CATEGORY, cat));
+				response->AddTag(CECTag(EC_TAG_STRING, wxTRANSLATE("No such category.")));
+			} else {
+				// this does not only update the gui, but actually deletes the cat
+				Notify_CategoryDelete(cat);
+				response = new CECPacket(EC_OP_NOOP);
+			}
 		}
-		response = new CECPacket(EC_OP_NOOP);
 		break;
 
 	//

--- a/src/Preferences.h
+++ b/src/Preferences.h
@@ -555,6 +555,10 @@ public:
 	// Download Categories
 	uint32 AddCat(Category_Struct *cat);
 	void RemoveCat(size_t index);
+	//! May the caller commit the removal now? Always yes here: this process
+	//! owns the list. amulegui hides this to defer until the daemon replies
+	//! (amule-org/amule#1231); bound by static type, like RemoveCat already is.
+	bool RequestRemoveCat(size_t) { return true; }
 	uint32 GetCatCount();
 	Category_Struct *GetCategory(size_t index);
 	const CPath &GetCatPath(uint8 index);

--- a/src/TransferWnd.cpp
+++ b/src/TransferWnd.cpp
@@ -281,21 +281,35 @@ void CTransferWnd::OnDelCategory(wxCommandEvent &WXUNUSED(event))
 
 void CTransferWnd::RemoveCategory(int index)
 {
-	if (index > 0) {
-		theApp->downloadqueue->ResetCatParts(index);
-		theApp->glob_prefs->RemoveCat(index);
-		RemoveCategoryPage(index);
-		if (theApp->glob_prefs->GetCatCount() == 1) {
-			thePrefs::SetAllcatFilter(acfAll);
-		}
-		theApp->glob_prefs->SaveCats();
-		theApp->amuledlg->m_searchwnd->UpdateCatChoice();
-		// RemoveCat() asks for a re-walk (the category's directory leaves the
-		// shareset). Run it here behind a progress dialog rather than letting
-		// it land silently on a core tick -- CPreferences is shared with the
-		// daemon, so it cannot raise one itself.
-		ReloadSharedFilesIfPending(this);
+	if (index <= 0) {
+		return;
 	}
+	// Granted immediately in the monolithic build; in amulegui it goes out as
+	// EC_OP_DELETE_CATEGORY and the reply handler commits instead, so a
+	// refused delete cannot close the tab (amule-org/amule#1231).
+	if (theApp->glob_prefs->RequestRemoveCat(index)) {
+		CommitRemoveCategory(index);
+	}
+}
+
+void CTransferWnd::CommitRemoveCategory(int index)
+{
+	if (index <= 0) {
+		return;
+	}
+	theApp->downloadqueue->ResetCatParts(index);
+	theApp->glob_prefs->RemoveCat(index);
+	RemoveCategoryPage(index);
+	if (theApp->glob_prefs->GetCatCount() == 1) {
+		thePrefs::SetAllcatFilter(acfAll);
+	}
+	theApp->glob_prefs->SaveCats();
+	theApp->amuledlg->m_searchwnd->UpdateCatChoice();
+	// RemoveCat() asks for a re-walk (the category's directory leaves the
+	// shareset). Run it here behind a progress dialog rather than letting
+	// it land silently on a core tick -- CPreferences is shared with the
+	// daemon, so it cannot raise one itself.
+	ReloadSharedFilesIfPending(this);
 }
 
 void CTransferWnd::RemoveCategoryPage(int index)

--- a/src/TransferWnd.h
+++ b/src/TransferWnd.h
@@ -82,6 +82,9 @@ public:
 	 * Remove category
 	 */
 	void RemoveCategory(int index);
+	//! Everything that follows a category really being gone. Split out so the
+	//! monolithic build can run it inline and amulegui from the EC reply.
+	void CommitRemoveCategory(int index);
 	void RemoveCategoryPage(int index);
 
 	/**

--- a/src/amule-remote-gui.cpp
+++ b/src/amule-remote-gui.cpp
@@ -1720,6 +1720,43 @@ class CCatHandler : public CECPacketHandlerBase
 	virtual void HandlePacket(const CECPacket *packet);
 };
 
+// EC_OP_DELETE_CATEGORY reply. Holds the index because a successful delete
+// answers a bare EC_OP_NOOP; only the failures name the category.
+class CCatDeleteHandler : public CECPacketHandlerBase
+{
+public:
+	explicit CCatDeleteHandler(uint8 cat)
+	: m_cat(cat)
+	{
+	}
+	virtual void HandlePacket(const CECPacket *packet);
+	// Socket died mid-request: free ourselves (DiscardRequestQueue clears the
+	// queue without deleting) and commit nothing -- whether the daemon did the
+	// delete before the drop is exactly what is unknown.
+	virtual void AbortPendingRequest() { delete this; }
+
+private:
+	uint8 m_cat;
+};
+
+void CCatDeleteHandler::HandlePacket(const CECPacket *packet)
+{
+	if (packet->GetOpCode() == EC_OP_FAILED) {
+		// Nothing was removed locally, so there is nothing to undo. Report the
+		// reason: a rejected index means our list is behind the core's.
+		const CECTag *msgTag = packet->GetTagByName(EC_TAG_STRING);
+		const wxString reason = msgTag ? wxGetTranslation(msgTag->GetStringData())
+					       : wxString(_("The daemon refused the request."));
+		const wxString msg = CFormat(_("Could not delete the category: %s")) % reason;
+		// Modal off the OnPacketReceived stack, as the handlers above do.
+		wxTheApp->CallAfter([msg]() { wxMessageBox(msg, _("ERROR"), wxOK); });
+	} else if (theApp->amuledlg && theApp->amuledlg->m_transferwnd) {
+		// Confirmed gone core-side: same commit the monolithic build runs inline.
+		theApp->amuledlg->m_transferwnd->CommitRemoveCategory(m_cat);
+	}
+	delete this;
+}
+
 void CCatHandler::HandlePacket(const CECPacket *packet)
 {
 	if (packet->GetOpCode() == EC_OP_FAILED) {
@@ -1787,13 +1824,17 @@ bool CPreferencesRem::UpdateCategory(
 	return true;
 }
 
-void CPreferencesRem::RemoveCat(uint8 cat)
+bool CPreferencesRem::RequestRemoveCat(size_t cat)
 {
+	const uint8 cat8 = static_cast<uint8>(cat);
 	CECPacket req(EC_OP_DELETE_CATEGORY);
-	CEC_Category_Tag tag(cat, EC_DETAIL_CMD);
+	CEC_Category_Tag tag(cat8, EC_DETAIL_CMD);
 	req.AddTag(tag);
-	m_conn->SendPacket(&req);
-	CPreferences::RemoveCat(cat);
+	// SendRequest, not SendPacket: the reply decides whether this happened.
+	// Fire-and-forget updated the local list regardless, so a discarded delete
+	// shifted this client's indices against the core's -- and ids are positional.
+	m_conn->SendRequest(new CCatDeleteHandler(cat8), &req);
+	return false;
 }
 
 //

--- a/src/amule-remote-gui.h
+++ b/src/amule-remote-gui.h
@@ -123,7 +123,10 @@ public:
 		uint32 color,
 		uint8 prio);
 
-	void RemoveCat(uint8 cat);
+	//! Sends EC_OP_DELETE_CATEGORY and always answers false: the daemon owns
+	//! the list, so CCatDeleteHandler commits only once it agrees. size_t to
+	//! match the base it hides, so the shared call site widens.
+	bool RequestRemoveCat(size_t cat);
 
 	bool LoadRemote();
 	void SendToRemote();


### PR DESCRIPTION
Closes #1231.

### The problem

The handler answered `EC_OP_NOOP` unconditionally, with the reply built outside the tag-count check, so three requests that delete nothing were reported as successful: a malformed request, index `0`, and an index past the end. The guards that discard them are correct and deliberate - `MuleNotify::CategoryDelete` refuses index 0, `CPreferences::RemoveCat` is bounds-checked - they were simply never reported.

Category ids are positional, so a client holding a stale index is told its next delete succeeded and its list silently diverges from the core's. The same divergence on the update path produced the crash in #1227.

### Daemon

Validate before notifying and answer `EC_OP_FAILED` + `EC_TAG_CATEGORY` + `EC_TAG_STRING`, the shape #1228 established for `EC_OP_UPDATE_CATEGORY`. `EC_TAG_CATEGORY_PATH` is deliberately never attached: on a failed category command clients read it as success (#1213). Out-of-range reuses the existing `"No such category."`; the other two need one string each.

### Old EC clients are unaffected

A successful delete still answers `EC_OP_NOOP`, so nothing changes on the path they take. A reply to a request sent with `SendPacket` carries a null handler, which `CRemoteConnect::OnPacketReceived` pops and discards without reading the opcode.

Against an **older core**, new amulegui neither breaks nor improves: that handler always answers `EC_OP_NOOP`, so a discarded delete still commits locally, exactly as today. The truthfulness is core-gated.

### amulegui commits from the reply, not ahead of it

`CPreferencesRem::RemoveCat` sent fire-and-forget then removed the category locally regardless, so a refused delete closed the tab of a category the core still held. The send moves to `RequestRemoveCat`, which answers `false` so nothing commits locally; `CCatDeleteHandler` commits on `EC_OP_NOOP` or reports the daemon's reason on `EC_OP_FAILED`, and frees itself on `AbortPendingRequest` since a dropped socket leaves the outcome unknown. With the send gone the old `RemoveCat` override was identical to the base and is dropped.

One behaviour change lands against any core: the category disappears after a round trip rather than instantly, and a connection dropping in between leaves it in place.

### The shared GUI path is preserved, not duplicated

`CTransferWnd::RemoveCategory` splits into a request and a `CommitRemoveCategory` holding every step that follows a category really being gone. The monolithic build reaches it inline, because `CPreferences::RequestRemoveCat` answers `true` and that process owns the list; amulegui reaches the same function from the reply handler. The two overloads bind by static type, exactly as `CTransferWnd` already binds `RemoveCat`. Both take `size_t` so the shared call site widens rather than narrows.

### Strings stay English on the wire

`wxTRANSLATE` expands to the bare literal, so the daemon sends English regardless of locale; amuleapi never calls `wxGetTranslation` and relays verbatim; amulegui translates for display, as its other handlers do.

### Verification

Two concurrent `DELETE /categories/1` through amuleapi, one winning and the other addressing an index the daemon no longer has:

| Build | Result |
|---|---|
| pre-fix | `204 204` every iteration - the loser reports success for a delete that did nothing |
| post-fix | `400 amuled_rejected` `"No such category."` on the first iteration |

amulegui verified by hand against a throwaway daemon: with a category deleted out from under it by another client, deleting that tab now reports *"No such category."* and leaves the tab in place; deleting one the core still holds commits as before.

47/47 ctest; monolithic, daemon, amulegui and amuleapi all build; clang-format and both clang-tidy tiers clean with 0 compiler errors. amuleapi needed no change - it already maps `EC_OP_FAILED` to `400` - and its own guards mean it cannot reach the index-0 or malformed branches, so those two are verified by construction.
