### PR TITLE
fix(amuleapi): null-guard the address fields and settle three key names

### DIFF
--- a/docs/api/EVENTS.md
+++ b/docs/api/EVENTS.md
@@ -427,6 +427,8 @@ Identical to the REST [`/api/v0/friends`](REFERENCE.md#get-apiv0friends) list-it
 }
 ```
 
+`ip` and `port` are `null` for a friend with no address, exactly as the [`GET /friends`](REFERENCE.md#get-apiv0friends) row emits them - the payloads are key-for-key identical, so a subscriber hydrating from REST never sees a value flip `null` to `""` on the first tick that touches the row.
+
 `friend_updated` fires on any observable change, including a friend coming online or going offline — that transition is `client_ecid` moving between a live client's ECID and `null`, which is what drives the connected indicator in the desktop client.
 
 One `PATCH /api/v0/friends/{ecid}` can produce **two** `friend_updated` events. Only one friend may hold the friend slot, so granting it to one clears it on whoever held it before, and both records change.
@@ -555,7 +557,7 @@ Rate impact is small: the overhead rates move about as often as the speeds alrea
     "download_overhead_bytes_per_second": 8700, "upload_overhead_bytes_per_second": 1100
   },
   "disk":   { "temp_free_bytes": 48318382080, "incoming_free_bytes": 48318382080 },
-  "queue":  { "upload_clients_waiting": 12, "download_sources_total": 1843 }
+  "queue":  { "waiting_upload_client_count": 12, "download_source_count": 1843 }
 }
 ```
 

--- a/docs/api/REFERENCE.md
+++ b/docs/api/REFERENCE.md
@@ -356,7 +356,7 @@ A key is **omitted** only where absence itself is the meaning: something the dae
 
 So: `null` means "no value", an absent key means "not reported", and neither is ever spelled `0` or `-1`.
 
