### PR TITLE
refactor(gui): delete the dead "User name" field from the EC login dialog

### DIFF
--- a/po/amule.pot
+++ b/po/amule.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-04 07:50+0200\n"
+"POT-Creation-Date: 2026-09-04 09:46+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -5234,10 +5234,6 @@ msgstr ""
 
 #: src/muuli_wdr.cpp
 msgid "Login to remote amule"
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "User name"
 msgstr ""
 
 #: src/muuli_wdr.cpp

--- a/po/ar.po
+++ b/po/ar.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-04 07:50+0200\n"
+"POT-Creation-Date: 2026-09-04 09:46+0200\n"
 "PO-Revision-Date: 2026-09-03 11:00+0000\n"
 "Last-Translator: saleh alhathal <hathalsal@hotmail.com>\n"
 "Language-Team: \n"
@@ -5308,10 +5308,6 @@ msgstr ""
 
 #: src/muuli_wdr.cpp
 msgid "Login to remote amule"
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "User name"
 msgstr ""
 
 #: src/muuli_wdr.cpp

--- a/po/ast.po
+++ b/po/ast.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-04 07:50+0200\n"
+"POT-Creation-Date: 2026-09-04 09:46+0200\n"
 "PO-Revision-Date: 2026-09-03 11:01+0000\n"
 "Last-Translator: astur <malditoastur@gmail.com>\n"
 "Language-Team: Language ast <malditoastur@gmail.com>\n"
@@ -5400,10 +5400,6 @@ msgid "Login to remote amule"
 msgstr "Conexón a aMule remotu"
 
 #: src/muuli_wdr.cpp
-msgid "User name"
-msgstr "Nome usuariu:"
-
-#: src/muuli_wdr.cpp
 msgid "Remember those settings"
 msgstr "Remembrar estes opciones"
 
@@ -9391,6 +9387,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "User name"
+#~ msgstr "Nome usuariu:"
 
 #~ msgid "Obtained Parts"
 #~ msgstr "Partes obteníes"

--- a/po/bg.po
+++ b/po/bg.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-04 07:50+0200\n"
+"POT-Creation-Date: 2026-09-04 09:46+0200\n"
 "PO-Revision-Date: 2026-09-03 11:01+0000\n"
 "Last-Translator: Sebastiano Pistore <SebastianoPistore.info@protonmail.ch>\n"
 "Language-Team: Bulgarian <dict@linux.zonebg.com>\n"
@@ -5297,10 +5297,6 @@ msgstr ""
 
 #: src/muuli_wdr.cpp
 msgid "Login to remote amule"
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "User name"
 msgstr ""
 
 #: src/muuli_wdr.cpp

--- a/po/bn.po
+++ b/po/bn.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-04 07:50+0200\n"
+"POT-Creation-Date: 2026-09-04 09:46+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -5233,10 +5233,6 @@ msgstr ""
 
 #: src/muuli_wdr.cpp
 msgid "Login to remote amule"
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "User name"
 msgstr ""
 
 #: src/muuli_wdr.cpp

--- a/po/ca.po
+++ b/po/ca.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-04 07:50+0200\n"
+"POT-Creation-Date: 2026-09-04 09:46+0200\n"
 "PO-Revision-Date: 2026-09-03 11:01+0000\n"
 "Last-Translator: minterior <minterior@gmail.com>\n"
 "Language-Team: Català\n"
@@ -5383,10 +5383,6 @@ msgid "Login to remote amule"
 msgstr "Entra a l'aMule remot"
 
 #: src/muuli_wdr.cpp
-msgid "User name"
-msgstr "Nom d'usuari"
-
-#: src/muuli_wdr.cpp
 msgid "Remember those settings"
 msgstr "Recorda la configuració"
 
@@ -9337,6 +9333,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "User name"
+#~ msgstr "Nom d'usuari"
 
 #~ msgid "Obtained Parts"
 #~ msgstr "Parts obtingudes"

--- a/po/cs.po
+++ b/po/cs.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-04 07:50+0200\n"
+"POT-Creation-Date: 2026-09-04 09:46+0200\n"
 "PO-Revision-Date: 2026-09-03 11:02+0000\n"
 "Last-Translator: David Watzke <david@watzke.cz>\n"
 "Language-Team: cs <cs@li.org>\n"
@@ -5368,10 +5368,6 @@ msgid "Login to remote amule"
 msgstr "Připojit k vzdálené aMuli"
 
 #: src/muuli_wdr.cpp
-msgid "User name"
-msgstr "Uživatelské jméno"
-
-#: src/muuli_wdr.cpp
 msgid "Remember those settings"
 msgstr "Zapamatovat si toto nastavení"
 
@@ -9316,6 +9312,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "User name"
+#~ msgstr "Uživatelské jméno"
 
 #~ msgid "Obtained Parts"
 #~ msgstr "Obdržené části"

--- a/po/da.po
+++ b/po/da.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-04 07:50+0200\n"
+"POT-Creation-Date: 2026-09-04 09:46+0200\n"
 "PO-Revision-Date: 2026-09-03 11:02+0000\n"
 "Last-Translator: Alex Thomsen Leth <alexl@stofanet.dk>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -5325,10 +5325,6 @@ msgstr ""
 
 #: src/muuli_wdr.cpp
 msgid "Login to remote amule"
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "User name"
 msgstr ""
 
 #: src/muuli_wdr.cpp

--- a/po/de.po
+++ b/po/de.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-04 07:50+0200\n"
+"POT-Creation-Date: 2026-09-04 09:46+0200\n"
 "PO-Revision-Date: 2026-09-03 11:02+0000\n"
 "Last-Translator: Werner Mahr <werner@vollstreckernet.de>\n"
 "Language-Team: German <>\n"
