### PR TITLE
ci: keep one Actions cache per family, and stop PRs writing them

### DIFF
--- a/.github/workflows/cache-retention.yml
+++ b/.github/workflows/cache-retention.yml
@@ -1,0 +1,84 @@
+# Keeps one Actions cache per key prefix.
+#
+# Every ccache save key ends in `-${{ github.run_id }}` so that a run never
+# collides with an earlier one -- actions/cache refuses to overwrite a key, and
+# a stable key would freeze the cache at its first write. The cost is that
+# nothing is ever replaced: each run mints a fresh 400-500 MB entry and the
+# repo drifted to 32 GB across 139 entries against a 10 GB limit, so GitHub was
+# evicting continuously and entries were being deleted before they served a
+# hit.
+#
+# Restores key on hashFiles() but fall back through `restore-keys: <prefix>-`,
+# which resolves to the newest match, so older generations are never chosen.
+# Deleting them loses nothing.
+name: Cache retention
+
+on:
+  # After every master push, i.e. right behind the runs that write the caches
+  # this prunes. Cheap: one API listing plus a handful of DELETEs, no build.
+  push:
+    branches:
+      - master
+  # Backstop for stretches with no merges, and a manual handle.
+  schedule:
+    - cron: '0 3 * * *'
+  workflow_dispatch:
+
+permissions:
+  actions: write
+
+jobs:
+  prune:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Keep only the newest cache per prefix
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          gh api --paginate "repos/${REPO}/actions/caches?per_page=100" \
+            --jq '.actions_caches[] | [.id, .created_at, .size_in_bytes, .key] | @tsv' > caches.tsv
+          python3 - <<'PY' > to_delete.txt
+          import re, collections, os
+          rows = []
+          for line in open("caches.tsv"):
+              cid, created, size, key = line.rstrip("\n").split("\t", 3)
+              rows.append((int(cid), created, int(size), key))
+          # Group by the key with a trailing numeric run id removed. Keys that
+          # carry no run id (e.g. the macOS Intel keg cache, whose key is the
+          # formula versions) form single-entry groups and are always kept.
+          # Normalise the run id AND embedded hashes: CodeQL and msys2 key on a
+          # commit sha rather than a run id, so without this each lands in its
+          # own group and survives forever (5 CodeQL TRAP entries alone were
+          # 4.3 GB).
+          def family(key):
+              k = re.sub(r"-\d{6,}$", "", key)
+              return re.sub(r"[0-9a-f]{16,}", "<h>", k)
+          # Rank by the run id in the key, not by created_at. Two master merges
+          # in quick succession can finish out of order, and the later WRITE may
+          # be the older COMMIT; the run id orders by when the run started, so
+          # the newer commit's cache is the one kept. Falls back to the
+          # timestamp for keys that carry no run id.
+          def rank(entry):
+              created, cid, size, key = entry
+              m = re.search(r"-(\d{6,})$", key)
+              return (1, int(m.group(1))) if m else (0, created)
+          groups = collections.defaultdict(list)
+          for cid, created, size, key in rows:
+              groups[family(key)].append((created, cid, size, key))
+          freed = kept = 0
+          for prefix, entries in groups.items():
+              entries.sort(key=rank, reverse=True)   # newest run first
+              kept += 1
+              for created, cid, size, key in entries[1:]:
+                  freed += size
+                  print(cid)
+          print(f"::notice::keeping {kept} caches, freeing {freed/2**30:.1f} GB", file=__import__("sys").stderr)
+          PY
+          cat to_delete.txt | while read -r id; do
+              [ -n "$id" ] || continue
+              gh api -X DELETE "repos/${REPO}/actions/caches/${id}" >/dev/null 2>&1 \
+                && echo "deleted $id" || echo "skip $id (already gone)"
+          done
+          echo "remaining: $(gh api "repos/${REPO}/actions/cache/usage" --jq '.active_caches_count') caches, \
+          $(gh api "repos/${REPO}/actions/cache/usage" --jq '(.active_caches_size_in_bytes/1073741824*10|floor)/10') GB"

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -156,7 +156,7 @@ jobs:
         run: cmake --build build
       - name: save ccache
         uses: actions/cache/save@v6
-        if: always()
+        if: always() && github.event_name == 'push' && github.ref == 'refs/heads/master'
         with:
           path: ${{ env.CCACHE_DIR }}
           key: ${{ runner.os }}-${{ matrix.build_type }}-ccache-${{ github.run_id }}
@@ -207,7 +207,7 @@ jobs:
         run: cmake --build build
       - name: save ccache
         uses: actions/cache/save@v6
-        if: always()
+        if: always() && github.event_name == 'push' && github.ref == 'refs/heads/master'
         with:
           path: ${{ env.CCACHE_DIR }}
           key: ${{ runner.os }}-${{ matrix.build_type }}-ccache-${{ github.run_id }}
@@ -271,7 +271,7 @@ jobs:
         run: cmake --build build
       - name: save ccache
         uses: actions/cache/save@v6
-        if: always()
+        if: always() && github.event_name == 'push' && github.ref == 'refs/heads/master'
         with:
           path: ${{ env.CCACHE_DIR }}
           key: ${{ runner.os }}-${{ matrix.build_type }}-ccache-${{ github.run_id }}

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -143,7 +143,7 @@ jobs:
         run: cmake --build build
       - name: save ccache
         uses: actions/cache/save@v6
