### PR TITLE
feat(gui): name the shared-files bar for what it shows, and give it a legend

### DIFF
--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -63,6 +63,7 @@ src/MuleUDPSocket.cpp
 src/muuli_wdr.cpp
 src/OScopeCtrl.cpp
 src/OtherFunctions.cpp
+src/PartBarLegendUI.cpp
 src/PartFileConvert.cpp
 src/PartFileConvertDlg.cpp
 src/PartFile.cpp

--- a/po/amule.pot
+++ b/po/amule.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-02 12:15+0200\n"
+"POT-Creation-Date: 2026-09-04 07:50+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -2720,46 +2720,10 @@ msgid ""
 msgstr ""
 
 #: src/GenericClientListCtrl.cpp
-msgid "This source does not have the part"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "You and this source both have the part"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "Being downloaded from this source now"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "The next part that will be asked of this source"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "This source has the part and you still need it"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "This peer already has the part"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "This peer does not have the part"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "One block per part of the file being downloaded."
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "One block per part of the shared file."
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
 msgid "Swap to this file"
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Colour legend"
 msgstr ""
 
@@ -5469,6 +5433,75 @@ msgstr ""
 msgid "Using config dir: %s"
 msgstr ""
 
+#: src/PartBarLegendUI.cpp
+msgid "This source does not have the part"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "You and this source both have the part"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "Being downloaded from this source now"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "The next part that will be asked of this source"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "This source has the part and you still need it"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "This peer already has the part"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "This peer does not have the part"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "No source has this part"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "One source has this part"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+#, c-format
+msgid "%u or more sources have this part"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "Already read back and hashed"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "Still to be read"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "One block per part of the file being downloaded."
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "One block per part of the shared file."
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "One block per part of the shared file, coloured by how many sources have it."
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "One block per part of the shared file, showing how far the re-hash has read."
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "In between, darkening as sources are added"
+msgstr ""
+
 #: src/PartFileConvert.cpp
 msgid "Waiting for partfile convert thread to die..."
 msgstr ""
@@ -7211,7 +7244,7 @@ msgid "Shares File List"
 msgstr ""
 
 #: src/SharedFilesCtrl.cpp
-msgid "Obtained Parts"
+msgid "Source Availability"
 msgstr ""
 
 #: src/SharedFilesCtrl.cpp

--- a/po/amule.pot
+++ b/po/amule.pot
@@ -5462,16 +5462,16 @@ msgid "This peer does not have the part"
 msgstr ""
 
 #: src/PartBarLegendUI.cpp
-msgid "No source has this part"
+msgid "No other source has this part"
 msgstr ""
 
 #: src/PartBarLegendUI.cpp
-msgid "One source has this part"
+msgid "One other source has this part"
 msgstr ""
 
 #: src/PartBarLegendUI.cpp
 #, c-format
-msgid "%u or more sources have this part"
+msgid "%u or more other sources have this part"
 msgstr ""
 
 #: src/PartBarLegendUI.cpp
@@ -5491,7 +5491,7 @@ msgid "One block per part of the shared file."
 msgstr ""
 
 #: src/PartBarLegendUI.cpp
-msgid "One block per part of the shared file, coloured by how many sources have it."
+msgid "One block per part of the shared file, coloured by how many other sources have it."
 msgstr ""
 
 #: src/PartBarLegendUI.cpp
@@ -5499,7 +5499,7 @@ msgid "One block per part of the shared file, showing how far the re-hash has re
 msgstr ""
 
 #: src/PartBarLegendUI.cpp
-msgid "In between, darkening as sources are added"
+msgid "In between, darkening as other sources are added"
 msgstr ""
 
 #: src/PartFileConvert.cpp

--- a/po/ar.po
+++ b/po/ar.po
@@ -5546,16 +5546,16 @@ msgid "This peer does not have the part"
 msgstr ""
 
 #: src/PartBarLegendUI.cpp
-msgid "No source has this part"
+msgid "No other source has this part"
 msgstr ""
 
 #: src/PartBarLegendUI.cpp
-msgid "One source has this part"
+msgid "One other source has this part"
 msgstr ""
 
 #: src/PartBarLegendUI.cpp
 #, c-format
-msgid "%u or more sources have this part"
+msgid "%u or more other sources have this part"
 msgstr ""
 
 #: src/PartBarLegendUI.cpp
@@ -5575,7 +5575,7 @@ msgid "One block per part of the shared file."
 msgstr ""
 
 #: src/PartBarLegendUI.cpp
-msgid "One block per part of the shared file, coloured by how many sources have it."
+msgid "One block per part of the shared file, coloured by how many other sources have it."
 msgstr ""
 
 #: src/PartBarLegendUI.cpp
@@ -5583,7 +5583,7 @@ msgid "One block per part of the shared file, showing how far the re-hash has re
 msgstr ""
 
 #: src/PartBarLegendUI.cpp
-msgid "In between, darkening as sources are added"
+msgid "In between, darkening as other sources are added"
 msgstr ""
 
 #: src/PartFileConvert.cpp

--- a/po/ar.po
+++ b/po/ar.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-02 12:15+0200\n"
+"POT-Creation-Date: 2026-09-04 07:50+0200\n"
 "PO-Revision-Date: 2026-09-03 11:00+0000\n"
 "Last-Translator: saleh alhathal <hathalsal@hotmail.com>\n"
 "Language-Team: \n"
@@ -2767,46 +2767,10 @@ msgid ""
 msgstr ""
 
 #: src/GenericClientListCtrl.cpp
-msgid "This source does not have the part"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "You and this source both have the part"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "Being downloaded from this source now"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "The next part that will be asked of this source"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "This source has the part and you still need it"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "This peer already has the part"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "This peer does not have the part"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "One block per part of the file being downloaded."
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "One block per part of the shared file."
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
 msgid "Swap to this file"
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Colour legend"
 msgstr ""
 
@@ -5553,6 +5517,75 @@ msgstr "نص"
 msgid "Using config dir: %s"
 msgstr ""
 
+#: src/PartBarLegendUI.cpp
+msgid "This source does not have the part"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "You and this source both have the part"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "Being downloaded from this source now"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "The next part that will be asked of this source"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "This source has the part and you still need it"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "This peer already has the part"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "This peer does not have the part"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "No source has this part"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "One source has this part"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+#, c-format
+msgid "%u or more sources have this part"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "Already read back and hashed"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "Still to be read"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "One block per part of the file being downloaded."
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "One block per part of the shared file."
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "One block per part of the shared file, coloured by how many sources have it."
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "One block per part of the shared file, showing how far the re-hash has read."
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "In between, darkening as sources are added"
+msgstr ""
+
 #: src/PartFileConvert.cpp
 msgid "Waiting for partfile convert thread to die..."
 msgstr ""
@@ -7344,8 +7377,9 @@ msgid "Shares File List"
 msgstr "ملفات مشاركة"
 
 #: src/SharedFilesCtrl.cpp
-msgid "Obtained Parts"
-msgstr "أجزاء مكتسبة"
+#, fuzzy
+msgid "Source Availability"
+msgstr "غير متوفر"
 
 #: src/SharedFilesCtrl.cpp
 msgid "Directory Path"
@@ -9160,6 +9194,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "Obtained Parts"
+#~ msgstr "أجزاء مكتسبة"
 
 #, fuzzy
 #~ msgid "Available Parts"

--- a/po/ast.po
+++ b/po/ast.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-02 12:15+0200\n"
+"POT-Creation-Date: 2026-09-04 07:50+0200\n"
 "PO-Revision-Date: 2026-09-03 11:01+0000\n"
 "Last-Translator: astur <malditoastur@gmail.com>\n"
 "Language-Team: Language ast <malditoastur@gmail.com>\n"
@@ -2825,48 +2825,10 @@ msgstr ""
 " Namái s'asignó un puestu reserváu."
 
 #: src/GenericClientListCtrl.cpp
-#, fuzzy
-msgid "This source does not have the part"
-msgstr "Esti comandu nun tendría de tener dengún parámetru"
-
-#: src/GenericClientListCtrl.cpp
-msgid "You and this source both have the part"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "Being downloaded from this source now"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "The next part that will be asked of this source"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "This source has the part and you still need it"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "This peer already has the part"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "This peer does not have the part"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "One block per part of the file being downloaded."
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-#, fuzzy
-msgid "One block per part of the shared file."
-msgstr "Introduz el puertu del sirvidor"
-
-#: src/GenericClientListCtrl.cpp
 msgid "Swap to this file"
 msgstr "Intercambia esti ficheru"
 
-#: src/GenericClientListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Colour legend"
 msgstr ""
 
@@ -5643,6 +5605,81 @@ msgstr "Testu"
 msgid "Using config dir: %s"
 msgstr ""
 
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "This source does not have the part"
+msgstr "Esti comandu nun tendría de tener dengún parámetru"
+
+#: src/PartBarLegendUI.cpp
+msgid "You and this source both have the part"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "Being downloaded from this source now"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "The next part that will be asked of this source"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "This source has the part and you still need it"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "This peer already has the part"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "This peer does not have the part"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "No source has this part"
+msgstr "Esti comandu nun tendría de tener dengún parámetru"
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "One source has this part"
+msgstr "Esti comandu nun tendría de tener dengún parámetru"
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy, c-format
+msgid "%u or more sources have this part"
+msgstr "Esti comandu nun tendría de tener dengún parámetru"
+
+#: src/PartBarLegendUI.cpp
+msgid "Already read back and hashed"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "Still to be read"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "One block per part of the file being downloaded."
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "One block per part of the shared file."
+msgstr "Introduz el puertu del sirvidor"
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "One block per part of the shared file, coloured by how many sources have it."
+msgstr "Introduz el puertu del sirvidor"
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "One block per part of the shared file, showing how far the re-hash has read."
+msgstr "Introduz el puertu del sirvidor"
+
+#: src/PartBarLegendUI.cpp
+msgid "In between, darkening as sources are added"
+msgstr ""
+
 #: src/PartFileConvert.cpp
 msgid "Waiting for partfile convert thread to die..."
 msgstr "Esperando a ficheru part matando filu..."
@@ -7464,8 +7501,9 @@ msgid "Shares File List"
 msgstr "Fich compartíos"
 
 #: src/SharedFilesCtrl.cpp
-msgid "Obtained Parts"
-msgstr "Partes obteníes"
+#, fuzzy
+msgid "Source Availability"
+msgstr "Disponibilidá"
 
 #: src/SharedFilesCtrl.cpp
 msgid "Directory Path"
@@ -9353,6 +9391,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "Obtained Parts"
+#~ msgstr "Partes obteníes"
 
 #, fuzzy
 #~ msgid "Available Parts"

--- a/po/ast.po
+++ b/po/ast.po
@@ -5636,17 +5636,17 @@ msgstr ""
 
 #: src/PartBarLegendUI.cpp
 #, fuzzy
-msgid "No source has this part"
+msgid "No other source has this part"
 msgstr "Esti comandu nun tendría de tener dengún parámetru"
 
 #: src/PartBarLegendUI.cpp
 #, fuzzy
-msgid "One source has this part"
+msgid "One other source has this part"
 msgstr "Esti comandu nun tendría de tener dengún parámetru"
 
 #: src/PartBarLegendUI.cpp
 #, fuzzy, c-format
-msgid "%u or more sources have this part"
+msgid "%u or more other sources have this part"
 msgstr "Esti comandu nun tendría de tener dengún parámetru"
 
 #: src/PartBarLegendUI.cpp
@@ -5668,7 +5668,7 @@ msgstr "Introduz el puertu del sirvidor"
 
 #: src/PartBarLegendUI.cpp
 #, fuzzy
-msgid "One block per part of the shared file, coloured by how many sources have it."
+msgid "One block per part of the shared file, coloured by how many other sources have it."
 msgstr "Introduz el puertu del sirvidor"
 
 #: src/PartBarLegendUI.cpp
@@ -5677,7 +5677,7 @@ msgid "One block per part of the shared file, showing how far the re-hash has re
 msgstr "Introduz el puertu del sirvidor"
 
 #: src/PartBarLegendUI.cpp
-msgid "In between, darkening as sources are added"
+msgid "In between, darkening as other sources are added"
 msgstr ""
 
 #: src/PartFileConvert.cpp

--- a/po/bg.po
+++ b/po/bg.po
@@ -5531,16 +5531,16 @@ msgid "This peer does not have the part"
 msgstr ""
 
 #: src/PartBarLegendUI.cpp
-msgid "No source has this part"
+msgid "No other source has this part"
 msgstr ""
 
 #: src/PartBarLegendUI.cpp
-msgid "One source has this part"
+msgid "One other source has this part"
 msgstr ""
 
 #: src/PartBarLegendUI.cpp
 #, c-format
-msgid "%u or more sources have this part"
+msgid "%u or more other sources have this part"
 msgstr ""
 
 #: src/PartBarLegendUI.cpp
@@ -5560,7 +5560,7 @@ msgid "One block per part of the shared file."
 msgstr ""
 
 #: src/PartBarLegendUI.cpp
-msgid "One block per part of the shared file, coloured by how many sources have it."
+msgid "One block per part of the shared file, coloured by how many other sources have it."
 msgstr ""
 
 #: src/PartBarLegendUI.cpp
@@ -5568,7 +5568,7 @@ msgid "One block per part of the shared file, showing how far the re-hash has re
 msgstr ""
 
 #: src/PartBarLegendUI.cpp
-msgid "In between, darkening as sources are added"
+msgid "In between, darkening as other sources are added"
 msgstr ""
 
 #: src/PartFileConvert.cpp

--- a/po/bg.po
+++ b/po/bg.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-02 12:15+0200\n"
+"POT-Creation-Date: 2026-09-04 07:50+0200\n"
 "PO-Revision-Date: 2026-09-03 11:01+0000\n"
 "Last-Translator: Sebastiano Pistore <SebastianoPistore.info@protonmail.ch>\n"
 "Language-Team: Bulgarian <dict@linux.zonebg.com>\n"
@@ -2763,46 +2763,10 @@ msgid ""
 msgstr ""
 
 #: src/GenericClientListCtrl.cpp
-msgid "This source does not have the part"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "You and this source both have the part"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "Being downloaded from this source now"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "The next part that will be asked of this source"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "This source has the part and you still need it"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "This peer already has the part"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "This peer does not have the part"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "One block per part of the file being downloaded."
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "One block per part of the shared file."
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
 msgid "Swap to this file"
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Colour legend"
 msgstr ""
 
@@ -5538,6 +5502,75 @@ msgstr "Текст"
 msgid "Using config dir: %s"
 msgstr ""
 
+#: src/PartBarLegendUI.cpp
+msgid "This source does not have the part"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "You and this source both have the part"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "Being downloaded from this source now"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "The next part that will be asked of this source"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "This source has the part and you still need it"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "This peer already has the part"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "This peer does not have the part"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "No source has this part"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "One source has this part"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+#, c-format
+msgid "%u or more sources have this part"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "Already read back and hashed"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "Still to be read"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "One block per part of the file being downloaded."
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "One block per part of the shared file."
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "One block per part of the shared file, coloured by how many sources have it."
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "One block per part of the shared file, showing how far the re-hash has read."
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "In between, darkening as sources are added"
+msgstr ""
+
 #: src/PartFileConvert.cpp
 msgid "Waiting for partfile convert thread to die..."
 msgstr ""
@@ -7316,7 +7349,7 @@ msgid "Shares File List"
 msgstr "Споделени файлове (%i)"
 
 #: src/SharedFilesCtrl.cpp
-msgid "Obtained Parts"
+msgid "Source Availability"
 msgstr ""
 
 #: src/SharedFilesCtrl.cpp

--- a/po/bn.po
+++ b/po/bn.po
@@ -5461,16 +5461,16 @@ msgid "This peer does not have the part"
 msgstr ""
 
 #: src/PartBarLegendUI.cpp
-msgid "No source has this part"
+msgid "No other source has this part"
 msgstr ""
 
 #: src/PartBarLegendUI.cpp
-msgid "One source has this part"
+msgid "One other source has this part"
 msgstr ""
 
 #: src/PartBarLegendUI.cpp
 #, c-format
-msgid "%u or more sources have this part"
+msgid "%u or more other sources have this part"
 msgstr ""
 
 #: src/PartBarLegendUI.cpp
@@ -5490,7 +5490,7 @@ msgid "One block per part of the shared file."
 msgstr ""
 
 #: src/PartBarLegendUI.cpp
-msgid "One block per part of the shared file, coloured by how many sources have it."
+msgid "One block per part of the shared file, coloured by how many other sources have it."
 msgstr ""
 
 #: src/PartBarLegendUI.cpp
@@ -5498,7 +5498,7 @@ msgid "One block per part of the shared file, showing how far the re-hash has re
 msgstr ""
 
 #: src/PartBarLegendUI.cpp
-msgid "In between, darkening as sources are added"
+msgid "In between, darkening as other sources are added"
 msgstr ""
 
 #: src/PartFileConvert.cpp

--- a/po/bn.po
+++ b/po/bn.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-02 12:15+0200\n"
+"POT-Creation-Date: 2026-09-04 07:50+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -2719,46 +2719,10 @@ msgid ""
 msgstr ""
 
 #: src/GenericClientListCtrl.cpp
-msgid "This source does not have the part"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "You and this source both have the part"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "Being downloaded from this source now"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "The next part that will be asked of this source"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "This source has the part and you still need it"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "This peer already has the part"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "This peer does not have the part"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "One block per part of the file being downloaded."
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "One block per part of the shared file."
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
 msgid "Swap to this file"
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Colour legend"
 msgstr ""
 
@@ -5468,6 +5432,75 @@ msgstr ""
 msgid "Using config dir: %s"
 msgstr ""
 
+#: src/PartBarLegendUI.cpp
+msgid "This source does not have the part"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "You and this source both have the part"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "Being downloaded from this source now"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "The next part that will be asked of this source"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "This source has the part and you still need it"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "This peer already has the part"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "This peer does not have the part"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "No source has this part"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "One source has this part"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+#, c-format
+msgid "%u or more sources have this part"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "Already read back and hashed"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "Still to be read"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "One block per part of the file being downloaded."
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "One block per part of the shared file."
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "One block per part of the shared file, coloured by how many sources have it."
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "One block per part of the shared file, showing how far the re-hash has read."
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "In between, darkening as sources are added"
+msgstr ""
+
 #: src/PartFileConvert.cpp
 msgid "Waiting for partfile convert thread to die..."
 msgstr ""
@@ -7210,7 +7243,7 @@ msgid "Shares File List"
 msgstr ""
 
 #: src/SharedFilesCtrl.cpp
-msgid "Obtained Parts"
+msgid "Source Availability"
 msgstr ""
 
 #: src/SharedFilesCtrl.cpp

--- a/po/ca.po
+++ b/po/ca.po
@@ -5612,17 +5612,17 @@ msgstr ""
 
 #: src/PartBarLegendUI.cpp
 #, fuzzy
-msgid "No source has this part"
+msgid "No other source has this part"
 msgstr "Aquesta ordre no hauria de tenir cap paràmetre."
 
 #: src/PartBarLegendUI.cpp
 #, fuzzy
-msgid "One source has this part"
+msgid "One other source has this part"
 msgstr "Aquesta ordre no hauria de tenir cap paràmetre."
 
 #: src/PartBarLegendUI.cpp
 #, fuzzy, c-format
-msgid "%u or more sources have this part"
+msgid "%u or more other sources have this part"
 msgstr "Aquesta ordre no hauria de tenir cap paràmetre."
 
 #: src/PartBarLegendUI.cpp
@@ -5644,7 +5644,7 @@ msgstr "Introduïu el port del servidor."
 
 #: src/PartBarLegendUI.cpp
 #, fuzzy
-msgid "One block per part of the shared file, coloured by how many sources have it."
+msgid "One block per part of the shared file, coloured by how many other sources have it."
 msgstr "Introduïu el port del servidor."
 
 #: src/PartBarLegendUI.cpp
@@ -5653,7 +5653,7 @@ msgid "One block per part of the shared file, showing how far the re-hash has re
 msgstr "Introduïu el port del servidor."
 
 #: src/PartBarLegendUI.cpp
-msgid "In between, darkening as sources are added"
+msgid "In between, darkening as other sources are added"
 msgstr ""
 
 #: src/PartFileConvert.cpp

--- a/po/ca.po
+++ b/po/ca.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-02 12:15+0200\n"
+"POT-Creation-Date: 2026-09-04 07:50+0200\n"
 "PO-Revision-Date: 2026-09-03 11:01+0000\n"
 "Last-Translator: minterior <minterior@gmail.com>\n"
 "Language-Team: Català\n"
@@ -2818,48 +2818,10 @@ msgstr ""
 " Només s'ha assignat una posició."
 
 #: src/GenericClientListCtrl.cpp
-#, fuzzy
-msgid "This source does not have the part"
-msgstr "Aquesta ordre no hauria de tenir cap paràmetre."
-
-#: src/GenericClientListCtrl.cpp
-msgid "You and this source both have the part"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "Being downloaded from this source now"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "The next part that will be asked of this source"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "This source has the part and you still need it"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "This peer already has the part"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "This peer does not have the part"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "One block per part of the file being downloaded."
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-#, fuzzy
-msgid "One block per part of the shared file."
-msgstr "Introduïu el port del servidor."
-
-#: src/GenericClientListCtrl.cpp
 msgid "Swap to this file"
 msgstr "Intercanvia cap a aquest fitxer"
 
-#: src/GenericClientListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Colour legend"
 msgstr ""
 
@@ -5619,6 +5581,81 @@ msgstr "Documents"
 msgid "Using config dir: %s"
 msgstr "Directori de configuració: %s"
 
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "This source does not have the part"
+msgstr "Aquesta ordre no hauria de tenir cap paràmetre."
+
+#: src/PartBarLegendUI.cpp
+msgid "You and this source both have the part"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "Being downloaded from this source now"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "The next part that will be asked of this source"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "This source has the part and you still need it"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "This peer already has the part"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "This peer does not have the part"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "No source has this part"
+msgstr "Aquesta ordre no hauria de tenir cap paràmetre."
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "One source has this part"
+msgstr "Aquesta ordre no hauria de tenir cap paràmetre."
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy, c-format
+msgid "%u or more sources have this part"
+msgstr "Aquesta ordre no hauria de tenir cap paràmetre."
+
+#: src/PartBarLegendUI.cpp
+msgid "Already read back and hashed"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "Still to be read"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "One block per part of the file being downloaded."
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "One block per part of the shared file."
+msgstr "Introduïu el port del servidor."
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "One block per part of the shared file, coloured by how many sources have it."
+msgstr "Introduïu el port del servidor."
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "One block per part of the shared file, showing how far the re-hash has read."
+msgstr "Introduïu el port del servidor."
+
+#: src/PartBarLegendUI.cpp
+msgid "In between, darkening as sources are added"
+msgstr ""
+
 #: src/PartFileConvert.cpp
 msgid "Waiting for partfile convert thread to die..."
 msgstr "Esperant que el fil de conversió de fitxers de parts acabi..."
@@ -7427,8 +7464,9 @@ msgid "Shares File List"
 msgstr "Llista de fitxers compartits"
 
 #: src/SharedFilesCtrl.cpp
-msgid "Obtained Parts"
-msgstr "Parts obtingudes"
+#, fuzzy
+msgid "Source Availability"
+msgstr "Disponibilitat"
 
 #: src/SharedFilesCtrl.cpp
 msgid "Directory Path"
@@ -9299,6 +9337,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "Obtained Parts"
+#~ msgstr "Parts obtingudes"
 
 #~ msgid "Available Parts"
 #~ msgstr "Parts disponibles"

--- a/po/cs.po
+++ b/po/cs.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-02 12:15+0200\n"
+"POT-Creation-Date: 2026-09-04 07:50+0200\n"
 "PO-Revision-Date: 2026-09-03 11:02+0000\n"
 "Last-Translator: David Watzke <david@watzke.cz>\n"
 "Language-Team: cs <cs@li.org>\n"
@@ -2820,48 +2820,10 @@ msgstr ""
 " Byl přidělen pouze jeden slot."
 
 #: src/GenericClientListCtrl.cpp
-#, fuzzy
-msgid "This source does not have the part"
-msgstr "Tento příkaz by neměl mít parametry."
-
-#: src/GenericClientListCtrl.cpp
-msgid "You and this source both have the part"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "Being downloaded from this source now"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "The next part that will be asked of this source"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "This source has the part and you still need it"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "This peer already has the part"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "This peer does not have the part"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "One block per part of the file being downloaded."
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-#, fuzzy
-msgid "One block per part of the shared file."
-msgstr "Zadejte port serveru."
-
-#: src/GenericClientListCtrl.cpp
 msgid "Swap to this file"
 msgstr "Swapovat do tohoto souboru"
 
-#: src/GenericClientListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Colour legend"
 msgstr ""
 
@@ -5604,6 +5566,81 @@ msgstr "Text"
 msgid "Using config dir: %s"
 msgstr "Používám konfigurační adresář: %s"
 
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "This source does not have the part"
+msgstr "Tento příkaz by neměl mít parametry."
+
+#: src/PartBarLegendUI.cpp
+msgid "You and this source both have the part"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "Being downloaded from this source now"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "The next part that will be asked of this source"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "This source has the part and you still need it"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "This peer already has the part"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "This peer does not have the part"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "No source has this part"
+msgstr "Tento příkaz by neměl mít parametry."
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "One source has this part"
+msgstr "Tento příkaz by neměl mít parametry."
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy, c-format
+msgid "%u or more sources have this part"
+msgstr "Tento příkaz by neměl mít parametry."
+
+#: src/PartBarLegendUI.cpp
+msgid "Already read back and hashed"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "Still to be read"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "One block per part of the file being downloaded."
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "One block per part of the shared file."
+msgstr "Zadejte port serveru."
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "One block per part of the shared file, coloured by how many sources have it."
+msgstr "Zadejte port serveru."
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "One block per part of the shared file, showing how far the re-hash has read."
+msgstr "Zadejte port serveru."
+
+#: src/PartBarLegendUI.cpp
+msgid "In between, darkening as sources are added"
+msgstr ""
+
 #: src/PartFileConvert.cpp
 msgid "Waiting for partfile convert thread to die..."
 msgstr "Čekání na ukončení vlákna pro převod souboru part..."
@@ -7425,8 +7462,9 @@ msgid "Shares File List"
 msgstr "Sdílené soubory"
 
 #: src/SharedFilesCtrl.cpp
-msgid "Obtained Parts"
-msgstr "Obdržené části"
+#, fuzzy
+msgid "Source Availability"
+msgstr "Dostupnost"
 
 #: src/SharedFilesCtrl.cpp
 msgid "Directory Path"
@@ -9278,6 +9316,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "Obtained Parts"
+#~ msgstr "Obdržené části"
 
 #~ msgid "Available Parts"
 #~ msgstr "Dostupné části"

--- a/po/cs.po
+++ b/po/cs.po
@@ -5597,17 +5597,17 @@ msgstr ""
 
 #: src/PartBarLegendUI.cpp
 #, fuzzy
-msgid "No source has this part"
+msgid "No other source has this part"
 msgstr "Tento příkaz by neměl mít parametry."
 
 #: src/PartBarLegendUI.cpp
 #, fuzzy
-msgid "One source has this part"
+msgid "One other source has this part"
 msgstr "Tento příkaz by neměl mít parametry."
 
 #: src/PartBarLegendUI.cpp
 #, fuzzy, c-format
-msgid "%u or more sources have this part"
+msgid "%u or more other sources have this part"
 msgstr "Tento příkaz by neměl mít parametry."
 
 #: src/PartBarLegendUI.cpp
@@ -5629,7 +5629,7 @@ msgstr "Zadejte port serveru."
 
 #: src/PartBarLegendUI.cpp
 #, fuzzy
-msgid "One block per part of the shared file, coloured by how many sources have it."
+msgid "One block per part of the shared file, coloured by how many other sources have it."
 msgstr "Zadejte port serveru."
 
 #: src/PartBarLegendUI.cpp
@@ -5638,7 +5638,7 @@ msgid "One block per part of the shared file, showing how far the re-hash has re
 msgstr "Zadejte port serveru."
 
 #: src/PartBarLegendUI.cpp
-msgid "In between, darkening as sources are added"
+msgid "In between, darkening as other sources are added"
 msgstr ""
 
 #: src/PartFileConvert.cpp

--- a/po/da.po
+++ b/po/da.po
@@ -5562,16 +5562,16 @@ msgid "This peer does not have the part"
 msgstr ""
 
 #: src/PartBarLegendUI.cpp
-msgid "No source has this part"
+msgid "No other source has this part"
 msgstr ""
 
 #: src/PartBarLegendUI.cpp
-msgid "One source has this part"
+msgid "One other source has this part"
 msgstr ""
 
 #: src/PartBarLegendUI.cpp
 #, c-format
-msgid "%u or more sources have this part"
+msgid "%u or more other sources have this part"
 msgstr ""
 
 #: src/PartBarLegendUI.cpp
@@ -5591,7 +5591,7 @@ msgid "One block per part of the shared file."
 msgstr ""
 
 #: src/PartBarLegendUI.cpp
-msgid "One block per part of the shared file, coloured by how many sources have it."
+msgid "One block per part of the shared file, coloured by how many other sources have it."
 msgstr ""
 
 #: src/PartBarLegendUI.cpp
@@ -5599,7 +5599,7 @@ msgid "One block per part of the shared file, showing how far the re-hash has re
 msgstr ""
 
 #: src/PartBarLegendUI.cpp
-msgid "In between, darkening as sources are added"
+msgid "In between, darkening as other sources are added"
 msgstr ""
 
 #: src/PartFileConvert.cpp

--- a/po/da.po
+++ b/po/da.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-02 12:15+0200\n"
+"POT-Creation-Date: 2026-09-04 07:50+0200\n"
 "PO-Revision-Date: 2026-09-03 11:02+0000\n"
 "Last-Translator: Alex Thomsen Leth <alexl@stofanet.dk>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -2773,46 +2773,10 @@ msgid ""
 msgstr ""
 
 #: src/GenericClientListCtrl.cpp
-msgid "This source does not have the part"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "You and this source both have the part"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "Being downloaded from this source now"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "The next part that will be asked of this source"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "This source has the part and you still need it"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "This peer already has the part"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "This peer does not have the part"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "One block per part of the file being downloaded."
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "One block per part of the shared file."
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
 msgid "Swap to this file"
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Colour legend"
 msgstr ""
 
@@ -5569,6 +5533,75 @@ msgstr "Tekst"
 msgid "Using config dir: %s"
 msgstr ""
 
+#: src/PartBarLegendUI.cpp
+msgid "This source does not have the part"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "You and this source both have the part"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "Being downloaded from this source now"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "The next part that will be asked of this source"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "This source has the part and you still need it"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "This peer already has the part"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "This peer does not have the part"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "No source has this part"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "One source has this part"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+#, c-format
+msgid "%u or more sources have this part"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "Already read back and hashed"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "Still to be read"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "One block per part of the file being downloaded."
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "One block per part of the shared file."
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "One block per part of the shared file, coloured by how many sources have it."
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "One block per part of the shared file, showing how far the re-hash has read."
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "In between, darkening as sources are added"
+msgstr ""
+
 #: src/PartFileConvert.cpp
 msgid "Waiting for partfile convert thread to die..."
 msgstr ""
@@ -7364,8 +7397,8 @@ msgid "Shares File List"
 msgstr "Delte Filer"
 
 #: src/SharedFilesCtrl.cpp
-msgid "Obtained Parts"
-msgstr "Sendte Dele"
+msgid "Source Availability"
+msgstr ""
 
 #: src/SharedFilesCtrl.cpp
 msgid "Directory Path"
@@ -9191,6 +9224,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "Obtained Parts"
+#~ msgstr "Sendte Dele"
 
 #, fuzzy
 #~ msgid "Available Parts"

--- a/po/de.po
+++ b/po/de.po
@@ -5608,17 +5608,17 @@ msgstr ""
 
 #: src/PartBarLegendUI.cpp
 #, fuzzy
-msgid "No source has this part"
+msgid "No other source has this part"
 msgstr "Dieser Befehl sollte keine Parameter haben."
 
 #: src/PartBarLegendUI.cpp
 #, fuzzy
-msgid "One source has this part"
+msgid "One other source has this part"
 msgstr "Dieser Befehl sollte keine Parameter haben."
 
 #: src/PartBarLegendUI.cpp
 #, fuzzy, c-format
-msgid "%u or more sources have this part"
+msgid "%u or more other sources have this part"
 msgstr "Dieser Befehl sollte keine Parameter haben."
 
 #: src/PartBarLegendUI.cpp
@@ -5640,7 +5640,7 @@ msgstr "Hier den Serverport eingeben."
 
 #: src/PartBarLegendUI.cpp
 #, fuzzy
-msgid "One block per part of the shared file, coloured by how many sources have it."
+msgid "One block per part of the shared file, coloured by how many other sources have it."
 msgstr "Hier den Serverport eingeben."
 
 #: src/PartBarLegendUI.cpp
@@ -5649,7 +5649,7 @@ msgid "One block per part of the shared file, showing how far the re-hash has re
 msgstr "Hier den Serverport eingeben."
 
 #: src/PartBarLegendUI.cpp
-msgid "In between, darkening as sources are added"
+msgid "In between, darkening as other sources are added"
 msgstr ""
 
 #: src/PartFileConvert.cpp

--- a/po/de.po
+++ b/po/de.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-02 12:15+0200\n"
+"POT-Creation-Date: 2026-09-04 07:50+0200\n"
 "PO-Revision-Date: 2026-09-03 11:02+0000\n"
 "Last-Translator: Werner Mahr <werner@vollstreckernet.de>\n"
 "Language-Team: German <>\n"
@@ -2823,48 +2823,10 @@ msgstr ""
 " Nur ein Slot wurde vergeben."
 
 #: src/GenericClientListCtrl.cpp
-#, fuzzy
-msgid "This source does not have the part"
-msgstr "Dieser Befehl sollte keine Parameter haben."
-
-#: src/GenericClientListCtrl.cpp
-msgid "You and this source both have the part"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "Being downloaded from this source now"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "The next part that will be asked of this source"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "This source has the part and you still need it"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "This peer already has the part"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "This peer does not have the part"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "One block per part of the file being downloaded."
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-#, fuzzy
-msgid "One block per part of the shared file."
-msgstr "Hier den Serverport eingeben."
-
-#: src/GenericClientListCtrl.cpp
 msgid "Swap to this file"
 msgstr "Zu dieser Datei verschieben"
 
-#: src/GenericClientListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Colour legend"
 msgstr ""
 
@@ -5615,6 +5577,81 @@ msgstr "Text"
 msgid "Using config dir: %s"
 msgstr "Verwende Konfigurationsverzeichnis: %s"
 
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "This source does not have the part"
+msgstr "Dieser Befehl sollte keine Parameter haben."
+
+#: src/PartBarLegendUI.cpp
+msgid "You and this source both have the part"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "Being downloaded from this source now"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "The next part that will be asked of this source"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "This source has the part and you still need it"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "This peer already has the part"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "This peer does not have the part"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "No source has this part"
+msgstr "Dieser Befehl sollte keine Parameter haben."
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "One source has this part"
+msgstr "Dieser Befehl sollte keine Parameter haben."
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy, c-format
+msgid "%u or more sources have this part"
+msgstr "Dieser Befehl sollte keine Parameter haben."
+
+#: src/PartBarLegendUI.cpp
+msgid "Already read back and hashed"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "Still to be read"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "One block per part of the file being downloaded."
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "One block per part of the shared file."
+msgstr "Hier den Serverport eingeben."
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "One block per part of the shared file, coloured by how many sources have it."
+msgstr "Hier den Serverport eingeben."
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "One block per part of the shared file, showing how far the re-hash has read."
+msgstr "Hier den Serverport eingeben."
+
+#: src/PartBarLegendUI.cpp
+msgid "In between, darkening as sources are added"
+msgstr ""
+
 #: src/PartFileConvert.cpp
 msgid "Waiting for partfile convert thread to die..."
 msgstr "Warte auf Ende des Umwandlungsthreads für unfertige Dateien..."
@@ -7422,8 +7459,9 @@ msgid "Shares File List"
 msgstr "Liste der Freigaben"
 
 #: src/SharedFilesCtrl.cpp
-msgid "Obtained Parts"
-msgstr "Erhaltene Teile"
+#, fuzzy
+msgid "Source Availability"
+msgstr "Verfügbarkeit"
 
 #: src/SharedFilesCtrl.cpp
 msgid "Directory Path"
@@ -9313,6 +9351,9 @@ msgstr "aMule scheint zu laufen. Bitte schließen und das Entfernprogram erneut 
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "Entferne Benutzerdaten von $APPDATA\\aMule..."
+
+#~ msgid "Obtained Parts"
+#~ msgstr "Erhaltene Teile"
 
 #~ msgid "Available Parts"
 #~ msgstr "Verfügbare Teile"

--- a/po/el.po
+++ b/po/el.po
@@ -5647,17 +5647,17 @@ msgstr ""
 
 #: src/PartBarLegendUI.cpp
 #, fuzzy
-msgid "No source has this part"
+msgid "No other source has this part"
 msgstr "Αυτή η εντολή δεν πρέπει να έχει παραμέτρους."
 
 #: src/PartBarLegendUI.cpp
 #, fuzzy
-msgid "One source has this part"
+msgid "One other source has this part"
 msgstr "Αυτή η εντολή δεν πρέπει να έχει παραμέτρους."
 
 #: src/PartBarLegendUI.cpp
 #, fuzzy, c-format
