### PR TITLE
fix(gui): route the protocol extensions label through LabelWithColon

### DIFF
--- a/po/amule.pot
+++ b/po/amule.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-06 23:44+0200\n"
+"POT-Creation-Date: 2026-09-07 16:21+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -4175,7 +4175,7 @@ msgid "Obfuscation"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Protocol extensions:"
+msgid "Protocol extensions"
 msgstr ""
 
 #: src/muuli_wdr.cpp

--- a/po/ar.po
+++ b/po/ar.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-06 23:44+0200\n"
+"POT-Creation-Date: 2026-09-07 16:21+0200\n"
 "PO-Revision-Date: 2026-09-05 10:44+0000\n"
 "Last-Translator: saleh alhathal <hathalsal@hotmail.com>\n"
 "Language-Team: \n"
@@ -4248,7 +4248,7 @@ msgid "Obfuscation"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Protocol extensions:"
+msgid "Protocol extensions"
 msgstr ""
 
 #: src/muuli_wdr.cpp

--- a/po/ast.po
+++ b/po/ast.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-06 23:44+0200\n"
+"POT-Creation-Date: 2026-09-07 16:21+0200\n"
 "PO-Revision-Date: 2026-09-05 10:45+0000\n"
 "Last-Translator: astur <malditoastur@gmail.com>\n"
 "Language-Team: Language ast <malditoastur@gmail.com>\n"
@@ -4309,7 +4309,7 @@ msgstr "Ofuscación"
 
 #: src/muuli_wdr.cpp
 #, fuzzy
-msgid "Protocol extensions:"
+msgid "Protocol extensions"
 msgstr "Ofuscación de protocolu"
 
 #: src/muuli_wdr.cpp

--- a/po/bg.po
+++ b/po/bg.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-06 23:44+0200\n"
+"POT-Creation-Date: 2026-09-07 16:21+0200\n"
 "PO-Revision-Date: 2026-09-05 10:45+0000\n"
 "Last-Translator: Sebastiano Pistore <SebastianoPistore.info@protonmail.ch>\n"
 "Language-Team: Bulgarian <dict@linux.zonebg.com>\n"
@@ -4248,7 +4248,7 @@ msgstr ""
 
 #: src/muuli_wdr.cpp
 #, fuzzy
-msgid "Protocol extensions:"
+msgid "Protocol extensions"
 msgstr ""
 "\n"
 "Налични разширения:\n"

--- a/po/bn.po
+++ b/po/bn.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-06 23:44+0200\n"
+"POT-Creation-Date: 2026-09-07 16:21+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -4174,7 +4174,7 @@ msgid "Obfuscation"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Protocol extensions:"
+msgid "Protocol extensions"
 msgstr ""
 
 #: src/muuli_wdr.cpp

--- a/po/ca.po
+++ b/po/ca.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-06 23:44+0200\n"
+"POT-Creation-Date: 2026-09-07 16:21+0200\n"
 "PO-Revision-Date: 2026-09-05 10:46+0000\n"
 "Last-Translator: minterior <minterior@gmail.com>\n"
 "Language-Team: Català\n"
@@ -4296,7 +4296,7 @@ msgstr "Ofuscació"
 
 #: src/muuli_wdr.cpp
 #, fuzzy
-msgid "Protocol extensions:"
+msgid "Protocol extensions"
 msgstr "Ofuscació de protocol"
 
 #: src/muuli_wdr.cpp

--- a/po/cs.po
+++ b/po/cs.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-06 23:44+0200\n"
+"POT-Creation-Date: 2026-09-07 16:21+0200\n"
 "PO-Revision-Date: 2026-09-05 10:47+0000\n"
 "Last-Translator: David Watzke <david@watzke.cz>\n"
 "Language-Team: cs <cs@li.org>\n"
@@ -4294,7 +4294,7 @@ msgstr "Zamaskování"
 
 #: src/muuli_wdr.cpp
 #, fuzzy
-msgid "Protocol extensions:"
+msgid "Protocol extensions"
 msgstr "Zamaskování protokolu"
 
 #: src/muuli_wdr.cpp

