### PR TITLE
feat(kad): adaptive request timeout and node protection behind ENABLE_KAD_NODE_PROTECTION

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -170,39 +170,36 @@ jobs:
   # experimental switch defaults to OFF. This job is the other half: one Linux
   # build per switch with it ON, so the code behind it cannot rot unnoticed.
   #
-  # A matrix over the switches rather than one job apiece. Deliberately not an
-  # extra dimension on the OS jobs -- doubling every one of those would cost
-  # far more than it tells us, since these switches change no
-  # platform-dependent code. Adding a switch is one entry here, which is the
-  # point: NAT traversal, uTP, QUIC and IPv6 are all still to come, and a
-  # second hand-written near-copy of this job was the alternative.
+  # One job for the whole set rather than one per switch. It asks for the set
+  # through ENABLE_ALL_EXPERIMENTAL, so CI cost stays flat as switches are
+  # added and no entry here has to be edited: NAT traversal, uTP, QUIC and
+  # IPv6 are all still to come. Enabling everything at once is also what a
+  # user who wants the features actually builds, and it is the only
+  # combination that catches switches which do not compile together.
   #
-  # `flags` rather than a bare name so an entry can set more than one, which
-  # is what the `all` entry needs: enabling every switch at once is what a user
-  # who wants the features actually builds, and no per-switch job covers the
-  # combination. `all` asks for the set through ENABLE_ALL_EXPERIMENTAL rather
-  # than naming switches, so it keeps covering the combination as more arrive.
+  # The cost of not building each switch alone: one that compiles only
+  # alongside another would pass here and fail for someone enabling just that
+  # one. Accepted deliberately, since these switches are independent
+  # subsystems; a per-switch entry can be added to the matrix if that changes.
+  #
+  # Deliberately not an extra dimension on the OS jobs -- doubling every one of
+  # those would cost far more than it tells us, since these switches change no
+  # platform-dependent code.
   build_cmake_ubuntu_experimental:
-    name: Build CMake Ubuntu Experimental (Release, ${{ matrix.name }})
+    name: Build CMake Ubuntu Experimental (${{ matrix.build_type }})
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - name: ENABLE_KAD_PROTOCOL_10
-            flags: -DENABLE_KAD_PROTOCOL_10=YES
-          - name: ENABLE_KAD_NODE_PROTECTION
-            flags: -DENABLE_KAD_NODE_PROTECTION=YES
-          - name: all
-            flags: -DENABLE_ALL_EXPERIMENTAL=YES
+        build_type: [Debug, Release]
     steps:
       - uses: actions/checkout@v7
       - name: restore ccache
         uses: actions/cache/restore@v6
         with:
           path: ${{ env.CCACHE_DIR }}
-          key: ${{ runner.os }}-${{ matrix.name }}-ccache-${{ hashFiles('**/CMakeLists.txt', 'cmake/**') }}
-          restore-keys: ${{ runner.os }}-${{ matrix.name }}-ccache-
+          key: ${{ runner.os }}-experimental-${{ matrix.build_type }}-ccache-${{ hashFiles('**/CMakeLists.txt', 'cmake/**') }}
+          restore-keys: ${{ runner.os }}-experimental-${{ matrix.build_type }}-ccache-
       - name: install deps
         run: |
           sudo apt-get update
@@ -210,10 +207,10 @@ jobs:
       - name: create build system
         run: |
           cmake \
-            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
             ${{ env.cmake_common_config_flags }} \
             ${{ env.cmake_ubuntu_config_flags }} \
-            ${{ matrix.flags }}
+            -DENABLE_ALL_EXPERIMENTAL=YES
       - name: zero ccache stats
         run: ccache --zero-stats
       - name: make
@@ -223,7 +220,7 @@ jobs:
         if: always() && github.event_name == 'push' && github.ref == 'refs/heads/master'
         with:
           path: ${{ env.CCACHE_DIR }}
-          key: ${{ runner.os }}-${{ matrix.name }}-ccache-${{ github.run_id }}
+          key: ${{ runner.os }}-experimental-${{ matrix.build_type }}-ccache-${{ github.run_id }}
       - name: ccache stats
         if: always()
         run: ccache --show-stats

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -178,12 +178,12 @@ jobs:
   # second hand-written near-copy of this job was the alternative.
   #
   # `flags` rather than a bare name so an entry can set more than one, which
-  # is what an `all` entry needs: enabling every switch at once is what a user
+  # is what the `all` entry needs: enabling every switch at once is what a user
   # who wants the features actually builds, and no per-switch job covers the
-  # combination. There is only one switch here, so `all` would be a duplicate
-  # job today; it belongs in the change that adds the second.
+  # combination. `all` asks for the set through ENABLE_ALL_EXPERIMENTAL rather
+  # than naming switches, so it keeps covering the combination as more arrive.
   build_cmake_ubuntu_experimental:
-    name: Build CMake Ubuntu (Release, ${{ matrix.name }})
+    name: Build CMake Ubuntu Experimental (Release, ${{ matrix.name }})
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -191,6 +191,10 @@ jobs:
         include:
           - name: ENABLE_KAD_PROTOCOL_10
             flags: -DENABLE_KAD_PROTOCOL_10=YES
+          - name: ENABLE_KAD_NODE_PROTECTION
+            flags: -DENABLE_KAD_NODE_PROTECTION=YES
+          - name: all
+            flags: -DENABLE_ALL_EXPERIMENTAL=YES
     steps:
       - uses: actions/checkout@v7
       - name: restore ccache

--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -350,6 +350,12 @@ foreach (experimental_option IN LISTS AMULE_EXPERIMENTAL_OPTIONS)
 	# Nothing here writes the cache, so enabling the set for one configure
 	# does not leave the individual switches ON for later ones.
 	if (${experimental_option} OR ENABLE_ALL_EXPERIMENTAL)
+		# The variable is set as well as the definition added, because a
+		# switch may gate more than preprocessor state: ENABLE_KAD_NODE_PROTECTION
+		# also selects source files in cmake/source-vars.cmake, and an if()
+		# there has to see it. Directory scope, so it reaches the
+		# subdirectories included after this and still never touches the cache.
+		set (${experimental_option} ON)
 		add_compile_definitions (${experimental_option})
 	endif()
 endforeach()

--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -301,6 +301,28 @@ option (ENABLE_VERSION_CHECK "compile in the in-app new-version check (startup n
 # pulled in by headers that never see config.h.
 option (ENABLE_KAD_PROTOCOL_10 "advertise Kademlia protocol 0x0a and enable the AICH hashes on keyword storage that Kad 0x09 introduced" OFF)
 
+# Master switch for the local Kad node-protection heuristics: the adaptive
+# request-timeout estimate (CFastKad) and the Kad identity protections
+# (CSafeKad).
+#
+# Deliberately NOT part of ENABLE_KAD_PROTOCOL_10, and deliberately not named
+# after a protocol version. Neither class defines a tag, an opcode or a packet
+# field: they consume what the Kad protocol already carries and decide only
+# what we do locally -- whether to admit a contact, whether to believe an
+# answer, how long to wait before treating a request as stalled. A peer cannot
+# observe whether we run them and has nothing to implement in response, so
+# gating them behind a protocol-version switch would imply a wire contract that
+# does not exist.
+#
+# OFF by default, and OFF means inert: every call site is compiled out and the
+# two classes are left out of the build entirely, so a default build is the
+# upstream one. Their unit tests compile the two sources directly and run
+# either way, so nothing is gated out of test coverage.
+#
+# A plain compile definition rather than a config.h entry, so it is visible in
+# the Kad headers that never see config.h.
+option (ENABLE_KAD_NODE_PROTECTION "enable the local Kad node-protection heuristics: adaptive request timeouts and Kad identity protections (no wire-protocol change)" OFF)
+
 # Every experimental switch, named once. A switch belongs here as well as in its
 # own option() above, and that is the only bookkeeping adding one costs: the
 # loop below defines it, and ENABLE_ALL_EXPERIMENTAL turns the whole set on, so
@@ -313,6 +335,7 @@ option (ENABLE_KAD_PROTOCOL_10 "advertise Kademlia protocol 0x0a and enable the 
 # ordinary build options rather than unfinished features.
 set (AMULE_EXPERIMENTAL_OPTIONS
 	ENABLE_KAD_PROTOCOL_10
+	ENABLE_KAD_NODE_PROTECTION
 )
 
 option (ENABLE_ALL_EXPERIMENTAL "turn on every switch in AMULE_EXPERIMENTAL_OPTIONS at once" OFF)

--- a/cmake/source-vars.cmake
+++ b/cmake/source-vars.cmake
@@ -53,6 +53,17 @@ if (BUILD_MONOLITHIC OR BUILD_DAEMON)
 		FreeSpaceThread.cpp
 		ThreadTasks.cpp
 	)
+
+	# Only compiled in when the switch is on. Every call site is behind the
+	# same guard, so with the switch off these two would be dead weight in
+	# the binary; the unit tests compile them directly, so gating them here
+	# costs no coverage.
+	if (ENABLE_KAD_NODE_PROTECTION)
+		list (APPEND CORE_SOURCES
+			kademlia/net/FastKad.cpp
+			kademlia/net/SafeKad.cpp
+		)
+	endif()
 endif()
 
 if (BUILD_MONOLITHIC OR BUILD_REMOTEGUI)

--- a/src/kademlia/kademlia/Kademlia.cpp
+++ b/src/kademlia/kademlia/Kademlia.cpp
@@ -43,6 +43,10 @@ there client on the eMule forum..
 #include "Defines.h"
 #include "Indexed.h"
 #include "UDPFirewallTester.h"
+#ifdef ENABLE_KAD_NODE_PROTECTION
+#include "../net/FastKad.h"
+#include "../net/SafeKad.h"
+#endif
 #include "../routing/RoutingZone.h"
 #include "../utils/KadUDPKey.h"
 #include "../utils/KadClientSearcher.h"
@@ -166,6 +170,15 @@ void CKademlia::Stop()
 
 	// Make sure all zones are removed.
 	m_events.clear();
+
+#ifdef ENABLE_KAD_NODE_PROTECTION
+	// The protection tables and the response-time window are keyed on
+	// addresses from a Kad session that has just ended; carrying them into
+	// the next one would judge fresh contacts on stale evidence, and Kad is
+	// restarted on every reconnect.
+	safeKad.Clear();
+	fastKad.Clear();
+#endif
 
 	//	theApp->ShowConnectionState();
 }

--- a/src/kademlia/kademlia/Search.cpp
+++ b/src/kademlia/kademlia/Search.cpp
@@ -50,6 +50,10 @@ there client on the eMule forum..
 #include "Defines.h"
 #include "AICHHashList.h"
 #include "UDPFirewallTester.h"
+#ifdef ENABLE_KAD_NODE_PROTECTION
+#include "../net/FastKad.h"
+#include "../net/SafeKad.h"
+#endif
 #include "../routing/RoutingZone.h"
 #include "../routing/Contact.h"
 #include "../net/KademliaUDPListener.h"
@@ -65,6 +69,10 @@ there client on the eMule forum..
 #include "../../updownclient.h"
 #include "../../Logger.h"
 #include "../../Preferences.h"
+#ifdef ENABLE_KAD_NODE_PROTECTION
+#include "../../GetTickCount.h"     // Needed for GetTickCount64
+#include "../../NetworkFunctions.h" // Needed for KadIPPortToString
+#endif
 #include "../../GuiEvents.h"
 
 ////////////////////////////////////////
@@ -90,6 +98,9 @@ CSearch::CSearch()
 	m_totalLoad = 0;
 	m_totalLoadResponses = 0;
 	m_lastResponse = m_created;
+#ifdef ENABLE_KAD_NODE_PROTECTION
+	m_lastResponseTick = ::GetTickCount64();
+#endif
 	m_searchTermsData = NULL;
 	m_searchTermsDataSize = 0;
 	m_nodeSpecialSearchRequester = NULL;
