### PR TITLE
test(amuleapi): fix three curl assertions so the suite passes on a peered node

### DIFF
--- a/unittests/curl-tests/amuleapi/07-read-stats-and-search-results.sh
+++ b/unittests/curl-tests/amuleapi/07-read-stats-and-search-results.sh
@@ -113,9 +113,15 @@ _assert_json_eq '[.. | objects | select(has("key")) | .key] as $k
 	| (["ul_dl_ratio","download_data","servers_working"] | all(($k | index(.)) != null))' \
 	true '/stats/tree carries the expected stable keys'
 # Skeleton keys are unique; the dynamic per-client-software rows deliberately
-# share a key by kind (client_version / client_os), so exclude those.
+# share a key by kind, so exclude those. Both the leaves (client_version,
+# client_os) and the containers that group them (client_versions,
+# client_operating_system) repeat: the daemon emits one set per software
+# family, so they collide as soon as two families report a breakdown. Only
+# the leaves were excluded, which held on a node whose peers were all one
+# software and failed the moment a second family appeared.
 _assert_json_eq '[.. | objects | select(has("key")) | .key]
-	| map(select(. != "client_version" and . != "client_os"))
+	| map(select(. != "client_version" and . != "client_os"
+		and . != "client_versions" and . != "client_operating_system"))
 	| (length > 0) and (length == (unique | length))' \
 	true '/stats/tree skeleton keys are present and unique'
 # The ratio node keeps its composite string value for legacy consumers...

--- a/unittests/curl-tests/amuleapi/19-search.sh
+++ b/unittests/curl-tests/amuleapi/19-search.sh
@@ -1530,10 +1530,30 @@ if [ -n "$UNREACHABLE_ECID" ]; then
 			_fail "browse of an uncontactable peer" \
 				"expected finished within 10s, got $DEAD_STATE"
 		fi
-		_curl -H "Authorization: Bearer $ADMIN_TOKEN" \
-			"$HOST/api/v0/search/$DEAD_SID/results?limit=1"
-		_assert_json_eq '.progress.state' finished \
-			'the results endpoint agrees the dead browse is finished'
+		# Poll this endpoint too, rather than reading it once the moment the
+		# LIST flipped. The two answer from different places: GET /search is
+		# a live EC_OP_SEARCH_LIST roundtrip, so it sees the daemon's state
+		# immediately, while the `progress` block here is served from the
+		# snapshot the refresher tick maintains. Between the daemon ending
+		# the browse and the next tick they legitimately disagree, and
+		# asserting straight after the list flipped raced that window --
+		# reproducibly, on a node with LowID peers, where two consecutive
+		# browses read `list=finished results=running`. It settles within a
+		# tick; what would be a real defect is it never settling.
+		DEAD_RESULT_STATE=""
+		for _ in 1 2 3 4 5 6 7 8 9 10; do
+			_curl -H "Authorization: Bearer $ADMIN_TOKEN" \
+				"$HOST/api/v0/search/$DEAD_SID/results?limit=1"
+			DEAD_RESULT_STATE=$(printf '%s' "$CURL_BODY" | jq -r '.progress.state')
+			[ "$DEAD_RESULT_STATE" = "finished" ] && break
+			sleep 1
+		done
+		if [ "$DEAD_RESULT_STATE" = "finished" ]; then
+			_pass "the results endpoint agrees the dead browse is finished"
+		else
+			_fail "dead browse results progress" \
+				"expected finished within 10s, got $DEAD_RESULT_STATE"
+		fi
 
 		# The in-flight flag was cleared with the terminal mark, so the peer
 		# is still browsable rather than joined to a dead browse for good.

--- a/unittests/curl-tests/amuleapi/33-known-clients.sh
+++ b/unittests/curl-tests/amuleapi/33-known-clients.sh
@@ -334,8 +334,13 @@ _cross_check_online() {
 		| jq -r '[.known_clients[] | select(.online == true) | .user_hash] | .[]')
 	[ -z "$online_hashes" ] && { echo "__NONE__"; return; }
 	_curl "$HOST/api/v0/clients?limit=1000"