-The rule now reaches the whole surface rather than just the download and shared objects. Keys that used to disappear and are `null` instead: `name`, `ip`, `port`, `kad_port`, `country_code`, `software`, `version`, `source_origin`, `obfuscation`, `first_seen` and `sessions` on [`GET /known_clients`](#get-apiv0known_clients); `part_progress_percent` and `parts_offered_count` on the client rows and the `client_*` events; `client_ecid` on [`GET /search`](#get-apiv0search), [`GET /friends`](#get-apiv0friends) and the `friend_*` events; `last_message` on [`GET /chats`](#get-apiv0chats); `token`, `label_value` and `extra` on the statistics tree; and `media` everywhere it appears.
+The rule now reaches the whole surface rather than just the download and shared objects. Keys that used to disappear and are `null` instead: `name`, `ip`, `port`, `kad_port`, `country_code`, `software`, `version`, `source_origin`, `obfuscation`, `first_seen` and `sessions` on [`GET /known_clients`](#get-apiv0known_clients); `part_progress_percent` and `parts_offered_count` on the client rows and the `client_*` events; `client_ecid` on [`GET /search`](#get-apiv0search), [`GET /friends`](#get-apiv0friends) and the `friend_*` events; `last_message` on [`GET /chats`](#get-apiv0chats); `token`, `label_value` and `extra` on the statistics tree; and `media` everywhere it appears. The same pass reached the remaining address fields: `port` on [`GET /friends`](#get-apiv0friends) and the `friend_*` events, `ed2k.public_ip` and `ed2k.server_ip` on [`GET /status`](#get-apiv0status), and `public_ip` on [`GET /kad`](#get-apiv0kad); and `server_ip` / `server_port` on [`GET /clients/{ecid}`](#get-apiv0clientsecid), which used `""` for the same "unknown" its own snapshot field documents.
 
 `media` is the one place this reaches an **object** rather than a scalar, so a client tests `media === null` before reaching into it -- which it had to do regardless, since the object's own fields can be absent.
 
@@ -618,7 +618,7 @@ curl -s -H "Authorization: Bearer $TOKEN" http://$HOST/api/v0/status
     "upload_overhead_bytes_per_second": 1100
   },
   "disk": { "temp_free_bytes": 48318382080, "incoming_free_bytes": 48318382080 },
-  "queue": { "upload_clients_waiting": 12, "download_sources_total": 1843 }
+  "queue": { "waiting_upload_client_count": 12, "download_source_count": 1843 }
 }
 ```
 
@@ -630,9 +630,9 @@ curl -s -H "Authorization: Bearer $TOKEN" http://$HOST/api/v0/status
 
 **`kad.firewalled_tcp` is named for its transport.** It is the TCP half of a pair; [`GET /api/v0/kad`](#get-apiv0kad) reports `firewalled_udp` alongside it. The two are independent measurements taken by different mechanisms, not a verdict and a refinement of it. See the `/kad` field table for what each one measures and how their defaults differ.
 
-**Our eD2k identity.** `ed2k.user_id` is the id the connected server assigned us, and `ed2k.high_id` is `true` when it is a HighID — an id `>= 16777216`, the same threshold the client-side `high_id` on [`GET /clients/{ecid}`](#get-apiv0clientsecid) uses. A HighID **is** our public IPv4 packed into that integer, which is where `ed2k.public_ip` comes from; a LowID is a small number the server picked for a firewalled client and carries no address, so `public_ip` is `""` there.
+**Our eD2k identity.** `ed2k.user_id` is the id the connected server assigned us, and `ed2k.high_id` is `true` when it is a HighID — an id `>= 16777216`, the same threshold the client-side `high_id` on [`GET /clients/{ecid}`](#get-apiv0clientsecid) uses. A HighID **is** our public IPv4 packed into that integer, which is where `ed2k.public_ip` comes from; a LowID is a small number the server picked for a firewalled client and carries no address, so `public_ip` is `null` there.
 
-While disconnected `user_id` is `0`, `public_ip` is `""` and `high_id` is `false` — so read `high_id` **together with `state`**: `false` means "LowID" only once `state` is `"connected"`, and means "no id yet" otherwise. The transient `0xffffffff` the daemon sends mid-connect is normalized to `0` and never appears.
+While disconnected `user_id` is `0`, `public_ip` is `null` and `high_id` is `false` — so read `high_id` **together with `state`**: `false` means "LowID" only once `state` is `"connected"`, and means "no id yet" otherwise. The transient `0xffffffff` the daemon sends mid-connect is normalized to `0` and never appears.
 
 **`ed2k.user_id` is not the same encoding as a client's `ed2k_user_id`.** [`GET /api/v0/clients/{ecid}`](#get-apiv0clientsecid) reports `ed2k_user_id` for a remote client, and the similar name invites the assumption that the two are interchangeable. They are not. Ours is stored exactly as the server sent it and is read least-significant-byte-first to produce `public_ip`; a client's HighID is **byte-swapped** on the way in. A consumer that compares the two values, or feeds one through the other's IP decoder, gets a reversed address. The `>= 16777216` HighID threshold *is* common to both; the byte order is not.
 
@@ -1065,7 +1065,7 @@ The swap moves the client between two files' source lists, so an SSE subscriber 
 
 `source_ecids` are the ECIDs of the clients holding this file as an A4AF source, joinable against [`GET /api/v0/clients`](#get-apiv0clients). The same array, under the same name, rides the download object and its `download_updated` SSE event, so a subscriber does not have to POST here to keep it current. The array is the post-action state, so a `swap_this` naming a single client shows up as that ECID having left it. The same clients appear as rows with `"a4af": true` on [`GET /api/v0/downloads/{hash}/clients`](#get-apiv0downloadshashclients--get-apiv0sharedhashclients), which carries the whole client object rather than a bare ECID.
 
-**Errors:** `400 bad_request` (missing or unknown `action`; `swap_this_auto`, which moved to `PATCH`; a non-integer `client_ecid`; `client_ecid` with the wrong action), `400 amuled_rejected` (the daemon refused the swap — most commonly because the client is actively sending data, which it will not be swapped away from), `404 not_found` (no download with that hash, or no client with that ECID), `409 conflict` (that client is not an A4AF source of this download), `503 ec_unavailable`.
+**Errors:** `400 bad_request` (missing or unknown `action`; `swap_this_auto`, which moved to `PATCH`; a non-integer `client_ecid`; `client_ecid` with the wrong action), `400 amuled_rejected` (the daemon refused the swap — most commonly because the client is actively sending data, which it will not be swapped away from), `404 not_found` (no download with that hash, or no client with that ECID), `409 not_a4af_source` (that client is not an A4AF source of this download), `503 ec_unavailable`.
 
 #### `POST /api/v0/downloads`
 
@@ -1356,7 +1356,7 @@ curl -s -H "Authorization: Bearer $TOKEN" \
 }
 ```
 