@@ -5380,10 +5380,6 @@ msgid "Login to remote amule"
 msgstr "Beim entfernten aMule anmelden"
 
 #: src/muuli_wdr.cpp
-msgid "User name"
-msgstr "Benutzername"
-
-#: src/muuli_wdr.cpp
 msgid "Remember those settings"
 msgstr "Diese Einstellungen speichern"
 
@@ -9351,6 +9347,9 @@ msgstr "aMule scheint zu laufen. Bitte schließen und das Entfernprogram erneut 
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "Entferne Benutzerdaten von $APPDATA\\aMule..."
+
+#~ msgid "User name"
+#~ msgstr "Benutzername"
 
 #~ msgid "Obtained Parts"
 #~ msgstr "Erhaltene Teile"

--- a/po/el.po
+++ b/po/el.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-04 07:50+0200\n"
+"POT-Creation-Date: 2026-09-04 09:46+0200\n"
 "PO-Revision-Date: 2026-09-03 11:02+0000\n"
 "Last-Translator: Dimitris <dgalanak@yahoo.com>\n"
 "Language-Team: Greek\n"
@@ -5411,10 +5411,6 @@ msgid "Login to remote amule"
 msgstr "Σύνδεση σε απομακρυσμένο amule"
 
 #: src/muuli_wdr.cpp
-msgid "User name"
-msgstr "Όνομα χρήστη"
-
-#: src/muuli_wdr.cpp
 msgid "Remember those settings"
 msgstr "Απομνημόνευση αυτών των ρυθμίσεων"
 
@@ -9409,6 +9405,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "User name"
+#~ msgstr "Όνομα χρήστη"
 
 #~ msgid "Obtained Parts"
 #~ msgstr "Κεκτημένα τμήματα"

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-04 07:50+0200\n"
+"POT-Creation-Date: 2026-09-04 09:46+0200\n"
 "PO-Revision-Date: 2020-03-04 14:43+0100\n"
 "Last-Translator: Dévai Tamás <devait@vnet.hu>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -5234,10 +5234,6 @@ msgstr ""
 
 #: src/muuli_wdr.cpp
 msgid "Login to remote amule"
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "User name"
 msgstr ""
 
 #: src/muuli_wdr.cpp

--- a/po/es.po
+++ b/po/es.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-04 07:50+0200\n"
+"POT-Creation-Date: 2026-09-04 09:46+0200\n"
 "PO-Revision-Date: 2026-09-03 11:03+0000\n"
 "Last-Translator: Diego Heras <ngosang@hotmail.es>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/amule/amule-application/es/>\n"
@@ -5350,10 +5350,6 @@ msgid "Login to remote amule"
 msgstr "Conexión a aMule remoto"
 
 #: src/muuli_wdr.cpp
-msgid "User name"
-msgstr "Nombre de usuario"
-
-#: src/muuli_wdr.cpp
 msgid "Remember those settings"
 msgstr "Recordar estas opciones"
 
@@ -9281,6 +9277,9 @@ msgstr "aMule parece estar en ejecución. Por favor, ciérrelo y vuelva a ejecut
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "Eliminando los datos de usuario en $APPDATA\\aMule..."
+
+#~ msgid "User name"
+#~ msgstr "Nombre de usuario"
 
 #~ msgid "Obtained Parts"
 #~ msgstr "Partes obtenidas"

--- a/po/et_EE.po
+++ b/po/et_EE.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-04 07:50+0200\n"
+"POT-Creation-Date: 2026-09-04 09:46+0200\n"
 "PO-Revision-Date: 2026-09-03 11:03+0000\n"
 "Last-Translator: \n"
 "Language-Team: Estonian <kde-i18n-doc@kde.org>\n"
@@ -5384,10 +5384,6 @@ msgid "Login to remote amule"
 msgstr "Logi sisse eemalasuvasse amuula"
 
 #: src/muuli_wdr.cpp
-msgid "User name"
-msgstr "Kasutaja nimi"
-
-#: src/muuli_wdr.cpp
 msgid "Remember those settings"
 msgstr "Pea need seaded meeles"
 
@@ -9339,6 +9335,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "User name"
+#~ msgstr "Kasutaja nimi"
 
 #~ msgid "Obtained Parts"
 #~ msgstr "Saadud osi"

--- a/po/eu.po
+++ b/po/eu.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-04 07:50+0200\n"
+"POT-Creation-Date: 2026-09-04 09:46+0200\n"
 "PO-Revision-Date: 2026-09-03 11:04+0000\n"
 "Last-Translator: Piarres Beobide <pi@beobide.net>\n"
 "Language-Team: Euskara <librezale@librezale.org>\n"
@@ -5384,10 +5384,6 @@ msgid "Login to remote amule"
 msgstr "Urruneko aMulen saioa hasi"
 
 #: src/muuli_wdr.cpp
-msgid "User name"
-msgstr "Erabiltzaile izena"
-
-#: src/muuli_wdr.cpp
 msgid "Remember those settings"
 msgstr "Ezarpen hauek gogoratu"
 
@@ -9339,6 +9335,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "User name"
+#~ msgstr "Erabiltzaile izena"
 
 #~ msgid "Obtained Parts"
 #~ msgstr "Eskuratutako zatiak"

--- a/po/fi.po
+++ b/po/fi.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-04 07:50+0200\n"
+"POT-Creation-Date: 2026-09-04 09:46+0200\n"
 "PO-Revision-Date: 2026-09-03 11:04+0000\n"
 "Last-Translator: Tapio Rantala <tapio.rantala@iki.fi>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -5384,10 +5384,6 @@ msgid "Login to remote amule"
 msgstr "Kirjaudu etä-aMuleen"
 
 #: src/muuli_wdr.cpp
