### PR TITLE
packaging: build wx from the 3.2 branch to get the wxEpollDispatcher fix

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -101,7 +101,14 @@ jobs:
       - name: Zero ccache stats
         if: github.event_name != 'workflow_call'
         run: ccache --zero-stats
+      # buildx + a gha layer cache for the image build, matching the static
+      # track. wxWidgets is compiled inside the image, so ccache never sees
+      # it; without this every run rebuilds it from scratch.
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v4
       - name: Build AppImage
+        env:
+          APPIMAGE_CACHE_SCOPE: ${{ github.event_name != 'workflow_call' && format('appimage-{0}', matrix.arch) || '' }}
         run: packaging/linux/build.sh appimage
       - name: Validate via cross-distro Docker matrix
         run: packaging/linux/build.sh validate

--- a/packaging/flathub/org.amule.aMule.yaml
+++ b/packaging/flathub/org.amule.aMule.yaml
@@ -222,9 +222,12 @@ modules:
       - --without-opengl
       - --with-libcurl
     sources:
-      - type: archive
-        url: https://github.com/wxWidgets/wxWidgets/releases/download/v3.2.6/wxWidgets-3.2.6.tar.bz2
-        sha256: 939e5b77ddc5b6092d1d7d29491fe67010a2433cf9b9c0d841ee4d04acb9dce7
+      # 3.2 branch at a pinned commit: no 3.2.x release carries the
+      # wxEpollDispatcher unregister fix amuled needs (amule-org/amule#1136).
+      # Revert to a type: archive tarball when 3.2.12 ships.
+      - type: git
+        url: https://github.com/wxWidgets/wxWidgets.git
+        commit: d73e1df63abee30759a6c8f134be8c091b619b7e
 
   - name: amule
     buildsystem: cmake-ninja

--- a/packaging/linux/appimage/Dockerfile
+++ b/packaging/linux/appimage/Dockerfile
@@ -6,7 +6,8 @@ ARG UBUNTU_BASE
 FROM ubuntu:${UBUNTU_BASE}
 
 ARG WX_VERSION
-ARG WX_SHA256
+ARG WX_GIT_URL
+ARG WX_COMMIT
 ARG LINUXDEPLOY_VERSION
 ARG LINUXDEPLOY_GTK_SHA
 ARG LIBUPNP_VERSION
@@ -124,10 +125,17 @@ RUN wget -qO /tmp/libupnp.tar.gz "${LIBUPNP_TARBALL_URL}" \
 # Ubuntu 22.04 base. Subsystems aMule doesn't use are disabled to
 # shrink the static archives.
 WORKDIR /opt/wxwidgets
-RUN wget -q "https://github.com/wxWidgets/wxWidgets/releases/download/v${WX_VERSION}/wxWidgets-${WX_VERSION}.tar.bz2" -O wx.tar.bz2 \
-    && echo "${WX_SHA256}  wx.tar.bz2" | sha256sum -c - \
-    && tar xf wx.tar.bz2 \
-    && cd "wxWidgets-${WX_VERSION}" \
+# Fetched from the 3.2 branch at a pinned commit, not a release tarball: no
+# 3.2.x release yet carries the wxEpollDispatcher unregister fix amuled needs
+# (amule-org/amule#1136). Fetching the SHA directly keeps this reproducible
+# and avoids cloning the full history; submodules supply wx's bundled
+# third-party sources. Revert to the tarball when 3.2.12 ships.
+RUN git init wx \
+    && cd wx \
+    && git remote add origin "${WX_GIT_URL}" \
+    && git fetch --depth 1 origin "${WX_COMMIT}" \
+    && git checkout FETCH_HEAD \
+    && git submodule update --init --depth 1 --recursive \
     && ./configure \
         --prefix=/usr/local \
         --with-gtk=3 \

