### PR TITLE
fix(gui): drop "Swap to this file" from the Clients list

### DIFF
--- a/po/amule.pot
+++ b/po/amule.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-01 11:32+0200\n"
+"POT-Creation-Date: 2026-09-02 12:15+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1211,10 +1211,6 @@ msgstr ""
 
 #: src/ClientContextActions.cpp
 msgid "Send message"
-msgstr ""
-
-#: src/ClientContextActions.cpp
-msgid "Swap to this file"
 msgstr ""
 
 #: src/ClientContextActions.cpp
@@ -2757,6 +2753,10 @@ msgstr ""
 
 #: src/GenericClientListCtrl.cpp
 msgid "One block per part of the shared file."
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "Swap to this file"
 msgstr ""
 
 #: src/GenericClientListCtrl.cpp

--- a/po/ar.po
+++ b/po/ar.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-01 11:32+0200\n"
+"POT-Creation-Date: 2026-09-02 12:15+0200\n"
 "PO-Revision-Date: 2026-09-01 17:57+0000\n"
 "Last-Translator: saleh alhathal <hathalsal@hotmail.com>\n"
 "Language-Team: \n"
@@ -1237,10 +1237,6 @@ msgstr "اعرض الملفات"
 
 #: src/ClientContextActions.cpp
 msgid "Send message"
-msgstr ""
-
-#: src/ClientContextActions.cpp
-msgid "Swap to this file"
 msgstr ""
 
 #: src/ClientContextActions.cpp
@@ -2804,6 +2800,10 @@ msgstr ""
 
 #: src/GenericClientListCtrl.cpp
 msgid "One block per part of the shared file."
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "Swap to this file"
 msgstr ""
 
 #: src/GenericClientListCtrl.cpp

--- a/po/ast.po
+++ b/po/ast.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-01 11:32+0200\n"
+"POT-Creation-Date: 2026-09-02 12:15+0200\n"
 "PO-Revision-Date: 2026-09-01 17:58+0000\n"
 "Last-Translator: astur <malditoastur@gmail.com>\n"
 "Language-Team: Language ast <malditoastur@gmail.com>\n"
@@ -1254,10 +1254,6 @@ msgstr "Ver ficheros"
 #: src/ClientContextActions.cpp
 msgid "Send message"
 msgstr "Unviar mensax"
-
-#: src/ClientContextActions.cpp
-msgid "Swap to this file"
-msgstr "Intercambia esti ficheru"
 
 #: src/ClientContextActions.cpp
 #, fuzzy
@@ -2865,6 +2861,10 @@ msgstr ""
 #, fuzzy
 msgid "One block per part of the shared file."
 msgstr "Introduz el puertu del sirvidor"
+
+#: src/GenericClientListCtrl.cpp
+msgid "Swap to this file"
+msgstr "Intercambia esti ficheru"
 
 #: src/GenericClientListCtrl.cpp
 msgid "Colour legend"

--- a/po/bg.po
+++ b/po/bg.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-01 11:32+0200\n"
+"POT-Creation-Date: 2026-09-02 12:15+0200\n"
 "PO-Revision-Date: 2026-09-01 18:00+0000\n"
 "Last-Translator: Sebastiano Pistore <SebastianoPistore.info@protonmail.ch>\n"
 "Language-Team: Bulgarian <dict@linux.zonebg.com>\n"
@@ -1231,10 +1231,6 @@ msgstr "Преглед на файловете"
 
 #: src/ClientContextActions.cpp
 msgid "Send message"
-msgstr ""
-
-#: src/ClientContextActions.cpp
-msgid "Swap to this file"
 msgstr ""
 
 #: src/ClientContextActions.cpp
@@ -2800,6 +2796,10 @@ msgstr ""
 
 #: src/GenericClientListCtrl.cpp
 msgid "One block per part of the shared file."
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "Swap to this file"
 msgstr ""
 
 #: src/GenericClientListCtrl.cpp

--- a/po/bn.po
+++ b/po/bn.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-01 11:32+0200\n"
+"POT-Creation-Date: 2026-09-02 12:15+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -1210,10 +1210,6 @@ msgstr ""
 
 #: src/ClientContextActions.cpp
 msgid "Send message"
-msgstr ""
-
-#: src/ClientContextActions.cpp
-msgid "Swap to this file"
 msgstr ""
 
 #: src/ClientContextActions.cpp
@@ -2756,6 +2752,10 @@ msgstr ""
 
 #: src/GenericClientListCtrl.cpp
 msgid "One block per part of the shared file."
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "Swap to this file"
 msgstr ""
 
 #: src/GenericClientListCtrl.cpp

--- a/po/ca.po
+++ b/po/ca.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-01 11:32+0200\n"
+"POT-Creation-Date: 2026-09-02 12:15+0200\n"
 "PO-Revision-Date: 2026-09-01 18:01+0000\n"
 "Last-Translator: minterior <minterior@gmail.com>\n"
 "Language-Team: Català\n"
@@ -1252,10 +1252,6 @@ msgstr "Veure els compartits"
 #: src/ClientContextActions.cpp
 msgid "Send message"
 msgstr "Envia un missatge"
-
-#: src/ClientContextActions.cpp
-msgid "Swap to this file"
-msgstr "Intercanvia cap a aquest fitxer"
 
 #: src/ClientContextActions.cpp
 #, fuzzy
@@ -2858,6 +2854,10 @@ msgstr ""
 #, fuzzy
 msgid "One block per part of the shared file."
 msgstr "Introduïu el port del servidor."
+
+#: src/GenericClientListCtrl.cpp
+msgid "Swap to this file"
+msgstr "Intercanvia cap a aquest fitxer"
 
 #: src/GenericClientListCtrl.cpp
 msgid "Colour legend"

--- a/po/cs.po
+++ b/po/cs.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-01 11:32+0200\n"
+"POT-Creation-Date: 2026-09-02 12:15+0200\n"
 "PO-Revision-Date: 2026-09-01 18:02+0000\n"
 "Last-Translator: David Watzke <david@watzke.cz>\n"
 "Language-Team: cs <cs@li.org>\n"
@@ -1256,10 +1256,6 @@ msgstr "Zobrazit soubory"
 #: src/ClientContextActions.cpp
 msgid "Send message"
 msgstr "Poslat zprávu"
-
-#: src/ClientContextActions.cpp
-msgid "Swap to this file"
-msgstr "Swapovat do tohoto souboru"
 
 #: src/ClientContextActions.cpp
 msgid ""
