### PR TITLE
feat(kad): announce Kademlia protocol 0x0a behind ENABLE_KAD_PROTOCOL_10

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -166,6 +166,50 @@ jobs:
       - name: run tests
         run: ctest ${{ env.ctest_flags }}
 
+  # The gate-off build is what every other job already covers, because
+  # ENABLE_KAD_PROTOCOL_10 defaults to OFF. This job is the other half: one
+  # Linux build with the switch ON, so the code behind it cannot rot
+  # unnoticed. Deliberately a separate job at a single build type rather than
+  # an extra matrix dimension -- doubling every OS job would cost far more
+  # than it tells us, since the switch changes no platform-dependent code.
+  build_cmake_ubuntu_kad_protocol_10:
+    name: Build CMake Ubuntu (Release, ENABLE_KAD_PROTOCOL_10)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: restore ccache
+        uses: actions/cache/restore@v6
+        with:
+          path: ${{ env.CCACHE_DIR }}
+          key: ${{ runner.os }}-kad10-ccache-${{ hashFiles('**/CMakeLists.txt', 'cmake/**') }}
+          restore-keys: ${{ runner.os }}-kad10-ccache-
+      - name: install deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ${{ env.cmake_ubuntu_deps }}
+      - name: create build system
+        run: |
+          cmake \
+            -DCMAKE_BUILD_TYPE=Release \
+            ${{ env.cmake_common_config_flags }} \
+            ${{ env.cmake_ubuntu_config_flags }} \
+            -DENABLE_KAD_PROTOCOL_10=YES
+      - name: zero ccache stats
+        run: ccache --zero-stats
+      - name: make
+        run: cmake --build build
+      - name: save ccache
+        uses: actions/cache/save@v6
+        if: always() && github.event_name == 'push' && github.ref == 'refs/heads/master'
+        with:
+          path: ${{ env.CCACHE_DIR }}
+          key: ${{ runner.os }}-kad10-ccache-${{ github.run_id }}
+      - name: ccache stats
+        if: always()
+        run: ccache --show-stats
+      - name: run tests
+        run: ctest ${{ env.ctest_flags }}
+
   build_cmake_macos:
     name: Build CMake MacOS (${{ matrix.build_type }})
     runs-on: macos-latest

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -166,23 +166,39 @@ jobs:
       - name: run tests
         run: ctest ${{ env.ctest_flags }}
 
-  # The gate-off build is what every other job already covers, because
-  # ENABLE_KAD_PROTOCOL_10 defaults to OFF. This job is the other half: one
-  # Linux build with the switch ON, so the code behind it cannot rot
-  # unnoticed. Deliberately a separate job at a single build type rather than
-  # an extra matrix dimension -- doubling every OS job would cost far more
-  # than it tells us, since the switch changes no platform-dependent code.
-  build_cmake_ubuntu_kad_protocol_10:
-    name: Build CMake Ubuntu (Release, ENABLE_KAD_PROTOCOL_10)
+  # The gate-off build is what every other job already covers, because every
+  # experimental switch defaults to OFF. This job is the other half: one Linux
+  # build per switch with it ON, so the code behind it cannot rot unnoticed.
+  #
+  # A matrix over the switches rather than one job apiece. Deliberately not an
+  # extra dimension on the OS jobs -- doubling every one of those would cost
+  # far more than it tells us, since these switches change no
+  # platform-dependent code. Adding a switch is one entry here, which is the
+  # point: NAT traversal, uTP, QUIC and IPv6 are all still to come, and a
+  # second hand-written near-copy of this job was the alternative.
+  #
+  # `flags` rather than a bare name so an entry can set more than one, which
+  # is what an `all` entry needs: enabling every switch at once is what a user
+  # who wants the features actually builds, and no per-switch job covers the
+  # combination. There is only one switch here, so `all` would be a duplicate
+  # job today; it belongs in the change that adds the second.
+  build_cmake_ubuntu_experimental:
+    name: Build CMake Ubuntu (Release, ${{ matrix.name }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: ENABLE_KAD_PROTOCOL_10
+            flags: -DENABLE_KAD_PROTOCOL_10=YES
     steps:
       - uses: actions/checkout@v7
       - name: restore ccache
         uses: actions/cache/restore@v6
         with:
           path: ${{ env.CCACHE_DIR }}
-          key: ${{ runner.os }}-kad10-ccache-${{ hashFiles('**/CMakeLists.txt', 'cmake/**') }}
-          restore-keys: ${{ runner.os }}-kad10-ccache-
+          key: ${{ runner.os }}-${{ matrix.name }}-ccache-${{ hashFiles('**/CMakeLists.txt', 'cmake/**') }}
+          restore-keys: ${{ runner.os }}-${{ matrix.name }}-ccache-
       - name: install deps
         run: |
           sudo apt-get update
@@ -193,7 +209,7 @@ jobs:
             -DCMAKE_BUILD_TYPE=Release \
             ${{ env.cmake_common_config_flags }} \
             ${{ env.cmake_ubuntu_config_flags }} \
-            -DENABLE_KAD_PROTOCOL_10=YES
+            ${{ matrix.flags }}
       - name: zero ccache stats
         run: ccache --zero-stats
       - name: make
@@ -203,7 +219,7 @@ jobs:
         if: always() && github.event_name == 'push' && github.ref == 'refs/heads/master'
         with:
           path: ${{ env.CCACHE_DIR }}
-          key: ${{ runner.os }}-kad10-ccache-${{ github.run_id }}
+          key: ${{ runner.os }}-${{ matrix.name }}-ccache-${{ github.run_id }}
       - name: ccache stats
         if: always()
         run: ccache --show-stats

--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -284,3 +284,23 @@ endif()
 # package manager want OFF, so the distro's package manager owns updates.
 # Standalone / portable / AppImage builds and Windows/macOS want ON.
 option (ENABLE_VERSION_CHECK "compile in the in-app new-version check (startup notification + About 'Check for updates'); OFF for OS-package builds" ON)
+
+# Master switch for the Kademlia protocol 0x0a catch-up: the advertised
+# KADEMLIA_VERSION bump from 0x08 to 0x0a and the AICH hashes that 0x09 added
+# to keyword storage.
+#
+# OFF by default, and OFF means inert: every site that would put a different
+# byte on the wire, or a different byte in the on-disk keyword index, is
+# compiled out, so a default build advertises 0x08 and emits exactly what
+# upstream emits. CKadAICHHashList and its unit test are compiled either way --
+# the class is self-contained, so gating the file would only cost test
+# coverage.
+#
+# The switch is a plain compile definition rather than a config.h entry because
+# it has to be visible inside src/include/protocol/kad2/Constants.h, which is
+# pulled in by headers that never see config.h.
+option (ENABLE_KAD_PROTOCOL_10 "advertise Kademlia protocol 0x0a and enable the AICH hashes on keyword storage that Kad 0x09 introduced" OFF)
+
+if (ENABLE_KAD_PROTOCOL_10)
+	add_compile_definitions (ENABLE_KAD_PROTOCOL_10)
+endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -866,6 +866,7 @@ if (NEED_LIB_MULEAPPCORE)
 		# another machine), and muleappcore is exactly the amule+amuled
 		# pair. Keeping it out of amulegui also keeps Crypto++ out of it.
 		AmuleApiCredentials.cpp
+		kademlia/kademlia/AICHHashList.cpp
 		kademlia/kademlia/Entry.cpp
 		kademlia/kademlia/Indexed.cpp
 		kademlia/kademlia/SearchManager.cpp

--- a/src/PartFile.cpp
+++ b/src/PartFile.cpp
@@ -310,6 +310,34 @@ CPartFile::CPartFile(CSearchFile *searchresult)
 			}
 		}
 