--- a/packaging/linux/build.sh
+++ b/packaging/linux/build.sh
@@ -97,7 +97,8 @@ build_appimage() {
         --platform "${docker_platform}" \
         --build-arg "UBUNTU_BASE=${UBUNTU_BASE}" \
         --build-arg "WX_VERSION=${WX_VERSION}" \
-        --build-arg "WX_SHA256=${WX_SHA256}" \
+        --build-arg "WX_GIT_URL=${WX_GIT_URL}" \
+        --build-arg "WX_COMMIT=${WX_COMMIT}" \
         --build-arg "LINUXDEPLOY_VERSION=${LINUXDEPLOY_VERSION}" \
         --build-arg "LINUXDEPLOY_GTK_SHA=${LINUXDEPLOY_GTK_SHA}" \
         --build-arg "LIBUPNP_VERSION=${LIBUPNP_VERSION}" \
@@ -278,8 +279,8 @@ build_static() {
         -f "${SCRIPT_DIR}/static/Dockerfile" \
         --build-arg "ALPINE_STATIC_BASE=${ALPINE_STATIC_BASE}" \
         --build-arg "WX_VERSION=${WX_VERSION}" \
-        --build-arg "WX_TARBALL_URL=${WX_TARBALL_URL}" \
-        --build-arg "WX_SHA256=${WX_SHA256}" \
+        --build-arg "WX_GIT_URL=${WX_GIT_URL}" \
+        --build-arg "WX_COMMIT=${WX_COMMIT}" \
         --build-arg "CRYPTOPP_TAG_SUFFIX=${CRYPTOPP_TAG_SUFFIX}" \
         --build-arg "LIBUPNP_VERSION=${LIBUPNP_VERSION}" \
         --build-arg "LIBUPNP_TARBALL_URL=${LIBUPNP_TARBALL_URL}" \

--- a/packaging/linux/build.sh
+++ b/packaging/linux/build.sh
@@ -93,7 +93,23 @@ build_appimage() {
             exit 1
         fi
     fi
-    docker build \
+    # Optional buildx layer cache, mirroring the static track. CI sets
+    # APPIMAGE_CACHE_SCOPE for non-release runs so the wxWidgets, pupnp and
+    # appindicator layers persist across runs -- wx alone is minutes of
+    # compile that no ccache covers, because it happens inside the image
+    # build. Unset = plain build, so release (workflow_call) builds
+    # cold-compile, same rule as the static track.
+    local -a cache_args=()
+    if [[ -n "${APPIMAGE_CACHE_SCOPE:-}" ]]; then
+        cache_args+=(--cache-from "type=gha,scope=${APPIMAGE_CACHE_SCOPE}")
+        cache_args+=(--cache-to "type=gha,mode=max,scope=${APPIMAGE_CACHE_SCOPE}")
+    fi
+
+    # buildx rather than plain `docker build`: the gha cache backend needs
+    # it. --load puts the image in the local daemon, which the docker run
+    # below requires; it is a no-op on the default driver, so local dev
+    # builds are unaffected.
+    docker buildx build \
         --platform "${docker_platform}" \
         --build-arg "UBUNTU_BASE=${UBUNTU_BASE}" \
         --build-arg "WX_VERSION=${WX_VERSION}" \
@@ -108,6 +124,8 @@ build_appimage() {
         --build-arg "APPINDICATOR_TARBALL_URL=${APPINDICATOR_TARBALL_URL}" \
         --build-arg "APPINDICATOR_SHA256=${APPINDICATOR_SHA256}" \
         -t "${image_tag}" \
+        "${cache_args[@]}" \
+        --load \
         "${SCRIPT_DIR}/appimage"
 
     echo "==> Building AppImage (${target_arch})"

--- a/packaging/linux/flatpak/org.amule.aMule.yaml.in
+++ b/packaging/linux/flatpak/org.amule.aMule.yaml.in
@@ -331,9 +331,12 @@ modules:
       - --without-opengl
       - --with-libcurl
     sources:
-      - type: archive
-        url: ${WX_TARBALL_URL}
-        sha256: ${WX_SHA256}
+      # 3.2 branch at a pinned commit: no 3.2.x release carries the
+      # wxEpollDispatcher unregister fix amuled needs (amule-org/amule#1136).
+      # Revert to a type: archive tarball when 3.2.12 ships.
+      - type: git
+        url: ${WX_GIT_URL}
+        commit: ${WX_COMMIT}
 
   - name: amule
     buildsystem: cmake-ninja

--- a/packaging/linux/static/Dockerfile
+++ b/packaging/linux/static/Dockerfile
@@ -26,8 +26,8 @@ ARG ALPINE_STATIC_BASE
 FROM alpine:${ALPINE_STATIC_BASE} AS builder
 
 ARG WX_VERSION
-ARG WX_TARBALL_URL
-ARG WX_SHA256
+ARG WX_GIT_URL
+ARG WX_COMMIT
 ARG CRYPTOPP_TAG_SUFFIX
 ARG LIBUPNP_VERSION
 ARG LIBUPNP_TARBALL_URL
@@ -60,10 +60,16 @@ RUN git clone --depth 1 --branch "CRYPTOPP_${CRYPTOPP_TAG_SUFFIX}" \
  && make -C /tmp/cryptopp PREFIX=/usr/local install
 
 # --- wxWidgets (static, base + net, no GUI) ---
-RUN wget -qO /tmp/wx.tar.bz2 "${WX_TARBALL_URL}" \
- && echo "${WX_SHA256}  /tmp/wx.tar.bz2" | sha256sum -c - \
- && mkdir -p /tmp/wx && tar -xf /tmp/wx.tar.bz2 -C /tmp/wx --strip-components=1 \
- && cd /tmp/wx && ./configure \
+# From the 3.2 branch at a pinned commit rather than a release tarball: no
+# 3.2.x release carries the wxEpollDispatcher unregister fix amuled needs
+# (amule-org/amule#1136). Revert to the tarball when 3.2.12 ships.
+RUN git init /tmp/wx \
+ && cd /tmp/wx \
+ && git remote add origin "${WX_GIT_URL}" \
+ && git fetch --depth 1 origin "${WX_COMMIT}" \
+ && git checkout FETCH_HEAD \
+ && git submodule update --init --depth 1 --recursive \
+ && ./configure \
         --disable-shared \
         --disable-gui \
         --with-zlib=builtin \

--- a/packaging/linux/versions.env
+++ b/packaging/linux/versions.env
@@ -27,9 +27,14 @@ ALPINE_STATIC_BASE=3.20
 # wxWidgets (built from source for AppImage; consumed as a Flatpak module)
 # --------------------------------------------------------------------
 
-WX_VERSION=3.2.6
-WX_TARBALL_URL=https://github.com/wxWidgets/wxWidgets/releases/download/v${WX_VERSION}/wxWidgets-${WX_VERSION}.tar.bz2
-WX_SHA256=939e5b77ddc5b6092d1d7d29491fe67010a2433cf9b9c0d841ee4d04acb9dce7
+# Tracked from the upstream 3.2 maintenance branch rather than a release
+# tarball: every 3.2.x release to date predates the wxEpollDispatcher
+# unregister fix (upstream 3382306c8) that amuled needs under wxWebRequest,
+# see amule-org/amule#1136. Pinned to a commit, so builds stay reproducible.
+# SWITCH BACK to the release tarball once 3.2.12 ships with that fix.
+WX_VERSION=3.2.12-dev
+WX_GIT_URL=https://github.com/wxWidgets/wxWidgets.git
+WX_COMMIT=d73e1df63abee30759a6c8f134be8c091b619b7e
 
 # --------------------------------------------------------------------
 # AppImage tooling (linuxdeploy + GTK plugin)


### PR DESCRIPTION
Closes #1136.

### The bug

amuled aborts in `wxEpollDispatcher::Dispatch` under `wxWebRequest`: the dispatcher kept calling a handler that had already been unregistered from inside a curl callback. Our code is not at fault - we only use `wxWebRequest`, and wx's own curl backend correctly unregisters the descriptor before freeing the handler. `wxEpollDispatcher` ignored the unregister.

The fix is upstream on the wx `3.2` branch as [3382306c8](https://github.com/wxWidgets/wxWidgets/pull/26774), but **no 3.2.x release carries it yet**: 3.2.11 predates it, and `epolldispatcher.{h,cpp}` are byte-identical in 3.2.6, 3.2.11 and the branch point.

### The change

Take the branch instead of patching a release. All three Linux builds acquire wx the same way, so they move together:

- AppImage and the static Alpine image `git init` + `fetch --depth 1 <commit>` + `checkout FETCH_HEAD`, then init submodules for wx's bundled third-party sources
- both Flatpak manifests switch from `type: archive` to `type: git`

Pinned to a commit, not the branch head, so builds stay reproducible; the commit hash replaces the tarball `sha256` as the integrity check. This is the same approach ngosang took for the Docker images ([cc30edb](https://github.com/ngosang/docker-amule/commit/cc30edbaed6ba13d708f1aa3da68664b98f64bdb)).

The alternative was 3.2.11 plus a vendored copy of the one commit. That ships strictly less unreleased code - 25 commits versus 26 - but leaves a patch to apply at three sites, keep byte-identical to upstream, and remember to delete. **Revert to a release tarball when 3.2.12 ships**; `versions.env` says so at the pin.

### Second commit: a layer cache for the AppImage image

wxWidgets is compiled *inside* the AppImage image, where ccache never sees it, so every packaging run rebuilt it from scratch on both arches. The static track already solved this with buildx's gha layer cache via `STATIC_CACHE_SCOPE`; this mirrors it as `APPIMAGE_CACHE_SCOPE`, with the same exclusion for `workflow_call` so release builds still cold-compile. Flatpak needs nothing - `--ccache` covers its wx module already.

### Verification

Built on an aarch64 VM from a clean clone of this branch:

| Build | Result |
|---|---|
| static | `Configured wxWidgets 3.2.12`, pcre2 built from the fetched submodule, tarball produced |
| AppImage | 56 MB `.AppImage` produced, via the new buildx path |
| Flatpak | **not built locally** - the manifest change is the same one-line source swap, and the packaging run on master will exercise it |

`3.2.12` rather than `3.2.11` in the configure banner is what confirms the branch was used rather than a release.

### Note on CI cache budget

While measuring this I found the repo is at **32 GB of Actions cache across 139 entries**, against a documented 10 GB per-repo limit, so eviction is running continuously. The cause is uniform: every save key ends in `${{ github.run_id }}`, so no run ever overwrites another and each mints a fresh 400-500 MB entry - twelve copies of `macOS-Debug-ccache`, and so on.

That is not addressed here. It wants its own change (save only on the default branch, plus a prune), and it means the AppImage cache added above lands in a budget with no headroom until then.