+	# Flattened to one space-separated line: the membership test below is a
+	# `case` glob looking for " $h ", and jq -r emits one hash per LINE, so a
+	# newline-separated list matched nothing and reported every online hash
+	# as missing. It passed only when exactly one hash was connected, which
+	# is what made the failure look intermittent.
 	connected_hashes=$(printf '%s' "$CURL_BODY" \
-		| jq -r '[.clients[] | select(.connected == true) | .user_hash] | .[]')
+		| jq -r '[.clients[] | select(.connected == true) | .user_hash] | .[]' | tr '\n' ' ')
 	for h in $online_hashes; do
 		case " $connected_hashes " in
 		*" $h "*) ;;
@@ -344,27 +349,42 @@ _cross_check_online() {
 	done
 	echo "$missing"
 }
-# Poll rather than settle once. The two lists are separate requests served
-# from a snapshot the refresher tick maintains, so a peer that disconnects
-# between them shows as online here and unconnected there until the next
-# tick reconciles it. Under full-suite load that tick lags well past a
-# couple of seconds, which a fixed 3s settle did not cover. Passing as soon
-# as the lists agree keeps it quick on an idle node; an inconsistency that
-# never clears still fails, which is the defect worth catching.
-MISMATCH=""
-for _ in $(seq 1 15); do
-	MISMATCH=$(_cross_check_online)
-	[ "$MISMATCH" = "__NONE__" ] && break
-	[ -z "$MISMATCH" ] && break
+# Sample repeatedly and intersect. The two lists come from separate
+# requests, so a peer that disconnects between them is inconsistent for that
+# sample alone and says nothing about the invariant. A hash inconsistent in
+# EVERY sample is not a disconnect in flight, and that is the defect this
+# exists to catch: a record claiming online with no connected peer behind
+# it. The loop exits on the first clean sample, so it costs nothing when the
+# lists agree, which is the normal case.
+PERSISTENT=""
+for i in $(seq 1 8); do
+	SAMPLE=$(_cross_check_online)
+	[ "$SAMPLE" = "__NONE__" ] && { PERSISTENT="__NONE__"; break; }
+	if [ -z "$SAMPLE" ]; then
+		PERSISTENT=""
+		break
+	fi
+	if [ "$i" = "1" ]; then
+		PERSISTENT="$SAMPLE"
+	else
+		KEEP=""
+		for h in $PERSISTENT; do
+			case " $SAMPLE " in
+			*" $h "*) KEEP="$KEEP $h" ;;
+			esac
+		done
+		PERSISTENT="$KEEP"
+		[ -z "$PERSISTENT" ] && break
+	fi
 	sleep 1
 done
-if [ "$MISMATCH" = "__NONE__" ]; then
+if [ "$PERSISTENT" = "__NONE__" ]; then
 	_skip "no known client is online; cannot cross-check against /clients"
-elif [ -z "$MISMATCH" ]; then
+elif [ -z "$PERSISTENT" ]; then
 	_pass "every online known client has a connected /clients counterpart"
 else
 	_fail "known_clients online" \
-		"no connected /clients row for:$MISMATCH (still inconsistent after 15s)"
+		"no connected /clients row for:$PERSISTENT (in every one of 8 samples)"
 fi
 
 echo

--- a/unittests/curl-tests/amuleapi/33-known-clients.sh
+++ b/unittests/curl-tests/amuleapi/33-known-clients.sh
@@ -344,26 +344,27 @@ _cross_check_online() {
 	done
 	echo "$missing"
 }
-FIRST_PASS=$(_cross_check_online)
-if [ "$FIRST_PASS" = "__NONE__" ]; then
+# Poll rather than settle once. The two lists are separate requests served
+# from a snapshot the refresher tick maintains, so a peer that disconnects
+# between them shows as online here and unconnected there until the next
+# tick reconciles it. Under full-suite load that tick lags well past a
+# couple of seconds, which a fixed 3s settle did not cover. Passing as soon
+# as the lists agree keeps it quick on an idle node; an inconsistency that
+# never clears still fails, which is the defect worth catching.
+MISMATCH=""
+for _ in $(seq 1 15); do
+	MISMATCH=$(_cross_check_online)
+	[ "$MISMATCH" = "__NONE__" ] && break
+	[ -z "$MISMATCH" ] && break
+	sleep 1
+done
+if [ "$MISMATCH" = "__NONE__" ]; then
 	_skip "no known client is online; cannot cross-check against /clients"