--- a/po/da.po
+++ b/po/da.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-06 23:44+0200\n"
+"POT-Creation-Date: 2026-09-07 16:21+0200\n"
 "PO-Revision-Date: 2026-09-05 10:47+0000\n"
 "Last-Translator: Alex Thomsen Leth <alexl@stofanet.dk>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -4263,7 +4263,7 @@ msgid "Obfuscation"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Protocol extensions:"
+msgid "Protocol extensions"
 msgstr ""
 
 #: src/muuli_wdr.cpp

--- a/po/de.po
+++ b/po/de.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-06 23:44+0200\n"
+"POT-Creation-Date: 2026-09-07 16:21+0200\n"
 "PO-Revision-Date: 2026-09-05 10:47+0000\n"
 "Last-Translator: Werner Mahr <werner@vollstreckernet.de>\n"
 "Language-Team: German <>\n"
@@ -4294,7 +4294,7 @@ msgstr "Verschleierung"
 
 #: src/muuli_wdr.cpp
 #, fuzzy
-msgid "Protocol extensions:"
+msgid "Protocol extensions"
 msgstr "Protokollverschleierung"
 
 #: src/muuli_wdr.cpp

--- a/po/el.po
+++ b/po/el.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-06 23:44+0200\n"
+"POT-Creation-Date: 2026-09-07 16:21+0200\n"
 "PO-Revision-Date: 2026-09-05 10:48+0000\n"
 "Last-Translator: Dimitris <dgalanak@yahoo.com>\n"
 "Language-Team: Greek\n"
@@ -4321,7 +4321,7 @@ msgstr "Συσκότιση"
 
 #: src/muuli_wdr.cpp
 #, fuzzy
-msgid "Protocol extensions:"
+msgid "Protocol extensions"
 msgstr "Συσκότιση πρωτοκόλλου"
 
 #: src/muuli_wdr.cpp

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-06 23:44+0200\n"
+"POT-Creation-Date: 2026-09-07 16:21+0200\n"
 "PO-Revision-Date: 2020-03-04 14:43+0100\n"
 "Last-Translator: Dévai Tamás <devait@vnet.hu>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -4175,7 +4175,7 @@ msgid "Obfuscation"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Protocol extensions:"
+msgid "Protocol extensions"
 msgstr ""
 
 #: src/muuli_wdr.cpp

--- a/po/es.po
+++ b/po/es.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-06 23:44+0200\n"
+"POT-Creation-Date: 2026-09-07 16:21+0200\n"
 "PO-Revision-Date: 2026-09-05 10:49+0000\n"
 "Last-Translator: Diego Heras <ngosang@hotmail.es>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/amule/amule-application/es/>\n"
@@ -4270,7 +4270,7 @@ msgstr "Ofuscación"
 
 #: src/muuli_wdr.cpp
 #, fuzzy
-msgid "Protocol extensions:"
+msgid "Protocol extensions"
 msgstr "Ofuscación de protocolo"
 
 #: src/muuli_wdr.cpp

--- a/po/et_EE.po
+++ b/po/et_EE.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-06 23:44+0200\n"
+"POT-Creation-Date: 2026-09-07 16:21+0200\n"
 "PO-Revision-Date: 2026-09-05 10:49+0000\n"
 "Last-Translator: \n"
 "Language-Team: Estonian <kde-i18n-doc@kde.org>\n"
@@ -4296,7 +4296,7 @@ msgstr "Hämatud"
 
 #: src/muuli_wdr.cpp
 #, fuzzy
-msgid "Protocol extensions:"
+msgid "Protocol extensions"
 msgstr "Protokolli Hämamine"
 
 #: src/muuli_wdr.cpp

--- a/po/eu.po
+++ b/po/eu.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-06 23:44+0200\n"
+"POT-Creation-Date: 2026-09-07 16:21+0200\n"
 "PO-Revision-Date: 2026-09-05 10:50+0000\n"
 "Last-Translator: Piarres Beobide <pi@beobide.net>\n"
 "Language-Team: Euskara <librezale@librezale.org>\n"
@@ -4297,7 +4297,7 @@ msgstr "Nahasmena"
 
 #: src/muuli_wdr.cpp
 #, fuzzy