-msgid "User name"
-msgstr "Käyttäjänimi"
-
-#: src/muuli_wdr.cpp
 msgid "Remember those settings"
 msgstr "Muista nämä asetukset"
 
@@ -9339,6 +9335,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "User name"
+#~ msgstr "Käyttäjänimi"
 
 #~ msgid "Obtained Parts"
 #~ msgstr "Hankitut osat"

--- a/po/fr.po
+++ b/po/fr.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-04 07:50+0200\n"
+"POT-Creation-Date: 2026-09-04 09:46+0200\n"
 "PO-Revision-Date: 2026-09-03 11:04+0000\n"
 "Last-Translator: Dylan Aïssi <bob.dybian@gmail.com>\n"
 "Language-Team: Français\n"
@@ -5345,10 +5345,6 @@ msgid "Login to remote amule"
 msgstr "Connexion distante à aMule"
 
 #: src/muuli_wdr.cpp
-msgid "User name"
-msgstr "Nom d'utilisateur"
-
-#: src/muuli_wdr.cpp
 msgid "Remember those settings"
 msgstr "Se rappeler de ces réglages"
 
@@ -9281,6 +9277,9 @@ msgstr "aMule semble être en cours d'exécution. Veuillez le fermer et relancer
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "Suppression des données d'utilisateur sur $APPDATA\\aMule…"
+
+#~ msgid "User name"
+#~ msgstr "Nom d'utilisateur"
 
 #~ msgid "Obtained Parts"
 #~ msgstr "Parties obtenues"

--- a/po/gl.po
+++ b/po/gl.po
@@ -24,7 +24,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-04 07:50+0200\n"
+"POT-Creation-Date: 2026-09-04 09:46+0200\n"
 "PO-Revision-Date: 2026-09-03 11:05+0000\n"
 "Last-Translator: Pablo <parodper@gmail.com>\n"
 "Language-Team: http://forum.amule.org/index.php?topic=13883\n"
@@ -5393,10 +5393,6 @@ msgid "Login to remote amule"
 msgstr "Conectar a amule remoto"
 
 #: src/muuli_wdr.cpp
-msgid "User name"
-msgstr "Nome de usuario"
-
-#: src/muuli_wdr.cpp
 msgid "Remember those settings"
 msgstr "Recordar esas opcións"
 
@@ -9361,6 +9357,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "User name"
+#~ msgstr "Nome de usuario"
 
 #~ msgid "Obtained Parts"
 #~ msgstr "Partes obtidas"

--- a/po/he.po
+++ b/po/he.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-04 07:50+0200\n"
+"POT-Creation-Date: 2026-09-04 09:46+0200\n"
 "PO-Revision-Date: 2026-09-03 11:05+0000\n"
 "Last-Translator: Peace Kramer <kpeace1@gmail.com>\n"
 "Language-Team: Hebrew\n"
@@ -5345,10 +5345,6 @@ msgstr ""
 
 #: src/muuli_wdr.cpp
 msgid "Login to remote amule"
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "User name"
 msgstr ""
 
 #: src/muuli_wdr.cpp

--- a/po/hr.po
+++ b/po/hr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-04 07:50+0200\n"
+"POT-Creation-Date: 2026-09-04 09:46+0200\n"
 "PO-Revision-Date: 2026-09-03 11:05+0000\n"
 "Last-Translator: Sebastiano Pistore <sebastiano.pistore.info@aol.com>\n"
 "Language-Team: https://github.com/amule-org/amule <forum@aMule.org>\n"
@@ -5342,10 +5342,6 @@ msgid "Login to remote amule"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "User name"
-msgstr "Korisničko ime"
-
-#: src/muuli_wdr.cpp
 msgid "Remember those settings"
 msgstr ""
 
@@ -9259,6 +9255,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "User name"
+#~ msgstr "Korisničko ime"
 
 #~ msgid "Obtained Parts"
 #~ msgstr "Dobiveni dijelovi"

--- a/po/hu.po
+++ b/po/hu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-04 07:50+0200\n"
+"POT-Creation-Date: 2026-09-04 09:46+0200\n"
 "PO-Revision-Date: 2026-09-03 11:05+0000\n"
 "Last-Translator: Dévai Tamás <gonosztopi@amule.org>\n"
 "Language-Team: Hungarian <hu@li.org>\n"
@@ -5367,10 +5367,6 @@ msgid "Login to remote amule"
 msgstr "Bejeletkezés a távoli amule-ra"
 
 #: src/muuli_wdr.cpp
-msgid "User name"
-msgstr "Felhasználói név"
-
-#: src/muuli_wdr.cpp
 msgid "Remember those settings"
 msgstr "Emlékezzen ezekre a beállításokra"
 
@@ -9293,6 +9289,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "User name"
+#~ msgstr "Felhasználói név"
 
 #~ msgid "Obtained Parts"
 #~ msgstr "Megszerzett részek"

--- a/po/it.po
+++ b/po/it.po
@@ -19,7 +19,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule 2.3.3\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-04 07:50+0200\n"
+"POT-Creation-Date: 2026-09-04 09:46+0200\n"
 "PO-Revision-Date: 2026-09-03 11:06+0000\n"
 "Last-Translator: got3nks <got3nks@users.noreply.github.com>\n"
 "Language-Team: SebastianoPistore.info@protonmail.ch\n"
@@ -5352,10 +5352,6 @@ msgid "Login to remote amule"
 msgstr "Login su aMule remoto"
 
 #: src/muuli_wdr.cpp
