### PR TITLE
fix(kad): refuse a result-only tag arriving on a publish

### DIFF
--- a/src/kademlia/kademlia/Entry.cpp
+++ b/src/kademlia/kademlia/Entry.cpp
@@ -77,6 +77,23 @@ CEntry *CEntry::Copy() const
 	return entry;
 }
 
+void CEntry::AddTag(CTag *tag, uint32_t dbgSourceIP)
+{
+	// Filter tags which are for sending query results only and should never be stored (or even
+	// worse sent within the taglist). TAG_PUBLISHINFO is one we build when answering a keyword
+	// search, out of our own count of distinct publishers and how much we trust them; stored, a
+	// peer-supplied one travels back out of CKeyEntry::WriteTagListWithPublishInfo() alongside
+	// our genuine value.
+	if (!tag->GetName().Cmp(TAG_PUBLISHINFO)) {
+		AddDebugLogLineN(logKadEntryTracking,
+			CFormat("Filtered result-only tag on storing, source %s") %
+				(dbgSourceIP ? KadIPToString(dbgSourceIP) : wxString(wxT("local"))));
+		delete tag;
+		return;
+	}
+	m_taglist.push_back(tag);
+}
+
 bool CEntry::GetIntTagValue(const wxString &tagname, uint64_t &value, bool includeVirtualTags) const
 {
 	for (TagPtrList::const_iterator it = m_taglist.begin(); it != m_taglist.end(); ++it) {

--- a/src/kademlia/kademlia/Entry.h
+++ b/src/kademlia/kademlia/Entry.h
@@ -80,7 +80,8 @@ public:
 	bool GetIntTagValue(const wxString &tagname, uint64_t &value, bool includeVirtualTags = true) const;
 	wxString GetStrTagValue(const wxString &tagname) const;
 
-	void AddTag(CTag *tag) { m_taglist.push_back(tag); }
+	// dbgSourceIP is the peer the tag came from, or 0 when we generated it ourselves.
+	void AddTag(CTag *tag, uint32_t dbgSourceIP);
 	uint32_t GetTagCount() const
 	{
 		return m_taglist.size() + ((m_uSize != 0) ? 1 : 0) + (GetCommonFileName().IsEmpty() ? 0 : 1);

--- a/src/kademlia/kademlia/Indexed.cpp
+++ b/src/kademlia/kademlia/Indexed.cpp
@@ -178,24 +178,28 @@ void CIndexed::ReadFile()
 												toAdd->m_uIP =
 													tag->GetInt();
 												toAdd->AddTag(
-													tag);
+													tag,
+													0);
 											} else if (
 												!tag->GetName()
 													 .Cmp(TAG_SOURCEPORT)) {
 												toAdd->m_uTCPport =
 													tag->GetInt();
 												toAdd->AddTag(
-													tag);
+													tag,
+													0);
 											} else if (
 												!tag->GetName()
 													 .Cmp(TAG_SOURCEUPORT)) {
 												toAdd->m_uUDPport =
 													tag->GetInt();
 												toAdd->AddTag(
-													tag);
+													tag,
+													0);
 											} else {
 												toAdd->AddTag(
-													tag);
+													tag,
+													0);
 											}
 										}
 										tagList--;
@@ -247,21 +251,21 @@ void CIndexed::ReadFile()
 											    TAG_SOURCEIP)) {
 											toAdd->m_uIP =
 												tag->GetInt();
-											toAdd->AddTag(tag);
+											toAdd->AddTag(tag, 0);
 										} else if (
 											!tag->GetName().Cmp(
 												TAG_SOURCEPORT)) {
 											toAdd->m_uTCPport =
 												tag->GetInt();
-											toAdd->AddTag(tag);
+											toAdd->AddTag(tag, 0);
 										} else if (
 											!tag->GetName().Cmp(
 												TAG_SOURCEUPORT)) {
 											toAdd->m_uUDPport =
 												tag->GetInt();
-											toAdd->AddTag(tag);
+											toAdd->AddTag(tag, 0);
 										} else {
-											toAdd->AddTag(tag);
+											toAdd->AddTag(tag, 0);
 										}
 									}
 									tagList--;

--- a/src/kademlia/kademlia/Search.cpp
+++ b/src/kademlia/kademlia/Search.cpp
@@ -1128,10 +1128,10 @@ void CSearch::ProcessResultNotes(const CUInt128 &answer, TagPtrList *info)
 		} else if (!tag->GetName().Cmp(TAG_DESCRIPTION)) {
 			wxString strComment(tag->GetStr());
 			bFilterComment = thePrefs::IsMessageFiltered(strComment);
-			entry->AddTag(tag);
+			entry->AddTag(tag, entry->m_uIP);
 			*it = NULL; // Prevent actual data being freed
 		} else if (!tag->GetName().Cmp(TAG_FILERATING)) {
-			entry->AddTag(tag);
+			entry->AddTag(tag, entry->m_uIP);
 			*it = NULL; // Prevent actual data being freed
 		}
 	}

--- a/src/kademlia/net/KademliaUDPListener.cpp
+++ b/src/kademlia/net/KademliaUDPListener.cpp
@@ -1248,7 +1248,7 @@ void CKademliaUDPListener::Process2PublishKeyRequest(const uint8_t *packetData,
 						delete tag; // tag is no longer stored, but membervar is used
 					} else {
 						// TODO: Filter tags
-						entry->AddTag(tag);
+						entry->AddTag(tag, ip);
 					}
 				}
 				tags--;
