### PR TITLE
refactor(amuleapi,web-ui): name the search row id "search_id" everywhere

### DIFF
--- a/docs/api/REFERENCE.md
+++ b/docs/api/REFERENCE.md
@@ -316,7 +316,7 @@ Rows added or removed *during* a sweep are not missed: both emit an SSE event, s
 | `GET /friends`        | **`ecid`** (id), `name`, `online` |
 | `GET /chats`          | **`client_ecid`** (id), `last_message_at`, `name` |
 | `GET /search/{id}/results` | **`hash`** (id), `name`, `size_bytes`, `sources.total`, `rating`, `directory` |
-| `GET /search`         | **`id`** (id), `query`, `started_at`, `result_count` |
+| `GET /search`         | **`search_id`** (id), `query`, `started_at`, `result_count` |
 | `GET /categories`     | **`index`** (id), `name` |
 
 The column marked **id** is the endpoint's identity: immutable for the life of the row, and the only one `after` accepts. Note that `ecid` is stable **within a daemon session** only — `CECID` hands ids out from a counter that restarts with the process — which is enough for a bootstrap sweep, since a reconnect invalidates the sweep anyway and triggers a `resync`.
@@ -1388,7 +1388,7 @@ curl -s -X POST -H "Authorization: Bearer $TOKEN" \
 {
   "search_id":   17,
   "query":       "some client",
-  "kind":        "browse",
+  "type":        "browse",
   "state":       "running",
   "client_ecid": null,
   "started_at":  1750412400
@@ -2838,9 +2838,9 @@ Lists every search amuled currently holds — including ones started by a **diff
 ```json
 {
   "searches": [
-    { "id": 42, "query": "ubuntu desktop iso", "type": "global", "state": "finished", "client_ecid": null, "started_at": 1751000000, "result_count": 182 },
-    { "id": 43, "query": "debian",             "type": "kad",    "state": "running",  "client_ecid": null, "started_at": 1751000042, "result_count": 57  },
-    { "id": 44, "query": "SomePeerNick",       "type": "browse", "state": "running",  "client_ecid": 621,  "result_count": 237 }
+    { "search_id": 42, "query": "ubuntu desktop iso", "type": "global", "state": "finished", "client_ecid": null, "started_at": 1751000000, "result_count": 182 },
+    { "search_id": 43, "query": "debian",             "type": "kad",    "state": "running",  "client_ecid": null, "started_at": 1751000042, "result_count": 57  },
+    { "search_id": 44, "query": "SomePeerNick",       "type": "browse", "state": "running",  "client_ecid": 621,  "result_count": 237 }
   ],
   "total": 3,
   "offset": 0,
@@ -2848,9 +2848,9 @@ Lists every search amuled currently holds — including ones started by a **diff
 }
 ```
 
-This is a list endpoint like the others: it takes `?limit`, `?offset`, `?sort` and `?order`, and carries the same `total` / `offset` / `limit` trio. See [List pagination and sorting](#list-pagination-and-sorting); the sort keys are `id`, `query`, `started_at` and `result_count`.
+This is a list endpoint like the others: it takes `?limit`, `?offset`, `?sort` and `?order`, and carries the same `total` / `offset` / `limit` trio. See [List pagination and sorting](#list-pagination-and-sorting); the sort keys are `search_id`, `query`, `started_at` and `result_count`.
 
-`id` is the value that fills `{id}` on every search-scoped path: [`GET /search/{id}/results`](#get-apiv0searchidresults) to read its hits, [`POST /search/{id}/stop`](#post-apiv0searchidstop) to stop it, [`DELETE /search/{id}`](#delete-apiv0searchid) to free it. `type` is `"local"` | `"global"` | `"kad"` | `"browse"`. The first three are the vocabulary `POST /search`'s `type` accepts; `"browse"` is reported only, for a "View Files" listing of one client's share, which is started through the client endpoints rather than by a query. `state` is `"running"` | `"finished"` | `"idle"`, same vocabulary and meaning as `GET /search/{id}/results`'s `progress.state`.
+`search_id` is the value that fills `{id}` on every search-scoped path: [`GET /search/{id}/results`](#get-apiv0searchidresults) to read its hits, [`POST /search/{id}/stop`](#post-apiv0searchidstop) to stop it, [`DELETE /search/{id}`](#delete-apiv0searchid) to free it. `type` is `"local"` | `"global"` | `"kad"` | `"browse"`. The first three are the vocabulary `POST /search`'s `type` accepts; `"browse"` is reported only, for a "View Files" listing of one client's share, which is started through the client endpoints rather than by a query. `state` is `"running"` | `"finished"` | `"idle"`, same vocabulary and meaning as `GET /search/{id}/results`'s `progress.state`.
 
 For a `"browse"` entry, `state` and the results endpoint's `progress.percent` come from the browse's own lifecycle rather than from a query's: the request being sent is `"running"`, and the client having answered, denied the request, or disconnected mid-list is `"finished"` — a browse is never reported as `"idle"`. `percent` is the share of the client's directory list received so far, so it climbs while the listing streams in rather than jumping straight from `0` to `100`.
 
@@ -2896,7 +2896,7 @@ Only `query` is required. `type` defaults to `"global"`; valid values are `"loca
 
 ```json
 {
-  "id":         42,
+  "search_id":  42,
   "query":       "ubuntu desktop iso",
   "type":        "global",
   "state":       "running",
@@ -2905,7 +2905,7 @@ Only `query` is required. `type` defaults to `"global"`; valid values are `"loca
 }
 ```
 
-Keep the `id` to read this search's results/progress or to stop it. This is one of the two creations that answer with the resource, because `EC_OP_SEARCH_START` really does hand one back; the ones whose EC op answers success or failure and nothing more are a bare `202` with no body.
+Keep the `search_id` to read this search's results/progress or to stop it. This is one of the two creations that answer with the resource, because `EC_OP_SEARCH_START` really does hand one back; the ones whose EC op answers success or failure and nothing more are a bare `202` with no body.
 
 **Errors:** `502 amuled_rejected` (daemon returned no search_id), `503 ec_unavailable`.
 

--- a/src/webapi/Api.cpp
+++ b/src/webapi/Api.cpp
@@ -3475,10 +3475,10 @@ struct SearchListRow
 void WriteSearchListRow(CJsonWriter &w, const SearchListRow &row)
 {
 	w.BeginObject();
-	// `id`, not `search_id`: the object would be prefixing its own key with
-	// its own type. References from OUTSIDE keep the prefix -- the SSE
-	// payloads and the results envelope point into this object.
-	w.Key("id");
+	// `search_id`, the same key the SSE payloads and the results envelope
+	// already use for this value -- one spelling for a search's id across the
+	// whole surface, so a client never has to read it under two names.
+	w.Key("search_id");
 	w.ValueInt(static_cast<int64_t>(row.search_id));
 	w.Key("query");
 	w.ValueString(row.query);
@@ -3504,7 +3504,7 @@ void WriteSearchListRow(CJsonWriter &w, const SearchListRow &row)
 const ListComparators<SearchListRow> &SearchListComparators()
 {
 	static const ListComparators<SearchListRow> kComps = {
-		{ "id", SORT_BY(search_id), ANCHOR_ON_NUM(search_id) },
+		{ "search_id", SORT_BY(search_id), ANCHOR_ON_NUM(search_id) },
 		{ "query", SORT_BY(query) },
 		{ "started_at", SORT_BY(started_at) },
 		{ "result_count", SORT_BY(result_count) },

--- a/src/webapi/static/js/searches.js
+++ b/src/webapi/static/js/searches.js
@@ -137,7 +137,7 @@ async function adopt() {
   list = list.slice().sort((a, b) => ord(a) - ord(b));
   let added = false;
   for (const s of list) {
-    const known = tabs.get(s.id);
+    const known = tabs.get(s.search_id);
     if (known) {
       if (!known.query && s.query) { known.query = s.query; known.label = known.label || s.query; }
       // Keep an unopened tab's badge current. Only while it holds no results
@@ -153,8 +153,8 @@ async function adopt() {
     // result_count is what makes an unopened tab show a real badge instead of
     // 0 after a reload; it is omitted by a daemon that does not report counts,
     // in which case the badge stays 0 until the tab is opened and fetched.
-    tabs.set(s.id, newTab({
-      id: s.id, query: s.query || "", kind: s.type || "global",
+    tabs.set(s.search_id, newTab({
+      id: s.search_id, query: s.query || "", kind: s.type || "global",
       state: s.state || "finished", startedAt: s.started_at || 0,
       count: typeof s.result_count === "number" ? s.result_count : 0,
     }));
@@ -163,7 +163,7 @@ async function adopt() {
   if (!tabs.has(activeId)) {
     const running = list.filter((s) => s.state === "running");
     const pick = (running.length ? running : list).slice(-1)[0];
-    if (pick) { setActive(pick.id); return; }
+    if (pick) { setActive(pick.search_id); return; }
     activeId = 0;
   }
   if (added) publishTabs();
@@ -308,7 +308,7 @@ export const searches = {
     // from what we asked for -- `kind` and `startedAt` in particular, which
     // the request only implies.
     const r = await api.post("search", body);
-    const id = r.id;
+    const id = r.search_id;
     tabs.set(id, newTab({
       id, query: r.query || body.query || "", label: label || "",
       kind: r.type || body.type || "global",
@@ -329,7 +329,7 @@ export const searches = {
   // filter, per-row category) for a browse that never restarted.
   async browse(ecid, name) {
     const r = await api.post("clients/" + ecid + "/shared_files");
-    const id = r.id;
+    const id = r.search_id;
     const open = tabs.get(id);
     if (open) {
       if (name) { open.query = name; open.label = name; }


### PR DESCRIPTION
Enforce the REST/SSE alignment rule -- EVENTS.md: "the _added and _updated payloads are BYTE-FOR-BYTE identical to the matching REST resource's list-item shape" -- and R6 ("one concept, one key, everywhere"): the same value must carry one name across the whole surface, however it reaches the client.

The search id broke that rule. GET /search rows, the POST /search response and the two browse responses serialized it as "id", while the SSE search_* payloads and the GET /search/{id}/results envelope named the same value "search_id". A bare "id" cannot work on the stream -- search_result_added prepends it beside the result's own "hash", and search_closed is "{search_id}" on its own -- so "search_id" is the id's real name on the wire and the REST row was the lone outlier. Unifying up to "search_id" is the smaller, rule-compliant fix.

- amuleapi: WriteSearchListRow emits "search_id"; the /search sort key is renamed "id" -> "search_id" (?sort=search_id). No default-order change: an unsorted list still preserves the daemon's order.
- web UI: searches.js reads search_id from GET /search, POST /search and the browse responses. The tab object's internal `id` is unchanged.
- docs: GET /search and POST /search examples, the sortable-fields table and the surrounding prose use search_id. Also fixes the browse example, which showed "kind" where the row field is "type".

Verified against a rebuilt daemon: GET/POST /search and both browse routes return "search_id"; ?sort=search_id sorts and ?sort=id is 400; and the web UI's adopt/start/browse plus live SSE result streaming all work.