### PR TITLE
fix(amuleapi): withhold CORS credentials from the wildcard origin echo

### DIFF
--- a/docs/QUICKSTART-AMULEAPI.md
+++ b/docs/QUICKSTART-AMULEAPI.md
@@ -84,6 +84,12 @@ cannot be read back, only replaced — which is why the preference fields open
 blank, and why leaving one empty keeps the current password. Changes apply at
 the next login, with no restart.
 
+Guest is read-only, not a sandbox: it can see the daemon's incoming, temp and
+shared folder paths, this node's user hash, the configured proxy user, and the
+raw amuled log with the peer addresses and filenames in it. Hand a guest
+password to someone you would give read access to the machine, and not to
+anyone else.
+
 If amuleapi runs on a different machine from aMule, set its password there:
 the preferences panel only writes the file on aMule's own host.
 
@@ -195,7 +201,7 @@ restarts.
 BindAddress=127.0.0.1     ; who can reach the API
 Port=4713                 ; amuleapi's own HTTP port
 AllowCORS=0               ; see CORS below
-CorsOriginAllowlist=
+CorsOriginAllowlist=      ; origins allowed to log in cross-origin
 StaticRoot=               ; folder to serve a web frontend from
 
 [EC]
@@ -253,10 +259,20 @@ To allow others:
 ```ini
 [Server]
 AllowCORS=1
-CorsOriginAllowlist=https://your-app.example.com
+CorsOriginAllowlist=https://your-app.example.com, http://localhost:5173
 ```
 
-Leaving the allowlist empty accepts any origin.
+The allowlist is comma-separated and matched exactly against the browser's
+`Origin`: scheme, host and port, no path and no wildcards. So
+`https://example.com` does not cover `https://www.example.com`, and two ports
+on one host are two entries.
+
+**List the origins you actually use.** Leaving the allowlist empty still
+accepts any origin, but only for anonymous requests: a cross-origin page
+cannot then send the session cookie or a bearer token, because amuleapi
+withholds `Access-Control-Allow-Credentials` on that path. Otherwise any site
+your browser visits could call the API as you. A web frontend that logs in
+needs its origin listed.
 
 ## What you get
 

--- a/docs/api/REFERENCE.md
+++ b/docs/api/REFERENCE.md
@@ -171,6 +171,8 @@ A role is implicitly assigned at login based on which password matched; the veri
 
 Guest access is on exactly when a guest password is configured — there is no separate switch. Clearing the guest password is how guest access is turned off.
 
+**What `guest` is, and is not.** It is a read-only role for someone you already trust on the network, not a sandbox for a hostile party. A guest reads the whole read surface, and that surface includes things an operator may not think of as public: the daemon's incoming, temp and shared **filesystem paths**; the node's `user_hash`; the configured `proxy_user`; and the raw daemon **log**, which carries peer addresses and file names as they are logged. None of that is a defect - a read-only API that hid the paths it is reading from would be hard to use - but it means guest credentials should be handed out on the same basis as read access to the machine, and a guest password is not a way to expose amuleapi to the open internet safely. If a caller should not see those, do not give them a credential at all.
+
 ### Where the passwords live
 
 Both are stored in `${config_dir}/amuleapi-passwords` (mode 0600), each as a salted PBKDF2-HMAC-SHA256 record rather than a reversible digest. That file is the only store; nothing is kept in `amule.conf`.
@@ -435,7 +437,8 @@ If `amuleapi.conf[Server]/AllowCORS=1`:
 
 - Every response carries `Vary: Origin`.
 - The origin is echoed in `Access-Control-Allow-Origin` if either the allowlist is empty (any-origin echo) or the request's `Origin` header matches a configured entry.