-msgid "%u or more sources have this part"
+msgid "%u or more other sources have this part"
 msgstr "Αυτή η εντολή δεν πρέπει να έχει παραμέτρους."
 
 #: src/PartBarLegendUI.cpp
@@ -5679,7 +5679,7 @@ msgstr "Γράψτε την θύρα του διακομιστή εδώ."
 
 #: src/PartBarLegendUI.cpp
 #, fuzzy
-msgid "One block per part of the shared file, coloured by how many sources have it."
+msgid "One block per part of the shared file, coloured by how many other sources have it."
 msgstr "Γράψτε την θύρα του διακομιστή εδώ."
 
 #: src/PartBarLegendUI.cpp
@@ -5688,7 +5688,7 @@ msgid "One block per part of the shared file, showing how far the re-hash has re
 msgstr "Γράψτε την θύρα του διακομιστή εδώ."
 
 #: src/PartBarLegendUI.cpp
-msgid "In between, darkening as sources are added"
+msgid "In between, darkening as other sources are added"
 msgstr ""
 
 #: src/PartFileConvert.cpp

--- a/po/el.po
+++ b/po/el.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-02 12:15+0200\n"
+"POT-Creation-Date: 2026-09-04 07:50+0200\n"
 "PO-Revision-Date: 2026-09-03 11:02+0000\n"
 "Last-Translator: Dimitris <dgalanak@yahoo.com>\n"
 "Language-Team: Greek\n"
@@ -2834,48 +2834,10 @@ msgstr ""
 " Γι αυτό μόνο μία ανατέθηκε."
 
 #: src/GenericClientListCtrl.cpp
-#, fuzzy
-msgid "This source does not have the part"
-msgstr "Αυτή η εντολή δεν πρέπει να έχει παραμέτρους."
-
-#: src/GenericClientListCtrl.cpp
-msgid "You and this source both have the part"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "Being downloaded from this source now"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "The next part that will be asked of this source"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "This source has the part and you still need it"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "This peer already has the part"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "This peer does not have the part"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "One block per part of the file being downloaded."
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-#, fuzzy
-msgid "One block per part of the shared file."
-msgstr "Γράψτε την θύρα του διακομιστή εδώ."
-
-#: src/GenericClientListCtrl.cpp
 msgid "Swap to this file"
 msgstr "Εναλλαγή σε αυτό το αρχείο"
 
-#: src/GenericClientListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Colour legend"
 msgstr ""
 
@@ -5654,6 +5616,81 @@ msgstr "Κείμενο "
 msgid "Using config dir: %s"
 msgstr ""
 
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "This source does not have the part"
+msgstr "Αυτή η εντολή δεν πρέπει να έχει παραμέτρους."
+
+#: src/PartBarLegendUI.cpp
+msgid "You and this source both have the part"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "Being downloaded from this source now"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "The next part that will be asked of this source"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "This source has the part and you still need it"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "This peer already has the part"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "This peer does not have the part"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "No source has this part"
+msgstr "Αυτή η εντολή δεν πρέπει να έχει παραμέτρους."
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "One source has this part"
+msgstr "Αυτή η εντολή δεν πρέπει να έχει παραμέτρους."
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy, c-format
+msgid "%u or more sources have this part"
+msgstr "Αυτή η εντολή δεν πρέπει να έχει παραμέτρους."
+
+#: src/PartBarLegendUI.cpp
+msgid "Already read back and hashed"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "Still to be read"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "One block per part of the file being downloaded."
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "One block per part of the shared file."
+msgstr "Γράψτε την θύρα του διακομιστή εδώ."
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "One block per part of the shared file, coloured by how many sources have it."
+msgstr "Γράψτε την θύρα του διακομιστή εδώ."
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "One block per part of the shared file, showing how far the re-hash has read."
+msgstr "Γράψτε την θύρα του διακομιστή εδώ."
+
+#: src/PartBarLegendUI.cpp
+msgid "In between, darkening as sources are added"
+msgstr ""
+
 #: src/PartFileConvert.cpp
 msgid "Waiting for partfile convert thread to die..."
 msgstr ""
@@ -7480,8 +7517,9 @@ msgid "Shares File List"
 msgstr "Κοινόχρηστα αρχεία"
 
 #: src/SharedFilesCtrl.cpp
-msgid "Obtained Parts"
-msgstr "Κεκτημένα τμήματα"
+#, fuzzy
+msgid "Source Availability"
+msgstr "Διαθεσιμότητα"
 
 #: src/SharedFilesCtrl.cpp
 msgid "Directory Path"
@@ -9371,6 +9409,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "Obtained Parts"
+#~ msgstr "Κεκτημένα τμήματα"
 
 #, fuzzy
 #~ msgid "Available Parts"

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -5462,16 +5462,16 @@ msgid "This peer does not have the part"
 msgstr ""
 
 #: src/PartBarLegendUI.cpp
-msgid "No source has this part"
+msgid "No other source has this part"
 msgstr ""
 
 #: src/PartBarLegendUI.cpp
-msgid "One source has this part"
+msgid "One other source has this part"
 msgstr ""
 
 #: src/PartBarLegendUI.cpp
 #, c-format
-msgid "%u or more sources have this part"
+msgid "%u or more other sources have this part"
 msgstr ""
 
 #: src/PartBarLegendUI.cpp
@@ -5491,7 +5491,7 @@ msgid "One block per part of the shared file."
 msgstr ""
 
 #: src/PartBarLegendUI.cpp
-msgid "One block per part of the shared file, coloured by how many sources have it."
+msgid "One block per part of the shared file, coloured by how many other sources have it."
 msgstr ""
 
 #: src/PartBarLegendUI.cpp
@@ -5499,7 +5499,7 @@ msgid "One block per part of the shared file, showing how far the re-hash has re
 msgstr ""
 
 #: src/PartBarLegendUI.cpp
-msgid "In between, darkening as sources are added"
+msgid "In between, darkening as other sources are added"
 msgstr ""
 
 #: src/PartFileConvert.cpp

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-02 12:15+0200\n"
+"POT-Creation-Date: 2026-09-04 07:50+0200\n"
 "PO-Revision-Date: 2020-03-04 14:43+0100\n"
 "Last-Translator: Dévai Tamás <devait@vnet.hu>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -2720,46 +2720,10 @@ msgid ""
 msgstr ""
 
 #: src/GenericClientListCtrl.cpp
-msgid "This source does not have the part"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "You and this source both have the part"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "Being downloaded from this source now"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "The next part that will be asked of this source"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "This source has the part and you still need it"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "This peer already has the part"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "This peer does not have the part"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "One block per part of the file being downloaded."
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "One block per part of the shared file."
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
 msgid "Swap to this file"
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Colour legend"
 msgstr ""
 
@@ -5469,6 +5433,75 @@ msgstr ""
 msgid "Using config dir: %s"
 msgstr ""
 
+#: src/PartBarLegendUI.cpp
+msgid "This source does not have the part"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "You and this source both have the part"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "Being downloaded from this source now"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "The next part that will be asked of this source"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "This source has the part and you still need it"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "This peer already has the part"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "This peer does not have the part"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "No source has this part"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "One source has this part"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+#, c-format
+msgid "%u or more sources have this part"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "Already read back and hashed"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "Still to be read"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "One block per part of the file being downloaded."
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "One block per part of the shared file."
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "One block per part of the shared file, coloured by how many sources have it."
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "One block per part of the shared file, showing how far the re-hash has read."
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "In between, darkening as sources are added"
+msgstr ""
+
 #: src/PartFileConvert.cpp
 msgid "Waiting for partfile convert thread to die..."
 msgstr ""
@@ -7211,7 +7244,7 @@ msgid "Shares File List"
 msgstr ""
 
 #: src/SharedFilesCtrl.cpp
-msgid "Obtained Parts"
+msgid "Source Availability"
 msgstr ""
 
 #: src/SharedFilesCtrl.cpp

--- a/po/es.po
+++ b/po/es.po
@@ -5576,17 +5576,17 @@ msgstr "Este par no tiene la parte"
 
 #: src/PartBarLegendUI.cpp
 #, fuzzy
-msgid "No source has this part"
+msgid "No other source has this part"
 msgstr "La fuente no tiene la parte"
 
 #: src/PartBarLegendUI.cpp
 #, fuzzy
-msgid "One source has this part"
+msgid "One other source has this part"
 msgstr "La fuente no tiene la parte"
 
 #: src/PartBarLegendUI.cpp
 #, fuzzy, c-format
-msgid "%u or more sources have this part"
+msgid "%u or more other sources have this part"
 msgstr "Ambos, tú y esta fuente, tenéis la parte"
 
 #: src/PartBarLegendUI.cpp
@@ -5607,7 +5607,7 @@ msgstr "Un bloque por parte del archivo compartido."
 
 #: src/PartBarLegendUI.cpp
 #, fuzzy
-msgid "One block per part of the shared file, coloured by how many sources have it."
+msgid "One block per part of the shared file, coloured by how many other sources have it."
 msgstr "Un bloque por parte del archivo compartido."
 
 #: src/PartBarLegendUI.cpp
@@ -5616,7 +5616,7 @@ msgid "One block per part of the shared file, showing how far the re-hash has re
 msgstr "Un bloque por parte del archivo compartido."
 
 #: src/PartBarLegendUI.cpp
-msgid "In between, darkening as sources are added"
+msgid "In between, darkening as other sources are added"
 msgstr ""
 
 #: src/PartFileConvert.cpp

--- a/po/es.po
+++ b/po/es.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-02 12:15+0200\n"
+"POT-Creation-Date: 2026-09-04 07:50+0200\n"
 "PO-Revision-Date: 2026-09-03 11:03+0000\n"
 "Last-Translator: Diego Heras <ngosang@hotmail.es>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/amule/amule-application/es/>\n"
@@ -2812,46 +2812,10 @@ msgstr ""
 " Solo se ha asignado uno."
 
 #: src/GenericClientListCtrl.cpp
-msgid "This source does not have the part"
-msgstr "La fuente no tiene la parte"
-
-#: src/GenericClientListCtrl.cpp
-msgid "You and this source both have the part"
-msgstr "Ambos, tú y esta fuente, tenéis la parte"
-
-#: src/GenericClientListCtrl.cpp
-msgid "Being downloaded from this source now"
-msgstr "Está siendo descargado de esta fuente ahora"
-
-#: src/GenericClientListCtrl.cpp
-msgid "The next part that will be asked of this source"
-msgstr "La próxima parte se le pedirá a esta fuente"
-
-#: src/GenericClientListCtrl.cpp
-msgid "This source has the part and you still need it"
-msgstr "Esta fuente tiene la parte y todavía la necesitas"
-
-#: src/GenericClientListCtrl.cpp
-msgid "This peer already has the part"
-msgstr "Este par ya tiene la parte"
-
-#: src/GenericClientListCtrl.cpp
-msgid "This peer does not have the part"
-msgstr "Este par no tiene la parte"
-
-#: src/GenericClientListCtrl.cpp
-msgid "One block per part of the file being downloaded."
-msgstr "Un bloque por parte del archivo que se está descargando."
-
-#: src/GenericClientListCtrl.cpp
-msgid "One block per part of the shared file."
-msgstr "Un bloque por parte del archivo compartido."
-
-#: src/GenericClientListCtrl.cpp
 msgid "Swap to this file"
 msgstr "Intercambiar a este archivo"
 
-#: src/GenericClientListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Colour legend"
 msgstr "Leyenda de color"
 
@@ -5582,6 +5546,79 @@ msgstr "Texto"
 msgid "Using config dir: %s"
 msgstr "Usando el directorio de configuración: %s"
 
+#: src/PartBarLegendUI.cpp
+msgid "This source does not have the part"
+msgstr "La fuente no tiene la parte"
+
+#: src/PartBarLegendUI.cpp
+msgid "You and this source both have the part"
+msgstr "Ambos, tú y esta fuente, tenéis la parte"
+
+#: src/PartBarLegendUI.cpp
+msgid "Being downloaded from this source now"
+msgstr "Está siendo descargado de esta fuente ahora"
+
+#: src/PartBarLegendUI.cpp
+msgid "The next part that will be asked of this source"
+msgstr "La próxima parte se le pedirá a esta fuente"
+
+#: src/PartBarLegendUI.cpp
+msgid "This source has the part and you still need it"
+msgstr "Esta fuente tiene la parte y todavía la necesitas"
+
+#: src/PartBarLegendUI.cpp
+msgid "This peer already has the part"
+msgstr "Este par ya tiene la parte"
+
+#: src/PartBarLegendUI.cpp
+msgid "This peer does not have the part"
+msgstr "Este par no tiene la parte"
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "No source has this part"
+msgstr "La fuente no tiene la parte"
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "One source has this part"
+msgstr "La fuente no tiene la parte"
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy, c-format
+msgid "%u or more sources have this part"
+msgstr "Ambos, tú y esta fuente, tenéis la parte"
+
+#: src/PartBarLegendUI.cpp
+msgid "Already read back and hashed"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "Still to be read"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "One block per part of the file being downloaded."
+msgstr "Un bloque por parte del archivo que se está descargando."
+
+#: src/PartBarLegendUI.cpp
+msgid "One block per part of the shared file."
+msgstr "Un bloque por parte del archivo compartido."
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "One block per part of the shared file, coloured by how many sources have it."
+msgstr "Un bloque por parte del archivo compartido."
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "One block per part of the shared file, showing how far the re-hash has read."
+msgstr "Un bloque por parte del archivo compartido."
+
+#: src/PartBarLegendUI.cpp
+msgid "In between, darkening as sources are added"
+msgstr ""
+
 #: src/PartFileConvert.cpp
 msgid "Waiting for partfile convert thread to die..."
 msgstr "Esperando que la tarea de conversión del archivo de partes termine..."
@@ -7360,8 +7397,9 @@ msgid "Shares File List"
 msgstr "Lista de compartidos"
 
 #: src/SharedFilesCtrl.cpp
-msgid "Obtained Parts"
-msgstr "Partes obtenidas"
+#, fuzzy
+msgid "Source Availability"
+msgstr "Disponibilidad"
 
 #: src/SharedFilesCtrl.cpp
 msgid "Directory Path"
@@ -9248,6 +9286,9 @@ msgstr "aMule parece estar en ejecución. Por favor, ciérrelo y vuelva a ejecut
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "Eliminando los datos de usuario en $APPDATA\\aMule..."
+
+#~ msgid "Obtained Parts"
+#~ msgstr "Partes obtenidas"
 
 #~ msgid "Available Parts"
 #~ msgstr "Partes disponibles"

--- a/po/es.po
+++ b/po/es.po
@@ -5575,27 +5575,25 @@ msgid "This peer does not have the part"
 msgstr "Este par no tiene la parte"
 
 #: src/PartBarLegendUI.cpp
-#, fuzzy
 msgid "No other source has this part"
-msgstr "La fuente no tiene la parte"
+msgstr "Ninguna otra fuente tiene esta parte"
 
 #: src/PartBarLegendUI.cpp
-#, fuzzy
 msgid "One other source has this part"
-msgstr "La fuente no tiene la parte"
+msgstr "Otra fuente tiene esta parte"
 
 #: src/PartBarLegendUI.cpp
-#, fuzzy, c-format
+#, c-format
 msgid "%u or more other sources have this part"
-msgstr "Ambos, tú y esta fuente, tenéis la parte"
+msgstr "Otras %u fuentes o más tienen esta parte"
 
 #: src/PartBarLegendUI.cpp
 msgid "Already read back and hashed"
-msgstr ""
+msgstr "Ya releída y con el hash calculado"
 
 #: src/PartBarLegendUI.cpp
 msgid "Still to be read"
-msgstr ""
+msgstr "Pendiente de leer"
 
 #: src/PartBarLegendUI.cpp
 msgid "One block per part of the file being downloaded."
@@ -5606,18 +5604,16 @@ msgid "One block per part of the shared file."
 msgstr "Un bloque por parte del archivo compartido."
 
 #: src/PartBarLegendUI.cpp
-#, fuzzy
 msgid "One block per part of the shared file, coloured by how many other sources have it."
-msgstr "Un bloque por parte del archivo compartido."
+msgstr "Un bloque por parte del archivo compartido, coloreado según cuántas otras fuentes la tienen."
 
 #: src/PartBarLegendUI.cpp
-#, fuzzy
 msgid "One block per part of the shared file, showing how far the re-hash has read."
-msgstr "Un bloque por parte del archivo compartido."
+msgstr "Un bloque por parte del archivo compartido, que muestra hasta dónde ha leído el recálculo del hash."
 
 #: src/PartBarLegendUI.cpp
 msgid "In between, darkening as other sources are added"
-msgstr ""
+msgstr "Intermedio, oscureciéndose a medida que se añaden otras fuentes"
 
 #: src/PartFileConvert.cpp
 msgid "Waiting for partfile convert thread to die..."
@@ -7397,9 +7393,8 @@ msgid "Shares File List"
 msgstr "Lista de compartidos"
 
 #: src/SharedFilesCtrl.cpp
-#, fuzzy
 msgid "Source Availability"
-msgstr "Disponibilidad"
+msgstr "Disponibilidad de fuentes"
 
 #: src/SharedFilesCtrl.cpp
 msgid "Directory Path"

--- a/po/et_EE.po
+++ b/po/et_EE.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-02 12:15+0200\n"
+"POT-Creation-Date: 2026-09-04 07:50+0200\n"
 "PO-Revision-Date: 2026-09-03 11:03+0000\n"
 "Last-Translator: \n"
 "Language-Team: Estonian <kde-i18n-doc@kde.org>\n"
@@ -2818,48 +2818,10 @@ msgstr ""
 "Määrati ainult üks slott."
 
 #: src/GenericClientListCtrl.cpp
-#, fuzzy
-msgid "This source does not have the part"
-msgstr "Sellel käsul ei tohiks olla ühtegi parameetrit."
-
-#: src/GenericClientListCtrl.cpp
-msgid "You and this source both have the part"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "Being downloaded from this source now"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "The next part that will be asked of this source"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "This source has the part and you still need it"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "This peer already has the part"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "This peer does not have the part"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "One block per part of the file being downloaded."
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-#, fuzzy
-msgid "One block per part of the shared file."
-msgstr "Sisesta siia serveri port."
-
-#: src/GenericClientListCtrl.cpp
 msgid "Swap to this file"
 msgstr "Tõsta selle faili külge"
 
-#: src/GenericClientListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Colour legend"
 msgstr ""
 
@@ -5621,6 +5583,81 @@ msgstr "Tekst"
 msgid "Using config dir: %s"
 msgstr "Kasutan seadete kataloogi: %s"
 
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "This source does not have the part"
+msgstr "Sellel käsul ei tohiks olla ühtegi parameetrit."
+
+#: src/PartBarLegendUI.cpp
+msgid "You and this source both have the part"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "Being downloaded from this source now"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "The next part that will be asked of this source"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "This source has the part and you still need it"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "This peer already has the part"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "This peer does not have the part"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "No source has this part"
+msgstr "Sellel käsul ei tohiks olla ühtegi parameetrit."
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "One source has this part"
+msgstr "Sellel käsul ei tohiks olla ühtegi parameetrit."
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy, c-format
+msgid "%u or more sources have this part"
+msgstr "Sellel käsul ei tohiks olla ühtegi parameetrit."
+
+#: src/PartBarLegendUI.cpp
+msgid "Already read back and hashed"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "Still to be read"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "One block per part of the file being downloaded."
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "One block per part of the shared file."
+msgstr "Sisesta siia serveri port."
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "One block per part of the shared file, coloured by how many sources have it."
+msgstr "Sisesta siia serveri port."
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "One block per part of the shared file, showing how far the re-hash has read."
+msgstr "Sisesta siia serveri port."
+
+#: src/PartBarLegendUI.cpp
+msgid "In between, darkening as sources are added"
+msgstr ""
+
 #: src/PartFileConvert.cpp
 msgid "Waiting for partfile convert thread to die..."
 msgstr "Ootan osafaili konverteerimise lõime suremist ..."
@@ -7435,8 +7472,9 @@ msgid "Shares File List"
 msgstr "Jagatud failid"
 
 #: src/SharedFilesCtrl.cpp
-msgid "Obtained Parts"
-msgstr "Saadud osi"
+#, fuzzy
+msgid "Source Availability"
+msgstr "Saadavus"
 
 #: src/SharedFilesCtrl.cpp
 msgid "Directory Path"
@@ -9301,6 +9339,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "Obtained Parts"
+#~ msgstr "Saadud osi"
 
 #~ msgid "Available Parts"
 #~ msgstr "Saadaval osi"

--- a/po/et_EE.po
+++ b/po/et_EE.po
@@ -5614,17 +5614,17 @@ msgstr ""
 
 #: src/PartBarLegendUI.cpp
 #, fuzzy
-msgid "No source has this part"
+msgid "No other source has this part"
 msgstr "Sellel käsul ei tohiks olla ühtegi parameetrit."
 
 #: src/PartBarLegendUI.cpp
 #, fuzzy
-msgid "One source has this part"
+msgid "One other source has this part"
 msgstr "Sellel käsul ei tohiks olla ühtegi parameetrit."
 
 #: src/PartBarLegendUI.cpp
 #, fuzzy, c-format
-msgid "%u or more sources have this part"
+msgid "%u or more other sources have this part"
 msgstr "Sellel käsul ei tohiks olla ühtegi parameetrit."
 
 #: src/PartBarLegendUI.cpp
@@ -5646,7 +5646,7 @@ msgstr "Sisesta siia serveri port."
 
 #: src/PartBarLegendUI.cpp
 #, fuzzy
-msgid "One block per part of the shared file, coloured by how many sources have it."
+msgid "One block per part of the shared file, coloured by how many other sources have it."
 msgstr "Sisesta siia serveri port."
 
 #: src/PartBarLegendUI.cpp
@@ -5655,7 +5655,7 @@ msgid "One block per part of the shared file, showing how far the re-hash has re
 msgstr "Sisesta siia serveri port."
 
 #: src/PartBarLegendUI.cpp
-msgid "In between, darkening as sources are added"
+msgid "In between, darkening as other sources are added"
 msgstr ""
 
 #: src/PartFileConvert.cpp

--- a/po/eu.po
+++ b/po/eu.po
@@ -5614,17 +5614,17 @@ msgstr ""
 
 #: src/PartBarLegendUI.cpp
 #, fuzzy
-msgid "No source has this part"
+msgid "No other source has this part"
 msgstr "Komando honek ez luke parametrorik eduki beharko."
 
 #: src/PartBarLegendUI.cpp
 #, fuzzy
-msgid "One source has this part"
+msgid "One other source has this part"
 msgstr "Komando honek ez luke parametrorik eduki beharko."
 
 #: src/PartBarLegendUI.cpp
 #, fuzzy, c-format
-msgid "%u or more sources have this part"
+msgid "%u or more other sources have this part"
 msgstr "Komando honek ez luke parametrorik eduki beharko."
 
 #: src/PartBarLegendUI.cpp
@@ -5646,7 +5646,7 @@ msgstr "Idatzi zerbitzariaren ataka hemen."
 
 #: src/PartBarLegendUI.cpp
 #, fuzzy
-msgid "One block per part of the shared file, coloured by how many sources have it."
+msgid "One block per part of the shared file, coloured by how many other sources have it."
 msgstr "Idatzi zerbitzariaren ataka hemen."
 
 #: src/PartBarLegendUI.cpp
@@ -5655,7 +5655,7 @@ msgid "One block per part of the shared file, showing how far the re-hash has re
 msgstr "Idatzi zerbitzariaren ataka hemen."
 
 #: src/PartBarLegendUI.cpp
-msgid "In between, darkening as sources are added"
+msgid "In between, darkening as other sources are added"
 msgstr ""
 
 #: src/PartFileConvert.cpp

--- a/po/eu.po
+++ b/po/eu.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-02 12:15+0200\n"
+"POT-Creation-Date: 2026-09-04 07:50+0200\n"
 "PO-Revision-Date: 2026-09-03 11:04+0000\n"
 "Last-Translator: Piarres Beobide <pi@beobide.net>\n"
 "Language-Team: Euskara <librezale@librezale.org>\n"
@@ -2819,48 +2819,10 @@ msgstr ""
 " Ataka bat bakarrik dago sinaturik."
 
 #: src/GenericClientListCtrl.cpp
-#, fuzzy
-msgid "This source does not have the part"
-msgstr "Komando honek ez luke parametrorik eduki beharko."
-
-#: src/GenericClientListCtrl.cpp
-msgid "You and this source both have the part"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "Being downloaded from this source now"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "The next part that will be asked of this source"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "This source has the part and you still need it"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "This peer already has the part"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "This peer does not have the part"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "One block per part of the file being downloaded."
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-#, fuzzy
-msgid "One block per part of the shared file."
-msgstr "Idatzi zerbitzariaren ataka hemen."
-
-#: src/GenericClientListCtrl.cpp
 msgid "Swap to this file"
 msgstr "Swap fitxategi honentzat"
 
-#: src/GenericClientListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Colour legend"
 msgstr ""
 
@@ -5621,6 +5583,81 @@ msgstr "Testua"
 msgid "Using config dir: %s"
 msgstr "Konfigurazio direktorioa: %s"
 
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "This source does not have the part"
+msgstr "Komando honek ez luke parametrorik eduki beharko."
+
+#: src/PartBarLegendUI.cpp
+msgid "You and this source both have the part"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "Being downloaded from this source now"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "The next part that will be asked of this source"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "This source has the part and you still need it"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "This peer already has the part"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "This peer does not have the part"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "No source has this part"
+msgstr "Komando honek ez luke parametrorik eduki beharko."
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "One source has this part"
+msgstr "Komando honek ez luke parametrorik eduki beharko."
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy, c-format
+msgid "%u or more sources have this part"
+msgstr "Komando honek ez luke parametrorik eduki beharko."
+
+#: src/PartBarLegendUI.cpp
+msgid "Already read back and hashed"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "Still to be read"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "One block per part of the file being downloaded."
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "One block per part of the shared file."
+msgstr "Idatzi zerbitzariaren ataka hemen."
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "One block per part of the shared file, coloured by how many sources have it."
+msgstr "Idatzi zerbitzariaren ataka hemen."
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "One block per part of the shared file, showing how far the re-hash has read."
+msgstr "Idatzi zerbitzariaren ataka hemen."
+
+#: src/PartBarLegendUI.cpp
+msgid "In between, darkening as sources are added"
+msgstr ""
+
 #: src/PartFileConvert.cpp
 msgid "Waiting for partfile convert thread to die..."
 msgstr "Zati-fitxategiak aria bihurtzearen zain ixteko..."
@@ -7431,8 +7468,9 @@ msgid "Shares File List"
 msgstr "Partekatutako fitxategi zerrendak"
 
 #: src/SharedFilesCtrl.cpp
-msgid "Obtained Parts"
-msgstr "Eskuratutako zatiak"
+#, fuzzy
+msgid "Source Availability"
+msgstr "Eskuragarritasuna"
 
 #: src/SharedFilesCtrl.cpp
 msgid "Directory Path"
@@ -9301,6 +9339,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "Obtained Parts"
+#~ msgstr "Eskuratutako zatiak"
 
 #~ msgid "Available Parts"
 #~ msgstr "Zati eskuragarriak"

--- a/po/fi.po
+++ b/po/fi.po
@@ -5614,17 +5614,17 @@ msgstr ""
 
 #: src/PartBarLegendUI.cpp
 #, fuzzy
-msgid "No source has this part"
+msgid "No other source has this part"
 msgstr "Tämä komento ei tarvitse parametreja."
 
 #: src/PartBarLegendUI.cpp
 #, fuzzy
-msgid "One source has this part"
+msgid "One other source has this part"
 msgstr "Tämä komento ei tarvitse parametreja."
 
 #: src/PartBarLegendUI.cpp
 #, fuzzy, c-format
-msgid "%u or more sources have this part"
+msgid "%u or more other sources have this part"
 msgstr "Tämä komento ei tarvitse parametreja."
 
 #: src/PartBarLegendUI.cpp
@@ -5646,7 +5646,7 @@ msgstr "Syötä palvelimen portti tähän."
 
 #: src/PartBarLegendUI.cpp
 #, fuzzy
-msgid "One block per part of the shared file, coloured by how many sources have it."
+msgid "One block per part of the shared file, coloured by how many other sources have it."
 msgstr "Syötä palvelimen portti tähän."
 
 #: src/PartBarLegendUI.cpp
@@ -5655,7 +5655,7 @@ msgid "One block per part of the shared file, showing how far the re-hash has re
 msgstr "Syötä palvelimen portti tähän."
 
 #: src/PartBarLegendUI.cpp
-msgid "In between, darkening as sources are added"
+msgid "In between, darkening as other sources are added"
 msgstr ""
 
 #: src/PartFileConvert.cpp

--- a/po/fi.po
+++ b/po/fi.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-02 12:15+0200\n"
+"POT-Creation-Date: 2026-09-04 07:50+0200\n"
 "PO-Revision-Date: 2026-09-03 11:04+0000\n"
 "Last-Translator: Tapio Rantala <tapio.rantala@iki.fi>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -2819,48 +2819,10 @@ msgstr ""
 " Asetettiin yksi paikka."
 
 #: src/GenericClientListCtrl.cpp
-#, fuzzy
-msgid "This source does not have the part"
-msgstr "Tämä komento ei tarvitse parametreja."
-
-#: src/GenericClientListCtrl.cpp
-msgid "You and this source both have the part"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "Being downloaded from this source now"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "The next part that will be asked of this source"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "This source has the part and you still need it"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "This peer already has the part"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "This peer does not have the part"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "One block per part of the file being downloaded."
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-#, fuzzy
-msgid "One block per part of the shared file."
-msgstr "Syötä palvelimen portti tähän."
-
-#: src/GenericClientListCtrl.cpp
 msgid "Swap to this file"
 msgstr "Vaihda tähän tiedostoon"
 
-#: src/GenericClientListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Colour legend"
 msgstr ""
 
@@ -5621,6 +5583,81 @@ msgstr "Teksti"
 msgid "Using config dir: %s"
 msgstr "Asetuskansio: %s"
 
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "This source does not have the part"
+msgstr "Tämä komento ei tarvitse parametreja."
+
+#: src/PartBarLegendUI.cpp
+msgid "You and this source both have the part"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "Being downloaded from this source now"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "The next part that will be asked of this source"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "This source has the part and you still need it"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "This peer already has the part"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "This peer does not have the part"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "No source has this part"
+msgstr "Tämä komento ei tarvitse parametreja."
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "One source has this part"
+msgstr "Tämä komento ei tarvitse parametreja."
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy, c-format
+msgid "%u or more sources have this part"
+msgstr "Tämä komento ei tarvitse parametreja."
+
+#: src/PartBarLegendUI.cpp
+msgid "Already read back and hashed"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "Still to be read"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "One block per part of the file being downloaded."
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "One block per part of the shared file."
+msgstr "Syötä palvelimen portti tähän."
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "One block per part of the shared file, coloured by how many sources have it."
+msgstr "Syötä palvelimen portti tähän."
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "One block per part of the shared file, showing how far the re-hash has read."
+msgstr "Syötä palvelimen portti tähän."
+
+#: src/PartBarLegendUI.cpp
+msgid "In between, darkening as sources are added"
+msgstr ""
+
 #: src/PartFileConvert.cpp
 msgid "Waiting for partfile convert thread to die..."
 msgstr "Odotellaan osatiedostojen muuntosäikeen päättymistä..."
@@ -7431,8 +7468,9 @@ msgid "Shares File List"
 msgstr "Jaettujen tiedostojen lista"
 
 #: src/SharedFilesCtrl.cpp
-msgid "Obtained Parts"
-msgstr "Hankitut osat"
+#, fuzzy
+msgid "Source Availability"
+msgstr "Saatavuus"
 
 #: src/SharedFilesCtrl.cpp
 msgid "Directory Path"
@@ -9301,6 +9339,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "Obtained Parts"
+#~ msgstr "Hankitut osat"
 
 #~ msgid "Available Parts"
 #~ msgstr "Saatavilla olevat osat"

--- a/po/fr.po
+++ b/po/fr.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-02 12:15+0200\n"
+"POT-Creation-Date: 2026-09-04 07:50+0200\n"
 "PO-Revision-Date: 2026-09-03 11:04+0000\n"
 "Last-Translator: Dylan Aïssi <bob.dybian@gmail.com>\n"
 "Language-Team: Français\n"
@@ -2811,46 +2811,10 @@ msgstr ""
 " Seul un slot a été attribué."
 
 #: src/GenericClientListCtrl.cpp
-msgid "This source does not have the part"
-msgstr "Cette source n'a pas la partie"
-
-#: src/GenericClientListCtrl.cpp
-msgid "You and this source both have the part"
-msgstr "Vous et cette source avez tous les deux la partie"
-
-#: src/GenericClientListCtrl.cpp
-msgid "Being downloaded from this source now"
-msgstr "En cours de téléchargement depuis cette source"
-
-#: src/GenericClientListCtrl.cpp
-msgid "The next part that will be asked of this source"
-msgstr "La partie suivante qui sera demandée à cette source"
-
-#: src/GenericClientListCtrl.cpp
-msgid "This source has the part and you still need it"
-msgstr "Cette source a la partie et vous en avez encore besoin"
-
-#: src/GenericClientListCtrl.cpp
-msgid "This peer already has the part"
-msgstr "Ce pair a déjà la partie"
-
-#: src/GenericClientListCtrl.cpp
-msgid "This peer does not have the part"
-msgstr "Ce pair n'a pas la partie"
-
-#: src/GenericClientListCtrl.cpp
-msgid "One block per part of the file being downloaded."
-msgstr "Un bloc par partie du fichier en cours de téléchargement."
-
-#: src/GenericClientListCtrl.cpp
-msgid "One block per part of the shared file."
-msgstr "Un bloc par partie du fichier partagé."
-
-#: src/GenericClientListCtrl.cpp
 msgid "Swap to this file"
 msgstr "Échanger vers ce fichier"
 
-#: src/GenericClientListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Colour legend"
 msgstr "Légende des couleurs"
 
@@ -5577,6 +5541,79 @@ msgstr "Texte"
 msgid "Using config dir: %s"
 msgstr "Utilisation du répertoire de config : %s"
 
+#: src/PartBarLegendUI.cpp
+msgid "This source does not have the part"
+msgstr "Cette source n'a pas la partie"
+
+#: src/PartBarLegendUI.cpp
+msgid "You and this source both have the part"
+msgstr "Vous et cette source avez tous les deux la partie"
+
+#: src/PartBarLegendUI.cpp
+msgid "Being downloaded from this source now"
+msgstr "En cours de téléchargement depuis cette source"
+
+#: src/PartBarLegendUI.cpp
+msgid "The next part that will be asked of this source"
+msgstr "La partie suivante qui sera demandée à cette source"
+
+#: src/PartBarLegendUI.cpp
+msgid "This source has the part and you still need it"
+msgstr "Cette source a la partie et vous en avez encore besoin"
+
+#: src/PartBarLegendUI.cpp
+msgid "This peer already has the part"
+msgstr "Ce pair a déjà la partie"
+
+#: src/PartBarLegendUI.cpp
+msgid "This peer does not have the part"
+msgstr "Ce pair n'a pas la partie"
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "No source has this part"
+msgstr "Cette source n'a pas la partie"
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "One source has this part"
+msgstr "Cette source n'a pas la partie"
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy, c-format
+msgid "%u or more sources have this part"
+msgstr "Vous et cette source avez tous les deux la partie"
+
+#: src/PartBarLegendUI.cpp
+msgid "Already read back and hashed"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "Still to be read"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "One block per part of the file being downloaded."
+msgstr "Un bloc par partie du fichier en cours de téléchargement."
+
+#: src/PartBarLegendUI.cpp
+msgid "One block per part of the shared file."
+msgstr "Un bloc par partie du fichier partagé."
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "One block per part of the shared file, coloured by how many sources have it."
+msgstr "Un bloc par partie du fichier partagé."
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "One block per part of the shared file, showing how far the re-hash has read."
+msgstr "Un bloc par partie du fichier partagé."
+
+#: src/PartBarLegendUI.cpp
+msgid "In between, darkening as sources are added"
+msgstr ""
+
 #: src/PartFileConvert.cpp
 msgid "Waiting for partfile convert thread to die..."
 msgstr "Attente de la mort du processus de conversion du fichier .part…"
@@ -7355,8 +7392,9 @@ msgid "Shares File List"
 msgstr "Partage de la liste des fichiers"
 
 #: src/SharedFilesCtrl.cpp
-msgid "Obtained Parts"
-msgstr "Parties obtenues"
+#, fuzzy
+msgid "Source Availability"
+msgstr "Disponibilité"
 
 #: src/SharedFilesCtrl.cpp
 msgid "Directory Path"
@@ -9243,6 +9281,9 @@ msgstr "aMule semble être en cours d'exécution. Veuillez le fermer et relancer
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "Suppression des données d'utilisateur sur $APPDATA\\aMule…"
+
+#~ msgid "Obtained Parts"
+#~ msgstr "Parties obtenues"
 
 #~ msgid "Available Parts"
 #~ msgstr "Parties Disponibles"

--- a/po/fr.po
+++ b/po/fr.po
@@ -5571,17 +5571,17 @@ msgstr "Ce pair n'a pas la partie"
 
 #: src/PartBarLegendUI.cpp
 #, fuzzy
-msgid "No source has this part"
+msgid "No other source has this part"
 msgstr "Cette source n'a pas la partie"
 
 #: src/PartBarLegendUI.cpp
 #, fuzzy
