### PR TITLE
ci(packaging): source-build and cache the deps that lost macOS Intel bottles

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -271,11 +271,51 @@ jobs:
           # x86_64 Homebrew at /usr/local so we can fetch x86_64 bottles
           # for our deps. The native /opt/homebrew install is left alone.
           arch -x86_64 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+      - name: Update Homebrew
+        run: ${{ matrix.archcmd }} ${{ matrix.brew_prefix }}/bin/brew update
+      # Homebrew dropped macOS Intel support in September 2026, so pcre2
+      # and openssl@3 now publish arm64_* macOS tags only (plus
+      # x86_64_linux, a Linuxbrew ELF build unusable on a Mac). The
+      # x86_64 prefix cannot be filled from bottles alone: `brew install`
+      # aborts with "no bottle available!" before reaching the rest of
+      # the list. Building the two from source costs ~68 min, so the
+      # kegs are cached; only a version bump pays that again.
+      - name: Resolve x86_64 source-built versions
+        id: intelkegs
+        if: matrix.arch == 'x86_64'
+        run: |
+          # Key on the versions brew resolved after `update`, not a
+          # literal: a stale keg must never shadow a newer release.
+          V=$(${{ matrix.archcmd }} ${{ matrix.brew_prefix }}/bin/brew info --json=v2 pcre2 openssl@3 \
+              | python3 -c 'import sys,json;print("-".join(f["versions"]["stable"] for f in json.load(sys.stdin)["formulae"]))')
+          echo "vers=$V" >> "$GITHUB_OUTPUT"
+      - name: Restore x86_64 source-built kegs
+        if: matrix.arch == 'x86_64' && github.event_name != 'workflow_call'
+        uses: actions/cache/restore@v6
+        with:
+          path: |
+            /usr/local/Cellar/pcre2
+            /usr/local/Cellar/openssl@3
+            /usr/local/opt/pcre2
+            /usr/local/opt/openssl@3
+          key: ${{ runner.os }}-macos-intel-kegs-${{ steps.intelkegs.outputs.vers }}
       - name: Install Homebrew deps
         run: |
           BREW=${{ matrix.brew_prefix }}/bin/brew
-          ${{ matrix.archcmd }} $BREW update
-          ${{ matrix.archcmd }} $BREW install --quiet \
+          if [ "${{ matrix.arch }}" = "x86_64" ]; then
+              # No-op when the cache restored a keg of the same version.
+              ${{ matrix.archcmd }} $BREW install --build-from-source pcre2 openssl@3
+              # A restored keg has no /usr/local/{lib,include} symlinks --
+              # only the Cellar and opt paths are cached -- so relink or
+              # dependents will not find the headers. openssl@3 is keg-only
+              # and is found through its opt path, which is cached.
+              ${{ matrix.archcmd }} $BREW link --overwrite pcre2
+          fi
+          # NOT --quiet: when the next formula loses its Intel bottle,
+          # the reason has to be in the log. It was suppressed here, so
+          # this step failed with a bare exit 1 and the breakage only
+          # surfaced two steps later as "ccache: command not found".
+          ${{ matrix.archcmd }} $BREW install \
               cmake wxwidgets cryptopp libupnp gd gettext boost dylibbundler libmaxminddb \
               ccache
           # Prepend the matrix-selected brew prefix to PATH so every
@@ -284,6 +324,16 @@ jobs:
           # is keg-only on macOS; add msgfmt to PATH for the NLS probe.
           echo "${{ matrix.brew_prefix }}/bin" >> "$GITHUB_PATH"
           echo "${{ matrix.brew_prefix }}/opt/gettext/bin" >> "$GITHUB_PATH"
+      - name: Save x86_64 source-built kegs
+        if: matrix.arch == 'x86_64' && github.event_name != 'workflow_call'
+        uses: actions/cache/save@v6
+        with:
+          path: |
+            /usr/local/Cellar/pcre2
+            /usr/local/Cellar/openssl@3
+            /usr/local/opt/pcre2
+            /usr/local/opt/openssl@3
+          key: ${{ runner.os }}-macos-intel-kegs-${{ steps.intelkegs.outputs.vers }}
       - name: Restore ccache
         if: github.event_name != 'workflow_call'
         uses: actions/cache/restore@v6


### PR DESCRIPTION
The macOS x86_64 packaging job has failed since 31 Aug. Not our code - Homebrew has formally dropped macOS Intel support.

### What happens

```
##[error]pcre2: no bottle available!
##[error]openssl@3: no bottle available!
```

`brew install` aborts at the first missing bottle, before reaching the rest of the list, so the step exits 1 and the breakage surfaces two steps later as the misleading `ccache: command not found`. `--quiet` suppressed the reason entirely.

Both formulae now publish `arm64_*` macOS tags only, plus `x86_64_linux` - a Linuxbrew ELF build, unusable on a Mac. Homebrew states it directly in the log:

> We do not provide support for this platform (as-of September 2026, announced August 2025). Apple have dropped Intel x86_64 support in macOS Golden Gate (27). GitHub Actions are dropping macOS Intel x86_64 runners in 2027.

### The change

Build those two from source, for x86_64 only - arm64 still has bottles for everything and must not pay the build time. Neither cascades: `pcre2` has no dependencies and `openssl@3` needs only `ca-certificates`, which ships an arch-independent bottle.

The source build is expensive, so the kegs are cached. The key carries the versions brew resolved after `update`, so a stale keg cannot shadow a newer release, and only a version bump pays the build again. Cellar and `opt` paths are cached; `pcre2` is relinked afterwards because `/usr/local/{lib,include}` symlinks are not - a restored keg comes back "already installed, just not linked".

Also drop `--quiet`, so the next formula to lose its Intel bottle names itself in the log instead of producing a bare exit 1.

### Verification

Validated by `workflow_dispatch` on a fork with `only=macos`, since packaging does not run on open PRs. Three runs: one before caching, then a deliberate cache miss and a cache hit.

| | arm64 | x86_64 (miss) | x86_64 (hit) |
|---|---|---|---|
| `Install Homebrew deps` | 32 s | 39 min | **3 min 45 s** |
| Job total | 3 min | 56 min | **19 min** |

All three macOS jobs green in each run, with all five artifacts produced including Universal2. The hit is confirmed by the log rather than inferred from the clock:

```
Cache hit for: macOS-macos-intel-kegs-10.48-3.6.4
pcre2 10.48 is already installed, it's just not linked.
openssl@3 3.6.4 is already installed, it's just not linked.
```

The miss cost varied between 39 and 68 min across runs on identical commits, so treat it as runner variance rather than a fixed figure.

### This is a stopgap, deliberately

All ten direct dependencies still have Intel bottles, mostly via the `sonoma` fallback, so this restores the build now. The platform is ending on three independent clocks though: Apple dropped Intel in macOS 27, Homebrew exited in September 2026, and the Intel runners go in 2027. When `boost` or `wxwidgets` loses its bottle, source-building stops being viable and the question becomes whether to keep shipping Intel at all - which also decides the fate of the Universal2 `.dmg`, since that is a `lipo` of both slices and cannot survive one going away.