-        if: always()
+        if: always() && github.event_name == 'push' && github.ref == 'refs/heads/master'
         with:
           path: ${{ env.CCACHE_DIR }}
           key: clang-tidy-ccache-${{ github.run_id }}
@@ -191,7 +191,7 @@ jobs:
       # this run. Unlike ccache (filled by the build), ctcache is filled here.
       - name: save ctcache
         uses: actions/cache/save@v6
-        if: always()
+        if: always() && github.event_name == 'push' && github.ref == 'refs/heads/master'
         with:
           path: ${{ env.CTCACHE_DIR }}
           key: clang-tidy-ctcache-llvm${{ env.LLVM_VERSION }}-${{ env.CTCACHE_SHA }}-${{ github.run_id }}
@@ -241,7 +241,7 @@ jobs:
         run: cmake --build build
       - name: save ccache
         uses: actions/cache/save@v6
-        if: always()
+        if: always() && github.event_name == 'push' && github.ref == 'refs/heads/master'
         with:
           path: ${{ env.CCACHE_DIR }}
           key: clang-tidy-ccache-${{ github.run_id }}

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -106,7 +106,7 @@ jobs:
       - name: Validate via cross-distro Docker matrix
         run: packaging/linux/build.sh validate
       - name: Save ccache
-        if: always() && github.event_name != 'workflow_call'
+        if: always() && github.event_name == 'push' && github.ref == 'refs/heads/master'
         uses: actions/cache/save@v6
         with:
           path: ${{ env.CCACHE_DIR }}
@@ -220,7 +220,7 @@ jobs:
       - name: Build Flatpak
         run: packaging/linux/build.sh flatpak
       - name: Save flatpak-builder ccache
-        if: always() && github.event_name != 'workflow_call'
+        if: always() && github.event_name == 'push' && github.ref == 'refs/heads/master'
         uses: actions/cache/save@v6
         with:
           path: ${{ env.CCACHE_DIR }}
@@ -373,7 +373,7 @@ jobs:
           [ -d "${MNT}/aMuleGUI.app" ] || { echo "aMuleGUI.app missing from per-arch dmg" >&2; exit 1; }
           hdiutil detach "${MNT}"
       - name: Save ccache
-        if: always() && github.event_name != 'workflow_call'
+        if: always() && github.event_name == 'push' && github.ref == 'refs/heads/master'
         uses: actions/cache/save@v6
         with:
           path: ${{ env.CCACHE_DIR }}
@@ -607,7 +607,7 @@ jobs:
           # any tagged-release banner ("aMuleD 3.0.0 ...", etc.).
           grep -q '^aMuleD ' /tmp/version.txt
       - name: Save ccache
-        if: always() && github.event_name != 'workflow_call'
+        if: always() && github.event_name == 'push' && github.ref == 'refs/heads/master'
         uses: actions/cache/save@v6
         with:
           path: ${{ env.CCACHE_DIR }}


### PR DESCRIPTION
The repo sits at **32.1 GB of Actions cache across 139 entries**, against a 10 GB per-repo limit, so GitHub is evicting continuously and entries are being deleted before they ever serve a hit. Twelve copies of `macOS-Debug-ccache` exist at once.

### Why it grew

Every ccache save key ends in `${{ github.run_id }}`:

```yaml
restore:  key: <prefix>-ccache-${{ hashFiles(...) }}   restore-keys: <prefix>-ccache-
save:     key: <prefix>-ccache-${{ github.run_id }}
```

That is a deliberate idiom - `actions/cache` refuses to overwrite an existing key, and a stable key would freeze the cache at its first write - but nothing is ever replaced, so each run mints a fresh 400-500 MB entry and they accumulate until eviction.

### Two changes

**Saves only on master pushes.** A cache written by a PR run is scoped to that branch: no other PR and not master can read it, and it is garbage the moment the PR merges. Restores are untouched - they key on `hashFiles()` and fall back through `restore-keys` to the base branch, so PRs keep getting master's warm cache.

**A prune keeping one entry per family**, in a new `cache-retention.yml`. Two details matter:

- Families normalise the trailing run id **and** embedded hashes. CodeQL and msys2 key on a commit sha rather than a run id, so without that each lands in its own group and survives forever - five CodeQL TRAP entries alone were 4.3 GB. Grouping on run id only would have left 8.8 GB, still at the limit.
- Within a family the **highest run id** wins, not the newest timestamp. Two merges in quick succession can finish out of order, so the later write may be the older commit; run ids order by when a run started.

### Effect

Dry-run against the live cache list:

| | Entries | Size |
|---|---|---|
| now | 139 | 32.1 GB |
| after | 28 | **5.5 GB** |

That leaves comfortable headroom under the limit, so no need to shrink `CCACHE_MAXSIZE` or disable CodeQL TRAP caching as well.

It runs after every master push, right behind the runs that write the caches, with a daily backstop and a manual handle. It therefore performs the one-off cleanup on the merge of this commit - no extra step.

### Deliberately not gated

The macOS Intel keg cache keeps writing from PRs. Its key carries the two formula versions, so it is already bounded to one entry per version pair, and a PR bumping the pin would otherwise pay the ~39-minute source build on every run.

### Note

Nothing here is verified by CI, because a cache-retention workflow cannot be exercised from a PR. The selection logic was dry-run against the live cache list of this repository, which is how the numbers above were produced; the first real run is the merge itself.