-msgid "One source has this part"
+msgid "One other source has this part"
 msgstr "Cette source n'a pas la partie"
 
 #: src/PartBarLegendUI.cpp
 #, fuzzy, c-format
-msgid "%u or more sources have this part"
+msgid "%u or more other sources have this part"
 msgstr "Vous et cette source avez tous les deux la partie"
 
 #: src/PartBarLegendUI.cpp
@@ -5602,7 +5602,7 @@ msgstr "Un bloc par partie du fichier partagé."
 
 #: src/PartBarLegendUI.cpp
 #, fuzzy
-msgid "One block per part of the shared file, coloured by how many sources have it."
+msgid "One block per part of the shared file, coloured by how many other sources have it."
 msgstr "Un bloc par partie du fichier partagé."
 
 #: src/PartBarLegendUI.cpp
@@ -5611,7 +5611,7 @@ msgid "One block per part of the shared file, showing how far the re-hash has re
 msgstr "Un bloc par partie du fichier partagé."
 
 #: src/PartBarLegendUI.cpp
-msgid "In between, darkening as sources are added"
+msgid "In between, darkening as other sources are added"
 msgstr ""
 
 #: src/PartFileConvert.cpp

--- a/po/gl.po
+++ b/po/gl.po
@@ -5622,17 +5622,17 @@ msgstr ""
 
 #: src/PartBarLegendUI.cpp
 #, fuzzy
-msgid "No source has this part"
+msgid "No other source has this part"
 msgstr "Esta orde non debería ter ningún parámetro."
 
 #: src/PartBarLegendUI.cpp
 #, fuzzy
-msgid "One source has this part"
+msgid "One other source has this part"
 msgstr "Esta orde non debería ter ningún parámetro."
 
 #: src/PartBarLegendUI.cpp
 #, fuzzy, c-format
-msgid "%u or more sources have this part"
+msgid "%u or more other sources have this part"
 msgstr "Esta orde non debería ter ningún parámetro."
 
 #: src/PartBarLegendUI.cpp
@@ -5654,7 +5654,7 @@ msgstr "Introduza o porto do servidor aquí."
 
 #: src/PartBarLegendUI.cpp
 #, fuzzy
-msgid "One block per part of the shared file, coloured by how many sources have it."
+msgid "One block per part of the shared file, coloured by how many other sources have it."
 msgstr "Introduza o porto do servidor aquí."
 
 #: src/PartBarLegendUI.cpp
@@ -5663,7 +5663,7 @@ msgid "One block per part of the shared file, showing how far the re-hash has re
 msgstr "Introduza o porto do servidor aquí."
 
 #: src/PartBarLegendUI.cpp
-msgid "In between, darkening as sources are added"
+msgid "In between, darkening as other sources are added"
 msgstr ""
 
 #: src/PartFileConvert.cpp

--- a/po/gl.po
+++ b/po/gl.po
@@ -24,7 +24,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-02 12:15+0200\n"
+"POT-Creation-Date: 2026-09-04 07:50+0200\n"
 "PO-Revision-Date: 2026-09-03 11:05+0000\n"
 "Last-Translator: Pablo <parodper@gmail.com>\n"
 "Language-Team: http://forum.amule.org/index.php?topic=13883\n"
@@ -2836,48 +2836,10 @@ msgstr ""
 " Só se asignou un espazo."
 
 #: src/GenericClientListCtrl.cpp
-#, fuzzy
-msgid "This source does not have the part"
-msgstr "Esta orde non debería ter ningún parámetro."
-
-#: src/GenericClientListCtrl.cpp
-msgid "You and this source both have the part"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "Being downloaded from this source now"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "The next part that will be asked of this source"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "This source has the part and you still need it"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "This peer already has the part"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "This peer does not have the part"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "One block per part of the file being downloaded."
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-#, fuzzy
-msgid "One block per part of the shared file."
-msgstr "Introduza o porto do servidor aquí."
-
-#: src/GenericClientListCtrl.cpp
 msgid "Swap to this file"
 msgstr "Intercambiar a este ficheiro"
 
-#: src/GenericClientListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Colour legend"
 msgstr ""
 
@@ -5629,6 +5591,81 @@ msgstr "Texto"
 msgid "Using config dir: %s"
 msgstr "Usando directorio de configuración: %s"
 
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "This source does not have the part"
+msgstr "Esta orde non debería ter ningún parámetro."
+
+#: src/PartBarLegendUI.cpp
+msgid "You and this source both have the part"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "Being downloaded from this source now"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "The next part that will be asked of this source"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "This source has the part and you still need it"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "This peer already has the part"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "This peer does not have the part"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "No source has this part"
+msgstr "Esta orde non debería ter ningún parámetro."
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "One source has this part"
+msgstr "Esta orde non debería ter ningún parámetro."
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy, c-format
+msgid "%u or more sources have this part"
+msgstr "Esta orde non debería ter ningún parámetro."
+
+#: src/PartBarLegendUI.cpp
+msgid "Already read back and hashed"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "Still to be read"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "One block per part of the file being downloaded."
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "One block per part of the shared file."
+msgstr "Introduza o porto do servidor aquí."
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "One block per part of the shared file, coloured by how many sources have it."
+msgstr "Introduza o porto do servidor aquí."
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "One block per part of the shared file, showing how far the re-hash has read."
+msgstr "Introduza o porto do servidor aquí."
+
+#: src/PartBarLegendUI.cpp
+msgid "In between, darkening as sources are added"
+msgstr ""
+
 #: src/PartFileConvert.cpp
 msgid "Waiting for partfile convert thread to die..."
 msgstr "Esperando que o fío remate de converter os ficheiros partidos..."
@@ -7437,8 +7474,9 @@ msgid "Shares File List"
 msgstr "Lista de ficheiros compartidos"
 
 #: src/SharedFilesCtrl.cpp
-msgid "Obtained Parts"
-msgstr "Partes obtidas"
+#, fuzzy
+msgid "Source Availability"
+msgstr "Dispoñibilidade"
 
 #: src/SharedFilesCtrl.cpp
 msgid "Directory Path"
@@ -9323,6 +9361,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "Obtained Parts"
+#~ msgstr "Partes obtidas"
 
 #~ msgid "Available Parts"
 #~ msgstr "Partes dispoñibles"

--- a/po/he.po
+++ b/po/he.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-02 12:15+0200\n"
+"POT-Creation-Date: 2026-09-04 07:50+0200\n"
 "PO-Revision-Date: 2026-09-03 11:05+0000\n"
 "Last-Translator: Peace Kramer <kpeace1@gmail.com>\n"
 "Language-Team: Hebrew\n"
@@ -2789,46 +2789,10 @@ msgstr ""
 "רק משבצת אחת הוגדרה."
 
 #: src/GenericClientListCtrl.cpp
-msgid "This source does not have the part"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "You and this source both have the part"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "Being downloaded from this source now"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "The next part that will be asked of this source"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "This source has the part and you still need it"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "This peer already has the part"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "This peer does not have the part"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "One block per part of the file being downloaded."
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "One block per part of the shared file."
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
 msgid "Swap to this file"
 msgstr "החלף לקובץ זה"
 
-#: src/GenericClientListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Colour legend"
 msgstr ""
 
@@ -5590,6 +5554,75 @@ msgstr "טקסט"
 msgid "Using config dir: %s"
 msgstr ""
 
+#: src/PartBarLegendUI.cpp
+msgid "This source does not have the part"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "You and this source both have the part"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "Being downloaded from this source now"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "The next part that will be asked of this source"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "This source has the part and you still need it"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "This peer already has the part"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "This peer does not have the part"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "No source has this part"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "One source has this part"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+#, c-format
+msgid "%u or more sources have this part"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "Already read back and hashed"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "Still to be read"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "One block per part of the file being downloaded."
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "One block per part of the shared file."
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "One block per part of the shared file, coloured by how many sources have it."
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "One block per part of the shared file, showing how far the re-hash has read."
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "In between, darkening as sources are added"
+msgstr ""
+
 #: src/PartFileConvert.cpp
 msgid "Waiting for partfile convert thread to die..."
 msgstr ""
@@ -7403,8 +7436,9 @@ msgid "Shares File List"
 msgstr "קבצים משותפים"
 
 #: src/SharedFilesCtrl.cpp
-msgid "Obtained Parts"
-msgstr "חלקים שהושגו"
+#, fuzzy
+msgid "Source Availability"
+msgstr "זמינות"
 
 #: src/SharedFilesCtrl.cpp
 msgid "Directory Path"
@@ -9270,6 +9304,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "Obtained Parts"
+#~ msgstr "חלקים שהושגו"
 
 #, fuzzy
 #~ msgid "Available Parts"

--- a/po/he.po
+++ b/po/he.po
@@ -5583,16 +5583,16 @@ msgid "This peer does not have the part"
 msgstr ""
 
 #: src/PartBarLegendUI.cpp
-msgid "No source has this part"
+msgid "No other source has this part"
 msgstr ""
 
 #: src/PartBarLegendUI.cpp
-msgid "One source has this part"
+msgid "One other source has this part"
 msgstr ""
 
 #: src/PartBarLegendUI.cpp
 #, c-format
-msgid "%u or more sources have this part"
+msgid "%u or more other sources have this part"
 msgstr ""
 
 #: src/PartBarLegendUI.cpp
@@ -5612,7 +5612,7 @@ msgid "One block per part of the shared file."
 msgstr ""
 
 #: src/PartBarLegendUI.cpp
-msgid "One block per part of the shared file, coloured by how many sources have it."
+msgid "One block per part of the shared file, coloured by how many other sources have it."
 msgstr ""
 
 #: src/PartBarLegendUI.cpp
@@ -5620,7 +5620,7 @@ msgid "One block per part of the shared file, showing how far the re-hash has re
 msgstr ""
 
 #: src/PartBarLegendUI.cpp
-msgid "In between, darkening as sources are added"
+msgid "In between, darkening as other sources are added"
 msgstr ""
 
 #: src/PartFileConvert.cpp

--- a/po/hr.po
+++ b/po/hr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-02 12:15+0200\n"
+"POT-Creation-Date: 2026-09-04 07:50+0200\n"
 "PO-Revision-Date: 2026-09-03 11:05+0000\n"
 "Last-Translator: Sebastiano Pistore <sebastiano.pistore.info@aol.com>\n"
 "Language-Team: https://github.com/amule-org/amule <forum@aMule.org>\n"
@@ -2781,46 +2781,10 @@ msgid ""
 msgstr ""
 
 #: src/GenericClientListCtrl.cpp
-msgid "This source does not have the part"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "You and this source both have the part"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "Being downloaded from this source now"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "The next part that will be asked of this source"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "This source has the part and you still need it"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "This peer already has the part"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "This peer does not have the part"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "One block per part of the file being downloaded."
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "One block per part of the shared file."
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
 msgid "Swap to this file"
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Colour legend"
 msgstr ""
 
@@ -5586,6 +5550,75 @@ msgstr "Tekst"
 msgid "Using config dir: %s"
 msgstr ""
 
+#: src/PartBarLegendUI.cpp
+msgid "This source does not have the part"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "You and this source both have the part"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "Being downloaded from this source now"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "The next part that will be asked of this source"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "This source has the part and you still need it"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "This peer already has the part"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "This peer does not have the part"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "No source has this part"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "One source has this part"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+#, c-format
+msgid "%u or more sources have this part"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "Already read back and hashed"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "Still to be read"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "One block per part of the file being downloaded."
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "One block per part of the shared file."
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "One block per part of the shared file, coloured by how many sources have it."
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "One block per part of the shared file, showing how far the re-hash has read."
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "In between, darkening as sources are added"
+msgstr ""
+
 #: src/PartFileConvert.cpp
 msgid "Waiting for partfile convert thread to die..."
 msgstr ""
@@ -7402,8 +7435,9 @@ msgid "Shares File List"
 msgstr "Dijeljeni fajlovi"
 
 #: src/SharedFilesCtrl.cpp
-msgid "Obtained Parts"
-msgstr "Dobiveni dijelovi"
+#, fuzzy
+msgid "Source Availability"
+msgstr "Dostupnost"
 
 #: src/SharedFilesCtrl.cpp
 msgid "Directory Path"
@@ -9225,6 +9259,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "Obtained Parts"
+#~ msgstr "Dobiveni dijelovi"
 
 #, fuzzy
 #~ msgid "Available Parts"

--- a/po/hr.po
+++ b/po/hr.po
@@ -5579,16 +5579,16 @@ msgid "This peer does not have the part"
 msgstr ""
 
 #: src/PartBarLegendUI.cpp
-msgid "No source has this part"
+msgid "No other source has this part"
 msgstr ""
 
 #: src/PartBarLegendUI.cpp
-msgid "One source has this part"
+msgid "One other source has this part"
 msgstr ""
 
 #: src/PartBarLegendUI.cpp
 #, c-format
-msgid "%u or more sources have this part"
+msgid "%u or more other sources have this part"
 msgstr ""
 
 #: src/PartBarLegendUI.cpp
@@ -5608,7 +5608,7 @@ msgid "One block per part of the shared file."
 msgstr ""
 
 #: src/PartBarLegendUI.cpp
-msgid "One block per part of the shared file, coloured by how many sources have it."
+msgid "One block per part of the shared file, coloured by how many other sources have it."
 msgstr ""
 
 #: src/PartBarLegendUI.cpp
@@ -5616,7 +5616,7 @@ msgid "One block per part of the shared file, showing how far the re-hash has re
 msgstr ""
 
 #: src/PartBarLegendUI.cpp
-msgid "In between, darkening as sources are added"
+msgid "In between, darkening as other sources are added"
 msgstr ""
 
 #: src/PartFileConvert.cpp

--- a/po/hu.po
+++ b/po/hu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-02 12:15+0200\n"
+"POT-Creation-Date: 2026-09-04 07:50+0200\n"
 "PO-Revision-Date: 2026-09-03 11:05+0000\n"
 "Last-Translator: Dévai Tamás <gonosztopi@amule.org>\n"
 "Language-Team: Hungarian <hu@li.org>\n"
@@ -2810,48 +2810,10 @@ msgstr ""
 "Csak egy slot lett hozzárendelve."
 
 #: src/GenericClientListCtrl.cpp
-#, fuzzy
-msgid "This source does not have the part"
-msgstr "Ennek a parancsnak nem kellene paraméterének lennie."
-
-#: src/GenericClientListCtrl.cpp
-msgid "You and this source both have the part"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "Being downloaded from this source now"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "The next part that will be asked of this source"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "This source has the part and you still need it"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "This peer already has the part"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "This peer does not have the part"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "One block per part of the file being downloaded."
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-#, fuzzy
-msgid "One block per part of the shared file."
-msgstr "Add meg a kiszolgáló portját."
-
-#: src/GenericClientListCtrl.cpp
 msgid "Swap to this file"
 msgstr "Csere ehhez a fájlhoz"
 
-#: src/GenericClientListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Colour legend"
 msgstr ""
 
@@ -5600,6 +5562,81 @@ msgstr "Szöveg"
 msgid "Using config dir: %s"
 msgstr "Konfigurációk könyvtára: %s"
 
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "This source does not have the part"
+msgstr "Ennek a parancsnak nem kellene paraméterének lennie."
+
+#: src/PartBarLegendUI.cpp
+msgid "You and this source both have the part"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "Being downloaded from this source now"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "The next part that will be asked of this source"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "This source has the part and you still need it"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "This peer already has the part"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "This peer does not have the part"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "No source has this part"
+msgstr "Ennek a parancsnak nem kellene paraméterének lennie."
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "One source has this part"
+msgstr "Ennek a parancsnak nem kellene paraméterének lennie."
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy, c-format
+msgid "%u or more sources have this part"
+msgstr "Ennek a parancsnak nem kellene paraméterének lennie."
+
+#: src/PartBarLegendUI.cpp
+msgid "Already read back and hashed"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "Still to be read"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "One block per part of the file being downloaded."
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "One block per part of the shared file."
+msgstr "Add meg a kiszolgáló portját."
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "One block per part of the shared file, coloured by how many sources have it."
+msgstr "Add meg a kiszolgáló portját."
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "One block per part of the shared file, showing how far the re-hash has read."
+msgstr "Add meg a kiszolgáló portját."
+
+#: src/PartBarLegendUI.cpp
+msgid "In between, darkening as sources are added"
+msgstr ""
+
 #: src/PartFileConvert.cpp
 msgid "Waiting for partfile convert thread to die..."
 msgstr "Várakozás a partfile kovertáló thread befejeztére..."
@@ -7388,8 +7425,9 @@ msgid "Shares File List"
 msgstr "Fájl lista megosztása"
 
 #: src/SharedFilesCtrl.cpp
-msgid "Obtained Parts"
-msgstr "Megszerzett részek"
+#, fuzzy
+msgid "Source Availability"
+msgstr "Elérhetőség"
 
 #: src/SharedFilesCtrl.cpp
 msgid "Directory Path"
@@ -9255,6 +9293,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "Obtained Parts"
+#~ msgstr "Megszerzett részek"
 
 #~ msgid "Available Parts"
 #~ msgstr "Elérhető részek"

--- a/po/hu.po
+++ b/po/hu.po
@@ -5593,17 +5593,17 @@ msgstr ""
 
 #: src/PartBarLegendUI.cpp
 #, fuzzy
-msgid "No source has this part"
+msgid "No other source has this part"
 msgstr "Ennek a parancsnak nem kellene paraméterének lennie."
 
 #: src/PartBarLegendUI.cpp
 #, fuzzy
-msgid "One source has this part"
+msgid "One other source has this part"
 msgstr "Ennek a parancsnak nem kellene paraméterének lennie."
 
 #: src/PartBarLegendUI.cpp
 #, fuzzy, c-format
-msgid "%u or more sources have this part"
+msgid "%u or more other sources have this part"
 msgstr "Ennek a parancsnak nem kellene paraméterének lennie."
 
 #: src/PartBarLegendUI.cpp
@@ -5625,7 +5625,7 @@ msgstr "Add meg a kiszolgáló portját."
 
 #: src/PartBarLegendUI.cpp
 #, fuzzy
-msgid "One block per part of the shared file, coloured by how many sources have it."
+msgid "One block per part of the shared file, coloured by how many other sources have it."
 msgstr "Add meg a kiszolgáló portját."
 
 #: src/PartBarLegendUI.cpp
@@ -5634,7 +5634,7 @@ msgid "One block per part of the shared file, showing how far the re-hash has re
 msgstr "Add meg a kiszolgáló portját."
 
 #: src/PartBarLegendUI.cpp
-msgid "In between, darkening as sources are added"
+msgid "In between, darkening as other sources are added"
 msgstr ""
 
 #: src/PartFileConvert.cpp

--- a/po/it.po
+++ b/po/it.po
@@ -5578,17 +5578,17 @@ msgstr "Questo peer non ha la parte"
 
 #: src/PartBarLegendUI.cpp
 #, fuzzy
-msgid "No source has this part"
+msgid "No other source has this part"
 msgstr "Questa fonte non ha la parte"
 
 #: src/PartBarLegendUI.cpp
 #, fuzzy
-msgid "One source has this part"
+msgid "One other source has this part"
 msgstr "Questa fonte non ha la parte"
 
 #: src/PartBarLegendUI.cpp
 #, fuzzy, c-format
-msgid "%u or more sources have this part"
+msgid "%u or more other sources have this part"
 msgstr "Tu e questa fonte avete entrambi la parte"
 
 #: src/PartBarLegendUI.cpp
@@ -5609,7 +5609,7 @@ msgstr "Un blocco per ogni parte del file condiviso."
 
 #: src/PartBarLegendUI.cpp
 #, fuzzy
-msgid "One block per part of the shared file, coloured by how many sources have it."
+msgid "One block per part of the shared file, coloured by how many other sources have it."
 msgstr "Un blocco per ogni parte del file condiviso."
 
 #: src/PartBarLegendUI.cpp
@@ -5618,7 +5618,7 @@ msgid "One block per part of the shared file, showing how far the re-hash has re
 msgstr "Un blocco per ogni parte del file condiviso."
 
 #: src/PartBarLegendUI.cpp
-msgid "In between, darkening as sources are added"
+msgid "In between, darkening as other sources are added"
 msgstr ""
 
 #: src/PartFileConvert.cpp

--- a/po/it.po
+++ b/po/it.po
@@ -19,7 +19,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule 2.3.3\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-02 12:15+0200\n"
+"POT-Creation-Date: 2026-09-04 07:50+0200\n"
 "PO-Revision-Date: 2026-09-03 11:06+0000\n"
 "Last-Translator: got3nks <got3nks@users.noreply.github.com>\n"
 "Language-Team: SebastianoPistore.info@protonmail.ch\n"
@@ -2818,46 +2818,10 @@ msgstr ""
 "Assegnato un solo slot."
 
 #: src/GenericClientListCtrl.cpp
-msgid "This source does not have the part"
-msgstr "Questa fonte non ha la parte"
-
-#: src/GenericClientListCtrl.cpp
-msgid "You and this source both have the part"
-msgstr "Tu e questa fonte avete entrambi la parte"
-
-#: src/GenericClientListCtrl.cpp
-msgid "Being downloaded from this source now"
-msgstr "Attualmente in download da questa fonte"
-
-#: src/GenericClientListCtrl.cpp
-msgid "The next part that will be asked of this source"
-msgstr "La prossima parte che verrà richiesta a questa fonte"
-
-#: src/GenericClientListCtrl.cpp
-msgid "This source has the part and you still need it"
-msgstr "Questa fonte ha la parte e ti serve ancora"
-
-#: src/GenericClientListCtrl.cpp
-msgid "This peer already has the part"
-msgstr "Questo peer ha già la parte"
-
-#: src/GenericClientListCtrl.cpp
-msgid "This peer does not have the part"
-msgstr "Questo peer non ha la parte"
-
-#: src/GenericClientListCtrl.cpp
-msgid "One block per part of the file being downloaded."
-msgstr "Un blocco per ogni parte del file in download."
-
-#: src/GenericClientListCtrl.cpp
-msgid "One block per part of the shared file."
-msgstr "Un blocco per ogni parte del file condiviso."
-
-#: src/GenericClientListCtrl.cpp
 msgid "Swap to this file"
 msgstr "Sposta su questo file"
 
-#: src/GenericClientListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Colour legend"
 msgstr "Legenda colori"
 
@@ -5584,6 +5548,79 @@ msgstr "Testo"
 msgid "Using config dir: %s"
 msgstr "Directory di configurazione in uso: %s"
 
+#: src/PartBarLegendUI.cpp
+msgid "This source does not have the part"
+msgstr "Questa fonte non ha la parte"
+
+#: src/PartBarLegendUI.cpp
+msgid "You and this source both have the part"
+msgstr "Tu e questa fonte avete entrambi la parte"
+
+#: src/PartBarLegendUI.cpp
+msgid "Being downloaded from this source now"
+msgstr "Attualmente in download da questa fonte"
+
+#: src/PartBarLegendUI.cpp
+msgid "The next part that will be asked of this source"
+msgstr "La prossima parte che verrà richiesta a questa fonte"
+
+#: src/PartBarLegendUI.cpp
+msgid "This source has the part and you still need it"
+msgstr "Questa fonte ha la parte e ti serve ancora"
+
+#: src/PartBarLegendUI.cpp
+msgid "This peer already has the part"
+msgstr "Questo peer ha già la parte"
+
+#: src/PartBarLegendUI.cpp
+msgid "This peer does not have the part"
+msgstr "Questo peer non ha la parte"
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "No source has this part"
+msgstr "Questa fonte non ha la parte"
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "One source has this part"
+msgstr "Questa fonte non ha la parte"
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy, c-format
+msgid "%u or more sources have this part"
+msgstr "Tu e questa fonte avete entrambi la parte"
+
+#: src/PartBarLegendUI.cpp
+msgid "Already read back and hashed"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "Still to be read"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "One block per part of the file being downloaded."
+msgstr "Un blocco per ogni parte del file in download."
+
+#: src/PartBarLegendUI.cpp
+msgid "One block per part of the shared file."
+msgstr "Un blocco per ogni parte del file condiviso."
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "One block per part of the shared file, coloured by how many sources have it."
+msgstr "Un blocco per ogni parte del file condiviso."
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "One block per part of the shared file, showing how far the re-hash has read."
+msgstr "Un blocco per ogni parte del file condiviso."
+
+#: src/PartBarLegendUI.cpp
+msgid "In between, darkening as sources are added"
+msgstr ""
+
 #: src/PartFileConvert.cpp
 msgid "Waiting for partfile convert thread to die..."
 msgstr "In attesa della fine del processo di conversione del file incompleto..."
@@ -7362,8 +7399,9 @@ msgid "Shares File List"
 msgstr "Lista file condivisi"
 
 #: src/SharedFilesCtrl.cpp
-msgid "Obtained Parts"
-msgstr "Parti ricevute"
+#, fuzzy
+msgid "Source Availability"
+msgstr "Disponibilità"
 
 #: src/SharedFilesCtrl.cpp
 msgid "Directory Path"
@@ -9250,6 +9288,9 @@ msgstr "Sembra che aMule sia in esecuzione. Chiudilo e riavvia il programma di d
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "Rimozione dei dati utente in $APPDATA\\aMule..."
+
+#~ msgid "Obtained Parts"
+#~ msgstr "Parti ricevute"
 
 #~ msgid "Available Parts"
 #~ msgstr "Parti disponibili"

--- a/po/ja.po
+++ b/po/ja.po
@@ -5614,17 +5614,17 @@ msgstr ""
 
 #: src/PartBarLegendUI.cpp
 #, fuzzy
-msgid "No source has this part"
+msgid "No other source has this part"
 msgstr "このコマンドには引数が認められていません。"
 
 #: src/PartBarLegendUI.cpp
 #, fuzzy
-msgid "One source has this part"
+msgid "One other source has this part"
 msgstr "このコマンドには引数が認められていません。"
 
 #: src/PartBarLegendUI.cpp
 #, fuzzy, c-format
-msgid "%u or more sources have this part"
+msgid "%u or more other sources have this part"
 msgstr "このコマンドには引数が認められていません。"
 
 #: src/PartBarLegendUI.cpp
@@ -5646,7 +5646,7 @@ msgstr "サーバのポートをここに入力してください。"
 
 #: src/PartBarLegendUI.cpp
 #, fuzzy
-msgid "One block per part of the shared file, coloured by how many sources have it."
+msgid "One block per part of the shared file, coloured by how many other sources have it."
 msgstr "サーバのポートをここに入力してください。"
 
 #: src/PartBarLegendUI.cpp
@@ -5655,7 +5655,7 @@ msgid "One block per part of the shared file, showing how far the re-hash has re
 msgstr "サーバのポートをここに入力してください。"
 
 #: src/PartBarLegendUI.cpp
-msgid "In between, darkening as sources are added"
+msgid "In between, darkening as other sources are added"
 msgstr ""
 
 #: src/PartFileConvert.cpp

--- a/po/ja.po
+++ b/po/ja.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-02 12:15+0200\n"
+"POT-Creation-Date: 2026-09-04 07:50+0200\n"
 "PO-Revision-Date: 2026-09-03 11:06+0000\n"
 "Last-Translator: \n"
 "Language-Team: Japanese\n"
@@ -2819,48 +2819,10 @@ msgid ""
 msgstr "スロットが一つのみ提供されました。"
 
 #: src/GenericClientListCtrl.cpp
-#, fuzzy
-msgid "This source does not have the part"
-msgstr "このコマンドには引数が認められていません。"
-
-#: src/GenericClientListCtrl.cpp
-msgid "You and this source both have the part"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "Being downloaded from this source now"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "The next part that will be asked of this source"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "This source has the part and you still need it"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "This peer already has the part"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "This peer does not have the part"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "One block per part of the file being downloaded."
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-#, fuzzy
-msgid "One block per part of the shared file."
-msgstr "サーバのポートをここに入力してください。"
-
-#: src/GenericClientListCtrl.cpp
 msgid "Swap to this file"
 msgstr "このファイルへ交換する"
 
-#: src/GenericClientListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Colour legend"
 msgstr ""
 
@@ -5621,6 +5583,81 @@ msgstr "テキスト"
 msgid "Using config dir: %s"
 msgstr ""
 
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "This source does not have the part"
+msgstr "このコマンドには引数が認められていません。"
+
+#: src/PartBarLegendUI.cpp
+msgid "You and this source both have the part"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "Being downloaded from this source now"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "The next part that will be asked of this source"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "This source has the part and you still need it"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "This peer already has the part"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "This peer does not have the part"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "No source has this part"
+msgstr "このコマンドには引数が認められていません。"
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "One source has this part"
+msgstr "このコマンドには引数が認められていません。"
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy, c-format
+msgid "%u or more sources have this part"
+msgstr "このコマンドには引数が認められていません。"
+
+#: src/PartBarLegendUI.cpp
+msgid "Already read back and hashed"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "Still to be read"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "One block per part of the file being downloaded."
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "One block per part of the shared file."
+msgstr "サーバのポートをここに入力してください。"
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "One block per part of the shared file, coloured by how many sources have it."
+msgstr "サーバのポートをここに入力してください。"
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "One block per part of the shared file, showing how far the re-hash has read."
+msgstr "サーバのポートをここに入力してください。"
+
+#: src/PartBarLegendUI.cpp
+msgid "In between, darkening as sources are added"
+msgstr ""
+
 #: src/PartFileConvert.cpp
 msgid "Waiting for partfile convert thread to die..."
 msgstr ""
@@ -7422,8 +7459,9 @@ msgid "Shares File List"
 msgstr "共有ファイル"
 
 #: src/SharedFilesCtrl.cpp
-msgid "Obtained Parts"
-msgstr "得られた部分"
+#, fuzzy
+msgid "Source Availability"
+msgstr "入手可能範囲"
 
 #: src/SharedFilesCtrl.cpp
 msgid "Directory Path"
@@ -9287,6 +9325,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "Obtained Parts"
+#~ msgstr "得られた部分"
 
 #, fuzzy
 #~ msgid "Available Parts"

--- a/po/ko_KR.po
+++ b/po/ko_KR.po
@@ -5641,17 +5641,17 @@ msgstr ""
 
 #: src/PartBarLegendUI.cpp
 #, fuzzy
-msgid "No source has this part"
+msgid "No other source has this part"
 msgstr "이 명령은 어떤 변수도 필요하지 않습니다."
 
 #: src/PartBarLegendUI.cpp
 #, fuzzy
-msgid "One source has this part"
+msgid "One other source has this part"
 msgstr "이 명령은 어떤 변수도 필요하지 않습니다."
 
 #: src/PartBarLegendUI.cpp
 #, fuzzy, c-format
-msgid "%u or more sources have this part"
+msgid "%u or more other sources have this part"
 msgstr "이 명령은 어떤 변수도 필요하지 않습니다."
 
 #: src/PartBarLegendUI.cpp
@@ -5673,7 +5673,7 @@ msgstr "서버의 포트를 이곳에 입력하세요."
 
 #: src/PartBarLegendUI.cpp
 #, fuzzy
-msgid "One block per part of the shared file, coloured by how many sources have it."
+msgid "One block per part of the shared file, coloured by how many other sources have it."
 msgstr "서버의 포트를 이곳에 입력하세요."
 
 #: src/PartBarLegendUI.cpp
@@ -5682,7 +5682,7 @@ msgid "One block per part of the shared file, showing how far the re-hash has re
 msgstr "서버의 포트를 이곳에 입력하세요."
 
 #: src/PartBarLegendUI.cpp
-msgid "In between, darkening as sources are added"
+msgid "In between, darkening as other sources are added"
 msgstr ""
 
 #: src/PartFileConvert.cpp

--- a/po/ko_KR.po
+++ b/po/ko_KR.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-02 12:15+0200\n"
+"POT-Creation-Date: 2026-09-04 07:50+0200\n"
 "PO-Revision-Date: 2026-09-03 11:06+0000\n"
 "Last-Translator: Hyunju Kang <rexington@gmail.com>\n"
 "Language-Team: Korean <hoenny@daum.net>\n"
@@ -2834,48 +2834,10 @@ msgstr ""
 "단지 하나의 칸만 가능합니다."
 
 #: src/GenericClientListCtrl.cpp
-#, fuzzy
-msgid "This source does not have the part"
-msgstr "이 명령은 어떤 변수도 필요하지 않습니다."
-
-#: src/GenericClientListCtrl.cpp
-msgid "You and this source both have the part"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "Being downloaded from this source now"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "The next part that will be asked of this source"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "This source has the part and you still need it"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "This peer already has the part"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "This peer does not have the part"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "One block per part of the file being downloaded."
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-#, fuzzy
-msgid "One block per part of the shared file."
-msgstr "서버의 포트를 이곳에 입력하세요."
-
-#: src/GenericClientListCtrl.cpp
 msgid "Swap to this file"
 msgstr "파일을 교환"
 
-#: src/GenericClientListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Colour legend"
 msgstr ""
 
@@ -5648,6 +5610,81 @@ msgstr "문자"
 msgid "Using config dir: %s"
 msgstr ""
 
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "This source does not have the part"
+msgstr "이 명령은 어떤 변수도 필요하지 않습니다."
+
+#: src/PartBarLegendUI.cpp
+msgid "You and this source both have the part"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "Being downloaded from this source now"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "The next part that will be asked of this source"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "This source has the part and you still need it"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "This peer already has the part"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "This peer does not have the part"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "No source has this part"
+msgstr "이 명령은 어떤 변수도 필요하지 않습니다."
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "One source has this part"
+msgstr "이 명령은 어떤 변수도 필요하지 않습니다."
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy, c-format
+msgid "%u or more sources have this part"
+msgstr "이 명령은 어떤 변수도 필요하지 않습니다."
+
+#: src/PartBarLegendUI.cpp
+msgid "Already read back and hashed"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "Still to be read"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "One block per part of the file being downloaded."
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "One block per part of the shared file."
+msgstr "서버의 포트를 이곳에 입력하세요."
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "One block per part of the shared file, coloured by how many sources have it."
+msgstr "서버의 포트를 이곳에 입력하세요."
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "One block per part of the shared file, showing how far the re-hash has read."
+msgstr "서버의 포트를 이곳에 입력하세요."
+
+#: src/PartBarLegendUI.cpp
+msgid "In between, darkening as sources are added"
+msgstr ""
+
 #: src/PartFileConvert.cpp
 msgid "Waiting for partfile convert thread to die..."
 msgstr ""
@@ -7478,8 +7515,9 @@ msgid "Shares File List"
 msgstr "공유 파일"
 
 #: src/SharedFilesCtrl.cpp
-msgid "Obtained Parts"
-msgstr "획득한 부분"
+#, fuzzy
+msgid "Source Availability"
+msgstr "유효성"
 
 #: src/SharedFilesCtrl.cpp
 msgid "Directory Path"
@@ -9351,6 +9389,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "Obtained Parts"
+#~ msgstr "획득한 부분"
 
 #, fuzzy
 #~ msgid "Available Parts"

--- a/po/lt.po
+++ b/po/lt.po
@@ -5661,17 +5661,17 @@ msgstr ""
 
 #: src/PartBarLegendUI.cpp
 #, fuzzy
-msgid "No source has this part"
+msgid "No other source has this part"
 msgstr "Ši komanda negali turėti parametrų."
 
 #: src/PartBarLegendUI.cpp
 #, fuzzy
-msgid "One source has this part"
+msgid "One other source has this part"
 msgstr "Ši komanda negali turėti parametrų."
 
 #: src/PartBarLegendUI.cpp
 #, fuzzy, c-format
-msgid "%u or more sources have this part"
+msgid "%u or more other sources have this part"
 msgstr "Ši komanda negali turėti parametrų."
 
 #: src/PartBarLegendUI.cpp
@@ -5693,7 +5693,7 @@ msgstr "Įrašykite serverio prievadą."
 
 #: src/PartBarLegendUI.cpp
 #, fuzzy
-msgid "One block per part of the shared file, coloured by how many sources have it."
+msgid "One block per part of the shared file, coloured by how many other sources have it."
 msgstr "Įrašykite serverio prievadą."
 
 #: src/PartBarLegendUI.cpp
@@ -5702,7 +5702,7 @@ msgid "One block per part of the shared file, showing how far the re-hash has re
 msgstr "Įrašykite serverio prievadą."
 
 #: src/PartBarLegendUI.cpp
-msgid "In between, darkening as sources are added"
+msgid "In between, darkening as other sources are added"
 msgstr ""
 
 #: src/PartFileConvert.cpp

--- a/po/lt.po
+++ b/po/lt.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-02 12:15+0200\n"
+"POT-Creation-Date: 2026-09-04 07:50+0200\n"
 "PO-Revision-Date: 2026-09-03 11:07+0000\n"
 "Last-Translator: Dovydas Sankauskas <laisve@gmail.com>\n"
 "Language-Team: Lithuanian <komp_lt@konf.lt>\n"
@@ -2842,48 +2842,10 @@ msgstr ""
 "Buvo sukurtas tik vienas kanalas."
 
 #: src/GenericClientListCtrl.cpp
-#, fuzzy
-msgid "This source does not have the part"
-msgstr "Ši komanda negali turėti parametrų."
-
-#: src/GenericClientListCtrl.cpp
-msgid "You and this source both have the part"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "Being downloaded from this source now"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "The next part that will be asked of this source"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "This source has the part and you still need it"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "This peer already has the part"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "This peer does not have the part"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "One block per part of the file being downloaded."
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-#, fuzzy
-msgid "One block per part of the shared file."
-msgstr "Įrašykite serverio prievadą."
-
-#: src/GenericClientListCtrl.cpp
 msgid "Swap to this file"
 msgstr "Keisti į šį failą"
 
-#: src/GenericClientListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Colour legend"
 msgstr ""
 
