### PR TITLE
refactor(web-ui): give the row key one owner

### DIFF
--- a/src/webapi/static/js/table.js
+++ b/src/webapi/static/js/table.js
@@ -261,13 +261,19 @@ export function VirtualTable({
 
   // Striping is keyed off the absolute row index, not :nth-child — a spacer <tr>
   // shifts parity, so app.css disables nth-child striping for .virtual tables.
-  const rowTr = (r, i) => html`
-    <tr key=${rowKey(r)}
+  // The key goes to the click handler too, so a caller that tracks a selected
+  // row never has to derive row identity a second time: the value it stores is
+  // the same one used for reconciliation here and for rowClass below.
+  const rowTr = (r, i) => {
+    const k = rowKey(r);
+    return html`
+    <tr key=${k}
         class=${(onRowClick ? "clickable " : "") + ((start + i) % 2 ? "stripe " : "") + (rowClass ? rowClass(r) : "")}
-        onClick=${onRowClick ? (e) => onRowClick(r, e) : null}
+        onClick=${onRowClick ? (e) => onRowClick(r, e, k) : null}
         style=${{ height: rowHeight + "px" }}>
       ${columns.map((c) => html`<td class=${colClass(c)}>${c.cell(r)}</td>`)}
     </tr>`;
+  };
 
   const spacer = (h) => h > 0
     ? html`<tr class="spacer" style=${{ height: h + "px" }}><td colspan=${ncols}></td></tr>` : null;

--- a/src/webapi/static/js/views/clients.js
+++ b/src/webapi/static/js/views/clients.js
@@ -26,8 +26,6 @@ const TAB_HIDDEN = {
 };
 const TAB_SORT = { active: "downloaded", downloading: "downloaded", uploading: "uploaded", known: "downloaded" };
 
-const rowKey = (c) => c.ecid != null ? c.ecid : c.user_hash;
-
 export default function ClientsPanel() {
   const raw = useClients(); // undefined until the first snapshot lands
   const clients = raw || [];
@@ -74,11 +72,12 @@ export default function ClientsPanel() {
     { key: "known", label: t("clients_tab_known"), badge: knownRaw ? knownRaw.length : null },
   ];
 
-  const onRowClick = (c, e) => {
+  // `key` comes from the table, which owns row identity (ecid, or user_hash on
+  // the Known tab where there is none). We only carry it back as selectedKey.
+  const onRowClick = (c, e, key) => {
     // A click on the row-actions buttons (View files / Send message) must not
     // also toggle the detail panel.
     if (e && e.target && e.target.closest(".row-actions")) return;
-    const key = rowKey(c);
     // A known row that is online resolves to its live ecid for the full detail;
     // offline, only the stored credit-store fields are available.
     const next = isKnown


### PR DESCRIPTION
Closes #1285.

`clients.js:29` and `client-table.js:277` each carried the same row-identity
expression, byte for byte:

```js
(c) => c.ecid != null ? c.ecid : c.user_hash
```

They had to agree. `clients.js` keyed its selection state with its copy;
`ClientTable` matched `selectedKey` against its own and also used it as the
`rowKey` for reconciliation. A divergence would have stopped the selected-row
highlight from ever appearing — no error, no exception, no test, just a
highlight that quietly never shows.

## Why the key moves

`ClientTable` already hands its function to the generic table as `rowKey`
(`client-table.js:287`), and `VirtualTable` already calls it for the row's `key`
(`table.js:265`). It just did not pass the result to the click handler, and that
was the only reason the panel had to derive it a second time.

Now it does, so `clients.js` carries a key it never interprets and
`client-table.js` is the only module that knows what identifies a row. The value
used for reconciliation, for `rowClass`, and for the selection is the same one
by construction rather than by two expressions happening to match.

## Scope

`table.js` computes the key once per row rather than twice, and appends it to
the handler call. Appending is backward compatible: `downloads.js:40` and
`shared.js:39` declare `(d, e)` and `(s, e)`, so they ignore a third argument
and are untouched.

`client-table.js` is unchanged and its `key` stays unexported.

## Verification

- Active rows key on the numeric `ecid`; Known rows have none, because
  `WriteKnownClientObject` never emits one, so they key on `user_hash`. Both
  paths were exercised, including the click-again-to-close toggle and the
  switch between two rows.
- `rowKey` is a required prop — `table.js:265` already called it unguarded — so
  no caller can reach the new argument without one.

Not covered: the web UI has no JS test harness, so this is verified by reading
the call chain and exercising the key logic in isolation, not by a test.
`check-i18n.mjs` passes and all five touched or dependent modules parse under
`node --check`; neither exercises the change.

