### PR TITLE
fix(download): resume throttled reads that stall browsing and chat

### DIFF
--- a/src/DownloadBandwidthThrottler.cpp
+++ b/src/DownloadBandwidthThrottler.cpp
@@ -11,6 +11,8 @@
 
 #include "DownloadBandwidthThrottler.h"
 
+#include "EMSocket.h" // Needed for CEMSocket::WakeIfPaused
+
 #include <climits>
 
 CDownloadBandwidthThrottler &CDownloadBandwidthThrottler::Get()
@@ -74,6 +76,48 @@ uint32 CDownloadBandwidthThrottler::Reserve(uint32 wantBytes)
 		// CAS failed; `current` was reloaded with the latest value.
 	}
 	return 0;
+}
+
+void CDownloadBandwidthThrottler::PauseUntilRefill(CEMSocket *socket)
+{
+	std::lock_guard<std::mutex> lock(m_pausedLock);
+	m_paused.insert(socket);
+}
+
+void CDownloadBandwidthThrottler::Forget(CEMSocket *socket)
+{
+	std::lock_guard<std::mutex> lock(m_pausedLock);
+	m_paused.erase(socket);
+	// Also while a wake pass is walking it, which is how a socket destroyed
+	// as a side effect of waking another never gets handed out.
+	m_waking.erase(socket);
+}
+
+void CDownloadBandwidthThrottler::WakePaused()
+{
+	{
+		std::lock_guard<std::mutex> lock(m_pausedLock);
+		// Move rather than copy: anything that suspends again during this
+		// pass accumulates in m_paused for the next tick instead of being
+		// retried now against a bucket it has just emptied.
+		m_waking.swap(m_paused);
+	}
+
+	// One at a time, each taken under the lock and woken outside it, because
+	// waking runs the whole receive path and can destroy other sockets.
+	for (;;) {
+		CEMSocket *socket = nullptr;
+		{
+			std::lock_guard<std::mutex> lock(m_pausedLock);
+			if (m_waking.empty()) {
+				return;
+			}
+			const std::set<CEMSocket *>::iterator it = m_waking.begin();
+			socket = *it;
+			m_waking.erase(it);
+		}
+		socket->WakeIfPaused();
+	}
 }
 
 void CDownloadBandwidthThrottler::Refund(uint32 bytes)

--- a/src/DownloadBandwidthThrottler.h
+++ b/src/DownloadBandwidthThrottler.h
@@ -15,6 +15,10 @@
 #include "Types.h"
 #include <atomic>
 #include <cstdint>
+#include <mutex>
+#include <set>
+
+class CEMSocket;
 
 // Global token bucket that enforces thePrefs::GetMaxDownload() as a literal
 // byte/sec cap across all downloading sockets.
@@ -58,11 +62,43 @@ public:
 	// the unused capacity stays available to other peers in the same tick.
 	void Refund(uint32 bytes);
 
+	// A socket that suspended its read because Reserve() came back empty,
+	// and the counterpart for one that goes away while suspended.
+	//
+	// The throttler is what stopped these reads, so it is what has to
+	// restart them. Leaving that to whoever happens to tick the socket means
+	// a socket nobody ticks -- one we are browsing rather than downloading
+	// from -- never reads again: its half-received packet never completes,
+	// and the peer looks like it answered nothing at all.
+	void PauseUntilRefill(CEMSocket *socket);
+	void Forget(CEMSocket *socket);
+
+	// Restart the reads suspended before this call. Run once per tick after
+	// RefillBudget(), and OUTSIDE any lock the read path can reach: waking
+	// re-enters CEMSocket::OnReceive(), which parses packets and can run
+	// most of the core.
+	//
+	// Only the sockets already waiting when it starts are woken. A socket
+	// that exhausts the refilled bucket suspends again immediately, and
+	// waking it a second time in the same pass would achieve nothing but
+	// spin the main loop until the next refill, which cannot arrive while
+	// that loop is blocked.
+	void WakePaused();
+
 private:
 	CDownloadBandwidthThrottler() = default;
 
 	std::atomic<int64_t> m_bytesAvailable{ 0 };
 	std::atomic<bool> m_unlimited{ true };
+
+	std::mutex m_pausedLock;
+	// Suspended, waiting for the next refill.
+	std::set<CEMSocket *> m_paused;
+	// Being woken by the pass currently running. Held separately so a socket
+	// that suspends again lands in m_paused and waits for the next tick,
+	// while one that is destroyed mid-pass is dropped from here by Forget()
+	// and never handed out.
+	std::set<CEMSocket *> m_waking;
 };
 
 #endif // DOWNLOADBANDWIDTHTHROTTLER_H

--- a/src/DownloadBandwidthThrottler.h
+++ b/src/DownloadBandwidthThrottler.h
@@ -70,6 +70,11 @@ public:
 	// a socket nobody ticks -- one we are browsing rather than downloading
 	// from -- never reads again: its half-received packet never completes,
 	// and the peer looks like it answered nothing at all.