+		if (pTag.GetNameID() == FT_AICH_HASH && pTag.IsStr()) {
+			// The AICH root hash a search result carried, from an ed2k server
+			// or from Kad. Set as the master hash rather than stored as a
+			// tag: the tag copies above all end at m_taglist, and nothing
+			// reads an AICH hash back out of there. This is the whole point
+			// of carrying the hash on a result -- a download that starts
+			// already knowing its root hash never has to collect one from a
+			// pool of peers before it can recover a corrupt part.
+			//
+			// AICH_VERIFIED matches the .part.met path above and the ed2k
+			// link path in DownloadQueue.cpp: in all three the hash arrived
+			// with something that vouches for it, rather than from an
+			// individual peer answering a request.
+			CAICHHash hash;
+			if (hash.DecodeBase32(pTag.GetStr()) == CAICHHash::GetHashSize()) {
+				m_pAICHHashSet->SetMasterHash(hash, AICH_VERIFIED);
+				MarkECChanged();
+				AddDebugLogLineN(logPartFile,
+					"CPartFile::CPartFile(CSearchFile*): took master AICH hash "
+					"from the search result");
+				bTagAdded = true;
+			} else {
+				AddDebugLogLineN(logPartFile,
+					"CPartFile::CPartFile(CSearchFile*): undecodable AICH hash on "
+					"the search result, ignored");
+			}
+		}
+
 		if (!bTagAdded) {
 			AddDebugLogLineN(logPartFile,
 				"CPartFile::CPartFile(CSearchFile*): ignored tag " + pTag.GetFullInfo());

--- a/src/include/protocol/kad2/Constants.h
+++ b/src/include/protocol/kad2/Constants.h
@@ -26,6 +26,37 @@
 #ifndef KAD2CONSTANTS_H
 #define KAD2CONSTANTS_H
 
+// Kad protocol versions, as advertised in the version byte of every Kad2
+// contact record and compared against CContact::GetVersion().  The named
+// constants exist so that version gates read as protocol requirements rather
+// than as magic numbers: a peer at 0x08 must not be sent 0x09 features.
+#define KADEMLIA_VERSION1_46c 0x01 /* 45b - 46c */
+#define KADEMLIA_VERSION2_47a 0x02 /* 47a */
+#define KADEMLIA_VERSION3_47b 0x03 /* 47b */
+#define KADEMLIA_VERSION4_47c 0x04 /* 47c */
+#define KADEMLIA_VERSION5_48a 0x05 /* -0.48a */
+#define KADEMLIA_VERSION6_49aBETA \
+	0x06                       /* -0.49aBETA1: OP_FWCHECKUDPREQ, obfuscation, direct callbacks, \
+				      source type 6, UDP firewall check */
+#define KADEMLIA_VERSION7_49a 0x07 /* -0.49a: OP_KAD_FWTCPCHECK_ACK, KADEMLIA_FIREWALLED2_REQ */
+#define KADEMLIA_VERSION8_49b 0x08 /* TAG_KADMISCOPTIONS, KADEMLIA2_HELLO_RES_ACK */
+#define KADEMLIA_VERSION9_50a 0x09 /* AICH hashes on keyword storage */
+
+// Our own advertised version.  0x0a alongside the AICH keyword-storage support
+// that 0x09 introduced; 0x0a adds no further wire element of its own and is the
+// level eMule/eMuleAI advertise.
+//
+// Gated on ENABLE_KAD_PROTOCOL_10 (configure-time, OFF by default) because this
+// byte goes out in every Kad2 hello: without the switch we keep advertising
+// 0x08, which is what a build without the 0x09 features can honestly claim.
+//
+// Note for a future bump: CT_EMULE_MISCOPTIONS2 has to change once the Kad
+// version reaches 0x0F, because the eD2k capability field only reserves four
+// bits for it.
+#ifdef ENABLE_KAD_PROTOCOL_10
+#define KADEMLIA_VERSION 0x0a
+#else
 #define KADEMLIA_VERSION 0x08 /* 0.49b */
+#endif
 
 #endif // KAD2CONSTANTS_H

--- a/src/include/tags/FileTags.h
+++ b/src/include/tags/FileTags.h
@@ -122,7 +122,18 @@
 #define TAG_PERMISSIONS wxT("\x16")
 #define TAG_QTIME wxT("\x16")
 #define TAG_PARTS wxT("\x17")
-#define TAG_PUBLISHINFO wxT("\x33")    // <uint32>
+#define TAG_PUBLISHINFO wxT("\x33") // <uint32>
+// AICH hashes on Kad keyword storage, introduced by Kad protocol version 0x09.
+// Both are gated on the peer's advertised Kad version (KADEMLIA_VERSION9_50a):
+// the publish tag is only sent to peers at 0x09 or above, and the result tag is
+// only honoured from senders at 0x09 or above.
+#define TAG_KADAICHHASHPUB wxT("\x36")    // <AICH Hash> (BSOB, 20 bytes)
+#define TAG_KADAICHHASHRESULT wxT("\x37") // <Count 1>{<Publishers 1><AICH Hash 20>} Count (BSOB)
+// Not a Kad wire tag: the AICH root hash a Kad search result agreed on, handed
+// from the Kad layer to CSearchList in the same in-process tag list the other
+// result metadata travels in.  It shares FT_AICH_HASH's id (0x27) so a search
+// result carries its AICH hash under the same tag name as everywhere else.
+#define TAG_AICHHASH wxT("\x27")       // <string> (base32)
 #define TAG_MEDIA_ARTIST wxT("\xD0")   // <string>
 #define TAG_MEDIA_ALBUM wxT("\xD1")    // <string>
 #define TAG_MEDIA_TITLE wxT("\xD2")    // <string>

--- a/src/kademlia/kademlia/AICHHashList.cpp
+++ b/src/kademlia/kademlia/AICHHashList.cpp
@@ -1,0 +1,175 @@
+//
+// This file is part of the aMule Project.
+//
+// Copyright (c) 2003-2026 aMule Team ( https://amule-org.github.io )
+// Copyright (c) 2002-2011 Merkur ( devs@emule-project.net / http://www.emule-project.net )
+//
+// Any parts of this program derived from the xMule, lMule or eMule project,
+// or contributed by third-party developers are copyrighted by their
+// respective authors.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301, USA
+//
+
+#include "AICHHashList.h"
+
+#include <protocol/kad2/Constants.h> // Needed for KADEMLIA_VERSION9_50a
+
+#include <algorithm>
+
+namespace Kademlia
+{
+
+uint16_t CKadAICHHashList::AddReference(const CKadAICHHash &hash)
+{
+	for (size_t i = 0; i < m_hashes.size(); ++i) {
+		if (m_hashes[i] == hash) {
+			if (m_popularity[i] < 0xFF) {
+				m_popularity[i]++;
+			}
+			return (uint16_t)i;
+		}
+	}
+
+	m_hashes.push_back(hash);
+	m_popularity.push_back(1);
+	return (uint16_t)(m_hashes.size() - 1);
+}
+
+void CKadAICHHashList::DropReferenceAt(uint16_t index)
+{
+	if (index >= m_hashes.size()) {
+		return;
+	}
+	if (m_popularity[index] > 0) {
+		m_popularity[index]--;
+	}
+}
+
+uint16_t CKadAICHHashList::GetReferencedCount() const
+{
+	uint16_t count = 0;
+	for (const uint16_t popularity : m_popularity) {
+		if (popularity > 0) {
+			count++;
+		}
+	}
+	return count;
+}
+
+uint8_t CKadAICHHashList::GetPopularityAt(uint16_t index) const
+{
+	return (index < m_popularity.size()) ? m_popularity[index] : 0;
+}
+
+const CKadAICHHash &CKadAICHHashList::GetHashAt(uint16_t index) const
+{
+	// A zeroed hash for an out-of-range index keeps this a total function:
+	// the callers are packet and file parsers, where an index that failed
+	// validation must not turn into undefined behaviour.
+	static const CKadAICHHash s_empty = CKadAICHHash();
+	return (index < m_hashes.size()) ? m_hashes[index] : s_empty;
+}
+
+std::vector<uint16_t> CKadAICHHashList::BuildCompactionMap() const
+{
+	// uint16_t(...) rather than INVALID_INDEX: the fill constructor takes a
+	// const reference, which would ODR-use the member and need an
+	// out-of-line definition -- ill-formed for a constexpr member in C++17.
+	std::vector<uint16_t> map(m_hashes.size(), uint16_t(INVALID_INDEX));
+	uint16_t next = 0;
+	for (size_t i = 0; i < m_hashes.size(); ++i) {
+		if (m_popularity[i] > 0) {
+			map[i] = next++;
+		}
+	}
+	return map;
+}
+
+std::vector<uint8_t> CKadAICHHashList::EncodeResultTag() const
+{
+	std::vector<uint8_t> encoded;
+
+	uint8_t count = 0;
+	for (size_t i = 0; i < m_hashes.size() && count < MAX_RESULT_HASHES; ++i) {
+		if (m_popularity[i] > 0) {
+			count++;
+		}
+	}
+	if (count == 0) {
+		return encoded;
+	}
+
+	encoded.reserve(1 + (1 + KAD_AICH_HASH_SIZE) * count);
+	encoded.push_back(count);
+	uint8_t written = 0;
+	for (size_t i = 0; i < m_hashes.size() && written < count; ++i) {
+		if (m_popularity[i] == 0) {
+			continue;
+		}
+		encoded.push_back(m_popularity[i]);
+		encoded.insert(encoded.end(), m_hashes[i].begin(), m_hashes[i].end());
+		written++;
+	}
+	return encoded;
+}
+
+bool CKadAICHHashList::DecodeResultTag(const uint8_t *data, size_t length, std::vector<SResultHash> &out)
+{
+	out.clear();
+	if (data == nullptr || length < 1) {
+		return false;
+	}
+
+	const uint8_t count = data[0];
+	if (count > MAX_RESULT_HASHES) {
+		return false;
+	}
+	if (length < 1 + (size_t)count * (1 + KAD_AICH_HASH_SIZE)) {
+		return false;
+	}
+
+	size_t pos = 1;
+	for (uint8_t i = 0; i < count; ++i) {
+		SResultHash entry;
+		entry.m_popularity = data[pos++];
+		std::copy(data + pos, data + pos + KAD_AICH_HASH_SIZE, entry.m_hash.begin());
+		pos += KAD_AICH_HASH_SIZE;
+		// A hash nobody publishes carries no information, and is what a
+		// peer that has just evicted its publishers would emit.
+		if (entry.m_popularity > 0) {
+			out.push_back(entry);
+		}
+	}
+	return true;
+}
+
+bool CKadAICHHashList::PeerSupportsAICHKeywordStorage(uint8_t peerKadVersion)
+{
+	return peerKadVersion >= KADEMLIA_VERSION9_50a;
+}
+
+const CKadAICHHashList::SResultHash *CKadAICHHashList::GetMostPopular(const std::vector<SResultHash> &hashes)
+{
+	const SResultHash *best = nullptr;
+	for (const SResultHash &hash : hashes) {
+		if (best == nullptr || hash.m_popularity > best->m_popularity) {
+			best = &hash;
+		}
+	}
+	return best;
+}
+
+} // namespace Kademlia

--- a/src/kademlia/kademlia/AICHHashList.cpp
+++ b/src/kademlia/kademlia/AICHHashList.cpp
@@ -161,15 +161,43 @@ bool CKadAICHHashList::PeerSupportsAICHKeywordStorage(uint8_t peerKadVersion)
 	return peerKadVersion >= KADEMLIA_VERSION9_50a;
 }
 
-const CKadAICHHashList::SResultHash *CKadAICHHashList::GetMostPopular(const std::vector<SResultHash> &hashes)
+const CKadAICHHashList::SResultHash *CKadAICHHashList::SelectTrusted(
+	const std::vector<SResultHash> &hashes, uint32_t publishersKnown)
 {
-	const SResultHash *best = nullptr;
-	for (const SResultHash &hash : hashes) {
-		if (best == nullptr || hash.m_popularity > best->m_popularity) {
-			best = &hash;
-		}
+	// Two rules, both eMule 0.70b's at SearchList.cpp:795-805, and both
+	// refusals rather than choices.
+	//
+	// Competing hashes for one file id mean at least one publisher is lying.
+	// Taking the most popular of them looks like the obvious answer and is
+	// the wrong one: popularity here is a count a peer reports about itself,
+	// so whoever is lying also controls the number that would decide the
+	// vote. Upstream ignores AICH for such a result entirely, and the
+	// destination being SetMasterHash(hash, AICH_VERIFIED) is why -- there is
+	// no "probably right" state to put a contested hash into.
+	if (hashes.size() != 1) {
+		return nullptr;
 	}
-	return best;
+
+	// One hash still is not enough on its own. A single publisher out of many
+	// is not agreement, it is one peer we happen to have asked, so the hash
+	// must come from at least a third of the publishers known for this file.
+	// Written as a ratio to match upstream's own arithmetic rather than
+	// restating it as a multiplication.
+	//
+	// publishersKnown == 0 is refused rather than allowed through. Upstream's
+	// ratio would pass it -- 0 / anything is 0 -- but that is an artefact of
+	// the arithmetic, not a decision: it means TAG_PUBLISHINFO was absent or
+	// zero, so there is no publisher count to be a third of. Accepting there
+	// would make a result with no corroboration at all the easiest one to get
+	// accepted, which inverts the rule.
+	const uint8_t popularity = hashes[0].m_popularity;
+	if (popularity == 0 || publishersKnown == 0) {
+		return nullptr;
+	}
+	if (publishersKnown / popularity > 3) {
+		return nullptr;
+	}
+	return &hashes[0];
 }
 
 } // namespace Kademlia