-msgid "Protocol extensions:"
+msgid "Protocol extensions"
 msgstr "Protokolo nahastea"
 
 #: src/muuli_wdr.cpp

--- a/po/fi.po
+++ b/po/fi.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-06 23:44+0200\n"
+"POT-Creation-Date: 2026-09-07 16:21+0200\n"
 "PO-Revision-Date: 2026-09-05 10:50+0000\n"
 "Last-Translator: Tapio Rantala <tapio.rantala@iki.fi>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -4297,7 +4297,7 @@ msgstr "Kätkeminen"
 
 #: src/muuli_wdr.cpp
 #, fuzzy
-msgid "Protocol extensions:"
+msgid "Protocol extensions"
 msgstr "Protokollan kätkeminen"
 
 #: src/muuli_wdr.cpp

--- a/po/fr.po
+++ b/po/fr.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-06 23:44+0200\n"
+"POT-Creation-Date: 2026-09-07 16:21+0200\n"
 "PO-Revision-Date: 2026-09-05 10:51+0000\n"
 "Last-Translator: Dylan Aïssi <bob.dybian@gmail.com>\n"
 "Language-Team: Français\n"
@@ -4269,7 +4269,7 @@ msgstr "Brouillage"
 
 #: src/muuli_wdr.cpp
 #, fuzzy
-msgid "Protocol extensions:"
+msgid "Protocol extensions"
 msgstr "Brouillage de protocole"
 
 #: src/muuli_wdr.cpp

--- a/po/gl.po
+++ b/po/gl.po
@@ -24,7 +24,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-06 23:44+0200\n"
+"POT-Creation-Date: 2026-09-07 16:21+0200\n"
 "PO-Revision-Date: 2026-09-05 10:52+0000\n"
 "Last-Translator: Pablo <parodper@gmail.com>\n"
 "Language-Team: http://forum.amule.org/index.php?topic=13883\n"
@@ -4307,7 +4307,7 @@ msgstr "Ofuscación"
 
 #: src/muuli_wdr.cpp
 #, fuzzy
-msgid "Protocol extensions:"
+msgid "Protocol extensions"
 msgstr "Ofuscación do protocolo"
 
 #: src/muuli_wdr.cpp

--- a/po/he.po
+++ b/po/he.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-06 23:44+0200\n"
+"POT-Creation-Date: 2026-09-07 16:21+0200\n"
 "PO-Revision-Date: 2026-09-05 10:52+0000\n"
 "Last-Translator: Peace Kramer <kpeace1@gmail.com>\n"
 "Language-Team: Hebrew\n"
@@ -4271,7 +4271,7 @@ msgid "Obfuscation"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Protocol extensions:"
+msgid "Protocol extensions"
 msgstr ""
 
 #: src/muuli_wdr.cpp

--- a/po/hr.po
+++ b/po/hr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-06 23:44+0200\n"
+"POT-Creation-Date: 2026-09-07 16:21+0200\n"
 "PO-Revision-Date: 2026-09-05 10:52+0000\n"
 "Last-Translator: Sebastiano Pistore <sebastiano.pistore.info@aol.com>\n"
 "Language-Team: https://github.com/amule-org/amule <forum@aMule.org>\n"
@@ -4273,7 +4273,7 @@ msgid "Obfuscation"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Protocol extensions:"
+msgid "Protocol extensions"
 msgstr ""
 
 #: src/muuli_wdr.cpp

--- a/po/hu.po
+++ b/po/hu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-06 23:44+0200\n"
+"POT-Creation-Date: 2026-09-07 16:21+0200\n"
 "PO-Revision-Date: 2026-09-05 10:53+0000\n"
 "Last-Translator: Dévai Tamás <gonosztopi@amule.org>\n"
 "Language-Team: Hungarian <hu@li.org>\n"
@@ -4267,7 +4267,7 @@ msgstr "Zavarás"
 
 #: src/muuli_wdr.cpp
 #, fuzzy
-msgid "Protocol extensions:"
+msgid "Protocol extensions"
 msgstr "Protokoll zavarás"
 
 #: src/muuli_wdr.cpp