-msgid "User name"
-msgstr "Nome utente"
-
-#: src/muuli_wdr.cpp
 msgid "Remember those settings"
 msgstr "Ricorda impostazioni"
 
@@ -9288,6 +9284,9 @@ msgstr "Sembra che aMule sia in esecuzione. Chiudilo e riavvia il programma di d
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "Rimozione dei dati utente in $APPDATA\\aMule..."
+
+#~ msgid "User name"
+#~ msgstr "Nome utente"
 
 #~ msgid "Obtained Parts"
 #~ msgstr "Parti ricevute"

--- a/po/ja.po
+++ b/po/ja.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-04 07:50+0200\n"
+"POT-Creation-Date: 2026-09-04 09:46+0200\n"
 "PO-Revision-Date: 2026-09-03 11:06+0000\n"
 "Last-Translator: \n"
 "Language-Team: Japanese\n"
@@ -5380,10 +5380,6 @@ msgid "Login to remote amule"
 msgstr "リモートamuleにログインする"
 
 #: src/muuli_wdr.cpp
-msgid "User name"
-msgstr "ユーザ名"
-
-#: src/muuli_wdr.cpp
 msgid "Remember those settings"
 msgstr "設定を記憶する"
 
@@ -9325,6 +9321,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "User name"
+#~ msgstr "ユーザ名"
 
 #~ msgid "Obtained Parts"
 #~ msgstr "得られた部分"

--- a/po/ko_KR.po
+++ b/po/ko_KR.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-04 07:50+0200\n"
+"POT-Creation-Date: 2026-09-04 09:46+0200\n"
 "PO-Revision-Date: 2026-09-03 11:06+0000\n"
 "Last-Translator: Hyunju Kang <rexington@gmail.com>\n"
 "Language-Team: Korean <hoenny@daum.net>\n"
@@ -5403,10 +5403,6 @@ msgid "Login to remote amule"
 msgstr "원격 어뮬에 로그인"
 
 #: src/muuli_wdr.cpp
-msgid "User name"
-msgstr "사용자이름"
-
-#: src/muuli_wdr.cpp
 msgid "Remember those settings"
 msgstr "설정을 기억"
 
@@ -9389,6 +9385,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "User name"
+#~ msgstr "사용자이름"
 
 #~ msgid "Obtained Parts"
 #~ msgstr "획득한 부분"

--- a/po/lt.po
+++ b/po/lt.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-04 07:50+0200\n"
+"POT-Creation-Date: 2026-09-04 09:46+0200\n"
 "PO-Revision-Date: 2026-09-03 11:07+0000\n"
 "Last-Translator: Dovydas Sankauskas <laisve@gmail.com>\n"
 "Language-Team: Lithuanian <komp_lt@konf.lt>\n"
@@ -5423,10 +5423,6 @@ msgid "Login to remote amule"
 msgstr "Prisijungti prie nutolusios aMule"
 
 #: src/muuli_wdr.cpp
-msgid "User name"
-msgstr "Naudotojo vardas"
-
-#: src/muuli_wdr.cpp
 msgid "Remember those settings"
 msgstr "Įsiminti parinktis"
 
@@ -9442,6 +9438,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "User name"
+#~ msgstr "Naudotojo vardas"
 
 #~ msgid "Obtained Parts"
 #~ msgstr "Gautos dalys"

--- a/po/lv.po
+++ b/po/lv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-04 07:50+0200\n"
+"POT-Creation-Date: 2026-09-04 09:46+0200\n"
 "PO-Revision-Date: 2026-09-03 11:13+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -5265,10 +5265,6 @@ msgid "Login to remote amule"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "User name"
-msgstr "Lietotājvārds"
-
-#: src/muuli_wdr.cpp
 msgid "Remember those settings"
 msgstr ""
 
@@ -9117,6 +9113,9 @@ msgstr "Izskatās, ka aMule darbojas. Lūdzu, aizveriet to un vēlreiz palaidiet
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "Dzēš lietotāja datus, kas atrodas $APPDATA\\aMule mapē…"
+
+#~ msgid "User name"
+#~ msgstr "Lietotājvārds"
 
 #~ msgid " MB/s"
 #~ msgstr " MB/s"

--- a/po/nl.po
+++ b/po/nl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-04 07:50+0200\n"
+"POT-Creation-Date: 2026-09-04 09:46+0200\n"
 "PO-Revision-Date: 2026-09-03 11:07+0000\n"
 "Last-Translator: Marcel Pol <marcel@timelord.nl>\n"
 "Language-Team: Dutch <nl@li.org>\n"
@@ -5343,10 +5343,6 @@ msgid "Login to remote amule"
 msgstr "Inloggen op amule op afstand"
 
 #: src/muuli_wdr.cpp
-msgid "User name"
-msgstr "Gebruikersnaam"
-
-#: src/muuli_wdr.cpp
 msgid "Remember those settings"
 msgstr "Onthoud deze instellingen"
 
@@ -9283,6 +9279,9 @@ msgstr "aMule lijkt te worden uitgevoerd. Sluit het en voer het verwijderprogram
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "Gebruikersgegevens op $APPDATA\\aMule worden verwijderd..."
+
+#~ msgid "User name"
+#~ msgstr "Gebruikersnaam"
 
 #~ msgid "Obtained Parts"
 #~ msgstr "Ontvangen delen"

--- a/po/nn.po
+++ b/po/nn.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-04 07:50+0200\n"
+"POT-Creation-Date: 2026-09-04 09:46+0200\n"
 "PO-Revision-Date: 2026-09-03 11:08+0000\n"
 "Last-Translator: Hallvor Brunstad <Hallvor_1976@yahoo.com>\n"
 "Language-Team: <i18n-nn@lister.ping.uio.no>\n"