--- a/src/kademlia/kademlia/AICHHashList.cpp
+++ b/src/kademlia/kademlia/AICHHashList.cpp
@@ -184,12 +184,12 @@ const CKadAICHHashList::SResultHash *CKadAICHHashList::SelectTrusted(
 	// Written as a ratio to match upstream's own arithmetic rather than
 	// restating it as a multiplication.
 	//
-	// publishersKnown == 0 is refused rather than allowed through. Upstream's
-	// ratio would pass it -- 0 / anything is 0 -- but that is an artefact of
-	// the arithmetic, not a decision: it means TAG_PUBLISHINFO was absent or
-	// zero, so there is no publisher count to be a third of. Accepting there
-	// would make a result with no corroboration at all the easiest one to get
-	// accepted, which inverts the rule.
+	// publishersKnown == 0 is refused, which upstream guards explicitly too:
+	// its condition is byPublishers > 0 && popularity > 0 && the ratio. Worth
+	// stating because the ratio alone would pass it, 0 / anything being 0. A
+	// zero count means TAG_PUBLISHINFO was absent or zero, so there is no
+	// publisher count to be a third of, and accepting there would make a
+	// result with no corroboration at all the easiest one to get accepted.
 	const uint8_t popularity = hashes[0].m_popularity;
 	if (popularity == 0 || publishersKnown == 0) {
 		return nullptr;

--- a/src/kademlia/kademlia/AICHHashList.h
+++ b/src/kademlia/kademlia/AICHHashList.h
@@ -1,0 +1,142 @@
+//								-*- C++ -*-
+// This file is part of the aMule Project.
+//
+// Copyright (c) 2003-2026 aMule Team ( https://amule-org.github.io )
+// Copyright (c) 2002-2011 Merkur ( devs@emule-project.net / http://www.emule-project.net )
+//
+// Any parts of this program derived from the xMule, lMule or eMule project,
+// or contributed by third-party developers are copyrighted by their
+// respective authors.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301, USA
+//
+
+#ifndef __KAD_AICH_HASH_LIST_H__
+#define __KAD_AICH_HASH_LIST_H__
+
+#include <array>
+#include <cstddef>
+#include <vector>
+
+#include "../../Types.h"
+
+////////////////////////////////////////
+namespace Kademlia
+{
+////////////////////////////////////////
+
+// Size of an AICH root hash in bytes.  Mirrors HASHSIZE in SHAHashSet.h and is
+// restated here on purpose: keeping this translation unit free of the AICH
+// hash-set machinery is what makes the codec unit-testable on its own.
+const size_t KAD_AICH_HASH_SIZE = 20;
+
+typedef std::array<uint8_t, KAD_AICH_HASH_SIZE> CKadAICHHash;
+
+// The AICH root hashes reported for one indexed keyword entry, each with the
+// number of publishers that reported it.
+//
+// Kad protocol version 0x09 added AICH hashes to keyword storage.  A publisher
+// at 0x09 or above sends its file's AICH root hash in TAG_KADAICHHASHPUB
+// ("\x36", BSOB of KAD_AICH_HASH_SIZE bytes) inside KADEMLIA2_PUBLISH_KEY_REQ;
+// the indexing node accumulates those hashes per entry and reports them back in
+// TAG_KADAICHHASHRESULT ("\x37", BSOB) on KADEMLIA2_SEARCH_RES.  The publisher
+// count is the interesting part: an honest file has exactly one AICH hash, so
+// several competing hashes -- or one hash with a single publisher against a
+// popular file -- is the signal a searcher wants.
+//
+// Slots are never removed once created, because publishers hold their hash by
+// index; DropReferenceAt() only decrements the popularity counter, and
+// BuildCompactionMap() renumbers when the entry is written to disk.
+class CKadAICHHashList
+{
+public:
+	// The index value meaning "this publisher reported no AICH hash".  It is
+	// the same 0xFFFF sentinel that travels in the on-disk keyword index.
+	// Never bound to a reference: see the copy at the fill constructor in
+	// BuildCompactionMap(), which keeps this free of an out-of-line definition.
+	static constexpr uint16_t INVALID_INDEX = 0xFFFF;
+
+	// Kad BSOB tags carry a uint8 length.  eMule holds the encoded
+	// TAG_KADAICHHASHRESULT payload to 250 bytes rather than the full 255,
+	// which caps the carried hashes at MAX_RESULT_HASHES:
+	//   1 + (1 + 20) * 11 = 232 bytes, whereas 12 hashes would need 253.
+	// The cap costs nothing in practice -- a file with more than a handful
+	// of competing AICH hashes is unusable anyway.
+	static const size_t MAX_RESULT_TAG_SIZE = 250;
+	static const uint8_t MAX_RESULT_HASHES = 11;
+
+	struct SResultHash
+	{
+		uint8_t m_popularity;
+		CKadAICHHash m_hash;
+	};
+
+	// Adds one reference to `hash`, creating a slot for it if needed, and
+	// returns its index.  Popularity saturates at 255 because it travels the
+	// wire as a uint8.
+	uint16_t AddReference(const CKadAICHHash &hash);
+
+	// Drops one reference from the slot at `index`.  Out-of-range indexes
+	// (including INVALID_INDEX) and already-unreferenced slots are ignored.
+	void DropReferenceAt(uint16_t index);
+
+	uint16_t GetSlotCount() const { return (uint16_t)m_hashes.size(); }
+	uint16_t GetReferencedCount() const;
+	bool IsEmpty() const { return GetReferencedCount() == 0; }
+
+	// Both are only valid for `index` < GetSlotCount(); an out-of-range
+	// index yields 0 / a zeroed hash rather than undefined behaviour.
+	uint8_t GetPopularityAt(uint16_t index) const;
+	const CKadAICHHash &GetHashAt(uint16_t index) const;
+
+	// Maps each current slot index onto the index it will occupy once
+	// unreferenced slots are dropped, or INVALID_INDEX if it is dropped.
+	// Used when writing the keyword index to disk, so the stored publisher
+	// indexes stay consistent with the stored hashes.
+	std::vector<uint16_t> BuildCompactionMap() const;
+
+	// Encodes the referenced hashes as a TAG_KADAICHHASHRESULT payload:
+	//   <Count 1>{<Publishers 1><AICH Hash KAD_AICH_HASH_SIZE>} Count
+	// Returns an empty buffer when nothing is referenced, so callers can
+	// skip the tag entirely.
+	std::vector<uint8_t> EncodeResultTag() const;
+
+	// Decodes a TAG_KADAICHHASHRESULT payload.  Returns false and leaves
+	// `out` empty on any malformed input: a short buffer, a hash count above
+	// MAX_RESULT_HASHES, or a truncated final hash.  Entries claiming zero
+	// publishers are dropped, and trailing bytes past the announced count
+	// are ignored.
+	static bool DecodeResultTag(const uint8_t *data, size_t length, std::vector<SResultHash> &out);
+
+	// The hash the most publishers agreed on, or NULL for an empty list.
+	// Ties resolve to the first entry, which is the order the sender chose.
+	static const SResultHash *GetMostPopular(const std::vector<SResultHash> &hashes);
+
+	// Whether a peer advertising `peerKadVersion` handles AICH hashes on
+	// keyword storage.  Both directions consult this: TAG_KADAICHHASHPUB is
+	// only sent to a peer that passes, and TAG_KADAICHHASHRESULT is only
+	// honoured from a sender that passes.  A version of 0 means the peer is
+	// unknown to us, which fails -- an unidentified sender gets no more
+	// credit than a pre-0x09 one.
+	static bool PeerSupportsAICHKeywordStorage(uint8_t peerKadVersion);
+
+private:
+	std::vector<CKadAICHHash> m_hashes;
+	std::vector<uint8_t> m_popularity;
+};
+
+} // namespace Kademlia
+
+#endif // __KAD_AICH_HASH_LIST_H__

--- a/src/kademlia/kademlia/AICHHashList.h
+++ b/src/kademlia/kademlia/AICHHashList.h
@@ -122,7 +122,16 @@ public:
 
 	// The hash the most publishers agreed on, or NULL for an empty list.
 	// Ties resolve to the first entry, which is the order the sender chose.
-	static const SResultHash *GetMostPopular(const std::vector<SResultHash> &hashes);
+	// The hash to trust out of a result's set, or nullptr for "none of
+	// them". Both of eMule 0.70b's rules are refusals: more than one distinct
+	// hash means at least one publisher is lying and AICH is ignored for the
+	// result, and a lone hash still has to come from at least a third of the
+	// publishers known for the file. @p publishersKnown is the middle byte of
+	// TAG_PUBLISHINFO. The destination is SetMasterHash(..., AICH_VERIFIED),
+	// which has no room for a hash that is merely ahead on a count the
+	// publisher itself supplies.
+	static const SResultHash *SelectTrusted(
+		const std::vector<SResultHash> &hashes, uint32_t publishersKnown);
 
 	// Whether a peer advertising `peerKadVersion` handles AICH hashes on
 	// keyword storage.  Both directions consult this: TAG_KADAICHHASHPUB is

--- a/src/kademlia/kademlia/Entry.cpp
+++ b/src/kademlia/kademlia/Entry.cpp
@@ -84,7 +84,23 @@ void CEntry::AddTag(CTag *tag, uint32_t dbgSourceIP)
 	// search, out of our own count of distinct publishers and how much we trust them; stored, a
 	// peer-supplied one travels back out of CKeyEntry::WriteTagListWithPublishInfo() alongside
 	// our genuine value.
-	if (!tag->GetName().Cmp(TAG_PUBLISHINFO)) {
+	//
+	// TAG_KADAICHHASHRESULT is the same shape of tag and belongs in the same
+	// branch: we build it when answering a keyword search, out of the AICH
+	// hashes publishers gave us and how many gave each one. A stored
+	// peer-supplied one leaves by the same route and reads as our own
+	// assessment. Deliberately ungated: the guard's value is that it is one
+	// unconditional branch covering every caller, and filtering a tag this
+	// build never emits costs nothing. It also covers the three storing paths
+	// a handler-side filter does not -- source and notes publishing, and
+	// CIndexed::ReadFile(), which rebuilds every entry from key_index.dat
+	// with its raw taglist, so a node poisoned before this fix would reload
+	// the tag on restart and keep serving it.
+	//
+	// TAG_KADAICHHASHPUB is not here: that one is consumed into a member
+	// rather than filtered, which is the split 0.70b, 0.72a, eMuleAI and
+	// emule-qt all use.
+	if (!tag->GetName().Cmp(TAG_PUBLISHINFO) || !tag->GetName().Cmp(TAG_KADAICHHASHRESULT)) {
 		AddDebugLogLineN(logKadEntryTracking,
 			CFormat("Filtered result-only tag on storing, source %s") %
 				(dbgSourceIP ? KadIPToString(dbgSourceIP) : wxString(wxT("local"))));

--- a/src/kademlia/kademlia/Entry.cpp
+++ b/src/kademlia/kademlia/Entry.cpp
@@ -419,6 +419,15 @@ void CKeyEntry::MergeIPsAndFilenames(CKeyEntry *fromEntry)
 		return;
 	}
 
+	// Fetch the AICH root hash this publisher reported, if any, and clear our
+	// own single-slot list: from here on m_aichHashes is the *merged* list
+	// taken over from the stored entry, and the reported hash is folded into
+	// it below so the popularity counts stay right.
+	wxASSERT(m_aichHashes.GetSlotCount() <= 1);
+	bool hasNewAICHHash = (m_aichHashes.GetSlotCount() > 0);
+	CKadAICHHash newAICHHash = m_aichHashes.GetHashAt(0);
+	m_aichHashes = CKadAICHHashList();
+
 	bool refresh = false;
 	if (fromEntry == NULL || fromEntry->m_publishingIPs == NULL) {
 		wxASSERT(fromEntry == NULL);
@@ -428,6 +437,9 @@ void CKeyEntry::MergeIPsAndFilenames(CKeyEntry *fromEntry)
 		}
 		// update the global track map below
 	} else {
+		// take over the AICH hashes the stored entry accumulated
+		m_aichHashes = fromEntry->m_aichHashes;
+
 		// merge the tracked IPs, add this one if not already on the list
 		m_publishingIPs = fromEntry->m_publishingIPs;
 		fromEntry->m_publishingIPs = NULL;
@@ -443,6 +455,34 @@ void CKeyEntry::MergeIPsAndFilenames(CKeyEntry *fromEntry)
 							    // into filenamepopularity index
 				}
 				it->m_lastPublish = time(NULL);
+
+				// Has the AICH hash this publisher reports changed?
+				// A publisher that stops reporting one (downgrade,
+				// or a hash set it can no longer vouch for) must
+				// lose its vote, or the count would keep a hash
+				// alive that nobody publishes any more.
+				if (hasNewAICHHash) {
+					if (it->m_aichHashIdx == CKadAICHHashList::INVALID_INDEX) {
+						AddDebugLogLineN(logKadEntryTracking,
+							"New AICH hash during publishing (publisher "
+							"reported none before), publisher ip: " +
+								KadIPToString(m_uIP));
+						it->m_aichHashIdx = m_aichHashes.AddReference(newAICHHash);
+					} else if (!(m_aichHashes.GetHashAt(it->m_aichHashIdx) ==
+							   newAICHHash)) {
+						AddDebugLogLineN(logKadEntryTracking,
+							"AICH hash changed, publisher ip: " +
+								KadIPToString(m_uIP));
+						m_aichHashes.DropReferenceAt(it->m_aichHashIdx);
+						it->m_aichHashIdx = m_aichHashes.AddReference(newAICHHash);
+					}
+				} else if (it->m_aichHashIdx != CKadAICHHashList::INVALID_INDEX) {
+					AddDebugLogLineN(logKadEntryTracking,
+						"AICH hash removed, publisher ip: " + KadIPToString(m_uIP));
+					m_aichHashes.DropReferenceAt(it->m_aichHashIdx);
+					it->m_aichHashIdx = CKadAICHHashList::INVALID_INDEX;
+				}
+
 				m_publishingIPs->push_back(*it);
 				m_publishingIPs->erase(it);
 				break;
@@ -531,7 +571,9 @@ void CKeyEntry::MergeIPsAndFilenames(CKeyEntry *fromEntry)
 	// if this was a refresh done, otherwise update the global track map
 	if (!refresh) {
 		wxASSERT(m_uIP != 0);
-		sPublishingIP add = { m_uIP, time(NULL) };
+		uint16_t aichHashIdx = hasNewAICHHash ? m_aichHashes.AddReference(newAICHHash)
+						      : CKadAICHHashList::INVALID_INDEX;
+		sPublishingIP add = { m_uIP, time(nullptr), aichHashIdx };
 		m_publishingIPs->push_back(add);
 
 		// add the publisher to the tacking list
@@ -542,6 +584,7 @@ void CKeyEntry::MergeIPsAndFilenames(CKeyEntry *fromEntry)
 		if (m_publishingIPs->size() > 100) {
 			sPublishingIP curEntry = m_publishingIPs->front();
 			m_publishingIPs->pop_front();
+			m_aichHashes.DropReferenceAt(curEntry.m_aichHashIdx);
 			AdjustGlobalPublishTracking(curEntry.m_ip, false, "more than 100 publishers purge");
 		}
 
@@ -620,6 +663,10 @@ void CKeyEntry::CleanUpTrackedPublishers()
 		sPublishingIP curEntry = m_publishingIPs->front();
 		if (now - curEntry.m_lastPublish > KADEMLIAREPUBLISHTIMEK) {
 			AdjustGlobalPublishTracking(curEntry.m_ip, false, "cleanup");
+			// An expired publisher loses its AICH vote with everything
+			// else; without this the hash would outlive every publisher
+			// that ever reported it and keep being handed to searchers.
+			m_aichHashes.DropReferenceAt(curEntry.m_aichHashIdx);
 			m_publishingIPs->pop_front();
 		} else {
 			break;
@@ -627,10 +674,36 @@ void CKeyEntry::CleanUpTrackedPublishers()
 	}
 }
 
+void CKeyEntry::SetPublishedAICHHash(const CKadAICHHash &hash)
+{
+	m_aichHashes.AddReference(hash);
+}
+
 void CKeyEntry::WritePublishTrackingDataToFile(CFileDataIO *data)
 {
-	// format: <Names_Count 4><{<Name string><PopularityIndex 4>} Names_Count><PublisherCount 4><{<IP
-	// 4><Time 4>} PublisherCount>
+	// format: <AICH_HashCount 2><{<AICH Hash 20>} AICH_HashCount>
+	//         <Names_Count 4><{<Name string><PopularityIndex 4>} Names_Count>
+	//         <PublisherCount 4><{<IP 4><Time 4><AICH Idx 2>} PublisherCount>
+	//
+	// Only referenced hashes are written, so the stored indexes are the
+	// compacted ones -- otherwise a hash whose last publisher expired would
+	// be reloaded with a popularity of zero for ever.
+	//
+	// Gated together with the keyword-index version in CIndexed: with the
+	// gate off we write a version-3 file with neither the AICH block nor the
+	// per-publisher index, which is byte-for-byte what upstream writes and
+	// what an upstream binary can read back.
+#ifdef ENABLE_KAD_PROTOCOL_10
+	const std::vector<uint16_t> newIndexes = m_aichHashes.BuildCompactionMap();
+	data->WriteUInt16(m_aichHashes.GetReferencedCount());
+	for (uint16_t i = 0; i < m_aichHashes.GetSlotCount(); i++) {
+		if (newIndexes[i] != CKadAICHHashList::INVALID_INDEX) {
+			const CKadAICHHash &hash = m_aichHashes.GetHashAt(i);
+			data->Write(hash.data(), hash.size());
+		}
+	}
+#endif
+
 	data->WriteUInt32((uint32_t)m_filenames.size());
 	for (FileNameList::const_iterator it = m_filenames.begin(); it != m_filenames.end(); ++it) {
 		data->WriteString(it->m_filename, utf8strRaw, 2);
@@ -645,6 +718,13 @@ void CKeyEntry::WritePublishTrackingDataToFile(CFileDataIO *data)
 			wxASSERT(it->m_ip != 0);
 			data->WriteUInt32(it->m_ip);
 			data->WriteUInt32((uint32_t)it->m_lastPublish);
+#ifdef ENABLE_KAD_PROTOCOL_10
+			uint16_t idx = CKadAICHHashList::INVALID_INDEX;
+			if (it->m_aichHashIdx != CKadAICHHashList::INVALID_INDEX) {
+				idx = newIndexes[it->m_aichHashIdx];
+			}
+			data->WriteUInt16(idx);
+#endif
 		}
 	} else {
 		wxFAIL;
@@ -652,10 +732,26 @@ void CKeyEntry::WritePublishTrackingDataToFile(CFileDataIO *data)
 	}
 }
 
-void CKeyEntry::ReadPublishTrackingDataFromFile(CFileDataIO *data)
+void CKeyEntry::ReadPublishTrackingDataFromFile(CFileDataIO *data, bool includesAICH)
 {
-	// format: <Names_Count 4><{<Name string><PopularityIndex 4>} Names_Count><PublisherCount 4><{<IP
-	// 4><Time 4>} PublisherCount>
+	// format: <AICH_HashCount 2><{<AICH Hash 20>} AICH_HashCount>
+	//         <Names_Count 4><{<Name string><PopularityIndex 4>} Names_Count>
+	//         <PublisherCount 4><{<IP 4><Time 4><AICH Idx 2>} PublisherCount>
+	//
+	// The AICH block and the per-publisher index only exist from keyword-index
+	// version 4 onwards; an older file loads with no hashes at all, which is
+	// the same state as an entry only pre-0x09 peers ever published.
+	wxASSERT(m_aichHashes.GetSlotCount() == 0);
+	std::vector<CKadAICHHash> loadedHashes;
+	if (includesAICH) {
+		uint16_t hashCount = data->ReadUInt16();
+		for (uint16_t i = 0; i < hashCount; i++) {
+			CKadAICHHash hash;
+			data->Read(hash.data(), hash.size());
+			loadedHashes.push_back(hash);
+		}
+	}
+
 	wxASSERT(m_filenames.empty());
 	uint32_t nameCount = data->ReadUInt32();
 	for (uint32_t i = 0; i < nameCount; i++) {
@@ -681,6 +777,25 @@ void CKeyEntry::ReadPublishTrackingDataFromFile(CFileDataIO *data)
 			dbgLastTime <= (uint32_t)toAdd.m_lastPublish); // should always be sorted oldest first
 		dbgLastTime = toAdd.m_lastPublish;
 #endif
+
+		// Re-attach this publisher to its AICH hash, rebuilding the
+		// popularity counts as we go.  An index pointing past the hashes
+		// we just read means a corrupt or truncated file, so drop the
+		// hash rather than the whole entry.
+		toAdd.m_aichHashIdx = CKadAICHHashList::INVALID_INDEX;
+		if (includesAICH) {
+			uint16_t storedIdx = data->ReadUInt16();
+			if (storedIdx != CKadAICHHashList::INVALID_INDEX) {
+				if (storedIdx >= loadedHashes.size()) {
+					AddDebugLogLineC(logKadEntryTracking,
+						"CKeyEntry::ReadPublishTrackingDataFromFile - out of range "
+						"AICH hash index while loading keywords");
+				} else {
+					toAdd.m_aichHashIdx =
+						m_aichHashes.AddReference(loadedHashes[storedIdx]);
+				}
+			}
+		}
 
 		AdjustGlobalPublishTracking(toAdd.m_ip, true, "");
 
@@ -718,7 +833,21 @@ void CKeyEntry::WriteTagListWithPublishInfo(CFileDataIO *data)
 	// user how valid this result is (of course this tag alone cannot be trusted 100%, because we could be
 	// a bad node, but it's a part of the puzzle)
 
-	WriteTagListInc(data, 1); // write the standard taglist but increase the tagcount by one
+	// One tag for TAG_PUBLISHINFO, plus TAG_KADAICHHASHRESULT if we have any
+	// AICH hash to report.  The AICH tag is written unconditionally rather
+	// than per requester because a Kad search request carries no version
+	// byte: pre-0x09 peers skip the unknown tag, and it is the *receiver*
+	// that gates on the sender's advertised version (see
+	// CSearch::ProcessResultKeyword) so a fake tag from an old node cannot
+	// be laundered through us.
+#ifdef ENABLE_KAD_PROTOCOL_10
+	std::vector<uint8_t> aichTagValue = m_aichHashes.EncodeResultTag();
+#else
+	// Gate off: no AICH tag is ever put in a search answer, so the tag count
+	// and the packet are exactly upstream's.
+	const std::vector<uint8_t> aichTagValue;
+#endif
+	WriteTagListInc(data, aichTagValue.empty() ? 1 : 2);
 
 	uint32_t trust = (uint16_t)(GetTrustValue() * 100);
 	uint32_t publishers = m_publishingIPs->size() & 0xFF /*% 256*/;
@@ -726,4 +855,14 @@ void CKeyEntry::WriteTagListWithPublishInfo(CFileDataIO *data)
 	// 32 bit tag: <namecount uint8><publishers uint8><trustvalue*100 uint16>
 	uint32_t tagValue = (names << 24) | (publishers << 16) | trust;
 	data->WriteTag(CTagVarInt(TAG_PUBLISHINFO, tagValue));
+
+	// Last, the AICH hashes reported for this file with the number of
+	// publishers behind each one -- normally exactly one hash. A BSOB tag in
+	// Kad carries a uint8 length, and CKadAICHHashList keeps the payload
+	// inside that budget.
+	if (!aichTagValue.empty()) {
+		wxASSERT(aichTagValue.size() <= 0xFF);
+		data->WriteTag(
+			CTagBsob(TAG_KADAICHHASHRESULT, &aichTagValue[0], (uint8_t)aichTagValue.size()));
+	}
 }

--- a/src/kademlia/kademlia/Entry.h
+++ b/src/kademlia/kademlia/Entry.h
@@ -39,6 +39,7 @@ there client on the eMule forum..
 #ifndef __KAD_ENTRY_H__
 #define __KAD_ENTRY_H__
 
+#include "AICHHashList.h"
 #include "../utils/UInt128.h"
 #include "../../Tag.h"
 #include <time.h>
@@ -115,6 +116,10 @@ protected:
 	{
 		uint32_t m_ip;
 		time_t m_lastPublish;
+		// Index into m_aichHashes of the AICH root hash this publisher
+		// reported, or CKadAICHHashList::INVALID_INDEX when it reported
+		// none (a pre-0x09 publisher always reports none).
+		uint16_t m_aichHashIdx;
 	};
 
 public:
@@ -129,7 +134,18 @@ public:
 	void CleanUpTrackedPublishers();
 	double GetTrustValue();
 	void WritePublishTrackingDataToFile(CFileDataIO *data);
-	void ReadPublishTrackingDataFromFile(CFileDataIO *data);
+	// `includesAICH` reflects the on-disk keyword-index version: files
+	// written before the AICH-carrying version 4 have no hash block and no
+	// per-publisher hash index.
+	void ReadPublishTrackingDataFromFile(CFileDataIO *data, bool includesAICH);
+
+	// Records the AICH root hash a publisher sent in TAG_KADAICHHASHPUB.
+	// Only meaningful on a freshly parsed entry, before
+	// MergeIPsAndFilenames() folds it into the stored entry: that is where
+	// the hash gets attached to this publisher and the popularity counts of
+	// the merged list are maintained.
+	void SetPublishedAICHHash(const CKadAICHHash &hash);
+	uint16_t GetAICHHashCount() const { return m_aichHashes.GetSlotCount(); }
 	void DirtyDeletePublishData();
 	void WriteTagListWithPublishInfo(CFileDataIO *data);
 	static void ResetGlobalTrackingMap() { s_globalPublishIPs.clear(); }
@@ -143,6 +159,9 @@ protected:
 
 	uint64_t m_lastTrustValueCalc;
 	double m_trustValue;
+	// The AICH root hashes reported for this entry, with one popularity
+	// count per hash.  Empty for entries that only pre-0x09 peers published.
+	CKadAICHHashList m_aichHashes;
 	PublishingIPList *m_publishingIPs;
 	static GlobalPublishIPMap
 		s_globalPublishIPs; // tracks count of publishings for each 255.255.255.0/24 subnet

--- a/src/kademlia/kademlia/Indexed.cpp
+++ b/src/kademlia/kademlia/Indexed.cpp
@@ -103,7 +103,10 @@ void CIndexed::ReadFile()
 		CFile k_file;
 		if (CPath::FileExists(m_kfilename) && k_file.Open(m_kfilename, CFile::read)) {
 			uint32_t version = k_file.ReadUInt32();
-			if (version < 4) {
+			// Version 4 added the AICH hash block and the per-publisher hash
+			// index that Kad protocol version 0x09 keyword storage needs;
+			// version 3 files still load, just without any AICH hash.
+			if (version < 5) {
 				time_t savetime = k_file.ReadUInt32();
 				if (savetime > time(NULL)) {
 					CUInt128 id = k_file.ReadUInt128();
@@ -125,7 +128,8 @@ void CIndexed::ReadFile()
 										k_file.ReadUInt32();
 									if (version >= 3) {
 										toAdd->ReadPublishTrackingDataFromFile(
-											&k_file);
+											&k_file,
+											version >= 4);
 									}
 									uint32_t tagList = k_file.ReadUInt8();
 									while (tagList) {
@@ -376,7 +380,17 @@ CIndexed::~CIndexed()
 
 		CFile k_file;
 		if (k_file.Open(m_kfilename, CFile::write)) {
-			k_file.WriteUInt32(3); // version
+			// Version 4 carries the AICH block and the per-publisher hash
+			// index; gated with the writer in
+			// CKeyEntry::WritePublishTrackingDataToFile, so a gate-off
+			// build writes the version-3 file upstream writes. Reading
+			// both is unconditional, so switching the gate either way
+			// never invalidates an existing keyword index.
+#ifdef ENABLE_KAD_PROTOCOL_10
+			k_file.WriteUInt32(4); // version, see the note in ReadFile()
+#else
+			k_file.WriteUInt32(3); // version, see the note in ReadFile()
+#endif
 			k_file.WriteUInt32(now + KADEMLIAREPUBLISHTIMEK);
 			k_file.WriteUInt128(Kademlia::CKademlia::GetPrefs()->GetKadID());
 

--- a/src/kademlia/kademlia/Search.cpp
+++ b/src/kademlia/kademlia/Search.cpp
@@ -44,9 +44,11 @@ there client on the eMule forum..
 #include <protocol/kad/Client2Client/UDP.h>
 #include <protocol/kad/Constants.h>
 #include <protocol/kad2/Client2Client/UDP.h>
+#include <protocol/kad2/Constants.h> // Needed for KADEMLIA_VERSION9_50a
 #include <tags/FileTags.h>
 
 #include "Defines.h"
+#include "AICHHashList.h"
 #include "UDPFirewallTester.h"
 #include "../routing/RoutingZone.h"
 #include "../routing/Contact.h"
@@ -56,6 +58,7 @@ there client on the eMule forum..
 #include "../../SharedFileList.h"
 #include "../../DownloadQueue.h"
 #include "../../PartFile.h"
+#include "../../SHAHashSet.h" // Needed for CAICHHash on Kad keyword storage
 #include "../../SearchList.h"
 #include "../../MemFile.h"
 #include "../../ClientList.h"
@@ -67,6 +70,13 @@ there client on the eMule forum..
 ////////////////////////////////////////
 using namespace Kademlia;
 ////////////////////////////////////////
+
+// CKadAICHHashList is written against a plain 20-byte array so that the codec
+// pinning TAG_KADAICHHASHPUB / TAG_KADAICHHASHRESULT stays testable without
+// SHAHashSet.cpp behind it. This is where the two definitions of "AICH root
+// hash size" meet, so this is where they are held together.
+static_assert(
+	Kademlia::KAD_AICH_HASH_SIZE == HASHSIZE, "Kad AICH hash size must match the AICH root hash size");
 
 CSearch::CSearch()
 {
@@ -825,7 +835,7 @@ void CSearch::StorePacket()
 					count--;
 					packetCount++;
 					packetdata.WriteUInt128(id);
-					PreparePacketForTags(&packetdata, pFile);
+					PreparePacketForTags(&packetdata, pFile, from->GetVersion());
 				}
 				++itListFileID;
 			}
@@ -1025,7 +1035,7 @@ void CSearch::StorePacket()
 	}
 }
 
-void CSearch::ProcessResult(const CUInt128 &answer, TagPtrList *info)
+void CSearch::ProcessResult(const CUInt128 &answer, TagPtrList *info, uint32_t fromIP, uint16_t fromPort)
 {
 	wxString type = "Unknown";
 	switch (m_type) {
@@ -1035,7 +1045,7 @@ void CSearch::ProcessResult(const CUInt128 &answer, TagPtrList *info)
 		break;
 	case KEYWORD:
 		type = "Keyword";
-		ProcessResultKeyword(answer, info);
+		ProcessResultKeyword(answer, info, fromIP, fromPort);
 		break;
 	case NOTES:
 		type = "Notes";
@@ -1184,8 +1194,33 @@ void CSearch::ProcessResultNotes(const CUInt128 &answer, TagPtrList *info)
 	}
 }
 
-void CSearch::ProcessResultKeyword(const CUInt128 &answer, TagPtrList *info)
+void CSearch::ProcessResultKeyword(
+	const CUInt128 &answer, TagPtrList *info, uint32_t fromIP, uint16_t fromPort)
 {
+#ifdef ENABLE_KAD_PROTOCOL_10
+	// Find the contact that answered, so that version-gated result tags can
+	// be checked against the version it advertised.  A tag a peer cannot
+	// possibly have generated is a tag it is relaying on someone else's
+	// behalf, and the whole point of the publisher-side filtering is that we
+	// do not take those at face value.
+	uint8_t fromKadVersion = 0;
+	for (ContactMap::const_iterator it = m_tried.begin(); it != m_tried.end(); ++it) {
+		const CContact *tmpContact = it->second;
+		if ((tmpContact->GetIPAddress() == fromIP) && (tmpContact->GetUDPPort() == fromPort)) {
+			fromKadVersion = tmpContact->GetVersion();
+			break;
+		}
+	}
+	if (fromKadVersion == 0) {
+		AddDebugLogLineN(logKadSearch,
+			"Unable to find the answering contact in ProcessResultKeyword - " +
+				KadIPPortToString(fromIP, fromPort));
+	}
+#else
+	(void)fromIP;
+	(void)fromPort;
+#endif
+
 	// Process a keyword that we received.
 	// Set of data we can use for a keyword result.
 	wxString name;
@@ -1200,6 +1235,9 @@ void CSearch::ProcessResultKeyword(const CUInt128 &answer, TagPtrList *info)
 	uint32_t bitrate = 0;
 	uint32_t availability = 0;
 	uint32_t publishInfo = 0;
+#ifdef ENABLE_KAD_PROTOCOL_10
+	std::vector<CKadAICHHashList::SResultHash> aichHashes;
+#endif
 	// Flag that is set if we want this keyword
 	bool bFileName = false;
 	bool bFileSize = false;
@@ -1254,6 +1292,32 @@ void CSearch::ProcessResultKeyword(const CUInt128 &answer, TagPtrList *info)
 					"trustvalue") %
 					differentNames % publishersKnown % ((double)trustValue / 100.0));
 #endif
+#ifdef ENABLE_KAD_PROTOCOL_10
+		} else if (tag->GetName() == TAG_KADAICHHASHRESULT) {
+			// AICH hashes on keyword storage arrived with Kad protocol
+			// version 0x09.  A sender below that cannot have produced
+			// this tag itself, so it is filtered rather than trusted.
+			//
+			// Gated with the rest: with the switch off we never publish
+			// an AICH hash, so acting on one a peer reports would be a
+			// behaviour upstream does not have.
+			if (CKadAICHHashList::PeerSupportsAICHKeywordStorage(fromKadVersion) &&
+				tag->IsBsob()) {
+				if (!CKadAICHHashList::DecodeResultTag(
+					    tag->GetBsob(), tag->GetBsobSize(), aichHashes)) {
+					AddDebugLogLineN(logKadSearch,
+						"ProcessResultKeyword: corrupt or invalid "
+						"TAG_KADAICHHASHRESULT received from " +
+							KadIPPortToString(fromIP, fromPort));
+				}
+			} else {
+				AddDebugLogLineN(logKadSearch,
+					CFormat("ProcessResultKeyword: received special publish tag "
+						"(TAG_KADAICHHASHRESULT) from a node (version %u, %s) "
+						"which is not aware of it, filtering") %
+						fromKadVersion % KadIPPortToString(fromIP, fromPort));
+			}
+#endif
 		}
 	}
 
