### PR TITLE
fix(gui): let the translation place the colon on label/value pairs

### DIFF
--- a/po/amule.pot
+++ b/po/amule.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-04 12:13+0200\n"
+"POT-Creation-Date: 2026-09-05 12:01+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1322,7 +1322,7 @@ msgstr ""
 msgid "%.1f KiB/s"
 msgstr ""
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/muuli_wdr.cpp
 msgid "Name"
 msgstr ""
 
@@ -1330,7 +1330,7 @@ msgstr ""
 msgid "Software"
 msgstr ""
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/muuli_wdr.cpp
 msgid "IP Address"
 msgstr ""
 
@@ -1498,7 +1498,7 @@ msgstr ""
 msgid "File Comments"
 msgstr ""
 
-#: src/CommentDialogLst.cpp src/FriendListCtrl.cpp
+#: src/CommentDialogLst.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
 msgid "Username"
 msgstr ""
 
@@ -1511,7 +1511,7 @@ msgstr ""
 msgid "Rating"
 msgstr ""
 
-#: src/CommentDialogLst.cpp
+#: src/CommentDialogLst.cpp src/muuli_wdr.cpp
 msgid "Comment"
 msgstr ""
 
@@ -3580,10 +3580,6 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
-#: src/muuli_wdr.cpp
-msgid "Name:"
-msgstr ""
-
 #: src/muuli_wdr.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Type"
 msgstr ""
@@ -3673,7 +3669,7 @@ msgid "Availability"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Filter:"
+msgid "Filter"
 msgstr ""
 
 #: src/muuli_wdr.cpp
@@ -3729,6 +3725,10 @@ msgid "Clears completed downloads"
 msgstr ""
 
 #: src/muuli_wdr.cpp
+msgid "Filter:"
+msgstr ""
+
+#: src/muuli_wdr.cpp
 msgid "File sources:"
 msgstr ""
 
@@ -3737,19 +3737,19 @@ msgid "General"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Full Name :"
+msgid "Full Name"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "met-File :"
+msgid "met-File"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Hash :"
+msgid "Hash"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Filesize :"
+msgid "Filesize"
 msgstr ""
 
 #: src/muuli_wdr.cpp src/Statistics.cpp
@@ -3757,43 +3757,39 @@ msgid "Transfer"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Partfilestatus :"
+msgid "Partfilestatus"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Last seen complete :"
+msgid "Last seen complete"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Found Sources :"
+msgid "Found Sources"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Transferring Sources :"
+msgid "Transferring Sources"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Filepart-Count :"
+msgid "Filepart-Count"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Available :"
+msgid "Available"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Datarate :"
+msgid "Datarate"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Download Active Time: "
+msgid "Download Active Time"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Transferred :"
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "Completed Size :"
+msgid "Completed Size"
 msgstr ""
 
 #: src/muuli_wdr.cpp
@@ -3801,15 +3797,15 @@ msgid "Intelligent Corruption Handling"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Lost to corruption :"
+msgid "Lost to corruption"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Gained by compression :"
+msgid "Gained by compression"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Packages saved by I.C.H. :"
+msgid "Packages saved by I.C.H."
 msgstr ""
 
 #: src/muuli_wdr.cpp
@@ -3848,28 +3844,28 @@ msgstr ""
 msgid "Media Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp
-msgid "Length :"
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
+msgid "Length"
+msgstr ""
+
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
+msgid "Bitrate"
+msgstr ""
+
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
+msgid "Codec"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Bitrate :"
+msgid "Artist"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Codec :"
+msgid "Album"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Artist :"
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "Album :"
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "Title :"
+msgid "Title"
 msgstr ""
 
 #: src/muuli_wdr.cpp
@@ -3954,12 +3950,8 @@ msgstr ""
 msgid "Required Information"
 msgstr ""
 
-#: src/muuli_wdr.cpp
-msgid "IP Address :"
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "Port :"
+#: src/muuli_wdr.cpp src/ServerListCtrl.cpp
+msgid "Port"
 msgstr ""
 
 #: src/muuli_wdr.cpp
@@ -3967,11 +3959,7 @@ msgid "Additional Information"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Username :"
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "Userhash :"
+msgid "Userhash"
 msgstr ""
 
 #: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
@@ -4007,43 +3995,27 @@ msgid "Statistics Tree"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Username:"
+msgid "Client software"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Userhash:"
+msgid "Client version"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Client software:"
+msgid "User ID"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Client version:"
-msgstr ""
-
-#: src/muuli_wdr.cpp src/ServerWnd.cpp
-msgid "IP address:"
+msgid "Server IP"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "User ID:"
+msgid "Server name"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Server IP:"
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "Server name:"
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "Obfuscation:"
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "Kad:"
+msgid "Obfuscation"
 msgstr ""
 
 #: src/muuli_wdr.cpp
@@ -4051,31 +4023,31 @@ msgid "Transfers to client"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Current request:"
+msgid "Current request"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Average upload rate:"
+msgid "Average upload rate"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Average download rate:"
+msgid "Average download rate"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Uploaded (session):"
+msgid "Uploaded (session)"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Downloaded (session):"
+msgid "Downloaded (session)"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Uploaded (total):"
+msgid "Uploaded (total)"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Downloaded (total):"
+msgid "Downloaded (total)"
 msgstr ""
 
 #: src/muuli_wdr.cpp
@@ -4083,19 +4055,19 @@ msgid "Scores"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "DL/UP modifier:"
+msgid "DL/UP modifier"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Secure ident:"
+msgid "Secure ident"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Queue rank:"
+msgid "Queue rank"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Queue score:"
+msgid "Queue score"
 msgstr ""
 
 #: src/muuli_wdr.cpp
@@ -4873,15 +4845,11 @@ msgid "Reset any changes made to the preferences."
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Comment :"
+msgid "Incoming Dir"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Incoming Dir :"
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "Change priority for new assigned files :"
+msgid "Change priority for new assigned files"
 msgstr ""
 
 #: src/muuli_wdr.cpp
@@ -4889,7 +4857,7 @@ msgid "Don't change"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Select color for this Category (currently selected) :"
+msgid "Select color for this Category (currently selected)"
 msgstr ""
 
 #: src/muuli_wdr.cpp
@@ -4970,10 +4938,6 @@ msgstr ""
 
 #: src/muuli_wdr.cpp
 msgid "Enter the IP of the node here, using the x.x.x.x format."
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "Port:"
 msgstr ""
 
 #: src/muuli_wdr.cpp
@@ -5238,11 +5202,11 @@ msgid "Enable/disable proxy support"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Proxy type:"
+msgid "Proxy type"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Proxy host:"
+msgid "Proxy host"
 msgstr ""
 
 #: src/muuli_wdr.cpp
@@ -5250,7 +5214,7 @@ msgid "The proxy host name"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Proxy port:"
+msgid "Proxy port"
 msgstr ""
 
 #: src/muuli_wdr.cpp
@@ -5266,15 +5230,7 @@ msgid "Enable/disable username/password authentication"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Username: "
-msgstr ""
-
-#: src/muuli_wdr.cpp
 msgid "The username to use to connect to the proxy"
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "Password:"
 msgstr ""
 
 #: src/muuli_wdr.cpp
@@ -5447,6 +5403,15 @@ msgstr ""
 
 #: src/OtherFunctions.cpp
 msgid "days"
+msgstr ""
+
+#. TRANSLATORS:
+#. Punctuation for a "label: value" pair. %s is the already-translated
+#. label. Place the colon as your language requires -- e.g. "%s :" with a
+#. space in French, "%s:" without one in Russian and English.
+#: src/OtherFunctions.cpp
+#, c-format
+msgid "%s:"
 msgstr ""
 
 #: src/OtherFunctions.cpp
@@ -6570,18 +6535,6 @@ msgid "FileID"
 msgstr ""
 
 #: src/SearchListCtrl.cpp
-msgid "Length"
-msgstr ""
-
-#: src/SearchListCtrl.cpp
-msgid "Bitrate"
-msgstr ""
-
-#: src/SearchListCtrl.cpp
-msgid "Codec"
-msgstr ""
-
-#: src/SearchListCtrl.cpp
 msgid "Expand all"
 msgstr ""
 
@@ -6856,10 +6809,6 @@ msgstr ""
 
 #: src/ServerListCtrl.cpp
 msgid "Server Name"
-msgstr ""
-
-#: src/ServerListCtrl.cpp
-msgid "Port"
 msgstr ""
 
 #: src/ServerListCtrl.cpp
@@ -7146,6 +7095,10 @@ msgstr ""
 #: src/ServerWnd.cpp
 #, c-format
 msgid "Connected to buddy at %s"
+msgstr ""
+
+#: src/ServerWnd.cpp
+msgid "IP address:"
 msgstr ""
 
 #: src/ServerWnd.cpp

--- a/po/ar.po
+++ b/po/ar.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-04 12:13+0200\n"
+"POT-Creation-Date: 2026-09-05 12:01+0200\n"
 "PO-Revision-Date: 2026-09-03 11:00+0000\n"
 "Last-Translator: saleh alhathal <hathalsal@hotmail.com>\n"
 "Language-Team: \n"
@@ -375,8 +375,7 @@ msgstr ""
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr ""
 
-#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
-#: src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
+#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
 msgid "ERROR"
 msgstr ""
 
@@ -656,8 +655,7 @@ msgstr ""
 msgid "Searches"
 msgstr "بحث"
 
-#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/Statistics.cpp
+#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/Statistics.cpp
 msgid "Downloads"
 msgstr "تحميل"
 
@@ -743,9 +741,7 @@ msgstr ""
 msgid "Core"
 msgstr ""
 
-#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#: src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp
-#: src/SourceListCtrl.cpp src/Statistics.cpp
+#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp src/Statistics.cpp
 msgid "Version"
 msgstr "نسخة"
 
@@ -1047,11 +1043,7 @@ msgstr ""
 msgid "The remote core sent inconsistent data for \"%s\" (part status %d, expected %d). The file list may be showing the wrong information; reconnect to clear it."
 msgstr ""
 
-#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp
-#: src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp
-#: src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp
-#: src/Statistics.cpp
+#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp src/Statistics.cpp
 msgid "Unknown"
 msgstr "غير معرف"
 
@@ -1149,8 +1141,7 @@ msgstr "خطأ أثناء اﻹتصال بي%s (%s:%i): %d"
 msgid "Enter Captcha"
 msgstr ""
 
-#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp
-#: src/TransferWnd.cpp
+#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp src/TransferWnd.cpp
 msgid "Category"
 msgstr "صنف"
 
@@ -1311,13 +1302,11 @@ msgstr ""
 msgid "Client Details"
 msgstr "تفاصيل العميل"
 
-#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
-#: src/utils/wxCas/src/onlinesig.cpp
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
 msgid "LowID"
 msgstr "هوية متدنية"
 
-#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
-#: src/utils/wxCas/src/onlinesig.cpp
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
 msgid "HighID"
 msgstr ""
 
@@ -1333,8 +1322,7 @@ msgstr ""
 msgid "Not supported"
 msgstr ""
 
-#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
-#: src/TextClient.cpp
+#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp src/TextClient.cpp
 msgid "Connected"
 msgstr "متصل"
 
@@ -1342,13 +1330,12 @@ msgstr "متصل"
 msgid "Disconnected"
 msgstr "فصل الإتصال"
 
-#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp
-#: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f KiB/s"
 msgstr ""
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/muuli_wdr.cpp
 #, fuzzy
 msgid "Name"
 msgstr "اسم الملف"
@@ -1357,13 +1344,11 @@ msgstr "اسم الملف"
 msgid "Software"
 msgstr ""
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#, fuzzy
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/muuli_wdr.cpp
 msgid "IP Address"
-msgstr "عنوان IP :"
+msgstr "عنوان IP"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Origin"
 msgstr ""
 
@@ -1381,14 +1366,12 @@ msgstr "اخر إستقبال"
 msgid "Sessions"
 msgstr "نسخة"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp
 #, fuzzy
 msgid "Upload Speed"
 msgstr "سرعة-الرفع"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp
 #, fuzzy
 msgid "Download Speed"
 msgstr "سرعة-التحميل"
@@ -1443,13 +1426,11 @@ msgstr[1] ""
 msgid "Files"
 msgstr "ملفات"
 
-#: src/ClientsListCtrl.cpp src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp
-#: src/SourceListCtrl.cpp
+#: src/ClientsListCtrl.cpp src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Uploaded"
 msgstr ""
 
-#: src/ClientsListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientsListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Downloaded"
 msgstr ""
 
@@ -1536,12 +1517,11 @@ msgstr ""
 msgid "File Comments"
 msgstr "ملف تعليقات"
 
-#: src/CommentDialogLst.cpp src/FriendListCtrl.cpp
+#: src/CommentDialogLst.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
 msgid "Username"
 msgstr "اسم مستخدم"
 
-#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp
-#: src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "File Name"
 msgstr "اسم الملف"
 
@@ -1549,7 +1529,7 @@ msgstr "اسم الملف"
 msgid "Rating"
 msgstr "تقيم"
 
-#: src/CommentDialogLst.cpp
+#: src/CommentDialogLst.cpp src/muuli_wdr.cpp
 msgid "Comment"
 msgstr ""
 
@@ -1603,18 +1583,15 @@ msgstr "ذاتي عالي"
 msgid "Very low"
 msgstr "متدني جدا"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Low"
 msgstr "متدني"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Normal"
 msgstr "عادي"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "High"
 msgstr "مرتفع"
 
@@ -1638,13 +1615,11 @@ msgstr "اتصال من خلال خادم"
 msgid "Queue Full"
 msgstr "اﻻنتظار ممتلئ"
 
-#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp
-#: src/muuli_wdr.cpp
+#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp src/muuli_wdr.cpp
 msgid "On Queue"
 msgstr "في اﻻنتظار"
 
-#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp
-#: src/PartFile.cpp src/TransferWnd.cpp
+#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Downloading"
 msgstr "تحميل"
 
@@ -1704,8 +1679,7 @@ msgstr ""
 msgid "Remote Server"
 msgstr ""
 
-#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp
-#: src/TextClient.cpp
+#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp src/TextClient.cpp
 msgid "Kad"
 msgstr ""
 
@@ -1729,8 +1703,7 @@ msgstr ""
 msgid "Search Result"
 msgstr ""
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp
-#: src/TransferWnd.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Completed"
 msgstr "اكمل"
 
@@ -1782,8 +1755,7 @@ msgstr ""
 msgid "Part"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp
-#: src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Size"
 msgstr "حجم"
 
@@ -1791,8 +1763,7 @@ msgstr "حجم"
 msgid "Transferred"
 msgstr "نقل"
 
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
-#: src/SourceListCtrl.cpp
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp src/SourceListCtrl.cpp
 msgid "Speed"
 msgstr "سرعة"
 
@@ -1800,13 +1771,11 @@ msgstr "سرعة"
 msgid "Progress"
 msgstr "تقدم"
 
-#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp
-#: src/SearchListCtrl.cpp
+#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
 msgid "Sources"
 msgstr "مصدر"
 
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp
-#: src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Priority"
 msgstr "أولوية"
 
@@ -1830,9 +1799,7 @@ msgstr "اخر إستقبال"
 msgid "Auto"
 msgstr "ذاتي"
 
-#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/TransferWnd.cpp
-#: src/utils/wxCas/src/wxcasprefs.cpp
+#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/TransferWnd.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Cancel"
 msgstr "إلغاء"
 
@@ -1933,8 +1900,7 @@ msgstr ""
 msgid "File rename"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp
-#: src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f MiB/s"
 msgstr ""
@@ -2705,13 +2671,11 @@ msgstr ""
 msgid "Start aMule automatically when I log in"
 msgstr ""
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
-#: packaging/windows/installer_strings.c
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp packaging/windows/installer_strings.c
 msgid "Register aMule for ed2k:// links"
 msgstr ""
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
-#: packaging/windows/installer_strings.c
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp packaging/windows/installer_strings.c
 msgid "Register aMule for magnet: links"
 msgstr ""
 
@@ -2737,8 +2701,7 @@ msgstr ""
 msgid "Destination folder for downloads"
 msgstr ""
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
-#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Browse"
 msgstr "تصفح"
 
@@ -3184,18 +3147,15 @@ msgstr "اكتمال"
 msgid "Complete"
 msgstr "اكتمل"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
-#: src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Paused"
 msgstr "ايقاف مؤقت"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
-#: src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Erroneous"
 msgstr "خاطئ"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
-#: src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Waiting"
 msgstr "انتظار"
 
@@ -3359,8 +3319,7 @@ msgstr "اغلق"
 msgid "Cut"
 msgstr ""
 
-#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp
-#: src/utils/aLinkCreator/src/alcframe.cpp
+#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy"
 msgstr ""
 
@@ -3368,8 +3327,7 @@ msgstr ""
 msgid "Paste"
 msgstr ""
 
-#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp
-#: src/utils/aLinkCreator/src/alcframe.cpp
+#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Clear"
 msgstr "واضح"
 
@@ -3377,8 +3335,7 @@ msgstr "واضح"
 msgid "Select All"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
-#: src/StatisticsDlg.cpp
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp src/StatisticsDlg.cpp
 msgid "KiB/s"
 msgstr ""
 
@@ -3638,10 +3595,6 @@ msgstr ""
 msgid "Search"
 msgstr "بحث"
 
-#: src/muuli_wdr.cpp
-msgid "Name:"
-msgstr ""
-
 #: src/muuli_wdr.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Type"
 msgstr "نوع"
@@ -3731,8 +3684,9 @@ msgid "Availability"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Filter:"
-msgstr ""
+#, fuzzy
+msgid "Filter"
+msgstr "تم ترشيح : %i"
 
 #: src/muuli_wdr.cpp
 msgid "Invert Result"
@@ -3789,6 +3743,10 @@ msgid "Clears completed downloads"
 msgstr ""
 
 #: src/muuli_wdr.cpp
+msgid "Filter:"
+msgstr ""
+
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "File sources:"
 msgstr "ايجاد المصدر :"
@@ -3798,79 +3756,77 @@ msgid "General"
 msgstr "عام"
 
 #: src/muuli_wdr.cpp
-msgid "Full Name :"
-msgstr "اﻻسم كامل :"
+msgid "Full Name"
+msgstr "اﻻسم كامل"
 
 #: src/muuli_wdr.cpp
-msgid "met-File :"
+#, fuzzy
+msgid "met-File"
+msgstr "ملفات"
+
+#: src/muuli_wdr.cpp
+msgid "Hash"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Hash :"
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "Filesize :"
-msgstr "حجم الملف :"
+msgid "Filesize"
+msgstr "حجم الملف"
 
 #: src/muuli_wdr.cpp src/Statistics.cpp
 msgid "Transfer"
 msgstr "نقل"
 
 #: src/muuli_wdr.cpp
-msgid "Partfilestatus :"
-msgstr "حالة جزء الملف :"
+msgid "Partfilestatus"
+msgstr "حالة جزء الملف"
 
 #: src/muuli_wdr.cpp
-msgid "Last seen complete :"
-msgstr "اخر مرة تم اكتمال :"
+msgid "Last seen complete"
+msgstr "اخر مرة تم اكتمال"
 
 #: src/muuli_wdr.cpp
-msgid "Found Sources :"
-msgstr "ايجاد المصدر :"
+msgid "Found Sources"
+msgstr "ايجاد المصدر"
 
 #: src/muuli_wdr.cpp
-msgid "Transferring Sources :"
-msgstr "نقل المصدر :"
+msgid "Transferring Sources"
+msgstr "نقل المصدر"
 
 #: src/muuli_wdr.cpp
-msgid "Filepart-Count :"
-msgstr "احصاء اجزاء الملف :"
+msgid "Filepart-Count"
+msgstr "احصاء اجزاء الملف"
 
 #: src/muuli_wdr.cpp
-msgid "Available :"
-msgstr "متوفر :"
+msgid "Available"
+msgstr "متوفر"
 
 #: src/muuli_wdr.cpp
-msgid "Datarate :"
-msgstr "نسبة المصادر :"
+msgid "Datarate"
+msgstr "نسبة المصادر"
 
 #: src/muuli_wdr.cpp
-msgid "Download Active Time: "
-msgstr ""
+#, fuzzy
+msgid "Download Active Time"
+msgstr "سرعة-التحميل"
 
 #: src/muuli_wdr.cpp
-msgid "Transferred :"
-msgstr "محول :"
-
-#: src/muuli_wdr.cpp
-msgid "Completed Size :"
-msgstr "حجم المكمل :"
+msgid "Completed Size"
+msgstr "حجم المكمل"
 
 #: src/muuli_wdr.cpp
 msgid "Intelligent Corruption Handling"
 msgstr "معالجة الفاسد بذكاء"
 
 #: src/muuli_wdr.cpp
-msgid "Lost to corruption :"
-msgstr "فقد بسبب فساد :"
+msgid "Lost to corruption"
+msgstr "فقد بسبب فساد"
 
 #: src/muuli_wdr.cpp
-msgid "Gained by compression :"
-msgstr "أكتسب بواسطة الضغط :"
+msgid "Gained by compression"
+msgstr "أكتسب بواسطة الضغط"
 
 #: src/muuli_wdr.cpp
-msgid "Packages saved by I.C.H. :"
+msgid "Packages saved by I.C.H."
 msgstr ""
 
 #: src/muuli_wdr.cpp
@@ -3911,30 +3867,30 @@ msgstr "رفع نشط"
 msgid "Media Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp
-msgid "Length :"
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
+msgid "Length"
 msgstr ""
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
 #, fuzzy
-msgid "Bitrate :"
+msgid "Bitrate"
 msgstr "غير مقيم"
 
-#: src/muuli_wdr.cpp
-msgid "Codec :"
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
+msgid "Codec"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Artist :"
+msgid "Artist"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Album :"
+msgid "Album"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Title :"
-msgstr "عنوان :"
+msgid "Title"
+msgstr "عنوان"
 
 #: src/muuli_wdr.cpp
 msgid "File Names"
@@ -4018,25 +3974,18 @@ msgstr ""
 msgid "Required Information"
 msgstr "مطلوب معلومات"
 
-#: src/muuli_wdr.cpp
-msgid "IP Address :"
-msgstr "عنوان IP :"
-
-#: src/muuli_wdr.cpp
-msgid "Port :"
-msgstr "منفذ :"
+#: src/muuli_wdr.cpp src/ServerListCtrl.cpp
+msgid "Port"
+msgstr "منفذ"
 
 #: src/muuli_wdr.cpp
 msgid "Additional Information"
 msgstr "معلومت إضافية"
 
 #: src/muuli_wdr.cpp
-msgid "Username :"
-msgstr "اسم المستخدم :"
-
-#: src/muuli_wdr.cpp
-msgid "Userhash :"
-msgstr ""
+#, fuzzy
+msgid "Userhash"
+msgstr "مستخدمين"
 
 #: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Add"
@@ -4071,43 +4020,31 @@ msgid "Statistics Tree"
 msgstr "شجرة اﻻحصائيات"
 
 #: src/muuli_wdr.cpp
-msgid "Username:"
-msgstr "اسم المستخدم:"
+#, fuzzy
+msgid "Client software"
+msgstr "عميل"
 
 #: src/muuli_wdr.cpp
-msgid "Userhash:"
-msgstr ""
+#, fuzzy
+msgid "Client version"
+msgstr "عميل"
 
 #: src/muuli_wdr.cpp
-msgid "Client software:"
-msgstr ""
+#, fuzzy
+msgid "User ID"
+msgstr "مستخدمين: 0"
 
 #: src/muuli_wdr.cpp
-msgid "Client version:"
-msgstr ""
-
-#: src/muuli_wdr.cpp src/ServerWnd.cpp
-msgid "IP address:"
-msgstr ""
+msgid "Server IP"
+msgstr "عنوان الخادم"
 
 #: src/muuli_wdr.cpp
-msgid "User ID:"
-msgstr ""
+#, fuzzy
+msgid "Server name"
+msgstr "إسم الخادم"
 
 #: src/muuli_wdr.cpp
-msgid "Server IP:"
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "Server name:"
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "Obfuscation:"
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "Kad:"
+msgid "Obfuscation"
 msgstr ""
 
 #: src/muuli_wdr.cpp
@@ -4115,53 +4052,61 @@ msgid "Transfers to client"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Current request:"
-msgstr ""
+#, fuzzy
+msgid "Current request"
+msgstr "الحالي"
 
 #: src/muuli_wdr.cpp
-msgid "Average upload rate:"
-msgstr ""
+#, fuzzy
+msgid "Average upload rate"
+msgstr "متوسط زمن التحميل : %s"
 
 #: src/muuli_wdr.cpp
-msgid "Average download rate:"
-msgstr ""
+#, fuzzy
+msgid "Average download rate"
+msgstr "متوسط زمن التحميل : %s"
 
 #: src/muuli_wdr.cpp
-msgid "Uploaded (session):"
-msgstr ""
+#, fuzzy
+msgid "Uploaded (session)"
+msgstr "معدل رفع الجلسة"
 
 #: src/muuli_wdr.cpp
-msgid "Downloaded (session):"
-msgstr ""
+#, fuzzy
+msgid "Downloaded (session)"
+msgstr "معدل تحميل الجلسة"
 
 #: src/muuli_wdr.cpp
-msgid "Uploaded (total):"
-msgstr ""
+#, fuzzy
+msgid "Uploaded (total)"
+msgstr "الرفع"
 
 #: src/muuli_wdr.cpp
-msgid "Downloaded (total):"
-msgstr ""
+#, fuzzy
+msgid "Downloaded (total)"
+msgstr "تحميل (%i)"
 
 #: src/muuli_wdr.cpp
 msgid "Scores"
 msgstr "مصدر"
 
 #: src/muuli_wdr.cpp
-msgid "DL/UP modifier:"
+msgid "DL/UP modifier"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Secure ident:"
+msgid "Secure ident"
 msgstr ""
 
 #: src/muuli_wdr.cpp
 #, fuzzy
-msgid "Queue rank:"
+msgid "Queue rank"
 msgstr "اﻻنتظار ممتلئ"
 
 #: src/muuli_wdr.cpp
-msgid "Queue score:"
-msgstr ""
+#, fuzzy
+msgid "Queue score"
+msgstr "اﻻنتظار ممتلئ"
 
 #: src/muuli_wdr.cpp
 msgid "Nick"
@@ -4942,16 +4887,12 @@ msgid "Reset any changes made to the preferences."
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Comment :"
-msgstr "تعليق :"
-
-#: src/muuli_wdr.cpp
-msgid "Incoming Dir :"
+msgid "Incoming Dir"
 msgstr "مجلد القادم"
 
 #: src/muuli_wdr.cpp
-msgid "Change priority for new assigned files :"
-msgstr "تغير الأولوية للملفات الحديثة :"
+msgid "Change priority for new assigned files"
+msgstr "تغير الأولوية للملفات الحديثة"
 
 #: src/muuli_wdr.cpp
 #, fuzzy
@@ -4959,7 +4900,7 @@ msgid "Don't change"
 msgstr "ﻻ تغير"
 
 #: src/muuli_wdr.cpp
-msgid "Select color for this Category (currently selected) :"
+msgid "Select color for this Category (currently selected)"
 msgstr ""
 
 #: src/muuli_wdr.cpp
@@ -5040,10 +4981,6 @@ msgstr ""
 
 #: src/muuli_wdr.cpp
 msgid "Enter the IP of the node here, using the x.x.x.x format."
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "Port:"
 msgstr ""
 
 #: src/muuli_wdr.cpp
@@ -5312,11 +5249,11 @@ msgid "Enable/disable proxy support"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Proxy type:"
+msgid "Proxy type"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Proxy host:"
+msgid "Proxy host"
 msgstr ""
 
 #: src/muuli_wdr.cpp
@@ -5324,7 +5261,7 @@ msgid "The proxy host name"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Proxy port:"
+msgid "Proxy port"
 msgstr ""
 
 #: src/muuli_wdr.cpp
@@ -5340,15 +5277,7 @@ msgid "Enable/disable username/password authentication"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Username: "
-msgstr ""
-
-#: src/muuli_wdr.cpp
 msgid "The username to use to connect to the proxy"
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "Password:"
 msgstr ""
 
 #: src/muuli_wdr.cpp
@@ -5531,6 +5460,15 @@ msgstr ""
 
 #: src/OtherFunctions.cpp
 msgid "days"
+msgstr ""
+
+#. TRANSLATORS:
+#. Punctuation for a "label: value" pair. %s is the already-translated
+#. label. Place the colon as your language requires -- e.g. "%s :" with a
+#. space in French, "%s:" without one in Russian and English.
+#: src/OtherFunctions.cpp
+#, c-format
+msgid "%s:"
 msgstr ""
 
 #: src/OtherFunctions.cpp
@@ -6545,8 +6483,7 @@ msgstr ""
 msgid "Confirm shared folders"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp
-#: src/SharedFilesReloadProgress.cpp
+#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp src/SharedFilesReloadProgress.cpp
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "وجد %i ملف مشاركة معرف"
@@ -6674,19 +6611,6 @@ msgstr ""
 #: src/SearchListCtrl.cpp
 msgid "FileID"
 msgstr "تعريف ملف"
-
-#: src/SearchListCtrl.cpp
-msgid "Length"
-msgstr ""
-
-#: src/SearchListCtrl.cpp
-#, fuzzy
-msgid "Bitrate"
-msgstr "غير مقيم"
-
-#: src/SearchListCtrl.cpp
-msgid "Codec"
-msgstr ""
 
 #: src/SearchListCtrl.cpp
 msgid "Expand all"
@@ -6972,10 +6896,6 @@ msgstr ""
 #: src/ServerListCtrl.cpp
 msgid "Server Name"
 msgstr "إسم الخادم"
-
-#: src/ServerListCtrl.cpp
-msgid "Port"
-msgstr "منفذ"
 
 #: src/ServerListCtrl.cpp
 msgid "Description"
@@ -7274,6 +7194,10 @@ msgstr "يتم الإتصال"
 #, fuzzy, c-format
 msgid "Connected to buddy at %s"
 msgstr "متصل بي %s (%s:%i)"
+
+#: src/ServerWnd.cpp
+msgid "IP address:"
+msgstr ""
 
 #: src/ServerWnd.cpp
 #, fuzzy

--- a/po/ast.po
+++ b/po/ast.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-04 12:13+0200\n"
+"POT-Creation-Date: 2026-09-05 12:01+0200\n"
 "PO-Revision-Date: 2026-09-03 11:01+0000\n"
 "Last-Translator: astur <malditoastur@gmail.com>\n"
 "Language-Team: Language ast <malditoastur@gmail.com>\n"
@@ -387,8 +387,7 @@ msgstr "sirvidor web corriendo con pid: %d"
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Solicitaste executar el sirvidor web al aniciu pero nun pudo correse'l binariu d'amuleweb. Por favor instala'l paquete que contenga'l sirvidor web d'aMule o compila aMule usando --enable-webserver y executa make install"
 
-#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
-#: src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
+#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
 msgid "ERROR"
 msgstr "FALLU"
 
@@ -676,8 +675,7 @@ msgstr "Redes"
 msgid "Searches"
 msgstr "Guetar"
 
-#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/Statistics.cpp
+#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/Statistics.cpp
 msgid "Downloads"
 msgstr "Descargues"
 
@@ -761,9 +759,7 @@ msgstr "Kad: Apagada"
 msgid "Core"
 msgstr ""
 
-#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#: src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp
-#: src/SourceListCtrl.cpp src/Statistics.cpp
+#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp src/Statistics.cpp
 msgid "Version"
 msgstr "Versión"
 
@@ -1063,11 +1059,7 @@ msgstr "Nun puede crease'l direutoriu '%s' pa la categoría '%s', calteniendo di
 msgid "The remote core sent inconsistent data for \"%s\" (part status %d, expected %d). The file list may be showing the wrong information; reconnect to clear it."
 msgstr ""
 
-#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp
-#: src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp
-#: src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp
-#: src/Statistics.cpp
+#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp src/Statistics.cpp
 msgid "Unknown"
 msgstr "Desconocíu"
 
@@ -1165,8 +1157,7 @@ msgstr "Fallu guardando ficheru known.met: %s"
 msgid "Enter Captcha"
 msgstr "Inxertar Captcha"
 
-#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp
-#: src/TransferWnd.cpp
+#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp src/TransferWnd.cpp
 msgid "Category"
 msgstr "Categoría"
 
@@ -1330,13 +1321,11 @@ msgstr "Ficheru 'cryptkey.dat' nun alcontráu, criando."
 msgid "Client Details"
 msgstr "Detalles del veceru"
 
-#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
-#: src/utils/wxCas/src/onlinesig.cpp
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
 msgid "LowID"
 msgstr "ID-Baxa"
 
-#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
-#: src/utils/wxCas/src/onlinesig.cpp
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
 msgid "HighID"
 msgstr "ID-Alta"
 
@@ -1352,8 +1341,7 @@ msgstr "Sofitáu"
 msgid "Not supported"
 msgstr "Non sofitáu"
 
-#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
-#: src/TextClient.cpp
+#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp src/TextClient.cpp
 msgid "Connected"
 msgstr "Coneutáu"
 
@@ -1361,28 +1349,24 @@ msgstr "Coneutáu"
 msgid "Disconnected"
 msgstr "Desconeutáu"
 
-#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp
-#: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f KiB/s"
 msgstr ""
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#, fuzzy
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/muuli_wdr.cpp
 msgid "Name"
-msgstr "Nome:"
+msgstr "Nome"
 
 #: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
 msgid "Software"
 msgstr ""
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#, fuzzy
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/muuli_wdr.cpp
 msgid "IP Address"
-msgstr "Señes IP :"
+msgstr "Señes IP"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Origin"
 msgstr ""
 
@@ -1400,14 +1384,12 @@ msgstr "Cabera receición"
 msgid "Sessions"
 msgstr "Versión"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp
 #, fuzzy
 msgid "Upload Speed"
 msgstr "Velocidá de xuba"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp
 #, fuzzy
 msgid "Download Speed"
 msgstr "Velocidá de descarga"
@@ -1463,13 +1445,11 @@ msgstr[1] ""
 msgid "Files"
 msgstr "Ficheros"
 
-#: src/ClientsListCtrl.cpp src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp
-#: src/SourceListCtrl.cpp
+#: src/ClientsListCtrl.cpp src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Uploaded"
 msgstr "Xubío"
 
-#: src/ClientsListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientsListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Downloaded"
 msgstr "Descargáu"
 
@@ -1556,12 +1536,11 @@ msgstr "Usuariu %s (%u) refugó l'accesu a la llista de direutorios/ficheros com
 msgid "File Comments"
 msgstr "Comentarios de ficheru"
 
-#: src/CommentDialogLst.cpp src/FriendListCtrl.cpp
+#: src/CommentDialogLst.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
 msgid "Username"
 msgstr "Nome d'usuariu"
 
-#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp
-#: src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "File Name"
 msgstr "Nome de ficheru"
 
@@ -1569,7 +1548,7 @@ msgstr "Nome de ficheru"
 msgid "Rating"
 msgstr "Valoración"
 
-#: src/CommentDialogLst.cpp
+#: src/CommentDialogLst.cpp src/muuli_wdr.cpp
 msgid "Comment"
 msgstr "Comentariu"
 
@@ -1623,18 +1602,15 @@ msgstr "Auto [Al]"
 msgid "Very low"
 msgstr "Mui baxa"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Low"
 msgstr "Baxa"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Normal"
 msgstr "Normal"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "High"
 msgstr "Alta"
 
@@ -1658,13 +1634,11 @@ msgstr "Coneutando vía sirvidor"
 msgid "Queue Full"
 msgstr "Cola enllena"
 
-#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp
-#: src/muuli_wdr.cpp
+#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp src/muuli_wdr.cpp
 msgid "On Queue"
 msgstr "Na cola"
 
-#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp
-#: src/PartFile.cpp src/TransferWnd.cpp
+#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Downloading"
 msgstr "Descargando"
 
@@ -1724,8 +1698,7 @@ msgstr "Sirvidor llocal"
 msgid "Remote Server"
 msgstr "Sirvidor remotu"
 
-#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp
-#: src/TextClient.cpp
+#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp src/TextClient.cpp
 msgid "Kad"
 msgstr "Kad"
 
@@ -1749,8 +1722,7 @@ msgstr "Semientes fonte"
 msgid "Search Result"
 msgstr "Resultáu de la gueta"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp
-#: src/TransferWnd.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Completed"
 msgstr "Completáu"
 
@@ -1803,8 +1775,7 @@ msgstr ""
 msgid "Part"
 msgstr "Parte"
 
-#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp
-#: src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Size"
 msgstr "Tamañu"
 
@@ -1812,8 +1783,7 @@ msgstr "Tamañu"
 msgid "Transferred"
 msgstr "Tresferío"
 
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
-#: src/SourceListCtrl.cpp
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp src/SourceListCtrl.cpp
 msgid "Speed"
 msgstr "Velocidá"
 
@@ -1821,13 +1791,11 @@ msgstr "Velocidá"
 msgid "Progress"
 msgstr "Progresu"
 
-#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp
-#: src/SearchListCtrl.cpp
+#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
 msgid "Sources"
 msgstr "Fontes"
 
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp
-#: src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Priority"
 msgstr "Prioridá"
 
@@ -1851,9 +1819,7 @@ msgstr "Cabera receición"
 msgid "Auto"
 msgstr "Auto"
 
-#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/TransferWnd.cpp
-#: src/utils/wxCas/src/wxcasprefs.cpp
+#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/TransferWnd.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Cancel"
 msgstr "Encaboxar"
 
@@ -1954,8 +1920,7 @@ msgstr "Introduza'l nuevu nome pa esti ficheru:"
 msgid "File rename"
 msgstr "Renomar ficheru"
 
-#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp
-#: src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f MiB/s"
 msgstr ""
@@ -2763,13 +2728,11 @@ msgstr ""
 msgid "Start aMule automatically when I log in"
 msgstr ""
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
-#: packaging/windows/installer_strings.c
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp packaging/windows/installer_strings.c
 msgid "Register aMule for ed2k:// links"
 msgstr ""
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
-#: packaging/windows/installer_strings.c
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp packaging/windows/installer_strings.c
 msgid "Register aMule for magnet: links"
 msgstr ""
 
@@ -2795,8 +2758,7 @@ msgstr ""
 msgid "Destination folder for downloads"
 msgstr "Carpeta de destín pa les descargues"
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
-#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Browse"
 msgstr "Desaminar"
 
@@ -3243,18 +3205,15 @@ msgstr "Completando"
 msgid "Complete"
 msgstr "Completáu"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
-#: src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Paused"
 msgstr "Posáu"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
-#: src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Erroneous"
 msgstr "Erróneu"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
-#: src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Waiting"
 msgstr "Aguardando"
 
@@ -3418,8 +3377,7 @@ msgstr "Zarrar"
 msgid "Cut"
 msgstr "Cortar"
 
-#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp
-#: src/utils/aLinkCreator/src/alcframe.cpp
+#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy"
 msgstr "Copiar"
 
@@ -3427,8 +3385,7 @@ msgstr "Copiar"
 msgid "Paste"
 msgstr "Apegar"
 
-#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp
-#: src/utils/aLinkCreator/src/alcframe.cpp
+#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Clear"
 msgstr "Llimpiar"
 
@@ -3436,8 +3393,7 @@ msgstr "Llimpiar"
 msgid "Select All"
 msgstr "Esbillar too"
 
-#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
-#: src/StatisticsDlg.cpp
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp src/StatisticsDlg.cpp
 msgid "KiB/s"
 msgstr ""
 
@@ -3701,10 +3657,6 @@ msgstr "Coneutáu al sirvidor."
 msgid "Search"
 msgstr "Guetar"
 
-#: src/muuli_wdr.cpp
-msgid "Name:"
-msgstr "Nome:"
-
 #: src/muuli_wdr.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Type"
 msgstr "Triba"
@@ -3794,8 +3746,8 @@ msgid "Availability"
 msgstr "Disponibilidá"
 
 #: src/muuli_wdr.cpp
-msgid "Filter:"
-msgstr "Fieltru:"
+msgid "Filter"
+msgstr "Fieltru"
 
 #: src/muuli_wdr.cpp
 msgid "Invert Result"
@@ -3853,6 +3805,10 @@ msgid "Clears completed downloads"
 msgstr "Llimpiar descargues completaes"
 
 #: src/muuli_wdr.cpp
+msgid "Filter:"
+msgstr "Fieltru:"
+
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "File sources:"
 msgstr "Fontes completes"
@@ -3862,80 +3818,76 @@ msgid "General"
 msgstr "Xeneral"
 
 #: src/muuli_wdr.cpp
-msgid "Full Name :"
-msgstr "Nome Completu :"
+msgid "Full Name"
+msgstr "Nome Completu"
 
 #: src/muuli_wdr.cpp
-msgid "met-File :"
-msgstr "Ficheru-met :"
+msgid "met-File"
+msgstr "Ficheru-met"
 
 #: src/muuli_wdr.cpp
-msgid "Hash :"
-msgstr "Hash :"
+msgid "Hash"
+msgstr "Hash"
 
 #: src/muuli_wdr.cpp
-msgid "Filesize :"
-msgstr "Tamañu :"
+msgid "Filesize"
+msgstr "Tamañu"
 
 #: src/muuli_wdr.cpp src/Statistics.cpp
 msgid "Transfer"
 msgstr "Tresferencia"
 
 #: src/muuli_wdr.cpp
-msgid "Partfilestatus :"
-msgstr "Estáu ficheru part :"
+msgid "Partfilestatus"
+msgstr "Estáu ficheru part"
 
 #: src/muuli_wdr.cpp
-msgid "Last seen complete :"
-msgstr "Cabera comprobación completa :"
+msgid "Last seen complete"
+msgstr "Cabera comprobación completa"
 
 #: src/muuli_wdr.cpp
-msgid "Found Sources :"
-msgstr "Fontes alcontraes :"
+msgid "Found Sources"
+msgstr "Fontes alcontraes"
 
 #: src/muuli_wdr.cpp
-msgid "Transferring Sources :"
-msgstr "Tresfiriendo fontes :"
+msgid "Transferring Sources"
+msgstr "Tresfiriendo fontes"
 
 #: src/muuli_wdr.cpp
-msgid "Filepart-Count :"
-msgstr "Númberu de partes :"
+msgid "Filepart-Count"
+msgstr "Númberu de partes"
 
 #: src/muuli_wdr.cpp
-msgid "Available :"
-msgstr "Disponibles :"
+msgid "Available"
+msgstr "Disponibles"
 
 #: src/muuli_wdr.cpp
-msgid "Datarate :"
-msgstr "Fluxu de datos :"
+msgid "Datarate"
+msgstr "Fluxu de datos"
 
 #: src/muuli_wdr.cpp
-msgid "Download Active Time: "
-msgstr "Tiempu Descarga Activa: "
+msgid "Download Active Time"
+msgstr "Tiempu Descarga Activa"
 
 #: src/muuli_wdr.cpp
-msgid "Transferred :"
-msgstr "Tresferío :"
-
-#: src/muuli_wdr.cpp
-msgid "Completed Size :"
-msgstr "Tamañu Completáu :"
+msgid "Completed Size"
+msgstr "Tamañu Completáu"
 
 #: src/muuli_wdr.cpp
 msgid "Intelligent Corruption Handling"
 msgstr "Xestión intelixente de corrupción"
 
 #: src/muuli_wdr.cpp
-msgid "Lost to corruption :"
-msgstr "Perdío por corrupción :"
+msgid "Lost to corruption"
+msgstr "Perdío por corrupción"
 
 #: src/muuli_wdr.cpp
-msgid "Gained by compression :"
-msgstr "Ganao por compresión :"
+msgid "Gained by compression"
+msgstr "Ganao por compresión"
 
 #: src/muuli_wdr.cpp
-msgid "Packages saved by I.C.H. :"
-msgstr "Paquetes salvaos por I.C.H.:"
+msgid "Packages saved by I.C.H."
+msgstr "Paquetes salvaos por I.C.H."
 
 #: src/muuli_wdr.cpp
 #, fuzzy
@@ -3977,30 +3929,30 @@ msgstr ", Xubío:"
 msgid "Media Info"
 msgstr "Info Kad"
 
-#: src/muuli_wdr.cpp
-msgid "Length :"
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
+msgid "Length"
 msgstr ""
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
 #, fuzzy
-msgid "Bitrate :"
+msgid "Bitrate"
 msgstr "Non evaluada"
 
-#: src/muuli_wdr.cpp
-msgid "Codec :"
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
+msgid "Codec"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Artist :"
+msgid "Artist"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Album :"
+msgid "Album"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Title :"
-msgstr "Títulu :"
+msgid "Title"
+msgstr "Títulu"
 
 #: src/muuli_wdr.cpp
 msgid "File Names"
@@ -4087,25 +4039,17 @@ msgstr "Tamañu desconocíu"
 msgid "Required Information"
 msgstr "Información requería"
 
-#: src/muuli_wdr.cpp
-msgid "IP Address :"
-msgstr "Señes IP :"
-
-#: src/muuli_wdr.cpp
-msgid "Port :"
-msgstr "Puertu :"
+#: src/muuli_wdr.cpp src/ServerListCtrl.cpp
+msgid "Port"
+msgstr "Puertu"
 
 #: src/muuli_wdr.cpp
 msgid "Additional Information"
 msgstr "Información adicional"
 
 #: src/muuli_wdr.cpp
-msgid "Username :"
-msgstr "Nome d'usuariu :"
-
-#: src/muuli_wdr.cpp
-msgid "Userhash :"
-msgstr "Hash del usuariu :"
+msgid "Userhash"
+msgstr "Hash del usuariu"
 
 #: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Add"
@@ -4140,97 +4084,81 @@ msgid "Statistics Tree"
 msgstr "Árbol d'estadístiques"
 
 #: src/muuli_wdr.cpp
-msgid "Username:"
-msgstr "Nome d'usuariu:"
+msgid "Client software"
+msgstr "Software del veceru"
 
 #: src/muuli_wdr.cpp
-msgid "Userhash:"
-msgstr "Hash d'usuariu:"
+msgid "Client version"
+msgstr "Versión del veceru"
 
 #: src/muuli_wdr.cpp
-msgid "Client software:"
-msgstr "Software del veceru:"
+msgid "User ID"
+msgstr "ID usuariu"
 
 #: src/muuli_wdr.cpp
-msgid "Client version:"
-msgstr "Versión del veceru:"
-
-#: src/muuli_wdr.cpp src/ServerWnd.cpp
-msgid "IP address:"
-msgstr "Señes IP:"
+msgid "Server IP"
+msgstr "IP Sirvidor"
 
 #: src/muuli_wdr.cpp
-msgid "User ID:"
-msgstr "ID usuariu:"
+msgid "Server name"
+msgstr "Nome sirvidor"
 
 #: src/muuli_wdr.cpp
-msgid "Server IP:"
-msgstr "IP Sirvidor:"
-
-#: src/muuli_wdr.cpp
-msgid "Server name:"
-msgstr "Nome sirvidor:"
-
-#: src/muuli_wdr.cpp
-msgid "Obfuscation:"
-msgstr "Ofuscación:"
-
-#: src/muuli_wdr.cpp
-msgid "Kad:"
-msgstr "Kad:"
+msgid "Obfuscation"
+msgstr "Ofuscación"
 
 #: src/muuli_wdr.cpp
 msgid "Transfers to client"
 msgstr "Tresferencies al veceru"
 
 #: src/muuli_wdr.cpp
-msgid "Current request:"
-msgstr "Solicitú actual:"
+msgid "Current request"
+msgstr "Solicitú actual"
 
 #: src/muuli_wdr.cpp
-msgid "Average upload rate:"
-msgstr "Velocidá media de xuba :"
+msgid "Average upload rate"
+msgstr "Velocidá media de xuba"
 
 #: src/muuli_wdr.cpp
-msgid "Average download rate:"
-msgstr "Velocidá media de descarga :"
+msgid "Average download rate"
+msgstr "Velocidá media de descarga"
 
 #: src/muuli_wdr.cpp
-msgid "Uploaded (session):"
-msgstr "Xubíu (sesión):"
+msgid "Uploaded (session)"
+msgstr "Xubíu (sesión)"
 
 #: src/muuli_wdr.cpp
-msgid "Downloaded (session):"
-msgstr "Descargáu (sesión):"
+msgid "Downloaded (session)"
+msgstr "Descargáu (sesión)"
 
 #: src/muuli_wdr.cpp
-msgid "Uploaded (total):"
-msgstr "Xubíu (total):"
+msgid "Uploaded (total)"
+msgstr "Xubíu (total)"
 
 #: src/muuli_wdr.cpp
-msgid "Downloaded (total):"
-msgstr "Descargáu (total):"
+msgid "Downloaded (total)"
+msgstr "Descargáu (total)"
 
 #: src/muuli_wdr.cpp
 msgid "Scores"
 msgstr "Resultaos"
 
 #: src/muuli_wdr.cpp
-msgid "DL/UP modifier:"
-msgstr "Modificador DE/XU:"
+msgid "DL/UP modifier"
+msgstr "Modificador DE/XU"
 
 #: src/muuli_wdr.cpp
-msgid "Secure ident:"
-msgstr "Ident Segura:"
+msgid "Secure ident"
+msgstr "Ident Segura"
 
 #: src/muuli_wdr.cpp
 #, fuzzy
-msgid "Queue rank:"
+msgid "Queue rank"
 msgstr "En cola"
 
 #: src/muuli_wdr.cpp
-msgid "Queue score:"
-msgstr "Puntuación cola:"
+msgid "Queue score"
+msgstr "Puntuación cola"
 
 #: src/muuli_wdr.cpp
 msgid "Nick"
@@ -5026,16 +4954,12 @@ msgid "Reset any changes made to the preferences."
 msgstr "Encaboxar cualesquier cambéu fechu nes opciones."
 
 #: src/muuli_wdr.cpp
-msgid "Comment :"
-msgstr "Comentariu : "
+msgid "Incoming Dir"
+msgstr "Direutoriu entrante"
 
 #: src/muuli_wdr.cpp
-msgid "Incoming Dir :"
-msgstr "Direutoriu entrante :"
-
-#: src/muuli_wdr.cpp
-msgid "Change priority for new assigned files :"
-msgstr "Cambiar prioridá a nuevos ficheros asignaos :"
+msgid "Change priority for new assigned files"
+msgstr "Cambiar prioridá a nuevos ficheros asignaos"
 
 #: src/muuli_wdr.cpp
 #, fuzzy
@@ -5043,8 +4967,8 @@ msgid "Don't change"
 msgstr "Non cambiar"
 
 #: src/muuli_wdr.cpp
-msgid "Select color for this Category (currently selected) :"
-msgstr "Seleiciona color pa esta categoría (seleicionada) :"
+msgid "Select color for this Category (currently selected)"
+msgstr "Seleiciona color pa esta categoría (seleicionada)"
 
 #: src/muuli_wdr.cpp
 msgid "Click this button to reset the log."
@@ -5129,10 +5053,6 @@ msgstr ""
 #, fuzzy
 msgid "Enter the IP of the node here, using the x.x.x.x format."
 msgstr "Introduz la IP del sirvidor, usando'l formatu X.X.X.X."
-
-#: src/muuli_wdr.cpp
-msgid "Port:"
-msgstr "Puertu:"
 
 #: src/muuli_wdr.cpp
 msgid "Use Secure User Identification"
@@ -5401,20 +5321,20 @@ msgid "Enable/disable proxy support"
 msgstr "Habilitar/Deshabilitar soporte Proxy"
 
 #: src/muuli_wdr.cpp
-msgid "Proxy type:"
-msgstr "Triba Proxy:"
+msgid "Proxy type"
+msgstr "Triba Proxy"
 
 #: src/muuli_wdr.cpp
-msgid "Proxy host:"
-msgstr "Sirvidor Proxy:"
+msgid "Proxy host"
+msgstr "Sirvidor Proxy"
 
 #: src/muuli_wdr.cpp
 msgid "The proxy host name"
 msgstr "Nome del host del proxy"
 
 #: src/muuli_wdr.cpp
-msgid "Proxy port:"
-msgstr "Puertu Proxy:"
+msgid "Proxy port"
+msgstr "Puertu Proxy"
 
 #: src/muuli_wdr.cpp
 msgid "The proxy port"
@@ -5429,16 +5349,8 @@ msgid "Enable/disable username/password authentication"
 msgstr "Habilita/deshabilita autentificación usuariu/contraseña"
 
 #: src/muuli_wdr.cpp
-msgid "Username: "
-msgstr "Nome d'usuariu:"
-
-#: src/muuli_wdr.cpp
 msgid "The username to use to connect to the proxy"
 msgstr "El nome d'usuariu a usar pa coneutar al proxy"
-
-#: src/muuli_wdr.cpp
-msgid "Password:"
-msgstr "Contraseña:"
 
 #: src/muuli_wdr.cpp
 msgid "The password to use to connect to the proxy"
@@ -5620,6 +5532,15 @@ msgstr "hores"
 #: src/OtherFunctions.cpp
 msgid "days"
 msgstr "díes"
+
+#. TRANSLATORS:
+#. Punctuation for a "label: value" pair. %s is the already-translated
+#. label. Place the colon as your language requires -- e.g. "%s :" with a
+#. space in French, "%s:" without one in Russian and English.
+#: src/OtherFunctions.cpp
+#, c-format
+msgid "%s:"
+msgstr ""
 
 #: src/OtherFunctions.cpp
 msgid "all"
@@ -6667,8 +6588,7 @@ msgstr ""
 msgid "Confirm shared folders"
 msgstr "Carpetes compartíes"
 
-#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp
-#: src/SharedFilesReloadProgress.cpp
+#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp src/SharedFilesReloadProgress.cpp
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "Recargar los tos ficheros compartíos"
@@ -6801,19 +6721,6 @@ msgstr "Fallu actualizando GeoIP.dat"
 #: src/SearchListCtrl.cpp
 msgid "FileID"
 msgstr "ID Ficheru"
-
-#: src/SearchListCtrl.cpp
-msgid "Length"
-msgstr ""
-
-#: src/SearchListCtrl.cpp
-#, fuzzy
-msgid "Bitrate"
-msgstr "Non evaluada"
-
-#: src/SearchListCtrl.cpp
-msgid "Codec"
-msgstr ""
 
 #: src/SearchListCtrl.cpp
 msgid "Expand all"
@@ -7101,10 +7008,6 @@ msgstr "Sirvidor llocal ye fieltráu polos Fieltros IP, ¡coneutando a un sirvid
 #: src/ServerListCtrl.cpp
 msgid "Server Name"
 msgstr "Nome del Sirvidor"
-
-#: src/ServerListCtrl.cpp
-msgid "Port"
-msgstr "Puertu"
 
 #: src/ServerListCtrl.cpp
 msgid "Description"
@@ -7400,6 +7303,10 @@ msgstr "Coneutando a collaciu"
 #, c-format
 msgid "Connected to buddy at %s"
 msgstr "Coneutáu a collaciu en %s"
+
+#: src/ServerWnd.cpp
+msgid "IP address:"
+msgstr "Señes IP:"
 
 #: src/ServerWnd.cpp
 msgid "Indexed sources:"

--- a/po/bg.po
+++ b/po/bg.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-04 12:13+0200\n"
+"POT-Creation-Date: 2026-09-05 12:01+0200\n"
 "PO-Revision-Date: 2026-09-03 11:01+0000\n"
 "Last-Translator: Sebastiano Pistore <SebastianoPistore.info@protonmail.ch>\n"
 "Language-Team: Bulgarian <dict@linux.zonebg.com>\n"
@@ -375,8 +375,7 @@ msgstr ""
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr ""
 
-#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
-#: src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
+#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
 msgid "ERROR"
 msgstr ""
 
@@ -655,8 +654,7 @@ msgstr ""
 msgid "Searches"
 msgstr ""
 
-#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/Statistics.cpp
+#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/Statistics.cpp
 msgid "Downloads"
 msgstr ""
 
@@ -741,9 +739,7 @@ msgstr ""
 msgid "Core"
 msgstr ""
 
-#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#: src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp
-#: src/SourceListCtrl.cpp src/Statistics.cpp
+#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp src/Statistics.cpp
 msgid "Version"
 msgstr "версия"
 
@@ -1041,11 +1037,7 @@ msgstr ""
 msgid "The remote core sent inconsistent data for \"%s\" (part status %d, expected %d). The file list may be showing the wrong information; reconnect to clear it."
 msgstr ""
 
-#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp
-#: src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp
-#: src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp
-#: src/Statistics.cpp
+#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp src/Statistics.cpp
 msgid "Unknown"
 msgstr "Неизвестен"
 
@@ -1143,8 +1135,7 @@ msgstr ""
 msgid "Enter Captcha"
 msgstr ""
 
-#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp
-#: src/TransferWnd.cpp
+#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp src/TransferWnd.cpp
 msgid "Category"
 msgstr "Категория"
 
@@ -1305,13 +1296,11 @@ msgstr ""
 msgid "Client Details"
 msgstr "Клиентските Детайли"
 
-#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
-#: src/utils/wxCas/src/onlinesig.cpp
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
 msgid "LowID"
 msgstr ""
 
-#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
-#: src/utils/wxCas/src/onlinesig.cpp
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
 msgid "HighID"
 msgstr ""
 
@@ -1327,8 +1316,7 @@ msgstr ""
 msgid "Not supported"
 msgstr ""
 
-#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
-#: src/TextClient.cpp
+#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp src/TextClient.cpp
 msgid "Connected"
 msgstr "Връзкате е установена"
 
@@ -1336,28 +1324,25 @@ msgstr "Връзкате е установена"
 msgid "Disconnected"
 msgstr "Връзката е разпадната"
 
-#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp
-#: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f KiB/s"
 msgstr ""
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#, fuzzy
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/muuli_wdr.cpp
 msgid "Name"
-msgstr "Име:"
+msgstr "Име"
 
 #: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
 msgid "Software"
 msgstr ""
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/muuli_wdr.cpp
 #, fuzzy
 msgid "IP Address"
 msgstr "адрес"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Origin"
 msgstr ""
 
@@ -1374,14 +1359,12 @@ msgstr ""
 msgid "Sessions"
 msgstr "версия"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp
 #, fuzzy
 msgid "Upload Speed"
 msgstr "Време на качване"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp
 #, fuzzy
 msgid "Download Speed"
 msgstr "Изтегляне"
@@ -1436,13 +1419,11 @@ msgstr[1] ""
 msgid "Files"
 msgstr "Файлове"
 
-#: src/ClientsListCtrl.cpp src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp
-#: src/SourceListCtrl.cpp
+#: src/ClientsListCtrl.cpp src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Uploaded"
 msgstr ""
 
-#: src/ClientsListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientsListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Downloaded"
 msgstr ""
 
@@ -1529,12 +1510,11 @@ msgstr ""
 msgid "File Comments"
 msgstr "Коментари за файла"
 
-#: src/CommentDialogLst.cpp src/FriendListCtrl.cpp
+#: src/CommentDialogLst.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
 msgid "Username"
 msgstr "Потребителско име"
 
-#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp
-#: src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "File Name"
 msgstr "Име на файл"
 
@@ -1542,7 +1522,7 @@ msgstr "Име на файл"
 msgid "Rating"
 msgstr "Оценка"
 
-#: src/CommentDialogLst.cpp
+#: src/CommentDialogLst.cpp src/muuli_wdr.cpp
 msgid "Comment"
 msgstr "коментар"
 
@@ -1596,18 +1576,15 @@ msgstr "Автоматичен [Hi]"
 msgid "Very low"
 msgstr ""
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Low"
 msgstr "Ниско"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Normal"
 msgstr "Нормален"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "High"
 msgstr "Високо"
 
@@ -1631,13 +1608,11 @@ msgstr "Свързване чрез сървър"
 msgid "Queue Full"
 msgstr "Опашката е пълна"
 
-#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp
-#: src/muuli_wdr.cpp
+#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp src/muuli_wdr.cpp
 msgid "On Queue"
 msgstr "На опашката"
 
-#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp
-#: src/PartFile.cpp src/TransferWnd.cpp
+#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Downloading"
 msgstr "Изтегляне"
 
@@ -1697,8 +1672,7 @@ msgstr ""
 msgid "Remote Server"
 msgstr ""
 
-#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp
-#: src/TextClient.cpp
+#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp src/TextClient.cpp
 msgid "Kad"
 msgstr ""
 
@@ -1722,8 +1696,7 @@ msgstr ""
 msgid "Search Result"
 msgstr ""
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp
-#: src/TransferWnd.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Completed"
 msgstr "Завършен"
 
@@ -1775,8 +1748,7 @@ msgstr ""
 msgid "Part"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp
-#: src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Size"
 msgstr "Размер"
 
@@ -1784,8 +1756,7 @@ msgstr "Размер"
 msgid "Transferred"
 msgstr "Пренесен"
 
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
-#: src/SourceListCtrl.cpp
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp src/SourceListCtrl.cpp
 msgid "Speed"
 msgstr "Скорост"
 
@@ -1793,13 +1764,11 @@ msgstr "Скорост"
 msgid "Progress"
 msgstr "Прогрес"
 
-#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp
-#: src/SearchListCtrl.cpp
+#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
 msgid "Sources"
 msgstr "Източници"
 
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp
-#: src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Priority"
 msgstr "Приоритет"
 
@@ -1823,9 +1792,7 @@ msgstr ""
 msgid "Auto"
 msgstr "Автоматично"
 
-#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/TransferWnd.cpp
-#: src/utils/wxCas/src/wxcasprefs.cpp
+#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/TransferWnd.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Cancel"
 msgstr "Отказ"
 
@@ -1926,8 +1893,7 @@ msgstr ""
 msgid "File rename"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp
-#: src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f MiB/s"
 msgstr ""
@@ -2702,13 +2668,11 @@ msgstr ""
 msgid "Start aMule automatically when I log in"
 msgstr ""
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
-#: packaging/windows/installer_strings.c
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp packaging/windows/installer_strings.c
 msgid "Register aMule for ed2k:// links"
 msgstr ""
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
-#: packaging/windows/installer_strings.c
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp packaging/windows/installer_strings.c
 msgid "Register aMule for magnet: links"
 msgstr ""
 
@@ -2734,8 +2698,7 @@ msgstr ""
 msgid "Destination folder for downloads"
 msgstr ""
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
-#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Browse"
 msgstr "Избери"
 
@@ -3178,18 +3141,15 @@ msgstr ""
 msgid "Complete"
 msgstr "Завършено"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
-#: src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Paused"
 msgstr "Пауза"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
-#: src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Erroneous"
 msgstr ""
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
-#: src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Waiting"
 msgstr ""
 
@@ -3352,8 +3312,7 @@ msgstr "Затвори"
 msgid "Cut"
 msgstr ""
 
-#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp
-#: src/utils/aLinkCreator/src/alcframe.cpp
+#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy"
 msgstr "копие"
 
@@ -3361,8 +3320,7 @@ msgstr "копие"
 msgid "Paste"
 msgstr ""
 
-#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp
-#: src/utils/aLinkCreator/src/alcframe.cpp
+#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Clear"
 msgstr "Изчисти"
 
@@ -3370,8 +3328,7 @@ msgstr "Изчисти"
 msgid "Select All"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
-#: src/StatisticsDlg.cpp
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp src/StatisticsDlg.cpp
 msgid "KiB/s"
 msgstr ""
 
@@ -3630,10 +3587,6 @@ msgstr ""
 msgid "Search"
 msgstr "Търсене"
 
-#: src/muuli_wdr.cpp
-msgid "Name:"
-msgstr "Име:"
-
 #: src/muuli_wdr.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Type"
 msgstr "Тип"
@@ -3723,8 +3676,9 @@ msgid "Availability"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Filter:"
-msgstr ""
+#, fuzzy
+msgid "Filter"
+msgstr "Филтрирани: %i"
 
 #: src/muuli_wdr.cpp
 msgid "Invert Result"
@@ -3781,6 +3735,10 @@ msgid "Clears completed downloads"
 msgstr ""
 
 #: src/muuli_wdr.cpp
+msgid "Filter:"
+msgstr ""
+
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "File sources:"
 msgstr "Намерени източници: %i"
@@ -3790,79 +3748,86 @@ msgid "General"
 msgstr "Общи"
 
 #: src/muuli_wdr.cpp
-msgid "Full Name :"
+#, fuzzy
+msgid "Full Name"
+msgstr "Име на файл"
+
+#: src/muuli_wdr.cpp
+#, fuzzy
+msgid "met-File"
+msgstr "Файлове"
+
+#: src/muuli_wdr.cpp
+msgid "Hash"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "met-File :"
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "Hash :"
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "Filesize :"
-msgstr ""
+#, fuzzy
+msgid "Filesize"
+msgstr "Размер на файла"
 
 #: src/muuli_wdr.cpp src/Statistics.cpp
 msgid "Transfer"
 msgstr "Трансфер"
 
 #: src/muuli_wdr.cpp
-msgid "Partfilestatus :"
+#, fuzzy
+msgid "Partfilestatus"
+msgstr "Статус"
+
+#: src/muuli_wdr.cpp
+#, fuzzy
+msgid "Last seen complete"
+msgstr "Незавършен"
+
+#: src/muuli_wdr.cpp
+#, fuzzy
+msgid "Found Sources"
+msgstr "Източници"
+
+#: src/muuli_wdr.cpp
+#, fuzzy
+msgid "Transferring Sources"
+msgstr "Пренесен"
+
+#: src/muuli_wdr.cpp
+msgid "Filepart-Count"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Last seen complete :"
-msgstr ""
+#, fuzzy
+msgid "Available"
+msgstr "Наличен"
 
 #: src/muuli_wdr.cpp
-msgid "Found Sources :"
-msgstr ""
+#, fuzzy
+msgid "Datarate"
+msgstr "Няма оценки"
 
 #: src/muuli_wdr.cpp
-msgid "Transferring Sources :"
-msgstr ""
+#, fuzzy
+msgid "Download Active Time"
+msgstr "Изтегляне"
 
 #: src/muuli_wdr.cpp
-msgid "Filepart-Count :"
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "Available :"
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "Datarate :"
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "Download Active Time: "
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "Transferred :"
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "Completed Size :"
-msgstr ""
+#, fuzzy
+msgid "Completed Size"
+msgstr "Завършен"
 
 #: src/muuli_wdr.cpp
 msgid "Intelligent Corruption Handling"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Lost to corruption :"
+msgid "Lost to corruption"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Gained by compression :"
+msgid "Gained by compression"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Packages saved by I.C.H. :"
+msgid "Packages saved by I.C.H."
 msgstr ""
 
 #: src/muuli_wdr.cpp
@@ -3902,30 +3867,30 @@ msgstr ""
 msgid "Media Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp
-msgid "Length :"
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
+msgid "Length"
 msgstr ""
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
 #, fuzzy
-msgid "Bitrate :"
+msgid "Bitrate"
 msgstr "Няма оценки"
 
-#: src/muuli_wdr.cpp
-msgid "Codec :"
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
+msgid "Codec"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Artist :"
+msgid "Artist"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Album :"
+msgid "Album"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Title :"
-msgstr "Заглавие :"
+msgid "Title"
+msgstr "Заглавие"
 
 #: src/muuli_wdr.cpp
 msgid "File Names"
@@ -4009,25 +3974,18 @@ msgstr ""
 msgid "Required Information"
 msgstr ""
 
-#: src/muuli_wdr.cpp
-msgid "IP Address :"
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "Port :"
-msgstr ""
+#: src/muuli_wdr.cpp src/ServerListCtrl.cpp
+msgid "Port"
+msgstr "Порт"
 
 #: src/muuli_wdr.cpp
 msgid "Additional Information"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Username :"
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "Userhash :"
-msgstr ""
+#, fuzzy
+msgid "Userhash"
+msgstr "Потребители"
 
 #: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Add"
@@ -4062,43 +4020,32 @@ msgid "Statistics Tree"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Username:"
-msgstr "Име на потребител:"
+#, fuzzy
+msgid "Client software"
+msgstr "Клиенти"
 
 #: src/muuli_wdr.cpp
-msgid "Userhash:"
-msgstr ""
+#, fuzzy
+msgid "Client version"
+msgstr "Клиенти"
 
 #: src/muuli_wdr.cpp
-msgid "Client software:"
-msgstr ""
+#, fuzzy
+msgid "User ID"
+msgstr "Потребители"
 
 #: src/muuli_wdr.cpp
-msgid "Client version:"
-msgstr ""
-
-#: src/muuli_wdr.cpp src/ServerWnd.cpp
-msgid "IP address:"
-msgstr ""
+#, fuzzy
+msgid "Server IP"
+msgstr "Сървър"
 
 #: src/muuli_wdr.cpp
-msgid "User ID:"
-msgstr ""
+#, fuzzy
+msgid "Server name"
+msgstr "Име на сървър"
 
 #: src/muuli_wdr.cpp
-msgid "Server IP:"
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "Server name:"
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "Obfuscation:"
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "Kad:"
+msgid "Obfuscation"
 msgstr ""
 
 #: src/muuli_wdr.cpp
@@ -4106,53 +4053,60 @@ msgid "Transfers to client"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Current request:"
+#, fuzzy
+msgid "Current request"
+msgstr "Текущ"
+
+#: src/muuli_wdr.cpp
+#, fuzzy
+msgid "Average upload rate"
+msgstr "Средно време за качване: %s"
+
+#: src/muuli_wdr.cpp
+#, fuzzy
+msgid "Average download rate"
+msgstr "Средно време за качване: %s"
+
+#: src/muuli_wdr.cpp
+msgid "Uploaded (session)"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Average upload rate:"
-msgstr ""
+#, fuzzy
+msgid "Downloaded (session)"
+msgstr "Файлове за сваляне (%i)"
 
 #: src/muuli_wdr.cpp
-msgid "Average download rate:"
-msgstr ""
+#, fuzzy
+msgid "Uploaded (total)"
+msgstr "Качване"
 
 #: src/muuli_wdr.cpp
-msgid "Uploaded (session):"
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "Downloaded (session):"
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "Uploaded (total):"
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "Downloaded (total):"
-msgstr ""
+#, fuzzy
+msgid "Downloaded (total)"
+msgstr "Файлове за сваляне (%i)"
 
 #: src/muuli_wdr.cpp
 msgid "Scores"
 msgstr "Точки"
 
 #: src/muuli_wdr.cpp
-msgid "DL/UP modifier:"
+msgid "DL/UP modifier"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Secure ident:"
+msgid "Secure ident"
 msgstr ""
 
 #: src/muuli_wdr.cpp
 #, fuzzy
-msgid "Queue rank:"
+msgid "Queue rank"
 msgstr "Опашката е пълна"
 
 #: src/muuli_wdr.cpp
-msgid "Queue score:"
-msgstr ""
+#, fuzzy
+msgid "Queue score"
+msgstr "Опашката е пълна"
 
 #: src/muuli_wdr.cpp
 msgid "Nick"
@@ -4934,15 +4888,11 @@ msgid "Reset any changes made to the preferences."
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Comment :"
-msgstr "Коментар:"
-
-#: src/muuli_wdr.cpp
-msgid "Incoming Dir :"
+msgid "Incoming Dir"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Change priority for new assigned files :"
+msgid "Change priority for new assigned files"
 msgstr ""
 
 #: src/muuli_wdr.cpp
@@ -4950,7 +4900,7 @@ msgid "Don't change"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Select color for this Category (currently selected) :"
+msgid "Select color for this Category (currently selected)"
 msgstr ""
 
 #: src/muuli_wdr.cpp
@@ -5031,10 +4981,6 @@ msgstr ""
 
 #: src/muuli_wdr.cpp
 msgid "Enter the IP of the node here, using the x.x.x.x format."
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "Port:"
 msgstr ""
 
 #: src/muuli_wdr.cpp
@@ -5301,11 +5247,11 @@ msgid "Enable/disable proxy support"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Proxy type:"
+msgid "Proxy type"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Proxy host:"
+msgid "Proxy host"
 msgstr ""
 
 #: src/muuli_wdr.cpp
@@ -5313,7 +5259,7 @@ msgid "The proxy host name"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Proxy port:"
+msgid "Proxy port"
 msgstr ""
 
 #: src/muuli_wdr.cpp
@@ -5329,15 +5275,7 @@ msgid "Enable/disable username/password authentication"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Username: "
-msgstr ""
-
-#: src/muuli_wdr.cpp
 msgid "The username to use to connect to the proxy"
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "Password:"
 msgstr ""
 
 #: src/muuli_wdr.cpp
@@ -5517,6 +5455,15 @@ msgstr "часа"
 #: src/OtherFunctions.cpp
 msgid "days"
 msgstr "дни"
+
+#. TRANSLATORS:
+#. Punctuation for a "label: value" pair. %s is the already-translated
+#. label. Place the colon as your language requires -- e.g. "%s :" with a
+#. space in French, "%s:" without one in Russian and English.
+#: src/OtherFunctions.cpp
+#, c-format
+msgid "%s:"
+msgstr ""
 
 #: src/OtherFunctions.cpp
 msgid "all"
@@ -6520,8 +6467,7 @@ msgstr ""
 msgid "Confirm shared folders"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp
-#: src/SharedFilesReloadProgress.cpp
+#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp src/SharedFilesReloadProgress.cpp
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "Известни са %i споделени файлове"
@@ -6648,19 +6594,6 @@ msgstr ""
 
 #: src/SearchListCtrl.cpp
 msgid "FileID"
-msgstr ""
-
-#: src/SearchListCtrl.cpp
-msgid "Length"
-msgstr ""
-
-#: src/SearchListCtrl.cpp
-#, fuzzy
-msgid "Bitrate"
-msgstr "Няма оценки"
-
-#: src/SearchListCtrl.cpp
-msgid "Codec"
 msgstr ""
 
 #: src/SearchListCtrl.cpp
@@ -6945,10 +6878,6 @@ msgstr ""
 #: src/ServerListCtrl.cpp
 msgid "Server Name"
 msgstr "Име на сървър"
-
-#: src/ServerListCtrl.cpp
-msgid "Port"
-msgstr "Порт"
 
 #: src/ServerListCtrl.cpp
 msgid "Description"
@@ -7246,6 +7175,10 @@ msgstr "Свързва"
 #, fuzzy, c-format
 msgid "Connected to buddy at %s"
 msgstr "Свързан към %s (%s:%i)"
+
+#: src/ServerWnd.cpp
+msgid "IP address:"
+msgstr ""
 
 #: src/ServerWnd.cpp
 #, fuzzy
@@ -9213,10 +9146,6 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
-
-#, fuzzy
-#~ msgid "Available Parts"
-#~ msgstr "Наличен"
 
 #, fuzzy, c-format
 #~ msgid "Found %i known shared file, %i unknown"

--- a/po/bn.po
+++ b/po/bn.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-04 12:13+0200\n"
+"POT-Creation-Date: 2026-09-05 12:01+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -1321,7 +1321,7 @@ msgstr ""
 msgid "%.1f KiB/s"
 msgstr ""
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/muuli_wdr.cpp
 msgid "Name"
 msgstr ""
 
@@ -1329,7 +1329,7 @@ msgstr ""
 msgid "Software"
 msgstr ""
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/muuli_wdr.cpp
 msgid "IP Address"
 msgstr ""
 
@@ -1497,7 +1497,7 @@ msgstr ""
 msgid "File Comments"
 msgstr ""
 
-#: src/CommentDialogLst.cpp src/FriendListCtrl.cpp
+#: src/CommentDialogLst.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
 msgid "Username"
 msgstr ""
 
@@ -1510,7 +1510,7 @@ msgstr ""
 msgid "Rating"
 msgstr ""
 
-#: src/CommentDialogLst.cpp
+#: src/CommentDialogLst.cpp src/muuli_wdr.cpp
 msgid "Comment"
 msgstr ""
 
@@ -3579,10 +3579,6 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
-#: src/muuli_wdr.cpp
-msgid "Name:"
-msgstr ""
-
 #: src/muuli_wdr.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Type"
 msgstr ""
@@ -3672,7 +3668,7 @@ msgid "Availability"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Filter:"
+msgid "Filter"
 msgstr ""
 
 #: src/muuli_wdr.cpp
@@ -3728,6 +3724,10 @@ msgid "Clears completed downloads"
 msgstr ""
 
 #: src/muuli_wdr.cpp
+msgid "Filter:"
+msgstr ""
+
+#: src/muuli_wdr.cpp
 msgid "File sources:"
 msgstr ""
 
@@ -3736,19 +3736,19 @@ msgid "General"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Full Name :"
+msgid "Full Name"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "met-File :"
+msgid "met-File"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Hash :"
+msgid "Hash"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Filesize :"
+msgid "Filesize"
 msgstr ""
 
 #: src/muuli_wdr.cpp src/Statistics.cpp
@@ -3756,43 +3756,39 @@ msgid "Transfer"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Partfilestatus :"
+msgid "Partfilestatus"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Last seen complete :"
+msgid "Last seen complete"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Found Sources :"
+msgid "Found Sources"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Transferring Sources :"
+msgid "Transferring Sources"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Filepart-Count :"
+msgid "Filepart-Count"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Available :"
+msgid "Available"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Datarate :"
+msgid "Datarate"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Download Active Time: "
+msgid "Download Active Time"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Transferred :"
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "Completed Size :"
+msgid "Completed Size"
 msgstr ""
 
 #: src/muuli_wdr.cpp
@@ -3800,15 +3796,15 @@ msgid "Intelligent Corruption Handling"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Lost to corruption :"
+msgid "Lost to corruption"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Gained by compression :"
+msgid "Gained by compression"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Packages saved by I.C.H. :"
+msgid "Packages saved by I.C.H."
 msgstr ""
 
 #: src/muuli_wdr.cpp
@@ -3847,28 +3843,28 @@ msgstr ""
 msgid "Media Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp
-msgid "Length :"
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
+msgid "Length"
+msgstr ""
+
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
+msgid "Bitrate"
+msgstr ""
+
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
+msgid "Codec"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Bitrate :"
+msgid "Artist"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Codec :"
+msgid "Album"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Artist :"
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "Album :"
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "Title :"
+msgid "Title"
 msgstr ""
 
 #: src/muuli_wdr.cpp
@@ -3953,12 +3949,8 @@ msgstr ""
 msgid "Required Information"
 msgstr ""
 
-#: src/muuli_wdr.cpp
-msgid "IP Address :"
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "Port :"
+#: src/muuli_wdr.cpp src/ServerListCtrl.cpp
+msgid "Port"
 msgstr ""
 
 #: src/muuli_wdr.cpp
@@ -3966,11 +3958,7 @@ msgid "Additional Information"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Username :"
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "Userhash :"
+msgid "Userhash"
 msgstr ""
 
 #: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
@@ -4006,43 +3994,27 @@ msgid "Statistics Tree"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Username:"
+msgid "Client software"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Userhash:"
+msgid "Client version"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Client software:"
+msgid "User ID"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Client version:"
-msgstr ""
-
-#: src/muuli_wdr.cpp src/ServerWnd.cpp
-msgid "IP address:"
+msgid "Server IP"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "User ID:"
+msgid "Server name"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Server IP:"
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "Server name:"
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "Obfuscation:"
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "Kad:"
+msgid "Obfuscation"
 msgstr ""
 
 #: src/muuli_wdr.cpp
@@ -4050,31 +4022,31 @@ msgid "Transfers to client"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Current request:"
+msgid "Current request"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Average upload rate:"
+msgid "Average upload rate"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Average download rate:"
+msgid "Average download rate"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Uploaded (session):"
+msgid "Uploaded (session)"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Downloaded (session):"
+msgid "Downloaded (session)"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Uploaded (total):"
+msgid "Uploaded (total)"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Downloaded (total):"
+msgid "Downloaded (total)"
 msgstr ""
 
 #: src/muuli_wdr.cpp
@@ -4082,19 +4054,19 @@ msgid "Scores"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "DL/UP modifier:"
+msgid "DL/UP modifier"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Secure ident:"
+msgid "Secure ident"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Queue rank:"
+msgid "Queue rank"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Queue score:"
+msgid "Queue score"
 msgstr ""
 
 #: src/muuli_wdr.cpp
@@ -4872,15 +4844,11 @@ msgid "Reset any changes made to the preferences."
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Comment :"
+msgid "Incoming Dir"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Incoming Dir :"
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "Change priority for new assigned files :"
+msgid "Change priority for new assigned files"
 msgstr ""
 
 #: src/muuli_wdr.cpp
@@ -4888,7 +4856,7 @@ msgid "Don't change"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Select color for this Category (currently selected) :"
+msgid "Select color for this Category (currently selected)"
 msgstr ""
 
 #: src/muuli_wdr.cpp
@@ -4969,10 +4937,6 @@ msgstr ""
 
 #: src/muuli_wdr.cpp
 msgid "Enter the IP of the node here, using the x.x.x.x format."
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "Port:"
 msgstr ""
 
 #: src/muuli_wdr.cpp
@@ -5237,11 +5201,11 @@ msgid "Enable/disable proxy support"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Proxy type:"
+msgid "Proxy type"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Proxy host:"
+msgid "Proxy host"
 msgstr ""
 
 #: src/muuli_wdr.cpp
@@ -5249,7 +5213,7 @@ msgid "The proxy host name"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Proxy port:"
+msgid "Proxy port"
 msgstr ""
 
 #: src/muuli_wdr.cpp
@@ -5265,15 +5229,7 @@ msgid "Enable/disable username/password authentication"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Username: "
-msgstr ""
-
-#: src/muuli_wdr.cpp
 msgid "The username to use to connect to the proxy"
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "Password:"
 msgstr ""
 
 #: src/muuli_wdr.cpp
@@ -5446,6 +5402,15 @@ msgstr ""
 
 #: src/OtherFunctions.cpp
 msgid "days"
+msgstr ""
+
+#. TRANSLATORS:
+#. Punctuation for a "label: value" pair. %s is the already-translated
+#. label. Place the colon as your language requires -- e.g. "%s :" with a
+#. space in French, "%s:" without one in Russian and English.
+#: src/OtherFunctions.cpp
+#, c-format
+msgid "%s:"
 msgstr ""
 
 #: src/OtherFunctions.cpp
@@ -6569,18 +6534,6 @@ msgid "FileID"
 msgstr ""
 
 #: src/SearchListCtrl.cpp
-msgid "Length"
-msgstr ""
-
-#: src/SearchListCtrl.cpp
-msgid "Bitrate"
-msgstr ""
-
-#: src/SearchListCtrl.cpp
-msgid "Codec"
-msgstr ""
-
-#: src/SearchListCtrl.cpp
 msgid "Expand all"
 msgstr ""
 
@@ -6855,10 +6808,6 @@ msgstr ""
 
 #: src/ServerListCtrl.cpp
 msgid "Server Name"
-msgstr ""
-
-#: src/ServerListCtrl.cpp
-msgid "Port"
 msgstr ""
 
 #: src/ServerListCtrl.cpp
@@ -7145,6 +7094,10 @@ msgstr ""
 #: src/ServerWnd.cpp
 #, c-format
 msgid "Connected to buddy at %s"
+msgstr ""
+
+#: src/ServerWnd.cpp
+msgid "IP address:"
 msgstr ""
 
 #: src/ServerWnd.cpp

--- a/po/ca.po
+++ b/po/ca.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-04 12:13+0200\n"
+"POT-Creation-Date: 2026-09-05 12:01+0200\n"
 "PO-Revision-Date: 2026-09-03 11:01+0000\n"
 "Last-Translator: minterior <minterior@gmail.com>\n"
 "Language-Team: Català\n"
@@ -387,8 +387,7 @@ msgstr "servidor web executant-se al pid %d"
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Heu demanat que s'executi el servidor web a l'inici, però no s'ha trobat el fitxer binari de l'amuleweb. Si us plau instal·leu el paquet que conté el servidor web de l'aMule, o compileu l'aMule usant la opció --enable-webserver i executeu make install"
 
-#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
-#: src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
+#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
 msgid "ERROR"
 msgstr "ERROR"
 
@@ -676,8 +675,7 @@ msgstr "Xarxes"
 msgid "Searches"
 msgstr "Cerques"
 
-#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/Statistics.cpp
+#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/Statistics.cpp
 msgid "Downloads"
 msgstr "Baixades"
 
@@ -761,9 +759,7 @@ msgstr "Kad: Inativa"
 msgid "Core"
 msgstr ""
 
-#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#: src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp
-#: src/SourceListCtrl.cpp src/Statistics.cpp
+#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp src/Statistics.cpp
 msgid "Version"
 msgstr "Versió"
 
@@ -1062,11 +1058,7 @@ msgstr "No s'ha pogut crear el directori '%s' per a la categoria '%s', es mantin
 msgid "The remote core sent inconsistent data for \"%s\" (part status %d, expected %d). The file list may be showing the wrong information; reconnect to clear it."
 msgstr ""
 
-#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp
-#: src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp
-#: src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp
-#: src/Statistics.cpp
+#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp src/Statistics.cpp
 msgid "Unknown"
 msgstr "Desconegut"
 
@@ -1163,8 +1155,7 @@ msgstr "Error mentre es desava el fitxer %s: %s"
 msgid "Enter Captcha"
 msgstr "Introdueix el Captcha"
 
-#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp
-#: src/TransferWnd.cpp
+#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp src/TransferWnd.cpp
 msgid "Category"
 msgstr "Categoria"
 
@@ -1328,13 +1319,11 @@ msgstr "No s'ha trobat el fitxer 'cryptkey.dat', creant-lo."
 msgid "Client Details"
 msgstr "Detalls del client"
 
-#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
-#: src/utils/wxCas/src/onlinesig.cpp
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
 msgid "LowID"
 msgstr "ID Baixa"
 
-#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
-#: src/utils/wxCas/src/onlinesig.cpp
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
 msgid "HighID"
 msgstr "ID Alta"
 
@@ -1350,8 +1339,7 @@ msgstr "Suportada"
 msgid "Not supported"
 msgstr "No suportada"
 
-#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
-#: src/TextClient.cpp
+#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp src/TextClient.cpp
 msgid "Connected"
 msgstr "Connectat"
 
@@ -1359,28 +1347,24 @@ msgstr "Connectat"
 msgid "Disconnected"
 msgstr "Desconnectat"
 
-#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp
-#: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f KiB/s"
 msgstr ""
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#, fuzzy
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/muuli_wdr.cpp
 msgid "Name"
-msgstr "Nom:"
+msgstr "Nom"
 
 #: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
 msgid "Software"
 msgstr ""
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#, fuzzy
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/muuli_wdr.cpp
 msgid "IP Address"
-msgstr "Adreça IP:"
+msgstr "Adreça IP"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Origin"
 msgstr "Origen"
 
@@ -1398,13 +1382,11 @@ msgstr "Última recepció"
 msgid "Sessions"
 msgstr "Versió"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp
 msgid "Upload Speed"
 msgstr "Velocitat de pujada"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp
 msgid "Download Speed"
 msgstr "Velocitat de baixada"
 
@@ -1459,13 +1441,11 @@ msgstr[1] ""
 msgid "Files"
 msgstr "Fitxers"
 
-#: src/ClientsListCtrl.cpp src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp
-#: src/SourceListCtrl.cpp
+#: src/ClientsListCtrl.cpp src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Uploaded"
 msgstr "Transferit"
 
-#: src/ClientsListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientsListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Downloaded"
 msgstr "Baixat"
 
@@ -1552,12 +1532,11 @@ msgstr "L'usuari %s (%u) ha denegat l'accés a la llista de fitxers/directoris c
 msgid "File Comments"
 msgstr "Comentaris del Fitxer"
 
-#: src/CommentDialogLst.cpp src/FriendListCtrl.cpp
+#: src/CommentDialogLst.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
 msgid "Username"
 msgstr "Usuari"
 
-#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp
-#: src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "File Name"
 msgstr "Fitxer"
 
@@ -1565,7 +1544,7 @@ msgstr "Fitxer"
 msgid "Rating"
 msgstr "Valoració"
 
-#: src/CommentDialogLst.cpp
+#: src/CommentDialogLst.cpp src/muuli_wdr.cpp
 msgid "Comment"
 msgstr "Comentari"
 
@@ -1619,18 +1598,15 @@ msgstr "Auto [Al]"
 msgid "Very low"
 msgstr "Molt baixa"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Low"
 msgstr "Baixa"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Normal"
 msgstr "Normal"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "High"
 msgstr "Alta"
 
@@ -1654,13 +1630,11 @@ msgstr "S'està connectant via servidor"
 msgid "Queue Full"
 msgstr "Cua plena"
 
-#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp
-#: src/muuli_wdr.cpp
+#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp src/muuli_wdr.cpp
 msgid "On Queue"
 msgstr "Cua"
 
-#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp
-#: src/PartFile.cpp src/TransferWnd.cpp
+#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Downloading"
 msgstr "S'està baixant"
 
@@ -1720,8 +1694,7 @@ msgstr "Servidor local"
 msgid "Remote Server"
 msgstr "Servidor remot"
 
-#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp
-#: src/TextClient.cpp
+#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp src/TextClient.cpp
 msgid "Kad"
 msgstr "Kad"
 
@@ -1745,8 +1718,7 @@ msgstr "Llavors font"
 msgid "Search Result"
 msgstr "Resultat de la cerca"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp
-#: src/TransferWnd.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Completed"
 msgstr "Completat"
 
@@ -1799,8 +1771,7 @@ msgstr ""
 msgid "Part"
 msgstr "Part"
 
-#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp
-#: src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Size"
 msgstr "Mida"
 
@@ -1808,8 +1779,7 @@ msgstr "Mida"
 msgid "Transferred"
 msgstr "Transferit"
 
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
-#: src/SourceListCtrl.cpp
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp src/SourceListCtrl.cpp
 msgid "Speed"
 msgstr "Velocitat"
 
@@ -1817,13 +1787,11 @@ msgstr "Velocitat"
 msgid "Progress"
 msgstr "Progrés"
 
-#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp
-#: src/SearchListCtrl.cpp
+#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
 msgid "Sources"
 msgstr "Fonts"
 
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp
-#: src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Priority"
 msgstr "Prioritat"
 
@@ -1847,9 +1815,7 @@ msgstr "Última recepció"
 msgid "Auto"
 msgstr "Auto"
 
-#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/TransferWnd.cpp
-#: src/utils/wxCas/src/wxcasprefs.cpp
+#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/TransferWnd.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Cancel"
 msgstr "Cancel·la"
 
@@ -1950,8 +1916,7 @@ msgstr "Introduïu un nom nou per al fitxer:"
 msgid "File rename"
 msgstr "Reanomena"
 
-#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp
-#: src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f MiB/s"
 msgstr ""
@@ -2756,13 +2721,11 @@ msgstr ""
 msgid "Start aMule automatically when I log in"
 msgstr ""
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
-#: packaging/windows/installer_strings.c
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp packaging/windows/installer_strings.c
 msgid "Register aMule for ed2k:// links"
 msgstr ""
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
-#: packaging/windows/installer_strings.c
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp packaging/windows/installer_strings.c
 msgid "Register aMule for magnet: links"
 msgstr ""
 
@@ -2788,8 +2751,7 @@ msgstr ""
 msgid "Destination folder for downloads"
 msgstr "Carpeta on desar les descàrregues"
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
-#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Browse"
 msgstr "Explora"
 
@@ -3232,18 +3194,15 @@ msgstr "Completant"
 msgid "Complete"
 msgstr "Complet"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
-#: src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Paused"
 msgstr "Pausat"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
-#: src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Erroneous"
 msgstr "Erroni"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
-#: src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Waiting"
 msgstr "Esperant"
 
@@ -3407,8 +3366,7 @@ msgstr "Tanca"
 msgid "Cut"
 msgstr "Retalla"
 
-#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp
-#: src/utils/aLinkCreator/src/alcframe.cpp
+#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy"
 msgstr "Copia"
 
@@ -3416,8 +3374,7 @@ msgstr "Copia"
 msgid "Paste"
 msgstr "Enganxa"
 
-#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp
-#: src/utils/aLinkCreator/src/alcframe.cpp
+#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Clear"
 msgstr "Neteja"
 
@@ -3425,8 +3382,7 @@ msgstr "Neteja"
 msgid "Select All"
 msgstr "Selecciona-ho tot"
 
-#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
-#: src/StatisticsDlg.cpp
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp src/StatisticsDlg.cpp
 msgid "KiB/s"
 msgstr ""
 
@@ -3690,10 +3646,6 @@ msgstr "Servidor connectat actualment."
 msgid "Search"
 msgstr "Cerca"
 
-#: src/muuli_wdr.cpp
-msgid "Name:"
-msgstr "Nom:"
-
 #: src/muuli_wdr.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Type"
 msgstr "Tipus"
@@ -3783,8 +3735,8 @@ msgid "Availability"
 msgstr "Disponibilitat"
 
 #: src/muuli_wdr.cpp
-msgid "Filter:"
-msgstr "Filtre:"
+msgid "Filter"
+msgstr "Filtre"
 
 #: src/muuli_wdr.cpp
 msgid "Invert Result"
@@ -3842,6 +3794,10 @@ msgid "Clears completed downloads"
 msgstr "Neteja les baixades completades"
 
 #: src/muuli_wdr.cpp
+msgid "Filter:"
+msgstr "Filtre:"
+
+#: src/muuli_wdr.cpp
 msgid "File sources:"
 msgstr "Fonts del fitxer:"
 
@@ -3850,80 +3806,76 @@ msgid "General"
 msgstr "General "
 
 #: src/muuli_wdr.cpp
-msgid "Full Name :"
-msgstr "Nom Complet:"
+msgid "Full Name"
+msgstr "Nom Complet"
 
 #: src/muuli_wdr.cpp
-msgid "met-File :"
-msgstr "Fitxer-met:"
+msgid "met-File"
+msgstr "Fitxer-met"
 
 #: src/muuli_wdr.cpp
-msgid "Hash :"
-msgstr "Resum:"
+msgid "Hash"
+msgstr "Resum"
 
 #: src/muuli_wdr.cpp
-msgid "Filesize :"
-msgstr "Mida:"
+msgid "Filesize"
+msgstr "Mida"
 
 #: src/muuli_wdr.cpp src/Statistics.cpp
 msgid "Transfer"
 msgstr "Transferència "
 
 #: src/muuli_wdr.cpp
-msgid "Partfilestatus :"
-msgstr "Estat de les parts:"
+msgid "Partfilestatus"
+msgstr "Estat de les parts"
 
 #: src/muuli_wdr.cpp
-msgid "Last seen complete :"
-msgstr "Últim cop vist complet:"
+msgid "Last seen complete"
+msgstr "Últim cop vist complet"
 
 #: src/muuli_wdr.cpp
-msgid "Found Sources :"
-msgstr "Fonts trobades:"
+msgid "Found Sources"
+msgstr "Fonts trobades"
 
 #: src/muuli_wdr.cpp
-msgid "Transferring Sources :"
-msgstr "Fonts transferint:"
+msgid "Transferring Sources"
+msgstr "Fonts transferint"
 
 #: src/muuli_wdr.cpp
-msgid "Filepart-Count :"
-msgstr "Compte de parts:"
+msgid "Filepart-Count"
+msgstr "Compte de parts"
 
 #: src/muuli_wdr.cpp
-msgid "Available :"
-msgstr "Disponibilitat:"
+msgid "Available"
+msgstr "Disponibilitat"
 
 #: src/muuli_wdr.cpp
-msgid "Datarate :"
-msgstr "Velocitat:"
+msgid "Datarate"
+msgstr "Velocitat"
 
 #: src/muuli_wdr.cpp
-msgid "Download Active Time: "
-msgstr "Temps actiu de baixada:"
+msgid "Download Active Time"
+msgstr "Temps actiu de baixada"
 
 #: src/muuli_wdr.cpp
-msgid "Transferred :"
-msgstr "Transferit:"
-
-#: src/muuli_wdr.cpp
-msgid "Completed Size :"
-msgstr "Completats:"
+msgid "Completed Size"
+msgstr "Completats"
 
 #: src/muuli_wdr.cpp
 msgid "Intelligent Corruption Handling"
 msgstr "Gestió intel·ligent de la corrupció "
 
 #: src/muuli_wdr.cpp
-msgid "Lost to corruption :"
-msgstr "Perdut per corrupció:"
+msgid "Lost to corruption"
+msgstr "Perdut per corrupció"
 
 #: src/muuli_wdr.cpp
-msgid "Gained by compression :"
-msgstr "Guanyat per compressió:"
+msgid "Gained by compression"
+msgstr "Guanyat per compressió"
 
 #: src/muuli_wdr.cpp
-msgid "Packages saved by I.C.H. :"
-msgstr "Paquets recuperats per I.C.H.:"
+msgid "Packages saved by I.C.H."
+msgstr "Paquets recuperats per I.C.H."
 
 #: src/muuli_wdr.cpp
 #, fuzzy
@@ -3965,30 +3917,30 @@ msgstr ", pujat: "
 msgid "Media Info"
 msgstr "Info. Kad"
 
-#: src/muuli_wdr.cpp
-msgid "Length :"
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
+msgid "Length"
 msgstr ""
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
 #, fuzzy
-msgid "Bitrate :"
+msgid "Bitrate"
 msgstr "Sense Valorar"
 
-#: src/muuli_wdr.cpp
-msgid "Codec :"
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
+msgid "Codec"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Artist :"
+msgid "Artist"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Album :"
+msgid "Album"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Title :"
-msgstr "Títol:"
+msgid "Title"
+msgstr "Títol"
 
 #: src/muuli_wdr.cpp
 msgid "File Names"
@@ -4075,25 +4027,17 @@ msgstr "Mida desconeguda"
 msgid "Required Information"
 msgstr "Informació requerida"
 
-#: src/muuli_wdr.cpp
-msgid "IP Address :"
-msgstr "Adreça IP:"
-
-#: src/muuli_wdr.cpp
-msgid "Port :"
-msgstr "Port:"
+#: src/muuli_wdr.cpp src/ServerListCtrl.cpp
+msgid "Port"
+msgstr "Port"
 
 #: src/muuli_wdr.cpp
 msgid "Additional Information"
 msgstr "Informació addicional"
 
 #: src/muuli_wdr.cpp
-msgid "Username :"
-msgstr "Usuari:"
-
-#: src/muuli_wdr.cpp
-msgid "Userhash :"
-msgstr "Resum de l'usuari:"
+msgid "Userhash"
+msgstr "Resum de l'usuari"
 
 #: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Add"
@@ -4128,96 +4072,80 @@ msgid "Statistics Tree"
 msgstr "Arbre d'estadístiques"
 
 #: src/muuli_wdr.cpp
-msgid "Username:"
-msgstr "Nom d'usuari:"
+msgid "Client software"
+msgstr "Programari"
 
 #: src/muuli_wdr.cpp
-msgid "Userhash:"
-msgstr "Resum de l'usuari:"
+msgid "Client version"
+msgstr "Versió del client"
 
 #: src/muuli_wdr.cpp
-msgid "Client software:"
-msgstr "Programari:"
+msgid "User ID"
+msgstr "ID de l'usuari"
 
 #: src/muuli_wdr.cpp
-msgid "Client version:"
-msgstr "Versió del client:"
-
-#: src/muuli_wdr.cpp src/ServerWnd.cpp
-msgid "IP address:"
-msgstr "Adreça IP:"
+msgid "Server IP"
+msgstr "IP del servidor"
 
 #: src/muuli_wdr.cpp
-msgid "User ID:"
-msgstr "ID de l'usuari:"
+msgid "Server name"
+msgstr "Nom del servidor"
 
 #: src/muuli_wdr.cpp
-msgid "Server IP:"
-msgstr "IP del servidor:"
-
-#: src/muuli_wdr.cpp
-msgid "Server name:"
-msgstr "Nom del servidor:"
-
-#: src/muuli_wdr.cpp
-msgid "Obfuscation:"
-msgstr "Ofuscació:"
-
-#: src/muuli_wdr.cpp
-msgid "Kad:"
-msgstr "Kad:"
+msgid "Obfuscation"
+msgstr "Ofuscació"
 
 #: src/muuli_wdr.cpp
 msgid "Transfers to client"
 msgstr "Transferències amb el client"
 
 #: src/muuli_wdr.cpp
-msgid "Current request:"
-msgstr "Petició actual:"
+msgid "Current request"
+msgstr "Petició actual"
 
 #: src/muuli_wdr.cpp
-msgid "Average upload rate:"
-msgstr "Mitjana de pujada:"
+msgid "Average upload rate"
+msgstr "Mitjana de pujada"
 
 #: src/muuli_wdr.cpp
-msgid "Average download rate:"
-msgstr "Mitjana de baixada:"
+msgid "Average download rate"
+msgstr "Mitjana de baixada"
 
 #: src/muuli_wdr.cpp
-msgid "Uploaded (session):"
-msgstr "Pujat (sessió):"
+msgid "Uploaded (session)"
+msgstr "Pujat (sessió)"
 
 #: src/muuli_wdr.cpp
-msgid "Downloaded (session):"
-msgstr "Baixat (sessió):"
+msgid "Downloaded (session)"
+msgstr "Baixat (sessió)"
 
 #: src/muuli_wdr.cpp
-msgid "Uploaded (total):"
-msgstr "Pujat (total):"
+msgid "Uploaded (total)"
+msgstr "Pujat (total)"
 
 #: src/muuli_wdr.cpp
-msgid "Downloaded (total):"
-msgstr "Baixat (total):"
+msgid "Downloaded (total)"
+msgstr "Baixat (total)"
 
 #: src/muuli_wdr.cpp
 msgid "Scores"
 msgstr "Puntuacions"
 
 #: src/muuli_wdr.cpp
-msgid "DL/UP modifier:"
-msgstr "Modificador PU/BA:"
+msgid "DL/UP modifier"
+msgstr "Modificador PU/BA"
 
 #: src/muuli_wdr.cpp
-msgid "Secure ident:"
-msgstr "Identificació segura:"
+msgid "Secure ident"
+msgstr "Identificació segura"
 
 #: src/muuli_wdr.cpp
-msgid "Queue rank:"
-msgstr "Posició a la cua:"
+msgid "Queue rank"
+msgstr "Posició a la cua"
 
 #: src/muuli_wdr.cpp
-msgid "Queue score:"
-msgstr "Puntuació (a la cua):"
+msgid "Queue score"
+msgstr "Puntuació (a la cua)"
 
 #: src/muuli_wdr.cpp
 msgid "Nick"
@@ -5012,24 +4940,20 @@ msgid "Reset any changes made to the preferences."
 msgstr "Reinicia qualsevol canvi fet a les preferències."
 
 #: src/muuli_wdr.cpp
-msgid "Comment :"
-msgstr "Comentari:"
+msgid "Incoming Dir"
+msgstr "Dir. d'entrada"
 
 #: src/muuli_wdr.cpp
-msgid "Incoming Dir :"
-msgstr "Dir. d'entrada:"
-
-#: src/muuli_wdr.cpp
-msgid "Change priority for new assigned files :"
-msgstr "Canvia la prioritat per als nous fitxers assignats:"
+msgid "Change priority for new assigned files"
+msgstr "Canvia la prioritat per als nous fitxers assignats"
 
 #: src/muuli_wdr.cpp
 msgid "Don't change"
 msgstr "No canviar"
 
 #: src/muuli_wdr.cpp
-msgid "Select color for this Category (currently selected) :"
-msgstr "Seleccioneu un color per a la Categoria (actualment seleccionat):"
+msgid "Select color for this Category (currently selected)"
+msgstr "Seleccioneu un color per a la Categoria (actualment seleccionat)"
 
 #: src/muuli_wdr.cpp
 msgid "Click this button to reset the log."
@@ -5112,10 +5036,6 @@ msgstr "Inicia des dels clients coneguts"
 #, fuzzy
 msgid "Enter the IP of the node here, using the x.x.x.x format."
 msgstr "Introduïu la IP del servidor, fent servir el format x.x.x.x."
-
-#: src/muuli_wdr.cpp
-msgid "Port:"
-msgstr "Port:"
 
 #: src/muuli_wdr.cpp
 msgid "Use Secure User Identification"
@@ -5384,20 +5304,20 @@ msgid "Enable/disable proxy support"
 msgstr "Habilita/inhabilita el suport per a servidor intermediari"
 
 #: src/muuli_wdr.cpp
-msgid "Proxy type:"
-msgstr "Tipus de servidor:"
+msgid "Proxy type"
+msgstr "Tipus de servidor"
 
 #: src/muuli_wdr.cpp
-msgid "Proxy host:"
-msgstr "Servidor intermediari:"
+msgid "Proxy host"
+msgstr "Servidor intermediari"
 
 #: src/muuli_wdr.cpp
 msgid "The proxy host name"
 msgstr "El nom del servidor intermediari"
 
 #: src/muuli_wdr.cpp
-msgid "Proxy port:"
-msgstr "Port del servidor:"
+msgid "Proxy port"
+msgstr "Port del servidor"
 
 #: src/muuli_wdr.cpp
 msgid "The proxy port"
@@ -5412,16 +5332,8 @@ msgid "Enable/disable username/password authentication"
 msgstr "Habilita/inhabilita l'autenticació amb usuari/contrasenya"
 
 #: src/muuli_wdr.cpp
-msgid "Username: "
-msgstr "Nom d'usuari:"
-
-#: src/muuli_wdr.cpp
 msgid "The username to use to connect to the proxy"
 msgstr "El nom d'usuari per a connectar al servidor intermediari"
-
-#: src/muuli_wdr.cpp
-msgid "Password:"
-msgstr "Contrasenya:"
 
 #: src/muuli_wdr.cpp
 msgid "The password to use to connect to the proxy"
@@ -5596,6 +5508,15 @@ msgstr "hores"
 #: src/OtherFunctions.cpp
 msgid "days"
 msgstr "dies"
+
+#. TRANSLATORS:
+#. Punctuation for a "label: value" pair. %s is the already-translated
+#. label. Place the colon as your language requires -- e.g. "%s :" with a
+#. space in French, "%s:" without one in Russian and English.
+#: src/OtherFunctions.cpp
+#, c-format
+msgid "%s:"
+msgstr ""
 
 #: src/OtherFunctions.cpp
 msgid "all"
@@ -6640,8 +6561,7 @@ msgstr ""
 msgid "Confirm shared folders"
 msgstr "Carpetes compartides"
 
-#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp
-#: src/SharedFilesReloadProgress.cpp
+#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp src/SharedFilesReloadProgress.cpp
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "Recarrega els compartits"
@@ -6773,19 +6693,6 @@ msgstr "Error actualitzant GeoIP.dat"
 #: src/SearchListCtrl.cpp
 msgid "FileID"
 msgstr "Resum del fitxer"
-
-#: src/SearchListCtrl.cpp
-msgid "Length"
-msgstr ""
-
-#: src/SearchListCtrl.cpp
-#, fuzzy
-msgid "Bitrate"
-msgstr "Sense Valorar"
-
-#: src/SearchListCtrl.cpp
-msgid "Codec"
-msgstr ""
 
 #: src/SearchListCtrl.cpp
 msgid "Expand all"
@@ -7070,10 +6977,6 @@ msgstr "El servidor local està filtrat pels filtres IP, s'està reconnectant a 
 #: src/ServerListCtrl.cpp
 msgid "Server Name"
 msgstr "Nom"
-
-#: src/ServerListCtrl.cpp
-msgid "Port"
-msgstr "Port"
 
 #: src/ServerListCtrl.cpp
 msgid "Description"
@@ -7367,6 +7270,10 @@ msgstr "Connectant amb un amic"
 #, c-format
 msgid "Connected to buddy at %s"
 msgstr "Connectat amb l'amic a %s"
+
+#: src/ServerWnd.cpp
+msgid "IP address:"
+msgstr "Adreça IP:"
 
 #: src/ServerWnd.cpp
 msgid "Indexed sources:"

--- a/po/cs.po
+++ b/po/cs.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-04 12:13+0200\n"
+"POT-Creation-Date: 2026-09-05 12:01+0200\n"
 "PO-Revision-Date: 2026-09-03 11:02+0000\n"
 "Last-Translator: David Watzke <david@watzke.cz>\n"
 "Language-Team: cs <cs@li.org>\n"
@@ -387,8 +387,7 @@ msgstr "webserver běží s PID %d"
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Požádali jste o spuštění webového serveru po startu, avšak binární soubor amuleweb nelze spustit. Nainstalujte balíček obsahující webový server aMule, nebo sestavte aMule ze zdrojového kódu pomocí přepínače -DBUILD_WEBSERVER=YES a pak jej nainstalujte."
 
-#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
-#: src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
+#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
 msgid "ERROR"
 msgstr "CHYBA"
 
@@ -674,8 +673,7 @@ msgstr "Sítě"
 msgid "Searches"
 msgstr "Vyhledávání"
 
-#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/Statistics.cpp
+#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/Statistics.cpp
 msgid "Downloads"
 msgstr "Stahování"
 
@@ -763,9 +761,7 @@ msgstr "Kad: vypnut"
 msgid "Core"
 msgstr ""
 
-#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#: src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp
-#: src/SourceListCtrl.cpp src/Statistics.cpp
+#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp src/Statistics.cpp
 msgid "Version"
 msgstr "Verze"
 
@@ -1064,11 +1060,7 @@ msgstr "Nejde vytvořit adresář '%s' pro kategorii '%s', zachovávám adresá�
 msgid "The remote core sent inconsistent data for \"%s\" (part status %d, expected %d). The file list may be showing the wrong information; reconnect to clear it."
 msgstr "Vzdálené jádro odeslalo nekonzistentní data pro \"%s\" (částečný stav %d, očekáváno %d). Seznam souborů může zobrazovat nesprávné informace; opět se připojte pro vyčištění."
 
-#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp
-#: src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp
-#: src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp
-#: src/Statistics.cpp
+#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp src/Statistics.cpp
 msgid "Unknown"
 msgstr "Neznámý"
 
@@ -1167,8 +1159,7 @@ msgstr "Chyba při ukládání souboru %s: %s"
 msgid "Enter Captcha"
 msgstr "Vložte captchu"
 
-#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp
-#: src/TransferWnd.cpp
+#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp src/TransferWnd.cpp
 msgid "Category"
 msgstr "Kategorie"
 
@@ -1337,13 +1328,11 @@ msgstr "Soubor 'cryptkey.dat' nenalezen, vytvářím."
 msgid "Client Details"
 msgstr "Podrobnosti klienta"
 
-#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
-#: src/utils/wxCas/src/onlinesig.cpp
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
 msgid "LowID"
 msgstr "LowID"
 
-#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
-#: src/utils/wxCas/src/onlinesig.cpp
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
 msgid "HighID"
 msgstr "HighID"
 
@@ -1359,8 +1348,7 @@ msgstr "Podporováno"
 msgid "Not supported"
 msgstr "Nepodporováno"
 
-#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
-#: src/TextClient.cpp
+#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp src/TextClient.cpp
 msgid "Connected"
 msgstr "Připojen"
 
@@ -1368,13 +1356,12 @@ msgstr "Připojen"
 msgid "Disconnected"
 msgstr "Odpojeno"
 
-#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp
-#: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f KiB/s"
 msgstr ""
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/muuli_wdr.cpp
 msgid "Name"
 msgstr "Název"
 
@@ -1382,12 +1369,11 @@ msgstr "Název"
 msgid "Software"
 msgstr "Software"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/muuli_wdr.cpp
 msgid "IP Address"
 msgstr "IP adresa"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Origin"
 msgstr "Původ"
 
@@ -1403,13 +1389,11 @@ msgstr "Naposledy viděn"
 msgid "Sessions"
 msgstr "Sezení"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp
 msgid "Upload Speed"
 msgstr "Rychlost odesílání"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp
 msgid "Download Speed"
 msgstr "Rychlost stahování"
 
@@ -1461,13 +1445,11 @@ msgstr[2] "Nešlo přidat %u odkazů (podrobnosti viz log)."
 msgid "Files"
 msgstr "Soubory"
 
-#: src/ClientsListCtrl.cpp src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp
-#: src/SourceListCtrl.cpp
+#: src/ClientsListCtrl.cpp src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Uploaded"
 msgstr "Odesláno"
 
-#: src/ClientsListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientsListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Downloaded"
 msgstr "Staženo"
 
@@ -1551,12 +1533,11 @@ msgstr "Uživatel %s (%u) odmítl přístup k seznamu sdílených adresářů/so
 msgid "File Comments"
 msgstr "Komentáře k souboru"
 
-#: src/CommentDialogLst.cpp src/FriendListCtrl.cpp
+#: src/CommentDialogLst.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
 msgid "Username"
 msgstr "Jméno"
 
-#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp
-#: src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "File Name"
 msgstr "Název souboru"
 
@@ -1564,7 +1545,7 @@ msgstr "Název souboru"
 msgid "Rating"
 msgstr "Hodnocení"
 
-#: src/CommentDialogLst.cpp
+#: src/CommentDialogLst.cpp src/muuli_wdr.cpp
 msgid "Comment"
 msgstr "Komentář"
 
@@ -1618,18 +1599,15 @@ msgstr "Auto [Vy]"
 msgid "Very low"
 msgstr "Velmi nízká"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Low"
 msgstr "Nízká"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Normal"
 msgstr "Normální"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "High"
 msgstr "Vysoká"
 
@@ -1653,13 +1631,11 @@ msgstr "Připojuji se přes server"
 msgid "Queue Full"
 msgstr "Plná fronta"
 
-#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp
-#: src/muuli_wdr.cpp
+#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp src/muuli_wdr.cpp
 msgid "On Queue"
 msgstr "Ve frontě"
 
-#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp
-#: src/PartFile.cpp src/TransferWnd.cpp
+#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Downloading"
 msgstr "Stahuji"
 
@@ -1719,8 +1695,7 @@ msgstr "Lokální server"
 msgid "Remote Server"
 msgstr "Vzdálený server"
 
-#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp
-#: src/TextClient.cpp
+#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp src/TextClient.cpp
 msgid "Kad"
 msgstr "Kad"
 
@@ -1744,8 +1719,7 @@ msgstr "Zdrojové seedy"
 msgid "Search Result"
 msgstr "Výsledek hledání"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp
-#: src/TransferWnd.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Completed"
 msgstr "Dokončeno"
 
@@ -1797,8 +1771,7 @@ msgstr "Nelze provézt úpravu v rekurzivním sdílení"
 msgid "Part"
 msgstr "Část"
 
-#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp
-#: src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Size"
 msgstr "Velikost"
 
@@ -1806,8 +1779,7 @@ msgstr "Velikost"
 msgid "Transferred"
 msgstr "Přeneseno"
 
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
-#: src/SourceListCtrl.cpp
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp src/SourceListCtrl.cpp
 msgid "Speed"
 msgstr "Rychlost"
 
@@ -1815,13 +1787,11 @@ msgstr "Rychlost"
 msgid "Progress"
 msgstr "Průběh"
 
-#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp
-#: src/SearchListCtrl.cpp
+#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
 msgid "Sources"
 msgstr "Zdroje"
 
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp
-#: src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Priority"
 msgstr "Priorita"
 
@@ -1845,9 +1815,7 @@ msgstr "Poslední příjem"
 msgid "Auto"
 msgstr "Auto"
 
-#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/TransferWnd.cpp
-#: src/utils/wxCas/src/wxcasprefs.cpp
+#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/TransferWnd.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Cancel"
 msgstr "Zrušit"
 
@@ -1948,8 +1916,7 @@ msgstr "Zadejte nový název pro tento soubor:"
 msgid "File rename"
 msgstr "Přejmenování souboru"
 
-#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp
-#: src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f MiB/s"
 msgstr ""
@@ -2759,13 +2726,11 @@ msgstr ""
 msgid "Start aMule automatically when I log in"
 msgstr "Spustit aMule automaticky po přihlášení"
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
-#: packaging/windows/installer_strings.c
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp packaging/windows/installer_strings.c
 msgid "Register aMule for ed2k:// links"
 msgstr "Zaregistrovat aMule pro odkazy ed2k://"
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
-#: packaging/windows/installer_strings.c
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp packaging/windows/installer_strings.c
 msgid "Register aMule for magnet: links"
 msgstr "Zaregistrovat aMule pro odkazy magnet:"
 
@@ -2793,8 +2758,7 @@ msgstr ""
 msgid "Destination folder for downloads"
 msgstr "Cílová složka pro stahování"
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
-#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Browse"
 msgstr "Procházet"
 
@@ -3243,18 +3207,15 @@ msgstr "Dokončování"
 msgid "Complete"
 msgstr "Dokončeno"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
-#: src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Paused"
 msgstr "Pozastaveno"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
-#: src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Erroneous"
 msgstr "Poškozený"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
-#: src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Waiting"
 msgstr "Čekám"
 
@@ -3421,8 +3382,7 @@ msgstr "Zavřít"
 msgid "Cut"
 msgstr "Vyjmout"
 
-#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp
-#: src/utils/aLinkCreator/src/alcframe.cpp
+#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy"
 msgstr "Kopírovat"
 
@@ -3430,8 +3390,7 @@ msgstr "Kopírovat"
 msgid "Paste"
 msgstr "Vložit"
 
-#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp
-#: src/utils/aLinkCreator/src/alcframe.cpp
+#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Clear"
 msgstr "Vyčistit"
 
@@ -3439,8 +3398,7 @@ msgstr "Vyčistit"
 msgid "Select All"
 msgstr "Označit vše"
 
-#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
-#: src/StatisticsDlg.cpp
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp src/StatisticsDlg.cpp
 msgid "KiB/s"
 msgstr ""
 
@@ -3695,10 +3653,6 @@ msgstr "Aktuální připojený server."
 msgid "Search"
 msgstr "Vyhledávání"
 
-#: src/muuli_wdr.cpp
-msgid "Name:"
-msgstr "Název:"
-
 #: src/muuli_wdr.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Type"
 msgstr "Typ"
@@ -3788,8 +3742,8 @@ msgid "Availability"
 msgstr "Dostupnost"
 
 #: src/muuli_wdr.cpp
-msgid "Filter:"
-msgstr "Filtr:"
+msgid "Filter"
+msgstr "Filtr"
 
 #: src/muuli_wdr.cpp
 msgid "Invert Result"
@@ -3844,6 +3798,10 @@ msgid "Clears completed downloads"
 msgstr "Vyčistí dokončená stahování"
 
 #: src/muuli_wdr.cpp
+msgid "Filter:"
+msgstr "Filtr:"
+
+#: src/muuli_wdr.cpp
 msgid "File sources:"
 msgstr "Zdroje souboru:"
 
@@ -3852,80 +3810,77 @@ msgid "General"
 msgstr "Hlavní"
 
 #: src/muuli_wdr.cpp
-msgid "Full Name :"
-msgstr "Celá název:"
+msgid "Full Name"
+msgstr "Celá název"
 
 #: src/muuli_wdr.cpp
-msgid "met-File :"
-msgstr "Soubor .met:"
+msgid "met-File"
+msgstr "Soubor .met"
 
 #: src/muuli_wdr.cpp
-msgid "Hash :"
-msgstr "Hash:"
+msgid "Hash"
+msgstr "Hash"
 
 #: src/muuli_wdr.cpp
-msgid "Filesize :"
-msgstr "Velikost:"
+msgid "Filesize"
+msgstr "Velikost"
 
 #: src/muuli_wdr.cpp src/Statistics.cpp
 msgid "Transfer"
 msgstr "Přenos"
 
 #: src/muuli_wdr.cpp
-msgid "Partfilestatus :"
-msgstr "Stav souboru part :"
+msgid "Partfilestatus"
+msgstr "Stav souboru part"
 
 #: src/muuli_wdr.cpp
-msgid "Last seen complete :"
-msgstr "Naposledy spatřen kompletní:"
+msgid "Last seen complete"
+msgstr "Naposledy spatřen kompletní"
 
 #: src/muuli_wdr.cpp
-msgid "Found Sources :"
-msgstr "Nalezené zdroje:"
+msgid "Found Sources"
+msgstr "Nalezené zdroje"
 
 #: src/muuli_wdr.cpp
-msgid "Transferring Sources :"
-msgstr "Přenášející zdroje :"
+msgid "Transferring Sources"
+msgstr "Přenášející zdroje"
 
 #: src/muuli_wdr.cpp
-msgid "Filepart-Count :"
+msgid "Filepart-Count"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Available :"
-msgstr "Dostupný:"
+msgid "Available"
+msgstr "Dostupný"
 
 #: src/muuli_wdr.cpp
-msgid "Datarate :"
-msgstr ""
+#, fuzzy
+msgid "Datarate"
+msgstr "Nehodnocené"
 
 #: src/muuli_wdr.cpp
-msgid "Download Active Time: "
-msgstr "Doba stahování:"
+msgid "Download Active Time"
+msgstr "Doba stahování"
 
 #: src/muuli_wdr.cpp
-msgid "Transferred :"
-msgstr "Přeneseno:"
-
-#: src/muuli_wdr.cpp
-msgid "Completed Size :"
-msgstr "Dokončeno:"
+msgid "Completed Size"
+msgstr "Dokončeno"
 
 #: src/muuli_wdr.cpp
 msgid "Intelligent Corruption Handling"
 msgstr "Chytré zacházení s poškozenými částmi"
 
 #: src/muuli_wdr.cpp
-msgid "Lost to corruption :"
-msgstr "Ztraceno poškozením:"
+msgid "Lost to corruption"
+msgstr "Ztraceno poškozením"
 
 #: src/muuli_wdr.cpp
-msgid "Gained by compression :"
-msgstr "Získáno kompresí:"
+msgid "Gained by compression"
+msgstr "Získáno kompresí"
 
 #: src/muuli_wdr.cpp
-msgid "Packages saved by I.C.H. :"
-msgstr "Balíčků zachráněných pomocí I.C.H.:"
+msgid "Packages saved by I.C.H."
+msgstr "Balíčků zachráněných pomocí I.C.H."
 
 #: src/muuli_wdr.cpp
 msgid "Sharing"
@@ -3963,29 +3918,30 @@ msgstr "Poslední odeslání"
 msgid "Media Info"
 msgstr "Media Info"
 
-#: src/muuli_wdr.cpp
-msgid "Length :"
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
+msgid "Length"
+msgstr ""
+
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
+#, fuzzy
+msgid "Bitrate"
+msgstr "Nehodnocené"
+
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
+msgid "Codec"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Bitrate :"
-msgstr "Datový tok :"
+msgid "Artist"
+msgstr "Umělec"
 
 #: src/muuli_wdr.cpp
-msgid "Codec :"
+msgid "Album"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Artist :"
-msgstr "Umělec :"
-
-#: src/muuli_wdr.cpp
-msgid "Album :"
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "Title :"
-msgstr "Titulek:"
+msgid "Title"
+msgstr "Titulek"
 
 #: src/muuli_wdr.cpp
 msgid "File Names"
@@ -4071,25 +4027,17 @@ msgstr "Neznámá velikost"
 msgid "Required Information"
 msgstr "Nezbytné informace"
 
-#: src/muuli_wdr.cpp
-msgid "IP Address :"
-msgstr "IP adresa :"
-
-#: src/muuli_wdr.cpp
-msgid "Port :"
-msgstr "Port :"
+#: src/muuli_wdr.cpp src/ServerListCtrl.cpp
+msgid "Port"
+msgstr "Port"
 
 #: src/muuli_wdr.cpp
 msgid "Additional Information"
 msgstr "Dodatečné informace"
 
 #: src/muuli_wdr.cpp
-msgid "Username :"
-msgstr "Uživatelské jméno:"
-
-#: src/muuli_wdr.cpp
-msgid "Userhash :"
-msgstr "Hash uživatele :"
+msgid "Userhash"
+msgstr "Hash uživatele"
 
 #: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Add"
@@ -4124,96 +4072,82 @@ msgid "Statistics Tree"
 msgstr "Strom statistik"
 
 #: src/muuli_wdr.cpp
-msgid "Username:"
-msgstr "Jméno:"
+msgid "Client software"
+msgstr "Software klienta"
 
 #: src/muuli_wdr.cpp
-msgid "Userhash:"
-msgstr "Hash uživatele:"
+msgid "Client version"
+msgstr "Verze klienta"
 
 #: src/muuli_wdr.cpp
-msgid "Client software:"
-msgstr "Software klienta:"
+msgid "User ID"
+msgstr "ID uživ."
 
 #: src/muuli_wdr.cpp
-msgid "Client version:"
-msgstr "Verze klienta:"
-
-#: src/muuli_wdr.cpp src/ServerWnd.cpp
-msgid "IP address:"
-msgstr "IP adresa:"
+msgid "Server IP"
+msgstr "IP serveru"
 
 #: src/muuli_wdr.cpp
-msgid "User ID:"
-msgstr "ID uživ.:"
+msgid "Server name"
+msgstr "Název serveru"
 
 #: src/muuli_wdr.cpp
-msgid "Server IP:"
-msgstr "IP serveru:"
-
-#: src/muuli_wdr.cpp
-msgid "Server name:"
-msgstr "Název serveru:"
-
-#: src/muuli_wdr.cpp
-msgid "Obfuscation:"
-msgstr "Zamaskování:"
-
-#: src/muuli_wdr.cpp
-msgid "Kad:"
-msgstr "Kad:"
+msgid "Obfuscation"
+msgstr "Zamaskování"
 
 #: src/muuli_wdr.cpp
 msgid "Transfers to client"
 msgstr "Přenosy ke klientovi"
 
 #: src/muuli_wdr.cpp
-msgid "Current request:"
-msgstr ""
+#, fuzzy
+msgid "Current request"
+msgstr "Bylo vyžádáno odhlášení\n"
 
 #: src/muuli_wdr.cpp
-msgid "Average upload rate:"
-msgstr "Průmerná rychlost odesílání:"
+msgid "Average upload rate"
+msgstr "Průmerná rychlost odesílání"
 
 #: src/muuli_wdr.cpp
-msgid "Average download rate:"
-msgstr "Průměrná rychlost stahování:"
+msgid "Average download rate"
+msgstr "Průměrná rychlost stahování"
 
 #: src/muuli_wdr.cpp
-msgid "Uploaded (session):"
-msgstr "Odesláno (sezení):"
+msgid "Uploaded (session)"
+msgstr "Odesláno (sezení)"
 
 #: src/muuli_wdr.cpp
-msgid "Downloaded (session):"
-msgstr "Staženo (sezení):"
+msgid "Downloaded (session)"
+msgstr "Staženo (sezení)"
 
 #: src/muuli_wdr.cpp
-msgid "Uploaded (total):"
-msgstr "Odesláno (celkem):"
+msgid "Uploaded (total)"
+msgstr "Odesláno (celkem)"
 
 #: src/muuli_wdr.cpp
-msgid "Downloaded (total):"
-msgstr "Staženo (celkem):"
+msgid "Downloaded (total)"
+msgstr "Staženo (celkem)"
 
 #: src/muuli_wdr.cpp
 msgid "Scores"
 msgstr "Skóre"
 
 #: src/muuli_wdr.cpp
-msgid "DL/UP modifier:"
-msgstr "DL/UP poměr:"
+msgid "DL/UP modifier"
+msgstr "DL/UP poměr"
 
 #: src/muuli_wdr.cpp
-msgid "Secure ident:"
-msgstr ""
+#, fuzzy
+msgid "Secure ident"
+msgstr "Bezpečnost"
 
 #: src/muuli_wdr.cpp
-msgid "Queue rank:"
-msgstr "Pořadí ve frontě:"
+msgid "Queue rank"
+msgstr "Pořadí ve frontě"
 
 #: src/muuli_wdr.cpp
-msgid "Queue score:"
-msgstr "Skóre fronty:"
+msgid "Queue score"
+msgstr "Skóre fronty"
 
 #: src/muuli_wdr.cpp
 msgid "Nick"
@@ -4995,16 +4929,12 @@ msgid "Reset any changes made to the preferences."
 msgstr "Resetovat jakékoli změny v nastavení."
 
 #: src/muuli_wdr.cpp
-msgid "Comment :"
-msgstr "Komentář:"
+msgid "Incoming Dir"
+msgstr "Příchozí adresář"
 
 #: src/muuli_wdr.cpp
-msgid "Incoming Dir :"
-msgstr "Příchozí adresář:"
-
-#: src/muuli_wdr.cpp
-msgid "Change priority for new assigned files :"
-msgstr "Změnit prioritu pro nově přiřazené soubory:"
+msgid "Change priority for new assigned files"
+msgstr "Změnit prioritu pro nově přiřazené soubory"
 
 #: src/muuli_wdr.cpp
 #, fuzzy
@@ -5012,8 +4942,8 @@ msgid "Don't change"
 msgstr "Neměnit"
 
 #: src/muuli_wdr.cpp
-msgid "Select color for this Category (currently selected) :"
-msgstr "Barva pro tuto kategorii:"
+msgid "Select color for this Category (currently selected)"
+msgstr "Barva pro tuto kategorii"
 
 #: src/muuli_wdr.cpp
 msgid "Click this button to reset the log."
@@ -5094,10 +5024,6 @@ msgstr "Zavedení prostřednictvím uzlu: IP"
 #: src/muuli_wdr.cpp
 msgid "Enter the IP of the node here, using the x.x.x.x format."
 msgstr "Zadejte sem IP adresu uzlu ve formátu x.x.x.x."
-
-#: src/muuli_wdr.cpp
-msgid "Port:"
-msgstr "Port:"
 
 #: src/muuli_wdr.cpp
 msgid "Use Secure User Identification"
@@ -5374,20 +5300,20 @@ msgid "Enable/disable proxy support"
 msgstr "Povolí/zakáže proxy"
 
 #: src/muuli_wdr.cpp
-msgid "Proxy type:"
-msgstr "Typ proxy:"
+msgid "Proxy type"
+msgstr "Typ proxy"
 
 #: src/muuli_wdr.cpp
-msgid "Proxy host:"
-msgstr "Hostitel proxy:"
+msgid "Proxy host"
+msgstr "Hostitel proxy"
 
 #: src/muuli_wdr.cpp
 msgid "The proxy host name"
 msgstr "Název hostitele proxy"
 
 #: src/muuli_wdr.cpp
-msgid "Proxy port:"
-msgstr "Port proxy:"
+msgid "Proxy port"
+msgstr "Port proxy"
 
 #: src/muuli_wdr.cpp
 msgid "The proxy port"
@@ -5402,16 +5328,8 @@ msgid "Enable/disable username/password authentication"
 msgstr "Povolí/zakáže autentizaci (uživatelské jméno a heslo)"
 
 #: src/muuli_wdr.cpp
-msgid "Username: "
-msgstr "Uživatelské jméno: "
-
-#: src/muuli_wdr.cpp
 msgid "The username to use to connect to the proxy"
 msgstr "Uživatelské jméno, které se použije pro přihlášení k proxy"
-
-#: src/muuli_wdr.cpp
-msgid "Password:"
-msgstr "Heslo:"
 
 #: src/muuli_wdr.cpp
 msgid "The password to use to connect to the proxy"
@@ -5586,6 +5504,15 @@ msgstr "hod."
 #: src/OtherFunctions.cpp
 msgid "days"
 msgstr "dní"
+
+#. TRANSLATORS:
+#. Punctuation for a "label: value" pair. %s is the already-translated
+#. label. Place the colon as your language requires -- e.g. "%s :" with a
+#. space in French, "%s:" without one in Russian and English.
+#: src/OtherFunctions.cpp
+#, c-format
+msgid "%s:"
+msgstr ""
 
 #: src/OtherFunctions.cpp
 msgid "all"
@@ -6627,8 +6554,7 @@ msgstr ""
 msgid "Confirm shared folders"
 msgstr "Potvrdit sdílené složky"
 
-#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp
-#: src/SharedFilesReloadProgress.cpp
+#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp src/SharedFilesReloadProgress.cpp
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "Znovu načíst vaše sdílené soubory"
@@ -6757,19 +6683,6 @@ msgstr "Selhala aktualizace GeoIP.dat"
 #: src/SearchListCtrl.cpp
 msgid "FileID"
 msgstr "ID souboru"
-
-#: src/SearchListCtrl.cpp
-msgid "Length"
-msgstr ""
-
-#: src/SearchListCtrl.cpp
-#, fuzzy
-msgid "Bitrate"
-msgstr "Nehodnocené"
-
-#: src/SearchListCtrl.cpp
-msgid "Codec"
-msgstr ""
 
 #: src/SearchListCtrl.cpp
 msgid "Expand all"
@@ -7057,10 +6970,6 @@ msgstr ""
 #: src/ServerListCtrl.cpp
 msgid "Server Name"
 msgstr "Název serveru"
-
-#: src/ServerListCtrl.cpp
-msgid "Port"
-msgstr "Port"
 
 #: src/ServerListCtrl.cpp
 msgid "Description"
@@ -7359,6 +7268,10 @@ msgstr "Připojuji se ke kamarádovi"
 #, c-format
 msgid "Connected to buddy at %s"
 msgstr "Připojen ke kamarádovi na %s"
+
+#: src/ServerWnd.cpp
+msgid "IP address:"
+msgstr "IP adresa:"
 
 #: src/ServerWnd.cpp
 msgid "Indexed sources:"

--- a/po/da.po
+++ b/po/da.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-04 12:13+0200\n"
+"POT-Creation-Date: 2026-09-05 12:01+0200\n"
 "PO-Revision-Date: 2026-09-03 11:02+0000\n"
 "Last-Translator: Alex Thomsen Leth <alexl@stofanet.dk>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -376,8 +376,7 @@ msgstr ""
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr ""
 
-#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
-#: src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
+#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
 msgid "ERROR"
 msgstr ""
 
@@ -657,8 +656,7 @@ msgstr ""
 msgid "Searches"
 msgstr "Søg"
 
-#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/Statistics.cpp
+#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/Statistics.cpp
 msgid "Downloads"
 msgstr "Downloads"
 
@@ -746,9 +744,7 @@ msgstr " Kad: "
 msgid "Core"
 msgstr ""
 
-#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#: src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp
-#: src/SourceListCtrl.cpp src/Statistics.cpp
+#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp src/Statistics.cpp
 msgid "Version"
 msgstr ""
 
@@ -1050,11 +1046,7 @@ msgstr ""
 msgid "The remote core sent inconsistent data for \"%s\" (part status %d, expected %d). The file list may be showing the wrong information; reconnect to clear it."
 msgstr ""
 
-#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp
-#: src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp
-#: src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp
-#: src/Statistics.cpp
+#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp src/Statistics.cpp
 msgid "Unknown"
 msgstr "Ukendt"
 
@@ -1152,8 +1144,7 @@ msgstr "Fejl ved forbindelse til %s (%s:%i): %d"
 msgid "Enter Captcha"
 msgstr ""
 
-#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp
-#: src/TransferWnd.cpp
+#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp src/TransferWnd.cpp
 msgid "Category"
 msgstr "Kategori"
 
@@ -1314,13 +1305,11 @@ msgstr ""
 msgid "Client Details"
 msgstr "Klient Detaljer"
 
-#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
-#: src/utils/wxCas/src/onlinesig.cpp
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
 msgid "LowID"
 msgstr "Lavt ID"
 
-#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
-#: src/utils/wxCas/src/onlinesig.cpp
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
 msgid "HighID"
 msgstr "HøjtID"
 
@@ -1336,8 +1325,7 @@ msgstr ""
 msgid "Not supported"
 msgstr ""
 
-#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
-#: src/TextClient.cpp
+#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp src/TextClient.cpp
 msgid "Connected"
 msgstr "Forbundet"
 
@@ -1345,13 +1333,12 @@ msgstr "Forbundet"
 msgid "Disconnected"
 msgstr "Afbrudt"
 
-#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp
-#: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f KiB/s"
 msgstr ""
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/muuli_wdr.cpp
 #, fuzzy
 msgid "Name"
 msgstr "Fil Navn"
@@ -1360,13 +1347,11 @@ msgstr "Fil Navn"
 msgid "Software"
 msgstr ""
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#, fuzzy
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/muuli_wdr.cpp
 msgid "IP Address"
-msgstr "IP Adresse :"
+msgstr "IP Adresse"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Origin"
 msgstr ""
 
@@ -1384,14 +1369,12 @@ msgstr "Sidste Kontakt"
 msgid "Sessions"
 msgstr "Sessions Gennemsnit"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp
 #, fuzzy
 msgid "Upload Speed"
 msgstr "Upload-Hastighed"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp
 #, fuzzy
 msgid "Download Speed"
 msgstr "Download-Hastighed"
@@ -1446,13 +1429,11 @@ msgstr[1] ""
 msgid "Files"
 msgstr "Filer"
 
-#: src/ClientsListCtrl.cpp src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp
-#: src/SourceListCtrl.cpp
+#: src/ClientsListCtrl.cpp src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Uploaded"
 msgstr ""
 
-#: src/ClientsListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientsListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Downloaded"
 msgstr ""
 
@@ -1539,12 +1520,11 @@ msgstr ""
 msgid "File Comments"
 msgstr "Fil Kommentarer"
 
-#: src/CommentDialogLst.cpp src/FriendListCtrl.cpp
+#: src/CommentDialogLst.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
 msgid "Username"
 msgstr "Brugernavn"
 
-#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp
-#: src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "File Name"
 msgstr "Fil Navn"
 
@@ -1552,7 +1532,7 @@ msgstr "Fil Navn"
 msgid "Rating"
 msgstr ""
 
-#: src/CommentDialogLst.cpp
+#: src/CommentDialogLst.cpp src/muuli_wdr.cpp
 msgid "Comment"
 msgstr ""
 
@@ -1606,18 +1586,15 @@ msgstr "Auto [Hø]"
 msgid "Very low"
 msgstr "Meget lav"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Low"
 msgstr "Lav"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Normal"
 msgstr "Normal"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "High"
 msgstr "Høj"
 
@@ -1641,13 +1618,11 @@ msgstr "Forbinder via Server"
 msgid "Queue Full"
 msgstr "Kø Fuld"
 
-#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp
-#: src/muuli_wdr.cpp
+#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp src/muuli_wdr.cpp
 msgid "On Queue"
 msgstr "I Kø"
 
-#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp
-#: src/PartFile.cpp src/TransferWnd.cpp
+#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Downloading"
 msgstr "Henter"
 
@@ -1707,8 +1682,7 @@ msgstr ""
 msgid "Remote Server"
 msgstr ""
 
-#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp
-#: src/TextClient.cpp
+#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp src/TextClient.cpp
 msgid "Kad"
 msgstr ""
 
@@ -1732,8 +1706,7 @@ msgstr ""
 msgid "Search Result"
 msgstr ""
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp
-#: src/TransferWnd.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Completed"
 msgstr "Færdig"
 
@@ -1785,8 +1758,7 @@ msgstr ""
 msgid "Part"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp
-#: src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Size"
 msgstr "Størrelse"
 
@@ -1794,8 +1766,7 @@ msgstr "Størrelse"
 msgid "Transferred"
 msgstr "Overført"
 
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
-#: src/SourceListCtrl.cpp
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp src/SourceListCtrl.cpp
 msgid "Speed"
 msgstr "Hastighed"
 
@@ -1803,13 +1774,11 @@ msgstr "Hastighed"
 msgid "Progress"
 msgstr "Forløb"
 
-#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp
-#: src/SearchListCtrl.cpp
+#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
 msgid "Sources"
 msgstr "Kilder"
 
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp
-#: src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Priority"
 msgstr "Priotet"
 
@@ -1833,9 +1802,7 @@ msgstr "Sidste Kontakt"
 msgid "Auto"
 msgstr "Auto"
 
-#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/TransferWnd.cpp
-#: src/utils/wxCas/src/wxcasprefs.cpp
+#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/TransferWnd.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Cancel"
 msgstr "Afbryd"
 
@@ -1936,8 +1903,7 @@ msgstr "Indtast nyt navn for denne fil:"
 msgid "File rename"
 msgstr "Omdøb fil"
 
-#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp
-#: src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f MiB/s"
 msgstr ""
@@ -2711,13 +2677,11 @@ msgstr ""
 msgid "Start aMule automatically when I log in"
 msgstr ""
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
-#: packaging/windows/installer_strings.c
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp packaging/windows/installer_strings.c
 msgid "Register aMule for ed2k:// links"
 msgstr ""
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
-#: packaging/windows/installer_strings.c
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp packaging/windows/installer_strings.c
 msgid "Register aMule for magnet: links"
 msgstr ""
 
@@ -2743,8 +2707,7 @@ msgstr ""
 msgid "Destination folder for downloads"
 msgstr ""
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
-#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Browse"
 msgstr "Gennemse"
 
@@ -3191,18 +3154,15 @@ msgstr "Færdiggør"
 msgid "Complete"
 msgstr "Færdig"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
-#: src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Paused"
 msgstr "Pause"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
-#: src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Erroneous"
 msgstr "Beskadiget"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
-#: src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Waiting"
 msgstr "Venter"
 
@@ -3368,8 +3328,7 @@ msgstr "Luk"
 msgid "Cut"
 msgstr ""
 
-#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp
-#: src/utils/aLinkCreator/src/alcframe.cpp
+#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy"
 msgstr ""
 
@@ -3377,8 +3336,7 @@ msgstr ""
 msgid "Paste"
 msgstr ""
 
-#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp
-#: src/utils/aLinkCreator/src/alcframe.cpp
+#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Clear"
 msgstr "Ryd"
 
@@ -3386,8 +3344,7 @@ msgstr "Ryd"
 msgid "Select All"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
-#: src/StatisticsDlg.cpp
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp src/StatisticsDlg.cpp
 msgid "KiB/s"
 msgstr ""
 
@@ -3649,10 +3606,6 @@ msgstr ""
 msgid "Search"
 msgstr "Søg"
 
-#: src/muuli_wdr.cpp
-msgid "Name:"
-msgstr ""
-
 #: src/muuli_wdr.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Type"
 msgstr "Type"
@@ -3742,8 +3695,9 @@ msgid "Availability"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Filter:"
-msgstr ""
+#, fuzzy
+msgid "Filter"
+msgstr "Filtreret: %i"
 
 #: src/muuli_wdr.cpp
 msgid "Invert Result"
@@ -3800,6 +3754,10 @@ msgid "Clears completed downloads"
 msgstr ""
 
 #: src/muuli_wdr.cpp
+msgid "Filter:"
+msgstr ""
+
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "File sources:"
 msgstr "Fundne Kilder :"
@@ -3809,79 +3767,79 @@ msgid "General"
 msgstr "General"
 
 #: src/muuli_wdr.cpp
-msgid "Full Name :"
-msgstr "Navn :"
+msgid "Full Name"
+msgstr "Navn"
 
 #: src/muuli_wdr.cpp
-msgid "met-File :"
-msgstr "met-Fil :"
+msgid "met-File"
+msgstr "met-Fil"
 
 #: src/muuli_wdr.cpp
-msgid "Hash :"
-msgstr "Hash :"
+msgid "Hash"
+msgstr "Hash"
 
 #: src/muuli_wdr.cpp
-msgid "Filesize :"
-msgstr "Filstørrelse :"
+msgid "Filesize"
+msgstr "Filstørrelse"
 
 #: src/muuli_wdr.cpp src/Statistics.cpp
 msgid "Transfer"
 msgstr "Overfør"
 
 #: src/muuli_wdr.cpp
-msgid "Partfilestatus :"
+#, fuzzy
+msgid "Partfilestatus"
+msgstr "Status"
+
+#: src/muuli_wdr.cpp
+msgid "Last seen complete"
+msgstr "Sidst færdig"
+
+#: src/muuli_wdr.cpp
+msgid "Found Sources"
+msgstr "Fundne Kilder"
+
+#: src/muuli_wdr.cpp
+msgid "Transferring Sources"
+msgstr "Overfører Kilder"
+
+#: src/muuli_wdr.cpp
+msgid "Filepart-Count"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Last seen complete :"
-msgstr "Sidst færdig :"
+msgid "Available"
+msgstr "Tilgængelig"
 
 #: src/muuli_wdr.cpp
-msgid "Found Sources :"
-msgstr "Fundne Kilder :"
+#, fuzzy
+msgid "Datarate"
+msgstr "Ikke anslået"
 
 #: src/muuli_wdr.cpp
-msgid "Transferring Sources :"
-msgstr "Overfører Kilder :"
+#, fuzzy
+msgid "Download Active Time"
+msgstr "Download-Hastighed"
 
 #: src/muuli_wdr.cpp
-msgid "Filepart-Count :"
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "Available :"
-msgstr "Tilgængelig :"
-
-#: src/muuli_wdr.cpp
-msgid "Datarate :"
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "Download Active Time: "
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "Transferred :"
-msgstr "Overført :"
-
-#: src/muuli_wdr.cpp
-msgid "Completed Size :"
-msgstr "Færdig Størrelse :"
+msgid "Completed Size"
+msgstr "Færdig Størrelse"
 
 #: src/muuli_wdr.cpp
 msgid "Intelligent Corruption Handling"
 msgstr "Intelligent Fejl Håndtering"
 
 #: src/muuli_wdr.cpp
-msgid "Lost to corruption :"
-msgstr "Tabt pga beskadigelse :"
+msgid "Lost to corruption"
+msgstr "Tabt pga beskadigelse"
 
 #: src/muuli_wdr.cpp
-msgid "Gained by compression :"
-msgstr ""
+#, fuzzy
+msgid "Gained by compression"
+msgstr "Brug gzip komprimering"
 
 #: src/muuli_wdr.cpp
-msgid "Packages saved by I.C.H. :"
+msgid "Packages saved by I.C.H."
 msgstr ""
 
 #: src/muuli_wdr.cpp
@@ -3923,30 +3881,30 @@ msgstr ", Upload: "
 msgid "Media Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp
-msgid "Length :"
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
+msgid "Length"
 msgstr ""
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
 #, fuzzy
-msgid "Bitrate :"
+msgid "Bitrate"
 msgstr "Ikke anslået"
 
-#: src/muuli_wdr.cpp
-msgid "Codec :"
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
+msgid "Codec"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Artist :"
+msgid "Artist"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Album :"
+msgid "Album"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Title :"
-msgstr "Titel :"
+msgid "Title"
+msgstr "Titel"
 
 #: src/muuli_wdr.cpp
 msgid "File Names"
@@ -4031,25 +3989,18 @@ msgstr ""
 msgid "Required Information"
 msgstr "Krævet Information"
 
-#: src/muuli_wdr.cpp
-msgid "IP Address :"
-msgstr "IP Adresse :"
-
-#: src/muuli_wdr.cpp
-msgid "Port :"
-msgstr "Port :"
+#: src/muuli_wdr.cpp src/ServerListCtrl.cpp
+msgid "Port"
+msgstr "Port"
 
 #: src/muuli_wdr.cpp
 msgid "Additional Information"
 msgstr "Aktuelle Adresse"
 
 #: src/muuli_wdr.cpp
-msgid "Username :"
-msgstr "Brugernavn :"
-
-#: src/muuli_wdr.cpp
-msgid "Userhash :"
-msgstr ""
+#, fuzzy
+msgid "Userhash"
+msgstr "Brugere"
 
 #: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Add"
@@ -4084,43 +4035,31 @@ msgid "Statistics Tree"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Username:"
-msgstr "Navn:"
+#, fuzzy
+msgid "Client software"
+msgstr "Klienter"
 
 #: src/muuli_wdr.cpp
-msgid "Userhash:"
-msgstr ""
+#, fuzzy
+msgid "Client version"
+msgstr "Klienter"
 
 #: src/muuli_wdr.cpp
-msgid "Client software:"
-msgstr ""
+#, fuzzy
+msgid "User ID"
+msgstr "Bruger"
 
 #: src/muuli_wdr.cpp
-msgid "Client version:"
-msgstr ""
-
-#: src/muuli_wdr.cpp src/ServerWnd.cpp
-msgid "IP address:"
-msgstr ""
+msgid "Server IP"
+msgstr "ServerIP"
 
 #: src/muuli_wdr.cpp
-msgid "User ID:"
-msgstr ""
+#, fuzzy
+msgid "Server name"
+msgstr "Servernavn"
 
 #: src/muuli_wdr.cpp
-msgid "Server IP:"
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "Server name:"
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "Obfuscation:"
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "Kad:"
+msgid "Obfuscation"
 msgstr ""
 
 #: src/muuli_wdr.cpp
@@ -4128,53 +4067,60 @@ msgid "Transfers to client"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Current request:"
+#, fuzzy
+msgid "Current request"
+msgstr "Nuværende"
+
+#: src/muuli_wdr.cpp
+#, fuzzy
+msgid "Average upload rate"
+msgstr "Gennemsnitlig upload tid: %s"
+
+#: src/muuli_wdr.cpp
+#, fuzzy
+msgid "Average download rate"
+msgstr "Gennemsnitlig upload tid: %s"
+
+#: src/muuli_wdr.cpp
+msgid "Uploaded (session)"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Average upload rate:"
-msgstr ""
+#, fuzzy
+msgid "Downloaded (session)"
+msgstr "Downloads (%i)"
 
 #: src/muuli_wdr.cpp
-msgid "Average download rate:"
-msgstr ""
+#, fuzzy
+msgid "Uploaded (total)"
+msgstr "Upload"
 
 #: src/muuli_wdr.cpp
-msgid "Uploaded (session):"
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "Downloaded (session):"
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "Uploaded (total):"
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "Downloaded (total):"
-msgstr ""
+#, fuzzy
+msgid "Downloaded (total)"
+msgstr "Downloads (%i)"
 
 #: src/muuli_wdr.cpp
 msgid "Scores"
 msgstr "Point:"
 
 #: src/muuli_wdr.cpp
-msgid "DL/UP modifier:"
+msgid "DL/UP modifier"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Secure ident:"
+msgid "Secure ident"
 msgstr ""
 
 #: src/muuli_wdr.cpp
 #, fuzzy
-msgid "Queue rank:"
+msgid "Queue rank"
 msgstr "Kø Fuld"
 
 #: src/muuli_wdr.cpp
-msgid "Queue score:"
-msgstr ""
+#, fuzzy
+msgid "Queue score"
+msgstr "Kø Fuld"
 
 #: src/muuli_wdr.cpp
 msgid "Nick"
@@ -4961,15 +4907,11 @@ msgid "Reset any changes made to the preferences."
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Comment :"
-msgstr "Kommentar :"
+msgid "Incoming Dir"
+msgstr "Indkommende Mappe"
 
 #: src/muuli_wdr.cpp
-msgid "Incoming Dir :"
-msgstr "Indkommende Mappe :"
-
-#: src/muuli_wdr.cpp
-msgid "Change priority for new assigned files :"
+msgid "Change priority for new assigned files"
 msgstr ""
 
 #: src/muuli_wdr.cpp
@@ -4977,7 +4919,7 @@ msgid "Don't change"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Select color for this Category (currently selected) :"
+msgid "Select color for this Category (currently selected)"
 msgstr ""
 
 #: src/muuli_wdr.cpp
@@ -5058,10 +5000,6 @@ msgstr ""
 
 #: src/muuli_wdr.cpp
 msgid "Enter the IP of the node here, using the x.x.x.x format."
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "Port:"
 msgstr ""
 
 #: src/muuli_wdr.cpp
@@ -5329,11 +5267,11 @@ msgid "Enable/disable proxy support"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Proxy type:"
+msgid "Proxy type"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Proxy host:"
+msgid "Proxy host"
 msgstr ""
 
 #: src/muuli_wdr.cpp
@@ -5341,8 +5279,9 @@ msgid "The proxy host name"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Proxy port:"
-msgstr ""
+#, fuzzy
+msgid "Proxy port"
+msgstr "UPnP port"
 
 #: src/muuli_wdr.cpp
 msgid "The proxy port"
@@ -5357,15 +5296,7 @@ msgid "Enable/disable username/password authentication"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Username: "
-msgstr ""
-
-#: src/muuli_wdr.cpp
 msgid "The username to use to connect to the proxy"
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "Password:"
 msgstr ""
 
 #: src/muuli_wdr.cpp
@@ -5547,6 +5478,15 @@ msgstr ""
 
 #: src/OtherFunctions.cpp
 msgid "days"
+msgstr ""
+
+#. TRANSLATORS:
+#. Punctuation for a "label: value" pair. %s is the already-translated
+#. label. Place the colon as your language requires -- e.g. "%s :" with a
+#. space in French, "%s:" without one in Russian and English.
+#: src/OtherFunctions.cpp
+#, c-format
+msgid "%s:"
 msgstr ""
 
 #: src/OtherFunctions.cpp
@@ -6563,8 +6503,7 @@ msgstr ""
 msgid "Confirm shared folders"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp
-#: src/SharedFilesReloadProgress.cpp
+#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp src/SharedFilesReloadProgress.cpp
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "Fandt %i kendte delte filer"
@@ -6692,19 +6631,6 @@ msgstr ""
 #: src/SearchListCtrl.cpp
 msgid "FileID"
 msgstr "Fil ID"
-
-#: src/SearchListCtrl.cpp
-msgid "Length"
-msgstr ""
-
-#: src/SearchListCtrl.cpp
-#, fuzzy
-msgid "Bitrate"
-msgstr "Ikke anslået"
-
-#: src/SearchListCtrl.cpp
-msgid "Codec"
-msgstr ""
 
 #: src/SearchListCtrl.cpp
 msgid "Expand all"
@@ -6991,10 +6917,6 @@ msgstr ""
 #: src/ServerListCtrl.cpp
 msgid "Server Name"
 msgstr "Servernavn"
-
-#: src/ServerListCtrl.cpp
-msgid "Port"
-msgstr "Port"
 
 #: src/ServerListCtrl.cpp
 msgid "Description"
@@ -7293,6 +7215,10 @@ msgstr "Forbundet til %s"
 #, fuzzy, c-format
 msgid "Connected to buddy at %s"
 msgstr "Forbundet til %s %s"
+
+#: src/ServerWnd.cpp
+msgid "IP address:"
+msgstr ""
 
 #: src/ServerWnd.cpp
 #, fuzzy

--- a/po/de.po
+++ b/po/de.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-04 12:13+0200\n"
+"POT-Creation-Date: 2026-09-05 12:01+0200\n"
 "PO-Revision-Date: 2026-09-03 11:02+0000\n"
 "Last-Translator: Werner Mahr <werner@vollstreckernet.de>\n"
 "Language-Team: German <>\n"
@@ -395,8 +395,7 @@ msgstr "Webserver läuft mit pid %d"
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Du hast \"amuleweb zusammen mit aMule starten\" aktiviert, allerdings kann die amuleweb-Programmdatei nicht gestartet werden. Bitte installiere das Paket, das amuleweb enthält, oder kompiliere aMule mit -DBUILD_WEBSERVER=YES  neu und installiere dies."
 
-#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
-#: src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
+#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
 msgid "ERROR"
 msgstr "FEHLER"
 
@@ -683,8 +682,7 @@ msgstr "Netzwerke"
 msgid "Searches"
 msgstr "Suchen"
 
-#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/Statistics.cpp
+#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/Statistics.cpp
 msgid "Downloads"
 msgstr "Downloads"
 
@@ -768,9 +766,7 @@ msgstr "Kad: aus"
 msgid "Core"
 msgstr ""
 
-#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#: src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp
-#: src/SourceListCtrl.cpp src/Statistics.cpp
+#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp src/Statistics.cpp
 msgid "Version"
 msgstr "Version"
 
@@ -1071,11 +1067,7 @@ msgstr "Konnte das Verzeichnis '%s' für die Kategorie '%s' nicht erstellen, nut
 msgid "The remote core sent inconsistent data for \"%s\" (part status %d, expected %d). The file list may be showing the wrong information; reconnect to clear it."
 msgstr ""
 
-#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp
-#: src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp
-#: src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp
-#: src/Statistics.cpp
+#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp src/Statistics.cpp
 msgid "Unknown"
 msgstr "Unbekannt"
 
@@ -1172,8 +1164,7 @@ msgstr "Fehler während des Speicherns der Datei '%s': %s"
 msgid "Enter Captcha"
 msgstr "Captcha eingeben"
 
-#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp
-#: src/TransferWnd.cpp
+#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp src/TransferWnd.cpp
 msgid "Category"
 msgstr "Kategorie"
 
@@ -1336,13 +1327,11 @@ msgstr "Keine 'cryptkey.dat' gefunden, erzeuge eine neue."
 msgid "Client Details"
 msgstr "Client-Details"
 
-#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
-#: src/utils/wxCas/src/onlinesig.cpp
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
 msgid "LowID"
 msgstr "Niedrige ID"
 
-#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
-#: src/utils/wxCas/src/onlinesig.cpp
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
 msgid "HighID"
 msgstr "Hohe ID"
 
@@ -1358,8 +1347,7 @@ msgstr "Unterstützt"
 msgid "Not supported"
 msgstr "Nicht Unterstützt"
 
-#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
-#: src/TextClient.cpp
+#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp src/TextClient.cpp
 msgid "Connected"
 msgstr "Verbunden"
 
@@ -1367,28 +1355,24 @@ msgstr "Verbunden"
 msgid "Disconnected"
 msgstr "Verbindung getrennt"
 
-#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp
-#: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f KiB/s"
 msgstr ""
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#, fuzzy
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/muuli_wdr.cpp
 msgid "Name"
-msgstr "Name:"
+msgstr "Name"
 
 #: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
 msgid "Software"
 msgstr ""
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#, fuzzy
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/muuli_wdr.cpp
 msgid "IP Address"
-msgstr "IP-Adresse:"
+msgstr "IP-Adresse"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Origin"
 msgstr "Ursprung"
 
@@ -1406,13 +1390,11 @@ msgstr "Letzter Empfang"
 msgid "Sessions"
 msgstr "Version"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp
 msgid "Upload Speed"
 msgstr "Upload-Geschwindigkeit"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp
 msgid "Download Speed"
 msgstr "Download-Geschwindigkeit"
 
@@ -1467,13 +1449,11 @@ msgstr[1] "Konnte %u Links nicht hinzufügen (Details: siehe Log)"
 msgid "Files"
 msgstr "Dateien"
 
-#: src/ClientsListCtrl.cpp src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp
-#: src/SourceListCtrl.cpp
+#: src/ClientsListCtrl.cpp src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Uploaded"
 msgstr "Hochgeladen"
 
-#: src/ClientsListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientsListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Downloaded"
 msgstr "Heruntergeladen"
 
@@ -1560,12 +1540,11 @@ msgstr "Benutzer %s (%u) verweigert den Zugriff auf die Liste freigegebener Verz
 msgid "File Comments"
 msgstr "Dateikommentare"
 
-#: src/CommentDialogLst.cpp src/FriendListCtrl.cpp
+#: src/CommentDialogLst.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
 msgid "Username"
 msgstr "Benutzername"
 
-#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp
-#: src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "File Name"
 msgstr "Dateiname"
 
@@ -1573,7 +1552,7 @@ msgstr "Dateiname"
 msgid "Rating"
 msgstr "Bewertung"
 
-#: src/CommentDialogLst.cpp
+#: src/CommentDialogLst.cpp src/muuli_wdr.cpp
 msgid "Comment"
 msgstr "Kommentar"
 
@@ -1627,18 +1606,15 @@ msgstr "Auto [Ho]"
 msgid "Very low"
 msgstr "Sehr niedrig"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Low"
 msgstr "Niedrig"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Normal"
 msgstr "Normal"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "High"
 msgstr "Hoch"
 
@@ -1662,13 +1638,11 @@ msgstr "Verbunden über Server"
 msgid "Queue Full"
 msgstr "Warteschlange voll"
 
-#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp
-#: src/muuli_wdr.cpp
+#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp src/muuli_wdr.cpp
 msgid "On Queue"
 msgstr "in Warteschlange"
 
-#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp
-#: src/PartFile.cpp src/TransferWnd.cpp
+#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Downloading"
 msgstr "Herunterladen"
 
@@ -1728,8 +1702,7 @@ msgstr "Lokaler Server"
 msgid "Remote Server"
 msgstr "Entfernter Server"
 
-#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp
-#: src/TextClient.cpp
+#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp src/TextClient.cpp
 msgid "Kad"
 msgstr "Kad"
 
@@ -1753,8 +1726,7 @@ msgstr "Einstiegsquellen"
 msgid "Search Result"
 msgstr "Suchresultate:"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp
-#: src/TransferWnd.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Completed"
 msgstr "Fertiggestellt"
 
@@ -1806,8 +1778,7 @@ msgstr ""
 msgid "Part"
 msgstr "Teil"
 
-#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp
-#: src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Size"
 msgstr "Größe"
 
@@ -1815,8 +1786,7 @@ msgstr "Größe"
 msgid "Transferred"
 msgstr "Übertragen"
 
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
-#: src/SourceListCtrl.cpp
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp src/SourceListCtrl.cpp
 msgid "Speed"
 msgstr "Geschwindigkeit"
 
@@ -1824,13 +1794,11 @@ msgstr "Geschwindigkeit"
 msgid "Progress"
 msgstr "Fortschritt"
 
-#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp
-#: src/SearchListCtrl.cpp
+#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
 msgid "Sources"
 msgstr "Quellen"
 
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp
-#: src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Priority"
 msgstr "Priorität"
 
@@ -1854,9 +1822,7 @@ msgstr "Letzter Empfang"
 msgid "Auto"
 msgstr "Automatisch"
 
-#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/TransferWnd.cpp
-#: src/utils/wxCas/src/wxcasprefs.cpp
+#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/TransferWnd.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Cancel"
 msgstr "Abbruch"
 
@@ -1957,8 +1923,7 @@ msgstr "Einen neuen Namen für diese Datei eingeben:"
 msgid "File rename"
 msgstr "Datei umbenennen"
 
-#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp
-#: src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f MiB/s"
 msgstr ""
@@ -2761,13 +2726,11 @@ msgstr ""
 msgid "Start aMule automatically when I log in"
 msgstr "aMule automatisch starten wenn ich mich einlogge"
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
-#: packaging/windows/installer_strings.c
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp packaging/windows/installer_strings.c
 msgid "Register aMule for ed2k:// links"
 msgstr ""
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
-#: packaging/windows/installer_strings.c
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp packaging/windows/installer_strings.c
 msgid "Register aMule for magnet: links"
 msgstr ""
 
@@ -2793,8 +2756,7 @@ msgstr ""
 msgid "Destination folder for downloads"
 msgstr "Zielverzeichnis für Downloads."
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
-#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Browse"
 msgstr "Durchsuchen"
 
@@ -3237,18 +3199,15 @@ msgstr "Wird abgeschlossen"
 msgid "Complete"
 msgstr "Vollständig"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
-#: src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Paused"
 msgstr "Pausiert"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
-#: src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Erroneous"
 msgstr "Fehlerhaft"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
-#: src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Waiting"
 msgstr "Warten"
 
@@ -3412,8 +3371,7 @@ msgstr "Schließen"
 msgid "Cut"
 msgstr "Ausschneiden"
 
-#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp
-#: src/utils/aLinkCreator/src/alcframe.cpp
+#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy"
 msgstr "Kopieren"
 
@@ -3421,8 +3379,7 @@ msgstr "Kopieren"
 msgid "Paste"
 msgstr "Einfügen"
 
-#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp
-#: src/utils/aLinkCreator/src/alcframe.cpp
+#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Clear"
 msgstr "Leeren"
 
@@ -3430,8 +3387,7 @@ msgstr "Leeren"
 msgid "Select All"
 msgstr "Alles auswählen"
 
-#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
-#: src/StatisticsDlg.cpp
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp src/StatisticsDlg.cpp
 msgid "KiB/s"
 msgstr ""
 
@@ -3688,10 +3644,6 @@ msgstr "Momentan verbundener Server."
 msgid "Search"
 msgstr "Suche"
 
-#: src/muuli_wdr.cpp
-msgid "Name:"
-msgstr "Name:"
-
 #: src/muuli_wdr.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Type"
 msgstr "Suchtyp"
@@ -3781,8 +3733,8 @@ msgid "Availability"
 msgstr "Verfügbarkeit"
 
 #: src/muuli_wdr.cpp
-msgid "Filter:"
-msgstr "Filter:"
+msgid "Filter"
+msgstr "Filter"
 
 #: src/muuli_wdr.cpp
 msgid "Invert Result"
@@ -3840,6 +3792,10 @@ msgid "Clears completed downloads"
 msgstr "Vollständige Downloads entfernen"
 
 #: src/muuli_wdr.cpp
+msgid "Filter:"
+msgstr "Filter:"
+
+#: src/muuli_wdr.cpp
 msgid "File sources:"
 msgstr "Dateiquellen:"
 
@@ -3848,80 +3804,76 @@ msgid "General"
 msgstr "Allgemein"
 
 #: src/muuli_wdr.cpp
-msgid "Full Name :"
-msgstr "Name:"
+msgid "Full Name"
+msgstr "Name"
 
 #: src/muuli_wdr.cpp
-msgid "met-File :"
-msgstr "met-Datei:"
+msgid "met-File"
+msgstr "met-Datei"
 
 #: src/muuli_wdr.cpp
-msgid "Hash :"
-msgstr "Prüfsumme:"
+msgid "Hash"
+msgstr "Prüfsumme"
 
 #: src/muuli_wdr.cpp
-msgid "Filesize :"
-msgstr "Dateigröße:"
+msgid "Filesize"
+msgstr "Dateigröße"
 
 #: src/muuli_wdr.cpp src/Statistics.cpp
 msgid "Transfer"
 msgstr "Übertragungen"
 
 #: src/muuli_wdr.cpp
-msgid "Partfilestatus :"
-msgstr "Status der Part-Datei:"
+msgid "Partfilestatus"
+msgstr "Status der Part-Datei"
 
 #: src/muuli_wdr.cpp
-msgid "Last seen complete :"
-msgstr "Zuletzt vollständig gesehen:"
+msgid "Last seen complete"
+msgstr "Zuletzt vollständig gesehen"
 
 #: src/muuli_wdr.cpp
-msgid "Found Sources :"
-msgstr "Gefundene Quellen:"
+msgid "Found Sources"
+msgstr "Gefundene Quellen"
 
 #: src/muuli_wdr.cpp
-msgid "Transferring Sources :"
-msgstr "Übertragende Quellen:"
+msgid "Transferring Sources"
+msgstr "Übertragende Quellen"
 
 #: src/muuli_wdr.cpp
-msgid "Filepart-Count :"
-msgstr "Anzahl der Part-Dateien:"
+msgid "Filepart-Count"
+msgstr "Anzahl der Part-Dateien"
 
 #: src/muuli_wdr.cpp
-msgid "Available :"
-msgstr "Verfügbar:"
+msgid "Available"
+msgstr "Verfügbar"
 
 #: src/muuli_wdr.cpp
-msgid "Datarate :"
-msgstr "Datenrate:"
+msgid "Datarate"
+msgstr "Datenrate"
 
 #: src/muuli_wdr.cpp
-msgid "Download Active Time: "
-msgstr "Dauer aktiven Herunterladens: "
+msgid "Download Active Time"
+msgstr "Dauer aktiven Herunterladens"
 
 #: src/muuli_wdr.cpp
-msgid "Transferred :"
-msgstr "Übertragen:"
-
-#: src/muuli_wdr.cpp
-msgid "Completed Size :"
-msgstr "Fertiggestellt:"
+msgid "Completed Size"
+msgstr "Fertiggestellt"
 
 #: src/muuli_wdr.cpp
 msgid "Intelligent Corruption Handling"
 msgstr "Intelligente Fehlerkorrektur"
 
 #: src/muuli_wdr.cpp
-msgid "Lost to corruption :"
-msgstr "Durch Fehler verloren:"
+msgid "Lost to corruption"
+msgstr "Durch Fehler verloren"
 
 #: src/muuli_wdr.cpp
-msgid "Gained by compression :"
-msgstr "Durch Kompression gewonnen:"
+msgid "Gained by compression"
+msgstr "Durch Kompression gewonnen"
 
 #: src/muuli_wdr.cpp
-msgid "Packages saved by I.C.H. :"
-msgstr "Durch I.C.H. gesparte Pakete:"
+msgid "Packages saved by I.C.H."
+msgstr "Durch I.C.H. gesparte Pakete"
 
 #: src/muuli_wdr.cpp
 #, fuzzy
@@ -3963,30 +3915,30 @@ msgstr ", Upload: "
 msgid "Media Info"
 msgstr "Kad-Info"
 
-#: src/muuli_wdr.cpp
-msgid "Length :"
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
+msgid "Length"
 msgstr ""
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
 #, fuzzy
-msgid "Bitrate :"
+msgid "Bitrate"
 msgstr "Nicht bewertet"
 
-#: src/muuli_wdr.cpp
-msgid "Codec :"
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
+msgid "Codec"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Artist :"
+msgid "Artist"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Album :"
+msgid "Album"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Title :"
-msgstr "Titel:"
+msgid "Title"
+msgstr "Titel"
 
 #: src/muuli_wdr.cpp
 msgid "File Names"
@@ -4073,25 +4025,17 @@ msgstr "Unbekannte Größe"
 msgid "Required Information"
 msgstr "Benötigte Information"
 
-#: src/muuli_wdr.cpp
-msgid "IP Address :"
-msgstr "IP-Adresse:"
-
-#: src/muuli_wdr.cpp
-msgid "Port :"
-msgstr "Port:"
+#: src/muuli_wdr.cpp src/ServerListCtrl.cpp
+msgid "Port"
+msgstr "Port"
 
 #: src/muuli_wdr.cpp
 msgid "Additional Information"
 msgstr "Zusätzliche Information"
 
 #: src/muuli_wdr.cpp
-msgid "Username :"
-msgstr "Benutzername:"
-
-#: src/muuli_wdr.cpp
-msgid "Userhash :"
-msgstr "Benutzerprüfsumme:"
+msgid "Userhash"
+msgstr "Benutzerprüfsumme"
 
 #: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Add"
@@ -4126,96 +4070,80 @@ msgid "Statistics Tree"
 msgstr "Statistikbaum"
 
 #: src/muuli_wdr.cpp
-msgid "Username:"
-msgstr "Benutzername:"
+msgid "Client software"
+msgstr "Client-Software"
 
 #: src/muuli_wdr.cpp
-msgid "Userhash:"
-msgstr "Benutzerprüfsumme:"
+msgid "Client version"
+msgstr "Client-Version"
 
 #: src/muuli_wdr.cpp
-msgid "Client software:"
-msgstr "Client-Software:"
+msgid "User ID"
+msgstr "Benutzer-ID"
 
 #: src/muuli_wdr.cpp
-msgid "Client version:"
-msgstr "Client-Version:"
-
-#: src/muuli_wdr.cpp src/ServerWnd.cpp
-msgid "IP address:"
-msgstr "IP-Adresse:"
+msgid "Server IP"
+msgstr "Server-IP"
 
 #: src/muuli_wdr.cpp
-msgid "User ID:"
-msgstr "Benutzer-ID:"
+msgid "Server name"
+msgstr "Servername"
 
 #: src/muuli_wdr.cpp
-msgid "Server IP:"
-msgstr "Server-IP:"
-
-#: src/muuli_wdr.cpp
-msgid "Server name:"
-msgstr "Servername:"
-
-#: src/muuli_wdr.cpp
-msgid "Obfuscation:"
-msgstr "Verschleierung:"
-
-#: src/muuli_wdr.cpp
-msgid "Kad:"
-msgstr "Kad:"
+msgid "Obfuscation"
+msgstr "Verschleierung"
 
 #: src/muuli_wdr.cpp
 msgid "Transfers to client"
 msgstr "Übertragungen zum Client"
 
 #: src/muuli_wdr.cpp
-msgid "Current request:"
-msgstr "Momentane Anfrage:"
+msgid "Current request"
+msgstr "Momentane Anfrage"
 
 #: src/muuli_wdr.cpp
-msgid "Average upload rate:"
-msgstr "Durchschnittliche Uploadrate:"
+msgid "Average upload rate"
+msgstr "Durchschnittliche Uploadrate"
 
 #: src/muuli_wdr.cpp
-msgid "Average download rate:"
-msgstr "Durchschnittliche Downloadrate:"
+msgid "Average download rate"
+msgstr "Durchschnittliche Downloadrate"
 
 #: src/muuli_wdr.cpp
-msgid "Uploaded (session):"
-msgstr "Hochgeladen (Sitzung):"
+msgid "Uploaded (session)"
+msgstr "Hochgeladen (Sitzung)"
 
 #: src/muuli_wdr.cpp
-msgid "Downloaded (session):"
-msgstr "Heruntergeladen (Sitzung):"
+msgid "Downloaded (session)"
+msgstr "Heruntergeladen (Sitzung)"
 
 #: src/muuli_wdr.cpp
-msgid "Uploaded (total):"
-msgstr "Hochgeladen (Gesamt):"
+msgid "Uploaded (total)"
+msgstr "Hochgeladen (Gesamt)"
 
 #: src/muuli_wdr.cpp
-msgid "Downloaded (total):"
-msgstr "Heruntergeladen (Gesamt):"
+msgid "Downloaded (total)"
+msgstr "Heruntergeladen (Gesamt)"
 
 #: src/muuli_wdr.cpp
 msgid "Scores"
 msgstr "Punkte"
 
 #: src/muuli_wdr.cpp
-msgid "DL/UP modifier:"
-msgstr "DL/UP-Modifikator:"
+msgid "DL/UP modifier"
+msgstr "DL/UP-Modifikator"
 
 #: src/muuli_wdr.cpp
-msgid "Secure ident:"
-msgstr "Sichere Erkennung:"
+msgid "Secure ident"
+msgstr "Sichere Erkennung"
 
 #: src/muuli_wdr.cpp
-msgid "Queue rank:"
-msgstr "Warteschlangenposition:"
+msgid "Queue rank"
+msgstr "Warteschlangenposition"
 
 #: src/muuli_wdr.cpp
-msgid "Queue score:"
-msgstr "Wartepunkte:"
+msgid "Queue score"
+msgstr "Wartepunkte"
 
 #: src/muuli_wdr.cpp
 msgid "Nick"
@@ -5010,24 +4938,20 @@ msgid "Reset any changes made to the preferences."
 msgstr "Alle Änderungen zu den Einstellungen zurücksetzen."
 
 #: src/muuli_wdr.cpp
-msgid "Comment :"
-msgstr "Kommentar:"
+msgid "Incoming Dir"
+msgstr "Verzeichnis für eingehende Dateien"
 
 #: src/muuli_wdr.cpp
-msgid "Incoming Dir :"
-msgstr "Verzeichnis für eingehende Dateien:"
-
-#: src/muuli_wdr.cpp
-msgid "Change priority for new assigned files :"
-msgstr "Priorität bei neu zugewiesenen Dateien ändern:"
+msgid "Change priority for new assigned files"
+msgstr "Priorität bei neu zugewiesenen Dateien ändern"
 
 #: src/muuli_wdr.cpp
 msgid "Don't change"
 msgstr "Nicht ändern"
 
 #: src/muuli_wdr.cpp
-msgid "Select color for this Category (currently selected) :"
-msgstr "Farbe für diese Kategorie wählen (momentan ausgewählt):"
+msgid "Select color for this Category (currently selected)"
+msgstr "Farbe für diese Kategorie wählen (momentan ausgewählt)"
 
 #: src/muuli_wdr.cpp
 msgid "Click this button to reset the log."
@@ -5110,10 +5034,6 @@ msgstr "Bootstrap von bekannten Clients"
 #, fuzzy
 msgid "Enter the IP of the node here, using the x.x.x.x format."
 msgstr "Hier die IP des Servers im Format x.x.x.x eingeben."
-
-#: src/muuli_wdr.cpp
-msgid "Port:"
-msgstr "Port:"
 
 #: src/muuli_wdr.cpp
 msgid "Use Secure User Identification"
@@ -5381,20 +5301,20 @@ msgid "Enable/disable proxy support"
 msgstr "Aktiviere/Deaktiviere Proxy-Unterstützung"
 
 #: src/muuli_wdr.cpp
-msgid "Proxy type:"
-msgstr "Proxy-Typ:"
+msgid "Proxy type"
+msgstr "Proxy-Typ"
 
 #: src/muuli_wdr.cpp
-msgid "Proxy host:"
-msgstr "Proxy-Host:"
+msgid "Proxy host"
+msgstr "Proxy-Host"
 
 #: src/muuli_wdr.cpp
 msgid "The proxy host name"
 msgstr "Der Hostname des Proxy"
 
 #: src/muuli_wdr.cpp
-msgid "Proxy port:"
-msgstr "Proxy-Port:"
+msgid "Proxy port"
+msgstr "Proxy-Port"
 
 #: src/muuli_wdr.cpp
 msgid "The proxy port"
@@ -5409,16 +5329,8 @@ msgid "Enable/disable username/password authentication"
 msgstr "Aktiviere/Deaktiviere Authentifizierung mit Benutzername/Passwort"
 
 #: src/muuli_wdr.cpp
-msgid "Username: "
-msgstr "Benutzername:"
-
-#: src/muuli_wdr.cpp
 msgid "The username to use to connect to the proxy"
 msgstr "Der Benutzername, um sich beim Proxy anzumelden"
-
-#: src/muuli_wdr.cpp
-msgid "Password:"
-msgstr "Passwort:"
 
 #: src/muuli_wdr.cpp
 msgid "The password to use to connect to the proxy"
@@ -5592,6 +5504,15 @@ msgstr "Stunden"
 #: src/OtherFunctions.cpp
 msgid "days"
 msgstr "tage"
+
+#. TRANSLATORS:
+#. Punctuation for a "label: value" pair. %s is the already-translated
+#. label. Place the colon as your language requires -- e.g. "%s :" with a
+#. space in French, "%s:" without one in Russian and English.
+#: src/OtherFunctions.cpp
+#, c-format
+msgid "%s:"
+msgstr ""
 
 #: src/OtherFunctions.cpp
 msgid "all"
@@ -6638,8 +6559,7 @@ msgstr "Rekursives Teilen würde jede Datei im eD2k/Kad Netzwerk verfügbar mach
 msgid "Confirm shared folders"
 msgstr "Freigegebene Ordner bestätigen"
 
-#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp
-#: src/SharedFilesReloadProgress.cpp
+#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp src/SharedFilesReloadProgress.cpp
 msgid "Reloading shared files..."
 msgstr "Freigegebene Dateien neu laden..."
 
@@ -6769,19 +6689,6 @@ msgstr "Fehler beim Aktualisieren von %s"
 #: src/SearchListCtrl.cpp
 msgid "FileID"
 msgstr "Datei-ID"
-
-#: src/SearchListCtrl.cpp
-msgid "Length"
-msgstr ""
-
-#: src/SearchListCtrl.cpp
-#, fuzzy
-msgid "Bitrate"
-msgstr "Nicht bewertet"
-
-#: src/SearchListCtrl.cpp
-msgid "Codec"
-msgstr ""
 
 #: src/SearchListCtrl.cpp
 msgid "Expand all"
@@ -7066,10 +6973,6 @@ msgstr "Lokaler Server ist gefiltert durch IPFilters, verbinde neu zu einem ande
 #: src/ServerListCtrl.cpp
 msgid "Server Name"
 msgstr "Servername"
-
-#: src/ServerListCtrl.cpp
-msgid "Port"
-msgstr "Port"
 
 #: src/ServerListCtrl.cpp
 msgid "Description"
@@ -7362,6 +7265,10 @@ msgstr "Verbinde zu Kumpel"
 #, c-format
 msgid "Connected to buddy at %s"
 msgstr "Verbunden mit Kumpel an %s"
+
+#: src/ServerWnd.cpp
+msgid "IP address:"
+msgstr "IP-Adresse:"
 
 #: src/ServerWnd.cpp
 msgid "Indexed sources:"

--- a/po/el.po
+++ b/po/el.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-04 12:13+0200\n"
+"POT-Creation-Date: 2026-09-05 12:01+0200\n"
 "PO-Revision-Date: 2026-09-03 11:02+0000\n"
 "Last-Translator: Dimitris <dgalanak@yahoo.com>\n"
 "Language-Team: Greek\n"
@@ -391,8 +391,7 @@ msgstr "διακομιστής ιστού τρέχει με αριθμό διε�
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Ζητήσατε να τρέχετε τον διακομιστή ιστού κατά την εκκίνηση, αλλά το εκτελέσιμο αρχείο amuleweb δεν βρέθηκε. Παρακαλώ εγκαταστήστε το πακέτο που περιέχει τον διακομιστή ιστού του aMule, ή μεταφράστε το aMule χρησιμοποιώντας την παράμετρο --enable-webserver"
 
-#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
-#: src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
+#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
 msgid "ERROR"
 msgstr "ΣΦΑΛΜΑ"
 
@@ -681,8 +680,7 @@ msgstr "Δίκτυα"
 msgid "Searches"
 msgstr "Αναζητήσεις"
 
-#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/Statistics.cpp
+#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/Statistics.cpp
 msgid "Downloads"
 msgstr "Κατεβασμένα"
 
@@ -766,9 +764,7 @@ msgstr "Kad: Εκτός"
 msgid "Core"
 msgstr ""
 
-#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#: src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp
-#: src/SourceListCtrl.cpp src/Statistics.cpp
+#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp src/Statistics.cpp
 msgid "Version"
 msgstr "Έκδοση"
 
@@ -1072,11 +1068,7 @@ msgstr ""
 msgid "The remote core sent inconsistent data for \"%s\" (part status %d, expected %d). The file list may be showing the wrong information; reconnect to clear it."
 msgstr ""
 
-#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp
-#: src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp
-#: src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp
-#: src/Statistics.cpp
+#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp src/Statistics.cpp
 msgid "Unknown"
 msgstr "Άγνωστο"
 
@@ -1174,8 +1166,7 @@ msgstr "Σφάλμα κατά το αποθήκευση του αρχείου kn
 msgid "Enter Captcha"
 msgstr ""
 
-#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp
-#: src/TransferWnd.cpp
+#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp src/TransferWnd.cpp
 msgid "Category"
 msgstr "Κατηγορία"
 
@@ -1339,13 +1330,11 @@ msgstr "Δεν βρέθηκε το αρχείο 'cryptkey.dat' και γι αυ�
 msgid "Client Details"
 msgstr "Πληροφορίες πελάτη"
 
-#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
-#: src/utils/wxCas/src/onlinesig.cpp
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
 msgid "LowID"
 msgstr "Κακή ποιότητα σύνδεσης (LowID)"
 
-#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
-#: src/utils/wxCas/src/onlinesig.cpp
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
 msgid "HighID"
 msgstr "Καλή ποιότητα σύνδεσης (HighID)"
 
@@ -1361,8 +1350,7 @@ msgstr "Υποστηρίζεται"
 msgid "Not supported"
 msgstr "Δεν υποστηρίζεται"
 
-#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
-#: src/TextClient.cpp
+#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp src/TextClient.cpp
 msgid "Connected"
 msgstr "Συνδεδεμένο"
 
@@ -1370,28 +1358,24 @@ msgstr "Συνδεδεμένο"
 msgid "Disconnected"
 msgstr "Αποσυνδεδεμένο"
 
-#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp
-#: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f KiB/s"
 msgstr ""
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#, fuzzy
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/muuli_wdr.cpp
 msgid "Name"
-msgstr "Όνομα:"
+msgstr "Όνομα"
 
 #: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
 msgid "Software"
 msgstr ""
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#, fuzzy
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/muuli_wdr.cpp
 msgid "IP Address"
-msgstr "Διεύθυνση IP :"
+msgstr "Διεύθυνση IP"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Origin"
 msgstr ""
 
@@ -1409,14 +1393,12 @@ msgstr "Τελευταία λήψη"
 msgid "Sessions"
 msgstr "Έκδοση"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp
 #, fuzzy
 msgid "Upload Speed"
 msgstr "Ταχύτητα ανεβάσματος"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp
 #, fuzzy
 msgid "Download Speed"
 msgstr "Ταχύτητα κατεβάσματος"
@@ -1472,13 +1454,11 @@ msgstr[1] ""
 msgid "Files"
 msgstr "Αρχεία"
 
-#: src/ClientsListCtrl.cpp src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp
-#: src/SourceListCtrl.cpp
+#: src/ClientsListCtrl.cpp src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Uploaded"
 msgstr "Ανέβηκε"
 
-#: src/ClientsListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientsListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Downloaded"
 msgstr "Έχει κατεβεί"
 
@@ -1565,12 +1545,11 @@ msgstr "Ο χρήστης %s (%u) αρνήθηκε πρόσβαση στη λί�
 msgid "File Comments"
 msgstr "Σχόλια αρχείου"
 
-#: src/CommentDialogLst.cpp src/FriendListCtrl.cpp
+#: src/CommentDialogLst.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
 msgid "Username"
 msgstr "Όνομα Χρήστη"
 
-#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp
-#: src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "File Name"
 msgstr "Όνομα αρχείου"
 
@@ -1578,7 +1557,7 @@ msgstr "Όνομα αρχείου"
 msgid "Rating"
 msgstr "Αξιολόγηση"
 
-#: src/CommentDialogLst.cpp
+#: src/CommentDialogLst.cpp src/muuli_wdr.cpp
 msgid "Comment"
 msgstr "Σχόλιο"
 
@@ -1631,18 +1610,15 @@ msgstr "Αυτόματη [Υψηλή]"
 msgid "Very low"
 msgstr "Πολύ χαμηλή"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Low"
 msgstr "Χαμηλή"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Normal"
 msgstr "Κανονική"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "High"
 msgstr "Υψηλή"
 
@@ -1666,13 +1642,11 @@ msgstr "Σύνδεση μέσω διακομιστή"
 msgid "Queue Full"
 msgstr "Ουρά γεμάτη"
 
-#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp
-#: src/muuli_wdr.cpp
+#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp src/muuli_wdr.cpp
 msgid "On Queue"
 msgstr "Εν αναμονή"
 
-#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp
-#: src/PartFile.cpp src/TransferWnd.cpp
+#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Downloading"
 msgstr "Κατεβαίνει"
 
@@ -1732,8 +1706,7 @@ msgstr "Τοπικός διακομιστής"
 msgid "Remote Server"
 msgstr "Απομακρυσμένος διακομιστής"
 
-#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp
-#: src/TextClient.cpp
+#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp src/TextClient.cpp
 msgid "Kad"
 msgstr "Kad"
 
@@ -1757,8 +1730,7 @@ msgstr "Πηγαίος σπόρος"
 msgid "Search Result"
 msgstr "Αποτέλεσμα Αναζήτησης"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp
-#: src/TransferWnd.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Completed"
 msgstr "Ολοκληρώθηκαν"
 
@@ -1811,8 +1783,7 @@ msgstr ""
 msgid "Part"
 msgstr "Μέρος"
 
-#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp
-#: src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Size"
 msgstr "Μέγεθος"
 
@@ -1820,8 +1791,7 @@ msgstr "Μέγεθος"
 msgid "Transferred"
 msgstr "Μεταφέρθηκαν"
 
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
-#: src/SourceListCtrl.cpp
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp src/SourceListCtrl.cpp
 msgid "Speed"
 msgstr "Ταχύτητα"
 
@@ -1829,13 +1799,11 @@ msgstr "Ταχύτητα"
 msgid "Progress"
 msgstr "Πρόοδος"
 
-#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp
-#: src/SearchListCtrl.cpp
+#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
 msgid "Sources"
 msgstr "Αρ. πηγών"
 
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp
-#: src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Priority"
 msgstr "Προτεραιότητα"
 
@@ -1859,9 +1827,7 @@ msgstr "Τελευταία λήψη"
 msgid "Auto"
 msgstr "Αυτόματη"
 
-#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/TransferWnd.cpp
-#: src/utils/wxCas/src/wxcasprefs.cpp
+#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/TransferWnd.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Cancel"
 msgstr "Ακύρωση"
 
@@ -1962,8 +1928,7 @@ msgstr "Δώστε νέο όνομα γι αυτό το αρχείο:"
 msgid "File rename"
 msgstr "Μετονομασία αρχείου"
 
-#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp
-#: src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f MiB/s"
 msgstr ""
@@ -2772,13 +2737,11 @@ msgstr ""
 msgid "Start aMule automatically when I log in"
 msgstr ""
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
-#: packaging/windows/installer_strings.c
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp packaging/windows/installer_strings.c
 msgid "Register aMule for ed2k:// links"
 msgstr ""
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
-#: packaging/windows/installer_strings.c
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp packaging/windows/installer_strings.c
 msgid "Register aMule for magnet: links"
 msgstr ""
 
@@ -2804,8 +2767,7 @@ msgstr ""
 msgid "Destination folder for downloads"
 msgstr "Κατάλογος για τα εισερχόμενα"
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
-#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Browse"
 msgstr "Επιλογή"
 
@@ -3252,18 +3214,15 @@ msgstr "Ολοκληρώνεται"
 msgid "Complete"
 msgstr "Ολοκληρωμένο"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
-#: src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Paused"
 msgstr "Σταματημένο"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
-#: src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Erroneous"
 msgstr "Εσφαλμένο"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
-#: src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Waiting"
 msgstr "Εν αναμονή"
 
@@ -3429,8 +3388,7 @@ msgstr "Κλείσιμο"
 msgid "Cut"
 msgstr "Αποκοπή"
 
-#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp
-#: src/utils/aLinkCreator/src/alcframe.cpp
+#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy"
 msgstr "Αντιγραφή"
 
@@ -3438,8 +3396,7 @@ msgstr "Αντιγραφή"
 msgid "Paste"
 msgstr "Επικόλληση"
 
-#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp
-#: src/utils/aLinkCreator/src/alcframe.cpp
+#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Clear"
 msgstr "Καθαρισμός"
 
@@ -3447,8 +3404,7 @@ msgstr "Καθαρισμός"
 msgid "Select All"
 msgstr "Επιλογή όλων"
 
-#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
-#: src/StatisticsDlg.cpp
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp src/StatisticsDlg.cpp
 msgid "KiB/s"
 msgstr ""
 
@@ -3712,10 +3668,6 @@ msgstr "Διακομιστές συνδεδεμένοι αυτή τη στιγμ
 msgid "Search"
 msgstr "Αναζήτηση"
 
-#: src/muuli_wdr.cpp
-msgid "Name:"
-msgstr "Όνομα:"
-
 #: src/muuli_wdr.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Type"
 msgstr "Τύπος"
@@ -3805,8 +3757,8 @@ msgid "Availability"
 msgstr "Διαθεσιμότητα"
 
 #: src/muuli_wdr.cpp
-msgid "Filter:"
-msgstr "Φίλτρο:"
+msgid "Filter"
+msgstr "Φίλτρο"
 
 #: src/muuli_wdr.cpp
 msgid "Invert Result"
@@ -3864,6 +3816,10 @@ msgid "Clears completed downloads"
 msgstr "Καθάρισμα των ολοκληρωμένων κατεβασμάτων"
 
 #: src/muuli_wdr.cpp
+msgid "Filter:"
+msgstr "Φίλτρο:"
+
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "File sources:"
 msgstr "Ολοκλήρωση πηγών"
@@ -3873,80 +3829,76 @@ msgid "General"
 msgstr "Γενικά"
 
 #: src/muuli_wdr.cpp
-msgid "Full Name :"
-msgstr "Πλήρες Όνομα :"
+msgid "Full Name"
+msgstr "Πλήρες Όνομα"
 
 #: src/muuli_wdr.cpp
-msgid "met-File :"
-msgstr "Αρχείο met:"
+msgid "met-File"
+msgstr "Αρχείο met"
 
 #: src/muuli_wdr.cpp
-msgid "Hash :"
-msgstr "Κατακερματισμός :"
+msgid "Hash"
+msgstr "Κατακερματισμός"
 
 #: src/muuli_wdr.cpp
-msgid "Filesize :"
-msgstr "Μέγεθος αρχείου :"
+msgid "Filesize"
+msgstr "Μέγεθος αρχείου"
 
 #: src/muuli_wdr.cpp src/Statistics.cpp
 msgid "Transfer"
 msgstr "Μεταφορά"
 
 #: src/muuli_wdr.cpp
-msgid "Partfilestatus :"
-msgstr "Κατάσταση ημιτελούς αρχείου:"
+msgid "Partfilestatus"
+msgstr "Κατάσταση ημιτελούς αρχείου"
 
 #: src/muuli_wdr.cpp
-msgid "Last seen complete :"
-msgstr "Τελευταία φορά που εμφανίστηκε ολόκληρο :"
+msgid "Last seen complete"
+msgstr "Τελευταία φορά που εμφανίστηκε ολόκληρο"
 
 #: src/muuli_wdr.cpp
-msgid "Found Sources :"
-msgstr "Βρέθηκαν πηγές :"
+msgid "Found Sources"
+msgstr "Βρέθηκαν πηγές"
 
 #: src/muuli_wdr.cpp
-msgid "Transferring Sources :"
-msgstr "Ενεργές πηγές :"
+msgid "Transferring Sources"
+msgstr "Ενεργές πηγές"
 
 #: src/muuli_wdr.cpp
-msgid "Filepart-Count :"
-msgstr "Απαρίθμηση τμημάτων αρχείου:"
+msgid "Filepart-Count"
+msgstr "Απαρίθμηση τμημάτων αρχείου"
 
 #: src/muuli_wdr.cpp
-msgid "Available :"
-msgstr "Διαθέσιμα:"
+msgid "Available"
+msgstr "Διαθέσιμα"
 
 #: src/muuli_wdr.cpp
-msgid "Datarate :"
-msgstr "Ρυθμός ροής δεδομένων :"
+msgid "Datarate"
+msgstr "Ρυθμός ροής δεδομένων"
 
 #: src/muuli_wdr.cpp
-msgid "Download Active Time: "
-msgstr "Ενεργός χρόνος κατεβάσματος:"
+msgid "Download Active Time"
+msgstr "Ενεργός χρόνος κατεβάσματος"
 
 #: src/muuli_wdr.cpp
-msgid "Transferred :"
-msgstr "Μεταφέρθηκαν :"
-
-#: src/muuli_wdr.cpp
-msgid "Completed Size :"
-msgstr "Ολοκληρωμένος όγκος :"
+msgid "Completed Size"
+msgstr "Ολοκληρωμένος όγκος"
 
 #: src/muuli_wdr.cpp
 msgid "Intelligent Corruption Handling"
 msgstr "Έξυπνη διαχείριση φθοράς (Ε.Δ.Φ.):"
 
 #: src/muuli_wdr.cpp
-msgid "Lost to corruption :"
-msgstr "Χάθηκε λόγο φθοράς :"
+msgid "Lost to corruption"
+msgstr "Χάθηκε λόγο φθοράς"
 
 #: src/muuli_wdr.cpp
-msgid "Gained by compression :"
-msgstr "Κέρδος σε μέγεθος λόγω συμπίεσης :"
+msgid "Gained by compression"
+msgstr "Κέρδος σε μέγεθος λόγω συμπίεσης"
 
 #: src/muuli_wdr.cpp
-msgid "Packages saved by I.C.H. :"
-msgstr "Πακέτα που σώθηκαν από την Ε.Δ.Φ. :"
+msgid "Packages saved by I.C.H."
+msgstr "Πακέτα που σώθηκαν από την Ε.Δ.Φ."
 
 #: src/muuli_wdr.cpp
 #, fuzzy
@@ -3988,30 +3940,30 @@ msgstr ", Ανέβασμα: "
 msgid "Media Info"
 msgstr "Πληροφορίες Kad"
 
-#: src/muuli_wdr.cpp
-msgid "Length :"
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
+msgid "Length"
 msgstr ""
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
 #, fuzzy
-msgid "Bitrate :"
+msgid "Bitrate"
 msgstr "Μη αποτιμημένο"
 
-#: src/muuli_wdr.cpp
-msgid "Codec :"
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
+msgid "Codec"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Artist :"
+msgid "Artist"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Album :"
+msgid "Album"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Title :"
-msgstr "Τίτλος:"
+msgid "Title"
+msgstr "Τίτλος"
 
 #: src/muuli_wdr.cpp
 msgid "File Names"
@@ -4098,25 +4050,17 @@ msgstr "Άγνωστο μέγεθος"
 msgid "Required Information"
 msgstr "Απαιτούμενες πληροφορίες"
 
-#: src/muuli_wdr.cpp
-msgid "IP Address :"
-msgstr "Διεύθυνση IP :"
-
-#: src/muuli_wdr.cpp
-msgid "Port :"
-msgstr "Θύρα :"
+#: src/muuli_wdr.cpp src/ServerListCtrl.cpp
+msgid "Port"
+msgstr "Θύρα"
 
 #: src/muuli_wdr.cpp
 msgid "Additional Information"
 msgstr "Πρόσθετες πληροφορίες"
 
 #: src/muuli_wdr.cpp
-msgid "Username :"
-msgstr "Όνομα χρήστη :"
-
-#: src/muuli_wdr.cpp
-msgid "Userhash :"
-msgstr "Τεμάχιο χρήστη :"
+msgid "Userhash"
+msgstr "Τεμάχιο χρήστη"
 
 #: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Add"
@@ -4151,97 +4095,81 @@ msgid "Statistics Tree"
 msgstr "Δέντρο στατιστικών"
 
 #: src/muuli_wdr.cpp
-msgid "Username:"
-msgstr "Όνομα χρήστη:"
+msgid "Client software"
+msgstr "Λογισμικό πελάτη"
 
 #: src/muuli_wdr.cpp
-msgid "Userhash:"
-msgstr "Τεμάχιο χρήστη:"
+msgid "Client version"
+msgstr "Αριθμός έκδοσης πελάτη"
 
 #: src/muuli_wdr.cpp
-msgid "Client software:"
-msgstr "Λογισμικό πελάτη:"
+msgid "User ID"
+msgstr "Αριθμός Χρήστη"
 
 #: src/muuli_wdr.cpp
-msgid "Client version:"
-msgstr "Αριθμός έκδοσης πελάτη:"
-
-#: src/muuli_wdr.cpp src/ServerWnd.cpp
-msgid "IP address:"
-msgstr "Διεύθυνση IP:"
+msgid "Server IP"
+msgstr "Διεύθυνση διακομιστή"
 
 #: src/muuli_wdr.cpp
-msgid "User ID:"
-msgstr "Αριθμός Χρήστη:"
+msgid "Server name"
+msgstr "Όνομα διακομιστή"
 
 #: src/muuli_wdr.cpp
-msgid "Server IP:"
-msgstr "Διεύθυνση διακομιστή:"
-
-#: src/muuli_wdr.cpp
-msgid "Server name:"
-msgstr "Όνομα διακομιστή:"
-
-#: src/muuli_wdr.cpp
-msgid "Obfuscation:"
-msgstr "Συσκότιση:"
-
-#: src/muuli_wdr.cpp
-msgid "Kad:"
-msgstr "Kad:"
+msgid "Obfuscation"
+msgstr "Συσκότιση"
 
 #: src/muuli_wdr.cpp
 msgid "Transfers to client"
 msgstr "Μεταφορές προς τον πελάτη"
 
 #: src/muuli_wdr.cpp
-msgid "Current request:"
-msgstr "Τρέχουσα αίτηση:"
+msgid "Current request"
+msgstr "Τρέχουσα αίτηση"
 
 #: src/muuli_wdr.cpp
-msgid "Average upload rate:"
-msgstr "Μέσος ρυθμός ανεβάσματος:"
+msgid "Average upload rate"
+msgstr "Μέσος ρυθμός ανεβάσματος"
 
 #: src/muuli_wdr.cpp
-msgid "Average download rate:"
-msgstr "Μέσος ρυθμός κατεβάσματος:"
+msgid "Average download rate"
+msgstr "Μέσος ρυθμός κατεβάσματος"
 
 #: src/muuli_wdr.cpp
-msgid "Uploaded (session):"
-msgstr "Ανέβηκαν (συνεδρία):"
+msgid "Uploaded (session)"
+msgstr "Ανέβηκαν (συνεδρία)"
 
 #: src/muuli_wdr.cpp
-msgid "Downloaded (session):"
-msgstr "Κατέβηκαν (συνεδρία):"
+msgid "Downloaded (session)"
+msgstr "Κατέβηκαν (συνεδρία)"
 
 #: src/muuli_wdr.cpp
-msgid "Uploaded (total):"
-msgstr "Ανέβηκαν (συνολικά):"
+msgid "Uploaded (total)"
+msgstr "Ανέβηκαν (συνολικά)"
 
 #: src/muuli_wdr.cpp
-msgid "Downloaded (total):"
-msgstr "Κατέβηκαν (συνολικά):"
+msgid "Downloaded (total)"
+msgstr "Κατέβηκαν (συνολικά)"
 
 #: src/muuli_wdr.cpp
 msgid "Scores"
 msgstr "Σκορ"
 
 #: src/muuli_wdr.cpp
-msgid "DL/UP modifier:"
-msgstr "Τροποποιητής Ανεβοκατεβάσματος:"
+msgid "DL/UP modifier"
+msgstr "Τροποποιητής Ανεβοκατεβάσματος"
 
 #: src/muuli_wdr.cpp
-msgid "Secure ident:"
-msgstr "Ασφαλής ταυτότητα:"
+msgid "Secure ident"
+msgstr "Ασφαλής ταυτότητα"
 
 #: src/muuli_wdr.cpp
 #, fuzzy
-msgid "Queue rank:"
+msgid "Queue rank"
 msgstr "Εν αναμονή"
 
 #: src/muuli_wdr.cpp
-msgid "Queue score:"
-msgstr "Βαθμολογία αναμονής:"
+msgid "Queue score"
+msgstr "Βαθμολογία αναμονής"
 
 #: src/muuli_wdr.cpp
 msgid "Nick"
@@ -5037,16 +4965,12 @@ msgid "Reset any changes made to the preferences."
 msgstr "Επαναφορά κάθε αλλαγής που έγινε στις προτιμήσεις."
 
 #: src/muuli_wdr.cpp
-msgid "Comment :"
-msgstr "Σχόλιο:"
+msgid "Incoming Dir"
+msgstr "Κατάλογος εισερχομένων"
 
 #: src/muuli_wdr.cpp
-msgid "Incoming Dir :"
-msgstr "Κατάλογος εισερχομένων :"
-
-#: src/muuli_wdr.cpp
-msgid "Change priority for new assigned files :"
-msgstr "Αλλαγή προτεραιότητας για τα νέα προσδιορισμένα αρχεία :"
+msgid "Change priority for new assigned files"
+msgstr "Αλλαγή προτεραιότητας για τα νέα προσδιορισμένα αρχεία"
 
 #: src/muuli_wdr.cpp
 #, fuzzy
@@ -5054,8 +4978,8 @@ msgid "Don't change"
 msgstr "Να μην αλλάξει"
 
 #: src/muuli_wdr.cpp
-msgid "Select color for this Category (currently selected) :"
-msgstr "Επιλογή χρώματος για τη συγκεκριμένη κατηγορία (τρέχουσα επιλογή) :"
+msgid "Select color for this Category (currently selected)"
+msgstr "Επιλογή χρώματος για τη συγκεκριμένη κατηγορία (τρέχουσα επιλογή)"
 
 #: src/muuli_wdr.cpp
 msgid "Click this button to reset the log."
@@ -5140,10 +5064,6 @@ msgstr ""
 #, fuzzy
 msgid "Enter the IP of the node here, using the x.x.x.x format."
 msgstr "Γράψτε την IP του διακομιστή εδώ, σε μορφή x.x.x.x"
-
-#: src/muuli_wdr.cpp
-msgid "Port:"
-msgstr "Θύρα:"
 
 #: src/muuli_wdr.cpp
 msgid "Use Secure User Identification"
@@ -5412,20 +5332,20 @@ msgid "Enable/disable proxy support"
 msgstr "Ενεργοποίηση/Απενεργοποίηση υποστήριξης διακομιστή μεσολάβησης"
 
 #: src/muuli_wdr.cpp
-msgid "Proxy type:"
+msgid "Proxy type"
 msgstr "Τύπος διαμεσολάβησης"
 
 #: src/muuli_wdr.cpp
-msgid "Proxy host:"
-msgstr "Διεύθυνση διακομιστή μεσολάβησης:"
+msgid "Proxy host"
+msgstr "Διεύθυνση διακομιστή μεσολάβησης"
 
 #: src/muuli_wdr.cpp
 msgid "The proxy host name"
 msgstr "Όνομα του διακομιστή μεσολάβησης"
 
 #: src/muuli_wdr.cpp
-msgid "Proxy port:"
-msgstr "Θύρα διακομιστή μεσολάβησης:"
+msgid "Proxy port"
+msgstr "Θύρα διακομιστή μεσολάβησης"
 
 #: src/muuli_wdr.cpp
 msgid "The proxy port"
@@ -5440,16 +5360,8 @@ msgid "Enable/disable username/password authentication"
 msgstr "Ενεργοποίηση/Απενεργοποίηση πιστοποίησης ονόματος χρήστη/κωδικού"
 
 #: src/muuli_wdr.cpp
-msgid "Username: "
-msgstr "Όνομα χρήστη:"
-
-#: src/muuli_wdr.cpp
 msgid "The username to use to connect to the proxy"
 msgstr "Το όνομα χρήστη για τη σύνδεση με τον μεσολαβητή"
-
-#: src/muuli_wdr.cpp
-msgid "Password:"
-msgstr "Κωδικός:"
 
 #: src/muuli_wdr.cpp
 msgid "The password to use to connect to the proxy"
@@ -5631,6 +5543,15 @@ msgstr "ώρες"
 #: src/OtherFunctions.cpp
 msgid "days"
 msgstr "μέρες"
+
+#. TRANSLATORS:
+#. Punctuation for a "label: value" pair. %s is the already-translated
+#. label. Place the colon as your language requires -- e.g. "%s :" with a
+#. space in French, "%s:" without one in Russian and English.
+#: src/OtherFunctions.cpp
+#, c-format
+msgid "%s:"
+msgstr ""
 
 #: src/OtherFunctions.cpp
 msgid "all"
@@ -6680,8 +6601,7 @@ msgstr ""
 msgid "Confirm shared folders"
 msgstr "Κοινόχρηστα αρχεία"
 
-#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp
-#: src/SharedFilesReloadProgress.cpp
+#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp src/SharedFilesReloadProgress.cpp
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "Επαναφόρτωση των κοινόχρηστων αρχείων"
@@ -6813,19 +6733,6 @@ msgstr ""
 #: src/SearchListCtrl.cpp
 msgid "FileID"
 msgstr "Τιμή ταυτότητας αρχείου"
-
-#: src/SearchListCtrl.cpp
-msgid "Length"
-msgstr ""
-
-#: src/SearchListCtrl.cpp
-#, fuzzy
-msgid "Bitrate"
-msgstr "Μη αποτιμημένο"
-
-#: src/SearchListCtrl.cpp
-msgid "Codec"
-msgstr ""
 
 #: src/SearchListCtrl.cpp
 msgid "Expand all"
@@ -7113,10 +7020,6 @@ msgstr "Ο τοπικός διακομιστής είναι φιλτραρισμ
 #: src/ServerListCtrl.cpp
 msgid "Server Name"
 msgstr "Όνομα διακομιστή"
-
-#: src/ServerListCtrl.cpp
-msgid "Port"
-msgstr "Θύρα"
 
 #: src/ServerListCtrl.cpp
 msgid "Description"
@@ -7414,6 +7317,10 @@ msgstr "Συνδεδεμένος στον φιλαράκο"
 #, fuzzy, c-format
 msgid "Connected to buddy at %s"
 msgstr "Συνδεδεμένος στον φιλαράκο"
+
+#: src/ServerWnd.cpp
+msgid "IP address:"
+msgstr "Διεύθυνση IP:"
 
 #: src/ServerWnd.cpp
 #, fuzzy

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-04 12:13+0200\n"
+"POT-Creation-Date: 2026-09-05 12:01+0200\n"
 "PO-Revision-Date: 2020-03-04 14:43+0100\n"
 "Last-Translator: Dévai Tamás <devait@vnet.hu>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -1322,7 +1322,7 @@ msgstr ""
 msgid "%.1f KiB/s"
 msgstr ""
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/muuli_wdr.cpp
 msgid "Name"
 msgstr ""
 
@@ -1330,7 +1330,7 @@ msgstr ""
 msgid "Software"
 msgstr ""
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/muuli_wdr.cpp
 msgid "IP Address"
 msgstr ""
 
@@ -1498,7 +1498,7 @@ msgstr ""
 msgid "File Comments"
 msgstr ""
 
-#: src/CommentDialogLst.cpp src/FriendListCtrl.cpp
+#: src/CommentDialogLst.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
 msgid "Username"
 msgstr ""
 
@@ -1511,7 +1511,7 @@ msgstr ""
 msgid "Rating"
 msgstr ""
 
-#: src/CommentDialogLst.cpp
+#: src/CommentDialogLst.cpp src/muuli_wdr.cpp
 msgid "Comment"
 msgstr ""
 
@@ -3580,10 +3580,6 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
-#: src/muuli_wdr.cpp
-msgid "Name:"
-msgstr ""
-
 #: src/muuli_wdr.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Type"
 msgstr ""
@@ -3673,7 +3669,7 @@ msgid "Availability"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Filter:"
+msgid "Filter"
 msgstr ""
 
 #: src/muuli_wdr.cpp
@@ -3729,6 +3725,10 @@ msgid "Clears completed downloads"
 msgstr ""
 
 #: src/muuli_wdr.cpp
+msgid "Filter:"
+msgstr ""
+
+#: src/muuli_wdr.cpp
 msgid "File sources:"
 msgstr ""
 
@@ -3737,19 +3737,19 @@ msgid "General"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Full Name :"
+msgid "Full Name"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "met-File :"
+msgid "met-File"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Hash :"
+msgid "Hash"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Filesize :"
+msgid "Filesize"
 msgstr ""
 
 #: src/muuli_wdr.cpp src/Statistics.cpp
@@ -3757,43 +3757,39 @@ msgid "Transfer"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Partfilestatus :"
+msgid "Partfilestatus"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Last seen complete :"
+msgid "Last seen complete"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Found Sources :"
+msgid "Found Sources"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Transferring Sources :"
+msgid "Transferring Sources"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Filepart-Count :"
+msgid "Filepart-Count"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Available :"
+msgid "Available"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Datarate :"
+msgid "Datarate"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Download Active Time: "
+msgid "Download Active Time"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Transferred :"
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "Completed Size :"
+msgid "Completed Size"
 msgstr ""
 
 #: src/muuli_wdr.cpp
@@ -3801,15 +3797,15 @@ msgid "Intelligent Corruption Handling"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Lost to corruption :"
+msgid "Lost to corruption"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Gained by compression :"
+msgid "Gained by compression"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Packages saved by I.C.H. :"
+msgid "Packages saved by I.C.H."
 msgstr ""
 
 #: src/muuli_wdr.cpp
@@ -3848,28 +3844,28 @@ msgstr ""
 msgid "Media Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp
-msgid "Length :"
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
+msgid "Length"
+msgstr ""
+
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
+msgid "Bitrate"
+msgstr ""
+
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
+msgid "Codec"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Bitrate :"
+msgid "Artist"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Codec :"
+msgid "Album"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Artist :"
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "Album :"
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "Title :"
+msgid "Title"
 msgstr ""
 
 #: src/muuli_wdr.cpp
@@ -3954,12 +3950,8 @@ msgstr ""
 msgid "Required Information"
 msgstr ""
 
-#: src/muuli_wdr.cpp
-msgid "IP Address :"
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "Port :"
+#: src/muuli_wdr.cpp src/ServerListCtrl.cpp
+msgid "Port"
 msgstr ""
 
 #: src/muuli_wdr.cpp
@@ -3967,11 +3959,7 @@ msgid "Additional Information"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Username :"
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "Userhash :"
+msgid "Userhash"
 msgstr ""
 
 #: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
@@ -4007,43 +3995,27 @@ msgid "Statistics Tree"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Username:"
+msgid "Client software"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Userhash:"
+msgid "Client version"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Client software:"
+msgid "User ID"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Client version:"
-msgstr ""
-
-#: src/muuli_wdr.cpp src/ServerWnd.cpp
-msgid "IP address:"
+msgid "Server IP"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "User ID:"
+msgid "Server name"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Server IP:"
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "Server name:"
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "Obfuscation:"
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "Kad:"
+msgid "Obfuscation"
 msgstr ""
 
 #: src/muuli_wdr.cpp
@@ -4051,31 +4023,31 @@ msgid "Transfers to client"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Current request:"
+msgid "Current request"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Average upload rate:"
+msgid "Average upload rate"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Average download rate:"
+msgid "Average download rate"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Uploaded (session):"
+msgid "Uploaded (session)"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Downloaded (session):"
+msgid "Downloaded (session)"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Uploaded (total):"
+msgid "Uploaded (total)"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Downloaded (total):"
+msgid "Downloaded (total)"
 msgstr ""
 
 #: src/muuli_wdr.cpp
@@ -4083,19 +4055,19 @@ msgid "Scores"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "DL/UP modifier:"
+msgid "DL/UP modifier"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Secure ident:"
+msgid "Secure ident"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Queue rank:"
+msgid "Queue rank"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Queue score:"
+msgid "Queue score"
 msgstr ""
 
 #: src/muuli_wdr.cpp
@@ -4873,15 +4845,11 @@ msgid "Reset any changes made to the preferences."
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Comment :"
+msgid "Incoming Dir"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Incoming Dir :"
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "Change priority for new assigned files :"
+msgid "Change priority for new assigned files"
 msgstr ""
 
 #: src/muuli_wdr.cpp
@@ -4889,7 +4857,7 @@ msgid "Don't change"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Select color for this Category (currently selected) :"
+msgid "Select color for this Category (currently selected)"
 msgstr ""
 
 #: src/muuli_wdr.cpp
@@ -4970,10 +4938,6 @@ msgstr ""
 
 #: src/muuli_wdr.cpp
 msgid "Enter the IP of the node here, using the x.x.x.x format."
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "Port:"
 msgstr ""
 
 #: src/muuli_wdr.cpp
@@ -5238,11 +5202,11 @@ msgid "Enable/disable proxy support"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Proxy type:"
+msgid "Proxy type"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Proxy host:"
+msgid "Proxy host"
 msgstr ""
 
 #: src/muuli_wdr.cpp
@@ -5250,7 +5214,7 @@ msgid "The proxy host name"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Proxy port:"
+msgid "Proxy port"
 msgstr ""
 
 #: src/muuli_wdr.cpp
@@ -5266,15 +5230,7 @@ msgid "Enable/disable username/password authentication"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Username: "
-msgstr ""
-
-#: src/muuli_wdr.cpp
 msgid "The username to use to connect to the proxy"
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "Password:"
 msgstr ""
 
 #: src/muuli_wdr.cpp
@@ -5447,6 +5403,15 @@ msgstr ""
 
 #: src/OtherFunctions.cpp
 msgid "days"
+msgstr ""
+
+#. TRANSLATORS:
+#. Punctuation for a "label: value" pair. %s is the already-translated
+#. label. Place the colon as your language requires -- e.g. "%s :" with a
+#. space in French, "%s:" without one in Russian and English.
+#: src/OtherFunctions.cpp
+#, c-format
+msgid "%s:"
 msgstr ""
 
 #: src/OtherFunctions.cpp
@@ -6570,18 +6535,6 @@ msgid "FileID"
 msgstr ""
 
 #: src/SearchListCtrl.cpp
-msgid "Length"
-msgstr ""
-
-#: src/SearchListCtrl.cpp
-msgid "Bitrate"
-msgstr ""
-
-#: src/SearchListCtrl.cpp
-msgid "Codec"
-msgstr ""
-
-#: src/SearchListCtrl.cpp
 msgid "Expand all"
 msgstr ""
 
@@ -6856,10 +6809,6 @@ msgstr ""
 
 #: src/ServerListCtrl.cpp
 msgid "Server Name"
-msgstr ""
-
-#: src/ServerListCtrl.cpp
-msgid "Port"
 msgstr ""
 
 #: src/ServerListCtrl.cpp
@@ -7146,6 +7095,10 @@ msgstr ""
 #: src/ServerWnd.cpp
 #, c-format
 msgid "Connected to buddy at %s"
+msgstr ""
+
+#: src/ServerWnd.cpp
+msgid "IP address:"
 msgstr ""
 
 #: src/ServerWnd.cpp

--- a/po/es.po
+++ b/po/es.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-04 12:13+0200\n"
+"POT-Creation-Date: 2026-09-05 12:01+0200\n"
 "PO-Revision-Date: 2026-09-03 11:03+0000\n"
 "Last-Translator: Diego Heras <ngosang@hotmail.es>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/amule/amule-application/es/>\n"
@@ -393,8 +393,7 @@ msgstr "servidor web corriendo con pid: %d"
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Ha solicitado ejecutar el servidor web al inicio pero no se puede ejecutar el binario amuleweb. Por favor, instale el paquete que contiene el servidor web de aMule, o compile aMule desde el código fuente con -DBUILD_WEBSERVER=YES e instálelo."
 
-#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
-#: src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
+#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
 msgid "ERROR"
 msgstr "ERROR"
 
@@ -680,8 +679,7 @@ msgstr "Redes"
 msgid "Searches"
 msgstr "Búsquedas"
 
-#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/Statistics.cpp
+#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/Statistics.cpp
 msgid "Downloads"
 msgstr "Descargas"
 
@@ -769,9 +767,7 @@ msgstr "Kad: apagado"
 msgid "Core"
 msgstr "Núcleo"
 
-#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#: src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp
-#: src/SourceListCtrl.cpp src/Statistics.cpp
+#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp src/Statistics.cpp
 msgid "Version"
 msgstr "Versión"
 
@@ -1068,11 +1064,7 @@ msgstr "No se puede crear el directorio '%s' para la categoría '%s', se mantien
 msgid "The remote core sent inconsistent data for \"%s\" (part status %d, expected %d). The file list may be showing the wrong information; reconnect to clear it."
 msgstr "El núcleo remoto envió datos inconsistentes para \"%s\" (Estado de la parte %d, esperado %d). La lista de archivos puede estar mostrando la información incorrecta; volver a conectarse para limpiarla."
 
-#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp
-#: src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp
-#: src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp
-#: src/Statistics.cpp
+#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp src/Statistics.cpp
 msgid "Unknown"
 msgstr "Desconocido"
 
@@ -1169,8 +1161,7 @@ msgstr "Error guardando el archivo %s: %s"
 msgid "Enter Captcha"
 msgstr "Introduzca el \"captcha\""
 
-#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp
-#: src/TransferWnd.cpp
+#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp src/TransferWnd.cpp
 msgid "Category"
 msgstr "Categoría"
 
@@ -1333,13 +1324,11 @@ msgstr "No se ha encontrado el archivo 'cryptkey.dat', se crea."
 msgid "Client Details"
 msgstr "Detalles del cliente"
 
-#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
-#: src/utils/wxCas/src/onlinesig.cpp
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
 msgid "LowID"
 msgstr "Id Baja"
 
-#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
-#: src/utils/wxCas/src/onlinesig.cpp
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
 msgid "HighID"
 msgstr "Id Alta"
 
@@ -1355,8 +1344,7 @@ msgstr "Soportada"
 msgid "Not supported"
 msgstr "No soportada"
 
-#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
-#: src/TextClient.cpp
+#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp src/TextClient.cpp
 msgid "Connected"
 msgstr "Conectado"
 
@@ -1364,13 +1352,12 @@ msgstr "Conectado"
 msgid "Disconnected"
 msgstr "Desconectado"
 
-#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp
-#: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f KiB/s"
 msgstr "%.1f KiB/s"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/muuli_wdr.cpp
 msgid "Name"
 msgstr "Nombre"
 
@@ -1378,12 +1365,11 @@ msgstr "Nombre"
 msgid "Software"
 msgstr "Software"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/muuli_wdr.cpp
 msgid "IP Address"
 msgstr "Dirección IP"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Origin"
 msgstr "Origen"
 
@@ -1399,13 +1385,11 @@ msgstr "Visto por última vez"
 msgid "Sessions"
 msgstr "Sesiones"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp
 msgid "Upload Speed"
 msgstr "Velocidad de subida"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp
 msgid "Download Speed"
 msgstr "Velocidad de descarga"
 
@@ -1456,13 +1440,11 @@ msgstr[1] "No se pudieron añadir los enlaces %u (consulte el registro para más
 msgid "Files"
 msgstr "Archivos"
 
-#: src/ClientsListCtrl.cpp src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp
-#: src/SourceListCtrl.cpp
+#: src/ClientsListCtrl.cpp src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Uploaded"
 msgstr "Subido"
 
-#: src/ClientsListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientsListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Downloaded"
 msgstr "Descargado"
 
@@ -1546,12 +1528,11 @@ msgstr "El usuario %s (%u) ha denegado el acceso a su lista de directorios/archi
 msgid "File Comments"
 msgstr "Comentarios del archivo"
 
-#: src/CommentDialogLst.cpp src/FriendListCtrl.cpp
+#: src/CommentDialogLst.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
 msgid "Username"
 msgstr "Nombre de usuario"
 
-#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp
-#: src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "File Name"
 msgstr "Nombre del archivo"
 
@@ -1559,7 +1540,7 @@ msgstr "Nombre del archivo"
 msgid "Rating"
 msgstr "Valoración"
 
-#: src/CommentDialogLst.cpp
+#: src/CommentDialogLst.cpp src/muuli_wdr.cpp
 msgid "Comment"
 msgstr "Comentario"
 
@@ -1612,18 +1593,15 @@ msgstr "Automática [Al]"
 msgid "Very low"
 msgstr "Muy baja"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Low"
 msgstr "Baja"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Normal"
 msgstr "Normal"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "High"
 msgstr "Alta"
 
@@ -1647,13 +1625,11 @@ msgstr "Conectando vía servidor"
 msgid "Queue Full"
 msgstr "Cola llena"
 
-#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp
-#: src/muuli_wdr.cpp
+#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp src/muuli_wdr.cpp
 msgid "On Queue"
 msgstr "En cola"
 
-#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp
-#: src/PartFile.cpp src/TransferWnd.cpp
+#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Downloading"
 msgstr "Descargando"
 
@@ -1713,8 +1689,7 @@ msgstr "Servidor local"
 msgid "Remote Server"
 msgstr "Servidor remoto"
 
-#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp
-#: src/TextClient.cpp
+#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp src/TextClient.cpp
 msgid "Kad"
 msgstr "Kad"
 
@@ -1738,8 +1713,7 @@ msgstr "Semillas fuente"
 msgid "Search Result"
 msgstr "Resultado de la búsqueda"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp
-#: src/TransferWnd.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Completed"
 msgstr "Completado"
 
@@ -1791,8 +1765,7 @@ msgstr "No se puede modificar dentro de una compartición recursiva"
 msgid "Part"
 msgstr "Parte"
 
-#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp
-#: src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Size"
 msgstr "Tamaño"
 
@@ -1800,8 +1773,7 @@ msgstr "Tamaño"
 msgid "Transferred"
 msgstr "Transferido"
 
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
-#: src/SourceListCtrl.cpp
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp src/SourceListCtrl.cpp
 msgid "Speed"
 msgstr "Velocidad"
 
@@ -1809,13 +1781,11 @@ msgstr "Velocidad"
 msgid "Progress"
 msgstr "Progreso"
 
-#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp
-#: src/SearchListCtrl.cpp
+#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
 msgid "Sources"
 msgstr "Fuentes"
 
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp
-#: src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Priority"
 msgstr "Prioridad"
 
@@ -1839,9 +1809,7 @@ msgstr "Última recepción"
 msgid "Auto"
 msgstr "Automática"
 
-#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/TransferWnd.cpp
-#: src/utils/wxCas/src/wxcasprefs.cpp
+#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/TransferWnd.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Cancel"
 msgstr "Cancelar"
 
@@ -1942,8 +1910,7 @@ msgstr "Introduzca el nuevo nombre para el archivo:"
 msgid "File rename"
 msgstr "Renombrar el archivo"
 
-#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp
-#: src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f MiB/s"
 msgstr "%.1f MiB/s"
@@ -2746,13 +2713,11 @@ msgstr ""
 msgid "Start aMule automatically when I log in"
 msgstr "Iniciar aMule automáticamente al iniciar sesión"
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
-#: packaging/windows/installer_strings.c
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp packaging/windows/installer_strings.c
 msgid "Register aMule for ed2k:// links"
 msgstr "Registrar aMule para los enlaces ed2k://"
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
-#: packaging/windows/installer_strings.c
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp packaging/windows/installer_strings.c
 msgid "Register aMule for magnet: links"
 msgstr "Registrar aMule para los enlaces magnet:"
 
@@ -2780,8 +2745,7 @@ msgstr ""
 msgid "Destination folder for downloads"
 msgstr "Carpeta de destino para las descargas"
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
-#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Browse"
 msgstr "Examinar"
 
@@ -3225,18 +3189,15 @@ msgstr "Completando"
 msgid "Complete"
 msgstr "Completado"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
-#: src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Paused"
 msgstr "Pausado"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
-#: src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Erroneous"
 msgstr "Erróneo"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
-#: src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Waiting"
 msgstr "Esperando"
 
@@ -3398,8 +3359,7 @@ msgstr "Cerrar"
 msgid "Cut"
 msgstr "Cortar"
 
-#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp
-#: src/utils/aLinkCreator/src/alcframe.cpp
+#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy"
 msgstr "Copiar"
 
@@ -3407,8 +3367,7 @@ msgstr "Copiar"
 msgid "Paste"
 msgstr "Pegar"
 
-#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp
-#: src/utils/aLinkCreator/src/alcframe.cpp
+#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Clear"
 msgstr "Limpiar"
 
@@ -3416,8 +3375,7 @@ msgstr "Limpiar"
 msgid "Select All"
 msgstr "Seleccionar todo"
 
-#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
-#: src/StatisticsDlg.cpp
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp src/StatisticsDlg.cpp
 msgid "KiB/s"
 msgstr "KiB/s"
 
@@ -3672,10 +3630,6 @@ msgstr "Conectado al servidor."
 msgid "Search"
 msgstr "Buscar"
 
-#: src/muuli_wdr.cpp
-msgid "Name:"
-msgstr "Nombre:"
-
 #: src/muuli_wdr.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Type"
 msgstr "Tipo"
@@ -3765,8 +3719,8 @@ msgid "Availability"
 msgstr "Disponibilidad"
 
 #: src/muuli_wdr.cpp
-msgid "Filter:"
-msgstr "Filtro:"
+msgid "Filter"
+msgstr "Filtro"
 
 #: src/muuli_wdr.cpp
 msgid "Invert Result"
@@ -3821,6 +3775,10 @@ msgid "Clears completed downloads"
 msgstr "Quita de la lista las descargas completadas"
 
 #: src/muuli_wdr.cpp
+msgid "Filter:"
+msgstr "Filtro:"
+
+#: src/muuli_wdr.cpp
 msgid "File sources:"
 msgstr "Fuentes del archivo:"
 
@@ -3829,80 +3787,76 @@ msgid "General"
 msgstr "General"
 
 #: src/muuli_wdr.cpp
-msgid "Full Name :"
-msgstr "Nombre completo:"
+msgid "Full Name"
+msgstr "Nombre completo"
 
 #: src/muuli_wdr.cpp
-msgid "met-File :"
-msgstr "Archivo met:"
+msgid "met-File"
+msgstr "Archivo met"
 
 #: src/muuli_wdr.cpp
-msgid "Hash :"
-msgstr "Hash:"
+msgid "Hash"
+msgstr "Hash"
 
 #: src/muuli_wdr.cpp
-msgid "Filesize :"
-msgstr "Tamaño:"
+msgid "Filesize"
+msgstr "Tamaño"
 
 #: src/muuli_wdr.cpp src/Statistics.cpp
 msgid "Transfer"
 msgstr "Transferencia"
 
 #: src/muuli_wdr.cpp
-msgid "Partfilestatus :"
-msgstr "Estado del archivo de partes:"
+msgid "Partfilestatus"
+msgstr "Estado del archivo de partes"
 
 #: src/muuli_wdr.cpp
-msgid "Last seen complete :"
-msgstr "Visto completo por última vez:"
+msgid "Last seen complete"
+msgstr "Visto completo por última vez"
 
 #: src/muuli_wdr.cpp
-msgid "Found Sources :"
-msgstr "Fuentes encontradas:"
+msgid "Found Sources"
+msgstr "Fuentes encontradas"
 
 #: src/muuli_wdr.cpp
-msgid "Transferring Sources :"
-msgstr "Fuentes transfiriendo:"
+msgid "Transferring Sources"
+msgstr "Fuentes transfiriendo"
 
 #: src/muuli_wdr.cpp
-msgid "Filepart-Count :"
-msgstr "Número de partes:"
+msgid "Filepart-Count"
+msgstr "Número de partes"
 
 #: src/muuli_wdr.cpp
-msgid "Available :"
-msgstr "Disponibles:"
+msgid "Available"
+msgstr "Disponibles"
 
 #: src/muuli_wdr.cpp
-msgid "Datarate :"
-msgstr "Tasa de datos:"
+msgid "Datarate"
+msgstr "Tasa de datos"
 
 #: src/muuli_wdr.cpp
-msgid "Download Active Time: "
-msgstr "Tiempo activo de descarga: "
+msgid "Download Active Time"
+msgstr "Tiempo activo de descarga"
 
 #: src/muuli_wdr.cpp
-msgid "Transferred :"
-msgstr "Transferido:"
-
-#: src/muuli_wdr.cpp
-msgid "Completed Size :"
-msgstr "Tamaño completado:"
+msgid "Completed Size"
+msgstr "Tamaño completado"
 
 #: src/muuli_wdr.cpp
 msgid "Intelligent Corruption Handling"
 msgstr "Gestión inteligente de corrupción"
 
 #: src/muuli_wdr.cpp
-msgid "Lost to corruption :"
-msgstr "Perdido por corrupción:"
+msgid "Lost to corruption"
+msgstr "Perdido por corrupción"
 
 #: src/muuli_wdr.cpp
-msgid "Gained by compression :"
-msgstr "Ganado por compresión:"
+msgid "Gained by compression"
+msgstr "Ganado por compresión"
 
 #: src/muuli_wdr.cpp
-msgid "Packages saved by I.C.H. :"
-msgstr "Paquetes salvados por I.C.H.:"
+msgid "Packages saved by I.C.H."
+msgstr "Paquetes salvados por I.C.H."
 
 #: src/muuli_wdr.cpp
 msgid "Sharing"
@@ -3940,29 +3894,29 @@ msgstr "Última subida"
 msgid "Media Info"
 msgstr "Información del medio"
 
-#: src/muuli_wdr.cpp
-msgid "Length :"
-msgstr "Duración :"
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
+msgid "Length"
+msgstr "Duración"
+
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
+msgid "Bitrate"
+msgstr "Tasa de bits"
+
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
+msgid "Codec"
+msgstr "Códec"
 
 #: src/muuli_wdr.cpp
-msgid "Bitrate :"
-msgstr "Tasa de bits :"
+msgid "Artist"
+msgstr "Artista"
 
 #: src/muuli_wdr.cpp
-msgid "Codec :"
-msgstr "Códec :"
+msgid "Album"
+msgstr "Álbum"
 
 #: src/muuli_wdr.cpp
-msgid "Artist :"
-msgstr "Artista :"
-
-#: src/muuli_wdr.cpp
-msgid "Album :"
-msgstr "Álbum :"
-
-#: src/muuli_wdr.cpp
-msgid "Title :"
-msgstr "Título:"
+msgid "Title"
+msgstr "Título"
 
 #: src/muuli_wdr.cpp
 msgid "File Names"
@@ -4048,25 +4002,17 @@ msgstr "Tamaño desconocido"
 msgid "Required Information"
 msgstr "Información requerida"
 
-#: src/muuli_wdr.cpp
-msgid "IP Address :"
-msgstr "Dirección IP:"
-
-#: src/muuli_wdr.cpp
-msgid "Port :"
-msgstr "Puerto:"
+#: src/muuli_wdr.cpp src/ServerListCtrl.cpp
+msgid "Port"
+msgstr "Puerto"
 
 #: src/muuli_wdr.cpp
 msgid "Additional Information"
 msgstr "Información adicional"
 
 #: src/muuli_wdr.cpp
-msgid "Username :"
-msgstr "Nombre del usuario:"
-
-#: src/muuli_wdr.cpp
-msgid "Userhash :"
-msgstr "Hash del usuario:"
+msgid "Userhash"
+msgstr "Hash del usuario"
 
 #: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Add"
@@ -4101,96 +4047,80 @@ msgid "Statistics Tree"
 msgstr "Árbol de estadísticas"
 
 #: src/muuli_wdr.cpp
-msgid "Username:"
-msgstr "Nombre del usuario:"
+msgid "Client software"
+msgstr "Software del cliente"
 
 #: src/muuli_wdr.cpp
-msgid "Userhash:"
-msgstr "Hash del usuario:"
+msgid "Client version"
+msgstr "Versión del cliente"
 
 #: src/muuli_wdr.cpp
-msgid "Client software:"
-msgstr "Software del cliente:"
+msgid "User ID"
+msgstr "ID del usuario"
 
 #: src/muuli_wdr.cpp
-msgid "Client version:"
-msgstr "Versión del cliente:"
-
-#: src/muuli_wdr.cpp src/ServerWnd.cpp
-msgid "IP address:"
-msgstr "Dirección IP:"
+msgid "Server IP"
+msgstr "IP del servidor"
 
 #: src/muuli_wdr.cpp
-msgid "User ID:"
-msgstr "ID del usuario:"
+msgid "Server name"
+msgstr "Nombre del servidor"
 
 #: src/muuli_wdr.cpp
-msgid "Server IP:"
-msgstr "IP del servidor:"
-
-#: src/muuli_wdr.cpp
-msgid "Server name:"
-msgstr "Nombre del servidor:"
-
-#: src/muuli_wdr.cpp
-msgid "Obfuscation:"
-msgstr "Ofuscación:"
-
-#: src/muuli_wdr.cpp
-msgid "Kad:"
-msgstr "Kad:"
+msgid "Obfuscation"
+msgstr "Ofuscación"
 
 #: src/muuli_wdr.cpp
 msgid "Transfers to client"
 msgstr "Transferencias al cliente"
 
 #: src/muuli_wdr.cpp
-msgid "Current request:"
-msgstr "Solicitud actual:"
+msgid "Current request"
+msgstr "Solicitud actual"
 
 #: src/muuli_wdr.cpp
-msgid "Average upload rate:"
-msgstr "Velocidad media de subida:"
+msgid "Average upload rate"
+msgstr "Velocidad media de subida"
 
 #: src/muuli_wdr.cpp
-msgid "Average download rate:"
-msgstr "Velocidad media de descarga:"
+msgid "Average download rate"
+msgstr "Velocidad media de descarga"
 
 #: src/muuli_wdr.cpp
-msgid "Uploaded (session):"
-msgstr "Subido (sesión):"
+msgid "Uploaded (session)"
+msgstr "Subido (sesión)"
 
 #: src/muuli_wdr.cpp
-msgid "Downloaded (session):"
-msgstr "Descargado (sesión):"
+msgid "Downloaded (session)"
+msgstr "Descargado (sesión)"
 
 #: src/muuli_wdr.cpp
-msgid "Uploaded (total):"
-msgstr "Subido (total):"
+msgid "Uploaded (total)"
+msgstr "Subido (total)"
 
 #: src/muuli_wdr.cpp
-msgid "Downloaded (total):"
-msgstr "Descargado (total):"
+msgid "Downloaded (total)"
+msgstr "Descargado (total)"
 
 #: src/muuli_wdr.cpp
 msgid "Scores"
 msgstr "Resultados"
 
 #: src/muuli_wdr.cpp
-msgid "DL/UP modifier:"
-msgstr "Modificador de DE/SU:"
+msgid "DL/UP modifier"
+msgstr "Modificador de DE/SU"
 
 #: src/muuli_wdr.cpp
-msgid "Secure ident:"
-msgstr "Identificación segura:"
+msgid "Secure ident"
+msgstr "Identificación segura"
 
 #: src/muuli_wdr.cpp
-msgid "Queue rank:"
-msgstr "Rango de cola:"
+msgid "Queue rank"
+msgstr "Rango de cola"
 
 #: src/muuli_wdr.cpp
-msgid "Queue score:"
-msgstr "Puntuación de cola:"
+msgid "Queue score"
+msgstr "Puntuación de cola"
 
 #: src/muuli_wdr.cpp
 msgid "Nick"
@@ -4973,24 +4903,20 @@ msgid "Reset any changes made to the preferences."
 msgstr "Cancelar los cambios hechos en las preferencias."
 
 #: src/muuli_wdr.cpp
-msgid "Comment :"
-msgstr "Comentario:"
+msgid "Incoming Dir"
+msgstr "Directorio entrante"
 
 #: src/muuli_wdr.cpp
-msgid "Incoming Dir :"
-msgstr "Directorio entrante:"
-
-#: src/muuli_wdr.cpp
-msgid "Change priority for new assigned files :"
-msgstr "Cambiar la prioridad de los nuevos archivos asignados:"
+msgid "Change priority for new assigned files"
+msgstr "Cambiar la prioridad de los nuevos archivos asignados"
 
 #: src/muuli_wdr.cpp
 msgid "Don't change"
 msgstr "No cambiar"
 
 #: src/muuli_wdr.cpp
-msgid "Select color for this Category (currently selected) :"
-msgstr "Seleccione el color para esta categoría (actualmente seleccionado):"
+msgid "Select color for this Category (currently selected)"
+msgstr "Seleccione el color para esta categoría (actualmente seleccionado)"
 
 #: src/muuli_wdr.cpp
 msgid "Click this button to reset the log."
@@ -5071,10 +4997,6 @@ msgstr "Inicializar desde el nodo: IP"
 #: src/muuli_wdr.cpp
 msgid "Enter the IP of the node here, using the x.x.x.x format."
 msgstr "Introduzca aquí la IP del nodo, usando el formato \"x.x.x.x\"."
-
-#: src/muuli_wdr.cpp
-msgid "Port:"
-msgstr "Puerto:"
 
 #: src/muuli_wdr.cpp
 msgid "Use Secure User Identification"
@@ -5351,20 +5273,20 @@ msgid "Enable/disable proxy support"
 msgstr "Habilitar/deshabilitar el soporte para proxy"
 
 #: src/muuli_wdr.cpp
-msgid "Proxy type:"
-msgstr "Tipo de proxy:"
+msgid "Proxy type"
+msgstr "Tipo de proxy"
 
 #: src/muuli_wdr.cpp
-msgid "Proxy host:"
-msgstr "Servidor proxy:"
+msgid "Proxy host"
+msgstr "Servidor proxy"
 
 #: src/muuli_wdr.cpp
 msgid "The proxy host name"
 msgstr "Nombre del host del proxy"
 
 #: src/muuli_wdr.cpp
-msgid "Proxy port:"
-msgstr "Puerto del proxy:"
+msgid "Proxy port"
+msgstr "Puerto del proxy"
 
 #: src/muuli_wdr.cpp
 msgid "The proxy port"
@@ -5379,16 +5301,8 @@ msgid "Enable/disable username/password authentication"
 msgstr "Habilitar/deshabilitar la autenticación mediante usuario/contraseña"
 
 #: src/muuli_wdr.cpp
-msgid "Username: "
-msgstr "Nombre de usuario: "
-
-#: src/muuli_wdr.cpp
 msgid "The username to use to connect to the proxy"
 msgstr "El nombre de usuario a usar para conectar al proxy"
-
-#: src/muuli_wdr.cpp
-msgid "Password:"
-msgstr "Contraseña:"
 
 #: src/muuli_wdr.cpp
 msgid "The password to use to connect to the proxy"
@@ -5561,6 +5475,15 @@ msgstr "horas"
 #: src/OtherFunctions.cpp
 msgid "days"
 msgstr "días"
+
+#. TRANSLATORS:
+#. Punctuation for a "label: value" pair. %s is the already-translated
+#. label. Place the colon as your language requires -- e.g. "%s :" with a
+#. space in French, "%s:" without one in Russian and English.
+#: src/OtherFunctions.cpp
+#, c-format
+msgid "%s:"
+msgstr ""
 
 #: src/OtherFunctions.cpp
 msgid "all"
@@ -6587,8 +6510,7 @@ msgstr "Compartirlas recursivamente publicará todos los archivos en las redes e
 msgid "Confirm shared folders"
 msgstr "Confirmar carpetas compartidas"
 
-#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp
-#: src/SharedFilesReloadProgress.cpp
+#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp src/SharedFilesReloadProgress.cpp
 msgid "Reloading shared files..."
 msgstr "Recargando los archivos compartidos..."
 
@@ -6717,18 +6639,6 @@ msgstr "Error %u: %s\n"
 #: src/SearchListCtrl.cpp
 msgid "FileID"
 msgstr "ID del archivo"
-
-#: src/SearchListCtrl.cpp
-msgid "Length"
-msgstr "Duración"
-
-#: src/SearchListCtrl.cpp
-msgid "Bitrate"
-msgstr "Tasa de bits"
-
-#: src/SearchListCtrl.cpp
-msgid "Codec"
-msgstr "Códec"
 
 #: src/SearchListCtrl.cpp
 msgid "Expand all"
@@ -7006,10 +6916,6 @@ msgstr "El servidor local está filtrado por los filtros de IP, ¡conectando a u
 #: src/ServerListCtrl.cpp
 msgid "Server Name"
 msgstr "Nombre del servidor"
-
-#: src/ServerListCtrl.cpp
-msgid "Port"
-msgstr "Puerto"
 
 #: src/ServerListCtrl.cpp
 msgid "Description"
@@ -7296,6 +7202,10 @@ msgstr "Conectando a amigo"
 #, c-format
 msgid "Connected to buddy at %s"
 msgstr "Conectando a amigo en %s"
+
+#: src/ServerWnd.cpp
+msgid "IP address:"
+msgstr "Dirección IP:"
 
 #: src/ServerWnd.cpp
 msgid "Indexed sources:"

--- a/po/et_EE.po
+++ b/po/et_EE.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-04 12:13+0200\n"
+"POT-Creation-Date: 2026-09-05 12:01+0200\n"
 "PO-Revision-Date: 2026-09-03 11:03+0000\n"
 "Last-Translator: \n"
 "Language-Team: Estonian <kde-i18n-doc@kde.org>\n"
@@ -387,8 +387,7 @@ msgstr "web server töötab protsessi id'ga %d"
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Soovisid et web server käivitataks käivitumisel, kuid amuleweb programm pole võimeline käivituma. Palun paigalada versioon mis sisaldab aMule web serverit või kompileeri aMule kasutades võtit --enable-webserver ja seejärel make install"
 
-#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
-#: src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
+#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
 msgid "ERROR"
 msgstr "VIGA"
 
@@ -676,8 +675,7 @@ msgstr "Võrgud"
 msgid "Searches"
 msgstr "Otsingud"
 
-#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/Statistics.cpp
+#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/Statistics.cpp
 msgid "Downloads"
 msgstr "Tõmbamised"
 
@@ -761,9 +759,7 @@ msgstr "Kad: Väljas"
 msgid "Core"
 msgstr ""
 
-#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#: src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp
-#: src/SourceListCtrl.cpp src/Statistics.cpp
+#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp src/Statistics.cpp
 msgid "Version"
 msgstr "Versioon"
 
@@ -1062,11 +1058,7 @@ msgstr "Ei suuda luua kataloogi '%s' '%s' kategooria jaoks, säilitan '%s' katal
 msgid "The remote core sent inconsistent data for \"%s\" (part status %d, expected %d). The file list may be showing the wrong information; reconnect to clear it."
 msgstr ""
 
-#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp
-#: src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp
-#: src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp
-#: src/Statistics.cpp
+#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp src/Statistics.cpp
 msgid "Unknown"
 msgstr "Teadmata"
 
@@ -1163,8 +1155,7 @@ msgstr "VIGA: tekkis %s faili salvestamisel: %s"
 msgid "Enter Captcha"
 msgstr "Sisesta inimtesti kontrollkood"
 
-#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp
-#: src/TransferWnd.cpp
+#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp src/TransferWnd.cpp
 msgid "Category"
 msgstr "Kategooria"
 
@@ -1328,13 +1319,11 @@ msgstr "Ei leidnud 'cryptkey.dat' faili, loon uue."
 msgid "Client Details"
 msgstr "Kliendi detailid"
 
-#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
-#: src/utils/wxCas/src/onlinesig.cpp
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
 msgid "LowID"
 msgstr "LowID"
 
-#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
-#: src/utils/wxCas/src/onlinesig.cpp
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
 msgid "HighID"
 msgstr "HighID"
 
@@ -1350,8 +1339,7 @@ msgstr "Toetatud"
 msgid "Not supported"
 msgstr "Pole toetatud"
 
-#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
-#: src/TextClient.cpp
+#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp src/TextClient.cpp
 msgid "Connected"
 msgstr "Ühendatud"
 
@@ -1359,28 +1347,24 @@ msgstr "Ühendatud"
 msgid "Disconnected"
 msgstr "Pole ühendust"
 
-#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp
-#: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f KiB/s"
 msgstr ""
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#, fuzzy
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/muuli_wdr.cpp
 msgid "Name"
-msgstr "Nimi:"
+msgstr "Nimi"
 
 #: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
 msgid "Software"
 msgstr ""
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#, fuzzy
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/muuli_wdr.cpp
 msgid "IP Address"
-msgstr "IP Aadress :"
+msgstr "IP Aadress"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Origin"
 msgstr "Allikas"
 
@@ -1398,13 +1382,11 @@ msgstr "Viimane vastuvõtt"
 msgid "Sessions"
 msgstr "Versioon"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp
 msgid "Upload Speed"
 msgstr "Saatmise kiirus"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp
 msgid "Download Speed"
 msgstr "Tõmbamise kiirus"
 
@@ -1459,13 +1441,11 @@ msgstr[1] ""
 msgid "Files"
 msgstr "Failid"
 
-#: src/ClientsListCtrl.cpp src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp
-#: src/SourceListCtrl.cpp
+#: src/ClientsListCtrl.cpp src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Uploaded"
 msgstr "Üleslaaditud"
 
-#: src/ClientsListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientsListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Downloaded"
 msgstr "Allalaetud"
 
@@ -1552,12 +1532,11 @@ msgstr "Kasutaja %s (%u) keelas ligipääsu jagatud kataloogide/failide nimekirj
 msgid "File Comments"
 msgstr "Faili kommentaarid"
 
-#: src/CommentDialogLst.cpp src/FriendListCtrl.cpp
+#: src/CommentDialogLst.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
 msgid "Username"
 msgstr "Kasutajanimi"
 
-#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp
-#: src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "File Name"
 msgstr "Faili nimi"
 
@@ -1565,7 +1544,7 @@ msgstr "Faili nimi"
 msgid "Rating"
 msgstr "Hinnang"
 
-#: src/CommentDialogLst.cpp
+#: src/CommentDialogLst.cpp src/muuli_wdr.cpp
 msgid "Comment"
 msgstr "Kommentaar"
 
@@ -1619,18 +1598,15 @@ msgstr "Auto [Kõrge]"
 msgid "Very low"
 msgstr "Väga madal"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Low"
 msgstr "Madal"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Normal"
 msgstr "Keskmine"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "High"
 msgstr "Kõrge"
 
@@ -1654,13 +1630,11 @@ msgstr "Ühendun serveri kaudu"
 msgid "Queue Full"
 msgstr "Järjekord täis"
 
-#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp
-#: src/muuli_wdr.cpp
+#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp src/muuli_wdr.cpp
 msgid "On Queue"
 msgstr "Järjekorras"
 
-#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp
-#: src/PartFile.cpp src/TransferWnd.cpp
+#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Downloading"
 msgstr "Tõmban"
 
@@ -1720,8 +1694,7 @@ msgstr "Kohalik server"
 msgid "Remote Server"
 msgstr "Kaug server"
 
-#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp
-#: src/TextClient.cpp
+#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp src/TextClient.cpp
 msgid "Kad"
 msgstr "Kad"
 
@@ -1745,8 +1718,7 @@ msgstr "Allikaid"
 msgid "Search Result"
 msgstr "Otsingu tulemus"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp
-#: src/TransferWnd.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Completed"
 msgstr "Valmis"
 
@@ -1799,8 +1771,7 @@ msgstr ""
 msgid "Part"
 msgstr "Osa"
 
-#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp
-#: src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Size"
 msgstr "Suurus"
 
@@ -1808,8 +1779,7 @@ msgstr "Suurus"
 msgid "Transferred"
 msgstr "Siiratud"
 
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
-#: src/SourceListCtrl.cpp
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp src/SourceListCtrl.cpp
 msgid "Speed"
 msgstr "Kiirus"
 
@@ -1817,13 +1787,11 @@ msgstr "Kiirus"
 msgid "Progress"
 msgstr "Edenemine"
 
-#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp
-#: src/SearchListCtrl.cpp
+#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
 msgid "Sources"
 msgstr "Allikaid"
 
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp
-#: src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Priority"
 msgstr "Prioriteet"
 
@@ -1847,9 +1815,7 @@ msgstr "Viimane vastuvõtt"
 msgid "Auto"
 msgstr "Auto"
 
-#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/TransferWnd.cpp
-#: src/utils/wxCas/src/wxcasprefs.cpp
+#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/TransferWnd.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Cancel"
 msgstr "Loobu"
 
@@ -1950,8 +1916,7 @@ msgstr "Sisesta selle faili uus nimi:"
 msgid "File rename"
 msgstr "Faili ümbernimetamine"
 
-#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp
-#: src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f MiB/s"
 msgstr ""
@@ -2756,13 +2721,11 @@ msgstr ""
 msgid "Start aMule automatically when I log in"
 msgstr ""
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
-#: packaging/windows/installer_strings.c
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp packaging/windows/installer_strings.c
 msgid "Register aMule for ed2k:// links"
 msgstr ""
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
-#: packaging/windows/installer_strings.c
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp packaging/windows/installer_strings.c
 msgid "Register aMule for magnet: links"
 msgstr ""
 
@@ -2788,8 +2751,7 @@ msgstr ""
 msgid "Destination folder for downloads"
 msgstr "Tõmmatavate failide kataloog"
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
-#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Browse"
 msgstr "Lehitse"
 
@@ -3232,18 +3194,15 @@ msgstr "Lõpetatud"
 msgid "Complete"
 msgstr "Valmis"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
-#: src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Paused"
 msgstr "Peatatud"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
-#: src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Erroneous"
 msgstr "Vigane"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
-#: src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Waiting"
 msgstr "Ootan"
 
@@ -3407,8 +3366,7 @@ msgstr "Sulge"
 msgid "Cut"
 msgstr "Lõika"
 
-#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp
-#: src/utils/aLinkCreator/src/alcframe.cpp
+#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy"
 msgstr "Kopeeri"
 
@@ -3416,8 +3374,7 @@ msgstr "Kopeeri"
 msgid "Paste"
 msgstr "Aseta"
 
-#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp
-#: src/utils/aLinkCreator/src/alcframe.cpp
+#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Clear"
 msgstr "Puhasta"
 
@@ -3425,8 +3382,7 @@ msgstr "Puhasta"
 msgid "Select All"
 msgstr "Vali kõik"
 
-#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
-#: src/StatisticsDlg.cpp
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp src/StatisticsDlg.cpp
 msgid "KiB/s"
 msgstr ""
 
@@ -3690,10 +3646,6 @@ msgstr "Sa oled serveriga ühenduses."
 msgid "Search"
 msgstr "Otsing"
 
-#: src/muuli_wdr.cpp
-msgid "Name:"
-msgstr "Nimi:"
-
 #: src/muuli_wdr.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Type"
 msgstr "Tüüp"
@@ -3783,8 +3735,8 @@ msgid "Availability"
 msgstr "Saadavus"
 
 #: src/muuli_wdr.cpp
-msgid "Filter:"
-msgstr "Filter:"
+msgid "Filter"
+msgstr "Filter"
 
 #: src/muuli_wdr.cpp
 msgid "Invert Result"
@@ -3842,6 +3794,10 @@ msgid "Clears completed downloads"
 msgstr "Puhastab lõpetatud tõmbamised"
 
 #: src/muuli_wdr.cpp
+msgid "Filter:"
+msgstr "Filter:"
+
+#: src/muuli_wdr.cpp
 msgid "File sources:"
 msgstr "Faili allikad:"
 
@@ -3850,80 +3806,76 @@ msgid "General"
 msgstr "Üldine"
 
 #: src/muuli_wdr.cpp
-msgid "Full Name :"
-msgstr "Täis nimi :"
+msgid "Full Name"
+msgstr "Täis nimi"
 
 #: src/muuli_wdr.cpp
-msgid "met-File :"
-msgstr "met-Fail :"
+msgid "met-File"
+msgstr "met-Fail"
 
 #: src/muuli_wdr.cpp
-msgid "Hash :"
-msgstr "Kontrollsumma :"
+msgid "Hash"
+msgstr "Kontrollsumma"
 
 #: src/muuli_wdr.cpp
-msgid "Filesize :"
-msgstr "Faili suurus :"
+msgid "Filesize"
+msgstr "Faili suurus"
 
 #: src/muuli_wdr.cpp src/Statistics.cpp
 msgid "Transfer"
 msgstr "Liiklus"
 
 #: src/muuli_wdr.cpp
-msgid "Partfilestatus :"
-msgstr "Osafaili staatus :"
+msgid "Partfilestatus"
+msgstr "Osafaili staatus"
 
 #: src/muuli_wdr.cpp
-msgid "Last seen complete :"
-msgstr "Viimati nähtud tervikuna :"
+msgid "Last seen complete"
+msgstr "Viimati nähtud tervikuna"
 
 #: src/muuli_wdr.cpp
-msgid "Found Sources :"
-msgstr "Leitud allikaid :"
+msgid "Found Sources"
+msgstr "Leitud allikaid"
 
 #: src/muuli_wdr.cpp
-msgid "Transferring Sources :"
-msgstr "Saatvaid allikaid :"
+msgid "Transferring Sources"
+msgstr "Saatvaid allikaid"
 
 #: src/muuli_wdr.cpp
-msgid "Filepart-Count :"
-msgstr "Failiosi :"
+msgid "Filepart-Count"
+msgstr "Failiosi"
 
 #: src/muuli_wdr.cpp
-msgid "Available :"
-msgstr "Saadaval :"
+msgid "Available"
+msgstr "Saadaval"
 
 #: src/muuli_wdr.cpp
-msgid "Datarate :"
-msgstr "Andmekiirus :"
+msgid "Datarate"
+msgstr "Andmekiirus"
 
 #: src/muuli_wdr.cpp
-msgid "Download Active Time: "
-msgstr "Aktiivne Tõmbamine: "
+msgid "Download Active Time"
+msgstr "Aktiivne Tõmbamine"
 
 #: src/muuli_wdr.cpp
-msgid "Transferred :"
-msgstr "Siiratud :"
-
-#: src/muuli_wdr.cpp
-msgid "Completed Size :"
-msgstr "Valmis suurus :"
+msgid "Completed Size"
+msgstr "Valmis suurus"
 
 #: src/muuli_wdr.cpp
 msgid "Intelligent Corruption Handling"
 msgstr "Intelligentne riknemise vältimine"
 
 #: src/muuli_wdr.cpp
-msgid "Lost to corruption :"
-msgstr "Riknemise tõttu kaotatud :"
+msgid "Lost to corruption"
+msgstr "Riknemise tõttu kaotatud"
 
 #: src/muuli_wdr.cpp
-msgid "Gained by compression :"
-msgstr "Võidetud tänu kokkusurumisele :"
+msgid "Gained by compression"
+msgstr "Võidetud tänu kokkusurumisele"
 
 #: src/muuli_wdr.cpp
-msgid "Packages saved by I.C.H. :"
-msgstr "I.C.H. päästetud paketid :"
+msgid "Packages saved by I.C.H."
+msgstr "I.C.H. päästetud paketid"
 
 #: src/muuli_wdr.cpp
 #, fuzzy
@@ -3965,30 +3917,30 @@ msgstr ", Saatmine: "
 msgid "Media Info"
 msgstr "Kad Info"
 
-#: src/muuli_wdr.cpp
-msgid "Length :"
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
+msgid "Length"
 msgstr ""
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
 #, fuzzy
-msgid "Bitrate :"
+msgid "Bitrate"
 msgstr "Pole hinnatud"
 
-#: src/muuli_wdr.cpp
-msgid "Codec :"
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
+msgid "Codec"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Artist :"
+msgid "Artist"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Album :"
+msgid "Album"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Title :"
-msgstr "Tiitel :"
+msgid "Title"
+msgstr "Tiitel"
 
 #: src/muuli_wdr.cpp
 msgid "File Names"
@@ -4075,25 +4027,17 @@ msgstr "Suurus teadmata"
 msgid "Required Information"
 msgstr "Vajalik informatsioon"
 
-#: src/muuli_wdr.cpp
-msgid "IP Address :"
-msgstr "IP Aadress :"
-
-#: src/muuli_wdr.cpp
-msgid "Port :"
-msgstr "Port :"
+#: src/muuli_wdr.cpp src/ServerListCtrl.cpp
+msgid "Port"
+msgstr "Port"
 
 #: src/muuli_wdr.cpp
 msgid "Additional Information"
 msgstr "Lisainformatsioon"
 
 #: src/muuli_wdr.cpp
-msgid "Username :"
-msgstr "Kasutajanimi :"
-
-#: src/muuli_wdr.cpp
-msgid "Userhash :"
-msgstr "Kasutaja kontrollsumma :"
+msgid "Userhash"
+msgstr "Kasutaja kontrollsumma"
 
 #: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Add"
@@ -4128,96 +4072,80 @@ msgid "Statistics Tree"
 msgstr "Statistika Puu"
 
 #: src/muuli_wdr.cpp
-msgid "Username:"
-msgstr "Kasutajanimi:"
+msgid "Client software"
+msgstr "Klienditarkvara"
 
 #: src/muuli_wdr.cpp
-msgid "Userhash:"
-msgstr "Kasutaja kontrollsumma:"
+msgid "Client version"
+msgstr "Kliendiversioon"
 
 #: src/muuli_wdr.cpp
-msgid "Client software:"
-msgstr "Klienditarkvara:"
+msgid "User ID"
+msgstr "Kasutaja ID"
 
 #: src/muuli_wdr.cpp
-msgid "Client version:"
-msgstr "Kliendiversioon:"
-
-#: src/muuli_wdr.cpp src/ServerWnd.cpp
-msgid "IP address:"
-msgstr "IP aadress:"
+msgid "Server IP"
+msgstr "Serveri IP"
 
 #: src/muuli_wdr.cpp
-msgid "User ID:"
-msgstr "Kasutaja ID:"
+msgid "Server name"
+msgstr "Serveri nimi"
 
 #: src/muuli_wdr.cpp
-msgid "Server IP:"
-msgstr "Serveri IP:"
-
-#: src/muuli_wdr.cpp
-msgid "Server name:"
-msgstr "Serveri nimi:"
-
-#: src/muuli_wdr.cpp
-msgid "Obfuscation:"
-msgstr "Hämatud:"
-
-#: src/muuli_wdr.cpp
-msgid "Kad:"
-msgstr "Kad:"
+msgid "Obfuscation"
+msgstr "Hämatud"
 
 #: src/muuli_wdr.cpp
 msgid "Transfers to client"
 msgstr "Liiklus kliendile"
 
 #: src/muuli_wdr.cpp
-msgid "Current request:"
-msgstr "Praegune päring:"
+msgid "Current request"
+msgstr "Praegune päring"
 
 #: src/muuli_wdr.cpp
-msgid "Average upload rate:"
-msgstr "Keskmine saatmise suhe:"
+msgid "Average upload rate"
+msgstr "Keskmine saatmise suhe"
 
 #: src/muuli_wdr.cpp
-msgid "Average download rate:"
-msgstr "Keskmine tõmbamise suhe:"
+msgid "Average download rate"
+msgstr "Keskmine tõmbamise suhe"
 
 #: src/muuli_wdr.cpp
-msgid "Uploaded (session):"
-msgstr "Saadetud (selles seansis):"
+msgid "Uploaded (session)"
+msgstr "Saadetud (selles seansis)"
 
 #: src/muuli_wdr.cpp
-msgid "Downloaded (session):"
-msgstr "Tõmmatud (selles seansis):"
+msgid "Downloaded (session)"
+msgstr "Tõmmatud (selles seansis)"
 
 #: src/muuli_wdr.cpp
-msgid "Uploaded (total):"
-msgstr "Saadetud (kokku):"
+msgid "Uploaded (total)"
+msgstr "Saadetud (kokku)"
 
 #: src/muuli_wdr.cpp
-msgid "Downloaded (total):"
-msgstr "Tõmmatud (kokku):"
+msgid "Downloaded (total)"
+msgstr "Tõmmatud (kokku)"
 
 #: src/muuli_wdr.cpp
 msgid "Scores"
 msgstr "Skoorid"
 
 #: src/muuli_wdr.cpp
-msgid "DL/UP modifier:"
-msgstr "AL/ÜL kordaja:"
+msgid "DL/UP modifier"
+msgstr "AL/ÜL kordaja"
 
 #: src/muuli_wdr.cpp
-msgid "Secure ident:"
-msgstr "Turvaline ident:"
+msgid "Secure ident"
+msgstr "Turvaline ident"
 
 #: src/muuli_wdr.cpp
-msgid "Queue rank:"
-msgstr "Järjekorras:"
+msgid "Queue rank"
+msgstr "Järjekorras"
 
 #: src/muuli_wdr.cpp
-msgid "Queue score:"
-msgstr "Saba skoor:"
+msgid "Queue score"
+msgstr "Saba skoor"
 
 #: src/muuli_wdr.cpp
 msgid "Nick"
@@ -5013,24 +4941,20 @@ msgid "Reset any changes made to the preferences."
 msgstr "Tühista kõik seadetes tehtud muudatused."
 
 #: src/muuli_wdr.cpp
-msgid "Comment :"
-msgstr "Kommentaar :"
+msgid "Incoming Dir"
+msgstr "Tõmmatud failide kataloog"
 
 #: src/muuli_wdr.cpp
-msgid "Incoming Dir :"
-msgstr "Tõmmatud failide kataloog :"
-
-#: src/muuli_wdr.cpp
-msgid "Change priority for new assigned files :"
-msgstr "Muuda uute failide prioriteeti :"
+msgid "Change priority for new assigned files"
+msgstr "Muuda uute failide prioriteeti"
 
 #: src/muuli_wdr.cpp
 msgid "Don't change"
 msgstr "Ära muuda"
 
 #: src/muuli_wdr.cpp
-msgid "Select color for this Category (currently selected) :"
-msgstr "Vali praegu valitud kategooriale värv :"
+msgid "Select color for this Category (currently selected)"
+msgstr "Vali praegu valitud kategooriale värv"
 
 #: src/muuli_wdr.cpp
 msgid "Click this button to reset the log."
@@ -5113,10 +5037,6 @@ msgstr "Tuntud klientide Bootstrap"
 #, fuzzy
 msgid "Enter the IP of the node here, using the x.x.x.x format."
 msgstr "Sisesta siia serveri IP aadrdess, kasutades x.x.x.x formaati."
-
-#: src/muuli_wdr.cpp
-msgid "Port:"
-msgstr "Port:"
 
 #: src/muuli_wdr.cpp
 msgid "Use Secure User Identification"
@@ -5385,20 +5305,20 @@ msgid "Enable/disable proxy support"
 msgstr "Kasuta/ärakasuta puhverserveri tuge"
 
 #: src/muuli_wdr.cpp
-msgid "Proxy type:"
-msgstr "Puhverserveri tüüp:"
+msgid "Proxy type"
+msgstr "Puhverserveri tüüp"
 
 #: src/muuli_wdr.cpp
-msgid "Proxy host:"
-msgstr "Puhverserveri nimi:"
+msgid "Proxy host"
+msgstr "Puhverserveri nimi"
 
 #: src/muuli_wdr.cpp
 msgid "The proxy host name"
 msgstr "Selle puhverserveri/hosti nimi "
 
 #: src/muuli_wdr.cpp
-msgid "Proxy port:"
-msgstr "Puhverserveri port:"
+msgid "Proxy port"
+msgstr "Puhverserveri port"
 
 #: src/muuli_wdr.cpp
 msgid "The proxy port"
@@ -5413,16 +5333,8 @@ msgid "Enable/disable username/password authentication"
 msgstr "Autoriseerimisel Kasuta/Ära kasuta kasutajanime/parooli"
 
 #: src/muuli_wdr.cpp
-msgid "Username: "
-msgstr "Kasutajanimi: "
-
-#: src/muuli_wdr.cpp
 msgid "The username to use to connect to the proxy"
 msgstr "Puhverserveriga ühenduseks vajalik kasutajanimi"
-
-#: src/muuli_wdr.cpp
-msgid "Password:"
-msgstr "Parool:"
 
 #: src/muuli_wdr.cpp
 msgid "The password to use to connect to the proxy"
@@ -5598,6 +5510,15 @@ msgstr "tundi"
 #: src/OtherFunctions.cpp
 msgid "days"
 msgstr "päev(a)"
+
+#. TRANSLATORS:
+#. Punctuation for a "label: value" pair. %s is the already-translated
+#. label. Place the colon as your language requires -- e.g. "%s :" with a
+#. space in French, "%s:" without one in Russian and English.
+#: src/OtherFunctions.cpp
+#, c-format
+msgid "%s:"
+msgstr ""
 
 #: src/OtherFunctions.cpp
 msgid "all"
@@ -6642,8 +6563,7 @@ msgstr ""
 msgid "Confirm shared folders"
 msgstr "Jagatud kataloogid"
 
-#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp
-#: src/SharedFilesReloadProgress.cpp
+#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp src/SharedFilesReloadProgress.cpp
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "Lae oma jagatud failid uuesti"
@@ -6777,19 +6697,6 @@ msgstr "GeoIP.dat uuendamise viga"
 #: src/SearchListCtrl.cpp
 msgid "FileID"
 msgstr "FailiID"
-
-#: src/SearchListCtrl.cpp
-msgid "Length"
-msgstr ""
-
-#: src/SearchListCtrl.cpp
-#, fuzzy
-msgid "Bitrate"
-msgstr "Pole hinnatud"
-
-#: src/SearchListCtrl.cpp
-msgid "Codec"
-msgstr ""
 
 #: src/SearchListCtrl.cpp
 msgid "Expand all"
@@ -7075,10 +6982,6 @@ msgstr "Kohalik server on IPFiltri poolt väljafiltreeritud, ühendud teise serv
 #: src/ServerListCtrl.cpp
 msgid "Server Name"
 msgstr "Serveri nimi"
-
-#: src/ServerListCtrl.cpp
-msgid "Port"
-msgstr "Port"
 
 #: src/ServerListCtrl.cpp
 msgid "Description"
@@ -7373,6 +7276,10 @@ msgstr "Ühendun semuga"
 #, c-format
 msgid "Connected to buddy at %s"
 msgstr "Ühendus semuga %s"
+
+#: src/ServerWnd.cpp
+msgid "IP address:"
+msgstr "IP aadress:"
 
 #: src/ServerWnd.cpp
 msgid "Indexed sources:"

--- a/po/eu.po
+++ b/po/eu.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-04 12:13+0200\n"
+"POT-Creation-Date: 2026-09-05 12:01+0200\n"
 "PO-Revision-Date: 2026-09-03 11:04+0000\n"
 "Last-Translator: Piarres Beobide <pi@beobide.net>\n"
 "Language-Team: Euskara <librezale@librezale.org>\n"
@@ -388,8 +388,7 @@ msgstr "web zerbitzaria abiarazirik %d pid-arekin"
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Abioan web-zerbitzaria exekutatzea eskatu duzu, baina amuleweb bitarra ezin da exekutatu. Mesedez instalatu amule web zerbitzaria duen paketea edo konpilatu ezazu amule --enable-webserver erabilian eta make install egin"
 
-#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
-#: src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
+#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
 msgid "ERROR"
 msgstr "ERROREA"
 
@@ -677,8 +676,7 @@ msgstr "Sareak"
 msgid "Searches"
 msgstr "Bilaketak"
 
-#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/Statistics.cpp
+#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/Statistics.cpp
 msgid "Downloads"
 msgstr "Deskargak"
 
@@ -762,9 +760,7 @@ msgstr "Kad: Itzalia"
 msgid "Core"
 msgstr ""
 
-#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#: src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp
-#: src/SourceListCtrl.cpp src/Statistics.cpp
+#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp src/Statistics.cpp
 msgid "Version"
 msgstr "Bertsioa"
 
@@ -1063,11 +1059,7 @@ msgstr "Ezin da '%s' direktorioa sortu '%s' kategoriarentzat, '%s' direktorioa m
 msgid "The remote core sent inconsistent data for \"%s\" (part status %d, expected %d). The file list may be showing the wrong information; reconnect to clear it."
 msgstr ""
 
-#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp
-#: src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp
-#: src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp
-#: src/Statistics.cpp
+#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp src/Statistics.cpp
 msgid "Unknown"
 msgstr "Ezezaguna"
 
@@ -1164,8 +1156,7 @@ msgstr "Errorea %s fitxategia gordetzerakoan: %s"
 msgid "Enter Captcha"
 msgstr "Idatzi kaptxa"
 
-#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp
-#: src/TransferWnd.cpp
+#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp src/TransferWnd.cpp
 msgid "Category"
 msgstr "Kategoria"
 
@@ -1329,13 +1320,11 @@ msgstr "Ez da 'cryptkey.dat' fitxategia aurkitu, sortzen."
 msgid "Client Details"
 msgstr "Bezero xehetasunak"
 
-#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
-#: src/utils/wxCas/src/onlinesig.cpp
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
 msgid "LowID"
 msgstr "IDBaxua"
 
-#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
-#: src/utils/wxCas/src/onlinesig.cpp
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
 msgid "HighID"
 msgstr "IDAltua"
 
@@ -1351,8 +1340,7 @@ msgstr "Onartua"
 msgid "Not supported"
 msgstr "Ez da onartzen"
 
-#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
-#: src/TextClient.cpp
+#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp src/TextClient.cpp
 msgid "Connected"
 msgstr "Konektaturik"
 
@@ -1360,28 +1348,24 @@ msgstr "Konektaturik"
 msgid "Disconnected"
 msgstr "Deskonektatuta"
 
-#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp
-#: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f KiB/s"
 msgstr ""
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#, fuzzy
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/muuli_wdr.cpp
 msgid "Name"
-msgstr "Izena:"
+msgstr "Izena"
 
 #: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
 msgid "Software"
 msgstr ""
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#, fuzzy
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/muuli_wdr.cpp
 msgid "IP Address"
-msgstr "IP helbidea :"
+msgstr "IP helbidea"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Origin"
 msgstr "Jatorria"
 
@@ -1399,13 +1383,11 @@ msgstr "Azkenez jasoa"
 msgid "Sessions"
 msgstr "Bertsioa"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp
 msgid "Upload Speed"
 msgstr "Igoera abiadura"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp
 msgid "Download Speed"
 msgstr "Deskarga abiadura"
 
@@ -1460,13 +1442,11 @@ msgstr[1] ""
 msgid "Files"
 msgstr "Fitxategiak"
 
-#: src/ClientsListCtrl.cpp src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp
-#: src/SourceListCtrl.cpp
+#: src/ClientsListCtrl.cpp src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Uploaded"
 msgstr "Igoa"
 
-#: src/ClientsListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientsListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Downloaded"
 msgstr "Deskargatua"
 
@@ -1553,12 +1533,11 @@ msgstr "%s (%u) erabiltzaileak fitxategi/direktorio partekatuen zerrenda ikustea
 msgid "File Comments"
 msgstr "Fitxategi Iruzkinak"
 
-#: src/CommentDialogLst.cpp src/FriendListCtrl.cpp
+#: src/CommentDialogLst.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
 msgid "Username"
 msgstr "Erabiltzaile izena"
 
-#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp
-#: src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "File Name"
 msgstr "Fitxategi izena"
 
@@ -1566,7 +1545,7 @@ msgstr "Fitxategi izena"
 msgid "Rating"
 msgstr "Kalifikazioa"
 
-#: src/CommentDialogLst.cpp
+#: src/CommentDialogLst.cpp src/muuli_wdr.cpp
 msgid "Comment"
 msgstr "Iruzkina"
 
@@ -1620,18 +1599,15 @@ msgstr "Auto[Alt]"
 msgid "Very low"
 msgstr "Oso txikia"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Low"
 msgstr "Baxua"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Normal"
 msgstr "Normala"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "High"
 msgstr "Altua"
 
@@ -1655,13 +1631,11 @@ msgstr "Konektatu zerbitzaria bidez"
 msgid "Queue Full"
 msgstr "Ilara Osoa"
 
-#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp
-#: src/muuli_wdr.cpp
+#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp src/muuli_wdr.cpp
 msgid "On Queue"
 msgstr "Ilaran"
 
-#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp
-#: src/PartFile.cpp src/TransferWnd.cpp
+#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Downloading"
 msgstr "Deskargatzen"
 
@@ -1721,8 +1695,7 @@ msgstr "Zerbitzari lokala"
 msgid "Remote Server"
 msgstr "Urruneko zerbitzaria"
 
-#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp
-#: src/TextClient.cpp
+#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp src/TextClient.cpp
 msgid "Kad"
 msgstr "Kad"
 
@@ -1746,8 +1719,7 @@ msgstr "Jatorri haziak"
 msgid "Search Result"
 msgstr "Bilaketa emaitza"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp
-#: src/TransferWnd.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Completed"
 msgstr "Amaitua"
 
@@ -1800,8 +1772,7 @@ msgstr ""
 msgid "Part"
 msgstr "Zatia"
 
-#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp
-#: src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Size"
 msgstr "Tamaina"
 
@@ -1809,8 +1780,7 @@ msgstr "Tamaina"
 msgid "Transferred"
 msgstr "Transferituta"
 
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
-#: src/SourceListCtrl.cpp
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp src/SourceListCtrl.cpp
 msgid "Speed"
 msgstr "Abiadura"
 
@@ -1818,13 +1788,11 @@ msgstr "Abiadura"
 msgid "Progress"
 msgstr "Egoera"
 
-#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp
-#: src/SearchListCtrl.cpp
+#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
 msgid "Sources"
 msgstr "Jatorriak"
 
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp
-#: src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Priority"
 msgstr "Lehentasuna"
 
@@ -1848,9 +1816,7 @@ msgstr "Azkenez jasoa"
 msgid "Auto"
 msgstr "Auto"
 
-#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/TransferWnd.cpp
-#: src/utils/wxCas/src/wxcasprefs.cpp
+#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/TransferWnd.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Cancel"
 msgstr "Utzi"
 
@@ -1951,8 +1917,7 @@ msgstr "Sar izen berri bat fitxategi honentzat:"
 msgid "File rename"
 msgstr "Fitxategia berrizendatu"
 
-#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp
-#: src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f MiB/s"
 msgstr ""
@@ -2757,13 +2722,11 @@ msgstr ""
 msgid "Start aMule automatically when I log in"
 msgstr ""
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
-#: packaging/windows/installer_strings.c
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp packaging/windows/installer_strings.c
 msgid "Register aMule for ed2k:// links"
 msgstr ""
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
-#: packaging/windows/installer_strings.c
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp packaging/windows/installer_strings.c
 msgid "Register aMule for magnet: links"
 msgstr ""
 
@@ -2789,8 +2752,7 @@ msgstr ""
 msgid "Destination folder for downloads"
 msgstr "Deskargentzat helburu karpeta"
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
-#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Browse"
 msgstr "Arakatu"
 
@@ -3233,18 +3195,15 @@ msgstr "Osotzen"
 msgid "Complete"
 msgstr "Amaitua"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
-#: src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Paused"
 msgstr "Geraturik"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
-#: src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Erroneous"
 msgstr "Akasdun"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
-#: src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Waiting"
 msgstr "Zain"
 
@@ -3408,8 +3367,7 @@ msgstr "Itxi"
 msgid "Cut"
 msgstr "Ebaki"
 
-#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp
-#: src/utils/aLinkCreator/src/alcframe.cpp
+#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy"
 msgstr "Kopiatu"
 
@@ -3417,8 +3375,7 @@ msgstr "Kopiatu"
 msgid "Paste"
 msgstr "Itsatsi"
 
-#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp
-#: src/utils/aLinkCreator/src/alcframe.cpp
+#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Clear"
 msgstr "Garbitu"
 
@@ -3426,8 +3383,7 @@ msgstr "Garbitu"
 msgid "Select All"
 msgstr "Hautatu dena"
 
-#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
-#: src/StatisticsDlg.cpp
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp src/StatisticsDlg.cpp
 msgid "KiB/s"
 msgstr ""
 
@@ -3691,10 +3647,6 @@ msgstr "Une honetan konektaturiko zerbitzaria."
 msgid "Search"
 msgstr "Bilatu"
 
-#: src/muuli_wdr.cpp
-msgid "Name:"
-msgstr "Izena:"
-
 #: src/muuli_wdr.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Type"
 msgstr "Mota"
@@ -3784,8 +3736,8 @@ msgid "Availability"
 msgstr "Eskuragarritasuna"
 
 #: src/muuli_wdr.cpp
-msgid "Filter:"
-msgstr "Iragazkia:"
+msgid "Filter"
+msgstr "Iragazkia"
 
 #: src/muuli_wdr.cpp
 msgid "Invert Result"
@@ -3843,6 +3795,10 @@ msgid "Clears completed downloads"
 msgstr "Garbitu amaituriko deskargak"
 
 #: src/muuli_wdr.cpp
+msgid "Filter:"
+msgstr "Iragazkia:"
+
+#: src/muuli_wdr.cpp
 msgid "File sources:"
 msgstr "Fitxategiaren iturburua:"
 
@@ -3851,80 +3807,76 @@ msgid "General"
 msgstr "Orokorra"
 
 #: src/muuli_wdr.cpp
-msgid "Full Name :"
-msgstr "Izen osoa :"
+msgid "Full Name"
+msgstr "Izen osoa"
 
 #: src/muuli_wdr.cpp
-msgid "met-File :"
-msgstr "met-fitxategia :"
+msgid "met-File"
+msgstr "met-fitxategia"
 
 #: src/muuli_wdr.cpp
-msgid "Hash :"
-msgstr "Aztertze zenbakia :"
+msgid "Hash"
+msgstr "Aztertze zenbakia"
 
 #: src/muuli_wdr.cpp
-msgid "Filesize :"
-msgstr "Fitxategi tamaina :"
+msgid "Filesize"
+msgstr "Fitxategi tamaina"
 
 #: src/muuli_wdr.cpp src/Statistics.cpp
 msgid "Transfer"
 msgstr "Transferentzia"
 
 #: src/muuli_wdr.cpp
-msgid "Partfilestatus :"
-msgstr "Fitxategi zati egoera :"
+msgid "Partfilestatus"
+msgstr "Fitxategi zati egoera"
 
 #: src/muuli_wdr.cpp
-msgid "Last seen complete :"
-msgstr "Azkenez osorik ikusia :"
+msgid "Last seen complete"
+msgstr "Azkenez osorik ikusia"
 
 #: src/muuli_wdr.cpp
-msgid "Found Sources :"
-msgstr "Aurkitutako jatorriak :"
+msgid "Found Sources"
+msgstr "Aurkitutako jatorriak"
 
 #: src/muuli_wdr.cpp
-msgid "Transferring Sources :"
-msgstr "Jatorriak transferitzen :"
+msgid "Transferring Sources"
+msgstr "Jatorriak transferitzen"
 
 #: src/muuli_wdr.cpp
-msgid "Filepart-Count :"
-msgstr "Fitxategi zati kopurua :"
+msgid "Filepart-Count"
+msgstr "Fitxategi zati kopurua"
 
 #: src/muuli_wdr.cpp
-msgid "Available :"
-msgstr "Erabilgarri :"
+msgid "Available"
+msgstr "Erabilgarri"
 
 #: src/muuli_wdr.cpp
-msgid "Datarate :"
-msgstr "Data abiadura :"
+msgid "Datarate"
+msgstr "Data abiadura"
 
 #: src/muuli_wdr.cpp
-msgid "Download Active Time: "
-msgstr "Deskarga aktibo denbora: "
+msgid "Download Active Time"
+msgstr "Deskarga aktibo denbora"
 
 #: src/muuli_wdr.cpp
-msgid "Transferred :"
-msgstr "Transferituta :"
-
-#: src/muuli_wdr.cpp
-msgid "Completed Size :"
-msgstr "Amaitua tamaina :"
+msgid "Completed Size"
+msgstr "Amaitua tamaina"
 
 #: src/muuli_wdr.cpp
 msgid "Intelligent Corruption Handling"
 msgstr "Hondatze kudeaketa adimentsua"
 
 #: src/muuli_wdr.cpp
-msgid "Lost to corruption :"
-msgstr "Hondaketan galdutakoa :"
+msgid "Lost to corruption"
+msgstr "Hondaketan galdutakoa"
 
 #: src/muuli_wdr.cpp
-msgid "Gained by compression :"
-msgstr "Konpresioaz irabazitakoa :"
+msgid "Gained by compression"
+msgstr "Konpresioaz irabazitakoa"
 
 #: src/muuli_wdr.cpp
-msgid "Packages saved by I.C.H. :"
-msgstr "I.C.H. gordetako paketeak :"
+msgid "Packages saved by I.C.H."
+msgstr "I.C.H. gordetako paketeak"
 
 #: src/muuli_wdr.cpp
 #, fuzzy
@@ -3966,30 +3918,30 @@ msgstr ", Igoerak: "
 msgid "Media Info"
 msgstr "Kad Argb"
 
-#: src/muuli_wdr.cpp
-msgid "Length :"
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
+msgid "Length"
 msgstr ""
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
 #, fuzzy
-msgid "Bitrate :"
+msgid "Bitrate"
 msgstr "Kalifikatu gabea"
 
-#: src/muuli_wdr.cpp
-msgid "Codec :"
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
+msgid "Codec"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Artist :"
+msgid "Artist"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Album :"
+msgid "Album"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Title :"
-msgstr "Titulua :"
+msgid "Title"
+msgstr "Titulua"
 
 #: src/muuli_wdr.cpp
 msgid "File Names"
@@ -4076,25 +4028,17 @@ msgstr "Ezezaguna"
 msgid "Required Information"
 msgstr "Behar den Informazioa"
 
-#: src/muuli_wdr.cpp
-msgid "IP Address :"
-msgstr "IP helbidea :"
-
-#: src/muuli_wdr.cpp
-msgid "Port :"
-msgstr "Ataka :"
+#: src/muuli_wdr.cpp src/ServerListCtrl.cpp
+msgid "Port"
+msgstr "Ataka"
 
 #: src/muuli_wdr.cpp
 msgid "Additional Information"
 msgstr "Bestelako informazioa"
 
 #: src/muuli_wdr.cpp
-msgid "Username :"
-msgstr "Erabiltzaile-izena :"
-
-#: src/muuli_wdr.cpp
-msgid "Userhash :"
-msgstr "Erabiltzaile aztertze zenbakia :"
+msgid "Userhash"
+msgstr "Erabiltzaile aztertze zenbakia"
 
 #: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Add"
@@ -4129,96 +4073,80 @@ msgid "Statistics Tree"
 msgstr "Estatistika zuhaitza"
 
 #: src/muuli_wdr.cpp
-msgid "Username:"
-msgstr "Erabiltzaile izena:"
+msgid "Client software"
+msgstr "Bezero softwarea"
 
 #: src/muuli_wdr.cpp
-msgid "Userhash:"
-msgstr "Erabiltzaile-Egiaztapena:"
+msgid "Client version"
+msgstr "Bezero bertsioa"
 
 #: src/muuli_wdr.cpp
-msgid "Client software:"
-msgstr "Bezero softwarea:"
+msgid "User ID"
+msgstr "Erabiltzaile ID-a"
 
 #: src/muuli_wdr.cpp
-msgid "Client version:"
-msgstr "Bezero bertsioa:"
-
-#: src/muuli_wdr.cpp src/ServerWnd.cpp
-msgid "IP address:"
-msgstr "IP helbidea:"
+msgid "Server IP"
+msgstr "Zerbitzaria IP-a"
 
 #: src/muuli_wdr.cpp
-msgid "User ID:"
-msgstr "Erabiltzaile ID-a:"
+msgid "Server name"
+msgstr "Zerbitzari izena"
 
 #: src/muuli_wdr.cpp
-msgid "Server IP:"
-msgstr "Zerbitzaria IP-a:"
-
-#: src/muuli_wdr.cpp
-msgid "Server name:"
-msgstr "Zerbitzari izena:"
-
-#: src/muuli_wdr.cpp
-msgid "Obfuscation:"
-msgstr "Nahasmena:"
-
-#: src/muuli_wdr.cpp
-msgid "Kad:"
-msgstr "Kad:"
+msgid "Obfuscation"
+msgstr "Nahasmena"
 
 #: src/muuli_wdr.cpp
 msgid "Transfers to client"
 msgstr "bezerora transferentziak"
 
 #: src/muuli_wdr.cpp
-msgid "Current request:"
-msgstr "Uneko eskakizuna:"
+msgid "Current request"
+msgstr "Uneko eskakizuna"
 
 #: src/muuli_wdr.cpp
-msgid "Average upload rate:"
-msgstr "Bataz besteko igoera abiadura:"
+msgid "Average upload rate"
+msgstr "Bataz besteko igoera abiadura"
 
 #: src/muuli_wdr.cpp
-msgid "Average download rate:"
-msgstr "Bataz besteko deskarga abiadura:"
+msgid "Average download rate"
+msgstr "Bataz besteko deskarga abiadura"
 
 #: src/muuli_wdr.cpp
-msgid "Uploaded (session):"
-msgstr "Igoa (saioa):"
+msgid "Uploaded (session)"
+msgstr "Igoa (saioa)"
 
 #: src/muuli_wdr.cpp
-msgid "Downloaded (session):"
-msgstr "Deskargatua (saioa):"
+msgid "Downloaded (session)"
+msgstr "Deskargatua (saioa)"
 
 #: src/muuli_wdr.cpp
-msgid "Uploaded (total):"
-msgstr "Igoa (denera):"
+msgid "Uploaded (total)"
+msgstr "Igoa (denera)"
 
 #: src/muuli_wdr.cpp
-msgid "Downloaded (total):"
-msgstr "Deskargatua (denera):"
+msgid "Downloaded (total)"
+msgstr "Deskargatua (denera)"
 
 #: src/muuli_wdr.cpp
 msgid "Scores"
 msgstr "Puntuak"
 
 #: src/muuli_wdr.cpp
-msgid "DL/UP modifier:"
-msgstr "DE/IG aldagaia:"
+msgid "DL/UP modifier"
+msgstr "DE/IG aldagaia"
 
 #: src/muuli_wdr.cpp
-msgid "Secure ident:"
-msgstr "Identitate ziurra:"
+msgid "Secure ident"
+msgstr "Identitate ziurra"
 
 #: src/muuli_wdr.cpp
-msgid "Queue rank:"
-msgstr "Ilara ranking-a:"
+msgid "Queue rank"
+msgstr "Ilara ranking-a"
 
 #: src/muuli_wdr.cpp
-msgid "Queue score:"
-msgstr "Ilara puntuak:"
+msgid "Queue score"
+msgstr "Ilara puntuak"
 
 #: src/muuli_wdr.cpp
 msgid "Nick"
@@ -5013,24 +4941,20 @@ msgid "Reset any changes made to the preferences."
 msgstr "Berrezarri hobespenetan eginiko edozein aldaketa."
 
 #: src/muuli_wdr.cpp
-msgid "Comment :"
-msgstr "Iruzkina :"
+msgid "Incoming Dir"
+msgstr "Deskarga direktorioa"
 
 #: src/muuli_wdr.cpp
-msgid "Incoming Dir :"
-msgstr "Deskarga direktorioa :"
-
-#: src/muuli_wdr.cpp
-msgid "Change priority for new assigned files :"
-msgstr "Aldatu lehentasuna fitxategi berrientzat :"
+msgid "Change priority for new assigned files"
+msgstr "Aldatu lehentasuna fitxategi berrientzat"
 
 #: src/muuli_wdr.cpp
 msgid "Don't change"
 msgstr "Ez aldatu"
 
 #: src/muuli_wdr.cpp
-msgid "Select color for this Category (currently selected) :"
-msgstr "Hautatu kolorea kategoria honentzat (unean aukeratutakoa) :"
+msgid "Select color for this Category (currently selected)"
+msgstr "Hautatu kolorea kategoria honentzat (unean aukeratutakoa)"
 
 #: src/muuli_wdr.cpp
 msgid "Click this button to reset the log."
@@ -5113,10 +5037,6 @@ msgstr "Bezero ezagunetarik abiarazi"
 #, fuzzy
 msgid "Enter the IP of the node here, using the x.x.x.x format."
 msgstr "Idatzi x.x.x.x formatua erabiliaz zerbitzariaren ip helbidea."
-
-#: src/muuli_wdr.cpp
-msgid "Port:"
-msgstr "Ataka:"
 
 #: src/muuli_wdr.cpp
 msgid "Use Secure User Identification"
@@ -5385,20 +5305,20 @@ msgid "Enable/disable proxy support"
 msgstr "Proxy onarpena gaitu/ezgaitu"
 
 #: src/muuli_wdr.cpp
-msgid "Proxy type:"
-msgstr "Proxy mota:"
+msgid "Proxy type"
+msgstr "Proxy mota"
 
 #: src/muuli_wdr.cpp
-msgid "Proxy host:"
-msgstr "Proxy ostalaria:"
+msgid "Proxy host"
+msgstr "Proxy ostalaria"
 
 #: src/muuli_wdr.cpp
 msgid "The proxy host name"
 msgstr "Proxy ostalari izena"
 
 #: src/muuli_wdr.cpp
-msgid "Proxy port:"
-msgstr "Proxy ataka:"
+msgid "Proxy port"
+msgstr "Proxy ataka"
 
 #: src/muuli_wdr.cpp
 msgid "The proxy port"
@@ -5413,16 +5333,8 @@ msgid "Enable/disable username/password authentication"
 msgstr "erabiltzaile/pasahitz autentifikazioa gaitu/ezgaitu"
 
 #: src/muuli_wdr.cpp
-msgid "Username: "
-msgstr "Erabiltzaile izena: "
-
-#: src/muuli_wdr.cpp
 msgid "The username to use to connect to the proxy"
 msgstr "Proxy-ra konektatzeko erabiliko den erabiltzaile izena"
-
-#: src/muuli_wdr.cpp
-msgid "Password:"
-msgstr "Pasahitza:"
 
 #: src/muuli_wdr.cpp
 msgid "The password to use to connect to the proxy"
@@ -5598,6 +5510,15 @@ msgstr "ordu"
 #: src/OtherFunctions.cpp
 msgid "days"
 msgstr "egunak"
+
+#. TRANSLATORS:
+#. Punctuation for a "label: value" pair. %s is the already-translated
+#. label. Place the colon as your language requires -- e.g. "%s :" with a
+#. space in French, "%s:" without one in Russian and English.
+#: src/OtherFunctions.cpp
+#, c-format
+msgid "%s:"
+msgstr ""
 
 #: src/OtherFunctions.cpp
 msgid "all"
@@ -6641,8 +6562,7 @@ msgstr ""
 msgid "Confirm shared folders"
 msgstr "Partekatutako karpetak"
 
-#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp
-#: src/SharedFilesReloadProgress.cpp
+#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp src/SharedFilesReloadProgress.cpp
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "Berritu zure partekatutako fitxategiak"
@@ -6776,19 +6696,6 @@ msgstr "Huts GeoIP.dat deskargatzean"
 #: src/SearchListCtrl.cpp
 msgid "FileID"
 msgstr "FitxategiID"
-
-#: src/SearchListCtrl.cpp
-msgid "Length"
-msgstr ""
-
-#: src/SearchListCtrl.cpp
-#, fuzzy
-msgid "Bitrate"
-msgstr "Kalifikatu gabea"
-
-#: src/SearchListCtrl.cpp
-msgid "Codec"
-msgstr ""
 
 #: src/SearchListCtrl.cpp
 msgid "Expand all"
@@ -7073,10 +6980,6 @@ msgstr "Zerbitzari lokala IPIragazkiak iragazirik dago, beste zerbitzari batetar
 #: src/ServerListCtrl.cpp
 msgid "Server Name"
 msgstr "Zerbitzaria izena"
-
-#: src/ServerListCtrl.cpp
-msgid "Port"
-msgstr "Ataka"
 
 #: src/ServerListCtrl.cpp
 msgid "Description"
@@ -7371,6 +7274,10 @@ msgstr "Lagunera konektatzen"
 #, c-format
 msgid "Connected to buddy at %s"
 msgstr "Lagunera %s-en konektaturik"
+
+#: src/ServerWnd.cpp
+msgid "IP address:"
+msgstr "IP helbidea:"
 
 #: src/ServerWnd.cpp
 msgid "Indexed sources:"

--- a/po/fi.po
+++ b/po/fi.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-04 12:13+0200\n"
+"POT-Creation-Date: 2026-09-05 12:01+0200\n"
 "PO-Revision-Date: 2026-09-03 11:04+0000\n"
 "Last-Translator: Tapio Rantala <tapio.rantala@iki.fi>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -388,8 +388,7 @@ msgstr "web-palvelin käynnissä prosessinumerolla %d"
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Olet asettanut web-palvelimen ajettavaksi käynnistettäessä, mutta amuleweb-ohjelmaa ei voida ajaa. Ole hyvä ja asenna aMule web-palvelimen sisältävä paketti tai käännä aMule käyttäen parametria --enable-webserver ja suorita make install"
 
-#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
-#: src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
+#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
 msgid "ERROR"
 msgstr "VIRHE"
 
@@ -677,8 +676,7 @@ msgstr "Verkot"
 msgid "Searches"
 msgstr "Haut"
 
-#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/Statistics.cpp
+#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/Statistics.cpp
 msgid "Downloads"
 msgstr "Lataukset"
 
@@ -762,9 +760,7 @@ msgstr "Kad: Pois päältä"
 msgid "Core"
 msgstr ""
 
-#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#: src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp
-#: src/SourceListCtrl.cpp src/Statistics.cpp
+#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp src/Statistics.cpp
 msgid "Version"
 msgstr "Versio"
 
@@ -1063,11 +1059,7 @@ msgstr "Ei voida luoda kansiota '%s' luokalle '%s', pidän kansion '%s'."
 msgid "The remote core sent inconsistent data for \"%s\" (part status %d, expected %d). The file list may be showing the wrong information; reconnect to clear it."
 msgstr ""
 
-#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp
-#: src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp
-#: src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp
-#: src/Statistics.cpp
+#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp src/Statistics.cpp
 msgid "Unknown"
 msgstr "Tuntematon"
 
@@ -1164,8 +1156,7 @@ msgstr "Virhe tallennettaessa tiedostoa %s: %s"
 msgid "Enter Captcha"
 msgstr "Syötä kuvavarmennus"
 
-#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp
-#: src/TransferWnd.cpp
+#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp src/TransferWnd.cpp
 msgid "Category"
 msgstr "Luokittelu"
 
@@ -1329,13 +1320,11 @@ msgstr "Tiedostoa 'cryptkey.dat' ei löydetty, luodaan."
 msgid "Client Details"
 msgstr "Asiakkaan tiedot"
 
-#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
-#: src/utils/wxCas/src/onlinesig.cpp
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
 msgid "LowID"
 msgstr "LowID"
 
-#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
-#: src/utils/wxCas/src/onlinesig.cpp
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
 msgid "HighID"
 msgstr "HighID"
 
@@ -1351,8 +1340,7 @@ msgstr "Tuettu"
 msgid "Not supported"
 msgstr "Ei tuettu"
 
-#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
-#: src/TextClient.cpp
+#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp src/TextClient.cpp
 msgid "Connected"
 msgstr "Yhdistetty"
 
@@ -1360,28 +1348,24 @@ msgstr "Yhdistetty"
 msgid "Disconnected"
 msgstr "Yhteys katkaistu"
 
-#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp
-#: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f KiB/s"
 msgstr ""
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#, fuzzy
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/muuli_wdr.cpp
 msgid "Name"
-msgstr "Nimi:"
+msgstr "Nimi"
 
 #: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
 msgid "Software"
 msgstr ""
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#, fuzzy
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/muuli_wdr.cpp
 msgid "IP Address"
-msgstr "IP-osoite :"
+msgstr "IP-osoite"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Origin"
 msgstr "Alkuperä"
 
@@ -1399,13 +1383,11 @@ msgstr "Viimeisin vastaanotto"
 msgid "Sessions"
 msgstr "Versio"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp
 msgid "Upload Speed"
 msgstr "Lähetysnopeus"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp
 msgid "Download Speed"
 msgstr "Latausnopeus"
 
@@ -1460,13 +1442,11 @@ msgstr[1] ""
 msgid "Files"
 msgstr "Tiedostot"
 
-#: src/ClientsListCtrl.cpp src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp
-#: src/SourceListCtrl.cpp
+#: src/ClientsListCtrl.cpp src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Uploaded"
 msgstr "Lähetetty"
 
-#: src/ClientsListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientsListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Downloaded"
 msgstr "Ladattu"
 
@@ -1553,12 +1533,11 @@ msgstr "Käyttäjä %s (%u) on estänyt jaettujen kansioiden/tiedostojen listaam
 msgid "File Comments"
 msgstr "Tiedoston kommentit"
 
-#: src/CommentDialogLst.cpp src/FriendListCtrl.cpp
+#: src/CommentDialogLst.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
 msgid "Username"
 msgstr "Käyttäjänimi"
 
-#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp
-#: src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "File Name"
 msgstr "Tiedoston nimi"
 
@@ -1566,7 +1545,7 @@ msgstr "Tiedoston nimi"
 msgid "Rating"
 msgstr "Luokitus"
 
-#: src/CommentDialogLst.cpp
+#: src/CommentDialogLst.cpp src/muuli_wdr.cpp
 msgid "Comment"
 msgstr "Kommentti"
 
@@ -1620,18 +1599,15 @@ msgstr "Auto [Ko]"
 msgid "Very low"
 msgstr "Erittäin matala"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Low"
 msgstr "Matala"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Normal"
 msgstr "Normaali"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "High"
 msgstr "Korkea"
 
@@ -1655,13 +1631,11 @@ msgstr "Yhdistetään serverin kautta"
 msgid "Queue Full"
 msgstr "Jono täynnä"
 
-#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp
-#: src/muuli_wdr.cpp
+#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp src/muuli_wdr.cpp
 msgid "On Queue"
 msgstr "Jonossa"
 
-#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp
-#: src/PartFile.cpp src/TransferWnd.cpp
+#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Downloading"
 msgstr "Lataa"
 
@@ -1721,8 +1695,7 @@ msgstr "Paikallinen Palvelin"
 msgid "Remote Server"
 msgstr "Etäpalvelin"
 
-#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp
-#: src/TextClient.cpp
+#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp src/TextClient.cpp
 msgid "Kad"
 msgstr "Kad"
 
@@ -1746,8 +1719,7 @@ msgstr "Lähteitä"
 msgid "Search Result"
 msgstr "Haun tulos"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp
-#: src/TransferWnd.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Completed"
 msgstr "Valmiina"
 
@@ -1800,8 +1772,7 @@ msgstr ""
 msgid "Part"
 msgstr "Osa"
 
-#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp
-#: src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Size"
 msgstr "Koko"
 
@@ -1809,8 +1780,7 @@ msgstr "Koko"
 msgid "Transferred"
 msgstr "Siirretty"
 
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
-#: src/SourceListCtrl.cpp
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp src/SourceListCtrl.cpp
 msgid "Speed"
 msgstr "Nopeus"
 
@@ -1818,13 +1788,11 @@ msgstr "Nopeus"
 msgid "Progress"
 msgstr "Edistyminen"
 
-#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp
-#: src/SearchListCtrl.cpp
+#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
 msgid "Sources"
 msgstr "Lähteet"
 
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp
-#: src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Priority"
 msgstr "Tärkeys"
 
@@ -1848,9 +1816,7 @@ msgstr "Viimeisin vastaanotto"
 msgid "Auto"
 msgstr "Automaattinen"
 
-#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/TransferWnd.cpp
-#: src/utils/wxCas/src/wxcasprefs.cpp
+#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/TransferWnd.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Cancel"
 msgstr "Peruuta"
 
@@ -1951,8 +1917,7 @@ msgstr "Anna uusi nimi tälle tiedostolle:"
 msgid "File rename"
 msgstr "Tiedoston uudelleennimeäminen"
 
-#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp
-#: src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f MiB/s"
 msgstr ""
@@ -2757,13 +2722,11 @@ msgstr ""
 msgid "Start aMule automatically when I log in"
 msgstr ""
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
-#: packaging/windows/installer_strings.c
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp packaging/windows/installer_strings.c
 msgid "Register aMule for ed2k:// links"
 msgstr ""
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
-#: packaging/windows/installer_strings.c
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp packaging/windows/installer_strings.c
 msgid "Register aMule for magnet: links"
 msgstr ""
 
@@ -2789,8 +2752,7 @@ msgstr ""
 msgid "Destination folder for downloads"
 msgstr "Kansio ladatuille tiedostoille"
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
-#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Browse"
 msgstr "Selaa"
 
@@ -3233,18 +3195,15 @@ msgstr "Viimeistelee"
 msgid "Complete"
 msgstr "Valmis"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
-#: src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Paused"
 msgstr "Tauotettu"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
-#: src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Erroneous"
 msgstr "Virheellinen"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
-#: src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Waiting"
 msgstr "Odottaa"
 
@@ -3408,8 +3367,7 @@ msgstr "Sulje"
 msgid "Cut"
 msgstr "Leikkaa"
 
-#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp
-#: src/utils/aLinkCreator/src/alcframe.cpp
+#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy"
 msgstr "Kopioi"
 
@@ -3417,8 +3375,7 @@ msgstr "Kopioi"
 msgid "Paste"
 msgstr "Liitä"
 
-#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp
-#: src/utils/aLinkCreator/src/alcframe.cpp
+#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Clear"
 msgstr "Pyyhi"
 
@@ -3426,8 +3383,7 @@ msgstr "Pyyhi"
 msgid "Select All"
 msgstr "Valitse kaikki"
 
-#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
-#: src/StatisticsDlg.cpp
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp src/StatisticsDlg.cpp
 msgid "KiB/s"
 msgstr ""
 
@@ -3691,10 +3647,6 @@ msgstr "Palvelin johon yhdistetty."
 msgid "Search"
 msgstr "Etsi"
 
-#: src/muuli_wdr.cpp
-msgid "Name:"
-msgstr "Nimi:"
-
 #: src/muuli_wdr.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Type"
 msgstr "Tyyppi"
@@ -3784,8 +3736,8 @@ msgid "Availability"
 msgstr "Saatavuus"
 
 #: src/muuli_wdr.cpp
-msgid "Filter:"
-msgstr "Suodatin:"
+msgid "Filter"
+msgstr "Suodatin"
 
 #: src/muuli_wdr.cpp
 msgid "Invert Result"
@@ -3843,6 +3795,10 @@ msgid "Clears completed downloads"
 msgstr "Siivoaa valmistuneet lataukset pois näkyvistä"
 
 #: src/muuli_wdr.cpp
+msgid "Filter:"
+msgstr "Suodatin:"
+
+#: src/muuli_wdr.cpp
 msgid "File sources:"
 msgstr "Tiedostolähteet:"
 
@@ -3851,80 +3807,76 @@ msgid "General"
 msgstr "Yleiset"
 
 #: src/muuli_wdr.cpp
-msgid "Full Name :"
-msgstr "Koko nimi :"
+msgid "Full Name"
+msgstr "Koko nimi"
 
 #: src/muuli_wdr.cpp
-msgid "met-File :"
-msgstr "Osatiedosto (met) :"
+msgid "met-File"
+msgstr "Osatiedosto (met)"
 
 #: src/muuli_wdr.cpp
-msgid "Hash :"
-msgstr "Tarkiste :"
+msgid "Hash"
+msgstr "Tarkiste"
 
 #: src/muuli_wdr.cpp
-msgid "Filesize :"
-msgstr "Tiedostokoko :"
+msgid "Filesize"
+msgstr "Tiedostokoko"
 
 #: src/muuli_wdr.cpp src/Statistics.cpp
 msgid "Transfer"
 msgstr "Siirto"
 
 #: src/muuli_wdr.cpp
-msgid "Partfilestatus :"
-msgstr "Osatiedoston tila  :"
+msgid "Partfilestatus"
+msgstr "Osatiedoston tila"
 
 #: src/muuli_wdr.cpp
-msgid "Last seen complete :"
-msgstr "Viimeksi nähty kokonaisena :"
+msgid "Last seen complete"
+msgstr "Viimeksi nähty kokonaisena"
 
 #: src/muuli_wdr.cpp
-msgid "Found Sources :"
-msgstr "Löydetyt lähteet :"
+msgid "Found Sources"
+msgstr "Löydetyt lähteet"
 
 #: src/muuli_wdr.cpp
-msgid "Transferring Sources :"
-msgstr "Siirtäviä lähteitä :"
+msgid "Transferring Sources"
+msgstr "Siirtäviä lähteitä"
 
 #: src/muuli_wdr.cpp
-msgid "Filepart-Count :"
-msgstr "Osien määrä :"
+msgid "Filepart-Count"
+msgstr "Osien määrä"
 
 #: src/muuli_wdr.cpp
-msgid "Available :"
-msgstr "Saatavilla :"
+msgid "Available"
+msgstr "Saatavilla"
 
 #: src/muuli_wdr.cpp
-msgid "Datarate :"
-msgstr "Siirtonopeus :"
+msgid "Datarate"
+msgstr "Siirtonopeus"
 
 #: src/muuli_wdr.cpp
-msgid "Download Active Time: "
-msgstr "Lataus ollut aktiivisena: "
+msgid "Download Active Time"
+msgstr "Lataus ollut aktiivisena"
 
 #: src/muuli_wdr.cpp
-msgid "Transferred :"
-msgstr "Siirretty :"
-
-#: src/muuli_wdr.cpp
-msgid "Completed Size :"
-msgstr "Valmiina :"
+msgid "Completed Size"
+msgstr "Valmiina"
 
 #: src/muuli_wdr.cpp
 msgid "Intelligent Corruption Handling"
 msgstr "Älykäs turmeltumien käsittely (I.C.H.)"
 
 #: src/muuli_wdr.cpp
-msgid "Lost to corruption :"
-msgstr "Menetetty turmeltumille :"
+msgid "Lost to corruption"
+msgstr "Menetetty turmeltumille"
 
 #: src/muuli_wdr.cpp
-msgid "Gained by compression :"
-msgstr "Pakkaamalla saatu hyöty :"
+msgid "Gained by compression"
+msgstr "Pakkaamalla saatu hyöty"
 
 #: src/muuli_wdr.cpp
-msgid "Packages saved by I.C.H. :"
-msgstr "Pelastetut paketit (I.C.H.) :"
+msgid "Packages saved by I.C.H."
+msgstr "Pelastetut paketit (I.C.H.)"
 
 #: src/muuli_wdr.cpp
 #, fuzzy
@@ -3966,30 +3918,30 @@ msgstr ", Lähetetty: "
 msgid "Media Info"
 msgstr "Kad Info"
 
-#: src/muuli_wdr.cpp
-msgid "Length :"
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
+msgid "Length"
 msgstr ""
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
 #, fuzzy
-msgid "Bitrate :"
+msgid "Bitrate"
 msgstr "Ei luokitusta"
 
-#: src/muuli_wdr.cpp
-msgid "Codec :"
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
+msgid "Codec"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Artist :"
+msgid "Artist"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Album :"
+msgid "Album"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Title :"
-msgstr "Otsikko :"
+msgid "Title"
+msgstr "Otsikko"
 
 #: src/muuli_wdr.cpp
 msgid "File Names"
@@ -4076,25 +4028,17 @@ msgstr "Koko on tuntematon"
 msgid "Required Information"
 msgstr "Vaadittavat tiedot"
 
-#: src/muuli_wdr.cpp
-msgid "IP Address :"
-msgstr "IP-osoite :"
-
-#: src/muuli_wdr.cpp
-msgid "Port :"
-msgstr "Portti :"
+#: src/muuli_wdr.cpp src/ServerListCtrl.cpp
+msgid "Port"
+msgstr "Portti"
 
 #: src/muuli_wdr.cpp
 msgid "Additional Information"
 msgstr "Lisätiedot"
 
 #: src/muuli_wdr.cpp
-msgid "Username :"
-msgstr "Käyttäjänimi :"
-
-#: src/muuli_wdr.cpp
-msgid "Userhash :"
-msgstr "Käyttäjätarkiste :"
+msgid "Userhash"
+msgstr "Käyttäjätarkiste"
 
 #: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Add"
@@ -4129,96 +4073,80 @@ msgid "Statistics Tree"
 msgstr "Tilastopuu"
 
 #: src/muuli_wdr.cpp
-msgid "Username:"
-msgstr "Käyttäjänimi:"
+msgid "Client software"
+msgstr "Asiakasohjelma"
 
 #: src/muuli_wdr.cpp
-msgid "Userhash:"
-msgstr "Käyttäjätarkiste:"
+msgid "Client version"
+msgstr "Asiakasversio"
 
 #: src/muuli_wdr.cpp
-msgid "Client software:"
-msgstr "Asiakasohjelma:"
+msgid "User ID"
+msgstr "Käyttäjätunniste"
 
 #: src/muuli_wdr.cpp
-msgid "Client version:"
-msgstr "Asiakasversio:"
-
-#: src/muuli_wdr.cpp src/ServerWnd.cpp
-msgid "IP address:"
-msgstr "IP-osoite:"
+msgid "Server IP"
+msgstr "Palvelimen IP"
 
 #: src/muuli_wdr.cpp
-msgid "User ID:"
-msgstr "Käyttäjätunniste:"
+msgid "Server name"
+msgstr "Palvelimen nimi"
 
 #: src/muuli_wdr.cpp
-msgid "Server IP:"
-msgstr "Palvelimen IP:"
-
-#: src/muuli_wdr.cpp
-msgid "Server name:"
-msgstr "Palvelimen nimi:"
-
-#: src/muuli_wdr.cpp
-msgid "Obfuscation:"
-msgstr "Kätkeminen:"
-
-#: src/muuli_wdr.cpp
-msgid "Kad:"
-msgstr "Kad:"
+msgid "Obfuscation"
+msgstr "Kätkeminen"
 
 #: src/muuli_wdr.cpp
 msgid "Transfers to client"
 msgstr "Siirrot asiakkaalle"
 
 #: src/muuli_wdr.cpp
-msgid "Current request:"
-msgstr "Nykyinen pyyntö:"
+msgid "Current request"
+msgstr "Nykyinen pyyntö"
 
 #: src/muuli_wdr.cpp
-msgid "Average upload rate:"
-msgstr "Keskimääräinen lähetysnopeus:"
+msgid "Average upload rate"
+msgstr "Keskimääräinen lähetysnopeus"
 
 #: src/muuli_wdr.cpp
-msgid "Average download rate:"
-msgstr "Keskimääräinen latausnopeus:"
+msgid "Average download rate"
+msgstr "Keskimääräinen latausnopeus"
 
 #: src/muuli_wdr.cpp
-msgid "Uploaded (session):"
-msgstr "Lähetetty (sessiossa):"
+msgid "Uploaded (session)"
+msgstr "Lähetetty (sessiossa)"
 
 #: src/muuli_wdr.cpp
-msgid "Downloaded (session):"
-msgstr "Ladattu (sessiossa):"
+msgid "Downloaded (session)"
+msgstr "Ladattu (sessiossa)"
 
 #: src/muuli_wdr.cpp
-msgid "Uploaded (total):"
-msgstr "Lähetetty (yhteensä):"
+msgid "Uploaded (total)"
+msgstr "Lähetetty (yhteensä)"
 
 #: src/muuli_wdr.cpp
-msgid "Downloaded (total):"
-msgstr "Ladattu (yhteensä):"
+msgid "Downloaded (total)"
+msgstr "Ladattu (yhteensä)"
 
 #: src/muuli_wdr.cpp
 msgid "Scores"
 msgstr "Pisteet"
 
 #: src/muuli_wdr.cpp
-msgid "DL/UP modifier:"
-msgstr "Lähetys/vastaanotto-määre:"
+msgid "DL/UP modifier"
+msgstr "Lähetys/vastaanotto-määre"
 
 #: src/muuli_wdr.cpp
-msgid "Secure ident:"
-msgstr "Turvattu tunnistus:"
+msgid "Secure ident"
+msgstr "Turvattu tunnistus"
 
 #: src/muuli_wdr.cpp
-msgid "Queue rank:"
-msgstr "Sijoitus jonossa:"
+msgid "Queue rank"
+msgstr "Sijoitus jonossa"
 
 #: src/muuli_wdr.cpp
-msgid "Queue score:"
-msgstr "Jonopisteet:"
+msgid "Queue score"
+msgstr "Jonopisteet"
 
 #: src/muuli_wdr.cpp
 msgid "Nick"
@@ -5013,24 +4941,20 @@ msgid "Reset any changes made to the preferences."
 msgstr "Nollaa asetuksiin tekemäsi muutokset."
 
 #: src/muuli_wdr.cpp
-msgid "Comment :"
-msgstr "Kommentti :"
+msgid "Incoming Dir"
+msgstr "Saapuvien kansio"
 
 #: src/muuli_wdr.cpp
-msgid "Incoming Dir :"
-msgstr "Saapuvien kansio :"
-
-#: src/muuli_wdr.cpp
-msgid "Change priority for new assigned files :"
-msgstr "Vaihda tärkeyttä uusille sijoitetuille tiedostoille :"
+msgid "Change priority for new assigned files"
+msgstr "Vaihda tärkeyttä uusille sijoitetuille tiedostoille"
 
 #: src/muuli_wdr.cpp
 msgid "Don't change"
 msgstr "Älä vaihda"
 
 #: src/muuli_wdr.cpp
-msgid "Select color for this Category (currently selected) :"
-msgstr "Valitse väri tälle luokalle (valittuna) :"
+msgid "Select color for this Category (currently selected)"
+msgstr "Valitse väri tälle luokalle (valittuna)"
 
 #: src/muuli_wdr.cpp
 msgid "Click this button to reset the log."
@@ -5113,10 +5037,6 @@ msgstr "Käytä tunnettuja asiakkaita yhdistämisapuna"
 #, fuzzy
 msgid "Enter the IP of the node here, using the x.x.x.x format."
 msgstr "Syötä uuden palvelimen IP tähän, muodossa x.x.x.x."
-
-#: src/muuli_wdr.cpp
-msgid "Port:"
-msgstr "Portti:"
 
 #: src/muuli_wdr.cpp
 msgid "Use Secure User Identification"
@@ -5385,20 +5305,20 @@ msgid "Enable/disable proxy support"
 msgstr "Kytke päälle/pois välityspalvelimen tuki"
 
 #: src/muuli_wdr.cpp
-msgid "Proxy type:"
-msgstr "Tyyppi:"
+msgid "Proxy type"
+msgstr "Tyyppi"
 
 #: src/muuli_wdr.cpp
-msgid "Proxy host:"
-msgstr "Välityspalvelin:"
+msgid "Proxy host"
+msgstr "Välityspalvelin"
 
 #: src/muuli_wdr.cpp
 msgid "The proxy host name"
 msgstr "Välityspalvelimen verkkonimi"
 
 #: src/muuli_wdr.cpp
-msgid "Proxy port:"
-msgstr "Portti:"
+msgid "Proxy port"
+msgstr "Portti"
 
 #: src/muuli_wdr.cpp
 msgid "The proxy port"
@@ -5413,16 +5333,8 @@ msgid "Enable/disable username/password authentication"
 msgstr "Kytkee päälle/pois käyttäjänimellä/salasanalla tunnistautumisen"
 
 #: src/muuli_wdr.cpp
-msgid "Username: "
-msgstr "Käyttäjänimi: "
-
-#: src/muuli_wdr.cpp
 msgid "The username to use to connect to the proxy"
 msgstr "Käyttäjänimi tunnistautuessa välityspalvelimelle"
-
-#: src/muuli_wdr.cpp
-msgid "Password:"
-msgstr "Salasana:"
 
 #: src/muuli_wdr.cpp
 msgid "The password to use to connect to the proxy"
@@ -5598,6 +5510,15 @@ msgstr "tuntia"
 #: src/OtherFunctions.cpp
 msgid "days"
 msgstr "päivää"
+
+#. TRANSLATORS:
+#. Punctuation for a "label: value" pair. %s is the already-translated
+#. label. Place the colon as your language requires -- e.g. "%s :" with a
+#. space in French, "%s:" without one in Russian and English.
+#: src/OtherFunctions.cpp
+#, c-format
+msgid "%s:"
+msgstr ""
 
 #: src/OtherFunctions.cpp
 msgid "all"
@@ -6641,8 +6562,7 @@ msgstr ""
 msgid "Confirm shared folders"
 msgstr "Jaetut kansiot"
 
-#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp
-#: src/SharedFilesReloadProgress.cpp
+#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp src/SharedFilesReloadProgress.cpp
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "Uudelleenlataa jaetut tiedostot"
@@ -6776,19 +6696,6 @@ msgstr "Virhe päivitettäessä GeoIP.dat-tiedostoa"
 #: src/SearchListCtrl.cpp
 msgid "FileID"
 msgstr "Tiedostotunniste"
-
-#: src/SearchListCtrl.cpp
-msgid "Length"
-msgstr ""
-
-#: src/SearchListCtrl.cpp
-#, fuzzy
-msgid "Bitrate"
-msgstr "Ei luokitusta"
-
-#: src/SearchListCtrl.cpp
-msgid "Codec"
-msgstr ""
 
 #: src/SearchListCtrl.cpp
 msgid "Expand all"
@@ -7073,10 +6980,6 @@ msgstr "Paikallinen palvelin IP-suodatetaan, yhdistän toiselle palvelimelle!"
 #: src/ServerListCtrl.cpp
 msgid "Server Name"
 msgstr "Palvelimen nimi"
-
-#: src/ServerListCtrl.cpp
-msgid "Port"
-msgstr "Portti"
 
 #: src/ServerListCtrl.cpp
 msgid "Description"
@@ -7371,6 +7274,10 @@ msgstr "Yhdistetään kaveriin"
 #, c-format
 msgid "Connected to buddy at %s"
 msgstr "Yhdistetty kaveriin osoitteessa %s"
+
+#: src/ServerWnd.cpp
+msgid "IP address:"
+msgstr "IP-osoite:"
 
 #: src/ServerWnd.cpp
 msgid "Indexed sources:"

--- a/po/fr.po
+++ b/po/fr.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-04 12:13+0200\n"
+"POT-Creation-Date: 2026-09-05 12:01+0200\n"
 "PO-Revision-Date: 2026-09-03 11:04+0000\n"
 "Last-Translator: Dylan Aïssi <bob.dybian@gmail.com>\n"
 "Language-Team: Français\n"
@@ -392,8 +392,7 @@ msgstr "serveur web s'exécutant avec le pid %d"
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Vous avez demandé à exécuter le serveur web au démarrage, mais le binaire amuleweb ne peut être exécuté. Veuillez installer le paquet contenant le serveur web aMule, ou compilez aMule depuis le code source avec -DBUILD_WEBSERVER=YES et installez-le."
 
-#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
-#: src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
+#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
 msgid "ERROR"
 msgstr "ERREUR"
 
@@ -679,8 +678,7 @@ msgstr "Réseaux"
 msgid "Searches"
 msgstr "Recherches"
 
-#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/Statistics.cpp
+#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/Statistics.cpp
 msgid "Downloads"
 msgstr "Téléchargements"
 
@@ -768,9 +766,7 @@ msgstr "Kad : Coupé"
 msgid "Core"
 msgstr "Noyau"
 
-#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#: src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp
-#: src/SourceListCtrl.cpp src/Statistics.cpp
+#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp src/Statistics.cpp
 msgid "Version"
 msgstr "Version"
 
@@ -1067,11 +1063,7 @@ msgstr "Impossible de créer le répertoire '%s' pour la catégorie '%s', on gar
 msgid "The remote core sent inconsistent data for \"%s\" (part status %d, expected %d). The file list may be showing the wrong information; reconnect to clear it."
 msgstr "Le serveur distant a envoyé des données incohérentes pour « %s » (état de la partie : %d, valeur attendue : %d). La liste des fichiers peut afficher des informations incorrectes ; reconnectez-vous pour les corriger."
 
-#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp
-#: src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp
-#: src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp
-#: src/Statistics.cpp
+#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp src/Statistics.cpp
 msgid "Unknown"
 msgstr "Inconnu"
 
@@ -1168,8 +1160,7 @@ msgstr "Erreur lors de la sauvegarde du fichier %s : %s"
 msgid "Enter Captcha"
 msgstr "Entrer le Captcha"
 
-#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp
-#: src/TransferWnd.cpp
+#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp src/TransferWnd.cpp
 msgid "Category"
 msgstr "Catégorie"
 
@@ -1332,13 +1323,11 @@ msgstr "Pas de fichier 'cryptkey.dat' trouvé, création."
 msgid "Client Details"
 msgstr "Détails du client"
 
-#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
-#: src/utils/wxCas/src/onlinesig.cpp
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
 msgid "LowID"
 msgstr "LowID"
 
-#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
-#: src/utils/wxCas/src/onlinesig.cpp
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
 msgid "HighID"
 msgstr "HighID"
 
@@ -1354,8 +1343,7 @@ msgstr "Supporté"
 msgid "Not supported"
 msgstr "Non supporté"
 
-#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
-#: src/TextClient.cpp
+#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp src/TextClient.cpp
 msgid "Connected"
 msgstr "Connecté"
 
@@ -1363,13 +1351,12 @@ msgstr "Connecté"
 msgid "Disconnected"
 msgstr "Déconnecté"
 
-#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp
-#: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f KiB/s"
 msgstr "%.1f Kio/s"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/muuli_wdr.cpp
 msgid "Name"
 msgstr "Nom"
 
@@ -1377,12 +1364,11 @@ msgstr "Nom"
 msgid "Software"
 msgstr "Logiciel"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/muuli_wdr.cpp
 msgid "IP Address"
 msgstr "Adresse IP"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Origin"
 msgstr "Origine"
 
@@ -1398,13 +1384,11 @@ msgstr "Vu pour la dernière fois"
 msgid "Sessions"
 msgstr "Sessions"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp
 msgid "Upload Speed"
 msgstr "Vitesse d'Émission"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp
 msgid "Download Speed"
 msgstr "Vitesse de Réception"
 
@@ -1455,13 +1439,11 @@ msgstr[1] "Impossible d'ajouter %u liens (cf. le journal pour les détails)."
 msgid "Files"
 msgstr "Fichiers"
 
-#: src/ClientsListCtrl.cpp src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp
-#: src/SourceListCtrl.cpp
+#: src/ClientsListCtrl.cpp src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Uploaded"
 msgstr "Émis"
 
-#: src/ClientsListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientsListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Downloaded"
 msgstr "Téléchargé"
 
@@ -1545,12 +1527,11 @@ msgstr "L'utilisateur %s (%u) a refusé l'accès à la liste des répertoires/fi
 msgid "File Comments"
 msgstr "Commentaires sur le fichier"
 
-#: src/CommentDialogLst.cpp src/FriendListCtrl.cpp
+#: src/CommentDialogLst.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
 msgid "Username"
 msgstr "Nom d'utilisateur"
 
-#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp
-#: src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "File Name"
 msgstr "Nom du fichier"
 
@@ -1558,7 +1539,7 @@ msgstr "Nom du fichier"
 msgid "Rating"
 msgstr "Évaluation"
 
-#: src/CommentDialogLst.cpp
+#: src/CommentDialogLst.cpp src/muuli_wdr.cpp
 msgid "Comment"
 msgstr "Commentaire"
 
@@ -1611,18 +1592,15 @@ msgstr "Auto [Haute]"
 msgid "Very low"
 msgstr "Très basse"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Low"
 msgstr "Basse"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Normal"
 msgstr "Normale"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "High"
 msgstr "Haute"
 
@@ -1646,13 +1624,11 @@ msgstr "Connexion via le serveur"
 msgid "Queue Full"
 msgstr "File d'attente pleine"
 
-#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp
-#: src/muuli_wdr.cpp
+#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp src/muuli_wdr.cpp
 msgid "On Queue"
 msgstr "En attente"
 
-#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp
-#: src/PartFile.cpp src/TransferWnd.cpp
+#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Downloading"
 msgstr "En téléchargement"
 
@@ -1712,8 +1688,7 @@ msgstr "Serveur Local"
 msgid "Remote Server"
 msgstr "Serveur Distant"
 
-#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp
-#: src/TextClient.cpp
+#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp src/TextClient.cpp
 msgid "Kad"
 msgstr "Kad"
 
@@ -1737,8 +1712,7 @@ msgstr "Source Seeds"
 msgid "Search Result"
 msgstr "Résultat de la recherche"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp
-#: src/TransferWnd.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Completed"
 msgstr "Terminé"
 
@@ -1790,8 +1764,7 @@ msgstr "Impossible de modifier un élément à l’intérieur d’un partage ré
 msgid "Part"
 msgstr "Partie"
 
-#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp
-#: src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Size"
 msgstr "Taille"
 
@@ -1799,8 +1772,7 @@ msgstr "Taille"
 msgid "Transferred"
 msgstr "Reçu"
 
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
-#: src/SourceListCtrl.cpp
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp src/SourceListCtrl.cpp
 msgid "Speed"
 msgstr "Vitesse"
 
@@ -1808,13 +1780,11 @@ msgstr "Vitesse"
 msgid "Progress"
 msgstr "Progression"
 
-#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp
-#: src/SearchListCtrl.cpp
+#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
 msgid "Sources"
 msgstr "Sources"
 
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp
-#: src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Priority"
 msgstr "Priorité"
 
@@ -1838,9 +1808,7 @@ msgstr "Dernière réception"
 msgid "Auto"
 msgstr "Auto"
 
-#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/TransferWnd.cpp
-#: src/utils/wxCas/src/wxcasprefs.cpp
+#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/TransferWnd.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Cancel"
 msgstr "Annuler"
 
@@ -1941,8 +1909,7 @@ msgstr "Entrez un nouveau nom pour ce fichier :"
 msgid "File rename"
 msgstr "Renommer"
 
-#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp
-#: src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f MiB/s"
 msgstr "%.1f Mio/s"
@@ -2745,13 +2712,11 @@ msgstr ""
 msgid "Start aMule automatically when I log in"
 msgstr "Lancer aMule automatiquement lorsque j'ouvre une session"
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
-#: packaging/windows/installer_strings.c
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp packaging/windows/installer_strings.c
 msgid "Register aMule for ed2k:// links"
 msgstr "Enregistrer aMule pour les liens ed2k://"
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
-#: packaging/windows/installer_strings.c
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp packaging/windows/installer_strings.c
 msgid "Register aMule for magnet: links"
 msgstr "Enregistrer aMule pour les liens magnet:"
 
@@ -2779,8 +2744,7 @@ msgstr ""
 msgid "Destination folder for downloads"
 msgstr "Dossier de destination des téléchargements"
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
-#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Browse"
 msgstr "Parcourir"
 
@@ -3224,18 +3188,15 @@ msgstr "Finalisation"
 msgid "Complete"
 msgstr "Terminé"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
-#: src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Paused"
 msgstr "En pause"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
-#: src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Erroneous"
 msgstr "Erroné"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
-#: src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Waiting"
 msgstr "En attente"
 
@@ -3397,8 +3358,7 @@ msgstr "Fermer"
 msgid "Cut"
 msgstr "Couper"
 
-#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp
-#: src/utils/aLinkCreator/src/alcframe.cpp
+#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy"
 msgstr "Copier"
 
@@ -3406,8 +3366,7 @@ msgstr "Copier"
 msgid "Paste"
 msgstr "Coller"
 
-#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp
-#: src/utils/aLinkCreator/src/alcframe.cpp
+#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Clear"
 msgstr "Effacer"
 
@@ -3415,8 +3374,7 @@ msgstr "Effacer"
 msgid "Select All"
 msgstr "Tout sélectionner"
 
-#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
-#: src/StatisticsDlg.cpp
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp src/StatisticsDlg.cpp
 msgid "KiB/s"
 msgstr "Kio/s"
 
@@ -3671,10 +3629,6 @@ msgstr "Serveur connecté."
 msgid "Search"
 msgstr "Rechercher"
 
-#: src/muuli_wdr.cpp
-msgid "Name:"
-msgstr "Nom :"
-
 #: src/muuli_wdr.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Type"
 msgstr "Type"
@@ -3764,8 +3718,8 @@ msgid "Availability"
 msgstr "Disponibilité"
 
 #: src/muuli_wdr.cpp
-msgid "Filter:"
-msgstr "Filtre :"
+msgid "Filter"
+msgstr "Filtre"
 
 #: src/muuli_wdr.cpp
 msgid "Invert Result"
@@ -3820,6 +3774,10 @@ msgid "Clears completed downloads"
 msgstr "Effacer les téléchargements terminés"
 
 #: src/muuli_wdr.cpp
+msgid "Filter:"
+msgstr "Filtre :"
+
+#: src/muuli_wdr.cpp
 msgid "File sources:"
 msgstr "Sources du fichier :"
 
@@ -3828,80 +3786,76 @@ msgid "General"
 msgstr "Général"
 
 #: src/muuli_wdr.cpp
-msgid "Full Name :"
-msgstr "Nom complet :"
+msgid "Full Name"
+msgstr "Nom complet"
 
 #: src/muuli_wdr.cpp
-msgid "met-File :"
-msgstr "Fichier .met :"
+msgid "met-File"
+msgstr "Fichier .met"
 
 #: src/muuli_wdr.cpp
-msgid "Hash :"
-msgstr "Hachage :"
+msgid "Hash"
+msgstr "Hachage"
 
 #: src/muuli_wdr.cpp
-msgid "Filesize :"
-msgstr "Taille du fichier :"
+msgid "Filesize"
+msgstr "Taille du fichier"
 
 #: src/muuli_wdr.cpp src/Statistics.cpp
 msgid "Transfer"
 msgstr "Transfert"
 
 #: src/muuli_wdr.cpp
-msgid "Partfilestatus :"
-msgstr "Statut du fichier .part :"
+msgid "Partfilestatus"
+msgstr "Statut du fichier .part"
 
 #: src/muuli_wdr.cpp
-msgid "Last seen complete :"
-msgstr "Vu complet pour la dernière fois :"
+msgid "Last seen complete"
+msgstr "Vu complet pour la dernière fois"
 
 #: src/muuli_wdr.cpp
-msgid "Found Sources :"
-msgstr "Sources trouvées :"
+msgid "Found Sources"
+msgstr "Sources trouvées"
 
 #: src/muuli_wdr.cpp
-msgid "Transferring Sources :"
-msgstr "Sources en transfert :"
+msgid "Transferring Sources"
+msgstr "Sources en transfert"
 
 #: src/muuli_wdr.cpp
-msgid "Filepart-Count :"
-msgstr "Nombre de fichiers .part :"
+msgid "Filepart-Count"
+msgstr "Nombre de fichiers .part"
 
 #: src/muuli_wdr.cpp
-msgid "Available :"
-msgstr "Disponibles :"
+msgid "Available"
+msgstr "Disponibles"
 
 #: src/muuli_wdr.cpp
-msgid "Datarate :"
-msgstr "Taux de transfert :"
+msgid "Datarate"
+msgstr "Taux de transfert"
 
 #: src/muuli_wdr.cpp
-msgid "Download Active Time: "
-msgstr "Temps de téléchargement actif : "
+msgid "Download Active Time"
+msgstr "Temps de téléchargement actif"
 
 #: src/muuli_wdr.cpp
-msgid "Transferred :"
-msgstr "Transféré :"
-
-#: src/muuli_wdr.cpp
-msgid "Completed Size :"
-msgstr "Taille reçue :"
+msgid "Completed Size"
+msgstr "Taille reçue"
 
 #: src/muuli_wdr.cpp
 msgid "Intelligent Corruption Handling"
 msgstr "Gestion Intelligente de la Corruption (I.C.H.)"
 
 #: src/muuli_wdr.cpp
-msgid "Lost to corruption :"
-msgstr "Perdus par corruption :"
+msgid "Lost to corruption"
+msgstr "Perdus par corruption"
 
 #: src/muuli_wdr.cpp
-msgid "Gained by compression :"
-msgstr "Gagné avec la compression :"
+msgid "Gained by compression"
+msgstr "Gagné avec la compression"
 
 #: src/muuli_wdr.cpp
-msgid "Packages saved by I.C.H. :"
-msgstr "Paquets sauvés par l'I.C.H :"
+msgid "Packages saved by I.C.H."
+msgstr "Paquets sauvés par l'I.C.H"
 
 #: src/muuli_wdr.cpp
 msgid "Sharing"
@@ -3939,29 +3893,29 @@ msgstr "Dernier téléversement"
 msgid "Media Info"
 msgstr "Infos média"
 
-#: src/muuli_wdr.cpp
-msgid "Length :"
-msgstr "Durée :"
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
+msgid "Length"
+msgstr "Durée"
+
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
+msgid "Bitrate"
+msgstr "Débit binaire"
+
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
+msgid "Codec"
+msgstr "Codec"
 
 #: src/muuli_wdr.cpp
-msgid "Bitrate :"
-msgstr "Débit binaire :"
+msgid "Artist"
+msgstr "Artiste"
 
 #: src/muuli_wdr.cpp
-msgid "Codec :"
-msgstr "Codec :"
+msgid "Album"
+msgstr "Album"
 
 #: src/muuli_wdr.cpp
-msgid "Artist :"
-msgstr "Artiste :"
-
-#: src/muuli_wdr.cpp
-msgid "Album :"
-msgstr "Album :"
-
-#: src/muuli_wdr.cpp
-msgid "Title :"
-msgstr "Titre :"
+msgid "Title"
+msgstr "Titre"
 
 #: src/muuli_wdr.cpp
 msgid "File Names"
@@ -4047,25 +4001,17 @@ msgstr "Taille inconnue"
 msgid "Required Information"
 msgstr "Informations Requises"
 
-#: src/muuli_wdr.cpp
-msgid "IP Address :"
-msgstr "Adresse IP :"
-
-#: src/muuli_wdr.cpp
-msgid "Port :"
-msgstr "Port :"
+#: src/muuli_wdr.cpp src/ServerListCtrl.cpp
+msgid "Port"
+msgstr "Port"
 
 #: src/muuli_wdr.cpp
 msgid "Additional Information"
 msgstr "Renseignements complémentaires"
 
 #: src/muuli_wdr.cpp
-msgid "Username :"
-msgstr "Nom d'utilisateur :"
-
-#: src/muuli_wdr.cpp
-msgid "Userhash :"
-msgstr "Hachage de l'utilisateur :"
+msgid "Userhash"
+msgstr "Hachage de l'utilisateur"
 
 #: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Add"
@@ -4100,96 +4046,80 @@ msgid "Statistics Tree"
 msgstr "Statistiques"
 
 #: src/muuli_wdr.cpp
-msgid "Username:"
-msgstr "Nom d'utilisateur :"
+msgid "Client software"
+msgstr "Logiciel client"
 
 #: src/muuli_wdr.cpp
-msgid "Userhash:"
-msgstr "Hachage de l'utilisateur :"
+msgid "Client version"
+msgstr "Version du client"
 
 #: src/muuli_wdr.cpp
-msgid "Client software:"
-msgstr "Logiciel client :"
+msgid "User ID"
+msgstr "ID Utilisateur"
 
 #: src/muuli_wdr.cpp
-msgid "Client version:"
-msgstr "Version du client :"
-
-#: src/muuli_wdr.cpp src/ServerWnd.cpp
-msgid "IP address:"
-msgstr "Adresse IP :"
+msgid "Server IP"
+msgstr "IP du serveur"
 
 #: src/muuli_wdr.cpp
-msgid "User ID:"
-msgstr "ID Utilisateur :"
+msgid "Server name"
+msgstr "Nom du serveur"
 
 #: src/muuli_wdr.cpp
-msgid "Server IP:"
-msgstr "IP du serveur :"
-
-#: src/muuli_wdr.cpp
-msgid "Server name:"
-msgstr "Nom du serveur :"
-
-#: src/muuli_wdr.cpp
-msgid "Obfuscation:"
-msgstr "Brouillage :"
-
-#: src/muuli_wdr.cpp
-msgid "Kad:"
-msgstr "Kad :"
+msgid "Obfuscation"
+msgstr "Brouillage"
 
 #: src/muuli_wdr.cpp
 msgid "Transfers to client"
 msgstr "Transferts avec le client"
 
 #: src/muuli_wdr.cpp
-msgid "Current request:"
-msgstr "Requête actuelle :"
+msgid "Current request"
+msgstr "Requête actuelle"
 
 #: src/muuli_wdr.cpp
-msgid "Average upload rate:"
-msgstr "Vitesse moyenne d'émission :"
+msgid "Average upload rate"
+msgstr "Vitesse moyenne d'émission"
 
 #: src/muuli_wdr.cpp
-msgid "Average download rate:"
-msgstr "Vitesse moyenne de réception :"
+msgid "Average download rate"
+msgstr "Vitesse moyenne de réception"
 
 #: src/muuli_wdr.cpp
-msgid "Uploaded (session):"
-msgstr "Envoyé (session) :"
+msgid "Uploaded (session)"
+msgstr "Envoyé (session)"
 
 #: src/muuli_wdr.cpp
-msgid "Downloaded (session):"
-msgstr "Reçu (session) :"
+msgid "Downloaded (session)"
+msgstr "Reçu (session)"
 
 #: src/muuli_wdr.cpp
-msgid "Uploaded (total):"
-msgstr "Envoyé (total) :"
+msgid "Uploaded (total)"
+msgstr "Envoyé (total)"
 
 #: src/muuli_wdr.cpp
-msgid "Downloaded (total):"
-msgstr "Reçu (total) :"
+msgid "Downloaded (total)"
+msgstr "Reçu (total)"
 
 #: src/muuli_wdr.cpp
 msgid "Scores"
 msgstr "Scores"
 
 #: src/muuli_wdr.cpp
-msgid "DL/UP modifier:"
-msgstr "Modificateur R/E :"
+msgid "DL/UP modifier"
+msgstr "Modificateur R/E"
 
 #: src/muuli_wdr.cpp
-msgid "Secure ident:"
-msgstr "Identification sécurisée :"
+msgid "Secure ident"
+msgstr "Identification sécurisée"
 
 #: src/muuli_wdr.cpp
-msgid "Queue rank:"
-msgstr "Rang dans la file d'attente :"
+msgid "Queue rank"
+msgstr "Rang dans la file d'attente"
 
 #: src/muuli_wdr.cpp
-msgid "Queue score:"
-msgstr "Score de la file d'attente :"
+msgid "Queue score"
+msgstr "Score de la file d'attente"
 
 #: src/muuli_wdr.cpp
 msgid "Nick"
@@ -4968,24 +4898,20 @@ msgid "Reset any changes made to the preferences."
 msgstr "Annule tous les changements effectués dans les Préférences."
 
 #: src/muuli_wdr.cpp
-msgid "Comment :"
-msgstr "Commentaire :"
+msgid "Incoming Dir"
+msgstr "Répertoire entrant"
 
 #: src/muuli_wdr.cpp
-msgid "Incoming Dir :"
-msgstr "Répertoire entrant :"
-
-#: src/muuli_wdr.cpp
-msgid "Change priority for new assigned files :"
-msgstr "Changer la priorité des nouveaux fichiers assignés :"
+msgid "Change priority for new assigned files"
+msgstr "Changer la priorité des nouveaux fichiers assignés"
 
 #: src/muuli_wdr.cpp
 msgid "Don't change"
 msgstr "Ne rien changer"
 
 #: src/muuli_wdr.cpp
-msgid "Select color for this Category (currently selected) :"
-msgstr "Choisir la couleur pour cette Catégorie (actuellement sélectionnée) :"
+msgid "Select color for this Category (currently selected)"
+msgstr "Choisir la couleur pour cette Catégorie (actuellement sélectionnée)"
 
 #: src/muuli_wdr.cpp
 msgid "Click this button to reset the log."
@@ -5066,10 +4992,6 @@ msgstr "Amorçage depuis le nœud : IP"
 #: src/muuli_wdr.cpp
 msgid "Enter the IP of the node here, using the x.x.x.x format."
 msgstr "Entrer ici l'adresse IP du nœud, avec le format x.x.x.x."
-
-#: src/muuli_wdr.cpp
-msgid "Port:"
-msgstr "Port :"
 
 #: src/muuli_wdr.cpp
 msgid "Use Secure User Identification"
@@ -5346,20 +5268,20 @@ msgid "Enable/disable proxy support"
 msgstr "Active/Désactive le support proxy"
 
 #: src/muuli_wdr.cpp
-msgid "Proxy type:"
-msgstr "Type de proxy :"
+msgid "Proxy type"
+msgstr "Type de proxy"
 
 #: src/muuli_wdr.cpp
-msgid "Proxy host:"
-msgstr "Hôte du proxy :"
+msgid "Proxy host"
+msgstr "Hôte du proxy"
 
 #: src/muuli_wdr.cpp
 msgid "The proxy host name"
 msgstr "Nom de l'hôte du proxy"
 
 #: src/muuli_wdr.cpp
-msgid "Proxy port:"
-msgstr "Port du proxy :"
+msgid "Proxy port"
+msgstr "Port du proxy"
 
 #: src/muuli_wdr.cpp
 msgid "The proxy port"
@@ -5374,16 +5296,8 @@ msgid "Enable/disable username/password authentication"
 msgstr "Active/Désactive l'authentification par nom d'utilisateur/mot de passe"
 
 #: src/muuli_wdr.cpp
-msgid "Username: "
-msgstr "Nom d'utilisateur : "
-
-#: src/muuli_wdr.cpp
 msgid "The username to use to connect to the proxy"
 msgstr "Nom d'utilisateur pour se connecter au proxy"
-
-#: src/muuli_wdr.cpp
-msgid "Password:"
-msgstr "Mot de passe :"
 
 #: src/muuli_wdr.cpp
 msgid "The password to use to connect to the proxy"
@@ -5556,6 +5470,15 @@ msgstr "heures"
 #: src/OtherFunctions.cpp
 msgid "days"
 msgstr "jours"
+
+#. TRANSLATORS:
+#. Punctuation for a "label: value" pair. %s is the already-translated
+#. label. Place the colon as your language requires -- e.g. "%s :" with a
+#. space in French, "%s:" without one in Russian and English.
+#: src/OtherFunctions.cpp
+#, c-format
+msgid "%s:"
+msgstr ""
 
 #: src/OtherFunctions.cpp
 msgid "all"
@@ -6586,8 +6509,7 @@ msgstr "Les partager récursivement publiera chaque fichier contenu dans les sou
 msgid "Confirm shared folders"
 msgstr "Confirmer les dossiers partagés"
 
-#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp
-#: src/SharedFilesReloadProgress.cpp
+#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp src/SharedFilesReloadProgress.cpp
 msgid "Reloading shared files..."
 msgstr "Rechargement des fichiers partagés…"
 
@@ -6716,18 +6638,6 @@ msgstr "Erreur %u : %s\n"
 #: src/SearchListCtrl.cpp
 msgid "FileID"
 msgstr "ID du fichier"
-
-#: src/SearchListCtrl.cpp
-msgid "Length"
-msgstr "Durée"
-
-#: src/SearchListCtrl.cpp
-msgid "Bitrate"
-msgstr "Débit binaire"
-
-#: src/SearchListCtrl.cpp
-msgid "Codec"
-msgstr "Codec"
 
 #: src/SearchListCtrl.cpp
 msgid "Expand all"
@@ -7005,10 +6915,6 @@ msgstr "Le serveur local est filtré par les filtres IP, reconnexion à un autre
 #: src/ServerListCtrl.cpp
 msgid "Server Name"
 msgstr "Nom du serveur"
-
-#: src/ServerListCtrl.cpp
-msgid "Port"
-msgstr "Port"
 
 #: src/ServerListCtrl.cpp
 msgid "Description"
@@ -7295,6 +7201,10 @@ msgstr "Connexion au pote"
 #, c-format
 msgid "Connected to buddy at %s"
 msgstr "Connecté au pote à %s"
+
+#: src/ServerWnd.cpp
+msgid "IP address:"
+msgstr "Adresse IP :"
 
 #: src/ServerWnd.cpp
 msgid "Indexed sources:"

--- a/po/gl.po
+++ b/po/gl.po
@@ -24,7 +24,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-04 12:13+0200\n"
+"POT-Creation-Date: 2026-09-05 12:01+0200\n"
 "PO-Revision-Date: 2026-09-03 11:05+0000\n"
 "Last-Translator: Pablo <parodper@gmail.com>\n"
 "Language-Team: http://forum.amule.org/index.php?topic=13883\n"
@@ -408,8 +408,7 @@ msgstr "servidor web executándose co pid %d"
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Solicitou executar o servidor web ó inicio pero non se puido executar o programa amuleweb. Instale o paquete que conteña o servidor web do aMule ou compile o aMule empregando o parámetro --enable-webserver e logo execute make install"
 
-#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
-#: src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
+#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
 msgid "ERROR"
 msgstr "ERRO"
 
@@ -696,8 +695,7 @@ msgstr "Redes"
 msgid "Searches"
 msgstr "Buscas"
 
-#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/Statistics.cpp
+#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/Statistics.cpp
 msgid "Downloads"
 msgstr "Descargas"
 
@@ -781,9 +779,7 @@ msgstr "Kad: Apagado"
 msgid "Core"
 msgstr ""
 
-#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#: src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp
-#: src/SourceListCtrl.cpp src/Statistics.cpp
+#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp src/Statistics.cpp
 msgid "Version"
 msgstr "Versión"
 
@@ -1084,11 +1080,7 @@ msgstr "Non se puido crear o directorio «%s» para a categoría «%s», mantend
 msgid "The remote core sent inconsistent data for \"%s\" (part status %d, expected %d). The file list may be showing the wrong information; reconnect to clear it."
 msgstr ""
 
-#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp
-#: src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp
-#: src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp
-#: src/Statistics.cpp
+#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp src/Statistics.cpp
 msgid "Unknown"
 msgstr "Descoñecido"
 
@@ -1185,8 +1177,7 @@ msgstr "Non se puido gardar o ficheiro %s: %s"
 msgid "Enter Captcha"
 msgstr "Introduza o Captcha"
 
-#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp
-#: src/TransferWnd.cpp
+#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp src/TransferWnd.cpp
 msgid "Category"
 msgstr "Categoría"
 
@@ -1349,13 +1340,11 @@ msgstr "Non se atopou o ficheiro «cryptkey.dat», creándoo."
 msgid "Client Details"
 msgstr "Detalles do cliente"
 
-#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
-#: src/utils/wxCas/src/onlinesig.cpp
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
 msgid "LowID"
 msgstr "IDBaixa"
 
-#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
-#: src/utils/wxCas/src/onlinesig.cpp
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
 msgid "HighID"
 msgstr "IDAlta"
 
@@ -1371,8 +1360,7 @@ msgstr "Permitido"
 msgid "Not supported"
 msgstr "Non permitido"
 
-#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
-#: src/TextClient.cpp
+#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp src/TextClient.cpp
 msgid "Connected"
 msgstr "Conectado"
 
@@ -1380,28 +1368,24 @@ msgstr "Conectado"
 msgid "Disconnected"
 msgstr "Desconectado"
 
-#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp
-#: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f KiB/s"
 msgstr ""
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#, fuzzy
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/muuli_wdr.cpp
 msgid "Name"
-msgstr "Nome:"
+msgstr "Nome"
 
 #: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
 msgid "Software"
 msgstr ""
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#, fuzzy
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/muuli_wdr.cpp
 msgid "IP Address"
-msgstr "Enderezo IP :"
+msgstr "Enderezo IP"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Origin"
 msgstr "Orixe"
 
@@ -1419,13 +1403,11 @@ msgstr "Última recepción"
 msgid "Sessions"
 msgstr "Versión"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp
 msgid "Upload Speed"
 msgstr "Velocidade de envío"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp
 msgid "Download Speed"
 msgstr "Velocidade de descarga"
 
@@ -1480,13 +1462,11 @@ msgstr[1] "Non se puideron engadir as ligazóns %u (consulte o rexistro)."
 msgid "Files"
 msgstr "Ficheiros"
 
-#: src/ClientsListCtrl.cpp src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp
-#: src/SourceListCtrl.cpp
+#: src/ClientsListCtrl.cpp src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Uploaded"
 msgstr "Enviado"
 
-#: src/ClientsListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientsListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Downloaded"
 msgstr "Descargado"
 
@@ -1573,12 +1553,11 @@ msgstr "O usuario %s (%u) denegou o acceso á lista de ficheiros e directorios c
 msgid "File Comments"
 msgstr "Comentarios do ficheiro"
 
-#: src/CommentDialogLst.cpp src/FriendListCtrl.cpp
+#: src/CommentDialogLst.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
 msgid "Username"
 msgstr "Nome de usuario"
 
-#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp
-#: src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "File Name"
 msgstr "Nome do ficheiro"
 
@@ -1586,7 +1565,7 @@ msgstr "Nome do ficheiro"
 msgid "Rating"
 msgstr "Valoración"
 
-#: src/CommentDialogLst.cpp
+#: src/CommentDialogLst.cpp src/muuli_wdr.cpp
 msgid "Comment"
 msgstr "Comentario"
 
@@ -1640,18 +1619,15 @@ msgstr "Auto [Al]"
 msgid "Very low"
 msgstr "Moi baixa"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Low"
 msgstr "Baixa"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Normal"
 msgstr "Normal"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "High"
 msgstr "Alta"
 
@@ -1675,13 +1651,11 @@ msgstr "Conectando vía servidor"
 msgid "Queue Full"
 msgstr "Cola chea"
 
-#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp
-#: src/muuli_wdr.cpp
+#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp src/muuli_wdr.cpp
 msgid "On Queue"
 msgstr "En cola"
 
-#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp
-#: src/PartFile.cpp src/TransferWnd.cpp
+#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Downloading"
 msgstr "Descargando"
 
@@ -1741,8 +1715,7 @@ msgstr "Servidor local"
 msgid "Remote Server"
 msgstr "Servidor remoto"
 
-#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp
-#: src/TextClient.cpp
+#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp src/TextClient.cpp
 msgid "Kad"
 msgstr "Kad"
 
@@ -1766,8 +1739,7 @@ msgstr "Sementes da fonte"
 msgid "Search Result"
 msgstr "Resultados da busca"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp
-#: src/TransferWnd.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Completed"
 msgstr "Completado"
 
@@ -1819,8 +1791,7 @@ msgstr ""
 msgid "Part"
 msgstr "Parte"
 
-#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp
-#: src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Size"
 msgstr "Tamaño"
 
@@ -1828,8 +1799,7 @@ msgstr "Tamaño"
 msgid "Transferred"
 msgstr "Transferido"
 
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
-#: src/SourceListCtrl.cpp
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp src/SourceListCtrl.cpp
 msgid "Speed"
 msgstr "Velocidade"
 
@@ -1837,13 +1807,11 @@ msgstr "Velocidade"
 msgid "Progress"
 msgstr "Progreso"
 
-#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp
-#: src/SearchListCtrl.cpp
+#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
 msgid "Sources"
 msgstr "Fontes"
 
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp
-#: src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Priority"
 msgstr "Prioridade"
 
@@ -1867,9 +1835,7 @@ msgstr "Última recepción"
 msgid "Auto"
 msgstr "Automático"
 
-#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/TransferWnd.cpp
-#: src/utils/wxCas/src/wxcasprefs.cpp
+#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/TransferWnd.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Cancel"
 msgstr "Cancelar"
 
@@ -1970,8 +1936,7 @@ msgstr "Introducir un novo nome para este ficheiro:"
 msgid "File rename"
 msgstr "Cambiar o nome do ficheiro"
 
-#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp
-#: src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f MiB/s"
 msgstr ""
@@ -2774,13 +2739,11 @@ msgstr ""
 msgid "Start aMule automatically when I log in"
 msgstr "Arrancar aMule automaticamente ao iniciar sesión"
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
-#: packaging/windows/installer_strings.c
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp packaging/windows/installer_strings.c
 msgid "Register aMule for ed2k:// links"
 msgstr ""
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
-#: packaging/windows/installer_strings.c
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp packaging/windows/installer_strings.c
 msgid "Register aMule for magnet: links"
 msgstr ""
 
@@ -2806,8 +2769,7 @@ msgstr ""
 msgid "Destination folder for downloads"
 msgstr "Cartafol de destino para descargas"
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
-#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Browse"
 msgstr "Navegador"
 
@@ -3250,18 +3212,15 @@ msgstr "Rematando"
 msgid "Complete"
 msgstr "Rematado"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
-#: src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Paused"
 msgstr "Pausado"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
-#: src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Erroneous"
 msgstr "Erróneo"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
-#: src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Waiting"
 msgstr "Agardando"
 
@@ -3425,8 +3384,7 @@ msgstr "Pechar"
 msgid "Cut"
 msgstr "Cortar"
 
-#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp
-#: src/utils/aLinkCreator/src/alcframe.cpp
+#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy"
 msgstr "Copiar"
 
@@ -3434,8 +3392,7 @@ msgstr "Copiar"
 msgid "Paste"
 msgstr "Pegar"
 
-#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp
-#: src/utils/aLinkCreator/src/alcframe.cpp
+#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Clear"
 msgstr "Limpar"
 
@@ -3443,8 +3400,7 @@ msgstr "Limpar"
 msgid "Select All"
 msgstr "Seleccionar todo"
 
-#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
-#: src/StatisticsDlg.cpp
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp src/StatisticsDlg.cpp
 msgid "KiB/s"
 msgstr ""
 
@@ -3701,10 +3657,6 @@ msgstr "Servidor actualmente conectado."
 msgid "Search"
 msgstr "Buscar"
 
-#: src/muuli_wdr.cpp
-msgid "Name:"
-msgstr "Nome:"
-
 #: src/muuli_wdr.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Type"
 msgstr "Tipo"
@@ -3794,8 +3746,8 @@ msgid "Availability"
 msgstr "Dispoñibilidade"
 
 #: src/muuli_wdr.cpp
-msgid "Filter:"
-msgstr "Filtrado:"
+msgid "Filter"
+msgstr "Filtrado"
 
 #: src/muuli_wdr.cpp
 msgid "Invert Result"
@@ -3853,6 +3805,10 @@ msgid "Clears completed downloads"
 msgstr "Limpar descargas completadas"
 
 #: src/muuli_wdr.cpp
+msgid "Filter:"
+msgstr "Filtrado:"
+
+#: src/muuli_wdr.cpp
 msgid "File sources:"
 msgstr "Fontes do ficheiro:"
 
@@ -3861,80 +3817,76 @@ msgid "General"
 msgstr "Xeral"
 
 #: src/muuli_wdr.cpp
-msgid "Full Name :"
-msgstr "Nome completo :"
+msgid "Full Name"
+msgstr "Nome completo"
 
 #: src/muuli_wdr.cpp
-msgid "met-File :"
-msgstr "Ficheiro .met:"
+msgid "met-File"
+msgstr "Ficheiro .met"
 
 #: src/muuli_wdr.cpp
-msgid "Hash :"
-msgstr "Resumo criptográfico (Hash) :"
+msgid "Hash"
+msgstr "Resumo criptográfico (Hash)"
 
 #: src/muuli_wdr.cpp
-msgid "Filesize :"
-msgstr "Tamaño do ficheiro:"
+msgid "Filesize"
+msgstr "Tamaño do ficheiro"
 
 #: src/muuli_wdr.cpp src/Statistics.cpp
 msgid "Transfer"
 msgstr "Transferir"
 
 #: src/muuli_wdr.cpp
-msgid "Partfilestatus :"
-msgstr "Estado do ficheiro parcial:"
+msgid "Partfilestatus"
+msgstr "Estado do ficheiro parcial"
 
 #: src/muuli_wdr.cpp
-msgid "Last seen complete :"
-msgstr "Visto completo por última vez:"
+msgid "Last seen complete"
+msgstr "Visto completo por última vez"
 
 #: src/muuli_wdr.cpp
-msgid "Found Sources :"
-msgstr "Fontes atopadas:"
+msgid "Found Sources"
+msgstr "Fontes atopadas"
 
 #: src/muuli_wdr.cpp
-msgid "Transferring Sources :"
-msgstr "Enviando fontes :"
+msgid "Transferring Sources"
+msgstr "Enviando fontes"
 
 #: src/muuli_wdr.cpp
-msgid "Filepart-Count :"
-msgstr "Número de partes:"
+msgid "Filepart-Count"
+msgstr "Número de partes"
 
 #: src/muuli_wdr.cpp
-msgid "Available :"
-msgstr "Dispoñible :"
+msgid "Available"
+msgstr "Dispoñible"
 
 #: src/muuli_wdr.cpp
-msgid "Datarate :"
-msgstr "Fluxo de datos :"
+msgid "Datarate"
+msgstr "Fluxo de datos"
 
 #: src/muuli_wdr.cpp
-msgid "Download Active Time: "
-msgstr "Tempo coa descarga activa: "
+msgid "Download Active Time"
+msgstr "Tempo coa descarga activa"
 
 #: src/muuli_wdr.cpp
-msgid "Transferred :"
-msgstr "Transferido :"
-
-#: src/muuli_wdr.cpp
-msgid "Completed Size :"
-msgstr "Tamaño total :"
+msgid "Completed Size"
+msgstr "Tamaño total"
 
 #: src/muuli_wdr.cpp
 msgid "Intelligent Corruption Handling"
 msgstr "Xestión Intelixente da Corrupción"
 
 #: src/muuli_wdr.cpp
-msgid "Lost to corruption :"
-msgstr "Perdido por corrupción:"
+msgid "Lost to corruption"
+msgstr "Perdido por corrupción"
 
 #: src/muuli_wdr.cpp
-msgid "Gained by compression :"
-msgstr "Gañado por compresión:"
+msgid "Gained by compression"
+msgstr "Gañado por compresión"
 
 #: src/muuli_wdr.cpp
-msgid "Packages saved by I.C.H. :"
-msgstr "Paquetes salvados pola X.I.C. :"
+msgid "Packages saved by I.C.H."
+msgstr "Paquetes salvados pola X.I.C."
 
 #: src/muuli_wdr.cpp
 #, fuzzy
@@ -3976,30 +3928,30 @@ msgstr ", Enviado: "
 msgid "Media Info"
 msgstr "Info. Kad"
 
-#: src/muuli_wdr.cpp
-msgid "Length :"
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
+msgid "Length"
 msgstr ""
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
 #, fuzzy
-msgid "Bitrate :"
+msgid "Bitrate"
 msgstr "Non evaluada"
 
-#: src/muuli_wdr.cpp
-msgid "Codec :"
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
+msgid "Codec"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Artist :"
+msgid "Artist"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Album :"
+msgid "Album"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Title :"
-msgstr "Título :"
+msgid "Title"
+msgstr "Título"
 
 #: src/muuli_wdr.cpp
 msgid "File Names"
@@ -4086,25 +4038,17 @@ msgstr "Tamaño descoñecido"
 msgid "Required Information"
 msgstr "Información requerida"
 
-#: src/muuli_wdr.cpp
-msgid "IP Address :"
-msgstr "Enderezo IP :"
-
-#: src/muuli_wdr.cpp
-msgid "Port :"
-msgstr "Porto :"
+#: src/muuli_wdr.cpp src/ServerListCtrl.cpp
+msgid "Port"
+msgstr "Porto"
 
 #: src/muuli_wdr.cpp
 msgid "Additional Information"
 msgstr "Información adicional"
 
 #: src/muuli_wdr.cpp
-msgid "Username :"
-msgstr "Nome de usuario :"
-
-#: src/muuli_wdr.cpp
-msgid "Userhash :"
-msgstr "Hash do usuario :"
+msgid "Userhash"
+msgstr "Hash do usuario"
 
 #: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Add"
@@ -4139,96 +4083,80 @@ msgid "Statistics Tree"
 msgstr "Árbore de estadísticas"
 
 #: src/muuli_wdr.cpp
-msgid "Username:"
-msgstr "Nome de usuario:"
+msgid "Client software"
+msgstr "Software do cliente"
 
 #: src/muuli_wdr.cpp
-msgid "Userhash:"
-msgstr "Hash do usuario :"
+msgid "Client version"
+msgstr "Versión do cliente"
 
 #: src/muuli_wdr.cpp
-msgid "Client software:"
-msgstr "Software do cliente :"
+msgid "User ID"
+msgstr "ID do usuario"
 
 #: src/muuli_wdr.cpp
-msgid "Client version:"
-msgstr "Versión do cliente :"
-
-#: src/muuli_wdr.cpp src/ServerWnd.cpp
-msgid "IP address:"
-msgstr "Enderezo IP :"
+msgid "Server IP"
+msgstr "IP do servidor"
 
 #: src/muuli_wdr.cpp
-msgid "User ID:"
-msgstr "ID do usuario :"
+msgid "Server name"
+msgstr "Nome do servidor"
 
 #: src/muuli_wdr.cpp
-msgid "Server IP:"
-msgstr "IP do servidor :"
-
-#: src/muuli_wdr.cpp
-msgid "Server name:"
-msgstr "Nome do servidor :"
-
-#: src/muuli_wdr.cpp
-msgid "Obfuscation:"
-msgstr "Ofuscación:"
-
-#: src/muuli_wdr.cpp
-msgid "Kad:"
-msgstr "Kad:"
+msgid "Obfuscation"
+msgstr "Ofuscación"
 
 #: src/muuli_wdr.cpp
 msgid "Transfers to client"
 msgstr "Transferencias ao cliente"
 
 #: src/muuli_wdr.cpp
-msgid "Current request:"
-msgstr "Peticións actuais:"
+msgid "Current request"
+msgstr "Peticións actuais"
 
 #: src/muuli_wdr.cpp
-msgid "Average upload rate:"
-msgstr "Taxa media de envío:"
+msgid "Average upload rate"
+msgstr "Taxa media de envío"
 
 #: src/muuli_wdr.cpp
-msgid "Average download rate:"
-msgstr "Índice medio de descarga :"
+msgid "Average download rate"
+msgstr "Índice medio de descarga"
 
 #: src/muuli_wdr.cpp
-msgid "Uploaded (session):"
-msgstr "Enviado (sesión):"
+msgid "Uploaded (session)"
+msgstr "Enviado (sesión)"
 
 #: src/muuli_wdr.cpp
-msgid "Downloaded (session):"
-msgstr "Descargado (sesión):"
+msgid "Downloaded (session)"
+msgstr "Descargado (sesión)"
 
 #: src/muuli_wdr.cpp
-msgid "Uploaded (total):"
-msgstr "Enviado (total):"
+msgid "Uploaded (total)"
+msgstr "Enviado (total)"
 
 #: src/muuli_wdr.cpp
-msgid "Downloaded (total):"
-msgstr "Descargado (total):"
+msgid "Downloaded (total)"
+msgstr "Descargado (total)"
 
 #: src/muuli_wdr.cpp
 msgid "Scores"
 msgstr "Resultados"
 
 #: src/muuli_wdr.cpp
-msgid "DL/UP modifier:"
-msgstr "Modificador DE/EV :"
+msgid "DL/UP modifier"
+msgstr "Modificador DE/EV"
 
 #: src/muuli_wdr.cpp
-msgid "Secure ident:"
-msgstr "Identidade segura:"
+msgid "Secure ident"
+msgstr "Identidade segura"
 
 #: src/muuli_wdr.cpp
-msgid "Queue rank:"
-msgstr "Posición na cola:"
+msgid "Queue rank"
+msgstr "Posición na cola"
 
 #: src/muuli_wdr.cpp
-msgid "Queue score:"
-msgstr "Puntuación na cola:"
+msgid "Queue score"
+msgstr "Puntuación na cola"
 
 #: src/muuli_wdr.cpp
 msgid "Nick"
@@ -5023,24 +4951,20 @@ msgid "Reset any changes made to the preferences."
 msgstr "Restablecer calquera troco feito nas preferencias."
 
 #: src/muuli_wdr.cpp
-msgid "Comment :"
-msgstr "Comentario :"
+msgid "Incoming Dir"
+msgstr "Cartafol de descargas"
 
 #: src/muuli_wdr.cpp
-msgid "Incoming Dir :"
-msgstr "Cartafol de descargas :"
-
-#: src/muuli_wdr.cpp
-msgid "Change priority for new assigned files :"
-msgstr "Cambiar prioridade para os novos ficheiros asignados :"
+msgid "Change priority for new assigned files"
+msgstr "Cambiar prioridade para os novos ficheiros asignados"
 
 #: src/muuli_wdr.cpp
 msgid "Don't change"
 msgstr "Non cambiar"
 
 #: src/muuli_wdr.cpp
-msgid "Select color for this Category (currently selected) :"
-msgstr "Seleccionar cor para esta categoría (a seleccionada) :"
+msgid "Select color for this Category (currently selected)"
+msgstr "Seleccionar cor para esta categoría (a seleccionada)"
 
 #: src/muuli_wdr.cpp
 msgid "Click this button to reset the log."
@@ -5123,10 +5047,6 @@ msgstr "Arrancar a partir de clientes coñecidos"
 #, fuzzy
 msgid "Enter the IP of the node here, using the x.x.x.x format."
 msgstr "Introduza a IP do servidor aquí, usando o formato x.x.x.x ."
-
-#: src/muuli_wdr.cpp
-msgid "Port:"
-msgstr "Porto:"
 
 #: src/muuli_wdr.cpp
 msgid "Use Secure User Identification"
@@ -5394,20 +5314,20 @@ msgid "Enable/disable proxy support"
 msgstr "Activar/desactivar o tipo de proxy"
 
 #: src/muuli_wdr.cpp
-msgid "Proxy type:"
-msgstr "Tipo de proxy:"
+msgid "Proxy type"
+msgstr "Tipo de proxy"
 
 #: src/muuli_wdr.cpp
-msgid "Proxy host:"
-msgstr "Anfitrión do proxy:"
+msgid "Proxy host"
+msgstr "Anfitrión do proxy"
 
 #: src/muuli_wdr.cpp
 msgid "The proxy host name"
 msgstr "O nome do anfitrión do proxy"
 
 #: src/muuli_wdr.cpp
-msgid "Proxy port:"
-msgstr "Porto do proxy:"
+msgid "Proxy port"
+msgstr "Porto do proxy"
 
 #: src/muuli_wdr.cpp
 msgid "The proxy port"
@@ -5422,16 +5342,8 @@ msgid "Enable/disable username/password authentication"
 msgstr "Activar/desactivar a identificación mediante nome de usuario e contrasinal"
 
 #: src/muuli_wdr.cpp
-msgid "Username: "
-msgstr "Nome de usuario: "
-
-#: src/muuli_wdr.cpp
 msgid "The username to use to connect to the proxy"
 msgstr "O nome de usuario a usar para conectarse ao proxy"
-
-#: src/muuli_wdr.cpp
-msgid "Password:"
-msgstr "Contrasinal:"
 
 #: src/muuli_wdr.cpp
 msgid "The password to use to connect to the proxy"
@@ -5606,6 +5518,15 @@ msgstr "horas"
 #: src/OtherFunctions.cpp
 msgid "days"
 msgstr "días"
+
+#. TRANSLATORS:
+#. Punctuation for a "label: value" pair. %s is the already-translated
+#. label. Place the colon as your language requires -- e.g. "%s :" with a
+#. space in French, "%s:" without one in Russian and English.
+#: src/OtherFunctions.cpp
+#, c-format
+msgid "%s:"
+msgstr ""
 
 #: src/OtherFunctions.cpp
 msgid "all"
@@ -6652,8 +6573,7 @@ msgstr "Compartir de xeito recursivo publicará calquera ficheiro que teñan deb
 msgid "Confirm shared folders"
 msgstr "Confirmar e compartir cartafoles"
 
-#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp
-#: src/SharedFilesReloadProgress.cpp
+#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp src/SharedFilesReloadProgress.cpp
 msgid "Reloading shared files..."
 msgstr "Recargando os ficheiros compartidos..."
 
@@ -6783,19 +6703,6 @@ msgstr "Fallou a actualización de %s"
 #: src/SearchListCtrl.cpp
 msgid "FileID"
 msgstr "IDFicheiro"
-
-#: src/SearchListCtrl.cpp
-msgid "Length"
-msgstr ""
-
-#: src/SearchListCtrl.cpp
-#, fuzzy
-msgid "Bitrate"
-msgstr "Non evaluada"
-
-#: src/SearchListCtrl.cpp
-msgid "Codec"
-msgstr ""
 
 #: src/SearchListCtrl.cpp
 msgid "Expand all"
@@ -7080,10 +6987,6 @@ msgstr "O servidor local está filtrado por IPFilters, conectando a un servidor 
 #: src/ServerListCtrl.cpp
 msgid "Server Name"
 msgstr "Nome do servidor"
-
-#: src/ServerListCtrl.cpp
-msgid "Port"
-msgstr "Porto"
 
 #: src/ServerListCtrl.cpp
 msgid "Description"
@@ -7377,6 +7280,10 @@ msgstr "Conectado a colega"
 #, c-format
 msgid "Connected to buddy at %s"
 msgstr "Conectado a colega en %s"
+
+#: src/ServerWnd.cpp
+msgid "IP address:"
+msgstr "Enderezo IP :"
 
 #: src/ServerWnd.cpp
 msgid "Indexed sources:"

--- a/po/he.po
+++ b/po/he.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-04 12:13+0200\n"
+"POT-Creation-Date: 2026-09-05 12:01+0200\n"
 "PO-Revision-Date: 2026-09-03 11:05+0000\n"
 "Last-Translator: Peace Kramer <kpeace1@gmail.com>\n"
 "Language-Team: Hebrew\n"
@@ -382,8 +382,7 @@ msgstr ""
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr ""
 
-#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
-#: src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
+#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
 msgid "ERROR"
 msgstr ""
 
@@ -663,8 +662,7 @@ msgstr "רשתות"
 msgid "Searches"
 msgstr "חיפושים"
 
-#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/Statistics.cpp
+#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/Statistics.cpp
 msgid "Downloads"
 msgstr "הורדות"
 
@@ -748,9 +746,7 @@ msgstr "קאד: מכובה"
 msgid "Core"
 msgstr ""
 
-#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#: src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp
-#: src/SourceListCtrl.cpp src/Statistics.cpp
+#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp src/Statistics.cpp
 msgid "Version"
 msgstr "גירסא"
 
@@ -1053,11 +1049,7 @@ msgstr ""
 msgid "The remote core sent inconsistent data for \"%s\" (part status %d, expected %d). The file list may be showing the wrong information; reconnect to clear it."
 msgstr ""
 
-#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp
-#: src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp
-#: src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp
-#: src/Statistics.cpp
+#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp src/Statistics.cpp
 msgid "Unknown"
 msgstr "לא ידוע"
 
@@ -1155,8 +1147,7 @@ msgstr "שגיאה במהלך שמירת הקובץ known.met: %s"
 msgid "Enter Captcha"
 msgstr ""
 
-#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp
-#: src/TransferWnd.cpp
+#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp src/TransferWnd.cpp
 msgid "Category"
 msgstr "קטיגוריה"
 
@@ -1320,13 +1311,11 @@ msgstr ""
 msgid "Client Details"
 msgstr ""
 
-#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
-#: src/utils/wxCas/src/onlinesig.cpp
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
 msgid "LowID"
 msgstr "מ\"ז נמוך (LowID)"
 
-#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
-#: src/utils/wxCas/src/onlinesig.cpp
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
 msgid "HighID"
 msgstr "מ\"ז גבוה (HighID)"
 
@@ -1342,8 +1331,7 @@ msgstr ""
 msgid "Not supported"
 msgstr ""
 
-#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
-#: src/TextClient.cpp
+#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp src/TextClient.cpp
 msgid "Connected"
 msgstr "מחובר"
 
@@ -1351,28 +1339,24 @@ msgstr "מחובר"
 msgid "Disconnected"
 msgstr "מנותק"
 
-#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp
-#: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f KiB/s"
 msgstr ""
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#, fuzzy
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/muuli_wdr.cpp
 msgid "Name"
-msgstr "שם:"
+msgstr "שם"
 
 #: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
 msgid "Software"
 msgstr ""
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#, fuzzy
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/muuli_wdr.cpp
 msgid "IP Address"
-msgstr "כתובת IP :"
+msgstr "כתובת IP"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Origin"
 msgstr ""
 
@@ -1390,14 +1374,12 @@ msgstr "פעם אחרונה שנתקבל"
 msgid "Sessions"
 msgstr "גירסא"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp
 #, fuzzy
 msgid "Upload Speed"
 msgstr "מהירות-העלאה"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp
 #, fuzzy
 msgid "Download Speed"
 msgstr "מהירות הורדה"
@@ -1453,13 +1435,11 @@ msgstr[1] ""
 msgid "Files"
 msgstr "קבצים"
 
-#: src/ClientsListCtrl.cpp src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp
-#: src/SourceListCtrl.cpp
+#: src/ClientsListCtrl.cpp src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Uploaded"
 msgstr ""
 
-#: src/ClientsListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientsListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Downloaded"
 msgstr ""
 
@@ -1546,12 +1526,11 @@ msgstr "משתמש %s (%u) שלל גישה לרשימת הקבצים/תקיות 
 msgid "File Comments"
 msgstr "הערות על הקובץ"
 
-#: src/CommentDialogLst.cpp src/FriendListCtrl.cpp
+#: src/CommentDialogLst.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
 msgid "Username"
 msgstr "שם משתמש"
 
-#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp
-#: src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "File Name"
 msgstr "שם קובץ"
 
@@ -1559,7 +1538,7 @@ msgstr "שם קובץ"
 msgid "Rating"
 msgstr "דרוג"
 
-#: src/CommentDialogLst.cpp
+#: src/CommentDialogLst.cpp src/muuli_wdr.cpp
 msgid "Comment"
 msgstr "הערה"
 
@@ -1612,18 +1591,15 @@ msgstr "אוטומטי [גבוה]"
 msgid "Very low"
 msgstr "מאוד נמוך"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Low"
 msgstr "נמוך"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Normal"
 msgstr "רגיל"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "High"
 msgstr "גבוה"
 
@@ -1647,13 +1623,11 @@ msgstr "מתחבר דרך השרת"
 msgid "Queue Full"
 msgstr "התור מלא"
 
-#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp
-#: src/muuli_wdr.cpp
+#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp src/muuli_wdr.cpp
 msgid "On Queue"
 msgstr "על התור"
 
-#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp
-#: src/PartFile.cpp src/TransferWnd.cpp
+#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Downloading"
 msgstr "מוריד מהרשת"
 
@@ -1713,8 +1687,7 @@ msgstr "שרת מקומי"
 msgid "Remote Server"
 msgstr "שרת מרוחק"
 
-#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp
-#: src/TextClient.cpp
+#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp src/TextClient.cpp
 msgid "Kad"
 msgstr "קאד"
 
@@ -1738,8 +1711,7 @@ msgstr "מזריעי מקורות"
 msgid "Search Result"
 msgstr ""
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp
-#: src/TransferWnd.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Completed"
 msgstr "הסתיים"
 
@@ -1792,8 +1764,7 @@ msgstr ""
 msgid "Part"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp
-#: src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Size"
 msgstr "גודל"
 
@@ -1801,8 +1772,7 @@ msgstr "גודל"
 msgid "Transferred"
 msgstr "הועברו"
 
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
-#: src/SourceListCtrl.cpp
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp src/SourceListCtrl.cpp
 msgid "Speed"
 msgstr "מהירות"
 
@@ -1810,13 +1780,11 @@ msgstr "מהירות"
 msgid "Progress"
 msgstr "התקדמות"
 
-#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp
-#: src/SearchListCtrl.cpp
+#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
 msgid "Sources"
 msgstr "מקורות"
 
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp
-#: src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Priority"
 msgstr "עדיפות"
 
@@ -1840,9 +1808,7 @@ msgstr "פעם אחרונה שנתקבל"
 msgid "Auto"
 msgstr "אוטמטי"
 
-#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/TransferWnd.cpp
-#: src/utils/wxCas/src/wxcasprefs.cpp
+#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/TransferWnd.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Cancel"
 msgstr "ביטול"
 
@@ -1941,8 +1907,7 @@ msgstr "הכנס שם חדש עבור קובץ זה"
 msgid "File rename"
 msgstr "שינוי שם לקובץ"
 
-#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp
-#: src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f MiB/s"
 msgstr ""
@@ -2727,13 +2692,11 @@ msgstr ""
 msgid "Start aMule automatically when I log in"
 msgstr ""
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
-#: packaging/windows/installer_strings.c
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp packaging/windows/installer_strings.c
 msgid "Register aMule for ed2k:// links"
 msgstr ""
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
-#: packaging/windows/installer_strings.c
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp packaging/windows/installer_strings.c
 msgid "Register aMule for magnet: links"
 msgstr ""
 
@@ -2759,8 +2722,7 @@ msgstr ""
 msgid "Destination folder for downloads"
 msgstr ""
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
-#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Browse"
 msgstr "דפדף"
 
@@ -3207,18 +3169,15 @@ msgstr "מסיים"
 msgid "Complete"
 msgstr "סיים"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
-#: src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Paused"
 msgstr "הושהה"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
-#: src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Erroneous"
 msgstr "שגוי"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
-#: src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Waiting"
 msgstr "ממתין"
 
@@ -3384,8 +3343,7 @@ msgstr "סגור"
 msgid "Cut"
 msgstr "גזור"
 
-#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp
-#: src/utils/aLinkCreator/src/alcframe.cpp
+#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy"
 msgstr "העתק"
 
@@ -3393,8 +3351,7 @@ msgstr "העתק"
 msgid "Paste"
 msgstr "הדבק"
 
-#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp
-#: src/utils/aLinkCreator/src/alcframe.cpp
+#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Clear"
 msgstr "נקה"
 
@@ -3402,8 +3359,7 @@ msgstr "נקה"
 msgid "Select All"
 msgstr "בחר הכל"
 
-#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
-#: src/StatisticsDlg.cpp
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp src/StatisticsDlg.cpp
 msgid "KiB/s"
 msgstr ""
 
@@ -3666,10 +3622,6 @@ msgstr "שרת מחובר נוכחי."
 msgid "Search"
 msgstr "חיפוש"
 
-#: src/muuli_wdr.cpp
-msgid "Name:"
-msgstr "שם:"
-
 #: src/muuli_wdr.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Type"
 msgstr "סוג/טיפוס"
@@ -3759,8 +3711,8 @@ msgid "Availability"
 msgstr "זמינות"
 
 #: src/muuli_wdr.cpp
-msgid "Filter:"
-msgstr "מסנן:"
+msgid "Filter"
+msgstr "מסנן"
 
 #: src/muuli_wdr.cpp
 msgid "Invert Result"
@@ -3818,6 +3770,10 @@ msgid "Clears completed downloads"
 msgstr "מנקה הורדות שהושלמו"
 
 #: src/muuli_wdr.cpp
+msgid "Filter:"
+msgstr "מסנן:"
+
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "File sources:"
 msgstr "מקורות שנמצאו :"
@@ -3827,80 +3783,76 @@ msgid "General"
 msgstr "כללי"
 
 #: src/muuli_wdr.cpp
-msgid "Full Name :"
-msgstr "שם מלא :"
+msgid "Full Name"
+msgstr "שם מלא"
 
 #: src/muuli_wdr.cpp
-msgid "met-File :"
-msgstr "קובץ-met :"
+msgid "met-File"
+msgstr "קובץ-met"
 
 #: src/muuli_wdr.cpp
-msgid "Hash :"
-msgstr "גיבוב :"
+msgid "Hash"
+msgstr "גיבוב"
 
 #: src/muuli_wdr.cpp
-msgid "Filesize :"
-msgstr "גודל קובץ :"
+msgid "Filesize"
+msgstr "גודל קובץ"
 
 #: src/muuli_wdr.cpp src/Statistics.cpp
 msgid "Transfer"
 msgstr "מעביר"
 
 #: src/muuli_wdr.cpp
-msgid "Partfilestatus :"
-msgstr "מצב קובץ-חלקים :"
+msgid "Partfilestatus"
+msgstr "מצב קובץ-חלקים"
 
 #: src/muuli_wdr.cpp
-msgid "Last seen complete :"
-msgstr "נראה שלם בפעם האחרונה :"
+msgid "Last seen complete"
+msgstr "נראה שלם בפעם האחרונה"
 
 #: src/muuli_wdr.cpp
-msgid "Found Sources :"
-msgstr "מקורות שנמצאו :"
+msgid "Found Sources"
+msgstr "מקורות שנמצאו"
 
 #: src/muuli_wdr.cpp
-msgid "Transferring Sources :"
-msgstr "מעביר מקורות :"
+msgid "Transferring Sources"
+msgstr "מעביר מקורות"
 
 #: src/muuli_wdr.cpp
-msgid "Filepart-Count :"
-msgstr "ספירת קובץ-חלקים :"
+msgid "Filepart-Count"
+msgstr "ספירת קובץ-חלקים"
 
 #: src/muuli_wdr.cpp
-msgid "Available :"
-msgstr "זמין :"
+msgid "Available"
+msgstr "זמין"
 
 #: src/muuli_wdr.cpp
-msgid "Datarate :"
-msgstr "קצב מידע :"
+msgid "Datarate"
+msgstr "קצב מידע"
 
 #: src/muuli_wdr.cpp
-msgid "Download Active Time: "
-msgstr "זמן הורדה פעיל: "
+msgid "Download Active Time"
+msgstr "זמן הורדה פעיל"
 
 #: src/muuli_wdr.cpp
-msgid "Transferred :"
-msgstr "הועבר :"
-
-#: src/muuli_wdr.cpp
-msgid "Completed Size :"
-msgstr "כמות שהושלמה :"
+msgid "Completed Size"
+msgstr "כמות שהושלמה"
 
 #: src/muuli_wdr.cpp
 msgid "Intelligent Corruption Handling"
 msgstr "תפעול מתוחכם של פגמים"
 
 #: src/muuli_wdr.cpp
-msgid "Lost to corruption :"
-msgstr "אבד עקב פגם :"
+msgid "Lost to corruption"
+msgstr "אבד עקב פגם"
 
 #: src/muuli_wdr.cpp
-msgid "Gained by compression :"
-msgstr "רווח באמצעות כיווץ :"
+msgid "Gained by compression"
+msgstr "רווח באמצעות כיווץ"
 
 #: src/muuli_wdr.cpp
-msgid "Packages saved by I.C.H. :"
-msgstr "חבילות שנשמרו ע\"י I.C.H.·:"
+msgid "Packages saved by I.C.H."
+msgstr "חבילות שנשמרו ע\"י I.C.H.·"
 
 #: src/muuli_wdr.cpp
 #, fuzzy
@@ -3941,29 +3893,29 @@ msgstr ", הועלה: "
 msgid "Media Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp
-msgid "Length :"
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
+msgid "Length"
 msgstr ""
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
 #, fuzzy
-msgid "Bitrate :"
+msgid "Bitrate"
 msgstr "לא מדורג"
 
-#: src/muuli_wdr.cpp
-msgid "Codec :"
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
+msgid "Codec"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Artist :"
+msgid "Artist"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Album :"
+msgid "Album"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Title :"
+msgid "Title"
 msgstr ""
 
 #: src/muuli_wdr.cpp
@@ -4049,25 +4001,17 @@ msgstr "גודל לא ידוע"
 msgid "Required Information"
 msgstr "נדרש מידע"
 
-#: src/muuli_wdr.cpp
-msgid "IP Address :"
-msgstr "כתובת IP :"
-
-#: src/muuli_wdr.cpp
-msgid "Port :"
-msgstr "מבואה :"
+#: src/muuli_wdr.cpp src/ServerListCtrl.cpp
+msgid "Port"
+msgstr "מבואה"
 
 #: src/muuli_wdr.cpp
 msgid "Additional Information"
 msgstr "מידע נוסף"
 
 #: src/muuli_wdr.cpp
-msgid "Username :"
-msgstr "שם משתמש :"
-
-#: src/muuli_wdr.cpp
-msgid "Userhash :"
-msgstr "גיבוב משתשמ :"
+msgid "Userhash"
+msgstr "גיבוב משתשמ"
 
 #: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Add"
@@ -4102,43 +4046,27 @@ msgid "Statistics Tree"
 msgstr "עץ סטטיסטיקה"
 
 #: src/muuli_wdr.cpp
-msgid "Username:"
-msgstr "שם משתמש:"
+msgid "Client software"
+msgstr "תוכנת לקוח"
 
 #: src/muuli_wdr.cpp
-msgid "Userhash:"
-msgstr "גיבוב קובץ:"
+msgid "Client version"
+msgstr "גרסת לקוח"
 
 #: src/muuli_wdr.cpp
-msgid "Client software:"
-msgstr "תוכנת לקוח:"
+msgid "User ID"
+msgstr "מ\"ז משתמש"
 
 #: src/muuli_wdr.cpp
-msgid "Client version:"
-msgstr "גרסת לקוח:"
-
-#: src/muuli_wdr.cpp src/ServerWnd.cpp
-msgid "IP address:"
-msgstr "כתובת IP:"
+msgid "Server IP"
+msgstr "כתובת IP של השרת"
 
 #: src/muuli_wdr.cpp
-msgid "User ID:"
-msgstr "מ\"ז משתמש:"
+msgid "Server name"
+msgstr "שם שרת"
 
 #: src/muuli_wdr.cpp
-msgid "Server IP:"
-msgstr "כתובת IP של השרת:"
-
-#: src/muuli_wdr.cpp
-msgid "Server name:"
-msgstr "שם שרת:"
-
-#: src/muuli_wdr.cpp
-msgid "Obfuscation:"
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "Kad:"
+msgid "Obfuscation"
 msgstr ""
 
 #: src/muuli_wdr.cpp
@@ -4146,53 +4074,55 @@ msgid "Transfers to client"
 msgstr "העברות ללקוח"
 
 #: src/muuli_wdr.cpp
-msgid "Current request:"
-msgstr "בקשה נוכחית:"
+msgid "Current request"
+msgstr "בקשה נוכחית"
 
 #: src/muuli_wdr.cpp
-msgid "Average upload rate:"
-msgstr "קצב העלאה ממוצע:"
+msgid "Average upload rate"
+msgstr "קצב העלאה ממוצע"
 
 #: src/muuli_wdr.cpp
-msgid "Average download rate:"
-msgstr "קצב הורדה ממוצע:"
+msgid "Average download rate"
+msgstr "קצב הורדה ממוצע"
 
 #: src/muuli_wdr.cpp
-msgid "Uploaded (session):"
-msgstr "הועלה (הרצה נוכחית):"
+msgid "Uploaded (session)"
+msgstr "הועלה (הרצה נוכחית)"
 
 #: src/muuli_wdr.cpp
-msgid "Downloaded (session):"
-msgstr "ירד (הרצה נוכחית):"
+msgid "Downloaded (session)"
+msgstr "ירד (הרצה נוכחית)"
 
 #: src/muuli_wdr.cpp
-msgid "Uploaded (total):"
-msgstr "הועלה (סה\"כ):"
+msgid "Uploaded (total)"
+msgstr "הועלה (סה\"כ)"
 
 #: src/muuli_wdr.cpp
-msgid "Downloaded (total):"
-msgstr "ירד (סה\"כ):"
+msgid "Downloaded (total)"
+msgstr "ירד (סה\"כ)"
 
 #: src/muuli_wdr.cpp
 msgid "Scores"
 msgstr "ציונים"
 
 #: src/muuli_wdr.cpp
-msgid "DL/UP modifier:"
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "Secure ident:"
+msgid "DL/UP modifier"
 msgstr ""
 
 #: src/muuli_wdr.cpp
 #, fuzzy
-msgid "Queue rank:"
+msgid "Secure ident"
+msgstr "אבטחה"
+
+#: src/muuli_wdr.cpp
+#, fuzzy
+msgid "Queue rank"
 msgstr "נכנס לתור"
 
 #: src/muuli_wdr.cpp
-msgid "Queue score:"
-msgstr ""
+#, fuzzy
+msgid "Queue score"
+msgstr "נכנס לתור"
 
 #: src/muuli_wdr.cpp
 msgid "Nick"
@@ -4979,15 +4909,12 @@ msgid "Reset any changes made to the preferences."
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Comment :"
-msgstr ""
+#, fuzzy
+msgid "Incoming Dir"
+msgstr "קבצים נכנסים"
 
 #: src/muuli_wdr.cpp
-msgid "Incoming Dir :"
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "Change priority for new assigned files :"
+msgid "Change priority for new assigned files"
 msgstr ""
 
 #: src/muuli_wdr.cpp
@@ -4996,7 +4923,7 @@ msgid "Don't change"
 msgstr "- מבואת UDP שונתה \n"
 
 #: src/muuli_wdr.cpp
-msgid "Select color for this Category (currently selected) :"
+msgid "Select color for this Category (currently selected)"
 msgstr ""
 
 #: src/muuli_wdr.cpp
@@ -5078,10 +5005,6 @@ msgstr "קבצים זמניים"
 
 #: src/muuli_wdr.cpp
 msgid "Enter the IP of the node here, using the x.x.x.x format."
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "Port:"
 msgstr ""
 
 #: src/muuli_wdr.cpp
@@ -5349,20 +5272,23 @@ msgid "Enable/disable proxy support"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Proxy type:"
-msgstr ""
+#, fuzzy
+msgid "Proxy type"
+msgstr "פרוקסי"
 
 #: src/muuli_wdr.cpp
-msgid "Proxy host:"
-msgstr ""
+#, fuzzy
+msgid "Proxy host"
+msgstr "פרוקסי"
 
 #: src/muuli_wdr.cpp
 msgid "The proxy host name"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Proxy port:"
-msgstr ""
+#, fuzzy
+msgid "Proxy port"
+msgstr "פרוקסי"
 
 #: src/muuli_wdr.cpp
 msgid "The proxy port"
@@ -5377,15 +5303,7 @@ msgid "Enable/disable username/password authentication"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Username: "
-msgstr ""
-
-#: src/muuli_wdr.cpp
 msgid "The username to use to connect to the proxy"
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "Password:"
 msgstr ""
 
 #: src/muuli_wdr.cpp
@@ -5569,6 +5487,15 @@ msgstr "שעות"
 #: src/OtherFunctions.cpp
 msgid "days"
 msgstr "ימים"
+
+#. TRANSLATORS:
+#. Punctuation for a "label: value" pair. %s is the already-translated
+#. label. Place the colon as your language requires -- e.g. "%s :" with a
+#. space in French, "%s:" without one in Russian and English.
+#: src/OtherFunctions.cpp
+#, c-format
+msgid "%s:"
+msgstr ""
 
 #: src/OtherFunctions.cpp
 msgid "all"
@@ -6602,8 +6529,7 @@ msgstr ""
 msgid "Confirm shared folders"
 msgstr "טען מחדש את הקבצים המשותפים שלך"
 
-#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp
-#: src/SharedFilesReloadProgress.cpp
+#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp src/SharedFilesReloadProgress.cpp
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "טען מחדש את הקבצים המשותפים שלך"
@@ -6734,19 +6660,6 @@ msgstr ""
 #: src/SearchListCtrl.cpp
 msgid "FileID"
 msgstr "מ\"ז של קובץ"
-
-#: src/SearchListCtrl.cpp
-msgid "Length"
-msgstr ""
-
-#: src/SearchListCtrl.cpp
-#, fuzzy
-msgid "Bitrate"
-msgstr "לא מדורג"
-
-#: src/SearchListCtrl.cpp
-msgid "Codec"
-msgstr ""
 
 #: src/SearchListCtrl.cpp
 msgid "Expand all"
@@ -7031,10 +6944,6 @@ msgstr ""
 #: src/ServerListCtrl.cpp
 msgid "Server Name"
 msgstr "שם שרת"
-
-#: src/ServerListCtrl.cpp
-msgid "Port"
-msgstr "מבואה"
 
 #: src/ServerListCtrl.cpp
 msgid "Description"
@@ -7332,6 +7241,10 @@ msgstr "מחובר לחבר"
 #, fuzzy, c-format
 msgid "Connected to buddy at %s"
 msgstr "מחובר לחבר"
+
+#: src/ServerWnd.cpp
+msgid "IP address:"
+msgstr "כתובת IP:"
 
 #: src/ServerWnd.cpp
 #, fuzzy

--- a/po/hr.po
+++ b/po/hr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-04 12:13+0200\n"
+"POT-Creation-Date: 2026-09-05 12:01+0200\n"
 "PO-Revision-Date: 2026-09-03 11:05+0000\n"
 "Last-Translator: Sebastiano Pistore <sebastiano.pistore.info@aol.com>\n"
 "Language-Team: https://github.com/amule-org/amule <forum@aMule.org>\n"
@@ -380,8 +380,7 @@ msgstr ""
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr ""
 
-#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
-#: src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
+#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
 msgid "ERROR"
 msgstr "GREŠKA"
 
@@ -661,8 +660,7 @@ msgstr ""
 msgid "Searches"
 msgstr "Pretrage"
 
-#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/Statistics.cpp
+#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/Statistics.cpp
 msgid "Downloads"
 msgstr "Downloads"
 
@@ -748,9 +746,7 @@ msgstr ""
 msgid "Core"
 msgstr ""
 
-#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#: src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp
-#: src/SourceListCtrl.cpp src/Statistics.cpp
+#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp src/Statistics.cpp
 msgid "Version"
 msgstr "Verzija"
 
@@ -1051,11 +1047,7 @@ msgstr ""
 msgid "The remote core sent inconsistent data for \"%s\" (part status %d, expected %d). The file list may be showing the wrong information; reconnect to clear it."
 msgstr ""
 
-#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp
-#: src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp
-#: src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp
-#: src/Statistics.cpp
+#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp src/Statistics.cpp
 msgid "Unknown"
 msgstr "Nepoznat"
 
@@ -1155,8 +1147,7 @@ msgstr "Greska prilikom spajanja sa %s (%s:%i): %d"
 msgid "Enter Captcha"
 msgstr "Pisati captcha"
 
-#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp
-#: src/TransferWnd.cpp
+#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp src/TransferWnd.cpp
 msgid "Category"
 msgstr "Kategorija"
 
@@ -1323,13 +1314,11 @@ msgstr ""
 msgid "Client Details"
 msgstr "Detalji klienta"
 
-#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
-#: src/utils/wxCas/src/onlinesig.cpp
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
 msgid "LowID"
 msgstr "LowID"
 
-#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
-#: src/utils/wxCas/src/onlinesig.cpp
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
 msgid "HighID"
 msgstr ""
 
@@ -1345,8 +1334,7 @@ msgstr "Podržano"
 msgid "Not supported"
 msgstr "Nije podržano"
 
-#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
-#: src/TextClient.cpp
+#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp src/TextClient.cpp
 msgid "Connected"
 msgstr "Veza uspostavljena"
 
@@ -1354,28 +1342,24 @@ msgstr "Veza uspostavljena"
 msgid "Disconnected"
 msgstr "Prekinuta veza"
 
-#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp
-#: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f KiB/s"
 msgstr ""
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#, fuzzy
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/muuli_wdr.cpp
 msgid "Name"
-msgstr "Naziv:"
+msgstr "Naziv"
 
 #: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
 msgid "Software"
 msgstr ""
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#, fuzzy
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/muuli_wdr.cpp
 msgid "IP Address"
-msgstr "IP adresa:"
+msgstr "IP adresa"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Origin"
 msgstr ""
 
@@ -1393,14 +1377,12 @@ msgstr "Posljedni prijem"
 msgid "Sessions"
 msgstr "Verzija"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp
 #, fuzzy
 msgid "Upload Speed"
 msgstr "Brzina uploada"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp
 #, fuzzy
 msgid "Download Speed"
 msgstr "Brzina downloada"
@@ -1456,13 +1438,11 @@ msgstr[2] ""
 msgid "Files"
 msgstr "Fajlovi"
 
-#: src/ClientsListCtrl.cpp src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp
-#: src/SourceListCtrl.cpp
+#: src/ClientsListCtrl.cpp src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Uploaded"
 msgstr ""
 
-#: src/ClientsListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientsListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Downloaded"
 msgstr ""
 
@@ -1549,12 +1529,11 @@ msgstr ""
 msgid "File Comments"
 msgstr "Komentari fajla"
 
-#: src/CommentDialogLst.cpp src/FriendListCtrl.cpp
+#: src/CommentDialogLst.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
 msgid "Username"
 msgstr "Ime korisnika"
 
-#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp
-#: src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "File Name"
 msgstr "Ime fajla"
 
@@ -1562,7 +1541,7 @@ msgstr "Ime fajla"
 msgid "Rating"
 msgstr "Ocjena"
 
-#: src/CommentDialogLst.cpp
+#: src/CommentDialogLst.cpp src/muuli_wdr.cpp
 msgid "Comment"
 msgstr "Komentiraj"
 
@@ -1617,18 +1596,15 @@ msgstr "Auto [Vi]"
 msgid "Very low"
 msgstr "Vrlo nizak"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Low"
 msgstr "Nisko"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Normal"
 msgstr "Normalan"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "High"
 msgstr "Visoko"
 
@@ -1652,13 +1628,11 @@ msgstr "Spaja preko servera"
 msgid "Queue Full"
 msgstr "Pun red cekanja"
 
-#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp
-#: src/muuli_wdr.cpp
+#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp src/muuli_wdr.cpp
 msgid "On Queue"
 msgstr "U redu cekanja"
 
-#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp
-#: src/PartFile.cpp src/TransferWnd.cpp
+#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Downloading"
 msgstr "Downloading"
 
@@ -1718,8 +1692,7 @@ msgstr ""
 msgid "Remote Server"
 msgstr ""
 
-#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp
-#: src/TextClient.cpp
+#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp src/TextClient.cpp
 msgid "Kad"
 msgstr "Kad"
 
@@ -1743,8 +1716,7 @@ msgstr ""
 msgid "Search Result"
 msgstr "Rezultati pretrage"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp
-#: src/TransferWnd.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Completed"
 msgstr "Zavrseno"
 
@@ -1796,8 +1768,7 @@ msgstr ""
 msgid "Part"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp
-#: src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Size"
 msgstr "Velicina"
 
@@ -1805,8 +1776,7 @@ msgstr "Velicina"
 msgid "Transferred"
 msgstr "Transferirano"
 
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
-#: src/SourceListCtrl.cpp
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp src/SourceListCtrl.cpp
 msgid "Speed"
 msgstr "Brzina"
 
@@ -1814,13 +1784,11 @@ msgstr "Brzina"
 msgid "Progress"
 msgstr "Napredak"
 
-#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp
-#: src/SearchListCtrl.cpp
+#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
 msgid "Sources"
 msgstr "Izvori"
 
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp
-#: src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Priority"
 msgstr "Prioritet"
 
@@ -1844,9 +1812,7 @@ msgstr "Posljedni prijem"
 msgid "Auto"
 msgstr "Automatski"
 
-#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/TransferWnd.cpp
-#: src/utils/wxCas/src/wxcasprefs.cpp
+#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/TransferWnd.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Cancel"
 msgstr "Otkaz"
 
@@ -1947,8 +1913,7 @@ msgstr ""
 msgid "File rename"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp
-#: src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f MiB/s"
 msgstr ""
@@ -2724,13 +2689,11 @@ msgstr ""
 msgid "Start aMule automatically when I log in"
 msgstr ""
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
-#: packaging/windows/installer_strings.c
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp packaging/windows/installer_strings.c
 msgid "Register aMule for ed2k:// links"
 msgstr ""
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
-#: packaging/windows/installer_strings.c
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp packaging/windows/installer_strings.c
 msgid "Register aMule for magnet: links"
 msgstr ""
 
@@ -2756,8 +2719,7 @@ msgstr ""
 msgid "Destination folder for downloads"
 msgstr ""
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
-#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Browse"
 msgstr "Pretrazi :"
 
@@ -3206,18 +3168,15 @@ msgstr "Zavrsavanje"
 msgid "Complete"
 msgstr "Zavrseno"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
-#: src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Paused"
 msgstr "Pausirano"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
-#: src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Erroneous"
 msgstr "Sa greskom"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
-#: src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Waiting"
 msgstr "Cekanje"
 
@@ -3385,8 +3344,7 @@ msgstr "Zatvori"
 msgid "Cut"
 msgstr ""
 
-#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp
-#: src/utils/aLinkCreator/src/alcframe.cpp
+#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy"
 msgstr "Kopiraj"
 
@@ -3394,8 +3352,7 @@ msgstr "Kopiraj"
 msgid "Paste"
 msgstr "Staviti"
 
-#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp
-#: src/utils/aLinkCreator/src/alcframe.cpp
+#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Clear"
 msgstr "Ocisti"
 
@@ -3403,8 +3360,7 @@ msgstr "Ocisti"
 msgid "Select All"
 msgstr "Izaberite sve"
 
-#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
-#: src/StatisticsDlg.cpp
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp src/StatisticsDlg.cpp
 msgid "KiB/s"
 msgstr ""
 
@@ -3667,10 +3623,6 @@ msgstr ""
 msgid "Search"
 msgstr "Pretraga"
 
-#: src/muuli_wdr.cpp
-msgid "Name:"
-msgstr "Naziv:"
-
 #: src/muuli_wdr.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Type"
 msgstr "Tip"
@@ -3760,8 +3712,8 @@ msgid "Availability"
 msgstr "Dostupnost"
 
 #: src/muuli_wdr.cpp
-msgid "Filter:"
-msgstr "Filtar:"
+msgid "Filter"
+msgstr "Filtar"
 
 #: src/muuli_wdr.cpp
 msgid "Invert Result"
@@ -3819,6 +3771,10 @@ msgid "Clears completed downloads"
 msgstr ""
 
 #: src/muuli_wdr.cpp
+msgid "Filter:"
+msgstr "Filtar:"
+
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "File sources:"
 msgstr "Nadjeni izvori :"
@@ -3828,80 +3784,77 @@ msgid "General"
 msgstr "Glavni"
 
 #: src/muuli_wdr.cpp
-msgid "Full Name :"
-msgstr "Puno ime :"
+msgid "Full Name"
+msgstr "Puno ime"
 
 #: src/muuli_wdr.cpp
-msgid "met-File :"
-msgstr "met-fajl :"
+msgid "met-File"
+msgstr "met-fajl"
 
 #: src/muuli_wdr.cpp
-msgid "Hash :"
-msgstr "Hash :"
+msgid "Hash"
+msgstr "Hash"
 
 #: src/muuli_wdr.cpp
-msgid "Filesize :"
-msgstr "Velicina fajla :"
+msgid "Filesize"
+msgstr "Velicina fajla"
 
 #: src/muuli_wdr.cpp src/Statistics.cpp
 msgid "Transfer"
 msgstr "Transfer"
 
 #: src/muuli_wdr.cpp
-msgid "Partfilestatus :"
-msgstr "Status pocetog fajla :"
+msgid "Partfilestatus"
+msgstr "Status pocetog fajla"
 
 #: src/muuli_wdr.cpp
-msgid "Last seen complete :"
-msgstr "Posljednji put vidjen kompletno :"
+msgid "Last seen complete"
+msgstr "Posljednji put vidjen kompletno"
 
 #: src/muuli_wdr.cpp
-msgid "Found Sources :"
-msgstr "Nadjeni izvori :"
+msgid "Found Sources"
+msgstr "Nadjeni izvori"
 
 #: src/muuli_wdr.cpp
-msgid "Transferring Sources :"
-msgstr "Izvori koji transferuju :"
+msgid "Transferring Sources"
+msgstr "Izvori koji transferuju"
 
 #: src/muuli_wdr.cpp
-msgid "Filepart-Count :"
-msgstr "Broj pocetog fajla :"
+msgid "Filepart-Count"
+msgstr "Broj pocetog fajla"
 
 #: src/muuli_wdr.cpp
-msgid "Available :"
-msgstr "Dostupnost :"
+msgid "Available"
+msgstr "Dostupnost"
 
 #: src/muuli_wdr.cpp
-msgid "Datarate :"
-msgstr "Podatak rate :"
+msgid "Datarate"
+msgstr "Podatak rate"
 
 #: src/muuli_wdr.cpp
-msgid "Download Active Time: "
-msgstr ""
+#, fuzzy
+msgid "Download Active Time"
+msgstr "Brzina downloada"
 
 #: src/muuli_wdr.cpp
-msgid "Transferred :"
-msgstr "Prenijeto :"
-
-#: src/muuli_wdr.cpp
-msgid "Completed Size :"
-msgstr "Zavrsna velicina :"
+msgid "Completed Size"
+msgstr "Zavrsna velicina"
 
 #: src/muuli_wdr.cpp
 msgid "Intelligent Corruption Handling"
 msgstr "Rukovanje inteligentne korupcije (I.C.H.)"
 
 #: src/muuli_wdr.cpp
-msgid "Lost to corruption :"
-msgstr "Izgubljeno zbog korupcije :"
+msgid "Lost to corruption"
+msgstr "Izgubljeno zbog korupcije"
 
 #: src/muuli_wdr.cpp
-msgid "Gained by compression :"
-msgstr "Steceno kompresijom :"
+msgid "Gained by compression"
+msgstr "Steceno kompresijom"
 
 #: src/muuli_wdr.cpp
-msgid "Packages saved by I.C.H. :"
-msgstr "Paketi spaseni kroz I.C.H. :"
+msgid "Packages saved by I.C.H."
+msgstr "Paketi spaseni kroz I.C.H."
 
 #: src/muuli_wdr.cpp
 msgid "Sharing"
@@ -3941,30 +3894,30 @@ msgstr "Aktivni uploadovi"
 msgid "Media Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp
-msgid "Length :"
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
+msgid "Length"
 msgstr ""
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
 #, fuzzy
-msgid "Bitrate :"
+msgid "Bitrate"
 msgstr "Bez ocjene"
 
-#: src/muuli_wdr.cpp
-msgid "Codec :"
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
+msgid "Codec"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Artist :"
+msgid "Artist"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Album :"
+msgid "Album"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Title :"
-msgstr "Naziv :"
+msgid "Title"
+msgstr "Naziv"
 
 #: src/muuli_wdr.cpp
 msgid "File Names"
@@ -4048,25 +4001,17 @@ msgstr ""
 msgid "Required Information"
 msgstr "Trazene informacije"
 
-#: src/muuli_wdr.cpp
-msgid "IP Address :"
-msgstr "IP adresa:"
-
-#: src/muuli_wdr.cpp
-msgid "Port :"
-msgstr "Port :"
+#: src/muuli_wdr.cpp src/ServerListCtrl.cpp
+msgid "Port"
+msgstr "Port"
 
 #: src/muuli_wdr.cpp
 msgid "Additional Information"
 msgstr "Dodatne informacije"
 
 #: src/muuli_wdr.cpp
-msgid "Username :"
-msgstr "Ime korisnika :"
-
-#: src/muuli_wdr.cpp
-msgid "Userhash :"
-msgstr "Hash korisnika :"
+msgid "Userhash"
+msgstr "Hash korisnika"
 
 #: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Add"
@@ -4101,97 +4046,94 @@ msgid "Statistics Tree"
 msgstr "Drvo statistike"
 
 #: src/muuli_wdr.cpp
-msgid "Username:"
-msgstr "Ime korisnika:"
+#, fuzzy
+msgid "Client software"
+msgstr "Klienti"
 
 #: src/muuli_wdr.cpp
-msgid "Userhash:"
+#, fuzzy
+msgid "Client version"
+msgstr "Klienti"
+
+#: src/muuli_wdr.cpp
+#, fuzzy
+msgid "User ID"
+msgstr "Korisnika: 0"
+
+#: src/muuli_wdr.cpp
+msgid "Server IP"
+msgstr "ServerIP"
+
+#: src/muuli_wdr.cpp
+#, fuzzy
+msgid "Server name"
+msgstr "Ime servera"
+
+#: src/muuli_wdr.cpp
+msgid "Obfuscation"
 msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "Client software:"
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "Client version:"
-msgstr ""
-
-#: src/muuli_wdr.cpp src/ServerWnd.cpp
-msgid "IP address:"
-msgstr "IP adresa:"
-
-#: src/muuli_wdr.cpp
-msgid "User ID:"
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "Server IP:"
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "Server name:"
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "Obfuscation:"
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "Kad:"
-msgstr "Kad:"
 
 #: src/muuli_wdr.cpp
 msgid "Transfers to client"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Current request:"
-msgstr ""
+#, fuzzy
+msgid "Current request"
+msgstr "Trenutno"
 
 #: src/muuli_wdr.cpp
-msgid "Average upload rate:"
-msgstr ""
+#, fuzzy
+msgid "Average upload rate"
+msgstr "Prosjecno vrijeme uploada: %s"
 
 #: src/muuli_wdr.cpp
-msgid "Average download rate:"
-msgstr ""
+#, fuzzy
+msgid "Average download rate"
+msgstr "Prosjecno vrijeme uploada: %s"
 
 #: src/muuli_wdr.cpp
-msgid "Uploaded (session):"
-msgstr ""
+#, fuzzy
+msgid "Uploaded (session)"
+msgstr "Prosjek uploada misije"
 
 #: src/muuli_wdr.cpp
-msgid "Downloaded (session):"
-msgstr ""
+#, fuzzy
+msgid "Downloaded (session)"
+msgstr "Prosjek downloada misije"
 
 #: src/muuli_wdr.cpp
-msgid "Uploaded (total):"
-msgstr ""
+#, fuzzy
+msgid "Uploaded (total)"
+msgstr "Prijenos"
 
 #: src/muuli_wdr.cpp
-msgid "Downloaded (total):"
-msgstr ""
+#, fuzzy
+msgid "Downloaded (total)"
+msgstr "Downloads (%i)"
 
 #: src/muuli_wdr.cpp
 msgid "Scores"
 msgstr "Rezultati"
 
 #: src/muuli_wdr.cpp
-msgid "DL/UP modifier:"
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "Secure ident:"
+msgid "DL/UP modifier"
 msgstr ""
 
 #: src/muuli_wdr.cpp
 #, fuzzy
-msgid "Queue rank:"
+msgid "Secure ident"
+msgstr "Sigurnost"
+
+#: src/muuli_wdr.cpp
+#, fuzzy
+msgid "Queue rank"
 msgstr "Pun red cekanja"
 
 #: src/muuli_wdr.cpp
-msgid "Queue score:"
-msgstr ""
+#, fuzzy
+msgid "Queue score"
+msgstr "Pun red cekanja"
 
 #: src/muuli_wdr.cpp
 msgid "Nick"
@@ -4977,16 +4919,12 @@ msgid "Reset any changes made to the preferences."
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Comment :"
-msgstr "Komentar:"
+msgid "Incoming Dir"
+msgstr "Prijemni direktorij"
 
 #: src/muuli_wdr.cpp
-msgid "Incoming Dir :"
-msgstr "Prijemni direktorij :"
-
-#: src/muuli_wdr.cpp
-msgid "Change priority for new assigned files :"
-msgstr "Promijeni prioritet za nove fajlove :"
+msgid "Change priority for new assigned files"
+msgstr "Promijeni prioritet za nove fajlove"
 
 #: src/muuli_wdr.cpp
 #, fuzzy
@@ -4994,8 +4932,8 @@ msgid "Don't change"
 msgstr "Ne mijenjaj"
 
 #: src/muuli_wdr.cpp
-msgid "Select color for this Category (currently selected) :"
-msgstr "Izaberi boju za ovu kategoriju (trenutno izabrana) :"
+msgid "Select color for this Category (currently selected)"
+msgstr "Izaberi boju za ovu kategoriju (trenutno izabrana)"
 
 #: src/muuli_wdr.cpp
 msgid "Click this button to reset the log."
@@ -5076,10 +5014,6 @@ msgstr "Privremene datoteke"
 
 #: src/muuli_wdr.cpp
 msgid "Enter the IP of the node here, using the x.x.x.x format."
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "Port:"
 msgstr ""
 
 #: src/muuli_wdr.cpp
@@ -5348,20 +5282,23 @@ msgid "Enable/disable proxy support"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Proxy type:"
-msgstr ""
+#, fuzzy
+msgid "Proxy type"
+msgstr "Proxy"
 
 #: src/muuli_wdr.cpp
-msgid "Proxy host:"
-msgstr ""
+#, fuzzy
+msgid "Proxy host"
+msgstr "Proxy"
 
 #: src/muuli_wdr.cpp
 msgid "The proxy host name"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Proxy port:"
-msgstr ""
+#, fuzzy
+msgid "Proxy port"
+msgstr "Proxy"
 
 #: src/muuli_wdr.cpp
 msgid "The proxy port"
@@ -5376,16 +5313,8 @@ msgid "Enable/disable username/password authentication"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Username: "
-msgstr "Korisničko ime:"
-
-#: src/muuli_wdr.cpp
 msgid "The username to use to connect to the proxy"
 msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "Password:"
-msgstr "Lozinka:"
 
 #: src/muuli_wdr.cpp
 msgid "The password to use to connect to the proxy"
@@ -5570,6 +5499,15 @@ msgstr "sati"
 #: src/OtherFunctions.cpp
 msgid "days"
 msgstr "dani"
+
+#. TRANSLATORS:
+#. Punctuation for a "label: value" pair. %s is the already-translated
+#. label. Place the colon as your language requires -- e.g. "%s :" with a
+#. space in French, "%s:" without one in Russian and English.
+#: src/OtherFunctions.cpp
+#, c-format
+msgid "%s:"
+msgstr ""
 
 #: src/OtherFunctions.cpp
 msgid "all"
@@ -6595,8 +6533,7 @@ msgstr ""
 msgid "Confirm shared folders"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp
-#: src/SharedFilesReloadProgress.cpp
+#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp src/SharedFilesReloadProgress.cpp
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "Pronadjeno %i poznatih dijeljenih fajlova"
@@ -6724,19 +6661,6 @@ msgstr ""
 #: src/SearchListCtrl.cpp
 msgid "FileID"
 msgstr "FileID"
-
-#: src/SearchListCtrl.cpp
-msgid "Length"
-msgstr ""
-
-#: src/SearchListCtrl.cpp
-#, fuzzy
-msgid "Bitrate"
-msgstr "Bez ocjene"
-
-#: src/SearchListCtrl.cpp
-msgid "Codec"
-msgstr ""
 
 #: src/SearchListCtrl.cpp
 msgid "Expand all"
@@ -7027,10 +6951,6 @@ msgstr ""
 #: src/ServerListCtrl.cpp
 msgid "Server Name"
 msgstr "Ime servera"
-
-#: src/ServerListCtrl.cpp
-msgid "Port"
-msgstr "Port"
 
 #: src/ServerListCtrl.cpp
 msgid "Description"
@@ -7330,6 +7250,10 @@ msgstr "Spajanje"
 #, fuzzy, c-format
 msgid "Connected to buddy at %s"
 msgstr "Spojen sa %s (%s:%i)"
+
+#: src/ServerWnd.cpp
+msgid "IP address:"
+msgstr "IP adresa:"
 
 #: src/ServerWnd.cpp
 #, fuzzy

--- a/po/hu.po
+++ b/po/hu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-04 12:13+0200\n"
+"POT-Creation-Date: 2026-09-05 12:01+0200\n"
 "PO-Revision-Date: 2026-09-03 11:05+0000\n"
 "Last-Translator: Dévai Tamás <gonosztopi@amule.org>\n"
 "Language-Team: Hungarian <hu@li.org>\n"
@@ -389,8 +389,7 @@ msgstr "web kiszolgáló fut, pid=%d"
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "A web szerver futtatását kérte induláskor, de az amuleweb program nem futtatható. Kérem telepítse az aMule web szervert tartalmazó csomagot, vagy építse az aMule-t a forráskódból a -DBUILD_WEBSERVER=YES paraméterrel és installálja azt."
 
-#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
-#: src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
+#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
 msgid "ERROR"
 msgstr "HIBA"
 
@@ -677,8 +676,7 @@ msgstr "Hálózatok"
 msgid "Searches"
 msgstr "Keresések"
 
-#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/Statistics.cpp
+#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/Statistics.cpp
 msgid "Downloads"
 msgstr "Letöltések"
 
@@ -762,9 +760,7 @@ msgstr "Kad: Nincs kapcsolat"
 msgid "Core"
 msgstr ""
 
-#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#: src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp
-#: src/SourceListCtrl.cpp src/Statistics.cpp
+#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp src/Statistics.cpp
 msgid "Version"
 msgstr "Verzió"
 
@@ -1065,11 +1061,7 @@ msgstr "A '%s' könyvtár létrehozása a '%s' kategóriához nem lehetséges, a
 msgid "The remote core sent inconsistent data for \"%s\" (part status %d, expected %d). The file list may be showing the wrong information; reconnect to clear it."
 msgstr ""
 
-#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp
-#: src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp
-#: src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp
-#: src/Statistics.cpp
+#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp src/Statistics.cpp
 msgid "Unknown"
 msgstr "Ismeretlen"
 
@@ -1164,8 +1156,7 @@ msgstr "Hiba a %s fájl mentése közben: %s"
 msgid "Enter Captcha"
 msgstr "Captcha megadása"
 
-#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp
-#: src/TransferWnd.cpp
+#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp src/TransferWnd.cpp
 msgid "Category"
 msgstr "Kategória"
 
@@ -1322,13 +1313,11 @@ msgstr "A 'cryptkey.dat' fájlt nem találom, létrehozok egyet."
 msgid "Client Details"
 msgstr "Kliens részletei"
 
-#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
-#: src/utils/wxCas/src/onlinesig.cpp
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
 msgid "LowID"
 msgstr "LowID"
 
-#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
-#: src/utils/wxCas/src/onlinesig.cpp
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
 msgid "HighID"
 msgstr "HighID"
 
@@ -1344,8 +1333,7 @@ msgstr "Támogatott"
 msgid "Not supported"
 msgstr "Nem támogatott"
 
-#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
-#: src/TextClient.cpp
+#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp src/TextClient.cpp
 msgid "Connected"
 msgstr "Csatlakozva"
 
@@ -1353,28 +1341,24 @@ msgstr "Csatlakozva"
 msgid "Disconnected"
 msgstr "Szétkapcsolva"
 
-#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp
-#: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f KiB/s"
 msgstr ""
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#, fuzzy
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/muuli_wdr.cpp
 msgid "Name"
-msgstr "Név:"
+msgstr "Név"
 
 #: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
 msgid "Software"
 msgstr ""
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#, fuzzy
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/muuli_wdr.cpp
 msgid "IP Address"
-msgstr "IP-cím :"
+msgstr "IP-cím"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Origin"
 msgstr "Eredet"
 
@@ -1392,13 +1376,11 @@ msgstr "Utoljára fogadott"
 msgid "Sessions"
 msgstr "Verzió"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp
 msgid "Upload Speed"
 msgstr "Feltöltési sebesség"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp
 msgid "Download Speed"
 msgstr "Letöltési sebesség"
 
@@ -1452,13 +1434,11 @@ msgstr[0] ""
 msgid "Files"
 msgstr "Fájlok"
 
-#: src/ClientsListCtrl.cpp src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp
-#: src/SourceListCtrl.cpp
+#: src/ClientsListCtrl.cpp src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Uploaded"
 msgstr "Feltöltve"
 
-#: src/ClientsListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientsListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Downloaded"
 msgstr "Letöltve"
 
@@ -1545,12 +1525,11 @@ msgstr "A(z) %s (%u) felhasználó megtagadta a megosztott könytár/fájl list�
 msgid "File Comments"
 msgstr "Fájl megjegyzés"
 
-#: src/CommentDialogLst.cpp src/FriendListCtrl.cpp
+#: src/CommentDialogLst.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
 msgid "Username"
 msgstr "Felhasználói név"
 
-#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp
-#: src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "File Name"
 msgstr "Fájlnév"
 
@@ -1558,7 +1537,7 @@ msgstr "Fájlnév"
 msgid "Rating"
 msgstr "Értékelés"
 
-#: src/CommentDialogLst.cpp
+#: src/CommentDialogLst.cpp src/muuli_wdr.cpp
 msgid "Comment"
 msgstr "Megjegyzés"
 
@@ -1611,18 +1590,15 @@ msgstr "Auto [Ma]"
 msgid "Very low"
 msgstr "Nagyon alacsony"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Low"
 msgstr "Alacsony"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Normal"
 msgstr "Normál"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "High"
 msgstr "Magas"
 
@@ -1646,13 +1622,11 @@ msgstr "Kapcsolódás a kiszolgálón keresztül"
 msgid "Queue Full"
 msgstr "Várólista betelt"
 
-#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp
-#: src/muuli_wdr.cpp
+#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp src/muuli_wdr.cpp
 msgid "On Queue"
 msgstr "Várólistások"
 
-#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp
-#: src/PartFile.cpp src/TransferWnd.cpp
+#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Downloading"
 msgstr "Letöltés alatt"
 
@@ -1712,8 +1686,7 @@ msgstr "Helyi kiszolgáló"
 msgid "Remote Server"
 msgstr "Távoli kiszolgáló"
 
-#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp
-#: src/TextClient.cpp
+#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp src/TextClient.cpp
 msgid "Kad"
 msgstr "Kad"
 
@@ -1737,8 +1710,7 @@ msgstr "Mentett források"
 msgid "Search Result"
 msgstr "Keresés eredménye"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp
-#: src/TransferWnd.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Completed"
 msgstr "Befejezett"
 
@@ -1790,8 +1762,7 @@ msgstr ""
 msgid "Part"
 msgstr "Rész"
 
-#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp
-#: src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Size"
 msgstr "Méret"
 
@@ -1799,8 +1770,7 @@ msgstr "Méret"
 msgid "Transferred"
 msgstr "Átmásolva"
 
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
-#: src/SourceListCtrl.cpp
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp src/SourceListCtrl.cpp
 msgid "Speed"
 msgstr "Sebesség"
 
@@ -1808,13 +1778,11 @@ msgstr "Sebesség"
 msgid "Progress"
 msgstr "Folyamatjelző"
 
-#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp
-#: src/SearchListCtrl.cpp
+#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
 msgid "Sources"
 msgstr "Források"
 
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp
-#: src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Priority"
 msgstr "Prioritás"
 
@@ -1838,9 +1806,7 @@ msgstr "Utoljára fogadott"
 msgid "Auto"
 msgstr "Automatikus"
 
-#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/TransferWnd.cpp
-#: src/utils/wxCas/src/wxcasprefs.cpp
+#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/TransferWnd.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Cancel"
 msgstr "Mégsem"
 
@@ -1941,8 +1907,7 @@ msgstr "Írd be az új nevet ennek a fájlnak:"
 msgid "File rename"
 msgstr "Fájl átnevezés"
 
-#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp
-#: src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f MiB/s"
 msgstr ""
@@ -2743,13 +2708,11 @@ msgstr ""
 msgid "Start aMule automatically when I log in"
 msgstr "aMule automatikus indítása bejelentkezéskor"
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
-#: packaging/windows/installer_strings.c
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp packaging/windows/installer_strings.c
 msgid "Register aMule for ed2k:// links"
 msgstr ""
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
-#: packaging/windows/installer_strings.c
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp packaging/windows/installer_strings.c
 msgid "Register aMule for magnet: links"
 msgstr ""
 
@@ -2775,8 +2738,7 @@ msgstr ""
 msgid "Destination folder for downloads"
 msgstr "Célkönyvtár a letöltéseknek"
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
-#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Browse"
 msgstr "Tallóz"
 
@@ -3214,18 +3176,15 @@ msgstr "Befejezés"
 msgid "Complete"
 msgstr "Kész"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
-#: src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Paused"
 msgstr "Szüneteltetve"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
-#: src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Erroneous"
 msgstr "Hibás"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
-#: src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Waiting"
 msgstr "Várakozik"
 
@@ -3385,8 +3344,7 @@ msgstr "Bezár"
 msgid "Cut"
 msgstr "Kivágás"
 
-#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp
-#: src/utils/aLinkCreator/src/alcframe.cpp
+#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy"
 msgstr "Másolás"
 
@@ -3394,8 +3352,7 @@ msgstr "Másolás"
 msgid "Paste"
 msgstr "Beillesztés"
 
-#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp
-#: src/utils/aLinkCreator/src/alcframe.cpp
+#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Clear"
 msgstr "Törlés"
 
@@ -3403,8 +3360,7 @@ msgstr "Törlés"
 msgid "Select All"
 msgstr "Mindent kijelöl"
 
-#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
-#: src/StatisticsDlg.cpp
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp src/StatisticsDlg.cpp
 msgid "KiB/s"
 msgstr ""
 
@@ -3661,10 +3617,6 @@ msgstr "Jelenleg csatlakozott kiszolgáló."
 msgid "Search"
 msgstr "Keresés"
 
-#: src/muuli_wdr.cpp
-msgid "Name:"
-msgstr "Név:"
-
 #: src/muuli_wdr.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Type"
 msgstr "Típus"
@@ -3754,8 +3706,8 @@ msgid "Availability"
 msgstr "Elérhetőség"
 
 #: src/muuli_wdr.cpp
-msgid "Filter:"
-msgstr "Szűrő:"
+msgid "Filter"
+msgstr "Szűrő"
 
 #: src/muuli_wdr.cpp
 msgid "Invert Result"
@@ -3813,6 +3765,10 @@ msgid "Clears completed downloads"
 msgstr "Befejeződött letöltések törlése"
 
 #: src/muuli_wdr.cpp
+msgid "Filter:"
+msgstr "Szűrő:"
+
+#: src/muuli_wdr.cpp
 msgid "File sources:"
 msgstr "Fájl források:"
 
@@ -3821,80 +3777,76 @@ msgid "General"
 msgstr "Általános"
 
 #: src/muuli_wdr.cpp
-msgid "Full Name :"
-msgstr "Teljes név :"
+msgid "Full Name"
+msgstr "Teljes név"
 
 #: src/muuli_wdr.cpp
-msgid "met-File :"
-msgstr "met-fájl :"
+msgid "met-File"
+msgstr "met-fájl"
 
 #: src/muuli_wdr.cpp
-msgid "Hash :"
-msgstr "Tördelőalgoritmus (hash) :"
+msgid "Hash"
+msgstr "Tördelőalgoritmus (hash)"
 
 #: src/muuli_wdr.cpp
-msgid "Filesize :"
-msgstr "Fájlméret :"
+msgid "Filesize"
+msgstr "Fájlméret"
 
 #: src/muuli_wdr.cpp src/Statistics.cpp
 msgid "Transfer"
 msgstr "Átvitel"
 
 #: src/muuli_wdr.cpp
-msgid "Partfilestatus :"
-msgstr "Fájlrész állapot :"
+msgid "Partfilestatus"
+msgstr "Fájlrész állapot"
 
 #: src/muuli_wdr.cpp
-msgid "Last seen complete :"
-msgstr "Utoljára teljesnek látott :"
+msgid "Last seen complete"
+msgstr "Utoljára teljesnek látott"
 
 #: src/muuli_wdr.cpp
-msgid "Found Sources :"
-msgstr "Forrás találatok :"
+msgid "Found Sources"
+msgstr "Forrás találatok"
 
 #: src/muuli_wdr.cpp
-msgid "Transferring Sources :"
-msgstr "Átviteli források :"
+msgid "Transferring Sources"
+msgstr "Átviteli források"
 
 #: src/muuli_wdr.cpp
-msgid "Filepart-Count :"
-msgstr "Fájlrész-számláló :"
+msgid "Filepart-Count"
+msgstr "Fájlrész-számláló"
 
 #: src/muuli_wdr.cpp
-msgid "Available :"
-msgstr "Elérhető :"
+msgid "Available"
+msgstr "Elérhető"
 
 #: src/muuli_wdr.cpp
-msgid "Datarate :"
-msgstr "Adatráta :"
+msgid "Datarate"
+msgstr "Adatráta"
 
 #: src/muuli_wdr.cpp
-msgid "Download Active Time: "
-msgstr "Aktív letöltési idő: "
+msgid "Download Active Time"
+msgstr "Aktív letöltési idő"
 
 #: src/muuli_wdr.cpp
-msgid "Transferred :"
-msgstr "Átmásolva :"
-
-#: src/muuli_wdr.cpp
-msgid "Completed Size :"
-msgstr "Teljes méret :"
+msgid "Completed Size"
+msgstr "Teljes méret"
 
 #: src/muuli_wdr.cpp
 msgid "Intelligent Corruption Handling"
 msgstr "Intelligens Sérülés Kezelés"
 
 #: src/muuli_wdr.cpp
-msgid "Lost to corruption :"
-msgstr "Sérülés miatt elveszett :"
+msgid "Lost to corruption"
+msgstr "Sérülés miatt elveszett"
 
 #: src/muuli_wdr.cpp
-msgid "Gained by compression :"
-msgstr "Tömörítéssel nyert :"
+msgid "Gained by compression"
+msgstr "Tömörítéssel nyert"
 
 #: src/muuli_wdr.cpp
-msgid "Packages saved by I.C.H. :"
-msgstr "I.S.K.-val megmentett csomagok :"
+msgid "Packages saved by I.C.H."
+msgstr "I.S.K.-val megmentett csomagok"
 
 #: src/muuli_wdr.cpp
 #, fuzzy
@@ -3936,30 +3888,30 @@ msgstr ", Feltöltés: "
 msgid "Media Info"
 msgstr "Kad infó"
 
-#: src/muuli_wdr.cpp
-msgid "Length :"
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
+msgid "Length"
 msgstr ""
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
 #, fuzzy
-msgid "Bitrate :"
+msgid "Bitrate"
 msgstr "Nincs értékelve"
 
-#: src/muuli_wdr.cpp
-msgid "Codec :"
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
+msgid "Codec"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Artist :"
+msgid "Artist"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Album :"
+msgid "Album"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Title :"
-msgstr "Cím :"
+msgid "Title"
+msgstr "Cím"
 
 #: src/muuli_wdr.cpp
 msgid "File Names"
@@ -4046,25 +3998,17 @@ msgstr "Ismeretlen méret"
 msgid "Required Information"
 msgstr "Kötelező adatok"
 
-#: src/muuli_wdr.cpp
-msgid "IP Address :"
-msgstr "IP-cím :"
-
-#: src/muuli_wdr.cpp
-msgid "Port :"
-msgstr "Port :"
+#: src/muuli_wdr.cpp src/ServerListCtrl.cpp
+msgid "Port"
+msgstr "Port"
 
 #: src/muuli_wdr.cpp
 msgid "Additional Information"
 msgstr "Kiegészítő adatok"
 
 #: src/muuli_wdr.cpp
-msgid "Username :"
-msgstr "User név :"
-
-#: src/muuli_wdr.cpp
-msgid "Userhash :"
-msgstr "Userhash :"
+msgid "Userhash"
+msgstr "Userhash"
 
 #: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Add"
@@ -4099,96 +4043,80 @@ msgid "Statistics Tree"
 msgstr "Statisztika fa"
 
 #: src/muuli_wdr.cpp
-msgid "Username:"
-msgstr "Felhasználó neve:"
+msgid "Client software"
+msgstr "Kliensszoftver"
 
 #: src/muuli_wdr.cpp
-msgid "Userhash:"
-msgstr "Felhasználói hash:"
+msgid "Client version"
+msgstr "Kliensverzió"
 
 #: src/muuli_wdr.cpp
-msgid "Client software:"
-msgstr "Kliensszoftver:"
+msgid "User ID"
+msgstr "Felhasználó ID"
 
 #: src/muuli_wdr.cpp
-msgid "Client version:"
-msgstr "Kliensverzió:"
-
-#: src/muuli_wdr.cpp src/ServerWnd.cpp
-msgid "IP address:"
-msgstr "IP-cím:"
+msgid "Server IP"
+msgstr "Kiszolgáló IP"
 
 #: src/muuli_wdr.cpp
-msgid "User ID:"
-msgstr "Felhasználó ID:"
+msgid "Server name"
+msgstr "Kiszolgáló neve"
 
 #: src/muuli_wdr.cpp
-msgid "Server IP:"
-msgstr "Kiszolgáló IP:"
-
-#: src/muuli_wdr.cpp
-msgid "Server name:"
-msgstr "Kiszolgáló neve:"
-
-#: src/muuli_wdr.cpp
-msgid "Obfuscation:"
-msgstr "Zavarás:"
-
-#: src/muuli_wdr.cpp
-msgid "Kad:"
-msgstr "Kad:"
+msgid "Obfuscation"
+msgstr "Zavarás"
 
 #: src/muuli_wdr.cpp
 msgid "Transfers to client"
 msgstr "Átvitel a kliensnek"
 
 #: src/muuli_wdr.cpp
-msgid "Current request:"
-msgstr "Aktuális kérés:"
+msgid "Current request"
+msgstr "Aktuális kérés"
 
 #: src/muuli_wdr.cpp
-msgid "Average upload rate:"
-msgstr "Átlagos feltöltési arány:"
+msgid "Average upload rate"
+msgstr "Átlagos feltöltési arány"
 
 #: src/muuli_wdr.cpp
-msgid "Average download rate:"
-msgstr "Átlagos letöltési arány:"
+msgid "Average download rate"
+msgstr "Átlagos letöltési arány"
 
 #: src/muuli_wdr.cpp
-msgid "Uploaded (session):"
-msgstr "Feltöltve (ebben a szakaszban):"
+msgid "Uploaded (session)"
+msgstr "Feltöltve (ebben a szakaszban)"
 
 #: src/muuli_wdr.cpp
-msgid "Downloaded (session):"
-msgstr "Letöltve (ebben a szakaszban):"
+msgid "Downloaded (session)"
+msgstr "Letöltve (ebben a szakaszban)"
 
 #: src/muuli_wdr.cpp
-msgid "Uploaded (total):"
-msgstr "Feltöltve (összesen):"
+msgid "Uploaded (total)"
+msgstr "Feltöltve (összesen)"
 
 #: src/muuli_wdr.cpp
-msgid "Downloaded (total):"
-msgstr "Letöltve (összesen):"
+msgid "Downloaded (total)"
+msgstr "Letöltve (összesen)"
 
 #: src/muuli_wdr.cpp
 msgid "Scores"
 msgstr "Eredmények"
 
 #: src/muuli_wdr.cpp
-msgid "DL/UP modifier:"
-msgstr "Le/Fel módosító:"
+msgid "DL/UP modifier"
+msgstr "Le/Fel módosító"
 
 #: src/muuli_wdr.cpp
-msgid "Secure ident:"
-msgstr "Biztonsági azonosító:"
+msgid "Secure ident"
+msgstr "Biztonsági azonosító"
 
 #: src/muuli_wdr.cpp
-msgid "Queue rank:"
-msgstr "Várólista helyezés:"
+msgid "Queue rank"
+msgstr "Várólista helyezés"
 
 #: src/muuli_wdr.cpp
-msgid "Queue score:"
-msgstr "Feltöltési várólista pontszám:"
+msgid "Queue score"
+msgstr "Feltöltési várólista pontszám"
 
 #: src/muuli_wdr.cpp
 msgid "Nick"
@@ -4983,24 +4911,20 @@ msgid "Reset any changes made to the preferences."
 msgstr "Beállítási módosítások figyelmen kívül hagyása."
 
 #: src/muuli_wdr.cpp
-msgid "Comment :"
-msgstr "Megjegyzés:"
+msgid "Incoming Dir"
+msgstr "Bejövő Mappa"
 
 #: src/muuli_wdr.cpp
-msgid "Incoming Dir :"
-msgstr "Bejövő Mappa :"
-
-#: src/muuli_wdr.cpp
-msgid "Change priority for new assigned files :"
-msgstr "Újonnan hozzárendelt fájlok prioritásának változtatása :"
+msgid "Change priority for new assigned files"
+msgstr "Újonnan hozzárendelt fájlok prioritásának változtatása"
 
 #: src/muuli_wdr.cpp
 msgid "Don't change"
 msgstr "Ne változzon"
 
 #: src/muuli_wdr.cpp
-msgid "Select color for this Category (currently selected) :"
-msgstr "Válassz színt ehhez a kategóriához (jelenleg kiválasztva) :"
+msgid "Select color for this Category (currently selected)"
+msgstr "Válassz színt ehhez a kategóriához (jelenleg kiválasztva)"
 
 #: src/muuli_wdr.cpp
 msgid "Click this button to reset the log."
@@ -5083,10 +5007,6 @@ msgstr "Indítás ismert kliensektől"
 #, fuzzy
 msgid "Enter the IP of the node here, using the x.x.x.x format."
 msgstr "Itt add meg a kiszolgálók IP-jét, használd az x.x.x.x formát."
-
-#: src/muuli_wdr.cpp
-msgid "Port:"
-msgstr "Port:"
 
 #: src/muuli_wdr.cpp
 msgid "Use Secure User Identification"
@@ -5363,20 +5283,20 @@ msgid "Enable/disable proxy support"
 msgstr "Proxy támogatás engedélyezése/tiltása"
 
 #: src/muuli_wdr.cpp
-msgid "Proxy type:"
-msgstr "Proxy típusa:"
+msgid "Proxy type"
+msgstr "Proxy típusa"
 
 #: src/muuli_wdr.cpp
-msgid "Proxy host:"
-msgstr "Proxy host:"
+msgid "Proxy host"
+msgstr "Proxy host"
 
 #: src/muuli_wdr.cpp
 msgid "The proxy host name"
 msgstr "A proxy host neve"
 
 #: src/muuli_wdr.cpp
-msgid "Proxy port:"
-msgstr "Proxy port:"
+msgid "Proxy port"
+msgstr "Proxy port"
 
 #: src/muuli_wdr.cpp
 msgid "The proxy port"
@@ -5391,16 +5311,8 @@ msgid "Enable/disable username/password authentication"
 msgstr "Felhasználói név/jelszó hitelesítés engedélyezése/tiltása"
 
 #: src/muuli_wdr.cpp
-msgid "Username: "
-msgstr "Felhasználói név: "
-
-#: src/muuli_wdr.cpp
 msgid "The username to use to connect to the proxy"
 msgstr "Felhasználói név a proxy kapcsolathoz"
-
-#: src/muuli_wdr.cpp
-msgid "Password:"
-msgstr "Jelszó:"
 
 #: src/muuli_wdr.cpp
 msgid "The password to use to connect to the proxy"
@@ -5572,6 +5484,15 @@ msgstr "óra"
 #: src/OtherFunctions.cpp
 msgid "days"
 msgstr "nap"
+
+#. TRANSLATORS:
+#. Punctuation for a "label: value" pair. %s is the already-translated
+#. label. Place the colon as your language requires -- e.g. "%s :" with a
+#. space in French, "%s:" without one in Russian and English.
+#: src/OtherFunctions.cpp
+#, c-format
+msgid "%s:"
+msgstr ""
 
 #: src/OtherFunctions.cpp
 msgid "all"
@@ -6607,8 +6528,7 @@ msgstr ""
 msgid "Confirm shared folders"
 msgstr "Megosztott mappák"
 
-#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp
-#: src/SharedFilesReloadProgress.cpp
+#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp src/SharedFilesReloadProgress.cpp
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "Megosztott fájlok frissítése"
@@ -6740,19 +6660,6 @@ msgstr "Hiba %s frissítésekor"
 #: src/SearchListCtrl.cpp
 msgid "FileID"
 msgstr "Fájl ID"
-
-#: src/SearchListCtrl.cpp
-msgid "Length"
-msgstr ""
-
-#: src/SearchListCtrl.cpp
-#, fuzzy
-msgid "Bitrate"
-msgstr "Nincs értékelve"
-
-#: src/SearchListCtrl.cpp
-msgid "Codec"
-msgstr ""
 
 #: src/SearchListCtrl.cpp
 msgid "Expand all"
@@ -7034,10 +6941,6 @@ msgstr "A helyi kiszolgálót kiszűrte az IP-szűrő, újracsatlakozom egy más
 #: src/ServerListCtrl.cpp
 msgid "Server Name"
 msgstr "Kiszolgáló neve"
-
-#: src/ServerListCtrl.cpp
-msgid "Port"
-msgstr "Port"
 
 #: src/ServerListCtrl.cpp
 msgid "Description"
@@ -7330,6 +7233,10 @@ msgstr "Kapcsolódás a pajtáshoz"
 #, c-format
 msgid "Connected to buddy at %s"
 msgstr "Pajtáshoz kapcsolódva %s-on"
+
+#: src/ServerWnd.cpp
+msgid "IP address:"
+msgstr "IP-cím:"
 
 #: src/ServerWnd.cpp
 msgid "Indexed sources:"

--- a/po/it.po
+++ b/po/it.po
@@ -19,7 +19,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule 2.3.3\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-04 12:13+0200\n"
+"POT-Creation-Date: 2026-09-05 12:01+0200\n"
 "PO-Revision-Date: 2026-09-03 11:06+0000\n"
 "Last-Translator: got3nks <got3nks@users.noreply.github.com>\n"
 "Language-Team: SebastianoPistore.info@protonmail.ch\n"
@@ -399,8 +399,7 @@ msgstr "web server in esecuzione su pid %d"
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Hai scelto di lanciare il web server all'avvio, ma il programma amuleweb non può essere eseguito. Installa il pacchetto contenente aMule web server, oppure compila aMule dai sorgenti con -DBUILD_WEBSERVER=YES e installalo."
 
-#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
-#: src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
+#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
 msgid "ERROR"
 msgstr "ERRORE"
 
@@ -686,8 +685,7 @@ msgstr "Reti"
 msgid "Searches"
 msgstr "Ricerca"
 
-#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/Statistics.cpp
+#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/Statistics.cpp
 msgid "Downloads"
 msgstr "Download"
 
@@ -775,9 +773,7 @@ msgstr "Kad: Spento"
 msgid "Core"
 msgstr "Core"
 
-#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#: src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp
-#: src/SourceListCtrl.cpp src/Statistics.cpp
+#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp src/Statistics.cpp
 msgid "Version"
 msgstr "Versione"
 
@@ -1074,11 +1070,7 @@ msgstr "Impossibile creare la directory '%s' per la categoria '%s', verrà mante
 msgid "The remote core sent inconsistent data for \"%s\" (part status %d, expected %d). The file list may be showing the wrong information; reconnect to clear it."
 msgstr "Il core remoto ha inviato dati incoerenti per \"%s\" (stato della parte %d, atteso %d). La lista dei file potrebbe mostrare informazioni errate; riconnettiti per azzerarla."
 
-#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp
-#: src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp
-#: src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp
-#: src/Statistics.cpp
+#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp src/Statistics.cpp
 msgid "Unknown"
 msgstr "Sconosciuto"
 
@@ -1175,8 +1167,7 @@ msgstr "Errore durante il salvataggio del file %s: %s"
 msgid "Enter Captcha"
 msgstr "Inserisci captcha"
 
-#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp
-#: src/TransferWnd.cpp
+#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp src/TransferWnd.cpp
 msgid "Category"
 msgstr "Categoria"
 
@@ -1339,13 +1330,11 @@ msgstr "Non è stato trovato il file 'cryptkey.dat', creazione del file in corso
 msgid "Client Details"
 msgstr "Dettagli client"
 
-#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
-#: src/utils/wxCas/src/onlinesig.cpp
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
 msgid "LowID"
 msgstr "ID basso"
 
-#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
-#: src/utils/wxCas/src/onlinesig.cpp
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
 msgid "HighID"
 msgstr "ID alto"
 
@@ -1361,8 +1350,7 @@ msgstr "Supportato"
 msgid "Not supported"
 msgstr "Non supportato"
 
-#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
-#: src/TextClient.cpp
+#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp src/TextClient.cpp
 msgid "Connected"
 msgstr "Connesso"
 
@@ -1370,13 +1358,12 @@ msgstr "Connesso"
 msgid "Disconnected"
 msgstr "Disconnesso"
 
-#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp
-#: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f KiB/s"
 msgstr "%.1f KiB/s"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/muuli_wdr.cpp
 msgid "Name"
 msgstr "Nome"
 
@@ -1384,12 +1371,11 @@ msgstr "Nome"
 msgid "Software"
 msgstr "Software"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/muuli_wdr.cpp
 msgid "IP Address"
 msgstr "Indirizzo IP"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Origin"
 msgstr "Origine"
 
@@ -1405,13 +1391,11 @@ msgstr "Ultimo contatto"
 msgid "Sessions"
 msgstr "Sessioni"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp
 msgid "Upload Speed"
 msgstr "Velocità upload"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp
 msgid "Download Speed"
 msgstr "Velocità download"
 
@@ -1462,13 +1446,11 @@ msgstr[1] "Impossibile aggiungere %u collegamenti (vedere il log per i dettagli)
 msgid "Files"
 msgstr "File"
 
-#: src/ClientsListCtrl.cpp src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp
-#: src/SourceListCtrl.cpp
+#: src/ClientsListCtrl.cpp src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Uploaded"
 msgstr "Inviato"
 
-#: src/ClientsListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientsListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Downloaded"
 msgstr "Scaricato"
 
@@ -1552,12 +1534,11 @@ msgstr "L'utente %s (%u) ha negato l'accesso alla lista dei file e directory con
 msgid "File Comments"
 msgstr "Commenti file"
 
-#: src/CommentDialogLst.cpp src/FriendListCtrl.cpp
+#: src/CommentDialogLst.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
 msgid "Username"
 msgstr "Nome utente"
 
-#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp
-#: src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "File Name"
 msgstr "Nome file"
 
@@ -1565,7 +1546,7 @@ msgstr "Nome file"
 msgid "Rating"
 msgstr "Giudizio"
 
-#: src/CommentDialogLst.cpp
+#: src/CommentDialogLst.cpp src/muuli_wdr.cpp
 msgid "Comment"
 msgstr "Commento"
 
@@ -1618,18 +1599,15 @@ msgstr "Auto [Alta]"
 msgid "Very low"
 msgstr "Molto bassa"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Low"
 msgstr "Bassa"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Normal"
 msgstr "Normale"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "High"
 msgstr "Alta"
 
@@ -1653,13 +1631,11 @@ msgstr "Connessione in corso attraverso il server"
 msgid "Queue Full"
 msgstr "Coda piena"
 
-#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp
-#: src/muuli_wdr.cpp
+#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp src/muuli_wdr.cpp
 msgid "On Queue"
 msgstr "In coda"
 
-#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp
-#: src/PartFile.cpp src/TransferWnd.cpp
+#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Downloading"
 msgstr "Download in corso"
 
@@ -1719,8 +1695,7 @@ msgstr "Server locale"
 msgid "Remote Server"
 msgstr "Server remoto"
 
-#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp
-#: src/TextClient.cpp
+#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp src/TextClient.cpp
 msgid "Kad"
 msgstr "Kad"
 
@@ -1744,8 +1719,7 @@ msgstr "Fonti salvate"
 msgid "Search Result"
 msgstr "Risultato della ricerca"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp
-#: src/TransferWnd.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Completed"
 msgstr "Completati"
 
@@ -1797,8 +1771,7 @@ msgstr "Impossibile modificare all'interno di una condivisione ricorsiva"
 msgid "Part"
 msgstr "Parte"
 
-#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp
-#: src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Size"
 msgstr "Dimensione"
 
@@ -1806,8 +1779,7 @@ msgstr "Dimensione"
 msgid "Transferred"
 msgstr "Trasferiti"
 
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
-#: src/SourceListCtrl.cpp
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp src/SourceListCtrl.cpp
 msgid "Speed"
 msgstr "Velocità"
 
@@ -1815,13 +1787,11 @@ msgstr "Velocità"
 msgid "Progress"
 msgstr "Avanzamento"
 
-#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp
-#: src/SearchListCtrl.cpp
+#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
 msgid "Sources"
 msgstr "Fonti"
 
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp
-#: src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Priority"
 msgstr "Priorità"
 
@@ -1845,9 +1815,7 @@ msgstr "Ultima ricezione"
 msgid "Auto"
 msgstr "Auto"
 
-#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/TransferWnd.cpp
-#: src/utils/wxCas/src/wxcasprefs.cpp
+#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/TransferWnd.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Cancel"
 msgstr "Annulla"
 
@@ -1948,8 +1916,7 @@ msgstr "Inserisci un nuovo nome per questo file:"
 msgid "File rename"
 msgstr "Rinomina file"
 
-#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp
-#: src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f MiB/s"
 msgstr "%.1f MiB/s"
@@ -2752,13 +2719,11 @@ msgstr ""
 msgid "Start aMule automatically when I log in"
 msgstr "Avvia aMule automaticamente all'accesso"
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
-#: packaging/windows/installer_strings.c
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp packaging/windows/installer_strings.c
 msgid "Register aMule for ed2k:// links"
 msgstr "Registra aMule per i link ed2k://"
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
-#: packaging/windows/installer_strings.c
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp packaging/windows/installer_strings.c
 msgid "Register aMule for magnet: links"
 msgstr "Registra aMule per i magnet: link"
 
@@ -2786,8 +2751,7 @@ msgstr ""
 msgid "Destination folder for downloads"
 msgstr "Cartella di destinazione per i file scaricati"
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
-#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Browse"
 msgstr "Sfoglia"
 
@@ -3231,18 +3195,15 @@ msgstr "In completamento"
 msgid "Complete"
 msgstr "Completo"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
-#: src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Paused"
 msgstr "In pausa"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
-#: src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Erroneous"
 msgstr "Errato"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
-#: src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Waiting"
 msgstr "In attesa"
 
@@ -3404,8 +3365,7 @@ msgstr "Chiudi"
 msgid "Cut"
 msgstr "Taglia"
 
-#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp
-#: src/utils/aLinkCreator/src/alcframe.cpp
+#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy"
 msgstr "Copia"
 
@@ -3413,8 +3373,7 @@ msgstr "Copia"
 msgid "Paste"
 msgstr "Incolla"
 
-#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp
-#: src/utils/aLinkCreator/src/alcframe.cpp
+#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Clear"
 msgstr "Pulisci"
 
@@ -3422,8 +3381,7 @@ msgstr "Pulisci"
 msgid "Select All"
 msgstr "Seleziona tutto"
 
-#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
-#: src/StatisticsDlg.cpp
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp src/StatisticsDlg.cpp
 msgid "KiB/s"
 msgstr "KiB/s"
 
@@ -3678,10 +3636,6 @@ msgstr "Server attualmente connesso."
 msgid "Search"
 msgstr "Cerca"
 
-#: src/muuli_wdr.cpp
-msgid "Name:"
-msgstr "Nome:"
-
 #: src/muuli_wdr.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Type"
 msgstr "Tipo"
@@ -3771,8 +3725,8 @@ msgid "Availability"
 msgstr "Disponibilità"
 
 #: src/muuli_wdr.cpp
-msgid "Filter:"
-msgstr "Filtro:"
+msgid "Filter"
+msgstr "Filtro"
 
 #: src/muuli_wdr.cpp
 msgid "Invert Result"
@@ -3827,6 +3781,10 @@ msgid "Clears completed downloads"
 msgstr "Rimuovi download completati"
 
 #: src/muuli_wdr.cpp
+msgid "Filter:"
+msgstr "Filtro:"
+
+#: src/muuli_wdr.cpp
 msgid "File sources:"
 msgstr "Fonti del file:"
 
@@ -3835,80 +3793,76 @@ msgid "General"
 msgstr "Generale"
 
 #: src/muuli_wdr.cpp
-msgid "Full Name :"
-msgstr "Nome completo:"
+msgid "Full Name"
+msgstr "Nome completo"
 
 #: src/muuli_wdr.cpp
-msgid "met-File :"
-msgstr "file met:"
+msgid "met-File"
+msgstr "file met"
 
 #: src/muuli_wdr.cpp
-msgid "Hash :"
-msgstr "Hash:"
+msgid "Hash"
+msgstr "Hash"
 
 #: src/muuli_wdr.cpp
-msgid "Filesize :"
-msgstr "Dimensione file:"
+msgid "Filesize"
+msgstr "Dimensione file"
 
 #: src/muuli_wdr.cpp src/Statistics.cpp
 msgid "Transfer"
 msgstr "Trasferimento"
 
 #: src/muuli_wdr.cpp
-msgid "Partfilestatus :"
-msgstr "Stato file part:"
+msgid "Partfilestatus"
+msgstr "Stato file part"
 
 #: src/muuli_wdr.cpp
-msgid "Last seen complete :"
-msgstr "Ultima volta visto completo:"
+msgid "Last seen complete"
+msgstr "Ultima volta visto completo"
 
 #: src/muuli_wdr.cpp
-msgid "Found Sources :"
-msgstr "Fonti trovate:"
+msgid "Found Sources"
+msgstr "Fonti trovate"
 
 #: src/muuli_wdr.cpp
-msgid "Transferring Sources :"
-msgstr "Fonti in trasferimento:"
+msgid "Transferring Sources"
+msgstr "Fonti in trasferimento"
 
 #: src/muuli_wdr.cpp
-msgid "Filepart-Count :"
-msgstr "Numero parti:"
+msgid "Filepart-Count"
+msgstr "Numero parti"
 
 #: src/muuli_wdr.cpp
-msgid "Available :"
-msgstr "Disponibili:"
+msgid "Available"
+msgstr "Disponibili"
 
 #: src/muuli_wdr.cpp
-msgid "Datarate :"
-msgstr "Velocità:"
+msgid "Datarate"
+msgstr "Velocità"
 
 #: src/muuli_wdr.cpp
-msgid "Download Active Time: "
-msgstr "Tempo Attivo Download: "
+msgid "Download Active Time"
+msgstr "Tempo Attivo Download"
 
 #: src/muuli_wdr.cpp
-msgid "Transferred :"
-msgstr "Trasferiti:"
-
-#: src/muuli_wdr.cpp
-msgid "Completed Size :"
-msgstr "Completati:"
+msgid "Completed Size"
+msgstr "Completati"
 
 #: src/muuli_wdr.cpp
 msgid "Intelligent Corruption Handling"
 msgstr "Gestione intelligente della Corruzione"
 
 #: src/muuli_wdr.cpp
-msgid "Lost to corruption :"
-msgstr "Perdita per corruzione:"
+msgid "Lost to corruption"
+msgstr "Perdita per corruzione"
 
 #: src/muuli_wdr.cpp
-msgid "Gained by compression :"
-msgstr "Guadagno per compressione:"
+msgid "Gained by compression"
+msgstr "Guadagno per compressione"
 
 #: src/muuli_wdr.cpp
-msgid "Packages saved by I.C.H. :"
-msgstr "Pacchetti recuperati da I.C.H. :"
+msgid "Packages saved by I.C.H."
+msgstr "Pacchetti recuperati da I.C.H."
 
 #: src/muuli_wdr.cpp
 msgid "Sharing"
@@ -3946,29 +3900,29 @@ msgstr "Ultimo upload"
 msgid "Media Info"
 msgstr "Media Info"
 
-#: src/muuli_wdr.cpp
-msgid "Length :"
-msgstr "Durata :"
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
+msgid "Length"
+msgstr "Durata"
+
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
+msgid "Bitrate"
+msgstr "Bitrate"
+
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
+msgid "Codec"
+msgstr "Codec"
 
 #: src/muuli_wdr.cpp
-msgid "Bitrate :"
-msgstr "Bitrate :"
+msgid "Artist"
+msgstr "Artista"
 
 #: src/muuli_wdr.cpp
-msgid "Codec :"
-msgstr "Codec :"
+msgid "Album"
+msgstr "Album"
 
 #: src/muuli_wdr.cpp
-msgid "Artist :"
-msgstr "Artista :"
-
-#: src/muuli_wdr.cpp
-msgid "Album :"
-msgstr "Album :"
-
-#: src/muuli_wdr.cpp
-msgid "Title :"
-msgstr "Titolo:"
+msgid "Title"
+msgstr "Titolo"
 
 #: src/muuli_wdr.cpp
 msgid "File Names"
@@ -4054,25 +4008,17 @@ msgstr "Dimensione sconosciuta"
 msgid "Required Information"
 msgstr "Informazioni richieste"
 
-#: src/muuli_wdr.cpp
-msgid "IP Address :"
-msgstr "Indirizzo IP:"
-
-#: src/muuli_wdr.cpp
-msgid "Port :"
-msgstr "Porta:"
+#: src/muuli_wdr.cpp src/ServerListCtrl.cpp
+msgid "Port"
+msgstr "Porta"
 
 #: src/muuli_wdr.cpp
 msgid "Additional Information"
 msgstr "Informazioni aggiuntive"
 
 #: src/muuli_wdr.cpp
-msgid "Username :"
-msgstr "Nome utente:"
-
-#: src/muuli_wdr.cpp
-msgid "Userhash :"
-msgstr "Hash utente:"
+msgid "Userhash"
+msgstr "Hash utente"
 
 #: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Add"
@@ -4107,96 +4053,80 @@ msgid "Statistics Tree"
 msgstr "Albero statistiche"
 
 #: src/muuli_wdr.cpp
-msgid "Username:"
-msgstr "Nome utente:"
+msgid "Client software"
+msgstr "Software client"
 
 #: src/muuli_wdr.cpp
-msgid "Userhash:"
-msgstr "Hash utente:"
+msgid "Client version"
+msgstr "Versione client"
 
 #: src/muuli_wdr.cpp
-msgid "Client software:"
-msgstr "Software client:"
+msgid "User ID"
+msgstr "ID utente"
 
 #: src/muuli_wdr.cpp
-msgid "Client version:"
-msgstr "Versione client:"
-
-#: src/muuli_wdr.cpp src/ServerWnd.cpp
-msgid "IP address:"
-msgstr "Indirizzo IP:"
+msgid "Server IP"
+msgstr "IP server"
 
 #: src/muuli_wdr.cpp
-msgid "User ID:"
-msgstr "ID utente:"
+msgid "Server name"
+msgstr "Nome server"
 
 #: src/muuli_wdr.cpp
-msgid "Server IP:"
-msgstr "IP server:"
-
-#: src/muuli_wdr.cpp
-msgid "Server name:"
-msgstr "Nome server:"
-
-#: src/muuli_wdr.cpp
-msgid "Obfuscation:"
-msgstr "Offuscamento:"
-
-#: src/muuli_wdr.cpp
-msgid "Kad:"
-msgstr "Kad:"
+msgid "Obfuscation"
+msgstr "Offuscamento"
 
 #: src/muuli_wdr.cpp
 msgid "Transfers to client"
 msgstr "Trasferimenti al client"
 
 #: src/muuli_wdr.cpp
-msgid "Current request:"
-msgstr "Richiesta attuale:"
+msgid "Current request"
+msgstr "Richiesta attuale"
 
 #: src/muuli_wdr.cpp
-msgid "Average upload rate:"
-msgstr "Velocità media upload:"
+msgid "Average upload rate"
+msgstr "Velocità media upload"
 
 #: src/muuli_wdr.cpp
-msgid "Average download rate:"
-msgstr "Velocità media download:"
+msgid "Average download rate"
+msgstr "Velocità media download"
 
 #: src/muuli_wdr.cpp
-msgid "Uploaded (session):"
-msgstr "Inviati nella sessione:"
+msgid "Uploaded (session)"
+msgstr "Inviati nella sessione"
 
 #: src/muuli_wdr.cpp
-msgid "Downloaded (session):"
-msgstr "Scaricati nella sessione:"
+msgid "Downloaded (session)"
+msgstr "Scaricati nella sessione"
 
 #: src/muuli_wdr.cpp
-msgid "Uploaded (total):"
-msgstr "Inviati in totale:"
+msgid "Uploaded (total)"
+msgstr "Inviati in totale"
 
 #: src/muuli_wdr.cpp
-msgid "Downloaded (total):"
-msgstr "Scaricati in totale:"
+msgid "Downloaded (total)"
+msgstr "Scaricati in totale"
 
 #: src/muuli_wdr.cpp
 msgid "Scores"
 msgstr "Punteggi"
 
 #: src/muuli_wdr.cpp
-msgid "DL/UP modifier:"
-msgstr "Modificatore DL/UL:"
+msgid "DL/UP modifier"
+msgstr "Modificatore DL/UL"
 
 #: src/muuli_wdr.cpp
-msgid "Secure ident:"
-msgstr "Identificazione sicura:"
+msgid "Secure ident"
+msgstr "Identificazione sicura"
 
 #: src/muuli_wdr.cpp
-msgid "Queue rank:"
-msgstr "Punteggio in coda:"
+msgid "Queue rank"
+msgstr "Punteggio in coda"
 
 #: src/muuli_wdr.cpp
-msgid "Queue score:"
-msgstr "Punteggio in coda:"
+msgid "Queue score"
+msgstr "Punteggio in coda"
 
 #: src/muuli_wdr.cpp
 msgid "Nick"
@@ -4975,24 +4905,20 @@ msgid "Reset any changes made to the preferences."
 msgstr "Annulla ogni modifica alle preferenze."
 
 #: src/muuli_wdr.cpp
-msgid "Comment :"
-msgstr "Commento:"
+msgid "Incoming Dir"
+msgstr "Directory file scaricati"
 
 #: src/muuli_wdr.cpp
-msgid "Incoming Dir :"
-msgstr "Directory file scaricati:"
-
-#: src/muuli_wdr.cpp
-msgid "Change priority for new assigned files :"
-msgstr "Cambia priorità per i nuovi file assegnati:"
+msgid "Change priority for new assigned files"
+msgstr "Cambia priorità per i nuovi file assegnati"
 
 #: src/muuli_wdr.cpp
 msgid "Don't change"
 msgstr "Non modificare"
 
 #: src/muuli_wdr.cpp
-msgid "Select color for this Category (currently selected) :"
-msgstr "Seleziona colore per questa categoria (attualmente selezionata):"
+msgid "Select color for this Category (currently selected)"
+msgstr "Seleziona colore per questa categoria (attualmente selezionata)"
 
 #: src/muuli_wdr.cpp
 msgid "Click this button to reset the log."
@@ -5073,10 +4999,6 @@ msgstr "Bootstrap dal nodo: IP"
 #: src/muuli_wdr.cpp
 msgid "Enter the IP of the node here, using the x.x.x.x format."
 msgstr "Inserisci qui l'indirizzo IP del nodo, utilizzando il formato x.x.x.x."
-
-#: src/muuli_wdr.cpp
-msgid "Port:"
-msgstr "Porta:"
 
 #: src/muuli_wdr.cpp
 msgid "Use Secure User Identification"
@@ -5353,20 +5275,20 @@ msgid "Enable/disable proxy support"
 msgstr "Abilita o disabilita il supporto proxy"
 
 #: src/muuli_wdr.cpp
-msgid "Proxy type:"
-msgstr "Tipo proxy:"
+msgid "Proxy type"
+msgstr "Tipo proxy"
 
 #: src/muuli_wdr.cpp
-msgid "Proxy host:"
-msgstr "Indirizzo proxy:"
+msgid "Proxy host"
+msgstr "Indirizzo proxy"
 
 #: src/muuli_wdr.cpp
 msgid "The proxy host name"
 msgstr "Il nome host del proxy"
 
 #: src/muuli_wdr.cpp
-msgid "Proxy port:"
-msgstr "Porta proxy:"
+msgid "Proxy port"
+msgstr "Porta proxy"
 
 #: src/muuli_wdr.cpp
 msgid "The proxy port"
@@ -5381,16 +5303,8 @@ msgid "Enable/disable username/password authentication"
 msgstr "Abilita o disabilita l'autenticazione con nome utente e password"
 
 #: src/muuli_wdr.cpp
-msgid "Username: "
-msgstr "Nome utente: "
-
-#: src/muuli_wdr.cpp
 msgid "The username to use to connect to the proxy"
 msgstr "Nome utente utilizzato per la connessione al proxy"
-
-#: src/muuli_wdr.cpp
-msgid "Password:"
-msgstr "Password:"
 
 #: src/muuli_wdr.cpp
 msgid "The password to use to connect to the proxy"
@@ -5563,6 +5477,15 @@ msgstr "ore"
 #: src/OtherFunctions.cpp
 msgid "days"
 msgstr "giorni"
+
+#. TRANSLATORS:
+#. Punctuation for a "label: value" pair. %s is the already-translated
+#. label. Place the colon as your language requires -- e.g. "%s :" with a
+#. space in French, "%s:" without one in Russian and English.
+#: src/OtherFunctions.cpp
+#, c-format
+msgid "%s:"
+msgstr ""
 
 #: src/OtherFunctions.cpp
 msgid "all"
@@ -6593,8 +6516,7 @@ msgstr "Condividerle ricorsivamente pubblicherà ogni file al loro interno sulle
 msgid "Confirm shared folders"
 msgstr "Conferma cartelle condivise"
 
-#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp
-#: src/SharedFilesReloadProgress.cpp
+#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp src/SharedFilesReloadProgress.cpp
 msgid "Reloading shared files..."
 msgstr "Ricarica file condivisi in corso..."
 
@@ -6723,18 +6645,6 @@ msgstr "Errore %u: %s\n"
 #: src/SearchListCtrl.cpp
 msgid "FileID"
 msgstr "ID File"
-
-#: src/SearchListCtrl.cpp
-msgid "Length"
-msgstr "Durata"
-
-#: src/SearchListCtrl.cpp
-msgid "Bitrate"
-msgstr "Bitrate"
-
-#: src/SearchListCtrl.cpp
-msgid "Codec"
-msgstr "Codec"
 
 #: src/SearchListCtrl.cpp
 msgid "Expand all"
@@ -7012,10 +6922,6 @@ msgstr "Il server locale è filtrato dal filtro IP, mi connetto a un altro serve
 #: src/ServerListCtrl.cpp
 msgid "Server Name"
 msgstr "Nome server"
-
-#: src/ServerListCtrl.cpp
-msgid "Port"
-msgstr "Porta"
 
 #: src/ServerListCtrl.cpp
 msgid "Description"
@@ -7302,6 +7208,10 @@ msgstr "Connessione in corso all'amico"
 #, c-format
 msgid "Connected to buddy at %s"
 msgstr "Connesso all'amico a %s"
+
+#: src/ServerWnd.cpp
+msgid "IP address:"
+msgstr "Indirizzo IP:"
 
 #: src/ServerWnd.cpp
 msgid "Indexed sources:"

--- a/po/ja.po
+++ b/po/ja.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-04 12:13+0200\n"
+"POT-Creation-Date: 2026-09-05 12:01+0200\n"
 "PO-Revision-Date: 2026-09-03 11:06+0000\n"
 "Last-Translator: \n"
 "Language-Team: Japanese\n"
@@ -386,8 +386,7 @@ msgstr ""
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr ""
 
-#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
-#: src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
+#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
 msgid "ERROR"
 msgstr ""
 
@@ -675,8 +674,7 @@ msgstr "ネットワーク"
 msgid "Searches"
 msgstr "検索"
 
-#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/Statistics.cpp
+#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/Statistics.cpp
 msgid "Downloads"
 msgstr "ダウンロード数"
 
@@ -760,9 +758,7 @@ msgstr "Kad: オフ"
 msgid "Core"
 msgstr ""
 
-#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#: src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp
-#: src/SourceListCtrl.cpp src/Statistics.cpp
+#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp src/Statistics.cpp
 msgid "Version"
 msgstr "バージョン"
 
@@ -1067,11 +1063,7 @@ msgstr ""
 msgid "The remote core sent inconsistent data for \"%s\" (part status %d, expected %d). The file list may be showing the wrong information; reconnect to clear it."
 msgstr ""
 
-#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp
-#: src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp
-#: src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp
-#: src/Statistics.cpp
+#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp src/Statistics.cpp
 msgid "Unknown"
 msgstr "不明"
 
@@ -1167,8 +1159,7 @@ msgstr "known.metファイル%sを保存する時にIOエラーが発生しま�
 msgid "Enter Captcha"
 msgstr ""
 
-#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp
-#: src/TransferWnd.cpp
+#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp src/TransferWnd.cpp
 msgid "Category"
 msgstr "カテゴリ"
 
@@ -1324,13 +1315,11 @@ msgstr "'cryptkey.dat'が見つかりませんでした。生成します。"
 msgid "Client Details"
 msgstr "クライアントの詳細"
 
-#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
-#: src/utils/wxCas/src/onlinesig.cpp
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
 msgid "LowID"
 msgstr "LowID"
 
-#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
-#: src/utils/wxCas/src/onlinesig.cpp
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
 msgid "HighID"
 msgstr "HighID"
 
@@ -1346,8 +1335,7 @@ msgstr "サポート"
 msgid "Not supported"
 msgstr "非サポート"
 
-#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
-#: src/TextClient.cpp
+#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp src/TextClient.cpp
 msgid "Connected"
 msgstr "接続"
 
@@ -1355,28 +1343,24 @@ msgstr "接続"
 msgid "Disconnected"
 msgstr "切断"
 
-#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp
-#: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f KiB/s"
 msgstr ""
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#, fuzzy
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/muuli_wdr.cpp
 msgid "Name"
-msgstr "名前："
+msgstr "名前"
 
 #: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
 msgid "Software"
 msgstr ""
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#, fuzzy
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/muuli_wdr.cpp
 msgid "IP Address"
-msgstr "IPアドレス："
+msgstr "IPアドレス"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Origin"
 msgstr ""
 
@@ -1394,14 +1378,12 @@ msgstr "最後に受信した時刻"
 msgid "Sessions"
 msgstr "バージョン"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp
 #, fuzzy
 msgid "Upload Speed"
 msgstr "アップロード速度"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp
 #, fuzzy
 msgid "Download Speed"
 msgstr "ダウンロード速度："
@@ -1456,13 +1438,11 @@ msgstr[0] ""
 msgid "Files"
 msgstr "ファイル"
 
-#: src/ClientsListCtrl.cpp src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp
-#: src/SourceListCtrl.cpp
+#: src/ClientsListCtrl.cpp src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Uploaded"
 msgstr "アップロード済み"
 
-#: src/ClientsListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientsListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Downloaded"
 msgstr "ダウンロード済み"
 
@@ -1549,12 +1529,11 @@ msgstr "ユーザ %s（%u）は共有ファイルまたはディレクトリ・�
 msgid "File Comments"
 msgstr "ファイル・コメント"
 
-#: src/CommentDialogLst.cpp src/FriendListCtrl.cpp
+#: src/CommentDialogLst.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
 msgid "Username"
 msgstr "ユーザ名"
 
-#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp
-#: src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "File Name"
 msgstr "ファイル名"
 
@@ -1562,7 +1541,7 @@ msgstr "ファイル名"
 msgid "Rating"
 msgstr "評価"
 
-#: src/CommentDialogLst.cpp
+#: src/CommentDialogLst.cpp src/muuli_wdr.cpp
 msgid "Comment"
 msgstr "コメント"
 
@@ -1614,18 +1593,15 @@ msgstr "オート [Hi]"
 msgid "Very low"
 msgstr "非常に低い"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Low"
 msgstr "低い"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Normal"
 msgstr "普通"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "High"
 msgstr "高い"
 
@@ -1649,13 +1625,11 @@ msgstr "サーバ経由に接続中"
 msgid "Queue Full"
 msgstr "キューが一杯"
 
-#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp
-#: src/muuli_wdr.cpp
+#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp src/muuli_wdr.cpp
 msgid "On Queue"
 msgstr "キューに入っています"
 
-#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp
-#: src/PartFile.cpp src/TransferWnd.cpp
+#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Downloading"
 msgstr "ダウンロード"
 
@@ -1715,8 +1689,7 @@ msgstr "ローカルサーバ"
 msgid "Remote Server"
 msgstr "リモートサーバ"
 
-#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp
-#: src/TextClient.cpp
+#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp src/TextClient.cpp
 msgid "Kad"
 msgstr "Kad"
 
@@ -1740,8 +1713,7 @@ msgstr "ソースシード"
 msgid "Search Result"
 msgstr ""
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp
-#: src/TransferWnd.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Completed"
 msgstr "完成された数"
 
@@ -1794,8 +1766,7 @@ msgstr ""
 msgid "Part"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp
-#: src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Size"
 msgstr "サイズ"
 
@@ -1803,8 +1774,7 @@ msgstr "サイズ"
 msgid "Transferred"
 msgstr "転送済み"
 
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
-#: src/SourceListCtrl.cpp
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp src/SourceListCtrl.cpp
 msgid "Speed"
 msgstr "スピード"
 
@@ -1812,13 +1782,11 @@ msgstr "スピード"
 msgid "Progress"
 msgstr "進捗状況"
 
-#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp
-#: src/SearchListCtrl.cpp
+#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
 msgid "Sources"
 msgstr "ソース数"
 
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp
-#: src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Priority"
 msgstr "優先度"
 
@@ -1842,9 +1810,7 @@ msgstr "最後に受信した時刻"
 msgid "Auto"
 msgstr "自動"
 
-#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/TransferWnd.cpp
-#: src/utils/wxCas/src/wxcasprefs.cpp
+#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/TransferWnd.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Cancel"
 msgstr "キャンセル"
 
@@ -1945,8 +1911,7 @@ msgstr "このファイルの新しい名前を入力してください："
 msgid "File rename"
 msgstr "ファイルの改名"
 
-#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp
-#: src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f MiB/s"
 msgstr ""
@@ -2754,13 +2719,11 @@ msgstr ""
 msgid "Start aMule automatically when I log in"
 msgstr ""
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
-#: packaging/windows/installer_strings.c
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp packaging/windows/installer_strings.c
 msgid "Register aMule for ed2k:// links"
 msgstr ""
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
-#: packaging/windows/installer_strings.c
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp packaging/windows/installer_strings.c
 msgid "Register aMule for magnet: links"
 msgstr ""
 
@@ -2786,8 +2749,7 @@ msgstr ""
 msgid "Destination folder for downloads"
 msgstr ""
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
-#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Browse"
 msgstr "閲覧"
 
@@ -3227,18 +3189,15 @@ msgstr "完了中"
 msgid "Complete"
 msgstr "完了"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
-#: src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Paused"
 msgstr "停止"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
-#: src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Erroneous"
 msgstr "エラーあり"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
-#: src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Waiting"
 msgstr "待機"
 
@@ -3400,8 +3359,7 @@ msgstr "閉じる"
 msgid "Cut"
 msgstr "カット"
 
-#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp
-#: src/utils/aLinkCreator/src/alcframe.cpp
+#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy"
 msgstr "コピー"
 
@@ -3409,8 +3367,7 @@ msgstr "コピー"
 msgid "Paste"
 msgstr "ペースト"
 
-#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp
-#: src/utils/aLinkCreator/src/alcframe.cpp
+#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Clear"
 msgstr "クリア"
 
@@ -3418,8 +3375,7 @@ msgstr "クリア"
 msgid "Select All"
 msgstr "全ての選択"
 
-#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
-#: src/StatisticsDlg.cpp
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp src/StatisticsDlg.cpp
 msgid "KiB/s"
 msgstr ""
 
@@ -3682,10 +3638,6 @@ msgstr "現在接続しているサーバ。"
 msgid "Search"
 msgstr "検索"
 
-#: src/muuli_wdr.cpp
-msgid "Name:"
-msgstr "名前："
-
 #: src/muuli_wdr.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Type"
 msgstr "タイプ"
@@ -3775,8 +3727,8 @@ msgid "Availability"
 msgstr "入手可能範囲"
 
 #: src/muuli_wdr.cpp
-msgid "Filter:"
-msgstr "フィルタ："
+msgid "Filter"
+msgstr "フィルタ"
 
 #: src/muuli_wdr.cpp
 msgid "Invert Result"
@@ -3834,6 +3786,10 @@ msgid "Clears completed downloads"
 msgstr "完成したダウンロードをクリアします"
 
 #: src/muuli_wdr.cpp
+msgid "Filter:"
+msgstr "フィルタ："
+
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "File sources:"
 msgstr "ソース完了"
@@ -3843,80 +3799,76 @@ msgid "General"
 msgstr "一般"
 
 #: src/muuli_wdr.cpp
-msgid "Full Name :"
-msgstr "完全名："
+msgid "Full Name"
+msgstr "完全名"
 
 #: src/muuli_wdr.cpp
-msgid "met-File :"
-msgstr "metファイル："
+msgid "met-File"
+msgstr "metファイル"
 
 #: src/muuli_wdr.cpp
-msgid "Hash :"
-msgstr "ハッシュ："
+msgid "Hash"
+msgstr "ハッシュ"
 
 #: src/muuli_wdr.cpp
-msgid "Filesize :"
-msgstr "ファイル・サイズ："
+msgid "Filesize"
+msgstr "ファイル・サイズ"
 
 #: src/muuli_wdr.cpp src/Statistics.cpp
 msgid "Transfer"
 msgstr "転送"
 
 #: src/muuli_wdr.cpp
-msgid "Partfilestatus :"
-msgstr "部分ファイルの状態："
+msgid "Partfilestatus"
+msgstr "部分ファイルの状態"
 
 #: src/muuli_wdr.cpp
-msgid "Last seen complete :"
-msgstr "最後に完全として見た時間："
+msgid "Last seen complete"
+msgstr "最後に完全として見た時間"
 
 #: src/muuli_wdr.cpp
-msgid "Found Sources :"
-msgstr "見つかったソース："
+msgid "Found Sources"
+msgstr "見つかったソース"
 
 #: src/muuli_wdr.cpp
-msgid "Transferring Sources :"
-msgstr "転送中のソース："
+msgid "Transferring Sources"
+msgstr "転送中のソース"
 
 #: src/muuli_wdr.cpp
-msgid "Filepart-Count :"
-msgstr "ファイル部分の数："
+msgid "Filepart-Count"
+msgstr "ファイル部分の数"
 
 #: src/muuli_wdr.cpp
-msgid "Available :"
-msgstr "入手可能数："
+msgid "Available"
+msgstr "入手可能数"
 
 #: src/muuli_wdr.cpp
-msgid "Datarate :"
-msgstr "データ・レート："
+msgid "Datarate"
+msgstr "データ・レート"
 
 #: src/muuli_wdr.cpp
-msgid "Download Active Time: "
-msgstr "ダウンロードのアクティブ時間："
+msgid "Download Active Time"
+msgstr "ダウンロードのアクティブ時間"
 
 #: src/muuli_wdr.cpp
-msgid "Transferred :"
-msgstr "転送済み："
-
-#: src/muuli_wdr.cpp
-msgid "Completed Size :"
-msgstr "完全サイズ："
+msgid "Completed Size"
+msgstr "完全サイズ"
 
 #: src/muuli_wdr.cpp
 msgid "Intelligent Corruption Handling"
 msgstr "I.C.H.（知的破損処理）"
 
 #: src/muuli_wdr.cpp
-msgid "Lost to corruption :"
-msgstr "破損による損失："
+msgid "Lost to corruption"
+msgstr "破損による損失"
 
 #: src/muuli_wdr.cpp
-msgid "Gained by compression :"
-msgstr "圧縮による獲得："
+msgid "Gained by compression"
+msgstr "圧縮による獲得"
 
 #: src/muuli_wdr.cpp
-msgid "Packages saved by I.C.H. :"
-msgstr "I.C.H.に救済されたパケット："
+msgid "Packages saved by I.C.H."
+msgstr "I.C.H.に救済されたパケット"
 
 #: src/muuli_wdr.cpp
 #, fuzzy
@@ -3958,30 +3910,30 @@ msgstr "、 アップロード： "
 msgid "Media Info"
 msgstr "Kad情報"
 
-#: src/muuli_wdr.cpp
-msgid "Length :"
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
+msgid "Length"
 msgstr ""
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
 #, fuzzy
-msgid "Bitrate :"
+msgid "Bitrate"
 msgstr "評価されていません"
 
-#: src/muuli_wdr.cpp
-msgid "Codec :"
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
+msgid "Codec"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Artist :"
+msgid "Artist"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Album :"
+msgid "Album"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Title :"
-msgstr "タイトル："
+msgid "Title"
+msgstr "タイトル"
 
 #: src/muuli_wdr.cpp
 msgid "File Names"
@@ -4066,25 +4018,17 @@ msgstr "サイズが不明です"
 msgid "Required Information"
 msgstr "不可欠な情報"
 
-#: src/muuli_wdr.cpp
-msgid "IP Address :"
-msgstr "IPアドレス："
-
-#: src/muuli_wdr.cpp
-msgid "Port :"
-msgstr "ポート："
+#: src/muuli_wdr.cpp src/ServerListCtrl.cpp
+msgid "Port"
+msgstr "ポート"
 
 #: src/muuli_wdr.cpp
 msgid "Additional Information"
 msgstr "追加情報"
 
 #: src/muuli_wdr.cpp
-msgid "Username :"
-msgstr "ユーザ名："
-
-#: src/muuli_wdr.cpp
-msgid "Userhash :"
-msgstr "ユーザ・ハッシュ："
+msgid "Userhash"
+msgstr "ユーザ・ハッシュ"
 
 #: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Add"
@@ -4119,97 +4063,81 @@ msgid "Statistics Tree"
 msgstr "統計木"
 
 #: src/muuli_wdr.cpp
-msgid "Username:"
-msgstr "ユーザ名："
+msgid "Client software"
+msgstr "クライアント・ソフトウェア"
 
 #: src/muuli_wdr.cpp
-msgid "Userhash:"
-msgstr "ユーザ・ハッシュ："
+msgid "Client version"
+msgstr "クライアント・バージョン"
 
 #: src/muuli_wdr.cpp
-msgid "Client software:"
-msgstr "クライアント・ソフトウェア："
+msgid "User ID"
+msgstr "ユーザID"
 
 #: src/muuli_wdr.cpp
-msgid "Client version:"
-msgstr "クライアント・バージョン："
-
-#: src/muuli_wdr.cpp src/ServerWnd.cpp
-msgid "IP address:"
-msgstr "IPアドレス："
+msgid "Server IP"
+msgstr "サーバIP"
 
 #: src/muuli_wdr.cpp
-msgid "User ID:"
-msgstr "ユーザID："
+msgid "Server name"
+msgstr "サーバ名"
 
 #: src/muuli_wdr.cpp
-msgid "Server IP:"
-msgstr "サーバIP："
-
-#: src/muuli_wdr.cpp
-msgid "Server name:"
-msgstr "サーバ名："
-
-#: src/muuli_wdr.cpp
-msgid "Obfuscation:"
-msgstr "難読化:"
-
-#: src/muuli_wdr.cpp
-msgid "Kad:"
-msgstr "Kad:"
+msgid "Obfuscation"
+msgstr "難読化"
 
 #: src/muuli_wdr.cpp
 msgid "Transfers to client"
 msgstr "クライアントへの転送数"
 
 #: src/muuli_wdr.cpp
-msgid "Current request:"
-msgstr "現在の要求："
+msgid "Current request"
+msgstr "現在の要求"
 
 #: src/muuli_wdr.cpp
-msgid "Average upload rate:"
-msgstr "平均アップロード速度："
+msgid "Average upload rate"
+msgstr "平均アップロード速度"
 
 #: src/muuli_wdr.cpp
-msgid "Average download rate:"
-msgstr "平均ダウンロード速度："
+msgid "Average download rate"
+msgstr "平均ダウンロード速度"
 
 #: src/muuli_wdr.cpp
-msgid "Uploaded (session):"
-msgstr "アップロード（セッション）："
+msgid "Uploaded (session)"
+msgstr "アップロード（セッション）"
 
 #: src/muuli_wdr.cpp
-msgid "Downloaded (session):"
-msgstr "ダウンロード（セッション）："
+msgid "Downloaded (session)"
+msgstr "ダウンロード（セッション）"
 
 #: src/muuli_wdr.cpp
-msgid "Uploaded (total):"
-msgstr "アップロード（合計）："
+msgid "Uploaded (total)"
+msgstr "アップロード（合計）"
 
 #: src/muuli_wdr.cpp
-msgid "Downloaded (total):"
-msgstr "ダウンロード（合計）："
+msgid "Downloaded (total)"
+msgstr "ダウンロード（合計）"
 
 #: src/muuli_wdr.cpp
 msgid "Scores"
 msgstr "スコア"
 
 #: src/muuli_wdr.cpp
-msgid "DL/UP modifier:"
-msgstr "DL/UP変更："
+msgid "DL/UP modifier"
+msgstr "DL/UP変更"
 
 #: src/muuli_wdr.cpp
-msgid "Secure ident:"
-msgstr "セキュア認証："
+msgid "Secure ident"
+msgstr "セキュア認証"
 
 #: src/muuli_wdr.cpp
 #, fuzzy
-msgid "Queue rank:"
+msgid "Queue rank"
 msgstr "キューに追加しました"
 
 #: src/muuli_wdr.cpp
-msgid "Queue score:"
-msgstr "キュースコア："
+msgid "Queue score"
+msgstr "キュースコア"
 
 #: src/muuli_wdr.cpp
 msgid "Nick"
@@ -5001,16 +4929,12 @@ msgid "Reset any changes made to the preferences."
 msgstr "設定の変更を全てリセットする"
 
 #: src/muuli_wdr.cpp
-msgid "Comment :"
-msgstr "コメント："
+msgid "Incoming Dir"
+msgstr "受信ディレクトリ"
 
 #: src/muuli_wdr.cpp
-msgid "Incoming Dir :"
-msgstr "受信ディレクトリ："
-
-#: src/muuli_wdr.cpp
-msgid "Change priority for new assigned files :"
-msgstr "新しく割り当てられたファイルの優先度を変更する："
+msgid "Change priority for new assigned files"
+msgstr "新しく割り当てられたファイルの優先度を変更する"
 
 #: src/muuli_wdr.cpp
 #, fuzzy
@@ -5018,8 +4942,8 @@ msgid "Don't change"
 msgstr "変更しない"
 
 #: src/muuli_wdr.cpp
-msgid "Select color for this Category (currently selected) :"
-msgstr "このカテゴリの色を選択する（現在選択中）："
+msgid "Select color for this Category (currently selected)"
+msgstr "このカテゴリの色を選択する（現在選択中）"
 
 #: src/muuli_wdr.cpp
 msgid "Click this button to reset the log."
@@ -5104,10 +5028,6 @@ msgstr ""
 #, fuzzy
 msgid "Enter the IP of the node here, using the x.x.x.x format."
 msgstr "x.x.x.xフォーマットでサーバのIPアドレスを入力してください。"
-
-#: src/muuli_wdr.cpp
-msgid "Port:"
-msgstr "ポート："
 
 #: src/muuli_wdr.cpp
 msgid "Use Secure User Identification"
@@ -5376,20 +5296,20 @@ msgid "Enable/disable proxy support"
 msgstr "プロクシ・サポートを有効／無効にする"
 
 #: src/muuli_wdr.cpp
-msgid "Proxy type:"
-msgstr "プロクシの種類："
+msgid "Proxy type"
+msgstr "プロクシの種類"
 
 #: src/muuli_wdr.cpp
-msgid "Proxy host:"
-msgstr "プロクシー・ホスト："
+msgid "Proxy host"
+msgstr "プロクシー・ホスト"
 
 #: src/muuli_wdr.cpp
 msgid "The proxy host name"
 msgstr "プロクシー・ホスト名："
 
 #: src/muuli_wdr.cpp
-msgid "Proxy port:"
-msgstr "プロクシー・ポート："
+msgid "Proxy port"
+msgstr "プロクシー・ポート"
 
 #: src/muuli_wdr.cpp
 msgid "The proxy port"
@@ -5404,16 +5324,8 @@ msgid "Enable/disable username/password authentication"
 msgstr "ユーザ名／パスワード認証を有効／無効にする"
 
 #: src/muuli_wdr.cpp
-msgid "Username: "
-msgstr ""
-
-#: src/muuli_wdr.cpp
 msgid "The username to use to connect to the proxy"
 msgstr "プロクシーに接続に使うユーザ名"
-
-#: src/muuli_wdr.cpp
-msgid "Password:"
-msgstr "パスワード："
 
 #: src/muuli_wdr.cpp
 msgid "The password to use to connect to the proxy"
@@ -5593,6 +5505,15 @@ msgstr "時間"
 #: src/OtherFunctions.cpp
 msgid "days"
 msgstr "日"
+
+#. TRANSLATORS:
+#. Punctuation for a "label: value" pair. %s is the already-translated
+#. label. Place the colon as your language requires -- e.g. "%s :" with a
+#. space in French, "%s:" without one in Russian and English.
+#: src/OtherFunctions.cpp
+#, c-format
+msgid "%s:"
+msgstr ""
 
 #: src/OtherFunctions.cpp
 msgid "all"
@@ -6629,8 +6550,7 @@ msgstr ""
 msgid "Confirm shared folders"
 msgstr "共有ファイルを再ロードする"
 
-#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp
-#: src/SharedFilesReloadProgress.cpp
+#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp src/SharedFilesReloadProgress.cpp
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "共有ファイルを再ロードする"
@@ -6762,19 +6682,6 @@ msgstr ""
 #: src/SearchListCtrl.cpp
 msgid "FileID"
 msgstr "ファイルID"
-
-#: src/SearchListCtrl.cpp
-msgid "Length"
-msgstr ""
-
-#: src/SearchListCtrl.cpp
-#, fuzzy
-msgid "Bitrate"
-msgstr "評価されていません"
-
-#: src/SearchListCtrl.cpp
-msgid "Codec"
-msgstr ""
 
 #: src/SearchListCtrl.cpp
 msgid "Expand all"
@@ -7058,10 +6965,6 @@ msgstr "ローカル・サーバはIPFiltersにフィルタされているため
 #: src/ServerListCtrl.cpp
 msgid "Server Name"
 msgstr "サーバ名"
-
-#: src/ServerListCtrl.cpp
-msgid "Port"
-msgstr "ポート"
 
 #: src/ServerListCtrl.cpp
 msgid "Description"
@@ -7358,6 +7261,10 @@ msgstr "仲間と接続しています"
 #, fuzzy, c-format
 msgid "Connected to buddy at %s"
 msgstr "仲間と接続しています"
+
+#: src/ServerWnd.cpp
+msgid "IP address:"
+msgstr "IPアドレス："
 
 #: src/ServerWnd.cpp
 #, fuzzy

--- a/po/ko_KR.po
+++ b/po/ko_KR.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-04 12:13+0200\n"
+"POT-Creation-Date: 2026-09-05 12:01+0200\n"
 "PO-Revision-Date: 2026-09-03 11:06+0000\n"
 "Last-Translator: Hyunju Kang <rexington@gmail.com>\n"
 "Language-Team: Korean <hoenny@daum.net>\n"
@@ -385,8 +385,7 @@ msgstr ""
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr ""
 
-#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
-#: src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
+#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
 msgid "ERROR"
 msgstr ""
 
@@ -674,8 +673,7 @@ msgstr "통신망"
 msgid "Searches"
 msgstr "검색"
 
-#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/Statistics.cpp
+#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/Statistics.cpp
 msgid "Downloads"
 msgstr "내려받기"
 
@@ -763,9 +761,7 @@ msgstr " Kad: "
 msgid "Core"
 msgstr ""
 
-#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#: src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp
-#: src/SourceListCtrl.cpp src/Statistics.cpp
+#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp src/Statistics.cpp
 msgid "Version"
 msgstr "버젼"
 
@@ -1070,11 +1066,7 @@ msgstr ""
 msgid "The remote core sent inconsistent data for \"%s\" (part status %d, expected %d). The file list may be showing the wrong information; reconnect to clear it."
 msgstr ""
 
-#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp
-#: src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp
-#: src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp
-#: src/Statistics.cpp
+#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp src/Statistics.cpp
 msgid "Unknown"
 msgstr "알수없는"
 
@@ -1172,8 +1164,7 @@ msgstr "known.met 파일을 저장하는 동안 오류: %s"
 msgid "Enter Captcha"
 msgstr ""
 
-#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp
-#: src/TransferWnd.cpp
+#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp src/TransferWnd.cpp
 msgid "Category"
 msgstr "분류"
 
@@ -1337,13 +1328,11 @@ msgstr "'cryptkey.dat' 파일을 찾을 수 없습니다. 생성합니다."
 msgid "Client Details"
 msgstr "클라이언트 세부내역"
 
-#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
-#: src/utils/wxCas/src/onlinesig.cpp
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
 msgid "LowID"
 msgstr "낮은아이디"
 
-#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
-#: src/utils/wxCas/src/onlinesig.cpp
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
 msgid "HighID"
 msgstr "높은아이디"
 
@@ -1359,8 +1348,7 @@ msgstr ""
 msgid "Not supported"
 msgstr ""
 
-#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
-#: src/TextClient.cpp
+#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp src/TextClient.cpp
 msgid "Connected"
 msgstr "연결됨"
 
@@ -1368,28 +1356,24 @@ msgstr "연결됨"
 msgid "Disconnected"
 msgstr "연결이 끊김"
 
-#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp
-#: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f KiB/s"
 msgstr ""
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#, fuzzy
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/muuli_wdr.cpp
 msgid "Name"
-msgstr "이름:"
+msgstr "이름"
 
 #: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
 msgid "Software"
 msgstr ""
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#, fuzzy
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/muuli_wdr.cpp
 msgid "IP Address"
-msgstr "IP 주소 :"
+msgstr "IP 주소"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Origin"
 msgstr ""
 
@@ -1407,14 +1391,12 @@ msgstr "최종 받음"
 msgid "Sessions"
 msgstr "버젼"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp
 #, fuzzy
 msgid "Upload Speed"
 msgstr "올려주기 속도"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp
 #, fuzzy
 msgid "Download Speed"
 msgstr "내려받기 속도"
@@ -1470,13 +1452,11 @@ msgstr[1] ""
 msgid "Files"
 msgstr "파일"
 
-#: src/ClientsListCtrl.cpp src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp
-#: src/SourceListCtrl.cpp
+#: src/ClientsListCtrl.cpp src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Uploaded"
 msgstr ""
 
-#: src/ClientsListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientsListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Downloaded"
 msgstr ""
 
@@ -1563,12 +1543,11 @@ msgstr "사용자 %s (%u)는 공유파일이나 공유폴더 목록에 접근하
 msgid "File Comments"
 msgstr "파일 의견"
 
-#: src/CommentDialogLst.cpp src/FriendListCtrl.cpp
+#: src/CommentDialogLst.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
 msgid "Username"
 msgstr "사용자이름"
 
-#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp
-#: src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "File Name"
 msgstr "파일 이름"
 
@@ -1576,7 +1555,7 @@ msgstr "파일 이름"
 msgid "Rating"
 msgstr "등급"
 
-#: src/CommentDialogLst.cpp
+#: src/CommentDialogLst.cpp src/muuli_wdr.cpp
 msgid "Comment"
 msgstr "의견"
 
@@ -1629,18 +1608,15 @@ msgstr "자동[높음]"
 msgid "Very low"
 msgstr "매우 낮음"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Low"
 msgstr "낮음"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Normal"
 msgstr "보통"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "High"
 msgstr "높음"
 
@@ -1664,13 +1640,11 @@ msgstr "서버를 경유하여 연결중"
 msgid "Queue Full"
 msgstr "대기열이 가득참"
 
-#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp
-#: src/muuli_wdr.cpp
+#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp src/muuli_wdr.cpp
 msgid "On Queue"
 msgstr "대기열에"
 
-#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp
-#: src/PartFile.cpp src/TransferWnd.cpp
+#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Downloading"
 msgstr "받는중"
 
@@ -1730,8 +1704,7 @@ msgstr "지역 서버"
 msgid "Remote Server"
 msgstr "원격 서버"
 
-#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp
-#: src/TextClient.cpp
+#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp src/TextClient.cpp
 msgid "Kad"
 msgstr "Kad"
 
@@ -1755,8 +1728,7 @@ msgstr "자료 핵"
 msgid "Search Result"
 msgstr ""
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp
-#: src/TransferWnd.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Completed"
 msgstr "완료됨"
 
@@ -1808,8 +1780,7 @@ msgstr ""
 msgid "Part"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp
-#: src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Size"
 msgstr "크기"
 
@@ -1817,8 +1788,7 @@ msgstr "크기"
 msgid "Transferred"
 msgstr "전송됨"
 
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
-#: src/SourceListCtrl.cpp
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp src/SourceListCtrl.cpp
 msgid "Speed"
 msgstr "속도"
 
@@ -1826,13 +1796,11 @@ msgstr "속도"
 msgid "Progress"
 msgstr "진척"
 
-#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp
-#: src/SearchListCtrl.cpp
+#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
 msgid "Sources"
 msgstr "자료"
 
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp
-#: src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Priority"
 msgstr "우선권"
 
@@ -1856,9 +1824,7 @@ msgstr "최종 받음"
 msgid "Auto"
 msgstr "자동"
 
-#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/TransferWnd.cpp
-#: src/utils/wxCas/src/wxcasprefs.cpp
+#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/TransferWnd.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Cancel"
 msgstr "취소"
 
@@ -1959,8 +1925,7 @@ msgstr "새이름 넣으세요:"
 msgid "File rename"
 msgstr "파일 이름변경"
 
-#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp
-#: src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f MiB/s"
 msgstr ""
@@ -2770,13 +2735,11 @@ msgstr ""
 msgid "Start aMule automatically when I log in"
 msgstr ""
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
-#: packaging/windows/installer_strings.c
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp packaging/windows/installer_strings.c
 msgid "Register aMule for ed2k:// links"
 msgstr ""
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
-#: packaging/windows/installer_strings.c
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp packaging/windows/installer_strings.c
 msgid "Register aMule for magnet: links"
 msgstr ""
 
@@ -2802,8 +2765,7 @@ msgstr ""
 msgid "Destination folder for downloads"
 msgstr ""
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
-#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Browse"
 msgstr "탐색"
 
@@ -3252,18 +3214,15 @@ msgstr "완료중"
 msgid "Complete"
 msgstr "완료"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
-#: src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Paused"
 msgstr "중지됨"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
-#: src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Erroneous"
 msgstr "오류투성이"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
-#: src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Waiting"
 msgstr "대기중"
 
@@ -3429,8 +3388,7 @@ msgstr "닫기"
 msgid "Cut"
 msgstr "자르기"
 
-#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp
-#: src/utils/aLinkCreator/src/alcframe.cpp
+#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy"
 msgstr "복사"
 
@@ -3438,8 +3396,7 @@ msgstr "복사"
 msgid "Paste"
 msgstr "붙이기"
 
-#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp
-#: src/utils/aLinkCreator/src/alcframe.cpp
+#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Clear"
 msgstr "깨끗이"
 
@@ -3447,8 +3404,7 @@ msgstr "깨끗이"
 msgid "Select All"
 msgstr "모두 선택"
 
-#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
-#: src/StatisticsDlg.cpp
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp src/StatisticsDlg.cpp
 msgid "KiB/s"
 msgstr ""
 
@@ -3711,10 +3667,6 @@ msgstr "현재 서버에 연결되었습니다."
 msgid "Search"
 msgstr "검색"
 
-#: src/muuli_wdr.cpp
-msgid "Name:"
-msgstr "이름:"
-
 #: src/muuli_wdr.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Type"
 msgstr "종류"
@@ -3804,8 +3756,8 @@ msgid "Availability"
 msgstr "유효성"
 
 #: src/muuli_wdr.cpp
-msgid "Filter:"
-msgstr "필터:"
+msgid "Filter"
+msgstr "필터"
 
 #: src/muuli_wdr.cpp
 msgid "Invert Result"
@@ -3863,6 +3815,10 @@ msgid "Clears completed downloads"
 msgstr "완료된 내려받기 정리"
 
 #: src/muuli_wdr.cpp
+msgid "Filter:"
+msgstr "필터:"
+
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "File sources:"
 msgstr "자료 유지"
@@ -3872,80 +3828,76 @@ msgid "General"
 msgstr "일반"
 
 #: src/muuli_wdr.cpp
-msgid "Full Name :"
-msgstr "전체 이름 :"
+msgid "Full Name"
+msgstr "전체 이름"
 
 #: src/muuli_wdr.cpp
-msgid "met-File :"
-msgstr "메타파일 :"
+msgid "met-File"
+msgstr "메타파일"
 
 #: src/muuli_wdr.cpp
-msgid "Hash :"
+msgid "Hash"
 msgstr "해시"
 
 #: src/muuli_wdr.cpp
-msgid "Filesize :"
-msgstr "파일 크기 :"
+msgid "Filesize"
+msgstr "파일 크기"
 
 #: src/muuli_wdr.cpp src/Statistics.cpp
 msgid "Transfer"
 msgstr "전송"
 
 #: src/muuli_wdr.cpp
-msgid "Partfilestatus :"
-msgstr "부분파일 상태 :"
+msgid "Partfilestatus"
+msgstr "부분파일 상태"
 
 #: src/muuli_wdr.cpp
-msgid "Last seen complete :"
-msgstr "마지막 부분이 완료 :"
+msgid "Last seen complete"
+msgstr "마지막 부분이 완료"
 
 #: src/muuli_wdr.cpp
-msgid "Found Sources :"
-msgstr "찾은 자료 :"
+msgid "Found Sources"
+msgstr "찾은 자료"
 
 #: src/muuli_wdr.cpp
-msgid "Transferring Sources :"
-msgstr "전송된 자료 :"
+msgid "Transferring Sources"
+msgstr "전송된 자료"
 
 #: src/muuli_wdr.cpp
-msgid "Filepart-Count :"
-msgstr "부분파일 카운트 :"
+msgid "Filepart-Count"
+msgstr "부분파일 카운트"
 
 #: src/muuli_wdr.cpp
-msgid "Available :"
-msgstr "가능함 :"
+msgid "Available"
+msgstr "가능함"
 
 #: src/muuli_wdr.cpp
-msgid "Datarate :"
-msgstr "데이터율 :"
+msgid "Datarate"
+msgstr "데이터율"
 
 #: src/muuli_wdr.cpp
-msgid "Download Active Time: "
-msgstr "내려받기 활성화 시간: "
+msgid "Download Active Time"
+msgstr "내려받기 활성화 시간"
 
 #: src/muuli_wdr.cpp
-msgid "Transferred :"
-msgstr "전송됨 :"
-
-#: src/muuli_wdr.cpp
-msgid "Completed Size :"
-msgstr "완료된 크기 :"
+msgid "Completed Size"
+msgstr "완료된 크기"
 
 #: src/muuli_wdr.cpp
 msgid "Intelligent Corruption Handling"
 msgstr "현명한 오류처리"
 
 #: src/muuli_wdr.cpp
-msgid "Lost to corruption :"
-msgstr "오류로 잃어버림 :"
+msgid "Lost to corruption"
+msgstr "오류로 잃어버림"
 
 #: src/muuli_wdr.cpp
-msgid "Gained by compression :"
-msgstr "압축으로 얻음 :"
+msgid "Gained by compression"
+msgstr "압축으로 얻음"
 
 #: src/muuli_wdr.cpp
-msgid "Packages saved by I.C.H. :"
-msgstr "I.C.H에의해 저장된 패키지 :"
+msgid "Packages saved by I.C.H."
+msgstr "I.C.H에의해 저장된 패키지"
 
 #: src/muuli_wdr.cpp
 #, fuzzy
@@ -3987,30 +3939,30 @@ msgstr ", 올려주기: "
 msgid "Media Info"
 msgstr "Kad 정보"
 
-#: src/muuli_wdr.cpp
-msgid "Length :"
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
+msgid "Length"
 msgstr ""
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
 #, fuzzy
-msgid "Bitrate :"
+msgid "Bitrate"
 msgstr "선택되지 않은"
 
-#: src/muuli_wdr.cpp
-msgid "Codec :"
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
+msgid "Codec"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Artist :"
+msgid "Artist"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Album :"
+msgid "Album"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Title :"
-msgstr "제목 :"
+msgid "Title"
+msgstr "제목"
 
 #: src/muuli_wdr.cpp
 msgid "File Names"
@@ -4095,25 +4047,17 @@ msgstr "알수없는 크기"
 msgid "Required Information"
 msgstr "요구된 정보"
 
-#: src/muuli_wdr.cpp
-msgid "IP Address :"
-msgstr "IP 주소 :"
-
-#: src/muuli_wdr.cpp
-msgid "Port :"
-msgstr "포트 :"
+#: src/muuli_wdr.cpp src/ServerListCtrl.cpp
+msgid "Port"
+msgstr "포트"
 
 #: src/muuli_wdr.cpp
 msgid "Additional Information"
 msgstr "추가적 정보"
 
 #: src/muuli_wdr.cpp
-msgid "Username :"
-msgstr "사용자 이름 :"
-
-#: src/muuli_wdr.cpp
-msgid "Userhash :"
-msgstr "사용자 해시 :"
+msgid "Userhash"
+msgstr "사용자 해시"
 
 #: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Add"
@@ -4148,75 +4092,60 @@ msgid "Statistics Tree"
 msgstr "통계 트리"
 
 #: src/muuli_wdr.cpp
-msgid "Username:"
-msgstr "사용자 이름:"
+msgid "Client software"
+msgstr "클라이언트 소프트웨어"
 
 #: src/muuli_wdr.cpp
-msgid "Userhash:"
-msgstr "사용자 해시:"
+msgid "Client version"
+msgstr "클라이언트 버전"
 
 #: src/muuli_wdr.cpp
-msgid "Client software:"
-msgstr "클라이언트 소프트웨어:"
+msgid "User ID"
+msgstr "사용자 아이디"
 
 #: src/muuli_wdr.cpp
-msgid "Client version:"
-msgstr "클라이언트 버전:"
-
-#: src/muuli_wdr.cpp src/ServerWnd.cpp
-msgid "IP address:"
-msgstr "IP 주소:"
+msgid "Server IP"
+msgstr "서버 IP"
 
 #: src/muuli_wdr.cpp
-msgid "User ID:"
-msgstr "사용자 아이디:"
+msgid "Server name"
+msgstr "서버 이름"
 
 #: src/muuli_wdr.cpp
-msgid "Server IP:"
-msgstr "서버 IP:"
-
-#: src/muuli_wdr.cpp
-msgid "Server name:"
-msgstr "서버 이름:"
-
-#: src/muuli_wdr.cpp
-msgid "Obfuscation:"
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "Kad:"
-msgstr ""
+#, fuzzy
+msgid "Obfuscation"
+msgstr "프로토콜 난독화"
 
 #: src/muuli_wdr.cpp
 msgid "Transfers to client"
 msgstr "클라이언트에 전송"
 
 #: src/muuli_wdr.cpp
-msgid "Current request:"
-msgstr "현재 요청:"
+msgid "Current request"
+msgstr "현재 요청"
 
 #: src/muuli_wdr.cpp
-msgid "Average upload rate:"
-msgstr "평균 올려주기율:"
+msgid "Average upload rate"
+msgstr "평균 올려주기율"
 
 #: src/muuli_wdr.cpp
-msgid "Average download rate:"
-msgstr "평균 내려받기율:"
+msgid "Average download rate"
+msgstr "평균 내려받기율"
 
 #: src/muuli_wdr.cpp
-msgid "Uploaded (session):"
+msgid "Uploaded (session)"
 msgstr "올려주기 (세션)"
 
 #: src/muuli_wdr.cpp
-msgid "Downloaded (session):"
+msgid "Downloaded (session)"
 msgstr "내려받기 (세션)"
 
 #: src/muuli_wdr.cpp
-msgid "Uploaded (total):"
+msgid "Uploaded (total)"
 msgstr "올려주기 (전체)"
 
 #: src/muuli_wdr.cpp
-msgid "Downloaded (total):"
+msgid "Downloaded (total)"
 msgstr "내려받기 (전체)"
 
 #: src/muuli_wdr.cpp
@@ -4224,21 +4153,21 @@ msgid "Scores"
 msgstr "점수"
 
 #: src/muuli_wdr.cpp
-msgid "DL/UP modifier:"
-msgstr "내려받기/올려주기 변경자:"
+msgid "DL/UP modifier"
+msgstr "내려받기/올려주기 변경자"
 
 #: src/muuli_wdr.cpp
-msgid "Secure ident:"
-msgstr "안전한 인증:"
+msgid "Secure ident"
+msgstr "안전한 인증"
 
 #: src/muuli_wdr.cpp
 #, fuzzy
-msgid "Queue rank:"
+msgid "Queue rank"
 msgstr "대기열에 있음"
 
 #: src/muuli_wdr.cpp
-msgid "Queue score:"
-msgstr "대기열 점수:"
+msgid "Queue score"
+msgstr "대기열 점수"
 
 #: src/muuli_wdr.cpp
 msgid "Nick"
@@ -5030,16 +4959,12 @@ msgid "Reset any changes made to the preferences."
 msgstr "환경설정으로 바꾼것을 초기화합니다."
 
 #: src/muuli_wdr.cpp
-msgid "Comment :"
-msgstr "의견 :"
+msgid "Incoming Dir"
+msgstr "내려받는 폴더"
 
 #: src/muuli_wdr.cpp
-msgid "Incoming Dir :"
-msgstr "내려받는 폴더 :"
-
-#: src/muuli_wdr.cpp
-msgid "Change priority for new assigned files :"
-msgstr "새롭게 할당된 파일의 우선권를 바꿉니다. :"
+msgid "Change priority for new assigned files"
+msgstr "새롭게 할당된 파일의 우선권를 바꿉니다."
 
 #: src/muuli_wdr.cpp
 #, fuzzy
@@ -5047,8 +4972,8 @@ msgid "Don't change"
 msgstr "변경 않음"
 
 #: src/muuli_wdr.cpp
-msgid "Select color for this Category (currently selected) :"
-msgstr "이 분류의 색을 선택 (일반적으로 선택된) :"
+msgid "Select color for this Category (currently selected)"
+msgstr "이 분류의 색을 선택 (일반적으로 선택된)"
 
 #: src/muuli_wdr.cpp
 msgid "Click this button to reset the log."
@@ -5133,10 +5058,6 @@ msgstr ""
 #, fuzzy
 msgid "Enter the IP of the node here, using the x.x.x.x format."
 msgstr "x.x.x.x형식으로 서버의 IP를 이곳에 입력하세요."
-
-#: src/muuli_wdr.cpp
-msgid "Port:"
-msgstr "포트:"
 
 #: src/muuli_wdr.cpp
 msgid "Use Secure User Identification"
@@ -5404,20 +5325,20 @@ msgid "Enable/disable proxy support"
 msgstr "프록시지원을 활성화/비활성화"
 
 #: src/muuli_wdr.cpp
-msgid "Proxy type:"
-msgstr "프록시 종류:"
+msgid "Proxy type"
+msgstr "프록시 종류"
 
 #: src/muuli_wdr.cpp
-msgid "Proxy host:"
-msgstr "프록시 호스트:"
+msgid "Proxy host"
+msgstr "프록시 호스트"
 
 #: src/muuli_wdr.cpp
 msgid "The proxy host name"
 msgstr "프록시 호스트 이름"
 
 #: src/muuli_wdr.cpp
-msgid "Proxy port:"
-msgstr "프록시 포트:"
+msgid "Proxy port"
+msgstr "프록시 포트"
 
 #: src/muuli_wdr.cpp
 msgid "The proxy port"
@@ -5432,16 +5353,8 @@ msgid "Enable/disable username/password authentication"
 msgstr "사용자이름/암호 인증을 활성화/비활성화"
 
 #: src/muuli_wdr.cpp
-msgid "Username: "
-msgstr ""
-
-#: src/muuli_wdr.cpp
 msgid "The username to use to connect to the proxy"
 msgstr "프록시에 접속하기 위한 사용자이름"
-
-#: src/muuli_wdr.cpp
-msgid "Password:"
-msgstr "암호:"
 
 #: src/muuli_wdr.cpp
 msgid "The password to use to connect to the proxy"
@@ -5625,6 +5538,15 @@ msgstr "시"
 #: src/OtherFunctions.cpp
 msgid "days"
 msgstr "일"
+
+#. TRANSLATORS:
+#. Punctuation for a "label: value" pair. %s is the already-translated
+#. label. Place the colon as your language requires -- e.g. "%s :" with a
+#. space in French, "%s:" without one in Russian and English.
+#: src/OtherFunctions.cpp
+#, c-format
+msgid "%s:"
+msgstr ""
 
 #: src/OtherFunctions.cpp
 msgid "all"
@@ -6671,8 +6593,7 @@ msgstr ""
 msgid "Confirm shared folders"
 msgstr "공유된 파일을 다시 읽어들임"
 
-#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp
-#: src/SharedFilesReloadProgress.cpp
+#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp src/SharedFilesReloadProgress.cpp
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "공유된 파일을 다시 읽어들임"
@@ -6804,19 +6725,6 @@ msgstr ""
 #: src/SearchListCtrl.cpp
 msgid "FileID"
 msgstr "파일아이디"
-
-#: src/SearchListCtrl.cpp
-msgid "Length"
-msgstr ""
-
-#: src/SearchListCtrl.cpp
-#, fuzzy
-msgid "Bitrate"
-msgstr "선택되지 않은"
-
-#: src/SearchListCtrl.cpp
-msgid "Codec"
-msgstr ""
 
 #: src/SearchListCtrl.cpp
 msgid "Expand all"
@@ -7103,10 +7011,6 @@ msgstr "지역 서버가 IPFilter에 의해 차단되어, 다른 서버로 재�
 #: src/ServerListCtrl.cpp
 msgid "Server Name"
 msgstr "서버 이름"
-
-#: src/ServerListCtrl.cpp
-msgid "Port"
-msgstr "포트"
 
 #: src/ServerListCtrl.cpp
 msgid "Description"
@@ -7412,6 +7316,10 @@ msgstr "친구에게 접속함"
 #, fuzzy, c-format
 msgid "Connected to buddy at %s"
 msgstr "친구에게 접속함"
+
+#: src/ServerWnd.cpp
+msgid "IP address:"
+msgstr "IP 주소:"
 
 #: src/ServerWnd.cpp
 #, fuzzy

--- a/po/lt.po
+++ b/po/lt.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-04 12:13+0200\n"
+"POT-Creation-Date: 2026-09-05 12:01+0200\n"
 "PO-Revision-Date: 2026-09-03 11:07+0000\n"
 "Last-Translator: Dovydas Sankauskas <laisve@gmail.com>\n"
 "Language-Team: Lithuanian <komp_lt@konf.lt>\n"
@@ -390,8 +390,7 @@ msgstr "žiniatinklio serverio pid yra %d"
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Nurodėte paleidus programą paleisti žiniatinklio serverį, bet amuleweb programos nepavyko paleisti. Įdiekite aMule žiniatinklio programos paketą arba sukompiliuokite aMule su --enable-webserver parinktimi ir paleiskite „make install“."
 
-#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
-#: src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
+#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
 msgid "ERROR"
 msgstr "KLAIDA"
 
@@ -681,8 +680,7 @@ msgstr "Tinklas"
 msgid "Searches"
 msgstr "Paieška"
 
-#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/Statistics.cpp
+#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/Statistics.cpp
 msgid "Downloads"
 msgstr "Siuntimai"
 
@@ -766,9 +764,7 @@ msgstr "Kad: išjungta"
 msgid "Core"
 msgstr ""
 
-#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#: src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp
-#: src/SourceListCtrl.cpp src/Statistics.cpp
+#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp src/Statistics.cpp
 msgid "Version"
 msgstr "Versija"
 
@@ -1072,11 +1068,7 @@ msgstr ""
 msgid "The remote core sent inconsistent data for \"%s\" (part status %d, expected %d). The file list may be showing the wrong information; reconnect to clear it."
 msgstr ""
 
-#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp
-#: src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp
-#: src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp
-#: src/Statistics.cpp
+#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp src/Statistics.cpp
 msgid "Unknown"
 msgstr "Nežinoma"
 
@@ -1176,8 +1168,7 @@ msgstr "Įrašant known.met failą įvyko klaida: %s"
 msgid "Enter Captcha"
 msgstr ""
 
-#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp
-#: src/TransferWnd.cpp
+#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp src/TransferWnd.cpp
 msgid "Category"
 msgstr "Kategorija"
 
@@ -1347,13 +1338,11 @@ msgstr "Nerasta cryptkey.dat failo. Failas kuriamas."
 msgid "Client Details"
 msgstr "Kliento savybės"
 
-#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
-#: src/utils/wxCas/src/onlinesig.cpp
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
 msgid "LowID"
 msgstr "Žemas ID"
 
-#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
-#: src/utils/wxCas/src/onlinesig.cpp
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
 msgid "HighID"
 msgstr "Aukštas ID"
 
@@ -1369,8 +1358,7 @@ msgstr "Palaikoma"
 msgid "Not supported"
 msgstr "Nepalaikoma"
 
-#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
-#: src/TextClient.cpp
+#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp src/TextClient.cpp
 msgid "Connected"
 msgstr "Prisijungta"
 
@@ -1378,28 +1366,24 @@ msgstr "Prisijungta"
 msgid "Disconnected"
 msgstr "Neprisijungta"
 
-#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp
-#: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f KiB/s"
 msgstr ""
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#, fuzzy
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/muuli_wdr.cpp
 msgid "Name"
-msgstr "Pavadinimas:"
+msgstr "Pavadinimas"
 
 #: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
 msgid "Software"
 msgstr ""
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#, fuzzy
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/muuli_wdr.cpp
 msgid "IP Address"
-msgstr "IP adresas:"
+msgstr "IP adresas"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Origin"
 msgstr ""
 
@@ -1417,14 +1401,12 @@ msgstr "Paskutinį kartą siųsta"
 msgid "Sessions"
 msgstr "Versija"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp
 #, fuzzy
 msgid "Upload Speed"
 msgstr "Išsiuntimo sparta"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp
 #, fuzzy
 msgid "Download Speed"
 msgstr "Atsiuntimo sparta"
@@ -1481,13 +1463,11 @@ msgstr[2] ""
 msgid "Files"
 msgstr "Failai"
 
-#: src/ClientsListCtrl.cpp src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp
-#: src/SourceListCtrl.cpp
+#: src/ClientsListCtrl.cpp src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Uploaded"
 msgstr "Išsiųsta"
 
-#: src/ClientsListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientsListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Downloaded"
 msgstr "Atsiųsta"
 
@@ -1574,12 +1554,11 @@ msgstr "Naudotojas %s (%u) nesuteikė prieigos prie dalinamų aplankų/failų s�
 msgid "File Comments"
 msgstr "Failo komentarai"
 
-#: src/CommentDialogLst.cpp src/FriendListCtrl.cpp
+#: src/CommentDialogLst.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
 msgid "Username"
 msgstr "Vardas"
 
-#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp
-#: src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "File Name"
 msgstr "Failo pavadinimas"
 
@@ -1587,7 +1566,7 @@ msgstr "Failo pavadinimas"
 msgid "Rating"
 msgstr "Reitingas"
 
-#: src/CommentDialogLst.cpp
+#: src/CommentDialogLst.cpp src/muuli_wdr.cpp
 msgid "Comment"
 msgstr "Komentaras"
 
@@ -1641,18 +1620,15 @@ msgstr "Automatiškai (aukštas)"
 msgid "Very low"
 msgstr "Labai žemas"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Low"
 msgstr "Žemas"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Normal"
 msgstr "Normalus"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "High"
 msgstr "Aukštas"
 
@@ -1676,13 +1652,11 @@ msgstr "Jungiamasi per serverį"
 msgid "Queue Full"
 msgstr "Eilė pilna"
 
-#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp
-#: src/muuli_wdr.cpp
+#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp src/muuli_wdr.cpp
 msgid "On Queue"
 msgstr "Eilėje"
 
-#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp
-#: src/PartFile.cpp src/TransferWnd.cpp
+#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Downloading"
 msgstr "Atsiunčiama"
 
@@ -1742,8 +1716,7 @@ msgstr "Vietinis serveris"
 msgid "Remote Server"
 msgstr "Nutolęs serveris"
 
-#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp
-#: src/TextClient.cpp
+#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp src/TextClient.cpp
 msgid "Kad"
 msgstr "Kademlia"
 
@@ -1767,8 +1740,7 @@ msgstr "Pilni šaltiniai"
 msgid "Search Result"
 msgstr ""
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp
-#: src/TransferWnd.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Completed"
 msgstr "Baigtos"
 
@@ -1821,8 +1793,7 @@ msgstr ""
 msgid "Part"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp
-#: src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Size"
 msgstr "Dydis"
 
@@ -1830,8 +1801,7 @@ msgstr "Dydis"
 msgid "Transferred"
 msgstr "Persiųsta"
 
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
-#: src/SourceListCtrl.cpp
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp src/SourceListCtrl.cpp
 msgid "Speed"
 msgstr "Sparta"
 
@@ -1839,13 +1809,11 @@ msgstr "Sparta"
 msgid "Progress"
 msgstr "Eiga"
 
-#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp
-#: src/SearchListCtrl.cpp
+#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
 msgid "Sources"
 msgstr "Šaltiniai"
 
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp
-#: src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Priority"
 msgstr "Prioritetas"
 
@@ -1869,9 +1837,7 @@ msgstr "Paskutinį kartą siųsta"
 msgid "Auto"
 msgstr "Automatiškas"
 
-#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/TransferWnd.cpp
-#: src/utils/wxCas/src/wxcasprefs.cpp
+#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/TransferWnd.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Cancel"
 msgstr "Atšaukti"
 
@@ -1972,8 +1938,7 @@ msgstr "Įrašykite naują failo pavadinimą:"
 msgid "File rename"
 msgstr "Pervadinti failą"
 
-#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp
-#: src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f MiB/s"
 msgstr ""
@@ -2785,13 +2750,11 @@ msgstr ""
 msgid "Start aMule automatically when I log in"
 msgstr ""
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
-#: packaging/windows/installer_strings.c
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp packaging/windows/installer_strings.c
 msgid "Register aMule for ed2k:// links"
 msgstr ""
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
-#: packaging/windows/installer_strings.c
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp packaging/windows/installer_strings.c
 msgid "Register aMule for magnet: links"
 msgstr ""
 
@@ -2817,8 +2780,7 @@ msgstr ""
 msgid "Destination folder for downloads"
 msgstr ""
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
-#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Browse"
 msgstr "Naršyti"
 
@@ -3270,18 +3232,15 @@ msgstr "Patvirtinama"
 msgid "Complete"
 msgstr "Baigta"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
-#: src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Paused"
 msgstr "Pristabdyta"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
-#: src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Erroneous"
 msgstr "Klaidinga"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
-#: src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Waiting"
 msgstr "Laukiama"
 
@@ -3451,8 +3410,7 @@ msgstr "Užverti"
 msgid "Cut"
 msgstr "Iškirpti"
 
-#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp
-#: src/utils/aLinkCreator/src/alcframe.cpp
+#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy"
 msgstr "Kopijuoti"
 
@@ -3460,8 +3418,7 @@ msgstr "Kopijuoti"
 msgid "Paste"
 msgstr "Įterpti"
 
-#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp
-#: src/utils/aLinkCreator/src/alcframe.cpp
+#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Clear"
 msgstr "Išvalyti"
 
@@ -3469,8 +3426,7 @@ msgstr "Išvalyti"
 msgid "Select All"
 msgstr "Pažymėti viską"
 
-#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
-#: src/StatisticsDlg.cpp
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp src/StatisticsDlg.cpp
 msgid "KiB/s"
 msgstr ""
 
@@ -3734,10 +3690,6 @@ msgstr "Dabartinis serveris."
 msgid "Search"
 msgstr "Paieška"
 
-#: src/muuli_wdr.cpp
-msgid "Name:"
-msgstr "Pavadinimas:"
-
 #: src/muuli_wdr.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Type"
 msgstr "Tipas"
@@ -3827,8 +3779,8 @@ msgid "Availability"
 msgstr "Skaičius"
 
 #: src/muuli_wdr.cpp
-msgid "Filter:"
-msgstr "Filtras:"
+msgid "Filter"
+msgstr "Filtras"
 
 #: src/muuli_wdr.cpp
 msgid "Invert Result"
@@ -3886,6 +3838,10 @@ msgid "Clears completed downloads"
 msgstr "Pašalinti iš sąrašo jau atsiųstus failus"
 
 #: src/muuli_wdr.cpp
+msgid "Filter:"
+msgstr "Filtras:"
+
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "File sources:"
 msgstr "Pilni šaltiniai"
@@ -3895,80 +3851,76 @@ msgid "General"
 msgstr "Bendra"
 
 #: src/muuli_wdr.cpp
-msgid "Full Name :"
-msgstr "Pilnas pavadinimas:"
+msgid "Full Name"
+msgstr "Pilnas pavadinimas"
 
 #: src/muuli_wdr.cpp
-msgid "met-File :"
-msgstr "met failas:"
+msgid "met-File"
+msgstr "met failas"
 
 #: src/muuli_wdr.cpp
-msgid "Hash :"
-msgstr "Maišos f-jos reikšmė:"
+msgid "Hash"
+msgstr "Maišos f-jos reikšmė"
 
 #: src/muuli_wdr.cpp
-msgid "Filesize :"
-msgstr "Failo dydis:"
+msgid "Filesize"
+msgstr "Failo dydis"
 
 #: src/muuli_wdr.cpp src/Statistics.cpp
 msgid "Transfer"
 msgstr "Siuntimas"
 
 #: src/muuli_wdr.cpp
-msgid "Partfilestatus :"
-msgstr "Dalinio failo būsena:"
+msgid "Partfilestatus"
+msgstr "Dalinio failo būsena"
 
 #: src/muuli_wdr.cpp
-msgid "Last seen complete :"
-msgstr "Paskutinį kartą matytas pilnas:"
+msgid "Last seen complete"
+msgstr "Paskutinį kartą matytas pilnas"
 
 #: src/muuli_wdr.cpp
-msgid "Found Sources :"
-msgstr "Rasti šaltiniai:"
+msgid "Found Sources"
+msgstr "Rasti šaltiniai"
 
 #: src/muuli_wdr.cpp
-msgid "Transferring Sources :"
-msgstr "Siunčiantys šaltiniai:"
+msgid "Transferring Sources"
+msgstr "Siunčiantys šaltiniai"
 
 #: src/muuli_wdr.cpp
-msgid "Filepart-Count :"
-msgstr "Dalių skaičius:"
+msgid "Filepart-Count"
+msgstr "Dalių skaičius"
 
 #: src/muuli_wdr.cpp
-msgid "Available :"
-msgstr "Pasiekiamos dalys:"
+msgid "Available"
+msgstr "Pasiekiamos dalys"
 
 #: src/muuli_wdr.cpp
-msgid "Datarate :"
-msgstr "Siuntimo sparta:"
+msgid "Datarate"
+msgstr "Siuntimo sparta"
 
 #: src/muuli_wdr.cpp
-msgid "Download Active Time: "
-msgstr "Atsiuntimo aktyvi trukmė: "
+msgid "Download Active Time"
+msgstr "Atsiuntimo aktyvi trukmė"
 
 #: src/muuli_wdr.cpp
-msgid "Transferred :"
-msgstr "Persiųsta duomenų:"
-
-#: src/muuli_wdr.cpp
-msgid "Completed Size :"
-msgstr "Atsiųstas kiekis:"
+msgid "Completed Size"
+msgstr "Atsiųstas kiekis"
 
 #: src/muuli_wdr.cpp
 msgid "Intelligent Corruption Handling"
 msgstr "Klaidų taisymo įrankis"
 
 #: src/muuli_wdr.cpp
-msgid "Lost to corruption :"
-msgstr "Dėl klaidų prarasta:"
+msgid "Lost to corruption"
+msgstr "Dėl klaidų prarasta"
 
 #: src/muuli_wdr.cpp
-msgid "Gained by compression :"
-msgstr "Sutaupyta supakuojant:"
+msgid "Gained by compression"
+msgstr "Sutaupyta supakuojant"
 
 #: src/muuli_wdr.cpp
-msgid "Packages saved by I.C.H. :"
-msgstr "Klaidų taisymo įrankis pataisė paketų:"
+msgid "Packages saved by I.C.H."
+msgstr "Klaidų taisymo įrankis pataisė paketų"
 
 #: src/muuli_wdr.cpp
 #, fuzzy
@@ -4010,30 +3962,30 @@ msgstr ", Išsiųsta: "
 msgid "Media Info"
 msgstr "Kademlia informacija"
 
-#: src/muuli_wdr.cpp
-msgid "Length :"
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
+msgid "Length"
 msgstr ""
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
 #, fuzzy
-msgid "Bitrate :"
+msgid "Bitrate"
 msgstr "Nevertinta"
 
-#: src/muuli_wdr.cpp
-msgid "Codec :"
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
+msgid "Codec"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Artist :"
+msgid "Artist"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Album :"
+msgid "Album"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Title :"
-msgstr "Pavadinimas:"
+msgid "Title"
+msgstr "Pavadinimas"
 
 #: src/muuli_wdr.cpp
 msgid "File Names"
@@ -4118,25 +4070,17 @@ msgstr "Dydis nežinomas"
 msgid "Required Information"
 msgstr "Būtina informacija"
 
-#: src/muuli_wdr.cpp
-msgid "IP Address :"
-msgstr "IP adresas:"
-
-#: src/muuli_wdr.cpp
-msgid "Port :"
-msgstr "Prievadas:"
+#: src/muuli_wdr.cpp src/ServerListCtrl.cpp
+msgid "Port"
+msgstr "Prievadas"
 
 #: src/muuli_wdr.cpp
 msgid "Additional Information"
 msgstr "Papildoma informacija"
 
 #: src/muuli_wdr.cpp
-msgid "Username :"
-msgstr "Naudotojo vardas:"
-
-#: src/muuli_wdr.cpp
-msgid "Userhash :"
-msgstr "Naudotojo maišos f-ja:"
+msgid "Userhash"
+msgstr "Naudotojo maišos f-ja"
 
 #: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Add"
@@ -4171,97 +4115,81 @@ msgid "Statistics Tree"
 msgstr "Statistikos duomenų medis"
 
 #: src/muuli_wdr.cpp
-msgid "Username:"
-msgstr "Naudotojo vardas:"
+msgid "Client software"
+msgstr "Kliento programinė įranga"
 
 #: src/muuli_wdr.cpp
-msgid "Userhash:"
-msgstr "Naudotojo maišos f-ja:"
+msgid "Client version"
+msgstr "Programinės įrangos versija"
 
 #: src/muuli_wdr.cpp
-msgid "Client software:"
-msgstr "Kliento programinė įranga:"
+msgid "User ID"
+msgstr "Naudotojo ID"
 
 #: src/muuli_wdr.cpp
-msgid "Client version:"
-msgstr "Programinės įrangos versija:"
-
-#: src/muuli_wdr.cpp src/ServerWnd.cpp
-msgid "IP address:"
-msgstr "IP adresas:"
+msgid "Server IP"
+msgstr "Serverio IP"
 
 #: src/muuli_wdr.cpp
-msgid "User ID:"
-msgstr "Naudotojo ID:"
+msgid "Server name"
+msgstr "Serverio pavadinimas"
 
 #: src/muuli_wdr.cpp
-msgid "Server IP:"
-msgstr "Serverio IP:"
-
-#: src/muuli_wdr.cpp
-msgid "Server name:"
-msgstr "Serverio pavadinimas:"
-
-#: src/muuli_wdr.cpp
-msgid "Obfuscation:"
-msgstr "Slėpimas:"
-
-#: src/muuli_wdr.cpp
-msgid "Kad:"
-msgstr "Kad:"
+msgid "Obfuscation"
+msgstr "Slėpimas"
 
 #: src/muuli_wdr.cpp
 msgid "Transfers to client"
 msgstr "Siuntimai naudotojui"
 
 #: src/muuli_wdr.cpp
-msgid "Current request:"
-msgstr "Dabartinis prašymas:"
+msgid "Current request"
+msgstr "Dabartinis prašymas"
 
 #: src/muuli_wdr.cpp
-msgid "Average upload rate:"
-msgstr "Vidutinė išsiuntimo sparta:"
+msgid "Average upload rate"
+msgstr "Vidutinė išsiuntimo sparta"
 
 #: src/muuli_wdr.cpp
-msgid "Average download rate:"
-msgstr "Vidutinė atsiuntimo sparta:"
+msgid "Average download rate"
+msgstr "Vidutinė atsiuntimo sparta"
 
 #: src/muuli_wdr.cpp
-msgid "Uploaded (session):"
-msgstr "Išsiųsta (per šį seansą):"
+msgid "Uploaded (session)"
+msgstr "Išsiųsta (per šį seansą)"
 
 #: src/muuli_wdr.cpp
-msgid "Downloaded (session):"
-msgstr "Atsiųsta (per šį seansą):"
+msgid "Downloaded (session)"
+msgstr "Atsiųsta (per šį seansą)"
 
 #: src/muuli_wdr.cpp
-msgid "Uploaded (total):"
-msgstr "Išsiųsta (iš viso):"
+msgid "Uploaded (total)"
+msgstr "Išsiųsta (iš viso)"
 
 #: src/muuli_wdr.cpp
-msgid "Downloaded (total):"
-msgstr "Atsiųsta (iš viso):"
+msgid "Downloaded (total)"
+msgstr "Atsiųsta (iš viso)"
 
 #: src/muuli_wdr.cpp
 msgid "Scores"
 msgstr "Reitingas"
 
 #: src/muuli_wdr.cpp
-msgid "DL/UP modifier:"
-msgstr "Ats./išs. indeksas:"
+msgid "DL/UP modifier"
+msgstr "Ats./išs. indeksas"
 
 #: src/muuli_wdr.cpp
-msgid "Secure ident:"
-msgstr "Saugus identifikatorius:"
+msgid "Secure ident"
+msgstr "Saugus identifikatorius"
 
 #: src/muuli_wdr.cpp
 #, fuzzy
-msgid "Queue rank:"
+msgid "Queue rank"
 msgstr "Eilėje"
 
 #: src/muuli_wdr.cpp
-msgid "Queue score:"
-msgstr "Reitingas eilėje:"
+msgid "Queue score"
+msgstr "Reitingas eilėje"
 
 #: src/muuli_wdr.cpp
 msgid "Nick"
@@ -5054,16 +4982,12 @@ msgid "Reset any changes made to the preferences."
 msgstr "Atšaukti bet kokius pakeitimus."
 
 #: src/muuli_wdr.cpp
-msgid "Comment :"
-msgstr "Komentaras:"
+msgid "Incoming Dir"
+msgstr "Atsiųstų failų aplankas"
 
 #: src/muuli_wdr.cpp
-msgid "Incoming Dir :"
-msgstr "Atsiųstų failų aplankas:"
-
-#: src/muuli_wdr.cpp
-msgid "Change priority for new assigned files :"
-msgstr "Keisti naujai priskirtų failų prioritetą:"
+msgid "Change priority for new assigned files"
+msgstr "Keisti naujai priskirtų failų prioritetą"
 
 #: src/muuli_wdr.cpp
 #, fuzzy
@@ -5071,8 +4995,8 @@ msgid "Don't change"
 msgstr "Nekeisti"
 
 #: src/muuli_wdr.cpp
-msgid "Select color for this Category (currently selected) :"
-msgstr "Nurodykite dabartinės kategorijos spalvą:"
+msgid "Select color for this Category (currently selected)"
+msgstr "Nurodykite dabartinės kategorijos spalvą"
 
 #: src/muuli_wdr.cpp
 msgid "Click this button to reset the log."
@@ -5157,10 +5081,6 @@ msgstr ""
 #, fuzzy
 msgid "Enter the IP of the node here, using the x.x.x.x format."
 msgstr "Įrašykite serverio IP adresą naudodami a.b.c.d formą."
-
-#: src/muuli_wdr.cpp
-msgid "Port:"
-msgstr "Prievadas:"
 
 #: src/muuli_wdr.cpp
 msgid "Use Secure User Identification"
@@ -5429,20 +5349,20 @@ msgid "Enable/disable proxy support"
 msgstr "Įjungti ar išjungti atstovaujančius serverius"
 
 #: src/muuli_wdr.cpp
-msgid "Proxy type:"
-msgstr "Serverio tipas:"
+msgid "Proxy type"
+msgstr "Serverio tipas"
 
 #: src/muuli_wdr.cpp
-msgid "Proxy host:"
-msgstr "Serverio mazgas:"
+msgid "Proxy host"
+msgstr "Serverio mazgas"
 
 #: src/muuli_wdr.cpp
 msgid "The proxy host name"
 msgstr "Atstovaujančio serverio mazgo pavadinimas"
 
 #: src/muuli_wdr.cpp
-msgid "Proxy port:"
-msgstr "Serverio prievadas:"
+msgid "Proxy port"
+msgstr "Serverio prievadas"
 
 #: src/muuli_wdr.cpp
 msgid "The proxy port"
@@ -5457,16 +5377,8 @@ msgid "Enable/disable username/password authentication"
 msgstr "Įjungti ar išjungti naudotojo vardo ir slaptažodžio autentifikavimą"
 
 #: src/muuli_wdr.cpp
-msgid "Username: "
-msgstr ""
-
-#: src/muuli_wdr.cpp
 msgid "The username to use to connect to the proxy"
 msgstr "Naudotojo vardas prisijungimui prie atstovaujančio serverio"
-
-#: src/muuli_wdr.cpp
-msgid "Password:"
-msgstr "Slaptažodis:"
 
 #: src/muuli_wdr.cpp
 msgid "The password to use to connect to the proxy"
@@ -5650,6 +5562,15 @@ msgstr "val."
 #: src/OtherFunctions.cpp
 msgid "days"
 msgstr "dienų"
+
+#. TRANSLATORS:
+#. Punctuation for a "label: value" pair. %s is the already-translated
+#. label. Place the colon as your language requires -- e.g. "%s :" with a
+#. space in French, "%s:" without one in Russian and English.
+#: src/OtherFunctions.cpp
+#, c-format
+msgid "%s:"
+msgstr ""
 
 #: src/OtherFunctions.cpp
 msgid "all"
@@ -6705,8 +6626,7 @@ msgstr ""
 msgid "Confirm shared folders"
 msgstr "Atnaujinti dalinamų failų sąrašą"
 
-#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp
-#: src/SharedFilesReloadProgress.cpp
+#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp src/SharedFilesReloadProgress.cpp
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "Atnaujinti dalinamų failų sąrašą"
@@ -6838,19 +6758,6 @@ msgstr ""
 #: src/SearchListCtrl.cpp
 msgid "FileID"
 msgstr "Failo ID"
-
-#: src/SearchListCtrl.cpp
-msgid "Length"
-msgstr ""
-
-#: src/SearchListCtrl.cpp
-#, fuzzy
-msgid "Bitrate"
-msgstr "Nevertinta"
-
-#: src/SearchListCtrl.cpp
-msgid "Codec"
-msgstr ""
 
 #: src/SearchListCtrl.cpp
 msgid "Expand all"
@@ -7140,10 +7047,6 @@ msgstr "Vietinis serveris filtruojamas IP filtro, jungiamasi prie kito serverio!
 #: src/ServerListCtrl.cpp
 msgid "Server Name"
 msgstr "Serverio pavadinimas"
-
-#: src/ServerListCtrl.cpp
-msgid "Port"
-msgstr "Prievadas"
 
 #: src/ServerListCtrl.cpp
 msgid "Description"
@@ -7442,6 +7345,10 @@ msgstr "Prisijungta prie draugo"
 #, fuzzy, c-format
 msgid "Connected to buddy at %s"
 msgstr "Prisijungta prie draugo"
+
+#: src/ServerWnd.cpp
+msgid "IP address:"
+msgstr "IP adresas:"
 
 #: src/ServerWnd.cpp
 #, fuzzy

--- a/po/lv.po
+++ b/po/lv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-04 12:13+0200\n"
+"POT-Creation-Date: 2026-09-05 12:01+0200\n"
 "PO-Revision-Date: 2026-09-03 11:13+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -1338,7 +1338,7 @@ msgstr "Atslēgts"
 msgid "%.1f KiB/s"
 msgstr "%.1f KiB/s"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/muuli_wdr.cpp
 msgid "Name"
 msgstr "Nosaukums"
 
@@ -1346,7 +1346,7 @@ msgstr "Nosaukums"
 msgid "Software"
 msgstr "Programma"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/muuli_wdr.cpp
 msgid "IP Address"
 msgstr "IP adrese"
 
@@ -1518,7 +1518,7 @@ msgstr ""
 msgid "File Comments"
 msgstr "Datnes komentāri"
 
-#: src/CommentDialogLst.cpp src/FriendListCtrl.cpp
+#: src/CommentDialogLst.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
 msgid "Username"
 msgstr "Dalībniekvārds"
 
@@ -1531,7 +1531,7 @@ msgstr "Datnes nosaukums"
 msgid "Rating"
 msgstr "Vērtējums"
 
-#: src/CommentDialogLst.cpp
+#: src/CommentDialogLst.cpp src/muuli_wdr.cpp
 msgid "Comment"
 msgstr "Komentārs"
 
@@ -3607,10 +3607,6 @@ msgstr "Serveris, kuram šobrīd esiet pieslēdzies."
 msgid "Search"
 msgstr "Meklēt"
 
-#: src/muuli_wdr.cpp
-msgid "Name:"
-msgstr "Nosaukums:"
-
 #: src/muuli_wdr.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Type"
 msgstr ""
@@ -3700,8 +3696,9 @@ msgid "Availability"
 msgstr "Pieejamība"
 
 #: src/muuli_wdr.cpp
-msgid "Filter:"
-msgstr ""
+#, fuzzy
+msgid "Filter"
+msgstr "Skatīt datnes"
 
 #: src/muuli_wdr.cpp
 msgid "Invert Result"
@@ -3758,6 +3755,10 @@ msgid "Clears completed downloads"
 msgstr ""
 
 #: src/muuli_wdr.cpp
+msgid "Filter:"
+msgstr ""
+
+#: src/muuli_wdr.cpp
 msgid "File sources:"
 msgstr ""
 
@@ -3766,79 +3767,86 @@ msgid "General"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Full Name :"
-msgstr ""
+#, fuzzy
+msgid "Full Name"
+msgstr "Datnes nosaukums"
 
 #: src/muuli_wdr.cpp
-msgid "met-File :"
-msgstr ""
+#, fuzzy
+msgid "met-File"
+msgstr "Datnes"
 
 #: src/muuli_wdr.cpp
-msgid "Hash :"
-msgstr "Kontrolsumma :"
+msgid "Hash"
+msgstr "Kontrolsumma"
 
 #: src/muuli_wdr.cpp
-msgid "Filesize :"
-msgstr "Datnes izmērs :"
+msgid "Filesize"
+msgstr "Datnes izmērs"
 
 #: src/muuli_wdr.cpp src/Statistics.cpp
 msgid "Transfer"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Partfilestatus :"
+#, fuzzy
+msgid "Partfilestatus"
+msgstr "Statuss"
+
+#: src/muuli_wdr.cpp
+#, fuzzy
+msgid "Last seen complete"
+msgstr "Pēdējo reizi datne bija pilnībā pieejama"
+
+#: src/muuli_wdr.cpp
+#, fuzzy
+msgid "Found Sources"
+msgstr "Avoti"
+
+#: src/muuli_wdr.cpp
+#, fuzzy
+msgid "Transferring Sources"
+msgstr "Pārsūtīti"
+
+#: src/muuli_wdr.cpp
+msgid "Filepart-Count"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Last seen complete :"
-msgstr ""
+#, fuzzy
+msgid "Available"
+msgstr "Pieejamība"
 
 #: src/muuli_wdr.cpp
-msgid "Found Sources :"
-msgstr ""
+#, fuzzy
+msgid "Datarate"
+msgstr "Datubāze"
 
 #: src/muuli_wdr.cpp
-msgid "Transferring Sources :"
-msgstr ""
+#, fuzzy
+msgid "Download Active Time"
+msgstr "↓ Lejupielādes ātrums"
 
 #: src/muuli_wdr.cpp
-msgid "Filepart-Count :"
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "Available :"
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "Datarate :"
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "Download Active Time: "
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "Transferred :"
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "Completed Size :"
-msgstr ""
+#, fuzzy
+msgid "Completed Size"
+msgstr "Pabeigta"
 
 #: src/muuli_wdr.cpp
 msgid "Intelligent Corruption Handling"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Lost to corruption :"
+msgid "Lost to corruption"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Gained by compression :"
-msgstr ""
+#, fuzzy
+msgid "Gained by compression"
+msgstr "Iespējot Gzip saspiešanu"
 
 #: src/muuli_wdr.cpp
-msgid "Packages saved by I.C.H. :"
+msgid "Packages saved by I.C.H."
 msgstr ""
 
 #: src/muuli_wdr.cpp
@@ -3877,29 +3885,29 @@ msgstr "Pēdējoreiz augšupielādēta"
 msgid "Media Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp
-msgid "Length :"
-msgstr "Ilgums :"
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
+msgid "Length"
+msgstr "Ilgums"
+
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
+msgid "Bitrate"
+msgstr "Bitu pārraides ātrums"
+
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
+msgid "Codec"
+msgstr "Kodeks"
 
 #: src/muuli_wdr.cpp
-msgid "Bitrate :"
-msgstr "Bitu pārraides ātrums :"
+msgid "Artist"
+msgstr "Izpildītājs"
 
 #: src/muuli_wdr.cpp
-msgid "Codec :"
-msgstr "Kodeks :"
+msgid "Album"
+msgstr "Albums"
 
 #: src/muuli_wdr.cpp
-msgid "Artist :"
-msgstr "Izpildītājs :"
-
-#: src/muuli_wdr.cpp
-msgid "Album :"
-msgstr "Albums :"
-
-#: src/muuli_wdr.cpp
-msgid "Title :"
-msgstr "Nosaukums :"
+msgid "Title"
+msgstr "Nosaukums"
 
 #: src/muuli_wdr.cpp
 msgid "File Names"
@@ -3983,25 +3991,17 @@ msgstr "Nezināms izmērs"
 msgid "Required Information"
 msgstr "Nepieciešamā informācija"
 
-#: src/muuli_wdr.cpp
-msgid "IP Address :"
-msgstr "IP adrese :"
-
-#: src/muuli_wdr.cpp
-msgid "Port :"
-msgstr "Ports :"
+#: src/muuli_wdr.cpp src/ServerListCtrl.cpp
+msgid "Port"
+msgstr "Ports"
 
 #: src/muuli_wdr.cpp
 msgid "Additional Information"
 msgstr "Papildinformācija"
 
 #: src/muuli_wdr.cpp
-msgid "Username :"
-msgstr "Dalībniekvārds :"
-
-#: src/muuli_wdr.cpp
-msgid "Userhash :"
-msgstr "Dalībnieka atpazīšanas kods (jaucējvērtība) :"
+msgid "Userhash"
+msgstr "Dalībnieka atpazīšanas kods (jaucējvērtība)"
 
 #: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Add"
@@ -4036,96 +4036,83 @@ msgid "Statistics Tree"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Username:"
-msgstr "Dalībniekvārds:"
+msgid "Client software"
+msgstr "Klienta programma"
 
 #: src/muuli_wdr.cpp
-msgid "Userhash:"
-msgstr "Dalībnieka atpazīšanas kods (jaucējvērtība):"
+msgid "Client version"
+msgstr "Klienta programmas versija"
 
 #: src/muuli_wdr.cpp
-msgid "Client software:"
-msgstr "Klienta programma:"
+msgid "User ID"
+msgstr "Dalībnieka ID"
 
 #: src/muuli_wdr.cpp
-msgid "Client version:"
-msgstr "Klienta programmas versija:"
-
-#: src/muuli_wdr.cpp src/ServerWnd.cpp
-msgid "IP address:"
-msgstr "IP adrese:"
+msgid "Server IP"
+msgstr "Servera IP adrese"
 
 #: src/muuli_wdr.cpp
-msgid "User ID:"
-msgstr "Dalībnieka ID:"
+msgid "Server name"
+msgstr "Servera nosaukums"
 
 #: src/muuli_wdr.cpp
-msgid "Server IP:"
-msgstr "Servera IP adrese:"
-
-#: src/muuli_wdr.cpp
-msgid "Server name:"
-msgstr "Servera nosaukums:"
-
-#: src/muuli_wdr.cpp
-msgid "Obfuscation:"
+msgid "Obfuscation"
 msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "Kad:"
-msgstr "Kad:"
 
 #: src/muuli_wdr.cpp
 msgid "Transfers to client"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Current request:"
-msgstr ""
+#, fuzzy
+msgid "Current request"
+msgstr "Pašreizējais"
 
 #: src/muuli_wdr.cpp
-msgid "Average upload rate:"
-msgstr "↑ Vidējais augšupielādes ātrums:"
+msgid "Average upload rate"
+msgstr "↑ Vidējais augšupielādes ātrums"
 
 #: src/muuli_wdr.cpp
-msgid "Average download rate:"
-msgstr "↓ Vidējais lejupielādes ātrums:"
+msgid "Average download rate"
+msgstr "↓ Vidējais lejupielādes ātrums"
 
 #: src/muuli_wdr.cpp
-msgid "Uploaded (session):"
-msgstr "↑ Augšupielādēti (šajā sesijā):"
+msgid "Uploaded (session)"
+msgstr "↑ Augšupielādēti (šajā sesijā)"
 
 #: src/muuli_wdr.cpp
-msgid "Downloaded (session):"
-msgstr "↓ Lejupielādēti (šajā sesijā):"
+msgid "Downloaded (session)"
+msgstr "↓ Lejupielādēti (šajā sesijā)"
 
 #: src/muuli_wdr.cpp
-msgid "Uploaded (total):"
-msgstr "↑ Augšupielādēti (pavisam kopā):"
+msgid "Uploaded (total)"
+msgstr "↑ Augšupielādēti (pavisam kopā)"
 
 #: src/muuli_wdr.cpp
-msgid "Downloaded (total):"
-msgstr "↓ Lejupielādēti (pavisam kopā):"
+msgid "Downloaded (total)"
+msgstr "↓ Lejupielādēti (pavisam kopā)"
 
 #: src/muuli_wdr.cpp
 msgid "Scores"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "DL/UP modifier:"
+msgid "DL/UP modifier"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Secure ident:"
-msgstr ""
+#, fuzzy
+msgid "Secure ident"
+msgstr "Drošība"
 
 #: src/muuli_wdr.cpp
-msgid "Queue rank:"
-msgstr "Rindas pozīcija:"
+msgid "Queue rank"
+msgstr "Rindas pozīcija"
 
 #: src/muuli_wdr.cpp
-msgid "Queue score:"
-msgstr ""
+#, fuzzy
+msgid "Queue score"
+msgstr "Rindas pozīcija"
 
 #: src/muuli_wdr.cpp
 msgid "Nick"
@@ -4906,15 +4893,12 @@ msgid "Reset any changes made to the preferences."
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Comment :"
-msgstr "Komentārs :"
+#, fuzzy
+msgid "Incoming Dir"
+msgstr "Ienākošās datnes"
 
 #: src/muuli_wdr.cpp
-msgid "Incoming Dir :"
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "Change priority for new assigned files :"
+msgid "Change priority for new assigned files"
 msgstr ""
 
 #: src/muuli_wdr.cpp
@@ -4922,7 +4906,7 @@ msgid "Don't change"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Select color for this Category (currently selected) :"
+msgid "Select color for this Category (currently selected)"
 msgstr ""
 
 #: src/muuli_wdr.cpp
@@ -5004,10 +4988,6 @@ msgstr ""
 #: src/muuli_wdr.cpp
 msgid "Enter the IP of the node here, using the x.x.x.x format."
 msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "Port:"
-msgstr "Ports:"
 
 #: src/muuli_wdr.cpp
 msgid "Use Secure User Identification"
@@ -5271,20 +5251,20 @@ msgid "Enable/disable proxy support"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Proxy type:"
-msgstr "Starpniekservera tips:"
+msgid "Proxy type"
+msgstr "Starpniekservera tips"
 
 #: src/muuli_wdr.cpp
-msgid "Proxy host:"
-msgstr "Starpniekserveris:"
+msgid "Proxy host"
+msgstr "Starpniekserveris"
 
 #: src/muuli_wdr.cpp
 msgid "The proxy host name"
 msgstr "Starpniekservera resursdatora nosaukums"
 
 #: src/muuli_wdr.cpp
-msgid "Proxy port:"
-msgstr "Starpniekservera ports:"
+msgid "Proxy port"
+msgstr "Starpniekservera ports"
 
 #: src/muuli_wdr.cpp
 msgid "The proxy port"
@@ -5299,16 +5279,8 @@ msgid "Enable/disable username/password authentication"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Username: "
-msgstr "Lietotājvārds: "
-
-#: src/muuli_wdr.cpp
 msgid "The username to use to connect to the proxy"
 msgstr "Lietotājvārds, ko lietot, kad izmanto starpniekserveri"
-
-#: src/muuli_wdr.cpp
-msgid "Password:"
-msgstr "Parole:"
 
 #: src/muuli_wdr.cpp
 msgid "The password to use to connect to the proxy"
@@ -5483,6 +5455,15 @@ msgstr "stundas"
 #: src/OtherFunctions.cpp
 msgid "days"
 msgstr "dienas"
+
+#. TRANSLATORS:
+#. Punctuation for a "label: value" pair. %s is the already-translated
+#. label. Place the colon as your language requires -- e.g. "%s :" with a
+#. space in French, "%s:" without one in Russian and English.
+#: src/OtherFunctions.cpp
+#, c-format
+msgid "%s:"
+msgstr ""
 
 #: src/OtherFunctions.cpp
 msgid "all"
@@ -6611,18 +6592,6 @@ msgid "FileID"
 msgstr "Datnes ID"
 
 #: src/SearchListCtrl.cpp
-msgid "Length"
-msgstr "Ilgums"
-
-#: src/SearchListCtrl.cpp
-msgid "Bitrate"
-msgstr "Bitu pārraides ātrums"
-
-#: src/SearchListCtrl.cpp
-msgid "Codec"
-msgstr "Kodeks"
-
-#: src/SearchListCtrl.cpp
 msgid "Expand all"
 msgstr "Izvērst visu"
 
@@ -6901,10 +6870,6 @@ msgstr ""
 #: src/ServerListCtrl.cpp
 msgid "Server Name"
 msgstr "Servera nosaukums"
-
-#: src/ServerListCtrl.cpp
-msgid "Port"
-msgstr "Ports"
 
 #: src/ServerListCtrl.cpp
 msgid "Description"
@@ -7194,6 +7159,10 @@ msgstr "Pieslēdzas draugam"
 #, c-format
 msgid "Connected to buddy at %s"
 msgstr "Savienots ar draugu %s"
+
+#: src/ServerWnd.cpp
+msgid "IP address:"
+msgstr "IP adrese:"
 
 #: src/ServerWnd.cpp
 msgid "Indexed sources:"

--- a/po/nl.po
+++ b/po/nl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-04 12:13+0200\n"
+"POT-Creation-Date: 2026-09-05 12:01+0200\n"
 "PO-Revision-Date: 2026-09-03 11:07+0000\n"
 "Last-Translator: Marcel Pol <marcel@timelord.nl>\n"
 "Language-Team: Dutch <nl@li.org>\n"
@@ -388,8 +388,7 @@ msgstr "webserver draait met pid %d"
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "U hebt gevraagd om de webserver bij het opstarten uit te voeren, maar het programma amuleweb kan niet worden uitgevoerd. Installeer het pakket met de aMule-webserver, of bouw aMule vanuit de broncode met -DBUILD_WEBSERVER=YES en installeer het."
 
-#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
-#: src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
+#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
 msgid "ERROR"
 msgstr "FOUT"
 
@@ -675,8 +674,7 @@ msgstr "Netwerken"
 msgid "Searches"
 msgstr "Zoeken"
 
-#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/Statistics.cpp
+#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/Statistics.cpp
 msgid "Downloads"
 msgstr "Downloads"
 
@@ -764,9 +762,7 @@ msgstr "Kad: Uitgeschakeld"
 msgid "Core"
 msgstr "Kern"
 
-#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#: src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp
-#: src/SourceListCtrl.cpp src/Statistics.cpp
+#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp src/Statistics.cpp
 msgid "Version"
 msgstr "Versie"
 
@@ -1063,11 +1059,7 @@ msgstr "Kan map '%s' niet aanmaken voor categorie '%s', map '%s' wordt behouden.
 msgid "The remote core sent inconsistent data for \"%s\" (part status %d, expected %d). The file list may be showing the wrong information; reconnect to clear it."
 msgstr "De externe kern stuurde inconsistente data voor \"%s\" (deel status %d, verwacht %d). De bestandslijst laat mogelijk de verkeerdeinformatie zien; herverbindt om die te legen."
 
-#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp
-#: src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp
-#: src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp
-#: src/Statistics.cpp
+#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp src/Statistics.cpp
 msgid "Unknown"
 msgstr "Onbekend"
 
@@ -1164,8 +1156,7 @@ msgstr "Fout bij het bewaren van bestand %s: %s"
 msgid "Enter Captcha"
 msgstr "Voer captcha in"
 
-#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp
-#: src/TransferWnd.cpp
+#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp src/TransferWnd.cpp
 msgid "Category"
 msgstr "Categorie"
 
@@ -1328,13 +1319,11 @@ msgstr "Geen 'cryptkey.dat' bestand gevonden, wordt aangemaakt."
 msgid "Client Details"
 msgstr "Client details"
 
-#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
-#: src/utils/wxCas/src/onlinesig.cpp
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
 msgid "LowID"
 msgstr "Laag-ID"
 
-#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
-#: src/utils/wxCas/src/onlinesig.cpp
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
 msgid "HighID"
 msgstr "Hoog ID"
 
@@ -1350,8 +1339,7 @@ msgstr "Ondersteund"
 msgid "Not supported"
 msgstr "Niet ondersteund"
 
-#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
-#: src/TextClient.cpp
+#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp src/TextClient.cpp
 msgid "Connected"
 msgstr "Verbonden"
 
@@ -1359,13 +1347,12 @@ msgstr "Verbonden"
 msgid "Disconnected"
 msgstr "Niet verbonden"
 
-#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp
-#: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f KiB/s"
 msgstr "%.1f KiB/s"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/muuli_wdr.cpp
 msgid "Name"
 msgstr "Naam"
 
@@ -1373,12 +1360,11 @@ msgstr "Naam"
 msgid "Software"
 msgstr "Software"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/muuli_wdr.cpp
 msgid "IP Address"
 msgstr "IP-Adres"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Origin"
 msgstr "Oorsprong"
 
@@ -1394,13 +1380,11 @@ msgstr "Voor het laatst gezien"
 msgid "Sessions"
 msgstr "Sessies"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp
 msgid "Upload Speed"
 msgstr "Uploadsnelheid"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp
 msgid "Download Speed"
 msgstr "Downloadsnelheid"
 
@@ -1451,13 +1435,11 @@ msgstr[1] "Kon %u links niet toevoegen (zie log voor details)."
 msgid "Files"
 msgstr "Bestanden"
 
-#: src/ClientsListCtrl.cpp src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp
-#: src/SourceListCtrl.cpp
+#: src/ClientsListCtrl.cpp src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Uploaded"
 msgstr "Geüpload"
 
-#: src/ClientsListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientsListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Downloaded"
 msgstr "Gedownload"
 
@@ -1541,12 +1523,11 @@ msgstr "Gebruiker %s (%u) weigerde toegang tot gedeelde mappen/bestanden-lijst"
 msgid "File Comments"
 msgstr "Bestand commentaren"
 
-#: src/CommentDialogLst.cpp src/FriendListCtrl.cpp
+#: src/CommentDialogLst.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
 msgid "Username"
 msgstr "Gebruikersnaam"
 
-#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp
-#: src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "File Name"
 msgstr "Bestandsnaam"
 
@@ -1554,7 +1535,7 @@ msgstr "Bestandsnaam"
 msgid "Rating"
 msgstr "Waardering"
 
-#: src/CommentDialogLst.cpp
+#: src/CommentDialogLst.cpp src/muuli_wdr.cpp
 msgid "Comment"
 msgstr "Commentaar"
 
@@ -1607,18 +1588,15 @@ msgstr "Auto [Ho]"
 msgid "Very low"
 msgstr "Heel laag"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Low"
 msgstr "Laag"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Normal"
 msgstr "Normaal"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "High"
 msgstr "Hoog"
 
@@ -1642,13 +1620,11 @@ msgstr "Verbinden via server"
 msgid "Queue Full"
 msgstr "Wachtrij vol"
 
-#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp
-#: src/muuli_wdr.cpp
+#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp src/muuli_wdr.cpp
 msgid "On Queue"
 msgstr "In wachtrij"
 
-#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp
-#: src/PartFile.cpp src/TransferWnd.cpp
+#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Downloading"
 msgstr "Downloaden"
 
@@ -1708,8 +1684,7 @@ msgstr "Lokale server"
 msgid "Remote Server"
 msgstr "Server op Afstand"
 
-#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp
-#: src/TextClient.cpp
+#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp src/TextClient.cpp
 msgid "Kad"
 msgstr "Kad"
 
@@ -1733,8 +1708,7 @@ msgstr "Bron seeds"
 msgid "Search Result"
 msgstr "Zoekresultaat"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp
-#: src/TransferWnd.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Completed"
 msgstr "Compleet"
 
@@ -1786,8 +1760,7 @@ msgstr "Kan niet aanpassen binnen een recursieve deellijst"
 msgid "Part"
 msgstr "Deel"
 
-#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp
-#: src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Size"
 msgstr "Grootte"
 
@@ -1795,8 +1768,7 @@ msgstr "Grootte"
 msgid "Transferred"
 msgstr "Overgebracht"
 
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
-#: src/SourceListCtrl.cpp
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp src/SourceListCtrl.cpp
 msgid "Speed"
 msgstr "Snelheid"
 
@@ -1804,13 +1776,11 @@ msgstr "Snelheid"
 msgid "Progress"
 msgstr "Voortgang"
 
-#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp
-#: src/SearchListCtrl.cpp
+#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
 msgid "Sources"
 msgstr "Bronnen"
 
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp
-#: src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Priority"
 msgstr "Prioriteit"
 
@@ -1834,9 +1804,7 @@ msgstr "Laatste overdracht"
 msgid "Auto"
 msgstr "Auto"
 
-#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/TransferWnd.cpp
-#: src/utils/wxCas/src/wxcasprefs.cpp
+#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/TransferWnd.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Cancel"
 msgstr "Annuleren"
 
@@ -1937,8 +1905,7 @@ msgstr "Voer een nieuwe naam voor dit bestand in:"
 msgid "File rename"
 msgstr "Naam wijzigen"
 
-#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp
-#: src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f MiB/s"
 msgstr "%.1f MiB/s"
@@ -2742,13 +2709,11 @@ msgstr ""
 msgid "Start aMule automatically when I log in"
 msgstr "aMule automatisch starten bij aanmelden"
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
-#: packaging/windows/installer_strings.c
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp packaging/windows/installer_strings.c
 msgid "Register aMule for ed2k:// links"
 msgstr "aMule registreren voor ed2k://-koppelingen"
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
-#: packaging/windows/installer_strings.c
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp packaging/windows/installer_strings.c
 msgid "Register aMule for magnet: links"
 msgstr "aMule registreren voor magnet:-koppelingen"
 
@@ -2776,8 +2741,7 @@ msgstr ""
 msgid "Destination folder for downloads"
 msgstr "Doelmap voor downloads"
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
-#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Browse"
 msgstr "Bladeren"
 
@@ -3221,18 +3185,15 @@ msgstr "Voltooien"
 msgid "Complete"
 msgstr "Compleet"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
-#: src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Paused"
 msgstr "Gepauzeerd"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
-#: src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Erroneous"
 msgstr "Foutief"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
-#: src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Waiting"
 msgstr "Wachten"
 
@@ -3394,8 +3355,7 @@ msgstr "Sluiten"
 msgid "Cut"
 msgstr "Knippen"
 
-#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp
-#: src/utils/aLinkCreator/src/alcframe.cpp
+#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy"
 msgstr "Kopiëren"
 
@@ -3403,8 +3363,7 @@ msgstr "Kopiëren"
 msgid "Paste"
 msgstr "Plakken"
 
-#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp
-#: src/utils/aLinkCreator/src/alcframe.cpp
+#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Clear"
 msgstr "Wissen"
 
@@ -3412,8 +3371,7 @@ msgstr "Wissen"
 msgid "Select All"
 msgstr "Alles selecteren"
 
-#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
-#: src/StatisticsDlg.cpp
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp src/StatisticsDlg.cpp
 msgid "KiB/s"
 msgstr "KiB/s"
 
@@ -3669,10 +3627,6 @@ msgstr "Server nu mee verbonden."
 msgid "Search"
 msgstr "Zoeken"
 
-#: src/muuli_wdr.cpp
-msgid "Name:"
-msgstr "Naam:"
-
 #: src/muuli_wdr.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Type"
 msgstr "Type"
@@ -3762,8 +3716,8 @@ msgid "Availability"
 msgstr "Beschikbaarheid"
 
 #: src/muuli_wdr.cpp
-msgid "Filter:"
-msgstr "Filter:"
+msgid "Filter"
+msgstr "Filter"
 
 #: src/muuli_wdr.cpp
 msgid "Invert Result"
@@ -3818,6 +3772,10 @@ msgid "Clears completed downloads"
 msgstr "Verwijdert complete downloads"
 
 #: src/muuli_wdr.cpp
+msgid "Filter:"
+msgstr "Filter:"
+
+#: src/muuli_wdr.cpp
 msgid "File sources:"
 msgstr "Bestandsbronnen:"
 
@@ -3826,80 +3784,76 @@ msgid "General"
 msgstr "Algemeen"
 
 #: src/muuli_wdr.cpp
-msgid "Full Name :"
-msgstr "Volledige naam :"
+msgid "Full Name"
+msgstr "Volledige naam"
 
 #: src/muuli_wdr.cpp
-msgid "met-File :"
-msgstr "met-Bestand :"
+msgid "met-File"
+msgstr "met-Bestand"
 
 #: src/muuli_wdr.cpp
-msgid "Hash :"
-msgstr "Hash :"
+msgid "Hash"
+msgstr "Hash"
 
 #: src/muuli_wdr.cpp
-msgid "Filesize :"
-msgstr "Bestandsgrootte :"
+msgid "Filesize"
+msgstr "Bestandsgrootte"
 
 #: src/muuli_wdr.cpp src/Statistics.cpp
 msgid "Transfer"
 msgstr "Overdracht"
 
 #: src/muuli_wdr.cpp
-msgid "Partfilestatus :"
-msgstr "Deelbestandstatus :"
+msgid "Partfilestatus"
+msgstr "Deelbestandstatus"
 
 #: src/muuli_wdr.cpp
-msgid "Last seen complete :"
-msgstr "Laatst compleet gezien :"
+msgid "Last seen complete"
+msgstr "Laatst compleet gezien"
 
 #: src/muuli_wdr.cpp
-msgid "Found Sources :"
-msgstr "Gevonden bronnen :"
+msgid "Found Sources"
+msgstr "Gevonden bronnen"
 
 #: src/muuli_wdr.cpp
-msgid "Transferring Sources :"
-msgstr "Bronnen overdragen :"
+msgid "Transferring Sources"
+msgstr "Bronnen overdragen"
 
 #: src/muuli_wdr.cpp
-msgid "Filepart-Count :"
-msgstr "Bestandsdeel-teller :"
+msgid "Filepart-Count"
+msgstr "Bestandsdeel-teller"
 
 #: src/muuli_wdr.cpp
-msgid "Available :"
-msgstr "Beschikbaar :"
+msgid "Available"
+msgstr "Beschikbaar"
 
 #: src/muuli_wdr.cpp
-msgid "Datarate :"
-msgstr "Datasnelheid :"
+msgid "Datarate"
+msgstr "Datasnelheid"
 
 #: src/muuli_wdr.cpp
-msgid "Download Active Time: "
-msgstr "Actieve downloadtijd: "
+msgid "Download Active Time"
+msgstr "Actieve downloadtijd"
 
 #: src/muuli_wdr.cpp
-msgid "Transferred :"
-msgstr "Overgedragen :"
-
-#: src/muuli_wdr.cpp
-msgid "Completed Size :"
-msgstr "Volledige grootte :"
+msgid "Completed Size"
+msgstr "Volledige grootte"
 
 #: src/muuli_wdr.cpp
 msgid "Intelligent Corruption Handling"
 msgstr "Intelligente corruptieafhandeling (I.C.H.)"
 
 #: src/muuli_wdr.cpp
-msgid "Lost to corruption :"
-msgstr "Verloren door beschadiging :"
+msgid "Lost to corruption"
+msgstr "Verloren door beschadiging"
 
 #: src/muuli_wdr.cpp
-msgid "Gained by compression :"
-msgstr "Gewonnen door compressie :"
+msgid "Gained by compression"
+msgstr "Gewonnen door compressie"
 
 #: src/muuli_wdr.cpp
-msgid "Packages saved by I.C.H. :"
-msgstr "Pakketten gered door I.C.H. :"
+msgid "Packages saved by I.C.H."
+msgstr "Pakketten gered door I.C.H."
 
 #: src/muuli_wdr.cpp
 msgid "Sharing"
@@ -3937,29 +3891,29 @@ msgstr "Laatste upload"
 msgid "Media Info"
 msgstr "Media-informatie"
 
-#: src/muuli_wdr.cpp
-msgid "Length :"
-msgstr "Lengte :"
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
+msgid "Length"
+msgstr "Lengte"
+
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
+msgid "Bitrate"
+msgstr "Bitrate"
+
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
+msgid "Codec"
+msgstr "Codec"
 
 #: src/muuli_wdr.cpp
-msgid "Bitrate :"
-msgstr "Bitrate :"
+msgid "Artist"
+msgstr "Artiest"
 
 #: src/muuli_wdr.cpp
-msgid "Codec :"
-msgstr "Codec :"
+msgid "Album"
+msgstr "Album"
 
 #: src/muuli_wdr.cpp
-msgid "Artist :"
-msgstr "Artiest :"
-
-#: src/muuli_wdr.cpp
-msgid "Album :"
-msgstr "Album :"
-
-#: src/muuli_wdr.cpp
-msgid "Title :"
-msgstr "Titel :"
+msgid "Title"
+msgstr "Titel"
 
 #: src/muuli_wdr.cpp
 msgid "File Names"
@@ -4045,25 +3999,17 @@ msgstr "Onbekende grootte"
 msgid "Required Information"
 msgstr "Benodigde informatie"
 
-#: src/muuli_wdr.cpp
-msgid "IP Address :"
-msgstr "IP-adres :"
-
-#: src/muuli_wdr.cpp
-msgid "Port :"
-msgstr "Poort :"
+#: src/muuli_wdr.cpp src/ServerListCtrl.cpp
+msgid "Port"
+msgstr "Poort"
 
 #: src/muuli_wdr.cpp
 msgid "Additional Information"
 msgstr "Extra informatie"
 
 #: src/muuli_wdr.cpp
-msgid "Username :"
-msgstr "Gebruikersnaam :"
-
-#: src/muuli_wdr.cpp
-msgid "Userhash :"
-msgstr "Gebruikershash :"
+msgid "Userhash"
+msgstr "Gebruikershash"
 
 #: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Add"
@@ -4098,96 +4044,80 @@ msgid "Statistics Tree"
 msgstr "Statistiekenboom"
 
 #: src/muuli_wdr.cpp
-msgid "Username:"
-msgstr "Gebruikersnaam:"
+msgid "Client software"
+msgstr "Client software"
 
 #: src/muuli_wdr.cpp
-msgid "Userhash:"
-msgstr "Gebruikershash:"
+msgid "Client version"
+msgstr "Client versie"
 
 #: src/muuli_wdr.cpp
-msgid "Client software:"
-msgstr "Client software:"
+msgid "User ID"
+msgstr "Gebruikers-ID"
 
 #: src/muuli_wdr.cpp
-msgid "Client version:"
-msgstr "Client versie:"
-
-#: src/muuli_wdr.cpp src/ServerWnd.cpp
-msgid "IP address:"
-msgstr "IP-adres:"
+msgid "Server IP"
+msgstr "Server-IP"
 
 #: src/muuli_wdr.cpp
-msgid "User ID:"
-msgstr "Gebruikers-ID:"
+msgid "Server name"
+msgstr "Server-naam"
 
 #: src/muuli_wdr.cpp
-msgid "Server IP:"
-msgstr "Server-IP:"
-
-#: src/muuli_wdr.cpp
-msgid "Server name:"
-msgstr "Server-naam:"
-
-#: src/muuli_wdr.cpp
-msgid "Obfuscation:"
-msgstr "Maskering:"
-
-#: src/muuli_wdr.cpp
-msgid "Kad:"
-msgstr "Kad:"
+msgid "Obfuscation"
+msgstr "Maskering"
 
 #: src/muuli_wdr.cpp
 msgid "Transfers to client"
 msgstr "Overdrachten naar client"
 
 #: src/muuli_wdr.cpp
-msgid "Current request:"
-msgstr "Huidige aanvraag:"
+msgid "Current request"
+msgstr "Huidige aanvraag"
 
 #: src/muuli_wdr.cpp
-msgid "Average upload rate:"
-msgstr "Gemiddelde uploadsnelheid:"
+msgid "Average upload rate"
+msgstr "Gemiddelde uploadsnelheid"
 
 #: src/muuli_wdr.cpp
-msgid "Average download rate:"
-msgstr "Gemiddelde downloadsnelheid:"
+msgid "Average download rate"
+msgstr "Gemiddelde downloadsnelheid"
 
 #: src/muuli_wdr.cpp
-msgid "Uploaded (session):"
-msgstr "Geupload (sessie):"
+msgid "Uploaded (session)"
+msgstr "Geupload (sessie)"
 
 #: src/muuli_wdr.cpp
-msgid "Downloaded (session):"
-msgstr "Gedownload (sessie):"
+msgid "Downloaded (session)"
+msgstr "Gedownload (sessie)"
 
 #: src/muuli_wdr.cpp
-msgid "Uploaded (total):"
-msgstr "Geupload (totaal):"
+msgid "Uploaded (total)"
+msgstr "Geupload (totaal)"
 
 #: src/muuli_wdr.cpp
-msgid "Downloaded (total):"
-msgstr "Gedownload (totaal):"
+msgid "Downloaded (total)"
+msgstr "Gedownload (totaal)"
 
 #: src/muuli_wdr.cpp
 msgid "Scores"
 msgstr "Scores"
 
 #: src/muuli_wdr.cpp
-msgid "DL/UP modifier:"
-msgstr "DL/UP-verhouding:"
+msgid "DL/UP modifier"
+msgstr "DL/UP-verhouding"
 
 #: src/muuli_wdr.cpp
-msgid "Secure ident:"
-msgstr "Veilige identiteit:"
+msgid "Secure ident"
+msgstr "Veilige identiteit"
 
 #: src/muuli_wdr.cpp
-msgid "Queue rank:"
-msgstr "Wachtrij positie:"
+msgid "Queue rank"
+msgstr "Wachtrij positie"
 
 #: src/muuli_wdr.cpp
-msgid "Queue score:"
-msgstr "Wachtrij score:"
+msgid "Queue score"
+msgstr "Wachtrij score"
 
 #: src/muuli_wdr.cpp
 msgid "Nick"
@@ -4966,24 +4896,20 @@ msgid "Reset any changes made to the preferences."
 msgstr "Maak veranderingen aan de voorkeuren ongedaan."
 
 #: src/muuli_wdr.cpp
-msgid "Comment :"
-msgstr "Commentaar :"
+msgid "Incoming Dir"
+msgstr "Binnenkomende map"
 
 #: src/muuli_wdr.cpp
-msgid "Incoming Dir :"
-msgstr "Binnenkomende map :"
-
-#: src/muuli_wdr.cpp
-msgid "Change priority for new assigned files :"
-msgstr "Verander prioriteit voor nieuw toegevoegde bestanden :"
+msgid "Change priority for new assigned files"
+msgstr "Verander prioriteit voor nieuw toegevoegde bestanden"
 
 #: src/muuli_wdr.cpp
 msgid "Don't change"
 msgstr "Niet veranderen"
 
 #: src/muuli_wdr.cpp
-msgid "Select color for this Category (currently selected) :"
-msgstr "Selecteer kleur voor deze categorie (nu geselecteerd) :"
+msgid "Select color for this Category (currently selected)"
+msgstr "Selecteer kleur voor deze categorie (nu geselecteerd)"
 
 #: src/muuli_wdr.cpp
 msgid "Click this button to reset the log."
@@ -5064,10 +4990,6 @@ msgstr "Bootstrap van node: IP"
 #: src/muuli_wdr.cpp
 msgid "Enter the IP of the node here, using the x.x.x.x format."
 msgstr "Voer hier het IP van de node in, gebuik het x.x.x.x formaat."
-
-#: src/muuli_wdr.cpp
-msgid "Port:"
-msgstr "Poort:"
 
 #: src/muuli_wdr.cpp
 msgid "Use Secure User Identification"
@@ -5344,20 +5266,20 @@ msgid "Enable/disable proxy support"
 msgstr "Schakel proxy ondersteuning in/uit"
 
 #: src/muuli_wdr.cpp
-msgid "Proxy type:"
-msgstr "Proxy-type:"
+msgid "Proxy type"
+msgstr "Proxy-type"
 
 #: src/muuli_wdr.cpp
-msgid "Proxy host:"
-msgstr "Proxy-host:"
+msgid "Proxy host"
+msgstr "Proxy-host"
 
 #: src/muuli_wdr.cpp
 msgid "The proxy host name"
 msgstr "De proxy hostnaam"
 
 #: src/muuli_wdr.cpp
-msgid "Proxy port:"
-msgstr "Proxy-poort:"
+msgid "Proxy port"
+msgstr "Proxy-poort"
 
 #: src/muuli_wdr.cpp
 msgid "The proxy port"
@@ -5372,16 +5294,8 @@ msgid "Enable/disable username/password authentication"
 msgstr "Schakel gebruikersnaam/wachtwoord aanmelding in/uit"
 
 #: src/muuli_wdr.cpp
-msgid "Username: "
-msgstr "Gebruikersnaam: "
-
-#: src/muuli_wdr.cpp
 msgid "The username to use to connect to the proxy"
 msgstr "De gebruikersnaam is nodig om te verbinden met de proxy"
-
-#: src/muuli_wdr.cpp
-msgid "Password:"
-msgstr "Wachtwoord:"
 
 #: src/muuli_wdr.cpp
 msgid "The password to use to connect to the proxy"
@@ -5554,6 +5468,15 @@ msgstr "uren"
 #: src/OtherFunctions.cpp
 msgid "days"
 msgstr "dagen"
+
+#. TRANSLATORS:
+#. Punctuation for a "label: value" pair. %s is the already-translated
+#. label. Place the colon as your language requires -- e.g. "%s :" with a
+#. space in French, "%s:" without one in Russian and English.
+#: src/OtherFunctions.cpp
+#, c-format
+msgid "%s:"
+msgstr ""
 
 #: src/OtherFunctions.cpp
 msgid "all"
@@ -6584,8 +6507,7 @@ msgstr "Als u ze recursief deelt, wordt elk bestand daaronder gepubliceerd op de
 msgid "Confirm shared folders"
 msgstr "Gedeelde mappen bevestigen"
 
-#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp
-#: src/SharedFilesReloadProgress.cpp
+#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp src/SharedFilesReloadProgress.cpp
 msgid "Reloading shared files..."
 msgstr "Gedeelde bestanden opnieuw laden..."
 
@@ -6714,18 +6636,6 @@ msgstr "Fout %u: %s\n"
 #: src/SearchListCtrl.cpp
 msgid "FileID"
 msgstr "Bestands-ID"
-
-#: src/SearchListCtrl.cpp
-msgid "Length"
-msgstr "Lengte"
-
-#: src/SearchListCtrl.cpp
-msgid "Bitrate"
-msgstr "Bitrate"
-
-#: src/SearchListCtrl.cpp
-msgid "Codec"
-msgstr "Codec"
 
 #: src/SearchListCtrl.cpp
 msgid "Expand all"
@@ -7003,10 +6913,6 @@ msgstr "De lokale server wordt door de IP-filters weggefilterd, er wordt verbond
 #: src/ServerListCtrl.cpp
 msgid "Server Name"
 msgstr "Server-naam"
-
-#: src/ServerListCtrl.cpp
-msgid "Port"
-msgstr "Poort"
 
 #: src/ServerListCtrl.cpp
 msgid "Description"
@@ -7293,6 +7199,10 @@ msgstr "Aan het verbinden met buddy"
 #, c-format
 msgid "Connected to buddy at %s"
 msgstr "Verbonden met buddy op %s"
+
+#: src/ServerWnd.cpp
+msgid "IP address:"
+msgstr "IP-adres:"
 
 #: src/ServerWnd.cpp
 msgid "Indexed sources:"

--- a/po/nn.po
+++ b/po/nn.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-04 12:13+0200\n"
+"POT-Creation-Date: 2026-09-05 12:01+0200\n"
 "PO-Revision-Date: 2026-09-03 11:08+0000\n"
 "Last-Translator: Hallvor Brunstad <Hallvor_1976@yahoo.com>\n"
 "Language-Team: <i18n-nn@lister.ping.uio.no>\n"
@@ -389,8 +389,7 @@ msgstr "vevtenar køyrer på pid %d"
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Du freista å køyre vevtenar ved oppstart, men binærfila amuleweb kan ikkje køyrast. Installer pakken som inneheld vevtenaren til aMule, eller kompiler aMule med --enable-webserver og køyr make install"
 
-#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
-#: src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
+#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
 msgid "ERROR"
 msgstr "FEIL"
 
@@ -679,8 +678,7 @@ msgstr "Nettverk"
 msgid "Searches"
 msgstr "Søk"
 
-#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/Statistics.cpp
+#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/Statistics.cpp
 msgid "Downloads"
 msgstr "Nedlastingar"
 
@@ -764,9 +762,7 @@ msgstr "Kad: Av"
 msgid "Core"
 msgstr ""
 
-#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#: src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp
-#: src/SourceListCtrl.cpp src/Statistics.cpp
+#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp src/Statistics.cpp
 msgid "Version"
 msgstr "Utgåve"
 
@@ -1070,11 +1066,7 @@ msgstr ""
 msgid "The remote core sent inconsistent data for \"%s\" (part status %d, expected %d). The file list may be showing the wrong information; reconnect to clear it."
 msgstr ""
 
-#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp
-#: src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp
-#: src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp
-#: src/Statistics.cpp
+#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp src/Statistics.cpp
 msgid "Unknown"
 msgstr "Ukjend"
 
@@ -1172,8 +1164,7 @@ msgstr "Feil under lagring av known.met fila: %s"
 msgid "Enter Captcha"
 msgstr ""
 
-#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp
-#: src/TransferWnd.cpp
+#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp src/TransferWnd.cpp
 msgid "Category"
 msgstr "Kategori"
 
@@ -1337,13 +1328,11 @@ msgstr "Inga 'cryptkey.dat' fil funne - opprettar."
 msgid "Client Details"
 msgstr "Klientdetaljar"
 
-#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
-#: src/utils/wxCas/src/onlinesig.cpp
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
 msgid "LowID"
 msgstr "LågID"
 
-#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
-#: src/utils/wxCas/src/onlinesig.cpp
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
 msgid "HighID"
 msgstr "HøgID"
 
@@ -1359,8 +1348,7 @@ msgstr "Støtta"
 msgid "Not supported"
 msgstr "Ikkje støtta"
 
-#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
-#: src/TextClient.cpp
+#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp src/TextClient.cpp
 msgid "Connected"
 msgstr "Tilkopla"
 
@@ -1368,28 +1356,24 @@ msgstr "Tilkopla"
 msgid "Disconnected"
 msgstr "Fråkopla"
 
-#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp
-#: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f KiB/s"
 msgstr ""
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#, fuzzy
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/muuli_wdr.cpp
 msgid "Name"
-msgstr "Namn:"
+msgstr "Namn"
 
 #: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
 msgid "Software"
 msgstr ""
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#, fuzzy
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/muuli_wdr.cpp
 msgid "IP Address"
-msgstr "IP-adresse :"
+msgstr "IP-adresse"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Origin"
 msgstr ""
 
@@ -1407,14 +1391,12 @@ msgstr "Sist motteke"
 msgid "Sessions"
 msgstr "Utgåve"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp
 #, fuzzy
 msgid "Upload Speed"
 msgstr "Opplastingsfart"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp
 #, fuzzy
 msgid "Download Speed"
 msgstr "Nedlastingsfart"
@@ -1470,13 +1452,11 @@ msgstr[1] ""
 msgid "Files"
 msgstr "Filer"
 
-#: src/ClientsListCtrl.cpp src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp
-#: src/SourceListCtrl.cpp
+#: src/ClientsListCtrl.cpp src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Uploaded"
 msgstr "Lasta opp"
 
-#: src/ClientsListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientsListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Downloaded"
 msgstr "Lasta ned"
 
@@ -1563,12 +1543,11 @@ msgstr "Brukar %s·(%u) nekta tilgang til delte kataloger/filer"
 msgid "File Comments"
 msgstr "Filkommentarar"
 
-#: src/CommentDialogLst.cpp src/FriendListCtrl.cpp
+#: src/CommentDialogLst.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
 msgid "Username"
 msgstr "Brukarnamn"
 
-#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp
-#: src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "File Name"
 msgstr "Filnamn"
 
@@ -1576,7 +1555,7 @@ msgstr "Filnamn"
 msgid "Rating"
 msgstr "Verdi"
 
-#: src/CommentDialogLst.cpp
+#: src/CommentDialogLst.cpp src/muuli_wdr.cpp
 msgid "Comment"
 msgstr "Kommentar"
 
@@ -1629,18 +1608,15 @@ msgstr "Auto·[Hø]"
 msgid "Very low"
 msgstr "Svært låg"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Low"
 msgstr "Låg"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Normal"
 msgstr "Vanleg"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "High"
 msgstr "Høg"
 
@@ -1664,13 +1640,11 @@ msgstr "Koplar til gjennom tenar"
 msgid "Queue Full"
 msgstr "Kø full"
 
-#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp
-#: src/muuli_wdr.cpp
+#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp src/muuli_wdr.cpp
 msgid "On Queue"
 msgstr "I kø"
 
-#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp
-#: src/PartFile.cpp src/TransferWnd.cpp
+#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Downloading"
 msgstr "Lastar ned"
 
@@ -1730,8 +1704,7 @@ msgstr "Lokal tenar"
 msgid "Remote Server"
 msgstr "Fjern tenar"
 
-#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp
-#: src/TextClient.cpp
+#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp src/TextClient.cpp
 msgid "Kad"
 msgstr "Kad"
 
@@ -1755,8 +1728,7 @@ msgstr "Kjeldefrø"
 msgid "Search Result"
 msgstr ""
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp
-#: src/TransferWnd.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Completed"
 msgstr "Ferdig"
 
@@ -1809,8 +1781,7 @@ msgstr ""
 msgid "Part"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp
-#: src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Size"
 msgstr "Storleik"
 
@@ -1818,8 +1789,7 @@ msgstr "Storleik"
 msgid "Transferred"
 msgstr "Overført"
 
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
-#: src/SourceListCtrl.cpp
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp src/SourceListCtrl.cpp
 msgid "Speed"
 msgstr "Fart"
 
@@ -1827,13 +1797,11 @@ msgstr "Fart"
 msgid "Progress"
 msgstr "Framdrift"
 
-#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp
-#: src/SearchListCtrl.cpp
+#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
 msgid "Sources"
 msgstr "Kjelder"
 
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp
-#: src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Priority"
 msgstr "Prioritet"
 
@@ -1857,9 +1825,7 @@ msgstr "Sist motteke"
 msgid "Auto"
 msgstr "Automatisk"
 
-#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/TransferWnd.cpp
-#: src/utils/wxCas/src/wxcasprefs.cpp
+#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/TransferWnd.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Cancel"
 msgstr "Avbryt"
 
@@ -1960,8 +1926,7 @@ msgstr "Skriv nytt namn på denne fila:"
 msgid "File rename"
 msgstr "Døyp om fil"
 
-#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp
-#: src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f MiB/s"
 msgstr ""
@@ -2771,13 +2736,11 @@ msgstr ""
 msgid "Start aMule automatically when I log in"
 msgstr ""
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
-#: packaging/windows/installer_strings.c
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp packaging/windows/installer_strings.c
 msgid "Register aMule for ed2k:// links"
 msgstr ""
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
-#: packaging/windows/installer_strings.c
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp packaging/windows/installer_strings.c
 msgid "Register aMule for magnet: links"
 msgstr ""
 
@@ -2803,8 +2766,7 @@ msgstr ""
 msgid "Destination folder for downloads"
 msgstr ""
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
-#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Browse"
 msgstr "Bla"
 
@@ -3251,18 +3213,15 @@ msgstr "Ferdigstiller"
 msgid "Complete"
 msgstr "Ferdig"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
-#: src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Paused"
 msgstr "Pausa"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
-#: src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Erroneous"
 msgstr "Feilaktig"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
-#: src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Waiting"
 msgstr "Ventar"
 
@@ -3428,8 +3387,7 @@ msgstr "Stengje"
 msgid "Cut"
 msgstr "Klipp ut"
 
-#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp
-#: src/utils/aLinkCreator/src/alcframe.cpp
+#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy"
 msgstr "Kopiér"
 
@@ -3437,8 +3395,7 @@ msgstr "Kopiér"
 msgid "Paste"
 msgstr "Lim inn"
 
-#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp
-#: src/utils/aLinkCreator/src/alcframe.cpp
+#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Clear"
 msgstr "Frigjer plass"
 
@@ -3446,8 +3403,7 @@ msgstr "Frigjer plass"
 msgid "Select All"
 msgstr "Vél alle"
 
-#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
-#: src/StatisticsDlg.cpp
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp src/StatisticsDlg.cpp
 msgid "KiB/s"
 msgstr ""
 
@@ -3711,10 +3667,6 @@ msgstr "Novérande tilkopla tenar."
 msgid "Search"
 msgstr "Søk"
 
-#: src/muuli_wdr.cpp
-msgid "Name:"
-msgstr "Namn:"
-
 #: src/muuli_wdr.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Type"
 msgstr "Sort"
@@ -3804,8 +3756,8 @@ msgid "Availability"
 msgstr "Tilgjenge"
 
 #: src/muuli_wdr.cpp
-msgid "Filter:"
-msgstr "Filter:"
+msgid "Filter"
+msgstr "Filter"
 
 #: src/muuli_wdr.cpp
 msgid "Invert Result"
@@ -3863,6 +3815,10 @@ msgid "Clears completed downloads"
 msgstr "Ryddar bort ferdige nedlastingar"
 
 #: src/muuli_wdr.cpp
+msgid "Filter:"
+msgstr "Filter:"
+
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "File sources:"
 msgstr "Komplette kjelder"
@@ -3872,80 +3828,76 @@ msgid "General"
 msgstr "Generelt"
 
 #: src/muuli_wdr.cpp
-msgid "Full Name :"
-msgstr "Fullt namn :"
+msgid "Full Name"
+msgstr "Fullt namn"
 
 #: src/muuli_wdr.cpp
-msgid "met-File :"
-msgstr "metfil :"
+msgid "met-File"
+msgstr "metfil"
 
 #: src/muuli_wdr.cpp
-msgid "Hash :"
-msgstr "Hash :"
+msgid "Hash"
+msgstr "Hash"
 
 #: src/muuli_wdr.cpp
-msgid "Filesize :"
-msgstr "Filstorleik :"
+msgid "Filesize"
+msgstr "Filstorleik"
 
 #: src/muuli_wdr.cpp src/Statistics.cpp
 msgid "Transfer"
 msgstr "Overføring"
 
 #: src/muuli_wdr.cpp
-msgid "Partfilestatus :"
-msgstr "Delfilstatus :"
+msgid "Partfilestatus"
+msgstr "Delfilstatus"
 
 #: src/muuli_wdr.cpp
-msgid "Last seen complete :"
-msgstr "Sist sett komplett :"
+msgid "Last seen complete"
+msgstr "Sist sett komplett"
 
 #: src/muuli_wdr.cpp
-msgid "Found Sources :"
-msgstr "Funne kjelder :"
+msgid "Found Sources"
+msgstr "Funne kjelder"
 
 #: src/muuli_wdr.cpp
-msgid "Transferring Sources :"
-msgstr "Overfører kjelder :"
+msgid "Transferring Sources"
+msgstr "Overfører kjelder"
 
 #: src/muuli_wdr.cpp
-msgid "Filepart-Count :"
-msgstr "Fildelstal :"
+msgid "Filepart-Count"
+msgstr "Fildelstal"
 
 #: src/muuli_wdr.cpp
-msgid "Available :"
-msgstr "Tilgjengeleg:"
+msgid "Available"
+msgstr "Tilgjengeleg"
 
 #: src/muuli_wdr.cpp
-msgid "Datarate :"
-msgstr "Datasnøggleik :"
+msgid "Datarate"
+msgstr "Datasnøggleik"
 
 #: src/muuli_wdr.cpp
-msgid "Download Active Time: "
-msgstr "Aktiv nedlastingstid: "
+msgid "Download Active Time"
+msgstr "Aktiv nedlastingstid"
 
 #: src/muuli_wdr.cpp
-msgid "Transferred :"
-msgstr "Overført :"
-
-#: src/muuli_wdr.cpp
-msgid "Completed Size :"
-msgstr "Ferdig storleik :"
+msgid "Completed Size"
+msgstr "Ferdig storleik"
 
 #: src/muuli_wdr.cpp
 msgid "Intelligent Corruption Handling"
 msgstr "Intelligent Korrupsjonshandsaming"
 
 #: src/muuli_wdr.cpp
-msgid "Lost to corruption :"
-msgstr "Tapt gjennom korrupsjon :"
+msgid "Lost to corruption"
+msgstr "Tapt gjennom korrupsjon"
 
 #: src/muuli_wdr.cpp
-msgid "Gained by compression :"
-msgstr "Vunne gjennom komprimering :"
+msgid "Gained by compression"
+msgstr "Vunne gjennom komprimering"
 
 #: src/muuli_wdr.cpp
-msgid "Packages saved by I.C.H. :"
-msgstr "Pakkar lagra av I.C.H. :"
+msgid "Packages saved by I.C.H."
+msgstr "Pakkar lagra av I.C.H."
 
 #: src/muuli_wdr.cpp
 #, fuzzy
@@ -3987,30 +3939,30 @@ msgstr " Opplasting: "
 msgid "Media Info"
 msgstr "Kad-info"
 
-#: src/muuli_wdr.cpp
-msgid "Length :"
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
+msgid "Length"
 msgstr ""
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
 #, fuzzy
-msgid "Bitrate :"
+msgid "Bitrate"
 msgstr "Ikkje gitt verdi"
 
-#: src/muuli_wdr.cpp
-msgid "Codec :"
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
+msgid "Codec"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Artist :"
+msgid "Artist"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Album :"
+msgid "Album"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Title :"
-msgstr "Tittel :"
+msgid "Title"
+msgstr "Tittel"
 
 #: src/muuli_wdr.cpp
 msgid "File Names"
@@ -4095,25 +4047,17 @@ msgstr "Ukjend storleik"
 msgid "Required Information"
 msgstr "Naudsynt informasjon"
 
-#: src/muuli_wdr.cpp
-msgid "IP Address :"
-msgstr "IP-adresse :"
-
-#: src/muuli_wdr.cpp
-msgid "Port :"
-msgstr "Port :"
+#: src/muuli_wdr.cpp src/ServerListCtrl.cpp
+msgid "Port"
+msgstr "Port"
 
 #: src/muuli_wdr.cpp
 msgid "Additional Information"
 msgstr "Tilleggsinformasjon"
 
 #: src/muuli_wdr.cpp
-msgid "Username :"
-msgstr "Brukarnamn :"
-
-#: src/muuli_wdr.cpp
-msgid "Userhash :"
-msgstr "Brukarhash :"
+msgid "Userhash"
+msgstr "Brukarhash"
 
 #: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Add"
@@ -4148,75 +4092,59 @@ msgid "Statistics Tree"
 msgstr "Statistikktre"
 
 #: src/muuli_wdr.cpp
-msgid "Username:"
-msgstr "Brukarnamn:"
+msgid "Client software"
+msgstr "Klientmjukvare"
 
 #: src/muuli_wdr.cpp
-msgid "Userhash:"
-msgstr "Brukarhash:"
+msgid "Client version"
+msgstr "Klienten si utgåve"
 
 #: src/muuli_wdr.cpp
-msgid "Client software:"
-msgstr "Klientmjukvare:"
+msgid "User ID"
+msgstr "BrukarID"
 
 #: src/muuli_wdr.cpp
-msgid "Client version:"
-msgstr "Klienten si utgåve:"
-
-#: src/muuli_wdr.cpp src/ServerWnd.cpp
-msgid "IP address:"
-msgstr "IP-adresse:"
+msgid "Server IP"
+msgstr "Tenar IP"
 
 #: src/muuli_wdr.cpp
-msgid "User ID:"
-msgstr "BrukarID:"
+msgid "Server name"
+msgstr "Tenarnamn"
 
 #: src/muuli_wdr.cpp
-msgid "Server IP:"
-msgstr "Tenar IP:"
-
-#: src/muuli_wdr.cpp
-msgid "Server name:"
-msgstr "Tenarnamn:"
-
-#: src/muuli_wdr.cpp
-msgid "Obfuscation:"
-msgstr "Tåkelegging:"
-
-#: src/muuli_wdr.cpp
-msgid "Kad:"
-msgstr "Kad:"
+msgid "Obfuscation"
+msgstr "Tåkelegging"
 
 #: src/muuli_wdr.cpp
 msgid "Transfers to client"
 msgstr "Overføringar til klient"
 
 #: src/muuli_wdr.cpp
-msgid "Current request:"
-msgstr "Novérande etterspurnader:"
+msgid "Current request"
+msgstr "Novérande etterspurnader"
 
 #: src/muuli_wdr.cpp
-msgid "Average upload rate:"
-msgstr "Gjennomsnittleg opplastingsfart:"
+msgid "Average upload rate"
+msgstr "Gjennomsnittleg opplastingsfart"
 
 #: src/muuli_wdr.cpp
-msgid "Average download rate:"
-msgstr "Gjennomsnittleg nedlastingsfart:"
+msgid "Average download rate"
+msgstr "Gjennomsnittleg nedlastingsfart"
 
 #: src/muuli_wdr.cpp
-msgid "Uploaded (session):"
-msgstr "Opplasta (økt):"
+msgid "Uploaded (session)"
+msgstr "Opplasta (økt)"
 
 #: src/muuli_wdr.cpp
-msgid "Downloaded (session):"
+msgid "Downloaded (session)"
 msgstr "Lasta ned (økt)"
 
 #: src/muuli_wdr.cpp
-msgid "Uploaded (total):"
-msgstr "Opplasta (totalt):"
+msgid "Uploaded (total)"
+msgstr "Opplasta (totalt)"
 
 #: src/muuli_wdr.cpp
-msgid "Downloaded (total):"
+msgid "Downloaded (total)"
 msgstr "Lasta ned (totalt)"
 
 #: src/muuli_wdr.cpp
@@ -4224,20 +4152,20 @@ msgid "Scores"
 msgstr "Scorar"
 
 #: src/muuli_wdr.cpp
-msgid "DL/UP modifier:"
-msgstr "NL/OL endringsfaktor:"
+msgid "DL/UP modifier"
+msgstr "NL/OL endringsfaktor"
 
 #: src/muuli_wdr.cpp
-msgid "Secure ident:"
-msgstr "Sikker identifikasjon:"
+msgid "Secure ident"
+msgstr "Sikker identifikasjon"
 
 #: src/muuli_wdr.cpp
 #, fuzzy
-msgid "Queue rank:"
+msgid "Queue rank"
 msgstr "I kø"
 
 #: src/muuli_wdr.cpp
-msgid "Queue score:"
+msgid "Queue score"
 msgstr "Køscore"
 
 #: src/muuli_wdr.cpp
@@ -5031,16 +4959,12 @@ msgid "Reset any changes made to the preferences."
 msgstr "Nullstill alle endringar i innstillingar."
 
 #: src/muuli_wdr.cpp
-msgid "Comment :"
-msgstr "Kommentar :"
+msgid "Incoming Dir"
+msgstr "Innkomande kat"
 
 #: src/muuli_wdr.cpp
-msgid "Incoming Dir :"
-msgstr "Innkomande kat:"
-
-#: src/muuli_wdr.cpp
-msgid "Change priority for new assigned files :"
-msgstr "Endre prioritet for nytileigna filer :"
+msgid "Change priority for new assigned files"
+msgstr "Endre prioritet for nytileigna filer"
 
 #: src/muuli_wdr.cpp
 #, fuzzy
@@ -5048,7 +4972,7 @@ msgid "Don't change"
 msgstr "Ikkje endre"
 
 #: src/muuli_wdr.cpp
-msgid "Select color for this Category (currently selected) :"
+msgid "Select color for this Category (currently selected)"
 msgstr "Vel farge for denne kategprien (no valt)"
 
 #: src/muuli_wdr.cpp
@@ -5134,10 +5058,6 @@ msgstr ""
 #, fuzzy
 msgid "Enter the IP of the node here, using the x.x.x.x format."
 msgstr "Skriv inn IP`en til tenaren her, i x.x.x.x format."
-
-#: src/muuli_wdr.cpp
-msgid "Port:"
-msgstr "Port:"
 
 #: src/muuli_wdr.cpp
 msgid "Use Secure User Identification"
@@ -5406,20 +5326,20 @@ msgid "Enable/disable proxy support"
 msgstr "Aktivere/deaktivere vikarstøtte"
 
 #: src/muuli_wdr.cpp
-msgid "Proxy type:"
-msgstr "Vikartype:"
+msgid "Proxy type"
+msgstr "Vikartype"
 
 #: src/muuli_wdr.cpp
-msgid "Proxy host:"
-msgstr "Vikarvert:"
+msgid "Proxy host"
+msgstr "Vikarvert"
 
 #: src/muuli_wdr.cpp
 msgid "The proxy host name"
 msgstr "Vikaren sitt vertsnamn"
 
 #: src/muuli_wdr.cpp
-msgid "Proxy port:"
-msgstr "Vikarport:"
+msgid "Proxy port"
+msgstr "Vikarport"
 
 #: src/muuli_wdr.cpp
 msgid "The proxy port"
@@ -5434,16 +5354,8 @@ msgid "Enable/disable username/password authentication"
 msgstr "Aktivér/deaktivér godkjenning av brukarnamn/passord"
 
 #: src/muuli_wdr.cpp
-msgid "Username: "
-msgstr ""
-
-#: src/muuli_wdr.cpp
 msgid "The username to use to connect to the proxy"
 msgstr "Brukarnamn å nytte for å kople til vikar"
-
-#: src/muuli_wdr.cpp
-msgid "Password:"
-msgstr "Passord:"
 
 #: src/muuli_wdr.cpp
 msgid "The password to use to connect to the proxy"
@@ -5625,6 +5537,15 @@ msgstr "timar"
 #: src/OtherFunctions.cpp
 msgid "days"
 msgstr "dagar"
+
+#. TRANSLATORS:
+#. Punctuation for a "label: value" pair. %s is the already-translated
+#. label. Place the colon as your language requires -- e.g. "%s :" with a
+#. space in French, "%s:" without one in Russian and English.
+#: src/OtherFunctions.cpp
+#, c-format
+msgid "%s:"
+msgstr ""
 
 #: src/OtherFunctions.cpp
 msgid "all"
@@ -6673,8 +6594,7 @@ msgstr ""
 msgid "Confirm shared folders"
 msgstr "Lastar inn att delte filer"
 
-#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp
-#: src/SharedFilesReloadProgress.cpp
+#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp src/SharedFilesReloadProgress.cpp
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "Lastar inn att delte filer"
@@ -6806,19 +6726,6 @@ msgstr ""
 #: src/SearchListCtrl.cpp
 msgid "FileID"
 msgstr "FilID"
-
-#: src/SearchListCtrl.cpp
-msgid "Length"
-msgstr ""
-
-#: src/SearchListCtrl.cpp
-#, fuzzy
-msgid "Bitrate"
-msgstr "Ikkje gitt verdi"
-
-#: src/SearchListCtrl.cpp
-msgid "Codec"
-msgstr ""
 
 #: src/SearchListCtrl.cpp
 msgid "Expand all"
@@ -7105,10 +7012,6 @@ msgstr "Lokal tenar er filtrert av ipfiltra - koplar til ein anna tenar!"
 #: src/ServerListCtrl.cpp
 msgid "Server Name"
 msgstr "Tenarnamn"
-
-#: src/ServerListCtrl.cpp
-msgid "Port"
-msgstr "Port"
 
 #: src/ServerListCtrl.cpp
 msgid "Description"
@@ -7406,6 +7309,10 @@ msgstr "Tilkopla kamerat"
 #, fuzzy, c-format
 msgid "Connected to buddy at %s"
 msgstr "Tilkopla kamerat"
+
+#: src/ServerWnd.cpp
+msgid "IP address:"
+msgstr "IP-adresse:"
 
 #: src/ServerWnd.cpp
 #, fuzzy

--- a/po/pl.po
+++ b/po/pl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-04 12:13+0200\n"
+"POT-Creation-Date: 2026-09-05 12:01+0200\n"
 "PO-Revision-Date: 2026-09-03 11:08+0000\n"
 "Last-Translator: Michał Trzebiatowski <hippie_1968@hotmail.com>\n"
 "Language-Team: translationproject.org/team/pl.html <translation-team-pl@lists.sourceforge.net>\n"
@@ -390,8 +390,7 @@ msgstr "serwer sieciowy uruchomiony na pid %d"
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Zażądałeś włączenia serwera sieciowego podczas uruchomienia, ale binarki amuleweb nie mogą być uruchomione. Zainstaluj paczkę zawierającą serwer sieciowy aMule lub skompiluj aMule używając --enable-webserver i uruchom make install"
 
-#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
-#: src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
+#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
 msgid "ERROR"
 msgstr "BŁĄD"
 
@@ -679,8 +678,7 @@ msgstr "Sieci"
 msgid "Searches"
 msgstr "Szukaj"
 
-#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/Statistics.cpp
+#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/Statistics.cpp
 msgid "Downloads"
 msgstr "Pobieranie"
 
@@ -764,9 +762,7 @@ msgstr "Kad: Wyłączony"
 msgid "Core"
 msgstr ""
 
-#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#: src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp
-#: src/SourceListCtrl.cpp src/Statistics.cpp
+#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp src/Statistics.cpp
 msgid "Version"
 msgstr "Wersja"
 
@@ -1065,11 +1061,7 @@ msgstr "Nie można utworzyć katalogu '%s' dla kategorii '%s', używany jest nad
 msgid "The remote core sent inconsistent data for \"%s\" (part status %d, expected %d). The file list may be showing the wrong information; reconnect to clear it."
 msgstr ""
 
-#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp
-#: src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp
-#: src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp
-#: src/Statistics.cpp
+#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp src/Statistics.cpp
 msgid "Unknown"
 msgstr "Nieznany"
 
@@ -1168,8 +1160,7 @@ msgstr "Błąd podczas zapisywania pliku %s: %s"
 msgid "Enter Captcha"
 msgstr "Wpisz Captcha"
 
-#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp
-#: src/TransferWnd.cpp
+#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp src/TransferWnd.cpp
 msgid "Category"
 msgstr "Kategoria"
 
@@ -1339,13 +1330,11 @@ msgstr "Nie znaleziono pliku cryptkey.dat, tworzenie."
 msgid "Client Details"
 msgstr "Szczegóły klienta"
 
-#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
-#: src/utils/wxCas/src/onlinesig.cpp
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
 msgid "LowID"
 msgstr "LowID"
 
-#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
-#: src/utils/wxCas/src/onlinesig.cpp
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
 msgid "HighID"
 msgstr "HighID"
 
@@ -1361,8 +1350,7 @@ msgstr "Obsługiwany"
 msgid "Not supported"
 msgstr "Nieobsługiwany"
 
-#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
-#: src/TextClient.cpp
+#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp src/TextClient.cpp
 msgid "Connected"
 msgstr "Połączony"
 
@@ -1370,28 +1358,24 @@ msgstr "Połączony"
 msgid "Disconnected"
 msgstr "Rozłączony"
 
-#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp
-#: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f KiB/s"
 msgstr ""
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#, fuzzy
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/muuli_wdr.cpp
 msgid "Name"
-msgstr "Nazwa:"
+msgstr "Nazwa"
 
 #: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
 msgid "Software"
 msgstr ""
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#, fuzzy
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/muuli_wdr.cpp
 msgid "IP Address"
-msgstr "Adres IP :"
+msgstr "Adres IP"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Origin"
 msgstr "Źródło"
 
@@ -1409,13 +1393,11 @@ msgstr "Ostatnio widziany"
 msgid "Sessions"
 msgstr "Wersja"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp
 msgid "Upload Speed"
 msgstr "Prędkość wysyłania"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp
 msgid "Download Speed"
 msgstr "Prędkość pobierania"
 
@@ -1471,13 +1453,11 @@ msgstr[2] ""
 msgid "Files"
 msgstr "Pliki"
 
-#: src/ClientsListCtrl.cpp src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp
-#: src/SourceListCtrl.cpp
+#: src/ClientsListCtrl.cpp src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Uploaded"
 msgstr "Wysłano"
 
-#: src/ClientsListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientsListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Downloaded"
 msgstr "Pobrano"
 
@@ -1564,12 +1544,11 @@ msgstr "Użytkownik %s (%u) odmówił dostępu do listy udostępnionych plików/
 msgid "File Comments"
 msgstr "Komentarze pliku"
 
-#: src/CommentDialogLst.cpp src/FriendListCtrl.cpp
+#: src/CommentDialogLst.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
 msgid "Username"
 msgstr "Nazwa użytkownika"
 
-#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp
-#: src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "File Name"
 msgstr "Nazwa pliku"
 
@@ -1577,7 +1556,7 @@ msgstr "Nazwa pliku"
 msgid "Rating"
 msgstr "Ocena"
 
-#: src/CommentDialogLst.cpp
+#: src/CommentDialogLst.cpp src/muuli_wdr.cpp
 msgid "Comment"
 msgstr "Komentarz"
 
@@ -1632,18 +1611,15 @@ msgstr "Auto [Wy]"
 msgid "Very low"
 msgstr "Bardzo niski"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Low"
 msgstr "Niski"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Normal"
 msgstr "Normalny"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "High"
 msgstr "Wysoki"
 
@@ -1667,13 +1643,11 @@ msgstr "Połączenie przez serwer"
 msgid "Queue Full"
 msgstr "Pełna kolejka"
 
-#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp
-#: src/muuli_wdr.cpp
+#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp src/muuli_wdr.cpp
 msgid "On Queue"
 msgstr "W kolejce"
 
-#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp
-#: src/PartFile.cpp src/TransferWnd.cpp
+#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Downloading"
 msgstr "Pobieranie"
 
@@ -1733,8 +1707,7 @@ msgstr "Serwer lokalny"
 msgid "Remote Server"
 msgstr "Serwer zdalny"
 
-#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp
-#: src/TextClient.cpp
+#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp src/TextClient.cpp
 msgid "Kad"
 msgstr "Kad"
 
@@ -1758,8 +1731,7 @@ msgstr "Ziarna źródła"
 msgid "Search Result"
 msgstr "Wynik wyszukiwania"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp
-#: src/TransferWnd.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Completed"
 msgstr "Zakończono"
 
@@ -1812,8 +1784,7 @@ msgstr ""
 msgid "Part"
 msgstr "Część"
 
-#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp
-#: src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Size"
 msgstr "Rozmiar"
 
@@ -1821,8 +1792,7 @@ msgstr "Rozmiar"
 msgid "Transferred"
 msgstr "Przesłano"
 
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
-#: src/SourceListCtrl.cpp
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp src/SourceListCtrl.cpp
 msgid "Speed"
 msgstr "Prędkość"
 
@@ -1830,13 +1800,11 @@ msgstr "Prędkość"
 msgid "Progress"
 msgstr "Postęp"
 
-#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp
-#: src/SearchListCtrl.cpp
+#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
 msgid "Sources"
 msgstr "Źródła"
 
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp
-#: src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Priority"
 msgstr "Priorytet"
 
@@ -1860,9 +1828,7 @@ msgstr "Ostatnio widziany"
 msgid "Auto"
 msgstr "Automatyczny"
 
-#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/TransferWnd.cpp
-#: src/utils/wxCas/src/wxcasprefs.cpp
+#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/TransferWnd.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Cancel"
 msgstr "Anuluj"
 
@@ -1963,8 +1929,7 @@ msgstr "Wprowadź nową nazwę dla tego pliku:"
 msgid "File rename"
 msgstr "Zmień nazwę"
 
-#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp
-#: src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f MiB/s"
 msgstr ""
@@ -2771,13 +2736,11 @@ msgstr ""
 msgid "Start aMule automatically when I log in"
 msgstr ""
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
-#: packaging/windows/installer_strings.c
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp packaging/windows/installer_strings.c
 msgid "Register aMule for ed2k:// links"
 msgstr ""
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
-#: packaging/windows/installer_strings.c
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp packaging/windows/installer_strings.c
 msgid "Register aMule for magnet: links"
 msgstr ""
 
@@ -2803,8 +2766,7 @@ msgstr ""
 msgid "Destination folder for downloads"
 msgstr "Folder docelowy dla pobrań"
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
-#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Browse"
 msgstr "Przeglądaj"
 
@@ -3252,18 +3214,15 @@ msgstr "Zakańczanie"
 msgid "Complete"
 msgstr "Ukończono"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
-#: src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Paused"
 msgstr "Wstrzymano"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
-#: src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Erroneous"
 msgstr "Błędne"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
-#: src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Waiting"
 msgstr "Czeka"
 
@@ -3431,8 +3390,7 @@ msgstr "Zamknij"
 msgid "Cut"
 msgstr "Wytnij"
 
-#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp
-#: src/utils/aLinkCreator/src/alcframe.cpp
+#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy"
 msgstr "Kopiuj"
 
@@ -3440,8 +3398,7 @@ msgstr "Kopiuj"
 msgid "Paste"
 msgstr "Wklej"
 
-#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp
-#: src/utils/aLinkCreator/src/alcframe.cpp
+#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Clear"
 msgstr "Wyczyść"
 
@@ -3449,8 +3406,7 @@ msgstr "Wyczyść"
 msgid "Select All"
 msgstr "Zaznacz wszystko"
 
-#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
-#: src/StatisticsDlg.cpp
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp src/StatisticsDlg.cpp
 msgid "KiB/s"
 msgstr ""
 
@@ -3714,10 +3670,6 @@ msgstr "Aktualnie połączony serwer."
 msgid "Search"
 msgstr "Szukaj"
 
-#: src/muuli_wdr.cpp
-msgid "Name:"
-msgstr "Nazwa:"
-
 #: src/muuli_wdr.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Type"
 msgstr "Typ"
@@ -3807,8 +3759,8 @@ msgid "Availability"
 msgstr "Dostępność"
 
 #: src/muuli_wdr.cpp
-msgid "Filter:"
-msgstr "Filtr:"
+msgid "Filter"
+msgstr "Filtr"
 
 #: src/muuli_wdr.cpp
 msgid "Invert Result"
@@ -3866,6 +3818,10 @@ msgid "Clears completed downloads"
 msgstr "Wyczyść skończone pobierania"
 
 #: src/muuli_wdr.cpp
+msgid "Filter:"
+msgstr "Filtr:"
+
+#: src/muuli_wdr.cpp
 msgid "File sources:"
 msgstr "Źródła pliku:"
 
@@ -3874,80 +3830,76 @@ msgid "General"
 msgstr "Ogólne"
 
 #: src/muuli_wdr.cpp
-msgid "Full Name :"
-msgstr "Pełna nazwa :"
+msgid "Full Name"
+msgstr "Pełna nazwa"
 
 #: src/muuli_wdr.cpp
-msgid "met-File :"
-msgstr "plik met :"
+msgid "met-File"
+msgstr "plik met"
 
 #: src/muuli_wdr.cpp
-msgid "Hash :"
-msgstr "Skrót :"
+msgid "Hash"
+msgstr "Skrót"
 
 #: src/muuli_wdr.cpp
-msgid "Filesize :"
-msgstr "Rozmiar pliku :"
+msgid "Filesize"
+msgstr "Rozmiar pliku"
 
 #: src/muuli_wdr.cpp src/Statistics.cpp
 msgid "Transfer"
 msgstr "Transfer"
 
 #: src/muuli_wdr.cpp
-msgid "Partfilestatus :"
-msgstr "Status pliku części:"
+msgid "Partfilestatus"
+msgstr "Status pliku części"
 
 #: src/muuli_wdr.cpp
-msgid "Last seen complete :"
-msgstr "Ostatnio widziano całość :"
+msgid "Last seen complete"
+msgstr "Ostatnio widziano całość"
 
 #: src/muuli_wdr.cpp
-msgid "Found Sources :"
-msgstr "Znaleziono źródeł :"
+msgid "Found Sources"
+msgstr "Znaleziono źródeł"
 
 #: src/muuli_wdr.cpp
-msgid "Transferring Sources :"
-msgstr "Przesyłam ze źródeł :"
+msgid "Transferring Sources"
+msgstr "Przesyłam ze źródeł"
 
 #: src/muuli_wdr.cpp
-msgid "Filepart-Count :"
-msgstr "Części pliku :"
+msgid "Filepart-Count"
+msgstr "Części pliku"
 
 #: src/muuli_wdr.cpp
-msgid "Available :"
-msgstr "Dostępne :"
+msgid "Available"
+msgstr "Dostępne"
 
 #: src/muuli_wdr.cpp
-msgid "Datarate :"
-msgstr "Prędkość transmisji danych :"
+msgid "Datarate"
+msgstr "Prędkość transmisji danych"
 
 #: src/muuli_wdr.cpp
-msgid "Download Active Time: "
-msgstr "Aktywny czas pobierania: "
+msgid "Download Active Time"
+msgstr "Aktywny czas pobierania"
 
 #: src/muuli_wdr.cpp
-msgid "Transferred :"
-msgstr "Przesłano :"
-
-#: src/muuli_wdr.cpp
-msgid "Completed Size :"
-msgstr "Zakończono :"
+msgid "Completed Size"
+msgstr "Zakończono"
 
 #: src/muuli_wdr.cpp
 msgid "Intelligent Corruption Handling"
 msgstr "Inteligentny System Obsługi Błędów"
 
 #: src/muuli_wdr.cpp
-msgid "Lost to corruption :"
-msgstr "Utracono z powodu błędów :"
+msgid "Lost to corruption"
+msgstr "Utracono z powodu błędów"
 
 #: src/muuli_wdr.cpp
-msgid "Gained by compression :"
-msgstr "Zyskano przez kompresję :"
+msgid "Gained by compression"
+msgstr "Zyskano przez kompresję"
 
 #: src/muuli_wdr.cpp
-msgid "Packages saved by I.C.H. :"
-msgstr "Pakietów uratowanych przez I.C.H. :"
+msgid "Packages saved by I.C.H."
+msgstr "Pakietów uratowanych przez I.C.H."
 
 #: src/muuli_wdr.cpp
 #, fuzzy
@@ -3989,30 +3941,30 @@ msgstr ", Wysłanych: "
 msgid "Media Info"
 msgstr "Info Kad"
 
-#: src/muuli_wdr.cpp
-msgid "Length :"
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
+msgid "Length"
 msgstr ""
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
 #, fuzzy
-msgid "Bitrate :"
+msgid "Bitrate"
 msgstr "Nieoceniony"
 
-#: src/muuli_wdr.cpp
-msgid "Codec :"
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
+msgid "Codec"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Artist :"
+msgid "Artist"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Album :"
+msgid "Album"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Title :"
-msgstr "Tytuł :"
+msgid "Title"
+msgstr "Tytuł"
 
 #: src/muuli_wdr.cpp
 msgid "File Names"
@@ -4099,25 +4051,17 @@ msgstr "Nieznany rozmiar"
 msgid "Required Information"
 msgstr "Wymagane informacje"
 
-#: src/muuli_wdr.cpp
-msgid "IP Address :"
-msgstr "Adres IP :"
-
-#: src/muuli_wdr.cpp
-msgid "Port :"
-msgstr "Port :"
+#: src/muuli_wdr.cpp src/ServerListCtrl.cpp
+msgid "Port"
+msgstr "Port"
 
 #: src/muuli_wdr.cpp
 msgid "Additional Information"
 msgstr "Dodatkowe informacje"
 
 #: src/muuli_wdr.cpp
-msgid "Username :"
-msgstr "Nazwa użytkownika :"
-
-#: src/muuli_wdr.cpp
-msgid "Userhash :"
-msgstr "Skrót użytkownika :"
+msgid "Userhash"
+msgstr "Skrót użytkownika"
 
 #: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Add"
@@ -4152,96 +4096,80 @@ msgid "Statistics Tree"
 msgstr "Drzewo statystyk"
 
 #: src/muuli_wdr.cpp
-msgid "Username:"
-msgstr "Nazwa użytkownika:"
+msgid "Client software"
+msgstr "Oprogramowanie klienta"
 
 #: src/muuli_wdr.cpp
-msgid "Userhash:"
-msgstr "Skrót użytkownika:"
+msgid "Client version"
+msgstr "Wersja klienta"
 
 #: src/muuli_wdr.cpp
-msgid "Client software:"
-msgstr "Oprogramowanie klienta:"
+msgid "User ID"
+msgstr "ID użytkownika"
 
 #: src/muuli_wdr.cpp
-msgid "Client version:"
-msgstr "Wersja klienta:"
-
-#: src/muuli_wdr.cpp src/ServerWnd.cpp
-msgid "IP address:"
-msgstr "Adres IP:"
+msgid "Server IP"
+msgstr "IP Serwera"
 
 #: src/muuli_wdr.cpp
-msgid "User ID:"
-msgstr "ID użytkownika:"
+msgid "Server name"
+msgstr "Nazwa serwera"
 
 #: src/muuli_wdr.cpp
-msgid "Server IP:"
-msgstr "IP Serwera:"
-
-#: src/muuli_wdr.cpp
-msgid "Server name:"
-msgstr "Nazwa serwera:"
-
-#: src/muuli_wdr.cpp
-msgid "Obfuscation:"
-msgstr "Maskowanie:"
-
-#: src/muuli_wdr.cpp
-msgid "Kad:"
-msgstr "Kad:"
+msgid "Obfuscation"
+msgstr "Maskowanie"
 
 #: src/muuli_wdr.cpp
 msgid "Transfers to client"
 msgstr "Transfery do klientów"
 
 #: src/muuli_wdr.cpp
-msgid "Current request:"
-msgstr "Aktualnie żądań:"
+msgid "Current request"
+msgstr "Aktualnie żądań"
 
 #: src/muuli_wdr.cpp
-msgid "Average upload rate:"
-msgstr "Średnia prędkość wysyłania:"
+msgid "Average upload rate"
+msgstr "Średnia prędkość wysyłania"
 
 #: src/muuli_wdr.cpp
-msgid "Average download rate:"
-msgstr "Średnia prędkość pobierania:"
+msgid "Average download rate"
+msgstr "Średnia prędkość pobierania"
 
 #: src/muuli_wdr.cpp
-msgid "Uploaded (session):"
-msgstr "Wysłane (sesja):"
+msgid "Uploaded (session)"
+msgstr "Wysłane (sesja)"
 
 #: src/muuli_wdr.cpp
-msgid "Downloaded (session):"
-msgstr "Pobrane (sesja):"
+msgid "Downloaded (session)"
+msgstr "Pobrane (sesja)"
 
 #: src/muuli_wdr.cpp
-msgid "Uploaded (total):"
-msgstr "Wysłanych (razem):"
+msgid "Uploaded (total)"
+msgstr "Wysłanych (razem)"
 
 #: src/muuli_wdr.cpp
-msgid "Downloaded (total):"
-msgstr "Pobranych (razem):"
+msgid "Downloaded (total)"
+msgstr "Pobranych (razem)"
 
 #: src/muuli_wdr.cpp
 msgid "Scores"
 msgstr "Punkty"
 
 #: src/muuli_wdr.cpp
-msgid "DL/UP modifier:"
-msgstr "Modyfikator DL/UL:"
+msgid "DL/UP modifier"
+msgstr "Modyfikator DL/UL"
 
 #: src/muuli_wdr.cpp
-msgid "Secure ident:"
-msgstr "Bezpieczny identyfikator:"
+msgid "Secure ident"
+msgstr "Bezpieczny identyfikator"
 
 #: src/muuli_wdr.cpp
-msgid "Queue rank:"
-msgstr "Pozycja kolejki:"
+msgid "Queue rank"
+msgstr "Pozycja kolejki"
 
 #: src/muuli_wdr.cpp
-msgid "Queue score:"
-msgstr "Punkty kolejki:"
+msgid "Queue score"
+msgstr "Punkty kolejki"
 
 #: src/muuli_wdr.cpp
 msgid "Nick"
@@ -5037,16 +4965,12 @@ msgid "Reset any changes made to the preferences."
 msgstr "Reset wszystkich zmian dokonanych w preferencjach."
 
 #: src/muuli_wdr.cpp
-msgid "Comment :"
-msgstr "Komentarz :"
+msgid "Incoming Dir"
+msgstr "Katalog przychodzących"
 
 #: src/muuli_wdr.cpp
-msgid "Incoming Dir :"
-msgstr "Katalog przychodzących :"
-
-#: src/muuli_wdr.cpp
-msgid "Change priority for new assigned files :"
-msgstr "Zmień priorytet nowo przydzielonych plików :"
+msgid "Change priority for new assigned files"
+msgstr "Zmień priorytet nowo przydzielonych plików"
 
 #: src/muuli_wdr.cpp
 #, fuzzy
@@ -5054,8 +4978,8 @@ msgid "Don't change"
 msgstr "Nie zmieniaj"
 
 #: src/muuli_wdr.cpp
-msgid "Select color for this Category (currently selected) :"
-msgstr "Wybierz kolor dla tej kategorii (aktualnie wybrany) :"
+msgid "Select color for this Category (currently selected)"
+msgstr "Wybierz kolor dla tej kategorii (aktualnie wybrany)"
 
 #: src/muuli_wdr.cpp
 msgid "Click this button to reset the log."
@@ -5138,10 +5062,6 @@ msgstr "Rozruch od znanych klientów"
 #, fuzzy
 msgid "Enter the IP of the node here, using the x.x.x.x format."
 msgstr "Wpisz tu IP serwera, używając formatu x.x.x.x ."
-
-#: src/muuli_wdr.cpp
-msgid "Port:"
-msgstr "Port:"
 
 #: src/muuli_wdr.cpp
 msgid "Use Secure User Identification"
@@ -5410,20 +5330,20 @@ msgid "Enable/disable proxy support"
 msgstr "Włącza/Wyłącza obsługę proxy"
 
 #: src/muuli_wdr.cpp
-msgid "Proxy type:"
-msgstr "Typ proxy:"
+msgid "Proxy type"
+msgstr "Typ proxy"
 
 #: src/muuli_wdr.cpp
-msgid "Proxy host:"
-msgstr "Adres proxy:"
+msgid "Proxy host"
+msgstr "Adres proxy"
 
 #: src/muuli_wdr.cpp
 msgid "The proxy host name"
 msgstr "Nazwa hosta proxy"
 
 #: src/muuli_wdr.cpp
-msgid "Proxy port:"
-msgstr "Port proxy:"
+msgid "Proxy port"
+msgstr "Port proxy"
 
 #: src/muuli_wdr.cpp
 msgid "The proxy port"
@@ -5438,16 +5358,8 @@ msgid "Enable/disable username/password authentication"
 msgstr "Włącza/Wyłącza uwierzytelnianie login/hasło"
 
 #: src/muuli_wdr.cpp
-msgid "Username: "
-msgstr "Nazwa uzytkownika: "
-
-#: src/muuli_wdr.cpp
 msgid "The username to use to connect to the proxy"
 msgstr "Login używany do połączeń z proxy"
-
-#: src/muuli_wdr.cpp
-msgid "Password:"
-msgstr "Hasło:"
 
 #: src/muuli_wdr.cpp
 msgid "The password to use to connect to the proxy"
@@ -5629,6 +5541,15 @@ msgstr "godzin"
 #: src/OtherFunctions.cpp
 msgid "days"
 msgstr "dni"
+
+#. TRANSLATORS:
+#. Punctuation for a "label: value" pair. %s is the already-translated
+#. label. Place the colon as your language requires -- e.g. "%s :" with a
+#. space in French, "%s:" without one in Russian and English.
+#: src/OtherFunctions.cpp
+#, c-format
+msgid "%s:"
+msgstr ""
 
 #: src/OtherFunctions.cpp
 msgid "all"
@@ -6683,8 +6604,7 @@ msgstr ""
 msgid "Confirm shared folders"
 msgstr "Udostępnione foldery"
 
-#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp
-#: src/SharedFilesReloadProgress.cpp
+#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp src/SharedFilesReloadProgress.cpp
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "Przeładuj twoje udostępnione pliki"
@@ -6818,19 +6738,6 @@ msgstr "Błąd aktualizacji GeoIP.dat"
 #: src/SearchListCtrl.cpp
 msgid "FileID"
 msgstr "ID pliku"
-
-#: src/SearchListCtrl.cpp
-msgid "Length"
-msgstr ""
-
-#: src/SearchListCtrl.cpp
-#, fuzzy
-msgid "Bitrate"
-msgstr "Nieoceniony"
-
-#: src/SearchListCtrl.cpp
-msgid "Codec"
-msgstr ""
 
 #: src/SearchListCtrl.cpp
 msgid "Expand all"
@@ -7120,10 +7027,6 @@ msgstr "Serwer lokalny jest filtrowany przez IPFilters, podłączam ponownie do 
 #: src/ServerListCtrl.cpp
 msgid "Server Name"
 msgstr "Nazwa serwera"
-
-#: src/ServerListCtrl.cpp
-msgid "Port"
-msgstr "Port"
 
 #: src/ServerListCtrl.cpp
 msgid "Description"
@@ -7420,6 +7323,10 @@ msgstr "Łączenie do kolegi"
 #, c-format
 msgid "Connected to buddy at %s"
 msgstr "Łączenie do kolegi przy %s"
+
+#: src/ServerWnd.cpp
+msgid "IP address:"
+msgstr "Adres IP:"
 
 #: src/ServerWnd.cpp
 msgid "Indexed sources:"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-04 12:13+0200\n"
+"POT-Creation-Date: 2026-09-05 12:01+0200\n"
 "PO-Revision-Date: 2026-09-03 11:08+0000\n"
 "Last-Translator: Marcelo Jimenez <mroberto@users.sourceforge.com>\n"
 "Language-Team: Português (Brasileiro) <pt@li.org>\n"
@@ -392,8 +392,7 @@ msgstr "web server rodando no pid %d"
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Você pediu para rodar o servidor web na início, mas o binário do amuleweb não pode ser rodado. Por favor instale o pacote contendo o servidro web do aMule, ou compile o aMule a partir do código fonte usando -DBUILD_WEBSERVER=YES e instale-o."
 
-#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
-#: src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
+#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
 msgid "ERROR"
 msgstr "ERRO"
 
@@ -680,8 +679,7 @@ msgstr "Redes"
 msgid "Searches"
 msgstr "Pesquisas"
 
-#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/Statistics.cpp
+#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/Statistics.cpp
 msgid "Downloads"
 msgstr "Downloads"
 
@@ -769,9 +767,7 @@ msgstr "Kad: Desligado"
 msgid "Core"
 msgstr "Núcleo"
 
-#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#: src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp
-#: src/SourceListCtrl.cpp src/Statistics.cpp
+#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp src/Statistics.cpp
 msgid "Version"
 msgstr "Versão"
 
@@ -1068,11 +1064,7 @@ msgstr "Incapaz criar o diretório '%s' para a categoria '%s', mantendo diretór
 msgid "The remote core sent inconsistent data for \"%s\" (part status %d, expected %d). The file list may be showing the wrong information; reconnect to clear it."
 msgstr "O núcleo remoto mandou dados inconsistentes para \"%s\" (estado da parte %d, esperado %d). A lista de arquivos pode estar mostrando a informação errada; reconecte para limpar."
 
-#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp
-#: src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp
-#: src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp
-#: src/Statistics.cpp
+#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp src/Statistics.cpp
 msgid "Unknown"
 msgstr "Desconhecido"
 
@@ -1169,8 +1161,7 @@ msgstr "Erro ao salvar arquivo %s: %s"
 msgid "Enter Captcha"
 msgstr "Insira o Captcha"
 
-#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp
-#: src/TransferWnd.cpp
+#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp src/TransferWnd.cpp
 msgid "Category"
 msgstr "Categoria"
 
@@ -1333,13 +1324,11 @@ msgstr "Arquivo 'cryptkey.dat' não foi encontrado, criando."
 msgid "Client Details"
 msgstr "Detalhes do Cliente"
 
-#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
-#: src/utils/wxCas/src/onlinesig.cpp
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
 msgid "LowID"
 msgstr "LowID"
 
-#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
-#: src/utils/wxCas/src/onlinesig.cpp
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
 msgid "HighID"
 msgstr "HighID"
 
@@ -1355,8 +1344,7 @@ msgstr "Suportado"
 msgid "Not supported"
 msgstr "Não suportado"
 
-#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
-#: src/TextClient.cpp
+#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp src/TextClient.cpp
 msgid "Connected"
 msgstr "Conectado"
 
@@ -1364,13 +1352,12 @@ msgstr "Conectado"
 msgid "Disconnected"
 msgstr "Desconectado"
 
-#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp
-#: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f KiB/s"
 msgstr "%.1f KiB/s"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/muuli_wdr.cpp
 msgid "Name"
 msgstr "Nome"
 
@@ -1378,12 +1365,11 @@ msgstr "Nome"
 msgid "Software"
 msgstr "Software"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/muuli_wdr.cpp
 msgid "IP Address"
 msgstr "Endereço IP"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Origin"
 msgstr "Origem"
 
@@ -1399,13 +1385,11 @@ msgstr "Visto por último"
 msgid "Sessions"
 msgstr "Sessões"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp
 msgid "Upload Speed"
 msgstr "Velocidade de Upload"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp
 msgid "Download Speed"
 msgstr "Velocidade de Download"
 
@@ -1456,13 +1440,11 @@ msgstr[1] "Não foi possível adicionar %u links (veja o log para detalhes)."
 msgid "Files"
 msgstr "Arquivos"
 
-#: src/ClientsListCtrl.cpp src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp
-#: src/SourceListCtrl.cpp
+#: src/ClientsListCtrl.cpp src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Uploaded"
 msgstr "Enviado"
 
-#: src/ClientsListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientsListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Downloaded"
 msgstr "Baixado"
 
@@ -1546,12 +1528,11 @@ msgstr "Usuário %s (%u) negou o acesso a lista de arquivos compartilhados"
 msgid "File Comments"
 msgstr "Comentários do arquivo"
 
-#: src/CommentDialogLst.cpp src/FriendListCtrl.cpp
+#: src/CommentDialogLst.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
 msgid "Username"
 msgstr "Nome do usuário"
 
-#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp
-#: src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "File Name"
 msgstr "Nome do arquivo"
 
@@ -1559,7 +1540,7 @@ msgstr "Nome do arquivo"
 msgid "Rating"
 msgstr "Avaliação"
 
-#: src/CommentDialogLst.cpp
+#: src/CommentDialogLst.cpp src/muuli_wdr.cpp
 msgid "Comment"
 msgstr "Comentário"
 
@@ -1612,18 +1593,15 @@ msgstr "Auto [Alto]"
 msgid "Very low"
 msgstr "Muito baixo"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Low"
 msgstr "Baixo"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Normal"
 msgstr "Normal"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "High"
 msgstr "Alto"
 
@@ -1647,13 +1625,11 @@ msgstr "Conectando via servidor"
 msgid "Queue Full"
 msgstr "Fila de espera cheia"
 
-#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp
-#: src/muuli_wdr.cpp
+#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp src/muuli_wdr.cpp
 msgid "On Queue"
 msgstr "Na fila de espera"
 
-#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp
-#: src/PartFile.cpp src/TransferWnd.cpp
+#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Downloading"
 msgstr "Baixando"
 
@@ -1713,8 +1689,7 @@ msgstr "Servidor Local"
 msgid "Remote Server"
 msgstr "Servidor Remoto"
 
-#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp
-#: src/TextClient.cpp
+#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp src/TextClient.cpp
 msgid "Kad"
 msgstr "Kad"
 
@@ -1738,8 +1713,7 @@ msgstr "Fontes de arquivo"
 msgid "Search Result"
 msgstr "Resultado da Busca"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp
-#: src/TransferWnd.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Completed"
 msgstr "Completado"
 
@@ -1791,8 +1765,7 @@ msgstr "Não é possível modificar dentro de um compartilhamento recursivo"
 msgid "Part"
 msgstr "Parte"
 
-#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp
-#: src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Size"
 msgstr "Tamanho"
 
@@ -1800,8 +1773,7 @@ msgstr "Tamanho"
 msgid "Transferred"
 msgstr "Transferido"
 
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
-#: src/SourceListCtrl.cpp
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp src/SourceListCtrl.cpp
 msgid "Speed"
 msgstr "Velocidade"
 
@@ -1809,13 +1781,11 @@ msgstr "Velocidade"
 msgid "Progress"
 msgstr "Progresso"
 
-#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp
-#: src/SearchListCtrl.cpp
+#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
 msgid "Sources"
 msgstr "Fontes"
 
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp
-#: src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Priority"
 msgstr "Prioridade"
 
@@ -1839,9 +1809,7 @@ msgstr "Último recebimento"
 msgid "Auto"
 msgstr "Auto"
 
-#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/TransferWnd.cpp
-#: src/utils/wxCas/src/wxcasprefs.cpp
+#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/TransferWnd.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Cancel"
 msgstr "Cancelar"
 
@@ -1942,8 +1910,7 @@ msgstr "Informe o novo nome para o arquivo:"
 msgid "File rename"
 msgstr "Renomear"
 
-#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp
-#: src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f MiB/s"
 msgstr "%.1f MiB/s"
@@ -2746,13 +2713,11 @@ msgstr ""
 msgid "Start aMule automatically when I log in"
 msgstr "Iniciar o aMule automaticamente quando eu logar no sistema"
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
-#: packaging/windows/installer_strings.c
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp packaging/windows/installer_strings.c
 msgid "Register aMule for ed2k:// links"
 msgstr "Registrar aMule para links ed2k://"
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
-#: packaging/windows/installer_strings.c
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp packaging/windows/installer_strings.c
 msgid "Register aMule for magnet: links"
 msgstr "Registra o aMule para links \"magnet:\""
 
@@ -2780,8 +2745,7 @@ msgstr ""
 msgid "Destination folder for downloads"
 msgstr "Pasta de destino para baixados"
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
-#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Browse"
 msgstr "Procurar"
 
@@ -3225,18 +3189,15 @@ msgstr "Finalizando"
 msgid "Complete"
 msgstr "Completo"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
-#: src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Paused"
 msgstr "Pausa"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
-#: src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Erroneous"
 msgstr "Com Erro"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
-#: src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Waiting"
 msgstr "Esperando"
 
@@ -3398,8 +3359,7 @@ msgstr "Fechar"
 msgid "Cut"
 msgstr "Recortar"
 
-#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp
-#: src/utils/aLinkCreator/src/alcframe.cpp
+#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy"
 msgstr "Copiar"
 
@@ -3407,8 +3367,7 @@ msgstr "Copiar"
 msgid "Paste"
 msgstr "Colar"
 
-#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp
-#: src/utils/aLinkCreator/src/alcframe.cpp
+#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Clear"
 msgstr "Limpar"
 
@@ -3416,8 +3375,7 @@ msgstr "Limpar"
 msgid "Select All"
 msgstr "Selecionar Tudo"
 
-#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
-#: src/StatisticsDlg.cpp
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp src/StatisticsDlg.cpp
 msgid "KiB/s"
 msgstr "KiB/s"
 
@@ -3672,10 +3630,6 @@ msgstr "Servidor atualmente conectado."
 msgid "Search"
 msgstr "Pesquisar"
 
-#: src/muuli_wdr.cpp
-msgid "Name:"
-msgstr "Nome:"
-
 #: src/muuli_wdr.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Type"
 msgstr "Tipo"
@@ -3765,8 +3719,8 @@ msgid "Availability"
 msgstr "Disponível"
 
 #: src/muuli_wdr.cpp
-msgid "Filter:"
-msgstr "Filtro:"
+msgid "Filter"
+msgstr "Filtro"
 
 #: src/muuli_wdr.cpp
 msgid "Invert Result"
@@ -3821,6 +3775,10 @@ msgid "Clears completed downloads"
 msgstr "Limpar downloads completados"
 
 #: src/muuli_wdr.cpp
+msgid "Filter:"
+msgstr "Filtro:"
+
+#: src/muuli_wdr.cpp
 msgid "File sources:"
 msgstr "Fontes de arquivos:"
 
@@ -3829,80 +3787,76 @@ msgid "General"
 msgstr "Geral"
 
 #: src/muuli_wdr.cpp
-msgid "Full Name :"
-msgstr "Nome Completo:"
+msgid "Full Name"
+msgstr "Nome Completo"
 
 #: src/muuli_wdr.cpp
-msgid "met-File :"
-msgstr "arquivo-met :"
+msgid "met-File"
+msgstr "arquivo-met"
 
 #: src/muuli_wdr.cpp
-msgid "Hash :"
-msgstr "Hash :"
+msgid "Hash"
+msgstr "Hash"
 
 #: src/muuli_wdr.cpp
-msgid "Filesize :"
-msgstr "Tamanho :"
+msgid "Filesize"
+msgstr "Tamanho"
 
 #: src/muuli_wdr.cpp src/Statistics.cpp
 msgid "Transfer"
 msgstr "Transferência"
 
 #: src/muuli_wdr.cpp
-msgid "Partfilestatus :"
-msgstr "Status parcial :"
+msgid "Partfilestatus"
+msgstr "Status parcial"
 
 #: src/muuli_wdr.cpp
-msgid "Last seen complete :"
-msgstr "Última vez completo:"
+msgid "Last seen complete"
+msgstr "Última vez completo"
 
 #: src/muuli_wdr.cpp
-msgid "Found Sources :"
-msgstr "Fontes encontradas:"
+msgid "Found Sources"
+msgstr "Fontes encontradas"
 
 #: src/muuli_wdr.cpp
-msgid "Transferring Sources :"
-msgstr "Transferindo de (fontes):"
+msgid "Transferring Sources"
+msgstr "Transferindo de (fontes)"
 
 #: src/muuli_wdr.cpp
-msgid "Filepart-Count :"
-msgstr "Contador de partes:"
+msgid "Filepart-Count"
+msgstr "Contador de partes"
 
 #: src/muuli_wdr.cpp
-msgid "Available :"
-msgstr "Disponíveis:"
+msgid "Available"
+msgstr "Disponíveis"
 
 #: src/muuli_wdr.cpp
-msgid "Datarate :"
-msgstr "Taxa de transf.:"
+msgid "Datarate"
+msgstr "Taxa de transf."
 
 #: src/muuli_wdr.cpp
-msgid "Download Active Time: "
-msgstr "Tempo ativo de download: "
+msgid "Download Active Time"
+msgstr "Tempo ativo de download"
 
 #: src/muuli_wdr.cpp
-msgid "Transferred :"
-msgstr "Transferido :"
-
-#: src/muuli_wdr.cpp
-msgid "Completed Size :"
-msgstr "Tamanho completo:"
+msgid "Completed Size"
+msgstr "Tamanho completo"
 
 #: src/muuli_wdr.cpp
 msgid "Intelligent Corruption Handling"
 msgstr "Manipulador Inteligente de Corrupção (I.C.H.)"
 
 #: src/muuli_wdr.cpp
-msgid "Lost to corruption :"
-msgstr "Perdido ao corromper:"
+msgid "Lost to corruption"
+msgstr "Perdido ao corromper"
 
 #: src/muuli_wdr.cpp
-msgid "Gained by compression :"
-msgstr "Ganho com compressão:"
+msgid "Gained by compression"
+msgstr "Ganho com compressão"
 
 #: src/muuli_wdr.cpp
-msgid "Packages saved by I.C.H. :"
-msgstr "Pacotes recuperados pelo I.C.H.:"
+msgid "Packages saved by I.C.H."
+msgstr "Pacotes recuperados pelo I.C.H."
 
 #: src/muuli_wdr.cpp
 msgid "Sharing"
@@ -3940,29 +3894,29 @@ msgstr "Ultimo upload"
 msgid "Media Info"
 msgstr "Informação da Mídia"
 
-#: src/muuli_wdr.cpp
-msgid "Length :"
-msgstr "Comprimento:"
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
+msgid "Length"
+msgstr "Comprimento"
+
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
+msgid "Bitrate"
+msgstr "Taxa de Bits"
+
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
+msgid "Codec"
+msgstr "Codec"
 
 #: src/muuli_wdr.cpp
-msgid "Bitrate :"
-msgstr "Taxa de Bits:"
+msgid "Artist"
+msgstr "Artista"
 
 #: src/muuli_wdr.cpp
-msgid "Codec :"
-msgstr "Codec:"
+msgid "Album"
+msgstr "Album"
 
 #: src/muuli_wdr.cpp
-msgid "Artist :"
-msgstr "Artista:"
-
-#: src/muuli_wdr.cpp
-msgid "Album :"
-msgstr "Album:"
-
-#: src/muuli_wdr.cpp
-msgid "Title :"
-msgstr "Título:"
+msgid "Title"
+msgstr "Título"
 
 #: src/muuli_wdr.cpp
 msgid "File Names"
@@ -4048,25 +4002,17 @@ msgstr "Tamanho desconhecido"
 msgid "Required Information"
 msgstr "Informação necessária"
 
-#: src/muuli_wdr.cpp
-msgid "IP Address :"
-msgstr "Endereço IP:"
-
-#: src/muuli_wdr.cpp
-msgid "Port :"
-msgstr "Porta:"
+#: src/muuli_wdr.cpp src/ServerListCtrl.cpp
+msgid "Port"
+msgstr "Porta"
 
 #: src/muuli_wdr.cpp
 msgid "Additional Information"
 msgstr "Informações adicionais"
 
 #: src/muuli_wdr.cpp
-msgid "Username :"
-msgstr "Usuário :"
-
-#: src/muuli_wdr.cpp
-msgid "Userhash :"
-msgstr "Hash do usuário :"
+msgid "Userhash"
+msgstr "Hash do usuário"
 
 #: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Add"
@@ -4101,96 +4047,80 @@ msgid "Statistics Tree"
 msgstr "Árvore de Estatísticas"
 
 #: src/muuli_wdr.cpp
-msgid "Username:"
-msgstr "Nome do Usuário:"
+msgid "Client software"
+msgstr "Software Cliente"
 
 #: src/muuli_wdr.cpp
-msgid "Userhash:"
-msgstr "Hash do Usuário:"
+msgid "Client version"
+msgstr "Versão do Cliente"
 
 #: src/muuli_wdr.cpp
-msgid "Client software:"
-msgstr "Software Cliente:"
+msgid "User ID"
+msgstr "ID do Usuário"
 
 #: src/muuli_wdr.cpp
-msgid "Client version:"
-msgstr "Versão do Cliente:"
-
-#: src/muuli_wdr.cpp src/ServerWnd.cpp
-msgid "IP address:"
-msgstr "Endereço IP:"
+msgid "Server IP"
+msgstr "IP do servidor"
 
 #: src/muuli_wdr.cpp
-msgid "User ID:"
-msgstr "ID do Usuário:"
+msgid "Server name"
+msgstr "Nome do Servidor"
 
 #: src/muuli_wdr.cpp
-msgid "Server IP:"
-msgstr "IP do servidor:"
-
-#: src/muuli_wdr.cpp
-msgid "Server name:"
-msgstr "Nome do Servidor:"
-
-#: src/muuli_wdr.cpp
-msgid "Obfuscation:"
-msgstr "Obfuscação:"
-
-#: src/muuli_wdr.cpp
-msgid "Kad:"
-msgstr "Kad:"
+msgid "Obfuscation"
+msgstr "Obfuscação"
 
 #: src/muuli_wdr.cpp
 msgid "Transfers to client"
 msgstr "Transferir para o cliente"
 
 #: src/muuli_wdr.cpp
-msgid "Current request:"
-msgstr "Solicitação atual:"
+msgid "Current request"
+msgstr "Solicitação atual"
 
 #: src/muuli_wdr.cpp
-msgid "Average upload rate:"
-msgstr "Taxa upload (média):"
+msgid "Average upload rate"
+msgstr "Taxa upload (média)"
 
 #: src/muuli_wdr.cpp
-msgid "Average download rate:"
-msgstr "Taxa download (média):"
+msgid "Average download rate"
+msgstr "Taxa download (média)"
 
 #: src/muuli_wdr.cpp
-msgid "Uploaded (session):"
-msgstr "Upload (Sessão):"
+msgid "Uploaded (session)"
+msgstr "Upload (Sessão)"
 
 #: src/muuli_wdr.cpp
-msgid "Downloaded (session):"
-msgstr "Download (sessão):"
+msgid "Downloaded (session)"
+msgstr "Download (sessão)"
 
 #: src/muuli_wdr.cpp
-msgid "Uploaded (total):"
-msgstr "Upload (total):"
+msgid "Uploaded (total)"
+msgstr "Upload (total)"
 
 #: src/muuli_wdr.cpp
-msgid "Downloaded (total):"
-msgstr "Download (total):"
+msgid "Downloaded (total)"
+msgstr "Download (total)"
 
 #: src/muuli_wdr.cpp
 msgid "Scores"
 msgstr "Pontuação"
 
 #: src/muuli_wdr.cpp
-msgid "DL/UP modifier:"
-msgstr "Modificador Down/Up:"
+msgid "DL/UP modifier"
+msgstr "Modificador Down/Up"
 
 #: src/muuli_wdr.cpp
-msgid "Secure ident:"
-msgstr "Identificação segura:"
+msgid "Secure ident"
+msgstr "Identificação segura"
 
 #: src/muuli_wdr.cpp
-msgid "Queue rank:"
-msgstr "Ranking de espera:"
+msgid "Queue rank"
+msgstr "Ranking de espera"
 
 #: src/muuli_wdr.cpp
-msgid "Queue score:"
-msgstr "Pontuação de fila:"
+msgid "Queue score"
+msgstr "Pontuação de fila"
 
 #: src/muuli_wdr.cpp
 msgid "Nick"
@@ -4969,24 +4899,20 @@ msgid "Reset any changes made to the preferences."
 msgstr "Ignora todas as alterações feitas."
 
 #: src/muuli_wdr.cpp
-msgid "Comment :"
-msgstr "Comentário:"
+msgid "Incoming Dir"
+msgstr "Dir incoming"
 
 #: src/muuli_wdr.cpp
-msgid "Incoming Dir :"
-msgstr "Dir incoming:"
-
-#: src/muuli_wdr.cpp
-msgid "Change priority for new assigned files :"
-msgstr "Alterar prioridade para novos arquivos:"
+msgid "Change priority for new assigned files"
+msgstr "Alterar prioridade para novos arquivos"
 
 #: src/muuli_wdr.cpp
 msgid "Don't change"
 msgstr "Não alterar"
 
 #: src/muuli_wdr.cpp
-msgid "Select color for this Category (currently selected) :"
-msgstr "Selecione a cor para esta Categoria (selecionada):"
+msgid "Select color for this Category (currently selected)"
+msgstr "Selecione a cor para esta Categoria (selecionada)"
 
 #: src/muuli_wdr.cpp
 msgid "Click this button to reset the log."
@@ -5067,10 +4993,6 @@ msgstr "Inicialização a partir do nó: IP"
 #: src/muuli_wdr.cpp
 msgid "Enter the IP of the node here, using the x.x.x.x format."
 msgstr "Informe o IP do nó aqui, usando o formato x.x.x.x."
-
-#: src/muuli_wdr.cpp
-msgid "Port:"
-msgstr "Porta:"
 
 #: src/muuli_wdr.cpp
 msgid "Use Secure User Identification"
@@ -5347,20 +5269,20 @@ msgid "Enable/disable proxy support"
 msgstr "Ativa/desativa suporte a proxy"
 
 #: src/muuli_wdr.cpp
-msgid "Proxy type:"
-msgstr "Tipo de proxy:"
+msgid "Proxy type"
+msgstr "Tipo de proxy"
 
 #: src/muuli_wdr.cpp
-msgid "Proxy host:"
-msgstr "Host do Proxy:"
+msgid "Proxy host"
+msgstr "Host do Proxy"
 
 #: src/muuli_wdr.cpp
 msgid "The proxy host name"
 msgstr "Nome do Host do proxy"
 
 #: src/muuli_wdr.cpp
-msgid "Proxy port:"
-msgstr "Porta do Proxy:"
+msgid "Proxy port"
+msgstr "Porta do Proxy"
 
 #: src/muuli_wdr.cpp
 msgid "The proxy port"
@@ -5375,16 +5297,8 @@ msgid "Enable/disable username/password authentication"
 msgstr "Ativa/Desativa autenticação por usuário/senha"
 
 #: src/muuli_wdr.cpp
-msgid "Username: "
-msgstr "Nome do usuário: "
-
-#: src/muuli_wdr.cpp
 msgid "The username to use to connect to the proxy"
 msgstr "Nome do usuário para conectar ao proxy"
-
-#: src/muuli_wdr.cpp
-msgid "Password:"
-msgstr "Senha:"
 
 #: src/muuli_wdr.cpp
 msgid "The password to use to connect to the proxy"
@@ -5557,6 +5471,15 @@ msgstr "horas"
 #: src/OtherFunctions.cpp
 msgid "days"
 msgstr "dias"
+
+#. TRANSLATORS:
+#. Punctuation for a "label: value" pair. %s is the already-translated
+#. label. Place the colon as your language requires -- e.g. "%s :" with a
+#. space in French, "%s:" without one in Russian and English.
+#: src/OtherFunctions.cpp
+#, c-format
+msgid "%s:"
+msgstr ""
 
 #: src/OtherFunctions.cpp
 msgid "all"
@@ -6587,8 +6510,7 @@ msgstr "Compartilha-los recursivamente vai publicar todos os arquivos sob as red
 msgid "Confirm shared folders"
 msgstr "Confirma pastas compartilhadas"
 
-#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp
-#: src/SharedFilesReloadProgress.cpp
+#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp src/SharedFilesReloadProgress.cpp
 msgid "Reloading shared files..."
 msgstr "Recarregando lista de arquivos compartilhados..."
 
@@ -6717,18 +6639,6 @@ msgstr "Erro %u: %s\n"
 #: src/SearchListCtrl.cpp
 msgid "FileID"
 msgstr "ID do arquivo"
-
-#: src/SearchListCtrl.cpp
-msgid "Length"
-msgstr "Comprimento"
-
-#: src/SearchListCtrl.cpp
-msgid "Bitrate"
-msgstr "Taxa de Bits"
-
-#: src/SearchListCtrl.cpp
-msgid "Codec"
-msgstr "Codec"
 
 #: src/SearchListCtrl.cpp
 msgid "Expand all"
@@ -7006,10 +6916,6 @@ msgstr "Servidor local é filtrado pelo IPFilters, reconectando em um servidor d
 #: src/ServerListCtrl.cpp
 msgid "Server Name"
 msgstr "Nome do Servidor"
-
-#: src/ServerListCtrl.cpp
-msgid "Port"
-msgstr "Porta"
 
 #: src/ServerListCtrl.cpp
 msgid "Description"
@@ -7296,6 +7202,10 @@ msgstr "Conectando ao amigo"
 #, c-format
 msgid "Connected to buddy at %s"
 msgstr "Conectado ao amigo em %s"
+
+#: src/ServerWnd.cpp
+msgid "IP address:"
+msgstr "Endereço IP:"
 
 #: src/ServerWnd.cpp
 msgid "Indexed sources:"

--- a/po/pt_PT.po
+++ b/po/pt_PT.po
@@ -17,7 +17,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-04 12:13+0200\n"
+"POT-Creation-Date: 2026-09-05 12:01+0200\n"
 "PO-Revision-Date: 2026-09-03 11:09+0000\n"
 "Last-Translator: Luís Picciochi Oliveira <Pitxyoki@Gmail.com>\n"
 "Language-Team: Portuguese <traduz@debianpt.org>\n"
@@ -394,8 +394,7 @@ msgstr "servidor web a executar no pid %d"
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Pediu para executar o servidor web no arranque, mas o executável não pode ser lançado. Por favor, instale o pacote que contém o servidor web ou compile o aMule com --enable-webserver e execute make install"
 
-#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
-#: src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
+#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
 msgid "ERROR"
 msgstr "ERRO"
 
@@ -683,8 +682,7 @@ msgstr "Redes"
 msgid "Searches"
 msgstr "Pesquisas"
 
-#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/Statistics.cpp
+#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/Statistics.cpp
 msgid "Downloads"
 msgstr "Downloads"
 
@@ -768,9 +766,7 @@ msgstr "Kad: Desligado"
 msgid "Core"
 msgstr ""
 
-#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#: src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp
-#: src/SourceListCtrl.cpp src/Statistics.cpp
+#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp src/Statistics.cpp
 msgid "Version"
 msgstr "Versão"
 
@@ -1069,11 +1065,7 @@ msgstr "Não é possível criar o directório '%s' para a categoria '%s', a mant
 msgid "The remote core sent inconsistent data for \"%s\" (part status %d, expected %d). The file list may be showing the wrong information; reconnect to clear it."
 msgstr ""
 
-#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp
-#: src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp
-#: src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp
-#: src/Statistics.cpp
+#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp src/Statistics.cpp
 msgid "Unknown"
 msgstr "Desconhecido"
 
@@ -1170,8 +1162,7 @@ msgstr "Erro ao gravar ficheiro %s: %s"
 msgid "Enter Captcha"
 msgstr "Escrever 'Captcha'"
 
-#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp
-#: src/TransferWnd.cpp
+#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp src/TransferWnd.cpp
 msgid "Category"
 msgstr "Categoria"
 
@@ -1335,13 +1326,11 @@ msgstr "Ficheiro 'cryptkey.dat' não encontrado, a criar."
 msgid "Client Details"
 msgstr "Detalhes do Cliente"
 
-#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
-#: src/utils/wxCas/src/onlinesig.cpp
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
 msgid "LowID"
 msgstr "LowID"
 
-#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
-#: src/utils/wxCas/src/onlinesig.cpp
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
 msgid "HighID"
 msgstr "HighID"
 
@@ -1357,8 +1346,7 @@ msgstr "Suportado"
 msgid "Not supported"
 msgstr "Não suportado"
 
-#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
-#: src/TextClient.cpp
+#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp src/TextClient.cpp
 msgid "Connected"
 msgstr "Ligado"
 
@@ -1366,28 +1354,24 @@ msgstr "Ligado"
 msgid "Disconnected"
 msgstr "Desligado"
 
-#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp
-#: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f KiB/s"
 msgstr ""
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#, fuzzy
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/muuli_wdr.cpp
 msgid "Name"
-msgstr "Nome:"
+msgstr "Nome"
 
 #: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
 msgid "Software"
 msgstr ""
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#, fuzzy
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/muuli_wdr.cpp
 msgid "IP Address"
-msgstr "Endereço IP :"
+msgstr "Endereço IP"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Origin"
 msgstr "Origem"
 
@@ -1405,13 +1389,11 @@ msgstr "Última recepção"
 msgid "Sessions"
 msgstr "Versão"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp
 msgid "Upload Speed"
 msgstr "Velocidade de Upload"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp
 msgid "Download Speed"
 msgstr "Velocidade de Download"
 
@@ -1466,13 +1448,11 @@ msgstr[1] ""
 msgid "Files"
 msgstr "Ficheiros"
 
-#: src/ClientsListCtrl.cpp src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp
-#: src/SourceListCtrl.cpp
+#: src/ClientsListCtrl.cpp src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Uploaded"
 msgstr "Enviado"
 
-#: src/ClientsListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientsListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Downloaded"
 msgstr "Transferido"
 
@@ -1559,12 +1539,11 @@ msgstr "O utilizador %s (%u) negou acesso à lista de pastas/ficheiros partilhad
 msgid "File Comments"
 msgstr "Comentários do ficheiro"
 
-#: src/CommentDialogLst.cpp src/FriendListCtrl.cpp
+#: src/CommentDialogLst.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
 msgid "Username"
 msgstr "Nome de Utilizador"
 
-#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp
-#: src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "File Name"
 msgstr "Nome do Ficheiro"
 
@@ -1572,7 +1551,7 @@ msgstr "Nome do Ficheiro"
 msgid "Rating"
 msgstr "Classificação"
 
-#: src/CommentDialogLst.cpp
+#: src/CommentDialogLst.cpp src/muuli_wdr.cpp
 msgid "Comment"
 msgstr "Comentário"
 
@@ -1626,18 +1605,15 @@ msgstr "Automática [Alta]"
 msgid "Very low"
 msgstr "Muito baixa"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Low"
 msgstr "Baixa"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Normal"
 msgstr "Normal"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "High"
 msgstr "Alta"
 
@@ -1661,13 +1637,11 @@ msgstr "A ligar via servidor"
 msgid "Queue Full"
 msgstr "Fila de Espera Cheia"
 
-#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp
-#: src/muuli_wdr.cpp
+#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp src/muuli_wdr.cpp
 msgid "On Queue"
 msgstr "Em Fila de Espera"
 
-#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp
-#: src/PartFile.cpp src/TransferWnd.cpp
+#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Downloading"
 msgstr "A Receber"
 
@@ -1727,8 +1701,7 @@ msgstr "Servidor Local"
 msgid "Remote Server"
 msgstr "Servidor Remoto"
 
-#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp
-#: src/TextClient.cpp
+#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp src/TextClient.cpp
 msgid "Kad"
 msgstr "Kad"
 
@@ -1752,8 +1725,7 @@ msgstr "Sementes de Fontes"
 msgid "Search Result"
 msgstr "Resultados de Pesquisas"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp
-#: src/TransferWnd.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Completed"
 msgstr "Concluído"
 
@@ -1806,8 +1778,7 @@ msgstr ""
 msgid "Part"
 msgstr "Parte"
 
-#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp
-#: src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Size"
 msgstr "Tamanho"
 
@@ -1815,8 +1786,7 @@ msgstr "Tamanho"
 msgid "Transferred"
 msgstr "Transferido"
 
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
-#: src/SourceListCtrl.cpp
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp src/SourceListCtrl.cpp
 msgid "Speed"
 msgstr "Velocidade"
 
@@ -1824,13 +1794,11 @@ msgstr "Velocidade"
 msgid "Progress"
 msgstr "Progresso"
 
-#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp
-#: src/SearchListCtrl.cpp
+#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
 msgid "Sources"
 msgstr "Fontes"
 
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp
-#: src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Priority"
 msgstr "Prioridade"
 
@@ -1854,9 +1822,7 @@ msgstr "Última recepção"
 msgid "Auto"
 msgstr "Automática"
 
-#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/TransferWnd.cpp
-#: src/utils/wxCas/src/wxcasprefs.cpp
+#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/TransferWnd.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Cancel"
 msgstr "Cancelar"
 
@@ -1957,8 +1923,7 @@ msgstr "Insira o novo nome para este ficheiro:"
 msgid "File rename"
 msgstr "Renomear ficheiro"
 
-#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp
-#: src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f MiB/s"
 msgstr ""
@@ -2763,13 +2728,11 @@ msgstr ""
 msgid "Start aMule automatically when I log in"
 msgstr ""
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
-#: packaging/windows/installer_strings.c
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp packaging/windows/installer_strings.c
 msgid "Register aMule for ed2k:// links"
 msgstr ""
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
-#: packaging/windows/installer_strings.c
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp packaging/windows/installer_strings.c
 msgid "Register aMule for magnet: links"
 msgstr ""
 
@@ -2795,8 +2758,7 @@ msgstr ""
 msgid "Destination folder for downloads"
 msgstr "Pasta de destino para downloads"
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
-#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Browse"
 msgstr "Procurar"
 
@@ -3239,18 +3201,15 @@ msgstr "A completar"
 msgid "Complete"
 msgstr "Completo"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
-#: src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Paused"
 msgstr "Em Pausa"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
-#: src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Erroneous"
 msgstr "Erróneo"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
-#: src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Waiting"
 msgstr "Em Espera"
 
@@ -3414,8 +3373,7 @@ msgstr "Fechar"
 msgid "Cut"
 msgstr "Cortar"
 
-#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp
-#: src/utils/aLinkCreator/src/alcframe.cpp
+#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy"
 msgstr "Copiar"
 
@@ -3423,8 +3381,7 @@ msgstr "Copiar"
 msgid "Paste"
 msgstr "Colar"
 
-#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp
-#: src/utils/aLinkCreator/src/alcframe.cpp
+#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Clear"
 msgstr "Limpar"
 
@@ -3432,8 +3389,7 @@ msgstr "Limpar"
 msgid "Select All"
 msgstr "Seleccionar tudo"
 
-#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
-#: src/StatisticsDlg.cpp
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp src/StatisticsDlg.cpp
 msgid "KiB/s"
 msgstr ""
 
@@ -3697,10 +3653,6 @@ msgstr "Servidor a que está ligado."
 msgid "Search"
 msgstr "Pesquisar"
 
-#: src/muuli_wdr.cpp
-msgid "Name:"
-msgstr "Nome:"
-
 #: src/muuli_wdr.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Type"
 msgstr "Tipo"
@@ -3790,8 +3742,8 @@ msgid "Availability"
 msgstr "Disponibilidade"
 
 #: src/muuli_wdr.cpp
-msgid "Filter:"
-msgstr "Filtro:"
+msgid "Filter"
+msgstr "Filtro"
 
 #: src/muuli_wdr.cpp
 msgid "Invert Result"
@@ -3849,6 +3801,10 @@ msgid "Clears completed downloads"
 msgstr "Limpa os downloads concluídos"
 
 #: src/muuli_wdr.cpp
+msgid "Filter:"
+msgstr "Filtro:"
+
+#: src/muuli_wdr.cpp
 msgid "File sources:"
 msgstr "Fontes de ficheiros:"
 
@@ -3857,80 +3813,76 @@ msgid "General"
 msgstr "Geral"
 
 #: src/muuli_wdr.cpp
-msgid "Full Name :"
-msgstr "Nome completo :"
+msgid "Full Name"
+msgstr "Nome completo"
 
 #: src/muuli_wdr.cpp
-msgid "met-File :"
-msgstr "Ficheiro de servidores conhecidos :"
+msgid "met-File"
+msgstr "Ficheiro de servidores conhecidos"
 
 #: src/muuli_wdr.cpp
-msgid "Hash :"
-msgstr "Chave :"
+msgid "Hash"
+msgstr "Chave"
 
 #: src/muuli_wdr.cpp
-msgid "Filesize :"
-msgstr "Tamanho do ficheiro :"
+msgid "Filesize"
+msgstr "Tamanho do ficheiro"
 
 #: src/muuli_wdr.cpp src/Statistics.cpp
 msgid "Transfer"
 msgstr "Transferência"
 
 #: src/muuli_wdr.cpp
-msgid "Partfilestatus :"
-msgstr "Estado do ficheiro de partes :"
+msgid "Partfilestatus"
+msgstr "Estado do ficheiro de partes"
 
 #: src/muuli_wdr.cpp
-msgid "Last seen complete :"
-msgstr "Última vez visto completo :"
+msgid "Last seen complete"
+msgstr "Última vez visto completo"
 
 #: src/muuli_wdr.cpp
-msgid "Found Sources :"
-msgstr "Fontes encontradas :"
+msgid "Found Sources"
+msgstr "Fontes encontradas"
 
 #: src/muuli_wdr.cpp
-msgid "Transferring Sources :"
-msgstr "Fontes em transferência :"
+msgid "Transferring Sources"
+msgstr "Fontes em transferência"
 
 #: src/muuli_wdr.cpp
-msgid "Filepart-Count :"
-msgstr "Contagem de partes :"
+msgid "Filepart-Count"
+msgstr "Contagem de partes"
 
 #: src/muuli_wdr.cpp
-msgid "Available :"
-msgstr "Disponíveis :"
+msgid "Available"
+msgstr "Disponíveis"
 
 #: src/muuli_wdr.cpp
-msgid "Datarate :"
-msgstr "Taxa de transferência :"
+msgid "Datarate"
+msgstr "Taxa de transferência"
 
 #: src/muuli_wdr.cpp
-msgid "Download Active Time: "
-msgstr "Tempo de Download Activo: "
+msgid "Download Active Time"
+msgstr "Tempo de Download Activo"
 
 #: src/muuli_wdr.cpp
-msgid "Transferred :"
-msgstr "Transferido :"
-
-#: src/muuli_wdr.cpp
-msgid "Completed Size :"
-msgstr "Tamanho Completo :"
+msgid "Completed Size"
+msgstr "Tamanho Completo"
 
 #: src/muuli_wdr.cpp
 msgid "Intelligent Corruption Handling"
 msgstr "Manipulação Inteligente de Corrupção (M.I.C.)"
 
 #: src/muuli_wdr.cpp
-msgid "Lost to corruption :"
-msgstr "Perdido por corrupção :"
+msgid "Lost to corruption"
+msgstr "Perdido por corrupção"
 
 #: src/muuli_wdr.cpp
-msgid "Gained by compression :"
-msgstr "Ganho por compressão :"
+msgid "Gained by compression"
+msgstr "Ganho por compressão"
 
 #: src/muuli_wdr.cpp
-msgid "Packages saved by I.C.H. :"
-msgstr "Pacotes recuperados por M.I.C. :"
+msgid "Packages saved by I.C.H."
+msgstr "Pacotes recuperados por M.I.C."
 
 #: src/muuli_wdr.cpp
 #, fuzzy
@@ -3972,30 +3924,30 @@ msgstr ", Upload: "
 msgid "Media Info"
 msgstr "Informação Kad"
 
-#: src/muuli_wdr.cpp
-msgid "Length :"
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
+msgid "Length"
 msgstr ""
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
 #, fuzzy
-msgid "Bitrate :"
+msgid "Bitrate"
 msgstr "Não avaliado"
 
-#: src/muuli_wdr.cpp
-msgid "Codec :"
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
+msgid "Codec"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Artist :"
+msgid "Artist"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Album :"
+msgid "Album"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Title :"
-msgstr "Título :"
+msgid "Title"
+msgstr "Título"
 
 #: src/muuli_wdr.cpp
 msgid "File Names"
@@ -4082,25 +4034,17 @@ msgstr "Tamanho desconhecido"
 msgid "Required Information"
 msgstr "Informação Necessária"
 
-#: src/muuli_wdr.cpp
-msgid "IP Address :"
-msgstr "Endereço IP :"
-
-#: src/muuli_wdr.cpp
-msgid "Port :"
-msgstr "Porto :"
+#: src/muuli_wdr.cpp src/ServerListCtrl.cpp
+msgid "Port"
+msgstr "Porto"
 
 #: src/muuli_wdr.cpp
 msgid "Additional Information"
 msgstr "Informações adicionais"
 
 #: src/muuli_wdr.cpp
-msgid "Username :"
-msgstr "Utilizador :"
-
-#: src/muuli_wdr.cpp
-msgid "Userhash :"
-msgstr "Chave de utilizador :"
+msgid "Userhash"
+msgstr "Chave de utilizador"
 
 #: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Add"
@@ -4135,96 +4079,80 @@ msgid "Statistics Tree"
 msgstr "Árvore de Estatísticas"
 
 #: src/muuli_wdr.cpp
-msgid "Username:"
-msgstr "Utilizador:"
+msgid "Client software"
+msgstr "Programa cliente"
 
 #: src/muuli_wdr.cpp
-msgid "Userhash:"
-msgstr "Chave de utilizador:"
+msgid "Client version"
+msgstr "Versão do cliente"
 
 #: src/muuli_wdr.cpp
-msgid "Client software:"
-msgstr "Programa cliente:"
+msgid "User ID"
+msgstr "ID do utilizador"
 
 #: src/muuli_wdr.cpp
-msgid "Client version:"
-msgstr "Versão do cliente:"
-
-#: src/muuli_wdr.cpp src/ServerWnd.cpp
-msgid "IP address:"
-msgstr "Endereço IP:"
+msgid "Server IP"
+msgstr "IP do servidor"
 
 #: src/muuli_wdr.cpp
-msgid "User ID:"
-msgstr "ID do utilizador:"
+msgid "Server name"
+msgstr "Nome do servidor"
 
 #: src/muuli_wdr.cpp
-msgid "Server IP:"
-msgstr "IP do servidor:"
-
-#: src/muuli_wdr.cpp
-msgid "Server name:"
-msgstr "Nome do servidor:"
-
-#: src/muuli_wdr.cpp
-msgid "Obfuscation:"
-msgstr "Ofuscação:"
-
-#: src/muuli_wdr.cpp
-msgid "Kad:"
-msgstr "Kad:"
+msgid "Obfuscation"
+msgstr "Ofuscação"
 
 #: src/muuli_wdr.cpp
 msgid "Transfers to client"
 msgstr "A transferir"
 
 #: src/muuli_wdr.cpp
-msgid "Current request:"
-msgstr "Pedidos actuais:"
+msgid "Current request"
+msgstr "Pedidos actuais"
 
 #: src/muuli_wdr.cpp
-msgid "Average upload rate:"
-msgstr "Taxa média de upload:"
+msgid "Average upload rate"
+msgstr "Taxa média de upload"
 
 #: src/muuli_wdr.cpp
-msgid "Average download rate:"
-msgstr "Taxa média de download:"
+msgid "Average download rate"
+msgstr "Taxa média de download"
 
 #: src/muuli_wdr.cpp
-msgid "Uploaded (session):"
-msgstr "Enviado (sessão):"
+msgid "Uploaded (session)"
+msgstr "Enviado (sessão)"
 
 #: src/muuli_wdr.cpp
-msgid "Downloaded (session):"
-msgstr "Recebido (sessão) :"
+msgid "Downloaded (session)"
+msgstr "Recebido (sessão)"
 
 #: src/muuli_wdr.cpp
-msgid "Uploaded (total):"
-msgstr "Enviado (total):"
+msgid "Uploaded (total)"
+msgstr "Enviado (total)"
 
 #: src/muuli_wdr.cpp
-msgid "Downloaded (total):"
-msgstr "Recebido (total):"
+msgid "Downloaded (total)"
+msgstr "Recebido (total)"
 
 #: src/muuli_wdr.cpp
 msgid "Scores"
 msgstr "Pontuações"
 
 #: src/muuli_wdr.cpp
-msgid "DL/UP modifier:"
-msgstr "Modificador DL/UL:"
+msgid "DL/UP modifier"
+msgstr "Modificador DL/UL"
 
 #: src/muuli_wdr.cpp
-msgid "Secure ident:"
-msgstr "Identificação segura:"
+msgid "Secure ident"
+msgstr "Identificação segura"
 
 #: src/muuli_wdr.cpp
-msgid "Queue rank:"
-msgstr "Pontuação na fila de espera:"
+msgid "Queue rank"
+msgstr "Pontuação na fila de espera"
 
 #: src/muuli_wdr.cpp
-msgid "Queue score:"
-msgstr "Pontuação na fila de espera:"
+msgid "Queue score"
+msgstr "Pontuação na fila de espera"
 
 #: src/muuli_wdr.cpp
 msgid "Nick"
@@ -5020,24 +4948,20 @@ msgid "Reset any changes made to the preferences."
 msgstr "Anular as alterações efectuadas nas preferências."
 
 #: src/muuli_wdr.cpp
-msgid "Comment :"
-msgstr "Comentário :"
+msgid "Incoming Dir"
+msgstr "Pasta de completos"
 
 #: src/muuli_wdr.cpp
-msgid "Incoming Dir :"
-msgstr "Pasta de completos :"
-
-#: src/muuli_wdr.cpp
-msgid "Change priority for new assigned files :"
-msgstr "Trocar prioridade nos novos ficheiros :"
+msgid "Change priority for new assigned files"
+msgstr "Trocar prioridade nos novos ficheiros"
 
 #: src/muuli_wdr.cpp
 msgid "Don't change"
 msgstr "Não mudar"
 
 #: src/muuli_wdr.cpp
-msgid "Select color for this Category (currently selected) :"
-msgstr "Seleccionar a cor para a categoria seleccionada :"
+msgid "Select color for this Category (currently selected)"
+msgstr "Seleccionar a cor para a categoria seleccionada"
 
 #: src/muuli_wdr.cpp
 msgid "Click this button to reset the log."
@@ -5120,10 +5044,6 @@ msgstr "Arrancar a partir de clientes conhecidos"
 #, fuzzy
 msgid "Enter the IP of the node here, using the x.x.x.x format."
 msgstr "Insira o IP do servidor, usando o formato x.x.x.x."
-
-#: src/muuli_wdr.cpp
-msgid "Port:"
-msgstr "Porto:"
 
 #: src/muuli_wdr.cpp
 msgid "Use Secure User Identification"
@@ -5392,20 +5312,20 @@ msgid "Enable/disable proxy support"
 msgstr "Activar/desactivar o suporte de proxy"
 
 #: src/muuli_wdr.cpp
-msgid "Proxy type:"
-msgstr "Tipo de proxy:"
+msgid "Proxy type"
+msgstr "Tipo de proxy"
 
 #: src/muuli_wdr.cpp
-msgid "Proxy host:"
-msgstr "Servidor:"
+msgid "Proxy host"
+msgstr "Servidor"
 
 #: src/muuli_wdr.cpp
 msgid "The proxy host name"
 msgstr "O nome da máquina proxy"
 
 #: src/muuli_wdr.cpp
-msgid "Proxy port:"
-msgstr "Porto do proxy:"
+msgid "Proxy port"
+msgstr "Porto do proxy"
 
 #: src/muuli_wdr.cpp
 msgid "The proxy port"
@@ -5420,16 +5340,8 @@ msgid "Enable/disable username/password authentication"
 msgstr "Activar/desactivar autenticação utilizador/palavra-passe"
 
 #: src/muuli_wdr.cpp
-msgid "Username: "
-msgstr "Utilizador: "
-
-#: src/muuli_wdr.cpp
 msgid "The username to use to connect to the proxy"
 msgstr "O nome de utilizador para ligar ao proxy"
-
-#: src/muuli_wdr.cpp
-msgid "Password:"
-msgstr "Palavra-passe:"
 
 #: src/muuli_wdr.cpp
 msgid "The password to use to connect to the proxy"
@@ -5605,6 +5517,15 @@ msgstr "horas"
 #: src/OtherFunctions.cpp
 msgid "days"
 msgstr "dias"
+
+#. TRANSLATORS:
+#. Punctuation for a "label: value" pair. %s is the already-translated
+#. label. Place the colon as your language requires -- e.g. "%s :" with a
+#. space in French, "%s:" without one in Russian and English.
+#: src/OtherFunctions.cpp
+#, c-format
+msgid "%s:"
+msgstr ""
 
 #: src/OtherFunctions.cpp
 msgid "all"
@@ -6649,8 +6570,7 @@ msgstr ""
 msgid "Confirm shared folders"
 msgstr "Pastas partilhadas"
 
-#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp
-#: src/SharedFilesReloadProgress.cpp
+#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp src/SharedFilesReloadProgress.cpp
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "Recarregar os seus ficheiros partilhados"
@@ -6784,19 +6704,6 @@ msgstr "Erro ao actualizar o GeoIP.dat"
 #: src/SearchListCtrl.cpp
 msgid "FileID"
 msgstr "ID do Ficheiro"
-
-#: src/SearchListCtrl.cpp
-msgid "Length"
-msgstr ""
-
-#: src/SearchListCtrl.cpp
-#, fuzzy
-msgid "Bitrate"
-msgstr "Não avaliado"
-
-#: src/SearchListCtrl.cpp
-msgid "Codec"
-msgstr ""
 
 #: src/SearchListCtrl.cpp
 msgid "Expand all"
@@ -7081,10 +6988,6 @@ msgstr "Servidor local filtrado pelo Filtro de IPs, a ligar a um servidor difere
 #: src/ServerListCtrl.cpp
 msgid "Server Name"
 msgstr "Nome do Servidor"
-
-#: src/ServerListCtrl.cpp
-msgid "Port"
-msgstr "Porto"
 
 #: src/ServerListCtrl.cpp
 msgid "Description"
@@ -7379,6 +7282,10 @@ msgstr "A ligar a um parceiro"
 #, c-format
 msgid "Connected to buddy at %s"
 msgstr "Ligado a parceiro em %s"
+
+#: src/ServerWnd.cpp
+msgid "IP address:"
+msgstr "Endereço IP:"
 
 #: src/ServerWnd.cpp
 msgid "Indexed sources:"

--- a/po/ro.po
+++ b/po/ro.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-04 12:13+0200\n"
+"POT-Creation-Date: 2026-09-05 12:01+0200\n"
 "PO-Revision-Date: 2026-09-03 11:09+0000\n"
 "Last-Translator: Angelescu Constantin <titus0818@yahoo.com>\n"
 "Language-Team: English <kde-i18n-doc@kde.org>\n"
@@ -387,8 +387,7 @@ msgstr "server web rulând pe pid %d"
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Ați solicitat să ruleze la pornire serverul web, dar fișierul binar amuleweb nu poate fi rulat. Instalați pachetul care conține serverul web aMule, sau compilați aMule utilizând --enable-webserver și apoi rulați make install"
 
-#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
-#: src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
+#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
 msgid "ERROR"
 msgstr "EROARE"
 
@@ -676,8 +675,7 @@ msgstr "Rețele"
 msgid "Searches"
 msgstr "Căutări"
 
-#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/Statistics.cpp
+#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/Statistics.cpp
 msgid "Downloads"
 msgstr "Descărcări"
 
@@ -761,9 +759,7 @@ msgstr "Kad: Închis"
 msgid "Core"
 msgstr ""
 
-#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#: src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp
-#: src/SourceListCtrl.cpp src/Statistics.cpp
+#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp src/Statistics.cpp
 msgid "Version"
 msgstr "Versiune"
 
@@ -1062,11 +1058,7 @@ msgstr "Nu se poate crea directorul '%s' pentru categoria '%s', se păstrează d
 msgid "The remote core sent inconsistent data for \"%s\" (part status %d, expected %d). The file list may be showing the wrong information; reconnect to clear it."
 msgstr ""
 
-#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp
-#: src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp
-#: src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp
-#: src/Statistics.cpp
+#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp src/Statistics.cpp
 msgid "Unknown"
 msgstr "Necunoscut"
 
@@ -1165,8 +1157,7 @@ msgstr "Eroare în timpul salvării fișierului %s : %s"
 msgid "Enter Captcha"
 msgstr "Introduceți Captcha"
 
-#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp
-#: src/TransferWnd.cpp
+#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp src/TransferWnd.cpp
 msgid "Category"
 msgstr "Categorie"
 
@@ -1336,13 +1327,11 @@ msgstr "Nu s-a găsit niciun fișier 'cryptkey.dat' , se creează."
 msgid "Client Details"
 msgstr "Detalii client"
 
-#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
-#: src/utils/wxCas/src/onlinesig.cpp
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
 msgid "LowID"
 msgstr "LowID"
 
-#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
-#: src/utils/wxCas/src/onlinesig.cpp
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
 msgid "HighID"
 msgstr "HighID"
 
@@ -1358,8 +1347,7 @@ msgstr "Susținut"
 msgid "Not supported"
 msgstr "Nu este susținut"
 
-#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
-#: src/TextClient.cpp
+#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp src/TextClient.cpp
 msgid "Connected"
 msgstr "Conectat"
 
@@ -1367,28 +1355,24 @@ msgstr "Conectat"
 msgid "Disconnected"
 msgstr "Deconectat"
 
-#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp
-#: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f KiB/s"
 msgstr ""
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#, fuzzy
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/muuli_wdr.cpp
 msgid "Name"
-msgstr "Name:"
+msgstr "Name"
 
 #: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
 msgid "Software"
 msgstr ""
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#, fuzzy
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/muuli_wdr.cpp
 msgid "IP Address"
-msgstr "Adresă IP :"
+msgstr "Adresă IP"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Origin"
 msgstr "Origine"
 
@@ -1406,13 +1390,11 @@ msgstr "Ultima recepție"
 msgid "Sessions"
 msgstr "Versiune"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp
 msgid "Upload Speed"
 msgstr "Viteză încărcare"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp
 msgid "Download Speed"
 msgstr "Viteză descărcare"
 
@@ -1468,13 +1450,11 @@ msgstr[2] ""
 msgid "Files"
 msgstr "Fișiere"
 
-#: src/ClientsListCtrl.cpp src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp
-#: src/SourceListCtrl.cpp
+#: src/ClientsListCtrl.cpp src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Uploaded"
 msgstr "Încărcat"
 
-#: src/ClientsListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientsListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Downloaded"
 msgstr "Descărcat"
 
@@ -1561,12 +1541,11 @@ msgstr "Utilizatorul %s (%u) interzice accesul la lista directoarelor/fișierelo
 msgid "File Comments"
 msgstr "Comentarii fișier"
 
-#: src/CommentDialogLst.cpp src/FriendListCtrl.cpp
+#: src/CommentDialogLst.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
 msgid "Username"
 msgstr "Utilizator"
 
-#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp
-#: src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "File Name"
 msgstr "Denumire fișier"
 
@@ -1574,7 +1553,7 @@ msgstr "Denumire fișier"
 msgid "Rating"
 msgstr "Evaluare"
 
-#: src/CommentDialogLst.cpp
+#: src/CommentDialogLst.cpp src/muuli_wdr.cpp
 msgid "Comment"
 msgstr "Comentariu"
 
@@ -1629,18 +1608,15 @@ msgstr "Automat [În]"
 msgid "Very low"
 msgstr "Foarte joasă"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Low"
 msgstr "Joasă"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Normal"
 msgstr "Normal"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "High"
 msgstr "Înaltă"
 
@@ -1664,13 +1640,11 @@ msgstr "Se conectează prin server"
 msgid "Queue Full"
 msgstr "Coadă plină"
 
-#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp
-#: src/muuli_wdr.cpp
+#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp src/muuli_wdr.cpp
 msgid "On Queue"
 msgstr "În coadă"
 
-#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp
-#: src/PartFile.cpp src/TransferWnd.cpp
+#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Downloading"
 msgstr "Se descarcă"
 
@@ -1730,8 +1704,7 @@ msgstr "Server local"
 msgid "Remote Server"
 msgstr "Server distant"
 
-#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp
-#: src/TextClient.cpp
+#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp src/TextClient.cpp
 msgid "Kad"
 msgstr "Kad"
 
@@ -1755,8 +1728,7 @@ msgstr "Semințe sursă"
 msgid "Search Result"
 msgstr "Rezultat căutare"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp
-#: src/TransferWnd.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Completed"
 msgstr "Terminat"
 
@@ -1809,8 +1781,7 @@ msgstr ""
 msgid "Part"
 msgstr "Parte"
 
-#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp
-#: src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Size"
 msgstr "Dimensiune"
 
@@ -1818,8 +1789,7 @@ msgstr "Dimensiune"
 msgid "Transferred"
 msgstr "Transferat"
 
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
-#: src/SourceListCtrl.cpp
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp src/SourceListCtrl.cpp
 msgid "Speed"
 msgstr "Viteză"
 
@@ -1827,13 +1797,11 @@ msgstr "Viteză"
 msgid "Progress"
 msgstr "Progres"
 
-#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp
-#: src/SearchListCtrl.cpp
+#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
 msgid "Sources"
 msgstr "Surse"
 
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp
-#: src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Priority"
 msgstr "Prioritate"
 
@@ -1857,9 +1825,7 @@ msgstr "Ultima recepție"
 msgid "Auto"
 msgstr "Automat"
 
-#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/TransferWnd.cpp
-#: src/utils/wxCas/src/wxcasprefs.cpp
+#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/TransferWnd.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Cancel"
 msgstr "Anulare"
 
@@ -1960,8 +1926,7 @@ msgstr "Introduceți noul nume pentru acest fișier:"
 msgid "File rename"
 msgstr "Redenumire fișier"
 
-#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp
-#: src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f MiB/s"
 msgstr ""
@@ -2766,13 +2731,11 @@ msgstr ""
 msgid "Start aMule automatically when I log in"
 msgstr ""
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
-#: packaging/windows/installer_strings.c
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp packaging/windows/installer_strings.c
 msgid "Register aMule for ed2k:// links"
 msgstr ""
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
-#: packaging/windows/installer_strings.c
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp packaging/windows/installer_strings.c
 msgid "Register aMule for magnet: links"
 msgstr ""
 
@@ -2798,8 +2761,7 @@ msgstr ""
 msgid "Destination folder for downloads"
 msgstr "Dosar destinație pentru descărcări"
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
-#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Browse"
 msgstr "Navigare"
 
@@ -3247,18 +3209,15 @@ msgstr "Finalizat"
 msgid "Complete"
 msgstr "Terminat"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
-#: src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Paused"
 msgstr "Întrerupt"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
-#: src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Erroneous"
 msgstr "Eronat"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
-#: src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Waiting"
 msgstr "Se așteaptă"
 
@@ -3426,8 +3385,7 @@ msgstr "Închide"
 msgid "Cut"
 msgstr "Taie"
 
-#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp
-#: src/utils/aLinkCreator/src/alcframe.cpp
+#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy"
 msgstr "Copiază"
 
@@ -3435,8 +3393,7 @@ msgstr "Copiază"
 msgid "Paste"
 msgstr "Lipește"
 
-#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp
-#: src/utils/aLinkCreator/src/alcframe.cpp
+#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Clear"
 msgstr "Curăță"
 
@@ -3444,8 +3401,7 @@ msgstr "Curăță"
 msgid "Select All"
 msgstr "Selectează tot"
 
-#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
-#: src/StatisticsDlg.cpp
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp src/StatisticsDlg.cpp
 msgid "KiB/s"
 msgstr ""
 
@@ -3709,10 +3665,6 @@ msgstr "Server conectat curent."
 msgid "Search"
 msgstr "Căutare"
 
-#: src/muuli_wdr.cpp
-msgid "Name:"
-msgstr "Name:"
-
 #: src/muuli_wdr.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Type"
 msgstr "Tip"
@@ -3802,8 +3754,8 @@ msgid "Availability"
 msgstr "Disponibilitate"
 
 #: src/muuli_wdr.cpp
-msgid "Filter:"
-msgstr "Filtru:"
+msgid "Filter"
+msgstr "Filtru"
 
 #: src/muuli_wdr.cpp
 msgid "Invert Result"
@@ -3861,6 +3813,10 @@ msgid "Clears completed downloads"
 msgstr "Curăță descărcările terminate"
 
 #: src/muuli_wdr.cpp
+msgid "Filter:"
+msgstr "Filtru:"
+
+#: src/muuli_wdr.cpp
 msgid "File sources:"
 msgstr "Surse fișier:"
 
@@ -3869,80 +3825,76 @@ msgid "General"
 msgstr "General"
 
 #: src/muuli_wdr.cpp
-msgid "Full Name :"
-msgstr "Nume complet :"
+msgid "Full Name"
+msgstr "Nume complet"
 
 #: src/muuli_wdr.cpp
-msgid "met-File :"
-msgstr "met-File :"
+msgid "met-File"
+msgstr "met-File"
 
 #: src/muuli_wdr.cpp
-msgid "Hash :"
-msgstr "Index :"
+msgid "Hash"
+msgstr "Index"
 
 #: src/muuli_wdr.cpp
-msgid "Filesize :"
-msgstr "Dimensiune fișier :"
+msgid "Filesize"
+msgstr "Dimensiune fișier"
 
 #: src/muuli_wdr.cpp src/Statistics.cpp
 msgid "Transfer"
 msgstr "Transfer"
 
 #: src/muuli_wdr.cpp
-msgid "Partfilestatus :"
-msgstr "Stare fișier parțial :"
+msgid "Partfilestatus"
+msgstr "Stare fișier parțial"
 
 #: src/muuli_wdr.cpp
-msgid "Last seen complete :"
-msgstr "Văzut ultima oară complet :"
+msgid "Last seen complete"
+msgstr "Văzut ultima oară complet"
 
 #: src/muuli_wdr.cpp
-msgid "Found Sources :"
-msgstr "S-au găsit sursele :"
+msgid "Found Sources"
+msgstr "S-au găsit sursele"
 
 #: src/muuli_wdr.cpp
-msgid "Transferring Sources :"
-msgstr "Se transferă sursele :"
+msgid "Transferring Sources"
+msgstr "Se transferă sursele"
 
 #: src/muuli_wdr.cpp
-msgid "Filepart-Count :"
-msgstr "Cantitate-fișiere parțiale :"
+msgid "Filepart-Count"
+msgstr "Cantitate-fișiere parțiale"
 
 #: src/muuli_wdr.cpp
-msgid "Available :"
-msgstr "Disponibil :"
+msgid "Available"
+msgstr "Disponibil"
 
 #: src/muuli_wdr.cpp
-msgid "Datarate :"
-msgstr "Rată date :"
+msgid "Datarate"
+msgstr "Rată date"
 
 #: src/muuli_wdr.cpp
-msgid "Download Active Time: "
-msgstr "Timp activ de descărcare:"
+msgid "Download Active Time"
+msgstr "Timp activ de descărcare"
 
 #: src/muuli_wdr.cpp
-msgid "Transferred :"
-msgstr "Transferat :"
-
-#: src/muuli_wdr.cpp
-msgid "Completed Size :"
-msgstr "Dimensiune completă :"
+msgid "Completed Size"
+msgstr "Dimensiune completă"
 
 #: src/muuli_wdr.cpp
 msgid "Intelligent Corruption Handling"
 msgstr "Gestionare inteligentă a fișierelor corupte"
 
 #: src/muuli_wdr.cpp
-msgid "Lost to corruption :"
-msgstr "Pierdut la corupte :"
+msgid "Lost to corruption"
+msgstr "Pierdut la corupte"
 
 #: src/muuli_wdr.cpp
-msgid "Gained by compression :"
-msgstr "Câștigat prin compresie :"
+msgid "Gained by compression"
+msgstr "Câștigat prin compresie"
 
 #: src/muuli_wdr.cpp
-msgid "Packages saved by I.C.H. :"
-msgstr "Pachete salvate de I.C.H. :"
+msgid "Packages saved by I.C.H."
+msgstr "Pachete salvate de I.C.H."
 
 #: src/muuli_wdr.cpp
 #, fuzzy
@@ -3984,30 +3936,30 @@ msgstr ", Încărcat: "
 msgid "Media Info"
 msgstr "Informație Kad"
 
-#: src/muuli_wdr.cpp
-msgid "Length :"
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
+msgid "Length"
 msgstr ""
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
 #, fuzzy
-msgid "Bitrate :"
+msgid "Bitrate"
 msgstr "Nu este apreciat"
 
-#: src/muuli_wdr.cpp
-msgid "Codec :"
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
+msgid "Codec"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Artist :"
+msgid "Artist"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Album :"
+msgid "Album"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Title :"
-msgstr "Titlu :"
+msgid "Title"
+msgstr "Titlu"
 
 #: src/muuli_wdr.cpp
 msgid "File Names"
@@ -4094,25 +4046,17 @@ msgstr "Mărime necunoscută"
 msgid "Required Information"
 msgstr "Informație solicitată"
 
-#: src/muuli_wdr.cpp
-msgid "IP Address :"
-msgstr "Adresă IP :"
-
-#: src/muuli_wdr.cpp
-msgid "Port :"
-msgstr "Port :"
+#: src/muuli_wdr.cpp src/ServerListCtrl.cpp
+msgid "Port"
+msgstr "Port"
 
 #: src/muuli_wdr.cpp
 msgid "Additional Information"
 msgstr "Informații suplimentare"
 
 #: src/muuli_wdr.cpp
-msgid "Username :"
-msgstr "Nume utilizator:"
-
-#: src/muuli_wdr.cpp
-msgid "Userhash :"
-msgstr "Index utilizator :"
+msgid "Userhash"
+msgstr "Index utilizator"
 
 #: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Add"
@@ -4147,96 +4091,80 @@ msgid "Statistics Tree"
 msgstr "Arbore statistici"
 
 #: src/muuli_wdr.cpp
-msgid "Username:"
-msgstr "Utilizator:"
+msgid "Client software"
+msgstr "Aplicație client"
 
 #: src/muuli_wdr.cpp
-msgid "Userhash:"
-msgstr "Index utilizator:"
+msgid "Client version"
+msgstr "Versiune client"
 
 #: src/muuli_wdr.cpp
-msgid "Client software:"
-msgstr "Aplicație client:"
+msgid "User ID"
+msgstr "Id. utilizator"
 
 #: src/muuli_wdr.cpp
-msgid "Client version:"
-msgstr "Versiune client:"
-
-#: src/muuli_wdr.cpp src/ServerWnd.cpp
-msgid "IP address:"
-msgstr "adresă IP:"
+msgid "Server IP"
+msgstr "IP server"
 
 #: src/muuli_wdr.cpp
-msgid "User ID:"
-msgstr "Id. utilizator:"
+msgid "Server name"
+msgstr "Nume server"
 
 #: src/muuli_wdr.cpp
-msgid "Server IP:"
-msgstr "IP server:"
-
-#: src/muuli_wdr.cpp
-msgid "Server name:"
-msgstr "Nume server:"
-
-#: src/muuli_wdr.cpp
-msgid "Obfuscation:"
-msgstr "Disimulare:"
-
-#: src/muuli_wdr.cpp
-msgid "Kad:"
-msgstr "Kad:"
+msgid "Obfuscation"
+msgstr "Disimulare"
 
 #: src/muuli_wdr.cpp
 msgid "Transfers to client"
 msgstr "Transferuri la client"
 
 #: src/muuli_wdr.cpp
-msgid "Current request:"
-msgstr "Solicitare curentă:"
+msgid "Current request"
+msgstr "Solicitare curentă"
 
 #: src/muuli_wdr.cpp
-msgid "Average upload rate:"
-msgstr "Rată medie de încărcare:"
+msgid "Average upload rate"
+msgstr "Rată medie de încărcare"
 
 #: src/muuli_wdr.cpp
-msgid "Average download rate:"
-msgstr "Rată medie de descărcare:"
+msgid "Average download rate"
+msgstr "Rată medie de descărcare"
 
 #: src/muuli_wdr.cpp
-msgid "Uploaded (session):"
-msgstr "Încărcare (sesiune):"
+msgid "Uploaded (session)"
+msgstr "Încărcare (sesiune)"
 
 #: src/muuli_wdr.cpp
-msgid "Downloaded (session):"
+msgid "Downloaded (session)"
 msgstr "Descărcare (sesiune)"
 
 #: src/muuli_wdr.cpp
-msgid "Uploaded (total):"
+msgid "Uploaded (total)"
 msgstr "Încărcat (total)"
 
 #: src/muuli_wdr.cpp
-msgid "Downloaded (total):"
-msgstr "Descărcat (total):"
+msgid "Downloaded (total)"
+msgstr "Descărcat (total)"
 
 #: src/muuli_wdr.cpp
 msgid "Scores"
 msgstr "Scoruri"
 
 #: src/muuli_wdr.cpp
-msgid "DL/UP modifier:"
-msgstr "Modificator De/În:"
+msgid "DL/UP modifier"
+msgstr "Modificator De/În"
 
 #: src/muuli_wdr.cpp
-msgid "Secure ident:"
-msgstr "Identificare sigură:"
+msgid "Secure ident"
+msgstr "Identificare sigură"
 
 #: src/muuli_wdr.cpp
-msgid "Queue rank:"
-msgstr "Rang coadă:"
+msgid "Queue rank"
+msgstr "Rang coadă"
 
 #: src/muuli_wdr.cpp
-msgid "Queue score:"
-msgstr "Scor coadă:"
+msgid "Queue score"
+msgstr "Scor coadă"
 
 #: src/muuli_wdr.cpp
 msgid "Nick"
@@ -5031,24 +4959,20 @@ msgid "Reset any changes made to the preferences."
 msgstr "Resetează orice schimbare efectuată la preferințe."
 
 #: src/muuli_wdr.cpp
-msgid "Comment :"
-msgstr "Comentariu :"
+msgid "Incoming Dir"
+msgstr "Director intrare"
 
 #: src/muuli_wdr.cpp
-msgid "Incoming Dir :"
-msgstr "Director intrare :"
-
-#: src/muuli_wdr.cpp
-msgid "Change priority for new assigned files :"
-msgstr "Schimbă prioritatea pentru noile fișiere alocate :"
+msgid "Change priority for new assigned files"
+msgstr "Schimbă prioritatea pentru noile fișiere alocate"
 
 #: src/muuli_wdr.cpp
 msgid "Don't change"
 msgstr "Nu modifica"
 
 #: src/muuli_wdr.cpp
-msgid "Select color for this Category (currently selected) :"
-msgstr "Selectați culoarea pentru această categorie (selectată curent):"
+msgid "Select color for this Category (currently selected)"
+msgstr "Selectați culoarea pentru această categorie (selectată curent)"
 
 #: src/muuli_wdr.cpp
 msgid "Click this button to reset the log."
@@ -5131,10 +5055,6 @@ msgstr "Bootstrap de la clienții cunoscuți"
 #, fuzzy
 msgid "Enter the IP of the node here, using the x.x.x.x format."
 msgstr "Introduceți aici adresa IP a serverului, utilizând formatul x.x.x.x  ."
-
-#: src/muuli_wdr.cpp
-msgid "Port:"
-msgstr "Port:"
 
 #: src/muuli_wdr.cpp
 msgid "Use Secure User Identification"
@@ -5403,20 +5323,20 @@ msgid "Enable/disable proxy support"
 msgstr "Activează/dezactivează suportul proxy"
 
 #: src/muuli_wdr.cpp
-msgid "Proxy type:"
-msgstr "Tip proxy:"
+msgid "Proxy type"
+msgstr "Tip proxy"
 
 #: src/muuli_wdr.cpp
-msgid "Proxy host:"
-msgstr "Gazdă proxy:"
+msgid "Proxy host"
+msgstr "Gazdă proxy"
 
 #: src/muuli_wdr.cpp
 msgid "The proxy host name"
 msgstr "Numele de gazdă proxy"
 
 #: src/muuli_wdr.cpp
-msgid "Proxy port:"
-msgstr "Port proxy:"
+msgid "Proxy port"
+msgstr "Port proxy"
 
 #: src/muuli_wdr.cpp
 msgid "The proxy port"
@@ -5431,16 +5351,8 @@ msgid "Enable/disable username/password authentication"
 msgstr "Activează/dezactivează autentificarea cu nume utilizator/parolă"
 
 #: src/muuli_wdr.cpp
-msgid "Username: "
-msgstr "Utilizator:"
-
-#: src/muuli_wdr.cpp
 msgid "The username to use to connect to the proxy"
 msgstr "Numele de utilizator de utilizat pentru conectarea la proxy"
-
-#: src/muuli_wdr.cpp
-msgid "Password:"
-msgstr "Parolă:"
 
 #: src/muuli_wdr.cpp
 msgid "The password to use to connect to the proxy"
@@ -5617,6 +5529,15 @@ msgstr "ore"
 #: src/OtherFunctions.cpp
 msgid "days"
 msgstr "zile"
+
+#. TRANSLATORS:
+#. Punctuation for a "label: value" pair. %s is the already-translated
+#. label. Place the colon as your language requires -- e.g. "%s :" with a
+#. space in French, "%s:" without one in Russian and English.
+#: src/OtherFunctions.cpp
+#, c-format
+msgid "%s:"
+msgstr ""
 
 #: src/OtherFunctions.cpp
 msgid "all"
@@ -6666,8 +6587,7 @@ msgstr ""
 msgid "Confirm shared folders"
 msgstr "Dosare partajate"
 
-#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp
-#: src/SharedFilesReloadProgress.cpp
+#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp src/SharedFilesReloadProgress.cpp
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "Reîncărcați fișierele partajate"
@@ -6801,19 +6721,6 @@ msgstr "Eroare la actualizarea GeoIP.dat"
 #: src/SearchListCtrl.cpp
 msgid "FileID"
 msgstr "ID fișier"
-
-#: src/SearchListCtrl.cpp
-msgid "Length"
-msgstr ""
-
-#: src/SearchListCtrl.cpp
-#, fuzzy
-msgid "Bitrate"
-msgstr "Nu este apreciat"
-
-#: src/SearchListCtrl.cpp
-msgid "Codec"
-msgstr ""
 
 #: src/SearchListCtrl.cpp
 msgid "Expand all"
@@ -7101,10 +7008,6 @@ msgstr "Serverul local este filtrat de filtrele IP, reconectați la un server di
 #: src/ServerListCtrl.cpp
 msgid "Server Name"
 msgstr "Nume server"
-
-#: src/ServerListCtrl.cpp
-msgid "Port"
-msgstr "Port"
 
 #: src/ServerListCtrl.cpp
 msgid "Description"
@@ -7400,6 +7303,10 @@ msgstr "Se conectează la persoane"
 #, c-format
 msgid "Connected to buddy at %s"
 msgstr "Conectat cu prietenul la %s"
+
+#: src/ServerWnd.cpp
+msgid "IP address:"
+msgstr "adresă IP:"
 
 #: src/ServerWnd.cpp
 msgid "Indexed sources:"

--- a/po/ru.po
+++ b/po/ru.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-04 12:13+0200\n"
+"POT-Creation-Date: 2026-09-05 12:01+0200\n"
 "PO-Revision-Date: 2026-09-03 11:09+0000\n"
 "Last-Translator: Radist Morse <radist.morse@gmail.com>\n"
 "Language-Team: Russian <kde-russian@lists.kde.ru>\n"
@@ -393,8 +393,7 @@ msgstr "веб-сервер работает с pid %d"
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Вы запросили запуск веб-сервера при старте, но исполняемый файл amuleweb не может быть запущен. Установите пакет, содержащий веб-сервер aMule, либо соберите aMule из исходного кода с параметром -DBUILD_WEBSERVER=YES и установите его."
 
-#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
-#: src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
+#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
 msgid "ERROR"
 msgstr "ОШИБКА"
 
@@ -684,8 +683,7 @@ msgstr "Сети"
 msgid "Searches"
 msgstr "Поиск"
 
-#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/Statistics.cpp
+#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/Statistics.cpp
 msgid "Downloads"
 msgstr "Загрузки"
 
@@ -773,9 +771,7 @@ msgstr "Kad: отключён"
 msgid "Core"
 msgstr "Ядро"
 
-#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#: src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp
-#: src/SourceListCtrl.cpp src/Statistics.cpp
+#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp src/Statistics.cpp
 msgid "Version"
 msgstr "Версия"
 
@@ -1072,11 +1068,7 @@ msgstr "Не удается создать директорию '%s' для ка
 msgid "The remote core sent inconsistent data for \"%s\" (part status %d, expected %d). The file list may be showing the wrong information; reconnect to clear it."
 msgstr "Удалённое ядро отправило противоречивые данные для «%s» (состояние части %d, ожидалось %d). Список файлов может отображать неверную информацию; переподключитесь для очистки."
 
-#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp
-#: src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp
-#: src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp
-#: src/Statistics.cpp
+#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp src/Statistics.cpp
 msgid "Unknown"
 msgstr "Неизвестно"
 
@@ -1175,8 +1167,7 @@ msgstr "Ошибка при сохранении файла %s: %s"
 msgid "Enter Captcha"
 msgstr "Введите код"
 
-#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp
-#: src/TransferWnd.cpp
+#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp src/TransferWnd.cpp
 msgid "Category"
 msgstr "Категория"
 
@@ -1345,13 +1336,11 @@ msgstr "Файл 'cryptkey.dat' не найден. Создаю заново."
 msgid "Client Details"
 msgstr "Сведения о клиенте"
 
-#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
-#: src/utils/wxCas/src/onlinesig.cpp
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
 msgid "LowID"
 msgstr "Низкий ИД"
 
-#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
-#: src/utils/wxCas/src/onlinesig.cpp
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
 msgid "HighID"
 msgstr "Высокий ИД"
 
@@ -1367,8 +1356,7 @@ msgstr "Поддерживается"
 msgid "Not supported"
 msgstr "Не поддерживается"
 
-#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
-#: src/TextClient.cpp
+#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp src/TextClient.cpp
 msgid "Connected"
 msgstr "Подключён"
 
@@ -1376,13 +1364,12 @@ msgstr "Подключён"
 msgid "Disconnected"
 msgstr "Отключён"
 
-#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp
-#: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f KiB/s"
 msgstr "%.1f КиБ/с"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/muuli_wdr.cpp
 msgid "Name"
 msgstr "Имя"
 
@@ -1390,14 +1377,13 @@ msgstr "Имя"
 msgid "Software"
 msgstr "ПО"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/muuli_wdr.cpp
 msgid "IP Address"
 msgstr "IP-адрес"
 
 # Source of a source. I mean, it's where a client came from.
 # (GonoszTopi)
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Origin"
 msgstr "Источник"
 
@@ -1413,13 +1399,11 @@ msgstr "Последнее появление"
 msgid "Sessions"
 msgstr "Сеансы"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp
 msgid "Upload Speed"
 msgstr "Скорость отдачи"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp
 msgid "Download Speed"
 msgstr "Скорость загрузки"
 
@@ -1471,13 +1455,11 @@ msgstr[2] "Не удалось добавить %u ссылок (подробн�
 msgid "Files"
 msgstr "Файлы"
 
-#: src/ClientsListCtrl.cpp src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp
-#: src/SourceListCtrl.cpp
+#: src/ClientsListCtrl.cpp src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Uploaded"
 msgstr "Отдано"
 
-#: src/ClientsListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientsListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Downloaded"
 msgstr "Загружено"
 
@@ -1561,12 +1543,11 @@ msgstr "Пользователь %s (%u) отказал в доступе к с�
 msgid "File Comments"
 msgstr "Комментарии файла"
 
-#: src/CommentDialogLst.cpp src/FriendListCtrl.cpp
+#: src/CommentDialogLst.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
 msgid "Username"
 msgstr "Имя пользователя"
 
-#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp
-#: src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "File Name"
 msgstr "Имя файла"
 
@@ -1574,7 +1555,7 @@ msgstr "Имя файла"
 msgid "Rating"
 msgstr "Оценка"
 
-#: src/CommentDialogLst.cpp
+#: src/CommentDialogLst.cpp src/muuli_wdr.cpp
 msgid "Comment"
 msgstr "Комментарий"
 
@@ -1629,18 +1610,15 @@ msgstr "Авто [высокий]"
 msgid "Very low"
 msgstr "Очень низкий"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Low"
 msgstr "Низкий"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Normal"
 msgstr "Обычный"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "High"
 msgstr "Высокий"
 
@@ -1664,13 +1642,11 @@ msgstr "Соединение через сервер"
 msgid "Queue Full"
 msgstr "Очередь заполнена"
 
-#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp
-#: src/muuli_wdr.cpp
+#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp src/muuli_wdr.cpp
 msgid "On Queue"
 msgstr "В очереди"
 
-#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp
-#: src/PartFile.cpp src/TransferWnd.cpp
+#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Downloading"
 msgstr "Загружается"
 
@@ -1730,8 +1706,7 @@ msgstr "Локальный сервер"
 msgid "Remote Server"
 msgstr "Удалённый сервер"
 
-#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp
-#: src/TextClient.cpp
+#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp src/TextClient.cpp
 msgid "Kad"
 msgstr "Kad"
 
@@ -1755,8 +1730,7 @@ msgstr "Источники сидов"
 msgid "Search Result"
 msgstr "Результаты поиска"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp
-#: src/TransferWnd.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Completed"
 msgstr "Завершено"
 
@@ -1809,8 +1783,7 @@ msgstr "Нельзя изменять внутри рекурсивной пуб
 msgid "Part"
 msgstr "Часть"
 
-#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp
-#: src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Size"
 msgstr "Размер"
 
@@ -1818,8 +1791,7 @@ msgstr "Размер"
 msgid "Transferred"
 msgstr "Передано"
 
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
-#: src/SourceListCtrl.cpp
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp src/SourceListCtrl.cpp
 msgid "Speed"
 msgstr "Скорость"
 
@@ -1827,13 +1799,11 @@ msgstr "Скорость"
 msgid "Progress"
 msgstr "Выполнено"
 
-#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp
-#: src/SearchListCtrl.cpp
+#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
 msgid "Sources"
 msgstr "Источники"
 
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp
-#: src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Priority"
 msgstr "Приоритет"
 
@@ -1857,9 +1827,7 @@ msgstr "Последний приём"
 msgid "Auto"
 msgstr "Авто"
 
-#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/TransferWnd.cpp
-#: src/utils/wxCas/src/wxcasprefs.cpp
+#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/TransferWnd.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Cancel"
 msgstr "Отмена"
 
@@ -1960,8 +1928,7 @@ msgstr "Введите новое имя файла:"
 msgid "File rename"
 msgstr "Переименовать файл"
 
-#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp
-#: src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f MiB/s"
 msgstr "%.1f МиБ/с"
@@ -2767,13 +2734,11 @@ msgstr ""
 msgid "Start aMule automatically when I log in"
 msgstr "Запускать aMule автоматически при моём входе в систему"
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
-#: packaging/windows/installer_strings.c
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp packaging/windows/installer_strings.c
 msgid "Register aMule for ed2k:// links"
 msgstr "Зарегистрировать aMule для ссылок ed2k://"
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
-#: packaging/windows/installer_strings.c
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp packaging/windows/installer_strings.c
 msgid "Register aMule for magnet: links"
 msgstr "Зарегистрировать aMule для магнит-ссылок"
 
@@ -2801,8 +2766,7 @@ msgstr ""
 msgid "Destination folder for downloads"
 msgstr "Папка для загружаемых файлов"
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
-#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Browse"
 msgstr "Открыть"
 
@@ -3252,18 +3216,15 @@ msgstr "Завершается"
 msgid "Complete"
 msgstr "Завершено"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
-#: src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Paused"
 msgstr "Приостановлен"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
-#: src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Erroneous"
 msgstr "Ошибочный"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
-#: src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Waiting"
 msgstr "Ожидает"
 
@@ -3429,8 +3390,7 @@ msgstr "Закрыть"
 msgid "Cut"
 msgstr "Вырезать"
 
-#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp
-#: src/utils/aLinkCreator/src/alcframe.cpp
+#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy"
 msgstr "Копировать"
 
@@ -3438,8 +3398,7 @@ msgstr "Копировать"
 msgid "Paste"
 msgstr "Вставить"
 
-#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp
-#: src/utils/aLinkCreator/src/alcframe.cpp
+#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Clear"
 msgstr "Очистить"
 
@@ -3447,8 +3406,7 @@ msgstr "Очистить"
 msgid "Select All"
 msgstr "Выделить все"
 
-#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
-#: src/StatisticsDlg.cpp
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp src/StatisticsDlg.cpp
 msgid "KiB/s"
 msgstr "КиБ/с"
 
@@ -3707,10 +3665,6 @@ msgstr "Сейчас подключён к серверу."
 msgid "Search"
 msgstr "Поиск"
 
-#: src/muuli_wdr.cpp
-msgid "Name:"
-msgstr "Имя:"
-
 #: src/muuli_wdr.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Type"
 msgstr "Тип"
@@ -3800,8 +3754,8 @@ msgid "Availability"
 msgstr "Доступность"
 
 #: src/muuli_wdr.cpp
-msgid "Filter:"
-msgstr "Фильтр:"
+msgid "Filter"
+msgstr "Фильтр"
 
 #: src/muuli_wdr.cpp
 msgid "Invert Result"
@@ -3856,6 +3810,10 @@ msgid "Clears completed downloads"
 msgstr "Очистить завершённые загрузки"
 
 #: src/muuli_wdr.cpp
+msgid "Filter:"
+msgstr "Фильтр:"
+
+#: src/muuli_wdr.cpp
 msgid "File sources:"
 msgstr "Источники файлов:"
 
@@ -3864,80 +3822,76 @@ msgid "General"
 msgstr "Основные"
 
 #: src/muuli_wdr.cpp
-msgid "Full Name :"
-msgstr "Полное имя:"
+msgid "Full Name"
+msgstr "Полное имя"
 
 #: src/muuli_wdr.cpp
-msgid "met-File :"
-msgstr "Met-файл:"
+msgid "met-File"
+msgstr "Met-файл"
 
 #: src/muuli_wdr.cpp
-msgid "Hash :"
-msgstr "Хеш:"
+msgid "Hash"
+msgstr "Хеш"
 
 #: src/muuli_wdr.cpp
-msgid "Filesize :"
-msgstr "Размер файла:"
+msgid "Filesize"
+msgstr "Размер файла"
 
 #: src/muuli_wdr.cpp src/Statistics.cpp
 msgid "Transfer"
 msgstr "Передача"
 
 #: src/muuli_wdr.cpp
-msgid "Partfilestatus :"
-msgstr "Статус:"
+msgid "Partfilestatus"
+msgstr "Статус"
 
 #: src/muuli_wdr.cpp
-msgid "Last seen complete :"
-msgstr "Замечен целиком:"
+msgid "Last seen complete"
+msgstr "Замечен целиком"
 
 #: src/muuli_wdr.cpp
-msgid "Found Sources :"
-msgstr "Найдено источников:"
+msgid "Found Sources"
+msgstr "Найдено источников"
 
 #: src/muuli_wdr.cpp
-msgid "Transferring Sources :"
-msgstr "Передающие источники:"
+msgid "Transferring Sources"
+msgstr "Передающие источники"
 
 #: src/muuli_wdr.cpp
-msgid "Filepart-Count :"
-msgstr "Число частей:"
+msgid "Filepart-Count"
+msgstr "Число частей"
 
 #: src/muuli_wdr.cpp
-msgid "Available :"
-msgstr "Доступно:"
+msgid "Available"
+msgstr "Доступно"
 
 #: src/muuli_wdr.cpp
-msgid "Datarate :"
-msgstr "Скорость передачи:"
+msgid "Datarate"
+msgstr "Скорость передачи"
 
 #: src/muuli_wdr.cpp
-msgid "Download Active Time: "
-msgstr "Время активности загрузки: "
+msgid "Download Active Time"
+msgstr "Время активности загрузки"
 
 #: src/muuli_wdr.cpp
-msgid "Transferred :"
-msgstr "Передано:"
-
-#: src/muuli_wdr.cpp
-msgid "Completed Size :"
-msgstr "Завершено:"
+msgid "Completed Size"
+msgstr "Завершено"
 
 #: src/muuli_wdr.cpp
 msgid "Intelligent Corruption Handling"
 msgstr "Умный обработчик повреждений (ICH)"
 
 #: src/muuli_wdr.cpp
-msgid "Lost to corruption :"
-msgstr "Потери из-за повреждений:"
+msgid "Lost to corruption"
+msgstr "Потери из-за повреждений"
 
 #: src/muuli_wdr.cpp
-msgid "Gained by compression :"
-msgstr "Выигрыш сжатия:"
+msgid "Gained by compression"
+msgstr "Выигрыш сжатия"
 
 #: src/muuli_wdr.cpp
-msgid "Packages saved by I.C.H. :"
-msgstr "Экономия пакетов от ICH:"
+msgid "Packages saved by I.C.H."
+msgstr "Экономия пакетов от ICH"
 
 #: src/muuli_wdr.cpp
 msgid "Sharing"
@@ -3975,29 +3929,29 @@ msgstr "Последняя отдача"
 msgid "Media Info"
 msgstr "Сведения о медиафайле"
 
-#: src/muuli_wdr.cpp
-msgid "Length :"
-msgstr "Длительность:"
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
+msgid "Length"
+msgstr "Длительность"
+
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
+msgid "Bitrate"
+msgstr "Битрейт"
+
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
+msgid "Codec"
+msgstr "Кодек"
 
 #: src/muuli_wdr.cpp
-msgid "Bitrate :"
-msgstr "Битрейт:"
+msgid "Artist"
+msgstr "Исполнитель"
 
 #: src/muuli_wdr.cpp
-msgid "Codec :"
-msgstr "Кодек:"
+msgid "Album"
+msgstr "Альбом"
 
 #: src/muuli_wdr.cpp
-msgid "Artist :"
-msgstr "Исполнитель:"
-
-#: src/muuli_wdr.cpp
-msgid "Album :"
-msgstr "Альбом:"
-
-#: src/muuli_wdr.cpp
-msgid "Title :"
-msgstr "Заголовок:"
+msgid "Title"
+msgstr "Заголовок"
 
 #: src/muuli_wdr.cpp
 msgid "File Names"
@@ -4085,25 +4039,17 @@ msgstr "Неизвестный размер"
 msgid "Required Information"
 msgstr "Обязательная информация"
 
-#: src/muuli_wdr.cpp
-msgid "IP Address :"
-msgstr "Адрес IP:"
-
-#: src/muuli_wdr.cpp
-msgid "Port :"
-msgstr "Порт:"
+#: src/muuli_wdr.cpp src/ServerListCtrl.cpp
+msgid "Port"
+msgstr "Порт"
 
 #: src/muuli_wdr.cpp
 msgid "Additional Information"
 msgstr "Дополнительная информация"
 
 #: src/muuli_wdr.cpp
-msgid "Username :"
-msgstr "Имя пользователя:"
-
-#: src/muuli_wdr.cpp
-msgid "Userhash :"
-msgstr "Хеш пользователя:"
+msgid "Userhash"
+msgstr "Хеш пользователя"
 
 #: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Add"
@@ -4138,96 +4084,80 @@ msgid "Statistics Tree"
 msgstr "Дерево статистики"
 
 #: src/muuli_wdr.cpp
-msgid "Username:"
-msgstr "Имя пользователя:"
+msgid "Client software"
+msgstr "ПО клиента"
 
 #: src/muuli_wdr.cpp
-msgid "Userhash:"
-msgstr "Хеш пользователя:"
+msgid "Client version"
+msgstr "Версия клиента"
 
 #: src/muuli_wdr.cpp
-msgid "Client software:"
-msgstr "ПО клиента:"
+msgid "User ID"
+msgstr "ИД пользователя"
 
 #: src/muuli_wdr.cpp
-msgid "Client version:"
-msgstr "Версия клиента:"
-
-#: src/muuli_wdr.cpp src/ServerWnd.cpp
-msgid "IP address:"
-msgstr "Адрес IP:"
+msgid "Server IP"
+msgstr "IP сервера"
 
 #: src/muuli_wdr.cpp
-msgid "User ID:"
-msgstr "ИД пользователя:"
+msgid "Server name"
+msgstr "Имя сервера"
 
 #: src/muuli_wdr.cpp
-msgid "Server IP:"
-msgstr "IP сервера:"
-
-#: src/muuli_wdr.cpp
-msgid "Server name:"
-msgstr "Имя сервера:"
-
-#: src/muuli_wdr.cpp
-msgid "Obfuscation:"
-msgstr "Маскировка:"
-
-#: src/muuli_wdr.cpp
-msgid "Kad:"
-msgstr "Kad:"
+msgid "Obfuscation"
+msgstr "Маскировка"
 
 #: src/muuli_wdr.cpp
 msgid "Transfers to client"
 msgstr "Передачи клиенту"
 
 #: src/muuli_wdr.cpp
-msgid "Current request:"
-msgstr "Текущий запрос:"
+msgid "Current request"
+msgstr "Текущий запрос"
 
 #: src/muuli_wdr.cpp
-msgid "Average upload rate:"
-msgstr "Средняя скорость отдачи:"
+msgid "Average upload rate"
+msgstr "Средняя скорость отдачи"
 
 #: src/muuli_wdr.cpp
-msgid "Average download rate:"
-msgstr "Средняя скорость загрузки:"
+msgid "Average download rate"
+msgstr "Средняя скорость загрузки"
 
 #: src/muuli_wdr.cpp
-msgid "Uploaded (session):"
-msgstr "Отдано (за сеанс):"
+msgid "Uploaded (session)"
+msgstr "Отдано (за сеанс)"
 
 #: src/muuli_wdr.cpp
-msgid "Downloaded (session):"
-msgstr "Загружено (за сеанс):"
+msgid "Downloaded (session)"
+msgstr "Загружено (за сеанс)"
 
 #: src/muuli_wdr.cpp
-msgid "Uploaded (total):"
-msgstr "Отдано (всего):"
+msgid "Uploaded (total)"
+msgstr "Отдано (всего)"
 
 #: src/muuli_wdr.cpp
-msgid "Downloaded (total):"
-msgstr "Загружено (всего):"
+msgid "Downloaded (total)"
+msgstr "Загружено (всего)"
 
 #: src/muuli_wdr.cpp
 msgid "Scores"
 msgstr "Счёт"
 
 #: src/muuli_wdr.cpp
-msgid "DL/UP modifier:"
-msgstr "Баланс приёма/отдачи:"
+msgid "DL/UP modifier"
+msgstr "Баланс приёма/отдачи"
 
 #: src/muuli_wdr.cpp
-msgid "Secure ident:"
-msgstr "Безопасная идентификация:"
+msgid "Secure ident"
+msgstr "Безопасная идентификация"
 
 #: src/muuli_wdr.cpp
-msgid "Queue rank:"
-msgstr "Позиция в очереди:"
+msgid "Queue rank"
+msgstr "Позиция в очереди"
 
 #: src/muuli_wdr.cpp
-msgid "Queue score:"
-msgstr "Счёт очереди:"
+msgid "Queue score"
+msgstr "Счёт очереди"
 
 #: src/muuli_wdr.cpp
 msgid "Nick"
@@ -5010,24 +4940,20 @@ msgid "Reset any changes made to the preferences."
 msgstr "Сбросить все изменения, внесенные вами."
 
 #: src/muuli_wdr.cpp
-msgid "Comment :"
-msgstr "Комментарий :"
+msgid "Incoming Dir"
+msgstr "Каталог загрузок"
 
 #: src/muuli_wdr.cpp
-msgid "Incoming Dir :"
-msgstr "Каталог загрузок:"
-
-#: src/muuli_wdr.cpp
-msgid "Change priority for new assigned files :"
-msgstr "Установить приоритет для новых файлов:"
+msgid "Change priority for new assigned files"
+msgstr "Установить приоритет для новых файлов"
 
 #: src/muuli_wdr.cpp
 msgid "Don't change"
 msgstr "Не изменять"
 
 #: src/muuli_wdr.cpp
-msgid "Select color for this Category (currently selected) :"
-msgstr "Выбрать цвет для этой категории:"
+msgid "Select color for this Category (currently selected)"
+msgstr "Выбрать цвет для этой категории"
 
 #: src/muuli_wdr.cpp
 msgid "Click this button to reset the log."
@@ -5109,10 +5035,6 @@ msgstr "Начальная загрузка от узла: IP"
 #: src/muuli_wdr.cpp
 msgid "Enter the IP of the node here, using the x.x.x.x format."
 msgstr "Введите здесь IP-адрес узла в формате x.x.x.x."
-
-#: src/muuli_wdr.cpp
-msgid "Port:"
-msgstr "Порт:"
 
 #: src/muuli_wdr.cpp
 msgid "Use Secure User Identification"
@@ -5390,20 +5312,20 @@ msgid "Enable/disable proxy support"
 msgstr "Включить/выключить поддержку прокси-сервера"
 
 #: src/muuli_wdr.cpp
-msgid "Proxy type:"
-msgstr "Тип прокси-сервера:"
+msgid "Proxy type"
+msgstr "Тип прокси-сервера"
 
 #: src/muuli_wdr.cpp
-msgid "Proxy host:"
-msgstr "Прокси-сервер:"
+msgid "Proxy host"
+msgstr "Прокси-сервер"
 
 #: src/muuli_wdr.cpp
 msgid "The proxy host name"
 msgstr "Имя прокси-сервера"
 
 #: src/muuli_wdr.cpp
-msgid "Proxy port:"
-msgstr "Порт прокси:"
+msgid "Proxy port"
+msgstr "Порт прокси"
 
 #: src/muuli_wdr.cpp
 msgid "The proxy port"
@@ -5418,16 +5340,8 @@ msgid "Enable/disable username/password authentication"
 msgstr "Включить/выключить использование пароля и логина"
 
 #: src/muuli_wdr.cpp
-msgid "Username: "
-msgstr "Имя пользователя: "
-
-#: src/muuli_wdr.cpp
 msgid "The username to use to connect to the proxy"
 msgstr "Имя пользователя для подключения к прокси-серверу"
-
-#: src/muuli_wdr.cpp
-msgid "Password:"
-msgstr "Пароль:"
 
 #: src/muuli_wdr.cpp
 msgid "The password to use to connect to the proxy"
@@ -5602,6 +5516,15 @@ msgstr "ч"
 #: src/OtherFunctions.cpp
 msgid "days"
 msgstr "д"
+
+#. TRANSLATORS:
+#. Punctuation for a "label: value" pair. %s is the already-translated
+#. label. Place the colon as your language requires -- e.g. "%s :" with a
+#. space in French, "%s:" without one in Russian and English.
+#: src/OtherFunctions.cpp
+#, c-format
+msgid "%s:"
+msgstr ""
 
 #: src/OtherFunctions.cpp
 msgid "all"
@@ -6644,8 +6567,7 @@ msgstr "Рекурсивный общий доступ к ним опублик�
 msgid "Confirm shared folders"
 msgstr "Подтверждение общих папок"
 
-#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp
-#: src/SharedFilesReloadProgress.cpp
+#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp src/SharedFilesReloadProgress.cpp
 msgid "Reloading shared files..."
 msgstr "Переподгрузка общих файлов…"
 
@@ -6775,18 +6697,6 @@ msgstr "Ошибка %u: %s\n"
 #: src/SearchListCtrl.cpp
 msgid "FileID"
 msgstr "ИД файла"
-
-#: src/SearchListCtrl.cpp
-msgid "Length"
-msgstr "Длительность"
-
-#: src/SearchListCtrl.cpp
-msgid "Bitrate"
-msgstr "Битрейт"
-
-#: src/SearchListCtrl.cpp
-msgid "Codec"
-msgstr "Кодек"
 
 #: src/SearchListCtrl.cpp
 msgid "Expand all"
@@ -7067,10 +6977,6 @@ msgstr "Локальный сервер отфильтрован IP-фильтр
 #: src/ServerListCtrl.cpp
 msgid "Server Name"
 msgstr "Имя сервера"
-
-#: src/ServerListCtrl.cpp
-msgid "Port"
-msgstr "Порт"
 
 #: src/ServerListCtrl.cpp
 msgid "Description"
@@ -7359,6 +7265,10 @@ msgstr "Соединяем с другом"
 #, c-format
 msgid "Connected to buddy at %s"
 msgstr "Соединяем с другом на %s"
+
+#: src/ServerWnd.cpp
+msgid "IP address:"
+msgstr "Адрес IP:"
 
 #: src/ServerWnd.cpp
 msgid "Indexed sources:"

--- a/po/sl.po
+++ b/po/sl.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-04 12:13+0200\n"
+"POT-Creation-Date: 2026-09-05 12:01+0200\n"
 "PO-Revision-Date: 2026-09-03 11:10+0000\n"
 "Last-Translator: Jure Repinc <jlp@holodeck1.com>\n"
 "Language-Team: Slovenian\n"
@@ -390,8 +390,7 @@ msgstr "spletni strežnik teče s PID %d"
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Zahtevali ste zagon spletnega strežnika ob zagonu programa, a programa amuleweb ni moč zagnati. Namestite paket, ki vsebuje spletni strežnik aMule, ali pa prevedite aMule z možnostjo »--enable-webserver« in ga znova namestite z »make install«."
 
-#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
-#: src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
+#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
 msgid "ERROR"
 msgstr "NAPAKA"
 
@@ -682,8 +681,7 @@ msgstr "Omrežja"
 msgid "Searches"
 msgstr "Iskanja"
 
-#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/Statistics.cpp
+#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/Statistics.cpp
 msgid "Downloads"
 msgstr "Prejemanja"
 
@@ -767,9 +765,7 @@ msgstr "Kad: izklopljen"
 msgid "Core"
 msgstr ""
 
-#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#: src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp
-#: src/SourceListCtrl.cpp src/Statistics.cpp
+#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp src/Statistics.cpp
 msgid "Version"
 msgstr "Različica"
 
@@ -1068,11 +1064,7 @@ msgstr "Ni moč ustvariti mape »%s« za kategorijo »%s«, obdržana bo mapa »
 msgid "The remote core sent inconsistent data for \"%s\" (part status %d, expected %d). The file list may be showing the wrong information; reconnect to clear it."
 msgstr ""
 
-#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp
-#: src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp
-#: src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp
-#: src/Statistics.cpp
+#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp src/Statistics.cpp
 msgid "Unknown"
 msgstr "Neznano"
 
@@ -1173,8 +1165,7 @@ msgstr "Napaka med shranjevanjem datoteke %s: %s"
 msgid "Enter Captcha"
 msgstr "Vnesite besedilo s slike"
 
-#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp
-#: src/TransferWnd.cpp
+#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp src/TransferWnd.cpp
 msgid "Category"
 msgstr "Kategorija"
 
@@ -1350,13 +1341,11 @@ msgstr "Datoteka »cryptkey.dat« ne obstaja. Ustvarjanje."
 msgid "Client Details"
 msgstr "Podrobnosti o odjemalcu"
 
-#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
-#: src/utils/wxCas/src/onlinesig.cpp
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
 msgid "LowID"
 msgstr "Nizek ID"
 
-#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
-#: src/utils/wxCas/src/onlinesig.cpp
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
 msgid "HighID"
 msgstr "Visok ID"
 
@@ -1372,8 +1361,7 @@ msgstr "Podprto"
 msgid "Not supported"
 msgstr "Ni podprto"
 
-#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
-#: src/TextClient.cpp
+#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp src/TextClient.cpp
 msgid "Connected"
 msgstr "Povezano"
 
@@ -1381,28 +1369,24 @@ msgstr "Povezano"
 msgid "Disconnected"
 msgstr "Ni povezave"
 
-#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp
-#: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f KiB/s"
 msgstr ""
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#, fuzzy
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/muuli_wdr.cpp
 msgid "Name"
-msgstr "Ime:"
+msgstr "Ime"
 
 #: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
 msgid "Software"
 msgstr ""
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#, fuzzy
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/muuli_wdr.cpp
 msgid "IP Address"
-msgstr "Naslov IP:"
+msgstr "Naslov IP"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Origin"
 msgstr "Izvor"
 
@@ -1420,13 +1404,11 @@ msgstr "Zadnji sprejem"
 msgid "Sessions"
 msgstr "Različica"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp
 msgid "Upload Speed"
 msgstr "Hitrost pošiljanja"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp
 msgid "Download Speed"
 msgstr "Hitrost prejemanja"
 
@@ -1483,13 +1465,11 @@ msgstr[3] ""
 msgid "Files"
 msgstr "Datoteke"
 
-#: src/ClientsListCtrl.cpp src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp
-#: src/SourceListCtrl.cpp
+#: src/ClientsListCtrl.cpp src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Uploaded"
 msgstr "Poslano"
 
-#: src/ClientsListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientsListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Downloaded"
 msgstr "Prejeto"
 
@@ -1576,12 +1556,11 @@ msgstr "Uporabnik %s (%u) je zavrnil dostop do seznama deljenih datotek/map"
 msgid "File Comments"
 msgstr "Komentarji o datoteki"
 
-#: src/CommentDialogLst.cpp src/FriendListCtrl.cpp
+#: src/CommentDialogLst.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
 msgid "Username"
 msgstr "Uporabniško ime"
 
-#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp
-#: src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "File Name"
 msgstr "Ime datoteke"
 
@@ -1589,7 +1568,7 @@ msgstr "Ime datoteke"
 msgid "Rating"
 msgstr "Ocena"
 
-#: src/CommentDialogLst.cpp
+#: src/CommentDialogLst.cpp src/muuli_wdr.cpp
 msgid "Comment"
 msgstr "Komentar"
 
@@ -1645,18 +1624,15 @@ msgstr "Samod. [Vi]"
 msgid "Very low"
 msgstr "Zelo nizka"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Low"
 msgstr "Nizka"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Normal"
 msgstr "Običajna"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "High"
 msgstr "Visoka"
 
@@ -1680,13 +1656,11 @@ msgstr "Povezovanje preko strežnika"
 msgid "Queue Full"
 msgstr "Vrsta polna"
 
-#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp
-#: src/muuli_wdr.cpp
+#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp src/muuli_wdr.cpp
 msgid "On Queue"
 msgstr "V vrsti"
 
-#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp
-#: src/PartFile.cpp src/TransferWnd.cpp
+#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Downloading"
 msgstr "Prejemanje"
 
@@ -1746,8 +1720,7 @@ msgstr "Krajevni strežnik"
 msgid "Remote Server"
 msgstr "Oddaljni strežnik"
 
-#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp
-#: src/TextClient.cpp
+#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp src/TextClient.cpp
 msgid "Kad"
 msgstr "Kad"
 
@@ -1771,8 +1744,7 @@ msgstr "Izvorna semena"
 msgid "Search Result"
 msgstr "Rezultat iskanja"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp
-#: src/TransferWnd.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Completed"
 msgstr "Zaključeno"
 
@@ -1825,8 +1797,7 @@ msgstr ""
 msgid "Part"
 msgstr "Del"
 
-#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp
-#: src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Size"
 msgstr "Velikost"
 
@@ -1834,8 +1805,7 @@ msgstr "Velikost"
 msgid "Transferred"
 msgstr "Preneseno"
 
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
-#: src/SourceListCtrl.cpp
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp src/SourceListCtrl.cpp
 msgid "Speed"
 msgstr "Hitrost"
 
@@ -1843,13 +1813,11 @@ msgstr "Hitrost"
 msgid "Progress"
 msgstr "Napredek"
 
-#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp
-#: src/SearchListCtrl.cpp
+#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
 msgid "Sources"
 msgstr "Viri"
 
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp
-#: src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Priority"
 msgstr "Prednost"
 
@@ -1873,9 +1841,7 @@ msgstr "Zadnji sprejem"
 msgid "Auto"
 msgstr "Samod."
 
-#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/TransferWnd.cpp
-#: src/utils/wxCas/src/wxcasprefs.cpp
+#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/TransferWnd.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Cancel"
 msgstr "Prekliči"
 
@@ -1976,8 +1942,7 @@ msgstr "Vnesite novo ime za to datoteko:"
 msgid "File rename"
 msgstr "Preimenuj datoteko"
 
-#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp
-#: src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f MiB/s"
 msgstr ""
@@ -2787,13 +2752,11 @@ msgstr ""
 msgid "Start aMule automatically when I log in"
 msgstr ""
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
-#: packaging/windows/installer_strings.c
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp packaging/windows/installer_strings.c
 msgid "Register aMule for ed2k:// links"
 msgstr ""
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
-#: packaging/windows/installer_strings.c
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp packaging/windows/installer_strings.c
 msgid "Register aMule for magnet: links"
 msgstr ""
 
@@ -2819,8 +2782,7 @@ msgstr ""
 msgid "Destination folder for downloads"
 msgstr "Ciljna mapa za prejeto"
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
-#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Browse"
 msgstr "Brskanje"
 
@@ -3273,18 +3235,15 @@ msgstr "Zaključevanje"
 msgid "Complete"
 msgstr "Zaključeno"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
-#: src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Paused"
 msgstr "Prekinjeno"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
-#: src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Erroneous"
 msgstr "Vsebuje napake"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
-#: src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Waiting"
 msgstr "Na čakanju"
 
@@ -3456,8 +3415,7 @@ msgstr "Zapri"
 msgid "Cut"
 msgstr "Izreži"
 
-#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp
-#: src/utils/aLinkCreator/src/alcframe.cpp
+#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy"
 msgstr "Skopiraj"
 
@@ -3465,8 +3423,7 @@ msgstr "Skopiraj"
 msgid "Paste"
 msgstr "Prilepi"
 
-#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp
-#: src/utils/aLinkCreator/src/alcframe.cpp
+#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Clear"
 msgstr "Počisti"
 
@@ -3474,8 +3431,7 @@ msgstr "Počisti"
 msgid "Select All"
 msgstr "Izberi vse"
 
-#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
-#: src/StatisticsDlg.cpp
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp src/StatisticsDlg.cpp
 msgid "KiB/s"
 msgstr ""
 
@@ -3739,10 +3695,6 @@ msgstr "Trenutno povezan strežnik."
 msgid "Search"
 msgstr "Iskanje"
 
-#: src/muuli_wdr.cpp
-msgid "Name:"
-msgstr "Ime:"
-
 #: src/muuli_wdr.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Type"
 msgstr "Vrsta"
@@ -3832,8 +3784,8 @@ msgid "Availability"
 msgstr "Razpoložljivost"
 
 #: src/muuli_wdr.cpp
-msgid "Filter:"
-msgstr "Filter:"
+msgid "Filter"
+msgstr "Filter"
 
 #: src/muuli_wdr.cpp
 msgid "Invert Result"
@@ -3891,6 +3843,10 @@ msgid "Clears completed downloads"
 msgstr "Počisti zaključena prejemanja"
 
 #: src/muuli_wdr.cpp
+msgid "Filter:"
+msgstr "Filter:"
+
+#: src/muuli_wdr.cpp
 msgid "File sources:"
 msgstr "Viri datoteke:"
 
@@ -3899,80 +3855,76 @@ msgid "General"
 msgstr "Splošno"
 
 #: src/muuli_wdr.cpp
-msgid "Full Name :"
-msgstr "Polno Ime:"
+msgid "Full Name"
+msgstr "Polno Ime"
 
 #: src/muuli_wdr.cpp
-msgid "met-File :"
-msgstr "Datoteka met:"
+msgid "met-File"
+msgstr "Datoteka met"
 
 #: src/muuli_wdr.cpp
-msgid "Hash :"
-msgstr "Koda:"
+msgid "Hash"
+msgstr "Koda"
 
 #: src/muuli_wdr.cpp
-msgid "Filesize :"
-msgstr "Velikost datoteke:"
+msgid "Filesize"
+msgstr "Velikost datoteke"
 
 #: src/muuli_wdr.cpp src/Statistics.cpp
 msgid "Transfer"
 msgstr "Prenos"
 
 #: src/muuli_wdr.cpp
-msgid "Partfilestatus :"
-msgstr "Stanje delne datoteke:"
+msgid "Partfilestatus"
+msgstr "Stanje delne datoteke"
 
 #: src/muuli_wdr.cpp
-msgid "Last seen complete :"
-msgstr "Nazadnje videno celotno:"
+msgid "Last seen complete"
+msgstr "Nazadnje videno celotno"
 
 #: src/muuli_wdr.cpp
-msgid "Found Sources :"
-msgstr "Najdenih virov:"
+msgid "Found Sources"
+msgstr "Najdenih virov"
 
 #: src/muuli_wdr.cpp
-msgid "Transferring Sources :"
-msgstr "Prenašajoči viri:"
+msgid "Transferring Sources"
+msgstr "Prenašajoči viri"
 
 #: src/muuli_wdr.cpp
-msgid "Filepart-Count :"
-msgstr "Število delov:"
+msgid "Filepart-Count"
+msgstr "Število delov"
 
 #: src/muuli_wdr.cpp
-msgid "Available :"
-msgstr "Razpoložljivih:"
+msgid "Available"
+msgstr "Razpoložljivih"
 
 #: src/muuli_wdr.cpp
-msgid "Datarate :"
-msgstr "Podatkovna hitrost:"
+msgid "Datarate"
+msgstr "Podatkovna hitrost"
 
 #: src/muuli_wdr.cpp
-msgid "Download Active Time: "
-msgstr "Čas dejavnega prejemanja: "
+msgid "Download Active Time"
+msgstr "Čas dejavnega prejemanja"
 
 #: src/muuli_wdr.cpp
-msgid "Transferred :"
-msgstr "Preneseno:"
-
-#: src/muuli_wdr.cpp
-msgid "Completed Size :"
-msgstr "Zaključeno:"
+msgid "Completed Size"
+msgstr "Zaključeno"
 
 #: src/muuli_wdr.cpp
 msgid "Intelligent Corruption Handling"
 msgstr "Inteligentno rokovanje s poškodbami"
 
 #: src/muuli_wdr.cpp
-msgid "Lost to corruption :"
-msgstr "Izguba zaradi poškodb:"
+msgid "Lost to corruption"
+msgstr "Izguba zaradi poškodb"
 
 #: src/muuli_wdr.cpp
-msgid "Gained by compression :"
-msgstr "Pridobitev zaradi stiskanja:"
+msgid "Gained by compression"
+msgstr "Pridobitev zaradi stiskanja"
 
 #: src/muuli_wdr.cpp
-msgid "Packages saved by I.C.H. :"
-msgstr "Paketi rešeni z I.R.P.:"
+msgid "Packages saved by I.C.H."
+msgstr "Paketi rešeni z I.R.P."
 
 #: src/muuli_wdr.cpp
 #, fuzzy
@@ -4014,30 +3966,30 @@ msgstr ", poslanega: "
 msgid "Media Info"
 msgstr "Podatki o Kad"
 
-#: src/muuli_wdr.cpp
-msgid "Length :"
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
+msgid "Length"
 msgstr ""
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
 #, fuzzy
-msgid "Bitrate :"
+msgid "Bitrate"
 msgstr "Ni ocenjena"
 
-#: src/muuli_wdr.cpp
-msgid "Codec :"
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
+msgid "Codec"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Artist :"
+msgid "Artist"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Album :"
+msgid "Album"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Title :"
-msgstr "Naslov:"
+msgid "Title"
+msgstr "Naslov"
 
 #: src/muuli_wdr.cpp
 msgid "File Names"
@@ -4124,25 +4076,17 @@ msgstr "Neznana velikost"
 msgid "Required Information"
 msgstr "Zahtevani podatki"
 
-#: src/muuli_wdr.cpp
-msgid "IP Address :"
-msgstr "Naslov IP:"
-
-#: src/muuli_wdr.cpp
-msgid "Port :"
-msgstr "Vrata:"
+#: src/muuli_wdr.cpp src/ServerListCtrl.cpp
+msgid "Port"
+msgstr "Vrata"
 
 #: src/muuli_wdr.cpp
 msgid "Additional Information"
 msgstr "Dodatni podatki"
 
 #: src/muuli_wdr.cpp
-msgid "Username :"
-msgstr "Uporabniško ime:"
-
-#: src/muuli_wdr.cpp
-msgid "Userhash :"
-msgstr "Koda uporabnika:"
+msgid "Userhash"
+msgstr "Koda uporabnika"
 
 #: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Add"
@@ -4177,96 +4121,80 @@ msgid "Statistics Tree"
 msgstr "Statistično drevo"
 
 #: src/muuli_wdr.cpp
-msgid "Username:"
-msgstr "Uporabniško ime:"
+msgid "Client software"
+msgstr "Program odjemalca"
 
 #: src/muuli_wdr.cpp
-msgid "Userhash:"
-msgstr "Koda uporabnika:"
+msgid "Client version"
+msgstr "Različica odjemalca"
 
 #: src/muuli_wdr.cpp
-msgid "Client software:"
-msgstr "Program odjemalca:"
+msgid "User ID"
+msgstr "ID uporabnika"
 
 #: src/muuli_wdr.cpp
-msgid "Client version:"
-msgstr "Različica odjemalca:"
-
-#: src/muuli_wdr.cpp src/ServerWnd.cpp
-msgid "IP address:"
-msgstr "Naslov IP:"
+msgid "Server IP"
+msgstr "IP strežnika"
 
 #: src/muuli_wdr.cpp
-msgid "User ID:"
-msgstr "ID uporabnika:"
+msgid "Server name"
+msgstr "Ime strežnika"
 
 #: src/muuli_wdr.cpp
-msgid "Server IP:"
-msgstr "IP strežnika:"
-
-#: src/muuli_wdr.cpp
-msgid "Server name:"
-msgstr "Ime strežnika:"
-
-#: src/muuli_wdr.cpp
-msgid "Obfuscation:"
-msgstr "Maskiranje:"
-
-#: src/muuli_wdr.cpp
-msgid "Kad:"
-msgstr "Kad:"
+msgid "Obfuscation"
+msgstr "Maskiranje"
 
 #: src/muuli_wdr.cpp
 msgid "Transfers to client"
 msgstr "Prenosi do uporabnika"
 
 #: src/muuli_wdr.cpp
-msgid "Current request:"
-msgstr "Trenutna zahteva:"
+msgid "Current request"
+msgstr "Trenutna zahteva"
 
 #: src/muuli_wdr.cpp
-msgid "Average upload rate:"
-msgstr "Povprečna hitrost pošiljanja:"
+msgid "Average upload rate"
+msgstr "Povprečna hitrost pošiljanja"
 
 #: src/muuli_wdr.cpp
-msgid "Average download rate:"
-msgstr "Povprečna hitrost prejemanja:"
+msgid "Average download rate"
+msgstr "Povprečna hitrost prejemanja"
 
 #: src/muuli_wdr.cpp
-msgid "Uploaded (session):"
-msgstr "Poslano (seja):"
+msgid "Uploaded (session)"
+msgstr "Poslano (seja)"
 
 #: src/muuli_wdr.cpp
-msgid "Downloaded (session):"
-msgstr "Prejeto (seja):"
+msgid "Downloaded (session)"
+msgstr "Prejeto (seja)"
 
 #: src/muuli_wdr.cpp
-msgid "Uploaded (total):"
-msgstr "Poslano (skupno):"
+msgid "Uploaded (total)"
+msgstr "Poslano (skupno)"
 
 #: src/muuli_wdr.cpp
-msgid "Downloaded (total):"
-msgstr "Prejeto (skupno):"
+msgid "Downloaded (total)"
+msgstr "Prejeto (skupno)"
 
 #: src/muuli_wdr.cpp
 msgid "Scores"
 msgstr "Točke"
 
 #: src/muuli_wdr.cpp
-msgid "DL/UP modifier:"
-msgstr "Količnik dol/gor:"
+msgid "DL/UP modifier"
+msgstr "Količnik dol/gor"
 
 #: src/muuli_wdr.cpp
-msgid "Secure ident:"
-msgstr "Varna identifikacija:"
+msgid "Secure ident"
+msgstr "Varna identifikacija"
 
 #: src/muuli_wdr.cpp
-msgid "Queue rank:"
-msgstr "Položaj v vrsti:"
+msgid "Queue rank"
+msgstr "Položaj v vrsti"
 
 #: src/muuli_wdr.cpp
-msgid "Queue score:"
-msgstr "Točke v vrsti:"
+msgid "Queue score"
+msgstr "Točke v vrsti"
 
 #: src/muuli_wdr.cpp
 msgid "Nick"
@@ -5062,24 +4990,20 @@ msgid "Reset any changes made to the preferences."
 msgstr "Razveljavi vse spremembe v nastavitvah."
 
 #: src/muuli_wdr.cpp
-msgid "Comment :"
-msgstr "Komentar:"
+msgid "Incoming Dir"
+msgstr "Mapa za prejeto"
 
 #: src/muuli_wdr.cpp
-msgid "Incoming Dir :"
-msgstr "Mapa za prejeto:"
-
-#: src/muuli_wdr.cpp
-msgid "Change priority for new assigned files :"
-msgstr "Spremeni prednost novo dodeljenim datotekam:"
+msgid "Change priority for new assigned files"
+msgstr "Spremeni prednost novo dodeljenim datotekam"
 
 #: src/muuli_wdr.cpp
 msgid "Don't change"
 msgstr "Ne spremeni"
 
 #: src/muuli_wdr.cpp
-msgid "Select color for this Category (currently selected) :"
-msgstr "Izberite barvo za to kategorijo (trenutno izbrano):"
+msgid "Select color for this Category (currently selected)"
+msgstr "Izberite barvo za to kategorijo (trenutno izbrano)"
 
 #: src/muuli_wdr.cpp
 msgid "Click this button to reset the log."
@@ -5164,10 +5088,6 @@ msgstr ""
 #, fuzzy
 msgid "Enter the IP of the node here, using the x.x.x.x format."
 msgstr "Sem vnesite IP strežnika v formatu x.x.x.x."
-
-#: src/muuli_wdr.cpp
-msgid "Port:"
-msgstr "Vrata:"
 
 #: src/muuli_wdr.cpp
 msgid "Use Secure User Identification"
@@ -5436,20 +5356,20 @@ msgid "Enable/disable proxy support"
 msgstr "Omogoči/onemogoči podporo za posrednika"
 
 #: src/muuli_wdr.cpp
-msgid "Proxy type:"
-msgstr "Vrsta posrednika:"
+msgid "Proxy type"
+msgstr "Vrsta posrednika"
 
 #: src/muuli_wdr.cpp
-msgid "Proxy host:"
-msgstr "Gostitelj posrednika:"
+msgid "Proxy host"
+msgstr "Gostitelj posrednika"
 
 #: src/muuli_wdr.cpp
 msgid "The proxy host name"
 msgstr "Ime gostitelja posredniškega strežnika"
 
 #: src/muuli_wdr.cpp
-msgid "Proxy port:"
-msgstr "Vrata posrednika:"
+msgid "Proxy port"
+msgstr "Vrata posrednika"
 
 #: src/muuli_wdr.cpp
 msgid "The proxy port"
@@ -5464,16 +5384,8 @@ msgid "Enable/disable username/password authentication"
 msgstr "Omogoči/onemogoči overjanje z uporabniškim imenom/geslom"
 
 #: src/muuli_wdr.cpp
-msgid "Username: "
-msgstr "Uporabniško ime: "
-
-#: src/muuli_wdr.cpp
 msgid "The username to use to connect to the proxy"
 msgstr "Uporabniško ime za povezavo s posrednikom"
-
-#: src/muuli_wdr.cpp
-msgid "Password:"
-msgstr "Geslo:"
 
 #: src/muuli_wdr.cpp
 msgid "The password to use to connect to the proxy"
@@ -5652,6 +5564,15 @@ msgstr "ur"
 #: src/OtherFunctions.cpp
 msgid "days"
 msgstr "dni"
+
+#. TRANSLATORS:
+#. Punctuation for a "label: value" pair. %s is the already-translated
+#. label. Place the colon as your language requires -- e.g. "%s :" with a
+#. space in French, "%s:" without one in Russian and English.
+#: src/OtherFunctions.cpp
+#, c-format
+msgid "%s:"
+msgstr ""
 
 #: src/OtherFunctions.cpp
 msgid "all"
@@ -6712,8 +6633,7 @@ msgstr ""
 msgid "Confirm shared folders"
 msgstr "Deljene mape"
 
-#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp
-#: src/SharedFilesReloadProgress.cpp
+#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp src/SharedFilesReloadProgress.cpp
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "Ponovno naloži deljene datoteke"
@@ -6845,19 +6765,6 @@ msgstr "Napaka pri posodabljanju GeoIP.dat"
 #: src/SearchListCtrl.cpp
 msgid "FileID"
 msgstr "ID datoteke"
-
-#: src/SearchListCtrl.cpp
-msgid "Length"
-msgstr ""
-
-#: src/SearchListCtrl.cpp
-#, fuzzy
-msgid "Bitrate"
-msgstr "Ni ocenjena"
-
-#: src/SearchListCtrl.cpp
-msgid "Codec"
-msgstr ""
 
 #: src/SearchListCtrl.cpp
 msgid "Expand all"
@@ -7148,10 +7055,6 @@ msgstr "IP Filter je filtriral krajevni strežnik. Povezovanje z drugim strežni
 #: src/ServerListCtrl.cpp
 msgid "Server Name"
 msgstr "Ime strežnika"
-
-#: src/ServerListCtrl.cpp
-msgid "Port"
-msgstr "Vrata"
 
 #: src/ServerListCtrl.cpp
 msgid "Description"
@@ -7448,6 +7351,10 @@ msgstr "Povezovanje s kolegom"
 #, c-format
 msgid "Connected to buddy at %s"
 msgstr "Povezano s kolegom na %s"
+
+#: src/ServerWnd.cpp
+msgid "IP address:"
+msgstr "Naslov IP:"
 
 #: src/ServerWnd.cpp
 msgid "Indexed sources:"

--- a/po/sq.po
+++ b/po/sq.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-04 12:13+0200\n"
+"POT-Creation-Date: 2026-09-05 12:01+0200\n"
 "PO-Revision-Date: 2026-09-03 11:10+0000\n"
 "Last-Translator: Fation <dj_barthezz@linuxmail.org lushnja_corps@hotmail.Language-Team:\n"
 "Language: sq\n"
@@ -387,8 +387,7 @@ msgstr ""
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr ""
 
-#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
-#: src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
+#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
 msgid "ERROR"
 msgstr ""
 
@@ -676,8 +675,7 @@ msgstr "Rrjetet"
 msgid "Searches"
 msgstr "Kerkimet"
 
-#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/Statistics.cpp
+#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/Statistics.cpp
 msgid "Downloads"
 msgstr "Shkarkime"
 
@@ -761,9 +759,7 @@ msgstr "Kad: Fikur"
 msgid "Core"
 msgstr ""
 
-#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#: src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp
-#: src/SourceListCtrl.cpp src/Statistics.cpp
+#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp src/Statistics.cpp
 msgid "Version"
 msgstr "Versioni"
 
@@ -1067,11 +1063,7 @@ msgstr ""
 msgid "The remote core sent inconsistent data for \"%s\" (part status %d, expected %d). The file list may be showing the wrong information; reconnect to clear it."
 msgstr ""
 
-#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp
-#: src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp
-#: src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp
-#: src/Statistics.cpp
+#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp src/Statistics.cpp
 msgid "Unknown"
 msgstr "E panjohur"
 
@@ -1169,8 +1161,7 @@ msgstr "Gabim duke shpetuar failin known.met: %s"
 msgid "Enter Captcha"
 msgstr ""
 
-#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp
-#: src/TransferWnd.cpp
+#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp src/TransferWnd.cpp
 msgid "Category"
 msgstr "Kategori"
 
@@ -1334,13 +1325,11 @@ msgstr "NUk u gjet faili cryptkey.dat,duke e krijuar."
 msgid "Client Details"
 msgstr "Detajet e klientit"
 
-#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
-#: src/utils/wxCas/src/onlinesig.cpp
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
 msgid "LowID"
 msgstr "ID i ulet"
 
-#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
-#: src/utils/wxCas/src/onlinesig.cpp
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
 msgid "HighID"
 msgstr "ID i larte"
 
@@ -1356,8 +1345,7 @@ msgstr ""
 msgid "Not supported"
 msgstr ""
 
-#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
-#: src/TextClient.cpp
+#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp src/TextClient.cpp
 msgid "Connected"
 msgstr "I lidhur"
 
@@ -1365,28 +1353,24 @@ msgstr "I lidhur"
 msgid "Disconnected"
 msgstr "I shkeputur"
 
-#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp
-#: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f KiB/s"
 msgstr ""
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#, fuzzy
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/muuli_wdr.cpp
 msgid "Name"
-msgstr "Emri:"
+msgstr "Emri"
 
 #: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
 msgid "Software"
 msgstr ""
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#, fuzzy
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/muuli_wdr.cpp
 msgid "IP Address"
-msgstr "Adresa IP :"
+msgstr "Adresa IP"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Origin"
 msgstr ""
 
@@ -1404,14 +1388,12 @@ msgstr "Marrja e fundit"
 msgid "Sessions"
 msgstr "Versioni"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp
 #, fuzzy
 msgid "Upload Speed"
 msgstr "Shpejtesia-Ngarkimit"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp
 #, fuzzy
 msgid "Download Speed"
 msgstr "Shpejtesia-Shkarkimit"
@@ -1467,13 +1449,11 @@ msgstr[1] ""
 msgid "Files"
 msgstr "Failet"
 
-#: src/ClientsListCtrl.cpp src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp
-#: src/SourceListCtrl.cpp
+#: src/ClientsListCtrl.cpp src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Uploaded"
 msgstr ""
 
-#: src/ClientsListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientsListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Downloaded"
 msgstr ""
 
@@ -1560,12 +1540,11 @@ msgstr "Perdoruesi %s (%u) nuk lejoi hyrjen ne listen e kartelave/faileve te nda
 msgid "File Comments"
 msgstr "Komentet e faileve"
 
-#: src/CommentDialogLst.cpp src/FriendListCtrl.cpp
+#: src/CommentDialogLst.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
 msgid "Username"
 msgstr "Emri i perdorimit"
 
-#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp
-#: src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "File Name"
 msgstr "Emri i failit"
 
@@ -1573,7 +1552,7 @@ msgstr "Emri i failit"
 msgid "Rating"
 msgstr "Vleresimi"
 
-#: src/CommentDialogLst.cpp
+#: src/CommentDialogLst.cpp src/muuli_wdr.cpp
 msgid "Comment"
 msgstr "Komenti"
 
@@ -1626,18 +1605,15 @@ msgstr "Automatike [Larte]"
 msgid "Very low"
 msgstr "Shume ngadale"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Low"
 msgstr "Ngadale"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Normal"
 msgstr "Normale"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "High"
 msgstr "E larte"
 
@@ -1661,13 +1637,11 @@ msgstr "Lidhje nepermjet serverit"
 msgid "Queue Full"
 msgstr "Radha ne pritje eshte plote"
 
-#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp
-#: src/muuli_wdr.cpp
+#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp src/muuli_wdr.cpp
 msgid "On Queue"
 msgstr "Ne radhe"
 
-#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp
-#: src/PartFile.cpp src/TransferWnd.cpp
+#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Downloading"
 msgstr "Duke shkarkuar"
 
@@ -1727,8 +1701,7 @@ msgstr "Server Lokal"
 msgid "Remote Server"
 msgstr "Server i larget"
 
-#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp
-#: src/TextClient.cpp
+#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp src/TextClient.cpp
 msgid "Kad"
 msgstr "Kad"
 
@@ -1752,8 +1725,7 @@ msgstr "Burime te shpetuara"
 msgid "Search Result"
 msgstr ""
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp
-#: src/TransferWnd.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Completed"
 msgstr "Te kompletuara"
 
@@ -1806,8 +1778,7 @@ msgstr ""
 msgid "Part"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp
-#: src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Size"
 msgstr "Madhesia"
 
@@ -1815,8 +1786,7 @@ msgstr "Madhesia"
 msgid "Transferred"
 msgstr "Te transferuara"
 
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
-#: src/SourceListCtrl.cpp
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp src/SourceListCtrl.cpp
 msgid "Speed"
 msgstr "Shpejtesia"
 
@@ -1824,13 +1794,11 @@ msgstr "Shpejtesia"
 msgid "Progress"
 msgstr "Avancimi"
 
-#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp
-#: src/SearchListCtrl.cpp
+#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
 msgid "Sources"
 msgstr "Burime"
 
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp
-#: src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Priority"
 msgstr "Perparesia"
 
@@ -1854,9 +1822,7 @@ msgstr "Marrja e fundit"
 msgid "Auto"
 msgstr "Automatike"
 
-#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/TransferWnd.cpp
-#: src/utils/wxCas/src/wxcasprefs.cpp
+#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/TransferWnd.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Cancel"
 msgstr "Fshij"
 
@@ -1955,8 +1921,7 @@ msgstr "Futni nje emer te ti per kete fail:"
 msgid "File rename"
 msgstr "Riemertim i failit"
 
-#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp
-#: src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f MiB/s"
 msgstr ""
@@ -2765,13 +2730,11 @@ msgstr ""
 msgid "Start aMule automatically when I log in"
 msgstr ""
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
-#: packaging/windows/installer_strings.c
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp packaging/windows/installer_strings.c
 msgid "Register aMule for ed2k:// links"
 msgstr ""
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
-#: packaging/windows/installer_strings.c
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp packaging/windows/installer_strings.c
 msgid "Register aMule for magnet: links"
 msgstr ""
 
@@ -2797,8 +2760,7 @@ msgstr ""
 msgid "Destination folder for downloads"
 msgstr ""
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
-#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Browse"
 msgstr "Shfleto"
 
@@ -3245,18 +3207,15 @@ msgstr "Duke perfunduar"
 msgid "Complete"
 msgstr "E kompletuar"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
-#: src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Paused"
 msgstr "Ne pritje"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
-#: src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Erroneous"
 msgstr "E gabuar"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
-#: src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Waiting"
 msgstr "Duke pritur"
 
@@ -3422,8 +3381,7 @@ msgstr "Mbylle"
 msgid "Cut"
 msgstr "Ndaj"
 
-#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp
-#: src/utils/aLinkCreator/src/alcframe.cpp
+#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy"
 msgstr "Kopjo"
 
@@ -3431,8 +3389,7 @@ msgstr "Kopjo"
 msgid "Paste"
 msgstr "Ngjit"
 
-#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp
-#: src/utils/aLinkCreator/src/alcframe.cpp
+#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Clear"
 msgstr "Pastro"
 
@@ -3440,8 +3397,7 @@ msgstr "Pastro"
 msgid "Select All"
 msgstr "Zgjidhi te gjitha"
 
-#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
-#: src/StatisticsDlg.cpp
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp src/StatisticsDlg.cpp
 msgid "KiB/s"
 msgstr ""
 
@@ -3704,10 +3660,6 @@ msgstr "Serveri aktualisht i lidhur."
 msgid "Search"
 msgstr "Kerko"
 
-#: src/muuli_wdr.cpp
-msgid "Name:"
-msgstr "Emri:"
-
 #: src/muuli_wdr.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Type"
 msgstr "Tipi"
@@ -3797,8 +3749,8 @@ msgid "Availability"
 msgstr "Te disponueshem"
 
 #: src/muuli_wdr.cpp
-msgid "Filter:"
-msgstr "Filteri:"
+msgid "Filter"
+msgstr "Filteri"
 
 #: src/muuli_wdr.cpp
 msgid "Invert Result"
@@ -3856,6 +3808,10 @@ msgid "Clears completed downloads"
 msgstr "Pastro shkarkimet e perfunduara"
 
 #: src/muuli_wdr.cpp
+msgid "Filter:"
+msgstr "Filteri:"
+
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "File sources:"
 msgstr "Burime te gjetura :"
@@ -3865,80 +3821,76 @@ msgid "General"
 msgstr "Te pergjithshme"
 
 #: src/muuli_wdr.cpp
-msgid "Full Name :"
-msgstr "Emri i plote :"
+msgid "Full Name"
+msgstr "Emri i plote"
 
 #: src/muuli_wdr.cpp
-msgid "met-File :"
-msgstr "Faili-met :"
+msgid "met-File"
+msgstr "Faili-met"
 
 #: src/muuli_wdr.cpp
-msgid "Hash :"
-msgstr "Hash :"
+msgid "Hash"
+msgstr "Hash"
 
 #: src/muuli_wdr.cpp
-msgid "Filesize :"
-msgstr "Madhesia e failit :"
+msgid "Filesize"
+msgstr "Madhesia e failit"
 
 #: src/muuli_wdr.cpp src/Statistics.cpp
 msgid "Transfer"
 msgstr "Transferimi"
 
 #: src/muuli_wdr.cpp
-msgid "Partfilestatus :"
-msgstr "Gjendja e pjeseve te failit :"
+msgid "Partfilestatus"
+msgstr "Gjendja e pjeseve te failit"
 
 #: src/muuli_wdr.cpp
-msgid "Last seen complete :"
-msgstr "Hera e fundit qe u pa i perfunduar :"
+msgid "Last seen complete"
+msgstr "Hera e fundit qe u pa i perfunduar"
 
 #: src/muuli_wdr.cpp
-msgid "Found Sources :"
-msgstr "Burime te gjetura :"
+msgid "Found Sources"
+msgstr "Burime te gjetura"
 
 #: src/muuli_wdr.cpp
-msgid "Transferring Sources :"
-msgstr "Burime ne transferim :"
+msgid "Transferring Sources"
+msgstr "Burime ne transferim"
 
 #: src/muuli_wdr.cpp
-msgid "Filepart-Count :"
-msgstr "Numerimi i pjeseve te failit :"
+msgid "Filepart-Count"
+msgstr "Numerimi i pjeseve te failit"
 
 #: src/muuli_wdr.cpp
-msgid "Available :"
-msgstr "Te disponueshem :"
+msgid "Available"
+msgstr "Te disponueshem"
 
 #: src/muuli_wdr.cpp
-msgid "Datarate :"
-msgstr "Shpejtesia :"
+msgid "Datarate"
+msgstr "Shpejtesia"
 
 #: src/muuli_wdr.cpp
-msgid "Download Active Time: "
-msgstr "Koha Aktive e Shkarkimit : "
+msgid "Download Active Time"
+msgstr "Koha Aktive e Shkarkimit"
 
 #: src/muuli_wdr.cpp
-msgid "Transferred :"
-msgstr "Te transferuara :"
-
-#: src/muuli_wdr.cpp
-msgid "Completed Size :"
-msgstr "Te kompletuara :"
+msgid "Completed Size"
+msgstr "Te kompletuara"
 
 #: src/muuli_wdr.cpp
 msgid "Intelligent Corruption Handling"
 msgstr "Intelligent Corruption Handling"
 
 #: src/muuli_wdr.cpp
-msgid "Lost to corruption :"
-msgstr "Humbje per pjese te prishura :"
+msgid "Lost to corruption"
+msgstr "Humbje per pjese te prishura"
 
 #: src/muuli_wdr.cpp
-msgid "Gained by compression :"
-msgstr "Fitimi nga kompresimi :"
+msgid "Gained by compression"
+msgstr "Fitimi nga kompresimi"
 
 #: src/muuli_wdr.cpp
-msgid "Packages saved by I.C.H. :"
-msgstr "Paketa te rekuperuara nga I.C.H. :"
+msgid "Packages saved by I.C.H."
+msgstr "Paketa te rekuperuara nga I.C.H."
 
 #: src/muuli_wdr.cpp
 #, fuzzy
@@ -3980,30 +3932,30 @@ msgstr ", Ngarkimi: "
 msgid "Media Info"
 msgstr "Informacioni i Kad"
 
-#: src/muuli_wdr.cpp
-msgid "Length :"
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
+msgid "Length"
 msgstr ""
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
 #, fuzzy
-msgid "Bitrate :"
+msgid "Bitrate"
 msgstr "E pavotuar"
 
-#: src/muuli_wdr.cpp
-msgid "Codec :"
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
+msgid "Codec"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Artist :"
+msgid "Artist"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Album :"
+msgid "Album"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Title :"
-msgstr "Titulli :"
+msgid "Title"
+msgstr "Titulli"
 
 #: src/muuli_wdr.cpp
 msgid "File Names"
@@ -4088,25 +4040,17 @@ msgstr "Madhesi e panjohur"
 msgid "Required Information"
 msgstr "Informacion i Kerkuar"
 
-#: src/muuli_wdr.cpp
-msgid "IP Address :"
-msgstr "Adresa IP :"
-
-#: src/muuli_wdr.cpp
-msgid "Port :"
-msgstr "Porta :"
+#: src/muuli_wdr.cpp src/ServerListCtrl.cpp
+msgid "Port"
+msgstr "Porta"
 
 #: src/muuli_wdr.cpp
 msgid "Additional Information"
 msgstr "Informacion i Shtuar"
 
 #: src/muuli_wdr.cpp
-msgid "Username :"
-msgstr "Emri i Perdoruesit :"
-
-#: src/muuli_wdr.cpp
-msgid "Userhash :"
-msgstr "Userhash :"
+msgid "Userhash"
+msgstr "Userhash"
 
 #: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Add"
@@ -4141,97 +4085,82 @@ msgid "Statistics Tree"
 msgstr "Pema e statistikave"
 
 #: src/muuli_wdr.cpp
-msgid "Username:"
-msgstr "Emri i perdoruesit:"
+msgid "Client software"
+msgstr "Software i klientit"
 
 #: src/muuli_wdr.cpp
-msgid "Userhash:"
-msgstr "Userhash:"
+msgid "Client version"
+msgstr "Versioni i klientit"
 
 #: src/muuli_wdr.cpp
-msgid "Client software:"
-msgstr "Software i klientit:"
+msgid "User ID"
+msgstr "ID-ja e Perdoruesit"
 
 #: src/muuli_wdr.cpp
-msgid "Client version:"
-msgstr "Versioni i klientit:"
-
-#: src/muuli_wdr.cpp src/ServerWnd.cpp
-msgid "IP address:"
-msgstr "Adresa IP:"
+msgid "Server IP"
+msgstr "IP-ja e Serverit"
 
 #: src/muuli_wdr.cpp
-msgid "User ID:"
-msgstr "ID-ja e Perdoruesit:"
+msgid "Server name"
+msgstr "Emri i Serverit"
 
 #: src/muuli_wdr.cpp
-msgid "Server IP:"
-msgstr "IP-ja e Serverit:"
-
-#: src/muuli_wdr.cpp
-msgid "Server name:"
-msgstr "Emri i Serverit:"
-
-#: src/muuli_wdr.cpp
-msgid "Obfuscation:"
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "Kad:"
-msgstr ""
+#, fuzzy
+msgid "Obfuscation"
+msgstr "Protokolli i Turbullimit"
 
 #: src/muuli_wdr.cpp
 msgid "Transfers to client"
 msgstr "Transferime tek klienti"
 
 #: src/muuli_wdr.cpp
-msgid "Current request:"
-msgstr "Kerkesa aktuale:"
+msgid "Current request"
+msgstr "Kerkesa aktuale"
 
 #: src/muuli_wdr.cpp
-msgid "Average upload rate:"
-msgstr "Shpejtesia mesatare e ngarkimeve:"
+msgid "Average upload rate"
+msgstr "Shpejtesia mesatare e ngarkimeve"
 
 #: src/muuli_wdr.cpp
-msgid "Average download rate:"
-msgstr "Shpejtesia mesatare e shkarkimeve:"
+msgid "Average download rate"
+msgstr "Shpejtesia mesatare e shkarkimeve"
 
 #: src/muuli_wdr.cpp
-msgid "Uploaded (session):"
-msgstr "Te ngarkuara (sesione):"
+msgid "Uploaded (session)"
+msgstr "Te ngarkuara (sesione)"
 
 #: src/muuli_wdr.cpp
-msgid "Downloaded (session):"
-msgstr "Te shkarkuara (sesione):"
+msgid "Downloaded (session)"
+msgstr "Te shkarkuara (sesione)"
 
 #: src/muuli_wdr.cpp
-msgid "Uploaded (total):"
-msgstr "Ngarkimet (total):"
+msgid "Uploaded (total)"
+msgstr "Ngarkimet (total)"
 
 #: src/muuli_wdr.cpp
-msgid "Downloaded (total):"
-msgstr "Shkarkimet (total):"
+msgid "Downloaded (total)"
+msgstr "Shkarkimet (total)"
 
 #: src/muuli_wdr.cpp
 msgid "Scores"
 msgstr "Piket"
 
 #: src/muuli_wdr.cpp
-msgid "DL/UP modifier:"
-msgstr "Modifikuesi DL/UP:"
+msgid "DL/UP modifier"
+msgstr "Modifikuesi DL/UP"
 
 #: src/muuli_wdr.cpp
-msgid "Secure ident:"
-msgstr "Identifikim i sigurte:"
+msgid "Secure ident"
+msgstr "Identifikim i sigurte"
 
 #: src/muuli_wdr.cpp
 #, fuzzy
-msgid "Queue rank:"
+msgid "Queue rank"
 msgstr "Ne radhe"
 
 #: src/muuli_wdr.cpp
-msgid "Queue score:"
-msgstr "Piket e pritjes:"
+msgid "Queue score"
+msgstr "Piket e pritjes"
 
 #: src/muuli_wdr.cpp
 msgid "Nick"
@@ -5023,16 +4952,12 @@ msgid "Reset any changes made to the preferences."
 msgstr "Rikthe ne gjendjen e meparshme ndryshimet te bera tek Preferencat."
 
 #: src/muuli_wdr.cpp
-msgid "Comment :"
-msgstr "Komente :"
+msgid "Incoming Dir"
+msgstr "Direktoria e Hyrjeve"
 
 #: src/muuli_wdr.cpp
-msgid "Incoming Dir :"
-msgstr "Direktoria e Hyrjeve :"
-
-#: src/muuli_wdr.cpp
-msgid "Change priority for new assigned files :"
-msgstr "Nderro perparesine per failet e reja te caktuara :"
+msgid "Change priority for new assigned files"
+msgstr "Nderro perparesine per failet e reja te caktuara"
 
 #: src/muuli_wdr.cpp
 #, fuzzy
@@ -5040,8 +4965,8 @@ msgid "Don't change"
 msgstr "Mos nderro"
 
 #: src/muuli_wdr.cpp
-msgid "Select color for this Category (currently selected) :"
-msgstr "Zgjidh ngjyren per kete kategori (e zgjedhur aktualisht) :"
+msgid "Select color for this Category (currently selected)"
+msgstr "Zgjidh ngjyren per kete kategori (e zgjedhur aktualisht)"
 
 #: src/muuli_wdr.cpp
 msgid "Click this button to reset the log."
@@ -5126,10 +5051,6 @@ msgstr ""
 #, fuzzy
 msgid "Enter the IP of the node here, using the x.x.x.x format."
 msgstr "Futni IP-ne e serverit ketu. duke perdorur formatin x.x.x.x."
-
-#: src/muuli_wdr.cpp
-msgid "Port:"
-msgstr "Porta:"
 
 #: src/muuli_wdr.cpp
 msgid "Use Secure User Identification"
@@ -5398,11 +5319,11 @@ msgid "Enable/disable proxy support"
 msgstr "Aktivizo/C'aktivizo mbeshtetjen e Proksit(Proxy)"
 
 #: src/muuli_wdr.cpp
-msgid "Proxy type:"
-msgstr "Lloji i Proksit(Proxy):"
+msgid "Proxy type"
+msgstr "Lloji i Proksit(Proxy)"
 
 #: src/muuli_wdr.cpp
-msgid "Proxy host:"
+msgid "Proxy host"
 msgstr "Hosti i Proksit(Proxy)"
 
 #: src/muuli_wdr.cpp
@@ -5410,8 +5331,8 @@ msgid "The proxy host name"
 msgstr "Host Name i Proksit(Proxy)"
 
 #: src/muuli_wdr.cpp
-msgid "Proxy port:"
-msgstr "Porta e Proksit:"
+msgid "Proxy port"
+msgstr "Porta e Proksit"
 
 #: src/muuli_wdr.cpp
 msgid "The proxy port"
@@ -5426,16 +5347,8 @@ msgid "Enable/disable username/password authentication"
 msgstr "Aktivizo/C'aktivizo emri i perdoruesit/njohja e fjalekalimit"
 
 #: src/muuli_wdr.cpp
-msgid "Username: "
-msgstr ""
-
-#: src/muuli_wdr.cpp
 msgid "The username to use to connect to the proxy"
 msgstr "Emri i perdorimit qe do perdoret per tu lidhur tek Proksi(Proxy)"
-
-#: src/muuli_wdr.cpp
-msgid "Password:"
-msgstr "Fjalekalimi:"
 
 #: src/muuli_wdr.cpp
 msgid "The password to use to connect to the proxy"
@@ -5617,6 +5530,15 @@ msgstr "ore"
 #: src/OtherFunctions.cpp
 msgid "days"
 msgstr "dite"
+
+#. TRANSLATORS:
+#. Punctuation for a "label: value" pair. %s is the already-translated
+#. label. Place the colon as your language requires -- e.g. "%s :" with a
+#. space in French, "%s:" without one in Russian and English.
+#: src/OtherFunctions.cpp
+#, c-format
+msgid "%s:"
+msgstr ""
 
 #: src/OtherFunctions.cpp
 msgid "all"
@@ -6663,8 +6585,7 @@ msgstr ""
 msgid "Confirm shared folders"
 msgstr "Ringarko failet e ndara"
 
-#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp
-#: src/SharedFilesReloadProgress.cpp
+#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp src/SharedFilesReloadProgress.cpp
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "Ringarko failet e ndara"
@@ -6796,19 +6717,6 @@ msgstr ""
 #: src/SearchListCtrl.cpp
 msgid "FileID"
 msgstr "FailiID"
-
-#: src/SearchListCtrl.cpp
-msgid "Length"
-msgstr ""
-
-#: src/SearchListCtrl.cpp
-#, fuzzy
-msgid "Bitrate"
-msgstr "E pavotuar"
-
-#: src/SearchListCtrl.cpp
-msgid "Codec"
-msgstr ""
 
 #: src/SearchListCtrl.cpp
 msgid "Expand all"
@@ -7095,10 +7003,6 @@ msgstr "Serverat lokale jane te filtruara nga IPFilters, duke u rilidhur ne nje 
 #: src/ServerListCtrl.cpp
 msgid "Server Name"
 msgstr "Emri i serverit"
-
-#: src/ServerListCtrl.cpp
-msgid "Port"
-msgstr "Porta"
 
 #: src/ServerListCtrl.cpp
 msgid "Description"
@@ -7396,6 +7300,10 @@ msgstr "I lidhur me shokun"
 #, fuzzy, c-format
 msgid "Connected to buddy at %s"
 msgstr "I lidhur me shokun"
+
+#: src/ServerWnd.cpp
+msgid "IP address:"
+msgstr "Adresa IP:"
 
 #: src/ServerWnd.cpp
 #, fuzzy

--- a/po/sv.po
+++ b/po/sv.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-04 12:13+0200\n"
+"POT-Creation-Date: 2026-09-05 12:01+0200\n"
 "PO-Revision-Date: 2026-09-03 11:10+0000\n"
 "Last-Translator: raffe <raffe@localhost.se>\n"
 "Language-Team: Swedish <tp-sv@listor.tp-sv.se>\n"
@@ -386,8 +386,7 @@ msgstr "webbservern kör på pid %d"
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Du vill köra webbservern vid uppstart, men binärfilen amuleweb kan inte köras. Vänligen installera paketet med aMule webservern eller compilera aMule med --enable-webserver och kör make install"
 
-#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
-#: src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
+#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
 msgid "ERROR"
 msgstr "FEL"
 
@@ -675,8 +674,7 @@ msgstr "Nätverk"
 msgid "Searches"
 msgstr "Sökningar"
 
-#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/Statistics.cpp
+#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/Statistics.cpp
 msgid "Downloads"
 msgstr "Hämtningar"
 
@@ -760,9 +758,7 @@ msgstr "Kad: Av"
 msgid "Core"
 msgstr ""
 
-#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#: src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp
-#: src/SourceListCtrl.cpp src/Statistics.cpp
+#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp src/Statistics.cpp
 msgid "Version"
 msgstr "Version"
 
@@ -1061,11 +1057,7 @@ msgstr "Kan inte skapa mappen '%s' för kategori '%s', behåller mappen '%s'."
 msgid "The remote core sent inconsistent data for \"%s\" (part status %d, expected %d). The file list may be showing the wrong information; reconnect to clear it."
 msgstr ""
 
-#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp
-#: src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp
-#: src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp
-#: src/Statistics.cpp
+#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp src/Statistics.cpp
 msgid "Unknown"
 msgstr "Okänd"
 
@@ -1162,8 +1154,7 @@ msgstr "Fel vid sparandet av %s fil: %s"
 msgid "Enter Captcha"
 msgstr "Ange Captcha"
 
-#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp
-#: src/TransferWnd.cpp
+#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp src/TransferWnd.cpp
 msgid "Category"
 msgstr "Kategori"
 
@@ -1327,13 +1318,11 @@ msgstr "Ingen 'cryptkey.dat'-fil funnen, skapar."
 msgid "Client Details"
 msgstr "Klientdetaljer"
 
-#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
-#: src/utils/wxCas/src/onlinesig.cpp
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
 msgid "LowID"
 msgstr "LowID"
 
-#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
-#: src/utils/wxCas/src/onlinesig.cpp
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
 msgid "HighID"
 msgstr "HighID"
 
@@ -1349,8 +1338,7 @@ msgstr "Stöds"
 msgid "Not supported"
 msgstr "Stöds inte"
 
-#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
-#: src/TextClient.cpp
+#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp src/TextClient.cpp
 msgid "Connected"
 msgstr "Ansluten"
 
@@ -1358,28 +1346,24 @@ msgstr "Ansluten"
 msgid "Disconnected"
 msgstr "Frånkopplad"
 
-#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp
-#: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f KiB/s"
 msgstr ""
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#, fuzzy
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/muuli_wdr.cpp
 msgid "Name"
-msgstr "Namn:"
+msgstr "Namn"
 
 #: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
 msgid "Software"
 msgstr ""
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#, fuzzy
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/muuli_wdr.cpp
 msgid "IP Address"
-msgstr "IP-adress :"
+msgstr "IP-adress"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Origin"
 msgstr "Ursprung"
 
@@ -1397,13 +1381,11 @@ msgstr "Senast mottagen"
 msgid "Sessions"
 msgstr "Version"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp
 msgid "Upload Speed"
 msgstr "Uppladdningshastighet"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp
 msgid "Download Speed"
 msgstr "Hämtningshastighet"
 
@@ -1458,13 +1440,11 @@ msgstr[1] ""
 msgid "Files"
 msgstr "Filer"
 
-#: src/ClientsListCtrl.cpp src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp
-#: src/SourceListCtrl.cpp
+#: src/ClientsListCtrl.cpp src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Uploaded"
 msgstr "Uppladdad"
 
-#: src/ClientsListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientsListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Downloaded"
 msgstr "Nedladdad"
 
@@ -1551,12 +1531,11 @@ msgstr "Användare %s (%u) nekade tillgång till listan för delade mappar/filer
 msgid "File Comments"
 msgstr "Filkommentarer"
 
-#: src/CommentDialogLst.cpp src/FriendListCtrl.cpp
+#: src/CommentDialogLst.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
 msgid "Username"
 msgstr "Användarnamn"
 
-#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp
-#: src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "File Name"
 msgstr "Filnamn"
 
@@ -1564,7 +1543,7 @@ msgstr "Filnamn"
 msgid "Rating"
 msgstr "Rankning"
 
-#: src/CommentDialogLst.cpp
+#: src/CommentDialogLst.cpp src/muuli_wdr.cpp
 msgid "Comment"
 msgstr "Kommentar"
 
@@ -1618,18 +1597,15 @@ msgstr "Auto [Hö]"
 msgid "Very low"
 msgstr "Mycket låg"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Low"
 msgstr "Låg"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Normal"
 msgstr "Normal"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "High"
 msgstr "Hög"
 
@@ -1653,13 +1629,11 @@ msgstr "Ansluter via server"
 msgid "Queue Full"
 msgstr "Kö full"
 
-#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp
-#: src/muuli_wdr.cpp
+#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp src/muuli_wdr.cpp
 msgid "On Queue"
 msgstr "I kö"
 
-#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp
-#: src/PartFile.cpp src/TransferWnd.cpp
+#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Downloading"
 msgstr "Hämtar"
 
@@ -1719,8 +1693,7 @@ msgstr "Lokal server"
 msgid "Remote Server"
 msgstr "Fjärrserver"
 
-#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp
-#: src/TextClient.cpp
+#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp src/TextClient.cpp
 msgid "Kad"
 msgstr "Kad"
 
@@ -1744,8 +1717,7 @@ msgstr "Käll-frön"
 msgid "Search Result"
 msgstr "Sökresultat"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp
-#: src/TransferWnd.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Completed"
 msgstr "Färdig"
 
@@ -1798,8 +1770,7 @@ msgstr ""
 msgid "Part"
 msgstr "Del"
 
-#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp
-#: src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Size"
 msgstr "Storlek"
 
@@ -1807,8 +1778,7 @@ msgstr "Storlek"
 msgid "Transferred"
 msgstr "Överfört"
 
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
-#: src/SourceListCtrl.cpp
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp src/SourceListCtrl.cpp
 msgid "Speed"
 msgstr "Hastighet"
 
@@ -1816,13 +1786,11 @@ msgstr "Hastighet"
 msgid "Progress"
 msgstr "Förlopp"
 
-#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp
-#: src/SearchListCtrl.cpp
+#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
 msgid "Sources"
 msgstr "Källor"
 
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp
-#: src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Priority"
 msgstr "Prioritet"
 
@@ -1846,9 +1814,7 @@ msgstr "Senast mottagen"
 msgid "Auto"
 msgstr "Auto"
 
-#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/TransferWnd.cpp
-#: src/utils/wxCas/src/wxcasprefs.cpp
+#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/TransferWnd.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Cancel"
 msgstr "Avbryt"
 
@@ -1949,8 +1915,7 @@ msgstr "Ange nytt namn för den här filen:"
 msgid "File rename"
 msgstr "Byt namn på fil"
 
-#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp
-#: src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f MiB/s"
 msgstr ""
@@ -2755,13 +2720,11 @@ msgstr ""
 msgid "Start aMule automatically when I log in"
 msgstr ""
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
-#: packaging/windows/installer_strings.c
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp packaging/windows/installer_strings.c
 msgid "Register aMule for ed2k:// links"
 msgstr ""
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
-#: packaging/windows/installer_strings.c
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp packaging/windows/installer_strings.c
 msgid "Register aMule for magnet: links"
 msgstr ""
 
@@ -2787,8 +2750,7 @@ msgstr ""
 msgid "Destination folder for downloads"
 msgstr "Målmapp för hämtningar"
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
-#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Browse"
 msgstr "Bläddra"
 
@@ -3231,18 +3193,15 @@ msgstr "Färdigställer"
 msgid "Complete"
 msgstr "Färdig"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
-#: src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Paused"
 msgstr "Pausad"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
-#: src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Erroneous"
 msgstr "Felaktig"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
-#: src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Waiting"
 msgstr "Väntar"
 
@@ -3406,8 +3365,7 @@ msgstr "Stäng"
 msgid "Cut"
 msgstr "Klipp ut"
 
-#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp
-#: src/utils/aLinkCreator/src/alcframe.cpp
+#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy"
 msgstr "Kopiera"
 
@@ -3415,8 +3373,7 @@ msgstr "Kopiera"
 msgid "Paste"
 msgstr "Klistra in"
 
-#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp
-#: src/utils/aLinkCreator/src/alcframe.cpp
+#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Clear"
 msgstr "Töm"
 
@@ -3424,8 +3381,7 @@ msgstr "Töm"
 msgid "Select All"
 msgstr "Markera alla"
 
-#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
-#: src/StatisticsDlg.cpp
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp src/StatisticsDlg.cpp
 msgid "KiB/s"
 msgstr ""
 
@@ -3689,10 +3645,6 @@ msgstr "Just nu ansluten server."
 msgid "Search"
 msgstr "Sök"
 
-#: src/muuli_wdr.cpp
-msgid "Name:"
-msgstr "Namn:"
-
 #: src/muuli_wdr.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Type"
 msgstr "Typ"
@@ -3782,8 +3734,8 @@ msgid "Availability"
 msgstr "Tillgänglighet"
 
 #: src/muuli_wdr.cpp
-msgid "Filter:"
-msgstr "Filter:"
+msgid "Filter"
+msgstr "Filter"
 
 #: src/muuli_wdr.cpp
 msgid "Invert Result"
@@ -3841,6 +3793,10 @@ msgid "Clears completed downloads"
 msgstr "Rensar färdiga nedladdningar"
 
 #: src/muuli_wdr.cpp
+msgid "Filter:"
+msgstr "Filter:"
+
+#: src/muuli_wdr.cpp
 msgid "File sources:"
 msgstr "Filkällor:"
 
@@ -3849,80 +3805,76 @@ msgid "General"
 msgstr "Allmänt"
 
 #: src/muuli_wdr.cpp
-msgid "Full Name :"
-msgstr "Hela namnet :"
+msgid "Full Name"
+msgstr "Hela namnet"
 
 #: src/muuli_wdr.cpp
-msgid "met-File :"
-msgstr "met-fil :"
+msgid "met-File"
+msgstr "met-fil"
 
 #: src/muuli_wdr.cpp
-msgid "Hash :"
-msgstr "Hash :"
+msgid "Hash"
+msgstr "Hash"
 
 #: src/muuli_wdr.cpp
-msgid "Filesize :"
-msgstr "Filstorlek :"
+msgid "Filesize"
+msgstr "Filstorlek"
 
 #: src/muuli_wdr.cpp src/Statistics.cpp
 msgid "Transfer"
 msgstr "Överför"
 
 #: src/muuli_wdr.cpp
-msgid "Partfilestatus :"
-msgstr "Partfilestatus :"
+msgid "Partfilestatus"
+msgstr "Partfilestatus"
 
 #: src/muuli_wdr.cpp
-msgid "Last seen complete :"
-msgstr "Senast sedd komplett :"
+msgid "Last seen complete"
+msgstr "Senast sedd komplett"
 
 #: src/muuli_wdr.cpp
-msgid "Found Sources :"
-msgstr "Hittade Källor :"
+msgid "Found Sources"
+msgstr "Hittade Källor"
 
 #: src/muuli_wdr.cpp
-msgid "Transferring Sources :"
-msgstr "Källor som överför :"
+msgid "Transferring Sources"
+msgstr "Källor som överför"
 
 #: src/muuli_wdr.cpp
-msgid "Filepart-Count :"
-msgstr "Filepart-antal :"
+msgid "Filepart-Count"
+msgstr "Filepart-antal"
 
 #: src/muuli_wdr.cpp
-msgid "Available :"
-msgstr "Tillgänglig :"
+msgid "Available"
+msgstr "Tillgänglig"
 
 #: src/muuli_wdr.cpp
-msgid "Datarate :"
-msgstr "Datahastighet :"
+msgid "Datarate"
+msgstr "Datahastighet"
 
 #: src/muuli_wdr.cpp
-msgid "Download Active Time: "
-msgstr "Hämta Aktiv Tid: "
+msgid "Download Active Time"
+msgstr "Hämta Aktiv Tid"
 
 #: src/muuli_wdr.cpp
-msgid "Transferred :"
-msgstr "Överförd :"
-
-#: src/muuli_wdr.cpp
-msgid "Completed Size :"
-msgstr "Färdig storlek :"
+msgid "Completed Size"
+msgstr "Färdig storlek"
 
 #: src/muuli_wdr.cpp
 msgid "Intelligent Corruption Handling"
 msgstr "Intelligent korruptionshantering"
 
 #: src/muuli_wdr.cpp
-msgid "Lost to corruption :"
-msgstr "Förlorat till korruption :"
+msgid "Lost to corruption"
+msgstr "Förlorat till korruption"
 
 #: src/muuli_wdr.cpp
-msgid "Gained by compression :"
-msgstr "Vunnits genom komprimering :"
+msgid "Gained by compression"
+msgstr "Vunnits genom komprimering"
 
 #: src/muuli_wdr.cpp
-msgid "Packages saved by I.C.H. :"
-msgstr "Paket sparad av I.C.H. :"
+msgid "Packages saved by I.C.H."
+msgstr "Paket sparad av I.C.H."
 
 #: src/muuli_wdr.cpp
 #, fuzzy
@@ -3964,30 +3916,30 @@ msgstr ", Ladda upp: "
 msgid "Media Info"
 msgstr "Kad-info"
 
-#: src/muuli_wdr.cpp
-msgid "Length :"
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
+msgid "Length"
 msgstr ""
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
 #, fuzzy
-msgid "Bitrate :"
+msgid "Bitrate"
 msgstr "Inte betygsatt"
 
-#: src/muuli_wdr.cpp
-msgid "Codec :"
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
+msgid "Codec"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Artist :"
+msgid "Artist"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Album :"
+msgid "Album"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Title :"
-msgstr "Titel :"
+msgid "Title"
+msgstr "Titel"
 
 #: src/muuli_wdr.cpp
 msgid "File Names"
@@ -4074,25 +4026,17 @@ msgstr "Okänd storlek"
 msgid "Required Information"
 msgstr "Nödvändig information"
 
-#: src/muuli_wdr.cpp
-msgid "IP Address :"
-msgstr "IP-adress :"
-
-#: src/muuli_wdr.cpp
-msgid "Port :"
-msgstr "Port :"
+#: src/muuli_wdr.cpp src/ServerListCtrl.cpp
+msgid "Port"
+msgstr "Port"
 
 #: src/muuli_wdr.cpp
 msgid "Additional Information"
 msgstr "Ytterligare information"
 
 #: src/muuli_wdr.cpp
-msgid "Username :"
-msgstr "Användarnamn :"
-
-#: src/muuli_wdr.cpp
-msgid "Userhash :"
-msgstr "Userhash:"
+msgid "Userhash"
+msgstr "Userhash"
 
 #: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Add"
@@ -4127,96 +4071,80 @@ msgid "Statistics Tree"
 msgstr "Statistikträd"
 
 #: src/muuli_wdr.cpp
-msgid "Username:"
-msgstr "Användarnamn:"
+msgid "Client software"
+msgstr "Klientprogramvara"
 
 #: src/muuli_wdr.cpp
-msgid "Userhash:"
-msgstr "Userhash:"
+msgid "Client version"
+msgstr "Klientversion"
 
 #: src/muuli_wdr.cpp
-msgid "Client software:"
-msgstr "Klientprogramvara:"
-
-#: src/muuli_wdr.cpp
-msgid "Client version:"
-msgstr "Klientversion:"
-
-#: src/muuli_wdr.cpp src/ServerWnd.cpp
-msgid "IP address:"
-msgstr "IP-adress:"
-
-#: src/muuli_wdr.cpp
-msgid "User ID:"
+msgid "User ID"
 msgstr "Användar-ID"
 
 #: src/muuli_wdr.cpp
-msgid "Server IP:"
-msgstr "Server-IP:"
+msgid "Server IP"
+msgstr "Server-IP"
 
 #: src/muuli_wdr.cpp
-msgid "Server name:"
-msgstr "Servernamn:"
+msgid "Server name"
+msgstr "Servernamn"
 
 #: src/muuli_wdr.cpp
-msgid "Obfuscation:"
-msgstr "Fördunkling:"
-
-#: src/muuli_wdr.cpp
-msgid "Kad:"
-msgstr "Kad:"
+msgid "Obfuscation"
+msgstr "Fördunkling"
 
 #: src/muuli_wdr.cpp
 msgid "Transfers to client"
 msgstr "Överföringar till klienten"
 
 #: src/muuli_wdr.cpp
-msgid "Current request:"
-msgstr "Aktuella begäran:"
+msgid "Current request"
+msgstr "Aktuella begäran"
 
 #: src/muuli_wdr.cpp
-msgid "Average upload rate:"
-msgstr "Genomsnittlig uppladdningshastighet:"
+msgid "Average upload rate"
+msgstr "Genomsnittlig uppladdningshastighet"
 
 #: src/muuli_wdr.cpp
-msgid "Average download rate:"
-msgstr "Genomsnittliga nedladdningshastighet:"
+msgid "Average download rate"
+msgstr "Genomsnittliga nedladdningshastighet"
 
 #: src/muuli_wdr.cpp
-msgid "Uploaded (session):"
-msgstr "Skickat (session):"
+msgid "Uploaded (session)"
+msgstr "Skickat (session)"
 
 #: src/muuli_wdr.cpp
-msgid "Downloaded (session):"
-msgstr "Hämtat (session):"
+msgid "Downloaded (session)"
+msgstr "Hämtat (session)"
 
 #: src/muuli_wdr.cpp
-msgid "Uploaded (total):"
-msgstr "Skickat (totalt):"
+msgid "Uploaded (total)"
+msgstr "Skickat (totalt)"
 
 #: src/muuli_wdr.cpp
-msgid "Downloaded (total):"
-msgstr "Hämtat (totalt):"
+msgid "Downloaded (total)"
+msgstr "Hämtat (totalt)"
 
 #: src/muuli_wdr.cpp
 msgid "Scores"
 msgstr "Poäng"
 
 #: src/muuli_wdr.cpp
-msgid "DL/UP modifier:"
-msgstr "DL/UP-modifierare:"
+msgid "DL/UP modifier"
+msgstr "DL/UP-modifierare"
 
 #: src/muuli_wdr.cpp
-msgid "Secure ident:"
-msgstr "Säker ident:"
+msgid "Secure ident"
+msgstr "Säker ident"
 
 #: src/muuli_wdr.cpp
-msgid "Queue rank:"
-msgstr "Kö-rang:"
+msgid "Queue rank"
+msgstr "Kö-rang"
 
 #: src/muuli_wdr.cpp
-msgid "Queue score:"
-msgstr "Kö-poäng:"
+msgid "Queue score"
+msgstr "Kö-poäng"
 
 #: src/muuli_wdr.cpp
 msgid "Nick"
@@ -5011,24 +4939,20 @@ msgid "Reset any changes made to the preferences."
 msgstr "Återställ eventuella ändringar i inställningarna."
 
 #: src/muuli_wdr.cpp
-msgid "Comment :"
-msgstr "Kommentar :"
+msgid "Incoming Dir"
+msgstr "Inkommande mapp"
 
 #: src/muuli_wdr.cpp
-msgid "Incoming Dir :"
-msgstr "Inkommande mapp:"
-
-#: src/muuli_wdr.cpp
-msgid "Change priority for new assigned files :"
-msgstr "Ändra prioritet för nya tilldelade filer:"
+msgid "Change priority for new assigned files"
+msgstr "Ändra prioritet för nya tilldelade filer"
 
 #: src/muuli_wdr.cpp
 msgid "Don't change"
 msgstr "Ändra inte"
 
 #: src/muuli_wdr.cpp
-msgid "Select color for this Category (currently selected) :"
-msgstr "Välj färg för denna kategori (den valda):"
+msgid "Select color for this Category (currently selected)"
+msgstr "Välj färg för denna kategori (den valda)"
 
 #: src/muuli_wdr.cpp
 msgid "Click this button to reset the log."
@@ -5111,10 +5035,6 @@ msgstr "Bootstrap från kända klienter"
 #, fuzzy
 msgid "Enter the IP of the node here, using the x.x.x.x format."
 msgstr "Ange IP på servern här, med hjälp av xxxx format."
-
-#: src/muuli_wdr.cpp
-msgid "Port:"
-msgstr "Port:"
 
 #: src/muuli_wdr.cpp
 msgid "Use Secure User Identification"
@@ -5383,20 +5303,20 @@ msgid "Enable/disable proxy support"
 msgstr "Aktivera/inaktivera proxy-stöd"
 
 #: src/muuli_wdr.cpp
-msgid "Proxy type:"
-msgstr "Proxytyp:"
+msgid "Proxy type"
+msgstr "Proxytyp"
 
 #: src/muuli_wdr.cpp
-msgid "Proxy host:"
-msgstr "Proxyserver:"
+msgid "Proxy host"
+msgstr "Proxyserver"
 
 #: src/muuli_wdr.cpp
 msgid "The proxy host name"
 msgstr "Proxyserverns värdnamn"
 
 #: src/muuli_wdr.cpp
-msgid "Proxy port:"
-msgstr "Proxyport:"
+msgid "Proxy port"
+msgstr "Proxyport"
 
 #: src/muuli_wdr.cpp
 msgid "The proxy port"
@@ -5411,16 +5331,8 @@ msgid "Enable/disable username/password authentication"
 msgstr "Aktivera/inaktivera användarnamn/lösenordsautentisering"
 
 #: src/muuli_wdr.cpp
-msgid "Username: "
-msgstr "Användarnamn: "
-
-#: src/muuli_wdr.cpp
 msgid "The username to use to connect to the proxy"
 msgstr "Användarnamnet som ska användas för att ansluta till proxyn"
-
-#: src/muuli_wdr.cpp
-msgid "Password:"
-msgstr "Lösenord:"
 
 #: src/muuli_wdr.cpp
 msgid "The password to use to connect to the proxy"
@@ -5595,6 +5507,15 @@ msgstr "timmar"
 #: src/OtherFunctions.cpp
 msgid "days"
 msgstr "dagar"
+
+#. TRANSLATORS:
+#. Punctuation for a "label: value" pair. %s is the already-translated
+#. label. Place the colon as your language requires -- e.g. "%s :" with a
+#. space in French, "%s:" without one in Russian and English.
+#: src/OtherFunctions.cpp
+#, c-format
+msgid "%s:"
+msgstr ""
 
 #: src/OtherFunctions.cpp
 msgid "all"
@@ -6637,8 +6558,7 @@ msgstr ""
 msgid "Confirm shared folders"
 msgstr "Delade mappar"
 
-#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp
-#: src/SharedFilesReloadProgress.cpp
+#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp src/SharedFilesReloadProgress.cpp
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "Återladda dina delade filer"
@@ -6772,19 +6692,6 @@ msgstr "Fel vid uppdatering av GeoIP.dat"
 #: src/SearchListCtrl.cpp
 msgid "FileID"
 msgstr "FileID"
-
-#: src/SearchListCtrl.cpp
-msgid "Length"
-msgstr ""
-
-#: src/SearchListCtrl.cpp
-#, fuzzy
-msgid "Bitrate"
-msgstr "Inte betygsatt"
-
-#: src/SearchListCtrl.cpp
-msgid "Codec"
-msgstr ""
 
 #: src/SearchListCtrl.cpp
 msgid "Expand all"
@@ -7069,10 +6976,6 @@ msgstr "Lokal server filtreras av IPFilters, återansluter till en annan server!
 #: src/ServerListCtrl.cpp
 msgid "Server Name"
 msgstr "Servernamn"
-
-#: src/ServerListCtrl.cpp
-msgid "Port"
-msgstr "Port"
 
 #: src/ServerListCtrl.cpp
 msgid "Description"
@@ -7366,6 +7269,10 @@ msgstr "Ansluter till vän"
 #, c-format
 msgid "Connected to buddy at %s"
 msgstr "Ansluten till vän på %s"
+
+#: src/ServerWnd.cpp
+msgid "IP address:"
+msgstr "IP-adress:"
 
 #: src/ServerWnd.cpp
 msgid "Indexed sources:"

--- a/po/ta.po
+++ b/po/ta.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-04 12:13+0200\n"
+"POT-Creation-Date: 2026-09-05 12:01+0200\n"
 "PO-Revision-Date: 2026-09-03 11:13+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -1321,7 +1321,7 @@ msgstr ""
 msgid "%.1f KiB/s"
 msgstr ""
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/muuli_wdr.cpp
 msgid "Name"
 msgstr ""
 
@@ -1329,7 +1329,7 @@ msgstr ""
 msgid "Software"
 msgstr ""
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/muuli_wdr.cpp
 msgid "IP Address"
 msgstr ""
 
@@ -1497,7 +1497,7 @@ msgstr "பயனர் %s (%u பகிரப்பட்ட கோப்பக
 msgid "File Comments"
 msgstr ""
 
-#: src/CommentDialogLst.cpp src/FriendListCtrl.cpp
+#: src/CommentDialogLst.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
 msgid "Username"
 msgstr ""
 
@@ -1510,7 +1510,7 @@ msgstr ""
 msgid "Rating"
 msgstr ""
 
-#: src/CommentDialogLst.cpp
+#: src/CommentDialogLst.cpp src/muuli_wdr.cpp
 msgid "Comment"
 msgstr ""
 
@@ -3579,10 +3579,6 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
-#: src/muuli_wdr.cpp
-msgid "Name:"
-msgstr ""
-
 #: src/muuli_wdr.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Type"
 msgstr ""
@@ -3672,7 +3668,7 @@ msgid "Availability"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Filter:"
+msgid "Filter"
 msgstr ""
 
 #: src/muuli_wdr.cpp
@@ -3728,6 +3724,10 @@ msgid "Clears completed downloads"
 msgstr ""
 
 #: src/muuli_wdr.cpp
+msgid "Filter:"
+msgstr ""
+
+#: src/muuli_wdr.cpp
 msgid "File sources:"
 msgstr ""
 
@@ -3736,19 +3736,19 @@ msgid "General"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Full Name :"
+msgid "Full Name"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "met-File :"
+msgid "met-File"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Hash :"
+msgid "Hash"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Filesize :"
+msgid "Filesize"
 msgstr ""
 
 #: src/muuli_wdr.cpp src/Statistics.cpp
@@ -3756,43 +3756,39 @@ msgid "Transfer"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Partfilestatus :"
+msgid "Partfilestatus"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Last seen complete :"
+msgid "Last seen complete"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Found Sources :"
+msgid "Found Sources"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Transferring Sources :"
+msgid "Transferring Sources"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Filepart-Count :"
+msgid "Filepart-Count"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Available :"
+msgid "Available"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Datarate :"
+msgid "Datarate"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Download Active Time: "
+msgid "Download Active Time"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Transferred :"
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "Completed Size :"
+msgid "Completed Size"
 msgstr ""
 
 #: src/muuli_wdr.cpp
@@ -3800,15 +3796,15 @@ msgid "Intelligent Corruption Handling"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Lost to corruption :"
+msgid "Lost to corruption"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Gained by compression :"
+msgid "Gained by compression"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Packages saved by I.C.H. :"
+msgid "Packages saved by I.C.H."
 msgstr ""
 
 #: src/muuli_wdr.cpp
@@ -3847,28 +3843,28 @@ msgstr ""
 msgid "Media Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp
-msgid "Length :"
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
+msgid "Length"
+msgstr ""
+
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
+msgid "Bitrate"
+msgstr ""
+
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
+msgid "Codec"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Bitrate :"
+msgid "Artist"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Codec :"
+msgid "Album"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Artist :"
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "Album :"
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "Title :"
+msgid "Title"
 msgstr ""
 
 #: src/muuli_wdr.cpp
@@ -3953,12 +3949,8 @@ msgstr ""
 msgid "Required Information"
 msgstr ""
 
-#: src/muuli_wdr.cpp
-msgid "IP Address :"
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "Port :"
+#: src/muuli_wdr.cpp src/ServerListCtrl.cpp
+msgid "Port"
 msgstr ""
 
 #: src/muuli_wdr.cpp
@@ -3966,11 +3958,7 @@ msgid "Additional Information"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Username :"
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "Userhash :"
+msgid "Userhash"
 msgstr ""
 
 #: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
@@ -4006,43 +3994,27 @@ msgid "Statistics Tree"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Username:"
+msgid "Client software"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Userhash:"
+msgid "Client version"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Client software:"
+msgid "User ID"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Client version:"
-msgstr ""
-
-#: src/muuli_wdr.cpp src/ServerWnd.cpp
-msgid "IP address:"
+msgid "Server IP"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "User ID:"
+msgid "Server name"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Server IP:"
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "Server name:"
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "Obfuscation:"
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "Kad:"
+msgid "Obfuscation"
 msgstr ""
 
 #: src/muuli_wdr.cpp
@@ -4050,31 +4022,31 @@ msgid "Transfers to client"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Current request:"
+msgid "Current request"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Average upload rate:"
+msgid "Average upload rate"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Average download rate:"
+msgid "Average download rate"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Uploaded (session):"
+msgid "Uploaded (session)"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Downloaded (session):"
+msgid "Downloaded (session)"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Uploaded (total):"
+msgid "Uploaded (total)"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Downloaded (total):"
+msgid "Downloaded (total)"
 msgstr ""
 
 #: src/muuli_wdr.cpp
@@ -4082,19 +4054,19 @@ msgid "Scores"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "DL/UP modifier:"
+msgid "DL/UP modifier"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Secure ident:"
+msgid "Secure ident"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Queue rank:"
+msgid "Queue rank"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Queue score:"
+msgid "Queue score"
 msgstr ""
 
 #: src/muuli_wdr.cpp
@@ -4872,15 +4844,11 @@ msgid "Reset any changes made to the preferences."
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Comment :"
+msgid "Incoming Dir"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Incoming Dir :"
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "Change priority for new assigned files :"
+msgid "Change priority for new assigned files"
 msgstr ""
 
 #: src/muuli_wdr.cpp
@@ -4888,7 +4856,7 @@ msgid "Don't change"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Select color for this Category (currently selected) :"
+msgid "Select color for this Category (currently selected)"
 msgstr ""
 
 #: src/muuli_wdr.cpp
@@ -4969,10 +4937,6 @@ msgstr ""
 
 #: src/muuli_wdr.cpp
 msgid "Enter the IP of the node here, using the x.x.x.x format."
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "Port:"
 msgstr ""
 
 #: src/muuli_wdr.cpp
@@ -5237,11 +5201,11 @@ msgid "Enable/disable proxy support"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Proxy type:"
+msgid "Proxy type"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Proxy host:"
+msgid "Proxy host"
 msgstr ""
 
 #: src/muuli_wdr.cpp
@@ -5249,7 +5213,7 @@ msgid "The proxy host name"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Proxy port:"
+msgid "Proxy port"
 msgstr ""
 
 #: src/muuli_wdr.cpp
@@ -5265,15 +5229,7 @@ msgid "Enable/disable username/password authentication"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Username: "
-msgstr ""
-
-#: src/muuli_wdr.cpp
 msgid "The username to use to connect to the proxy"
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "Password:"
 msgstr ""
 
 #: src/muuli_wdr.cpp
@@ -5446,6 +5402,15 @@ msgstr ""
 
 #: src/OtherFunctions.cpp
 msgid "days"
+msgstr ""
+
+#. TRANSLATORS:
+#. Punctuation for a "label: value" pair. %s is the already-translated
+#. label. Place the colon as your language requires -- e.g. "%s :" with a
+#. space in French, "%s:" without one in Russian and English.
+#: src/OtherFunctions.cpp
+#, c-format
+msgid "%s:"
 msgstr ""
 
 #: src/OtherFunctions.cpp
@@ -6569,18 +6534,6 @@ msgid "FileID"
 msgstr ""
 
 #: src/SearchListCtrl.cpp
-msgid "Length"
-msgstr ""
-
-#: src/SearchListCtrl.cpp
-msgid "Bitrate"
-msgstr ""
-
-#: src/SearchListCtrl.cpp
-msgid "Codec"
-msgstr ""
-
-#: src/SearchListCtrl.cpp
 msgid "Expand all"
 msgstr ""
 
@@ -6855,10 +6808,6 @@ msgstr ""
 
 #: src/ServerListCtrl.cpp
 msgid "Server Name"
-msgstr ""
-
-#: src/ServerListCtrl.cpp
-msgid "Port"
 msgstr ""
 
 #: src/ServerListCtrl.cpp
@@ -7145,6 +7094,10 @@ msgstr ""
 #: src/ServerWnd.cpp
 #, c-format
 msgid "Connected to buddy at %s"
+msgstr ""
+
+#: src/ServerWnd.cpp
+msgid "IP address:"
 msgstr ""
 
 #: src/ServerWnd.cpp

--- a/po/tr.po
+++ b/po/tr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-04 12:13+0200\n"
+"POT-Creation-Date: 2026-09-05 12:01+0200\n"
 "PO-Revision-Date: 2026-09-03 11:11+0000\n"
 "Last-Translator: \n"
 "Language-Team: Turkish <li@li.org>\n"
@@ -385,8 +385,7 @@ msgstr "web sunucusu pid %d üzerinde çalışıyor"
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Web sunucusunun başlangıçta çalışmasını istediniz, fakat amuleweb ikilisi çalıştırılamıyor. Lütfen aMule web sunucusunu içeren paketi yükleyin veya aMule' yi -DBUILD_WEBSERVER=YES seçeneği ile derleyin ve kurun."
 
-#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
-#: src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
+#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
 msgid "ERROR"
 msgstr "HATA"
 
@@ -672,8 +671,7 @@ msgstr "Ağlar"
 msgid "Searches"
 msgstr "Aramalar"
 
-#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/Statistics.cpp
+#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/Statistics.cpp
 msgid "Downloads"
 msgstr "İndirmeler"
 
@@ -761,9 +759,7 @@ msgstr "Kad: Kapalı"
 msgid "Core"
 msgstr "Çekirdek"
 
-#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#: src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp
-#: src/SourceListCtrl.cpp src/Statistics.cpp
+#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp src/Statistics.cpp
 msgid "Version"
 msgstr "Sürüm"
 
@@ -1060,11 +1056,7 @@ msgstr "'%s' dizini '%s' sınıfı için oluşturulamadı. '%s' dizini kullanıl
 msgid "The remote core sent inconsistent data for \"%s\" (part status %d, expected %d). The file list may be showing the wrong information; reconnect to clear it."
 msgstr "Uzaktaki çekirdek \"%s\" için tutarsız veri gönderdi (kısmi durum %d, beklenilen %d). Dosya listesi yanlış bilgi gösteriyor olabilir, bunu düzeltmek için tekrar bağlanın."
 
-#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp
-#: src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp
-#: src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp
-#: src/Statistics.cpp
+#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp src/Statistics.cpp
 msgid "Unknown"
 msgstr "Bilinmiyor"
 
@@ -1161,8 +1153,7 @@ msgstr "%s dosyası kaydedilirken hata: %s"
 msgid "Enter Captcha"
 msgstr "Captcha Gir"
 
-#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp
-#: src/TransferWnd.cpp
+#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp src/TransferWnd.cpp
 msgid "Category"
 msgstr "Sınıf"
 
@@ -1325,13 +1316,11 @@ msgstr "'cryptkey.dat' dosyası bulunamadı. Oluşturuluyor…"
 msgid "Client Details"
 msgstr "Kullanıcı Ayrıntıları"
 
-#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
-#: src/utils/wxCas/src/onlinesig.cpp
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
 msgid "LowID"
 msgstr "DüşükID"
 
-#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
-#: src/utils/wxCas/src/onlinesig.cpp
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
 msgid "HighID"
 msgstr "YüksekID"
 
@@ -1347,8 +1336,7 @@ msgstr "Destekleniyor"
 msgid "Not supported"
 msgstr "Desteklenmiyor"
 
-#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
-#: src/TextClient.cpp
+#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp src/TextClient.cpp
 msgid "Connected"
 msgstr "Bağlandı"
 
@@ -1356,13 +1344,12 @@ msgstr "Bağlandı"
 msgid "Disconnected"
 msgstr "Bağlantı kesildi"
 
-#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp
-#: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f KiB/s"
 msgstr "%.1f KiB/s"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/muuli_wdr.cpp
 msgid "Name"
 msgstr "Ad"
 
@@ -1370,12 +1357,11 @@ msgstr "Ad"
 msgid "Software"
 msgstr "Yazılım"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/muuli_wdr.cpp
 msgid "IP Address"
 msgstr "IP Adresi"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Origin"
 msgstr "Köken"
 
@@ -1391,13 +1377,11 @@ msgstr "Son Görülme"
 msgid "Sessions"
 msgstr "Oturumlar"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp
 msgid "Upload Speed"
 msgstr "Gönderme Hızı"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp
 msgid "Download Speed"
 msgstr "İndirme Hızı"
 
@@ -1448,13 +1432,11 @@ msgstr[1] "%u bağlantı eklenemedi (teferruatlar için kütüğe bakın)."
 msgid "Files"
 msgstr "Dosyalar"
 
-#: src/ClientsListCtrl.cpp src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp
-#: src/SourceListCtrl.cpp
+#: src/ClientsListCtrl.cpp src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Uploaded"
 msgstr "Gönderilen"
 
-#: src/ClientsListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientsListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Downloaded"
 msgstr "İndirildi"
 
@@ -1538,12 +1520,11 @@ msgstr "Kullanıcı %s (%u)nın paylaşılmış dizin/dosyalara erişimi reddedi
 msgid "File Comments"
 msgstr "Dosya Yorumları"
 
-#: src/CommentDialogLst.cpp src/FriendListCtrl.cpp
+#: src/CommentDialogLst.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
 msgid "Username"
 msgstr "Kullanıcı Adı"
 
-#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp
-#: src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "File Name"
 msgstr "Dosya Adı"
 
@@ -1551,7 +1532,7 @@ msgstr "Dosya Adı"
 msgid "Rating"
 msgstr "Puanlama"
 
-#: src/CommentDialogLst.cpp
+#: src/CommentDialogLst.cpp src/muuli_wdr.cpp
 msgid "Comment"
 msgstr "Yorum"
 
@@ -1604,18 +1585,15 @@ msgstr "Oto (Yük)"
 msgid "Very low"
 msgstr "Çok düşük"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Low"
 msgstr "Düşük"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Normal"
 msgstr "Normal"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "High"
 msgstr "Yüksek"
 
@@ -1639,13 +1617,11 @@ msgstr "Sunucu yoluyla bağlanıyor"
 msgid "Queue Full"
 msgstr "Sıra dolu"
 
-#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp
-#: src/muuli_wdr.cpp
+#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp src/muuli_wdr.cpp
 msgid "On Queue"
 msgstr "Sırada"
 
-#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp
-#: src/PartFile.cpp src/TransferWnd.cpp
+#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Downloading"
 msgstr "Aktarılıyor"
 
@@ -1705,8 +1681,7 @@ msgstr "Sunucu"
 msgid "Remote Server"
 msgstr "Uzak Sunucu"
 
-#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp
-#: src/TextClient.cpp
+#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp src/TextClient.cpp
 msgid "Kad"
 msgstr "Kad"
 
@@ -1730,8 +1705,7 @@ msgstr "Kaynak Girdileri"
 msgid "Search Result"
 msgstr "Arama Sonucu"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp
-#: src/TransferWnd.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Completed"
 msgstr "Tamamlandı"
 
@@ -1783,8 +1757,7 @@ msgstr "Özyinelemeli bir paylaşım dahilinde değişim yapılamaz"
 msgid "Part"
 msgstr "Parça"
 
-#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp
-#: src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Size"
 msgstr "Boyut"
 
@@ -1792,8 +1765,7 @@ msgstr "Boyut"
 msgid "Transferred"
 msgstr "Aktarıldı"
 
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
-#: src/SourceListCtrl.cpp
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp src/SourceListCtrl.cpp
 msgid "Speed"
 msgstr "Hız"
 
@@ -1801,13 +1773,11 @@ msgstr "Hız"
 msgid "Progress"
 msgstr "İşlem"
 
-#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp
-#: src/SearchListCtrl.cpp
+#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
 msgid "Sources"
 msgstr "Kaynaklar"
 
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp
-#: src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Priority"
 msgstr "Öncelik"
 
@@ -1831,9 +1801,7 @@ msgstr "Son Alım"
 msgid "Auto"
 msgstr "Otomatik"
 
-#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/TransferWnd.cpp
-#: src/utils/wxCas/src/wxcasprefs.cpp
+#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/TransferWnd.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Cancel"
 msgstr "İptal"
 
@@ -1934,8 +1902,7 @@ msgstr "Bu dosya için yeni bir isim girin:"
 msgid "File rename"
 msgstr "Dosya yeniden adlandır"
 
-#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp
-#: src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f MiB/s"
 msgstr "%.1f MiB/s"
@@ -2738,13 +2705,11 @@ msgstr ""
 msgid "Start aMule automatically when I log in"
 msgstr "aMule'ü oturum açtığımda otomatik olarak başlat"
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
-#: packaging/windows/installer_strings.c
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp packaging/windows/installer_strings.c
 msgid "Register aMule for ed2k:// links"
 msgstr "aMule'ü ed2k:// bağlantıları için kaydet"
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
-#: packaging/windows/installer_strings.c
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp packaging/windows/installer_strings.c
 msgid "Register aMule for magnet: links"
 msgstr "aMule'ü magnet: bağlantıları için kaydet"
 
@@ -2772,8 +2737,7 @@ msgstr ""
 msgid "Destination folder for downloads"
 msgstr "İndirmeler için hedef dizin"
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
-#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Browse"
 msgstr "Göz at"
 
@@ -3217,18 +3181,15 @@ msgstr "Tamamlanıyor"
 msgid "Complete"
 msgstr "Tamamlandı"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
-#: src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Paused"
 msgstr "Duraklatıldı"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
-#: src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Erroneous"
 msgstr "Hatalı"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
-#: src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Waiting"
 msgstr "Bekliyor"
 
@@ -3390,8 +3351,7 @@ msgstr "Kapat"
 msgid "Cut"
 msgstr "Kes"
 
-#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp
-#: src/utils/aLinkCreator/src/alcframe.cpp
+#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy"
 msgstr "Kopyala"
 
@@ -3399,8 +3359,7 @@ msgstr "Kopyala"
 msgid "Paste"
 msgstr "Yapıştır"
 
-#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp
-#: src/utils/aLinkCreator/src/alcframe.cpp
+#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Clear"
 msgstr "Temizle"
 
@@ -3408,8 +3367,7 @@ msgstr "Temizle"
 msgid "Select All"
 msgstr "Tümünü Seç"
 
-#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
-#: src/StatisticsDlg.cpp
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp src/StatisticsDlg.cpp
 msgid "KiB/s"
 msgstr "KiB/s"
 
@@ -3664,10 +3622,6 @@ msgstr "Şu an bağlanılan sunucu."
 msgid "Search"
 msgstr "Ara"
 
-#: src/muuli_wdr.cpp
-msgid "Name:"
-msgstr "Ad:"
-
 #: src/muuli_wdr.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Type"
 msgstr "Tür"
@@ -3757,8 +3711,8 @@ msgid "Availability"
 msgstr "Uygunluk"
 
 #: src/muuli_wdr.cpp
-msgid "Filter:"
-msgstr "Süz:"
+msgid "Filter"
+msgstr "Süz"
 
 #: src/muuli_wdr.cpp
 msgid "Invert Result"
@@ -3813,6 +3767,10 @@ msgid "Clears completed downloads"
 msgstr "Tamamlanan aktarımları temizler."
 
 #: src/muuli_wdr.cpp
+msgid "Filter:"
+msgstr "Süz:"
+
+#: src/muuli_wdr.cpp
 msgid "File sources:"
 msgstr "Dosya kaynakları:"
 
@@ -3821,80 +3779,76 @@ msgid "General"
 msgstr "Genel"
 
 #: src/muuli_wdr.cpp
-msgid "Full Name :"
-msgstr "Tam Ad :"
+msgid "Full Name"
+msgstr "Tam Ad"
 
 #: src/muuli_wdr.cpp
-msgid "met-File :"
-msgstr "met-Dosyası :"
+msgid "met-File"
+msgstr "met-Dosyası"
 
 #: src/muuli_wdr.cpp
-msgid "Hash :"
-msgstr "Adresleme:"
+msgid "Hash"
+msgstr "Adresleme"
 
 #: src/muuli_wdr.cpp
-msgid "Filesize :"
-msgstr "Dosya Boyutu :"
+msgid "Filesize"
+msgstr "Dosya Boyutu"
 
 #: src/muuli_wdr.cpp src/Statistics.cpp
 msgid "Transfer"
 msgstr "Aktarım"
 
 #: src/muuli_wdr.cpp
-msgid "Partfilestatus :"
-msgstr "Parça Dosya Durumu :"
+msgid "Partfilestatus"
+msgstr "Parça Dosya Durumu"
 
 #: src/muuli_wdr.cpp
-msgid "Last seen complete :"
-msgstr "Son Görülen Tamamlama :"
+msgid "Last seen complete"
+msgstr "Son Görülen Tamamlama"
 
 #: src/muuli_wdr.cpp
-msgid "Found Sources :"
-msgstr "Bulunan Kaynaklar:"
+msgid "Found Sources"
+msgstr "Bulunan Kaynaklar"
 
 #: src/muuli_wdr.cpp
-msgid "Transferring Sources :"
-msgstr "Aktarılan Kaynaklar:"
+msgid "Transferring Sources"
+msgstr "Aktarılan Kaynaklar"
 
 #: src/muuli_wdr.cpp
-msgid "Filepart-Count :"
-msgstr "Dosya Parçası-Sayısı:"
+msgid "Filepart-Count"
+msgstr "Dosya Parçası-Sayısı"
 
 #: src/muuli_wdr.cpp
-msgid "Available :"
-msgstr "Uygun:"
+msgid "Available"
+msgstr "Uygun"
 
 #: src/muuli_wdr.cpp
-msgid "Datarate :"
-msgstr "Veri Oranı:"
+msgid "Datarate"
+msgstr "Veri Oranı"
 
 #: src/muuli_wdr.cpp
-msgid "Download Active Time: "
-msgstr "Aktarım Süresi: "
+msgid "Download Active Time"
+msgstr "Aktarım Süresi"
 
 #: src/muuli_wdr.cpp
-msgid "Transferred :"
-msgstr "Aktarılan:"
-
-#: src/muuli_wdr.cpp
-msgid "Completed Size :"
-msgstr "Tamamlanmış Boyut:"
+msgid "Completed Size"
+msgstr "Tamamlanmış Boyut"
 
 #: src/muuli_wdr.cpp
 msgid "Intelligent Corruption Handling"
 msgstr "Akıllı Bozulma Yakalayıcısı"
 
 #: src/muuli_wdr.cpp
-msgid "Lost to corruption :"
-msgstr "Bozulma ile kaybedilen:"
+msgid "Lost to corruption"
+msgstr "Bozulma ile kaybedilen"
 
 #: src/muuli_wdr.cpp
-msgid "Gained by compression :"
-msgstr "Sıkıştırma ile kazanılan:"
+msgid "Gained by compression"
+msgstr "Sıkıştırma ile kazanılan"
 
 #: src/muuli_wdr.cpp
-msgid "Packages saved by I.C.H. :"
-msgstr "I.C.H ile kurtarılan paketler :"
+msgid "Packages saved by I.C.H."
+msgstr "I.C.H ile kurtarılan paketler"
 
 #: src/muuli_wdr.cpp
 msgid "Sharing"
@@ -3932,29 +3886,29 @@ msgstr "Son gönderme"
 msgid "Media Info"
 msgstr "Ortam Bilgileri"
 
-#: src/muuli_wdr.cpp
-msgid "Length :"
-msgstr "Süre:"
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
+msgid "Length"
+msgstr "Süre"
+
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
+msgid "Bitrate"
+msgstr "Akış hızı"
+
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
+msgid "Codec"
+msgstr "Kodlama"
 
 #: src/muuli_wdr.cpp
-msgid "Bitrate :"
-msgstr "Akış hızı:"
+msgid "Artist"
+msgstr "Sanatçı"
 
 #: src/muuli_wdr.cpp
-msgid "Codec :"
-msgstr "Kodlama:"
+msgid "Album"
+msgstr "Albüm"
 
 #: src/muuli_wdr.cpp
-msgid "Artist :"
-msgstr "Sanatçı:"
-
-#: src/muuli_wdr.cpp
-msgid "Album :"
-msgstr "Albüm:"
-
-#: src/muuli_wdr.cpp
-msgid "Title :"
-msgstr "Başlık :"
+msgid "Title"
+msgstr "Başlık"
 
 #: src/muuli_wdr.cpp
 msgid "File Names"
@@ -4040,25 +3994,17 @@ msgstr "Boyut bilinmiyor"
 msgid "Required Information"
 msgstr "Gerekli Bilgiler"
 
-#: src/muuli_wdr.cpp
-msgid "IP Address :"
-msgstr "IP Adresi:"
-
-#: src/muuli_wdr.cpp
-msgid "Port :"
-msgstr "Port:"
+#: src/muuli_wdr.cpp src/ServerListCtrl.cpp
+msgid "Port"
+msgstr "Port"
 
 #: src/muuli_wdr.cpp
 msgid "Additional Information"
 msgstr "Ek Bilgi"
 
 #: src/muuli_wdr.cpp
-msgid "Username :"
-msgstr "Kullanıcı Adı :"
-
-#: src/muuli_wdr.cpp
-msgid "Userhash :"
-msgstr "Kullanıcı Adreslemesi :"
+msgid "Userhash"
+msgstr "Kullanıcı Adreslemesi"
 
 #: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Add"
@@ -4093,96 +4039,80 @@ msgid "Statistics Tree"
 msgstr "İstatistik Ağacı"
 
 #: src/muuli_wdr.cpp
-msgid "Username:"
-msgstr "Kullanıcı Adı:"
+msgid "Client software"
+msgstr "Yazılım"
 
 #: src/muuli_wdr.cpp
-msgid "Userhash:"
-msgstr "Kullanıcı Adreslemesi:"
+msgid "Client version"
+msgstr "Yazılım Sürümü"
 
 #: src/muuli_wdr.cpp
-msgid "Client software:"
-msgstr "Yazılım:"
+msgid "User ID"
+msgstr "Kullanıcı ID"
 
 #: src/muuli_wdr.cpp
-msgid "Client version:"
-msgstr "Yazılım Sürümü:"
-
-#: src/muuli_wdr.cpp src/ServerWnd.cpp
-msgid "IP address:"
-msgstr "IP :"
+msgid "Server IP"
+msgstr "Sunucu IP"
 
 #: src/muuli_wdr.cpp
-msgid "User ID:"
-msgstr "Kullanıcı ID:"
+msgid "Server name"
+msgstr "Sunucu"
 
 #: src/muuli_wdr.cpp
-msgid "Server IP:"
-msgstr "Sunucu IP:"
-
-#: src/muuli_wdr.cpp
-msgid "Server name:"
-msgstr "Sunucu:"
-
-#: src/muuli_wdr.cpp
-msgid "Obfuscation:"
-msgstr "Gizleme:"
-
-#: src/muuli_wdr.cpp
-msgid "Kad:"
-msgstr "Kademlia:"
+msgid "Obfuscation"
+msgstr "Gizleme"
 
 #: src/muuli_wdr.cpp
 msgid "Transfers to client"
 msgstr "Yapılan aktarımlar"
 
 #: src/muuli_wdr.cpp
-msgid "Current request:"
-msgstr "Şimdiki İstek:"
+msgid "Current request"
+msgstr "Şimdiki İstek"
 
 #: src/muuli_wdr.cpp
-msgid "Average upload rate:"
-msgstr "Ortalama gönderim oranı:"
+msgid "Average upload rate"
+msgstr "Ortalama gönderim oranı"
 
 #: src/muuli_wdr.cpp
-msgid "Average download rate:"
-msgstr "Ortalama aktarım oranı:"
+msgid "Average download rate"
+msgstr "Ortalama aktarım oranı"
 
 #: src/muuli_wdr.cpp
-msgid "Uploaded (session):"
-msgstr "Gönderilen (oturum):"
+msgid "Uploaded (session)"
+msgstr "Gönderilen (oturum)"
 
 #: src/muuli_wdr.cpp
-msgid "Downloaded (session):"
-msgstr "İndirilen (oturum):"
+msgid "Downloaded (session)"
+msgstr "İndirilen (oturum)"
 
 #: src/muuli_wdr.cpp
-msgid "Uploaded (total):"
-msgstr "Gönderilen (toplam):"
+msgid "Uploaded (total)"
+msgstr "Gönderilen (toplam)"
 
 #: src/muuli_wdr.cpp
-msgid "Downloaded (total):"
-msgstr "İndirilen (toplam):"
+msgid "Downloaded (total)"
+msgstr "İndirilen (toplam)"
 
 #: src/muuli_wdr.cpp
 msgid "Scores"
 msgstr "Skor"
 
 #: src/muuli_wdr.cpp
-msgid "DL/UP modifier:"
-msgstr "İND./GÖN. niteleyici:"
+msgid "DL/UP modifier"
+msgstr "İND./GÖN. niteleyici"
 
 #: src/muuli_wdr.cpp
-msgid "Secure ident:"
-msgstr "Güvenli Kimlik:"
+msgid "Secure ident"
+msgstr "Güvenli Kimlik"
 
 #: src/muuli_wdr.cpp
-msgid "Queue rank:"
-msgstr "Kuyruk sırası:"
+msgid "Queue rank"
+msgstr "Kuyruk sırası"
 
 #: src/muuli_wdr.cpp
-msgid "Queue score:"
-msgstr "Sıra skoru:"
+msgid "Queue score"
+msgstr "Sıra skoru"
 
 #: src/muuli_wdr.cpp
 msgid "Nick"
@@ -4961,24 +4891,20 @@ msgid "Reset any changes made to the preferences."
 msgstr "Ayarlarda yapılan değişiklikleri sil."
 
 #: src/muuli_wdr.cpp
-msgid "Comment :"
-msgstr "Yorum:"
+msgid "Incoming Dir"
+msgstr "Gelen Dosyalar Dizini"
 
 #: src/muuli_wdr.cpp
-msgid "Incoming Dir :"
-msgstr "Gelen Dosyalar Dizini :"
-
-#: src/muuli_wdr.cpp
-msgid "Change priority for new assigned files :"
-msgstr "Yeni eklenen dosyalar için öncelikleri değiştir:"
+msgid "Change priority for new assigned files"
+msgstr "Yeni eklenen dosyalar için öncelikleri değiştir"
 
 #: src/muuli_wdr.cpp
 msgid "Don't change"
 msgstr "Değiştirme"
 
 #: src/muuli_wdr.cpp
-msgid "Select color for this Category (currently selected) :"
-msgstr "Bu sınıf için renk seçiniz (varsayılan) :"
+msgid "Select color for this Category (currently selected)"
+msgstr "Bu sınıf için renk seçiniz (varsayılan)"
 
 #: src/muuli_wdr.cpp
 msgid "Click this button to reset the log."
@@ -5059,10 +4985,6 @@ msgstr "Düğüm:IP unsurundan ön yükleme yap"
 #: src/muuli_wdr.cpp
 msgid "Enter the IP of the node here, using the x.x.x.x format."
 msgstr "Düğümün IP adresini x.x.x.x biçiminde buraya giriniz."
-
-#: src/muuli_wdr.cpp
-msgid "Port:"
-msgstr "Port:"
 
 #: src/muuli_wdr.cpp
 msgid "Use Secure User Identification"
@@ -5339,20 +5261,20 @@ msgid "Enable/disable proxy support"
 msgstr "Vekil sunucu desteğini etkinleştir/devre dışı bırak"
 
 #: src/muuli_wdr.cpp
-msgid "Proxy type:"
-msgstr "Vekil sunucu Türü:"
+msgid "Proxy type"
+msgstr "Vekil sunucu Türü"
 
 #: src/muuli_wdr.cpp
-msgid "Proxy host:"
-msgstr "Vekil sunucu makine:"
+msgid "Proxy host"
+msgstr "Vekil sunucu makine"
 
 #: src/muuli_wdr.cpp
 msgid "The proxy host name"
 msgstr "Vekil sunucu makine adı"
 
 #: src/muuli_wdr.cpp
-msgid "Proxy port:"
-msgstr "Vekil sunucu Portu:"
+msgid "Proxy port"
+msgstr "Vekil sunucu Portu"
 
 #: src/muuli_wdr.cpp
 msgid "The proxy port"
@@ -5367,16 +5289,8 @@ msgid "Enable/disable username/password authentication"
 msgstr "Kullanıcı adı/şifre yetkilendirmeyi etkinleştir/devre dışı bırak."
 
 #: src/muuli_wdr.cpp
-msgid "Username: "
-msgstr "Kullanıcı adı: "
-
-#: src/muuli_wdr.cpp
 msgid "The username to use to connect to the proxy"
 msgstr "Vekil sunucuya bağlanmak için gerekli kullanıcı adı"
-
-#: src/muuli_wdr.cpp
-msgid "Password:"
-msgstr "Şifre:"
 
 #: src/muuli_wdr.cpp
 msgid "The password to use to connect to the proxy"
@@ -5549,6 +5463,15 @@ msgstr "saat"
 #: src/OtherFunctions.cpp
 msgid "days"
 msgstr "gün"
+
+#. TRANSLATORS:
+#. Punctuation for a "label: value" pair. %s is the already-translated
+#. label. Place the colon as your language requires -- e.g. "%s :" with a
+#. space in French, "%s:" without one in Russian and English.
+#: src/OtherFunctions.cpp
+#, c-format
+msgid "%s:"
+msgstr ""
 
 #: src/OtherFunctions.cpp
 msgid "all"
@@ -6579,8 +6502,7 @@ msgstr "Bunları yinelemeli olarak paylaşmanız, kapsadıkları her dosyayı eD
 msgid "Confirm shared folders"
 msgstr "Paylaşılan dizinleri teyit et"
 
-#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp
-#: src/SharedFilesReloadProgress.cpp
+#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp src/SharedFilesReloadProgress.cpp
 msgid "Reloading shared files..."
 msgstr "Paylaşılan dosyalar yeniden yükleniyor…"
 
@@ -6709,18 +6631,6 @@ msgstr "Hata %u: %s\n"
 #: src/SearchListCtrl.cpp
 msgid "FileID"
 msgstr "Dosya Adresi"
-
-#: src/SearchListCtrl.cpp
-msgid "Length"
-msgstr "Süre"
-
-#: src/SearchListCtrl.cpp
-msgid "Bitrate"
-msgstr "Akış hızı"
-
-#: src/SearchListCtrl.cpp
-msgid "Codec"
-msgstr "Kodlama"
 
 #: src/SearchListCtrl.cpp
 msgid "Expand all"
@@ -6998,10 +6908,6 @@ msgstr "Yerel sunucu IP Süzgeci tarafından engellendi, başka bir sunucuya ba�
 #: src/ServerListCtrl.cpp
 msgid "Server Name"
 msgstr "Sunucu Adı"
-
-#: src/ServerListCtrl.cpp
-msgid "Port"
-msgstr "Port"
 
 #: src/ServerListCtrl.cpp
 msgid "Description"
@@ -7288,6 +7194,10 @@ msgstr "Eşe Bağlanıyor"
 #, c-format
 msgid "Connected to buddy at %s"
 msgstr "Eşe %s üzerinde bağlandı"
+
+#: src/ServerWnd.cpp
+msgid "IP address:"
+msgstr "IP :"
 
 #: src/ServerWnd.cpp
 msgid "Indexed sources:"

--- a/po/uk.po
+++ b/po/uk.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-04 12:13+0200\n"
+"POT-Creation-Date: 2026-09-05 12:01+0200\n"
 "PO-Revision-Date: 2026-09-03 11:11+0000\n"
 "Last-Translator: Oleksandr Kovalenko <alx.kovalenko@gmail.com>\n"
 "Language-Team: Ukrainian <translation@linux.org.ua>\n"
@@ -387,8 +387,7 @@ msgstr "Веб-сервер запущений з %d"
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Ви встановили запуск веб-сервера під час завантаження, але amuleweb не може бути запущено. Будь ласка, встановіть пакунок, що містить веб-сервер aMule, зберіть aMule з --enable-webserver та виконайте make install"
 
-#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
-#: src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
+#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
 msgid "ERROR"
 msgstr "ПОМИЛКА"
 
@@ -676,8 +675,7 @@ msgstr "Мережі"
 msgid "Searches"
 msgstr "Пошук"
 
-#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/Statistics.cpp
+#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/Statistics.cpp
 msgid "Downloads"
 msgstr "Звантаження"
 
@@ -761,9 +759,7 @@ msgstr "Kad: вимкнена"
 msgid "Core"
 msgstr ""
 
-#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#: src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp
-#: src/SourceListCtrl.cpp src/Statistics.cpp
+#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp src/Statistics.cpp
 msgid "Version"
 msgstr "Версія"
 
@@ -1063,11 +1059,7 @@ msgstr ""
 msgid "The remote core sent inconsistent data for \"%s\" (part status %d, expected %d). The file list may be showing the wrong information; reconnect to clear it."
 msgstr ""
 
-#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp
-#: src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp
-#: src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp
-#: src/Statistics.cpp
+#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp src/Statistics.cpp
 msgid "Unknown"
 msgstr "Невідомо"
 
@@ -1167,8 +1159,7 @@ msgstr "Помилка під час збереження файлу known.met: 
 msgid "Enter Captcha"
 msgstr ""
 
-#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp
-#: src/TransferWnd.cpp
+#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp src/TransferWnd.cpp
 msgid "Category"
 msgstr "Категорія"
 
@@ -1338,13 +1329,11 @@ msgstr "Не знайдено 'cryptkey.dat', створюємо."
 msgid "Client Details"
 msgstr "Подробиці клієнта"
 
-#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
-#: src/utils/wxCas/src/onlinesig.cpp
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
 msgid "LowID"
 msgstr "LowID"
 
-#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
-#: src/utils/wxCas/src/onlinesig.cpp
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
 msgid "HighID"
 msgstr "HighID"
 
@@ -1360,8 +1349,7 @@ msgstr "Підтримується"
 msgid "Not supported"
 msgstr "Не підтримується"
 
-#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
-#: src/TextClient.cpp
+#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp src/TextClient.cpp
 msgid "Connected"
 msgstr "З'єднано"
 
@@ -1369,28 +1357,24 @@ msgstr "З'єднано"
 msgid "Disconnected"
 msgstr "Від'єднана"
 
-#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp
-#: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f KiB/s"
 msgstr ""
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#, fuzzy
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/muuli_wdr.cpp
 msgid "Name"
-msgstr "Назва:"
+msgstr "Назва"
 
 #: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
 msgid "Software"
 msgstr ""
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#, fuzzy
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/muuli_wdr.cpp
 msgid "IP Address"
-msgstr "IP-адреса:"
+msgstr "IP-адреса"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Origin"
 msgstr ""
 
@@ -1408,14 +1392,12 @@ msgstr "Останнє отримання"
 msgid "Sessions"
 msgstr "Версія"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp
 #, fuzzy
 msgid "Upload Speed"
 msgstr "Швидкість вивантаження"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp
 #, fuzzy
 msgid "Download Speed"
 msgstr "Швидкість звантаження"
@@ -1472,13 +1454,11 @@ msgstr[2] ""
 msgid "Files"
 msgstr "Файли"
 
-#: src/ClientsListCtrl.cpp src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp
-#: src/SourceListCtrl.cpp
+#: src/ClientsListCtrl.cpp src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Uploaded"
 msgstr "Вивантажено"
 
-#: src/ClientsListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientsListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Downloaded"
 msgstr "Звантажені"
 
@@ -1565,12 +1545,11 @@ msgstr "Користувач %s (%u) заборонив доступ до пер
 msgid "File Comments"
 msgstr "Коментарі файлу"
 
-#: src/CommentDialogLst.cpp src/FriendListCtrl.cpp
+#: src/CommentDialogLst.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
 msgid "Username"
 msgstr "Ім'я користувача"
 
-#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp
-#: src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "File Name"
 msgstr "Назва файлу"
 
@@ -1578,7 +1557,7 @@ msgstr "Назва файлу"
 msgid "Rating"
 msgstr "Рейтинг"
 
-#: src/CommentDialogLst.cpp
+#: src/CommentDialogLst.cpp src/muuli_wdr.cpp
 msgid "Comment"
 msgstr "Коментар"
 
@@ -1636,18 +1615,15 @@ msgstr "Авто [висока]"
 msgid "Very low"
 msgstr "Дуже низька"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Low"
 msgstr "Низька"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Normal"
 msgstr "Звичайна"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "High"
 msgstr "Висока"
 
@@ -1671,13 +1647,11 @@ msgstr "З'єднується через сервер"
 msgid "Queue Full"
 msgstr "Черга заповнена"
 
-#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp
-#: src/muuli_wdr.cpp
+#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp src/muuli_wdr.cpp
 msgid "On Queue"
 msgstr "В черзі"
 
-#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp
-#: src/PartFile.cpp src/TransferWnd.cpp
+#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Downloading"
 msgstr "Звантажується"
 
@@ -1738,8 +1712,7 @@ msgstr "Місцевий сервер"
 msgid "Remote Server"
 msgstr "Віддалений сервер"
 
-#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp
-#: src/TextClient.cpp
+#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp src/TextClient.cpp
 msgid "Kad"
 msgstr "Kad"
 
@@ -1763,8 +1736,7 @@ msgstr "Поширювачі джерел"
 msgid "Search Result"
 msgstr "Здобутки пошуку"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp
-#: src/TransferWnd.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Completed"
 msgstr "Завершених"
 
@@ -1817,8 +1789,7 @@ msgstr ""
 msgid "Part"
 msgstr "Частина"
 
-#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp
-#: src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Size"
 msgstr "Розмір"
 
@@ -1826,8 +1797,7 @@ msgstr "Розмір"
 msgid "Transferred"
 msgstr "Переданих"
 
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
-#: src/SourceListCtrl.cpp
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp src/SourceListCtrl.cpp
 msgid "Speed"
 msgstr "Швидкість"
 
@@ -1835,13 +1805,11 @@ msgstr "Швидкість"
 msgid "Progress"
 msgstr "Перебіг"
 
-#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp
-#: src/SearchListCtrl.cpp
+#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
 msgid "Sources"
 msgstr "Джерела"
 
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp
-#: src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Priority"
 msgstr "Перевага"
 
@@ -1865,9 +1833,7 @@ msgstr "Останнє отримання"
 msgid "Auto"
 msgstr "Автоматично"
 
-#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/TransferWnd.cpp
-#: src/utils/wxCas/src/wxcasprefs.cpp
+#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/TransferWnd.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Cancel"
 msgstr "Скасувати"
 
@@ -1968,8 +1934,7 @@ msgstr "Введіть нову назву для цього файлу:"
 msgid "File rename"
 msgstr "Змінити назву файлу"
 
-#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp
-#: src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f MiB/s"
 msgstr ""
@@ -2780,13 +2745,11 @@ msgstr ""
 msgid "Start aMule automatically when I log in"
 msgstr ""
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
-#: packaging/windows/installer_strings.c
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp packaging/windows/installer_strings.c
 msgid "Register aMule for ed2k:// links"
 msgstr ""
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
-#: packaging/windows/installer_strings.c
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp packaging/windows/installer_strings.c
 msgid "Register aMule for magnet: links"
 msgstr ""
 
@@ -2812,8 +2775,7 @@ msgstr ""
 msgid "Destination folder for downloads"
 msgstr "Тека призначення для звантажень"
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
-#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Browse"
 msgstr "Переглянути"
 
@@ -3265,19 +3227,16 @@ msgstr "Завершується"
 msgid "Complete"
 msgstr "Завершений"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
-#: src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Paused"
 msgstr "Призупинений"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
-#: src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Erroneous"
 msgstr "Помилковий"
 
 # файл
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
-#: src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Waiting"
 msgstr "Очікує"
 
@@ -3447,8 +3406,7 @@ msgstr "Закрити"
 msgid "Cut"
 msgstr "Вирізати"
 
-#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp
-#: src/utils/aLinkCreator/src/alcframe.cpp
+#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy"
 msgstr "Скопіювати"
 
@@ -3456,8 +3414,7 @@ msgstr "Скопіювати"
 msgid "Paste"
 msgstr "Вставити"
 
-#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp
-#: src/utils/aLinkCreator/src/alcframe.cpp
+#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Clear"
 msgstr "Очистити"
 
@@ -3465,8 +3422,7 @@ msgstr "Очистити"
 msgid "Select All"
 msgstr "Вибрати всі"
 
-#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
-#: src/StatisticsDlg.cpp
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp src/StatisticsDlg.cpp
 msgid "KiB/s"
 msgstr ""
 
@@ -3730,10 +3686,6 @@ msgstr "З'єднаний сервер в даний час."
 msgid "Search"
 msgstr "Пошук"
 
-#: src/muuli_wdr.cpp
-msgid "Name:"
-msgstr "Назва:"
-
 #: src/muuli_wdr.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Type"
 msgstr "Тип"
@@ -3823,8 +3775,8 @@ msgid "Availability"
 msgstr "Доступність"
 
 #: src/muuli_wdr.cpp
-msgid "Filter:"
-msgstr "Фільтр:"
+msgid "Filter"
+msgstr "Фільтр"
 
 #: src/muuli_wdr.cpp
 msgid "Invert Result"
@@ -3882,6 +3834,10 @@ msgid "Clears completed downloads"
 msgstr "Очистити завершені звантаження"
 
 #: src/muuli_wdr.cpp
+msgid "Filter:"
+msgstr "Фільтр:"
+
+#: src/muuli_wdr.cpp
 #, fuzzy
 msgid "File sources:"
 msgstr "Завершених джерел"
@@ -3891,80 +3847,76 @@ msgid "General"
 msgstr "Загальні"
 
 #: src/muuli_wdr.cpp
-msgid "Full Name :"
-msgstr "Повна назва:"
+msgid "Full Name"
+msgstr "Повна назва"
 
 #: src/muuli_wdr.cpp
-msgid "met-File :"
-msgstr "met-файл:"
+msgid "met-File"
+msgstr "met-файл"
 
 #: src/muuli_wdr.cpp
-msgid "Hash :"
-msgstr "Хеш:"
+msgid "Hash"
+msgstr "Хеш"
 
 #: src/muuli_wdr.cpp
-msgid "Filesize :"
-msgstr "Розмір файлу:"
+msgid "Filesize"
+msgstr "Розмір файлу"
 
 #: src/muuli_wdr.cpp src/Statistics.cpp
 msgid "Transfer"
 msgstr "Передавання"
 
 #: src/muuli_wdr.cpp
-msgid "Partfilestatus :"
-msgstr "Стан часткових файлів:"
+msgid "Partfilestatus"
+msgstr "Стан часткових файлів"
 
 #: src/muuli_wdr.cpp
-msgid "Last seen complete :"
-msgstr "Востаннє повний:"
+msgid "Last seen complete"
+msgstr "Востаннє повний"
 
 #: src/muuli_wdr.cpp
-msgid "Found Sources :"
-msgstr "Знайдено джерел:"
+msgid "Found Sources"
+msgstr "Знайдено джерел"
 
 #: src/muuli_wdr.cpp
-msgid "Transferring Sources :"
-msgstr "Передані джерела:"
+msgid "Transferring Sources"
+msgstr "Передані джерела"
 
 #: src/muuli_wdr.cpp
-msgid "Filepart-Count :"
-msgstr "Кількість часткових файлів:"
+msgid "Filepart-Count"
+msgstr "Кількість часткових файлів"
 
 #: src/muuli_wdr.cpp
-msgid "Available :"
-msgstr "Наявні:"
+msgid "Available"
+msgstr "Наявні"
 
 #: src/muuli_wdr.cpp
-msgid "Datarate :"
-msgstr "Швидкість передачі:"
+msgid "Datarate"
+msgstr "Швидкість передачі"
 
 #: src/muuli_wdr.cpp
-msgid "Download Active Time: "
-msgstr "Чинний час звантаження: "
+msgid "Download Active Time"
+msgstr "Чинний час звантаження"
 
 #: src/muuli_wdr.cpp
-msgid "Transferred :"
-msgstr "Передані:"
-
-#: src/muuli_wdr.cpp
-msgid "Completed Size :"
-msgstr "Розмір завершених:"
+msgid "Completed Size"
+msgstr "Розмір завершених"
 
 #: src/muuli_wdr.cpp
 msgid "Intelligent Corruption Handling"
 msgstr "Розумна обробка пошкоджень"
 
 #: src/muuli_wdr.cpp
-msgid "Lost to corruption :"
-msgstr "Втрачено за рахунок спотворень:"
+msgid "Lost to corruption"
+msgstr "Втрачено за рахунок спотворень"
 
 #: src/muuli_wdr.cpp
-msgid "Gained by compression :"
-msgstr "Здобуто стисненням:"
+msgid "Gained by compression"
+msgstr "Здобуто стисненням"
 
 #: src/muuli_wdr.cpp
-msgid "Packages saved by I.C.H. :"
-msgstr "Пакунки збережено Р.О.П. :"
+msgid "Packages saved by I.C.H."
+msgstr "Пакунки збережено Р.О.П."
 
 #: src/muuli_wdr.cpp
 #, fuzzy
@@ -4006,30 +3958,30 @@ msgstr ", вивантажень: "
 msgid "Media Info"
 msgstr "Інфо Kad"
 
-#: src/muuli_wdr.cpp
-msgid "Length :"
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
+msgid "Length"
 msgstr ""
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
 #, fuzzy
-msgid "Bitrate :"
+msgid "Bitrate"
 msgstr "Без рейтингу"
 
-#: src/muuli_wdr.cpp
-msgid "Codec :"
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
+msgid "Codec"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Artist :"
+msgid "Artist"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Album :"
+msgid "Album"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Title :"
-msgstr "Назва:"
+msgid "Title"
+msgstr "Назва"
 
 #: src/muuli_wdr.cpp
 msgid "File Names"
@@ -4116,25 +4068,17 @@ msgstr "Невідомий розмір"
 msgid "Required Information"
 msgstr "Потрібна інформація"
 
-#: src/muuli_wdr.cpp
-msgid "IP Address :"
-msgstr "IP-адреса:"
-
-#: src/muuli_wdr.cpp
-msgid "Port :"
-msgstr "Порт:"
+#: src/muuli_wdr.cpp src/ServerListCtrl.cpp
+msgid "Port"
+msgstr "Порт"
 
 #: src/muuli_wdr.cpp
 msgid "Additional Information"
 msgstr "Додаткова інформація"
 
 #: src/muuli_wdr.cpp
-msgid "Username :"
-msgstr "Ім'я користувача:"
-
-#: src/muuli_wdr.cpp
-msgid "Userhash :"
-msgstr "Хеш користувача:"
+msgid "Userhash"
+msgstr "Хеш користувача"
 
 #: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Add"
@@ -4169,97 +4113,81 @@ msgid "Statistics Tree"
 msgstr "Дерево статистики"
 
 #: src/muuli_wdr.cpp
-msgid "Username:"
-msgstr "Ім'я користувача:"
+msgid "Client software"
+msgstr "Програма клієнта"
 
 #: src/muuli_wdr.cpp
-msgid "Userhash:"
-msgstr "Хеш користувача:"
+msgid "Client version"
+msgstr "Версія клієнта"
 
 #: src/muuli_wdr.cpp
-msgid "Client software:"
-msgstr "Програма клієнта:"
+msgid "User ID"
+msgstr "ID користувача"
 
 #: src/muuli_wdr.cpp
-msgid "Client version:"
-msgstr "Версія клієнта:"
-
-#: src/muuli_wdr.cpp src/ServerWnd.cpp
-msgid "IP address:"
-msgstr "IP-адреса:"
+msgid "Server IP"
+msgstr "Адреса сервера"
 
 #: src/muuli_wdr.cpp
-msgid "User ID:"
-msgstr "ID користувача:"
+msgid "Server name"
+msgstr "Назва сервера"
 
 #: src/muuli_wdr.cpp
-msgid "Server IP:"
-msgstr "Адреса сервера:"
-
-#: src/muuli_wdr.cpp
-msgid "Server name:"
-msgstr "Назва сервера:"
-
-#: src/muuli_wdr.cpp
-msgid "Obfuscation:"
-msgstr "Приховування:"
-
-#: src/muuli_wdr.cpp
-msgid "Kad:"
-msgstr "Kad:"
+msgid "Obfuscation"
+msgstr "Приховування"
 
 #: src/muuli_wdr.cpp
 msgid "Transfers to client"
 msgstr "Передано клієнту"
 
 #: src/muuli_wdr.cpp
-msgid "Current request:"
-msgstr "Поточні запити:"
+msgid "Current request"
+msgstr "Поточні запити"
 
 #: src/muuli_wdr.cpp
-msgid "Average upload rate:"
-msgstr "Середня швидкість вивантаження:"
+msgid "Average upload rate"
+msgstr "Середня швидкість вивантаження"
 
 #: src/muuli_wdr.cpp
-msgid "Average download rate:"
-msgstr "Середня швидкість звантаження:"
+msgid "Average download rate"
+msgstr "Середня швидкість звантаження"
 
 #: src/muuli_wdr.cpp
-msgid "Uploaded (session):"
-msgstr "Вивантажено (сесія):"
+msgid "Uploaded (session)"
+msgstr "Вивантажено (сесія)"
 
 #: src/muuli_wdr.cpp
-msgid "Downloaded (session):"
-msgstr "Звантажено (сесія):"
+msgid "Downloaded (session)"
+msgstr "Звантажено (сесія)"
 
 #: src/muuli_wdr.cpp
-msgid "Uploaded (total):"
-msgstr "Вивантажено (всього):"
+msgid "Uploaded (total)"
+msgstr "Вивантажено (всього)"
 
 #: src/muuli_wdr.cpp
-msgid "Downloaded (total):"
-msgstr "Звантажено (всього):"
+msgid "Downloaded (total)"
+msgstr "Звантажено (всього)"
 
 #: src/muuli_wdr.cpp
 msgid "Scores"
 msgstr "Рахунок"
 
 #: src/muuli_wdr.cpp
-msgid "DL/UP modifier:"
-msgstr "Модифікатор звантаження/вивантаження:"
+msgid "DL/UP modifier"
+msgstr "Модифікатор звантаження/вивантаження"
 
 #: src/muuli_wdr.cpp
-msgid "Secure ident:"
-msgstr "Безпечна ідентифікація:"
+msgid "Secure ident"
+msgstr "Безпечна ідентифікація"
 
 #: src/muuli_wdr.cpp
 #, fuzzy
-msgid "Queue rank:"
+msgid "Queue rank"
 msgstr "В черзі"
 
 #: src/muuli_wdr.cpp
-msgid "Queue score:"
-msgstr "Рахунок черги:"
+msgid "Queue score"
+msgstr "Рахунок черги"
 
 #: src/muuli_wdr.cpp
 msgid "Nick"
@@ -5055,16 +4983,12 @@ msgid "Reset any changes made to the preferences."
 msgstr "Скинути всі зміни внесені в налаштування."
 
 #: src/muuli_wdr.cpp
-msgid "Comment :"
-msgstr "Коментар:"
+msgid "Incoming Dir"
+msgstr "Вхідна тека"
 
 #: src/muuli_wdr.cpp
-msgid "Incoming Dir :"
-msgstr "Вхідна тека:"
-
-#: src/muuli_wdr.cpp
-msgid "Change priority for new assigned files :"
-msgstr "Змінити перевагу для нового призначеного файлу:"
+msgid "Change priority for new assigned files"
+msgstr "Змінити перевагу для нового призначеного файлу"
 
 #: src/muuli_wdr.cpp
 #, fuzzy
@@ -5072,8 +4996,8 @@ msgid "Don't change"
 msgstr "Не змінювати"
 
 #: src/muuli_wdr.cpp
-msgid "Select color for this Category (currently selected) :"
-msgstr "Виберіть колір для цієї категорії (зараз вибрано):"
+msgid "Select color for this Category (currently selected)"
+msgstr "Виберіть колір для цієї категорії (зараз вибрано)"
 
 #: src/muuli_wdr.cpp
 msgid "Click this button to reset the log."
@@ -5158,10 +5082,6 @@ msgstr ""
 #, fuzzy
 msgid "Enter the IP of the node here, using the x.x.x.x format."
 msgstr "Тут введіть IP-адресу сервера, використовуючи формат x.x.x.x."
-
-#: src/muuli_wdr.cpp
-msgid "Port:"
-msgstr "Порт:"
 
 #: src/muuli_wdr.cpp
 msgid "Use Secure User Identification"
@@ -5430,20 +5350,20 @@ msgid "Enable/disable proxy support"
 msgstr "Ввімкнути/вимкнути підтримку проксі"
 
 #: src/muuli_wdr.cpp
-msgid "Proxy type:"
-msgstr "Тип проксі:"
+msgid "Proxy type"
+msgstr "Тип проксі"
 
 #: src/muuli_wdr.cpp
-msgid "Proxy host:"
-msgstr "Хост проксі:"
+msgid "Proxy host"
+msgstr "Хост проксі"
 
 #: src/muuli_wdr.cpp
 msgid "The proxy host name"
 msgstr "Ім'я хосту проксі"
 
 #: src/muuli_wdr.cpp
-msgid "Proxy port:"
-msgstr "Порт проксі:"
+msgid "Proxy port"
+msgstr "Порт проксі"
 
 #: src/muuli_wdr.cpp
 msgid "The proxy port"
@@ -5458,16 +5378,8 @@ msgid "Enable/disable username/password authentication"
 msgstr "Ввімкнути/вимкнути аутентифікацію з ім'ям/паролем"
 
 #: src/muuli_wdr.cpp
-msgid "Username: "
-msgstr "Ім'я користувача: "
-
-#: src/muuli_wdr.cpp
 msgid "The username to use to connect to the proxy"
 msgstr "Ім'я користувача для з'єднання з проксі"
-
-#: src/muuli_wdr.cpp
-msgid "Password:"
-msgstr "Пароль:"
 
 #: src/muuli_wdr.cpp
 msgid "The password to use to connect to the proxy"
@@ -5651,6 +5563,15 @@ msgstr "год"
 #: src/OtherFunctions.cpp
 msgid "days"
 msgstr "діб"
+
+#. TRANSLATORS:
+#. Punctuation for a "label: value" pair. %s is the already-translated
+#. label. Place the colon as your language requires -- e.g. "%s :" with a
+#. space in French, "%s:" without one in Russian and English.
+#: src/OtherFunctions.cpp
+#, c-format
+msgid "%s:"
+msgstr ""
 
 #: src/OtherFunctions.cpp
 msgid "all"
@@ -6708,8 +6629,7 @@ msgstr ""
 msgid "Confirm shared folders"
 msgstr "Спільні теки"
 
-#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp
-#: src/SharedFilesReloadProgress.cpp
+#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp src/SharedFilesReloadProgress.cpp
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "Перезавантажити ваші спільні файли"
@@ -6842,19 +6762,6 @@ msgstr "Помилка оновлення GeoIP.dat"
 #: src/SearchListCtrl.cpp
 msgid "FileID"
 msgstr "ID файлу"
-
-#: src/SearchListCtrl.cpp
-msgid "Length"
-msgstr ""
-
-#: src/SearchListCtrl.cpp
-#, fuzzy
-msgid "Bitrate"
-msgstr "Без рейтингу"
-
-#: src/SearchListCtrl.cpp
-msgid "Codec"
-msgstr ""
 
 #: src/SearchListCtrl.cpp
 msgid "Expand all"
@@ -7145,10 +7052,6 @@ msgstr "Місцевий сервер відфільтрований IPFilters, 
 #: src/ServerListCtrl.cpp
 msgid "Server Name"
 msgstr "Назва сервера"
-
-#: src/ServerListCtrl.cpp
-msgid "Port"
-msgstr "Порт"
 
 #: src/ServerListCtrl.cpp
 msgid "Description"
@@ -7445,6 +7348,10 @@ msgstr "З'єднання з другом"
 #, c-format
 msgid "Connected to buddy at %s"
 msgstr "З'єднання з другом на %s"
+
+#: src/ServerWnd.cpp
+msgid "IP address:"
+msgstr "IP-адреса:"
 
 #: src/ServerWnd.cpp
 msgid "Indexed sources:"

--- a/po/vi.po
+++ b/po/vi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-04 12:13+0200\n"
+"POT-Creation-Date: 2026-09-05 12:01+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -1316,7 +1316,7 @@ msgstr ""
 msgid "%.1f KiB/s"
 msgstr ""
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/muuli_wdr.cpp
 msgid "Name"
 msgstr ""
 
@@ -1324,7 +1324,7 @@ msgstr ""
 msgid "Software"
 msgstr ""
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/muuli_wdr.cpp
 msgid "IP Address"
 msgstr ""
 
@@ -1491,7 +1491,7 @@ msgstr ""
 msgid "File Comments"
 msgstr ""
 
-#: src/CommentDialogLst.cpp src/FriendListCtrl.cpp
+#: src/CommentDialogLst.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
 msgid "Username"
 msgstr ""
 
@@ -1504,7 +1504,7 @@ msgstr ""
 msgid "Rating"
 msgstr ""
 
-#: src/CommentDialogLst.cpp
+#: src/CommentDialogLst.cpp src/muuli_wdr.cpp
 msgid "Comment"
 msgstr ""
 
@@ -3569,10 +3569,6 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
-#: src/muuli_wdr.cpp
-msgid "Name:"
-msgstr ""
-
 #: src/muuli_wdr.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Type"
 msgstr ""
@@ -3662,7 +3658,7 @@ msgid "Availability"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Filter:"
+msgid "Filter"
 msgstr ""
 
 #: src/muuli_wdr.cpp
@@ -3718,6 +3714,10 @@ msgid "Clears completed downloads"
 msgstr ""
 
 #: src/muuli_wdr.cpp
+msgid "Filter:"
+msgstr ""
+
+#: src/muuli_wdr.cpp
 msgid "File sources:"
 msgstr ""
 
@@ -3726,19 +3726,19 @@ msgid "General"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Full Name :"
+msgid "Full Name"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "met-File :"
+msgid "met-File"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Hash :"
+msgid "Hash"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Filesize :"
+msgid "Filesize"
 msgstr ""
 
 #: src/muuli_wdr.cpp src/Statistics.cpp
@@ -3746,43 +3746,39 @@ msgid "Transfer"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Partfilestatus :"
+msgid "Partfilestatus"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Last seen complete :"
+msgid "Last seen complete"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Found Sources :"
+msgid "Found Sources"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Transferring Sources :"
+msgid "Transferring Sources"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Filepart-Count :"
+msgid "Filepart-Count"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Available :"
+msgid "Available"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Datarate :"
+msgid "Datarate"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Download Active Time: "
+msgid "Download Active Time"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Transferred :"
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "Completed Size :"
+msgid "Completed Size"
 msgstr ""
 
 #: src/muuli_wdr.cpp
@@ -3790,15 +3786,15 @@ msgid "Intelligent Corruption Handling"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Lost to corruption :"
+msgid "Lost to corruption"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Gained by compression :"
+msgid "Gained by compression"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Packages saved by I.C.H. :"
+msgid "Packages saved by I.C.H."
 msgstr ""
 
 #: src/muuli_wdr.cpp
@@ -3837,28 +3833,28 @@ msgstr ""
 msgid "Media Info"
 msgstr ""
 
-#: src/muuli_wdr.cpp
-msgid "Length :"
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
+msgid "Length"
+msgstr ""
+
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
+msgid "Bitrate"
+msgstr ""
+
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
+msgid "Codec"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Bitrate :"
+msgid "Artist"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Codec :"
+msgid "Album"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Artist :"
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "Album :"
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "Title :"
+msgid "Title"
 msgstr ""
 
 #: src/muuli_wdr.cpp
@@ -3943,12 +3939,8 @@ msgstr ""
 msgid "Required Information"
 msgstr ""
 
-#: src/muuli_wdr.cpp
-msgid "IP Address :"
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "Port :"
+#: src/muuli_wdr.cpp src/ServerListCtrl.cpp
+msgid "Port"
 msgstr ""
 
 #: src/muuli_wdr.cpp
@@ -3956,11 +3948,7 @@ msgid "Additional Information"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Username :"
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "Userhash :"
+msgid "Userhash"
 msgstr ""
 
 #: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
@@ -3996,43 +3984,27 @@ msgid "Statistics Tree"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Username:"
+msgid "Client software"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Userhash:"
+msgid "Client version"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Client software:"
+msgid "User ID"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Client version:"
-msgstr ""
-
-#: src/muuli_wdr.cpp src/ServerWnd.cpp
-msgid "IP address:"
+msgid "Server IP"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "User ID:"
+msgid "Server name"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Server IP:"
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "Server name:"
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "Obfuscation:"
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "Kad:"
+msgid "Obfuscation"
 msgstr ""
 
 #: src/muuli_wdr.cpp
@@ -4040,31 +4012,31 @@ msgid "Transfers to client"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Current request:"
+msgid "Current request"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Average upload rate:"
+msgid "Average upload rate"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Average download rate:"
+msgid "Average download rate"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Uploaded (session):"
+msgid "Uploaded (session)"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Downloaded (session):"
+msgid "Downloaded (session)"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Uploaded (total):"
+msgid "Uploaded (total)"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Downloaded (total):"
+msgid "Downloaded (total)"
 msgstr ""
 
 #: src/muuli_wdr.cpp
@@ -4072,19 +4044,19 @@ msgid "Scores"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "DL/UP modifier:"
+msgid "DL/UP modifier"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Secure ident:"
+msgid "Secure ident"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Queue rank:"
+msgid "Queue rank"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Queue score:"
+msgid "Queue score"
 msgstr ""
 
 #: src/muuli_wdr.cpp
@@ -4862,15 +4834,11 @@ msgid "Reset any changes made to the preferences."
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Comment :"
+msgid "Incoming Dir"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Incoming Dir :"
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "Change priority for new assigned files :"
+msgid "Change priority for new assigned files"
 msgstr ""
 
 #: src/muuli_wdr.cpp
@@ -4878,7 +4846,7 @@ msgid "Don't change"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Select color for this Category (currently selected) :"
+msgid "Select color for this Category (currently selected)"
 msgstr ""
 
 #: src/muuli_wdr.cpp
@@ -4959,10 +4927,6 @@ msgstr ""
 
 #: src/muuli_wdr.cpp
 msgid "Enter the IP of the node here, using the x.x.x.x format."
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "Port:"
 msgstr ""
 
 #: src/muuli_wdr.cpp
@@ -5227,11 +5191,11 @@ msgid "Enable/disable proxy support"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Proxy type:"
+msgid "Proxy type"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Proxy host:"
+msgid "Proxy host"
 msgstr ""
 
 #: src/muuli_wdr.cpp
@@ -5239,7 +5203,7 @@ msgid "The proxy host name"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Proxy port:"
+msgid "Proxy port"
 msgstr ""
 
 #: src/muuli_wdr.cpp
@@ -5255,15 +5219,7 @@ msgid "Enable/disable username/password authentication"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Username: "
-msgstr ""
-
-#: src/muuli_wdr.cpp
 msgid "The username to use to connect to the proxy"
-msgstr ""
-
-#: src/muuli_wdr.cpp
-msgid "Password:"
 msgstr ""
 
 #: src/muuli_wdr.cpp
@@ -5436,6 +5392,15 @@ msgstr ""
 
 #: src/OtherFunctions.cpp
 msgid "days"
+msgstr ""
+
+#. TRANSLATORS:
+#. Punctuation for a "label: value" pair. %s is the already-translated
+#. label. Place the colon as your language requires -- e.g. "%s :" with a
+#. space in French, "%s:" without one in Russian and English.
+#: src/OtherFunctions.cpp
+#, c-format
+msgid "%s:"
 msgstr ""
 
 #: src/OtherFunctions.cpp
@@ -6559,18 +6524,6 @@ msgid "FileID"
 msgstr ""
 
 #: src/SearchListCtrl.cpp
-msgid "Length"
-msgstr ""
-
-#: src/SearchListCtrl.cpp
-msgid "Bitrate"
-msgstr ""
-
-#: src/SearchListCtrl.cpp
-msgid "Codec"
-msgstr ""
-
-#: src/SearchListCtrl.cpp
 msgid "Expand all"
 msgstr ""
 
@@ -6845,10 +6798,6 @@ msgstr ""
 
 #: src/ServerListCtrl.cpp
 msgid "Server Name"
-msgstr ""
-
-#: src/ServerListCtrl.cpp
-msgid "Port"
 msgstr ""
 
 #: src/ServerListCtrl.cpp
@@ -7135,6 +7084,10 @@ msgstr ""
 #: src/ServerWnd.cpp
 #, c-format
 msgid "Connected to buddy at %s"
+msgstr ""
+
+#: src/ServerWnd.cpp
+msgid "IP address:"
 msgstr ""
 
 #: src/ServerWnd.cpp

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-04 12:13+0200\n"
+"POT-Creation-Date: 2026-09-05 12:01+0200\n"
 "PO-Revision-Date: 2026-09-03 11:12+0000\n"
 "Last-Translator: Mike Akiba <mike2718@gmail.com>\n"
 "Language-Team: Chinese Simplified <kde-i18n-doc@kde.org>\n"
@@ -389,8 +389,7 @@ msgstr "web 服务器正在运行，pid 为 %d"
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "您要求启动时运行 Web 服务器，但 amuleweb 程序无法运行， 请先安装包含 amule web 服务器的 aMule 包，或者使用 -DBUILD_WEBSERVER=YES 选项从源码构建 aMule 并安装它。"
 
-#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
-#: src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
+#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
 msgid "ERROR"
 msgstr "错误"
 
@@ -676,8 +675,7 @@ msgstr "网络"
 msgid "Searches"
 msgstr "搜索"
 
-#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/Statistics.cpp
+#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/Statistics.cpp
 msgid "Downloads"
 msgstr "下载"
 
@@ -765,9 +763,7 @@ msgstr "Kad: 关闭"
 msgid "Core"
 msgstr "核心"
 
-#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#: src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp
-#: src/SourceListCtrl.cpp src/Statistics.cpp
+#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp src/Statistics.cpp
 msgid "Version"
 msgstr "版本"
 
@@ -1064,11 +1060,7 @@ msgstr "无法创建 “%s” 目录用于 “%s” 分类，保留 “%s” 目
 msgid "The remote core sent inconsistent data for \"%s\" (part status %d, expected %d). The file list may be showing the wrong information; reconnect to clear it."
 msgstr "远程核心发送了不一致的 \"%s\" 数据（part 状态 %d，预期 %d）。 文件列表可能显示错误信息；重连清除它。"
 
-#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp
-#: src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp
-#: src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp
-#: src/Statistics.cpp
+#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp src/Statistics.cpp
 msgid "Unknown"
 msgstr "未知"
 
@@ -1165,8 +1157,7 @@ msgstr "保存 %s 文件时发生错误：%s"
 msgid "Enter Captcha"
 msgstr "输入验证码"
 
-#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp
-#: src/TransferWnd.cpp
+#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp src/TransferWnd.cpp
 msgid "Category"
 msgstr "分类"
 
@@ -1329,13 +1320,11 @@ msgstr "文件 'crytkey.dat' 未找到，正在创建。"
 msgid "Client Details"
 msgstr "客户端详细信息"
 
-#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
-#: src/utils/wxCas/src/onlinesig.cpp
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
 msgid "LowID"
 msgstr "Low ID"
 
-#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
-#: src/utils/wxCas/src/onlinesig.cpp
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
 msgid "HighID"
 msgstr "High ID"
 
@@ -1351,8 +1340,7 @@ msgstr "已支持"
 msgid "Not supported"
 msgstr "不支持"
 
-#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
-#: src/TextClient.cpp
+#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp src/TextClient.cpp
 msgid "Connected"
 msgstr "已连接"
 
@@ -1360,13 +1348,12 @@ msgstr "已连接"
 msgid "Disconnected"
 msgstr "断开连接"
 
-#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp
-#: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f KiB/s"
 msgstr "%.1f KiB/s"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/muuli_wdr.cpp
 msgid "Name"
 msgstr "名称"
 
@@ -1374,12 +1361,11 @@ msgstr "名称"
 msgid "Software"
 msgstr "软件"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/muuli_wdr.cpp
 msgid "IP Address"
 msgstr "IP 地址"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Origin"
 msgstr "来源"
 
@@ -1395,13 +1381,11 @@ msgstr "上次看到"
 msgid "Sessions"
 msgstr "会话"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp
 msgid "Upload Speed"
 msgstr "上传速度"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp
 msgid "Download Speed"
 msgstr "下载速度"
 
@@ -1452,13 +1436,11 @@ msgstr[1] "无法添加 %u 个链接（详情请查看日志）"
 msgid "Files"
 msgstr "文件"
 
-#: src/ClientsListCtrl.cpp src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp
-#: src/SourceListCtrl.cpp
+#: src/ClientsListCtrl.cpp src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Uploaded"
 msgstr "已上传"
 
-#: src/ClientsListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientsListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Downloaded"
 msgstr "已下载"
 
@@ -1542,12 +1524,11 @@ msgstr "用户 %s (%u) 拒绝了目录/文件列表的访问"
 msgid "File Comments"
 msgstr "文件评论"
 
-#: src/CommentDialogLst.cpp src/FriendListCtrl.cpp
+#: src/CommentDialogLst.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
 msgid "Username"
 msgstr "用户名"
 
-#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp
-#: src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "File Name"
 msgstr "文件名"
 
@@ -1555,7 +1536,7 @@ msgstr "文件名"
 msgid "Rating"
 msgstr "评价"
 
-#: src/CommentDialogLst.cpp
+#: src/CommentDialogLst.cpp src/muuli_wdr.cpp
 msgid "Comment"
 msgstr "评论"
 
@@ -1608,18 +1589,15 @@ msgstr "自动 [高]"
 msgid "Very low"
 msgstr "极低"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Low"
 msgstr "低"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Normal"
 msgstr "普通"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "High"
 msgstr "高"
 
@@ -1643,13 +1621,11 @@ msgstr "通过服务器连接中"
 msgid "Queue Full"
 msgstr "队列已满"
 
-#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp
-#: src/muuli_wdr.cpp
+#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp src/muuli_wdr.cpp
 msgid "On Queue"
 msgstr "正在排队"
 
-#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp
-#: src/PartFile.cpp src/TransferWnd.cpp
+#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Downloading"
 msgstr "正在下载"
 
@@ -1709,8 +1685,7 @@ msgstr "本地服务器"
 msgid "Remote Server"
 msgstr "远程服务器"
 
-#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp
-#: src/TextClient.cpp
+#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp src/TextClient.cpp
 msgid "Kad"
 msgstr "Kad"
 
@@ -1734,8 +1709,7 @@ msgstr "资源种子"
 msgid "Search Result"
 msgstr "搜索结果"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp
-#: src/TransferWnd.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Completed"
 msgstr "已完成"
 
@@ -1787,8 +1761,7 @@ msgstr "无法在递归共享中修改"
 msgid "Part"
 msgstr "块"
 
-#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp
-#: src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Size"
 msgstr "大小"
 
@@ -1796,8 +1769,7 @@ msgstr "大小"
 msgid "Transferred"
 msgstr "已传输"
 
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
-#: src/SourceListCtrl.cpp
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp src/SourceListCtrl.cpp
 msgid "Speed"
 msgstr "速度"
 
@@ -1805,13 +1777,11 @@ msgstr "速度"
 msgid "Progress"
 msgstr "进度"
 
-#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp
-#: src/SearchListCtrl.cpp
+#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
 msgid "Sources"
 msgstr "源"
 
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp
-#: src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Priority"
 msgstr "优先级"
 
@@ -1835,9 +1805,7 @@ msgstr "最后一次下载"
 msgid "Auto"
 msgstr "自动"
 
-#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/TransferWnd.cpp
-#: src/utils/wxCas/src/wxcasprefs.cpp
+#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/TransferWnd.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Cancel"
 msgstr "取消"
 
@@ -1938,8 +1906,7 @@ msgstr "请输入新文件名:"
 msgid "File rename"
 msgstr "重命名文件"
 
-#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp
-#: src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f MiB/s"
 msgstr "%.1f MiB/s"
@@ -2742,13 +2709,11 @@ msgstr ""
 msgid "Start aMule automatically when I log in"
 msgstr "登录时自动启动 aMule"
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
-#: packaging/windows/installer_strings.c
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp packaging/windows/installer_strings.c
 msgid "Register aMule for ed2k:// links"
 msgstr "将 aMule 注册为打开 ed2k:// 链接的应用"
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
-#: packaging/windows/installer_strings.c
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp packaging/windows/installer_strings.c
 msgid "Register aMule for magnet: links"
 msgstr "将 aMule 注册为打开 magnet: 链接的应用"
 
@@ -2776,8 +2741,7 @@ msgstr ""
 msgid "Destination folder for downloads"
 msgstr "存放下载文件的文件夹"
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
-#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Browse"
 msgstr "浏览"
 
@@ -3221,18 +3185,15 @@ msgstr "即将完成"
 msgid "Complete"
 msgstr "已完成"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
-#: src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Paused"
 msgstr "已暂停"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
-#: src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Erroneous"
 msgstr "已出错"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
-#: src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Waiting"
 msgstr "等待中"
 
@@ -3394,8 +3355,7 @@ msgstr "关闭"
 msgid "Cut"
 msgstr "剪切"
 
-#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp
-#: src/utils/aLinkCreator/src/alcframe.cpp
+#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy"
 msgstr "复制"
 
@@ -3403,8 +3363,7 @@ msgstr "复制"
 msgid "Paste"
 msgstr "粘贴"
 
-#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp
-#: src/utils/aLinkCreator/src/alcframe.cpp
+#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Clear"
 msgstr "清除"
 
@@ -3412,8 +3371,7 @@ msgstr "清除"
 msgid "Select All"
 msgstr "全选"
 
-#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
-#: src/StatisticsDlg.cpp
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp src/StatisticsDlg.cpp
 msgid "KiB/s"
 msgstr "KiB/s"
 
@@ -3668,10 +3626,6 @@ msgstr "现在已连接的服务器。"
 msgid "Search"
 msgstr "搜索"
 
-#: src/muuli_wdr.cpp
-msgid "Name:"
-msgstr "名称:"
-
 #: src/muuli_wdr.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Type"
 msgstr "类型"
@@ -3761,8 +3715,8 @@ msgid "Availability"
 msgstr "可用来源数"
 
 #: src/muuli_wdr.cpp
-msgid "Filter:"
-msgstr "过滤："
+msgid "Filter"
+msgstr "过滤"
 
 #: src/muuli_wdr.cpp
 msgid "Invert Result"
@@ -3817,6 +3771,10 @@ msgid "Clears completed downloads"
 msgstr "清除已完成的下载"
 
 #: src/muuli_wdr.cpp
+msgid "Filter:"
+msgstr "过滤："
+
+#: src/muuli_wdr.cpp
 msgid "File sources:"
 msgstr "文件源:"
 
@@ -3825,80 +3783,76 @@ msgid "General"
 msgstr "常规"
 
 #: src/muuli_wdr.cpp
-msgid "Full Name :"
-msgstr "全名 :"
+msgid "Full Name"
+msgstr "全名"
 
 #: src/muuli_wdr.cpp
-msgid "met-File :"
-msgstr ".met 文件 :"
+msgid "met-File"
+msgstr ".met 文件"
 
 #: src/muuli_wdr.cpp
-msgid "Hash :"
-msgstr "eD2k 文件哈希 :"
+msgid "Hash"
+msgstr "eD2k 文件哈希"
 
 #: src/muuli_wdr.cpp
-msgid "Filesize :"
-msgstr "文件大小 :"
+msgid "Filesize"
+msgstr "文件大小"
 
 #: src/muuli_wdr.cpp src/Statistics.cpp
 msgid "Transfer"
 msgstr "传输"
 
 #: src/muuli_wdr.cpp
-msgid "Partfilestatus :"
-msgstr "part 文件状态 :"
+msgid "Partfilestatus"
+msgstr "part 文件状态"
 
 #: src/muuli_wdr.cpp
-msgid "Last seen complete :"
-msgstr "最后发现完成的文件 :"
+msgid "Last seen complete"
+msgstr "最后发现完成的文件"
 
 #: src/muuli_wdr.cpp
-msgid "Found Sources :"
-msgstr "已发现源 :"
+msgid "Found Sources"
+msgstr "已发现源"
 
 #: src/muuli_wdr.cpp
-msgid "Transferring Sources :"
-msgstr "正在传输的源 :"
+msgid "Transferring Sources"
+msgstr "正在传输的源"
 
 #: src/muuli_wdr.cpp
-msgid "Filepart-Count :"
-msgstr "文件分块数量 :"
+msgid "Filepart-Count"
+msgstr "文件分块数量"
 
 #: src/muuli_wdr.cpp
-msgid "Available :"
-msgstr "可用 :"
+msgid "Available"
+msgstr "可用"
 
 #: src/muuli_wdr.cpp
-msgid "Datarate :"
-msgstr "数据率 :"
+msgid "Datarate"
+msgstr "数据率"
 
 #: src/muuli_wdr.cpp
-msgid "Download Active Time: "
-msgstr "下载活动时间: "
+msgid "Download Active Time"
+msgstr "下载活动时间"
 
 #: src/muuli_wdr.cpp
-msgid "Transferred :"
-msgstr "已传输 :"
-
-#: src/muuli_wdr.cpp
-msgid "Completed Size :"
-msgstr "已完成大小 :"
+msgid "Completed Size"
+msgstr "已完成大小"
 
 #: src/muuli_wdr.cpp
 msgid "Intelligent Corruption Handling"
 msgstr "智能损坏数据处理"
 
 #: src/muuli_wdr.cpp
-msgid "Lost to corruption :"
-msgstr "因数据损坏而丢失 :"
+msgid "Lost to corruption"
+msgstr "因数据损坏而丢失"
 
 #: src/muuli_wdr.cpp
-msgid "Gained by compression :"
-msgstr "压缩效益 :"
+msgid "Gained by compression"
+msgstr "压缩效益"
 
 #: src/muuli_wdr.cpp
-msgid "Packages saved by I.C.H. :"
-msgstr "由 I.C.H. 挽救的数据包 :"
+msgid "Packages saved by I.C.H."
+msgstr "由 I.C.H. 挽救的数据包"
 
 #: src/muuli_wdr.cpp
 msgid "Sharing"
@@ -3936,29 +3890,29 @@ msgstr "最后上传"
 msgid "Media Info"
 msgstr "媒体信息"
 
-#: src/muuli_wdr.cpp
-msgid "Length :"
-msgstr "长度："
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
+msgid "Length"
+msgstr "长度"
+
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
+msgid "Bitrate"
+msgstr "比特率"
+
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
+msgid "Codec"
+msgstr "编解码器"
 
 #: src/muuli_wdr.cpp
-msgid "Bitrate :"
-msgstr "比特率："
+msgid "Artist"
+msgstr "艺术家"
 
 #: src/muuli_wdr.cpp
-msgid "Codec :"
-msgstr "编解码器："
+msgid "Album"
+msgstr "专辑"
 
 #: src/muuli_wdr.cpp
-msgid "Artist :"
-msgstr "艺术家："
-
-#: src/muuli_wdr.cpp
-msgid "Album :"
-msgstr "专辑："
-
-#: src/muuli_wdr.cpp
-msgid "Title :"
-msgstr "标题 :"
+msgid "Title"
+msgstr "标题"
 
 #: src/muuli_wdr.cpp
 msgid "File Names"
@@ -4044,25 +3998,17 @@ msgstr "未知大小"
 msgid "Required Information"
 msgstr "必填信息"
 
-#: src/muuli_wdr.cpp
-msgid "IP Address :"
-msgstr "IP 地址 :"
-
-#: src/muuli_wdr.cpp
-msgid "Port :"
-msgstr "端口 :"
+#: src/muuli_wdr.cpp src/ServerListCtrl.cpp
+msgid "Port"
+msgstr "端口"
 
 #: src/muuli_wdr.cpp
 msgid "Additional Information"
 msgstr "附加信息"
 
 #: src/muuli_wdr.cpp
-msgid "Username :"
-msgstr "用户名 :"
-
-#: src/muuli_wdr.cpp
-msgid "Userhash :"
-msgstr "用户哈希 :"
+msgid "Userhash"
+msgstr "用户哈希"
 
 #: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Add"
@@ -4097,96 +4043,80 @@ msgid "Statistics Tree"
 msgstr "统计树"
 
 #: src/muuli_wdr.cpp
-msgid "Username:"
-msgstr "用户名："
+msgid "Client software"
+msgstr "客户端软件"
 
 #: src/muuli_wdr.cpp
-msgid "Userhash:"
-msgstr "用户哈希:"
+msgid "Client version"
+msgstr "客户端版本"
 
 #: src/muuli_wdr.cpp
-msgid "Client software:"
-msgstr "客户端软件:"
+msgid "User ID"
+msgstr "用户 ID"
 
 #: src/muuli_wdr.cpp
-msgid "Client version:"
-msgstr "客户端版本:"
-
-#: src/muuli_wdr.cpp src/ServerWnd.cpp
-msgid "IP address:"
-msgstr "IP 地址:"
+msgid "Server IP"
+msgstr "服务器 IP"
 
 #: src/muuli_wdr.cpp
-msgid "User ID:"
-msgstr "用户 ID:"
+msgid "Server name"
+msgstr "服务器名称"
 
 #: src/muuli_wdr.cpp
-msgid "Server IP:"
-msgstr "服务器 IP:"
-
-#: src/muuli_wdr.cpp
-msgid "Server name:"
-msgstr "服务器名称:"
-
-#: src/muuli_wdr.cpp
-msgid "Obfuscation:"
-msgstr "模糊协议:"
-
-#: src/muuli_wdr.cpp
-msgid "Kad:"
-msgstr "Kad:"
+msgid "Obfuscation"
+msgstr "模糊协议"
 
 #: src/muuli_wdr.cpp
 msgid "Transfers to client"
 msgstr "到客户端的传输"
 
 #: src/muuli_wdr.cpp
-msgid "Current request:"
-msgstr "当前请求:"
+msgid "Current request"
+msgstr "当前请求"
 
 #: src/muuli_wdr.cpp
-msgid "Average upload rate:"
-msgstr "平均上传速度:"
+msgid "Average upload rate"
+msgstr "平均上传速度"
 
 #: src/muuli_wdr.cpp
-msgid "Average download rate:"
-msgstr "平均下载速度:"
+msgid "Average download rate"
+msgstr "平均下载速度"
 
 #: src/muuli_wdr.cpp
-msgid "Uploaded (session):"
-msgstr "上传 (本次运行):"
+msgid "Uploaded (session)"
+msgstr "上传 (本次运行)"
 
 #: src/muuli_wdr.cpp
-msgid "Downloaded (session):"
-msgstr "下载 (本次运行):"
+msgid "Downloaded (session)"
+msgstr "下载 (本次运行)"
 
 #: src/muuli_wdr.cpp
-msgid "Uploaded (total):"
-msgstr "上传 (总共):"
+msgid "Uploaded (total)"
+msgstr "上传 (总共)"
 
 #: src/muuli_wdr.cpp
-msgid "Downloaded (total):"
-msgstr "下载 (总共):"
+msgid "Downloaded (total)"
+msgstr "下载 (总共)"
 
 #: src/muuli_wdr.cpp
 msgid "Scores"
 msgstr "得分"
 
 #: src/muuli_wdr.cpp
-msgid "DL/UP modifier:"
-msgstr "下载/上传比率:"
+msgid "DL/UP modifier"
+msgstr "下载/上传比率"
 
 #: src/muuli_wdr.cpp
-msgid "Secure ident:"
-msgstr "安全身份认证:"
+msgid "Secure ident"
+msgstr "安全身份认证"
 
 #: src/muuli_wdr.cpp
-msgid "Queue rank:"
-msgstr "队列等级:"
+msgid "Queue rank"
+msgstr "队列等级"
 
 #: src/muuli_wdr.cpp
-msgid "Queue score:"
-msgstr "队列积分:"
+msgid "Queue score"
+msgstr "队列积分"
 
 #: src/muuli_wdr.cpp
 msgid "Nick"
@@ -4965,24 +4895,20 @@ msgid "Reset any changes made to the preferences."
 msgstr "取消所有首选项改动。"
 
 #: src/muuli_wdr.cpp
-msgid "Comment :"
-msgstr "注释 :"
+msgid "Incoming Dir"
+msgstr "下载目录"
 
 #: src/muuli_wdr.cpp
-msgid "Incoming Dir :"
-msgstr "下载目录 :"
-
-#: src/muuli_wdr.cpp
-msgid "Change priority for new assigned files :"
-msgstr "设置新加入的文件优先级为 :"
+msgid "Change priority for new assigned files"
+msgstr "设置新加入的文件优先级为"
 
 #: src/muuli_wdr.cpp
 msgid "Don't change"
 msgstr "不要改变"
 
 #: src/muuli_wdr.cpp
-msgid "Select color for this Category (currently selected) :"
-msgstr "选择该分类颜色 (当前选择) :"
+msgid "Select color for this Category (currently selected)"
+msgstr "选择该分类颜色 (当前选择)"
 
 #: src/muuli_wdr.cpp
 msgid "Click this button to reset the log."
@@ -5063,10 +4989,6 @@ msgstr "从 node: IP 启动"
 #: src/muuli_wdr.cpp
 msgid "Enter the IP of the node here, using the x.x.x.x format."
 msgstr "在此输入节点的 IP 地址 (x.x.x.x 格式)。"
-
-#: src/muuli_wdr.cpp
-msgid "Port:"
-msgstr "端口："
 
 #: src/muuli_wdr.cpp
 msgid "Use Secure User Identification"
@@ -5343,20 +5265,20 @@ msgid "Enable/disable proxy support"
 msgstr "启用/禁用代理支持"
 
 #: src/muuli_wdr.cpp
-msgid "Proxy type:"
-msgstr "代理类型:"
+msgid "Proxy type"
+msgstr "代理类型"
 
 #: src/muuli_wdr.cpp
-msgid "Proxy host:"
-msgstr "代理服务器:"
+msgid "Proxy host"
+msgstr "代理服务器"
 
 #: src/muuli_wdr.cpp
 msgid "The proxy host name"
 msgstr "代理服务器名称"
 
 #: src/muuli_wdr.cpp
-msgid "Proxy port:"
-msgstr "代理端口:"
+msgid "Proxy port"
+msgstr "代理端口"
 
 #: src/muuli_wdr.cpp
 msgid "The proxy port"
@@ -5371,16 +5293,8 @@ msgid "Enable/disable username/password authentication"
 msgstr "启用/禁用用户名/密码验证"
 
 #: src/muuli_wdr.cpp
-msgid "Username: "
-msgstr "用户名: "
-
-#: src/muuli_wdr.cpp
 msgid "The username to use to connect to the proxy"
 msgstr "连接代理服务器的用户名"
-
-#: src/muuli_wdr.cpp
-msgid "Password:"
-msgstr "密码:"
 
 #: src/muuli_wdr.cpp
 msgid "The password to use to connect to the proxy"
@@ -5553,6 +5467,15 @@ msgstr "小时"
 #: src/OtherFunctions.cpp
 msgid "days"
 msgstr "日"
+
+#. TRANSLATORS:
+#. Punctuation for a "label: value" pair. %s is the already-translated
+#. label. Place the colon as your language requires -- e.g. "%s :" with a
+#. space in French, "%s:" without one in Russian and English.
+#: src/OtherFunctions.cpp
+#, c-format
+msgid "%s:"
+msgstr ""
 
 #: src/OtherFunctions.cpp
 msgid "all"
@@ -6583,8 +6506,7 @@ msgstr "递归共享会将每个子文件发布到 eD2k/Kad 网络上。您确�
 msgid "Confirm shared folders"
 msgstr "确认共享的文件夹"
 
-#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp
-#: src/SharedFilesReloadProgress.cpp
+#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp src/SharedFilesReloadProgress.cpp
 msgid "Reloading shared files..."
 msgstr "正重新加载共享文件..."
 
@@ -6713,18 +6635,6 @@ msgstr "错误 %u：%s\n"
 #: src/SearchListCtrl.cpp
 msgid "FileID"
 msgstr "文件 ID"
-
-#: src/SearchListCtrl.cpp
-msgid "Length"
-msgstr "长度"
-
-#: src/SearchListCtrl.cpp
-msgid "Bitrate"
-msgstr "比特率"
-
-#: src/SearchListCtrl.cpp
-msgid "Codec"
-msgstr "编解码器"
 
 #: src/SearchListCtrl.cpp
 msgid "Expand all"
@@ -7002,10 +6912,6 @@ msgstr "本地服务器被IP过滤器过滤掉了，正在重新连接至其他�
 #: src/ServerListCtrl.cpp
 msgid "Server Name"
 msgstr "服务器名称"
-
-#: src/ServerListCtrl.cpp
-msgid "Port"
-msgstr "端口"
 
 #: src/ServerListCtrl.cpp
 msgid "Description"
@@ -7292,6 +7198,10 @@ msgstr "已连接至好友"
 #, c-format
 msgid "Connected to buddy at %s"
 msgstr "连接到好友于 %s"
+
+#: src/ServerWnd.cpp
+msgid "IP address:"
+msgstr "IP 地址:"
 
 #: src/ServerWnd.cpp
 msgid "Indexed sources:"

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-04 12:13+0200\n"
+"POT-Creation-Date: 2026-09-05 12:01+0200\n"
 "PO-Revision-Date: 2026-09-03 11:12+0000\n"
 "Last-Translator: Wayne Su <mstarmstar@gmail.com>\n"
 "Language-Team: \n"
@@ -391,8 +391,7 @@ msgstr "執行中的網站伺服器 pid：%d"
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "您要求啟動時執行網站伺服器，但系統無法執行 amuleweb。請安裝含有 aMule 網站伺服器的套件，或於編譯 aMule 程式碼時加入 --enable-webserver 選項"
 
-#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
-#: src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
+#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
 msgid "ERROR"
 msgstr "錯誤"
 
@@ -680,8 +679,7 @@ msgstr "網路"
 msgid "Searches"
 msgstr "搜尋"
 
-#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/Statistics.cpp
+#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/Statistics.cpp
 msgid "Downloads"
 msgstr "下載"
 
@@ -765,9 +763,7 @@ msgstr "Kad：關閉"
 msgid "Core"
 msgstr ""
 
-#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#: src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp
-#: src/SourceListCtrl.cpp src/Statistics.cpp
+#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp src/Statistics.cpp
 msgid "Version"
 msgstr "版本"
 
@@ -1066,11 +1062,7 @@ msgstr "無法建立 %s 目錄 ( %s 分類用)，繼續使用 %s 目錄。"
 msgid "The remote core sent inconsistent data for \"%s\" (part status %d, expected %d). The file list may be showing the wrong information; reconnect to clear it."
 msgstr ""
 
-#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp
-#: src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp
-#: src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp
-#: src/Statistics.cpp
+#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp src/Statistics.cpp
 msgid "Unknown"
 msgstr "不明"
 
@@ -1165,8 +1157,7 @@ msgstr "儲存 %s 時發生錯誤：%s"
 msgid "Enter Captcha"
 msgstr "輸入圖形驗證碼"
 
-#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp
-#: src/TransferWnd.cpp
+#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp src/TransferWnd.cpp
 msgid "Category"
 msgstr "分類"
 
@@ -1324,13 +1315,11 @@ msgstr "找不到 crytkey.dat，正在建立新的。"
 msgid "Client Details"
 msgstr "客戶端詳細資訊"
 
-#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
-#: src/utils/wxCas/src/onlinesig.cpp
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
 msgid "LowID"
 msgstr "LowID"
 
-#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
-#: src/utils/wxCas/src/onlinesig.cpp
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
 msgid "HighID"
 msgstr "HighID"
 
@@ -1346,8 +1335,7 @@ msgstr "已支援"
 msgid "Not supported"
 msgstr "不支援"
 
-#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
-#: src/TextClient.cpp
+#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp src/TextClient.cpp
 msgid "Connected"
 msgstr "已連線"
 
@@ -1355,28 +1343,25 @@ msgstr "已連線"
 msgid "Disconnected"
 msgstr "已中斷連線"
 
-#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp
-#: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f KiB/s"
 msgstr ""
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#, fuzzy
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/muuli_wdr.cpp
 msgid "Name"
-msgstr "名稱："
+msgstr "名稱"
 
 #: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
 msgid "Software"
 msgstr ""
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/muuli_wdr.cpp
 #, fuzzy
 msgid "IP Address"
 msgstr "IP 位址︰"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Origin"
 msgstr "來源"
 
@@ -1394,13 +1379,11 @@ msgstr "最後一次下載"
 msgid "Sessions"
 msgstr "版本"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp
 msgid "Upload Speed"
 msgstr "上傳速度"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp
 msgid "Download Speed"
 msgstr "下載速度"
 
@@ -1454,13 +1437,11 @@ msgstr[0] ""
 msgid "Files"
 msgstr "檔案"
 
-#: src/ClientsListCtrl.cpp src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp
-#: src/SourceListCtrl.cpp
+#: src/ClientsListCtrl.cpp src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Uploaded"
 msgstr "已上傳"
 
-#: src/ClientsListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
-#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientsListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Downloaded"
 msgstr "已下載"
 
@@ -1547,12 +1528,11 @@ msgstr "使用者 %s (%u) 拒絕傳送分享檔案/目錄清單"
 msgid "File Comments"
 msgstr "檔案註解"
 
-#: src/CommentDialogLst.cpp src/FriendListCtrl.cpp
+#: src/CommentDialogLst.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
 msgid "Username"
 msgstr "使用者名稱"
 
-#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp
-#: src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "File Name"
 msgstr "檔案名稱"
 
@@ -1560,7 +1540,7 @@ msgstr "檔案名稱"
 msgid "Rating"
 msgstr "評價"
 
-#: src/CommentDialogLst.cpp
+#: src/CommentDialogLst.cpp src/muuli_wdr.cpp
 msgid "Comment"
 msgstr "註解"
 
@@ -1613,18 +1593,15 @@ msgstr "自動 [高]"
 msgid "Very low"
 msgstr "極低"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Low"
 msgstr "低"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Normal"
 msgstr "普通"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "High"
 msgstr "高"
 
@@ -1648,13 +1625,11 @@ msgstr "正在經伺服器連線"
 msgid "Queue Full"
 msgstr "等候區已滿"
 
-#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp
-#: src/muuli_wdr.cpp
+#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp src/muuli_wdr.cpp
 msgid "On Queue"
 msgstr "等候中"
 
-#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp
-#: src/PartFile.cpp src/TransferWnd.cpp
+#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Downloading"
 msgstr "正在下載"
 
@@ -1714,8 +1689,7 @@ msgstr "本地伺服器"
 msgid "Remote Server"
 msgstr "遠端伺服器"
 
-#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp
-#: src/TextClient.cpp
+#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp src/TextClient.cpp
 msgid "Kad"
 msgstr "Kad"
 
@@ -1739,8 +1713,7 @@ msgstr "來源種子"
 msgid "Search Result"
 msgstr "搜尋結果"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp
-#: src/TransferWnd.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
 msgid "Completed"
 msgstr "已完成"
 
@@ -1793,8 +1766,7 @@ msgstr ""
 msgid "Part"
 msgstr "部份"
 
-#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp
-#: src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Size"
 msgstr "大小"
 
@@ -1802,8 +1774,7 @@ msgstr "大小"
 msgid "Transferred"
 msgstr "已傳輸"
 
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
-#: src/SourceListCtrl.cpp
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp src/SourceListCtrl.cpp
 msgid "Speed"
 msgstr "速度"
 
@@ -1811,13 +1782,11 @@ msgstr "速度"
 msgid "Progress"
 msgstr "進度"
 
-#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp
-#: src/SearchListCtrl.cpp
+#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
 msgid "Sources"
 msgstr "來源"
 
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp
-#: src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Priority"
 msgstr "優先等級"
 
@@ -1841,9 +1810,7 @@ msgstr "最後一次下載"
 msgid "Auto"
 msgstr "自動"
 
-#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
-#: src/ServerListCtrl.cpp src/TransferWnd.cpp
-#: src/utils/wxCas/src/wxcasprefs.cpp
+#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/TransferWnd.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Cancel"
 msgstr "取消"
 
@@ -1944,8 +1911,7 @@ msgstr "請輸入新檔案名稱："
 msgid "File rename"
 msgstr "更改檔名"
 
-#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp
-#: src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f MiB/s"
 msgstr ""
@@ -2748,13 +2714,11 @@ msgstr ""
 msgid "Start aMule automatically when I log in"
 msgstr ""
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
-#: packaging/windows/installer_strings.c
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp packaging/windows/installer_strings.c
 msgid "Register aMule for ed2k:// links"
 msgstr ""
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
-#: packaging/windows/installer_strings.c
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp packaging/windows/installer_strings.c
 msgid "Register aMule for magnet: links"
 msgstr ""
 
@@ -2780,8 +2744,7 @@ msgstr ""
 msgid "Destination folder for downloads"
 msgstr "下載資料夾"
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
-#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Browse"
 msgstr "瀏覽"
 
@@ -3219,18 +3182,15 @@ msgstr "正在完成"
 msgid "Complete"
 msgstr "完成"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
-#: src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Paused"
 msgstr "已暫停"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
-#: src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Erroneous"
 msgstr "錯誤的"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
-#: src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
 msgid "Waiting"
 msgstr "正在等候"
 
@@ -3390,8 +3350,7 @@ msgstr "關閉"
 msgid "Cut"
 msgstr "剪下"
 
-#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp
-#: src/utils/aLinkCreator/src/alcframe.cpp
+#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy"
 msgstr "複製"
 
@@ -3399,8 +3358,7 @@ msgstr "複製"
 msgid "Paste"
 msgstr "貼上"
 
-#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp
-#: src/utils/aLinkCreator/src/alcframe.cpp
+#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Clear"
 msgstr "清除"
 
@@ -3408,8 +3366,7 @@ msgstr "清除"
 msgid "Select All"
 msgstr "全選"
 
-#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
-#: src/StatisticsDlg.cpp
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp src/StatisticsDlg.cpp
 msgid "KiB/s"
 msgstr ""
 
@@ -3673,10 +3630,6 @@ msgstr "目前連線的伺服器。"
 msgid "Search"
 msgstr "搜尋"
 
-#: src/muuli_wdr.cpp
-msgid "Name:"
-msgstr "名稱："
-
 #: src/muuli_wdr.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Type"
 msgstr "類型"
@@ -3766,8 +3719,8 @@ msgid "Availability"
 msgstr "最小來源數"
 
 #: src/muuli_wdr.cpp
-msgid "Filter:"
-msgstr "過濾："
+msgid "Filter"
+msgstr "過濾"
 
 #: src/muuli_wdr.cpp
 msgid "Invert Result"
@@ -3825,6 +3778,10 @@ msgid "Clears completed downloads"
 msgstr "清除已完成的檔案"
 
 #: src/muuli_wdr.cpp
+msgid "Filter:"
+msgstr "過濾："
+
+#: src/muuli_wdr.cpp
 msgid "File sources:"
 msgstr "檔案來源："
 
@@ -3833,80 +3790,76 @@ msgid "General"
 msgstr "一般"
 
 #: src/muuli_wdr.cpp
-msgid "Full Name :"
+msgid "Full Name"
 msgstr "全名︰"
 
 #: src/muuli_wdr.cpp
-msgid "met-File :"
+msgid "met-File"
 msgstr "met 檔"
 
 #: src/muuli_wdr.cpp
-msgid "Hash :"
-msgstr "hash 值："
+msgid "Hash"
+msgstr "hash 值"
 
 #: src/muuli_wdr.cpp
-msgid "Filesize :"
-msgstr "檔案大小："
+msgid "Filesize"
+msgstr "檔案大小"
 
 #: src/muuli_wdr.cpp src/Statistics.cpp
 msgid "Transfer"
 msgstr "傳輸"
 
 #: src/muuli_wdr.cpp
-msgid "Partfilestatus :"
-msgstr "暫存檔狀態："
+msgid "Partfilestatus"
+msgstr "暫存檔狀態"
 
 #: src/muuli_wdr.cpp
-msgid "Last seen complete :"
-msgstr "最後看到完整檔案："
+msgid "Last seen complete"
+msgstr "最後看到完整檔案"
 
 #: src/muuli_wdr.cpp
-msgid "Found Sources :"
-msgstr "找到的來源："
+msgid "Found Sources"
+msgstr "找到的來源"
 
 #: src/muuli_wdr.cpp
-msgid "Transferring Sources :"
-msgstr "正在傳輸的來源："
+msgid "Transferring Sources"
+msgstr "正在傳輸的來源"
 
 #: src/muuli_wdr.cpp
-msgid "Filepart-Count :"
-msgstr "檔案分段數："
+msgid "Filepart-Count"
+msgstr "檔案分段數"
 
 #: src/muuli_wdr.cpp
-msgid "Available :"
-msgstr "可用："
+msgid "Available"
+msgstr "可用"
 
 #: src/muuli_wdr.cpp
-msgid "Datarate :"
-msgstr "速度："
+msgid "Datarate"
+msgstr "速度"
 
 #: src/muuli_wdr.cpp
-msgid "Download Active Time: "
-msgstr "下載時間："
+msgid "Download Active Time"
+msgstr "下載時間"
 
 #: src/muuli_wdr.cpp
-msgid "Transferred :"
-msgstr "已傳輸："
-
-#: src/muuli_wdr.cpp
-msgid "Completed Size :"
-msgstr "已完成："
+msgid "Completed Size"
+msgstr "已完成"
 
 #: src/muuli_wdr.cpp
 msgid "Intelligent Corruption Handling"
 msgstr "智慧資料損壞處理 (I.C.H.)"
 
 #: src/muuli_wdr.cpp
-msgid "Lost to corruption :"
-msgstr "因資料損壞而損失："
+msgid "Lost to corruption"
+msgstr "因資料損壞而損失"
 
 #: src/muuli_wdr.cpp
-msgid "Gained by compression :"
-msgstr "壓縮量："
+msgid "Gained by compression"
+msgstr "壓縮量"
 
 #: src/muuli_wdr.cpp
-msgid "Packages saved by I.C.H. :"
-msgstr "由 I.C.H. 救回的封包："
+msgid "Packages saved by I.C.H."
+msgstr "由 I.C.H. 救回的封包"
 
 #: src/muuli_wdr.cpp
 #, fuzzy
@@ -3948,30 +3901,30 @@ msgstr "，上傳："
 msgid "Media Info"
 msgstr "Kad 資訊"
 
-#: src/muuli_wdr.cpp
-msgid "Length :"
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
+msgid "Length"
 msgstr ""
 
-#: src/muuli_wdr.cpp
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
 #, fuzzy
-msgid "Bitrate :"
+msgid "Bitrate"
 msgstr "未評價"
 
-#: src/muuli_wdr.cpp
-msgid "Codec :"
+#: src/muuli_wdr.cpp src/SearchListCtrl.cpp
+msgid "Codec"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Artist :"
+msgid "Artist"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Album :"
+msgid "Album"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Title :"
-msgstr "標題："
+msgid "Title"
+msgstr "標題"
 
 #: src/muuli_wdr.cpp
 msgid "File Names"
@@ -4058,25 +4011,17 @@ msgstr "不明大小"
 msgid "Required Information"
 msgstr "必要資訊"
 
-#: src/muuli_wdr.cpp
-msgid "IP Address :"
-msgstr "IP 位址︰"
-
-#: src/muuli_wdr.cpp
-msgid "Port :"
-msgstr "通訊埠︰"
+#: src/muuli_wdr.cpp src/ServerListCtrl.cpp
+msgid "Port"
+msgstr "通訊埠"
 
 #: src/muuli_wdr.cpp
 msgid "Additional Information"
 msgstr "附加資訊"
 
 #: src/muuli_wdr.cpp
-msgid "Username :"
-msgstr "使用者名稱︰"
-
-#: src/muuli_wdr.cpp
-msgid "Userhash :"
-msgstr "使用者 hash 值："
+msgid "Userhash"
+msgstr "使用者 hash 值"
 
 #: src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Add"
@@ -4111,96 +4056,80 @@ msgid "Statistics Tree"
 msgstr "統計資訊"
 
 #: src/muuli_wdr.cpp
-msgid "Username:"
-msgstr "使用者名稱︰"
+msgid "Client software"
+msgstr "客戶端軟體"
 
 #: src/muuli_wdr.cpp
-msgid "Userhash:"
-msgstr "使用者 hash 值："
+msgid "Client version"
+msgstr "版本"
 
 #: src/muuli_wdr.cpp
-msgid "Client software:"
-msgstr "客戶端軟體："
+msgid "User ID"
+msgstr "使用者 ID"
 
 #: src/muuli_wdr.cpp
-msgid "Client version:"
-msgstr "版本："
-
-#: src/muuli_wdr.cpp src/ServerWnd.cpp
-msgid "IP address:"
-msgstr "IP 位址："
+msgid "Server IP"
+msgstr "伺服器 IP"
 
 #: src/muuli_wdr.cpp
-msgid "User ID:"
-msgstr "使用者 ID："
+msgid "Server name"
+msgstr "伺服器名稱"
 
 #: src/muuli_wdr.cpp
-msgid "Server IP:"
-msgstr "伺服器 IP："
-
-#: src/muuli_wdr.cpp
-msgid "Server name:"
-msgstr "伺服器名稱："
-
-#: src/muuli_wdr.cpp
-msgid "Obfuscation:"
-msgstr "模糊協定："
-
-#: src/muuli_wdr.cpp
-msgid "Kad:"
-msgstr "Kad："
+msgid "Obfuscation"
+msgstr "模糊協定"
 
 #: src/muuli_wdr.cpp
 msgid "Transfers to client"
 msgstr "傳輸"
 
 #: src/muuli_wdr.cpp
-msgid "Current request:"
-msgstr "目前要求："
+msgid "Current request"
+msgstr "目前要求"
 
 #: src/muuli_wdr.cpp
-msgid "Average upload rate:"
-msgstr "平均上傳速度："
+msgid "Average upload rate"
+msgstr "平均上傳速度"
 
 #: src/muuli_wdr.cpp
-msgid "Average download rate:"
-msgstr "平均下載速度："
+msgid "Average download rate"
+msgstr "平均下載速度"
 
 #: src/muuli_wdr.cpp
-msgid "Uploaded (session):"
-msgstr "本次上傳："
+msgid "Uploaded (session)"
+msgstr "本次上傳"
 
 #: src/muuli_wdr.cpp
-msgid "Downloaded (session):"
-msgstr "本次下載："
+msgid "Downloaded (session)"
+msgstr "本次下載"
 
 #: src/muuli_wdr.cpp
-msgid "Uploaded (total):"
-msgstr "總計上傳："
+msgid "Uploaded (total)"
+msgstr "總計上傳"
 
 #: src/muuli_wdr.cpp
-msgid "Downloaded (total):"
-msgstr "總計下載："
+msgid "Downloaded (total)"
+msgstr "總計下載"
 
 #: src/muuli_wdr.cpp
 msgid "Scores"
 msgstr "分數"
 
 #: src/muuli_wdr.cpp
-msgid "DL/UP modifier:"
-msgstr "下載/上傳 比率："
+msgid "DL/UP modifier"
+msgstr "下載/上傳 比率"
 
 #: src/muuli_wdr.cpp
-msgid "Secure ident:"
-msgstr "安全驗證："
+msgid "Secure ident"
+msgstr "安全驗證"
 
 #: src/muuli_wdr.cpp
-msgid "Queue rank:"
-msgstr "等候排名："
+msgid "Queue rank"
+msgstr "等候排名"
 
 #: src/muuli_wdr.cpp
-msgid "Queue score:"
-msgstr "得分："
+msgid "Queue score"
+msgstr "得分"
 
 #: src/muuli_wdr.cpp
 msgid "Nick"
@@ -4995,24 +4924,20 @@ msgid "Reset any changes made to the preferences."
 msgstr "取消所有偏好設定變更。"
 
 #: src/muuli_wdr.cpp
-msgid "Comment :"
-msgstr "註解："
+msgid "Incoming Dir"
+msgstr "新進檔目錄"
 
 #: src/muuli_wdr.cpp
-msgid "Incoming Dir :"
-msgstr "新進檔目錄："
-
-#: src/muuli_wdr.cpp
-msgid "Change priority for new assigned files :"
-msgstr "設定新加入的檔案優先等級為："
+msgid "Change priority for new assigned files"
+msgstr "設定新加入的檔案優先等級為"
 
 #: src/muuli_wdr.cpp
 msgid "Don't change"
 msgstr "不要變更"
 
 #: src/muuli_wdr.cpp
-msgid "Select color for this Category (currently selected) :"
-msgstr "選取該分類的顏色 (目前選擇)："
+msgid "Select color for this Category (currently selected)"
+msgstr "選取該分類的顏色 (目前選擇)"
 
 #: src/muuli_wdr.cpp
 msgid "Click this button to reset the log."
@@ -5095,10 +5020,6 @@ msgstr "從已知客戶端啓動"
 #, fuzzy
 msgid "Enter the IP of the node here, using the x.x.x.x format."
 msgstr "輸入新伺服器的 IP (格式：x.x.x.x)。"
-
-#: src/muuli_wdr.cpp
-msgid "Port:"
-msgstr "埠："
 
 #: src/muuli_wdr.cpp
 msgid "Use Secure User Identification"
@@ -5367,20 +5288,20 @@ msgid "Enable/disable proxy support"
 msgstr "啓用/停用代理伺服器支援"
 
 #: src/muuli_wdr.cpp
-msgid "Proxy type:"
-msgstr "類型："
+msgid "Proxy type"
+msgstr "類型"
 
 #: src/muuli_wdr.cpp
-msgid "Proxy host:"
-msgstr "主機："
+msgid "Proxy host"
+msgstr "主機"
 
 #: src/muuli_wdr.cpp
 msgid "The proxy host name"
 msgstr "代理伺服器主機名稱"
 
 #: src/muuli_wdr.cpp
-msgid "Proxy port:"
-msgstr "連接埠："
+msgid "Proxy port"
+msgstr "連接埠"
 
 #: src/muuli_wdr.cpp
 msgid "The proxy port"
@@ -5395,16 +5316,8 @@ msgid "Enable/disable username/password authentication"
 msgstr "啓用/停用 使用者名稱/密碼登入驗證"
 
 #: src/muuli_wdr.cpp
-msgid "Username: "
-msgstr "使用者名稱："
-
-#: src/muuli_wdr.cpp
 msgid "The username to use to connect to the proxy"
 msgstr "登入代理伺服器的使用者名稱"
-
-#: src/muuli_wdr.cpp
-msgid "Password:"
-msgstr "密碼："
 
 #: src/muuli_wdr.cpp
 msgid "The password to use to connect to the proxy"
@@ -5578,6 +5491,15 @@ msgstr "時"
 #: src/OtherFunctions.cpp
 msgid "days"
 msgstr "天"
+
+#. TRANSLATORS:
+#. Punctuation for a "label: value" pair. %s is the already-translated
+#. label. Place the colon as your language requires -- e.g. "%s :" with a
+#. space in French, "%s:" without one in Russian and English.
+#: src/OtherFunctions.cpp
+#, c-format
+msgid "%s:"
+msgstr ""
 
 #: src/OtherFunctions.cpp
 msgid "all"
@@ -6614,8 +6536,7 @@ msgstr ""
 msgid "Confirm shared folders"
 msgstr "分享資料夾"
 
-#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp
-#: src/SharedFilesReloadProgress.cpp
+#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp src/SharedFilesReloadProgress.cpp
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "重新載入分享的檔案"
@@ -6749,19 +6670,6 @@ msgstr "GeoIP.dat 更新錯誤"
 #: src/SearchListCtrl.cpp
 msgid "FileID"
 msgstr "檔案 ID"
-
-#: src/SearchListCtrl.cpp
-msgid "Length"
-msgstr ""
-
-#: src/SearchListCtrl.cpp
-#, fuzzy
-msgid "Bitrate"
-msgstr "未評價"
-
-#: src/SearchListCtrl.cpp
-msgid "Codec"
-msgstr ""
 
 #: src/SearchListCtrl.cpp
 msgid "Expand all"
@@ -7043,10 +6951,6 @@ msgstr "本地伺服器被 IP 過濾器過濾掉了，正在重新連線到其�
 #: src/ServerListCtrl.cpp
 msgid "Server Name"
 msgstr "伺服器名稱"
-
-#: src/ServerListCtrl.cpp
-msgid "Port"
-msgstr "通訊埠"
 
 #: src/ServerListCtrl.cpp
 msgid "Description"
@@ -7340,6 +7244,10 @@ msgstr "正在與好友連線"
 #, c-format
 msgid "Connected to buddy at %s"
 msgstr "已與在 %s 的好友連線"
+
+#: src/ServerWnd.cpp
+msgid "IP address:"
+msgstr "IP 位址："
 
 #: src/ServerWnd.cpp
 msgid "Indexed sources:"

--- a/src/OtherFunctions.cpp
+++ b/src/OtherFunctions.cpp
@@ -117,6 +117,15 @@ wxString CastSecondsToHM(uint32 count, uint16 msecs)
 	}
 }
 
+wxString LabelWithColon(const wxString &label)
+{
+	/* TRANSLATORS:
+	   Punctuation for a "label: value" pair. %s is the already-translated
+	   label. Place the colon as your language requires -- e.g. "%s :" with a
+	   space in French, "%s:" without one in Russian and English. */
+	return CFormat(_("%s:")) % label;
+}
+
 wxString FormatLocalDateTime(const wxDateTime &when)
 {
 	// %x %X: both halves come from LC_TIME, so a locale that writes the day

--- a/src/OtherFunctions.h
+++ b/src/OtherFunctions.h
@@ -232,6 +232,20 @@ wxString CastSecondsToHM(uint32 seconds, uint16 msecs = 0);
  * survives being pasted into a bug report by someone in another locale, all
  * of which matter more there than looking familiar does.
  */
+/**
+ * Punctuation for a "label: value" pair, applied to an already-translated
+ * label.
+ *
+ * Where the colon sits is a property of the language, not of the layout:
+ * Russian typography forbids a space before it, French requires one. Building
+ * the string in C++ ("label" + ": ") puts that choice out of a translator's
+ * reach, which is what amule-org/amule#1294 reported. Routing it through one
+ * catalog entry settles the convention for every label at once, and lets the
+ * bare label stay shared with the list columns and menus that already
+ * translate it -- rather than each dialog minting a colon-suffixed twin.
+ */
+wxString LabelWithColon(const wxString &label);
+
 wxString FormatLocalDateTime(const wxDateTime &when);
 // Date-only form of the above, for a column too narrow to carry both.
 wxString FormatLocalDate(const wxDateTime &when);

--- a/src/muuli_wdr.cpp
+++ b/src/muuli_wdr.cpp
@@ -38,6 +38,7 @@
 #include "muuli_wdr.h"
 
 #include "amuleDlg.h" // Needed for CLIENT_SKIN_SIZE (clientImages' artIds static_assert)
+#include "OtherFunctions.h" // Needed for LabelWithColon
 
 #include <wx/artprov.h> // Needed for the "amule:" art ids (status bar + transfer window icons)
 #include <wx/intl.h>
@@ -232,7 +233,7 @@ wxSizer *searchDlg( wxWindow *parent, bool call_fit, bool set_sizer )
 
     wxBoxSizer *item3 = new wxBoxSizer( wxHORIZONTAL );
 
-    wxStaticText *item4 = new wxStaticText( parent, -1, _("Name:"), wxDefaultPosition, wxDefaultSize, 0 );
+    wxStaticText *item4 = new wxStaticText( parent, -1, LabelWithColon( _("Name") ), wxDefaultPosition, wxDefaultSize, 0 );
     item3->Add( item4, wxSizerFlags().Center().Border(wxALL, 5) );
     wxComboBox *item5 = new wxComboBox( parent, IDC_SEARCHNAME, "", wxDefaultPosition, wxSize(80,-1), 0, nullptr, wxTE_PROCESS_ENTER );
     item3->Add( item5, wxSizerFlags(1).Center().Border(wxALL, 5) );
@@ -341,7 +342,7 @@ wxSizer *searchDlg( wxWindow *parent, bool call_fit, bool set_sizer )
     s_filter_sizer = item34;
 
     item34->Add( 10, 10, wxSizerFlags(1).Center().Border(wxALL, 5) );
-    wxStaticText *item35 = new wxStaticText( parent, -1, _("Filter:"), wxDefaultPosition, wxDefaultSize, 0 );
+    wxStaticText *item35 = new wxStaticText( parent, -1, LabelWithColon( _("Filter") ), wxDefaultPosition, wxDefaultSize, 0 );
     item34->Add( item35, wxSizerFlags().Center().Border(wxALL, 5) );
     wxTextCtrl *item36 = new wxTextCtrl( parent, ID_FILTER_TEXT, "", wxDefaultPosition, wxSize(220,-1), wxTE_PROCESS_ENTER );
     item34->Add( item36, wxSizerFlags().Center().Border(wxALL, 5) );
@@ -593,14 +594,22 @@ namespace
 // fileDetails(), so the relocated download rows and the Sharing box stay
 // visually consistent with the hand-written rows.
 //
-// `appendColon` tacks a literal " :" onto the label at display time. The
-// Sharing rows use it so they can reuse existing bare translations (e.g.
-// "Requests") and still read "Requests :" without minting new catalog strings.
+// `appendColon` renders the label as "label:" at display time. The Sharing
+// rows use it so they can reuse existing bare translations (e.g. "Requests")
+// instead of minting a second, colon-suffixed catalog string for each.
+//
+// The punctuation goes through the catalog rather than being concatenated in
+// C++, because where the colon sits is a property of the language, not of the
+// layout: Russian typography forbids the space this used to hard-code, while
+// French requires it (amule-org/amule#1294). One format string lets a
+// translator settle the convention for every row at once, and keeps the reuse
+// that motivated the flag.
 void AddFileDetailRow(
     wxWindow *rowParent, wxSizer *grid, const wxString &label, int valueId, bool appendColon = false )
 {
     wxBoxSizer *row = new wxBoxSizer( wxHORIZONTAL );
-    row->Add( new wxStaticText( rowParent, -1, appendColon ? label + wxT(" :") : label,
+    const wxString labelText = appendColon ? LabelWithColon( label ) : label;
+    row->Add( new wxStaticText( rowParent, -1, labelText,
                   wxDefaultPosition, wxDefaultSize, 0 ),
         wxSizerFlags().Expand().CenterVertical() );
     wxStaticText *val = new wxStaticText( rowParent, valueId, _("N/A"), wxDefaultPosition, wxDefaultSize, 0 );
@@ -621,7 +630,7 @@ wxSizer *fileDetails( wxWindow *parent, bool call_fit, bool set_sizer )
 
     wxBoxSizer *item3 = new wxBoxSizer( wxHORIZONTAL );
 
-    wxStaticText *item4 = new wxStaticText( parent, -1, _("Full Name :"), wxDefaultPosition, wxDefaultSize, 0 );
+    wxStaticText *item4 = new wxStaticText( parent, -1, LabelWithColon( _("Full Name") ), wxDefaultPosition, wxDefaultSize, 0 );
     item3->Add( item4, wxSizerFlags().Expand().CenterVertical() );
 
     wxStaticText *item5 = new wxStaticText( parent, IDC_FNAME, _("N/A"), wxDefaultPosition, wxDefaultSize, 0 );
@@ -630,7 +639,7 @@ wxSizer *fileDetails( wxWindow *parent, bool call_fit, bool set_sizer )
     item1->Add( item3, wxSizerFlags().Expand().CenterVertical() );
     wxBoxSizer *item6 = new wxBoxSizer( wxHORIZONTAL );
 
-    wxStaticText *item7 = new wxStaticText( parent, -1, _("met-File :"), wxDefaultPosition, wxDefaultSize, 0 );
+    wxStaticText *item7 = new wxStaticText( parent, -1, LabelWithColon( _("met-File") ), wxDefaultPosition, wxDefaultSize, 0 );
     item6->Add( item7, wxSizerFlags().Expand().CenterVertical() );
     wxStaticText *item8 = new wxStaticText( parent, IDC_METFILE, _("N/A"), wxDefaultPosition, wxDefaultSize, 0 );
     item8->SetForegroundColour( wxSystemSettings::GetColour(wxSYS_COLOUR_HOTLIGHT) );
@@ -638,7 +647,7 @@ wxSizer *fileDetails( wxWindow *parent, bool call_fit, bool set_sizer )
     item1->Add( item6, wxSizerFlags().Expand().CenterVertical().Border(wxALL, 0) );
     wxBoxSizer *item9 = new wxBoxSizer( wxHORIZONTAL );
 
-    wxStaticText *item10 = new wxStaticText( parent, -1, _("Hash :"), wxDefaultPosition, wxDefaultSize, 0 );
+    wxStaticText *item10 = new wxStaticText( parent, -1, LabelWithColon( _("Hash") ), wxDefaultPosition, wxDefaultSize, 0 );
     item9->Add( item10, wxSizerFlags().Expand().CenterVertical() );
     wxStaticText *item11 = new wxStaticText( parent, IDC_FHASH, _("N/A"), wxDefaultPosition, wxDefaultSize, 0 );
     item11->SetForegroundColour( wxSystemSettings::GetColour(wxSYS_COLOUR_HOTLIGHT) );
@@ -650,7 +659,7 @@ wxSizer *fileDetails( wxWindow *parent, bool call_fit, bool set_sizer )
 
     wxBoxSizer *item13 = new wxBoxSizer( wxHORIZONTAL );
 
-    wxStaticText *item14 = new wxStaticText( parent, -1, _("Filesize :"), wxDefaultPosition, wxDefaultSize, 0 );
+    wxStaticText *item14 = new wxStaticText( parent, -1, LabelWithColon( _("Filesize") ), wxDefaultPosition, wxDefaultSize, 0 );
     item13->Add( item14, wxSizerFlags().Expand().CenterVertical() );
     wxStaticText *item15 = new wxStaticText( parent, IDC_FSIZE, _("N/A"), wxDefaultPosition, wxDefaultSize, 0 );
     item15->SetForegroundColour( wxSystemSettings::GetColour(wxSYS_COLOUR_HOTLIGHT) );
@@ -676,19 +685,19 @@ wxSizer *fileDetails( wxWindow *parent, bool call_fit, bool set_sizer )
 
     // Partfile status + last seen complete (download-only; relocated here from
     // the General box).
-    AddFileDetailRow( dlPanel, item24, _("Partfilestatus :"), IDC_PFSTATUS );
-    AddFileDetailRow( dlPanel, item24, _("Last seen complete :"), IDC_LASTSEENCOMPL );
-    AddFileDetailRow( dlPanel, item24, _("Found Sources :"), IDC_SOURCECOUNT );
-    AddFileDetailRow( dlPanel, item24, _("Transferring Sources :"), IDC_SOURCECOUNT2 );
-    AddFileDetailRow( dlPanel, item24, _("Filepart-Count :"), IDC_PARTCOUNT );
-    AddFileDetailRow( dlPanel, item24, _("Available :"), IDC_PARTAVAILABLE );
-    AddFileDetailRow( dlPanel, item24, _("Datarate :"), IDC_DATARATE );
-    AddFileDetailRow( dlPanel, item24, _("Download Active Time: "), IDC_DLACTIVETIME );
-    AddFileDetailRow( dlPanel, item24, _("Transferred :"), IDC_TRANSFERRED );
+    AddFileDetailRow( dlPanel, item24, _("Partfilestatus"), IDC_PFSTATUS, true );
+    AddFileDetailRow( dlPanel, item24, _("Last seen complete"), IDC_LASTSEENCOMPL, true );
+    AddFileDetailRow( dlPanel, item24, _("Found Sources"), IDC_SOURCECOUNT, true );
+    AddFileDetailRow( dlPanel, item24, _("Transferring Sources"), IDC_SOURCECOUNT2, true );
+    AddFileDetailRow( dlPanel, item24, _("Filepart-Count"), IDC_PARTCOUNT, true );
+    AddFileDetailRow( dlPanel, item24, _("Available"), IDC_PARTAVAILABLE, true );
+    AddFileDetailRow( dlPanel, item24, _("Datarate"), IDC_DATARATE, true );
+    AddFileDetailRow( dlPanel, item24, _("Download Active Time"), IDC_DLACTIVETIME, true );
+    AddFileDetailRow( dlPanel, item24, _("Transferred"), IDC_TRANSFERRED, true );
 
     // Completed Size keeps its composite "value / (percent)" display.
     wxBoxSizer *item46 = new wxBoxSizer( wxHORIZONTAL );
-    item46->Add( new wxStaticText( dlPanel, -1, _("Completed Size :"), wxDefaultPosition, wxDefaultSize, 0 ), wxSizerFlags().Expand().CenterVertical() );
+    item46->Add( new wxStaticText( dlPanel, -1, LabelWithColon( _("Completed Size") ), wxDefaultPosition, wxDefaultSize, 0 ), wxSizerFlags().Expand().CenterVertical() );
     wxBoxSizer *item48 = new wxBoxSizer( wxHORIZONTAL );
     wxStaticText *item49 = new wxStaticText( dlPanel, IDC_COMPLSIZE, _("N/A"), wxDefaultPosition, wxDefaultSize, 0 );
     item49->SetForegroundColour( wxSystemSettings::GetColour(wxSYS_COLOUR_HOTLIGHT) );
@@ -709,9 +718,9 @@ wxSizer *fileDetails( wxWindow *parent, bool call_fit, bool set_sizer )
     wxFlexGridSizer *item55 = new wxFlexGridSizer( 2, 0, 0 );
     item55->AddGrowableCol( 0 );
     item55->AddGrowableCol( 1 );
-    AddFileDetailRow( dlPanel, item55, _("Lost to corruption :"), IDC_FD_STATS1 );
-    AddFileDetailRow( dlPanel, item55, _("Gained by compression :"), IDC_FD_STATS2 );
-    AddFileDetailRow( dlPanel, item55, _("Packages saved by I.C.H. :"), IDC_FD_STATS3 );
+    AddFileDetailRow( dlPanel, item55, _("Lost to corruption"), IDC_FD_STATS1, true );
+    AddFileDetailRow( dlPanel, item55, _("Gained by compression"), IDC_FD_STATS2, true );
+    AddFileDetailRow( dlPanel, item55, _("Packages saved by I.C.H."), IDC_FD_STATS3, true );
     item53->Add( item55, wxSizerFlags().Expand().CenterVertical() );
     dlPanelSizer->Add( item53, wxSizerFlags().Expand().CenterVertical().Border(wxLEFT|wxRIGHT|wxBOTTOM, 5) );
 
@@ -728,8 +737,9 @@ wxSizer *fileDetails( wxWindow *parent, bool call_fit, bool set_sizer )
     wxFlexGridSizer *shGrid = new wxFlexGridSizer( 2, 0, 0 );
     shGrid->AddGrowableCol( 0 );
     shGrid->AddGrowableCol( 1 );
-    // Labels reuse existing bare translations; " :" is appended at display time
-    // (appendColon) so no new catalog strings are needed for the reused ones.
+    // Labels reuse existing bare translations; the colon is applied at display
+    // time through the localizable "%s :" format (appendColon), so no new
+    // catalog string is needed per row and the punctuation stays translatable.
     AddFileDetailRow( shPanel, shGrid, _("Requests"), IDC_FD_SHARE_REQ, true );
     AddFileDetailRow( shPanel, shGrid, _("Accepted Requests"), IDC_FD_SHARE_ACC, true );
     AddFileDetailRow( shPanel, shGrid, _("Transferred Data"), IDC_FD_SHARE_XFER, true );
@@ -758,42 +768,42 @@ wxSizer *fileDetails( wxWindow *parent, bool call_fit, bool set_sizer )
     mediaGrid->AddGrowableCol( 1 );
 
     wxBoxSizer *mLenRow = new wxBoxSizer( wxHORIZONTAL );
-    mLenRow->Add( new wxStaticText( parent, -1, _("Length :"), wxDefaultPosition, wxDefaultSize, 0 ), wxSizerFlags().Expand().CenterVertical() );
+    mLenRow->Add( new wxStaticText( parent, -1, LabelWithColon( _("Length") ), wxDefaultPosition, wxDefaultSize, 0 ), wxSizerFlags().Expand().CenterVertical() );
     wxStaticText *mLenVal = new wxStaticText( parent, IDC_FD_MEDIA_LENGTH, _("N/A"), wxDefaultPosition, wxDefaultSize, 0 );
     mLenVal->SetForegroundColour( wxSystemSettings::GetColour(wxSYS_COLOUR_HOTLIGHT) );
     mLenRow->Add( mLenVal, wxSizerFlags().Center().Border(wxLEFT, 5) );
     mediaGrid->Add( mLenRow, wxSizerFlags().Expand().CenterVertical() );
 
     wxBoxSizer *mBrRow = new wxBoxSizer( wxHORIZONTAL );
-    mBrRow->Add( new wxStaticText( parent, -1, _("Bitrate :"), wxDefaultPosition, wxDefaultSize, 0 ), wxSizerFlags().Expand().CenterVertical().Border(wxLEFT, 5) );
+    mBrRow->Add( new wxStaticText( parent, -1, LabelWithColon( _("Bitrate") ), wxDefaultPosition, wxDefaultSize, 0 ), wxSizerFlags().Expand().CenterVertical().Border(wxLEFT, 5) );
     wxStaticText *mBrVal = new wxStaticText( parent, IDC_FD_MEDIA_BITRATE, _("N/A"), wxDefaultPosition, wxDefaultSize, 0 );
     mBrVal->SetForegroundColour( wxSystemSettings::GetColour(wxSYS_COLOUR_HOTLIGHT) );
     mBrRow->Add( mBrVal, wxSizerFlags().Center().Border(wxLEFT, 5) );
     mediaGrid->Add( mBrRow, wxSizerFlags().Expand().CenterVertical() );
 
     wxBoxSizer *mCodecRow = new wxBoxSizer( wxHORIZONTAL );
-    mCodecRow->Add( new wxStaticText( parent, -1, _("Codec :"), wxDefaultPosition, wxDefaultSize, 0 ), wxSizerFlags().Expand().CenterVertical() );
+    mCodecRow->Add( new wxStaticText( parent, -1, LabelWithColon( _("Codec") ), wxDefaultPosition, wxDefaultSize, 0 ), wxSizerFlags().Expand().CenterVertical() );
     wxStaticText *mCodecVal = new wxStaticText( parent, IDC_FD_MEDIA_CODEC, _("N/A"), wxDefaultPosition, wxDefaultSize, 0 );
     mCodecVal->SetForegroundColour( wxSystemSettings::GetColour(wxSYS_COLOUR_HOTLIGHT) );
     mCodecRow->Add( mCodecVal, wxSizerFlags().Center().Border(wxLEFT, 5) );
     mediaGrid->Add( mCodecRow, wxSizerFlags().Expand().CenterVertical() );
 
     wxBoxSizer *mArtistRow = new wxBoxSizer( wxHORIZONTAL );
-    mArtistRow->Add( new wxStaticText( parent, -1, _("Artist :"), wxDefaultPosition, wxDefaultSize, 0 ), wxSizerFlags().Expand().CenterVertical().Border(wxLEFT, 5) );
+    mArtistRow->Add( new wxStaticText( parent, -1, LabelWithColon( _("Artist") ), wxDefaultPosition, wxDefaultSize, 0 ), wxSizerFlags().Expand().CenterVertical().Border(wxLEFT, 5) );
     wxStaticText *mArtistVal = new wxStaticText( parent, IDC_FD_MEDIA_ARTIST, _("N/A"), wxDefaultPosition, wxDefaultSize, 0 );
     mArtistVal->SetForegroundColour( wxSystemSettings::GetColour(wxSYS_COLOUR_HOTLIGHT) );
     mArtistRow->Add( mArtistVal, wxSizerFlags().Center().Border(wxLEFT, 5) );
     mediaGrid->Add( mArtistRow, wxSizerFlags().Expand().CenterVertical() );
 
     wxBoxSizer *mAlbumRow = new wxBoxSizer( wxHORIZONTAL );
-    mAlbumRow->Add( new wxStaticText( parent, -1, _("Album :"), wxDefaultPosition, wxDefaultSize, 0 ), wxSizerFlags().Expand().CenterVertical() );
+    mAlbumRow->Add( new wxStaticText( parent, -1, LabelWithColon( _("Album") ), wxDefaultPosition, wxDefaultSize, 0 ), wxSizerFlags().Expand().CenterVertical() );
     wxStaticText *mAlbumVal = new wxStaticText( parent, IDC_FD_MEDIA_ALBUM, _("N/A"), wxDefaultPosition, wxDefaultSize, 0 );
     mAlbumVal->SetForegroundColour( wxSystemSettings::GetColour(wxSYS_COLOUR_HOTLIGHT) );
     mAlbumRow->Add( mAlbumVal, wxSizerFlags().Center().Border(wxLEFT, 5) );
     mediaGrid->Add( mAlbumRow, wxSizerFlags().Expand().CenterVertical() );
 
     wxBoxSizer *mTitleRow = new wxBoxSizer( wxHORIZONTAL );
-    mTitleRow->Add( new wxStaticText( parent, -1, _("Title :"), wxDefaultPosition, wxDefaultSize, 0 ), wxSizerFlags().Expand().CenterVertical().Border(wxLEFT, 5) );
+    mTitleRow->Add( new wxStaticText( parent, -1, LabelWithColon( _("Title") ), wxDefaultPosition, wxDefaultSize, 0 ), wxSizerFlags().Expand().CenterVertical().Border(wxLEFT, 5) );
     wxStaticText *mTitleVal = new wxStaticText( parent, IDC_FD_MEDIA_TITLE, _("N/A"), wxDefaultPosition, wxDefaultSize, 0 );
     mTitleVal->SetForegroundColour( wxSystemSettings::GetColour(wxSYS_COLOUR_HOTLIGHT) );
     mTitleRow->Add( mTitleVal, wxSizerFlags().Center().Border(wxLEFT, 5) );
@@ -976,11 +986,11 @@ wxSizer *addFriendDlg( wxWindow *parent, bool call_fit, bool set_sizer )
 
     wxFlexGridSizer *item3 = new wxFlexGridSizer( 2, 0, 0 );
 
-    wxStaticText *item4 = new wxStaticText( parent, -1, _("IP Address :"), wxDefaultPosition, wxDefaultSize, 0 );
+    wxStaticText *item4 = new wxStaticText( parent, -1, LabelWithColon( _("IP Address") ), wxDefaultPosition, wxDefaultSize, 0 );
     item3->Add( item4, wxSizerFlags().CenterVertical().Border(wxRIGHT|wxBOTTOM, 5) );
     CMuleTextCtrl *item5 = new CMuleTextCtrl( parent, ID_IPADDRESS, "", wxDefaultPosition, wxSize(150,-1), 0 );
     item3->Add( item5, wxSizerFlags().CenterVertical().Border(wxLEFT|wxRIGHT|wxBOTTOM, 5) );
-    wxStaticText *item6 = new wxStaticText( parent, -1, _("Port :"), wxDefaultPosition, wxDefaultSize, 0 );
+    wxStaticText *item6 = new wxStaticText( parent, -1, LabelWithColon( _("Port") ), wxDefaultPosition, wxDefaultSize, 0 );
     item3->Add( item6, wxSizerFlags().CenterVertical().Border(wxRIGHT|wxTOP, 5) );
     CMuleTextCtrl *item7 = new CMuleTextCtrl( parent, ID_IPORT, "", wxDefaultPosition, wxSize(80,-1), 0 );
     item3->Add( item7, wxSizerFlags().CenterVertical().Border(wxLEFT|wxRIGHT|wxTOP, 5) );
@@ -991,11 +1001,11 @@ wxSizer *addFriendDlg( wxWindow *parent, bool call_fit, bool set_sizer )
 
     wxFlexGridSizer *item10 = new wxFlexGridSizer( 2, 0, 0 );
 
-    wxStaticText *item11 = new wxStaticText( parent, -1, _("Username :"), wxDefaultPosition, wxDefaultSize, 0 );
+    wxStaticText *item11 = new wxStaticText( parent, -1, LabelWithColon( _("Username") ), wxDefaultPosition, wxDefaultSize, 0 );
     item10->Add( item11, wxSizerFlags().CenterVertical().Border(wxRIGHT|wxBOTTOM, 5) );
     CMuleTextCtrl *item12 = new CMuleTextCtrl( parent, ID_USERNAME, "", wxDefaultPosition, wxSize(250,-1), 0 );
     item10->Add( item12, wxSizerFlags().CenterVertical().Border(wxLEFT|wxBOTTOM, 5) );
-    wxStaticText *item13 = new wxStaticText( parent, -1, _("Userhash :"), wxDefaultPosition, wxDefaultSize, 0 );
+    wxStaticText *item13 = new wxStaticText( parent, -1, LabelWithColon( _("Userhash") ), wxDefaultPosition, wxDefaultSize, 0 );
     item10->Add( item13, wxSizerFlags().CenterVertical().Border(wxRIGHT|wxBOTTOM, 5) );
     CMuleTextCtrl *item14 = new CMuleTextCtrl( parent, ID_USERHASH, "", wxDefaultPosition, wxSize(250,-1), 0 );
     item10->Add( item14, wxSizerFlags().CenterVertical().Border(wxLEFT|wxBOTTOM, 5) );
@@ -1180,9 +1190,9 @@ wxSizer *clientDetails( wxWindow *parent, bool call_fit, bool set_sizer )
 
     wxBoxSizer *item4 = new wxBoxSizer( wxVERTICAL );
 
-    wxStaticText *item5 = new wxStaticText( parent, -1, _("Username:"), wxDefaultPosition, wxDefaultSize, 0 );
+    wxStaticText *item5 = new wxStaticText( parent, -1, LabelWithColon( _("Username") ), wxDefaultPosition, wxDefaultSize, 0 );
     item4->Add( item5, wxSizerFlags().Expand().Border(wxALL, 5) );
-    wxStaticText *item6 = new wxStaticText( parent, -1, _("Userhash:"), wxDefaultPosition, wxDefaultSize, 0 );
+    wxStaticText *item6 = new wxStaticText( parent, -1, LabelWithColon( _("Userhash") ), wxDefaultPosition, wxDefaultSize, 0 );
     item4->Add( item6, wxSizerFlags().Expand().CenterVertical().Border(wxLEFT|wxRIGHT|wxBOTTOM, 5) );
     item3->Add( item4, wxSizerFlags().Center() );
 
@@ -1201,50 +1211,50 @@ wxSizer *clientDetails( wxWindow *parent, bool call_fit, bool set_sizer )
     item10->AddGrowableCol( 1 );
     item10->AddGrowableCol( 4 );
 
-    wxStaticText *item11 = new wxStaticText( parent, -1, _("Client software:"), wxDefaultPosition, wxDefaultSize, 0 );
+    wxStaticText *item11 = new wxStaticText( parent, -1, LabelWithColon( _("Client software") ), wxDefaultPosition, wxDefaultSize, 0 );
     item10->Add( item11, wxSizerFlags().CenterVertical().Border(wxLEFT|wxRIGHT|wxBOTTOM, 5) );
     wxStaticText *item12 = new wxStaticText( parent, ID_DSOFT, _("N/A"), wxDefaultPosition, wxDefaultSize, 0 );
     item12->SetForegroundColour( wxSystemSettings::GetColour(wxSYS_COLOUR_HOTLIGHT) );
     item10->Add( item12, wxSizerFlags().CenterVertical().Border(wxLEFT|wxRIGHT|wxBOTTOM, 5) );
     item10->Add( 20, 20, 0, wxALIGN_CENTER, 5 );
 
-    wxStaticText *item13 = new wxStaticText( parent, -1, _("Client version:"), wxDefaultPosition, wxDefaultSize, 0 );
+    wxStaticText *item13 = new wxStaticText( parent, -1, LabelWithColon( _("Client version") ), wxDefaultPosition, wxDefaultSize, 0 );
     item10->Add( item13, wxSizerFlags().CenterVertical().Border(wxLEFT|wxRIGHT|wxBOTTOM, 5) );
     wxStaticText *item14 = new wxStaticText( parent, ID_DVERSION, _("N/A"), wxDefaultPosition, wxDefaultSize, 0 );
     item14->SetForegroundColour( wxSystemSettings::GetColour(wxSYS_COLOUR_HOTLIGHT) );
     item10->Add( item14, wxSizerFlags().CenterVertical().Border(wxLEFT|wxRIGHT|wxBOTTOM, 5) );
-    wxStaticText *item15 = new wxStaticText( parent, -1, _("IP address:"), wxDefaultPosition, wxDefaultSize, 0 );
+    wxStaticText *item15 = new wxStaticText( parent, -1, LabelWithColon( _("IP Address") ), wxDefaultPosition, wxDefaultSize, 0 );
     item10->Add( item15, wxSizerFlags().CenterVertical().Border(wxLEFT|wxRIGHT|wxBOTTOM, 5) );
     wxStaticText *item16 = new wxStaticText( parent, ID_DIP, _("N/A"), wxDefaultPosition, wxDefaultSize, 0 );
     item16->SetForegroundColour( wxSystemSettings::GetColour(wxSYS_COLOUR_HOTLIGHT) );
     item10->Add( item16, wxSizerFlags().CenterVertical().Border(wxLEFT|wxRIGHT|wxBOTTOM, 5) );
     item10->Add( 20, 20, 0, wxALIGN_CENTER, 5 );
 
-    wxStaticText *item17 = new wxStaticText( parent, -1, _("User ID:"), wxDefaultPosition, wxDefaultSize, 0 );
+    wxStaticText *item17 = new wxStaticText( parent, -1, LabelWithColon( _("User ID") ), wxDefaultPosition, wxDefaultSize, 0 );
     item10->Add( item17, wxSizerFlags().CenterVertical().Border(wxLEFT|wxRIGHT|wxBOTTOM, 5) );
     wxStaticText *item18 = new wxStaticText( parent, ID_DID, _("N/A"), wxDefaultPosition, wxDefaultSize, 0 );
     item18->SetForegroundColour( wxSystemSettings::GetColour(wxSYS_COLOUR_HOTLIGHT) );
     item10->Add( item18, wxSizerFlags().CenterVertical().Border(wxLEFT|wxRIGHT|wxBOTTOM, 5) );
-    wxStaticText *item19 = new wxStaticText( parent, -1, _("Server IP:"), wxDefaultPosition, wxDefaultSize, 0 );
+    wxStaticText *item19 = new wxStaticText( parent, -1, LabelWithColon( _("Server IP") ), wxDefaultPosition, wxDefaultSize, 0 );
     item10->Add( item19, wxSizerFlags().CenterVertical().Border(wxLEFT|wxRIGHT|wxBOTTOM, 5) );
     wxStaticText *item20 = new wxStaticText( parent, ID_DSIP, _("N/A"), wxDefaultPosition, wxDefaultSize, 0 );
     item20->SetForegroundColour( wxSystemSettings::GetColour(wxSYS_COLOUR_HOTLIGHT) );
     item10->Add( item20, wxSizerFlags().CenterVertical().Border(wxLEFT|wxRIGHT|wxBOTTOM, 5) );
     item10->Add( 20, 20, 0, wxALIGN_CENTER, 5 );
 
-    wxStaticText *item21 = new wxStaticText( parent, -1, _("Server name:"), wxDefaultPosition, wxDefaultSize, 0 );
+    wxStaticText *item21 = new wxStaticText( parent, -1, LabelWithColon( _("Server name") ), wxDefaultPosition, wxDefaultSize, 0 );
     item10->Add( item21, wxSizerFlags().CenterVertical().Border(wxLEFT|wxRIGHT|wxBOTTOM, 5) );
     wxStaticText *item22 = new wxStaticText( parent, ID_DSNAME, _("N/A"), wxDefaultPosition, wxDefaultSize, 0 );
     item22->SetForegroundColour( wxSystemSettings::GetColour(wxSYS_COLOUR_HOTLIGHT) );
     item10->Add( item22, wxSizerFlags().CenterVertical().Border(wxLEFT|wxRIGHT|wxBOTTOM, 5) );
-    wxStaticText *item23 = new wxStaticText( parent, -1, _("Obfuscation:"), wxDefaultPosition, wxDefaultSize, 0 );
+    wxStaticText *item23 = new wxStaticText( parent, -1, LabelWithColon( _("Obfuscation") ), wxDefaultPosition, wxDefaultSize, 0 );
     item10->Add( item23, wxSizerFlags().CenterVertical().Border(wxLEFT|wxRIGHT|wxBOTTOM, 5) );
     wxStaticText *item24 = new wxStaticText( parent, IDT_OBFUSCATION, _("N/A"), wxDefaultPosition, wxDefaultSize, 0 );
     item24->SetForegroundColour( wxSystemSettings::GetColour(wxSYS_COLOUR_HOTLIGHT) );
     item10->Add( item24, wxSizerFlags().CenterVertical().Border(wxLEFT|wxRIGHT|wxBOTTOM, 5) );
     item10->Add( 20, 20, 0, wxALIGN_CENTER, 5 );
 
-    wxStaticText *item25 = new wxStaticText( parent, -1, _("Kad:"), wxDefaultPosition, wxDefaultSize, 0 );
+    wxStaticText *item25 = new wxStaticText( parent, -1, LabelWithColon( _("Kad") ), wxDefaultPosition, wxDefaultSize, 0 );
     item10->Add( item25, wxSizerFlags().CenterVertical().Border(wxLEFT|wxRIGHT|wxBOTTOM, 5) );
     wxStaticText *item26 = new wxStaticText( parent, IDT_KAD, _("N/A"), wxDefaultPosition, wxDefaultSize, 0 );
     item26->SetForegroundColour( wxSystemSettings::GetColour(wxSYS_COLOUR_HOTLIGHT) );
@@ -1256,7 +1266,7 @@ wxSizer *clientDetails( wxWindow *parent, bool call_fit, bool set_sizer )
 
     wxBoxSizer *item29 = new wxBoxSizer( wxHORIZONTAL );
 
-    wxStaticText *item30 = new wxStaticText( parent, -1, _("Current request:"), wxDefaultPosition, wxDefaultSize, 0 );
+    wxStaticText *item30 = new wxStaticText( parent, -1, LabelWithColon( _("Current request") ), wxDefaultPosition, wxDefaultSize, 0 );
     item29->Add( item30, wxSizerFlags().CenterVertical().Border(wxALL, 5) );
     wxStaticText *item31 = new wxStaticText( parent, ID_DDOWNLOADING, _("N/A"), wxDefaultPosition, wxDefaultSize, 0 );
     item31->SetForegroundColour( wxSystemSettings::GetColour(wxSYS_COLOUR_HOTLIGHT) );
@@ -1266,38 +1276,38 @@ wxSizer *clientDetails( wxWindow *parent, bool call_fit, bool set_sizer )
     item32->AddGrowableCol( 1 );
     item32->AddGrowableCol( 4 );
 
-    wxStaticText *item33 = new wxStaticText( parent, -1, _("Average upload rate:"), wxDefaultPosition, wxDefaultSize, 0 );
+    wxStaticText *item33 = new wxStaticText( parent, -1, LabelWithColon( _("Average upload rate") ), wxDefaultPosition, wxDefaultSize, 0 );
     item32->Add( item33, wxSizerFlags().CenterVertical().Border(wxLEFT|wxRIGHT|wxBOTTOM, 5) );
     wxStaticText *item34 = new wxStaticText( parent, ID_DAVDR, _("N/A"), wxDefaultPosition, wxDefaultSize, 0 );
     item34->SetForegroundColour( wxSystemSettings::GetColour(wxSYS_COLOUR_HOTLIGHT) );
     item32->Add( item34, wxSizerFlags().Expand().CenterVertical().Border(wxLEFT|wxRIGHT|wxBOTTOM, 5) );
     item32->Add( 20, 20, 0, wxALIGN_CENTER, 5 );
 
-    wxStaticText *item35 = new wxStaticText( parent, -1, _("Average download rate:"), wxDefaultPosition, wxDefaultSize, 0 );
+    wxStaticText *item35 = new wxStaticText( parent, -1, LabelWithColon( _("Average download rate") ), wxDefaultPosition, wxDefaultSize, 0 );
     item32->Add( item35, wxSizerFlags().CenterVertical().Border(wxLEFT|wxRIGHT|wxBOTTOM, 5) );
     wxStaticText *item36 = new wxStaticText( parent, ID_DAVUR, _("N/A"), wxDefaultPosition, wxDefaultSize, 0 );
     item36->SetForegroundColour( wxSystemSettings::GetColour(wxSYS_COLOUR_HOTLIGHT) );
     item32->Add( item36, wxSizerFlags().Expand().CenterVertical().Border(wxLEFT|wxRIGHT|wxBOTTOM, 5) );
-    wxStaticText *item37 = new wxStaticText( parent, -1, _("Uploaded (session):"), wxDefaultPosition, wxDefaultSize, 0 );
+    wxStaticText *item37 = new wxStaticText( parent, -1, LabelWithColon( _("Uploaded (session)") ), wxDefaultPosition, wxDefaultSize, 0 );
     item32->Add( item37, wxSizerFlags().CenterVertical().Border(wxLEFT|wxRIGHT|wxBOTTOM, 5) );
     wxStaticText *item38 = new wxStaticText( parent, ID_DDOWN, _("N/A"), wxDefaultPosition, wxDefaultSize, 0 );
     item38->SetForegroundColour( wxSystemSettings::GetColour(wxSYS_COLOUR_HOTLIGHT) );
     item32->Add( item38, wxSizerFlags().Expand().CenterVertical().Border(wxLEFT|wxRIGHT|wxBOTTOM, 5) );
     item32->Add( 20, 20, 0, wxALIGN_CENTER, 5 );
 
-    wxStaticText *item39 = new wxStaticText( parent, -1, _("Downloaded (session):"), wxDefaultPosition, wxDefaultSize, 0 );
+    wxStaticText *item39 = new wxStaticText( parent, -1, LabelWithColon( _("Downloaded (session)") ), wxDefaultPosition, wxDefaultSize, 0 );
     item32->Add( item39, wxSizerFlags().CenterVertical().Border(wxLEFT|wxRIGHT|wxBOTTOM, 5) );
     wxStaticText *item40 = new wxStaticText( parent, ID_DDUP, _("N/A"), wxDefaultPosition, wxDefaultSize, 0 );
     item40->SetForegroundColour( wxSystemSettings::GetColour(wxSYS_COLOUR_HOTLIGHT) );
     item32->Add( item40, wxSizerFlags().Expand().CenterVertical().Border(wxLEFT|wxRIGHT|wxBOTTOM, 5) );
-    wxStaticText *item41 = new wxStaticText( parent, -1, _("Uploaded (total):"), wxDefaultPosition, wxDefaultSize, 0 );
+    wxStaticText *item41 = new wxStaticText( parent, -1, LabelWithColon( _("Uploaded (total)") ), wxDefaultPosition, wxDefaultSize, 0 );
     item32->Add( item41, wxSizerFlags().CenterVertical().Border(wxLEFT|wxRIGHT|wxBOTTOM, 5) );
     wxStaticText *item42 = new wxStaticText( parent, ID_DDOWNTOTAL, _("N/A"), wxDefaultPosition, wxDefaultSize, 0 );
     item42->SetForegroundColour( wxSystemSettings::GetColour(wxSYS_COLOUR_HOTLIGHT) );
     item32->Add( item42, wxSizerFlags().Expand().CenterVertical().Border(wxLEFT|wxRIGHT|wxBOTTOM, 5) );
     item32->Add( 20, 20, 0, wxALIGN_CENTER, 5 );
 
-    wxStaticText *item43 = new wxStaticText( parent, -1, _("Downloaded (total):"), wxDefaultPosition, wxDefaultSize, 0 );
+    wxStaticText *item43 = new wxStaticText( parent, -1, LabelWithColon( _("Downloaded (total)") ), wxDefaultPosition, wxDefaultSize, 0 );
     item32->Add( item43, wxSizerFlags().CenterVertical().Border(wxLEFT|wxRIGHT|wxBOTTOM, 5) );
     wxStaticText *item44 = new wxStaticText( parent, ID_DUPTOTAL, _("N/A"), wxDefaultPosition, wxDefaultSize, 0 );
     item44->SetForegroundColour( wxSystemSettings::GetColour(wxSYS_COLOUR_HOTLIGHT) );
@@ -1311,26 +1321,26 @@ wxSizer *clientDetails( wxWindow *parent, bool call_fit, bool set_sizer )
     item47->AddGrowableCol( 1 );
     item47->AddGrowableCol( 4 );
 
-    wxStaticText *item48 = new wxStaticText( parent, -1, _("DL/UP modifier:"), wxDefaultPosition, wxDefaultSize, 0 );
+    wxStaticText *item48 = new wxStaticText( parent, -1, LabelWithColon( _("DL/UP modifier") ), wxDefaultPosition, wxDefaultSize, 0 );
     item47->Add( item48, wxSizerFlags().CenterVertical().Border(wxALL, 5) );
     wxStaticText *item49 = new wxStaticText( parent, ID_DRATIO, _("N/A"), wxDefaultPosition, wxDefaultSize, 0 );
     item49->SetForegroundColour( wxSystemSettings::GetColour(wxSYS_COLOUR_HOTLIGHT) );
     item47->Add( item49, wxSizerFlags().Expand().CenterVertical().Border(wxALL, 5) );
     item47->Add( 20, 20, 0, wxALIGN_CENTER, 5 );
 
-    wxStaticText *item50 = new wxStaticText( parent, -1, _("Secure ident:"), wxDefaultPosition, wxDefaultSize, 0 );
+    wxStaticText *item50 = new wxStaticText( parent, -1, LabelWithColon( _("Secure ident") ), wxDefaultPosition, wxDefaultSize, 0 );
     item47->Add( item50, wxSizerFlags().CenterVertical().Border(wxALL, 5) );
     wxStaticText *item51 = new wxStaticText( parent, IDC_CDIDENT, _("N/A"), wxDefaultPosition, wxDefaultSize, 0 );
     item51->SetForegroundColour( wxSystemSettings::GetColour(wxSYS_COLOUR_HOTLIGHT) );
     item47->Add( item51, wxSizerFlags().Expand().CenterVertical().Border(wxALL, 5) );
-    wxStaticText *item52 = new wxStaticText( parent, -1, _("Queue rank:"), wxDefaultPosition, wxDefaultSize, 0 );
+    wxStaticText *item52 = new wxStaticText( parent, -1, LabelWithColon( _("Queue rank") ), wxDefaultPosition, wxDefaultSize, 0 );
     item47->Add( item52, wxSizerFlags().CenterVertical().Border(wxLEFT|wxRIGHT|wxBOTTOM, 5) );
     wxStaticText *item53 = new wxStaticText( parent, ID_QUEUERANK, _("N/A"), wxDefaultPosition, wxDefaultSize, 0 );
     item53->SetForegroundColour( wxSystemSettings::GetColour(wxSYS_COLOUR_HOTLIGHT) );
     item47->Add( item53, wxSizerFlags().Expand().CenterVertical().Border(wxLEFT|wxRIGHT|wxBOTTOM, 5) );
     item47->Add( 20, 20, 0, wxALIGN_CENTER, 5 );
 
-    wxStaticText *item54 = new wxStaticText( parent, -1, _("Queue score:"), wxDefaultPosition, wxDefaultSize, 0 );
+    wxStaticText *item54 = new wxStaticText( parent, -1, LabelWithColon( _("Queue score") ), wxDefaultPosition, wxDefaultSize, 0 );
     item47->Add( item54, wxSizerFlags().CenterVertical().Border(wxLEFT|wxRIGHT|wxBOTTOM, 5) );
     wxStaticText *item55 = new wxStaticText( parent, ID_DSCORE, _("N/A"), wxDefaultPosition, wxDefaultSize, 0 );
     item55->SetForegroundColour( wxSystemSettings::GetColour(wxSYS_COLOUR_HOTLIGHT) );
@@ -1954,7 +1964,7 @@ wxSizer *PreferencesPathMappingTab( wxWindow *parent, bool call_fit, bool set_si
     itemBoxSizer->Add( itemList, wxSizerFlags(1).Expand().CenterVertical() );
 
     wxBoxSizer *itemRemoteRow = new wxBoxSizer( wxHORIZONTAL );
-    wxStaticText *itemRemoteLabel = new wxStaticText( parent, -1, _("Remote prefix") + ":", wxDefaultPosition, wxDefaultSize, 0 );
+    wxStaticText *itemRemoteLabel = new wxStaticText( parent, -1, LabelWithColon( _("Remote prefix") ), wxDefaultPosition, wxDefaultSize, 0 );
     itemRemoteRow->Add( itemRemoteLabel, wxSizerFlags().CenterVertical().Border(wxRIGHT, 4) );
     CMuleTextCtrl *itemRemote = new CMuleTextCtrl( parent, IDC_PATHMAP_REMOTE, "", wxDefaultPosition, wxSize(80,-1), 0 );
     itemRemote->SetToolTip(_("A path prefix as the core reports it, e.g. /home/user/downloads/incoming"));
@@ -1962,7 +1972,7 @@ wxSizer *PreferencesPathMappingTab( wxWindow *parent, bool call_fit, bool set_si
     itemBoxSizer->Add( itemRemoteRow, wxSizerFlags().Expand().Border(wxTOP, 4) );
 
     wxBoxSizer *itemLocalRow = new wxBoxSizer( wxHORIZONTAL );
-    wxStaticText *itemLocalLabel = new wxStaticText( parent, -1, _("Local prefix") + ":", wxDefaultPosition, wxDefaultSize, 0 );
+    wxStaticText *itemLocalLabel = new wxStaticText( parent, -1, LabelWithColon( _("Local prefix") ), wxDefaultPosition, wxDefaultSize, 0 );
     itemLocalRow->Add( itemLocalLabel, wxSizerFlags().CenterVertical().Border(wxRIGHT, 4) );
     CMuleTextCtrl *itemLocal = new CMuleTextCtrl( parent, IDC_PATHMAP_LOCAL, "", wxDefaultPosition, wxSize(80,-1), 0 );
     itemLocal->SetToolTip(_("Where that same folder is reachable from this computer, e.g. a mounted network share"));
@@ -2473,21 +2483,21 @@ wxSizer *CategoriesEditWindow( wxWindow *parent, bool call_fit, bool set_sizer )
 
     wxBoxSizer *item3 = new wxBoxSizer( wxHORIZONTAL );
 
-    wxStaticText *item4 = new wxStaticText( parent, -1, _("Title :"), wxDefaultPosition, wxDefaultSize, 0 );
+    wxStaticText *item4 = new wxStaticText( parent, -1, LabelWithColon( _("Title") ), wxDefaultPosition, wxDefaultSize, 0 );
     item3->Add( item4, wxSizerFlags().Center().Border(wxLEFT|wxRIGHT, 5) );
     CMuleTextCtrl *item5 = new CMuleTextCtrl( parent, IDC_TITLE, "", wxDefaultPosition, wxDefaultSize, 0 );
     item3->Add( item5, wxSizerFlags(1).Expand().CenterHorizontal().Border(wxRIGHT, 5) );
     item1->Add( item3, wxSizerFlags().Expand().CenterVertical().Border(wxTOP|wxBOTTOM, 5) );
     wxBoxSizer *item6 = new wxBoxSizer( wxHORIZONTAL );
 
-    wxStaticText *item7 = new wxStaticText( parent, -1, _("Comment :"), wxDefaultPosition, wxDefaultSize, 0 );
+    wxStaticText *item7 = new wxStaticText( parent, -1, LabelWithColon( _("Comment") ), wxDefaultPosition, wxDefaultSize, 0 );
     item6->Add( item7, wxSizerFlags().Center().Border(wxLEFT|wxRIGHT, 5) );
     CMuleTextCtrl *item8 = new CMuleTextCtrl( parent, IDC_COMMENT, "", wxDefaultPosition, wxDefaultSize, 0 );
     item6->Add( item8, wxSizerFlags(1).Expand().CenterHorizontal().Border(wxRIGHT, 5) );
     item1->Add( item6, wxSizerFlags().Expand().CenterVertical().Border(wxBOTTOM, 5) );
     wxBoxSizer *item9 = new wxBoxSizer( wxHORIZONTAL );
 
-    wxStaticText *item10 = new wxStaticText( parent, -1, _("Incoming Dir :"), wxDefaultPosition, wxDefaultSize, 0 );
+    wxStaticText *item10 = new wxStaticText( parent, -1, LabelWithColon( _("Incoming Dir") ), wxDefaultPosition, wxDefaultSize, 0 );
     item9->Add( item10, wxSizerFlags().Center().Border(wxLEFT|wxRIGHT, 5) );
     CMuleTextCtrl *item11 = new CMuleTextCtrl( parent, IDC_INCOMING, "", wxDefaultPosition, wxDefaultSize, 0 );
     item9->Add( item11, wxSizerFlags(1).Expand().CenterHorizontal() );
@@ -2496,7 +2506,7 @@ wxSizer *CategoriesEditWindow( wxWindow *parent, bool call_fit, bool set_sizer )
     item1->Add( item9, wxSizerFlags().Expand().CenterVertical().Border(wxBOTTOM, 5) );
     wxFlexGridSizer *item13 = new wxFlexGridSizer( 2, 0, 0 );
 
-    wxStaticText *item14 = new wxStaticText( parent, -1, _("Change priority for new assigned files :"), wxDefaultPosition, wxDefaultSize, 0 );
+    wxStaticText *item14 = new wxStaticText( parent, -1, LabelWithColon( _("Change priority for new assigned files") ), wxDefaultPosition, wxDefaultSize, 0 );
     item13->Add( item14, wxSizerFlags().CenterVertical().Border(wxLEFT|wxRIGHT, 5) );
     wxString strs15[] = 
     {
@@ -2512,7 +2522,7 @@ wxSizer *CategoriesEditWindow( wxWindow *parent, bool call_fit, bool set_sizer )
     wxFlexGridSizer *item16 = new wxFlexGridSizer( 3, 0, 0 );
     item16->AddGrowableCol( 2 );
 
-    wxStaticText *item17 = new wxStaticText( parent, -1, _("Select color for this Category (currently selected) :"), wxDefaultPosition, wxDefaultSize, 0 );
+    wxStaticText *item17 = new wxStaticText( parent, -1, LabelWithColon( _("Select color for this Category (currently selected)") ), wxDefaultPosition, wxDefaultSize, 0 );
     item16->Add( item17, wxSizerFlags().CenterVertical().Border(wxLEFT|wxRIGHT, 5) );
     wxStaticBox *item19 = new wxStaticBox( parent, -1, "" );
     wxStaticBoxSizer *item18 = new wxStaticBoxSizer( item19, wxVERTICAL );
@@ -2830,7 +2840,7 @@ item9->SetName("kadScope");
     CMuleTextCtrl *item26 = new CMuleTextCtrl( parent, ID_NODE_IP, "", wxDefaultPosition, wxDefaultSize, 0 );
     item26->SetToolTip( _("Enter the IP of the node here, using the x.x.x.x format.") );
     item24->Add( item26, wxSizerFlags(1).Center().Border(wxLEFT|wxRIGHT, 5) );
-    wxStaticText *item34 = new wxStaticText( parent, -1, _("Port:"), wxDefaultPosition, wxDefaultSize, wxST_NO_AUTORESIZE );
+    wxStaticText *item34 = new wxStaticText( parent, -1, LabelWithColon( _("Port") ), wxDefaultPosition, wxDefaultSize, wxST_NO_AUTORESIZE );
     item24->Add( item34, wxSizerFlags().Center().Border(wxLEFT|wxRIGHT, 5) );
     CMuleTextCtrl *item35 = new CMuleTextCtrl( parent, ID_NODE_PORT, "", wxDefaultPosition, wxSize(80,-1), 0 );
     item24->Add( item35, wxSizerFlags().Center().Border(wxLEFT|wxRIGHT, 5) );
@@ -3192,7 +3202,7 @@ wxSizer *PreferencesProxyTab( wxWindow *parent, bool call_fit, bool set_sizer )
     item8->SetToolTip( _("Enable/disable proxy support") );
     item2->Add( item8, wxSizerFlags().CenterVertical().Border(wxALL, 0) );
     item2->Add( 20, 20, wxSizerFlags().CenterVertical().Border(wxALL, 5) );
-    wxStaticText *item9 = new wxStaticText( parent, -1, _("Proxy type:"), wxDefaultPosition, wxDefaultSize, 0 );
+    wxStaticText *item9 = new wxStaticText( parent, -1, LabelWithColon( _("Proxy type") ), wxDefaultPosition, wxDefaultSize, 0 );
     item2->Add( item9, wxSizerFlags().CenterVertical().Border(wxLEFT, 20) );
     wxString strs10[] =
     {
@@ -3203,12 +3213,12 @@ wxSizer *PreferencesProxyTab( wxWindow *parent, bool call_fit, bool set_sizer )
     };
     wxChoice *item10 = new wxChoice( parent, ID_PROXY_TYPE, wxDefaultPosition, wxSize(100,-1), 4, strs10, 0 );
     item2->Add( item10, wxSizerFlags().Expand().CenterVertical().Border(wxLEFT|wxTOP, 5) );
-    wxStaticText *item11 = new wxStaticText( parent, -1, _("Proxy host:"), wxDefaultPosition, wxDefaultSize, 0 );
+    wxStaticText *item11 = new wxStaticText( parent, -1, LabelWithColon( _("Proxy host") ), wxDefaultPosition, wxDefaultSize, 0 );
     item2->Add( item11, wxSizerFlags().CenterVertical().Border(wxLEFT, 20) );
     wxTextCtrl *item12 = new wxTextCtrl( parent, ID_PROXY_NAME, "", wxDefaultPosition, wxDefaultSize, 0 );
     item12->SetToolTip( _("The proxy host name") );
     item2->Add( item12, wxSizerFlags().Expand().CenterVertical().Border(wxLEFT|wxTOP, 5) );
-    wxStaticText *item13 = new wxStaticText( parent, -1, _("Proxy port:"), wxDefaultPosition, wxDefaultSize, 0 );
+    wxStaticText *item13 = new wxStaticText( parent, -1, LabelWithColon( _("Proxy port") ), wxDefaultPosition, wxDefaultSize, 0 );
     item2->Add( item13, wxSizerFlags().CenterVertical().Border(wxLEFT, 20) );
     wxTextCtrl *item14 = new wxTextCtrl( parent, ID_PROXY_PORT, "", wxDefaultPosition, wxSize(80,-1), 0 );
     item14->SetToolTip( _("The proxy port") );
@@ -3217,12 +3227,12 @@ wxSizer *PreferencesProxyTab( wxWindow *parent, bool call_fit, bool set_sizer )
     item3->SetToolTip( _("Enable/disable username/password authentication") );
     item2->Add( item3, wxSizerFlags().CenterVertical().Border(wxALL, 0) );
     item2->Add( 20, 20, wxSizerFlags().CenterVertical().Border(wxALL, 5) );
-    wxStaticText *item4 = new wxStaticText( parent, -1, _("Username: "), wxDefaultPosition, wxDefaultSize, 0 );
+    wxStaticText *item4 = new wxStaticText( parent, -1, LabelWithColon( _("Username") ), wxDefaultPosition, wxDefaultSize, 0 );
     item2->Add( item4, wxSizerFlags().CenterVertical().Border(wxLEFT, 20) );
     wxTextCtrl *item5 = new wxTextCtrl( parent, ID_PROXY_USER, "", wxDefaultPosition, wxSize(80,-1), 0 );
     item5->SetToolTip( _("The username to use to connect to the proxy") );
     item2->Add( item5, wxSizerFlags().Expand().CenterVertical().Border(wxALL, 0) );
-    wxStaticText *item6 = new wxStaticText( parent, -1, _("Password:"), wxDefaultPosition, wxDefaultSize, 0 );
+    wxStaticText *item6 = new wxStaticText( parent, -1, LabelWithColon( _("Password") ), wxDefaultPosition, wxDefaultSize, 0 );
     item2->Add( item6, wxSizerFlags().CenterVertical().Border(wxLEFT, 20) );
     wxTextCtrl *item7 = new wxTextCtrl( parent, ID_PROXY_PASSWORD, "", wxDefaultPosition, wxSize(80,-1), wxTE_PASSWORD );
     item7->SetToolTip( _("The password to use to connect to the proxy") );


### PR DESCRIPTION
Labels built their punctuation in C++ - `label + wxT(" :")` on the file-details Sharing rows, `_("Remote prefix") + ":"` on the directories page - so the spacing lived outside the catalog and no translation could change it. Russian typography forbids a space before a colon, French requires one, and neither could be expressed. That is what #1294 reports.

Elsewhere the colon sat inside the msgid. That is translatable, but costs a second string per label - `Name` for the list column and `Name:` for the dialog field, `Username` plus **three** different colon spellings across three dialogs.

Both go through one helper now, `LabelWithColon()`, applying a single localizable `"%s:"` format to the already-translated label. A translator settles the convention once and it applies everywhere.

## Whole dialogs, not just the broken rows

Converting only the eleven broken Sharing rows would have been **worse than leaving them alone**: they would read `Requests:` beside an unconverted `Available :` in the same dialog - exactly the inconsistency the report is about. Every dialog touched is converted end to end:

| Dialog | Labels |
|---|---|
| `fileDetails` | 34 |
| `clientDetails` | 21 |
| `CategoriesEditWindow` | 5 |
| `PreferencesProxyTab` | 5 |
| `addFriendDlg` | 4 |
| `searchDlg` | 2 |

`ServerWnd`'s info panel is deliberately untouched so it stays internally consistent; converting it is a separate decision.

## Translations are migrated, not discarded

A plain rename would have cost forty-odd strings times forty languages of retranslation. Instead each retired msgid hands its translation to the bare form with the trailing punctuation stripped, honouring what each language actually wrote:

| | before | after |
|---|---|---|
| fr `Album :` | `Album :` (non-breaking space) | `Album` |
| ja `IP Address:` | `IPアドレス：` (full-width colon) | `IPアドレス` |

| | entries | untranslated | fuzzy |
|---|---|---|---|
| master | 82840 | 25114 | 6572 |
| this PR | 82320 | **24906** | 6601 |
| delta | -520 | **-208** | **+29** |

1344 translations carry across. Net: translators get **208 fewer untranslated strings** than master, and under one extra fuzzy per language.

## A latent bug this exposes

83 translations of the *bare* labels already carried a colon of their own - German `Name:` for a msgid containing no colon - added to compensate for the label context. Left alone they would now render `Name::`. They are stripped too, which also corrects the list column headers sharing those msgids: headers in 26 languages stop showing a trailing colon they should never have had.

The `clientDetails` IP row used `IP address:` where the columns use `IP Address`; it now reuses the existing msgid rather than minting a case-only twin.

## Catalog

`2071` msgids -> `2058`, net **-13**: 58 colon-suffixed strings retired, 45 added (44 bare labels plus `%s:`).

Of the 58 retired, **14 reuse a bare msgid that already existed** - pure deduplication:

| Retired | Reuses |
|---|---|
| `Bitrate :` | `Bitrate` |
| `Codec :` | `Codec` |
| `Comment :` | `Comment` |
| `IP Address :` | `IP Address` |
| `Kad:` | `Kad` |
| `Length :` | `Length` |
| `Name:` | `Name` |
| `Password:` | `Password` |
| `Port :` | `Port` |
| `Port:` | `Port` |
| `Transferred :` | `Transferred` |
| `Username :` | `Username` |
| `Username:` | `Username` |
| `Username: ` | `Username` |

<details><summary>the other 44, which mint their bare form</summary>

| Retired | Now |
|---|---|
| `Album :` | `Album` |
| `Artist :` | `Artist` |
| `Available :` | `Available` |
| `Average download rate:` | `Average download rate` |
| `Average upload rate:` | `Average upload rate` |
| `Change priority for new assigned files :` | `Change priority for new assigned files` |
| `Client software:` | `Client software` |
| `Client version:` | `Client version` |
| `Completed Size :` | `Completed Size` |
| `Current request:` | `Current request` |
| `DL/UP modifier:` | `DL/UP modifier` |
| `Datarate :` | `Datarate` |
| `Download Active Time: ` | `Download Active Time` |
| `Downloaded (session):` | `Downloaded (session)` |
| `Downloaded (total):` | `Downloaded (total)` |
| `Filepart-Count :` | `Filepart-Count` |
| `Filesize :` | `Filesize` |
| `Found Sources :` | `Found Sources` |
| `Full Name :` | `Full Name` |
| `Gained by compression :` | `Gained by compression` |
| `Hash :` | `Hash` |
| `Incoming Dir :` | `Incoming Dir` |
| `Last seen complete :` | `Last seen complete` |
| `Lost to corruption :` | `Lost to corruption` |
| `Obfuscation:` | `Obfuscation` |
| `Packages saved by I.C.H. :` | `Packages saved by I.C.H.` |
| `Partfilestatus :` | `Partfilestatus` |
| `Proxy host:` | `Proxy host` |
| `Proxy port:` | `Proxy port` |
| `Proxy type:` | `Proxy type` |
| `Queue rank:` | `Queue rank` |
| `Queue score:` | `Queue score` |
| `Secure ident:` | `Secure ident` |
| `Select color for this Category (currently selected) :` | `Select color for this Category (currently selected)` |
| `Server IP:` | `Server IP` |
| `Server name:` | `Server name` |
| `Title :` | `Title` |
| `Transferring Sources :` | `Transferring Sources` |
| `Uploaded (session):` | `Uploaded (session)` |
| `Uploaded (total):` | `Uploaded (total)` |
| `User ID:` | `User ID` |
| `Userhash :` | `Userhash` |
| `Userhash:` | `Userhash` |
| `met-File :` | `met-File` |

</details>

## Left alone deliberately

| Msgid | Why |
|---|---|
| `ERROR: `, `WARNING: ` | matched with `StartsWith()` in Logger.cpp - log prefixes, not labels |
| `eD2k: `, `Kad: `, `Server: `, `Download: `, `Sharing: ` | tray-icon and wxCas strings built by concatenation; the trailing space is load-bearing |
| ` KiB/s`, ` MiB/s`, `aMule `, `Server IP: ` (note the trailing space) | leading/trailing space is a separator at ~9 concatenation sites. Distinct from `Server IP:` without one, which is a `clientDetails` label and *is* converted above |
| `Filter:` | still used by the Downloads and Shared Files toolbars (`transferTopPane`, `sharedfilesTopDlg`), which are not swept here, so it coexists with the new bare `Filter` from `searchDlg` |
| `Status:` | `ServerWnd`'s panel is left whole, so it keeps its own copy alongside the bare `Status` used elsewhere |
| other colon msgids in untouched dialogs | those dialogs are internally consistent; converting them is a project-wide typography decision |

## Visible change

English now reads `Bitrate:`, `Name:`, `Requests:` throughout the six dialogs. `"%s:"` is chosen because English and Russian want no space; French adds it in translation, once, for the whole UI.

## Verification

- No converted dialog contains any colon-bearing literal, via `_()` or `wxT()`, in any spelling.
- No retired msgid still referenced in `src/`; no translation changed for any msgid outside the converted set, checked pairwise against master across all 40 catalogs.
- No label msgid in scope is left translated with a trailing colon.
- Builds clean; clang-format and both clang-tidy tiers clean; `msgfmt --check-format` passes.
- gettext marks the entry `c-format`, so a translation dropping the `%s` is rejected rather than silently losing the label.

Closes #1294.
