### PR TITLE
fix(gui): give the availability fade back its range

### DIFF
--- a/src/PartBarLegend.h
+++ b/src/PartBarLegend.h
@@ -120,12 +120,17 @@ constexpr BarColour kZeroSources{ 255, 0, 0 };
 //! or the same file looks differently shared in the GUI and in a browser.
 constexpr unsigned kAvailFull = 10;
 
-//! The endpoints of the fade: one source, and kAvailFull or more. Taken from
-//! the Web UI's --piece-avail-lo / --piece-avail (src/webapi/static/css/
-//! app.css:29-30), which is the pair that survives; the GUI's former
-//! (0,210,255) -> (0,0,255) does not.
+//! The endpoints of the fade: one source, and kAvailFull or more. Shared with
+//! the Web UI's light theme as --piece-avail-lo / --piece-avail (src/webapi/
+//! static/css/app.css:29-30); the test reads them from there, so the two
+//! surfaces cannot drift.
+//!
+//! The dark end is deeper than the pair adopted in #1282. That pair travelled
+//! about a third less than the ramp it replaced and compressed the middle of
+//! the scale, so neighbouring source counts were hard to tell apart at a
+//! glance -- the one thing the bar exists to show. The light end is unchanged.
 constexpr BarColour kAvailFew{ 166, 212, 238 };
-constexpr BarColour kAvailMany{ 47, 143, 208 };
+constexpr BarColour kAvailMany{ 13, 59, 102 };
 
 //! Steps between the two endpoints, so kAvailFull is stated once.
 constexpr int kAvailFadeSteps = static_cast<int>(kAvailFull) - 1;

--- a/src/webapi/static/css/app.css
+++ b/src/webapi/static/css/app.css
@@ -26,7 +26,7 @@
   /* download pieces bar: available-but-not-downloaded parts (aMule's blue).
      The graph fades --piece-avail-lo (few sources) -> --piece-avail (many)
      to show availability, like the desktop GUI's blue gradient. */
-  --piece-avail: #2f8fd0;
+  --piece-avail: #0d3b66;
   --piece-avail-lo: #a6d4ee;
   --sel: rgba(22, 100, 192, .2);
   --stripe: rgba(0, 0, 0, .025);

--- a/unittests/tests/PartBarLegendTest.cpp
+++ b/unittests/tests/PartBarLegendTest.cpp
@@ -91,14 +91,14 @@ constexpr BarColour kExpectedNextPending{ 255, 255, 100 };
 //! agree with a wrong one.
 constexpr BarColour kExpectedZeroSources{ 255, 0, 0 };
 constexpr BarColour kExpectedOneSource{ 166, 212, 238 };
-constexpr BarColour kExpectedFiveSources{ 113, 181, 225 };
-constexpr BarColour kExpectedNineSources{ 60, 151, 211 };
-constexpr BarColour kExpectedManySources{ 47, 143, 208 };
+constexpr BarColour kExpectedFiveSources{ 98, 144, 178 };
+constexpr BarColour kExpectedNineSources{ 30, 76, 117 };
+constexpr BarColour kExpectedManySources{ 13, 59, 102 };
 
 //! One more sample, one step along the fade, so the table below has a value
-//! between the light endpoint and the halfway point. 166 - 119/9 rounds to
-//! 153, 212 - 69/9 to 204, 238 - 30/9 to 235.
-constexpr BarColour kExpectedTwoSources{ 153, 204, 235 };
+//! between the light endpoint and the halfway point. 166 - 153/9 rounds to
+//! 149, 212 - 153/9 to 195, 238 - 136/9 to 223.
+constexpr BarColour kExpectedTwoSources{ 149, 195, 223 };
 
 //! What a bar cell shows for a part @c sources peers hold, as one table.
 //!


### PR DESCRIPTION
#1282 converged the desktop GUI's two chunk bars and the Web UI on one fade, which was the right move. This keeps that and widens the pair, because the one it adopted is too narrow to read.

| | endpoints | travel | luminance spread | smallest step |
|---|---|---|---|---|
| ramp before #1282 | `#00d2ff` to `#0000ff` | 210 | 0.46 | 23.0 |
| after #1282 | `#a6d4ee` to `#2f8fd0` | 141 | 0.37 | 15.3 |
| **this PR** | `#a6d4ee` to `#0d3b66` | **256** | **0.57** | **28.3** |

The loss landed in the middle of the scale, which is where the counts a user compares actually sit: telling six sources from seven at a glance is the one thing this bar exists to do.

**The light end does not move.** Only the deep end deepens, so the pale end of the Web UI's light theme is exactly as it was, and the direction is unchanged: darker as more peers hold the part. The Web UI's dark theme keeps its own pair, which runs the other way because that is what reads as "more" against a dark ground.

### Both definitions move together

`kAvailMany` in `PartBarLegend.h` and `--piece-avail` in `app.css`, as the pin requires. Reverting either one alone fails `TheWebUiFadesBetweenTheSameTwoColours` by name, which I checked rather than assumed. That property is #1282's and this change keeps it.

### The legend dialog needs no edit

Its two blue rows are `AvailabilityPartColour(FewSources)` and `(ManySources)`, defined as the fade at 1 and at `kAvailFull`, and the gradient swatch is filled between *those two rows* rather than from the fade, per its own comment. All three follow the constants.

The test's hand-written expectations are recomputed, still by hand: a value derived from the header's own arithmetic would agree with a wrong header.

### Verification

Monolithic and amulegui build with 0 errors and no new warnings. 48/48 ctest. clang-format 18.1.8 whole-file with `--style=file:<repo>/.clang-format`: clean. clang-tidy Tier-1 and Tier-2 on the diff: 0 findings, 0 compiler errors. No translatable strings touched, so no catalog work; the Web UI dictionary check passes.

The bar itself cannot be exercised headlessly. The comparison above was rendered from both formulas and reviewed against the old ramp before picking this pair.