+	// Registration is on an empty bucket, not on what the socket is doing,
+	// so under a saturated cap this also collects sockets a part file will
+	// wake anyway. Those get a second, cheap wake per tick (WakeIfPaused()
+	// is a bool test when nothing is pending); telling the two apart from
+	// here would mean teaching the throttler about download sources.
 	void PauseUntilRefill(CEMSocket *socket);
 	void Forget(CEMSocket *socket);
 

--- a/src/DownloadQueue.cpp
+++ b/src/DownloadQueue.cpp
@@ -593,6 +593,11 @@ void CDownloadQueue::Process()
 		CheckDiskspace(thePrefs::GetTempDir());
 	}
 
+	// Outside the lock on purpose: this re-enters CEMSocket::OnReceive() for
+	// every socket the bucket suspended last tick, which parses packets and
+	// can reach back into the download queue.
+	CDownloadBandwidthThrottler::Get().WakePaused();
+
 	// Check for new links once per second.
 	if ((curTick - m_nLastED2KLinkCheck) >= 1000) {
 		theApp->AddLinksFromFile();

--- a/src/DownloadQueue.cpp
+++ b/src/DownloadQueue.cpp
@@ -448,20 +448,30 @@ void CDownloadQueue::Process()
 	// send src requests to local server
 	ProcessLocalRequests();
 	const uint64 curTick = ::GetTickCount64();
+
+	// Refill the global download bucket for this tick. The previous per-peer
+	// ratio controller (50-200% adaptive against the observed aggregate
+	// datarate) never actually enforced MaxDownload as a literal byte/sec
+	// cap. The throttler is a single shared atomic budget that every
+	// CEMSocket consults before each Read(); fast peers can claim unused
+	// capacity from slow ones within the same tick (demand-aware
+	// redistribution), and the global cap is the only constraint.
+	// MaxDownload=0 (UNLIMITED) sets the throttler to bypass mode.
+	//
+	// Both of these run before the lock, and the wake runs immediately after
+	// the refill, because the part-file walk below reads from every
+	// downloading socket synchronously while holding the lock. Refilling
+	// inside that block and waking after it hands the whole tick's budget to
+	// the peers we are downloading from, and a socket parked mid-packet --
+	// the browse or chat answer this wake exists for -- finds an empty bucket
+	// again every tick and never finishes reading.
+	CDownloadBandwidthThrottler::Get().RefillBudget(thePrefs::GetMaxDownload(), CORE_TIMER_PERIOD);
+	// Outside the lock on purpose: this re-enters CEMSocket::OnReceive(),
+	// which parses packets and can reach back into the download queue.
+	CDownloadBandwidthThrottler::Get().WakePaused();
+
 	{
 		wxMutexLocker lock(m_mutex);
-
-		// Refill the global download bucket for this tick. The previous
-		// per-peer ratio controller (50-200% adaptive against the
-		// observed aggregate datarate) never actually enforced
-		// MaxDownload as a literal byte/sec cap. The throttler is a
-		// single shared atomic budget that every CEMSocket consults
-		// before each Read(); fast peers can claim unused capacity
-		// from slow ones within the same tick (demand-aware
-		// redistribution), and the global cap is the only constraint.
-		// MaxDownload=0 (UNLIMITED) sets the throttler to bypass mode.
-		CDownloadBandwidthThrottler::Get().RefillBudget(
-			thePrefs::GetMaxDownload(), CORE_TIMER_PERIOD);
 
 		m_datarate = 0;
 		m_udcounter++;
@@ -592,11 +602,6 @@ void CDownloadQueue::Process()
 
 		CheckDiskspace(thePrefs::GetTempDir());
 	}
-
-	// Outside the lock on purpose: this re-enters CEMSocket::OnReceive() for
-	// every socket the bucket suspended last tick, which parses packets and
-	// can reach back into the download queue.
-	CDownloadBandwidthThrottler::Get().WakePaused();
 
 	// Check for new links once per second.
 	if ((curTick - m_nLastED2KLinkCheck) >= 1000) {

--- a/src/EMSocket.cpp
+++ b/src/EMSocket.cpp
@@ -112,6 +112,7 @@ CEMSocket::~CEMSocket()
 	if (theApp->uploadBandwidthThrottler) {
 		theApp->uploadBandwidthThrottler->RemoveFromAllQueues(this);
 	}
+	CDownloadBandwidthThrottler::Get().Forget(this);
 
 	ClearQueues();
 }
@@ -160,6 +161,7 @@ void CEMSocket::OnClose(int WXUNUSED(nErrorCode))
 	// now that we know no other method will keep adding to the queue
 	// we can remove ourself from the queue
 	theApp->uploadBandwidthThrottler->RemoveFromAllQueues(this);
+	CDownloadBandwidthThrottler::Get().Forget(this);
 
 	ClearQueues();
 }
@@ -222,7 +224,12 @@ void CEMSocket::OnReceive(int nErrorCode)
 				grantedBytes = CDownloadBandwidthThrottler::Get().Reserve(readMax);
 				if (grantedBytes == 0) {
 					// Bucket exhausted; resume on next tick refill.
+					// Register for that wake-up rather than relying on
+					// something else to tick this socket: a socket we
+					// are only browsing belongs to no download, so
+					// nothing else would.
 					pendingOnReceive = true;
+					CDownloadBandwidthThrottler::Get().PauseUntilRefill(this);
 					return;
 				}
 				readMax = grantedBytes;

