### PR TITLE
refactor(amuleapi): spell the last four v0 key names by the rules

### DIFF
--- a/docs/api/EVENTS.md
+++ b/docs/api/EVENTS.md
@@ -288,7 +288,7 @@ Identical to the REST [`/api/v0/downloads`](REFERENCE.md#get-apiv0downloads) lis
   "progress": { "percent": 29.85 },
   "kad_comment_lookup_running": false,
   "hashed_part_count":  0,
-  "parts_total_count":  411,
+  "total_part_count":  411,
   "source_ecids":  [ 1234, 5678 ]
 }
 ```
@@ -450,7 +450,7 @@ One event per message, **inbound and outbound alike**. An outbound one is how a 
 
 ```json
 {
-  "client_address": "203.0.113.42:4662",
+  "address": "203.0.113.42:4662",
   "ip":          "203.0.113.42",
   "port":        4662,
   "name":        "alice",
@@ -460,17 +460,17 @@ One event per message, **inbound and outbound alike**. An outbound one is how a 
 }
 ```
 
-`message` is identical to a `messages[]` entry on [`GET /api/v0/chats/{client_address}/messages`](REFERENCE.md#get-apiv0chatsclient_addressmessages), and `name` uses the same `"IP: <ip> Port: <port>"` fallback the REST list does.
+`message` is identical to a `messages[]` entry on [`GET /api/v0/chats/{address}/messages`](REFERENCE.md#get-apiv0chatsaddressmessages), and `name` uses the same `"IP: <ip> Port: <port>"` fallback the REST list does.
 
-There is no separate "conversation started" event: a conversation that did not exist yet is implied by the first message carrying its `client_address`.
+There is no separate "conversation started" event: a conversation that did not exist yet is implied by the first message carrying its `address`.
 
 #### `chat_session_closed`
 
 ```json
