### PR TITLE
ci(packaging): retry the dmg build, and verify NSIS actually installed

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -487,8 +487,7 @@ jobs:
           cp -R aMule.app    "${STAGE}/"
           cp -R aMuleGUI.app "${STAGE}/"
           ln -s /Applications "${STAGE}/Applications"
-          hdiutil create -volname "aMule ${VERSION}" \
-              -srcfolder "${STAGE}" -ov -format UDZO \
+          packaging/macos/create-dmg.sh "aMule ${VERSION}" "${STAGE}" \
               "dist/aMule-${VERSION}-macOS-universal2.dmg"
       - uses: actions/upload-artifact@v7
         with:
@@ -683,7 +682,29 @@ jobs:
         # build.sh installer auto-discovers makensis at the standard
         # install dir, so no $GITHUB_PATH plumbing is needed.
         shell: pwsh
-        run: choco install -y --no-progress nsis
+        run: |
+          # choco exits 0 when the community feed is unreachable ("Unable to
+          # find package 'nsis'" after a 504), so the missing tool only
+          # surfaces two steps later as "makensis not on PATH". Verify what
+          # actually landed, at the paths build.sh searches, and retry the
+          # outage rather than trusting the exit code.
+          $nsis = @(
+            "C:\Program Files (x86)\NSIS\makensis.exe",
+            "C:\Program Files\NSIS\makensis.exe"
+          )
+          foreach ($attempt in 1..3) {
+            if ($nsis | Where-Object { Test-Path $_ }) { break }
+            if ($attempt -gt 1) {
+              Write-Host "NSIS still missing, retrying in 20s (attempt $attempt/3)"
+              Start-Sleep -Seconds 20
+            }
+            choco install -y --no-progress nsis
+          }
+          $found = $nsis | Where-Object { Test-Path $_ }
+          if (-not $found) {
+            throw "NSIS install reported success but makensis.exe is at neither $($nsis -join ' nor ')"
+          }
+          Write-Host "makensis: $($found[0])"
       - name: Configure git safe.directory for MSYS2 git
         run: git config --global --add safe.directory '*'
       - name: Download portable .zip from windows-zip job

--- a/packaging/macos/build.sh
+++ b/packaging/macos/build.sh
@@ -171,12 +171,7 @@ make_dmg() {
     ln -s /Applications "${stage}/Applications"
 
     local out="${DIST_DIR}/aMule-${VERSION}-macOS.dmg"
-    rm -f "${out}"
-    hdiutil create \
-        -volname "aMule ${VERSION}" \
-        -srcfolder "${stage}" \
-        -ov -format UDZO \
-        "${out}"
+    "${SCRIPT_DIR}/create-dmg.sh" "aMule ${VERSION}" "${stage}" "${out}"
 
     echo "==> Produced ${out}"
 }

--- a/packaging/macos/create-dmg.sh
+++ b/packaging/macos/create-dmg.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# Compressed .dmg from a staged folder, with a retry.
+#
+# Usage:
+#   packaging/macos/create-dmg.sh <volume-name> <src-folder> <out.dmg>
+#
+# hdiutil attaches the image it is building, so it loses to whatever else on
+# the machine touches the new volume first (Spotlight, disk arbitration) and
+# fails with "hdiutil: create failed - Resource busy". Nothing the caller does
+# causes it and nothing prevents it, so retry instead of losing the build:
+# observed on CI twice in one morning, a different arch each time. Shared by
+# build.sh and the Universal2 job so both get the same behaviour.
+
+set -euo pipefail
+
+if [[ $# -ne 3 ]]; then
+    echo "usage: $0 <volume-name> <src-folder> <out.dmg>" >&2
+    exit 2
+fi
+
+volname="$1"
+srcfolder="$2"
+out="$3"
+
+for attempt in 1 2 3; do
+    rm -f "${out}"
+    if hdiutil create \
+        -volname "${volname}" \
+        -srcfolder "${srcfolder}" \
+        -ov -format UDZO \
+        "${out}"; then
+        exit 0
+    fi
+    if [[ ${attempt} -eq 3 ]]; then
+        echo "fatal: hdiutil create failed ${attempt} times." >&2
+        exit 1
+    fi
+    echo "==> hdiutil create failed (attempt ${attempt}/3), retrying in 15s"
+    sleep 15
+done


### PR DESCRIPTION
Two packaging jobs failed on master this morning, neither for a reason connected to the code they were building.

### `hdiutil: create failed - Resource busy`

`hdiutil create -srcfolder` attaches the image it is building, so it loses to whatever else on the machine touches the new volume first (Spotlight, disk arbitration). Nothing in `make_dmg` races itself: the `cp -R` calls complete first, and the job's other `attach`/`detach` pair runs in a later step.

The failure pattern says the same thing:

| Run | arm64 | x86_64 |
|---|---|---|
| 33612291950 | success | **busy** |
| 33609211540 | **busy** | success |
| the four runs before those | success | success |

Two hits in consecutive runs, a different arch each time, never both in one run: a per-runner race, not a defect in the recipe. It now retries three times with a 15 s backoff.

The same `hdiutil create` was spelled out twice, in `build.sh` and in the Universal2 job, so the retry went into one helper (`packaging/macos/create-dmg.sh`) that both call rather than being pasted into each.

### `makensis` not on PATH

The x64 installer failed with `fatal: 'makensis' not on PATH`, but NSIS was never the problem:

```
Failed to fetch results from V2 feed ... 504 (Gateway Timeout).
Unable to find package 'nsis'.
```

Chocolatey's feed was down and **`choco install -y` exited 0 anyway**, so the step went green having installed nothing, and the failure surfaced two steps later pointing at the wrong thing. The step now tests the two paths `build.sh` searches, retries the outage, and throws with what actually happened when the tool is missing, so an outage fails at the step that caused it.

### Verification

`create-dmg.sh` was run locally both ways: against a staged `.app` plus the `/Applications` symlink it produces a `UDZO` image (confirmed with `hdiutil imageinfo`); against an unusable source it makes three attempts, prints two backoffs and exits 1, so the loop is not vacuous. The file is committed `100755`, and the Universal2 job checks out the repo, so the helper is present and executable there. YAML parses under `ruby -ryaml`.

The packaging run itself is the real test, since neither path runs in PR CI.