@@ -5668,6 +5630,81 @@ msgstr "Teksto failai"
 msgid "Using config dir: %s"
 msgstr ""
 
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "This source does not have the part"
+msgstr "Ši komanda negali turėti parametrų."
+
+#: src/PartBarLegendUI.cpp
+msgid "You and this source both have the part"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "Being downloaded from this source now"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "The next part that will be asked of this source"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "This source has the part and you still need it"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "This peer already has the part"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "This peer does not have the part"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "No source has this part"
+msgstr "Ši komanda negali turėti parametrų."
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "One source has this part"
+msgstr "Ši komanda negali turėti parametrų."
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy, c-format
+msgid "%u or more sources have this part"
+msgstr "Ši komanda negali turėti parametrų."
+
+#: src/PartBarLegendUI.cpp
+msgid "Already read back and hashed"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "Still to be read"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "One block per part of the file being downloaded."
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "One block per part of the shared file."
+msgstr "Įrašykite serverio prievadą."
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "One block per part of the shared file, coloured by how many sources have it."
+msgstr "Įrašykite serverio prievadą."
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "One block per part of the shared file, showing how far the re-hash has read."
+msgstr "Įrašykite serverio prievadą."
+
+#: src/PartBarLegendUI.cpp
+msgid "In between, darkening as sources are added"
+msgstr ""
+
 #: src/PartFileConvert.cpp
 msgid "Waiting for partfile convert thread to die..."
 msgstr ""
@@ -7510,8 +7547,9 @@ msgid "Shares File List"
 msgstr "Dalinami failai"
 
 #: src/SharedFilesCtrl.cpp
-msgid "Obtained Parts"
-msgstr "Gautos dalys"
+#, fuzzy
+msgid "Source Availability"
+msgstr "Skaičius"
 
 #: src/SharedFilesCtrl.cpp
 msgid "Directory Path"
@@ -9404,6 +9442,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "Obtained Parts"
+#~ msgstr "Gautos dalys"
 
 #, fuzzy
 #~ msgid "Available Parts"

--- a/po/lv.po
+++ b/po/lv.po
@@ -5492,16 +5492,16 @@ msgid "This peer does not have the part"
 msgstr ""
 
 #: src/PartBarLegendUI.cpp
-msgid "No source has this part"
+msgid "No other source has this part"
 msgstr ""
 
 #: src/PartBarLegendUI.cpp
-msgid "One source has this part"
+msgid "One other source has this part"
 msgstr ""
 
 #: src/PartBarLegendUI.cpp
 #, c-format
-msgid "%u or more sources have this part"
+msgid "%u or more other sources have this part"
 msgstr ""
 
 #: src/PartBarLegendUI.cpp
@@ -5521,7 +5521,7 @@ msgid "One block per part of the shared file."
 msgstr ""
 
 #: src/PartBarLegendUI.cpp
-msgid "One block per part of the shared file, coloured by how many sources have it."
+msgid "One block per part of the shared file, coloured by how many other sources have it."
 msgstr ""
 
 #: src/PartBarLegendUI.cpp
@@ -5529,7 +5529,7 @@ msgid "One block per part of the shared file, showing how far the re-hash has re
 msgstr ""
 
 #: src/PartBarLegendUI.cpp
-msgid "In between, darkening as sources are added"
+msgid "In between, darkening as other sources are added"
 msgstr ""
 
 #: src/PartFileConvert.cpp

--- a/po/lv.po
+++ b/po/lv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-02 12:15+0200\n"
+"POT-Creation-Date: 2026-09-04 07:50+0200\n"
 "PO-Revision-Date: 2026-09-03 11:13+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -2738,46 +2738,10 @@ msgid ""
 msgstr ""
 
 #: src/GenericClientListCtrl.cpp
-msgid "This source does not have the part"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "You and this source both have the part"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "Being downloaded from this source now"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "The next part that will be asked of this source"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "This source has the part and you still need it"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "This peer already has the part"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "This peer does not have the part"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "One block per part of the file being downloaded."
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "One block per part of the shared file."
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
 msgid "Swap to this file"
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Colour legend"
 msgstr ""
 
@@ -5499,6 +5463,75 @@ msgstr ""
 msgid "Using config dir: %s"
 msgstr ""
 
+#: src/PartBarLegendUI.cpp
+msgid "This source does not have the part"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "You and this source both have the part"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "Being downloaded from this source now"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "The next part that will be asked of this source"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "This source has the part and you still need it"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "This peer already has the part"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "This peer does not have the part"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "No source has this part"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "One source has this part"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+#, c-format
+msgid "%u or more sources have this part"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "Already read back and hashed"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "Still to be read"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "One block per part of the file being downloaded."
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "One block per part of the shared file."
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "One block per part of the shared file, coloured by how many sources have it."
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "One block per part of the shared file, showing how far the re-hash has read."
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "In between, darkening as sources are added"
+msgstr ""
+
 #: src/PartFileConvert.cpp
 msgid "Waiting for partfile convert thread to die..."
 msgstr ""
@@ -7259,8 +7292,9 @@ msgid "Shares File List"
 msgstr ""
 
 #: src/SharedFilesCtrl.cpp
-msgid "Obtained Parts"
-msgstr ""
+#, fuzzy
+msgid "Source Availability"
+msgstr "Pieejamība"
 
 #: src/SharedFilesCtrl.cpp
 msgid "Directory Path"

--- a/po/nl.po
+++ b/po/nl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-02 12:15+0200\n"
+"POT-Creation-Date: 2026-09-04 07:50+0200\n"
 "PO-Revision-Date: 2026-09-03 11:07+0000\n"
 "Last-Translator: Marcel Pol <marcel@timelord.nl>\n"
 "Language-Team: Dutch <nl@li.org>\n"
@@ -2808,46 +2808,10 @@ msgstr ""
 " Slechts één slot is toegekend."
 
 #: src/GenericClientListCtrl.cpp
-msgid "This source does not have the part"
-msgstr "Deze bron heeft het onderdeel niet"
-
-#: src/GenericClientListCtrl.cpp
-msgid "You and this source both have the part"
-msgstr "U en deze bron hebben het onderdeel allebei"
-
-#: src/GenericClientListCtrl.cpp
-msgid "Being downloaded from this source now"
-msgstr "Wordt nu vanuit deze bron gedownload"
-
-#: src/GenericClientListCtrl.cpp
-msgid "The next part that will be asked of this source"
-msgstr "Het volgende onderdeel dat van deze bron gevraagd zal worden"
-
-#: src/GenericClientListCtrl.cpp
-msgid "This source has the part and you still need it"
-msgstr "Deze bron heeft het onderdeel en u heeft het nog nodig"
-
-#: src/GenericClientListCtrl.cpp
-msgid "This peer already has the part"
-msgstr "Deze peer heeft het onderdeel al"
-
-#: src/GenericClientListCtrl.cpp
-msgid "This peer does not have the part"
-msgstr "Deze peer heeft het onderdeel niet"
-
-#: src/GenericClientListCtrl.cpp
-msgid "One block per part of the file being downloaded."
-msgstr "Één blok per onderdeel van het bestand dat wordt gedownload."
-
-#: src/GenericClientListCtrl.cpp
-msgid "One block per part of the shared file."
-msgstr "Één blok per onderdeel van het gedeelde bestand."
-
-#: src/GenericClientListCtrl.cpp
 msgid "Swap to this file"
 msgstr "Wissel uit naar dit bestand"
 
-#: src/GenericClientListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Colour legend"
 msgstr "Kleurenlegenda"
 
@@ -5575,6 +5539,79 @@ msgstr "Tekst"
 msgid "Using config dir: %s"
 msgstr "Gebruikte configdir: %s"
 
+#: src/PartBarLegendUI.cpp
+msgid "This source does not have the part"
+msgstr "Deze bron heeft het onderdeel niet"
+
+#: src/PartBarLegendUI.cpp
+msgid "You and this source both have the part"
+msgstr "U en deze bron hebben het onderdeel allebei"
+
+#: src/PartBarLegendUI.cpp
+msgid "Being downloaded from this source now"
+msgstr "Wordt nu vanuit deze bron gedownload"
+
+#: src/PartBarLegendUI.cpp
+msgid "The next part that will be asked of this source"
+msgstr "Het volgende onderdeel dat van deze bron gevraagd zal worden"
+
+#: src/PartBarLegendUI.cpp
+msgid "This source has the part and you still need it"
+msgstr "Deze bron heeft het onderdeel en u heeft het nog nodig"
+
+#: src/PartBarLegendUI.cpp
+msgid "This peer already has the part"
+msgstr "Deze peer heeft het onderdeel al"
+
+#: src/PartBarLegendUI.cpp
+msgid "This peer does not have the part"
+msgstr "Deze peer heeft het onderdeel niet"
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "No source has this part"
+msgstr "Deze bron heeft het onderdeel niet"
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "One source has this part"
+msgstr "Deze bron heeft het onderdeel niet"
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy, c-format
+msgid "%u or more sources have this part"
+msgstr "U en deze bron hebben het onderdeel allebei"
+
+#: src/PartBarLegendUI.cpp
+msgid "Already read back and hashed"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "Still to be read"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "One block per part of the file being downloaded."
+msgstr "Één blok per onderdeel van het bestand dat wordt gedownload."
+
+#: src/PartBarLegendUI.cpp
+msgid "One block per part of the shared file."
+msgstr "Één blok per onderdeel van het gedeelde bestand."
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "One block per part of the shared file, coloured by how many sources have it."
+msgstr "Één blok per onderdeel van het gedeelde bestand."
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "One block per part of the shared file, showing how far the re-hash has read."
+msgstr "Één blok per onderdeel van het gedeelde bestand."
+
+#: src/PartBarLegendUI.cpp
+msgid "In between, darkening as sources are added"
+msgstr ""
+
 #: src/PartFileConvert.cpp
 msgid "Waiting for partfile convert thread to die..."
 msgstr "Wachten tot deelbestand-conversiethread sterft..."
@@ -7353,8 +7390,9 @@ msgid "Shares File List"
 msgstr "Deelt bestandenlijst"
 
 #: src/SharedFilesCtrl.cpp
-msgid "Obtained Parts"
-msgstr "Ontvangen delen"
+#, fuzzy
+msgid "Source Availability"
+msgstr "Beschikbaarheid"
 
 #: src/SharedFilesCtrl.cpp
 msgid "Directory Path"
@@ -9245,6 +9283,9 @@ msgstr "aMule lijkt te worden uitgevoerd. Sluit het en voer het verwijderprogram
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "Gebruikersgegevens op $APPDATA\\aMule worden verwijderd..."
+
+#~ msgid "Obtained Parts"
+#~ msgstr "Ontvangen delen"
 
 #~ msgid "Available Parts"
 #~ msgstr "Beschikbare delen"

--- a/po/nl.po
+++ b/po/nl.po
@@ -5569,17 +5569,17 @@ msgstr "Deze peer heeft het onderdeel niet"
 
 #: src/PartBarLegendUI.cpp
 #, fuzzy
-msgid "No source has this part"
+msgid "No other source has this part"
 msgstr "Deze bron heeft het onderdeel niet"
 
 #: src/PartBarLegendUI.cpp
 #, fuzzy
-msgid "One source has this part"
+msgid "One other source has this part"
 msgstr "Deze bron heeft het onderdeel niet"
 
 #: src/PartBarLegendUI.cpp
 #, fuzzy, c-format
-msgid "%u or more sources have this part"
+msgid "%u or more other sources have this part"
 msgstr "U en deze bron hebben het onderdeel allebei"
 
 #: src/PartBarLegendUI.cpp
@@ -5600,7 +5600,7 @@ msgstr "Één blok per onderdeel van het gedeelde bestand."
 
 #: src/PartBarLegendUI.cpp
 #, fuzzy
-msgid "One block per part of the shared file, coloured by how many sources have it."
+msgid "One block per part of the shared file, coloured by how many other sources have it."
 msgstr "Één blok per onderdeel van het gedeelde bestand."
 
 #: src/PartBarLegendUI.cpp
@@ -5609,7 +5609,7 @@ msgid "One block per part of the shared file, showing how far the re-hash has re
 msgstr "Één blok per onderdeel van het gedeelde bestand."
 
 #: src/PartBarLegendUI.cpp
-msgid "In between, darkening as sources are added"
+msgid "In between, darkening as other sources are added"
 msgstr ""
 
 #: src/PartFileConvert.cpp

--- a/po/nn.po
+++ b/po/nn.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-02 12:15+0200\n"
+"POT-Creation-Date: 2026-09-04 07:50+0200\n"
 "PO-Revision-Date: 2026-09-03 11:08+0000\n"
 "Last-Translator: Hallvor Brunstad <Hallvor_1976@yahoo.com>\n"
 "Language-Team: <i18n-nn@lister.ping.uio.no>\n"
@@ -2833,48 +2833,10 @@ msgstr ""
 " Berre ei venekopling vart oppretta."
 
 #: src/GenericClientListCtrl.cpp
-#, fuzzy
-msgid "This source does not have the part"
-msgstr "Denne kommandoen skulle ikkje ha nokon parameter."
-
-#: src/GenericClientListCtrl.cpp
-msgid "You and this source both have the part"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "Being downloaded from this source now"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "The next part that will be asked of this source"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "This source has the part and you still need it"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "This peer already has the part"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "This peer does not have the part"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "One block per part of the file being downloaded."
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-#, fuzzy
-msgid "One block per part of the shared file."
-msgstr "Skriv inn porten til tenaren her."
-
-#: src/GenericClientListCtrl.cpp
 msgid "Swap to this file"
 msgstr "Byt til denne fila"
 
-#: src/GenericClientListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Colour legend"
 msgstr ""
 
@@ -5648,6 +5610,81 @@ msgstr "Tekst"
 msgid "Using config dir: %s"
 msgstr ""
 
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "This source does not have the part"
+msgstr "Denne kommandoen skulle ikkje ha nokon parameter."
+
+#: src/PartBarLegendUI.cpp
+msgid "You and this source both have the part"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "Being downloaded from this source now"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "The next part that will be asked of this source"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "This source has the part and you still need it"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "This peer already has the part"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "This peer does not have the part"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "No source has this part"
+msgstr "Denne kommandoen skulle ikkje ha nokon parameter."
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "One source has this part"
+msgstr "Denne kommandoen skulle ikkje ha nokon parameter."
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy, c-format
+msgid "%u or more sources have this part"
+msgstr "Denne kommandoen skulle ikkje ha nokon parameter."
+
+#: src/PartBarLegendUI.cpp
+msgid "Already read back and hashed"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "Still to be read"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "One block per part of the file being downloaded."
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "One block per part of the shared file."
+msgstr "Skriv inn porten til tenaren her."
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "One block per part of the shared file, coloured by how many sources have it."
+msgstr "Skriv inn porten til tenaren her."
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "One block per part of the shared file, showing how far the re-hash has read."
+msgstr "Skriv inn porten til tenaren her."
+
+#: src/PartBarLegendUI.cpp
+msgid "In between, darkening as sources are added"
+msgstr ""
+
 #: src/PartFileConvert.cpp
 msgid "Waiting for partfile convert thread to die..."
 msgstr ""
@@ -7472,8 +7509,9 @@ msgid "Shares File List"
 msgstr "Delte filer"
 
 #: src/SharedFilesCtrl.cpp
-msgid "Obtained Parts"
-msgstr "Nedlasta delar"
+#, fuzzy
+msgid "Source Availability"
+msgstr "Tilgjenge"
 
 #: src/SharedFilesCtrl.cpp
 msgid "Directory Path"
@@ -9361,6 +9399,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "Obtained Parts"
+#~ msgstr "Nedlasta delar"
 
 #, fuzzy
 #~ msgid "Available Parts"

--- a/po/nn.po
+++ b/po/nn.po
@@ -5641,17 +5641,17 @@ msgstr ""
 
 #: src/PartBarLegendUI.cpp
 #, fuzzy
-msgid "No source has this part"
+msgid "No other source has this part"
 msgstr "Denne kommandoen skulle ikkje ha nokon parameter."
 
 #: src/PartBarLegendUI.cpp
 #, fuzzy
-msgid "One source has this part"
+msgid "One other source has this part"
 msgstr "Denne kommandoen skulle ikkje ha nokon parameter."
 
 #: src/PartBarLegendUI.cpp
 #, fuzzy, c-format
-msgid "%u or more sources have this part"
+msgid "%u or more other sources have this part"
 msgstr "Denne kommandoen skulle ikkje ha nokon parameter."
 
 #: src/PartBarLegendUI.cpp
@@ -5673,7 +5673,7 @@ msgstr "Skriv inn porten til tenaren her."
 
 #: src/PartBarLegendUI.cpp
 #, fuzzy
-msgid "One block per part of the shared file, coloured by how many sources have it."
+msgid "One block per part of the shared file, coloured by how many other sources have it."
 msgstr "Skriv inn porten til tenaren her."
 
 #: src/PartBarLegendUI.cpp
@@ -5682,7 +5682,7 @@ msgid "One block per part of the shared file, showing how far the re-hash has re
 msgstr "Skriv inn porten til tenaren her."
 
 #: src/PartBarLegendUI.cpp
-msgid "In between, darkening as sources are added"
+msgid "In between, darkening as other sources are added"
 msgstr ""
 
 #: src/PartFileConvert.cpp

--- a/po/pl.po
+++ b/po/pl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-02 12:15+0200\n"
+"POT-Creation-Date: 2026-09-04 07:50+0200\n"
 "PO-Revision-Date: 2026-09-03 11:08+0000\n"
 "Last-Translator: Michał Trzebiatowski <hippie_1968@hotmail.com>\n"
 "Language-Team: translationproject.org/team/pl.html <translation-team-pl@lists.sourceforge.net>\n"
@@ -2828,48 +2828,10 @@ msgstr ""
 "Przydzielono tylko jeden slot."
 
 #: src/GenericClientListCtrl.cpp
-#, fuzzy
-msgid "This source does not have the part"
-msgstr "Ta komenda nie powinna posiadać żadnego parametru."
-
-#: src/GenericClientListCtrl.cpp
-msgid "You and this source both have the part"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "Being downloaded from this source now"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "The next part that will be asked of this source"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "This source has the part and you still need it"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "This peer already has the part"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "This peer does not have the part"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "One block per part of the file being downloaded."
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-#, fuzzy
-msgid "One block per part of the shared file."
-msgstr "Wpisz tu port serwera."
-
-#: src/GenericClientListCtrl.cpp
 msgid "Swap to this file"
 msgstr "Zamień na ten plik"
 
-#: src/GenericClientListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Colour legend"
 msgstr ""
 
@@ -5647,6 +5609,81 @@ msgstr "Tekst"
 msgid "Using config dir: %s"
 msgstr "Używanie katalogu konfiguracyjnego: %s"
 
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "This source does not have the part"
+msgstr "Ta komenda nie powinna posiadać żadnego parametru."
+
+#: src/PartBarLegendUI.cpp
+msgid "You and this source both have the part"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "Being downloaded from this source now"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "The next part that will be asked of this source"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "This source has the part and you still need it"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "This peer already has the part"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "This peer does not have the part"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "No source has this part"
+msgstr "Ta komenda nie powinna posiadać żadnego parametru."
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "One source has this part"
+msgstr "Ta komenda nie powinna posiadać żadnego parametru."
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy, c-format
+msgid "%u or more sources have this part"
+msgstr "Ta komenda nie powinna posiadać żadnego parametru."
+
+#: src/PartBarLegendUI.cpp
+msgid "Already read back and hashed"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "Still to be read"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "One block per part of the file being downloaded."
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "One block per part of the shared file."
+msgstr "Wpisz tu port serwera."
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "One block per part of the shared file, coloured by how many sources have it."
+msgstr "Wpisz tu port serwera."
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "One block per part of the shared file, showing how far the re-hash has read."
+msgstr "Wpisz tu port serwera."
+
+#: src/PartBarLegendUI.cpp
+msgid "In between, darkening as sources are added"
+msgstr ""
+
 #: src/PartFileConvert.cpp
 msgid "Waiting for partfile convert thread to die..."
 msgstr "Oczekiwanie na koniec wątku przemiany pliku części ..."
@@ -7484,8 +7521,9 @@ msgid "Shares File List"
 msgstr "Udostępnione pliki"
 
 #: src/SharedFilesCtrl.cpp
-msgid "Obtained Parts"
-msgstr "Otrzymane części"
+#, fuzzy
+msgid "Source Availability"
+msgstr "Dostępność"
 
 #: src/SharedFilesCtrl.cpp
 msgid "Directory Path"
@@ -9363,6 +9401,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "Obtained Parts"
+#~ msgstr "Otrzymane części"
 
 #~ msgid "Available Parts"
 #~ msgstr "Dostępne części"

--- a/po/pl.po
+++ b/po/pl.po
@@ -5640,17 +5640,17 @@ msgstr ""
 
 #: src/PartBarLegendUI.cpp
 #, fuzzy
-msgid "No source has this part"
+msgid "No other source has this part"
 msgstr "Ta komenda nie powinna posiadać żadnego parametru."
 
 #: src/PartBarLegendUI.cpp
 #, fuzzy
-msgid "One source has this part"
+msgid "One other source has this part"
 msgstr "Ta komenda nie powinna posiadać żadnego parametru."
 
 #: src/PartBarLegendUI.cpp
 #, fuzzy, c-format
-msgid "%u or more sources have this part"
+msgid "%u or more other sources have this part"
 msgstr "Ta komenda nie powinna posiadać żadnego parametru."
 
 #: src/PartBarLegendUI.cpp
@@ -5672,7 +5672,7 @@ msgstr "Wpisz tu port serwera."
 
 #: src/PartBarLegendUI.cpp
 #, fuzzy
-msgid "One block per part of the shared file, coloured by how many sources have it."
+msgid "One block per part of the shared file, coloured by how many other sources have it."
 msgstr "Wpisz tu port serwera."
 
 #: src/PartBarLegendUI.cpp
@@ -5681,7 +5681,7 @@ msgid "One block per part of the shared file, showing how far the re-hash has re
 msgstr "Wpisz tu port serwera."
 
 #: src/PartBarLegendUI.cpp
-msgid "In between, darkening as sources are added"
+msgid "In between, darkening as other sources are added"
 msgstr ""
 
 #: src/PartFileConvert.cpp

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-02 12:15+0200\n"
+"POT-Creation-Date: 2026-09-04 07:50+0200\n"
 "PO-Revision-Date: 2026-09-03 11:08+0000\n"
 "Last-Translator: Marcelo Jimenez <mroberto@users.sourceforge.com>\n"
 "Language-Team: Português (Brasileiro) <pt@li.org>\n"
@@ -2812,46 +2812,10 @@ msgstr ""
 " Apenas um foi definido."
 
 #: src/GenericClientListCtrl.cpp
-msgid "This source does not have the part"
-msgstr "Esta fonte não tem a parte"
-
-#: src/GenericClientListCtrl.cpp
-msgid "You and this source both have the part"
-msgstr "Você e esta fonte, ambos têm a parte"
-
-#: src/GenericClientListCtrl.cpp
-msgid "Being downloaded from this source now"
-msgstr "Sendo baixada agora desta fonte"
-
-#: src/GenericClientListCtrl.cpp
-msgid "The next part that will be asked of this source"
-msgstr "A pŕoxima parte que será pedida desta fonte"
-
-#: src/GenericClientListCtrl.cpp
-msgid "This source has the part and you still need it"
-msgstr "Esta fonte tem a parte e você ainda precisa dela"
-
-#: src/GenericClientListCtrl.cpp
-msgid "This peer already has the part"
-msgstr "Este par já tem a parte"
-
-#: src/GenericClientListCtrl.cpp
-msgid "This peer does not have the part"
-msgstr "Este par não tem a parte"
-
-#: src/GenericClientListCtrl.cpp
-msgid "One block per part of the file being downloaded."
-msgstr "Um bloco por parte do arquivo sendo baixado."
-
-#: src/GenericClientListCtrl.cpp
-msgid "One block per part of the shared file."
-msgstr "Um bloco por parte do arquivo compartilhado."
-
-#: src/GenericClientListCtrl.cpp
 msgid "Swap to this file"
 msgstr "Trocar para esse arquivo"
 
-#: src/GenericClientListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Colour legend"
 msgstr "Legenda colorida"
 
@@ -5578,6 +5542,79 @@ msgstr "Texto"
 msgid "Using config dir: %s"
 msgstr "Usando diretório de configuração: %s"
 
+#: src/PartBarLegendUI.cpp
+msgid "This source does not have the part"
+msgstr "Esta fonte não tem a parte"
+
+#: src/PartBarLegendUI.cpp
+msgid "You and this source both have the part"
+msgstr "Você e esta fonte, ambos têm a parte"
+
+#: src/PartBarLegendUI.cpp
+msgid "Being downloaded from this source now"
+msgstr "Sendo baixada agora desta fonte"
+
+#: src/PartBarLegendUI.cpp
+msgid "The next part that will be asked of this source"
+msgstr "A pŕoxima parte que será pedida desta fonte"
+
+#: src/PartBarLegendUI.cpp
+msgid "This source has the part and you still need it"
+msgstr "Esta fonte tem a parte e você ainda precisa dela"
+
+#: src/PartBarLegendUI.cpp
+msgid "This peer already has the part"
+msgstr "Este par já tem a parte"
+
+#: src/PartBarLegendUI.cpp
+msgid "This peer does not have the part"
+msgstr "Este par não tem a parte"
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "No source has this part"
+msgstr "Esta fonte não tem a parte"
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "One source has this part"
+msgstr "Esta fonte não tem a parte"
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy, c-format
+msgid "%u or more sources have this part"
+msgstr "Você e esta fonte, ambos têm a parte"
+
+#: src/PartBarLegendUI.cpp
+msgid "Already read back and hashed"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "Still to be read"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "One block per part of the file being downloaded."
+msgstr "Um bloco por parte do arquivo sendo baixado."
+
+#: src/PartBarLegendUI.cpp
+msgid "One block per part of the shared file."
+msgstr "Um bloco por parte do arquivo compartilhado."
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "One block per part of the shared file, coloured by how many sources have it."
+msgstr "Um bloco por parte do arquivo compartilhado."
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "One block per part of the shared file, showing how far the re-hash has read."
+msgstr "Um bloco por parte do arquivo compartilhado."
+
+#: src/PartBarLegendUI.cpp
+msgid "In between, darkening as sources are added"
+msgstr ""
+
 #: src/PartFileConvert.cpp
 msgid "Waiting for partfile convert thread to die..."
 msgstr "Esperando pela linha de conversão do partfile para morrer..."
@@ -7356,8 +7393,9 @@ msgid "Shares File List"
 msgstr "Lista de Arquivos Compartilhados"
 
 #: src/SharedFilesCtrl.cpp
-msgid "Obtained Parts"
-msgstr "Partes já baixadas"
+#, fuzzy
+msgid "Source Availability"
+msgstr "Disponível"
 
 #: src/SharedFilesCtrl.cpp
 msgid "Directory Path"
@@ -9244,6 +9282,9 @@ msgstr "O aMule parece estar rodando. Por favor, feche-o e rode o desinstalador 
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "Removendo os dados do usuário em $APPDATA\\aMule..."
+
+#~ msgid "Obtained Parts"
+#~ msgstr "Partes já baixadas"
 
 #~ msgid "Available Parts"
 #~ msgstr "Partes Disponíveis"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -5572,17 +5572,17 @@ msgstr "Este par não tem a parte"
 
 #: src/PartBarLegendUI.cpp
 #, fuzzy
-msgid "No source has this part"
+msgid "No other source has this part"
 msgstr "Esta fonte não tem a parte"
 
 #: src/PartBarLegendUI.cpp
 #, fuzzy
-msgid "One source has this part"
+msgid "One other source has this part"
 msgstr "Esta fonte não tem a parte"
 
 #: src/PartBarLegendUI.cpp
 #, fuzzy, c-format
-msgid "%u or more sources have this part"
+msgid "%u or more other sources have this part"
 msgstr "Você e esta fonte, ambos têm a parte"
 
 #: src/PartBarLegendUI.cpp
@@ -5603,7 +5603,7 @@ msgstr "Um bloco por parte do arquivo compartilhado."
 
 #: src/PartBarLegendUI.cpp
 #, fuzzy
-msgid "One block per part of the shared file, coloured by how many sources have it."
+msgid "One block per part of the shared file, coloured by how many other sources have it."
 msgstr "Um bloco por parte do arquivo compartilhado."
 
 #: src/PartBarLegendUI.cpp
@@ -5612,7 +5612,7 @@ msgid "One block per part of the shared file, showing how far the re-hash has re
 msgstr "Um bloco por parte do arquivo compartilhado."
 
 #: src/PartBarLegendUI.cpp
-msgid "In between, darkening as sources are added"
+msgid "In between, darkening as other sources are added"
 msgstr ""
 
 #: src/PartFileConvert.cpp

--- a/po/pt_PT.po
+++ b/po/pt_PT.po
@@ -5621,17 +5621,17 @@ msgstr ""
 
 #: src/PartBarLegendUI.cpp
 #, fuzzy
-msgid "No source has this part"
+msgid "No other source has this part"
 msgstr "Este comando não deveria ter quaisquer parâmetros."
 
 #: src/PartBarLegendUI.cpp
 #, fuzzy
-msgid "One source has this part"
+msgid "One other source has this part"
 msgstr "Este comando não deveria ter quaisquer parâmetros."
 
 #: src/PartBarLegendUI.cpp
 #, fuzzy, c-format
-msgid "%u or more sources have this part"
+msgid "%u or more other sources have this part"
 msgstr "Este comando não deveria ter quaisquer parâmetros."
 
 #: src/PartBarLegendUI.cpp
@@ -5653,7 +5653,7 @@ msgstr "Insira o porto do servidor."
 
 #: src/PartBarLegendUI.cpp
 #, fuzzy
-msgid "One block per part of the shared file, coloured by how many sources have it."
+msgid "One block per part of the shared file, coloured by how many other sources have it."
 msgstr "Insira o porto do servidor."
 
 #: src/PartBarLegendUI.cpp
@@ -5662,7 +5662,7 @@ msgid "One block per part of the shared file, showing how far the re-hash has re
 msgstr "Insira o porto do servidor."
 
 #: src/PartBarLegendUI.cpp
-msgid "In between, darkening as sources are added"
+msgid "In between, darkening as other sources are added"
 msgstr ""
 
 #: src/PartFileConvert.cpp

--- a/po/pt_PT.po
+++ b/po/pt_PT.po
@@ -17,7 +17,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-02 12:15+0200\n"
+"POT-Creation-Date: 2026-09-04 07:50+0200\n"
 "PO-Revision-Date: 2026-09-03 11:09+0000\n"
 "Last-Translator: Luís Picciochi Oliveira <Pitxyoki@Gmail.com>\n"
 "Language-Team: Portuguese <traduz@debianpt.org>\n"
@@ -2825,48 +2825,10 @@ msgstr ""
 " Apenas uma ligação foi atribuída."
 
 #: src/GenericClientListCtrl.cpp
-#, fuzzy
-msgid "This source does not have the part"
-msgstr "Este comando não deveria ter quaisquer parâmetros."
-
-#: src/GenericClientListCtrl.cpp
-msgid "You and this source both have the part"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "Being downloaded from this source now"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "The next part that will be asked of this source"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "This source has the part and you still need it"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "This peer already has the part"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "This peer does not have the part"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "One block per part of the file being downloaded."
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-#, fuzzy
-msgid "One block per part of the shared file."
-msgstr "Insira o porto do servidor."
-
-#: src/GenericClientListCtrl.cpp
 msgid "Swap to this file"
 msgstr "Mudar para este ficheiro"
 
-#: src/GenericClientListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Colour legend"
 msgstr ""
 
@@ -5628,6 +5590,81 @@ msgstr "Texto"
 msgid "Using config dir: %s"
 msgstr "A utilizar pasta de configuração: %s"
 
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "This source does not have the part"
+msgstr "Este comando não deveria ter quaisquer parâmetros."
+
+#: src/PartBarLegendUI.cpp
+msgid "You and this source both have the part"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "Being downloaded from this source now"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "The next part that will be asked of this source"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "This source has the part and you still need it"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "This peer already has the part"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "This peer does not have the part"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "No source has this part"
+msgstr "Este comando não deveria ter quaisquer parâmetros."
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "One source has this part"
+msgstr "Este comando não deveria ter quaisquer parâmetros."
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy, c-format
+msgid "%u or more sources have this part"
+msgstr "Este comando não deveria ter quaisquer parâmetros."
+
+#: src/PartBarLegendUI.cpp
+msgid "Already read back and hashed"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "Still to be read"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "One block per part of the file being downloaded."
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "One block per part of the shared file."
+msgstr "Insira o porto do servidor."
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "One block per part of the shared file, coloured by how many sources have it."
+msgstr "Insira o porto do servidor."
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "One block per part of the shared file, showing how far the re-hash has read."
+msgstr "Insira o porto do servidor."
+
+#: src/PartBarLegendUI.cpp
+msgid "In between, darkening as sources are added"
+msgstr ""
+
 #: src/PartFileConvert.cpp
 msgid "Waiting for partfile convert thread to die..."
 msgstr "À espera que o programa de conversão do ficheiro de partes termine..."
@@ -7439,8 +7476,9 @@ msgid "Shares File List"
 msgstr "Partilha a Lista de Ficheiros"
 
 #: src/SharedFilesCtrl.cpp
-msgid "Obtained Parts"
-msgstr "Partes Obtidas"
+#, fuzzy
+msgid "Source Availability"
+msgstr "Disponibilidade"
 
 #: src/SharedFilesCtrl.cpp
 msgid "Directory Path"
@@ -9310,6 +9348,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "Obtained Parts"
+#~ msgstr "Partes Obtidas"
 
 #~ msgid "Available Parts"
 #~ msgstr "Partes Disponíveis"

--- a/po/ro.po
+++ b/po/ro.po
@@ -5628,17 +5628,17 @@ msgstr ""
 
 #: src/PartBarLegendUI.cpp
 #, fuzzy
-msgid "No source has this part"
+msgid "No other source has this part"
 msgstr "Această comandă nu ar trebui să aibă niciun parametru."
 
 #: src/PartBarLegendUI.cpp
 #, fuzzy
-msgid "One source has this part"
+msgid "One other source has this part"
 msgstr "Această comandă nu ar trebui să aibă niciun parametru."
 
 #: src/PartBarLegendUI.cpp
 #, fuzzy, c-format
-msgid "%u or more sources have this part"
+msgid "%u or more other sources have this part"
 msgstr "Această comandă nu ar trebui să aibă niciun parametru."
 
 #: src/PartBarLegendUI.cpp
@@ -5660,7 +5660,7 @@ msgstr "Introduceți aici portul serverului."
 
 #: src/PartBarLegendUI.cpp
 #, fuzzy
-msgid "One block per part of the shared file, coloured by how many sources have it."
+msgid "One block per part of the shared file, coloured by how many other sources have it."
 msgstr "Introduceți aici portul serverului."
 
 #: src/PartBarLegendUI.cpp
@@ -5669,7 +5669,7 @@ msgid "One block per part of the shared file, showing how far the re-hash has re
 msgstr "Introduceți aici portul serverului."
 
 #: src/PartBarLegendUI.cpp
-msgid "In between, darkening as sources are added"
+msgid "In between, darkening as other sources are added"
 msgstr ""
 
 #: src/PartFileConvert.cpp

--- a/po/ro.po
+++ b/po/ro.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-02 12:15+0200\n"
+"POT-Creation-Date: 2026-09-04 07:50+0200\n"
 "PO-Revision-Date: 2026-09-03 11:09+0000\n"
 "Last-Translator: Angelescu Constantin <titus0818@yahoo.com>\n"
 "Language-Team: English <kde-i18n-doc@kde.org>\n"
@@ -2823,48 +2823,10 @@ msgstr ""
 "A fost alocat numai un singur slot."
 
 #: src/GenericClientListCtrl.cpp
-#, fuzzy
-msgid "This source does not have the part"
-msgstr "Această comandă nu ar trebui să aibă niciun parametru."
-
-#: src/GenericClientListCtrl.cpp
-msgid "You and this source both have the part"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "Being downloaded from this source now"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "The next part that will be asked of this source"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "This source has the part and you still need it"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "This peer already has the part"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "This peer does not have the part"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "One block per part of the file being downloaded."
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-#, fuzzy
-msgid "One block per part of the shared file."
-msgstr "Introduceți aici portul serverului."
-
-#: src/GenericClientListCtrl.cpp
 msgid "Swap to this file"
 msgstr "Schimbă la acest fișier"
 
-#: src/GenericClientListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Colour legend"
 msgstr ""
 
@@ -5635,6 +5597,81 @@ msgstr "Text"
 msgid "Using config dir: %s"
 msgstr "Utilizând directorul de configurare: %s"
 
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "This source does not have the part"
+msgstr "Această comandă nu ar trebui să aibă niciun parametru."
+
+#: src/PartBarLegendUI.cpp
+msgid "You and this source both have the part"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "Being downloaded from this source now"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "The next part that will be asked of this source"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "This source has the part and you still need it"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "This peer already has the part"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "This peer does not have the part"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "No source has this part"
+msgstr "Această comandă nu ar trebui să aibă niciun parametru."
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "One source has this part"
+msgstr "Această comandă nu ar trebui să aibă niciun parametru."
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy, c-format
+msgid "%u or more sources have this part"
+msgstr "Această comandă nu ar trebui să aibă niciun parametru."
+
+#: src/PartBarLegendUI.cpp
+msgid "Already read back and hashed"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "Still to be read"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "One block per part of the file being downloaded."
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "One block per part of the shared file."
+msgstr "Introduceți aici portul serverului."
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "One block per part of the shared file, coloured by how many sources have it."
+msgstr "Introduceți aici portul serverului."
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "One block per part of the shared file, showing how far the re-hash has read."
+msgstr "Introduceți aici portul serverului."
+
+#: src/PartBarLegendUI.cpp
+msgid "In between, darkening as sources are added"
+msgstr ""
+
 #: src/PartFileConvert.cpp
 msgid "Waiting for partfile convert thread to die..."
 msgstr "Se așteaptă ca procesul de conversie pentru fișierul parțial să moară..."