@@ -2860,6 +2856,10 @@ msgstr ""
 #, fuzzy
 msgid "One block per part of the shared file."
 msgstr "Zadejte port serveru."
+
+#: src/GenericClientListCtrl.cpp
+msgid "Swap to this file"
+msgstr "Swapovat do tohoto souboru"
 
 #: src/GenericClientListCtrl.cpp
 msgid "Colour legend"

--- a/po/da.po
+++ b/po/da.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-01 11:32+0200\n"
+"POT-Creation-Date: 2026-09-02 12:15+0200\n"
 "PO-Revision-Date: 2026-09-01 18:04+0000\n"
 "Last-Translator: Alex Thomsen Leth <alexl@stofanet.dk>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -1240,10 +1240,6 @@ msgstr "Se Filer"
 
 #: src/ClientContextActions.cpp
 msgid "Send message"
-msgstr ""
-
-#: src/ClientContextActions.cpp
-msgid "Swap to this file"
 msgstr ""
 
 #: src/ClientContextActions.cpp
@@ -2810,6 +2806,10 @@ msgstr ""
 
 #: src/GenericClientListCtrl.cpp
 msgid "One block per part of the shared file."
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "Swap to this file"
 msgstr ""
 
 #: src/GenericClientListCtrl.cpp

--- a/po/de.po
+++ b/po/de.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-01 11:32+0200\n"
+"POT-Creation-Date: 2026-09-02 12:15+0200\n"
 "PO-Revision-Date: 2026-09-01 18:05+0000\n"
 "Last-Translator: Werner Mahr <werner@vollstreckernet.de>\n"
 "Language-Team: German <>\n"
@@ -1261,10 +1261,6 @@ msgstr "Dateien ansehen"
 #: src/ClientContextActions.cpp
 msgid "Send message"
 msgstr "Sende Nachricht"
-
-#: src/ClientContextActions.cpp
-msgid "Swap to this file"
-msgstr "Zu dieser Datei verschieben"
 
 #: src/ClientContextActions.cpp
 msgid ""
@@ -2863,6 +2859,10 @@ msgstr ""
 #, fuzzy
 msgid "One block per part of the shared file."
 msgstr "Hier den Serverport eingeben."
+
+#: src/GenericClientListCtrl.cpp
+msgid "Swap to this file"
+msgstr "Zu dieser Datei verschieben"
 
 #: src/GenericClientListCtrl.cpp
 msgid "Colour legend"

--- a/po/el.po
+++ b/po/el.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-01 11:32+0200\n"
+"POT-Creation-Date: 2026-09-02 12:15+0200\n"
 "PO-Revision-Date: 2026-09-01 18:06+0000\n"
 "Last-Translator: Dimitris <dgalanak@yahoo.com>\n"
 "Language-Team: Greek\n"
@@ -1263,10 +1263,6 @@ msgstr "Παρουσίαση αρχείων"
 #: src/ClientContextActions.cpp
 msgid "Send message"
 msgstr "Αποστολή μηνύματος"
-
-#: src/ClientContextActions.cpp
-msgid "Swap to this file"
-msgstr "Εναλλαγή σε αυτό το αρχείο"
 
 #: src/ClientContextActions.cpp
 #, fuzzy
@@ -2874,6 +2870,10 @@ msgstr ""
 #, fuzzy
 msgid "One block per part of the shared file."
 msgstr "Γράψτε την θύρα του διακομιστή εδώ."
+
+#: src/GenericClientListCtrl.cpp
+msgid "Swap to this file"
+msgstr "Εναλλαγή σε αυτό το αρχείο"
 
 #: src/GenericClientListCtrl.cpp
 msgid "Colour legend"

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-01 11:32+0200\n"
+"POT-Creation-Date: 2026-09-02 12:15+0200\n"
 "PO-Revision-Date: 2020-03-04 14:43+0100\n"
 "Last-Translator: Dévai Tamás <devait@vnet.hu>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -1211,10 +1211,6 @@ msgstr ""
 
 #: src/ClientContextActions.cpp
 msgid "Send message"
-msgstr ""
-
-#: src/ClientContextActions.cpp
-msgid "Swap to this file"
 msgstr ""
 
 #: src/ClientContextActions.cpp
@@ -2757,6 +2753,10 @@ msgstr ""
 
 #: src/GenericClientListCtrl.cpp
 msgid "One block per part of the shared file."
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "Swap to this file"
 msgstr ""
 
 #: src/GenericClientListCtrl.cpp

--- a/po/es.po
+++ b/po/es.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-01 11:32+0200\n"
+"POT-Creation-Date: 2026-09-02 12:15+0200\n"
 "PO-Revision-Date: 2026-09-01 18:07+0000\n"
 "Last-Translator: Diego Heras <ngosang@hotmail.es>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/amule/amule-application/es/>\n"
@@ -1258,10 +1258,6 @@ msgstr "Ver los archivos"
 #: src/ClientContextActions.cpp
 msgid "Send message"
 msgstr "Enviar un mensaje"
-
-#: src/ClientContextActions.cpp
-msgid "Swap to this file"
-msgstr "Intercambiar a este archivo"
 
 #: src/ClientContextActions.cpp
 msgid ""
@@ -2851,6 +2847,10 @@ msgstr "Un bloque por parte del archivo que se está descargando."
 #: src/GenericClientListCtrl.cpp
 msgid "One block per part of the shared file."
 msgstr "Un bloque por parte del archivo compartido."
+
+#: src/GenericClientListCtrl.cpp
+msgid "Swap to this file"
+msgstr "Intercambiar a este archivo"
 
 #: src/GenericClientListCtrl.cpp
 msgid "Colour legend"

--- a/po/et_EE.po
+++ b/po/et_EE.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-01 11:32+0200\n"
+"POT-Creation-Date: 2026-09-02 12:15+0200\n"
 "PO-Revision-Date: 2026-09-01 18:08+0000\n"
 "Last-Translator: \n"
 "Language-Team: Estonian <kde-i18n-doc@kde.org>\n"
@@ -1252,10 +1252,6 @@ msgstr "Vaata faile"
 #: src/ClientContextActions.cpp
 msgid "Send message"
 msgstr "Saada teade"
-
-#: src/ClientContextActions.cpp
-msgid "Swap to this file"
-msgstr "Tõsta selle faili külge"
 
 #: src/ClientContextActions.cpp
 #, fuzzy
