### PR TITLE
fix(web-ui): take the A4AF source set from the live download row

### DIFF
--- a/src/webapi/static/js/views/download-detail.js
+++ b/src/webapi/static/js/views/download-detail.js
@@ -44,6 +44,13 @@ export function DownloadDetail({ hash, isGuest, categories = [], onPatch, onDele
   if (!detail) return html`<div class="detail-panel"><${Placeholder} kind="loading">${t("downloads_detail_loading")}<//></div>`;
 
   const d = detail;
+
+  // A4AF membership changes while the Clients tab is open, but the detail fetch
+  // above only ticks on the Details tab, so `detail` is a snapshot there. The
+  // live row carries source_ecids for exactly this reason -- Api.cpp puts it on
+  // the list object so the SSE event brings it -- and EventDiff compares
+  // a4af_sources, so a change really does emit download_updated.
+  const live = (x) => downloads.find((y) => y.hash === x.hash) || x;
   const src = d.sources || {};
   const media = d.media;
   // Empty when the daemon has sent no chunk map: the bar is skipped entirely
@@ -92,7 +99,7 @@ export function DownloadDetail({ hash, isGuest, categories = [], onPatch, onDele
       <div class="detail-body">
       ${tab === "clients" ? html`
         <${FileClients} hash=${d.hash} prefsKey="download_clients" defaultHidden=${DL_HIDDEN}
-                        defaultSort="downloaded" a4afEcids=${d.source_ecids || []}
+                        defaultSort="downloaded" a4afEcids=${live(d).source_ecids || []}
                         partsTotal=${d.total_part_count} files=${downloads} />
       ` : tab === "comments" ? html`
         <${DownloadComments} hash=${d.hash} comment=${d.my_comment} rating=${d.my_rating}

--- a/src/webapi/static/js/views/download-detail.js
+++ b/src/webapi/static/js/views/download-detail.js
@@ -45,12 +45,9 @@ export function DownloadDetail({ hash, isGuest, categories = [], onPatch, onDele
 
   const d = detail;
 
-  // A4AF membership changes while the Clients tab is open, but the detail fetch
-  // above only ticks on the Details tab, so `detail` is a snapshot there. The
-  // live row carries source_ecids for exactly this reason -- Api.cpp puts it on
-  // the list object so the SSE event brings it -- and EventDiff compares
-  // a4af_sources, so a change really does emit download_updated.
-  const live = (x) => downloads.find((y) => y.hash === x.hash) || x;
+  // Off the Details tab `d` is a frozen snapshot (liveTick is 0); read the
+  // fields that move while the panel is open from the SSE-fed store row instead.
+  const live = downloads.find((x) => x.hash === d.hash) || d;
   const src = d.sources || {};
   const media = d.media;
   // Empty when the daemon has sent no chunk map: the bar is skipped entirely
@@ -99,11 +96,11 @@ export function DownloadDetail({ hash, isGuest, categories = [], onPatch, onDele
       <div class="detail-body">
       ${tab === "clients" ? html`
         <${FileClients} hash=${d.hash} prefsKey="download_clients" defaultHidden=${DL_HIDDEN}
-                        defaultSort="downloaded" a4afEcids=${live(d).source_ecids || []}
+                        defaultSort="downloaded" a4afEcids=${live.source_ecids || []}
                         partsTotal=${d.total_part_count} files=${downloads} />
       ` : tab === "comments" ? html`
         <${DownloadComments} hash=${d.hash} comment=${d.my_comment} rating=${d.my_rating}
-                             running=${!!(downloads.find((x) => x.hash === d.hash) || {}).kad_comment_lookup_running}
+                             running=${!!live.kad_comment_lookup_running}
                              parts=${parts} />
       ` : tab === "filename" ? html`
         <${DownloadFilenames} hash=${d.hash} name=${d.name}


### PR DESCRIPTION
Closes #1283.

`download-detail.js` passed `a4afEcids` out of the `downloads/{hash}` detail
fetch. That fetch only re-runs when `liveTick` changes, and `liveTick` is the
constant `0` on every tab but Details, so on the Clients tab the effect ran once
on entry and never again: the `A4AF: <other file>` badges were right when the
tab opened and frozen from then on.

The live row already carries what is needed, and reading it costs no request:

- `Api.cpp:2977-2983` puts `source_ecids` on the list object so the SSE event
  brings it, with a comment saying that is why.
- `EventDiff.cpp:110-139` (`ToJsonDownloadEvent`) always writes the key, empty
  array included.
- `EventDiff.cpp:459` compares `a4af_sources` in `Equal()`, so a change really
  does emit `download_updated`.
- `events.js:255` applies deltas with `m.set(id, payload)` — whole-object
  replacement, not a partial merge — so the field cannot go missing from a row
  that exists.

This is the same pattern already used three lines below for
`kad_comment_lookup_running`, and it restores the behaviour
`client-table.js:297-300` documents: join-SSE, no polling.

Falls back to the detail snapshot when the hash is no longer in the list, so a
file removed while its panel is open renders its last known state rather than
dropping the badges.

Not covered: the web UI has no JS test harness, so this is verified by reading
the data path rather than by a test. `check-i18n.mjs` passes (975 keys) and the
file parses under `node --check`; neither exercises the change.