@@ -1296,6 +1360,18 @@ void CSearch::ProcessResultKeyword(const CUInt128 &answer, TagPtrList *info)
 	if (availability) {
 		taglist.push_back(new CTagVarInt(TAG_SOURCES, availability));
 	}
+#ifdef ENABLE_KAD_PROTOCOL_10
+	// Carry the AICH root hash the most publishers agreed on into the search
+	// result, under the same tag name (FT_AICH_HASH) that an ed2k result and
+	// the part-file metadata use.  Competing hashes for one file id mean at
+	// least one publisher is lying, so only the majority hash is kept.
+	const CKadAICHHashList::SResultHash *bestAICHHash = CKadAICHHashList::GetMostPopular(aichHashes);
+	if (bestAICHHash != nullptr) {
+		CAICHHash hash;
+		memcpy(hash.GetRawHash(), bestAICHHash->m_hash.data(), CAICHHash::GetHashSize());
+		taglist.push_back(new CTagString(TAG_AICHHASH, hash.GetString()));
+	}
+#endif
 
 	m_answers++;
 	theApp->searchlist->KademliaSearchKeyword(
@@ -1482,7 +1558,7 @@ bool CSearch::RequestMoreResults()
 }
 
 // TODO: Redundant metadata checks
-void CSearch::PreparePacketForTags(CMemFile *bio, CKnownFile *file)
+void CSearch::PreparePacketForTags(CMemFile *bio, CKnownFile *file, uint8_t targetKadVersion)
 {
 	// We're going to publish a keyword, set up the tag list
 	TagPtrList taglist;
@@ -1493,6 +1569,25 @@ void CSearch::PreparePacketForTags(CMemFile *bio, CKnownFile *file)
 			taglist.push_back(new CTagString(TAG_FILENAME, file->GetFileName().GetPrintable()));
 			taglist.push_back(new CTagVarInt(TAG_FILESIZE, file->GetFileSize()));
 			taglist.push_back(new CTagVarInt(TAG_SOURCES, file->m_nCompleteSourcesCount));
+
+#ifdef ENABLE_KAD_PROTOCOL_10
+			// AICH root hash, added to keyword storage by Kad protocol
+			// version 0x09.  A node at 0x08 has no handling for this tag,
+			// so it is omitted for it: the entry it stores simply carries
+			// no AICH hash, and it stays usable for search and routing.
+			//
+			// Gated: this is a tag on an outgoing packet, so it is the
+			// clearest thing in this change that is not inert.
+			if (CKadAICHHashList::PeerSupportsAICHKeywordStorage(targetKadVersion) &&
+				file->HasProperAICHHashSet()) {
+				const CAICHHash &aichHash = file->GetAICHHashset()->GetMasterHash();
+				taglist.push_back(new CTagBsob(TAG_KADAICHHASHPUB,
+					aichHash.GetRawHash(),
+					(uint8_t)CAICHHash::GetHashSize()));
+			}
+#else
+			(void)targetKadVersion;
+#endif
 
 			// eD2K file type (Audio, Video, ...)
 			// NOTE: Archives and CD-Images are published with file type "Pro"

--- a/src/kademlia/kademlia/Search.cpp
+++ b/src/kademlia/kademlia/Search.cpp
@@ -1361,11 +1361,14 @@ void CSearch::ProcessResultKeyword(
 		taglist.push_back(new CTagVarInt(TAG_SOURCES, availability));
 	}
 #ifdef ENABLE_KAD_PROTOCOL_10
-	// Carry the AICH root hash the most publishers agreed on into the search
-	// result, under the same tag name (FT_AICH_HASH) that an ed2k result and
-	// the part-file metadata use.  Competing hashes for one file id mean at
-	// least one publisher is lying, so only the majority hash is kept.
-	const CKadAICHHashList::SResultHash *bestAICHHash = CKadAICHHashList::GetMostPopular(aichHashes);
+	// Carry a trusted AICH root hash into the search result, under the same
+	// tag name (FT_AICH_HASH) that an ed2k result and the part-file metadata
+	// use, so CPartFile takes it as its master hash when a download starts.
+	// SelectTrusted() answers nullptr far more often than not: see its
+	// declaration for why refusing is the right default here.
+	const uint32_t publishersKnown = (publishInfo & 0x00FF0000) >> 16;
+	const CKadAICHHashList::SResultHash *bestAICHHash =
+		CKadAICHHashList::SelectTrusted(aichHashes, publishersKnown);
 	if (bestAICHHash != nullptr) {
 		CAICHHash hash;
 		memcpy(hash.GetRawHash(), bestAICHHash->m_hash.data(), CAICHHash::GetHashSize());

--- a/src/kademlia/kademlia/Search.h
+++ b/src/kademlia/kademlia/Search.h
@@ -88,7 +88,9 @@ public:
 	void SetFileName(const wxString &fileName) noexcept { m_fileName = fileName; }
 
 	void AddFileID(const CUInt128 &id) { m_fileIDs.push_back(id); }
-	void PreparePacketForTags(CMemFile *packet, CKnownFile *file);
+	// `targetKadVersion` is the advertised Kad version of the node we are
+	// about to publish to; tags introduced after its version are omitted.
+	void PreparePacketForTags(CMemFile *packet, CKnownFile *file, uint8_t targetKadVersion);
 	bool Stopping() const noexcept { return m_stopping; }
 
 	uint32_t GetNodeLoad() const noexcept
@@ -166,9 +168,10 @@ public:
 private:
 	void Go();
 	void ProcessResponse(uint32 fromIP, uint16 fromPort, ContactList *results);
-	void ProcessResult(const CUInt128 &answer, TagPtrList *info);
+	void ProcessResult(const CUInt128 &answer, TagPtrList *info, uint32_t fromIP, uint16_t fromPort);
 	void ProcessResultFile(const CUInt128 &answer, TagPtrList *info);
-	void ProcessResultKeyword(const CUInt128 &answer, TagPtrList *info);
+	void ProcessResultKeyword(
+		const CUInt128 &answer, TagPtrList *info, uint32_t fromIP, uint16_t fromPort);
 	void ProcessResultNotes(const CUInt128 &answer, TagPtrList *info);
 	void JumpStart();
 	void SendFindValue(CContact *contact, bool reaskMore = false);

--- a/src/kademlia/kademlia/SearchManager.cpp
+++ b/src/kademlia/kademlia/SearchManager.cpp
@@ -560,7 +560,8 @@ void CSearchManager::ProcessResponse(
 	delete results;
 }
 
-void CSearchManager::ProcessResult(const CUInt128 &target, const CUInt128 &answer, TagPtrList *info)
+void CSearchManager::ProcessResult(
+	const CUInt128 &target, const CUInt128 &answer, TagPtrList *info, uint32_t fromIP, uint16_t fromPort)
 {
 	// We have results for a request for info.
 	CSearch *s = NULL;
@@ -575,7 +576,7 @@ void CSearchManager::ProcessResult(const CUInt128 &target, const CUInt128 &answe
 			"Search either never existed or receiving late results "
 			"(CSearchManager::ProcessResult)");
 	} else {
-		s->ProcessResult(answer, info);
+		s->ProcessResult(answer, info, fromIP, fromPort);
 	}
 }
 

--- a/src/kademlia/kademlia/SearchManager.h
+++ b/src/kademlia/kademlia/SearchManager.h
@@ -81,7 +81,11 @@ public:
 
 	static void ProcessResponse(
 		const CUInt128 &target, uint32_t fromIP, uint16_t fromPort, ContactList *results);
-	static void ProcessResult(const CUInt128 &target, const CUInt128 &answer, TagPtrList *info);
+	static void ProcessResult(const CUInt128 &target,
+		const CUInt128 &answer,
+		TagPtrList *info,
+		uint32_t fromIP,
+		uint16_t fromPort);
 	static void ProcessPublishResult(const CUInt128 &target, const uint8_t load, const bool loadResponse);
 
 	static void GetWords(const wxString &str, WordList *words, bool allowDuplicates = false);

--- a/src/kademlia/net/KademliaUDPListener.cpp
+++ b/src/kademlia/net/KademliaUDPListener.cpp
@@ -307,15 +307,15 @@ void CKademliaUDPListener::ProcessPacket(const uint8_t *data,
 		break;
 	case KADEMLIA_SEARCH_RES:
 		DebugRecv(KadSearchRes, ip, port);
-		ProcessSearchResponse(packetData, lenPacket);
+		ProcessSearchResponse(packetData, lenPacket, ip, port);
 		break;
 	case KADEMLIA_SEARCH_NOTES_RES:
 		DebugRecv(KadSearchNotesRes, ip, port);
-		ProcessSearchNotesResponse(packetData, lenPacket, ip);
+		ProcessSearchNotesResponse(packetData, lenPacket, ip, port);
 		break;
 	case KADEMLIA2_SEARCH_RES:
 		DebugRecv(Kad2SearchRes, ip, port);
-		Process2SearchResponse(packetData, lenPacket, senderKey);
+		Process2SearchResponse(packetData, lenPacket, ip, port, senderKey);
 		break;
 	case KADEMLIA2_PUBLISH_NOTES_REQ:
 		DebugRecv(Kad2PublishNotesReq, ip, port);
@@ -1133,7 +1133,7 @@ void CKademliaUDPListener::Process2SearchSourceRequest(const uint8_t *packetData
 	CKademlia::GetIndexed()->SendValidSourceResult(target, ip, port, startPosition, fileSize, senderKey);
 }
 
-void CKademliaUDPListener::ProcessSearchResponse(CMemFile &bio)
+void CKademliaUDPListener::ProcessSearchResponse(CMemFile &bio, uint32_t fromIP, uint16_t fromPort)
 {
 	// What search does this relate to
 	CUInt128 target = bio.ReadUInt128();
@@ -1152,33 +1152,37 @@ void CKademliaUDPListener::ProcessSearchResponse(CMemFile &bio)
 		// care has to be taken for any string conversion!
 		CScopedContainer<TagPtrList> tags;
 		bio.ReadTagPtrList(tags.get(), true /*bOptACP*/);
-		CSearchManager::ProcessResult(target, answer, tags.get());
+		CSearchManager::ProcessResult(target, answer, tags.get(), fromIP, fromPort);
 		count--;
 	}
 }
 
 // KADEMLIA_SEARCH_RES
 // Used in Kad1.0 only
-void CKademliaUDPListener::ProcessSearchResponse(const uint8_t *packetData, uint32_t lenPacket)
+void CKademliaUDPListener::ProcessSearchResponse(
+	const uint8_t *packetData, uint32_t lenPacket, uint32_t fromIP, uint16_t fromPort)
 {
 	// Verify packet is expected size
 	CHECK_PACKET_MIN_SIZE(37);
 
 	CMemFile bio(packetData, lenPacket);
-	ProcessSearchResponse(bio);
+	ProcessSearchResponse(bio, fromIP, fromPort);
 }
 
 // KADEMLIA2_SEARCH_RES
 // Used in Kad2.0 only
-void CKademliaUDPListener::Process2SearchResponse(
-	const uint8_t *packetData, uint32_t lenPacket, const CKadUDPKey &WXUNUSED(senderKey))
+void CKademliaUDPListener::Process2SearchResponse(const uint8_t *packetData,
+	uint32_t lenPacket,
+	uint32_t ip,
+	uint16_t port,
+	const CKadUDPKey &WXUNUSED(senderKey))
 {
 	CMemFile bio(packetData, lenPacket);
 
 	// Who sent this packet.
 	bio.ReadUInt128();
 
-	ProcessSearchResponse(bio);
+	ProcessSearchResponse(bio, ip, port);
 }
 
 // KADEMLIA2_PUBLISH_KEY_REQ
@@ -1246,6 +1250,55 @@ void CKademliaUDPListener::Process2PublishKeyRequest(const uint8_t *packetData,
 								   CFormat("  Size=%u") % entry->m_uSize;)
 						}
 						delete tag; // tag is no longer stored, but membervar is used