@@ -2858,6 +2854,10 @@ msgstr ""
 #, fuzzy
 msgid "One block per part of the shared file."
 msgstr "Sisesta siia serveri port."
+
+#: src/GenericClientListCtrl.cpp
+msgid "Swap to this file"
+msgstr "Tõsta selle faili külge"
 
 #: src/GenericClientListCtrl.cpp
 msgid "Colour legend"

--- a/po/eu.po
+++ b/po/eu.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-01 11:32+0200\n"
+"POT-Creation-Date: 2026-09-02 12:15+0200\n"
 "PO-Revision-Date: 2026-09-01 18:09+0000\n"
 "Last-Translator: Piarres Beobide <pi@beobide.net>\n"
 "Language-Team: Euskara <librezale@librezale.org>\n"
@@ -1253,10 +1253,6 @@ msgstr "Ikusi fitxategiak"
 #: src/ClientContextActions.cpp
 msgid "Send message"
 msgstr "Mezua bidali"
-
-#: src/ClientContextActions.cpp
-msgid "Swap to this file"
-msgstr "Swap fitxategi honentzat"
 
 #: src/ClientContextActions.cpp
 #, fuzzy
@@ -2859,6 +2855,10 @@ msgstr ""
 #, fuzzy
 msgid "One block per part of the shared file."
 msgstr "Idatzi zerbitzariaren ataka hemen."
+
+#: src/GenericClientListCtrl.cpp
+msgid "Swap to this file"
+msgstr "Swap fitxategi honentzat"
 
 #: src/GenericClientListCtrl.cpp
 msgid "Colour legend"

--- a/po/fi.po
+++ b/po/fi.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-01 11:32+0200\n"
+"POT-Creation-Date: 2026-09-02 12:15+0200\n"
 "PO-Revision-Date: 2026-09-01 18:10+0000\n"
 "Last-Translator: Tapio Rantala <tapio.rantala@iki.fi>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -1253,10 +1253,6 @@ msgstr "Näytä tiedostot"
 #: src/ClientContextActions.cpp
 msgid "Send message"
 msgstr "Lähetä viesti"
-
-#: src/ClientContextActions.cpp
-msgid "Swap to this file"
-msgstr "Vaihda tähän tiedostoon"
 
 #: src/ClientContextActions.cpp
 #, fuzzy
@@ -2859,6 +2855,10 @@ msgstr ""
 #, fuzzy
 msgid "One block per part of the shared file."
 msgstr "Syötä palvelimen portti tähän."
+
+#: src/GenericClientListCtrl.cpp
+msgid "Swap to this file"
+msgstr "Vaihda tähän tiedostoon"
 
 #: src/GenericClientListCtrl.cpp
 msgid "Colour legend"

--- a/po/fr.po
+++ b/po/fr.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-01 11:32+0200\n"
+"POT-Creation-Date: 2026-09-02 12:15+0200\n"
 "PO-Revision-Date: 2026-09-01 20:34+0000\n"
 "Last-Translator: Dylan Aïssi <bob.dybian@gmail.com>\n"
 "Language-Team: Français\n"
@@ -1257,10 +1257,6 @@ msgstr "Voir les fichiers"
 #: src/ClientContextActions.cpp
 msgid "Send message"
 msgstr "Envoyer un message"
-
-#: src/ClientContextActions.cpp
-msgid "Swap to this file"
-msgstr "Échanger vers ce fichier"
 
 #: src/ClientContextActions.cpp
 msgid ""
@@ -2849,6 +2845,10 @@ msgstr "Un bloc par partie du fichier en cours de téléchargement."
 #: src/GenericClientListCtrl.cpp
 msgid "One block per part of the shared file."
 msgstr "Un bloc par partie du fichier partagé."
+
+#: src/GenericClientListCtrl.cpp
+msgid "Swap to this file"
+msgstr "Échanger vers ce fichier"
 
 #: src/GenericClientListCtrl.cpp
 msgid "Colour legend"

--- a/po/gl.po
+++ b/po/gl.po
@@ -24,7 +24,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-01 11:32+0200\n"
+"POT-Creation-Date: 2026-09-02 12:15+0200\n"
 "PO-Revision-Date: 2026-09-01 18:11+0000\n"
 "Last-Translator: Pablo <parodper@gmail.com>\n"
 "Language-Team: http://forum.amule.org/index.php?topic=13883\n"
@@ -1274,10 +1274,6 @@ msgstr "Ver ficheiros"
 #: src/ClientContextActions.cpp
 msgid "Send message"
 msgstr "Enviar mensaxe"
-
-#: src/ClientContextActions.cpp
-msgid "Swap to this file"
-msgstr "Intercambiar a este ficheiro"
 
 #: src/ClientContextActions.cpp
 msgid ""
@@ -2876,6 +2872,10 @@ msgstr ""
 #, fuzzy
 msgid "One block per part of the shared file."
 msgstr "Introduza o porto do servidor aquí."
+
+#: src/GenericClientListCtrl.cpp
+msgid "Swap to this file"
+msgstr "Intercambiar a este ficheiro"
 
 #: src/GenericClientListCtrl.cpp
 msgid "Colour legend"

--- a/po/he.po
+++ b/po/he.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-01 11:32+0200\n"
+"POT-Creation-Date: 2026-09-02 12:15+0200\n"
 "PO-Revision-Date: 2026-09-01 18:13+0000\n"
 "Last-Translator: Peace Kramer <kpeace1@gmail.com>\n"
 "Language-Team: Hebrew\n"
@@ -1244,10 +1244,6 @@ msgstr "הצג קבצים"
 #: src/ClientContextActions.cpp
 msgid "Send message"
 msgstr "שלך הודעה"
-
-#: src/ClientContextActions.cpp
-msgid "Swap to this file"
-msgstr "החלף לקובץ זה"
 
 #: src/ClientContextActions.cpp
 #, fuzzy
@@ -2827,6 +2823,10 @@ msgstr ""
 #: src/GenericClientListCtrl.cpp
 msgid "One block per part of the shared file."
 msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "Swap to this file"
+msgstr "החלף לקובץ זה"
 
 #: src/GenericClientListCtrl.cpp
 msgid "Colour legend"

--- a/po/hr.po
+++ b/po/hr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-01 11:32+0200\n"
+"POT-Creation-Date: 2026-09-02 12:15+0200\n"
 "PO-Revision-Date: 2026-09-01 18:13+0000\n"
 "Last-Translator: Sebastiano Pistore <sebastiano.pistore.info@aol.com>\n"
 "Language-Team: https://github.com/amule-org/amule <forum@aMule.org>\n"