@@ -5405,10 +5405,6 @@ msgid "Login to remote amule"
 msgstr "Logge inn på fjern aMule"
 
 #: src/muuli_wdr.cpp
-msgid "User name"
-msgstr "Brukarnamn"
-
-#: src/muuli_wdr.cpp
 msgid "Remember those settings"
 msgstr "Hugs desse innstillingane"
 
@@ -9399,6 +9395,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "User name"
+#~ msgstr "Brukarnamn"
 
 #~ msgid "Obtained Parts"
 #~ msgstr "Nedlasta delar"

--- a/po/pl.po
+++ b/po/pl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-04 07:50+0200\n"
+"POT-Creation-Date: 2026-09-04 09:46+0200\n"
 "PO-Revision-Date: 2026-09-03 11:08+0000\n"
 "Last-Translator: Michał Trzebiatowski <hippie_1968@hotmail.com>\n"
 "Language-Team: translationproject.org/team/pl.html <translation-team-pl@lists.sourceforge.net>\n"
@@ -5404,10 +5404,6 @@ msgid "Login to remote amule"
 msgstr "Login do zdalnego amule"
 
 #: src/muuli_wdr.cpp
-msgid "User name"
-msgstr "Nazwa użytkownika"
-
-#: src/muuli_wdr.cpp
 msgid "Remember those settings"
 msgstr "Zapamiętaj te ustawienia"
 
@@ -9401,6 +9397,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "User name"
+#~ msgstr "Nazwa użytkownika"
 
 #~ msgid "Obtained Parts"
 #~ msgstr "Otrzymane części"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-04 07:50+0200\n"
+"POT-Creation-Date: 2026-09-04 09:46+0200\n"
 "PO-Revision-Date: 2026-09-03 11:08+0000\n"
 "Last-Translator: Marcelo Jimenez <mroberto@users.sourceforge.com>\n"
 "Language-Team: Português (Brasileiro) <pt@li.org>\n"
@@ -5346,10 +5346,6 @@ msgid "Login to remote amule"
 msgstr "Fazer login em amule remoto"
 
 #: src/muuli_wdr.cpp
-msgid "User name"
-msgstr "Usuário"
-
-#: src/muuli_wdr.cpp
 msgid "Remember those settings"
 msgstr "Lembrar essas definições"
 
@@ -9282,6 +9278,9 @@ msgstr "O aMule parece estar rodando. Por favor, feche-o e rode o desinstalador 
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "Removendo os dados do usuário em $APPDATA\\aMule..."
+
+#~ msgid "User name"
+#~ msgstr "Usuário"
 
 #~ msgid "Obtained Parts"
 #~ msgstr "Partes já baixadas"

--- a/po/pt_PT.po
+++ b/po/pt_PT.po
@@ -17,7 +17,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-04 07:50+0200\n"
+"POT-Creation-Date: 2026-09-04 09:46+0200\n"
 "PO-Revision-Date: 2026-09-03 11:09+0000\n"
 "Last-Translator: Luís Picciochi Oliveira <Pitxyoki@Gmail.com>\n"
 "Language-Team: Portuguese <traduz@debianpt.org>\n"
@@ -5391,10 +5391,6 @@ msgid "Login to remote amule"
 msgstr "Autenticação remota"
 
 #: src/muuli_wdr.cpp
-msgid "User name"
-msgstr "Nome de utilizador"
-
-#: src/muuli_wdr.cpp
 msgid "Remember those settings"
 msgstr "Lembrar estas preferências"
 
@@ -9348,6 +9344,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "User name"
+#~ msgstr "Nome de utilizador"
 
 #~ msgid "Obtained Parts"
 #~ msgstr "Partes Obtidas"

--- a/po/ro.po
+++ b/po/ro.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-04 07:50+0200\n"
+"POT-Creation-Date: 2026-09-04 09:46+0200\n"
 "PO-Revision-Date: 2026-09-03 11:09+0000\n"
 "Last-Translator: Angelescu Constantin <titus0818@yahoo.com>\n"
 "Language-Team: English <kde-i18n-doc@kde.org>\n"
@@ -5397,10 +5397,6 @@ msgid "Login to remote amule"
 msgstr "Autentificare la amule distant"
 
 #: src/muuli_wdr.cpp
-msgid "User name"
-msgstr "Nume utilizator"
-
-#: src/muuli_wdr.cpp
 msgid "Remember those settings"
 msgstr "Amintește aceste configurări"
 
@@ -9379,6 +9375,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "User name"
+#~ msgstr "Nume utilizator"
 
 #~ msgid "Obtained Parts"
 #~ msgstr "Părți obținute"

--- a/po/ru.po
+++ b/po/ru.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-04 07:50+0200\n"
+"POT-Creation-Date: 2026-09-04 09:46+0200\n"
 "PO-Revision-Date: 2026-09-03 11:09+0000\n"
 "Last-Translator: Radist Morse <radist.morse@gmail.com>\n"
 "Language-Team: Russian <kde-russian@lists.kde.ru>\n"
@@ -5384,10 +5384,6 @@ msgid "Login to remote amule"
 msgstr "Войти на удалённый aMule"
 
 #: src/muuli_wdr.cpp
-msgid "User name"
-msgstr "Имя пользователя"
-
-#: src/muuli_wdr.cpp
 msgid "Remember those settings"
 msgstr "Запомнить эти настройки"
 
