### PR TITLE
fix(amuleapi): one chat serializer, one 202 convention, sortable twins, integer means integer

### DIFF
--- a/docs/api/REFERENCE.md
+++ b/docs/api/REFERENCE.md
@@ -231,7 +231,7 @@ That resolves to four shapes:
 Three bodies are deliberate exceptions, because each reports something no later read recovers:
 
 - the per-item [`results` envelope](#bulk-mutations-and-the-results-envelope), which carries a real outcome per input item;
-- `message` on the connection-control routes, which is the daemon's own explanation of what it did with the request;
+- `message` on the connection-control routes, which is the daemon's own explanation of what it did with the request - and only when the daemon actually said something: with nothing to report those routes answer `202` with no body, like the URL fetches beside them, rather than an empty object;
 - `ip` / `port` on [`POST /kad/bootstrap`](#post-apiv0kadbootstrap), which reports **which** address the daemon parsed.
 
 ### Idempotency
@@ -3183,7 +3183,7 @@ Served from the refresher snapshot — no EC roundtrip per request. Standard [li
 }
 ```
 
-`direction` is `"in"` (from the client) or `"out"` (sent by us — from **any** client: this API, amulegui, or the desktop GUI). `sent_at` is stamped by the core when the message was received or sent. `total` counts everything the store holds for this conversation, not the returned window.
+`direction` is `"in"` (from the client) or `"out"` (sent by us — from **any** client: this API, amulegui, or the desktop GUI). `sent_at` is stamped by the core when the message was received or sent, and is `null` only in the reply to a send: `EC_OP_CHAT_SEND` answers with the message id and no timestamp, and the core is the only thing entitled to stamp one. That reply is otherwise the same object shape this endpoint returns, emitted by the same writer, so a client can append it optimistically and reconcile on the next read. `total` counts everything the store holds for this conversation, not the returned window.
 
 **Errors:** `404 not_found` (no such conversation), `400 bad_request` (malformed `{client_address}` or query), `503 ec_unsupported`, `503 ec_unavailable`.
 
@@ -3200,10 +3200,10 @@ curl -s -X POST -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/
 
 ```json
 { "client_address": "203.0.113.42:4662",
-  "message": { "id": 92, "direction": "out", "text": "hello" } }
+  "message": { "id": 92, "direction": "out", "text": "hello", "sent_at": null } }
 ```
 
-The created message stays in the body because no per-message `GET` defines a shape for it, so the store-assigned `id` is only readable here. The **timestamp is not** in this reply — read it back from [`GET /chats`](#get-apiv0chats) (as `last_message`), from the per-conversation messages endpoint, or from the `chat_message` SSE event.
+The created message stays in the body because the store-assigned `id` is only readable here. It is the same object shape [`GET /chats/{client_address}/messages`](#get-apiv0chatsclient_addressmessages) returns, emitted by the same writer, with one difference: `sent_at` is **`null`**, because `EC_OP_CHAT_SEND` answers with the message id and no timestamp. Read the timestamp back from [`GET /chats`](#get-apiv0chats) (as `last_message`), from the per-conversation messages endpoint, or from the `chat_message` SSE event.
 
 The core creates the conversation if it does not exist, so this doubles as "start a chat with this address" — an unknown `{client_address}` is not a `404` here.
 

--- a/src/webapi/Api.cpp
+++ b/src/webapi/Api.cpp
@@ -3553,6 +3553,13 @@ const ListComparators<webapi::ClientSnapshot> &ClientComparators()
 		{ "ecid", SORT_BY(ecid), ANCHOR_ON_NUM(ecid) },
 		{ "name", SORT_BY(client_name) },
 		{ "software", SORT_BY(software) },
+		// R7: each value is spelled exactly like the response key it orders
+		// by. Only keys this row actually emits -- /known_clients can also
+		// sort by session_count / last_seen_at, which are not on a live peer.
+		{ "uploaded_bytes_total", SORT_BY(uploaded_bytes_total) },
+		{ "downloaded_bytes_total", SORT_BY(downloaded_bytes_total) },
+		{ "upload_speed_bytes_per_second", SORT_BY(upload_speed_bytes_per_second) },
+		{ "download_speed_bytes_per_second", SORT_BY(download_speed_bytes_per_second) },
 	};
 	return kComps;
 }
@@ -4586,8 +4593,12 @@ CHttpServer::Response CApiDispatcher::HandleSharedList(const CHttpServer::Reques
 		// cares about, not the order a UI table does.
 		{ "hash", SORT_BY(hash), ANCHOR_ON(hash) },
 		{ "name", SORT_BY(name) },
-		// R7: spelled like the response key it orders by.
+		// R7: spelled like the response key it orders by. The upload-side
+		// pair rather than /downloads' progress.percent / status: those
+		// describe a transfer this row does not report.
 		{ "size_bytes", SORT_BY(size) },
+		{ "uploaded_bytes_total", SORT_BY(shared.uploaded_bytes_total) },
+		{ "upload_speed_bytes_per_second", SORT_BY(shared.upload_speed_bytes_per_second) },
 	};
 	if (auto r = RequireSnapshot(m_state))
 		return *r;
@@ -4892,7 +4903,11 @@ CHttpServer::Response CApiDispatcher::HandleDownloadA4afAction(
 	bool per_source = false;
 	std::uint32_t client_ecid = 0;
 	if (const auto cit = obj.find("client_ecid"); cit != obj.end()) {
-		if (!cit->second.is<double>() || cit->second.get<double>() < 0) {
+		// Integrality checked, not just the sign: the message says integer,
+		// and without it 2.9 was accepted and truncated to 2.
+		if (!cit->second.is<double>() || cit->second.get<double>() < 0 ||
+			cit->second.get<double>() !=
+				static_cast<double>(static_cast<std::int64_t>(cit->second.get<double>()))) {
 			return ErrorResponse(
 				400, "bad_request", "`client_ecid` must be a non-negative integer");
 		}
@@ -5204,7 +5219,9 @@ CHttpServer::Response CApiDispatcher::HandleDownloadAdd(const CHttpServer::Reque
 					"`category_index` must be a non-negative integer");
 			}
 			const double v = it->second.get<double>();
-			if (v < 0 || v > 255) {
+			// The integrality test the message already promises: without it
+			// 2.9 was accepted and truncated to 2.
+			if (v < 0 || v > 255 || v != static_cast<double>(static_cast<int>(v))) {
 				return ErrorResponse(
 					400, "bad_request", "`category_index` must be in [0, 255]");
 			}
@@ -5516,7 +5533,9 @@ CHttpServer::Response CApiDispatcher::HandleDownloadPatch(
 					"`category_index` must be a non-negative integer");
 			}
 			const double v = it->second.get<double>();
-			if (v < 0 || v > 255) {
+			// The integrality test the message already promises: without it
+			// 2.9 was accepted and truncated to 2.
+			if (v < 0 || v > 255 || v != static_cast<double>(static_cast<int>(v))) {
 				return ErrorResponse(
 					400, "bad_request", "`category_index` must be in [0, 255]");
 			}
@@ -6175,8 +6194,9 @@ void WriteChatMessageObject(CJsonWriter &w, const webapi::ChatMessageSnapshot &m
 	w.ValueString(wxString::FromAscii(m.outgoing ? "out" : "in"));
 	w.Key("text");
 	w.ValueString(wxString::FromUTF8(m.text.c_str()));
-	w.Key("sent_at");
-	w.ValueInt(static_cast<int64_t>(m.timestamp));
+	// null, not 0, when the core has not stamped it: the send response builds
+	// its echo through here before any timestamp exists.
+	WriteIntOrNull(w, "sent_at", m.timestamp != 0, static_cast<int64_t>(m.timestamp));
 	w.EndObject();
 }
 
@@ -6525,19 +6545,20 @@ CHttpServer::Response CApiDispatcher::SendChatMessageTo(const CHttpServer::Reque
 	CJsonWriter w;
 	w.BeginObject();
 	// `ok` dropped. The nested `message` object stays: it is the created
-	// resource, carrying the id and direction the daemon assigned, and there
-	// is no per-message GET route whose shape it could mirror instead.
+	// resource, carrying the id and direction the daemon assigned. Built
+	// through the same writer GET /chats and GET /chats/{address}/messages
+	// use, so the row a client optimistically appends has the shape it will
+	// read back. `sent_at` is null here and only here: EC_OP_CHAT_SEND
+	// answers with the client and message ids and no timestamp, and the core
+	// is the only thing entitled to stamp one.
 	w.Key("client_address");
 	w.ValueString(wxString::FromUTF8(webapi::ChatPeerKeyFromGuiId(gui_id).c_str()));
 	w.Key("message");
-	w.BeginObject();
-	w.Key("id");
-	w.ValueInt(static_cast<int64_t>(msg_id));
-	w.Key("direction");
-	w.ValueString(wxString::FromAscii("out"));
-	w.Key("text");
-	w.ValueString(wxString::FromUTF8(text.c_str()));
-	w.EndObject();
+	webapi::ChatMessageSnapshot sent;
+	sent.id = msg_id;
+	sent.outgoing = true;
+	sent.text = text;
+	WriteChatMessageObject(w, sent);
 	w.EndObject();
 	CHttpServer::Response r;
 	r.status = 202;
@@ -6698,7 +6719,8 @@ CHttpServer::Response CApiDispatcher::HandleFriendAdd(const CHttpServer::Request
 	if (has_client) {
 		// Promote a connected peer, the desktop's "Add to Friends" item.
 		const auto &v = obj.at("client_ecid");
-		if (!v.is<double>() || v.get<double>() < 0) {
+		if (!v.is<double>() || v.get<double>() < 0 ||
+			v.get<double>() != static_cast<double>(static_cast<std::int64_t>(v.get<double>()))) {
 			return ErrorResponse(
 				400, "bad_request", "`client_ecid` must be a non-negative integer");
 		}
@@ -9013,16 +9035,21 @@ CHttpServer::Response SimpleConnControlOp(
 
 	CHttpServer::Response r;
 	r.status = http_status;
+	// `ok` dropped: the status code already said it. `message` stays -- it is
+	// the daemon's own explanation of what it did with the request, which is
+	// not recoverable from any subsequent read. With nothing to say, no body
+	// at all rather than `{}`: the URL-fetch triggers beside these answer the
+	// same 202 with no body, and `ipfilter/reload` vs `ipfilter/update` is
+	// otherwise two shapes for the same fire-and-forget shrug.
+	if (message.empty()) {
+		r.content_type.clear();
+		return r;
+	}
 	r.content_type = "application/json";
 	CJsonWriter w;
 	w.BeginObject();
-	// `ok` dropped: the status code already said it. `message` stays -- it is
-	// the daemon's own explanation of what it did with the request, which is
-	// not recoverable from any subsequent read.
-	if (!message.empty()) {
-		w.Key("message");
-		w.ValueString(wxString::FromUTF8(message.c_str()));
-	}
+	w.Key("message");
+	w.ValueString(wxString::FromUTF8(message.c_str()));
 	w.EndObject();
 	FinalizeJsonBody(w, r);
 	return r;
@@ -9561,7 +9588,9 @@ CHttpServer::Response CApiDispatcher::HandleDownloadsBulkPatch(const CHttpServer
 					"bad_request",
 					"`category_index` must be a non-negative integer");
 			const double v = it->second.get<double>();
-			if (v < 0 || v > 255)
+			// The integrality test the message already promises: without it
+			// 2.9 was accepted and truncated to 2.
+			if (v < 0 || v > 255 || v != static_cast<double>(static_cast<int>(v)))
 				return ErrorResponse(
 					400, "bad_request", "`category_index` must be in [0, 255]");
 			ops.push_back({ EC_OP_PARTFILE_SET_CAT,
@@ -11490,7 +11519,9 @@ CHttpServer::Response CApiDispatcher::HandleSearchDownload(
 					"`category_index` must be a non-negative integer");
 			}
 			const double v = it->second.get<double>();
-			if (v < 0 || v > 255) {
+			// The integrality test the message already promises: without it
+			// 2.9 was accepted and truncated to 2.
+			if (v < 0 || v > 255 || v != static_cast<double>(static_cast<int>(v))) {
 				return ErrorResponse(
 					400, "bad_request", "`category_index` must be in [0, 255]");
 			}

--- a/unittests/curl-tests/amuleapi/12-downloads-add-patch.sh
+++ b/unittests/curl-tests/amuleapi/12-downloads-add-patch.sh
@@ -302,6 +302,16 @@ _assert_status 200 "PATCH combined (action+priority+category_index) → 200"
 _assert_json_eq '.status'   paused 'combined PATCH response status=paused'
 _assert_json_eq '.priority' low    'combined PATCH response priority=low'
 _assert_json_eq '.category_index' 0      'combined PATCH response category_index=0'
+
+# `category_index` says "must be a non-negative integer", so it has to mean it:
+# a fractional value used to pass the is<double>() + range test and be
+# truncated to 2, the one integer field on the surface that enforced what its
+# own message promised being my_rating.
+_curl -X PATCH -H "Authorization: Bearer $ADMIN_TOKEN" \
+	-H "Content-Type: application/json" \
+	-d '{"category_index":2.9}' "$HOST/api/v0/downloads/$TEST_HASH"
+_assert_status 400 "PATCH category_index=2.9 -> 400 (not truncated to 2)"
+_assert_json_eq '.error.code' bad_request 'fractional category_index carries error.code=bad_request'
 _curl -H "Authorization: Bearer $ADMIN_TOKEN" \
 	"$HOST/api/v0/downloads/$TEST_HASH"
 _assert_json_eq '.status'   paused 'IMMEDIATE GET after combined PATCH status=paused'

--- a/unittests/curl-tests/amuleapi/28-list-pagination-sort.sh
+++ b/unittests/curl-tests/amuleapi/28-list-pagination-sort.sh
@@ -320,6 +320,26 @@ _curl "${AUTH[@]}" "$HOST/api/v0/categories?sort=index&after=1000000000"
 _assert_status 200 "after= past the last index → 200"
 _assert_json_eq ".categories | length" 0 "after= past the last index returns an empty page"
 
+# --- The sort surface a collection's own row can support. ----------
+# /clients and /shared used to expose three keys each while their twins
+# (/known_clients, /downloads) exposed eight and six. The keys added here are
+# only the ones each row actually emits, per R7: /shared gets the upload-side
+# pair, not /downloads' progress.percent or status, which describe a transfer a
+# shared row does not report -- sorting by an absent column is not a sort.
+for key in uploaded_bytes_total downloaded_bytes_total upload_speed_bytes_per_second download_speed_bytes_per_second; do
+	_curl "${AUTH[@]}" "$HOST/api/v0/clients?sort=$key"
+	_assert_status 200 "GET /clients?sort=$key -> 200"
+done
+for key in uploaded_bytes_total upload_speed_bytes_per_second; do
+	_curl "${AUTH[@]}" "$HOST/api/v0/shared?sort=$key"
+	_assert_status 200 "GET /shared?sort=$key -> 200"
+done
+# The download-only keys stay rejected on /shared: the row has no such column.
+for key in progress.percent status; do
+	_curl "${AUTH[@]}" "$HOST/api/v0/shared?sort=$key"
+	_assert_status 400 "GET /shared?sort=$key -> 400 (not a column of this row)"
+done
+
 # Delete the seeded row (a single row, so no index-renumber concern).
 [ -n "$NEW_IDX" ] && curl -s -X DELETE "${AUTH[@]}" "$HOST/api/v0/categories/$NEW_IDX" > /dev/null 2>&1
 

--- a/unittests/curl-tests/amuleapi/35-ipfilter-actions.sh
+++ b/unittests/curl-tests/amuleapi/35-ipfilter-actions.sh
@@ -149,7 +149,17 @@ fi
 
 _curl -X POST -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/ipfilter/reload"
 _assert_status 202 "POST /ipfilter/reload → 202"
-_assert_json_eq '. | has("ok")' false "reload response has no constant ok field"
+# amuled answers this one with no status string, so there is nothing to report
+# and the reply carries no body -- the same shape /ipfilter/update beside it
+# returns, rather than an empty object. When amuled does say something, the
+# body is {"message": "..."} (see the connect routes).
+if [ -z "$CURL_BODY" ]; then
+	_pass "reload with nothing to report returns no body (not an empty object)"
+else
+	_assert_json_eq '. | has("ok")' false "reload response has no constant ok field"
+	_assert_json_eq '. | has("message")' true \
+		"a reload body exists only to carry the daemon's message"
+fi
 
 _curl -X GET -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/ipfilter/reload"
 _assert_status 405 "GET /ipfilter/reload → 405"

--- a/unittests/curl-tests/amuleapi/38-chat.sh
+++ b/unittests/curl-tests/amuleapi/38-chat.sh
@@ -134,6 +134,11 @@ _assert_json_eq '. | has("ok")' false 'send response has no constant ok field'
 _assert_json_eq '.client_address'                "$PEER" 'send echoes the conversation key'
 _assert_json_eq '.message.direction'   out     'sent message is direction=out'
 _assert_json_eq '.message.text'        "curl-test hello" 'send echoes the text'
+# Same object shape the GET returns, from the same writer -- including the
+# sent_at key. It is null here and only here: EC_OP_CHAT_SEND answers with the
+# message id and no timestamp.
+_assert_json_eq '.message | has("sent_at")' true 'send echo carries the sent_at key'
+_assert_json_eq '.message.sent_at' null 'send echo sent_at is null, not a fabricated stamp'
 FIRST_ID=$(printf '%s' "$CURL_BODY" | jq -r '.message.id')
 
 # The refresher mirrors the store on its next tick (1 s).


### PR DESCRIPTION
Items **8, 9, 10 and 11** of #1253. That leaves only the doc/comment batch (17-21), the naming batch (12-16), and the two security decisions (22-23).

### 8 - the chat send response dropped a field every read carries

`SendChatMessageTo` hand-built its `message` object as `{id, direction, text}`, while `GET /chats`, `GET /chats/{address}/messages` and the `chat_message` SSE payload all emit `{id, direction, text, sent_at}`. A client optimistically appending the row it just sent held a differently-shaped one.

It now goes through `WriteChatMessageObject`. `EC_OP_CHAT_SEND` answers with the message id and **no timestamp**, and the core is the only thing entitled to stamp one - so rather than invent a value or emit a `0` sentinel, the writer null-guards it and the send reply carries `sent_at: null`. Its old comment claiming "there is no per-message GET route whose shape it could mirror" was simply wrong; there are two.

### 9 - two shapes for the same shrug

The connection-control routes answered `202` with `{}` when the daemon had nothing to say; the four URL-fetch triggers answer `202` with no body. `ipfilter/reload` vs `ipfilter/update` was the sharpest pair. The empty-object case is gone: a body now exists only to carry the daemon's own `message`.

### 10 - and where the audit is wrong

`/clients` and `/shared` offered three sort keys each against their twins' eight and six. But the audit's specific suggestion does not hold for `/shared`: **`progress.percent` and `status` describe a transfer a shared row does not report** - that row emits `upload_speed_bytes_per_second`, `uploaded_bytes_total`, `last_upload_at` and so on, with no progress or status key at all. R7 requires a sort value to name a key the response actually emits, so adding them would mean sorting by an absent column.

So each collection gets keys from **its own row**: `/clients` the four transfer counters it already carries, `/shared` its upload-side pair. The download-only keys stay rejected, which the tests now assert positively.

### 11 - "must be an integer" now means it

`category_index` (three sites) and the a4af `client_ecid` validated with `is<double>()` plus a range check, so `2.9` passed and was truncated to `2` - under a message promising an integer. `my_rating` was the only one of the three that enforced it. All now do.

### Verification

47/47 ctest, clang-format clean, 0 findings on both clang-tidy tiers with 0 compiler errors.

Curl: **12 (46/46)**, **35 (24/24)**, **38 (50/50)**, with new assertions in each - `sent_at: null` on the send echo, a reload body of zero bytes, and `category_index: 2.9` giving `400`.

The sort-key assertions live in phase 28, which **cannot reach them on my box**: it aborts at bring-up on `POST /search returned no search_id`, exactly as the unmodified binary does. I verified those by hand against a live daemon instead - the six new keys answer `200`, and `progress.percent` / `status` answer `400` on `/shared`.