@@ -1244,10 +1244,6 @@ msgstr "Ugledaj fajlove"
 #: src/ClientContextActions.cpp
 msgid "Send message"
 msgstr "Pošalji poruku"
-
-#: src/ClientContextActions.cpp
-msgid "Swap to this file"
-msgstr ""
 
 #: src/ClientContextActions.cpp
 msgid ""
@@ -2818,6 +2814,10 @@ msgstr ""
 
 #: src/GenericClientListCtrl.cpp
 msgid "One block per part of the shared file."
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "Swap to this file"
 msgstr ""
 
 #: src/GenericClientListCtrl.cpp

--- a/po/hu.po
+++ b/po/hu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-01 11:32+0200\n"
+"POT-Creation-Date: 2026-09-02 12:15+0200\n"
 "PO-Revision-Date: 2026-09-01 18:14+0000\n"
 "Last-Translator: Dévai Tamás <gonosztopi@amule.org>\n"
 "Language-Team: Hungarian <hu@li.org>\n"
@@ -1253,10 +1253,6 @@ msgstr "Fájlok megtekintése"
 #: src/ClientContextActions.cpp
 msgid "Send message"
 msgstr "Üzenet küldése"
-
-#: src/ClientContextActions.cpp
-msgid "Swap to this file"
-msgstr "Csere ehhez a fájlhoz"
 
 #: src/ClientContextActions.cpp
 msgid ""
@@ -2850,6 +2846,10 @@ msgstr ""
 #, fuzzy
 msgid "One block per part of the shared file."
 msgstr "Add meg a kiszolgáló portját."
+
+#: src/GenericClientListCtrl.cpp
+msgid "Swap to this file"
+msgstr "Csere ehhez a fájlhoz"
 
 #: src/GenericClientListCtrl.cpp
 msgid "Colour legend"

--- a/po/it.po
+++ b/po/it.po
@@ -19,7 +19,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule 2.3.3\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-01 11:32+0200\n"
+"POT-Creation-Date: 2026-09-02 12:15+0200\n"
 "PO-Revision-Date: 2026-09-01 18:15+0000\n"
 "Last-Translator: got3nks <got3nks@users.noreply.github.com>\n"
 "Language-Team: SebastianoPistore.info@protonmail.ch\n"
@@ -1264,10 +1264,6 @@ msgstr "Visualizza file"
 #: src/ClientContextActions.cpp
 msgid "Send message"
 msgstr "Invia messaggio"
-
-#: src/ClientContextActions.cpp
-msgid "Swap to this file"
-msgstr "Sposta su questo file"
 
 #: src/ClientContextActions.cpp
 msgid ""
@@ -2857,6 +2853,10 @@ msgstr "Un blocco per ogni parte del file in download."
 #: src/GenericClientListCtrl.cpp
 msgid "One block per part of the shared file."
 msgstr "Un blocco per ogni parte del file condiviso."
+
+#: src/GenericClientListCtrl.cpp
+msgid "Swap to this file"
+msgstr "Sposta su questo file"
 
 #: src/GenericClientListCtrl.cpp
 msgid "Colour legend"

--- a/po/ja.po
+++ b/po/ja.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-01 11:32+0200\n"
+"POT-Creation-Date: 2026-09-02 12:15+0200\n"
 "PO-Revision-Date: 2026-09-01 18:16+0000\n"
 "Last-Translator: \n"
 "Language-Team: Japanese\n"
@@ -1256,10 +1256,6 @@ msgstr "ファイルを見る"
 #: src/ClientContextActions.cpp
 msgid "Send message"
 msgstr "メッセージを送る"
-
-#: src/ClientContextActions.cpp
-msgid "Swap to this file"
-msgstr "このファイルへ交換する"
 
 #: src/ClientContextActions.cpp
 #, fuzzy
@@ -2859,6 +2855,10 @@ msgstr ""
 #, fuzzy
 msgid "One block per part of the shared file."
 msgstr "サーバのポートをここに入力してください。"
+
+#: src/GenericClientListCtrl.cpp
+msgid "Swap to this file"
+msgstr "このファイルへ交換する"
 
 #: src/GenericClientListCtrl.cpp
 msgid "Colour legend"

--- a/po/ko_KR.po
+++ b/po/ko_KR.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-01 11:32+0200\n"
+"POT-Creation-Date: 2026-09-02 12:15+0200\n"
 "PO-Revision-Date: 2026-09-01 18:18+0000\n"
 "Last-Translator: Hyunju Kang <rexington@gmail.com>\n"
 "Language-Team: Korean <hoenny@daum.net>\n"
@@ -1261,10 +1261,6 @@ msgstr "파일 보기"
 #: src/ClientContextActions.cpp
 msgid "Send message"
 msgstr "메시지 보내기"
-
-#: src/ClientContextActions.cpp
-msgid "Swap to this file"
-msgstr "파일을 교환"
 
 #: src/ClientContextActions.cpp
 #, fuzzy
@@ -2874,6 +2870,10 @@ msgstr ""
 #, fuzzy
 msgid "One block per part of the shared file."
 msgstr "서버의 포트를 이곳에 입력하세요."
+
+#: src/GenericClientListCtrl.cpp
+msgid "Swap to this file"
+msgstr "파일을 교환"
 
 #: src/GenericClientListCtrl.cpp
 msgid "Colour legend"

--- a/po/lt.po
+++ b/po/lt.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-01 11:32+0200\n"
+"POT-Creation-Date: 2026-09-02 12:15+0200\n"
 "PO-Revision-Date: 2026-09-01 18:19+0000\n"
 "Last-Translator: Dovydas Sankauskas <laisve@gmail.com>\n"
 "Language-Team: Lithuanian <komp_lt@konf.lt>\n"
@@ -1265,10 +1265,6 @@ msgstr "Peržiūrėti failus"
 #: src/ClientContextActions.cpp
 msgid "Send message"
 msgstr "Siųsti žinutę"
-
-#: src/ClientContextActions.cpp
-msgid "Swap to this file"
-msgstr "Keisti į šį failą"
 
 #: src/ClientContextActions.cpp
 #, fuzzy
@@ -2882,6 +2878,10 @@ msgstr ""
 #, fuzzy
 msgid "One block per part of the shared file."
 msgstr "Įrašykite serverio prievadą."