@@ -9361,6 +9357,9 @@ msgstr "Похоже, что aMule запущен. Закройте его и п
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "Удаление пользовательских данных в $APPDATA\\aMule…"
+
+#~ msgid "User name"
+#~ msgstr "Имя пользователя"
 
 #~ msgid "Obtained Parts"
 #~ msgstr "Полученные части"

--- a/po/sl.po
+++ b/po/sl.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-04 07:50+0200\n"
+"POT-Creation-Date: 2026-09-04 09:46+0200\n"
 "PO-Revision-Date: 2026-09-03 11:10+0000\n"
 "Last-Translator: Jure Repinc <jlp@holodeck1.com>\n"
 "Language-Team: Slovenian\n"
@@ -5425,10 +5425,6 @@ msgid "Login to remote amule"
 msgstr "Prijavi se pri oddaljenem aMule"
 
 #: src/muuli_wdr.cpp
-msgid "User name"
-msgstr "Uporabniško ime"
-
-#: src/muuli_wdr.cpp
 msgid "Remember those settings"
 msgstr "Zapomni si te nastavitve"
 
@@ -9432,6 +9428,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "User name"
+#~ msgstr "Uporabniško ime"
 
 #~ msgid "Obtained Parts"
 #~ msgstr "Dobljeni deli"

--- a/po/sq.po
+++ b/po/sq.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-04 07:50+0200\n"
+"POT-Creation-Date: 2026-09-04 09:46+0200\n"
 "PO-Revision-Date: 2026-09-03 11:10+0000\n"
 "Last-Translator: Fation <dj_barthezz@linuxmail.org lushnja_corps@hotmail.Language-Team:\n"
 "Language: sq\n"
@@ -5397,10 +5397,6 @@ msgid "Login to remote amule"
 msgstr "Futu tek Remote i aMule"
 
 #: src/muuli_wdr.cpp
-msgid "User name"
-msgstr "Emri i Perdoruesit"
-
-#: src/muuli_wdr.cpp
 msgid "Remember those settings"
 msgstr "Mbaji mend keto rregullime"
 
@@ -9370,6 +9366,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "User name"
+#~ msgstr "Emri i Perdoruesit"
 
 #~ msgid "Obtained Parts"
 #~ msgstr "Pjese te marra"

--- a/po/sv.po
+++ b/po/sv.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-04 07:50+0200\n"
+"POT-Creation-Date: 2026-09-04 09:46+0200\n"
 "PO-Revision-Date: 2026-09-03 11:10+0000\n"
 "Last-Translator: raffe <raffe@localhost.se>\n"
 "Language-Team: Swedish <tp-sv@listor.tp-sv.se>\n"
@@ -5382,10 +5382,6 @@ msgid "Login to remote amule"
 msgstr "Logga in på fjärr-amule"
 
 #: src/muuli_wdr.cpp
-msgid "User name"
-msgstr "Användarnamn"
-
-#: src/muuli_wdr.cpp
 msgid "Remember those settings"
 msgstr "Kom ihåg dessa inställningar"
 
@@ -9336,6 +9332,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "User name"
+#~ msgstr "Användarnamn"
 
 #~ msgid "Obtained Parts"
 #~ msgstr "Erhållna delar"

--- a/po/ta.po
+++ b/po/ta.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-04 07:50+0200\n"
+"POT-Creation-Date: 2026-09-04 09:46+0200\n"
 "PO-Revision-Date: 2026-09-03 11:13+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -5233,10 +5233,6 @@ msgstr ""
 
 #: src/muuli_wdr.cpp
 msgid "Login to remote amule"
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "User name"
 msgstr ""
 
 #: src/muuli_wdr.cpp

--- a/po/tr.po
+++ b/po/tr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-04 07:50+0200\n"
+"POT-Creation-Date: 2026-09-04 09:46+0200\n"
 "PO-Revision-Date: 2026-09-03 11:11+0000\n"
 "Last-Translator: \n"
 "Language-Team: Turkish <li@li.org>\n"
@@ -5338,10 +5338,6 @@ msgid "Login to remote amule"
 msgstr "Uzaktan aMule'ye giriş yapınız."
 
 #: src/muuli_wdr.cpp
-msgid "User name"
-msgstr "Kullanıcı adı"
-
-#: src/muuli_wdr.cpp
 msgid "Remember those settings"
 msgstr "Bu ayarları hatırla"
 
@@ -9274,6 +9270,9 @@ msgstr "aMule çalışmakta gibi görünüyor. Lütfen onu kapatıp kurulum prog
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "Kullanıcı verileri $APPDATA\\aMule konumunda kaldırılıyor…"
+
+#~ msgid "User name"
+#~ msgstr "Kullanıcı adı"
 
 #~ msgid "Obtained Parts"
 #~ msgstr "Alınan Parçalar"

--- a/po/uk.po
+++ b/po/uk.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-04 07:50+0200\n"
+"POT-Creation-Date: 2026-09-04 09:46+0200\n"
 "PO-Revision-Date: 2026-09-03 11:11+0000\n"
 "Last-Translator: Oleksandr Kovalenko <alx.kovalenko@gmail.com>\n"
 "Language-Team: Ukrainian <translation@linux.org.ua>\n"
@@ -5424,10 +5424,6 @@ msgid "Login to remote amule"
 msgstr "Вхід до віддаленого aMule"
 
 #: src/muuli_wdr.cpp
-msgid "User name"
-msgstr "Ім'я користувача"
-
-#: src/muuli_wdr.cpp
 msgid "Remember those settings"
 msgstr "Запам'ятати ці налаштування"
 
@@ -9447,6 +9443,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "User name"
+#~ msgstr "Ім'я користувача"
 
 #~ msgid "Obtained Parts"
 #~ msgstr "Отримані частини"