--- a/po/it.po
+++ b/po/it.po
@@ -19,7 +19,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule 2.3.3\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-06 23:44+0200\n"
+"POT-Creation-Date: 2026-09-07 16:21+0200\n"
 "PO-Revision-Date: 2026-09-05 10:54+0000\n"
 "Last-Translator: got3nks <got3nks@users.noreply.github.com>\n"
 "Language-Team: SebastianoPistore.info@protonmail.ch\n"
@@ -4276,7 +4276,7 @@ msgstr "Offuscamento"
 
 #: src/muuli_wdr.cpp
 #, fuzzy
-msgid "Protocol extensions:"
+msgid "Protocol extensions"
 msgstr "Offuscamento del protocollo"
 
 #: src/muuli_wdr.cpp

--- a/po/ja.po
+++ b/po/ja.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-06 23:44+0200\n"
+"POT-Creation-Date: 2026-09-07 16:21+0200\n"
 "PO-Revision-Date: 2026-09-05 10:54+0000\n"
 "Last-Translator: \n"
 "Language-Team: Japanese\n"
@@ -4289,7 +4289,7 @@ msgstr "難読化"
 
 #: src/muuli_wdr.cpp
 #, fuzzy
-msgid "Protocol extensions:"
+msgid "Protocol extensions"
 msgstr "プロトコルを難読化する"
 
 #: src/muuli_wdr.cpp

--- a/po/ko_KR.po
+++ b/po/ko_KR.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-06 23:44+0200\n"
+"POT-Creation-Date: 2026-09-07 16:21+0200\n"
 "PO-Revision-Date: 2026-09-05 10:55+0000\n"
 "Last-Translator: Hyunju Kang <rexington@gmail.com>\n"
 "Language-Team: Korean <hoenny@daum.net>\n"
@@ -4319,7 +4319,7 @@ msgstr "프로토콜 난독화"
 
 #: src/muuli_wdr.cpp
 #, fuzzy
-msgid "Protocol extensions:"
+msgid "Protocol extensions"
 msgstr "프로토콜 난독화"
 
 #: src/muuli_wdr.cpp

--- a/po/lt.po
+++ b/po/lt.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-06 23:44+0200\n"
+"POT-Creation-Date: 2026-09-07 16:21+0200\n"
 "PO-Revision-Date: 2026-09-05 10:55+0000\n"
 "Last-Translator: Dovydas Sankauskas <laisve@gmail.com>\n"
 "Language-Team: Lithuanian <komp_lt@konf.lt>\n"
@@ -4341,7 +4341,7 @@ msgstr "Slėpimas"
 
 #: src/muuli_wdr.cpp
 #, fuzzy
-msgid "Protocol extensions:"
+msgid "Protocol extensions"
 msgstr "Protokolo slėpimas"
 
 #: src/muuli_wdr.cpp

--- a/po/lv.po
+++ b/po/lv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-06 23:44+0200\n"
+"POT-Creation-Date: 2026-09-07 16:21+0200\n"
 "PO-Revision-Date: 2026-09-05 11:05+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -4216,7 +4216,7 @@ msgid "Obfuscation"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Protocol extensions:"
+msgid "Protocol extensions"
 msgstr ""
 
 #: src/muuli_wdr.cpp

--- a/po/nl.po
+++ b/po/nl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-06 23:44+0200\n"
+"POT-Creation-Date: 2026-09-07 16:21+0200\n"
 "PO-Revision-Date: 2026-09-05 10:56+0000\n"
 "Last-Translator: Marcel Pol <marcel@timelord.nl>\n"
 "Language-Team: Dutch <nl@li.org>\n"
@@ -4267,7 +4267,7 @@ msgstr "Maskering"
 
 #: src/muuli_wdr.cpp
 #, fuzzy
-msgid "Protocol extensions:"
+msgid "Protocol extensions"
 msgstr "Protocol-obfuscatie"
 
 #: src/muuli_wdr.cpp

