### PR TITLE
fix(knownfiles): count duplicate-list records as known in IsKnownFile

### DIFF
--- a/src/KnownFileList.cpp
+++ b/src/KnownFileList.cpp
@@ -245,17 +245,32 @@ size_t CKnownFileList::GetKnownFileCount() const
 
 bool CKnownFileList::IsKnownFile(const CKnownFile *file) const
 {
-	// Pointer-value scan over the canonical map; safe to call with a
+	// Pointer-value scan over both lists; safe to call with a
 	// possibly-freed `file` pointer (no deref). Used by
 	// OnFinishedHashing / OnFinishedAICHHashing to validate the
-	// owner pointer survived hashing. m_knownFileMap is hash-keyed
-	// not pointer-keyed, so we walk it — linear in shareset size but
+	// owner pointer survived hashing. Neither container is
+	// pointer-keyed, so we walk them — linear in shareset size but
 	// invoked only on rare events (hash completion). For 100 k+
 	// sharesets this is the cost; a per-pointer index would speed
 	// it up but isn't justified for the call rate.
 	wxMutexLocker sLock(list_mut);
-	for (CKnownFileMap::const_iterator it = m_knownFileMap.begin(); it != m_knownFileMap.end(); ++it) {
-		if (it->second == file) {
+	for (const auto &entry : m_knownFileMap) {
+		if (entry.second == file) {
+			return true;
+		}
+	}
+	// The duplicate list counts as alive: this asks whether the record
+	// still exists, not whether it is canonical. PromoteToCanonical
+	// moves a perfectly live record out of the map whenever the share
+	// scan finds a better copy for its hash, and an AICH result landing
+	// after that must not be read as "owner was destroyed" -- the
+	// result would be dropped with a log line that says the opposite of
+	// what happened, and the hashset recomputed on some later run.
+	// A record that really was freed is erased from this list by
+	// PruneDuplicates under the same lock, so the freed case still
+	// answers false, and this stays a pointer comparison either way.
+	for (const CKnownFile *record : m_duplicateFileList) {
+		if (record == file) {
 			return true;
 		}
 	}
@@ -404,6 +419,14 @@ CKnownFile *CKnownFileList::FindKnownFileByID(const CMD4Hash &hash)
 void CKnownFileList::EraseFromSizeMap(KnownFileSizeMap *sizeMap, CKnownFile *record)
 {
 	// Caller must hold list_mut.
+	//
+	// The key is recomputed from the record's CURRENT size and mtime, so
+	// a record whose either value changed while it was indexed cannot be
+	// found and the erase silently leaves the old entry behind. Every
+	// caller today either indexes a record it has not mutated or sets the
+	// new values before the first insert, so nothing hits it -- but a
+	// future caller that mutates an already-indexed record has to erase
+	// under the old key first.
 	if (!sizeMap) {
 		return;
 	}

--- a/src/KnownFileList.h
+++ b/src/KnownFileList.h
@@ -67,8 +67,11 @@ public:
 	// in the common case where `file` is already canonical.
 	bool PromoteToCanonical(CKnownFile *file);
 
-	// Returns true iff `file` is currently a member of the canonical
-	// known-file map. Pointer-value comparison only — `file` may
+	// Returns true iff `file` is still one of this list's records,
+	// canonical or duplicate. It answers "does this record still
+	// exist", not "is it canonical": PromoteToCanonical demotes live
+	// records, so a map-only answer would report a live file as
+	// destroyed. Pointer-value comparison only — `file` may
 	// already be freed when this is called, in which case the
 	// comparison reliably returns false without dereferencing it.
 	// Used by the async-task completion handlers (OnFinishedHashing,


### PR DESCRIPTION
Follow-up to #1269, which introduced this: `PromoteToCanonical` demotes the previously-canonical record out of `m_knownFileMap`, and `CKnownFileList::IsKnownFile` scans only that map.

`IsKnownFile` is not a "is this record canonical" query. Its single caller, `CamuleApp::OnFinishedAICHHashing`, uses it as a liveness check on the `CKnownFile` that owns an in-flight AICH hash, guarding a swap that would otherwise touch freed memory. Its own comment names the cases it exists for: a record TTL-evicted by `PruneDuplicates`, or destroyed via `CPartFile::Delete`. After #1269 a perfectly live record fails it too.

The window is reachable, not theoretical. `CheckAICHHashes` schedules `CHashingTask` against shared-list records, `Reload` clears `m_Files_map` before its walk, and AICH hashing of a multi-GB file runs for many seconds. A reload landing inside that window can give the hash to whichever copy the walk reaches first and demote the copy that owns the running hash. The result is then dropped, with a log line asserting the owner "was destroyed while AICH hashing was in flight" when it was not, and AICH sync redoes the work on a later run. It fails safe rather than dereferencing freed memory, so this is silent and repeating rather than unsafe.

## The fix

`IsKnownFile` scans `m_duplicateFileList` as well. That matches what the caller is actually asking: does this record still exist. It stays pointer-comparison only with no deref, and `PruneDuplicates` erases a record from that list under the same lock before freeing it, so a genuinely dead pointer still answers false. Teaching the one caller about promotion instead would leave the next caller to rediscover the same trap.

## Tests

Instrumented A/B on the #1265 fixture (four identical 20 MB copies, the canonical one deleted from disk), logging `IsKnownFile(demoted)` immediately after a promotion. The instrumentation is not part of this PR. Both runs used a byte-identical `known.met`, restored from a snapshot between them:

```
run A, master:   [instr] promoted 'copy_4'; IsKnownFile(demoted)=0
run B, this PR:  [instr] promoted 'copy_4'; IsKnownFile(demoted)=1
```

`0` is exactly the condition under which `OnFinishedAICHHashing` drops the result. Recording it directly is more reliable than racing a multi-second AICH hash against a reload, which is the same defect one layer up.

Also re-ran the #1265 check on this build: `POST /api/v0/shared/{hash}/verify` still logs `Verify Local Data (MD4 & AICH): Result OK for .../copy_4`. cf18 clean on both changed files, Tier-2 clang-tidy diff clean with 0 compiler errors.

## Drive-by

A comment on `EraseFromSizeMap` recording that the key is recomputed from the record's current size and mtime, so mutating either while the record is indexed makes the erase silently no-op and leaves a stale pointer. No caller does that today, and the hazard predates the helper, but the helper is where the next caller will look.
