### PR TITLE
fix(knownfiles): make the on-disk copy canonical for a duplicated hash

### DIFF
--- a/src/KnownFileList.cpp
+++ b/src/KnownFileList.cpp
@@ -401,6 +401,82 @@ CKnownFile *CKnownFileList::FindKnownFileByID(const CMD4Hash &hash)
 	return NULL;
 }
 
+void CKnownFileList::EraseFromSizeMap(KnownFileSizeMap *sizeMap, CKnownFile *record)
+{
+	// Caller must hold list_mut.
+	if (!sizeMap) {
+		return;
+	}
+	const auto key =
+		std::make_pair((uint32)record->GetFileSize(), (uint32)record->GetLastChangeDatetime());
+	const auto range = sizeMap->equal_range(key);
+	for (auto hit = range.first; hit != range.second; ++hit) {
+		if (hit->second == record) {
+			sizeMap->erase(hit);
+			return;
+		}
+	}
+}
+
+void CKnownFileList::InsertIntoSizeMap(KnownFileSizeMap *sizeMap, CKnownFile *record)
+{
+	// Caller must hold list_mut.
+	if (!sizeMap) {
+		return;
+	}
+	sizeMap->insert(std::make_pair(
+		std::make_pair((uint32)record->GetFileSize(), (uint32)record->GetLastChangeDatetime()),
+		record));
+}
+
+bool CKnownFileList::PromoteToCanonical(CKnownFile *file)
+{
+	if (!file) {
+		return false;
+	}
+
+	wxMutexLocker sLock(list_mut);
+
+	const CMD4Hash &tkey = file->GetFileHash();
+	const auto it = m_knownFileMap.find(tkey);
+	if (it == m_knownFileMap.end() || it->second == file) {
+		// Already canonical, or this hash has no live record at all --
+		// a freshly hashed file becomes canonical through Append, so
+		// there is nothing to take over here.
+		return false;
+	}
+
+	CKnownFile *demoted = it->second;
+
+	// Same swap Append performs when a later known.met entry takes over
+	// a hash, minus the Kad withdrawal: `demoted` cannot be in the
+	// shared list (m_Files_map is hash-keyed and `file` holds that slot)
+	// and only CSharedFileList::AddFile publishes keywords, so it has
+	// none to remove.
+	m_duplicateFileList.push_back(demoted);
+	EraseFromSizeMap(m_knownSizeMap, demoted);
+	InsertIntoSizeMap(m_duplicateSizeMap, demoted);
+
+	// `file` moves the other way. It is on the duplicate list in the
+	// case this exists for, but not necessarily: an already-canonical
+	// record short-circuits above, so nothing else is assumed here.
+	m_duplicateFileList.remove(file);
+	EraseFromSizeMap(m_duplicateSizeMap, file);
+	InsertIntoSizeMap(m_knownSizeMap, file);
+	m_knownFileMap[tkey] = file;
+
+	// m_pinnedDuplicates keeps `file` on purpose. The pin records that
+	// this session matched the record against a real on-disk file,
+	// which stays true, and it only ever guards duplicate-list records
+	// -- so it costs nothing while `file` is canonical and protects it
+	// from the cap prune if some later Append demotes it again.
+
+	AddDebugLogLineN(logKnownFiles,
+		CFormat("Duplicate '%s' is now the canonical record for its hash, replacing '%s'") %
+			file->GetFileName().GetPrintable() % demoted->GetFileName().GetPrintable());
+	return true;
+}
+
 bool CKnownFileList::SafeAddKFile(CKnownFile *toadd, bool afterHashing)
 {
 	bool ret;
@@ -456,12 +532,7 @@ bool CKnownFileList::Append(CKnownFile *Record, bool afterHashing)
 				}
 			}
 			m_knownFileMap[tkey] = Record;