-{ "client_address": "203.0.113.42:4662" }
+{ "address": "203.0.113.42:4662" }
 ```
 
-Closing is global — see [`DELETE /api/v0/chats/{client_address}`](REFERENCE.md#delete-apiv0chatsclient_address). This fires whichever client closed it, including the desktop GUI, so a viewer should drop the conversation rather than assume it still exists.
+Closing is global — see [`DELETE /api/v0/chats/{address}`](REFERENCE.md#delete-apiv0chatsaddress). This fires whichever client closed it, including the desktop GUI, so a viewer should drop the conversation rather than assume it still exists.
 
 ### `clients` channel
 

--- a/docs/api/REFERENCE.md
+++ b/docs/api/REFERENCE.md
@@ -77,9 +77,9 @@ The API is versioned in the path. **`/api/v0/` is the pre-release surface and is
 - [`POST /api/v0/friends/{ecid}/shared_files`](#post-apiv0friendsecidshared_files) — browse a friend's shared files
 - [`POST /api/v0/friends/{ecid}/messages`](#post-apiv0friendsecidmessages) — message a friend, online or offline
 - [`GET /api/v0/chats`](#get-apiv0chats) — list chat conversations
-- [`GET /api/v0/chats/{client_address}/messages`](#get-apiv0chatsclient_addressmessages) — read a conversation's history
-- [`POST /api/v0/chats/{client_address}/messages`](#post-apiv0chatsclient_addressmessages) — send a message to a client address
-- [`DELETE /api/v0/chats/{client_address}`](#delete-apiv0chatsclient_address) — close a conversation
+- [`GET /api/v0/chats/{address}/messages`](#get-apiv0chatsaddressmessages) — read a conversation's history
+- [`POST /api/v0/chats/{address}/messages`](#post-apiv0chatsaddressmessages) — send a message to a client address
+- [`DELETE /api/v0/chats/{address}`](#delete-apiv0chatsaddress) — close a conversation
 - [`POST /api/v0/clients/{ecid}/messages`](#post-apiv0clientsecidmessages) — message a connected client
 
 **Categories**
@@ -362,7 +362,7 @@ The rule now reaches the whole surface rather than just the download and shared 
 
 `media` is the one place this reaches an **object** rather than a scalar, so a client tests `media === null` before reaching into it -- which it had to do regardless, since the object's own fields can be absent.
 
-Five keys stay omitted, because for them absence really is the meaning: `started_at` and `result_count` on [`GET /search`](#get-apiv0search) as described above, `key` on a statistics node (absent from a daemon too old to send it), `ratio` on the statistics ratio node (absent when the daemon reported neither component), and `parts` under [`?include_parts=true`](#get-apiv0downloadshashclients--get-apiv0sharedhashclients) -- there the caller opted in, so the key's absence answers a question they did not ask.
+Five keys stay omitted, because for them absence really is the meaning: `started_at` and `result_count` on [`GET /search`](#get-apiv0search) as described above, `key` on a statistics node (absent from a daemon too old to send it), `ratio_session` / `ratio_total` on the statistics ratio node (each absent when the daemon could not compute it), and `parts` under [`?include_parts=true`](#get-apiv0downloadshashclients--get-apiv0sharedhashclients) -- there the caller opted in, so the key's absence answers a question they did not ask.
 
 Opting out is not one of them. `parts`, `next_requested_part_index` and `downloading_part_index` are all absent from a client row unless `?include_parts=true` was asked for, but that absence is a property of the request, not a fact about the client, so it is not what the null-versus-absent rule above is about. Under the flag the two index keys are *always* present — `null`, never absent, wherever the index does not apply — which is why only `parts` is in the list above.
 
@@ -472,7 +472,7 @@ Every path segment, query parameter and JSON key on this surface follows the rul
 | **R9** | **A writable field accepts the values the same field returns.** Where a write is really a command it belongs in a differently-named key (`action`), not in the read field's name. |
 | **R10** | **Always emit the key.** An unknown value is `null`, never an omitted key and never a `0`/`-1` sentinel. The few deliberate exceptions are enumerated under [Response model](#response-model). |
 | **R11** | **Group by quantity, not by scope.** A sub-object earns its place when it groups *different* quantities (`sources`, `progress`, `media`). One quantity split by time window does not — the window belongs in the key, not in a wrapper. |
-| **R12** | **One word for the remote party: `client`.** `client_address` is not used in a key, a path or an enum value. `source` is not a synonym: a source is a client *in a role with respect to one file*, so it survives only where that relation is what is being described (`sources.total`, `source_origin`). |
+| **R12** | **One word for the remote party: `client`.** `address` is not used in a key, a path or an enum value. `source` is not a synonym: a source is a client *in a role with respect to one file*, so it survives only where that relation is what is being described (`sources.total`, `source_origin`). |
 
 ### Why rates are spelled out
 
@@ -848,7 +848,7 @@ curl -s -H "Authorization: Bearer $TOKEN" "http://$HOST/api/v0/downloads"
       "progress": { "percent": 29.85 },
       "kad_comment_lookup_running": false,
       "hashed_part_count": 0,
-      "parts_total_count": 394,
+      "total_part_count": 394,
       "source_ecids": [ 1234, 5678 ]
     }
   ]
@@ -865,7 +865,7 @@ The list shape omits `progress.parts` to keep large libraries compact. Use the d
 
 `kad_comment_lookup_running` is `true` while an on-demand Kad notes lookup is in flight for the file (started by [`POST /downloads/{hash}/comments`](#post-apiv0downloadshashcomments)); it flips back to `false` when the lookup finishes. Because it lives on the download object, a client can watch the `download_updated` SSE event for the start → finish transition instead of polling.
 
-`hashed_part_count` is the number of parts hashed so far by a pass running over the file — a `hashing` status, an [`AICH`](#post-apiv0sharedhashverify) hashset rebuild — and `0` when nothing is hashing. It is a count of completed parts, not the index of the part in flight, so it runs `0` → `parts_total_count`; divide by `parts_total_count` (from the detail endpoint, or `ceil(size / 9728000)`) for a percentage.
+`hashed_part_count` is the number of parts hashed so far by a pass running over the file — a `hashing` status, an [`AICH`](#post-apiv0sharedhashverify) hashset rebuild — and `0` when nothing is hashing. It is a count of completed parts, not the index of the part in flight, so it runs `0` → `total_part_count`; divide by `total_part_count` (from the detail endpoint, or `ceil(size / 9728000)`) for a percentage.
 
 `source_ecids` are the ECIDs of the clients holding this file as an A4AF source — the same array, under the same name, that [`POST /downloads/{hash}/a4af`](#post-apiv0downloadshasha4af) returns, and `[]` when there are none. It is the one thing a per-file client list needs that [`GET /api/v0/clients`](#get-apiv0clients) and the `clients` SSE channel cannot say: A4AF is a relation between a client and a *file*, so it does not live on the client object. With it on the download event, a Clients panel driven by the `downloads` and `clients` channels can shade its A4AF rows from the stream instead of polling [`GET /downloads/{hash}/clients`](#get-apiv0downloadshashclients--get-apiv0sharedhashclients). Note the name is scoped to A4AF, not to sources at large — the count of *all* sources is `sources.total`.
 
@@ -892,8 +892,8 @@ Same envelope as the list item, plus the detail-only fields below (all omitted f
 | `last_seen_complete_at` | int \| null | Unix ts a complete copy was last seen across sources; `null` when no complete copy has ever been seen, or the daemon does not report it. |
 | `last_received_at` | int | Unix ts the partfile last received data. |
 | `active_seconds` | int | Seconds spent actively downloading. |
-| `parts_available_count` | int | Number of parts available across the current sources. |
-| `parts_total_count` | int | Total parts, `ceil(size / 9.28 MiB)`. |
+| `available_part_count` | int | Number of parts available across the current sources. |
+| `total_part_count` | int | Total parts, `ceil(size / 9.28 MiB)`. |
 | `remaining_seconds` | int \| null | ETA in seconds, or `null` when stalled or paused (speed ≈ 0) and there is nothing to compute from. |
 | `lost_to_corruption_bytes` | int | Bytes discarded to corruption. |
 | `gained_by_compression_bytes` | int | Bytes saved by on-the-wire compression. |
@@ -1025,9 +1025,9 @@ Each entry is the [`/clients`](#get-apiv0clients) list object plus five keys:
 
 `role` and `a4af` are orthogonal: a pure A4AF row is `role: "none"`, `a4af: true`, but a client can be parked on another file *and* be pulling this one from us (`role: "uploading_to"`, `a4af: true`).
 
-`parts` is opt-in because it is one boolean per chunk per client — a multi-TiB file is 100k+ entries each. It is exactly `parts_total_count` entries, and it describes the file this row is about: the download bitmap for a `"downloading_from"` row, the upload bitmap for an `"uploading_to"` one. A client the core reports as holding every part comes back all-`true`. A pure A4AF row has no bitmap for this file and omits the key. **`parts` never appears in SSE payloads.**
+`parts` is opt-in because it is one boolean per chunk per client — a multi-TiB file is 100k+ entries each. It is exactly `total_part_count` entries, and it describes the file this row is about: the download bitmap for a `"downloading_from"` row, the upload bitmap for an `"uploading_to"` one. A client the core reports as holding every part comes back all-`true`. A pure A4AF row has no bitmap for this file and omits the key. **`parts` never appears in SSE payloads.**
 
-`next_requested_part_index` and `downloading_part_index` are the two extra states the desktop paints on top of that bitmap — the chunk in flight in amber, the one queued behind it in pale yellow — turning a three-state bar into the desktop's five-state one. Both are `0`-based indices into `parts`, and both ride `include_parts` for the same reason: an index is meaningless without the bitmap it indexes, and a caller that did not ask for `parts` does not know the file's `parts_total_count`. Under the flag both keys are always present, `null` rather than omitted whenever the index does not apply, so one query returns one row shape. `null` covers every such case: the client never reported the value, it reported the `0xffff` "nothing pending" sentinel, the index does not address a chunk of this file, the row is not a source for this file at all (`role: "uploading_to"` or a pure A4AF row, whose indices belong to whatever else that client is downloading), or the row carries no `parts` bitmap for the index to point into. `downloading_part_index` carries one further rule: it is `null` unless the client's `download_state` is `"downloading"`, because the daemon reports a stale `0` for a source that is merely connected or queued — treat a number here as "this chunk is arriving right now", which is what makes it safe to paint, and which is why it is named for the present tense rather than for a previous part. Note that `0` is a real chunk index, never a stand-in for unknown — see [`Unknown values`](#unknown-values). Neither key ever appears in SSE payloads.
+`next_requested_part_index` and `downloading_part_index` are the two extra states the desktop paints on top of that bitmap — the chunk in flight in amber, the one queued behind it in pale yellow — turning a three-state bar into the desktop's five-state one. Both are `0`-based indices into `parts`, and both ride `include_parts` for the same reason: an index is meaningless without the bitmap it indexes, and a caller that did not ask for `parts` does not know the file's `total_part_count`. Under the flag both keys are always present, `null` rather than omitted whenever the index does not apply, so one query returns one row shape. `null` covers every such case: the client never reported the value, it reported the `0xffff` "nothing pending" sentinel, the index does not address a chunk of this file, the row is not a source for this file at all (`role: "uploading_to"` or a pure A4AF row, whose indices belong to whatever else that client is downloading), or the row carries no `parts` bitmap for the index to point into. `downloading_part_index` carries one further rule: it is `null` unless the client's `download_state` is `"downloading"`, because the daemon reports a stale `0` for a source that is merely connected or queued — treat a number here as "this chunk is arriving right now", which is what makes it safe to paint, and which is why it is named for the present tense rather than for a previous part. Note that `0` is a real chunk index, never a stand-in for unknown — see [`Unknown values`](#unknown-values). Neither key ever appears in SSE payloads.
 
 The file's own three-state part view (`complete` / `pending` / `unavailable`) is on [`GET /downloads/{hash}`](#get-apiv0downloadshash); combine it with this bitmap and the two indices above to render the desktop's five-state per-source bar.
 
@@ -1541,7 +1541,7 @@ curl -s -H "Authorization: Bearer $TOKEN" "http://$HOST/api/v0/shared"
 
 `priority` is the upload priority — `"very_low"` / `"low"` / `"normal"` / `"high"` / `"release"` — and `priority_auto` is `true` when amuled is deriving that level automatically from the upload queue. This mirrors the `/downloads` shape (base `priority` + separate `priority_auto` flag); on an auto file `priority` reports the current derived level, not the literal string `"auto"`. For a file that is both downloading and shared this upload priority is independent of the download priority reported by [`GET /api/v0/downloads`](#get-apiv0downloads).
 
-`hashed_part_count` is the number of parts hashed so far by a pass running over the file — a [`POST /shared/{hash}/verify`](#post-apiv0sharedhashverify) run, or an AICH hashset rebuild — and `0` when nothing is hashing. It is a count of completed parts, not the index of the part in flight, so it runs `0` → `parts_total_count` (see the detail endpoint, or compute `ceil(size / 9728000)`).
+`hashed_part_count` is the number of parts hashed so far by a pass running over the file — a [`POST /shared/{hash}/verify`](#post-apiv0sharedhashverify) run, or an AICH hashset rebuild — and `0` when nothing is hashing. It is a count of completed parts, not the index of the part in flight, so it runs `0` → `total_part_count` (see the detail endpoint, or compute `ceil(size / 9728000)`).
 
 A file that is both downloading and shared reports its progress here as well: amuled describes such a file as a partfile, so the value is read across from the download side and the two agree. That makes `hashed_part_count` usable from either list without checking which one owns the file.
 
@@ -1570,14 +1570,14 @@ curl -s -H "Authorization: Bearer $TOKEN" \
 | `incomplete` | bool | `true` while the file is still an incomplete partfile, `false` once complete. Always present. A download that has finished but has not been cleared yet reports `false`, since its data already sits in the destination directory. |
 | `sources.complete_min` / `sources.complete_max` | int | The low and high ends of the estimated full-copy source range behind `sources.complete`. Two scalars, not a nested object. |
 | `aich_hash` | string\|null | AICH master hash (hex), or `null` until the hashset exists. |
-| `parts_total_count` | int | Total parts, `ceil(size / 9.28 MiB)`. |
-| `parts` | array | Per-part source availability, `[{ "sources": int }, ...]`, exactly `parts_total_count` entries in file order. **`null`** until the first decode has landed, so "no data yet" and "no sources for any part" stay distinguishable. The key is always present. See below. |
+| `total_part_count` | int | Total parts, `ceil(size / 9.28 MiB)`. |
+| `parts` | array | Per-part source availability, `[{ "sources": int }, ...]`, exactly `total_part_count` entries in file order. **`null`** until the first decode has landed, so "no data yet" and "no sources for any part" stay distinguishable. The key is always present. See below. |
 | `upload_queue_count` | int | Clients waiting on this file's upload queue. |
 | `my_comment` | string | The user's own comment on this file (`""` if none). |
 | `my_rating` | int | The user's own rating, `0`–`5` (`0` = unrated). |
 | `media` | object | Audio/video metadata — see [Media metadata](#media-metadata). **`null`** when the file has no probed metadata; the key is always present. |
 
-`hashed_part_count` comes through from the list item; pair it with `parts_total_count` here for a percentage.
+`hashed_part_count` comes through from the list item; pair it with `total_part_count` here for a percentage.
 
 `parts[].sources` is how many clients currently requesting this file hold that part — an **availability** measure, not a progress one. A shared file is fully local by definition, so a part with `"sources": 0` means no other client has it and you are its only source. Counts saturate at `255`.
 
@@ -2749,7 +2749,8 @@ The UL:DL ratio node (`key: "ul_dl_ratio"`) additionally carries a `ratio` objec
               "label": "Session UL:DL Ratio (Total): %s",
               "label_value": null,
               "values": [ { "type": "string", "value": "1 : 769.34 (1 : 1125.54)", "token": null, "extra": null } ],
-              "ratio": { "session": 769.34, "total": 1125.54 },
+              "ratio_session": 769.34,
+              "ratio_total": 1125.54,
               "children": []
             }
           ]
@@ -2804,8 +2805,8 @@ Time-series points behind the desktop Statistics graphs.
   "interval_seconds": 1,
   "max_points": 1800,
   "points": [
-    { "at": 1781430000, "value": 42, "active_downloads": 7, "active_uploads": 4 },
-    { "at": 1781430001, "value": 44, "active_downloads": 8, "active_uploads": 4 }
+    { "at": 1781430000, "value": 42, "active_download_count": 7, "active_upload_count": 4 },
+    { "at": 1781430001, "value": 44, "active_download_count": 8, "active_upload_count": 4 }
   ],
   "session": {
     "download_bytes": 12400000000,
@@ -2820,7 +2821,7 @@ Each point has `at` (unix seconds) and `value`, spaced by `interval_seconds`. `u
 
 `max_points` is how many points this daemon can answer with before it starts repeating records; `points` is never longer than it. It is not a constant across daemons, so a client that wants the deepest window available should read it rather than assume 1800.
 