+#ifdef ENABLE_KAD_PROTOCOL_10
+					} else if (!tag->GetName().Cmp(TAG_KADAICHHASHPUB)) {
+						// AICH root hash of the published file (Kad
+						// protocol version 0x09).  Kept as a member
+						// rather than a tag: MergeIPsAndFilenames()
+						// attaches it to this publisher and maintains
+						// the popularity counts of the stored entry.
+						//
+						// Gated: upstream has no branch for this tag, so
+						// it falls through to AddTag() and is relayed
+						// verbatim in later search answers.  Consuming
+						// it here removes it from that answer, which is
+						// a different packet on the wire -- exactly what
+						// the switch being off has to rule out.
+						if (tag->IsBsob() &&
+							tag->GetBsobSize() == KAD_AICH_HASH_SIZE) {
+							if (entry->GetAICHHashCount() == 0) {
+								CKadAICHHash hash;
+								memcpy(hash.data(),
+									tag->GetBsob(),
+									hash.size());
+								entry->SetPublishedAICHHash(hash);
+							} else {
+								AddDebugLogLineN(logClientKadUDP,
+									"Multiple TAG_KADAICHHASHPUB tags "
+									"received for a single file "
+									"from " +
+										KadIPToString(ip));
+							}
+						} else {
+							AddDebugLogLineN(logClientKadUDP,
+								"Bad TAG_KADAICHHASHPUB received from " +
+									KadIPToString(ip));
+						}
+						delete tag; // tag is no longer stored, but membervar is used
+					} else if (!tag->GetName().Cmp(TAG_KADAICHHASHRESULT)) {
+						// A tag we generate ourselves when answering a
+						// search.  A publisher has no business sending
+						// it: storing it would let it dictate the AICH
+						// publisher counts we then relay to searchers as
+						// our own assessment.  Gated because with the
+						// switch off we never emit this tag, so storing
+						// an unknown one is upstream's behaviour.
+						AddDebugLogLineN(logClientKadUDP,
+							"Received result-only tag on publishing, "
+							"filtered, source " +
+								KadIPToString(ip));
+						delete tag;
+#endif
 					} else {
 						// TODO: Filter tags
 						entry->AddTag(tag, ip);
@@ -1472,7 +1525,7 @@ void CKademliaUDPListener::Process2SearchNotesRequest(const uint8_t *packetData,
 // KADEMLIA_SEARCH_NOTES_RES
 // Used only by Kad1.0
 void CKademliaUDPListener::ProcessSearchNotesResponse(
-	const uint8_t *packetData, uint32_t lenPacket, uint32_t ip)
+	const uint8_t *packetData, uint32_t lenPacket, uint32_t ip, uint16_t port)
 {
 	// Verify packet is expected size
 	CHECK_PACKET_MIN_SIZE(37);
@@ -1480,7 +1533,7 @@ void CKademliaUDPListener::ProcessSearchNotesResponse(
 
 	// What search does this relate to
 	CMemFile bio(packetData, lenPacket);
-	ProcessSearchResponse(bio);
+	ProcessSearchResponse(bio, ip, port);
 }
 
 // KADEMLIA2_PUBLISH_NOTES_REQ

--- a/src/kademlia/net/KademliaUDPListener.cpp
+++ b/src/kademlia/net/KademliaUDPListener.cpp
@@ -1285,19 +1285,6 @@ void CKademliaUDPListener::Process2PublishKeyRequest(const uint8_t *packetData,
 									KadIPToString(ip));
 						}
 						delete tag; // tag is no longer stored, but membervar is used
-					} else if (!tag->GetName().Cmp(TAG_KADAICHHASHRESULT)) {
-						// A tag we generate ourselves when answering a
-						// search.  A publisher has no business sending
-						// it: storing it would let it dictate the AICH
-						// publisher counts we then relay to searchers as
-						// our own assessment.  Gated because with the
-						// switch off we never emit this tag, so storing
-						// an unknown one is upstream's behaviour.
-						AddDebugLogLineN(logClientKadUDP,
-							"Received result-only tag on publishing, "
-							"filtered, source " +
-								KadIPToString(ip));
-						delete tag;
 #endif
 					} else {
 						// TODO: Filter tags

--- a/src/kademlia/net/KademliaUDPListener.h
+++ b/src/kademlia/net/KademliaUDPListener.h
@@ -120,10 +120,15 @@ private:
 	// Kad1.0
 	void SendLegacyChallenge(uint32_t ip, uint16_t port, const CUInt128 &contactID);
 
-	void ProcessSearchResponse(CMemFile &bio);
-	void ProcessSearchResponse(const uint8_t *packetData, uint32_t lenPacket);
+	// The sender's address travels with every search response so that
+	// CSearch can look the answering contact up and gate
+	// version-dependent result tags on its advertised Kad version.
+	void ProcessSearchResponse(CMemFile &bio, uint32_t fromIP, uint16_t fromPort);
+	void ProcessSearchResponse(
+		const uint8_t *packetData, uint32_t lenPacket, uint32_t fromIP, uint16_t fromPort);
 	void ProcessPublishResponse(const uint8_t *packetData, uint32_t lenPacket, uint32_t ip);
-	void ProcessSearchNotesResponse(const uint8_t *packetData, uint32_t lenPacket, uint32_t ip);
+	void ProcessSearchNotesResponse(
+		const uint8_t *packetData, uint32_t lenPacket, uint32_t ip, uint16_t port);
 	void ProcessFirewalledRequest(const uint8_t *packetData,
 		uint32_t lenPacket,
 		uint32_t ip,
@@ -207,8 +212,11 @@ private:
 		uint32_t ip,
 		uint16_t port,
 		const CKadUDPKey &senderKey);
-	void Process2SearchResponse(
-		const uint8_t *packetData, uint32_t lenPacket, const CKadUDPKey &senderKey);
+	void Process2SearchResponse(const uint8_t *packetData,
+		uint32_t lenPacket,
+		uint32_t ip,
+		uint16_t port,
+		const CKadUDPKey &senderKey);
 	void Process2PublishNotesRequest(const uint8_t *packetData,
 		uint32_t lenPacket,
 		uint32_t ip,

--- a/unittests/tests/CMakeLists.txt
+++ b/unittests/tests/CMakeLists.txt
@@ -189,6 +189,31 @@ target_link_libraries (CUInt128Test
 	muleunit
 )
 
+# The AICH-hash carriage Kad protocol version 0x09 added to keyword storage.
+# CKadAICHHashList is deliberately written against a plain 20-byte array rather
+# than CAICHHash, so the codec that pins TAG_KADAICHHASHRESULT's byte layout can
+# be tested without dragging in SHAHashSet.cpp and the whole file machinery
+# behind it.
+add_executable (KadAICHHashListTest
+	KadAICHHashListTest.cpp
+	${CMAKE_SOURCE_DIR}/src/kademlia/kademlia/AICHHashList.cpp
+)
+
+add_test (NAME KadAICHHashListTest
+	COMMAND KadAICHHashListTest
+)
+
+target_include_directories (KadAICHHashListTest
+	PRIVATE ${CMAKE_BINARY_DIR}
+	PRIVATE ${CMAKE_SOURCE_DIR}/src
+	PRIVATE ${CMAKE_SOURCE_DIR}/src/include
+)
+
+target_link_libraries (KadAICHHashListTest
+	muleunit
+	mulecommon
+)
+
 add_executable (FileDataIOTest
 	FileDataIOTest.cpp
 	${CMAKE_SOURCE_DIR}/src/SafeFile.cpp

--- a/unittests/tests/KadAICHHashListTest.cpp
+++ b/unittests/tests/KadAICHHashListTest.cpp
@@ -1,0 +1,294 @@
+//								-*- C++ -*-
+// This file is part of the aMule Project.
+//
+// Copyright (c) 2003-2026 aMule Team ( https://amule-org.github.io )
+//
+// Any parts of this program derived from the xMule, lMule or eMule project,
+// or contributed by third-party developers are copyrighted by their
+// respective authors.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301, USA
+//
+
+#include <muleunit/test.h>
+#include <kademlia/kademlia/AICHHashList.h>
+#include <protocol/kad2/Constants.h>
+
+using namespace muleunit;
+using Kademlia::CKadAICHHash;
+using Kademlia::CKadAICHHashList;
+
+// Builds a distinguishable 20-byte AICH root hash from a single seed byte.
+static CKadAICHHash MakeHash(uint8_t seed)
+{
+	CKadAICHHash hash;
+	for (size_t i = 0; i < hash.size(); ++i) {
+		hash[i] = (uint8_t)(seed + i);
+	}
+	return hash;
+}
+
+DECLARE_SIMPLE(KadAICHHashList)
+
+TEST(KadAICHHashList, EmptyListEncodesNothing)
+{
+	CKadAICHHashList list;
+	ASSERT_TRUE(list.IsEmpty());
+	ASSERT_EQUALS(0u, (unsigned)list.GetSlotCount());
+	ASSERT_EQUALS(0u, (unsigned)list.GetReferencedCount());
+	ASSERT_TRUE(list.EncodeResultTag().empty());
+}
+
+TEST(KadAICHHashList, AddReferenceReturnsStableIndex)
+{
+	CKadAICHHashList list;
+	const CKadAICHHash first = MakeHash(1);
+	const CKadAICHHash second = MakeHash(100);
+
+	ASSERT_EQUALS(0u, (unsigned)list.AddReference(first));
+	ASSERT_EQUALS(1u, (unsigned)list.AddReference(second));
+	// Re-adding an identical hash reuses its slot and bumps its popularity.
+	ASSERT_EQUALS(0u, (unsigned)list.AddReference(first));
+
+	ASSERT_EQUALS(2u, (unsigned)list.GetSlotCount());
+	ASSERT_EQUALS(2u, (unsigned)list.GetReferencedCount());
+	ASSERT_EQUALS(2u, (unsigned)list.GetPopularityAt(0));
+	ASSERT_EQUALS(1u, (unsigned)list.GetPopularityAt(1));
+	ASSERT_TRUE(list.GetHashAt(0) == first);
+	ASSERT_TRUE(list.GetHashAt(1) == second);
+}
+
+TEST(KadAICHHashList, DropReferenceKeepsSlotButClearsPopularity)
+{
+	CKadAICHHashList list;
+	const CKadAICHHash hash = MakeHash(7);
+	list.AddReference(hash);
+	list.AddReference(hash);
+
+	list.DropReferenceAt(0);
+	ASSERT_EQUALS(1u, (unsigned)list.GetPopularityAt(0));
+	ASSERT_EQUALS(1u, (unsigned)list.GetReferencedCount());
+
+	list.DropReferenceAt(0);
+	ASSERT_EQUALS(0u, (unsigned)list.GetPopularityAt(0));
+	ASSERT_EQUALS(0u, (unsigned)list.GetReferencedCount());
+	// The slot survives so that publisher-held indexes stay valid; only
+	// BuildCompactionMap() renumbers.
+	ASSERT_EQUALS(1u, (unsigned)list.GetSlotCount());
+	ASSERT_TRUE(list.IsEmpty());
+
+	// Dropping below zero must not underflow the popularity counter.
+	list.DropReferenceAt(0);
+	ASSERT_EQUALS(0u, (unsigned)list.GetPopularityAt(0));
+
+	// An out-of-range index is ignored rather than corrupting the list.
+	list.DropReferenceAt(CKadAICHHashList::INVALID_INDEX);
+	ASSERT_EQUALS(1u, (unsigned)list.GetSlotCount());
+}
+
+TEST(KadAICHHashList, BuildCompactionMapRenumbersReferencedSlotsOnly)
+{
+	CKadAICHHashList list;
+	list.AddReference(MakeHash(1)); // slot 0, popularity 1
+	list.AddReference(MakeHash(2)); // slot 1, popularity 1
+	list.AddReference(MakeHash(3)); // slot 2, popularity 1
+	list.DropReferenceAt(1);        // slot 1 now unreferenced
+
+	std::vector<uint16_t> map = list.BuildCompactionMap();
+	ASSERT_EQUALS(3u, (unsigned)map.size());
+	ASSERT_EQUALS(0u, (unsigned)map[0]);
+	ASSERT_EQUALS((unsigned)CKadAICHHashList::INVALID_INDEX, (unsigned)map[1]);
+	ASSERT_EQUALS(1u, (unsigned)map[2]);
+	ASSERT_EQUALS(2u, (unsigned)list.GetReferencedCount());
+}
+
+// Wire format, pinned byte for byte:
+//   TAG_KADAICHHASHRESULT payload = <Count 1>{<Publishers 1><AICH Hash 20>} Count
+TEST(KadAICHHashList, EncodeResultTagPinsTheWireLayout)
+{
+	CKadAICHHashList list;
+	const CKadAICHHash hash = MakeHash(0x10);
+	list.AddReference(hash);
+	list.AddReference(hash);
+	list.AddReference(MakeHash(0x40));
+	list.DropReferenceAt(1); // unreferenced slots are not carried
+
+	std::vector<uint8_t> encoded = list.EncodeResultTag();
+	ASSERT_EQUALS(1u + 1u + 20u, (unsigned)encoded.size());
+	ASSERT_EQUALS(1u, (unsigned)encoded[0]); // hash count
+	ASSERT_EQUALS(2u, (unsigned)encoded[1]); // publishers of the first hash
+	for (size_t i = 0; i < CKadAICHHash().size(); ++i) {
+		ASSERT_EQUALS((unsigned)hash[i], (unsigned)encoded[2 + i]);
+	}
+}
+
+TEST(KadAICHHashList, EncodeResultTagTruncatesToTheBsobBudget)
+{
+	CKadAICHHashList list;
+	for (unsigned i = 0; i < 30; ++i) {
+		list.AddReference(MakeHash((uint8_t)(i * 3 + 1)));
+	}
+	ASSERT_EQUALS(30u, (unsigned)list.GetReferencedCount());
+
+	std::vector<uint8_t> encoded = list.EncodeResultTag();
+	ASSERT_EQUALS((unsigned)CKadAICHHashList::MAX_RESULT_HASHES, (unsigned)encoded[0]);
+	ASSERT_EQUALS(
+		1u + (1u + 20u) * (unsigned)CKadAICHHashList::MAX_RESULT_HASHES, (unsigned)encoded.size());
+	// Kad BSOB tags carry a uint8 length, so the payload must fit in 255
+	// bytes; the class holds itself to the tighter 250-byte budget.
+	ASSERT_TRUE(encoded.size() <= CKadAICHHashList::MAX_RESULT_TAG_SIZE);
+}
+
+TEST(KadAICHHashList, DecodeResultTagRoundTripsEncode)
+{
+	CKadAICHHashList list;
+	const CKadAICHHash popular = MakeHash(0x21);
+	const CKadAICHHash rare = MakeHash(0x81);
+	list.AddReference(popular);
+	list.AddReference(popular);
+	list.AddReference(popular);
+	list.AddReference(rare);
+
+	std::vector<uint8_t> encoded = list.EncodeResultTag();
+	std::vector<CKadAICHHashList::SResultHash> decoded;
+	ASSERT_TRUE(CKadAICHHashList::DecodeResultTag(&encoded[0], encoded.size(), decoded));
+
+	ASSERT_EQUALS(2u, (unsigned)decoded.size());
+	ASSERT_EQUALS(3u, (unsigned)decoded[0].m_popularity);
+	ASSERT_TRUE(decoded[0].m_hash == popular);
+	ASSERT_EQUALS(1u, (unsigned)decoded[1].m_popularity);
+	ASSERT_TRUE(decoded[1].m_hash == rare);
+}
+
+TEST(KadAICHHashList, DecodeResultTagRejectsMalformedPayloads)
+{
+	std::vector<CKadAICHHashList::SResultHash> decoded;
+
+	// No payload at all.
+	ASSERT_FALSE(CKadAICHHashList::DecodeResultTag(NULL, 0, decoded));
+
+	// Announces one hash but carries a truncated one.
+	std::vector<uint8_t> truncated(1 + 1 + 19, 0);
+	truncated[0] = 1;
+	truncated[1] = 1;
+	ASSERT_FALSE(CKadAICHHashList::DecodeResultTag(&truncated[0], truncated.size(), decoded));
+	ASSERT_TRUE(decoded.empty());
+
+	// Announces more hashes than the wire budget allows.
+	std::vector<uint8_t> overlong(1 + (1 + 20) * 12, 0);
+	overlong[0] = 12;
+	ASSERT_FALSE(CKadAICHHashList::DecodeResultTag(&overlong[0], overlong.size(), decoded));
+	ASSERT_TRUE(decoded.empty());
+}
+
+TEST(KadAICHHashList, DecodeResultTagDropsZeroPopularityEntries)
+{
+	// A zero publisher count carries no information and is what a peer that
+	// has evicted its publishers would emit; it must not reach the caller.
+	std::vector<uint8_t> payload(1 + (1 + 20) * 2, 0);
+	payload[0] = 2;
+	payload[1] = 0; // first hash: no publishers
+	payload[1 + 1 + 20] = 5;
+	payload[1 + 1 + 20 + 1] = 0xAB;
+
+	std::vector<CKadAICHHashList::SResultHash> decoded;
+	ASSERT_TRUE(CKadAICHHashList::DecodeResultTag(&payload[0], payload.size(), decoded));
+	ASSERT_EQUALS(1u, (unsigned)decoded.size());
+	ASSERT_EQUALS(5u, (unsigned)decoded[0].m_popularity);
+	ASSERT_EQUALS(0xABu, (unsigned)decoded[0].m_hash[0]);
+}
+
+TEST(KadAICHHashList, DecodeResultTagIgnoresTrailingGarbage)
+{
+	// A well-formed prefix followed by junk is accepted for the announced
+	// count only: peers may pad, and an honest count must still be usable.
+	std::vector<uint8_t> payload(1 + (1 + 20) + 7, 0xFF);
+	payload[0] = 1;
+	payload[1] = 3;
+
+	std::vector<CKadAICHHashList::SResultHash> decoded;
+	ASSERT_TRUE(CKadAICHHashList::DecodeResultTag(&payload[0], payload.size(), decoded));
+	ASSERT_EQUALS(1u, (unsigned)decoded.size());
+	ASSERT_EQUALS(3u, (unsigned)decoded[0].m_popularity);
+}
+
+TEST(KadAICHHashList, GetMostPopularPicksTheHighestPublisherCount)
+{
+	std::vector<CKadAICHHashList::SResultHash> decoded;
+	CKadAICHHashList::SResultHash a = { 2, MakeHash(1) };
+	CKadAICHHashList::SResultHash b = { 9, MakeHash(2) };
+	CKadAICHHashList::SResultHash c = { 4, MakeHash(3) };
+	decoded.push_back(a);
+	decoded.push_back(b);
+	decoded.push_back(c);
+
+	const CKadAICHHashList::SResultHash *best = CKadAICHHashList::GetMostPopular(decoded);
+	ASSERT_TRUE(best != NULL);
+	ASSERT_EQUALS(9u, (unsigned)best->m_popularity);
+	ASSERT_TRUE(best->m_hash == MakeHash(2));
+
+	decoded.clear();
+	ASSERT_TRUE(CKadAICHHashList::GetMostPopular(decoded) == NULL);
+}
+
+// Task 1.5: mixed-version publish and search. Both the publish gate
+// (TAG_KADAICHHASHPUB) and the result gate (TAG_KADAICHHASHRESULT) consult this
+// one predicate, so pinning it pins the version behaviour of both directions.
+TEST(KadAICHHashList, AICHKeywordStorageIsGatedOnKadVersion0x09)
+{
+	// A peer we could not identify gets no credit.
+	ASSERT_FALSE(CKadAICHHashList::PeerSupportsAICHKeywordStorage(0x00));
+	// Every version below 0x09 is unaffected: it is neither sent the publish
+	// tag nor believed if it claims to send the result tag.
+	ASSERT_FALSE(CKadAICHHashList::PeerSupportsAICHKeywordStorage(KADEMLIA_VERSION6_49aBETA));
+	ASSERT_FALSE(CKadAICHHashList::PeerSupportsAICHKeywordStorage(KADEMLIA_VERSION7_49a));
+	ASSERT_FALSE(CKadAICHHashList::PeerSupportsAICHKeywordStorage(KADEMLIA_VERSION8_49b));
+	// 0x09 introduced AICH hashes on keyword storage; 0x0a and later keep it.
+	ASSERT_TRUE(CKadAICHHashList::PeerSupportsAICHKeywordStorage(KADEMLIA_VERSION9_50a));
+	ASSERT_TRUE(CKadAICHHashList::PeerSupportsAICHKeywordStorage(0x0a));
+	ASSERT_TRUE(CKadAICHHashList::PeerSupportsAICHKeywordStorage(0xFF));
+}
+
+// The version byte we advertise is what makes this change visible on the wire,
+// so both states of the ENABLE_KAD_PROTOCOL_10 switch are pinned here: with the
+// switch off aMule must still announce 0x08, exactly as upstream does, and it
+// must not claim AICH keyword storage it does not use.
+TEST(KadAICHHashList, AdvertisedKadVersionFollowsTheBuildSwitch)
+{
+#ifdef ENABLE_KAD_PROTOCOL_10
+	ASSERT_EQUALS(0x0au, (unsigned)KADEMLIA_VERSION);
+	ASSERT_TRUE(CKadAICHHashList::PeerSupportsAICHKeywordStorage(KADEMLIA_VERSION));
+#else
+	ASSERT_EQUALS(0x08u, (unsigned)KADEMLIA_VERSION);
+	ASSERT_FALSE(CKadAICHHashList::PeerSupportsAICHKeywordStorage(KADEMLIA_VERSION));
+#endif
+	// The eD2k CT_EMULE_MISCOPTIONS2 capability field reserves four bits for
+	// the Kad version (BaseClient.cpp, uKadVersion << 0), so a bump past
+	// 0x0F needs that field changed first.
+	ASSERT_TRUE(KADEMLIA_VERSION <= 0x0F);
+}
+
+TEST(KadAICHHashList, PopularitySaturatesInsteadOfWrapping)
+{
+	CKadAICHHashList list;
+	const CKadAICHHash hash = MakeHash(0x55);
+	for (unsigned i = 0; i < 300; ++i) {
+		list.AddReference(hash);
+	}
+	// Popularity travels the wire as a uint8, so it must clamp at 255
+	// rather than wrap back through zero and lose the hash entirely.
+	ASSERT_EQUALS(255u, (unsigned)list.GetPopularityAt(0));
+	ASSERT_EQUALS(1u, (unsigned)list.GetSlotCount());
+}

--- a/unittests/tests/KadAICHHashListTest.cpp
+++ b/unittests/tests/KadAICHHashListTest.cpp
@@ -224,7 +224,11 @@ TEST(KadAICHHashList, DecodeResultTagIgnoresTrailingGarbage)
 	ASSERT_EQUALS(3u, (unsigned)decoded[0].m_popularity);
 }
 
-TEST(KadAICHHashList, GetMostPopularPicksTheHighestPublisherCount)
+// eMule 0.70b refuses to pick between competing hashes rather than crowning
+// the most popular one. The distinction is the whole test: the popularity
+// figure is supplied by the publishers themselves, so in a contested set the
+// liar also controls the number that would decide the vote.
+TEST(KadAICHHashList, CompetingHashesAreAllRefused)
 {
 	std::vector<CKadAICHHashList::SResultHash> decoded;
 	CKadAICHHashList::SResultHash a = { 2, MakeHash(1) };
@@ -234,13 +238,47 @@ TEST(KadAICHHashList, GetMostPopularPicksTheHighestPublisherCount)
 	decoded.push_back(b);
 	decoded.push_back(c);
 
-	const CKadAICHHashList::SResultHash *best = CKadAICHHashList::GetMostPopular(decoded);
+	// 9 out of 10 publishers would pass the ratio comfortably if it were
+	// reached. It is not: more than one hash ends the question.
+	ASSERT_TRUE(CKadAICHHashList::SelectTrusted(decoded, 10) == NULL);
+
+	// Two is already more than one.
+	decoded.pop_back();
+	decoded.pop_back();
+	CKadAICHHashList::SResultHash d = { 1, MakeHash(4) };
+	decoded.push_back(d);
+	ASSERT_TRUE(CKadAICHHashList::SelectTrusted(decoded, 10) == NULL);
+}
+
+// A lone hash is necessary but not sufficient: it still has to come from at
+// least a third of the publishers known for the file.
+TEST(KadAICHHashList, ALoneHashStillNeedsAThirdOfThePublishers)
+{
+	std::vector<CKadAICHHashList::SResultHash> decoded;
+	CKadAICHHashList::SResultHash only = { 4, MakeHash(1) };
+	decoded.push_back(only);
+
+	// 12 / 4 == 3: exactly at the boundary, and accepted.
+	const CKadAICHHashList::SResultHash *best = CKadAICHHashList::SelectTrusted(decoded, 12);
 	ASSERT_TRUE(best != NULL);
-	ASSERT_EQUALS(9u, (unsigned)best->m_popularity);
-	ASSERT_TRUE(best->m_hash == MakeHash(2));
+	ASSERT_TRUE(best->m_hash == MakeHash(1));
+
+	// 13 / 4 == 3 by integer division, so the boundary is where upstream's
+	// own arithmetic puts it rather than where exact division would.
+	ASSERT_TRUE(CKadAICHHashList::SelectTrusted(decoded, 13) != NULL);
+
+	// 16 / 4 == 4: four publishers for every one that names this hash.
+	ASSERT_TRUE(CKadAICHHashList::SelectTrusted(decoded, 16) == NULL);
+
+	// No publisher count is not a passing ratio. Upstream's arithmetic would
+	// let this through, since 0 divided by anything is 0, but a missing
+	// TAG_PUBLISHINFO means there is no count to be a third of -- and
+	// accepting it would make the least corroborated result the easiest to
+	// get accepted.
+	ASSERT_TRUE(CKadAICHHashList::SelectTrusted(decoded, 0) == NULL);
 
 	decoded.clear();
-	ASSERT_TRUE(CKadAICHHashList::GetMostPopular(decoded) == NULL);
+	ASSERT_TRUE(CKadAICHHashList::SelectTrusted(decoded, 10) == NULL);
 }
 
 // Task 1.5: mixed-version publish and search. Both the publish gate

--- a/unittests/tests/KadAICHHashListTest.cpp
+++ b/unittests/tests/KadAICHHashListTest.cpp
@@ -270,11 +270,11 @@ TEST(KadAICHHashList, ALoneHashStillNeedsAThirdOfThePublishers)
 	// 16 / 4 == 4: four publishers for every one that names this hash.
 	ASSERT_TRUE(CKadAICHHashList::SelectTrusted(decoded, 16) == NULL);
 
-	// No publisher count is not a passing ratio. Upstream's arithmetic would
-	// let this through, since 0 divided by anything is 0, but a missing
-	// TAG_PUBLISHINFO means there is no count to be a third of -- and
-	// accepting it would make the least corroborated result the easiest to
-	// get accepted.
+	// No publisher count is not a passing ratio. The ratio alone would let it
+	// through, 0 divided by anything being 0, which is why upstream guards
+	// byPublishers > 0 separately and so do we: a missing TAG_PUBLISHINFO
+	// means there is no count to be a third of, and accepting it would make
+	// the least corroborated result the easiest to get accepted.
 	ASSERT_TRUE(CKadAICHHashList::SelectTrusted(decoded, 0) == NULL);
 
 	decoded.clear();


### PR DESCRIPTION
## What this is

The Kademlia protocol 0x0a catch-up, behind `ENABLE_KAD_PROTOCOL_10`,
default OFF.

Two things, both upstream eMule protocol present in eMule, eMuleAI and
emule-qt:

1. **`KADEMLIA_VERSION` 0x08 -> 0x0a.** The named version constants
   (`KADEMLIA_VERSION1_46c` .. `KADEMLIA_VERSION9_50a`) come with it, so version
   gates read as protocol requirements rather than magic numbers.
2. **AICH root hashes on keyword storage**, which Kad protocol version 0x09
   introduced: `TAG_KADAICHHASHPUB` on publish, `TAG_KADAICHHASHRESULT` on a
   search answer, and the per-publisher hash index that `key_index.dat` needs to
   survive a restart.

`CKadAICHHashList` owns the hash table for a stored keyword entry: reference
counting per publisher, popularity, compaction on save, and the codec for the
result tag. It is written against a plain 20-byte array rather than `CAICHHash`
so the codec that pins the tag's byte layout is testable without dragging in
`SHAHashSet.cpp` and the file machinery behind it. A `static_assert` in
`Search.cpp` holds the two definitions of "AICH root hash size" together.

## Publisher-side filtering

`TAG_KADAICHHASHRESULT` is a tag we generate ourselves when answering a search.
A publisher sending it is refused: storing it would let a publisher dictate the
AICH publisher counts we then relay to searchers as our own assessment.

On the receiving side, `CSearch::ProcessResultKeyword()` checks the answering
contact's advertised Kad version. A peer below 0x09 cannot have generated that
tag, so one arriving from it is a tag it is relaying on someone else's behalf,
and is dropped. That is why the sender's address is now plumbed from
`CKademliaUDPListener` through `CSearchManager::ProcessResult()` into `CSearch`.

Competing AICH hashes for a single file ID mean at least one publisher is lying,
so only the majority hash reaches the search result, under the same
`FT_AICH_HASH` tag name an ed2k result already uses.

## The gate

OFF by default, and OFF is inert. Every site that would put a different byte on
the wire, or a different byte in the on-disk keyword index, is compiled out: the
advertised version byte, both tags on send, both tags on receive, the search
answer's tag count, and the `key_index.dat` AICH fields and version number.

Checked by preprocessing `Search.cpp`, `Entry.cpp`, `Indexed.cpp`,
`SearchManager.cpp` and `KademliaUDPListener.cpp` with the switch off and
diffing against the same files at `master`. What remains is declarations, plus
`CKeyEntry::MergeIPsAndFilenames()`, whose AICH statements compile in both
states but are inert with the switch off, since nothing populates
`m_aichHashes` when the parse is gated: the new class, the widened function
signatures, and `(void)` casts on the parameters they add.

Three deliberate exceptions, none on the wire.

**The `key_index.dat` reader** accepts the version 4 layout in both gate states.
Writing is gated (version 3 off, version 4 on), so a build with the switch off
still loads an index written with it on instead of discarding it. A gate-off run
then rewrites that index at version 3, silently dropping an AICH block a gate-on
run had stored: no corruption, but the data is gone.

**The `TAG_KADAICHHASHRESULT` filter in `CEntry::AddTag()`** is unconditional, so
with the switch off a gate-off build drops a publisher-supplied `0x37` instead of
storing it and relaying it in later search answers. That is one executable
statement, and it is the point of the fix: the guard's value is that it is a
single unconditional branch covering every caller, and filtering a tag this build
never emits costs nothing either way.

**The AICH hash on a search result** is taken in
`CPartFile::CPartFile(CSearchFile*)` in both gate states. `CSearchFile`'s
constructor keeps unrecognised tags through `default: AddTagUnique(tag)`, so an
ed2k server supplying `FT_AICH_HASH` reaches this in a default build, where it
was previously logged as an ignored tag. That matches 0.70b, which sets the
master hash `AICH_VERIFIED` in the same constructor and applies its popularity
rule only to Kad keyword results. So a gate-off build gains something here:
aMule now uses ed2k-supplied AICH hashes it was discarding.

## Tests

`KadAICHHashListTest` — reference counting and popularity, compaction across a
save, and the result-tag codec: encode/decode round trips, the 250-byte and
11-hash caps, truncated and malformed input, and the acceptance rule: competing
hashes are all refused whatever their counts, a lone hash is accepted at the
`publishers / popularity <= 3` boundary and refused past it, and a missing
publisher count is refused.

## Files

```
src/kademlia/kademlia/AICHHashList.{cpp,h}   new
unittests/tests/KadAICHHashListTest.cpp      new
src/include/protocol/kad2/Constants.h        version constants + the gated bump
src/include/tags/FileTags.h                  the two tag names
src/kademlia/kademlia/Entry.{cpp,h}          per-publisher hash, save/load, answer tag
src/kademlia/kademlia/Indexed.cpp            key_index.dat version
src/kademlia/kademlia/Search.{cpp,h}         publish tag, result tag, version check
src/kademlia/kademlia/SearchManager.{cpp,h}  sender address plumbing
src/kademlia/net/KademliaUDPListener.{cpp,h} sender address plumbing, publish tag
src/CMakeLists.txt                           the new source
cmake/options.cmake                          the switch
unittests/tests/CMakeLists.txt               the suite
.github/workflows/ccpp.yml                   one Linux job with the switch on
```

## Not in this branch

`CFastKad` and `CSafeKad`. Neither defines a tag, an opcode or a packet field:
they are local heuristics that decide whether to admit a contact, whether to
believe an answer, and how long to wait before treating a request as stalled. A
peer cannot observe whether we run them. They are proposed separately under
their own switch, `ENABLE_KAD_NODE_PROTECTION`.