-elif [ -z "$FIRST_PASS" ]; then
+elif [ -z "$MISMATCH" ]; then
 	_pass "every online known client has a connected /clients counterpart"
 else
-	# Give the tick a moment to settle, then look again.
-	sleep 3
-	SECOND_PASS=$(_cross_check_online)
-	STILL=""
-	for h in $FIRST_PASS; do
-		case " $SECOND_PASS " in
-		*" $h "*) STILL="$STILL $h" ;;
-		esac
-	done
-	if [ -z "$STILL" ]; then
-		_pass "every online known client has a connected /clients counterpart (after a settle)"
-	else
-		_fail "known_clients online" "no connected /clients row for:$STILL (twice)"
-	fi
+	_fail "known_clients online" \
+		"no connected /clients row for:$MISMATCH (still inconsistent after 15s)"
 fi
 
 echo


### PR DESCRIPTION
The curl suite now passes end to end: **43/43 phases, 0 failures**, against a live ed2k-connected daemon with real peers. Three assertions were wrong; none of them is a product defect, and none is visible to CI, which does not run this suite.

## 33-known-clients: the online cross-check compared on the wrong separator

The check built its membership test as a `case` glob looking for `" $h "`, while `jq -r` emits one hash per **line**. A newline-separated list matched nothing, so every record flagged online was reported as having no connected counterpart.

It passed only when exactly one peer was connected - `" a "` matches trivially with no separator in play - or when none was online at all. That is what made it look intermittent, and it is why the assertion has been misreporting since it landed.

Verified against the node that produced the failure: the two hashes it named are in `/clients` with `connected: true` and in `/known_clients` with `online: true`. The phase now passes 42/42.

The sampling loop is kept, because a peer really can disconnect between the two requests and intersecting across samples tells that apart from a record that is genuinely wrong. It exits on the first clean sample, so it costs nothing in the normal case.

## 19-search: the dead-browse progress check raced the refresher tick

The phase polled `GET /search` until the browse reached `finished`, then read `GET /search/{id}/results` once and required it to agree.

The two answer from different places. `GET /search` is a live `EC_OP_SEARCH_LIST` roundtrip, so it sees the daemon immediately; the `progress` block on the results endpoint is served from the snapshot the refresher tick maintains. Between the daemon ending the browse and the next tick they legitimately disagree, and reading the second endpoint the instant the first flipped raced exactly that window - reproducibly, two consecutive browses reading `list=finished results=running`, settling well inside a tick.

The results endpoint now gets the polling the list already had. Never settling still fails, which is the defect worth catching; a bounded lag is not.

The block needs a peer in `download_state: "low_to_low_ip"` and skips when there is none, which is why a node without LowID sources never exercised it.

## 07-read-stats: the uniqueness check excluded the leaves but not their containers

It excluded `client_version` and `client_os`, the per-software leaves that deliberately share a key by kind, but not `client_versions` and `client_operating_system`, the containers grouping them - which the daemon also emits once per software family. Those collide as soon as a second family reports a breakdown. Observed with eMule, MLDonkey, Shareaza and aMule all present.

## Verification

- Full suite: 43/43 phases, 0 failures, 9 skips (all environment-dependent checks that report why).
- Control run for 07 and 19 on the same node and the same binary with only those two scripts reverted to master's version: both fail again. The assertions are what changed the outcome, not node conditions.
- For causation: none of today's merges touched the code these phases exercise - no `HandleSearchResults`, `HandleStatsTree` or `HandleSearchList`, and `RefresherTick.cpp` and `SearchJson.cpp` are untouched. 07 and 19 were long-standing bugs that only manifest on a node with a rich peer population; 33 was introduced with the online work in #1295 and is repaired here.

Shell-only, three files, no C++.
