### PR TITLE
test(curl): repair the checks the 202-body change broke, and two dead ones

### DIFF
--- a/unittests/curl-tests/amuleapi/16-networks-connect.sh
+++ b/unittests/curl-tests/amuleapi/16-networks-connect.sh
@@ -73,6 +73,21 @@ _assert_json_eq() {
 	fi
 }
 
+# A 202 from a connection-control trigger carries a body only when amuled had
+# something to say: `{"message": ...}` if it did, no body at all if it did not
+# (the empty `{}` was dropped so these match the URL-fetch triggers beside
+# them). Either is correct; a constant `ok` field is not.
+_assert_no_body_or_message() {
+	local what=$1
+	if [ -z "$CURL_BODY" ]; then
+		_pass "$what: 202 with no body (amuled reported nothing)"
+	elif echo "$CURL_BODY" | jq -e '(has("ok") | not) and (.message | type == "string")' >/dev/null 2>&1; then
+		_pass "$what: 202 body carries amuled's message and no constant ok"
+	else
+		_fail "$what 202 body" "expected no body or {message}, got: $CURL_BODY"
+	fi
+}
+
 if ! command -v jq >/dev/null 2>&1; then _die "jq is required."; fi
 if ! curl -s -o /dev/null --max-time 2 "$HOST/api/v0/health" 2>/dev/null; then
 	_die "amuleapi at $HOST is not reachable."
@@ -123,16 +138,14 @@ _curl -X POST -H "Authorization: Bearer $ADMIN_TOKEN" \
 	-d '{"network":"kad"}' \
 	"$HOST/api/v0/networks/disconnect"
 _assert_status 202 "POST /networks/disconnect {network:kad} → 202"
-_assert_json_eq '. | has("ok")' false \
-	'networks/disconnect(kad) response has no constant ok field'
+_assert_no_body_or_message 'networks/disconnect(kad)'
 
 _curl -X POST -H "Authorization: Bearer $ADMIN_TOKEN" \
 	-H "Content-Type: application/json" \
 	-d '{"network":"kad"}' \
 	"$HOST/api/v0/networks/connect"
 _assert_status 202 "POST /networks/connect {network:kad} → 202"
-_assert_json_eq '. | has("ok")' false \
-	'networks/connect(kad) response has no constant ok field'
+_assert_no_body_or_message 'networks/connect(kad)'
 
 # ed2k-only selector should also round-trip via the network field.
 _curl -X POST -H "Authorization: Bearer $ADMIN_TOKEN" \

--- a/unittests/curl-tests/amuleapi/19-search.sh
+++ b/unittests/curl-tests/amuleapi/19-search.sh
@@ -331,7 +331,14 @@ for bad in "limit=abc" "limit=1000000001" "order=sideways" "sort=nonexistent_fie
 	_assert_status 400 "GET /search?$bad → 400"
 done
 
+# result_count on the list row against total on the results endpoint. Re-read
+# the list first: the four 400-probes above each overwrote CURL_BODY, so this
+# used to parse the last error body, find no .searches, and skip itself with an
+# empty state in the message.
+#
+# Only compared for a finished search: while one is running the two can
 # legitimately differ by a fetch.
