### PR TITLE
fix(gui): list every installed language without a second step

### DIFF
--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -49,6 +49,7 @@ src/kademlia/kademlia/SearchManager.cpp
 src/kademlia/routing/RoutingZone.cpp
 src/KnownFile.cpp
 src/KnownFileList.cpp
+src/LanguageList.cpp
 src/libs/common/Format.cpp
 src/libs/ec/cpp/ECSpecialTags.cpp
 src/libs/ec/cpp/RemoteConnect.cpp

--- a/po/amule.pot
+++ b/po/amule.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-05 12:01+0200\n"
+"POT-Creation-Date: 2026-09-06 14:35+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -3111,6 +3111,162 @@ msgstr ""
 msgid "Invalid entry in known file list, file may be corrupt: "
 msgstr ""
 
+#: src/LanguageList.cpp
+msgid "System default"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Albanian"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Arabic"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Asturian"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Basque"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Bulgarian"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Catalan"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Chinese (Simplified)"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Chinese (Traditional)"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Croatian"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Czech"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Danish"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Dutch"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "English (U.K.)"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "English (U.S.)"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Estonian"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Finnish"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "French"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Galician"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "German"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Greek"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Hebrew"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Hungarian"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Italian"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Japanese"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Korean"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Latvian"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Lithuanian"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Norwegian (Nynorsk)"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Polish"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Portuguese"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Portuguese (Brazilian)"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Romanian"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Russian"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Slovenian"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Spanish"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Swedish"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Turkish"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Ukrainian"
+msgstr ""
+
 #: src/libs/common/Format.cpp
 #, c-format
 msgid "Unknown error %d"
@@ -5765,174 +5921,6 @@ msgstr ""
 #: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Failed to open partfile '%s'"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "System default"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Albanian"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Arabic"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Asturian"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Basque"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Bulgarian"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Catalan"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Chinese (Simplified)"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Chinese (Traditional)"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Croatian"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Czech"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Danish"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Dutch"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "English (U.K.)"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "English (U.S.)"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Estonian"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Finnish"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "French"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Galician"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "German"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Greek"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Hebrew"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Hungarian"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Italian"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Japanese"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Korean"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Latvian"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Lithuanian"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Norwegian (Nynorsk)"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Polish"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Portuguese"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Portuguese (Brazilian)"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Romanian"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Russian"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Slovenian"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Spanish"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Swedish"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Turkish"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Ukrainian"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Change Language"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "There are no translations installed for aMule"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "No languages available"
 msgstr ""
 
 #: src/Preferences.cpp

--- a/po/ar.po
+++ b/po/ar.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-05 12:01+0200\n"
+"POT-Creation-Date: 2026-09-06 14:35+0200\n"
 "PO-Revision-Date: 2026-09-05 10:44+0000\n"
 "Last-Translator: saleh alhathal <hathalsal@hotmail.com>\n"
 "Language-Team: \n"
@@ -375,7 +375,8 @@ msgstr ""
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr ""
 
-#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
+#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
+#: src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
 msgid "ERROR"
 msgstr ""
 
@@ -655,7 +656,8 @@ msgstr ""
 msgid "Searches"
 msgstr "بحث"
 
-#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/Statistics.cpp
+#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/Statistics.cpp
 msgid "Downloads"
 msgstr "تحميل"
 
@@ -741,7 +743,9 @@ msgstr ""
 msgid "Core"
 msgstr ""
 
-#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp src/Statistics.cpp
+#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp src/Statistics.cpp
 msgid "Version"
 msgstr "نسخة"
 
@@ -1043,7 +1047,11 @@ msgstr ""
 msgid "The remote core sent inconsistent data for \"%s\" (part status %d, expected %d). The file list may be showing the wrong information; reconnect to clear it."
 msgstr ""
 
-#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp src/Statistics.cpp
+#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp
+#: src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp
+#: src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp
+#: src/Statistics.cpp
 msgid "Unknown"
 msgstr "غير معرف"
 
@@ -1141,7 +1149,8 @@ msgstr "خطأ أثناء اﻹتصال بي%s (%s:%i): %d"
 msgid "Enter Captcha"
 msgstr ""
 
-#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp src/TransferWnd.cpp
+#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp
+#: src/TransferWnd.cpp
 msgid "Category"
 msgstr "صنف"
 
@@ -1302,11 +1311,13 @@ msgstr ""
 msgid "Client Details"
 msgstr "تفاصيل العميل"
 
-#: src/ClientDetailDialog.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
+#: src/utils/wxCas/src/onlinesig.cpp
 msgid "LowID"
 msgstr "هوية متدنية"
 
-#: src/ClientDetailDialog.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
+#: src/utils/wxCas/src/onlinesig.cpp
 msgid "HighID"
 msgstr ""
 
@@ -1322,7 +1333,8 @@ msgstr ""
 msgid "Not supported"
 msgstr ""
 
-#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp src/TextClient.cpp
+#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
+#: src/TextClient.cpp
 msgid "Connected"
 msgstr "متصل"
 
@@ -1330,7 +1342,8 @@ msgstr "متصل"
 msgid "Disconnected"
 msgstr "فصل الإتصال"
 
-#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f KiB/s"
 msgstr ""
@@ -1348,7 +1361,8 @@ msgstr ""
 msgid "IP Address"
 msgstr "عنوان IP"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Origin"
 msgstr ""
 
@@ -1366,12 +1380,14 @@ msgstr "اخر إستقبال"
 msgid "Sessions"
 msgstr "نسخة"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/SharedFilePeersListCtrl.cpp
 #, fuzzy
 msgid "Upload Speed"
 msgstr "سرعة-الرفع"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/SharedFilePeersListCtrl.cpp
 #, fuzzy
 msgid "Download Speed"
 msgstr "سرعة-التحميل"
@@ -1426,11 +1442,13 @@ msgstr[1] ""
 msgid "Files"
 msgstr "ملفات"
 
-#: src/ClientsListCtrl.cpp src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientsListCtrl.cpp src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp
 msgid "Uploaded"
 msgstr ""
 
-#: src/ClientsListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientsListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Downloaded"
 msgstr ""
 
@@ -1521,7 +1539,8 @@ msgstr "ملف تعليقات"
 msgid "Username"
 msgstr "اسم مستخدم"
 
-#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp
+#: src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "File Name"
 msgstr "اسم الملف"
 
@@ -1583,15 +1602,18 @@ msgstr "ذاتي عالي"
 msgid "Very low"
 msgstr "متدني جدا"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Low"
 msgstr "متدني"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Normal"
 msgstr "عادي"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "High"
 msgstr "مرتفع"
 
@@ -1615,11 +1637,13 @@ msgstr "اتصال من خلال خادم"
 msgid "Queue Full"
 msgstr "اﻻنتظار ممتلئ"
 
-#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp src/muuli_wdr.cpp
+#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp
+#: src/muuli_wdr.cpp
 msgid "On Queue"
 msgstr "في اﻻنتظار"
 
-#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
+#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp
+#: src/PartFile.cpp src/TransferWnd.cpp
 msgid "Downloading"
 msgstr "تحميل"
 
@@ -1679,7 +1703,8 @@ msgstr ""
 msgid "Remote Server"
 msgstr ""
 
-#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp src/TextClient.cpp
+#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp
+#: src/TextClient.cpp
 msgid "Kad"
 msgstr ""
 
@@ -1703,7 +1728,8 @@ msgstr ""
 msgid "Search Result"
 msgstr ""
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp
+#: src/TransferWnd.cpp
 msgid "Completed"
 msgstr "اكمل"
 
@@ -1755,7 +1781,8 @@ msgstr ""
 msgid "Part"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 msgid "Size"
 msgstr "حجم"
 
@@ -1763,7 +1790,8 @@ msgstr "حجم"
 msgid "Transferred"
 msgstr "نقل"
 
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp src/SourceListCtrl.cpp
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
+#: src/SourceListCtrl.cpp
 msgid "Speed"
 msgstr "سرعة"
 
@@ -1771,11 +1799,13 @@ msgstr "سرعة"
 msgid "Progress"
 msgstr "تقدم"
 
-#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
+#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp
+#: src/SearchListCtrl.cpp
 msgid "Sources"
 msgstr "مصدر"
 
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 msgid "Priority"
 msgstr "أولوية"
 
@@ -1799,7 +1829,9 @@ msgstr "اخر إستقبال"
 msgid "Auto"
 msgstr "ذاتي"
 
-#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/TransferWnd.cpp src/utils/wxCas/src/wxcasprefs.cpp
+#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/TransferWnd.cpp
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Cancel"
 msgstr "إلغاء"
 
@@ -1900,7 +1932,8 @@ msgstr ""
 msgid "File rename"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f MiB/s"
 msgstr ""
@@ -2671,11 +2704,13 @@ msgstr ""
 msgid "Start aMule automatically when I log in"
 msgstr ""
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp packaging/windows/installer_strings.c
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: packaging/windows/installer_strings.c
 msgid "Register aMule for ed2k:// links"
 msgstr ""
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp packaging/windows/installer_strings.c
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: packaging/windows/installer_strings.c
 msgid "Register aMule for magnet: links"
 msgstr ""
 
@@ -2701,7 +2736,8 @@ msgstr ""
 msgid "Destination folder for downloads"
 msgstr ""
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Browse"
 msgstr "تصفح"
 
@@ -3125,6 +3161,164 @@ msgstr ""
 msgid "Invalid entry in known file list, file may be corrupt: "
 msgstr ""
 
+#: src/LanguageList.cpp
+msgid "System default"
+msgstr "اﻹفتراضية بالنظام"
+
+#: src/LanguageList.cpp
+msgid "Albanian"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Arabic"
+msgstr "العربيه"
+
+#: src/LanguageList.cpp
+#, fuzzy
+msgid "Asturian"
+msgstr "الأستونيه"
+
+#: src/LanguageList.cpp
+msgid "Basque"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Bulgarian"
+msgstr "البلغاريه"
+
+#: src/LanguageList.cpp
+msgid "Catalan"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Chinese (Simplified)"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Chinese (Traditional)"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Croatian"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Czech"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Danish"
+msgstr "الدانماركيه"
+
+#: src/LanguageList.cpp
+msgid "Dutch"
+msgstr "الهولنديه"
+
+#: src/LanguageList.cpp
+msgid "English (U.K.)"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "English (U.S.)"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Estonian"
+msgstr "الأستونيه"
+
+#: src/LanguageList.cpp
+msgid "Finnish"
+msgstr "الفلنديه"
+
+#: src/LanguageList.cpp
+msgid "French"
+msgstr "الفرنسية"
+
+#: src/LanguageList.cpp
+msgid "Galician"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "German"
+msgstr "الألمانيه"
+
+#: src/LanguageList.cpp
+msgid "Greek"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Hebrew"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Hungarian"
+msgstr "الهنغاريه"
+
+#: src/LanguageList.cpp
+msgid "Italian"
+msgstr "الايطاليه"
+
+#: src/LanguageList.cpp
+msgid "Japanese"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Korean"
+msgstr "الكوريه"
+
+#: src/LanguageList.cpp
+msgid "Latvian"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Lithuanian"
+msgstr "الليتوانيه"
+
+#: src/LanguageList.cpp
+msgid "Norwegian (Nynorsk)"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Polish"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Portuguese"
+msgstr "البرتغاليه"
+
+#: src/LanguageList.cpp
+msgid "Portuguese (Brazilian)"
+msgstr ""
+
+#: src/LanguageList.cpp
+#, fuzzy
+msgid "Romanian"
+msgstr "الأستونيه"
+
+#: src/LanguageList.cpp
+msgid "Russian"
+msgstr "الروسيه"
+
+#: src/LanguageList.cpp
+msgid "Slovenian"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Spanish"
+msgstr "الإسبانيه"
+
+#: src/LanguageList.cpp
+msgid "Swedish"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Turkish"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Ukrainian"
+msgstr ""
+
 #: src/libs/common/Format.cpp
 #, fuzzy, c-format
 msgid "Unknown error %d"
@@ -3147,15 +3341,18 @@ msgstr "اكتمال"
 msgid "Complete"
 msgstr "اكتمل"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Paused"
 msgstr "ايقاف مؤقت"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Erroneous"
 msgstr "خاطئ"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Waiting"
 msgstr "انتظار"
 
@@ -3319,7 +3516,8 @@ msgstr "اغلق"
 msgid "Cut"
 msgstr ""
 
-#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp src/utils/aLinkCreator/src/alcframe.cpp
+#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy"
 msgstr ""
 
@@ -3327,7 +3525,8 @@ msgstr ""
 msgid "Paste"
 msgstr ""
 
-#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
+#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Clear"
 msgstr "واضح"
 
@@ -3335,7 +3534,8 @@ msgstr "واضح"
 msgid "Select All"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp src/StatisticsDlg.cpp
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
+#: src/StatisticsDlg.cpp
 msgid "KiB/s"
 msgstr ""
 
@@ -5827,178 +6027,6 @@ msgid "ERROR: Failed to open partfile '%s'"
 msgstr ""
 
 #: src/Preferences.cpp
-msgid "System default"
-msgstr "اﻹفتراضية بالنظام"
-
-#: src/Preferences.cpp
-msgid "Albanian"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Arabic"
-msgstr "العربيه"
-
-#: src/Preferences.cpp
-#, fuzzy
-msgid "Asturian"
-msgstr "الأستونيه"
-
-#: src/Preferences.cpp
-msgid "Basque"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Bulgarian"
-msgstr "البلغاريه"
-
-#: src/Preferences.cpp
-msgid "Catalan"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Chinese (Simplified)"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Chinese (Traditional)"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Croatian"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Czech"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Danish"
-msgstr "الدانماركيه"
-
-#: src/Preferences.cpp
-msgid "Dutch"
-msgstr "الهولنديه"
-
-#: src/Preferences.cpp
-msgid "English (U.K.)"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "English (U.S.)"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Estonian"
-msgstr "الأستونيه"
-
-#: src/Preferences.cpp
-msgid "Finnish"
-msgstr "الفلنديه"
-
-#: src/Preferences.cpp
-msgid "French"
-msgstr "الفرنسية"
-
-#: src/Preferences.cpp
-msgid "Galician"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "German"
-msgstr "الألمانيه"
-
-#: src/Preferences.cpp
-msgid "Greek"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Hebrew"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Hungarian"
-msgstr "الهنغاريه"
-
-#: src/Preferences.cpp
-msgid "Italian"
-msgstr "الايطاليه"
-
-#: src/Preferences.cpp
-msgid "Japanese"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Korean"
-msgstr "الكوريه"
-
-#: src/Preferences.cpp
-msgid "Latvian"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Lithuanian"
-msgstr "الليتوانيه"
-
-#: src/Preferences.cpp
-msgid "Norwegian (Nynorsk)"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Polish"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Portuguese"
-msgstr "البرتغاليه"
-
-#: src/Preferences.cpp
-msgid "Portuguese (Brazilian)"
-msgstr ""
-
-#: src/Preferences.cpp
-#, fuzzy
-msgid "Romanian"
-msgstr "الأستونيه"
-
-#: src/Preferences.cpp
-msgid "Russian"
-msgstr "الروسيه"
-
-#: src/Preferences.cpp
-msgid "Slovenian"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Spanish"
-msgstr "الإسبانيه"
-
-#: src/Preferences.cpp
-msgid "Swedish"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Turkish"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Ukrainian"
-msgstr ""
-
-#: src/Preferences.cpp
-#, fuzzy
-msgid "Change Language"
-msgstr "الغة"
-
-#: src/Preferences.cpp
-msgid "There are no translations installed for aMule"
-msgstr ""
-
-#: src/Preferences.cpp
-#, fuzzy
-msgid "No languages available"
-msgstr "غير متوفر"
-
-#: src/Preferences.cpp
 msgid "no options available"
 msgstr ""
 
@@ -6483,7 +6511,8 @@ msgstr ""
 msgid "Confirm shared folders"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp src/SharedFilesReloadProgress.cpp
+#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp
+#: src/SharedFilesReloadProgress.cpp
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "وجد %i ملف مشاركة معرف"
@@ -9167,6 +9196,14 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#, fuzzy
+#~ msgid "Change Language"
+#~ msgstr "الغة"
+
+#, fuzzy
+#~ msgid "No languages available"
+#~ msgstr "غير متوفر"
 
 #~ msgid "Obtained Parts"
 #~ msgstr "أجزاء مكتسبة"

--- a/po/ast.po
+++ b/po/ast.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-05 12:01+0200\n"
+"POT-Creation-Date: 2026-09-06 14:35+0200\n"
 "PO-Revision-Date: 2026-09-05 10:45+0000\n"
 "Last-Translator: astur <malditoastur@gmail.com>\n"
 "Language-Team: Language ast <malditoastur@gmail.com>\n"
@@ -387,7 +387,8 @@ msgstr "sirvidor web corriendo con pid: %d"
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Solicitaste executar el sirvidor web al aniciu pero nun pudo correse'l binariu d'amuleweb. Por favor instala'l paquete que contenga'l sirvidor web d'aMule o compila aMule usando --enable-webserver y executa make install"
 
-#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
+#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
+#: src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
 msgid "ERROR"
 msgstr "FALLU"
 
@@ -675,7 +676,8 @@ msgstr "Redes"
 msgid "Searches"
 msgstr "Guetar"
 
-#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/Statistics.cpp
+#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/Statistics.cpp
 msgid "Downloads"
 msgstr "Descargues"
 
@@ -759,7 +761,9 @@ msgstr "Kad: Apagada"
 msgid "Core"
 msgstr ""
 
-#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp src/Statistics.cpp
+#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp src/Statistics.cpp
 msgid "Version"
 msgstr "Versión"
 
@@ -1059,7 +1063,11 @@ msgstr "Nun puede crease'l direutoriu '%s' pa la categoría '%s', calteniendo di
 msgid "The remote core sent inconsistent data for \"%s\" (part status %d, expected %d). The file list may be showing the wrong information; reconnect to clear it."
 msgstr ""
 
-#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp src/Statistics.cpp
+#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp
+#: src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp
+#: src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp
+#: src/Statistics.cpp
 msgid "Unknown"
 msgstr "Desconocíu"
 
@@ -1157,7 +1165,8 @@ msgstr "Fallu guardando ficheru known.met: %s"
 msgid "Enter Captcha"
 msgstr "Inxertar Captcha"
 
-#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp src/TransferWnd.cpp
+#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp
+#: src/TransferWnd.cpp
 msgid "Category"
 msgstr "Categoría"
 
@@ -1321,11 +1330,13 @@ msgstr "Ficheru 'cryptkey.dat' nun alcontráu, criando."
 msgid "Client Details"
 msgstr "Detalles del veceru"
 
-#: src/ClientDetailDialog.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
+#: src/utils/wxCas/src/onlinesig.cpp
 msgid "LowID"
 msgstr "ID-Baxa"
 
-#: src/ClientDetailDialog.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
+#: src/utils/wxCas/src/onlinesig.cpp
 msgid "HighID"
 msgstr "ID-Alta"
 
@@ -1341,7 +1352,8 @@ msgstr "Sofitáu"
 msgid "Not supported"
 msgstr "Non sofitáu"
 
-#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp src/TextClient.cpp
+#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
+#: src/TextClient.cpp
 msgid "Connected"
 msgstr "Coneutáu"
 
@@ -1349,7 +1361,8 @@ msgstr "Coneutáu"
 msgid "Disconnected"
 msgstr "Desconeutáu"
 
-#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f KiB/s"
 msgstr ""
@@ -1366,7 +1379,8 @@ msgstr ""
 msgid "IP Address"
 msgstr "Señes IP"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Origin"
 msgstr ""
 
@@ -1384,12 +1398,14 @@ msgstr "Cabera receición"
 msgid "Sessions"
 msgstr "Versión"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/SharedFilePeersListCtrl.cpp
 #, fuzzy
 msgid "Upload Speed"
 msgstr "Velocidá de xuba"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/SharedFilePeersListCtrl.cpp
 #, fuzzy
 msgid "Download Speed"
 msgstr "Velocidá de descarga"
@@ -1445,11 +1461,13 @@ msgstr[1] ""
 msgid "Files"
 msgstr "Ficheros"
 
-#: src/ClientsListCtrl.cpp src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientsListCtrl.cpp src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp
 msgid "Uploaded"
 msgstr "Xubío"
 
-#: src/ClientsListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientsListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Downloaded"
 msgstr "Descargáu"
 
@@ -1540,7 +1558,8 @@ msgstr "Comentarios de ficheru"
 msgid "Username"
 msgstr "Nome d'usuariu"
 
-#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp
+#: src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "File Name"
 msgstr "Nome de ficheru"
 
@@ -1602,15 +1621,18 @@ msgstr "Auto [Al]"
 msgid "Very low"
 msgstr "Mui baxa"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Low"
 msgstr "Baxa"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Normal"
 msgstr "Normal"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "High"
 msgstr "Alta"
 
@@ -1634,11 +1656,13 @@ msgstr "Coneutando vía sirvidor"
 msgid "Queue Full"
 msgstr "Cola enllena"
 
-#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp src/muuli_wdr.cpp
+#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp
+#: src/muuli_wdr.cpp
 msgid "On Queue"
 msgstr "Na cola"
 
-#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
+#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp
+#: src/PartFile.cpp src/TransferWnd.cpp
 msgid "Downloading"
 msgstr "Descargando"
 
@@ -1698,7 +1722,8 @@ msgstr "Sirvidor llocal"
 msgid "Remote Server"
 msgstr "Sirvidor remotu"
 
-#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp src/TextClient.cpp
+#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp
+#: src/TextClient.cpp
 msgid "Kad"
 msgstr "Kad"
 
@@ -1722,7 +1747,8 @@ msgstr "Semientes fonte"
 msgid "Search Result"
 msgstr "Resultáu de la gueta"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp
+#: src/TransferWnd.cpp
 msgid "Completed"
 msgstr "Completáu"
 
@@ -1775,7 +1801,8 @@ msgstr ""
 msgid "Part"
 msgstr "Parte"
 
-#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 msgid "Size"
 msgstr "Tamañu"
 
@@ -1783,7 +1810,8 @@ msgstr "Tamañu"
 msgid "Transferred"
 msgstr "Tresferío"
 
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp src/SourceListCtrl.cpp
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
+#: src/SourceListCtrl.cpp
 msgid "Speed"
 msgstr "Velocidá"
 
@@ -1791,11 +1819,13 @@ msgstr "Velocidá"
 msgid "Progress"
 msgstr "Progresu"
 
-#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
+#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp
+#: src/SearchListCtrl.cpp
 msgid "Sources"
 msgstr "Fontes"
 
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 msgid "Priority"
 msgstr "Prioridá"
 
@@ -1819,7 +1849,9 @@ msgstr "Cabera receición"
 msgid "Auto"
 msgstr "Auto"
 
-#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/TransferWnd.cpp src/utils/wxCas/src/wxcasprefs.cpp
+#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/TransferWnd.cpp
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Cancel"
 msgstr "Encaboxar"
 
@@ -1920,7 +1952,8 @@ msgstr "Introduza'l nuevu nome pa esti ficheru:"
 msgid "File rename"
 msgstr "Renomar ficheru"
 
-#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f MiB/s"
 msgstr ""
@@ -2728,11 +2761,13 @@ msgstr ""
 msgid "Start aMule automatically when I log in"
 msgstr ""
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp packaging/windows/installer_strings.c
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: packaging/windows/installer_strings.c
 msgid "Register aMule for ed2k:// links"
 msgstr ""
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp packaging/windows/installer_strings.c
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: packaging/windows/installer_strings.c
 msgid "Register aMule for magnet: links"
 msgstr ""
 
@@ -2758,7 +2793,8 @@ msgstr ""
 msgid "Destination folder for downloads"
 msgstr "Carpeta de destín pa les descargues"
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Browse"
 msgstr "Desaminar"
 
@@ -3183,6 +3219,164 @@ msgstr ""
 msgid "Invalid entry in known file list, file may be corrupt: "
 msgstr ""
 
+#: src/LanguageList.cpp
+msgid "System default"
+msgstr "Por defeutu"
+
+#: src/LanguageList.cpp
+msgid "Albanian"
+msgstr "Albanés"
+
+#: src/LanguageList.cpp
+msgid "Arabic"
+msgstr "Árabe"
+
+#: src/LanguageList.cpp
+msgid "Asturian"
+msgstr "Asturianu"
+
+#: src/LanguageList.cpp
+msgid "Basque"
+msgstr "Euskera"
+
+#: src/LanguageList.cpp
+msgid "Bulgarian"
+msgstr "Búlgaru"
+
+#: src/LanguageList.cpp
+msgid "Catalan"
+msgstr "Catalán"
+
+#: src/LanguageList.cpp
+msgid "Chinese (Simplified)"
+msgstr "Chinu (simplificáu)"
+
+#: src/LanguageList.cpp
+msgid "Chinese (Traditional)"
+msgstr "Chinu (Tradicional)"
+
+#: src/LanguageList.cpp
+msgid "Croatian"
+msgstr "Croata"
+
+#: src/LanguageList.cpp
+msgid "Czech"
+msgstr "Checu"
+
+#: src/LanguageList.cpp
+msgid "Danish"
+msgstr "Danés"
+
+#: src/LanguageList.cpp
+msgid "Dutch"
+msgstr "Holandés"
+
+#: src/LanguageList.cpp
+msgid "English (U.K.)"
+msgstr "Inglés (U.K.)"
+
+#: src/LanguageList.cpp
+#, fuzzy
+msgid "English (U.S.)"
+msgstr "Inglés (U.K.)"
+
+#: src/LanguageList.cpp
+msgid "Estonian"
+msgstr "Estoniu"
+
+#: src/LanguageList.cpp
+msgid "Finnish"
+msgstr "Finlandés"
+
+#: src/LanguageList.cpp
+msgid "French"
+msgstr "Francés"
+
+#: src/LanguageList.cpp
+msgid "Galician"
+msgstr "Gallegu"
+
+#: src/LanguageList.cpp
+msgid "German"
+msgstr "Alemán"
+
+#: src/LanguageList.cpp
+msgid "Greek"
+msgstr "Griegu"
+
+#: src/LanguageList.cpp
+msgid "Hebrew"
+msgstr "Hebréu"
+
+#: src/LanguageList.cpp
+msgid "Hungarian"
+msgstr "Húngaru"
+
+#: src/LanguageList.cpp
+msgid "Italian"
+msgstr "Italianu"
+
+#: src/LanguageList.cpp
+msgid "Japanese"
+msgstr "Xaponés"
+
+#: src/LanguageList.cpp
+msgid "Korean"
+msgstr "Coreanu"
+
+#: src/LanguageList.cpp
+msgid "Latvian"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Lithuanian"
+msgstr "Lituanu"
+
+#: src/LanguageList.cpp
+msgid "Norwegian (Nynorsk)"
+msgstr "Noruegu"
+
+#: src/LanguageList.cpp
+msgid "Polish"
+msgstr "Polacu"
+
+#: src/LanguageList.cpp
+msgid "Portuguese"
+msgstr "Portugués"
+
+#: src/LanguageList.cpp
+msgid "Portuguese (Brazilian)"
+msgstr "Portugués (Brasil)"
+
+#: src/LanguageList.cpp
+#, fuzzy
+msgid "Romanian"
+msgstr "Albanés"
+
+#: src/LanguageList.cpp
+msgid "Russian"
+msgstr "Rusu"
+
+#: src/LanguageList.cpp
+msgid "Slovenian"
+msgstr "Eslovenu"
+
+#: src/LanguageList.cpp
+msgid "Spanish"
+msgstr "Español"
+
+#: src/LanguageList.cpp
+msgid "Swedish"
+msgstr "Suecu"
+
+#: src/LanguageList.cpp
+msgid "Turkish"
+msgstr "Turcu"
+
+#: src/LanguageList.cpp
+msgid "Ukrainian"
+msgstr "Ucranianu"
+
 #: src/libs/common/Format.cpp
 #, fuzzy, c-format
 msgid "Unknown error %d"
@@ -3205,15 +3399,18 @@ msgstr "Completando"
 msgid "Complete"
 msgstr "Completáu"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Paused"
 msgstr "Posáu"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Erroneous"
 msgstr "Erróneu"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Waiting"
 msgstr "Aguardando"
 
@@ -3377,7 +3574,8 @@ msgstr "Zarrar"
 msgid "Cut"
 msgstr "Cortar"
 
-#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp src/utils/aLinkCreator/src/alcframe.cpp
+#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy"
 msgstr "Copiar"
 
@@ -3385,7 +3583,8 @@ msgstr "Copiar"
 msgid "Paste"
 msgstr "Apegar"
 
-#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
+#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Clear"
 msgstr "Llimpiar"
 
@@ -3393,7 +3592,8 @@ msgstr "Llimpiar"
 msgid "Select All"
 msgstr "Esbillar too"
 
-#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp src/StatisticsDlg.cpp
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
+#: src/StatisticsDlg.cpp
 msgid "KiB/s"
 msgstr ""
 
@@ -5904,178 +6104,6 @@ msgid "ERROR: Failed to open partfile '%s'"
 msgstr "ERROR: Fallu al abrir ficheru part '%s'"
 
 #: src/Preferences.cpp
-msgid "System default"
-msgstr "Por defeutu"
-
-#: src/Preferences.cpp
-msgid "Albanian"
-msgstr "Albanés"
-
-#: src/Preferences.cpp
-msgid "Arabic"
-msgstr "Árabe"
-
-#: src/Preferences.cpp
-msgid "Asturian"
-msgstr "Asturianu"
-
-#: src/Preferences.cpp
-msgid "Basque"
-msgstr "Euskera"
-
-#: src/Preferences.cpp
-msgid "Bulgarian"
-msgstr "Búlgaru"
-
-#: src/Preferences.cpp
-msgid "Catalan"
-msgstr "Catalán"
-
-#: src/Preferences.cpp
-msgid "Chinese (Simplified)"
-msgstr "Chinu (simplificáu)"
-
-#: src/Preferences.cpp
-msgid "Chinese (Traditional)"
-msgstr "Chinu (Tradicional)"
-
-#: src/Preferences.cpp
-msgid "Croatian"
-msgstr "Croata"
-
-#: src/Preferences.cpp
-msgid "Czech"
-msgstr "Checu"
-
-#: src/Preferences.cpp
-msgid "Danish"
-msgstr "Danés"
-
-#: src/Preferences.cpp
-msgid "Dutch"
-msgstr "Holandés"
-
-#: src/Preferences.cpp
-msgid "English (U.K.)"
-msgstr "Inglés (U.K.)"
-
-#: src/Preferences.cpp
-#, fuzzy
-msgid "English (U.S.)"
-msgstr "Inglés (U.K.)"
-
-#: src/Preferences.cpp
-msgid "Estonian"
-msgstr "Estoniu"
-
-#: src/Preferences.cpp
-msgid "Finnish"
-msgstr "Finlandés"
-
-#: src/Preferences.cpp
-msgid "French"
-msgstr "Francés"
-
-#: src/Preferences.cpp
-msgid "Galician"
-msgstr "Gallegu"
-
-#: src/Preferences.cpp
-msgid "German"
-msgstr "Alemán"
-
-#: src/Preferences.cpp
-msgid "Greek"
-msgstr "Griegu"
-
-#: src/Preferences.cpp
-msgid "Hebrew"
-msgstr "Hebréu"
-
-#: src/Preferences.cpp
-msgid "Hungarian"
-msgstr "Húngaru"
-
-#: src/Preferences.cpp
-msgid "Italian"
-msgstr "Italianu"
-
-#: src/Preferences.cpp
-msgid "Japanese"
-msgstr "Xaponés"
-
-#: src/Preferences.cpp
-msgid "Korean"
-msgstr "Coreanu"
-
-#: src/Preferences.cpp
-msgid "Latvian"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Lithuanian"
-msgstr "Lituanu"
-
-#: src/Preferences.cpp
-msgid "Norwegian (Nynorsk)"
-msgstr "Noruegu"
-
-#: src/Preferences.cpp
-msgid "Polish"
-msgstr "Polacu"
-
-#: src/Preferences.cpp
-msgid "Portuguese"
-msgstr "Portugués"
-
-#: src/Preferences.cpp
-msgid "Portuguese (Brazilian)"
-msgstr "Portugués (Brasil)"
-
-#: src/Preferences.cpp
-#, fuzzy
-msgid "Romanian"
-msgstr "Albanés"
-
-#: src/Preferences.cpp
-msgid "Russian"
-msgstr "Rusu"
-
-#: src/Preferences.cpp
-msgid "Slovenian"
-msgstr "Eslovenu"
-
-#: src/Preferences.cpp
-msgid "Spanish"
-msgstr "Español"
-
-#: src/Preferences.cpp
-msgid "Swedish"
-msgstr "Suecu"
-
-#: src/Preferences.cpp
-msgid "Turkish"
-msgstr "Turcu"
-
-#: src/Preferences.cpp
-msgid "Ukrainian"
-msgstr "Ucranianu"
-
-#: src/Preferences.cpp
-#, fuzzy
-msgid "Change Language"
-msgstr "Llingua: "
-
-#: src/Preferences.cpp
-msgid "There are no translations installed for aMule"
-msgstr ""
-
-#: src/Preferences.cpp
-#, fuzzy
-msgid "No languages available"
-msgstr "Non disponible"
-
-#: src/Preferences.cpp
 msgid "no options available"
 msgstr "opciones non disponibles"
 
@@ -6588,7 +6616,8 @@ msgstr ""
 msgid "Confirm shared folders"
 msgstr "Carpetes compartíes"
 
-#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp src/SharedFilesReloadProgress.cpp
+#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp
+#: src/SharedFilesReloadProgress.cpp
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "Recargar los tos ficheros compartíos"
@@ -9347,6 +9376,14 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#, fuzzy
+#~ msgid "Change Language"
+#~ msgstr "Llingua: "
+
+#, fuzzy
+#~ msgid "No languages available"
+#~ msgstr "Non disponible"
 
 #~ msgid "User name"
 #~ msgstr "Nome usuariu:"

--- a/po/bg.po
+++ b/po/bg.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-05 12:01+0200\n"
+"POT-Creation-Date: 2026-09-06 14:35+0200\n"
 "PO-Revision-Date: 2026-09-05 10:45+0000\n"
 "Last-Translator: Sebastiano Pistore <SebastianoPistore.info@protonmail.ch>\n"
 "Language-Team: Bulgarian <dict@linux.zonebg.com>\n"
@@ -375,7 +375,8 @@ msgstr ""
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr ""
 
-#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
+#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
+#: src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
 msgid "ERROR"
 msgstr ""
 
@@ -654,7 +655,8 @@ msgstr ""
 msgid "Searches"
 msgstr ""
 
-#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/Statistics.cpp
+#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/Statistics.cpp
 msgid "Downloads"
 msgstr ""
 
@@ -739,7 +741,9 @@ msgstr ""
 msgid "Core"
 msgstr ""
 
-#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp src/Statistics.cpp
+#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp src/Statistics.cpp
 msgid "Version"
 msgstr "версия"
 
@@ -1037,7 +1041,11 @@ msgstr ""
 msgid "The remote core sent inconsistent data for \"%s\" (part status %d, expected %d). The file list may be showing the wrong information; reconnect to clear it."
 msgstr ""
 
-#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp src/Statistics.cpp
+#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp
+#: src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp
+#: src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp
+#: src/Statistics.cpp
 msgid "Unknown"
 msgstr "Неизвестен"
 
@@ -1135,7 +1143,8 @@ msgstr ""
 msgid "Enter Captcha"
 msgstr ""
 
-#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp src/TransferWnd.cpp
+#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp
+#: src/TransferWnd.cpp
 msgid "Category"
 msgstr "Категория"
 
@@ -1296,11 +1305,13 @@ msgstr ""
 msgid "Client Details"
 msgstr "Клиентските Детайли"
 
-#: src/ClientDetailDialog.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
+#: src/utils/wxCas/src/onlinesig.cpp
 msgid "LowID"
 msgstr ""
 
-#: src/ClientDetailDialog.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
+#: src/utils/wxCas/src/onlinesig.cpp
 msgid "HighID"
 msgstr ""
 
@@ -1316,7 +1327,8 @@ msgstr ""
 msgid "Not supported"
 msgstr ""
 
-#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp src/TextClient.cpp
+#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
+#: src/TextClient.cpp
 msgid "Connected"
 msgstr "Връзкате е установена"
 
@@ -1324,7 +1336,8 @@ msgstr "Връзкате е установена"
 msgid "Disconnected"
 msgstr "Връзката е разпадната"
 
-#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f KiB/s"
 msgstr ""
@@ -1342,7 +1355,8 @@ msgstr ""
 msgid "IP Address"
 msgstr "адрес"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Origin"
 msgstr ""
 
@@ -1359,12 +1373,14 @@ msgstr ""
 msgid "Sessions"
 msgstr "версия"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/SharedFilePeersListCtrl.cpp
 #, fuzzy
 msgid "Upload Speed"
 msgstr "Време на качване"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/SharedFilePeersListCtrl.cpp
 #, fuzzy
 msgid "Download Speed"
 msgstr "Изтегляне"
@@ -1419,11 +1435,13 @@ msgstr[1] ""
 msgid "Files"
 msgstr "Файлове"
 
-#: src/ClientsListCtrl.cpp src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientsListCtrl.cpp src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp
 msgid "Uploaded"
 msgstr ""
 
-#: src/ClientsListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientsListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Downloaded"
 msgstr ""
 
@@ -1514,7 +1532,8 @@ msgstr "Коментари за файла"
 msgid "Username"
 msgstr "Потребителско име"
 
-#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp
+#: src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "File Name"
 msgstr "Име на файл"
 
@@ -1576,15 +1595,18 @@ msgstr "Автоматичен [Hi]"
 msgid "Very low"
 msgstr ""
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Low"
 msgstr "Ниско"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Normal"
 msgstr "Нормален"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "High"
 msgstr "Високо"
 
@@ -1608,11 +1630,13 @@ msgstr "Свързване чрез сървър"
 msgid "Queue Full"
 msgstr "Опашката е пълна"
 
-#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp src/muuli_wdr.cpp
+#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp
+#: src/muuli_wdr.cpp
 msgid "On Queue"
 msgstr "На опашката"
 
-#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
+#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp
+#: src/PartFile.cpp src/TransferWnd.cpp
 msgid "Downloading"
 msgstr "Изтегляне"
 
@@ -1672,7 +1696,8 @@ msgstr ""
 msgid "Remote Server"
 msgstr ""
 
-#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp src/TextClient.cpp
+#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp
+#: src/TextClient.cpp
 msgid "Kad"
 msgstr ""
 
@@ -1696,7 +1721,8 @@ msgstr ""
 msgid "Search Result"
 msgstr ""
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp
+#: src/TransferWnd.cpp
 msgid "Completed"
 msgstr "Завършен"
 
@@ -1748,7 +1774,8 @@ msgstr ""
 msgid "Part"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 msgid "Size"
 msgstr "Размер"
 
@@ -1756,7 +1783,8 @@ msgstr "Размер"
 msgid "Transferred"
 msgstr "Пренесен"
 
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp src/SourceListCtrl.cpp
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
+#: src/SourceListCtrl.cpp
 msgid "Speed"
 msgstr "Скорост"
 
@@ -1764,11 +1792,13 @@ msgstr "Скорост"
 msgid "Progress"
 msgstr "Прогрес"
 
-#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
+#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp
+#: src/SearchListCtrl.cpp
 msgid "Sources"
 msgstr "Източници"
 
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 msgid "Priority"
 msgstr "Приоритет"
 
@@ -1792,7 +1822,9 @@ msgstr ""
 msgid "Auto"
 msgstr "Автоматично"
 
-#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/TransferWnd.cpp src/utils/wxCas/src/wxcasprefs.cpp
+#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/TransferWnd.cpp
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Cancel"
 msgstr "Отказ"
 
@@ -1893,7 +1925,8 @@ msgstr ""
 msgid "File rename"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f MiB/s"
 msgstr ""
@@ -2668,11 +2701,13 @@ msgstr ""
 msgid "Start aMule automatically when I log in"
 msgstr ""
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp packaging/windows/installer_strings.c
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: packaging/windows/installer_strings.c
 msgid "Register aMule for ed2k:// links"
 msgstr ""
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp packaging/windows/installer_strings.c
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: packaging/windows/installer_strings.c
 msgid "Register aMule for magnet: links"
 msgstr ""
 
@@ -2698,7 +2733,8 @@ msgstr ""
 msgid "Destination folder for downloads"
 msgstr ""
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Browse"
 msgstr "Избери"
 
@@ -3119,6 +3155,162 @@ msgstr ""
 msgid "Invalid entry in known file list, file may be corrupt: "
 msgstr ""
 
+#: src/LanguageList.cpp
+msgid "System default"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Albanian"
+msgstr "албанец"
+
+#: src/LanguageList.cpp
+msgid "Arabic"
+msgstr "арабски"
+
+#: src/LanguageList.cpp
+msgid "Asturian"
+msgstr "Астурия"
+
+#: src/LanguageList.cpp
+msgid "Basque"
+msgstr "баска"
+
+#: src/LanguageList.cpp
+msgid "Bulgarian"
+msgstr "български"
+
+#: src/LanguageList.cpp
+msgid "Catalan"
+msgstr "Каталунски"
+
+#: src/LanguageList.cpp
+msgid "Chinese (Simplified)"
+msgstr "Китайски (опростен)"
+
+#: src/LanguageList.cpp
+msgid "Chinese (Traditional)"
+msgstr "Китайски (традиционен)"
+
+#: src/LanguageList.cpp
+msgid "Croatian"
+msgstr "хърватски"
+
+#: src/LanguageList.cpp
+msgid "Czech"
+msgstr "чешки"
+
+#: src/LanguageList.cpp
+msgid "Danish"
+msgstr "датски"
+
+#: src/LanguageList.cpp
+msgid "Dutch"
+msgstr "холандски"
+
+#: src/LanguageList.cpp
+msgid "English (U.K.)"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "English (U.S.)"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Estonian"
+msgstr "естонски"
+
+#: src/LanguageList.cpp
+msgid "Finnish"
+msgstr "фински"
+
+#: src/LanguageList.cpp
+msgid "French"
+msgstr "Френски"
+
+#: src/LanguageList.cpp
+msgid "Galician"
+msgstr "галисийски"
+
+#: src/LanguageList.cpp
+msgid "German"
+msgstr "Немски"
+
+#: src/LanguageList.cpp
+msgid "Greek"
+msgstr "Гръцки"
+
+#: src/LanguageList.cpp
+msgid "Hebrew"
+msgstr "иврит"
+
+#: src/LanguageList.cpp
+msgid "Hungarian"
+msgstr "унгарски"
+
+#: src/LanguageList.cpp
+msgid "Italian"
+msgstr "Италиански"
+
+#: src/LanguageList.cpp
+msgid "Japanese"
+msgstr "японски"
+
+#: src/LanguageList.cpp
+msgid "Korean"
+msgstr "корейски"
+
+#: src/LanguageList.cpp
+msgid "Latvian"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Lithuanian"
+msgstr "литовски"
+
+#: src/LanguageList.cpp
+msgid "Norwegian (Nynorsk)"
+msgstr "норвежки (Съвременен)"
+
+#: src/LanguageList.cpp
+msgid "Polish"
+msgstr "полски"
+
+#: src/LanguageList.cpp
+msgid "Portuguese"
+msgstr "португалски"
+
+#: src/LanguageList.cpp
+msgid "Portuguese (Brazilian)"
+msgstr "португалски (бразилски)"
+
+#: src/LanguageList.cpp
+msgid "Romanian"
+msgstr "румънски"
+
+#: src/LanguageList.cpp
+msgid "Russian"
+msgstr "Руски"
+
+#: src/LanguageList.cpp
+msgid "Slovenian"
+msgstr "словенски"
+
+#: src/LanguageList.cpp
+msgid "Spanish"
+msgstr "Spanish"
+
+#: src/LanguageList.cpp
+msgid "Swedish"
+msgstr "шведски"
+
+#: src/LanguageList.cpp
+msgid "Turkish"
+msgstr "Турски"
+
+#: src/LanguageList.cpp
+msgid "Ukrainian"
+msgstr "украински"
+
 #: src/libs/common/Format.cpp
 #, c-format
 msgid "Unknown error %d"
@@ -3141,15 +3333,18 @@ msgstr ""
 msgid "Complete"
 msgstr "Завършено"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Paused"
 msgstr "Пауза"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Erroneous"
 msgstr ""
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Waiting"
 msgstr ""
 
@@ -3312,7 +3507,8 @@ msgstr "Затвори"
 msgid "Cut"
 msgstr ""
 
-#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp src/utils/aLinkCreator/src/alcframe.cpp
+#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy"
 msgstr "копие"
 
@@ -3320,7 +3516,8 @@ msgstr "копие"
 msgid "Paste"
 msgstr ""
 
-#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
+#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Clear"
 msgstr "Изчисти"
 
@@ -3328,7 +3525,8 @@ msgstr "Изчисти"
 msgid "Select All"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp src/StatisticsDlg.cpp
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
+#: src/StatisticsDlg.cpp
 msgid "KiB/s"
 msgstr ""
 
@@ -5820,174 +6018,6 @@ msgid "ERROR: Failed to open partfile '%s'"
 msgstr ""
 
 #: src/Preferences.cpp
-msgid "System default"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Albanian"
-msgstr "албанец"
-
-#: src/Preferences.cpp
-msgid "Arabic"
-msgstr "арабски"
-
-#: src/Preferences.cpp
-msgid "Asturian"
-msgstr "Астурия"
-
-#: src/Preferences.cpp
-msgid "Basque"
-msgstr "баска"
-
-#: src/Preferences.cpp
-msgid "Bulgarian"
-msgstr "български"
-
-#: src/Preferences.cpp
-msgid "Catalan"
-msgstr "Каталунски"
-
-#: src/Preferences.cpp
-msgid "Chinese (Simplified)"
-msgstr "Китайски (опростен)"
-
-#: src/Preferences.cpp
-msgid "Chinese (Traditional)"
-msgstr "Китайски (традиционен)"
-
-#: src/Preferences.cpp
-msgid "Croatian"
-msgstr "хърватски"
-
-#: src/Preferences.cpp
-msgid "Czech"
-msgstr "чешки"
-
-#: src/Preferences.cpp
-msgid "Danish"
-msgstr "датски"
-
-#: src/Preferences.cpp
-msgid "Dutch"
-msgstr "холандски"
-
-#: src/Preferences.cpp
-msgid "English (U.K.)"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "English (U.S.)"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Estonian"
-msgstr "естонски"
-
-#: src/Preferences.cpp
-msgid "Finnish"
-msgstr "фински"
-
-#: src/Preferences.cpp
-msgid "French"
-msgstr "Френски"
-
-#: src/Preferences.cpp
-msgid "Galician"
-msgstr "галисийски"
-
-#: src/Preferences.cpp
-msgid "German"
-msgstr "Немски"
-
-#: src/Preferences.cpp
-msgid "Greek"
-msgstr "Гръцки"
-
-#: src/Preferences.cpp
-msgid "Hebrew"
-msgstr "иврит"
-
-#: src/Preferences.cpp
-msgid "Hungarian"
-msgstr "унгарски"
-
-#: src/Preferences.cpp
-msgid "Italian"
-msgstr "Италиански"
-
-#: src/Preferences.cpp
-msgid "Japanese"
-msgstr "японски"
-
-#: src/Preferences.cpp
-msgid "Korean"
-msgstr "корейски"
-
-#: src/Preferences.cpp
-msgid "Latvian"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Lithuanian"
-msgstr "литовски"
-
-#: src/Preferences.cpp
-msgid "Norwegian (Nynorsk)"
-msgstr "норвежки (Съвременен)"
-
-#: src/Preferences.cpp
-msgid "Polish"
-msgstr "полски"
-
-#: src/Preferences.cpp
-msgid "Portuguese"
-msgstr "португалски"
-
-#: src/Preferences.cpp
-msgid "Portuguese (Brazilian)"
-msgstr "португалски (бразилски)"
-
-#: src/Preferences.cpp
-msgid "Romanian"
-msgstr "румънски"
-
-#: src/Preferences.cpp
-msgid "Russian"
-msgstr "Руски"
-
-#: src/Preferences.cpp
-msgid "Slovenian"
-msgstr "словенски"
-
-#: src/Preferences.cpp
-msgid "Spanish"
-msgstr "Spanish"
-
-#: src/Preferences.cpp
-msgid "Swedish"
-msgstr "шведски"
-
-#: src/Preferences.cpp
-msgid "Turkish"
-msgstr "Турски"
-
-#: src/Preferences.cpp
-msgid "Ukrainian"
-msgstr "украински"
-
-#: src/Preferences.cpp
-msgid "Change Language"
-msgstr "Смени езика"
-
-#: src/Preferences.cpp
-msgid "There are no translations installed for aMule"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "No languages available"
-msgstr ""
-
-#: src/Preferences.cpp
 msgid "no options available"
 msgstr ""
 
@@ -6467,7 +6497,8 @@ msgstr ""
 msgid "Confirm shared folders"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp src/SharedFilesReloadProgress.cpp
+#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp
+#: src/SharedFilesReloadProgress.cpp
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "Известни са %i споделени файлове"
@@ -9146,6 +9177,9 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "Change Language"
+#~ msgstr "Смени езика"
 
 #, fuzzy, c-format
 #~ msgid "Found %i known shared file, %i unknown"

--- a/po/bn.po
+++ b/po/bn.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-05 12:01+0200\n"
+"POT-Creation-Date: 2026-09-06 14:35+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -3110,6 +3110,162 @@ msgstr ""
 msgid "Invalid entry in known file list, file may be corrupt: "
 msgstr ""
 
+#: src/LanguageList.cpp
+msgid "System default"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Albanian"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Arabic"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Asturian"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Basque"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Bulgarian"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Catalan"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Chinese (Simplified)"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Chinese (Traditional)"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Croatian"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Czech"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Danish"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Dutch"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "English (U.K.)"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "English (U.S.)"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Estonian"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Finnish"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "French"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Galician"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "German"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Greek"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Hebrew"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Hungarian"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Italian"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Japanese"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Korean"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Latvian"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Lithuanian"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Norwegian (Nynorsk)"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Polish"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Portuguese"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Portuguese (Brazilian)"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Romanian"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Russian"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Slovenian"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Spanish"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Swedish"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Turkish"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Ukrainian"
+msgstr ""
+
 #: src/libs/common/Format.cpp
 #, c-format
 msgid "Unknown error %d"
@@ -5764,174 +5920,6 @@ msgstr ""
 #: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Failed to open partfile '%s'"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "System default"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Albanian"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Arabic"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Asturian"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Basque"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Bulgarian"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Catalan"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Chinese (Simplified)"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Chinese (Traditional)"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Croatian"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Czech"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Danish"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Dutch"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "English (U.K.)"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "English (U.S.)"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Estonian"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Finnish"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "French"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Galician"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "German"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Greek"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Hebrew"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Hungarian"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Italian"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Japanese"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Korean"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Latvian"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Lithuanian"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Norwegian (Nynorsk)"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Polish"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Portuguese"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Portuguese (Brazilian)"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Romanian"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Russian"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Slovenian"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Spanish"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Swedish"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Turkish"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Ukrainian"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Change Language"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "There are no translations installed for aMule"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "No languages available"
 msgstr ""
 
 #: src/Preferences.cpp

--- a/po/ca.po
+++ b/po/ca.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-05 12:01+0200\n"
+"POT-Creation-Date: 2026-09-06 14:35+0200\n"
 "PO-Revision-Date: 2026-09-05 10:46+0000\n"
 "Last-Translator: minterior <minterior@gmail.com>\n"
 "Language-Team: Català\n"
@@ -387,7 +387,8 @@ msgstr "servidor web executant-se al pid %d"
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Heu demanat que s'executi el servidor web a l'inici, però no s'ha trobat el fitxer binari de l'amuleweb. Si us plau instal·leu el paquet que conté el servidor web de l'aMule, o compileu l'aMule usant la opció --enable-webserver i executeu make install"
 
-#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
+#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
+#: src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
 msgid "ERROR"
 msgstr "ERROR"
 
@@ -675,7 +676,8 @@ msgstr "Xarxes"
 msgid "Searches"
 msgstr "Cerques"
 
-#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/Statistics.cpp
+#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/Statistics.cpp
 msgid "Downloads"
 msgstr "Baixades"
 
@@ -759,7 +761,9 @@ msgstr "Kad: Inativa"
 msgid "Core"
 msgstr ""
 
-#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp src/Statistics.cpp
+#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp src/Statistics.cpp
 msgid "Version"
 msgstr "Versió"
 
@@ -1058,7 +1062,11 @@ msgstr "No s'ha pogut crear el directori '%s' per a la categoria '%s', es mantin
 msgid "The remote core sent inconsistent data for \"%s\" (part status %d, expected %d). The file list may be showing the wrong information; reconnect to clear it."
 msgstr ""
 
-#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp src/Statistics.cpp
+#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp
+#: src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp
+#: src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp
+#: src/Statistics.cpp
 msgid "Unknown"
 msgstr "Desconegut"
 
@@ -1155,7 +1163,8 @@ msgstr "Error mentre es desava el fitxer %s: %s"
 msgid "Enter Captcha"
 msgstr "Introdueix el Captcha"
 
-#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp src/TransferWnd.cpp
+#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp
+#: src/TransferWnd.cpp
 msgid "Category"
 msgstr "Categoria"
 
@@ -1319,11 +1328,13 @@ msgstr "No s'ha trobat el fitxer 'cryptkey.dat', creant-lo."
 msgid "Client Details"
 msgstr "Detalls del client"
 
-#: src/ClientDetailDialog.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
+#: src/utils/wxCas/src/onlinesig.cpp
 msgid "LowID"
 msgstr "ID Baixa"
 
-#: src/ClientDetailDialog.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
+#: src/utils/wxCas/src/onlinesig.cpp
 msgid "HighID"
 msgstr "ID Alta"
 
@@ -1339,7 +1350,8 @@ msgstr "Suportada"
 msgid "Not supported"
 msgstr "No suportada"
 
-#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp src/TextClient.cpp
+#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
+#: src/TextClient.cpp
 msgid "Connected"
 msgstr "Connectat"
 
@@ -1347,7 +1359,8 @@ msgstr "Connectat"
 msgid "Disconnected"
 msgstr "Desconnectat"
 
-#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f KiB/s"
 msgstr ""
@@ -1364,7 +1377,8 @@ msgstr ""
 msgid "IP Address"
 msgstr "Adreça IP"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Origin"
 msgstr "Origen"
 
@@ -1382,11 +1396,13 @@ msgstr "Última recepció"
 msgid "Sessions"
 msgstr "Versió"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/SharedFilePeersListCtrl.cpp
 msgid "Upload Speed"
 msgstr "Velocitat de pujada"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/SharedFilePeersListCtrl.cpp
 msgid "Download Speed"
 msgstr "Velocitat de baixada"
 
@@ -1441,11 +1457,13 @@ msgstr[1] ""
 msgid "Files"
 msgstr "Fitxers"
 
-#: src/ClientsListCtrl.cpp src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientsListCtrl.cpp src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp
 msgid "Uploaded"
 msgstr "Transferit"
 
-#: src/ClientsListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientsListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Downloaded"
 msgstr "Baixat"
 
@@ -1536,7 +1554,8 @@ msgstr "Comentaris del Fitxer"
 msgid "Username"
 msgstr "Usuari"
 
-#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp
+#: src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "File Name"
 msgstr "Fitxer"
 
@@ -1598,15 +1617,18 @@ msgstr "Auto [Al]"
 msgid "Very low"
 msgstr "Molt baixa"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Low"
 msgstr "Baixa"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Normal"
 msgstr "Normal"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "High"
 msgstr "Alta"
 
@@ -1630,11 +1652,13 @@ msgstr "S'està connectant via servidor"
 msgid "Queue Full"
 msgstr "Cua plena"
 
-#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp src/muuli_wdr.cpp
+#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp
+#: src/muuli_wdr.cpp
 msgid "On Queue"
 msgstr "Cua"
 
-#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
+#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp
+#: src/PartFile.cpp src/TransferWnd.cpp
 msgid "Downloading"
 msgstr "S'està baixant"
 
@@ -1694,7 +1718,8 @@ msgstr "Servidor local"
 msgid "Remote Server"
 msgstr "Servidor remot"
 
-#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp src/TextClient.cpp
+#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp
+#: src/TextClient.cpp
 msgid "Kad"
 msgstr "Kad"
 
@@ -1718,7 +1743,8 @@ msgstr "Llavors font"
 msgid "Search Result"
 msgstr "Resultat de la cerca"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp
+#: src/TransferWnd.cpp
 msgid "Completed"
 msgstr "Completat"
 
@@ -1771,7 +1797,8 @@ msgstr ""
 msgid "Part"
 msgstr "Part"
 
-#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 msgid "Size"
 msgstr "Mida"
 
@@ -1779,7 +1806,8 @@ msgstr "Mida"
 msgid "Transferred"
 msgstr "Transferit"
 
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp src/SourceListCtrl.cpp
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
+#: src/SourceListCtrl.cpp
 msgid "Speed"
 msgstr "Velocitat"
 
@@ -1787,11 +1815,13 @@ msgstr "Velocitat"
 msgid "Progress"
 msgstr "Progrés"
 
-#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
+#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp
+#: src/SearchListCtrl.cpp
 msgid "Sources"
 msgstr "Fonts"
 
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 msgid "Priority"
 msgstr "Prioritat"
 
@@ -1815,7 +1845,9 @@ msgstr "Última recepció"
 msgid "Auto"
 msgstr "Auto"
 
-#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/TransferWnd.cpp src/utils/wxCas/src/wxcasprefs.cpp
+#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/TransferWnd.cpp
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Cancel"
 msgstr "Cancel·la"
 
@@ -1916,7 +1948,8 @@ msgstr "Introduïu un nom nou per al fitxer:"
 msgid "File rename"
 msgstr "Reanomena"
 
-#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f MiB/s"
 msgstr ""
@@ -2721,11 +2754,13 @@ msgstr ""
 msgid "Start aMule automatically when I log in"
 msgstr ""
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp packaging/windows/installer_strings.c
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: packaging/windows/installer_strings.c
 msgid "Register aMule for ed2k:// links"
 msgstr ""
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp packaging/windows/installer_strings.c
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: packaging/windows/installer_strings.c
 msgid "Register aMule for magnet: links"
 msgstr ""
 
@@ -2751,7 +2786,8 @@ msgstr ""
 msgid "Destination folder for downloads"
 msgstr "Carpeta on desar les descàrregues"
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Browse"
 msgstr "Explora"
 
@@ -3172,6 +3208,163 @@ msgstr "No s'ha pogut carregar l'entrada a la llista de fitxers coneguts, el fit
 msgid "Invalid entry in known file list, file may be corrupt: "
 msgstr "Entrada no vàlida a la llista de fitxers coneguts, el fitxer podria estar corrupte: "
 
+#: src/LanguageList.cpp
+msgid "System default"
+msgstr "Predeterminat"
+
+#: src/LanguageList.cpp
+msgid "Albanian"
+msgstr "Albanès"
+
+#: src/LanguageList.cpp
+msgid "Arabic"
+msgstr "Àrab"
+
+#: src/LanguageList.cpp
+msgid "Asturian"
+msgstr "Asturià"
+
+#: src/LanguageList.cpp
+msgid "Basque"
+msgstr "Basc"
+
+#: src/LanguageList.cpp
+msgid "Bulgarian"
+msgstr "Búlgar"
+
+#: src/LanguageList.cpp
+msgid "Catalan"
+msgstr "Català; Valencià"
+
+#: src/LanguageList.cpp
+msgid "Chinese (Simplified)"
+msgstr "Xinès (Simplificat)"
+
+#: src/LanguageList.cpp
+msgid "Chinese (Traditional)"
+msgstr "Xinès (Tradicional)"
+
+#: src/LanguageList.cpp
+msgid "Croatian"
+msgstr "Croat"
+
+#: src/LanguageList.cpp
+msgid "Czech"
+msgstr "Txec"
+
+#: src/LanguageList.cpp
+msgid "Danish"
+msgstr "Danès"
+
+#: src/LanguageList.cpp
+msgid "Dutch"
+msgstr "Holandès"
+
+#: src/LanguageList.cpp
+msgid "English (U.K.)"
+msgstr "Anglès (R.U.)"
+
+#: src/LanguageList.cpp
+#, fuzzy
+msgid "English (U.S.)"
+msgstr "Anglès (R.U.)"
+
+#: src/LanguageList.cpp
+msgid "Estonian"
+msgstr "Estonià"
+
+#: src/LanguageList.cpp
+msgid "Finnish"
+msgstr "Finès"
+
+#: src/LanguageList.cpp
+msgid "French"
+msgstr "Francès"
+
+#: src/LanguageList.cpp
+msgid "Galician"
+msgstr "Gallec"
+
+#: src/LanguageList.cpp
+msgid "German"
+msgstr "Alemany"
+
+#: src/LanguageList.cpp
+msgid "Greek"
+msgstr "Grec"
+
+#: src/LanguageList.cpp
+msgid "Hebrew"
+msgstr "Hebreu"
+
+#: src/LanguageList.cpp
+msgid "Hungarian"
+msgstr "Hongarès"
+
+#: src/LanguageList.cpp
+msgid "Italian"
+msgstr "Italià"
+
+#: src/LanguageList.cpp
+msgid "Japanese"
+msgstr "Japonès"
+
+#: src/LanguageList.cpp
+msgid "Korean"
+msgstr "Coreà"
+
+#: src/LanguageList.cpp
+msgid "Latvian"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Lithuanian"
+msgstr "Lituà"
+
+#: src/LanguageList.cpp
+msgid "Norwegian (Nynorsk)"
+msgstr "Noruec"
+
+#: src/LanguageList.cpp
+msgid "Polish"
+msgstr "Polonès"
+
+#: src/LanguageList.cpp
+msgid "Portuguese"
+msgstr "Portuguès"
+
+#: src/LanguageList.cpp
+msgid "Portuguese (Brazilian)"
+msgstr "Portuguès (Brasil)"
+
+#: src/LanguageList.cpp
+msgid "Romanian"
+msgstr "Romanès"
+
+#: src/LanguageList.cpp
+msgid "Russian"
+msgstr "Rus"
+
+#: src/LanguageList.cpp
+msgid "Slovenian"
+msgstr "Eslovè"
+
+#: src/LanguageList.cpp
+msgid "Spanish"
+msgstr "Espanyol; Castellà"
+
+#: src/LanguageList.cpp
+msgid "Swedish"
+msgstr "Suec"
+
+#: src/LanguageList.cpp
+msgid "Turkish"
+msgstr "Turc"
+
+#: src/LanguageList.cpp
+msgid "Ukrainian"
+msgstr "Ucranià"
+
 #: src/libs/common/Format.cpp
 #, c-format
 msgid "Unknown error %d"
@@ -3194,15 +3387,18 @@ msgstr "Completant"
 msgid "Complete"
 msgstr "Complet"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Paused"
 msgstr "Pausat"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Erroneous"
 msgstr "Erroni"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Waiting"
 msgstr "Esperant"
 
@@ -3366,7 +3562,8 @@ msgstr "Tanca"
 msgid "Cut"
 msgstr "Retalla"
 
-#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp src/utils/aLinkCreator/src/alcframe.cpp
+#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy"
 msgstr "Copia"
 
@@ -3374,7 +3571,8 @@ msgstr "Copia"
 msgid "Paste"
 msgstr "Enganxa"
 
-#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
+#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Clear"
 msgstr "Neteja"
 
@@ -3382,7 +3580,8 @@ msgstr "Neteja"
 msgid "Select All"
 msgstr "Selecciona-ho tot"
 
-#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp src/StatisticsDlg.cpp
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
+#: src/StatisticsDlg.cpp
 msgid "KiB/s"
 msgstr ""
 
@@ -5881,175 +6080,6 @@ msgid "ERROR: Failed to open partfile '%s'"
 msgstr "ERROR: No s'ha pogut obrir el fitxer part '%s'"
 
 #: src/Preferences.cpp
-msgid "System default"
-msgstr "Predeterminat"
-
-#: src/Preferences.cpp
-msgid "Albanian"
-msgstr "Albanès"
-
-#: src/Preferences.cpp
-msgid "Arabic"
-msgstr "Àrab"
-
-#: src/Preferences.cpp
-msgid "Asturian"
-msgstr "Asturià"
-
-#: src/Preferences.cpp
-msgid "Basque"
-msgstr "Basc"
-
-#: src/Preferences.cpp
-msgid "Bulgarian"
-msgstr "Búlgar"
-
-#: src/Preferences.cpp
-msgid "Catalan"
-msgstr "Català; Valencià"
-
-#: src/Preferences.cpp
-msgid "Chinese (Simplified)"
-msgstr "Xinès (Simplificat)"
-
-#: src/Preferences.cpp
-msgid "Chinese (Traditional)"
-msgstr "Xinès (Tradicional)"
-
-#: src/Preferences.cpp
-msgid "Croatian"
-msgstr "Croat"
-
-#: src/Preferences.cpp
-msgid "Czech"
-msgstr "Txec"
-
-#: src/Preferences.cpp
-msgid "Danish"
-msgstr "Danès"
-
-#: src/Preferences.cpp
-msgid "Dutch"
-msgstr "Holandès"
-
-#: src/Preferences.cpp
-msgid "English (U.K.)"
-msgstr "Anglès (R.U.)"
-
-#: src/Preferences.cpp
-#, fuzzy
-msgid "English (U.S.)"
-msgstr "Anglès (R.U.)"
-
-#: src/Preferences.cpp
-msgid "Estonian"
-msgstr "Estonià"
-
-#: src/Preferences.cpp
-msgid "Finnish"
-msgstr "Finès"
-
-#: src/Preferences.cpp
-msgid "French"
-msgstr "Francès"
-
-#: src/Preferences.cpp
-msgid "Galician"
-msgstr "Gallec"
-
-#: src/Preferences.cpp
-msgid "German"
-msgstr "Alemany"
-
-#: src/Preferences.cpp
-msgid "Greek"
-msgstr "Grec"
-
-#: src/Preferences.cpp
-msgid "Hebrew"
-msgstr "Hebreu"
-
-#: src/Preferences.cpp
-msgid "Hungarian"
-msgstr "Hongarès"
-
-#: src/Preferences.cpp
-msgid "Italian"
-msgstr "Italià"
-
-#: src/Preferences.cpp
-msgid "Japanese"
-msgstr "Japonès"
-
-#: src/Preferences.cpp
-msgid "Korean"
-msgstr "Coreà"
-
-#: src/Preferences.cpp
-msgid "Latvian"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Lithuanian"
-msgstr "Lituà"
-
-#: src/Preferences.cpp
-msgid "Norwegian (Nynorsk)"
-msgstr "Noruec"
-
-#: src/Preferences.cpp
-msgid "Polish"
-msgstr "Polonès"
-
-#: src/Preferences.cpp
-msgid "Portuguese"
-msgstr "Portuguès"
-
-#: src/Preferences.cpp
-msgid "Portuguese (Brazilian)"
-msgstr "Portuguès (Brasil)"
-
-#: src/Preferences.cpp
-msgid "Romanian"
-msgstr "Romanès"
-
-#: src/Preferences.cpp
-msgid "Russian"
-msgstr "Rus"
-
-#: src/Preferences.cpp
-msgid "Slovenian"
-msgstr "Eslovè"
-
-#: src/Preferences.cpp
-msgid "Spanish"
-msgstr "Espanyol; Castellà"
-
-#: src/Preferences.cpp
-msgid "Swedish"
-msgstr "Suec"
-
-#: src/Preferences.cpp
-msgid "Turkish"
-msgstr "Turc"
-
-#: src/Preferences.cpp
-msgid "Ukrainian"
-msgstr "Ucranià"
-
-#: src/Preferences.cpp
-msgid "Change Language"
-msgstr "Canvi d'idioma"
-
-#: src/Preferences.cpp
-msgid "There are no translations installed for aMule"
-msgstr "No hi ha traduccions instal·lades per a l'aMule"
-
-#: src/Preferences.cpp
-msgid "No languages available"
-msgstr "Sense idiomes disponibles"
-
-#: src/Preferences.cpp
 msgid "no options available"
 msgstr "No hi ha opcions disponibles"
 
@@ -6561,7 +6591,8 @@ msgstr ""
 msgid "Confirm shared folders"
 msgstr "Carpetes compartides"
 
-#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp src/SharedFilesReloadProgress.cpp
+#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp
+#: src/SharedFilesReloadProgress.cpp
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "Recarrega els compartits"
@@ -9293,6 +9324,15 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "Change Language"
+#~ msgstr "Canvi d'idioma"
+
+#~ msgid "There are no translations installed for aMule"
+#~ msgstr "No hi ha traduccions instal·lades per a l'aMule"
+
+#~ msgid "No languages available"
+#~ msgstr "Sense idiomes disponibles"
 
 #~ msgid "User name"
 #~ msgstr "Nom d'usuari"

--- a/po/cs.po
+++ b/po/cs.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-05 12:01+0200\n"
+"POT-Creation-Date: 2026-09-06 14:35+0200\n"
 "PO-Revision-Date: 2026-09-05 10:47+0000\n"
 "Last-Translator: David Watzke <david@watzke.cz>\n"
 "Language-Team: cs <cs@li.org>\n"
@@ -387,7 +387,8 @@ msgstr "webserver běží s PID %d"
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Požádali jste o spuštění webového serveru po startu, avšak binární soubor amuleweb nelze spustit. Nainstalujte balíček obsahující webový server aMule, nebo sestavte aMule ze zdrojového kódu pomocí přepínače -DBUILD_WEBSERVER=YES a pak jej nainstalujte."
 
-#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
+#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
+#: src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
 msgid "ERROR"
 msgstr "CHYBA"
 
@@ -673,7 +674,8 @@ msgstr "Sítě"
 msgid "Searches"
 msgstr "Vyhledávání"
 
-#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/Statistics.cpp
+#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/Statistics.cpp
 msgid "Downloads"
 msgstr "Stahování"
 
@@ -761,7 +763,9 @@ msgstr "Kad: vypnut"
 msgid "Core"
 msgstr ""
 
-#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp src/Statistics.cpp
+#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp src/Statistics.cpp
 msgid "Version"
 msgstr "Verze"
 
@@ -1060,7 +1064,11 @@ msgstr "Nejde vytvořit adresář '%s' pro kategorii '%s', zachovávám adresá�
 msgid "The remote core sent inconsistent data for \"%s\" (part status %d, expected %d). The file list may be showing the wrong information; reconnect to clear it."
 msgstr "Vzdálené jádro odeslalo nekonzistentní data pro \"%s\" (částečný stav %d, očekáváno %d). Seznam souborů může zobrazovat nesprávné informace; opět se připojte pro vyčištění."
 
-#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp src/Statistics.cpp
+#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp
+#: src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp
+#: src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp
+#: src/Statistics.cpp
 msgid "Unknown"
 msgstr "Neznámý"
 
@@ -1159,7 +1167,8 @@ msgstr "Chyba při ukládání souboru %s: %s"
 msgid "Enter Captcha"
 msgstr "Vložte captchu"
 
-#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp src/TransferWnd.cpp
+#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp
+#: src/TransferWnd.cpp
 msgid "Category"
 msgstr "Kategorie"
 
@@ -1328,11 +1337,13 @@ msgstr "Soubor 'cryptkey.dat' nenalezen, vytvářím."
 msgid "Client Details"
 msgstr "Podrobnosti klienta"
 
-#: src/ClientDetailDialog.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
+#: src/utils/wxCas/src/onlinesig.cpp
 msgid "LowID"
 msgstr "LowID"
 
-#: src/ClientDetailDialog.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
+#: src/utils/wxCas/src/onlinesig.cpp
 msgid "HighID"
 msgstr "HighID"
 
@@ -1348,7 +1359,8 @@ msgstr "Podporováno"
 msgid "Not supported"
 msgstr "Nepodporováno"
 
-#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp src/TextClient.cpp
+#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
+#: src/TextClient.cpp
 msgid "Connected"
 msgstr "Připojen"
 
@@ -1356,7 +1368,8 @@ msgstr "Připojen"
 msgid "Disconnected"
 msgstr "Odpojeno"
 
-#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f KiB/s"
 msgstr ""
@@ -1373,7 +1386,8 @@ msgstr "Software"
 msgid "IP Address"
 msgstr "IP adresa"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Origin"
 msgstr "Původ"
 
@@ -1389,11 +1403,13 @@ msgstr "Naposledy viděn"
 msgid "Sessions"
 msgstr "Sezení"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/SharedFilePeersListCtrl.cpp
 msgid "Upload Speed"
 msgstr "Rychlost odesílání"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/SharedFilePeersListCtrl.cpp
 msgid "Download Speed"
 msgstr "Rychlost stahování"
 
@@ -1445,11 +1461,13 @@ msgstr[2] "Nešlo přidat %u odkazů (podrobnosti viz log)."
 msgid "Files"
 msgstr "Soubory"
 
-#: src/ClientsListCtrl.cpp src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientsListCtrl.cpp src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp
 msgid "Uploaded"
 msgstr "Odesláno"
 
-#: src/ClientsListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientsListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Downloaded"
 msgstr "Staženo"
 
@@ -1537,7 +1555,8 @@ msgstr "Komentáře k souboru"
 msgid "Username"
 msgstr "Jméno"
 
-#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp
+#: src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "File Name"
 msgstr "Název souboru"
 
@@ -1599,15 +1618,18 @@ msgstr "Auto [Vy]"
 msgid "Very low"
 msgstr "Velmi nízká"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Low"
 msgstr "Nízká"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Normal"
 msgstr "Normální"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "High"
 msgstr "Vysoká"
 
@@ -1631,11 +1653,13 @@ msgstr "Připojuji se přes server"
 msgid "Queue Full"
 msgstr "Plná fronta"
 
-#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp src/muuli_wdr.cpp
+#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp
+#: src/muuli_wdr.cpp
 msgid "On Queue"
 msgstr "Ve frontě"
 
-#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
+#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp
+#: src/PartFile.cpp src/TransferWnd.cpp
 msgid "Downloading"
 msgstr "Stahuji"
 
@@ -1695,7 +1719,8 @@ msgstr "Lokální server"
 msgid "Remote Server"
 msgstr "Vzdálený server"
 
-#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp src/TextClient.cpp
+#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp
+#: src/TextClient.cpp
 msgid "Kad"
 msgstr "Kad"
 
@@ -1719,7 +1744,8 @@ msgstr "Zdrojové seedy"
 msgid "Search Result"
 msgstr "Výsledek hledání"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp
+#: src/TransferWnd.cpp
 msgid "Completed"
 msgstr "Dokončeno"
 
@@ -1771,7 +1797,8 @@ msgstr "Nelze provézt úpravu v rekurzivním sdílení"
 msgid "Part"
 msgstr "Část"
 
-#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 msgid "Size"
 msgstr "Velikost"
 
@@ -1779,7 +1806,8 @@ msgstr "Velikost"
 msgid "Transferred"
 msgstr "Přeneseno"
 
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp src/SourceListCtrl.cpp
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
+#: src/SourceListCtrl.cpp
 msgid "Speed"
 msgstr "Rychlost"
 
@@ -1787,11 +1815,13 @@ msgstr "Rychlost"
 msgid "Progress"
 msgstr "Průběh"
 
-#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
+#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp
+#: src/SearchListCtrl.cpp
 msgid "Sources"
 msgstr "Zdroje"
 
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 msgid "Priority"
 msgstr "Priorita"
 
@@ -1815,7 +1845,9 @@ msgstr "Poslední příjem"
 msgid "Auto"
 msgstr "Auto"
 
-#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/TransferWnd.cpp src/utils/wxCas/src/wxcasprefs.cpp
+#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/TransferWnd.cpp
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Cancel"
 msgstr "Zrušit"
 
@@ -1916,7 +1948,8 @@ msgstr "Zadejte nový název pro tento soubor:"
 msgid "File rename"
 msgstr "Přejmenování souboru"
 
-#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f MiB/s"
 msgstr ""
@@ -2726,11 +2759,13 @@ msgstr ""
 msgid "Start aMule automatically when I log in"
 msgstr "Spustit aMule automaticky po přihlášení"
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp packaging/windows/installer_strings.c
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: packaging/windows/installer_strings.c
 msgid "Register aMule for ed2k:// links"
 msgstr "Zaregistrovat aMule pro odkazy ed2k://"
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp packaging/windows/installer_strings.c
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: packaging/windows/installer_strings.c
 msgid "Register aMule for magnet: links"
 msgstr "Zaregistrovat aMule pro odkazy magnet:"
 
@@ -2758,7 +2793,8 @@ msgstr ""
 msgid "Destination folder for downloads"
 msgstr "Cílová složka pro stahování"
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Browse"
 msgstr "Procházet"
 
@@ -3185,6 +3221,162 @@ msgstr "Nepodařilo se načíst záznam v seznamu známých souborů, soubor mů
 msgid "Invalid entry in known file list, file may be corrupt: "
 msgstr "Neplatný záznam v seznamu známých souborů, soubor může být poškozen: "
 
+#: src/LanguageList.cpp
+msgid "System default"
+msgstr "Výchozí pro systém"
+
+#: src/LanguageList.cpp
+msgid "Albanian"
+msgstr "Albánština"
+
+#: src/LanguageList.cpp
+msgid "Arabic"
+msgstr "Arabský"
+
+#: src/LanguageList.cpp
+msgid "Asturian"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Basque"
+msgstr "Baskičtina"
+
+#: src/LanguageList.cpp
+msgid "Bulgarian"
+msgstr "Bulharský"
+
+#: src/LanguageList.cpp
+msgid "Catalan"
+msgstr "Katalánština"
+
+#: src/LanguageList.cpp
+msgid "Chinese (Simplified)"
+msgstr "Čínština (zjednodušená)"
+
+#: src/LanguageList.cpp
+msgid "Chinese (Traditional)"
+msgstr "Čínština (tradiční)"
+
+#: src/LanguageList.cpp
+msgid "Croatian"
+msgstr "Chorvatština"
+
+#: src/LanguageList.cpp
+msgid "Czech"
+msgstr "Česky"
+
+#: src/LanguageList.cpp
+msgid "Danish"
+msgstr "Dánština"
+
+#: src/LanguageList.cpp
+msgid "Dutch"
+msgstr "Nizozemština"
+
+#: src/LanguageList.cpp
+msgid "English (U.K.)"
+msgstr "Angličtina (britská)"
+
+#: src/LanguageList.cpp
+msgid "English (U.S.)"
+msgstr "Angličtina (USA)"
+
+#: src/LanguageList.cpp
+msgid "Estonian"
+msgstr "Estonština"
+
+#: src/LanguageList.cpp
+msgid "Finnish"
+msgstr "Finština"
+
+#: src/LanguageList.cpp
+msgid "French"
+msgstr "Francouzština"
+
+#: src/LanguageList.cpp
+msgid "Galician"
+msgstr "Galicijština"
+
+#: src/LanguageList.cpp
+msgid "German"
+msgstr "Němčina"
+
+#: src/LanguageList.cpp
+msgid "Greek"
+msgstr "Řečtina"
+
+#: src/LanguageList.cpp
+msgid "Hebrew"
+msgstr "Hebrejština"
+
+#: src/LanguageList.cpp
+msgid "Hungarian"
+msgstr "Maďarština"
+
+#: src/LanguageList.cpp
+msgid "Italian"
+msgstr "Italština"
+
+#: src/LanguageList.cpp
+msgid "Japanese"
+msgstr "Japonština"
+
+#: src/LanguageList.cpp
+msgid "Korean"
+msgstr "Korejština"
+
+#: src/LanguageList.cpp
+msgid "Latvian"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Lithuanian"
+msgstr "Litevština"
+
+#: src/LanguageList.cpp
+msgid "Norwegian (Nynorsk)"
+msgstr "Norština"
+
+#: src/LanguageList.cpp
+msgid "Polish"
+msgstr "Polština"
+
+#: src/LanguageList.cpp
+msgid "Portuguese"
+msgstr "Portugalština"
+
+#: src/LanguageList.cpp
+msgid "Portuguese (Brazilian)"
+msgstr "Portugalština (brazilská)"
+
+#: src/LanguageList.cpp
+msgid "Romanian"
+msgstr "Rumunština"
+
+#: src/LanguageList.cpp
+msgid "Russian"
+msgstr "Ruština"
+
+#: src/LanguageList.cpp
+msgid "Slovenian"
+msgstr "Slovinština"
+
+#: src/LanguageList.cpp
+msgid "Spanish"
+msgstr "Španělština"
+
+#: src/LanguageList.cpp
+msgid "Swedish"
+msgstr "Švédština"
+
+#: src/LanguageList.cpp
+msgid "Turkish"
+msgstr "Turečtina"
+
+#: src/LanguageList.cpp
+msgid "Ukrainian"
+msgstr "Ukrajinština"
+
 #: src/libs/common/Format.cpp
 #, c-format
 msgid "Unknown error %d"
@@ -3207,15 +3399,18 @@ msgstr "Dokončování"
 msgid "Complete"
 msgstr "Dokončeno"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Paused"
 msgstr "Pozastaveno"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Erroneous"
 msgstr "Poškozený"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Waiting"
 msgstr "Čekám"
 
@@ -3382,7 +3577,8 @@ msgstr "Zavřít"
 msgid "Cut"
 msgstr "Vyjmout"
 
-#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp src/utils/aLinkCreator/src/alcframe.cpp
+#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy"
 msgstr "Kopírovat"
 
@@ -3390,7 +3586,8 @@ msgstr "Kopírovat"
 msgid "Paste"
 msgstr "Vložit"
 
-#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
+#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Clear"
 msgstr "Vyčistit"
 
@@ -3398,7 +3595,8 @@ msgstr "Vyčistit"
 msgid "Select All"
 msgstr "Označit vše"
 
-#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp src/StatisticsDlg.cpp
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
+#: src/StatisticsDlg.cpp
 msgid "KiB/s"
 msgstr ""
 
@@ -5877,174 +6075,6 @@ msgid "ERROR: Failed to open partfile '%s'"
 msgstr "CHYBA: Nepodařilo se otevřít soubor part '%s'"
 
 #: src/Preferences.cpp
-msgid "System default"
-msgstr "Výchozí pro systém"
-
-#: src/Preferences.cpp
-msgid "Albanian"
-msgstr "Albánština"
-
-#: src/Preferences.cpp
-msgid "Arabic"
-msgstr "Arabský"
-
-#: src/Preferences.cpp
-msgid "Asturian"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Basque"
-msgstr "Baskičtina"
-
-#: src/Preferences.cpp
-msgid "Bulgarian"
-msgstr "Bulharský"
-
-#: src/Preferences.cpp
-msgid "Catalan"
-msgstr "Katalánština"
-
-#: src/Preferences.cpp
-msgid "Chinese (Simplified)"
-msgstr "Čínština (zjednodušená)"
-
-#: src/Preferences.cpp
-msgid "Chinese (Traditional)"
-msgstr "Čínština (tradiční)"
-
-#: src/Preferences.cpp
-msgid "Croatian"
-msgstr "Chorvatština"
-
-#: src/Preferences.cpp
-msgid "Czech"
-msgstr "Česky"
-
-#: src/Preferences.cpp
-msgid "Danish"
-msgstr "Dánština"
-
-#: src/Preferences.cpp
-msgid "Dutch"
-msgstr "Nizozemština"
-
-#: src/Preferences.cpp
-msgid "English (U.K.)"
-msgstr "Angličtina (britská)"
-
-#: src/Preferences.cpp
-msgid "English (U.S.)"
-msgstr "Angličtina (USA)"
-
-#: src/Preferences.cpp
-msgid "Estonian"
-msgstr "Estonština"
-
-#: src/Preferences.cpp
-msgid "Finnish"
-msgstr "Finština"
-
-#: src/Preferences.cpp
-msgid "French"
-msgstr "Francouzština"
-
-#: src/Preferences.cpp
-msgid "Galician"
-msgstr "Galicijština"
-
-#: src/Preferences.cpp
-msgid "German"
-msgstr "Němčina"
-
-#: src/Preferences.cpp
-msgid "Greek"
-msgstr "Řečtina"
-
-#: src/Preferences.cpp
-msgid "Hebrew"
-msgstr "Hebrejština"
-
-#: src/Preferences.cpp
-msgid "Hungarian"
-msgstr "Maďarština"
-
-#: src/Preferences.cpp
-msgid "Italian"
-msgstr "Italština"
-
-#: src/Preferences.cpp
-msgid "Japanese"
-msgstr "Japonština"
-
-#: src/Preferences.cpp
-msgid "Korean"
-msgstr "Korejština"
-
-#: src/Preferences.cpp
-msgid "Latvian"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Lithuanian"
-msgstr "Litevština"
-
-#: src/Preferences.cpp
-msgid "Norwegian (Nynorsk)"
-msgstr "Norština"
-
-#: src/Preferences.cpp
-msgid "Polish"
-msgstr "Polština"
-
-#: src/Preferences.cpp
-msgid "Portuguese"
-msgstr "Portugalština"
-
-#: src/Preferences.cpp
-msgid "Portuguese (Brazilian)"
-msgstr "Portugalština (brazilská)"
-
-#: src/Preferences.cpp
-msgid "Romanian"
-msgstr "Rumunština"
-
-#: src/Preferences.cpp
-msgid "Russian"
-msgstr "Ruština"
-
-#: src/Preferences.cpp
-msgid "Slovenian"
-msgstr "Slovinština"
-
-#: src/Preferences.cpp
-msgid "Spanish"
-msgstr "Španělština"
-
-#: src/Preferences.cpp
-msgid "Swedish"
-msgstr "Švédština"
-
-#: src/Preferences.cpp
-msgid "Turkish"
-msgstr "Turečtina"
-
-#: src/Preferences.cpp
-msgid "Ukrainian"
-msgstr "Ukrajinština"
-
-#: src/Preferences.cpp
-msgid "Change Language"
-msgstr "Změnit jazyk"
-
-#: src/Preferences.cpp
-msgid "There are no translations installed for aMule"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "No languages available"
-msgstr "Nejsou k dispozici žádné jazyky"
-
-#: src/Preferences.cpp
 msgid "no options available"
 msgstr "není dostupné žádné nastavení"
 
@@ -6553,7 +6583,8 @@ msgstr "Jejich rekurzivní sdílení zveřejní všechny soubory pod nimi v sít
 msgid "Confirm shared folders"
 msgstr "Potvrdit sdílené složky"
 
-#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp src/SharedFilesReloadProgress.cpp
+#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp
+#: src/SharedFilesReloadProgress.cpp
 msgid "Reloading shared files..."
 msgstr "Opětovné načítání sdílených souborů..."
 
@@ -9280,6 +9311,12 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "Change Language"
+#~ msgstr "Změnit jazyk"
+
+#~ msgid "No languages available"
+#~ msgstr "Nejsou k dispozici žádné jazyky"
 
 #~ msgid "User name"
 #~ msgstr "Uživatelské jméno"

--- a/po/da.po
+++ b/po/da.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-05 12:01+0200\n"
+"POT-Creation-Date: 2026-09-06 14:35+0200\n"
 "PO-Revision-Date: 2026-09-05 10:47+0000\n"
 "Last-Translator: Alex Thomsen Leth <alexl@stofanet.dk>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -376,7 +376,8 @@ msgstr ""
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr ""
 
-#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
+#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
+#: src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
 msgid "ERROR"
 msgstr ""
 
@@ -656,7 +657,8 @@ msgstr ""
 msgid "Searches"
 msgstr "Søg"
 
-#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/Statistics.cpp
+#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/Statistics.cpp
 msgid "Downloads"
 msgstr "Downloads"
 
@@ -744,7 +746,9 @@ msgstr " Kad: "
 msgid "Core"
 msgstr ""
 
-#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp src/Statistics.cpp
+#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp src/Statistics.cpp
 msgid "Version"
 msgstr ""
 
@@ -1046,7 +1050,11 @@ msgstr ""
 msgid "The remote core sent inconsistent data for \"%s\" (part status %d, expected %d). The file list may be showing the wrong information; reconnect to clear it."
 msgstr ""
 
-#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp src/Statistics.cpp
+#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp
+#: src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp
+#: src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp
+#: src/Statistics.cpp
 msgid "Unknown"
 msgstr "Ukendt"
 
@@ -1144,7 +1152,8 @@ msgstr "Fejl ved forbindelse til %s (%s:%i): %d"
 msgid "Enter Captcha"
 msgstr ""
 
-#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp src/TransferWnd.cpp
+#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp
+#: src/TransferWnd.cpp
 msgid "Category"
 msgstr "Kategori"
 
@@ -1305,11 +1314,13 @@ msgstr ""
 msgid "Client Details"
 msgstr "Klient Detaljer"
 
-#: src/ClientDetailDialog.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
+#: src/utils/wxCas/src/onlinesig.cpp
 msgid "LowID"
 msgstr "Lavt ID"
 
-#: src/ClientDetailDialog.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
+#: src/utils/wxCas/src/onlinesig.cpp
 msgid "HighID"
 msgstr "HøjtID"
 
@@ -1325,7 +1336,8 @@ msgstr ""
 msgid "Not supported"
 msgstr ""
 
-#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp src/TextClient.cpp
+#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
+#: src/TextClient.cpp
 msgid "Connected"
 msgstr "Forbundet"
 
@@ -1333,7 +1345,8 @@ msgstr "Forbundet"
 msgid "Disconnected"
 msgstr "Afbrudt"
 
-#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f KiB/s"
 msgstr ""
@@ -1351,7 +1364,8 @@ msgstr ""
 msgid "IP Address"
 msgstr "IP Adresse"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Origin"
 msgstr ""
 
@@ -1369,12 +1383,14 @@ msgstr "Sidste Kontakt"
 msgid "Sessions"
 msgstr "Sessions Gennemsnit"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/SharedFilePeersListCtrl.cpp
 #, fuzzy
 msgid "Upload Speed"
 msgstr "Upload-Hastighed"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/SharedFilePeersListCtrl.cpp
 #, fuzzy
 msgid "Download Speed"
 msgstr "Download-Hastighed"
@@ -1429,11 +1445,13 @@ msgstr[1] ""
 msgid "Files"
 msgstr "Filer"
 
-#: src/ClientsListCtrl.cpp src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientsListCtrl.cpp src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp
 msgid "Uploaded"
 msgstr ""
 
-#: src/ClientsListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientsListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Downloaded"
 msgstr ""
 
@@ -1524,7 +1542,8 @@ msgstr "Fil Kommentarer"
 msgid "Username"
 msgstr "Brugernavn"
 
-#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp
+#: src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "File Name"
 msgstr "Fil Navn"
 
@@ -1586,15 +1605,18 @@ msgstr "Auto [Hø]"
 msgid "Very low"
 msgstr "Meget lav"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Low"
 msgstr "Lav"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Normal"
 msgstr "Normal"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "High"
 msgstr "Høj"
 
@@ -1618,11 +1640,13 @@ msgstr "Forbinder via Server"
 msgid "Queue Full"
 msgstr "Kø Fuld"
 
-#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp src/muuli_wdr.cpp
+#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp
+#: src/muuli_wdr.cpp
 msgid "On Queue"
 msgstr "I Kø"
 
-#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
+#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp
+#: src/PartFile.cpp src/TransferWnd.cpp
 msgid "Downloading"
 msgstr "Henter"
 
@@ -1682,7 +1706,8 @@ msgstr ""
 msgid "Remote Server"
 msgstr ""
 
-#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp src/TextClient.cpp
+#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp
+#: src/TextClient.cpp
 msgid "Kad"
 msgstr ""
 
@@ -1706,7 +1731,8 @@ msgstr ""
 msgid "Search Result"
 msgstr ""
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp
+#: src/TransferWnd.cpp
 msgid "Completed"
 msgstr "Færdig"
 
@@ -1758,7 +1784,8 @@ msgstr ""
 msgid "Part"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 msgid "Size"
 msgstr "Størrelse"
 
@@ -1766,7 +1793,8 @@ msgstr "Størrelse"
 msgid "Transferred"
 msgstr "Overført"
 
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp src/SourceListCtrl.cpp
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
+#: src/SourceListCtrl.cpp
 msgid "Speed"
 msgstr "Hastighed"
 
@@ -1774,11 +1802,13 @@ msgstr "Hastighed"
 msgid "Progress"
 msgstr "Forløb"
 
-#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
+#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp
+#: src/SearchListCtrl.cpp
 msgid "Sources"
 msgstr "Kilder"
 
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 msgid "Priority"
 msgstr "Priotet"
 
@@ -1802,7 +1832,9 @@ msgstr "Sidste Kontakt"
 msgid "Auto"
 msgstr "Auto"
 
-#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/TransferWnd.cpp src/utils/wxCas/src/wxcasprefs.cpp
+#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/TransferWnd.cpp
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Cancel"
 msgstr "Afbryd"
 
@@ -1903,7 +1935,8 @@ msgstr "Indtast nyt navn for denne fil:"
 msgid "File rename"
 msgstr "Omdøb fil"
 
-#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f MiB/s"
 msgstr ""
@@ -2677,11 +2710,13 @@ msgstr ""
 msgid "Start aMule automatically when I log in"
 msgstr ""
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp packaging/windows/installer_strings.c
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: packaging/windows/installer_strings.c
 msgid "Register aMule for ed2k:// links"
 msgstr ""
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp packaging/windows/installer_strings.c
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: packaging/windows/installer_strings.c
 msgid "Register aMule for magnet: links"
 msgstr ""
 
@@ -2707,7 +2742,8 @@ msgstr ""
 msgid "Destination folder for downloads"
 msgstr ""
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Browse"
 msgstr "Gennemse"
 
@@ -3132,6 +3168,164 @@ msgstr ""
 msgid "Invalid entry in known file list, file may be corrupt: "
 msgstr ""
 
+#: src/LanguageList.cpp
+msgid "System default"
+msgstr "System standard"
+
+#: src/LanguageList.cpp
+msgid "Albanian"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Arabic"
+msgstr "Arabic"
+
+#: src/LanguageList.cpp
+#, fuzzy
+msgid "Asturian"
+msgstr "Estonian"
+
+#: src/LanguageList.cpp
+msgid "Basque"
+msgstr "Basque"
+
+#: src/LanguageList.cpp
+msgid "Bulgarian"
+msgstr "Bulgarian"
+
+#: src/LanguageList.cpp
+msgid "Catalan"
+msgstr "Catalan"
+
+#: src/LanguageList.cpp
+msgid "Chinese (Simplified)"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Chinese (Traditional)"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Croatian"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Czech"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Danish"
+msgstr "Danish"
+
+#: src/LanguageList.cpp
+msgid "Dutch"
+msgstr "Dutch"
+
+#: src/LanguageList.cpp
+msgid "English (U.K.)"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "English (U.S.)"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Estonian"
+msgstr "Estonian"
+
+#: src/LanguageList.cpp
+msgid "Finnish"
+msgstr "Finnish"
+
+#: src/LanguageList.cpp
+msgid "French"
+msgstr "French"
+
+#: src/LanguageList.cpp
+msgid "Galician"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "German"
+msgstr "German"
+
+#: src/LanguageList.cpp
+msgid "Greek"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Hebrew"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Hungarian"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Italian"
+msgstr "Italian"
+
+#: src/LanguageList.cpp
+msgid "Japanese"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Korean"
+msgstr "Korean"
+
+#: src/LanguageList.cpp
+msgid "Latvian"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Lithuanian"
+msgstr "Lithuanian"
+
+#: src/LanguageList.cpp
+msgid "Norwegian (Nynorsk)"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Polish"
+msgstr "Polish"
+
+#: src/LanguageList.cpp
+msgid "Portuguese"
+msgstr "Portuguese"
+
+#: src/LanguageList.cpp
+msgid "Portuguese (Brazilian)"
+msgstr ""
+
+#: src/LanguageList.cpp
+#, fuzzy
+msgid "Romanian"
+msgstr "Estonian"
+
+#: src/LanguageList.cpp
+msgid "Russian"
+msgstr "Russian"
+
+#: src/LanguageList.cpp
+msgid "Slovenian"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Spanish"
+msgstr "Spanish"
+
+#: src/LanguageList.cpp
+msgid "Swedish"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Turkish"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Ukrainian"
+msgstr ""
+
 #: src/libs/common/Format.cpp
 #, fuzzy, c-format
 msgid "Unknown error %d"
@@ -3154,15 +3348,18 @@ msgstr "Færdiggør"
 msgid "Complete"
 msgstr "Færdig"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Paused"
 msgstr "Pause"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Erroneous"
 msgstr "Beskadiget"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Waiting"
 msgstr "Venter"
 
@@ -3328,7 +3525,8 @@ msgstr "Luk"
 msgid "Cut"
 msgstr ""
 
-#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp src/utils/aLinkCreator/src/alcframe.cpp
+#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy"
 msgstr ""
 
@@ -3336,7 +3534,8 @@ msgstr ""
 msgid "Paste"
 msgstr ""
 
-#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
+#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Clear"
 msgstr "Ryd"
 
@@ -3344,7 +3543,8 @@ msgstr "Ryd"
 msgid "Select All"
 msgstr ""
 
-#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp src/StatisticsDlg.cpp
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
+#: src/StatisticsDlg.cpp
 msgid "KiB/s"
 msgstr ""
 
@@ -5845,178 +6045,6 @@ msgid "ERROR: Failed to open partfile '%s'"
 msgstr ""
 
 #: src/Preferences.cpp
-msgid "System default"
-msgstr "System standard"
-
-#: src/Preferences.cpp
-msgid "Albanian"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Arabic"
-msgstr "Arabic"
-
-#: src/Preferences.cpp
-#, fuzzy
-msgid "Asturian"
-msgstr "Estonian"
-
-#: src/Preferences.cpp
-msgid "Basque"
-msgstr "Basque"
-
-#: src/Preferences.cpp
-msgid "Bulgarian"
-msgstr "Bulgarian"
-
-#: src/Preferences.cpp
-msgid "Catalan"
-msgstr "Catalan"
-
-#: src/Preferences.cpp
-msgid "Chinese (Simplified)"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Chinese (Traditional)"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Croatian"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Czech"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Danish"
-msgstr "Danish"
-
-#: src/Preferences.cpp
-msgid "Dutch"
-msgstr "Dutch"
-
-#: src/Preferences.cpp
-msgid "English (U.K.)"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "English (U.S.)"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Estonian"
-msgstr "Estonian"
-
-#: src/Preferences.cpp
-msgid "Finnish"
-msgstr "Finnish"
-
-#: src/Preferences.cpp
-msgid "French"
-msgstr "French"
-
-#: src/Preferences.cpp
-msgid "Galician"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "German"
-msgstr "German"
-
-#: src/Preferences.cpp
-msgid "Greek"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Hebrew"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Hungarian"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Italian"
-msgstr "Italian"
-
-#: src/Preferences.cpp
-msgid "Japanese"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Korean"
-msgstr "Korean"
-
-#: src/Preferences.cpp
-msgid "Latvian"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Lithuanian"
-msgstr "Lithuanian"
-
-#: src/Preferences.cpp
-msgid "Norwegian (Nynorsk)"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Polish"
-msgstr "Polish"
-
-#: src/Preferences.cpp
-msgid "Portuguese"
-msgstr "Portuguese"
-
-#: src/Preferences.cpp
-msgid "Portuguese (Brazilian)"
-msgstr ""
-
-#: src/Preferences.cpp
-#, fuzzy
-msgid "Romanian"
-msgstr "Estonian"
-
-#: src/Preferences.cpp
-msgid "Russian"
-msgstr "Russian"
-
-#: src/Preferences.cpp
-msgid "Slovenian"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Spanish"
-msgstr "Spanish"
-
-#: src/Preferences.cpp
-msgid "Swedish"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Turkish"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Ukrainian"
-msgstr ""
-
-#: src/Preferences.cpp
-#, fuzzy
-msgid "Change Language"
-msgstr "Sprog"
-
-#: src/Preferences.cpp
-msgid "There are no translations installed for aMule"
-msgstr ""
-
-#: src/Preferences.cpp
-#, fuzzy
-msgid "No languages available"
-msgstr "Ikke tilgængelig"
-
-#: src/Preferences.cpp
 msgid "no options available"
 msgstr ""
 
@@ -6503,7 +6531,8 @@ msgstr ""
 msgid "Confirm shared folders"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp src/SharedFilesReloadProgress.cpp
+#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp
+#: src/SharedFilesReloadProgress.cpp
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "Fandt %i kendte delte filer"
@@ -9199,6 +9228,14 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#, fuzzy
+#~ msgid "Change Language"
+#~ msgstr "Sprog"
+
+#, fuzzy
+#~ msgid "No languages available"
+#~ msgstr "Ikke tilgængelig"
 
 #~ msgid "Obtained Parts"
 #~ msgstr "Sendte Dele"

--- a/po/de.po
+++ b/po/de.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-05 12:01+0200\n"
+"POT-Creation-Date: 2026-09-06 14:35+0200\n"
 "PO-Revision-Date: 2026-09-05 10:47+0000\n"
 "Last-Translator: Werner Mahr <werner@vollstreckernet.de>\n"
 "Language-Team: German <>\n"
@@ -395,7 +395,8 @@ msgstr "Webserver läuft mit pid %d"
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Du hast \"amuleweb zusammen mit aMule starten\" aktiviert, allerdings kann die amuleweb-Programmdatei nicht gestartet werden. Bitte installiere das Paket, das amuleweb enthält, oder kompiliere aMule mit -DBUILD_WEBSERVER=YES  neu und installiere dies."
 
-#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
+#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
+#: src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
 msgid "ERROR"
 msgstr "FEHLER"
 
@@ -682,7 +683,8 @@ msgstr "Netzwerke"
 msgid "Searches"
 msgstr "Suchen"
 
-#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/Statistics.cpp
+#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/Statistics.cpp
 msgid "Downloads"
 msgstr "Downloads"
 
@@ -766,7 +768,9 @@ msgstr "Kad: aus"
 msgid "Core"
 msgstr ""
 
-#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp src/Statistics.cpp
+#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp src/Statistics.cpp
 msgid "Version"
 msgstr "Version"
 
@@ -1067,7 +1071,11 @@ msgstr "Konnte das Verzeichnis '%s' für die Kategorie '%s' nicht erstellen, nut
 msgid "The remote core sent inconsistent data for \"%s\" (part status %d, expected %d). The file list may be showing the wrong information; reconnect to clear it."
 msgstr ""
 
-#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp src/Statistics.cpp
+#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp
+#: src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp
+#: src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp
+#: src/Statistics.cpp
 msgid "Unknown"
 msgstr "Unbekannt"
 
@@ -1164,7 +1172,8 @@ msgstr "Fehler während des Speicherns der Datei '%s': %s"
 msgid "Enter Captcha"
 msgstr "Captcha eingeben"
 
-#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp src/TransferWnd.cpp
+#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp
+#: src/TransferWnd.cpp
 msgid "Category"
 msgstr "Kategorie"
 
@@ -1327,11 +1336,13 @@ msgstr "Keine 'cryptkey.dat' gefunden, erzeuge eine neue."
 msgid "Client Details"
 msgstr "Client-Details"
 
-#: src/ClientDetailDialog.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
+#: src/utils/wxCas/src/onlinesig.cpp
 msgid "LowID"
 msgstr "Niedrige ID"
 
-#: src/ClientDetailDialog.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
+#: src/utils/wxCas/src/onlinesig.cpp
 msgid "HighID"
 msgstr "Hohe ID"
 
@@ -1347,7 +1358,8 @@ msgstr "Unterstützt"
 msgid "Not supported"
 msgstr "Nicht Unterstützt"
 
-#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp src/TextClient.cpp
+#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
+#: src/TextClient.cpp
 msgid "Connected"
 msgstr "Verbunden"
 
@@ -1355,7 +1367,8 @@ msgstr "Verbunden"
 msgid "Disconnected"
 msgstr "Verbindung getrennt"
 
-#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f KiB/s"
 msgstr ""
@@ -1372,7 +1385,8 @@ msgstr ""
 msgid "IP Address"
 msgstr "IP-Adresse"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Origin"
 msgstr "Ursprung"
 
@@ -1390,11 +1404,13 @@ msgstr "Letzter Empfang"
 msgid "Sessions"
 msgstr "Version"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/SharedFilePeersListCtrl.cpp
 msgid "Upload Speed"
 msgstr "Upload-Geschwindigkeit"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/SharedFilePeersListCtrl.cpp
 msgid "Download Speed"
 msgstr "Download-Geschwindigkeit"
 
@@ -1449,11 +1465,13 @@ msgstr[1] "Konnte %u Links nicht hinzufügen (Details: siehe Log)"
 msgid "Files"
 msgstr "Dateien"
 
-#: src/ClientsListCtrl.cpp src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientsListCtrl.cpp src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp
 msgid "Uploaded"
 msgstr "Hochgeladen"
 
-#: src/ClientsListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientsListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Downloaded"
 msgstr "Heruntergeladen"
 
@@ -1544,7 +1562,8 @@ msgstr "Dateikommentare"
 msgid "Username"
 msgstr "Benutzername"
 
-#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp
+#: src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "File Name"
 msgstr "Dateiname"
 
@@ -1606,15 +1625,18 @@ msgstr "Auto [Ho]"
 msgid "Very low"
 msgstr "Sehr niedrig"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Low"
 msgstr "Niedrig"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Normal"
 msgstr "Normal"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "High"
 msgstr "Hoch"
 
@@ -1638,11 +1660,13 @@ msgstr "Verbunden über Server"
 msgid "Queue Full"
 msgstr "Warteschlange voll"
 
-#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp src/muuli_wdr.cpp
+#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp
+#: src/muuli_wdr.cpp
 msgid "On Queue"
 msgstr "in Warteschlange"
 
-#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
+#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp
+#: src/PartFile.cpp src/TransferWnd.cpp
 msgid "Downloading"
 msgstr "Herunterladen"
 
@@ -1702,7 +1726,8 @@ msgstr "Lokaler Server"
 msgid "Remote Server"
 msgstr "Entfernter Server"
 
-#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp src/TextClient.cpp
+#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp
+#: src/TextClient.cpp
 msgid "Kad"
 msgstr "Kad"
 
@@ -1726,7 +1751,8 @@ msgstr "Einstiegsquellen"
 msgid "Search Result"
 msgstr "Suchresultate:"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp
+#: src/TransferWnd.cpp
 msgid "Completed"
 msgstr "Fertiggestellt"
 
@@ -1778,7 +1804,8 @@ msgstr ""
 msgid "Part"
 msgstr "Teil"
 
-#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 msgid "Size"
 msgstr "Größe"
 
@@ -1786,7 +1813,8 @@ msgstr "Größe"
 msgid "Transferred"
 msgstr "Übertragen"
 
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp src/SourceListCtrl.cpp
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
+#: src/SourceListCtrl.cpp
 msgid "Speed"
 msgstr "Geschwindigkeit"
 
@@ -1794,11 +1822,13 @@ msgstr "Geschwindigkeit"
 msgid "Progress"
 msgstr "Fortschritt"
 
-#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
+#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp
+#: src/SearchListCtrl.cpp
 msgid "Sources"
 msgstr "Quellen"
 
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 msgid "Priority"
 msgstr "Priorität"
 
@@ -1822,7 +1852,9 @@ msgstr "Letzter Empfang"
 msgid "Auto"
 msgstr "Automatisch"
 
-#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/TransferWnd.cpp src/utils/wxCas/src/wxcasprefs.cpp
+#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/TransferWnd.cpp
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Cancel"
 msgstr "Abbruch"
 
@@ -1923,7 +1955,8 @@ msgstr "Einen neuen Namen für diese Datei eingeben:"
 msgid "File rename"
 msgstr "Datei umbenennen"
 
-#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f MiB/s"
 msgstr ""
@@ -2726,11 +2759,13 @@ msgstr ""
 msgid "Start aMule automatically when I log in"
 msgstr "aMule automatisch starten wenn ich mich einlogge"
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp packaging/windows/installer_strings.c
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: packaging/windows/installer_strings.c
 msgid "Register aMule for ed2k:// links"
 msgstr ""
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp packaging/windows/installer_strings.c
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: packaging/windows/installer_strings.c
 msgid "Register aMule for magnet: links"
 msgstr ""
 
@@ -2756,7 +2791,8 @@ msgstr ""
 msgid "Destination folder for downloads"
 msgstr "Zielverzeichnis für Downloads."
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Browse"
 msgstr "Durchsuchen"
 
@@ -3177,6 +3213,163 @@ msgstr "Laden eines Eintrags aus der Liste bekannter Dateien fehlgeschlagen, Dat
 msgid "Invalid entry in known file list, file may be corrupt: "
 msgstr "Ungültiger Eintrag in der Liste bekannter Dateien, Datei möglicherweise beschädigt: "
 
+#: src/LanguageList.cpp
+msgid "System default"
+msgstr "Systemvorgabe"
+
+#: src/LanguageList.cpp
+msgid "Albanian"
+msgstr "Albanisch"
+
+#: src/LanguageList.cpp
+msgid "Arabic"
+msgstr "Arabisch"
+
+#: src/LanguageList.cpp
+msgid "Asturian"
+msgstr "Asturisch"
+
+#: src/LanguageList.cpp
+msgid "Basque"
+msgstr "Baskisch"
+
+#: src/LanguageList.cpp
+msgid "Bulgarian"
+msgstr "Bulgarisch"
+
+#: src/LanguageList.cpp
+msgid "Catalan"
+msgstr "Katalanisch"
+
+#: src/LanguageList.cpp
+msgid "Chinese (Simplified)"
+msgstr "Chinesisch (vereinfacht)"
+
+#: src/LanguageList.cpp
+msgid "Chinese (Traditional)"
+msgstr "Chinesisch (traditionell)"
+
+#: src/LanguageList.cpp
+msgid "Croatian"
+msgstr "Kroatisch"
+
+#: src/LanguageList.cpp
+msgid "Czech"
+msgstr "Tschechisch"
+
+#: src/LanguageList.cpp
+msgid "Danish"
+msgstr "Dänisch"
+
+#: src/LanguageList.cpp
+msgid "Dutch"
+msgstr "Holländisch"
+
+#: src/LanguageList.cpp
+msgid "English (U.K.)"
+msgstr "Englisch (UK)"
+
+#: src/LanguageList.cpp
+#, fuzzy
+msgid "English (U.S.)"
+msgstr "Englisch (UK)"
+
+#: src/LanguageList.cpp
+msgid "Estonian"
+msgstr "Estnisch"
+
+#: src/LanguageList.cpp
+msgid "Finnish"
+msgstr "Finnisch"
+
+#: src/LanguageList.cpp
+msgid "French"
+msgstr "Französisch"
+
+#: src/LanguageList.cpp
+msgid "Galician"
+msgstr "Galizisch"
+
+#: src/LanguageList.cpp
+msgid "German"
+msgstr "Deutsch"
+
+#: src/LanguageList.cpp
+msgid "Greek"
+msgstr "Griechisch"
+
+#: src/LanguageList.cpp
+msgid "Hebrew"
+msgstr "Hebräisch"
+
+#: src/LanguageList.cpp
+msgid "Hungarian"
+msgstr "Ungarisch"
+
+#: src/LanguageList.cpp
+msgid "Italian"
+msgstr "Italienisch"
+
+#: src/LanguageList.cpp
+msgid "Japanese"
+msgstr "Japanisch"
+
+#: src/LanguageList.cpp
+msgid "Korean"
+msgstr "Koreanisch"
+
+#: src/LanguageList.cpp
+msgid "Latvian"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Lithuanian"
+msgstr "Litauisch"
+
+#: src/LanguageList.cpp
+msgid "Norwegian (Nynorsk)"
+msgstr "Norwegisch"
+
+#: src/LanguageList.cpp
+msgid "Polish"
+msgstr "Polnisch"
+
+#: src/LanguageList.cpp
+msgid "Portuguese"
+msgstr "Portugiesisch"
+
+#: src/LanguageList.cpp
+msgid "Portuguese (Brazilian)"
+msgstr "Portugiesisch (Brasilianisch)"
+
+#: src/LanguageList.cpp
+msgid "Romanian"
+msgstr "Rumänisch"
+
+#: src/LanguageList.cpp
+msgid "Russian"
+msgstr "Russisch"
+
+#: src/LanguageList.cpp
+msgid "Slovenian"
+msgstr "Slowenisch"
+
+#: src/LanguageList.cpp
+msgid "Spanish"
+msgstr "Spanisch"
+
+#: src/LanguageList.cpp
+msgid "Swedish"
+msgstr "Schwedisch"
+
+#: src/LanguageList.cpp
+msgid "Turkish"
+msgstr "Türkisch"
+
+#: src/LanguageList.cpp
+msgid "Ukrainian"
+msgstr "Ukrainisch"
+
 #: src/libs/common/Format.cpp
 #, c-format
 msgid "Unknown error %d"
@@ -3199,15 +3392,18 @@ msgstr "Wird abgeschlossen"
 msgid "Complete"
 msgstr "Vollständig"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Paused"
 msgstr "Pausiert"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Erroneous"
 msgstr "Fehlerhaft"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Waiting"
 msgstr "Warten"
 
@@ -3371,7 +3567,8 @@ msgstr "Schließen"
 msgid "Cut"
 msgstr "Ausschneiden"
 
-#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp src/utils/aLinkCreator/src/alcframe.cpp
+#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy"
 msgstr "Kopieren"
 
@@ -3379,7 +3576,8 @@ msgstr "Kopieren"
 msgid "Paste"
 msgstr "Einfügen"
 
-#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
+#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Clear"
 msgstr "Leeren"
 
@@ -3387,7 +3585,8 @@ msgstr "Leeren"
 msgid "Select All"
 msgstr "Alles auswählen"
 
-#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp src/StatisticsDlg.cpp
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
+#: src/StatisticsDlg.cpp
 msgid "KiB/s"
 msgstr ""
 
@@ -5876,175 +6075,6 @@ msgid "ERROR: Failed to open partfile '%s'"
 msgstr "FEHLER: Öffnen von Partfile '%s' fehlgeschlagen"
 
 #: src/Preferences.cpp
-msgid "System default"
-msgstr "Systemvorgabe"
-
-#: src/Preferences.cpp
-msgid "Albanian"
-msgstr "Albanisch"
-
-#: src/Preferences.cpp
-msgid "Arabic"
-msgstr "Arabisch"
-
-#: src/Preferences.cpp
-msgid "Asturian"
-msgstr "Asturisch"
-
-#: src/Preferences.cpp
-msgid "Basque"
-msgstr "Baskisch"
-
-#: src/Preferences.cpp
-msgid "Bulgarian"
-msgstr "Bulgarisch"
-
-#: src/Preferences.cpp
-msgid "Catalan"
-msgstr "Katalanisch"
-
-#: src/Preferences.cpp
-msgid "Chinese (Simplified)"
-msgstr "Chinesisch (vereinfacht)"
-
-#: src/Preferences.cpp
-msgid "Chinese (Traditional)"
-msgstr "Chinesisch (traditionell)"
-
-#: src/Preferences.cpp
-msgid "Croatian"
-msgstr "Kroatisch"
-
-#: src/Preferences.cpp
-msgid "Czech"
-msgstr "Tschechisch"
-
-#: src/Preferences.cpp
-msgid "Danish"
-msgstr "Dänisch"
-
-#: src/Preferences.cpp
-msgid "Dutch"
-msgstr "Holländisch"
-
-#: src/Preferences.cpp
-msgid "English (U.K.)"
-msgstr "Englisch (UK)"
-
-#: src/Preferences.cpp
-#, fuzzy
-msgid "English (U.S.)"
-msgstr "Englisch (UK)"
-
-#: src/Preferences.cpp
-msgid "Estonian"
-msgstr "Estnisch"
-
-#: src/Preferences.cpp
-msgid "Finnish"
-msgstr "Finnisch"
-
-#: src/Preferences.cpp
-msgid "French"
-msgstr "Französisch"
-
-#: src/Preferences.cpp
-msgid "Galician"
-msgstr "Galizisch"
-
-#: src/Preferences.cpp
-msgid "German"
-msgstr "Deutsch"
-
-#: src/Preferences.cpp
-msgid "Greek"
-msgstr "Griechisch"
-
-#: src/Preferences.cpp
-msgid "Hebrew"
-msgstr "Hebräisch"
-
-#: src/Preferences.cpp
-msgid "Hungarian"
-msgstr "Ungarisch"
-
-#: src/Preferences.cpp
-msgid "Italian"
-msgstr "Italienisch"
-
-#: src/Preferences.cpp
-msgid "Japanese"
-msgstr "Japanisch"
-
-#: src/Preferences.cpp
-msgid "Korean"
-msgstr "Koreanisch"
-
-#: src/Preferences.cpp
-msgid "Latvian"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Lithuanian"
-msgstr "Litauisch"
-
-#: src/Preferences.cpp
-msgid "Norwegian (Nynorsk)"
-msgstr "Norwegisch"
-
-#: src/Preferences.cpp
-msgid "Polish"
-msgstr "Polnisch"
-
-#: src/Preferences.cpp
-msgid "Portuguese"
-msgstr "Portugiesisch"
-
-#: src/Preferences.cpp
-msgid "Portuguese (Brazilian)"
-msgstr "Portugiesisch (Brasilianisch)"
-
-#: src/Preferences.cpp
-msgid "Romanian"
-msgstr "Rumänisch"
-
-#: src/Preferences.cpp
-msgid "Russian"
-msgstr "Russisch"
-
-#: src/Preferences.cpp
-msgid "Slovenian"
-msgstr "Slowenisch"
-
-#: src/Preferences.cpp
-msgid "Spanish"
-msgstr "Spanisch"
-
-#: src/Preferences.cpp
-msgid "Swedish"
-msgstr "Schwedisch"
-
-#: src/Preferences.cpp
-msgid "Turkish"
-msgstr "Türkisch"
-
-#: src/Preferences.cpp
-msgid "Ukrainian"
-msgstr "Ukrainisch"
-
-#: src/Preferences.cpp
-msgid "Change Language"
-msgstr "Sprache ändern"
-
-#: src/Preferences.cpp
-msgid "There are no translations installed for aMule"
-msgstr "Für aMule sind keine Übersetzungen installiert"
-
-#: src/Preferences.cpp
-msgid "No languages available"
-msgstr "Keine Sprachen verfügbar"
-
-#: src/Preferences.cpp
 msgid "no options available"
 msgstr "keine Optionen verfügbar"
 
@@ -6559,7 +6589,8 @@ msgstr "Rekursives Teilen würde jede Datei im eD2k/Kad Netzwerk verfügbar mach
 msgid "Confirm shared folders"
 msgstr "Freigegebene Ordner bestätigen"
 
-#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp src/SharedFilesReloadProgress.cpp
+#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp
+#: src/SharedFilesReloadProgress.cpp
 msgid "Reloading shared files..."
 msgstr "Freigegebene Dateien neu laden..."
 
@@ -9307,6 +9338,15 @@ msgstr "aMule scheint zu laufen. Bitte schließen und das Entfernprogram erneut 
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "Entferne Benutzerdaten von $APPDATA\\aMule..."
+
+#~ msgid "Change Language"
+#~ msgstr "Sprache ändern"
+
+#~ msgid "There are no translations installed for aMule"
+#~ msgstr "Für aMule sind keine Übersetzungen installiert"
+
+#~ msgid "No languages available"
+#~ msgstr "Keine Sprachen verfügbar"
 
 #~ msgid "User name"
 #~ msgstr "Benutzername"

--- a/po/el.po
+++ b/po/el.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-05 12:01+0200\n"
+"POT-Creation-Date: 2026-09-06 14:35+0200\n"
 "PO-Revision-Date: 2026-09-05 10:48+0000\n"
 "Last-Translator: Dimitris <dgalanak@yahoo.com>\n"
 "Language-Team: Greek\n"
@@ -391,7 +391,8 @@ msgstr "διακομιστής ιστού τρέχει με αριθμό διε�
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Ζητήσατε να τρέχετε τον διακομιστή ιστού κατά την εκκίνηση, αλλά το εκτελέσιμο αρχείο amuleweb δεν βρέθηκε. Παρακαλώ εγκαταστήστε το πακέτο που περιέχει τον διακομιστή ιστού του aMule, ή μεταφράστε το aMule χρησιμοποιώντας την παράμετρο --enable-webserver"
 
-#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
+#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
+#: src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
 msgid "ERROR"
 msgstr "ΣΦΑΛΜΑ"
 
@@ -680,7 +681,8 @@ msgstr "Δίκτυα"
 msgid "Searches"
 msgstr "Αναζητήσεις"
 
-#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/Statistics.cpp
+#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/Statistics.cpp
 msgid "Downloads"
 msgstr "Κατεβασμένα"
 
@@ -764,7 +766,9 @@ msgstr "Kad: Εκτός"
 msgid "Core"
 msgstr ""
 
-#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp src/Statistics.cpp
+#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp src/Statistics.cpp
 msgid "Version"
 msgstr "Έκδοση"
 
@@ -1068,7 +1072,11 @@ msgstr ""
 msgid "The remote core sent inconsistent data for \"%s\" (part status %d, expected %d). The file list may be showing the wrong information; reconnect to clear it."
 msgstr ""
 
-#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp src/Statistics.cpp
+#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp
+#: src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp
+#: src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp
+#: src/Statistics.cpp
 msgid "Unknown"
 msgstr "Άγνωστο"
 
@@ -1166,7 +1174,8 @@ msgstr "Σφάλμα κατά το αποθήκευση του αρχείου kn
 msgid "Enter Captcha"
 msgstr ""
 
-#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp src/TransferWnd.cpp
+#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp
+#: src/TransferWnd.cpp
 msgid "Category"
 msgstr "Κατηγορία"
 
@@ -1330,11 +1339,13 @@ msgstr "Δεν βρέθηκε το αρχείο 'cryptkey.dat' και γι αυ�
 msgid "Client Details"
 msgstr "Πληροφορίες πελάτη"
 
-#: src/ClientDetailDialog.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
+#: src/utils/wxCas/src/onlinesig.cpp
 msgid "LowID"
 msgstr "Κακή ποιότητα σύνδεσης (LowID)"
 
-#: src/ClientDetailDialog.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
+#: src/utils/wxCas/src/onlinesig.cpp
 msgid "HighID"
 msgstr "Καλή ποιότητα σύνδεσης (HighID)"
 
@@ -1350,7 +1361,8 @@ msgstr "Υποστηρίζεται"
 msgid "Not supported"
 msgstr "Δεν υποστηρίζεται"
 
-#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp src/TextClient.cpp
+#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
+#: src/TextClient.cpp
 msgid "Connected"
 msgstr "Συνδεδεμένο"
 
@@ -1358,7 +1370,8 @@ msgstr "Συνδεδεμένο"
 msgid "Disconnected"
 msgstr "Αποσυνδεδεμένο"
 
-#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f KiB/s"
 msgstr ""
@@ -1375,7 +1388,8 @@ msgstr ""
 msgid "IP Address"
 msgstr "Διεύθυνση IP"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Origin"
 msgstr ""
 
@@ -1393,12 +1407,14 @@ msgstr "Τελευταία λήψη"
 msgid "Sessions"
 msgstr "Έκδοση"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/SharedFilePeersListCtrl.cpp
 #, fuzzy
 msgid "Upload Speed"
 msgstr "Ταχύτητα ανεβάσματος"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/SharedFilePeersListCtrl.cpp
 #, fuzzy
 msgid "Download Speed"
 msgstr "Ταχύτητα κατεβάσματος"
@@ -1454,11 +1470,13 @@ msgstr[1] ""
 msgid "Files"
 msgstr "Αρχεία"
 
-#: src/ClientsListCtrl.cpp src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientsListCtrl.cpp src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp
 msgid "Uploaded"
 msgstr "Ανέβηκε"
 
-#: src/ClientsListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientsListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Downloaded"
 msgstr "Έχει κατεβεί"
 
@@ -1549,7 +1567,8 @@ msgstr "Σχόλια αρχείου"
 msgid "Username"
 msgstr "Όνομα Χρήστη"
 
-#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp
+#: src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "File Name"
 msgstr "Όνομα αρχείου"
 
@@ -1610,15 +1629,18 @@ msgstr "Αυτόματη [Υψηλή]"
 msgid "Very low"
 msgstr "Πολύ χαμηλή"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Low"
 msgstr "Χαμηλή"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Normal"
 msgstr "Κανονική"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "High"
 msgstr "Υψηλή"
 
@@ -1642,11 +1664,13 @@ msgstr "Σύνδεση μέσω διακομιστή"
 msgid "Queue Full"
 msgstr "Ουρά γεμάτη"
 
-#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp src/muuli_wdr.cpp
+#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp
+#: src/muuli_wdr.cpp
 msgid "On Queue"
 msgstr "Εν αναμονή"
 
-#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
+#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp
+#: src/PartFile.cpp src/TransferWnd.cpp
 msgid "Downloading"
 msgstr "Κατεβαίνει"
 
@@ -1706,7 +1730,8 @@ msgstr "Τοπικός διακομιστής"
 msgid "Remote Server"
 msgstr "Απομακρυσμένος διακομιστής"
 
-#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp src/TextClient.cpp
+#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp
+#: src/TextClient.cpp
 msgid "Kad"
 msgstr "Kad"
 
@@ -1730,7 +1755,8 @@ msgstr "Πηγαίος σπόρος"
 msgid "Search Result"
 msgstr "Αποτέλεσμα Αναζήτησης"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp
+#: src/TransferWnd.cpp
 msgid "Completed"
 msgstr "Ολοκληρώθηκαν"
 
@@ -1783,7 +1809,8 @@ msgstr ""
 msgid "Part"
 msgstr "Μέρος"
 
-#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 msgid "Size"
 msgstr "Μέγεθος"
 
@@ -1791,7 +1818,8 @@ msgstr "Μέγεθος"
 msgid "Transferred"
 msgstr "Μεταφέρθηκαν"
 
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp src/SourceListCtrl.cpp
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
+#: src/SourceListCtrl.cpp
 msgid "Speed"
 msgstr "Ταχύτητα"
 
@@ -1799,11 +1827,13 @@ msgstr "Ταχύτητα"
 msgid "Progress"
 msgstr "Πρόοδος"
 
-#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
+#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp
+#: src/SearchListCtrl.cpp
 msgid "Sources"
 msgstr "Αρ. πηγών"
 
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 msgid "Priority"
 msgstr "Προτεραιότητα"
 
@@ -1827,7 +1857,9 @@ msgstr "Τελευταία λήψη"
 msgid "Auto"
 msgstr "Αυτόματη"
 
-#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/TransferWnd.cpp src/utils/wxCas/src/wxcasprefs.cpp
+#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/TransferWnd.cpp
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Cancel"
 msgstr "Ακύρωση"
 
@@ -1928,7 +1960,8 @@ msgstr "Δώστε νέο όνομα γι αυτό το αρχείο:"
 msgid "File rename"
 msgstr "Μετονομασία αρχείου"
 
-#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f MiB/s"
 msgstr ""
@@ -2737,11 +2770,13 @@ msgstr ""
 msgid "Start aMule automatically when I log in"
 msgstr ""
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp packaging/windows/installer_strings.c
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: packaging/windows/installer_strings.c
 msgid "Register aMule for ed2k:// links"
 msgstr ""
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp packaging/windows/installer_strings.c
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: packaging/windows/installer_strings.c
 msgid "Register aMule for magnet: links"
 msgstr ""
 
@@ -2767,7 +2802,8 @@ msgstr ""
 msgid "Destination folder for downloads"
 msgstr "Κατάλογος για τα εισερχόμενα"
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Browse"
 msgstr "Επιλογή"
 
@@ -3192,6 +3228,165 @@ msgstr ""
 msgid "Invalid entry in known file list, file may be corrupt: "
 msgstr ""
 
+#: src/LanguageList.cpp
+msgid "System default"
+msgstr "Εργοστασιακές ρυθμίσεις"
+
+#: src/LanguageList.cpp
+msgid "Albanian"
+msgstr "Αλβανικά"
+
+#: src/LanguageList.cpp
+msgid "Arabic"
+msgstr "Αραβικά"
+
+#: src/LanguageList.cpp
+#, fuzzy
+msgid "Asturian"
+msgstr "Εσθονικά"
+
+#: src/LanguageList.cpp
+msgid "Basque"
+msgstr "Βάσκικα"
+
+#: src/LanguageList.cpp
+msgid "Bulgarian"
+msgstr "Βουλγάρικα"
+
+#: src/LanguageList.cpp
+msgid "Catalan"
+msgstr "Καταλανικά"
+
+#: src/LanguageList.cpp
+msgid "Chinese (Simplified)"
+msgstr "Κινέζικα (απλοποιημένα)"
+
+#: src/LanguageList.cpp
+msgid "Chinese (Traditional)"
+msgstr "Κινέζικα (Παραδοσιακά)"
+
+#: src/LanguageList.cpp
+msgid "Croatian"
+msgstr "Κροατικά"
+
+#: src/LanguageList.cpp
+msgid "Czech"
+msgstr "Τσέχικα"
+
+#: src/LanguageList.cpp
+msgid "Danish"
+msgstr "Δανέζικα"
+
+#: src/LanguageList.cpp
+msgid "Dutch"
+msgstr "Ολλανδικά"
+
+#: src/LanguageList.cpp
+msgid "English (U.K.)"
+msgstr "Αγγλικά (Ην. Βασίλειο)"
+
+#: src/LanguageList.cpp
+#, fuzzy
+msgid "English (U.S.)"
+msgstr "Αγγλικά (Ην. Βασίλειο)"
+
+#: src/LanguageList.cpp
+msgid "Estonian"
+msgstr "Εσθονικά"
+
+#: src/LanguageList.cpp
+msgid "Finnish"
+msgstr "Φιλανδικά"
+
+#: src/LanguageList.cpp
+msgid "French"
+msgstr "Γαλλικά"
+
+#: src/LanguageList.cpp
+msgid "Galician"
+msgstr "Γαλικιακά"
+
+#: src/LanguageList.cpp
+msgid "German"
+msgstr "Γερμανικά"
+
+#: src/LanguageList.cpp
+msgid "Greek"
+msgstr "Ελληνικά"
+
+#: src/LanguageList.cpp
+msgid "Hebrew"
+msgstr "Εβραϊκά"
+
+#: src/LanguageList.cpp
+msgid "Hungarian"
+msgstr "Ουγγαρέζικα"
+
+#: src/LanguageList.cpp
+msgid "Italian"
+msgstr "Ιταλικά"
+
+#: src/LanguageList.cpp
+msgid "Japanese"
+msgstr "Γιαπωνέζικα"
+
+#: src/LanguageList.cpp
+msgid "Korean"
+msgstr "Κορεάτικα"
+
+#: src/LanguageList.cpp
+msgid "Latvian"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Lithuanian"
+msgstr "Λιθουανικά"
+
+#: src/LanguageList.cpp
+msgid "Norwegian (Nynorsk)"
+msgstr "Νορβηγικά"
+
+#: src/LanguageList.cpp
+msgid "Polish"
+msgstr "Πολωνέζικα"
+
+#: src/LanguageList.cpp
+msgid "Portuguese"
+msgstr "Πορτογαλλικά"
+
+#: src/LanguageList.cpp
+msgid "Portuguese (Brazilian)"
+msgstr "Πορτογαλλικά (Βραζιλίας)"
+
+#: src/LanguageList.cpp
+#, fuzzy
+msgid "Romanian"
+msgstr "Αλβανικά"
+
+#: src/LanguageList.cpp
+msgid "Russian"
+msgstr "Ρωσικά"
+
+#: src/LanguageList.cpp
+msgid "Slovenian"
+msgstr "Σλοβένικα"
+
+#: src/LanguageList.cpp
+msgid "Spanish"
+msgstr "Ισπανικά"
+
+#: src/LanguageList.cpp
+msgid "Swedish"
+msgstr "Σουηδικά"
+
+#: src/LanguageList.cpp
+msgid "Turkish"
+msgstr "Τούρκικα"
+
+#: src/LanguageList.cpp
+msgid "Ukrainian"
+msgstr ""
+
 #: src/libs/common/Format.cpp
 #, fuzzy, c-format
 msgid "Unknown error %d"
@@ -3214,15 +3409,18 @@ msgstr "Ολοκληρώνεται"
 msgid "Complete"
 msgstr "Ολοκληρωμένο"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Paused"
 msgstr "Σταματημένο"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Erroneous"
 msgstr "Εσφαλμένο"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Waiting"
 msgstr "Εν αναμονή"
 
@@ -3388,7 +3586,8 @@ msgstr "Κλείσιμο"
 msgid "Cut"
 msgstr "Αποκοπή"
 
-#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp src/utils/aLinkCreator/src/alcframe.cpp
+#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy"
 msgstr "Αντιγραφή"
 
@@ -3396,7 +3595,8 @@ msgstr "Αντιγραφή"
 msgid "Paste"
 msgstr "Επικόλληση"
 
-#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
+#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Clear"
 msgstr "Καθαρισμός"
 
@@ -3404,7 +3604,8 @@ msgstr "Καθαρισμός"
 msgid "Select All"
 msgstr "Επιλογή όλων"
 
-#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp src/StatisticsDlg.cpp
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
+#: src/StatisticsDlg.cpp
 msgid "KiB/s"
 msgstr ""
 
@@ -5916,179 +6117,6 @@ msgid "ERROR: Failed to open partfile '%s'"
 msgstr "ΣΦΑΛΜΑ: Αποτυχία ανοίγματος του ημιτελούς αρχείου '%s'"
 
 #: src/Preferences.cpp
-msgid "System default"
-msgstr "Εργοστασιακές ρυθμίσεις"
-
-#: src/Preferences.cpp
-msgid "Albanian"
-msgstr "Αλβανικά"
-
-#: src/Preferences.cpp
-msgid "Arabic"
-msgstr "Αραβικά"
-
-#: src/Preferences.cpp
-#, fuzzy
-msgid "Asturian"
-msgstr "Εσθονικά"
-
-#: src/Preferences.cpp
-msgid "Basque"
-msgstr "Βάσκικα"
-
-#: src/Preferences.cpp
-msgid "Bulgarian"
-msgstr "Βουλγάρικα"
-
-#: src/Preferences.cpp
-msgid "Catalan"
-msgstr "Καταλανικά"
-
-#: src/Preferences.cpp
-msgid "Chinese (Simplified)"
-msgstr "Κινέζικα (απλοποιημένα)"
-
-#: src/Preferences.cpp
-msgid "Chinese (Traditional)"
-msgstr "Κινέζικα (Παραδοσιακά)"
-
-#: src/Preferences.cpp
-msgid "Croatian"
-msgstr "Κροατικά"
-
-#: src/Preferences.cpp
-msgid "Czech"
-msgstr "Τσέχικα"
-
-#: src/Preferences.cpp
-msgid "Danish"
-msgstr "Δανέζικα"
-
-#: src/Preferences.cpp
-msgid "Dutch"
-msgstr "Ολλανδικά"
-
-#: src/Preferences.cpp
-msgid "English (U.K.)"
-msgstr "Αγγλικά (Ην. Βασίλειο)"
-
-#: src/Preferences.cpp
-#, fuzzy
-msgid "English (U.S.)"
-msgstr "Αγγλικά (Ην. Βασίλειο)"
-
-#: src/Preferences.cpp
-msgid "Estonian"
-msgstr "Εσθονικά"
-
-#: src/Preferences.cpp
-msgid "Finnish"
-msgstr "Φιλανδικά"
-
-#: src/Preferences.cpp
-msgid "French"
-msgstr "Γαλλικά"
-
-#: src/Preferences.cpp
-msgid "Galician"
-msgstr "Γαλικιακά"
-
-#: src/Preferences.cpp
-msgid "German"
-msgstr "Γερμανικά"
-
-#: src/Preferences.cpp
-msgid "Greek"
-msgstr "Ελληνικά"
-
-#: src/Preferences.cpp
-msgid "Hebrew"
-msgstr "Εβραϊκά"
-
-#: src/Preferences.cpp
-msgid "Hungarian"
-msgstr "Ουγγαρέζικα"
-
-#: src/Preferences.cpp
-msgid "Italian"
-msgstr "Ιταλικά"
-
-#: src/Preferences.cpp
-msgid "Japanese"
-msgstr "Γιαπωνέζικα"
-
-#: src/Preferences.cpp
-msgid "Korean"
-msgstr "Κορεάτικα"
-
-#: src/Preferences.cpp
-msgid "Latvian"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Lithuanian"
-msgstr "Λιθουανικά"
-
-#: src/Preferences.cpp
-msgid "Norwegian (Nynorsk)"
-msgstr "Νορβηγικά"
-
-#: src/Preferences.cpp
-msgid "Polish"
-msgstr "Πολωνέζικα"
-
-#: src/Preferences.cpp
-msgid "Portuguese"
-msgstr "Πορτογαλλικά"
-
-#: src/Preferences.cpp
-msgid "Portuguese (Brazilian)"
-msgstr "Πορτογαλλικά (Βραζιλίας)"
-
-#: src/Preferences.cpp
-#, fuzzy
-msgid "Romanian"
-msgstr "Αλβανικά"
-
-#: src/Preferences.cpp
-msgid "Russian"
-msgstr "Ρωσικά"
-
-#: src/Preferences.cpp
-msgid "Slovenian"
-msgstr "Σλοβένικα"
-
-#: src/Preferences.cpp
-msgid "Spanish"
-msgstr "Ισπανικά"
-
-#: src/Preferences.cpp
-msgid "Swedish"
-msgstr "Σουηδικά"
-
-#: src/Preferences.cpp
-msgid "Turkish"
-msgstr "Τούρκικα"
-
-#: src/Preferences.cpp
-msgid "Ukrainian"
-msgstr ""
-
-#: src/Preferences.cpp
-#, fuzzy
-msgid "Change Language"
-msgstr "Γλώσσα"
-
-#: src/Preferences.cpp
-msgid "There are no translations installed for aMule"
-msgstr ""
-
-#: src/Preferences.cpp
-#, fuzzy
-msgid "No languages available"
-msgstr "Δεν είναι διαθέσιμο"
-
-#: src/Preferences.cpp
 msgid "no options available"
 msgstr "Δεν υπάρχουν επιλογές"
 
@@ -6601,7 +6629,8 @@ msgstr ""
 msgid "Confirm shared folders"
 msgstr "Κοινόχρηστα αρχεία"
 
-#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp src/SharedFilesReloadProgress.cpp
+#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp
+#: src/SharedFilesReloadProgress.cpp
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "Επαναφόρτωση των κοινόχρηστων αρχείων"
@@ -9365,6 +9394,14 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#, fuzzy
+#~ msgid "Change Language"
+#~ msgstr "Γλώσσα"
+
+#, fuzzy
+#~ msgid "No languages available"
+#~ msgstr "Δεν είναι διαθέσιμο"
 
 #~ msgid "User name"
 #~ msgstr "Όνομα χρήστη"

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-05 12:01+0200\n"
+"POT-Creation-Date: 2026-09-06 14:35+0200\n"
 "PO-Revision-Date: 2020-03-04 14:43+0100\n"
 "Last-Translator: Dévai Tamás <devait@vnet.hu>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -3111,6 +3111,162 @@ msgstr ""
 msgid "Invalid entry in known file list, file may be corrupt: "
 msgstr ""
 
+#: src/LanguageList.cpp
+msgid "System default"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Albanian"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Arabic"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Asturian"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Basque"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Bulgarian"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Catalan"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Chinese (Simplified)"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Chinese (Traditional)"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Croatian"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Czech"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Danish"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Dutch"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "English (U.K.)"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "English (U.S.)"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Estonian"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Finnish"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "French"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Galician"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "German"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Greek"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Hebrew"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Hungarian"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Italian"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Japanese"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Korean"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Latvian"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Lithuanian"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Norwegian (Nynorsk)"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Polish"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Portuguese"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Portuguese (Brazilian)"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Romanian"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Russian"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Slovenian"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Spanish"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Swedish"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Turkish"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Ukrainian"
+msgstr ""
+
 #: src/libs/common/Format.cpp
 #, c-format
 msgid "Unknown error %d"
@@ -5765,174 +5921,6 @@ msgstr ""
 #: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Failed to open partfile '%s'"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "System default"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Albanian"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Arabic"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Asturian"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Basque"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Bulgarian"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Catalan"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Chinese (Simplified)"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Chinese (Traditional)"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Croatian"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Czech"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Danish"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Dutch"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "English (U.K.)"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "English (U.S.)"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Estonian"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Finnish"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "French"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Galician"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "German"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Greek"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Hebrew"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Hungarian"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Italian"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Japanese"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Korean"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Latvian"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Lithuanian"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Norwegian (Nynorsk)"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Polish"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Portuguese"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Portuguese (Brazilian)"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Romanian"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Russian"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Slovenian"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Spanish"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Swedish"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Turkish"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Ukrainian"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Change Language"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "There are no translations installed for aMule"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "No languages available"
 msgstr ""
 
 #: src/Preferences.cpp

--- a/po/es.po
+++ b/po/es.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-05 12:01+0200\n"
+"POT-Creation-Date: 2026-09-06 14:35+0200\n"
 "PO-Revision-Date: 2026-09-05 10:49+0000\n"
 "Last-Translator: Diego Heras <ngosang@hotmail.es>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/amule/amule-application/es/>\n"
@@ -393,7 +393,8 @@ msgstr "servidor web corriendo con pid: %d"
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Ha solicitado ejecutar el servidor web al inicio pero no se puede ejecutar el binario amuleweb. Por favor, instale el paquete que contiene el servidor web de aMule, o compile aMule desde el código fuente con -DBUILD_WEBSERVER=YES e instálelo."
 
-#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
+#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
+#: src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
 msgid "ERROR"
 msgstr "ERROR"
 
@@ -679,7 +680,8 @@ msgstr "Redes"
 msgid "Searches"
 msgstr "Búsquedas"
 
-#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/Statistics.cpp
+#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/Statistics.cpp
 msgid "Downloads"
 msgstr "Descargas"
 
@@ -767,7 +769,9 @@ msgstr "Kad: apagado"
 msgid "Core"
 msgstr "Núcleo"
 
-#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp src/Statistics.cpp
+#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp src/Statistics.cpp
 msgid "Version"
 msgstr "Versión"
 
@@ -1064,7 +1068,11 @@ msgstr "No se puede crear el directorio '%s' para la categoría '%s', se mantien
 msgid "The remote core sent inconsistent data for \"%s\" (part status %d, expected %d). The file list may be showing the wrong information; reconnect to clear it."
 msgstr "El núcleo remoto envió datos inconsistentes para \"%s\" (Estado de la parte %d, esperado %d). La lista de archivos puede estar mostrando la información incorrecta; volver a conectarse para limpiarla."
 
-#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp src/Statistics.cpp
+#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp
+#: src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp
+#: src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp
+#: src/Statistics.cpp
 msgid "Unknown"
 msgstr "Desconocido"
 
@@ -1161,7 +1169,8 @@ msgstr "Error guardando el archivo %s: %s"
 msgid "Enter Captcha"
 msgstr "Introduzca el \"captcha\""
 
-#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp src/TransferWnd.cpp
+#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp
+#: src/TransferWnd.cpp
 msgid "Category"
 msgstr "Categoría"
 
@@ -1324,11 +1333,13 @@ msgstr "No se ha encontrado el archivo 'cryptkey.dat', se crea."
 msgid "Client Details"
 msgstr "Detalles del cliente"
 
-#: src/ClientDetailDialog.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
+#: src/utils/wxCas/src/onlinesig.cpp
 msgid "LowID"
 msgstr "Id Baja"
 
-#: src/ClientDetailDialog.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
+#: src/utils/wxCas/src/onlinesig.cpp
 msgid "HighID"
 msgstr "Id Alta"
 
@@ -1344,7 +1355,8 @@ msgstr "Soportada"
 msgid "Not supported"
 msgstr "No soportada"
 
-#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp src/TextClient.cpp
+#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
+#: src/TextClient.cpp
 msgid "Connected"
 msgstr "Conectado"
 
@@ -1352,7 +1364,8 @@ msgstr "Conectado"
 msgid "Disconnected"
 msgstr "Desconectado"
 
-#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f KiB/s"
 msgstr "%.1f KiB/s"
@@ -1369,7 +1382,8 @@ msgstr "Software"
 msgid "IP Address"
 msgstr "Dirección IP"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Origin"
 msgstr "Origen"
 
@@ -1385,11 +1399,13 @@ msgstr "Visto por última vez"
 msgid "Sessions"
 msgstr "Sesiones"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/SharedFilePeersListCtrl.cpp
 msgid "Upload Speed"
 msgstr "Velocidad de subida"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/SharedFilePeersListCtrl.cpp
 msgid "Download Speed"
 msgstr "Velocidad de descarga"
 
@@ -1440,11 +1456,13 @@ msgstr[1] "No se pudo solicitar a %u clientes seleccionados sus archivos compart
 msgid "Files"
 msgstr "Archivos"
 
-#: src/ClientsListCtrl.cpp src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientsListCtrl.cpp src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp
 msgid "Uploaded"
 msgstr "Subido"
 
-#: src/ClientsListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientsListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Downloaded"
 msgstr "Descargado"
 
@@ -1532,7 +1550,8 @@ msgstr "Comentarios del archivo"
 msgid "Username"
 msgstr "Nombre de usuario"
 
-#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp
+#: src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "File Name"
 msgstr "Nombre del archivo"
 
@@ -1593,15 +1612,18 @@ msgstr "Automática [Al]"
 msgid "Very low"
 msgstr "Muy baja"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Low"
 msgstr "Baja"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Normal"
 msgstr "Normal"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "High"
 msgstr "Alta"
 
@@ -1625,11 +1647,13 @@ msgstr "Conectando vía servidor"
 msgid "Queue Full"
 msgstr "Cola llena"
 
-#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp src/muuli_wdr.cpp
+#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp
+#: src/muuli_wdr.cpp
 msgid "On Queue"
 msgstr "En cola"
 
-#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
+#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp
+#: src/PartFile.cpp src/TransferWnd.cpp
 msgid "Downloading"
 msgstr "Descargando"
 
@@ -1689,7 +1713,8 @@ msgstr "Servidor local"
 msgid "Remote Server"
 msgstr "Servidor remoto"
 
-#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp src/TextClient.cpp
+#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp
+#: src/TextClient.cpp
 msgid "Kad"
 msgstr "Kad"
 
@@ -1713,7 +1738,8 @@ msgstr "Semillas fuente"
 msgid "Search Result"
 msgstr "Resultado de la búsqueda"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp
+#: src/TransferWnd.cpp
 msgid "Completed"
 msgstr "Completado"
 
@@ -1765,7 +1791,8 @@ msgstr "No se puede modificar dentro de una compartición recursiva"
 msgid "Part"
 msgstr "Parte"
 
-#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 msgid "Size"
 msgstr "Tamaño"
 
@@ -1773,7 +1800,8 @@ msgstr "Tamaño"
 msgid "Transferred"
 msgstr "Transferido"
 
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp src/SourceListCtrl.cpp
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
+#: src/SourceListCtrl.cpp
 msgid "Speed"
 msgstr "Velocidad"
 
@@ -1781,11 +1809,13 @@ msgstr "Velocidad"
 msgid "Progress"
 msgstr "Progreso"
 
-#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
+#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp
+#: src/SearchListCtrl.cpp
 msgid "Sources"
 msgstr "Fuentes"
 
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 msgid "Priority"
 msgstr "Prioridad"
 
@@ -1809,7 +1839,9 @@ msgstr "Última recepción"
 msgid "Auto"
 msgstr "Automática"
 
-#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/TransferWnd.cpp src/utils/wxCas/src/wxcasprefs.cpp
+#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/TransferWnd.cpp
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Cancel"
 msgstr "Cancelar"
 
@@ -1910,7 +1942,8 @@ msgstr "Introduzca el nuevo nombre para el archivo:"
 msgid "File rename"
 msgstr "Renombrar el archivo"
 
-#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f MiB/s"
 msgstr "%.1f MiB/s"
@@ -2713,11 +2746,13 @@ msgstr ""
 msgid "Start aMule automatically when I log in"
 msgstr "Iniciar aMule automáticamente al iniciar sesión"
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp packaging/windows/installer_strings.c
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: packaging/windows/installer_strings.c
 msgid "Register aMule for ed2k:// links"
 msgstr "Registrar aMule para los enlaces ed2k://"
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp packaging/windows/installer_strings.c
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: packaging/windows/installer_strings.c
 msgid "Register aMule for magnet: links"
 msgstr "Registrar aMule para los enlaces magnet:"
 
@@ -2745,7 +2780,8 @@ msgstr ""
 msgid "Destination folder for downloads"
 msgstr "Carpeta de destino para las descargas"
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Browse"
 msgstr "Examinar"
 
@@ -3167,6 +3203,162 @@ msgstr "Error al cargar una entrada de la lista de archivos conocidos, el archiv
 msgid "Invalid entry in known file list, file may be corrupt: "
 msgstr "Entrada inválida en lista de archivos conocidos, el archivo debe de estar dañado: "
 
+#: src/LanguageList.cpp
+msgid "System default"
+msgstr "Por defecto"
+
+#: src/LanguageList.cpp
+msgid "Albanian"
+msgstr "Albanés"
+
+#: src/LanguageList.cpp
+msgid "Arabic"
+msgstr "Árabe"
+
+#: src/LanguageList.cpp
+msgid "Asturian"
+msgstr "Asturiano"
+
+#: src/LanguageList.cpp
+msgid "Basque"
+msgstr "Euskera"
+
+#: src/LanguageList.cpp
+msgid "Bulgarian"
+msgstr "Búlgaro"
+
+#: src/LanguageList.cpp
+msgid "Catalan"
+msgstr "Catalán"
+
+#: src/LanguageList.cpp
+msgid "Chinese (Simplified)"
+msgstr "Chino (simplificado)"
+
+#: src/LanguageList.cpp
+msgid "Chinese (Traditional)"
+msgstr "Chino (tradicional)"
+
+#: src/LanguageList.cpp
+msgid "Croatian"
+msgstr "Croata"
+
+#: src/LanguageList.cpp
+msgid "Czech"
+msgstr "Checo"
+
+#: src/LanguageList.cpp
+msgid "Danish"
+msgstr "Danés"
+
+#: src/LanguageList.cpp
+msgid "Dutch"
+msgstr "Holandés"
+
+#: src/LanguageList.cpp
+msgid "English (U.K.)"
+msgstr "Inglés (Reino Unido)"
+
+#: src/LanguageList.cpp
+msgid "English (U.S.)"
+msgstr "Inglés (EE.UU.)"
+
+#: src/LanguageList.cpp
+msgid "Estonian"
+msgstr "Estonio"
+
+#: src/LanguageList.cpp
+msgid "Finnish"
+msgstr "Finés"
+
+#: src/LanguageList.cpp
+msgid "French"
+msgstr "Francés"
+
+#: src/LanguageList.cpp
+msgid "Galician"
+msgstr "Gallego"
+
+#: src/LanguageList.cpp
+msgid "German"
+msgstr "Alemán"
+
+#: src/LanguageList.cpp
+msgid "Greek"
+msgstr "Griego"
+
+#: src/LanguageList.cpp
+msgid "Hebrew"
+msgstr "Hebreo"
+
+#: src/LanguageList.cpp
+msgid "Hungarian"
+msgstr "Húngaro"
+
+#: src/LanguageList.cpp
+msgid "Italian"
+msgstr "Italiano"
+
+#: src/LanguageList.cpp
+msgid "Japanese"
+msgstr "Japonés"
+
+#: src/LanguageList.cpp
+msgid "Korean"
+msgstr "Coreano"
+
+#: src/LanguageList.cpp
+msgid "Latvian"
+msgstr "Letón"
+
+#: src/LanguageList.cpp
+msgid "Lithuanian"
+msgstr "Lituano"
+
+#: src/LanguageList.cpp
+msgid "Norwegian (Nynorsk)"
+msgstr "Noruego (Nynorsk)"
+
+#: src/LanguageList.cpp
+msgid "Polish"
+msgstr "Polaco"
+
+#: src/LanguageList.cpp
+msgid "Portuguese"
+msgstr "Portugués"
+
+#: src/LanguageList.cpp
+msgid "Portuguese (Brazilian)"
+msgstr "Portugués (brasileño)"
+
+#: src/LanguageList.cpp
+msgid "Romanian"
+msgstr "Rumano"
+
+#: src/LanguageList.cpp
+msgid "Russian"
+msgstr "Ruso"
+
+#: src/LanguageList.cpp
+msgid "Slovenian"
+msgstr "Esloveno"
+
+#: src/LanguageList.cpp
+msgid "Spanish"
+msgstr "Español"
+
+#: src/LanguageList.cpp
+msgid "Swedish"
+msgstr "Sueco"
+
+#: src/LanguageList.cpp
+msgid "Turkish"
+msgstr "Turco"
+
+#: src/LanguageList.cpp
+msgid "Ukrainian"
+msgstr "Ucraniano"
+
 #: src/libs/common/Format.cpp
 #, c-format
 msgid "Unknown error %d"
@@ -3189,15 +3381,18 @@ msgstr "Completando"
 msgid "Complete"
 msgstr "Completado"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Paused"
 msgstr "Pausado"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Erroneous"
 msgstr "Erróneo"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Waiting"
 msgstr "Esperando"
 
@@ -3359,7 +3554,8 @@ msgstr "Cerrar"
 msgid "Cut"
 msgstr "Cortar"
 
-#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp src/utils/aLinkCreator/src/alcframe.cpp
+#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy"
 msgstr "Copiar"
 
@@ -3367,7 +3563,8 @@ msgstr "Copiar"
 msgid "Paste"
 msgstr "Pegar"
 
-#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
+#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Clear"
 msgstr "Limpiar"
 
@@ -3375,7 +3572,8 @@ msgstr "Limpiar"
 msgid "Select All"
 msgstr "Seleccionar todo"
 
-#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp src/StatisticsDlg.cpp
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
+#: src/StatisticsDlg.cpp
 msgid "KiB/s"
 msgstr "KiB/s"
 
@@ -5841,174 +6039,6 @@ msgid "ERROR: Failed to open partfile '%s'"
 msgstr "ERROR: no se ha podido abrir el archivo de partes '%s'"
 
 #: src/Preferences.cpp
-msgid "System default"
-msgstr "Por defecto"
-
-#: src/Preferences.cpp
-msgid "Albanian"
-msgstr "Albanés"
-
-#: src/Preferences.cpp
-msgid "Arabic"
-msgstr "Árabe"
-
-#: src/Preferences.cpp
-msgid "Asturian"
-msgstr "Asturiano"
-
-#: src/Preferences.cpp
-msgid "Basque"
-msgstr "Euskera"
-
-#: src/Preferences.cpp
-msgid "Bulgarian"
-msgstr "Búlgaro"
-
-#: src/Preferences.cpp
-msgid "Catalan"
-msgstr "Catalán"
-
-#: src/Preferences.cpp
-msgid "Chinese (Simplified)"
-msgstr "Chino (simplificado)"
-
-#: src/Preferences.cpp
-msgid "Chinese (Traditional)"
-msgstr "Chino (tradicional)"
-
-#: src/Preferences.cpp
-msgid "Croatian"
-msgstr "Croata"
-
-#: src/Preferences.cpp
-msgid "Czech"
-msgstr "Checo"
-
-#: src/Preferences.cpp
-msgid "Danish"
-msgstr "Danés"
-
-#: src/Preferences.cpp
-msgid "Dutch"
-msgstr "Holandés"
-
-#: src/Preferences.cpp
-msgid "English (U.K.)"
-msgstr "Inglés (Reino Unido)"
-
-#: src/Preferences.cpp
-msgid "English (U.S.)"
-msgstr "Inglés (EE.UU.)"
-
-#: src/Preferences.cpp
-msgid "Estonian"
-msgstr "Estonio"
-
-#: src/Preferences.cpp
-msgid "Finnish"
-msgstr "Finés"
-
-#: src/Preferences.cpp
-msgid "French"
-msgstr "Francés"
-
-#: src/Preferences.cpp
-msgid "Galician"
-msgstr "Gallego"
-
-#: src/Preferences.cpp
-msgid "German"
-msgstr "Alemán"
-
-#: src/Preferences.cpp
-msgid "Greek"
-msgstr "Griego"
-
-#: src/Preferences.cpp
-msgid "Hebrew"
-msgstr "Hebreo"
-
-#: src/Preferences.cpp
-msgid "Hungarian"
-msgstr "Húngaro"
-
-#: src/Preferences.cpp
-msgid "Italian"
-msgstr "Italiano"
-
-#: src/Preferences.cpp
-msgid "Japanese"
-msgstr "Japonés"
-
-#: src/Preferences.cpp
-msgid "Korean"
-msgstr "Coreano"
-
-#: src/Preferences.cpp
-msgid "Latvian"
-msgstr "Letón"
-
-#: src/Preferences.cpp
-msgid "Lithuanian"
-msgstr "Lituano"
-
-#: src/Preferences.cpp
-msgid "Norwegian (Nynorsk)"
-msgstr "Noruego (Nynorsk)"
-
-#: src/Preferences.cpp
-msgid "Polish"
-msgstr "Polaco"
-
-#: src/Preferences.cpp
-msgid "Portuguese"
-msgstr "Portugués"
-
-#: src/Preferences.cpp
-msgid "Portuguese (Brazilian)"
-msgstr "Portugués (brasileño)"
-
-#: src/Preferences.cpp
-msgid "Romanian"
-msgstr "Rumano"
-
-#: src/Preferences.cpp
-msgid "Russian"
-msgstr "Ruso"
-
-#: src/Preferences.cpp
-msgid "Slovenian"
-msgstr "Esloveno"
-
-#: src/Preferences.cpp
-msgid "Spanish"
-msgstr "Español"
-
-#: src/Preferences.cpp
-msgid "Swedish"
-msgstr "Sueco"
-
-#: src/Preferences.cpp
-msgid "Turkish"
-msgstr "Turco"
-
-#: src/Preferences.cpp
-msgid "Ukrainian"
-msgstr "Ucraniano"
-
-#: src/Preferences.cpp
-msgid "Change Language"
-msgstr "Cambiar el idioma"
-
-#: src/Preferences.cpp
-msgid "There are no translations installed for aMule"
-msgstr "No hay traducciones instaladas para aMule"
-
-#: src/Preferences.cpp
-msgid "No languages available"
-msgstr "No hay idiomas disponibles"
-
-#: src/Preferences.cpp
 msgid "no options available"
 msgstr "no hay opciones disponibles"
 
@@ -6510,7 +6540,8 @@ msgstr "Compartirlas recursivamente publicará todos los archivos en las redes e
 msgid "Confirm shared folders"
 msgstr "Confirmar carpetas compartidas"
 
-#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp src/SharedFilesReloadProgress.cpp
+#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp
+#: src/SharedFilesReloadProgress.cpp
 msgid "Reloading shared files..."
 msgstr "Recargando los archivos compartidos..."
 
@@ -9240,6 +9271,15 @@ msgstr "aMule parece estar en ejecución. Por favor, ciérrelo y vuelva a ejecut
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "Eliminando los datos de usuario en $APPDATA\\aMule..."
+
+#~ msgid "Change Language"
+#~ msgstr "Cambiar el idioma"
+
+#~ msgid "There are no translations installed for aMule"
+#~ msgstr "No hay traducciones instaladas para aMule"
+
+#~ msgid "No languages available"
+#~ msgstr "No hay idiomas disponibles"
 
 #~ msgid "User name"
 #~ msgstr "Nombre de usuario"

--- a/po/et_EE.po
+++ b/po/et_EE.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-05 12:01+0200\n"
+"POT-Creation-Date: 2026-09-06 14:35+0200\n"
 "PO-Revision-Date: 2026-09-05 10:49+0000\n"
 "Last-Translator: \n"
 "Language-Team: Estonian <kde-i18n-doc@kde.org>\n"
@@ -387,7 +387,8 @@ msgstr "web server töötab protsessi id'ga %d"
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Soovisid et web server käivitataks käivitumisel, kuid amuleweb programm pole võimeline käivituma. Palun paigalada versioon mis sisaldab aMule web serverit või kompileeri aMule kasutades võtit --enable-webserver ja seejärel make install"
 
-#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
+#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
+#: src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
 msgid "ERROR"
 msgstr "VIGA"
 
@@ -675,7 +676,8 @@ msgstr "Võrgud"
 msgid "Searches"
 msgstr "Otsingud"
 
-#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/Statistics.cpp
+#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/Statistics.cpp
 msgid "Downloads"
 msgstr "Tõmbamised"
 
@@ -759,7 +761,9 @@ msgstr "Kad: Väljas"
 msgid "Core"
 msgstr ""
 
-#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp src/Statistics.cpp
+#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp src/Statistics.cpp
 msgid "Version"
 msgstr "Versioon"
 
@@ -1058,7 +1062,11 @@ msgstr "Ei suuda luua kataloogi '%s' '%s' kategooria jaoks, säilitan '%s' katal
 msgid "The remote core sent inconsistent data for \"%s\" (part status %d, expected %d). The file list may be showing the wrong information; reconnect to clear it."
 msgstr ""
 
-#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp src/Statistics.cpp
+#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp
+#: src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp
+#: src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp
+#: src/Statistics.cpp
 msgid "Unknown"
 msgstr "Teadmata"
 
@@ -1155,7 +1163,8 @@ msgstr "VIGA: tekkis %s faili salvestamisel: %s"
 msgid "Enter Captcha"
 msgstr "Sisesta inimtesti kontrollkood"
 
-#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp src/TransferWnd.cpp
+#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp
+#: src/TransferWnd.cpp
 msgid "Category"
 msgstr "Kategooria"
 
@@ -1319,11 +1328,13 @@ msgstr "Ei leidnud 'cryptkey.dat' faili, loon uue."
 msgid "Client Details"
 msgstr "Kliendi detailid"
 
-#: src/ClientDetailDialog.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
+#: src/utils/wxCas/src/onlinesig.cpp
 msgid "LowID"
 msgstr "LowID"
 
-#: src/ClientDetailDialog.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
+#: src/utils/wxCas/src/onlinesig.cpp
 msgid "HighID"
 msgstr "HighID"
 
@@ -1339,7 +1350,8 @@ msgstr "Toetatud"
 msgid "Not supported"
 msgstr "Pole toetatud"
 
-#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp src/TextClient.cpp
+#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
+#: src/TextClient.cpp
 msgid "Connected"
 msgstr "Ühendatud"
 
@@ -1347,7 +1359,8 @@ msgstr "Ühendatud"
 msgid "Disconnected"
 msgstr "Pole ühendust"
 
-#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f KiB/s"
 msgstr ""
@@ -1364,7 +1377,8 @@ msgstr ""
 msgid "IP Address"
 msgstr "IP Aadress"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Origin"
 msgstr "Allikas"
 
@@ -1382,11 +1396,13 @@ msgstr "Viimane vastuvõtt"
 msgid "Sessions"
 msgstr "Versioon"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/SharedFilePeersListCtrl.cpp
 msgid "Upload Speed"
 msgstr "Saatmise kiirus"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/SharedFilePeersListCtrl.cpp
 msgid "Download Speed"
 msgstr "Tõmbamise kiirus"
 
@@ -1441,11 +1457,13 @@ msgstr[1] ""
 msgid "Files"
 msgstr "Failid"
 
-#: src/ClientsListCtrl.cpp src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientsListCtrl.cpp src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp
 msgid "Uploaded"
 msgstr "Üleslaaditud"
 
-#: src/ClientsListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientsListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Downloaded"
 msgstr "Allalaetud"
 
@@ -1536,7 +1554,8 @@ msgstr "Faili kommentaarid"
 msgid "Username"
 msgstr "Kasutajanimi"
 
-#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp
+#: src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "File Name"
 msgstr "Faili nimi"
 
@@ -1598,15 +1617,18 @@ msgstr "Auto [Kõrge]"
 msgid "Very low"
 msgstr "Väga madal"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Low"
 msgstr "Madal"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Normal"
 msgstr "Keskmine"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "High"
 msgstr "Kõrge"
 
@@ -1630,11 +1652,13 @@ msgstr "Ühendun serveri kaudu"
 msgid "Queue Full"
 msgstr "Järjekord täis"
 
-#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp src/muuli_wdr.cpp
+#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp
+#: src/muuli_wdr.cpp
 msgid "On Queue"
 msgstr "Järjekorras"
 
-#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
+#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp
+#: src/PartFile.cpp src/TransferWnd.cpp
 msgid "Downloading"
 msgstr "Tõmban"
 
@@ -1694,7 +1718,8 @@ msgstr "Kohalik server"
 msgid "Remote Server"
 msgstr "Kaug server"
 
-#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp src/TextClient.cpp
+#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp
+#: src/TextClient.cpp
 msgid "Kad"
 msgstr "Kad"
 
@@ -1718,7 +1743,8 @@ msgstr "Allikaid"
 msgid "Search Result"
 msgstr "Otsingu tulemus"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp
+#: src/TransferWnd.cpp
 msgid "Completed"
 msgstr "Valmis"
 
@@ -1771,7 +1797,8 @@ msgstr ""
 msgid "Part"
 msgstr "Osa"
 
-#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 msgid "Size"
 msgstr "Suurus"
 
@@ -1779,7 +1806,8 @@ msgstr "Suurus"
 msgid "Transferred"
 msgstr "Siiratud"
 
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp src/SourceListCtrl.cpp
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
+#: src/SourceListCtrl.cpp
 msgid "Speed"
 msgstr "Kiirus"
 
@@ -1787,11 +1815,13 @@ msgstr "Kiirus"
 msgid "Progress"
 msgstr "Edenemine"
 
-#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
+#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp
+#: src/SearchListCtrl.cpp
 msgid "Sources"
 msgstr "Allikaid"
 
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 msgid "Priority"
 msgstr "Prioriteet"
 
@@ -1815,7 +1845,9 @@ msgstr "Viimane vastuvõtt"
 msgid "Auto"
 msgstr "Auto"
 
-#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/TransferWnd.cpp src/utils/wxCas/src/wxcasprefs.cpp
+#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/TransferWnd.cpp
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Cancel"
 msgstr "Loobu"
 
@@ -1916,7 +1948,8 @@ msgstr "Sisesta selle faili uus nimi:"
 msgid "File rename"
 msgstr "Faili ümbernimetamine"
 
-#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f MiB/s"
 msgstr ""
@@ -2721,11 +2754,13 @@ msgstr ""
 msgid "Start aMule automatically when I log in"
 msgstr ""
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp packaging/windows/installer_strings.c
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: packaging/windows/installer_strings.c
 msgid "Register aMule for ed2k:// links"
 msgstr ""
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp packaging/windows/installer_strings.c
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: packaging/windows/installer_strings.c
 msgid "Register aMule for magnet: links"
 msgstr ""
 
@@ -2751,7 +2786,8 @@ msgstr ""
 msgid "Destination folder for downloads"
 msgstr "Tõmmatavate failide kataloog"
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Browse"
 msgstr "Lehitse"
 
@@ -3172,6 +3208,163 @@ msgstr "Tuntud falide loetelu laadimine ebaõnnestus, fail võib olla vigane"
 msgid "Invalid entry in known file list, file may be corrupt: "
 msgstr "Tuntud falide loetelus vigane kirje, fail võib olla vigane: "
 
+#: src/LanguageList.cpp
+msgid "System default"
+msgstr "Süsteemi vaikeväärtus"
+
+#: src/LanguageList.cpp
+msgid "Albanian"
+msgstr "Albaania"
+
+#: src/LanguageList.cpp
+msgid "Arabic"
+msgstr "Araabia"
+
+#: src/LanguageList.cpp
+msgid "Asturian"
+msgstr "Asturia"
+
+#: src/LanguageList.cpp
+msgid "Basque"
+msgstr "Baski"
+
+#: src/LanguageList.cpp
+msgid "Bulgarian"
+msgstr "Bulgaaria"
+
+#: src/LanguageList.cpp
+msgid "Catalan"
+msgstr "Kataloonia"
+
+#: src/LanguageList.cpp
+msgid "Chinese (Simplified)"
+msgstr "Hiina (Lihtsustatud)"
+
+#: src/LanguageList.cpp
+msgid "Chinese (Traditional)"
+msgstr "Hiina (Traditsiooniline)"
+
+#: src/LanguageList.cpp
+msgid "Croatian"
+msgstr "Kroaatia"
+
+#: src/LanguageList.cpp
+msgid "Czech"
+msgstr "Tšehhi"
+
+#: src/LanguageList.cpp
+msgid "Danish"
+msgstr "Taani"
+
+#: src/LanguageList.cpp
+msgid "Dutch"
+msgstr "Hollandi"
+
+#: src/LanguageList.cpp
+msgid "English (U.K.)"
+msgstr "Inglise (U.K.)"
+
+#: src/LanguageList.cpp
+#, fuzzy
+msgid "English (U.S.)"
+msgstr "Inglise (U.K.)"
+
+#: src/LanguageList.cpp
+msgid "Estonian"
+msgstr "Eesti"
+
+#: src/LanguageList.cpp
+msgid "Finnish"
+msgstr "Soome"
+
+#: src/LanguageList.cpp
+msgid "French"
+msgstr "Prantsuse"
+
+#: src/LanguageList.cpp
+msgid "Galician"
+msgstr "Galiitsia"
+
+#: src/LanguageList.cpp
+msgid "German"
+msgstr "Saksa"
+
+#: src/LanguageList.cpp
+msgid "Greek"
+msgstr "Kreeka"
+
+#: src/LanguageList.cpp
+msgid "Hebrew"
+msgstr "Heebrea"
+
+#: src/LanguageList.cpp
+msgid "Hungarian"
+msgstr "Ungari"
+
+#: src/LanguageList.cpp
+msgid "Italian"
+msgstr "Itaalia"
+
+#: src/LanguageList.cpp
+msgid "Japanese"
+msgstr "Jaapani"
+
+#: src/LanguageList.cpp
+msgid "Korean"
+msgstr "Korea"
+
+#: src/LanguageList.cpp
+msgid "Latvian"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Lithuanian"
+msgstr "Leedu"
+
+#: src/LanguageList.cpp
+msgid "Norwegian (Nynorsk)"
+msgstr "Norra"
+
+#: src/LanguageList.cpp
+msgid "Polish"
+msgstr "Poola"
+
+#: src/LanguageList.cpp
+msgid "Portuguese"
+msgstr "Portugali"
+
+#: src/LanguageList.cpp
+msgid "Portuguese (Brazilian)"
+msgstr "Portugali (Brasiilia)"
+
+#: src/LanguageList.cpp
+msgid "Romanian"
+msgstr "Rumeenia"
+
+#: src/LanguageList.cpp
+msgid "Russian"
+msgstr "Vene"
+
+#: src/LanguageList.cpp
+msgid "Slovenian"
+msgstr "Sloveenia"
+
+#: src/LanguageList.cpp
+msgid "Spanish"
+msgstr "Hispaania"
+
+#: src/LanguageList.cpp
+msgid "Swedish"
+msgstr "Rootsi"
+
+#: src/LanguageList.cpp
+msgid "Turkish"
+msgstr "Türgi"
+
+#: src/LanguageList.cpp
+msgid "Ukrainian"
+msgstr "Ukraina"
+
 #: src/libs/common/Format.cpp
 #, fuzzy, c-format
 msgid "Unknown error %d"
@@ -3194,15 +3387,18 @@ msgstr "Lõpetatud"
 msgid "Complete"
 msgstr "Valmis"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Paused"
 msgstr "Peatatud"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Erroneous"
 msgstr "Vigane"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Waiting"
 msgstr "Ootan"
 
@@ -3366,7 +3562,8 @@ msgstr "Sulge"
 msgid "Cut"
 msgstr "Lõika"
 
-#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp src/utils/aLinkCreator/src/alcframe.cpp
+#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy"
 msgstr "Kopeeri"
 
@@ -3374,7 +3571,8 @@ msgstr "Kopeeri"
 msgid "Paste"
 msgstr "Aseta"
 
-#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
+#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Clear"
 msgstr "Puhasta"
 
@@ -3382,7 +3580,8 @@ msgstr "Puhasta"
 msgid "Select All"
 msgstr "Vali kõik"
 
-#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp src/StatisticsDlg.cpp
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
+#: src/StatisticsDlg.cpp
 msgid "KiB/s"
 msgstr ""
 
@@ -5881,176 +6080,6 @@ msgid "ERROR: Failed to open partfile '%s'"
 msgstr "VIGA: Osafaili '%s' avamine ebaõnnestus"
 
 #: src/Preferences.cpp
-msgid "System default"
-msgstr "Süsteemi vaikeväärtus"
-
-#: src/Preferences.cpp
-msgid "Albanian"
-msgstr "Albaania"
-
-#: src/Preferences.cpp
-msgid "Arabic"
-msgstr "Araabia"
-
-#: src/Preferences.cpp
-msgid "Asturian"
-msgstr "Asturia"
-
-#: src/Preferences.cpp
-msgid "Basque"
-msgstr "Baski"
-
-#: src/Preferences.cpp
-msgid "Bulgarian"
-msgstr "Bulgaaria"
-
-#: src/Preferences.cpp
-msgid "Catalan"
-msgstr "Kataloonia"
-
-#: src/Preferences.cpp
-msgid "Chinese (Simplified)"
-msgstr "Hiina (Lihtsustatud)"
-
-#: src/Preferences.cpp
-msgid "Chinese (Traditional)"
-msgstr "Hiina (Traditsiooniline)"
-
-#: src/Preferences.cpp
-msgid "Croatian"
-msgstr "Kroaatia"
-
-#: src/Preferences.cpp
-msgid "Czech"
-msgstr "Tšehhi"
-
-#: src/Preferences.cpp
-msgid "Danish"
-msgstr "Taani"
-
-#: src/Preferences.cpp
-msgid "Dutch"
-msgstr "Hollandi"
-
-#: src/Preferences.cpp
-msgid "English (U.K.)"
-msgstr "Inglise (U.K.)"
-
-#: src/Preferences.cpp
-#, fuzzy
-msgid "English (U.S.)"
-msgstr "Inglise (U.K.)"
-
-#: src/Preferences.cpp
-msgid "Estonian"
-msgstr "Eesti"
-
-#: src/Preferences.cpp
-msgid "Finnish"
-msgstr "Soome"
-
-#: src/Preferences.cpp
-msgid "French"
-msgstr "Prantsuse"
-
-#: src/Preferences.cpp
-msgid "Galician"
-msgstr "Galiitsia"
-
-#: src/Preferences.cpp
-msgid "German"
-msgstr "Saksa"
-
-#: src/Preferences.cpp
-msgid "Greek"
-msgstr "Kreeka"
-
-#: src/Preferences.cpp
-msgid "Hebrew"
-msgstr "Heebrea"
-
-#: src/Preferences.cpp
-msgid "Hungarian"
-msgstr "Ungari"
-
-#: src/Preferences.cpp
-msgid "Italian"
-msgstr "Itaalia"
-
-#: src/Preferences.cpp
-msgid "Japanese"
-msgstr "Jaapani"
-
-#: src/Preferences.cpp
-msgid "Korean"
-msgstr "Korea"
-
-#: src/Preferences.cpp
-msgid "Latvian"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Lithuanian"
-msgstr "Leedu"
-
-#: src/Preferences.cpp
-msgid "Norwegian (Nynorsk)"
-msgstr "Norra"
-
-#: src/Preferences.cpp
-msgid "Polish"
-msgstr "Poola"
-
-#: src/Preferences.cpp
-msgid "Portuguese"
-msgstr "Portugali"
-
-#: src/Preferences.cpp
-msgid "Portuguese (Brazilian)"
-msgstr "Portugali (Brasiilia)"
-
-#: src/Preferences.cpp
-msgid "Romanian"
-msgstr "Rumeenia"
-
-#: src/Preferences.cpp
-msgid "Russian"
-msgstr "Vene"
-
-#: src/Preferences.cpp
-msgid "Slovenian"
-msgstr "Sloveenia"
-
-#: src/Preferences.cpp
-msgid "Spanish"
-msgstr "Hispaania"
-
-#: src/Preferences.cpp
-msgid "Swedish"
-msgstr "Rootsi"
-
-#: src/Preferences.cpp
-msgid "Turkish"
-msgstr "Türgi"
-
-#: src/Preferences.cpp
-msgid "Ukrainian"
-msgstr "Ukraina"
-
-#: src/Preferences.cpp
-msgid "Change Language"
-msgstr "Muuda keel"
-
-#: src/Preferences.cpp
-msgid "There are no translations installed for aMule"
-msgstr ""
-
-#: src/Preferences.cpp
-#, fuzzy
-msgid "No languages available"
-msgstr "Info puudub"
-
-#: src/Preferences.cpp
 msgid "no options available"
 msgstr "valikud puuduvad"
 
@@ -6563,7 +6592,8 @@ msgstr ""
 msgid "Confirm shared folders"
 msgstr "Jagatud kataloogid"
 
-#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp src/SharedFilesReloadProgress.cpp
+#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp
+#: src/SharedFilesReloadProgress.cpp
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "Lae oma jagatud failid uuesti"
@@ -9295,6 +9325,13 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "Change Language"
+#~ msgstr "Muuda keel"
+
+#, fuzzy
+#~ msgid "No languages available"
+#~ msgstr "Info puudub"
 
 #~ msgid "User name"
 #~ msgstr "Kasutaja nimi"

--- a/po/eu.po
+++ b/po/eu.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-05 12:01+0200\n"
+"POT-Creation-Date: 2026-09-06 14:35+0200\n"
 "PO-Revision-Date: 2026-09-05 10:50+0000\n"
 "Last-Translator: Piarres Beobide <pi@beobide.net>\n"
 "Language-Team: Euskara <librezale@librezale.org>\n"
@@ -388,7 +388,8 @@ msgstr "web zerbitzaria abiarazirik %d pid-arekin"
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Abioan web-zerbitzaria exekutatzea eskatu duzu, baina amuleweb bitarra ezin da exekutatu. Mesedez instalatu amule web zerbitzaria duen paketea edo konpilatu ezazu amule --enable-webserver erabilian eta make install egin"
 
-#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
+#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
+#: src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
 msgid "ERROR"
 msgstr "ERROREA"
 
@@ -676,7 +677,8 @@ msgstr "Sareak"
 msgid "Searches"
 msgstr "Bilaketak"
 
-#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/Statistics.cpp
+#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/Statistics.cpp
 msgid "Downloads"
 msgstr "Deskargak"
 
@@ -760,7 +762,9 @@ msgstr "Kad: Itzalia"
 msgid "Core"
 msgstr ""
 
-#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp src/Statistics.cpp
+#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp src/Statistics.cpp
 msgid "Version"
 msgstr "Bertsioa"
 
@@ -1059,7 +1063,11 @@ msgstr "Ezin da '%s' direktorioa sortu '%s' kategoriarentzat, '%s' direktorioa m
 msgid "The remote core sent inconsistent data for \"%s\" (part status %d, expected %d). The file list may be showing the wrong information; reconnect to clear it."
 msgstr ""
 
-#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp src/Statistics.cpp
+#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp
+#: src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp
+#: src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp
+#: src/Statistics.cpp
 msgid "Unknown"
 msgstr "Ezezaguna"
 
@@ -1156,7 +1164,8 @@ msgstr "Errorea %s fitxategia gordetzerakoan: %s"
 msgid "Enter Captcha"
 msgstr "Idatzi kaptxa"
 
-#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp src/TransferWnd.cpp
+#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp
+#: src/TransferWnd.cpp
 msgid "Category"
 msgstr "Kategoria"
 
@@ -1320,11 +1329,13 @@ msgstr "Ez da 'cryptkey.dat' fitxategia aurkitu, sortzen."
 msgid "Client Details"
 msgstr "Bezero xehetasunak"
 
-#: src/ClientDetailDialog.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
+#: src/utils/wxCas/src/onlinesig.cpp
 msgid "LowID"
 msgstr "IDBaxua"
 
-#: src/ClientDetailDialog.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
+#: src/utils/wxCas/src/onlinesig.cpp
 msgid "HighID"
 msgstr "IDAltua"
 
@@ -1340,7 +1351,8 @@ msgstr "Onartua"
 msgid "Not supported"
 msgstr "Ez da onartzen"
 
-#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp src/TextClient.cpp
+#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
+#: src/TextClient.cpp
 msgid "Connected"
 msgstr "Konektaturik"
 
@@ -1348,7 +1360,8 @@ msgstr "Konektaturik"
 msgid "Disconnected"
 msgstr "Deskonektatuta"
 
-#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f KiB/s"
 msgstr ""
@@ -1365,7 +1378,8 @@ msgstr ""
 msgid "IP Address"
 msgstr "IP helbidea"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Origin"
 msgstr "Jatorria"
 
@@ -1383,11 +1397,13 @@ msgstr "Azkenez jasoa"
 msgid "Sessions"
 msgstr "Bertsioa"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/SharedFilePeersListCtrl.cpp
 msgid "Upload Speed"
 msgstr "Igoera abiadura"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/SharedFilePeersListCtrl.cpp
 msgid "Download Speed"
 msgstr "Deskarga abiadura"
 
@@ -1442,11 +1458,13 @@ msgstr[1] ""
 msgid "Files"
 msgstr "Fitxategiak"
 
-#: src/ClientsListCtrl.cpp src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientsListCtrl.cpp src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp
 msgid "Uploaded"
 msgstr "Igoa"
 
-#: src/ClientsListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientsListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Downloaded"
 msgstr "Deskargatua"
 
@@ -1537,7 +1555,8 @@ msgstr "Fitxategi Iruzkinak"
 msgid "Username"
 msgstr "Erabiltzaile izena"
 
-#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp
+#: src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "File Name"
 msgstr "Fitxategi izena"
 
@@ -1599,15 +1618,18 @@ msgstr "Auto[Alt]"
 msgid "Very low"
 msgstr "Oso txikia"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Low"
 msgstr "Baxua"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Normal"
 msgstr "Normala"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "High"
 msgstr "Altua"
 
@@ -1631,11 +1653,13 @@ msgstr "Konektatu zerbitzaria bidez"
 msgid "Queue Full"
 msgstr "Ilara Osoa"
 
-#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp src/muuli_wdr.cpp
+#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp
+#: src/muuli_wdr.cpp
 msgid "On Queue"
 msgstr "Ilaran"
 
-#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
+#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp
+#: src/PartFile.cpp src/TransferWnd.cpp
 msgid "Downloading"
 msgstr "Deskargatzen"
 
@@ -1695,7 +1719,8 @@ msgstr "Zerbitzari lokala"
 msgid "Remote Server"
 msgstr "Urruneko zerbitzaria"
 
-#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp src/TextClient.cpp
+#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp
+#: src/TextClient.cpp
 msgid "Kad"
 msgstr "Kad"
 
@@ -1719,7 +1744,8 @@ msgstr "Jatorri haziak"
 msgid "Search Result"
 msgstr "Bilaketa emaitza"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp
+#: src/TransferWnd.cpp
 msgid "Completed"
 msgstr "Amaitua"
 
@@ -1772,7 +1798,8 @@ msgstr ""
 msgid "Part"
 msgstr "Zatia"
 
-#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 msgid "Size"
 msgstr "Tamaina"
 
@@ -1780,7 +1807,8 @@ msgstr "Tamaina"
 msgid "Transferred"
 msgstr "Transferituta"
 
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp src/SourceListCtrl.cpp
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
+#: src/SourceListCtrl.cpp
 msgid "Speed"
 msgstr "Abiadura"
 
@@ -1788,11 +1816,13 @@ msgstr "Abiadura"
 msgid "Progress"
 msgstr "Egoera"
 
-#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
+#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp
+#: src/SearchListCtrl.cpp
 msgid "Sources"
 msgstr "Jatorriak"
 
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 msgid "Priority"
 msgstr "Lehentasuna"
 
@@ -1816,7 +1846,9 @@ msgstr "Azkenez jasoa"
 msgid "Auto"
 msgstr "Auto"
 
-#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/TransferWnd.cpp src/utils/wxCas/src/wxcasprefs.cpp
+#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/TransferWnd.cpp
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Cancel"
 msgstr "Utzi"
 
@@ -1917,7 +1949,8 @@ msgstr "Sar izen berri bat fitxategi honentzat:"
 msgid "File rename"
 msgstr "Fitxategia berrizendatu"
 
-#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f MiB/s"
 msgstr ""
@@ -2722,11 +2755,13 @@ msgstr ""
 msgid "Start aMule automatically when I log in"
 msgstr ""
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp packaging/windows/installer_strings.c
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: packaging/windows/installer_strings.c
 msgid "Register aMule for ed2k:// links"
 msgstr ""
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp packaging/windows/installer_strings.c
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: packaging/windows/installer_strings.c
 msgid "Register aMule for magnet: links"
 msgstr ""
 
@@ -2752,7 +2787,8 @@ msgstr ""
 msgid "Destination folder for downloads"
 msgstr "Deskargentzat helburu karpeta"
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Browse"
 msgstr "Arakatu"
 
@@ -3173,6 +3209,163 @@ msgstr "Huts fitxategi ezagunen zerrendako sarrera bat kargatzean, hondaturik eg
 msgid "Invalid entry in known file list, file may be corrupt: "
 msgstr "Okerreko sarrera fitxategi ezagunen zerrendako fitxategian, hondaturik egon liteke: "
 
+#: src/LanguageList.cpp
+msgid "System default"
+msgstr "Sistema lehenetsia"
+
+#: src/LanguageList.cpp
+msgid "Albanian"
+msgstr "Albaniera"
+
+#: src/LanguageList.cpp
+msgid "Arabic"
+msgstr "Arabiera"
+
+#: src/LanguageList.cpp
+msgid "Asturian"
+msgstr "Bablea"
+
+#: src/LanguageList.cpp
+msgid "Basque"
+msgstr "Euskara"
+
+#: src/LanguageList.cpp
+msgid "Bulgarian"
+msgstr "Bulgariera"
+
+#: src/LanguageList.cpp
+msgid "Catalan"
+msgstr "Katalana"
+
+#: src/LanguageList.cpp
+msgid "Chinese (Simplified)"
+msgstr "Txinatarra (Sinplea)"
+
+#: src/LanguageList.cpp
+msgid "Chinese (Traditional)"
+msgstr "Txinatarra (ohizkoa)"
+
+#: src/LanguageList.cpp
+msgid "Croatian"
+msgstr "Kroaziera"
+
+#: src/LanguageList.cpp
+msgid "Czech"
+msgstr "Txekiera"
+
+#: src/LanguageList.cpp
+msgid "Danish"
+msgstr "Daniera"
+
+#: src/LanguageList.cpp
+msgid "Dutch"
+msgstr "Nederlandera"
+
+#: src/LanguageList.cpp
+msgid "English (U.K.)"
+msgstr "Ingelesa (E.B.)"
+
+#: src/LanguageList.cpp
+#, fuzzy
+msgid "English (U.S.)"
+msgstr "Ingelesa (E.B.)"
+
+#: src/LanguageList.cpp
+msgid "Estonian"
+msgstr "Estoniera"
+
+#: src/LanguageList.cpp
+msgid "Finnish"
+msgstr "Finlandiera"
+
+#: src/LanguageList.cpp
+msgid "French"
+msgstr "Frantsesa"
+
+#: src/LanguageList.cpp
+msgid "Galician"
+msgstr "Galiziera"
+
+#: src/LanguageList.cpp
+msgid "German"
+msgstr "Alemana"
+
+#: src/LanguageList.cpp
+msgid "Greek"
+msgstr "Grekoa"
+
+#: src/LanguageList.cpp
+msgid "Hebrew"
+msgstr "Hebreera"
+
+#: src/LanguageList.cpp
+msgid "Hungarian"
+msgstr "Hungariera"
+
+#: src/LanguageList.cpp
+msgid "Italian"
+msgstr "Italiera"
+
+#: src/LanguageList.cpp
+msgid "Japanese"
+msgstr "Japoniera"
+
+#: src/LanguageList.cpp
+msgid "Korean"
+msgstr "Koreera"
+
+#: src/LanguageList.cpp
+msgid "Latvian"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Lithuanian"
+msgstr "Lituaniera"
+
+#: src/LanguageList.cpp
+msgid "Norwegian (Nynorsk)"
+msgstr "Norvegiera (Nynorsk)"
+
+#: src/LanguageList.cpp
+msgid "Polish"
+msgstr "Poloniera"
+
+#: src/LanguageList.cpp
+msgid "Portuguese"
+msgstr "Portugesa"
+
+#: src/LanguageList.cpp
+msgid "Portuguese (Brazilian)"
+msgstr "Portugesa (Brasildarra)"
+
+#: src/LanguageList.cpp
+msgid "Romanian"
+msgstr "Errumaniera"
+
+#: src/LanguageList.cpp
+msgid "Russian"
+msgstr "Errusiera"
+
+#: src/LanguageList.cpp
+msgid "Slovenian"
+msgstr "Esloveniera"
+
+#: src/LanguageList.cpp
+msgid "Spanish"
+msgstr "Gaztelera"
+
+#: src/LanguageList.cpp
+msgid "Swedish"
+msgstr "Suediera"
+
+#: src/LanguageList.cpp
+msgid "Turkish"
+msgstr "Turkiera"
+
+#: src/LanguageList.cpp
+msgid "Ukrainian"
+msgstr "Ukraniera"
+
 #: src/libs/common/Format.cpp
 #, c-format
 msgid "Unknown error %d"
@@ -3195,15 +3388,18 @@ msgstr "Osotzen"
 msgid "Complete"
 msgstr "Amaitua"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Paused"
 msgstr "Geraturik"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Erroneous"
 msgstr "Akasdun"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Waiting"
 msgstr "Zain"
 
@@ -3367,7 +3563,8 @@ msgstr "Itxi"
 msgid "Cut"
 msgstr "Ebaki"
 
-#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp src/utils/aLinkCreator/src/alcframe.cpp
+#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy"
 msgstr "Kopiatu"
 
@@ -3375,7 +3572,8 @@ msgstr "Kopiatu"
 msgid "Paste"
 msgstr "Itsatsi"
 
-#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
+#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Clear"
 msgstr "Garbitu"
 
@@ -3383,7 +3581,8 @@ msgstr "Garbitu"
 msgid "Select All"
 msgstr "Hautatu dena"
 
-#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp src/StatisticsDlg.cpp
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
+#: src/StatisticsDlg.cpp
 msgid "KiB/s"
 msgstr ""
 
@@ -5881,175 +6080,6 @@ msgid "ERROR: Failed to open partfile '%s'"
 msgstr "ERROREA: Huts '%s' zati fitxategia irekitzean"
 
 #: src/Preferences.cpp
-msgid "System default"
-msgstr "Sistema lehenetsia"
-
-#: src/Preferences.cpp
-msgid "Albanian"
-msgstr "Albaniera"
-
-#: src/Preferences.cpp
-msgid "Arabic"
-msgstr "Arabiera"
-
-#: src/Preferences.cpp
-msgid "Asturian"
-msgstr "Bablea"
-
-#: src/Preferences.cpp
-msgid "Basque"
-msgstr "Euskara"
-
-#: src/Preferences.cpp
-msgid "Bulgarian"
-msgstr "Bulgariera"
-
-#: src/Preferences.cpp
-msgid "Catalan"
-msgstr "Katalana"
-
-#: src/Preferences.cpp
-msgid "Chinese (Simplified)"
-msgstr "Txinatarra (Sinplea)"
-
-#: src/Preferences.cpp
-msgid "Chinese (Traditional)"
-msgstr "Txinatarra (ohizkoa)"
-
-#: src/Preferences.cpp
-msgid "Croatian"
-msgstr "Kroaziera"
-
-#: src/Preferences.cpp
-msgid "Czech"
-msgstr "Txekiera"
-
-#: src/Preferences.cpp
-msgid "Danish"
-msgstr "Daniera"
-
-#: src/Preferences.cpp
-msgid "Dutch"
-msgstr "Nederlandera"
-
-#: src/Preferences.cpp
-msgid "English (U.K.)"
-msgstr "Ingelesa (E.B.)"
-
-#: src/Preferences.cpp
-#, fuzzy
-msgid "English (U.S.)"
-msgstr "Ingelesa (E.B.)"
-
-#: src/Preferences.cpp
-msgid "Estonian"
-msgstr "Estoniera"
-
-#: src/Preferences.cpp
-msgid "Finnish"
-msgstr "Finlandiera"
-
-#: src/Preferences.cpp
-msgid "French"
-msgstr "Frantsesa"
-
-#: src/Preferences.cpp
-msgid "Galician"
-msgstr "Galiziera"
-
-#: src/Preferences.cpp
-msgid "German"
-msgstr "Alemana"
-
-#: src/Preferences.cpp
-msgid "Greek"
-msgstr "Grekoa"
-
-#: src/Preferences.cpp
-msgid "Hebrew"
-msgstr "Hebreera"
-
-#: src/Preferences.cpp
-msgid "Hungarian"
-msgstr "Hungariera"
-
-#: src/Preferences.cpp
-msgid "Italian"
-msgstr "Italiera"
-
-#: src/Preferences.cpp
-msgid "Japanese"
-msgstr "Japoniera"
-
-#: src/Preferences.cpp
-msgid "Korean"
-msgstr "Koreera"
-
-#: src/Preferences.cpp
-msgid "Latvian"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Lithuanian"
-msgstr "Lituaniera"
-
-#: src/Preferences.cpp
-msgid "Norwegian (Nynorsk)"
-msgstr "Norvegiera (Nynorsk)"
-
-#: src/Preferences.cpp
-msgid "Polish"
-msgstr "Poloniera"
-
-#: src/Preferences.cpp
-msgid "Portuguese"
-msgstr "Portugesa"
-
-#: src/Preferences.cpp
-msgid "Portuguese (Brazilian)"
-msgstr "Portugesa (Brasildarra)"
-
-#: src/Preferences.cpp
-msgid "Romanian"
-msgstr "Errumaniera"
-
-#: src/Preferences.cpp
-msgid "Russian"
-msgstr "Errusiera"
-
-#: src/Preferences.cpp
-msgid "Slovenian"
-msgstr "Esloveniera"
-
-#: src/Preferences.cpp
-msgid "Spanish"
-msgstr "Gaztelera"
-
-#: src/Preferences.cpp
-msgid "Swedish"
-msgstr "Suediera"
-
-#: src/Preferences.cpp
-msgid "Turkish"
-msgstr "Turkiera"
-
-#: src/Preferences.cpp
-msgid "Ukrainian"
-msgstr "Ukraniera"
-
-#: src/Preferences.cpp
-msgid "Change Language"
-msgstr "Aldatu hizkuntza"
-
-#: src/Preferences.cpp
-msgid "There are no translations installed for aMule"
-msgstr "Ez dago aMulerentzat itzulpen instalaturik"
-
-#: src/Preferences.cpp
-msgid "No languages available"
-msgstr "Ez dago hizkuntza erabilgarririk"
-
-#: src/Preferences.cpp
 msgid "no options available"
 msgstr "ez dago aukera erabilgarririk"
 
@@ -6562,7 +6592,8 @@ msgstr ""
 msgid "Confirm shared folders"
 msgstr "Partekatutako karpetak"
 
-#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp src/SharedFilesReloadProgress.cpp
+#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp
+#: src/SharedFilesReloadProgress.cpp
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "Berritu zure partekatutako fitxategiak"
@@ -9295,6 +9326,15 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "Change Language"
+#~ msgstr "Aldatu hizkuntza"
+
+#~ msgid "There are no translations installed for aMule"
+#~ msgstr "Ez dago aMulerentzat itzulpen instalaturik"
+
+#~ msgid "No languages available"
+#~ msgstr "Ez dago hizkuntza erabilgarririk"
 
 #~ msgid "User name"
 #~ msgstr "Erabiltzaile izena"

--- a/po/fi.po
+++ b/po/fi.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-05 12:01+0200\n"
+"POT-Creation-Date: 2026-09-06 14:35+0200\n"
 "PO-Revision-Date: 2026-09-05 10:50+0000\n"
 "Last-Translator: Tapio Rantala <tapio.rantala@iki.fi>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -388,7 +388,8 @@ msgstr "web-palvelin käynnissä prosessinumerolla %d"
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Olet asettanut web-palvelimen ajettavaksi käynnistettäessä, mutta amuleweb-ohjelmaa ei voida ajaa. Ole hyvä ja asenna aMule web-palvelimen sisältävä paketti tai käännä aMule käyttäen parametria --enable-webserver ja suorita make install"
 
-#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
+#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
+#: src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
 msgid "ERROR"
 msgstr "VIRHE"
 
@@ -676,7 +677,8 @@ msgstr "Verkot"
 msgid "Searches"
 msgstr "Haut"
 
-#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/Statistics.cpp
+#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/Statistics.cpp
 msgid "Downloads"
 msgstr "Lataukset"
 
@@ -760,7 +762,9 @@ msgstr "Kad: Pois päältä"
 msgid "Core"
 msgstr ""
 
-#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp src/Statistics.cpp
+#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp src/Statistics.cpp
 msgid "Version"
 msgstr "Versio"
 
@@ -1059,7 +1063,11 @@ msgstr "Ei voida luoda kansiota '%s' luokalle '%s', pidän kansion '%s'."
 msgid "The remote core sent inconsistent data for \"%s\" (part status %d, expected %d). The file list may be showing the wrong information; reconnect to clear it."
 msgstr ""
 
-#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp src/Statistics.cpp
+#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp
+#: src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp
+#: src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp
+#: src/Statistics.cpp
 msgid "Unknown"
 msgstr "Tuntematon"
 
@@ -1156,7 +1164,8 @@ msgstr "Virhe tallennettaessa tiedostoa %s: %s"
 msgid "Enter Captcha"
 msgstr "Syötä kuvavarmennus"
 
-#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp src/TransferWnd.cpp
+#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp
+#: src/TransferWnd.cpp
 msgid "Category"
 msgstr "Luokittelu"
 
@@ -1320,11 +1329,13 @@ msgstr "Tiedostoa 'cryptkey.dat' ei löydetty, luodaan."
 msgid "Client Details"
 msgstr "Asiakkaan tiedot"
 
-#: src/ClientDetailDialog.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
+#: src/utils/wxCas/src/onlinesig.cpp
 msgid "LowID"
 msgstr "LowID"
 
-#: src/ClientDetailDialog.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
+#: src/utils/wxCas/src/onlinesig.cpp
 msgid "HighID"
 msgstr "HighID"
 
@@ -1340,7 +1351,8 @@ msgstr "Tuettu"
 msgid "Not supported"
 msgstr "Ei tuettu"
 
-#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp src/TextClient.cpp
+#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
+#: src/TextClient.cpp
 msgid "Connected"
 msgstr "Yhdistetty"
 
@@ -1348,7 +1360,8 @@ msgstr "Yhdistetty"
 msgid "Disconnected"
 msgstr "Yhteys katkaistu"
 
-#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f KiB/s"
 msgstr ""
@@ -1365,7 +1378,8 @@ msgstr ""
 msgid "IP Address"
 msgstr "IP-osoite"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Origin"
 msgstr "Alkuperä"
 
@@ -1383,11 +1397,13 @@ msgstr "Viimeisin vastaanotto"
 msgid "Sessions"
 msgstr "Versio"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/SharedFilePeersListCtrl.cpp
 msgid "Upload Speed"
 msgstr "Lähetysnopeus"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/SharedFilePeersListCtrl.cpp
 msgid "Download Speed"
 msgstr "Latausnopeus"
 
@@ -1442,11 +1458,13 @@ msgstr[1] ""
 msgid "Files"
 msgstr "Tiedostot"
 
-#: src/ClientsListCtrl.cpp src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientsListCtrl.cpp src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp
 msgid "Uploaded"
 msgstr "Lähetetty"
 
-#: src/ClientsListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientsListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Downloaded"
 msgstr "Ladattu"
 
@@ -1537,7 +1555,8 @@ msgstr "Tiedoston kommentit"
 msgid "Username"
 msgstr "Käyttäjänimi"
 
-#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp
+#: src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "File Name"
 msgstr "Tiedoston nimi"
 
@@ -1599,15 +1618,18 @@ msgstr "Auto [Ko]"
 msgid "Very low"
 msgstr "Erittäin matala"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Low"
 msgstr "Matala"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Normal"
 msgstr "Normaali"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "High"
 msgstr "Korkea"
 
@@ -1631,11 +1653,13 @@ msgstr "Yhdistetään serverin kautta"
 msgid "Queue Full"
 msgstr "Jono täynnä"
 
-#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp src/muuli_wdr.cpp
+#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp
+#: src/muuli_wdr.cpp
 msgid "On Queue"
 msgstr "Jonossa"
 
-#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
+#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp
+#: src/PartFile.cpp src/TransferWnd.cpp
 msgid "Downloading"
 msgstr "Lataa"
 
@@ -1695,7 +1719,8 @@ msgstr "Paikallinen Palvelin"
 msgid "Remote Server"
 msgstr "Etäpalvelin"
 
-#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp src/TextClient.cpp
+#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp
+#: src/TextClient.cpp
 msgid "Kad"
 msgstr "Kad"
 
@@ -1719,7 +1744,8 @@ msgstr "Lähteitä"
 msgid "Search Result"
 msgstr "Haun tulos"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp
+#: src/TransferWnd.cpp
 msgid "Completed"
 msgstr "Valmiina"
 
@@ -1772,7 +1798,8 @@ msgstr ""
 msgid "Part"
 msgstr "Osa"
 
-#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 msgid "Size"
 msgstr "Koko"
 
@@ -1780,7 +1807,8 @@ msgstr "Koko"
 msgid "Transferred"
 msgstr "Siirretty"
 
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp src/SourceListCtrl.cpp
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
+#: src/SourceListCtrl.cpp
 msgid "Speed"
 msgstr "Nopeus"
 
@@ -1788,11 +1816,13 @@ msgstr "Nopeus"
 msgid "Progress"
 msgstr "Edistyminen"
 
-#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
+#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp
+#: src/SearchListCtrl.cpp
 msgid "Sources"
 msgstr "Lähteet"
 
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 msgid "Priority"
 msgstr "Tärkeys"
 
@@ -1816,7 +1846,9 @@ msgstr "Viimeisin vastaanotto"
 msgid "Auto"
 msgstr "Automaattinen"
 
-#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/TransferWnd.cpp src/utils/wxCas/src/wxcasprefs.cpp
+#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/TransferWnd.cpp
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Cancel"
 msgstr "Peruuta"
 
@@ -1917,7 +1949,8 @@ msgstr "Anna uusi nimi tälle tiedostolle:"
 msgid "File rename"
 msgstr "Tiedoston uudelleennimeäminen"
 
-#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f MiB/s"
 msgstr ""
@@ -2722,11 +2755,13 @@ msgstr ""
 msgid "Start aMule automatically when I log in"
 msgstr ""
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp packaging/windows/installer_strings.c
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: packaging/windows/installer_strings.c
 msgid "Register aMule for ed2k:// links"
 msgstr ""
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp packaging/windows/installer_strings.c
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: packaging/windows/installer_strings.c
 msgid "Register aMule for magnet: links"
 msgstr ""
 
@@ -2752,7 +2787,8 @@ msgstr ""
 msgid "Destination folder for downloads"
 msgstr "Kansio ladatuille tiedostoille"
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Browse"
 msgstr "Selaa"
 
@@ -3173,6 +3209,163 @@ msgstr "Merkinnän luku tunnettujen tiedostojen lista -tiedostosta epäonnistui,
 msgid "Invalid entry in known file list, file may be corrupt: "
 msgstr "Epäkelpo merkintä tunnettujen tiedostojen lista -tiedostossa, tiedosto saattaa olla turmeltunut: "
 
+#: src/LanguageList.cpp
+msgid "System default"
+msgstr "Järjestelmän vakio"
+
+#: src/LanguageList.cpp
+msgid "Albanian"
+msgstr "Albania"
+
+#: src/LanguageList.cpp
+msgid "Arabic"
+msgstr "Arabia"
+
+#: src/LanguageList.cpp
+msgid "Asturian"
+msgstr "Asturia"
+
+#: src/LanguageList.cpp
+msgid "Basque"
+msgstr "Baski"
+
+#: src/LanguageList.cpp
+msgid "Bulgarian"
+msgstr "Bulgaria"
+
+#: src/LanguageList.cpp
+msgid "Catalan"
+msgstr "Katalaani"
+
+#: src/LanguageList.cpp
+msgid "Chinese (Simplified)"
+msgstr "Kiina (Yksinkertaistettu)"
+
+#: src/LanguageList.cpp
+msgid "Chinese (Traditional)"
+msgstr "Kiina (Perinteinen)"
+
+#: src/LanguageList.cpp
+msgid "Croatian"
+msgstr "Kroatia"
+
+#: src/LanguageList.cpp
+msgid "Czech"
+msgstr "Tsekki"
+
+#: src/LanguageList.cpp
+msgid "Danish"
+msgstr "Tanska"
+
+#: src/LanguageList.cpp
+msgid "Dutch"
+msgstr "Hollanti"
+
+#: src/LanguageList.cpp
+msgid "English (U.K.)"
+msgstr "Englanti (U.K.)"
+
+#: src/LanguageList.cpp
+#, fuzzy
+msgid "English (U.S.)"
+msgstr "Englanti (U.K.)"
+
+#: src/LanguageList.cpp
+msgid "Estonian"
+msgstr "Viro"
+
+#: src/LanguageList.cpp
+msgid "Finnish"
+msgstr "Suomi"
+
+#: src/LanguageList.cpp
+msgid "French"
+msgstr "Ranska"
+
+#: src/LanguageList.cpp
+msgid "Galician"
+msgstr "Galicia (Galego)"
+
+#: src/LanguageList.cpp
+msgid "German"
+msgstr "Saksa"
+
+#: src/LanguageList.cpp
+msgid "Greek"
+msgstr "Kreikka"
+
+#: src/LanguageList.cpp
+msgid "Hebrew"
+msgstr "Heprea"
+
+#: src/LanguageList.cpp
+msgid "Hungarian"
+msgstr "Unkari"
+
+#: src/LanguageList.cpp
+msgid "Italian"
+msgstr "Italia"
+
+#: src/LanguageList.cpp
+msgid "Japanese"
+msgstr "Japani"
+
+#: src/LanguageList.cpp
+msgid "Korean"
+msgstr "Korea"
+
+#: src/LanguageList.cpp
+msgid "Latvian"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Lithuanian"
+msgstr "Liettua"
+
+#: src/LanguageList.cpp
+msgid "Norwegian (Nynorsk)"
+msgstr "Norja (Nynorsk)"
+
+#: src/LanguageList.cpp
+msgid "Polish"
+msgstr "Puola"
+
+#: src/LanguageList.cpp
+msgid "Portuguese"
+msgstr "Portugali"
+
+#: src/LanguageList.cpp
+msgid "Portuguese (Brazilian)"
+msgstr "Portugali (Brazilia)"
+
+#: src/LanguageList.cpp
+msgid "Romanian"
+msgstr "Romanian"
+
+#: src/LanguageList.cpp
+msgid "Russian"
+msgstr "Venäjä"
+
+#: src/LanguageList.cpp
+msgid "Slovenian"
+msgstr "Slovenia"
+
+#: src/LanguageList.cpp
+msgid "Spanish"
+msgstr "Espanja"
+
+#: src/LanguageList.cpp
+msgid "Swedish"
+msgstr "Ruotsi"
+
+#: src/LanguageList.cpp
+msgid "Turkish"
+msgstr "Turkki"
+
+#: src/LanguageList.cpp
+msgid "Ukrainian"
+msgstr "Ukraina"
+
 #: src/libs/common/Format.cpp
 #, c-format
 msgid "Unknown error %d"
@@ -3195,15 +3388,18 @@ msgstr "Viimeistelee"
 msgid "Complete"
 msgstr "Valmis"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Paused"
 msgstr "Tauotettu"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Erroneous"
 msgstr "Virheellinen"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Waiting"
 msgstr "Odottaa"
 
@@ -3367,7 +3563,8 @@ msgstr "Sulje"
 msgid "Cut"
 msgstr "Leikkaa"
 
-#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp src/utils/aLinkCreator/src/alcframe.cpp
+#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy"
 msgstr "Kopioi"
 
@@ -3375,7 +3572,8 @@ msgstr "Kopioi"
 msgid "Paste"
 msgstr "Liitä"
 
-#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
+#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Clear"
 msgstr "Pyyhi"
 
@@ -3383,7 +3581,8 @@ msgstr "Pyyhi"
 msgid "Select All"
 msgstr "Valitse kaikki"
 
-#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp src/StatisticsDlg.cpp
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
+#: src/StatisticsDlg.cpp
 msgid "KiB/s"
 msgstr ""
 
@@ -5881,175 +6080,6 @@ msgid "ERROR: Failed to open partfile '%s'"
 msgstr "VIRHE: Ei voida avata osatiedostoa '%s'"
 
 #: src/Preferences.cpp
-msgid "System default"
-msgstr "Järjestelmän vakio"
-
-#: src/Preferences.cpp
-msgid "Albanian"
-msgstr "Albania"
-
-#: src/Preferences.cpp
-msgid "Arabic"
-msgstr "Arabia"
-
-#: src/Preferences.cpp
-msgid "Asturian"
-msgstr "Asturia"
-
-#: src/Preferences.cpp
-msgid "Basque"
-msgstr "Baski"
-
-#: src/Preferences.cpp
-msgid "Bulgarian"
-msgstr "Bulgaria"
-
-#: src/Preferences.cpp
-msgid "Catalan"
-msgstr "Katalaani"
-
-#: src/Preferences.cpp
-msgid "Chinese (Simplified)"
-msgstr "Kiina (Yksinkertaistettu)"
-
-#: src/Preferences.cpp
-msgid "Chinese (Traditional)"
-msgstr "Kiina (Perinteinen)"
-
-#: src/Preferences.cpp
-msgid "Croatian"
-msgstr "Kroatia"
-
-#: src/Preferences.cpp
-msgid "Czech"
-msgstr "Tsekki"
-
-#: src/Preferences.cpp
-msgid "Danish"
-msgstr "Tanska"
-
-#: src/Preferences.cpp
-msgid "Dutch"
-msgstr "Hollanti"
-
-#: src/Preferences.cpp
-msgid "English (U.K.)"
-msgstr "Englanti (U.K.)"
-
-#: src/Preferences.cpp
-#, fuzzy
-msgid "English (U.S.)"
-msgstr "Englanti (U.K.)"
-
-#: src/Preferences.cpp
-msgid "Estonian"
-msgstr "Viro"
-
-#: src/Preferences.cpp
-msgid "Finnish"
-msgstr "Suomi"
-
-#: src/Preferences.cpp
-msgid "French"
-msgstr "Ranska"
-
-#: src/Preferences.cpp
-msgid "Galician"
-msgstr "Galicia (Galego)"
-
-#: src/Preferences.cpp
-msgid "German"
-msgstr "Saksa"
-
-#: src/Preferences.cpp
-msgid "Greek"
-msgstr "Kreikka"
-
-#: src/Preferences.cpp
-msgid "Hebrew"
-msgstr "Heprea"
-
-#: src/Preferences.cpp
-msgid "Hungarian"
-msgstr "Unkari"
-
-#: src/Preferences.cpp
-msgid "Italian"
-msgstr "Italia"
-
-#: src/Preferences.cpp
-msgid "Japanese"
-msgstr "Japani"
-
-#: src/Preferences.cpp
-msgid "Korean"
-msgstr "Korea"
-
-#: src/Preferences.cpp
-msgid "Latvian"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Lithuanian"
-msgstr "Liettua"
-
-#: src/Preferences.cpp
-msgid "Norwegian (Nynorsk)"
-msgstr "Norja (Nynorsk)"
-
-#: src/Preferences.cpp
-msgid "Polish"
-msgstr "Puola"
-
-#: src/Preferences.cpp
-msgid "Portuguese"
-msgstr "Portugali"
-
-#: src/Preferences.cpp
-msgid "Portuguese (Brazilian)"
-msgstr "Portugali (Brazilia)"
-
-#: src/Preferences.cpp
-msgid "Romanian"
-msgstr "Romanian"
-
-#: src/Preferences.cpp
-msgid "Russian"
-msgstr "Venäjä"
-
-#: src/Preferences.cpp
-msgid "Slovenian"
-msgstr "Slovenia"
-
-#: src/Preferences.cpp
-msgid "Spanish"
-msgstr "Espanja"
-
-#: src/Preferences.cpp
-msgid "Swedish"
-msgstr "Ruotsi"
-
-#: src/Preferences.cpp
-msgid "Turkish"
-msgstr "Turkki"
-
-#: src/Preferences.cpp
-msgid "Ukrainian"
-msgstr "Ukraina"
-
-#: src/Preferences.cpp
-msgid "Change Language"
-msgstr "Vaihda kieli"
-
-#: src/Preferences.cpp
-msgid "There are no translations installed for aMule"
-msgstr "Käännöksiä ei ole asennettuna aMulelle"
-
-#: src/Preferences.cpp
-msgid "No languages available"
-msgstr "Kieliä ei saatavilla"
-
-#: src/Preferences.cpp
 msgid "no options available"
 msgstr "vaihtoehtoja ei saatavilla"
 
@@ -6562,7 +6592,8 @@ msgstr ""
 msgid "Confirm shared folders"
 msgstr "Jaetut kansiot"
 
-#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp src/SharedFilesReloadProgress.cpp
+#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp
+#: src/SharedFilesReloadProgress.cpp
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "Uudelleenlataa jaetut tiedostot"
@@ -9295,6 +9326,15 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "Change Language"
+#~ msgstr "Vaihda kieli"
+
+#~ msgid "There are no translations installed for aMule"
+#~ msgstr "Käännöksiä ei ole asennettuna aMulelle"
+
+#~ msgid "No languages available"
+#~ msgstr "Kieliä ei saatavilla"
 
 #~ msgid "User name"
 #~ msgstr "Käyttäjänimi"

--- a/po/fr.po
+++ b/po/fr.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-05 12:01+0200\n"
+"POT-Creation-Date: 2026-09-06 14:35+0200\n"
 "PO-Revision-Date: 2026-09-05 10:51+0000\n"
 "Last-Translator: Dylan Aïssi <bob.dybian@gmail.com>\n"
 "Language-Team: Français\n"
@@ -392,7 +392,8 @@ msgstr "serveur web s'exécutant avec le pid %d"
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Vous avez demandé à exécuter le serveur web au démarrage, mais le binaire amuleweb ne peut être exécuté. Veuillez installer le paquet contenant le serveur web aMule, ou compilez aMule depuis le code source avec -DBUILD_WEBSERVER=YES et installez-le."
 
-#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
+#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
+#: src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
 msgid "ERROR"
 msgstr "ERREUR"
 
@@ -678,7 +679,8 @@ msgstr "Réseaux"
 msgid "Searches"
 msgstr "Recherches"
 
-#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/Statistics.cpp
+#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/Statistics.cpp
 msgid "Downloads"
 msgstr "Téléchargements"
 
@@ -766,7 +768,9 @@ msgstr "Kad : Coupé"
 msgid "Core"
 msgstr "Noyau"
 
-#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp src/Statistics.cpp
+#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp src/Statistics.cpp
 msgid "Version"
 msgstr "Version"
 
@@ -1063,7 +1067,11 @@ msgstr "Impossible de créer le répertoire '%s' pour la catégorie '%s', on gar
 msgid "The remote core sent inconsistent data for \"%s\" (part status %d, expected %d). The file list may be showing the wrong information; reconnect to clear it."
 msgstr "Le serveur distant a envoyé des données incohérentes pour « %s » (état de la partie : %d, valeur attendue : %d). La liste des fichiers peut afficher des informations incorrectes ; reconnectez-vous pour les corriger."
 
-#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp src/Statistics.cpp
+#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp
+#: src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp
+#: src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp
+#: src/Statistics.cpp
 msgid "Unknown"
 msgstr "Inconnu"
 
@@ -1160,7 +1168,8 @@ msgstr "Erreur lors de la sauvegarde du fichier %s : %s"
 msgid "Enter Captcha"
 msgstr "Entrer le Captcha"
 
-#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp src/TransferWnd.cpp
+#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp
+#: src/TransferWnd.cpp
 msgid "Category"
 msgstr "Catégorie"
 
@@ -1323,11 +1332,13 @@ msgstr "Pas de fichier 'cryptkey.dat' trouvé, création."
 msgid "Client Details"
 msgstr "Détails du client"
 
-#: src/ClientDetailDialog.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
+#: src/utils/wxCas/src/onlinesig.cpp
 msgid "LowID"
 msgstr "LowID"
 
-#: src/ClientDetailDialog.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
+#: src/utils/wxCas/src/onlinesig.cpp
 msgid "HighID"
 msgstr "HighID"
 
@@ -1343,7 +1354,8 @@ msgstr "Supporté"
 msgid "Not supported"
 msgstr "Non supporté"
 
-#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp src/TextClient.cpp
+#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
+#: src/TextClient.cpp
 msgid "Connected"
 msgstr "Connecté"
 
@@ -1351,7 +1363,8 @@ msgstr "Connecté"
 msgid "Disconnected"
 msgstr "Déconnecté"
 
-#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f KiB/s"
 msgstr "%.1f Kio/s"
@@ -1368,7 +1381,8 @@ msgstr "Logiciel"
 msgid "IP Address"
 msgstr "Adresse IP"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Origin"
 msgstr "Origine"
 
@@ -1384,11 +1398,13 @@ msgstr "Vu pour la dernière fois"
 msgid "Sessions"
 msgstr "Sessions"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/SharedFilePeersListCtrl.cpp
 msgid "Upload Speed"
 msgstr "Vitesse d'Émission"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/SharedFilePeersListCtrl.cpp
 msgid "Download Speed"
 msgstr "Vitesse de Réception"
 
@@ -1439,11 +1455,13 @@ msgstr[1] "Impossible de demander à %u clients sélectionnés leurs fichiers pa
 msgid "Files"
 msgstr "Fichiers"
 
-#: src/ClientsListCtrl.cpp src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientsListCtrl.cpp src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp
 msgid "Uploaded"
 msgstr "Émis"
 
-#: src/ClientsListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientsListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Downloaded"
 msgstr "Téléchargé"
 
@@ -1531,7 +1549,8 @@ msgstr "Commentaires sur le fichier"
 msgid "Username"
 msgstr "Nom d'utilisateur"
 
-#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp
+#: src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "File Name"
 msgstr "Nom du fichier"
 
@@ -1592,15 +1611,18 @@ msgstr "Auto [Haute]"
 msgid "Very low"
 msgstr "Très basse"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Low"
 msgstr "Basse"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Normal"
 msgstr "Normale"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "High"
 msgstr "Haute"
 
@@ -1624,11 +1646,13 @@ msgstr "Connexion via le serveur"
 msgid "Queue Full"
 msgstr "File d'attente pleine"
 
-#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp src/muuli_wdr.cpp
+#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp
+#: src/muuli_wdr.cpp
 msgid "On Queue"
 msgstr "En attente"
 
-#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
+#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp
+#: src/PartFile.cpp src/TransferWnd.cpp
 msgid "Downloading"
 msgstr "En téléchargement"
 
@@ -1688,7 +1712,8 @@ msgstr "Serveur Local"
 msgid "Remote Server"
 msgstr "Serveur Distant"
 
-#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp src/TextClient.cpp
+#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp
+#: src/TextClient.cpp
 msgid "Kad"
 msgstr "Kad"
 
@@ -1712,7 +1737,8 @@ msgstr "Source Seeds"
 msgid "Search Result"
 msgstr "Résultat de la recherche"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp
+#: src/TransferWnd.cpp
 msgid "Completed"
 msgstr "Terminé"
 
@@ -1764,7 +1790,8 @@ msgstr "Impossible de modifier un élément à l’intérieur d’un partage ré
 msgid "Part"
 msgstr "Partie"
 
-#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 msgid "Size"
 msgstr "Taille"
 
@@ -1772,7 +1799,8 @@ msgstr "Taille"
 msgid "Transferred"
 msgstr "Reçu"
 
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp src/SourceListCtrl.cpp
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
+#: src/SourceListCtrl.cpp
 msgid "Speed"
 msgstr "Vitesse"
 
@@ -1780,11 +1808,13 @@ msgstr "Vitesse"
 msgid "Progress"
 msgstr "Progression"
 
-#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
+#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp
+#: src/SearchListCtrl.cpp
 msgid "Sources"
 msgstr "Sources"
 
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 msgid "Priority"
 msgstr "Priorité"
 
@@ -1808,7 +1838,9 @@ msgstr "Dernière réception"
 msgid "Auto"
 msgstr "Auto"
 
-#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/TransferWnd.cpp src/utils/wxCas/src/wxcasprefs.cpp
+#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/TransferWnd.cpp
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Cancel"
 msgstr "Annuler"
 
@@ -1909,7 +1941,8 @@ msgstr "Entrez un nouveau nom pour ce fichier :"
 msgid "File rename"
 msgstr "Renommer"
 
-#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f MiB/s"
 msgstr "%.1f Mio/s"
@@ -2712,11 +2745,13 @@ msgstr ""
 msgid "Start aMule automatically when I log in"
 msgstr "Lancer aMule automatiquement lorsque j'ouvre une session"
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp packaging/windows/installer_strings.c
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: packaging/windows/installer_strings.c
 msgid "Register aMule for ed2k:// links"
 msgstr "Enregistrer aMule pour les liens ed2k://"
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp packaging/windows/installer_strings.c
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: packaging/windows/installer_strings.c
 msgid "Register aMule for magnet: links"
 msgstr "Enregistrer aMule pour les liens magnet:"
 
@@ -2744,7 +2779,8 @@ msgstr ""
 msgid "Destination folder for downloads"
 msgstr "Dossier de destination des téléchargements"
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Browse"
 msgstr "Parcourir"
 
@@ -3166,6 +3202,162 @@ msgstr "Échec du chargement de l'entrée dans la liste des fichiers connus, le 
 msgid "Invalid entry in known file list, file may be corrupt: "
 msgstr "Entrée invalide dans la liste des fichiers connus, le fichier est peut être corrompu : "
 
+#: src/LanguageList.cpp
+msgid "System default"
+msgstr "Système par défaut"
+
+#: src/LanguageList.cpp
+msgid "Albanian"
+msgstr "Albanais"
+
+#: src/LanguageList.cpp
+msgid "Arabic"
+msgstr "Arabe"
+
+#: src/LanguageList.cpp
+msgid "Asturian"
+msgstr "Asturien"
+
+#: src/LanguageList.cpp
+msgid "Basque"
+msgstr "Basque"
+
+#: src/LanguageList.cpp
+msgid "Bulgarian"
+msgstr "Bulgare"
+
+#: src/LanguageList.cpp
+msgid "Catalan"
+msgstr "Catalan"
+
+#: src/LanguageList.cpp
+msgid "Chinese (Simplified)"
+msgstr "Chinois (Simplifié)"
+
+#: src/LanguageList.cpp
+msgid "Chinese (Traditional)"
+msgstr "Chinois (Traditionnel)"
+
+#: src/LanguageList.cpp
+msgid "Croatian"
+msgstr "Croate"
+
+#: src/LanguageList.cpp
+msgid "Czech"
+msgstr "Tchèque"
+
+#: src/LanguageList.cpp
+msgid "Danish"
+msgstr "Danois"
+
+#: src/LanguageList.cpp
+msgid "Dutch"
+msgstr "Hollandais"
+
+#: src/LanguageList.cpp
+msgid "English (U.K.)"
+msgstr "Anglais (U.K.)"
+
+#: src/LanguageList.cpp
+msgid "English (U.S.)"
+msgstr "Anglais (É-U)"
+
+#: src/LanguageList.cpp
+msgid "Estonian"
+msgstr "Estonien"
+
+#: src/LanguageList.cpp
+msgid "Finnish"
+msgstr "Finlandais"
+
+#: src/LanguageList.cpp
+msgid "French"
+msgstr "Français"
+
+#: src/LanguageList.cpp
+msgid "Galician"
+msgstr "Galicien"
+
+#: src/LanguageList.cpp
+msgid "German"
+msgstr "Allemand"
+
+#: src/LanguageList.cpp
+msgid "Greek"
+msgstr "Grec"
+
+#: src/LanguageList.cpp
+msgid "Hebrew"
+msgstr "Hébreux"
+
+#: src/LanguageList.cpp
+msgid "Hungarian"
+msgstr "Hongrois"
+
+#: src/LanguageList.cpp
+msgid "Italian"
+msgstr "Italien"
+
+#: src/LanguageList.cpp
+msgid "Japanese"
+msgstr "Japonais"
+
+#: src/LanguageList.cpp
+msgid "Korean"
+msgstr "Coréen"
+
+#: src/LanguageList.cpp
+msgid "Latvian"
+msgstr "Letton"
+
+#: src/LanguageList.cpp
+msgid "Lithuanian"
+msgstr "Lituanien"
+
+#: src/LanguageList.cpp
+msgid "Norwegian (Nynorsk)"
+msgstr "Norvégien (Nynorsk)"
+
+#: src/LanguageList.cpp
+msgid "Polish"
+msgstr "Polonais"
+
+#: src/LanguageList.cpp
+msgid "Portuguese"
+msgstr "Portugais"
+
+#: src/LanguageList.cpp
+msgid "Portuguese (Brazilian)"
+msgstr "Portugais (Brésilien)"
+
+#: src/LanguageList.cpp
+msgid "Romanian"
+msgstr "Roumain"
+
+#: src/LanguageList.cpp
+msgid "Russian"
+msgstr "Russe"
+
+#: src/LanguageList.cpp
+msgid "Slovenian"
+msgstr "Slovène"
+
+#: src/LanguageList.cpp
+msgid "Spanish"
+msgstr "Espagnol"
+
+#: src/LanguageList.cpp
+msgid "Swedish"
+msgstr "Suédois"
+
+#: src/LanguageList.cpp
+msgid "Turkish"
+msgstr "Turc"
+
+#: src/LanguageList.cpp
+msgid "Ukrainian"
+msgstr "Ukrainien"
+
 #: src/libs/common/Format.cpp
 #, c-format
 msgid "Unknown error %d"
@@ -3188,15 +3380,18 @@ msgstr "Finalisation"
 msgid "Complete"
 msgstr "Terminé"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Paused"
 msgstr "En pause"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Erroneous"
 msgstr "Erroné"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Waiting"
 msgstr "En attente"
 
@@ -3358,7 +3553,8 @@ msgstr "Fermer"
 msgid "Cut"
 msgstr "Couper"
 
-#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp src/utils/aLinkCreator/src/alcframe.cpp
+#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy"
 msgstr "Copier"
 
@@ -3366,7 +3562,8 @@ msgstr "Copier"
 msgid "Paste"
 msgstr "Coller"
 
-#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
+#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Clear"
 msgstr "Effacer"
 
@@ -3374,7 +3571,8 @@ msgstr "Effacer"
 msgid "Select All"
 msgstr "Tout sélectionner"
 
-#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp src/StatisticsDlg.cpp
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
+#: src/StatisticsDlg.cpp
 msgid "KiB/s"
 msgstr "Kio/s"
 
@@ -5836,174 +6034,6 @@ msgid "ERROR: Failed to open partfile '%s'"
 msgstr "ERREUR : Impossible d'ouvrir fichier .part : '%s'"
 
 #: src/Preferences.cpp
-msgid "System default"
-msgstr "Système par défaut"
-
-#: src/Preferences.cpp
-msgid "Albanian"
-msgstr "Albanais"
-
-#: src/Preferences.cpp
-msgid "Arabic"
-msgstr "Arabe"
-
-#: src/Preferences.cpp
-msgid "Asturian"
-msgstr "Asturien"
-
-#: src/Preferences.cpp
-msgid "Basque"
-msgstr "Basque"
-
-#: src/Preferences.cpp
-msgid "Bulgarian"
-msgstr "Bulgare"
-
-#: src/Preferences.cpp
-msgid "Catalan"
-msgstr "Catalan"
-
-#: src/Preferences.cpp
-msgid "Chinese (Simplified)"
-msgstr "Chinois (Simplifié)"
-
-#: src/Preferences.cpp
-msgid "Chinese (Traditional)"
-msgstr "Chinois (Traditionnel)"
-
-#: src/Preferences.cpp
-msgid "Croatian"
-msgstr "Croate"
-
-#: src/Preferences.cpp
-msgid "Czech"
-msgstr "Tchèque"
-
-#: src/Preferences.cpp
-msgid "Danish"
-msgstr "Danois"
-
-#: src/Preferences.cpp
-msgid "Dutch"
-msgstr "Hollandais"
-
-#: src/Preferences.cpp
-msgid "English (U.K.)"
-msgstr "Anglais (U.K.)"
-
-#: src/Preferences.cpp
-msgid "English (U.S.)"
-msgstr "Anglais (É-U)"
-
-#: src/Preferences.cpp
-msgid "Estonian"
-msgstr "Estonien"
-
-#: src/Preferences.cpp
-msgid "Finnish"
-msgstr "Finlandais"
-
-#: src/Preferences.cpp
-msgid "French"
-msgstr "Français"
-
-#: src/Preferences.cpp
-msgid "Galician"
-msgstr "Galicien"
-
-#: src/Preferences.cpp
-msgid "German"
-msgstr "Allemand"
-
-#: src/Preferences.cpp
-msgid "Greek"
-msgstr "Grec"
-
-#: src/Preferences.cpp
-msgid "Hebrew"
-msgstr "Hébreux"
-
-#: src/Preferences.cpp
-msgid "Hungarian"
-msgstr "Hongrois"
-
-#: src/Preferences.cpp
-msgid "Italian"
-msgstr "Italien"
-
-#: src/Preferences.cpp
-msgid "Japanese"
-msgstr "Japonais"
-
-#: src/Preferences.cpp
-msgid "Korean"
-msgstr "Coréen"
-
-#: src/Preferences.cpp
-msgid "Latvian"
-msgstr "Letton"
-
-#: src/Preferences.cpp
-msgid "Lithuanian"
-msgstr "Lituanien"
-
-#: src/Preferences.cpp
-msgid "Norwegian (Nynorsk)"
-msgstr "Norvégien (Nynorsk)"
-
-#: src/Preferences.cpp
-msgid "Polish"
-msgstr "Polonais"
-
-#: src/Preferences.cpp
-msgid "Portuguese"
-msgstr "Portugais"
-
-#: src/Preferences.cpp
-msgid "Portuguese (Brazilian)"
-msgstr "Portugais (Brésilien)"
-
-#: src/Preferences.cpp
-msgid "Romanian"
-msgstr "Roumain"
-
-#: src/Preferences.cpp
-msgid "Russian"
-msgstr "Russe"
-
-#: src/Preferences.cpp
-msgid "Slovenian"
-msgstr "Slovène"
-
-#: src/Preferences.cpp
-msgid "Spanish"
-msgstr "Espagnol"
-
-#: src/Preferences.cpp
-msgid "Swedish"
-msgstr "Suédois"
-
-#: src/Preferences.cpp
-msgid "Turkish"
-msgstr "Turc"
-
-#: src/Preferences.cpp
-msgid "Ukrainian"
-msgstr "Ukrainien"
-
-#: src/Preferences.cpp
-msgid "Change Language"
-msgstr "Changer de langue"
-
-#: src/Preferences.cpp
-msgid "There are no translations installed for aMule"
-msgstr "Il n'y a pas de traductions installées pour aMule"
-
-#: src/Preferences.cpp
-msgid "No languages available"
-msgstr "Pas de langues disponibles"
-
-#: src/Preferences.cpp
 msgid "no options available"
 msgstr "pas d'option disponible"
 
@@ -6505,7 +6535,8 @@ msgstr "Les partager récursivement publiera chaque fichier contenu dans les sou
 msgid "Confirm shared folders"
 msgstr "Confirmer les dossiers partagés"
 
-#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp src/SharedFilesReloadProgress.cpp
+#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp
+#: src/SharedFilesReloadProgress.cpp
 msgid "Reloading shared files..."
 msgstr "Rechargement des fichiers partagés…"
 
@@ -9235,6 +9266,15 @@ msgstr "aMule semble être en cours d'exécution. Veuillez le fermer et relancer
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "Suppression des données d'utilisateur sur $APPDATA\\aMule…"
+
+#~ msgid "Change Language"
+#~ msgstr "Changer de langue"
+
+#~ msgid "There are no translations installed for aMule"
+#~ msgstr "Il n'y a pas de traductions installées pour aMule"
+
+#~ msgid "No languages available"
+#~ msgstr "Pas de langues disponibles"
 
 #~ msgid "User name"
 #~ msgstr "Nom d'utilisateur"

--- a/po/gl.po
+++ b/po/gl.po
@@ -24,7 +24,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-05 12:01+0200\n"
+"POT-Creation-Date: 2026-09-06 14:35+0200\n"
 "PO-Revision-Date: 2026-09-05 10:52+0000\n"
 "Last-Translator: Pablo <parodper@gmail.com>\n"
 "Language-Team: http://forum.amule.org/index.php?topic=13883\n"
@@ -408,7 +408,8 @@ msgstr "servidor web executándose co pid %d"
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Solicitou executar o servidor web ó inicio pero non se puido executar o programa amuleweb. Instale o paquete que conteña o servidor web do aMule ou compile o aMule empregando o parámetro --enable-webserver e logo execute make install"
 
-#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
+#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
+#: src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
 msgid "ERROR"
 msgstr "ERRO"
 
@@ -695,7 +696,8 @@ msgstr "Redes"
 msgid "Searches"
 msgstr "Buscas"
 
-#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/Statistics.cpp
+#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/Statistics.cpp
 msgid "Downloads"
 msgstr "Descargas"
 
@@ -779,7 +781,9 @@ msgstr "Kad: Apagado"
 msgid "Core"
 msgstr ""
 
-#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp src/Statistics.cpp
+#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp src/Statistics.cpp
 msgid "Version"
 msgstr "Versión"
 
@@ -1080,7 +1084,11 @@ msgstr "Non se puido crear o directorio «%s» para a categoría «%s», mantend
 msgid "The remote core sent inconsistent data for \"%s\" (part status %d, expected %d). The file list may be showing the wrong information; reconnect to clear it."
 msgstr ""
 
-#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp src/Statistics.cpp
+#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp
+#: src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp
+#: src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp
+#: src/Statistics.cpp
 msgid "Unknown"
 msgstr "Descoñecido"
 
@@ -1177,7 +1185,8 @@ msgstr "Non se puido gardar o ficheiro %s: %s"
 msgid "Enter Captcha"
 msgstr "Introduza o Captcha"
 
-#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp src/TransferWnd.cpp
+#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp
+#: src/TransferWnd.cpp
 msgid "Category"
 msgstr "Categoría"
 
@@ -1340,11 +1349,13 @@ msgstr "Non se atopou o ficheiro «cryptkey.dat», creándoo."
 msgid "Client Details"
 msgstr "Detalles do cliente"
 
-#: src/ClientDetailDialog.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
+#: src/utils/wxCas/src/onlinesig.cpp
 msgid "LowID"
 msgstr "IDBaixa"
 
-#: src/ClientDetailDialog.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
+#: src/utils/wxCas/src/onlinesig.cpp
 msgid "HighID"
 msgstr "IDAlta"
 
@@ -1360,7 +1371,8 @@ msgstr "Permitido"
 msgid "Not supported"
 msgstr "Non permitido"
 
-#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp src/TextClient.cpp
+#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
+#: src/TextClient.cpp
 msgid "Connected"
 msgstr "Conectado"
 
@@ -1368,7 +1380,8 @@ msgstr "Conectado"
 msgid "Disconnected"
 msgstr "Desconectado"
 
-#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f KiB/s"
 msgstr ""
@@ -1385,7 +1398,8 @@ msgstr ""
 msgid "IP Address"
 msgstr "Enderezo IP"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Origin"
 msgstr "Orixe"
 
@@ -1403,11 +1417,13 @@ msgstr "Última recepción"
 msgid "Sessions"
 msgstr "Versión"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/SharedFilePeersListCtrl.cpp
 msgid "Upload Speed"
 msgstr "Velocidade de envío"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/SharedFilePeersListCtrl.cpp
 msgid "Download Speed"
 msgstr "Velocidade de descarga"
 
@@ -1462,11 +1478,13 @@ msgstr[1] "Non se puideron engadir as ligazóns %u (consulte o rexistro)."
 msgid "Files"
 msgstr "Ficheiros"
 
-#: src/ClientsListCtrl.cpp src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientsListCtrl.cpp src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp
 msgid "Uploaded"
 msgstr "Enviado"
 
-#: src/ClientsListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientsListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Downloaded"
 msgstr "Descargado"
 
@@ -1557,7 +1575,8 @@ msgstr "Comentarios do ficheiro"
 msgid "Username"
 msgstr "Nome de usuario"
 
-#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp
+#: src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "File Name"
 msgstr "Nome do ficheiro"
 
@@ -1619,15 +1638,18 @@ msgstr "Auto [Al]"
 msgid "Very low"
 msgstr "Moi baixa"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Low"
 msgstr "Baixa"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Normal"
 msgstr "Normal"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "High"
 msgstr "Alta"
 
@@ -1651,11 +1673,13 @@ msgstr "Conectando vía servidor"
 msgid "Queue Full"
 msgstr "Cola chea"
 
-#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp src/muuli_wdr.cpp
+#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp
+#: src/muuli_wdr.cpp
 msgid "On Queue"
 msgstr "En cola"
 
-#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
+#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp
+#: src/PartFile.cpp src/TransferWnd.cpp
 msgid "Downloading"
 msgstr "Descargando"
 
@@ -1715,7 +1739,8 @@ msgstr "Servidor local"
 msgid "Remote Server"
 msgstr "Servidor remoto"
 
-#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp src/TextClient.cpp
+#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp
+#: src/TextClient.cpp
 msgid "Kad"
 msgstr "Kad"
 
@@ -1739,7 +1764,8 @@ msgstr "Sementes da fonte"
 msgid "Search Result"
 msgstr "Resultados da busca"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp
+#: src/TransferWnd.cpp
 msgid "Completed"
 msgstr "Completado"
 
@@ -1791,7 +1817,8 @@ msgstr ""
 msgid "Part"
 msgstr "Parte"
 
-#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 msgid "Size"
 msgstr "Tamaño"
 
@@ -1799,7 +1826,8 @@ msgstr "Tamaño"
 msgid "Transferred"
 msgstr "Transferido"
 
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp src/SourceListCtrl.cpp
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
+#: src/SourceListCtrl.cpp
 msgid "Speed"
 msgstr "Velocidade"
 
@@ -1807,11 +1835,13 @@ msgstr "Velocidade"
 msgid "Progress"
 msgstr "Progreso"
 
-#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
+#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp
+#: src/SearchListCtrl.cpp
 msgid "Sources"
 msgstr "Fontes"
 
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 msgid "Priority"
 msgstr "Prioridade"
 
@@ -1835,7 +1865,9 @@ msgstr "Última recepción"
 msgid "Auto"
 msgstr "Automático"
 
-#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/TransferWnd.cpp src/utils/wxCas/src/wxcasprefs.cpp
+#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/TransferWnd.cpp
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Cancel"
 msgstr "Cancelar"
 
@@ -1936,7 +1968,8 @@ msgstr "Introducir un novo nome para este ficheiro:"
 msgid "File rename"
 msgstr "Cambiar o nome do ficheiro"
 
-#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f MiB/s"
 msgstr ""
@@ -2739,11 +2772,13 @@ msgstr ""
 msgid "Start aMule automatically when I log in"
 msgstr "Arrancar aMule automaticamente ao iniciar sesión"
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp packaging/windows/installer_strings.c
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: packaging/windows/installer_strings.c
 msgid "Register aMule for ed2k:// links"
 msgstr ""
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp packaging/windows/installer_strings.c
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: packaging/windows/installer_strings.c
 msgid "Register aMule for magnet: links"
 msgstr ""
 
@@ -2769,7 +2804,8 @@ msgstr ""
 msgid "Destination folder for downloads"
 msgstr "Cartafol de destino para descargas"
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Browse"
 msgstr "Navegador"
 
@@ -3190,6 +3226,163 @@ msgstr "Non se puido cargar o campo da lista de ficheiros coñecidos. Pode ser q
 msgid "Invalid entry in known file list, file may be corrupt: "
 msgstr "Campo inválido na lista de ficheiros coñecidos, Pode ser que se corrompera o ficheiro: "
 
+#: src/LanguageList.cpp
+msgid "System default"
+msgstr "Predeterminado"
+
+#: src/LanguageList.cpp
+msgid "Albanian"
+msgstr "Albanés"
+
+#: src/LanguageList.cpp
+msgid "Arabic"
+msgstr "Árabe"
+
+#: src/LanguageList.cpp
+msgid "Asturian"
+msgstr "Asturiano"
+
+#: src/LanguageList.cpp
+msgid "Basque"
+msgstr "Euskera"
+
+#: src/LanguageList.cpp
+msgid "Bulgarian"
+msgstr "Búlgaro"
+
+#: src/LanguageList.cpp
+msgid "Catalan"
+msgstr "Catalán"
+
+#: src/LanguageList.cpp
+msgid "Chinese (Simplified)"
+msgstr "Chinés (Simplificado)"
+
+#: src/LanguageList.cpp
+msgid "Chinese (Traditional)"
+msgstr "Chinés (Tradicional)"
+
+#: src/LanguageList.cpp
+msgid "Croatian"
+msgstr "Croata"
+
+#: src/LanguageList.cpp
+msgid "Czech"
+msgstr "Checo"
+
+#: src/LanguageList.cpp
+msgid "Danish"
+msgstr "Danés"
+
+#: src/LanguageList.cpp
+msgid "Dutch"
+msgstr "Holandés"
+
+#: src/LanguageList.cpp
+msgid "English (U.K.)"
+msgstr "Inglés (R. U.)"
+
+#: src/LanguageList.cpp
+#, fuzzy
+msgid "English (U.S.)"
+msgstr "Inglés (R. U.)"
+
+#: src/LanguageList.cpp
+msgid "Estonian"
+msgstr "Estonio"
+
+#: src/LanguageList.cpp
+msgid "Finnish"
+msgstr "Finlandés"
+
+#: src/LanguageList.cpp
+msgid "French"
+msgstr "Francés"
+
+#: src/LanguageList.cpp
+msgid "Galician"
+msgstr "Galego"
+
+#: src/LanguageList.cpp
+msgid "German"
+msgstr "Alemán"
+
+#: src/LanguageList.cpp
+msgid "Greek"
+msgstr "Grego"
+
+#: src/LanguageList.cpp
+msgid "Hebrew"
+msgstr "Hebreo"
+
+#: src/LanguageList.cpp
+msgid "Hungarian"
+msgstr "Húngaro"
+
+#: src/LanguageList.cpp
+msgid "Italian"
+msgstr "Italiano"
+
+#: src/LanguageList.cpp
+msgid "Japanese"
+msgstr "Xaponés"
+
+#: src/LanguageList.cpp
+msgid "Korean"
+msgstr "Coreano"
+
+#: src/LanguageList.cpp
+msgid "Latvian"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Lithuanian"
+msgstr "Lituano"
+
+#: src/LanguageList.cpp
+msgid "Norwegian (Nynorsk)"
+msgstr "Noruegués (Nynorsk)"
+
+#: src/LanguageList.cpp
+msgid "Polish"
+msgstr "Polaco"
+
+#: src/LanguageList.cpp
+msgid "Portuguese"
+msgstr "Portugués"
+
+#: src/LanguageList.cpp
+msgid "Portuguese (Brazilian)"
+msgstr "Portugués (Brasileiro)"
+
+#: src/LanguageList.cpp
+msgid "Romanian"
+msgstr "Rumano"
+
+#: src/LanguageList.cpp
+msgid "Russian"
+msgstr "Ruso"
+
+#: src/LanguageList.cpp
+msgid "Slovenian"
+msgstr "Esloveno"
+
+#: src/LanguageList.cpp
+msgid "Spanish"
+msgstr "Castelán"
+
+#: src/LanguageList.cpp
+msgid "Swedish"
+msgstr "Sueco"
+
+#: src/LanguageList.cpp
+msgid "Turkish"
+msgstr "Turco"
+
+#: src/LanguageList.cpp
+msgid "Ukrainian"
+msgstr "Ucraniano"
+
 #: src/libs/common/Format.cpp
 #, c-format
 msgid "Unknown error %d"
@@ -3212,15 +3405,18 @@ msgstr "Rematando"
 msgid "Complete"
 msgstr "Rematado"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Paused"
 msgstr "Pausado"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Erroneous"
 msgstr "Erróneo"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Waiting"
 msgstr "Agardando"
 
@@ -3384,7 +3580,8 @@ msgstr "Pechar"
 msgid "Cut"
 msgstr "Cortar"
 
-#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp src/utils/aLinkCreator/src/alcframe.cpp
+#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy"
 msgstr "Copiar"
 
@@ -3392,7 +3589,8 @@ msgstr "Copiar"
 msgid "Paste"
 msgstr "Pegar"
 
-#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
+#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Clear"
 msgstr "Limpar"
 
@@ -3400,7 +3598,8 @@ msgstr "Limpar"
 msgid "Select All"
 msgstr "Seleccionar todo"
 
-#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp src/StatisticsDlg.cpp
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
+#: src/StatisticsDlg.cpp
 msgid "KiB/s"
 msgstr ""
 
@@ -5890,175 +6089,6 @@ msgid "ERROR: Failed to open partfile '%s'"
 msgstr "ERRO: Non se puido abrir o partfile «%s»"
 
 #: src/Preferences.cpp
-msgid "System default"
-msgstr "Predeterminado"
-
-#: src/Preferences.cpp
-msgid "Albanian"
-msgstr "Albanés"
-
-#: src/Preferences.cpp
-msgid "Arabic"
-msgstr "Árabe"
-
-#: src/Preferences.cpp
-msgid "Asturian"
-msgstr "Asturiano"
-
-#: src/Preferences.cpp
-msgid "Basque"
-msgstr "Euskera"
-
-#: src/Preferences.cpp
-msgid "Bulgarian"
-msgstr "Búlgaro"
-
-#: src/Preferences.cpp
-msgid "Catalan"
-msgstr "Catalán"
-
-#: src/Preferences.cpp
-msgid "Chinese (Simplified)"
-msgstr "Chinés (Simplificado)"
-
-#: src/Preferences.cpp
-msgid "Chinese (Traditional)"
-msgstr "Chinés (Tradicional)"
-
-#: src/Preferences.cpp
-msgid "Croatian"
-msgstr "Croata"
-
-#: src/Preferences.cpp
-msgid "Czech"
-msgstr "Checo"
-
-#: src/Preferences.cpp
-msgid "Danish"
-msgstr "Danés"
-
-#: src/Preferences.cpp
-msgid "Dutch"
-msgstr "Holandés"
-
-#: src/Preferences.cpp
-msgid "English (U.K.)"
-msgstr "Inglés (R. U.)"
-
-#: src/Preferences.cpp
-#, fuzzy
-msgid "English (U.S.)"
-msgstr "Inglés (R. U.)"
-
-#: src/Preferences.cpp
-msgid "Estonian"
-msgstr "Estonio"
-
-#: src/Preferences.cpp
-msgid "Finnish"
-msgstr "Finlandés"
-
-#: src/Preferences.cpp
-msgid "French"
-msgstr "Francés"
-
-#: src/Preferences.cpp
-msgid "Galician"
-msgstr "Galego"
-
-#: src/Preferences.cpp
-msgid "German"
-msgstr "Alemán"
-
-#: src/Preferences.cpp
-msgid "Greek"
-msgstr "Grego"
-
-#: src/Preferences.cpp
-msgid "Hebrew"
-msgstr "Hebreo"
-
-#: src/Preferences.cpp
-msgid "Hungarian"
-msgstr "Húngaro"
-
-#: src/Preferences.cpp
-msgid "Italian"
-msgstr "Italiano"
-
-#: src/Preferences.cpp
-msgid "Japanese"
-msgstr "Xaponés"
-
-#: src/Preferences.cpp
-msgid "Korean"
-msgstr "Coreano"
-
-#: src/Preferences.cpp
-msgid "Latvian"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Lithuanian"
-msgstr "Lituano"
-
-#: src/Preferences.cpp
-msgid "Norwegian (Nynorsk)"
-msgstr "Noruegués (Nynorsk)"
-
-#: src/Preferences.cpp
-msgid "Polish"
-msgstr "Polaco"
-
-#: src/Preferences.cpp
-msgid "Portuguese"
-msgstr "Portugués"
-
-#: src/Preferences.cpp
-msgid "Portuguese (Brazilian)"
-msgstr "Portugués (Brasileiro)"
-
-#: src/Preferences.cpp
-msgid "Romanian"
-msgstr "Rumano"
-
-#: src/Preferences.cpp
-msgid "Russian"
-msgstr "Ruso"
-
-#: src/Preferences.cpp
-msgid "Slovenian"
-msgstr "Esloveno"
-
-#: src/Preferences.cpp
-msgid "Spanish"
-msgstr "Castelán"
-
-#: src/Preferences.cpp
-msgid "Swedish"
-msgstr "Sueco"
-
-#: src/Preferences.cpp
-msgid "Turkish"
-msgstr "Turco"
-
-#: src/Preferences.cpp
-msgid "Ukrainian"
-msgstr "Ucraniano"
-
-#: src/Preferences.cpp
-msgid "Change Language"
-msgstr "Cambiar idioma"
-
-#: src/Preferences.cpp
-msgid "There are no translations installed for aMule"
-msgstr "Non hai traducións instaladas para aMule"
-
-#: src/Preferences.cpp
-msgid "No languages available"
-msgstr "Ningunha lingua dispoñible"
-
-#: src/Preferences.cpp
 msgid "no options available"
 msgstr "non hai opcións disponibles"
 
@@ -6573,7 +6603,8 @@ msgstr "Compartir de xeito recursivo publicará calquera ficheiro que teñan deb
 msgid "Confirm shared folders"
 msgstr "Confirmar e compartir cartafoles"
 
-#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp src/SharedFilesReloadProgress.cpp
+#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp
+#: src/SharedFilesReloadProgress.cpp
 msgid "Reloading shared files..."
 msgstr "Recargando os ficheiros compartidos..."
 
@@ -9317,6 +9348,15 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "Change Language"
+#~ msgstr "Cambiar idioma"
+
+#~ msgid "There are no translations installed for aMule"
+#~ msgstr "Non hai traducións instaladas para aMule"
+
+#~ msgid "No languages available"
+#~ msgstr "Ningunha lingua dispoñible"
 
 #~ msgid "User name"
 #~ msgstr "Nome de usuario"

--- a/po/he.po
+++ b/po/he.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-05 12:01+0200\n"
+"POT-Creation-Date: 2026-09-06 14:35+0200\n"
 "PO-Revision-Date: 2026-09-05 10:52+0000\n"
 "Last-Translator: Peace Kramer <kpeace1@gmail.com>\n"
 "Language-Team: Hebrew\n"
@@ -382,7 +382,8 @@ msgstr ""
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr ""
 
-#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
+#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
+#: src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
 msgid "ERROR"
 msgstr ""
 
@@ -662,7 +663,8 @@ msgstr "רשתות"
 msgid "Searches"
 msgstr "חיפושים"
 
-#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/Statistics.cpp
+#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/Statistics.cpp
 msgid "Downloads"
 msgstr "הורדות"
 
@@ -746,7 +748,9 @@ msgstr "קאד: מכובה"
 msgid "Core"
 msgstr ""
 
-#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp src/Statistics.cpp
+#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp src/Statistics.cpp
 msgid "Version"
 msgstr "גירסא"
 
@@ -1049,7 +1053,11 @@ msgstr ""
 msgid "The remote core sent inconsistent data for \"%s\" (part status %d, expected %d). The file list may be showing the wrong information; reconnect to clear it."
 msgstr ""
 
-#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp src/Statistics.cpp
+#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp
+#: src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp
+#: src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp
+#: src/Statistics.cpp
 msgid "Unknown"
 msgstr "לא ידוע"
 
@@ -1147,7 +1155,8 @@ msgstr "שגיאה במהלך שמירת הקובץ known.met: %s"
 msgid "Enter Captcha"
 msgstr ""
 
-#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp src/TransferWnd.cpp
+#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp
+#: src/TransferWnd.cpp
 msgid "Category"
 msgstr "קטיגוריה"
 
@@ -1311,11 +1320,13 @@ msgstr ""
 msgid "Client Details"
 msgstr ""
 
-#: src/ClientDetailDialog.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
+#: src/utils/wxCas/src/onlinesig.cpp
 msgid "LowID"
 msgstr "מ\"ז נמוך (LowID)"
 
-#: src/ClientDetailDialog.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
+#: src/utils/wxCas/src/onlinesig.cpp
 msgid "HighID"
 msgstr "מ\"ז גבוה (HighID)"
 
@@ -1331,7 +1342,8 @@ msgstr ""
 msgid "Not supported"
 msgstr ""
 
-#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp src/TextClient.cpp
+#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
+#: src/TextClient.cpp
 msgid "Connected"
 msgstr "מחובר"
 
@@ -1339,7 +1351,8 @@ msgstr "מחובר"
 msgid "Disconnected"
 msgstr "מנותק"
 
-#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f KiB/s"
 msgstr ""
@@ -1356,7 +1369,8 @@ msgstr ""
 msgid "IP Address"
 msgstr "כתובת IP"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Origin"
 msgstr ""
 
@@ -1374,12 +1388,14 @@ msgstr "פעם אחרונה שנתקבל"
 msgid "Sessions"
 msgstr "גירסא"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/SharedFilePeersListCtrl.cpp
 #, fuzzy
 msgid "Upload Speed"
 msgstr "מהירות-העלאה"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/SharedFilePeersListCtrl.cpp
 #, fuzzy
 msgid "Download Speed"
 msgstr "מהירות הורדה"
@@ -1435,11 +1451,13 @@ msgstr[1] ""
 msgid "Files"
 msgstr "קבצים"
 
-#: src/ClientsListCtrl.cpp src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientsListCtrl.cpp src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp
 msgid "Uploaded"
 msgstr ""
 
-#: src/ClientsListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientsListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Downloaded"
 msgstr ""
 
@@ -1530,7 +1548,8 @@ msgstr "הערות על הקובץ"
 msgid "Username"
 msgstr "שם משתמש"
 
-#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp
+#: src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "File Name"
 msgstr "שם קובץ"
 
@@ -1591,15 +1610,18 @@ msgstr "אוטומטי [גבוה]"
 msgid "Very low"
 msgstr "מאוד נמוך"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Low"
 msgstr "נמוך"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Normal"
 msgstr "רגיל"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "High"
 msgstr "גבוה"
 
@@ -1623,11 +1645,13 @@ msgstr "מתחבר דרך השרת"
 msgid "Queue Full"
 msgstr "התור מלא"
 
-#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp src/muuli_wdr.cpp
+#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp
+#: src/muuli_wdr.cpp
 msgid "On Queue"
 msgstr "על התור"
 
-#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
+#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp
+#: src/PartFile.cpp src/TransferWnd.cpp
 msgid "Downloading"
 msgstr "מוריד מהרשת"
 
@@ -1687,7 +1711,8 @@ msgstr "שרת מקומי"
 msgid "Remote Server"
 msgstr "שרת מרוחק"
 
-#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp src/TextClient.cpp
+#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp
+#: src/TextClient.cpp
 msgid "Kad"
 msgstr "קאד"
 
@@ -1711,7 +1736,8 @@ msgstr "מזריעי מקורות"
 msgid "Search Result"
 msgstr ""
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp
+#: src/TransferWnd.cpp
 msgid "Completed"
 msgstr "הסתיים"
 
@@ -1764,7 +1790,8 @@ msgstr ""
 msgid "Part"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 msgid "Size"
 msgstr "גודל"
 
@@ -1772,7 +1799,8 @@ msgstr "גודל"
 msgid "Transferred"
 msgstr "הועברו"
 
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp src/SourceListCtrl.cpp
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
+#: src/SourceListCtrl.cpp
 msgid "Speed"
 msgstr "מהירות"
 
@@ -1780,11 +1808,13 @@ msgstr "מהירות"
 msgid "Progress"
 msgstr "התקדמות"
 
-#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
+#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp
+#: src/SearchListCtrl.cpp
 msgid "Sources"
 msgstr "מקורות"
 
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 msgid "Priority"
 msgstr "עדיפות"
 
@@ -1808,7 +1838,9 @@ msgstr "פעם אחרונה שנתקבל"
 msgid "Auto"
 msgstr "אוטמטי"
 
-#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/TransferWnd.cpp src/utils/wxCas/src/wxcasprefs.cpp
+#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/TransferWnd.cpp
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Cancel"
 msgstr "ביטול"
 
@@ -1907,7 +1939,8 @@ msgstr "הכנס שם חדש עבור קובץ זה"
 msgid "File rename"
 msgstr "שינוי שם לקובץ"
 
-#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f MiB/s"
 msgstr ""
@@ -2692,11 +2725,13 @@ msgstr ""
 msgid "Start aMule automatically when I log in"
 msgstr ""
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp packaging/windows/installer_strings.c
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: packaging/windows/installer_strings.c
 msgid "Register aMule for ed2k:// links"
 msgstr ""
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp packaging/windows/installer_strings.c
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: packaging/windows/installer_strings.c
 msgid "Register aMule for magnet: links"
 msgstr ""
 
@@ -2722,7 +2757,8 @@ msgstr ""
 msgid "Destination folder for downloads"
 msgstr ""
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Browse"
 msgstr "דפדף"
 
@@ -3147,6 +3183,165 @@ msgstr ""
 msgid "Invalid entry in known file list, file may be corrupt: "
 msgstr ""
 
+#: src/LanguageList.cpp
+msgid "System default"
+msgstr "ברירת מחדל של המערכת"
+
+#: src/LanguageList.cpp
+msgid "Albanian"
+msgstr "אלבני"
+
+#: src/LanguageList.cpp
+msgid "Arabic"
+msgstr "ערבית"
+
+#: src/LanguageList.cpp
+#, fuzzy
+msgid "Asturian"
+msgstr "אסטונית"
+
+#: src/LanguageList.cpp
+msgid "Basque"
+msgstr "בסקית"
+
+#: src/LanguageList.cpp
+msgid "Bulgarian"
+msgstr "בולגרית"
+
+#: src/LanguageList.cpp
+msgid "Catalan"
+msgstr "קטלונית"
+
+#: src/LanguageList.cpp
+msgid "Chinese (Simplified)"
+msgstr "סינית (מופשטת)"
+
+#: src/LanguageList.cpp
+msgid "Chinese (Traditional)"
+msgstr "סינית (מסורתית)"
+
+#: src/LanguageList.cpp
+msgid "Croatian"
+msgstr "קרואטית"
+
+#: src/LanguageList.cpp
+msgid "Czech"
+msgstr "צ'כית"
+
+#: src/LanguageList.cpp
+msgid "Danish"
+msgstr "דנית"
+
+#: src/LanguageList.cpp
+msgid "Dutch"
+msgstr "הולנדית"
+
+#: src/LanguageList.cpp
+msgid "English (U.K.)"
+msgstr "אנגלית (בריטית)"
+
+#: src/LanguageList.cpp
+#, fuzzy
+msgid "English (U.S.)"
+msgstr "אנגלית (בריטית)"
+
+#: src/LanguageList.cpp
+msgid "Estonian"
+msgstr "אסטונית"
+
+#: src/LanguageList.cpp
+msgid "Finnish"
+msgstr "פינית"
+
+#: src/LanguageList.cpp
+msgid "French"
+msgstr "צרפתית"
+
+#: src/LanguageList.cpp
+msgid "Galician"
+msgstr "גאלית"
+
+#: src/LanguageList.cpp
+msgid "German"
+msgstr "גרמנית"
+
+#: src/LanguageList.cpp
+msgid "Greek"
+msgstr "יוונית"
+
+#: src/LanguageList.cpp
+msgid "Hebrew"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Hungarian"
+msgstr "הונגרית"
+
+#: src/LanguageList.cpp
+msgid "Italian"
+msgstr "איטלקית"
+
+#: src/LanguageList.cpp
+msgid "Japanese"
+msgstr "יפנית"
+
+#: src/LanguageList.cpp
+msgid "Korean"
+msgstr "קוראינית"
+
+#: src/LanguageList.cpp
+msgid "Latvian"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Lithuanian"
+msgstr "ליטאית"
+
+#: src/LanguageList.cpp
+msgid "Norwegian (Nynorsk)"
+msgstr "נורבגית (Nynorsk)"
+
+#: src/LanguageList.cpp
+msgid "Polish"
+msgstr "פונלית"
+
+#: src/LanguageList.cpp
+msgid "Portuguese"
+msgstr "פורטגזית"
+
+#: src/LanguageList.cpp
+msgid "Portuguese (Brazilian)"
+msgstr "פורטגזית (ברזילאית)"
+
+#: src/LanguageList.cpp
+#, fuzzy
+msgid "Romanian"
+msgstr "אלבני"
+
+#: src/LanguageList.cpp
+msgid "Russian"
+msgstr "רוסית"
+
+#: src/LanguageList.cpp
+msgid "Slovenian"
+msgstr "סלובקית"
+
+#: src/LanguageList.cpp
+msgid "Spanish"
+msgstr "ספרדית"
+
+#: src/LanguageList.cpp
+msgid "Swedish"
+msgstr "שוודית"
+
+#: src/LanguageList.cpp
+msgid "Turkish"
+msgstr "טורקית"
+
+#: src/LanguageList.cpp
+msgid "Ukrainian"
+msgstr ""
+
 #: src/libs/common/Format.cpp
 #, fuzzy, c-format
 msgid "Unknown error %d"
@@ -3169,15 +3364,18 @@ msgstr "מסיים"
 msgid "Complete"
 msgstr "סיים"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Paused"
 msgstr "הושהה"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Erroneous"
 msgstr "שגוי"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Waiting"
 msgstr "ממתין"
 
@@ -3343,7 +3541,8 @@ msgstr "סגור"
 msgid "Cut"
 msgstr "גזור"
 
-#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp src/utils/aLinkCreator/src/alcframe.cpp
+#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy"
 msgstr "העתק"
 
@@ -3351,7 +3550,8 @@ msgstr "העתק"
 msgid "Paste"
 msgstr "הדבק"
 
-#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
+#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Clear"
 msgstr "נקה"
 
@@ -3359,7 +3559,8 @@ msgstr "נקה"
 msgid "Select All"
 msgstr "בחר הכל"
 
-#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp src/StatisticsDlg.cpp
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
+#: src/StatisticsDlg.cpp
 msgid "KiB/s"
 msgstr ""
 
@@ -5854,178 +6055,6 @@ msgid "ERROR: Failed to open partfile '%s'"
 msgstr ""
 
 #: src/Preferences.cpp
-msgid "System default"
-msgstr "ברירת מחדל של המערכת"
-
-#: src/Preferences.cpp
-msgid "Albanian"
-msgstr "אלבני"
-
-#: src/Preferences.cpp
-msgid "Arabic"
-msgstr "ערבית"
-
-#: src/Preferences.cpp
-#, fuzzy
-msgid "Asturian"
-msgstr "אסטונית"
-
-#: src/Preferences.cpp
-msgid "Basque"
-msgstr "בסקית"
-
-#: src/Preferences.cpp
-msgid "Bulgarian"
-msgstr "בולגרית"
-
-#: src/Preferences.cpp
-msgid "Catalan"
-msgstr "קטלונית"
-
-#: src/Preferences.cpp
-msgid "Chinese (Simplified)"
-msgstr "סינית (מופשטת)"
-
-#: src/Preferences.cpp
-msgid "Chinese (Traditional)"
-msgstr "סינית (מסורתית)"
-
-#: src/Preferences.cpp
-msgid "Croatian"
-msgstr "קרואטית"
-
-#: src/Preferences.cpp
-msgid "Czech"
-msgstr "צ'כית"
-
-#: src/Preferences.cpp
-msgid "Danish"
-msgstr "דנית"
-
-#: src/Preferences.cpp
-msgid "Dutch"
-msgstr "הולנדית"
-
-#: src/Preferences.cpp
-msgid "English (U.K.)"
-msgstr "אנגלית (בריטית)"
-
-#: src/Preferences.cpp
-#, fuzzy
-msgid "English (U.S.)"
-msgstr "אנגלית (בריטית)"
-
-#: src/Preferences.cpp
-msgid "Estonian"
-msgstr "אסטונית"
-
-#: src/Preferences.cpp
-msgid "Finnish"
-msgstr "פינית"
-
-#: src/Preferences.cpp
-msgid "French"
-msgstr "צרפתית"
-
-#: src/Preferences.cpp
-msgid "Galician"
-msgstr "גאלית"
-
-#: src/Preferences.cpp
-msgid "German"
-msgstr "גרמנית"
-
-#: src/Preferences.cpp
-msgid "Greek"
-msgstr "יוונית"
-
-#: src/Preferences.cpp
-msgid "Hebrew"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Hungarian"
-msgstr "הונגרית"
-
-#: src/Preferences.cpp
-msgid "Italian"
-msgstr "איטלקית"
-
-#: src/Preferences.cpp
-msgid "Japanese"
-msgstr "יפנית"
-
-#: src/Preferences.cpp
-msgid "Korean"
-msgstr "קוראינית"
-
-#: src/Preferences.cpp
-msgid "Latvian"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Lithuanian"
-msgstr "ליטאית"
-
-#: src/Preferences.cpp
-msgid "Norwegian (Nynorsk)"
-msgstr "נורבגית (Nynorsk)"
-
-#: src/Preferences.cpp
-msgid "Polish"
-msgstr "פונלית"
-
-#: src/Preferences.cpp
-msgid "Portuguese"
-msgstr "פורטגזית"
-
-#: src/Preferences.cpp
-msgid "Portuguese (Brazilian)"
-msgstr "פורטגזית (ברזילאית)"
-
-#: src/Preferences.cpp
-#, fuzzy
-msgid "Romanian"
-msgstr "אלבני"
-
-#: src/Preferences.cpp
-msgid "Russian"
-msgstr "רוסית"
-
-#: src/Preferences.cpp
-msgid "Slovenian"
-msgstr "סלובקית"
-
-#: src/Preferences.cpp
-msgid "Spanish"
-msgstr "ספרדית"
-
-#: src/Preferences.cpp
-msgid "Swedish"
-msgstr "שוודית"
-
-#: src/Preferences.cpp
-msgid "Turkish"
-msgstr "טורקית"
-
-#: src/Preferences.cpp
-msgid "Ukrainian"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Change Language"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "There are no translations installed for aMule"
-msgstr ""
-
-#: src/Preferences.cpp
-#, fuzzy
-msgid "No languages available"
-msgstr "לא זמין"
-
-#: src/Preferences.cpp
 msgid "no options available"
 msgstr ""
 
@@ -6529,7 +6558,8 @@ msgstr ""
 msgid "Confirm shared folders"
 msgstr "טען מחדש את הקבצים המשותפים שלך"
 
-#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp src/SharedFilesReloadProgress.cpp
+#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp
+#: src/SharedFilesReloadProgress.cpp
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "טען מחדש את הקבצים המשותפים שלך"
@@ -9266,6 +9296,10 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#, fuzzy
+#~ msgid "No languages available"
+#~ msgstr "לא זמין"
 
 #~ msgid "Obtained Parts"
 #~ msgstr "חלקים שהושגו"

--- a/po/hr.po
+++ b/po/hr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-05 12:01+0200\n"
+"POT-Creation-Date: 2026-09-06 14:35+0200\n"
 "PO-Revision-Date: 2026-09-05 10:52+0000\n"
 "Last-Translator: Sebastiano Pistore <sebastiano.pistore.info@aol.com>\n"
 "Language-Team: https://github.com/amule-org/amule <forum@aMule.org>\n"
@@ -380,7 +380,8 @@ msgstr ""
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr ""
 
-#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
+#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
+#: src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
 msgid "ERROR"
 msgstr "GREŠKA"
 
@@ -660,7 +661,8 @@ msgstr ""
 msgid "Searches"
 msgstr "Pretrage"
 
-#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/Statistics.cpp
+#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/Statistics.cpp
 msgid "Downloads"
 msgstr "Downloads"
 
@@ -746,7 +748,9 @@ msgstr ""
 msgid "Core"
 msgstr ""
 
-#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp src/Statistics.cpp
+#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp src/Statistics.cpp
 msgid "Version"
 msgstr "Verzija"
 
@@ -1047,7 +1051,11 @@ msgstr ""
 msgid "The remote core sent inconsistent data for \"%s\" (part status %d, expected %d). The file list may be showing the wrong information; reconnect to clear it."
 msgstr ""
 
-#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp src/Statistics.cpp
+#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp
+#: src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp
+#: src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp
+#: src/Statistics.cpp
 msgid "Unknown"
 msgstr "Nepoznat"
 
@@ -1147,7 +1155,8 @@ msgstr "Greska prilikom spajanja sa %s (%s:%i): %d"
 msgid "Enter Captcha"
 msgstr "Pisati captcha"
 
-#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp src/TransferWnd.cpp
+#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp
+#: src/TransferWnd.cpp
 msgid "Category"
 msgstr "Kategorija"
 
@@ -1314,11 +1323,13 @@ msgstr ""
 msgid "Client Details"
 msgstr "Detalji klienta"
 
-#: src/ClientDetailDialog.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
+#: src/utils/wxCas/src/onlinesig.cpp
 msgid "LowID"
 msgstr "LowID"
 
-#: src/ClientDetailDialog.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
+#: src/utils/wxCas/src/onlinesig.cpp
 msgid "HighID"
 msgstr ""
 
@@ -1334,7 +1345,8 @@ msgstr "Podržano"
 msgid "Not supported"
 msgstr "Nije podržano"
 
-#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp src/TextClient.cpp
+#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
+#: src/TextClient.cpp
 msgid "Connected"
 msgstr "Veza uspostavljena"
 
@@ -1342,7 +1354,8 @@ msgstr "Veza uspostavljena"
 msgid "Disconnected"
 msgstr "Prekinuta veza"
 
-#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f KiB/s"
 msgstr ""
@@ -1359,7 +1372,8 @@ msgstr ""
 msgid "IP Address"
 msgstr "IP adresa"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Origin"
 msgstr ""
 
@@ -1377,12 +1391,14 @@ msgstr "Posljedni prijem"
 msgid "Sessions"
 msgstr "Verzija"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/SharedFilePeersListCtrl.cpp
 #, fuzzy
 msgid "Upload Speed"
 msgstr "Brzina uploada"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/SharedFilePeersListCtrl.cpp
 #, fuzzy
 msgid "Download Speed"
 msgstr "Brzina downloada"
@@ -1438,11 +1454,13 @@ msgstr[2] ""
 msgid "Files"
 msgstr "Fajlovi"
 
-#: src/ClientsListCtrl.cpp src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientsListCtrl.cpp src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp
 msgid "Uploaded"
 msgstr ""
 
-#: src/ClientsListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientsListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Downloaded"
 msgstr ""
 
@@ -1533,7 +1551,8 @@ msgstr "Komentari fajla"
 msgid "Username"
 msgstr "Ime korisnika"
 
-#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp
+#: src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "File Name"
 msgstr "Ime fajla"
 
@@ -1596,15 +1615,18 @@ msgstr "Auto [Vi]"
 msgid "Very low"
 msgstr "Vrlo nizak"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Low"
 msgstr "Nisko"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Normal"
 msgstr "Normalan"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "High"
 msgstr "Visoko"
 
@@ -1628,11 +1650,13 @@ msgstr "Spaja preko servera"
 msgid "Queue Full"
 msgstr "Pun red cekanja"
 
-#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp src/muuli_wdr.cpp
+#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp
+#: src/muuli_wdr.cpp
 msgid "On Queue"
 msgstr "U redu cekanja"
 
-#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
+#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp
+#: src/PartFile.cpp src/TransferWnd.cpp
 msgid "Downloading"
 msgstr "Downloading"
 
@@ -1692,7 +1716,8 @@ msgstr ""
 msgid "Remote Server"
 msgstr ""
 
-#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp src/TextClient.cpp
+#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp
+#: src/TextClient.cpp
 msgid "Kad"
 msgstr "Kad"
 
@@ -1716,7 +1741,8 @@ msgstr ""
 msgid "Search Result"
 msgstr "Rezultati pretrage"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp
+#: src/TransferWnd.cpp
 msgid "Completed"
 msgstr "Zavrseno"
 
@@ -1768,7 +1794,8 @@ msgstr ""
 msgid "Part"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 msgid "Size"
 msgstr "Velicina"
 
@@ -1776,7 +1803,8 @@ msgstr "Velicina"
 msgid "Transferred"
 msgstr "Transferirano"
 
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp src/SourceListCtrl.cpp
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
+#: src/SourceListCtrl.cpp
 msgid "Speed"
 msgstr "Brzina"
 
@@ -1784,11 +1812,13 @@ msgstr "Brzina"
 msgid "Progress"
 msgstr "Napredak"
 
-#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
+#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp
+#: src/SearchListCtrl.cpp
 msgid "Sources"
 msgstr "Izvori"
 
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 msgid "Priority"
 msgstr "Prioritet"
 
@@ -1812,7 +1842,9 @@ msgstr "Posljedni prijem"
 msgid "Auto"
 msgstr "Automatski"
 
-#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/TransferWnd.cpp src/utils/wxCas/src/wxcasprefs.cpp
+#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/TransferWnd.cpp
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Cancel"
 msgstr "Otkaz"
 
@@ -1913,7 +1945,8 @@ msgstr ""
 msgid "File rename"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f MiB/s"
 msgstr ""
@@ -2689,11 +2722,13 @@ msgstr ""
 msgid "Start aMule automatically when I log in"
 msgstr ""
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp packaging/windows/installer_strings.c
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: packaging/windows/installer_strings.c
 msgid "Register aMule for ed2k:// links"
 msgstr ""
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp packaging/windows/installer_strings.c
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: packaging/windows/installer_strings.c
 msgid "Register aMule for magnet: links"
 msgstr ""
 
@@ -2719,7 +2754,8 @@ msgstr ""
 msgid "Destination folder for downloads"
 msgstr ""
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Browse"
 msgstr "Pretrazi :"
 
@@ -3146,6 +3182,163 @@ msgstr ""
 msgid "Invalid entry in known file list, file may be corrupt: "
 msgstr ""
 
+#: src/LanguageList.cpp
+msgid "System default"
+msgstr "Standard sistema"
+
+#: src/LanguageList.cpp
+msgid "Albanian"
+msgstr "Albanski"
+
+#: src/LanguageList.cpp
+msgid "Arabic"
+msgstr "Arapski"
+
+#: src/LanguageList.cpp
+msgid "Asturian"
+msgstr "Asturleonski"
+
+#: src/LanguageList.cpp
+msgid "Basque"
+msgstr "Baskijski"
+
+#: src/LanguageList.cpp
+msgid "Bulgarian"
+msgstr "Bugarski"
+
+#: src/LanguageList.cpp
+msgid "Catalan"
+msgstr "Katalonski"
+
+#: src/LanguageList.cpp
+msgid "Chinese (Simplified)"
+msgstr "Kineski"
+
+#: src/LanguageList.cpp
+msgid "Chinese (Traditional)"
+msgstr "Kinesko (tradicionalno)"
+
+#: src/LanguageList.cpp
+msgid "Croatian"
+msgstr "Hrvatski"
+
+#: src/LanguageList.cpp
+msgid "Czech"
+msgstr "Češki"
+
+#: src/LanguageList.cpp
+msgid "Danish"
+msgstr "Danski"
+
+#: src/LanguageList.cpp
+msgid "Dutch"
+msgstr "Nizozemski"
+
+#: src/LanguageList.cpp
+msgid "English (U.K.)"
+msgstr "Engleski (U.K.)"
+
+#: src/LanguageList.cpp
+#, fuzzy
+msgid "English (U.S.)"
+msgstr "Engleski (U.K.)"
+
+#: src/LanguageList.cpp
+msgid "Estonian"
+msgstr "Estonski"
+
+#: src/LanguageList.cpp
+msgid "Finnish"
+msgstr "Finski"
+
+#: src/LanguageList.cpp
+msgid "French"
+msgstr "Francuski"
+
+#: src/LanguageList.cpp
+msgid "Galician"
+msgstr "Galješki"
+
+#: src/LanguageList.cpp
+msgid "German"
+msgstr "Njemački"
+
+#: src/LanguageList.cpp
+msgid "Greek"
+msgstr "Grčki"
+
+#: src/LanguageList.cpp
+msgid "Hebrew"
+msgstr "Hebrejski"
+
+#: src/LanguageList.cpp
+msgid "Hungarian"
+msgstr "Mađarski"
+
+#: src/LanguageList.cpp
+msgid "Italian"
+msgstr "Talijanski"
+
+#: src/LanguageList.cpp
+msgid "Japanese"
+msgstr "Japanski"
+
+#: src/LanguageList.cpp
+msgid "Korean"
+msgstr "Korejski"
+
+#: src/LanguageList.cpp
+msgid "Latvian"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Lithuanian"
+msgstr "Litavski"
+
+#: src/LanguageList.cpp
+msgid "Norwegian (Nynorsk)"
+msgstr "Norveški (Nynorsk)"
+
+#: src/LanguageList.cpp
+msgid "Polish"
+msgstr "Poljski"
+
+#: src/LanguageList.cpp
+msgid "Portuguese"
+msgstr "Portugalski"
+
+#: src/LanguageList.cpp
+msgid "Portuguese (Brazilian)"
+msgstr "Portugalski (Brazil)"
+
+#: src/LanguageList.cpp
+msgid "Romanian"
+msgstr "Rumunjski"
+
+#: src/LanguageList.cpp
+msgid "Russian"
+msgstr "Ruski"
+
+#: src/LanguageList.cpp
+msgid "Slovenian"
+msgstr "Slovenski"
+
+#: src/LanguageList.cpp
+msgid "Spanish"
+msgstr "Španjolski"
+
+#: src/LanguageList.cpp
+msgid "Swedish"
+msgstr "Švedski"
+
+#: src/LanguageList.cpp
+msgid "Turkish"
+msgstr "Turski"
+
+#: src/LanguageList.cpp
+msgid "Ukrainian"
+msgstr "Ukrajinski"
+
 #: src/libs/common/Format.cpp
 #, fuzzy, c-format
 msgid "Unknown error %d"
@@ -3168,15 +3361,18 @@ msgstr "Zavrsavanje"
 msgid "Complete"
 msgstr "Zavrseno"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Paused"
 msgstr "Pausirano"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Erroneous"
 msgstr "Sa greskom"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Waiting"
 msgstr "Cekanje"
 
@@ -3344,7 +3540,8 @@ msgstr "Zatvori"
 msgid "Cut"
 msgstr ""
 
-#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp src/utils/aLinkCreator/src/alcframe.cpp
+#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy"
 msgstr "Kopiraj"
 
@@ -3352,7 +3549,8 @@ msgstr "Kopiraj"
 msgid "Paste"
 msgstr "Staviti"
 
-#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
+#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Clear"
 msgstr "Ocisti"
 
@@ -3360,7 +3558,8 @@ msgstr "Ocisti"
 msgid "Select All"
 msgstr "Izaberite sve"
 
-#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp src/StatisticsDlg.cpp
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
+#: src/StatisticsDlg.cpp
 msgid "KiB/s"
 msgstr ""
 
@@ -5867,175 +6066,6 @@ msgid "ERROR: Failed to open partfile '%s'"
 msgstr ""
 
 #: src/Preferences.cpp
-msgid "System default"
-msgstr "Standard sistema"
-
-#: src/Preferences.cpp
-msgid "Albanian"
-msgstr "Albanski"
-
-#: src/Preferences.cpp
-msgid "Arabic"
-msgstr "Arapski"
-
-#: src/Preferences.cpp
-msgid "Asturian"
-msgstr "Asturleonski"
-
-#: src/Preferences.cpp
-msgid "Basque"
-msgstr "Baskijski"
-
-#: src/Preferences.cpp
-msgid "Bulgarian"
-msgstr "Bugarski"
-
-#: src/Preferences.cpp
-msgid "Catalan"
-msgstr "Katalonski"
-
-#: src/Preferences.cpp
-msgid "Chinese (Simplified)"
-msgstr "Kineski"
-
-#: src/Preferences.cpp
-msgid "Chinese (Traditional)"
-msgstr "Kinesko (tradicionalno)"
-
-#: src/Preferences.cpp
-msgid "Croatian"
-msgstr "Hrvatski"
-
-#: src/Preferences.cpp
-msgid "Czech"
-msgstr "Češki"
-
-#: src/Preferences.cpp
-msgid "Danish"
-msgstr "Danski"
-
-#: src/Preferences.cpp
-msgid "Dutch"
-msgstr "Nizozemski"
-
-#: src/Preferences.cpp
-msgid "English (U.K.)"
-msgstr "Engleski (U.K.)"
-
-#: src/Preferences.cpp
-#, fuzzy
-msgid "English (U.S.)"
-msgstr "Engleski (U.K.)"
-
-#: src/Preferences.cpp
-msgid "Estonian"
-msgstr "Estonski"
-
-#: src/Preferences.cpp
-msgid "Finnish"
-msgstr "Finski"
-
-#: src/Preferences.cpp
-msgid "French"
-msgstr "Francuski"
-
-#: src/Preferences.cpp
-msgid "Galician"
-msgstr "Galješki"
-
-#: src/Preferences.cpp
-msgid "German"
-msgstr "Njemački"
-
-#: src/Preferences.cpp
-msgid "Greek"
-msgstr "Grčki"
-
-#: src/Preferences.cpp
-msgid "Hebrew"
-msgstr "Hebrejski"
-
-#: src/Preferences.cpp
-msgid "Hungarian"
-msgstr "Mađarski"
-
-#: src/Preferences.cpp
-msgid "Italian"
-msgstr "Talijanski"
-
-#: src/Preferences.cpp
-msgid "Japanese"
-msgstr "Japanski"
-
-#: src/Preferences.cpp
-msgid "Korean"
-msgstr "Korejski"
-
-#: src/Preferences.cpp
-msgid "Latvian"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Lithuanian"
-msgstr "Litavski"
-
-#: src/Preferences.cpp
-msgid "Norwegian (Nynorsk)"
-msgstr "Norveški (Nynorsk)"
-
-#: src/Preferences.cpp
-msgid "Polish"
-msgstr "Poljski"
-
-#: src/Preferences.cpp
-msgid "Portuguese"
-msgstr "Portugalski"
-
-#: src/Preferences.cpp
-msgid "Portuguese (Brazilian)"
-msgstr "Portugalski (Brazil)"
-
-#: src/Preferences.cpp
-msgid "Romanian"
-msgstr "Rumunjski"
-
-#: src/Preferences.cpp
-msgid "Russian"
-msgstr "Ruski"
-
-#: src/Preferences.cpp
-msgid "Slovenian"
-msgstr "Slovenski"
-
-#: src/Preferences.cpp
-msgid "Spanish"
-msgstr "Španjolski"
-
-#: src/Preferences.cpp
-msgid "Swedish"
-msgstr "Švedski"
-
-#: src/Preferences.cpp
-msgid "Turkish"
-msgstr "Turski"
-
-#: src/Preferences.cpp
-msgid "Ukrainian"
-msgstr "Ukrajinski"
-
-#: src/Preferences.cpp
-msgid "Change Language"
-msgstr "Promijeniti jezik"
-
-#: src/Preferences.cpp
-msgid "There are no translations installed for aMule"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "No languages available"
-msgstr "Nema dostupnih jezika"
-
-#: src/Preferences.cpp
 msgid "no options available"
 msgstr ""
 
@@ -6533,7 +6563,8 @@ msgstr ""
 msgid "Confirm shared folders"
 msgstr ""
 
-#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp src/SharedFilesReloadProgress.cpp
+#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp
+#: src/SharedFilesReloadProgress.cpp
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "Pronadjeno %i poznatih dijeljenih fajlova"
@@ -9237,6 +9268,12 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "Change Language"
+#~ msgstr "Promijeniti jezik"
+
+#~ msgid "No languages available"
+#~ msgstr "Nema dostupnih jezika"
 
 #~ msgid "User name"
 #~ msgstr "Korisničko ime"

--- a/po/hu.po
+++ b/po/hu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-05 12:01+0200\n"
+"POT-Creation-Date: 2026-09-06 14:35+0200\n"
 "PO-Revision-Date: 2026-09-05 10:53+0000\n"
 "Last-Translator: Dévai Tamás <gonosztopi@amule.org>\n"
 "Language-Team: Hungarian <hu@li.org>\n"
@@ -389,7 +389,8 @@ msgstr "web kiszolgáló fut, pid=%d"
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "A web szerver futtatását kérte induláskor, de az amuleweb program nem futtatható. Kérem telepítse az aMule web szervert tartalmazó csomagot, vagy építse az aMule-t a forráskódból a -DBUILD_WEBSERVER=YES paraméterrel és installálja azt."
 
-#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
+#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
+#: src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
 msgid "ERROR"
 msgstr "HIBA"
 
@@ -676,7 +677,8 @@ msgstr "Hálózatok"
 msgid "Searches"
 msgstr "Keresések"
 
-#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/Statistics.cpp
+#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/Statistics.cpp
 msgid "Downloads"
 msgstr "Letöltések"
 
@@ -760,7 +762,9 @@ msgstr "Kad: Nincs kapcsolat"
 msgid "Core"
 msgstr ""
 
-#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp src/Statistics.cpp
+#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp src/Statistics.cpp
 msgid "Version"
 msgstr "Verzió"
 
@@ -1061,7 +1065,11 @@ msgstr "A '%s' könyvtár létrehozása a '%s' kategóriához nem lehetséges, a
 msgid "The remote core sent inconsistent data for \"%s\" (part status %d, expected %d). The file list may be showing the wrong information; reconnect to clear it."
 msgstr ""
 
-#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp src/Statistics.cpp
+#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp
+#: src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp
+#: src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp
+#: src/Statistics.cpp
 msgid "Unknown"
 msgstr "Ismeretlen"
 
@@ -1156,7 +1164,8 @@ msgstr "Hiba a %s fájl mentése közben: %s"
 msgid "Enter Captcha"
 msgstr "Captcha megadása"
 
-#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp src/TransferWnd.cpp
+#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp
+#: src/TransferWnd.cpp
 msgid "Category"
 msgstr "Kategória"
 
@@ -1313,11 +1322,13 @@ msgstr "A 'cryptkey.dat' fájlt nem találom, létrehozok egyet."
 msgid "Client Details"
 msgstr "Kliens részletei"
 
-#: src/ClientDetailDialog.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
+#: src/utils/wxCas/src/onlinesig.cpp
 msgid "LowID"
 msgstr "LowID"
 
-#: src/ClientDetailDialog.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
+#: src/utils/wxCas/src/onlinesig.cpp
 msgid "HighID"
 msgstr "HighID"
 
@@ -1333,7 +1344,8 @@ msgstr "Támogatott"
 msgid "Not supported"
 msgstr "Nem támogatott"
 
-#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp src/TextClient.cpp
+#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
+#: src/TextClient.cpp
 msgid "Connected"
 msgstr "Csatlakozva"
 
@@ -1341,7 +1353,8 @@ msgstr "Csatlakozva"
 msgid "Disconnected"
 msgstr "Szétkapcsolva"
 
-#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f KiB/s"
 msgstr ""
@@ -1358,7 +1371,8 @@ msgstr ""
 msgid "IP Address"
 msgstr "IP-cím"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Origin"
 msgstr "Eredet"
 
@@ -1376,11 +1390,13 @@ msgstr "Utoljára fogadott"
 msgid "Sessions"
 msgstr "Verzió"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/SharedFilePeersListCtrl.cpp
 msgid "Upload Speed"
 msgstr "Feltöltési sebesség"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/SharedFilePeersListCtrl.cpp
 msgid "Download Speed"
 msgstr "Letöltési sebesség"
 
@@ -1434,11 +1450,13 @@ msgstr[0] ""
 msgid "Files"
 msgstr "Fájlok"
 
-#: src/ClientsListCtrl.cpp src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientsListCtrl.cpp src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp
 msgid "Uploaded"
 msgstr "Feltöltve"
 
-#: src/ClientsListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientsListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Downloaded"
 msgstr "Letöltve"
 
@@ -1529,7 +1547,8 @@ msgstr "Fájl megjegyzés"
 msgid "Username"
 msgstr "Felhasználói név"
 
-#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp
+#: src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "File Name"
 msgstr "Fájlnév"
 
@@ -1590,15 +1609,18 @@ msgstr "Auto [Ma]"
 msgid "Very low"
 msgstr "Nagyon alacsony"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Low"
 msgstr "Alacsony"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Normal"
 msgstr "Normál"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "High"
 msgstr "Magas"
 
@@ -1622,11 +1644,13 @@ msgstr "Kapcsolódás a kiszolgálón keresztül"
 msgid "Queue Full"
 msgstr "Várólista betelt"
 
-#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp src/muuli_wdr.cpp
+#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp
+#: src/muuli_wdr.cpp
 msgid "On Queue"
 msgstr "Várólistások"
 
-#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
+#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp
+#: src/PartFile.cpp src/TransferWnd.cpp
 msgid "Downloading"
 msgstr "Letöltés alatt"
 
@@ -1686,7 +1710,8 @@ msgstr "Helyi kiszolgáló"
 msgid "Remote Server"
 msgstr "Távoli kiszolgáló"
 
-#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp src/TextClient.cpp
+#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp
+#: src/TextClient.cpp
 msgid "Kad"
 msgstr "Kad"
 
@@ -1710,7 +1735,8 @@ msgstr "Mentett források"
 msgid "Search Result"
 msgstr "Keresés eredménye"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp
+#: src/TransferWnd.cpp
 msgid "Completed"
 msgstr "Befejezett"
 
@@ -1762,7 +1788,8 @@ msgstr ""
 msgid "Part"
 msgstr "Rész"
 
-#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 msgid "Size"
 msgstr "Méret"
 
@@ -1770,7 +1797,8 @@ msgstr "Méret"
 msgid "Transferred"
 msgstr "Átmásolva"
 
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp src/SourceListCtrl.cpp
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
+#: src/SourceListCtrl.cpp
 msgid "Speed"
 msgstr "Sebesség"
 
@@ -1778,11 +1806,13 @@ msgstr "Sebesség"
 msgid "Progress"
 msgstr "Folyamatjelző"
 
-#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
+#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp
+#: src/SearchListCtrl.cpp
 msgid "Sources"
 msgstr "Források"
 
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 msgid "Priority"
 msgstr "Prioritás"
 
@@ -1806,7 +1836,9 @@ msgstr "Utoljára fogadott"
 msgid "Auto"
 msgstr "Automatikus"
 
-#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/TransferWnd.cpp src/utils/wxCas/src/wxcasprefs.cpp
+#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/TransferWnd.cpp
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Cancel"
 msgstr "Mégsem"
 
@@ -1907,7 +1939,8 @@ msgstr "Írd be az új nevet ennek a fájlnak:"
 msgid "File rename"
 msgstr "Fájl átnevezés"
 
-#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f MiB/s"
 msgstr ""
@@ -2708,11 +2741,13 @@ msgstr ""
 msgid "Start aMule automatically when I log in"
 msgstr "aMule automatikus indítása bejelentkezéskor"
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp packaging/windows/installer_strings.c
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: packaging/windows/installer_strings.c
 msgid "Register aMule for ed2k:// links"
 msgstr ""
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp packaging/windows/installer_strings.c
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: packaging/windows/installer_strings.c
 msgid "Register aMule for magnet: links"
 msgstr ""
 
@@ -2738,7 +2773,8 @@ msgstr ""
 msgid "Destination folder for downloads"
 msgstr "Célkönyvtár a letöltéseknek"
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Browse"
 msgstr "Tallóz"
 
@@ -3154,6 +3190,163 @@ msgstr "Bejegyzés betöltése az ismert fájlok listájából sikertelen, hiba 
 msgid "Invalid entry in known file list, file may be corrupt: "
 msgstr "Érvénytelen bejegyzés az ismert fájlok listájában, hiba lehet a fájlban: "
 
+#: src/LanguageList.cpp
+msgid "System default"
+msgstr "Alapértelmezett"
+
+#: src/LanguageList.cpp
+msgid "Albanian"
+msgstr "Albán"
+
+#: src/LanguageList.cpp
+msgid "Arabic"
+msgstr "Arab"
+
+#: src/LanguageList.cpp
+msgid "Asturian"
+msgstr "Asztúriai"
+
+#: src/LanguageList.cpp
+msgid "Basque"
+msgstr "Baszk"
+
+#: src/LanguageList.cpp
+msgid "Bulgarian"
+msgstr "Bolgár"
+
+#: src/LanguageList.cpp
+msgid "Catalan"
+msgstr "Katalán"
+
+#: src/LanguageList.cpp
+msgid "Chinese (Simplified)"
+msgstr "Kínai (egyszerűsített)"
+
+#: src/LanguageList.cpp
+msgid "Chinese (Traditional)"
+msgstr "Kínai (hagyományos)"
+
+#: src/LanguageList.cpp
+msgid "Croatian"
+msgstr "Horvát"
+
+#: src/LanguageList.cpp
+msgid "Czech"
+msgstr "Cseh"
+
+#: src/LanguageList.cpp
+msgid "Danish"
+msgstr "Dán"
+
+#: src/LanguageList.cpp
+msgid "Dutch"
+msgstr "Holland"
+
+#: src/LanguageList.cpp
+msgid "English (U.K.)"
+msgstr "Angol (Egyesült Királyság)"
+
+#: src/LanguageList.cpp
+#, fuzzy
+msgid "English (U.S.)"
+msgstr "Angol (Egyesült Királyság)"
+
+#: src/LanguageList.cpp
+msgid "Estonian"
+msgstr "Észt"
+
+#: src/LanguageList.cpp
+msgid "Finnish"
+msgstr "Finn"
+
+#: src/LanguageList.cpp
+msgid "French"
+msgstr "Francia"
+
+#: src/LanguageList.cpp
+msgid "Galician"
+msgstr "Gall"
+
+#: src/LanguageList.cpp
+msgid "German"
+msgstr "Német"
+
+#: src/LanguageList.cpp
+msgid "Greek"
+msgstr "Görög"
+
+#: src/LanguageList.cpp
+msgid "Hebrew"
+msgstr "Héber"
+
+#: src/LanguageList.cpp
+msgid "Hungarian"
+msgstr "Magyar"
+
+#: src/LanguageList.cpp
+msgid "Italian"
+msgstr "Olasz"
+
+#: src/LanguageList.cpp
+msgid "Japanese"
+msgstr "Japán"
+
+#: src/LanguageList.cpp
+msgid "Korean"
+msgstr "Koreai"
+
+#: src/LanguageList.cpp
+msgid "Latvian"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Lithuanian"
+msgstr "Litván"
+
+#: src/LanguageList.cpp
+msgid "Norwegian (Nynorsk)"
+msgstr "Norvég (Nynorsk)"
+
+#: src/LanguageList.cpp
+msgid "Polish"
+msgstr "Lengyel"
+
+#: src/LanguageList.cpp
+msgid "Portuguese"
+msgstr "Portugál"
+
+#: src/LanguageList.cpp
+msgid "Portuguese (Brazilian)"
+msgstr "Portugál (Brazíliai)"
+
+#: src/LanguageList.cpp
+msgid "Romanian"
+msgstr "Román"
+
+#: src/LanguageList.cpp
+msgid "Russian"
+msgstr "Orosz"
+
+#: src/LanguageList.cpp
+msgid "Slovenian"
+msgstr "Szlovén"
+
+#: src/LanguageList.cpp
+msgid "Spanish"
+msgstr "Spanyol"
+
+#: src/LanguageList.cpp
+msgid "Swedish"
+msgstr "Svéd"
+
+#: src/LanguageList.cpp
+msgid "Turkish"
+msgstr "Török"
+
+#: src/LanguageList.cpp
+msgid "Ukrainian"
+msgstr "Ukrán"
+
 #: src/libs/common/Format.cpp
 #, c-format
 msgid "Unknown error %d"
@@ -3176,15 +3369,18 @@ msgstr "Befejezés"
 msgid "Complete"
 msgstr "Kész"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Paused"
 msgstr "Szüneteltetve"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Erroneous"
 msgstr "Hibás"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Waiting"
 msgstr "Várakozik"
 
@@ -3344,7 +3540,8 @@ msgstr "Bezár"
 msgid "Cut"
 msgstr "Kivágás"
 
-#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp src/utils/aLinkCreator/src/alcframe.cpp
+#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy"
 msgstr "Másolás"
 
@@ -3352,7 +3549,8 @@ msgstr "Másolás"
 msgid "Paste"
 msgstr "Beillesztés"
 
-#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
+#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Clear"
 msgstr "Törlés"
 
@@ -3360,7 +3558,8 @@ msgstr "Törlés"
 msgid "Select All"
 msgstr "Mindent kijelöl"
 
-#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp src/StatisticsDlg.cpp
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
+#: src/StatisticsDlg.cpp
 msgid "KiB/s"
 msgstr ""
 
@@ -5854,175 +6053,6 @@ msgid "ERROR: Failed to open partfile '%s'"
 msgstr "HIBA: A(z) '%s' részfájl megnyitása sikertelen."
 
 #: src/Preferences.cpp
-msgid "System default"
-msgstr "Alapértelmezett"
-
-#: src/Preferences.cpp
-msgid "Albanian"
-msgstr "Albán"
-
-#: src/Preferences.cpp
-msgid "Arabic"
-msgstr "Arab"
-
-#: src/Preferences.cpp
-msgid "Asturian"
-msgstr "Asztúriai"
-
-#: src/Preferences.cpp
-msgid "Basque"
-msgstr "Baszk"
-
-#: src/Preferences.cpp
-msgid "Bulgarian"
-msgstr "Bolgár"
-
-#: src/Preferences.cpp
-msgid "Catalan"
-msgstr "Katalán"
-
-#: src/Preferences.cpp
-msgid "Chinese (Simplified)"
-msgstr "Kínai (egyszerűsített)"
-
-#: src/Preferences.cpp
-msgid "Chinese (Traditional)"
-msgstr "Kínai (hagyományos)"
-
-#: src/Preferences.cpp
-msgid "Croatian"
-msgstr "Horvát"
-
-#: src/Preferences.cpp
-msgid "Czech"
-msgstr "Cseh"
-
-#: src/Preferences.cpp
-msgid "Danish"
-msgstr "Dán"
-
-#: src/Preferences.cpp
-msgid "Dutch"
-msgstr "Holland"
-
-#: src/Preferences.cpp
-msgid "English (U.K.)"
-msgstr "Angol (Egyesült Királyság)"
-
-#: src/Preferences.cpp
-#, fuzzy
-msgid "English (U.S.)"
-msgstr "Angol (Egyesült Királyság)"
-
-#: src/Preferences.cpp
-msgid "Estonian"
-msgstr "Észt"
-
-#: src/Preferences.cpp
-msgid "Finnish"
-msgstr "Finn"
-
-#: src/Preferences.cpp
-msgid "French"
-msgstr "Francia"
-
-#: src/Preferences.cpp
-msgid "Galician"
-msgstr "Gall"
-
-#: src/Preferences.cpp
-msgid "German"
-msgstr "Német"
-
-#: src/Preferences.cpp
-msgid "Greek"
-msgstr "Görög"
-
-#: src/Preferences.cpp
-msgid "Hebrew"
-msgstr "Héber"
-
-#: src/Preferences.cpp
-msgid "Hungarian"
-msgstr "Magyar"
-
-#: src/Preferences.cpp
-msgid "Italian"
-msgstr "Olasz"
-
-#: src/Preferences.cpp
-msgid "Japanese"
-msgstr "Japán"
-
-#: src/Preferences.cpp
-msgid "Korean"
-msgstr "Koreai"
-
-#: src/Preferences.cpp
-msgid "Latvian"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Lithuanian"
-msgstr "Litván"
-
-#: src/Preferences.cpp
-msgid "Norwegian (Nynorsk)"
-msgstr "Norvég (Nynorsk)"
-
-#: src/Preferences.cpp
-msgid "Polish"
-msgstr "Lengyel"
-
-#: src/Preferences.cpp
-msgid "Portuguese"
-msgstr "Portugál"
-
-#: src/Preferences.cpp
-msgid "Portuguese (Brazilian)"
-msgstr "Portugál (Brazíliai)"
-
-#: src/Preferences.cpp
-msgid "Romanian"
-msgstr "Román"
-
-#: src/Preferences.cpp
-msgid "Russian"
-msgstr "Orosz"
-
-#: src/Preferences.cpp
-msgid "Slovenian"
-msgstr "Szlovén"
-
-#: src/Preferences.cpp
-msgid "Spanish"
-msgstr "Spanyol"
-
-#: src/Preferences.cpp
-msgid "Swedish"
-msgstr "Svéd"
-
-#: src/Preferences.cpp
-msgid "Turkish"
-msgstr "Török"
-
-#: src/Preferences.cpp
-msgid "Ukrainian"
-msgstr "Ukrán"
-
-#: src/Preferences.cpp
-msgid "Change Language"
-msgstr "Nyelv megváltoztatása"
-
-#: src/Preferences.cpp
-msgid "There are no translations installed for aMule"
-msgstr "Nincsenek fordítások telepítve az aMule-hez"
-
-#: src/Preferences.cpp
-msgid "No languages available"
-msgstr "Nincs elérhető nyelv"
-
-#: src/Preferences.cpp
 msgid "no options available"
 msgstr "nincs elérhető opció"
 
@@ -6528,7 +6558,8 @@ msgstr ""
 msgid "Confirm shared folders"
 msgstr "Megosztott mappák"
 
-#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp src/SharedFilesReloadProgress.cpp
+#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp
+#: src/SharedFilesReloadProgress.cpp
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "Megosztott fájlok frissítése"
@@ -9244,6 +9275,15 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "Change Language"
+#~ msgstr "Nyelv megváltoztatása"
+
+#~ msgid "There are no translations installed for aMule"
+#~ msgstr "Nincsenek fordítások telepítve az aMule-hez"
+
+#~ msgid "No languages available"
+#~ msgstr "Nincs elérhető nyelv"
 
 #~ msgid "User name"
 #~ msgstr "Felhasználói név"

--- a/po/it.po
+++ b/po/it.po
@@ -19,7 +19,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule 2.3.3\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-05 12:01+0200\n"
+"POT-Creation-Date: 2026-09-06 14:35+0200\n"
 "PO-Revision-Date: 2026-09-05 10:54+0000\n"
 "Last-Translator: got3nks <got3nks@users.noreply.github.com>\n"
 "Language-Team: SebastianoPistore.info@protonmail.ch\n"
@@ -399,7 +399,8 @@ msgstr "web server in esecuzione su pid %d"
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Hai scelto di lanciare il web server all'avvio, ma il programma amuleweb non può essere eseguito. Installa il pacchetto contenente aMule web server, oppure compila aMule dai sorgenti con -DBUILD_WEBSERVER=YES e installalo."
 
-#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
+#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
+#: src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
 msgid "ERROR"
 msgstr "ERRORE"
 
@@ -685,7 +686,8 @@ msgstr "Reti"
 msgid "Searches"
 msgstr "Ricerca"
 
-#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/Statistics.cpp
+#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/Statistics.cpp
 msgid "Downloads"
 msgstr "Download"
 
@@ -773,7 +775,9 @@ msgstr "Kad: Spento"
 msgid "Core"
 msgstr "Core"
 
-#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp src/Statistics.cpp
+#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp src/Statistics.cpp
 msgid "Version"
 msgstr "Versione"
 
@@ -1070,7 +1074,11 @@ msgstr "Impossibile creare la directory '%s' per la categoria '%s', verrà mante
 msgid "The remote core sent inconsistent data for \"%s\" (part status %d, expected %d). The file list may be showing the wrong information; reconnect to clear it."
 msgstr "Il core remoto ha inviato dati incoerenti per \"%s\" (stato della parte %d, atteso %d). La lista dei file potrebbe mostrare informazioni errate; riconnettiti per azzerarla."
 
-#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp src/Statistics.cpp
+#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp
+#: src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp
+#: src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp
+#: src/Statistics.cpp
 msgid "Unknown"
 msgstr "Sconosciuto"
 
@@ -1167,7 +1175,8 @@ msgstr "Errore durante il salvataggio del file %s: %s"
 msgid "Enter Captcha"
 msgstr "Inserisci captcha"
 
-#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp src/TransferWnd.cpp
+#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp
+#: src/TransferWnd.cpp
 msgid "Category"
 msgstr "Categoria"
 
@@ -1330,11 +1339,13 @@ msgstr "Non è stato trovato il file 'cryptkey.dat', creazione del file in corso
 msgid "Client Details"
 msgstr "Dettagli client"
 
-#: src/ClientDetailDialog.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
+#: src/utils/wxCas/src/onlinesig.cpp
 msgid "LowID"
 msgstr "ID basso"
 
-#: src/ClientDetailDialog.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
+#: src/utils/wxCas/src/onlinesig.cpp
 msgid "HighID"
 msgstr "ID alto"
 
@@ -1350,7 +1361,8 @@ msgstr "Supportato"
 msgid "Not supported"
 msgstr "Non supportato"
 
-#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp src/TextClient.cpp
+#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
+#: src/TextClient.cpp
 msgid "Connected"
 msgstr "Connesso"
 
@@ -1358,7 +1370,8 @@ msgstr "Connesso"
 msgid "Disconnected"
 msgstr "Disconnesso"
 
-#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f KiB/s"
 msgstr "%.1f KiB/s"
@@ -1375,7 +1388,8 @@ msgstr "Software"
 msgid "IP Address"
 msgstr "Indirizzo IP"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Origin"
 msgstr "Origine"
 
@@ -1391,11 +1405,13 @@ msgstr "Ultimo contatto"
 msgid "Sessions"
 msgstr "Sessioni"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/SharedFilePeersListCtrl.cpp
 msgid "Upload Speed"
 msgstr "Velocità upload"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/SharedFilePeersListCtrl.cpp
 msgid "Download Speed"
 msgstr "Velocità download"
 
@@ -1446,11 +1462,13 @@ msgstr[1] "Impossibile richiedere i file condivisi a %u clients selezionati."
 msgid "Files"
 msgstr "File"
 
-#: src/ClientsListCtrl.cpp src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientsListCtrl.cpp src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp
 msgid "Uploaded"
 msgstr "Inviato"
 
-#: src/ClientsListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientsListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Downloaded"
 msgstr "Scaricato"
 
@@ -1538,7 +1556,8 @@ msgstr "Commenti file"
 msgid "Username"
 msgstr "Nome utente"
 
-#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp
+#: src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "File Name"
 msgstr "Nome file"
 
@@ -1599,15 +1618,18 @@ msgstr "Auto [Alta]"
 msgid "Very low"
 msgstr "Molto bassa"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Low"
 msgstr "Bassa"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Normal"
 msgstr "Normale"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "High"
 msgstr "Alta"
 
@@ -1631,11 +1653,13 @@ msgstr "Connessione in corso attraverso il server"
 msgid "Queue Full"
 msgstr "Coda piena"
 
-#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp src/muuli_wdr.cpp
+#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp
+#: src/muuli_wdr.cpp
 msgid "On Queue"
 msgstr "In coda"
 
-#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
+#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp
+#: src/PartFile.cpp src/TransferWnd.cpp
 msgid "Downloading"
 msgstr "Download in corso"
 
@@ -1695,7 +1719,8 @@ msgstr "Server locale"
 msgid "Remote Server"
 msgstr "Server remoto"
 
-#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp src/TextClient.cpp
+#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp
+#: src/TextClient.cpp
 msgid "Kad"
 msgstr "Kad"
 
@@ -1719,7 +1744,8 @@ msgstr "Fonti salvate"
 msgid "Search Result"
 msgstr "Risultato della ricerca"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp
+#: src/TransferWnd.cpp
 msgid "Completed"
 msgstr "Completati"
 
@@ -1771,7 +1797,8 @@ msgstr "Impossibile modificare all'interno di una condivisione ricorsiva"
 msgid "Part"
 msgstr "Parte"
 
-#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 msgid "Size"
 msgstr "Dimensione"
 
@@ -1779,7 +1806,8 @@ msgstr "Dimensione"
 msgid "Transferred"
 msgstr "Trasferiti"
 
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp src/SourceListCtrl.cpp
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
+#: src/SourceListCtrl.cpp
 msgid "Speed"
 msgstr "Velocità"
 
@@ -1787,11 +1815,13 @@ msgstr "Velocità"
 msgid "Progress"
 msgstr "Avanzamento"
 
-#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
+#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp
+#: src/SearchListCtrl.cpp
 msgid "Sources"
 msgstr "Fonti"
 
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 msgid "Priority"
 msgstr "Priorità"
 
@@ -1815,7 +1845,9 @@ msgstr "Ultima ricezione"
 msgid "Auto"
 msgstr "Auto"
 
-#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/TransferWnd.cpp src/utils/wxCas/src/wxcasprefs.cpp
+#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/TransferWnd.cpp
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Cancel"
 msgstr "Annulla"
 
@@ -1916,7 +1948,8 @@ msgstr "Inserisci un nuovo nome per questo file:"
 msgid "File rename"
 msgstr "Rinomina file"
 
-#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f MiB/s"
 msgstr "%.1f MiB/s"
@@ -2719,11 +2752,13 @@ msgstr ""
 msgid "Start aMule automatically when I log in"
 msgstr "Avvia aMule automaticamente all'accesso"
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp packaging/windows/installer_strings.c
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: packaging/windows/installer_strings.c
 msgid "Register aMule for ed2k:// links"
 msgstr "Registra aMule per i link ed2k://"
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp packaging/windows/installer_strings.c
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: packaging/windows/installer_strings.c
 msgid "Register aMule for magnet: links"
 msgstr "Registra aMule per i magnet: link"
 
@@ -2751,7 +2786,8 @@ msgstr ""
 msgid "Destination folder for downloads"
 msgstr "Cartella di destinazione per i file scaricati"
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Browse"
 msgstr "Sfoglia"
 
@@ -3173,6 +3209,162 @@ msgstr "Impossibile caricare la voce nella lista dei file conosciuti, il file po
 msgid "Invalid entry in known file list, file may be corrupt: "
 msgstr "Voce non valida nella lista dei file conosciuti, il file potrebbe essere corrotto: "
 
+#: src/LanguageList.cpp
+msgid "System default"
+msgstr "Predefinita di sistema"
+
+#: src/LanguageList.cpp
+msgid "Albanian"
+msgstr "Albanese"
+
+#: src/LanguageList.cpp
+msgid "Arabic"
+msgstr "Arabo"
+
+#: src/LanguageList.cpp
+msgid "Asturian"
+msgstr "Asturiano"
+
+#: src/LanguageList.cpp
+msgid "Basque"
+msgstr "Basco"
+
+#: src/LanguageList.cpp
+msgid "Bulgarian"
+msgstr "Bulgaro"
+
+#: src/LanguageList.cpp
+msgid "Catalan"
+msgstr "Catalano"
+
+#: src/LanguageList.cpp
+msgid "Chinese (Simplified)"
+msgstr "Cinese (semplificato)"
+
+#: src/LanguageList.cpp
+msgid "Chinese (Traditional)"
+msgstr "Cinese (tradizionale)"
+
+#: src/LanguageList.cpp
+msgid "Croatian"
+msgstr "Croato"
+
+#: src/LanguageList.cpp
+msgid "Czech"
+msgstr "Ceco"
+
+#: src/LanguageList.cpp
+msgid "Danish"
+msgstr "Danese"
+
+#: src/LanguageList.cpp
+msgid "Dutch"
+msgstr "Olandese"
+
+#: src/LanguageList.cpp
+msgid "English (U.K.)"
+msgstr "Inglese (Regno Unito)"
+
+#: src/LanguageList.cpp
+msgid "English (U.S.)"
+msgstr "Inglese (U.S.)"
+
+#: src/LanguageList.cpp
+msgid "Estonian"
+msgstr "Estone"
+
+#: src/LanguageList.cpp
+msgid "Finnish"
+msgstr "Finlandese"
+
+#: src/LanguageList.cpp
+msgid "French"
+msgstr "Francese"
+
+#: src/LanguageList.cpp
+msgid "Galician"
+msgstr "Galiziano"
+
+#: src/LanguageList.cpp
+msgid "German"
+msgstr "Tedesco"
+
+#: src/LanguageList.cpp
+msgid "Greek"
+msgstr "Greco"
+
+#: src/LanguageList.cpp
+msgid "Hebrew"
+msgstr "Ebraico"
+
+#: src/LanguageList.cpp
+msgid "Hungarian"
+msgstr "Ungherese"
+
+#: src/LanguageList.cpp
+msgid "Italian"
+msgstr "Italiano"
+
+#: src/LanguageList.cpp
+msgid "Japanese"
+msgstr "Giapponese"
+
+#: src/LanguageList.cpp
+msgid "Korean"
+msgstr "Coreano"
+
+#: src/LanguageList.cpp
+msgid "Latvian"
+msgstr "Lettone"
+
+#: src/LanguageList.cpp
+msgid "Lithuanian"
+msgstr "Lituano"
+
+#: src/LanguageList.cpp
+msgid "Norwegian (Nynorsk)"
+msgstr "Norvegese (Nynorsk)"
+
+#: src/LanguageList.cpp
+msgid "Polish"
+msgstr "Polacco"
+
+#: src/LanguageList.cpp
+msgid "Portuguese"
+msgstr "Portoghese"
+
+#: src/LanguageList.cpp
+msgid "Portuguese (Brazilian)"
+msgstr "Portoghese (Brasile)"
+
+#: src/LanguageList.cpp
+msgid "Romanian"
+msgstr "Romeno"
+
+#: src/LanguageList.cpp
+msgid "Russian"
+msgstr "Russo"
+
+#: src/LanguageList.cpp
+msgid "Slovenian"
+msgstr "Sloveno"
+
+#: src/LanguageList.cpp
+msgid "Spanish"
+msgstr "Spagnolo"
+
+#: src/LanguageList.cpp
+msgid "Swedish"
+msgstr "Svedese"
+
+#: src/LanguageList.cpp
+msgid "Turkish"
+msgstr "Turco"
+
+#: src/LanguageList.cpp
+msgid "Ukrainian"
+msgstr "Ucraino"
+
 #: src/libs/common/Format.cpp
 #, c-format
 msgid "Unknown error %d"
@@ -3195,15 +3387,18 @@ msgstr "In completamento"
 msgid "Complete"
 msgstr "Completo"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Paused"
 msgstr "In pausa"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Erroneous"
 msgstr "Errato"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Waiting"
 msgstr "In attesa"
 
@@ -3365,7 +3560,8 @@ msgstr "Chiudi"
 msgid "Cut"
 msgstr "Taglia"
 
-#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp src/utils/aLinkCreator/src/alcframe.cpp
+#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy"
 msgstr "Copia"
 
@@ -3373,7 +3569,8 @@ msgstr "Copia"
 msgid "Paste"
 msgstr "Incolla"
 
-#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
+#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Clear"
 msgstr "Pulisci"
 
@@ -3381,7 +3578,8 @@ msgstr "Pulisci"
 msgid "Select All"
 msgstr "Seleziona tutto"
 
-#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp src/StatisticsDlg.cpp
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
+#: src/StatisticsDlg.cpp
 msgid "KiB/s"
 msgstr "KiB/s"
 
@@ -5843,174 +6041,6 @@ msgid "ERROR: Failed to open partfile '%s'"
 msgstr "ERRORE: Apertura del file Part fallita '%s'"
 
 #: src/Preferences.cpp
-msgid "System default"
-msgstr "Predefinita di sistema"
-
-#: src/Preferences.cpp
-msgid "Albanian"
-msgstr "Albanese"
-
-#: src/Preferences.cpp
-msgid "Arabic"
-msgstr "Arabo"
-
-#: src/Preferences.cpp
-msgid "Asturian"
-msgstr "Asturiano"
-
-#: src/Preferences.cpp
-msgid "Basque"
-msgstr "Basco"
-
-#: src/Preferences.cpp
-msgid "Bulgarian"
-msgstr "Bulgaro"
-
-#: src/Preferences.cpp
-msgid "Catalan"
-msgstr "Catalano"
-
-#: src/Preferences.cpp
-msgid "Chinese (Simplified)"
-msgstr "Cinese (semplificato)"
-
-#: src/Preferences.cpp
-msgid "Chinese (Traditional)"
-msgstr "Cinese (tradizionale)"
-
-#: src/Preferences.cpp
-msgid "Croatian"
-msgstr "Croato"
-
-#: src/Preferences.cpp
-msgid "Czech"
-msgstr "Ceco"
-
-#: src/Preferences.cpp
-msgid "Danish"
-msgstr "Danese"
-
-#: src/Preferences.cpp
-msgid "Dutch"
-msgstr "Olandese"
-
-#: src/Preferences.cpp
-msgid "English (U.K.)"
-msgstr "Inglese (Regno Unito)"
-
-#: src/Preferences.cpp
-msgid "English (U.S.)"
-msgstr "Inglese (U.S.)"
-
-#: src/Preferences.cpp
-msgid "Estonian"
-msgstr "Estone"
-
-#: src/Preferences.cpp
-msgid "Finnish"
-msgstr "Finlandese"
-
-#: src/Preferences.cpp
-msgid "French"
-msgstr "Francese"
-
-#: src/Preferences.cpp
-msgid "Galician"
-msgstr "Galiziano"
-
-#: src/Preferences.cpp
-msgid "German"
-msgstr "Tedesco"
-
-#: src/Preferences.cpp
-msgid "Greek"
-msgstr "Greco"
-
-#: src/Preferences.cpp
-msgid "Hebrew"
-msgstr "Ebraico"
-
-#: src/Preferences.cpp
-msgid "Hungarian"
-msgstr "Ungherese"
-
-#: src/Preferences.cpp
-msgid "Italian"
-msgstr "Italiano"
-
-#: src/Preferences.cpp
-msgid "Japanese"
-msgstr "Giapponese"
-
-#: src/Preferences.cpp
-msgid "Korean"
-msgstr "Coreano"
-
-#: src/Preferences.cpp
-msgid "Latvian"
-msgstr "Lettone"
-
-#: src/Preferences.cpp
-msgid "Lithuanian"
-msgstr "Lituano"
-
-#: src/Preferences.cpp
-msgid "Norwegian (Nynorsk)"
-msgstr "Norvegese (Nynorsk)"
-
-#: src/Preferences.cpp
-msgid "Polish"
-msgstr "Polacco"
-
-#: src/Preferences.cpp
-msgid "Portuguese"
-msgstr "Portoghese"
-
-#: src/Preferences.cpp
-msgid "Portuguese (Brazilian)"
-msgstr "Portoghese (Brasile)"
-
-#: src/Preferences.cpp
-msgid "Romanian"
-msgstr "Romeno"
-
-#: src/Preferences.cpp
-msgid "Russian"
-msgstr "Russo"
-
-#: src/Preferences.cpp
-msgid "Slovenian"
-msgstr "Sloveno"
-
-#: src/Preferences.cpp
-msgid "Spanish"
-msgstr "Spagnolo"
-
-#: src/Preferences.cpp
-msgid "Swedish"
-msgstr "Svedese"
-
-#: src/Preferences.cpp
-msgid "Turkish"
-msgstr "Turco"
-
-#: src/Preferences.cpp
-msgid "Ukrainian"
-msgstr "Ucraino"
-
-#: src/Preferences.cpp
-msgid "Change Language"
-msgstr "Cambia lingua"
-
-#: src/Preferences.cpp
-msgid "There are no translations installed for aMule"
-msgstr "Non ci sono traduzioni di aMule installate"
-
-#: src/Preferences.cpp
-msgid "No languages available"
-msgstr "Nessuna lingua disponibile"
-
-#: src/Preferences.cpp
 msgid "no options available"
 msgstr "nessuna opzione disponibile"
 
@@ -6512,7 +6542,8 @@ msgstr "Condividerle ricorsivamente pubblicherà ogni file al loro interno sulle
 msgid "Confirm shared folders"
 msgstr "Conferma cartelle condivise"
 
-#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp src/SharedFilesReloadProgress.cpp
+#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp
+#: src/SharedFilesReloadProgress.cpp
 msgid "Reloading shared files..."
 msgstr "Ricarica file condivisi in corso..."
 
@@ -9242,6 +9273,15 @@ msgstr "Sembra che aMule sia in esecuzione. Chiudilo e riavvia il programma di d
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "Rimozione dei dati utente in $APPDATA\\aMule..."
+
+#~ msgid "Change Language"
+#~ msgstr "Cambia lingua"
+
+#~ msgid "There are no translations installed for aMule"
+#~ msgstr "Non ci sono traduzioni di aMule installate"
+
+#~ msgid "No languages available"
+#~ msgstr "Nessuna lingua disponibile"
 
 #~ msgid "User name"
 #~ msgstr "Nome utente"

--- a/po/ja.po
+++ b/po/ja.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-05 12:01+0200\n"
+"POT-Creation-Date: 2026-09-06 14:35+0200\n"
 "PO-Revision-Date: 2026-09-05 10:54+0000\n"
 "Last-Translator: \n"
 "Language-Team: Japanese\n"
@@ -386,7 +386,8 @@ msgstr ""
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr ""
 
-#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
+#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
+#: src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
 msgid "ERROR"
 msgstr ""
 
@@ -674,7 +675,8 @@ msgstr "ネットワーク"
 msgid "Searches"
 msgstr "検索"
 
-#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/Statistics.cpp
+#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/Statistics.cpp
 msgid "Downloads"
 msgstr "ダウンロード数"
 
@@ -758,7 +760,9 @@ msgstr "Kad: オフ"
 msgid "Core"
 msgstr ""
 
-#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp src/Statistics.cpp
+#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp src/Statistics.cpp
 msgid "Version"
 msgstr "バージョン"
 
@@ -1063,7 +1067,11 @@ msgstr ""
 msgid "The remote core sent inconsistent data for \"%s\" (part status %d, expected %d). The file list may be showing the wrong information; reconnect to clear it."
 msgstr ""
 
-#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp src/Statistics.cpp
+#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp
+#: src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp
+#: src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp
+#: src/Statistics.cpp
 msgid "Unknown"
 msgstr "不明"
 
@@ -1159,7 +1167,8 @@ msgstr "known.metファイル%sを保存する時にIOエラーが発生しま�
 msgid "Enter Captcha"
 msgstr ""
 
-#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp src/TransferWnd.cpp
+#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp
+#: src/TransferWnd.cpp
 msgid "Category"
 msgstr "カテゴリ"
 
@@ -1315,11 +1324,13 @@ msgstr "'cryptkey.dat'が見つかりませんでした。生成します。"
 msgid "Client Details"
 msgstr "クライアントの詳細"
 
-#: src/ClientDetailDialog.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
+#: src/utils/wxCas/src/onlinesig.cpp
 msgid "LowID"
 msgstr "LowID"
 
-#: src/ClientDetailDialog.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
+#: src/utils/wxCas/src/onlinesig.cpp
 msgid "HighID"
 msgstr "HighID"
 
@@ -1335,7 +1346,8 @@ msgstr "サポート"
 msgid "Not supported"
 msgstr "非サポート"
 
-#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp src/TextClient.cpp
+#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
+#: src/TextClient.cpp
 msgid "Connected"
 msgstr "接続"
 
@@ -1343,7 +1355,8 @@ msgstr "接続"
 msgid "Disconnected"
 msgstr "切断"
 
-#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f KiB/s"
 msgstr ""
@@ -1360,7 +1373,8 @@ msgstr ""
 msgid "IP Address"
 msgstr "IPアドレス"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Origin"
 msgstr ""
 
@@ -1378,12 +1392,14 @@ msgstr "最後に受信した時刻"
 msgid "Sessions"
 msgstr "バージョン"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/SharedFilePeersListCtrl.cpp
 #, fuzzy
 msgid "Upload Speed"
 msgstr "アップロード速度"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/SharedFilePeersListCtrl.cpp
 #, fuzzy
 msgid "Download Speed"
 msgstr "ダウンロード速度："
@@ -1438,11 +1454,13 @@ msgstr[0] ""
 msgid "Files"
 msgstr "ファイル"
 
-#: src/ClientsListCtrl.cpp src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientsListCtrl.cpp src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp
 msgid "Uploaded"
 msgstr "アップロード済み"
 
-#: src/ClientsListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientsListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Downloaded"
 msgstr "ダウンロード済み"
 
@@ -1533,7 +1551,8 @@ msgstr "ファイル・コメント"
 msgid "Username"
 msgstr "ユーザ名"
 
-#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp
+#: src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "File Name"
 msgstr "ファイル名"
 
@@ -1593,15 +1612,18 @@ msgstr "オート [Hi]"
 msgid "Very low"
 msgstr "非常に低い"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Low"
 msgstr "低い"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Normal"
 msgstr "普通"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "High"
 msgstr "高い"
 
@@ -1625,11 +1647,13 @@ msgstr "サーバ経由に接続中"
 msgid "Queue Full"
 msgstr "キューが一杯"
 
-#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp src/muuli_wdr.cpp
+#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp
+#: src/muuli_wdr.cpp
 msgid "On Queue"
 msgstr "キューに入っています"
 
-#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
+#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp
+#: src/PartFile.cpp src/TransferWnd.cpp
 msgid "Downloading"
 msgstr "ダウンロード"
 
@@ -1689,7 +1713,8 @@ msgstr "ローカルサーバ"
 msgid "Remote Server"
 msgstr "リモートサーバ"
 
-#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp src/TextClient.cpp
+#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp
+#: src/TextClient.cpp
 msgid "Kad"
 msgstr "Kad"
 
@@ -1713,7 +1738,8 @@ msgstr "ソースシード"
 msgid "Search Result"
 msgstr ""
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp
+#: src/TransferWnd.cpp
 msgid "Completed"
 msgstr "完成された数"
 
@@ -1766,7 +1792,8 @@ msgstr ""
 msgid "Part"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 msgid "Size"
 msgstr "サイズ"
 
@@ -1774,7 +1801,8 @@ msgstr "サイズ"
 msgid "Transferred"
 msgstr "転送済み"
 
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp src/SourceListCtrl.cpp
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
+#: src/SourceListCtrl.cpp
 msgid "Speed"
 msgstr "スピード"
 
@@ -1782,11 +1810,13 @@ msgstr "スピード"
 msgid "Progress"
 msgstr "進捗状況"
 
-#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
+#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp
+#: src/SearchListCtrl.cpp
 msgid "Sources"
 msgstr "ソース数"
 
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 msgid "Priority"
 msgstr "優先度"
 
@@ -1810,7 +1840,9 @@ msgstr "最後に受信した時刻"
 msgid "Auto"
 msgstr "自動"
 
-#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/TransferWnd.cpp src/utils/wxCas/src/wxcasprefs.cpp
+#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/TransferWnd.cpp
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Cancel"
 msgstr "キャンセル"
 
@@ -1911,7 +1943,8 @@ msgstr "このファイルの新しい名前を入力してください："
 msgid "File rename"
 msgstr "ファイルの改名"
 
-#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f MiB/s"
 msgstr ""
@@ -2719,11 +2752,13 @@ msgstr ""
 msgid "Start aMule automatically when I log in"
 msgstr ""
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp packaging/windows/installer_strings.c
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: packaging/windows/installer_strings.c
 msgid "Register aMule for ed2k:// links"
 msgstr ""
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp packaging/windows/installer_strings.c
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: packaging/windows/installer_strings.c
 msgid "Register aMule for magnet: links"
 msgstr ""
 
@@ -2749,7 +2784,8 @@ msgstr ""
 msgid "Destination folder for downloads"
 msgstr ""
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Browse"
 msgstr "閲覧"
 
@@ -3167,6 +3203,165 @@ msgstr ""
 msgid "Invalid entry in known file list, file may be corrupt: "
 msgstr ""
 
+#: src/LanguageList.cpp
+msgid "System default"
+msgstr "システムの標準設定"
+
+#: src/LanguageList.cpp
+msgid "Albanian"
+msgstr "アルバニア語"
+
+#: src/LanguageList.cpp
+msgid "Arabic"
+msgstr "アラブ語"
+
+#: src/LanguageList.cpp
+#, fuzzy
+msgid "Asturian"
+msgstr "エストニア語"
+
+#: src/LanguageList.cpp
+msgid "Basque"
+msgstr "バスク語"
+
+#: src/LanguageList.cpp
+msgid "Bulgarian"
+msgstr "ブルガリア語"
+
+#: src/LanguageList.cpp
+msgid "Catalan"
+msgstr "カタロニア語"
+
+#: src/LanguageList.cpp
+msgid "Chinese (Simplified)"
+msgstr "中国語（簡体字）"
+
+#: src/LanguageList.cpp
+msgid "Chinese (Traditional)"
+msgstr "中国語（繁体字）"
+
+#: src/LanguageList.cpp
+msgid "Croatian"
+msgstr "クロアチア語"
+
+#: src/LanguageList.cpp
+msgid "Czech"
+msgstr "チェコ語"
+
+#: src/LanguageList.cpp
+msgid "Danish"
+msgstr "デンマーク語"
+
+#: src/LanguageList.cpp
+msgid "Dutch"
+msgstr "オランダ語"
+
+#: src/LanguageList.cpp
+msgid "English (U.K.)"
+msgstr "英語（U.K.）"
+
+#: src/LanguageList.cpp
+#, fuzzy
+msgid "English (U.S.)"
+msgstr "英語（U.K.）"
+
+#: src/LanguageList.cpp
+msgid "Estonian"
+msgstr "エストニア語"
+
+#: src/LanguageList.cpp
+msgid "Finnish"
+msgstr "フィンランド語"
+
+#: src/LanguageList.cpp
+msgid "French"
+msgstr "フランス語"
+
+#: src/LanguageList.cpp
+msgid "Galician"
+msgstr "ガリシア語"
+
+#: src/LanguageList.cpp
+msgid "German"
+msgstr "ドイツ語"
+
+#: src/LanguageList.cpp
+msgid "Greek"
+msgstr "ギリシア語"
+
+#: src/LanguageList.cpp
+msgid "Hebrew"
+msgstr "ヘブライ語"
+
+#: src/LanguageList.cpp
+msgid "Hungarian"
+msgstr "ハンガリー語"
+
+#: src/LanguageList.cpp
+msgid "Italian"
+msgstr "イタリア語"
+
+#: src/LanguageList.cpp
+msgid "Japanese"
+msgstr "日本語"
+
+#: src/LanguageList.cpp
+msgid "Korean"
+msgstr "韓国語"
+
+#: src/LanguageList.cpp
+msgid "Latvian"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Lithuanian"
+msgstr "リトアニア語"
+
+#: src/LanguageList.cpp
+msgid "Norwegian (Nynorsk)"
+msgstr "ルウェー語"
+
+#: src/LanguageList.cpp
+msgid "Polish"
+msgstr "ポーランド語"
+
+#: src/LanguageList.cpp
+msgid "Portuguese"
+msgstr "ポルトガル語"
+
+#: src/LanguageList.cpp
+msgid "Portuguese (Brazilian)"
+msgstr "ポルトガル語（ブラジル）"
+
+#: src/LanguageList.cpp
+#, fuzzy
+msgid "Romanian"
+msgstr "アルバニア語"
+
+#: src/LanguageList.cpp
+msgid "Russian"
+msgstr "ロシア語"
+
+#: src/LanguageList.cpp
+msgid "Slovenian"
+msgstr "スロベニア語"
+
+#: src/LanguageList.cpp
+msgid "Spanish"
+msgstr "スペイン語"
+
+#: src/LanguageList.cpp
+msgid "Swedish"
+msgstr "スウェーデン語"
+
+#: src/LanguageList.cpp
+msgid "Turkish"
+msgstr "トルコ語"
+
+#: src/LanguageList.cpp
+msgid "Ukrainian"
+msgstr ""
+
 #: src/libs/common/Format.cpp
 #, fuzzy, c-format
 msgid "Unknown error %d"
@@ -3189,15 +3384,18 @@ msgstr "完了中"
 msgid "Complete"
 msgstr "完了"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Paused"
 msgstr "停止"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Erroneous"
 msgstr "エラーあり"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Waiting"
 msgstr "待機"
 
@@ -3359,7 +3557,8 @@ msgstr "閉じる"
 msgid "Cut"
 msgstr "カット"
 
-#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp src/utils/aLinkCreator/src/alcframe.cpp
+#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy"
 msgstr "コピー"
 
@@ -3367,7 +3566,8 @@ msgstr "コピー"
 msgid "Paste"
 msgstr "ペースト"
 
-#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
+#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Clear"
 msgstr "クリア"
 
@@ -3375,7 +3575,8 @@ msgstr "クリア"
 msgid "Select All"
 msgstr "全ての選択"
 
-#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp src/StatisticsDlg.cpp
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
+#: src/StatisticsDlg.cpp
 msgid "KiB/s"
 msgstr ""
 
@@ -5876,179 +6077,6 @@ msgid "ERROR: Failed to open partfile '%s'"
 msgstr "エラー: 部分ファイル '%s' が開けませんでした"
 
 #: src/Preferences.cpp
-msgid "System default"
-msgstr "システムの標準設定"
-
-#: src/Preferences.cpp
-msgid "Albanian"
-msgstr "アルバニア語"
-
-#: src/Preferences.cpp
-msgid "Arabic"
-msgstr "アラブ語"
-
-#: src/Preferences.cpp
-#, fuzzy
-msgid "Asturian"
-msgstr "エストニア語"
-
-#: src/Preferences.cpp
-msgid "Basque"
-msgstr "バスク語"
-
-#: src/Preferences.cpp
-msgid "Bulgarian"
-msgstr "ブルガリア語"
-
-#: src/Preferences.cpp
-msgid "Catalan"
-msgstr "カタロニア語"
-
-#: src/Preferences.cpp
-msgid "Chinese (Simplified)"
-msgstr "中国語（簡体字）"
-
-#: src/Preferences.cpp
-msgid "Chinese (Traditional)"
-msgstr "中国語（繁体字）"
-
-#: src/Preferences.cpp
-msgid "Croatian"
-msgstr "クロアチア語"
-
-#: src/Preferences.cpp
-msgid "Czech"
-msgstr "チェコ語"
-
-#: src/Preferences.cpp
-msgid "Danish"
-msgstr "デンマーク語"
-
-#: src/Preferences.cpp
-msgid "Dutch"
-msgstr "オランダ語"
-
-#: src/Preferences.cpp
-msgid "English (U.K.)"
-msgstr "英語（U.K.）"
-
-#: src/Preferences.cpp
-#, fuzzy
-msgid "English (U.S.)"
-msgstr "英語（U.K.）"
-
-#: src/Preferences.cpp
-msgid "Estonian"
-msgstr "エストニア語"
-
-#: src/Preferences.cpp
-msgid "Finnish"
-msgstr "フィンランド語"
-
-#: src/Preferences.cpp
-msgid "French"
-msgstr "フランス語"
-
-#: src/Preferences.cpp
-msgid "Galician"
-msgstr "ガリシア語"
-
-#: src/Preferences.cpp
-msgid "German"
-msgstr "ドイツ語"
-
-#: src/Preferences.cpp
-msgid "Greek"
-msgstr "ギリシア語"
-
-#: src/Preferences.cpp
-msgid "Hebrew"
-msgstr "ヘブライ語"
-
-#: src/Preferences.cpp
-msgid "Hungarian"
-msgstr "ハンガリー語"
-
-#: src/Preferences.cpp
-msgid "Italian"
-msgstr "イタリア語"
-
-#: src/Preferences.cpp
-msgid "Japanese"
-msgstr "日本語"
-
-#: src/Preferences.cpp
-msgid "Korean"
-msgstr "韓国語"
-
-#: src/Preferences.cpp
-msgid "Latvian"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Lithuanian"
-msgstr "リトアニア語"
-
-#: src/Preferences.cpp
-msgid "Norwegian (Nynorsk)"
-msgstr "ルウェー語"
-
-#: src/Preferences.cpp
-msgid "Polish"
-msgstr "ポーランド語"
-
-#: src/Preferences.cpp
-msgid "Portuguese"
-msgstr "ポルトガル語"
-
-#: src/Preferences.cpp
-msgid "Portuguese (Brazilian)"
-msgstr "ポルトガル語（ブラジル）"
-
-#: src/Preferences.cpp
-#, fuzzy
-msgid "Romanian"
-msgstr "アルバニア語"
-
-#: src/Preferences.cpp
-msgid "Russian"
-msgstr "ロシア語"
-
-#: src/Preferences.cpp
-msgid "Slovenian"
-msgstr "スロベニア語"
-
-#: src/Preferences.cpp
-msgid "Spanish"
-msgstr "スペイン語"
-
-#: src/Preferences.cpp
-msgid "Swedish"
-msgstr "スウェーデン語"
-
-#: src/Preferences.cpp
-msgid "Turkish"
-msgstr "トルコ語"
-
-#: src/Preferences.cpp
-msgid "Ukrainian"
-msgstr ""
-
-#: src/Preferences.cpp
-#, fuzzy
-msgid "Change Language"
-msgstr "言語"
-
-#: src/Preferences.cpp
-msgid "There are no translations installed for aMule"
-msgstr ""
-
-#: src/Preferences.cpp
-#, fuzzy
-msgid "No languages available"
-msgstr "利用不可"
-
-#: src/Preferences.cpp
 msgid "no options available"
 msgstr ""
 
@@ -6550,7 +6578,8 @@ msgstr ""
 msgid "Confirm shared folders"
 msgstr "共有ファイルを再ロードする"
 
-#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp src/SharedFilesReloadProgress.cpp
+#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp
+#: src/SharedFilesReloadProgress.cpp
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "共有ファイルを再ロードする"
@@ -9276,6 +9305,14 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#, fuzzy
+#~ msgid "Change Language"
+#~ msgstr "言語"
+
+#, fuzzy
+#~ msgid "No languages available"
+#~ msgstr "利用不可"
 
 #~ msgid "User name"
 #~ msgstr "ユーザ名"

--- a/po/ko_KR.po
+++ b/po/ko_KR.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-05 12:01+0200\n"
+"POT-Creation-Date: 2026-09-06 14:35+0200\n"
 "PO-Revision-Date: 2026-09-05 10:55+0000\n"
 "Last-Translator: Hyunju Kang <rexington@gmail.com>\n"
 "Language-Team: Korean <hoenny@daum.net>\n"
@@ -385,7 +385,8 @@ msgstr ""
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr ""
 
-#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
+#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
+#: src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
 msgid "ERROR"
 msgstr ""
 
@@ -673,7 +674,8 @@ msgstr "통신망"
 msgid "Searches"
 msgstr "검색"
 
-#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/Statistics.cpp
+#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/Statistics.cpp
 msgid "Downloads"
 msgstr "내려받기"
 
@@ -761,7 +763,9 @@ msgstr " Kad: "
 msgid "Core"
 msgstr ""
 
-#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp src/Statistics.cpp
+#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp src/Statistics.cpp
 msgid "Version"
 msgstr "버젼"
 
@@ -1066,7 +1070,11 @@ msgstr ""
 msgid "The remote core sent inconsistent data for \"%s\" (part status %d, expected %d). The file list may be showing the wrong information; reconnect to clear it."
 msgstr ""
 
-#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp src/Statistics.cpp
+#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp
+#: src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp
+#: src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp
+#: src/Statistics.cpp
 msgid "Unknown"
 msgstr "알수없는"
 
@@ -1164,7 +1172,8 @@ msgstr "known.met 파일을 저장하는 동안 오류: %s"
 msgid "Enter Captcha"
 msgstr ""
 
-#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp src/TransferWnd.cpp
+#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp
+#: src/TransferWnd.cpp
 msgid "Category"
 msgstr "분류"
 
@@ -1328,11 +1337,13 @@ msgstr "'cryptkey.dat' 파일을 찾을 수 없습니다. 생성합니다."
 msgid "Client Details"
 msgstr "클라이언트 세부내역"
 
-#: src/ClientDetailDialog.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
+#: src/utils/wxCas/src/onlinesig.cpp
 msgid "LowID"
 msgstr "낮은아이디"
 
-#: src/ClientDetailDialog.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
+#: src/utils/wxCas/src/onlinesig.cpp
 msgid "HighID"
 msgstr "높은아이디"
 
@@ -1348,7 +1359,8 @@ msgstr ""
 msgid "Not supported"
 msgstr ""
 
-#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp src/TextClient.cpp
+#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
+#: src/TextClient.cpp
 msgid "Connected"
 msgstr "연결됨"
 
@@ -1356,7 +1368,8 @@ msgstr "연결됨"
 msgid "Disconnected"
 msgstr "연결이 끊김"
 
-#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f KiB/s"
 msgstr ""
@@ -1373,7 +1386,8 @@ msgstr ""
 msgid "IP Address"
 msgstr "IP 주소"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Origin"
 msgstr ""
 
@@ -1391,12 +1405,14 @@ msgstr "최종 받음"
 msgid "Sessions"
 msgstr "버젼"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/SharedFilePeersListCtrl.cpp
 #, fuzzy
 msgid "Upload Speed"
 msgstr "올려주기 속도"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/SharedFilePeersListCtrl.cpp
 #, fuzzy
 msgid "Download Speed"
 msgstr "내려받기 속도"
@@ -1452,11 +1468,13 @@ msgstr[1] ""
 msgid "Files"
 msgstr "파일"
 
-#: src/ClientsListCtrl.cpp src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientsListCtrl.cpp src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp
 msgid "Uploaded"
 msgstr ""
 
-#: src/ClientsListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientsListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Downloaded"
 msgstr ""
 
@@ -1547,7 +1565,8 @@ msgstr "파일 의견"
 msgid "Username"
 msgstr "사용자이름"
 
-#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp
+#: src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "File Name"
 msgstr "파일 이름"
 
@@ -1608,15 +1627,18 @@ msgstr "자동[높음]"
 msgid "Very low"
 msgstr "매우 낮음"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Low"
 msgstr "낮음"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Normal"
 msgstr "보통"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "High"
 msgstr "높음"
 
@@ -1640,11 +1662,13 @@ msgstr "서버를 경유하여 연결중"
 msgid "Queue Full"
 msgstr "대기열이 가득참"
 
-#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp src/muuli_wdr.cpp
+#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp
+#: src/muuli_wdr.cpp
 msgid "On Queue"
 msgstr "대기열에"
 
-#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
+#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp
+#: src/PartFile.cpp src/TransferWnd.cpp
 msgid "Downloading"
 msgstr "받는중"
 
@@ -1704,7 +1728,8 @@ msgstr "지역 서버"
 msgid "Remote Server"
 msgstr "원격 서버"
 
-#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp src/TextClient.cpp
+#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp
+#: src/TextClient.cpp
 msgid "Kad"
 msgstr "Kad"
 
@@ -1728,7 +1753,8 @@ msgstr "자료 핵"
 msgid "Search Result"
 msgstr ""
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp
+#: src/TransferWnd.cpp
 msgid "Completed"
 msgstr "완료됨"
 
@@ -1780,7 +1806,8 @@ msgstr ""
 msgid "Part"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 msgid "Size"
 msgstr "크기"
 
@@ -1788,7 +1815,8 @@ msgstr "크기"
 msgid "Transferred"
 msgstr "전송됨"
 
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp src/SourceListCtrl.cpp
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
+#: src/SourceListCtrl.cpp
 msgid "Speed"
 msgstr "속도"
 
@@ -1796,11 +1824,13 @@ msgstr "속도"
 msgid "Progress"
 msgstr "진척"
 
-#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
+#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp
+#: src/SearchListCtrl.cpp
 msgid "Sources"
 msgstr "자료"
 
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 msgid "Priority"
 msgstr "우선권"
 
@@ -1824,7 +1854,9 @@ msgstr "최종 받음"
 msgid "Auto"
 msgstr "자동"
 
-#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/TransferWnd.cpp src/utils/wxCas/src/wxcasprefs.cpp
+#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/TransferWnd.cpp
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Cancel"
 msgstr "취소"
 
@@ -1925,7 +1957,8 @@ msgstr "새이름 넣으세요:"
 msgid "File rename"
 msgstr "파일 이름변경"
 
-#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f MiB/s"
 msgstr ""
@@ -2735,11 +2768,13 @@ msgstr ""
 msgid "Start aMule automatically when I log in"
 msgstr ""
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp packaging/windows/installer_strings.c
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: packaging/windows/installer_strings.c
 msgid "Register aMule for ed2k:// links"
 msgstr ""
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp packaging/windows/installer_strings.c
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: packaging/windows/installer_strings.c
 msgid "Register aMule for magnet: links"
 msgstr ""
 
@@ -2765,7 +2800,8 @@ msgstr ""
 msgid "Destination folder for downloads"
 msgstr ""
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Browse"
 msgstr "탐색"
 
@@ -3192,6 +3228,165 @@ msgstr ""
 msgid "Invalid entry in known file list, file may be corrupt: "
 msgstr ""
 
+#: src/LanguageList.cpp
+msgid "System default"
+msgstr "기본 설정"
+
+#: src/LanguageList.cpp
+msgid "Albanian"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Arabic"
+msgstr "아랍어"
+
+#: src/LanguageList.cpp
+#, fuzzy
+msgid "Asturian"
+msgstr "에스토니아어"
+
+#: src/LanguageList.cpp
+msgid "Basque"
+msgstr "바스크어"
+
+#: src/LanguageList.cpp
+msgid "Bulgarian"
+msgstr "불가리아어"
+
+#: src/LanguageList.cpp
+msgid "Catalan"
+msgstr "카탈로니아어"
+
+#: src/LanguageList.cpp
+msgid "Chinese (Simplified)"
+msgstr "중국어(간체)"
+
+#: src/LanguageList.cpp
+msgid "Chinese (Traditional)"
+msgstr "중국어(번체)"
+
+#: src/LanguageList.cpp
+msgid "Croatian"
+msgstr "크로티아어"
+
+#: src/LanguageList.cpp
+msgid "Czech"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Danish"
+msgstr "덴마크어"
+
+#: src/LanguageList.cpp
+msgid "Dutch"
+msgstr "네델란드어"
+
+#: src/LanguageList.cpp
+msgid "English (U.K.)"
+msgstr "영어(영국)"
+
+#: src/LanguageList.cpp
+#, fuzzy
+msgid "English (U.S.)"
+msgstr "영어(영국)"
+
+#: src/LanguageList.cpp
+msgid "Estonian"
+msgstr "에스토니아어"
+
+#: src/LanguageList.cpp
+msgid "Finnish"
+msgstr "필란드어"
+
+#: src/LanguageList.cpp
+msgid "French"
+msgstr "프랑스어"
+
+#: src/LanguageList.cpp
+msgid "Galician"
+msgstr "갈리시아어"
+
+#: src/LanguageList.cpp
+msgid "German"
+msgstr "독일어"
+
+#: src/LanguageList.cpp
+msgid "Greek"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Hebrew"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Hungarian"
+msgstr "헝가리어"
+
+#: src/LanguageList.cpp
+msgid "Italian"
+msgstr "이탈리아어"
+
+#: src/LanguageList.cpp
+msgid "Japanese"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Korean"
+msgstr "한국어"
+
+#: src/LanguageList.cpp
+msgid "Latvian"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Lithuanian"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Norwegian (Nynorsk)"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Polish"
+msgstr "폴란드어"
+
+#: src/LanguageList.cpp
+msgid "Portuguese"
+msgstr "포르투갈어"
+
+#: src/LanguageList.cpp
+msgid "Portuguese (Brazilian)"
+msgstr "포르투갈어(브라질)"
+
+#: src/LanguageList.cpp
+#, fuzzy
+msgid "Romanian"
+msgstr "크로티아어"
+
+#: src/LanguageList.cpp
+msgid "Russian"
+msgstr "러시아어"
+
+#: src/LanguageList.cpp
+msgid "Slovenian"
+msgstr "슬로베니아어"
+
+#: src/LanguageList.cpp
+msgid "Spanish"
+msgstr "스페인어"
+
+#: src/LanguageList.cpp
+msgid "Swedish"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Turkish"
+msgstr "터키어"
+
+#: src/LanguageList.cpp
+msgid "Ukrainian"
+msgstr ""
+
 #: src/libs/common/Format.cpp
 #, fuzzy, c-format
 msgid "Unknown error %d"
@@ -3214,15 +3409,18 @@ msgstr "완료중"
 msgid "Complete"
 msgstr "완료"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Paused"
 msgstr "중지됨"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Erroneous"
 msgstr "오류투성이"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Waiting"
 msgstr "대기중"
 
@@ -3388,7 +3586,8 @@ msgstr "닫기"
 msgid "Cut"
 msgstr "자르기"
 
-#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp src/utils/aLinkCreator/src/alcframe.cpp
+#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy"
 msgstr "복사"
 
@@ -3396,7 +3595,8 @@ msgstr "복사"
 msgid "Paste"
 msgstr "붙이기"
 
-#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
+#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Clear"
 msgstr "깨끗이"
 
@@ -3404,7 +3604,8 @@ msgstr "깨끗이"
 msgid "Select All"
 msgstr "모두 선택"
 
-#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp src/StatisticsDlg.cpp
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
+#: src/StatisticsDlg.cpp
 msgid "KiB/s"
 msgstr ""
 
@@ -5911,179 +6112,6 @@ msgid "ERROR: Failed to open partfile '%s'"
 msgstr ""
 
 #: src/Preferences.cpp
-msgid "System default"
-msgstr "기본 설정"
-
-#: src/Preferences.cpp
-msgid "Albanian"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Arabic"
-msgstr "아랍어"
-
-#: src/Preferences.cpp
-#, fuzzy
-msgid "Asturian"
-msgstr "에스토니아어"
-
-#: src/Preferences.cpp
-msgid "Basque"
-msgstr "바스크어"
-
-#: src/Preferences.cpp
-msgid "Bulgarian"
-msgstr "불가리아어"
-
-#: src/Preferences.cpp
-msgid "Catalan"
-msgstr "카탈로니아어"
-
-#: src/Preferences.cpp
-msgid "Chinese (Simplified)"
-msgstr "중국어(간체)"
-
-#: src/Preferences.cpp
-msgid "Chinese (Traditional)"
-msgstr "중국어(번체)"
-
-#: src/Preferences.cpp
-msgid "Croatian"
-msgstr "크로티아어"
-
-#: src/Preferences.cpp
-msgid "Czech"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Danish"
-msgstr "덴마크어"
-
-#: src/Preferences.cpp
-msgid "Dutch"
-msgstr "네델란드어"
-
-#: src/Preferences.cpp
-msgid "English (U.K.)"
-msgstr "영어(영국)"
-
-#: src/Preferences.cpp
-#, fuzzy
-msgid "English (U.S.)"
-msgstr "영어(영국)"
-
-#: src/Preferences.cpp
-msgid "Estonian"
-msgstr "에스토니아어"
-
-#: src/Preferences.cpp
-msgid "Finnish"
-msgstr "필란드어"
-
-#: src/Preferences.cpp
-msgid "French"
-msgstr "프랑스어"
-
-#: src/Preferences.cpp
-msgid "Galician"
-msgstr "갈리시아어"
-
-#: src/Preferences.cpp
-msgid "German"
-msgstr "독일어"
-
-#: src/Preferences.cpp
-msgid "Greek"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Hebrew"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Hungarian"
-msgstr "헝가리어"
-
-#: src/Preferences.cpp
-msgid "Italian"
-msgstr "이탈리아어"
-
-#: src/Preferences.cpp
-msgid "Japanese"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Korean"
-msgstr "한국어"
-
-#: src/Preferences.cpp
-msgid "Latvian"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Lithuanian"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Norwegian (Nynorsk)"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Polish"
-msgstr "폴란드어"
-
-#: src/Preferences.cpp
-msgid "Portuguese"
-msgstr "포르투갈어"
-
-#: src/Preferences.cpp
-msgid "Portuguese (Brazilian)"
-msgstr "포르투갈어(브라질)"
-
-#: src/Preferences.cpp
-#, fuzzy
-msgid "Romanian"
-msgstr "크로티아어"
-
-#: src/Preferences.cpp
-msgid "Russian"
-msgstr "러시아어"
-
-#: src/Preferences.cpp
-msgid "Slovenian"
-msgstr "슬로베니아어"
-
-#: src/Preferences.cpp
-msgid "Spanish"
-msgstr "스페인어"
-
-#: src/Preferences.cpp
-msgid "Swedish"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Turkish"
-msgstr "터키어"
-
-#: src/Preferences.cpp
-msgid "Ukrainian"
-msgstr ""
-
-#: src/Preferences.cpp
-#, fuzzy
-msgid "Change Language"
-msgstr "언어"
-
-#: src/Preferences.cpp
-msgid "There are no translations installed for aMule"
-msgstr ""
-
-#: src/Preferences.cpp
-#, fuzzy
-msgid "No languages available"
-msgstr "유효하지 않음"
-
-#: src/Preferences.cpp
 msgid "no options available"
 msgstr ""
 
@@ -6593,7 +6621,8 @@ msgstr ""
 msgid "Confirm shared folders"
 msgstr "공유된 파일을 다시 읽어들임"
 
-#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp src/SharedFilesReloadProgress.cpp
+#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp
+#: src/SharedFilesReloadProgress.cpp
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "공유된 파일을 다시 읽어들임"
@@ -9346,6 +9375,14 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#, fuzzy
+#~ msgid "Change Language"
+#~ msgstr "언어"
+
+#, fuzzy
+#~ msgid "No languages available"
+#~ msgstr "유효하지 않음"
 
 #~ msgid "User name"
 #~ msgstr "사용자이름"

--- a/po/lt.po
+++ b/po/lt.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-05 12:01+0200\n"
+"POT-Creation-Date: 2026-09-06 14:35+0200\n"
 "PO-Revision-Date: 2026-09-05 10:55+0000\n"
 "Last-Translator: Dovydas Sankauskas <laisve@gmail.com>\n"
 "Language-Team: Lithuanian <komp_lt@konf.lt>\n"
@@ -390,7 +390,8 @@ msgstr "žiniatinklio serverio pid yra %d"
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Nurodėte paleidus programą paleisti žiniatinklio serverį, bet amuleweb programos nepavyko paleisti. Įdiekite aMule žiniatinklio programos paketą arba sukompiliuokite aMule su --enable-webserver parinktimi ir paleiskite „make install“."
 
-#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
+#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
+#: src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
 msgid "ERROR"
 msgstr "KLAIDA"
 
@@ -680,7 +681,8 @@ msgstr "Tinklas"
 msgid "Searches"
 msgstr "Paieška"
 
-#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/Statistics.cpp
+#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/Statistics.cpp
 msgid "Downloads"
 msgstr "Siuntimai"
 
@@ -764,7 +766,9 @@ msgstr "Kad: išjungta"
 msgid "Core"
 msgstr ""
 
-#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp src/Statistics.cpp
+#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp src/Statistics.cpp
 msgid "Version"
 msgstr "Versija"
 
@@ -1068,7 +1072,11 @@ msgstr ""
 msgid "The remote core sent inconsistent data for \"%s\" (part status %d, expected %d). The file list may be showing the wrong information; reconnect to clear it."
 msgstr ""
 
-#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp src/Statistics.cpp
+#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp
+#: src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp
+#: src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp
+#: src/Statistics.cpp
 msgid "Unknown"
 msgstr "Nežinoma"
 
@@ -1168,7 +1176,8 @@ msgstr "Įrašant known.met failą įvyko klaida: %s"
 msgid "Enter Captcha"
 msgstr ""
 
-#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp src/TransferWnd.cpp
+#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp
+#: src/TransferWnd.cpp
 msgid "Category"
 msgstr "Kategorija"
 
@@ -1338,11 +1347,13 @@ msgstr "Nerasta cryptkey.dat failo. Failas kuriamas."
 msgid "Client Details"
 msgstr "Kliento savybės"
 
-#: src/ClientDetailDialog.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
+#: src/utils/wxCas/src/onlinesig.cpp
 msgid "LowID"
 msgstr "Žemas ID"
 
-#: src/ClientDetailDialog.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
+#: src/utils/wxCas/src/onlinesig.cpp
 msgid "HighID"
 msgstr "Aukštas ID"
 
@@ -1358,7 +1369,8 @@ msgstr "Palaikoma"
 msgid "Not supported"
 msgstr "Nepalaikoma"
 
-#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp src/TextClient.cpp
+#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
+#: src/TextClient.cpp
 msgid "Connected"
 msgstr "Prisijungta"
 
@@ -1366,7 +1378,8 @@ msgstr "Prisijungta"
 msgid "Disconnected"
 msgstr "Neprisijungta"
 
-#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f KiB/s"
 msgstr ""
@@ -1383,7 +1396,8 @@ msgstr ""
 msgid "IP Address"
 msgstr "IP adresas"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Origin"
 msgstr ""
 
@@ -1401,12 +1415,14 @@ msgstr "Paskutinį kartą siųsta"
 msgid "Sessions"
 msgstr "Versija"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/SharedFilePeersListCtrl.cpp
 #, fuzzy
 msgid "Upload Speed"
 msgstr "Išsiuntimo sparta"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/SharedFilePeersListCtrl.cpp
 #, fuzzy
 msgid "Download Speed"
 msgstr "Atsiuntimo sparta"
@@ -1463,11 +1479,13 @@ msgstr[2] ""
 msgid "Files"
 msgstr "Failai"
 
-#: src/ClientsListCtrl.cpp src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientsListCtrl.cpp src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp
 msgid "Uploaded"
 msgstr "Išsiųsta"
 
-#: src/ClientsListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientsListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Downloaded"
 msgstr "Atsiųsta"
 
@@ -1558,7 +1576,8 @@ msgstr "Failo komentarai"
 msgid "Username"
 msgstr "Vardas"
 
-#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp
+#: src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "File Name"
 msgstr "Failo pavadinimas"
 
@@ -1620,15 +1639,18 @@ msgstr "Automatiškai (aukštas)"
 msgid "Very low"
 msgstr "Labai žemas"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Low"
 msgstr "Žemas"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Normal"
 msgstr "Normalus"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "High"
 msgstr "Aukštas"
 
@@ -1652,11 +1674,13 @@ msgstr "Jungiamasi per serverį"
 msgid "Queue Full"
 msgstr "Eilė pilna"
 
-#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp src/muuli_wdr.cpp
+#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp
+#: src/muuli_wdr.cpp
 msgid "On Queue"
 msgstr "Eilėje"
 
-#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
+#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp
+#: src/PartFile.cpp src/TransferWnd.cpp
 msgid "Downloading"
 msgstr "Atsiunčiama"
 
@@ -1716,7 +1740,8 @@ msgstr "Vietinis serveris"
 msgid "Remote Server"
 msgstr "Nutolęs serveris"
 
-#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp src/TextClient.cpp
+#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp
+#: src/TextClient.cpp
 msgid "Kad"
 msgstr "Kademlia"
 
@@ -1740,7 +1765,8 @@ msgstr "Pilni šaltiniai"
 msgid "Search Result"
 msgstr ""
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp
+#: src/TransferWnd.cpp
 msgid "Completed"
 msgstr "Baigtos"
 
@@ -1793,7 +1819,8 @@ msgstr ""
 msgid "Part"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 msgid "Size"
 msgstr "Dydis"
 
@@ -1801,7 +1828,8 @@ msgstr "Dydis"
 msgid "Transferred"
 msgstr "Persiųsta"
 
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp src/SourceListCtrl.cpp
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
+#: src/SourceListCtrl.cpp
 msgid "Speed"
 msgstr "Sparta"
 
@@ -1809,11 +1837,13 @@ msgstr "Sparta"
 msgid "Progress"
 msgstr "Eiga"
 
-#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
+#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp
+#: src/SearchListCtrl.cpp
 msgid "Sources"
 msgstr "Šaltiniai"
 
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 msgid "Priority"
 msgstr "Prioritetas"
 
@@ -1837,7 +1867,9 @@ msgstr "Paskutinį kartą siųsta"
 msgid "Auto"
 msgstr "Automatiškas"
 
-#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/TransferWnd.cpp src/utils/wxCas/src/wxcasprefs.cpp
+#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/TransferWnd.cpp
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Cancel"
 msgstr "Atšaukti"
 
@@ -1938,7 +1970,8 @@ msgstr "Įrašykite naują failo pavadinimą:"
 msgid "File rename"
 msgstr "Pervadinti failą"
 
-#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f MiB/s"
 msgstr ""
@@ -2750,11 +2783,13 @@ msgstr ""
 msgid "Start aMule automatically when I log in"
 msgstr ""
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp packaging/windows/installer_strings.c
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: packaging/windows/installer_strings.c
 msgid "Register aMule for ed2k:// links"
 msgstr ""
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp packaging/windows/installer_strings.c
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: packaging/windows/installer_strings.c
 msgid "Register aMule for magnet: links"
 msgstr ""
 
@@ -2780,7 +2815,8 @@ msgstr ""
 msgid "Destination folder for downloads"
 msgstr ""
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Browse"
 msgstr "Naršyti"
 
@@ -3210,6 +3246,165 @@ msgstr ""
 msgid "Invalid entry in known file list, file may be corrupt: "
 msgstr ""
 
+#: src/LanguageList.cpp
+msgid "System default"
+msgstr "Numatyta"
+
+#: src/LanguageList.cpp
+msgid "Albanian"
+msgstr "Albanų"
+
+#: src/LanguageList.cpp
+msgid "Arabic"
+msgstr "Arabų"
+
+#: src/LanguageList.cpp
+#, fuzzy
+msgid "Asturian"
+msgstr "Estų"
+
+#: src/LanguageList.cpp
+msgid "Basque"
+msgstr "Baskų"
+
+#: src/LanguageList.cpp
+msgid "Bulgarian"
+msgstr "Bulgarų"
+
+#: src/LanguageList.cpp
+msgid "Catalan"
+msgstr "Katalonų"
+
+#: src/LanguageList.cpp
+msgid "Chinese (Simplified)"
+msgstr "Kinų (supaprastinta)"
+
+#: src/LanguageList.cpp
+msgid "Chinese (Traditional)"
+msgstr "Kinų (tradicinė)"
+
+#: src/LanguageList.cpp
+msgid "Croatian"
+msgstr "Kroatų"
+
+#: src/LanguageList.cpp
+msgid "Czech"
+msgstr "Čekų"
+
+#: src/LanguageList.cpp
+msgid "Danish"
+msgstr "Danų"
+
+#: src/LanguageList.cpp
+msgid "Dutch"
+msgstr "Olandų"
+
+#: src/LanguageList.cpp
+msgid "English (U.K.)"
+msgstr "Anglų (DB)"
+
+#: src/LanguageList.cpp
+#, fuzzy
+msgid "English (U.S.)"
+msgstr "Anglų (DB)"
+
+#: src/LanguageList.cpp
+msgid "Estonian"
+msgstr "Estų"
+
+#: src/LanguageList.cpp
+msgid "Finnish"
+msgstr "Suomių"
+
+#: src/LanguageList.cpp
+msgid "French"
+msgstr "Prancūzų"
+
+#: src/LanguageList.cpp
+msgid "Galician"
+msgstr "Galisijos"
+
+#: src/LanguageList.cpp
+msgid "German"
+msgstr "Vokiečių"
+
+#: src/LanguageList.cpp
+msgid "Greek"
+msgstr "Graikų"
+
+#: src/LanguageList.cpp
+msgid "Hebrew"
+msgstr "Žydų"
+
+#: src/LanguageList.cpp
+msgid "Hungarian"
+msgstr "Vengrų"
+
+#: src/LanguageList.cpp
+msgid "Italian"
+msgstr "Italų"
+
+#: src/LanguageList.cpp
+msgid "Japanese"
+msgstr "Japonų"
+
+#: src/LanguageList.cpp
+msgid "Korean"
+msgstr "Korėjiečių"
+
+#: src/LanguageList.cpp
+msgid "Latvian"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Lithuanian"
+msgstr "Lietuvių"
+
+#: src/LanguageList.cpp
+msgid "Norwegian (Nynorsk)"
+msgstr "Norvegų (naujoji norvegų)"
+
+#: src/LanguageList.cpp
+msgid "Polish"
+msgstr "Lenkų"
+
+#: src/LanguageList.cpp
+msgid "Portuguese"
+msgstr "Portugalų"
+
+#: src/LanguageList.cpp
+msgid "Portuguese (Brazilian)"
+msgstr "Portugalų (Brazilijos)"
+
+#: src/LanguageList.cpp
+#, fuzzy
+msgid "Romanian"
+msgstr "Albanų"
+
+#: src/LanguageList.cpp
+msgid "Russian"
+msgstr "Rusų"
+
+#: src/LanguageList.cpp
+msgid "Slovenian"
+msgstr "Slovėnų"
+
+#: src/LanguageList.cpp
+msgid "Spanish"
+msgstr "Ispanų"
+
+#: src/LanguageList.cpp
+msgid "Swedish"
+msgstr "Švedų"
+
+#: src/LanguageList.cpp
+msgid "Turkish"
+msgstr "Turkų"
+
+#: src/LanguageList.cpp
+msgid "Ukrainian"
+msgstr ""
+
 #: src/libs/common/Format.cpp
 #, fuzzy, c-format
 msgid "Unknown error %d"
@@ -3232,15 +3427,18 @@ msgstr "Patvirtinama"
 msgid "Complete"
 msgstr "Baigta"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Paused"
 msgstr "Pristabdyta"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Erroneous"
 msgstr "Klaidinga"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Waiting"
 msgstr "Laukiama"
 
@@ -3410,7 +3608,8 @@ msgstr "Užverti"
 msgid "Cut"
 msgstr "Iškirpti"
 
-#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp src/utils/aLinkCreator/src/alcframe.cpp
+#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy"
 msgstr "Kopijuoti"
 
@@ -3418,7 +3617,8 @@ msgstr "Kopijuoti"
 msgid "Paste"
 msgstr "Įterpti"
 
-#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
+#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Clear"
 msgstr "Išvalyti"
 
@@ -3426,7 +3626,8 @@ msgstr "Išvalyti"
 msgid "Select All"
 msgstr "Pažymėti viską"
 
-#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp src/StatisticsDlg.cpp
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
+#: src/StatisticsDlg.cpp
 msgid "KiB/s"
 msgstr ""
 
@@ -5937,179 +6138,6 @@ msgid "ERROR: Failed to open partfile '%s'"
 msgstr "KLAIDA: nepavyko atverti dalių failo „%s“"
 
 #: src/Preferences.cpp
-msgid "System default"
-msgstr "Numatyta"
-
-#: src/Preferences.cpp
-msgid "Albanian"
-msgstr "Albanų"
-
-#: src/Preferences.cpp
-msgid "Arabic"
-msgstr "Arabų"
-
-#: src/Preferences.cpp
-#, fuzzy
-msgid "Asturian"
-msgstr "Estų"
-
-#: src/Preferences.cpp
-msgid "Basque"
-msgstr "Baskų"
-
-#: src/Preferences.cpp
-msgid "Bulgarian"
-msgstr "Bulgarų"
-
-#: src/Preferences.cpp
-msgid "Catalan"
-msgstr "Katalonų"
-
-#: src/Preferences.cpp
-msgid "Chinese (Simplified)"
-msgstr "Kinų (supaprastinta)"
-
-#: src/Preferences.cpp
-msgid "Chinese (Traditional)"
-msgstr "Kinų (tradicinė)"
-
-#: src/Preferences.cpp
-msgid "Croatian"
-msgstr "Kroatų"
-
-#: src/Preferences.cpp
-msgid "Czech"
-msgstr "Čekų"
-
-#: src/Preferences.cpp
-msgid "Danish"
-msgstr "Danų"
-
-#: src/Preferences.cpp
-msgid "Dutch"
-msgstr "Olandų"
-
-#: src/Preferences.cpp
-msgid "English (U.K.)"
-msgstr "Anglų (DB)"
-
-#: src/Preferences.cpp
-#, fuzzy
-msgid "English (U.S.)"
-msgstr "Anglų (DB)"
-
-#: src/Preferences.cpp
-msgid "Estonian"
-msgstr "Estų"
-
-#: src/Preferences.cpp
-msgid "Finnish"
-msgstr "Suomių"
-
-#: src/Preferences.cpp
-msgid "French"
-msgstr "Prancūzų"
-
-#: src/Preferences.cpp
-msgid "Galician"
-msgstr "Galisijos"
-
-#: src/Preferences.cpp
-msgid "German"
-msgstr "Vokiečių"
-
-#: src/Preferences.cpp
-msgid "Greek"
-msgstr "Graikų"
-
-#: src/Preferences.cpp
-msgid "Hebrew"
-msgstr "Žydų"
-
-#: src/Preferences.cpp
-msgid "Hungarian"
-msgstr "Vengrų"
-
-#: src/Preferences.cpp
-msgid "Italian"
-msgstr "Italų"
-
-#: src/Preferences.cpp
-msgid "Japanese"
-msgstr "Japonų"
-
-#: src/Preferences.cpp
-msgid "Korean"
-msgstr "Korėjiečių"
-
-#: src/Preferences.cpp
-msgid "Latvian"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Lithuanian"
-msgstr "Lietuvių"
-
-#: src/Preferences.cpp
-msgid "Norwegian (Nynorsk)"
-msgstr "Norvegų (naujoji norvegų)"
-
-#: src/Preferences.cpp
-msgid "Polish"
-msgstr "Lenkų"
-
-#: src/Preferences.cpp
-msgid "Portuguese"
-msgstr "Portugalų"
-
-#: src/Preferences.cpp
-msgid "Portuguese (Brazilian)"
-msgstr "Portugalų (Brazilijos)"
-
-#: src/Preferences.cpp
-#, fuzzy
-msgid "Romanian"
-msgstr "Albanų"
-
-#: src/Preferences.cpp
-msgid "Russian"
-msgstr "Rusų"
-
-#: src/Preferences.cpp
-msgid "Slovenian"
-msgstr "Slovėnų"
-
-#: src/Preferences.cpp
-msgid "Spanish"
-msgstr "Ispanų"
-
-#: src/Preferences.cpp
-msgid "Swedish"
-msgstr "Švedų"
-
-#: src/Preferences.cpp
-msgid "Turkish"
-msgstr "Turkų"
-
-#: src/Preferences.cpp
-msgid "Ukrainian"
-msgstr ""
-
-#: src/Preferences.cpp
-#, fuzzy
-msgid "Change Language"
-msgstr "Kalba"
-
-#: src/Preferences.cpp
-msgid "There are no translations installed for aMule"
-msgstr ""
-
-#: src/Preferences.cpp
-#, fuzzy
-msgid "No languages available"
-msgstr "Nėra"
-
-#: src/Preferences.cpp
 msgid "no options available"
 msgstr ""
 
@@ -6626,7 +6654,8 @@ msgstr ""
 msgid "Confirm shared folders"
 msgstr "Atnaujinti dalinamų failų sąrašą"
 
-#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp src/SharedFilesReloadProgress.cpp
+#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp
+#: src/SharedFilesReloadProgress.cpp
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "Atnaujinti dalinamų failų sąrašą"
@@ -9403,6 +9432,14 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#, fuzzy
+#~ msgid "Change Language"
+#~ msgstr "Kalba"
+
+#, fuzzy
+#~ msgid "No languages available"
+#~ msgstr "Nėra"
 
 #~ msgid "User name"
 #~ msgstr "Naudotojo vardas"

--- a/po/lv.po
+++ b/po/lv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-05 12:01+0200\n"
+"POT-Creation-Date: 2026-09-06 14:35+0200\n"
 "PO-Revision-Date: 2026-09-05 11:05+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -3134,6 +3134,162 @@ msgstr ""
 msgid "Invalid entry in known file list, file may be corrupt: "
 msgstr ""
 
+#: src/LanguageList.cpp
+msgid "System default"
+msgstr "Sistēmas"
+
+#: src/LanguageList.cpp
+msgid "Albanian"
+msgstr "Albāņu"
+
+#: src/LanguageList.cpp
+msgid "Arabic"
+msgstr "Arābu"
+
+#: src/LanguageList.cpp
+msgid "Asturian"
+msgstr "Astūriešu"
+
+#: src/LanguageList.cpp
+msgid "Basque"
+msgstr "Basku"
+
+#: src/LanguageList.cpp
+msgid "Bulgarian"
+msgstr "Bulgāru"
+
+#: src/LanguageList.cpp
+msgid "Catalan"
+msgstr "Katalāņu"
+
+#: src/LanguageList.cpp
+msgid "Chinese (Simplified)"
+msgstr "Ķīniešu (vienkāršotā)"
+
+#: src/LanguageList.cpp
+msgid "Chinese (Traditional)"
+msgstr "Ķīniešu (tradicionālā)"
+
+#: src/LanguageList.cpp
+msgid "Croatian"
+msgstr "Horvātu"
+
+#: src/LanguageList.cpp
+msgid "Czech"
+msgstr "Čehu"
+
+#: src/LanguageList.cpp
+msgid "Danish"
+msgstr "Dāņu"
+
+#: src/LanguageList.cpp
+msgid "Dutch"
+msgstr "Nīderlandiešu"
+
+#: src/LanguageList.cpp
+msgid "English (U.K.)"
+msgstr "Angļu (Apvienotās Karalistes)"
+
+#: src/LanguageList.cpp
+msgid "English (U.S.)"
+msgstr "Angļu (ASV)"
+
+#: src/LanguageList.cpp
+msgid "Estonian"
+msgstr "Igauņu"
+
+#: src/LanguageList.cpp
+msgid "Finnish"
+msgstr "Somu"
+
+#: src/LanguageList.cpp
+msgid "French"
+msgstr "Franču"
+
+#: src/LanguageList.cpp
+msgid "Galician"
+msgstr "Galisiešu"
+
+#: src/LanguageList.cpp
+msgid "German"
+msgstr "Vācu"
+
+#: src/LanguageList.cpp
+msgid "Greek"
+msgstr "Grieķu"
+
+#: src/LanguageList.cpp
+msgid "Hebrew"
+msgstr "Ivrits"
+
+#: src/LanguageList.cpp
+msgid "Hungarian"
+msgstr "Ungāru"
+
+#: src/LanguageList.cpp
+msgid "Italian"
+msgstr "Itāļu"
+
+#: src/LanguageList.cpp
+msgid "Japanese"
+msgstr "Japāņu"
+
+#: src/LanguageList.cpp
+msgid "Korean"
+msgstr "Korejiešu"
+
+#: src/LanguageList.cpp
+msgid "Latvian"
+msgstr "Latviešu"
+
+#: src/LanguageList.cpp
+msgid "Lithuanian"
+msgstr "Lietuviešu"
+
+#: src/LanguageList.cpp
+msgid "Norwegian (Nynorsk)"
+msgstr "Norvēģu (Jaunnorvēģu)"
+
+#: src/LanguageList.cpp
+msgid "Polish"
+msgstr "Poļu"
+
+#: src/LanguageList.cpp
+msgid "Portuguese"
+msgstr "Portugāļu"
+
+#: src/LanguageList.cpp
+msgid "Portuguese (Brazilian)"
+msgstr "Portugāļu (Brazīlijas)"
+
+#: src/LanguageList.cpp
+msgid "Romanian"
+msgstr "Rumāņu"
+
+#: src/LanguageList.cpp
+msgid "Russian"
+msgstr "Krievu"
+
+#: src/LanguageList.cpp
+msgid "Slovenian"
+msgstr "Slovēņu"
+
+#: src/LanguageList.cpp
+msgid "Spanish"
+msgstr "Spāņu"
+
+#: src/LanguageList.cpp
+msgid "Swedish"
+msgstr "Zviedru"
+
+#: src/LanguageList.cpp
+msgid "Turkish"
+msgstr "Turku"
+
+#: src/LanguageList.cpp
+msgid "Ukrainian"
+msgstr "Ukraiņu"
+
 #: src/libs/common/Format.cpp
 #, c-format
 msgid "Unknown error %d"
@@ -5817,174 +5973,6 @@ msgstr ""
 #, c-format
 msgid "ERROR: Failed to open partfile '%s'"
 msgstr ""
-
-#: src/Preferences.cpp
-msgid "System default"
-msgstr "Sistēmas"
-
-#: src/Preferences.cpp
-msgid "Albanian"
-msgstr "Albāņu"
-
-#: src/Preferences.cpp
-msgid "Arabic"
-msgstr "Arābu"
-
-#: src/Preferences.cpp
-msgid "Asturian"
-msgstr "Astūriešu"
-
-#: src/Preferences.cpp
-msgid "Basque"
-msgstr "Basku"
-
-#: src/Preferences.cpp
-msgid "Bulgarian"
-msgstr "Bulgāru"
-
-#: src/Preferences.cpp
-msgid "Catalan"
-msgstr "Katalāņu"
-
-#: src/Preferences.cpp
-msgid "Chinese (Simplified)"
-msgstr "Ķīniešu (vienkāršotā)"
-
-#: src/Preferences.cpp
-msgid "Chinese (Traditional)"
-msgstr "Ķīniešu (tradicionālā)"
-
-#: src/Preferences.cpp
-msgid "Croatian"
-msgstr "Horvātu"
-
-#: src/Preferences.cpp
-msgid "Czech"
-msgstr "Čehu"
-
-#: src/Preferences.cpp
-msgid "Danish"
-msgstr "Dāņu"
-
-#: src/Preferences.cpp
-msgid "Dutch"
-msgstr "Nīderlandiešu"
-
-#: src/Preferences.cpp
-msgid "English (U.K.)"
-msgstr "Angļu (Apvienotās Karalistes)"
-
-#: src/Preferences.cpp
-msgid "English (U.S.)"
-msgstr "Angļu (ASV)"
-
-#: src/Preferences.cpp
-msgid "Estonian"
-msgstr "Igauņu"
-
-#: src/Preferences.cpp
-msgid "Finnish"
-msgstr "Somu"
-
-#: src/Preferences.cpp
-msgid "French"
-msgstr "Franču"
-
-#: src/Preferences.cpp
-msgid "Galician"
-msgstr "Galisiešu"
-
-#: src/Preferences.cpp
-msgid "German"
-msgstr "Vācu"
-
-#: src/Preferences.cpp
-msgid "Greek"
-msgstr "Grieķu"
-
-#: src/Preferences.cpp
-msgid "Hebrew"
-msgstr "Ivrits"
-
-#: src/Preferences.cpp
-msgid "Hungarian"
-msgstr "Ungāru"
-
-#: src/Preferences.cpp
-msgid "Italian"
-msgstr "Itāļu"
-
-#: src/Preferences.cpp
-msgid "Japanese"
-msgstr "Japāņu"
-
-#: src/Preferences.cpp
-msgid "Korean"
-msgstr "Korejiešu"
-
-#: src/Preferences.cpp
-msgid "Latvian"
-msgstr "Latviešu"
-
-#: src/Preferences.cpp
-msgid "Lithuanian"
-msgstr "Lietuviešu"
-
-#: src/Preferences.cpp
-msgid "Norwegian (Nynorsk)"
-msgstr "Norvēģu (Jaunnorvēģu)"
-
-#: src/Preferences.cpp
-msgid "Polish"
-msgstr "Poļu"
-
-#: src/Preferences.cpp
-msgid "Portuguese"
-msgstr "Portugāļu"
-
-#: src/Preferences.cpp
-msgid "Portuguese (Brazilian)"
-msgstr "Portugāļu (Brazīlijas)"
-
-#: src/Preferences.cpp
-msgid "Romanian"
-msgstr "Rumāņu"
-
-#: src/Preferences.cpp
-msgid "Russian"
-msgstr "Krievu"
-
-#: src/Preferences.cpp
-msgid "Slovenian"
-msgstr "Slovēņu"
-
-#: src/Preferences.cpp
-msgid "Spanish"
-msgstr "Spāņu"
-
-#: src/Preferences.cpp
-msgid "Swedish"
-msgstr "Zviedru"
-
-#: src/Preferences.cpp
-msgid "Turkish"
-msgstr "Turku"
-
-#: src/Preferences.cpp
-msgid "Ukrainian"
-msgstr "Ukraiņu"
-
-#: src/Preferences.cpp
-msgid "Change Language"
-msgstr "Mainīt valodu"
-
-#: src/Preferences.cpp
-msgid "There are no translations installed for aMule"
-msgstr "aMule nav uzstādīta neviena valodas datne"
-
-#: src/Preferences.cpp
-msgid "No languages available"
-msgstr "Nav pieejama neviena valoda"
 
 #: src/Preferences.cpp
 msgid "no options available"
@@ -9140,6 +9128,15 @@ msgstr "Izskatās, ka aMule darbojas. Lūdzu, aizveriet to un vēlreiz palaidiet
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "Dzēš lietotāja datus, kas atrodas $APPDATA\\aMule mapē…"
+
+#~ msgid "Change Language"
+#~ msgstr "Mainīt valodu"
+
+#~ msgid "There are no translations installed for aMule"
+#~ msgstr "aMule nav uzstādīta neviena valodas datne"
+
+#~ msgid "No languages available"
+#~ msgstr "Nav pieejama neviena valoda"
 
 #~ msgid "User name"
 #~ msgstr "Lietotājvārds"

--- a/po/nl.po
+++ b/po/nl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-05 12:01+0200\n"
+"POT-Creation-Date: 2026-09-06 14:35+0200\n"
 "PO-Revision-Date: 2026-09-05 10:56+0000\n"
 "Last-Translator: Marcel Pol <marcel@timelord.nl>\n"
 "Language-Team: Dutch <nl@li.org>\n"
@@ -388,7 +388,8 @@ msgstr "webserver draait met pid %d"
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "U hebt gevraagd om de webserver bij het opstarten uit te voeren, maar het programma amuleweb kan niet worden uitgevoerd. Installeer het pakket met de aMule-webserver, of bouw aMule vanuit de broncode met -DBUILD_WEBSERVER=YES en installeer het."
 
-#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
+#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
+#: src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
 msgid "ERROR"
 msgstr "FOUT"
 
@@ -674,7 +675,8 @@ msgstr "Netwerken"
 msgid "Searches"
 msgstr "Zoeken"
 
-#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/Statistics.cpp
+#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/Statistics.cpp
 msgid "Downloads"
 msgstr "Downloads"
 
@@ -762,7 +764,9 @@ msgstr "Kad: Uitgeschakeld"
 msgid "Core"
 msgstr "Kern"
 
-#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp src/Statistics.cpp
+#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp src/Statistics.cpp
 msgid "Version"
 msgstr "Versie"
 
@@ -1059,7 +1063,11 @@ msgstr "Kan map '%s' niet aanmaken voor categorie '%s', map '%s' wordt behouden.
 msgid "The remote core sent inconsistent data for \"%s\" (part status %d, expected %d). The file list may be showing the wrong information; reconnect to clear it."
 msgstr "De externe kern stuurde inconsistente data voor \"%s\" (deel status %d, verwacht %d). De bestandslijst laat mogelijk de verkeerdeinformatie zien; herverbindt om die te legen."
 
-#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp src/Statistics.cpp
+#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp
+#: src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp
+#: src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp
+#: src/Statistics.cpp
 msgid "Unknown"
 msgstr "Onbekend"
 
@@ -1156,7 +1164,8 @@ msgstr "Fout bij het bewaren van bestand %s: %s"
 msgid "Enter Captcha"
 msgstr "Voer captcha in"
 
-#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp src/TransferWnd.cpp
+#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp
+#: src/TransferWnd.cpp
 msgid "Category"
 msgstr "Categorie"
 
@@ -1319,11 +1328,13 @@ msgstr "Geen 'cryptkey.dat' bestand gevonden, wordt aangemaakt."
 msgid "Client Details"
 msgstr "Client details"
 
-#: src/ClientDetailDialog.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
+#: src/utils/wxCas/src/onlinesig.cpp
 msgid "LowID"
 msgstr "Laag-ID"
 
-#: src/ClientDetailDialog.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
+#: src/utils/wxCas/src/onlinesig.cpp
 msgid "HighID"
 msgstr "Hoog ID"
 
@@ -1339,7 +1350,8 @@ msgstr "Ondersteund"
 msgid "Not supported"
 msgstr "Niet ondersteund"
 
-#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp src/TextClient.cpp
+#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
+#: src/TextClient.cpp
 msgid "Connected"
 msgstr "Verbonden"
 
@@ -1347,7 +1359,8 @@ msgstr "Verbonden"
 msgid "Disconnected"
 msgstr "Niet verbonden"
 
-#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f KiB/s"
 msgstr "%.1f KiB/s"
@@ -1364,7 +1377,8 @@ msgstr "Software"
 msgid "IP Address"
 msgstr "IP-Adres"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Origin"
 msgstr "Oorsprong"
 
@@ -1380,11 +1394,13 @@ msgstr "Voor het laatst gezien"
 msgid "Sessions"
 msgstr "Sessies"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/SharedFilePeersListCtrl.cpp
 msgid "Upload Speed"
 msgstr "Uploadsnelheid"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/SharedFilePeersListCtrl.cpp
 msgid "Download Speed"
 msgstr "Downloadsnelheid"
 
@@ -1435,11 +1451,13 @@ msgstr[1] "Kon %u links niet toevoegen (zie log voor details)."
 msgid "Files"
 msgstr "Bestanden"
 
-#: src/ClientsListCtrl.cpp src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientsListCtrl.cpp src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp
 msgid "Uploaded"
 msgstr "Geüpload"
 
-#: src/ClientsListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientsListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Downloaded"
 msgstr "Gedownload"
 
@@ -1527,7 +1545,8 @@ msgstr "Bestand commentaren"
 msgid "Username"
 msgstr "Gebruikersnaam"
 
-#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp
+#: src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "File Name"
 msgstr "Bestandsnaam"
 
@@ -1588,15 +1607,18 @@ msgstr "Auto [Ho]"
 msgid "Very low"
 msgstr "Heel laag"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Low"
 msgstr "Laag"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Normal"
 msgstr "Normaal"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "High"
 msgstr "Hoog"
 
@@ -1620,11 +1642,13 @@ msgstr "Verbinden via server"
 msgid "Queue Full"
 msgstr "Wachtrij vol"
 
-#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp src/muuli_wdr.cpp
+#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp
+#: src/muuli_wdr.cpp
 msgid "On Queue"
 msgstr "In wachtrij"
 
-#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
+#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp
+#: src/PartFile.cpp src/TransferWnd.cpp
 msgid "Downloading"
 msgstr "Downloaden"
 
@@ -1684,7 +1708,8 @@ msgstr "Lokale server"
 msgid "Remote Server"
 msgstr "Server op Afstand"
 
-#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp src/TextClient.cpp
+#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp
+#: src/TextClient.cpp
 msgid "Kad"
 msgstr "Kad"
 
@@ -1708,7 +1733,8 @@ msgstr "Bron seeds"
 msgid "Search Result"
 msgstr "Zoekresultaat"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp
+#: src/TransferWnd.cpp
 msgid "Completed"
 msgstr "Compleet"
 
@@ -1760,7 +1786,8 @@ msgstr "Kan niet aanpassen binnen een recursieve deellijst"
 msgid "Part"
 msgstr "Deel"
 
-#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 msgid "Size"
 msgstr "Grootte"
 
@@ -1768,7 +1795,8 @@ msgstr "Grootte"
 msgid "Transferred"
 msgstr "Overgebracht"
 
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp src/SourceListCtrl.cpp
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
+#: src/SourceListCtrl.cpp
 msgid "Speed"
 msgstr "Snelheid"
 
@@ -1776,11 +1804,13 @@ msgstr "Snelheid"
 msgid "Progress"
 msgstr "Voortgang"
 
-#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
+#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp
+#: src/SearchListCtrl.cpp
 msgid "Sources"
 msgstr "Bronnen"
 
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 msgid "Priority"
 msgstr "Prioriteit"
 
@@ -1804,7 +1834,9 @@ msgstr "Laatste overdracht"
 msgid "Auto"
 msgstr "Auto"
 
-#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/TransferWnd.cpp src/utils/wxCas/src/wxcasprefs.cpp
+#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/TransferWnd.cpp
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Cancel"
 msgstr "Annuleren"
 
@@ -1905,7 +1937,8 @@ msgstr "Voer een nieuwe naam voor dit bestand in:"
 msgid "File rename"
 msgstr "Naam wijzigen"
 
-#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f MiB/s"
 msgstr "%.1f MiB/s"
@@ -2709,11 +2742,13 @@ msgstr ""
 msgid "Start aMule automatically when I log in"
 msgstr "aMule automatisch starten bij aanmelden"
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp packaging/windows/installer_strings.c
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: packaging/windows/installer_strings.c
 msgid "Register aMule for ed2k:// links"
 msgstr "aMule registreren voor ed2k://-koppelingen"
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp packaging/windows/installer_strings.c
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: packaging/windows/installer_strings.c
 msgid "Register aMule for magnet: links"
 msgstr "aMule registreren voor magnet:-koppelingen"
 
@@ -2741,7 +2776,8 @@ msgstr ""
 msgid "Destination folder for downloads"
 msgstr "Doelmap voor downloads"
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Browse"
 msgstr "Bladeren"
 
@@ -3163,6 +3199,162 @@ msgstr "Kon vermelding in bekende-bestandenlijst niet laden, bestand kan beschad
 msgid "Invalid entry in known file list, file may be corrupt: "
 msgstr "Ongeldige vermelding in bekende-bestandenlijst, bestand kan beschadigd zijn: "
 
+#: src/LanguageList.cpp
+msgid "System default"
+msgstr "Systeemstandaard"
+
+#: src/LanguageList.cpp
+msgid "Albanian"
+msgstr "Albanees"
+
+#: src/LanguageList.cpp
+msgid "Arabic"
+msgstr "Arabisch"
+
+#: src/LanguageList.cpp
+msgid "Asturian"
+msgstr "Asturisch"
+
+#: src/LanguageList.cpp
+msgid "Basque"
+msgstr "Baskisch"
+
+#: src/LanguageList.cpp
+msgid "Bulgarian"
+msgstr "Bulgaars"
+
+#: src/LanguageList.cpp
+msgid "Catalan"
+msgstr "Catalaans"
+
+#: src/LanguageList.cpp
+msgid "Chinese (Simplified)"
+msgstr "Chinees (Vereenvoudigd)"
+
+#: src/LanguageList.cpp
+msgid "Chinese (Traditional)"
+msgstr "Chinees (Traditioneel)"
+
+#: src/LanguageList.cpp
+msgid "Croatian"
+msgstr "Kroatisch"
+
+#: src/LanguageList.cpp
+msgid "Czech"
+msgstr "Tsjechisch"
+
+#: src/LanguageList.cpp
+msgid "Danish"
+msgstr "Deens"
+
+#: src/LanguageList.cpp
+msgid "Dutch"
+msgstr "Nederlands"
+
+#: src/LanguageList.cpp
+msgid "English (U.K.)"
+msgstr "Engels (V.K.)"
+
+#: src/LanguageList.cpp
+msgid "English (U.S.)"
+msgstr "Engels (V.S.)"
+
+#: src/LanguageList.cpp
+msgid "Estonian"
+msgstr "Estonisch"
+
+#: src/LanguageList.cpp
+msgid "Finnish"
+msgstr "Fins"
+
+#: src/LanguageList.cpp
+msgid "French"
+msgstr "Frans"
+
+#: src/LanguageList.cpp
+msgid "Galician"
+msgstr "Gallisch"
+
+#: src/LanguageList.cpp
+msgid "German"
+msgstr "Duits"
+
+#: src/LanguageList.cpp
+msgid "Greek"
+msgstr "Grieks"
+
+#: src/LanguageList.cpp
+msgid "Hebrew"
+msgstr "Hebreeuws"
+
+#: src/LanguageList.cpp
+msgid "Hungarian"
+msgstr "Hongaars"
+
+#: src/LanguageList.cpp
+msgid "Italian"
+msgstr "Italiaans"
+
+#: src/LanguageList.cpp
+msgid "Japanese"
+msgstr "Japans"
+
+#: src/LanguageList.cpp
+msgid "Korean"
+msgstr "Koreaans"
+
+#: src/LanguageList.cpp
+msgid "Latvian"
+msgstr "Lets"
+
+#: src/LanguageList.cpp
+msgid "Lithuanian"
+msgstr "Litouws"
+
+#: src/LanguageList.cpp
+msgid "Norwegian (Nynorsk)"
+msgstr "Noors"
+
+#: src/LanguageList.cpp
+msgid "Polish"
+msgstr "Pools"
+
+#: src/LanguageList.cpp
+msgid "Portuguese"
+msgstr "Portugees"
+
+#: src/LanguageList.cpp
+msgid "Portuguese (Brazilian)"
+msgstr "Portugees (Braziliaans)"
+
+#: src/LanguageList.cpp
+msgid "Romanian"
+msgstr "Roemeens"
+
+#: src/LanguageList.cpp
+msgid "Russian"
+msgstr "Russisch"
+
+#: src/LanguageList.cpp
+msgid "Slovenian"
+msgstr "Sloveens"
+
+#: src/LanguageList.cpp
+msgid "Spanish"
+msgstr "Spaans"
+
+#: src/LanguageList.cpp
+msgid "Swedish"
+msgstr "Zweeds"
+
+#: src/LanguageList.cpp
+msgid "Turkish"
+msgstr "Turks"
+
+#: src/LanguageList.cpp
+msgid "Ukrainian"
+msgstr "Oekraïens"
+
 #: src/libs/common/Format.cpp
 #, c-format
 msgid "Unknown error %d"
@@ -3185,15 +3377,18 @@ msgstr "Voltooien"
 msgid "Complete"
 msgstr "Compleet"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Paused"
 msgstr "Gepauzeerd"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Erroneous"
 msgstr "Foutief"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Waiting"
 msgstr "Wachten"
 
@@ -3355,7 +3550,8 @@ msgstr "Sluiten"
 msgid "Cut"
 msgstr "Knippen"
 
-#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp src/utils/aLinkCreator/src/alcframe.cpp
+#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy"
 msgstr "Kopiëren"
 
@@ -3363,7 +3559,8 @@ msgstr "Kopiëren"
 msgid "Paste"
 msgstr "Plakken"
 
-#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
+#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Clear"
 msgstr "Wissen"
 
@@ -3371,7 +3568,8 @@ msgstr "Wissen"
 msgid "Select All"
 msgstr "Alles selecteren"
 
-#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp src/StatisticsDlg.cpp
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
+#: src/StatisticsDlg.cpp
 msgid "KiB/s"
 msgstr "KiB/s"
 
@@ -5838,174 +6036,6 @@ msgid "ERROR: Failed to open partfile '%s'"
 msgstr "FOUT: Kon deelbestand '%s' niet openen"
 
 #: src/Preferences.cpp
-msgid "System default"
-msgstr "Systeemstandaard"
-
-#: src/Preferences.cpp
-msgid "Albanian"
-msgstr "Albanees"
-
-#: src/Preferences.cpp
-msgid "Arabic"
-msgstr "Arabisch"
-
-#: src/Preferences.cpp
-msgid "Asturian"
-msgstr "Asturisch"
-
-#: src/Preferences.cpp
-msgid "Basque"
-msgstr "Baskisch"
-
-#: src/Preferences.cpp
-msgid "Bulgarian"
-msgstr "Bulgaars"
-
-#: src/Preferences.cpp
-msgid "Catalan"
-msgstr "Catalaans"
-
-#: src/Preferences.cpp
-msgid "Chinese (Simplified)"
-msgstr "Chinees (Vereenvoudigd)"
-
-#: src/Preferences.cpp
-msgid "Chinese (Traditional)"
-msgstr "Chinees (Traditioneel)"
-
-#: src/Preferences.cpp
-msgid "Croatian"
-msgstr "Kroatisch"
-
-#: src/Preferences.cpp
-msgid "Czech"
-msgstr "Tsjechisch"
-
-#: src/Preferences.cpp
-msgid "Danish"
-msgstr "Deens"
-
-#: src/Preferences.cpp
-msgid "Dutch"
-msgstr "Nederlands"
-
-#: src/Preferences.cpp
-msgid "English (U.K.)"
-msgstr "Engels (V.K.)"
-
-#: src/Preferences.cpp
-msgid "English (U.S.)"
-msgstr "Engels (V.S.)"
-
-#: src/Preferences.cpp
-msgid "Estonian"
-msgstr "Estonisch"
-
-#: src/Preferences.cpp
-msgid "Finnish"
-msgstr "Fins"
-
-#: src/Preferences.cpp
-msgid "French"
-msgstr "Frans"
-
-#: src/Preferences.cpp
-msgid "Galician"
-msgstr "Gallisch"
-
-#: src/Preferences.cpp
-msgid "German"
-msgstr "Duits"
-
-#: src/Preferences.cpp
-msgid "Greek"
-msgstr "Grieks"
-
-#: src/Preferences.cpp
-msgid "Hebrew"
-msgstr "Hebreeuws"
-
-#: src/Preferences.cpp
-msgid "Hungarian"
-msgstr "Hongaars"
-
-#: src/Preferences.cpp
-msgid "Italian"
-msgstr "Italiaans"
-
-#: src/Preferences.cpp
-msgid "Japanese"
-msgstr "Japans"
-
-#: src/Preferences.cpp
-msgid "Korean"
-msgstr "Koreaans"
-
-#: src/Preferences.cpp
-msgid "Latvian"
-msgstr "Lets"
-
-#: src/Preferences.cpp
-msgid "Lithuanian"
-msgstr "Litouws"
-
-#: src/Preferences.cpp
-msgid "Norwegian (Nynorsk)"
-msgstr "Noors"
-
-#: src/Preferences.cpp
-msgid "Polish"
-msgstr "Pools"
-
-#: src/Preferences.cpp
-msgid "Portuguese"
-msgstr "Portugees"
-
-#: src/Preferences.cpp
-msgid "Portuguese (Brazilian)"
-msgstr "Portugees (Braziliaans)"
-
-#: src/Preferences.cpp
-msgid "Romanian"
-msgstr "Roemeens"
-
-#: src/Preferences.cpp
-msgid "Russian"
-msgstr "Russisch"
-
-#: src/Preferences.cpp
-msgid "Slovenian"
-msgstr "Sloveens"
-
-#: src/Preferences.cpp
-msgid "Spanish"
-msgstr "Spaans"
-
-#: src/Preferences.cpp
-msgid "Swedish"
-msgstr "Zweeds"
-
-#: src/Preferences.cpp
-msgid "Turkish"
-msgstr "Turks"
-
-#: src/Preferences.cpp
-msgid "Ukrainian"
-msgstr "Oekraïens"
-
-#: src/Preferences.cpp
-msgid "Change Language"
-msgstr "Verander taal"
-
-#: src/Preferences.cpp
-msgid "There are no translations installed for aMule"
-msgstr "Er zijn geen vertalingen voor aMule geïnstalleerd"
-
-#: src/Preferences.cpp
-msgid "No languages available"
-msgstr "Geen talen beschikbaar"
-
-#: src/Preferences.cpp
 msgid "no options available"
 msgstr "geen opties beschikbaar"
 
@@ -6507,7 +6537,8 @@ msgstr "Als u ze recursief deelt, wordt elk bestand daaronder gepubliceerd op de
 msgid "Confirm shared folders"
 msgstr "Gedeelde mappen bevestigen"
 
-#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp src/SharedFilesReloadProgress.cpp
+#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp
+#: src/SharedFilesReloadProgress.cpp
 msgid "Reloading shared files..."
 msgstr "Gedeelde bestanden opnieuw laden..."
 
@@ -9242,6 +9273,15 @@ msgstr "aMule lijkt te worden uitgevoerd. Sluit het en voer het verwijderprogram
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "Gebruikersgegevens op $APPDATA\\aMule worden verwijderd..."
+
+#~ msgid "Change Language"
+#~ msgstr "Verander taal"
+
+#~ msgid "There are no translations installed for aMule"
+#~ msgstr "Er zijn geen vertalingen voor aMule geïnstalleerd"
+
+#~ msgid "No languages available"
+#~ msgstr "Geen talen beschikbaar"
 
 #~ msgid "User name"
 #~ msgstr "Gebruikersnaam"

--- a/po/nn.po
+++ b/po/nn.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-05 12:01+0200\n"
+"POT-Creation-Date: 2026-09-06 14:35+0200\n"
 "PO-Revision-Date: 2026-09-05 10:56+0000\n"
 "Last-Translator: Hallvor Brunstad <Hallvor_1976@yahoo.com>\n"
 "Language-Team: <i18n-nn@lister.ping.uio.no>\n"
@@ -389,7 +389,8 @@ msgstr "vevtenar køyrer på pid %d"
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Du freista å køyre vevtenar ved oppstart, men binærfila amuleweb kan ikkje køyrast. Installer pakken som inneheld vevtenaren til aMule, eller kompiler aMule med --enable-webserver og køyr make install"
 
-#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
+#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
+#: src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
 msgid "ERROR"
 msgstr "FEIL"
 
@@ -678,7 +679,8 @@ msgstr "Nettverk"
 msgid "Searches"
 msgstr "Søk"
 
-#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/Statistics.cpp
+#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/Statistics.cpp
 msgid "Downloads"
 msgstr "Nedlastingar"
 
@@ -762,7 +764,9 @@ msgstr "Kad: Av"
 msgid "Core"
 msgstr ""
 
-#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp src/Statistics.cpp
+#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp src/Statistics.cpp
 msgid "Version"
 msgstr "Utgåve"
 
@@ -1066,7 +1070,11 @@ msgstr ""
 msgid "The remote core sent inconsistent data for \"%s\" (part status %d, expected %d). The file list may be showing the wrong information; reconnect to clear it."
 msgstr ""
 
-#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp src/Statistics.cpp
+#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp
+#: src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp
+#: src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp
+#: src/Statistics.cpp
 msgid "Unknown"
 msgstr "Ukjend"
 
@@ -1164,7 +1172,8 @@ msgstr "Feil under lagring av known.met fila: %s"
 msgid "Enter Captcha"
 msgstr ""
 
-#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp src/TransferWnd.cpp
+#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp
+#: src/TransferWnd.cpp
 msgid "Category"
 msgstr "Kategori"
 
@@ -1328,11 +1337,13 @@ msgstr "Inga 'cryptkey.dat' fil funne - opprettar."
 msgid "Client Details"
 msgstr "Klientdetaljar"
 
-#: src/ClientDetailDialog.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
+#: src/utils/wxCas/src/onlinesig.cpp
 msgid "LowID"
 msgstr "LågID"
 
-#: src/ClientDetailDialog.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
+#: src/utils/wxCas/src/onlinesig.cpp
 msgid "HighID"
 msgstr "HøgID"
 
@@ -1348,7 +1359,8 @@ msgstr "Støtta"
 msgid "Not supported"
 msgstr "Ikkje støtta"
 
-#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp src/TextClient.cpp
+#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
+#: src/TextClient.cpp
 msgid "Connected"
 msgstr "Tilkopla"
 
@@ -1356,7 +1368,8 @@ msgstr "Tilkopla"
 msgid "Disconnected"
 msgstr "Fråkopla"
 
-#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f KiB/s"
 msgstr ""
@@ -1373,7 +1386,8 @@ msgstr ""
 msgid "IP Address"
 msgstr "IP-adresse"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Origin"
 msgstr ""
 
@@ -1391,12 +1405,14 @@ msgstr "Sist motteke"
 msgid "Sessions"
 msgstr "Utgåve"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/SharedFilePeersListCtrl.cpp
 #, fuzzy
 msgid "Upload Speed"
 msgstr "Opplastingsfart"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/SharedFilePeersListCtrl.cpp
 #, fuzzy
 msgid "Download Speed"
 msgstr "Nedlastingsfart"
@@ -1452,11 +1468,13 @@ msgstr[1] ""
 msgid "Files"
 msgstr "Filer"
 
-#: src/ClientsListCtrl.cpp src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientsListCtrl.cpp src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp
 msgid "Uploaded"
 msgstr "Lasta opp"
 
-#: src/ClientsListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientsListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Downloaded"
 msgstr "Lasta ned"
 
@@ -1547,7 +1565,8 @@ msgstr "Filkommentarar"
 msgid "Username"
 msgstr "Brukarnamn"
 
-#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp
+#: src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "File Name"
 msgstr "Filnamn"
 
@@ -1608,15 +1627,18 @@ msgstr "Auto·[Hø]"
 msgid "Very low"
 msgstr "Svært låg"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Low"
 msgstr "Låg"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Normal"
 msgstr "Vanleg"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "High"
 msgstr "Høg"
 
@@ -1640,11 +1662,13 @@ msgstr "Koplar til gjennom tenar"
 msgid "Queue Full"
 msgstr "Kø full"
 
-#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp src/muuli_wdr.cpp
+#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp
+#: src/muuli_wdr.cpp
 msgid "On Queue"
 msgstr "I kø"
 
-#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
+#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp
+#: src/PartFile.cpp src/TransferWnd.cpp
 msgid "Downloading"
 msgstr "Lastar ned"
 
@@ -1704,7 +1728,8 @@ msgstr "Lokal tenar"
 msgid "Remote Server"
 msgstr "Fjern tenar"
 
-#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp src/TextClient.cpp
+#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp
+#: src/TextClient.cpp
 msgid "Kad"
 msgstr "Kad"
 
@@ -1728,7 +1753,8 @@ msgstr "Kjeldefrø"
 msgid "Search Result"
 msgstr ""
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp
+#: src/TransferWnd.cpp
 msgid "Completed"
 msgstr "Ferdig"
 
@@ -1781,7 +1807,8 @@ msgstr ""
 msgid "Part"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 msgid "Size"
 msgstr "Storleik"
 
@@ -1789,7 +1816,8 @@ msgstr "Storleik"
 msgid "Transferred"
 msgstr "Overført"
 
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp src/SourceListCtrl.cpp
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
+#: src/SourceListCtrl.cpp
 msgid "Speed"
 msgstr "Fart"
 
@@ -1797,11 +1825,13 @@ msgstr "Fart"
 msgid "Progress"
 msgstr "Framdrift"
 
-#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
+#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp
+#: src/SearchListCtrl.cpp
 msgid "Sources"
 msgstr "Kjelder"
 
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 msgid "Priority"
 msgstr "Prioritet"
 
@@ -1825,7 +1855,9 @@ msgstr "Sist motteke"
 msgid "Auto"
 msgstr "Automatisk"
 
-#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/TransferWnd.cpp src/utils/wxCas/src/wxcasprefs.cpp
+#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/TransferWnd.cpp
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Cancel"
 msgstr "Avbryt"
 
@@ -1926,7 +1958,8 @@ msgstr "Skriv nytt namn på denne fila:"
 msgid "File rename"
 msgstr "Døyp om fil"
 
-#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f MiB/s"
 msgstr ""
@@ -2736,11 +2769,13 @@ msgstr ""
 msgid "Start aMule automatically when I log in"
 msgstr ""
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp packaging/windows/installer_strings.c
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: packaging/windows/installer_strings.c
 msgid "Register aMule for ed2k:// links"
 msgstr ""
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp packaging/windows/installer_strings.c
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: packaging/windows/installer_strings.c
 msgid "Register aMule for magnet: links"
 msgstr ""
 
@@ -2766,7 +2801,8 @@ msgstr ""
 msgid "Destination folder for downloads"
 msgstr ""
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Browse"
 msgstr "Bla"
 
@@ -3191,6 +3227,165 @@ msgstr ""
 msgid "Invalid entry in known file list, file may be corrupt: "
 msgstr ""
 
+#: src/LanguageList.cpp
+msgid "System default"
+msgstr "Standardinnstillingar"
+
+#: src/LanguageList.cpp
+msgid "Albanian"
+msgstr "Albansk"
+
+#: src/LanguageList.cpp
+msgid "Arabic"
+msgstr "Arabisk"
+
+#: src/LanguageList.cpp
+#, fuzzy
+msgid "Asturian"
+msgstr "Estisk"
+
+#: src/LanguageList.cpp
+msgid "Basque"
+msgstr "Baskisk"
+
+#: src/LanguageList.cpp
+msgid "Bulgarian"
+msgstr "Bulgarsk"
+
+#: src/LanguageList.cpp
+msgid "Catalan"
+msgstr "Katalansk"
+
+#: src/LanguageList.cpp
+msgid "Chinese (Simplified)"
+msgstr "Kinesisk (forenkla)"
+
+#: src/LanguageList.cpp
+msgid "Chinese (Traditional)"
+msgstr "Kinesisk (tradisjonell)"
+
+#: src/LanguageList.cpp
+msgid "Croatian"
+msgstr "Kroatisk"
+
+#: src/LanguageList.cpp
+msgid "Czech"
+msgstr "Tsjekkisk"
+
+#: src/LanguageList.cpp
+msgid "Danish"
+msgstr "Dansk"
+
+#: src/LanguageList.cpp
+msgid "Dutch"
+msgstr "Nederlansk"
+
+#: src/LanguageList.cpp
+msgid "English (U.K.)"
+msgstr "Engelsk (U.K.)"
+
+#: src/LanguageList.cpp
+#, fuzzy
+msgid "English (U.S.)"
+msgstr "Engelsk (U.K.)"
+
+#: src/LanguageList.cpp
+msgid "Estonian"
+msgstr "Estisk"
+
+#: src/LanguageList.cpp
+msgid "Finnish"
+msgstr "Finsk"
+
+#: src/LanguageList.cpp
+msgid "French"
+msgstr "Fransk"
+
+#: src/LanguageList.cpp
+msgid "Galician"
+msgstr "Galisisk"
+
+#: src/LanguageList.cpp
+msgid "German"
+msgstr "Tysk"
+
+#: src/LanguageList.cpp
+msgid "Greek"
+msgstr "Gresk"
+
+#: src/LanguageList.cpp
+msgid "Hebrew"
+msgstr "Hebraisk"
+
+#: src/LanguageList.cpp
+msgid "Hungarian"
+msgstr "Ungarsk"
+
+#: src/LanguageList.cpp
+msgid "Italian"
+msgstr "Italiensk"
+
+#: src/LanguageList.cpp
+msgid "Japanese"
+msgstr "Japansk"
+
+#: src/LanguageList.cpp
+msgid "Korean"
+msgstr "Koreansk"
+
+#: src/LanguageList.cpp
+msgid "Latvian"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Lithuanian"
+msgstr "Litauisk"
+
+#: src/LanguageList.cpp
+msgid "Norwegian (Nynorsk)"
+msgstr "Norsk (Nynorsk)"
+
+#: src/LanguageList.cpp
+msgid "Polish"
+msgstr "Polsk"
+
+#: src/LanguageList.cpp
+msgid "Portuguese"
+msgstr "Portugisisk"
+
+#: src/LanguageList.cpp
+msgid "Portuguese (Brazilian)"
+msgstr "Portugisisk (Brasil)"
+
+#: src/LanguageList.cpp
+#, fuzzy
+msgid "Romanian"
+msgstr "Albansk"
+
+#: src/LanguageList.cpp
+msgid "Russian"
+msgstr "Russisk"
+
+#: src/LanguageList.cpp
+msgid "Slovenian"
+msgstr "Slovensk"
+
+#: src/LanguageList.cpp
+msgid "Spanish"
+msgstr "Spansk"
+
+#: src/LanguageList.cpp
+msgid "Swedish"
+msgstr "Svensk"
+
+#: src/LanguageList.cpp
+msgid "Turkish"
+msgstr "Tyrkisk"
+
+#: src/LanguageList.cpp
+msgid "Ukrainian"
+msgstr ""
+
 #: src/libs/common/Format.cpp
 #, fuzzy, c-format
 msgid "Unknown error %d"
@@ -3213,15 +3408,18 @@ msgstr "Ferdigstiller"
 msgid "Complete"
 msgstr "Ferdig"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Paused"
 msgstr "Pausa"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Erroneous"
 msgstr "Feilaktig"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Waiting"
 msgstr "Ventar"
 
@@ -3387,7 +3585,8 @@ msgstr "Stengje"
 msgid "Cut"
 msgstr "Klipp ut"
 
-#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp src/utils/aLinkCreator/src/alcframe.cpp
+#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy"
 msgstr "Kopiér"
 
@@ -3395,7 +3594,8 @@ msgstr "Kopiér"
 msgid "Paste"
 msgstr "Lim inn"
 
-#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
+#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Clear"
 msgstr "Frigjer plass"
 
@@ -3403,7 +3603,8 @@ msgstr "Frigjer plass"
 msgid "Select All"
 msgstr "Vél alle"
 
-#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp src/StatisticsDlg.cpp
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
+#: src/StatisticsDlg.cpp
 msgid "KiB/s"
 msgstr ""
 
@@ -5910,179 +6111,6 @@ msgid "ERROR: Failed to open partfile '%s'"
 msgstr "Feil: Greidde ikkje opne delfila '%s'"
 
 #: src/Preferences.cpp
-msgid "System default"
-msgstr "Standardinnstillingar"
-
-#: src/Preferences.cpp
-msgid "Albanian"
-msgstr "Albansk"
-
-#: src/Preferences.cpp
-msgid "Arabic"
-msgstr "Arabisk"
-
-#: src/Preferences.cpp
-#, fuzzy
-msgid "Asturian"
-msgstr "Estisk"
-
-#: src/Preferences.cpp
-msgid "Basque"
-msgstr "Baskisk"
-
-#: src/Preferences.cpp
-msgid "Bulgarian"
-msgstr "Bulgarsk"
-
-#: src/Preferences.cpp
-msgid "Catalan"
-msgstr "Katalansk"
-
-#: src/Preferences.cpp
-msgid "Chinese (Simplified)"
-msgstr "Kinesisk (forenkla)"
-
-#: src/Preferences.cpp
-msgid "Chinese (Traditional)"
-msgstr "Kinesisk (tradisjonell)"
-
-#: src/Preferences.cpp
-msgid "Croatian"
-msgstr "Kroatisk"
-
-#: src/Preferences.cpp
-msgid "Czech"
-msgstr "Tsjekkisk"
-
-#: src/Preferences.cpp
-msgid "Danish"
-msgstr "Dansk"
-
-#: src/Preferences.cpp
-msgid "Dutch"
-msgstr "Nederlansk"
-
-#: src/Preferences.cpp
-msgid "English (U.K.)"
-msgstr "Engelsk (U.K.)"
-
-#: src/Preferences.cpp
-#, fuzzy
-msgid "English (U.S.)"
-msgstr "Engelsk (U.K.)"
-
-#: src/Preferences.cpp
-msgid "Estonian"
-msgstr "Estisk"
-
-#: src/Preferences.cpp
-msgid "Finnish"
-msgstr "Finsk"
-
-#: src/Preferences.cpp
-msgid "French"
-msgstr "Fransk"
-
-#: src/Preferences.cpp
-msgid "Galician"
-msgstr "Galisisk"
-
-#: src/Preferences.cpp
-msgid "German"
-msgstr "Tysk"
-
-#: src/Preferences.cpp
-msgid "Greek"
-msgstr "Gresk"
-
-#: src/Preferences.cpp
-msgid "Hebrew"
-msgstr "Hebraisk"
-
-#: src/Preferences.cpp
-msgid "Hungarian"
-msgstr "Ungarsk"
-
-#: src/Preferences.cpp
-msgid "Italian"
-msgstr "Italiensk"
-
-#: src/Preferences.cpp
-msgid "Japanese"
-msgstr "Japansk"
-
-#: src/Preferences.cpp
-msgid "Korean"
-msgstr "Koreansk"
-
-#: src/Preferences.cpp
-msgid "Latvian"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Lithuanian"
-msgstr "Litauisk"
-
-#: src/Preferences.cpp
-msgid "Norwegian (Nynorsk)"
-msgstr "Norsk (Nynorsk)"
-
-#: src/Preferences.cpp
-msgid "Polish"
-msgstr "Polsk"
-
-#: src/Preferences.cpp
-msgid "Portuguese"
-msgstr "Portugisisk"
-
-#: src/Preferences.cpp
-msgid "Portuguese (Brazilian)"
-msgstr "Portugisisk (Brasil)"
-
-#: src/Preferences.cpp
-#, fuzzy
-msgid "Romanian"
-msgstr "Albansk"
-
-#: src/Preferences.cpp
-msgid "Russian"
-msgstr "Russisk"
-
-#: src/Preferences.cpp
-msgid "Slovenian"
-msgstr "Slovensk"
-
-#: src/Preferences.cpp
-msgid "Spanish"
-msgstr "Spansk"
-
-#: src/Preferences.cpp
-msgid "Swedish"
-msgstr "Svensk"
-
-#: src/Preferences.cpp
-msgid "Turkish"
-msgstr "Tyrkisk"
-
-#: src/Preferences.cpp
-msgid "Ukrainian"
-msgstr ""
-
-#: src/Preferences.cpp
-#, fuzzy
-msgid "Change Language"
-msgstr "Språk"
-
-#: src/Preferences.cpp
-msgid "There are no translations installed for aMule"
-msgstr ""
-
-#: src/Preferences.cpp
-#, fuzzy
-msgid "No languages available"
-msgstr "Ikkje tilgjengeleg"
-
-#: src/Preferences.cpp
 msgid "no options available"
 msgstr ""
 
@@ -6594,7 +6622,8 @@ msgstr ""
 msgid "Confirm shared folders"
 msgstr "Lastar inn att delte filer"
 
-#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp src/SharedFilesReloadProgress.cpp
+#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp
+#: src/SharedFilesReloadProgress.cpp
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "Lastar inn att delte filer"
@@ -9355,6 +9384,14 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#, fuzzy
+#~ msgid "Change Language"
+#~ msgstr "Språk"
+
+#, fuzzy
+#~ msgid "No languages available"
+#~ msgstr "Ikkje tilgjengeleg"
 
 #~ msgid "User name"
 #~ msgstr "Brukarnamn"

--- a/po/pl.po
+++ b/po/pl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-05 12:01+0200\n"
+"POT-Creation-Date: 2026-09-06 14:35+0200\n"
 "PO-Revision-Date: 2026-09-05 10:57+0000\n"
 "Last-Translator: Michał Trzebiatowski <hippie_1968@hotmail.com>\n"
 "Language-Team: translationproject.org/team/pl.html <translation-team-pl@lists.sourceforge.net>\n"
@@ -390,7 +390,8 @@ msgstr "serwer sieciowy uruchomiony na pid %d"
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Zażądałeś włączenia serwera sieciowego podczas uruchomienia, ale binarki amuleweb nie mogą być uruchomione. Zainstaluj paczkę zawierającą serwer sieciowy aMule lub skompiluj aMule używając --enable-webserver i uruchom make install"
 
-#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
+#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
+#: src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
 msgid "ERROR"
 msgstr "BŁĄD"
 
@@ -678,7 +679,8 @@ msgstr "Sieci"
 msgid "Searches"
 msgstr "Szukaj"
 
-#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/Statistics.cpp
+#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/Statistics.cpp
 msgid "Downloads"
 msgstr "Pobieranie"
 
@@ -762,7 +764,9 @@ msgstr "Kad: Wyłączony"
 msgid "Core"
 msgstr ""
 
-#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp src/Statistics.cpp
+#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp src/Statistics.cpp
 msgid "Version"
 msgstr "Wersja"
 
@@ -1061,7 +1065,11 @@ msgstr "Nie można utworzyć katalogu '%s' dla kategorii '%s', używany jest nad
 msgid "The remote core sent inconsistent data for \"%s\" (part status %d, expected %d). The file list may be showing the wrong information; reconnect to clear it."
 msgstr ""
 
-#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp src/Statistics.cpp
+#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp
+#: src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp
+#: src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp
+#: src/Statistics.cpp
 msgid "Unknown"
 msgstr "Nieznany"
 
@@ -1160,7 +1168,8 @@ msgstr "Błąd podczas zapisywania pliku %s: %s"
 msgid "Enter Captcha"
 msgstr "Wpisz Captcha"
 
-#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp src/TransferWnd.cpp
+#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp
+#: src/TransferWnd.cpp
 msgid "Category"
 msgstr "Kategoria"
 
@@ -1330,11 +1339,13 @@ msgstr "Nie znaleziono pliku cryptkey.dat, tworzenie."
 msgid "Client Details"
 msgstr "Szczegóły klienta"
 
-#: src/ClientDetailDialog.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
+#: src/utils/wxCas/src/onlinesig.cpp
 msgid "LowID"
 msgstr "LowID"
 
-#: src/ClientDetailDialog.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
+#: src/utils/wxCas/src/onlinesig.cpp
 msgid "HighID"
 msgstr "HighID"
 
@@ -1350,7 +1361,8 @@ msgstr "Obsługiwany"
 msgid "Not supported"
 msgstr "Nieobsługiwany"
 
-#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp src/TextClient.cpp
+#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
+#: src/TextClient.cpp
 msgid "Connected"
 msgstr "Połączony"
 
@@ -1358,7 +1370,8 @@ msgstr "Połączony"
 msgid "Disconnected"
 msgstr "Rozłączony"
 
-#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f KiB/s"
 msgstr ""
@@ -1375,7 +1388,8 @@ msgstr ""
 msgid "IP Address"
 msgstr "Adres IP"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Origin"
 msgstr "Źródło"
 
@@ -1393,11 +1407,13 @@ msgstr "Ostatnio widziany"
 msgid "Sessions"
 msgstr "Wersja"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/SharedFilePeersListCtrl.cpp
 msgid "Upload Speed"
 msgstr "Prędkość wysyłania"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/SharedFilePeersListCtrl.cpp
 msgid "Download Speed"
 msgstr "Prędkość pobierania"
 
@@ -1453,11 +1469,13 @@ msgstr[2] ""
 msgid "Files"
 msgstr "Pliki"
 
-#: src/ClientsListCtrl.cpp src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientsListCtrl.cpp src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp
 msgid "Uploaded"
 msgstr "Wysłano"
 
-#: src/ClientsListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientsListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Downloaded"
 msgstr "Pobrano"
 
@@ -1548,7 +1566,8 @@ msgstr "Komentarze pliku"
 msgid "Username"
 msgstr "Nazwa użytkownika"
 
-#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp
+#: src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "File Name"
 msgstr "Nazwa pliku"
 
@@ -1611,15 +1630,18 @@ msgstr "Auto [Wy]"
 msgid "Very low"
 msgstr "Bardzo niski"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Low"
 msgstr "Niski"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Normal"
 msgstr "Normalny"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "High"
 msgstr "Wysoki"
 
@@ -1643,11 +1665,13 @@ msgstr "Połączenie przez serwer"
 msgid "Queue Full"
 msgstr "Pełna kolejka"
 
-#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp src/muuli_wdr.cpp
+#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp
+#: src/muuli_wdr.cpp
 msgid "On Queue"
 msgstr "W kolejce"
 
-#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
+#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp
+#: src/PartFile.cpp src/TransferWnd.cpp
 msgid "Downloading"
 msgstr "Pobieranie"
 
@@ -1707,7 +1731,8 @@ msgstr "Serwer lokalny"
 msgid "Remote Server"
 msgstr "Serwer zdalny"
 
-#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp src/TextClient.cpp
+#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp
+#: src/TextClient.cpp
 msgid "Kad"
 msgstr "Kad"
 
@@ -1731,7 +1756,8 @@ msgstr "Ziarna źródła"
 msgid "Search Result"
 msgstr "Wynik wyszukiwania"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp
+#: src/TransferWnd.cpp
 msgid "Completed"
 msgstr "Zakończono"
 
@@ -1784,7 +1810,8 @@ msgstr ""
 msgid "Part"
 msgstr "Część"
 
-#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 msgid "Size"
 msgstr "Rozmiar"
 
@@ -1792,7 +1819,8 @@ msgstr "Rozmiar"
 msgid "Transferred"
 msgstr "Przesłano"
 
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp src/SourceListCtrl.cpp
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
+#: src/SourceListCtrl.cpp
 msgid "Speed"
 msgstr "Prędkość"
 
@@ -1800,11 +1828,13 @@ msgstr "Prędkość"
 msgid "Progress"
 msgstr "Postęp"
 
-#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
+#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp
+#: src/SearchListCtrl.cpp
 msgid "Sources"
 msgstr "Źródła"
 
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 msgid "Priority"
 msgstr "Priorytet"
 
@@ -1828,7 +1858,9 @@ msgstr "Ostatnio widziany"
 msgid "Auto"
 msgstr "Automatyczny"
 
-#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/TransferWnd.cpp src/utils/wxCas/src/wxcasprefs.cpp
+#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/TransferWnd.cpp
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Cancel"
 msgstr "Anuluj"
 
@@ -1929,7 +1961,8 @@ msgstr "Wprowadź nową nazwę dla tego pliku:"
 msgid "File rename"
 msgstr "Zmień nazwę"
 
-#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f MiB/s"
 msgstr ""
@@ -2736,11 +2769,13 @@ msgstr ""
 msgid "Start aMule automatically when I log in"
 msgstr ""
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp packaging/windows/installer_strings.c
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: packaging/windows/installer_strings.c
 msgid "Register aMule for ed2k:// links"
 msgstr ""
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp packaging/windows/installer_strings.c
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: packaging/windows/installer_strings.c
 msgid "Register aMule for magnet: links"
 msgstr ""
 
@@ -2766,7 +2801,8 @@ msgstr ""
 msgid "Destination folder for downloads"
 msgstr "Folder docelowy dla pobrań"
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Browse"
 msgstr "Przeglądaj"
 
@@ -3192,6 +3228,163 @@ msgstr "Nie można załadować wpisu w znanej liście plików, plik może być u
 msgid "Invalid entry in known file list, file may be corrupt: "
 msgstr "Nieprawidłowy wpis w znanej liście plików, plik może być uszkodzony: "
 
+#: src/LanguageList.cpp
+msgid "System default"
+msgstr "Domyślny systemowy"
+
+#: src/LanguageList.cpp
+msgid "Albanian"
+msgstr "Albański"
+
+#: src/LanguageList.cpp
+msgid "Arabic"
+msgstr "Arabski"
+
+#: src/LanguageList.cpp
+msgid "Asturian"
+msgstr "Asturyjski"
+
+#: src/LanguageList.cpp
+msgid "Basque"
+msgstr "Baskijski"
+
+#: src/LanguageList.cpp
+msgid "Bulgarian"
+msgstr "Bułgarski"
+
+#: src/LanguageList.cpp
+msgid "Catalan"
+msgstr "Kataloński"
+
+#: src/LanguageList.cpp
+msgid "Chinese (Simplified)"
+msgstr "Chiński (Uproszczony)"
+
+#: src/LanguageList.cpp
+msgid "Chinese (Traditional)"
+msgstr "Chiński (Tradycyjny)"
+
+#: src/LanguageList.cpp
+msgid "Croatian"
+msgstr "Chorwacki"
+
+#: src/LanguageList.cpp
+msgid "Czech"
+msgstr "Czeski"
+
+#: src/LanguageList.cpp
+msgid "Danish"
+msgstr "Duński"
+
+#: src/LanguageList.cpp
+msgid "Dutch"
+msgstr "Holenderski"
+
+#: src/LanguageList.cpp
+msgid "English (U.K.)"
+msgstr "Angielski (U.K.)"
+
+#: src/LanguageList.cpp
+#, fuzzy
+msgid "English (U.S.)"
+msgstr "Angielski (U.K.)"
+
+#: src/LanguageList.cpp
+msgid "Estonian"
+msgstr "Estoński"
+
+#: src/LanguageList.cpp
+msgid "Finnish"
+msgstr "Fiński"
+
+#: src/LanguageList.cpp
+msgid "French"
+msgstr "Francuski"
+
+#: src/LanguageList.cpp
+msgid "Galician"
+msgstr "Galicyjski"
+
+#: src/LanguageList.cpp
+msgid "German"
+msgstr "Niemiecki"
+
+#: src/LanguageList.cpp
+msgid "Greek"
+msgstr "Grecki"
+
+#: src/LanguageList.cpp
+msgid "Hebrew"
+msgstr "Hebrajski"
+
+#: src/LanguageList.cpp
+msgid "Hungarian"
+msgstr "Węgierski"
+
+#: src/LanguageList.cpp
+msgid "Italian"
+msgstr "Włoski"
+
+#: src/LanguageList.cpp
+msgid "Japanese"
+msgstr "Japoński"
+
+#: src/LanguageList.cpp
+msgid "Korean"
+msgstr "Koreański"
+
+#: src/LanguageList.cpp
+msgid "Latvian"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Lithuanian"
+msgstr "Litewski"
+
+#: src/LanguageList.cpp
+msgid "Norwegian (Nynorsk)"
+msgstr "Norweski (Nynorsk)"
+
+#: src/LanguageList.cpp
+msgid "Polish"
+msgstr "Polski"
+
+#: src/LanguageList.cpp
+msgid "Portuguese"
+msgstr "Portugalski"
+
+#: src/LanguageList.cpp
+msgid "Portuguese (Brazilian)"
+msgstr "Portugalski (Brazylijski)"
+
+#: src/LanguageList.cpp
+msgid "Romanian"
+msgstr "Rumuński"
+
+#: src/LanguageList.cpp
+msgid "Russian"
+msgstr "Rosyjski"
+
+#: src/LanguageList.cpp
+msgid "Slovenian"
+msgstr "Słoweński"
+
+#: src/LanguageList.cpp
+msgid "Spanish"
+msgstr "Hiszpański"
+
+#: src/LanguageList.cpp
+msgid "Swedish"
+msgstr "Szwedzki"
+
+#: src/LanguageList.cpp
+msgid "Turkish"
+msgstr "Turecki"
+
+#: src/LanguageList.cpp
+msgid "Ukrainian"
+msgstr "Ukraiński"
+
 #: src/libs/common/Format.cpp
 #, fuzzy, c-format
 msgid "Unknown error %d"
@@ -3214,15 +3407,18 @@ msgstr "Zakańczanie"
 msgid "Complete"
 msgstr "Ukończono"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Paused"
 msgstr "Wstrzymano"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Erroneous"
 msgstr "Błędne"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Waiting"
 msgstr "Czeka"
 
@@ -3390,7 +3586,8 @@ msgstr "Zamknij"
 msgid "Cut"
 msgstr "Wytnij"
 
-#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp src/utils/aLinkCreator/src/alcframe.cpp
+#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy"
 msgstr "Kopiuj"
 
@@ -3398,7 +3595,8 @@ msgstr "Kopiuj"
 msgid "Paste"
 msgstr "Wklej"
 
-#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
+#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Clear"
 msgstr "Wyczyść"
 
@@ -3406,7 +3604,8 @@ msgstr "Wyczyść"
 msgid "Select All"
 msgstr "Zaznacz wszystko"
 
-#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp src/StatisticsDlg.cpp
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
+#: src/StatisticsDlg.cpp
 msgid "KiB/s"
 msgstr ""
 
@@ -5915,176 +6114,6 @@ msgid "ERROR: Failed to open partfile '%s'"
 msgstr "BŁĄD: Nie udało się otworzyć pliku części '%s'"
 
 #: src/Preferences.cpp
-msgid "System default"
-msgstr "Domyślny systemowy"
-
-#: src/Preferences.cpp
-msgid "Albanian"
-msgstr "Albański"
-
-#: src/Preferences.cpp
-msgid "Arabic"
-msgstr "Arabski"
-
-#: src/Preferences.cpp
-msgid "Asturian"
-msgstr "Asturyjski"
-
-#: src/Preferences.cpp
-msgid "Basque"
-msgstr "Baskijski"
-
-#: src/Preferences.cpp
-msgid "Bulgarian"
-msgstr "Bułgarski"
-
-#: src/Preferences.cpp
-msgid "Catalan"
-msgstr "Kataloński"
-
-#: src/Preferences.cpp
-msgid "Chinese (Simplified)"
-msgstr "Chiński (Uproszczony)"
-
-#: src/Preferences.cpp
-msgid "Chinese (Traditional)"
-msgstr "Chiński (Tradycyjny)"
-
-#: src/Preferences.cpp
-msgid "Croatian"
-msgstr "Chorwacki"
-
-#: src/Preferences.cpp
-msgid "Czech"
-msgstr "Czeski"
-
-#: src/Preferences.cpp
-msgid "Danish"
-msgstr "Duński"
-
-#: src/Preferences.cpp
-msgid "Dutch"
-msgstr "Holenderski"
-
-#: src/Preferences.cpp
-msgid "English (U.K.)"
-msgstr "Angielski (U.K.)"
-
-#: src/Preferences.cpp
-#, fuzzy
-msgid "English (U.S.)"
-msgstr "Angielski (U.K.)"
-
-#: src/Preferences.cpp
-msgid "Estonian"
-msgstr "Estoński"
-
-#: src/Preferences.cpp
-msgid "Finnish"
-msgstr "Fiński"
-
-#: src/Preferences.cpp
-msgid "French"
-msgstr "Francuski"
-
-#: src/Preferences.cpp
-msgid "Galician"
-msgstr "Galicyjski"
-
-#: src/Preferences.cpp
-msgid "German"
-msgstr "Niemiecki"
-
-#: src/Preferences.cpp
-msgid "Greek"
-msgstr "Grecki"
-
-#: src/Preferences.cpp
-msgid "Hebrew"
-msgstr "Hebrajski"
-
-#: src/Preferences.cpp
-msgid "Hungarian"
-msgstr "Węgierski"
-
-#: src/Preferences.cpp
-msgid "Italian"
-msgstr "Włoski"
-
-#: src/Preferences.cpp
-msgid "Japanese"
-msgstr "Japoński"
-
-#: src/Preferences.cpp
-msgid "Korean"
-msgstr "Koreański"
-
-#: src/Preferences.cpp
-msgid "Latvian"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Lithuanian"
-msgstr "Litewski"
-
-#: src/Preferences.cpp
-msgid "Norwegian (Nynorsk)"
-msgstr "Norweski (Nynorsk)"
-
-#: src/Preferences.cpp
-msgid "Polish"
-msgstr "Polski"
-
-#: src/Preferences.cpp
-msgid "Portuguese"
-msgstr "Portugalski"
-
-#: src/Preferences.cpp
-msgid "Portuguese (Brazilian)"
-msgstr "Portugalski (Brazylijski)"
-
-#: src/Preferences.cpp
-msgid "Romanian"
-msgstr "Rumuński"
-
-#: src/Preferences.cpp
-msgid "Russian"
-msgstr "Rosyjski"
-
-#: src/Preferences.cpp
-msgid "Slovenian"
-msgstr "Słoweński"
-
-#: src/Preferences.cpp
-msgid "Spanish"
-msgstr "Hiszpański"
-
-#: src/Preferences.cpp
-msgid "Swedish"
-msgstr "Szwedzki"
-
-#: src/Preferences.cpp
-msgid "Turkish"
-msgstr "Turecki"
-
-#: src/Preferences.cpp
-msgid "Ukrainian"
-msgstr "Ukraiński"
-
-#: src/Preferences.cpp
-msgid "Change Language"
-msgstr "Zmień język"
-
-#: src/Preferences.cpp
-msgid "There are no translations installed for aMule"
-msgstr ""
-
-#: src/Preferences.cpp
-#, fuzzy
-msgid "No languages available"
-msgstr "Niedostępny"
-
-#: src/Preferences.cpp
 msgid "no options available"
 msgstr "nie ma dostępnych opcji"
 
@@ -6604,7 +6633,8 @@ msgstr ""
 msgid "Confirm shared folders"
 msgstr "Udostępnione foldery"
 
-#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp src/SharedFilesReloadProgress.cpp
+#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp
+#: src/SharedFilesReloadProgress.cpp
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "Przeładuj twoje udostępnione pliki"
@@ -9362,6 +9392,13 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "Change Language"
+#~ msgstr "Zmień język"
+
+#, fuzzy
+#~ msgid "No languages available"
+#~ msgstr "Niedostępny"
 
 #~ msgid "User name"
 #~ msgstr "Nazwa użytkownika"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-05 12:01+0200\n"
+"POT-Creation-Date: 2026-09-06 14:35+0200\n"
 "PO-Revision-Date: 2026-09-05 10:58+0000\n"
 "Last-Translator: Marcelo Jimenez <mroberto@users.sourceforge.com>\n"
 "Language-Team: Português (Brasileiro) <pt@li.org>\n"
@@ -392,7 +392,8 @@ msgstr "web server rodando no pid %d"
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Você pediu para rodar o servidor web na início, mas o binário do amuleweb não pode ser rodado. Por favor instale o pacote contendo o servidro web do aMule, ou compile o aMule a partir do código fonte usando -DBUILD_WEBSERVER=YES e instale-o."
 
-#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
+#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
+#: src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
 msgid "ERROR"
 msgstr "ERRO"
 
@@ -679,7 +680,8 @@ msgstr "Redes"
 msgid "Searches"
 msgstr "Pesquisas"
 
-#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/Statistics.cpp
+#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/Statistics.cpp
 msgid "Downloads"
 msgstr "Downloads"
 
@@ -767,7 +769,9 @@ msgstr "Kad: Desligado"
 msgid "Core"
 msgstr "Núcleo"
 
-#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp src/Statistics.cpp
+#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp src/Statistics.cpp
 msgid "Version"
 msgstr "Versão"
 
@@ -1064,7 +1068,11 @@ msgstr "Incapaz criar o diretório '%s' para a categoria '%s', mantendo diretór
 msgid "The remote core sent inconsistent data for \"%s\" (part status %d, expected %d). The file list may be showing the wrong information; reconnect to clear it."
 msgstr "O núcleo remoto mandou dados inconsistentes para \"%s\" (estado da parte %d, esperado %d). A lista de arquivos pode estar mostrando a informação errada; reconecte para limpar."
 
-#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp src/Statistics.cpp
+#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp
+#: src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp
+#: src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp
+#: src/Statistics.cpp
 msgid "Unknown"
 msgstr "Desconhecido"
 
@@ -1161,7 +1169,8 @@ msgstr "Erro ao salvar arquivo %s: %s"
 msgid "Enter Captcha"
 msgstr "Insira o Captcha"
 
-#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp src/TransferWnd.cpp
+#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp
+#: src/TransferWnd.cpp
 msgid "Category"
 msgstr "Categoria"
 
@@ -1324,11 +1333,13 @@ msgstr "Arquivo 'cryptkey.dat' não foi encontrado, criando."
 msgid "Client Details"
 msgstr "Detalhes do Cliente"
 
-#: src/ClientDetailDialog.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
+#: src/utils/wxCas/src/onlinesig.cpp
 msgid "LowID"
 msgstr "LowID"
 
-#: src/ClientDetailDialog.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
+#: src/utils/wxCas/src/onlinesig.cpp
 msgid "HighID"
 msgstr "HighID"
 
@@ -1344,7 +1355,8 @@ msgstr "Suportado"
 msgid "Not supported"
 msgstr "Não suportado"
 
-#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp src/TextClient.cpp
+#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
+#: src/TextClient.cpp
 msgid "Connected"
 msgstr "Conectado"
 
@@ -1352,7 +1364,8 @@ msgstr "Conectado"
 msgid "Disconnected"
 msgstr "Desconectado"
 
-#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f KiB/s"
 msgstr "%.1f KiB/s"
@@ -1369,7 +1382,8 @@ msgstr "Software"
 msgid "IP Address"
 msgstr "Endereço IP"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Origin"
 msgstr "Origem"
 
@@ -1385,11 +1399,13 @@ msgstr "Visto por último"
 msgid "Sessions"
 msgstr "Sessões"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/SharedFilePeersListCtrl.cpp
 msgid "Upload Speed"
 msgstr "Velocidade de Upload"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/SharedFilePeersListCtrl.cpp
 msgid "Download Speed"
 msgstr "Velocidade de Download"
 
@@ -1440,11 +1456,13 @@ msgstr[1] "Não foi possível adicionar %u links (veja o log para detalhes)."
 msgid "Files"
 msgstr "Arquivos"
 
-#: src/ClientsListCtrl.cpp src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientsListCtrl.cpp src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp
 msgid "Uploaded"
 msgstr "Enviado"
 
-#: src/ClientsListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientsListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Downloaded"
 msgstr "Baixado"
 
@@ -1532,7 +1550,8 @@ msgstr "Comentários do arquivo"
 msgid "Username"
 msgstr "Nome do usuário"
 
-#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp
+#: src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "File Name"
 msgstr "Nome do arquivo"
 
@@ -1593,15 +1612,18 @@ msgstr "Auto [Alto]"
 msgid "Very low"
 msgstr "Muito baixo"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Low"
 msgstr "Baixo"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Normal"
 msgstr "Normal"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "High"
 msgstr "Alto"
 
@@ -1625,11 +1647,13 @@ msgstr "Conectando via servidor"
 msgid "Queue Full"
 msgstr "Fila de espera cheia"
 
-#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp src/muuli_wdr.cpp
+#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp
+#: src/muuli_wdr.cpp
 msgid "On Queue"
 msgstr "Na fila de espera"
 
-#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
+#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp
+#: src/PartFile.cpp src/TransferWnd.cpp
 msgid "Downloading"
 msgstr "Baixando"
 
@@ -1689,7 +1713,8 @@ msgstr "Servidor Local"
 msgid "Remote Server"
 msgstr "Servidor Remoto"
 
-#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp src/TextClient.cpp
+#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp
+#: src/TextClient.cpp
 msgid "Kad"
 msgstr "Kad"
 
@@ -1713,7 +1738,8 @@ msgstr "Fontes de arquivo"
 msgid "Search Result"
 msgstr "Resultado da Busca"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp
+#: src/TransferWnd.cpp
 msgid "Completed"
 msgstr "Completado"
 
@@ -1765,7 +1791,8 @@ msgstr "Não é possível modificar dentro de um compartilhamento recursivo"
 msgid "Part"
 msgstr "Parte"
 
-#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 msgid "Size"
 msgstr "Tamanho"
 
@@ -1773,7 +1800,8 @@ msgstr "Tamanho"
 msgid "Transferred"
 msgstr "Transferido"
 
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp src/SourceListCtrl.cpp
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
+#: src/SourceListCtrl.cpp
 msgid "Speed"
 msgstr "Velocidade"
 
@@ -1781,11 +1809,13 @@ msgstr "Velocidade"
 msgid "Progress"
 msgstr "Progresso"
 
-#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
+#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp
+#: src/SearchListCtrl.cpp
 msgid "Sources"
 msgstr "Fontes"
 
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 msgid "Priority"
 msgstr "Prioridade"
 
@@ -1809,7 +1839,9 @@ msgstr "Último recebimento"
 msgid "Auto"
 msgstr "Auto"
 
-#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/TransferWnd.cpp src/utils/wxCas/src/wxcasprefs.cpp
+#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/TransferWnd.cpp
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Cancel"
 msgstr "Cancelar"
 
@@ -1910,7 +1942,8 @@ msgstr "Informe o novo nome para o arquivo:"
 msgid "File rename"
 msgstr "Renomear"
 
-#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f MiB/s"
 msgstr "%.1f MiB/s"
@@ -2713,11 +2746,13 @@ msgstr ""
 msgid "Start aMule automatically when I log in"
 msgstr "Iniciar o aMule automaticamente quando eu logar no sistema"
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp packaging/windows/installer_strings.c
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: packaging/windows/installer_strings.c
 msgid "Register aMule for ed2k:// links"
 msgstr "Registrar aMule para links ed2k://"
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp packaging/windows/installer_strings.c
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: packaging/windows/installer_strings.c
 msgid "Register aMule for magnet: links"
 msgstr "Registra o aMule para links \"magnet:\""
 
@@ -2745,7 +2780,8 @@ msgstr ""
 msgid "Destination folder for downloads"
 msgstr "Pasta de destino para baixados"
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Browse"
 msgstr "Procurar"
 
@@ -3167,6 +3203,162 @@ msgstr "Falha ao carregar entrada em lista de arquivo known, arquivo pode estar 
 msgid "Invalid entry in known file list, file may be corrupt: "
 msgstr "Entrada inválida na lista de arquivo known, arquivo pode estar corrompido: "
 
+#: src/LanguageList.cpp
+msgid "System default"
+msgstr "Padrão do sistema"
+
+#: src/LanguageList.cpp
+msgid "Albanian"
+msgstr "Albanês"
+
+#: src/LanguageList.cpp
+msgid "Arabic"
+msgstr "Árabe"
+
+#: src/LanguageList.cpp
+msgid "Asturian"
+msgstr "Asturiano"
+
+#: src/LanguageList.cpp
+msgid "Basque"
+msgstr "Basco"
+
+#: src/LanguageList.cpp
+msgid "Bulgarian"
+msgstr "Búlgaro"
+
+#: src/LanguageList.cpp
+msgid "Catalan"
+msgstr "Catalão"
+
+#: src/LanguageList.cpp
+msgid "Chinese (Simplified)"
+msgstr "Chinês (Simplificado)"
+
+#: src/LanguageList.cpp
+msgid "Chinese (Traditional)"
+msgstr "Chinês (Tradicional)"
+
+#: src/LanguageList.cpp
+msgid "Croatian"
+msgstr "Croácia"
+
+#: src/LanguageList.cpp
+msgid "Czech"
+msgstr "Tcheco"
+
+#: src/LanguageList.cpp
+msgid "Danish"
+msgstr "Dinamarquês"
+
+#: src/LanguageList.cpp
+msgid "Dutch"
+msgstr "Holandês"
+
+#: src/LanguageList.cpp
+msgid "English (U.K.)"
+msgstr "Inglês (UK)"
+
+#: src/LanguageList.cpp
+msgid "English (U.S.)"
+msgstr "Inglês (U.S.)"
+
+#: src/LanguageList.cpp
+msgid "Estonian"
+msgstr "Estônia"
+
+#: src/LanguageList.cpp
+msgid "Finnish"
+msgstr "Finlandês"
+
+#: src/LanguageList.cpp
+msgid "French"
+msgstr "Francês"
+
+#: src/LanguageList.cpp
+msgid "Galician"
+msgstr "Galego"
+
+#: src/LanguageList.cpp
+msgid "German"
+msgstr "Alemão"
+
+#: src/LanguageList.cpp
+msgid "Greek"
+msgstr "Grego"
+
+#: src/LanguageList.cpp
+msgid "Hebrew"
+msgstr "Hebreu"
+
+#: src/LanguageList.cpp
+msgid "Hungarian"
+msgstr "Hungria"
+
+#: src/LanguageList.cpp
+msgid "Italian"
+msgstr "Italiano"
+
+#: src/LanguageList.cpp
+msgid "Japanese"
+msgstr "Japonês"
+
+#: src/LanguageList.cpp
+msgid "Korean"
+msgstr "Coreano"
+
+#: src/LanguageList.cpp
+msgid "Latvian"
+msgstr "Letão"
+
+#: src/LanguageList.cpp
+msgid "Lithuanian"
+msgstr "Lituânia"
+
+#: src/LanguageList.cpp
+msgid "Norwegian (Nynorsk)"
+msgstr "Noruega (Nynorsk)"
+
+#: src/LanguageList.cpp
+msgid "Polish"
+msgstr "Polonês"
+
+#: src/LanguageList.cpp
+msgid "Portuguese"
+msgstr "Português (Portugal)"
+
+#: src/LanguageList.cpp
+msgid "Portuguese (Brazilian)"
+msgstr "Português (Brasil)"
+
+#: src/LanguageList.cpp
+msgid "Romanian"
+msgstr "Albanês"
+
+#: src/LanguageList.cpp
+msgid "Russian"
+msgstr "Russo"
+
+#: src/LanguageList.cpp
+msgid "Slovenian"
+msgstr "Esloveno"
+
+#: src/LanguageList.cpp
+msgid "Spanish"
+msgstr "Espanhol"
+
+#: src/LanguageList.cpp
+msgid "Swedish"
+msgstr "Suécia"
+
+#: src/LanguageList.cpp
+msgid "Turkish"
+msgstr "Turquia"
+
+#: src/LanguageList.cpp
+msgid "Ukrainian"
+msgstr "Ucraniano"
+
 #: src/libs/common/Format.cpp
 #, c-format
 msgid "Unknown error %d"
@@ -3189,15 +3381,18 @@ msgstr "Finalizando"
 msgid "Complete"
 msgstr "Completo"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Paused"
 msgstr "Pausa"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Erroneous"
 msgstr "Com Erro"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Waiting"
 msgstr "Esperando"
 
@@ -3359,7 +3554,8 @@ msgstr "Fechar"
 msgid "Cut"
 msgstr "Recortar"
 
-#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp src/utils/aLinkCreator/src/alcframe.cpp
+#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy"
 msgstr "Copiar"
 
@@ -3367,7 +3563,8 @@ msgstr "Copiar"
 msgid "Paste"
 msgstr "Colar"
 
-#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
+#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Clear"
 msgstr "Limpar"
 
@@ -3375,7 +3572,8 @@ msgstr "Limpar"
 msgid "Select All"
 msgstr "Selecionar Tudo"
 
-#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp src/StatisticsDlg.cpp
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
+#: src/StatisticsDlg.cpp
 msgid "KiB/s"
 msgstr "KiB/s"
 
@@ -5841,174 +6039,6 @@ msgid "ERROR: Failed to open partfile '%s'"
 msgstr "ERRO: Falha ao abrir partfile '%s'"
 
 #: src/Preferences.cpp
-msgid "System default"
-msgstr "Padrão do sistema"
-
-#: src/Preferences.cpp
-msgid "Albanian"
-msgstr "Albanês"
-
-#: src/Preferences.cpp
-msgid "Arabic"
-msgstr "Árabe"
-
-#: src/Preferences.cpp
-msgid "Asturian"
-msgstr "Asturiano"
-
-#: src/Preferences.cpp
-msgid "Basque"
-msgstr "Basco"
-
-#: src/Preferences.cpp
-msgid "Bulgarian"
-msgstr "Búlgaro"
-
-#: src/Preferences.cpp
-msgid "Catalan"
-msgstr "Catalão"
-
-#: src/Preferences.cpp
-msgid "Chinese (Simplified)"
-msgstr "Chinês (Simplificado)"
-
-#: src/Preferences.cpp
-msgid "Chinese (Traditional)"
-msgstr "Chinês (Tradicional)"
-
-#: src/Preferences.cpp
-msgid "Croatian"
-msgstr "Croácia"
-
-#: src/Preferences.cpp
-msgid "Czech"
-msgstr "Tcheco"
-
-#: src/Preferences.cpp
-msgid "Danish"
-msgstr "Dinamarquês"
-
-#: src/Preferences.cpp
-msgid "Dutch"
-msgstr "Holandês"
-
-#: src/Preferences.cpp
-msgid "English (U.K.)"
-msgstr "Inglês (UK)"
-
-#: src/Preferences.cpp
-msgid "English (U.S.)"
-msgstr "Inglês (U.S.)"
-
-#: src/Preferences.cpp
-msgid "Estonian"
-msgstr "Estônia"
-
-#: src/Preferences.cpp
-msgid "Finnish"
-msgstr "Finlandês"
-
-#: src/Preferences.cpp
-msgid "French"
-msgstr "Francês"
-
-#: src/Preferences.cpp
-msgid "Galician"
-msgstr "Galego"
-
-#: src/Preferences.cpp
-msgid "German"
-msgstr "Alemão"
-
-#: src/Preferences.cpp
-msgid "Greek"
-msgstr "Grego"
-
-#: src/Preferences.cpp
-msgid "Hebrew"
-msgstr "Hebreu"
-
-#: src/Preferences.cpp
-msgid "Hungarian"
-msgstr "Hungria"
-
-#: src/Preferences.cpp
-msgid "Italian"
-msgstr "Italiano"
-
-#: src/Preferences.cpp
-msgid "Japanese"
-msgstr "Japonês"
-
-#: src/Preferences.cpp
-msgid "Korean"
-msgstr "Coreano"
-
-#: src/Preferences.cpp
-msgid "Latvian"
-msgstr "Letão"
-
-#: src/Preferences.cpp
-msgid "Lithuanian"
-msgstr "Lituânia"
-
-#: src/Preferences.cpp
-msgid "Norwegian (Nynorsk)"
-msgstr "Noruega (Nynorsk)"
-
-#: src/Preferences.cpp
-msgid "Polish"
-msgstr "Polonês"
-
-#: src/Preferences.cpp
-msgid "Portuguese"
-msgstr "Português (Portugal)"
-
-#: src/Preferences.cpp
-msgid "Portuguese (Brazilian)"
-msgstr "Português (Brasil)"
-
-#: src/Preferences.cpp
-msgid "Romanian"
-msgstr "Albanês"
-
-#: src/Preferences.cpp
-msgid "Russian"
-msgstr "Russo"
-
-#: src/Preferences.cpp
-msgid "Slovenian"
-msgstr "Esloveno"
-
-#: src/Preferences.cpp
-msgid "Spanish"
-msgstr "Espanhol"
-
-#: src/Preferences.cpp
-msgid "Swedish"
-msgstr "Suécia"
-
-#: src/Preferences.cpp
-msgid "Turkish"
-msgstr "Turquia"
-
-#: src/Preferences.cpp
-msgid "Ukrainian"
-msgstr "Ucraniano"
-
-#: src/Preferences.cpp
-msgid "Change Language"
-msgstr "Mudar Idioma"
-
-#: src/Preferences.cpp
-msgid "There are no translations installed for aMule"
-msgstr "Não há traduções instaladas no aMule"
-
-#: src/Preferences.cpp
-msgid "No languages available"
-msgstr "Nenhum idioma disponível"
-
-#: src/Preferences.cpp
 msgid "no options available"
 msgstr "nenhuma opção disponível"
 
@@ -6510,7 +6540,8 @@ msgstr "Compartilha-los recursivamente vai publicar todos os arquivos sob as red
 msgid "Confirm shared folders"
 msgstr "Confirma pastas compartilhadas"
 
-#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp src/SharedFilesReloadProgress.cpp
+#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp
+#: src/SharedFilesReloadProgress.cpp
 msgid "Reloading shared files..."
 msgstr "Recarregando lista de arquivos compartilhados..."
 
@@ -9241,6 +9272,15 @@ msgstr "O aMule parece estar rodando. Por favor, feche-o e rode o desinstalador 
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "Removendo os dados do usuário em $APPDATA\\aMule..."
+
+#~ msgid "Change Language"
+#~ msgstr "Mudar Idioma"
+
+#~ msgid "There are no translations installed for aMule"
+#~ msgstr "Não há traduções instaladas no aMule"
+
+#~ msgid "No languages available"
+#~ msgstr "Nenhum idioma disponível"
 
 #~ msgid "User name"
 #~ msgstr "Usuário"

--- a/po/pt_PT.po
+++ b/po/pt_PT.po
@@ -17,7 +17,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-05 12:01+0200\n"
+"POT-Creation-Date: 2026-09-06 14:35+0200\n"
 "PO-Revision-Date: 2026-09-05 10:58+0000\n"
 "Last-Translator: Luís Picciochi Oliveira <Pitxyoki@Gmail.com>\n"
 "Language-Team: Portuguese <traduz@debianpt.org>\n"
@@ -394,7 +394,8 @@ msgstr "servidor web a executar no pid %d"
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Pediu para executar o servidor web no arranque, mas o executável não pode ser lançado. Por favor, instale o pacote que contém o servidor web ou compile o aMule com --enable-webserver e execute make install"
 
-#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
+#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
+#: src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
 msgid "ERROR"
 msgstr "ERRO"
 
@@ -682,7 +683,8 @@ msgstr "Redes"
 msgid "Searches"
 msgstr "Pesquisas"
 
-#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/Statistics.cpp
+#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/Statistics.cpp
 msgid "Downloads"
 msgstr "Downloads"
 
@@ -766,7 +768,9 @@ msgstr "Kad: Desligado"
 msgid "Core"
 msgstr ""
 
-#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp src/Statistics.cpp
+#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp src/Statistics.cpp
 msgid "Version"
 msgstr "Versão"
 
@@ -1065,7 +1069,11 @@ msgstr "Não é possível criar o directório '%s' para a categoria '%s', a mant
 msgid "The remote core sent inconsistent data for \"%s\" (part status %d, expected %d). The file list may be showing the wrong information; reconnect to clear it."
 msgstr ""
 
-#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp src/Statistics.cpp
+#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp
+#: src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp
+#: src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp
+#: src/Statistics.cpp
 msgid "Unknown"
 msgstr "Desconhecido"
 
@@ -1162,7 +1170,8 @@ msgstr "Erro ao gravar ficheiro %s: %s"
 msgid "Enter Captcha"
 msgstr "Escrever 'Captcha'"
 
-#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp src/TransferWnd.cpp
+#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp
+#: src/TransferWnd.cpp
 msgid "Category"
 msgstr "Categoria"
 
@@ -1326,11 +1335,13 @@ msgstr "Ficheiro 'cryptkey.dat' não encontrado, a criar."
 msgid "Client Details"
 msgstr "Detalhes do Cliente"
 
-#: src/ClientDetailDialog.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
+#: src/utils/wxCas/src/onlinesig.cpp
 msgid "LowID"
 msgstr "LowID"
 
-#: src/ClientDetailDialog.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
+#: src/utils/wxCas/src/onlinesig.cpp
 msgid "HighID"
 msgstr "HighID"
 
@@ -1346,7 +1357,8 @@ msgstr "Suportado"
 msgid "Not supported"
 msgstr "Não suportado"
 
-#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp src/TextClient.cpp
+#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
+#: src/TextClient.cpp
 msgid "Connected"
 msgstr "Ligado"
 
@@ -1354,7 +1366,8 @@ msgstr "Ligado"
 msgid "Disconnected"
 msgstr "Desligado"
 
-#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f KiB/s"
 msgstr ""
@@ -1371,7 +1384,8 @@ msgstr ""
 msgid "IP Address"
 msgstr "Endereço IP"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Origin"
 msgstr "Origem"
 
@@ -1389,11 +1403,13 @@ msgstr "Última recepção"
 msgid "Sessions"
 msgstr "Versão"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/SharedFilePeersListCtrl.cpp
 msgid "Upload Speed"
 msgstr "Velocidade de Upload"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/SharedFilePeersListCtrl.cpp
 msgid "Download Speed"
 msgstr "Velocidade de Download"
 
@@ -1448,11 +1464,13 @@ msgstr[1] ""
 msgid "Files"
 msgstr "Ficheiros"
 
-#: src/ClientsListCtrl.cpp src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientsListCtrl.cpp src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp
 msgid "Uploaded"
 msgstr "Enviado"
 
-#: src/ClientsListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientsListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Downloaded"
 msgstr "Transferido"
 
@@ -1543,7 +1561,8 @@ msgstr "Comentários do ficheiro"
 msgid "Username"
 msgstr "Nome de Utilizador"
 
-#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp
+#: src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "File Name"
 msgstr "Nome do Ficheiro"
 
@@ -1605,15 +1624,18 @@ msgstr "Automática [Alta]"
 msgid "Very low"
 msgstr "Muito baixa"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Low"
 msgstr "Baixa"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Normal"
 msgstr "Normal"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "High"
 msgstr "Alta"
 
@@ -1637,11 +1659,13 @@ msgstr "A ligar via servidor"
 msgid "Queue Full"
 msgstr "Fila de Espera Cheia"
 
-#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp src/muuli_wdr.cpp
+#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp
+#: src/muuli_wdr.cpp
 msgid "On Queue"
 msgstr "Em Fila de Espera"
 
-#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
+#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp
+#: src/PartFile.cpp src/TransferWnd.cpp
 msgid "Downloading"
 msgstr "A Receber"
 
@@ -1701,7 +1725,8 @@ msgstr "Servidor Local"
 msgid "Remote Server"
 msgstr "Servidor Remoto"
 
-#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp src/TextClient.cpp
+#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp
+#: src/TextClient.cpp
 msgid "Kad"
 msgstr "Kad"
 
@@ -1725,7 +1750,8 @@ msgstr "Sementes de Fontes"
 msgid "Search Result"
 msgstr "Resultados de Pesquisas"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp
+#: src/TransferWnd.cpp
 msgid "Completed"
 msgstr "Concluído"
 
@@ -1778,7 +1804,8 @@ msgstr ""
 msgid "Part"
 msgstr "Parte"
 
-#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 msgid "Size"
 msgstr "Tamanho"
 
@@ -1786,7 +1813,8 @@ msgstr "Tamanho"
 msgid "Transferred"
 msgstr "Transferido"
 
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp src/SourceListCtrl.cpp
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
+#: src/SourceListCtrl.cpp
 msgid "Speed"
 msgstr "Velocidade"
 
@@ -1794,11 +1822,13 @@ msgstr "Velocidade"
 msgid "Progress"
 msgstr "Progresso"
 
-#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
+#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp
+#: src/SearchListCtrl.cpp
 msgid "Sources"
 msgstr "Fontes"
 
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 msgid "Priority"
 msgstr "Prioridade"
 
@@ -1822,7 +1852,9 @@ msgstr "Última recepção"
 msgid "Auto"
 msgstr "Automática"
 
-#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/TransferWnd.cpp src/utils/wxCas/src/wxcasprefs.cpp
+#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/TransferWnd.cpp
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Cancel"
 msgstr "Cancelar"
 
@@ -1923,7 +1955,8 @@ msgstr "Insira o novo nome para este ficheiro:"
 msgid "File rename"
 msgstr "Renomear ficheiro"
 
-#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f MiB/s"
 msgstr ""
@@ -2728,11 +2761,13 @@ msgstr ""
 msgid "Start aMule automatically when I log in"
 msgstr ""
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp packaging/windows/installer_strings.c
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: packaging/windows/installer_strings.c
 msgid "Register aMule for ed2k:// links"
 msgstr ""
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp packaging/windows/installer_strings.c
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: packaging/windows/installer_strings.c
 msgid "Register aMule for magnet: links"
 msgstr ""
 
@@ -2758,7 +2793,8 @@ msgstr ""
 msgid "Destination folder for downloads"
 msgstr "Pasta de destino para downloads"
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Browse"
 msgstr "Procurar"
 
@@ -3179,6 +3215,163 @@ msgstr "Falhou ao carregar entrada na lista de ficheiros conhecidos, o ficheiro 
 msgid "Invalid entry in known file list, file may be corrupt: "
 msgstr "Entrada inválida na lista de ficheiros conhecidos, o ficheiro pode estar corrompido"
 
+#: src/LanguageList.cpp
+msgid "System default"
+msgstr "Predefinição do sistema"
+
+#: src/LanguageList.cpp
+msgid "Albanian"
+msgstr "Albanês"
+
+#: src/LanguageList.cpp
+msgid "Arabic"
+msgstr "Árabe"
+
+#: src/LanguageList.cpp
+msgid "Asturian"
+msgstr "Asturiano"
+
+#: src/LanguageList.cpp
+msgid "Basque"
+msgstr "Basco"
+
+#: src/LanguageList.cpp
+msgid "Bulgarian"
+msgstr "Búlgaro"
+
+#: src/LanguageList.cpp
+msgid "Catalan"
+msgstr "Catalão"
+
+#: src/LanguageList.cpp
+msgid "Chinese (Simplified)"
+msgstr "Chinês (Simplificado)"
+
+#: src/LanguageList.cpp
+msgid "Chinese (Traditional)"
+msgstr "Chinês (Tradicional)"
+
+#: src/LanguageList.cpp
+msgid "Croatian"
+msgstr "Croata"
+
+#: src/LanguageList.cpp
+msgid "Czech"
+msgstr "Checo"
+
+#: src/LanguageList.cpp
+msgid "Danish"
+msgstr "Dinamarquês"
+
+#: src/LanguageList.cpp
+msgid "Dutch"
+msgstr "Holandês"
+
+#: src/LanguageList.cpp
+msgid "English (U.K.)"
+msgstr "Inglês"
+
+#: src/LanguageList.cpp
+#, fuzzy
+msgid "English (U.S.)"
+msgstr "Inglês"
+
+#: src/LanguageList.cpp
+msgid "Estonian"
+msgstr "Estoniano"
+
+#: src/LanguageList.cpp
+msgid "Finnish"
+msgstr "Finlandês"
+
+#: src/LanguageList.cpp
+msgid "French"
+msgstr "Francês"
+
+#: src/LanguageList.cpp
+msgid "Galician"
+msgstr "Galego"
+
+#: src/LanguageList.cpp
+msgid "German"
+msgstr "Alemão"
+
+#: src/LanguageList.cpp
+msgid "Greek"
+msgstr "Grego"
+
+#: src/LanguageList.cpp
+msgid "Hebrew"
+msgstr "Hebreu"
+
+#: src/LanguageList.cpp
+msgid "Hungarian"
+msgstr "Húngaro"
+
+#: src/LanguageList.cpp
+msgid "Italian"
+msgstr "Italiano"
+
+#: src/LanguageList.cpp
+msgid "Japanese"
+msgstr "Japonês"
+
+#: src/LanguageList.cpp
+msgid "Korean"
+msgstr "Coreano"
+
+#: src/LanguageList.cpp
+msgid "Latvian"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Lithuanian"
+msgstr "Lituano"
+
+#: src/LanguageList.cpp
+msgid "Norwegian (Nynorsk)"
+msgstr "Norueguês (Nynorsk)"
+
+#: src/LanguageList.cpp
+msgid "Polish"
+msgstr "Polaco"
+
+#: src/LanguageList.cpp
+msgid "Portuguese"
+msgstr "Português"
+
+#: src/LanguageList.cpp
+msgid "Portuguese (Brazilian)"
+msgstr "Português (Brasil)"
+
+#: src/LanguageList.cpp
+msgid "Romanian"
+msgstr "Romeno"
+
+#: src/LanguageList.cpp
+msgid "Russian"
+msgstr "Russo"
+
+#: src/LanguageList.cpp
+msgid "Slovenian"
+msgstr "Esloveno"
+
+#: src/LanguageList.cpp
+msgid "Spanish"
+msgstr "Espanhol"
+
+#: src/LanguageList.cpp
+msgid "Swedish"
+msgstr "Sueco"
+
+#: src/LanguageList.cpp
+msgid "Turkish"
+msgstr "Turco"
+
+#: src/LanguageList.cpp
+msgid "Ukrainian"
+msgstr "Ucraniano"
+
 #: src/libs/common/Format.cpp
 #, c-format
 msgid "Unknown error %d"
@@ -3201,15 +3394,18 @@ msgstr "A completar"
 msgid "Complete"
 msgstr "Completo"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Paused"
 msgstr "Em Pausa"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Erroneous"
 msgstr "Erróneo"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Waiting"
 msgstr "Em Espera"
 
@@ -3373,7 +3569,8 @@ msgstr "Fechar"
 msgid "Cut"
 msgstr "Cortar"
 
-#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp src/utils/aLinkCreator/src/alcframe.cpp
+#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy"
 msgstr "Copiar"
 
@@ -3381,7 +3578,8 @@ msgstr "Copiar"
 msgid "Paste"
 msgstr "Colar"
 
-#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
+#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Clear"
 msgstr "Limpar"
 
@@ -3389,7 +3587,8 @@ msgstr "Limpar"
 msgid "Select All"
 msgstr "Seleccionar tudo"
 
-#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp src/StatisticsDlg.cpp
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
+#: src/StatisticsDlg.cpp
 msgid "KiB/s"
 msgstr ""
 
@@ -5888,176 +6087,6 @@ msgid "ERROR: Failed to open partfile '%s'"
 msgstr "ERRO: Falhou ao abrir ficheiro de partes '%s'"
 
 #: src/Preferences.cpp
-msgid "System default"
-msgstr "Predefinição do sistema"
-
-#: src/Preferences.cpp
-msgid "Albanian"
-msgstr "Albanês"
-
-#: src/Preferences.cpp
-msgid "Arabic"
-msgstr "Árabe"
-
-#: src/Preferences.cpp
-msgid "Asturian"
-msgstr "Asturiano"
-
-#: src/Preferences.cpp
-msgid "Basque"
-msgstr "Basco"
-
-#: src/Preferences.cpp
-msgid "Bulgarian"
-msgstr "Búlgaro"
-
-#: src/Preferences.cpp
-msgid "Catalan"
-msgstr "Catalão"
-
-#: src/Preferences.cpp
-msgid "Chinese (Simplified)"
-msgstr "Chinês (Simplificado)"
-
-#: src/Preferences.cpp
-msgid "Chinese (Traditional)"
-msgstr "Chinês (Tradicional)"
-
-#: src/Preferences.cpp
-msgid "Croatian"
-msgstr "Croata"
-
-#: src/Preferences.cpp
-msgid "Czech"
-msgstr "Checo"
-
-#: src/Preferences.cpp
-msgid "Danish"
-msgstr "Dinamarquês"
-
-#: src/Preferences.cpp
-msgid "Dutch"
-msgstr "Holandês"
-
-#: src/Preferences.cpp
-msgid "English (U.K.)"
-msgstr "Inglês"
-
-#: src/Preferences.cpp
-#, fuzzy
-msgid "English (U.S.)"
-msgstr "Inglês"
-
-#: src/Preferences.cpp
-msgid "Estonian"
-msgstr "Estoniano"
-
-#: src/Preferences.cpp
-msgid "Finnish"
-msgstr "Finlandês"
-
-#: src/Preferences.cpp
-msgid "French"
-msgstr "Francês"
-
-#: src/Preferences.cpp
-msgid "Galician"
-msgstr "Galego"
-
-#: src/Preferences.cpp
-msgid "German"
-msgstr "Alemão"
-
-#: src/Preferences.cpp
-msgid "Greek"
-msgstr "Grego"
-
-#: src/Preferences.cpp
-msgid "Hebrew"
-msgstr "Hebreu"
-
-#: src/Preferences.cpp
-msgid "Hungarian"
-msgstr "Húngaro"
-
-#: src/Preferences.cpp
-msgid "Italian"
-msgstr "Italiano"
-
-#: src/Preferences.cpp
-msgid "Japanese"
-msgstr "Japonês"
-
-#: src/Preferences.cpp
-msgid "Korean"
-msgstr "Coreano"
-
-#: src/Preferences.cpp
-msgid "Latvian"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Lithuanian"
-msgstr "Lituano"
-
-#: src/Preferences.cpp
-msgid "Norwegian (Nynorsk)"
-msgstr "Norueguês (Nynorsk)"
-
-#: src/Preferences.cpp
-msgid "Polish"
-msgstr "Polaco"
-
-#: src/Preferences.cpp
-msgid "Portuguese"
-msgstr "Português"
-
-#: src/Preferences.cpp
-msgid "Portuguese (Brazilian)"
-msgstr "Português (Brasil)"
-
-#: src/Preferences.cpp
-msgid "Romanian"
-msgstr "Romeno"
-
-#: src/Preferences.cpp
-msgid "Russian"
-msgstr "Russo"
-
-#: src/Preferences.cpp
-msgid "Slovenian"
-msgstr "Esloveno"
-
-#: src/Preferences.cpp
-msgid "Spanish"
-msgstr "Espanhol"
-
-#: src/Preferences.cpp
-msgid "Swedish"
-msgstr "Sueco"
-
-#: src/Preferences.cpp
-msgid "Turkish"
-msgstr "Turco"
-
-#: src/Preferences.cpp
-msgid "Ukrainian"
-msgstr "Ucraniano"
-
-#: src/Preferences.cpp
-msgid "Change Language"
-msgstr "Alterar Idioma"
-
-#: src/Preferences.cpp
-msgid "There are no translations installed for aMule"
-msgstr ""
-
-#: src/Preferences.cpp
-#, fuzzy
-msgid "No languages available"
-msgstr "Indisponível"
-
-#: src/Preferences.cpp
 msgid "no options available"
 msgstr "sem opções disponíveis"
 
@@ -6570,7 +6599,8 @@ msgstr ""
 msgid "Confirm shared folders"
 msgstr "Pastas partilhadas"
 
-#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp src/SharedFilesReloadProgress.cpp
+#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp
+#: src/SharedFilesReloadProgress.cpp
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "Recarregar os seus ficheiros partilhados"
@@ -9304,6 +9334,13 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "Change Language"
+#~ msgstr "Alterar Idioma"
+
+#, fuzzy
+#~ msgid "No languages available"
+#~ msgstr "Indisponível"
 
 #~ msgid "User name"
 #~ msgstr "Nome de utilizador"

--- a/po/ro.po
+++ b/po/ro.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-05 12:01+0200\n"
+"POT-Creation-Date: 2026-09-06 14:35+0200\n"
 "PO-Revision-Date: 2026-09-05 10:59+0000\n"
 "Last-Translator: Angelescu Constantin <titus0818@yahoo.com>\n"
 "Language-Team: English <kde-i18n-doc@kde.org>\n"
@@ -387,7 +387,8 @@ msgstr "server web rulând pe pid %d"
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Ați solicitat să ruleze la pornire serverul web, dar fișierul binar amuleweb nu poate fi rulat. Instalați pachetul care conține serverul web aMule, sau compilați aMule utilizând --enable-webserver și apoi rulați make install"
 
-#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
+#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
+#: src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
 msgid "ERROR"
 msgstr "EROARE"
 
@@ -675,7 +676,8 @@ msgstr "Rețele"
 msgid "Searches"
 msgstr "Căutări"
 
-#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/Statistics.cpp
+#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/Statistics.cpp
 msgid "Downloads"
 msgstr "Descărcări"
 
@@ -759,7 +761,9 @@ msgstr "Kad: Închis"
 msgid "Core"
 msgstr ""
 
-#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp src/Statistics.cpp
+#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp src/Statistics.cpp
 msgid "Version"
 msgstr "Versiune"
 
@@ -1058,7 +1062,11 @@ msgstr "Nu se poate crea directorul '%s' pentru categoria '%s', se păstrează d
 msgid "The remote core sent inconsistent data for \"%s\" (part status %d, expected %d). The file list may be showing the wrong information; reconnect to clear it."
 msgstr ""
 
-#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp src/Statistics.cpp
+#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp
+#: src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp
+#: src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp
+#: src/Statistics.cpp
 msgid "Unknown"
 msgstr "Necunoscut"
 
@@ -1157,7 +1165,8 @@ msgstr "Eroare în timpul salvării fișierului %s : %s"
 msgid "Enter Captcha"
 msgstr "Introduceți Captcha"
 
-#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp src/TransferWnd.cpp
+#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp
+#: src/TransferWnd.cpp
 msgid "Category"
 msgstr "Categorie"
 
@@ -1327,11 +1336,13 @@ msgstr "Nu s-a găsit niciun fișier 'cryptkey.dat' , se creează."
 msgid "Client Details"
 msgstr "Detalii client"
 
-#: src/ClientDetailDialog.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
+#: src/utils/wxCas/src/onlinesig.cpp
 msgid "LowID"
 msgstr "LowID"
 
-#: src/ClientDetailDialog.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
+#: src/utils/wxCas/src/onlinesig.cpp
 msgid "HighID"
 msgstr "HighID"
 
@@ -1347,7 +1358,8 @@ msgstr "Susținut"
 msgid "Not supported"
 msgstr "Nu este susținut"
 
-#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp src/TextClient.cpp
+#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
+#: src/TextClient.cpp
 msgid "Connected"
 msgstr "Conectat"
 
@@ -1355,7 +1367,8 @@ msgstr "Conectat"
 msgid "Disconnected"
 msgstr "Deconectat"
 
-#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f KiB/s"
 msgstr ""
@@ -1372,7 +1385,8 @@ msgstr ""
 msgid "IP Address"
 msgstr "Adresă IP"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Origin"
 msgstr "Origine"
 
@@ -1390,11 +1404,13 @@ msgstr "Ultima recepție"
 msgid "Sessions"
 msgstr "Versiune"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/SharedFilePeersListCtrl.cpp
 msgid "Upload Speed"
 msgstr "Viteză încărcare"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/SharedFilePeersListCtrl.cpp
 msgid "Download Speed"
 msgstr "Viteză descărcare"
 
@@ -1450,11 +1466,13 @@ msgstr[2] ""
 msgid "Files"
 msgstr "Fișiere"
 
-#: src/ClientsListCtrl.cpp src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientsListCtrl.cpp src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp
 msgid "Uploaded"
 msgstr "Încărcat"
 
-#: src/ClientsListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientsListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Downloaded"
 msgstr "Descărcat"
 
@@ -1545,7 +1563,8 @@ msgstr "Comentarii fișier"
 msgid "Username"
 msgstr "Utilizator"
 
-#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp
+#: src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "File Name"
 msgstr "Denumire fișier"
 
@@ -1608,15 +1627,18 @@ msgstr "Automat [În]"
 msgid "Very low"
 msgstr "Foarte joasă"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Low"
 msgstr "Joasă"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Normal"
 msgstr "Normal"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "High"
 msgstr "Înaltă"
 
@@ -1640,11 +1662,13 @@ msgstr "Se conectează prin server"
 msgid "Queue Full"
 msgstr "Coadă plină"
 
-#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp src/muuli_wdr.cpp
+#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp
+#: src/muuli_wdr.cpp
 msgid "On Queue"
 msgstr "În coadă"
 
-#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
+#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp
+#: src/PartFile.cpp src/TransferWnd.cpp
 msgid "Downloading"
 msgstr "Se descarcă"
 
@@ -1704,7 +1728,8 @@ msgstr "Server local"
 msgid "Remote Server"
 msgstr "Server distant"
 
-#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp src/TextClient.cpp
+#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp
+#: src/TextClient.cpp
 msgid "Kad"
 msgstr "Kad"
 
@@ -1728,7 +1753,8 @@ msgstr "Semințe sursă"
 msgid "Search Result"
 msgstr "Rezultat căutare"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp
+#: src/TransferWnd.cpp
 msgid "Completed"
 msgstr "Terminat"
 
@@ -1781,7 +1807,8 @@ msgstr ""
 msgid "Part"
 msgstr "Parte"
 
-#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 msgid "Size"
 msgstr "Dimensiune"
 
@@ -1789,7 +1816,8 @@ msgstr "Dimensiune"
 msgid "Transferred"
 msgstr "Transferat"
 
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp src/SourceListCtrl.cpp
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
+#: src/SourceListCtrl.cpp
 msgid "Speed"
 msgstr "Viteză"
 
@@ -1797,11 +1825,13 @@ msgstr "Viteză"
 msgid "Progress"
 msgstr "Progres"
 
-#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
+#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp
+#: src/SearchListCtrl.cpp
 msgid "Sources"
 msgstr "Surse"
 
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 msgid "Priority"
 msgstr "Prioritate"
 
@@ -1825,7 +1855,9 @@ msgstr "Ultima recepție"
 msgid "Auto"
 msgstr "Automat"
 
-#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/TransferWnd.cpp src/utils/wxCas/src/wxcasprefs.cpp
+#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/TransferWnd.cpp
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Cancel"
 msgstr "Anulare"
 
@@ -1926,7 +1958,8 @@ msgstr "Introduceți noul nume pentru acest fișier:"
 msgid "File rename"
 msgstr "Redenumire fișier"
 
-#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f MiB/s"
 msgstr ""
@@ -2731,11 +2764,13 @@ msgstr ""
 msgid "Start aMule automatically when I log in"
 msgstr ""
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp packaging/windows/installer_strings.c
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: packaging/windows/installer_strings.c
 msgid "Register aMule for ed2k:// links"
 msgstr ""
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp packaging/windows/installer_strings.c
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: packaging/windows/installer_strings.c
 msgid "Register aMule for magnet: links"
 msgstr ""
 
@@ -2761,7 +2796,8 @@ msgstr ""
 msgid "Destination folder for downloads"
 msgstr "Dosar destinație pentru descărcări"
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Browse"
 msgstr "Navigare"
 
@@ -3187,6 +3223,163 @@ msgstr "A eșuat încărcarea intrării în lista de fișiere cunoscute, fișier
 msgid "Invalid entry in known file list, file may be corrupt: "
 msgstr "Intrare nevalidă în lista de fișiere cunoscute, fișierul poate fi corupt:"
 
+#: src/LanguageList.cpp
+msgid "System default"
+msgstr "Valoare implicită a sistemului"
+
+#: src/LanguageList.cpp
+msgid "Albanian"
+msgstr "Albaneză"
+
+#: src/LanguageList.cpp
+msgid "Arabic"
+msgstr "Arabă"
+
+#: src/LanguageList.cpp
+msgid "Asturian"
+msgstr "Asturian"
+
+#: src/LanguageList.cpp
+msgid "Basque"
+msgstr "Bască"
+
+#: src/LanguageList.cpp
+msgid "Bulgarian"
+msgstr "Bulgară"
+
+#: src/LanguageList.cpp
+msgid "Catalan"
+msgstr "Catalană"
+
+#: src/LanguageList.cpp
+msgid "Chinese (Simplified)"
+msgstr "Chineză (Simplificat)"
+
+#: src/LanguageList.cpp
+msgid "Chinese (Traditional)"
+msgstr "Chinez (tradițional)"
+
+#: src/LanguageList.cpp
+msgid "Croatian"
+msgstr "Croată"
+
+#: src/LanguageList.cpp
+msgid "Czech"
+msgstr "Cehă"
+
+#: src/LanguageList.cpp
+msgid "Danish"
+msgstr "Daneză"
+
+#: src/LanguageList.cpp
+msgid "Dutch"
+msgstr "Olandeză"
+
+#: src/LanguageList.cpp
+msgid "English (U.K.)"
+msgstr "Englez (U.K.)"
+
+#: src/LanguageList.cpp
+#, fuzzy
+msgid "English (U.S.)"
+msgstr "Englez (U.K.)"
+
+#: src/LanguageList.cpp
+msgid "Estonian"
+msgstr "Estonă"
+
+#: src/LanguageList.cpp
+msgid "Finnish"
+msgstr "Finlandeză"
+
+#: src/LanguageList.cpp
+msgid "French"
+msgstr "Franceză"
+
+#: src/LanguageList.cpp
+msgid "Galician"
+msgstr "Galiciană"
+
+#: src/LanguageList.cpp
+msgid "German"
+msgstr "Germană"
+
+#: src/LanguageList.cpp
+msgid "Greek"
+msgstr "Grecesc"
+
+#: src/LanguageList.cpp
+msgid "Hebrew"
+msgstr "Ebraică"
+
+#: src/LanguageList.cpp
+msgid "Hungarian"
+msgstr "Maghiară"
+
+#: src/LanguageList.cpp
+msgid "Italian"
+msgstr "Italiană"
+
+#: src/LanguageList.cpp
+msgid "Japanese"
+msgstr "Japoneză"
+
+#: src/LanguageList.cpp
+msgid "Korean"
+msgstr "Koreană"
+
+#: src/LanguageList.cpp
+msgid "Latvian"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Lithuanian"
+msgstr "Lituaniană"
+
+#: src/LanguageList.cpp
+msgid "Norwegian (Nynorsk)"
+msgstr "Norvegian"
+
+#: src/LanguageList.cpp
+msgid "Polish"
+msgstr "Poloneză"
+
+#: src/LanguageList.cpp
+msgid "Portuguese"
+msgstr "Portugheză"
+
+#: src/LanguageList.cpp
+msgid "Portuguese (Brazilian)"
+msgstr "Portugheză (Brazilia)"
+
+#: src/LanguageList.cpp
+msgid "Romanian"
+msgstr "Română"
+
+#: src/LanguageList.cpp
+msgid "Russian"
+msgstr "Rusă"
+
+#: src/LanguageList.cpp
+msgid "Slovenian"
+msgstr "Slovenă"
+
+#: src/LanguageList.cpp
+msgid "Spanish"
+msgstr "Spaniolă"
+
+#: src/LanguageList.cpp
+msgid "Swedish"
+msgstr "Suedeză"
+
+#: src/LanguageList.cpp
+msgid "Turkish"
+msgstr "Turcă"
+
+#: src/LanguageList.cpp
+msgid "Ukrainian"
+msgstr "Ucraineană"
+
 #: src/libs/common/Format.cpp
 #, c-format
 msgid "Unknown error %d"
@@ -3209,15 +3402,18 @@ msgstr "Finalizat"
 msgid "Complete"
 msgstr "Terminat"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Paused"
 msgstr "Întrerupt"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Erroneous"
 msgstr "Eronat"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Waiting"
 msgstr "Se așteaptă"
 
@@ -3385,7 +3581,8 @@ msgstr "Închide"
 msgid "Cut"
 msgstr "Taie"
 
-#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp src/utils/aLinkCreator/src/alcframe.cpp
+#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy"
 msgstr "Copiază"
 
@@ -3393,7 +3590,8 @@ msgstr "Copiază"
 msgid "Paste"
 msgstr "Lipește"
 
-#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
+#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Clear"
 msgstr "Curăță"
 
@@ -3401,7 +3599,8 @@ msgstr "Curăță"
 msgid "Select All"
 msgstr "Selectează tot"
 
-#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp src/StatisticsDlg.cpp
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
+#: src/StatisticsDlg.cpp
 msgid "KiB/s"
 msgstr ""
 
@@ -5902,175 +6101,6 @@ msgid "ERROR: Failed to open partfile '%s'"
 msgstr "EROARE: A eșuat deschiderea fișierului parțial '%s'"
 
 #: src/Preferences.cpp
-msgid "System default"
-msgstr "Valoare implicită a sistemului"
-
-#: src/Preferences.cpp
-msgid "Albanian"
-msgstr "Albaneză"
-
-#: src/Preferences.cpp
-msgid "Arabic"
-msgstr "Arabă"
-
-#: src/Preferences.cpp
-msgid "Asturian"
-msgstr "Asturian"
-
-#: src/Preferences.cpp
-msgid "Basque"
-msgstr "Bască"
-
-#: src/Preferences.cpp
-msgid "Bulgarian"
-msgstr "Bulgară"
-
-#: src/Preferences.cpp
-msgid "Catalan"
-msgstr "Catalană"
-
-#: src/Preferences.cpp
-msgid "Chinese (Simplified)"
-msgstr "Chineză (Simplificat)"
-
-#: src/Preferences.cpp
-msgid "Chinese (Traditional)"
-msgstr "Chinez (tradițional)"
-
-#: src/Preferences.cpp
-msgid "Croatian"
-msgstr "Croată"
-
-#: src/Preferences.cpp
-msgid "Czech"
-msgstr "Cehă"
-
-#: src/Preferences.cpp
-msgid "Danish"
-msgstr "Daneză"
-
-#: src/Preferences.cpp
-msgid "Dutch"
-msgstr "Olandeză"
-
-#: src/Preferences.cpp
-msgid "English (U.K.)"
-msgstr "Englez (U.K.)"
-
-#: src/Preferences.cpp
-#, fuzzy
-msgid "English (U.S.)"
-msgstr "Englez (U.K.)"
-
-#: src/Preferences.cpp
-msgid "Estonian"
-msgstr "Estonă"
-
-#: src/Preferences.cpp
-msgid "Finnish"
-msgstr "Finlandeză"
-
-#: src/Preferences.cpp
-msgid "French"
-msgstr "Franceză"
-
-#: src/Preferences.cpp
-msgid "Galician"
-msgstr "Galiciană"
-
-#: src/Preferences.cpp
-msgid "German"
-msgstr "Germană"
-
-#: src/Preferences.cpp
-msgid "Greek"
-msgstr "Grecesc"
-
-#: src/Preferences.cpp
-msgid "Hebrew"
-msgstr "Ebraică"
-
-#: src/Preferences.cpp
-msgid "Hungarian"
-msgstr "Maghiară"
-
-#: src/Preferences.cpp
-msgid "Italian"
-msgstr "Italiană"
-
-#: src/Preferences.cpp
-msgid "Japanese"
-msgstr "Japoneză"
-
-#: src/Preferences.cpp
-msgid "Korean"
-msgstr "Koreană"
-
-#: src/Preferences.cpp
-msgid "Latvian"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Lithuanian"
-msgstr "Lituaniană"
-
-#: src/Preferences.cpp
-msgid "Norwegian (Nynorsk)"
-msgstr "Norvegian"
-
-#: src/Preferences.cpp
-msgid "Polish"
-msgstr "Poloneză"
-
-#: src/Preferences.cpp
-msgid "Portuguese"
-msgstr "Portugheză"
-
-#: src/Preferences.cpp
-msgid "Portuguese (Brazilian)"
-msgstr "Portugheză (Brazilia)"
-
-#: src/Preferences.cpp
-msgid "Romanian"
-msgstr "Română"
-
-#: src/Preferences.cpp
-msgid "Russian"
-msgstr "Rusă"
-
-#: src/Preferences.cpp
-msgid "Slovenian"
-msgstr "Slovenă"
-
-#: src/Preferences.cpp
-msgid "Spanish"
-msgstr "Spaniolă"
-
-#: src/Preferences.cpp
-msgid "Swedish"
-msgstr "Suedeză"
-
-#: src/Preferences.cpp
-msgid "Turkish"
-msgstr "Turcă"
-
-#: src/Preferences.cpp
-msgid "Ukrainian"
-msgstr "Ucraineană"
-
-#: src/Preferences.cpp
-msgid "Change Language"
-msgstr "Schimbă limba"
-
-#: src/Preferences.cpp
-msgid "There are no translations installed for aMule"
-msgstr "Nu sunt instalate traduceri pentru aMule"
-
-#: src/Preferences.cpp
-msgid "No languages available"
-msgstr "Nu sunt limbi disponibile"
-
-#: src/Preferences.cpp
 msgid "no options available"
 msgstr "Nu sunt opțiuni disponibile"
 
@@ -6587,7 +6617,8 @@ msgstr ""
 msgid "Confirm shared folders"
 msgstr "Dosare partajate"
 
-#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp src/SharedFilesReloadProgress.cpp
+#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp
+#: src/SharedFilesReloadProgress.cpp
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "Reîncărcați fișierele partajate"
@@ -9340,6 +9371,15 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "Change Language"
+#~ msgstr "Schimbă limba"
+
+#~ msgid "There are no translations installed for aMule"
+#~ msgstr "Nu sunt instalate traduceri pentru aMule"
+
+#~ msgid "No languages available"
+#~ msgstr "Nu sunt limbi disponibile"
 
 #~ msgid "User name"
 #~ msgstr "Nume utilizator"

--- a/po/ru.po
+++ b/po/ru.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-05 12:01+0200\n"
+"POT-Creation-Date: 2026-09-06 14:35+0200\n"
 "PO-Revision-Date: 2026-09-05 11:00+0000\n"
 "Last-Translator: Radist Morse <radist.morse@gmail.com>\n"
 "Language-Team: Russian <kde-russian@lists.kde.ru>\n"
@@ -393,7 +393,8 @@ msgstr "веб-сервер работает с pid %d"
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Вы запросили запуск веб-сервера при старте, но исполняемый файл amuleweb не может быть запущен. Установите пакет, содержащий веб-сервер aMule, либо соберите aMule из исходного кода с параметром -DBUILD_WEBSERVER=YES и установите его."
 
-#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
+#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
+#: src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
 msgid "ERROR"
 msgstr "ОШИБКА"
 
@@ -683,7 +684,8 @@ msgstr "Сети"
 msgid "Searches"
 msgstr "Поиск"
 
-#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/Statistics.cpp
+#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/Statistics.cpp
 msgid "Downloads"
 msgstr "Загрузки"
 
@@ -771,7 +773,9 @@ msgstr "Kad: отключён"
 msgid "Core"
 msgstr "Ядро"
 
-#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp src/Statistics.cpp
+#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp src/Statistics.cpp
 msgid "Version"
 msgstr "Версия"
 
@@ -1068,7 +1072,11 @@ msgstr "Не удается создать директорию '%s' для ка
 msgid "The remote core sent inconsistent data for \"%s\" (part status %d, expected %d). The file list may be showing the wrong information; reconnect to clear it."
 msgstr "Удалённое ядро отправило противоречивые данные для «%s» (состояние части %d, ожидалось %d). Список файлов может отображать неверную информацию; переподключитесь для очистки."
 
-#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp src/Statistics.cpp
+#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp
+#: src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp
+#: src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp
+#: src/Statistics.cpp
 msgid "Unknown"
 msgstr "Неизвестно"
 
@@ -1167,7 +1175,8 @@ msgstr "Ошибка при сохранении файла %s: %s"
 msgid "Enter Captcha"
 msgstr "Введите код"
 
-#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp src/TransferWnd.cpp
+#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp
+#: src/TransferWnd.cpp
 msgid "Category"
 msgstr "Категория"
 
@@ -1336,11 +1345,13 @@ msgstr "Файл 'cryptkey.dat' не найден. Создаю заново."
 msgid "Client Details"
 msgstr "Сведения о клиенте"
 
-#: src/ClientDetailDialog.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
+#: src/utils/wxCas/src/onlinesig.cpp
 msgid "LowID"
 msgstr "Низкий ИД"
 
-#: src/ClientDetailDialog.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
+#: src/utils/wxCas/src/onlinesig.cpp
 msgid "HighID"
 msgstr "Высокий ИД"
 
@@ -1356,7 +1367,8 @@ msgstr "Поддерживается"
 msgid "Not supported"
 msgstr "Не поддерживается"
 
-#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp src/TextClient.cpp
+#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
+#: src/TextClient.cpp
 msgid "Connected"
 msgstr "Подключён"
 
@@ -1364,7 +1376,8 @@ msgstr "Подключён"
 msgid "Disconnected"
 msgstr "Отключён"
 
-#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f KiB/s"
 msgstr "%.1f КиБ/с"
@@ -1383,7 +1396,8 @@ msgstr "IP-адрес"
 
 # Source of a source. I mean, it's where a client came from.
 # (GonoszTopi)
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Origin"
 msgstr "Источник"
 
@@ -1399,11 +1413,13 @@ msgstr "Последнее появление"
 msgid "Sessions"
 msgstr "Сеансы"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/SharedFilePeersListCtrl.cpp
 msgid "Upload Speed"
 msgstr "Скорость отдачи"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/SharedFilePeersListCtrl.cpp
 msgid "Download Speed"
 msgstr "Скорость загрузки"
 
@@ -1455,11 +1471,13 @@ msgstr[2] "Не удалось запросить список общих фай
 msgid "Files"
 msgstr "Файлы"
 
-#: src/ClientsListCtrl.cpp src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientsListCtrl.cpp src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp
 msgid "Uploaded"
 msgstr "Отдано"
 
-#: src/ClientsListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientsListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Downloaded"
 msgstr "Загружено"
 
@@ -1547,7 +1565,8 @@ msgstr "Комментарии файла"
 msgid "Username"
 msgstr "Имя пользователя"
 
-#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp
+#: src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "File Name"
 msgstr "Имя файла"
 
@@ -1610,15 +1629,18 @@ msgstr "Авто [высокий]"
 msgid "Very low"
 msgstr "Очень низкий"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Low"
 msgstr "Низкий"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Normal"
 msgstr "Обычный"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "High"
 msgstr "Высокий"
 
@@ -1642,11 +1664,13 @@ msgstr "Соединение через сервер"
 msgid "Queue Full"
 msgstr "Очередь заполнена"
 
-#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp src/muuli_wdr.cpp
+#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp
+#: src/muuli_wdr.cpp
 msgid "On Queue"
 msgstr "В очереди"
 
-#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
+#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp
+#: src/PartFile.cpp src/TransferWnd.cpp
 msgid "Downloading"
 msgstr "Загружается"
 
@@ -1706,7 +1730,8 @@ msgstr "Локальный сервер"
 msgid "Remote Server"
 msgstr "Удалённый сервер"
 
-#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp src/TextClient.cpp
+#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp
+#: src/TextClient.cpp
 msgid "Kad"
 msgstr "Kad"
 
@@ -1730,7 +1755,8 @@ msgstr "Источники сидов"
 msgid "Search Result"
 msgstr "Результаты поиска"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp
+#: src/TransferWnd.cpp
 msgid "Completed"
 msgstr "Завершено"
 
@@ -1783,7 +1809,8 @@ msgstr "Нельзя изменять внутри рекурсивной пуб
 msgid "Part"
 msgstr "Часть"
 
-#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 msgid "Size"
 msgstr "Размер"
 
@@ -1791,7 +1818,8 @@ msgstr "Размер"
 msgid "Transferred"
 msgstr "Передано"
 
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp src/SourceListCtrl.cpp
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
+#: src/SourceListCtrl.cpp
 msgid "Speed"
 msgstr "Скорость"
 
@@ -1799,11 +1827,13 @@ msgstr "Скорость"
 msgid "Progress"
 msgstr "Выполнено"
 
-#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
+#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp
+#: src/SearchListCtrl.cpp
 msgid "Sources"
 msgstr "Источники"
 
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 msgid "Priority"
 msgstr "Приоритет"
 
@@ -1827,7 +1857,9 @@ msgstr "Последний приём"
 msgid "Auto"
 msgstr "Авто"
 
-#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/TransferWnd.cpp src/utils/wxCas/src/wxcasprefs.cpp
+#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/TransferWnd.cpp
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Cancel"
 msgstr "Отмена"
 
@@ -1928,7 +1960,8 @@ msgstr "Введите новое имя файла:"
 msgid "File rename"
 msgstr "Переименовать файл"
 
-#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f MiB/s"
 msgstr "%.1f МиБ/с"
@@ -2734,11 +2767,13 @@ msgstr ""
 msgid "Start aMule automatically when I log in"
 msgstr "Запускать aMule автоматически при моём входе в систему"
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp packaging/windows/installer_strings.c
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: packaging/windows/installer_strings.c
 msgid "Register aMule for ed2k:// links"
 msgstr "Зарегистрировать aMule для ссылок ed2k://"
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp packaging/windows/installer_strings.c
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: packaging/windows/installer_strings.c
 msgid "Register aMule for magnet: links"
 msgstr "Зарегистрировать aMule для магнит-ссылок"
 
@@ -2766,7 +2801,8 @@ msgstr ""
 msgid "Destination folder for downloads"
 msgstr "Папка для загружаемых файлов"
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Browse"
 msgstr "Открыть"
 
@@ -3194,6 +3230,162 @@ msgstr "Ошибка подгрузки элемента списка извес
 msgid "Invalid entry in known file list, file may be corrupt: "
 msgstr "Неверный элемент списка известных файлов, файл возможно повреждён: "
 
+#: src/LanguageList.cpp
+msgid "System default"
+msgstr "Системный"
+
+#: src/LanguageList.cpp
+msgid "Albanian"
+msgstr "Албанский"
+
+#: src/LanguageList.cpp
+msgid "Arabic"
+msgstr "Арабский"
+
+#: src/LanguageList.cpp
+msgid "Asturian"
+msgstr "Астурианский"
+
+#: src/LanguageList.cpp
+msgid "Basque"
+msgstr "Баскский"
+
+#: src/LanguageList.cpp
+msgid "Bulgarian"
+msgstr "Болгарский"
+
+#: src/LanguageList.cpp
+msgid "Catalan"
+msgstr "Каталонский"
+
+#: src/LanguageList.cpp
+msgid "Chinese (Simplified)"
+msgstr "Китайский (упрощенный)"
+
+#: src/LanguageList.cpp
+msgid "Chinese (Traditional)"
+msgstr "Китайский (традиционный)"
+
+#: src/LanguageList.cpp
+msgid "Croatian"
+msgstr "Хорватский"
+
+#: src/LanguageList.cpp
+msgid "Czech"
+msgstr "Чешский"
+
+#: src/LanguageList.cpp
+msgid "Danish"
+msgstr "Датский"
+
+#: src/LanguageList.cpp
+msgid "Dutch"
+msgstr "Голландский"
+
+#: src/LanguageList.cpp
+msgid "English (U.K.)"
+msgstr "Английский (Великобритания)"
+
+#: src/LanguageList.cpp
+msgid "English (U.S.)"
+msgstr "Английский (США)"
+
+#: src/LanguageList.cpp
+msgid "Estonian"
+msgstr "Эстонский"
+
+#: src/LanguageList.cpp
+msgid "Finnish"
+msgstr "Финский"
+
+#: src/LanguageList.cpp
+msgid "French"
+msgstr "Французский"
+
+#: src/LanguageList.cpp
+msgid "Galician"
+msgstr "Гальский"
+
+#: src/LanguageList.cpp
+msgid "German"
+msgstr "Немецкий"
+
+#: src/LanguageList.cpp
+msgid "Greek"
+msgstr "Греческий"
+
+#: src/LanguageList.cpp
+msgid "Hebrew"
+msgstr "Израильский"
+
+#: src/LanguageList.cpp
+msgid "Hungarian"
+msgstr "Венгерский"
+
+#: src/LanguageList.cpp
+msgid "Italian"
+msgstr "Итальянский"
+
+#: src/LanguageList.cpp
+msgid "Japanese"
+msgstr "Японский"
+
+#: src/LanguageList.cpp
+msgid "Korean"
+msgstr "Корейский"
+
+#: src/LanguageList.cpp
+msgid "Latvian"
+msgstr "Латышский"
+
+#: src/LanguageList.cpp
+msgid "Lithuanian"
+msgstr "Литовский"
+
+#: src/LanguageList.cpp
+msgid "Norwegian (Nynorsk)"
+msgstr "Норвежский (Нюнорск)"
+
+#: src/LanguageList.cpp
+msgid "Polish"
+msgstr "Польский"
+
+#: src/LanguageList.cpp
+msgid "Portuguese"
+msgstr "Португальский"
+
+#: src/LanguageList.cpp
+msgid "Portuguese (Brazilian)"
+msgstr "Португальский (Бразилия)"
+
+#: src/LanguageList.cpp
+msgid "Romanian"
+msgstr "Румынский"
+
+#: src/LanguageList.cpp
+msgid "Russian"
+msgstr "Русский"
+
+#: src/LanguageList.cpp
+msgid "Slovenian"
+msgstr "Словакский"
+
+#: src/LanguageList.cpp
+msgid "Spanish"
+msgstr "Испанский"
+
+#: src/LanguageList.cpp
+msgid "Swedish"
+msgstr "Шведский"
+
+#: src/LanguageList.cpp
+msgid "Turkish"
+msgstr "Турецкий"
+
+#: src/LanguageList.cpp
+msgid "Ukrainian"
+msgstr "Украинский"
+
 #: src/libs/common/Format.cpp
 #, c-format
 msgid "Unknown error %d"
@@ -3216,15 +3408,18 @@ msgstr "Завершается"
 msgid "Complete"
 msgstr "Завершено"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Paused"
 msgstr "Приостановлен"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Erroneous"
 msgstr "Ошибочный"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Waiting"
 msgstr "Ожидает"
 
@@ -3390,7 +3585,8 @@ msgstr "Закрыть"
 msgid "Cut"
 msgstr "Вырезать"
 
-#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp src/utils/aLinkCreator/src/alcframe.cpp
+#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy"
 msgstr "Копировать"
 
@@ -3398,7 +3594,8 @@ msgstr "Копировать"
 msgid "Paste"
 msgstr "Вставить"
 
-#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
+#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Clear"
 msgstr "Очистить"
 
@@ -3406,7 +3603,8 @@ msgstr "Очистить"
 msgid "Select All"
 msgstr "Выделить все"
 
-#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp src/StatisticsDlg.cpp
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
+#: src/StatisticsDlg.cpp
 msgid "KiB/s"
 msgstr "КиБ/с"
 
@@ -5887,174 +6085,6 @@ msgid "ERROR: Failed to open partfile '%s'"
 msgstr "ОШИБКА: не удалось открыть частично закаченный '%s'"
 
 #: src/Preferences.cpp
-msgid "System default"
-msgstr "Системный"
-
-#: src/Preferences.cpp
-msgid "Albanian"
-msgstr "Албанский"
-
-#: src/Preferences.cpp
-msgid "Arabic"
-msgstr "Арабский"
-
-#: src/Preferences.cpp
-msgid "Asturian"
-msgstr "Астурианский"
-
-#: src/Preferences.cpp
-msgid "Basque"
-msgstr "Баскский"
-
-#: src/Preferences.cpp
-msgid "Bulgarian"
-msgstr "Болгарский"
-
-#: src/Preferences.cpp
-msgid "Catalan"
-msgstr "Каталонский"
-
-#: src/Preferences.cpp
-msgid "Chinese (Simplified)"
-msgstr "Китайский (упрощенный)"
-
-#: src/Preferences.cpp
-msgid "Chinese (Traditional)"
-msgstr "Китайский (традиционный)"
-
-#: src/Preferences.cpp
-msgid "Croatian"
-msgstr "Хорватский"
-
-#: src/Preferences.cpp
-msgid "Czech"
-msgstr "Чешский"
-
-#: src/Preferences.cpp
-msgid "Danish"
-msgstr "Датский"
-
-#: src/Preferences.cpp
-msgid "Dutch"
-msgstr "Голландский"
-
-#: src/Preferences.cpp
-msgid "English (U.K.)"
-msgstr "Английский (Великобритания)"
-
-#: src/Preferences.cpp
-msgid "English (U.S.)"
-msgstr "Английский (США)"
-
-#: src/Preferences.cpp
-msgid "Estonian"
-msgstr "Эстонский"
-
-#: src/Preferences.cpp
-msgid "Finnish"
-msgstr "Финский"
-
-#: src/Preferences.cpp
-msgid "French"
-msgstr "Французский"
-
-#: src/Preferences.cpp
-msgid "Galician"
-msgstr "Гальский"
-
-#: src/Preferences.cpp
-msgid "German"
-msgstr "Немецкий"
-
-#: src/Preferences.cpp
-msgid "Greek"
-msgstr "Греческий"
-
-#: src/Preferences.cpp
-msgid "Hebrew"
-msgstr "Израильский"
-
-#: src/Preferences.cpp
-msgid "Hungarian"
-msgstr "Венгерский"
-
-#: src/Preferences.cpp
-msgid "Italian"
-msgstr "Итальянский"
-
-#: src/Preferences.cpp
-msgid "Japanese"
-msgstr "Японский"
-
-#: src/Preferences.cpp
-msgid "Korean"
-msgstr "Корейский"
-
-#: src/Preferences.cpp
-msgid "Latvian"
-msgstr "Латышский"
-
-#: src/Preferences.cpp
-msgid "Lithuanian"
-msgstr "Литовский"
-
-#: src/Preferences.cpp
-msgid "Norwegian (Nynorsk)"
-msgstr "Норвежский (Нюнорск)"
-
-#: src/Preferences.cpp
-msgid "Polish"
-msgstr "Польский"
-
-#: src/Preferences.cpp
-msgid "Portuguese"
-msgstr "Португальский"
-
-#: src/Preferences.cpp
-msgid "Portuguese (Brazilian)"
-msgstr "Португальский (Бразилия)"
-
-#: src/Preferences.cpp
-msgid "Romanian"
-msgstr "Румынский"
-
-#: src/Preferences.cpp
-msgid "Russian"
-msgstr "Русский"
-
-#: src/Preferences.cpp
-msgid "Slovenian"
-msgstr "Словакский"
-
-#: src/Preferences.cpp
-msgid "Spanish"
-msgstr "Испанский"
-
-#: src/Preferences.cpp
-msgid "Swedish"
-msgstr "Шведский"
-
-#: src/Preferences.cpp
-msgid "Turkish"
-msgstr "Турецкий"
-
-#: src/Preferences.cpp
-msgid "Ukrainian"
-msgstr "Украинский"
-
-#: src/Preferences.cpp
-msgid "Change Language"
-msgstr "Сменить язык"
-
-#: src/Preferences.cpp
-msgid "There are no translations installed for aMule"
-msgstr "Для aMule не установлено ни одного перевода"
-
-#: src/Preferences.cpp
-msgid "No languages available"
-msgstr "Нет доступных языков"
-
-#: src/Preferences.cpp
 msgid "no options available"
 msgstr "нет доступных опций"
 
@@ -6563,7 +6593,8 @@ msgstr "Рекурсивный общий доступ к ним опублик�
 msgid "Confirm shared folders"
 msgstr "Подтверждение общих папок"
 
-#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp src/SharedFilesReloadProgress.cpp
+#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp
+#: src/SharedFilesReloadProgress.cpp
 msgid "Reloading shared files..."
 msgstr "Переподгрузка общих файлов…"
 
@@ -9320,6 +9351,15 @@ msgstr "Похоже, что aMule запущен. Закройте его и п
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "Удаление пользовательских данных в $APPDATA\\aMule…"
+
+#~ msgid "Change Language"
+#~ msgstr "Сменить язык"
+
+#~ msgid "There are no translations installed for aMule"
+#~ msgstr "Для aMule не установлено ни одного перевода"
+
+#~ msgid "No languages available"
+#~ msgstr "Нет доступных языков"
 
 #~ msgid "User name"
 #~ msgstr "Имя пользователя"

--- a/po/sl.po
+++ b/po/sl.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-05 12:01+0200\n"
+"POT-Creation-Date: 2026-09-06 14:35+0200\n"
 "PO-Revision-Date: 2026-09-05 11:00+0000\n"
 "Last-Translator: Jure Repinc <jlp@holodeck1.com>\n"
 "Language-Team: Slovenian\n"
@@ -390,7 +390,8 @@ msgstr "spletni strežnik teče s PID %d"
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Zahtevali ste zagon spletnega strežnika ob zagonu programa, a programa amuleweb ni moč zagnati. Namestite paket, ki vsebuje spletni strežnik aMule, ali pa prevedite aMule z možnostjo »--enable-webserver« in ga znova namestite z »make install«."
 
-#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
+#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
+#: src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
 msgid "ERROR"
 msgstr "NAPAKA"
 
@@ -681,7 +682,8 @@ msgstr "Omrežja"
 msgid "Searches"
 msgstr "Iskanja"
 
-#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/Statistics.cpp
+#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/Statistics.cpp
 msgid "Downloads"
 msgstr "Prejemanja"
 
@@ -765,7 +767,9 @@ msgstr "Kad: izklopljen"
 msgid "Core"
 msgstr ""
 
-#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp src/Statistics.cpp
+#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp src/Statistics.cpp
 msgid "Version"
 msgstr "Različica"
 
@@ -1064,7 +1068,11 @@ msgstr "Ni moč ustvariti mape »%s« za kategorijo »%s«, obdržana bo mapa »
 msgid "The remote core sent inconsistent data for \"%s\" (part status %d, expected %d). The file list may be showing the wrong information; reconnect to clear it."
 msgstr ""
 
-#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp src/Statistics.cpp
+#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp
+#: src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp
+#: src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp
+#: src/Statistics.cpp
 msgid "Unknown"
 msgstr "Neznano"
 
@@ -1165,7 +1173,8 @@ msgstr "Napaka med shranjevanjem datoteke %s: %s"
 msgid "Enter Captcha"
 msgstr "Vnesite besedilo s slike"
 
-#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp src/TransferWnd.cpp
+#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp
+#: src/TransferWnd.cpp
 msgid "Category"
 msgstr "Kategorija"
 
@@ -1341,11 +1350,13 @@ msgstr "Datoteka »cryptkey.dat« ne obstaja. Ustvarjanje."
 msgid "Client Details"
 msgstr "Podrobnosti o odjemalcu"
 
-#: src/ClientDetailDialog.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
+#: src/utils/wxCas/src/onlinesig.cpp
 msgid "LowID"
 msgstr "Nizek ID"
 
-#: src/ClientDetailDialog.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
+#: src/utils/wxCas/src/onlinesig.cpp
 msgid "HighID"
 msgstr "Visok ID"
 
@@ -1361,7 +1372,8 @@ msgstr "Podprto"
 msgid "Not supported"
 msgstr "Ni podprto"
 
-#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp src/TextClient.cpp
+#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
+#: src/TextClient.cpp
 msgid "Connected"
 msgstr "Povezano"
 
@@ -1369,7 +1381,8 @@ msgstr "Povezano"
 msgid "Disconnected"
 msgstr "Ni povezave"
 
-#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f KiB/s"
 msgstr ""
@@ -1386,7 +1399,8 @@ msgstr ""
 msgid "IP Address"
 msgstr "Naslov IP"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Origin"
 msgstr "Izvor"
 
@@ -1404,11 +1418,13 @@ msgstr "Zadnji sprejem"
 msgid "Sessions"
 msgstr "Različica"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/SharedFilePeersListCtrl.cpp
 msgid "Upload Speed"
 msgstr "Hitrost pošiljanja"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/SharedFilePeersListCtrl.cpp
 msgid "Download Speed"
 msgstr "Hitrost prejemanja"
 
@@ -1465,11 +1481,13 @@ msgstr[3] ""
 msgid "Files"
 msgstr "Datoteke"
 
-#: src/ClientsListCtrl.cpp src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientsListCtrl.cpp src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp
 msgid "Uploaded"
 msgstr "Poslano"
 
-#: src/ClientsListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientsListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Downloaded"
 msgstr "Prejeto"
 
@@ -1560,7 +1578,8 @@ msgstr "Komentarji o datoteki"
 msgid "Username"
 msgstr "Uporabniško ime"
 
-#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp
+#: src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "File Name"
 msgstr "Ime datoteke"
 
@@ -1624,15 +1643,18 @@ msgstr "Samod. [Vi]"
 msgid "Very low"
 msgstr "Zelo nizka"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Low"
 msgstr "Nizka"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Normal"
 msgstr "Običajna"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "High"
 msgstr "Visoka"
 
@@ -1656,11 +1678,13 @@ msgstr "Povezovanje preko strežnika"
 msgid "Queue Full"
 msgstr "Vrsta polna"
 
-#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp src/muuli_wdr.cpp
+#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp
+#: src/muuli_wdr.cpp
 msgid "On Queue"
 msgstr "V vrsti"
 
-#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
+#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp
+#: src/PartFile.cpp src/TransferWnd.cpp
 msgid "Downloading"
 msgstr "Prejemanje"
 
@@ -1720,7 +1744,8 @@ msgstr "Krajevni strežnik"
 msgid "Remote Server"
 msgstr "Oddaljni strežnik"
 
-#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp src/TextClient.cpp
+#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp
+#: src/TextClient.cpp
 msgid "Kad"
 msgstr "Kad"
 
@@ -1744,7 +1769,8 @@ msgstr "Izvorna semena"
 msgid "Search Result"
 msgstr "Rezultat iskanja"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp
+#: src/TransferWnd.cpp
 msgid "Completed"
 msgstr "Zaključeno"
 
@@ -1797,7 +1823,8 @@ msgstr ""
 msgid "Part"
 msgstr "Del"
 
-#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 msgid "Size"
 msgstr "Velikost"
 
@@ -1805,7 +1832,8 @@ msgstr "Velikost"
 msgid "Transferred"
 msgstr "Preneseno"
 
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp src/SourceListCtrl.cpp
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
+#: src/SourceListCtrl.cpp
 msgid "Speed"
 msgstr "Hitrost"
 
@@ -1813,11 +1841,13 @@ msgstr "Hitrost"
 msgid "Progress"
 msgstr "Napredek"
 
-#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
+#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp
+#: src/SearchListCtrl.cpp
 msgid "Sources"
 msgstr "Viri"
 
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 msgid "Priority"
 msgstr "Prednost"
 
@@ -1841,7 +1871,9 @@ msgstr "Zadnji sprejem"
 msgid "Auto"
 msgstr "Samod."
 
-#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/TransferWnd.cpp src/utils/wxCas/src/wxcasprefs.cpp
+#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/TransferWnd.cpp
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Cancel"
 msgstr "Prekliči"
 
@@ -1942,7 +1974,8 @@ msgstr "Vnesite novo ime za to datoteko:"
 msgid "File rename"
 msgstr "Preimenuj datoteko"
 
-#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f MiB/s"
 msgstr ""
@@ -2752,11 +2785,13 @@ msgstr ""
 msgid "Start aMule automatically when I log in"
 msgstr ""
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp packaging/windows/installer_strings.c
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: packaging/windows/installer_strings.c
 msgid "Register aMule for ed2k:// links"
 msgstr ""
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp packaging/windows/installer_strings.c
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: packaging/windows/installer_strings.c
 msgid "Register aMule for magnet: links"
 msgstr ""
 
@@ -2782,7 +2817,8 @@ msgstr ""
 msgid "Destination folder for downloads"
 msgstr "Ciljna mapa za prejeto"
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Browse"
 msgstr "Brskanje"
 
@@ -3213,6 +3249,163 @@ msgstr "Nalaganje vnosa iz seznama znanih datotek ni uspelo, datoteka je morda p
 msgid "Invalid entry in known file list, file may be corrupt: "
 msgstr "Neveljaven vnos na seznamu znanih datotek, datoteka je morda pokvarjena: "
 
+#: src/LanguageList.cpp
+msgid "System default"
+msgstr "Sistemsko privzet"
+
+#: src/LanguageList.cpp
+msgid "Albanian"
+msgstr "Albansko"
+
+#: src/LanguageList.cpp
+msgid "Arabic"
+msgstr "Arabsko"
+
+#: src/LanguageList.cpp
+msgid "Asturian"
+msgstr "Asturijsko"
+
+#: src/LanguageList.cpp
+msgid "Basque"
+msgstr "Baskovsko"
+
+#: src/LanguageList.cpp
+msgid "Bulgarian"
+msgstr "Bolgarsko"
+
+#: src/LanguageList.cpp
+msgid "Catalan"
+msgstr "Katalonsko"
+
+#: src/LanguageList.cpp
+msgid "Chinese (Simplified)"
+msgstr "Kitajsko (poenostavljeno)"
+
+#: src/LanguageList.cpp
+msgid "Chinese (Traditional)"
+msgstr "Kitajsko (tradicionalno)"
+
+#: src/LanguageList.cpp
+msgid "Croatian"
+msgstr "Hrvaško"
+
+#: src/LanguageList.cpp
+msgid "Czech"
+msgstr "Češko"
+
+#: src/LanguageList.cpp
+msgid "Danish"
+msgstr "Dansko"
+
+#: src/LanguageList.cpp
+msgid "Dutch"
+msgstr "Nizozemsko"
+
+#: src/LanguageList.cpp
+msgid "English (U.K.)"
+msgstr "Angleško (Z.K.)"
+
+#: src/LanguageList.cpp
+#, fuzzy
+msgid "English (U.S.)"
+msgstr "Angleško (Z.K.)"
+
+#: src/LanguageList.cpp
+msgid "Estonian"
+msgstr "Estonsko"
+
+#: src/LanguageList.cpp
+msgid "Finnish"
+msgstr "Finsko"
+
+#: src/LanguageList.cpp
+msgid "French"
+msgstr "Francosko"
+
+#: src/LanguageList.cpp
+msgid "Galician"
+msgstr "Galicijsko"
+
+#: src/LanguageList.cpp
+msgid "German"
+msgstr "Nemško"
+
+#: src/LanguageList.cpp
+msgid "Greek"
+msgstr "Grško"
+
+#: src/LanguageList.cpp
+msgid "Hebrew"
+msgstr "Hebrejsko"
+
+#: src/LanguageList.cpp
+msgid "Hungarian"
+msgstr "Madžarsko"
+
+#: src/LanguageList.cpp
+msgid "Italian"
+msgstr "Italijansko"
+
+#: src/LanguageList.cpp
+msgid "Japanese"
+msgstr "Japonsko"
+
+#: src/LanguageList.cpp
+msgid "Korean"
+msgstr "Korejsko"
+
+#: src/LanguageList.cpp
+msgid "Latvian"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Lithuanian"
+msgstr "Litvansko"
+
+#: src/LanguageList.cpp
+msgid "Norwegian (Nynorsk)"
+msgstr "Norveško (Nynorsk)"
+
+#: src/LanguageList.cpp
+msgid "Polish"
+msgstr "Poljsko"
+
+#: src/LanguageList.cpp
+msgid "Portuguese"
+msgstr "Portugalsko"
+
+#: src/LanguageList.cpp
+msgid "Portuguese (Brazilian)"
+msgstr "Portugalsko (brazilsko)"
+
+#: src/LanguageList.cpp
+msgid "Romanian"
+msgstr "Romunsko"
+
+#: src/LanguageList.cpp
+msgid "Russian"
+msgstr "Rusko"
+
+#: src/LanguageList.cpp
+msgid "Slovenian"
+msgstr "Slovensko"
+
+#: src/LanguageList.cpp
+msgid "Spanish"
+msgstr "Špansko"
+
+#: src/LanguageList.cpp
+msgid "Swedish"
+msgstr "Švedsko"
+
+#: src/LanguageList.cpp
+msgid "Turkish"
+msgstr "Turško"
+
+#: src/LanguageList.cpp
+msgid "Ukrainian"
+msgstr "Ukrajinsko"
+
 #: src/libs/common/Format.cpp
 #, c-format
 msgid "Unknown error %d"
@@ -3235,15 +3428,18 @@ msgstr "Zaključevanje"
 msgid "Complete"
 msgstr "Zaključeno"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Paused"
 msgstr "Prekinjeno"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Erroneous"
 msgstr "Vsebuje napake"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Waiting"
 msgstr "Na čakanju"
 
@@ -3415,7 +3611,8 @@ msgstr "Zapri"
 msgid "Cut"
 msgstr "Izreži"
 
-#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp src/utils/aLinkCreator/src/alcframe.cpp
+#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy"
 msgstr "Skopiraj"
 
@@ -3423,7 +3620,8 @@ msgstr "Skopiraj"
 msgid "Paste"
 msgstr "Prilepi"
 
-#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
+#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Clear"
 msgstr "Počisti"
 
@@ -3431,7 +3629,8 @@ msgstr "Počisti"
 msgid "Select All"
 msgstr "Izberi vse"
 
-#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp src/StatisticsDlg.cpp
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
+#: src/StatisticsDlg.cpp
 msgid "KiB/s"
 msgstr ""
 
@@ -5941,175 +6140,6 @@ msgid "ERROR: Failed to open partfile '%s'"
 msgstr "NAPAKA: delne datoteke »%s« ni bilo moč odpreti"
 
 #: src/Preferences.cpp
-msgid "System default"
-msgstr "Sistemsko privzet"
-
-#: src/Preferences.cpp
-msgid "Albanian"
-msgstr "Albansko"
-
-#: src/Preferences.cpp
-msgid "Arabic"
-msgstr "Arabsko"
-
-#: src/Preferences.cpp
-msgid "Asturian"
-msgstr "Asturijsko"
-
-#: src/Preferences.cpp
-msgid "Basque"
-msgstr "Baskovsko"
-
-#: src/Preferences.cpp
-msgid "Bulgarian"
-msgstr "Bolgarsko"
-
-#: src/Preferences.cpp
-msgid "Catalan"
-msgstr "Katalonsko"
-
-#: src/Preferences.cpp
-msgid "Chinese (Simplified)"
-msgstr "Kitajsko (poenostavljeno)"
-
-#: src/Preferences.cpp
-msgid "Chinese (Traditional)"
-msgstr "Kitajsko (tradicionalno)"
-
-#: src/Preferences.cpp
-msgid "Croatian"
-msgstr "Hrvaško"
-
-#: src/Preferences.cpp
-msgid "Czech"
-msgstr "Češko"
-
-#: src/Preferences.cpp
-msgid "Danish"
-msgstr "Dansko"
-
-#: src/Preferences.cpp
-msgid "Dutch"
-msgstr "Nizozemsko"
-
-#: src/Preferences.cpp
-msgid "English (U.K.)"
-msgstr "Angleško (Z.K.)"
-
-#: src/Preferences.cpp
-#, fuzzy
-msgid "English (U.S.)"
-msgstr "Angleško (Z.K.)"
-
-#: src/Preferences.cpp
-msgid "Estonian"
-msgstr "Estonsko"
-
-#: src/Preferences.cpp
-msgid "Finnish"
-msgstr "Finsko"
-
-#: src/Preferences.cpp
-msgid "French"
-msgstr "Francosko"
-
-#: src/Preferences.cpp
-msgid "Galician"
-msgstr "Galicijsko"
-
-#: src/Preferences.cpp
-msgid "German"
-msgstr "Nemško"
-
-#: src/Preferences.cpp
-msgid "Greek"
-msgstr "Grško"
-
-#: src/Preferences.cpp
-msgid "Hebrew"
-msgstr "Hebrejsko"
-
-#: src/Preferences.cpp
-msgid "Hungarian"
-msgstr "Madžarsko"
-
-#: src/Preferences.cpp
-msgid "Italian"
-msgstr "Italijansko"
-
-#: src/Preferences.cpp
-msgid "Japanese"
-msgstr "Japonsko"
-
-#: src/Preferences.cpp
-msgid "Korean"
-msgstr "Korejsko"
-
-#: src/Preferences.cpp
-msgid "Latvian"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Lithuanian"
-msgstr "Litvansko"
-
-#: src/Preferences.cpp
-msgid "Norwegian (Nynorsk)"
-msgstr "Norveško (Nynorsk)"
-
-#: src/Preferences.cpp
-msgid "Polish"
-msgstr "Poljsko"
-
-#: src/Preferences.cpp
-msgid "Portuguese"
-msgstr "Portugalsko"
-
-#: src/Preferences.cpp
-msgid "Portuguese (Brazilian)"
-msgstr "Portugalsko (brazilsko)"
-
-#: src/Preferences.cpp
-msgid "Romanian"
-msgstr "Romunsko"
-
-#: src/Preferences.cpp
-msgid "Russian"
-msgstr "Rusko"
-
-#: src/Preferences.cpp
-msgid "Slovenian"
-msgstr "Slovensko"
-
-#: src/Preferences.cpp
-msgid "Spanish"
-msgstr "Špansko"
-
-#: src/Preferences.cpp
-msgid "Swedish"
-msgstr "Švedsko"
-
-#: src/Preferences.cpp
-msgid "Turkish"
-msgstr "Turško"
-
-#: src/Preferences.cpp
-msgid "Ukrainian"
-msgstr "Ukrajinsko"
-
-#: src/Preferences.cpp
-msgid "Change Language"
-msgstr "Spremeni jezik"
-
-#: src/Preferences.cpp
-msgid "There are no translations installed for aMule"
-msgstr "Za aMule ni nameščenega nobenega prevoda"
-
-#: src/Preferences.cpp
-msgid "No languages available"
-msgstr "Na voljo ni nobenega jezika"
-
-#: src/Preferences.cpp
 msgid "no options available"
 msgstr "na voljo ni nobene možnosti"
 
@@ -6633,7 +6663,8 @@ msgstr ""
 msgid "Confirm shared folders"
 msgstr "Deljene mape"
 
-#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp src/SharedFilesReloadProgress.cpp
+#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp
+#: src/SharedFilesReloadProgress.cpp
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "Ponovno naloži deljene datoteke"
@@ -9398,6 +9429,15 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "Change Language"
+#~ msgstr "Spremeni jezik"
+
+#~ msgid "There are no translations installed for aMule"
+#~ msgstr "Za aMule ni nameščenega nobenega prevoda"
+
+#~ msgid "No languages available"
+#~ msgstr "Na voljo ni nobenega jezika"
 
 #~ msgid "User name"
 #~ msgstr "Uporabniško ime"

--- a/po/sq.po
+++ b/po/sq.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-05 12:01+0200\n"
+"POT-Creation-Date: 2026-09-06 14:35+0200\n"
 "PO-Revision-Date: 2026-09-05 11:01+0000\n"
 "Last-Translator: Fation <dj_barthezz@linuxmail.org lushnja_corps@hotmail.Language-Team:\n"
 "Language: sq\n"
@@ -387,7 +387,8 @@ msgstr ""
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr ""
 
-#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
+#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
+#: src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
 msgid "ERROR"
 msgstr ""
 
@@ -675,7 +676,8 @@ msgstr "Rrjetet"
 msgid "Searches"
 msgstr "Kerkimet"
 
-#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/Statistics.cpp
+#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/Statistics.cpp
 msgid "Downloads"
 msgstr "Shkarkime"
 
@@ -759,7 +761,9 @@ msgstr "Kad: Fikur"
 msgid "Core"
 msgstr ""
 
-#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp src/Statistics.cpp
+#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp src/Statistics.cpp
 msgid "Version"
 msgstr "Versioni"
 
@@ -1063,7 +1067,11 @@ msgstr ""
 msgid "The remote core sent inconsistent data for \"%s\" (part status %d, expected %d). The file list may be showing the wrong information; reconnect to clear it."
 msgstr ""
 
-#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp src/Statistics.cpp
+#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp
+#: src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp
+#: src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp
+#: src/Statistics.cpp
 msgid "Unknown"
 msgstr "E panjohur"
 
@@ -1161,7 +1169,8 @@ msgstr "Gabim duke shpetuar failin known.met: %s"
 msgid "Enter Captcha"
 msgstr ""
 
-#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp src/TransferWnd.cpp
+#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp
+#: src/TransferWnd.cpp
 msgid "Category"
 msgstr "Kategori"
 
@@ -1325,11 +1334,13 @@ msgstr "NUk u gjet faili cryptkey.dat,duke e krijuar."
 msgid "Client Details"
 msgstr "Detajet e klientit"
 
-#: src/ClientDetailDialog.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
+#: src/utils/wxCas/src/onlinesig.cpp
 msgid "LowID"
 msgstr "ID i ulet"
 
-#: src/ClientDetailDialog.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
+#: src/utils/wxCas/src/onlinesig.cpp
 msgid "HighID"
 msgstr "ID i larte"
 
@@ -1345,7 +1356,8 @@ msgstr ""
 msgid "Not supported"
 msgstr ""
 
-#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp src/TextClient.cpp
+#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
+#: src/TextClient.cpp
 msgid "Connected"
 msgstr "I lidhur"
 
@@ -1353,7 +1365,8 @@ msgstr "I lidhur"
 msgid "Disconnected"
 msgstr "I shkeputur"
 
-#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f KiB/s"
 msgstr ""
@@ -1370,7 +1383,8 @@ msgstr ""
 msgid "IP Address"
 msgstr "Adresa IP"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Origin"
 msgstr ""
 
@@ -1388,12 +1402,14 @@ msgstr "Marrja e fundit"
 msgid "Sessions"
 msgstr "Versioni"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/SharedFilePeersListCtrl.cpp
 #, fuzzy
 msgid "Upload Speed"
 msgstr "Shpejtesia-Ngarkimit"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/SharedFilePeersListCtrl.cpp
 #, fuzzy
 msgid "Download Speed"
 msgstr "Shpejtesia-Shkarkimit"
@@ -1449,11 +1465,13 @@ msgstr[1] ""
 msgid "Files"
 msgstr "Failet"
 
-#: src/ClientsListCtrl.cpp src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientsListCtrl.cpp src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp
 msgid "Uploaded"
 msgstr ""
 
-#: src/ClientsListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientsListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Downloaded"
 msgstr ""
 
@@ -1544,7 +1562,8 @@ msgstr "Komentet e faileve"
 msgid "Username"
 msgstr "Emri i perdorimit"
 
-#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp
+#: src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "File Name"
 msgstr "Emri i failit"
 
@@ -1605,15 +1624,18 @@ msgstr "Automatike [Larte]"
 msgid "Very low"
 msgstr "Shume ngadale"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Low"
 msgstr "Ngadale"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Normal"
 msgstr "Normale"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "High"
 msgstr "E larte"
 
@@ -1637,11 +1659,13 @@ msgstr "Lidhje nepermjet serverit"
 msgid "Queue Full"
 msgstr "Radha ne pritje eshte plote"
 
-#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp src/muuli_wdr.cpp
+#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp
+#: src/muuli_wdr.cpp
 msgid "On Queue"
 msgstr "Ne radhe"
 
-#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
+#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp
+#: src/PartFile.cpp src/TransferWnd.cpp
 msgid "Downloading"
 msgstr "Duke shkarkuar"
 
@@ -1701,7 +1725,8 @@ msgstr "Server Lokal"
 msgid "Remote Server"
 msgstr "Server i larget"
 
-#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp src/TextClient.cpp
+#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp
+#: src/TextClient.cpp
 msgid "Kad"
 msgstr "Kad"
 
@@ -1725,7 +1750,8 @@ msgstr "Burime te shpetuara"
 msgid "Search Result"
 msgstr ""
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp
+#: src/TransferWnd.cpp
 msgid "Completed"
 msgstr "Te kompletuara"
 
@@ -1778,7 +1804,8 @@ msgstr ""
 msgid "Part"
 msgstr ""
 
-#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 msgid "Size"
 msgstr "Madhesia"
 
@@ -1786,7 +1813,8 @@ msgstr "Madhesia"
 msgid "Transferred"
 msgstr "Te transferuara"
 
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp src/SourceListCtrl.cpp
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
+#: src/SourceListCtrl.cpp
 msgid "Speed"
 msgstr "Shpejtesia"
 
@@ -1794,11 +1822,13 @@ msgstr "Shpejtesia"
 msgid "Progress"
 msgstr "Avancimi"
 
-#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
+#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp
+#: src/SearchListCtrl.cpp
 msgid "Sources"
 msgstr "Burime"
 
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 msgid "Priority"
 msgstr "Perparesia"
 
@@ -1822,7 +1852,9 @@ msgstr "Marrja e fundit"
 msgid "Auto"
 msgstr "Automatike"
 
-#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/TransferWnd.cpp src/utils/wxCas/src/wxcasprefs.cpp
+#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/TransferWnd.cpp
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Cancel"
 msgstr "Fshij"
 
@@ -1921,7 +1953,8 @@ msgstr "Futni nje emer te ti per kete fail:"
 msgid "File rename"
 msgstr "Riemertim i failit"
 
-#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f MiB/s"
 msgstr ""
@@ -2730,11 +2763,13 @@ msgstr ""
 msgid "Start aMule automatically when I log in"
 msgstr ""
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp packaging/windows/installer_strings.c
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: packaging/windows/installer_strings.c
 msgid "Register aMule for ed2k:// links"
 msgstr ""
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp packaging/windows/installer_strings.c
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: packaging/windows/installer_strings.c
 msgid "Register aMule for magnet: links"
 msgstr ""
 
@@ -2760,7 +2795,8 @@ msgstr ""
 msgid "Destination folder for downloads"
 msgstr ""
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Browse"
 msgstr "Shfleto"
 
@@ -3185,6 +3221,165 @@ msgstr ""
 msgid "Invalid entry in known file list, file may be corrupt: "
 msgstr ""
 
+#: src/LanguageList.cpp
+msgid "System default"
+msgstr "E vendosur nga sistemi"
+
+#: src/LanguageList.cpp
+msgid "Albanian"
+msgstr "Shqip"
+
+#: src/LanguageList.cpp
+msgid "Arabic"
+msgstr "Arabe"
+
+#: src/LanguageList.cpp
+#, fuzzy
+msgid "Asturian"
+msgstr "Estoneze"
+
+#: src/LanguageList.cpp
+msgid "Basque"
+msgstr "Baske"
+
+#: src/LanguageList.cpp
+msgid "Bulgarian"
+msgstr "Bullgare"
+
+#: src/LanguageList.cpp
+msgid "Catalan"
+msgstr "Katallanase"
+
+#: src/LanguageList.cpp
+msgid "Chinese (Simplified)"
+msgstr "Kineze (E thjeshtesuar)"
+
+#: src/LanguageList.cpp
+msgid "Chinese (Traditional)"
+msgstr "KIneze (Tradicionale)"
+
+#: src/LanguageList.cpp
+msgid "Croatian"
+msgstr "Kroate"
+
+#: src/LanguageList.cpp
+msgid "Czech"
+msgstr "Ceke"
+
+#: src/LanguageList.cpp
+msgid "Danish"
+msgstr "Daneze"
+
+#: src/LanguageList.cpp
+msgid "Dutch"
+msgstr "Holandeze"
+
+#: src/LanguageList.cpp
+msgid "English (U.K.)"
+msgstr "Anglisht (G.B.)"
+
+#: src/LanguageList.cpp
+#, fuzzy
+msgid "English (U.S.)"
+msgstr "Anglisht (G.B.)"
+
+#: src/LanguageList.cpp
+msgid "Estonian"
+msgstr "Estoneze"
+
+#: src/LanguageList.cpp
+msgid "Finnish"
+msgstr "Finlandeze"
+
+#: src/LanguageList.cpp
+msgid "French"
+msgstr "Frengjisht"
+
+#: src/LanguageList.cpp
+msgid "Galician"
+msgstr "Galiciane"
+
+#: src/LanguageList.cpp
+msgid "German"
+msgstr "Gjermanisht"
+
+#: src/LanguageList.cpp
+msgid "Greek"
+msgstr "Greqisht"
+
+#: src/LanguageList.cpp
+msgid "Hebrew"
+msgstr "Cifut"
+
+#: src/LanguageList.cpp
+msgid "Hungarian"
+msgstr "Hungarisht"
+
+#: src/LanguageList.cpp
+msgid "Italian"
+msgstr "Italiane"
+
+#: src/LanguageList.cpp
+msgid "Japanese"
+msgstr "Japonisht"
+
+#: src/LanguageList.cpp
+msgid "Korean"
+msgstr "Koreane"
+
+#: src/LanguageList.cpp
+msgid "Latvian"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Lithuanian"
+msgstr "Lituane"
+
+#: src/LanguageList.cpp
+msgid "Norwegian (Nynorsk)"
+msgstr "Norvegjeze (Nynorsk)"
+
+#: src/LanguageList.cpp
+msgid "Polish"
+msgstr "Polake"
+
+#: src/LanguageList.cpp
+msgid "Portuguese"
+msgstr "Portugeze"
+
+#: src/LanguageList.cpp
+msgid "Portuguese (Brazilian)"
+msgstr "Portugeze (Braziliane)"
+
+#: src/LanguageList.cpp
+#, fuzzy
+msgid "Romanian"
+msgstr "Shqip"
+
+#: src/LanguageList.cpp
+msgid "Russian"
+msgstr "Ruse"
+
+#: src/LanguageList.cpp
+msgid "Slovenian"
+msgstr "Sllovene"
+
+#: src/LanguageList.cpp
+msgid "Spanish"
+msgstr "Spanjolle"
+
+#: src/LanguageList.cpp
+msgid "Swedish"
+msgstr "Suedeze"
+
+#: src/LanguageList.cpp
+msgid "Turkish"
+msgstr "Turqisht"
+
+#: src/LanguageList.cpp
+msgid "Ukrainian"
+msgstr ""
+
 #: src/libs/common/Format.cpp
 #, fuzzy, c-format
 msgid "Unknown error %d"
@@ -3207,15 +3402,18 @@ msgstr "Duke perfunduar"
 msgid "Complete"
 msgstr "E kompletuar"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Paused"
 msgstr "Ne pritje"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Erroneous"
 msgstr "E gabuar"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Waiting"
 msgstr "Duke pritur"
 
@@ -3381,7 +3579,8 @@ msgstr "Mbylle"
 msgid "Cut"
 msgstr "Ndaj"
 
-#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp src/utils/aLinkCreator/src/alcframe.cpp
+#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy"
 msgstr "Kopjo"
 
@@ -3389,7 +3588,8 @@ msgstr "Kopjo"
 msgid "Paste"
 msgstr "Ngjit"
 
-#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
+#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Clear"
 msgstr "Pastro"
 
@@ -3397,7 +3597,8 @@ msgstr "Pastro"
 msgid "Select All"
 msgstr "Zgjidhi te gjitha"
 
-#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp src/StatisticsDlg.cpp
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
+#: src/StatisticsDlg.cpp
 msgid "KiB/s"
 msgstr ""
 
@@ -5903,179 +6104,6 @@ msgid "ERROR: Failed to open partfile '%s'"
 msgstr ""
 
 #: src/Preferences.cpp
-msgid "System default"
-msgstr "E vendosur nga sistemi"
-
-#: src/Preferences.cpp
-msgid "Albanian"
-msgstr "Shqip"
-
-#: src/Preferences.cpp
-msgid "Arabic"
-msgstr "Arabe"
-
-#: src/Preferences.cpp
-#, fuzzy
-msgid "Asturian"
-msgstr "Estoneze"
-
-#: src/Preferences.cpp
-msgid "Basque"
-msgstr "Baske"
-
-#: src/Preferences.cpp
-msgid "Bulgarian"
-msgstr "Bullgare"
-
-#: src/Preferences.cpp
-msgid "Catalan"
-msgstr "Katallanase"
-
-#: src/Preferences.cpp
-msgid "Chinese (Simplified)"
-msgstr "Kineze (E thjeshtesuar)"
-
-#: src/Preferences.cpp
-msgid "Chinese (Traditional)"
-msgstr "KIneze (Tradicionale)"
-
-#: src/Preferences.cpp
-msgid "Croatian"
-msgstr "Kroate"
-
-#: src/Preferences.cpp
-msgid "Czech"
-msgstr "Ceke"
-
-#: src/Preferences.cpp
-msgid "Danish"
-msgstr "Daneze"
-
-#: src/Preferences.cpp
-msgid "Dutch"
-msgstr "Holandeze"
-
-#: src/Preferences.cpp
-msgid "English (U.K.)"
-msgstr "Anglisht (G.B.)"
-
-#: src/Preferences.cpp
-#, fuzzy
-msgid "English (U.S.)"
-msgstr "Anglisht (G.B.)"
-
-#: src/Preferences.cpp
-msgid "Estonian"
-msgstr "Estoneze"
-
-#: src/Preferences.cpp
-msgid "Finnish"
-msgstr "Finlandeze"
-
-#: src/Preferences.cpp
-msgid "French"
-msgstr "Frengjisht"
-
-#: src/Preferences.cpp
-msgid "Galician"
-msgstr "Galiciane"
-
-#: src/Preferences.cpp
-msgid "German"
-msgstr "Gjermanisht"
-
-#: src/Preferences.cpp
-msgid "Greek"
-msgstr "Greqisht"
-
-#: src/Preferences.cpp
-msgid "Hebrew"
-msgstr "Cifut"
-
-#: src/Preferences.cpp
-msgid "Hungarian"
-msgstr "Hungarisht"
-
-#: src/Preferences.cpp
-msgid "Italian"
-msgstr "Italiane"
-
-#: src/Preferences.cpp
-msgid "Japanese"
-msgstr "Japonisht"
-
-#: src/Preferences.cpp
-msgid "Korean"
-msgstr "Koreane"
-
-#: src/Preferences.cpp
-msgid "Latvian"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Lithuanian"
-msgstr "Lituane"
-
-#: src/Preferences.cpp
-msgid "Norwegian (Nynorsk)"
-msgstr "Norvegjeze (Nynorsk)"
-
-#: src/Preferences.cpp
-msgid "Polish"
-msgstr "Polake"
-
-#: src/Preferences.cpp
-msgid "Portuguese"
-msgstr "Portugeze"
-
-#: src/Preferences.cpp
-msgid "Portuguese (Brazilian)"
-msgstr "Portugeze (Braziliane)"
-
-#: src/Preferences.cpp
-#, fuzzy
-msgid "Romanian"
-msgstr "Shqip"
-
-#: src/Preferences.cpp
-msgid "Russian"
-msgstr "Ruse"
-
-#: src/Preferences.cpp
-msgid "Slovenian"
-msgstr "Sllovene"
-
-#: src/Preferences.cpp
-msgid "Spanish"
-msgstr "Spanjolle"
-
-#: src/Preferences.cpp
-msgid "Swedish"
-msgstr "Suedeze"
-
-#: src/Preferences.cpp
-msgid "Turkish"
-msgstr "Turqisht"
-
-#: src/Preferences.cpp
-msgid "Ukrainian"
-msgstr ""
-
-#: src/Preferences.cpp
-#, fuzzy
-msgid "Change Language"
-msgstr "Gjuha"
-
-#: src/Preferences.cpp
-msgid "There are no translations installed for aMule"
-msgstr ""
-
-#: src/Preferences.cpp
-#, fuzzy
-msgid "No languages available"
-msgstr "Nuk eshte ne dispozicion"
-
-#: src/Preferences.cpp
 msgid "no options available"
 msgstr ""
 
@@ -6585,7 +6613,8 @@ msgstr ""
 msgid "Confirm shared folders"
 msgstr "Ringarko failet e ndara"
 
-#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp src/SharedFilesReloadProgress.cpp
+#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp
+#: src/SharedFilesReloadProgress.cpp
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "Ringarko failet e ndara"
@@ -9327,6 +9356,14 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#, fuzzy
+#~ msgid "Change Language"
+#~ msgstr "Gjuha"
+
+#, fuzzy
+#~ msgid "No languages available"
+#~ msgstr "Nuk eshte ne dispozicion"
 
 #~ msgid "User name"
 #~ msgstr "Emri i Perdoruesit"

--- a/po/sv.po
+++ b/po/sv.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-05 12:01+0200\n"
+"POT-Creation-Date: 2026-09-06 14:35+0200\n"
 "PO-Revision-Date: 2026-09-05 11:01+0000\n"
 "Last-Translator: raffe <raffe@localhost.se>\n"
 "Language-Team: Swedish <tp-sv@listor.tp-sv.se>\n"
@@ -386,7 +386,8 @@ msgstr "webbservern kör på pid %d"
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Du vill köra webbservern vid uppstart, men binärfilen amuleweb kan inte köras. Vänligen installera paketet med aMule webservern eller compilera aMule med --enable-webserver och kör make install"
 
-#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
+#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
+#: src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
 msgid "ERROR"
 msgstr "FEL"
 
@@ -674,7 +675,8 @@ msgstr "Nätverk"
 msgid "Searches"
 msgstr "Sökningar"
 
-#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/Statistics.cpp
+#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/Statistics.cpp
 msgid "Downloads"
 msgstr "Hämtningar"
 
@@ -758,7 +760,9 @@ msgstr "Kad: Av"
 msgid "Core"
 msgstr ""
 
-#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp src/Statistics.cpp
+#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp src/Statistics.cpp
 msgid "Version"
 msgstr "Version"
 
@@ -1057,7 +1061,11 @@ msgstr "Kan inte skapa mappen '%s' för kategori '%s', behåller mappen '%s'."
 msgid "The remote core sent inconsistent data for \"%s\" (part status %d, expected %d). The file list may be showing the wrong information; reconnect to clear it."
 msgstr ""
 
-#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp src/Statistics.cpp
+#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp
+#: src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp
+#: src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp
+#: src/Statistics.cpp
 msgid "Unknown"
 msgstr "Okänd"
 
@@ -1154,7 +1162,8 @@ msgstr "Fel vid sparandet av %s fil: %s"
 msgid "Enter Captcha"
 msgstr "Ange Captcha"
 
-#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp src/TransferWnd.cpp
+#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp
+#: src/TransferWnd.cpp
 msgid "Category"
 msgstr "Kategori"
 
@@ -1318,11 +1327,13 @@ msgstr "Ingen 'cryptkey.dat'-fil funnen, skapar."
 msgid "Client Details"
 msgstr "Klientdetaljer"
 
-#: src/ClientDetailDialog.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
+#: src/utils/wxCas/src/onlinesig.cpp
 msgid "LowID"
 msgstr "LowID"
 
-#: src/ClientDetailDialog.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
+#: src/utils/wxCas/src/onlinesig.cpp
 msgid "HighID"
 msgstr "HighID"
 
@@ -1338,7 +1349,8 @@ msgstr "Stöds"
 msgid "Not supported"
 msgstr "Stöds inte"
 
-#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp src/TextClient.cpp
+#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
+#: src/TextClient.cpp
 msgid "Connected"
 msgstr "Ansluten"
 
@@ -1346,7 +1358,8 @@ msgstr "Ansluten"
 msgid "Disconnected"
 msgstr "Frånkopplad"
 
-#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f KiB/s"
 msgstr ""
@@ -1363,7 +1376,8 @@ msgstr ""
 msgid "IP Address"
 msgstr "IP-adress"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Origin"
 msgstr "Ursprung"
 
@@ -1381,11 +1395,13 @@ msgstr "Senast mottagen"
 msgid "Sessions"
 msgstr "Version"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/SharedFilePeersListCtrl.cpp
 msgid "Upload Speed"
 msgstr "Uppladdningshastighet"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/SharedFilePeersListCtrl.cpp
 msgid "Download Speed"
 msgstr "Hämtningshastighet"
 
@@ -1440,11 +1456,13 @@ msgstr[1] ""
 msgid "Files"
 msgstr "Filer"
 
-#: src/ClientsListCtrl.cpp src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientsListCtrl.cpp src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp
 msgid "Uploaded"
 msgstr "Uppladdad"
 
-#: src/ClientsListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientsListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Downloaded"
 msgstr "Nedladdad"
 
@@ -1535,7 +1553,8 @@ msgstr "Filkommentarer"
 msgid "Username"
 msgstr "Användarnamn"
 
-#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp
+#: src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "File Name"
 msgstr "Filnamn"
 
@@ -1597,15 +1616,18 @@ msgstr "Auto [Hö]"
 msgid "Very low"
 msgstr "Mycket låg"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Low"
 msgstr "Låg"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Normal"
 msgstr "Normal"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "High"
 msgstr "Hög"
 
@@ -1629,11 +1651,13 @@ msgstr "Ansluter via server"
 msgid "Queue Full"
 msgstr "Kö full"
 
-#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp src/muuli_wdr.cpp
+#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp
+#: src/muuli_wdr.cpp
 msgid "On Queue"
 msgstr "I kö"
 
-#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
+#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp
+#: src/PartFile.cpp src/TransferWnd.cpp
 msgid "Downloading"
 msgstr "Hämtar"
 
@@ -1693,7 +1717,8 @@ msgstr "Lokal server"
 msgid "Remote Server"
 msgstr "Fjärrserver"
 
-#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp src/TextClient.cpp
+#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp
+#: src/TextClient.cpp
 msgid "Kad"
 msgstr "Kad"
 
@@ -1717,7 +1742,8 @@ msgstr "Käll-frön"
 msgid "Search Result"
 msgstr "Sökresultat"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp
+#: src/TransferWnd.cpp
 msgid "Completed"
 msgstr "Färdig"
 
@@ -1770,7 +1796,8 @@ msgstr ""
 msgid "Part"
 msgstr "Del"
 
-#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 msgid "Size"
 msgstr "Storlek"
 
@@ -1778,7 +1805,8 @@ msgstr "Storlek"
 msgid "Transferred"
 msgstr "Överfört"
 
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp src/SourceListCtrl.cpp
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
+#: src/SourceListCtrl.cpp
 msgid "Speed"
 msgstr "Hastighet"
 
@@ -1786,11 +1814,13 @@ msgstr "Hastighet"
 msgid "Progress"
 msgstr "Förlopp"
 
-#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
+#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp
+#: src/SearchListCtrl.cpp
 msgid "Sources"
 msgstr "Källor"
 
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 msgid "Priority"
 msgstr "Prioritet"
 
@@ -1814,7 +1844,9 @@ msgstr "Senast mottagen"
 msgid "Auto"
 msgstr "Auto"
 
-#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/TransferWnd.cpp src/utils/wxCas/src/wxcasprefs.cpp
+#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/TransferWnd.cpp
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Cancel"
 msgstr "Avbryt"
 
@@ -1915,7 +1947,8 @@ msgstr "Ange nytt namn för den här filen:"
 msgid "File rename"
 msgstr "Byt namn på fil"
 
-#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f MiB/s"
 msgstr ""
@@ -2720,11 +2753,13 @@ msgstr ""
 msgid "Start aMule automatically when I log in"
 msgstr ""
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp packaging/windows/installer_strings.c
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: packaging/windows/installer_strings.c
 msgid "Register aMule for ed2k:// links"
 msgstr ""
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp packaging/windows/installer_strings.c
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: packaging/windows/installer_strings.c
 msgid "Register aMule for magnet: links"
 msgstr ""
 
@@ -2750,7 +2785,8 @@ msgstr ""
 msgid "Destination folder for downloads"
 msgstr "Målmapp för hämtningar"
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Browse"
 msgstr "Bläddra"
 
@@ -3171,6 +3207,163 @@ msgstr "Det gick inte att läsa posten i filen med kända filer, filen kan vara 
 msgid "Invalid entry in known file list, file may be corrupt: "
 msgstr "Ogiltig post i filen med kända filer, filen kan vara skadad: "
 
+#: src/LanguageList.cpp
+msgid "System default"
+msgstr "Systemets standard"
+
+#: src/LanguageList.cpp
+msgid "Albanian"
+msgstr "Albansk"
+
+#: src/LanguageList.cpp
+msgid "Arabic"
+msgstr "Arabiska"
+
+#: src/LanguageList.cpp
+msgid "Asturian"
+msgstr "Asturiska"
+
+#: src/LanguageList.cpp
+msgid "Basque"
+msgstr "Baskiska"
+
+#: src/LanguageList.cpp
+msgid "Bulgarian"
+msgstr "Bulgariska"
+
+#: src/LanguageList.cpp
+msgid "Catalan"
+msgstr "Katalanska"
+
+#: src/LanguageList.cpp
+msgid "Chinese (Simplified)"
+msgstr "Kinesiska (Förenklad)"
+
+#: src/LanguageList.cpp
+msgid "Chinese (Traditional)"
+msgstr "Kinesiska (Traditionell)"
+
+#: src/LanguageList.cpp
+msgid "Croatian"
+msgstr "Kroatiska"
+
+#: src/LanguageList.cpp
+msgid "Czech"
+msgstr "Checkiska"
+
+#: src/LanguageList.cpp
+msgid "Danish"
+msgstr "Danska"
+
+#: src/LanguageList.cpp
+msgid "Dutch"
+msgstr "Nederländska"
+
+#: src/LanguageList.cpp
+msgid "English (U.K.)"
+msgstr "Engelska (Storbritannien)"
+
+#: src/LanguageList.cpp
+#, fuzzy
+msgid "English (U.S.)"
+msgstr "Engelska (Storbritannien)"
+
+#: src/LanguageList.cpp
+msgid "Estonian"
+msgstr "Estniska"
+
+#: src/LanguageList.cpp
+msgid "Finnish"
+msgstr "Finska"
+
+#: src/LanguageList.cpp
+msgid "French"
+msgstr "Franska"
+
+#: src/LanguageList.cpp
+msgid "Galician"
+msgstr "Galiciska"
+
+#: src/LanguageList.cpp
+msgid "German"
+msgstr "Tyska"
+
+#: src/LanguageList.cpp
+msgid "Greek"
+msgstr "Grekisk"
+
+#: src/LanguageList.cpp
+msgid "Hebrew"
+msgstr "Hebreiska"
+
+#: src/LanguageList.cpp
+msgid "Hungarian"
+msgstr "Ungerska"
+
+#: src/LanguageList.cpp
+msgid "Italian"
+msgstr "Italienska"
+
+#: src/LanguageList.cpp
+msgid "Japanese"
+msgstr "Japanska"
+
+#: src/LanguageList.cpp
+msgid "Korean"
+msgstr "Koreanska"
+
+#: src/LanguageList.cpp
+msgid "Latvian"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Lithuanian"
+msgstr "Litauisk"
+
+#: src/LanguageList.cpp
+msgid "Norwegian (Nynorsk)"
+msgstr "Norska (nynorsk)"
+
+#: src/LanguageList.cpp
+msgid "Polish"
+msgstr "Polska"
+
+#: src/LanguageList.cpp
+msgid "Portuguese"
+msgstr "Portugisiska"
+
+#: src/LanguageList.cpp
+msgid "Portuguese (Brazilian)"
+msgstr "Portugisiska (Brasilien)"
+
+#: src/LanguageList.cpp
+msgid "Romanian"
+msgstr "Romänska"
+
+#: src/LanguageList.cpp
+msgid "Russian"
+msgstr "Ryska"
+
+#: src/LanguageList.cpp
+msgid "Slovenian"
+msgstr "Slovenska"
+
+#: src/LanguageList.cpp
+msgid "Spanish"
+msgstr "Spanska"
+
+#: src/LanguageList.cpp
+msgid "Swedish"
+msgstr "Svenska"
+
+#: src/LanguageList.cpp
+msgid "Turkish"
+msgstr "Turkiska"
+
+#: src/LanguageList.cpp
+msgid "Ukrainian"
+msgstr "Ukraina"
+
 #: src/libs/common/Format.cpp
 #, c-format
 msgid "Unknown error %d"
@@ -3193,15 +3386,18 @@ msgstr "Färdigställer"
 msgid "Complete"
 msgstr "Färdig"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Paused"
 msgstr "Pausad"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Erroneous"
 msgstr "Felaktig"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Waiting"
 msgstr "Väntar"
 
@@ -3365,7 +3561,8 @@ msgstr "Stäng"
 msgid "Cut"
 msgstr "Klipp ut"
 
-#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp src/utils/aLinkCreator/src/alcframe.cpp
+#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy"
 msgstr "Kopiera"
 
@@ -3373,7 +3570,8 @@ msgstr "Kopiera"
 msgid "Paste"
 msgstr "Klistra in"
 
-#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
+#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Clear"
 msgstr "Töm"
 
@@ -3381,7 +3579,8 @@ msgstr "Töm"
 msgid "Select All"
 msgstr "Markera alla"
 
-#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp src/StatisticsDlg.cpp
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
+#: src/StatisticsDlg.cpp
 msgid "KiB/s"
 msgstr ""
 
@@ -5878,175 +6077,6 @@ msgid "ERROR: Failed to open partfile '%s'"
 msgstr "FEL: Det gick inte att öppna partfile ' %s '"
 
 #: src/Preferences.cpp
-msgid "System default"
-msgstr "Systemets standard"
-
-#: src/Preferences.cpp
-msgid "Albanian"
-msgstr "Albansk"
-
-#: src/Preferences.cpp
-msgid "Arabic"
-msgstr "Arabiska"
-
-#: src/Preferences.cpp
-msgid "Asturian"
-msgstr "Asturiska"
-
-#: src/Preferences.cpp
-msgid "Basque"
-msgstr "Baskiska"
-
-#: src/Preferences.cpp
-msgid "Bulgarian"
-msgstr "Bulgariska"
-
-#: src/Preferences.cpp
-msgid "Catalan"
-msgstr "Katalanska"
-
-#: src/Preferences.cpp
-msgid "Chinese (Simplified)"
-msgstr "Kinesiska (Förenklad)"
-
-#: src/Preferences.cpp
-msgid "Chinese (Traditional)"
-msgstr "Kinesiska (Traditionell)"
-
-#: src/Preferences.cpp
-msgid "Croatian"
-msgstr "Kroatiska"
-
-#: src/Preferences.cpp
-msgid "Czech"
-msgstr "Checkiska"
-
-#: src/Preferences.cpp
-msgid "Danish"
-msgstr "Danska"
-
-#: src/Preferences.cpp
-msgid "Dutch"
-msgstr "Nederländska"
-
-#: src/Preferences.cpp
-msgid "English (U.K.)"
-msgstr "Engelska (Storbritannien)"
-
-#: src/Preferences.cpp
-#, fuzzy
-msgid "English (U.S.)"
-msgstr "Engelska (Storbritannien)"
-
-#: src/Preferences.cpp
-msgid "Estonian"
-msgstr "Estniska"
-
-#: src/Preferences.cpp
-msgid "Finnish"
-msgstr "Finska"
-
-#: src/Preferences.cpp
-msgid "French"
-msgstr "Franska"
-
-#: src/Preferences.cpp
-msgid "Galician"
-msgstr "Galiciska"
-
-#: src/Preferences.cpp
-msgid "German"
-msgstr "Tyska"
-
-#: src/Preferences.cpp
-msgid "Greek"
-msgstr "Grekisk"
-
-#: src/Preferences.cpp
-msgid "Hebrew"
-msgstr "Hebreiska"
-
-#: src/Preferences.cpp
-msgid "Hungarian"
-msgstr "Ungerska"
-
-#: src/Preferences.cpp
-msgid "Italian"
-msgstr "Italienska"
-
-#: src/Preferences.cpp
-msgid "Japanese"
-msgstr "Japanska"
-
-#: src/Preferences.cpp
-msgid "Korean"
-msgstr "Koreanska"
-
-#: src/Preferences.cpp
-msgid "Latvian"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Lithuanian"
-msgstr "Litauisk"
-
-#: src/Preferences.cpp
-msgid "Norwegian (Nynorsk)"
-msgstr "Norska (nynorsk)"
-
-#: src/Preferences.cpp
-msgid "Polish"
-msgstr "Polska"
-
-#: src/Preferences.cpp
-msgid "Portuguese"
-msgstr "Portugisiska"
-
-#: src/Preferences.cpp
-msgid "Portuguese (Brazilian)"
-msgstr "Portugisiska (Brasilien)"
-
-#: src/Preferences.cpp
-msgid "Romanian"
-msgstr "Romänska"
-
-#: src/Preferences.cpp
-msgid "Russian"
-msgstr "Ryska"
-
-#: src/Preferences.cpp
-msgid "Slovenian"
-msgstr "Slovenska"
-
-#: src/Preferences.cpp
-msgid "Spanish"
-msgstr "Spanska"
-
-#: src/Preferences.cpp
-msgid "Swedish"
-msgstr "Svenska"
-
-#: src/Preferences.cpp
-msgid "Turkish"
-msgstr "Turkiska"
-
-#: src/Preferences.cpp
-msgid "Ukrainian"
-msgstr "Ukraina"
-
-#: src/Preferences.cpp
-msgid "Change Language"
-msgstr "Byt språk"
-
-#: src/Preferences.cpp
-msgid "There are no translations installed for aMule"
-msgstr "Det finns inga översättningar installerade för aMule"
-
-#: src/Preferences.cpp
-msgid "No languages available"
-msgstr "Inga språk tillgängliga"
-
-#: src/Preferences.cpp
 msgid "no options available"
 msgstr "Inga alternativ tillgängliga"
 
@@ -6558,7 +6588,8 @@ msgstr ""
 msgid "Confirm shared folders"
 msgstr "Delade mappar"
 
-#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp src/SharedFilesReloadProgress.cpp
+#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp
+#: src/SharedFilesReloadProgress.cpp
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "Återladda dina delade filer"
@@ -9292,6 +9323,15 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "Change Language"
+#~ msgstr "Byt språk"
+
+#~ msgid "There are no translations installed for aMule"
+#~ msgstr "Det finns inga översättningar installerade för aMule"
+
+#~ msgid "No languages available"
+#~ msgstr "Inga språk tillgängliga"
 
 #~ msgid "User name"
 #~ msgstr "Användarnamn"

--- a/po/ta.po
+++ b/po/ta.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-05 12:01+0200\n"
+"POT-Creation-Date: 2026-09-06 14:35+0200\n"
 "PO-Revision-Date: 2026-09-05 11:06+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -3110,6 +3110,162 @@ msgstr ""
 msgid "Invalid entry in known file list, file may be corrupt: "
 msgstr ""
 
+#: src/LanguageList.cpp
+msgid "System default"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Albanian"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Arabic"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Asturian"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Basque"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Bulgarian"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Catalan"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Chinese (Simplified)"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Chinese (Traditional)"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Croatian"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Czech"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Danish"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Dutch"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "English (U.K.)"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "English (U.S.)"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Estonian"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Finnish"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "French"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Galician"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "German"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Greek"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Hebrew"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Hungarian"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Italian"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Japanese"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Korean"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Latvian"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Lithuanian"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Norwegian (Nynorsk)"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Polish"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Portuguese"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Portuguese (Brazilian)"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Romanian"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Russian"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Slovenian"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Spanish"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Swedish"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Turkish"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Ukrainian"
+msgstr ""
+
 #: src/libs/common/Format.cpp
 #, c-format
 msgid "Unknown error %d"
@@ -5764,174 +5920,6 @@ msgstr ""
 #: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Failed to open partfile '%s'"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "System default"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Albanian"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Arabic"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Asturian"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Basque"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Bulgarian"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Catalan"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Chinese (Simplified)"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Chinese (Traditional)"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Croatian"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Czech"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Danish"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Dutch"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "English (U.K.)"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "English (U.S.)"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Estonian"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Finnish"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "French"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Galician"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "German"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Greek"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Hebrew"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Hungarian"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Italian"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Japanese"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Korean"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Latvian"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Lithuanian"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Norwegian (Nynorsk)"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Polish"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Portuguese"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Portuguese (Brazilian)"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Romanian"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Russian"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Slovenian"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Spanish"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Swedish"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Turkish"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Ukrainian"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Change Language"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "There are no translations installed for aMule"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "No languages available"
 msgstr ""
 
 #: src/Preferences.cpp

--- a/po/tr.po
+++ b/po/tr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-05 12:01+0200\n"
+"POT-Creation-Date: 2026-09-06 14:35+0200\n"
 "PO-Revision-Date: 2026-09-05 11:02+0000\n"
 "Last-Translator: \n"
 "Language-Team: Turkish <li@li.org>\n"
@@ -385,7 +385,8 @@ msgstr "web sunucusu pid %d üzerinde çalışıyor"
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Web sunucusunun başlangıçta çalışmasını istediniz, fakat amuleweb ikilisi çalıştırılamıyor. Lütfen aMule web sunucusunu içeren paketi yükleyin veya aMule' yi -DBUILD_WEBSERVER=YES seçeneği ile derleyin ve kurun."
 
-#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
+#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
+#: src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
 msgid "ERROR"
 msgstr "HATA"
 
@@ -671,7 +672,8 @@ msgstr "Ağlar"
 msgid "Searches"
 msgstr "Aramalar"
 
-#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/Statistics.cpp
+#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/Statistics.cpp
 msgid "Downloads"
 msgstr "İndirmeler"
 
@@ -759,7 +761,9 @@ msgstr "Kad: Kapalı"
 msgid "Core"
 msgstr "Çekirdek"
 
-#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp src/Statistics.cpp
+#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp src/Statistics.cpp
 msgid "Version"
 msgstr "Sürüm"
 
@@ -1056,7 +1060,11 @@ msgstr "'%s' dizini '%s' sınıfı için oluşturulamadı. '%s' dizini kullanıl
 msgid "The remote core sent inconsistent data for \"%s\" (part status %d, expected %d). The file list may be showing the wrong information; reconnect to clear it."
 msgstr "Uzaktaki çekirdek \"%s\" için tutarsız veri gönderdi (kısmi durum %d, beklenilen %d). Dosya listesi yanlış bilgi gösteriyor olabilir, bunu düzeltmek için tekrar bağlanın."
 
-#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp src/Statistics.cpp
+#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp
+#: src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp
+#: src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp
+#: src/Statistics.cpp
 msgid "Unknown"
 msgstr "Bilinmiyor"
 
@@ -1153,7 +1161,8 @@ msgstr "%s dosyası kaydedilirken hata: %s"
 msgid "Enter Captcha"
 msgstr "Captcha Gir"
 
-#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp src/TransferWnd.cpp
+#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp
+#: src/TransferWnd.cpp
 msgid "Category"
 msgstr "Sınıf"
 
@@ -1316,11 +1325,13 @@ msgstr "'cryptkey.dat' dosyası bulunamadı. Oluşturuluyor…"
 msgid "Client Details"
 msgstr "Kullanıcı Ayrıntıları"
 
-#: src/ClientDetailDialog.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
+#: src/utils/wxCas/src/onlinesig.cpp
 msgid "LowID"
 msgstr "DüşükID"
 
-#: src/ClientDetailDialog.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
+#: src/utils/wxCas/src/onlinesig.cpp
 msgid "HighID"
 msgstr "YüksekID"
 
@@ -1336,7 +1347,8 @@ msgstr "Destekleniyor"
 msgid "Not supported"
 msgstr "Desteklenmiyor"
 
-#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp src/TextClient.cpp
+#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
+#: src/TextClient.cpp
 msgid "Connected"
 msgstr "Bağlandı"
 
@@ -1344,7 +1356,8 @@ msgstr "Bağlandı"
 msgid "Disconnected"
 msgstr "Bağlantı kesildi"
 
-#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f KiB/s"
 msgstr "%.1f KiB/s"
@@ -1361,7 +1374,8 @@ msgstr "Yazılım"
 msgid "IP Address"
 msgstr "IP Adresi"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Origin"
 msgstr "Köken"
 
@@ -1377,11 +1391,13 @@ msgstr "Son Görülme"
 msgid "Sessions"
 msgstr "Oturumlar"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/SharedFilePeersListCtrl.cpp
 msgid "Upload Speed"
 msgstr "Gönderme Hızı"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/SharedFilePeersListCtrl.cpp
 msgid "Download Speed"
 msgstr "İndirme Hızı"
 
@@ -1432,11 +1448,13 @@ msgstr[1] "%u seçili istemciden paylaşılan dosyaları talep edilemedi."
 msgid "Files"
 msgstr "Dosyalar"
 
-#: src/ClientsListCtrl.cpp src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientsListCtrl.cpp src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp
 msgid "Uploaded"
 msgstr "Gönderilen"
 
-#: src/ClientsListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientsListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Downloaded"
 msgstr "İndirildi"
 
@@ -1524,7 +1542,8 @@ msgstr "Dosya Yorumları"
 msgid "Username"
 msgstr "Kullanıcı Adı"
 
-#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp
+#: src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "File Name"
 msgstr "Dosya Adı"
 
@@ -1585,15 +1604,18 @@ msgstr "Oto (Yük)"
 msgid "Very low"
 msgstr "Çok düşük"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Low"
 msgstr "Düşük"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Normal"
 msgstr "Normal"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "High"
 msgstr "Yüksek"
 
@@ -1617,11 +1639,13 @@ msgstr "Sunucu yoluyla bağlanıyor"
 msgid "Queue Full"
 msgstr "Sıra dolu"
 
-#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp src/muuli_wdr.cpp
+#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp
+#: src/muuli_wdr.cpp
 msgid "On Queue"
 msgstr "Sırada"
 
-#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
+#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp
+#: src/PartFile.cpp src/TransferWnd.cpp
 msgid "Downloading"
 msgstr "Aktarılıyor"
 
@@ -1681,7 +1705,8 @@ msgstr "Sunucu"
 msgid "Remote Server"
 msgstr "Uzak Sunucu"
 
-#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp src/TextClient.cpp
+#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp
+#: src/TextClient.cpp
 msgid "Kad"
 msgstr "Kad"
 
@@ -1705,7 +1730,8 @@ msgstr "Kaynak Girdileri"
 msgid "Search Result"
 msgstr "Arama Sonucu"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp
+#: src/TransferWnd.cpp
 msgid "Completed"
 msgstr "Tamamlandı"
 
@@ -1757,7 +1783,8 @@ msgstr "Özyinelemeli bir paylaşım dahilinde değişim yapılamaz"
 msgid "Part"
 msgstr "Parça"
 
-#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 msgid "Size"
 msgstr "Boyut"
 
@@ -1765,7 +1792,8 @@ msgstr "Boyut"
 msgid "Transferred"
 msgstr "Aktarıldı"
 
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp src/SourceListCtrl.cpp
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
+#: src/SourceListCtrl.cpp
 msgid "Speed"
 msgstr "Hız"
 
@@ -1773,11 +1801,13 @@ msgstr "Hız"
 msgid "Progress"
 msgstr "İşlem"
 
-#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
+#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp
+#: src/SearchListCtrl.cpp
 msgid "Sources"
 msgstr "Kaynaklar"
 
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 msgid "Priority"
 msgstr "Öncelik"
 
@@ -1801,7 +1831,9 @@ msgstr "Son Alım"
 msgid "Auto"
 msgstr "Otomatik"
 
-#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/TransferWnd.cpp src/utils/wxCas/src/wxcasprefs.cpp
+#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/TransferWnd.cpp
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Cancel"
 msgstr "İptal"
 
@@ -1902,7 +1934,8 @@ msgstr "Bu dosya için yeni bir isim girin:"
 msgid "File rename"
 msgstr "Dosya yeniden adlandır"
 
-#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f MiB/s"
 msgstr "%.1f MiB/s"
@@ -2705,11 +2738,13 @@ msgstr ""
 msgid "Start aMule automatically when I log in"
 msgstr "aMule'ü oturum açtığımda otomatik olarak başlat"
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp packaging/windows/installer_strings.c
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: packaging/windows/installer_strings.c
 msgid "Register aMule for ed2k:// links"
 msgstr "aMule'ü ed2k:// bağlantıları için kaydet"
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp packaging/windows/installer_strings.c
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: packaging/windows/installer_strings.c
 msgid "Register aMule for magnet: links"
 msgstr "aMule'ü magnet: bağlantıları için kaydet"
 
@@ -2737,7 +2772,8 @@ msgstr ""
 msgid "Destination folder for downloads"
 msgstr "İndirmeler için hedef dizin"
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Browse"
 msgstr "Göz at"
 
@@ -3159,6 +3195,162 @@ msgstr "Bilinen dosyalar listesinden girdi yüklenemedi. Dosya bozuk olabilir"
 msgid "Invalid entry in known file list, file may be corrupt: "
 msgstr "Bilinen dosyalar listesinde geçersiz girdi bulundu. Dosya bozuk olabilir: "
 
+#: src/LanguageList.cpp
+msgid "System default"
+msgstr "Sistem öntanımlısı"
+
+#: src/LanguageList.cpp
+msgid "Albanian"
+msgstr "Arnavutça"
+
+#: src/LanguageList.cpp
+msgid "Arabic"
+msgstr "Arapça"
+
+#: src/LanguageList.cpp
+msgid "Asturian"
+msgstr "Asturyasça"
+
+#: src/LanguageList.cpp
+msgid "Basque"
+msgstr "Baskça"
+
+#: src/LanguageList.cpp
+msgid "Bulgarian"
+msgstr "Bulgarca"
+
+#: src/LanguageList.cpp
+msgid "Catalan"
+msgstr "Katalanca"
+
+#: src/LanguageList.cpp
+msgid "Chinese (Simplified)"
+msgstr "Çince (Basitleştirilmiş)"
+
+#: src/LanguageList.cpp
+msgid "Chinese (Traditional)"
+msgstr "Çince (Geleneksel)"
+
+#: src/LanguageList.cpp
+msgid "Croatian"
+msgstr "Hırvatça"
+
+#: src/LanguageList.cpp
+msgid "Czech"
+msgstr "Çekçe"
+
+#: src/LanguageList.cpp
+msgid "Danish"
+msgstr "Danca"
+
+#: src/LanguageList.cpp
+msgid "Dutch"
+msgstr "Felemenkçe"
+
+#: src/LanguageList.cpp
+msgid "English (U.K.)"
+msgstr "İngilizce (U.K)"
+
+#: src/LanguageList.cpp
+msgid "English (U.S.)"
+msgstr "İngilizce (ABD)"
+
+#: src/LanguageList.cpp
+msgid "Estonian"
+msgstr "Estonca"
+
+#: src/LanguageList.cpp
+msgid "Finnish"
+msgstr "Fince"
+
+#: src/LanguageList.cpp
+msgid "French"
+msgstr "Fransızca"
+
+#: src/LanguageList.cpp
+msgid "Galician"
+msgstr "Galce"
+
+#: src/LanguageList.cpp
+msgid "German"
+msgstr "Almanca"
+
+#: src/LanguageList.cpp
+msgid "Greek"
+msgstr "Yunanca"
+
+#: src/LanguageList.cpp
+msgid "Hebrew"
+msgstr "İbranice"
+
+#: src/LanguageList.cpp
+msgid "Hungarian"
+msgstr "Macarca"
+
+#: src/LanguageList.cpp
+msgid "Italian"
+msgstr "İtalyanca"
+
+#: src/LanguageList.cpp
+msgid "Japanese"
+msgstr "Japonca"
+
+#: src/LanguageList.cpp
+msgid "Korean"
+msgstr "Korece"
+
+#: src/LanguageList.cpp
+msgid "Latvian"
+msgstr "Letonca"
+
+#: src/LanguageList.cpp
+msgid "Lithuanian"
+msgstr "Litvanyaca"
+
+#: src/LanguageList.cpp
+msgid "Norwegian (Nynorsk)"
+msgstr "Norveççe (Nynorsk)"
+
+#: src/LanguageList.cpp
+msgid "Polish"
+msgstr "Lehçe"
+
+#: src/LanguageList.cpp
+msgid "Portuguese"
+msgstr "Portekizce"
+
+#: src/LanguageList.cpp
+msgid "Portuguese (Brazilian)"
+msgstr "Portekizce (Brezilya)"
+
+#: src/LanguageList.cpp
+msgid "Romanian"
+msgstr "Rumence"
+
+#: src/LanguageList.cpp
+msgid "Russian"
+msgstr "Rusça"
+
+#: src/LanguageList.cpp
+msgid "Slovenian"
+msgstr "Slovence"
+
+#: src/LanguageList.cpp
+msgid "Spanish"
+msgstr "İspanyolca"
+
+#: src/LanguageList.cpp
+msgid "Swedish"
+msgstr "İsveççe"
+
+#: src/LanguageList.cpp
+msgid "Turkish"
+msgstr "Türkçe"
+
+#: src/LanguageList.cpp
+msgid "Ukrainian"
+msgstr "Ukraynaca"
+
 #: src/libs/common/Format.cpp
 #, c-format
 msgid "Unknown error %d"
@@ -3181,15 +3373,18 @@ msgstr "Tamamlanıyor"
 msgid "Complete"
 msgstr "Tamamlandı"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Paused"
 msgstr "Duraklatıldı"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Erroneous"
 msgstr "Hatalı"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Waiting"
 msgstr "Bekliyor"
 
@@ -3351,7 +3546,8 @@ msgstr "Kapat"
 msgid "Cut"
 msgstr "Kes"
 
-#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp src/utils/aLinkCreator/src/alcframe.cpp
+#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy"
 msgstr "Kopyala"
 
@@ -3359,7 +3555,8 @@ msgstr "Kopyala"
 msgid "Paste"
 msgstr "Yapıştır"
 
-#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
+#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Clear"
 msgstr "Temizle"
 
@@ -3367,7 +3564,8 @@ msgstr "Temizle"
 msgid "Select All"
 msgstr "Tümünü Seç"
 
-#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp src/StatisticsDlg.cpp
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
+#: src/StatisticsDlg.cpp
 msgid "KiB/s"
 msgstr "KiB/s"
 
@@ -5829,174 +6027,6 @@ msgid "ERROR: Failed to open partfile '%s'"
 msgstr "HATA: Parça dosyası '%s' açılamıyor"
 
 #: src/Preferences.cpp
-msgid "System default"
-msgstr "Sistem öntanımlısı"
-
-#: src/Preferences.cpp
-msgid "Albanian"
-msgstr "Arnavutça"
-
-#: src/Preferences.cpp
-msgid "Arabic"
-msgstr "Arapça"
-
-#: src/Preferences.cpp
-msgid "Asturian"
-msgstr "Asturyasça"
-
-#: src/Preferences.cpp
-msgid "Basque"
-msgstr "Baskça"
-
-#: src/Preferences.cpp
-msgid "Bulgarian"
-msgstr "Bulgarca"
-
-#: src/Preferences.cpp
-msgid "Catalan"
-msgstr "Katalanca"
-
-#: src/Preferences.cpp
-msgid "Chinese (Simplified)"
-msgstr "Çince (Basitleştirilmiş)"
-
-#: src/Preferences.cpp
-msgid "Chinese (Traditional)"
-msgstr "Çince (Geleneksel)"
-
-#: src/Preferences.cpp
-msgid "Croatian"
-msgstr "Hırvatça"
-
-#: src/Preferences.cpp
-msgid "Czech"
-msgstr "Çekçe"
-
-#: src/Preferences.cpp
-msgid "Danish"
-msgstr "Danca"
-
-#: src/Preferences.cpp
-msgid "Dutch"
-msgstr "Felemenkçe"
-
-#: src/Preferences.cpp
-msgid "English (U.K.)"
-msgstr "İngilizce (U.K)"
-
-#: src/Preferences.cpp
-msgid "English (U.S.)"
-msgstr "İngilizce (ABD)"
-
-#: src/Preferences.cpp
-msgid "Estonian"
-msgstr "Estonca"
-
-#: src/Preferences.cpp
-msgid "Finnish"
-msgstr "Fince"
-
-#: src/Preferences.cpp
-msgid "French"
-msgstr "Fransızca"
-
-#: src/Preferences.cpp
-msgid "Galician"
-msgstr "Galce"
-
-#: src/Preferences.cpp
-msgid "German"
-msgstr "Almanca"
-
-#: src/Preferences.cpp
-msgid "Greek"
-msgstr "Yunanca"
-
-#: src/Preferences.cpp
-msgid "Hebrew"
-msgstr "İbranice"
-
-#: src/Preferences.cpp
-msgid "Hungarian"
-msgstr "Macarca"
-
-#: src/Preferences.cpp
-msgid "Italian"
-msgstr "İtalyanca"
-
-#: src/Preferences.cpp
-msgid "Japanese"
-msgstr "Japonca"
-
-#: src/Preferences.cpp
-msgid "Korean"
-msgstr "Korece"
-
-#: src/Preferences.cpp
-msgid "Latvian"
-msgstr "Letonca"
-
-#: src/Preferences.cpp
-msgid "Lithuanian"
-msgstr "Litvanyaca"
-
-#: src/Preferences.cpp
-msgid "Norwegian (Nynorsk)"
-msgstr "Norveççe (Nynorsk)"
-
-#: src/Preferences.cpp
-msgid "Polish"
-msgstr "Lehçe"
-
-#: src/Preferences.cpp
-msgid "Portuguese"
-msgstr "Portekizce"
-
-#: src/Preferences.cpp
-msgid "Portuguese (Brazilian)"
-msgstr "Portekizce (Brezilya)"
-
-#: src/Preferences.cpp
-msgid "Romanian"
-msgstr "Rumence"
-
-#: src/Preferences.cpp
-msgid "Russian"
-msgstr "Rusça"
-
-#: src/Preferences.cpp
-msgid "Slovenian"
-msgstr "Slovence"
-
-#: src/Preferences.cpp
-msgid "Spanish"
-msgstr "İspanyolca"
-
-#: src/Preferences.cpp
-msgid "Swedish"
-msgstr "İsveççe"
-
-#: src/Preferences.cpp
-msgid "Turkish"
-msgstr "Türkçe"
-
-#: src/Preferences.cpp
-msgid "Ukrainian"
-msgstr "Ukraynaca"
-
-#: src/Preferences.cpp
-msgid "Change Language"
-msgstr "Dili Değiştirin"
-
-#: src/Preferences.cpp
-msgid "There are no translations installed for aMule"
-msgstr "aMule tercümeleri kurulu değildir"
-
-#: src/Preferences.cpp
-msgid "No languages available"
-msgstr "Diller mevcut değil"
-
-#: src/Preferences.cpp
 msgid "no options available"
 msgstr "mevcut seçenek yok"
 
@@ -6498,7 +6528,8 @@ msgstr "Bunları yinelemeli olarak paylaşmanız, kapsadıkları her dosyayı eD
 msgid "Confirm shared folders"
 msgstr "Paylaşılan dizinleri teyit et"
 
-#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp src/SharedFilesReloadProgress.cpp
+#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp
+#: src/SharedFilesReloadProgress.cpp
 msgid "Reloading shared files..."
 msgstr "Paylaşılan dosyalar yeniden yükleniyor…"
 
@@ -9228,6 +9259,15 @@ msgstr "aMule çalışmakta gibi görünüyor. Lütfen onu kapatıp kurulum prog
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "Kullanıcı verileri $APPDATA\\aMule konumunda kaldırılıyor…"
+
+#~ msgid "Change Language"
+#~ msgstr "Dili Değiştirin"
+
+#~ msgid "There are no translations installed for aMule"
+#~ msgstr "aMule tercümeleri kurulu değildir"
+
+#~ msgid "No languages available"
+#~ msgstr "Diller mevcut değil"
 
 #~ msgid "User name"
 #~ msgstr "Kullanıcı adı"

--- a/po/uk.po
+++ b/po/uk.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-05 12:01+0200\n"
+"POT-Creation-Date: 2026-09-06 14:35+0200\n"
 "PO-Revision-Date: 2026-09-05 11:02+0000\n"
 "Last-Translator: Oleksandr Kovalenko <alx.kovalenko@gmail.com>\n"
 "Language-Team: Ukrainian <translation@linux.org.ua>\n"
@@ -387,7 +387,8 @@ msgstr "Веб-сервер запущений з %d"
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "Ви встановили запуск веб-сервера під час завантаження, але amuleweb не може бути запущено. Будь ласка, встановіть пакунок, що містить веб-сервер aMule, зберіть aMule з --enable-webserver та виконайте make install"
 
-#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
+#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
+#: src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
 msgid "ERROR"
 msgstr "ПОМИЛКА"
 
@@ -675,7 +676,8 @@ msgstr "Мережі"
 msgid "Searches"
 msgstr "Пошук"
 
-#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/Statistics.cpp
+#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/Statistics.cpp
 msgid "Downloads"
 msgstr "Звантаження"
 
@@ -759,7 +761,9 @@ msgstr "Kad: вимкнена"
 msgid "Core"
 msgstr ""
 
-#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp src/Statistics.cpp
+#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp src/Statistics.cpp
 msgid "Version"
 msgstr "Версія"
 
@@ -1059,7 +1063,11 @@ msgstr ""
 msgid "The remote core sent inconsistent data for \"%s\" (part status %d, expected %d). The file list may be showing the wrong information; reconnect to clear it."
 msgstr ""
 
-#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp src/Statistics.cpp
+#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp
+#: src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp
+#: src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp
+#: src/Statistics.cpp
 msgid "Unknown"
 msgstr "Невідомо"
 
@@ -1159,7 +1167,8 @@ msgstr "Помилка під час збереження файлу known.met: 
 msgid "Enter Captcha"
 msgstr ""
 
-#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp src/TransferWnd.cpp
+#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp
+#: src/TransferWnd.cpp
 msgid "Category"
 msgstr "Категорія"
 
@@ -1329,11 +1338,13 @@ msgstr "Не знайдено 'cryptkey.dat', створюємо."
 msgid "Client Details"
 msgstr "Подробиці клієнта"
 
-#: src/ClientDetailDialog.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
+#: src/utils/wxCas/src/onlinesig.cpp
 msgid "LowID"
 msgstr "LowID"
 
-#: src/ClientDetailDialog.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
+#: src/utils/wxCas/src/onlinesig.cpp
 msgid "HighID"
 msgstr "HighID"
 
@@ -1349,7 +1360,8 @@ msgstr "Підтримується"
 msgid "Not supported"
 msgstr "Не підтримується"
 
-#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp src/TextClient.cpp
+#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
+#: src/TextClient.cpp
 msgid "Connected"
 msgstr "З'єднано"
 
@@ -1357,7 +1369,8 @@ msgstr "З'єднано"
 msgid "Disconnected"
 msgstr "Від'єднана"
 
-#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f KiB/s"
 msgstr ""
@@ -1374,7 +1387,8 @@ msgstr ""
 msgid "IP Address"
 msgstr "IP-адреса"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Origin"
 msgstr ""
 
@@ -1392,12 +1406,14 @@ msgstr "Останнє отримання"
 msgid "Sessions"
 msgstr "Версія"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/SharedFilePeersListCtrl.cpp
 #, fuzzy
 msgid "Upload Speed"
 msgstr "Швидкість вивантаження"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/SharedFilePeersListCtrl.cpp
 #, fuzzy
 msgid "Download Speed"
 msgstr "Швидкість звантаження"
@@ -1454,11 +1470,13 @@ msgstr[2] ""
 msgid "Files"
 msgstr "Файли"
 
-#: src/ClientsListCtrl.cpp src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientsListCtrl.cpp src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp
 msgid "Uploaded"
 msgstr "Вивантажено"
 
-#: src/ClientsListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientsListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Downloaded"
 msgstr "Звантажені"
 
@@ -1549,7 +1567,8 @@ msgstr "Коментарі файлу"
 msgid "Username"
 msgstr "Ім'я користувача"
 
-#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp
+#: src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "File Name"
 msgstr "Назва файлу"
 
@@ -1615,15 +1634,18 @@ msgstr "Авто [висока]"
 msgid "Very low"
 msgstr "Дуже низька"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Low"
 msgstr "Низька"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Normal"
 msgstr "Звичайна"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "High"
 msgstr "Висока"
 
@@ -1647,11 +1669,13 @@ msgstr "З'єднується через сервер"
 msgid "Queue Full"
 msgstr "Черга заповнена"
 
-#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp src/muuli_wdr.cpp
+#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp
+#: src/muuli_wdr.cpp
 msgid "On Queue"
 msgstr "В черзі"
 
-#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
+#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp
+#: src/PartFile.cpp src/TransferWnd.cpp
 msgid "Downloading"
 msgstr "Звантажується"
 
@@ -1712,7 +1736,8 @@ msgstr "Місцевий сервер"
 msgid "Remote Server"
 msgstr "Віддалений сервер"
 
-#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp src/TextClient.cpp
+#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp
+#: src/TextClient.cpp
 msgid "Kad"
 msgstr "Kad"
 
@@ -1736,7 +1761,8 @@ msgstr "Поширювачі джерел"
 msgid "Search Result"
 msgstr "Здобутки пошуку"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp
+#: src/TransferWnd.cpp
 msgid "Completed"
 msgstr "Завершених"
 
@@ -1789,7 +1815,8 @@ msgstr ""
 msgid "Part"
 msgstr "Частина"
 
-#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 msgid "Size"
 msgstr "Розмір"
 
@@ -1797,7 +1824,8 @@ msgstr "Розмір"
 msgid "Transferred"
 msgstr "Переданих"
 
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp src/SourceListCtrl.cpp
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
+#: src/SourceListCtrl.cpp
 msgid "Speed"
 msgstr "Швидкість"
 
@@ -1805,11 +1833,13 @@ msgstr "Швидкість"
 msgid "Progress"
 msgstr "Перебіг"
 
-#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
+#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp
+#: src/SearchListCtrl.cpp
 msgid "Sources"
 msgstr "Джерела"
 
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 msgid "Priority"
 msgstr "Перевага"
 
@@ -1833,7 +1863,9 @@ msgstr "Останнє отримання"
 msgid "Auto"
 msgstr "Автоматично"
 
-#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/TransferWnd.cpp src/utils/wxCas/src/wxcasprefs.cpp
+#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/TransferWnd.cpp
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Cancel"
 msgstr "Скасувати"
 
@@ -1934,7 +1966,8 @@ msgstr "Введіть нову назву для цього файлу:"
 msgid "File rename"
 msgstr "Змінити назву файлу"
 
-#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f MiB/s"
 msgstr ""
@@ -2745,11 +2778,13 @@ msgstr ""
 msgid "Start aMule automatically when I log in"
 msgstr ""
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp packaging/windows/installer_strings.c
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: packaging/windows/installer_strings.c
 msgid "Register aMule for ed2k:// links"
 msgstr ""
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp packaging/windows/installer_strings.c
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: packaging/windows/installer_strings.c
 msgid "Register aMule for magnet: links"
 msgstr ""
 
@@ -2775,7 +2810,8 @@ msgstr ""
 msgid "Destination folder for downloads"
 msgstr "Тека призначення для звантажень"
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Browse"
 msgstr "Переглянути"
 
@@ -3205,6 +3241,165 @@ msgstr ""
 msgid "Invalid entry in known file list, file may be corrupt: "
 msgstr ""
 
+#: src/LanguageList.cpp
+msgid "System default"
+msgstr "Мова системи"
+
+#: src/LanguageList.cpp
+msgid "Albanian"
+msgstr "Албанська"
+
+#: src/LanguageList.cpp
+msgid "Arabic"
+msgstr "Арабська"
+
+#: src/LanguageList.cpp
+#, fuzzy
+msgid "Asturian"
+msgstr "Естонська"
+
+#: src/LanguageList.cpp
+msgid "Basque"
+msgstr "Баскська"
+
+#: src/LanguageList.cpp
+msgid "Bulgarian"
+msgstr "Болгарська"
+
+#: src/LanguageList.cpp
+msgid "Catalan"
+msgstr "Каталонська"
+
+#: src/LanguageList.cpp
+msgid "Chinese (Simplified)"
+msgstr "Китайська (спрощена)"
+
+#: src/LanguageList.cpp
+msgid "Chinese (Traditional)"
+msgstr "Китайська (традиційна)"
+
+#: src/LanguageList.cpp
+msgid "Croatian"
+msgstr "Хорватська"
+
+#: src/LanguageList.cpp
+msgid "Czech"
+msgstr "Чеська"
+
+#: src/LanguageList.cpp
+msgid "Danish"
+msgstr "Данська"
+
+#: src/LanguageList.cpp
+msgid "Dutch"
+msgstr "Нідерландська"
+
+#: src/LanguageList.cpp
+msgid "English (U.K.)"
+msgstr "Англійська (Великобританія)"
+
+#: src/LanguageList.cpp
+#, fuzzy
+msgid "English (U.S.)"
+msgstr "Англійська (Великобританія)"
+
+#: src/LanguageList.cpp
+msgid "Estonian"
+msgstr "Естонська"
+
+#: src/LanguageList.cpp
+msgid "Finnish"
+msgstr "Фінська"
+
+#: src/LanguageList.cpp
+msgid "French"
+msgstr "Французька"
+
+#: src/LanguageList.cpp
+msgid "Galician"
+msgstr "Галісійська"
+
+#: src/LanguageList.cpp
+msgid "German"
+msgstr "Німецька"
+
+#: src/LanguageList.cpp
+msgid "Greek"
+msgstr "Грецька"
+
+#: src/LanguageList.cpp
+msgid "Hebrew"
+msgstr "Іврит"
+
+#: src/LanguageList.cpp
+msgid "Hungarian"
+msgstr "Угорська"
+
+#: src/LanguageList.cpp
+msgid "Italian"
+msgstr "Італійська"
+
+#: src/LanguageList.cpp
+msgid "Japanese"
+msgstr "Японська"
+
+#: src/LanguageList.cpp
+msgid "Korean"
+msgstr "Корейська"
+
+#: src/LanguageList.cpp
+msgid "Latvian"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Lithuanian"
+msgstr "Литовська"
+
+#: src/LanguageList.cpp
+msgid "Norwegian (Nynorsk)"
+msgstr "Норвезька (Нюнорск)"
+
+#: src/LanguageList.cpp
+msgid "Polish"
+msgstr "Польська"
+
+#: src/LanguageList.cpp
+msgid "Portuguese"
+msgstr "Португальська"
+
+#: src/LanguageList.cpp
+msgid "Portuguese (Brazilian)"
+msgstr "Португальська (Бразилія)"
+
+#: src/LanguageList.cpp
+#, fuzzy
+msgid "Romanian"
+msgstr "Албанська"
+
+#: src/LanguageList.cpp
+msgid "Russian"
+msgstr "Російська"
+
+#: src/LanguageList.cpp
+msgid "Slovenian"
+msgstr "Словенська"
+
+#: src/LanguageList.cpp
+msgid "Spanish"
+msgstr "Іспанська"
+
+#: src/LanguageList.cpp
+msgid "Swedish"
+msgstr "Шведська"
+
+#: src/LanguageList.cpp
+msgid "Turkish"
+msgstr "Турецька"
+
+#: src/LanguageList.cpp
+msgid "Ukrainian"
+msgstr "Українська"
+
 #: src/libs/common/Format.cpp
 #, fuzzy, c-format
 msgid "Unknown error %d"
@@ -3227,16 +3422,19 @@ msgstr "Завершується"
 msgid "Complete"
 msgstr "Завершений"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Paused"
 msgstr "Призупинений"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Erroneous"
 msgstr "Помилковий"
 
 # файл
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Waiting"
 msgstr "Очікує"
 
@@ -3406,7 +3604,8 @@ msgstr "Закрити"
 msgid "Cut"
 msgstr "Вирізати"
 
-#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp src/utils/aLinkCreator/src/alcframe.cpp
+#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy"
 msgstr "Скопіювати"
 
@@ -3414,7 +3613,8 @@ msgstr "Скопіювати"
 msgid "Paste"
 msgstr "Вставити"
 
-#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
+#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Clear"
 msgstr "Очистити"
 
@@ -3422,7 +3622,8 @@ msgstr "Очистити"
 msgid "Select All"
 msgstr "Вибрати всі"
 
-#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp src/StatisticsDlg.cpp
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
+#: src/StatisticsDlg.cpp
 msgid "KiB/s"
 msgstr ""
 
@@ -5937,179 +6138,6 @@ msgid "ERROR: Failed to open partfile '%s'"
 msgstr "ПОМИЛКА: не вдалося відкрити частковий файл '%s'"
 
 #: src/Preferences.cpp
-msgid "System default"
-msgstr "Мова системи"
-
-#: src/Preferences.cpp
-msgid "Albanian"
-msgstr "Албанська"
-
-#: src/Preferences.cpp
-msgid "Arabic"
-msgstr "Арабська"
-
-#: src/Preferences.cpp
-#, fuzzy
-msgid "Asturian"
-msgstr "Естонська"
-
-#: src/Preferences.cpp
-msgid "Basque"
-msgstr "Баскська"
-
-#: src/Preferences.cpp
-msgid "Bulgarian"
-msgstr "Болгарська"
-
-#: src/Preferences.cpp
-msgid "Catalan"
-msgstr "Каталонська"
-
-#: src/Preferences.cpp
-msgid "Chinese (Simplified)"
-msgstr "Китайська (спрощена)"
-
-#: src/Preferences.cpp
-msgid "Chinese (Traditional)"
-msgstr "Китайська (традиційна)"
-
-#: src/Preferences.cpp
-msgid "Croatian"
-msgstr "Хорватська"
-
-#: src/Preferences.cpp
-msgid "Czech"
-msgstr "Чеська"
-
-#: src/Preferences.cpp
-msgid "Danish"
-msgstr "Данська"
-
-#: src/Preferences.cpp
-msgid "Dutch"
-msgstr "Нідерландська"
-
-#: src/Preferences.cpp
-msgid "English (U.K.)"
-msgstr "Англійська (Великобританія)"
-
-#: src/Preferences.cpp
-#, fuzzy
-msgid "English (U.S.)"
-msgstr "Англійська (Великобританія)"
-
-#: src/Preferences.cpp
-msgid "Estonian"
-msgstr "Естонська"
-
-#: src/Preferences.cpp
-msgid "Finnish"
-msgstr "Фінська"
-
-#: src/Preferences.cpp
-msgid "French"
-msgstr "Французька"
-
-#: src/Preferences.cpp
-msgid "Galician"
-msgstr "Галісійська"
-
-#: src/Preferences.cpp
-msgid "German"
-msgstr "Німецька"
-
-#: src/Preferences.cpp
-msgid "Greek"
-msgstr "Грецька"
-
-#: src/Preferences.cpp
-msgid "Hebrew"
-msgstr "Іврит"
-
-#: src/Preferences.cpp
-msgid "Hungarian"
-msgstr "Угорська"
-
-#: src/Preferences.cpp
-msgid "Italian"
-msgstr "Італійська"
-
-#: src/Preferences.cpp
-msgid "Japanese"
-msgstr "Японська"
-
-#: src/Preferences.cpp
-msgid "Korean"
-msgstr "Корейська"
-
-#: src/Preferences.cpp
-msgid "Latvian"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Lithuanian"
-msgstr "Литовська"
-
-#: src/Preferences.cpp
-msgid "Norwegian (Nynorsk)"
-msgstr "Норвезька (Нюнорск)"
-
-#: src/Preferences.cpp
-msgid "Polish"
-msgstr "Польська"
-
-#: src/Preferences.cpp
-msgid "Portuguese"
-msgstr "Португальська"
-
-#: src/Preferences.cpp
-msgid "Portuguese (Brazilian)"
-msgstr "Португальська (Бразилія)"
-
-#: src/Preferences.cpp
-#, fuzzy
-msgid "Romanian"
-msgstr "Албанська"
-
-#: src/Preferences.cpp
-msgid "Russian"
-msgstr "Російська"
-
-#: src/Preferences.cpp
-msgid "Slovenian"
-msgstr "Словенська"
-
-#: src/Preferences.cpp
-msgid "Spanish"
-msgstr "Іспанська"
-
-#: src/Preferences.cpp
-msgid "Swedish"
-msgstr "Шведська"
-
-#: src/Preferences.cpp
-msgid "Turkish"
-msgstr "Турецька"
-
-#: src/Preferences.cpp
-msgid "Ukrainian"
-msgstr "Українська"
-
-#: src/Preferences.cpp
-#, fuzzy
-msgid "Change Language"
-msgstr "Мова: "
-
-#: src/Preferences.cpp
-msgid "There are no translations installed for aMule"
-msgstr ""
-
-#: src/Preferences.cpp
-#, fuzzy
-msgid "No languages available"
-msgstr "Недоступний"
-
-#: src/Preferences.cpp
 msgid "no options available"
 msgstr "немає наявних опцій"
 
@@ -6629,7 +6657,8 @@ msgstr ""
 msgid "Confirm shared folders"
 msgstr "Спільні теки"
 
-#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp src/SharedFilesReloadProgress.cpp
+#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp
+#: src/SharedFilesReloadProgress.cpp
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "Перезавантажити ваші спільні файли"
@@ -9408,6 +9437,14 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#, fuzzy
+#~ msgid "Change Language"
+#~ msgstr "Мова: "
+
+#, fuzzy
+#~ msgid "No languages available"
+#~ msgstr "Недоступний"
 
 #~ msgid "User name"
 #~ msgstr "Ім'я користувача"

--- a/po/vi.po
+++ b/po/vi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-05 12:01+0200\n"
+"POT-Creation-Date: 2026-09-06 14:35+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -3104,6 +3104,162 @@ msgstr ""
 msgid "Invalid entry in known file list, file may be corrupt: "
 msgstr ""
 
+#: src/LanguageList.cpp
+msgid "System default"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Albanian"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Arabic"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Asturian"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Basque"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Bulgarian"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Catalan"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Chinese (Simplified)"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Chinese (Traditional)"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Croatian"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Czech"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Danish"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Dutch"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "English (U.K.)"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "English (U.S.)"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Estonian"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Finnish"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "French"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Galician"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "German"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Greek"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Hebrew"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Hungarian"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Italian"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Japanese"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Korean"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Latvian"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Lithuanian"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Norwegian (Nynorsk)"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Polish"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Portuguese"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Portuguese (Brazilian)"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Romanian"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Russian"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Slovenian"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Spanish"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Swedish"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Turkish"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Ukrainian"
+msgstr ""
+
 #: src/libs/common/Format.cpp
 #, c-format
 msgid "Unknown error %d"
@@ -5754,174 +5910,6 @@ msgstr ""
 #: src/PartFile.cpp
 #, c-format
 msgid "ERROR: Failed to open partfile '%s'"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "System default"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Albanian"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Arabic"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Asturian"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Basque"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Bulgarian"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Catalan"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Chinese (Simplified)"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Chinese (Traditional)"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Croatian"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Czech"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Danish"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Dutch"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "English (U.K.)"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "English (U.S.)"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Estonian"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Finnish"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "French"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Galician"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "German"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Greek"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Hebrew"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Hungarian"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Italian"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Japanese"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Korean"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Latvian"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Lithuanian"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Norwegian (Nynorsk)"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Polish"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Portuguese"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Portuguese (Brazilian)"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Romanian"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Russian"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Slovenian"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Spanish"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Swedish"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Turkish"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Ukrainian"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Change Language"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "There are no translations installed for aMule"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "No languages available"
 msgstr ""
 
 #: src/Preferences.cpp

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-05 12:01+0200\n"
+"POT-Creation-Date: 2026-09-06 14:35+0200\n"
 "PO-Revision-Date: 2026-09-05 11:03+0000\n"
 "Last-Translator: Mike Akiba <mike2718@gmail.com>\n"
 "Language-Team: Chinese Simplified <kde-i18n-doc@kde.org>\n"
@@ -389,7 +389,8 @@ msgstr "web 服务器正在运行，pid 为 %d"
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "您要求启动时运行 Web 服务器，但 amuleweb 程序无法运行， 请先安装包含 amule web 服务器的 aMule 包，或者使用 -DBUILD_WEBSERVER=YES 选项从源码构建 aMule 并安装它。"
 
-#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
+#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
+#: src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
 msgid "ERROR"
 msgstr "错误"
 
@@ -675,7 +676,8 @@ msgstr "网络"
 msgid "Searches"
 msgstr "搜索"
 
-#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/Statistics.cpp
+#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/Statistics.cpp
 msgid "Downloads"
 msgstr "下载"
 
@@ -763,7 +765,9 @@ msgstr "Kad: 关闭"
 msgid "Core"
 msgstr "核心"
 
-#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp src/Statistics.cpp
+#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp src/Statistics.cpp
 msgid "Version"
 msgstr "版本"
 
@@ -1060,7 +1064,11 @@ msgstr "无法创建 “%s” 目录用于 “%s” 分类，保留 “%s” 目
 msgid "The remote core sent inconsistent data for \"%s\" (part status %d, expected %d). The file list may be showing the wrong information; reconnect to clear it."
 msgstr "远程核心发送了不一致的 \"%s\" 数据（part 状态 %d，预期 %d）。 文件列表可能显示错误信息；重连清除它。"
 
-#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp src/Statistics.cpp
+#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp
+#: src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp
+#: src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp
+#: src/Statistics.cpp
 msgid "Unknown"
 msgstr "未知"
 
@@ -1157,7 +1165,8 @@ msgstr "保存 %s 文件时发生错误：%s"
 msgid "Enter Captcha"
 msgstr "输入验证码"
 
-#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp src/TransferWnd.cpp
+#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp
+#: src/TransferWnd.cpp
 msgid "Category"
 msgstr "分类"
 
@@ -1320,11 +1329,13 @@ msgstr "文件 'crytkey.dat' 未找到，正在创建。"
 msgid "Client Details"
 msgstr "客户端详细信息"
 
-#: src/ClientDetailDialog.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
+#: src/utils/wxCas/src/onlinesig.cpp
 msgid "LowID"
 msgstr "Low ID"
 
-#: src/ClientDetailDialog.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
+#: src/utils/wxCas/src/onlinesig.cpp
 msgid "HighID"
 msgstr "High ID"
 
@@ -1340,7 +1351,8 @@ msgstr "已支持"
 msgid "Not supported"
 msgstr "不支持"
 
-#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp src/TextClient.cpp
+#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
+#: src/TextClient.cpp
 msgid "Connected"
 msgstr "已连接"
 
@@ -1348,7 +1360,8 @@ msgstr "已连接"
 msgid "Disconnected"
 msgstr "断开连接"
 
-#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f KiB/s"
 msgstr "%.1f KiB/s"
@@ -1365,7 +1378,8 @@ msgstr "软件"
 msgid "IP Address"
 msgstr "IP 地址"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Origin"
 msgstr "来源"
 
@@ -1381,11 +1395,13 @@ msgstr "上次看到"
 msgid "Sessions"
 msgstr "会话"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/SharedFilePeersListCtrl.cpp
 msgid "Upload Speed"
 msgstr "上传速度"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/SharedFilePeersListCtrl.cpp
 msgid "Download Speed"
 msgstr "下载速度"
 
@@ -1436,11 +1452,13 @@ msgstr[1] "无法请求 %u 个所选客户端的共享文件。"
 msgid "Files"
 msgstr "文件"
 
-#: src/ClientsListCtrl.cpp src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientsListCtrl.cpp src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp
 msgid "Uploaded"
 msgstr "已上传"
 
-#: src/ClientsListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientsListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Downloaded"
 msgstr "已下载"
 
@@ -1528,7 +1546,8 @@ msgstr "文件评论"
 msgid "Username"
 msgstr "用户名"
 
-#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp
+#: src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "File Name"
 msgstr "文件名"
 
@@ -1589,15 +1608,18 @@ msgstr "自动 [高]"
 msgid "Very low"
 msgstr "极低"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Low"
 msgstr "低"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Normal"
 msgstr "普通"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "High"
 msgstr "高"
 
@@ -1621,11 +1643,13 @@ msgstr "通过服务器连接中"
 msgid "Queue Full"
 msgstr "队列已满"
 
-#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp src/muuli_wdr.cpp
+#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp
+#: src/muuli_wdr.cpp
 msgid "On Queue"
 msgstr "正在排队"
 
-#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
+#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp
+#: src/PartFile.cpp src/TransferWnd.cpp
 msgid "Downloading"
 msgstr "正在下载"
 
@@ -1685,7 +1709,8 @@ msgstr "本地服务器"
 msgid "Remote Server"
 msgstr "远程服务器"
 
-#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp src/TextClient.cpp
+#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp
+#: src/TextClient.cpp
 msgid "Kad"
 msgstr "Kad"
 
@@ -1709,7 +1734,8 @@ msgstr "资源种子"
 msgid "Search Result"
 msgstr "搜索结果"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp
+#: src/TransferWnd.cpp
 msgid "Completed"
 msgstr "已完成"
 
@@ -1761,7 +1787,8 @@ msgstr "无法在递归共享中修改"
 msgid "Part"
 msgstr "块"
 
-#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 msgid "Size"
 msgstr "大小"
 
@@ -1769,7 +1796,8 @@ msgstr "大小"
 msgid "Transferred"
 msgstr "已传输"
 
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp src/SourceListCtrl.cpp
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
+#: src/SourceListCtrl.cpp
 msgid "Speed"
 msgstr "速度"
 
@@ -1777,11 +1805,13 @@ msgstr "速度"
 msgid "Progress"
 msgstr "进度"
 
-#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
+#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp
+#: src/SearchListCtrl.cpp
 msgid "Sources"
 msgstr "源"
 
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 msgid "Priority"
 msgstr "优先级"
 
@@ -1805,7 +1835,9 @@ msgstr "最后一次下载"
 msgid "Auto"
 msgstr "自动"
 
-#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/TransferWnd.cpp src/utils/wxCas/src/wxcasprefs.cpp
+#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/TransferWnd.cpp
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Cancel"
 msgstr "取消"
 
@@ -1906,7 +1938,8 @@ msgstr "请输入新文件名:"
 msgid "File rename"
 msgstr "重命名文件"
 
-#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f MiB/s"
 msgstr "%.1f MiB/s"
@@ -2709,11 +2742,13 @@ msgstr ""
 msgid "Start aMule automatically when I log in"
 msgstr "登录时自动启动 aMule"
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp packaging/windows/installer_strings.c
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: packaging/windows/installer_strings.c
 msgid "Register aMule for ed2k:// links"
 msgstr "将 aMule 注册为打开 ed2k:// 链接的应用"
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp packaging/windows/installer_strings.c
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: packaging/windows/installer_strings.c
 msgid "Register aMule for magnet: links"
 msgstr "将 aMule 注册为打开 magnet: 链接的应用"
 
@@ -2741,7 +2776,8 @@ msgstr ""
 msgid "Destination folder for downloads"
 msgstr "存放下载文件的文件夹"
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Browse"
 msgstr "浏览"
 
@@ -3163,6 +3199,162 @@ msgstr "在已知文件列表载入条目失败，文件可能损坏"
 msgid "Invalid entry in known file list, file may be corrupt: "
 msgstr "已知文件列表包含非法条目，文件可能损坏："
 
+#: src/LanguageList.cpp
+msgid "System default"
+msgstr "系统默认"
+
+#: src/LanguageList.cpp
+msgid "Albanian"
+msgstr "阿尔巴尼亚语"
+
+#: src/LanguageList.cpp
+msgid "Arabic"
+msgstr "阿拉伯语"
+
+#: src/LanguageList.cpp
+msgid "Asturian"
+msgstr "澳大利亚"
+
+#: src/LanguageList.cpp
+msgid "Basque"
+msgstr "巴斯克语"
+
+#: src/LanguageList.cpp
+msgid "Bulgarian"
+msgstr "保加利亚语"
+
+#: src/LanguageList.cpp
+msgid "Catalan"
+msgstr "加泰罗尼亚语"
+
+#: src/LanguageList.cpp
+msgid "Chinese (Simplified)"
+msgstr "简体中文"
+
+#: src/LanguageList.cpp
+msgid "Chinese (Traditional)"
+msgstr "繁体中文"
+
+#: src/LanguageList.cpp
+msgid "Croatian"
+msgstr "克罗的亚语"
+
+#: src/LanguageList.cpp
+msgid "Czech"
+msgstr "捷克语"
+
+#: src/LanguageList.cpp
+msgid "Danish"
+msgstr "丹麦语"
+
+#: src/LanguageList.cpp
+msgid "Dutch"
+msgstr "荷兰语"
+
+#: src/LanguageList.cpp
+msgid "English (U.K.)"
+msgstr "英语（英国）"
+
+#: src/LanguageList.cpp
+msgid "English (U.S.)"
+msgstr "英语（美国）"
+
+#: src/LanguageList.cpp
+msgid "Estonian"
+msgstr "爱斯托尼亚语"
+
+#: src/LanguageList.cpp
+msgid "Finnish"
+msgstr "芬兰语"
+
+#: src/LanguageList.cpp
+msgid "French"
+msgstr "法语"
+
+#: src/LanguageList.cpp
+msgid "Galician"
+msgstr "加利西亚语"
+
+#: src/LanguageList.cpp
+msgid "German"
+msgstr "德语"
+
+#: src/LanguageList.cpp
+msgid "Greek"
+msgstr "希腊语"
+
+#: src/LanguageList.cpp
+msgid "Hebrew"
+msgstr "希伯来语"
+
+#: src/LanguageList.cpp
+msgid "Hungarian"
+msgstr "匈牙利语"
+
+#: src/LanguageList.cpp
+msgid "Italian"
+msgstr "意大利语"
+
+#: src/LanguageList.cpp
+msgid "Japanese"
+msgstr "日语"
+
+#: src/LanguageList.cpp
+msgid "Korean"
+msgstr "韩语"
+
+#: src/LanguageList.cpp
+msgid "Latvian"
+msgstr "拉脱维亚语"
+
+#: src/LanguageList.cpp
+msgid "Lithuanian"
+msgstr "立陶宛语"
+
+#: src/LanguageList.cpp
+msgid "Norwegian (Nynorsk)"
+msgstr "新挪威语"
+
+#: src/LanguageList.cpp
+msgid "Polish"
+msgstr "芬兰语"
+
+#: src/LanguageList.cpp
+msgid "Portuguese"
+msgstr "葡萄牙语"
+
+#: src/LanguageList.cpp
+msgid "Portuguese (Brazilian)"
+msgstr "葡萄牙语（巴西）"
+
+#: src/LanguageList.cpp
+msgid "Romanian"
+msgstr "罗马尼亚语"
+
+#: src/LanguageList.cpp
+msgid "Russian"
+msgstr "俄语"
+
+#: src/LanguageList.cpp
+msgid "Slovenian"
+msgstr "斯洛文尼亚语"
+
+#: src/LanguageList.cpp
+msgid "Spanish"
+msgstr "西班牙语"
+
+#: src/LanguageList.cpp
+msgid "Swedish"
+msgstr "瑞典语"
+
+#: src/LanguageList.cpp
+msgid "Turkish"
+msgstr "土耳其语"
+
+#: src/LanguageList.cpp
+msgid "Ukrainian"
+msgstr "乌克兰"
+
 #: src/libs/common/Format.cpp
 #, c-format
 msgid "Unknown error %d"
@@ -3185,15 +3377,18 @@ msgstr "即将完成"
 msgid "Complete"
 msgstr "已完成"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Paused"
 msgstr "已暂停"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Erroneous"
 msgstr "已出错"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Waiting"
 msgstr "等待中"
 
@@ -3355,7 +3550,8 @@ msgstr "关闭"
 msgid "Cut"
 msgstr "剪切"
 
-#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp src/utils/aLinkCreator/src/alcframe.cpp
+#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy"
 msgstr "复制"
 
@@ -3363,7 +3559,8 @@ msgstr "复制"
 msgid "Paste"
 msgstr "粘贴"
 
-#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
+#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Clear"
 msgstr "清除"
 
@@ -3371,7 +3568,8 @@ msgstr "清除"
 msgid "Select All"
 msgstr "全选"
 
-#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp src/StatisticsDlg.cpp
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
+#: src/StatisticsDlg.cpp
 msgid "KiB/s"
 msgstr "KiB/s"
 
@@ -5833,174 +6031,6 @@ msgid "ERROR: Failed to open partfile '%s'"
 msgstr "错误：打开part文件'%s'失败"
 
 #: src/Preferences.cpp
-msgid "System default"
-msgstr "系统默认"
-
-#: src/Preferences.cpp
-msgid "Albanian"
-msgstr "阿尔巴尼亚语"
-
-#: src/Preferences.cpp
-msgid "Arabic"
-msgstr "阿拉伯语"
-
-#: src/Preferences.cpp
-msgid "Asturian"
-msgstr "澳大利亚"
-
-#: src/Preferences.cpp
-msgid "Basque"
-msgstr "巴斯克语"
-
-#: src/Preferences.cpp
-msgid "Bulgarian"
-msgstr "保加利亚语"
-
-#: src/Preferences.cpp
-msgid "Catalan"
-msgstr "加泰罗尼亚语"
-
-#: src/Preferences.cpp
-msgid "Chinese (Simplified)"
-msgstr "简体中文"
-
-#: src/Preferences.cpp
-msgid "Chinese (Traditional)"
-msgstr "繁体中文"
-
-#: src/Preferences.cpp
-msgid "Croatian"
-msgstr "克罗的亚语"
-
-#: src/Preferences.cpp
-msgid "Czech"
-msgstr "捷克语"
-
-#: src/Preferences.cpp
-msgid "Danish"
-msgstr "丹麦语"
-
-#: src/Preferences.cpp
-msgid "Dutch"
-msgstr "荷兰语"
-
-#: src/Preferences.cpp
-msgid "English (U.K.)"
-msgstr "英语（英国）"
-
-#: src/Preferences.cpp
-msgid "English (U.S.)"
-msgstr "英语（美国）"
-
-#: src/Preferences.cpp
-msgid "Estonian"
-msgstr "爱斯托尼亚语"
-
-#: src/Preferences.cpp
-msgid "Finnish"
-msgstr "芬兰语"
-
-#: src/Preferences.cpp
-msgid "French"
-msgstr "法语"
-
-#: src/Preferences.cpp
-msgid "Galician"
-msgstr "加利西亚语"
-
-#: src/Preferences.cpp
-msgid "German"
-msgstr "德语"
-
-#: src/Preferences.cpp
-msgid "Greek"
-msgstr "希腊语"
-
-#: src/Preferences.cpp
-msgid "Hebrew"
-msgstr "希伯来语"
-
-#: src/Preferences.cpp
-msgid "Hungarian"
-msgstr "匈牙利语"
-
-#: src/Preferences.cpp
-msgid "Italian"
-msgstr "意大利语"
-
-#: src/Preferences.cpp
-msgid "Japanese"
-msgstr "日语"
-
-#: src/Preferences.cpp
-msgid "Korean"
-msgstr "韩语"
-
-#: src/Preferences.cpp
-msgid "Latvian"
-msgstr "拉脱维亚语"
-
-#: src/Preferences.cpp
-msgid "Lithuanian"
-msgstr "立陶宛语"
-
-#: src/Preferences.cpp
-msgid "Norwegian (Nynorsk)"
-msgstr "新挪威语"
-
-#: src/Preferences.cpp
-msgid "Polish"
-msgstr "芬兰语"
-
-#: src/Preferences.cpp
-msgid "Portuguese"
-msgstr "葡萄牙语"
-
-#: src/Preferences.cpp
-msgid "Portuguese (Brazilian)"
-msgstr "葡萄牙语（巴西）"
-
-#: src/Preferences.cpp
-msgid "Romanian"
-msgstr "罗马尼亚语"
-
-#: src/Preferences.cpp
-msgid "Russian"
-msgstr "俄语"
-
-#: src/Preferences.cpp
-msgid "Slovenian"
-msgstr "斯洛文尼亚语"
-
-#: src/Preferences.cpp
-msgid "Spanish"
-msgstr "西班牙语"
-
-#: src/Preferences.cpp
-msgid "Swedish"
-msgstr "瑞典语"
-
-#: src/Preferences.cpp
-msgid "Turkish"
-msgstr "土耳其语"
-
-#: src/Preferences.cpp
-msgid "Ukrainian"
-msgstr "乌克兰"
-
-#: src/Preferences.cpp
-msgid "Change Language"
-msgstr "更改语言"
-
-#: src/Preferences.cpp
-msgid "There are no translations installed for aMule"
-msgstr "没有为 aMule 安装语言文件"
-
-#: src/Preferences.cpp
-msgid "No languages available"
-msgstr "语言文件不可用"
-
-#: src/Preferences.cpp
 msgid "no options available"
 msgstr "选项不可用"
 
@@ -6502,7 +6532,8 @@ msgstr "递归共享会将每个子文件发布到 eD2k/Kad 网络上。您确�
 msgid "Confirm shared folders"
 msgstr "确认共享的文件夹"
 
-#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp src/SharedFilesReloadProgress.cpp
+#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp
+#: src/SharedFilesReloadProgress.cpp
 msgid "Reloading shared files..."
 msgstr "正重新加载共享文件..."
 
@@ -9229,6 +9260,15 @@ msgstr "aMule 似乎正在运行。请将其关闭并重新运行卸载程序。
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr "正在删除 $APPDATA\\aMule 中的用户数据..."
+
+#~ msgid "Change Language"
+#~ msgstr "更改语言"
+
+#~ msgid "There are no translations installed for aMule"
+#~ msgstr "没有为 aMule 安装语言文件"
+
+#~ msgid "No languages available"
+#~ msgstr "语言文件不可用"
 
 #~ msgid "User name"
 #~ msgstr "用户名"

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-05 12:01+0200\n"
+"POT-Creation-Date: 2026-09-06 14:35+0200\n"
 "PO-Revision-Date: 2026-09-05 11:04+0000\n"
 "Last-Translator: Wayne Su <mstarmstar@gmail.com>\n"
 "Language-Team: \n"
@@ -391,7 +391,8 @@ msgstr "執行中的網站伺服器 pid：%d"
 msgid "You requested to run web server on startup, but the amuleweb binary cannot be run. Please install the package containing aMule web server, or build aMule from source with -DBUILD_WEBSERVER=YES and install it."
 msgstr "您要求啟動時執行網站伺服器，但系統無法執行 amuleweb。請安裝含有 aMule 網站伺服器的套件，或於編譯 aMule 程式碼時加入 --enable-webserver 選項"
 
-#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
+#: src/amule.cpp src/amule-remote-gui.cpp src/DownloadQueue.cpp
+#: src/PrefsUnifiedDlg.cpp src/SearchDlg.cpp
 msgid "ERROR"
 msgstr "錯誤"
 
@@ -679,7 +680,8 @@ msgstr "網路"
 msgid "Searches"
 msgstr "搜尋"
 
-#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/Statistics.cpp
+#: src/amuleDlg.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/Statistics.cpp
 msgid "Downloads"
 msgstr "下載"
 
@@ -763,7 +765,9 @@ msgstr "Kad：關閉"
 msgid "Core"
 msgstr ""
 
-#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp src/Statistics.cpp
+#: src/amuleDlg.cpp src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/ServerListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp src/Statistics.cpp
 msgid "Version"
 msgstr "版本"
 
@@ -1062,7 +1066,11 @@ msgstr "無法建立 %s 目錄 ( %s 分類用)，繼續使用 %s 目錄。"
 msgid "The remote core sent inconsistent data for \"%s\" (part status %d, expected %d). The file list may be showing the wrong information; reconnect to clear it."
 msgstr ""
 
-#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp src/Statistics.cpp
+#: src/amule-remote-gui.cpp src/BaseClient.cpp src/ClientDetailDialog.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/ExternalConn.cpp
+#: src/FileDetailDialog.cpp src/GenericClientListCtrl.cpp src/HTTPDownload.cpp
+#: src/KnownFile.cpp src/MuleTrayIcon.cpp src/PartFile.cpp src/Server.cpp
+#: src/Statistics.cpp
 msgid "Unknown"
 msgstr "不明"
 
@@ -1157,7 +1165,8 @@ msgstr "儲存 %s 時發生錯誤：%s"
 msgid "Enter Captcha"
 msgstr "輸入圖形驗證碼"
 
-#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp src/TransferWnd.cpp
+#: src/CatDialog.cpp src/DownloadListCtrl.cpp src/SearchListCtrl.cpp
+#: src/TransferWnd.cpp
 msgid "Category"
 msgstr "分類"
 
@@ -1315,11 +1324,13 @@ msgstr "找不到 crytkey.dat，正在建立新的。"
 msgid "Client Details"
 msgstr "客戶端詳細資訊"
 
-#: src/ClientDetailDialog.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
+#: src/utils/wxCas/src/onlinesig.cpp
 msgid "LowID"
 msgstr "LowID"
 
-#: src/ClientDetailDialog.cpp src/ServerWnd.cpp src/utils/wxCas/src/onlinesig.cpp
+#: src/ClientDetailDialog.cpp src/ServerWnd.cpp
+#: src/utils/wxCas/src/onlinesig.cpp
 msgid "HighID"
 msgstr "HighID"
 
@@ -1335,7 +1346,8 @@ msgstr "已支援"
 msgid "Not supported"
 msgstr "不支援"
 
-#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp src/TextClient.cpp
+#: src/ClientDetailDialog.cpp src/MuleTrayIcon.cpp src/ServerWnd.cpp
+#: src/TextClient.cpp
 msgid "Connected"
 msgstr "已連線"
 
@@ -1343,7 +1355,8 @@ msgstr "已連線"
 msgid "Disconnected"
 msgstr "已中斷連線"
 
-#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/ClientDetailDialog.cpp src/DownloadListCtrl.cpp
+#: src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f KiB/s"
 msgstr ""
@@ -1361,7 +1374,8 @@ msgstr ""
 msgid "IP Address"
 msgstr "IP 位址︰"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Origin"
 msgstr "來源"
 
@@ -1379,11 +1393,13 @@ msgstr "最後一次下載"
 msgid "Sessions"
 msgstr "版本"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/SharedFilePeersListCtrl.cpp
 msgid "Upload Speed"
 msgstr "上傳速度"
 
-#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp src/SharedFilePeersListCtrl.cpp
+#: src/ClientHistoryListCtrl.cpp src/ClientsListCtrl.cpp
+#: src/SharedFilePeersListCtrl.cpp
 msgid "Download Speed"
 msgstr "下載速度"
 
@@ -1437,11 +1453,13 @@ msgstr[0] ""
 msgid "Files"
 msgstr "檔案"
 
-#: src/ClientsListCtrl.cpp src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientsListCtrl.cpp src/KnownFile.cpp src/SharedFilePeersListCtrl.cpp
+#: src/SourceListCtrl.cpp
 msgid "Uploaded"
 msgstr "已上傳"
 
-#: src/ClientsListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
+#: src/ClientsListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
+#: src/SharedFilePeersListCtrl.cpp src/SourceListCtrl.cpp
 msgid "Downloaded"
 msgstr "已下載"
 
@@ -1532,7 +1550,8 @@ msgstr "檔案註解"
 msgid "Username"
 msgstr "使用者名稱"
 
-#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/CommentDialogLst.cpp src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp
+#: src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "File Name"
 msgstr "檔案名稱"
 
@@ -1593,15 +1612,18 @@ msgstr "自動 [高]"
 msgid "Very low"
 msgstr "極低"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Low"
 msgstr "低"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Normal"
 msgstr "普通"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "High"
 msgstr "高"
 
@@ -1625,11 +1647,13 @@ msgstr "正在經伺服器連線"
 msgid "Queue Full"
 msgstr "等候區已滿"
 
-#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp src/muuli_wdr.cpp
+#: src/DataToText.cpp src/GenericClientListCtrl.cpp src/KnownFile.cpp
+#: src/muuli_wdr.cpp
 msgid "On Queue"
 msgstr "等候中"
 
-#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
+#: src/DataToText.cpp src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp
+#: src/PartFile.cpp src/TransferWnd.cpp
 msgid "Downloading"
 msgstr "正在下載"
 
@@ -1689,7 +1713,8 @@ msgstr "本地伺服器"
 msgid "Remote Server"
 msgstr "遠端伺服器"
 
-#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp src/TextClient.cpp
+#: src/DataToText.cpp src/KadDlg.cpp src/muuli_wdr.cpp src/SearchDlg.cpp
+#: src/TextClient.cpp
 msgid "Kad"
 msgstr "Kad"
 
@@ -1713,7 +1738,8 @@ msgstr "來源種子"
 msgid "Search Result"
 msgstr "搜尋結果"
 
-#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp src/TransferWnd.cpp
+#: src/DataToText.cpp src/DownloadListCtrl.cpp src/OtherFunctions.cpp
+#: src/TransferWnd.cpp
 msgid "Completed"
 msgstr "已完成"
 
@@ -1766,7 +1792,8 @@ msgstr ""
 msgid "Part"
 msgstr "部份"
 
-#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/PartFileConvertDlg.cpp src/SearchListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 msgid "Size"
 msgstr "大小"
 
@@ -1774,7 +1801,8 @@ msgstr "大小"
 msgid "Transferred"
 msgstr "已傳輸"
 
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp src/SourceListCtrl.cpp
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/SharedFilesCtrl.cpp
+#: src/SourceListCtrl.cpp
 msgid "Speed"
 msgstr "速度"
 
@@ -1782,11 +1810,13 @@ msgstr "速度"
 msgid "Progress"
 msgstr "進度"
 
-#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp src/SearchListCtrl.cpp
+#: src/DownloadListCtrl.cpp src/FileDetailListCtrl.cpp src/PartFile.cpp
+#: src/SearchListCtrl.cpp
 msgid "Sources"
 msgstr "來源"
 
-#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 msgid "Priority"
 msgstr "優先等級"
 
@@ -1810,7 +1840,9 @@ msgstr "最後一次下載"
 msgid "Auto"
 msgstr "自動"
 
-#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp src/ServerListCtrl.cpp src/TransferWnd.cpp src/utils/wxCas/src/wxcasprefs.cpp
+#: src/DownloadListCtrl.cpp src/FriendListCtrl.cpp src/muuli_wdr.cpp
+#: src/ServerListCtrl.cpp src/TransferWnd.cpp
+#: src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Cancel"
 msgstr "取消"
 
@@ -1911,7 +1943,8 @@ msgstr "請輸入新檔案名稱："
 msgid "File rename"
 msgstr "更改檔名"
 
-#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp src/SharedFilesCtrl.cpp
+#: src/DownloadListCtrl.cpp src/GenericClientListCtrl.cpp
+#: src/SharedFilesCtrl.cpp
 #, c-format
 msgid "%.1f MiB/s"
 msgstr ""
@@ -2714,11 +2747,13 @@ msgstr ""
 msgid "Start aMule automatically when I log in"
 msgstr ""
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp packaging/windows/installer_strings.c
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: packaging/windows/installer_strings.c
 msgid "Register aMule for ed2k:// links"
 msgstr ""
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp packaging/windows/installer_strings.c
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: packaging/windows/installer_strings.c
 msgid "Register aMule for magnet: links"
 msgstr ""
 
@@ -2744,7 +2779,8 @@ msgstr ""
 msgid "Destination folder for downloads"
 msgstr "下載資料夾"
 
-#: src/FirstRunWizard.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
+#: src/FirstRunWizard.cpp src/muuli_wdr.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp src/utils/wxCas/src/wxcasprefs.cpp
 msgid "Browse"
 msgstr "瀏覽"
 
@@ -3160,6 +3196,163 @@ msgstr "無法載入已知檔案清單內的項目，檔案可能有損壞"
 msgid "Invalid entry in known file list, file may be corrupt: "
 msgstr "已知檔案清單內有無效的項目，檔案可能有損壞： "
 
+#: src/LanguageList.cpp
+msgid "System default"
+msgstr "系統預設"
+
+#: src/LanguageList.cpp
+msgid "Albanian"
+msgstr "阿爾巴尼亞語"
+
+#: src/LanguageList.cpp
+msgid "Arabic"
+msgstr "阿拉伯語"
+
+#: src/LanguageList.cpp
+msgid "Asturian"
+msgstr "奧地利語"
+
+#: src/LanguageList.cpp
+msgid "Basque"
+msgstr "巴斯克語"
+
+#: src/LanguageList.cpp
+msgid "Bulgarian"
+msgstr "保加利亞語"
+
+#: src/LanguageList.cpp
+msgid "Catalan"
+msgstr "加泰隆尼亞語"
+
+#: src/LanguageList.cpp
+msgid "Chinese (Simplified)"
+msgstr "簡體中文"
+
+#: src/LanguageList.cpp
+msgid "Chinese (Traditional)"
+msgstr "正體中文"
+
+#: src/LanguageList.cpp
+msgid "Croatian"
+msgstr "克羅埃西亞語"
+
+#: src/LanguageList.cpp
+msgid "Czech"
+msgstr "捷克語"
+
+#: src/LanguageList.cpp
+msgid "Danish"
+msgstr "丹麥語"
+
+#: src/LanguageList.cpp
+msgid "Dutch"
+msgstr "荷蘭語"
+
+#: src/LanguageList.cpp
+msgid "English (U.K.)"
+msgstr "英語 (英國)"
+
+#: src/LanguageList.cpp
+#, fuzzy
+msgid "English (U.S.)"
+msgstr "英語 (英國)"
+
+#: src/LanguageList.cpp
+msgid "Estonian"
+msgstr "愛沙尼亞語"
+
+#: src/LanguageList.cpp
+msgid "Finnish"
+msgstr "芬蘭語"
+
+#: src/LanguageList.cpp
+msgid "French"
+msgstr "法語"
+
+#: src/LanguageList.cpp
+msgid "Galician"
+msgstr "加利西亞語"
+
+#: src/LanguageList.cpp
+msgid "German"
+msgstr "德語"
+
+#: src/LanguageList.cpp
+msgid "Greek"
+msgstr "希臘語"
+
+#: src/LanguageList.cpp
+msgid "Hebrew"
+msgstr "希伯來語"
+
+#: src/LanguageList.cpp
+msgid "Hungarian"
+msgstr "匈牙利語"
+
+#: src/LanguageList.cpp
+msgid "Italian"
+msgstr "義大利語"
+
+#: src/LanguageList.cpp
+msgid "Japanese"
+msgstr "日語"
+
+#: src/LanguageList.cpp
+msgid "Korean"
+msgstr "韓語"
+
+#: src/LanguageList.cpp
+msgid "Latvian"
+msgstr ""
+
+#: src/LanguageList.cpp
+msgid "Lithuanian"
+msgstr "立陶宛語"
+
+#: src/LanguageList.cpp
+msgid "Norwegian (Nynorsk)"
+msgstr "新挪威語"
+
+#: src/LanguageList.cpp
+msgid "Polish"
+msgstr "波蘭語"
+
+#: src/LanguageList.cpp
+msgid "Portuguese"
+msgstr "葡萄牙語"
+
+#: src/LanguageList.cpp
+msgid "Portuguese (Brazilian)"
+msgstr "葡萄牙語 (巴西)"
+
+#: src/LanguageList.cpp
+msgid "Romanian"
+msgstr "羅馬尼亞語"
+
+#: src/LanguageList.cpp
+msgid "Russian"
+msgstr "俄語"
+
+#: src/LanguageList.cpp
+msgid "Slovenian"
+msgstr "斯洛維尼亞語"
+
+#: src/LanguageList.cpp
+msgid "Spanish"
+msgstr "西班牙語"
+
+#: src/LanguageList.cpp
+msgid "Swedish"
+msgstr "瑞典語"
+
+#: src/LanguageList.cpp
+msgid "Turkish"
+msgstr "土耳其語"
+
+#: src/LanguageList.cpp
+msgid "Ukrainian"
+msgstr "烏克蘭語"
+
 #: src/libs/common/Format.cpp
 #, c-format
 msgid "Unknown error %d"
@@ -3182,15 +3375,18 @@ msgstr "正在完成"
 msgid "Complete"
 msgstr "完成"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Paused"
 msgstr "已暫停"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Erroneous"
 msgstr "錯誤的"
 
-#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp src/TransferWnd.cpp
+#: src/libs/ec/cpp/ECSpecialTags.cpp src/OtherFunctions.cpp src/PartFile.cpp
+#: src/TransferWnd.cpp
 msgid "Waiting"
 msgstr "正在等候"
 
@@ -3350,7 +3546,8 @@ msgstr "關閉"
 msgid "Cut"
 msgstr "剪下"
 
-#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp src/utils/aLinkCreator/src/alcframe.cpp
+#: src/MuleTextCtrl.cpp src/PartFileConvert.cpp src/ServerWnd.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Copy"
 msgstr "複製"
 
@@ -3358,7 +3555,8 @@ msgstr "複製"
 msgid "Paste"
 msgstr "貼上"
 
-#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp src/utils/aLinkCreator/src/alcframe.cpp
+#: src/MuleTextCtrl.cpp src/muuli_wdr.cpp
+#: src/utils/aLinkCreator/src/alcframe.cpp
 msgid "Clear"
 msgstr "清除"
 
@@ -3366,7 +3564,8 @@ msgstr "清除"
 msgid "Select All"
 msgstr "全選"
 
-#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp src/StatisticsDlg.cpp
+#: src/MuleTrayIcon.cpp src/muuli_wdr.cpp src/OtherFunctions.cpp
+#: src/StatisticsDlg.cpp
 msgid "KiB/s"
 msgstr ""
 
@@ -5860,175 +6059,6 @@ msgid "ERROR: Failed to open partfile '%s'"
 msgstr "錯誤：無法開啟暫存檔 %s"
 
 #: src/Preferences.cpp
-msgid "System default"
-msgstr "系統預設"
-
-#: src/Preferences.cpp
-msgid "Albanian"
-msgstr "阿爾巴尼亞語"
-
-#: src/Preferences.cpp
-msgid "Arabic"
-msgstr "阿拉伯語"
-
-#: src/Preferences.cpp
-msgid "Asturian"
-msgstr "奧地利語"
-
-#: src/Preferences.cpp
-msgid "Basque"
-msgstr "巴斯克語"
-
-#: src/Preferences.cpp
-msgid "Bulgarian"
-msgstr "保加利亞語"
-
-#: src/Preferences.cpp
-msgid "Catalan"
-msgstr "加泰隆尼亞語"
-
-#: src/Preferences.cpp
-msgid "Chinese (Simplified)"
-msgstr "簡體中文"
-
-#: src/Preferences.cpp
-msgid "Chinese (Traditional)"
-msgstr "正體中文"
-
-#: src/Preferences.cpp
-msgid "Croatian"
-msgstr "克羅埃西亞語"
-
-#: src/Preferences.cpp
-msgid "Czech"
-msgstr "捷克語"
-
-#: src/Preferences.cpp
-msgid "Danish"
-msgstr "丹麥語"
-
-#: src/Preferences.cpp
-msgid "Dutch"
-msgstr "荷蘭語"
-
-#: src/Preferences.cpp
-msgid "English (U.K.)"
-msgstr "英語 (英國)"
-
-#: src/Preferences.cpp
-#, fuzzy
-msgid "English (U.S.)"
-msgstr "英語 (英國)"
-
-#: src/Preferences.cpp
-msgid "Estonian"
-msgstr "愛沙尼亞語"
-
-#: src/Preferences.cpp
-msgid "Finnish"
-msgstr "芬蘭語"
-
-#: src/Preferences.cpp
-msgid "French"
-msgstr "法語"
-
-#: src/Preferences.cpp
-msgid "Galician"
-msgstr "加利西亞語"
-
-#: src/Preferences.cpp
-msgid "German"
-msgstr "德語"
-
-#: src/Preferences.cpp
-msgid "Greek"
-msgstr "希臘語"
-
-#: src/Preferences.cpp
-msgid "Hebrew"
-msgstr "希伯來語"
-
-#: src/Preferences.cpp
-msgid "Hungarian"
-msgstr "匈牙利語"
-
-#: src/Preferences.cpp
-msgid "Italian"
-msgstr "義大利語"
-
-#: src/Preferences.cpp
-msgid "Japanese"
-msgstr "日語"
-
-#: src/Preferences.cpp
-msgid "Korean"
-msgstr "韓語"
-
-#: src/Preferences.cpp
-msgid "Latvian"
-msgstr ""
-
-#: src/Preferences.cpp
-msgid "Lithuanian"
-msgstr "立陶宛語"
-
-#: src/Preferences.cpp
-msgid "Norwegian (Nynorsk)"
-msgstr "新挪威語"
-
-#: src/Preferences.cpp
-msgid "Polish"
-msgstr "波蘭語"
-
-#: src/Preferences.cpp
-msgid "Portuguese"
-msgstr "葡萄牙語"
-
-#: src/Preferences.cpp
-msgid "Portuguese (Brazilian)"
-msgstr "葡萄牙語 (巴西)"
-
-#: src/Preferences.cpp
-msgid "Romanian"
-msgstr "羅馬尼亞語"
-
-#: src/Preferences.cpp
-msgid "Russian"
-msgstr "俄語"
-
-#: src/Preferences.cpp
-msgid "Slovenian"
-msgstr "斯洛維尼亞語"
-
-#: src/Preferences.cpp
-msgid "Spanish"
-msgstr "西班牙語"
-
-#: src/Preferences.cpp
-msgid "Swedish"
-msgstr "瑞典語"
-
-#: src/Preferences.cpp
-msgid "Turkish"
-msgstr "土耳其語"
-
-#: src/Preferences.cpp
-msgid "Ukrainian"
-msgstr "烏克蘭語"
-
-#: src/Preferences.cpp
-msgid "Change Language"
-msgstr "變更語言"
-
-#: src/Preferences.cpp
-msgid "There are no translations installed for aMule"
-msgstr "沒有已安裝的 aMule 翻譯"
-
-#: src/Preferences.cpp
-msgid "No languages available"
-msgstr "沒有可用的語言"
-
-#: src/Preferences.cpp
 msgid "no options available"
 msgstr "沒有選項"
 
@@ -6536,7 +6566,8 @@ msgstr ""
 msgid "Confirm shared folders"
 msgstr "分享資料夾"
 
-#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp src/SharedFilesReloadProgress.cpp
+#: src/PrefsUnifiedDlg.cpp src/SharedFileList.cpp
+#: src/SharedFilesReloadProgress.cpp
 #, fuzzy
 msgid "Reloading shared files..."
 msgstr "重新載入分享的檔案"
@@ -9250,6 +9281,15 @@ msgstr ""
 #: packaging/windows/installer_strings.c
 msgid "Removing user data at $APPDATA\\aMule..."
 msgstr ""
+
+#~ msgid "Change Language"
+#~ msgstr "變更語言"
+
+#~ msgid "There are no translations installed for aMule"
+#~ msgstr "沒有已安裝的 aMule 翻譯"
+
+#~ msgid "No languages available"
+#~ msgstr "沒有可用的語言"
 
 #~ msgid "User name"
 #~ msgstr "使用者名稱"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -764,6 +764,10 @@ if (NEED_LIB_MULEAPPCOMMON)
 		ED2KLink.cpp
 		Friend.cpp
 		GapList.cpp
+		# Here rather than in COMMON_SOURCES: nothing in the language table
+		# varies with the per-target defines, so amule, amuled and amulegui
+		# share one object instead of each compiling their own.
+		LanguageList.cpp
 		MagnetURI.cpp
 		MemFile.cpp
 		# Lives here rather than in muleappgui because InitCommon expands

--- a/src/LanguageList.cpp
+++ b/src/LanguageList.cpp
@@ -1,0 +1,126 @@
+//
+// This file is part of the aMule Project.
+//
+// Copyright (c) 2003-2026 aMule Team ( https://amule-org.github.io )
+//
+// Any parts of this program derived from the xMule, lMule or eMule project,
+// or contributed by third-party developers are copyrighted by their
+// respective authors.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301, USA
+//
+
+#include "LanguageList.h"
+
+#include "OtherFunctions.h" // Needed for StrLang2wx
+
+#include <common/Macros.h> // Needed for itemsof
+
+#include <wx/intl.h>
+
+/**
+ * The languages aMule has a translation for.
+ *
+ * The catalog column is the po/ basename, which is also the directory the catalog
+ * installs into. It is spelled out rather than derived from the wx language id
+ * because for three languages the two differ: wx canonicalises wxLANGUAGE_ESTONIAN
+ * to "et", wxLANGUAGE_KOREAN to "ko" and wxLANGUAGE_PORTUGUESE to "pt", while the
+ * catalogs live in et_EE, ko_KR and pt_PT.
+ */
+static const SLanguageEntry s_languages[] = {
+	{ wxLANGUAGE_DEFAULT, "", wxTRANSLATE("System default") },
+	{ wxLANGUAGE_ALBANIAN, "sq", wxTRANSLATE("Albanian") },
+	{ wxLANGUAGE_ARABIC, "ar", wxTRANSLATE("Arabic") },
+	{ wxLANGUAGE_ASTURIAN, "ast", wxTRANSLATE("Asturian") },
+	{ wxLANGUAGE_BASQUE, "eu", wxTRANSLATE("Basque") },
+	{ wxLANGUAGE_BULGARIAN, "bg", wxTRANSLATE("Bulgarian") },
+	{ wxLANGUAGE_CATALAN, "ca", wxTRANSLATE("Catalan") },
+	{ wxLANGUAGE_CHINESE_SIMPLIFIED, "zh_CN", wxTRANSLATE("Chinese (Simplified)") },
+	{ wxLANGUAGE_CHINESE_TRADITIONAL, "zh_TW", wxTRANSLATE("Chinese (Traditional)") },
+	{ wxLANGUAGE_CROATIAN, "hr", wxTRANSLATE("Croatian") },
+	{ wxLANGUAGE_CZECH, "cs", wxTRANSLATE("Czech") },
+	{ wxLANGUAGE_DANISH, "da", wxTRANSLATE("Danish") },
+	{ wxLANGUAGE_DUTCH, "nl", wxTRANSLATE("Dutch") },
+	{ wxLANGUAGE_ENGLISH_UK, "en_GB", wxTRANSLATE("English (U.K.)") },
+	// The .pot source language: the msgids are the translation, so no catalog ships.
+	{ wxLANGUAGE_ENGLISH_US, "", wxTRANSLATE("English (U.S.)") },
+	{ wxLANGUAGE_ESTONIAN, "et_EE", wxTRANSLATE("Estonian") },
+	{ wxLANGUAGE_FINNISH, "fi", wxTRANSLATE("Finnish") },
+	{ wxLANGUAGE_FRENCH, "fr", wxTRANSLATE("French") },
+	{ wxLANGUAGE_GALICIAN, "gl", wxTRANSLATE("Galician") },
+	{ wxLANGUAGE_GERMAN, "de", wxTRANSLATE("German") },
+	{ wxLANGUAGE_GREEK, "el", wxTRANSLATE("Greek") },
+	{ wxLANGUAGE_HEBREW, "he", wxTRANSLATE("Hebrew") },
+	{ wxLANGUAGE_HUNGARIAN, "hu", wxTRANSLATE("Hungarian") },
+	{ wxLANGUAGE_ITALIAN, "it", wxTRANSLATE("Italian") },
+	{ wxLANGUAGE_JAPANESE, "ja", wxTRANSLATE("Japanese") },
+	{ wxLANGUAGE_KOREAN, "ko_KR", wxTRANSLATE("Korean") },
+	{ wxLANGUAGE_LATVIAN, "lv", wxTRANSLATE("Latvian") },
+	{ wxLANGUAGE_LITHUANIAN, "lt", wxTRANSLATE("Lithuanian") },
+	{ wxLANGUAGE_NORWEGIAN_NYNORSK, "nn", wxTRANSLATE("Norwegian (Nynorsk)") },
+	{ wxLANGUAGE_POLISH, "pl", wxTRANSLATE("Polish") },
+	{ wxLANGUAGE_PORTUGUESE, "pt_PT", wxTRANSLATE("Portuguese") },
+	{ wxLANGUAGE_PORTUGUESE_BRAZILIAN, "pt_BR", wxTRANSLATE("Portuguese (Brazilian)") },
+	{ wxLANGUAGE_ROMANIAN, "ro", wxTRANSLATE("Romanian") },
+	{ wxLANGUAGE_RUSSIAN, "ru", wxTRANSLATE("Russian") },
+	{ wxLANGUAGE_SLOVENIAN, "sl", wxTRANSLATE("Slovenian") },
+	{ wxLANGUAGE_SPANISH, "es", wxTRANSLATE("Spanish") },
+	{ wxLANGUAGE_SWEDISH, "sv", wxTRANSLATE("Swedish") },
+	{ wxLANGUAGE_TURKISH, "tr", wxTRANSLATE("Turkish") },
+	{ wxLANGUAGE_UKRAINIAN, "uk", wxTRANSLATE("Ukrainian") },
+};
+
+const SLanguageEntry *GetLanguageList(std::size_t &count)
+{
+	count = itemsof(s_languages);
+
+	return s_languages;
+}
+
+int FindLanguageEntry(const wxString &languageID)
+{
+	const int wxId = StrLang2wx(languageID);
+
+	std::size_t count = 0;
+	const SLanguageEntry *languages = GetLanguageList(count);
+	for (std::size_t i = 0; i < count; ++i) {
+		// A stored value can spell the same language two ways. The picker writes the
+		// entry's own id, so Estonian is saved as "et", but a config written by hand,
+		// carried over from another install, or copied from the form amulecmd's -l
+		// option documents can carry the territory the catalog directory uses,
+		// "et_EE". Both name this entry, and matching only the first left the picker
+		// unable to find the current language and liable to reset it.
+		if (languages[i].wxId == wxId) {
+			return static_cast<int>(i);
+		}
+
+		if (*languages[i].catalog && StrLang2wx(languages[i].catalog) == wxId) {
+			return static_cast<int>(i);
+		}
+	}
+
+	return -1;
+}
+
+bool IsLanguageAvailable(const SLanguageEntry &entry, const wxArrayString &installed)
+{
+	// "System default" follows the OS and the source language is the msgids
+	// themselves, so neither has a catalog to look for.
+	if (!*entry.catalog) {
+		return true;
+	}
+
+	return installed.Index(entry.catalog) != wxNOT_FOUND;
+}

--- a/src/LanguageList.h
+++ b/src/LanguageList.h
@@ -1,0 +1,83 @@
+//
+// This file is part of the aMule Project.
+//
+// Copyright (c) 2003-2026 aMule Team ( https://amule-org.github.io )
+//
+// Any parts of this program derived from the xMule, lMule or eMule project,
+// or contributed by third-party developers are copyrighted by their
+// respective authors.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301, USA
+//
+
+#ifndef LANGUAGELIST_H
+#define LANGUAGELIST_H
+
+#include <wx/arrstr.h>
+#include <wx/string.h>
+
+#include <cstddef>
+
+/**
+ * One language offered by the Preferences language picker.
+ */
+struct SLanguageEntry
+{
+	//! wx language id. This is what ends up in the /eMule/Language config key,
+	//! spelled by wxLang2Str(), and what InitLocale() is handed on startup.
+	int wxId;
+	//! Catalog name: po/<catalog>.po in the source tree, installed as
+	//! <catalog>/LC_MESSAGES/amule.mo. Empty for the entries that ship no catalog.
+	//!
+	//! This is stored rather than derived from wxId because the two disagree:
+	//! wxLocale::GetLanguageInfo(wxLANGUAGE_ESTONIAN)->CanonicalName is "et" while
+	//! the catalog directory is "et_EE". Deriving it silently loses Estonian,
+	//! Korean and Portuguese.
+	const char *catalog;
+	//! English display name, run through wxGetTranslation() when shown.
+	const char *name;
+};
+
+/**
+ * The languages aMule ships a translation for.
+ *
+ * Add new languages here, with the po/<catalog>.po that carries them.
+ * LanguageListTest keeps this list and po/ in step.
+ *
+ * @param count Receives the number of entries.
+ * @return The entries, starting with "System default".
+ */
+const SLanguageEntry *GetLanguageList(std::size_t &count);
+
+/**
+ * Finds the entry a stored /eMule/Language value names.
+ *
+ * @param languageID The stored value, as written by wxLang2Str().
+ * @return Index into GetLanguageList(), or -1 when nothing matches.
+ */
+int FindLanguageEntry(const wxString &languageID);
+
+/**
+ * Tells whether an entry's translation is installed.
+ *
+ * @param entry The entry to check.
+ * @param installed Catalog names present on disk, as returned by
+ *                  wxTranslations::GetAvailableTranslations().
+ * @return true when the entry can be offered. Entries without a catalog
+ *         ("System default" and the source language) are always available.
+ */
+bool IsLanguageAvailable(const SLanguageEntry &entry, const wxArrayString &installed);
+
+#endif /* LANGUAGELIST_H */

--- a/src/Preferences.cpp
+++ b/src/Preferences.cpp
@@ -37,7 +37,6 @@
 #include <wx/stdpaths.h>
 #include <wx/stopwatch.h>
 #include <wx/tokenzr.h>
-#include <wx/utils.h> // Needed for wxBusyCursor
 
 #include "amule.h"
 #include "FileArea.h" // Needed to push MMapEnabled into CFileArea
@@ -55,10 +54,13 @@
 #include "UserEvents.h"
 
 #ifndef AMULE_DAEMON
+#include <wx/translation.h> // Needed for wxTranslations
 #include <wx/valgen.h>
+#include "LanguageList.h"
 #include "muuli_wdr.h"
 #include "StatisticsDlg.h"
 #include "MuleColour.h"
+#include <vector> // Needed for the language picker's entry list
 #endif
 
 #ifndef CLIENT_GUI
@@ -91,7 +93,6 @@ CProxyData CPreferences::s_ProxyData;
 
 /* The rest, organize it! */
 wxString CPreferences::s_nick;
-Cfg_Lang_Base *CPreferences::s_cfgLang;
 uint32 CPreferences::s_maxupload;
 uint32 CPreferences::s_maxdownload;
 uint32 CPreferences::s_slotallocation;
@@ -688,114 +689,15 @@ private:
 	long int m_default;
 };
 
-typedef struct
-{
-	int id;
-	bool available;
-	wxString displayname;
-	wxString name;
-} LangInfo;
-
-/**
- * The languages aMule has translation for.
- *
- * Add new languages here.
- * Then activate the test code in Cfg_Lang::UpdateChoice below!
- */
-static LangInfo aMuleLanguages[] = {
-	{ wxLANGUAGE_DEFAULT, true, "", wxTRANSLATE("System default") },
-	{ wxLANGUAGE_ALBANIAN, false, "", wxTRANSLATE("Albanian") },
-	{ wxLANGUAGE_ARABIC, false, "", wxTRANSLATE("Arabic") },
-	{ wxLANGUAGE_ASTURIAN, false, "", wxTRANSLATE("Asturian") },
-	{ wxLANGUAGE_BASQUE, false, "", wxTRANSLATE("Basque") },
-	{ wxLANGUAGE_BULGARIAN, false, "", wxTRANSLATE("Bulgarian") },
-	{ wxLANGUAGE_CATALAN, false, "", wxTRANSLATE("Catalan") },
-	{ wxLANGUAGE_CHINESE_SIMPLIFIED, false, "", wxTRANSLATE("Chinese (Simplified)") },
-	{ wxLANGUAGE_CHINESE_TRADITIONAL, false, "", wxTRANSLATE("Chinese (Traditional)") },
-	{ wxLANGUAGE_CROATIAN, false, "", wxTRANSLATE("Croatian") },
-	{ wxLANGUAGE_CZECH, false, "", wxTRANSLATE("Czech") },
-	{ wxLANGUAGE_DANISH, false, "", wxTRANSLATE("Danish") },
-	{ wxLANGUAGE_DUTCH, false, "", wxTRANSLATE("Dutch") },
-	{ wxLANGUAGE_ENGLISH_UK, false, "", wxTRANSLATE("English (U.K.)") },
-	{ wxLANGUAGE_ENGLISH_US, false, "", wxTRANSLATE("English (U.S.)") },
-	{ wxLANGUAGE_ESTONIAN, false, "", wxTRANSLATE("Estonian") },
-	{ wxLANGUAGE_FINNISH, false, "", wxTRANSLATE("Finnish") },
-	{ wxLANGUAGE_FRENCH, false, "", wxTRANSLATE("French") },
-	{ wxLANGUAGE_GALICIAN, false, "", wxTRANSLATE("Galician") },
-	{ wxLANGUAGE_GERMAN, false, "", wxTRANSLATE("German") },
-	{ wxLANGUAGE_GREEK, false, "", wxTRANSLATE("Greek") },
-	{ wxLANGUAGE_HEBREW, false, "", wxTRANSLATE("Hebrew") },
-	{ wxLANGUAGE_HUNGARIAN, false, "", wxTRANSLATE("Hungarian") },
-	{ wxLANGUAGE_ITALIAN, false, "", wxTRANSLATE("Italian") },
-	{ wxLANGUAGE_JAPANESE, false, "", wxTRANSLATE("Japanese") },
-	{ wxLANGUAGE_KOREAN, false, "", wxTRANSLATE("Korean") },
-	{ wxLANGUAGE_LATVIAN, false, "", wxTRANSLATE("Latvian") },
-	{ wxLANGUAGE_LITHUANIAN, false, "", wxTRANSLATE("Lithuanian") },
-	{ wxLANGUAGE_NORWEGIAN_NYNORSK, false, "", wxTRANSLATE("Norwegian (Nynorsk)") },
-	{ wxLANGUAGE_POLISH, false, "", wxTRANSLATE("Polish") },
-	{ wxLANGUAGE_PORTUGUESE, false, "", wxTRANSLATE("Portuguese") },
-	{ wxLANGUAGE_PORTUGUESE_BRAZILIAN, false, "", wxTRANSLATE("Portuguese (Brazilian)") },
-	{ wxLANGUAGE_ROMANIAN, false, "", wxTRANSLATE("Romanian") },
-	{ wxLANGUAGE_RUSSIAN, false, "", wxTRANSLATE("Russian") },
-	{ wxLANGUAGE_SLOVENIAN, false, "", wxTRANSLATE("Slovenian") },
-	{ wxLANGUAGE_SPANISH, false, "", wxTRANSLATE("Spanish") },
-	{ wxLANGUAGE_SWEDISH, false, "", wxTRANSLATE("Swedish") },
-	{ wxLANGUAGE_TURKISH, false, "", wxTRANSLATE("Turkish") },
-	{ wxLANGUAGE_UKRAINIAN, false, "", wxTRANSLATE("Ukrainian") },
-};
-
 typedef Cfg_Int<int> Cfg_PureInt;
 
-// Returns true if aMule's translation catalog (PACKAGE.mo) exists on
-// disk for the given wxWidgets language id, using the same lookup
-// prefixes that InitLocale() registers. Used as an additional gate
-// in the language-picker probe below: the standard wxLocale::IsAvailable
-// / locale_to_check.IsOk() path depends on glibc-locale data being
-// present for each candidate language, which is *not* the case inside
-// Flatpak sandboxes — the GNOME runtime ships only the user's preferred
-// locale, so every other language fails the probe even when our .mo
-// files are reachable. Treating "catalog file is on disk" as also-OK
-// makes the picker show every language we actually ship a translation
-// for, regardless of sandbox glibc state.
-static bool HasAMuleCatalogForLanguage(int wxLanguageId)
-{
-	const wxLanguageInfo *info = wxLocale::GetLanguageInfo(wxLanguageId);
-	if (!info) {
-		return false;
-	}
-	const wxString canonical = info->CanonicalName;
-	if (canonical.IsEmpty()) {
-		return false;
-	}
-
-	// Same prefixes as InitLocale (OtherFunctions.cpp) — keep in sync.
-	wxArrayString prefixes;
-#if defined(__WXMAC__) || defined(__WINDOWS__)
-	prefixes.Add(JoinPaths(wxStandardPaths::Get().GetResourcesDir(), "locale"));
-#elif defined(__WXGTK__) || defined(__UNIX__)
-	prefixes.Add(JoinPaths(JoinPaths(wxStandardPaths::Get().GetInstallPrefix(), "share"), "locale"));
-#endif
-
-	const wxString catalog = wxString(PACKAGE) + ".mo";
-	for (size_t i = 0; i < prefixes.GetCount(); ++i) {
-		const wxString candidate =
-			JoinPaths(JoinPaths(JoinPaths(prefixes[i], canonical), "LC_MESSAGES"), catalog);
-		if (wxFileExists(candidate)) {
-			return true;
-		}
-	}
-	return false;
-}
-
-class Cfg_Lang : public Cfg_PureInt, public Cfg_Lang_Base
+class Cfg_Lang : public Cfg_PureInt
 {
 public:
 	// cppcheck-suppress uninitMemberVar m_selection, m_langSelector
 	Cfg_Lang()
 	: Cfg_PureInt("", m_selection, 0)
 	{
-		m_languagesReady = false;
-		m_changePos = 0;
 	}
 
 	virtual void LoadFromFile(wxConfigBase *WXUNUSED(cfg)) {}
@@ -803,148 +705,77 @@ public:
 
 	virtual bool TransferFromWindow()
 	{
-		if (!m_languagesReady) {
-			return true; // nothing changed, no problem
+		if (!Cfg_PureInt::TransferFromWindow()) {
+			return false;
 		}
 
-		if (Cfg_PureInt::TransferFromWindow()) {
-			// find wx ID of selected language
-			int i = 0;
-			while (m_selection > 0) {
-				i++;
-				if (aMuleLanguages[i].available) {
-					m_selection--;
-				}
-			}
-			int id = aMuleLanguages[i].id;
-
-			// save language selection
-			thePrefs::SetLanguageID(wxLang2Str(id));
-
-			return true;
+		if (m_selection >= 0 && m_selection < static_cast<int>(m_shown.size())) {
+			thePrefs::SetLanguageID(wxLang2Str(m_shown[m_selection]->wxId));
 		}
 
-		return false;
+		return true;
 	}
 
 	virtual bool TransferToWindow()
 	{
 		m_langSelector = dynamic_cast<wxChoice *>(m_widget); // doesn't work in ctor!
-		if (m_languagesReady) {
-			FillChoice();
-		} else {
-			int wxId = StrLang2wx(thePrefs::GetLanguageID());
-			m_langSelector->Clear();
-			m_selection = 0;
-			for (uint32 i = 0; i < itemsof(aMuleLanguages); i++) {
-				if (aMuleLanguages[i].id == wxId) {
-					m_langSelector->Append(
-						wxString(wxGetTranslation(aMuleLanguages[i].name)) + " [" +
-						aMuleLanguages[i].name + "]");
-					break;
-				}
-			}
-			m_langSelector->Append(_("Change Language"));
-			m_changePos = m_langSelector->GetCount() - 1;
-		}
+		FillChoice();
 
 		return Cfg_PureInt::TransferToWindow();
-	}
-
-	virtual void UpdateChoice(int pos)
-	{
-		if (!m_languagesReady && pos == m_changePos) {
-			// Find available languages and translate them.
-			// This is only done when the user selects "Change Language"
-			// Language is changed rarely, and the go-through-all locales takes a considerable
-			// time when the settings dialog is opened for the first time.
-			wxBusyCursor busyCursor;
-			aMuleLanguages[0].displayname = wxGetTranslation(aMuleLanguages[0].name);
-
-			// This suppresses error-messages about invalid locales
-			for (unsigned int i = 1; i < itemsof(aMuleLanguages); ++i) {
-				// Outer gate: glibc-locale-data path OR aMule .mo catalog on
-				// disk. The catalog path is required for Flatpak sandboxes
-				// where the GNOME runtime ships only the user's preferred
-				// glibc locale, so wxLocale::IsAvailable returns false for
-				// every other language despite the .mo being present.
-				const bool hasCatalog = HasAMuleCatalogForLanguage(aMuleLanguages[i].id);
-				if ((aMuleLanguages[i].id > wxLANGUAGE_USER_DEFINED) ||
-					wxLocale::IsAvailable(aMuleLanguages[i].id) || hasCatalog) {
-					wxLogNull logTarget;
-					wxLocale locale_to_check;
-					InitLocale(locale_to_check, aMuleLanguages[i].id);
-					// English (U.S.) is the source language for the .pot catalog,
-					// so it is always available even though no en_US.mo is shipped.
-					const bool isSourceLanguage =
-						aMuleLanguages[i].id == wxLANGUAGE_ENGLISH_US;
-					// Inner gate: same Flatpak rationale — InitLocale() can
-					// fail with IsOk()==false when glibc lacks the locale
-					// data for the candidate, but our .mo is still on disk
-					// and will be applied correctly when the user actually
-					// switches to this language. Accept `hasCatalog` here as
-					// well so those entries surface in the picker.
-					if ((locale_to_check.IsOk() && (locale_to_check.IsLoaded(PACKAGE) ||
-									       isSourceLanguage)) ||
-						hasCatalog) {
-						aMuleLanguages[i].displayname =
-							wxString(wxGetTranslation(aMuleLanguages[i].name)) +
-							" [" + aMuleLanguages[i].name + "]";
-						aMuleLanguages[i].available = true;
-#if 0
-						// Check for language problems
-						// Activate this code temporarily after messing with the languages!
-						int wxid = StrLang2wx(wxLang2Str(aMuleLanguages[i].id));
-						if (wxid != aMuleLanguages[i].id) {
-							AddDebugLogLineN(logGeneral, CFormat("Language problem for %s : aMule id %d != wx id %d")
-								% aMuleLanguages[i].name % aMuleLanguages[i].id % wxid);
-						}
-#endif
-					}
-				}
-			}
-			// Restore original locale
-			wxLocale tmpLocale;
-			InitLocale(tmpLocale, theApp->m_locale.GetLanguage());
-			FillChoice();
-			if (m_langSelector->GetCount() == 1) {
-				wxMessageBox(_("There are no translations installed for aMule"),
-					_("No languages available"),
-					wxICON_INFORMATION | wxOK);
-			}
-			m_langSelector->SetSelection(m_selection);
-			m_languagesReady = true;
-		}
 	}
 
 protected:
 	int m_selection;
 
 private:
+	/**
+	 * Rebuilds the picker from the catalogs that are actually installed.
+	 *
+	 * wxTranslations walks the catalog directories in wx's own search path instead
+	 * of constructing a path per language, so asking it what is installed costs one
+	 * directory listing. The picker used to construct a wxLocale for every language
+	 * instead, which is why it hid behind a "Change Language" entry and only did the
+	 * work once the user asked for it.
+	 */
 	void FillChoice()
 	{
-		int wxId = StrLang2wx(thePrefs::GetLanguageID());
+		wxArrayString installed;
+		if (wxTranslations *translations = wxTranslations::Get()) {
+			installed = translations->GetAvailableTranslations(PACKAGE);
+		}
+
+		const int current = FindLanguageEntry(thePrefs::GetLanguageID());
+
+		std::size_t count = 0;
+		const SLanguageEntry *languages = GetLanguageList(count);
+
+		m_shown.clear();
 		m_langSelector->Clear();
-		// Add all available languages and find the index of the selected language.
-		for (unsigned int i = 0, j = 0; i < itemsof(aMuleLanguages); i++) {
-			if (aMuleLanguages[i].available) {
-				m_langSelector->Append(aMuleLanguages[i].displayname);
-				if (aMuleLanguages[i].id == wxId) {
-					m_selection = j;
-				}
-				j++;
+		m_selection = 0;
+		for (std::size_t i = 0; i < count; ++i) {
+			if (!IsLanguageAvailable(languages[i], installed)) {
+				continue;
 			}
+
+			wxString label = wxGetTranslation(languages[i].name);
+			if (*languages[i].catalog) {
+				label += " [" + wxString(languages[i].name) + "]";
+			}
+			m_langSelector->Append(label);
+
+			if (current == static_cast<int>(i)) {
+				m_selection = static_cast<int>(m_shown.size());
+			}
+			m_shown.push_back(&languages[i]);
 		}
 	}
 
-	bool m_languagesReady; // true: all translations calculated
-	int m_changePos;
+	//! The entries currently in the widget, in widget order.
+	std::vector<const SLanguageEntry *> m_shown;
 	wxChoice *m_langSelector;
 };
 
 #endif /* ! AMULE_DAEMON */
-
-void Cfg_Lang_Base::UpdateChoice(int) {} // dummy
 
 class Cfg_Skin : public Cfg_Str
 {
@@ -1285,9 +1116,7 @@ void CPreferences::BuildItemList(const wxString &appdir)
 	 **/
 	NewCfgItem(IDC_NICK, (new Cfg_Str("/eMule/Nick", s_nick, "https://amule-org.github.io")));
 #ifndef AMULE_DAEMON
-	Cfg_Lang *cfgLang = new Cfg_Lang();
-	s_cfgLang = cfgLang;
-	NewCfgItem(IDC_LANGUAGE, cfgLang);
+	NewCfgItem(IDC_LANGUAGE, (new Cfg_Lang()));
 #endif
 
 /**

--- a/src/Preferences.h
+++ b/src/Preferences.h
@@ -213,12 +213,6 @@ private:
 	bool m_changed;
 };
 
-class Cfg_Lang_Base
-{
-public:
-	virtual void UpdateChoice(int pos);
-};
-
 const int cntStatColors = 15;
 
 //! This typedef is a shortcut similar to the theApp shortcut, but uses :: instead of .
@@ -287,7 +281,6 @@ public:
 	static void SetDeadServer(bool val) { s_deadserver = val; }
 	static const wxString &GetUserNick() { return s_nick; }
 	static void SetUserNick(const wxString &nick) { s_nick = nick; }
-	static Cfg_Lang_Base *GetCfgLang() { return s_cfgLang; }
 
 	static const wxString &GetAddress() { return s_Addr; }
 	static void SetAddress(const wxString &val) { s_Addr = val; }
@@ -1027,8 +1020,6 @@ protected:
 	static wxString s_nick;
 
 	static CMD4Hash s_userhash;
-
-	static Cfg_Lang_Base *s_cfgLang;
 
 	////////////// CONNECTION
 	static uint32 s_maxupload;

--- a/src/PrefsUnifiedDlg.cpp
+++ b/src/PrefsUnifiedDlg.cpp
@@ -312,8 +312,6 @@ wxBEGIN_EVENT_TABLE(PrefsUnifiedDlg, wxDialog)
 
 	EVT_LIST_ITEM_SELECTED(IDC_EVENTLIST, PrefsUnifiedDlg::OnUserEventSelected)
 
-	EVT_CHOICE(IDC_LANGUAGE, PrefsUnifiedDlg::OnLanguageChoice)
-
 	EVT_CLOSE(PrefsUnifiedDlg::OnClose)
 
 wxEND_EVENT_TABLE()
@@ -2753,11 +2751,6 @@ void PrefsUnifiedDlg::OnUserEventSelected(wxListEvent &event)
 	IDC_PREFS_EVENTS_PAGE->Layout();
 
 	event.Skip();
-}
-
-void PrefsUnifiedDlg::OnLanguageChoice(wxCommandEvent &evt)
-{
-	thePrefs::GetCfgLang()->UpdateChoice(evt.GetSelection());
 }
 
 void PrefsUnifiedDlg::CreateEventPanels(const int idx, const wxString &vars, wxWindow *parent)

--- a/src/PrefsUnifiedDlg.h
+++ b/src/PrefsUnifiedDlg.h
@@ -323,7 +323,6 @@ public:
 	void OnRateLimitChanged(wxSpinEvent &event);
 	void OnTCPClientPortChange(wxSpinEvent &event);
 	void OnUserEventSelected(wxListEvent &event);
-	void OnLanguageChoice(wxCommandEvent &event);
 	void CreateEventPanels(const int idx, const wxString &vars, wxWindow *parent);
 
 	void OnInitDialog(wxInitDialogEvent &evt);

--- a/unittests/tests/CMakeLists.txt
+++ b/unittests/tests/CMakeLists.txt
@@ -481,6 +481,33 @@ target_link_libraries (OtherFunctionsTest
 	CRYPTOPP::CRYPTOPP
 )
 
+add_executable (LanguageListTest
+	LanguageListTest.cpp
+	${CMAKE_SOURCE_DIR}/src/LanguageList.cpp
+	${CMAKE_SOURCE_DIR}/src/OtherFunctions.cpp
+)
+
+add_test (NAME LanguageListTest
+	COMMAND LanguageListTest
+)
+
+# The list names po/ basenames, so the test needs the catalogs to check against.
+target_compile_definitions (LanguageListTest
+	PRIVATE "PO_SRCDIR=${CMAKE_SOURCE_DIR}/po"
+)
+
+target_include_directories (LanguageListTest
+	PRIVATE ${CMAKE_BINARY_DIR}
+	PRIVATE ${CMAKE_SOURCE_DIR}/src
+	PRIVATE ${CMAKE_SOURCE_DIR}/src/include
+)
+
+target_link_libraries (LanguageListTest
+	muleunit
+	mulecommon
+	CRYPTOPP::CRYPTOPP
+)
+
 
 # libwebcommon — JWT / JSON writer / route patterns. `webcommon` PUBLIC-links
 # wxWidgets::BASE and CRYPTOPP::CRYPTOPP and exposes its own headers through

--- a/unittests/tests/LanguageListTest.cpp
+++ b/unittests/tests/LanguageListTest.cpp
@@ -1,0 +1,185 @@
+//
+// This file is part of the aMule Project.
+//
+// Copyright (c) 2003-2026 aMule Team ( https://amule-org.github.io )
+//
+// Any parts of this program derived from the xMule, lMule or eMule project,
+// or contributed by third-party developers are copyrighted by their
+// respective authors.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301, USA
+//
+
+#include "LanguageList.h"
+
+#include "OtherFunctions.h"
+
+#include <muleunit/test.h>
+
+#include <wx/dir.h>
+#include <wx/filename.h>
+#include <wx/intl.h>
+
+using namespace muleunit;
+
+DECLARE_SIMPLE(LanguageList)
+
+//! Catalogs that ship but are deliberately not offered in the picker, because they
+//! hold (next to) no translated strings: offering them would show an English UI
+//! under a native-language label. Move one here into GetLanguageList() once it is
+//! actually translated.
+static const char *const s_unlistedCatalogs[] = { "bn", "ta", "vi" };
+
+static bool IsUnlisted(const wxString &catalog)
+{
+	for (const char *unlisted : s_unlistedCatalogs) {
+		if (catalog == unlisted) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+static wxArrayString PoBasenames()
+{
+	wxArrayString names;
+	wxDir dir(wxSTRINGIZE_T(PO_SRCDIR));
+	if (!dir.IsOpened()) {
+		return names;
+	}
+
+	wxString file;
+	for (bool ok = dir.GetFirst(&file, "*.po", wxDIR_FILES); ok; ok = dir.GetNext(&file)) {
+		names.Add(wxFileName(file).GetName());
+	}
+
+	return names;
+}
+
+// The picker matches a catalog by name, so an entry naming a po file that is not
+// there is a language silently missing from Preferences.
+TEST(LanguageList, EveryListedCatalogExists)
+{
+	const wxArrayString po = PoBasenames();
+	ASSERT_TRUE(!po.IsEmpty());
+
+	std::size_t count = 0;
+	const SLanguageEntry *languages = GetLanguageList(count);
+	for (std::size_t i = 0; i < count; ++i) {
+		if (!*languages[i].catalog) {
+			continue;
+		}
+
+		CONTEXT(wxString("Listed language: ") + languages[i].name);
+		ASSERT_TRUE_M(po.Index(languages[i].catalog) != wxNOT_FOUND,
+			wxString("No po/") + languages[i].catalog + ".po for " + languages[i].name);
+	}
+}
+
+// The other direction: a translation added to po/ without a list entry never
+// reaches the picker. Failing here is the prompt to add it, or to record it as a
+// deliberately unlisted stub.
+TEST(LanguageList, EveryCatalogIsListedOrDeliberatelyNot)
+{
+	const wxArrayString po = PoBasenames();
+	ASSERT_TRUE(!po.IsEmpty());
+
+	std::size_t count = 0;
+	const SLanguageEntry *languages = GetLanguageList(count);
+	for (const wxString &catalog : po) {
+		CONTEXT(wxString("Catalog: ") + catalog);
+
+		bool listed = false;
+		for (std::size_t j = 0; j < count && !listed; ++j) {
+			listed = (catalog == languages[j].catalog);
+		}
+
+		ASSERT_TRUE_M(listed || IsUnlisted(catalog),
+			wxString("po/") + catalog +
+				".po is neither in GetLanguageList() nor recorded as an "
+				"untranslated stub");
+	}
+}
+
+// FindLanguageEntry() accepts a language under two names, so no two entries may
+// answer to the same one.
+TEST(LanguageList, NoTwoEntriesClaimTheSameLanguage)
+{
+	std::size_t count = 0;
+	const SLanguageEntry *languages = GetLanguageList(count);
+	for (std::size_t i = 0; i < count; ++i) {
+		CONTEXT(wxString("Entry: ") + languages[i].name);
+
+		ASSERT_EQUALS(static_cast<int>(i), FindLanguageEntry(wxLang2Str(languages[i].wxId)));
+
+		if (*languages[i].catalog) {
+			ASSERT_EQUALS(static_cast<int>(i), FindLanguageEntry(languages[i].catalog));
+		}
+	}
+}
+
+// The three languages whose catalog directory is not the wx canonical name. A
+// config can spell these either way, and both must land on the same entry.
+TEST(LanguageList, BothSpellingsFindTheSameEntry)
+{
+	ASSERT_EQUALS(FindLanguageEntry("et"), FindLanguageEntry("et_EE"));
+	ASSERT_EQUALS(FindLanguageEntry("ko"), FindLanguageEntry("ko_KR"));
+	ASSERT_EQUALS(FindLanguageEntry("pt"), FindLanguageEntry("pt_PT"));
+
+	// Portuguese and its Brazilian variant stay apart.
+	ASSERT_TRUE(FindLanguageEntry("pt_PT") != FindLanguageEntry("pt_BR"));
+}
+
+// An empty or unrecognised value is what a fresh or hand-broken config holds, and
+// the app runs it as the system language.
+TEST(LanguageList, AnUnknownLanguageIsTheSystemDefault)
+{
+	std::size_t count = 0;
+	const SLanguageEntry *languages = GetLanguageList(count);
+	ASSERT_TRUE(count > 0);
+	ASSERT_EQUALS(wxLANGUAGE_DEFAULT, languages[0].wxId);
+
+	ASSERT_EQUALS(0, FindLanguageEntry(""));
+	ASSERT_EQUALS(0, FindLanguageEntry("no-such-language"));
+}
+
+TEST(LanguageList, AvailabilityFollowsTheInstalledCatalogs)
+{
+	wxArrayString installed;
+	installed.Add("de");
+	installed.Add("et_EE");
+
+	std::size_t count = 0;
+	const SLanguageEntry *languages = GetLanguageList(count);
+
+	const int german = FindLanguageEntry("de");
+	const int estonian = FindLanguageEntry("et_EE");
+	const int italian = FindLanguageEntry("it");
+	ASSERT_TRUE(german >= 0 && estonian >= 0 && italian >= 0);
+
+	ASSERT_TRUE(IsLanguageAvailable(languages[german], installed));
+	ASSERT_TRUE(IsLanguageAvailable(languages[estonian], installed));
+	ASSERT_FALSE(IsLanguageAvailable(languages[italian], installed));
+
+	// System default and the source language ship no catalog and are always offered.
+	for (std::size_t i = 0; i < count; ++i) {
+		if (!*languages[i].catalog) {
+			CONTEXT(wxString("Catalog-less entry: ") + languages[i].name);
+			ASSERT_TRUE(IsLanguageAvailable(languages[i], installed));
+			ASSERT_TRUE(IsLanguageAvailable(languages[i], wxArrayString()));
+		}
+	}
+}


### PR DESCRIPTION
## What this is

Two things the language picker gets wrong, and they turn out to be the same bug seen from either end.

**The picker opened holding a stub.** `Preferences > General > Language` showed only the current language and a `Change Language` entry; the real list appeared once you clicked that. Reported as #1303.

**Three languages were missing from that list on Flatpak.** Estonian, Korean and Portuguese ship catalogs and never appeared.

## Why the second step existed

It is a deliberate optimisation from `fd7a37613` (2010, "Removed lag caused by language pref when opening preferences dialog"). Building the list meant constructing a `wxLocale` for each of the 38 languages and asking whether our catalog loaded. Measured against wx 3.3.3 today, that probe still costs around 200 ms, so simply deleting the stub would put the lag straight back.

It does not have to cost that. `wxTranslations` does not probe: it enumerates the catalog directories in wx's own search path and keeps the ones holding the domain. That is public API, and on a tree with all 40 catalogs installed:

```
A  wxLocale probe (38 langs): 209.0 / 181.0 / 211.4 ms
B  GetAvailableTranslations(): 1.294 / 1.372 / 1.087 ms
```

1.3 ms is cheap enough to spend when the dialog opens, so the list is built up front and `Change Language` is gone, along with the `Cfg_Lang_Base` / `UpdateChoice` / `EVT_CHOICE` plumbing that existed only to drive it.

`GetAvailableTranslations()` also searches every prefix wx itself searches, including the one wx was built against. That is what the removed `HasAMuleCatalogForLanguage()` was hand-rolling, and it is why this direction is safe rather than a narrowing.

## The three languages

`HasAMuleCatalogForLanguage()` built its path from `wxLanguageInfo::CanonicalName`. For three languages that is not the directory we install into:

| po dir | `CanonicalName` | looked for |
|---|---|---|
| `et_EE` | `et` | `.../et/LC_MESSAGES/amule.mo` |
| `ko_KR` | `ko` | `.../ko/LC_MESSAGES/amule.mo` |
| `pt_PT` | `pt` | `.../pt/LC_MESSAGES/amule.mo` |

```
wxID 287  canonical=et      HasAMuleCatalogForLanguage=FALSE
wxID 491  canonical=ko      HasAMuleCatalogForLanguage=FALSE
wxID 637  canonical=pt      HasAMuleCatalogForLanguage=FALSE
wxID 639  canonical=pt_BR   HasAMuleCatalogForLanguage=true
```

On an ordinary install the `wxLocale` probe still found them, so this stayed invisible. On Flatpak, which is the only reason that helper exists, the probe is exactly what fails, leaving `hasCatalog` as the only gate that can pass. Those three were missing there.

So the catalog name stops being derived and becomes a column of the table, which moves to `LanguageList.{cpp,h}` so it can be tested.

## Configs that already name one of the three

The picker writes `wxLang2Str(entry.id)`, so it saves Estonian as `Language=et`, and that has always loaded `et_EE` correctly. Unchanged here.

A config can also carry the territory spelling, `et_EE`, from a hand edit, from another install, or copied from the form `amulecmd.1` documents for `-l`. The translation loaded fine, but no table entry matched, so the dialog could not find the current language and would write System default over it on OK. `FindLanguageEntry()` now accepts either spelling. Checked exhaustively: no two entries claim the same language, and `pt`, `pt_PT` and `pt_BR` stay distinct.

## Tests

`LanguageListTest`, 6 cases: both directions between the table and `po/`, no two entries claiming one language, both spellings resolving alike, an unknown value falling back to System default, and availability following the installed catalogs.

Restoring the derived catalog name fails four of the six, naming the language in each message:

```
Test "EveryListedCatalogExists"
  No po/et.po for Estonian
Test "EveryCatalogIsListedOrDeliberatelyNot"
  po/et_EE.po is neither in GetLanguageList() nor recorded as an untranslated stub
```

The second direction is the one that catches the next Weblate-added language: a new `po/xx.po` fails until it is either added to the picker or recorded as an untranslated stub. `bn`, `ta` and `vi` are recorded as stubs today, holding 0, 23 and 0 translated strings of 2062, which is why they are correctly not offered.

## Strings

Three msgids go with the second step: `Change Language`, `There are no translations installed for aMule` and `No languages available`. Catalogs regenerated with `scripts/update-po.sh`; the pot loses exactly those three and gains nothing, and every language's counts drop by exactly three.

The middle one was a modal shown when the probe found nothing. It is not replaced: the picker now shows just `System default` and `English (U.S.)` in that case, which says the same thing without a dialog on every open.

## Where the new source lives

`LanguageList.cpp` sits in `muleappcommon` rather than in `COMMON_SOURCES`. Nothing in it varies with `CLIENT_GUI`, `AMULE_DAEMON` or `ENABLE_IP2COUNTRY`, and all three executables already link that library, so one object serves them instead of three identical ones. It also means `amuled`, which has no picker, drops the table entirely at link time rather than carrying it as dead weight:

```
             GetLanguageList   Cfg_Lang
aMule              1             11
aMuleGUI           1             11
amuled             0              0
```

amulegui gets the eager fill and the detection fix on the same code as the monolithic build, which matters for it in particular since its language setting is local to the machine running the GUI.

## Checked

macOS build green, ctest 49/49, `clang-format` 18 clean whole-file on all seven touched files, `scripts/check-potfiles.sh` clean, and the `pot-sync` drift check reproduced locally at zero drift. Ran the built app against a config holding `Language=et` and it came up in Estonian.

## Files

```
src/LanguageList.{cpp,h}             new   the table, lookup and availability
unittests/tests/LanguageListTest.cpp new   6 cases
src/Preferences.{cpp,h}                    eager fill, HasAMuleCatalogForLanguage and Cfg_Lang_Base gone
src/PrefsUnifiedDlg.{cpp,h}                the choice handler that drove the second step
src/CMakeLists.txt                         the new source, in muleappcommon
po/POTFILES.in                             the language names moved file
po/*.po, po/amule.pot                      regenerated
unittests/tests/CMakeLists.txt             the new suite
```

Closes #1303.
