### PR TITLE
fix(gui): let a friend slot be granted while the friend is offline

### DIFF
--- a/src/FriendListCtrl.cpp
+++ b/src/FriendListCtrl.cpp
@@ -189,13 +189,16 @@ void CFriendListCtrl::OnItemRightClicked(wxDataViewEvent &event)
 		menu->Append(MP_REMOVEFRIEND, _("Remove Friend"));
 		menu->Append(MP_MESSAGE, _("Send &Message"));
 		menu->Append(MP_SHOWLIST, _("View Files"));
+		// No connection gate: the slot is a property of the CFriend
+		// record, not of a live session. CFriendList::SetFriendSlot
+		// persists it through CFriend::SetPersistentFriendSlot and only
+		// additionally pokes the live client when one is linked, and
+		// CFriend::LinkClient applies the stored flag when the friend
+		// reconnects. Granting it in advance to a friend who is offline
+		// is therefore the case it is most useful for, and was the one
+		// case this menu refused.
 		menu->AppendCheckItem(MP_FRIENDSLOT, _("Establish Friend Slot"));
-		if (cur_friend->GetLinkedClient().IsLinked()) {
-			menu->Enable(MP_FRIENDSLOT, true);
-			menu->Check(MP_FRIENDSLOT, cur_friend->HasFriendSlot());
-		} else {
-			menu->Enable(MP_FRIENDSLOT, false);
-		}
+		menu->Check(MP_FRIENDSLOT, cur_friend->HasFriendSlot());
 	}
 
 	PopupMenu(menu, event.GetPosition());


### PR DESCRIPTION
The Friends list disabled **Establish Friend Slot** unless the friend had a linked client, which forbids exactly the case the feature is most useful for: granting the slot in advance to someone who will reconnect later.

The gate reads the wrong thing. The slot is a property of the `CFriend` record, not of a live session:

- `CFriendList::SetFriendSlot` writes it via `CFriend::SetPersistentFriendSlot`, clears the flag on every other friend, and only *additionally* pokes the live client `if (Friend->GetLinkedClient().IsLinked())`.
- `Friend.h` documents `m_HasFriendSlot` as the source of truth across disconnects and daemon restarts.
- `CFriend::LinkClient` applies the stored flag to the client when the friend reconnects, with a comment saying that is what the branch is for.

So the persisted grant does take effect later. Only the menu disagreed.

The item is now always enabled and always checked from `cur_friend->HasFriendSlot()`, which is the persistent flag whether or not a client is linked.

### Verified rather than assumed

- **`OnSetFriendslot`** casts the selected row's `CFriend*` straight into `CFriendList::SetFriendSlot`, guarded on an empty selection. No identity resolution and no null path.
- **amulegui works too.** `CFriend` derives from `CECID`, so an offline friend has its own ECID; `CFriendListRem::SetFriendSlot` sends it as `EC_TAG_FRIEND`, and the daemon resolves it with `CFriendList::FindFriend(ecid)`, which walks `m_FriendList` comparing `ECID()` and never touches a client.
- **The only other path** to this entry is `BuildClientContextMenu`, which gates on `c.IsFriend()`. That is a different and correct question: those lists show live clients, and a non-friend cannot hold a slot. Left alone.

### Verification

Built monolithic and amulegui: 0 errors, no warnings in the touched file. 47/47 ctest. clang-format 18.1.8 whole-file with `--style=file:<repo>/.clang-format`: clean. clang-tidy Tier-1 and Tier-2 on the diff: 0 findings, 0 compiler errors.

No new translatable strings and no catalog commit: regenerating moves only `POT-Creation-Date`, and the CI gate's own stripped comparison reports no content drift.

The menu cannot be exercised headlessly, so the behavioural claim rests on the code path above.
