### PR TITLE
perf(shared): cut the startup share scan to a single stat per file

### DIFF
--- a/src/SharedFileList.cpp
+++ b/src/SharedFileList.cpp
@@ -607,32 +607,32 @@ CSharedFileList::AddPathResult CSharedFileList::AddPathToShares(
 {
 	CPath fullPath = directory.JoinPaths(fname);
 
-	if (!fullPath.FileExists()) {
-		AddDebugLogLineN(logKnownFiles,
-			CFormat("Shared file does not exist (possibly a broken link): %s") % fullPath);
-		return kAddPathSkipped;
-	}
-
-	AddDebugLogLineN(logKnownFiles, CFormat("Found shared file: %s") % fullPath);
-
-	// User-configured name exclusion. Checked before the stat calls below
-	// so excluded files cost only a name match. Applies identically to the
-	// bulk walk and the incremental watcher path.
+	// User-configured name exclusion. Checked before touching the filesystem
+	// so an excluded file costs a name match and nothing else. Applies
+	// identically to the bulk walk and the incremental watcher path.
 	if (thePrefs::IsShareExcluded(fname.GetPrintable())) {
 		AddDebugLogLineN(logKnownFiles, CFormat("Excluded from shares by filter: %s") % fullPath);
 		return kAddPathExcluded;
 	}
 
-	time_t fdate = CPath::GetModificationTime(fullPath);
-	sint64 fsize = fullPath.GetFileSize();
-
-	// This will also catch files with too strict permissions.
-	if ((fdate == (time_t)-1) || (fsize == wxInvalidOffset)) {
+	// One stat for all three answers. Asking separately -- exists, then
+	// modification time, then size -- costs four filesystem round-trips per
+	// file, and the size query opens the file to measure it. Multiplied by
+	// the share, that was the larger half of a cold-cache startup walk.
+	//
+	// A false here is every reason the three separate checks used to report
+	// individually: a broken symlink, something that is not a regular file,
+	// or permissions too strict to stat.
+	time_t fdate;
+	sint64 fsize;
+	if (!fullPath.GetFileStat(fdate, fsize)) {
 		AddDebugLogLineN(logKnownFiles,
-			CFormat("Failed to retrieve modification time or size for '%s', skipping.") %
+			CFormat("Not a readable regular file (broken link, or permissions), skipping: %s") %
 				fullPath);
 		return kAddPathSkipped;
 	}
+
+	AddDebugLogLineN(logKnownFiles, CFormat("Found shared file: %s") % fullPath);
 
 	if (fsize == 0) {
 		AddDebugLogLineN(logKnownFiles, CFormat("Skip zero size file '%s'") % fullPath);

--- a/src/libs/common/Path.cpp
+++ b/src/libs/common/Path.cpp
@@ -443,9 +443,23 @@ sint64 CPath::GetFileSize() const
 bool CPath::GetFileStat(time_t &mtime, sint64 &size) const
 {
 #ifdef __WINDOWS__
-	// No single-call equivalent worth the #ifdef here: wxWidgets already
-	// routes both queries through the same GetFileAttributesEx, so the
-	// separate calls cost what one would.
+	// Windows keeps the three separate wx calls, in the order the callers
+	// used to make them. That order is load-bearing rather than habit:
+	// wxFileName::GetTimes() reports a failure through wxLogSysError(), so
+	// asking it about a path that does not exist -- a broken shortcut, or a
+	// file that vanished mid-scan -- puts a system-error line in the user's
+	// log. FileExists() is what kept that quiet, so it stays in front.
+	//
+	// No saving here, then; this platform gets only the path-comparison fix
+	// that comes with it. Collapsing these into one GetFileAttributesEx()
+	// would work, but its FILETIME would have to convert to exactly the
+	// time_t wxFileModificationTime() returns today: known.met matches on the
+	// stored modification time, so a conversion that differs by so much as a
+	// second re-hashes every shared file on the user's next start.
+	if (!FileExists()) {
+		return false;
+	}
+
 	const time_t fileDate = CPath::GetModificationTime(*this);
 	const sint64 fileSize = GetFileSize();
 	if ((fileDate == (time_t)-1) || (fileSize == wxInvalidOffset)) {

--- a/src/libs/common/Path.cpp
+++ b/src/libs/common/Path.cpp
@@ -33,6 +33,10 @@
 #include <wx/filename.h>
 #include <algorithm> // Needed for std::min
 
+#ifndef __WINDOWS__
+#include <sys/stat.h> // Needed for ::stat in GetFileStat
+#endif
+
 // Windows has case-insensitive paths, so we use a
 // case-insensitive cmp for that platform. TODO:
 // Perhaps it would be better to simply lowercase
@@ -236,6 +240,23 @@ static bool IsSameAs(const wxString &a, const wxString &b)
 		return PATHCMP(a.c_str(), b.c_str()) == 0;
 	}
 
+	// Identical strings normalise identically, so both calls below are known
+	// to agree before either runs.
+	if (a == b) {
+		return true;
+	}
+
+	// An empty path names no file, so it can only equal another empty path --
+	// which the comparison above already answered. Falling through instead
+	// would hand "" to NormalizedKey(), and that is not merely slow: an empty
+	// path is not absolute, so it normalises to the process working directory
+	// and compares equal to whichever directory aMule happens to be sitting
+	// in. A CKnownFile loaded from known.met has no directory until the share
+	// scan stamps one, so this is every known file on every scan.
+	if (a.empty() || b.empty()) {
+		return false;
+	}
+
 	return NormalizedKey(a) == NormalizedKey(b);
 }
 
@@ -417,6 +438,44 @@ sint64 CPath::GetFileSize() const
 	}
 
 	return wxInvalidOffset;
+}
+
+bool CPath::GetFileStat(time_t &mtime, sint64 &size) const
+{
+#ifdef __WINDOWS__
+	// No single-call equivalent worth the #ifdef here: wxWidgets already
+	// routes both queries through the same GetFileAttributesEx, so the
+	// separate calls cost what one would.
+	const time_t fileDate = CPath::GetModificationTime(*this);
+	const sint64 fileSize = GetFileSize();
+	if ((fileDate == (time_t)-1) || (fileSize == wxInvalidOffset)) {
+		return false;
+	}
+	mtime = fileDate;
+	size = fileSize;
+	return true;
+#else
+	const wxCharBuffer path = m_filesystem.mb_str(wxConvFile);
+	if (!path.data()) {
+		return false;
+	}
+
+	struct stat st;
+	if (::stat(path.data(), &st) != 0) {
+		return false;
+	}
+
+	// Same predicate wxFileExists() applies, kept explicit because this is
+	// what makes the single stat a drop-in for the FileExists() the callers
+	// no longer make: a directory or a broken link must still fail.
+	if (!S_ISREG(st.st_mode)) {
+		return false;
+	}
+
+	mtime = st.st_mtime;
+	size = (sint64)st.st_size;
+	return true;
+#endif
 }
 
 wxString CPath::GetDirKey() const

--- a/src/libs/common/Path.h
+++ b/src/libs/common/Path.h
@@ -120,6 +120,20 @@ public:
 	sint64 GetFileSize() const;
 
 	/**
+	 * Existence, modification time and size from a single stat().
+	 *
+	 * Returns false when the path is not an existing regular file, which
+	 * covers the cases the callers used to test separately: a broken
+	 * symlink, a directory, and permissions too strict to stat.
+	 *
+	 * FileExists() + GetModificationTime() + GetFileSize() answer the same
+	 * question in four filesystem round-trips, one of which opens the file
+	 * (GetFileSize() below). The share scan asks it once per shared file,
+	 * where that difference is most of the walk on a cold cache.
+	 */
+	bool GetFileStat(time_t &mtime, sint64 &size) const;
+
+	/**
 	 * Compares under the assumption that both objects are dirs, even if
 	 * one or the other lacks a terminal directory-separator. However, an
 	 * empty CPath object will not be considered equal to a path to the root.


### PR DESCRIPTION
The startup share scan is what the splash screen is covering, and on a cold cache it is most of the wait. Profiling it on 10000 shared files showed almost three quarters of the walk going to filesystem calls that need not happen.

### One stat instead of four round-trips

`AddPathToShares()` asked for existence, then modification time, then size. `CPath::GetFileSize()` re-checks existence and then *opens the file* to measure it, so that is four round-trips per shared file, one of them an `open()`, for three facts a single `stat()` returns together. New `CPath::GetFileStat()` answers all three at once. The name-exclusion filter also moves ahead of it, so a filtered-out file now costs a name match and no filesystem access at all.

### A getcwd() per file, inside a string comparison

`known.met` records no directory, so a `CKnownFile` loaded from it has an empty `m_filePath` until the scan stamps one. `SetFilePath()` compares the two, which falls through to `NormalizedKey("")` - and an empty path is not absolute, so `wxFileName::Normalize` resolves it against the process working directory. That is a `wxGetCwd()` per shared file, which on macOS is an `open`, `stat`, `fcntl` and `close`.

**This one is a correctness fix as well.** Normalising an empty path against the cwd makes an unset path compare *equal* to whichever directory aMule happened to be launched from, so a known file would silently keep its empty path whenever the two coincided. `IsSameAs()` now answers both cases without normalising: equal strings normalise equally, and an empty path can only equal another empty path. This changes `CPath::operator==` for every caller, not just the scan.

### Measurements

10000 known shared files, steady state (nothing left to hash), macOS ARM64:

| | before | after | |
|---|---|---|---|
| Warm cache | 660 ms | 190 ms | 3.5x |
| Cold volume | 763 ms | 298 ms | 2.6x |

Cold here means a disk image detached and reattached between runs, so the volume's metadata cache is dropped while the backing file may still be in RAM - the real-world gain should be at least this, not less. Where the baseline 685 ms went: 33% `wxGetCwd()`, 29% the `open()` inside `GetFileSize()`, 12% `wxDir::GetNextFile`, 8% the keyword list, 10% the two other stats, 5% the splash repaint, and 1.5% `FindKnownFile` - the known-file lookup was never the bottleneck.

### Verification

- Same 10000 files found before and after.
- Edge fixture - zero-size file, broken symlink, FIFO, `chmod 000`, subdirectory, valid symlink - both binaries share exactly the same set and skip exactly the same set. `GetFileStat()` keeps the `S_ISREG` predicate `wxFileExists()` applied, so a directory or broken link still fails.
- `PathTest` passes.

Context: #1299.