--- a/po/vi.po
+++ b/po/vi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-04 07:50+0200\n"
+"POT-Creation-Date: 2026-09-04 09:46+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -5228,10 +5228,6 @@ msgstr ""
 
 #: src/muuli_wdr.cpp
 msgid "Login to remote amule"
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "User name"
 msgstr ""
 
 #: src/muuli_wdr.cpp

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-04 07:50+0200\n"
+"POT-Creation-Date: 2026-09-04 09:46+0200\n"
 "PO-Revision-Date: 2026-09-03 11:12+0000\n"
 "Last-Translator: Mike Akiba <mike2718@gmail.com>\n"
 "Language-Team: Chinese Simplified <kde-i18n-doc@kde.org>\n"
@@ -5342,10 +5342,6 @@ msgid "Login to remote amule"
 msgstr "登录远程 amule"
 
 #: src/muuli_wdr.cpp
-msgid "User name"
-msgstr "用户名"
-
-#: src/muuli_wdr.cpp
 msgid "Remember those settings"
 msgstr "记住这些设置"
 
@@ -9275,6 +9271,9 @@ msgstr "aMule 似乎正在运行。请将其关闭并重新运行卸载程序。
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "正在删除 $APPDATA\\aMule 中的用户数据..."
+
+#~ msgid "User name"
+#~ msgstr "用户名"
 
 #~ msgid "Obtained Parts"
 #~ msgstr "已获取的部分"

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-04 07:50+0200\n"
+"POT-Creation-Date: 2026-09-04 09:46+0200\n"
 "PO-Revision-Date: 2026-09-03 11:12+0000\n"
 "Last-Translator: Wayne Su <mstarmstar@gmail.com>\n"
 "Language-Team: \n"
@@ -5371,10 +5371,6 @@ msgid "Login to remote amule"
 msgstr "登入遠端 amule"
 
 #: src/muuli_wdr.cpp
-msgid "User name"
-msgstr "使用者名稱"
-
-#: src/muuli_wdr.cpp
 msgid "Remember those settings"
 msgstr "記住這些設定"
 
@@ -9298,6 +9294,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "User name"
+#~ msgstr "使用者名稱"
 
 #~ msgid "Obtained Parts"
 #~ msgstr "已獲得部分"

