### PR TITLE
fix(web-ui): drop duplicate queued state key, catch it in i18n check

### DIFF
--- a/src/webapi/static/i18n/en.json
+++ b/src/webapi/static/i18n/en.json
@@ -660,7 +660,6 @@
   "downloads_peer_state_downloading": "Downloading",
   "downloads_peer_state_uploading": "Uploading",
   "downloads_peer_state_queued": "Queued",
-  "downloads_peer_state_queued": "On queue",
   "downloads_peer_state_pending": "Pending",
   "downloads_peer_state_waiting_callback": "Wait callback",
   "downloads_peer_state_waiting_callback_kad": "Wait callback (Kad)",

--- a/src/webapi/static/i18n/es.json
+++ b/src/webapi/static/i18n/es.json
@@ -660,7 +660,6 @@
   "downloads_peer_state_downloading": "Descargando",
   "downloads_peer_state_uploading": "Subiendo",
   "downloads_peer_state_queued": "En cola",
-  "downloads_peer_state_queued": "En cola",
   "downloads_peer_state_pending": "Pendiente",
   "downloads_peer_state_waiting_callback": "Esperando callback",
   "downloads_peer_state_waiting_callback_kad": "Esperando callback (Kad)",

--- a/src/webapi/tools/check-i18n.mjs
+++ b/src/webapi/tools/check-i18n.mjs
@@ -11,8 +11,19 @@ import assert from "node:assert";
 
 const here = dirname(new URL(import.meta.url).pathname);
 const dir = join(here, "..", "static", "i18n");
-const load = (f) => JSON.parse(readFileSync(join(dir, f), "utf8"));
 const placeholders = (s) => (s.match(/\{[a-z_]+\}/g) || []).sort().join(",");
+
+// JSON.parse silently keeps the last value for a repeated key, so a duplicate
+// is invisible to a parsed comparison. The catalogs are flat, one "key": per
+// line, so the raw keys are reliable to scan.
+const load = (f) => {
+  const raw = readFileSync(join(dir, f), "utf8");
+  const seen = new Set(), dupes = new Set();
+  for (const [, k] of raw.matchAll(/^\s*"((?:[^"\\]|\\.)*)"\s*:/gm))
+    (seen.has(k) ? dupes : seen).add(k);
+  assert.deepStrictEqual([...dupes], [], f + ": duplicate keys");
+  return JSON.parse(raw);
+};
 
 const en = load("en.json");
 for (const file of readdirSync(dir).filter((f) => f.endsWith(".json") && f !== "en.json")) {


### PR DESCRIPTION
The onqueue -> queued state fold (amuleapi #1243) renamed the downloads_peer_state_onqueue label to downloads_peer_state_queued, which already existed, leaving a duplicate JSON key in both catalogs. JSON.parse keeps the last value, so en.json rendered "On queue" for every queued peer instead of the intended "Queued"; es.json's copies were identical and harmless but still duplicated.

- en.json / es.json: remove the duplicate downloads_peer_state_queued line, keeping "Queued" / "En cola".
- check-i18n.mjs: scan raw keys for duplicates before JSON.parse (which hides them by last-wins dedup), so a repeated key now fails the check instead of passing CI silently. Applies to en.json and every locale.