### PR TITLE
ci: let clang-tidy see the code behind experimental switches

### DIFF
--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -90,7 +90,8 @@ env:
     -DBUILD_WEBSERVER=YES \
     -DENABLE_NLS=YES \
     -DENABLE_UPNP=YES \
-    -DENABLE_IP2COUNTRY=YES
+    -DENABLE_IP2COUNTRY=YES \
+    -DENABLE_ALL_EXPERIMENTAL=YES
 
 jobs:
   # Whole-tree Tier-1 gate: the bug-oriented checks in .clang-tidy must report

--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -301,6 +301,32 @@ option (ENABLE_VERSION_CHECK "compile in the in-app new-version check (startup n
 # pulled in by headers that never see config.h.
 option (ENABLE_KAD_PROTOCOL_10 "advertise Kademlia protocol 0x0a and enable the AICH hashes on keyword storage that Kad 0x09 introduced" OFF)
 
-if (ENABLE_KAD_PROTOCOL_10)
-	add_compile_definitions (ENABLE_KAD_PROTOCOL_10)
-endif()
+# Every experimental switch, named once. A switch belongs here as well as in its
+# own option() above, and that is the only bookkeeping adding one costs: the
+# loop below defines it, and ENABLE_ALL_EXPERIMENTAL turns the whole set on, so
+# no CI job has to name individual switches. The clang-tidy jobs build their
+# compile database with ENABLE_ALL_EXPERIMENTAL, because a switch that is OFF is
+# removed by the preprocessor and never analysed at all.
+#
+# Deliberately a list rather than a naming convention or a grep over ENABLE_*:
+# the latter would sweep in ENABLE_UPNP, ENABLE_NLS and the rest, which are
+# ordinary build options rather than unfinished features.
+set (AMULE_EXPERIMENTAL_OPTIONS
+	ENABLE_KAD_PROTOCOL_10
+)
+
+option (ENABLE_ALL_EXPERIMENTAL "turn on every switch in AMULE_EXPERIMENTAL_OPTIONS at once" OFF)
+
+foreach (experimental_option IN LISTS AMULE_EXPERIMENTAL_OPTIONS)
+	# ENABLE_ALL_EXPERIMENTAL wins over an individual switch: option() leaves
+	# an unset switch defined as OFF, so an explicit -DENABLE_X=NO is
+	# indistinguishable from not passing it and cannot be honoured as an
+	# opt-out. To build every switch but one, name the switches individually
+	# and leave ENABLE_ALL_EXPERIMENTAL off.
+	#
+	# Nothing here writes the cache, so enabling the set for one configure
+	# does not leave the individual switches ON for later ones.
+	if (${experimental_option} OR ENABLE_ALL_EXPERIMENTAL)
+		add_compile_definitions (${experimental_option})
+	endif()
+endforeach()


### PR DESCRIPTION
Both clang-tidy jobs build their compile database from `cmake_config_flags`, which turns on every `BUILD_*` and `ENABLE_*` option precisely so the analysis covers the whole tree. The experimental switches were the one exception: they default to OFF, so the preprocessor removed that code before clang-tidy saw a token of it. Neither Tier-1 nor Tier-2 has ever checked it.

The workflow already documents this exact failure mode for a different flag, in the comment explaining why `libayatana-appindicator3-dev` is installed: without it the SNI tray backend in `MuleTrayIcon.cpp` is `#ifdef`'d out, "so neither tidy tier ever sees it". Same trap, same fix.

## Not one flag at a time

Naming `ENABLE_KAD_PROTOCOL_10` in the workflow would mean editing CI for every new switch, and more are coming: #1304 adds `ENABLE_KAD_NODE_PROTECTION`, with NAT traversal, uTP, QUIC and IPv6 behind it. So the switches are listed once in `cmake/options.cmake`:

```cmake
set (AMULE_EXPERIMENTAL_OPTIONS
	ENABLE_KAD_PROTOCOL_10
)

option (ENABLE_ALL_EXPERIMENTAL "turn on every switch in AMULE_EXPERIMENTAL_OPTIONS at once" OFF)
```

with a loop that defines each switch that is on. CI asks for the set with `-DENABLE_ALL_EXPERIMENTAL=YES` and never names a switch again. Adding one costs a line next to the `option()` declaration it already needs, so #1304 needs no CI change at all.

A list rather than a grep over `ENABLE_*`, which would sweep in `ENABLE_UPNP`, `ENABLE_NLS` and the other ordinary build options, and rather than a naming convention, which would rename a switch that has already shipped.

The same flag is what the experimental build matrix's deferred `all` entry wants, since enabling everything at once is the only thing that catches switches which do not compile together.

## Two things worth knowing

**`ENABLE_ALL_EXPERIMENTAL` wins over an individual switch.** `option()` leaves an unset switch defined as `OFF`, so an explicit `-DENABLE_X=NO` cannot be told apart from not passing it and cannot be honoured as an opt-out. To build all but one, name the switches individually. If two switches ever fail to compile together, that is the point at which the tidy jobs need their own matrix rather than one shared database.

**clang-format is unaffected either way**, being a text pass over `src/` and `unittests/` with no build behind it, so the gated code was always covered there.

## Verification

- The define appears in the compile database under `-DENABLE_KAD_PROTOCOL_10=YES` and under `-DENABLE_ALL_EXPERIMENTAL=YES`, and in neither case by default (151 / 151 / 0 compile entries).
- A build with the set enabled is clean and 50/50 tests pass.
- Tier-1 over the six files holding the newly visible code (`KademliaUDPListener.cpp`, `Indexed.cpp`, `Entry.cpp`, `Search.cpp`, `AICHHashList.cpp`, `PartFile.cpp`) reports no findings and no compiler errors, so turning this on does not make Tier-1 red. That was checked on those six files only; CI's whole-tree run is the real check, though nothing else changes what the compiler sees.