--- a/src/ExternalConnector.cpp
+++ b/src/ExternalConnector.cpp
@@ -469,8 +469,11 @@ void CaMuleExternalConnector::ConnectAndRun(const wxString &ProgName, const wxSt
 		m_ECClient->SetConnectTimeout(15000);
 
 		// ConnectToCore is blocking since m_ECClient was initialized with NULL
+		// m_port is parsed as a long (the option parser's type) and the EC
+		// client takes an int; the value is range-checked when it is read,
+		// so the cast is a narrowing the compiler should not have to guess at.
 		if (!m_ECClient->ConnectToCore(
-			    m_host, m_port, "foobar", m_password.Encode(), ProgName, ProgVersion)) {
+			    m_host, static_cast<int>(m_port), m_password.Encode(), ProgName, ProgVersion)) {
 			// no connection => close gracefully
 			if (!m_ECClient->GetServerReply().IsEmpty()) {
 				Show(CFormat("%s\n") % m_ECClient->GetServerReply());

--- a/src/amule-remote-gui.cpp
+++ b/src/amule-remote-gui.cpp
@@ -713,12 +713,8 @@ bool CamuleRemoteGuiApp::ShowConnectionDialog()
 		// on the fresh object right here.
 		m_connect->SetForceZlib(dialog->ForceZlib());
 		m_connect->SetCanAEAD(dialog->Encryption());
-		if (m_connect->ConnectToCore(dialog->Host(),
-			    dialog->Port(),
-			    dialog->Login(),
-			    dialog->PassHash(),
-			    "amule-remote",
-			    "0x0001")) {
+		if (m_connect->ConnectToCore(
+			    dialog->Host(), dialog->Port(), dialog->PassHash(), "amule-remote", "0x0001")) {
 			// Sync part succeeded; async OnECConnection will
 			// resolve the auth outcome.
 			return true;
@@ -1086,8 +1082,7 @@ void CamuleRemoteGuiApp::AttemptReconnect()
 	connect_timeout_timer = new wxTimer(this, ID_REMOTE_CONNECT_TIMEOUT_TIMER);
 	connect_timeout_timer->StartOnce(15000);
 
-	if (!m_connect->ConnectToCore(
-		    m_ecHost, m_ecPort, wxEmptyString, m_ecPass, "amule-remote", "0x0001")) {
+	if (!m_connect->ConnectToCore(m_ecHost, m_ecPort, m_ecPass, "amule-remote", "0x0001")) {
 		// Couldn't even initiate the connect — space out the next attempt.
 		AddLogLineCS(_("Reconnect could not start; retrying shortly."));
 		delete connect_timeout_timer;

--- a/src/amule-remote-gui.h
+++ b/src/amule-remote-gui.h
@@ -61,7 +61,7 @@ class CEConnectDlg : public wxDialog
 	int port;
 
 	wxString pwd_hash;
-	wxString login, passwd;
+	wxString passwd;
 	bool m_save_user_pass;
 	bool m_force_zlib;
 	bool m_encryption;
@@ -76,7 +76,6 @@ public:
 	wxString Host() { return host; }
 	int Port() { return port; }
 
-	wxString Login() { return login; }
 	wxString PassHash();
 	bool SaveUserPass() { return m_save_user_pass; }
 	bool ForceZlib() { return m_force_zlib; }

--- a/src/libs/ec/cpp/RemoteConnect.cpp
+++ b/src/libs/ec/cpp/RemoteConnect.cpp
@@ -240,12 +240,8 @@ void CRemoteConnect::SetCapabilities(bool canZLIB, bool canUTF8numbers, bool can
 	m_canNotify = canNotify;
 }
 
-bool CRemoteConnect::ConnectToCore(const wxString &host,
-	int port,
-	const wxString &WXUNUSED(login),
-	const wxString &pass,
-	const wxString &client,
-	const wxString &version)
+bool CRemoteConnect::ConnectToCore(
+	const wxString &host, int port, const wxString &pass, const wxString &client, const wxString &version)
 {
 	m_connectionPassword = pass;
 	// Both ends hold md5(password) and neither sends it; the salted challenge

--- a/src/libs/ec/cpp/RemoteConnect.h
+++ b/src/libs/ec/cpp/RemoteConnect.h
@@ -354,9 +354,12 @@ public:
 
 	bool ServerSupportsSearchProgressUnion() const { return m_serverSearchProgressUnion; }
 
+	// No `login`: EC authenticates on the password alone. The parameter
+	// existed since 2005, was declared WXUNUSED in the definition, and the
+	// three callers passed an empty string, a dialog field that was never
+	// filled in, and the literal "foobar" (issue #1266).
 	bool ConnectToCore(const wxString &host,
 		int port,
-		const wxString &login,
 		const wxString &pass,
 		const wxString &client,
 		const wxString &version);

--- a/src/muuli_wdr.cpp
+++ b/src/muuli_wdr.cpp
@@ -3258,11 +3258,6 @@ wxSizer *CoreConnect( wxWindow *parent, bool call_fit, bool set_sizer )
 
     wxFlexGridSizer *item8 = new wxFlexGridSizer( 2, 0, 0 );
 
-    wxStaticText *item9 = new wxStaticText( parent, -1, _("User name"), wxDefaultPosition, wxDefaultSize, 0 );
-    item8->Add( item9, wxSizerFlags().CenterVertical().Border(wxALL, 5) );
-    CMuleTextCtrl *item10 = new CMuleTextCtrl( parent, ID_EC_LOGIN, "amule", wxDefaultPosition, wxSize(200,-1), 0 );
-    item10->Enable( false );
-    item8->Add( item10, wxSizerFlags().Center().Border(wxALL, 5) );
     wxStaticText *item11 = new wxStaticText( parent, -1, _("Password"), wxDefaultPosition, wxDefaultSize, 0 );
     item8->Add( item11, wxSizerFlags().CenterVertical().Border(wxALL, 5) );
     CMuleTextCtrl *item12 = new CMuleTextCtrl( parent, ID_EC_PASSWD, "", wxDefaultPosition, wxSize(200,-1), wxTE_PASSWORD );

--- a/src/muuli_wdr.h
+++ b/src/muuli_wdr.h
@@ -584,7 +584,6 @@ wxSizer *PreferencesProxyTab(wxWindow *parent, bool call_fit = TRUE, bool set_si
 
 #define ID_REMOTE_HOST 10301
 #define ID_REMOTE_PORT 10302
-#define ID_EC_LOGIN 10303
 #define ID_EC_PASSWD 10304
 #define ID_EC_SAVE 10305
 #define ID_EC_FORCE_ZLIB 10344


### PR DESCRIPTION
Closes #1266.

The amulegui connect dialog carried a "User name" box, greyed out and hardcoded to `"amule"`. The issue asked whether it was ever used; it never was, so per the discussion there it goes.

## Why it was inert

EC has no notion of a user: authentication is the EC password alone, exchanged as a salted MD5 challenge. `EC_TAG_CLIENT_NAME` in the login packet is the client's product name for the daemon's log line ("Connecting client: amulegui 3.x"), not an identity.

The widget matched that. `CEConnectDlg::OnOK()` read host, port, password and the checkboxes and never assigned the member behind the field, so `Login()` returned an empty string, and `CRemoteConnect::ConnectToCore()` declared the parameter `WXUNUSED` and discarded it. That has been true since the field arrived with the "Connection settings" dialog in February 2005 (`ba3cfc0338606a7ae08578ca29dbdf33e4374af4`) -- `login` was already unassigned in that same commit.

## What is removed

- The label and text control from `CoreConnect()`, and `ID_EC_LOGIN` with them.
- `CEConnectDlg::Login()` and the `login` member it read.
- The `login` parameter of `ConnectToCore()`. Deleting only the widget would have left the dead parameter behind, and its three callers were passing an empty string, the dialog field that was never filled in, and the literal `"foobar"` -- none of which reached the wire.

One incidental fix: `CaMuleExternalConnector` holds the port as a `long` and `ConnectToCore` takes an `int`, so reflowing that call brought a pre-existing narrowing under the changed-lines tidy gate. It is an explicit `static_cast<int>` now.

## Catalogs

`./scripts/update-po.sh` regenerated `amule.pot` and all 40 `po/*.po`. I checked the result entry by entry rather than trusting the diff size: **the only active msgid any catalog loses is `"User name"`**, nothing is added, and the only msgstr that changes anywhere is the header, which is the volatile metadata the sync gate already filters. The translated strings become obsolete `#~` entries, so a future re-use of the same English string would pick them up again.

## Testing

- Builds clean: `amule`, `amulegui`, `amuled`, `amulecmd`.
- `amulegui` starts and shows the dialog with no wx assertions; the reporter confirmed visually that the field is gone and the dialog looks right.
- `amulecmd` authenticates against a daemon on the changed signature, which is the call site that had been passing `"foobar"`.
- cf18 clean on all seven changed sources; Tier-2 clang-tidy diff clean with 0 compiler errors.
