### PR TITLE
fix(web-ui): restore active up/down graph lines after the v0 rename

### DIFF
--- a/src/webapi/static/js/views/client-table.js
+++ b/src/webapi/static/js/views/client-table.js
@@ -80,7 +80,7 @@ export const COLS = [
     cell: (c) => c.a4af
       ? html`<span class="a4af-badge" title=${c.a4af_name || "?"}>${t("downloads_peer_a4af")}: ${c.a4af_name || "?"}</span>`
       : c.parts_offered_count == null ? "—"
-      : formatInt(c.parts_offered_count) + (c.parts_total_count ? " / " + formatInt(c.parts_total_count) : "") },
+      : formatInt(c.parts_offered_count) + (c.partsTotal ? " / " + formatInt(c.partsTotal) : "") },
 
   { key: "dl_state", th: "downloads_peer_col_dl_state", width: "120px", sortable: true,
     sortVal: (c) => c.download_state || "", cell: (c) => stateBadge(c.download_state) },
@@ -312,7 +312,7 @@ export function FileClients({ hash, prefsKey, defaultHidden, defaultSort, a4afEc
   for (const c of clients || []) {
     const a4af = a4afSet.has(c.ecid);
     if (!a4af && !inThisFile(c)) continue;
-    rows.push({ ...c, a4af, parts_total_count: partsTotal,
+    rows.push({ ...c, a4af, partsTotal,
                 a4af_name: a4af ? (nameByHash.get(c.download_file_hash) || c.download_file_name || "?") : undefined });
   }
   if (ident !== "all") rows = rows.filter((c) => c.ident_state === ident);

--- a/src/webapi/static/js/views/stats.js
+++ b/src/webapi/static/js/views/stats.js
@@ -67,7 +67,7 @@ export default function Stats() {
         // zeroed) by an amuled that does not report them — then it draws as the
         // single line it used to be.
         const rest = g.name !== "connections" ? [sma(ys, SMA_WINDOW)]
-          : pts.length && pts[0].active_downloads !== undefined
+          : pts.length && pts[0].active_download_count !== undefined
             ? [pts.map((p) => p.active_download_count), pts.map((p) => p.active_upload_count)]
             : [];
         if (alive) setGraphData((d) => ({ ...d, [g.name]: [pts.map((p) => p.at), ys, ...rest] }));
@@ -173,7 +173,7 @@ function fmtValue(v, spec) {
   return s;
 }
 
-// UL:DL ratio from the raw numbers (node.ratio), formatted locale-aware
+// UL:DL ratio from the raw ratio_session / ratio_total numbers, formatted locale-aware
 // instead of pasting the daemon's pre-formatted composite string. Mirrors the
 // desktop GUI's "1 : <session> (1 : <total>)".
 function formatRatio(r) {
@@ -185,8 +185,8 @@ function formatRatio(r) {
 
 // Fill the label template's printf placeholders from values, in order.
 function nodeText(node) {
-  // Ratio node: build from node.ratio when present; else fall back to the
-  // composite string value (legacy daemons emit no ratio object).
+  // Ratio node: build from ratio_session / ratio_total when present; else fall
+  // back to the composite string value (legacy daemons emit no ratio numbers).
   if (node.ratio_session != null) {
     return tNodeLabel(node).replace("%s",
       formatRatio({ session: node.ratio_session, total: node.ratio_total }));


### PR DESCRIPTION
The v0 key rename (#1262) changed the connections graph point keys active_downloads / active_uploads to active_download_count / active_upload_count. stats.js updated the .map() reads but left the presence guard testing the old key pts[0].active_downloads, so the guard was always false and the two extra series (active downloads / uploads) stopped being drawn -- the connections chart fell back to a single line with no legend.

- stats.js: guard on active_download_count so the two series render again
- stats.js: refresh two stale comments that still referenced node.ratio, which the code no longer reads (it uses the flat ratio_session / ratio_total keys)
- client-table.js: align the injected parts-total field with its prop name (partsTotal), dropping the parts_total_count name that echoed the now-removed v0 API key