@@ -287,7 +298,42 @@ void CSearch::PrepareToStop() noexcept
 
 void CSearch::JumpStart()
 {
-	// If we had a response within the last 3 seconds, no need to jumpstart the search.
+#ifdef ENABLE_KAD_NODE_PROTECTION
+	// How long to wait on an outstanding request before treating the search
+	// as stalled.  Derived from the response times we have actually observed
+	// (CFastKad) rather than fixed at 3 seconds: on a fast link the old
+	// constant wasted seconds on nodes that were never going to answer, and
+	// on a congested one it abandoned nodes that answered just too late.
+	//
+	// Background store operations keep the old fixed 3 seconds.  They are not
+	// latency-sensitive -- nobody is waiting on a publish -- and holding them
+	// to a tight adaptive deadline would only add republish traffic.
+	const uint32_t maxPending = (m_type == STOREFILE || m_type == STOREKEYWORD || m_type == STORENOTES)
+					    ? SEC2MS(3)
+					    : fastKad.GetEstMaxResponseTime();
+
+	const uint64_t nowTick = ::GetTickCount64();
+
+	// Stop waiting on requests that have passed the ceiling, and remember
+	// those addresses as problematic so the next search does not queue behind
+	// the same dead nodes.
+	for (PendingRequestMap::iterator it = m_pendingRequests.begin(); it != m_pendingRequests.end();) {
+		if (nowTick - it->second.m_sentTick < maxPending) {
+			++it;
+			continue;
+		}
+		safeKad.TrackProblematicNode(it->second.m_ip, it->second.m_port, time(NULL));
+		m_pendingRequests.erase(it++);
+	}
+
+	// If we had a response within the derived ceiling, no need to jumpstart.
+	if (m_lastResponseTick + maxPending > nowTick) {
+		return;
+	}
+#else
+	// Gate off: the fixed 3-second ceiling, at the second granularity it has
+	// always had, so the moment a jumpstart goes out is unchanged.
+	//
 	// Cast m_lastResponse to time_t before adding so the addition happens in
 	// time_t, not in uint32_t -- the latter would wrap near the 2106 32-bit
 	// time boundary and reorder the comparison silently.  Eighty years out,
@@ -295,6 +341,7 @@ void CSearch::JumpStart()
 	if ((time_t)m_lastResponse + SEC(3) > time(NULL)) {
 		return;
 	}
+#endif
 
 	// If we ran out of contacts, stop search.
 	if (m_possible.empty()) {
@@ -369,6 +416,9 @@ void CSearch::ProcessResponse(uint32_t fromIP, uint16_t fromPort, ContactList *r
 	}
 
 	m_lastResponse = time(NULL);
+#ifdef ENABLE_KAD_NODE_PROTECTION
+	m_lastResponseTick = ::GetTickCount64();
+#endif
 
 	// Find contact that is responding.
 	CUInt128 fromDistance(0u);
@@ -381,6 +431,44 @@ void CSearch::ProcessResponse(uint32_t fromIP, uint16_t fromPort, ContactList *r
 			break;
 		}
 	}
+
+#ifdef ENABLE_KAD_NODE_PROTECTION
+	if (fromContact != nullptr) {
+		// The answer closes out its pending record: leaving satisfied
+		// entries in the map would only make the timeout sweep in
+		// JumpStart walk dead weight.
+		PendingRequestMap::iterator pending = m_pendingRequests.find(fromContact->GetClientID());
+		if (pending != m_pendingRequests.end()) {
+			// A useful answer: feed its round-trip time to the shared
+			// estimator so the next timeout reflects the network we are
+			// actually on.
+			const uint64_t nowTick = ::GetTickCount64();
+			fastKad.AddResponseTime(
+				fromIP, (uint32_t)(nowTick - pending->second.m_sentTick), nowTick);
+			m_pendingRequests.erase(pending);
+		}
+
+		// The contact may have gone bad since we sent the request. This
+		// is the point at which we know the node stands behind this
+		// identity, so it is the right place to check it -- and
+		// onlyOneNodePerIP is off here because the contact is already in
+		// our routing table and a second port on the address is the
+		// routing table's problem, not this answer's.
+		if (safeKad.IsBadNode(fromIP,
+			    fromPort,
+			    fromContact->GetClientID(),
+			    fromContact->GetVersion(),
+			    true,
+			    false,
+			    time(NULL))) {
+			AddDebugLogLineN(logKadSearch,
+				"Ignoring search response from a node judged bad by the Kad identity "
+				"protections: " +
+					KadIPPortToString(fromIP, fromPort));
+			return;
+		}
+	}
+#endif
 
 	// Make sure the node is not sending more results than we requested, which is not only a protocol
 	// violation but most likely a malicious answer.  When fromContact is in m_requestedMoreNodes we asked
@@ -1484,6 +1572,16 @@ void CSearch::SendFindValue(CContact *contact, bool reaskMore)
 				DebugSend(Kad2Req, contact->GetIPAddress(), contact->GetUDPPort());
 				break;
 			}
+#endif
+#ifdef ENABLE_KAD_NODE_PROTECTION
+			// Start the clock on this request. The answer's round-trip
+			// time feeds the shared response-time estimator, and
+			// JumpStart uses the same record to notice a request that
+			// has gone past the estimated ceiling.
+			sPendingRequest pending = {
+				::GetTickCount64(), contact->GetIPAddress(), contact->GetUDPPort()
+			};
+			m_pendingRequests[contact->GetClientID()] = pending;
 #endif
 		} else {
 			wxFAIL;

--- a/src/kademlia/kademlia/Search.cpp
+++ b/src/kademlia/kademlia/Search.cpp
@@ -322,7 +322,7 @@ void CSearch::JumpStart()
 			++it;
 			continue;
 		}
-		safeKad.TrackProblematicNode(it->second.m_ip, it->second.m_port, time(NULL));
+		safeKad.TrackProblematicNode(it->second.m_ip, it->second.m_port, time(nullptr));
 		m_pendingRequests.erase(it++);
 	}
 