+
+#: src/GenericClientListCtrl.cpp
+msgid "Swap to this file"
+msgstr "Keisti į šį failą"
 
 #: src/GenericClientListCtrl.cpp
 msgid "Colour legend"

--- a/po/lv.po
+++ b/po/lv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-01 11:32+0200\n"
+"POT-Creation-Date: 2026-09-02 12:15+0200\n"
 "PO-Revision-Date: 2026-09-01 18:34+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -1226,10 +1226,6 @@ msgstr "Skatīt datnes"
 #: src/ClientContextActions.cpp
 msgid "Send message"
 msgstr "Sūtīt ziņojumu"
-
-#: src/ClientContextActions.cpp
-msgid "Swap to this file"
-msgstr ""
 
 #: src/ClientContextActions.cpp
 msgid ""
@@ -2779,6 +2775,10 @@ msgstr ""
 
 #: src/GenericClientListCtrl.cpp
 msgid "One block per part of the shared file."
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "Swap to this file"
 msgstr ""
 
 #: src/GenericClientListCtrl.cpp

--- a/po/nl.po
+++ b/po/nl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-01 11:32+0200\n"
+"POT-Creation-Date: 2026-09-02 12:15+0200\n"
 "PO-Revision-Date: 2026-09-01 18:20+0000\n"
 "Last-Translator: Marcel Pol <marcel@timelord.nl>\n"
 "Language-Team: Dutch <nl@li.org>\n"
@@ -1255,10 +1255,6 @@ msgstr "Bekijk bestanden"
 #: src/ClientContextActions.cpp
 msgid "Send message"
 msgstr "Verstuur bericht"
-
-#: src/ClientContextActions.cpp
-msgid "Swap to this file"
-msgstr "Wissel uit naar dit bestand"
 
 #: src/ClientContextActions.cpp
 msgid ""
@@ -2849,6 +2845,10 @@ msgstr "Één blok per onderdeel van het bestand dat wordt gedownload."
 #: src/GenericClientListCtrl.cpp
 msgid "One block per part of the shared file."
 msgstr "Één blok per onderdeel van het gedeelde bestand."
+
+#: src/GenericClientListCtrl.cpp
+msgid "Swap to this file"
+msgstr "Wissel uit naar dit bestand"
 
 #: src/GenericClientListCtrl.cpp
 msgid "Colour legend"

--- a/po/nn.po
+++ b/po/nn.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-01 11:32+0200\n"
+"POT-Creation-Date: 2026-09-02 12:15+0200\n"
 "PO-Revision-Date: 2026-09-01 18:21+0000\n"
 "Last-Translator: Hallvor Brunstad <Hallvor_1976@yahoo.com>\n"
 "Language-Team: <i18n-nn@lister.ping.uio.no>\n"
@@ -1261,10 +1261,6 @@ msgstr "Sjå filer"
 #: src/ClientContextActions.cpp
 msgid "Send message"
 msgstr "Send melding"
-
-#: src/ClientContextActions.cpp
-msgid "Swap to this file"
-msgstr "Byt til denne fila"
 
 #: src/ClientContextActions.cpp
 #, fuzzy
@@ -2873,6 +2869,10 @@ msgstr ""
 #, fuzzy
 msgid "One block per part of the shared file."
 msgstr "Skriv inn porten til tenaren her."
+
+#: src/GenericClientListCtrl.cpp
+msgid "Swap to this file"
+msgstr "Byt til denne fila"
 
 #: src/GenericClientListCtrl.cpp
 msgid "Colour legend"

--- a/po/pl.po
+++ b/po/pl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-01 11:32+0200\n"
+"POT-Creation-Date: 2026-09-02 12:15+0200\n"
 "PO-Revision-Date: 2026-09-01 18:22+0000\n"
 "Last-Translator: Michał Trzebiatowski <hippie_1968@hotmail.com>\n"
 "Language-Team: translationproject.org/team/pl.html <translation-team-pl@lists.sourceforge.net>\n"
@@ -1257,10 +1257,6 @@ msgstr "Pokaż pliki"
 #: src/ClientContextActions.cpp
 msgid "Send message"
 msgstr "Wyślij wiadomość"
-
-#: src/ClientContextActions.cpp
-msgid "Swap to this file"
-msgstr "Zamień na ten plik"
 
 #: src/ClientContextActions.cpp
 #, fuzzy
@@ -2868,6 +2864,10 @@ msgstr ""
 #, fuzzy
 msgid "One block per part of the shared file."
 msgstr "Wpisz tu port serwera."
+
+#: src/GenericClientListCtrl.cpp
+msgid "Swap to this file"
+msgstr "Zamień na ten plik"
 
 #: src/GenericClientListCtrl.cpp
 msgid "Colour legend"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-01 11:32+0200\n"
+"POT-Creation-Date: 2026-09-02 12:15+0200\n"
 "PO-Revision-Date: 2026-09-01 18:23+0000\n"
 "Last-Translator: Marcelo Jimenez <mroberto@users.sourceforge.com>\n"
 "Language-Team: Português (Brasileiro) <pt@li.org>\n"
@@ -1258,10 +1258,6 @@ msgstr "Exibir Arquivos"
 #: src/ClientContextActions.cpp
 msgid "Send message"
 msgstr "Enviar mensagem"
-
-#: src/ClientContextActions.cpp
-msgid "Swap to this file"
-msgstr "Trocar para esse arquivo"
 
 #: src/ClientContextActions.cpp
 msgid ""
@@ -2851,6 +2847,10 @@ msgstr "Um bloco por parte do arquivo sendo baixado."
 #: src/GenericClientListCtrl.cpp
 msgid "One block per part of the shared file."
 msgstr "Um bloco por parte do arquivo compartilhado."
+
+#: src/GenericClientListCtrl.cpp
+msgid "Swap to this file"
+msgstr "Trocar para esse arquivo"
 
 #: src/GenericClientListCtrl.cpp
 msgid "Colour legend"

--- a/po/pt_PT.po
+++ b/po/pt_PT.po
@@ -17,7 +17,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-01 11:32+0200\n"
+"POT-Creation-Date: 2026-09-02 12:15+0200\n"
 "PO-Revision-Date: 2026-09-01 18:24+0000\n"
 "Last-Translator: Luís Picciochi Oliveira <Pitxyoki@Gmail.com>\n"
 "Language-Team: Portuguese <traduz@debianpt.org>\n"