@@ -7462,8 +7499,9 @@ msgid "Shares File List"
 msgstr "Listă fișiere partajate"
 
 #: src/SharedFilesCtrl.cpp
-msgid "Obtained Parts"
-msgstr "Părți obținute"
+#, fuzzy
+msgid "Source Availability"
+msgstr "Disponibilitate"
 
 #: src/SharedFilesCtrl.cpp
 msgid "Directory Path"
@@ -9341,6 +9379,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "Obtained Parts"
+#~ msgstr "Părți obținute"
 
 #~ msgid "Available Parts"
 #~ msgstr "Părți disponibile"

--- a/po/ru.po
+++ b/po/ru.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-02 12:15+0200\n"
+"POT-Creation-Date: 2026-09-04 07:50+0200\n"
 "PO-Revision-Date: 2026-09-03 11:09+0000\n"
 "Last-Translator: Radist Morse <radist.morse@gmail.com>\n"
 "Language-Team: Russian <kde-russian@lists.kde.ru>\n"
@@ -2828,46 +2828,10 @@ msgstr ""
 " Был выделен только один слот."
 
 #: src/GenericClientListCtrl.cpp
-msgid "This source does not have the part"
-msgstr "У этого источника нет части"
-
-#: src/GenericClientListCtrl.cpp
-msgid "You and this source both have the part"
-msgstr "Эта часть есть и у вас, и у источника"
-
-#: src/GenericClientListCtrl.cpp
-msgid "Being downloaded from this source now"
-msgstr "Сейчас загружается от этого источника"
-
-#: src/GenericClientListCtrl.cpp
-msgid "The next part that will be asked of this source"
-msgstr "Следующая часть, которая будет запрошена у этого источника"
-
-#: src/GenericClientListCtrl.cpp
-msgid "This source has the part and you still need it"
-msgstr "У источника есть эта часть, и она вам ещё нужна"
-
-#: src/GenericClientListCtrl.cpp
-msgid "This peer already has the part"
-msgstr "У этого пира уже есть эта часть"
-
-#: src/GenericClientListCtrl.cpp
-msgid "This peer does not have the part"
-msgstr "У этого пира нет этой части"
-
-#: src/GenericClientListCtrl.cpp
-msgid "One block per part of the file being downloaded."
-msgstr "Один блок на каждую часть загружаемого файла."
-
-#: src/GenericClientListCtrl.cpp
-msgid "One block per part of the shared file."
-msgstr "По одному блоку на каждую часть публикуемого файла."
-
-#: src/GenericClientListCtrl.cpp
 msgid "Swap to this file"
 msgstr "Переключить на этот файл"
 
-#: src/GenericClientListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Colour legend"
 msgstr "Легенда цветов"
 
@@ -5618,6 +5582,79 @@ msgstr "Текст"
 msgid "Using config dir: %s"
 msgstr "Используем директорию конфигурации: %s"
 
+#: src/PartBarLegendUI.cpp
+msgid "This source does not have the part"
+msgstr "У этого источника нет части"
+
+#: src/PartBarLegendUI.cpp
+msgid "You and this source both have the part"
+msgstr "Эта часть есть и у вас, и у источника"
+
+#: src/PartBarLegendUI.cpp
+msgid "Being downloaded from this source now"
+msgstr "Сейчас загружается от этого источника"
+
+#: src/PartBarLegendUI.cpp
+msgid "The next part that will be asked of this source"
+msgstr "Следующая часть, которая будет запрошена у этого источника"
+
+#: src/PartBarLegendUI.cpp
+msgid "This source has the part and you still need it"
+msgstr "У источника есть эта часть, и она вам ещё нужна"
+
+#: src/PartBarLegendUI.cpp
+msgid "This peer already has the part"
+msgstr "У этого пира уже есть эта часть"
+
+#: src/PartBarLegendUI.cpp
+msgid "This peer does not have the part"
+msgstr "У этого пира нет этой части"
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "No source has this part"
+msgstr "У этого источника нет части"
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "One source has this part"
+msgstr "У этого источника нет части"
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy, c-format
+msgid "%u or more sources have this part"
+msgstr "Эта часть есть и у вас, и у источника"
+
+#: src/PartBarLegendUI.cpp
+msgid "Already read back and hashed"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "Still to be read"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "One block per part of the file being downloaded."
+msgstr "Один блок на каждую часть загружаемого файла."
+
+#: src/PartBarLegendUI.cpp
+msgid "One block per part of the shared file."
+msgstr "По одному блоку на каждую часть публикуемого файла."
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "One block per part of the shared file, coloured by how many sources have it."
+msgstr "По одному блоку на каждую часть публикуемого файла."
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "One block per part of the shared file, showing how far the re-hash has read."
+msgstr "По одному блоку на каждую часть публикуемого файла."
+
+#: src/PartBarLegendUI.cpp
+msgid "In between, darkening as sources are added"
+msgstr ""
+
 #: src/PartFileConvert.cpp
 msgid "Waiting for partfile convert thread to die..."
 msgstr "Ожидание завершения нити конвертации файла..."
@@ -7423,8 +7460,9 @@ msgid "Shares File List"
 msgstr "Общ. файлы"
 
 #: src/SharedFilesCtrl.cpp
-msgid "Obtained Parts"
-msgstr "Полученные части"
+#, fuzzy
+msgid "Source Availability"
+msgstr "Доступность"
 
 #: src/SharedFilesCtrl.cpp
 msgid "Directory Path"
@@ -9323,6 +9361,9 @@ msgstr "Похоже, что aMule запущен. Закройте его и п
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "Удаление пользовательских данных в $APPDATA\\aMule…"
+
+#~ msgid "Obtained Parts"
+#~ msgstr "Полученные части"
 
 #~ msgid "Available Parts"
 #~ msgstr "Доступные части"

--- a/po/ru.po
+++ b/po/ru.po
@@ -5612,17 +5612,17 @@ msgstr "У этого пира нет этой части"
 
 #: src/PartBarLegendUI.cpp
 #, fuzzy
-msgid "No source has this part"
+msgid "No other source has this part"
 msgstr "У этого источника нет части"
 
 #: src/PartBarLegendUI.cpp
 #, fuzzy
-msgid "One source has this part"
+msgid "One other source has this part"
 msgstr "У этого источника нет части"
 
 #: src/PartBarLegendUI.cpp
 #, fuzzy, c-format
-msgid "%u or more sources have this part"
+msgid "%u or more other sources have this part"
 msgstr "Эта часть есть и у вас, и у источника"
 
 #: src/PartBarLegendUI.cpp
@@ -5643,7 +5643,7 @@ msgstr "По одному блоку на каждую часть публику
 
 #: src/PartBarLegendUI.cpp
 #, fuzzy
-msgid "One block per part of the shared file, coloured by how many sources have it."
+msgid "One block per part of the shared file, coloured by how many other sources have it."
 msgstr "По одному блоку на каждую часть публикуемого файла."
 
 #: src/PartBarLegendUI.cpp
@@ -5652,7 +5652,7 @@ msgid "One block per part of the shared file, showing how far the re-hash has re
 msgstr "По одному блоку на каждую часть публикуемого файла."
 
 #: src/PartBarLegendUI.cpp
-msgid "In between, darkening as sources are added"
+msgid "In between, darkening as other sources are added"
 msgstr ""
 
 #: src/PartFileConvert.cpp

--- a/po/sl.po
+++ b/po/sl.po
@@ -5658,17 +5658,17 @@ msgstr ""
 
 #: src/PartBarLegendUI.cpp
 #, fuzzy
-msgid "No source has this part"
+msgid "No other source has this part"
 msgstr "Ta ukaz ne sme imeti parametrov."
 
 #: src/PartBarLegendUI.cpp
 #, fuzzy
-msgid "One source has this part"
+msgid "One other source has this part"
 msgstr "Ta ukaz ne sme imeti parametrov."
 
 #: src/PartBarLegendUI.cpp
 #, fuzzy, c-format
-msgid "%u or more sources have this part"
+msgid "%u or more other sources have this part"
 msgstr "Ta ukaz ne sme imeti parametrov."
 
 #: src/PartBarLegendUI.cpp
@@ -5690,7 +5690,7 @@ msgstr "Sem vnesite vrata strežnika."
 
 #: src/PartBarLegendUI.cpp
 #, fuzzy
-msgid "One block per part of the shared file, coloured by how many sources have it."
+msgid "One block per part of the shared file, coloured by how many other sources have it."
 msgstr "Sem vnesite vrata strežnika."
 
 #: src/PartBarLegendUI.cpp
@@ -5699,7 +5699,7 @@ msgid "One block per part of the shared file, showing how far the re-hash has re
 msgstr "Sem vnesite vrata strežnika."
 
 #: src/PartBarLegendUI.cpp
-msgid "In between, darkening as sources are added"
+msgid "In between, darkening as other sources are added"
 msgstr ""
 
 #: src/PartFileConvert.cpp

--- a/po/sl.po
+++ b/po/sl.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-02 12:15+0200\n"
+"POT-Creation-Date: 2026-09-04 07:50+0200\n"
 "PO-Revision-Date: 2026-09-03 11:10+0000\n"
 "Last-Translator: Jure Repinc <jlp@holodeck1.com>\n"
 "Language-Team: Slovenian\n"
@@ -2839,48 +2839,10 @@ msgstr ""
 "Samo eno mesto je bilo dodeljeno."
 
 #: src/GenericClientListCtrl.cpp
-#, fuzzy
-msgid "This source does not have the part"
-msgstr "Ta ukaz ne sme imeti parametrov."
-
-#: src/GenericClientListCtrl.cpp
-msgid "You and this source both have the part"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "Being downloaded from this source now"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "The next part that will be asked of this source"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "This source has the part and you still need it"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "This peer already has the part"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "This peer does not have the part"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "One block per part of the file being downloaded."
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-#, fuzzy
-msgid "One block per part of the shared file."
-msgstr "Sem vnesite vrata strežnika."
-
-#: src/GenericClientListCtrl.cpp
 msgid "Swap to this file"
 msgstr "Prenesi k tej datoteki"
 
-#: src/GenericClientListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Colour legend"
 msgstr ""
 
@@ -5665,6 +5627,81 @@ msgstr "Besedilo"
 msgid "Using config dir: %s"
 msgstr "Uporaba mape z nastavitvami: %s"
 
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "This source does not have the part"
+msgstr "Ta ukaz ne sme imeti parametrov."
+
+#: src/PartBarLegendUI.cpp
+msgid "You and this source both have the part"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "Being downloaded from this source now"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "The next part that will be asked of this source"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "This source has the part and you still need it"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "This peer already has the part"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "This peer does not have the part"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "No source has this part"
+msgstr "Ta ukaz ne sme imeti parametrov."
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "One source has this part"
+msgstr "Ta ukaz ne sme imeti parametrov."
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy, c-format
+msgid "%u or more sources have this part"
+msgstr "Ta ukaz ne sme imeti parametrov."
+
+#: src/PartBarLegendUI.cpp
+msgid "Already read back and hashed"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "Still to be read"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "One block per part of the file being downloaded."
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "One block per part of the shared file."
+msgstr "Sem vnesite vrata strežnika."
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "One block per part of the shared file, coloured by how many sources have it."
+msgstr "Sem vnesite vrata strežnika."
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "One block per part of the shared file, showing how far the re-hash has read."
+msgstr "Sem vnesite vrata strežnika."
+
+#: src/PartBarLegendUI.cpp
+msgid "In between, darkening as sources are added"
+msgstr ""
+
 #: src/PartFileConvert.cpp
 msgid "Waiting for partfile convert thread to die..."
 msgstr "Čakanje na zamrtje niti za pretvarjanje delnih datotek …"
@@ -7512,8 +7549,9 @@ msgid "Shares File List"
 msgstr "Deli seznam datotek"
 
 #: src/SharedFilesCtrl.cpp
-msgid "Obtained Parts"
-msgstr "Dobljeni deli"
+#, fuzzy
+msgid "Source Availability"
+msgstr "Razpoložljivost"
 
 #: src/SharedFilesCtrl.cpp
 msgid "Directory Path"
@@ -9394,6 +9432,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "Obtained Parts"
+#~ msgstr "Dobljeni deli"
 
 #~ msgid "Available Parts"
 #~ msgstr "Razpoložljivi deli"

--- a/po/sq.po
+++ b/po/sq.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-02 12:15+0200\n"
+"POT-Creation-Date: 2026-09-04 07:50+0200\n"
 "PO-Revision-Date: 2026-09-03 11:10+0000\n"
 "Last-Translator: Fation <dj_barthezz@linuxmail.org lushnja_corps@hotmail.Language-Team:\n"
 "Language: sq\n"
@@ -2827,48 +2827,10 @@ msgstr ""
 " Vetem nje slot i vetem u vendos."
 
 #: src/GenericClientListCtrl.cpp
-#, fuzzy
-msgid "This source does not have the part"
-msgstr "Kjo komande nuk duhet te kete parametra."
-
-#: src/GenericClientListCtrl.cpp
-msgid "You and this source both have the part"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "Being downloaded from this source now"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "The next part that will be asked of this source"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "This source has the part and you still need it"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "This peer already has the part"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "This peer does not have the part"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "One block per part of the file being downloaded."
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-#, fuzzy
-msgid "One block per part of the shared file."
-msgstr "Futni porten e serverit ketu."
-
-#: src/GenericClientListCtrl.cpp
 msgid "Swap to this file"
 msgstr "Sposto tek ky fail"
 
-#: src/GenericClientListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Colour legend"
 msgstr ""
 
@@ -5640,6 +5602,81 @@ msgstr "Tekst"
 msgid "Using config dir: %s"
 msgstr ""
 
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "This source does not have the part"
+msgstr "Kjo komande nuk duhet te kete parametra."
+
+#: src/PartBarLegendUI.cpp
+msgid "You and this source both have the part"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "Being downloaded from this source now"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "The next part that will be asked of this source"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "This source has the part and you still need it"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "This peer already has the part"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "This peer does not have the part"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "No source has this part"
+msgstr "Kjo komande nuk duhet te kete parametra."
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "One source has this part"
+msgstr "Kjo komande nuk duhet te kete parametra."
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy, c-format
+msgid "%u or more sources have this part"
+msgstr "Kjo komande nuk duhet te kete parametra."
+
+#: src/PartBarLegendUI.cpp
+msgid "Already read back and hashed"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "Still to be read"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "One block per part of the file being downloaded."
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "One block per part of the shared file."
+msgstr "Futni porten e serverit ketu."
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "One block per part of the shared file, coloured by how many sources have it."
+msgstr "Futni porten e serverit ketu."
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "One block per part of the shared file, showing how far the re-hash has read."
+msgstr "Futni porten e serverit ketu."
+
+#: src/PartBarLegendUI.cpp
+msgid "In between, darkening as sources are added"
+msgstr ""
+
 #: src/PartFileConvert.cpp
 msgid "Waiting for partfile convert thread to die..."
 msgstr ""
@@ -7462,8 +7499,9 @@ msgid "Shares File List"
 msgstr "File te ndara"
 
 #: src/SharedFilesCtrl.cpp
-msgid "Obtained Parts"
-msgstr "Pjese te marra"
+#, fuzzy
+msgid "Source Availability"
+msgstr "Te disponueshem"
 
 #: src/SharedFilesCtrl.cpp
 msgid "Directory Path"
@@ -9332,6 +9370,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "Obtained Parts"
+#~ msgstr "Pjese te marra"
 
 #, fuzzy
 #~ msgid "Available Parts"

--- a/po/sq.po
+++ b/po/sq.po
@@ -5633,17 +5633,17 @@ msgstr ""
 
 #: src/PartBarLegendUI.cpp
 #, fuzzy
-msgid "No source has this part"
+msgid "No other source has this part"
 msgstr "Kjo komande nuk duhet te kete parametra."
 
 #: src/PartBarLegendUI.cpp
 #, fuzzy
-msgid "One source has this part"
+msgid "One other source has this part"
 msgstr "Kjo komande nuk duhet te kete parametra."
 
 #: src/PartBarLegendUI.cpp
 #, fuzzy, c-format
-msgid "%u or more sources have this part"
+msgid "%u or more other sources have this part"
 msgstr "Kjo komande nuk duhet te kete parametra."
 
 #: src/PartBarLegendUI.cpp
@@ -5665,7 +5665,7 @@ msgstr "Futni porten e serverit ketu."
 
 #: src/PartBarLegendUI.cpp
 #, fuzzy
-msgid "One block per part of the shared file, coloured by how many sources have it."
+msgid "One block per part of the shared file, coloured by how many other sources have it."
 msgstr "Futni porten e serverit ketu."
 
 #: src/PartBarLegendUI.cpp
@@ -5674,7 +5674,7 @@ msgid "One block per part of the shared file, showing how far the re-hash has re
 msgstr "Futni porten e serverit ketu."
 
 #: src/PartBarLegendUI.cpp
-msgid "In between, darkening as sources are added"
+msgid "In between, darkening as other sources are added"
 msgstr ""
 
 #: src/PartFileConvert.cpp

--- a/po/sv.po
+++ b/po/sv.po
@@ -5611,17 +5611,17 @@ msgstr ""
 
 #: src/PartBarLegendUI.cpp
 #, fuzzy
-msgid "No source has this part"
+msgid "No other source has this part"
 msgstr "Det här kommandot ska inte ha några parametrar."
 
 #: src/PartBarLegendUI.cpp
 #, fuzzy
-msgid "One source has this part"
+msgid "One other source has this part"
 msgstr "Det här kommandot ska inte ha några parametrar."
 
 #: src/PartBarLegendUI.cpp
 #, fuzzy, c-format
-msgid "%u or more sources have this part"
+msgid "%u or more other sources have this part"
 msgstr "Det här kommandot ska inte ha några parametrar."
 
 #: src/PartBarLegendUI.cpp
@@ -5643,7 +5643,7 @@ msgstr "Ange porten på servern här."
 
 #: src/PartBarLegendUI.cpp
 #, fuzzy
-msgid "One block per part of the shared file, coloured by how many sources have it."
+msgid "One block per part of the shared file, coloured by how many other sources have it."
 msgstr "Ange porten på servern här."
 
 #: src/PartBarLegendUI.cpp
@@ -5652,7 +5652,7 @@ msgid "One block per part of the shared file, showing how far the re-hash has re
 msgstr "Ange porten på servern här."
 
 #: src/PartBarLegendUI.cpp
-msgid "In between, darkening as sources are added"
+msgid "In between, darkening as other sources are added"
 msgstr ""
 
 #: src/PartFileConvert.cpp

--- a/po/sv.po
+++ b/po/sv.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-02 12:15+0200\n"
+"POT-Creation-Date: 2026-09-04 07:50+0200\n"
 "PO-Revision-Date: 2026-09-03 11:10+0000\n"
 "Last-Translator: raffe <raffe@localhost.se>\n"
 "Language-Team: Swedish <tp-sv@listor.tp-sv.se>\n"
@@ -2817,48 +2817,10 @@ msgstr ""
 " Endast ett spår tilldelades. "
 
 #: src/GenericClientListCtrl.cpp
-#, fuzzy
-msgid "This source does not have the part"
-msgstr "Det här kommandot ska inte ha några parametrar."
-
-#: src/GenericClientListCtrl.cpp
-msgid "You and this source both have the part"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "Being downloaded from this source now"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "The next part that will be asked of this source"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "This source has the part and you still need it"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "This peer already has the part"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "This peer does not have the part"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "One block per part of the file being downloaded."
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-#, fuzzy
-msgid "One block per part of the shared file."
-msgstr "Ange porten på servern här."
-
-#: src/GenericClientListCtrl.cpp
 msgid "Swap to this file"
 msgstr "Växla till den här filen"
 
-#: src/GenericClientListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Colour legend"
 msgstr ""
 
@@ -5618,6 +5580,81 @@ msgstr "Text"
 msgid "Using config dir: %s"
 msgstr "Använder config dir: %s"
 
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "This source does not have the part"
+msgstr "Det här kommandot ska inte ha några parametrar."
+
+#: src/PartBarLegendUI.cpp
+msgid "You and this source both have the part"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "Being downloaded from this source now"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "The next part that will be asked of this source"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "This source has the part and you still need it"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "This peer already has the part"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "This peer does not have the part"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "No source has this part"
+msgstr "Det här kommandot ska inte ha några parametrar."
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "One source has this part"
+msgstr "Det här kommandot ska inte ha några parametrar."
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy, c-format
+msgid "%u or more sources have this part"
+msgstr "Det här kommandot ska inte ha några parametrar."
+
+#: src/PartBarLegendUI.cpp
+msgid "Already read back and hashed"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "Still to be read"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "One block per part of the file being downloaded."
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "One block per part of the shared file."
+msgstr "Ange porten på servern här."
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "One block per part of the shared file, coloured by how many sources have it."
+msgstr "Ange porten på servern här."
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "One block per part of the shared file, showing how far the re-hash has read."
+msgstr "Ange porten på servern här."
+
+#: src/PartBarLegendUI.cpp
+msgid "In between, darkening as sources are added"
+msgstr ""
+
 #: src/PartFileConvert.cpp
 msgid "Waiting for partfile convert thread to die..."
 msgstr "Väntar på att partfile-konverterings-tråd ska dö..."
@@ -7426,8 +7463,9 @@ msgid "Shares File List"
 msgstr "Lista på delade filer"
 
 #: src/SharedFilesCtrl.cpp
-msgid "Obtained Parts"
-msgstr "Erhållna delar"
+#, fuzzy
+msgid "Source Availability"
+msgstr "Tillgänglighet"
 
 #: src/SharedFilesCtrl.cpp
 msgid "Directory Path"
@@ -9298,6 +9336,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "Obtained Parts"
+#~ msgstr "Erhållna delar"
 
 #~ msgid "Available Parts"
 #~ msgstr "Tillgängliga delar"

--- a/po/ta.po
+++ b/po/ta.po
@@ -5461,16 +5461,16 @@ msgid "This peer does not have the part"
 msgstr ""
 
 #: src/PartBarLegendUI.cpp
-msgid "No source has this part"
+msgid "No other source has this part"
 msgstr ""
 
 #: src/PartBarLegendUI.cpp
-msgid "One source has this part"
+msgid "One other source has this part"
 msgstr ""
 
 #: src/PartBarLegendUI.cpp
 #, c-format
-msgid "%u or more sources have this part"
+msgid "%u or more other sources have this part"
 msgstr ""
 
 #: src/PartBarLegendUI.cpp
@@ -5490,7 +5490,7 @@ msgid "One block per part of the shared file."
 msgstr ""
 
 #: src/PartBarLegendUI.cpp
-msgid "One block per part of the shared file, coloured by how many sources have it."
+msgid "One block per part of the shared file, coloured by how many other sources have it."
 msgstr ""
 
 #: src/PartBarLegendUI.cpp
@@ -5498,7 +5498,7 @@ msgid "One block per part of the shared file, showing how far the re-hash has re
 msgstr ""
 
 #: src/PartBarLegendUI.cpp
-msgid "In between, darkening as sources are added"
+msgid "In between, darkening as other sources are added"
 msgstr ""
 
 #: src/PartFileConvert.cpp

--- a/po/ta.po
+++ b/po/ta.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-02 12:15+0200\n"
+"POT-Creation-Date: 2026-09-04 07:50+0200\n"
 "PO-Revision-Date: 2026-09-03 11:13+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -2719,46 +2719,10 @@ msgid ""
 msgstr ""
 
 #: src/GenericClientListCtrl.cpp
-msgid "This source does not have the part"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "You and this source both have the part"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "Being downloaded from this source now"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "The next part that will be asked of this source"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "This source has the part and you still need it"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "This peer already has the part"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "This peer does not have the part"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "One block per part of the file being downloaded."
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "One block per part of the shared file."
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
 msgid "Swap to this file"
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Colour legend"
 msgstr ""
 
@@ -5468,6 +5432,75 @@ msgstr ""
 msgid "Using config dir: %s"
 msgstr ""
 
+#: src/PartBarLegendUI.cpp
+msgid "This source does not have the part"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "You and this source both have the part"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "Being downloaded from this source now"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "The next part that will be asked of this source"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "This source has the part and you still need it"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "This peer already has the part"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "This peer does not have the part"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "No source has this part"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "One source has this part"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+#, c-format
+msgid "%u or more sources have this part"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "Already read back and hashed"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "Still to be read"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "One block per part of the file being downloaded."
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "One block per part of the shared file."
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "One block per part of the shared file, coloured by how many sources have it."
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "One block per part of the shared file, showing how far the re-hash has read."
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "In between, darkening as sources are added"
+msgstr ""
+
 #: src/PartFileConvert.cpp
 msgid "Waiting for partfile convert thread to die..."
 msgstr ""
@@ -7210,7 +7243,7 @@ msgid "Shares File List"
 msgstr ""
 
 #: src/SharedFilesCtrl.cpp
-msgid "Obtained Parts"
+msgid "Source Availability"
 msgstr ""
 
 #: src/SharedFilesCtrl.cpp

--- a/po/tr.po
+++ b/po/tr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-02 12:15+0200\n"
+"POT-Creation-Date: 2026-09-04 07:50+0200\n"
 "PO-Revision-Date: 2026-09-03 11:11+0000\n"
 "Last-Translator: \n"
 "Language-Team: Turkish <li@li.org>\n"
@@ -2804,46 +2804,10 @@ msgstr ""
 "Sadece bir slot kuruldu."
 
 #: src/GenericClientListCtrl.cpp
-msgid "This source does not have the part"
-msgstr "Bu kaynakta parça mevcut değil"
-
-#: src/GenericClientListCtrl.cpp
-msgid "You and this source both have the part"
-msgstr "Hem siz hem de bu kaynak parçaya sahipsiniz"
-
-#: src/GenericClientListCtrl.cpp
-msgid "Being downloaded from this source now"
-msgstr "Şu anda bu kaynaktan indiriliyor"
-
-#: src/GenericClientListCtrl.cpp
-msgid "The next part that will be asked of this source"
-msgstr "Bu kaynaktan istenecek gelecek parça"
-
-#: src/GenericClientListCtrl.cpp
-msgid "This source has the part and you still need it"
-msgstr "Bu kaynak parçaya sahip ve sizin hâlâ buna ihtiyacınız var"
-
-#: src/GenericClientListCtrl.cpp
-msgid "This peer already has the part"
-msgstr "Bu eşte zaten parça mevcut"
-
-#: src/GenericClientListCtrl.cpp
-msgid "This peer does not have the part"
-msgstr "Bu eşte parça mevcut değil"
-
-#: src/GenericClientListCtrl.cpp
-msgid "One block per part of the file being downloaded."
-msgstr "İndirilmekte olan dosyanın her bir parçası için bir blok."
-
-#: src/GenericClientListCtrl.cpp
-msgid "One block per part of the shared file."
-msgstr "Paylaşılan dosyanın her bir parçası için bir blok."
-
-#: src/GenericClientListCtrl.cpp
 msgid "Swap to this file"
 msgstr "Bu dosyaya geçir"
 
-#: src/GenericClientListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Colour legend"
 msgstr "Renk açıklaması"
 
@@ -5570,6 +5534,79 @@ msgstr "Belge"
 msgid "Using config dir: %s"
 msgstr "Kullanılan yapılandırma dizini: %s"
 
+#: src/PartBarLegendUI.cpp
+msgid "This source does not have the part"
+msgstr "Bu kaynakta parça mevcut değil"
+
+#: src/PartBarLegendUI.cpp
+msgid "You and this source both have the part"
+msgstr "Hem siz hem de bu kaynak parçaya sahipsiniz"
+
+#: src/PartBarLegendUI.cpp
+msgid "Being downloaded from this source now"
+msgstr "Şu anda bu kaynaktan indiriliyor"
+
+#: src/PartBarLegendUI.cpp
+msgid "The next part that will be asked of this source"
+msgstr "Bu kaynaktan istenecek gelecek parça"
+
+#: src/PartBarLegendUI.cpp
+msgid "This source has the part and you still need it"
+msgstr "Bu kaynak parçaya sahip ve sizin hâlâ buna ihtiyacınız var"
+
+#: src/PartBarLegendUI.cpp
+msgid "This peer already has the part"
+msgstr "Bu eşte zaten parça mevcut"
+
+#: src/PartBarLegendUI.cpp
+msgid "This peer does not have the part"
+msgstr "Bu eşte parça mevcut değil"
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "No source has this part"
+msgstr "Bu kaynakta parça mevcut değil"
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "One source has this part"
+msgstr "Bu kaynakta parça mevcut değil"
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy, c-format
+msgid "%u or more sources have this part"
+msgstr "Hem siz hem de bu kaynak parçaya sahipsiniz"
+
+#: src/PartBarLegendUI.cpp
+msgid "Already read back and hashed"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "Still to be read"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "One block per part of the file being downloaded."
+msgstr "İndirilmekte olan dosyanın her bir parçası için bir blok."
+
+#: src/PartBarLegendUI.cpp
+msgid "One block per part of the shared file."
+msgstr "Paylaşılan dosyanın her bir parçası için bir blok."
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "One block per part of the shared file, coloured by how many sources have it."
+msgstr "Paylaşılan dosyanın her bir parçası için bir blok."
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "One block per part of the shared file, showing how far the re-hash has read."
+msgstr "Paylaşılan dosyanın her bir parçası için bir blok."
+
+#: src/PartBarLegendUI.cpp
+msgid "In between, darkening as sources are added"
+msgstr ""
+
 #: src/PartFileConvert.cpp
 msgid "Waiting for partfile convert thread to die..."
 msgstr "Parçadosyası dönüşümünün bitmesi bekleniyor…"
@@ -7348,8 +7385,9 @@ msgid "Shares File List"
 msgstr "Paylaşılan Dosyalar Listesi"
 
 #: src/SharedFilesCtrl.cpp
-msgid "Obtained Parts"
-msgstr "Alınan Parçalar"
+#, fuzzy
+msgid "Source Availability"
+msgstr "Uygunluk"
 
 #: src/SharedFilesCtrl.cpp
 msgid "Directory Path"
@@ -9236,6 +9274,9 @@ msgstr "aMule çalışmakta gibi görünüyor. Lütfen onu kapatıp kurulum prog
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "Kullanıcı verileri $APPDATA\\aMule konumunda kaldırılıyor…"
+
+#~ msgid "Obtained Parts"
+#~ msgstr "Alınan Parçalar"
 
 #~ msgid "Available Parts"
 #~ msgstr "Erişilebilir Parçalar"

--- a/po/tr.po
+++ b/po/tr.po
@@ -5564,17 +5564,17 @@ msgstr "Bu eşte parça mevcut değil"
 
 #: src/PartBarLegendUI.cpp
 #, fuzzy
-msgid "No source has this part"
+msgid "No other source has this part"
 msgstr "Bu kaynakta parça mevcut değil"
 
 #: src/PartBarLegendUI.cpp
 #, fuzzy
-msgid "One source has this part"
+msgid "One other source has this part"
 msgstr "Bu kaynakta parça mevcut değil"
 
 #: src/PartBarLegendUI.cpp
 #, fuzzy, c-format
-msgid "%u or more sources have this part"
+msgid "%u or more other sources have this part"
 msgstr "Hem siz hem de bu kaynak parçaya sahipsiniz"
 
 #: src/PartBarLegendUI.cpp
@@ -5595,7 +5595,7 @@ msgstr "Paylaşılan dosyanın her bir parçası için bir blok."
 
 #: src/PartBarLegendUI.cpp
 #, fuzzy
-msgid "One block per part of the shared file, coloured by how many sources have it."
+msgid "One block per part of the shared file, coloured by how many other sources have it."
 msgstr "Paylaşılan dosyanın her bir parçası için bir blok."
 
 #: src/PartBarLegendUI.cpp
@@ -5604,7 +5604,7 @@ msgid "One block per part of the shared file, showing how far the re-hash has re
 msgstr "Paylaşılan dosyanın her bir parçası için bir blok."
 
 #: src/PartBarLegendUI.cpp
-msgid "In between, darkening as sources are added"
+msgid "In between, darkening as other sources are added"
 msgstr ""
 
 #: src/PartFileConvert.cpp

--- a/po/uk.po
+++ b/po/uk.po
@@ -5662,17 +5662,17 @@ msgstr ""
 
 #: src/PartBarLegendUI.cpp
 #, fuzzy
-msgid "No source has this part"
+msgid "No other source has this part"
 msgstr "Ця команда не повинна мати жодного параметру."
 
 #: src/PartBarLegendUI.cpp
 #, fuzzy
-msgid "One source has this part"
+msgid "One other source has this part"
 msgstr "Ця команда не повинна мати жодного параметру."
 
 #: src/PartBarLegendUI.cpp
 #, fuzzy, c-format
-msgid "%u or more sources have this part"
+msgid "%u or more other sources have this part"
 msgstr "Ця команда не повинна мати жодного параметру."
 
 #: src/PartBarLegendUI.cpp
@@ -5694,7 +5694,7 @@ msgstr "Введіть тут порт сервера."
 
 #: src/PartBarLegendUI.cpp
 #, fuzzy
-msgid "One block per part of the shared file, coloured by how many sources have it."
+msgid "One block per part of the shared file, coloured by how many other sources have it."
 msgstr "Введіть тут порт сервера."
 
 #: src/PartBarLegendUI.cpp
@@ -5703,7 +5703,7 @@ msgid "One block per part of the shared file, showing how far the re-hash has re
 msgstr "Введіть тут порт сервера."
 
 #: src/PartBarLegendUI.cpp
-msgid "In between, darkening as sources are added"
+msgid "In between, darkening as other sources are added"
 msgstr ""
 
 #: src/PartFileConvert.cpp

--- a/po/uk.po
+++ b/po/uk.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-02 12:15+0200\n"
+"POT-Creation-Date: 2026-09-04 07:50+0200\n"
 "PO-Revision-Date: 2026-09-03 11:11+0000\n"
 "Last-Translator: Oleksandr Kovalenko <alx.kovalenko@gmail.com>\n"
 "Language-Team: Ukrainian <translation@linux.org.ua>\n"
@@ -2837,48 +2837,10 @@ msgstr ""
 "Був виділений тільки один слот."
 
 #: src/GenericClientListCtrl.cpp
-#, fuzzy
-msgid "This source does not have the part"
-msgstr "Ця команда не повинна мати жодного параметру."
-
-#: src/GenericClientListCtrl.cpp
-msgid "You and this source both have the part"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "Being downloaded from this source now"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "The next part that will be asked of this source"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "This source has the part and you still need it"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "This peer already has the part"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "This peer does not have the part"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "One block per part of the file being downloaded."
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-#, fuzzy
-msgid "One block per part of the shared file."
-msgstr "Введіть тут порт сервера."
-
-#: src/GenericClientListCtrl.cpp
 msgid "Swap to this file"
 msgstr "Перемкнути на цей файл"
 
-#: src/GenericClientListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Colour legend"
 msgstr ""
 
@@ -5669,6 +5631,81 @@ msgstr "Текст"
 msgid "Using config dir: %s"
 msgstr ""
 
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "This source does not have the part"
+msgstr "Ця команда не повинна мати жодного параметру."
+
+#: src/PartBarLegendUI.cpp
+msgid "You and this source both have the part"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "Being downloaded from this source now"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "The next part that will be asked of this source"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "This source has the part and you still need it"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "This peer already has the part"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "This peer does not have the part"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "No source has this part"
+msgstr "Ця команда не повинна мати жодного параметру."
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "One source has this part"
+msgstr "Ця команда не повинна мати жодного параметру."
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy, c-format
+msgid "%u or more sources have this part"
+msgstr "Ця команда не повинна мати жодного параметру."
+
+#: src/PartBarLegendUI.cpp
+msgid "Already read back and hashed"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "Still to be read"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "One block per part of the file being downloaded."
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "One block per part of the shared file."
+msgstr "Введіть тут порт сервера."
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "One block per part of the shared file, coloured by how many sources have it."
+msgstr "Введіть тут порт сервера."
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "One block per part of the shared file, showing how far the re-hash has read."
+msgstr "Введіть тут порт сервера."
+
+#: src/PartBarLegendUI.cpp
+msgid "In between, darkening as sources are added"
+msgstr ""
+
 #: src/PartFileConvert.cpp
 msgid "Waiting for partfile convert thread to die..."
 msgstr "Очікується завершення потому перетворення часткового файлу..."
@@ -7511,8 +7548,9 @@ msgid "Shares File List"
 msgstr "Спільні файли"
 
 #: src/SharedFilesCtrl.cpp
-msgid "Obtained Parts"
-msgstr "Отримані частини"
+#, fuzzy
+msgid "Source Availability"
+msgstr "Доступність"
 
 #: src/SharedFilesCtrl.cpp
 msgid "Directory Path"
@@ -9409,6 +9447,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "Obtained Parts"
+#~ msgstr "Отримані частини"
 
 #, fuzzy
 #~ msgid "Available Parts"