--- a/po/nn.po
+++ b/po/nn.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-06 23:44+0200\n"
+"POT-Creation-Date: 2026-09-07 16:21+0200\n"
 "PO-Revision-Date: 2026-09-05 10:56+0000\n"
 "Last-Translator: Hallvor Brunstad <Hallvor_1976@yahoo.com>\n"
 "Language-Team: <i18n-nn@lister.ping.uio.no>\n"
@@ -4318,7 +4318,7 @@ msgstr "Tåkelegging"
 
 #: src/muuli_wdr.cpp
 #, fuzzy
-msgid "Protocol extensions:"
+msgid "Protocol extensions"
 msgstr "Protokolltåkeleggjing"
 
 #: src/muuli_wdr.cpp

--- a/po/pl.po
+++ b/po/pl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-06 23:44+0200\n"
+"POT-Creation-Date: 2026-09-07 16:21+0200\n"
 "PO-Revision-Date: 2026-09-05 10:57+0000\n"
 "Last-Translator: Michał Trzebiatowski <hippie_1968@hotmail.com>\n"
 "Language-Team: translationproject.org/team/pl.html <translation-team-pl@lists.sourceforge.net>\n"
@@ -4320,7 +4320,7 @@ msgstr "Maskowanie"
 
 #: src/muuli_wdr.cpp
 #, fuzzy
-msgid "Protocol extensions:"
+msgid "Protocol extensions"
 msgstr "Maskowanie protokołu"
 
 #: src/muuli_wdr.cpp

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-06 23:44+0200\n"
+"POT-Creation-Date: 2026-09-07 16:21+0200\n"
 "PO-Revision-Date: 2026-09-05 10:58+0000\n"
 "Last-Translator: Marcelo Jimenez <mroberto@users.sourceforge.com>\n"
 "Language-Team: Português (Brasileiro) <pt@li.org>\n"
@@ -4270,7 +4270,7 @@ msgstr "Obfuscação"
 
 #: src/muuli_wdr.cpp
 #, fuzzy
-msgid "Protocol extensions:"
+msgid "Protocol extensions"
 msgstr "Obscurecimento de Protocolo"
 
 #: src/muuli_wdr.cpp

--- a/po/pt_PT.po
+++ b/po/pt_PT.po
@@ -17,7 +17,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-06 23:44+0200\n"
+"POT-Creation-Date: 2026-09-07 16:21+0200\n"
 "PO-Revision-Date: 2026-09-05 10:58+0000\n"
 "Last-Translator: Luís Picciochi Oliveira <Pitxyoki@Gmail.com>\n"
 "Language-Team: Portuguese <traduz@debianpt.org>\n"
@@ -4303,7 +4303,7 @@ msgstr "Ofuscação"
 
 #: src/muuli_wdr.cpp
 #, fuzzy
-msgid "Protocol extensions:"
+msgid "Protocol extensions"
 msgstr "Ofuscação do Protocolo"
 
 #: src/muuli_wdr.cpp

--- a/po/ro.po
+++ b/po/ro.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-06 23:44+0200\n"
+"POT-Creation-Date: 2026-09-07 16:21+0200\n"
 "PO-Revision-Date: 2026-09-05 10:59+0000\n"
 "Last-Translator: Angelescu Constantin <titus0818@yahoo.com>\n"
 "Language-Team: English <kde-i18n-doc@kde.org>\n"
@@ -4315,7 +4315,7 @@ msgstr "Disimulare"
 
 #: src/muuli_wdr.cpp
 #, fuzzy
-msgid "Protocol extensions:"
+msgid "Protocol extensions"
 msgstr "Protocol disimulare"
 
 #: src/muuli_wdr.cpp

--- a/po/ru.po
+++ b/po/ru.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-06 23:44+0200\n"
+"POT-Creation-Date: 2026-09-07 16:21+0200\n"
 "PO-Revision-Date: 2026-09-05 11:00+0000\n"
 "Last-Translator: Radist Morse <radist.morse@gmail.com>\n"
 "Language-Team: Russian <kde-russian@lists.kde.ru>\n"
@@ -4307,7 +4307,7 @@ msgstr "Маскировка"
 
 #: src/muuli_wdr.cpp
 #, fuzzy
-msgid "Protocol extensions:"
+msgid "Protocol extensions"
 msgstr "Маскировка протокола"
 
 #: src/muuli_wdr.cpp

