### PR TITLE
feat(amuleapi): emit search_result_removed so a dropped row can be dropped

### DIFF
--- a/docs/api/EVENTS.md
+++ b/docs/api/EVENTS.md
@@ -39,7 +39,8 @@ const EVENT_TYPES = [
   "server_added",   "server_updated",   "server_removed",
   "friend_added",   "friend_updated",   "friend_removed",
   "status_changed", "log_appended",
-  "search_result_added", "search_result_updated", "search_progress", "search_closed",
+  "search_result_added", "search_result_updated", "search_result_removed",
+  "search_progress", "search_closed",
   "comments_updated",
 ];
 const es = new EventSource("/api/v0/events", { withCredentials: true });
@@ -262,7 +263,7 @@ On any of them, the client's correct response is:
 
 ## Event catalog
 
-Every event the bus publishes. The `_added` and `_updated` payloads are BYTE-FOR-BYTE identical to the matching REST resource's list-item shape — clients receiving a `*_updated` event get the full new state and never need to re-GET. `_removed` carries only the identity field — `hash` for files (`download_removed`, `shared_removed`) and `ecid` for every ECID-keyed collection (`client_removed`, `friend_removed`, `server_removed`) — so the client can drop the cache entry without needing the old object. Three events don't fit the collection-delta model: `status_changed` ships a full status envelope (replace, not merge), `log_appended` is an append operation (`{lines}` — push the lines onto the amule log buffer, don't replace), and `search_closed` retires a whole result space rather than one item (`{search_id}` — drop the view, not a row). Branch on the event type in your dispatcher accordingly.
+Every event the bus publishes. The `_added` and `_updated` payloads are BYTE-FOR-BYTE identical to the matching REST resource's list-item shape — clients receiving a `*_updated` event get the full new state and never need to re-GET. `_removed` carries only the identity field — `hash` for files (`download_removed`, `shared_removed`) and `ecid` for every ECID-keyed collection (`client_removed`, `friend_removed`, `server_removed`) — so the client can drop the cache entry without needing the old object. `search_result_removed` follows the same rule with the `search_id` that scopes it: `{search_id, hash}`. Three events don't fit the collection-delta model: `status_changed` ships a full status envelope (replace, not merge), `log_appended` is an append operation (`{lines}` — push the lines onto the amule log buffer, don't replace), and `search_closed` retires a whole result space rather than one item (`{search_id}` — drop the view, not a row). Branch on the event type in your dispatcher accordingly.
 
 ### `downloads` channel
 
@@ -606,6 +607,18 @@ It does **not** fire on `sources` or `alternate_names[]`. Those churn on essenti
 ```
 
 `search_id` routes the result to the search that produced it — amuleapi runs several searches at once (see [REFERENCE.md](REFERENCE.md#post-apiv0search)), so demux on it. Key results by `(search_id, hash)`. Aside from the leading `search_id`, the payload is byte-for-byte identical to a `/search/{id}/results` array entry — the two are emitted by the same writer, so the promise holds by construction. That includes `status`, `file_type`, `directory` (the folder inside a browsed client's share, `""` on ordinary hits), `kad_comment_lookup_running`, `comments[]` and the `alternate_names[]` grouping array — see [REFERENCE.md](REFERENCE.md#get-apiv0searchidresults); `sources` is the nested `{total, complete}` object, `media` — the audio/video metadata object — is present for locally-known/probed hits and `null` otherwise (the one place the unknown-value rule reaches an object rather than a scalar, so test `media === null` before reaching into it), and `alternate_names` holds the same-hash/different-name alternatives (empty for a single-name hit), same as the REST endpoint. Only parent results fire these events — children are folded into their parent's `alternate_names[]`, never emitted on their own. A change to a child therefore surfaces as a `search_result_updated` for its parent. Each `search_id` is an independent result space — a new `POST /search` starts a fresh one without disturbing the others.
+
+#### `search_result_removed`
+
+```json
+{ "search_id": 42, "hash": "0a1b..." }
+```
+
+A result the daemon no longer serves for this search. Identity-only, like every other `_removed`: drop the row keyed by `(search_id, hash)`; there is nothing to merge and no re-read needed.
+
+Two things produce one. The incremental union merge erases a result the daemon stopped reporting, and the folding pass drops a row that has since become a child of another result, surfacing instead inside that parent's `alternate_names[]` — so a removal is sometimes a regrouping rather than a disappearance, and the parent's `search_result_updated` carries the new grouping.
+
+This matters most on a **finished** search, which publishes no further [`search_progress`](#search_progress): without this event nothing would signal that a row the API has stopped serving is still on screen.
 
 #### `search_progress`
 

--- a/src/webapi/EventDiff.cpp
+++ b/src/webapi/EventDiff.cpp
@@ -1040,6 +1040,23 @@ void EmitDiffsAndUpdate(CEventBus &bus, LastSeenState &prev, const CState &state
 			}
 
 			auto &pstate = prev.searches[sid];
+			// Results do leave an attached search: the union merge erases an
+			// ECID the daemon stopped reporting, and RebuildFoldedResults drops
+			// a row that has since been folded into a parent's
+			// alternate_names[]. Emitted before the additions below, the order
+			// DiffMap uses, and identity-only like every other _removed.
+			//
+			// Without this the row stays on every subscriber's screen for the
+			// life of the search: a finished one publishes no further
+			// search_progress, so nothing even hints that a re-read is due.
+			for (const auto &kv : pstate.results) {
+				if (search_now.find(kv.first) != search_now.end())
+					continue;
+				std::ostringstream removed;
+				removed << "{\"search_id\":" << sid << ",\"hash\":\""
+					<< EscJson(kv.second.hash) << "\"}";
+				bus.Publish("search_result_removed", removed.str());
+			}
 			// New and mutated result entries for this search.
 			for (const auto &kv : search_now) {
 				const auto pit = pstate.results.find(kv.first);

--- a/src/webapi/static/js/events.js
+++ b/src/webapi/static/js/events.js
@@ -169,9 +169,9 @@ function openSse() {
     try { store.set("log:appended", JSON.parse(ev.data)); } catch (_) {}
   });
 
-  // Search has its own channel but doesn't fit the added/updated/removed
-  // resource model (no _removed; each search is a fresh result space), so
-  // it's surfaced via store keys the search view consumes directly.
+  // Search has its own channel and only partly fits the collection model --
+  // each search is a fresh result space -- so it's surfaced via store keys the
+  // search view consumes directly rather than the generic resource plumbing.
   // search_result_added is byte-for-byte a /search/{id}/results[] entry (keyed
   // by hash, nested sources {total, complete}); search_progress carries
   // {state, percent, results, kind} and its terminal frame (state:
@@ -188,6 +188,11 @@ function openSse() {
   };
   es.addEventListener("search_result_added", onSearchResult);
   es.addEventListener("search_result_updated", onSearchResult);
+  // Identity-only ({search_id, hash}), so it gets its own key: routing it
+  // through onSearchResult would upsert a row with no fields.
+  es.addEventListener("search_result_removed", (ev) => {
+    try { store.set("search:result_removed", JSON.parse(ev.data)); } catch (_) {}
+  });
   es.addEventListener("search_progress", (ev) => {
     try { store.set("search:progress", JSON.parse(ev.data)); } catch (_) {}
   });

--- a/src/webapi/static/js/searches.js
+++ b/src/webapi/static/js/searches.js
@@ -34,7 +34,7 @@ let tabsTimer = 0;
 let resultsTimer = 0;
 let lastAdopt = 0;
 let offs = [];
-let lastResult = null, lastProgress = null, lastClosed = null;
+let lastResult = null, lastResultRemoved = null, lastProgress = null, lastClosed = null;
 
 function newTab({ id, query = "", label = "", kind = "global", state = "running", startedAt = 0,
                  percent = 0, count = 0 }) {
@@ -211,6 +211,19 @@ function onResult(p) {
   publishResultsSoon(p.search_id);
 }
 
+// The row left the daemon's result space (folded into a parent's alternate
+// names, or dropped by the union merge). Identity-only payload, like every
+// other _removed: drop the cache entry, no re-fetch.
+function onResultRemoved(p) {
+  if (!p || p === lastResultRemoved) return;
+  lastResultRemoved = p;
+  const tab = tabs.get(p.search_id);
+  if (!tab || !tab.results.delete(p.hash)) return;
+  tab.count = tab.results.size;
+  publishTabsSoon();
+  publishResultsSoon(p.search_id);
+}
+
 function onProgress(p) {
   if (!p || p === lastProgress) return;
   lastProgress = p;
@@ -260,9 +273,11 @@ export const searches = {
     if (started) return;
     started = true;
     lastResult = store.get("search:result");
+    lastResultRemoved = store.get("search:result_removed");
     lastProgress = store.get("search:progress");
     lastClosed = store.get("search:closed");
     offs.push(store.subscribe("search:result", onResult));
+    offs.push(store.subscribe("search:result_removed", onResultRemoved));
     offs.push(store.subscribe("search:progress", onProgress));
     offs.push(store.subscribe("search:closed", onClosed));
     startPolling();

--- a/unittests/tests/EventDiffTest.cpp
+++ b/unittests/tests/EventDiffTest.cpp
@@ -639,6 +639,60 @@ std::size_t CountEvent(CEventBus &bus, const char *name)
 }
 } // namespace
 
+// --- search_result_removed: the row the API stopped serving ---
+//
+// Every other collection emits a _removed; the search diff walked only the
+// current results, so a row that left the result space stayed on every
+// subscriber's screen for the life of the search. On a finished search no
+// further search_progress fires either, so nothing prompted a re-read.
+TEST(EventDiff, SearchResultRemovedFiresWhenAResultLeavesTheSearch)
+{
+	CState state;
+	CEventBus bus;
+	LastSeenState prev;
+	SeedOneResult(state, bus, prev);
+	ASSERT_EQUALS(static_cast<size_t>(1), CountEvent(bus, "search_result_added"));
+
+	// The daemon stops reporting it: the union merge erases the ECID, or the
+	// fold makes it a child of another row.
+	state.MutateSearch(42, [](std::map<std::uint32_t, SearchResult> &cache) { cache.erase(7); });
+	EmitDiffsAndUpdate(bus, prev, state);
+
+	ASSERT_EQUALS(static_cast<size_t>(1), CountEvent(bus, "search_result_removed"));
+	// Counts are cumulative over the run: still the one _added from the seed,
+	// and the row was not announced as an update on its way out.
+	ASSERT_EQUALS(static_cast<size_t>(1), CountEvent(bus, "search_result_added"));
+	ASSERT_EQUALS(static_cast<size_t>(0), CountEvent(bus, "search_result_updated"));
+
+	std::string payload;
+	for (const auto &e : DrainAll(bus))
+		if (e.name == "search_result_removed")
+			payload = e.data;
+	// Identity only, scoped by the search that owned the row.
+	ASSERT_EQUALS(
+		std::string("{\"search_id\":42,\"hash\":\"8b54a3c28b54a3c28b54a3c28b54a3c2\"}"), payload);
+
+	// Idempotent: with the baseline updated, a further tick adds no second
+	// removal (the count is cumulative, so it must still read exactly one).
+	EmitDiffsAndUpdate(bus, prev, state);
+	ASSERT_EQUALS(static_cast<size_t>(1), CountEvent(bus, "search_result_removed"));
+}
+
+// A row that stays put must not be announced as removed.
+TEST(EventDiff, SearchResultRemovedSilentWhileTheResultRemains)
+{
+	CState state;
+	CEventBus bus;
+	LastSeenState prev;
+	SeedOneResult(state, bus, prev);
+
+	state.MutateSearch(
+		42, [](std::map<std::uint32_t, SearchResult> &cache) { cache[7].status = "downloaded"; });
+	EmitDiffsAndUpdate(bus, prev, state);
+
+	ASSERT_EQUALS(static_cast<size_t>(0), CountEvent(bus, "search_result_removed"));
+}
+
 TEST(EventDiff, SearchResultUpdatedFiresWhenADownloadStateChanges)
 {
 	CState state;


### PR DESCRIPTION
Item **4** of #1253. The search diff walked only the *current* results, emitting `added`/`updated`, then overwrote its baseline - so a row that left the result space stayed on every subscriber's screen for the life of the search. Every other collection emits a `_removed`; this was the one that did not, and the code comments elsewhere already note that "a lost `shared_removed` leaves a ghost row on every client".

### How narrow the removal path actually is

Worth stating plainly, because the audit reads wider than the code supports: **nothing in eD2k or Kad retracts a result.** Searches are additive on the wire. Every removal comes from the container, and there are three sources:

| Source | Reachable? |
|---|---|
| A results list **replaced by a new search on the same id** - the daemon tombstones each ECID it previously sent (`ExternalConn.cpp:2922-2940`) | **Yes** - this is the real case |
| The **folding pass**: a child promoted to top-level while its parent is missing, then folded into `alternate_names[]` when the parent arrives (`Refresher.cpp:2598-2609`) | Only if parent-first ordering breaks, which the core is supposed to guarantee |
| **Search eviction** | **No - deliberately ignored.** `RefresherTick` detaches the slot *before* applying the union precisely so those tombstones do not erase results being kept for late reads |

So this closes a real hole in the event model rather than a bug users hit daily. I would rather say that than inherit the audit's framing.

### The event

Identity-only and scoped by the search that owned the row - `{search_id, hash}` - matching every other `_removed`. It is emitted before the additions, the order `DiffMap` uses. The channel comes free: event names route to channels by prefix, so `search_result_removed` is already on `search` with no registration.

### Web UI

`searches.js` drops the row and republishes; `events.js` subscribes on its own store key, since routing it through `onSearchResult` would upsert a row with no fields. Its comment asserting that search "doesn't fit the added/updated/removed resource model (no `_removed`)" is no longer true and is corrected.

### Verification

47/47 ctest, clang-format clean, 0 findings on both clang-tidy tiers with 0 compiler errors, Web UI dictionary check green.

Two new unit tests, both **mutation-checked**: reverting the removal pass fails both by name. One asserts the event fires once with the exact identity payload and is idempotent on the next tick; the other asserts silence while the row is merely updated.

No curl assertion: producing a removal needs a search id to be reused or a fold to invert, neither of which a smoke run can force - and the search phases cannot currently get a `search_id` on my box at all (the unmodified binary fails the same way).