--- a/po/vi.po
+++ b/po/vi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-02 12:15+0200\n"
+"POT-Creation-Date: 2026-09-04 07:50+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -2718,46 +2718,10 @@ msgid ""
 msgstr ""
 
 #: src/GenericClientListCtrl.cpp
-msgid "This source does not have the part"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "You and this source both have the part"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "Being downloaded from this source now"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "The next part that will be asked of this source"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "This source has the part and you still need it"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "This peer already has the part"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "This peer does not have the part"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "One block per part of the file being downloaded."
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "One block per part of the shared file."
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
 msgid "Swap to this file"
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Colour legend"
 msgstr ""
 
@@ -5463,6 +5427,75 @@ msgstr ""
 msgid "Using config dir: %s"
 msgstr ""
 
+#: src/PartBarLegendUI.cpp
+msgid "This source does not have the part"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "You and this source both have the part"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "Being downloaded from this source now"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "The next part that will be asked of this source"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "This source has the part and you still need it"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "This peer already has the part"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "This peer does not have the part"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "No source has this part"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "One source has this part"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+#, c-format
+msgid "%u or more sources have this part"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "Already read back and hashed"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "Still to be read"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "One block per part of the file being downloaded."
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "One block per part of the shared file."
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "One block per part of the shared file, coloured by how many sources have it."
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "One block per part of the shared file, showing how far the re-hash has read."
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "In between, darkening as sources are added"
+msgstr ""
+
 #: src/PartFileConvert.cpp
 msgid "Waiting for partfile convert thread to die..."
 msgstr ""
@@ -7200,7 +7233,7 @@ msgid "Shares File List"
 msgstr ""
 
 #: src/SharedFilesCtrl.cpp
-msgid "Obtained Parts"
+msgid "Source Availability"
 msgstr ""
 
 #: src/SharedFilesCtrl.cpp

--- a/po/vi.po
+++ b/po/vi.po
@@ -5456,16 +5456,16 @@ msgid "This peer does not have the part"
 msgstr ""
 
 #: src/PartBarLegendUI.cpp
-msgid "No source has this part"
+msgid "No other source has this part"
 msgstr ""
 
 #: src/PartBarLegendUI.cpp
-msgid "One source has this part"
+msgid "One other source has this part"
 msgstr ""
 
 #: src/PartBarLegendUI.cpp
 #, c-format
-msgid "%u or more sources have this part"
+msgid "%u or more other sources have this part"
 msgstr ""
 
 #: src/PartBarLegendUI.cpp
@@ -5485,7 +5485,7 @@ msgid "One block per part of the shared file."
 msgstr ""
 
 #: src/PartBarLegendUI.cpp
-msgid "One block per part of the shared file, coloured by how many sources have it."
+msgid "One block per part of the shared file, coloured by how many other sources have it."
 msgstr ""
 
 #: src/PartBarLegendUI.cpp
@@ -5493,7 +5493,7 @@ msgid "One block per part of the shared file, showing how far the re-hash has re
 msgstr ""
 
 #: src/PartBarLegendUI.cpp
-msgid "In between, darkening as sources are added"
+msgid "In between, darkening as other sources are added"
 msgstr ""
 
 #: src/PartFileConvert.cpp

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-02 12:15+0200\n"
+"POT-Creation-Date: 2026-09-04 07:50+0200\n"
 "PO-Revision-Date: 2026-09-03 11:12+0000\n"
 "Last-Translator: Mike Akiba <mike2718@gmail.com>\n"
 "Language-Team: Chinese Simplified <kde-i18n-doc@kde.org>\n"
@@ -2808,46 +2808,10 @@ msgstr ""
 " 只能指定一个通道。"
 
 #: src/GenericClientListCtrl.cpp
-msgid "This source does not have the part"
-msgstr "这个源没有该部分"
-
-#: src/GenericClientListCtrl.cpp
-msgid "You and this source both have the part"
-msgstr "你和这个源都有该部分"
-
-#: src/GenericClientListCtrl.cpp
-msgid "Being downloaded from this source now"
-msgstr "正从这个源下载"
-
-#: src/GenericClientListCtrl.cpp
-msgid "The next part that will be asked of this source"
-msgstr "下一个要从这个源请求的部分"
-
-#: src/GenericClientListCtrl.cpp
-msgid "This source has the part and you still need it"
-msgstr "这个源有该部分，你仍需要它"
-
-#: src/GenericClientListCtrl.cpp
-msgid "This peer already has the part"
-msgstr "这个对等方已经有该部分"
-
-#: src/GenericClientListCtrl.cpp
-msgid "This peer does not have the part"
-msgstr "这个对等方没有该部分"
-
-#: src/GenericClientListCtrl.cpp
-msgid "One block per part of the file being downloaded."
-msgstr "正被下载的文件每部分对应一个区块。"
-
-#: src/GenericClientListCtrl.cpp
-msgid "One block per part of the shared file."
-msgstr "共享文件每个部分对应一个区块。"
-
-#: src/GenericClientListCtrl.cpp
 msgid "Swap to this file"
 msgstr "转移到这个文件"
 
-#: src/GenericClientListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Colour legend"
 msgstr "颜色图例"
 
@@ -5574,6 +5538,79 @@ msgstr "文本"
 msgid "Using config dir: %s"
 msgstr "使用配置目录：%s"
 
+#: src/PartBarLegendUI.cpp
+msgid "This source does not have the part"
+msgstr "这个源没有该部分"
+
+#: src/PartBarLegendUI.cpp
+msgid "You and this source both have the part"
+msgstr "你和这个源都有该部分"
+
+#: src/PartBarLegendUI.cpp
+msgid "Being downloaded from this source now"
+msgstr "正从这个源下载"
+
+#: src/PartBarLegendUI.cpp
+msgid "The next part that will be asked of this source"
+msgstr "下一个要从这个源请求的部分"
+
+#: src/PartBarLegendUI.cpp
+msgid "This source has the part and you still need it"
+msgstr "这个源有该部分，你仍需要它"
+
+#: src/PartBarLegendUI.cpp
+msgid "This peer already has the part"
+msgstr "这个对等方已经有该部分"
+
+#: src/PartBarLegendUI.cpp
+msgid "This peer does not have the part"
+msgstr "这个对等方没有该部分"
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "No source has this part"
+msgstr "这个源没有该部分"
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "One source has this part"
+msgstr "这个源没有该部分"
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy, c-format
+msgid "%u or more sources have this part"
+msgstr "你和这个源都有该部分"
+
+#: src/PartBarLegendUI.cpp
+msgid "Already read back and hashed"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "Still to be read"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "One block per part of the file being downloaded."
+msgstr "正被下载的文件每部分对应一个区块。"
+
+#: src/PartBarLegendUI.cpp
+msgid "One block per part of the shared file."
+msgstr "共享文件每个部分对应一个区块。"
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "One block per part of the shared file, coloured by how many sources have it."
+msgstr "共享文件每个部分对应一个区块。"
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "One block per part of the shared file, showing how far the re-hash has read."
+msgstr "共享文件每个部分对应一个区块。"
+
+#: src/PartBarLegendUI.cpp
+msgid "In between, darkening as sources are added"
+msgstr ""
+
 #: src/PartFileConvert.cpp
 msgid "Waiting for partfile convert thread to die..."
 msgstr "等待partfile转换线程结束..."
@@ -7352,8 +7389,9 @@ msgid "Shares File List"
 msgstr "共享文件列表"
 
 #: src/SharedFilesCtrl.cpp
-msgid "Obtained Parts"
-msgstr "已获取的部分"
+#, fuzzy
+msgid "Source Availability"
+msgstr "可用来源数"
 
 #: src/SharedFilesCtrl.cpp
 msgid "Directory Path"
@@ -9237,6 +9275,9 @@ msgstr "aMule 似乎正在运行。请将其关闭并重新运行卸载程序。
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "正在删除 $APPDATA\\aMule 中的用户数据..."
+
+#~ msgid "Obtained Parts"
+#~ msgstr "已获取的部分"
 
 #~ msgid "Available Parts"
 #~ msgstr "可用分块"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -5568,17 +5568,17 @@ msgstr "这个对等方没有该部分"
 
 #: src/PartBarLegendUI.cpp
 #, fuzzy
-msgid "No source has this part"
+msgid "No other source has this part"
 msgstr "这个源没有该部分"
 
 #: src/PartBarLegendUI.cpp
 #, fuzzy
-msgid "One source has this part"
+msgid "One other source has this part"
 msgstr "这个源没有该部分"
 
 #: src/PartBarLegendUI.cpp
 #, fuzzy, c-format
-msgid "%u or more sources have this part"
+msgid "%u or more other sources have this part"
 msgstr "你和这个源都有该部分"
 
 #: src/PartBarLegendUI.cpp
@@ -5599,7 +5599,7 @@ msgstr "共享文件每个部分对应一个区块。"
 
 #: src/PartBarLegendUI.cpp
 #, fuzzy
-msgid "One block per part of the shared file, coloured by how many sources have it."
+msgid "One block per part of the shared file, coloured by how many other sources have it."
 msgstr "共享文件每个部分对应一个区块。"
 
 #: src/PartBarLegendUI.cpp
@@ -5608,7 +5608,7 @@ msgid "One block per part of the shared file, showing how far the re-hash has re
 msgstr "共享文件每个部分对应一个区块。"
 
 #: src/PartBarLegendUI.cpp
-msgid "In between, darkening as sources are added"
+msgid "In between, darkening as other sources are added"
 msgstr ""
 
 #: src/PartFileConvert.cpp

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -5599,17 +5599,17 @@ msgstr ""
 
 #: src/PartBarLegendUI.cpp
 #, fuzzy
-msgid "No source has this part"
+msgid "No other source has this part"
 msgstr "這個指令不能有參數。"
 
 #: src/PartBarLegendUI.cpp
 #, fuzzy
-msgid "One source has this part"
+msgid "One other source has this part"
 msgstr "這個指令不能有參數。"
 
 #: src/PartBarLegendUI.cpp
 #, fuzzy, c-format
-msgid "%u or more sources have this part"
+msgid "%u or more other sources have this part"
 msgstr "這個指令不能有參數。"
 
 #: src/PartBarLegendUI.cpp
@@ -5631,7 +5631,7 @@ msgstr "輸入伺服器的通訊埠。"
 
 #: src/PartBarLegendUI.cpp
 #, fuzzy
-msgid "One block per part of the shared file, coloured by how many sources have it."
+msgid "One block per part of the shared file, coloured by how many other sources have it."
 msgstr "輸入伺服器的通訊埠。"
 
 #: src/PartBarLegendUI.cpp
@@ -5640,7 +5640,7 @@ msgid "One block per part of the shared file, showing how far the re-hash has re
 msgstr "輸入伺服器的通訊埠。"
 
 #: src/PartBarLegendUI.cpp
-msgid "In between, darkening as sources are added"
+msgid "In between, darkening as other sources are added"
 msgstr ""
 
 #: src/PartFileConvert.cpp

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-02 12:15+0200\n"
+"POT-Creation-Date: 2026-09-04 07:50+0200\n"
 "PO-Revision-Date: 2026-09-03 11:12+0000\n"
 "Last-Translator: Wayne Su <mstarmstar@gmail.com>\n"
 "Language-Team: \n"
@@ -2815,48 +2815,10 @@ msgstr ""
 " 只設定了一個位置。"
 
 #: src/GenericClientListCtrl.cpp
-#, fuzzy
-msgid "This source does not have the part"
-msgstr "這個指令不能有參數。"
-
-#: src/GenericClientListCtrl.cpp
-msgid "You and this source both have the part"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "Being downloaded from this source now"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "The next part that will be asked of this source"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "This source has the part and you still need it"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "This peer already has the part"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "This peer does not have the part"
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-msgid "One block per part of the file being downloaded."
-msgstr ""
-
-#: src/GenericClientListCtrl.cpp
-#, fuzzy
-msgid "One block per part of the shared file."
-msgstr "輸入伺服器的通訊埠。"
-
-#: src/GenericClientListCtrl.cpp
 msgid "Swap to this file"
 msgstr "轉移到這個檔案"
 
-#: src/GenericClientListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Colour legend"
 msgstr ""
 
@@ -5606,6 +5568,81 @@ msgstr "文件"
 msgid "Using config dir: %s"
 msgstr "使用設定目錄：%s"
 
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "This source does not have the part"
+msgstr "這個指令不能有參數。"
+
+#: src/PartBarLegendUI.cpp
+msgid "You and this source both have the part"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "Being downloaded from this source now"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "The next part that will be asked of this source"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "This source has the part and you still need it"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "This peer already has the part"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "This peer does not have the part"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "No source has this part"
+msgstr "這個指令不能有參數。"
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "One source has this part"
+msgstr "這個指令不能有參數。"
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy, c-format
+msgid "%u or more sources have this part"
+msgstr "這個指令不能有參數。"
+
+#: src/PartBarLegendUI.cpp
+msgid "Already read back and hashed"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "Still to be read"
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+msgid "One block per part of the file being downloaded."
+msgstr ""
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "One block per part of the shared file."
+msgstr "輸入伺服器的通訊埠。"
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "One block per part of the shared file, coloured by how many sources have it."
+msgstr "輸入伺服器的通訊埠。"
+
+#: src/PartBarLegendUI.cpp
+#, fuzzy
+msgid "One block per part of the shared file, showing how far the re-hash has read."
+msgstr "輸入伺服器的通訊埠。"
+
+#: src/PartBarLegendUI.cpp
+msgid "In between, darkening as sources are added"
+msgstr ""
+
 #: src/PartFileConvert.cpp
 msgid "Waiting for partfile convert thread to die..."
 msgstr "正在等候暫存檔轉換執行緒終止..."
@@ -7398,8 +7435,9 @@ msgid "Shares File List"
 msgstr "分享檔案清單"
 
 #: src/SharedFilesCtrl.cpp
-msgid "Obtained Parts"
-msgstr "已獲得部分"
+#, fuzzy
+msgid "Source Availability"
+msgstr "最小來源數"
 
 #: src/SharedFilesCtrl.cpp
 msgid "Directory Path"
@@ -9260,6 +9298,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "Obtained Parts"
+#~ msgstr "已獲得部分"
 
 #~ msgid "Available Parts"
 #~ msgstr "可取得的部份"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -972,6 +972,7 @@ if (NEED_LIB_MULEAPPGUI)
 		MuleNotebook.cpp
 		MuleTextCtrl.cpp
 		MuleLogCtrl.cpp
+		PartBarLegendUI.cpp
 	)
 
 

--- a/src/DownloadListCtrl.cpp
+++ b/src/DownloadListCtrl.cpp
@@ -38,6 +38,7 @@
 #include "GuiEvents.h"        // Needed for CoreNotify_*, Notify_DownloadCtrlDoItemSelectionChanged
 #include "Logger.h"
 #include "MuleBarRenderer.h" // Needed for CBarFillSpec, CBarFillSpan, CMuleBarRenderer
+#include "PartBarLegendUI.h" // Needed for partbar::SourceAvailabilityColour, ToMuleColour
 #include "PartFile.h"        // Needed for CPartFile
 #include "Preferences.h"
 #include "SharedFileList.h" // Needed for CSharedFileList
@@ -997,8 +998,15 @@ void CDownloadListCtrl::GetItemBarFill(wxUIntPtr item, unsigned column, CBarFill
 		for (uint64 i = start; i < end; ++i) {
 			CMuleColour colour;
 			if (i < file->m_SrcpartFrequency.size() && file->m_SrcpartFrequency[i]) {
-				const int blue = 210 - (22 * (file->m_SrcpartFrequency[i] - 1));
-				colour.Set(0, static_cast<uint8_t>(blue < 0 ? 0 : blue), 255);
+				// The same fade the shared-files bar draws. This used to be a
+				// linear ramp of its own, saturating one source later, written
+				// into the green channel through a local called "blue" while
+				// the blue channel stayed at 255 -- so the same file read as
+				// differently shared depending on which list you looked at.
+				// The suite greps this file for that ramp, which is why it is
+				// described here rather than quoted.
+				colour = ToMuleColour(
+					partbar::SourceAvailabilityColour(file->m_SrcpartFrequency[i]));
 			} else {
 				colour = crMissing;
 			}

--- a/src/GenericClientListCtrl.cpp
+++ b/src/GenericClientListCtrl.cpp
@@ -40,7 +40,6 @@
 #include "DataToText.h"           // Needed for PriorityToStr
 #include "FileDetailDialog.h"     // Needed for CFileDetailDialog
 #include "GuiEvents.h"            // Needed for CoreNotify_*
-#include "InfoGridDialog.h"       // Needed for ShowInfoGridDialog
 #ifdef GEOIP_GUI
 #include "CountryFlags.h"   // Needed for CCountryFlags (flag bitmaps)
 #include "CountryDisplay.h" // Needed for GetDisplayCountryCode
@@ -48,6 +47,7 @@
 #include "MuleBarRenderer.h" // Needed for CBarFillSpec, CBarFillSpan, CMuleBarRenderer
 #include "MuleColour.h"      // Needed for IsListBackgroundDark
 #include "muuli_wdr.h"       // Needed for ID_CLIENTCOUNT
+#include "PartBarLegendUI.h" // Needed for ShowPartBarLegend, ToMuleColour
 #include "PartFile.h"        // Needed for CPartFile
 #include "Preferences.h"
 #include "SharedFileList.h" // Needed for CSharedFileList
@@ -62,12 +62,6 @@
 #include "updownclient.h"
 #endif
 #include "FriendList.h"
-
-#include <wx/dcmemory.h> // Needed for wxMemoryDC (legend swatches)
-#include <wx/dialog.h>   // Needed for wxDialog (legend)
-#include <wx/sizer.h>    // Needed for wxBoxSizer, wxFlexGridSizer
-#include <wx/statbmp.h>  // Needed for wxStaticBitmap
-#include <wx/stattext.h> // Needed for wxStaticText
 
 namespace
 {
@@ -103,57 +97,6 @@ public:
 		return true;
 	}
 };
-
-/**
- * A 16x16 swatch of one bar colour, drawn the way CCatDialog::MakeBitmap()
- * draws the category colour: a wxMemoryDC over a wxBitmap, default pen, so the
- * fill keeps a border and the two pale greys stay visible on a light dialog.
- */
-wxBitmap MakeLegendSwatch(const partbar::BarColour &colour)
-{
-	wxBitmap bitmap(16, 16);
-	wxMemoryDC dc(bitmap);
-
-	dc.SetBrush(CMuleColour(colour.red, colour.green, colour.blue).GetBrush());
-	dc.DrawRectangle(0, 0, 16, 16);
-
-	return bitmap;
-}
-
-wxString SourcePartStateLabel(partbar::SourcePartState state)
-{
-	switch (state) {
-	case partbar::SourcePartState::Missing:
-		return _("This source does not have the part");
-	case partbar::SourcePartState::Complete:
-		return _("You and this source both have the part");
-	case partbar::SourcePartState::Downloading:
-		return _("Being downloaded from this source now");
-	case partbar::SourcePartState::NextRequested:
-		return _("The next part that will be asked of this source");
-	case partbar::SourcePartState::Needed:
-		return _("This source has the part and you still need it");
-	}
-	return wxEmptyString;
-}
-
-wxString PeerPartStateLabel(partbar::PeerPartState state)
-{
-	switch (state) {
-	case partbar::PeerPartState::Present:
-		return _("This peer already has the part");
-	case partbar::PeerPartState::Missing:
-		return _("This peer does not have the part");
-	}
-	return wxEmptyString;
-}
-
-//! One swatch-and-text row of a legend.
-void AddLegendRow(wxWindow *parent, wxSizer *grid, const partbar::BarColour &colour, const wxString &label)
-{
-	grid->Add(new wxStaticBitmap(parent, wxID_ANY, MakeLegendSwatch(colour)), 0, wxALIGN_CENTRE_VERTICAL);
-	grid->Add(new wxStaticText(parent, wxID_ANY, label), 0, wxALIGN_CENTRE_VERTICAL);
-}
 } // namespace
 
 #define m_ImageList theApp->amuledlg->m_imagelist
@@ -708,33 +651,10 @@ int CGenericClientListCtrl::FindBarLegendColumn() const
 
 void CGenericClientListCtrl::ShowBarLegend(partbar::BarLegendKind kind, const wxString &columnTitle)
 {
-	// Both legends read their colours from the functions GetItemBarFill()
-	// fills the bar from, under the bar preference in force right now: a
-	// swatch cannot disagree with the pixels it explains.
-	const bool bFlat = thePrefs::UseFlatBar();
-	const bool sourceKind = (kind == partbar::BarLegendKind::SourceParts);
-
-	ShowInfoGridDialog(this,
-		columnTitle,
-		sourceKind ? _("One block per part of the file being downloaded.")
-			   : _("One block per part of the shared file."),
-		[bFlat, sourceKind](wxWindow *dlg, wxSizer *grid) {
-			if (sourceKind) {
-				for (const partbar::SourcePartState state : partbar::kSourceLegendOrder) {
-					AddLegendRow(dlg,
-						grid,
-						partbar::SourcePartColour(state, bFlat),
-						SourcePartStateLabel(state));
-				}
-			} else {
-				for (const partbar::PeerPartState state : partbar::kPeerLegendOrder) {
-					AddLegendRow(dlg,
-						grid,
-						partbar::PeerPartColour(state, bFlat),
-						PeerPartStateLabel(state));
-				}
-			}
-		});
+	// The dialog and its swatches live in PartBarLegendUI: since #1220 the
+	// shared-files list opens legends of its own, and two copies of a swatch
+	// are two things to keep in step with the palette.
+	ShowPartBarLegend(this, kind, columnTitle);
 }
 
 void CGenericClientListCtrl::OnShowBarLegend(wxCommandEvent &WXUNUSED(event))
@@ -971,16 +891,6 @@ bool CGenericClientListCtrl::GetItemAttr(wxUIntPtr data, unsigned column, wxData
 		return false;
 	}
 }
-
-namespace
-{
-//! The bar palette lives in PartBarLegend.h, where the legend reads the same
-//! values -- see the header comment for why they cannot be kept in two places.
-inline CMuleColour ToMuleColour(const partbar::BarColour &colour)
-{
-	return CMuleColour(colour.red, colour.green, colour.blue);
-}
-} // namespace
 
 void CGenericClientListCtrl::GetItemBarFill(wxUIntPtr data, unsigned column, CBarFillSpec &out) const
 {

--- a/src/PartBarLegend.h
+++ b/src/PartBarLegend.h
@@ -25,8 +25,9 @@
 #ifndef PARTBARLEGEND_H
 #define PARTBARLEGEND_H
 
-// The palette of the two chunk-bar columns of the client lists, and the legend
-// the row context menu opens to explain it.
+// The palette of the chunk-bar columns -- the two in the client lists and the
+// source-availability one in the shared-files list -- and the legends the row
+// context menu opens to explain them.
 //
 // The point of this header is that there is exactly one copy of each colour.
 // A legend that restated the palette -- in words, or in swatches filled from a
@@ -36,16 +37,26 @@
 // SourcePartColour()/PeerPartColour(), so a colour can only change for both at
 // once.
 //
-// It pulls in nothing but <cstddef>/<cstdint> and ClientListColumns.h, so the
-// part of the feature worth checking -- which states a legend lists, in which
-// order, in which colour, and which legend a column gets -- is reachable from
-// a unit test with no wx, no app and no display session. Same rationale as
-// webapi/PartIndex.h. What is left needing a display is the drawing itself.
+// "One copy of each colour" is a rule about definitions, not about values. Two
+// constants may hold the same RGB when they mean different things and never
+// appear in the same legend -- kNextPending and kFlatHashPending do -- and
+// collapsing them would tie a shared-files bar to a client-list cue for no
+// reason. So the no-two-rows-alike invariant is scoped PER LEGEND: within one
+// legend a repeated colour is a distinction the reader cannot see, which is a
+// real defect; across two legends it is a coincidence.
+//
+// It pulls in nothing but <cstddef>/<cstdint>, ClientListColumns.h and
+// PartBarSpans.h -- itself wx-free -- so the part of the feature worth checking
+// -- which states a legend lists, in which order, in which colour, and which
+// legend a column gets -- is reachable from a unit test with no wx, no app and
+// no display session. Same rationale as webapi/PartIndex.h. What is left
+// needing a display is the drawing itself.
 
 #include <cstddef>
 #include <cstdint>
 
 #include "ClientListColumns.h" // Needed for GenericColumnEnum
+#include "PartBarSpans.h"      // Needed for BarMode
 
 namespace partbar
 {
@@ -92,6 +103,77 @@ constexpr BarColour kFlatUnavailable{ 224, 224, 224 };
 constexpr BarColour kAvailable{ 104, 104, 104 };
 constexpr BarColour kFlatAvailable{ 0, 0, 0 };
 
+// The part of a shared file not yet re-hashed, drawn flat. Byte-identical to
+// kNextPending and deliberately a separate constant: one is a request cue in a
+// client list, the other is unread bytes of a local file, and the only thing
+// they have in common is the shade someone picked. Merging them would mean a
+// change to either bar silently moved the other.
+constexpr BarColour kFlatHashPending{ 255, 255, 100 };
+
+// The shared-files availability bar. A part no source holds is its own state,
+// not the dark end of the fade, so it keeps its own constant.
+constexpr BarColour kZeroSources{ 255, 0, 0 };
+
+//! Source count at which the fade reaches its dark end. Adding an eleventh
+//! source darkens nothing. This is AVAIL_FULL in
+//! src/webapi/static/js/components.js, and the two surfaces have to agree on it
+//! or the same file looks differently shared in the GUI and in a browser.
+constexpr unsigned kAvailFull = 10;
+
+//! The endpoints of the fade: one source, and kAvailFull or more. Taken from
+//! the Web UI's --piece-avail-lo / --piece-avail (src/webapi/static/css/
+//! app.css:29-30), which is the pair that survives; the GUI's former
+//! (0,210,255) -> (0,0,255) does not.
+constexpr BarColour kAvailFew{ 166, 212, 238 };
+constexpr BarColour kAvailMany{ 47, 143, 208 };
+
+//! Steps between the two endpoints, so kAvailFull is stated once.
+constexpr int kAvailFadeSteps = static_cast<int>(kAvailFull) - 1;
+
+/**
+ * One channel of the blend, @p k steps of kAvailFadeSteps from @p lo to @p hi.
+ *
+ * round(lo + (hi - lo) * k / 9) without floating point: doubling numerator and
+ * denominator and adding half the denominator turns C++ truncating division
+ * into rounding. The numerator's minimum is hi * 9, which is positive, so the
+ * truncation is a floor and the identity holds.
+ *
+ * Nothing here can land on a half. lo * 9 + (hi - lo) * k over a denominator of
+ * 9 has a fractional part in ninths, and 1/2 is not one of them, so the
+ * rounding mode never matters -- Math.round in components.js:404-407,
+ * std::lround and banker's rounding all produce these same numbers. That is why
+ * the browser and the GUI agree by construction rather than by convention.
+ */
+constexpr std::uint8_t AvailabilityFadeChannel(int lo, int hi, int k)
+{
+	return static_cast<std::uint8_t>(
+		(2 * (lo * kAvailFadeSteps + (hi - lo) * k) + kAvailFadeSteps) / (2 * kAvailFadeSteps));
+}
+
+//! How far along the fade @p sources sits, saturating at kAvailFull.
+constexpr int AvailabilityFadeStep(unsigned sources)
+{
+	return sources >= kAvailFull ? kAvailFadeSteps : static_cast<int>(sources) - 1;
+}
+
+/**
+ * Bar colour for a part @p sources peers hold, for @p sources >= 1.
+ *
+ * Takes the source count and nothing else. That arity is deliberate: it is what
+ * stops the shared-files list and the downloads list from drifting apart again,
+ * because neither can pass its own endpoints without adding a parameter, and a
+ * changed signature is something a reviewer sees.
+ *
+ * @p sources == 0 is not on this fade at all -- see kZeroSources.
+ */
+constexpr BarColour SourceAvailabilityColour(unsigned sources)
+{
+	return BarColour{ AvailabilityFadeChannel(
+				  kAvailFew.red, kAvailMany.red, AvailabilityFadeStep(sources)),
+		AvailabilityFadeChannel(kAvailFew.green, kAvailMany.green, AvailabilityFadeStep(sources)),
+		AvailabilityFadeChannel(kAvailFew.blue, kAvailMany.blue, AvailabilityFadeStep(sources)) };
+}
+
 /**
  * The five fills the Sources bar (ColumnUserProgress) distinguishes, in the
  * order GetItemBarFill() tests them -- which is also the order the legend
@@ -136,12 +218,62 @@ constexpr BarColour PeerPartColour(PeerPartState state, bool flat)
 					       : (flat ? kFlatUnavailable : kUnavailable);
 }
 
+/**
+ * What the source-availability bar can say about one part, as its legend lists
+ * it. The two blue rows are the ends of a continuum rather than two discrete
+ * fills, so the legend explains a gradient by naming where it starts and where
+ * it stops; the red is not on that gradient at all.
+ */
+enum class AvailabilityPartState
+{
+	ZeroSources = 0, //!< no source holds this part
+	FewSources,      //!< one source: the light end of the fade
+	ManySources      //!< kAvailFull or more: the dark end
+};
+
+/**
+ * What the same cell says while a re-hash is running. Unrelated to the above:
+ * availability is a fact about the swarm, this is progress through local data
+ * that happens to occupy the same column.
+ */
+enum class HashingPartState
+{
+	Hashed = 0,  //!< already read back and hashed
+	NotYetHashed //!< still to be read
+};
+
+/**
+ * Colour the source-availability bar fills a part with.
+ *
+ * @p flat is accepted and ignored, on purpose. The renderer took the flat-bar
+ * preference and never consulted it for this bar, so inventing a second set of
+ * values here would have the legend explaining a distinction the bar does not
+ * draw. The parameter stays for the shape it shares with its siblings, and the
+ * suite asserts both arguments give the same colour.
+ */
+constexpr BarColour AvailabilityPartColour(AvailabilityPartState state, bool)
+{
+	return state == AvailabilityPartState::ZeroSources  ? kZeroSources
+	       : state == AvailabilityPartState::FewSources ? SourceAvailabilityColour(1)
+							    : SourceAvailabilityColour(kAvailFull);
+}
+
+//! Colour the hashing bar fills a part with. Hashed reuses the palette's green
+//! rather than the private one the shared-files bar used to carry.
+constexpr BarColour HashingPartColour(HashingPartState state, bool flat)
+{
+	return state == HashingPartState::Hashed ? (flat ? kFlatBoth : kBoth)
+						 : (flat ? kFlatHashPending : kPending);
+}
+
 //! Which legend, if any, explains a column's cells.
 enum class BarLegendKind
 {
-	None = 0,    //!< the column draws no chunk bar
-	SourceParts, //!< ColumnUserProgress, five states
-	PeerParts    //!< ColumnUserAvailable, two states
+	None = 0,           //!< the column draws no chunk bar
+	SourceParts,        //!< ColumnUserProgress, five states
+	PeerParts,          //!< ColumnUserAvailable, two states
+	SharedAvailability, //!< the shared-files bar, source counts
+	SharedHashing       //!< the same cell, re-hash progress
 };
 
 //! The legend a column's colours are explained by. BarLegendKind::None means
@@ -152,6 +284,43 @@ constexpr BarLegendKind LegendForColumn(GenericColumnEnum cid)
 	return cid == ColumnUserProgress    ? BarLegendKind::SourceParts
 	       : cid == ColumnUserAvailable ? BarLegendKind::PeerParts
 					    : BarLegendKind::None;
+}
+
+/**
+ * The shared-files list's bar column, as a type of its own.
+ *
+ * That list identifies its columns with plain #defines
+ * (src/SharedFilesCtrl.h:31-46) whose numbers overlap GenericColumnEnum's:
+ * COLUMN_SHARED_PART is 8, which is also ColumnUserQueueRankLocal. Passing one
+ * where the other is wanted therefore compiled, silently, and returned a legend
+ * for the wrong thing. A distinct scoped enum has no conversion to the other, so
+ * that call is now a compile error -- and none of the existing call sites had to
+ * change, because this is an overload rather than a replacement.
+ *
+ * A deliberate static_cast still gets through; types cannot stop that, and the
+ * suite pins what it produces instead.
+ */
+enum class SharedFilesBarColumn
+{
+	SourceAvailability //!< COLUMN_SHARED_PART, the only bar column in that list
+};
+
+/**
+ * The legend explaining the shared-files bar, given what that row's bar is
+ * drawing.
+ *
+ * One column, two legends. The cell shows source availability most of the time
+ * and re-hash progress while a hash runs, and neither explains the other, so
+ * the mode has to reach the selector. It arrives as a value -- ModeFor() in
+ * PartBarSpans.h turns two integers into it -- which keeps this header free of
+ * row state and the whole thing constexpr.
+ */
+constexpr BarLegendKind LegendForColumn(SharedFilesBarColumn column, BarMode mode)
+{
+	return column != SharedFilesBarColumn::SourceAvailability ? BarLegendKind::None
+	       : mode == BarMode::Availability                    ? BarLegendKind::SharedAvailability
+	       : mode == BarMode::Hashing                         ? BarLegendKind::SharedHashing
+								  : BarLegendKind::None;
 }
 
 //! Rows of the Sources legend, top to bottom.
@@ -167,6 +336,21 @@ constexpr std::size_t kSourceLegendSize = sizeof(kSourceLegendOrder) / sizeof(kS
 constexpr PeerPartState kPeerLegendOrder[] = { PeerPartState::Present, PeerPartState::Missing };
 
 constexpr std::size_t kPeerLegendSize = sizeof(kPeerLegendOrder) / sizeof(kPeerLegendOrder[0]);
+
+//! Rows of the source-availability legend, top to bottom: the distinct state
+//! first, then the fade from its light end to its dark one.
+constexpr AvailabilityPartState kAvailabilityLegendOrder[] = { AvailabilityPartState::ZeroSources,
+	AvailabilityPartState::FewSources,
+	AvailabilityPartState::ManySources };
+
+constexpr std::size_t kAvailabilityLegendSize =
+	sizeof(kAvailabilityLegendOrder) / sizeof(kAvailabilityLegendOrder[0]);
+
+//! Rows of the hashing legend, top to bottom.
+constexpr HashingPartState kHashingLegendOrder[] = { HashingPartState::Hashed,
+	HashingPartState::NotYetHashed };
+
+constexpr std::size_t kHashingLegendSize = sizeof(kHashingLegendOrder) / sizeof(kHashingLegendOrder[0]);
 
 } // namespace partbar
 

--- a/src/PartBarLegend.h
+++ b/src/PartBarLegend.h
@@ -323,6 +323,20 @@ constexpr BarLegendKind LegendForColumn(SharedFilesBarColumn column, BarMode mod
 								  : BarLegendKind::None;
 }
 
+/**
+ * The legend for a shared-files row, straight from the two integers the file
+ * reports.
+ *
+ * The row context menu has exactly this decision to make and nothing else:
+ * which of the one column's two legends the clicked file wants, or none at all.
+ * Composed here rather than at the call site because the composition is the
+ * part a headless run can check -- opening the dialog is not.
+ */
+constexpr BarLegendKind LegendForSharedFilesRow(std::uint64_t hashedPartCount, std::size_t partCount)
+{
+	return LegendForColumn(SharedFilesBarColumn::SourceAvailability, ModeFor(hashedPartCount, partCount));
+}
+
 //! Rows of the Sources legend, top to bottom.
 constexpr SourcePartState kSourceLegendOrder[] = { SourcePartState::Missing,
 	SourcePartState::Complete,

--- a/src/PartBarLegendUI.cpp
+++ b/src/PartBarLegendUI.cpp
@@ -1,0 +1,229 @@
+//
+// This file is part of the aMule Project.
+//
+// Copyright (c) 2003-2026 aMule Team ( https://amule-org.github.io )
+//
+// Any parts of this program derived from the xMule, lMule or eMule project,
+// or contributed by third-party developers are copyrighted by their
+// respective authors.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301, USA
+//
+
+#include "PartBarLegendUI.h" // Interface declarations
+
+#include <wx/dcmemory.h> // Needed for wxMemoryDC (legend swatches)
+#include <wx/intl.h>     // Needed for _()
+#include <wx/sizer.h>    // Needed for wxSizer
+#include <wx/statbmp.h>  // Needed for wxStaticBitmap
+#include <wx/stattext.h> // Needed for wxStaticText
+#include <wx/window.h>   // Needed for wxWindow
+
+#include "InfoGridDialog.h" // Needed for ShowInfoGridDialog
+#include "Preferences.h"    // Needed for thePrefs::UseFlatBar
+
+namespace
+{
+
+//! Swatch size in both directions. One constant, so the gradient covers exactly
+//! the area a flat swatch fills and the rows line up.
+constexpr int kSwatchSide = 16;
+
+//! The two cells of one legend row, once, whatever the swatch was drawn by.
+void AddSwatchRow(wxWindow *parent, wxSizer *grid, const wxBitmap &swatch, const wxString &label)
+{
+	grid->Add(new wxStaticBitmap(parent, wxID_ANY, swatch), 0, wxALIGN_CENTRE_VERTICAL);
+	grid->Add(new wxStaticText(parent, wxID_ANY, label), 0, wxALIGN_CENTRE_VERTICAL);
+}
+
+wxString SourcePartStateLabel(partbar::SourcePartState state)
+{
+	switch (state) {
+	case partbar::SourcePartState::Missing:
+		return _("This source does not have the part");
+	case partbar::SourcePartState::Complete:
+		return _("You and this source both have the part");
+	case partbar::SourcePartState::Downloading:
+		return _("Being downloaded from this source now");
+	case partbar::SourcePartState::NextRequested:
+		return _("The next part that will be asked of this source");
+	case partbar::SourcePartState::Needed:
+		return _("This source has the part and you still need it");
+	}
+	return wxEmptyString;
+}
+
+wxString PeerPartStateLabel(partbar::PeerPartState state)
+{
+	switch (state) {
+	case partbar::PeerPartState::Present:
+		return _("This peer already has the part");
+	case partbar::PeerPartState::Missing:
+		return _("This peer does not have the part");
+	}
+	return wxEmptyString;
+}
+
+wxString AvailabilityPartStateLabel(partbar::AvailabilityPartState state)
+{
+	switch (state) {
+	case partbar::AvailabilityPartState::ZeroSources:
+		return _("No source has this part");
+	case partbar::AvailabilityPartState::FewSources:
+		return _("One source has this part");
+	case partbar::AvailabilityPartState::ManySources:
+		// Formatted from kAvailFull rather than spelled out: the number is
+		// where the fade stops darkening, and a label naming a different
+		// one would be wrong in a way no reader could tell from the bar.
+		return wxString::Format(_("%u or more sources have this part"), partbar::kAvailFull);
+	}
+	return wxEmptyString;
+}
+
+wxString HashingPartStateLabel(partbar::HashingPartState state)
+{
+	switch (state) {
+	case partbar::HashingPartState::Hashed:
+		return _("Already read back and hashed");
+	case partbar::HashingPartState::NotYetHashed:
+		return _("Still to be read");
+	}
+	return wxEmptyString;
+}
+
+//! The line above the grid, saying what one block of the bar stands for.
+wxString LegendIntro(partbar::BarLegendKind kind)
+{
+	switch (kind) {
+	case partbar::BarLegendKind::SourceParts:
+		return _("One block per part of the file being downloaded.");
+	case partbar::BarLegendKind::PeerParts:
+		return _("One block per part of the shared file.");
+	case partbar::BarLegendKind::SharedAvailability:
+		return _("One block per part of the shared file, coloured by how many sources have it.");
+	case partbar::BarLegendKind::SharedHashing:
+		return _("One block per part of the shared file, showing how far the re-hash has read.");
+	case partbar::BarLegendKind::None:
+		break;
+	}
+	return wxEmptyString;
+}
+
+//! Fills the grid of the legend @a kind explains, under bar preference @a flat.
+void FillLegendGrid(wxWindow *dlg, wxSizer *grid, partbar::BarLegendKind kind, bool flat)
+{
+	switch (kind) {
+	case partbar::BarLegendKind::SourceParts:
+		for (const partbar::SourcePartState state : partbar::kSourceLegendOrder) {
+			AddLegendRow(dlg,
+				grid,
+				partbar::SourcePartColour(state, flat),
+				SourcePartStateLabel(state));
+		}
+		return;
+
+	case partbar::BarLegendKind::PeerParts:
+		for (const partbar::PeerPartState state : partbar::kPeerLegendOrder) {
+			AddLegendRow(
+				dlg, grid, partbar::PeerPartColour(state, flat), PeerPartStateLabel(state));
+		}
+		return;
+
+	case partbar::BarLegendKind::SharedAvailability: {
+		for (const partbar::AvailabilityPartState state : partbar::kAvailabilityLegendOrder) {
+			AddLegendRow(dlg,
+				grid,
+				partbar::AvailabilityPartColour(state, flat),
+				AvailabilityPartStateLabel(state));
+		}
+		// The two blue rows above are the ends of a continuum, not two
+		// fills the bar picks between, so one more row shows the ramp
+		// itself. Its endpoints are those same two rows -- read from the
+		// legend order rather than from the fade, so the swatch cannot
+		// illustrate a range the rows above it do not name.
+		const partbar::BarColour from =
+			partbar::AvailabilityPartColour(partbar::AvailabilityPartState::FewSources, flat);
+		const partbar::BarColour to =
+			partbar::AvailabilityPartColour(partbar::AvailabilityPartState::ManySources, flat);
+		AddSwatchRow(dlg,
+			grid,
+			MakeGradientLegendSwatch(from, to),
+			_("In between, darkening as sources are added"));
+		return;
+	}
+
+	case partbar::BarLegendKind::SharedHashing:
+		for (const partbar::HashingPartState state : partbar::kHashingLegendOrder) {
+			AddLegendRow(dlg,
+				grid,
+				partbar::HashingPartColour(state, flat),
+				HashingPartStateLabel(state));
+		}
+		return;
+
+	case partbar::BarLegendKind::None:
+		return;
+	}
+}
+
+} // namespace
+
+wxBitmap MakeLegendSwatch(const partbar::BarColour &colour)
+{
+	wxBitmap bitmap(kSwatchSide, kSwatchSide);
+	wxMemoryDC dc(bitmap);
+
+	dc.SetBrush(ToMuleColour(colour).GetBrush());
+	dc.DrawRectangle(0, 0, kSwatchSide, kSwatchSide);
+
+	return bitmap;
+}
+
+wxBitmap MakeGradientLegendSwatch(const partbar::BarColour &from, const partbar::BarColour &to)
+{
+	wxBitmap bitmap(kSwatchSide, kSwatchSide);
+	wxMemoryDC dc(bitmap);
+
+	// wxEAST: left to right, matching the bar, which fills a file from its
+	// first part on the left. No pen is set, so unlike the flat swatches this
+	// one has no border -- a border would read as a fill of its own next to
+	// the pale left end.
+	dc.GradientFillLinear(
+		wxRect(0, 0, kSwatchSide, kSwatchSide), ToMuleColour(from), ToMuleColour(to), wxEAST);
+
+	return bitmap;
+}
+
+void AddLegendRow(wxWindow *parent, wxSizer *grid, const partbar::BarColour &colour, const wxString &label)
+{
+	AddSwatchRow(parent, grid, MakeLegendSwatch(colour), label);
+}
+
+void ShowPartBarLegend(wxWindow *parent, partbar::BarLegendKind kind, const wxString &columnTitle)
+{
+	if (kind == partbar::BarLegendKind::None) {
+		return;
+	}
+
+	// Read once and captured, not asked again inside the lambda: every swatch
+	// in one dialog has to answer the same preference, and the grid is filled
+	// while a nested event loop is not yet running anyway.
+	const bool flat = thePrefs::UseFlatBar();
+
+	ShowInfoGridDialog(
+		parent, columnTitle, LegendIntro(kind), [kind, flat](wxWindow *dlg, wxSizer *grid) {
+			FillLegendGrid(dlg, grid, kind, flat);
+		});
+}

--- a/src/PartBarLegendUI.cpp
+++ b/src/PartBarLegendUI.cpp
@@ -76,18 +76,23 @@ wxString PeerPartStateLabel(partbar::PeerPartState state)
 	return wxEmptyString;
 }
 
+// "other" is load-bearing. CKnownFile::UpdateAvailablePartsCount() fills
+// m_AvailPartFrequency from the GetUpPartStatus() of remote clients only; our own
+// copy is never counted. On the shared-files list we hold every part by
+// definition, so a red block does not mean the part is gone -- it means no peer
+// we know of has it too.
 wxString AvailabilityPartStateLabel(partbar::AvailabilityPartState state)
 {
 	switch (state) {
 	case partbar::AvailabilityPartState::ZeroSources:
-		return _("No source has this part");
+		return _("No other source has this part");
 	case partbar::AvailabilityPartState::FewSources:
-		return _("One source has this part");
+		return _("One other source has this part");
 	case partbar::AvailabilityPartState::ManySources:
 		// Formatted from kAvailFull rather than spelled out: the number is
 		// where the fade stops darkening, and a label naming a different
 		// one would be wrong in a way no reader could tell from the bar.
-		return wxString::Format(_("%u or more sources have this part"), partbar::kAvailFull);
+		return wxString::Format(_("%u or more other sources have this part"), partbar::kAvailFull);
 	}
 	return wxEmptyString;
 }
@@ -112,7 +117,8 @@ wxString LegendIntro(partbar::BarLegendKind kind)
 	case partbar::BarLegendKind::PeerParts:
 		return _("One block per part of the shared file.");
 	case partbar::BarLegendKind::SharedAvailability:
-		return _("One block per part of the shared file, coloured by how many sources have it.");
+		return _(
+			"One block per part of the shared file, coloured by how many other sources have it.");
 	case partbar::BarLegendKind::SharedHashing:
 		return _("One block per part of the shared file, showing how far the re-hash has read.");
 	case partbar::BarLegendKind::None:
@@ -160,7 +166,7 @@ void FillLegendGrid(wxWindow *dlg, wxSizer *grid, partbar::BarLegendKind kind, b
 		AddSwatchRow(dlg,
 			grid,
 			MakeGradientLegendSwatch(from, to),
-			_("In between, darkening as sources are added"));
+			_("In between, darkening as other sources are added"));
 		return;
 	}
 