-**`connections` only:** each point also carries `active_downloads` (clients being pulled from) and `active_uploads` (clients being pushed to), alongside `value`, which stays the total connection count. Against an amuled that does not report them the two keys are **omitted entirely** rather than sent as `0`, so "not reported" is distinguishable from "nothing was transferring". They are all-or-nothing: either every point in a response has them or none does.
+**`connections` only:** each point also carries `active_download_count` (clients being pulled from) and `active_upload_count` (clients being pushed to), alongside `value`, which stays the total connection count. Against an amuled that does not report them the two keys are **omitted entirely** rather than sent as `0`, so "not reported" is distinguishable from "nothing was transferring". They are all-or-nothing: either every point in a response has them or none does.
 
 **`session`** carries this-session figures so a client doesn't need a separate roundtrip:
 
@@ -3124,7 +3125,7 @@ Clients whose country could not be resolved — GeoIP disabled, unsupported by t
 
 Conversations with clients, backed by the chat session store in `amuled`. The store is shared: a message sent from the desktop GUI, from amulegui or through this API lands in the same transcript, and every client sees the same conversation.
 
-A conversation is keyed on `{client_address}` = `"<ip>:<port>"` (for example `203.0.113.42:4662`). That is the readable form of the internal id the EC wire already uses, it is stable across client reconnects — unlike an ECID — and it needs no identifier of its own. A `{client_address}` that is not four dotted octets plus a port is a `400`.
+A conversation is keyed on `{address}` = `"<ip>:<port>"` (for example `203.0.113.42:4662`). That is the readable form of the internal id the EC wire already uses, it is stable across client reconnects — unlike an ECID — and it needs no identifier of its own. A `{address}` that is not four dotted octets plus a port is a `400`.
 
 The store is **in memory**: an `amuled` restart empties every conversation, exactly as the desktop's own transcript dies with its notebook tab. Retention is bounded at 200 messages per conversation and 50 conversations, evicting the least recently active first.
 