+_curl -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/search"
 LIST_COUNT=$(printf '%s' "$CURL_BODY" \
 	| jq -r "[.searches[] | select(.search_id == $FIRST_SID)][0].result_count")
 LIST_STATE=$(printf '%s' "$CURL_BODY" \

--- a/unittests/curl-tests/amuleapi/22-sse-diff-emission.sh
+++ b/unittests/curl-tests/amuleapi/22-sse-diff-emission.sh
@@ -279,7 +279,11 @@ rm -f "$SSE_A" "$SSE_B"
 # network. Even on a fully-disconnected daemon `local` returns
 # immediately with 0 results, which still triggers the finished frame.
 # (search_progress supersedes the old standalone search_finished event.)
-SSE_PID=$(_sse_start 15)
+# 25 s, not 15: the terminal frame arrives when the SERVER declares the search
+# done, which on a LowID link is routinely slower than the old 8 s poll allowed
+# -- the check failed intermittently for that reason alone, which is the kind
+# of flake that teaches people to ignore a red run.
+SSE_PID=$(_sse_start 25)
 sleep 1
 SEARCH_QUERY=ubuntu
 SSE_SEARCH=$(curl -s -X POST -H "Authorization: Bearer $ADMIN_TOKEN" \
@@ -288,11 +292,10 @@ SSE_SEARCH=$(curl -s -X POST -H "Authorization: Bearer $ADMIN_TOKEN" \
 	"$HOST/api/v0/search")
 SSE_SID=$(printf '%s' "$SSE_SEARCH" | jq -r '.search_id // empty')
 SEARCH_FINISHED=""
-for _ in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 \
-         21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40; do
+for _ in $(seq 1 110); do
 	# The terminal frame is a search_progress event whose data has
 	# state=="finished". Several running frames may precede it; pick the
-	# finished one.
+	# finished one. 110 x 0.2 s = 22 s, inside the stream's 25 s.
 	if grep -q "^event: search_progress$" "$SSE_OUT"; then
 		SEARCH_FINISHED=$(grep -A2 "^event: search_progress$" "$SSE_OUT" \
 			| grep "^data: " | sed 's/^data: //' \
@@ -304,7 +307,7 @@ done
 wait $SSE_PID 2>/dev/null
 
 if [ -n "$SEARCH_FINISHED" ]; then
-	_pass "search_progress finished frame fired within 8 s of POST /search type=local"
+	_pass "search_progress finished frame fired within 22 s of POST /search type=local"
 	JSON="$SEARCH_FINISHED"
 	if echo "$JSON" | jq -e '.state == "finished"' >/dev/null 2>&1; then
 		_pass "search_progress .data.state == 'finished'"
@@ -350,7 +353,7 @@ if [ -n "$SEARCH_FINISHED" ]; then
 	fi
 else
 	_fail "search_progress finished frame missing" \
-		"no finished search_progress within 8 s of POST /search; stream sample: $(head -40 "$SSE_OUT")"
+		"no finished search_progress within 22 s of POST /search; stream sample: $(head -40 "$SSE_OUT")"
 fi
 
 # --- 6.1 search_closed fires when a search is freed. ---------------

--- a/unittests/curl-tests/amuleapi/26-rfc-followup-endpoints.sh
+++ b/unittests/curl-tests/amuleapi/26-rfc-followup-endpoints.sh
@@ -92,11 +92,16 @@ if [ "$RC" = "202" ]; then
 else
 	_fail "shared_reload status" "expected 202, got $RC: $(cat /tmp/p11_shared_reload.json)"
 fi
-# No constant `ok`: the 202 already said the call was accepted.
-if jq -e 'has("ok") | not' /tmp/p11_shared_reload.json >/dev/null 2>&1; then
-	_pass "POST /shared_reload has no constant ok field"
+# The 202 already said the call was accepted, so there is no constant `ok`.
+# A body exists only when amuled had a message; with nothing to report the
+# reply carries none, matching the URL-fetch triggers.
+if [ ! -s /tmp/p11_shared_reload.json ]; then
+	_pass "POST /shared_reload: 202 with no body (amuled reported nothing)"
+elif jq -e '(has("ok") | not) and (.message | type == "string")' \
+	/tmp/p11_shared_reload.json >/dev/null 2>&1; then
+	_pass "POST /shared_reload: 202 body carries amuled's message and no constant ok"
 else
-	_fail "shared_reload body" "$(cat /tmp/p11_shared_reload.json)"
+	_fail "shared_reload body" "expected no body or {message}, got: $(cat /tmp/p11_shared_reload.json)"
 fi
 
 # --- 3. POST /servers_update — body validation. ------------------

--- a/unittests/curl-tests/amuleapi/36-shared-reload.sh
+++ b/unittests/curl-tests/amuleapi/36-shared-reload.sh
@@ -73,6 +73,20 @@ _assert_json_eq() {
 	fi
 }
 
+# A 202 from shared_reload carries a body only when amuled had
+# something to say: `{"message": ...}` if it did, no body at all if it did not
+# (the empty `{}` was dropped so this matches the URL-fetch triggers). Either is correct; a constant `ok` field is not.
+_assert_no_body_or_message() {
+	local what=$1
+	if [ -z "$CURL_BODY" ]; then
+		_pass "$what: 202 with no body (amuled reported nothing)"
+	elif echo "$CURL_BODY" | jq -e '(has("ok") | not) and (.message | type == "string")' >/dev/null 2>&1; then
+		_pass "$what: 202 body carries amuled's message and no constant ok"
+	else
+		_fail "$what 202 body" "expected no body or {message}, got: $CURL_BODY"
+	fi
+}
+
 _assert_body_empty() {
 	local label=$1
 	if [ -z "$CURL_BODY" ]; then
@@ -114,8 +128,7 @@ fi
 # --- 2. Accept path. -----------------------------------------------
 _curl -X POST -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/shared_reload"
 _assert_status 202 "POST /shared_reload (admin) → 202"
-# No constant `ok`: the 202 already said the call was accepted.
-_assert_json_eq '. | has("ok")' false "/shared_reload has no constant ok field"
+_assert_no_body_or_message "/shared_reload"
 
 # --- 3. Repeated calls coalesce. -----------------------------------
 # A second request while the first is still pending (or its walk running)
@@ -124,7 +137,7 @@ _assert_json_eq '. | has("ok")' false "/shared_reload has no constant ok field"
 # collapse into one walk is amuled-side and shows up in its log.
 _curl -X POST -H "Authorization: Bearer $ADMIN_TOKEN" "$HOST/api/v0/shared_reload"
 _assert_status 202 "POST /shared_reload again immediately → 202"
-_assert_json_eq '. | has("ok")' false "second /shared_reload has no constant ok field"
+_assert_no_body_or_message "second /shared_reload"
 
 # --- 4. The reply does not wait for the walk. ----------------------
 # Generous bound: this is a smoke against a regression to the old inline


### PR DESCRIPTION
Running the whole suite end to end turned up five failures and two checks that could never have run.

### Three phases still asserted the old 202 contract - my regression

#1257 dropped the empty `{}` body from the connection-control triggers so they match the URL-fetch triggers beside them. `has("ok") == false` does not hold against a response with **no body at all**: jq answers empty, not false.

I updated `35-ipfilter-actions.sh` when making that change and ran it. Phases **16**, **26** and **36** assert the same thing and I did not run them, which is how a behaviour change I made shipped with three stale tests behind it. They now assert the real contract: no body, or a body carrying amuled's own message and no constant `ok`.

### 19: a comparison that read the wrong response

`LIST_COUNT` / `LIST_STATE` read `$CURL_BODY` after four `400`-probes had each overwritten it, so it parsed an error body, found no `.searches`, and skipped itself. The only evidence was two `jq: Cannot iterate over null` lines and an info line reading `search still ;` with an empty state. It re-reads the list first.

### 22: an 8-second deadline for something the server decides

The terminal-frame check gave the search 8 s to be declared finished **by the server**. On a LowID link that is routinely not enough, so it failed intermittently for a reason unrelated to the code - the kind of flake that teaches people to ignore a red run. Now 22 s inside a 25 s stream.

### Verification

Against a live daemon, all five phases green: **16 37/37**, **19 187/187**, **22 28/28**, **26 41/41**, **36 13/13**.

A full-suite run follows once this lands, and I will report the totals and every skip.