--- a/src/PartBarLegendUI.h
+++ b/src/PartBarLegendUI.h
@@ -1,0 +1,95 @@
+//
+// This file is part of the aMule Project.
+//
+// Copyright (c) 2003-2026 aMule Team ( https://amule-org.github.io )
+//
+// Any parts of this program derived from the xMule, lMule or eMule project,
+// or contributed by third-party developers are copyrighted by their
+// respective authors.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301, USA
+//
+
+#ifndef PARTBARLEGENDUI_H
+#define PARTBARLEGENDUI_H
+
+// The wx side of the chunk-bar legends: the dialog the row context menus open,
+// and the one conversion from the palette's plain components to CMuleColour.
+//
+// Separate from PartBarLegend.h on purpose. That header states which legend a
+// column gets, which rows it lists, in which order and in which colour, and it
+// states all of it without wx so a headless run can check it. This file draws
+// what that one decided, and drawing is the part no test in this tree can look
+// at. Keeping the two apart is what stops the unverifiable half from dragging
+// the verifiable half out of reach.
+//
+// It lives here rather than in GenericClientListCtrl.cpp -- where it was, in an
+// anonymous namespace -- because since #1220 the shared-files list opens legends
+// too, and a second copy of a swatch is a second thing to keep in step with the
+// palette.
+
+#include <wx/bitmap.h>
+#include <wx/string.h>
+
+#include "MuleColour.h"    // Needed for CMuleColour
+#include "PartBarLegend.h" // Needed for partbar::BarColour, partbar::BarLegendKind
+
+class wxSizer;
+class wxWindow;
+
+//! The palette's components as the drawing code wants them. One conversion, so
+//! a bar and the swatch explaining it cannot pick different ones.
+inline CMuleColour ToMuleColour(const partbar::BarColour &colour)
+{
+	return CMuleColour(colour.red, colour.green, colour.blue);
+}
+
+/**
+ * A 16x16 swatch of one bar colour, drawn the way CCatDialog::MakeBitmap()
+ * draws the category colour: a wxMemoryDC over a wxBitmap, default pen, so the
+ * fill keeps a border and the two pale greys stay visible on a light dialog.
+ */
+wxBitmap MakeLegendSwatch(const partbar::BarColour &colour);
+
+/**
+ * The same swatch, faded from @a from on the left to @a to on the right.
+ *
+ * Both endpoints are arguments and neither is known here: the availability
+ * legend passes the very colours its own FewSources and ManySources rows show,
+ * which are the fade's ends as PartBarLegend.h defines them and its suite pins
+ * them. So there is nothing left in this function to get wrong except the
+ * gradient itself, which is one toolkit call and cannot be checked without a
+ * display.
+ */
+wxBitmap MakeGradientLegendSwatch(const partbar::BarColour &from, const partbar::BarColour &to);
+
+//! One swatch-and-text row of a legend.
+void AddLegendRow(wxWindow *parent, wxSizer *grid, const partbar::BarColour &colour, const wxString &label);
+
+/**
+ * Pops up the legend of @a kind, titled with @a columnTitle.
+ *
+ * Swatches are filled from partbar::SourcePartColour(), PeerPartColour(),
+ * AvailabilityPartColour() and HashingPartColour() -- the same functions the
+ * GetItemBarFill() implementations fill the bars themselves from, under the bar
+ * preference in force right now, so a swatch cannot disagree with the pixels it
+ * explains.
+ *
+ * BarLegendKind::None shows nothing: a caller that could not work out what its
+ * cell was drawing has nothing to explain.
+ */
+void ShowPartBarLegend(wxWindow *parent, partbar::BarLegendKind kind, const wxString &columnTitle);
+
+#endif // PARTBARLEGENDUI_H

--- a/src/PartBarSpans.h
+++ b/src/PartBarSpans.h
@@ -1,0 +1,124 @@
+//
+// This file is part of the aMule Project.
+//
+// Copyright (c) 2003-2026 aMule Team ( https://amule-org.github.io )
+//
+// Any parts of this program derived from the xMule, lMule or eMule project,
+// or contributed by third-party developers are copyrighted by their
+// respective authors.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301, USA
+//
+
+#ifndef PARTBARSPANS_H
+#define PARTBARSPANS_H
+
+// Which byte range each part of a file occupies in a chunk bar, and which of the
+// two things the shared-files bar is drawing.
+//
+// Extracted because the arithmetic was wrong and nothing could see it. The three
+// bar columns computed their own spans, and CSharedFilesCtrl computed them
+// differently from the other two -- an end one byte past where CBarShader wants
+// it (src/BarShader.cpp:113-124 treats end as inclusive and increments it
+// itself). Invisible at MiB scale and unassertable while it lived inside a
+// method that needs a CKnownFile and a wxDC.
+//
+// Header-only, wx-free and constexpr on purpose, like PartBarLegend.h: the
+// geometry and the mode choice are decided from two integers, so a headless run
+// can check them.
+
+#include <cstddef>
+#include <cstdint>
+
+namespace partbar
+{
+
+//! One part's byte range, both ends inclusive, as CBarShader::FillRange reads
+//! them.
+struct Span
+{
+	std::uint64_t start = 0;
+	std::uint64_t end = 0;
+};
+
+constexpr bool operator==(const Span &a, const Span &b)
+{
+	return a.start == b.start && a.end == b.end;
+}
+
+constexpr bool operator!=(const Span &a, const Span &b)
+{
+	return !(a == b);
+}
+
+//! What the shared-files bar is drawing for one row. The two are unrelated: one
+//! is availability across the swarm, the other is local re-hash progress that
+//! happens to occupy the same cell.
+enum class BarMode
+{
+	None = 0,     //!< nothing to draw; the file reports no parts
+	Availability, //!< source count per part
+	Hashing       //!< re-hash progress over local data
+};
+
+/**
+ * The byte range of part @p index.
+ *
+ * @param index     zero-based part index, expected < partCount.
+ * @param partSize  bytes per part (PARTSIZE at every call site).
+ * @param fileSize  total bytes; the last part is short whenever the file does
+ *                  not divide evenly, and its end is clamped to the last byte
+ *                  rather than running past it.
+ *
+ * Ends are inclusive and adjacent spans do not overlap, so span(i).end is
+ * exactly span(i+1).start - 1. That property is what the old arithmetic broke.
+ */
+constexpr Span SpanFor(std::size_t index, std::uint64_t partSize, std::uint64_t fileSize)
+{
+	const std::uint64_t start = partSize * static_cast<std::uint64_t>(index);
+	const std::uint64_t past = start + partSize;
+	return Span{ start, (past < fileSize ? past : fileSize) - 1 };
+}
+
+/**
+ * Which mode the bar is in.
+ *
+ * A file reporting no parts draws nothing at all, whatever progress says: the
+ * caller has no span to fill, and a hashing bar over zero parts would be a bar
+ * over nothing. Progress above zero otherwise means a re-hash is running.
+ */
+constexpr BarMode ModeFor(std::uint64_t hashedPartCount, std::size_t partCount)
+{
+	return partCount == 0 ? BarMode::None
+			      : (hashedPartCount > 0 ? BarMode::Hashing : BarMode::Availability);
+}
+
+/**
+ * How many parts of @p partCount are already hashed, clamped.
+ *
+ * CHashingTask reports part + 1 (src/ThreadTasks.cpp:179, :693), so a completed
+ * pass reports one past the last part and the raw number cannot be used as an
+ * index or a span count.
+ */
+constexpr std::size_t HashedPartsClamped(std::uint64_t hashedPartCount, std::size_t partCount)
+{
+	return hashedPartCount > static_cast<std::uint64_t>(partCount)
+		       ? partCount
+		       : static_cast<std::size_t>(hashedPartCount);
+}
+
+} // namespace partbar
+
+#endif // PARTBARSPANS_H

--- a/src/SharedFilesCtrl.cpp
+++ b/src/SharedFilesCtrl.cpp
@@ -43,6 +43,8 @@
 #include "ServerConnect.h"    // Needed for CServerConnect
 #include "Preferences.h"      // Needed for thePrefs
 #include "MuleBarRenderer.h"  // Needed for CBarFillSpec, CBarFillSpan
+#include "PartBarLegendUI.h"  // Needed for ShowPartBarLegend, ToMuleColour
+#include "PartBarSpans.h"     // Needed for partbar::SpanFor, ModeFor, HashedPartsClamped
 #include "DataToText.h"       // Needed for PriorityToStr
 #include "Statistics.h"       // Needed for theStats (incoming free space)
 #include "GuiEvents.h"        // Needed for CoreNotify_*
@@ -127,6 +129,7 @@ wxBEGIN_EVENT_TABLE(CSharedFilesCtrl, CMuleVirtualDataViewCtrl)
 	EVT_MENU(MP_REFRESHMEDIAMETA, CSharedFilesCtrl::OnRefreshMediaMetadata)
 	EVT_MENU(MP_WS, CSharedFilesCtrl::OnGetFeedback)
 	EVT_MENU(MP_VERIFY, CSharedFilesCtrl::OnVerifyLocalData)
+	EVT_MENU(MP_BARLEGEND, CSharedFilesCtrl::OnShowBarLegend)
 wxEND_EVENT_TABLE()
 
 CSharedFilesCtrl::CSharedFilesCtrl(wxWindow *parent, int id, const wxPoint &pos, wxSize size, int flags)
@@ -259,6 +262,24 @@ void CSharedFilesCtrl::OnItemRightClicked(wxDataViewEvent &event)
 		m_menu->AppendSeparator();
 		m_menu->Append(MP_EXPORTCOLLECTION, _("Export selected files to an emulecollection"));
 
+		// The bar column is the only cell in this list whose colours need
+		// explaining, and it explains two unrelated things depending on the
+		// row, so the legend is chosen from the clicked file: right-click a
+		// file being re-hashed and the hashing legend opens, not the
+		// availability one.
+		//
+		// Guarded by IsColumnHidden() rather than by
+		// CGenericClientListCtrl::FindBarLegendColumn(), which is a member of
+		// the other list and does not reach here. Model id and view position
+		// coincide -- InitColumnState() requires it -- so COLUMN_SHARED_PART
+		// answers both. A bar the user has hidden is not on screen to explain.
+		const partbar::BarLegendKind legend =
+			partbar::LegendForSharedFilesRow(file->GetHashingProgress(), file->GetPartCount());
+		if (legend != partbar::BarLegendKind::None && !IsColumnHidden(COLUMN_SHARED_PART)) {
+			m_menu->AppendSeparator();
+			m_menu->Append(MP_BARLEGEND, _("Colour legend"));
+		}
+
 		// Offered only when the file is reachable from this host: the shared
 		// list carries the daemon's directory in amulegui, which resolves here
 		// only on a shared filesystem, and a locally shared file can have been
@@ -349,6 +370,27 @@ void CSharedFilesCtrl::ShowFileDetailDialog(long focused)
 		files.push_back(FileAtRow(i));
 	}
 	CFileDetailDialog(this, files, index).ShowModal();
+}
+
+void CSharedFilesCtrl::OnShowBarLegend(wxCommandEvent &WXUNUSED(event))
+{
+	// Bound re-checked, for the reason OnOpenFile gives: PopupMenu runs a
+	// nested event loop, so the shared-dir watcher can drop the row while the
+	// menu is open.
+	if (m_menuItem == 0 || !HasItemData(m_menuItem)) {
+		return;
+	}
+
+	// Resolved again rather than remembered from when the entry was appended: a
+	// re-hash can start or finish while the menu is up, and the legend has to
+	// explain what the cell is drawing now.
+	const CKnownFile *file = reinterpret_cast<CKnownFile *>(m_menuItem);
+
+	// Titled from the live column rather than from a second copy of its label,
+	// so the two cannot end up saying different things.
+	ShowPartBarLegend(this,
+		partbar::LegendForSharedFilesRow(file->GetHashingProgress(), file->GetPartCount()),
+		GetColumn(COLUMN_SHARED_PART)->GetTitle());
 }
 
 void CSharedFilesCtrl::OnViewFileDetails(wxCommandEvent &WXUNUSED(event))
@@ -633,51 +675,77 @@ void CSharedFilesCtrl::GetItemBarFill(wxUIntPtr item, unsigned column, CBarFillS
 		return;
 	}
 	CKnownFile *file = reinterpret_cast<CKnownFile *>(item);
-	if (!file->GetPartCount()) {
-		return;
-	}
 
-	std::vector<CBarFillSpan> spans;
+	const uint64 fileSize = file->GetFileSize();
+	const std::size_t partCount = file->GetPartCount();
 	const bool bFlat = thePrefs::UseFlatBar();
 
