### PR TITLE
fix(amuleapi): publish resync when the log buffer is cleared

### DIFF
--- a/docs/api/EVENTS.md
+++ b/docs/api/EVENTS.md
@@ -250,6 +250,7 @@ data: {"reason":"gap","since_id":<old cursor>,"newest_id":<new cursor>}
 - `"gap"` — events were evicted from the ring before the subscriber read them.
 - `"restart"` — the subscriber's id was past the bus's newest, only possible after a daemon restart.
 - `"idle"` — the daemon stopped diffing because nothing had been subscribed for several ticks, so no collection change is represented on the bus for that period. A cursor from before it cannot be trusted however in-range it looks — and it may well still be in range, because the chat publisher keeps ids moving regardless.
+- `"log_cleared"` — [`DELETE /logs/amule`](REFERENCE.md#delete-apiv0logsamule) emptied the log buffer. The lines a `log_appended` subscriber was tracking no longer exist, and the buffer may already have refilled, so the tail cursor is meaningless: re-read [`GET /logs/amule`](REFERENCE.md#get-apiv0logsamule). Any client can clear the log, so this reaches subscribers that did not issue the DELETE.
 
 On any of them, the client's correct response is:
 
@@ -576,7 +577,7 @@ Emitted when the amuled log buffer appends new lines.
 { "lines": ["2026-06-19 11:00:00: line one", "2026-06-19 11:00:01: line two"] }
 ```
 
-Only the amuled log has a live channel; the server_info buffer has no SSE feed and is fetched by polling [`GET /logs/serverinfo`](REFERENCE.md#get-apiv0logsserverinfo). Multiple lines may be batched into a single event when the buffer landed several lines between refresher ticks. The [Bootstrap example](#bootstrap-snapshot--stream) doesn't pull `/logs/amule` — fetch it in step 2 if your UI shows historical log lines, otherwise treat `log_appended` as a live-only feed.
+Only the amuled log has a live channel; the server_info buffer has no SSE feed and is fetched by polling [`GET /logs/serverinfo`](REFERENCE.md#get-apiv0logsserverinfo). Multiple lines may be batched into a single event when the buffer landed several lines between refresher ticks. The feed is append-only with one exception: [`DELETE /logs/amule`](REFERENCE.md#delete-apiv0logsamule) empties the buffer, and rather than a log event that would leave the cursor pointing into a buffer that no longer exists, every subscriber gets a [`resync`](#resync-frame) with `reason: "log_cleared"` and re-reads. Any client can clear the log, so this can arrive without your having asked for it. The [Bootstrap example](#bootstrap-snapshot--stream) doesn't pull `/logs/amule` — fetch it in step 2 if your UI shows historical log lines, otherwise treat `log_appended` as a live-only feed.
 
 ### `search` channel
 

--- a/src/webapi/Api.cpp
+++ b/src/webapi/Api.cpp
@@ -8282,12 +8282,12 @@ CHttpServer::Response CApiDispatcher::HandleLogAmuleReset(const CHttpServer::Req
 	}
 	delete ec_resp;
 
-	// Drop the in-process mirror. The refresher's append-only path
-	// (AppendAmuleLog) can't shrink the cache, and EmitDiffsAndUpdate treats a
-	// size decrease as a silent truncation (its `log_size <
-	// prev.amule_log_count` branch), so no spurious log_appended event fires on
-	// the next tick -- and, as noted there, no event at all for whatever was
-	// appended before that tick.
+	// Drop the in-process mirror. This also bumps the log's clear-generation,
+	// which is what the next refresher tick reads to publish a `resync` for
+	// every subscriber rather than a log event -- the lines this channel
+	// promised are gone, so "re-read" is the honest signal. Publishing it here
+	// instead is not open to us: the bus has a single-publisher invariant and
+	// this is the HTTP thread.
 	m_state.ClearAmuleLog();
 
 	CHttpServer::Response r;

--- a/src/webapi/EventDiff.cpp
+++ b/src/webapi/EventDiff.cpp
@@ -1146,25 +1146,39 @@ void EmitDiffsAndUpdate(CEventBus &bus, LastSeenState &prev, const CState &state
 	// the tail is new. First tick records the baseline silently — clients GET
 	// /api/v0/logs/amule for the history; this channel is the live tail only.
 	//
-	// A size that shrank means `DELETE /logs/amule` cleared the buffer, and the
-	// only thing this does about it is re-point the counter. Lines appended
-	// between that DELETE and this tick are NOT published, and if the counter
-	// was below the new size the append branch publishes a mid-buffer slice as
-	// though it were a tail. Only the client that issued the DELETE knows to
-	// refetch; other subscribers are not told. Pre-existing, and fixable by
-	// publishing `resync` on the reset edge -- which needs the bus-published
-	// resync to bypass the `?channels=` filter, so it is not this change.
+	// `DELETE /logs/amule` empties the buffer, and the clear-generation is what
+	// says so. A shrunk size was the old signal and it misses the case that
+	// matters: cleared and refilled past the old count between two ticks, the
+	// size only grows, so the append branch would publish a mid-buffer slice
+	// as though it were the tail and never publish what came before it.
+	//
+	// On that edge subscribers get `resync`, not a log event: lines are gone
+	// that this channel promised to deliver, so the honest signal is "your
+	// copy is stale, re-read", which is exactly what resync means. It bypasses
+	// `?channels=`, so a log-only subscriber is told too -- and the HTTP
+	// thread could not have published it from the DELETE handler anyway, the
+	// bus having a single-publisher invariant that only this tick satisfies.
 	//
 	// Size and tail in one read: the history is uncapped, so asking AmuleLog()
 	// for a `.size()` that is unchanged on almost every tick copies all of it
 	// -- and splitting the two would let that DELETE land in between, pairing
-	// a pre-truncation size with an empty tail.
+	// a pre-truncation size with an empty tail. The generation rides along for
+	// the same reason.
 	std::size_t log_size = 0;
-	const auto tail = state.AmuleLogFrom(prev.amule_log_count, log_size);
+	std::uint64_t log_generation = 0;
+	const auto tail = state.AmuleLogFrom(prev.amule_log_count, log_size, &log_generation);
 	if (!prev.amule_log_initialised) {
 		prev.amule_log_count = log_size;
+		prev.amule_log_generation = log_generation;
 		prev.amule_log_initialised = true;
+	} else if (log_generation != prev.amule_log_generation) {
+		bus.Publish("resync", "{\"reason\":\"log_cleared\"}");
+		prev.amule_log_count = log_size;
+		prev.amule_log_generation = log_generation;
 	} else if (log_size < prev.amule_log_count) {
+		// No generation bump, so this is not a clear: the buffer is capped
+		// elsewhere or the daemon replaced it wholesale. Re-point and stay
+		// quiet, as before.
 		prev.amule_log_count = log_size;
 	} else if (!tail.empty()) {
 		std::ostringstream payload;

--- a/src/webapi/EventDiff.h
+++ b/src/webapi/EventDiff.h
@@ -72,6 +72,9 @@ struct LastSeenState
 	// event — clients can GET /api/v0/logs/amule for the history.
 	std::size_t amule_log_count = 0;
 	bool amule_log_initialised = false;
+	// Last clear-generation seen. A bump means DELETE /logs/amule emptied the
+	// buffer since the previous tick, which the count alone cannot tell.
+	std::uint64_t amule_log_generation = 0;
 
 	// Per-search event baseline (multi-search). One entry per open search_id,
 	// diffed against that search's state each tick: new result ECIDs →

--- a/src/webapi/State.cpp
+++ b/src/webapi/State.cpp
@@ -139,10 +139,13 @@ std::vector<std::string> CState::AmuleLog() const
 	return m_amule_log_lines;
 }
 
-std::vector<std::string> CState::AmuleLogFrom(std::size_t first, std::size_t &total) const
+std::vector<std::string> CState::AmuleLogFrom(
+	std::size_t first, std::size_t &total, std::uint64_t *generation) const
 {
 	std::shared_lock<std::shared_timed_mutex> lock(m_mu);
 	total = m_amule_log_lines.size();
+	if (generation)
+		*generation = m_amule_log_generation;
 	if (first >= total)
 		return {};
 	return std::vector<std::string>(
@@ -517,6 +520,7 @@ void CState::ClearAmuleLog()
 {
 	std::unique_lock<std::shared_timed_mutex> lock(m_mu);
 	m_amule_log_lines.clear();
+	++m_amule_log_generation;
 }
 
 void CState::WriteServerInfo(ServerInfoLog s)

--- a/src/webapi/State.h
+++ b/src/webapi/State.h
@@ -1699,7 +1699,14 @@ public:
 	//! `first` past the end gives an empty tail, which with `total` is how the
 	//! caller sees a truncation. Copies nothing when nothing was appended,
 	//! which the per-tick log diff needs and AmuleLog() cannot do.
-	std::vector<std::string> AmuleLogFrom(std::size_t first, std::size_t &total) const;
+	//! `generation`, when asked for, is read under the same lock as the window
+	//! and is bumped by every ClearAmuleLog(). Size alone cannot detect a
+	//! clear: a buffer cleared and refilled past its old length between two
+	//! ticks looks like growth, and the diff would then publish a mid-buffer
+	//! slice as a tail. Taking it here rather than from a second call is what
+	//! keeps a concurrent DELETE from tearing the pair.
+	std::vector<std::string> AmuleLogFrom(
+		std::size_t first, std::size_t &total, std::uint64_t *generation = nullptr) const;
 	ServerInfoLog ServerInfo() const;
 
 	// Flat list views. Reads the ECID-keyed map under shared_lock and
@@ -2085,6 +2092,7 @@ private:
 	std::vector<ChatSessionSnapshot> m_chats;
 	std::uint32_t m_chat_cursor = 0;
 	std::vector<std::string> m_amule_log_lines;
+	std::uint64_t m_amule_log_generation = 0;
 	ServerInfoLog m_server_info;
 	StatsTreeNode m_stats_tree;
 	StatsGraphs m_graphs;

--- a/src/webapi/static/js/events.js
+++ b/src/webapi/static/js/events.js
@@ -225,7 +225,8 @@ function openSse() {
   es.addEventListener("resync", () => {
     if (statusActive) refreshStatus();
     for (const k of active) seed(k);
-    // chats.js isn't an `active` resource, so the re-seed above misses it.
+    // chats.js and the log panel aren't `active` resources, so the re-seed
+    // above misses them: one counter both can watch.
     store.set("resync", (store.get("resync") || 0) + 1);
   });
 

--- a/src/webapi/static/js/views/networks.js
+++ b/src/webapi/static/js/views/networks.js
@@ -394,8 +394,18 @@ function AmuleLogPanel() {
       if (!boxRef.current) return;
       for (const line of (v.lines || [])) append(boxRef.current, line);
     });
+    // resync means the tail cursor is worthless -- DELETE /logs/amule emptied
+    // the buffer, from this client or another one -- so re-read rather than
+    // keep appending to what is on screen.
+    let lastResync = store.get("resync");
+    const unsubResync = store.subscribe("resync", (v) => {
+      if (v === lastResync) return;
+      lastResync = v;
+      if (boxRef.current) setText(boxRef.current, "");
+      load();
+    });
     load();
-    return () => unsub();
+    return () => { unsub(); unsubResync(); };
   }, []);
 
   return logBox(clear, save, boxRef);

--- a/unittests/tests/EventDiffTest.cpp
+++ b/unittests/tests/EventDiffTest.cpp
@@ -693,6 +693,69 @@ TEST(EventDiff, SearchResultRemovedSilentWhileTheResultRemains)
 	ASSERT_EQUALS(static_cast<size_t>(0), CountEvent(bus, "search_result_removed"));
 }
 
+// DELETE /logs/amule empties the buffer. The old signal was a shrunk size,
+// which misses the case that matters: cleared and refilled past the old count
+// between two ticks, the size only grows, so the append branch published a
+// mid-buffer slice as though it were the tail and never published what came
+// before it. The clear-generation catches both shapes.
+TEST(EventDiff, LogClearPublishesResyncRatherThanAMidBufferSlice)
+{
+	CState state;
+	CEventBus bus;
+	LastSeenState prev;
+
+	state.AppendAmuleLog({ "one\n", "two\n" });
+	EmitDiffsAndUpdate(bus, prev, state); // cold-start baseline, silent
+	ASSERT_EQUALS(static_cast<size_t>(0), CountEvent(bus, "log_appended"));
+
+	// Cleared, then refilled past the old length before the next tick: three
+	// lines where there were two, so the size alone reads as growth.
+	state.ClearAmuleLog();
+	state.AppendAmuleLog({ "A\n", "B\n", "C\n" });
+	EmitDiffsAndUpdate(bus, prev, state);
+
+	ASSERT_EQUALS(static_cast<size_t>(1), CountEvent(bus, "resync"));
+	// No log_appended: publishing "C" alone as the tail is exactly the bug.
+	ASSERT_EQUALS(static_cast<size_t>(0), CountEvent(bus, "log_appended"));
+
+	std::string payload;
+	for (const auto &e : DrainAll(bus))
+		if (e.name == "resync")
+			payload = e.data;
+	ASSERT_EQUALS(std::string("{\"reason\":\"log_cleared\"}"), payload);
+
+	// The baseline moved to the refilled buffer, so the next append is a
+	// clean tail again and no second resync fires.
+	state.AppendAmuleLog({ "D\n" });
+	EmitDiffsAndUpdate(bus, prev, state);
+	ASSERT_EQUALS(static_cast<size_t>(1), CountEvent(bus, "resync"));
+	ASSERT_EQUALS(static_cast<size_t>(1), CountEvent(bus, "log_appended"));
+	for (const auto &e : DrainAll(bus))
+		if (e.name == "log_appended")
+			payload = e.data;
+	ASSERT_TRUE(payload.find("D") != std::string::npos);
+	ASSERT_TRUE(payload.find("C") == std::string::npos);
+}
+
+// A clear that leaves the buffer smaller is the same edge, and must not be
+// mistaken for the old silent-truncation path.
+TEST(EventDiff, LogClearToASmallerBufferAlsoPublishesResync)
+{
+	CState state;
+	CEventBus bus;
+	LastSeenState prev;
+
+	state.AppendAmuleLog({ "one\n", "two\n", "three\n" });
+	EmitDiffsAndUpdate(bus, prev, state);
+
+	state.ClearAmuleLog();
+	state.AppendAmuleLog({ "X\n" });
+	EmitDiffsAndUpdate(bus, prev, state);
+
+	ASSERT_EQUALS(static_cast<size_t>(1), CountEvent(bus, "resync"));
+	ASSERT_EQUALS(static_cast<size_t>(0), CountEvent(bus, "log_appended"));
+}
+
 TEST(EventDiff, SearchResultUpdatedFiresWhenADownloadStateChanges)
 {
 	CState state;


### PR DESCRIPTION
Item **6** of #1253 - the one the audit deferred.

### The defect

`DELETE /logs/amule` empties the buffer, and the diff's only signal was a shrunk size. That misses the case that matters: **cleared and refilled past the old count between two ticks**, the size only *grows*, so the append branch published a mid-buffer slice as though it were the tail and never published the lines before it. In the smaller-shrink case, lines appended between the DELETE and the tick were dropped silently. Either way, only the client that issued the DELETE knew to re-read.

### The fix

`CState` carries a clear-generation, bumped by `ClearAmuleLog` and handed out **by `AmuleLogFrom` under the same lock as the window**. A separate accessor would let a concurrent DELETE tear the pair - which is precisely why the existing code already takes size and tail together, and the new value rides along for the same reason.

A generation bump publishes `resync` with reason `log_cleared` and re-baselines the cursor. The shrink branch stays, for a size decrease with no clear behind it.

**Why `resync` and not a log event:** lines this channel promised are gone, so "your copy is stale, re-read" is the honest signal, and `resync` already bypasses `?channels=` so a log-only subscriber hears it.

Two notes on the audit's framing. It assumed the filter bypass had to be built - **it already existed** (`Api.cpp`, `if (name == "resync") return true;`). And publishing from the DELETE handler was never an option: the bus has a single-publisher invariant that only the refresher tick satisfies, and the release build aborts on a violation.

### Web UI

The log panel owns a text box rather than one of the generic resources the `resync` handler re-seeds, so it gets its own nudge and re-reads, instead of appending to a buffer that no longer exists.

### Verification

Two unit tests, both **mutation-checked** - reverting the branch fails both by name. One covers the grew-past-the-old-count shape and asserts the payload plus that the *next* append is a clean tail again (`D` present, `C` absent); the other covers the shrink shape.

47/47 ctest, clang-format clean, 0 findings on both clang-tidy tiers with 0 compiler errors.