-The detail fields mirror the desktop "Client Details" modal. Five of the fields below — `source_origin`, `parts_offered_count`, `client_mod_name`, `shared_files_browsable` and `part_progress_percent` — are **not** detail-only: they are on the [`GET /clients`](#get-apiv0clients) row and the SSE payload too, and are described here because this is where the rest of their neighbours live. `ed2k_user_id` is the client's hybrid eD2k id; `high_id` is `true` for a HighID client (id ≥ `16777216`, i.e. `0x1000000`) and `false` for LowID — the same threshold and the same spelling as `ed2k.high_id` on [`GET /status`](#get-apiv0status), so the value means the same thing on both ends of the API. `server_ip` / `server_port` / `server_name` describe the eD2k server the client connects through (`server_ip` is `""` when unknown). `kad_port` is non-zero when the client is reachable on Kad. `source_origin` is how the client was discovered (values in the enumerated-fields table under [`GET /clients`](#get-apiv0clients)). (`upload_file_name` is part of the base field set — see [`GET /clients`](#get-apiv0clients) above.) `parts_offered_count` is the count of parts the client holds of the linked file, or `null` when the client has not reported a part map (see [Unknown values](#unknown-values)); `client_mod_name` is the client's client-mod string (often `""`); `shared_files_browsable` is `true` when the client forbids browsing its shared files. `friend` is `true` when the client is in your friends list (`CUpDownClient::IsFriend()`) — **distinct** from `friend_slot`, which is a *reserved upload slot* granted to a client and can be set for non-friends. `credit_ratio` is the upload score modifier the GUI labels "DL/UP modifier" (`GetScoreRatio()`). `part_progress_percent` is the client's completeness of the file we are downloading **from** them (`parts_offered_count` over that file's part count) and is `null` when there is no linked download or the part count is unknown (see [Unknown values](#unknown-values)).
+The detail fields mirror the desktop "Client Details" modal. Five of the fields below — `source_origin`, `parts_offered_count`, `client_mod_name`, `shared_files_browsable` and `part_progress_percent` — are **not** detail-only: they are on the [`GET /clients`](#get-apiv0clients) row and the SSE payload too, and are described here because this is where the rest of their neighbours live. `ed2k_user_id` is the client's hybrid eD2k id; `high_id` is `true` for a HighID client (id ≥ `16777216`, i.e. `0x1000000`) and `false` for LowID — the same threshold and the same spelling as `ed2k.high_id` on [`GET /status`](#get-apiv0status), so the value means the same thing on both ends of the API. `server_ip` / `server_port` / `server_name` describe the eD2k server the client connects through; `server_ip` and `server_port` are `null` together when the server is unknown. `kad_port` is non-zero when the client is reachable on Kad. `source_origin` is how the client was discovered (values in the enumerated-fields table under [`GET /clients`](#get-apiv0clients)). (`upload_file_name` is part of the base field set — see [`GET /clients`](#get-apiv0clients) above.) `parts_offered_count` is the count of parts the client holds of the linked file, or `null` when the client has not reported a part map (see [Unknown values](#unknown-values)); `client_mod_name` is the client's client-mod string (often `""`); `shared_files_browsable` is `true` when the client forbids browsing its shared files. `friend` is `true` when the client is in your friends list (`CUpDownClient::IsFriend()`) — **distinct** from `friend_slot`, which is a *reserved upload slot* granted to a client and can be set for non-friends. `credit_ratio` is the upload score modifier the GUI labels "DL/UP modifier" (`GetScoreRatio()`). `part_progress_percent` is the client's completeness of the file we are downloading **from** them (`parts_offered_count` over that file's part count) and is `null` when there is no linked download or the part count is unknown (see [Unknown values](#unknown-values)).
 
 > `friend` and `credit_ratio` ride two EC tags added for this endpoint. A webapi built against a newer core talking to an **older** amuled that doesn't send them degrades gracefully — `friend` reads `false` and `credit_ratio` reads `0`.
 
@@ -2077,7 +2077,7 @@ The friends list amuled persists to `emfriends.met`. The daemon ships the whole 
 }
 ```
 
-`client_ecid` is the live client this friend is currently linked to, joinable against [`GET /api/v0/clients`](#get-apiv0clients), and `null` when the friend is offline — `online` is the convenience form of that test. `user_hash` is `""` for a friend added by address only, and `ip` is `""` for a zero address.
+`client_ecid` is the live client this friend is currently linked to, joinable against [`GET /api/v0/clients`](#get-apiv0clients), and `null` when the friend is offline — `online` is the convenience form of that test. `user_hash` is `""` for a friend added by address only; `ip` and `port` are `null` for a zero address, and the `friend_*` events emit the same nulls.
 
 `friend_slot` reads `false` against a daemon predating the tag that carries it, the same way `friend` and `credit_ratio` degrade on `/clients`.
 
@@ -2420,7 +2420,7 @@ The three **clamped at daemon start** rows are the reason this is enforced on th
 
 **A low `connection.max_upload_kbps` caps `max_download_kbps`,** which is the one place a `PATCH` changes a field the request did not name. Below `4` kB/s up the download limit is forced to 3× the upload; below `10` it is forced to 4×. So `PATCH {"connection": {"max_upload_kbps": 3}}` also sets `max_download_kbps` to `9`. This is a deliberate anti-leech rule in the core rather than a defect, it applies whichever of the two you write, and the `PATCH` response echoes the whole preferences object so the adjusted value is visible in the reply.
 
-**Errors:** `400 bad_request` (unknown/mis-typed field, or a body with no recognized fields), `409 conflict` (the daemon was built without support for the option being set), `400 amuled_rejected`, `503 ec_unavailable`.
+**Errors:** `400 bad_request` (unknown/mis-typed field, or a body with no recognized fields), `409 option_not_supported` (the daemon was built without support for the option being set), `400 amuled_rejected`, `503 ec_unavailable`.
 
 ---
 
@@ -2534,7 +2534,7 @@ Standalone view of the Kad subtree from `/status`, plus the detail fields the st
 | `state` | string | `disabled` / `connecting` / `connected`. `disabled` means Kad is not running at all, which is the condition several fields below key their "no measurement" value on. The same value `GET /api/v0/status` reports as `kad.state`. |
 | `node_id` | string | This node's own 128-bit Kademlia id, 32 lowercase hex characters (the desktop panel shows the same value uppercase). `""` while Kad is not running, which is exactly when `state` is `disabled`. Persisted by the daemon, so unlike the session-scoped ECIDs and the server-assigned eD2k id it is stable across restarts — the one identifier for the local node a consumer can key on. It is a DHT routing key, not a credential: every Kad contact the daemon talks to learns it. |
 | `connected_since_at` | int | Unix seconds of the most recent Kad connect, the same value `GET /api/v0/status` reports as `kad.connected_since`. `0` when not connected, so gate on `state` rather than trusting a `0`. |
-| `public_ip` | string | This node's externally-visible IPv4, as a remote Kad contact reported it back. Two "not known" cases, both matching what the desktop panel's *IP address* row shows: `""` while Kad is not connected (the daemon sends the field only then), and `0.0.0.0` while connected but not yet told its own address by any contact. **Two distinct "unknown" sentinels, one of them a syntactically valid address**: a consumer that only checks for `""` will treat `0.0.0.0` as a real IP. Distinct from `preferences.connection.bind_address`, which is the local interface the daemon binds to. Named `public_ip` rather than `ip` because `buddy.ip` in the same payload belongs to somebody else. |
+| `public_ip` | string | This node's externally-visible IPv4, as a remote Kad contact reported it back. Two "not known" cases, both matching what the desktop panel's *IP address* row shows: `null` while Kad is not connected (the daemon sends the field only then), and `0.0.0.0` while connected but not yet told its own address by any contact. **Two distinct "unknown" sentinels, one of them a syntactically valid address**: a consumer that only checks for `null` will treat `0.0.0.0` as a real IP. Distinct from `preferences.connection.bind_address`, which is the local interface the daemon binds to. Named `public_ip` rather than `ip` because `buddy.ip` in the same payload belongs to somebody else. |
 | `firewalled_tcp` | bool \| null | Whether this node is firewalled for **TCP**. The verdict is a **vote**: two distinct clients must confirm reachability by opening an incoming TCP connection carrying `OP_KAD_FWTCPCHECK_ACK` before it clears to `false`. With no verdict yet it reads **`true`**, the conservative assumption. During an IP recheck it freezes at its previous value rather than momentarily reporting a false LowID. **`null` unless `state` is `connected`** - the underlying bit outlives a disconnect, so this used to report a reachability verdict for a network the daemon was not on. Named for the transport because it is one half of a pair, not an overall verdict that `firewalled_udp` refines. |
 | `firewalled_udp` | bool \| null | Whether this node is firewalled for **UDP**, measured by an entirely different mechanism: a directed test with its own state, which can also declare firewalled **by timeout** after six minutes. **`null` unless `state` is `connected`.** It previously read `false` while Kad was down, which was the absence of a measurement dressed as "UDP is open" - the asymmetry with `firewalled_tcp`'s `true` made the pair actively misleading. Both are `null` now, so there is nothing to misread. |
 | `lan_mode` | bool \| null | `true` when the daemon is running Kad in LAN mode. It **forces both firewalled fields to `false`** regardless of any measurement, which is why it belongs beside them: a `false` on either flag is only meaningful once you have checked this one. `null` unless `state` is `connected`. |
@@ -2807,7 +2807,7 @@ Time-series points behind the desktop Statistics graphs.
 }
 ```
 
-Each point has `t` (ISO-8601 UTC), `at` (unix seconds) and `value`, spaced by `interval_seconds`. `unit` is `"bytes_per_second"` for the two speed graphs and `"count"` for the other two.
+Each point has `at` (unix seconds) and `value`, spaced by `interval_seconds`. `unit` is `"bytes_per_second"` for the two speed graphs and `"count"` for the other two.
 
 `max_points` is how many points this daemon can answer with before it starts repeating records; `points` is never longer than it. It is not a constant across daemons, so a client that wants the deepest window available should read it rather than assume 1800.
 
@@ -3055,7 +3055,7 @@ The route is deliberately **not** nested under a search id: amuled runs one Kad 
 
 ```json
 {
-  "count": 2,
+  "total": 2,
   "kad_comment_lookup_running": false,
   "comments": [
     { "username": "203.0.113.7", "filename": "example-distribution-26.04-amd64.iso", "rating": 5, "comment": "Verified good, fast sources." },

--- a/src/webapi/Api.cpp
+++ b/src/webapi/Api.cpp
@@ -142,10 +142,11 @@ void WriteUIntOrNull(CJsonWriter &w, const char *key, bool known, std::uint64_t 
 		w.ValueNull();
 }
 
-// Siblings of WriteIntOrNull for the other two shapes the rule reaches. An
-// empty string is NOT the same as unknown -- `server_ip` is legitimately ""
-// when the peer has no server -- so callers pass the predicate rather than
-// letting this guess from the value.
+// Siblings of WriteIntOrNull for the other two shapes the rule reaches.
+// Callers pass the predicate rather than letting this guess from the value,
+// because "empty" and "unknown" are not always the same question: a count of 0
+// is a real answer (parts_offered_count), while "" on an address field is a
+// sentinel the rule spells null.
 // Bool half of the OrNull family. `false` and "not measured" are different
 // answers for a firewall verdict or a LAN-mode flag, and only one of them is
 // something a consumer should act on.
@@ -2648,15 +2649,18 @@ CHttpServer::Response CApiDispatcher::HandleStatus(const CHttpServer::Request &r
 	// the two must not be compared or fed through each other's decoder.
 	w.Key("user_id");
 	w.ValueInt(static_cast<int64_t>(s.ed2k_user_id));
-	w.Key("public_ip");
-	w.ValueString(wxString::FromUTF8(s.ed2k_public_ip.c_str()));
+	WriteStringOrNull(w, "public_ip", !s.ed2k_public_ip.empty(), s.ed2k_public_ip);
 	// 0 when not connected -- gate on ed2k.state, not on this being nonzero.
 	w.Key("connected_since_at");
 	w.ValueInt(static_cast<int64_t>(s.ed2k_connected_since));
 	w.Key("server_name");
 	w.ValueString(wxString::FromUTF8(s.server_name.c_str()));
-	w.Key("server_ip");
-	w.ValueString(wxString::FromUTF8(s.server_ip.c_str()));
+	// Null when not connected. The "an empty string is legitimately 'no
+	// server'" note on WriteStringOrNull is about a PEER's server_ip
+	// (WriteKnownClientObject, untouched): a connected peer can genuinely
+	// have none. This is our own connection, where ed2k.state already says
+	// whether there is a server, so "" here only ever meant "not connected".
+	WriteStringOrNull(w, "server_ip", !s.server_ip.empty(), s.server_ip);
 	w.Key("server_port");
 	w.ValueInt(static_cast<int64_t>(s.server_port));
 	// Network rollup, symmetric with kad.network below. Aggregate
@@ -2725,9 +2729,9 @@ CHttpServer::Response CApiDispatcher::HandleStatus(const CHttpServer::Request &r
 
 	w.Key("queue");
 	w.BeginObject();
-	w.Key("upload_clients_waiting");
+	w.Key("waiting_upload_client_count");
 	w.ValueInt(static_cast<int64_t>(s.ul_queue_len));
-	w.Key("download_sources_total");
+	w.Key("download_source_count");
 	w.ValueInt(static_cast<int64_t>(s.total_src_count));
 	w.EndObject();
 	// Nickname is a /preferences field, not a /status one.
@@ -3227,10 +3231,14 @@ void WriteClientDetailObject(CJsonWriter &w, const webapi::ClientSnapshot &c)
 	w.ValueUInt(static_cast<uint64_t>(c.ed2k_user_id));
 	w.Key("high_id");
 	w.ValueBool(c.high_id);
-	w.Key("server_ip");
-	w.ValueString(wxString::FromUTF8(c.server_ip.c_str()));
-	w.Key("server_port");
-	w.ValueInt(static_cast<int64_t>(c.server_port));
+	// Paired and nulled together, like ip/port/kad_port on the base row.
+	// ClientSnapshot::server_ip is documented as `"" when unknown/0`, so the
+	// empty string here is the unknown case the R10 rule spells null -- and
+	// "" is not a value an address field can legitimately take, unlike the 0
+	// that parts_offered_count uses as a real answer.
+	const bool has_server = !c.server_ip.empty();
+	WriteStringOrNull(w, "server_ip", has_server, c.server_ip);
+	WriteIntOrNull(w, "server_port", has_server, static_cast<int64_t>(c.server_port));
 	w.Key("server_name");
 	w.ValueString(wxString::FromUTF8(c.server_name.c_str()));
 	w.Key("kad_port");
@@ -5906,8 +5914,10 @@ void WriteFriendObject(CJsonWriter &w, const webapi::FriendSnapshot &f)
 	w.ValueString(wxString::FromUTF8(f.user_hash.c_str()));
 	// null rather than "" when the daemon has not reported an address (R10).
 	WriteStringOrNull(w, "ip", !f.ip.empty(), f.ip);
-	w.Key("port");
-	w.ValueInt(static_cast<int64_t>(f.port));
+	// Paired with ip, the way WriteKnownClientObject nulls ip/port/kad_port
+	// together: a 0 port on an address-less friend is the sentinel R10 removed
+	// everywhere else.
+	WriteIntOrNull(w, "port", !f.ip.empty(), static_cast<int64_t>(f.port));
 	// The live peer this friend is linked to, joinable against /clients. null
 	// when the friend is not connected, which is the common case and which
 	// `online` also reports. Deliberately not the 0 it used to be: the surface
@@ -7412,8 +7422,7 @@ CHttpServer::Response CApiDispatcher::HandleKad(const CHttpServer::Request &req)
 	w.ValueInt(static_cast<int64_t>(d.status.kad_connected_since));
 	// Ours, as opposed to `buddy.ip` below — which is why this one
 	// is not called plain `ip`.
-	w.Key("public_ip");
-	w.ValueString(wxString::FromUTF8(k.public_ip.c_str()));
+	WriteStringOrNull(w, "public_ip", !k.public_ip.empty(), k.public_ip);
 	WriteKadNetworkObject(w, k);
 	// Both objects are null-valued unless Kad is connected: amuled only ships
 	// these tags inside its own connected gate, so the numbers below were the
@@ -9243,16 +9252,14 @@ CHttpServer::Response CApiDispatcher::HandleGeoipUpdate(const CHttpServer::Reque
 
 	(void)RefresherTick(m_app, m_state);
 
-	// 202, like the three sibling fetch routes: the download runs in the
-	// daemon after the reply. Progress is observable on GET /preferences as
-	// geoip.download_in_progress, and the outcome as geoip.last_update_status.
+	// 202 with no body, like the three sibling fetch routes (UrlFetchOp): the
+	// download runs in the daemon after the reply. Progress is observable on
+	// GET /preferences as geoip.download_in_progress, and the outcome as
+	// geoip.last_update_status. This used to emit `{}`, which made four
+	// interchangeable routes answer in two different shapes.
 	CHttpServer::Response r;
 	r.status = 202;
-	r.content_type = "application/json";
-	CJsonWriter w;
-	w.BeginObject();
-	w.EndObject();
-	FinalizeJsonBody(w, r);
+	r.content_type.clear();
 	return r;
 }
 
@@ -11126,9 +11133,9 @@ CHttpServer::Response CApiDispatcher::HandleSearchStart(const CHttpServer::Reque
 	//    "type":  "local" | "global" | "kad" (default "global"),
 	//    "file_type":  string (optional, amule file-type label),
 	//    "extension":  string (optional, e.g. "mkv"),
-	//    "min_size":   uint64 bytes (optional, default 0),
-	//    "max_size":   uint64 bytes (optional, default 0 = no cap),
-	//    "min_avail":  uint32 (optional, default 0) }
+	//    "min_size_bytes":    uint64 (optional, default 0),
+	//    "max_size_bytes":    uint64 (optional, default 0 = no cap),
+	//    "min_source_count":  uint32 (optional, default 0) }
 	std::string query;
 	{
 		const auto it = obj.find("query");
@@ -11575,7 +11582,7 @@ CHttpServer::Response CApiDispatcher::HandleSearchComments(
 	r.content_type = "application/json";
 	CJsonWriter w;
 	w.BeginObject();
-	w.Key("count");
+	w.Key("total");
 	w.ValueInt(static_cast<int64_t>(hit.comments.size()));
 	w.Key("kad_comment_lookup_running");
 	w.ValueBool(hit.kad_comment_searching);

--- a/src/webapi/EventDiff.cpp
+++ b/src/webapi/EventDiff.cpp
@@ -268,9 +268,15 @@ std::string ToJson(const FriendSnapshot &f)
 	std::ostringstream o;
 	o << "{"
 	  << "\"ecid\":" << f.ecid << ",\"name\":\"" << EscJson(f.name) << "\""
-	  << ",\"user_hash\":\"" << EscJson(f.user_hash) << "\""
-	  << ",\"ip\":\"" << EscJson(f.ip) << "\""
-	  << ",\"port\":" << f.port
+	  << ",\"user_hash\":\"" << EscJson(f.user_hash)
+	  << "\""
+	  // null, not "" / 0, when the daemon has not reported an address: the
+	  // REST row this event promises key parity with emits null for both
+	  // (WriteFriendObject), and a subscriber hydrating from GET /friends
+	  // would otherwise see ip flip null -> "" on the first tick that
+	  // touches the row, with no real change behind it.
+	  << ",\"ip\":" << (f.ip.empty() ? std::string("null") : "\"" + EscJson(f.ip) + "\"")
+	  << ",\"port\":" << (f.ip.empty() ? std::string("null") : std::to_string(f.port))
 	  << ",\"client_ecid\":" << (f.client_ecid ? std::to_string(f.client_ecid) : std::string("null"))
 	  << ",\"online\":" << (f.client_ecid != 0 ? "true" : "false")
 	  << ",\"friend_slot\":" << (f.friend_slot ? "true" : "false") << "}";
@@ -282,13 +288,17 @@ std::string ToJson(const ClientSnapshot &c)
 	std::ostringstream o;
 	o << "{"
 	  << "\"ecid\":" << c.ecid << ",\"name\":\"" << EscJson(c.client_name) << "\""
-	  << ",\"user_hash\":\"" << EscJson(c.user_hash) << "\""
-	  << ",\"ip\":\"" << EscJson(c.ip) << "\""
+	  << ",\"user_hash\":\"" << EscJson(c.user_hash)
+	  << "\""
+	  // Same guard as country_code below and as WriteKnownClientObject's
+	  // has_addr, which nulls ip/port/kad_port together.
+	  << ",\"ip\":" << (c.ip.empty() ? std::string("null") : "\"" + EscJson(c.ip) + "\"")
 	  << ",\"country_code\":"
 	  // null, not "", when the lookup has not resolved -- the REST row this
 	  // event promises key parity with emits null here.
 	  << (c.country_code.empty() ? std::string("null") : "\"" + EscJson(c.country_code) + "\"")
-	  << ",\"port\":" << c.port << ",\"software\":\"" << EscJson(c.software) << "\""
+	  << ",\"port\":" << (c.ip.empty() ? std::string("null") : std::to_string(c.port))
+	  << ",\"software\":\"" << EscJson(c.software) << "\""
 	  << ",\"software_version\":\"" << EscJson(c.software_version) << "\""
 	  << ",\"reported_os\":\"" << EscJson(c.reported_os) << "\""
 	  << ",\"upload_state\":\"" << EscJson(c.upload_state) << "\""
@@ -397,8 +407,8 @@ std::string ToJsonStatusEvent(const StatusSnapshot &s, const KadSnapshot &k, boo
 	  << "\"temp_free_bytes\":" << JsonFreeSpace(s.temp_free_bytes)
 	  << ",\"incoming_free_bytes\":" << JsonFreeSpace(s.incoming_free_bytes) << "}"
 	  << ",\"queue\":{"
-	  << "\"upload_clients_waiting\":" << s.ul_queue_len
-	  << ",\"download_sources_total\":" << s.total_src_count << "}"
+	  << "\"waiting_upload_client_count\":" << s.ul_queue_len
+	  << ",\"download_source_count\":" << s.total_src_count << "}"
 	  << "}";
 	return o.str();
 }

--- a/unittests/curl-tests/amuleapi/03-read-status.sh
+++ b/unittests/curl-tests/amuleapi/03-read-status.sh
@@ -132,12 +132,13 @@ _assert_json_eq '.ed2k.user_id | type' number \
 # the server-assigned identity it actually is.
 _assert_json_eq '.ed2k | has("id")' false \
 	'ed2k.id is gone, replaced by ed2k.user_id'
-_assert_json_eq '.ed2k.public_ip | type' string \
-	'ed2k.public_ip is string'
+_assert_json_eq '.ed2k.public_ip | type | . == "string" or . == "null"' true \
+	'ed2k.public_ip is a string or null'
 # A public address exists exactly when we hold a HighID on a live connection;
-# a LowID carries none, and neither does a disconnected daemon.
-_assert_json_eq '(.ed2k.public_ip != "") == (.ed2k.high_id and .ed2k.state == "connected")' \
-	true 'ed2k.public_ip is non-empty exactly when high_id and connected'
+# a LowID carries none, and neither does a disconnected daemon. Absent is null,
+# not "" -- the surface spells "no value" one way (R10).
+_assert_json_eq '(.ed2k.public_ip != null) == (.ed2k.high_id and .ed2k.state == "connected")' \
+	true 'ed2k.public_ip is non-null exactly when high_id and connected'
 # The 0xffffffff "connect in flight" sentinel must never surface.
 _assert_json_eq '.ed2k.user_id != 4294967295' true \
 	'ed2k.user_id never reports the connecting sentinel'
@@ -178,10 +179,10 @@ _assert_json_eq '.speeds.download_overhead_bytes_per_second | type' number \
 	'speeds.download_overhead_bytes_per_second is numeric'
 _assert_json_eq '.speeds.upload_overhead_bytes_per_second | type' number \
 	'speeds.upload_overhead_bytes_per_second is numeric'
-_assert_json_eq '.queue.upload_clients_waiting | type' number \
-	'queue.upload_clients_waiting is numeric'
-_assert_json_eq '.queue.download_sources_total | type' number \
-	'queue.download_sources_total is numeric'
+_assert_json_eq '.queue.waiting_upload_client_count | type' number \
+	'queue.waiting_upload_client_count is numeric'
+_assert_json_eq '.queue.download_source_count | type' number \
+	'queue.download_source_count is numeric'
 
 # disk subtree: a number, or null when the daemon has no figure. Never the
 # unsigned reading of the -1 sentinel, and never 0 (which would read as a

--- a/unittests/curl-tests/amuleapi/05-read-servers-kad-categories-prefs.sh
+++ b/unittests/curl-tests/amuleapi/05-read-servers-kad-categories-prefs.sh
@@ -170,7 +170,8 @@ _assert_json_eq '(.lan_mode | not) or ((.firewalled_tcp | not) and (.firewalled_
 # measurement wearing the costume of one, and it is null now.
 _assert_json_eq '.connected_since_at | type' number  '/kad.connected_since_ate is numeric'
 # Ours. Named apart from the buddy's address, which the rename must not touch.
-_assert_json_eq '.public_ip        | type' string  '/kad.public_ip is string'
+_assert_json_eq '.public_ip | type | . == "string" or . == "null"' true \
+	'/kad.public_ip is a string or null'
 _assert_json_eq '.ip               | type' null    '/kad has no bare top-level ip'
 # 32 lowercase hex while Kad runs, "" while it does not -- gated on .state,
 # which is "disabled" exactly when amuled withholds EC_TAG_KAD_ID.
@@ -191,10 +192,10 @@ for F in network.user_count network.file_count network.node_count \
 done
 # indexed.load_percent is a load figure rather than a count, despite sitting beside
 # three counts -- covered by the loop above.
-# Two distinct "unknown" sentinels: "" while Kad is not connected, and a
+# Two distinct "unknown" answers: null while Kad is not connected, and a
 # syntactically valid 0.0.0.0 while connected but not yet told our address.
-_assert_json_eq '(.state == "connected") or (.public_ip == "")' \
-	true '/kad.public_ip is empty while Kad is not connected'
+_assert_json_eq '(.state == "connected") or (.public_ip == null)' \
+	true '/kad.public_ip is null while Kad is not connected'
 # Gated with the rest: `no_buddy` is a real state, so reporting it on a stopped
 # Kad claimed we had looked and found none. Null when not connected; the enum
 # and the types still hold while connected.

--- a/unittests/curl-tests/amuleapi/19-search.sh
+++ b/unittests/curl-tests/amuleapi/19-search.sh
@@ -814,7 +814,7 @@ if [ -n "$CMT_HASH" ]; then
 	_curl -H "Authorization: Bearer $ADMIN_TOKEN" \
 		"$HOST/api/v0/search/results/$CMT_HASH/comments"
 	_assert_status 200 "GET /search/results/{hash}/comments → 200"
-	_assert_json_eq '.count | type' number 'search comments.count is numeric'
+	_assert_json_eq '.total | type' number 'search comments.total is numeric'
 	_assert_json_eq '.kad_comment_lookup_running | type' boolean \
 		'search comments carries kad_comment_lookup_running flag'
 	_assert_json_eq '.comments | type' array 'search comments.comments is an array'

--- a/unittests/curl-tests/amuleapi/22-sse-diff-emission.sh
+++ b/unittests/curl-tests/amuleapi/22-sse-diff-emission.sh
@@ -390,7 +390,7 @@ fi
 # is validated manually.
 CU=$(grep -A1 "^event: comments_updated$" "$SSE_OUT" | grep "^data: " | head -1 | sed 's/^data: //')
 if [ -n "$CU" ]; then
-	if echo "$CU" | jq -e '(.hash|type=="string") and (.count|type=="number") and (.comments|type=="array")' >/dev/null 2>&1; then
+	if echo "$CU" | jq -e '(.hash|type=="string") and (.total|type=="number") and (.comments|type=="array")' >/dev/null 2>&1; then
 		_pass "comments_updated payload shape valid"
 	else
 		_fail "comments_updated payload shape" "unexpected: $CU"


### PR DESCRIPTION
The mechanical half of #1240: the one client-visible defect, the coherence gaps around it, and the documentation drift. The naming decisions (§7-§9) and the enum-value rename (§4) are deliberately left out.

### §1 - and it is wider than reported

`friend.ip` was `null` over REST and `""` over SSE, so a subscriber hydrating from `GET /friends` saw the value flip on the first tick that touched the row, with no real change behind it.

The audit reports friends. **The client serializer has the same split**, for `ip` *and* `port`, two lines from a `country_code` that guards correctly and carries a comment stating the rule those fields break. Both are fixed, so the REST and SSE payloads agree.

### §2 - plus one field the audit excluded

`friend.port`, `ed2k.public_ip`, `ed2k.server_ip` and `kad.public_ip` now go through the `OrNull` writers.

Beyond the audit: **the peer's `server_ip` on `GET /clients/{ecid}`**. `WriteStringOrNull`'s comment defended it as legitimately `""` for a peer with no server, which is presumably why it was excluded. The snapshot field says otherwise - `ClientSnapshot::server_ip` is documented `"" when unknown/0`. It cannot be both: a peer with no server and a peer whose server we have not learned collapse to the same `""`, which is exactly what `null` exists to separate. `server_ip` and `server_port` now null together, matching `ip`/`port`/`kad_port` on the base row, and the comment is corrected - `0` is a real answer for a count, `""` is not one for an address.

`ed2k.server_ip` needs the same note in reverse: that comment is about a PEER's server, not our own connection, where `ed2k.state` already reports whether a server exists.

### §3, §5, §6

`POST /geoip/update` answered `202` with a `{}` body while its three sibling fetch routes answer `202` with none - its own comment claimed otherwise. `count` becomes `total` on the search-comments route, the only such key on the surface. The two `queue.*` counts gain `_count`, **and the SSE `status_changed` payload moves with them** - renaming only the REST side would have opened the very REST/SSE divergence §1 exists to close.

### §10, §11, §12 - docs and a comment

A `409 conflict` code that was split into `option_not_supported` / `not_a4af_source`; a graph-point `t` key the R3 pass dropped from the writer; a `POST /search` comment naming three body keys the parser rejects.

### Two curl assertions were already wrong

`22-sse-diff-emission` asserted `.count` on a `comments_updated` payload that has only ever emitted `.total`. It survives because its branch needs a Kad note the smoke daemon cannot force - an assertion that could never have passed if it ran.

### Verification

47/47 ctest; clang-format and both clang-tidy tiers clean with 0 compiler errors. Curl phases 03 (39/39) and 05 (99/99) green. For the search phases I ran a throwaway daemon connected to a real eD2k server: 144 assertions, with `search comments.total is numeric` passing against a live result. The 4 remaining failures are all `type=kad` with Kad disabled in that config.

**No curl assertion covers the peer's `server_ip` / `server_port`**, so nothing needed updating there - a coverage gap worth its own look rather than a reason for comfort.

The Web UI needs no change: every consumer of these fields is either a truthiness test, which `""` and `null` both satisfy, or a helper that already does `String(v || "")`.