-	if (file->GetHashingProgress() > 0) {
-		const CMuleColour crPending(255, 208, 0);
-		const CMuleColour crFlatPending(255, 255, 100);
-		const CMuleColour crProgress(0, 224, 0);
-		const CMuleColour crFlatProgress(0, 150, 0);
+	std::vector<CBarFillSpan> spans;
 
-		uint64 left = file->GetHashingProgress() * PARTSIZE;
-		if (left < file->GetFileSize() - 1) {
-			spans.push_back(
-				{ left + 1, file->GetFileSize() - 1, bFlat ? crFlatPending : crPending });
-		} else {
-			left = file->GetFileSize() - 1;
+	// Which of the two unrelated things this cell is drawing. Decided from the
+	// same two integers the row context menu picks the legend from, so the bar
+	// and its explanation cannot disagree about which one is on screen.
+	switch (partbar::ModeFor(file->GetHashingProgress(), partCount)) {
+	case partbar::BarMode::None:
+		return;
+
+	case partbar::BarMode::Hashing: {
+		// CHashingTask reports part + 1, so a finished pass reports one part
+		// past the end of the file and the raw count cannot be used as an
+		// index. Clamped, then turned into the last hashed byte.
+		const std::size_t hashedParts =
+			partbar::HashedPartsClamped(file->GetHashingProgress(), partCount);
+		const uint64 hashedEnd = partbar::SpanFor(hashedParts - 1, PARTSIZE, fileSize).end;
+
+		if (hashedEnd < fileSize - 1) {
+			spans.push_back({ hashedEnd + 1,
+				fileSize - 1,
+				ToMuleColour(partbar::HashingPartColour(
+					partbar::HashingPartState::NotYetHashed, bFlat)) });
 		}
-		// The amount already hashed, in green.
-		spans.push_back({ 0, left, bFlat ? crFlatProgress : crProgress });
-	} else {
-		// Reference to the availability list
+		spans.push_back({ 0,
+			hashedEnd,
+			ToMuleColour(partbar::HashingPartColour(partbar::HashingPartState::Hashed, bFlat)) });
+		break;
+	}
+
+	case partbar::BarMode::Availability: {
+		// A partfile's availability is what the download queue sees from its
+		// sources; a complete file's is what our own uploads have observed.
 		const ArrayOfUInts16 &list = file->IsPartFile()
 						     ? static_cast<CPartFile *>(file)->m_SrcpartFrequency
 						     : file->m_AvailPartFrequency;
 
-		uint64 end = 0;
-		for (unsigned int i = 0; i < list.size(); ++i) {
-			const uint64 start = PARTSIZE * static_cast<uint64>(i);
-			end = PARTSIZE * static_cast<uint64>(i + 1);
-			spans.push_back({ start,
-				end,
-				CMuleColour(list[i] ? 0 : 255,
-					list[i] ? ((210 - (22 * (list[i] - 1)) < 0)
-								  ? 0
-								  : (210 - (22 * (list[i] - 1))))
-						: 0,
-					list[i] ? 255 : 0) });
+		// Indexed alongside the range rather than by subscript: the index is
+		// the part number SpanFor() wants, not a way of reaching the element.
+		std::size_t index = 0;
+		for (const uint16 sources : list) {
+			const partbar::Span span = partbar::SpanFor(index++, PARTSIZE, fileSize);
+			spans.push_back({ span.start,
+				span.end,
+				ToMuleColour(
+					sources == 0
+						? partbar::AvailabilityPartColour(
+							  partbar::AvailabilityPartState::ZeroSources, bFlat)
+						: partbar::SourceAvailabilityColour(sources)) });
 		}
-		spans.push_back({ end + 1, file->GetFileSize() - 1, CMuleColour(255, 0, 0) });
+
+		// Whatever the availability array did not cover. It is normally exactly
+		// partCount long, but a remote GUI can see a share before the daemon's
+		// frequencies arrive, and a tail nobody is known to hold reads as the
+		// same red a zero count draws rather than as unpainted background.
+		const uint64 covered = PARTSIZE * static_cast<uint64>(list.size());
+		if (covered < fileSize) {
+			spans.push_back({ covered,
+				fileSize - 1,
+				ToMuleColour(partbar::AvailabilityPartColour(
+					partbar::AvailabilityPartState::ZeroSources, bFlat)) });
+		}
+		break;
+	}
 	}
 
-	out = CBarFillSpec(item, file->GetFileSize(), std::move(spans));
+	out = CBarFillSpec(item, fileSize, std::move(spans));
 }
 
 bool CSharedFilesCtrl::AltSortAllowed(unsigned column) const

--- a/src/SharedFilesCtrl.cpp
+++ b/src/SharedFilesCtrl.cpp
@@ -157,7 +157,7 @@ CSharedFilesCtrl::CSharedFilesCtrl(wxWindow *parent, int id, const wxPoint &pos,
 	AddTextColumn(_("Accepted Requests"), COLUMN_SHARED_AREQ, "A", 80, wxALIGN_LEFT, colFlags);
 	AddTextColumn(_("Transferred Data"), COLUMN_SHARED_TRA, "T", 120, wxALIGN_LEFT, colFlags);
 	AddTextColumn(_("Share Ratio"), COLUMN_SHARED_RTIO, "R", 80, wxALIGN_LEFT, colFlags);
-	AddBarColumn(_("Obtained Parts"), COLUMN_SHARED_PART, "P", 120, colFlags);
+	AddBarColumn(_("Source Availability"), COLUMN_SHARED_PART, "P", 120, colFlags);
 	AddTextColumn(_("Complete Sources"), COLUMN_SHARED_CMPL, "C", 120, wxALIGN_LEFT, colFlags);
 	// FileID (== file hash) was dropped — the hash is on the details modal. The
 	// three new columns reuse existing translations ("Speed", "Shared since",

--- a/src/SharedFilesCtrl.h
+++ b/src/SharedFilesCtrl.h
@@ -356,6 +356,17 @@ private:
 	void OnViewFileDetails(wxCommandEvent &event);
 
 	/**
+	 * Opens the colour legend for the bar column, for the row the menu was
+	 * built from.
+	 *
+	 * That one column draws two unrelated things -- how many sources hold each
+	 * part, and how far a running re-hash has read -- so which legend to open
+	 * is a property of the row, not of the column
+	 * (partbar::LegendForSharedFilesRow).
+	 */
+	void OnShowBarLegend(wxCommandEvent &event);
+
+	/**
 	 * Double-click / Enter on a row also opens the file-details dialog, for
 	 * parity with the downloads list.
 	 */

--- a/src/webapi/static/js/components.js
+++ b/src/webapi/static/js/components.js
@@ -384,8 +384,18 @@ export async function copyText(text) {
 // The pieces bar mirrors the aMule GUI download bar, theme-tuned via CSS vars:
 // green (--ok) = have it, blue (--piece-avail-lo -> --piece-avail, faded by
 // source count) = available, red (--bad) = missing (nobody has it).
-// Sources at which an available part reaches full-intensity blue (aMule's
-// gradient saturates around 10 sources: blue = 210 - 22*(sources-1)).
+// Sources at which an available part reaches full-intensity blue. This is
+// partbar::kAvailFull in src/PartBarLegend.h, which is where the desktop GUI's
+// two bars now take the same fade from, so the number has to match: a file that
+// looks fully shared in the GUI must look fully shared here.
+//
+// It used to say the GUI faded "blue = 210 - 22*(sources-1), saturating around
+// 10". Every part of that was wrong. The expression was written into the GREEN
+// channel while blue stayed at 255, and it does not reach zero until the
+// eleventh source, so the GUI and this file disagreed both about which colour
+// they were fading and about where the fade stopped. Both bars read
+// SourceAvailabilityColour() since #1220 and neither computes a shade of its
+// own.
 const AVAIL_FULL = 10;
 
 // Parse a CSS colour ("#rgb", "#rrggbb", or "rgb(...)") to [r,g,b].
@@ -408,8 +418,10 @@ function mix(a, b, f) {
 }
 
 // Blue shade for a part that at least one peer has: fades from
-// --piece-avail-lo to --piece-avail as the source count rises, matching
-// the desktop gradient (blue = 210 - 22*(sources-1), saturating near 10).
+// --piece-avail-lo to --piece-avail as the source count rises. The desktop GUI
+// blends the same two endpoints over the same AVAIL_FULL - 1 steps, and no
+// channel of that blend can land on a half, so Math.round here and integer
+// division there produce the same bytes rather than merely similar ones.
 function availShade(sources, lo, hi) {
   const frac = Math.min(1, Math.max(0, ((sources || 1) - 1) / (AVAIL_FULL - 1)));
   return mix(lo, hi, frac);

--- a/unittests/tests/CMakeLists.txt
+++ b/unittests/tests/CMakeLists.txt
@@ -974,11 +974,40 @@ target_link_libraries (RangeFileBodyTest
 # parts, a source whose state flips to "downloading" -- so PartIndex.h is
 # header-only and free of wx, Beast and EC, and the test needs nothing but
 # the harness.
-# The chunk-bar palette and the two legends the "?" beside the bar column
-# headers opens. Header-only and wx-free on purpose (see PartBarLegend.h): the
-# colours, the rows of each legend, which legend a column gets and where the "?"
-# is clickable are all decided without a toolkit, so a headless run can check
-# the half of the feature that can drift silently. Needs no app and no daemon.
+# The chunk-bar palette and the two legends the row context menu opens.
+# Header-only and wx-free on purpose (see PartBarLegend.h): the colours, the rows
+# of each legend and which legend a column gets are all decided without a
+# toolkit, so a headless run can check the half of the feature that can drift
+# silently. Needs no app and no daemon.
+#
+# This comment described a "?" beside the column headers until now. That
+# affordance never shipped: #1218 replaced it with a row context-menu entry
+# because the header hit test could not work -- clickX and GetColumnLeft() are
+# not in the same coordinate space -- and header clicks only sort. The test it
+# claimed to cover went with it.
+# Where each part sits in a chunk bar, and which of the two unrelated things the
+# shared-files bar draws. Header-only and wx-free (see PartBarSpans.h): the
+# geometry and the mode choice come from two integers, so a headless run can
+# check the arithmetic that was silently wrong. Needs no app and no daemon.
+add_executable (PartBarSpansTest
+	PartBarSpansTest.cpp
+)
+
+add_test (NAME PartBarSpansTest
+	COMMAND PartBarSpansTest
+)
+
+target_include_directories (PartBarSpansTest
+	PRIVATE ${CMAKE_SOURCE_DIR}/src
+)
+
+# mulecommon even though the header is inline-only: macOS links without it,
+# GNU ld and mingw do not (see JsonDepthScanTest).
+target_link_libraries (PartBarSpansTest
+	muleunit
+	mulecommon
+)
+
 add_executable (PartBarLegendTest
 	PartBarLegendTest.cpp
 )

--- a/unittests/tests/CMakeLists.txt
+++ b/unittests/tests/CMakeLists.txt
@@ -1016,6 +1016,14 @@ add_test (NAME PartBarLegendTest
 	COMMAND PartBarLegendTest
 )
 
+# The one thing in this suite that is not header-only: the availability fade is
+# duplicated in the Web UI, which has no build step to generate one side from the
+# other, so the test reads the browser's own sources and compares. Same SRCDIR
+# trick as TextFileTest.
+target_compile_definitions (PartBarLegendTest
+	PRIVATE "SRCDIR=${CMAKE_CURRENT_SOURCE_DIR}"
+)
+
 target_include_directories (PartBarLegendTest
 	PRIVATE ${CMAKE_SOURCE_DIR}/src
 )

--- a/unittests/tests/PartBarLegendTest.cpp
+++ b/unittests/tests/PartBarLegendTest.cpp
@@ -477,6 +477,32 @@ TEST(PartBarLegend, TheSharedFilesBarColumnGetsALegendPerMode)
 		    LegendForColumn(SharedFilesBarColumn::SourceAvailability, BarMode::None));
 }
 
+TEST(PartBarLegend, ASharedFilesRowResolvesItsLegendFromTwoIntegers)
+{
+	// What the row context menu has to decide when it is clicked: the file
+	// gives a hashed-part count and a part count, and the legend follows from
+	// those two numbers alone. Composed once here rather than at the call site
+	// so the composition is checkable without a display -- opening the dialog
+	// is not, but choosing which one to open is.
+	//
+	// Expected values are the mode table of the spec, not a second call to
+	// ModeFor(): if the composition were wired the wrong way round, reading the
+	// answer back out of the same expression would agree with it.
+	ASSERT_TRUE(BarLegendKind::SharedAvailability == LegendForSharedFilesRow(0, 9));
+	ASSERT_TRUE(BarLegendKind::SharedHashing == LegendForSharedFilesRow(1, 9));
+	ASSERT_TRUE(BarLegendKind::SharedHashing == LegendForSharedFilesRow(9, 9));
+
+	// A count past the end of the file still means a hash is running:
+	// CHashingTask reports part + 1, so a finished pass reports one too many.
+	ASSERT_TRUE(BarLegendKind::SharedHashing == LegendForSharedFilesRow(9, 4));
+
+	// No parts, no bar, no legend -- for every hashed count, including one
+	// that claims progress through a file with nothing in it.
+	ASSERT_TRUE(BarLegendKind::None == LegendForSharedFilesRow(0, 0));
+	ASSERT_TRUE(BarLegendKind::None == LegendForSharedFilesRow(1, 0));
+	ASSERT_TRUE(BarLegendKind::None == LegendForSharedFilesRow(9, 0));
+}
+
 TEST(PartBarLegend, TheClientListLegendsAreUnaffectedByTheSharedFilesModes)
 {
 	// The mode argument belongs to the shared-files overload alone. The two

--- a/unittests/tests/PartBarLegendTest.cpp
+++ b/unittests/tests/PartBarLegendTest.cpp
@@ -36,16 +36,29 @@
 // needs in order to be readable at all -- one row per state the bar can draw,
 // in the order the renderer decides them, no two rows the same colour.
 //
+// Since #1220 it also covers the shared-files source-availability bar, whose
+// colour was a gradient the GUI and the Web UI each computed with their own
+// endpoints and their own saturation point. The fade is now one function, so
+// the endpoints are asserted as literals worked out by hand, and the two
+// interior samples pin the rounding; the last two tests read the browser's own
+// components.js and app.css and compare, because nothing generates one surface
+// from the other and a hand-maintained duplicate rots quietly.
+//
 // It links no wx and opens no display session, which is the point: this is the
 // half of the feature that a headless CI run can actually check. The drawing
-// (16x16 swatches through a wxMemoryDC) and the context-menu entry that opens
-// the dialog are not reachable from here.
+// (16x16 swatches through a wxMemoryDC, the gradient swatch included) and the
+// context-menu entry that opens the dialog are not reachable from here.
 
 #include <muleunit/test.h>
 
 #include "PartBarLegend.h"
+#include "PartBarSpans.h"
 
 #include <cstddef>
+#include <fstream>
+#include <regex>
+#include <sstream>
+#include <string>
 
 using namespace muleunit;
 using namespace partbar;
@@ -64,6 +77,34 @@ constexpr BarColour kExpectedClientOnly{ 104, 104, 104 };
 constexpr BarColour kExpectedFlatClientOnly{ 0, 0, 0 };
 constexpr BarColour kExpectedPending{ 255, 208, 0 };
 constexpr BarColour kExpectedNextPending{ 255, 255, 100 };
+
+//! The shared-files availability fade, likewise spelled out. These are the Web
+//! UI's endpoints (--piece-avail-lo / --piece-avail, src/webapi/static/css/
+//! app.css:29-30) transcribed by hand, and the two interior values are what
+//! rounding the blend produces at n=5 and n=9 -- worked out independently of
+//! the header's arithmetic, because a test that ran the same expression would
+//! agree with a wrong one.
+constexpr BarColour kExpectedZeroSources{ 255, 0, 0 };
+constexpr BarColour kExpectedOneSource{ 166, 212, 238 };
+constexpr BarColour kExpectedFiveSources{ 113, 181, 225 };
+constexpr BarColour kExpectedNineSources{ 60, 151, 211 };
+constexpr BarColour kExpectedManySources{ 47, 143, 208 };
+
+//! The hashing legend's two fills. Written out again rather than reused from
+//! kExpectedPending / kExpectedNextPending above: that the not-yet-hashed flat
+//! fill is byte-identical to the sources bar's next-requested cue is the
+//! collision this change resolved by naming them apart, and a test that shared
+//! one literal between the two legends would be asserting they are the same
+//! thing, which is what stopped being true.
+constexpr BarColour kExpectedHashed{ 0, 192, 0 };
+constexpr BarColour kExpectedFlatHashed{ 0, 150, 0 };
+constexpr BarColour kExpectedHashPending{ 255, 208, 0 };
+constexpr BarColour kExpectedFlatHashPending{ 255, 255, 100 };
+
+//! The green the shared-files hashing bar used to draw
+//! (src/SharedFilesCtrl.cpp:646). The bar adopts the palette's kBoth instead,
+//! so this value must no longer appear anywhere in the legend.
+constexpr BarColour kRetiredHashingGreen{ 0, 224, 0 };
 
 //! Every column id, so the legend mapping can be checked exhaustively rather
 //! than on the two interesting cases alone.
@@ -85,6 +126,74 @@ constexpr GenericColumnEnum kAllColumns[] = { ColumnUserName,
 	ColumnInvalid };
 
 constexpr std::size_t kAllColumnsSize = sizeof(kAllColumns) / sizeof(kAllColumns[0]);
+
+//! The shared-files list's own column ids, as literals. They are plain
+//! #defines (src/SharedFilesCtrl.h:31-46) in a header that needs wx, and they
+//! deliberately never enter PartBarLegend.h -- putting them there would undo
+//! the separation the typed key exists for. Stated here so the two id spaces
+//! can be exercised against each other.
+constexpr int kAllSharedFilesColumns[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14 };
+
+constexpr std::size_t kAllSharedFilesColumnsSize =
+	sizeof(kAllSharedFilesColumns) / sizeof(kAllSharedFilesColumns[0]);
+
+//! COLUMN_SHARED_PART, the shared-files bar column. Named because the point of
+//! the exhaustive test below is what happens to this particular number.
+constexpr int kSharedFilesBarColumnId = 8;
+
+// SRCDIR arrives as an unquoted path; stringize it without wx, since nothing
+// else in this suite needs a wxString for a filename.
+#define PARTBAR_STRINGIZE_(x) #x
+#define PARTBAR_STRINGIZE(x) PARTBAR_STRINGIZE_(x)
+
+//! The Web UI's sources, relative to this directory. Two different files, so
+//! the comparison below is not a restatement of either side's assumption.
+const std::string kWebUiJs =
+	std::string(PARTBAR_STRINGIZE(SRCDIR)) + "/../../src/webapi/static/js/components.js";
+const std::string kWebUiCss = std::string(PARTBAR_STRINGIZE(SRCDIR)) + "/../../src/webapi/static/css/app.css";
+
+//! Whole file as text, or empty if it could not be opened -- which the caller
+//! reports as a failure naming the path, because a pin that silently passes
+//! when it cannot find the other surface is worse than no pin.
+std::string ReadWholeFile(const std::string &path)
+{
+	std::ifstream in(path.c_str());
+	if (!in) {
+		return std::string();
+	}
+	std::ostringstream all;
+	all << in.rdbuf();
+	return all.str();
+}
+
+//! First capture of @p pattern in @p text, or empty if it does not match.
+std::string FirstCapture(const std::string &text, const std::string &pattern)
+{
+	std::smatch found;
+	const std::regex expression(pattern);
+	if (!std::regex_search(text, found, expression) || found.size() < 2) {
+		return std::string();
+	}
+	return found[1].str();
+}
+
+//! "a6d4ee" -> (166,212,238). Six digits only; the Web UI writes them long.
+BarColour ColourFromHex(const std::string &hex)
+{
+	const unsigned long packed = std::stoul(hex, nullptr, 16);
+	return BarColour{ static_cast<std::uint8_t>((packed >> 16) & 0xFF),
+		static_cast<std::uint8_t>((packed >> 8) & 0xFF),
+		static_cast<std::uint8_t>(packed & 0xFF) };
+}
+
+//! Compare channel by channel, so a failure names the channel and the two
+//! numbers instead of only saying the colours differ.
+void AssertColourEquals(const BarColour &expected, const BarColour &actual)
+{
+	ASSERT_EQUALS((int)expected.red, (int)actual.red);
+	ASSERT_EQUALS((int)expected.green, (int)actual.green);
+	ASSERT_EQUALS((int)expected.blue, (int)actual.blue);
+}
 
 } // namespace
 
@@ -124,6 +233,76 @@ TEST(PartBarLegend, PeerColoursAreTheOnesTheBarDrew)
 	ASSERT_TRUE(kExpectedFlatNeither == PeerPartColour(PeerPartState::Missing, true));
 }
 
+// --- the shared-files availability fade ---------------------------------
+
+TEST(PartBarLegend, TheFadeRunsBetweenTheWebUiEndpoints)
+{
+	// One definition serves the shared-files list, the downloads list and the
+	// Web UI, so the endpoints have to be one set of numbers. Decision 3 picks
+	// the Web UI's: the GUI's old (0,210,255) -> (0,0,255) does not survive.
+	CONTEXT("one source");
+	AssertColourEquals(kExpectedOneSource, SourceAvailabilityColour(1));
+}
+
+TEST(PartBarLegend, TheFadeRoundsItsInteriorStepsToTheseValues)
+{
+	// Halfway and one step short of saturation. Both are exact: the blend has
+	// a denominator of nine, so no channel can land on .5 and every rounding
+	// mode -- Math.round in components.js included -- gives these numbers.
+	{
+		CONTEXT("five sources");
+		AssertColourEquals(kExpectedFiveSources, SourceAvailabilityColour(5));
+	}
+	{
+		CONTEXT("nine sources");
+		AssertColourEquals(kExpectedNineSources, SourceAvailabilityColour(9));
+	}
+}
+
+TEST(PartBarLegend, TheFadeSaturatesAtTenSources)
+{
+	// Ten, not the GUI's former eleven: AVAIL_FULL in
+	// src/webapi/static/js/components.js:389 is what a user comparing the two
+	// surfaces sees, and one more source past saturation must not darken the
+	// part further.
+	{
+		CONTEXT("ten sources");
+		AssertColourEquals(kExpectedManySources, SourceAvailabilityColour(10));
+	}
+	{
+		CONTEXT("eleven sources");
+		AssertColourEquals(kExpectedManySources, SourceAvailabilityColour(11));
+	}
+	{
+		CONTEXT("a thousand sources");
+		AssertColourEquals(kExpectedManySources, SourceAvailabilityColour(1000));
+	}
+}
+
+TEST(PartBarLegend, TheFadeNeverBrightensAsSourcesAreAdded)
+{
+	// More sources must never read as less availability. Checked as a property
+	// across the whole range rather than at the sampled points, because a sign
+	// slip in one channel is invisible at the endpoints.
+	for (unsigned n = 1; n < 40; ++n) {
+		CONTEXT(wxString::Format("from %u to %u sources", n, n + 1));
+		const BarColour here = SourceAvailabilityColour(n);
+		const BarColour next = SourceAvailabilityColour(n + 1);
+		ASSERT_TRUE(next.red <= here.red);
+		ASSERT_TRUE(next.green <= here.green);
+		ASSERT_TRUE(next.blue <= here.blue);
+	}
+}
+
+TEST(PartBarLegend, ZeroSourcesIsItsOwnStateAndNotTheFadesDarkEnd)
+{
+	// A part nobody holds is a different fact from a part one peer holds, and
+	// the bar says so in red. Putting it on the fade would make "unavailable"
+	// the darkest shade of "available".
+	AssertColourEquals(kExpectedZeroSources, kZeroSources);
+	ASSERT_TRUE(kZeroSources != SourceAvailabilityColour(1));
+}
+
 // --- the legends --------------------------------------------------------
 
 TEST(PartBarLegend, TheSourceLegendListsEveryStateOnceInRendererOrder)
@@ -149,11 +328,102 @@ TEST(PartBarLegend, ThePeerLegendListsItsTwoStates)
 	ASSERT_TRUE(PeerPartState::Missing == kPeerLegendOrder[1]);
 }
 
+TEST(PartBarLegend, TheAvailabilityLegendListsItsThreeStatesInOrder)
+{
+	// Nobody has it, a few have it, many have it. Three rows, because the red
+	// is a different fact rather than the dark end of the blue.
+	ASSERT_EQUALS((std::size_t)3, kAvailabilityLegendSize);
+	ASSERT_TRUE(AvailabilityPartState::ZeroSources == kAvailabilityLegendOrder[0]);
+	ASSERT_TRUE(AvailabilityPartState::FewSources == kAvailabilityLegendOrder[1]);
+	ASSERT_TRUE(AvailabilityPartState::ManySources == kAvailabilityLegendOrder[2]);
+}
+
+TEST(PartBarLegend, TheHashingLegendListsItsTwoStatesInOrder)
+{
+	ASSERT_EQUALS((std::size_t)2, kHashingLegendSize);
+	ASSERT_TRUE(HashingPartState::Hashed == kHashingLegendOrder[0]);
+	ASSERT_TRUE(HashingPartState::NotYetHashed == kHashingLegendOrder[1]);
+}
+
+TEST(PartBarLegend, TheAvailabilityLegendRowsAreTheFadesOwnColours)
+{
+	// The legend's two blue rows are the fade's endpoints, read from the same
+	// function the renderer calls, so a changed endpoint moves both or
+	// neither. The literals are asserted separately, above and below.
+	{
+		CONTEXT("few sources row");
+		AssertColourEquals(SourceAvailabilityColour(1),
+			AvailabilityPartColour(AvailabilityPartState::FewSources, false));
+	}
+	{
+		CONTEXT("many sources row");
+		AssertColourEquals(SourceAvailabilityColour(kAvailFull),
+			AvailabilityPartColour(AvailabilityPartState::ManySources, false));
+	}
+}
+
+TEST(PartBarLegend, TheAvailabilityLegendRowsAreTheseValues)
+{
+	{
+		CONTEXT("zero sources row");
+		AssertColourEquals(kExpectedZeroSources,
+			AvailabilityPartColour(AvailabilityPartState::ZeroSources, false));
+	}
+	{
+		CONTEXT("few sources row");
+		AssertColourEquals(
+			kExpectedOneSource, AvailabilityPartColour(AvailabilityPartState::FewSources, false));
+	}
+	{
+		CONTEXT("many sources row");
+		AssertColourEquals(kExpectedManySources,
+			AvailabilityPartColour(AvailabilityPartState::ManySources, false));
+	}
+}
+
+TEST(PartBarLegend, TheAvailabilityLegendIgnoresTheFlatBarPreference)
+{
+	// The renderer never consulted UseFlatBar() for this bar
+	// (src/SharedFilesCtrl.cpp:658-678 takes bFlat and does not use it), so
+	// the legend must not invent a second set of values for a distinction the
+	// bar does not draw.
+	for (std::size_t i = 0; i < kAvailabilityLegendSize; ++i) {
+		CONTEXT(wxString::Format("availability row %zu", i));
+		AssertColourEquals(AvailabilityPartColour(kAvailabilityLegendOrder[i], false),
+			AvailabilityPartColour(kAvailabilityLegendOrder[i], true));
+	}
+}
+
+TEST(PartBarLegend, TheHashingLegendColoursAreTheOnesTheBarDraws)
+{
+	AssertColourEquals(kExpectedHashed, HashingPartColour(HashingPartState::Hashed, false));
+	AssertColourEquals(kExpectedFlatHashed, HashingPartColour(HashingPartState::Hashed, true));
+	AssertColourEquals(kExpectedHashPending, HashingPartColour(HashingPartState::NotYetHashed, false));
+	AssertColourEquals(kExpectedFlatHashPending, HashingPartColour(HashingPartState::NotYetHashed, true));
+}
+
+TEST(PartBarLegend, TheHashingBarGaveUpItsPrivateGreen)
+{
+	// It carried its own (0,224,0) next to the palette's (0,192,0) for no
+	// stated reason. Adopting the palette's darkens the hashing bar slightly,
+	// which is deliberate: two greens meaning "have it" is the drift this
+	// header exists to remove.
+	ASSERT_TRUE(kRetiredHashingGreen != HashingPartColour(HashingPartState::Hashed, false));
+	ASSERT_TRUE(kRetiredHashingGreen != HashingPartColour(HashingPartState::Hashed, true));
+}
+
 TEST(PartBarLegend, NoTwoRowsOfALegendShareAColour)
 {
 	// Two rows of one swatch cannot be told apart on screen, so the legend
 	// would be explaining a distinction the bar does not draw. Checked under
 	// both bar styles, since each has its own values.
+	//
+	// Scoped to one legend at a time, and that is not laziness: the hashing
+	// legend's flat not-yet-hashed fill and the sources legend's
+	// next-requested cue are both (255,255,100) and mean different things. A
+	// global uniqueness check would fail on two colours that never appear side
+	// by side, and the only way to satisfy it would be to repaint a bar for
+	// the sake of a legend it is not in.
 	for (int flat = 0; flat <= 1; ++flat) {
 		for (std::size_t i = 0; i < kSourceLegendSize; ++i) {
 			for (std::size_t j = i + 1; j < kSourceLegendSize; ++j) {
@@ -163,6 +433,15 @@ TEST(PartBarLegend, NoTwoRowsOfALegendShareAColour)
 		}
 		ASSERT_TRUE(PeerPartColour(kPeerLegendOrder[0], flat != 0) !=
 			    PeerPartColour(kPeerLegendOrder[1], flat != 0));
+
+		for (std::size_t i = 0; i < kAvailabilityLegendSize; ++i) {
+			for (std::size_t j = i + 1; j < kAvailabilityLegendSize; ++j) {
+				ASSERT_TRUE(AvailabilityPartColour(kAvailabilityLegendOrder[i], flat != 0) !=
+					    AvailabilityPartColour(kAvailabilityLegendOrder[j], flat != 0));
+			}
+		}
+		ASSERT_TRUE(HashingPartColour(kHashingLegendOrder[0], flat != 0) !=
+			    HashingPartColour(kHashingLegendOrder[1], flat != 0));
 	}
 }
 
@@ -180,5 +459,117 @@ TEST(PartBarLegend, OnlyTheTwoBarColumnsHaveALegend)
 			continue;
 		}
 		ASSERT_TRUE(BarLegendKind::None == LegendForColumn(kAllColumns[i]));
+	}
+}
+
+TEST(PartBarLegend, TheSharedFilesBarColumnGetsALegendPerMode)
+{
+	// One column, two legends: the cell draws availability most of the time
+	// and re-hash progress while a hash is running, and they share nothing.
+	// Which one to show is decided by the row's mode, not by the column.
+	ASSERT_TRUE(BarLegendKind::SharedAvailability ==
+		    LegendForColumn(SharedFilesBarColumn::SourceAvailability, BarMode::Availability));
+	ASSERT_TRUE(BarLegendKind::SharedHashing ==
+		    LegendForColumn(SharedFilesBarColumn::SourceAvailability, BarMode::Hashing));
+
+	// A row with no parts draws no bar, so there is nothing to explain.
+	ASSERT_TRUE(BarLegendKind::None ==
+		    LegendForColumn(SharedFilesBarColumn::SourceAvailability, BarMode::None));
+}
+
+TEST(PartBarLegend, TheClientListLegendsAreUnaffectedByTheSharedFilesModes)
+{
+	// The mode argument belongs to the shared-files overload alone. The two
+	// client-list bar columns have one legend each and keep answering the
+	// single-argument call, so nothing already in the tree had to change.
+	ASSERT_TRUE(BarLegendKind::SourceParts == LegendForColumn(ColumnUserProgress));
+	ASSERT_TRUE(BarLegendKind::PeerParts == LegendForColumn(ColumnUserAvailable));
+	ASSERT_TRUE(BarLegendKind::SharedAvailability != BarLegendKind::SourceParts);
+	ASSERT_TRUE(BarLegendKind::SharedHashing != BarLegendKind::PeerParts);
+}
+
+TEST(PartBarLegend, ACastFromTheSharedFilesIdSpaceReachesTheWrongLegend)
+{
+	// The two id spaces overlap. COLUMN_SHARED_AREQ is 5 and so is
+	// ColumnUserProgress; COLUMN_SHARED_TRA is 6 and so is
+	// ColumnUserAvailable; COLUMN_SHARED_PART -- the bar column, the one that
+	// actually has a legend -- is 8, which is ColumnUserQueueRankLocal and has
+	// none.
+	//
+	// The distinct enum types stop this by accident, but a deliberate
+	// static_cast still compiles, and this is what it gets: a legend for two
+	// text columns and no legend for the bar. Pinned rather than argued about,
+	// so that if the id spaces are ever merged the numbers here fail loudly.
+	for (std::size_t i = 0; i < kAllSharedFilesColumnsSize; ++i) {
+		const int id = kAllSharedFilesColumns[i];
+		CONTEXT(wxString::Format("shared-files column id %d cast across", id));
+
+		const BarLegendKind wrong = LegendForColumn(static_cast<GenericColumnEnum>(id));
+		if (id == 5) {
+			ASSERT_TRUE(BarLegendKind::SourceParts == wrong);
+		} else if (id == 6) {
+			ASSERT_TRUE(BarLegendKind::PeerParts == wrong);
+		} else {
+			ASSERT_TRUE(BarLegendKind::None == wrong);
+		}
+	}
+
+	// Including the bar column itself, which is the whole problem.
+	ASSERT_TRUE(BarLegendKind::None ==
+		    LegendForColumn(static_cast<GenericColumnEnum>(kSharedFilesBarColumnId)));
+
+	// The typed call is the one that works.
+	ASSERT_TRUE(BarLegendKind::SharedAvailability ==
+		    LegendForColumn(SharedFilesBarColumn::SourceAvailability, BarMode::Availability));
+}
+
+// --- the other surface --------------------------------------------------
+
+TEST(PartBarLegend, TheWebUiSaturatesAtTheSameSourceCount)
+{
+	// Nothing generates one side from the other: there is no JS build step
+	// under src/webapi/static/, so AVAIL_FULL and kAvailFull are two numbers
+	// maintained by hand. That is the honest description of the arrangement,
+	// and this is what stops it rotting quietly -- the test reads the
+	// browser's own source and fails naming both files.
+	const std::string js = ReadWholeFile(kWebUiJs);
+	ASSERT_TRUE_M(!js.empty(),
+		wxString("Could not read ") + kWebUiJs +
+			" -- the pin between partbar::kAvailFull and the Web UI's AVAIL_FULL "
+			"cannot be checked, so it is failing rather than passing silently");
+
+	const std::string found = FirstCapture(js, "AVAIL_FULL\\s*=\\s*([0-9]+)");
+	ASSERT_TRUE_M(!found.empty(),
+		wxString("No AVAIL_FULL assignment in ") + kWebUiJs +
+			" -- it was renamed or reformatted; src/PartBarLegend.h and this test "
+			"both need updating with it");
+
+	ASSERT_EQUALS((int)kAvailFull, std::stoi(found));
+}
+
+TEST(PartBarLegend, TheWebUiFadesBetweenTheSameTwoColours)
+{
+	// The endpoints live in CSS custom properties, so a theme edit is the
+	// realistic way they drift. Read them from app.css and compare to the two
+	// constants the GUI fade is built from.
+	const std::string css = ReadWholeFile(kWebUiCss);
+	ASSERT_TRUE_M(!css.empty(),
+		wxString("Could not read ") + kWebUiCss +
+			" -- the pin between the GUI fade endpoints and --piece-avail-lo / "
+			"--piece-avail cannot be checked");
+
+	const std::string lo = FirstCapture(css, "--piece-avail-lo\\s*:\\s*#([0-9a-fA-F]{6})");
+	const std::string hi = FirstCapture(css, "--piece-avail\\s*:\\s*#([0-9a-fA-F]{6})");
+	ASSERT_TRUE_M(!lo.empty() && !hi.empty(),
+		wxString("--piece-avail-lo and --piece-avail are not both six-digit hex in ") + kWebUiCss +
+			" -- src/PartBarLegend.h's kAvailFew/kAvailMany are pinned to them");
+
+	{
+		CONTEXT("--piece-avail-lo against kAvailFew");
+		AssertColourEquals(ColourFromHex(lo), SourceAvailabilityColour(1));
+	}
+	{
+		CONTEXT("--piece-avail against kAvailMany");
+		AssertColourEquals(ColourFromHex(hi), SourceAvailabilityColour(kAvailFull));
 	}
 }

--- a/unittests/tests/PartBarLegendTest.cpp
+++ b/unittests/tests/PartBarLegendTest.cpp
@@ -44,6 +44,11 @@
 // components.js and app.css and compare, because nothing generates one surface
 // from the other and a hand-maintained duplicate rots quietly.
 //
+// The same technique is what covers the two GUI bars against each other. They
+// cannot be linked here either, so they are read as text: what is checked is
+// that both call the one fade and that neither has grown a replacement for it.
+//
+
 // It links no wx and opens no display session, which is the point: this is the
 // half of the feature that a headless CI run can actually check. The drawing
 // (16x16 swatches through a wxMemoryDC, the gradient swatch included) and the
@@ -89,6 +94,50 @@ constexpr BarColour kExpectedOneSource{ 166, 212, 238 };
 constexpr BarColour kExpectedFiveSources{ 113, 181, 225 };
 constexpr BarColour kExpectedNineSources{ 60, 151, 211 };
 constexpr BarColour kExpectedManySources{ 47, 143, 208 };
+
+//! One more sample, one step along the fade, so the table below has a value
+//! between the light endpoint and the halfway point. 166 - 119/9 rounds to
+//! 153, 212 - 69/9 to 204, 238 - 30/9 to 235.
+constexpr BarColour kExpectedTwoSources{ 153, 204, 235 };
+
+//! What a bar cell shows for a part @c sources peers hold, as one table.
+//!
+//! Both GUI call sites -- CSharedFilesCtrl::GetItemBarFill and
+//! CDownloadListCtrl::GetItemBarFill -- reach a colour through the same two
+//! branches: no source is its own state, any other count is a point on the
+//! fade. This is that decision written out once, at the counts worth naming:
+//! the two endpoints, the step either side of them, halfway, and three counts
+//! past saturation.
+struct AvailabilityTableRow
+{
+	unsigned sources;
+	BarColour colour;
+};
+
+constexpr AvailabilityTableRow kAvailabilityTable[] = { { 0, kExpectedZeroSources },
+	{ 1, kExpectedOneSource },
+	{ 2, kExpectedTwoSources },
+	{ 5, kExpectedFiveSources },
+	{ 9, kExpectedNineSources },
+	{ 10, kExpectedManySources },
+	{ 11, kExpectedManySources },
+	{ 1000, kExpectedManySources } };
+
+constexpr std::size_t kAvailabilityTableSize = sizeof(kAvailabilityTable) / sizeof(kAvailabilityTable[0]);
+
+//! The fade takes a source count and nothing else, pinned as a type rather
+//! than as prose.
+//!
+//! This is the whole enforcement mechanism, and it is worth being plain about
+//! why. No test in this tree can watch two renderers and see them agree: both
+//! GetItemBarFill() implementations need wx, an app and a display, and this
+//! suite has none of the three. What can be enforced is that neither call site
+//! is *able* to supply its own endpoints -- adding a lo/hi parameter changes
+//! this signature, which fails to compile here and is something a reviewer
+//! reads in a diff rather than something that slips past in a colour literal.
+using SourceAvailabilityColourSignature = BarColour (*)(unsigned);
+
+constexpr SourceAvailabilityColourSignature kFadeTakesOnlyASourceCount = &SourceAvailabilityColour;
 
 //! The hashing legend's two fills. Written out again rather than reused from
 //! kExpectedPending / kExpectedNextPending above: that the not-yet-hashed flat
@@ -152,6 +201,14 @@ const std::string kWebUiJs =
 	std::string(PARTBAR_STRINGIZE(SRCDIR)) + "/../../src/webapi/static/js/components.js";
 const std::string kWebUiCss = std::string(PARTBAR_STRINGIZE(SRCDIR)) + "/../../src/webapi/static/css/app.css";
 
+//! The two GUI bars that draw source availability. Neither translation unit
+//! links here -- both pull in wx, the app and a display -- so they are read as
+//! text, the same way the Web UI's two files above are.
+const std::string kSharedFilesCtrlSource =
+	std::string(PARTBAR_STRINGIZE(SRCDIR)) + "/../../src/SharedFilesCtrl.cpp";
+const std::string kDownloadListCtrlSource =
+	std::string(PARTBAR_STRINGIZE(SRCDIR)) + "/../../src/DownloadListCtrl.cpp";
+
 //! Whole file as text, or empty if it could not be opened -- which the caller
 //! reports as a failure naming the path, because a pin that silently passes
 //! when it cannot find the other surface is worse than no pin.
@@ -184,6 +241,13 @@ BarColour ColourFromHex(const std::string &hex)
 	return BarColour{ static_cast<std::uint8_t>((packed >> 16) & 0xFF),
 		static_cast<std::uint8_t>((packed >> 8) & 0xFF),
 		static_cast<std::uint8_t>(packed & 0xFF) };
+}
+
+//! Does @p text still compute a fade of its own? The downloads list's retired
+//! ramp, matched loosely enough that reformatting it does not hide it.
+bool HasItsOwnFadeArithmetic(const std::string &text)
+{
+	return std::regex_search(text, std::regex("210\\s*-\\s*\\(?\\s*22\\s*\\*"));
 }
 
 //! Compare channel by channel, so a failure names the channel and the two
@@ -547,6 +611,65 @@ TEST(PartBarLegend, ACastFromTheSharedFilesIdSpaceReachesTheWrongLegend)
 	// The typed call is the one that works.
 	ASSERT_TRUE(BarLegendKind::SharedAvailability ==
 		    LegendForColumn(SharedFilesBarColumn::SourceAvailability, BarMode::Availability));
+}
+
+// --- the two GUI call sites ---------------------------------------------
+
+TEST(PartBarLegend, OneTableAnswersForEitherBar)
+{
+	// The expression both GetItemBarFill() implementations contain, run over
+	// the counts the table names. The literals were worked out by hand and are
+	// not recomputed from the header's arithmetic, so this fails if the fade
+	// moves rather than agreeing with it wherever it went.
+	for (std::size_t i = 0; i < kAvailabilityTableSize; ++i) {
+		const AvailabilityTableRow &row = kAvailabilityTable[i];
+		CONTEXT(wxString::Format("%u sources", row.sources));
+		const BarColour drawn =
+			row.sources == 0 ? AvailabilityPartColour(AvailabilityPartState::ZeroSources, false)
+					 : SourceAvailabilityColour(row.sources);
+		AssertColourEquals(row.colour, drawn);
+	}
+}
+
+TEST(PartBarLegend, NeitherBarKeepsItsOwnFadeArithmetic)
+{
+	// The convergence this change is for, checked where it can actually be
+	// observed: in the text of the two files. Until #1220 the downloads list
+	// computed its own shade -- 210 - 22*(sources-1), assigned to the green
+	// channel through a local misnamed "blue", with the blue channel pinned at
+	// 255 -- and the shared-files list computed a third one. Two constants in a
+	// header do not stop that coming back; a call to the one function is what
+	// does, and this is what notices if either file grows a replacement.
+	//
+	// A grep over a foreign source file is a blunt instrument and worth the
+	// bluntness here: the alternative is nothing at all, because neither
+	// translation unit can be linked into a headless suite. It is blunt in one
+	// direction worth knowing about -- it cannot tell code from prose, so
+	// neither file may write the retired expression out even in a comment.
+	// Both describe it in words instead.
+	const std::string sharedFiles = ReadWholeFile(kSharedFilesCtrlSource);
+	const std::string downloads = ReadWholeFile(kDownloadListCtrlSource);
+	ASSERT_TRUE_M(!sharedFiles.empty() && !downloads.empty(),
+		wxString("Could not read ") + kSharedFilesCtrlSource + " and " + kDownloadListCtrlSource +
+			" -- whether the two bars still share one fade cannot be checked, so it is "
+			"failing rather than passing silently");
+
+	{
+		CONTEXT("the shared-files bar calls the shared fade");
+		ASSERT_TRUE(sharedFiles.find("SourceAvailabilityColour") != std::string::npos);
+	}
+	{
+		CONTEXT("the downloads bar calls the shared fade");
+		ASSERT_TRUE(downloads.find("SourceAvailabilityColour") != std::string::npos);
+	}
+	{
+		CONTEXT("no second fade in the shared-files bar");
+		ASSERT_FALSE(HasItsOwnFadeArithmetic(sharedFiles));
+	}
+	{
+		CONTEXT("no second fade in the downloads bar");
+		ASSERT_FALSE(HasItsOwnFadeArithmetic(downloads));
+	}
 }
 
 // --- the other surface --------------------------------------------------

--- a/unittests/tests/PartBarSpansTest.cpp
+++ b/unittests/tests/PartBarSpansTest.cpp
@@ -1,0 +1,117 @@
+//
+// This file is part of the aMule Project.
+//
+// Copyright (c) 2003-2026 aMule Team ( https://amule-org.github.io )
+//
+// Any parts of this program derived from the xMule, lMule or eMule project,
+// or contributed by third-party developers are copyrighted by their
+// respective authors.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301, USA
+//
+
+// Where each part of a file sits in a chunk bar, and which of the two things the
+// shared-files bar is drawing.
+//
+// Wx-free and header-only, like PartBarLegendTest: the expected values are
+// spelled out rather than recomputed from the header's own formula, because a
+// test that derived them the way production does would pass whatever either
+// said. The drawing itself is not reachable from here and is not attempted.
+
+#include <muleunit/test.h>
+
+#include "PartBarSpans.h"
+
+#include <cstddef>
+#include <cstdint>
+
+using namespace muleunit;
+using namespace partbar;
+
+namespace
+{
+
+//! PARTSIZE as the callers use it: 9500 KiB.
+constexpr std::uint64_t kPartSize = 9728000ULL;
+
+} // namespace
+
+DECLARE_SIMPLE(PartBarSpans)
+
+TEST(PartBarSpans, AdjacentSpansDoNotOverlap)
+{
+	// CBarShader::FillRange takes end as inclusive and increments it itself
+	// (src/BarShader.cpp:113-124), so part i must end exactly one byte before
+	// part i+1 begins. Overlapping spans paint one byte twice, and the shared
+	// files bar has been doing that where the other two bars do not.
+	const std::uint64_t fileSize = kPartSize * 4 + 12345;
+	for (std::size_t i = 0; i + 1 < 5; ++i) {
+		const Span here = SpanFor(i, kPartSize, fileSize);
+		const Span next = SpanFor(i + 1, kPartSize, fileSize);
+		ASSERT_EQUALS(next.start - 1, here.end);
+	}
+}
+
+TEST(PartBarSpans, TheLastSpanEndsAtTheLastByte)
+{
+	// A file that does not divide evenly has a short last part. Its end is the
+	// file's last byte, not one past it: FillRange clamps a span that runs past
+	// m_FileSize, so an over-long end is silently truncated rather than
+	// reported, which is why this was never noticed.
+	const std::uint64_t fileSize = kPartSize * 3 + 1;
+	const Span last = SpanFor(3, kPartSize, fileSize);
+	ASSERT_EQUALS(fileSize - 1, last.end);
+}
+
+TEST(PartBarSpans, AFileOfExactlyOnePartCoversItWhole)
+{
+	const Span only = SpanFor(0, kPartSize, kPartSize);
+	ASSERT_EQUALS((std::uint64_t)0, only.start);
+	ASSERT_EQUALS(kPartSize - 1, only.end);
+}
+
+TEST(PartBarSpans, SpansStartWherePartSizeSaysAndNowhereElse)
+{
+	const std::uint64_t fileSize = kPartSize * 3;
+	ASSERT_EQUALS((std::uint64_t)0, SpanFor(0, kPartSize, fileSize).start);
+	ASSERT_EQUALS(kPartSize, SpanFor(1, kPartSize, fileSize).start);
+	ASSERT_EQUALS(kPartSize * 2, SpanFor(2, kPartSize, fileSize).start);
+}
+
+TEST(PartBarSpans, NoPartsMeansNothingToDrawWhateverProgressSays)
+{
+	// The caller has no span to fill, so a hashing bar over zero parts would be
+	// a bar over nothing. Progress must not override that.
+	ASSERT_TRUE(BarMode::None == ModeFor(0, 0));
+	ASSERT_TRUE(BarMode::None == ModeFor(7, 0));
+}
+
+TEST(PartBarSpans, ProgressAboveZeroSelectsHashingAndZeroSelectsAvailability)
+{
+	ASSERT_TRUE(BarMode::Availability == ModeFor(0, 9));
+	ASSERT_TRUE(BarMode::Hashing == ModeFor(1, 9));
+	ASSERT_TRUE(BarMode::Hashing == ModeFor(4, 9));
+}
+
+TEST(PartBarSpans, TheHashedCountIsClampedToTheParts)
+{
+	// CHashingTask reports part + 1 (src/ThreadTasks.cpp:179, :693), so a
+	// finished pass reports one past the last part. Used unclamped as an index
+	// or a count, that reads or fills one span too many.
+	ASSERT_EQUALS((std::size_t)4, HashedPartsClamped(4, 9));
+	ASSERT_EQUALS((std::size_t)9, HashedPartsClamped(9, 9));
+	ASSERT_EQUALS((std::size_t)9, HashedPartsClamped(10, 9));
+	ASSERT_EQUALS((std::size_t)0, HashedPartsClamped(0, 9));
+}


### PR DESCRIPTION
Closes #1220.

The shared-files bar was named for something it does not show, carried a third
private copy of the source-count fade, and had no way to ask what its colours
mean.

| | |
|---|---|
| `d6a9256` | extract the chunk-bar span geometry, and fix it |
| `09ceffe` | converge the source-availability fade on one definition |
| `a52a23a` | draw the shared-files bar from the shared palette, and explain it |
| `e1cb1e4` | draw the downloads bar from the one source-availability fade |
| `13dd707` | name the bar for what it shows, and regenerate the catalogues |
| `201ef5f` | say 'other' in the availability legend, because we are not counted |
| `19d7d73` | translate the source-availability legend into Spanish by hand |

## Span geometry

`src/PartBarSpans.h` holds the chunk-bar geometry as `SpanFor`, `ModeFor` and
`HashedPartsClamped`. Ends are inclusive. The previous arithmetic overlapped
adjacent spans by one byte and let the last span run past the end of the file;
both are fixed here and covered by `PartBarSpansTest`.

## One fade

`SourceAvailabilityColour(n)` in `src/PartBarLegend.h` is now the only definition
of the source-count fade. It takes `n` alone — no `lo`/`hi` parameters — so
divergence requires a signature change. The C++ adopts the web UI's endpoints;
`210 - 22 * (n - 1)` no longer appears in `SharedFilesCtrl.cpp` or
`DownloadListCtrl.cpp`. A test reads `AVAIL_FULL` from `components.js` and the
hex from `app.css`, so the C++ and the web UI cannot drift apart unnoticed.

`SpanFor` is deliberately **not** adopted by `DownloadListCtrl` — that bar walks
gaps, not fixed parts.

## Legend

`src/PartBarLegendUI.{h,cpp}` carries the dialog, reached from the shared-files
row context menu and guarded by the column being visible. The bar has two
meanings — source availability, and re-hash progress — and the legend follows
whichever the bar is drawing.

![Shared files column headed Source Availability](https://raw.githubusercontent.com/kno/amule/screenshots/part-availability-spans/shot-column-renamed.png)

![Context menu with the colour legend entry](https://raw.githubusercontent.com/kno/amule/screenshots/part-availability-spans/shot-legend-menu-entry.png)

![Legend dialog with four rows and a gradient swatch](https://raw.githubusercontent.com/kno/amule/screenshots/part-availability-spans/shot-legend-dialog.png)

With the column hidden, the entry is absent:

![Same context menu with the entry absent](https://raw.githubusercontent.com/kno/amule/screenshots/part-availability-spans/shot-entry-hidden-with-column.png)

One file mid re-hash (green read, amber pending) while the others show
availability, and the legend that goes with it:

![Shared files list with one file hashing and three showing availability](https://raw.githubusercontent.com/kno/amule/screenshots/part-availability-spans/shot-hashing-mode.png)

![Legend dialog showing the two hashing rows](https://raw.githubusercontent.com/kno/amule/screenshots/part-availability-spans/shot-hashing-legend.png)

## Why the labels say "other"

`CKnownFile::UpdateAvailablePartsCount()` fills `m_AvailPartFrequency` from the
`GetUpPartStatus()` of remote clients only; the local copy is never counted. On
the shared-files list we hold every part by definition, so a red block means no
peer we know of has the part too — it measures how far the file has spread, not
whether it exists.

## Spanish

`po/es.po` carries the new legend strings, following the catalogue's existing
vocabulary: `hash` untranslated as in the other 36 strings that use it, and
*re-hash* as *"recálculo del hash"*, matching `Finished rehashing %s`.

![Legend dialog in Spanish](https://raw.githubusercontent.com/kno/amule/screenshots/part-availability-spans/shot-legend-dialog-es.png)

The other 39 catalogues keep their fuzzy entries and fall back to English.
Weblate owns these files and will overwrite `es` on its next sync; drop the
commit if you would rather the translation only ever arrive that way.

## Not covered

- The fade itself is not visible in the screenshots: the test files have no
  sources, so every part is red.
- No test observes two renderers agreeing. The shared literal table and the
  arity of `SourceAvailabilityColour` are what guard convergence.
- Whether a saved column layout still restores is asserted from the diff, not
  tested: the persistence letter `P` at `SharedFilesCtrl.cpp:185` is
  byte-unchanged and `p` and `P` remain distinct entries.
- `Source Availability` is one choice of wording; changing it is one line plus a
  catalogue regeneration.

`ctest` 48/48, clang-format 18 clean, `check-potfiles.sh` exit 0.

