### PR TITLE
fix(amuleapi): answer one question one way across the v0 surface

### DIFF
--- a/docs/api/REFERENCE.md
+++ b/docs/api/REFERENCE.md
@@ -360,7 +360,7 @@ A key is **omitted** only where absence itself is the meaning: something the dae
 
 So: `null` means "no value", an absent key means "not reported", and neither is ever spelled `0` or `-1`.
 
-The rule now reaches the whole surface rather than just the download and shared objects. Keys that used to disappear and are `null` instead: `name`, `ip`, `port`, `kad_port`, `country_code`, `software`, `version`, `source_origin`, `obfuscation`, `first_seen` and `sessions` on [`GET /known_clients`](#get-apiv0known_clients); `part_progress_percent` and `parts_offered_count` on the client rows and the `client_*` events; `client_ecid` on [`GET /search`](#get-apiv0search), [`GET /friends`](#get-apiv0friends) and the `friend_*` events; `last_message` on [`GET /chats`](#get-apiv0chats); `token`, `label_value` and `extra` on the statistics tree; and `media` everywhere it appears. The same pass reached the remaining address fields: `port` on [`GET /friends`](#get-apiv0friends) and the `friend_*` events, `ed2k.public_ip` and `ed2k.server_ip` on [`GET /status`](#get-apiv0status), and `public_ip` on [`GET /kad`](#get-apiv0kad); and `server_ip` / `server_port` on [`GET /clients/{ecid}`](#get-apiv0clientsecid), which used `""` for the same "unknown" its own snapshot field documents. Completing that sweep: `ip` and `port` on [`GET /clients`](#get-apiv0clients) and the client detail row, which the `client_*` events already nulled, and `ed2k.server_port` on [`GET /status`](#get-apiv0status), which stayed a bare `0` beside its own nulled `server_ip`. The `status_changed` event nulls `ed2k.public_ip`, `ed2k.server_ip` and `ed2k.server_port` to match the REST row.
+The rule now reaches the whole surface rather than just the download and shared objects. Keys that used to disappear and are `null` instead: `name`, `ip`, `port`, `kad_port`, `country_code`, `software`, `version`, `source_origin`, `obfuscation`, `first_seen` and `sessions` on [`GET /known_clients`](#get-apiv0known_clients); `part_progress_percent` and `parts_offered_count` on the client rows and the `client_*` events; `client_ecid` on [`GET /search`](#get-apiv0search), [`GET /friends`](#get-apiv0friends) and the `friend_*` events; `last_message` on [`GET /chats`](#get-apiv0chats); `token`, `label_value` and `extra` on the statistics tree; and `media` everywhere it appears. The same pass reached the remaining address fields: `port` on [`GET /friends`](#get-apiv0friends) and the `friend_*` events, `ed2k.public_ip` and `ed2k.server_ip` on [`GET /status`](#get-apiv0status), and `public_ip` on [`GET /kad`](#get-apiv0kad); and `server_ip` / `server_port` on [`GET /clients/{ecid}`](#get-apiv0clientsecid), which used `""` for the same "unknown" its own snapshot field documents. Completing that sweep: `ip` and `port` on [`GET /clients`](#get-apiv0clients) and the client detail row, which the `client_*` events already nulled, and `ed2k.server_port` on [`GET /status`](#get-apiv0status), which stayed a bare `0` beside its own nulled `server_ip`. The `status_changed` event nulls `ed2k.public_ip`, `ed2k.server_ip` and `ed2k.server_port` to match the REST row. Continuing it: `kad_port` on [`GET /api/v0/clients/{ecid}`](#get-apiv0clientsecid), which stayed a raw `0` beside the `ip`/`port` it is nulled with everywhere else; `last_received_at` on [`GET /api/v0/downloads/{hash}`](#get-apiv0downloadshash), which read as 1970 for a partfile that had received nothing; and `node_id` on [`GET /api/v0/kad`](#get-apiv0kad), the last `""` sentinel in an object whose every other field already answered `null`.
 
 `media` is the one place this reaches an **object** rather than a scalar, so a client tests `media === null` before reaching into it -- which it had to do regardless, since the object's own fields can be absent.
 
@@ -894,7 +894,7 @@ Same envelope as the list item, plus the detail-only fields below (all omitted f
 |---|---|---|
 | `progress.parts` | array | One entry per ~9.28 MiB chunk: `{ "state": string, "sources": int }` — `state` is `complete`/`pending`/`unavailable` -- `complete` when the chunk is done, `pending` when a gap remains and at least one client offers it, `unavailable` when a gap remains and none does -- and `sources` counts clients offering that chunk. |
 | `last_seen_complete_at` | int \| null | Unix ts a complete copy was last seen across sources; `null` when no complete copy has ever been seen, or the daemon does not report it. |
-| `last_received_at` | int | Unix ts the partfile last received data. |
+| `last_received_at` | int \| null | Unix ts the partfile last received data, `null` when it has never received a byte (see [Unknown values](#unknown-values)). |
 | `active_seconds` | int | Seconds spent actively downloading. |
 | `available_part_count` | int | Number of parts available across the current sources. |
 | `remaining_seconds` | int \| null | ETA in seconds, or `null` when stalled or paused (speed ≈ 0) and there is nothing to compute from. |
@@ -910,7 +910,7 @@ Same envelope as the list item, plus the detail-only fields below (all omitted f
 | `a4af_auto` | bool | Whether automatic A4AF source-swapping is on for this file. See [A4AF](#post-apiv0downloadshasha4af). |
 | `media` | object | Audio/video metadata — see [Media metadata](#media-metadata). **`null`** when the file has no probed metadata; the key is always present. |
 
-**Errors:** `404 not_found` (no partfile with that hash), `503 ec_unavailable`.
+**Errors:** `400 bad_request` (`{hash}` is not 32 hex characters), `404 not_found` (no partfile with that hash), `503 ec_unavailable`.
 
 ##### Media metadata
 
@@ -971,7 +971,7 @@ A per-source `rating` of `-1` means the source left a comment but no rating. Rat
 | 4 | Good |
 | 5 | Excellent |
 
-**Errors:** `404 not_found` (no download with that hash), `503 ec_unavailable`.
+**Errors:** `400 bad_request` (`{hash}` is not 32 hex characters), `404 not_found` (no download with that hash), `503 ec_unavailable`.
 
 #### `POST /api/v0/downloads/{hash}/comments`
 
@@ -1164,7 +1164,7 @@ curl -s -X PATCH -H "Authorization: Bearer $TOKEN" \
 
 **Response:** `200 OK` — the updated download object (full detail envelope including `progress.parts`).
 
-**Errors:** `400 bad_request` (no recognised field, invalid enum, or `my_comment`/`my_rating` sent alone), `409 not_shared` (comment/rating on a non-shared file), `400 amuled_rejected`, `404 not_found`, `503 ec_unavailable`.
+**Errors:** `400 bad_request` (`{hash}` is not 32 hex characters, no recognised field, invalid enum, or `my_comment`/`my_rating` sent alone), `409 not_shared` (comment/rating on a non-shared file), `400 amuled_rejected`, `404 not_found`, `503 ec_unavailable`.
 
 #### `DELETE /api/v0/downloads/{hash}`
 
@@ -1179,7 +1179,7 @@ curl -s -X DELETE -H "Authorization: Bearer $TOKEN" \
 
 **Response:** `204 No Content`.
 
-**Errors:** `400 amuled_rejected`, `404 not_found`, `409 download_completed`, `503 ec_unavailable`.
+**Errors:** `400 bad_request` (`{hash}` is not 32 hex characters), `400 amuled_rejected`, `404 not_found`, `409 download_completed`, `503 ec_unavailable`.
 
 #### `POST /api/v0/downloads_clear_completed`
 
@@ -1363,7 +1363,7 @@ curl -s -H "Authorization: Bearer $TOKEN" \
 }
 ```
 
-The detail fields mirror the desktop "Client Details" modal. Five of the fields below — `source_origin`, `parts_offered_count`, `client_mod_name`, `shared_files_browsable` and `part_progress_percent` — are **not** detail-only: they are on the [`GET /clients`](#get-apiv0clients) row and the SSE payload too, and are described here because this is where the rest of their neighbours live. `ed2k_user_id` is the client's hybrid eD2k id; `high_id` is `true` for a HighID client (id ≥ `16777216`, i.e. `0x1000000`) and `false` for LowID — the same threshold and the same spelling as `ed2k.high_id` on [`GET /status`](#get-apiv0status), so the value means the same thing on both ends of the API. `server_ip` / `server_port` / `server_name` describe the eD2k server the client connects through; `server_ip` and `server_port` are `null` together when the server is unknown. `kad_port` is non-zero when the client is reachable on Kad. `source_origin` is how the client was discovered (values in the enumerated-fields table under [`GET /clients`](#get-apiv0clients)). (`upload_file_name` is part of the base field set — see [`GET /clients`](#get-apiv0clients) above.) `parts_offered_count` is the count of parts the client holds of the linked file, or `null` when the client has not reported a part map (see [Unknown values](#unknown-values)); `client_mod_name` is the client's client-mod string (often `""`); `shared_files_browsable` is `true` when the client allows browsing its shared files, and `false` when it forbids it. `friend` is `true` when the client is in your friends list (`CUpDownClient::IsFriend()`) — **distinct** from `friend_slot`, which is a *reserved upload slot* granted to a client and can be set for non-friends. `credit_ratio` is the upload score modifier the GUI labels "DL/UP modifier" (`GetScoreRatio()`). `part_progress_percent` is the client's completeness of the file we are downloading **from** them (`parts_offered_count` over that file's part count) and is `null` when there is no linked download or the part count is unknown (see [Unknown values](#unknown-values)).
+The detail fields mirror the desktop "Client Details" modal. Five of the fields below — `source_origin`, `parts_offered_count`, `client_mod_name`, `shared_files_browsable` and `part_progress_percent` — are **not** detail-only: they are on the [`GET /clients`](#get-apiv0clients) row and the SSE payload too, and are described here because this is where the rest of their neighbours live. `ed2k_user_id` is the client's hybrid eD2k id; `high_id` is `true` for a HighID client (id ≥ `16777216`, i.e. `0x1000000`) and `false` for LowID — the same threshold and the same spelling as `ed2k.high_id` on [`GET /status`](#get-apiv0status), so the value means the same thing on both ends of the API. `server_ip` / `server_port` / `server_name` describe the eD2k server the client connects through; `server_ip` and `server_port` are `null` together when the server is unknown. `kad_port` is non-zero when the client is reachable on Kad, and `null` when the client has no recorded address at all — it is nulled together with `ip` and `port`, the way [`GET /known_clients`](#get-apiv0known_clients) has always nulled the three. `source_origin` is how the client was discovered (values in the enumerated-fields table under [`GET /clients`](#get-apiv0clients)). (`upload_file_name` is part of the base field set — see [`GET /clients`](#get-apiv0clients) above.) `parts_offered_count` is the count of parts the client holds of the linked file, or `null` when the client has not reported a part map (see [Unknown values](#unknown-values)); `client_mod_name` is the client's client-mod string (often `""`); `shared_files_browsable` is `true` when the client allows browsing its shared files, and `false` when it forbids it. `friend` is `true` when the client is in your friends list (`CUpDownClient::IsFriend()`) — **distinct** from `friend_slot`, which is a *reserved upload slot* granted to a client and can be set for non-friends. `credit_ratio` is the upload score modifier the GUI labels "DL/UP modifier" (`GetScoreRatio()`). `part_progress_percent` is the client's completeness of the file we are downloading **from** them (`parts_offered_count` over that file's part count) and is `null` when there is no linked download or the part count is unknown (see [Unknown values](#unknown-values)).
 
 > `friend` and `credit_ratio` ride two EC tags added for this endpoint. A webapi built against a newer core talking to an **older** amuled that doesn't send them degrades gracefully — `friend` reads `false` and `credit_ratio` reads `0`.
 
@@ -1588,7 +1588,7 @@ This is deliberately detail-only. A 100 GB file has ~10 800 parts, so carrying t
 
 For a shared file that is also still downloading, the same values are available as `progress.parts[].sources` on [`GET /downloads/{hash}`](#get-apiv0downloadshash); both come from one encoder in amuled, so they agree.
 
-**Errors:** `404 not_found` (no shared file with that hash), `503 ec_unavailable`.
+**Errors:** `400 bad_request` (`{hash}` is not 32 hex characters), `404 not_found` (no shared file with that hash), `503 ec_unavailable`.
 
 #### `GET /api/v0/shared/{hash}/content`
 
@@ -1870,7 +1870,7 @@ Send a bare priority level to pin it (the file's `priority_auto` becomes `false`
 
 `name` renames the file — a non-empty string with no path separators (`/` or `\`, rejected to prevent the rename escaping the file's directory). Rename works on any known file, so it is accepted on both this endpoint and [`PATCH /downloads/{hash}`](#patch-apiv0downloadshash).
 
-**Errors:** `400 bad_request` (missing/invalid fields, `my_comment`/`my_rating` sent alone, or a `name` that is empty or contains a path separator), `404 not_found` (no shared file with that hash), `409 not_shared` (comment/rating on a non-shared file), `400 amuled_rejected`, `503 ec_unavailable`.
+**Errors:** `400 bad_request` (`{hash}` is not 32 hex characters, missing/invalid fields, `my_comment`/`my_rating` sent alone, or a `name` that is empty or contains a path separator), `404 not_found` (no shared file with that hash), `409 not_shared` (comment/rating on a non-shared file), `400 amuled_rejected`, `503 ec_unavailable`.
 
 ---
 
@@ -2104,7 +2104,7 @@ Promote a connected client:
 { "client_ecid": 4382 }
 ```
 
-Or add by address, where `ip` and `port` are required and non-zero, `user_hash` must be 32 hexadecimal characters when given, and `name` defaults to the address:
+Or add by address, where `ip` and `port` are required and `port` is an integer in `1..65535` (the same contract [`POST /api/v0/kad/bootstrap`](#post-apiv0kadbootstrap) enforces), `user_hash` must be 32 hexadecimal characters when given, and `name` defaults to the address:
 
 ```json
 { "ip": "203.0.113.42", "port": 4662, "name": "alice", "user_hash": "a1b2c3d4e5060e708090a0b0c0d06f00" }
@@ -2495,7 +2495,7 @@ curl -s -X POST -H "Authorization: Bearer $TOKEN" \
 
 The echo is the documented exception to the no-body rule for actions: it reports **which address the daemon parsed**, which the caller cannot read back anywhere else. `ip` comes back as a dotted quad whichever form the request used -- answering with the host-order integer meant a client that posted `"1.2.3.4"` and stored the reply held `16909060`, a value no other field on this surface produces and one it could not post back without converting.
 
-**Errors:** `400 bad_request` (missing `ip`, or an `ip` that is not a string — a numeric one included, missing/non-numeric `port`, port outside `[0, 65535]`, malformed dotted-quad), `400 amuled_rejected`, `503 ec_unavailable`.
+**Errors:** `400 bad_request` (missing `ip`, or an `ip` that is not a string — a numeric one included, missing/non-integer `port`, port outside `1..65535`, malformed dotted-quad), `400 amuled_rejected`, `503 ec_unavailable`.
 
 #### `POST /api/v0/kad/update`
 
@@ -2546,7 +2546,7 @@ Standalone view of the Kad subtree from `/status`, plus the detail fields the st
 | Field | Type | Meaning |
 |---|---|---|
 | `state` | string | `disabled` / `connecting` / `connected`. `disabled` means Kad is not running at all, which is the condition several fields below key their "no measurement" value on. The same value `GET /api/v0/status` reports as `kad.state`. |
-| `node_id` | string | This node's own 128-bit Kademlia id, 32 lowercase hex characters (the desktop panel shows the same value uppercase). `""` while Kad is not running, which is exactly when `state` is `disabled`. Persisted by the daemon, so unlike the session-scoped ECIDs and the server-assigned eD2k id it is stable across restarts — the one identifier for the local node a consumer can key on. It is a DHT routing key, not a credential: every Kad contact the daemon talks to learns it. |
+| `node_id` | string \| null | This node's own 128-bit Kademlia id, 32 lowercase hex characters (the desktop panel shows the same value uppercase). `null` while Kad is not running, which is exactly when `state` is `disabled`. Persisted by the daemon, so unlike the session-scoped ECIDs and the server-assigned eD2k id it is stable across restarts — the one identifier for the local node a consumer can key on. It is a DHT routing key, not a credential: every Kad contact the daemon talks to learns it. |
 | `connected_since_at` | int | Unix seconds of the most recent Kad connect, the same value `GET /api/v0/status` reports as `kad.connected_since`. `0` when not connected, so gate on `state` rather than trusting a `0`. |
 | `public_ip` | string | This node's externally-visible IPv4, as a remote Kad contact reported it back. Two "not known" cases, both matching what the desktop panel's *IP address* row shows: `null` while Kad is not connected (the daemon sends the field only then), and `0.0.0.0` while connected but not yet told its own address by any contact. **Two distinct "unknown" sentinels, one of them a syntactically valid address**: a consumer that only checks for `null` will treat `0.0.0.0` as a real IP. Distinct from `preferences.connection.bind_address`, which is the local interface the daemon binds to. Named `public_ip` rather than `ip` because `buddy.ip` in the same payload belongs to somebody else. |
 | `firewalled_tcp` | bool \| null | Whether this node is firewalled for **TCP**. The verdict is a **vote**: two distinct clients must confirm reachability by opening an incoming TCP connection carrying `OP_KAD_FWTCPCHECK_ACK` before it clears to `false`. With no verdict yet it reads **`true`**, the conservative assumption. During an IP recheck it freezes at its previous value rather than momentarily reporting a false LowID. **`null` unless `state` is `connected`** - the underlying bit outlives a disconnect, so this used to report a reachability verdict for a network the daemon was not on. Named for the transport because it is one half of a pair, not an overall verdict that `firewalled_udp` refines. |
@@ -2909,7 +2909,7 @@ Kicks off a new search. amuleapi supports **several concurrent searches** — a 
 }
 ```
 
-Only `query` is required. `type` defaults to `"global"`; valid values are `"local"`, `"global"`, `"kad"`. A `"global"`/`"local"` (ed2k) search and a `"kad"` search run independently and can be in flight at the same time; starting one never disturbs the other.
+Only `query` is required. `type` defaults to `"global"`; valid values are `"local"`, `"global"`, `"kad"`. `min_size_bytes`, `max_size_bytes` and `min_source_count` are integers: a fractional value is a `400` rather than being truncated, so a client that computed a size cannot half-apply a filter it thinks it set. A `"global"`/`"local"` (ed2k) search and a `"kad"` search run independently and can be in flight at the same time; starting one never disturbs the other.
 
 **Response:** `202 Accepted`, with a `Location: /api/v0/search/{search_id}` header and the created search as the body -- the same row [`GET /search`](#get-apiv0search) lists, so it can go straight into a collection the client already keeps:
 
@@ -3089,7 +3089,7 @@ The route is deliberately **not** nested under a search id: amuled runs one Kad 
 
 **Polling is the only mechanism here — there is no event to wait for.** [`comments_updated`](EVENTS.md#comments_updated) is emitted for downloads only and never fires for a search hit, so a client that starts a lookup polls this endpoint (or the results list) while `kad_comment_lookup_running` is `true`.
 
-**Errors:** `404 not_found` (no live search result with that hash), `503 ec_unavailable`.
+**Errors:** `400 bad_request` (`{hash}` is not 32 hex characters), `404 not_found` (no live search result with that hash), `503 ec_unavailable`.
 
 #### `POST /api/v0/search/results/{hash}/comments`
 

--- a/src/webapi/Api.cpp
+++ b/src/webapi/Api.cpp
@@ -44,6 +44,7 @@
 #include "StaticFs.h"      // IsDir, ResolveWithinRoot
 #include "SharedContent.h" // /shared/{hash}/content: path resolution, Range, disposition
 #include "PartIndex.h"     // UsablePartIndex / UsableLastDownloadingPart, unit-tested standalone
+#include <cmath>
 #include <cstring>
 #include <map>
 
@@ -3002,8 +3003,14 @@ void WriteDownloadObject(
 			"last_seen_complete_at",
 			f.download.last_seen_complete_at != 0,
 			static_cast<std::int64_t>(f.download.last_seen_complete_at));
-		w.Key("last_received_at");
-		w.ValueInt(static_cast<int64_t>(f.download.last_received_at));
+		// Same rule as the timestamp above: 0 is "no byte has arrived yet",
+		// which is not a 1970 date. It defaults to 0 and is only set when
+		// amuled ships the tag, so a partfile that has received nothing
+		// would otherwise date to the epoch.
+		WriteIntOrNull(w,
+			"last_received_at",
+			f.download.last_received_at != 0,
+			static_cast<std::int64_t>(f.download.last_received_at));
 		w.Key("active_seconds");
 		w.ValueInt(static_cast<int64_t>(f.download.active_seconds));
 		w.Key("available_part_count");
@@ -3265,8 +3272,11 @@ void WriteClientDetailObject(CJsonWriter &w, const webapi::ClientSnapshot &c)
 	WriteIntOrNull(w, "server_port", has_server, static_cast<int64_t>(c.server_port));
 	w.Key("server_name");
 	w.ValueString(wxString::FromUTF8(c.server_name.c_str()));
-	w.Key("kad_port");
-	w.ValueInt(static_cast<int64_t>(c.kad_port));
+	// Nulled on the same condition WriteClientBaseFields nulls ip/port, and
+	// the same one WriteKnownClientObject uses: a client with no recorded
+	// address has no recorded Kad port either, and a raw 0 here would spell
+	// absence differently from the very fields it is paired with.
+	WriteIntOrNull(w, "kad_port", !c.ip.empty(), static_cast<int64_t>(c.kad_port));
 	// Friend status + the credit-system modifier (issue #423). `friend` is
 	// friends-list membership, distinct from the `friend_slot` reserved
 	// upload slot above.
@@ -4155,6 +4165,17 @@ CHttpServer::Response UrlFetchOp(
 	return r;
 }
 
+// JSON has one number type and picojson hands every one of them over as a
+// double, so a body field documented as an integer has to say so itself:
+// without this, `{"min_size_bytes": 2.9}` is accepted and silently truncated
+// to 2. One helper rather than a cast per site: `v != (double)(int)v` cannot
+// judge a byte count above INT_MAX, which is exactly the range the size
+// fields live in.
+inline bool IsIntegralJsonNumber(double v)
+{
+	return std::isfinite(v) && v == std::floor(v);
+}
+
 // MD4 hex string → CMD4Hash. Returns false if the string isn't 32
 // lowercase-or-uppercase hex chars (we tolerate both cases; the
 // route already lowercases what comes off the URL).
@@ -4163,6 +4184,23 @@ bool HashFromHex(const std::string &hex, CMD4Hash &out)
 	if (hex.size() != 32)
 		return false;
 	return out.Decode(wxString::FromAscii(hex.c_str()));
+}
+
+// The {hash} twin of RequireEcidPath: a path hash that is not 32 hex
+// characters is a malformed request, not a missing file. The find-based
+// routes used to skip the format check and fall through to their own 404,
+// so a client could not tell "not a hash" from "valid hash, no such file" --
+// and the split ran through a single route, GET
+// /search/results/{hash}/comments answering 404 where its own POST answered
+// 400. Same reason RequireEcidPath exists: the status, the code and the
+// sentence are contract, not local wording.
+std::unique_ptr<CHttpServer::Response> RequireHashPath(const std::string &hash)
+{
+	CMD4Hash parsed;
+	if (!HashFromHex(hash, parsed)) {
+		return BadRequestPtr("path `{hash}` must be 32 hex characters");
+	}
+	return nullptr;
 }
 
 } // namespace
@@ -4643,6 +4681,9 @@ CHttpServer::Response CApiDispatcher::HandleDownloadDetail(
 	if (!a.ok)
 		return a.rejection;
 
+	if (auto r = RequireHashPath(key))
+		return *r;
+
 	if (auto r = RequireSnapshot(m_state))
 		return *r;
 
@@ -4678,6 +4719,9 @@ CHttpServer::Response CApiDispatcher::HandleSharedDetail(
 	if (!a.ok)
 		return a.rejection;
 
+	if (auto r = RequireHashPath(key))
+		return *r;
+
 	if (auto r = RequireSnapshot(m_state))
 		return *r;
 
@@ -4707,6 +4751,9 @@ CHttpServer::Response CApiDispatcher::HandleDownloadComments(
 	auto a = Authenticate(req);
 	if (!a.ok)
 		return a.rejection;
+
+	if (auto r = RequireHashPath(key))
+		return *r;
 
 	if (auto r = RequireSnapshot(m_state))
 		return *r;
@@ -5234,7 +5281,7 @@ CHttpServer::Response CApiDispatcher::HandleDownloadAdd(const CHttpServer::Reque
 			const double v = it->second.get<double>();
 			// The integrality test the message already promises: without it
 			// 2.9 was accepted and truncated to 2.
-			if (v < 0 || v > 255 || v != static_cast<double>(static_cast<int>(v))) {
+			if (v < 0 || v > 255 || !IsIntegralJsonNumber(v)) {
 				return ErrorResponse(
 					400, "bad_request", "`category_index` must be in [0, 255]");
 			}
@@ -5427,8 +5474,11 @@ CHttpServer::Response CApiDispatcher::HandleDownloadPatch(
 	auto a = Authenticate(req);
 	if (!a.ok)
 		return a.rejection;
+
 	if (auto rej = RequireAdmin(a))
 		return *rej;
+	if (auto r = RequireHashPath(key))
+		return *r;
 
 	if (auto r = RequireSnapshot(m_state))
 		return *r;
@@ -5520,8 +5570,7 @@ CHttpServer::Response CApiDispatcher::HandleDownloadPatch(
 		const auto it = obj.find("priority");
 		if (it != obj.end()) {
 			if (!it->second.is<std::string>()) {
-				return ErrorResponse(
-					400, "bad_request", "`priority` must be a wire-string enum");
+				return ErrorResponse(400, "bad_request", "`priority` must be a string");
 			}
 			std::uint8_t code = 0;
 			if (!FilePriorityToCode(it->second.get<std::string>(), kPrioDownload, code)) {
@@ -5548,7 +5597,7 @@ CHttpServer::Response CApiDispatcher::HandleDownloadPatch(
 			const double v = it->second.get<double>();
 			// The integrality test the message already promises: without it
 			// 2.9 was accepted and truncated to 2.
-			if (v < 0 || v > 255 || v != static_cast<double>(static_cast<int>(v))) {
+			if (v < 0 || v > 255 || !IsIntegralJsonNumber(v)) {
 				return ErrorResponse(
 					400, "bad_request", "`category_index` must be in [0, 255]");
 			}
@@ -5652,8 +5701,11 @@ CHttpServer::Response CApiDispatcher::HandleDownloadDelete(
 	auto a = Authenticate(req);
 	if (!a.ok)
 		return a.rejection;
+
 	if (auto rej = RequireAdmin(a))
 		return *rej;
+	if (auto r = RequireHashPath(key))
+		return *r;
 
 	if (auto r = RequireSnapshot(m_state))
 		return *r;
@@ -6769,8 +6821,9 @@ CHttpServer::Response CApiDispatcher::HandleFriendAdd(const CHttpServer::Request
 					400, "bad_request", "required integer field `port` is missing");
 			}
 			const double d = it->second.get<double>();
-			if (d <= 0 || d > 65535) {
-				return ErrorResponse(400, "bad_request", "`port` must be in 1..65535");
+			if (!IsIntegralJsonNumber(d) || d < 1 || d > 65535) {
+				return ErrorResponse(
+					400, "bad_request", "`port` must be an integer in 1..65535");
 			}
 			port = static_cast<std::uint16_t>(d);
 		}
@@ -7445,12 +7498,13 @@ CHttpServer::Response CApiDispatcher::HandleKad(const CHttpServer::Request &req)
 	// Bare object (Q3 — Kad is a single resource, not a list).
 	w.Key("state");
 	w.ValueString(wxString::FromUTF8(k.state.c_str()));
-	// Our own Kademlia node id, "" while Kad is not running (i.e.
+	// Our own Kademlia node id, null while Kad is not running (i.e.
 	// exactly when `state` is "disabled"). Persisted by the daemon,
 	// so unlike every other identifier for the local node it is
-	// stable across restarts.
-	w.Key("node_id");
-	w.ValueString(wxString::FromUTF8(k.node_id.c_str()));
+	// stable across restarts. Null rather than "": every other field
+	// in this object spells absence that way, and an empty string is
+	// not a value a node id can take.
+	WriteStringOrNull(w, "node_id", !k.node_id.empty(), k.node_id);
 	// Two independent measurements, not a verdict and a refinement.
 	// firewalled_tcp is a vote needing two peers to confirm reachability;
 	// firewalled_udp is a directed test. LAN mode forces both to false.
@@ -9358,11 +9412,14 @@ CHttpServer::Response CApiDispatcher::HandleKadBootstrap(const CHttpServer::Requ
 	{
 		const auto it = obj.find("port");
 		if (it == obj.end() || !it->second.is<double>()) {
-			return ErrorResponse(400, "bad_request", "required numeric field `port` is missing");
+			return ErrorResponse(400, "bad_request", "required integer field `port` is missing");
 		}
 		const double v = it->second.get<double>();
-		if (v < 0 || v > 65535) {
-			return ErrorResponse(400, "bad_request", "`port` must be in [0, 65535]");
+		// Same contract as the `port` on POST /friends: one spelling, one
+		// range. 0 used to be accepted here, which no Kad contact can be
+		// reached on -- the probe was sent and silently went nowhere.
+		if (!IsIntegralJsonNumber(v) || v < 1 || v > 65535) {
+			return ErrorResponse(400, "bad_request", "`port` must be an integer in 1..65535");
 		}
 		port = static_cast<std::uint16_t>(v);
 	}
@@ -9415,8 +9472,11 @@ CHttpServer::Response CApiDispatcher::HandleSharedPatch(
 	auto a = Authenticate(req);
 	if (!a.ok)
 		return a.rejection;
+
 	if (auto rej = RequireAdmin(a))
 		return *rej;
+	if (auto r = RequireHashPath(key))
+		return *r;
 
 	if (auto r = RequireSnapshot(m_state))
 		return *r;
@@ -9439,7 +9499,7 @@ CHttpServer::Response CApiDispatcher::HandleSharedPatch(
 	const auto pit = obj.find("priority");
 	if (pit != obj.end()) {
 		if (!pit->second.is<std::string>()) {
-			return ErrorResponse(400, "bad_request", "`priority` must be a wire-string enum");
+			return ErrorResponse(400, "bad_request", "`priority` must be a string");
 		}
 		std::uint8_t code = 0;
 		if (!FilePriorityToCode(pit->second.get<std::string>(), kPrioShared, code)) {
@@ -9582,8 +9642,7 @@ CHttpServer::Response CApiDispatcher::HandleDownloadsBulkPatch(const CHttpServer
 		const auto it = obj.find("priority");
 		if (it != obj.end()) {
 			if (!it->second.is<std::string>())
-				return ErrorResponse(
-					400, "bad_request", "`priority` must be a wire-string enum");
+				return ErrorResponse(400, "bad_request", "`priority` must be a string");
 			std::uint8_t code = 0;
 			if (!FilePriorityToCode(it->second.get<std::string>(), kPrioDownload, code))
 				return ErrorResponse(
@@ -9601,7 +9660,7 @@ CHttpServer::Response CApiDispatcher::HandleDownloadsBulkPatch(const CHttpServer
 			const double v = it->second.get<double>();
 			// The integrality test the message already promises: without it
 			// 2.9 was accepted and truncated to 2.
-			if (v < 0 || v > 255 || v != static_cast<double>(static_cast<int>(v)))
+			if (v < 0 || v > 255 || !IsIntegralJsonNumber(v))
 				return ErrorResponse(
 					400, "bad_request", "`category_index` must be in [0, 255]");
 			ops.push_back({ EC_OP_PARTFILE_SET_CAT,
@@ -9753,7 +9812,7 @@ CHttpServer::Response CApiDispatcher::HandleSharedBulkPatch(const CHttpServer::R
 	if (pit == obj.end())
 		return ErrorResponse(400, "bad_request", "request body must include `priority`");
 	if (!pit->second.is<std::string>())
-		return ErrorResponse(400, "bad_request", "`priority` must be a wire-string enum");
+		return ErrorResponse(400, "bad_request", "`priority` must be a string");
 	std::uint8_t code = 0;
 	if (!FilePriorityToCode(pit->second.get<std::string>(), kPrioShared, code))
 		return ErrorResponse(400, "bad_request", FilePriorityAccepted(kPrioShared).c_str());
@@ -10749,8 +10808,7 @@ CHttpServer::Response ParseCategoryFields(const picojson::object &obj, CategoryF
 		const auto it = obj.find("priority");
 		if (it != obj.end()) {
 			if (!it->second.is<std::string>()) {
-				return ErrorResponse(
-					400, "bad_request", "`priority` must be a wire-string enum");
+				return ErrorResponse(400, "bad_request", "`priority` must be a string");
 			}
 			if (!FilePriorityToCode(it->second.get<std::string>(), kPrioCategory, out.prio)) {
 				return ErrorResponse(
@@ -11250,8 +11308,10 @@ CHttpServer::Response CApiDispatcher::HandleSearchStart(const CHttpServer::Reque
 					"`min_size_bytes` must be a non-negative integer (bytes)");
 			}
 			const double v = it->second.get<double>();
-			if (v < 0)
-				return ErrorResponse(400, "bad_request", "`min_size_bytes` must be >= 0");
+			if (!IsIntegralJsonNumber(v) || v < 0)
+				return ErrorResponse(400,
+					"bad_request",
+					"`min_size_bytes` must be a non-negative integer");
 			min_size = static_cast<std::uint64_t>(v);
 		}
 	}
@@ -11265,8 +11325,10 @@ CHttpServer::Response CApiDispatcher::HandleSearchStart(const CHttpServer::Reque
 					"cap)");
 			}
 			const double v = it->second.get<double>();
-			if (v < 0)
-				return ErrorResponse(400, "bad_request", "`max_size_bytes` must be >= 0");
+			if (!IsIntegralJsonNumber(v) || v < 0)
+				return ErrorResponse(400,
+					"bad_request",
+					"`max_size_bytes` must be a non-negative integer");
 			max_size = static_cast<std::uint64_t>(v);
 		}
 	}
@@ -11279,6 +11341,11 @@ CHttpServer::Response CApiDispatcher::HandleSearchStart(const CHttpServer::Reque
 					"`min_source_count` must be a non-negative integer");
 			}
 			const double v = it->second.get<double>();
+			if (!IsIntegralJsonNumber(v)) {
+				return ErrorResponse(400,
+					"bad_request",
+					"`min_source_count` must be a non-negative integer");
+			}
 			if (v < 0 || v > 4294967295.0) {
 				return ErrorResponse(400, "bad_request", "`min_source_count` out of range");
 			}
@@ -11532,7 +11599,7 @@ CHttpServer::Response CApiDispatcher::HandleSearchDownload(
 			const double v = it->second.get<double>();
 			// The integrality test the message already promises: without it
 			// 2.9 was accepted and truncated to 2.
-			if (v < 0 || v > 255 || v != static_cast<double>(static_cast<int>(v))) {
+			if (v < 0 || v > 255 || !IsIntegralJsonNumber(v)) {
 				return ErrorResponse(
 					400, "bad_request", "`category_index` must be in [0, 255]");
 			}
@@ -11545,6 +11612,10 @@ CHttpServer::Response CApiDispatcher::HandleSearchDownload(
 					400, "bad_request", "`ecid` must be a non-negative integer");
 			}
 			const double v = eit->second.get<double>();
+			if (!IsIntegralJsonNumber(v)) {
+				return ErrorResponse(
+					400, "bad_request", "`ecid` must be a non-negative integer");
+			}
 			if (v < 0 || v > 4294967295.0) {
 				return ErrorResponse(400, "bad_request", "`ecid` out of range");
 			}
@@ -11599,6 +11670,9 @@ CHttpServer::Response CApiDispatcher::HandleSearchComments(
 	auto a = Authenticate(req);
 	if (!a.ok)
 		return a.rejection;
+
+	if (auto r = RequireHashPath(hash))
+		return *r;
 
 	if (auto r = RequireSnapshot(m_state))
 		return *r;

--- a/unittests/curl-tests/amuleapi/05-read-servers-kad-categories-prefs.sh
+++ b/unittests/curl-tests/amuleapi/05-read-servers-kad-categories-prefs.sh
@@ -173,12 +173,14 @@ _assert_json_eq '.connected_since_at | type' number  '/kad.connected_since_ate i
 _assert_json_eq '.public_ip | type | . == "string" or . == "null"' true \
 	'/kad.public_ip is a string or null'
 _assert_json_eq '.ip               | type' null    '/kad has no bare top-level ip'
-# 32 lowercase hex while Kad runs, "" while it does not -- gated on .state,
-# which is "disabled" exactly when amuled withholds EC_TAG_KAD_ID.
+# 32 lowercase hex while Kad runs, null while it does not -- gated on .state,
+# which is "disabled" exactly when amuled withholds EC_TAG_KAD_ID. Null, not
+# "": every other field in this object already spells absence that way, and
+# an empty string is not a value a node id can take.
 _assert_json_eq '(.state == "disabled") or (.node_id | test("^[0-9a-f]{32}$"))' \
 	true '/kad.node_id is 32 lowercase hex chars while Kad runs'
-_assert_json_eq '(.state != "disabled") or (.node_id == "")' \
-	true '/kad.node_id is empty while Kad is not running'
+_assert_json_eq '(.state != "disabled") or (.node_id == null)' \
+	true '/kad.node_id is null while Kad is not running'
 # The network rollup and the store counters, both gated on being connected.
 # `nodes` is the sharp one: it is this node's OWN routing-table size, and
 # contacts outlive a disconnect, so it was measured at 2 on a fully stopped Kad

--- a/unittests/curl-tests/amuleapi/42-path-and-body-contracts.sh
+++ b/unittests/curl-tests/amuleapi/42-path-and-body-contracts.sh
@@ -225,16 +225,16 @@ else
 	_skip 'client detail kad_port check: every connected client has an address'
 fi
 
-_curl -H "$AUTH" "$HOST/api/v0/downloads?limit=50"
-FRESH_HASH=$(printf '%s' "$CURL_BODY" \
-	| jq -r 'first(.downloads[]? | select(.completed_bytes == 0) | .hash) // empty')
-if [ -n "$FRESH_HASH" ]; then
-	_curl -H "$AUTH" "$HOST/api/v0/downloads/$FRESH_HASH"
-	_assert_json_eq '.last_received_at' null \
-		'download that has received nothing nulls last_received_at'
-else
-	_skip 'last_received_at null check: no download with 0 bytes received'
-fi
+# `last_received_at` is the partfile's last-changed stamp, which amuled sets
+# even for a download that has transferred nothing -- so "0 bytes received"
+# is NOT the never-case and cannot be used to find one. What the contract
+# forbids is the raw 0 itself: the serializer maps it to null, because a
+# unix 0 reads as 1970 rather than as "never". Assert that no row carries
+# one, which holds on any daemon state and fails the moment the mapping is
+# dropped.
+_curl -H "$AUTH" "$HOST/api/v0/downloads?limit=200"
+_assert_json_eq '[.downloads[]? | select(.last_received_at == 0)] | length' 0 \
+	'no download reports last_received_at as a raw 0 (the never-case is null)'
 
 # --- Summary. -----------------------------------------------------
 echo

--- a/unittests/curl-tests/amuleapi/42-path-and-body-contracts.sh
+++ b/unittests/curl-tests/amuleapi/42-path-and-body-contracts.sh
@@ -1,0 +1,248 @@
+#!/usr/bin/env bash
+#
+# amuleapi 42-path-and-body-contracts — the two contracts that are stated
+# once and have to hold everywhere.
+#
+# 1. A `{hash}` that is not 32 hex characters is a MALFORMED REQUEST, so it
+#    answers `400 bad_request`, on every route that takes one. The
+#    find-based routes used to skip the format check and fall through to
+#    their own `404`, which left a client unable to tell "not a hash" from
+#    "valid hash, no such file" -- and the split ran through a single route:
+#    `GET /search/results/{hash}/comments` answered `404` where its own
+#    `POST` answered `400`. `{ecid}` has always drawn this line
+#    (`RequireEcidPath`); these are its hash twin.
+#
+# 2. A body field documented as an integer rejects a fractional value
+#    instead of truncating it. JSON has one number type, so `2.9` reaches
+#    the handler as a double and a bare cast turns a filter the client
+#    thinks it set into a different one.
+#
+# The `404` half of contract 1 is asserted too: a well-formed hash that
+# names nothing must still be `404`, or the guard would have turned every
+# missing file into a bad request.
+set -u
+set -o pipefail
+
+HOST=${HOST:-localhost:4713}
+ADMIN_PASS=${ADMIN_PASS:-adminpass}
+
+# Well-formed, and nothing on this surface can hold it: 32 hex characters.
+ABSENT_HASH=00000000000000000000000000000000
+# Malformed three ways: too short, non-hex characters, right length but
+# with a non-hex character in it.
+SHORT_HASH=deadbeef
+NONHEX_HASH=zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz
+ALMOST_HASH=0000000000000000000000000000000g
+
+FAIL_COUNT=0
+TEST_COUNT=0
+# Counted apart from TEST_COUNT: a skipped check is coverage that did not
+# happen, and folding it into the passed tally would report the absence of
+# a check as a check that succeeded.
+SKIP_COUNT=0
+
+CURL_BODY_FILE=$(mktemp -t amuleapi_42_contracts_body.XXXXXX)
+trap 'rm -f "$CURL_BODY_FILE"' EXIT
+
+_die()  { echo "FATAL: $*" >&2; exit 2; }
+_pass() { TEST_COUNT=$((TEST_COUNT+1)); echo "  PASS  $1"; }
+_fail() {
+	TEST_COUNT=$((TEST_COUNT+1)); FAIL_COUNT=$((FAIL_COUNT+1))
+	echo "  FAIL  $1"
+	shift
+	for arg in "$@"; do echo "        $arg"; done
+}
+_skip() { SKIP_COUNT=$((SKIP_COUNT+1)); echo "  SKIP  $1"; }
+
+_curl() {
+	local resp
+	resp=$(curl -s --max-time 10 -o "$CURL_BODY_FILE" -w '%{http_code}' "$@") \
+		|| _die "curl invocation failed for $*"
+	CURL_STATUS=$resp
+	CURL_BODY=$(cat "$CURL_BODY_FILE")
+}
+
+_assert_status() {
+	local expected=$1 label=$2
+	if [ "$CURL_STATUS" = "$expected" ]; then
+		_pass "$label (HTTP $CURL_STATUS)"
+	else
+		_fail "$label" "expected HTTP $expected, got $CURL_STATUS" \
+			"body head: $(printf '%s' "$CURL_BODY" | head -c 200)"
+	fi
+}
+
+# A bare 400 does not prove the validator rejected the body: a daemon with
+# its networks disabled answers `400 amuled_rejected` to a perfectly
+# well-formed search or bootstrap. Every body-contract check below asserts
+# the error CODE too, so it means the same thing on a connected daemon and
+# on an idle one.
+_assert_bad_request() {
+	local label=$1
+	_assert_status 400 "$label"
+	_assert_json_eq '.error.code' bad_request "$label names bad_request"
+}
+
+_assert_json_eq() {
+	local expr=$1 expected=$2 label=$3
+	local actual
+	actual=$(printf '%s' "$CURL_BODY" | jq -r "$expr" 2>/dev/null) \
+		|| { _fail "$label" "body was not valid JSON" "body: $CURL_BODY"; return; }
+	if [ "$actual" = "$expected" ]; then
+		_pass "$label"
+	else
+		_fail "$label" "expected $expected, got $actual" "body: $CURL_BODY"
+	fi
+}
+
+if ! command -v jq >/dev/null 2>&1; then _die "jq is required."; fi
+
+echo "amuleapi 42-path-and-body-contracts smoke @ $HOST"
+
+ADMIN_TOKEN=$(curl -s -X POST -H "Content-Type: application/json" \
+	-d "{\"password\":\"$ADMIN_PASS\"}" "$HOST/api/v0/auth/login?include_token=true" | jq -r .token)
+[ -n "$ADMIN_TOKEN" ] && [ "$ADMIN_TOKEN" != "null" ] || _die "admin login failed"
+AUTH="Authorization: Bearer $ADMIN_TOKEN"
+
+# --- 1. Malformed {hash} → 400 on every route that takes one. -----
+#
+# GET routes first, then the mutations. A mutation with a malformed hash
+# cannot have a side effect: the guard runs before any lookup, which is
+# also why it is safe to fire DELETE here.
+echo
+echo "  -- malformed {hash} → 400 --"
+
+for h in "$SHORT_HASH" "$NONHEX_HASH" "$ALMOST_HASH"; do
+	_curl -H "$AUTH" "$HOST/api/v0/downloads/$h"
+	_assert_status 400 "GET /downloads/$h"
+	_assert_json_eq '.error.code' bad_request "GET /downloads/$h names bad_request"
+done
+
+_curl -H "$AUTH" "$HOST/api/v0/downloads/$NONHEX_HASH/comments"
+_assert_status 400 "GET /downloads/{bad}/comments"
+
+_curl -H "$AUTH" "$HOST/api/v0/shared/$NONHEX_HASH"
+_assert_status 400 "GET /shared/{bad}"
+
+_curl -X PATCH -H "$AUTH" -H "Content-Type: application/json" \
+	-d '{"priority":"high"}' "$HOST/api/v0/downloads/$NONHEX_HASH"
+_assert_status 400 "PATCH /downloads/{bad}"
+
+_curl -X PATCH -H "$AUTH" -H "Content-Type: application/json" \
+	-d '{"priority":"high"}' "$HOST/api/v0/shared/$NONHEX_HASH"
+_assert_status 400 "PATCH /shared/{bad}"
+
+_curl -X DELETE -H "$AUTH" "$HOST/api/v0/downloads/$NONHEX_HASH"
+_assert_status 400 "DELETE /downloads/{bad}"
+
+# The route the split ran through: both methods on one path now agree.
+_curl -H "$AUTH" "$HOST/api/v0/search/results/$NONHEX_HASH/comments"
+_assert_status 400 "GET /search/results/{bad}/comments"
+_curl -X POST -H "$AUTH" "$HOST/api/v0/search/results/$NONHEX_HASH/comments"
+_assert_status 400 "POST /search/results/{bad}/comments (was already 400)"
+
+# --- 2. A well-formed hash that names nothing is still 404. -------
+#
+# The guard must reject the shape, not the lookup. If this ever turns into
+# a 400, "no such file" has been collapsed into "bad request" and the
+# distinction the section above exists for is gone in the other direction.
+echo
+echo "  -- well-formed but absent {hash} → 404 --"
+
+_curl -H "$AUTH" "$HOST/api/v0/downloads/$ABSENT_HASH"
+_assert_status 404 "GET /downloads/{absent}"
+_curl -H "$AUTH" "$HOST/api/v0/shared/$ABSENT_HASH"
+_assert_status 404 "GET /shared/{absent}"
+_curl -H "$AUTH" "$HOST/api/v0/downloads/$ABSENT_HASH/comments"
+_assert_status 404 "GET /downloads/{absent}/comments"
+
+# --- 3. Integer body fields reject a fractional value. ------------
+echo
+echo "  -- fractional value where an integer is documented → 400 --"
+
+_curl -X POST -H "$AUTH" -H "Content-Type: application/json" \
+	-d '{"query":"contract-probe","min_size_bytes":2.9}' "$HOST/api/v0/search"
+_assert_bad_request "POST /search (min_size_bytes 2.9)"
+_assert_json_eq '.error.message | test("integer")' true \
+	'the min_size_bytes 400 says an integer is wanted'
+
+_curl -X POST -H "$AUTH" -H "Content-Type: application/json" \
+	-d '{"query":"contract-probe","max_size_bytes":9.5}' "$HOST/api/v0/search"
+_assert_bad_request "POST /search (max_size_bytes 9.5)"
+
+_curl -X POST -H "$AUTH" -H "Content-Type: application/json" \
+	-d '{"query":"contract-probe","min_source_count":1.5}' "$HOST/api/v0/search"
+_assert_bad_request "POST /search (min_source_count 1.5)"
+
+_curl -X POST -H "$AUTH" -H "Content-Type: application/json" \
+	-d '{"ip":"127.0.0.1","port":4672.5}' "$HOST/api/v0/kad/bootstrap"
+_assert_bad_request "POST /kad/bootstrap (fractional port)"
+
+_curl -X POST -H "$AUTH" -H "Content-Type: application/json" \
+	-d '{"ip":"203.0.113.42","port":4662.5}' "$HOST/api/v0/friends"
+_assert_bad_request "POST /friends (fractional port)"
+
+# --- 4. One port contract on both routes that take one. -----------
+#
+# 0 used to be accepted by /kad/bootstrap and rejected by /friends. No Kad
+# contact is reachable on port 0, so the probe was sent and went nowhere.
+echo
+echo "  -- port 0 → 400 on both routes --"
+
+_curl -X POST -H "$AUTH" -H "Content-Type: application/json" \
+	-d '{"ip":"127.0.0.1","port":0}' "$HOST/api/v0/kad/bootstrap"
+_assert_bad_request "POST /kad/bootstrap (port 0)"
+_assert_json_eq '.error.message | test("1\\.\\.65535")' true \
+	'the kad/bootstrap 400 quotes the shared 1..65535 range'
+
+_curl -X POST -H "$AUTH" -H "Content-Type: application/json" \
+	-d '{"ip":"203.0.113.42","port":0}' "$HOST/api/v0/friends"
+_assert_bad_request "POST /friends (port 0)"
+_assert_json_eq '.error.message | test("1\\.\\.65535")' true \
+	'the friends 400 quotes the same range'
+
+# --- 5. Absence is spelled null, not a zero or an empty string. ---
+#
+# State-dependent, so each check skips when the daemon is not in the shape
+# that exercises it rather than asserting something it cannot know.
+echo
+echo "  -- absence reads as null --"
+
+_curl -H "$AUTH" "$HOST/api/v0/kad"
+KAD_STATE=$(printf '%s' "$CURL_BODY" | jq -r '.state')
+if [ "$KAD_STATE" = "disabled" ]; then
+	_assert_json_eq '.node_id' null 'GET /kad node_id is null while Kad is stopped'
+else
+	_skip "GET /kad node_id null check: Kad state is \"$KAD_STATE\", not disabled"
+fi
+
+_curl -H "$AUTH" "$HOST/api/v0/clients?limit=50"
+NOADDR_ECID=$(printf '%s' "$CURL_BODY" | jq -r 'first(.clients[]? | select(.ip == null) | .ecid) // empty')
+if [ -n "$NOADDR_ECID" ]; then
+	_curl -H "$AUTH" "$HOST/api/v0/clients/$NOADDR_ECID"
+	_assert_json_eq '.kad_port' null 'client detail nulls kad_port with ip/port'
+else
+	_skip 'client detail kad_port check: every connected client has an address'
+fi
+
+_curl -H "$AUTH" "$HOST/api/v0/downloads?limit=50"
+FRESH_HASH=$(printf '%s' "$CURL_BODY" \
+	| jq -r 'first(.downloads[]? | select(.completed_bytes == 0) | .hash) // empty')
+if [ -n "$FRESH_HASH" ]; then
+	_curl -H "$AUTH" "$HOST/api/v0/downloads/$FRESH_HASH"
+	_assert_json_eq '.last_received_at' null \
+		'download that has received nothing nulls last_received_at'
+else
+	_skip 'last_received_at null check: no download with 0 bytes received'
+fi
+
+# --- Summary. -----------------------------------------------------
+echo
+SKIP_NOTE=""
+[ "$SKIP_COUNT" -gt 0 ] && SKIP_NOTE=" ($SKIP_COUNT check(s) skipped -- see the SKIP lines above for why)"
+if [ "$FAIL_COUNT" -eq 0 ]; then
+	echo "OK: $TEST_COUNT/$TEST_COUNT passed$SKIP_NOTE"
+	exit 0
+fi
+echo "FAIL: $FAIL_COUNT/$TEST_COUNT failed"
+exit 1

--- a/unittests/curl-tests/amuleapi/run-all.sh
+++ b/unittests/curl-tests/amuleapi/run-all.sh
@@ -260,6 +260,7 @@ PHASES=(
 	39-shared-media-refresh.sh
 	40-http-conformance.sh
 	41-shared-content.sh
+	42-path-and-body-contracts.sh
 )
 
 # Override list from the command line if given.


### PR DESCRIPTION
First of three PRs for #1275, covering section **A. Coherence / design**. B (renames) plus C (stale comments) and D (doc drift) follow, in that order, so that each of A and B fixes the `REFERENCE.md` sections it touches and D is left with only the drift on endpoints nothing else moved.

## A1, A2, A5 — absence spelled one way

- `WriteClientDetailObject` wrote a raw `kad_port` directly under a comment claiming the address fields are "paired and nulled together, like ip/port/kad_port on the base row". It now nulls on the same condition `WriteClientBaseFields` uses for `ip`/`port`, which is also the one `WriteKnownClientObject` has always used.
- `last_received_at` emitted a raw `0` between three siblings that null the never-case, so a partfile that has not received a byte read as 1970. The rule was already documented four lines above it.
- `node_id` was the last `""` sentinel in a `/kad` object whose every other field answers `null` when Kad is stopped.

## A3 — body contracts that hold

`port` was a "required **integer** field" in `1..65535` on `POST /friends` and a "required **numeric** field" in `0..65535` on `POST /kad/bootstrap`. One contract now, on both: an integer in `1..65535`. Port `0` used to be accepted for a Kad bootstrap, which no contact is reachable on, so that probe was sent and went nowhere.

Six fields documented as integers accepted a fractional value and truncated it: the two ports and `min_size_bytes` / `max_size_bytes` / `min_source_count` / `ecid` on the search routes. `POST /search {"min_size_bytes": 2.9}` was accepted as `2`. JSON has one number type, so an integer field has to say so itself. `IsIntegralJsonNumber` does that once and the four existing guards adopt it, because the `v != (double)(int)v` idiom they used cannot judge a byte count above `INT_MAX` — exactly the range the size fields live in.

The `priority` type error was "must be a string" on one route and "must be a wire-string enum" on five. It is one sentence now, and it is the one a client can act on.

## A4 — a malformed `{hash}` is a bad request everywhere

The find-based routes lower-cased and looked up, so an unparseable hash fell through to their `404`. A client could not tell "not a hash" from "valid hash, no such file", and the split ran through a single route: `GET /search/results/{hash}/comments` answered `404` where its own `POST` answered `400`.

`RequireHashPath` is the `{hash}` twin of the existing `RequireEcidPath`, applied to all seven routes. On the three mutating ones it runs **after** `RequireAdmin`, matching how the `{ecid}` routes order those two, so authorization still answers before request shape.

## Tests

New phase `42-path-and-body-contracts.sh`, registered in `PHASES`: 35/35 passing. Two things it does deliberately:

- It asserts the error **code**, not just the `400`. A daemon with its networks disabled answers `400 amuled_rejected` to a perfectly valid search or bootstrap, so a bare status check would have passed for the wrong reason.
- It pins that a well-formed but absent hash is still `404`, so the new guard cannot collapse "missing" into "malformed" in the other direction.

`05-read-servers-kad-categories-prefs.sh` asserted `node_id == ""`; it now asserts `null`. The suite caught that contract change on its own, which is the same-PR test obligation doing its job.

Every phase in the blast radius was run, in two passes.

Against an idle daemon (own config dir, networks off): 04, 05, 12, 13, 17, 26, 29, 30, 33, 34 and 42, with 526 checks passing.

Against a daemon connected to ed2k (LowID) and Kad, for the phases that need one: 07 (85/85), 10, 16, 26 and 19 (172/173), plus 42 again at 34/34. The connected pass is what exercises the three `/status` Kad network counters, the SSE `search_progress` and the `networks/connect` paths that an idle daemon cannot answer. The single failure in 19 is the daemon dropping its ed2k link mid-phase ("eD2k search can't be done if eD2k is not connected") after falling back to another server, which is the phase-ordering hazard the suite documents rather than anything from this change: 16 disconnects the networks just before 19 runs.

The connected pass also broke one of the new checks, which is why the second commit is here. 42 asserted that a download with 0 bytes received nulls `last_received_at`, and that premise is wrong: the field is the partfile's last-CHANGED stamp, which amuled sets for a download that has transferred nothing, so the check passed on an idle daemon and failed on a connected one. It now asserts what the contract actually forbids -- no row may carry a raw `0` -- which holds on any daemon state and fails the moment the mapping is dropped.

Frontend checked and unchanged: `formatTimestamp` renders `null` as `—` exactly as it did `0`, and the client-detail Kad row reads `c.kad_port` for truthiness, so both already handle the null.

cf18 clean on the changed source, Tier-2 clang-tidy diff clean with 0 compiler errors.
