### PR TITLE
fix(gui): keep the list where the user left it when rows are added

### DIFF
--- a/src/MuleVirtualDataViewCtrl.cpp
+++ b/src/MuleVirtualDataViewCtrl.cpp
@@ -368,6 +368,22 @@ void CMuleVirtualDataViewCtrl::RemoveItemDataBatch(const std::vector<wxUIntPtr> 
 void CMuleVirtualDataViewCtrl::FinishBulkLoad()
 {
 	const std::vector<wxUIntPtr> selected = GetSelectedItemData();
+	// The row the user is looking at, remembered by its data. Reset() below
+	// says the model was replaced, and every backend answers that by dropping
+	// the view to the top -- so a list that rebuilds whenever a row joins it
+	// scrolled itself home under anyone reading further down (the clients
+	// lists do this on each arrival or departure).
+	long firstRow = 0;
+	long lastRow = 0;
+	wxUIntPtr anchor = GetVisibleRowRange(firstRow, lastRow) ? ItemAt(firstRow) : 0;
+	if (!anchor) {
+		// The rebuild cleared the list first, so the live query has nothing to
+		// answer with and ClearItemData()'s note is the only record of where
+		// the user was.
+		anchor = m_bulkAnchor;
+	}
+	m_bulkAnchor = 0;
+
 	SortItems();
 
 	// Reset() here, unlike SortList(): AppendItemData() adds rows without
@@ -377,6 +393,40 @@ void CMuleVirtualDataViewCtrl::FinishBulkLoad()
 	m_virtualModel->Reset(static_cast<unsigned>(m_items.size()));
 
 	SetSelectedItemData(selected);
+	ScrollDataToTop(anchor);
+}
+
+void CMuleVirtualDataViewCtrl::ScrollDataToTop(wxUIntPtr data)
+{
+	if (!data) {
+		return;
+	}
+	const long row = RowOfData(data);
+	if (row < 0) {
+		return;
+	}
+	// Reset() left the view at the top, so a row that sorted to the top is
+	// already where it belongs. This is the common case on a list nobody has
+	// scrolled, and it costs no scrolling at all.
+	if (row == 0) {
+		return;
+	}
+
+	// Two calls, because EnsureVisible() scrolls the shortest distance that
+	// makes its target visible. The view is at the top after Reset(), so
+	// asking for the anchor alone would stop as soon as it appeared at the
+	// BOTTOM edge. Bringing the last row of the anchor's page into view first
+	// scrolls past it, and the second call then comes back up to it, which
+	// leaves the anchor on the top line where it was.
+	const int perPage = GetCountPerPage();
+	if (perPage > 1 && !m_items.empty()) {
+		const long last = static_cast<long>(m_items.size()) - 1;
+		const long bottom = std::min(row + perPage - 1, last);
+		if (bottom > row) {
+			EnsureVisible(m_virtualModel->GetItem(static_cast<unsigned>(bottom)));
+		}
+	}
+	EnsureVisible(m_virtualModel->GetItem(static_cast<unsigned>(row)));
 }
 
 void CMuleVirtualDataViewCtrl::RemoveItemData(wxUIntPtr data)
@@ -451,6 +501,18 @@ void CMuleVirtualDataViewCtrl::RefreshItemData(wxUIntPtr data)
 
 void CMuleVirtualDataViewCtrl::ClearItemData()
 {
+	// Remembered before the rows go, for the clear-then-refill rebuild the
+	// clients list does on every arrival and departure: by the time
+	// FinishBulkLoad() runs, the control has been told it holds nothing and
+	// cannot say what was on top. Harmless for a clear that is really a clear
+	// -- the data will not be in the list afterwards, and restoring skips
+	// anything it cannot find.
+	long firstRow = 0;
+	long lastRow = 0;
+	if (GetVisibleRowRange(firstRow, lastRow)) {
+		m_bulkAnchor = ItemAt(firstRow);
+	}
+
 	m_items.clear();
 	m_rowOf.clear();
 	m_virtualModel->Reset(0);

--- a/src/MuleVirtualDataViewCtrl.h
+++ b/src/MuleVirtualDataViewCtrl.h
@@ -77,7 +77,8 @@ public:
 	 * loop, so the row would otherwise not appear until the menu closed.
 	 */
 	void AppendItemDataNow(wxUIntPtr data);
-	//! Sorts and refreshes once, after a run of AppendItemData().
+	//! Sorts and refreshes once, after a run of AppendItemData(). Keeps the
+	//! row the user was looking at at the top of the viewport.
 	void FinishBulkLoad();
 	//! Drops the row, keeping the selection on the items that remain.
 	void RemoveItemData(wxUIntPtr data);
@@ -125,6 +126,16 @@ public:
 	 */
 	bool IsItemDataSelected(wxUIntPtr data) const;
 	wxUIntPtr ItemAt(long row) const;
+	/**
+	 * Scroll so that @p data sits at the top of the viewport again.
+	 *
+	 * Anchored to the row's data rather than to a wxDataViewItem: in a virtual
+	 * list an item is a row number, which names a different row once a sort has
+	 * moved things, so it cannot survive the rebuild. Does nothing for 0 or for
+	 * data no longer in the list, which is what a row that has since gone away
+	 * should do.
+	 */
+	void ScrollDataToTop(wxUIntPtr data);
 	long ItemDataCount() const { return static_cast<long>(m_items.size()); }
 
 	/**
@@ -271,6 +282,9 @@ private:
 	//! The rows, in display order. The single source of truth for ordering.
 	std::vector<wxUIntPtr> m_items;
 	std::unordered_map<wxUIntPtr, long> m_rowOf;
+	//! Top row remembered across a ClearItemData() + refill + FinishBulkLoad()
+	//! rebuild, which is the only sequence where the control cannot be asked.
+	wxUIntPtr m_bulkAnchor = 0;
 
 	wxDECLARE_EVENT_TABLE();
 };


### PR DESCRIPTION
Reported on the clients view: the list sometimes jumps back to the top, seemingly when a peer appears. It does, and it is not only that view.

### What happens

`Reset()` tells the control the model was replaced, and every backend answers by dropping the view to the top. The rebuild paths already carried the **selection** across; nothing did the same for the scroll position.

| List | When it jumped |
|---|---|
| Clients, Active | a peer arrives **or leaves**, so the ECID set changes and the rows are rebuilt |
| Clients, Known | a peer the list has never seen appears, so new rows must enter the sort order |
| Downloads | a download joins the queue |
| Shared Files | a file is newly shared |

The Known tab only moves for a genuinely new peer; going online or offline, or a speed changing, takes the per-row refresh path and does not disturb the view. That is why it reads as occasional.

### The fix

`FinishBulkLoad()` notes the row on the top line before sorting and puts it back afterwards, anchoring on the row's **data** rather than a `wxDataViewItem` -- an item in a virtual list is a row number, so it names a different row the moment the sort moves anything. `SearchListCtrl` already does this trick for the tree and its comment says the virtual lists cannot, which is exactly this obstacle.

Restoring takes two `EnsureVisible()` calls: it scrolls the shortest distance that reveals its target, and the view is at the top after `Reset()`, so asking for the anchor alone would stop with it on the *bottom* line. Reaching past it and coming back up leaves it on top.

**The Active tab needed more.** It rebuilds as `ClearItemData()` then refill then `FinishBulkLoad()`, and `ClearItemData()` has already emptied the model and told the control so, leaving nothing to ask. It now takes the same note before wiping, and `FinishBulkLoad()` falls back to it. Without this the reported tab would have got no fix at all.

### It is inherited, not per-list

Only two paths reach `Reset()`, and both are in the base class, so all four bulk-rebuilding lists get this from one change. The other four virtual lists -- servers, friends, per-file peers, file detail -- never reach `Reset()`: they add, drop and repaint rows individually, so they neither had the symptom nor need the fix.

### Cost

O(1) on top of a function that already sorts every row: two native queries, a vector index and one `unordered_map` lookup, plus at most two native scroll calls, and none at all when the anchor sorts back to the top. Nothing added here walks the list, so a 100k-row list pays what it always paid, which is the `std::sort` in `SortItems()`. I have not benchmarked a live 100k list; this is from the container and model types, `wxDataViewVirtualListModel::GetRow()` being pointer arithmetic.

### Verification

Monolithic and amulegui build with 0 errors and no warnings in the touched file. 49/49 ctest. clang-format 18.1.8 whole-file with `--style=file:<repo>/.clang-format`: clean. clang-tidy Tier-1 and Tier-2 on the diff: 0 findings, 0 compiler errors. No translatable strings, so no catalogue work.

Scrolling cannot be exercised headlessly, so the behaviour rests on the two `Reset()` call sites being the only ones, which is checked, and on the anchor being resolvable after the sort, which `SortItems()` guarantees by rebuilding the row index before it returns.