-- Allowed responses also carry `Access-Control-Allow-Credentials: true` and `Access-Control-Expose-Headers: ETag, Allow, Retry-After` so cookie-auth clients can read the validator, the supported-method list from a `405`, and the back-off hint from a `429` or `503`, from JS.
+- **`Access-Control-Allow-Credentials: true` is sent only for an origin the allowlist names.** With an empty allowlist the echo is `*`-equivalent, and granting credentials there would let any site the user happens to visit call this API with their session cookie and read the replies, which is what the same-origin policy exists to prevent. Anonymous cross-origin reads still work with an empty allowlist; a **credentialed** cross-origin client needs its origin listed in `amuleapi.conf[Server]/CorsOriginAllowlist`: a comma-separated list, entries trimmed, matched by exact string equality against the request's `Origin` header. An origin is a scheme, host and port (`https://app.example.com`, or `http://localhost:5173` in development) with no path and no wildcards, so `https://example.com` does not cover `https://www.example.com` and the two ports of the same host are two entries.
+- Allowed responses carry `Access-Control-Expose-Headers: ETag, Allow, Retry-After` so clients can read the validator, the supported-method list from a `405`, and the back-off hint from a `429` or `503`, from JS.
 - Preflight (`OPTIONS` with `Access-Control-Request-Method`) returns `204` with `Access-Control-Allow-Methods: GET, HEAD, POST, PUT, PATCH, DELETE, OPTIONS`, `Access-Control-Allow-Headers: Authorization, Content-Type, If-None-Match, Last-Event-ID`, and `Access-Control-Max-Age: 86400`.
 
 ### Path validation

--- a/src/webapi/AmuleApiConfig.cpp
+++ b/src/webapi/AmuleApiConfig.cpp
@@ -167,6 +167,11 @@ bool CAmuleApiConfig::LoadAmuleapiConf(const wxString &path)
 			       "BindAddress=127.0.0.1\n"
 			       "Port=4713\n"
 			       "AllowCORS=0\n"
+			       // Written empty so the key is discoverable: with
+			       // AllowCORS=1 and no entries the echo is anonymous-only,
+			       // and a cross-origin client that logs in needs its origin
+			       // listed here.
+			       "CorsOriginAllowlist=\n"
 			       "StaticRoot=\n"
 			       "\n"
 			       "[EC]\n"

--- a/src/webapi/Api.cpp
+++ b/src/webapi/Api.cpp
@@ -672,30 +672,36 @@ std::string FindHeaderCaseInsensitive(
 	return std::string();
 }
 
-// resolve the CORS Origin echo for this request. Returns
-// the verbatim Origin to put in `Access-Control-Allow-Origin`, or
-// an empty string when CORS is disabled, the request had no Origin
-// (same-origin browser navigation; non-browser caller), or the
-// allowlist rejected the value. Wildcard semantics: `allow_cors=1`
-// with an empty allowlist echoes the request's Origin verbatim,
-// which is `*`-equivalent but cookie-auth-compatible (the literal
-// `*` is incompatible with `Access-Control-Allow-Credentials: true`
-// per CORS Fetch §3.2.5).
-std::string ResolveCorsOrigin(const CHttpServer::Request &req, const CAmuleApiConfig &cfg)
+// resolve the CORS Origin echo for this request. Returns the verbatim
+// Origin to put in `Access-Control-Allow-Origin` plus whether the
+// allowlist named it, or an empty origin when CORS is disabled, the
+// request had no Origin (same-origin browser navigation; non-browser
+// caller), or the allowlist rejected the value.
+//
+// Wildcard semantics: `allow_cors=1` with an empty allowlist echoes the
+// request's Origin verbatim, which is `*`-equivalent. Credentials are
+// NOT granted on that path -- see ApplyCorsHeaders.
+struct CorsDecision
+{
+	std::string origin;
+	bool allowlisted = false;
+};
+
+CorsDecision ResolveCorsOrigin(const CHttpServer::Request &req, const CAmuleApiConfig &cfg)
 {
 	if (!cfg.ServerCfg().allow_cors)
-		return std::string();
+		return CorsDecision{};
 	const std::string origin = FindHeaderCaseInsensitive(req.headers, "Origin");
 	if (origin.empty())
-		return std::string();
+		return CorsDecision{};
 	const auto &list = cfg.ServerCfg().cors_origin_allowlist;
 	if (list.empty())
-		return origin; // echo any origin
+		return CorsDecision{ origin, false }; // echo any origin, no credentials
 	for (const auto &allowed : list) {
 		if (allowed == origin)
-			return origin;
+			return CorsDecision{ origin, true };
 	}
-	return std::string();
+	return CorsDecision{};
 }
 
 // stamp the resolved CORS headers onto a response. `Vary:
@@ -704,15 +710,22 @@ std::string ResolveCorsOrigin(const CHttpServer::Request &req, const CAmuleApiCo
 // against a same-origin cache key. The auth + content headers go
 // on iff the origin was actually allowed.
 void ApplyCorsHeaders(
-	std::map<std::string, std::string> &headers, const std::string &resolved_origin, bool cors_enabled)
+	std::map<std::string, std::string> &headers, const CorsDecision &cors, bool cors_enabled)
 {
 	if (!cors_enabled)
 		return;
 	AppendHeaderToken(headers, "Vary", "Origin");
-	if (resolved_origin.empty())
+	if (cors.origin.empty())
 		return;
-	headers["Access-Control-Allow-Origin"] = resolved_origin;
-	headers["Access-Control-Allow-Credentials"] = "true";
+	headers["Access-Control-Allow-Origin"] = cors.origin;
+	// Credentials only for an origin the operator named. With an empty
+	// allowlist the echo is `*`-equivalent, and granting credentials there
+	// would let any site the user happens to visit call this API with their
+	// session cookie and read the replies -- the exact thing the same-origin
+	// policy exists to stop. An anonymous cross-origin read still works;
+	// a credentialed one needs an allowlist entry.
+	if (cors.allowlisted)
+		headers["Access-Control-Allow-Credentials"] = "true";
 	// Header names the client may read from `fetch().headers.get(...)`
 	// — by default the Fetch spec only exposes the CORS-safelisted
 	// response headers (Cache-Control, Content-Language, Content-Type,
@@ -792,7 +805,7 @@ bool RequestCarriesCredentials(const CHttpServer::Request &req, const std::strin
 CHttpServer::Response CApiDispatcher::Dispatch(const CHttpServer::Request &req)
 {
 	const bool cors_enabled = m_config.ServerCfg().allow_cors;
-	const std::string cors_org = ResolveCorsOrigin(req, m_config);
+	const CorsDecision cors_org = ResolveCorsOrigin(req, m_config);
 
 	// CORS preflight short-circuit. OPTIONS requests with
 	// `Access-Control-Request-Method` are browser preflights — they
@@ -806,7 +819,7 @@ CHttpServer::Response CApiDispatcher::Dispatch(const CHttpServer::Request &req)
 		pre.status = 204;
 		pre.content_type.clear();
 		ApplyCorsHeaders(pre.headers, cors_org, cors_enabled);
-		if (!cors_org.empty()) {
+		if (!cors_org.origin.empty()) {
 			pre.headers["Access-Control-Allow-Methods"] =
 				"GET, HEAD, POST, PUT, PATCH, DELETE, OPTIONS";
 			// Headers actual requests may send. Authorization for
@@ -11736,7 +11749,7 @@ void CApiDispatcher::StampCorsForTransport(
 	if (!origin_header.empty()) {
 		synthetic.headers.emplace("Origin", origin_header);
 	}
-	const std::string cors_org = ResolveCorsOrigin(synthetic, m_config);
+	const CorsDecision cors_org = ResolveCorsOrigin(synthetic, m_config);
 	ApplyCorsHeaders(headers, cors_org, m_config.ServerCfg().allow_cors);
 }
 
@@ -11756,7 +11769,7 @@ boost::optional<CHttpServer::Response> CApiDispatcher::PreflightEvents(const CHt
 		// an opaque fetch failure exactly when it most needs to read
 		// why it was turned away.
 		{
-			const std::string cors_org = ResolveCorsOrigin(req, m_config);
+			const CorsDecision cors_org = ResolveCorsOrigin(req, m_config);
 			ApplyCorsHeaders(a.rejection.headers, cors_org, m_config.ServerCfg().allow_cors);
 		}
 		return a.rejection;
@@ -11786,7 +11799,7 @@ boost::optional<CHttpServer::Response> CApiDispatcher::PreflightEvents(const CHt
 		// request on a socket we already shut down.
 		probe.headers["Connection"] = "close";
 		{
-			const std::string cors_org = ResolveCorsOrigin(req, m_config);
+			const CorsDecision cors_org = ResolveCorsOrigin(req, m_config);
 			ApplyCorsHeaders(probe.headers, cors_org, m_config.ServerCfg().allow_cors);
 		}
 		return probe;
@@ -11860,7 +11873,7 @@ void CApiDispatcher::DispatchEvents(const CHttpServer::Request &req,
 	// cross-origin streams. No Expose-Headers needed (SSE clients don't
 	// read response headers programmatically).
 	{
-		const std::string cors_org = ResolveCorsOrigin(req, m_config);
+		const CorsDecision cors_org = ResolveCorsOrigin(req, m_config);
 		ApplyCorsHeaders(response_headers, cors_org, m_config.ServerCfg().allow_cors);
 	}
 	// Also disable Connection: keep-alive override — chunked +

--- a/unittests/curl-tests/amuleapi/25-cors.sh
+++ b/unittests/curl-tests/amuleapi/25-cors.sh
@@ -14,9 +14,10 @@
 #     echoed only if it appears verbatim in the comma-separated
 #     allowlist. Non-matching origins receive `Vary: Origin` but
 #     no `Access-Control-Allow-Origin`.
-#   * Credentials: when an origin is allowed,
-#     `Access-Control-Allow-Credentials: true` is always set
-#     (cookie-auth-compatible with the per-origin echo).
+#   * Credentials: `Access-Control-Allow-Credentials: true` is set
+#     only for an origin the allowlist names. The empty-allowlist
+#     wildcard echoes the Origin but withholds credentials, so a
+#     drive-by site cannot call the API with the user's cookie.
 #   * Preflight: `OPTIONS` + `Access-Control-Request-Method` short-
 #     circuits before auth, replies 204 with
 #     `Access-Control-Allow-Methods: GET, HEAD, POST, PUT, PATCH,
@@ -191,10 +192,14 @@ if [ "$ACAO" = "https://wild.example.com" ]; then
 else
 	_fail "Wildcard echo" "expected 'https://wild.example.com', got '$ACAO'"
 fi
-if [ "$ACAC" = "true" ]; then
-	_pass "AllowCORS=1: Access-Control-Allow-Credentials: true"
+# The wildcard echo must NOT grant credentials: with no allowlist the echo
+# is `*`-equivalent, so any site the user visits could otherwise call this
+# API with their session cookie and read the replies. An anonymous
+# cross-origin read still works; a credentialed one needs an allowlist entry.
+if [ -z "$ACAC" ]; then
+	_pass "AllowCORS=1 (wildcard): no Access-Control-Allow-Credentials"
 else
-	_fail "Allow-Credentials" "expected 'true', got '$ACAC'"
+	_fail "wildcard Allow-Credentials" "expected no header, got '$ACAC'"
 fi
 if echo "$ACEH" | grep -qi "ETag"; then
 	_pass "AllowCORS=1: Access-Control-Expose-Headers lists ETag"


### PR DESCRIPTION
Items **22 and 23** of #1253 - the two the audit raised as decisions rather than defects.

### 22 - credentials on a wildcard echo

With `AllowCORS=1` and an **empty** allowlist, amuleapi echoed the request's `Origin` verbatim (`*`-equivalent) *and* sent `Access-Control-Allow-Credentials: true`. So any site the user happened to visit could call this API with their session cookie and read the replies - the thing the same-origin policy exists to prevent.

CORS is off by default (`allow_cors = false`), so this needed an operator to turn it on. But "enable CORS" should not mean "publish the API to every website".

Credentials are now granted **only for an origin the allowlist names**. `ResolveCorsOrigin` reports *how* the origin was allowed rather than merely whether it was, and the header stamper withholds the credentials header on the wildcard path. Anonymous cross-origin reads still work with an empty allowlist; a credentialed client needs its origin listed.

### 23 - guest is documented, not narrowed

Per the decision: guest stays a read-only role for someone already trusted on the network, not a sandbox for a hostile party. Its read surface legitimately includes the daemon's filesystem paths, the node's `user_hash`, the configured `proxy_user` and the raw log - hiding those would make a read-only API hard to use. The reference now says plainly that a guest credential should be handed out on the same basis as read access to the machine, and that it is not a way to expose amuleapi to the open internet safely.

### Tests

`25-cors.sh` asserted the *old* contract, so it now asserts the new one from both sides: the wildcard echo carries **no** credentials header, and an allowlisted origin still does - including on the SSE stream, which has its own assertion in Mode C.

### Verification

**25/25** on the CORS phase, 47/47 ctest, clang-format clean, 0 findings on both clang-tidy tiers with 0 compiler errors.

### Docs and the generated config

The QUICKSTART carried the same claim ("leaving the allowlist empty accepts any origin") and now says what that costs, spells out the allowlist format, and warns what a guest credential actually exposes.

One thing the review of that turned up: the generated `amuleapi.conf` **never wrote `CorsOriginAllowlist` at all**, though the QUICKSTART showed it as part of the file created on first run. The key was undiscoverable without reading the parser. It is written empty now (verified against a freshly generated file), which also makes the doc true. Existing configs are untouched; defaults are only written on first run.

The allowlist, for the record: comma-separated, entries trimmed, matched by exact string equality against the request's `Origin` (scheme, host and port, no path, no wildcards).