-			if (m_knownSizeMap) {
-				m_knownSizeMap->insert(
-					std::make_pair(std::make_pair((uint32)Record->GetFileSize(),
-							       (uint32)Record->GetLastChangeDatetime()),
-						Record));
-			}
+			InsertIntoSizeMap(m_knownSizeMap, Record);
 			return true;
 		} else {
 			CKnownFile *existing = it->second;
@@ -530,37 +601,16 @@ bool CKnownFileList::Append(CKnownFile *Record, bool afterHashing)
 				// (This is used when reading the known file list where the duplicates are
 				// stored in front.)
 				m_duplicateFileList.push_back(existing);
-				if (m_duplicateSizeMap) {
-					m_duplicateSizeMap->insert(std::make_pair(
-						std::make_pair((uint32)existing->GetFileSize(),
-							(uint32)existing->GetLastChangeDatetime()),
-						existing));
-				}
+				InsertIntoSizeMap(m_duplicateSizeMap, existing);
 				if (theApp->sharedfiles) {
 					// Removing the old kad keywords created with the old filename
 					theApp->sharedfiles->RemoveKeywords(existing);
 				}
-				if (m_knownSizeMap) {
-					// existing is leaving m_knownFileMap for m_duplicateFileList;
-					// drop its size-map entry so FindKnownFile doesn't return a
-					// pointer that no longer belongs to the live map.
-					const auto existingKey =
-						std::make_pair((uint32)existing->GetFileSize(),
-							(uint32)existing->GetLastChangeDatetime());
-					std::pair<KnownFileSizeMap::iterator, KnownFileSizeMap::iterator> p =
-						m_knownSizeMap->equal_range(existingKey);
-					for (KnownFileSizeMap::iterator hit = p.first; hit != p.second;
-						++hit) {
-						if (hit->second == existing) {
-							m_knownSizeMap->erase(hit);
-							break;
-						}
-					}
-					m_knownSizeMap->insert(std::make_pair(
-						std::make_pair((uint32)Record->GetFileSize(),
-							(uint32)Record->GetLastChangeDatetime()),
-						Record));
-				}
+				// existing is leaving m_knownFileMap for m_duplicateFileList;
+				// drop its size-map entry so FindKnownFile doesn't return a
+				// pointer that no longer belongs to the live map.
+				EraseFromSizeMap(m_knownSizeMap, existing);
+				InsertIntoSizeMap(m_knownSizeMap, Record);
 				// On the afterHashing path the copy-existing-tags
 				// block above pulled the prior FT_LASTSEEN into
 				// Record; refresh it so the new live entry isn't
@@ -592,17 +642,12 @@ void CKnownFileList::PrepareIndex()
 {
 	ReleaseIndex();
 	m_knownSizeMap = new KnownFileSizeMap;
-	for (CKnownFileMap::const_iterator it = m_knownFileMap.begin(); it != m_knownFileMap.end(); ++it) {
-		m_knownSizeMap->insert(std::make_pair(std::make_pair((uint32)it->second->GetFileSize(),
-							      (uint32)it->second->GetLastChangeDatetime()),
-			it->second));
+	for (const auto &entry : m_knownFileMap) {
+		InsertIntoSizeMap(m_knownSizeMap, entry.second);
 	}
 	m_duplicateSizeMap = new KnownFileSizeMap;
-	for (KnownFileList::const_iterator it = m_duplicateFileList.begin(); it != m_duplicateFileList.end();
-		++it) {
-		m_duplicateSizeMap->insert(std::make_pair(
-			std::make_pair((uint32)(*it)->GetFileSize(), (uint32)(*it)->GetLastChangeDatetime()),
-			*it));
+	for (CKnownFile *record : m_duplicateFileList) {
+		InsertIntoSizeMap(m_duplicateSizeMap, record);
 	}
 }
 
@@ -632,22 +677,6 @@ void CKnownFileList::PruneDuplicates(const std::unordered_set<CKnownFile *> &inU
 
 	auto isProtected = [&](CKnownFile *r) {
 		return inUse.count(r) > 0 || m_pinnedDuplicates.count(r) > 0;
-	};
-
-	auto eraseFromSizeMap = [&](KnownFileSizeMap *sizeMap, CKnownFile *dead) {
-		if (!sizeMap) {
-			return;
-		}
-		const auto key =
-			std::make_pair((uint32)dead->GetFileSize(), (uint32)dead->GetLastChangeDatetime());
-		std::pair<KnownFileSizeMap::iterator, KnownFileSizeMap::iterator> p =
-			sizeMap->equal_range(key);
-		for (KnownFileSizeMap::iterator hit = p.first; hit != p.second; ++hit) {
-			if (hit->second == dead) {
-				sizeMap->erase(hit);
-				return;
-			}
-		}
 	};
 
 	// Pass 1: live entries (m_knownFileMap) past TTL. A non-refreshed
@@ -681,7 +710,7 @@ void CKnownFileList::PruneDuplicates(const std::unordered_set<CKnownFile *> &inU
 		const bool hashDead = deadHashes.count(record->GetFileHash()) > 0;
 		const bool ownStale = record->GetLastSeen() < ttlCutoff;
 		if (hashDead || ownStale) {
-			eraseFromSizeMap(m_duplicateSizeMap, record);
+			EraseFromSizeMap(m_duplicateSizeMap, record);
 			KnownFileList::iterator victim = it++;
 			Notify_KnownFileBeingDestroyed(record);
 			delete record;
@@ -716,7 +745,7 @@ void CKnownFileList::PruneDuplicates(const std::unordered_set<CKnownFile *> &inU
 			continue;
 		}
 
-		eraseFromSizeMap(m_knownSizeMap, dead);
+		EraseFromSizeMap(m_knownSizeMap, dead);
 		Notify_KnownFileBeingDestroyed(dead);
 		delete dead;
 		m_knownFileMap.erase(kit);
@@ -757,7 +786,7 @@ void CKnownFileList::PruneDuplicates(const std::unordered_set<CKnownFile *> &inU
 			});
 		for (size_t i = KNOWN_DUPLICATE_HASH_CAP; i < prunable.size(); ++i) {
 			CKnownFile *dead = *prunable[i];
-			eraseFromSizeMap(m_duplicateSizeMap, dead);
+			EraseFromSizeMap(m_duplicateSizeMap, dead);
 			m_duplicateFileList.erase(prunable[i]);
 			Notify_KnownFileBeingDestroyed(dead);
 			delete dead;

--- a/src/KnownFileList.h
+++ b/src/KnownFileList.h
@@ -46,6 +46,27 @@ public:
 	CKnownFile *FindKnownFile(const CPath &filename, time_t in_date, uint64 in_size);
 	CKnownFile *FindKnownFileByID(const CMD4Hash &hash);
 
+	// Make `file` the record that hash-keyed lookups resolve to, and
+	// return whether that changed anything.
+	//
+	// m_knownFileMap holds exactly one record per hash: whichever
+	// known.met entry was loaded last, since Append demotes the
+	// earlier ones to m_duplicateFileList. For content that exists at
+	// several paths that record is not necessarily the copy the share
+	// scan found on disk, and once its own copy is deleted it is not
+	// on disk at all. FindKnownFileByID then hands out a record whose
+	// path cannot be opened, which is what broke "verify local data",
+	// the EC rename handler and the search "already known" flag for a
+	// deleted duplicate (issue #1265). The cap/TTL prune cannot heal
+	// it either: it only evicts duplicate-list records, and it keeps
+	// the dead live entry precisely because a same-hash record is
+	// shared.
+	//
+	// Called by the share scan for each file it actually shares, so
+	// the record backed by a file we just saw wins the hash. A no-op
+	// in the common case where `file` is already canonical.
+	bool PromoteToCanonical(CKnownFile *file);
+
 	// Returns true iff `file` is currently a member of the canonical
 	// known-file map. Pointer-value comparison only — `file` may
 	// already be freed when this is called, in which case the
@@ -127,6 +148,20 @@ private:
 	typedef std::multimap<std::pair<uint32, uint32>, CKnownFile *> KnownFileSizeMap;
 	KnownFileSizeMap *m_knownSizeMap;
 	KnownFileSizeMap *m_duplicateSizeMap;
+
+	// Drop `record`'s entry from one of the (size, mtime) indexes
+	// above. Each index mirrors a list, so a record that moves between
+	// the live map and the duplicate list has to be moved here too or
+	// FindKnownFile hands out a pointer that no longer belongs to the
+	// list it was indexed under. Takes the index rather than reading
+	// the member, because every caller moves a record in one specific
+	// direction.
+	void EraseFromSizeMap(KnownFileSizeMap *sizeMap, CKnownFile *record);
+
+	// Add `record` to one of the indexes above, keyed the same way
+	// EraseFromSizeMap looks it up. The two must agree on the key, so
+	// they live side by side.
+	void InsertIntoSizeMap(KnownFileSizeMap *sizeMap, CKnownFile *record);
 
 	// Duplicate-list records that FindKnownFile / IsOnDuplicates
 	// returned during this session — i.e. their (name, date, size)

--- a/src/SharedFileList.cpp
+++ b/src/SharedFileList.cpp
@@ -677,6 +677,16 @@ CSharedFileList::AddPathResult CSharedFileList::AddPathToShares(
 		toadd->SetFilePath(directory);
 		if (AddFile(toadd)) {
 			AddDebugLogLineN(logKnownFiles, CFormat("Added known file '%s' to shares") % fname);
+			// This record matched a file we just saw on disk and it now
+			// owns the hash in the shared list. Give it the hash in the
+			// known-file map too: that map keeps whichever known.met
+			// entry loaded last, which for duplicated content can be a
+			// different record -- and if that record's own copy has been
+			// deleted, every hash-keyed known-file lookup resolves to a
+			// path that cannot be opened (issue #1265). Called outside
+			// AddFile's lock on purpose: nothing may enter knownfiles
+			// while holding the shared-list lock.
+			filelist->PromoteToCanonical(toadd);
 			// The bulk-Reload caller repaints the whole view once its
 			// walk finishes; the incremental watcher caller has no such
 			// follow-up, so tell the GUI about this freshly-shared file


### PR DESCRIPTION
Fixes #1265.

## The bug

known.met can hold several records for one hash, one per path the same content was found at. `CKnownFileList::Append` keeps whichever entry was loaded last in `m_knownFileMap` and demotes the earlier ones to `m_duplicateFileList`, so which record is canonical is decided by file order, not by what is on disk.

The share scan matches files by (name, mtime, size) through `FindKnownFile`, which falls back to the duplicate list, so the record that ends up in the shared list can be a different object than the canonical one. When the canonical record's own copy has been deleted, it is a record for a file that is not there, and every hash-keyed known-file lookup resolves to it: "verify local data" opened the deleted path, and the EC rename handler and the search "already known" flag had the same target.

Nothing healed it. The cap/TTL prune only evicts duplicate-list records, and it deliberately keeps a dead live entry when a same-hash record is shared, so the dead record stayed canonical until some other copy of the content was rehashed.

Uploads were never affected: every peer-facing path resolves through `CSharedFileList::GetFileByID`, whose entry came from a scan hit against a real path.

## The fix

`CKnownFileList::PromoteToCanonical` gives the hash to the record the scan just matched against a real file, demoting the previous live entry to the duplicate list. `CSharedFileList::AddPathToShares` calls it for each file it actually shares, which covers both the bulk walk and the incremental watcher, and it runs outside `AddFile`'s lock so the one-way knownfiles -> sharedfiles lock order is preserved. The repair persists: `Save()` writes duplicates first and the live map last, so the promoted record loads canonical on the next start.

The demoted record keeps no Kad keywords to withdraw (only `AddFile` publishes them, and it cannot be in the shared list because `m_Files_map` is hash-keyed and the promoted record holds that slot), which is the one step this swap does not share with `Append`'s.

I first planned a second change to make `CVerifyLocalDataTask` prefer `sharedfiles->GetFileByID` over the known-file map, mirroring the #1116 fix in `OnMediaProbeFinished`. It is not needed once the map itself is correct: verify can only be triggered on a shared file, since both `CSharedFilesCtrl::OnVerifyLocalData` and the `EC_OP_VERIFY_LOCAL_DATA` handler resolve the target through the shared list before scheduling the task. Two mechanisms enforcing one invariant is what eventually disagrees, and the map fix also covers the rename and search-flag callers that the task-local change would have left wrong.

Drive-by: the (size, mtime) index updates that `Append`, `PrepareIndex` and `PruneDuplicates` each open-coded are now `EraseFromSizeMap` / `InsertIntoSizeMap`, so the erase key and the insert key cannot drift apart.

## Tests

Headless repro on macOS, following the reporter's steps: private config dir, EC on 4812, four identical 20 MB copies in the shared dir, `POST /api/v0/shared/{hash}/verify` as the trigger, and `fileview known.met` to confirm the record order. Both runs started from a byte-identical state: order copy_4, copy_3, copy_2, copy_1 (last one canonical) with copy_1 deleted from disk.

Pre-fix, built from master:

```
shared entry: copy_4
CFile: Error when opening file (copy_1): No such file or directory
Verify Local Data: Warning, failed to open file, skipping: copy_1
```

Post-fix, same known.met and same deleted copy:

```
shared entry: copy_4
Verify Local Data (MD4 & AICH): Result OK for .../repro/share/copy_4
```

known.met after the fixed run is reordered to copy_3, copy_2, copy_1, copy_4 with all four records intact, so the promotion persists across restarts and loses nothing.

Regression checks:

- A distinct 5 MB file added to the same share verifies OK alongside the duplicated one, with the promotion a no-op for it.
- A second restart keeps the duplicated hash on copy_4 without another swap.
- amuleapi curl-smoke phases 04-read-downloads-shared, 30-shared-verify, 36-shared-reload and 41-shared-content all pass (151 checks, skips limited to the no-peer and no-partfile cases).
- cf18 whole-file clean on the three changed files, and the Tier-2 clang-tidy diff run is clean with 0 compiler errors. The single Tier-1 `clang-analyzer-cplusplus.Move` hit in `PruneDuplicates` is pre-existing on master, verified by running the same check against master's copy of the file.

No unit test: `CKnownFileList` pulls in `CKnownFile`, which reaches `theApp` and so cannot be linked into a unittest target, as the existing note in `unittests/tests/CMakeLists.txt` records.