@@ -1330,8 +1330,8 @@ void CKademliaUDPListener::Process2PublishSourceRequest(const uint8_t *packetDat
 			if (tag) {
 				if (!tag->GetName().Cmp(TAG_SOURCETYPE)) {
 					if (entry->m_bSource == false) {
-						entry->AddTag(new CTagVarInt(TAG_SOURCEIP, entry->m_uIP));
-						entry->AddTag(tag);
+						entry->AddTag(new CTagVarInt(TAG_SOURCEIP, entry->m_uIP), 0);
+						entry->AddTag(tag, ip);
 						entry->m_bSource = true;
 					} else {
 						// More than one sourcetype tag found.
@@ -1350,7 +1350,7 @@ void CKademliaUDPListener::Process2PublishSourceRequest(const uint8_t *packetDat
 				} else if (!tag->GetName().Cmp(TAG_SOURCEPORT)) {
 					if (entry->m_uTCPport == 0) {
 						entry->m_uTCPport = (uint16_t)tag->GetInt();
-						entry->AddTag(tag);
+						entry->AddTag(tag, ip);
 					} else {
 						// More than one port tag found
 						delete tag;
@@ -1358,7 +1358,7 @@ void CKademliaUDPListener::Process2PublishSourceRequest(const uint8_t *packetDat
 				} else if (!tag->GetName().Cmp(TAG_SOURCEUPORT)) {
 					if (addUDPPortTag && tag->IsInt() && tag->GetInt() != 0) {
 						entry->m_uUDPport = (uint16_t)tag->GetInt();
-						entry->AddTag(tag);
+						entry->AddTag(tag, ip);
 						addUDPPortTag = false;
 					} else {
 						// More than one udp port tag found
@@ -1366,13 +1366,13 @@ void CKademliaUDPListener::Process2PublishSourceRequest(const uint8_t *packetDat
 					}
 				} else {
 					// TODO: Filter tags
-					entry->AddTag(tag);
+					entry->AddTag(tag, ip);
 				}
 			}
 			tags--;
 		}
 		if (addUDPPortTag) {
-			entry->AddTag(new CTagVarInt(TAG_SOURCEUPORT, entry->m_uUDPport));
+			entry->AddTag(new CTagVarInt(TAG_SOURCEUPORT, entry->m_uUDPport), 0);
 		}
 #ifdef __DEBUG__
 		if (!strInfo.IsEmpty()) {
@@ -1532,7 +1532,7 @@ void CKademliaUDPListener::Process2PublishNotesRequest(const uint8_t *packetData
 					delete tag;
 				} else {
 					// TODO: Filter tags
-					entry->AddTag(tag);
+					entry->AddTag(tag, ip);
 				}
 			}
 			tags--;


### PR DESCRIPTION
## What

`TAG_PUBLISHINFO` is a tag aMule generates itself when answering a keyword search: it packs our own count of distinct publishers behind the keyword and how much we trust them. Nothing legitimate sends it on a publish, but every path that stored a peer-supplied taglist stored it unfiltered.

This moves the filter into `CEntry::AddTag()`, which is where eMule 0.70b puts it, so one guard covers all four callers: `Process2PublishKeyRequest()`, `Process2PublishSourceRequest()`, `Process2PublishNotesRequest()` and `CIndexed::ReadFile()`. `AddTag()` now takes the source IP (0.70b's `uDbgSourceIP`) so the drop is logged with the peer that sent the tag.

## Impact

A stored tag is served back out of `CKeyEntry::WriteTagListWithPublishInfo()`, which writes the stored taglist first and appends our genuine tag last. Both aMule's reader (`Search.cpp:1243`) and eMuleAI's are `else if` chains in a loop with no `break`, so the forged value is served **alongside** our genuine one rather than replacing it, and ours is the one that lands. The one path where an injected value stands alone is the empty-`m_publishingIPs` fallback at the top of `WriteTagListWithPublishInfo()` (`Entry.cpp:710` on this branch), which falls back to `WriteTagList()`, appends no genuine tag, and is guarded only by `wxFAIL`.

The reload path is the one that motivated the move: key entries are persisted with their raw taglist (`WriteTagList(&k_file)`, `Indexed.cpp:414` on this branch), so a node poisoned before this lands would reload the tag on restart and keep serving it. `CIndexed::ReadFile()` adds every tag through `CEntry::AddTag()`, so it now goes through the guard.

## Source IP at the call sites

- Peer-supplied tags on the three publish paths pass the sending peer's `ip`.
- `TAG_SOURCEIP` and `TAG_SOURCEUPORT` on the source-publish path are generated by the daemon from values it already holds, not received, so they pass `0`.
- `CIndexed::ReadFile()` passes `0`: the tags come from disk, with no sending peer to name.
- `CSearch::ProcessResultNotes()` passes the note's advertised source IP, the only IP in scope there.

## Not covered

The 0.70b branch filters `TAG_PUBLISHINFO` and `TAG_KADAICHHASHRESULT` together. Only `TAG_PUBLISHINFO` is filtered here: `TAG_KADAICHHASHRESULT` does not exist in this tree and its tag id is not sourceable from it, so adding the name would mean inventing a value. The second half belongs with the change that introduces the tag (#1297), and it is a one-line addition to the same branch.

This does not add tag filtering beyond the result-only case; the `// TODO: Filter tags` comments on the publish paths still stand for everything else.