@@ -1259,10 +1259,6 @@ msgstr "Ver Ficheiros"
 #: src/ClientContextActions.cpp
 msgid "Send message"
 msgstr "Enviar mensagem"
-
-#: src/ClientContextActions.cpp
-msgid "Swap to this file"
-msgstr "Mudar para este ficheiro"
 
 #: src/ClientContextActions.cpp
 #, fuzzy
@@ -2865,6 +2861,10 @@ msgstr ""
 #, fuzzy
 msgid "One block per part of the shared file."
 msgstr "Insira o porto do servidor."
+
+#: src/GenericClientListCtrl.cpp
+msgid "Swap to this file"
+msgstr "Mudar para este ficheiro"
 
 #: src/GenericClientListCtrl.cpp
 msgid "Colour legend"

--- a/po/ro.po
+++ b/po/ro.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-01 11:32+0200\n"
+"POT-Creation-Date: 2026-09-02 12:15+0200\n"
 "PO-Revision-Date: 2026-09-01 18:24+0000\n"
 "Last-Translator: Angelescu Constantin <titus0818@yahoo.com>\n"
 "Language-Team: English <kde-i18n-doc@kde.org>\n"
@@ -1254,10 +1254,6 @@ msgstr "Vizualizare fișiere"
 #: src/ClientContextActions.cpp
 msgid "Send message"
 msgstr "Trimite mesaj"
-
-#: src/ClientContextActions.cpp
-msgid "Swap to this file"
-msgstr "Schimbă la acest fișier"
 
 #: src/ClientContextActions.cpp
 #, fuzzy
@@ -2863,6 +2859,10 @@ msgstr ""
 #, fuzzy
 msgid "One block per part of the shared file."
 msgstr "Introduceți aici portul serverului."
+
+#: src/GenericClientListCtrl.cpp
+msgid "Swap to this file"
+msgstr "Schimbă la acest fișier"
 
 #: src/GenericClientListCtrl.cpp
 msgid "Colour legend"

--- a/po/ru.po
+++ b/po/ru.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-01 11:32+0200\n"
+"POT-Creation-Date: 2026-09-02 12:15+0200\n"
 "PO-Revision-Date: 2026-09-01 18:25+0000\n"
 "Last-Translator: Radist Morse <radist.morse@gmail.com>\n"
 "Language-Team: Russian <kde-russian@lists.kde.ru>\n"
@@ -1264,10 +1264,6 @@ msgstr "Просмотреть файлы"
 #: src/ClientContextActions.cpp
 msgid "Send message"
 msgstr "Отправить сообщение"
-
-#: src/ClientContextActions.cpp
-msgid "Swap to this file"
-msgstr "Переключить на этот файл"
 
 #: src/ClientContextActions.cpp
 msgid ""
@@ -2867,6 +2863,10 @@ msgstr "Один блок на каждую часть загружаемого 
 #: src/GenericClientListCtrl.cpp
 msgid "One block per part of the shared file."
 msgstr "По одному блоку на каждую часть публикуемого файла."
+
+#: src/GenericClientListCtrl.cpp
+msgid "Swap to this file"
+msgstr "Переключить на этот файл"
 
 #: src/GenericClientListCtrl.cpp
 msgid "Colour legend"

--- a/po/sl.po
+++ b/po/sl.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-01 11:32+0200\n"
+"POT-Creation-Date: 2026-09-02 12:15+0200\n"
 "PO-Revision-Date: 2026-09-01 18:26+0000\n"
 "Last-Translator: Jure Repinc <jlp@holodeck1.com>\n"
 "Language-Team: Slovenian\n"
@@ -1262,10 +1262,6 @@ msgstr "Prikaži datoteke"
 #: src/ClientContextActions.cpp
 msgid "Send message"
 msgstr "Pošlji sporočilo"
-
-#: src/ClientContextActions.cpp
-msgid "Swap to this file"
-msgstr "Prenesi k tej datoteki"
 
 #: src/ClientContextActions.cpp
 #, fuzzy
@@ -2879,6 +2875,10 @@ msgstr ""
 #, fuzzy
 msgid "One block per part of the shared file."
 msgstr "Sem vnesite vrata strežnika."
+
+#: src/GenericClientListCtrl.cpp
+msgid "Swap to this file"
+msgstr "Prenesi k tej datoteki"
 
 #: src/GenericClientListCtrl.cpp
 msgid "Colour legend"

--- a/po/sq.po
+++ b/po/sq.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-01 11:32+0200\n"
+"POT-Creation-Date: 2026-09-02 12:15+0200\n"
 "PO-Revision-Date: 2026-09-01 18:27+0000\n"
 "Last-Translator: Fation <dj_barthezz@linuxmail.org lushnja_corps@hotmail.Language-Team:\n"
 "Language: sq\n"
@@ -1258,10 +1258,6 @@ msgstr "Shiko failet"
 #: src/ClientContextActions.cpp
 msgid "Send message"
 msgstr "Dergo mesazh"
-
-#: src/ClientContextActions.cpp
-msgid "Swap to this file"
-msgstr "Sposto tek ky fail"
 
 #: src/ClientContextActions.cpp
 #, fuzzy
@@ -2867,6 +2863,10 @@ msgstr ""
 #, fuzzy
 msgid "One block per part of the shared file."
 msgstr "Futni porten e serverit ketu."
+
+#: src/GenericClientListCtrl.cpp
+msgid "Swap to this file"
+msgstr "Sposto tek ky fail"
 
 #: src/GenericClientListCtrl.cpp
 msgid "Colour legend"

--- a/po/sv.po
+++ b/po/sv.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-01 11:32+0200\n"
+"POT-Creation-Date: 2026-09-02 12:15+0200\n"
 "PO-Revision-Date: 2026-09-01 18:28+0000\n"
 "Last-Translator: raffe <raffe@localhost.se>\n"
 "Language-Team: Swedish <tp-sv@listor.tp-sv.se>\n"
@@ -1251,10 +1251,6 @@ msgstr "Visa filer"
 #: src/ClientContextActions.cpp
 msgid "Send message"
 msgstr "Skicka meddelande"
-
-#: src/ClientContextActions.cpp
-msgid "Swap to this file"
-msgstr "Växla till den här filen"
 
 #: src/ClientContextActions.cpp
 #, fuzzy
@@ -2857,6 +2853,10 @@ msgstr ""
 #, fuzzy
 msgid "One block per part of the shared file."
 msgstr "Ange porten på servern här."