@@ -3144,7 +3145,7 @@ curl -s -H "Authorization: Bearer $TOKEN" "http://$HOST/api/v0/chats"
 {
   "chats": [
     {
-      "client_address":            "203.0.113.42:4662",
+      "address":            "203.0.113.42:4662",
       "ip":              "203.0.113.42",
       "port":            4662,
       "name":            "alice",
@@ -3169,7 +3170,7 @@ Served from the refresher snapshot — no EC roundtrip per request. Standard [li
 
 **Errors:** `503 ec_unsupported`, `503 ec_unavailable`.
 
-#### `GET /api/v0/chats/{client_address}/messages`
+#### `GET /api/v0/chats/{address}/messages`
 
 **Auth:** `GUEST`
 
@@ -3177,7 +3178,7 @@ Served from the refresher snapshot — no EC roundtrip per request. Standard [li
 
 ```json
 {
-  "client_address": "203.0.113.42:4662",
+  "address": "203.0.113.42:4662",
   "messages": [
     { "id": 90, "direction": "out", "text": "hi",      "sent_at": 1786652700 },
     { "id": 91, "direction": "in",  "text": "thanks!", "sent_at": 1786652714 }
@@ -3189,9 +3190,9 @@ Served from the refresher snapshot — no EC roundtrip per request. Standard [li
 
 `direction` is `"in"` (from the client) or `"out"` (sent by us — from **any** client: this API, amulegui, or the desktop GUI). `sent_at` is stamped by the core when the message was received or sent, and is `null` only in the reply to a send: `EC_OP_CHAT_SEND` answers with the message id and no timestamp, and the core is the only thing entitled to stamp one. That reply is otherwise the same object shape this endpoint returns, emitted by the same writer, so a client can append it optimistically and reconcile on the next read. `total` counts everything the store holds for this conversation, not the returned window.
 
-**Errors:** `404 not_found` (no such conversation), `400 bad_request` (malformed `{client_address}` or query), `503 ec_unsupported`, `503 ec_unavailable`.
+**Errors:** `404 not_found` (no such conversation), `400 bad_request` (malformed `{address}` or query), `503 ec_unsupported`, `503 ec_unavailable`.
 
-#### `POST /api/v0/chats/{client_address}/messages`
+#### `POST /api/v0/chats/{address}/messages`
 
 **Auth:** `ADMIN`
 
@@ -3203,13 +3204,13 @@ curl -s -X POST -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/
 ```
 
 ```json
-{ "client_address": "203.0.113.42:4662",
+{ "address": "203.0.113.42:4662",
   "message": { "id": 92, "direction": "out", "text": "hello", "sent_at": null } }
 ```
 
-The created message stays in the body because the store-assigned `id` is only readable here. It is the same object shape [`GET /chats/{client_address}/messages`](#get-apiv0chatsclient_addressmessages) returns, emitted by the same writer, with one difference: `sent_at` is **`null`**, because `EC_OP_CHAT_SEND` answers with the message id and no timestamp. Read the timestamp back from [`GET /chats`](#get-apiv0chats) (as `last_message`), from the per-conversation messages endpoint, or from the `chat_message` SSE event.
+The created message stays in the body because the store-assigned `id` is only readable here. It is the same object shape [`GET /chats/{address}/messages`](#get-apiv0chatsaddressmessages) returns, emitted by the same writer, with one difference: `sent_at` is **`null`**, because `EC_OP_CHAT_SEND` answers with the message id and no timestamp. Read the timestamp back from [`GET /chats`](#get-apiv0chats) (as `last_message`), from the per-conversation messages endpoint, or from the `chat_message` SSE event.
 
-The core creates the conversation if it does not exist, so this doubles as "start a chat with this address" — an unknown `{client_address}` is not a `404` here.
+The core creates the conversation if it does not exist, so this doubles as "start a chat with this address" — an unknown `{address}` is not a `404` here.
 
 Returns `202 Accepted`, not `200`: the core acknowledges that it queued the message on the client connection, not that the client received it. An unreachable client is not an error — the desktop behaves the same, optimistically showing `*** Connecting to Client ***`.
 
@@ -3223,7 +3224,7 @@ Message a friend by friend ECID. This is the form that reaches an **offline** fr
 
 **Body:** `{ "text": "hello" }`
 
-**Response:** `202 Accepted` → `{ "client_address": "203.0.113.42:4662", "message": { … } }`, so the caller learns the conversation key to read back.
+**Response:** `202 Accepted` → `{ "address": "203.0.113.42:4662", "message": { … } }`, so the caller learns the conversation key to read back.
 
 **Errors:** `404 not_found` (no friend with that ECID), plus the set above.
 
@@ -3235,7 +3236,7 @@ The client-addressed form, for a caller holding a client row that should not hav
 
 **Errors:** `404 not_found` (no live client with that ECID), plus the set above.
 
-#### `DELETE /api/v0/chats/{client_address}`
+#### `DELETE /api/v0/chats/{address}`
 
 **Auth:** `ADMIN`
 

--- a/src/webapi/Api.cpp
+++ b/src/webapi/Api.cpp
@@ -1247,25 +1247,25 @@ CHttpServer::Response CApiDispatcher::DispatchToHandler(const CHttpServer::Reque
 	// the longer pattern would otherwise be shadowed.
 	{
 		static const auto chat_messages =
-			web_api_path::ParsePattern("/api/v0/chats/{client_address}/messages");
-		static const auto chat_one = web_api_path::ParsePattern("/api/v0/chats/{client_address}");
+			web_api_path::ParsePattern("/api/v0/chats/{address}/messages");
+		static const auto chat_one = web_api_path::ParsePattern("/api/v0/chats/{address}");
 		const auto path_segs = web_api_path::SplitPath(path);
 		std::map<std::string, std::string> caps;
 		if (web_api_path::Match(chat_messages, path_segs, caps)) {
 			if (req.method == "GET" || req.method == "HEAD") {
-				return HandleChatMessages(req, caps["client_address"]);
+				return HandleChatMessages(req, caps["address"]);
 			}
 			if (req.method == "POST") {
-				return HandleChatSend(req, caps["client_address"]);
+				return HandleChatSend(req, caps["address"]);
 			}
-			return MethodNotAllowed("GET, HEAD, POST",
-				"only GET / HEAD / POST on /chats/{client_address}/messages");
+			return MethodNotAllowed(
+				"GET, HEAD, POST", "only GET / HEAD / POST on /chats/{address}/messages");
 		}
 		if (web_api_path::Match(chat_one, path_segs, caps)) {
 			if (req.method == "DELETE") {
-				return HandleChatClose(req, caps["client_address"]);
+				return HandleChatClose(req, caps["address"]);
 			}
-			return MethodNotAllowed("DELETE", "only DELETE on /chats/{client_address}");
+			return MethodNotAllowed("DELETE", "only DELETE on /chats/{address}");
 		}
 	}
 
@@ -2950,9 +2950,9 @@ void WriteDownloadObject(
 	// no total beside it cannot be rendered: fed straight to a progress bar
 	// it shows 3% for three parts of a hundred and 300% for three hundred of
 	// a thousand. Computed, not decoded -- there is no EC tag for it.
-	const std::int64_t parts_total_count = static_cast<std::int64_t>(webapi::PartCountForSize(f.size));
-	w.Key("parts_total_count");
-	w.ValueInt(parts_total_count);
+	const std::int64_t total_part_count = static_cast<std::int64_t>(webapi::PartCountForSize(f.size));
+	w.Key("total_part_count");
+	w.ValueInt(total_part_count);
 	// On the list, not detail-only, so the SSE download event carries it:
 	// A4AF is a client-to-file relation, the one thing a per-file client
 	// list needs that the `clients` channel cannot say. Same spelling as on
@@ -2993,8 +2993,8 @@ void WriteDownloadObject(
 		w.ValueInt(static_cast<int64_t>(f.download.last_received_at));
 		w.Key("active_seconds");
 		w.ValueInt(static_cast<int64_t>(f.download.active_seconds));
-		w.Key("parts_available_count");
-		w.ValueInt(static_cast<int64_t>(f.download.parts_available_count));
+		w.Key("available_part_count");
+		w.ValueInt(static_cast<int64_t>(f.download.available_part_count));
 		WriteIntOrNull(w, "remaining_seconds", has_remaining_seconds, remaining_seconds);
 		w.Key("lost_to_corruption_bytes");
 		w.ValueInt(static_cast<int64_t>(f.download.lost_to_corruption_bytes));
@@ -3386,7 +3386,7 @@ void WriteSharedDetailObject(CJsonWriter &w, const webapi::FileSnapshot &f)
 	// deliberately carry neither, so the SSE event rate is unaffected.
 	w.ValueBool(f.IsIncompletePartfile());
 	WriteStringOrNull(w, "aich_hash", !f.aich_hash.empty(), f.aich_hash);
-	w.Key("parts_total_count");
+	w.Key("total_part_count");
 	w.ValueInt(static_cast<int64_t>(webapi::PartCountForSize(f.size)));
 	WriteSharedAvailabilityParts(w, f);
 	w.Key("upload_queue_count");
@@ -6203,7 +6203,7 @@ void WriteChatMessageObject(CJsonWriter &w, const webapi::ChatMessageSnapshot &m
 void WriteChatObject(CJsonWriter &w, const webapi::ChatSessionSnapshot &s)
 {
 	w.BeginObject();
-	w.Key("client_address");
+	w.Key("address");
 	w.ValueString(wxString::FromUTF8(s.PeerKey().c_str()));
 	w.Key("ip");
 	w.ValueString(wxString::FromUTF8(s.ip.c_str()));
@@ -6426,7 +6426,7 @@ CHttpServer::Response CApiDispatcher::HandleChatMessages(
 
 	std::uint64_t gui_id = 0;
 	if (!ParseChatPeerKey(peer, gui_id)) {
-		return ErrorResponse(400, "bad_request", "path `{client_address}` must be `<ip>:<port>`");
+		return ErrorResponse(400, "bad_request", "path `{address}` must be `<ip>:<port>`");
 	}
 
 	const std::vector<webapi::ChatSessionSnapshot> chats = m_state.Chats();
@@ -6473,7 +6473,7 @@ CHttpServer::Response CApiDispatcher::HandleChatMessages(
 
 	CJsonWriter w;
 	w.BeginObject();
-	w.Key("client_address");
+	w.Key("address");
 	w.ValueString(wxString::FromUTF8(session->PeerKey().c_str()));
 	w.Key("messages");
 	w.BeginArray();
@@ -6551,7 +6551,7 @@ CHttpServer::Response CApiDispatcher::SendChatMessageTo(const CHttpServer::Reque
 	// read back. `sent_at` is null here and only here: EC_OP_CHAT_SEND
 	// answers with the client and message ids and no timestamp, and the core
 	// is the only thing entitled to stamp one.
-	w.Key("client_address");
+	w.Key("address");
 	w.ValueString(wxString::FromUTF8(webapi::ChatPeerKeyFromGuiId(gui_id).c_str()));
 	w.Key("message");
 	webapi::ChatMessageSnapshot sent;
@@ -6580,7 +6580,7 @@ CHttpServer::Response CApiDispatcher::HandleChatSend(const CHttpServer::Request 
 	}
 	std::uint64_t gui_id = 0;
 	if (!ParseChatPeerKey(peer, gui_id)) {
-		return ErrorResponse(400, "bad_request", "path `{client_address}` must be `<ip>:<port>`");
+		return ErrorResponse(400, "bad_request", "path `{address}` must be `<ip>:<port>`");
 	}
 	// No 404 for an unknown peer here: the core creates the session if it does
 	// not exist, so this doubles as "start a chat with this address".
@@ -6637,7 +6637,7 @@ CHttpServer::Response CApiDispatcher::HandleChatClose(
 	}
 	std::uint64_t gui_id = 0;
 	if (!ParseChatPeerKey(peer, gui_id)) {
-		return ErrorResponse(400, "bad_request", "path `{client_address}` must be `<ip>:<port>`");
+		return ErrorResponse(400, "bad_request", "path `{address}` must be `<ip>:<port>`");
 	}
 
 	std::unique_ptr<CECPacket> ec_req(new CECPacket(EC_OP_CHAT_CLOSE_SESSION));
@@ -7600,20 +7600,18 @@ void WriteStatsNode(CJsonWriter &w, const webapi::StatsTreeNode &n)
 		WriteStatsValue(w, v);
 	w.EndArray();
 	// Raw numeric UL:DL ratio (download-per-upload), for the ratio node only.
-	// Emitted when the daemon provided at least one component; each field is
-	// present only when computable, so a legacy daemon yields no "ratio" key.
+	// Flat rather than wrapped by window: R11 puts the window in the key, the
+	// way uploaded_bytes_session / _total do everywhere else. Each is emitted
+	// only when computable, so a legacy daemon yields neither key.
 	if (n.has_ratio_session || n.has_ratio_total) {
-		w.Key("ratio");
-		w.BeginObject();
 		if (n.has_ratio_session) {
-			w.Key("session");
+			w.Key("ratio_session");
 			w.ValueDouble(n.ratio_session);
 		}
 		if (n.has_ratio_total) {
-			w.Key("total");
+			w.Key("ratio_total");
 			w.ValueDouble(n.ratio_total);
 		}
-		w.EndObject();
 	}
 	w.Key("children");
 	w.BeginArray();
@@ -7939,9 +7937,9 @@ CHttpServer::Response CApiDispatcher::HandleStatsGraph(
 			g.interval_seconds,
 			width,
 			&g.active_downloads,
-			"active_downloads",
+			"active_download_count",
 			&g.active_uploads,
-			"active_uploads");
+			"active_upload_count");
 	} else {
 		WritePointArray(w, *series, ts, g.interval_seconds, width);
 	}

--- a/src/webapi/EventDiff.cpp
+++ b/src/webapi/EventDiff.cpp
@@ -127,7 +127,7 @@ std::string ToJsonDownloadEvent(const FileSnapshot &f)
 	  << ",\"progress\":{\"percent\":" << JsonDoubleToString(f.download.percent) << "}"
 	  << ",\"kad_comment_lookup_running\":" << (f.download.kad_comment_searching ? "true" : "false")
 	  << ",\"hashed_part_count\":" << f.download.hashed_part_count
-	  << ",\"parts_total_count\":" << webapi::PartCountForSize(f.size) << ",\"source_ecids\":[";
+	  << ",\"total_part_count\":" << webapi::PartCountForSize(f.size) << ",\"source_ecids\":[";
 	bool first_a4af = true;
 	for (const std::uint32_t ecid : f.download.a4af_sources) {
 		if (!first_a4af)
@@ -719,7 +719,7 @@ void EnforceSinglePublisher()
 } // namespace
 
 // One chat message as the `message` object both the SSE payload and
-// GET /chats/{client_address}/messages expose. Written here in the same string-building
+// GET /chats/{address}/messages expose. Written here in the same string-building
 // style as the other event payloads in this file; the REST side renders the
 // identical shape through CJsonWriter.
 std::string ChatMessageJson(const ChatMessageSnapshot &msg)
@@ -739,7 +739,7 @@ void PublishChatEvents(CEventBus &bus,
 	for (const ChatSessionSnapshot &session : new_messages) {
 		const std::string peer = session.PeerKey();
 		for (const ChatMessageSnapshot &msg : session.messages) {
-			std::string payload = "{\"client_address\":\"" + EscJson(peer) + "\",\"ip\":\"" +
+			std::string payload = "{\"address\":\"" + EscJson(peer) + "\",\"ip\":\"" +
 					      EscJson(session.ip) +
 					      "\",\"port\":" + std::to_string(session.port) + ",\"name\":\"" +
 					      EscJson(session.DisplayName()) +
@@ -757,7 +757,7 @@ void PublishChatEvents(CEventBus &bus,
 	}
 	for (std::uint64_t gui_id : closed) {
 		const std::string peer = ChatPeerKeyFromGuiId(gui_id);
-		batch.emplace_back("chat_session_closed", "{\"client_address\":\"" + EscJson(peer) + "\"}");
+		batch.emplace_back("chat_session_closed", "{\"address\":\"" + EscJson(peer) + "\"}");
 	}
 	bus.PublishBatch(batch);
 }

--- a/src/webapi/Refresher.cpp
+++ b/src/webapi/Refresher.cpp
@@ -598,7 +598,7 @@ void MergePartFileTag(const CEC_PartFile_Tag *pf, FileSnapshot &f, bool is_new)
 	{
 		std::uint16_t v = 0;
 		if (pf->AssignIfExist(EC_TAG_PARTFILE_AVAILABLE_PARTS, v))
-			f.download.parts_available_count = v;
+			f.download.available_part_count = v;
 		if (pf->AssignIfExist(EC_TAG_PARTFILE_HASHED_PART_COUNT, v))
 			f.download.hashed_part_count = v;
 	}

--- a/src/webapi/State.h
+++ b/src/webapi/State.h
@@ -169,7 +169,7 @@ struct FileSnapshot
 		std::uint32_t last_seen_complete_at = 0;       // unix ts; 0 = unknown
 		std::uint32_t last_received_at = 0;            // unix ts of last change
 		std::uint32_t active_seconds = 0;              // seconds downloading
-		std::uint16_t parts_available_count = 0;       // parts across sources
+		std::uint16_t available_part_count = 0;        // parts across sources
 		std::uint16_t hashed_part_count = 0;           // parts hashed so far; 0 = idle
 		std::uint64_t lost_to_corruption_bytes = 0;    // bytes
 		std::uint64_t gained_by_compression_bytes = 0; // bytes

--- a/src/webapi/static/js/chats.js
+++ b/src/webapi/static/js/chats.js
@@ -155,7 +155,7 @@ async function adopt() {
   catch (e) { noteError(e); return; }
   let added = false;
   for (const s of list) {
-    const cur = convs.get(s.client_address);
+    const cur = convs.get(s.address);
     if (cur) {
       cur.known = true;
       const name = betterName(cur, s.name);
@@ -164,25 +164,25 @@ async function adopt() {
       const cEcid = s.client_ecid || 0, fEcid = s.friend_ecid || 0;
       if (cEcid !== cur.clientEcid) { cur.clientEcid = cEcid; added = true; }
       if (fEcid !== cur.friendEcid) { cur.friendEcid = fEcid; added = true; }
-      if (cur.loaded && s.last_message_id > cur.lastMsgId) loadMessages(s.client_address);
+      if (cur.loaded && s.last_message_id > cur.lastMsgId) loadMessages(s.address);
       continue;
     }
     const conv = newConv({
-      peer: s.client_address, ip: s.ip, port: s.port, name: s.name,
+      peer: s.address, ip: s.ip, port: s.port, name: s.name,
       clientEcid: s.client_ecid || 0, friendEcid: s.friend_ecid || 0,
     });
     conv.known = true;
-    convs.set(s.client_address, conv);
+    convs.set(s.address, conv);
     added = true;
   }
   // Absent = closed elsewhere or evicted by the daemon's cap. Skip local-only
   // ones, not listed yet by definition.
   for (const peer of Array.from(convs.keys())) {
     const conv = convs.get(peer);
-    if (conv && conv.known && !list.some((s) => s.client_address === peer)) { drop(peer, false); added = true; }
+    if (conv && conv.known && !list.some((s) => s.address === peer)) { drop(peer, false); added = true; }
   }
   // The daemon lists most-recently-active first.
-  if (!activePeer && list.length) { setActive(list[0].client_address); return; }
+  if (!activePeer && list.length) { setActive(list[0].address); return; }
   if (added) publishTabs();
 }
 
@@ -236,15 +236,15 @@ function drop(peer, notify) {
 function onMessage(p) {
   if (!p || p === lastMessage) return;
   lastMessage = p;
-  if (!p.client_address || !p.message) return;
-  let conv = convs.get(p.client_address);
+  if (!p.address || !p.message) return;
+  let conv = convs.get(p.address);
   if (!conv) {
     // No "conversation started" event; the first message implies a new one.
     conv = newConv({
-      peer: p.client_address, ip: p.ip, port: p.port, name: p.name,
+      peer: p.address, ip: p.ip, port: p.port, name: p.name,
       clientEcid: p.client_ecid || 0, friendEcid: p.friend_ecid || 0,
     });
-    convs.set(p.client_address, conv);
+    convs.set(p.address, conv);
   } else {
     conv.name = betterName(conv, p.name);
     conv.clientEcid = p.client_ecid || 0;
@@ -254,20 +254,20 @@ function onMessage(p) {
   const seen = conv.messages.has(p.message.id);
   addMessage(conv, p.message);
   // Not unread: our own outbound line, or an id already held (a send's echo).
-  if (!seen && p.message.direction === "in" && (!pageVisible() || p.client_address !== activePeer)) {
+  if (!seen && p.message.direction === "in" && (!pageVisible() || p.address !== activePeer)) {
     conv.unread++;
   }
   // The strip must always have one selected; off-page, don't clear its unread.
-  if (!activePeer) { setActive(p.client_address, pageVisible()); return; }
+  if (!activePeer) { setActive(p.address, pageVisible()); return; }
   publishTabsSoon();
-  publishLogSoon(p.client_address);
+  publishLogSoon(p.address);
 }
 
 function onClosed(p) {
   if (!p || p === lastClosed) return;
   lastClosed = p;
   // Closing is global — any client can do it.
-  if (p.client_address) drop(p.client_address, p.client_address === activePeer);
+  if (p.address) drop(p.address, p.address === activePeer);
 }
 
 function onResync(v) {

--- a/src/webapi/static/js/components.js
+++ b/src/webapi/static/js/components.js
@@ -423,7 +423,7 @@ function availShade(sources, lo, hi) {
 // while a re-hash runs over the file (Verify Local Data, or an AICH hashset
 // rebuild), mirroring the desktop's two-span bar. That pass reports only a
 // *count* of parts done, never a per-part map, so it is driven by
-// `total` (= parts_total_count) + `hashed` instead of `parts`.
+// `total` (= total_part_count) + `hashed` instead of `parts`.
 // Canvas rather than N <div>s so files with hundreds/thousands of parts redraw
 // cheaply on every live tick. Colours are read from the theme each draw.
 export function PiecesBar({ parts, mode = "download", total = 0, hashed = 0 }) {

--- a/src/webapi/static/js/views/download-detail.js
+++ b/src/webapi/static/js/views/download-detail.js
@@ -104,9 +104,9 @@ export function DownloadDetail({ hash, isGuest, categories = [], onPatch, onDele
       <div class="detail-sections">
         <div class="detail-progress">
           <${ProgressBar} percent=${d.progress && d.progress.percent} />
-          ${d.hashed_part_count > 0 && d.parts_total_count ? html`
-            <${PiecesBar} mode="hashing" total=${d.parts_total_count} hashed=${d.hashed_part_count} />
-            <${PiecesLegend} mode="hashing" total=${d.parts_total_count} hashed=${d.hashed_part_count} />`
+          ${d.hashed_part_count > 0 && d.total_part_count ? html`
+            <${PiecesBar} mode="hashing" total=${d.total_part_count} hashed=${d.hashed_part_count} />
+            <${PiecesLegend} mode="hashing" total=${d.total_part_count} hashed=${d.hashed_part_count} />`
           : parts.length ? html`
             <${PiecesBar} parts=${parts} />
             <${PiecesLegend} parts=${parts} />` : null}
@@ -135,7 +135,7 @@ export function DownloadDetail({ hash, isGuest, categories = [], onPatch, onDele
           media.codec ? statRow("downloads_detail_media_codec", media.codec, "downloads_detail_tip_media_codec") : null,
         ].filter(Boolean), "downloads_detail_group_media") : null}
         ${Section([
-          statRow("downloads_detail_available_parts", formatInt(d.parts_available_count) + " / " + formatInt(d.parts_total_count), "downloads_detail_tip_available_parts"),
+          statRow("downloads_detail_available_parts", formatInt(d.available_part_count) + " / " + formatInt(d.total_part_count), "downloads_detail_tip_available_parts"),
           statRow("downloads_detail_saved_ich", formatInt(d.ich_recovered_packet_count) + " " + t("downloads_detail_ich_unit"), "downloads_detail_tip_saved_ich"),
           statRow("downloads_detail_lost_corruption", formatBytes(d.lost_to_corruption_bytes), "downloads_detail_tip_lost_corruption"),
           statRow("downloads_detail_gained_compression", formatBytes(d.gained_by_compression_bytes), "downloads_detail_tip_gained_compression"),

--- a/src/webapi/static/js/views/shared-detail.js
+++ b/src/webapi/static/js/views/shared-detail.js
@@ -121,10 +121,10 @@ export function SharedDetail({ hash }) {
         </div>
       ` : html`
       <div class="detail-sections">
-        ${s.hashed_part_count > 0 && s.parts_total_count ? html`
+        ${s.hashed_part_count > 0 && s.total_part_count ? html`
         <div class="detail-progress">
-          <${PiecesBar} mode="hashing" total=${s.parts_total_count} hashed=${s.hashed_part_count} />
-          <${PiecesLegend} mode="hashing" total=${s.parts_total_count} hashed=${s.hashed_part_count} />
+          <${PiecesBar} mode="hashing" total=${s.total_part_count} hashed=${s.hashed_part_count} />
+          <${PiecesLegend} mode="hashing" total=${s.total_part_count} hashed=${s.hashed_part_count} />
         </div>` : s.parts && s.parts.length ? html`
         <div class="detail-progress">
           <${PiecesBar} mode="availability" parts=${s.parts} />
@@ -168,7 +168,7 @@ export function SharedDetail({ hash }) {
         ].filter(Boolean), "downloads_detail_group_media") : null}
         ${IdentityLine({ file: s, copy, titleKey: "downloads_detail_group_identity", extra: [
           statRow("shared_detail_directory", s.directory || "—", "shared_detail_tip_directory"),
-          statRow("shared_detail_parts", formatInt(s.parts_total_count), "shared_detail_tip_parts"),
+          statRow("shared_detail_parts", formatInt(s.total_part_count), "shared_detail_tip_parts"),
         ] })}
       </div>`}
       </div>

--- a/src/webapi/static/js/views/stats.js
+++ b/src/webapi/static/js/views/stats.js
@@ -68,7 +68,7 @@ export default function Stats() {
         // single line it used to be.
         const rest = g.name !== "connections" ? [sma(ys, SMA_WINDOW)]
           : pts.length && pts[0].active_downloads !== undefined
-            ? [pts.map((p) => p.active_downloads), pts.map((p) => p.active_uploads)]
+            ? [pts.map((p) => p.active_download_count), pts.map((p) => p.active_upload_count)]
             : [];
         if (alive) setGraphData((d) => ({ ...d, [g.name]: [pts.map((p) => p.at), ys, ...rest] }));
       } catch (_) { /* leave previous data */ }
@@ -187,8 +187,9 @@ function formatRatio(r) {
 function nodeText(node) {
   // Ratio node: build from node.ratio when present; else fall back to the
   // composite string value (legacy daemons emit no ratio object).
-  if (node.ratio && node.ratio.session != null) {
-    return tNodeLabel(node).replace("%s", formatRatio(node.ratio));
+  if (node.ratio_session != null) {
+    return tNodeLabel(node).replace("%s",
+      formatRatio({ session: node.ratio_session, total: node.ratio_total }));
   }
   const values = node.values || [];
   let i = 0;

--- a/unittests/curl-tests/amuleapi/04-read-downloads-shared.sh
+++ b/unittests/curl-tests/amuleapi/04-read-downloads-shared.sh
@@ -160,8 +160,8 @@ if [ "$COUNT" -gt 0 ]; then
 	_assert_json_eq '.progress.percent | type' number \
 		'/downloads/{hash} carries progress.percent'
 	# Part-A detail fields (issue #417) — detail-only, type-tolerant.
-	_assert_json_eq '.parts_total_count | type' number \
-		'/downloads/{hash} carries parts_total_count'
+	_assert_json_eq '.total_part_count | type' number \
+		'/downloads/{hash} carries total_part_count'
 	# null when stalled/paused: nothing to compute an ETA from. It was -1,
 	# which a client had to know meant "unknown".
 	_assert_json_eq '(.remaining_seconds == null or (.remaining_seconds | type) == "number")' true \
@@ -308,14 +308,14 @@ if [ "$COUNT" -gt 0 ]; then
 		_skip "row-shape checks: no peer is connected to the download"
 	fi
 
-	# Opt-in bitmaps are exactly parts_total_count long for a row that has one.
+	# Opt-in bitmaps are exactly total_part_count long for a row that has one.
 	PARTCOUNT=$(curl -s -H "Authorization: Bearer $TOKEN" "$HOST/api/v0/downloads/$HASH" | jq -r '.progress.parts | length')
 	_curl -H "Authorization: Bearer $TOKEN" "$HOST/api/v0/downloads/$HASH/clients?include_parts=true"
 	_assert_status 200 "GET /downloads/{hash}/clients?include_parts=true → 200"
 	DLBITMAPS=$(printf '%s' "$CURL_BODY" | jq '[.clients[] | select(has("parts"))] | length')
 	if [ "$DLBITMAPS" -gt 0 ]; then
 		_assert_json_eq "[.clients[] | select(has(\"parts\")) | select((.parts | length) != $PARTCOUNT)] | length" \
-			0 "every parts bitmap ($DLBITMAPS of them) is exactly parts_total_count entries"
+			0 "every parts bitmap ($DLBITMAPS of them) is exactly total_part_count entries"
 	else
 		_skip "parts-length check: no row carries a bitmap"
 	fi
@@ -542,15 +542,15 @@ if [ "$SHCOUNT" -gt 0 ]; then
 		'/shared/{hash} carries sources'
 	_assert_json_eq '.aich_hash | type' string \
 		'/shared/{hash} carries aich_hash'
-	_assert_json_eq '.parts_total_count | type' number \
-		'/shared/{hash} carries parts_total_count'
+	_assert_json_eq '.total_part_count | type' number \
+		'/shared/{hash} carries total_part_count'
 	_assert_json_eq '.hashed_part_count | type' number \
 		'/shared/{hash} carries hashed_part_count (#1054)'
 	_assert_json_eq '.my_comment | type' string \
 		'/shared/{hash} carries my_comment'
 	_assert_json_eq '.my_rating | type' number \
 		'/shared/{hash} carries my_rating'
-	SHPARTCOUNT=$(printf '%s' "$CURL_BODY" | jq -r '.parts_total_count')
+	SHPARTCOUNT=$(printf '%s' "$CURL_BODY" | jq -r '.total_part_count')
 
 	# --- 6c. GET /shared/{hash}/clients: the upload-side half of the
 	# per-file client rows (issue #984). Same handler and same row shape as
@@ -623,7 +623,7 @@ if [ "$SHCOUNT" -gt 0 ]; then
 	SHBITMAPS=$(printf '%s' "$CURL_BODY" | jq '[.clients[] | select(has("parts"))] | length')
 	if [ "$SHBITMAPS" -gt 0 ]; then
 		_assert_json_eq "[.clients[] | select(has(\"parts\")) | select((.parts | length) != $SHPARTCOUNT)] | length" \
-			0 "every shared-side parts bitmap ($SHBITMAPS of them) is exactly parts_total_count entries"
+			0 "every shared-side parts bitmap ($SHBITMAPS of them) is exactly total_part_count entries"
 	else
 		_skip "shared-side parts-length check: no row carries a bitmap"
 	fi

--- a/unittests/curl-tests/amuleapi/07-read-stats-and-search-results.sh
+++ b/unittests/curl-tests/amuleapi/07-read-stats-and-search-results.sh
@@ -123,9 +123,12 @@ _assert_json_eq '[.. | objects | select(.key? == "ul_dl_ratio") | .values[0].typ
 	string '/stats/tree ratio node still carries its composite string value'
 # ...and when the daemon can compute it, exposes numeric ratio fields. Absent
 # on a freshly-started daemon with no transfer, so assert shape, not presence.
-_assert_json_eq '[.. | objects | select(has("ratio")) | .ratio | (.session, .total)
+_assert_json_eq '[.. | objects | (.ratio_session, .ratio_total)
 	| select(. != null) | type] | all(. == "number")' \
 	true '/stats/tree ratio fields, when present, are numbers'
+# Flattened per R11: the window belongs in the key, so there is no wrapper left.
+_assert_json_eq '[.. | objects | select(has("ratio"))] | length' 0 \
+	'/stats/tree emits no wrapping ratio object'
 # label_value: the untranslated version/OS value on per-client-software rows.
 # `null` on every other node rather than absent, so the presence test is
 # `!= null` -- the key is always there. Assert shape, not presence: it is only
@@ -180,11 +183,11 @@ _assert_json_eq '.session | has("kad_bytes")' false \
 # The connections graph carries the second data blob's two series when the
 # daemon reports it; the other graphs never do.
 if [ "$(printf '%s' "$CURL_BODY" | jq '.points | length')" -gt 0 ]; then
-	_assert_json_eq '[.points[] | has("active_uploads")] | (all(.) or (any(.) | not))' true \
+	_assert_json_eq '[.points[] | has("active_upload_count")] | (all(.) or (any(.) | not))' true \
 		'/stats/graphs/connections active_uploads is present on all points or none'
 fi
 _curl -H "Authorization: Bearer $TOKEN" "$HOST/api/v0/stats/graphs/download_speed"
-_assert_json_eq '[.points[]? | has("active_uploads")] | any(.) | not' true \
+_assert_json_eq '[.points[]? | has("active_upload_count")] | any(.) | not' true \
 	'/stats/graphs/download_speed never carries the connections-only series'
 
 # --- 3b. ?interval=N and its validation. ---------------------------

--- a/unittests/curl-tests/amuleapi/37-shared-availability-parts.sh
+++ b/unittests/curl-tests/amuleapi/37-shared-availability-parts.sh
@@ -136,13 +136,13 @@ if [ "$COUNT" -gt 0 ]; then
 		_assert_json_eq '.parts | type' array '/shared/{hash}.parts is array'
 		PARTS_LEN=$(printf '%s' "$CURL_BODY" | jq '.parts | length')
 
-		# --- 3. parts.length == parts_total_count == ceil(size/PARTSIZE). --
-		PART_COUNT=$(printf '%s' "$CURL_BODY" | jq '.parts_total_count')
+		# --- 3. parts.length == total_part_count == ceil(size/PARTSIZE). --
+		PART_COUNT=$(printf '%s' "$CURL_BODY" | jq '.total_part_count')
 		if [ "$PARTS_LEN" = "$PART_COUNT" ]; then
-			_pass "/shared/{hash}.parts.length == parts_total_count ($PARTS_LEN)"
+			_pass "/shared/{hash}.parts.length == total_part_count ($PARTS_LEN)"
 		else
-			_fail "/shared/{hash}.parts.length vs parts_total_count" \
-				"parts_total_count=$PART_COUNT, parts.length=$PARTS_LEN"
+			_fail "/shared/{hash}.parts.length vs total_part_count" \
+				"total_part_count=$PART_COUNT, parts.length=$PARTS_LEN"
 		fi
 		if [ "$FIRST_SIZE" -gt 0 ]; then
 			EXPECTED_PARTS=$(( (FIRST_SIZE + 9728000 - 1) / 9728000 ))

--- a/unittests/curl-tests/amuleapi/38-chat.sh
+++ b/unittests/curl-tests/amuleapi/38-chat.sh
@@ -8,9 +8,9 @@
 #
 # Wire contract:
 #   GET    /chats                   → list envelope of conversations
-#   GET    /chats/{client_address}/messages   → { peer, messages[], total, last_message_id }
-#   POST   /chats/{client_address}/messages   → 202 + the created message
-#   DELETE /chats/{client_address}            → 204, no body
+#   GET    /chats/{address}/messages   → { peer, messages[], total, last_message_id }
+#   POST   /chats/{address}/messages   → 202 + the created message
+#   DELETE /chats/{address}            → 204, no body
 #   POST   /friends/{ecid}/messages → 202 (reaches an OFFLINE friend)
 #   POST   /clients/{ecid}/messages → 202
 #
@@ -126,12 +126,12 @@ _assert_json_eq '.chats | type' array '/chats .chats is array'
 # doubles as "start a chat with this address".
 _curl -X POST -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
 	-d '{"text":"curl-test hello"}' "$HOST/api/v0/chats/$PEER/messages"
-_assert_status 202 "POST /chats/{client_address}/messages → 202 Accepted"
+_assert_status 202 "POST /chats/{address}/messages → 202 Accepted"
 # The created message stays in the body: no per-message GET defines a shape
 # for it, so the id and the timestamp the store assigned are only readable
 # here. `ok` is gone; the 202 already carried it.
 _assert_json_eq '. | has("ok")' false 'send response has no constant ok field'
-_assert_json_eq '.client_address'                "$PEER" 'send echoes the conversation key'
+_assert_json_eq '.address'                "$PEER" 'send echoes the conversation key'
 _assert_json_eq '.message.direction'   out     'sent message is direction=out'
 _assert_json_eq '.message.text'        "curl-test hello" 'send echoes the text'
 # Same object shape the GET returns, from the same writer -- including the
@@ -147,14 +147,14 @@ sleep 3
 # --- 3. The conversation is now on the list. ----------------------
 _curl -H "Authorization: Bearer $TOKEN" "$HOST/api/v0/chats"
 _assert_status 200 "GET /chats → 200 after send"
-FOUND=$(printf '%s' "$CURL_BODY" | jq --arg p "$PEER" '[.chats[] | select(.client_address == $p)] | length')
+FOUND=$(printf '%s' "$CURL_BODY" | jq --arg p "$PEER" '[.chats[] | select(.address == $p)] | length')
 if [ "$FOUND" = "1" ]; then
 	_pass "/chats lists the new conversation"
 else
 	_fail "/chats conversation presence" "expected exactly 1 row for $PEER, got $FOUND"
 fi
 # Narrow the body to just this conversation's row for the field checks.
-ROW=$(printf '%s' "$CURL_BODY" | jq --arg p "$PEER" -c '.chats[] | select(.client_address == $p)')
+ROW=$(printf '%s' "$CURL_BODY" | jq --arg p "$PEER" -c '.chats[] | select(.address == $p)')
 printf '%s' "$ROW" > "$CURL_BODY_FILE"; CURL_BODY=$ROW
 _assert_json_eq '.ip'                 "$PEER_IP"   'row carries the split ip'
 _assert_json_eq '.port'               "$PEER_PORT" 'row carries the split port'
@@ -168,8 +168,8 @@ _assert_json_eq '.name' "IP: $PEER_IP Port: $PEER_PORT" 'name falls back to the 
 
 # --- 4. Reading the transcript. -----------------------------------
 _curl -H "Authorization: Bearer $TOKEN" "$HOST/api/v0/chats/$PEER/messages"
-_assert_status 200 "GET /chats/{client_address}/messages → 200"
-_assert_json_eq '.client_address'            "$PEER" 'messages echo the conversation key'
+_assert_status 200 "GET /chats/{address}/messages → 200"
+_assert_json_eq '.address'            "$PEER" 'messages echo the conversation key'
 _assert_json_eq '.messages | type' array   'messages is an array'
 _assert_json_eq '.messages[0].direction' out 'first message is direction=out'
 
@@ -248,7 +248,7 @@ _assert_status 404 "POST to an unknown friend ECID → 404"
 _curl -X PUT -H "Authorization: Bearer $TOKEN" "$HOST/api/v0/chats"
 _assert_status 405 "PUT /chats → 405"
 _curl -X PATCH -H "Authorization: Bearer $TOKEN" "$HOST/api/v0/chats/$PEER"
-_assert_status 405 "PATCH /chats/{client_address} → 405"
+_assert_status 405 "PATCH /chats/{address} → 405"
 
 # --- 8. Guests read but do not write. -----------------------------
 GUEST_TOKEN=$(curl -s -X POST -H "Content-Type: application/json" \
@@ -269,11 +269,11 @@ fi
 # --- 9. Closing is global and actually removes it. ----------------
 _curl -X DELETE -H "Authorization: Bearer $TOKEN" "$HOST/api/v0/chats/$PEER"
 # 204, no body: `peer` came from the URL and `ok` restated the status code.
-_assert_status 204 "DELETE /chats/{client_address} → 204"
+_assert_status 204 "DELETE /chats/{address} → 204"
 _assert_body_empty 'close sends no body'
 sleep 3
 _curl -H "Authorization: Bearer $TOKEN" "$HOST/api/v0/chats"
-GONE=$(printf '%s' "$CURL_BODY" | jq --arg p "$PEER" '[.chats[] | select(.client_address == $p)] | length')
+GONE=$(printf '%s' "$CURL_BODY" | jq --arg p "$PEER" '[.chats[] | select(.address == $p)] | length')
 if [ "$GONE" = "0" ]; then
 	_pass "closed conversation is gone from /chats"
 else

--- a/unittests/tests/RefresherTest.cpp
+++ b/unittests/tests/RefresherTest.cpp
@@ -864,7 +864,7 @@ TEST(Refresher, DownloadDetailTagsDecodeIntoSnapshot)
 	ASSERT_EQUALS(static_cast<std::uint32_t>(1700000000), d.download.last_seen_complete_at);
 	ASSERT_EQUALS(static_cast<std::uint32_t>(1700000123), d.download.last_received_at);
 	ASSERT_EQUALS(static_cast<std::uint32_t>(3600), d.download.active_seconds);
-	ASSERT_EQUALS(static_cast<std::uint16_t>(12), d.download.parts_available_count);
+	ASSERT_EQUALS(static_cast<std::uint16_t>(12), d.download.available_part_count);
 	ASSERT_EQUALS(static_cast<std::uint16_t>(3), d.download.hashed_part_count);
 	ASSERT_EQUALS(static_cast<std::uint64_t>(9728000), d.download.lost_to_corruption_bytes);
 	ASSERT_EQUALS(static_cast<std::uint64_t>(4096), d.download.gained_by_compression_bytes);


### PR DESCRIPTION
Items **12-15** of #1253, the naming remainder - and the last of the audit. §16 was decided the other way: `friend_slot` stays.

| # | Was | Now | Why |
|---|---|---|---|
| 12 | `client_address` | `address` | R12 names this exact token as the one not to use, and the chat resource had it in **all three** forbidden positions: path segment, response key and SSE key. `/servers/by-address/{address}` already spelled it bare. |
| 13 | `parts_total_count`, `parts_available_count` | `total_part_count`, `available_part_count` | R6 - they sat beside `hashed_part_count` on the same object, one file's part count spelled two ways. |
| 14 | `ratio: {session, total}` | `ratio_session`, `ratio_total` | R11 - the window belongs in the key; `uploaded_bytes_session`/`_total` are flat everywhere else. Each is still emitted only when computable. |
| 15 | `active_downloads`, `active_uploads` | `active_download_count`, `active_upload_count` | R5 - counts as siblings of `value`, not inside an object naming the thing counted. |

The snapshot members move with the keys for 13, so member and wire name keep matching.

### Deliberately untouched

`Statistics.cpp` sets `active_uploads` / `active_downloads` as **stats-tree node keys** - that is a different surface, shared with the desktop and amuleweb, not the graph point series §15 is about. Renaming those would be its own decision.

### Verification

47/47 ctest, clang-format clean, 0 findings on both clang-tidy tiers with 0 compiler errors, Web UI dictionary check green.

Curl: **04 (141/141)**, **37 (15/15)**, **38 (50/50)** - the whole chat surface exercised on the renamed route.

Phase 07 carries the ratio and graph assertions but aborts at bring-up on `POST /search returned no search_id`, which the unmodified binary does too on this box. Those four were verified by hand against a live daemon instead: zero wrapping `ratio` objects with a computed `ratio_total` present, and a connections point reading `{at, value, active_download_count, active_upload_count}`.

Closes #1253.