--- a/po/sl.po
+++ b/po/sl.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-06 23:44+0200\n"
+"POT-Creation-Date: 2026-09-07 16:21+0200\n"
 "PO-Revision-Date: 2026-09-05 11:00+0000\n"
 "Last-Translator: Jure Repinc <jlp@holodeck1.com>\n"
 "Language-Team: Slovenian\n"
@@ -4345,7 +4345,7 @@ msgstr "Maskiranje"
 
 #: src/muuli_wdr.cpp
 #, fuzzy
-msgid "Protocol extensions:"
+msgid "Protocol extensions"
 msgstr "Maskiranje protokola"
 
 #: src/muuli_wdr.cpp

--- a/po/sq.po
+++ b/po/sq.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-06 23:44+0200\n"
+"POT-Creation-Date: 2026-09-07 16:21+0200\n"
 "PO-Revision-Date: 2026-09-05 11:01+0000\n"
 "Last-Translator: Fation <dj_barthezz@linuxmail.org lushnja_corps@hotmail.Language-Team:\n"
 "Language: sq\n"
@@ -4312,7 +4312,7 @@ msgstr "Protokolli i Turbullimit"
 
 #: src/muuli_wdr.cpp
 #, fuzzy
-msgid "Protocol extensions:"
+msgid "Protocol extensions"
 msgstr "Protokolli i Turbullimit"
 
 #: src/muuli_wdr.cpp

--- a/po/sv.po
+++ b/po/sv.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-06 23:44+0200\n"
+"POT-Creation-Date: 2026-09-07 16:21+0200\n"
 "PO-Revision-Date: 2026-09-05 11:01+0000\n"
 "Last-Translator: raffe <raffe@localhost.se>\n"
 "Language-Team: Swedish <tp-sv@listor.tp-sv.se>\n"
@@ -4295,7 +4295,7 @@ msgstr "Fördunkling"
 
 #: src/muuli_wdr.cpp
 #, fuzzy
-msgid "Protocol extensions:"
+msgid "Protocol extensions"
 msgstr "Protokollfördunkling"
 
 #: src/muuli_wdr.cpp

--- a/po/ta.po
+++ b/po/ta.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-06 23:44+0200\n"
+"POT-Creation-Date: 2026-09-07 16:21+0200\n"
 "PO-Revision-Date: 2026-09-05 11:06+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -4174,7 +4174,7 @@ msgid "Obfuscation"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Protocol extensions:"
+msgid "Protocol extensions"
 msgstr ""
 
 #: src/muuli_wdr.cpp

--- a/po/tr.po
+++ b/po/tr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-06 23:44+0200\n"
+"POT-Creation-Date: 2026-09-07 16:21+0200\n"
 "PO-Revision-Date: 2026-09-05 11:02+0000\n"
 "Last-Translator: \n"
 "Language-Team: Turkish <li@li.org>\n"
@@ -4262,7 +4262,7 @@ msgstr "Gizleme"
 
 #: src/muuli_wdr.cpp
 #, fuzzy
-msgid "Protocol extensions:"
+msgid "Protocol extensions"
 msgstr "Protokol Gizleme"
 
 #: src/muuli_wdr.cpp

--- a/po/uk.po
+++ b/po/uk.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-06 23:44+0200\n"
+"POT-Creation-Date: 2026-09-07 16:21+0200\n"
 "PO-Revision-Date: 2026-09-05 11:02+0000\n"
 "Last-Translator: Oleksandr Kovalenko <alx.kovalenko@gmail.com>\n"
 "Language-Team: Ukrainian <translation@linux.org.ua>\n"
@@ -4339,7 +4339,7 @@ msgstr "Приховування"
 
 #: src/muuli_wdr.cpp
 #, fuzzy
-msgid "Protocol extensions:"
+msgid "Protocol extensions"
 msgstr "Приховування протоколу"
 
 #: src/muuli_wdr.cpp

--- a/po/vi.po
+++ b/po/vi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-06 23:44+0200\n"
+"POT-Creation-Date: 2026-09-07 16:21+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -4164,7 +4164,7 @@ msgid "Obfuscation"
 msgstr ""
 
 #: src/muuli_wdr.cpp