+
+#: src/GenericClientListCtrl.cpp
+msgid "Swap to this file"
+msgstr "Växla till den här filen"
 
 #: src/GenericClientListCtrl.cpp
 msgid "Colour legend"

--- a/po/ta.po
+++ b/po/ta.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-01 11:32+0200\n"
+"POT-Creation-Date: 2026-09-02 12:15+0200\n"
 "PO-Revision-Date: 2026-09-01 18:37+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -1210,10 +1210,6 @@ msgstr ""
 
 #: src/ClientContextActions.cpp
 msgid "Send message"
-msgstr ""
-
-#: src/ClientContextActions.cpp
-msgid "Swap to this file"
 msgstr ""
 
 #: src/ClientContextActions.cpp
@@ -2756,6 +2752,10 @@ msgstr ""
 
 #: src/GenericClientListCtrl.cpp
 msgid "One block per part of the shared file."
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "Swap to this file"
 msgstr ""
 
 #: src/GenericClientListCtrl.cpp

--- a/po/tr.po
+++ b/po/tr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-01 11:32+0200\n"
+"POT-Creation-Date: 2026-09-02 12:15+0200\n"
 "PO-Revision-Date: 2026-09-01 18:29+0000\n"
 "Last-Translator: \n"
 "Language-Team: Turkish <li@li.org>\n"
@@ -1250,10 +1250,6 @@ msgstr "Paylaşılmış Dosyalara bak"
 #: src/ClientContextActions.cpp
 msgid "Send message"
 msgstr "İleti Gönder"
-
-#: src/ClientContextActions.cpp
-msgid "Swap to this file"
-msgstr "Bu dosyaya geçir"
 
 #: src/ClientContextActions.cpp
 msgid ""
@@ -2843,6 +2839,10 @@ msgstr "İndirilmekte olan dosyanın her bir parçası için bir blok."
 #: src/GenericClientListCtrl.cpp
 msgid "One block per part of the shared file."
 msgstr "Paylaşılan dosyanın her bir parçası için bir blok."
+
+#: src/GenericClientListCtrl.cpp
+msgid "Swap to this file"
+msgstr "Bu dosyaya geçir"
 
 #: src/GenericClientListCtrl.cpp
 msgid "Colour legend"

--- a/po/uk.po
+++ b/po/uk.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-01 11:32+0200\n"
+"POT-Creation-Date: 2026-09-02 12:15+0200\n"
 "PO-Revision-Date: 2026-09-01 18:30+0000\n"
 "Last-Translator: Oleksandr Kovalenko <alx.kovalenko@gmail.com>\n"
 "Language-Team: Ukrainian <translation@linux.org.ua>\n"
@@ -1256,10 +1256,6 @@ msgstr "Переглянути файли"
 #: src/ClientContextActions.cpp
 msgid "Send message"
 msgstr "Надіслати повідомлення"
-
-#: src/ClientContextActions.cpp
-msgid "Swap to this file"
-msgstr "Перемкнути на цей файл"
 
 #: src/ClientContextActions.cpp
 #, fuzzy
@@ -2877,6 +2873,10 @@ msgstr ""
 #, fuzzy
 msgid "One block per part of the shared file."
 msgstr "Введіть тут порт сервера."
+
+#: src/GenericClientListCtrl.cpp
+msgid "Swap to this file"
+msgstr "Перемкнути на цей файл"
 
 #: src/GenericClientListCtrl.cpp
 msgid "Colour legend"

--- a/po/vi.po
+++ b/po/vi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-01 11:32+0200\n"
+"POT-Creation-Date: 2026-09-02 12:15+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -1209,10 +1209,6 @@ msgstr ""
 
 #: src/ClientContextActions.cpp
 msgid "Send message"
-msgstr ""
-
-#: src/ClientContextActions.cpp
-msgid "Swap to this file"
 msgstr ""
 
 #: src/ClientContextActions.cpp
@@ -2755,6 +2751,10 @@ msgstr ""
 
 #: src/GenericClientListCtrl.cpp
 msgid "One block per part of the shared file."
+msgstr ""
+
+#: src/GenericClientListCtrl.cpp
+msgid "Swap to this file"
 msgstr ""
 
 #: src/GenericClientListCtrl.cpp

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-01 11:32+0200\n"
+"POT-Creation-Date: 2026-09-02 12:15+0200\n"
 "PO-Revision-Date: 2026-09-01 18:31+0000\n"
 "Last-Translator: Mike Akiba <mike2718@gmail.com>\n"
 "Language-Team: Chinese Simplified <kde-i18n-doc@kde.org>\n"
@@ -1254,10 +1254,6 @@ msgstr "查看共享文件"
 #: src/ClientContextActions.cpp
 msgid "Send message"
 msgstr "发送消息"
-
-#: src/ClientContextActions.cpp
-msgid "Swap to this file"
-msgstr "转移到这个文件"
 
 #: src/ClientContextActions.cpp
 msgid ""
@@ -2847,6 +2843,10 @@ msgstr "正被下载的文件每部分对应一个区块。"
 #: src/GenericClientListCtrl.cpp
 msgid "One block per part of the shared file."
 msgstr "共享文件每个部分对应一个区块。"
+
+#: src/GenericClientListCtrl.cpp
+msgid "Swap to this file"
+msgstr "转移到这个文件"
 
 #: src/GenericClientListCtrl.cpp
 msgid "Colour legend"

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-01 11:32+0200\n"
+"POT-Creation-Date: 2026-09-02 12:15+0200\n"
 "PO-Revision-Date: 2026-09-01 18:31+0000\n"
 "Last-Translator: Wayne Su <mstarmstar@gmail.com>\n"
 "Language-Team: \n"
@@ -1254,10 +1254,6 @@ msgstr "檢視檔案"
 #: src/ClientContextActions.cpp
 msgid "Send message"
 msgstr "傳送訊息"
-
-#: src/ClientContextActions.cpp
-msgid "Swap to this file"
-msgstr "轉移到這個檔案"
 
 #: src/ClientContextActions.cpp
 #, fuzzy
@@ -2855,6 +2851,10 @@ msgstr ""
 #, fuzzy
 msgid "One block per part of the shared file."
 msgstr "輸入伺服器的通訊埠。"
+
+#: src/GenericClientListCtrl.cpp
+msgid "Swap to this file"
+msgstr "轉移到這個檔案"
 
 #: src/GenericClientListCtrl.cpp
 msgid "Colour legend"