--- a/src/EMSocket.h
+++ b/src/EMSocket.h
@@ -57,8 +57,14 @@ public:
 	uint8 GetConState() { return byConnected; }
 	// Re-trigger OnReceive if this socket suspended its read loop last
 	// tick because CDownloadBandwidthThrottler's bucket was empty.
-	// Called once per tick from CPartFile::Process via
-	// CUpDownClient::TickDownloadAndMeasure.
+	//
+	// Two callers, once per tick each. CDownloadBandwidthThrottler::
+	// WakePaused() drives the sockets the bucket itself parked, which is the
+	// only wake a socket gets when it belongs to no download. CPartFile::
+	// Process(), via CUpDownClient::TickDownloadAndMeasure(), drives the
+	// downloading ones, and is the only wake for the two pendingOnReceive
+	// cases the throttler does not register: a read that would block, and a
+	// read that filled its grant with more still pending.
 	void WakeIfPaused();
 
 	virtual uint64 GetTimeOut() const;


### PR DESCRIPTION
Browsing a peer fails whenever a download limit is set and the peer's answer is larger than one tick's budget. The peer answers, nothing arrives, and the browse dies 40 seconds later with "Failed to retrieve shared files from user".

## What happens

`CEMSocket::OnReceive()` asks `CDownloadBandwidthThrottler::Reserve()` before every read. When the bucket is empty it sets `pendingOnReceive` and returns, leaving the packet half-read and waiting to be resumed on the next refill.

The only thing that resumes it is `CUpDownClient::TickDownloadAndMeasure()`, which `CPartFile` calls while walking its own source lists, and only for sources in `DS_DOWNLOADING`. A peer we are browsing is a source for no download, so it is in no part file's source list and nothing ever wakes it. The rest of the packet is never read, so it never completes and is never even logged. Forty seconds later `CONNECTION_TIMEOUT` reaps the client and `CBrowseManager` reports the browse as failed.

The threshold is exact. `RefillBudget()` grants `MaxDownload * tick` per tick and caps the bucket at twice that, so a browse answer larger than `2 * MaxDownload * tick` can never be read within one tick and always suspends. On the GUI (100 ms tick) at 28 KB/s that ceiling is 5734 bytes, about 160 shared directories. A peer sharing 203 directories answers with 7435 bytes and fails every single time, which is how this was found. Chat is affected identically, just far more rarely because messages are small.

This is not a regression. The same code shipped in 3.0.0 and 3.0.1; only the trigger is environmental. Confirmed by clearing `MaxDownload` on unmodified master, which restores browsing immediately.

## The fix

The throttler is what suspends the read, so it is what resumes it. Sockets register when `Reserve()` comes back empty and deregister when they go away, and `CDownloadQueue::Process()` drains that set once per tick after refilling the bucket.

Both the refill and the wake run **before** `Process()` takes its lock, refill immediately followed by wake. Between them, the part-file walk reads from every downloading socket synchronously, so refilling inside that block and waking after it hands the tick's whole budget to the peers being downloaded from: a socket parked mid-packet then finds an empty bucket again every tick and never finishes. Giving parked sockets first claim costs downloads very little, because a browse or chat answer is small next to file traffic.

Three further details are deliberate:

- Waking happens **outside** the download queue's lock, because it re-enters `OnReceive()`, which parses packets and can reach back into the queue.
- Sockets are taken **one at a time under the lock**, not as a batch, so one destroyed as a side effect of waking another is never handed out.
- Only sockets **already waiting when the pass starts** are woken. Waking a socket that has just drained the refilled bucket again in the same pass spins the main loop against a bucket that cannot refill until the tick completes.

The existing `TickDownloadAndMeasure()` wake stays. `pendingOnReceive` is set in three places and the throttler registers only one of them; the other two, a read that would block and a read that filled its grant with more still pending, are on the hot path of an actively downloading socket and would lose their only wake-up.

## Test results

30 GB file from a LAN seeder, same peer, same harness, master versus this branch:

| | master | this branch |
|---|---|---|
| Unlimited | 138.41 MiB/s | 139.26 MiB/s |
| Cap 5000 KB/s | 4.68 MiB/s | 4.79 MiB/s |

The cap is still enforced in both. Unlimited differs by 0.6%, which is noise, and structurally cannot be affected: `m_unlimited` short-circuits `Reserve()` before the pause path exists. The capped figure improves slightly because refilling ahead of the part-file walk means the first reads of each tick see a full bucket.

**Limits of these measurements.** Both are a single peer downloading with nothing else contending, which is not the situation the fix targets. Two cases remain unmeasured: a browse running while a download saturates the cap, which is the case this exists for and the likely-common one since people set `MaxDownload` precisely because they download; and a node with many peers, where more sockets park per tick. The ordering above is what makes the first case work, and it is reasoned rather than measured.

Builds monolithic and daemon, 47/47 unit tests, clang-format clean, clang-tidy Tier-1 and Tier-2 clean on the diff.