-msgid "Protocol extensions:"
+msgid "Protocol extensions"
 msgstr ""
 
 #: src/muuli_wdr.cpp

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-06 23:44+0200\n"
+"POT-Creation-Date: 2026-09-07 16:21+0200\n"
 "PO-Revision-Date: 2026-09-05 11:03+0000\n"
 "Last-Translator: Mike Akiba <mike2718@gmail.com>\n"
 "Language-Team: Chinese Simplified <kde-i18n-doc@kde.org>\n"
@@ -4266,7 +4266,7 @@ msgstr "模糊协议"
 
 #: src/muuli_wdr.cpp
 #, fuzzy
-msgid "Protocol extensions:"
+msgid "Protocol extensions"
 msgstr "模糊协议"
 
 #: src/muuli_wdr.cpp

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-06 23:44+0200\n"
+"POT-Creation-Date: 2026-09-07 16:21+0200\n"
 "PO-Revision-Date: 2026-09-05 11:04+0000\n"
 "Last-Translator: Wayne Su <mstarmstar@gmail.com>\n"
 "Language-Team: \n"
@@ -4280,7 +4280,7 @@ msgstr "模糊協定"
 
 #: src/muuli_wdr.cpp
 #, fuzzy
-msgid "Protocol extensions:"
+msgid "Protocol extensions"
 msgstr "模糊協定"
 
 #: src/muuli_wdr.cpp

--- a/src/muuli_wdr.cpp
+++ b/src/muuli_wdr.cpp
@@ -1259,7 +1259,7 @@ wxSizer *clientDetails( wxWindow *parent, bool call_fit, bool set_sizer )
     wxStaticText *item26 = new wxStaticText( parent, IDT_KAD, _("N/A"), wxDefaultPosition, wxDefaultSize, 0 );
     item26->SetForegroundColour( wxSystemSettings::GetColour(wxSYS_COLOUR_HOTLIGHT) );
     item10->Add( item26, wxSizerFlags().CenterVertical().Border(wxLEFT|wxRIGHT|wxBOTTOM, 5) );
-    wxStaticText *item26a = new wxStaticText( parent, IDT_MOD_CAPABILITIES_LABEL, _("Protocol extensions:"), wxDefaultPosition, wxDefaultSize, 0 );
+    wxStaticText *item26a = new wxStaticText( parent, IDT_MOD_CAPABILITIES_LABEL, LabelWithColon( _("Protocol extensions") ), wxDefaultPosition, wxDefaultSize, 0 );
     item10->Add( item26a, wxSizerFlags().CenterVertical().Border(wxLEFT|wxRIGHT|wxBOTTOM, 5) );
     wxStaticText *item26b = new wxStaticText( parent, IDT_MOD_CAPABILITIES, _("N/A"), wxDefaultPosition, wxDefaultSize, 0 );
     item26b->SetForegroundColour( wxSystemSettings::GetColour(wxSYS_COLOUR_HOTLIGHT) );


### PR DESCRIPTION
The client details dialog was converted whole in #1300, so every label there takes its colon from the localizable `"%s:"` format. The protocol extensions row landed afterwards, in #1288, and kept the colon inside its own msgid.

That leaves one row in an otherwise converted dialog that a translator cannot repunctuate: French wants a space before the colon and Russian forbids one, and both settings now apply to every neighbouring row but not this one.

Routing it through the same helper drops `"Protocol extensions:"` from the catalogs in favour of `"Protocol extensions"`. No translation is lost: the old msgid is fuzzy in all 40 catalogs, never confirmed anywhere, so msgmerge carries each fuzzy translation across unchanged and the string counts do not move.

Diff is one line in `src/muuli_wdr.cpp` plus the regenerated catalogs (one msgid, no reordering).

Verified: monolithic + amulegui build clean on macOS, ctest 56/56, clang-format 18 whole-file on `src/muuli_wdr.cpp` clean, clang-tidy Tier-1 and Tier-2 clean on the diff with 0 compiler errors, `check-potfiles.sh` clean.
