### PR TITLE
feat(net): recognise eMuleAI peer capabilities and demux reserved frames

### DIFF
--- a/docs/EC_Protocol.md
+++ b/docs/EC_Protocol.md
@@ -624,3 +624,30 @@ from the session's absence in the next `EC_OP_CHAT_SESSIONS` reply.
 > gigabit connections. EC clients reading these tags should use
 > `GetInt()` (which handles any integer width); clients sending them
 > should encode them as 32-bit values.
+
+### Peer vendor capabilities (`EC_TAG_CLIENT_MOD_CAPABILITIES = 0x0632`)
+
+| Tag                              | Code     | Type     | Description |
+| -------------------------------- | -------- | -------- | ----------- |
+| `EC_TAG_CLIENT_MOD_CAPABILITIES` | `0x0632` | `uint32` | Peer's eMuleAI vendor capability bitfield |
+
+A child of `EC_TAG_CLIENT`, carrying what the peer advertised in the
+eD2k handshake tag `CT_MOD_MISCOPTIONS` (`0xAA`):
+
+| Bit | Meaning |
+| --- | ------- |
+| 0 | Extended source exchange |
+| 1 | Legacy uTP NAT traversal |
+| 2 | IPv6 |
+| 3 | Serving-buddy pull |
+| 4 | QUIC NAT traversal |
+
+Bits 5 and above are reserved. The core masks them off before sending,
+so an EC client never has to know which bits are defined — a set bit it
+does not recognise cannot reach it.
+
+The tag is additive and follows the usual convention: a reply without it
+means an older daemon, which is a **third state**, distinct from a peer
+that advertised no capabilities (word `0`). aMule itself advertises
+nothing here yet — it implements none of the five features — so the tag
+describes the peer only.

--- a/docs/api/EVENTS.md
+++ b/docs/api/EVENTS.md
@@ -508,11 +508,12 @@ Identical to the REST [`/api/v0/clients`](REFERENCE.md#get-apiv0clients) list-it
   "upload_queue_score":                  150,
   "obfuscation_state":     "enabled",
   "connected":            true,
+  "protocol_extensions":    0,
   "friend_slot":            false,
   "part_progress_percent":  75.0
 }
 ```
-Carries the same field set as the [`/clients`](REFERENCE.md#get-apiv0clients) list row, including `source_origin`, `parts_offered_count`, `client_mod_name` and `shared_files_browsable`.
+Carries the same field set as the [`/clients`](REFERENCE.md#get-apiv0clients) list row, including `source_origin`, `protocol_extensions`, `parts_offered_count`, `client_mod_name` and `shared_files_browsable`.
 
 `part_progress_percent` follows the same rule as on the REST row: it is how much of the file we are downloading **from** this client the client already holds, and it is `null` when there is no such file, rather than sent as a negative sentinel. It is derived from `parts_offered_count` and the linked download's part count, so it moves when `parts_offered_count` does, and goes back to `null` if that download goes away. The key is always present -- see [REFERENCE.md's unknown-value rule](REFERENCE.md#unknown-values), under which `null` means "no value" and an absent key means "not reported".
 

--- a/docs/api/EVENTS.md
+++ b/docs/api/EVENTS.md
@@ -508,7 +508,7 @@ Identical to the REST [`/api/v0/clients`](REFERENCE.md#get-apiv0clients) list-it
   "upload_queue_score":                  150,
   "obfuscation_state":     "enabled",
   "connected":            true,
-  "protocol_extensions":    0,
+  "protocol_extensions":    [],
   "friend_slot":            false,
   "part_progress_percent":  75.0
 }

--- a/docs/api/REFERENCE.md
+++ b/docs/api/REFERENCE.md
@@ -1268,6 +1268,7 @@ curl -s -H "Authorization: Bearer $TOKEN" \
       "upload_queue_score": 150,
       "obfuscation_state": "enabled",
       "connected": true,
+      "protocol_extensions": 0,
       "friend_slot": false,
       "source_origin": "kad",
       "parts_offered_count": 42,
@@ -1303,6 +1304,10 @@ The last five were originally detail-only and were promoted onto this row (and o
 Every one of them falls back to `"unknown"` for a code the daemon does not map, so a client can treat `"unknown"` as its default branch and never has to handle an unexpected token. Three of them are also nullable on the live client objects: `software`, `obfuscation_state` and `source_origin` are `null` when the daemon never reported the field at all, which is a different thing from reporting a code we could not map. `upload_state`, `download_state` and `ident_state` are never `null` — the daemon always answers those. Note the two distinct sentinels on `obfuscation_state`: `"undefined"` is *the client has not told us yet*, `"unknown"` is *the daemon received a code it does not recognise*. The authoritative mappings are the `Client*Name()` / `SourceOriginName()` functions in `src/webapi/Refresher.cpp`.
 
 `connected` says whether a socket to this peer is up right now. A row existing in this list does not answer that: the daemon holds a client object from the first contact attempt, so a peer it is still trying to reach - or can never reach - appears here with `connected: false`. It is `null` on a daemon that does not report peer connectivity. The `online` fields on [`GET /friends`](#get-apiv0friends), [`GET /chats`](#get-apiv0chats) and [`GET /known_clients`](#get-apiv0known_clients) are the same fact reached by their own keys.
+
+`protocol_extensions` is the peer's eMuleAI vendor capability word, taken verbatim from `EC_TAG_CLIENT_MOD_CAPABILITIES` — the same value the desktop GUI renders as its *Protocol extensions* row. It is a bitfield, not one of the enumerated tokens above, because a peer claims any combination of the bits rather than one state: `0x01` extended source exchange, `0x02` uTP NAT traversal, `0x04` IPv6, `0x08` serving-buddy pull, `0x10` QUIC NAT traversal. The daemon has already cleared every bit it does not define, so a bit set here is one aMule names; a bit aMule does not name reads as absent, not as unknown. `0` means the peer claimed nothing, which is what nearly every peer on the network does — a peer that sent no capability tag and one that sent an all-zero word are the same state on the wire and report the same here.
+
+It says what the *peer* supports, never what this daemon does: aMule implements none of these extensions yet and advertises none of them back, so the field is recognition only. The bit meanings are wire format shared with eMuleAI and are defined in `src/PeerCapabilities.h`.
 
 `country_code` is the client's ISO 3166-1 alpha-2 country code (lowercase, e.g. `"de"`), resolved server-side from the client IP by the daemon's GeoIP database. It is `null` when GeoIP is disabled or unsupported by the build, or when the IP does not resolve — render the flag and localized country name client-side from the code. The flag image is served by [`GET /flags/{code}.png`](#get-flagscodepng); the localized name has no endpoint because the browser already has it (`Intl.DisplayNames` with `{ type: "region" }`).
 
@@ -1351,6 +1356,7 @@ curl -s -H "Authorization: Bearer $TOKEN" \
   "upload_queue_score": 150,
   "obfuscation_state": "enabled",
   "connected": true,
+  "protocol_extensions": 0,
   "friend_slot": false,
   "ed2k_user_id": 3232238090,
   "high_id": true,

--- a/docs/api/REFERENCE.md
+++ b/docs/api/REFERENCE.md
@@ -1268,7 +1268,7 @@ curl -s -H "Authorization: Bearer $TOKEN" \
       "upload_queue_score": 150,
       "obfuscation_state": "enabled",
       "connected": true,
-      "protocol_extensions": 0,
+      "protocol_extensions": [],
       "friend_slot": false,
       "source_origin": "kad",
       "parts_offered_count": 42,
@@ -1305,7 +1305,7 @@ Every one of them falls back to `"unknown"` for a code the daemon does not map, 
 
 `connected` says whether a socket to this peer is up right now. A row existing in this list does not answer that: the daemon holds a client object from the first contact attempt, so a peer it is still trying to reach - or can never reach - appears here with `connected: false`. It is `null` on a daemon that does not report peer connectivity. The `online` fields on [`GET /friends`](#get-apiv0friends), [`GET /chats`](#get-apiv0chats) and [`GET /known_clients`](#get-apiv0known_clients) are the same fact reached by their own keys.
 
-`protocol_extensions` is the peer's eMuleAI vendor capability word, taken verbatim from `EC_TAG_CLIENT_MOD_CAPABILITIES` — the same value the desktop GUI renders as its *Protocol extensions* row. It is a bitfield, not one of the enumerated tokens above, because a peer claims any combination of the bits rather than one state: `0x01` extended source exchange, `0x02` uTP NAT traversal, `0x04` IPv6, `0x08` serving-buddy pull, `0x10` QUIC NAT traversal. The daemon has already cleared every bit it does not define, so a bit set here is one aMule names; a bit aMule does not name reads as absent, not as unknown. `0` means the peer claimed nothing, which is what nearly every peer on the network does — a peer that sent no capability tag and one that sent an all-zero word are the same state on the wire and report the same here.
+`protocol_extensions` is the set of protocol extensions the peer claimed in its handshake, as stable tokens: `extended_source_exchange`, `nat_traversal_utp`, `ipv6`, `serving_buddy_pull`, `nat_traversal_quic`. A list rather than one token because a peer claims any combination of them, and tokens rather than the `EC_TAG_CLIENT_MOD_CAPABILITIES` bitfield they arrive in so no consumer has to carry its own copy of aMule's bit meanings. The order is stable. The daemon has already dropped every extension it does not define, so a token here is one aMule names, and an extension aMule does not name is absent rather than unknown. `[]` means the peer claimed nothing, which is what nearly every peer on the network does — a peer that sent no capability tag and one that sent an all-zero word are the same state on the wire and report the same here. The desktop GUI renders the same set as its *Protocol extensions* row.
 
 It says what the *peer* supports, never what this daemon does: aMule implements none of these extensions yet and advertises none of them back, so the field is recognition only. The bit meanings are wire format shared with eMuleAI and are defined in `src/PeerCapabilities.h`.
 
@@ -1356,7 +1356,7 @@ curl -s -H "Authorization: Bearer $TOKEN" \
   "upload_queue_score": 150,
   "obfuscation_state": "enabled",
   "connected": true,
-  "protocol_extensions": 0,
+  "protocol_extensions": [],
   "friend_slot": false,
   "ed2k_user_id": 3232238090,
   "high_id": true,

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -69,6 +69,7 @@ src/PartBarLegendUI.cpp
 src/PartFileConvert.cpp
 src/PartFileConvertDlg.cpp
 src/PartFile.cpp
+src/PeerCapabilities.h
 src/Preferences.cpp
 src/PrefsUnifiedDlg.cpp
 src/SearchDlg.cpp

--- a/po/amule.pot
+++ b/po/amule.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-06 14:35+0200\n"
+"POT-Creation-Date: 2026-09-06 23:44+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -2802,7 +2802,7 @@ msgstr ""
 msgid "Uploading"
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/PeerCapabilities.h
 msgid "None"
 msgstr ""
 
@@ -4172,6 +4172,10 @@ msgstr ""
 
 #: src/muuli_wdr.cpp
 msgid "Obfuscation"
+msgstr ""
+
+#: src/muuli_wdr.cpp
+msgid "Vendor capabilities:"
 msgstr ""
 
 #: src/muuli_wdr.cpp

--- a/po/amule.pot
+++ b/po/amule.pot
@@ -2802,7 +2802,7 @@ msgstr ""
 msgid "Uploading"
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp src/PeerCapabilities.h
+#: src/GenericClientListCtrl.cpp
 msgid "None"
 msgstr ""
 
@@ -4175,7 +4175,7 @@ msgid "Obfuscation"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Vendor capabilities:"
+msgid "Protocol extensions:"
 msgstr ""
 
 #: src/muuli_wdr.cpp
@@ -5925,6 +5925,26 @@ msgstr ""
 #: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Failed to open partfile '%s'"
+msgstr ""
+
+#: src/PeerCapabilities.h
+msgid "Extended source exchange"
+msgstr ""
+
+#: src/PeerCapabilities.h
+msgid "NAT traversal (uTP)"
+msgstr ""
+
+#: src/PeerCapabilities.h
+msgid "IPv6"
+msgstr ""
+
+#: src/PeerCapabilities.h
+msgid "Buddy info pull"
+msgstr ""
+
+#: src/PeerCapabilities.h
+msgid "NAT traversal (QUIC)"
 msgstr ""
 
 #: src/Preferences.cpp

--- a/po/ar.po
+++ b/po/ar.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-06 14:35+0200\n"
+"POT-Creation-Date: 2026-09-06 23:44+0200\n"
 "PO-Revision-Date: 2026-09-05 10:44+0000\n"
 "Last-Translator: saleh alhathal <hathalsal@hotmail.com>\n"
 "Language-Team: \n"
@@ -2850,7 +2850,7 @@ msgstr "في اﻻنتظار"
 msgid "Uploading"
 msgstr "الرفع"
 
-#: src/GenericClientListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/PeerCapabilities.h
 #, fuzzy
 msgid "None"
 msgstr "ﻻ احد"
@@ -4245,6 +4245,10 @@ msgstr "إسم الخادم"
 
 #: src/muuli_wdr.cpp
 msgid "Obfuscation"
+msgstr ""
+
+#: src/muuli_wdr.cpp
+msgid "Vendor capabilities:"
 msgstr ""
 
 #: src/muuli_wdr.cpp

--- a/po/ar.po
+++ b/po/ar.po
@@ -2850,7 +2850,7 @@ msgstr "في اﻻنتظار"
 msgid "Uploading"
 msgstr "الرفع"
 
-#: src/GenericClientListCtrl.cpp src/PeerCapabilities.h
+#: src/GenericClientListCtrl.cpp
 #, fuzzy
 msgid "None"
 msgstr "ﻻ احد"
@@ -4248,7 +4248,7 @@ msgid "Obfuscation"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Vendor capabilities:"
+msgid "Protocol extensions:"
 msgstr ""
 
 #: src/muuli_wdr.cpp
@@ -6028,6 +6028,26 @@ msgstr ""
 #: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Failed to open partfile '%s'"
+msgstr ""
+
+#: src/PeerCapabilities.h
+msgid "Extended source exchange"
+msgstr ""
+
+#: src/PeerCapabilities.h
+msgid "NAT traversal (uTP)"
+msgstr ""
+
+#: src/PeerCapabilities.h
+msgid "IPv6"
+msgstr ""
+
+#: src/PeerCapabilities.h
+msgid "Buddy info pull"
+msgstr ""
+
+#: src/PeerCapabilities.h
+msgid "NAT traversal (QUIC)"
 msgstr ""
 
 #: src/Preferences.cpp

--- a/po/ast.po
+++ b/po/ast.po
@@ -2907,7 +2907,7 @@ msgstr "Na cola"
 msgid "Uploading"
 msgstr "Xuba"
 
-#: src/GenericClientListCtrl.cpp src/PeerCapabilities.h
+#: src/GenericClientListCtrl.cpp
 #, fuzzy
 msgid "None"
 msgstr "Dengún"
@@ -4308,8 +4308,9 @@ msgid "Obfuscation"
 msgstr "Ofuscación"
 
 #: src/muuli_wdr.cpp
-msgid "Vendor capabilities:"
-msgstr ""
+#, fuzzy
+msgid "Protocol extensions:"
+msgstr "Ofuscación de protocolu"
 
 #: src/muuli_wdr.cpp
 msgid "Transfers to client"
@@ -6106,6 +6107,27 @@ msgstr "Espaciu en discu insuficiente"
 #, c-format
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "ERROR: Fallu al abrir ficheru part '%s'"
+
+#: src/PeerCapabilities.h
+#, fuzzy
+msgid "Extended source exchange"
+msgstr "Intercambéu de Fontes"
+
+#: src/PeerCapabilities.h
+msgid "NAT traversal (uTP)"
+msgstr ""
+
+#: src/PeerCapabilities.h
+msgid "IPv6"
+msgstr ""
+
+#: src/PeerCapabilities.h
+msgid "Buddy info pull"
+msgstr ""
+
+#: src/PeerCapabilities.h
+msgid "NAT traversal (QUIC)"
+msgstr ""
 
 #: src/Preferences.cpp
 msgid "no options available"

--- a/po/ast.po
+++ b/po/ast.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-06 14:35+0200\n"
+"POT-Creation-Date: 2026-09-06 23:44+0200\n"
 "PO-Revision-Date: 2026-09-05 10:45+0000\n"
 "Last-Translator: astur <malditoastur@gmail.com>\n"
 "Language-Team: Language ast <malditoastur@gmail.com>\n"
@@ -2907,7 +2907,7 @@ msgstr "Na cola"
 msgid "Uploading"
 msgstr "Xuba"
 
-#: src/GenericClientListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/PeerCapabilities.h
 #, fuzzy
 msgid "None"
 msgstr "Dengún"
@@ -4306,6 +4306,10 @@ msgstr "Nome sirvidor"
 #: src/muuli_wdr.cpp
 msgid "Obfuscation"
 msgstr "Ofuscación"
+
+#: src/muuli_wdr.cpp
+msgid "Vendor capabilities:"
+msgstr ""
 
 #: src/muuli_wdr.cpp
 msgid "Transfers to client"

--- a/po/bg.po
+++ b/po/bg.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-06 14:35+0200\n"
+"POT-Creation-Date: 2026-09-06 23:44+0200\n"
 "PO-Revision-Date: 2026-09-05 10:45+0000\n"
 "Last-Translator: Sebastiano Pistore <SebastianoPistore.info@protonmail.ch>\n"
 "Language-Team: Bulgarian <dict@linux.zonebg.com>\n"
@@ -2846,7 +2846,7 @@ msgstr "На опашката"
 msgid "Uploading"
 msgstr "Качване"
 
-#: src/GenericClientListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/PeerCapabilities.h
 msgid "None"
 msgstr "никой"
 
@@ -4244,6 +4244,10 @@ msgstr "Име на сървър"
 
 #: src/muuli_wdr.cpp
 msgid "Obfuscation"
+msgstr ""
+
+#: src/muuli_wdr.cpp
+msgid "Vendor capabilities:"
 msgstr ""
 
 #: src/muuli_wdr.cpp

--- a/po/bg.po
+++ b/po/bg.po
@@ -2846,7 +2846,7 @@ msgstr "На опашката"
 msgid "Uploading"
 msgstr "Качване"
 
-#: src/GenericClientListCtrl.cpp src/PeerCapabilities.h
+#: src/GenericClientListCtrl.cpp
 msgid "None"
 msgstr "никой"
 
@@ -4247,8 +4247,11 @@ msgid "Obfuscation"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Vendor capabilities:"
+#, fuzzy
+msgid "Protocol extensions:"
 msgstr ""
+"\n"
+"Налични разширения:\n"
 
 #: src/muuli_wdr.cpp
 msgid "Transfers to client"
@@ -6019,6 +6022,26 @@ msgstr ""
 #: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Failed to open partfile '%s'"
+msgstr ""
+
+#: src/PeerCapabilities.h
+msgid "Extended source exchange"
+msgstr ""
+
+#: src/PeerCapabilities.h
+msgid "NAT traversal (uTP)"
+msgstr ""
+
+#: src/PeerCapabilities.h
+msgid "IPv6"
+msgstr ""
+
+#: src/PeerCapabilities.h
+msgid "Buddy info pull"
+msgstr ""
+
+#: src/PeerCapabilities.h
+msgid "NAT traversal (QUIC)"
 msgstr ""
 
 #: src/Preferences.cpp

--- a/po/bn.po
+++ b/po/bn.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-06 14:35+0200\n"
+"POT-Creation-Date: 2026-09-06 23:44+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -2801,7 +2801,7 @@ msgstr ""
 msgid "Uploading"
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/PeerCapabilities.h
 msgid "None"
 msgstr ""
 
@@ -4171,6 +4171,10 @@ msgstr ""
 
 #: src/muuli_wdr.cpp
 msgid "Obfuscation"
+msgstr ""
+
+#: src/muuli_wdr.cpp
+msgid "Vendor capabilities:"
 msgstr ""
 
 #: src/muuli_wdr.cpp

--- a/po/bn.po
+++ b/po/bn.po
@@ -2801,7 +2801,7 @@ msgstr ""
 msgid "Uploading"
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp src/PeerCapabilities.h
+#: src/GenericClientListCtrl.cpp
 msgid "None"
 msgstr ""
 
@@ -4174,7 +4174,7 @@ msgid "Obfuscation"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Vendor capabilities:"
+msgid "Protocol extensions:"
 msgstr ""
 
 #: src/muuli_wdr.cpp
@@ -5924,6 +5924,26 @@ msgstr ""
 #: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Failed to open partfile '%s'"
+msgstr ""
+
+#: src/PeerCapabilities.h
+msgid "Extended source exchange"
+msgstr ""
+
+#: src/PeerCapabilities.h
+msgid "NAT traversal (uTP)"
+msgstr ""
+
+#: src/PeerCapabilities.h
+msgid "IPv6"
+msgstr ""
+
+#: src/PeerCapabilities.h
+msgid "Buddy info pull"
+msgstr ""
+
+#: src/PeerCapabilities.h
+msgid "NAT traversal (QUIC)"
 msgstr ""
 
 #: src/Preferences.cpp

--- a/po/ca.po
+++ b/po/ca.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-06 14:35+0200\n"
+"POT-Creation-Date: 2026-09-06 23:44+0200\n"
 "PO-Revision-Date: 2026-09-05 10:46+0000\n"
 "Last-Translator: minterior <minterior@gmail.com>\n"
 "Language-Team: Català\n"
@@ -2898,7 +2898,7 @@ msgstr "En cua: %u"
 msgid "Uploading"
 msgstr "Pujant"
 
-#: src/GenericClientListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/PeerCapabilities.h
 msgid "None"
 msgstr "Cap"
 
@@ -4293,6 +4293,10 @@ msgstr "Nom del servidor"
 #: src/muuli_wdr.cpp
 msgid "Obfuscation"
 msgstr "Ofuscació"
+
+#: src/muuli_wdr.cpp
+msgid "Vendor capabilities:"
+msgstr ""
 
 #: src/muuli_wdr.cpp
 msgid "Transfers to client"

--- a/po/ca.po
+++ b/po/ca.po
@@ -2898,7 +2898,7 @@ msgstr "En cua: %u"
 msgid "Uploading"
 msgstr "Pujant"
 
-#: src/GenericClientListCtrl.cpp src/PeerCapabilities.h
+#: src/GenericClientListCtrl.cpp
 msgid "None"
 msgstr "Cap"
 
@@ -4295,8 +4295,9 @@ msgid "Obfuscation"
 msgstr "Ofuscació"
 
 #: src/muuli_wdr.cpp
-msgid "Vendor capabilities:"
-msgstr ""
+#, fuzzy
+msgid "Protocol extensions:"
+msgstr "Ofuscació de protocol"
 
 #: src/muuli_wdr.cpp
 msgid "Transfers to client"
@@ -6082,6 +6083,27 @@ msgstr "Espai en disc insuficient"
 #, c-format
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "ERROR: No s'ha pogut obrir el fitxer part '%s'"
+
+#: src/PeerCapabilities.h
+#, fuzzy
+msgid "Extended source exchange"
+msgstr "Intercanvi de fonts"
+
+#: src/PeerCapabilities.h
+msgid "NAT traversal (uTP)"
+msgstr ""
+
+#: src/PeerCapabilities.h
+msgid "IPv6"
+msgstr ""
+
+#: src/PeerCapabilities.h
+msgid "Buddy info pull"
+msgstr ""
+
+#: src/PeerCapabilities.h
+msgid "NAT traversal (QUIC)"
+msgstr ""
 
 #: src/Preferences.cpp
 msgid "no options available"

--- a/po/cs.po
+++ b/po/cs.po
@@ -2907,7 +2907,7 @@ msgstr "Ve frontě: %u"
 msgid "Uploading"
 msgstr "Odesílám"
 
-#: src/GenericClientListCtrl.cpp src/PeerCapabilities.h
+#: src/GenericClientListCtrl.cpp
 msgid "None"
 msgstr "Nic"
 
@@ -4293,8 +4293,9 @@ msgid "Obfuscation"
 msgstr "Zamaskování"
 
 #: src/muuli_wdr.cpp
-msgid "Vendor capabilities:"
-msgstr ""
+#, fuzzy
+msgid "Protocol extensions:"
+msgstr "Zamaskování protokolu"
 
 #: src/muuli_wdr.cpp
 msgid "Transfers to client"
@@ -6077,6 +6078,27 @@ msgstr "Nedostatek místa na disku"
 #, c-format
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "CHYBA: Nepodařilo se otevřít soubor part '%s'"
+
+#: src/PeerCapabilities.h
+#, fuzzy
+msgid "Extended source exchange"
+msgstr "Výměna zdrojů"
+
+#: src/PeerCapabilities.h
+msgid "NAT traversal (uTP)"
+msgstr ""
+
+#: src/PeerCapabilities.h
+msgid "IPv6"
+msgstr ""
+
+#: src/PeerCapabilities.h
+msgid "Buddy info pull"
+msgstr ""
+
+#: src/PeerCapabilities.h
+msgid "NAT traversal (QUIC)"
+msgstr ""
 
 #: src/Preferences.cpp
 msgid "no options available"

--- a/po/cs.po
+++ b/po/cs.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-06 14:35+0200\n"
+"POT-Creation-Date: 2026-09-06 23:44+0200\n"
 "PO-Revision-Date: 2026-09-05 10:47+0000\n"
 "Last-Translator: David Watzke <david@watzke.cz>\n"
 "Language-Team: cs <cs@li.org>\n"
@@ -2907,7 +2907,7 @@ msgstr "Ve frontě: %u"
 msgid "Uploading"
 msgstr "Odesílám"
 
-#: src/GenericClientListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/PeerCapabilities.h
 msgid "None"
 msgstr "Nic"
 
@@ -4291,6 +4291,10 @@ msgstr "Název serveru"
 #: src/muuli_wdr.cpp
 msgid "Obfuscation"
 msgstr "Zamaskování"
+
+#: src/muuli_wdr.cpp
+msgid "Vendor capabilities:"
+msgstr ""
 
 #: src/muuli_wdr.cpp
 msgid "Transfers to client"

--- a/po/da.po
+++ b/po/da.po
@@ -2856,7 +2856,7 @@ msgstr "I Kø"
 msgid "Uploading"
 msgstr "Upload"
 
-#: src/GenericClientListCtrl.cpp src/PeerCapabilities.h
+#: src/GenericClientListCtrl.cpp
 #, fuzzy
 msgid "None"
 msgstr "Ingen"
@@ -4263,7 +4263,7 @@ msgid "Obfuscation"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Vendor capabilities:"
+msgid "Protocol extensions:"
 msgstr ""
 
 #: src/muuli_wdr.cpp
@@ -6046,6 +6046,26 @@ msgstr ""
 #: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Failed to open partfile '%s'"
+msgstr ""
+
+#: src/PeerCapabilities.h
+msgid "Extended source exchange"
+msgstr ""
+
+#: src/PeerCapabilities.h
+msgid "NAT traversal (uTP)"
+msgstr ""
+
+#: src/PeerCapabilities.h
+msgid "IPv6"
+msgstr ""
+
+#: src/PeerCapabilities.h
+msgid "Buddy info pull"
+msgstr ""
+
+#: src/PeerCapabilities.h
+msgid "NAT traversal (QUIC)"
 msgstr ""
 
 #: src/Preferences.cpp

--- a/po/da.po
+++ b/po/da.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-06 14:35+0200\n"
+"POT-Creation-Date: 2026-09-06 23:44+0200\n"
 "PO-Revision-Date: 2026-09-05 10:47+0000\n"
 "Last-Translator: Alex Thomsen Leth <alexl@stofanet.dk>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -2856,7 +2856,7 @@ msgstr "I Kø"
 msgid "Uploading"
 msgstr "Upload"
 
-#: src/GenericClientListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/PeerCapabilities.h
 #, fuzzy
 msgid "None"
 msgstr "Ingen"
@@ -4260,6 +4260,10 @@ msgstr "Servernavn"
 
 #: src/muuli_wdr.cpp
 msgid "Obfuscation"
+msgstr ""
+
+#: src/muuli_wdr.cpp
+msgid "Vendor capabilities:"
 msgstr ""
 
 #: src/muuli_wdr.cpp

--- a/po/de.po
+++ b/po/de.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-06 14:35+0200\n"
+"POT-Creation-Date: 2026-09-06 23:44+0200\n"
 "PO-Revision-Date: 2026-09-05 10:47+0000\n"
 "Last-Translator: Werner Mahr <werner@vollstreckernet.de>\n"
 "Language-Team: German <>\n"
@@ -2903,7 +2903,7 @@ msgstr "In Warteschlange: %u"
 msgid "Uploading"
 msgstr "Hochladen"
 
-#: src/GenericClientListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/PeerCapabilities.h
 msgid "None"
 msgstr "Keine"
 
@@ -4291,6 +4291,10 @@ msgstr "Servername"
 #: src/muuli_wdr.cpp
 msgid "Obfuscation"
 msgstr "Verschleierung"
+
+#: src/muuli_wdr.cpp
+msgid "Vendor capabilities:"
+msgstr ""
 
 #: src/muuli_wdr.cpp
 msgid "Transfers to client"

--- a/po/de.po
+++ b/po/de.po
@@ -2903,7 +2903,7 @@ msgstr "In Warteschlange: %u"
 msgid "Uploading"
 msgstr "Hochladen"
 
-#: src/GenericClientListCtrl.cpp src/PeerCapabilities.h
+#: src/GenericClientListCtrl.cpp
 msgid "None"
 msgstr "Keine"
 
@@ -4293,8 +4293,9 @@ msgid "Obfuscation"
 msgstr "Verschleierung"
 
 #: src/muuli_wdr.cpp
-msgid "Vendor capabilities:"
-msgstr ""
+#, fuzzy
+msgid "Protocol extensions:"
+msgstr "Protokollverschleierung"
 
 #: src/muuli_wdr.cpp
 msgid "Transfers to client"
@@ -6077,6 +6078,27 @@ msgstr "Zu wenig Festplattenplatz"
 #, c-format
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "FEHLER: Öffnen von Partfile '%s' fehlgeschlagen"
+
+#: src/PeerCapabilities.h
+#, fuzzy
+msgid "Extended source exchange"
+msgstr "Quellenaustausch"
+
+#: src/PeerCapabilities.h
+msgid "NAT traversal (uTP)"
+msgstr ""
+
+#: src/PeerCapabilities.h
+msgid "IPv6"
+msgstr ""
+
+#: src/PeerCapabilities.h
+msgid "Buddy info pull"
+msgstr ""
+
+#: src/PeerCapabilities.h
+msgid "NAT traversal (QUIC)"
+msgstr ""
 
 #: src/Preferences.cpp
 msgid "no options available"

--- a/po/el.po
+++ b/po/el.po
@@ -2916,7 +2916,7 @@ msgstr "Εν αναμονή"
 msgid "Uploading"
 msgstr "Ανέβασμα"
 
-#: src/GenericClientListCtrl.cpp src/PeerCapabilities.h
+#: src/GenericClientListCtrl.cpp
 #, fuzzy
 msgid "None"
 msgstr "Κανείς"
@@ -4320,8 +4320,9 @@ msgid "Obfuscation"
 msgstr "Συσκότιση"
 
 #: src/muuli_wdr.cpp
-msgid "Vendor capabilities:"
-msgstr ""
+#, fuzzy
+msgid "Protocol extensions:"
+msgstr "Συσκότιση πρωτοκόλλου"
 
 #: src/muuli_wdr.cpp
 msgid "Transfers to client"
@@ -6119,6 +6120,27 @@ msgstr "Ανεπαρκής χώρος στο δίσκο"
 #, c-format
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "ΣΦΑΛΜΑ: Αποτυχία ανοίγματος του ημιτελούς αρχείου '%s'"
+
+#: src/PeerCapabilities.h
+#, fuzzy
+msgid "Extended source exchange"
+msgstr "Ανταλλαγή πηγών"
+
+#: src/PeerCapabilities.h
+msgid "NAT traversal (uTP)"
+msgstr ""
+
+#: src/PeerCapabilities.h
+msgid "IPv6"
+msgstr ""
+
+#: src/PeerCapabilities.h
+msgid "Buddy info pull"
+msgstr ""
+
+#: src/PeerCapabilities.h
+msgid "NAT traversal (QUIC)"
+msgstr ""
 
 #: src/Preferences.cpp
 msgid "no options available"

--- a/po/el.po
+++ b/po/el.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-06 14:35+0200\n"
+"POT-Creation-Date: 2026-09-06 23:44+0200\n"
 "PO-Revision-Date: 2026-09-05 10:48+0000\n"
 "Last-Translator: Dimitris <dgalanak@yahoo.com>\n"
 "Language-Team: Greek\n"
@@ -2916,7 +2916,7 @@ msgstr "Εν αναμονή"
 msgid "Uploading"
 msgstr "Ανέβασμα"
 
-#: src/GenericClientListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/PeerCapabilities.h
 #, fuzzy
 msgid "None"
 msgstr "Κανείς"
@@ -4318,6 +4318,10 @@ msgstr "Όνομα διακομιστή"
 #: src/muuli_wdr.cpp
 msgid "Obfuscation"
 msgstr "Συσκότιση"
+
+#: src/muuli_wdr.cpp
+msgid "Vendor capabilities:"
+msgstr ""
 
 #: src/muuli_wdr.cpp
 msgid "Transfers to client"

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -2802,7 +2802,7 @@ msgstr ""
 msgid "Uploading"
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp src/PeerCapabilities.h
+#: src/GenericClientListCtrl.cpp
 msgid "None"
 msgstr ""
 
@@ -4175,7 +4175,7 @@ msgid "Obfuscation"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Vendor capabilities:"
+msgid "Protocol extensions:"
 msgstr ""
 
 #: src/muuli_wdr.cpp
@@ -5925,6 +5925,26 @@ msgstr ""
 #: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Failed to open partfile '%s'"
+msgstr ""
+
+#: src/PeerCapabilities.h
+msgid "Extended source exchange"
+msgstr ""
+
+#: src/PeerCapabilities.h
+msgid "NAT traversal (uTP)"
+msgstr ""
+
+#: src/PeerCapabilities.h
+msgid "IPv6"
+msgstr ""
+
+#: src/PeerCapabilities.h
+msgid "Buddy info pull"
+msgstr ""
+
+#: src/PeerCapabilities.h
+msgid "NAT traversal (QUIC)"
 msgstr ""
 
 #: src/Preferences.cpp

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-06 14:35+0200\n"
+"POT-Creation-Date: 2026-09-06 23:44+0200\n"
 "PO-Revision-Date: 2020-03-04 14:43+0100\n"
 "Last-Translator: Dévai Tamás <devait@vnet.hu>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -2802,7 +2802,7 @@ msgstr ""
 msgid "Uploading"
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/PeerCapabilities.h
 msgid "None"
 msgstr ""
 
@@ -4172,6 +4172,10 @@ msgstr ""
 
 #: src/muuli_wdr.cpp
 msgid "Obfuscation"
+msgstr ""
+
+#: src/muuli_wdr.cpp
+msgid "Vendor capabilities:"
 msgstr ""
 
 #: src/muuli_wdr.cpp

--- a/po/es.po
+++ b/po/es.po
@@ -2894,7 +2894,7 @@ msgstr "En la cola: %u"
 msgid "Uploading"
 msgstr "Subiendo"
 
-#: src/GenericClientListCtrl.cpp src/PeerCapabilities.h
+#: src/GenericClientListCtrl.cpp
 msgid "None"
 msgstr "Ninguno"
 
@@ -4269,8 +4269,9 @@ msgid "Obfuscation"
 msgstr "Ofuscación"
 
 #: src/muuli_wdr.cpp
-msgid "Vendor capabilities:"
-msgstr ""
+#, fuzzy
+msgid "Protocol extensions:"
+msgstr "Ofuscación de protocolo"
 
 #: src/muuli_wdr.cpp
 msgid "Transfers to client"
@@ -6041,6 +6042,27 @@ msgstr "Espacio en disco insuficiente"
 #, c-format
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "ERROR: no se ha podido abrir el archivo de partes '%s'"
+
+#: src/PeerCapabilities.h
+#, fuzzy
+msgid "Extended source exchange"
+msgstr "Intercambio de fuentes"
+
+#: src/PeerCapabilities.h
+msgid "NAT traversal (uTP)"
+msgstr ""
+
+#: src/PeerCapabilities.h
+msgid "IPv6"
+msgstr ""
+
+#: src/PeerCapabilities.h
+msgid "Buddy info pull"
+msgstr ""
+
+#: src/PeerCapabilities.h
+msgid "NAT traversal (QUIC)"
+msgstr ""
 
 #: src/Preferences.cpp
 msgid "no options available"

--- a/po/es.po
+++ b/po/es.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-06 14:35+0200\n"
+"POT-Creation-Date: 2026-09-06 23:44+0200\n"
 "PO-Revision-Date: 2026-09-05 10:49+0000\n"
 "Last-Translator: Diego Heras <ngosang@hotmail.es>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/amule/amule-application/es/>\n"
@@ -2894,7 +2894,7 @@ msgstr "En la cola: %u"
 msgid "Uploading"
 msgstr "Subiendo"
 
-#: src/GenericClientListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/PeerCapabilities.h
 msgid "None"
 msgstr "Ninguno"
 
@@ -4267,6 +4267,10 @@ msgstr "Nombre del servidor"
 #: src/muuli_wdr.cpp
 msgid "Obfuscation"
 msgstr "Ofuscación"
+
+#: src/muuli_wdr.cpp
+msgid "Vendor capabilities:"
+msgstr ""
 
 #: src/muuli_wdr.cpp
 msgid "Transfers to client"

--- a/po/et_EE.po
+++ b/po/et_EE.po
@@ -2898,7 +2898,7 @@ msgstr "Järjekorras: %u"
 msgid "Uploading"
 msgstr "Saadan"
 
-#: src/GenericClientListCtrl.cpp src/PeerCapabilities.h
+#: src/GenericClientListCtrl.cpp
 msgid "None"
 msgstr "Mitte keegi"
 
@@ -4295,8 +4295,9 @@ msgid "Obfuscation"
 msgstr "Hämatud"
 
 #: src/muuli_wdr.cpp
-msgid "Vendor capabilities:"
-msgstr ""
+#, fuzzy
+msgid "Protocol extensions:"
+msgstr "Protokolli Hämamine"
 
 #: src/muuli_wdr.cpp
 msgid "Transfers to client"
@@ -6082,6 +6083,27 @@ msgstr "Ebapiisav kettaruum"
 #, c-format
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "VIGA: Osafaili '%s' avamine ebaõnnestus"
+
+#: src/PeerCapabilities.h
+#, fuzzy
+msgid "Extended source exchange"
+msgstr "Allikate Vahetus"
+
+#: src/PeerCapabilities.h
+msgid "NAT traversal (uTP)"
+msgstr ""
+
+#: src/PeerCapabilities.h
+msgid "IPv6"
+msgstr ""
+
+#: src/PeerCapabilities.h
+msgid "Buddy info pull"
+msgstr ""
+
+#: src/PeerCapabilities.h
+msgid "NAT traversal (QUIC)"
+msgstr ""
 
 #: src/Preferences.cpp
 msgid "no options available"

--- a/po/et_EE.po
+++ b/po/et_EE.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-06 14:35+0200\n"
+"POT-Creation-Date: 2026-09-06 23:44+0200\n"
 "PO-Revision-Date: 2026-09-05 10:49+0000\n"
 "Last-Translator: \n"
 "Language-Team: Estonian <kde-i18n-doc@kde.org>\n"
@@ -2898,7 +2898,7 @@ msgstr "Järjekorras: %u"
 msgid "Uploading"
 msgstr "Saadan"
 
-#: src/GenericClientListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/PeerCapabilities.h
 msgid "None"
 msgstr "Mitte keegi"
 
@@ -4293,6 +4293,10 @@ msgstr "Serveri nimi"
 #: src/muuli_wdr.cpp
 msgid "Obfuscation"
 msgstr "Hämatud"
+
+#: src/muuli_wdr.cpp
+msgid "Vendor capabilities:"
+msgstr ""
 
 #: src/muuli_wdr.cpp
 msgid "Transfers to client"

--- a/po/eu.po
+++ b/po/eu.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-06 14:35+0200\n"
+"POT-Creation-Date: 2026-09-06 23:44+0200\n"
 "PO-Revision-Date: 2026-09-05 10:50+0000\n"
 "Last-Translator: Piarres Beobide <pi@beobide.net>\n"
 "Language-Team: Euskara <librezale@librezale.org>\n"
@@ -2899,7 +2899,7 @@ msgstr "Ilaran: %u"
 msgid "Uploading"
 msgstr "Igotzen"
 
-#: src/GenericClientListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/PeerCapabilities.h
 msgid "None"
 msgstr "Batez"
 
@@ -4294,6 +4294,10 @@ msgstr "Zerbitzari izena"
 #: src/muuli_wdr.cpp
 msgid "Obfuscation"
 msgstr "Nahasmena"
+
+#: src/muuli_wdr.cpp
+msgid "Vendor capabilities:"
+msgstr ""
 
 #: src/muuli_wdr.cpp
 msgid "Transfers to client"

--- a/po/eu.po
+++ b/po/eu.po
@@ -2899,7 +2899,7 @@ msgstr "Ilaran: %u"
 msgid "Uploading"
 msgstr "Igotzen"
 
-#: src/GenericClientListCtrl.cpp src/PeerCapabilities.h
+#: src/GenericClientListCtrl.cpp
 msgid "None"
 msgstr "Batez"
 
@@ -4296,8 +4296,9 @@ msgid "Obfuscation"
 msgstr "Nahasmena"
 
 #: src/muuli_wdr.cpp
-msgid "Vendor capabilities:"
-msgstr ""
+#, fuzzy
+msgid "Protocol extensions:"
+msgstr "Protokolo nahastea"
 
 #: src/muuli_wdr.cpp
 msgid "Transfers to client"
@@ -6082,6 +6083,27 @@ msgstr "Disko leku askieza"
 #, c-format
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "ERROREA: Huts '%s' zati fitxategia irekitzean"
+
+#: src/PeerCapabilities.h
+#, fuzzy
+msgid "Extended source exchange"
+msgstr "Jatorri trukaketa"
+
+#: src/PeerCapabilities.h
+msgid "NAT traversal (uTP)"
+msgstr ""
+
+#: src/PeerCapabilities.h
+msgid "IPv6"
+msgstr ""
+
+#: src/PeerCapabilities.h
+msgid "Buddy info pull"
+msgstr ""
+
+#: src/PeerCapabilities.h
+msgid "NAT traversal (QUIC)"
+msgstr ""
 
 #: src/Preferences.cpp
 msgid "no options available"

--- a/po/fi.po
+++ b/po/fi.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-06 14:35+0200\n"
+"POT-Creation-Date: 2026-09-06 23:44+0200\n"
 "PO-Revision-Date: 2026-09-05 10:50+0000\n"
 "Last-Translator: Tapio Rantala <tapio.rantala@iki.fi>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -2899,7 +2899,7 @@ msgstr "Jonossa: %u"
 msgid "Uploading"
 msgstr "Lähettää"
 
-#: src/GenericClientListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/PeerCapabilities.h
 msgid "None"
 msgstr "Ei yhtään"
 
@@ -4294,6 +4294,10 @@ msgstr "Palvelimen nimi"
 #: src/muuli_wdr.cpp
 msgid "Obfuscation"
 msgstr "Kätkeminen"
+
+#: src/muuli_wdr.cpp
+msgid "Vendor capabilities:"
+msgstr ""
 
 #: src/muuli_wdr.cpp
 msgid "Transfers to client"

--- a/po/fi.po
+++ b/po/fi.po
@@ -2899,7 +2899,7 @@ msgstr "Jonossa: %u"
 msgid "Uploading"
 msgstr "Lähettää"
 
-#: src/GenericClientListCtrl.cpp src/PeerCapabilities.h
+#: src/GenericClientListCtrl.cpp
 msgid "None"
 msgstr "Ei yhtään"
 
@@ -4296,8 +4296,9 @@ msgid "Obfuscation"
 msgstr "Kätkeminen"
 
 #: src/muuli_wdr.cpp
-msgid "Vendor capabilities:"
-msgstr ""
+#, fuzzy
+msgid "Protocol extensions:"
+msgstr "Protokollan kätkeminen"
 
 #: src/muuli_wdr.cpp
 msgid "Transfers to client"
@@ -6082,6 +6083,27 @@ msgstr "Riittämätön levytila"
 #, c-format
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "VIRHE: Ei voida avata osatiedostoa '%s'"
+
+#: src/PeerCapabilities.h
+#, fuzzy
+msgid "Extended source exchange"
+msgstr "Lähdevälitys"
+
+#: src/PeerCapabilities.h
+msgid "NAT traversal (uTP)"
+msgstr ""
+
+#: src/PeerCapabilities.h
+msgid "IPv6"
+msgstr ""
+
+#: src/PeerCapabilities.h
+msgid "Buddy info pull"
+msgstr ""
+
+#: src/PeerCapabilities.h
+msgid "NAT traversal (QUIC)"
+msgstr ""
 
 #: src/Preferences.cpp
 msgid "no options available"

--- a/po/fr.po
+++ b/po/fr.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-06 14:35+0200\n"
+"POT-Creation-Date: 2026-09-06 23:44+0200\n"
 "PO-Revision-Date: 2026-09-05 10:51+0000\n"
 "Last-Translator: Dylan Aïssi <bob.dybian@gmail.com>\n"
 "Language-Team: Français\n"
@@ -2893,7 +2893,7 @@ msgstr "En attente : %u"
 msgid "Uploading"
 msgstr "Émission en cours"
 
-#: src/GenericClientListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/PeerCapabilities.h
 msgid "None"
 msgstr "Aucun"
 
@@ -4266,6 +4266,10 @@ msgstr "Nom du serveur"
 #: src/muuli_wdr.cpp
 msgid "Obfuscation"
 msgstr "Brouillage"
+
+#: src/muuli_wdr.cpp
+msgid "Vendor capabilities:"
+msgstr ""
 
 #: src/muuli_wdr.cpp
 msgid "Transfers to client"

--- a/po/fr.po
+++ b/po/fr.po
@@ -2893,7 +2893,7 @@ msgstr "En attente : %u"
 msgid "Uploading"
 msgstr "Émission en cours"
 
-#: src/GenericClientListCtrl.cpp src/PeerCapabilities.h
+#: src/GenericClientListCtrl.cpp
 msgid "None"
 msgstr "Aucun"
 
@@ -4268,8 +4268,9 @@ msgid "Obfuscation"
 msgstr "Brouillage"
 
 #: src/muuli_wdr.cpp
-msgid "Vendor capabilities:"
-msgstr ""
+#, fuzzy
+msgid "Protocol extensions:"
+msgstr "Brouillage de protocole"
 
 #: src/muuli_wdr.cpp
 msgid "Transfers to client"
@@ -6036,6 +6037,27 @@ msgstr "Espace disque insuffisant"
 #, c-format
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "ERREUR : Impossible d'ouvrir fichier .part : '%s'"
+
+#: src/PeerCapabilities.h
+#, fuzzy
+msgid "Extended source exchange"
+msgstr "Échange de Sources"
+
+#: src/PeerCapabilities.h
+msgid "NAT traversal (uTP)"
+msgstr ""
+
+#: src/PeerCapabilities.h
+msgid "IPv6"
+msgstr ""
+
+#: src/PeerCapabilities.h
+msgid "Buddy info pull"
+msgstr ""
+
+#: src/PeerCapabilities.h
+msgid "NAT traversal (QUIC)"
+msgstr ""
 
 #: src/Preferences.cpp
 msgid "no options available"

--- a/po/gl.po
+++ b/po/gl.po
@@ -2916,7 +2916,7 @@ msgstr "En cola: %u"
 msgid "Uploading"
 msgstr "Enviando"
 
-#: src/GenericClientListCtrl.cpp src/PeerCapabilities.h
+#: src/GenericClientListCtrl.cpp
 msgid "None"
 msgstr "Ningún"
 
@@ -4306,8 +4306,9 @@ msgid "Obfuscation"
 msgstr "Ofuscación"
 
 #: src/muuli_wdr.cpp
-msgid "Vendor capabilities:"
-msgstr ""
+#, fuzzy
+msgid "Protocol extensions:"
+msgstr "Ofuscación do protocolo"
 
 #: src/muuli_wdr.cpp
 msgid "Transfers to client"
@@ -6091,6 +6092,27 @@ msgstr "Espazo no disco insuficiente"
 #, c-format
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "ERRO: Non se puido abrir o partfile «%s»"
+
+#: src/PeerCapabilities.h
+#, fuzzy
+msgid "Extended source exchange"
+msgstr "Intercambio de fontes"
+
+#: src/PeerCapabilities.h
+msgid "NAT traversal (uTP)"
+msgstr ""
+
+#: src/PeerCapabilities.h
+msgid "IPv6"
+msgstr ""
+
+#: src/PeerCapabilities.h
+msgid "Buddy info pull"
+msgstr ""
+
+#: src/PeerCapabilities.h
+msgid "NAT traversal (QUIC)"
+msgstr ""
 
 #: src/Preferences.cpp
 msgid "no options available"

--- a/po/gl.po
+++ b/po/gl.po
@@ -24,7 +24,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-06 14:35+0200\n"
+"POT-Creation-Date: 2026-09-06 23:44+0200\n"
 "PO-Revision-Date: 2026-09-05 10:52+0000\n"
 "Last-Translator: Pablo <parodper@gmail.com>\n"
 "Language-Team: http://forum.amule.org/index.php?topic=13883\n"
@@ -2916,7 +2916,7 @@ msgstr "En cola: %u"
 msgid "Uploading"
 msgstr "Enviando"
 
-#: src/GenericClientListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/PeerCapabilities.h
 msgid "None"
 msgstr "Ningún"
 
@@ -4304,6 +4304,10 @@ msgstr "Nome do servidor"
 #: src/muuli_wdr.cpp
 msgid "Obfuscation"
 msgstr "Ofuscación"
+
+#: src/muuli_wdr.cpp
+msgid "Vendor capabilities:"
+msgstr ""
 
 #: src/muuli_wdr.cpp
 msgid "Transfers to client"

--- a/po/he.po
+++ b/po/he.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-06 14:35+0200\n"
+"POT-Creation-Date: 2026-09-06 23:44+0200\n"
 "PO-Revision-Date: 2026-09-05 10:52+0000\n"
 "Last-Translator: Peace Kramer <kpeace1@gmail.com>\n"
 "Language-Team: Hebrew\n"
@@ -2871,7 +2871,7 @@ msgstr "על התור"
 msgid "Uploading"
 msgstr "ההעלאות"
 
-#: src/GenericClientListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/PeerCapabilities.h
 #, fuzzy
 msgid "None"
 msgstr "לא"
@@ -4268,6 +4268,10 @@ msgstr "שם שרת"
 
 #: src/muuli_wdr.cpp
 msgid "Obfuscation"
+msgstr ""
+
+#: src/muuli_wdr.cpp
+msgid "Vendor capabilities:"
 msgstr ""
 
 #: src/muuli_wdr.cpp

--- a/po/he.po
+++ b/po/he.po
@@ -2871,7 +2871,7 @@ msgstr "על התור"
 msgid "Uploading"
 msgstr "ההעלאות"
 
-#: src/GenericClientListCtrl.cpp src/PeerCapabilities.h
+#: src/GenericClientListCtrl.cpp
 #, fuzzy
 msgid "None"
 msgstr "לא"
@@ -4271,7 +4271,7 @@ msgid "Obfuscation"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Vendor capabilities:"
+msgid "Protocol extensions:"
 msgstr ""
 
 #: src/muuli_wdr.cpp
@@ -6056,6 +6056,27 @@ msgstr ""
 #: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Failed to open partfile '%s'"
+msgstr ""
+
+#: src/PeerCapabilities.h
+#, fuzzy
+msgid "Extended source exchange"
+msgstr "החלפת מקורות"
+
+#: src/PeerCapabilities.h
+msgid "NAT traversal (uTP)"
+msgstr ""
+
+#: src/PeerCapabilities.h
+msgid "IPv6"
+msgstr ""
+
+#: src/PeerCapabilities.h
+msgid "Buddy info pull"
+msgstr ""
+
+#: src/PeerCapabilities.h
+msgid "NAT traversal (QUIC)"
 msgstr ""
 
 #: src/Preferences.cpp

--- a/po/hr.po
+++ b/po/hr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-06 14:35+0200\n"
+"POT-Creation-Date: 2026-09-06 23:44+0200\n"
 "PO-Revision-Date: 2026-09-05 10:52+0000\n"
 "Last-Translator: Sebastiano Pistore <sebastiano.pistore.info@aol.com>\n"
 "Language-Team: https://github.com/amule-org/amule <forum@aMule.org>\n"
@@ -2867,7 +2867,7 @@ msgstr "U redu cekanja"
 msgid "Uploading"
 msgstr "Prijenos"
 
-#: src/GenericClientListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/PeerCapabilities.h
 msgid "None"
 msgstr "Nijedno"
 
@@ -4270,6 +4270,10 @@ msgstr "Ime servera"
 
 #: src/muuli_wdr.cpp
 msgid "Obfuscation"
+msgstr ""
+
+#: src/muuli_wdr.cpp
+msgid "Vendor capabilities:"
 msgstr ""
 
 #: src/muuli_wdr.cpp

--- a/po/hr.po
+++ b/po/hr.po
@@ -2867,7 +2867,7 @@ msgstr "U redu cekanja"
 msgid "Uploading"
 msgstr "Prijenos"
 
-#: src/GenericClientListCtrl.cpp src/PeerCapabilities.h
+#: src/GenericClientListCtrl.cpp
 msgid "None"
 msgstr "Nijedno"
 
@@ -4273,7 +4273,7 @@ msgid "Obfuscation"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Vendor capabilities:"
+msgid "Protocol extensions:"
 msgstr ""
 
 #: src/muuli_wdr.cpp
@@ -6067,6 +6067,26 @@ msgstr ""
 #: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Failed to open partfile '%s'"
+msgstr ""
+
+#: src/PeerCapabilities.h
+msgid "Extended source exchange"
+msgstr ""
+
+#: src/PeerCapabilities.h
+msgid "NAT traversal (uTP)"
+msgstr ""
+
+#: src/PeerCapabilities.h
+msgid "IPv6"
+msgstr ""
+
+#: src/PeerCapabilities.h
+msgid "Buddy info pull"
+msgstr ""
+
+#: src/PeerCapabilities.h
+msgid "NAT traversal (QUIC)"
 msgstr ""
 
 #: src/Preferences.cpp

--- a/po/hu.po
+++ b/po/hu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-06 14:35+0200\n"
+"POT-Creation-Date: 2026-09-06 23:44+0200\n"
 "PO-Revision-Date: 2026-09-05 10:53+0000\n"
 "Last-Translator: Dévai Tamás <gonosztopi@amule.org>\n"
 "Language-Team: Hungarian <hu@li.org>\n"
@@ -2885,7 +2885,7 @@ msgstr "Várólistán: %u"
 msgid "Uploading"
 msgstr "Feltöltés alatt"
 
-#: src/GenericClientListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/PeerCapabilities.h
 msgid "None"
 msgstr "Egyik sem"
 
@@ -4264,6 +4264,10 @@ msgstr "Kiszolgáló neve"
 #: src/muuli_wdr.cpp
 msgid "Obfuscation"
 msgstr "Zavarás"
+
+#: src/muuli_wdr.cpp
+msgid "Vendor capabilities:"
+msgstr ""
 
 #: src/muuli_wdr.cpp
 msgid "Transfers to client"

--- a/po/hu.po
+++ b/po/hu.po
@@ -2885,7 +2885,7 @@ msgstr "Várólistán: %u"
 msgid "Uploading"
 msgstr "Feltöltés alatt"
 
-#: src/GenericClientListCtrl.cpp src/PeerCapabilities.h
+#: src/GenericClientListCtrl.cpp
 msgid "None"
 msgstr "Egyik sem"
 
@@ -4266,8 +4266,9 @@ msgid "Obfuscation"
 msgstr "Zavarás"
 
 #: src/muuli_wdr.cpp
-msgid "Vendor capabilities:"
-msgstr ""
+#, fuzzy
+msgid "Protocol extensions:"
+msgstr "Protokoll zavarás"
 
 #: src/muuli_wdr.cpp
 msgid "Transfers to client"
@@ -6055,6 +6056,27 @@ msgstr "Elégtelen lemezterület"
 #, c-format
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "HIBA: A(z) '%s' részfájl megnyitása sikertelen."
+
+#: src/PeerCapabilities.h
+#, fuzzy
+msgid "Extended source exchange"
+msgstr "Forrás-csere"
+
+#: src/PeerCapabilities.h
+msgid "NAT traversal (uTP)"
+msgstr ""
+
+#: src/PeerCapabilities.h
+msgid "IPv6"
+msgstr ""
+
+#: src/PeerCapabilities.h
+msgid "Buddy info pull"
+msgstr ""
+
+#: src/PeerCapabilities.h
+msgid "NAT traversal (QUIC)"
+msgstr ""
 
 #: src/Preferences.cpp
 msgid "no options available"

--- a/po/it.po
+++ b/po/it.po
@@ -19,7 +19,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule 2.3.3\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-06 14:35+0200\n"
+"POT-Creation-Date: 2026-09-06 23:44+0200\n"
 "PO-Revision-Date: 2026-09-05 10:54+0000\n"
 "Last-Translator: got3nks <got3nks@users.noreply.github.com>\n"
 "Language-Team: SebastianoPistore.info@protonmail.ch\n"
@@ -2900,7 +2900,7 @@ msgstr "In coda: %u"
 msgid "Uploading"
 msgstr "Caricamento"
 
-#: src/GenericClientListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/PeerCapabilities.h
 msgid "None"
 msgstr "Nessuno"
 
@@ -4273,6 +4273,10 @@ msgstr "Nome server"
 #: src/muuli_wdr.cpp
 msgid "Obfuscation"
 msgstr "Offuscamento"
+
+#: src/muuli_wdr.cpp
+msgid "Vendor capabilities:"
+msgstr ""
 
 #: src/muuli_wdr.cpp
 msgid "Transfers to client"

--- a/po/it.po
+++ b/po/it.po
@@ -2900,7 +2900,7 @@ msgstr "In coda: %u"
 msgid "Uploading"
 msgstr "Caricamento"
 
-#: src/GenericClientListCtrl.cpp src/PeerCapabilities.h
+#: src/GenericClientListCtrl.cpp
 msgid "None"
 msgstr "Nessuno"
 
@@ -4275,8 +4275,9 @@ msgid "Obfuscation"
 msgstr "Offuscamento"
 
 #: src/muuli_wdr.cpp
-msgid "Vendor capabilities:"
-msgstr ""
+#, fuzzy
+msgid "Protocol extensions:"
+msgstr "Offuscamento del protocollo"
 
 #: src/muuli_wdr.cpp
 msgid "Transfers to client"
@@ -6043,6 +6044,27 @@ msgstr "Spazio su disco insufficiente"
 #, c-format
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "ERRORE: Apertura del file Part fallita '%s'"
+
+#: src/PeerCapabilities.h
+#, fuzzy
+msgid "Extended source exchange"
+msgstr "Scambio fonti"
+
+#: src/PeerCapabilities.h
+msgid "NAT traversal (uTP)"
+msgstr ""
+
+#: src/PeerCapabilities.h
+msgid "IPv6"
+msgstr ""
+
+#: src/PeerCapabilities.h
+msgid "Buddy info pull"
+msgstr ""
+
+#: src/PeerCapabilities.h
+msgid "NAT traversal (QUIC)"
+msgstr ""
 
 #: src/Preferences.cpp
 msgid "no options available"

--- a/po/ja.po
+++ b/po/ja.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-06 14:35+0200\n"
+"POT-Creation-Date: 2026-09-06 23:44+0200\n"
 "PO-Revision-Date: 2026-09-05 10:54+0000\n"
 "Last-Translator: \n"
 "Language-Team: Japanese\n"
@@ -2896,7 +2896,7 @@ msgstr "キューに入っています"
 msgid "Uploading"
 msgstr "アップロード"
 
-#: src/GenericClientListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/PeerCapabilities.h
 #, fuzzy
 msgid "None"
 msgstr "誰も許可しない"
@@ -4286,6 +4286,10 @@ msgstr "サーバ名"
 #: src/muuli_wdr.cpp
 msgid "Obfuscation"
 msgstr "難読化"
+
+#: src/muuli_wdr.cpp
+msgid "Vendor capabilities:"
+msgstr ""
 
 #: src/muuli_wdr.cpp
 msgid "Transfers to client"

--- a/po/ja.po
+++ b/po/ja.po
@@ -2896,7 +2896,7 @@ msgstr "キューに入っています"
 msgid "Uploading"
 msgstr "アップロード"
 
-#: src/GenericClientListCtrl.cpp src/PeerCapabilities.h
+#: src/GenericClientListCtrl.cpp
 #, fuzzy
 msgid "None"
 msgstr "誰も許可しない"
@@ -4288,8 +4288,9 @@ msgid "Obfuscation"
 msgstr "難読化"
 
 #: src/muuli_wdr.cpp
-msgid "Vendor capabilities:"
-msgstr ""
+#, fuzzy
+msgid "Protocol extensions:"
+msgstr "プロトコルを難読化する"
 
 #: src/muuli_wdr.cpp
 msgid "Transfers to client"
@@ -6079,6 +6080,27 @@ msgstr ""
 #, c-format
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "エラー: 部分ファイル '%s' が開けませんでした"
+
+#: src/PeerCapabilities.h
+#, fuzzy
+msgid "Extended source exchange"
+msgstr "ソース交流"
+
+#: src/PeerCapabilities.h
+msgid "NAT traversal (uTP)"
+msgstr ""
+
+#: src/PeerCapabilities.h
+msgid "IPv6"
+msgstr ""
+
+#: src/PeerCapabilities.h
+msgid "Buddy info pull"
+msgstr ""
+
+#: src/PeerCapabilities.h
+msgid "NAT traversal (QUIC)"
+msgstr ""
 
 #: src/Preferences.cpp
 msgid "no options available"

--- a/po/ko_KR.po
+++ b/po/ko_KR.po
@@ -2916,7 +2916,7 @@ msgstr "대기열에"
 msgid "Uploading"
 msgstr "올려주기"
 
-#: src/GenericClientListCtrl.cpp src/PeerCapabilities.h
+#: src/GenericClientListCtrl.cpp
 #, fuzzy
 msgid "None"
 msgstr "아무도"
@@ -4318,8 +4318,9 @@ msgid "Obfuscation"
 msgstr "프로토콜 난독화"
 
 #: src/muuli_wdr.cpp
-msgid "Vendor capabilities:"
-msgstr ""
+#, fuzzy
+msgid "Protocol extensions:"
+msgstr "프로토콜 난독화"
 
 #: src/muuli_wdr.cpp
 msgid "Transfers to client"
@@ -6113,6 +6114,27 @@ msgstr ""
 #: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Failed to open partfile '%s'"
+msgstr ""
+
+#: src/PeerCapabilities.h
+#, fuzzy
+msgid "Extended source exchange"
+msgstr "자료 교환"
+
+#: src/PeerCapabilities.h
+msgid "NAT traversal (uTP)"
+msgstr ""
+
+#: src/PeerCapabilities.h
+msgid "IPv6"
+msgstr ""
+
+#: src/PeerCapabilities.h
+msgid "Buddy info pull"
+msgstr ""
+
+#: src/PeerCapabilities.h
+msgid "NAT traversal (QUIC)"
 msgstr ""
 
 #: src/Preferences.cpp

--- a/po/ko_KR.po
+++ b/po/ko_KR.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-06 14:35+0200\n"
+"POT-Creation-Date: 2026-09-06 23:44+0200\n"
 "PO-Revision-Date: 2026-09-05 10:55+0000\n"
 "Last-Translator: Hyunju Kang <rexington@gmail.com>\n"
 "Language-Team: Korean <hoenny@daum.net>\n"
@@ -2916,7 +2916,7 @@ msgstr "대기열에"
 msgid "Uploading"
 msgstr "올려주기"
 
-#: src/GenericClientListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/PeerCapabilities.h
 #, fuzzy
 msgid "None"
 msgstr "아무도"
@@ -4316,6 +4316,10 @@ msgstr "서버 이름"
 #, fuzzy
 msgid "Obfuscation"
 msgstr "프로토콜 난독화"
+
+#: src/muuli_wdr.cpp
+msgid "Vendor capabilities:"
+msgstr ""
 
 #: src/muuli_wdr.cpp
 msgid "Transfers to client"

--- a/po/lt.po
+++ b/po/lt.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-06 14:35+0200\n"
+"POT-Creation-Date: 2026-09-06 23:44+0200\n"
 "PO-Revision-Date: 2026-09-05 10:55+0000\n"
 "Last-Translator: Dovydas Sankauskas <laisve@gmail.com>\n"
 "Language-Team: Lithuanian <komp_lt@konf.lt>\n"
@@ -2929,7 +2929,7 @@ msgstr "Eilėje"
 msgid "Uploading"
 msgstr "Išsiuntimas"
 
-#: src/GenericClientListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/PeerCapabilities.h
 #, fuzzy
 msgid "None"
 msgstr "Niekas"
@@ -4338,6 +4338,10 @@ msgstr "Serverio pavadinimas"
 #: src/muuli_wdr.cpp
 msgid "Obfuscation"
 msgstr "Slėpimas"
+
+#: src/muuli_wdr.cpp
+msgid "Vendor capabilities:"
+msgstr ""
 
 #: src/muuli_wdr.cpp
 msgid "Transfers to client"

--- a/po/lt.po
+++ b/po/lt.po
@@ -2929,7 +2929,7 @@ msgstr "Eilėje"
 msgid "Uploading"
 msgstr "Išsiuntimas"
 
-#: src/GenericClientListCtrl.cpp src/PeerCapabilities.h
+#: src/GenericClientListCtrl.cpp
 #, fuzzy
 msgid "None"
 msgstr "Niekas"
@@ -4340,8 +4340,9 @@ msgid "Obfuscation"
 msgstr "Slėpimas"
 
 #: src/muuli_wdr.cpp
-msgid "Vendor capabilities:"
-msgstr ""
+#, fuzzy
+msgid "Protocol extensions:"
+msgstr "Protokolo slėpimas"
 
 #: src/muuli_wdr.cpp
 msgid "Transfers to client"
@@ -6140,6 +6141,27 @@ msgstr "Nepakanka laisvos vietos"
 #, c-format
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "KLAIDA: nepavyko atverti dalių failo „%s“"
+
+#: src/PeerCapabilities.h
+#, fuzzy
+msgid "Extended source exchange"
+msgstr "Keičiamasi šaltiniais"
+
+#: src/PeerCapabilities.h
+msgid "NAT traversal (uTP)"
+msgstr ""
+
+#: src/PeerCapabilities.h
+msgid "IPv6"
+msgstr ""
+
+#: src/PeerCapabilities.h
+msgid "Buddy info pull"
+msgstr ""
+
+#: src/PeerCapabilities.h
+msgid "NAT traversal (QUIC)"
+msgstr ""
 
 #: src/Preferences.cpp
 msgid "no options available"

--- a/po/lv.po
+++ b/po/lv.po
@@ -2825,7 +2825,7 @@ msgstr ""
 msgid "Uploading"
 msgstr "Augšupielādē"
 
-#: src/GenericClientListCtrl.cpp src/PeerCapabilities.h
+#: src/GenericClientListCtrl.cpp
 msgid "None"
 msgstr ""
 
@@ -4216,7 +4216,7 @@ msgid "Obfuscation"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Vendor capabilities:"
+msgid "Protocol extensions:"
 msgstr ""
 
 #: src/muuli_wdr.cpp
@@ -5976,6 +5976,26 @@ msgstr ""
 #: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Failed to open partfile '%s'"
+msgstr ""
+
+#: src/PeerCapabilities.h
+msgid "Extended source exchange"
+msgstr ""
+
+#: src/PeerCapabilities.h
+msgid "NAT traversal (uTP)"
+msgstr ""
+
+#: src/PeerCapabilities.h
+msgid "IPv6"
+msgstr ""
+
+#: src/PeerCapabilities.h
+msgid "Buddy info pull"
+msgstr ""
+
+#: src/PeerCapabilities.h
+msgid "NAT traversal (QUIC)"
 msgstr ""
 
 #: src/Preferences.cpp

--- a/po/lv.po
+++ b/po/lv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-06 14:35+0200\n"
+"POT-Creation-Date: 2026-09-06 23:44+0200\n"
 "PO-Revision-Date: 2026-09-05 11:05+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -2825,7 +2825,7 @@ msgstr ""
 msgid "Uploading"
 msgstr "Augšupielādē"
 
-#: src/GenericClientListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/PeerCapabilities.h
 msgid "None"
 msgstr ""
 
@@ -4213,6 +4213,10 @@ msgstr "Servera nosaukums"
 
 #: src/muuli_wdr.cpp
 msgid "Obfuscation"
+msgstr ""
+
+#: src/muuli_wdr.cpp
+msgid "Vendor capabilities:"
 msgstr ""
 
 #: src/muuli_wdr.cpp

--- a/po/nl.po
+++ b/po/nl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-06 14:35+0200\n"
+"POT-Creation-Date: 2026-09-06 23:44+0200\n"
 "PO-Revision-Date: 2026-09-05 10:56+0000\n"
 "Last-Translator: Marcel Pol <marcel@timelord.nl>\n"
 "Language-Team: Dutch <nl@li.org>\n"
@@ -2890,7 +2890,7 @@ msgstr "In wachtrij: %u"
 msgid "Uploading"
 msgstr "Aan het uploaden"
 
-#: src/GenericClientListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/PeerCapabilities.h
 msgid "None"
 msgstr "Geen"
 
@@ -4264,6 +4264,10 @@ msgstr "Server-naam"
 #: src/muuli_wdr.cpp
 msgid "Obfuscation"
 msgstr "Maskering"
+
+#: src/muuli_wdr.cpp
+msgid "Vendor capabilities:"
+msgstr ""
 
 #: src/muuli_wdr.cpp
 msgid "Transfers to client"

--- a/po/nl.po
+++ b/po/nl.po
@@ -2890,7 +2890,7 @@ msgstr "In wachtrij: %u"
 msgid "Uploading"
 msgstr "Aan het uploaden"
 
-#: src/GenericClientListCtrl.cpp src/PeerCapabilities.h
+#: src/GenericClientListCtrl.cpp
 msgid "None"
 msgstr "Geen"
 
@@ -4266,8 +4266,9 @@ msgid "Obfuscation"
 msgstr "Maskering"
 
 #: src/muuli_wdr.cpp
-msgid "Vendor capabilities:"
-msgstr ""
+#, fuzzy
+msgid "Protocol extensions:"
+msgstr "Protocol-obfuscatie"
 
 #: src/muuli_wdr.cpp
 msgid "Transfers to client"
@@ -6038,6 +6039,27 @@ msgstr "Onvoldoende schijfruimte"
 #, c-format
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "FOUT: Kon deelbestand '%s' niet openen"
+
+#: src/PeerCapabilities.h
+#, fuzzy
+msgid "Extended source exchange"
+msgstr "Bron uitwisseling"
+
+#: src/PeerCapabilities.h
+msgid "NAT traversal (uTP)"
+msgstr ""
+
+#: src/PeerCapabilities.h
+msgid "IPv6"
+msgstr ""
+
+#: src/PeerCapabilities.h
+msgid "Buddy info pull"
+msgstr ""
+
+#: src/PeerCapabilities.h
+msgid "NAT traversal (QUIC)"
+msgstr ""
 
 #: src/Preferences.cpp
 msgid "no options available"

--- a/po/nn.po
+++ b/po/nn.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-06 14:35+0200\n"
+"POT-Creation-Date: 2026-09-06 23:44+0200\n"
 "PO-Revision-Date: 2026-09-05 10:56+0000\n"
 "Last-Translator: Hallvor Brunstad <Hallvor_1976@yahoo.com>\n"
 "Language-Team: <i18n-nn@lister.ping.uio.no>\n"
@@ -2915,7 +2915,7 @@ msgstr "I kø"
 msgid "Uploading"
 msgstr "Opplasting"
 
-#: src/GenericClientListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/PeerCapabilities.h
 #, fuzzy
 msgid "None"
 msgstr "Ingen"
@@ -4315,6 +4315,10 @@ msgstr "Tenarnamn"
 #: src/muuli_wdr.cpp
 msgid "Obfuscation"
 msgstr "Tåkelegging"
+
+#: src/muuli_wdr.cpp
+msgid "Vendor capabilities:"
+msgstr ""
 
 #: src/muuli_wdr.cpp
 msgid "Transfers to client"

--- a/po/nn.po
+++ b/po/nn.po
@@ -2915,7 +2915,7 @@ msgstr "I kø"
 msgid "Uploading"
 msgstr "Opplasting"
 
-#: src/GenericClientListCtrl.cpp src/PeerCapabilities.h
+#: src/GenericClientListCtrl.cpp
 #, fuzzy
 msgid "None"
 msgstr "Ingen"
@@ -4317,8 +4317,9 @@ msgid "Obfuscation"
 msgstr "Tåkelegging"
 
 #: src/muuli_wdr.cpp
-msgid "Vendor capabilities:"
-msgstr ""
+#, fuzzy
+msgid "Protocol extensions:"
+msgstr "Protokolltåkeleggjing"
 
 #: src/muuli_wdr.cpp
 msgid "Transfers to client"
@@ -6113,6 +6114,27 @@ msgstr "Ikkje nok diskplass"
 #, c-format
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "Feil: Greidde ikkje opne delfila '%s'"
+
+#: src/PeerCapabilities.h
+#, fuzzy
+msgid "Extended source exchange"
+msgstr "Kjeldeutveksling"
+
+#: src/PeerCapabilities.h
+msgid "NAT traversal (uTP)"
+msgstr ""
+
+#: src/PeerCapabilities.h
+msgid "IPv6"
+msgstr ""
+
+#: src/PeerCapabilities.h
+msgid "Buddy info pull"
+msgstr ""
+
+#: src/PeerCapabilities.h
+msgid "NAT traversal (QUIC)"
+msgstr ""
 
 #: src/Preferences.cpp
 msgid "no options available"

--- a/po/pl.po
+++ b/po/pl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-06 14:35+0200\n"
+"POT-Creation-Date: 2026-09-06 23:44+0200\n"
 "PO-Revision-Date: 2026-09-05 10:57+0000\n"
 "Last-Translator: Michał Trzebiatowski <hippie_1968@hotmail.com>\n"
 "Language-Team: translationproject.org/team/pl.html <translation-team-pl@lists.sourceforge.net>\n"
@@ -2913,7 +2913,7 @@ msgstr "W kolejce"
 msgid "Uploading"
 msgstr "Wysyłanie"
 
-#: src/GenericClientListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/PeerCapabilities.h
 msgid "None"
 msgstr "Brak"
 
@@ -4317,6 +4317,10 @@ msgstr "Nazwa serwera"
 #: src/muuli_wdr.cpp
 msgid "Obfuscation"
 msgstr "Maskowanie"
+
+#: src/muuli_wdr.cpp
+msgid "Vendor capabilities:"
+msgstr ""
 
 #: src/muuli_wdr.cpp
 msgid "Transfers to client"

--- a/po/pl.po
+++ b/po/pl.po
@@ -2913,7 +2913,7 @@ msgstr "W kolejce"
 msgid "Uploading"
 msgstr "Wysyłanie"
 
-#: src/GenericClientListCtrl.cpp src/PeerCapabilities.h
+#: src/GenericClientListCtrl.cpp
 msgid "None"
 msgstr "Brak"
 
@@ -4319,8 +4319,9 @@ msgid "Obfuscation"
 msgstr "Maskowanie"
 
 #: src/muuli_wdr.cpp
-msgid "Vendor capabilities:"
-msgstr ""
+#, fuzzy
+msgid "Protocol extensions:"
+msgstr "Maskowanie protokołu"
 
 #: src/muuli_wdr.cpp
 msgid "Transfers to client"
@@ -6116,6 +6117,27 @@ msgstr "Niewystarczająca ilość przestrzeni dyskowej"
 #, c-format
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "BŁĄD: Nie udało się otworzyć pliku części '%s'"
+
+#: src/PeerCapabilities.h
+#, fuzzy
+msgid "Extended source exchange"
+msgstr "Wymiana źródeł"
+
+#: src/PeerCapabilities.h
+msgid "NAT traversal (uTP)"
+msgstr ""
+
+#: src/PeerCapabilities.h
+msgid "IPv6"
+msgstr ""
+
+#: src/PeerCapabilities.h
+msgid "Buddy info pull"
+msgstr ""
+
+#: src/PeerCapabilities.h
+msgid "NAT traversal (QUIC)"
+msgstr ""
 
 #: src/Preferences.cpp
 msgid "no options available"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-06 14:35+0200\n"
+"POT-Creation-Date: 2026-09-06 23:44+0200\n"
 "PO-Revision-Date: 2026-09-05 10:58+0000\n"
 "Last-Translator: Marcelo Jimenez <mroberto@users.sourceforge.com>\n"
 "Language-Team: Português (Brasileiro) <pt@li.org>\n"
@@ -2894,7 +2894,7 @@ msgstr "Na fila: %u"
 msgid "Uploading"
 msgstr "Enviando"
 
-#: src/GenericClientListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/PeerCapabilities.h
 msgid "None"
 msgstr "Nenhum"
 
@@ -4267,6 +4267,10 @@ msgstr "Nome do Servidor"
 #: src/muuli_wdr.cpp
 msgid "Obfuscation"
 msgstr "Obfuscação"
+
+#: src/muuli_wdr.cpp
+msgid "Vendor capabilities:"
+msgstr ""
 
 #: src/muuli_wdr.cpp
 msgid "Transfers to client"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -2894,7 +2894,7 @@ msgstr "Na fila: %u"
 msgid "Uploading"
 msgstr "Enviando"
 
-#: src/GenericClientListCtrl.cpp src/PeerCapabilities.h
+#: src/GenericClientListCtrl.cpp
 msgid "None"
 msgstr "Nenhum"
 
@@ -4269,8 +4269,9 @@ msgid "Obfuscation"
 msgstr "Obfuscação"
 
 #: src/muuli_wdr.cpp
-msgid "Vendor capabilities:"
-msgstr ""
+#, fuzzy
+msgid "Protocol extensions:"
+msgstr "Obscurecimento de Protocolo"
 
 #: src/muuli_wdr.cpp
 msgid "Transfers to client"
@@ -6041,6 +6042,27 @@ msgstr "Espaço em disco insuficiente"
 #, c-format
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "ERRO: Falha ao abrir partfile '%s'"
+
+#: src/PeerCapabilities.h
+#, fuzzy
+msgid "Extended source exchange"
+msgstr "Troca de Fontes"
+
+#: src/PeerCapabilities.h
+msgid "NAT traversal (uTP)"
+msgstr ""
+
+#: src/PeerCapabilities.h
+msgid "IPv6"
+msgstr ""
+
+#: src/PeerCapabilities.h
+msgid "Buddy info pull"
+msgstr ""
+
+#: src/PeerCapabilities.h
+msgid "NAT traversal (QUIC)"
+msgstr ""
 
 #: src/Preferences.cpp
 msgid "no options available"

--- a/po/pt_PT.po
+++ b/po/pt_PT.po
@@ -2905,7 +2905,7 @@ msgstr "Em Fila de Espera: %u"
 msgid "Uploading"
 msgstr "A Enviar"
 
-#: src/GenericClientListCtrl.cpp src/PeerCapabilities.h
+#: src/GenericClientListCtrl.cpp
 msgid "None"
 msgstr "Nenhum"
 
@@ -4302,8 +4302,9 @@ msgid "Obfuscation"
 msgstr "Ofuscação"
 
 #: src/muuli_wdr.cpp
-msgid "Vendor capabilities:"
-msgstr ""
+#, fuzzy
+msgid "Protocol extensions:"
+msgstr "Ofuscação do Protocolo"
 
 #: src/muuli_wdr.cpp
 msgid "Transfers to client"
@@ -6089,6 +6090,27 @@ msgstr "Espaço em disco insuficiente"
 #, c-format
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "ERRO: Falhou ao abrir ficheiro de partes '%s'"
+
+#: src/PeerCapabilities.h
+#, fuzzy
+msgid "Extended source exchange"
+msgstr "Troca de Fontes"
+
+#: src/PeerCapabilities.h
+msgid "NAT traversal (uTP)"
+msgstr ""
+
+#: src/PeerCapabilities.h
+msgid "IPv6"
+msgstr ""
+
+#: src/PeerCapabilities.h
+msgid "Buddy info pull"
+msgstr ""
+
+#: src/PeerCapabilities.h
+msgid "NAT traversal (QUIC)"
+msgstr ""
 
 #: src/Preferences.cpp
 msgid "no options available"

--- a/po/pt_PT.po
+++ b/po/pt_PT.po
@@ -17,7 +17,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-06 14:35+0200\n"
+"POT-Creation-Date: 2026-09-06 23:44+0200\n"
 "PO-Revision-Date: 2026-09-05 10:58+0000\n"
 "Last-Translator: Luís Picciochi Oliveira <Pitxyoki@Gmail.com>\n"
 "Language-Team: Portuguese <traduz@debianpt.org>\n"
@@ -2905,7 +2905,7 @@ msgstr "Em Fila de Espera: %u"
 msgid "Uploading"
 msgstr "A Enviar"
 
-#: src/GenericClientListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/PeerCapabilities.h
 msgid "None"
 msgstr "Nenhum"
 
@@ -4300,6 +4300,10 @@ msgstr "Nome do servidor"
 #: src/muuli_wdr.cpp
 msgid "Obfuscation"
 msgstr "Ofuscação"
+
+#: src/muuli_wdr.cpp
+msgid "Vendor capabilities:"
+msgstr ""
 
 #: src/muuli_wdr.cpp
 msgid "Transfers to client"

--- a/po/ro.po
+++ b/po/ro.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-06 14:35+0200\n"
+"POT-Creation-Date: 2026-09-06 23:44+0200\n"
 "PO-Revision-Date: 2026-09-05 10:59+0000\n"
 "Last-Translator: Angelescu Constantin <titus0818@yahoo.com>\n"
 "Language-Team: English <kde-i18n-doc@kde.org>\n"
@@ -2908,7 +2908,7 @@ msgstr "În coadă: %u"
 msgid "Uploading"
 msgstr "Se încarcă"
 
-#: src/GenericClientListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/PeerCapabilities.h
 msgid "None"
 msgstr "Niciunul"
 
@@ -4312,6 +4312,10 @@ msgstr "Nume server"
 #: src/muuli_wdr.cpp
 msgid "Obfuscation"
 msgstr "Disimulare"
+
+#: src/muuli_wdr.cpp
+msgid "Vendor capabilities:"
+msgstr ""
 
 #: src/muuli_wdr.cpp
 msgid "Transfers to client"

--- a/po/ro.po
+++ b/po/ro.po
@@ -2908,7 +2908,7 @@ msgstr "În coadă: %u"
 msgid "Uploading"
 msgstr "Se încarcă"
 
-#: src/GenericClientListCtrl.cpp src/PeerCapabilities.h
+#: src/GenericClientListCtrl.cpp
 msgid "None"
 msgstr "Niciunul"
 
@@ -4314,8 +4314,9 @@ msgid "Obfuscation"
 msgstr "Disimulare"
 
 #: src/muuli_wdr.cpp
-msgid "Vendor capabilities:"
-msgstr ""
+#, fuzzy
+msgid "Protocol extensions:"
+msgstr "Protocol disimulare"
 
 #: src/muuli_wdr.cpp
 msgid "Transfers to client"
@@ -6103,6 +6104,27 @@ msgstr "Spațiu pe disc insuficient"
 #, c-format
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "EROARE: A eșuat deschiderea fișierului parțial '%s'"
+
+#: src/PeerCapabilities.h
+#, fuzzy
+msgid "Extended source exchange"
+msgstr "Schimb surse"
+
+#: src/PeerCapabilities.h
+msgid "NAT traversal (uTP)"
+msgstr ""
+
+#: src/PeerCapabilities.h
+msgid "IPv6"
+msgstr ""
+
+#: src/PeerCapabilities.h
+msgid "Buddy info pull"
+msgstr ""
+
+#: src/PeerCapabilities.h
+msgid "NAT traversal (QUIC)"
+msgstr ""
 
 #: src/Preferences.cpp
 msgid "no options available"

--- a/po/ru.po
+++ b/po/ru.po
@@ -2915,7 +2915,7 @@ msgstr "В очереди: %u"
 msgid "Uploading"
 msgstr "Отдаётся"
 
-#: src/GenericClientListCtrl.cpp src/PeerCapabilities.h
+#: src/GenericClientListCtrl.cpp
 msgid "None"
 msgstr "Нет"
 
@@ -4306,8 +4306,9 @@ msgid "Obfuscation"
 msgstr "Маскировка"
 
 #: src/muuli_wdr.cpp
-msgid "Vendor capabilities:"
-msgstr ""
+#, fuzzy
+msgid "Protocol extensions:"
+msgstr "Маскировка протокола"
 
 #: src/muuli_wdr.cpp
 msgid "Transfers to client"
@@ -6087,6 +6088,27 @@ msgstr "Недостаточно места на диске"
 #, c-format
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "ОШИБКА: не удалось открыть частично закаченный '%s'"
+
+#: src/PeerCapabilities.h
+#, fuzzy
+msgid "Extended source exchange"
+msgstr "Обмен источниками"
+
+#: src/PeerCapabilities.h
+msgid "NAT traversal (uTP)"
+msgstr ""
+
+#: src/PeerCapabilities.h
+msgid "IPv6"
+msgstr ""
+
+#: src/PeerCapabilities.h
+msgid "Buddy info pull"
+msgstr ""
+
+#: src/PeerCapabilities.h
+msgid "NAT traversal (QUIC)"
+msgstr ""
 
 #: src/Preferences.cpp
 msgid "no options available"

--- a/po/ru.po
+++ b/po/ru.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-06 14:35+0200\n"
+"POT-Creation-Date: 2026-09-06 23:44+0200\n"
 "PO-Revision-Date: 2026-09-05 11:00+0000\n"
 "Last-Translator: Radist Morse <radist.morse@gmail.com>\n"
 "Language-Team: Russian <kde-russian@lists.kde.ru>\n"
@@ -2915,7 +2915,7 @@ msgstr "В очереди: %u"
 msgid "Uploading"
 msgstr "Отдаётся"
 
-#: src/GenericClientListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/PeerCapabilities.h
 msgid "None"
 msgstr "Нет"
 
@@ -4304,6 +4304,10 @@ msgstr "Имя сервера"
 #: src/muuli_wdr.cpp
 msgid "Obfuscation"
 msgstr "Маскировка"
+
+#: src/muuli_wdr.cpp
+msgid "Vendor capabilities:"
+msgstr ""
 
 #: src/muuli_wdr.cpp
 msgid "Transfers to client"

--- a/po/sl.po
+++ b/po/sl.po
@@ -2929,7 +2929,7 @@ msgstr "V vrsti: %u"
 msgid "Uploading"
 msgstr "Pošiljanje"
 
-#: src/GenericClientListCtrl.cpp src/PeerCapabilities.h
+#: src/GenericClientListCtrl.cpp
 msgid "None"
 msgstr "Brez"
 
@@ -4344,8 +4344,9 @@ msgid "Obfuscation"
 msgstr "Maskiranje"
 
 #: src/muuli_wdr.cpp
-msgid "Vendor capabilities:"
-msgstr ""
+#, fuzzy
+msgid "Protocol extensions:"
+msgstr "Maskiranje protokola"
 
 #: src/muuli_wdr.cpp
 msgid "Transfers to client"
@@ -6142,6 +6143,27 @@ msgstr "Premalo prostora na disku"
 #, c-format
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "NAPAKA: delne datoteke »%s« ni bilo moč odpreti"
+
+#: src/PeerCapabilities.h
+#, fuzzy
+msgid "Extended source exchange"
+msgstr "Izmenjava virov"
+
+#: src/PeerCapabilities.h
+msgid "NAT traversal (uTP)"
+msgstr ""
+
+#: src/PeerCapabilities.h
+msgid "IPv6"
+msgstr ""
+
+#: src/PeerCapabilities.h
+msgid "Buddy info pull"
+msgstr ""
+
+#: src/PeerCapabilities.h
+msgid "NAT traversal (QUIC)"
+msgstr ""
 
 #: src/Preferences.cpp
 msgid "no options available"

--- a/po/sl.po
+++ b/po/sl.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-06 14:35+0200\n"
+"POT-Creation-Date: 2026-09-06 23:44+0200\n"
 "PO-Revision-Date: 2026-09-05 11:00+0000\n"
 "Last-Translator: Jure Repinc <jlp@holodeck1.com>\n"
 "Language-Team: Slovenian\n"
@@ -2929,7 +2929,7 @@ msgstr "V vrsti: %u"
 msgid "Uploading"
 msgstr "Pošiljanje"
 
-#: src/GenericClientListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/PeerCapabilities.h
 msgid "None"
 msgstr "Brez"
 
@@ -4342,6 +4342,10 @@ msgstr "Ime strežnika"
 #: src/muuli_wdr.cpp
 msgid "Obfuscation"
 msgstr "Maskiranje"
+
+#: src/muuli_wdr.cpp
+msgid "Vendor capabilities:"
+msgstr ""
 
 #: src/muuli_wdr.cpp
 msgid "Transfers to client"

--- a/po/sq.po
+++ b/po/sq.po
@@ -2909,7 +2909,7 @@ msgstr "Ne radhe"
 msgid "Uploading"
 msgstr "Ngarkim"
 
-#: src/GenericClientListCtrl.cpp src/PeerCapabilities.h
+#: src/GenericClientListCtrl.cpp
 #, fuzzy
 msgid "None"
 msgstr "Asnjeri"
@@ -4311,8 +4311,9 @@ msgid "Obfuscation"
 msgstr "Protokolli i Turbullimit"
 
 #: src/muuli_wdr.cpp
-msgid "Vendor capabilities:"
-msgstr ""
+#, fuzzy
+msgid "Protocol extensions:"
+msgstr "Protokolli i Turbullimit"
 
 #: src/muuli_wdr.cpp
 msgid "Transfers to client"
@@ -6105,6 +6106,27 @@ msgstr ""
 #: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Failed to open partfile '%s'"
+msgstr ""
+
+#: src/PeerCapabilities.h
+#, fuzzy
+msgid "Extended source exchange"
+msgstr "Shkembim burimesh"
+
+#: src/PeerCapabilities.h
+msgid "NAT traversal (uTP)"
+msgstr ""
+
+#: src/PeerCapabilities.h
+msgid "IPv6"
+msgstr ""
+
+#: src/PeerCapabilities.h
+msgid "Buddy info pull"
+msgstr ""
+
+#: src/PeerCapabilities.h
+msgid "NAT traversal (QUIC)"
 msgstr ""
 
 #: src/Preferences.cpp

--- a/po/sq.po
+++ b/po/sq.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-06 14:35+0200\n"
+"POT-Creation-Date: 2026-09-06 23:44+0200\n"
 "PO-Revision-Date: 2026-09-05 11:01+0000\n"
 "Last-Translator: Fation <dj_barthezz@linuxmail.org lushnja_corps@hotmail.Language-Team:\n"
 "Language: sq\n"
@@ -2909,7 +2909,7 @@ msgstr "Ne radhe"
 msgid "Uploading"
 msgstr "Ngarkim"
 
-#: src/GenericClientListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/PeerCapabilities.h
 #, fuzzy
 msgid "None"
 msgstr "Asnjeri"
@@ -4309,6 +4309,10 @@ msgstr "Emri i Serverit"
 #, fuzzy
 msgid "Obfuscation"
 msgstr "Protokolli i Turbullimit"
+
+#: src/muuli_wdr.cpp
+msgid "Vendor capabilities:"
+msgstr ""
 
 #: src/muuli_wdr.cpp
 msgid "Transfers to client"

--- a/po/sv.po
+++ b/po/sv.po
@@ -2897,7 +2897,7 @@ msgstr "På kö: %u"
 msgid "Uploading"
 msgstr "Skickar"
 
-#: src/GenericClientListCtrl.cpp src/PeerCapabilities.h
+#: src/GenericClientListCtrl.cpp
 msgid "None"
 msgstr "Ingen"
 
@@ -4294,8 +4294,9 @@ msgid "Obfuscation"
 msgstr "Fördunkling"
 
 #: src/muuli_wdr.cpp
-msgid "Vendor capabilities:"
-msgstr ""
+#, fuzzy
+msgid "Protocol extensions:"
+msgstr "Protokollfördunkling"
 
 #: src/muuli_wdr.cpp
 msgid "Transfers to client"
@@ -6079,6 +6080,27 @@ msgstr "Otillräckligt diskutrymme"
 #, c-format
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "FEL: Det gick inte att öppna partfile ' %s '"
+
+#: src/PeerCapabilities.h
+#, fuzzy
+msgid "Extended source exchange"
+msgstr "Källutbyte"
+
+#: src/PeerCapabilities.h
+msgid "NAT traversal (uTP)"
+msgstr ""
+
+#: src/PeerCapabilities.h
+msgid "IPv6"
+msgstr ""
+
+#: src/PeerCapabilities.h
+msgid "Buddy info pull"
+msgstr ""
+
+#: src/PeerCapabilities.h
+msgid "NAT traversal (QUIC)"
+msgstr ""
 
 #: src/Preferences.cpp
 msgid "no options available"

--- a/po/sv.po
+++ b/po/sv.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-06 14:35+0200\n"
+"POT-Creation-Date: 2026-09-06 23:44+0200\n"
 "PO-Revision-Date: 2026-09-05 11:01+0000\n"
 "Last-Translator: raffe <raffe@localhost.se>\n"
 "Language-Team: Swedish <tp-sv@listor.tp-sv.se>\n"
@@ -2897,7 +2897,7 @@ msgstr "På kö: %u"
 msgid "Uploading"
 msgstr "Skickar"
 
-#: src/GenericClientListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/PeerCapabilities.h
 msgid "None"
 msgstr "Ingen"
 
@@ -4292,6 +4292,10 @@ msgstr "Servernamn"
 #: src/muuli_wdr.cpp
 msgid "Obfuscation"
 msgstr "Fördunkling"
+
+#: src/muuli_wdr.cpp
+msgid "Vendor capabilities:"
+msgstr ""
 
 #: src/muuli_wdr.cpp
 msgid "Transfers to client"

--- a/po/ta.po
+++ b/po/ta.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-06 14:35+0200\n"
+"POT-Creation-Date: 2026-09-06 23:44+0200\n"
 "PO-Revision-Date: 2026-09-05 11:06+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -2801,7 +2801,7 @@ msgstr ""
 msgid "Uploading"
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/PeerCapabilities.h
 msgid "None"
 msgstr ""
 
@@ -4171,6 +4171,10 @@ msgstr ""
 
 #: src/muuli_wdr.cpp
 msgid "Obfuscation"
+msgstr ""
+
+#: src/muuli_wdr.cpp
+msgid "Vendor capabilities:"
 msgstr ""
 
 #: src/muuli_wdr.cpp

--- a/po/ta.po
+++ b/po/ta.po
@@ -2801,7 +2801,7 @@ msgstr ""
 msgid "Uploading"
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp src/PeerCapabilities.h
+#: src/GenericClientListCtrl.cpp
 msgid "None"
 msgstr ""
 
@@ -4174,7 +4174,7 @@ msgid "Obfuscation"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Vendor capabilities:"
+msgid "Protocol extensions:"
 msgstr ""
 
 #: src/muuli_wdr.cpp
@@ -5924,6 +5924,26 @@ msgstr ""
 #: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Failed to open partfile '%s'"
+msgstr ""
+
+#: src/PeerCapabilities.h
+msgid "Extended source exchange"
+msgstr ""
+
+#: src/PeerCapabilities.h
+msgid "NAT traversal (uTP)"
+msgstr ""
+
+#: src/PeerCapabilities.h
+msgid "IPv6"
+msgstr ""
+
+#: src/PeerCapabilities.h
+msgid "Buddy info pull"
+msgstr ""
+
+#: src/PeerCapabilities.h
+msgid "NAT traversal (QUIC)"
 msgstr ""
 
 #: src/Preferences.cpp

--- a/po/tr.po
+++ b/po/tr.po
@@ -2886,7 +2886,7 @@ msgstr "Sırada: %u"
 msgid "Uploading"
 msgstr "Gönderiliyor"
 
-#: src/GenericClientListCtrl.cpp src/PeerCapabilities.h
+#: src/GenericClientListCtrl.cpp
 msgid "None"
 msgstr "Yok"
 
@@ -4261,8 +4261,9 @@ msgid "Obfuscation"
 msgstr "Gizleme"
 
 #: src/muuli_wdr.cpp
-msgid "Vendor capabilities:"
-msgstr ""
+#, fuzzy
+msgid "Protocol extensions:"
+msgstr "Protokol Gizleme"
 
 #: src/muuli_wdr.cpp
 msgid "Transfers to client"
@@ -6029,6 +6030,27 @@ msgstr "Yetersiz disk alanı"
 #, c-format
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "HATA: Parça dosyası '%s' açılamıyor"
+
+#: src/PeerCapabilities.h
+#, fuzzy
+msgid "Extended source exchange"
+msgstr "Kaynak Değişimi"
+
+#: src/PeerCapabilities.h
+msgid "NAT traversal (uTP)"
+msgstr ""
+
+#: src/PeerCapabilities.h
+msgid "IPv6"
+msgstr ""
+
+#: src/PeerCapabilities.h
+msgid "Buddy info pull"
+msgstr ""
+
+#: src/PeerCapabilities.h
+msgid "NAT traversal (QUIC)"
+msgstr ""
 
 #: src/Preferences.cpp
 msgid "no options available"

--- a/po/tr.po
+++ b/po/tr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-06 14:35+0200\n"
+"POT-Creation-Date: 2026-09-06 23:44+0200\n"
 "PO-Revision-Date: 2026-09-05 11:02+0000\n"
 "Last-Translator: \n"
 "Language-Team: Turkish <li@li.org>\n"
@@ -2886,7 +2886,7 @@ msgstr "Sırada: %u"
 msgid "Uploading"
 msgstr "Gönderiliyor"
 
-#: src/GenericClientListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/PeerCapabilities.h
 msgid "None"
 msgstr "Yok"
 
@@ -4259,6 +4259,10 @@ msgstr "Sunucu"
 #: src/muuli_wdr.cpp
 msgid "Obfuscation"
 msgstr "Gizleme"
+
+#: src/muuli_wdr.cpp
+msgid "Vendor capabilities:"
+msgstr ""
 
 #: src/muuli_wdr.cpp
 msgid "Transfers to client"

--- a/po/uk.po
+++ b/po/uk.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-06 14:35+0200\n"
+"POT-Creation-Date: 2026-09-06 23:44+0200\n"
 "PO-Revision-Date: 2026-09-05 11:02+0000\n"
 "Last-Translator: Oleksandr Kovalenko <alx.kovalenko@gmail.com>\n"
 "Language-Team: Ukrainian <translation@linux.org.ua>\n"
@@ -2924,7 +2924,7 @@ msgstr "В черзі"
 msgid "Uploading"
 msgstr "Вивантаження"
 
-#: src/GenericClientListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/PeerCapabilities.h
 #, fuzzy
 msgid "None"
 msgstr "Жоден"
@@ -4336,6 +4336,10 @@ msgstr "Назва сервера"
 #: src/muuli_wdr.cpp
 msgid "Obfuscation"
 msgstr "Приховування"
+
+#: src/muuli_wdr.cpp
+msgid "Vendor capabilities:"
+msgstr ""
 
 #: src/muuli_wdr.cpp
 msgid "Transfers to client"

--- a/po/uk.po
+++ b/po/uk.po
@@ -2924,7 +2924,7 @@ msgstr "В черзі"
 msgid "Uploading"
 msgstr "Вивантаження"
 
-#: src/GenericClientListCtrl.cpp src/PeerCapabilities.h
+#: src/GenericClientListCtrl.cpp
 #, fuzzy
 msgid "None"
 msgstr "Жоден"
@@ -4338,8 +4338,9 @@ msgid "Obfuscation"
 msgstr "Приховування"
 
 #: src/muuli_wdr.cpp
-msgid "Vendor capabilities:"
-msgstr ""
+#, fuzzy
+msgid "Protocol extensions:"
+msgstr "Приховування протоколу"
 
 #: src/muuli_wdr.cpp
 msgid "Transfers to client"
@@ -6140,6 +6141,27 @@ msgstr "Не вистачає місця на диску"
 #, c-format
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "ПОМИЛКА: не вдалося відкрити частковий файл '%s'"
+
+#: src/PeerCapabilities.h
+#, fuzzy
+msgid "Extended source exchange"
+msgstr "Обмін джерелами"
+
+#: src/PeerCapabilities.h
+msgid "NAT traversal (uTP)"
+msgstr ""
+
+#: src/PeerCapabilities.h
+msgid "IPv6"
+msgstr ""
+
+#: src/PeerCapabilities.h
+msgid "Buddy info pull"
+msgstr ""
+
+#: src/PeerCapabilities.h
+msgid "NAT traversal (QUIC)"
+msgstr ""
 
 #: src/Preferences.cpp
 msgid "no options available"

--- a/po/vi.po
+++ b/po/vi.po
@@ -2795,7 +2795,7 @@ msgstr ""
 msgid "Uploading"
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp src/PeerCapabilities.h
+#: src/GenericClientListCtrl.cpp
 msgid "None"
 msgstr ""
 
@@ -4164,7 +4164,7 @@ msgid "Obfuscation"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Vendor capabilities:"
+msgid "Protocol extensions:"
 msgstr ""
 
 #: src/muuli_wdr.cpp
@@ -5914,6 +5914,26 @@ msgstr ""
 #: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Failed to open partfile '%s'"
+msgstr ""
+
+#: src/PeerCapabilities.h
+msgid "Extended source exchange"
+msgstr ""
+
+#: src/PeerCapabilities.h
+msgid "NAT traversal (uTP)"
+msgstr ""
+
+#: src/PeerCapabilities.h
+msgid "IPv6"
+msgstr ""
+
+#: src/PeerCapabilities.h
+msgid "Buddy info pull"
+msgstr ""
+
+#: src/PeerCapabilities.h
+msgid "NAT traversal (QUIC)"
 msgstr ""
 
 #: src/Preferences.cpp

--- a/po/vi.po
+++ b/po/vi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-06 14:35+0200\n"
+"POT-Creation-Date: 2026-09-06 23:44+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -2795,7 +2795,7 @@ msgstr ""
 msgid "Uploading"
 msgstr ""
 
-#: src/GenericClientListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/PeerCapabilities.h
 msgid "None"
 msgstr ""
 
@@ -4161,6 +4161,10 @@ msgstr ""
 
 #: src/muuli_wdr.cpp
 msgid "Obfuscation"
+msgstr ""
+
+#: src/muuli_wdr.cpp
+msgid "Vendor capabilities:"
 msgstr ""
 
 #: src/muuli_wdr.cpp

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -2890,7 +2890,7 @@ msgstr "在队列中: %u"
 msgid "Uploading"
 msgstr "正在上传"
 
-#: src/GenericClientListCtrl.cpp src/PeerCapabilities.h
+#: src/GenericClientListCtrl.cpp
 msgid "None"
 msgstr "没有"
 
@@ -4265,8 +4265,9 @@ msgid "Obfuscation"
 msgstr "模糊协议"
 
 #: src/muuli_wdr.cpp
-msgid "Vendor capabilities:"
-msgstr ""
+#, fuzzy
+msgid "Protocol extensions:"
+msgstr "模糊协议"
 
 #: src/muuli_wdr.cpp
 msgid "Transfers to client"
@@ -6033,6 +6034,27 @@ msgstr "磁盘空间不足"
 #, c-format
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "错误：打开part文件'%s'失败"
+
+#: src/PeerCapabilities.h
+#, fuzzy
+msgid "Extended source exchange"
+msgstr "源交换"
+
+#: src/PeerCapabilities.h
+msgid "NAT traversal (uTP)"
+msgstr ""
+
+#: src/PeerCapabilities.h
+msgid "IPv6"
+msgstr ""
+
+#: src/PeerCapabilities.h
+msgid "Buddy info pull"
+msgstr ""
+
+#: src/PeerCapabilities.h
+msgid "NAT traversal (QUIC)"
+msgstr ""
 
 #: src/Preferences.cpp
 msgid "no options available"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-06 14:35+0200\n"
+"POT-Creation-Date: 2026-09-06 23:44+0200\n"
 "PO-Revision-Date: 2026-09-05 11:03+0000\n"
 "Last-Translator: Mike Akiba <mike2718@gmail.com>\n"
 "Language-Team: Chinese Simplified <kde-i18n-doc@kde.org>\n"
@@ -2890,7 +2890,7 @@ msgstr "在队列中: %u"
 msgid "Uploading"
 msgstr "正在上传"
 
-#: src/GenericClientListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/PeerCapabilities.h
 msgid "None"
 msgstr "没有"
 
@@ -4263,6 +4263,10 @@ msgstr "服务器名称"
 #: src/muuli_wdr.cpp
 msgid "Obfuscation"
 msgstr "模糊协议"
+
+#: src/muuli_wdr.cpp
+msgid "Vendor capabilities:"
+msgstr ""
 
 #: src/muuli_wdr.cpp
 msgid "Transfers to client"

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -2891,7 +2891,7 @@ msgstr "QR：%u"
 msgid "Uploading"
 msgstr "正在上傳"
 
-#: src/GenericClientListCtrl.cpp src/PeerCapabilities.h
+#: src/GenericClientListCtrl.cpp
 msgid "None"
 msgstr "無"
 
@@ -4279,8 +4279,9 @@ msgid "Obfuscation"
 msgstr "模糊協定"
 
 #: src/muuli_wdr.cpp
-msgid "Vendor capabilities:"
-msgstr ""
+#, fuzzy
+msgid "Protocol extensions:"
+msgstr "模糊協定"
 
 #: src/muuli_wdr.cpp
 msgid "Transfers to client"
@@ -6061,6 +6062,27 @@ msgstr "磁碟空間不足"
 #, c-format
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr "錯誤：無法開啟暫存檔 %s"
+
+#: src/PeerCapabilities.h
+#, fuzzy
+msgid "Extended source exchange"
+msgstr "來源交換"
+
+#: src/PeerCapabilities.h
+msgid "NAT traversal (uTP)"
+msgstr ""
+
+#: src/PeerCapabilities.h
+msgid "IPv6"
+msgstr ""
+
+#: src/PeerCapabilities.h
+msgid "Buddy info pull"
+msgstr ""
+
+#: src/PeerCapabilities.h
+msgid "NAT traversal (QUIC)"
+msgstr ""
 
 #: src/Preferences.cpp
 msgid "no options available"

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-06 14:35+0200\n"
+"POT-Creation-Date: 2026-09-06 23:44+0200\n"
 "PO-Revision-Date: 2026-09-05 11:04+0000\n"
 "Last-Translator: Wayne Su <mstarmstar@gmail.com>\n"
 "Language-Team: \n"
@@ -2891,7 +2891,7 @@ msgstr "QR：%u"
 msgid "Uploading"
 msgstr "正在上傳"
 
-#: src/GenericClientListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/PeerCapabilities.h
 msgid "None"
 msgstr "無"
 
@@ -4277,6 +4277,10 @@ msgstr "伺服器名稱"
 #: src/muuli_wdr.cpp
 msgid "Obfuscation"
 msgstr "模糊協定"
+
+#: src/muuli_wdr.cpp
+msgid "Vendor capabilities:"
+msgstr ""
 
 #: src/muuli_wdr.cpp
 msgid "Transfers to client"

--- a/src/BaseClient.cpp
+++ b/src/BaseClient.cpp
@@ -58,6 +58,7 @@
 #include "MemFile.h"           // Needed for CMemFile
 #include "Packet.h"            // Needed for CPacket
 #include "Friend.h"            // Needed for CFriend
+#include "PublicIPv6Corroboration.h"
 #include "ClientVersionString.h"
 #include "ClientList.h"       // Needed for CClientList
 #include "ChatSessionStore.h" // Needed for CChatSessionStore
@@ -689,6 +690,25 @@ bool CUpDownClient::ProcessHelloTypePacket(const CMemFile &data)
 			if (temptag.IsHash()) {
 				md4cpy(m_servingBuddyIPv6, temptag.GetHash().GetHash());
 				m_hasServingBuddyIPv6 = true;
+			}
+			break;
+
+		case CT_MOD_YOUR_IP:
+			// The address this peer says it saw us arrive from. Only the
+			// hash form is read: eMuleAI also accepts an integer form and
+			// sets its own public IPv4 from it, which lets a single
+			// unverified peer decide what this client believes its own
+			// address to be. emule-qt ignores the integer form, and this
+			// follows emule-qt.
+			//
+			// Even the hash form is not believed on one peer's word. It
+			// goes to a tracker that needs several distinct *observed*
+			// addresses to agree, keyed on where the packet actually came
+			// from rather than on the peer's self-declared user hash --
+			// a hash costs nothing to invent, a routable address does
+			// not. Nothing consumes the result yet; recognition only.
+			if (temptag.IsHash()) {
+				ObservedPublicIPv6().AddClaim(GetConnectIP(), temptag.GetHash().GetHash());
 			}
 			break;
 

--- a/src/BaseClient.cpp
+++ b/src/BaseClient.cpp
@@ -352,9 +352,9 @@ void CUpDownClient::ClearHelloProperties()
 	m_byKadVersion = 0;
 	m_modCapabilities.Reset();
 	m_hasModIPv6 = false;
-	m_hasModServerIPv6 = false;
+	m_hasServingBuddyIPv6 = false;
 	memset(m_modIPv6, 0, sizeof(m_modIPv6));
-	memset(m_modServerIPv6, 0, sizeof(m_modServerIPv6));
+	memset(m_servingBuddyIPv6, 0, sizeof(m_servingBuddyIPv6));
 	m_fRequestsCryptLayer = 0;
 	m_fSupportsCryptLayer = 0;
 	m_fRequiresCryptLayer = 0;
@@ -680,10 +680,15 @@ bool CUpDownClient::ProcessHelloTypePacket(const CMemFile &data)
 			}
 			break;
 
-		case CT_MOD_SVR_IP_V6:
+		case CT_EMULE_SERVINGBUDDYIPV6:
+			// 16 bytes, big-endian: the v6 counterpart of
+			// CT_EMULE_BUDDYIP above. aMule has no IPv6 stack yet, so
+			// like CT_MOD_IP_V6 this is stored for the dual-stack change
+			// and otherwise unused. Without it the buddy's v6 address
+			// arrives over Kad ("bi6") and is dropped in the hello.
 			if (temptag.IsHash()) {
-				md4cpy(m_modServerIPv6, temptag.GetHash().GetHash());
-				m_hasModServerIPv6 = true;
+				md4cpy(m_servingBuddyIPv6, temptag.GetHash().GetHash());
+				m_hasServingBuddyIPv6 = true;
 			}
 			break;
 

--- a/src/BaseClient.cpp
+++ b/src/BaseClient.cpp
@@ -666,7 +666,7 @@ bool CUpDownClient::ProcessHelloTypePacket(const CMemFile &data)
 				m_modCapabilities.SetFromWire((uint32)temptag.GetInt());
 				AddDebugLogLineN(logClient,
 					CFormat("Peer advertises vendor capabilities 0x%02X (%s)") %
-						m_modCapabilities.ToWire() %
+						m_modCapabilities.KnownBits() %
 						m_modCapabilities.GetDisplayText());
 			}
 			break;

--- a/src/BaseClient.cpp
+++ b/src/BaseClient.cpp
@@ -350,6 +350,11 @@ void CUpDownClient::ClearHelloProperties()
 	m_fOsInfoSupport = 0;
 	SecIdentSupRec = 0;
 	m_byKadVersion = 0;
+	m_modCapabilities.Reset();
+	m_hasModIPv6 = false;
+	m_hasModServerIPv6 = false;
+	memset(m_modIPv6, 0, sizeof(m_modIPv6));
+	memset(m_modServerIPv6, 0, sizeof(m_modServerIPv6));
 	m_fRequestsCryptLayer = 0;
 	m_fSupportsCryptLayer = 0;
 	m_fRequiresCryptLayer = 0;
@@ -643,6 +648,56 @@ bool CUpDownClient::ProcessHelloTypePacket(const CMemFile &data)
 			m_byEmuleVersion = 0x99;
 			m_fSharedDirectories = 1;
 			dwEmuleTags |= 4;
+			break;
+
+		// eMuleAI vendor capability tags. Recorded, never acted on: what
+		// aMule buys here is that an eMuleAI peer stops looking like a
+		// client sending malformed handshakes. The bit meanings are wire
+		// format and live in src/PeerCapabilities.h.
+		case CT_MOD_MISCOPTIONS:
+			//  1 Extended source exchange
+			//  1 Legacy uTP NAT traversal
+			//  1 IPv6
+			//  1 Serving-buddy pull
+			//  1 QUIC NAT traversal
+			// 27 Reserved -- masked off by SetFromWire, so nothing can be
+			//    inferred from a peer that sets them.
+			if (temptag.IsInt()) {
+				m_modCapabilities.SetFromWire((uint32)temptag.GetInt());
+				AddDebugLogLineN(logClient,
+					CFormat("Peer advertises vendor capabilities 0x%02X (%s)") %
+						m_modCapabilities.ToWire() %
+						m_modCapabilities.GetDisplayText());
+			}
+			break;
+
+		case CT_MOD_IP_V6:
+			// 16 bytes, big-endian. aMule has no IPv6 stack yet, so this
+			// is stored for the dual-stack change and otherwise unused.
+			if (temptag.IsHash()) {
+				md4cpy(m_modIPv6, temptag.GetHash().GetHash());
+				m_hasModIPv6 = true;
+			}
+			break;
+
+		case CT_MOD_SVR_IP_V6:
+			if (temptag.IsHash()) {
+				md4cpy(m_modServerIPv6, temptag.GetHash().GetHash());
+				m_hasModServerIPv6 = true;
+			}
+			break;
+
+		default:
+			// An unrecognised tag is not a broken handshake. The switch
+			// has always fallen through silently for tags aMule does not
+			// know; the only thing added here is visibility for the
+			// vendor range, because a new CT_MOD_* tag arriving in the
+			// wild is worth knowing about and is otherwise invisible.
+			if (temptag.GetNameID() >= 0xA0 && temptag.GetNameID() <= 0xAF) {
+				AddDebugLogLineN(logClient,
+					CFormat("Ignoring unknown vendor tag 0x%02X in hello from %s") %
+						temptag.GetNameID() % GetFullIP());
+			}
 			break;
 		}
 	}
@@ -1194,6 +1249,23 @@ void CUpDownClient::SendHelloTypePacket(CMemFile *data)
 	CTagVarInt tagMisCompatOptions(CT_EMULECOMPAT_OPTIONS, (nOSInfoSupport << 1 * 0), 32);
 
 	tagMisCompatOptions.WriteTagToFile(data);
+
+	// eMuleAI vendor capabilities (CT_MOD_MISCOPTIONS).
+	//
+	// Nothing is written, and that is the whole of the emit side for now:
+	// LocalAdvertisedModMiscOptions() is zero because aMule implements none
+	// of the five features, and eMuleAI treats an absent tag and an all-zero
+	// word identically. Advertising a capability aMule does not have is
+	// strictly worse than advertising none -- the peer opens a handshake that
+	// cannot complete and neither side logs a reason.
+	//
+	// A later change that ships one of these transports turns its bit on in
+	// LocalAdvertisedModMiscOptions(), emits the tag here, and adds one to
+	// `tagcount` above. Both must happen together: the tagcount is written
+	// before the tags and a mismatch desynchronises the reader.
+	static_assert(LocalAdvertisedModMiscOptions() == 0,
+		"a non-zero advertised capability word needs the CT_MOD_MISCOPTIONS tag emitted here "
+		"and tagcount incremented above");
 
 #ifdef __GIT__
 	wxString mod_name(MOD_VERSION_LONG);

--- a/src/BaseClient.cpp
+++ b/src/BaseClient.cpp
@@ -702,13 +702,17 @@ bool CUpDownClient::ProcessHelloTypePacket(const CMemFile &data)
 			// follows emule-qt.
 			//
 			// Even the hash form is not believed on one peer's word. It
-			// goes to a tracker that needs several distinct *observed*
-			// addresses to agree, keyed on where the packet actually came
-			// from rather than on the peer's self-declared user hash --
-			// a hash costs nothing to invent, a routable address does
-			// not. Nothing consumes the result yet; recognition only.
+			// goes to a tracker that first checks the value is an address
+			// this machine actually holds -- so peers can never make us
+			// adopt a foreign one, only disambiguate between our own -- and
+			// then requires several distinct *observed* addresses to agree
+			// within a time window, keyed on where the packet actually came
+			// from rather than on the peer's self-declared user hash: a hash
+			// costs nothing to invent, a routable address does not. Nothing
+			// consumes the result yet; recognition only.
 			if (temptag.IsHash()) {
-				ObservedPublicIPv6().AddClaim(GetConnectIP(), temptag.GetHash().GetHash());
+				ObservedPublicIPv6().AddClaim(
+					GetConnectIP(), temptag.GetHash().GetHash(), ::GetTickCount64());
 			}
 			break;
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1017,6 +1017,13 @@ endif()
 IF (NEED_LIB_MULESOCKET)
 	add_library (mulesocket STATIC
 		LibSocket.cpp
+		# The one interface enumeration in the tree. Here rather than in
+		# muleappcommon because LibSocketAsio.cpp resolves a bind-to-interface
+		# name through it and mulesocket does not link muleappcommon, while
+		# every target that links muleappcommon links mulesocket too - so this
+		# is the placement that reaches amuled, amule, amulegui and the
+		# preferences dialog with a single copy.
+		NetworkInterfaces.cpp
 	)
 
 	target_compile_definitions (mulesocket
@@ -1035,8 +1042,9 @@ IF (NEED_LIB_MULESOCKET)
 		PUBLIC wxWidgets::BASE
 	)
 	if (WIN32)
-		# GetAdaptersAddresses() in LibSocketAsio.cpp resolves a Windows
-		# adapter FriendlyName to its interface index for bind-to-interface.
+		# GetAdaptersAddresses() in NetworkInterfaces.cpp enumerates the
+		# adapters that LibSocketAsio.cpp resolves a Windows FriendlyName
+		# against for bind-to-interface.
 		# PUBLIC (not PRIVATE): mulesocket is a static lib, so the dependency
 		# must propagate to every consumer that links it (including the
 		# NetworkFunctionsTest unit-test exe), not just to mulesocket itself.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1046,8 +1046,8 @@ IF (NEED_LIB_MULESOCKET)
 		# adapters that LibSocketAsio.cpp resolves a Windows FriendlyName
 		# against for bind-to-interface.
 		# PUBLIC (not PRIVATE): mulesocket is a static lib, so the dependency
-		# must propagate to every consumer that links it (including the
-		# NetworkFunctionsTest unit-test exe), not just to mulesocket itself.
+		# must propagate to every consumer that links it, not just to
+		# mulesocket itself.
 		target_link_libraries (mulesocket PUBLIC iphlpapi)
 	endif()
 endif()

--- a/src/ClientDetailDialog.cpp
+++ b/src/ClientDetailDialog.cpp
@@ -60,6 +60,7 @@ ClientDetailInfo ClientDetailInfoFromClient(const CClientRef &client)
 	info.serverPort = c.GetServerPort();
 	info.serverName = c.GetServerName();
 	info.kadPort = c.GetKadPort();
+	info.modCapabilities = c.GetModCapabilitiesText();
 	info.uploadFile = c.GetUploadFile();
 	info.transferredDown = c.GetTransferredDown();
 	info.transferredUp = c.GetTransferredUp();
@@ -180,7 +181,8 @@ bool CClientDetailDialog::OnInitDialog()
 	// eMuleAI vendor capabilities. What the peer claims, not what this build
 	// can do with it: aMule implements none of these yet, so the line reads as
 	// "this peer would support X if we did".
-	CastChild(IDT_MOD_CAPABILITIES, wxStaticText)->SetLabel(m_client.GetModCapabilitiesText());
+	CastChild(IDT_MOD_CAPABILITIES, wxStaticText)
+		->SetLabel(m_info.hasSession ? m_info.modCapabilities : kNoValue);
 
 	// Kad
 	if (!m_info.hasSession) {

--- a/src/ClientDetailDialog.cpp
+++ b/src/ClientDetailDialog.cpp
@@ -178,11 +178,24 @@ bool CClientDetailDialog::OnInitDialog()
 	}
 	CastChild(IDT_OBFUSCATION, wxStaticText)->SetLabel(buffer);
 
-	// eMuleAI vendor capabilities. What the peer claims, not what this build
-	// can do with it: aMule implements none of these yet, so the line reads as
-	// "this peer would support X if we did".
-	CastChild(IDT_MOD_CAPABILITIES, wxStaticText)
-		->SetLabel(m_info.hasSession ? m_info.modCapabilities : kNoValue);
+	// Protocol extensions the peer claims -- not what this build can do with
+	// them: aMule implements none of these yet, so the line reads as "this
+	// peer would support X if we did".
+	//
+	// Label and value are both hidden when there is nothing to claim, rather
+	// than shown with a placeholder. Almost no peer on the network sets any
+	// of these bits, and a stored row has no hello to read at all, so the
+	// alternative is a row that reads "None" or "-" for nearly every peer,
+	// permanently -- a row that says nothing while taking up the space of one
+	// that does. Hiding both controls leaves no gap: the sizer skips a hidden
+	// pair, and Layout() below reflows what is left.
+	const bool hasCapabilities = m_info.hasSession && !m_info.modCapabilities.IsEmpty();
+	CastChild(IDT_MOD_CAPABILITIES_LABEL, wxStaticText)->Show(hasCapabilities);
+	wxStaticText *capabilities = CastChild(IDT_MOD_CAPABILITIES, wxStaticText);
+	capabilities->Show(hasCapabilities);
+	if (hasCapabilities) {
+		capabilities->SetLabel(m_info.modCapabilities);
+	}
 
 	// Kad
 	if (!m_info.hasSession) {

--- a/src/ClientDetailDialog.cpp
+++ b/src/ClientDetailDialog.cpp
@@ -177,6 +177,11 @@ bool CClientDetailDialog::OnInitDialog()
 	}
 	CastChild(IDT_OBFUSCATION, wxStaticText)->SetLabel(buffer);
 
+	// eMuleAI vendor capabilities. What the peer claims, not what this build
+	// can do with it: aMule implements none of these yet, so the line reads as
+	// "this peer would support X if we did".
+	CastChild(IDT_MOD_CAPABILITIES, wxStaticText)->SetLabel(m_client.GetModCapabilitiesText());
+
 	// Kad
 	if (!m_info.hasSession) {
 		CastChild(IDT_KAD, wxStaticText)->SetLabel(kNoValue);

--- a/src/ClientDetailDialog.h
+++ b/src/ClientDetailDialog.h
@@ -66,7 +66,9 @@ struct ClientDetailInfo
 	uint16 serverPort = 0;
 	wxString serverName;
 	uint16 kadPort = 0;
-	//! What the peer claimed in its hello; a stored row has no hello to read.
+	//! Protocol extensions the peer claimed in its hello; a stored row has no
+	//! hello to read. Empty when it claimed none, which is the common case
+	//! and hides the row rather than filling it with a placeholder.
 	wxString modCapabilities;
 	const CKnownFile *uploadFile = nullptr;
 	uint64 transferredDown = 0;

--- a/src/ClientDetailDialog.h
+++ b/src/ClientDetailDialog.h
@@ -66,6 +66,8 @@ struct ClientDetailInfo
 	uint16 serverPort = 0;
 	wxString serverName;
 	uint16 kadPort = 0;
+	//! What the peer claimed in its hello; a stored row has no hello to read.
+	wxString modCapabilities;
 	const CKnownFile *uploadFile = nullptr;
 	uint64 transferredDown = 0;
 	uint64 transferredUp = 0;

--- a/src/ClientRef.cpp
+++ b/src/ClientRef.cpp
@@ -197,3 +197,12 @@ wxString CClientRef::GetSecureIdentTextStatus() const
 	}
 	return ret;
 }
+
+// Not a WRAPC: the client exposes the capability word, and the display string
+// is CPeerCapabilities' own business. This forwards through the one accessor
+// that both CUpDownClient and its EC mirror publish, so it compiles for all
+// three apps without a CLIENT_GUI branch.
+wxString CClientRef::GetModCapabilitiesText() const
+{
+	return m_client->GetModCapabilities().GetDisplayText();
+}

--- a/src/ClientRef.h
+++ b/src/ClientRef.h
@@ -152,6 +152,7 @@ public:
 	const wxString &GetSoftVerStr() const;
 	int GetSourceFrom() const; // ESourceFrom
 	wxString GetSecureIdentTextStatus() const;
+	wxString GetModCapabilitiesText() const;
 	uint64 GetTransferredDown() const;
 	uint64 GetTransferredUp() const;
 	uint16 GetUDPPort() const;

--- a/src/ClientUDPSocket.cpp
+++ b/src/ClientUDPSocket.cpp
@@ -139,6 +139,21 @@ void CClientUDPSocket::OnPacketReceived(uint32 ip, uint16 port, uint8_t *buffer,
 				}
 				break;
 
+			case OP_UDPRESERVEDPROT2:
+				// eMuleAI NAT traversal. Not an eD2k opcode: the byte
+				// after the protocol byte is a frame type. Dispatched
+				// here rather than through ProcessPacket() above, whose
+				// second argument is an opcode.
+				//
+				// This branch reaches no packet accounting at all, which
+				// is what keeps a dropped frame from feeding a ban:
+				// CPacketTracking is only entered from the Kad listener
+				// (kademlia/net/KademliaUDPListener.cpp:263), and an
+				// eMuleAI peer's NAT-T traffic would otherwise arrive
+				// here as an unknown protocol and read as malformed.
+				ProcessReservedProt2Frame(decryptedBuffer + 1, packetLen - 1, ip, port);
+				break;
+
 			default:
 				AddDebugLogLineN(logClientUDP,
 					CFormat("Unknown opcode on received packet: 0x%x") % protocol);
@@ -151,6 +166,81 @@ void CClientUDPSocket::OnPacketReceived(uint32 ip, uint16 port, uint8_t *buffer,
 			AddDebugLogLineN(logClientUDP,
 				"Malformed packet encountered while parsing UDP packet: " + e.what());
 		}
+	}
+}
+
+void CClientUDPSocket::ProcessReservedProt2Frame(
+	const uint8_t *frame, size_t frameLength, uint32 ip, uint16 port)
+{
+	const SReservedProt2Frame classified = ClassifyReservedProt2Frame(frame, frameLength);
+
+	switch (classified.disposition) {
+	case RP2_TRUNCATED:
+		// Nothing but the protocol byte arrived, so there is no type byte
+		// to read. Dropped without reading the window -- the guard is the
+		// point, this is the shortest datagram that can reach here.
+		AddDebugLogLineN(logClientUDP,
+			CFormat("Dropping truncated NAT-T datagram from %s:%u") % Uint32toStringIP(ip) %
+				port);
+		return;
+
+	case RP2_UNKNOWN_TYPE:
+		// A frame type this protocol does not define. Dropped, and
+		// deliberately not counted anywhere: see the OP_UDPRESERVEDPROT2
+		// comment in OnPacketReceived().
+		if (m_unknownFrameLog.ShouldLog(::GetTickCount64())) {
+			AddDebugLogLineN(logClientUDP,
+				CFormat("Dropping NAT-T frame of unknown type 0x%02X from %s:%u (%u further "
+					"occurrences suppressed)") %
+					classified.type % Uint32toStringIP(ip) % port %
+					m_unknownFrameLog.TakeSuppressedCount());
+		}
+		return;
+
+	case RP2_KNOWN_TYPE:
+		break;
+	}
+
+	// The five registered types. Every one of them belongs to a transport
+	// this build does not have, so each is dropped here rather than in a
+	// shared fallthrough: the change that ships a transport replaces its own
+	// case and nothing else, and until then a peer's NAT-T attempt is a
+	// recognised frame aMule cannot serve rather than malformed traffic.
+	switch (classified.type) {
+	case OP_NATT_FRAME_UTP:
+		AddDebugLogLineN(logClientUDP,
+			CFormat("Ignoring uTP NAT-T frame from %s:%u: no uTP transport in this build") %
+				Uint32toStringIP(ip) % port);
+		break;
+
+	case OP_NATT_FRAME_QUIC:
+		AddDebugLogLineN(logClientUDP,
+			CFormat("Ignoring QUIC NAT-T frame from %s:%u: no QUIC transport in this build") %
+				Uint32toStringIP(ip) % port);
+		break;
+
+	case OP_NATT_FRAME_CAPS:
+	case OP_NATT_FRAME_CAPS_ACK:
+		// Answering the capability negotiation would claim a transport
+		// aMule does not have. Silence is the correct answer here.
+		AddDebugLogLineN(logClientUDP,
+			CFormat("Ignoring NAT-T capability frame 0x%02X from %s:%u: nothing to negotiate") %
+				classified.type % Uint32toStringIP(ip) % port);
+		break;
+
+	case OP_NATT_FRAME_KEY:
+		AddDebugLogLineN(logClientUDP,
+			CFormat("Ignoring NAT-T key frame from %s:%u: no NAT traversal in this build") %
+				Uint32toStringIP(ip) % port);
+		break;
+
+	default:
+		// Unreachable: ClassifyReservedProt2Frame only reports
+		// RP2_KNOWN_TYPE for the five cases above. Kept so that adding a
+		// type there without a case here fails loudly rather than
+		// silently taking the drop path.
+		wxFAIL;
+		break;
 	}
 }
 

--- a/src/ClientUDPSocket.h
+++ b/src/ClientUDPSocket.h
@@ -27,6 +27,7 @@
 #define CLIENTUDPSOCKET_H
 
 #include "MuleUDPSocket.h"
+#include "ReservedProtocolFrames.h" // Needed for CUnknownFrameLogThrottle
 
 class CClientUDPSocket : public CMuleUDPSocket
 {
@@ -39,6 +40,20 @@ protected:
 private:
 	void OnPacketReceived(uint32 ip, uint16 port, uint8_t *buffer, size_t length);
 	void ProcessPacket(uint8_t *packet, int16 size, int8 opcode, uint32 host, uint16 port);
+
+	/**
+	 * OP_UDPRESERVEDPROT2: no opcode, a frame type byte instead.
+	 *
+	 * @param frame  points at the frame type byte.
+	 * @param frameLength  bytes available from there. Zero is a datagram
+	 *                     that carried nothing but the protocol byte.
+	 */
+	void ProcessReservedProt2Frame(const uint8_t *frame, size_t frameLength, uint32 ip, uint16 port);
+
+	//! One unknown-frame line per minute, with a suppressed count. A peer
+	//! speaking a frame type this build does not know retries, so the useful
+	//! information is that it happened plus how often.
+	CUnknownFrameLogThrottle m_unknownFrameLog{ 60 * 1000 };
 };
 
 #endif // CLIENTUDPSOCKET_H

--- a/src/ECSpecialCoreTags.cpp
+++ b/src/ECSpecialCoreTags.cpp
@@ -483,6 +483,9 @@ CEC_UpDownClient_Tag::CEC_UpDownClient_Tag(
 	AddDiffTag(this, EC_TAG_CLIENT_OBFUSCATION_STATUS, client->GetObfuscationStatus(), valuemap);
 	AddDiffTag(this, EC_TAG_CLIENT_KAD_PORT, client->GetKadPort(), valuemap);
 	AddDiffTag(this, EC_TAG_CLIENT_FRIEND_SLOT, client->GetFriendSlot(), valuemap);
+	// Already masked to the five defined bits by CPeerCapabilities, so the
+	// remote GUI never has to know which bits are reserved.
+	AddDiffTag(this, EC_TAG_CLIENT_MOD_CAPABILITIES, client->GetModCapabilities().ToWire(), valuemap);
 
 	if (detail_level == EC_DETAIL_UPDATE) {
 		return;

--- a/src/ECSpecialCoreTags.cpp
+++ b/src/ECSpecialCoreTags.cpp
@@ -485,7 +485,7 @@ CEC_UpDownClient_Tag::CEC_UpDownClient_Tag(
 	AddDiffTag(this, EC_TAG_CLIENT_FRIEND_SLOT, client->GetFriendSlot(), valuemap);
 	// Already masked to the five defined bits by CPeerCapabilities, so the
 	// remote GUI never has to know which bits are reserved.
-	AddDiffTag(this, EC_TAG_CLIENT_MOD_CAPABILITIES, client->GetModCapabilities().ToWire(), valuemap);
+	AddDiffTag(this, EC_TAG_CLIENT_MOD_CAPABILITIES, client->GetModCapabilities().KnownBits(), valuemap);
 
 	if (detail_level == EC_DETAIL_UPDATE) {
 		return;

--- a/src/LibSocketAsio.cpp
+++ b/src/LibSocketAsio.cpp
@@ -42,7 +42,7 @@
 #include <algorithm> // Needed for std::min - Boost up to 1.54 fails to compile with MSVC 2013 otherwise
 #include <atomic>
 #include <chrono>
-#include <vector> // GetAdaptersAddresses buffer (Windows interface resolution)
+#include <vector>
 
 #ifndef _WIN32
 #include <poll.h> // Bounded readability wait for the sync-read no-progress timeout
@@ -83,7 +83,8 @@
 #include "GuiEvents.h"
 #include "amuleIPV4Address.h"
 #include "MuleUDPSocket.h"
-#include "OtherFunctions.h" // DeleteContents
+#include "NetworkInterfaces.h" // DetectNetworkInterfaces (bind-to-interface resolution)
+#include "OtherFunctions.h"    // DeleteContents
 #include "ScopedPtr.h"
 #include <common/Macros.h>
 
@@ -91,7 +92,6 @@
 // SIO_KEEPALIVE_VALS + struct tcp_keepalive for SetTcpKeepalive.
 // winsock2.h is already brought in transitively by boost::asio.
 #include <mstcpip.h>
-#include <iphlpapi.h> // GetAdaptersAddresses (friendly-name -> interface index)
 // IP_UNICAST_IF / IPV6_UNICAST_IF are Vista+; define them if the SDK target
 // (see _WIN32_WINNT above) predates their headers. Values are ABI-stable.
 #ifndef IP_UNICAST_IF
@@ -203,25 +203,14 @@ static inline void SetTcpKeepalive(Handle native, int idleSec, int intervalSec, 
 // on Windows — it expects the adapter's GUID-style name, not the friendly one,
 // so the enumerated dropdown value is resolved here instead. Returns 0 if not
 // found (the caller then tries a bare numeric index).
+//
+// The friendly name comes out of the same enumeration the preferences dialog
+// filled the dropdown from, so a name that was offered there resolves here.
 static unsigned int ResolveWindowsInterfaceIndex(const wxString &friendlyName)
 {
-	ULONG size = 15000;
-	std::vector<uint8_t> buf(size);
-	const ULONG flags = GAA_FLAG_SKIP_UNICAST | GAA_FLAG_SKIP_ANYCAST | GAA_FLAG_SKIP_MULTICAST |
-			    GAA_FLAG_SKIP_DNS_SERVER;
-	PIP_ADAPTER_ADDRESSES aa = reinterpret_cast<PIP_ADAPTER_ADDRESSES>(&buf[0]);
-	ULONG ret = ::GetAdaptersAddresses(AF_UNSPEC, flags, NULL, aa, &size);
-	if (ret == ERROR_BUFFER_OVERFLOW) {
-		buf.resize(size);
-		aa = reinterpret_cast<PIP_ADAPTER_ADDRESSES>(&buf[0]);
-		ret = ::GetAdaptersAddresses(AF_UNSPEC, flags, NULL, aa, &size);
-	}
-	if (ret != NO_ERROR) {
-		return 0;
-	}
-	for (PIP_ADAPTER_ADDRESSES p = aa; p != NULL; p = p->Next) {
-		if (p->FriendlyName != NULL && friendlyName == wxString(p->FriendlyName)) {
-			return p->IfIndex ? p->IfIndex : p->Ipv6IfIndex;
+	for (const NetworkInterface &iface : DetectNetworkInterfaces()) {
+		if (iface.name == friendlyName) {
+			return iface.index;
 		}
 	}
 	return 0;

--- a/src/NetworkInterfaces.cpp
+++ b/src/NetworkInterfaces.cpp
@@ -1,0 +1,267 @@
+//
+// This file is part of the aMule Project.
+//
+// Copyright (c) 2003-2026 aMule Team ( https://amule-org.github.io )
+//
+// Any parts of this program derived from the xMule, lMule or eMule project,
+// or contributed by third-party developers are copyrighted by their
+// respective authors.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301, USA
+//
+
+#include "NetworkInterfaces.h"
+
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <utility>
+
+#ifdef __WINDOWS__
+#include <winsock2.h>
+#include <ws2tcpip.h>
+#include <iphlpapi.h>
+#else
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <ifaddrs.h>
+#include <net/if.h>
+#include <netinet/in.h>
+#include <arpa/inet.h> // inet_ntop
+#include <unistd.h>    // close() for the per-address flag probe
+// Every POSIX target other than Linux that this project builds for keeps the
+// per-address IPv6 flags behind SIOCGIFAFLAG_IN6 instead of a /proc file. The
+// header is BSD-family only, so it is reached by name rather than by "not
+// Linux", which would break the first time somebody builds on Solaris.
+#if defined(__APPLE__) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__) || \
+	defined(__DragonFly__)
+#include <sys/ioctl.h>
+#include <netinet6/in6_var.h> // SIOCGIFAFLAG_IN6 / IN6_IFF_TENTATIVE
+#endif
+#endif
+
+namespace
+{
+
+typedef std::array<std::uint8_t, 16> Ipv6Bytes;
+
+#if !defined(__WINDOWS__) && defined(__linux__)
+
+//! IFA_F_TENTATIVE, spelled out rather than pulled from <linux/if_addr.h>:
+//! that header is not reliably reachable from userspace across the libc
+//! implementations this project builds against, and the value is ABI-stable.
+const unsigned int LINUX_IFA_F_TENTATIVE = 0x40;
+
+/**
+ * Per-address IPv6 flags, as the kernel reports them.
+ *
+ * getifaddrs() lists which IPv6 addresses exist but not what state each one is
+ * in, and on Linux this file is the only place the flags are exposed. Without
+ * it an address still running duplicate address detection is indistinguishable
+ * from a finished one.
+ *
+ * An address missing from this list is treated as flagless rather than
+ * skipped: a container or a stripped-down root may not mount /proc, and losing
+ * the whole enumeration there would be worse than losing the DAD distinction.
+ */
+std::vector<std::pair<Ipv6Bytes, unsigned int>> ReadIfInet6Flags()
+{
+	std::vector<std::pair<Ipv6Bytes, unsigned int>> result;
+
+	std::FILE *file = std::fopen("/proc/net/if_inet6", "r");
+	if (file == nullptr) {
+		return result;
+	}
+
+	// One line per address: 32 hex digits, then index, prefix length, scope
+	// and flags in hex, then the device name.
+	char address[40] = { 0 };
+	char device[64] = { 0 };
+	unsigned int index = 0;
+	unsigned int prefix = 0;
+	unsigned int scope = 0;
+	unsigned int flags = 0;
+	while (std::fscanf(file, "%39s %x %x %x %x %63s", address, &index, &prefix, &scope, &flags, device) ==
+		6) {
+		if (std::strlen(address) != 32) {
+			continue;
+		}
+		Ipv6Bytes bytes = {};
+		bool parsed = true;
+		for (std::size_t i = 0; i < bytes.size() && parsed; ++i) {
+			char octet[3] = { address[i * 2], address[i * 2 + 1], '\0' };
+			char *end = nullptr;
+			const unsigned long value = std::strtoul(octet, &end, 16);
+			if (end != octet + 2) {
+				parsed = false;
+				break;
+			}
+			bytes[i] = static_cast<std::uint8_t>(value);
+		}
+		if (parsed) {
+			result.push_back(std::make_pair(bytes, flags));
+		}
+	}
+
+	std::fclose(file);
+	return result;
+}
+
+#endif // !__WINDOWS__ && __linux__
+
+} // namespace
+
+std::vector<NetworkInterface> DetectNetworkInterfaces()
+{
+	std::vector<NetworkInterface> result;
+
+	// Find the entry for @a name, appending one if this is the first time we
+	// have seen it. Needed because the POSIX enumeration lists one node per
+	// address family, so a dual-stack interface appears more than once.
+	auto entryFor = [&result](const wxString &name) -> NetworkInterface & {
+		for (NetworkInterface &iface : result) {
+			if (iface.name == name) {
+				return iface;
+			}
+		}
+		result.emplace_back();
+		result.back().name = name;
+		return result.back();
+	};
+
+#ifdef __WINDOWS__
+	ULONG size = 15000;
+	std::vector<uint8_t> buf(size);
+	// Unicast addresses are deliberately NOT skipped here: they are what
+	// fills the "bind to IP" drop-down.
+	const ULONG flags = GAA_FLAG_SKIP_ANYCAST | GAA_FLAG_SKIP_MULTICAST | GAA_FLAG_SKIP_DNS_SERVER;
+	PIP_ADAPTER_ADDRESSES aa = reinterpret_cast<PIP_ADAPTER_ADDRESSES>(&buf[0]);
+	ULONG ret = ::GetAdaptersAddresses(AF_UNSPEC, flags, nullptr, aa, &size);
+	if (ret == ERROR_BUFFER_OVERFLOW) {
+		buf.resize(size);
+		aa = reinterpret_cast<PIP_ADAPTER_ADDRESSES>(&buf[0]);
+		ret = ::GetAdaptersAddresses(AF_UNSPEC, flags, nullptr, aa, &size);
+	}
+	if (ret == NO_ERROR) {
+		for (PIP_ADAPTER_ADDRESSES p = aa; p != nullptr; p = p->Next) {
+			if (p->IfType == IF_TYPE_SOFTWARE_LOOPBACK || p->FriendlyName == nullptr) {
+				continue;
+			}
+			NetworkInterface &iface = entryFor(wxString(p->FriendlyName));
+			// An IPv6-only adapter reports its index in Ipv6IfIndex and
+			// leaves IfIndex zero, so both have to be consulted.
+			if (iface.index == 0) {
+				iface.index = p->IfIndex != 0 ? p->IfIndex : p->Ipv6IfIndex;
+			}
+			for (PIP_ADAPTER_UNICAST_ADDRESS ua = p->FirstUnicastAddress; ua != nullptr;
+				ua = ua->Next) {
+				const sockaddr *sa = ua->Address.lpSockaddr;
+				if (sa == nullptr) {
+					continue;
+				}
+				if (sa->sa_family == AF_INET) {
+					char text[INET_ADDRSTRLEN] = { 0 };
+					const sockaddr_in *sin = reinterpret_cast<const sockaddr_in *>(sa);
+					if (::inet_ntop(AF_INET, &sin->sin_addr, text, sizeof(text)) !=
+						nullptr) {
+						iface.ipv4.Add(wxString::FromUTF8(text));
+					}
+				} else if (sa->sa_family == AF_INET6) {
+					// Anything but Preferred is an address we cannot claim
+					// as ours: Tentative is still in duplicate address
+					// detection, Duplicate lost it, Invalid and Deprecated
+					// are on their way out.
+					if (ua->DadState != IpDadStatePreferred) {
+						continue;
+					}
+					const sockaddr_in6 *sin6 = reinterpret_cast<const sockaddr_in6 *>(sa);
+					Ipv6Bytes bytes = {};
+					std::memcpy(bytes.data(), &sin6->sin6_addr, bytes.size());
+					iface.ipv6.push_back(bytes);
+				}
+			}
+		}
+	}
+#else
+	struct ifaddrs *ifaces = nullptr;
+	if (getifaddrs(&ifaces) == 0) {
+#ifdef __linux__
+		const std::vector<std::pair<Ipv6Bytes, unsigned int>> inet6Flags = ReadIfInet6Flags();
+#elif defined(SIOCGIFAFLAG_IN6)
+		// One socket for the whole walk: the ioctl needs a handle of the
+		// right family, and opening one per address would turn an
+		// enumeration into a syscall storm.
+		const int flagSocket = ::socket(AF_INET6, SOCK_DGRAM, 0);
+#endif
+		for (struct ifaddrs *p = ifaces; p != nullptr; p = p->ifa_next) {
+			if (p->ifa_name == nullptr || (p->ifa_flags & IFF_LOOPBACK)) {
+				continue;
+			}
+			NetworkInterface &iface = entryFor(wxString::FromUTF8(p->ifa_name));
+			if (iface.index == 0) {
+				iface.index = ::if_nametoindex(p->ifa_name);
+			}
+			if (p->ifa_addr == nullptr) {
+				continue;
+			}
+			if (p->ifa_addr->sa_family == AF_INET) {
+				char text[INET_ADDRSTRLEN] = { 0 };
+				const sockaddr_in *sin = reinterpret_cast<const sockaddr_in *>(p->ifa_addr);
+				if (::inet_ntop(AF_INET, &sin->sin_addr, text, sizeof(text)) != nullptr) {
+					iface.ipv4.Add(wxString::FromUTF8(text));
+				}
+			} else if (p->ifa_addr->sa_family == AF_INET6) {
+				const sockaddr_in6 *sin6 =
+					reinterpret_cast<const sockaddr_in6 *>(p->ifa_addr);
+				Ipv6Bytes bytes = {};
+				std::memcpy(bytes.data(), &sin6->sin6_addr, bytes.size());
+#ifdef __linux__
+				bool tentative = false;
+				for (const auto &entry : inet6Flags) {
+					if (entry.first == bytes) {
+						tentative = (entry.second & LINUX_IFA_F_TENTATIVE) != 0;
+						break;
+					}
+				}
+				if (tentative) {
+					continue;
+				}
+#elif defined(SIOCGIFAFLAG_IN6)
+				if (flagSocket >= 0) {
+					struct in6_ifreq request;
+					std::memset(&request, 0, sizeof(request));
+					std::strncpy(
+						request.ifr_name, p->ifa_name, sizeof(request.ifr_name) - 1);
+					std::memcpy(&request.ifr_addr, sin6, sizeof(request.ifr_addr));
+					if (::ioctl(flagSocket, SIOCGIFAFLAG_IN6, &request) == 0 &&
+						(request.ifr_ifru.ifru_flags6 &
+							(IN6_IFF_TENTATIVE | IN6_IFF_DUPLICATED)) != 0) {
+						continue;
+					}
+				}
+#endif
+				iface.ipv6.push_back(bytes);
+			}
+		}
+#if !defined(__linux__) && defined(SIOCGIFAFLAG_IN6)
+		if (flagSocket >= 0) {
+			::close(flagSocket);
+		}
+#endif
+		freeifaddrs(ifaces);
+	}
+#endif
+	return result;
+}

--- a/src/NetworkInterfaces.cpp
+++ b/src/NetworkInterfaces.cpp
@@ -111,7 +111,7 @@ std::vector<std::pair<Ipv6Bytes, unsigned int>> ReadIfInet6Flags()
 			bytes[i] = static_cast<std::uint8_t>(value);
 		}
 		if (parsed) {
-			result.push_back(std::make_pair(bytes, flags));
+			result.emplace_back(bytes, flags);
 		}
 	}
 

--- a/src/NetworkInterfaces.h
+++ b/src/NetworkInterfaces.h
@@ -1,0 +1,81 @@
+//
+// This file is part of the aMule Project.
+//
+// Copyright (c) 2003-2026 aMule Team ( https://amule-org.github.io )
+//
+// Any parts of this program derived from the xMule, lMule or eMule project,
+// or contributed by third-party developers are copyrighted by their
+// respective authors.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301, USA
+//
+
+#ifndef NETWORKINTERFACES_H
+#define NETWORKINTERFACES_H
+
+#include <array>
+#include <cstdint>
+#include <vector>
+
+#include <wx/arrstr.h>
+#include <wx/string.h>
+
+/**
+ * One of this machine's network interfaces, with the addresses assigned to it.
+ *
+ * Name and addresses arrive together from the platform APIs, so they are
+ * reported together: splitting them would mean walking the interface list
+ * twice and risking two different answers.
+ */
+struct NetworkInterface
+{
+	//! Exactly what goes into the "bind to interface" preference and is later
+	//! resolved back to an index in LibSocketAsio.cpp: a POSIX interface name
+	//! (en0, eth0, tun0) or, on Windows, an adapter friendly name (Ethernet,
+	//! Wi-Fi).
+	wxString name;
+
+	//! The OS interface index, or 0 when the platform did not report one.
+	//! Windows adapter friendly names cannot be fed to if_nametoindex(), which
+	//! wants the GUID-style name, so the index has to come out of the same
+	//! enumeration that produced the friendly name.
+	unsigned int index = 0;
+
+	//! Assigned IPv4 addresses, printable, for the "bind to IP" drop-downs.
+	wxArrayString ipv4;
+
+	//! Assigned IPv6 addresses, 16 bytes each, big-endian as they travel on
+	//! the wire. Addresses still running duplicate address detection are
+	//! excluded: until DAD finishes the address may belong to somebody else on
+	//! the link, so treating it as ours is exactly the case DAD exists to
+	//! catch.
+	std::vector<std::array<std::uint8_t, 16>> ipv6;
+};
+
+/**
+ * Enumerate this machine's usable network interfaces.
+ *
+ * Loopback is skipped; callers that want 127.0.0.1 offer it unconditionally
+ * rather than only when the loopback interface happens to enumerate. An
+ * interface that is down right now -- a VPN tunnel, a laptop on another
+ * network -- simply does not appear, which is why the preference controls stay
+ * editable rather than being restricted to this list.
+ *
+ * Walks the interface list on every call. Callers on a path a remote peer can
+ * drive must cache the result instead of calling it per event.
+ */
+std::vector<NetworkInterface> DetectNetworkInterfaces();
+
+#endif // NETWORKINTERFACES_H

--- a/src/PeerCapabilities.h
+++ b/src/PeerCapabilities.h
@@ -1,0 +1,218 @@
+//
+// This file is part of the aMule Project.
+//
+// Copyright (c) 2003-2026 aMule Team ( https://amule-org.github.io )
+//
+// Any parts of this program derived from the xMule, lMule or eMule project,
+// or contributed by third-party developers are copyrighted by their
+// respective authors.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301, USA
+//
+
+#ifndef PEERCAPABILITIES_H
+#define PEERCAPABILITIES_H
+
+#include <cstddef>
+#include <cstdint>
+
+#include <wx/intl.h>   // Needed for _()
+#include <wx/string.h> // Needed for wxString
+
+/**
+ * eMuleAI vendor capability bits, carried in the CT_MOD_MISCOPTIONS (0xAA)
+ * handshake tag.
+ *
+ * These positions are wire format. They mirror eMuleAI's UModMiscOptions
+ * union field for field, least significant bit first, because that is the
+ * order the reference implementation lays that union out on the wire.
+ *
+ * A one-bit offset here has no runtime signal. aMule would claim a transport
+ * it does not have, the peer would open a handshake, and that handshake would
+ * simply never complete -- nothing logs, nothing fails, the source is just
+ * quietly unusable. PeerCapabilitiesTest pins each value as a literal word so
+ * a renumbering cannot pass.
+ */
+enum EModMiscOptions : uint32_t
+{
+	//! Extended source exchange with variable source info.
+	MOD_MISCOPT_EXTENDED_XS = 1u << 0,
+	//! Legacy uTP NAT traversal (simple UDP traversal through NATs).
+	MOD_MISCOPT_NAT_TRAVERSAL = 1u << 1,
+	//! IPv6 support.
+	MOD_MISCOPT_IPV6 = 1u << 2,
+	//! Vendor buddy-info pull.
+	MOD_MISCOPT_SERVING_BUDDY_PULL = 1u << 3,
+	//! QUIC NAT-T data transport.
+	MOD_MISCOPT_NAT_TRAVERSAL_QUIC = 1u << 4
+};
+
+//! Bits 0-4 are defined. Bits 5-31 are reserved and travel as zero in both
+//! directions: they are masked out of what a peer sends, so no capability can
+//! be inferred from them, and never set in what aMule sends.
+constexpr uint32_t MOD_MISCOPT_KNOWN_MASK = 0x0000001Fu;
+
+/**
+ * What a peer told us it can do.
+ *
+ * Read-only as far as this change is concerned: aMule records the peer's
+ * claims so later changes in this set can act on them, and advertises nothing
+ * new itself. See LocalAdvertisedModMiscOptions().
+ */
+class CPeerCapabilities
+{
+public:
+	CPeerCapabilities() = default;
+
+	//! Decode a CT_MOD_MISCOPTIONS word. Reserved bits are discarded here,
+	//! once, rather than at each query site.
+	void SetFromWire(uint32_t bits) { m_bits = bits & MOD_MISCOPT_KNOWN_MASK; }
+
+	//! The word as it would go back on the wire.
+	uint32_t ToWire() const { return m_bits & MOD_MISCOPT_KNOWN_MASK; }
+
+	void Reset() { m_bits = 0; }
+	bool IsEmpty() const { return m_bits == 0; }
+
+	bool Has(EModMiscOptions bit) const { return (m_bits & bit) != 0; }
+
+	void Set(EModMiscOptions bit, bool enabled)
+	{
+		if (enabled) {
+			m_bits |= bit;
+		} else {
+			m_bits &= ~static_cast<uint32_t>(bit);
+		}
+	}
+
+	bool SupportsExtendedSourceExchange() const { return Has(MOD_MISCOPT_EXTENDED_XS); }
+	bool SupportsNatTraversal() const { return Has(MOD_MISCOPT_NAT_TRAVERSAL); }
+	bool SupportsIPv6() const { return Has(MOD_MISCOPT_IPV6); }
+	bool SupportsServingBuddyPull() const { return Has(MOD_MISCOPT_SERVING_BUDDY_PULL); }
+	bool SupportsNatTraversalQuic() const { return Has(MOD_MISCOPT_NAT_TRAVERSAL_QUIC); }
+
+	/**
+	 * The capability word as a comma-separated list, for client details.
+	 *
+	 * The capability names are protocol feature names, not prose, so they
+	 * are not translated -- only the empty case is. A peer that sent no
+	 * CT_MOD_MISCOPTIONS tag and one that sent an all-zero word are the
+	 * same state and read the same way, because eMuleAI omits the tag when
+	 * the word is zero, exactly as aMule does.
+	 *
+	 * Lives here rather than on CUpDownClient because the core client and
+	 * the remote GUI's EC mirror both need it, and two copies of this table
+	 * would drift the moment a bit is added.
+	 */
+	wxString GetDisplayText() const
+	{
+		if (IsEmpty()) {
+			return _("None");
+		}
+
+		static const struct
+		{
+			EModMiscOptions bit;
+			const char *name;
+		} names[] = {
+			{ MOD_MISCOPT_EXTENDED_XS, "Extended SX" },
+			{ MOD_MISCOPT_NAT_TRAVERSAL, "uTP NAT-T" },
+			{ MOD_MISCOPT_IPV6, "IPv6" },
+			{ MOD_MISCOPT_SERVING_BUDDY_PULL, "Buddy pull" },
+			{ MOD_MISCOPT_NAT_TRAVERSAL_QUIC, "QUIC NAT-T" },
+		};
+
+		wxString text;
+		for (const auto &entry : names) {
+			if (Has(entry.bit)) {
+				if (!text.IsEmpty()) {
+					text += ", ";
+				}
+				text += entry.name;
+			}
+		}
+		return text;
+	}
+
+private:
+	uint32_t m_bits = 0;
+};
+
+/**
+ * The CT_MOD_MISCOPTIONS word aMule puts in its own handshake.
+ *
+ * Zero, and deliberately so: none of the five features exists in this tree
+ * yet. Recognising a capability and implementing it are separate changes, and
+ * advertising one aMule does not have is worse than advertising nothing --
+ * the peer opens a handshake that cannot complete and neither side logs a
+ * reason. Each bit turns on in the change that ships its transport.
+ *
+ * Because the word is zero, no CT_MOD_MISCOPTIONS tag is emitted at all: an
+ * absent tag and an all-zero one mean the same thing to eMuleAI, and the
+ * absent one costs no bytes.
+ */
+constexpr uint32_t LocalAdvertisedModMiscOptions()
+{
+	return 0;
+}
+
+/**
+ * Decode the 128-bit address carried by the "ip6" and "bi6" Kad tags.
+ *
+ * The wire form is exactly 32 hexadecimal characters, most significant byte
+ * first, upper or lower case -- the reference implementation writes them with
+ * its 128-bit hex formatter and reads them back with its MD4-hash parser, so
+ * the length is fixed and not a prefix. Anything else is a malformed tag, not
+ * a shorter address, and the caller must ignore it.
+ *
+ * @param text  the tag's string value; may be NULL.
+ * @param length  its length in characters.
+ * @param out  receives 16 bytes, big-endian. Untouched unless true is
+ *             returned.
+ * @return true when the whole run decoded.
+ */
+inline bool DecodeIPv6HexTag(const char *text, size_t length, uint8_t *out)
+{
+	if (text == nullptr || out == nullptr || length != 32) {
+		return false;
+	}
+
+	uint8_t decoded[16];
+	for (size_t i = 0; i < 16; ++i) {
+		uint8_t byte = 0;
+		for (size_t nibbleIndex = 0; nibbleIndex < 2; ++nibbleIndex) {
+			const char c = text[(i * 2) + nibbleIndex];
+			uint8_t nibble;
+			if (c >= '0' && c <= '9') {
+				nibble = static_cast<uint8_t>(c - '0');
+			} else if (c >= 'a' && c <= 'f') {
+				nibble = static_cast<uint8_t>(c - 'a' + 10);
+			} else if (c >= 'A' && c <= 'F') {
+				nibble = static_cast<uint8_t>(c - 'A' + 10);
+			} else {
+				return false;
+			}
+			byte = static_cast<uint8_t>((byte << 4) | nibble);
+		}
+		decoded[i] = byte;
+	}
+
+	for (size_t i = 0; i < 16; ++i) {
+		out[i] = decoded[i];
+	}
+	return true;
+}
+
+#endif // PEERCAPABILITIES_H

--- a/src/PeerCapabilities.h
+++ b/src/PeerCapabilities.h
@@ -28,7 +28,7 @@
 #include <cstddef>
 #include <cstdint>
 
-#include <wx/intl.h>   // Needed for _()
+#include <wx/intl.h>   // Needed for wxTRANSLATE() and wxGetTranslation()
 #include <wx/string.h> // Needed for wxString
 
 /**
@@ -121,11 +121,24 @@ public:
 	/**
 	 * The capability word as a comma-separated list, for client details.
 	 *
-	 * The capability names are protocol feature names, not prose, so they
-	 * are not translated -- only the empty case is. A peer that sent no
-	 * CT_MOD_MISCOPTIONS tag and one that sent an all-zero word are the
-	 * same state and read the same way, because eMuleAI omits the tag when
-	 * the word is zero, exactly as aMule does.
+	 * Empty when the peer claims nothing, and the caller decides what that
+	 * looks like: the client details dialog hides its row rather than
+	 * printing a word for it. A peer that sent no CT_MOD_MISCOPTIONS tag and
+	 * one that sent an all-zero word are the same state and read the same
+	 * way, because eMuleAI omits the tag when the word is zero, exactly as
+	 * aMule does.
+	 *
+	 * The names are spelled out as prose rather than abbreviated, so they
+	 * are translated like the rest of the dialog. They carry no protocol
+	 * meaning and nothing reads them back: the bit identity is pinned by
+	 * PeerCapabilitiesTest, which asserts each position as a literal word,
+	 * and the pairing of bit to name by the display test. So rewording or
+	 * translating one cannot move a bit.
+	 *
+	 * They are marked with wxTRANSLATE and translated at use rather than
+	 * written as _(), because the table is static: _() in its initialiser
+	 * would translate once, on first call, possibly before the locale is
+	 * loaded, and would never follow a language change afterwards.
 	 *
 	 * Lives here rather than on CUpDownClient because the core client and
 	 * the remote GUI's EC mirror both need it, and two copies of this table
@@ -133,20 +146,18 @@ public:
 	 */
 	wxString GetDisplayText() const
 	{
-		if (IsEmpty()) {
-			return _("None");
-		}
-
+		// One table on purpose: bit and name in the same row, so a bit
+		// cannot be added in one place and forgotten in the other.
 		static const struct
 		{
 			EModMiscOptions bit;
 			const char *name;
 		} names[] = {
-			{ MOD_MISCOPT_EXTENDED_XS, "Extended SX" },
-			{ MOD_MISCOPT_NAT_TRAVERSAL, "uTP NAT-T" },
-			{ MOD_MISCOPT_IPV6, "IPv6" },
-			{ MOD_MISCOPT_SERVING_BUDDY_PULL, "Buddy pull" },
-			{ MOD_MISCOPT_NAT_TRAVERSAL_QUIC, "QUIC NAT-T" },
+			{ MOD_MISCOPT_EXTENDED_XS, wxTRANSLATE("Extended source exchange") },
+			{ MOD_MISCOPT_NAT_TRAVERSAL, wxTRANSLATE("NAT traversal (uTP)") },
+			{ MOD_MISCOPT_IPV6, wxTRANSLATE("IPv6") },
+			{ MOD_MISCOPT_SERVING_BUDDY_PULL, wxTRANSLATE("Buddy info pull") },
+			{ MOD_MISCOPT_NAT_TRAVERSAL_QUIC, wxTRANSLATE("NAT traversal (QUIC)") },
 		};
 
 		wxString text;
@@ -155,7 +166,7 @@ public:
 				if (!text.IsEmpty()) {
 					text += ", ";
 				}
-				text += entry.name;
+				text += wxGetTranslation(entry.name);
 			}
 		}
 		return text;

--- a/src/PeerCapabilities.h
+++ b/src/PeerCapabilities.h
@@ -80,8 +80,9 @@ public:
 	//! once, rather than at each query site.
 	void SetFromWire(uint32_t bits) { m_bits = bits & MOD_MISCOPT_KNOWN_MASK; }
 
-	//! The word as it would go back on the wire.
-	uint32_t ToWire() const { return m_bits & MOD_MISCOPT_KNOWN_MASK; }
+	//! The peer's recorded capability bits, already limited to the known set
+	//! by SetFromWire(). For display and logging, not for re-encoding.
+	uint32_t KnownBits() const { return m_bits; }
 
 	void Reset() { m_bits = 0; }
 	bool IsEmpty() const { return m_bits == 0; }

--- a/src/PeerCapabilities.h
+++ b/src/PeerCapabilities.h
@@ -62,6 +62,20 @@ enum EModMiscOptions : uint32_t
 //! Bits 0-4 are defined. Bits 5-31 are reserved and travel as zero in both
 //! directions: they are masked out of what a peer sends, so no capability can
 //! be inferred from them, and never set in what aMule sends.
+//!
+//! "Reserved" means reserved to aMule, not unallocated on the wire. The 0xAA
+//! word is not eMuleAI's alone: emule-qt allocates bit 5 in it
+//! (MODMISC_EXTXS_SKIPTAGS, extended source exchange without the tag
+//! preamble) and bit 10 (MODMISC_HTTPCACHE, HTTP cache sourcing). This mask
+//! drops both, so a peer that sets either reaches m_bits with it cleared.
+//!
+//! That is right while aMule acts on neither -- a bit it cannot use is a bit
+//! it must not relay -- and wrong the moment it wants to gate on one, because
+//! a dropped bit reads as absent rather than as unknown, which is a different
+//! claim. Widening this mask is the change that has to happen first: no query
+//! site can recover a bit that was cleared here. A new bit needs an
+//! EModMiscOptions entry, a widened mask, an entry in the display table
+//! below, and the literal position pinned in PeerCapabilitiesTest.
 constexpr uint32_t MOD_MISCOPT_KNOWN_MASK = 0x0000001Fu;
 
 /**

--- a/src/PeerCapabilities.h
+++ b/src/PeerCapabilities.h
@@ -27,6 +27,8 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <string>
+#include <vector>
 
 #include <wx/intl.h>   // Needed for wxTRANSLATE() and wxGetTranslation()
 #include <wx/string.h> // Needed for wxString
@@ -148,20 +150,8 @@ public:
 	{
 		// One table on purpose: bit and name in the same row, so a bit
 		// cannot be added in one place and forgotten in the other.
-		static const struct
-		{
-			EModMiscOptions bit;
-			const char *name;
-		} names[] = {
-			{ MOD_MISCOPT_EXTENDED_XS, wxTRANSLATE("Extended source exchange") },
-			{ MOD_MISCOPT_NAT_TRAVERSAL, wxTRANSLATE("NAT traversal (uTP)") },
-			{ MOD_MISCOPT_IPV6, wxTRANSLATE("IPv6") },
-			{ MOD_MISCOPT_SERVING_BUDDY_PULL, wxTRANSLATE("Buddy info pull") },
-			{ MOD_MISCOPT_NAT_TRAVERSAL_QUIC, wxTRANSLATE("NAT traversal (QUIC)") },
-		};
-
 		wxString text;
-		for (const auto &entry : names) {
+		for (const auto &entry : Table()) {
 			if (Has(entry.bit)) {
 				if (!text.IsEmpty()) {
 					text += ", ";
@@ -170,6 +160,64 @@ public:
 			}
 		}
 		return text;
+	}
+
+	/**
+	 * The same bits as stable API tokens, in bit order.
+	 *
+	 * The /api/v0 surface spells every other multi-state field as an
+	 * enumerated token, and an integer there would make each consumer carry
+	 * its own copy of the table below -- reimplemented in JS for the Web UI
+	 * and again in every third-party client, each free to drift from this
+	 * file. A peer claims any combination of the bits rather than one state,
+	 * which is why this is a list rather than a single token.
+	 *
+	 * Unlike the display text these are not translated and never change:
+	 * they are wire vocabulary, and a consumer matches them literally.
+	 */
+	std::vector<std::string> GetApiTokens() const
+	{
+		std::vector<std::string> tokens;
+		for (const auto &entry : Table()) {
+			if (Has(entry.bit)) {
+				tokens.push_back(entry.token);
+			}
+		}
+		return tokens;
+	}
+
+	//! Bit, display name and API token in one row.
+	struct SCapabilityName
+	{
+		EModMiscOptions bit;
+		const char *name;
+		const char *token;
+	};
+
+	/**
+	 * One table on purpose, and now carrying three things rather than two:
+	 * a bit cannot be added to the enum and then forgotten in the display
+	 * row, the API row, or either separately. A second table keyed on the
+	 * same enum is exactly the drift this arrangement exists to prevent.
+	 */
+	static const std::vector<SCapabilityName> &Table()
+	{
+		static const std::vector<SCapabilityName> names = {
+			{ MOD_MISCOPT_EXTENDED_XS,
+				wxTRANSLATE("Extended source exchange"),
+				"extended_source_exchange" },
+			{ MOD_MISCOPT_NAT_TRAVERSAL,
+				wxTRANSLATE("NAT traversal (uTP)"),
+				"nat_traversal_utp" },
+			{ MOD_MISCOPT_IPV6, wxTRANSLATE("IPv6"), "ipv6" },
+			{ MOD_MISCOPT_SERVING_BUDDY_PULL,
+				wxTRANSLATE("Buddy info pull"),
+				"serving_buddy_pull" },
+			{ MOD_MISCOPT_NAT_TRAVERSAL_QUIC,
+				wxTRANSLATE("NAT traversal (QUIC)"),
+				"nat_traversal_quic" },
+		};
+		return names;
 	}
 
 private:

--- a/src/PeerCapabilities.h
+++ b/src/PeerCapabilities.h
@@ -180,7 +180,7 @@ public:
 		std::vector<std::string> tokens;
 		for (const auto &entry : Table()) {
 			if (Has(entry.bit)) {
-				tokens.push_back(entry.token);
+				tokens.emplace_back(entry.token);
 			}
 		}
 		return tokens;

--- a/src/PrefsUnifiedDlg.cpp
+++ b/src/PrefsUnifiedDlg.cpp
@@ -49,16 +49,7 @@
 // Network-interface enumeration for the "Bind to interface" and "Bind to IP"
 // drop-downs.
 #include <vector>
-#ifdef __WINDOWS__
-#include <winsock2.h>
-#include <ws2tcpip.h>
-#include <iphlpapi.h>
-#else
-#include <sys/types.h>
-#include <ifaddrs.h>
-#include <net/if.h>
-#include <arpa/inet.h> // inet_ntop
-#endif
+#include "NetworkInterfaces.h"
 
 #include "AmuleApiCredentials.h"
 #include "amule.h" // Needed for theApp
@@ -95,102 +86,6 @@
 #include "Statistics.h"
 #include "UserEvents.h"
 #include "PlatformSpecific.h" // Needed for PLATFORMSPECIFIC_CAN_PREVENT_SLEEP_MODE
-
-namespace
-{
-// One network interface as the preferences dialog needs it: the name that goes
-// into the "bind to interface" preference, plus the IPv4 addresses currently
-// assigned to it for the "bind to IP" drop-down. Both come out of a single
-// enumeration because the platform APIs hand back name and address together.
-struct NetworkInterface
-{
-	wxString name;
-	wxArrayString ipv4;
-};
-
-// Enumerate this machine's usable network interfaces. The names are exactly
-// what gets stored in the preference and later resolved to an index in
-// LibSocketAsio.cpp: POSIX interface names (en0, eth0, tun0) and, on Windows,
-// adapter friendly names (Ethernet, Wi-Fi). Loopback is skipped; callers that
-// want 127.0.0.1 offer it unconditionally rather than only when the loopback
-// interface happens to enumerate. Only IPv4 addresses are collected, because
-// aMule's sockets are IPv4 (see the isV6 note in LibSocketAsio.cpp). Both
-// controls stay editable, so an interface or address that is down right now --
-// a VPN tunnel, a laptop on a different network -- can still be typed in.
-std::vector<NetworkInterface> DetectNetworkInterfaces()
-{
-	std::vector<NetworkInterface> result;
-
-	// Find the entry for @a name, appending one if this is the first time we
-	// have seen it. Needed because the POSIX enumeration lists one node per
-	// address family, so a dual-stack interface appears more than once.
-	auto entryFor = [&result](const wxString &name) -> NetworkInterface & {
-		for (NetworkInterface &iface : result) {
-			if (iface.name == name) {
-				return iface;
-			}
-		}
-		result.emplace_back();
-		result.back().name = name;
-		return result.back();
-	};
-
-#ifdef __WINDOWS__
-	ULONG size = 15000;
-	std::vector<uint8_t> buf(size);
-	// Unicast addresses are deliberately NOT skipped here: they are what
-	// fills the "bind to IP" drop-down.
-	const ULONG flags = GAA_FLAG_SKIP_ANYCAST | GAA_FLAG_SKIP_MULTICAST | GAA_FLAG_SKIP_DNS_SERVER;
-	PIP_ADAPTER_ADDRESSES aa = reinterpret_cast<PIP_ADAPTER_ADDRESSES>(&buf[0]);
-	ULONG ret = ::GetAdaptersAddresses(AF_UNSPEC, flags, nullptr, aa, &size);
-	if (ret == ERROR_BUFFER_OVERFLOW) {
-		buf.resize(size);
-		aa = reinterpret_cast<PIP_ADAPTER_ADDRESSES>(&buf[0]);
-		ret = ::GetAdaptersAddresses(AF_UNSPEC, flags, nullptr, aa, &size);
-	}
-	if (ret == NO_ERROR) {
-		for (PIP_ADAPTER_ADDRESSES p = aa; p != nullptr; p = p->Next) {
-			if (p->IfType == IF_TYPE_SOFTWARE_LOOPBACK || p->FriendlyName == nullptr) {
-				continue;
-			}
-			NetworkInterface &iface = entryFor(wxString(p->FriendlyName));
-			for (PIP_ADAPTER_UNICAST_ADDRESS ua = p->FirstUnicastAddress; ua != nullptr;
-				ua = ua->Next) {
-				const sockaddr *sa = ua->Address.lpSockaddr;
-				if (sa == nullptr || sa->sa_family != AF_INET) {
-					continue;
-				}
-				char text[INET_ADDRSTRLEN] = { 0 };
-				const sockaddr_in *sin = reinterpret_cast<const sockaddr_in *>(sa);
-				if (::inet_ntop(AF_INET, &sin->sin_addr, text, sizeof(text)) != nullptr) {
-					iface.ipv4.Add(wxString::FromUTF8(text));
-				}
-			}
-		}
-	}
-#else
-	struct ifaddrs *ifaces = nullptr;
-	if (getifaddrs(&ifaces) == 0) {
-		for (struct ifaddrs *p = ifaces; p != nullptr; p = p->ifa_next) {
-			if (p->ifa_name == nullptr || (p->ifa_flags & IFF_LOOPBACK)) {
-				continue;
-			}
-			NetworkInterface &iface = entryFor(wxString::FromUTF8(p->ifa_name));
-			if (p->ifa_addr == nullptr || p->ifa_addr->sa_family != AF_INET) {
-				continue;
-			}
-			char text[INET_ADDRSTRLEN] = { 0 };
-			const sockaddr_in *sin = reinterpret_cast<const sockaddr_in *>(p->ifa_addr);
-			if (::inet_ntop(AF_INET, &sin->sin_addr, text, sizeof(text)) != nullptr) {
-				iface.ipv4.Add(wxString::FromUTF8(text));
-			}
-		}
-		freeifaddrs(ifaces);
-	}
-#endif
-	return result;
-}
-} // namespace
 
 #ifdef CLIENT_GUI
 namespace

--- a/src/PublicIPv6Corroboration.h
+++ b/src/PublicIPv6Corroboration.h
@@ -1,0 +1,239 @@
+//
+// This file is part of the aMule Project.
+//
+// Copyright (c) 2003-2026 aMule Team ( https://amule-org.github.io )
+//
+// Any parts of this program derived from the xMule, lMule or eMule project,
+// or contributed by third-party developers are copyrighted by their
+// respective authors.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301, USA
+//
+
+#ifndef PUBLICIPV6CORROBORATION_H
+#define PUBLICIPV6CORROBORATION_H
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <vector>
+
+/**
+ * What a peer claims our own public IPv6 address is, believed only once
+ * several unrelated peers say the same thing.
+ *
+ * The claim arrives in the CT_MOD_YOUR_IP (0xAD) hello tag. The two reference
+ * implementations disagree about it, and the disagreement is the whole reason
+ * this class exists:
+ *
+ *  - eMuleAI accepts the tag's integer form and sets its own public IPv4 from
+ *    it. One peer, unverified, decides what that client believes its own
+ *    address to be -- and a client that is wrong about its own address is
+ *    wrong about whether it is firewalled, which address it publishes to Kad
+ *    and where it asks to be called back.
+ *  - emule-qt refuses the integer form outright and takes only the 128-bit
+ *    hash form, then corroborates it across peers before believing it.
+ *
+ * aMule follows emule-qt. BaseClient.cpp reads only the hash form and routes
+ * it here.
+ *
+ * The key is the address the packet was observed arriving from, never the
+ * sender's self-declared user hash: a hash costs nothing to invent, so a
+ * single host could otherwise manufacture as many "distinct" corroborating
+ * peers as the threshold demands. A routable source address cannot be
+ * invented for free, because a reply has to come back through it.
+ *
+ * Nothing consumes the result yet. This is recognition only, like the rest of
+ * this change: aMule has no IPv6 stack, so the corroborated address is
+ * recorded for the dual-stack change and read by nothing else.
+ */
+
+//! How many distinct observed source addresses have to agree on the same
+//! value before it is believed.
+//!
+//! Two would be wrong: two source addresses is one dual-homed host, one host
+//! that reconnected from a new lease, or one attacker holding a second
+//! socket -- none of which is a second opinion. Three is the smallest count
+//! that forces a claimant to hold addresses it does not control alone, and it
+//! is still reachable in an ordinary session, where a handful of vendor peers
+//! connect over its lifetime and the tracker never expires an entry.
+//!
+//! It is a floor, not a proof: three addresses under one operator still agree
+//! with each other. That is acceptable while nothing acts on the result. A
+//! change that does act on it -- publishing this address, or deciding
+//! firewalled state from it -- needs more than a count here, because the
+//! addresses would also have to be shown to be unrelated.
+constexpr std::size_t PUBLIC_IPV6_CORROBORATION_THRESHOLD = 3;
+
+//! How many differing claimed values are tracked at once.
+//!
+//! Bounded on purpose: the input is attacker-controlled, and an unbounded map
+//! keyed on a value a peer chooses is a peer-driven allocation. Beyond this
+//! many distinct claims nothing is being corroborated anyway -- that is a
+//! peer population disagreeing, not a quorum forming -- so further new values
+//! are dropped rather than making room by evicting a candidate that may be
+//! the honest one.
+constexpr std::size_t PUBLIC_IPV6_CORROBORATION_MAX_CANDIDATES = 8;
+
+class CPublicIPv6Corroboration
+{
+public:
+	//! A 128-bit address, big-endian, as it travels in the tag.
+	typedef std::array<std::uint8_t, 16> Address;
+
+	CPublicIPv6Corroboration() = default;
+
+	/**
+	 * Record one peer's claim.
+	 *
+	 * @param observedFrom  the IPv4 address the hello was actually seen
+	 *                      arriving from, host order. Zero is ignored: with
+	 *                      no observed address there is nothing to key on,
+	 *                      and an unkeyed claim would let one peer supply
+	 *                      the whole quorum by itself.
+	 * @param claimed  16 bytes, big-endian. May be NULL, which is ignored.
+	 * @return whether some value is corroborated now. A repeat from an
+	 *         address already counted for that value changes nothing.
+	 */
+	bool AddClaim(std::uint32_t observedFrom, const std::uint8_t *claimed)
+	{
+		if (observedFrom == 0 || claimed == nullptr) {
+			return IsCorroborated();
+		}
+
+		const Address value = ToAddress(claimed);
+		Candidate *candidate = Find(value);
+		if (candidate == nullptr) {
+			if (m_candidates.size() >= PUBLIC_IPV6_CORROBORATION_MAX_CANDIDATES) {
+				return IsCorroborated();
+			}
+			m_candidates.push_back(Candidate());
+			candidate = &m_candidates.back();
+			candidate->value = value;
+		}
+
+		if (!candidate->HasObserver(observedFrom)) {
+			// Stops growing at the threshold: past it the count answers
+			// the only question asked of it, and the extra addresses
+			// would just be memory a peer can ask us to spend.
+			if (candidate->observers.size() < PUBLIC_IPV6_CORROBORATION_THRESHOLD) {
+				candidate->observers.push_back(observedFrom);
+			}
+		}
+
+		return IsCorroborated();
+	}
+
+	//! True once some value reached the threshold.
+	bool IsCorroborated() const { return Corroborated() != nullptr; }
+
+	//! The corroborated address, or NULL while none is. 16 bytes.
+	const std::uint8_t *CorroboratedAddress() const
+	{
+		const Candidate *candidate = Corroborated();
+		return candidate == nullptr ? nullptr : candidate->value.data();
+	}
+
+	//! How many distinct observed addresses have claimed this value. For
+	//! tests and diagnostics; nothing should gate on it instead of
+	//! IsCorroborated(), which owns the threshold.
+	std::size_t DistinctObserversFor(const std::uint8_t *claimed) const
+	{
+		if (claimed == nullptr) {
+			return 0;
+		}
+		const Candidate *candidate = Find(ToAddress(claimed));
+		return candidate == nullptr ? 0 : candidate->observers.size();
+	}
+
+	//! How many differing values are being tracked.
+	std::size_t CandidateCount() const { return m_candidates.size(); }
+
+	void Reset() { m_candidates.clear(); }
+
+private:
+	//! The 16 bytes at @a claimed, which is never NULL here.
+	static Address ToAddress(const std::uint8_t *claimed)
+	{
+		Address value = {};
+		std::memcpy(value.data(), claimed, value.size());
+		return value;
+	}
+
+	struct Candidate
+	{
+		Address value = {};
+		std::vector<std::uint32_t> observers;
+
+		bool HasObserver(std::uint32_t address) const
+		{
+			for (const auto &observer : observers) {
+				if (observer == address) {
+					return true;
+				}
+			}
+			return false;
+		}
+	};
+
+	Candidate *Find(const Address &value)
+	{
+		for (auto &candidate : m_candidates) {
+			if (candidate.value == value) {
+				return &candidate;
+			}
+		}
+		return nullptr;
+	}
+
+	const Candidate *Find(const Address &value) const
+	{
+		for (const auto &candidate : m_candidates) {
+			if (candidate.value == value) {
+				return &candidate;
+			}
+		}
+		return nullptr;
+	}
+
+	const Candidate *Corroborated() const
+	{
+		for (const auto &candidate : m_candidates) {
+			if (candidate.observers.size() >= PUBLIC_IPV6_CORROBORATION_THRESHOLD) {
+				return &candidate;
+			}
+		}
+		return nullptr;
+	}
+
+	std::vector<Candidate> m_candidates;
+};
+
+/**
+ * The one tracker the hello path feeds.
+ *
+ * A function-local static rather than a member of the app class: nothing
+ * consumes the corroborated address yet, and a recognition-only change should
+ * not reach into the app hierarchy to park state no caller reads. It moves to
+ * wherever its consumer lives when one exists.
+ */
+inline CPublicIPv6Corroboration &ObservedPublicIPv6()
+{
+	static CPublicIPv6Corroboration instance;
+	return instance;
+}
+
+#endif // PUBLICIPV6CORROBORATION_H

--- a/src/PublicIPv6Corroboration.h
+++ b/src/PublicIPv6Corroboration.h
@@ -120,7 +120,11 @@ public:
 			if (m_candidates.size() >= PUBLIC_IPV6_CORROBORATION_MAX_CANDIDATES) {
 				return IsCorroborated();
 			}
-			m_candidates.push_back(Candidate());
+			// emplace_back() rather than push_back(Candidate()), which
+			// clang-tidy flags. Its return value is not used: it only
+			// returns a reference from C++17, and the unit-test targets
+			// take clang's default of C++14.
+			m_candidates.emplace_back();
 			candidate = &m_candidates.back();
 			candidate->value = value;
 		}

--- a/src/PublicIPv6Corroboration.h
+++ b/src/PublicIPv6Corroboration.h
@@ -32,8 +32,8 @@
 #include <vector>
 
 /**
- * What a peer claims our own public IPv6 address is, believed only once
- * several unrelated peers say the same thing.
+ * What a peer claims our own public IPv6 address is, believed only when it is
+ * an address we actually hold and several unrelated peers agree on it.
  *
  * The claim arrives in the CT_MOD_YOUR_IP (0xAD) hello tag. The two reference
  * implementations disagree about it, and the disagreement is the whole reason
@@ -45,20 +45,36 @@
  *    wrong about whether it is firewalled, which address it publishes to Kad
  *    and where it asks to be called back.
  *  - emule-qt refuses the integer form outright and takes only the 128-bit
- *    hash form, then corroborates it across peers before believing it.
+ *    hash form, then filters and corroborates it before believing it.
  *
  * aMule follows emule-qt. BaseClient.cpp reads only the hash form and routes
  * it here.
  *
- * The key is the address the packet was observed arriving from, never the
- * sender's self-declared user hash: a hash costs nothing to invent, so a
- * single host could otherwise manufacture as many "distinct" corroborating
- * peers as the threshold demands. A routable source address cannot be
- * invented for free, because a reply has to come back through it.
+ * Two independent gates stand between a peer's word and an adopted address,
+ * and they do different jobs:
+ *
+ *  - The locally-assigned filter is the security control. Peers are
+ *    unauthenticated, so corroboration on its own must never be able to make
+ *    us advertise a foreign address. Requiring the claimed value to be one we
+ *    actually hold bounds the damage to "picks the wrong one of our own
+ *    addresses", which is the only question left.
+ *  - Corroboration is the tie-breaker for that remaining question. A
+ *    multi-homed host holds several global addresses and only some of them are
+ *    the one the outside world sees; asking several peers which one they see
+ *    is how the right one is picked.
+ *
+ * The quorum is keyed on the address the packet was observed arriving from,
+ * never the sender's self-declared user hash: a hash costs nothing to invent,
+ * so a single host could otherwise manufacture as many "distinct"
+ * corroborating peers as the threshold demands. A routable source address
+ * cannot be invented for free, because a reply has to come back through it.
  *
  * Nothing consumes the result yet. This is recognition only, like the rest of
  * this change: aMule has no IPv6 stack, so the corroborated address is
  * recorded for the dual-stack change and read by nothing else.
+ *
+ * Not thread-safe, and does not need to be: hellos and the interface refresh
+ * both run on the main thread.
  */
 
 //! How many distinct observed source addresses have to agree on the same
@@ -69,24 +85,28 @@
 //! socket -- none of which is a second opinion. Three is the smallest count
 //! that forces a claimant to hold addresses it does not control alone, and it
 //! is still reachable in an ordinary session, where a handful of vendor peers
-//! connect over its lifetime and the tracker never expires an entry.
+//! connect over its lifetime.
 //!
 //! It is a floor, not a proof: three addresses under one operator still agree
-//! with each other. That is acceptable while nothing acts on the result. A
-//! change that does act on it -- publishing this address, or deciding
-//! firewalled state from it -- needs more than a count here, because the
-//! addresses would also have to be shown to be unrelated.
+//! with each other. That is what the locally-assigned filter is for -- three
+//! colluding peers can still only steer us between addresses we hold.
 constexpr std::size_t PUBLIC_IPV6_CORROBORATION_THRESHOLD = 3;
 
-//! How many differing claimed values are tracked at once.
+//! How long one observer's claim keeps counting.
 //!
-//! Bounded on purpose: the input is attacker-controlled, and an unbounded map
-//! keyed on a value a peer chooses is a peer-driven allocation. Beyond this
-//! many distinct claims nothing is being corroborated anyway -- that is a
-//! peer population disagreeing, not a quorum forming -- so further new values
-//! are dropped rather than making room by evicting a candidate that may be
-//! the honest one.
-constexpr std::size_t PUBLIC_IPV6_CORROBORATION_MAX_CANDIDATES = 8;
+//! Without a window, "three distinct peers agree" means "three peers said so
+//! at some point since the process started", so a laptop that moved to another
+//! network hours ago still carries the votes that elected the address it had
+//! there, and no amount of fresh disagreement can unseat them. Votes that age
+//! out are what makes re-election possible at all.
+//!
+//! Thirty minutes because hellos from distinct peers arrive sporadically --
+//! minutes apart on a quiet client -- so a window of a few minutes would
+//! expire the first vote before the third arrived and the quorum would never
+//! form. It is an upper bound on how long a stale address can survive
+//! unchallenged, and the interface refresh already covers the case where the
+//! address simply went away.
+constexpr std::uint64_t PUBLIC_IPV6_CORROBORATION_WINDOW_MS = 30ull * 60ull * 1000ull;
 
 class CPublicIPv6Corroboration
 {
@@ -97,6 +117,56 @@ public:
 	CPublicIPv6Corroboration() = default;
 
 	/**
+	 * Publish the addresses currently assigned to a local interface.
+	 *
+	 * This set gates every claim, so it has to be published before any claim
+	 * can be believed -- with an empty set nothing is ever adopted, which is
+	 * the safe direction to fail in.
+	 *
+	 * It must be a refreshed cache rather than a startup snapshot: a prefix
+	 * renumber or a privacy-address rotation would otherwise go unnoticed for
+	 * as long as the session lasts, and we would keep an address we no longer
+	 * hold. It must equally not be re-scanned per claim -- that would put an
+	 * interface walk on a path any peer can drive.
+	 *
+	 * The second half of the refresh is what makes the cache safe: an already
+	 * adopted address is re-checked here and dropped when it is no longer
+	 * ours. Without that, a corroborated address outlives the prefix it came
+	 * from.
+	 *
+	 * @param local   addresses assigned to a local interface. Anything that is
+	 *                not global unicast is discarded, so callers can pass a
+	 *                whole interface enumeration.
+	 * @param nowMs   a millisecond tick count.
+	 */
+	void SetLocalAddresses(const std::vector<Address> &local, std::uint64_t nowMs)
+	{
+		m_local.clear();
+		for (const auto &address : local) {
+			// IsLocallyAssigned() reads the set being built, so this also
+			// collapses the duplicates an interface enumeration produces when
+			// the same address is reported on more than one node.
+			if (IsGlobalUnicast(address) && !IsLocallyAssigned(address)) {
+				m_local.push_back(address);
+			}
+		}
+
+		// A tally for an address we no longer hold is not evidence about the
+		// address we hold now, and keeping it would let the old value stay
+		// elected. Dropping it here is how a renumber gets noticed.
+		std::vector<Candidate> kept;
+		for (const auto &candidate : m_candidates) {
+			if (IsLocallyAssigned(candidate.value)) {
+				kept.push_back(candidate);
+			}
+		}
+		m_candidates.swap(kept);
+
+		Expire(nowMs);
+		Elect();
+	}
+
+	/**
 	 * Record one peer's claim.
 	 *
 	 * @param observedFrom  the IPv4 address the hello was actually seen
@@ -105,21 +175,39 @@ public:
 	 *                      and an unkeyed claim would let one peer supply
 	 *                      the whole quorum by itself.
 	 * @param claimed  16 bytes, big-endian. May be NULL, which is ignored.
+	 * @param nowMs    a millisecond tick count. Passed in rather than read
+	 *                 here so the window is testable at all.
 	 * @return whether some value is corroborated now. A repeat from an
-	 *         address already counted for that value changes nothing.
+	 *         address already counted for that value refreshes that vote and
+	 *         changes nothing else.
 	 */
-	bool AddClaim(std::uint32_t observedFrom, const std::uint8_t *claimed)
+	bool AddClaim(std::uint32_t observedFrom, const std::uint8_t *claimed, std::uint64_t nowMs)
 	{
+		// Aging runs before the claim is judged, so a claim arriving after a
+		// long quiet spell sees an empty tally rather than votes that should
+		// already have expired.
+		Expire(nowMs);
+		Elect();
+
 		if (observedFrom == 0 || claimed == nullptr) {
 			return IsCorroborated();
 		}
 
 		const Address value = ToAddress(claimed);
+		// Both checks, not just the second: the locally-assigned set is
+		// already filtered to global unicast, but the address family test is
+		// the invariant this class promises and it must not depend on how a
+		// caller happened to populate that set.
+		if (!IsGlobalUnicast(value) || !IsLocallyAssigned(value)) {
+			// Deliberately no state whatsoever for a rejected value. A
+			// rejection that allocated something would let a peer spend our
+			// memory on values it invented, which is exactly what the filter
+			// exists to prevent.
+			return IsCorroborated();
+		}
+
 		Candidate *candidate = Find(value);
 		if (candidate == nullptr) {
-			if (m_candidates.size() >= PUBLIC_IPV6_CORROBORATION_MAX_CANDIDATES) {
-				return IsCorroborated();
-			}
 			// emplace_back() rather than push_back(Candidate()), which
 			// clang-tidy flags. Its return value is not used: it only
 			// returns a reference from C++17, and the unit-test targets
@@ -129,26 +217,33 @@ public:
 			candidate->value = value;
 		}
 
-		if (!candidate->HasObserver(observedFrom)) {
+		Observer *observer = candidate->Find(observedFrom);
+		if (observer != nullptr) {
+			// A peer that is still saying it keeps its vote alive. Without
+			// this the window would expire long-lived peers that never
+			// stopped agreeing.
+			observer->lastSeenMs = nowMs;
+		} else if (candidate->observers.size() < PUBLIC_IPV6_CORROBORATION_THRESHOLD) {
 			// Stops growing at the threshold: past it the count answers
 			// the only question asked of it, and the extra addresses
 			// would just be memory a peer can ask us to spend.
-			if (candidate->observers.size() < PUBLIC_IPV6_CORROBORATION_THRESHOLD) {
-				candidate->observers.push_back(observedFrom);
-			}
+			Observer fresh;
+			fresh.address = observedFrom;
+			fresh.lastSeenMs = nowMs;
+			candidate->observers.push_back(fresh);
 		}
 
+		Elect();
 		return IsCorroborated();
 	}
 
-	//! True once some value reached the threshold.
-	bool IsCorroborated() const { return Corroborated() != nullptr; }
+	//! True once some value reached the threshold and still holds it.
+	bool IsCorroborated() const { return m_adopted; }
 
 	//! The corroborated address, or NULL while none is. 16 bytes.
 	const std::uint8_t *CorroboratedAddress() const
 	{
-		const Candidate *candidate = Corroborated();
-		return candidate == nullptr ? nullptr : candidate->value.data();
+		return m_adopted ? m_adoptedValue.data() : nullptr;
 	}
 
 	//! How many distinct observed addresses have claimed this value. For
@@ -166,7 +261,23 @@ public:
 	//! How many differing values are being tracked.
 	std::size_t CandidateCount() const { return m_candidates.size(); }
 
-	void Reset() { m_candidates.clear(); }
+	//! How many local addresses the filter is currently gating on.
+	std::size_t LocalAddressCount() const { return m_local.size(); }
+
+	//! Forget every claim. The local address set survives: it comes from this
+	//! machine rather than from peers, and clearing it would silently disable
+	//! the filter until the next refresh.
+	void Reset()
+	{
+		m_candidates.clear();
+		m_adopted = false;
+	}
+
+	//! Global unicast, 2000::/3. Everything a peer could otherwise reflect at
+	//! us -- the unspecified address, loopback, link-local, unique-local,
+	//! multicast, IPv4-mapped -- falls outside it, and none of those is an
+	//! address the outside world could have seen us arrive from.
+	static bool IsGlobalUnicast(const Address &value) { return (value[0] & 0xE0) == 0x20; }
 
 private:
 	//! The 16 bytes at @a claimed, which is never NULL here.
@@ -177,21 +288,92 @@ private:
 		return value;
 	}
 
+	struct Observer
+	{
+		std::uint32_t address = 0;
+		std::uint64_t lastSeenMs = 0;
+	};
+
 	struct Candidate
 	{
 		Address value = {};
-		std::vector<std::uint32_t> observers;
+		std::vector<Observer> observers;
 
-		bool HasObserver(std::uint32_t address) const
+		Observer *Find(std::uint32_t address)
 		{
-			for (const auto &observer : observers) {
-				if (observer == address) {
-					return true;
+			for (auto &observer : observers) {
+				if (observer.address == address) {
+					return &observer;
 				}
 			}
-			return false;
+			return nullptr;
 		}
 	};
+
+	bool IsLocallyAssigned(const Address &value) const
+	{
+		for (const auto &address : m_local) {
+			if (address == value) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	//! Drop votes older than the window, and candidates left with none.
+	void Expire(std::uint64_t nowMs)
+	{
+		std::vector<Candidate> kept;
+		for (auto &candidate : m_candidates) {
+			Candidate fresh;
+			fresh.value = candidate.value;
+			for (const auto &observer : candidate.observers) {
+				// A tick count that appears to move backwards expires the
+				// vote rather than keeping it. The tick source is uptime and
+				// does not go backwards, so this is a defence against a
+				// caller mixing clocks -- and holding a vote we cannot date
+				// is the one outcome worth avoiding, while re-gathering one
+				// costs nothing but time.
+				if (nowMs >= observer.lastSeenMs &&
+					nowMs - observer.lastSeenMs <= PUBLIC_IPV6_CORROBORATION_WINDOW_MS) {
+					fresh.observers.push_back(observer);
+				}
+			}
+			if (!fresh.observers.empty()) {
+				kept.push_back(fresh);
+			}
+		}
+		m_candidates.swap(kept);
+	}
+
+	/**
+	 * Re-run the election.
+	 *
+	 * An adopted value keeps its seat while it still holds a quorum, so a
+	 * second value reaching the threshold does not flip us back and forth
+	 * between two addresses we equally hold. It loses the seat the moment its
+	 * quorum lapses -- votes aged out, or the address no longer assigned --
+	 * and only then may another value take it.
+	 */
+	void Elect()
+	{
+		if (m_adopted) {
+			const Candidate *candidate = Find(m_adoptedValue);
+			if (candidate != nullptr &&
+				candidate->observers.size() >= PUBLIC_IPV6_CORROBORATION_THRESHOLD) {
+				return;
+			}
+			m_adopted = false;
+		}
+
+		for (const auto &candidate : m_candidates) {
+			if (candidate.observers.size() >= PUBLIC_IPV6_CORROBORATION_THRESHOLD) {
+				m_adoptedValue = candidate.value;
+				m_adopted = true;
+				return;
+			}
+		}
+	}
 
 	Candidate *Find(const Address &value)
 	{
@@ -213,17 +395,22 @@ private:
 		return nullptr;
 	}
 
-	const Candidate *Corroborated() const
-	{
-		for (const auto &candidate : m_candidates) {
-			if (candidate.observers.size() >= PUBLIC_IPV6_CORROBORATION_THRESHOLD) {
-				return &candidate;
-			}
-		}
-		return nullptr;
-	}
+	//! The addresses assigned to a local interface, global unicast only.
+	//!
+	//! There is no cap on this or on the candidate list, and there deliberately
+	//! is none. An earlier revision capped the number of tracked values because
+	//! the input was attacker-chosen; with the filter in front, a candidate can
+	//! only ever be one of the addresses in this set, which this machine's own
+	//! interfaces bound -- a handful, even with privacy addresses rotating. A
+	//! cap would now buy nothing and cost something real: occupying a slot
+	//! costs one claim while corroborating a value costs three, so refusing
+	//! entries past a limit would make permanent denial the cheaper attack.
+	std::vector<Address> m_local;
 
 	std::vector<Candidate> m_candidates;
+
+	Address m_adoptedValue = {};
+	bool m_adopted = false;
 };
 
 /**
@@ -239,5 +426,20 @@ inline CPublicIPv6Corroboration &ObservedPublicIPv6()
 	static CPublicIPv6Corroboration instance;
 	return instance;
 }
+
+/**
+ * Re-read this machine's interfaces and publish the result to
+ * ObservedPublicIPv6().
+ *
+ * Called at startup, on every server connect, and on a periodic tick. The
+ * periodic one is not redundant: without it the only triggers are startup and
+ * a server connect, so a prefix renumber or a privacy-address rotation goes
+ * unnoticed for as long as the session stays connected.
+ *
+ * Declared here, beside what it refreshes, but defined in amule.cpp: the
+ * interface enumeration pulls in wx and the platform socket headers, and this
+ * header stays clear of both so the tracker can be unit-tested on its own.
+ */
+void RefreshLocalPublicIPv6Addresses();
 
 #endif // PUBLICIPV6CORROBORATION_H

--- a/src/ReservedProtocolFrames.h
+++ b/src/ReservedProtocolFrames.h
@@ -1,0 +1,178 @@
+//
+// This file is part of the aMule Project.
+//
+// Copyright (c) 2003-2026 aMule Team ( https://amule-org.github.io )
+//
+// Any parts of this program derived from the xMule, lMule or eMule project,
+// or contributed by third-party developers are copyrighted by their
+// respective authors.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301, USA
+//
+
+#ifndef RESERVEDPROTOCOLFRAMES_H
+#define RESERVEDPROTOCOLFRAMES_H
+
+#include <cstddef>
+#include <cstdint>
+
+#include <protocol/Protocols.h> // Needed for the OP_NATT_FRAME_* frame types
+
+/**
+ * Demultiplexing for OP_UDPRESERVEDPROT2 (0xB2).
+ *
+ * Unlike every other UDP protocol byte aMule handles, 0xB2 carries no eD2k
+ * opcode. The byte after the protocol byte is a frame type and the rest is
+ * that frame's payload, which is why this cannot go through
+ * CClientUDPSocket::ProcessPacket -- that function's second argument is an
+ * opcode and these are not opcodes.
+ *
+ * The classification lives here rather than in CClientUDPSocket because
+ * CClientUDPSocket needs theApp and cannot be linked into a unit test, and
+ * because the two things worth getting wrong -- the truncation guard and the
+ * unknown-type drop -- are exactly the two that never produce a visible
+ * symptom when they are wrong.
+ */
+
+//! What the caller should do with an OP_UDPRESERVEDPROT2 frame.
+enum EReservedProt2Disposition
+{
+	//! No frame-type byte to read. Drop; do not read the window.
+	RP2_TRUNCATED,
+	//! One of the five registered types. Dispatch on SReservedProt2Frame::type.
+	RP2_KNOWN_TYPE,
+	//! Not a type this protocol defines. Drop.
+	RP2_UNKNOWN_TYPE
+};
+
+/**
+ * A classified frame.
+ *
+ * `payload` and `payloadLength` describe the bytes after the type byte and are
+ * only meaningful for RP2_KNOWN_TYPE. A zero-length payload is legitimate --
+ * only the type byte is mandatory, and each handler decides what it needs.
+ */
+struct SReservedProt2Frame
+{
+	EReservedProt2Disposition disposition;
+	uint8_t type;
+	const uint8_t *payload;
+	size_t payloadLength;
+};
+
+/**
+ * Classify an OP_UDPRESERVEDPROT2 frame.
+ *
+ * @param frame  points at the frame-type byte, i.e. one past the protocol
+ *               byte of the datagram. May be NULL when frameLength is 0.
+ * @param frameLength  bytes available from `frame` onwards. Zero is the
+ *                     datagram that carried nothing but the protocol byte;
+ *                     the type byte is never read in that case.
+ *
+ * Reads nothing beyond frame[0] and never writes through `frame`. The caller
+ * must not count a dropped frame against any flood or ban threshold: this
+ * function reaches no accounting of its own, and CPacketTracking is only
+ * entered from the Kad listener, so a drop here is exempt by placement.
+ */
+inline SReservedProt2Frame ClassifyReservedProt2Frame(const uint8_t *frame, size_t frameLength)
+{
+	SReservedProt2Frame result = { RP2_TRUNCATED, 0, nullptr, 0 };
+
+	if (frame == nullptr || frameLength == 0) {
+		return result;
+	}
+
+	result.type = frame[0];
+	result.payload = frame + 1;
+	result.payloadLength = frameLength - 1;
+
+	switch (result.type) {
+	case OP_NATT_FRAME_UTP:
+	case OP_NATT_FRAME_QUIC:
+	case OP_NATT_FRAME_CAPS:
+	case OP_NATT_FRAME_CAPS_ACK:
+	case OP_NATT_FRAME_KEY:
+		result.disposition = RP2_KNOWN_TYPE;
+		break;
+	default:
+		result.disposition = RP2_UNKNOWN_TYPE;
+		break;
+	}
+
+	return result;
+}
+
+/**
+ * Keeps an unknown-frame flood from becoming a log flood.
+ *
+ * A peer speaking a frame type this build does not know sends one per
+ * connection attempt and retries, so the interesting information is "it
+ * happened" plus a count -- not one line each. Logs the first occurrence, then
+ * at most one per interval, reporting how many were suppressed in between.
+ *
+ * Not thread-safe, and does not need to be: the client UDP socket's receive
+ * path is posted to the main thread.
+ */
+class CUnknownFrameLogThrottle
+{
+public:
+	//! @param intervalMs minimum gap between two logged lines.
+	explicit CUnknownFrameLogThrottle(uint64_t intervalMs)
+	: m_intervalMs(intervalMs)
+	{
+	}
+
+	/**
+	 * @param nowMs a millisecond tick count.
+	 * @return true when the caller should log. A tick count that appears to
+	 *         move backwards opens the window rather than closing it: the
+	 *         alternative is silence until the clock catches up, which on a
+	 *         64-bit wrap would be forever.
+	 */
+	bool ShouldLog(uint64_t nowMs)
+	{
+		if (!m_everLogged || nowMs < m_lastLoggedMs || nowMs - m_lastLoggedMs >= m_intervalMs) {
+			m_everLogged = true;
+			m_lastLoggedMs = nowMs;
+			// The live counter is moved aside here rather than in
+			// TakeSuppressedCount(), so it is reset even in a build
+			// where the debug log line it feeds compiles away.
+			m_reportable = m_suppressed;
+			m_suppressed = 0;
+			return true;
+		}
+
+		++m_suppressed;
+		return false;
+	}
+
+	//! How many occurrences were dropped since the previous logged line.
+	//! Reads the snapshot ShouldLog() took, so the number is reported once.
+	uint32_t TakeSuppressedCount()
+	{
+		const uint32_t suppressed = m_reportable;
+		m_reportable = 0;
+		return suppressed;
+	}
+
+private:
+	uint64_t m_intervalMs;
+	uint64_t m_lastLoggedMs = 0;
+	uint32_t m_suppressed = 0;
+	uint32_t m_reportable = 0;
+	bool m_everLogged = false;
+};
+
+#endif // RESERVEDPROTOCOLFRAMES_H

--- a/src/ServerConnect.cpp
+++ b/src/ServerConnect.cpp
@@ -44,8 +44,9 @@
 #include "Preferences.h"     // Needed for CPreferences
 #include "Statistics.h"      // Needed for theStats
 #include "Logger.h"
-#include "GuiEvents.h" // Needed for Notify_*
-#include "IPFilter.h"  // Needed for theApp->ipfilter->IsReady()
+#include "GuiEvents.h"               // Needed for Notify_*
+#include "IPFilter.h"                // Needed for theApp->ipfilter->IsReady()
+#include "PublicIPv6Corroboration.h" // Needed for RefreshLocalPublicIPv6Addresses
 #include <common/Format.h>
 
 // #define DEBUG_CLIENT_PROTOCOL
@@ -235,6 +236,14 @@ void CServerConnect::ConnectionEstablished(CServerSocket *sender)
 	if (sender->GetConnectionState() == CS_WAITFORLOGIN) {
 		AddLogLineN(CFormat(_("Connected to %s (%s:%i)")) % sender->cur_server->GetListName() %
 			    sender->cur_server->GetFullIP() % sender->cur_server->GetPort());
+
+		// A new server connection is the moment our outward-facing address is
+		// most likely to have just changed -- a reconnect after a link came
+		// back up lands here. Peers reached through this connection will start
+		// telling us what address they see, and their claims are only ever
+		// believed against the set published here, so it has to be current
+		// before the first hello arrives.
+		RefreshLocalPublicIPv6Addresses();
 
 		// send loginpacket
 		CServer *update = theApp->serverlist->GetServerByAddress(

--- a/src/UpDownClientEC.h
+++ b/src/UpDownClientEC.h
@@ -26,9 +26,10 @@
 #ifndef UPDOWNCLIENTEC_H
 #define UPDOWNCLIENTEC_H
 
-#include <ec/cpp/ECID.h> // Needed for CECID
-#include "BitVector.h"   // Needed for BitVector
-#include "ClientRef.h"   // Needed for debug defines
+#include <ec/cpp/ECID.h>      // Needed for CECID
+#include "BitVector.h"        // Needed for BitVector
+#include "ClientRef.h"        // Needed for debug defines
+#include "PeerCapabilities.h" // Needed for CPeerCapabilities
 
 class CKnownFile;
 class CPartFile;
@@ -103,6 +104,7 @@ public:
 	uint16 GetLastDownloadingPart() const { return m_lastDownloadingPart; }
 	uint16 GetNextRequestedPart() const { return m_nextRequestedPart; }
 	uint8 GetObfuscationStatus() const { return m_obfuscationStatus; }
+	const CPeerCapabilities &GetModCapabilities() const { return m_modCapabilities; }
 	uint16 GetOldRemoteQueueRank() const { return m_nOldRemoteQueueRank; }
 	const BitVector &GetPartStatus() const { return m_downPartStatus; }
 	uint16 GetRemoteQueueRank() const { return m_nRemoteQueueRank; }
@@ -179,6 +181,7 @@ private:
 	uint16 m_lastDownloadingPart;
 	uint16 m_nextRequestedPart;
 	uint8 m_obfuscationStatus;
+	CPeerCapabilities m_modCapabilities;
 	uint16 m_nOldRemoteQueueRank;
 	BitVector m_downPartStatus;
 	uint16 m_nRemoteQueueRank;

--- a/src/amule-remote-gui.cpp
+++ b/src/amule-remote-gui.cpp
@@ -2815,6 +2815,7 @@ CUpDownClient::CUpDownClient(const CEC_UpDownClient_Tag *tag)
 	m_lastDownloadingPart = 0xffff;
 	m_nextRequestedPart = 0xffff;
 	m_obfuscationStatus = 0;
+	m_modCapabilities.Reset();
 	m_nOldRemoteQueueRank = 0;
 	m_nRemoteQueueRank = 0;
 	m_reqfile = NULL;
@@ -2985,6 +2986,14 @@ void CUpDownClientListRem::ProcessItemUpdate(const CEC_UpDownClient_Tag *tag, CC
 
 	tag->GetCurrentIdentState(&client->m_identState);
 	tag->ObfuscationStatus(client->m_obfuscationStatus);
+	{
+		// Additive tag: an older daemon sends nothing and the mirror keeps
+		// whatever it had, which for a fresh client is the empty word.
+		uint32 modCapabilities = 0;
+		if (tag->ModCapabilities(modCapabilities)) {
+			client->m_modCapabilities.SetFromWire(modCapabilities);
+		}
+	}
 	tag->HasExtendedProtocol(&client->m_bEmuleProtocol);
 
 	tag->WaitingPosition(&client->m_waitingPosition);

--- a/src/amule.cpp
+++ b/src/amule.cpp
@@ -78,15 +78,18 @@
 #include "HTTPDownload.h"         // Needed for CHTTPDownloadThread
 #include "InternalEvents.h"       // Needed for CMuleInternalEvent
 #include "IPFilter.h"             // Needed for CIPFilter
+#include "GetTickCount.h"         // Needed for GetTickCount64
 #include "KnownFileList.h"        // Needed for CKnownFileList
 #include "LibSocket.h"            // Needed for SetSocketBindInterface
 #include "ListenSocket.h"         // Needed for CListenSocket
 #include "Logger.h"               // Needed for CLogger // Do_not_auto_remove
 #include "MagnetURI.h"            // Needed for CMagnetURI
+#include "NetworkInterfaces.h"    // Needed for DetectNetworkInterfaces
 #include "OtherFunctions.h"
 #include "PartFile.h"                   // Needed for CPartFile
 #include "PlatformSpecific.h"           // Needed for PlatformSpecific::AllowSleepMode();
 #include "Preferences.h"                // Needed for CPreferences
+#include "PublicIPv6Corroboration.h"    // Needed for ObservedPublicIPv6
 #include "SearchList.h"                 // Needed for CSearchList
 #include "Server.h"                     // Needed for GetListName
 #include "ServerList.h"                 // Needed for CServerList
@@ -1607,7 +1610,25 @@ bool CamuleApp::ReinitializeNetwork(wxString *msg)
 	StartUPnP();
 #endif
 
+	// Sockets have just been (re)created, so the interface list this machine
+	// presents is as current as it will ever be. Publishing it here also covers
+	// the reinitialisation path, where a changed bind address or a first-run
+	// wizard can leave us on a different interface entirely.
+	RefreshLocalPublicIPv6Addresses();
+
 	return ok;
+}
+
+void RefreshLocalPublicIPv6Addresses()
+{
+	std::vector<CPublicIPv6Corroboration::Address> local;
+	for (const NetworkInterface &iface : DetectNetworkInterfaces()) {
+		local.insert(local.end(), iface.ipv6.begin(), iface.ipv6.end());
+	}
+	// Publishing the set is only half of it: the same call re-validates an
+	// already adopted reflection against the addresses we still hold, which is
+	// how a prefix renumber gets noticed at all.
+	ObservedPublicIPv6().SetLocalAddresses(local, ::GetTickCount64());
 }
 
 #ifdef ENABLE_UPNP
@@ -1946,7 +1967,7 @@ void CamuleApp::OnTCPTimer(CTimerEvent &WXUNUSED(evt))
 void CamuleApp::OnCoreTimer(CTimerEvent &WXUNUSED(evt))
 {
 	// Former TimerProc section
-	static uint64 msPrev1, msPrev5, msPrevSave, msPrevHist, msPrevOS, msPrevKnownMet;
+	static uint64 msPrev1, msPrev5, msPrevSave, msPrevHist, msPrevOS, msPrevKnownMet, msPrevIfaces;
 	uint64 msCur = theStats::GetUptimeMillis();
 	TheTime = msCur / 1000;
 
@@ -2073,6 +2094,15 @@ void CamuleApp::OnCoreTimer(CTimerEvent &WXUNUSED(evt))
 	if (msCur - msPrev5 > 5000) { // every 5 seconds
 		msPrev5 = msCur;
 		listensocket->Process();
+	}
+
+	// Roughly every five minutes. An interface walk is too expensive to do per
+	// peer claim and too rare to leave to startup: between the two, this is
+	// what notices a prefix renumber or a privacy-address rotation on a session
+	// that never reconnects to a server.
+	if (msCur - msPrevIfaces >= 5 * 60 * 1000) {
+		msPrevIfaces = msCur;
+		RefreshLocalPublicIPv6Addresses();
 	}
 
 	if (msCur - msPrevSave >= 60000) {

--- a/src/include/protocol/Protocols.h
+++ b/src/include/protocol/Protocols.h
@@ -52,4 +52,30 @@ enum Protocols
 	OP_MLDONKEYPROT = 0x00
 };
 
+// OP_UDPRESERVEDPROT2 frame types.
+//
+// 0xB2 is the one UDP protocol byte that is not followed by an eD2k opcode:
+// the next byte selects a frame type and the rest is that frame's payload.
+// These are the types eMuleAI defines, and they are a separate namespace from
+// Protocols above -- OP_NATT_FRAME_UTP and OP_MLDONKEYPROT are both 0x00 and
+// mean unrelated things at different offsets.
+//
+// aMule implements none of the transports behind them yet; it recognises them
+// so an eMuleAI peer's NAT traversal traffic is dropped as a known frame it
+// cannot serve rather than treated as malformed traffic. See
+// src/ReservedProtocolFrames.h.
+enum ReservedProt2FrameTypes
+{
+	//! Legacy uTP NAT-T frame.
+	OP_NATT_FRAME_UTP = 0x00,
+	//! QUIC NAT-T frame.
+	OP_NATT_FRAME_QUIC = 0x01,
+	//! Direct peer NAT-T capability negotiation.
+	OP_NATT_FRAME_CAPS = 0x02,
+	//! Direct peer NAT-T capability negotiation acknowledgement.
+	OP_NATT_FRAME_CAPS_ACK = 0x03,
+	//! NAT-T key frame.
+	OP_NATT_FRAME_KEY = 0xFF
+};
+
 #endif // ED2KPROTOCOLS_H

--- a/src/include/tags/ClientTags.h
+++ b/src/include/tags/ClientTags.h
@@ -44,6 +44,10 @@ enum client_tags
 	// counterpart of the "bi6" Kad tag.
 	CT_EMULE_SERVINGBUDDYIPV6 = 0xA0,
 	CT_MOD_MISCOPTIONS = 0xAA, // <uint32> capability bitfield
+	// <hash> the address the peer observed this client arriving from, 16
+	// bytes. Only the hash form is read; see src/PublicIPv6Corroboration.h
+	// for why, and for why one peer saying it is not enough.
+	CT_MOD_YOUR_IP = 0xAD,
 	CT_MOD_IP_V6 = 0xAE, // <hash> client IPv6 address, 16 bytes
 	// 0xAF is deliberately not named here. eMuleAI defines it, but nothing in
 	// its tree writes it and its hello path never reads it as an address: the

--- a/src/include/tags/ClientTags.h
+++ b/src/include/tags/ClientTags.h
@@ -38,9 +38,22 @@ enum client_tags
 	// which is why the reference implementation took it. Bit meanings for
 	// CT_MOD_MISCOPTIONS live in src/PeerCapabilities.h -- they are wire
 	// format and a wrong bit position has no runtime signal.
+	//
+	// <hash> the peer's serving buddy's IPv6 address, 16 bytes. The v6
+	// counterpart of CT_EMULE_BUDDYIP (0xFC) below, and the hello-side
+	// counterpart of the "bi6" Kad tag.
+	CT_EMULE_SERVINGBUDDYIPV6 = 0xA0,
 	CT_MOD_MISCOPTIONS = 0xAA, // <uint32> capability bitfield
-	CT_MOD_IP_V6 = 0xAE,       // <hash> client IPv6 address, 16 bytes
-	CT_MOD_SVR_IP_V6 = 0xAF,   // <hash> server IPv6 address, 16 bytes
+	CT_MOD_IP_V6 = 0xAE, // <hash> client IPv6 address, 16 bytes
+	// 0xAF is deliberately not named here. eMuleAI defines it, but nothing in
+	// its tree writes it and its hello path never reads it as an address: the
+	// one case that mentions it sits in the reserved-for-future-releases block
+	// and only flags the sender as running an unofficial build. emule-qt gives
+	// the same id a server->client meaning (the server's own public IPv6),
+	// which aMule would be recording from a peer. Reading it as either would
+	// state something the wire does not say, so it falls through to the
+	// unknown-vendor-tag log in BaseClient.cpp like any other 0xA? id aMule
+	// does not handle.
 
 	CT_EMULECOMPAT_OPTIONS = 0xEF,
 	CT_EMULE_RESERVED1 = 0xF0,

--- a/src/include/tags/ClientTags.h
+++ b/src/include/tags/ClientTags.h
@@ -33,6 +33,15 @@ enum client_tags
 	CT_PORT = 0x0F,
 	CT_VERSION = 0x11,
 	CT_SERVER_FLAGS = 0x20, // currently only used to inform a server about supported features
+
+	// eMuleAI vendor tags. The 0xA? range is unclaimed by the major mods,
+	// which is why the reference implementation took it. Bit meanings for
+	// CT_MOD_MISCOPTIONS live in src/PeerCapabilities.h -- they are wire
+	// format and a wrong bit position has no runtime signal.
+	CT_MOD_MISCOPTIONS = 0xAA, // <uint32> capability bitfield
+	CT_MOD_IP_V6 = 0xAE,       // <hash> client IPv6 address, 16 bytes
+	CT_MOD_SVR_IP_V6 = 0xAF,   // <hash> server IPv6 address, 16 bytes
+
 	CT_EMULECOMPAT_OPTIONS = 0xEF,
 	CT_EMULE_RESERVED1 = 0xF0,
 	CT_EMULE_RESERVED2 = 0xF1,

--- a/src/include/tags/FileTags.h
+++ b/src/include/tags/FileTags.h
@@ -152,6 +152,14 @@
 #define TAG_SOURCEIP wxT("\xFE")       // <uint32>
 #define TAG_SOURCETYPE wxT("\xFF")     // <uint8>
 
+// eMuleAI vendor tags in Kad source publish/search results. Multi-character
+// names, deliberately: the single-byte space above is full. Both carry a
+// 128-bit address as exactly 32 hexadecimal characters, most significant byte
+// first -- see DecodeIPv6HexTag() in src/PeerCapabilities.h. aMule reads them
+// but cannot yet route to an IPv6 source, so it records and drops.
+#define TAG_IPV6 wxT("ip6")             // <string> unfirewalled IPv6
+#define TAG_SERVINGBUDDYIPV6 wxT("bi6") // <string> serving buddy IPv6
+
 // Media values for FT_FILETYPE
 #define ED2KFTSTR_AUDIO wxT("Audio")
 #define ED2KFTSTR_VIDEO wxT("Video")

--- a/src/kademlia/kademlia/Search.cpp
+++ b/src/kademlia/kademlia/Search.cpp
@@ -67,6 +67,7 @@ there client on the eMule forum..
 #include "../../MemFile.h"
 #include "../../ClientList.h"
 #include "../../updownclient.h"
+#include "../../PeerCapabilities.h" // Needed for DecodeIPv6HexTag
 #include "../../Logger.h"
 #include "../../Preferences.h"
 #ifdef ENABLE_KAD_NODE_PROTECTION
@@ -1181,6 +1182,28 @@ void CSearch::ProcessResultFile(const CUInt128 &answer, TagPtrList *info)
 			buddy.SetValueBE(hash.GetHash());
 		} else if (!tag->GetName().Cmp(TAG_ENCRYPTION)) {
 			byCryptOptions = (uint8)tag->GetInt();
+		} else if (!tag->GetName().Cmp(TAG_IPV6) || !tag->GetName().Cmp(TAG_SERVINGBUDDYIPV6)) {
+			// eMuleAI publishes IPv6 sources alongside the IPv4 ones as
+			// 32 hex characters. aMule has no IPv6 stack yet, so the
+			// address is validated and dropped: a malformed tag is worth
+			// a log line, and a well-formed one must not be mistaken for
+			// a reachable source. Routing to it is the dual-stack change.
+			uint8_t address[16];
+			bool decoded = false;
+			if (tag->IsStr()) {
+				const wxScopedCharBuffer text = tag->GetStr().utf8_str();
+				decoded = DecodeIPv6HexTag(text.data(), text.length(), address);
+			}
+			if (decoded) {
+				AddDebugLogLineN(logKadSearch,
+					CFormat("Ignoring IPv6 source tag '%s' in search result: no "
+						"IPv6 transport in this build") %
+						tag->GetName());
+			} else {
+				AddDebugLogLineN(logKadSearch,
+					CFormat("Invalid IPv6 source tag '%s' in search result") %
+						tag->GetName());
+			}
 		}
 	}
 

--- a/src/libs/ec/abstracts/ECCodes.abstract
+++ b/src/libs/ec/abstracts/ECCodes.abstract
@@ -445,6 +445,11 @@ EC_TAG_CLIENT                             0x0600
 	EC_TAG_CLIENT_LAST_SEEN                   0x062F
 	EC_TAG_CLIENT_FIRST_SEEN                  0x0630
 	EC_TAG_CLIENT_SESSIONS                    0x0631
+
+# eMuleAI vendor capability word (CT_MOD_MISCOPTIONS) as the peer sent it,
+# already masked to the five defined bits. Additive: a missing tag means an
+# older daemon, which is a distinct third state from "peer advertised nothing".
+	EC_TAG_CLIENT_MOD_CAPABILITIES            0x0632
 EC_TAG_SEARCHFILE                         0x0700
 	EC_TAG_SEARCH_TYPE                        0x0701
 	EC_TAG_SEARCH_NAME                        0x0702

--- a/src/libs/ec/abstracts/ECCodes.abstract
+++ b/src/libs/ec/abstracts/ECCodes.abstract
@@ -449,7 +449,7 @@ EC_TAG_CLIENT                             0x0600
 # eMuleAI vendor capability word (CT_MOD_MISCOPTIONS) as the peer sent it,
 # already masked to the five defined bits. Additive: a missing tag means an
 # older daemon, which is a distinct third state from "peer advertised nothing".
-	EC_TAG_CLIENT_MOD_CAPABILITIES            0x0632
+	EC_TAG_CLIENT_MOD_CAPABILITIES            0x0633
 EC_TAG_SEARCHFILE                         0x0700
 	EC_TAG_SEARCH_TYPE                        0x0701
 	EC_TAG_SEARCH_NAME                        0x0702

--- a/src/libs/ec/cpp/ECSpecialTags.h
+++ b/src/libs/ec/cpp/ECSpecialTags.h
@@ -622,6 +622,10 @@ public:
 	{
 		return AssignIfExist(EC_TAG_CLIENT_OBFUSCATION_STATUS, target);
 	}
+	bool ModCapabilities(uint32 &target) const
+	{
+		return AssignIfExist(EC_TAG_CLIENT_MOD_CAPABILITIES, target);
+	}
 	bool HasExtendedProtocol(bool *target = 0) const
 	{
 		return AssignIfExist(EC_TAG_CLIENT_EXT_PROTOCOL, target);

--- a/src/muuli_wdr.cpp
+++ b/src/muuli_wdr.cpp
@@ -1259,7 +1259,7 @@ wxSizer *clientDetails( wxWindow *parent, bool call_fit, bool set_sizer )
     wxStaticText *item26 = new wxStaticText( parent, IDT_KAD, _("N/A"), wxDefaultPosition, wxDefaultSize, 0 );
     item26->SetForegroundColour( wxSystemSettings::GetColour(wxSYS_COLOUR_HOTLIGHT) );
     item10->Add( item26, wxSizerFlags().CenterVertical().Border(wxLEFT|wxRIGHT|wxBOTTOM, 5) );
-    wxStaticText *item26a = new wxStaticText( parent, -1, _("Vendor capabilities:"), wxDefaultPosition, wxDefaultSize, 0 );
+    wxStaticText *item26a = new wxStaticText( parent, IDT_MOD_CAPABILITIES_LABEL, _("Protocol extensions:"), wxDefaultPosition, wxDefaultSize, 0 );
     item10->Add( item26a, wxSizerFlags().CenterVertical().Border(wxLEFT|wxRIGHT|wxBOTTOM, 5) );
     wxStaticText *item26b = new wxStaticText( parent, IDT_MOD_CAPABILITIES, _("N/A"), wxDefaultPosition, wxDefaultSize, 0 );
     item26b->SetForegroundColour( wxSystemSettings::GetColour(wxSYS_COLOUR_HOTLIGHT) );

--- a/src/muuli_wdr.cpp
+++ b/src/muuli_wdr.cpp
@@ -1259,6 +1259,11 @@ wxSizer *clientDetails( wxWindow *parent, bool call_fit, bool set_sizer )
     wxStaticText *item26 = new wxStaticText( parent, IDT_KAD, _("N/A"), wxDefaultPosition, wxDefaultSize, 0 );
     item26->SetForegroundColour( wxSystemSettings::GetColour(wxSYS_COLOUR_HOTLIGHT) );
     item10->Add( item26, wxSizerFlags().CenterVertical().Border(wxLEFT|wxRIGHT|wxBOTTOM, 5) );
+    wxStaticText *item26a = new wxStaticText( parent, -1, _("Vendor capabilities:"), wxDefaultPosition, wxDefaultSize, 0 );
+    item10->Add( item26a, wxSizerFlags().CenterVertical().Border(wxLEFT|wxRIGHT|wxBOTTOM, 5) );
+    wxStaticText *item26b = new wxStaticText( parent, IDT_MOD_CAPABILITIES, _("N/A"), wxDefaultPosition, wxDefaultSize, 0 );
+    item26b->SetForegroundColour( wxSystemSettings::GetColour(wxSYS_COLOUR_HOTLIGHT) );
+    item10->Add( item26b, wxSizerFlags().CenterVertical().Border(wxLEFT|wxRIGHT|wxBOTTOM, 5) );
     item1->Add( item10, wxSizerFlags().Expand().CenterVertical() );
     item0->Add( item1, wxSizerFlags().Expand().CenterVertical().Border(wxALL, 5) );
     wxStaticBox *item28 = new wxStaticBox( parent, -1, _("Transfers to client") );

--- a/src/muuli_wdr.h
+++ b/src/muuli_wdr.h
@@ -226,10 +226,15 @@ wxSizer *statsDlg(wxWindow *parent, bool call_fit = TRUE, bool set_sizer = TRUE)
 #define ID_DSNAME 10098
 #define IDT_OBFUSCATION 10099
 #define IDT_KAD 10100
-// Peer's eMuleAI vendor capability word, Client Details. Appended at the end
-// of the id space rather than next to IDT_KAD: the ids are bound implicitly
-// and by value, so inserting one here would renumber every id below it.
+// Peer's protocol-extension word, Client Details. Appended at the end of the
+// id space rather than next to IDT_KAD: the ids are bound implicitly and by
+// value, so inserting one here would renumber every id below it.
+//
+// The label carries an id of its own -- unlike every other label in this
+// dialog -- because the row is hidden whole when the peer claims no
+// extension, and a label with id -1 cannot be found to hide.
 #define IDT_MOD_CAPABILITIES 10510
+#define IDT_MOD_CAPABILITIES_LABEL 10511
 #define ID_DDOWNLOADING 10101
 #define ID_DAVDR 10102
 #define ID_DAVUR 10103

--- a/src/muuli_wdr.h
+++ b/src/muuli_wdr.h
@@ -226,6 +226,10 @@ wxSizer *statsDlg(wxWindow *parent, bool call_fit = TRUE, bool set_sizer = TRUE)
 #define ID_DSNAME 10098
 #define IDT_OBFUSCATION 10099
 #define IDT_KAD 10100
+// Peer's eMuleAI vendor capability word, Client Details. Appended at the end
+// of the id space rather than next to IDT_KAD: the ids are bound implicitly
+// and by value, so inserting one here would renumber every id below it.
+#define IDT_MOD_CAPABILITIES 10510
 #define ID_DDOWNLOADING 10101
 #define ID_DAVDR 10102
 #define ID_DAVUR 10103

--- a/src/updownclient.h
+++ b/src/updownclient.h
@@ -682,9 +682,11 @@ public:
 	//! Only meaningful while HasModIPv6() is true.
 	const uint8_t *GetModIPv6() const { return m_modIPv6; }
 	bool HasModIPv6() const { return m_hasModIPv6; }
-	//! The peer's server IPv6 address from CT_MOD_SVR_IP_V6.
-	const uint8_t *GetModServerIPv6() const { return m_modServerIPv6; }
-	bool HasModServerIPv6() const { return m_hasModServerIPv6; }
+	//! The peer's serving buddy's IPv6 address from
+	//! CT_EMULE_SERVINGBUDDYIPV6, big-endian, 16 bytes. Only meaningful
+	//! while HasServingBuddyIPv6() is true.
+	const uint8_t *GetServingBuddyIPv6() const { return m_servingBuddyIPv6; }
+	bool HasServingBuddyIPv6() const { return m_hasServingBuddyIPv6; }
 	// Kad added by me
 	bool SendBuddyPing();
 
@@ -1006,9 +1008,9 @@ private:
 	/* eMuleAI vendor capabilities, parsed from the CT_MOD_* hello tags */
 	CPeerCapabilities m_modCapabilities;
 	uint8_t m_modIPv6[16];
-	uint8_t m_modServerIPv6[16];
+	uint8_t m_servingBuddyIPv6[16];
 	bool m_hasModIPv6;
-	bool m_hasModServerIPv6;
+	bool m_hasServingBuddyIPv6;
 
 	uint64 m_dwLastBuddyPingPongTime;
 	uint64_t m_dwDirectCallbackTimeout;

--- a/src/updownclient.h
+++ b/src/updownclient.h
@@ -33,10 +33,11 @@
 #include <common/Macros.h>
 #include "NetworkFunctions.h"
 #include "OtherStructs.h"
-#include "ClientCredits.h" // Needed for EIdentState
-#include <ec/cpp/ECID.h>   // Needed for CECID
-#include "BitVector.h"     // Needed for BitVector
-#include "ClientRef.h"     // Needed for debug defines
+#include "ClientCredits.h"    // Needed for EIdentState
+#include <ec/cpp/ECID.h>      // Needed for CECID
+#include "BitVector.h"        // Needed for BitVector
+#include "ClientRef.h"        // Needed for debug defines
+#include "PeerCapabilities.h" // Needed for CPeerCapabilities
 
 #include <map>
 #include <wx/thread.h> // Needed for wxMutex
@@ -671,6 +672,19 @@ public:
 	void SetKadState(EKadState nNewS) { m_nKadState = nNewS; }
 	uint8 GetKadVersion() { return m_byKadVersion; }
 	void ProcessFirewallCheckUDPRequest(CMemFile *data);
+
+	/* eMuleAI vendor capabilities */
+	//! What the peer claimed in CT_MOD_MISCOPTIONS. Recorded only: aMule
+	//! implements none of these features yet and advertises none of them
+	//! back. See src/PeerCapabilities.h.
+	const CPeerCapabilities &GetModCapabilities() const { return m_modCapabilities; }
+	//! The peer's own IPv6 address from CT_MOD_IP_V6, big-endian, 16 bytes.
+	//! Only meaningful while HasModIPv6() is true.
+	const uint8_t *GetModIPv6() const { return m_modIPv6; }
+	bool HasModIPv6() const { return m_hasModIPv6; }
+	//! The peer's server IPv6 address from CT_MOD_SVR_IP_V6.
+	const uint8_t *GetModServerIPv6() const { return m_modServerIPv6; }
+	bool HasModServerIPv6() const { return m_hasModServerIPv6; }
 	// Kad added by me
 	bool SendBuddyPing();
 
@@ -988,6 +1002,14 @@ private:
 	EKadState m_nKadState;
 
 	uint8 m_byKadVersion;
+
+	/* eMuleAI vendor capabilities, parsed from the CT_MOD_* hello tags */
+	CPeerCapabilities m_modCapabilities;
+	uint8_t m_modIPv6[16];
+	uint8_t m_modServerIPv6[16];
+	bool m_hasModIPv6;
+	bool m_hasModServerIPv6;
+
 	uint64 m_dwLastBuddyPingPongTime;
 	uint64_t m_dwDirectCallbackTimeout;
 

--- a/src/webapi/Api.cpp
+++ b/src/webapi/Api.cpp
@@ -3128,6 +3128,14 @@ void WriteClientBaseFields(CJsonWriter &w, const webapi::ClientSnapshot &c)
 	// Being in this list means the daemon holds a client object, which starts
 	// at the first contact attempt. This says whether a socket is actually up.
 	WriteBoolOrNull(w, "connected", c.has_connected, c.connected);
+	// The peer's eMuleAI vendor capability word, the same one the remote GUI
+	// reads off EC_TAG_CLIENT_MOD_CAPABILITIES. A bitfield rather than the
+	// token this surface prefers because it is not an enumeration: a peer
+	// claims any combination of the bits, so there is no one value to name.
+	// The bit meanings are in src/PeerCapabilities.h; 0 means the peer
+	// claimed nothing, which is what nearly every peer on the network does.
+	w.Key("protocol_extensions");
+	w.ValueUInt(static_cast<uint64_t>(c.protocol_extensions));
 	w.Key("friend_slot");
 	w.ValueBool(c.friend_slot);
 	// Promoted out of the detail object (issue #984): the desktop's per-file

--- a/src/webapi/Api.cpp
+++ b/src/webapi/Api.cpp
@@ -36,6 +36,7 @@
 #include "ConstantTime.h"
 #include "Etag.h"
 #include "JsonWriter.h"
+#include "../PeerCapabilities.h" // Needed for CPeerCapabilities::GetApiTokens
 
 #include <mutex> // serialises the shared-directory read-modify-write
 #include "Jwt.h"
@@ -3128,14 +3129,27 @@ void WriteClientBaseFields(CJsonWriter &w, const webapi::ClientSnapshot &c)
 	// Being in this list means the daemon holds a client object, which starts
 	// at the first contact attempt. This says whether a socket is actually up.
 	WriteBoolOrNull(w, "connected", c.has_connected, c.connected);
-	// The peer's eMuleAI vendor capability word, the same one the remote GUI
-	// reads off EC_TAG_CLIENT_MOD_CAPABILITIES. A bitfield rather than the
-	// token this surface prefers because it is not an enumeration: a peer
-	// claims any combination of the bits, so there is no one value to name.
-	// The bit meanings are in src/PeerCapabilities.h; 0 means the peer
-	// claimed nothing, which is what nearly every peer on the network does.
+	// The protocol extensions the peer claimed, as tokens rather than as the
+	// EC_TAG_CLIENT_MOD_CAPABILITIES word they arrived in. An integer here
+	// would make every consumer carry its own copy of the bit table -- the
+	// Web UI in JS, and each third-party client again -- with nothing keeping
+	// those copies in step with src/PeerCapabilities.h, which is the only
+	// place the bits are actually defined. A list rather than one token
+	// because a peer claims any combination of them.
+	//
+	// An empty array is what nearly every peer on the network produces: it
+	// claimed nothing. A peer that sent no capability tag at all and one that
+	// sent an all-zero word are the same state on the wire and the same here.
 	w.Key("protocol_extensions");
-	w.ValueUInt(static_cast<uint64_t>(c.protocol_extensions));
+	w.BeginArray();
+	{
+		CPeerCapabilities caps;
+		caps.SetFromWire(c.protocol_extensions);
+		for (const std::string &token : caps.GetApiTokens()) {
+			w.ValueString(token.c_str());
+		}
+	}
+	w.EndArray();
 	w.Key("friend_slot");
 	w.ValueBool(c.friend_slot);
 	// Promoted out of the detail object (issue #984): the desktop's per-file

--- a/src/webapi/EventDiff.cpp
+++ b/src/webapi/EventDiff.cpp
@@ -564,10 +564,10 @@ bool Equal(const ClientSnapshot &a, const ClientSnapshot &b)
 	       a.download_speed_bytes_per_second == b.download_speed_bytes_per_second &&
 	       a.upload_queue_position == b.upload_queue_position &&
 	       a.remote_queue_position == b.remote_queue_position && a.score == b.score &&
-	       a.obfuscation_state == b.obfuscation_state &&
-	       a.protocol_extensions == b.protocol_extensions && a.friend_slot == b.friend_slot &&
-	       a.connected == b.connected && a.has_connected == b.has_connected &&
-	       a.source_origin == b.source_origin && a.parts_offered_count == b.parts_offered_count &&
+	       a.obfuscation_state == b.obfuscation_state && a.protocol_extensions == b.protocol_extensions &&
+	       a.friend_slot == b.friend_slot && a.connected == b.connected &&
+	       a.has_connected == b.has_connected && a.source_origin == b.source_origin &&
+	       a.parts_offered_count == b.parts_offered_count &&
 	       // Without the flag, null -> 0 (the part map arriving and reporting
 	       // zero) compares equal and the row never updates.
 	       a.has_parts_offered_count == b.has_parts_offered_count &&

--- a/src/webapi/EventDiff.cpp
+++ b/src/webapi/EventDiff.cpp
@@ -351,6 +351,7 @@ std::string ToJson(const ClientSnapshot &c)
 								  : std::to_string(c.remote_queue_position))
 	  << ",\"upload_queue_score\":" << c.score
 	  << ",\"obfuscation_state\":" << JsonStrOrNull(!c.obfuscation_state.empty(), c.obfuscation_state)
+	  << ",\"protocol_extensions\":" << c.protocol_extensions
 	  << ",\"connected\":" << JsonBoolOrNull(c.has_connected, c.connected)
 	  << ",\"friend_slot\":" << (c.friend_slot ? "true" : "false")
 	  << ",\"source_origin\":" << JsonStrOrNull(!c.source_origin.empty(), c.source_origin)
@@ -563,7 +564,8 @@ bool Equal(const ClientSnapshot &a, const ClientSnapshot &b)
 	       a.download_speed_bytes_per_second == b.download_speed_bytes_per_second &&
 	       a.upload_queue_position == b.upload_queue_position &&
 	       a.remote_queue_position == b.remote_queue_position && a.score == b.score &&
-	       a.obfuscation_state == b.obfuscation_state && a.friend_slot == b.friend_slot &&
+	       a.obfuscation_state == b.obfuscation_state &&
+	       a.protocol_extensions == b.protocol_extensions && a.friend_slot == b.friend_slot &&
 	       a.connected == b.connected && a.has_connected == b.has_connected &&
 	       a.source_origin == b.source_origin && a.parts_offered_count == b.parts_offered_count &&
 	       // Without the flag, null -> 0 (the part map arriving and reporting

--- a/src/webapi/EventDiff.cpp
+++ b/src/webapi/EventDiff.cpp
@@ -22,6 +22,7 @@
 // Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 //
 
+#include "../PeerCapabilities.h" // Needed for CPeerCapabilities::GetApiTokens
 #include "EventDiff.h"
 
 #include "EventBus.h"
@@ -123,6 +124,31 @@ std::string JsonStrOrNull(bool known, const std::string &v)
 std::string JsonNumOrNull(bool known, std::uint64_t v)
 {
 	return known ? std::to_string(v) : std::string("null");
+}
+
+// The protocol extensions as the API's token array, from the same table the
+// daemon and the desktop GUI read (src/PeerCapabilities.h). Rendered here
+// rather than stored on the row so there is one definition of the mapping:
+// a second copy in this file would be free to drift from the one bit that
+// actually arrived on the wire.
+//
+// Empty array, not null: the peer claimed nothing, which is a known answer
+// rather than a missing one, and it is what nearly every peer produces.
+std::string JsonProtocolExtensions(std::uint32_t bits)
+{
+	CPeerCapabilities caps;
+	caps.SetFromWire(bits);
+	std::string out = "[";
+	bool first = true;
+	for (const std::string &token : caps.GetApiTokens()) {
+		if (!first) {
+			out += ",";
+		}
+		first = false;
+		out += "\"" + token + "\"";
+	}
+	out += "]";
+	return out;
 }
 
 std::string JsonBoolOrNull(bool known, bool v)
@@ -351,8 +377,8 @@ std::string ToJson(const ClientSnapshot &c)
 								  : std::to_string(c.remote_queue_position))
 	  << ",\"upload_queue_score\":" << c.score
 	  << ",\"obfuscation_state\":" << JsonStrOrNull(!c.obfuscation_state.empty(), c.obfuscation_state)
-	  << ",\"protocol_extensions\":" << c.protocol_extensions
 	  << ",\"connected\":" << JsonBoolOrNull(c.has_connected, c.connected)
+	  << ",\"protocol_extensions\":" << JsonProtocolExtensions(c.protocol_extensions)
 	  << ",\"friend_slot\":" << (c.friend_slot ? "true" : "false")
 	  << ",\"source_origin\":" << JsonStrOrNull(!c.source_origin.empty(), c.source_origin)
 	  << ",\"parts_offered_count\":"

--- a/src/webapi/Refresher.cpp
+++ b/src/webapi/Refresher.cpp
@@ -1030,6 +1030,15 @@ void MergeClientTag(const CEC_UpDownClient_Tag *c, ClientSnapshot &cs, bool is_n
 		}
 	}
 	{
+		// Taken as delivered. The daemon already dropped the bits it does
+		// not know (CPeerCapabilities::SetFromWire), and re-masking here
+		// would put a second copy of that mask in the tree, free to drift
+		// from the one that actually saw the handshake.
+		std::uint32_t v = cs.protocol_extensions;
+		if (c->AssignIfExist(EC_TAG_CLIENT_MOD_CAPABILITIES, v))
+			cs.protocol_extensions = v;
+	}
+	{
 		bool v = false;
 		if (c->AssignIfExist(EC_TAG_CLIENT_FRIEND_SLOT, v))
 			cs.friend_slot = v;

--- a/src/webapi/State.h
+++ b/src/webapi/State.h
@@ -432,6 +432,15 @@ struct ClientSnapshot
 	// Complete set, see ClientObfuscationName() in Refresher.cpp:
 	std::string obfuscation_state; // "undefined" | "enabled" | "supported" | "not_supported" |
 				       // "disabled" | "unknown"
+	//! EC_TAG_CLIENT_MOD_CAPABILITIES: the peer's eMuleAI vendor capability
+	//! word, already limited to the bits aMule knows by
+	//! CPeerCapabilities::SetFromWire() in the daemon. Held as the word the
+	//! daemon sent, not re-masked here: a second mask in this process would
+	//! be free to disagree with the daemon's, and the surface would then
+	//! report something no client ever claimed. Bit meanings live in
+	//! src/PeerCapabilities.h. 0 for a peer that claims nothing and for one
+	//! that sent no capability tag -- the same state, as on the wire.
+	std::uint32_t protocol_extensions = 0;
 	bool friend_slot = false;
 	// Whether a socket to this peer is up right now (EC_TAG_CLIENT_CONNECTED,
 	// from CUpDownClient::IsConnected). A row existing here only means the

--- a/unittests/curl-tests/amuleapi/43-client-protocol-extensions.sh
+++ b/unittests/curl-tests/amuleapi/43-client-protocol-extensions.sh
@@ -1,0 +1,228 @@
+#!/usr/bin/env bash
+#
+# amuleapi 43-client-protocol-extensions — the peer capability word on the
+# REST surface.
+#
+# amuled publishes a peer's eMuleAI vendor capability word over EC as
+# EC_TAG_CLIENT_MOD_CAPABILITIES, and the desktop GUI renders it as its
+# "Protocol extensions" row. Without this field the EC surface and the REST
+# surface disagree about what is known of a peer, and a headless caller has
+# no way to see the word at all.
+#
+# What is asserted here:
+#
+#   * `protocol_extensions` is present on the /clients list row, on the
+#     /clients/{ecid} detail object, and in the client_* SSE payloads, so
+#     the three views of one peer do not disagree,
+#   * it is a number, not a token: the field is a bitfield and a peer claims
+#     any combination of the bits, so there is no single value to name,
+#   * only bits the daemon defines can appear. The daemon masks the word
+#     with MOD_MISCOPT_KNOWN_MASK (0x1F) before it reaches EC, so a value
+#     outside that mask means either the mask moved or something re-derived
+#     the word downstream — which is the failure this field is most likely
+#     to have, and the one nothing else would notice,
+#   * the key is always present, never omitted: 0 is a real answer here (the
+#     peer claimed nothing, which nearly every peer does) and a caller must
+#     not have to tell it from a missing key.
+#
+# Note on an empty peer list: a fresh regtest daemon may be connected to no
+# peers, so the per-row assertions skip themselves rather than fail. Run
+# against a daemon with live sources to exercise them.
+#
+# Usage:
+#   amuleapi --config-dir=/tmp/amuleapi-regtest &
+#   ./43-client-protocol-extensions.sh
+#
+# Exits 0 on success, 1 on any failed assertion, 2 on bring-up error.
+
+set -u
+set -o pipefail
+
+HOST=${HOST:-localhost:4713}
+ADMIN_PASS=${ADMIN_PASS:-adminpass}
+
+# Every bit the daemon defines: MOD_MISCOPT_KNOWN_MASK in
+# src/PeerCapabilities.h. Anything outside it must never reach the wire.
+KNOWN_MASK=31
+
+FAIL_COUNT=0
+TEST_COUNT=0
+SKIP_COUNT=0
+AUTH=()
+
+_die()  { echo "FATAL: $*" >&2; exit 2; }
+_pass() { TEST_COUNT=$((TEST_COUNT+1)); echo "  PASS  $1"; }
+_skip() { SKIP_COUNT=$((SKIP_COUNT+1)); echo "  SKIP  $1"; }
+_fail() {
+	TEST_COUNT=$((TEST_COUNT+1)); FAIL_COUNT=$((FAIL_COUNT+1))
+	echo "  FAIL  $1"
+	shift
+	for arg in "$@"; do echo "        $arg"; done
+}
+
+_curl() {
+	local resp
+	resp=$(curl -s --max-time 10 -D /tmp/amuleapi_43_head -o /tmp/amuleapi_43_body \
+		-w '%{http_code}' "${AUTH[@]}" "$@") || _die "curl invocation failed for $*"
+	CURL_STATUS=$resp
+	CURL_BODY=$(cat /tmp/amuleapi_43_body)
+}
+
+_assert_status() {
+	local expected=$1 label=$2
+	if [ "$CURL_STATUS" = "$expected" ]; then
+		_pass "$label (HTTP $CURL_STATUS)"
+	else
+		_fail "$label" "expected HTTP $expected, got $CURL_STATUS"
+	fi
+}
+
+_jq() { echo "$CURL_BODY" | jq -r "$1" 2>/dev/null; }
+
+# The two properties every appearance of the field has to hold, wherever it
+# came from: it is a number, and it carries no bit the daemon does not define.
+_assert_word() {
+	local where=$1 type=$2 value=$3
+
+	if [ "$type" = "number" ]; then
+		_pass "$where: protocol_extensions is a number, not a token"
+	else
+		_fail "$where" "expected a number, got type '$type'"
+		return
+	fi
+
+	if [ "$((value & ~KNOWN_MASK))" -eq 0 ]; then
+		_pass "$where: only defined bits are set (word=$value, mask=$KNOWN_MASK)"
+	else
+		_fail "$where" \
+			"word $value carries a bit outside MOD_MISCOPT_KNOWN_MASK ($KNOWN_MASK)" \
+			"the daemon masks in CPeerCapabilities::SetFromWire; a bit here means" \
+			"the mask moved or the word was re-derived downstream"
+	fi
+}
+
+trap 'rm -f /tmp/amuleapi_43_head /tmp/amuleapi_43_body /tmp/amuleapi_43_sse' EXIT
+
+command -v jq >/dev/null 2>&1 || _die "jq is required"
+
+if ! curl -s -o /dev/null --max-time 2 "$HOST/api/v0/health" 2>/dev/null; then
+	_die "amuleapi at $HOST is not reachable. Start amuleapi first."
+fi
+
+echo "amuleapi 43-client-protocol-extensions @ $HOST"
+
+# --- 0. Log in. ----------------------------------------------------
+TOKEN=$(curl -s -X POST -H "Content-Type: application/json" \
+	-d "{\"password\":\"$ADMIN_PASS\"}" \
+	"$HOST/api/v0/auth/login?include_token=true" | jq -r .token)
+[ -n "$TOKEN" ] && [ "$TOKEN" != "null" ] \
+	|| _die "could not log in for protocol-extension tests"
+AUTH=(-H "Authorization: Bearer $TOKEN")
+
+# --- 1. The list row. ----------------------------------------------
+_curl "$HOST/api/v0/clients"
+_assert_status 200 "GET /clients"
+
+COUNT=$(_jq '.clients | length')
+COUNT=${COUNT:-0}
+echo "        ($COUNT peer(s) connected)"
+
+if [ "$COUNT" -gt 0 ]; then
+	if [ "$(_jq '.clients[0] | has("protocol_extensions")')" = "true" ]; then
+		_pass "list row carries protocol_extensions"
+		_assert_word "list row" \
+			"$(_jq '.clients[0].protocol_extensions | type')" \
+			"$(_jq '.clients[0].protocol_extensions')"
+	else
+		_fail "list row" "no protocol_extensions key in: $(_jq '.clients[0] | keys')"
+	fi
+
+	# Present on every row, not only the first: the key is unconditional, so
+	# a peer that claimed nothing still reports 0 rather than dropping it.
+	MISSING=$(_jq '[.clients[] | select(has("protocol_extensions") | not)] | length')
+	if [ "${MISSING:-1}" -eq 0 ]; then
+		_pass "every list row carries the key, including peers claiming nothing"
+	else
+		_fail "list rows" "$MISSING of $COUNT rows omit protocol_extensions"
+	fi
+
+	ECID=$(_jq '.clients[0].ecid')
+else
+	_skip "list row shape (no peer connected)"
+	_skip "every list row carries the key (no peer connected)"
+	ECID=""
+fi
+
+# --- 2. The detail object. -----------------------------------------
+if [ -n "$ECID" ] && [ "$ECID" != "null" ]; then
+	_curl "$HOST/api/v0/clients/$ECID"
+	_assert_status 200 "GET /clients/$ECID"
+
+	if [ "$(_jq 'has("protocol_extensions")')" = "true" ]; then
+		_pass "detail object carries protocol_extensions"
+		_assert_word "detail object" \
+			"$(_jq '.protocol_extensions | type')" \
+			"$(_jq '.protocol_extensions')"
+	else
+		_fail "detail object" "no protocol_extensions key in: $(_jq 'keys')"
+	fi
+
+	# The detail object is documented as a superset of the list row, so the
+	# two must agree about this peer rather than merely both have the key.
+	_curl "$HOST/api/v0/clients"
+	LIST_WORD=$(_jq ".clients[] | select(.ecid == $ECID) | .protocol_extensions")
+	_curl "$HOST/api/v0/clients/$ECID"
+	DETAIL_WORD=$(_jq '.protocol_extensions')
+	if [ "$LIST_WORD" = "$DETAIL_WORD" ]; then
+		_pass "list and detail report the same word for ecid $ECID ($DETAIL_WORD)"
+	else
+		_fail "list vs detail" "list says '$LIST_WORD', detail says '$DETAIL_WORD'"
+	fi
+else
+	_skip "detail object shape (no peer connected)"
+	_skip "list and detail agree (no peer connected)"
+fi
+
+# --- 3. The SSE payload. -------------------------------------------
+# client_added / client_updated are documented to carry the same field set as
+# the list row. A field added to the REST writer and not to the diff writer
+# is exactly the failure that guarantee exists to catch, and it is invisible
+# from REST alone.
+curl -s --max-time 12 -N "${AUTH[@]}" \
+	"$HOST/api/v0/events?filter=client_added,client_updated" \
+	> /tmp/amuleapi_43_sse 2>/dev/null &
+SSE_PID=$!
+sleep 10
+kill "$SSE_PID" 2>/dev/null
+wait "$SSE_PID" 2>/dev/null
+
+CLIENT_FRAME=$(grep '^data: ' /tmp/amuleapi_43_sse 2>/dev/null \
+	| sed 's/^data: //' \
+	| jq -c 'select(has("ecid"))' 2>/dev/null \
+	| head -1)
+
+if [ -n "$CLIENT_FRAME" ]; then
+	if [ "$(echo "$CLIENT_FRAME" | jq -r 'has("protocol_extensions")')" = "true" ]; then
+		_pass "client_* payload carries protocol_extensions"
+		_assert_word "SSE payload" \
+			"$(echo "$CLIENT_FRAME" | jq -r '.protocol_extensions | type')" \
+			"$(echo "$CLIENT_FRAME" | jq -r '.protocol_extensions')"
+	else
+		_fail "SSE payload" \
+			"no protocol_extensions in client payload: ${CLIENT_FRAME:0:200}" \
+			"the REST row and the diff writer have drifted apart"
+	fi
+else
+	_skip "SSE payload shape (no client event within the listen window)"
+	_skip "SSE payload word (no client event within the listen window)"
+fi
+
+echo
+SKIP_NOTE=""
+[ "$SKIP_COUNT" -gt 0 ] && SKIP_NOTE=" ($SKIP_COUNT check(s) skipped)"
+if [ "$FAIL_COUNT" -eq 0 ]; then
+	echo "43-client-protocol-extensions: all $TEST_COUNT assertions passed$SKIP_NOTE"
+	exit 0
+fi
+echo "43-client-protocol-extensions: $FAIL_COUNT of $TEST_COUNT assertions FAILED"
+exit 1

--- a/unittests/curl-tests/amuleapi/43-client-protocol-extensions.sh
+++ b/unittests/curl-tests/amuleapi/43-client-protocol-extensions.sh
@@ -14,16 +14,19 @@
 #   * `protocol_extensions` is present on the /clients list row, on the
 #     /clients/{ecid} detail object, and in the client_* SSE payloads, so
 #     the three views of one peer do not disagree,
-#   * it is a number, not a token: the field is a bitfield and a peer claims
-#     any combination of the bits, so there is no single value to name,
-#   * only bits the daemon defines can appear. The daemon masks the word
-#     with MOD_MISCOPT_KNOWN_MASK (0x1F) before it reaches EC, so a value
-#     outside that mask means either the mask moved or something re-derived
-#     the word downstream — which is the failure this field is most likely
-#     to have, and the one nothing else would notice,
-#   * the key is always present, never omitted: 0 is a real answer here (the
-#     peer claimed nothing, which nearly every peer does) and a caller must
-#     not have to tell it from a missing key.
+#   * it is an array of tokens, not the bitfield the word arrives in: a
+#     caller must not have to carry its own copy of aMule's bit meanings,
+#     and a list rather than one token because a peer claims any
+#     combination of them,
+#   * every token is one the daemon defines. The daemon masks the word with
+#     MOD_MISCOPT_KNOWN_MASK (0x1F) before it reaches EC, so a token outside
+#     the known set means either the mask moved, the table in
+#     src/PeerCapabilities.h grew a row the serialiser does not know, or
+#     something re-derived the word downstream — which is the failure this
+#     field is most likely to have, and the one nothing else would notice,
+#   * the key is always present, never omitted: [] is a real answer here
+#     (the peer claimed nothing, which nearly every peer does) and a caller
+#     must not have to tell it from a missing key.
 #
 # Note on an empty peer list: a fresh regtest daemon may be connected to no
 # peers, so the per-row assertions skip themselves rather than fail. Run
@@ -40,10 +43,6 @@ set -o pipefail
 
 HOST=${HOST:-localhost:4713}
 ADMIN_PASS=${ADMIN_PASS:-adminpass}
-
-# Every bit the daemon defines: MOD_MISCOPT_KNOWN_MASK in
-# src/PeerCapabilities.h. Anything outside it must never reach the wire.
-KNOWN_MASK=31
 
 FAIL_COUNT=0
 TEST_COUNT=0
@@ -79,25 +78,40 @@ _assert_status() {
 
 _jq() { echo "$CURL_BODY" | jq -r "$1" 2>/dev/null; }
 
+# The tokens the table in src/PeerCapabilities.h defines, in bit order. A row
+# added there without a matching entry here fails the membership check below,
+# which is the point: the two must not drift.
+KNOWN_TOKENS="extended_source_exchange nat_traversal_utp ipv6 serving_buddy_pull nat_traversal_quic"
+
 # The two properties every appearance of the field has to hold, wherever it
-# came from: it is a number, and it carries no bit the daemon does not define.
+# came from: it is an array, and every token in it is one the daemon defines.
 _assert_word() {
 	local where=$1 type=$2 value=$3
 
-	if [ "$type" = "number" ]; then
-		_pass "$where: protocol_extensions is a number, not a token"
+	if [ "$type" = "array" ]; then
+		_pass "$where: protocol_extensions is an array of tokens"
 	else
-		_fail "$where" "expected a number, got type '$type'"
+		_fail "$where" "expected an array, got type '$type'"
 		return
 	fi
 
-	if [ "$((value & ~KNOWN_MASK))" -eq 0 ]; then
-		_pass "$where: only defined bits are set (word=$value, mask=$KNOWN_MASK)"
+	local unknown=""
+	local token
+	for token in $(echo "$value" | jq -r '.[]' 2>/dev/null); do
+		case " $KNOWN_TOKENS " in
+			*" $token "*) ;;
+			*) unknown="$unknown $token" ;;
+		esac
+	done
+
+	if [ -z "$unknown" ]; then
+		_pass "$where: only defined tokens appear (tokens=$value)"
 	else
 		_fail "$where" \
-			"word $value carries a bit outside MOD_MISCOPT_KNOWN_MASK ($KNOWN_MASK)" \
-			"the daemon masks in CPeerCapabilities::SetFromWire; a bit here means" \
-			"the mask moved or the word was re-derived downstream"
+			"unknown token(s):$unknown" \
+			"the daemon masks in CPeerCapabilities::SetFromWire and names bits in" \
+			"CPeerCapabilities::Table(); a token here means the mask moved, the" \
+			"table grew a row this test does not know, or the word was re-derived"
 	fi
 }
 

--- a/unittests/curl-tests/amuleapi/run-all.sh
+++ b/unittests/curl-tests/amuleapi/run-all.sh
@@ -265,6 +265,7 @@ PHASES=(
 	40-http-conformance.sh
 	41-shared-content.sh
 	42-path-and-body-contracts.sh
+	43-client-protocol-extensions.sh
 )
 
 # Override list from the command line if given.

--- a/unittests/tests/CMakeLists.txt
+++ b/unittests/tests/CMakeLists.txt
@@ -1169,6 +1169,29 @@ target_link_libraries (PeerCapabilitiesTest
 	muleunit
 )
 
+# CT_MOD_YOUR_IP corroboration: how many unrelated peers have to agree before
+# aMule believes a stranger's opinion of its own public address, and what
+# "unrelated" is keyed on. eMuleAI believes the first peer that answers; this
+# follows emule-qt and does not. Header-only for the same reason as
+# PeerCapabilities: CUpDownClient reaches theApp.
+add_executable (PublicIPv6CorroborationTest
+	PublicIPv6CorroborationTest.cpp
+)
+
+add_test (NAME PublicIPv6CorroborationTest
+	COMMAND PublicIPv6CorroborationTest
+)
+
+target_include_directories (PublicIPv6CorroborationTest
+	PRIVATE ${CMAKE_BINARY_DIR}
+	PRIVATE ${CMAKE_SOURCE_DIR}/src
+	PRIVATE ${CMAKE_SOURCE_DIR}/src/include
+)
+
+target_link_libraries (PublicIPv6CorroborationTest
+	muleunit
+)
+
 # OP_UDPRESERVEDPROT2 frame demultiplexing: the type byte, the payload window
 # handed to each handler, the unknown-type drop, and the log throttle that
 # keeps an unknown-frame flood from becoming a log flood. Same reason for the

--- a/unittests/tests/CMakeLists.txt
+++ b/unittests/tests/CMakeLists.txt
@@ -1169,11 +1169,13 @@ target_link_libraries (PeerCapabilitiesTest
 	muleunit
 )
 
-# CT_MOD_YOUR_IP corroboration: how many unrelated peers have to agree before
-# aMule believes a stranger's opinion of its own public address, and what
-# "unrelated" is keyed on. eMuleAI believes the first peer that answers; this
-# follows emule-qt and does not. Header-only for the same reason as
-# PeerCapabilities: CUpDownClient reaches theApp.
+# CT_MOD_YOUR_IP corroboration: that a claim for an address this machine does
+# not hold is never believed however many peers repeat it, and, among the
+# addresses it does hold, how many unrelated peers have to agree, what
+# "unrelated" is keyed on, and how long a voice keeps counting. eMuleAI
+# believes the first peer that answers; this follows emule-qt and does not.
+# Header-only for the same reason as PeerCapabilities: CUpDownClient reaches
+# theApp.
 add_executable (PublicIPv6CorroborationTest
 	PublicIPv6CorroborationTest.cpp
 )

--- a/unittests/tests/CMakeLists.txt
+++ b/unittests/tests/CMakeLists.txt
@@ -1137,6 +1137,61 @@ target_link_libraries (PartBarLegendTest
 	mulecommon
 )
 
+# eMuleAI vendor capability bits (CT_MOD_MISCOPTIONS) and the "ip6"/"bi6" hex
+# address encoding. Both are wire format shared with another implementation and
+# both fail silently when wrong -- a misplaced bit makes aMule advertise a
+# transport it does not have. CUpDownClient reaches theApp, so the model lives
+# in a header of its own and is tested there.
+add_executable (PeerCapabilitiesTest
+	PeerCapabilitiesTest.cpp
+	# The unknown-vendor-tag test reads a tag stream through the same classes
+	# the handshake does, because the property it pins -- an unknown tag
+	# consumes its own bytes -- is a wire property and not a client one. Same
+	# TU set as CTagTest.
+	${CMAKE_SOURCE_DIR}/src/SafeFile.cpp
+	${CMAKE_SOURCE_DIR}/src/MemFile.cpp
+	${CMAKE_SOURCE_DIR}/src/Tag.cpp
+	${CMAKE_SOURCE_DIR}/src/libs/common/Format.cpp
+	${CMAKE_SOURCE_DIR}/src/libs/common/strerror_r.c
+)
+
+add_test (NAME PeerCapabilitiesTest
+	COMMAND PeerCapabilitiesTest
+)
+
+target_include_directories (PeerCapabilitiesTest
+	PRIVATE ${CMAKE_BINARY_DIR}
+	PRIVATE ${CMAKE_SOURCE_DIR}/src
+	PRIVATE ${CMAKE_SOURCE_DIR}/src/include
+)
+
+target_link_libraries (PeerCapabilitiesTest
+	muleunit
+)
+
+# OP_UDPRESERVEDPROT2 frame demultiplexing: the type byte, the payload window
+# handed to each handler, the unknown-type drop, and the log throttle that
+# keeps an unknown-frame flood from becoming a log flood. Same reason for the
+# separate header: CClientUDPSocket needs theApp.
+add_executable (ReservedProtocolFramesTest
+	ReservedProtocolFramesTest.cpp
+)
+
+add_test (NAME ReservedProtocolFramesTest
+	COMMAND ReservedProtocolFramesTest
+)
+
+target_include_directories (ReservedProtocolFramesTest
+	PRIVATE ${CMAKE_BINARY_DIR}
+	PRIVATE ${CMAKE_SOURCE_DIR}/src
+	PRIVATE ${CMAKE_SOURCE_DIR}/src/include
+)
+
+target_link_libraries (ReservedProtocolFramesTest
+	muleunit
+	mulecommon
+)
+
 add_executable (PartIndexTest
 	PartIndexTest.cpp
 )
@@ -1153,5 +1208,35 @@ target_include_directories (PartIndexTest
 # GNU ld and mingw do not (see JsonDepthScanTest).
 target_link_libraries (PartIndexTest
 	muleunit
+	mulecommon
+)
+
+# EC_TAG_CLIENT_MOD_CAPABILITIES: the headless view of a peer's negotiated
+# vendor capabilities. The Client Details dialog that renders the same data
+# lives in amule/amulegui and needs an X server, so this tag is what makes that
+# display observable in CI -- and its encoding is pinned here rather than in a
+# GUI nobody can open. Same TU set and the same LoggerConsole.cpp reason as
+# ECIdDiffTest.
+add_executable (ECClientCapabilitiesTest
+	ECClientCapabilitiesTest.cpp
+	${CMAKE_SOURCE_DIR}/src/LoggerConsole.cpp
+)
+
+add_test (NAME ECClientCapabilitiesTest
+	COMMAND ECClientCapabilitiesTest
+)
+
+target_include_directories (ECClientCapabilitiesTest
+	PRIVATE ${CMAKE_BINARY_DIR}
+	PRIVATE ${CMAKE_SOURCE_DIR}/src
+	PRIVATE ${CMAKE_SOURCE_DIR}/src/include
+	PRIVATE ${CMAKE_SOURCE_DIR}/src/libs
+	PRIVATE ${CMAKE_BINARY_DIR}/src/libs
+	PRIVATE ${CMAKE_BINARY_DIR}/src/libs/ec/cpp
+)
+
+target_link_libraries (ECClientCapabilitiesTest
+	muleunit
+	ec
 	mulecommon
 )

--- a/unittests/tests/CMakeLists.txt
+++ b/unittests/tests/CMakeLists.txt
@@ -338,6 +338,12 @@ add_executable (NetworkFunctionsTest
 	NetworkFunctionsTest.cpp
 	${CMAKE_SOURCE_DIR}/src/NetworkFunctions.cpp
 	${CMAKE_SOURCE_DIR}/src/LibSocket.cpp
+	# LibSocket.cpp includes LibSocketAsio.cpp, which resolves a Windows
+	# adapter friendly name to an interface index through
+	# DetectNetworkInterfaces(). That definition lives in the mulesocket
+	# library this test does not link, so the translation unit has to be
+	# compiled in here or the Windows link fails on the undefined symbol.
+	${CMAKE_SOURCE_DIR}/src/NetworkInterfaces.cpp
 	${CMAKE_SOURCE_DIR}/src/libs/common/Format.cpp
 	${CMAKE_SOURCE_DIR}/src/libs/common/strerror_r.c
 )

--- a/unittests/tests/CMakeLists.txt
+++ b/unittests/tests/CMakeLists.txt
@@ -1190,6 +1190,7 @@ target_include_directories (PublicIPv6CorroborationTest
 
 target_link_libraries (PublicIPv6CorroborationTest
 	muleunit
+	mulecommon
 )
 
 # OP_UDPRESERVEDPROT2 frame demultiplexing: the type byte, the payload window

--- a/unittests/tests/ECClientCapabilitiesTest.cpp
+++ b/unittests/tests/ECClientCapabilitiesTest.cpp
@@ -53,7 +53,7 @@ TEST(ECClientCapabilities, TagCodeIsExact)
 	ASSERT_EQUALS(0x0632, (int)EC_TAG_CLIENT_MOD_CAPABILITIES);
 }
 
-// The core emits CPeerCapabilities::ToWire() and an EC client reads it back
+// The core emits CPeerCapabilities::KnownBits() and an EC client reads it back
 // with AssignIfExist. Nothing in between may alter the value.
 //
 // Deliberately no assertion on the tag's *type*: libec narrows an integer tag
@@ -68,7 +68,7 @@ TEST(ECClientCapabilities, WordSurvivesTheRoundTrip)
 		caps.SetFromWire(bits);
 
 		CECTag client(EC_TAG_CLIENT, (uint32_t)1);
-		client.AddTag(CECTag(EC_TAG_CLIENT_MOD_CAPABILITIES, caps.ToWire()));
+		client.AddTag(CECTag(EC_TAG_CLIENT_MOD_CAPABILITIES, caps.KnownBits()));
 
 		uint32_t received = 0xDEADBEEF;
 		ASSERT_TRUE(client.AssignIfExist(EC_TAG_CLIENT_MOD_CAPABILITIES, received));
@@ -77,7 +77,7 @@ TEST(ECClientCapabilities, WordSurvivesTheRoundTrip)
 		// And it decodes on the far side to the same capability set.
 		CPeerCapabilities mirrored;
 		mirrored.SetFromWire(received);
-		ASSERT_EQUALS(caps.ToWire(), mirrored.ToWire());
+		ASSERT_EQUALS(caps.KnownBits(), mirrored.KnownBits());
 	}
 }
 
@@ -91,7 +91,7 @@ TEST(ECClientCapabilities, ReservedBitsNeverCrossTheProtocol)
 	caps.SetFromWire(0xFFFFFFFFu);
 
 	CECTag client(EC_TAG_CLIENT, (uint32_t)1);
-	client.AddTag(CECTag(EC_TAG_CLIENT_MOD_CAPABILITIES, caps.ToWire()));
+	client.AddTag(CECTag(EC_TAG_CLIENT_MOD_CAPABILITIES, caps.KnownBits()));
 
 	uint32_t received = 0;
 	ASSERT_TRUE(client.AssignIfExist(EC_TAG_CLIENT_MOD_CAPABILITIES, received));
@@ -130,7 +130,7 @@ TEST(ECClientCapabilities, DisplayTextMatchesOnBothSidesOfTheProtocol)
 	core.SetFromWire(MOD_MISCOPT_IPV6 | MOD_MISCOPT_NAT_TRAVERSAL_QUIC);
 
 	CECTag client(EC_TAG_CLIENT, (uint32_t)1);
-	client.AddTag(CECTag(EC_TAG_CLIENT_MOD_CAPABILITIES, core.ToWire()));
+	client.AddTag(CECTag(EC_TAG_CLIENT_MOD_CAPABILITIES, core.KnownBits()));
 
 	uint32_t received = 0;
 	ASSERT_TRUE(client.AssignIfExist(EC_TAG_CLIENT_MOD_CAPABILITIES, received));

--- a/unittests/tests/ECClientCapabilitiesTest.cpp
+++ b/unittests/tests/ECClientCapabilitiesTest.cpp
@@ -50,7 +50,7 @@ DECLARE_SIMPLE(ECClientCapabilities)
 // header it checks.
 TEST(ECClientCapabilities, TagCodeIsExact)
 {
-	ASSERT_EQUALS(0x0632, (int)EC_TAG_CLIENT_MOD_CAPABILITIES);
+	ASSERT_EQUALS(0x0633, (int)EC_TAG_CLIENT_MOD_CAPABILITIES);
 }
 
 // The core emits CPeerCapabilities::KnownBits() and an EC client reads it back

--- a/unittests/tests/ECClientCapabilitiesTest.cpp
+++ b/unittests/tests/ECClientCapabilitiesTest.cpp
@@ -1,0 +1,143 @@
+//
+// This file is part of the aMule Project.
+//
+// Copyright (c) 2003-2026 aMule Team ( https://amule-org.github.io )
+//
+// Any parts of this program derived from the xMule, lMule or eMule project,
+// or contributed by third-party developers are copyrighted by their
+// respective authors.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301, USA
+//
+
+// EC_TAG_CLIENT_MOD_CAPABILITIES is the only way to observe a peer's
+// negotiated vendor capabilities without a display: the Client Details dialog
+// exists in `amule` and `amulegui`, and neither starts without an X server.
+// So this tag is what makes that display verifiable, and its encoding is
+// pinned here rather than left to a GUI nobody can open in CI.
+//
+// CEC_UpDownClient_Tag's only constructor takes a live CUpDownClient, which
+// reaches theApp and cannot be linked into a unit test. Its accessor is a
+// one-line call to CECTag::AssignIfExist, which is public, so the tag tree is
+// built directly here and read through exactly the call the accessor makes.
+// What that leaves untested is the one line of forwarding, not the encoding.
+
+#include <muleunit/test.h>
+
+#include <ec/cpp/ECTag.h>
+#include <ECCodes.h>
+#include <ECTagTypes.h>
+
+#include <PeerCapabilities.h>
+
+using namespace muleunit;
+
+DECLARE_SIMPLE(ECClientCapabilities)
+
+// The tag code is wire format. A literal, not a restatement of the generated
+// header it checks.
+TEST(ECClientCapabilities, TagCodeIsExact)
+{
+	ASSERT_EQUALS(0x0632, (int)EC_TAG_CLIENT_MOD_CAPABILITIES);
+}
+
+// The core emits CPeerCapabilities::ToWire() and an EC client reads it back
+// with AssignIfExist. Nothing in between may alter the value.
+//
+// Deliberately no assertion on the tag's *type*: libec narrows an integer tag
+// to the smallest width that holds it, so a word of 0x14 travels as a uint8
+// and GetInt() widens it back. Pinning the type here would pin that narrowing
+// rather than the protocol, and would break the first time a capability bit
+// above 8 is defined.
+TEST(ECClientCapabilities, WordSurvivesTheRoundTrip)
+{
+	for (uint32_t bits = 0; bits <= MOD_MISCOPT_KNOWN_MASK; ++bits) {
+		CPeerCapabilities caps;
+		caps.SetFromWire(bits);
+
+		CECTag client(EC_TAG_CLIENT, (uint32_t)1);
+		client.AddTag(CECTag(EC_TAG_CLIENT_MOD_CAPABILITIES, caps.ToWire()));
+
+		uint32_t received = 0xDEADBEEF;
+		ASSERT_TRUE(client.AssignIfExist(EC_TAG_CLIENT_MOD_CAPABILITIES, received));
+		ASSERT_EQUALS(bits, received);
+
+		// And it decodes on the far side to the same capability set.
+		CPeerCapabilities mirrored;
+		mirrored.SetFromWire(received);
+		ASSERT_EQUALS(caps.ToWire(), mirrored.ToWire());
+	}
+}
+
+// The spec delta requires reserved bits to be masked off and no capability
+// inferred from them. That masking happens in the core, before the tag is
+// built, so a reserved bit a peer set must not reach an EC client at all --
+// an EC client is then free to be ignorant of which bits are defined.
+TEST(ECClientCapabilities, ReservedBitsNeverCrossTheProtocol)
+{
+	CPeerCapabilities caps;
+	caps.SetFromWire(0xFFFFFFFFu);
+
+	CECTag client(EC_TAG_CLIENT, (uint32_t)1);
+	client.AddTag(CECTag(EC_TAG_CLIENT_MOD_CAPABILITIES, caps.ToWire()));
+
+	uint32_t received = 0;
+	ASSERT_TRUE(client.AssignIfExist(EC_TAG_CLIENT_MOD_CAPABILITIES, received));
+	ASSERT_EQUALS(MOD_MISCOPT_KNOWN_MASK, received);
+	ASSERT_EQUALS(0x00000000u, received & ~MOD_MISCOPT_KNOWN_MASK);
+}
+
+// Additive tag, so there are three states and not two: a peer that advertised
+// nothing (word 0, tag present) and a daemon too old to send the tag at all
+// must not read the same. The reference form of the accessor returns a bool
+// precisely so a client can tell them apart; a caller that used the
+// value-returning overload would collapse both to 0.
+TEST(ECClientCapabilities, AbsentTagIsDistinctFromAnEmptyWord)
+{
+	// Old daemon: no tag.
+	CECTag oldDaemon(EC_TAG_CLIENT, (uint32_t)1);
+	uint32_t target = 0xABCDEF01;
+	ASSERT_FALSE(oldDaemon.AssignIfExist(EC_TAG_CLIENT_MOD_CAPABILITIES, target));
+	// Untouched, so the caller's own default survives.
+	ASSERT_EQUALS(0xABCDEF01u, target);
+
+	// Current daemon, peer advertised nothing.
+	CECTag noCapabilities(EC_TAG_CLIENT, (uint32_t)1);
+	noCapabilities.AddTag(CECTag(EC_TAG_CLIENT_MOD_CAPABILITIES, (uint32_t)0));
+	target = 0xABCDEF01;
+	ASSERT_TRUE(noCapabilities.AssignIfExist(EC_TAG_CLIENT_MOD_CAPABILITIES, target));
+	ASSERT_EQUALS(0x00000000u, target);
+}
+
+// The dialog and the EC tag must not drift, so both read the same word through
+// the same class. This pins the pairing: the text an EC client would render
+// from the received word is the text the GUI renders from the live client.
+TEST(ECClientCapabilities, DisplayTextMatchesOnBothSidesOfTheProtocol)
+{
+	CPeerCapabilities core;
+	core.SetFromWire(MOD_MISCOPT_IPV6 | MOD_MISCOPT_NAT_TRAVERSAL_QUIC);
+
+	CECTag client(EC_TAG_CLIENT, (uint32_t)1);
+	client.AddTag(CECTag(EC_TAG_CLIENT_MOD_CAPABILITIES, core.ToWire()));
+
+	uint32_t received = 0;
+	ASSERT_TRUE(client.AssignIfExist(EC_TAG_CLIENT_MOD_CAPABILITIES, received));
+
+	CPeerCapabilities remote;
+	remote.SetFromWire(received);
+
+	ASSERT_EQUALS(core.GetDisplayText(), remote.GetDisplayText());
+	ASSERT_EQUALS(wxString("IPv6, QUIC NAT-T"), remote.GetDisplayText());
+}

--- a/unittests/tests/ECClientCapabilitiesTest.cpp
+++ b/unittests/tests/ECClientCapabilitiesTest.cpp
@@ -139,5 +139,7 @@ TEST(ECClientCapabilities, DisplayTextMatchesOnBothSidesOfTheProtocol)
 	remote.SetFromWire(received);
 
 	ASSERT_EQUALS(core.GetDisplayText(), remote.GetDisplayText());
-	ASSERT_EQUALS(wxString("IPv6, QUIC NAT-T"), remote.GetDisplayText());
+	// The names are translated, so this is the untranslated msgid -- which is
+	// what a test binary with no catalog loaded renders.
+	ASSERT_EQUALS(wxString("IPv6, NAT traversal (QUIC)"), remote.GetDisplayText());
 }

--- a/unittests/tests/PeerCapabilitiesTest.cpp
+++ b/unittests/tests/PeerCapabilitiesTest.cpp
@@ -127,7 +127,7 @@ TEST(PeerCapabilities, RoundTripsEveryKnownBit)
 	for (uint32_t bits = 0; bits <= MOD_MISCOPT_KNOWN_MASK; ++bits) {
 		CPeerCapabilities caps;
 		caps.SetFromWire(bits);
-		ASSERT_EQUALS(bits, caps.ToWire());
+		ASSERT_EQUALS(bits, caps.KnownBits());
 	}
 }
 
@@ -140,7 +140,7 @@ TEST(PeerCapabilities, ReservedBitsAreMaskedOff)
 	caps.SetFromWire(0x00000080u); // bit 7
 
 	ASSERT_TRUE(caps.IsEmpty());
-	ASSERT_EQUALS(0x00000000u, caps.ToWire());
+	ASSERT_EQUALS(0x00000000u, caps.KnownBits());
 	ASSERT_FALSE(caps.SupportsExtendedSourceExchange());
 	ASSERT_FALSE(caps.SupportsNatTraversal());
 	ASSERT_FALSE(caps.SupportsIPv6());
@@ -150,7 +150,7 @@ TEST(PeerCapabilities, ReservedBitsAreMaskedOff)
 	// All reserved bits at once, plus every known bit: only the known five
 	// come back out.
 	caps.SetFromWire(0xFFFFFFFFu);
-	ASSERT_EQUALS(MOD_MISCOPT_KNOWN_MASK, caps.ToWire());
+	ASSERT_EQUALS(MOD_MISCOPT_KNOWN_MASK, caps.KnownBits());
 }
 
 // The whole point of the change: aMule reads these capabilities but implements
@@ -170,10 +170,10 @@ TEST(PeerCapabilities, SetterAndDecoderAgree)
 
 	caps.Set(MOD_MISCOPT_IPV6, true);
 	caps.Set(MOD_MISCOPT_NAT_TRAVERSAL_QUIC, true);
-	ASSERT_EQUALS(0x00000014u, caps.ToWire());
+	ASSERT_EQUALS(0x00000014u, caps.KnownBits());
 
 	caps.Set(MOD_MISCOPT_IPV6, false);
-	ASSERT_EQUALS(0x00000010u, caps.ToWire());
+	ASSERT_EQUALS(0x00000010u, caps.KnownBits());
 
 	caps.Reset();
 	ASSERT_TRUE(caps.IsEmpty());

--- a/unittests/tests/PeerCapabilitiesTest.cpp
+++ b/unittests/tests/PeerCapabilitiesTest.cpp
@@ -1,0 +1,274 @@
+//
+// This file is part of the aMule Project.
+//
+// Copyright (c) 2003-2026 aMule Team ( https://amule-org.github.io )
+//
+// Any parts of this program derived from the xMule, lMule or eMule project,
+// or contributed by third-party developers are copyrighted by their
+// respective authors.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301, USA
+//
+
+// The CT_MOD_MISCOPTIONS bit positions are wire format shared with eMuleAI,
+// and getting one of them wrong has no runtime signal: aMule would claim a
+// transport it does not implement, the peer would open a handshake, and the
+// handshake would simply never complete. So the positions are pinned here as
+// literal words rather than restated from the enum -- a test that reads the
+// same enum it is checking cannot catch a renumbering.
+//
+// The reference is eMuleAI's UModMiscOptions union, srchybrid/Opcodes.h:710.
+//
+// CUpDownClient reaches theApp and cannot be linked into a unit test, which is
+// why the capability model lives in a header of its own.
+
+#include <muleunit/test.h>
+
+#include <PeerCapabilities.h>
+
+// The unknown-tag-tolerance test below reads a tag stream through exactly the
+// classes CUpDownClient::ProcessHelloTypePacket() uses. CUpDownClient itself
+// cannot be linked here, but the property that matters is a wire property, not
+// a client one: an unknown tag must consume its own bytes.
+#include <tags/ClientTags.h>
+#include "MemFile.h"
+#include "Tag.h"
+
+#include <cstring>
+
+using namespace muleunit;
+
+DECLARE_SIMPLE(PeerCapabilities)
+
+// Each bit, alone, at the position eMuleAI puts it. Literal words on purpose.
+TEST(PeerCapabilities, BitPositionsAreExact)
+{
+	ASSERT_EQUALS(0x00000001u, (uint32_t)MOD_MISCOPT_EXTENDED_XS);
+	ASSERT_EQUALS(0x00000002u, (uint32_t)MOD_MISCOPT_NAT_TRAVERSAL);
+	ASSERT_EQUALS(0x00000004u, (uint32_t)MOD_MISCOPT_IPV6);
+	ASSERT_EQUALS(0x00000008u, (uint32_t)MOD_MISCOPT_SERVING_BUDDY_PULL);
+	ASSERT_EQUALS(0x00000010u, (uint32_t)MOD_MISCOPT_NAT_TRAVERSAL_QUIC);
+	ASSERT_EQUALS(0x0000001Fu, MOD_MISCOPT_KNOWN_MASK);
+}
+
+// One decoded flag per bit, so a rotation of the enum shows up as a wrong
+// accessor rather than as a still-passing mask test.
+TEST(PeerCapabilities, EachBitDecodesToItsOwnAccessor)
+{
+	CPeerCapabilities caps;
+
+	caps.SetFromWire(0x00000001u);
+	ASSERT_TRUE(caps.SupportsExtendedSourceExchange());
+	ASSERT_FALSE(caps.SupportsNatTraversal());
+	ASSERT_FALSE(caps.SupportsIPv6());
+	ASSERT_FALSE(caps.SupportsServingBuddyPull());
+	ASSERT_FALSE(caps.SupportsNatTraversalQuic());
+
+	caps.SetFromWire(0x00000002u);
+	ASSERT_FALSE(caps.SupportsExtendedSourceExchange());
+	ASSERT_TRUE(caps.SupportsNatTraversal());
+	ASSERT_FALSE(caps.SupportsIPv6());
+	ASSERT_FALSE(caps.SupportsServingBuddyPull());
+	ASSERT_FALSE(caps.SupportsNatTraversalQuic());
+
+	caps.SetFromWire(0x00000004u);
+	ASSERT_FALSE(caps.SupportsExtendedSourceExchange());
+	ASSERT_FALSE(caps.SupportsNatTraversal());
+	ASSERT_TRUE(caps.SupportsIPv6());
+	ASSERT_FALSE(caps.SupportsServingBuddyPull());
+	ASSERT_FALSE(caps.SupportsNatTraversalQuic());
+
+	caps.SetFromWire(0x00000008u);
+	ASSERT_FALSE(caps.SupportsExtendedSourceExchange());
+	ASSERT_FALSE(caps.SupportsNatTraversal());
+	ASSERT_FALSE(caps.SupportsIPv6());
+	ASSERT_TRUE(caps.SupportsServingBuddyPull());
+	ASSERT_FALSE(caps.SupportsNatTraversalQuic());
+
+	caps.SetFromWire(0x00000010u);
+	ASSERT_FALSE(caps.SupportsExtendedSourceExchange());
+	ASSERT_FALSE(caps.SupportsNatTraversal());
+	ASSERT_FALSE(caps.SupportsIPv6());
+	ASSERT_FALSE(caps.SupportsServingBuddyPull());
+	ASSERT_TRUE(caps.SupportsNatTraversalQuic());
+}
+
+// The scenario from the spec delta: a peer that advertises IPv6 and QUIC NAT-T
+// and nothing else. 0x14 == bit 2 | bit 4.
+TEST(PeerCapabilities, PeerAdvertisingIPv6AndQuic)
+{
+	CPeerCapabilities caps;
+	caps.SetFromWire(0x00000014u);
+
+	ASSERT_TRUE(caps.SupportsIPv6());
+	ASSERT_TRUE(caps.SupportsNatTraversalQuic());
+	ASSERT_FALSE(caps.SupportsExtendedSourceExchange());
+	ASSERT_FALSE(caps.SupportsNatTraversal());
+	ASSERT_FALSE(caps.SupportsServingBuddyPull());
+}
+
+// Round-trip: the fixture encoding all five documented bits survives
+// decode -> encode unchanged.
+TEST(PeerCapabilities, RoundTripsEveryKnownBit)
+{
+	for (uint32_t bits = 0; bits <= MOD_MISCOPT_KNOWN_MASK; ++bits) {
+		CPeerCapabilities caps;
+		caps.SetFromWire(bits);
+		ASSERT_EQUALS(bits, caps.ToWire());
+	}
+}
+
+// Reserved bits 5..31 carry no meaning yet. A peer setting bit 7 must not
+// produce a capability, and must not survive a re-encode either -- otherwise
+// aMule would relay a claim it cannot interpret.
+TEST(PeerCapabilities, ReservedBitsAreMaskedOff)
+{
+	CPeerCapabilities caps;
+	caps.SetFromWire(0x00000080u); // bit 7
+
+	ASSERT_TRUE(caps.IsEmpty());
+	ASSERT_EQUALS(0x00000000u, caps.ToWire());
+	ASSERT_FALSE(caps.SupportsExtendedSourceExchange());
+	ASSERT_FALSE(caps.SupportsNatTraversal());
+	ASSERT_FALSE(caps.SupportsIPv6());
+	ASSERT_FALSE(caps.SupportsServingBuddyPull());
+	ASSERT_FALSE(caps.SupportsNatTraversalQuic());
+
+	// All reserved bits at once, plus every known bit: only the known five
+	// come back out.
+	caps.SetFromWire(0xFFFFFFFFu);
+	ASSERT_EQUALS(MOD_MISCOPT_KNOWN_MASK, caps.ToWire());
+}
+
+// The whole point of the change: aMule reads these capabilities but implements
+// none of them, so it must advertise none of them. This assertion is expected
+// to change exactly once per shipped feature -- and a change to it that is not
+// accompanied by a shipped transport is the bug the spec warns about.
+TEST(PeerCapabilities, AdvertisesNoUnimplementedCapability)
+{
+	ASSERT_EQUALS(0x00000000u, LocalAdvertisedModMiscOptions());
+}
+
+// Setters exist for the advertise side; they must land on the same bits the
+// decoder reads, or the two halves drift.
+TEST(PeerCapabilities, SetterAndDecoderAgree)
+{
+	CPeerCapabilities caps;
+
+	caps.Set(MOD_MISCOPT_IPV6, true);
+	caps.Set(MOD_MISCOPT_NAT_TRAVERSAL_QUIC, true);
+	ASSERT_EQUALS(0x00000014u, caps.ToWire());
+
+	caps.Set(MOD_MISCOPT_IPV6, false);
+	ASSERT_EQUALS(0x00000010u, caps.ToWire());
+
+	caps.Reset();
+	ASSERT_TRUE(caps.IsEmpty());
+}
+
+// The "ip6" / "bi6" Kad tags carry a 128-bit address as 32 hex characters,
+// big-endian -- eMuleAI writes them with CUInt128::ToHexString() and reads
+// them back with strmd4(). Anything that is not exactly 32 hex characters is
+// a malformed tag, not a shorter address.
+TEST(PeerCapabilities, DecodesIPv6HexTag)
+{
+	uint8_t out[16];
+
+	const char *loopback = "00000000000000000000000000000001";
+	ASSERT_TRUE(DecodeIPv6HexTag(loopback, 32, out));
+	for (int i = 0; i < 15; ++i) {
+		ASSERT_EQUALS(0, (int)out[i]);
+	}
+	ASSERT_EQUALS(1, (int)out[15]);
+
+	// 2001:db8::dead:beef -- mixed case accepted, byte order big-endian.
+	const char *documented = "20010DB80000000000000000DeAdBeeF";
+	ASSERT_TRUE(DecodeIPv6HexTag(documented, 32, out));
+	ASSERT_EQUALS(0x20, (int)out[0]);
+	ASSERT_EQUALS(0x01, (int)out[1]);
+	ASSERT_EQUALS(0x0D, (int)out[2]);
+	ASSERT_EQUALS(0xB8, (int)out[3]);
+	ASSERT_EQUALS(0xDE, (int)out[12]);
+	ASSERT_EQUALS(0xAD, (int)out[13]);
+	ASSERT_EQUALS(0xBE, (int)out[14]);
+	ASSERT_EQUALS(0xEF, (int)out[15]);
+}
+
+TEST(PeerCapabilities, RejectsMalformedIPv6HexTag)
+{
+	uint8_t out[16];
+
+	ASSERT_FALSE(DecodeIPv6HexTag("", 0, out));
+	ASSERT_FALSE(DecodeIPv6HexTag("0001", 4, out));                               // too short
+	ASSERT_FALSE(DecodeIPv6HexTag("000000000000000000000000000000012", 33, out)); // too long
+	ASSERT_FALSE(DecodeIPv6HexTag("0000000000000000000000000000000g", 32, out));  // not hex
+	ASSERT_FALSE(DecodeIPv6HexTag(NULL, 32, out));
+
+	// A space anywhere in the run is a malformed tag, not a shorter address.
+	char spaced[33];
+	memset(spaced, '0', 32);
+	spaced[32] = '\0';
+	spaced[17] = ' ';
+	ASSERT_FALSE(DecodeIPv6HexTag(spaced, 32, out));
+}
+
+// Spec delta, "Unknown vendor tag": a tag the client does not recognise must be
+// ignored and the handshake must continue as if it were absent.
+//
+// The failure this guards against is not the ignoring -- the switch in
+// ProcessHelloTypePacket() has no default branch and has always fallen through
+// for unknown ids. It is desynchronisation: the tag loop reads a fixed count of
+// tags, so an unknown tag whose bytes are not fully consumed shifts every later
+// tag by that much, and the hello then decodes as garbage with nothing logged.
+// So what is pinned here is that a stream of known-unknown-known survives with
+// the third tag's value intact.
+TEST(PeerCapabilities, UnknownVendorTagDoesNotDesynchroniseTheStream)
+{
+	CMemFile stream;
+
+	CTagVarInt written(CT_MOD_MISCOPTIONS, 0x00000014u, 32);
+	written.WriteTagToFile(&stream);
+
+	// 0xAB is inside the vendor range and defined by nothing aMule knows.
+	CTagString unknown(static_cast<uint8_t>(0xAB), "some future value");
+	unknown.WriteTagToFile(&stream);
+
+	CTagVarInt trailing(CT_EMULE_VERSION, 0x0A010203u, 32);
+	trailing.WriteTagToFile(&stream);
+
+	stream.Seek(0, wxFromStart);
+
+	const CTag first(stream, true);
+	ASSERT_EQUALS((int)CT_MOD_MISCOPTIONS, (int)first.GetNameID());
+	CPeerCapabilities caps;
+	caps.SetFromWire((uint32_t)first.GetInt());
+	ASSERT_TRUE(caps.SupportsIPv6());
+	ASSERT_TRUE(caps.SupportsNatTraversalQuic());
+
+	// Read and discard, exactly as the handshake does for an id it has no
+	// case for.
+	const CTag ignored(stream, true);
+	ASSERT_EQUALS(0xAB, (int)ignored.GetNameID());
+
+	// The tag after the unknown one is still where it should be. This is the
+	// assertion that fails if an unknown tag under-consumes.
+	const CTag third(stream, true);
+	ASSERT_EQUALS((int)CT_EMULE_VERSION, (int)third.GetNameID());
+	ASSERT_EQUALS(0x0A010203u, (uint32_t)third.GetInt());
+
+	// And the stream is fully consumed: no trailing bytes, so nothing
+	// over-consumed either.
+	ASSERT_EQUALS(stream.GetLength(), stream.GetPosition());
+}

--- a/unittests/tests/PeerCapabilitiesTest.cpp
+++ b/unittests/tests/PeerCapabilitiesTest.cpp
@@ -336,6 +336,7 @@ TEST(PeerCapabilities, VendorTagIdsAndKadTagNamesAreExact)
 {
 	ASSERT_EQUALS(0xA0, (int)CT_EMULE_SERVINGBUDDYIPV6);
 	ASSERT_EQUALS(0xAA, (int)CT_MOD_MISCOPTIONS);
+	ASSERT_EQUALS(0xAD, (int)CT_MOD_YOUR_IP);
 	ASSERT_EQUALS(0xAE, (int)CT_MOD_IP_V6);
 
 	ASSERT_EQUALS(wxString(wxT("ip6")), wxString(TAG_IPV6));

--- a/unittests/tests/PeerCapabilitiesTest.cpp
+++ b/unittests/tests/PeerCapabilitiesTest.cpp
@@ -179,6 +179,56 @@ TEST(PeerCapabilities, SetterAndDecoderAgree)
 	ASSERT_TRUE(caps.IsEmpty());
 }
 
+// A peer that claims nothing produces an empty string, not a word. That is
+// the contract the client details dialog hides its row on, so it is pinned
+// here rather than left to the dialog: a version of this that returned
+// "None" would put a permanent, meaningless row in front of nearly every
+// user, and the dialog could not tell that apart from a real claim.
+//
+// Reserved bits go the same way: they are masked off, so a peer setting only
+// bit 7 claims nothing and reads as nothing.
+TEST(PeerCapabilities, ClaimingNothingDisplaysAsEmpty)
+{
+	CPeerCapabilities caps;
+	ASSERT_TRUE(caps.GetDisplayText().IsEmpty());
+
+	caps.SetFromWire(0x00000000u);
+	ASSERT_TRUE(caps.GetDisplayText().IsEmpty());
+
+	caps.SetFromWire(0x00000080u); // reserved bit 7 only
+	ASSERT_TRUE(caps.GetDisplayText().IsEmpty());
+}
+
+// Each bit's name, one bit at a time, so the display table is pinned to the
+// positions rather than to the order it happens to be written in. The names
+// are marked for translation, so these are the msgids -- a test binary loads
+// no catalog, and it is the pairing that matters here, not the wording.
+TEST(PeerCapabilities, EachBitDisplaysItsOwnName)
+{
+	CPeerCapabilities caps;
+
+	caps.SetFromWire(MOD_MISCOPT_EXTENDED_XS);
+	ASSERT_EQUALS(wxString("Extended source exchange"), caps.GetDisplayText());
+
+	caps.SetFromWire(MOD_MISCOPT_NAT_TRAVERSAL);
+	ASSERT_EQUALS(wxString("NAT traversal (uTP)"), caps.GetDisplayText());
+
+	caps.SetFromWire(MOD_MISCOPT_IPV6);
+	ASSERT_EQUALS(wxString("IPv6"), caps.GetDisplayText());
+
+	caps.SetFromWire(MOD_MISCOPT_SERVING_BUDDY_PULL);
+	ASSERT_EQUALS(wxString("Buddy info pull"), caps.GetDisplayText());
+
+	caps.SetFromWire(MOD_MISCOPT_NAT_TRAVERSAL_QUIC);
+	ASSERT_EQUALS(wxString("NAT traversal (QUIC)"), caps.GetDisplayText());
+
+	// All five at once: comma-separated, in table order, no trailing comma.
+	caps.SetFromWire(MOD_MISCOPT_KNOWN_MASK);
+	ASSERT_EQUALS(wxString("Extended source exchange, NAT traversal (uTP), IPv6, "
+			       "Buddy info pull, NAT traversal (QUIC)"),
+		caps.GetDisplayText());
+}
+
 // The "ip6" / "bi6" Kad tags carry a 128-bit address as 32 hex characters,
 // big-endian -- eMuleAI writes them with CUInt128::ToHexString() and reads
 // them back with strmd4(). Anything that is not exactly 32 hex characters is

--- a/unittests/tests/PeerCapabilitiesTest.cpp
+++ b/unittests/tests/PeerCapabilitiesTest.cpp
@@ -334,9 +334,9 @@ TEST(PeerCapabilities, UnknownVendorTagDoesNotDesynchroniseTheStream)
 // The reference is eMuleAI's srchybrid/Opcodes.h and its Kad tag names.
 TEST(PeerCapabilities, VendorTagIdsAndKadTagNamesAreExact)
 {
+	ASSERT_EQUALS(0xA0, (int)CT_EMULE_SERVINGBUDDYIPV6);
 	ASSERT_EQUALS(0xAA, (int)CT_MOD_MISCOPTIONS);
 	ASSERT_EQUALS(0xAE, (int)CT_MOD_IP_V6);
-	ASSERT_EQUALS(0xAF, (int)CT_MOD_SVR_IP_V6);
 
 	ASSERT_EQUALS(wxString(wxT("ip6")), wxString(TAG_IPV6));
 	ASSERT_EQUALS(wxString(wxT("bi6")), wxString(TAG_SERVINGBUDDYIPV6));

--- a/unittests/tests/PeerCapabilitiesTest.cpp
+++ b/unittests/tests/PeerCapabilitiesTest.cpp
@@ -43,6 +43,7 @@
 // cannot be linked here, but the property that matters is a wire property, not
 // a client one: an unknown tag must consume its own bytes.
 #include <tags/ClientTags.h>
+#include <tags/FileTags.h>
 #include "MemFile.h"
 #include "Tag.h"
 
@@ -271,4 +272,22 @@ TEST(PeerCapabilities, UnknownVendorTagDoesNotDesynchroniseTheStream)
 	// And the stream is fully consumed: no trailing bytes, so nothing
 	// over-consumed either.
 	ASSERT_EQUALS(stream.GetLength(), stream.GetPosition());
+}
+
+// The vendor tag ids and the Kad tag names are wire format shared with eMuleAI,
+// and nothing at runtime notices a wrong one: aMule would write its IPv6
+// address under an id the peer decodes as something else, or under a name the
+// peer never looks up, and the handshake would carry on regardless. So the
+// values are pinned here as literals -- an assertion that reads the same
+// symbol it is checking cannot catch a renumbering or a renamed tag.
+//
+// The reference is eMuleAI's srchybrid/Opcodes.h and its Kad tag names.
+TEST(PeerCapabilities, VendorTagIdsAndKadTagNamesAreExact)
+{
+	ASSERT_EQUALS(0xAA, (int)CT_MOD_MISCOPTIONS);
+	ASSERT_EQUALS(0xAE, (int)CT_MOD_IP_V6);
+	ASSERT_EQUALS(0xAF, (int)CT_MOD_SVR_IP_V6);
+
+	ASSERT_EQUALS(wxString(wxT("ip6")), wxString(TAG_IPV6));
+	ASSERT_EQUALS(wxString(wxT("bi6")), wxString(TAG_SERVINGBUDDYIPV6));
 }

--- a/unittests/tests/PublicIPv6CorroborationTest.cpp
+++ b/unittests/tests/PublicIPv6CorroborationTest.cpp
@@ -1,0 +1,248 @@
+//
+// This file is part of the aMule Project.
+//
+// Copyright (c) 2003-2026 aMule Team ( https://amule-org.github.io )
+//
+// Any parts of this program derived from the xMule, lMule or eMule project,
+// or contributed by third-party developers are copyrighted by their
+// respective authors.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301, USA
+//
+
+// CT_MOD_YOUR_IP (0xAD) carries a peer's opinion of our own public address.
+// eMuleAI believes the first peer that offers one; emule-qt does not, and
+// neither does this. What is tested here is the "does not": that one voice is
+// never enough, that one host cannot be several voices by repeating itself,
+// and that the quorum is keyed on where a packet was seen coming from rather
+// than on anything the sender chose for itself.
+//
+// The rule has no runtime signal if it is wrong. A client that accepts a bad
+// address for itself does not fail -- it goes on working, publishing an
+// address nobody can reach, so the tests have to state the rule rather than
+// wait for a symptom.
+//
+// CUpDownClient reaches theApp and cannot be linked into a unit test, so the
+// tracker lives in a header of its own, like CPeerCapabilities.
+
+#include <muleunit/test.h>
+
+#include <PublicIPv6Corroboration.h>
+
+#include <cstring>
+
+using namespace muleunit;
+
+DECLARE_SIMPLE(PublicIPv6Corroboration)
+
+namespace
+{
+
+// 2001:db8::<last>, the documentation prefix. The last byte is the only thing
+// that varies, so two addresses differ in a single byte -- the case a
+// byte-wise comparison is most likely to get wrong.
+CPublicIPv6Corroboration::Address MakeAddress(uint8_t last)
+{
+	CPublicIPv6Corroboration::Address address = {};
+	address[0] = 0x20;
+	address[1] = 0x01;
+	address[2] = 0x0d;
+	address[3] = 0xb8;
+	address[15] = last;
+	return address;
+}
+
+// 203.0.113.<host>, host order, as GetConnectIP() would report it.
+uint32_t MakeObserver(uint8_t host)
+{
+	return 0xCB007100u | host;
+}
+
+} // namespace
+
+// The threshold is a policy decision, not an implementation detail: raising or
+// lowering it changes how much a stranger's word is worth. Pinned as a literal
+// so the change has to be deliberate.
+TEST(PublicIPv6Corroboration, ThresholdIsThreeDistinctObservers)
+{
+	ASSERT_EQUALS(3u, (unsigned)PUBLIC_IPV6_CORROBORATION_THRESHOLD);
+}
+
+// The whole point. eMuleAI would have believed this one.
+TEST(PublicIPv6Corroboration, OnePeerIsNotBelieved)
+{
+	CPublicIPv6Corroboration tracker;
+	const CPublicIPv6Corroboration::Address claimed = MakeAddress(0x01);
+
+	ASSERT_FALSE(tracker.AddClaim(MakeObserver(1), claimed.data()));
+	ASSERT_FALSE(tracker.IsCorroborated());
+	ASSERT_TRUE(tracker.CorroboratedAddress() == nullptr);
+	ASSERT_EQUALS(1u, (unsigned)tracker.DistinctObserversFor(claimed.data()));
+}
+
+// Two is still one short, and it is the interesting near-miss: two source
+// addresses is one dual-homed host as easily as it is two opinions.
+TEST(PublicIPv6Corroboration, TwoPeersAreStillNotEnough)
+{
+	CPublicIPv6Corroboration tracker;
+	const CPublicIPv6Corroboration::Address claimed = MakeAddress(0x01);
+
+	tracker.AddClaim(MakeObserver(1), claimed.data());
+	ASSERT_FALSE(tracker.AddClaim(MakeObserver(2), claimed.data()));
+	ASSERT_FALSE(tracker.IsCorroborated());
+}
+
+// N distinct observed addresses saying the same thing, and the value is
+// believed -- and it is the claimed value that comes back out, byte for byte.
+TEST(PublicIPv6Corroboration, DistinctObserversReachingTheThresholdCorroborate)
+{
+	CPublicIPv6Corroboration tracker;
+	const CPublicIPv6Corroboration::Address claimed = MakeAddress(0x01);
+
+	for (unsigned i = 0; i < PUBLIC_IPV6_CORROBORATION_THRESHOLD - 1; ++i) {
+		ASSERT_FALSE(tracker.AddClaim(MakeObserver((uint8_t)(i + 1)), claimed.data()));
+	}
+	ASSERT_TRUE(
+		tracker.AddClaim(MakeObserver((uint8_t)PUBLIC_IPV6_CORROBORATION_THRESHOLD), claimed.data()));
+
+	ASSERT_TRUE(tracker.IsCorroborated());
+	const uint8_t *corroborated = tracker.CorroboratedAddress();
+	ASSERT_TRUE(corroborated != nullptr);
+	ASSERT_EQUALS(0, memcmp(corroborated, claimed.data(), claimed.size()));
+}
+
+// One host repeating itself is one host. If the count were of claims rather
+// than of distinct sources, a single peer could reach any threshold alone,
+// which is exactly the property that makes the threshold meaningless.
+TEST(PublicIPv6Corroboration, OneObserverRepeatingItselfNeverCorroborates)
+{
+	CPublicIPv6Corroboration tracker;
+	const CPublicIPv6Corroboration::Address claimed = MakeAddress(0x01);
+
+	for (unsigned i = 0; i < PUBLIC_IPV6_CORROBORATION_THRESHOLD + 5; ++i) {
+		ASSERT_FALSE(tracker.AddClaim(MakeObserver(7), claimed.data()));
+	}
+	ASSERT_EQUALS(1u, (unsigned)tracker.DistinctObserversFor(claimed.data()));
+}
+
+// Agreement is per value. Peers that disagree corroborate nothing, however
+// many of them there are -- and the addresses here differ in one byte only.
+TEST(PublicIPv6Corroboration, DisagreeingPeersDoNotPoolIntoAQuorum)
+{
+	CPublicIPv6Corroboration tracker;
+
+	for (unsigned i = 0; i < PUBLIC_IPV6_CORROBORATION_THRESHOLD + 2; ++i) {
+		const CPublicIPv6Corroboration::Address claimed = MakeAddress((uint8_t)(i + 1));
+		tracker.AddClaim(MakeObserver((uint8_t)(i + 1)), claimed.data());
+	}
+
+	ASSERT_FALSE(tracker.IsCorroborated());
+}
+
+// A quorum for one value is not disturbed by a louder minority for another.
+TEST(PublicIPv6Corroboration, AMinorityClaimDoesNotUnseatAQuorum)
+{
+	CPublicIPv6Corroboration tracker;
+	const CPublicIPv6Corroboration::Address agreed = MakeAddress(0x01);
+	const CPublicIPv6Corroboration::Address other = MakeAddress(0x02);
+
+	for (unsigned i = 0; i < PUBLIC_IPV6_CORROBORATION_THRESHOLD; ++i) {
+		tracker.AddClaim(MakeObserver((uint8_t)(i + 1)), agreed.data());
+	}
+	tracker.AddClaim(MakeObserver(100), other.data());
+	tracker.AddClaim(MakeObserver(101), other.data());
+
+	ASSERT_TRUE(tracker.IsCorroborated());
+	ASSERT_EQUALS(0, memcmp(tracker.CorroboratedAddress(), agreed.data(), agreed.size()));
+}
+
+// With no observed source address there is nothing to key on, and an unkeyed
+// claim would let one caller supply the whole quorum by itself. Ignored, not
+// counted under a zero key.
+TEST(PublicIPv6Corroboration, ClaimsWithNoObservedAddressAreIgnored)
+{
+	CPublicIPv6Corroboration tracker;
+	const CPublicIPv6Corroboration::Address claimed = MakeAddress(0x01);
+
+	for (unsigned i = 0; i < PUBLIC_IPV6_CORROBORATION_THRESHOLD + 3; ++i) {
+		ASSERT_FALSE(tracker.AddClaim(0, claimed.data()));
+	}
+	ASSERT_EQUALS(0u, (unsigned)tracker.CandidateCount());
+}
+
+// A NULL payload is a tag that failed to decode, not a claim.
+TEST(PublicIPv6Corroboration, NullClaimsAreIgnored)
+{
+	CPublicIPv6Corroboration tracker;
+
+	ASSERT_FALSE(tracker.AddClaim(MakeObserver(1), nullptr));
+	ASSERT_EQUALS(0u, (unsigned)tracker.CandidateCount());
+	ASSERT_EQUALS(0u, (unsigned)tracker.DistinctObserversFor(nullptr));
+}
+
+// The set of tracked values is attacker-chosen, so it is bounded. Past the
+// bound new values are dropped rather than evicting one that may be honest.
+TEST(PublicIPv6Corroboration, CandidateTrackingIsBounded)
+{
+	CPublicIPv6Corroboration tracker;
+
+	for (unsigned i = 0; i < PUBLIC_IPV6_CORROBORATION_MAX_CANDIDATES + 20; ++i) {
+		const CPublicIPv6Corroboration::Address claimed = MakeAddress((uint8_t)(i + 1));
+		tracker.AddClaim(MakeObserver((uint8_t)(i + 1)), claimed.data());
+	}
+
+	ASSERT_EQUALS((unsigned)PUBLIC_IPV6_CORROBORATION_MAX_CANDIDATES, (unsigned)tracker.CandidateCount());
+	ASSERT_FALSE(tracker.IsCorroborated());
+}
+
+// A full bucket does not stop an existing candidate from gaining observers:
+// the honest value is usually the first one seen, and it has to be able to
+// reach the threshold while noise fills the rest of the table.
+TEST(PublicIPv6Corroboration, AnExistingCandidateStillGrowsWhileTheTableIsFull)
+{
+	CPublicIPv6Corroboration tracker;
+	const CPublicIPv6Corroboration::Address agreed = MakeAddress(0xFF);
+
+	tracker.AddClaim(MakeObserver(1), agreed.data());
+	for (unsigned i = 0; i < PUBLIC_IPV6_CORROBORATION_MAX_CANDIDATES + 20; ++i) {
+		const CPublicIPv6Corroboration::Address noise = MakeAddress((uint8_t)(i + 1));
+		tracker.AddClaim(MakeObserver((uint8_t)(i + 50)), noise.data());
+	}
+
+	for (unsigned i = 1; i < PUBLIC_IPV6_CORROBORATION_THRESHOLD; ++i) {
+		tracker.AddClaim(MakeObserver((uint8_t)(i + 1)), agreed.data());
+	}
+
+	ASSERT_TRUE(tracker.IsCorroborated());
+	ASSERT_EQUALS(0, memcmp(tracker.CorroboratedAddress(), agreed.data(), agreed.size()));
+}
+
+// Reset drops the quorum, so a tracker cannot carry a stale belief across
+// whatever lifetime a caller gives it.
+TEST(PublicIPv6Corroboration, ResetForgetsEverything)
+{
+	CPublicIPv6Corroboration tracker;
+	const CPublicIPv6Corroboration::Address claimed = MakeAddress(0x01);
+
+	for (unsigned i = 0; i < PUBLIC_IPV6_CORROBORATION_THRESHOLD; ++i) {
+		tracker.AddClaim(MakeObserver((uint8_t)(i + 1)), claimed.data());
+	}
+	ASSERT_TRUE(tracker.IsCorroborated());
+
+	tracker.Reset();
+	ASSERT_FALSE(tracker.IsCorroborated());
+	ASSERT_EQUALS(0u, (unsigned)tracker.CandidateCount());
+	ASSERT_EQUALS(0u, (unsigned)tracker.DistinctObserversFor(claimed.data()));
+}

--- a/unittests/tests/PublicIPv6CorroborationTest.cpp
+++ b/unittests/tests/PublicIPv6CorroborationTest.cpp
@@ -24,13 +24,19 @@
 
 // CT_MOD_YOUR_IP (0xAD) carries a peer's opinion of our own public address.
 // eMuleAI believes the first peer that offers one; emule-qt does not, and
-// neither does this. What is tested here is the "does not": that one voice is
-// never enough, that one host cannot be several voices by repeating itself,
-// and that the quorum is keyed on where a packet was seen coming from rather
-// than on anything the sender chose for itself.
+// neither does this.
 //
-// The rule has no runtime signal if it is wrong. A client that accepts a bad
-// address for itself does not fail -- it goes on working, publishing an
+// Two separate rules are under test, and they carry different weight:
+//
+//  - Peers are unauthenticated, so a claim for an address this machine does
+//    not hold must never be believed no matter how many peers repeat it. That
+//    is the security control, and it is what bounds the damage to "picks the
+//    wrong one of our own addresses".
+//  - Among addresses we do hold, one voice is never enough, one host cannot be
+//    several voices by repeating itself, and a voice goes quiet after a while.
+//
+// The rules have no runtime signal if they are wrong. A client that accepts a
+// bad address for itself does not fail -- it goes on working, publishing an
 // address nobody can reach, so the tests have to state the rule rather than
 // wait for a symptom.
 //
@@ -42,6 +48,7 @@
 #include <PublicIPv6Corroboration.h>
 
 #include <cstring>
+#include <vector>
 
 using namespace muleunit;
 
@@ -50,12 +57,15 @@ DECLARE_SIMPLE(PublicIPv6Corroboration)
 namespace
 {
 
-// 2001:db8::<last>, the documentation prefix. The last byte is the only thing
-// that varies, so two addresses differ in a single byte -- the case a
-// byte-wise comparison is most likely to get wrong.
-CPublicIPv6Corroboration::Address MakeAddress(uint8_t last)
+typedef CPublicIPv6Corroboration::Address Address;
+
+// 2001:db8::<last>, the documentation prefix -- global unicast, so it passes
+// the address-family gate and only the locally-assigned gate is under test.
+// The last byte is the only thing that varies, so two addresses differ in a
+// single byte -- the case a byte-wise comparison is most likely to get wrong.
+Address MakeAddress(uint8_t last)
 {
-	CPublicIPv6Corroboration::Address address = {};
+	Address address = {};
 	address[0] = 0x20;
 	address[1] = 0x01;
 	address[2] = 0x0d;
@@ -70,6 +80,35 @@ uint32_t MakeObserver(uint8_t host)
 	return 0xCB007100u | host;
 }
 
+// An address with the given leading bytes and nothing else set. Used for the
+// prefixes that are not global unicast, which no peer may ever reflect at us.
+Address MakePrefixed(uint8_t first, uint8_t second)
+{
+	Address address = {};
+	address[0] = first;
+	address[1] = second;
+	return address;
+}
+
+std::vector<Address> Held(const Address &one)
+{
+	std::vector<Address> local;
+	local.push_back(one);
+	return local;
+}
+
+std::vector<Address> Held(const Address &one, const Address &two)
+{
+	std::vector<Address> local;
+	local.push_back(one);
+	local.push_back(two);
+	return local;
+}
+
+// An arbitrary non-zero start, so a test that forgets to advance the clock
+// cannot pass by accident on a zero-initialised timestamp.
+const uint64_t START_MS = 5000;
+
 } // namespace
 
 // The threshold is a policy decision, not an implementation detail: raising or
@@ -80,164 +119,372 @@ TEST(PublicIPv6Corroboration, ThresholdIsThreeDistinctObservers)
 	ASSERT_EQUALS(3u, (unsigned)PUBLIC_IPV6_CORROBORATION_THRESHOLD);
 }
 
-// The whole point. eMuleAI would have believed this one.
+// Same for the window: it is the upper bound on how long a claim nobody
+// repeats keeps counting, and shortening or lengthening it changes how long a
+// stale address can survive.
+TEST(PublicIPv6Corroboration, WindowIsThirtyMinutes)
+{
+	ASSERT_EQUALS((uint64_t)(30 * 60 * 1000), (uint64_t)PUBLIC_IPV6_CORROBORATION_WINDOW_MS);
+}
+
+// The security control. A quorum -- more than the threshold, from distinct
+// observers, all agreeing -- must still not make us adopt an address this
+// machine does not hold. Corroboration disambiguates between our own
+// addresses; it does not confer ownership of somebody else's.
+TEST(PublicIPv6Corroboration, AQuorumCannotAdoptAnAddressWeDoNotHold)
+{
+	CPublicIPv6Corroboration tracker;
+	const Address ours = MakeAddress(0x01);
+	const Address foreign = MakeAddress(0x02);
+	tracker.SetLocalAddresses(Held(ours), START_MS);
+
+	for (unsigned i = 0; i < PUBLIC_IPV6_CORROBORATION_THRESHOLD + 5; ++i) {
+		ASSERT_FALSE(tracker.AddClaim(MakeObserver((uint8_t)(i + 1)), foreign.data(), START_MS));
+	}
+
+	ASSERT_FALSE(tracker.IsCorroborated());
+	ASSERT_TRUE(tracker.CorroboratedAddress() == nullptr);
+}
+
+// A rejected claim must cost nothing to hold. If it allocated a candidate, a
+// peer could spend our memory on values it invented at one claim each, which
+// is the whole reason the filter comes first.
+TEST(PublicIPv6Corroboration, ARejectedClaimLeavesNoTrace)
+{
+	CPublicIPv6Corroboration tracker;
+	const Address ours = MakeAddress(0xFF);
+	tracker.SetLocalAddresses(Held(ours), START_MS);
+
+	for (unsigned i = 0; i < 256; ++i) {
+		const Address invented = MakeAddress((uint8_t)i);
+		if (invented == ours) {
+			continue;
+		}
+		tracker.AddClaim(MakeObserver((uint8_t)i), invented.data(), START_MS);
+	}
+
+	ASSERT_EQUALS(0u, (unsigned)tracker.CandidateCount());
+	ASSERT_FALSE(tracker.IsCorroborated());
+}
+
+// Nothing outside 2000::/3 could be an address the outside world saw us arrive
+// from, so none of it is a legitimate reflection -- not even if the same bytes
+// somehow turned up in the locally-assigned list.
+TEST(PublicIPv6Corroboration, AddressesOutsideGlobalUnicastAreRejected)
+{
+	const Address unspecified = MakePrefixed(0x00, 0x00);
+	Address loopback = MakePrefixed(0x00, 0x00);
+	loopback[15] = 0x01;
+	const Address linkLocal = MakePrefixed(0xfe, 0x80);
+	const Address uniqueLocal = MakePrefixed(0xfd, 0x00);
+	const Address multicast = MakePrefixed(0xff, 0x02);
+
+	std::vector<Address> rejected;
+	rejected.push_back(unspecified);
+	rejected.push_back(loopback);
+	rejected.push_back(linkLocal);
+	rejected.push_back(uniqueLocal);
+	rejected.push_back(multicast);
+
+	for (const Address &value : rejected) {
+		ASSERT_FALSE(CPublicIPv6Corroboration::IsGlobalUnicast(value));
+
+		CPublicIPv6Corroboration tracker;
+		// Handed in as "local" on purpose: the address-family gate is an
+		// invariant of the tracker, not a side effect of how the caller
+		// happened to fill that set.
+		tracker.SetLocalAddresses(Held(value), START_MS);
+		for (unsigned i = 0; i < PUBLIC_IPV6_CORROBORATION_THRESHOLD; ++i) {
+			tracker.AddClaim(MakeObserver((uint8_t)(i + 1)), value.data(), START_MS);
+		}
+		ASSERT_FALSE(tracker.IsCorroborated());
+		ASSERT_EQUALS(0u, (unsigned)tracker.CandidateCount());
+	}
+}
+
+// Before the interface list has been published there is nothing to check a
+// claim against, and the safe reading of "I do not know which addresses I
+// hold" is "believe nobody".
+TEST(PublicIPv6Corroboration, WithNoPublishedInterfacesNothingIsBelieved)
+{
+	CPublicIPv6Corroboration tracker;
+	const Address claimed = MakeAddress(0x01);
+
+	for (unsigned i = 0; i < PUBLIC_IPV6_CORROBORATION_THRESHOLD; ++i) {
+		ASSERT_FALSE(tracker.AddClaim(MakeObserver((uint8_t)(i + 1)), claimed.data(), START_MS));
+	}
+	ASSERT_EQUALS(0u, (unsigned)tracker.LocalAddressCount());
+}
+
+// One peer is one peer, even about an address we do hold.
 TEST(PublicIPv6Corroboration, OnePeerIsNotBelieved)
 {
 	CPublicIPv6Corroboration tracker;
-	const CPublicIPv6Corroboration::Address claimed = MakeAddress(0x01);
+	const Address claimed = MakeAddress(0x01);
+	tracker.SetLocalAddresses(Held(claimed), START_MS);
 
-	ASSERT_FALSE(tracker.AddClaim(MakeObserver(1), claimed.data()));
+	ASSERT_FALSE(tracker.AddClaim(MakeObserver(1), claimed.data(), START_MS));
 	ASSERT_FALSE(tracker.IsCorroborated());
 	ASSERT_TRUE(tracker.CorroboratedAddress() == nullptr);
 	ASSERT_EQUALS(1u, (unsigned)tracker.DistinctObserversFor(claimed.data()));
 }
 
-// Two is still one short, and it is the interesting near-miss: two source
-// addresses is one dual-homed host as easily as it is two opinions.
+// Two source addresses is one dual-homed host, one new lease, or one attacker
+// with a second socket -- not a second opinion.
 TEST(PublicIPv6Corroboration, TwoPeersAreStillNotEnough)
 {
 	CPublicIPv6Corroboration tracker;
-	const CPublicIPv6Corroboration::Address claimed = MakeAddress(0x01);
+	const Address claimed = MakeAddress(0x01);
+	tracker.SetLocalAddresses(Held(claimed), START_MS);
 
-	tracker.AddClaim(MakeObserver(1), claimed.data());
-	ASSERT_FALSE(tracker.AddClaim(MakeObserver(2), claimed.data()));
+	tracker.AddClaim(MakeObserver(1), claimed.data(), START_MS);
+	ASSERT_FALSE(tracker.AddClaim(MakeObserver(2), claimed.data(), START_MS));
 	ASSERT_FALSE(tracker.IsCorroborated());
+	ASSERT_EQUALS(2u, (unsigned)tracker.DistinctObserversFor(claimed.data()));
 }
 
-// N distinct observed addresses saying the same thing, and the value is
-// believed -- and it is the claimed value that comes back out, byte for byte.
 TEST(PublicIPv6Corroboration, DistinctObserversReachingTheThresholdCorroborate)
 {
 	CPublicIPv6Corroboration tracker;
-	const CPublicIPv6Corroboration::Address claimed = MakeAddress(0x01);
+	const Address claimed = MakeAddress(0x01);
+	tracker.SetLocalAddresses(Held(claimed), START_MS);
 
-	for (unsigned i = 0; i < PUBLIC_IPV6_CORROBORATION_THRESHOLD - 1; ++i) {
-		ASSERT_FALSE(tracker.AddClaim(MakeObserver((uint8_t)(i + 1)), claimed.data()));
+	for (unsigned i = 0; i + 1 < PUBLIC_IPV6_CORROBORATION_THRESHOLD; ++i) {
+		ASSERT_FALSE(tracker.AddClaim(MakeObserver((uint8_t)(i + 1)), claimed.data(), START_MS));
 	}
-	ASSERT_TRUE(
-		tracker.AddClaim(MakeObserver((uint8_t)PUBLIC_IPV6_CORROBORATION_THRESHOLD), claimed.data()));
+	ASSERT_TRUE(tracker.AddClaim(
+		MakeObserver((uint8_t)PUBLIC_IPV6_CORROBORATION_THRESHOLD), claimed.data(), START_MS));
 
 	ASSERT_TRUE(tracker.IsCorroborated());
-	const uint8_t *corroborated = tracker.CorroboratedAddress();
-	ASSERT_TRUE(corroborated != nullptr);
-	ASSERT_EQUALS(0, memcmp(corroborated, claimed.data(), claimed.size()));
+	ASSERT_TRUE(tracker.CorroboratedAddress() != nullptr);
+	ASSERT_EQUALS(0, std::memcmp(tracker.CorroboratedAddress(), claimed.data(), claimed.size()));
 }
 
-// One host repeating itself is one host. If the count were of claims rather
-// than of distinct sources, a single peer could reach any threshold alone,
-// which is exactly the property that makes the threshold meaningless.
+// The point of keying on the observed source address: repetition is not
+// corroboration, however many times it happens.
 TEST(PublicIPv6Corroboration, OneObserverRepeatingItselfNeverCorroborates)
 {
 	CPublicIPv6Corroboration tracker;
-	const CPublicIPv6Corroboration::Address claimed = MakeAddress(0x01);
+	const Address claimed = MakeAddress(0x01);
+	tracker.SetLocalAddresses(Held(claimed), START_MS);
 
-	for (unsigned i = 0; i < PUBLIC_IPV6_CORROBORATION_THRESHOLD + 5; ++i) {
-		ASSERT_FALSE(tracker.AddClaim(MakeObserver(7), claimed.data()));
+	for (unsigned i = 0; i < PUBLIC_IPV6_CORROBORATION_THRESHOLD * 10; ++i) {
+		ASSERT_FALSE(tracker.AddClaim(MakeObserver(7), claimed.data(), START_MS));
 	}
 	ASSERT_EQUALS(1u, (unsigned)tracker.DistinctObserversFor(claimed.data()));
 }
 
-// Agreement is per value. Peers that disagree corroborate nothing, however
-// many of them there are -- and the addresses here differ in one byte only.
+// Votes are counted per value, never in total: three peers naming three
+// different addresses agree about nothing.
 TEST(PublicIPv6Corroboration, DisagreeingPeersDoNotPoolIntoAQuorum)
 {
 	CPublicIPv6Corroboration tracker;
+	std::vector<Address> local;
+	for (unsigned i = 0; i < PUBLIC_IPV6_CORROBORATION_THRESHOLD; ++i) {
+		local.push_back(MakeAddress((uint8_t)(i + 1)));
+	}
+	tracker.SetLocalAddresses(local, START_MS);
 
-	for (unsigned i = 0; i < PUBLIC_IPV6_CORROBORATION_THRESHOLD + 2; ++i) {
-		const CPublicIPv6Corroboration::Address claimed = MakeAddress((uint8_t)(i + 1));
-		tracker.AddClaim(MakeObserver((uint8_t)(i + 1)), claimed.data());
+	for (unsigned i = 0; i < PUBLIC_IPV6_CORROBORATION_THRESHOLD; ++i) {
+		const Address claimed = MakeAddress((uint8_t)(i + 1));
+		tracker.AddClaim(MakeObserver((uint8_t)(i + 1)), claimed.data(), START_MS);
 	}
 
 	ASSERT_FALSE(tracker.IsCorroborated());
+	ASSERT_EQUALS((unsigned)PUBLIC_IPV6_CORROBORATION_THRESHOLD, (unsigned)tracker.CandidateCount());
 }
 
-// A quorum for one value is not disturbed by a louder minority for another.
+// A seated value is not unseated by a minority. Both addresses here are ours,
+// so the loser is not a threat -- but flipping between them on every packet
+// would be a different address published every few seconds.
 TEST(PublicIPv6Corroboration, AMinorityClaimDoesNotUnseatAQuorum)
 {
 	CPublicIPv6Corroboration tracker;
-	const CPublicIPv6Corroboration::Address agreed = MakeAddress(0x01);
-	const CPublicIPv6Corroboration::Address other = MakeAddress(0x02);
+	const Address agreed = MakeAddress(0x01);
+	const Address other = MakeAddress(0x02);
+	tracker.SetLocalAddresses(Held(agreed, other), START_MS);
 
 	for (unsigned i = 0; i < PUBLIC_IPV6_CORROBORATION_THRESHOLD; ++i) {
-		tracker.AddClaim(MakeObserver((uint8_t)(i + 1)), agreed.data());
+		tracker.AddClaim(MakeObserver((uint8_t)(i + 1)), agreed.data(), START_MS);
 	}
-	tracker.AddClaim(MakeObserver(100), other.data());
-	tracker.AddClaim(MakeObserver(101), other.data());
+	tracker.AddClaim(MakeObserver(100), other.data(), START_MS);
+	tracker.AddClaim(MakeObserver(101), other.data(), START_MS);
 
 	ASSERT_TRUE(tracker.IsCorroborated());
-	ASSERT_EQUALS(0, memcmp(tracker.CorroboratedAddress(), agreed.data(), agreed.size()));
+	ASSERT_EQUALS(0, std::memcmp(tracker.CorroboratedAddress(), agreed.data(), agreed.size()));
 }
 
-// With no observed source address there is nothing to key on, and an unkeyed
-// claim would let one caller supply the whole quorum by itself. Ignored, not
-// counted under a zero key.
+// Without an observed address there is nothing to key on, and an unkeyed claim
+// would let one peer supply the whole quorum by itself.
 TEST(PublicIPv6Corroboration, ClaimsWithNoObservedAddressAreIgnored)
 {
 	CPublicIPv6Corroboration tracker;
-	const CPublicIPv6Corroboration::Address claimed = MakeAddress(0x01);
+	const Address claimed = MakeAddress(0x01);
+	tracker.SetLocalAddresses(Held(claimed), START_MS);
 
-	for (unsigned i = 0; i < PUBLIC_IPV6_CORROBORATION_THRESHOLD + 3; ++i) {
-		ASSERT_FALSE(tracker.AddClaim(0, claimed.data()));
+	for (unsigned i = 0; i < PUBLIC_IPV6_CORROBORATION_THRESHOLD * 5; ++i) {
+		ASSERT_FALSE(tracker.AddClaim(0, claimed.data(), START_MS));
 	}
 	ASSERT_EQUALS(0u, (unsigned)tracker.CandidateCount());
 }
 
-// A NULL payload is a tag that failed to decode, not a claim.
 TEST(PublicIPv6Corroboration, NullClaimsAreIgnored)
 {
 	CPublicIPv6Corroboration tracker;
+	tracker.SetLocalAddresses(Held(MakeAddress(0x01)), START_MS);
 
-	ASSERT_FALSE(tracker.AddClaim(MakeObserver(1), nullptr));
+	ASSERT_FALSE(tracker.AddClaim(MakeObserver(1), nullptr, START_MS));
 	ASSERT_EQUALS(0u, (unsigned)tracker.CandidateCount());
 	ASSERT_EQUALS(0u, (unsigned)tracker.DistinctObserversFor(nullptr));
 }
 
-// The set of tracked values is attacker-chosen, so it is bounded. Past the
-// bound new values are dropped rather than evicting one that may be honest.
-TEST(PublicIPv6Corroboration, CandidateTrackingIsBounded)
+// The filter is what bounds the table: a candidate can only ever be one of the
+// addresses this machine holds, so a peer flooding invented values cannot make
+// the table grow at all -- which is why there is no cap on it any more.
+TEST(PublicIPv6Corroboration, TheCandidateSetIsBoundedByOurOwnAddresses)
 {
 	CPublicIPv6Corroboration tracker;
+	const Address first = MakeAddress(0x01);
+	const Address second = MakeAddress(0x02);
+	tracker.SetLocalAddresses(Held(first, second), START_MS);
 
-	for (unsigned i = 0; i < PUBLIC_IPV6_CORROBORATION_MAX_CANDIDATES + 20; ++i) {
-		const CPublicIPv6Corroboration::Address claimed = MakeAddress((uint8_t)(i + 1));
-		tracker.AddClaim(MakeObserver((uint8_t)(i + 1)), claimed.data());
+	for (unsigned i = 0; i < 250; ++i) {
+		const Address claimed = MakeAddress((uint8_t)i);
+		tracker.AddClaim(MakeObserver((uint8_t)i), claimed.data(), START_MS);
 	}
 
-	ASSERT_EQUALS((unsigned)PUBLIC_IPV6_CORROBORATION_MAX_CANDIDATES, (unsigned)tracker.CandidateCount());
-	ASSERT_FALSE(tracker.IsCorroborated());
+	ASSERT_EQUALS(2u, (unsigned)tracker.CandidateCount());
+	ASSERT_EQUALS(2u, (unsigned)tracker.LocalAddressCount());
 }
 
-// A full bucket does not stop an existing candidate from gaining observers:
-// the honest value is usually the first one seen, and it has to be able to
-// reach the threshold while noise fills the rest of the table.
-TEST(PublicIPv6Corroboration, AnExistingCandidateStillGrowsWhileTheTableIsFull)
+// A vote nobody has repeated within the window is not current evidence. This
+// is the difference between "three peers agree" and "three peers said so at
+// some point since the daemon started".
+TEST(PublicIPv6Corroboration, VotesOlderThanTheWindowStopCounting)
 {
 	CPublicIPv6Corroboration tracker;
-	const CPublicIPv6Corroboration::Address agreed = MakeAddress(0xFF);
+	const Address claimed = MakeAddress(0x01);
+	tracker.SetLocalAddresses(Held(claimed), START_MS);
 
-	tracker.AddClaim(MakeObserver(1), agreed.data());
-	for (unsigned i = 0; i < PUBLIC_IPV6_CORROBORATION_MAX_CANDIDATES + 20; ++i) {
-		const CPublicIPv6Corroboration::Address noise = MakeAddress((uint8_t)(i + 1));
-		tracker.AddClaim(MakeObserver((uint8_t)(i + 50)), noise.data());
+	for (unsigned i = 0; i + 1 < PUBLIC_IPV6_CORROBORATION_THRESHOLD; ++i) {
+		tracker.AddClaim(MakeObserver((uint8_t)(i + 1)), claimed.data(), START_MS);
 	}
 
-	for (unsigned i = 1; i < PUBLIC_IPV6_CORROBORATION_THRESHOLD; ++i) {
-		tracker.AddClaim(MakeObserver((uint8_t)(i + 1)), agreed.data());
+	// The deciding claim arrives one millisecond after the first two aged out.
+	const uint64_t tooLate = START_MS + PUBLIC_IPV6_CORROBORATION_WINDOW_MS + 1;
+	ASSERT_FALSE(tracker.AddClaim(
+		MakeObserver((uint8_t)PUBLIC_IPV6_CORROBORATION_THRESHOLD), claimed.data(), tooLate));
+	ASSERT_EQUALS(1u, (unsigned)tracker.DistinctObserversFor(claimed.data()));
+}
+
+// A quorum that formed and then went quiet must lapse too, otherwise the
+// window only ever applies to claims that never made it.
+TEST(PublicIPv6Corroboration, AnAdoptedValueLapsesWhenItsVotesAgeOut)
+{
+	CPublicIPv6Corroboration tracker;
+	const Address claimed = MakeAddress(0x01);
+	tracker.SetLocalAddresses(Held(claimed), START_MS);
+
+	for (unsigned i = 0; i < PUBLIC_IPV6_CORROBORATION_THRESHOLD; ++i) {
+		tracker.AddClaim(MakeObserver((uint8_t)(i + 1)), claimed.data(), START_MS);
+	}
+	ASSERT_TRUE(tracker.IsCorroborated());
+
+	// No peer said anything since; only the periodic interface refresh ran.
+	tracker.SetLocalAddresses(Held(claimed), START_MS + PUBLIC_IPV6_CORROBORATION_WINDOW_MS + 1);
+	ASSERT_FALSE(tracker.IsCorroborated());
+	ASSERT_TRUE(tracker.CorroboratedAddress() == nullptr);
+}
+
+// A peer that is still connected and still saying the same thing keeps its
+// vote. Without this the window would date every vote from the first hello, so
+// a stable client whose peers never stopped agreeing would still lose its
+// quorum once, on the clock, for no reason.
+TEST(PublicIPv6Corroboration, ARepeatingObserverKeepsItsVoteAlive)
+{
+	CPublicIPv6Corroboration tracker;
+	const Address claimed = MakeAddress(0x01);
+	tracker.SetLocalAddresses(Held(claimed), START_MS);
+
+	for (unsigned i = 0; i < PUBLIC_IPV6_CORROBORATION_THRESHOLD; ++i) {
+		tracker.AddClaim(MakeObserver((uint8_t)(i + 1)), claimed.data(), START_MS);
+	}
+	ASSERT_TRUE(tracker.IsCorroborated());
+
+	// The same peers say it again, comfortably inside the window.
+	const uint64_t repeated = START_MS + (PUBLIC_IPV6_CORROBORATION_WINDOW_MS * 3) / 5;
+	for (unsigned i = 0; i < PUBLIC_IPV6_CORROBORATION_THRESHOLD; ++i) {
+		tracker.AddClaim(MakeObserver((uint8_t)(i + 1)), claimed.data(), repeated);
+	}
+
+	// Past the window measured from the first hello, inside it measured from
+	// the repeat. Only the interface refresh runs here, so nothing is re-added.
+	tracker.SetLocalAddresses(Held(claimed), START_MS + PUBLIC_IPV6_CORROBORATION_WINDOW_MS + 1000);
+
+	ASSERT_TRUE(tracker.IsCorroborated());
+	// Repetition renews a vote; it never adds one.
+	ASSERT_EQUALS((unsigned)PUBLIC_IPV6_CORROBORATION_THRESHOLD,
+		(unsigned)tracker.DistinctObserversFor(claimed.data()));
+}
+
+// The half of the refresh that makes the cache safe: an address that left the
+// interface takes its corroboration with it. Without this a reflection
+// outlives the prefix it came from.
+TEST(PublicIPv6Corroboration, ARenumberDropsTheAdoptedAddress)
+{
+	CPublicIPv6Corroboration tracker;
+	const Address oldPrefix = MakeAddress(0x01);
+	const Address newPrefix = MakeAddress(0x02);
+	tracker.SetLocalAddresses(Held(oldPrefix), START_MS);
+
+	for (unsigned i = 0; i < PUBLIC_IPV6_CORROBORATION_THRESHOLD; ++i) {
+		tracker.AddClaim(MakeObserver((uint8_t)(i + 1)), oldPrefix.data(), START_MS);
+	}
+	ASSERT_TRUE(tracker.IsCorroborated());
+
+	tracker.SetLocalAddresses(Held(newPrefix), START_MS + 1000);
+
+	ASSERT_FALSE(tracker.IsCorroborated());
+	ASSERT_EQUALS(0u, (unsigned)tracker.CandidateCount());
+	ASSERT_EQUALS(0u, (unsigned)tracker.DistinctObserversFor(oldPrefix.data()));
+}
+
+// After the old value loses its seat, the next value to hold a quorum takes
+// it. A tracker that could only ever elect once would be stuck on the first
+// address it saw for the life of the process.
+TEST(PublicIPv6Corroboration, AnotherAddressIsElectedAfterTheFirstLosesItsSeat)
+{
+	CPublicIPv6Corroboration tracker;
+	const Address oldPrefix = MakeAddress(0x01);
+	const Address newPrefix = MakeAddress(0x02);
+	tracker.SetLocalAddresses(Held(oldPrefix), START_MS);
+
+	for (unsigned i = 0; i < PUBLIC_IPV6_CORROBORATION_THRESHOLD; ++i) {
+		tracker.AddClaim(MakeObserver((uint8_t)(i + 1)), oldPrefix.data(), START_MS);
+	}
+	ASSERT_EQUALS(0, std::memcmp(tracker.CorroboratedAddress(), oldPrefix.data(), oldPrefix.size()));
+
+	const uint64_t later = START_MS + 1000;
+	tracker.SetLocalAddresses(Held(newPrefix), later);
+	for (unsigned i = 0; i < PUBLIC_IPV6_CORROBORATION_THRESHOLD; ++i) {
+		tracker.AddClaim(MakeObserver((uint8_t)(i + 1)), newPrefix.data(), later);
 	}
 
 	ASSERT_TRUE(tracker.IsCorroborated());
-	ASSERT_EQUALS(0, memcmp(tracker.CorroboratedAddress(), agreed.data(), agreed.size()));
+	ASSERT_EQUALS(0, std::memcmp(tracker.CorroboratedAddress(), newPrefix.data(), newPrefix.size()));
 }
 
-// Reset drops the quorum, so a tracker cannot carry a stale belief across
-// whatever lifetime a caller gives it.
-TEST(PublicIPv6Corroboration, ResetForgetsEverything)
+// Reset drops what peers said. It deliberately does not drop the interface
+// list: that comes from this machine, and clearing it would leave the filter
+// wide open until the next refresh.
+TEST(PublicIPv6Corroboration, ResetForgetsClaimsButKeepsOurOwnAddresses)
 {
 	CPublicIPv6Corroboration tracker;
-	const CPublicIPv6Corroboration::Address claimed = MakeAddress(0x01);
+	const Address claimed = MakeAddress(0x01);
+	tracker.SetLocalAddresses(Held(claimed), START_MS);
 
 	for (unsigned i = 0; i < PUBLIC_IPV6_CORROBORATION_THRESHOLD; ++i) {
-		tracker.AddClaim(MakeObserver((uint8_t)(i + 1)), claimed.data());
+		tracker.AddClaim(MakeObserver((uint8_t)(i + 1)), claimed.data(), START_MS);
 	}
 	ASSERT_TRUE(tracker.IsCorroborated());
 
@@ -245,4 +492,5 @@ TEST(PublicIPv6Corroboration, ResetForgetsEverything)
 	ASSERT_FALSE(tracker.IsCorroborated());
 	ASSERT_EQUALS(0u, (unsigned)tracker.CandidateCount());
 	ASSERT_EQUALS(0u, (unsigned)tracker.DistinctObserversFor(claimed.data()));
+	ASSERT_EQUALS(1u, (unsigned)tracker.LocalAddressCount());
 }

--- a/unittests/tests/ReservedProtocolFramesTest.cpp
+++ b/unittests/tests/ReservedProtocolFramesTest.cpp
@@ -1,0 +1,183 @@
+//
+// This file is part of the aMule Project.
+//
+// Copyright (c) 2003-2026 aMule Team ( https://amule-org.github.io )
+//
+// Any parts of this program derived from the xMule, lMule or eMule project,
+// or contributed by third-party developers are copyrighted by their
+// respective authors.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301, USA
+//
+
+// OP_UDPRESERVEDPROT2 (0xB2) carries no eD2k opcode: the byte after the
+// protocol byte is a frame type, and the rest is that frame's payload
+// (eMuleAI, srchybrid/ClientUDPSocket.cpp:982). Everything about that layout
+// is wire format, including the fact that a datagram consisting of the
+// protocol byte alone has no type byte to read.
+//
+// CClientUDPSocket needs theApp, so the classification is a free function in a
+// header of its own and the socket does nothing but dispatch on the result.
+// What this test therefore covers is the part that decides: truncation, the
+// five registered types, the payload window handed to each handler, and the
+// unknown-type drop. The switch in CClientUDPSocket::ProcessReservedProt2Frame
+// is a five-way jump over the same constants.
+
+#include <muleunit/test.h>
+
+#include <ReservedProtocolFrames.h>
+#include <protocol/Protocols.h>
+
+using namespace muleunit;
+
+DECLARE_SIMPLE(ReservedProtocolFrames)
+
+// The frame types are wire format. Literal values, not a restatement of the
+// header they check.
+TEST(ReservedProtocolFrames, FrameTypeValuesAreExact)
+{
+	ASSERT_EQUALS(0xB2, (int)OP_UDPRESERVEDPROT2);
+	ASSERT_EQUALS(0x00, (int)OP_NATT_FRAME_UTP);
+	ASSERT_EQUALS(0x01, (int)OP_NATT_FRAME_QUIC);
+	ASSERT_EQUALS(0x02, (int)OP_NATT_FRAME_CAPS);
+	ASSERT_EQUALS(0x03, (int)OP_NATT_FRAME_CAPS_ACK);
+	ASSERT_EQUALS(0xFF, (int)OP_NATT_FRAME_KEY);
+}
+
+// Spec delta, "Truncated frame": an empty payload must be dropped and the read
+// must not reach past the end. The classifier is handed the frame window only
+// (the byte after the protocol byte onwards), so an empty window is exactly
+// the datagram that carried nothing but 0xB2.
+TEST(ReservedProtocolFrames, EmptyFrameIsTruncated)
+{
+	// A deliberately non-zero guard byte one position before the window: if
+	// the classifier read backwards or past its length it would find 0xAA
+	// and report it as a frame type.
+	const uint8_t buffer[2] = { 0xAA, 0xAA };
+
+	SReservedProt2Frame frame = ClassifyReservedProt2Frame(buffer + 1, 0);
+	ASSERT_EQUALS((int)RP2_TRUNCATED, (int)frame.disposition);
+	ASSERT_EQUALS(0u, (unsigned)frame.payloadLength);
+
+	// A null window is the same condition, not a crash.
+	frame = ClassifyReservedProt2Frame(NULL, 0);
+	ASSERT_EQUALS((int)RP2_TRUNCATED, (int)frame.disposition);
+}
+
+// Each registered type reaches its handler with the payload that follows it,
+// and a type byte with nothing after it is a valid zero-length payload -- not
+// truncation. Only the type byte itself is mandatory.
+TEST(ReservedProtocolFrames, EachKnownTypeIsRecognised)
+{
+	const uint8_t known[5] = { OP_NATT_FRAME_UTP,
+		OP_NATT_FRAME_QUIC,
+		OP_NATT_FRAME_CAPS,
+		OP_NATT_FRAME_CAPS_ACK,
+		OP_NATT_FRAME_KEY };
+
+	for (int i = 0; i < 5; ++i) {
+		const uint8_t buffer[4] = { known[i], 0x11, 0x22, 0x33 };
+
+		SReservedProt2Frame frame = ClassifyReservedProt2Frame(buffer, 4);
+		ASSERT_EQUALS((int)RP2_KNOWN_TYPE, (int)frame.disposition);
+		ASSERT_EQUALS((int)known[i], (int)frame.type);
+		ASSERT_EQUALS(3u, (unsigned)frame.payloadLength);
+		ASSERT_TRUE(frame.payload == buffer + 1);
+		ASSERT_EQUALS(0x11, (int)frame.payload[0]);
+
+		// Type byte only: an empty payload for that handler to reject on
+		// its own terms.
+		frame = ClassifyReservedProt2Frame(buffer, 1);
+		ASSERT_EQUALS((int)RP2_KNOWN_TYPE, (int)frame.disposition);
+		ASSERT_EQUALS((int)known[i], (int)frame.type);
+		ASSERT_EQUALS(0u, (unsigned)frame.payloadLength);
+	}
+}
+
+// Spec delta, "Frame type the client cannot handle": every type outside the
+// registered five is dropped. Sweeping the whole byte range is what keeps a
+// later type addition from silently landing in the wrong branch.
+TEST(ReservedProtocolFrames, EveryUnregisteredTypeIsDropped)
+{
+	for (unsigned type = 0; type <= 0xFF; ++type) {
+		const bool registered = (type == OP_NATT_FRAME_UTP || type == OP_NATT_FRAME_QUIC ||
+					 type == OP_NATT_FRAME_CAPS || type == OP_NATT_FRAME_CAPS_ACK ||
+					 type == OP_NATT_FRAME_KEY);
+
+		const uint8_t buffer[2] = { (uint8_t)type, 0x55 };
+		SReservedProt2Frame frame = ClassifyReservedProt2Frame(buffer, 2);
+
+		if (registered) {
+			ASSERT_EQUALS((int)RP2_KNOWN_TYPE, (int)frame.disposition);
+		} else {
+			ASSERT_EQUALS((int)RP2_UNKNOWN_TYPE, (int)frame.disposition);
+			// The type still travels out, because the drop is logged.
+			ASSERT_EQUALS((int)type, (int)frame.type);
+		}
+	}
+}
+
+// The classifier is what the flood-accounting exemption rests on: it returns a
+// disposition and touches nothing else, so a dropped frame cannot reach
+// CPacketTracking. Only OP_KADEMLIAHEADER does
+// (KademliaUDPListener.cpp:263), and this classifier has no way to get there.
+// Asserting the function is const-correct over its input is the closest a unit
+// test gets to that; the placement is what actually guarantees it.
+TEST(ReservedProtocolFrames, ClassificationDoesNotMutateTheDatagram)
+{
+	uint8_t buffer[4] = { 0x7E, 0x11, 0x22, 0x33 };
+	const uint8_t before[4] = { 0x7E, 0x11, 0x22, 0x33 };
+
+	SReservedProt2Frame frame = ClassifyReservedProt2Frame(buffer, 4);
+	ASSERT_EQUALS((int)RP2_UNKNOWN_TYPE, (int)frame.disposition);
+
+	for (int i = 0; i < 4; ++i) {
+		ASSERT_EQUALS((int)before[i], (int)buffer[i]);
+	}
+}
+
+// An unknown-frame flood must not become a log flood. First occurrence logs,
+// the rest of the window is counted, and the count is reported with the next
+// line that does get through.
+TEST(ReservedProtocolFrames, UnknownFrameLogIsRateLimited)
+{
+	CUnknownFrameLogThrottle throttle(1000);
+
+	ASSERT_TRUE(throttle.ShouldLog(10000));
+	ASSERT_EQUALS(0u, throttle.TakeSuppressedCount());
+
+	ASSERT_FALSE(throttle.ShouldLog(10001));
+	ASSERT_FALSE(throttle.ShouldLog(10500));
+	ASSERT_FALSE(throttle.ShouldLog(10999));
+
+	ASSERT_TRUE(throttle.ShouldLog(11000));
+	ASSERT_EQUALS(3u, throttle.TakeSuppressedCount());
+	ASSERT_EQUALS(0u, throttle.TakeSuppressedCount());
+
+	ASSERT_FALSE(throttle.ShouldLog(11001));
+	ASSERT_TRUE(throttle.ShouldLog(99999));
+	ASSERT_EQUALS(1u, throttle.TakeSuppressedCount());
+}
+
+// A tick counter that appears to move backwards (it should not, but the
+// throttle must not answer with a silence that lasts until it catches up)
+// opens the window rather than closing it.
+TEST(ReservedProtocolFrames, ThrottleToleratesNonMonotonicClock)
+{
+	CUnknownFrameLogThrottle throttle(1000);
+
+	ASSERT_TRUE(throttle.ShouldLog(10000));
+	ASSERT_TRUE(throttle.ShouldLog(500));
+}


### PR DESCRIPTION
Refs #1177

This is piece 1 of the seven items listed in #1177 — peer capability recognition — offered on its own and first, as requested in that thread.

## What this adds

Reading of eMuleAI's vendor capability tags from a peer hello, and classification of `OP_UDPRESERVEDPROT2` frames by frame type instead of treating them as malformed traffic.

- `src/PeerCapabilities.h` — the `CT_MOD_MISCOPTIONS` bitfield: the five bit positions eMuleAI defines, a decoder that masks reserved bits out of what a peer sends, per-bit accessors, and the display text for each bit.
- `src/ReservedProtocolFrames.h` — classification of the byte after `0xB2` into truncated / known-type / unknown-type, the payload window handed to a handler, and a rate limit so an unknown-frame flood cannot become a log flood.
- The `CT_MOD_IP_V6` (`0xAE`) and `CT_MOD_SVR_IP_V6` (`0xAF`) tags, and the `ip6` / `bi6` Kad tag address encoding.
- The accessor for the decoded word is `KnownBits()`. Its earlier name, `ToWire()`, invited the misreading #1177 reports — that a bit added later would be stripped on send — when it only ever fed a log line and the EC tag below.
- `EC_TAG_CLIENT_MOD_CAPABILITIES` (`0x0632`), so a peer's recognised capabilities are readable over External Connections. The Client Details dialog renders the same data, but it needs an X server; the EC tag is what makes the display checkable without one.

## Wire format

Three constants are fixed by the peer implementation and are pinned in the tests as literals:

| Constant | Value |
| --- | --- |
| `CT_MOD_MISCOPTIONS` | `0xAA` |
| NAT-T bit within that word | `1u << 1` |
| `OP_UDPRESERVEDPROT2` | `0xB2` |

All three match the maintainer's own reference branch, `got3nks/amule@feat/nat-t-utp`, which uses tag id `0xAA` (`src/include/tags/ClientTags.h:61`), decodes bit 1 of that word as NAT-T support (`MOD_MISCOPT_BIT_NAT_TRAVERSAL = 0x00000002`, `src/NatTraversal.h:110`), and reads `0xB2` datagrams with a type byte following the protocol byte (`src/ClientUDPSocket.cpp:188`).

Beyond that reference, this piece adds:

- The remaining bit definitions. The reference documents bits 0–3 as a comment and implements decoding for bit 1 only. Here all five bits eMuleAI defines — extended source exchange (bit 0), NAT-T (bit 1), IPv6 (bit 2), serving buddy pull (bit 3), QUIC NAT-T (bit 4) — are named, decoded and individually readable, with bits 5–31 masked off in both directions so no capability can be inferred from a reserved bit.
- The `0xB2` frame-type classification in `src/ReservedProtocolFrames.h`. The reference reads a type byte on its own uTP path; this is a classification of the whole frame-type namespace (`0x00` uTP, `0x01` QUIC, `0x02` caps, `0x03` caps-ack, `0xFF` key) with an explicit disposition for a truncated frame and for an unregistered type, so an unknown frame is dropped as a known-unknown rather than counted against the sender.

### The connect-options byte is deliberately not used

This piece signals nothing through the connect-options byte. As read out of eMuleAI's `Opcodes.h:215-221` in the #1177 discussion, that byte claims `0x01, 0x02, 0x04, 0x08, 0x20, 0x40, 0x80`, leaving `0x10` as its only free bit and nothing safe to take.

A reader coming from the reference branch will find `CONNECT_OPT_BIT_NAT_TRAVERSAL = 0x80` there (`src/NatTraversal.h:67`). That is left out here on purpose, and for that reason: `0x80` is not free.

## Not covered

- **No capability is negotiated.** This piece only reads what a peer claims. `LocalAdvertisedModMiscOptions()` returns zero, so aMule advertises none of the five bits and emits no `CT_MOD_MISCOPTIONS` tag at all — an absent tag and an all-zero word mean the same thing to the peer, and the absent one costs no bytes. Negotiation is pieces 5–6.
- **No transport is implemented.** All five bit positions are defined here, because recognising a peer's claim requires the whole layout, and a decoder that knew only some bits would silently mask the rest. But nothing stands behind them: IPv6, uTP and QUIC arrive with their own pieces, and each turns its own bit on in the change that ships it. A bit set here without a transport behind it is a defect the tests fail on.
- **No frame is handled.** A known `0xB2` frame type is classified and then dropped, because the transports that would serve it do not exist in this tree.

## Checks

Three new suites (`PeerCapabilitiesTest`, 11 cases; `ReservedProtocolFramesTest`, 7; `ECClientCapabilitiesTest`, 5) bring `ctest` from 48 to 51, all passing; clang-format 18 reports no violations on the 22 touched sources.
