### PR TITLE
fix(gui): drop "Swap to this file" from the Shared Files peer list

### DIFF
--- a/src/GenericClientListCtrl.cpp
+++ b/src/GenericClientListCtrl.cpp
@@ -778,10 +778,18 @@ void CGenericClientListCtrl::OnItemRightClicked(wxDataViewEvent &event)
 	// the Clients tab, which has no file in context and draws no chunk bar, so
 	// neither entry can mean anything there.
 	//
+	// Swapping is a download notion: it moves a source off whatever it is
+	// currently downloading and onto this file, and A4AF only means anything
+	// among a download's sources. The shared-files peer list shows clients
+	// downloading FROM us, so there is nothing to swap and the entry is
+	// omitted rather than shown dead -- the same rule the Clients tab follows.
+	//
 	// Disabled for a non-A4AF source, where the peer is already on the file it
 	// would swap to: "not right now" rather than "never here".
-	m_menu->Append(MP_CHANGE2FILE, _("Swap to this file"));
-	m_menu->Enable(MP_CHANGE2FILE, item->GetType() == A4AF_SOURCE);
+	if (IsShowingDownloadSources()) {
+		m_menu->Append(MP_CHANGE2FILE, _("Swap to this file"));
+		m_menu->Enable(MP_CHANGE2FILE, item->GetType() == A4AF_SOURCE);
+	}
 
 	// Asking the list which of its own columns has a legend keeps this true for
 	// any future subclass without naming one here.


### PR DESCRIPTION
Swapping moves a source off whatever it is currently downloading and onto this file, and A4AF only means anything among a *download's* sources. The Shared Files detail list shows clients downloading **from** us, so there is nothing to swap - the entry was offered there and could never apply.

`CGenericClientListCtrl` backs both detail lists, so the entry #1246 moved out of the shared builder and into that handler reached the shared-files side too. A narrower version of the same defect, fixed the same way: omitted rather than shown dead, which is what the Clients tab already does.

No new hook was needed. The list is already asked which kind it is - `IsShowingDownloadSources()` is `true` for `CSourceListCtrl` and `false` for `CSharedFilePeersListCtrl`, and the row-building code above already uses it for the same distinction.

Behaviour on the Downloads detail list is unchanged: still shown, still enabled only for an A4AF source.

### Verification

`amule` and `amulegui` both build with no new warnings, 47/47 ctest, clang-format clean, 0 findings on both clang-tidy tiers with 0 compiler errors.

The menu itself cannot be exercised headlessly, so the behavioural claim rests on the gate: the entry is appended only when the list reports it is showing download sources, and `MP_CHANGE2FILE`'s handler is reachable only from that menu.
