### PR TITLE
test(amuleapi): wire StaticRoot for phase 40, and skip loudly without it

### DIFF
--- a/unittests/curl-tests/amuleapi/40-http-conformance.sh
+++ b/unittests/curl-tests/amuleapi/40-http-conformance.sh
@@ -240,8 +240,17 @@ done
 # The static fallthrough is deliberately not normalised -- there a trailing
 # slash is a directory rather than a spelling -- so the rule must not have
 # leaked outside the API prefix.
-_assert_eq "200" "$(curl -s -o /dev/null -w '%{http_code}' --max-time 10 "$HOST/")" \
-	"the static root still answers 200"
+# Needs a served static root; run-all.sh wires StaticRoot for this phase. If
+# the frontend is not being served (an install without it, or a hand-run
+# against a bare config) there is no 200 to assert and the trailing-slash
+# rule cannot be probed this way -- skip loudly rather than report a
+# conformance failure that is really a missing fixture.
+STATIC_ROOT_CODE=$(curl -s -o /dev/null -w '%{http_code}' --max-time 10 "$HOST/")
+if [ "$STATIC_ROOT_CODE" = "404" ]; then
+	_skip "static root is not served (got 404); cannot probe the trailing-slash rule there"
+else
+	_assert_eq "200" "$STATIC_ROOT_CODE" "the static root still answers 200"
+fi
 
 # /events reaches the dispatcher only on a method the streaming resolver
 # declined, and with no route there it used to fall through to the catch-all

--- a/unittests/curl-tests/amuleapi/run-all.sh
+++ b/unittests/curl-tests/amuleapi/run-all.sh
@@ -141,14 +141,18 @@ run_phase() {
 	# amuleapi.conf. Nothing spawns it here, so seed the config file.
 	sed -i'.bak' "s|^Password=.*|Password=$EC_PASSWORD|" /tmp/amuleapi-regtest/amuleapi.conf
 	rm -f /tmp/amuleapi-regtest/amuleapi.conf.bak
-	# 27-static-frontend exercises the static-frontend serve path. It
-	# plants symlinks + an oversized file into StaticRoot during the
+	# 27-static-frontend exercises the static-frontend serve path, and
+	# 40-http-conformance asserts the trailing-slash rule stops at the
+	# API prefix by checking the static root still answers 200 -- which
+	# it cannot do with StaticRoot unset. Both therefore need it wired.
+	#
+	# 27 plants symlinks + an oversized file into StaticRoot during the
 	# run, so the dir has to be writable. The bundled source tree is
 	# read-only in container CI; copy the placeholder out to a /tmp
-	# scratch dir and point StaticRoot at the copy. Other scripts
-	# leave it empty so the install-path discovery chain stays
-	# exercised by 27-static-frontend only.
-	if [ "$script" = "27-static-frontend.sh" ]; then
+	# scratch dir and point StaticRoot at the copy. Every other script
+	# leaves it unset, which is what keeps the install-path discovery
+	# chain exercised: these two pin it, the rest do not.
+	if [ "$script" = "27-static-frontend.sh" ] || [ "$script" = "40-http-conformance.sh" ]; then
 		STATIC_SRC="$ROOT/src/webapi/static"
 		STATIC_DIR=/tmp/amuleapi-static-frontend
 		rm -rf "$STATIC_DIR"


### PR DESCRIPTION
`40-http-conformance` asserts that the static root still answers 200. That is not a static-frontend test: it is there to prove the trailing-slash normalisation added for the API prefix did not leak outside it, and "the root still serves" is the probe it uses.

`run-all.sh` wired `StaticRoot` for `27-static-frontend` only, so in a tree whose install-path discovery finds nothing the root is a 404 and the phase reported a conformance failure that was really a missing fixture. It is not a product defect and it is invisible to CI, which does not run the curl suite - it only shows up when the suite is run by hand against a live daemon, where it reads as a real red.

Two changes:

- `run-all.sh` wires `StaticRoot` for phase 40 as well as 27. Every other phase still leaves it unset, which is what keeps the install-path discovery chain exercised.
- Phase 40 skips the assertion, with a reason, when the root is not served at all - so a hand-run against a bare config says why instead of failing. It goes through `_skip`, so it lands in `SKIP_COUNT` and stays out of `TEST_COUNT` like every other environment-dependent check in the suite.

Verified against a live daemon: phase 40 goes from 1 failure to 96/96, and 27-static-frontend still passes 14/14.

Shell-only, no C++ touched.