--- a/src/ClientContextActions.cpp
+++ b/src/ClientContextActions.cpp
@@ -38,7 +38,7 @@
 #include "OtherFunctions.h"     // Needed for GUI_ID
 #include "SearchDlg.h"          // Needed for CSearchDlg::ActivateBrowseTabIfOpen
 
-wxMenu *BuildClientContextMenu(const CClientRef &client, bool allowSwapSource)
+wxMenu *BuildClientContextMenu(const CClientRef &client)
 {
 	// const_cast because the accessors this menu reads are non-const on
 	// CClientRef; nothing here modifies the peer.
@@ -58,10 +58,7 @@ wxMenu *BuildClientContextMenu(const CClientRef &client, bool allowSwapSource)
 
 	menu->Append(MP_SHOWLIST, _("View Files"));
 	menu->Append(MP_SENDMESSAGE, _("Send message"));
-	menu->Append(MP_CHANGE2FILE, _("Swap to this file"));
 
-	// Only meaningful for an A4AF source, which only a per-file list has.
-	menu->Enable(MP_CHANGE2FILE, allowSwapSource);
 	// We need a valid IP if we are to message the client.
 	menu->Enable(MP_SENDMESSAGE, c.GetIP() != 0);
 	menu->Enable(MP_SHOWLIST, !c.HasDisabledSharedFiles());

--- a/src/ClientContextActions.h
+++ b/src/ClientContextActions.h
@@ -43,14 +43,14 @@ class wxWindow;
  */
 
 /**
- * Build the menu for `client`.
+ * Build the menu for `client`, with the entries every caller can act on.
  *
- * @param allowSwapSource Enables "Swap to this file", which only means anything
- *                        for an A4AF source in a per-file list.
+ * "Swap to this file" is not among them: it needs a file in context, so the
+ * per-file lists append it themselves.
  *
  * Caller owns the returned menu.
  */
-wxMenu *BuildClientContextMenu(const CClientRef &client, bool allowSwapSource);
+wxMenu *BuildClientContextMenu(const CClientRef &client);
 
 //! Browse each peer's shared files, reusing an already-open tab per peer.
 void ClientActionViewFiles(const std::vector<CClientRef> &clients);

--- a/src/ClientRowListCtrl.cpp
+++ b/src/ClientRowListCtrl.cpp
@@ -88,9 +88,10 @@ void CClientRowListCtrl::OnItemRightClicked(wxDataViewEvent &event)
 		return;
 	}
 
-	// No swap-to-file: that acts on an A4AF source of one particular download,
-	// which is a per-file notion neither of these lists has.
-	wxMenu *menu = BuildClientContextMenu(clients.front(), false);
+	// The builder omits "Swap to this file": it acts on an A4AF source of one
+	// particular download, which is a per-file notion neither of these lists
+	// has.
+	wxMenu *menu = BuildClientContextMenu(clients.front());
 	PopupMenu(menu, event.GetPosition());
 	delete menu;
 }

--- a/src/GenericClientListCtrl.cpp
+++ b/src/GenericClientListCtrl.cpp
@@ -770,15 +770,21 @@ void CGenericClientListCtrl::OnItemRightClicked(wxDataViewEvent &event)
 	CClientRef &client = item->GetSource();
 
 	delete m_menu;
-	// Same menu the global clients list offers; "Swap to this file" is the one
-	// entry only a per-file list can act on.
-	m_menu = BuildClientContextMenu(client, item->GetType() == A4AF_SOURCE);
+	// Same menu the global clients list offers.
+	m_menu = BuildClientContextMenu(client);
 
-	// Appended here rather than inside BuildClientContextMenu(): that builder
-	// is shared with CClientRowListCtrl, the Clients tab, which draws no chunk
-	// bar and so must not offer to explain one. Asking the list which of its
-	// own columns has a legend keeps that true for any future subclass without
-	// naming one here.
+	// Both of these are appended here rather than inside
+	// BuildClientContextMenu(): that builder is shared with CClientRowListCtrl,
+	// the Clients tab, which has no file in context and draws no chunk bar, so
+	// neither entry can mean anything there.
+	//
+	// Disabled for a non-A4AF source, where the peer is already on the file it
+	// would swap to: "not right now" rather than "never here".
+	m_menu->Append(MP_CHANGE2FILE, _("Swap to this file"));
+	m_menu->Enable(MP_CHANGE2FILE, item->GetType() == A4AF_SOURCE);
+
+	// Asking the list which of its own columns has a legend keeps this true for
+	// any future subclass without naming one here.
 	if (FindBarLegendColumn() >= 0) {
 		m_menu->AppendSeparator();
 		m_menu->Append(MP_BARLEGEND, _("Colour legend"));


### PR DESCRIPTION
Closes #1221.

`BuildClientContextMenu` appended "Swap to this file" unconditionally and then disabled it for callers that cannot use it, so the Clients tab offered a greyed entry in a context where no file exists. Disabled means "possible here, but not right now", which is false there: the question "which file?" has no answer on that list, and `CClientRowListCtrl` has no `MP_CHANGE2FILE` handler either, so the entry was dead twice over.

The entry now belongs to the per-file lists that can act on it, the same way the `Colour legend` entry two lines below is already appended at the call site, and the builder loses its `allowSwapSource` parameter rather than carrying a flag whose only job was to switch an entry off.

Behaviour on the per-file lists is unchanged: still shown, still enabled only for an A4AF source. The Clients tab and its two subclasses (`CClientsListCtrl`, `CClientHistoryListCtrl`) simply no longer show it.

### Translations

Catalogs regenerated. I first expected none to be needed, since the gate strips `#: file:lineno` lines before diffing and the string itself is unchanged. That was wrong, and CI said so: entries are **ordered** by source reference, so moving the string to another file moves its msgid block within every catalog, which the diff reads as a removal plus an insertion. `scripts/update-po.sh` regenerated all 41; translations travel with the msgid (e.g. es keeps `Intercambiar a este archivo`), and the only other change is the `POT-Creation-Date` header.

### Verification

`amule` and `amulegui` both build (0 errors, and no warnings in any touched file), 47/47 ctest, clang-format clean, 0 findings on both clang-tidy tiers with 0 compiler errors.

The menu itself cannot be exercised headlessly, so the behavioural claim rests on the code: the entry is appended only where a file is in context, and the one handler for it lives in that same class.