@@ -460,7 +460,7 @@ void CSearch::ProcessResponse(uint32_t fromIP, uint16_t fromPort, ContactList *r
 			    fromContact->GetVersion(),
 			    true,
 			    false,
-			    time(NULL))) {
+			    time(nullptr))) {
 			AddDebugLogLineN(logKadSearch,
 				"Ignoring search response from a node judged bad by the Kad identity "
 				"protections: " +

--- a/src/kademlia/kademlia/Search.h
+++ b/src/kademlia/kademlia/Search.h
@@ -202,6 +202,28 @@ private:
 
 	typedef std::map<CUInt128, bool> RespondedMap;
 
+#ifdef ENABLE_KAD_NODE_PROTECTION
+	// A request we have sent and not yet had an answer to, keyed by the
+	// contact's ClientID.  Two things need it: CFastKad wants the round-trip
+	// time of every answer, and JumpStart wants to know which contacts have
+	// gone past the estimated ceiling so it can stop waiting on them.  The
+	// address is carried along because by the time a request times out the
+	// contact may already have been dropped from m_tried.
+	struct sPendingRequest
+	{
+		uint64_t m_sentTick;
+		uint32_t m_ip;
+		uint16_t m_port;
+	};
+	typedef std::map<CUInt128, sPendingRequest> PendingRequestMap;
+
+	PendingRequestMap m_pendingRequests;
+	// Millisecond-resolution twin of m_lastResponse.  The stall check in
+	// JumpStart compares against a derived ceiling that is expressed in
+	// milliseconds, and second granularity would quantise it to uselessness.
+	uint64_t m_lastResponseTick;
+#endif
+
 	ContactMap m_possible;
 	ContactMap m_tried;
 	RespondedMap m_responded;

--- a/src/kademlia/net/FastKad.cpp
+++ b/src/kademlia/net/FastKad.cpp
@@ -1,0 +1,123 @@
+//
+// This file is part of the aMule Project.
+//
+// Copyright (c) 2003-2026 aMule Team ( https://amule-org.github.io )
+// Copyright (c) 2026 eMule AI
+//
+// Any parts of this program derived from the xMule, lMule or eMule project,
+// or contributed by third-party developers are copyrighted by their
+// respective authors.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301, USA
+//
+
+#include "FastKad.h"
+
+#include <algorithm>
+#include <cmath>
+
+namespace Kademlia
+{
+
+CFastKad fastKad;
+
+CFastKad::CFastKad()
+: m_estResponseTimeMs(DEFAULT_RESPONSE_TIME_MS)
+{
+}
+
+void CFastKad::Clear()
+{
+	m_samples.clear();
+	m_estResponseTimeMs = DEFAULT_RESPONSE_TIME_MS;
+}
+
+void CFastKad::AddResponseTime(uint32_t ip, uint32_t responseTimeMs, uint64_t nowMs)
+{
+	std::map<uint32_t, sResponseTime>::iterator it = m_samples.find(ip);
+	if (it == m_samples.end()) {
+		if (m_samples.size() >= MAX_SAMPLES) {
+			// Evict the least recently referenced sample, but only if
+			// it is old enough that dropping it will not make the
+			// estimate jump around.
+			uint64_t oldestAge = 0;
+			std::map<uint32_t, sResponseTime>::iterator oldest = m_samples.end();
+			for (std::map<uint32_t, sResponseTime>::iterator candidate = m_samples.begin();
+				candidate != m_samples.end();
+				++candidate) {
+				const uint64_t age = nowMs - candidate->second.m_lastReferencedMs;
+				if (age >= oldestAge && age > MIN_EVICTION_AGE_MS) {
+					oldestAge = age;
+					oldest = candidate;
+				}
+			}
+			if (oldest == m_samples.end()) {
+				// Every sample is recent. Discarding this
+				// observation is the right call: the window
+				// already holds a fresh picture of the network.
+				return;
+			}
+			m_samples.erase(oldest);
+		}
+		sResponseTime added = { responseTimeMs, nowMs };
+		m_samples[ip] = added;
+	} else {
+		it->second.m_responseTimeMs = responseTimeMs;
+		it->second.m_lastReferencedMs = nowMs;
+	}
+
+	RecalculateResponseTime();
+}
+
+void CFastKad::RecalculateResponseTime()
+{
+	// Unfilled slots count as DEFAULT_RESPONSE_TIME_MS, and both moments are
+	// divided by the full window size rather than by the sample count. That
+	// is what makes the cold start safe -- with zero or one sample the
+	// estimate stays at the default instead of collapsing, and there is no
+	// division by a zero (or by count - 1 == 0) sample count anywhere.
+	const double windowSize = (double)MAX_SAMPLES;
+	const double missing =
+		(m_samples.size() < MAX_SAMPLES) ? (windowSize - (double)m_samples.size()) : 0.0;
+
+	double sum = 0.0;
+	for (std::map<uint32_t, sResponseTime>::const_iterator it = m_samples.begin(); it != m_samples.end();
+		++it) {
+		sum += (double)it->second.m_responseTimeMs;
+	}
+	sum += missing * (double)DEFAULT_RESPONSE_TIME_MS;
+	const double mean = sum / windowSize;
+
+	double varianceSum = 0.0;
+	for (std::map<uint32_t, sResponseTime>::const_iterator it = m_samples.begin(); it != m_samples.end();
+		++it) {
+		const double deviation = (double)it->second.m_responseTimeMs - mean;
+		varianceSum += deviation * deviation;
+	}
+	varianceSum += missing * ((double)DEFAULT_RESPONSE_TIME_MS - mean) *
+		       ((double)DEFAULT_RESPONSE_TIME_MS - mean);
+	const double variance = varianceSum / (windowSize - 1.0);
+
+	// mean + 2 * standard deviation is roughly the 95th percentile of a
+	// normal distribution, plus a fixed margin, and never above the cap.
+	const double estimate = mean + 2.0 * std::sqrt(variance) + (double)RESPONSE_TIME_MARGIN_MS;
+	m_estResponseTimeMs =
+		(estimate >= (double)MAX_RESPONSE_TIME_MS) ? MAX_RESPONSE_TIME_MS : (uint32_t)estimate;
+	if (m_estResponseTimeMs < RESPONSE_TIME_MARGIN_MS) {
+		m_estResponseTimeMs = RESPONSE_TIME_MARGIN_MS;
+	}
+}
+
+} // namespace Kademlia

--- a/src/kademlia/net/FastKad.h
+++ b/src/kademlia/net/FastKad.h
@@ -1,0 +1,115 @@
+//								-*- C++ -*-
+// This file is part of the aMule Project.
+//
+// Copyright (c) 2003-2026 aMule Team ( https://amule-org.github.io )
+// Copyright (c) 2026 eMule AI
+//
+// Any parts of this program derived from the xMule, lMule or eMule project,
+// or contributed by third-party developers are copyrighted by their
+// respective authors.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301, USA
+//
+
+#ifndef __KAD_FASTKAD_H__
+#define __KAD_FASTKAD_H__
+
+#include <cstddef>
+#include <map>
+
+#include "../../Types.h"
+
+////////////////////////////////////////
+namespace Kademlia
+{
+////////////////////////////////////////
+
+// Derives the Kad request timeout from observed response times instead of a
+// fixed constant.
+//
+// A fixed timeout is wrong in both directions: on a fast link it wastes seconds
+// waiting for a node that was never going to answer, and on a slow or congested
+// one it discards contacts that would have answered just after the deadline.
+// This keeps a bounded window of the most recent per-address response times and
+// estimates the ceiling as mean + 2 standard deviations (about the 95th
+// percentile of a normal distribution), plus a small margin.
+//
+// Two deliberate biases keep a cold or lucky window from producing an
+// aggressively short timeout:
+//
+//  - The mean and variance are always divided by the *full* window size, with
+//    every unfilled slot counted as the default response time. A handful of
+//    fast samples therefore cannot pull the estimate far below the default;
+//    it takes a full window of fast samples to earn a short timeout.
+//  - Entries younger than MIN_EVICTION_AGE_MS are never evicted to make room,
+//    so a burst of new addresses cannot churn the whole window at once.
+//
+// All time values are in milliseconds and "now" is always passed in, which is
+// what lets the estimator be tested without waiting on a real clock.
+class CFastKad
+{
+public:
+	// Number of addresses whose response time is remembered.
+	static const size_t MAX_SAMPLES = 100;
+	// Response time assumed for every unfilled slot in the window, and the
+	// answer while the window is empty.
+	static const uint32_t DEFAULT_RESPONSE_TIME_MS = 1000;
+	// Absolute ceiling on the derived timeout. A node that has not answered
+	// within this is treated as gone no matter how bad the samples look;
+	// without a cap, one pathological sample would stall every search.
+	static const uint32_t MAX_RESPONSE_TIME_MS = 3000;
+	// Safety margin added to the estimate, for the jitter between the
+	// estimator's clock and the actual send/receive path.
+	static const uint32_t RESPONSE_TIME_MARGIN_MS = 100;
+	// Samples younger than this are kept even when the window is full, so a
+	// flood of new addresses cannot evict the recent history in one go.
+	static const uint32_t MIN_EVICTION_AGE_MS = 5 * 60 * 1000;
+
+	CFastKad();
+
+	// Records that the node at `ip` answered in `responseTimeMs`. Ignored if
+	// the window is full of samples too young to evict.
+	void AddResponseTime(uint32_t ip, uint32_t responseTimeMs, uint64_t nowMs);
+
+	// The current estimated ceiling, always within
+	// [RESPONSE_TIME_MARGIN_MS, MAX_RESPONSE_TIME_MS].
+	uint32_t GetEstMaxResponseTime() const { return m_estResponseTimeMs; }
+
+	size_t GetSampleCount() const { return m_samples.size(); }
+
+	// Drops every sample and returns the estimate to its cold-start value.
+	void Clear();
+
+private:
+	void RecalculateResponseTime();
+
+	struct sResponseTime
+	{
+		uint32_t m_responseTimeMs;
+		uint64_t m_lastReferencedMs;
+	};
+
+	std::map<uint32_t, sResponseTime> m_samples;
+	uint32_t m_estResponseTimeMs;
+};
+
+// The single estimator shared by every Kad search. Kad is driven from
+// CamuleApp::OnCoreTimer on the main thread, like the rest of the Kad
+// singletons reached through CKademlia.
+extern CFastKad fastKad;
+
+} // namespace Kademlia
+
+#endif // __KAD_FASTKAD_H__

--- a/src/kademlia/net/FastKad.h
+++ b/src/kademlia/net/FastKad.h
@@ -58,6 +58,21 @@ namespace Kademlia
 //
 // All time values are in milliseconds and "now" is always passed in, which is
 // what lets the estimator be tested without waiting on a real clock.
+//
+// Two places where this deliberately does not match eMuleAI, so that the next
+// person holding the two side by side reads them as decisions rather than as
+// transcription slips:
+//
+//  - eMuleAI accumulates `missing * CLOCKS_PER_SEC` into its sum of squares,
+//    which adds a raw time to a sum of squared times: the units do not agree,
+//    and the unfilled-slot term is then far too small to hold the estimate up.
+//    Here the squared deviation is added, so an unfilled slot biases the
+//    variance the way the comment above says it does. emule-qt reached the
+//    same correction independently.
+//  - eMuleAI reads the clock with clock(), which on POSIX is CPU time, not
+//    wall time: a mostly-idle client barely advances it, so response times
+//    measured against it are far too short. Passing the tick in avoids the
+//    question entirely, and is what makes the estimator testable.
 class CFastKad
 {
 public:

--- a/src/kademlia/net/SafeKad.cpp
+++ b/src/kademlia/net/SafeKad.cpp
@@ -1,0 +1,320 @@
+//
+// This file is part of the aMule Project.
+//
+// Copyright (c) 2003-2026 aMule Team ( https://amule-org.github.io )
+// Copyright (c) 2026 eMule AI
+//
+// Any parts of this program derived from the xMule, lMule or eMule project,
+// or contributed by third-party developers are copyrighted by their
+// respective authors.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301, USA
+//
+
+#include "SafeKad.h"
+
+namespace Kademlia
+{
+
+CSafeKad safeKad;
+
+CSafeKad::CSafeKad()
+: m_lastCleanup(0)
+{
+}
+
+void CSafeKad::Clear()
+{
+	m_trackedNodes.Clear();
+	m_problematicNodes.Clear();
+	m_bannedAddresses.Clear();
+	m_lastCleanup = 0;
+}
+
+bool CSafeKad::TrackNode(uint32_t ip, uint16_t port, const CUInt128 &id, bool idVerified, time_t now)
+{
+	if (IsBanned(ip, now)) {
+		return false;
+	}
+
+	const SKadNodeAddress address(ip, port);
+	CKadAgedMap<SKadNodeAddress, sTracked>::iterator it = m_trackedNodes.Find(address);
+	if (it == m_trackedNodes.End()) {
+		Cleanup(now); // make room for a new node to track
+		if (m_trackedNodes.Size() >= MAX_TRACKED_NODES) {
+			// Still full of entries too recent to drop: evict the
+			// least recently referenced one anyway, because refusing
+			// to track is worse than forgetting the oldest node --
+			// an untracked node gets no identity checks at all.
+			m_trackedNodes.Erase(m_trackedNodes.OldestKey());
+		}
+		sTracked tracked;
+		tracked.m_lastID = id;
+		tracked.m_lastIDChange = now;
+		tracked.m_lastReferenced = now;
+		tracked.m_idVerified = idVerified;
+		m_trackedNodes.Set(address, tracked);
+		return true;
+	}
+
+	sTracked tracked = it->second;
+	bool accepted = true;
+	if (id != tracked.m_lastID) {
+		// A verified identity is not replaced by an unverified claim:
+		// otherwise anyone able to spoof a source address could rewrite
+		// our view of a node that has actually proved who it is.
+		if (tracked.m_idVerified && !idVerified) {
+			accepted = false;
+		} else if (now - tracked.m_lastIDChange < MIN_ID_CHANGE_INTERVAL) {
+			// Rotating identity faster than once an hour. Mark the
+			// address problematic, and escalate to a ban if it was
+			// problematic already -- one rejected change is a
+			// plausible accident, two inside 300 s is not.
+			accepted = false;
+			Escalate(ip, port, now);
+		} else {
+			tracked.m_lastID = id;
+			tracked.m_lastIDChange = now;
+		}
+	}
+
+	tracked.m_lastReferenced = now;
+	// Verification is sticky: a node that once proved its identity is not
+	// downgraded by a later unverified packet.
+	if (!tracked.m_idVerified) {
+		tracked.m_idVerified = idVerified;
+	}
+	// The ban above may have dropped this entry, so only write it back if
+	// the address is still trackable.
+	if (!IsBanned(ip, now)) {
+		m_trackedNodes.Set(address, tracked);
+	} else {
+		m_trackedNodes.Erase(address);
+	}
+	return accepted;
+}
+
+void CSafeKad::Escalate(uint32_t ip, uint16_t port, time_t now)
+{
+	if (IsProblematic(ip, port, now)) {
+		BanAddress(ip, now);
+	} else {
+		TrackProblematicNode(ip, port, now);
+	}
+}
+
+void CSafeKad::TrackProblematicNode(uint32_t ip, uint16_t port, time_t now)
+{
+	if (IsBanned(ip, now)) {
+		return; // already covered by the stronger measure
+	}
+
+	const SKadNodeAddress address(ip, port);
+	CKadAgedMap<SKadNodeAddress, sProblematic>::iterator it = m_problematicNodes.Find(address);
+	sProblematic problematic;
+	if (it == m_problematicNodes.End()) {
+		Cleanup(now);
+		if (m_problematicNodes.Size() >= MAX_PROBLEMATIC_NODES) {
+			m_problematicNodes.Erase(m_problematicNodes.OldestKey());
+		}
+		problematic.m_failed = now;
+	} else {
+		problematic = it->second;
+	}
+	problematic.m_lastReferenced = now;
+	m_problematicNodes.Set(address, problematic);
+}
+
+void CSafeKad::BanAddress(uint32_t ip, time_t now)
+{
+	Cleanup(now);
+
+	CKadAgedMap<uint32_t, sBanned>::iterator it = m_bannedAddresses.Find(ip);
+	sBanned banned;
+	if (it == m_bannedAddresses.End() && m_bannedAddresses.Size() >= MAX_BANNED_ADDRESSES) {
+		// A thousand simultaneously banned addresses means something much
+		// larger is going on than one bad node; drop the oldest ban
+		// rather than growing without bound.
+		m_bannedAddresses.Erase(m_bannedAddresses.OldestKey());
+	}
+	banned.m_banned = now;
+	banned.m_lastReferenced = now;
+	m_bannedAddresses.Set(ip, banned);
+
+	// A banned address is not worth tracking an identity for, and its
+	// problematic entries have been superseded by the stronger measure.
+	// The ban covers the address, so every port on it goes.
+	DropAllPortsOf(ip);
+}
+
+void CSafeKad::DropAllPortsOf(uint32_t ip)
+{
+	// Collect first, erase after: erasing invalidates the iterator, and the
+	// aged map has to see each removal individually to keep its age index in
+	// step.
+	std::vector<uint16_t> ports;
+	for (CKadAgedMap<SKadNodeAddress, sTracked>::iterator it =
+			m_trackedNodes.LowerBound(SKadNodeAddress(ip, 0));
+		it != m_trackedNodes.End() && it->first.m_ip == ip;
+		++it) {
+		ports.push_back(it->first.m_port);
+	}
+	for (const uint16_t port : ports) {
+		m_trackedNodes.Erase(SKadNodeAddress(ip, port));
+	}
+
+	ports.clear();
+	for (CKadAgedMap<SKadNodeAddress, sProblematic>::iterator it =
+			m_problematicNodes.LowerBound(SKadNodeAddress(ip, 0));
+		it != m_problematicNodes.End() && it->first.m_ip == ip;
+		++it) {
+		ports.push_back(it->first.m_port);
+	}
+	for (const uint16_t port : ports) {
+		m_problematicNodes.Erase(SKadNodeAddress(ip, port));
+	}
+}
+
+bool CSafeKad::IsBanned(uint32_t ip, time_t now)
+{
+	CKadAgedMap<uint32_t, sBanned>::iterator it = m_bannedAddresses.Find(ip);
+	if (it == m_bannedAddresses.End()) {
+		return false;
+	}
+	if (now - it->second.m_banned > MAX_BAN_TIME) {
+		// The ban has lapsed; from here the address is judged on its
+		// current behaviour alone.
+		m_bannedAddresses.Erase(ip);
+		return false;
+	}
+	sBanned banned = it->second;
+	banned.m_lastReferenced = now;
+	m_bannedAddresses.Set(ip, banned);
+	return true;
+}
+
+bool CSafeKad::IsProblematic(uint32_t ip, uint16_t port, time_t now)
+{
+	const SKadNodeAddress address(ip, port);
+	CKadAgedMap<SKadNodeAddress, sProblematic>::iterator it = m_problematicNodes.Find(address);
+	if (it != m_problematicNodes.End()) {
+		if (now - it->second.m_failed > MAX_PROBLEMATIC_TIME) {
+			m_problematicNodes.Erase(address);
+		} else {
+			sProblematic problematic = it->second;
+			problematic.m_lastReferenced = now;
+			m_problematicNodes.Set(address, problematic);
+			return true;
+		}
+	}
+	// A banned address is problematic by construction.
+	return IsBanned(ip, now);
+}
+
+bool CSafeKad::HasOtherTrackedPort(uint32_t ip, uint16_t port)
+{
+	CKadAgedMap<SKadNodeAddress, sTracked>::iterator it =
+		m_trackedNodes.LowerBound(SKadNodeAddress(ip, 0));
+	for (; it != m_trackedNodes.End() && it->first.m_ip == ip; ++it) {
+		if (it->first.m_port != port) {
+			return true;
+		}
+	}
+	return false;
+}
+
+bool CSafeKad::IsBadNode(uint32_t ip,
+	uint16_t port,
+	const CUInt128 &id,
+	uint8_t kadVersion,
+	bool idVerified,
+	bool onlyOneNodePerIP,
+	time_t now)
+{
+	if (now - m_lastCleanup > CLEANUP_INTERVAL) {
+		Cleanup(now);
+	}
+
+	if (IsBanned(ip, now)) {
+		m_trackedNodes.Erase(SKadNodeAddress(ip, port));
+		return true;
+	}
+
+	const SKadNodeAddress address(ip, port);
+	CKadAgedMap<SKadNodeAddress, sTracked>::iterator it = m_trackedNodes.Find(address);
+	if (it != m_trackedNodes.End()) {
+		if (it->second.m_lastID == id) {
+			// Same identity as before: just refresh the reference.
+			sTracked tracked = it->second;
+			tracked.m_lastReferenced = now;
+			if (!tracked.m_idVerified) {
+				tracked.m_idVerified = idVerified;
+			}
+			m_trackedNodes.Set(address, tracked);
+			return false;
+		}
+		// A different identity. A node below 0x08 could not prove which
+		// port it listens on, so an unverified identity change from one
+		// is refused outright rather than rate-limited.
+		if ((it->second.m_idVerified || kadVersion < MIN_PORT_VERIFIABLE_VERSION) && !idVerified) {
+			// Refusing alone costs the sender nothing, so a rotation
+			// inside the one-hour interval still climbs the ladder:
+			// otherwise a sybil that always arrives unverified against
+			// a verified entry could retry the same rotation forever
+			// for free, which is exactly what the ladder exists to
+			// stop. Past the interval the change is not rotation, only
+			// unverifiable, and a legacy client that reinstalled once
+			// is not worth a four-hour ban. Escalate() may ban and so
+			// invalidate `it`; nothing reads it after this.
+			if (now - it->second.m_lastIDChange < MIN_ID_CHANGE_INTERVAL) {
+				Escalate(ip, port, now);
+			}
+			return true;
+		}
+		// TrackNode applies the one-hour interval and the escalation.
+		return !TrackNode(ip, port, id, idVerified, now) || IsBanned(ip, now);
+	}
+
+	if (onlyOneNodePerIP && HasOtherTrackedPort(ip, port)) {
+		// A second Kad port on one address is either a NAT hiding several
+		// clients or one client pretending to be several. Both are bad
+		// for the routing table, and the honest case still has its first
+		// port tracked and usable.
+		return true;
+	}
+	TrackNode(ip, port, id, idVerified, now);
+	return false;
+}
+
+void CSafeKad::Cleanup(time_t now)
+{
+	m_lastCleanup = now;
+
+	// Each table is walked oldest-first and stops at the first entry inside
+	// its horizon, so a clean table costs one comparison.
+	while (!m_trackedNodes.Empty() && now - m_trackedNodes.OldestReference() > NODE_MAX_REFERENCE_AGE) {
+		m_trackedNodes.Erase(m_trackedNodes.OldestKey());
+	}
+	while (!m_bannedAddresses.Empty() &&
+		now - m_bannedAddresses.OldestReference() > BAN_MAX_REFERENCE_AGE) {
+		m_bannedAddresses.Erase(m_bannedAddresses.OldestKey());
+	}
+	while (!m_problematicNodes.Empty() &&
+		now - m_problematicNodes.OldestReference() > PROBLEMATIC_MAX_REFERENCE_AGE) {
+		m_problematicNodes.Erase(m_problematicNodes.OldestKey());
+	}
+}
+
+} // namespace Kademlia

--- a/src/kademlia/net/SafeKad.cpp
+++ b/src/kademlia/net/SafeKad.cpp
@@ -82,8 +82,16 @@ bool CSafeKad::TrackNode(uint32_t ip, uint16_t port, const CUInt128 &id, bool id
 			// address problematic, and escalate to a ban if it was
 			// problematic already -- one rejected change is a
 			// plausible accident, two inside 300 s is not.
+			//
+			// idVerified gates the escalation, not the refusal. The
+			// rotation is refused either way, but only a peer that has
+			// proved which port it listens on can be banned for it:
+			// otherwise two fabricated mentions of an honest node ban
+			// it, which is the attack the verification exists to stop.
 			accepted = false;
-			Escalate(ip, port, now);
+			if (idVerified) {
+				Escalate(ip, port, now);
+			}
 		} else {
 			tracked.m_lastID = id;
 			tracked.m_lastIDChange = now;
@@ -269,18 +277,24 @@ bool CSafeKad::IsBadNode(uint32_t ip,
 		// port it listens on, so an unverified identity change from one
 		// is refused outright rather than rate-limited.
 		if ((it->second.m_idVerified || kadVersion < MIN_PORT_VERIFIABLE_VERSION) && !idVerified) {
-			// Refusing alone costs the sender nothing, so a rotation
-			// inside the one-hour interval still climbs the ladder:
-			// otherwise a sybil that always arrives unverified against
-			// a verified entry could retry the same rotation forever
-			// for free, which is exactly what the ladder exists to
-			// stop. Past the interval the change is not rotation, only
-			// unverifiable, and a legacy client that reinstalled once
-			// is not worth a four-hour ban. Escalate() may ban and so
-			// invalidate `it`; nothing reads it after this.
-			if (now - it->second.m_lastIDChange < MIN_ID_CHANGE_INTERVAL) {
-				Escalate(ip, port, now);
-			}
+			// Refused, and deliberately not escalated. This branch's own
+			// condition ends in !idVerified, so everything reaching it is
+			// an unverified claim -- and an unverified claim is exactly
+			// what a third party can fabricate about somebody else.
+			// ProcessKademlia2Response() calls AddUnfiltered() with
+			// verified hardcoded to false, and the peer answering our
+			// request picks the (IP, port, ID) triples it lists, so
+			// banning here would let one peer get an honest node banned
+			// by mentioning it twice. m_lastIDChange is stamped when an
+			// entry is created, so the sub-hour window covers every
+			// freshly-learned contact rather than only ones that really
+			// did just change ID.
+			//
+			// Both references decline for this reason; emule-qt states
+			// it outright: the ban requires verification by design, and
+			// unverified flips are recorded but never banned. Refusing
+			// still costs the sender its rotation, which is the part
+			// that has to hold.
 			return true;
 		}
 		// TrackNode applies the one-hour interval and the escalation.

--- a/src/kademlia/net/SafeKad.h
+++ b/src/kademlia/net/SafeKad.h
@@ -1,0 +1,276 @@
+//								-*- C++ -*-
+// This file is part of the aMule Project.
+//
+// Copyright (c) 2003-2026 aMule Team ( https://amule-org.github.io )
+// Copyright (c) 2026 eMule AI
+//
+// Any parts of this program derived from the xMule, lMule or eMule project,
+// or contributed by third-party developers are copyrighted by their
+// respective authors.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301, USA
+//
+
+#ifndef __KAD_SAFEKAD_H__
+#define __KAD_SAFEKAD_H__
+
+#include <cstddef>
+#include <map>
+#include <set>
+#include <time.h>
+#include <utility>
+#include <vector>
+
+#include "../utils/UInt128.h"
+#include "../../Types.h"
+
+////////////////////////////////////////
+namespace Kademlia
+{
+////////////////////////////////////////
+
+// One Kad node address. Kad keys on IPv4 throughout -- routing, the UDP key and
+// the publish tracking all take a uint32 -- so this does too.
+struct SKadNodeAddress
+{
+	SKadNodeAddress()
+	: m_ip(0)
+	, m_port(0)
+	{
+	}
+	SKadNodeAddress(uint32_t ip, uint16_t port)
+	: m_ip(ip)
+	, m_port(port)
+	{
+	}
+	bool operator<(const SKadNodeAddress &value) const
+	{
+		return (m_ip < value.m_ip) || (m_ip == value.m_ip && m_port < value.m_port);
+	}
+	bool operator==(const SKadNodeAddress &value) const
+	{
+		return m_ip == value.m_ip && m_port == value.m_port;
+	}
+
+	uint32_t m_ip;
+	uint16_t m_port;
+};
+
+// A bounded map whose entries are evicted by last-reference age.
+//
+// The plain map alone would need an O(n) scan to find the least recently
+// referenced entry, which is exactly the wrong complexity for a table that only
+// evicts while under a flood. The parallel set, keyed on (last reference, key),
+// makes both the oldest-first walk in Cleanup() and the make-room eviction
+// O(log n).
+//
+// `Entry` must expose a `time_t m_lastReferenced`; every mutation goes through
+// Set() so the two containers cannot drift apart.
+template <class Key, class Entry> class CKadAgedMap
+{
+public:
+	typedef std::map<Key, Entry> Map;
+	typedef typename Map::iterator iterator;
+	typedef typename Map::const_iterator const_iterator;
+
+	iterator Find(const Key &key) { return m_map.find(key); }
+	iterator LowerBound(const Key &key) { return m_map.lower_bound(key); }
+	iterator Begin() { return m_map.begin(); }
+	iterator End() { return m_map.end(); }
+	size_t Size() const { return m_map.size(); }
+	bool Empty() const { return m_map.empty(); }
+
+	void Set(const Key &key, const Entry &entry)
+	{
+		iterator it = m_map.find(key);
+		if (it != m_map.end()) {
+			m_age.erase(AgeKey(it->second.m_lastReferenced, key));
+			it->second = entry;
+		} else {
+			m_map.insert(std::make_pair(key, entry));
+		}
+		m_age.insert(AgeKey(entry.m_lastReferenced, key));
+	}
+
+	void Erase(const Key &key)
+	{
+		iterator it = m_map.find(key);
+		if (it == m_map.end()) {
+			return;
+		}
+		m_age.erase(AgeKey(it->second.m_lastReferenced, key));
+		m_map.erase(it);
+	}
+
+	// Only valid while !Empty().
+	const Key &OldestKey() const { return m_age.begin()->second; }
+	time_t OldestReference() const { return m_age.begin()->first; }
+
+	void Clear()
+	{
+		m_map.clear();
+		m_age.clear();
+	}
+
+private:
+	typedef std::pair<time_t, Key> AgeKey;
+
+	Map m_map;
+	std::set<AgeKey> m_age;
+};
+
+// Identity and address protections layered on top of the standard 0.49b Kad
+// defences, which stay exactly as they are.
+//
+// What this adds over CPacketTracking and the UDP key challenge:
+//
+//  - CPacketTracking rate-limits *packets* per IP and opcode. It says nothing
+//    about a node that behaves politely while presenting a new Kad ID every
+//    few minutes, which is how a routing table gets flooded with sybils that
+//    each look individually reasonable. That is what the tracked-node table
+//    and the one-hour minimum identity-change interval cover.
+//  - The UDP key challenge proves an address controls its own traffic. It does
+//    not remember that the same address failed us five minutes ago, which is
+//    what the problematic list is for.
+//
+// The escalation ladder mirrors CPacketTracking's own drop-then-ban shape:
+// first identity rotation marks the address problematic (300 s), a rotation
+// while already problematic bans it (4 h). The ban is Kad-routing-local and
+// deliberately separate from CClientList's eD2k-wide ban, which has its own
+// lifetime and its own triggers.
+//
+// Every table is bounded and evicts by last-reference age, so sustained inbound
+// traffic costs a fixed amount of memory. All entry points take `now` so that
+// the whole ladder is testable without waiting on a real clock.
+class CSafeKad
+{
+public:
+	static const size_t MAX_TRACKED_NODES = 10000;
+	static const size_t MAX_PROBLEMATIC_NODES = 10000;
+	static const size_t MAX_BANNED_ADDRESSES = 1000;
+
+	// A node may change its Kad ID at most once an hour. Legitimate reasons
+	// exist (a fresh install, a wiped preferencesKad.dat), and an hour is
+	// far longer than any of them need.
+	static const time_t MIN_ID_CHANGE_INTERVAL = 3600;
+	// A ban lapses after four hours; past that the address is judged on its
+	// current behaviour alone.
+	static const time_t MAX_BAN_TIME = 4 * 3600;
+	// A problematic address is ignored for 300 s.
+	static const time_t MAX_PROBLEMATIC_TIME = 300;
+
+	// Lowest advertised Kad version whose three-way handshake can prove
+	// which UDP port a node listens on (eMule 0.49b). Below it an
+	// unverified identity change cannot be told from a spoof, so it is
+	// refused outright instead of merely rate-limited.
+	//
+	// Written out here rather than taken from the protocol version table:
+	// this class adds nothing to the wire, so it has no business depending
+	// on the header that defines what we advertise.
+	static const uint8_t MIN_PORT_VERIFIABLE_VERSION = 0x08;
+
+	// Eviction horizons for Cleanup(): an entry nothing has referenced for
+	// this long carries no information worth its memory.
+	static const time_t NODE_MAX_REFERENCE_AGE = 3600;
+	static const time_t BAN_MAX_REFERENCE_AGE = 3600;
+	static const time_t PROBLEMATIC_MAX_REFERENCE_AGE = 300;
+	// Cleanup() also runs from IsBadNode() at most this often.
+	static const time_t CLEANUP_INTERVAL = 600;
+
+	CSafeKad();
+
+	// Records the identity `id` at this address. A changed ID inside
+	// MIN_ID_CHANGE_INTERVAL marks the address problematic (and bans it if
+	// it was problematic already) and leaves the tracked ID untouched.
+	// Returns false if the identity change was rejected.
+	bool TrackNode(uint32_t ip, uint16_t port, const CUInt128 &id, bool idVerified, time_t now);
+
+	// Marks an address as having misbehaved (a timeout, an inconsistent
+	// answer, a rejected identity change).
+	void TrackProblematicNode(uint32_t ip, uint16_t port, time_t now);
+
+	// Bans an address for MAX_BAN_TIME. Use only where the address is
+	// demonstrably at fault: a node can be *reported* bad by a third party,
+	// and acting on that would make this a remote-controlled blocklist.
+	void BanAddress(uint32_t ip, time_t now);
+
+	// The one call the Kad packet paths need: true when this contact must
+	// not be used or inserted into the routing table.
+	//
+	// `onlyOneNodePerIP` rejects a second port on an address that already
+	// has a tracked node -- a real client uses one Kad port. It is gated on
+	// `kadVersion` by the caller's choice because the pre-0x08 handshake
+	// could not prove which port a node really listens on.
+	bool IsBadNode(uint32_t ip,
+		uint16_t port,
+		const CUInt128 &id,
+		uint8_t kadVersion,
+		bool idVerified,
+		bool onlyOneNodePerIP,
+		time_t now);
+
+	bool IsBanned(uint32_t ip, time_t now);
+	bool IsProblematic(uint32_t ip, uint16_t port, time_t now);
+
+	// Drops entries nothing has referenced within their horizon.
+	void Cleanup(time_t now);
+	void Clear();
+
+	size_t GetTrackedNodeCount() const { return m_trackedNodes.Size(); }
+	size_t GetProblematicNodeCount() const { return m_problematicNodes.Size(); }
+	size_t GetBannedAddressCount() const { return m_bannedAddresses.Size(); }
+
+private:
+	struct sTracked
+	{
+		CUInt128 m_lastID;
+		time_t m_lastIDChange;
+		time_t m_lastReferenced;
+		bool m_idVerified;
+	};
+	struct sProblematic
+	{
+		time_t m_failed;
+		time_t m_lastReferenced;
+	};
+	struct sBanned
+	{
+		time_t m_banned;
+		time_t m_lastReferenced;
+	};
+
+	// One step up the escalation ladder for a rejected identity change:
+	// problematic the first time, banned if the address was problematic
+	// already. Both refusal paths share this so that one rejection is
+	// always exactly one step.
+	void Escalate(uint32_t ip, uint16_t port, time_t now);
+	// True when this address already has a tracked node on another port.
+	bool HasOtherTrackedPort(uint32_t ip, uint16_t port);
+	// Forgets every tracked and problematic entry for `ip`, on every port.
+	void DropAllPortsOf(uint32_t ip);
+
+	CKadAgedMap<SKadNodeAddress, sTracked> m_trackedNodes;
+	CKadAgedMap<SKadNodeAddress, sProblematic> m_problematicNodes;
+	CKadAgedMap<uint32_t, sBanned> m_bannedAddresses;
+	time_t m_lastCleanup;
+};
+
+// The single instance shared by the Kad packet, search and routing paths, like
+// the other Kad singletons reached through CKademlia.
+extern CSafeKad safeKad;
+
+} // namespace Kademlia
+
+#endif // __KAD_SAFEKAD_H__

--- a/src/kademlia/net/SafeKad.h
+++ b/src/kademlia/net/SafeKad.h
@@ -154,6 +154,41 @@ private:
 // Every table is bounded and evicts by last-reference age, so sustained inbound
 // traffic costs a fixed amount of memory. All entry points take `now` so that
 // the whole ladder is testable without waiting on a real clock.
+// Seven places where this deliberately does not match eMuleAI, listed so the
+// next person holding the two side by side reads them as decisions rather than
+// as transcription slips. emule-qt agrees with eMuleAI on all seven.
+//
+//  - eMuleAI bans on the FIRST verified sub-hour identity change; the ladder
+//    above needs two inside 300 s. Bans are per address while tracking is per
+//    (address, port), so under CGNAT a carrier reusing one external port for
+//    different subscribers makes a single tracked entry legitimately see
+//    different Kad IDs, and eMuleAI's rule would take out every aMule user
+//    behind that address for four hours on the first sighting.
+//  - eMuleAI gates banning on a user preference, IsBanBadKadNodes(). The
+//    compile switch stands in for it while this is experimental; a runtime
+//    equivalent is a precondition for ever defaulting the switch ON.
+//  - TrackNode() returns whether it accepted, and IsBadNode() refuses on a
+//    rejected rotation. eMuleAI's TrackNode() is void and IsBadNode() answers
+//    IsBanned() alone, so upstream ACCEPTS the first rejected rotation and only
+//    refuses once a ban lands. Refusing immediately is what makes a rotation
+//    cost the sender its rotation, which is the half that has to hold given the
+//    slower ladder above.
+//  - A full table evicts its oldest entry; eMuleAI returns without acting once
+//    the tracked table reaches 10000 or the ban table 1000, so a flood that
+//    fills the table lets every later abuser through, which inverts the
+//    protection exactly when it is needed.
+//  - BanAddress() drops the banned address's tracked ports. eMuleAI leaves them
+//    behind, where they are unreachable state for an address nothing may talk
+//    to.
+//  - The verified flag is also upgraded on a matching-ID sighting in
+//    IsBadNode(); eMuleAI upgrades it only inside TrackNode(). It moves in one
+//    direction only, and the one caller that hardcodes verified=false is
+//    AddUnfiltered(), so a peer cannot drive the upgrade for somebody else.
+//  - The last-reference time is not refreshed on the refused path. eMuleAI
+//    refreshes on every lookup, which lets an attacker's own traffic decide
+//    which entries survive age-based eviction; here such an entry ages out
+//    instead. The trade is real in both directions: forgetting a rotator also
+//    gives it a clean slate.
 class CSafeKad
 {
 public:

--- a/src/kademlia/routing/RoutingZone.cpp
+++ b/src/kademlia/routing/RoutingZone.cpp
@@ -59,6 +59,9 @@ there client on the eMule forum..
 #include "../kademlia/SearchManager.h"
 #include "../kademlia/UDPFirewallTester.h"
 #include "../net/KademliaUDPListener.h"
+#ifdef ENABLE_KAD_NODE_PROTECTION
+#include "../net/SafeKad.h"
+#endif
 #include "../utils/KadUDPKey.h"
 #include "../../amule.h"
 #include "../../CFile.h"
@@ -485,6 +488,25 @@ bool CRoutingZone::AddUnfiltered(const CUInt128 &id,
 	bool fromHello)
 {
 	if (id != me) {
+#ifdef ENABLE_KAD_NODE_PROTECTION
+		// Kad identity protections. This is the routing table's front door,
+		// so it is where an address that rotates Kad IDs faster than once
+		// an hour, or one banned for having done so, has to be turned away.
+		//
+		// onlyOneNodePerIP is deliberately off: CRoutingBin already caps
+		// the routing table at MAX_CONTACTS_IP (1) Kad ID per address plus
+		// MAX_CONTACTS_SUBNET (10) per /24, and duplicating that here would
+		// add a second, weaker copy of a rule the bin already enforces
+		// better. CSafeKad's own per-IP rule exists for callers outside the
+		// routing table.
+		if (safeKad.IsBadNode(ip, port, id, version, ipVerified, false, time(NULL))) {
+			AddDebugLogLineN(logKadRouting,
+				"Ignored kad contact (IP=" + KadIPPortToString(ip, port) +
+					") - rejected by the Kad identity protections");
+			return false;
+		}
+#endif
+
 		CContact *contact = new CContact(id, ip, port, tport, version, key, ipVerified);
 		if (fromHello) {
 			contact->SetReceivedHelloPacket();
@@ -1037,6 +1059,13 @@ bool CRoutingZone::VerifyContact(const CUInt128 &id, uint32_t ip)
 		} else {
 			contact->SetIPVerified(true);
 		}
+#ifdef ENABLE_KAD_NODE_PROTECTION
+		// The three-way handshake has just proved that this address stands
+		// behind this Kad ID. Recording it verified is what makes a later
+		// unverified claim of a different ID for the same address
+		// rejectable rather than merely rate-limited.
+		safeKad.TrackNode(ip, contact->GetUDPPort(), id, true, time(NULL));
+#endif
 		return true;
 	}
 }

--- a/src/kademlia/routing/RoutingZone.cpp
+++ b/src/kademlia/routing/RoutingZone.cpp
@@ -927,6 +927,28 @@ void CRoutingZone::OnSmallTimer()
 	m_bin->GetEntries(&entries);
 	for (ContactList::iterator it = entries.begin(); it != entries.end(); ++it) {
 		c = *it;
+#ifdef ENABLE_KAD_NODE_PROTECTION
+		// A banned address is swept out of the table, not merely refused
+		// re-entry. Without this the ban only applies to contacts we have
+		// yet to learn, and one already sitting in the table keeps being
+		// asked -- which is the node the ban was about. Folded into the
+		// dead-entry pass rather than given a sweep of its own, because
+		// this loop already walks every entry once a minute and already
+		// owns the InUse() rule that keeps a contact alive while a search
+		// holds it.
+		//
+		// Safe only because escalation now requires a verified identity:
+		// while an unverified flip could ban, this removal would have let
+		// two fabricated mentions evict an honest contact rather than
+		// merely block its return.
+		if (safeKad.IsBanned(c->GetIPAddress(), now)) {
+			if (!c->InUse()) {
+				m_bin->RemoveContact(c);
+				delete c;
+			}
+			continue;
+		}
+#endif
 		if (c->GetType() == 4) {
 			if ((c->GetExpireTime() > 0) && (c->GetExpireTime() <= now)) {
 				if (!c->InUse()) {

--- a/src/kademlia/routing/RoutingZone.cpp
+++ b/src/kademlia/routing/RoutingZone.cpp
@@ -493,13 +493,23 @@ bool CRoutingZone::AddUnfiltered(const CUInt128 &id,
 		// so it is where an address that rotates Kad IDs faster than once
 		// an hour, or one banned for having done so, has to be turned away.
 		//
+		// No upstream counterpart: eMuleAI and emule-qt each call IsBadNode()
+		// in exactly one place, the search answer, and neither gates routing
+		// table admission with it. This is ours, and it is the reason the
+		// switch must not default to ON without evidence: the table deciding
+		// who may enter is what Kad health rests on, and a heuristic that is
+		// even slightly too eager fails quietly, as a node that gradually
+		// stops finding peers with nothing in the log to say why. Measure
+		// routing table size and contact churn against a control node before
+		// changing the default.
+		//
 		// onlyOneNodePerIP is deliberately off: CRoutingBin already caps
 		// the routing table at MAX_CONTACTS_IP (1) Kad ID per address plus
 		// MAX_CONTACTS_SUBNET (10) per /24, and duplicating that here would
 		// add a second, weaker copy of a rule the bin already enforces
 		// better. CSafeKad's own per-IP rule exists for callers outside the
 		// routing table.
-		if (safeKad.IsBadNode(ip, port, id, version, ipVerified, false, time(NULL))) {
+		if (safeKad.IsBadNode(ip, port, id, version, ipVerified, false, time(nullptr))) {
 			AddDebugLogLineN(logKadRouting,
 				"Ignored kad contact (IP=" + KadIPPortToString(ip, port) +
 					") - rejected by the Kad identity protections");
@@ -1086,7 +1096,7 @@ bool CRoutingZone::VerifyContact(const CUInt128 &id, uint32_t ip)
 		// behind this Kad ID. Recording it verified is what makes a later
 		// unverified claim of a different ID for the same address
 		// rejectable rather than merely rate-limited.
-		safeKad.TrackNode(ip, contact->GetUDPPort(), id, true, time(NULL));
+		safeKad.TrackNode(ip, contact->GetUDPPort(), id, true, time(nullptr));
 #endif
 		return true;
 	}

--- a/unittests/tests/CMakeLists.txt
+++ b/unittests/tests/CMakeLists.txt
@@ -204,12 +204,53 @@ add_test (NAME KadAICHHashListTest
 )
 
 target_include_directories (KadAICHHashListTest
+# The adaptive Kad response-time ceiling. CFastKad takes "now" as a parameter
+# rather than reading a clock, which is what lets the cold start, a known series
+# of samples, the eviction rule and the window bound all be pinned without
+# waiting. Compiled and run regardless of ENABLE_KAD_NODE_PROTECTION: the class
+# is self-contained, so gating the suite would only cost coverage.
+add_executable (FastKadTest
+	FastKadTest.cpp
+	${CMAKE_SOURCE_DIR}/src/kademlia/net/FastKad.cpp
+)
+
+add_test (NAME FastKadTest
+	COMMAND FastKadTest
+)
+
+target_include_directories (FastKadTest
 	PRIVATE ${CMAKE_BINARY_DIR}
 	PRIVATE ${CMAKE_SOURCE_DIR}/src
 	PRIVATE ${CMAKE_SOURCE_DIR}/src/include
 )
 
 target_link_libraries (KadAICHHashListTest
+target_link_libraries (FastKadTest
+	muleunit
+	mulecommon
+)
+
+# The Kad identity protections: the one-hour identity-change interval, the
+# problematic list, the per-address ban and the bounds on all three tables.
+# Same reasoning as FastKad -- every entry point takes the time, so a four-hour
+# ban expiry is a single call rather than an untestable wait.
+add_executable (SafeKadTest
+	SafeKadTest.cpp
+	${CMAKE_SOURCE_DIR}/src/kademlia/net/SafeKad.cpp
+	${CMAKE_SOURCE_DIR}/src/kademlia/utils/UInt128.cpp
+)
+
+add_test (NAME SafeKadTest
+	COMMAND SafeKadTest
+)
+
+target_include_directories (SafeKadTest
+	PRIVATE ${CMAKE_BINARY_DIR}
+	PRIVATE ${CMAKE_SOURCE_DIR}/src
+	PRIVATE ${CMAKE_SOURCE_DIR}/src/include
+)
+
+target_link_libraries (SafeKadTest
 	muleunit
 	mulecommon
 )

--- a/unittests/tests/CMakeLists.txt
+++ b/unittests/tests/CMakeLists.txt
@@ -204,6 +204,16 @@ add_test (NAME KadAICHHashListTest
 )
 
 target_include_directories (KadAICHHashListTest
+	PRIVATE ${CMAKE_BINARY_DIR}
+	PRIVATE ${CMAKE_SOURCE_DIR}/src
+	PRIVATE ${CMAKE_SOURCE_DIR}/src/include
+)
+
+target_link_libraries (KadAICHHashListTest
+	muleunit
+	mulecommon
+)
+
 # The adaptive Kad response-time ceiling. CFastKad takes "now" as a parameter
 # rather than reading a clock, which is what lets the cold start, a known series
 # of samples, the eviction rule and the window bound all be pinned without
@@ -224,7 +234,6 @@ target_include_directories (FastKadTest
 	PRIVATE ${CMAKE_SOURCE_DIR}/src/include
 )
 
-target_link_libraries (KadAICHHashListTest
 target_link_libraries (FastKadTest
 	muleunit
 	mulecommon

--- a/unittests/tests/FastKadTest.cpp
+++ b/unittests/tests/FastKadTest.cpp
@@ -1,0 +1,230 @@
+//								-*- C++ -*-
+// This file is part of the aMule Project.
+//
+// Copyright (c) 2003-2026 aMule Team ( https://amule-org.github.io )
+//
+// Any parts of this program derived from the xMule, lMule or eMule project,
+// or contributed by third-party developers are copyrighted by their
+// respective authors.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301, USA
+//
+
+#include <muleunit/test.h>
+#include <kademlia/net/FastKad.h>
+
+using namespace muleunit;
+using Kademlia::CFastKad;
+
+DECLARE_SIMPLE(FastKad)
+
+// Wall-clock zero for these tests; every call passes "now" explicitly, so no
+// test here depends on a real clock.
+static const uint64_t T0 = 1000000;
+
+// Every expected ceiling below is a literal worked out by hand from the
+// documented estimator -- mean + 2 * stddev + margin, with both moments divided
+// by the full window and every unfilled slot counted as the default response
+// time -- and NOT by reading CFastKad's own constants back. Reading them here
+// would make the assertions restate the implementation instead of pinning its
+// output, and would stay green through an arithmetic change.
+//
+// The literals therefore assume the window and the two reference times below.
+// If any of them ever changes, ConstantsTheseTestsAssume fails first and says
+// so, instead of the arithmetic tests quietly re-deriving a new answer.
+static const unsigned WINDOW = 100;
+static const unsigned DEFAULT_MS = 1000;
+static const unsigned CAP_MS = 3000;
+
+TEST(FastKad, ConstantsTheseTestsAssume)
+{
+	ASSERT_EQUALS(WINDOW, (unsigned)CFastKad::MAX_SAMPLES);
+	ASSERT_EQUALS(DEFAULT_MS, (unsigned)CFastKad::DEFAULT_RESPONSE_TIME_MS);
+	ASSERT_EQUALS(CAP_MS, (unsigned)CFastKad::MAX_RESPONSE_TIME_MS);
+	ASSERT_EQUALS(100u, (unsigned)CFastKad::RESPONSE_TIME_MARGIN_MS);
+	ASSERT_EQUALS(300000u, (unsigned)CFastKad::MIN_EVICTION_AGE_MS);
+}
+
+TEST(FastKad, ColdStartIsTheDefaultResponseTime)
+{
+	CFastKad kad;
+	ASSERT_EQUALS(0u, (unsigned)kad.GetSampleCount());
+	// With no sample at all the estimate must be usable, not zero: a zero
+	// timeout would drop every contact the instant it was asked.
+	ASSERT_EQUALS(1000u, (unsigned)kad.GetEstMaxResponseTime());
+}
+
+TEST(FastKad, OneFastSampleMovesTheCeilingByTheDocumentedAmount)
+{
+	CFastKad kad;
+	kad.AddResponseTime(0x01020304, 500, T0);
+	ASSERT_EQUALS(1u, (unsigned)kad.GetSampleCount());
+
+	// One sample of 500 ms in a 100-slot window whose other 99 slots count
+	// as 1000 ms:
+	//   mean     = (500 + 99 * 1000) / 100                      = 995
+	//   variance = ((500-995)^2 + 99 * (1000-995)^2) / 99       = 2500
+	//   estimate = 995 + 2 * 50 + 100                           = 1195
+	// A single fast answer therefore cannot collapse the ceiling: it moves
+	// it by 5 ms shy of the margin, not by half the default.
+	ASSERT_EQUALS(1195u, (unsigned)kad.GetEstMaxResponseTime());
+}
+
+TEST(FastKad, AKnownSeriesProducesTheHandComputedCeiling)
+{
+	CFastKad kad;
+	// Four addresses, one answer each, at 200/400/600/800 ms.
+	//   mean     = (2000 + 96 * 1000) / 100                     = 980
+	//   variance = (780^2 + 580^2 + 380^2 + 180^2
+	//               + 96 * 20^2) / 99                           = 11717.171...
+	//   stddev   = 108.2458...
+	//   estimate = 980 + 216.4917... + 100                      = 1296.4917...
+	// truncated to 1296.
+	kad.AddResponseTime(0x0A000001, 200, T0);
+	kad.AddResponseTime(0x0A000002, 400, T0 + 1);
+	kad.AddResponseTime(0x0A000003, 600, T0 + 2);
+	kad.AddResponseTime(0x0A000004, 800, T0 + 3);
+
+	ASSERT_EQUALS(4u, (unsigned)kad.GetSampleCount());
+	ASSERT_EQUALS(1296u, (unsigned)kad.GetEstMaxResponseTime());
+}
+
+TEST(FastKad, AFullWindowOfEqualSamplesIsThatValuePlusTheMargin)
+{
+	CFastKad kad;
+	// A full window removes the unfilled-slot bias entirely, and equal
+	// samples have zero variance, so the estimate is exactly the sample
+	// value plus the margin. This is the tightest available check on the
+	// mean, on the margin, and on the window being genuinely full.
+	for (unsigned i = 0; i < WINDOW; ++i) {
+		kad.AddResponseTime(0x0B000000 + i, 200, T0);
+	}
+	ASSERT_EQUALS(WINDOW, (unsigned)kad.GetSampleCount());
+	ASSERT_EQUALS(300u, (unsigned)kad.GetEstMaxResponseTime());
+}
+
+TEST(FastKad, AWindowOfInstantAnswersLeavesOnlyTheMargin)
+{
+	CFastKad kad;
+	// The pathological floor: a whole window of instant answers. Mean and
+	// variance are both zero, so only the margin is left.
+	for (unsigned i = 0; i < WINDOW; ++i) {
+		kad.AddResponseTime(0x0C000000 + i, 0, T0);
+	}
+	ASSERT_EQUALS(100u, (unsigned)kad.GetEstMaxResponseTime());
+}
+
+TEST(FastKad, TheEstimateIsCappedAtTheDocumentedMaximum)
+{
+	CFastKad kad;
+	// Half the nodes answer instantly, half take ten minutes. The raw
+	// formula yields roughly 903122 ms, which would stall every search;
+	// the cap is what makes that survivable.
+	for (unsigned i = 0; i < WINDOW; ++i) {
+		kad.AddResponseTime(0x0D000000 + i, (i % 2) ? 1 : 600000, T0);
+	}
+	ASSERT_EQUALS(3000u, (unsigned)kad.GetEstMaxResponseTime());
+}
+
+TEST(FastKad, ARisingDistributionRaisesTheCeilingToTheHandComputedValue)
+{
+	CFastKad kad;
+	for (unsigned i = 0; i < WINDOW; ++i) {
+		kad.AddResponseTime(0x0E000000 + i, 200, T0);
+	}
+	ASSERT_EQUALS(300u, (unsigned)kad.GetEstMaxResponseTime());
+
+	// The same hundred addresses now answer in 2500 ms each. Still a full
+	// window, still zero variance: 2500 + 100.
+	for (unsigned i = 0; i < WINDOW; ++i) {
+		kad.AddResponseTime(0x0E000000 + i, 2500, T0 + 1);
+	}
+	ASSERT_EQUALS(WINDOW, (unsigned)kad.GetSampleCount());
+	ASSERT_EQUALS(2600u, (unsigned)kad.GetEstMaxResponseTime());
+
+	// And back down again, to prove the window replaces rather than
+	// accumulates.
+	for (unsigned i = 0; i < WINDOW; ++i) {
+		kad.AddResponseTime(0x0E000000 + i, 120, T0 + 2);
+	}
+	ASSERT_EQUALS(220u, (unsigned)kad.GetEstMaxResponseTime());
+}
+
+TEST(FastKad, TheWindowIsBoundedAndFreshSamplesAreNotEvicted)
+{
+	CFastKad kad;
+	for (unsigned i = 0; i < WINDOW; ++i) {
+		kad.AddResponseTime(0x0F000000 + i, 200, T0);
+	}
+	ASSERT_EQUALS(300u, (unsigned)kad.GetEstMaxResponseTime());
+
+	// Every existing sample is younger than the eviction age, so a flood of
+	// new addresses must be dropped rather than churn the window. Memory use
+	// stops growing AND the estimate is untouched -- the second half is what
+	// distinguishes "rejected" from "admitted and coincidentally equal".
+	for (unsigned i = 0; i < WINDOW * 2; ++i) {
+		kad.AddResponseTime(0xA0000000 + i, 2500, T0 + 1);
+	}
+	ASSERT_EQUALS(WINDOW, (unsigned)kad.GetSampleCount());
+	ASSERT_EQUALS(300u, (unsigned)kad.GetEstMaxResponseTime());
+}
+
+TEST(FastKad, AStaleSampleIsEvictedToMakeRoomForANewAddress)
+{
+	CFastKad kad;
+	for (unsigned i = 0; i < WINDOW; ++i) {
+		kad.AddResponseTime(0x10000000 + i, 200, T0);
+	}
+
+	// Past the eviction age the window is all stale, so one entry gives way.
+	// The window is then 99 samples of 200 ms plus one of 2500 ms:
+	//   mean     = (99 * 200 + 2500) / 100                      = 223
+	//   variance = (99 * 23^2 + 2277^2) / 99                    = 52900
+	//   estimate = 223 + 2 * 230 + 100                          = 783
+	// Nothing but a genuine eviction-and-insert produces 783.
+	kad.AddResponseTime(0xFFFFFFFF, 2500, T0 + 300001);
+	ASSERT_EQUALS(WINDOW, (unsigned)kad.GetSampleCount());
+	ASSERT_EQUALS(783u, (unsigned)kad.GetEstMaxResponseTime());
+}
+
+TEST(FastKad, RepeatedSamplesFromOneAddressReplaceRatherThanAccumulate)
+{
+	CFastKad kad;
+	for (unsigned i = 0; i < 10; ++i) {
+		kad.AddResponseTime(0x7F000001, 100 + i, T0 + i);
+	}
+	ASSERT_EQUALS(1u, (unsigned)kad.GetSampleCount());
+
+	// Only the last value, 109 ms, survives:
+	//   mean     = (109 + 99 * 1000) / 100                      = 991.09
+	//   variance = ((109-991.09)^2 + 99 * 8.91^2) / 99          = 7938.81
+	//   estimate = 991.09 + 2 * 89.1 + 100                      = 1269.29
+	// truncated to 1269. Accumulating the ten samples instead would leave a
+	// different mean and a different answer.
+	ASSERT_EQUALS(1269u, (unsigned)kad.GetEstMaxResponseTime());
+}
+
+TEST(FastKad, ClearReturnsToColdStart)
+{
+	CFastKad kad;
+	for (unsigned i = 0; i < WINDOW; ++i) {
+		kad.AddResponseTime(0x11000000 + i, 2500, T0);
+	}
+	ASSERT_EQUALS(2600u, (unsigned)kad.GetEstMaxResponseTime());
+
+	kad.Clear();
+	ASSERT_EQUALS(0u, (unsigned)kad.GetSampleCount());
+	ASSERT_EQUALS(1000u, (unsigned)kad.GetEstMaxResponseTime());
+}

--- a/unittests/tests/SafeKadTest.cpp
+++ b/unittests/tests/SafeKadTest.cpp
@@ -1,0 +1,395 @@
+//								-*- C++ -*-
+// This file is part of the aMule Project.
+//
+// Copyright (c) 2003-2026 aMule Team ( https://amule-org.github.io )
+//
+// Any parts of this program derived from the xMule, lMule or eMule project,
+// or contributed by third-party developers are copyrighted by their
+// respective authors.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301, USA
+//
+
+#include <muleunit/test.h>
+#include <kademlia/net/SafeKad.h>
+#include <protocol/kad2/Constants.h>
+
+using namespace muleunit;
+using Kademlia::CSafeKad;
+using Kademlia::CUInt128;
+
+// A fixed "now" for every test; the class takes the time as a parameter, so no
+// test here waits on a real clock.
+static const time_t T0 = 1700000000;
+
+static const uint32_t IP_A = 0x0A000001;
+static const uint32_t IP_B = 0x0A000002;
+static const uint16_t PORT_A = 4672;
+static const uint16_t PORT_B = 4673;
+
+static CUInt128 Id(uint32_t seed)
+{
+	return CUInt128(seed);
+}
+
+DECLARE_SIMPLE(SafeKad)
+
+TEST(SafeKad, FirstSightingOfANodeIsAccepted)
+{
+	CSafeKad safe;
+	ASSERT_FALSE(safe.IsBadNode(IP_A, PORT_A, Id(1), KADEMLIA_VERSION, true, true, T0));
+	ASSERT_EQUALS(1u, (unsigned)safe.GetTrackedNodeCount());
+	ASSERT_FALSE(safe.IsProblematic(IP_A, PORT_A, T0));
+	ASSERT_FALSE(safe.IsBanned(IP_A, T0));
+}
+
+TEST(SafeKad, SameIdentityIsAcceptedRepeatedly)
+{
+	CSafeKad safe;
+	for (unsigned i = 0; i < 20; ++i) {
+		ASSERT_FALSE(safe.IsBadNode(IP_A, PORT_A, Id(1), KADEMLIA_VERSION, true, true, T0 + i));
+	}
+	ASSERT_EQUALS(1u, (unsigned)safe.GetTrackedNodeCount());
+}
+
+TEST(SafeKad, RapidIdentityRotationIsRejectedAndMarkedProblematic)
+{
+	CSafeKad safe;
+	ASSERT_TRUE(safe.TrackNode(IP_A, PORT_A, Id(1), true, T0));
+
+	// Same address, new ID, well inside the one-hour minimum interval.
+	const time_t soon = T0 + CSafeKad::MIN_ID_CHANGE_INTERVAL - 1;
+	ASSERT_FALSE(safe.TrackNode(IP_A, PORT_A, Id(2), true, soon));
+
+	// The contact must be rejected...
+	ASSERT_TRUE(safe.IsBadNode(IP_A, PORT_A, Id(2), KADEMLIA_VERSION, true, false, soon));
+	// ...and the address must be on the problematic list.
+	ASSERT_TRUE(safe.IsProblematic(IP_A, PORT_A, soon));
+}
+
+TEST(SafeKad, IdentityChangeAfterTheIntervalIsAccepted)
+{
+	CSafeKad safe;
+	ASSERT_TRUE(safe.TrackNode(IP_A, PORT_A, Id(1), true, T0));
+
+	const time_t later = T0 + CSafeKad::MIN_ID_CHANGE_INTERVAL + 1;
+	ASSERT_TRUE(safe.TrackNode(IP_A, PORT_A, Id(2), true, later));
+	ASSERT_FALSE(safe.IsProblematic(IP_A, PORT_A, later));
+	ASSERT_FALSE(safe.IsBadNode(IP_A, PORT_A, Id(2), KADEMLIA_VERSION, true, false, later));
+}
+
+TEST(SafeKad, RepeatedRotationEscalatesToABan)
+{
+	CSafeKad safe;
+	ASSERT_TRUE(safe.TrackNode(IP_A, PORT_A, Id(1), true, T0));
+	// First rotation: problematic.
+	ASSERT_FALSE(safe.TrackNode(IP_A, PORT_A, Id(2), true, T0 + 10));
+	ASSERT_TRUE(safe.IsProblematic(IP_A, PORT_A, T0 + 10));
+	ASSERT_FALSE(safe.IsBanned(IP_A, T0 + 10));
+
+	// Second rotation while still problematic: banned.
+	ASSERT_FALSE(safe.TrackNode(IP_A, PORT_A, Id(3), true, T0 + 20));
+	ASSERT_TRUE(safe.IsBanned(IP_A, T0 + 20));
+	// A banned address stops being tracked; there is nothing left to weigh.
+	ASSERT_EQUALS(0u, (unsigned)safe.GetTrackedNodeCount());
+	ASSERT_TRUE(safe.IsBadNode(IP_A, PORT_A, Id(3), KADEMLIA_VERSION, true, false, T0 + 20));
+}
+
+TEST(SafeKad, AnUnverifiedClaimCannotOverwriteAVerifiedIdentity)
+{
+	CSafeKad safe;
+	ASSERT_TRUE(safe.TrackNode(IP_A, PORT_A, Id(1), true, T0));
+
+	// Long past the interval, so the rate limit is not what rejects this.
+	const time_t later = T0 + CSafeKad::MIN_ID_CHANGE_INTERVAL * 2;
+	ASSERT_FALSE(safe.TrackNode(IP_A, PORT_A, Id(9), false, later));
+	ASSERT_TRUE(safe.IsBadNode(IP_A, PORT_A, Id(9), KADEMLIA_VERSION, false, false, later));
+	// The verified identity is still the one we hold.
+	ASSERT_FALSE(safe.IsBadNode(IP_A, PORT_A, Id(1), KADEMLIA_VERSION, true, false, later));
+}
+
+TEST(SafeKad, PreVersion8NodesGetNoUnverifiedIdentityChangeAtAll)
+{
+	CSafeKad safe;
+	// Tracked unverified, so the "verified beats unverified" rule is not
+	// what is doing the work here.
+	ASSERT_TRUE(safe.TrackNode(IP_A, PORT_A, Id(1), false, T0));
+
+	// Keep the entry's last-reference time fresh while its last identity
+	// change ages. That is what a node we keep talking to looks like; without
+	// it, NODE_MAX_REFERENCE_AGE would reclaim the entry before the
+	// identity-change interval had elapsed and there would be nothing left
+	// to reject.
+	const time_t later = T0 + CSafeKad::MIN_ID_CHANGE_INTERVAL * 2;
+	safe.TrackNode(IP_A, PORT_A, Id(1), false, later - 1);
+
+	// A 0x07 node could not prove which port it listens on.
+	ASSERT_TRUE(safe.IsBadNode(IP_A, PORT_A, Id(2), 0x07, false, false, later));
+	// The same change from a 0x08 node, past the interval, is fine.
+	ASSERT_FALSE(safe.IsBadNode(IP_A, PORT_A, Id(2), 0x08, true, false, later));
+}
+
+TEST(SafeKad, OneNodePerAddressIsEnforcedWhenAsked)
+{
+	CSafeKad safe;
+	ASSERT_FALSE(safe.IsBadNode(IP_A, PORT_A, Id(1), KADEMLIA_VERSION, true, true, T0));
+
+	// A second Kad port on the same address.
+	ASSERT_TRUE(safe.IsBadNode(IP_A, PORT_B, Id(2), KADEMLIA_VERSION, true, true, T0));
+	// The first port keeps working.
+	ASSERT_FALSE(safe.IsBadNode(IP_A, PORT_A, Id(1), KADEMLIA_VERSION, true, true, T0));
+	// A different address is unaffected.
+	ASSERT_FALSE(safe.IsBadNode(IP_B, PORT_B, Id(3), KADEMLIA_VERSION, true, true, T0));
+
+	// With the check off (the search-response path, where the contact is
+	// already in our routing table), the second port is allowed.
+	CSafeKad relaxed;
+	ASSERT_FALSE(relaxed.IsBadNode(IP_A, PORT_A, Id(1), KADEMLIA_VERSION, true, false, T0));
+	ASSERT_FALSE(relaxed.IsBadNode(IP_A, PORT_B, Id(2), KADEMLIA_VERSION, true, false, T0));
+}
+
+TEST(SafeKad, ProblematicEntriesExpireAfterTheirHorizon)
+{
+	CSafeKad safe;
+	safe.TrackProblematicNode(IP_A, PORT_A, T0);
+	ASSERT_TRUE(safe.IsProblematic(IP_A, PORT_A, T0));
+	ASSERT_TRUE(safe.IsProblematic(IP_A, PORT_A, T0 + CSafeKad::MAX_PROBLEMATIC_TIME));
+
+	ASSERT_FALSE(safe.IsProblematic(IP_A, PORT_A, T0 + CSafeKad::MAX_PROBLEMATIC_TIME + 1));
+	ASSERT_EQUALS(0u, (unsigned)safe.GetProblematicNodeCount());
+}
+
+TEST(SafeKad, BansLapseAfterFourHours)
+{
+	CSafeKad safe;
+	safe.BanAddress(IP_A, T0);
+	ASSERT_TRUE(safe.IsBanned(IP_A, T0));
+	ASSERT_TRUE(safe.IsBanned(IP_A, T0 + CSafeKad::MAX_BAN_TIME));
+	ASSERT_EQUALS((unsigned)(4 * 3600), (unsigned)CSafeKad::MAX_BAN_TIME);
+
+	// Past the ceiling the address is judged on its current behaviour alone.
+	ASSERT_FALSE(safe.IsBanned(IP_A, T0 + CSafeKad::MAX_BAN_TIME + 1));
+	ASSERT_EQUALS(0u, (unsigned)safe.GetBannedAddressCount());
+	ASSERT_FALSE(safe.IsBadNode(
+		IP_A, PORT_A, Id(1), KADEMLIA_VERSION, true, true, T0 + CSafeKad::MAX_BAN_TIME + 1));
+}
+
+TEST(SafeKad, ABannedAddressIsProblematicByConstruction)
+{
+	CSafeKad safe;
+	safe.BanAddress(IP_A, T0);
+	ASSERT_TRUE(safe.IsProblematic(IP_A, PORT_A, T0));
+	ASSERT_TRUE(safe.IsProblematic(IP_A, PORT_B, T0));
+	// And it is not tracked or re-marked while banned.
+	safe.TrackProblematicNode(IP_A, PORT_A, T0);
+	ASSERT_EQUALS(0u, (unsigned)safe.GetProblematicNodeCount());
+	ASSERT_FALSE(safe.TrackNode(IP_A, PORT_A, Id(1), true, T0));
+	ASSERT_EQUALS(0u, (unsigned)safe.GetTrackedNodeCount());
+}
+
+TEST(SafeKad, TrackedTableStaysBoundedUnderSustainedTraffic)
+{
+	CSafeKad safe;
+	// Every address is distinct and fresh, which is the shape of a flood:
+	// nothing is old enough for the age horizon to reclaim.
+	for (unsigned i = 0; i < CSafeKad::MAX_TRACKED_NODES + 500; ++i) {
+		safe.TrackNode(0x20000000 + i, PORT_A, Id(i), true, T0);
+	}
+	ASSERT_TRUE(safe.GetTrackedNodeCount() <= CSafeKad::MAX_TRACKED_NODES);
+	ASSERT_EQUALS((unsigned)CSafeKad::MAX_TRACKED_NODES, (unsigned)safe.GetTrackedNodeCount());
+}
+
+TEST(SafeKad, ProblematicTableStaysBoundedUnderSustainedTraffic)
+{
+	CSafeKad safe;
+	for (unsigned i = 0; i < CSafeKad::MAX_PROBLEMATIC_NODES + 500; ++i) {
+		safe.TrackProblematicNode(0x30000000 + i, PORT_A, T0);
+	}
+	ASSERT_EQUALS((unsigned)CSafeKad::MAX_PROBLEMATIC_NODES, (unsigned)safe.GetProblematicNodeCount());
+}
+
+TEST(SafeKad, BannedTableStaysBoundedUnderSustainedTraffic)
+{
+	CSafeKad safe;
+	for (unsigned i = 0; i < CSafeKad::MAX_BANNED_ADDRESSES + 500; ++i) {
+		safe.BanAddress(0x40000000 + i, T0);
+	}
+	ASSERT_EQUALS((unsigned)CSafeKad::MAX_BANNED_ADDRESSES, (unsigned)safe.GetBannedAddressCount());
+}
+
+TEST(SafeKad, TableCapacitiesMatchTheSpecifiedBounds)
+{
+	ASSERT_EQUALS(10000u, (unsigned)CSafeKad::MAX_TRACKED_NODES);
+	ASSERT_EQUALS(10000u, (unsigned)CSafeKad::MAX_PROBLEMATIC_NODES);
+	ASSERT_EQUALS(1000u, (unsigned)CSafeKad::MAX_BANNED_ADDRESSES);
+	ASSERT_EQUALS(3600u, (unsigned)CSafeKad::MIN_ID_CHANGE_INTERVAL);
+	ASSERT_EQUALS(300u, (unsigned)CSafeKad::MAX_PROBLEMATIC_TIME);
+}
+
+TEST(SafeKad, EvictionAtCapacityDropsTheLeastRecentlyReferencedEntry)
+{
+	CSafeKad safe;
+	// One timestamp for the whole fill, so nothing is reclaimable by the age
+	// horizon and the capacity path is what has to do the work.
+	for (unsigned i = 0; i < CSafeKad::MAX_TRACKED_NODES; ++i) {
+		safe.TrackNode(0x50000000 + i, PORT_A, Id(i), true, T0);
+	}
+	ASSERT_EQUALS((unsigned)CSafeKad::MAX_TRACKED_NODES, (unsigned)safe.GetTrackedNodeCount());
+
+	// Refresh one address so it is strictly the most recently referenced.
+	safe.TrackNode(0x50000005, PORT_A, Id(5), true, T0 + 1);
+
+	// A new address has to displace something, and the table must not grow.
+	ASSERT_TRUE(safe.TrackNode(0x5FFFFFFF, PORT_A, Id(0xFFFF), true, T0 + 1));
+	ASSERT_EQUALS((unsigned)CSafeKad::MAX_TRACKED_NODES, (unsigned)safe.GetTrackedNodeCount());
+
+	// The refreshed address survived: it still remembers its identity, so a
+	// rotation inside the one-hour interval is refused.
+	ASSERT_TRUE(safe.IsBadNode(0x50000005, PORT_A, Id(0xBEEF), KADEMLIA_VERSION, true, false, T0 + 1));
+
+	// The least recently referenced address is the one that went: a new
+	// identity for it is accepted as a first sighting rather than rejected as
+	// a rotation, which is only possible if its entry is really gone.
+	ASSERT_TRUE(safe.TrackNode(0x50000000, PORT_A, Id(0x1234), true, T0 + 1));
+}
+
+TEST(SafeKad, CleanupReclaimsEntriesPastTheirReferenceHorizon)
+{
+	CSafeKad safe;
+	safe.TrackNode(IP_A, PORT_A, Id(1), true, T0);
+	safe.TrackProblematicNode(IP_B, PORT_B, T0);
+	safe.BanAddress(0x0A000003, T0);
+	ASSERT_EQUALS(1u, (unsigned)safe.GetTrackedNodeCount());
+	ASSERT_EQUALS(1u, (unsigned)safe.GetProblematicNodeCount());
+	ASSERT_EQUALS(1u, (unsigned)safe.GetBannedAddressCount());
+
+	// Nothing has referenced any of them for longer than every horizon.
+	safe.Cleanup(T0 + CSafeKad::NODE_MAX_REFERENCE_AGE + 1);
+	ASSERT_EQUALS(0u, (unsigned)safe.GetTrackedNodeCount());
+	ASSERT_EQUALS(0u, (unsigned)safe.GetProblematicNodeCount());
+	ASSERT_EQUALS(0u, (unsigned)safe.GetBannedAddressCount());
+}
+
+TEST(SafeKad, CleanupKeepsRecentlyReferencedEntries)
+{
+	CSafeKad safe;
+	safe.TrackNode(IP_A, PORT_A, Id(1), true, T0);
+	safe.Cleanup(T0 + CSafeKad::NODE_MAX_REFERENCE_AGE);
+	ASSERT_EQUALS(1u, (unsigned)safe.GetTrackedNodeCount());
+}
+
+TEST(SafeKad, ClearEmptiesEveryTable)
+{
+	CSafeKad safe;
+	safe.TrackNode(IP_A, PORT_A, Id(1), true, T0);
+	safe.TrackProblematicNode(IP_B, PORT_B, T0);
+	safe.BanAddress(0x0A000004, T0);
+
+	safe.Clear();
+	ASSERT_EQUALS(0u, (unsigned)safe.GetTrackedNodeCount());
+	ASSERT_EQUALS(0u, (unsigned)safe.GetProblematicNodeCount());
+	ASSERT_EQUALS(0u, (unsigned)safe.GetBannedAddressCount());
+}
+
+// An unverified identity change against a verified tracked entry is refused
+// outright rather than rate-limited, which is stricter than the spec asks for.
+// It must still escalate: a refusal that costs the sender nothing lets a sybil
+// retry the same rotation for as long as it likes, which is precisely what the
+// problematic-then-banned ladder exists to stop.
+TEST(SafeKad, AnUnverifiedIdentityChangeAgainstAVerifiedEntryEscalates)
+{
+	CSafeKad safe;
+	ASSERT_TRUE(safe.TrackNode(IP_A, PORT_A, Id(1), true, T0));
+
+	// First attempt, well inside the one-hour interval: refused, and the
+	// address is now on the problematic list.
+	ASSERT_TRUE(safe.IsBadNode(IP_A, PORT_A, Id(2), KADEMLIA_VERSION, false, false, T0 + 10));
+	ASSERT_TRUE(safe.IsProblematic(IP_A, PORT_A, T0 + 10));
+	ASSERT_FALSE(safe.IsBanned(IP_A, T0 + 10));
+
+	// Retrying costs it the address: a second attempt while problematic bans.
+	ASSERT_TRUE(safe.IsBadNode(IP_A, PORT_A, Id(3), KADEMLIA_VERSION, false, false, T0 + 20));
+	ASSERT_TRUE(safe.IsBanned(IP_A, T0 + 20));
+	// A banned address stops being tracked; there is nothing left to weigh.
+	ASSERT_EQUALS(0u, (unsigned)safe.GetTrackedNodeCount());
+
+	// And the ban covers the address, not just the rotation: even the
+	// identity we had verified is refused for as long as it lasts.
+	ASSERT_TRUE(safe.IsBadNode(IP_A, PORT_A, Id(1), KADEMLIA_VERSION, true, false, T0 + 30));
+}
+
+// The same ladder for a pre-0x08 node, where it is the version rather than the
+// verification state of the tracked entry that refuses the change.
+TEST(SafeKad, AnUnverifiedPreVersion8IdentityChangeEscalates)
+{
+	CSafeKad safe;
+	ASSERT_TRUE(safe.TrackNode(IP_A, PORT_A, Id(1), false, T0));
+
+	ASSERT_TRUE(safe.IsBadNode(IP_A, PORT_A, Id(2), 0x07, false, false, T0 + 10));
+	ASSERT_TRUE(safe.IsProblematic(IP_A, PORT_A, T0 + 10));
+	ASSERT_FALSE(safe.IsBanned(IP_A, T0 + 10));
+
+	ASSERT_TRUE(safe.IsBadNode(IP_A, PORT_A, Id(3), 0x07, false, false, T0 + 20));
+	ASSERT_TRUE(safe.IsBanned(IP_A, T0 + 20));
+}
+
+// One rejected rotation is one step up the ladder, never two. Both refusal
+// paths -- the outright one here and TrackNode's rate limit -- share a single
+// escalation, so a single call must leave the address problematic and not
+// banned. Double-counting would ban on first contact.
+TEST(SafeKad, OneRejectedRotationEscalatesExactlyOneStep)
+{
+	CSafeKad safe;
+	ASSERT_FALSE(safe.IsBadNode(IP_A, PORT_A, Id(1), KADEMLIA_VERSION, true, false, T0));
+
+	// Verified, so this goes through TrackNode's rate limit rather than the
+	// outright refusal.
+	ASSERT_TRUE(safe.IsBadNode(IP_A, PORT_A, Id(2), KADEMLIA_VERSION, true, false, T0 + 10));
+	ASSERT_TRUE(safe.IsProblematic(IP_A, PORT_A, T0 + 10));
+	ASSERT_FALSE(safe.IsBanned(IP_A, T0 + 10));
+	ASSERT_EQUALS(1u, (unsigned)safe.GetProblematicNodeCount());
+
+	CSafeKad other;
+	ASSERT_FALSE(other.IsBadNode(IP_B, PORT_A, Id(1), KADEMLIA_VERSION, true, false, T0));
+	// Unverified, so this takes the outright refusal instead.
+	ASSERT_TRUE(other.IsBadNode(IP_B, PORT_A, Id(2), KADEMLIA_VERSION, false, false, T0 + 10));
+	ASSERT_TRUE(other.IsProblematic(IP_B, PORT_A, T0 + 10));
+	ASSERT_FALSE(other.IsBanned(IP_B, T0 + 10));
+	ASSERT_EQUALS(1u, (unsigned)other.GetProblematicNodeCount());
+}
+
+// A change refused only because it could not be verified, long past the
+// interval, is not rapid rotation and must not escalate: a legacy client that
+// legitimately reinstalled once a year is not a sybil, and banning it for four
+// hours over a single refused change would be the protection misfiring.
+TEST(SafeKad, ARefusedChangePastTheIntervalIsNotEscalated)
+{
+	CSafeKad safe;
+	ASSERT_TRUE(safe.TrackNode(IP_A, PORT_A, Id(1), true, T0));
+
+	// Keep the entry referenced while its last identity change ages, so the
+	// reference horizon does not reclaim it before the interval elapses.
+	// The refresh goes through TrackNode on purpose: IsBadNode() runs
+	// Cleanup() before it looks the entry up, so refreshing through it would
+	// reclaim the entry first and turn the next call into a first sighting.
+	const time_t later = T0 + CSafeKad::MIN_ID_CHANGE_INTERVAL * 2;
+	ASSERT_TRUE(safe.TrackNode(IP_A, PORT_A, Id(1), true, later - 1));
+
+	ASSERT_TRUE(safe.IsBadNode(IP_A, PORT_A, Id(9), KADEMLIA_VERSION, false, false, later));
+	ASSERT_FALSE(safe.IsProblematic(IP_A, PORT_A, later));
+	ASSERT_FALSE(safe.IsBanned(IP_A, later));
+	// The verified identity we hold is untouched and still usable.
+	ASSERT_FALSE(safe.IsBadNode(IP_A, PORT_A, Id(1), KADEMLIA_VERSION, true, false, later));
+}

--- a/unittests/tests/SafeKadTest.cpp
+++ b/unittests/tests/SafeKadTest.cpp
@@ -304,45 +304,55 @@ TEST(SafeKad, ClearEmptiesEveryTable)
 }
 
 // An unverified identity change against a verified tracked entry is refused
-// outright rather than rate-limited, which is stricter than the spec asks for.
-// It must still escalate: a refusal that costs the sender nothing lets a sybil
-// retry the same rotation for as long as it likes, which is precisely what the
-// problematic-then-banned ladder exists to stop.
-TEST(SafeKad, AnUnverifiedIdentityChangeAgainstAVerifiedEntryEscalates)
+// outright rather than rate-limited -- and refused without escalating.
+//
+// The refusal is what protects the entry: the identity we verified is still
+// the one we hold, and the claim gets nothing. Escalating on top of it would
+// be the mistake, because nothing about an unverified claim ties it to the
+// address it names. A peer answering one of our Kad requests picks the
+// (IP, port, ID) triples it lists, so the ladder would climb on somebody
+// else's say-so and ban the node that did nothing.
+TEST(SafeKad, AnUnverifiedIdentityChangeAgainstAVerifiedEntryIsRefusedNotEscalated)
 {
 	CSafeKad safe;
 	ASSERT_TRUE(safe.TrackNode(IP_A, PORT_A, Id(1), true, T0));
 
-	// First attempt, well inside the one-hour interval: refused, and the
-	// address is now on the problematic list.
+	// Refused, and nothing recorded against the address.
 	ASSERT_TRUE(safe.IsBadNode(IP_A, PORT_A, Id(2), KADEMLIA_VERSION, false, false, T0 + 10));
-	ASSERT_TRUE(safe.IsProblematic(IP_A, PORT_A, T0 + 10));
+	ASSERT_FALSE(safe.IsProblematic(IP_A, PORT_A, T0 + 10));
 	ASSERT_FALSE(safe.IsBanned(IP_A, T0 + 10));
 
-	// Retrying costs it the address: a second attempt while problematic bans.
+	// Retrying earns no more than the first attempt did. Free for the
+	// sender, and that is the accepted cost: an unverified claim can waste
+	// our time, but it must not be able to spend somebody else's reputation.
 	ASSERT_TRUE(safe.IsBadNode(IP_A, PORT_A, Id(3), KADEMLIA_VERSION, false, false, T0 + 20));
-	ASSERT_TRUE(safe.IsBanned(IP_A, T0 + 20));
-	// A banned address stops being tracked; there is nothing left to weigh.
-	ASSERT_EQUALS(0u, (unsigned)safe.GetTrackedNodeCount());
+	ASSERT_FALSE(safe.IsBanned(IP_A, T0 + 20));
 
-	// And the ban covers the address, not just the rotation: even the
-	// identity we had verified is refused for as long as it lasts.
-	ASSERT_TRUE(safe.IsBadNode(IP_A, PORT_A, Id(1), KADEMLIA_VERSION, true, false, T0 + 30));
+	// The entry survives intact, and the identity we verified still works.
+	ASSERT_EQUALS(1u, (unsigned)safe.GetTrackedNodeCount());
+	ASSERT_FALSE(safe.IsBadNode(IP_A, PORT_A, Id(1), KADEMLIA_VERSION, true, false, T0 + 30));
 }
 
-// The same ladder for a pre-0x08 node, where it is the version rather than the
-// verification state of the tracked entry that refuses the change.
-TEST(SafeKad, AnUnverifiedPreVersion8IdentityChangeEscalates)
+// The same refusal for a pre-0x08 node, where it is the version rather than
+// the verification state of the tracked entry that refuses the change. Such a
+// node can never verify, so it can never be escalated either -- it keeps the
+// refusal and loses nothing else.
+TEST(SafeKad, AnUnverifiedPreVersion8IdentityChangeIsRefusedNotEscalated)
 {
 	CSafeKad safe;
 	ASSERT_TRUE(safe.TrackNode(IP_A, PORT_A, Id(1), false, T0));
 
+	// Refused, both times, and never escalated. A pre-0x08 node cannot prove
+	// which port it listens on, so nothing it says about its identity is
+	// verified -- and an unverified claim is the one a third party can
+	// fabricate. Refusing costs the sender its rotation; banning would let
+	// anyone spoofing this address get the honest node behind it banned.
 	ASSERT_TRUE(safe.IsBadNode(IP_A, PORT_A, Id(2), 0x07, false, false, T0 + 10));
-	ASSERT_TRUE(safe.IsProblematic(IP_A, PORT_A, T0 + 10));
+	ASSERT_FALSE(safe.IsProblematic(IP_A, PORT_A, T0 + 10));
 	ASSERT_FALSE(safe.IsBanned(IP_A, T0 + 10));
 
 	ASSERT_TRUE(safe.IsBadNode(IP_A, PORT_A, Id(3), 0x07, false, false, T0 + 20));
-	ASSERT_TRUE(safe.IsBanned(IP_A, T0 + 20));
+	ASSERT_FALSE(safe.IsBanned(IP_A, T0 + 20));
 }
 
 // One rejected rotation is one step up the ladder, never two. Both refusal
@@ -363,11 +373,58 @@ TEST(SafeKad, OneRejectedRotationEscalatesExactlyOneStep)
 
 	CSafeKad other;
 	ASSERT_FALSE(other.IsBadNode(IP_B, PORT_A, Id(1), KADEMLIA_VERSION, true, false, T0));
-	// Unverified, so this takes the outright refusal instead.
+	// Unverified, so this takes the outright refusal -- which refuses without
+	// escalating, and so leaves no problematic entry at all.
 	ASSERT_TRUE(other.IsBadNode(IP_B, PORT_A, Id(2), KADEMLIA_VERSION, false, false, T0 + 10));
-	ASSERT_TRUE(other.IsProblematic(IP_B, PORT_A, T0 + 10));
+	ASSERT_FALSE(other.IsProblematic(IP_B, PORT_A, T0 + 10));
 	ASSERT_FALSE(other.IsBanned(IP_B, T0 + 10));
-	ASSERT_EQUALS(1u, (unsigned)other.GetProblematicNodeCount());
+	ASSERT_EQUALS(0u, (unsigned)other.GetProblematicNodeCount());
+}
+
+// The attack the verification requirement exists to stop, written out as a
+// test because the code reads reasonable without it.
+//
+// ProcessKademlia2Response() calls AddUnfiltered() with verified hardcoded to
+// false, and the peer answering our request chooses the (IP, port, ID) triples
+// it lists. m_lastIDChange is stamped when an entry is created, so every
+// freshly-learned contact sits inside the sub-hour window. Two fabricated
+// mentions of an honest node would therefore have marked it problematic and
+// then banned it for four hours, without that node ever sending us anything.
+TEST(SafeKad, FabricatedUnverifiedMentionsCannotBanAnHonestNode)
+{
+	CSafeKad safe;
+
+	// An honest node we have just learned about, exactly as a response
+	// listing it would: unverified, and stamped now.
+	ASSERT_FALSE(safe.IsBadNode(IP_A, PORT_A, Id(1), KADEMLIA_VERSION, false, false, T0));
+
+	// A hostile peer names the same address twice with identities it made
+	// up, well inside the rotation window.
+	ASSERT_TRUE(safe.IsBadNode(IP_A, PORT_A, Id(2), KADEMLIA_VERSION, false, false, T0 + 5));
+	ASSERT_TRUE(safe.IsBadNode(IP_A, PORT_A, Id(3), KADEMLIA_VERSION, false, false, T0 + 10));
+
+	// Neither mention counted for anything.
+	ASSERT_FALSE(safe.IsBanned(IP_A, T0 + 10));
+	ASSERT_FALSE(safe.IsProblematic(IP_A, PORT_A, T0 + 10));
+
+	// And the honest node is still usable under the identity we hold.
+	ASSERT_FALSE(safe.IsBadNode(IP_A, PORT_A, Id(1), KADEMLIA_VERSION, false, false, T0 + 15));
+}
+
+// The other half: a peer that has proved which port it listens on and then
+// cycles identities faster than once an hour is escalated exactly as before.
+// Requiring verification narrows who can be banned, not what a ban is for.
+TEST(SafeKad, AVerifiedRotationStillEscalatesToABan)
+{
+	CSafeKad safe;
+	ASSERT_FALSE(safe.IsBadNode(IP_A, PORT_A, Id(1), KADEMLIA_VERSION, true, false, T0));
+
+	ASSERT_TRUE(safe.IsBadNode(IP_A, PORT_A, Id(2), KADEMLIA_VERSION, true, false, T0 + 10));
+	ASSERT_TRUE(safe.IsProblematic(IP_A, PORT_A, T0 + 10));
+	ASSERT_FALSE(safe.IsBanned(IP_A, T0 + 10));
+
+	ASSERT_TRUE(safe.IsBadNode(IP_A, PORT_A, Id(3), KADEMLIA_VERSION, true, false, T0 + 20));
+	ASSERT_TRUE(safe.IsBanned(IP_A, T0 + 20));
 }
 
 // A change refused only because it could not be verified, long past the


### PR DESCRIPTION
## What this is

Two local Kad heuristics from eMuleAI, behind a new configure switch
`ENABLE_KAD_NODE_PROTECTION`, default OFF.

Neither class defines a tag, an opcode or a packet field. They consume what the
Kad protocol already carries and decide only what we do locally: whether to
admit a contact, whether to believe an answer, how long to wait before treating
a request as stalled. A peer cannot observe whether we run them and has nothing
to implement in response.

That is why they are here and not in the Kad protocol 0x0a catch-up, and why the
switch is not named after a protocol version: `ENABLE_KAD_PROTOCOL_10` would
imply a wire contract that does not exist for this code.

### `CFastKad` — adaptive request timeout

Replaces the fixed 3-second jumpstart deadline in `CSearch::JumpStart()` with an
estimate derived from response times actually observed: a bounded window of the
100 most recent per-address round-trip times, estimated as mean + 2 standard
deviations plus a 100 ms margin, capped at 3000 ms.

Two deliberate biases keep a cold or lucky window from producing an
aggressively short timeout: both moments are divided by the full window size
with every unfilled slot counted as the 1000 ms default, and entries younger
than 5 minutes are never evicted to make room.

Background store operations (`STOREFILE`, `STOREKEYWORD`, `STORENOTES`) keep the
fixed 3 seconds. Nobody is waiting on a publish, and a tight adaptive deadline
there would only add republish traffic.

### `CSafeKad` — Kad identity protections

Tracks (address, port) -> Kad ID with a one-hour minimum identity-change
interval, a problematic list (300 s), and a per-address ban (4 h) reached by
escalation. All three tables are bounded (10000 / 10000 / 1000 entries) and
cleaned on a timer.

An unverified identity change is refused outright rather than rate-limited when
the tracked entry was verified, or when the peer advertises below Kad 0x08 and
therefore cannot prove which UDP port it listens on.

## Call sites

- `CSearch::ProcessResponse()` — records the round-trip time of every answer,
  and checks `IsBadNode()` on the answering contact.
- `CSearch::JumpStart()` — uses the derived ceiling, and marks timed-out
  requests problematic.
- `CSearch::SendFindValue()` — starts the clock on each outgoing request.
- `CRoutingZone::AddUnfiltered()` — checks `IsBadNode()` before admitting a
  contact.
- `CRoutingZone::VerifyContact()` — records a handshake-verified identity.
- `CKademlia::Stop()` — clears both tables, since they are keyed on addresses
  from a session that has ended.

### The routing-table call site is ours

eMuleAI and emule-qt each call `IsBadNode()` in exactly one place, the search
answer. The `CRoutingZone::AddUnfiltered()` call is an addition of ours: it
decides who enters the routing table, and neither reference implementation does
that.

It has **not** been exercised against a live Kad network. It is off by default
and behind the flag, but that is the state of the evidence for it.

`onlyOneNodePerIP` is deliberately off at both call sites. `CRoutingBin` already
caps the routing table at one Kad ID per address plus ten per /24, and
duplicating that would add a second, weaker copy of a rule the bin enforces
better.

## The gate

OFF by default. OFF compiles out every call site and leaves `FastKad.cpp` and
`SafeKad.cpp` out of the build entirely, so a default build is the upstream one.

Verified by preprocessing `Search.cpp`, `Kademlia.cpp` and `RoutingZone.cpp` with
the switch off and diffing the result against the same files at `master`: token
for token identical, modulo the `__LINE__` values that the added comment lines
shift inside the logging macros.

The unit tests compile the two sources directly and run in both gate states, so
nothing is gated out of test coverage.

## Tests

- `FastKadTest` — 12 cases. Every expected ceiling is a literal worked out by
  hand from the documented estimator, not read back from `CFastKad`'s own
  constants: a known series of 200/400/600/800 ms pins 1296 ms, a single 500 ms
  sample pins 1195 ms, a stale-eviction insert pins 783 ms. A separate case
  asserts the four constants those literals assume, so a constant change fails
  loudly instead of letting the arithmetic cases re-derive a new answer.
- `SafeKadTest` — the identity-change interval, the escalation ladder, ban
  expiry, the per-address rule, and the bounds on all three tables. Time is a
  parameter everywhere, so a four-hour ban expiry is one call rather than a wait.

## Files

```
src/kademlia/net/FastKad.{cpp,h}       new
src/kademlia/net/SafeKad.{cpp,h}       new
unittests/tests/FastKadTest.cpp        new
unittests/tests/SafeKadTest.cpp        new
src/kademlia/kademlia/Search.{cpp,h}   gated call sites
src/kademlia/kademlia/Kademlia.cpp     gated teardown
src/kademlia/routing/RoutingZone.cpp   gated call sites
cmake/options.cmake                    the switch
cmake/source-vars.cmake                gated sources
unittests/tests/CMakeLists.txt         the two suites
.github/workflows/ccpp.yml             one Linux job with the switch on
```

## Not in this branch

The Kad protocol 0x0a catch-up — the `KADEMLIA_VERSION` bump and the AICH
keyword storage that Kad 0x09 introduced. That is upstream eMule protocol and is
proposed separately under `ENABLE_KAD_PROTOCOL_10`.
