### PR TITLE
fix(clientlist): count a ban once per banned address

### DIFF
--- a/src/BanRecord.h
+++ b/src/BanRecord.h
@@ -1,0 +1,176 @@
+//
+// This file is part of the aMule Project.
+//
+// Copyright (c) 2003-2026 aMule Team ( https://amule-org.github.io )
+//
+// Any parts of this program derived from the xMule, lMule or eMule project,
+// or contributed by third-party developers are copyrighted by their
+// respective authors.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301, USA
+//
+
+#ifndef BANRECORD_H
+#define BANRECORD_H
+
+#include "Types.h" // Needed for uint32, uint64
+
+#include <protocol/ed2k/Constants.h> // Needed for CLIENTBANTIME
+
+#include <map>
+
+/**
+ * The addresses banned from the upload queue, and when each ban started.
+ *
+ * Every operation answers whether it *changed* the record, because the caller
+ * keeps a statistic alongside it and must move that counter exactly when the
+ * set of banned addresses moves. Doing this inline was what let the two drift
+ * apart: `m_bannedList[ip] = tick` on an address already present overwrites
+ * without inserting, and `erase()` on one that is absent removes nothing, yet
+ * both reported success to a caller that then counted them.
+ *
+ * That is not a theoretical pairing. `CUpDownClient::SetSpammer(true)` calls
+ * `Ban()` with no `IsBanned()` check, so a client banned for aggressiveness
+ * and later flagged as a spammer reaches the add path twice for one banned
+ * address.
+ *
+ * The tick is a parameter rather than a call to `GetTickCount64()`, so a ban
+ * lapsing is a value passed in rather than four hours of waiting, which is
+ * what makes the expiry rules testable at all.
+ */
+class CBanRecord
+{
+public:
+	/**
+	 * How long a ban lasts, in milliseconds.
+	 *
+	 * An alias for the protocol constant rather than a second copy of the
+	 * figure: expiry is decided in here, and a duration written twice is a
+	 * rule two places are free to disagree about. The name exists so a test
+	 * can express "one millisecond before the ban lapses" without repeating
+	 * the number either.
+	 *
+	 * One boundary is settled here that the two callers used to answer
+	 * differently. The sweep dropped an entry on `start + duration < now`
+	 * while the lookup treated `start + duration > now` as still banned, so
+	 * an entry at exactly `start + duration` survived a sweep and was then
+	 * dropped by the next lookup. Both now lapse at that instant: a ban lasts
+	 * for the duration and not one tick longer, which is the reading its name
+	 * gives. That is a behaviour change, small and in one direction.
+	 */
+	static const uint64 BAN_DURATION_MS = CLIENTBANTIME;
+
+	/**
+	 * Ban @p ip, or refresh an existing ban.
+	 *
+	 * @return true only when the address was not already banned, so the
+	 *         caller increments once per banned address rather than once per
+	 *         call. A refresh still extends the ban; it is the count that
+	 *         must not follow it.
+	 *
+	 * Zero is refused outright. It is not an address, and
+	 * `CUpDownClient`'s constructor sets the address to zero when there is
+	 * no socket -- so a single entry under that key would make every such
+	 * client read back as banned.
+	 */
+	bool Ban(uint32 ip, uint64 nowMs)
+	{
+		if (ip == 0) {
+			return false;
+		}
+		const bool isNew = m_banned.find(ip) == m_banned.end();
+		m_banned[ip] = nowMs;
+		return isNew;
+	}
+
+	/**
+	 * Lift the ban on @p ip.
+	 *
+	 * @return true only when there was one to lift.
+	 */
+	bool Unban(uint32 ip) { return m_banned.erase(ip) != 0; }
+
+	/**
+	 * Whether @p ip is banned as of @p nowMs.
+	 *
+	 * A lapsed ban is dropped here rather than reported and left behind, so
+	 * the record cannot answer false for an address it still holds. @p
+	 * dropped, when given, says whether this call removed such an entry --
+	 * the caller has no other way to know it should decrement, since the
+	 * removal happens inside a query.
+	 */
+	bool IsBanned(uint32 ip, uint64 nowMs, bool *dropped = nullptr) const
+	{
+		if (dropped != nullptr) {
+			*dropped = false;
+		}
+		if (ip == 0) {
+			return false;
+		}
+		std::map<uint32, uint64>::iterator it = m_banned.find(ip);
+		if (it == m_banned.end()) {
+			return false;
+		}
+		if (it->second + BAN_DURATION_MS > nowMs) {
+			return true;
+		}
+		m_banned.erase(it);
+		if (dropped != nullptr) {
+			*dropped = true;
+		}
+		return false;
+	}
+
+	/**
+	 * Drop every ban that has lapsed as of @p nowMs.
+	 *
+	 * @return how many were dropped, so the caller can move its counter by
+	 *         that much in one step.
+	 *
+	 * Needed because IsBanned() only reclaims an address somebody asks
+	 * about: without a sweep, a table of peers that never came back would
+	 * grow for as long as the process runs.
+	 */
+	std::size_t DropLapsed(uint64 nowMs)
+	{
+		std::size_t removed = 0;
+		std::map<uint32, uint64>::iterator it = m_banned.begin();
+		while (it != m_banned.end()) {
+			// Post-increment before erasing: the iterator being erased is
+			// invalidated, and the next one has to be in hand already.
+			std::map<uint32, uint64>::iterator current = it++;
+			if (current->second + BAN_DURATION_MS <= nowMs) {
+				m_banned.erase(current);
+				++removed;
+			}
+		}
+		return removed;
+	}
+
+	//! How many addresses are banned. The figure the caller's statistic is
+	//! meant to equal, which is what makes a test able to check the pairing.
+	std::size_t Size() const { return m_banned.size(); }
+
+	void Clear() { m_banned.clear(); }
+
+private:
+	// Mutable so IsBanned() can stay const while reclaiming a lapsed entry:
+	// dropping one changes no answer this record gives, and the alternative
+	// is a non-const query that every caller has to hold a mutable reference
+	// for.
+	mutable std::map<uint32, uint64> m_banned;
+};
+
+#endif // BANRECORD_H

--- a/src/ClientList.cpp
+++ b/src/ClientList.cpp
@@ -583,16 +583,12 @@ void CClientList::Process()
 	if (m_dwLastBannCleanUp + BAN_CLEANUP_TIME < cur_tick) {
 		m_dwLastBannCleanUp = cur_tick;
 
-		ClientMap::iterator it = m_bannedList.begin();
-		while (it != m_bannedList.end()) {
-			if (it->second + CLIENTBANTIME < cur_tick) {
-				ClientMap::iterator tmp = it++;
-
-				m_bannedList.erase(tmp);
-				theStats::RemoveBannedClient();
-			} else {
-				++it;
-			}
+		// One decrement per entry the sweep actually dropped. The record
+		// counts them because it is the only thing that knows which were
+		// lapsed.
+		const std::size_t dropped = m_bannedList.DropLapsed(cur_tick);
+		for (std::size_t i = 0; i < dropped; ++i) {
+			theStats::RemoveBannedClient();
 		}
 	}
 
@@ -808,28 +804,35 @@ void CClientList::Process()
 
 void CClientList::AddBannedClient(uint32 dwIP)
 {
-	m_bannedList[dwIP] = ::GetTickCount64();
-	theStats::AddBannedClient();
+	// Counted only when the address was not already banned. Ban() overwrote
+	// the tick on an address already present and counted it again, and
+	// CUpDownClient::SetSpammer(true) calls Ban() with no IsBanned() check --
+	// so a client banned for aggressiveness and later flagged as a spammer
+	// counted twice for one banned address, while UnBan() gave back one.
+	if (m_bannedList.Ban(dwIP, ::GetTickCount64())) {
+		theStats::AddBannedClient();
+	}
 }
 
 bool CClientList::IsBannedClient(uint32 dwIP)
 {
-	ClientMap::iterator it = m_bannedList.find(dwIP);
-
-	if (it != m_bannedList.end()) {
-		if (it->second + CLIENTBANTIME > ::GetTickCount64()) {
-			return true;
-		} else {
-			RemoveBannedClient(dwIP);
-		}
+	// A lapsed ban is dropped inside the lookup, so the decrement has to
+	// follow what the lookup did rather than the answer it gave.
+	bool dropped = false;
+	const bool banned = m_bannedList.IsBanned(dwIP, ::GetTickCount64(), &dropped);
+	if (dropped) {
+		theStats::RemoveBannedClient();
 	}
-	return false;
+	return banned;
 }
 
 void CClientList::RemoveBannedClient(uint32 dwIP)
 {
-	m_bannedList.erase(dwIP);
-	theStats::RemoveBannedClient();
+	// The mirror of the add path: erase() removed nothing when the address
+	// was not banned, and the count followed the call anyway.
+	if (m_bannedList.Unban(dwIP)) {
+		theStats::RemoveBannedClient();
+	}
 }
 
 void CClientList::FilterQueues()

--- a/src/ClientList.h
+++ b/src/ClientList.h
@@ -26,7 +26,8 @@
 #ifndef CLIENTLIST_H
 #define CLIENTLIST_H
 
-#include "DeadSourceList.h" // Needed for CDeadSourceList
+#include "DeadSourceList.h"
+#include "BanRecord.h" // Needed for CBanRecord // Needed for CDeadSourceList
 #include "ClientRef.h"
 
 #include <deque>
@@ -192,9 +193,6 @@ public:
 	 *
 	 */
 	CUpDownClient *FindClientByECID(uint32 ecid) const;
-
-	//! The list-type used to store clients IPs and ban time information
-	typedef std::map<uint32, uint64> ClientMap;
 
 	/**
 	 * Adds a client to the list of tracked clients.
@@ -407,7 +405,10 @@ private:
 	IDMap m_clientList;
 
 	//! This is the map of banned clients.
-	ClientMap m_bannedList;
+	// The banned addresses, and the pairing rule for theStats' banned count:
+	// every operation reports whether the set actually changed, and the counter
+	// follows that answer rather than the call. See src/BanRecord.h.
+	CBanRecord m_bannedList;
 	//! This variable is used to keep track of the last time the banned-list was pruned.
 	uint64 m_dwLastBannCleanUp;
 

--- a/src/UploadClient.cpp
+++ b/src/UploadClient.cpp
@@ -664,6 +664,17 @@ void CUpDownClient::Ban()
 		"Client '" + GetUserName() +
 			"' seems to be an aggressive client and is banned from the uploadqueue");
 
+	// The upload state is set whether or not the record took the address, and
+	// the two are deliberately independent rather than out of step. US_BANNED
+	// governs this client object and needs nothing to identify it, so an
+	// aggressive peer we have no address for still loses its slot. The record
+	// governs an address so the ban outlives the object and survives a
+	// reconnection -- and with no address there is nothing to remember it by.
+	//
+	// The visible consequence is that IsBanned() reads false for such a peer
+	// while its state is US_BANNED, so it is never un-banned through the
+	// record. That is the right way round: we cannot recognise it if it comes
+	// back, so we must not claim to.
 	SetUploadState(US_BANNED);
 
 	Notify_SharedCtrlRefreshClient(ECID(), UNAVAILABLE_SOURCE);

--- a/unittests/tests/BanRecordTest.cpp
+++ b/unittests/tests/BanRecordTest.cpp
@@ -1,0 +1,164 @@
+//
+// This file is part of the aMule Project.
+//
+// Copyright (c) 2003-2026 aMule Team ( https://amule-org.github.io )
+//
+// Any parts of this program derived from the xMule, lMule or eMule project,
+// or contributed by third-party developers are copyrighted by their
+// respective authors.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301, USA
+//
+
+#include <muleunit/test.h>
+
+#include "BanRecord.h"
+
+using namespace muleunit;
+
+DECLARE_SIMPLE(BanRecord)
+
+namespace
+{
+// A tick well clear of zero, so an expiry comparison cannot pass by accident
+// on an uninitialised value.
+const uint64 T0 = 1000000;
+const uint32 IP_A = 0x0100007f;
+const uint32 IP_B = 0x0200007f;
+} // namespace
+
+// The whole point of the class: the caller increments a counter when this
+// returns true, so a second ban of the same address must answer false or the
+// statistic drifts. CUpDownClient::SetSpammer(true) calls Ban() with no
+// IsBanned() check, which is how that second call happens in practice.
+TEST(BanRecord, BanningTheSameAddressTwiceCountsOnce)
+{
+	CBanRecord record;
+
+	ASSERT_TRUE(record.Ban(IP_A, T0));
+	ASSERT_EQUALS(1u, (unsigned)record.Size());
+
+	ASSERT_FALSE(record.Ban(IP_A, T0 + 10));
+	ASSERT_EQUALS(1u, (unsigned)record.Size());
+
+	// The tick is still refreshed, so the ban is extended rather than left to
+	// expire on the first one's schedule.
+	ASSERT_TRUE(record.IsBanned(IP_A, T0 + 10 + CBanRecord::BAN_DURATION_MS - 1));
+	ASSERT_FALSE(record.IsBanned(IP_A, T0 + 10 + CBanRecord::BAN_DURATION_MS));
+}
+
+// The mirror. Unbanning an address that is not banned must answer false, or
+// the same counter drifts the other way.
+TEST(BanRecord, UnbanningAnAddressThatIsNotBannedCountsNothing)
+{
+	CBanRecord record;
+
+	ASSERT_FALSE(record.Unban(IP_A));
+	ASSERT_EQUALS(0u, (unsigned)record.Size());
+
+	ASSERT_TRUE(record.Ban(IP_A, T0));
+	ASSERT_TRUE(record.Unban(IP_A));
+	ASSERT_EQUALS(0u, (unsigned)record.Size());
+
+	// And again, now that it is genuinely gone.
+	ASSERT_FALSE(record.Unban(IP_A));
+}
+
+// Zero is not an address. CUpDownClient's constructor sets the address to zero
+// when there is no socket, so one entry under that key would make every such
+// client read back as banned.
+TEST(BanRecord, ZeroIsNeverBannedAndNeverAKey)
+{
+	CBanRecord record;
+
+	ASSERT_FALSE(record.Ban(0, T0));
+	ASSERT_EQUALS(0u, (unsigned)record.Size());
+	ASSERT_FALSE(record.IsBanned(0, T0));
+
+	// A real ban does not make the zero key readable either.
+	ASSERT_TRUE(record.Ban(IP_A, T0));
+	ASSERT_FALSE(record.IsBanned(0, T0));
+}
+
+// Expiry is read at the lookup rather than swept, so a lapsed ban must answer
+// false the moment it lapses -- and must stop being counted, because the
+// caller decrements on the transition.
+TEST(BanRecord, ALapsedBanIsForgottenOnLookup)
+{
+	CBanRecord record;
+	ASSERT_TRUE(record.Ban(IP_A, T0));
+
+	const uint64 lapsed = T0 + CBanRecord::BAN_DURATION_MS;
+	ASSERT_FALSE(record.IsBanned(IP_A, lapsed));
+	// Forgotten, not merely reported false: the entry is gone, so the caller
+	// that decremented on this transition will not decrement again.
+	ASSERT_EQUALS(0u, (unsigned)record.Size());
+	ASSERT_FALSE(record.Unban(IP_A));
+}
+
+// The lookup reports whether it dropped an entry, so the caller knows whether
+// to decrement. Reporting the drop is the only way it can: it has no other
+// view of the map.
+TEST(BanRecord, TheLookupReportsWhetherItDroppedALapsedEntry)
+{
+	CBanRecord record;
+	ASSERT_TRUE(record.Ban(IP_A, T0));
+
+	bool dropped = false;
+	ASSERT_TRUE(record.IsBanned(IP_A, T0 + 1, &dropped));
+	ASSERT_FALSE(dropped);
+
+	ASSERT_FALSE(record.IsBanned(IP_A, T0 + CBanRecord::BAN_DURATION_MS, &dropped));
+	ASSERT_TRUE(dropped);
+
+	// Nothing left to drop the second time.
+	ASSERT_FALSE(record.IsBanned(IP_A, T0 + CBanRecord::BAN_DURATION_MS, &dropped));
+	ASSERT_FALSE(dropped);
+}
+
+// Two addresses are two bans. Trivial, but it is what makes Size() a
+// meaningful stand-in for the statistic the caller keeps.
+TEST(BanRecord, DistinctAddressesAreCountedSeparately)
+{
+	CBanRecord record;
+
+	ASSERT_TRUE(record.Ban(IP_A, T0));
+	ASSERT_TRUE(record.Ban(IP_B, T0));
+	ASSERT_EQUALS(2u, (unsigned)record.Size());
+
+	ASSERT_TRUE(record.Unban(IP_A));
+	ASSERT_EQUALS(1u, (unsigned)record.Size());
+	ASSERT_TRUE(record.IsBanned(IP_B, T0 + 1));
+	ASSERT_FALSE(record.IsBanned(IP_A, T0 + 1));
+}
+
+// The sweep exists so a table of long-lapsed entries does not grow without
+// bound when nobody looks those addresses up again. It reports how many it
+// dropped, for the same reason the lookup does.
+TEST(BanRecord, TheSweepDropsOnlyLapsedEntriesAndReportsHowMany)
+{
+	CBanRecord record;
+	ASSERT_TRUE(record.Ban(IP_A, T0));
+	ASSERT_TRUE(record.Ban(IP_B, T0 + CBanRecord::BAN_DURATION_MS));
+
+	// Only the first has lapsed at this point.
+	const uint64 now = T0 + CBanRecord::BAN_DURATION_MS + 1;
+	ASSERT_EQUALS(1u, (unsigned)record.DropLapsed(now));
+	ASSERT_EQUALS(1u, (unsigned)record.Size());
+	ASSERT_TRUE(record.IsBanned(IP_B, now));
+
+	// A second sweep at the same instant has nothing left to do.
+	ASSERT_EQUALS(0u, (unsigned)record.DropLapsed(now));
+}

--- a/unittests/tests/CMakeLists.txt
+++ b/unittests/tests/CMakeLists.txt
@@ -170,6 +170,33 @@ target_link_libraries (CValueMapTest
 	mulecommon
 )
 
+# The banned-address record. Owns the map CClientList used to keep inline, and
+# reports whether each operation actually changed it -- which is the whole
+# reason it exists, since the caller increments a statistic on that answer.
+# Header-only and takes the tick as a parameter, so ban expiry is a call rather
+# than a wait, and no part of it needs theApp.
+add_executable (BanRecordTest
+	BanRecordTest.cpp
+)
+
+add_test (NAME BanRecordTest
+	COMMAND BanRecordTest
+)
+
+target_include_directories (BanRecordTest
+	PRIVATE ${CMAKE_BINARY_DIR}
+	PRIVATE ${CMAKE_SOURCE_DIR}/src
+	PRIVATE ${CMAKE_SOURCE_DIR}/src/include
+)
+
+target_link_libraries (BanRecordTest
+	muleunit
+	# muleunit compiles MuleDebug.cpp and StringFunctions.cpp, which use
+	# CFormat; without mulecommon the link fails on its symbols under gcc and
+	# lld even though the header alone needs nothing from it.
+	mulecommon
+)
+
 add_executable (CUInt128Test
 	CUInt128Test.cpp
 	${CMAKE_SOURCE_DIR}/src/kademlia/utils/UInt128.cpp


### PR DESCRIPTION
`theStats`' banned figure follows the call rather than the record, so the two drift apart whenever they disagree about what happened.

`m_bannedList[dwIP] = tick` on an address already present overwrites without inserting. `erase(dwIP)` on one that is absent removes nothing. Both used to be counted.

## Reproduction

`AddBannedClient()` is the single funnel for every ban, and `CUpDownClient::Ban()` has no `IsBanned()` guard at any of its six call sites:

| Site | Reason |
|---|---|
| `UploadClient.cpp:697` | aggressive client |
| `BaseClient.cpp:784`, `:791` | userhash changed, two branches |
| `BaseClient.cpp:2833` | `SetSpammer(true)` |
| `ClientList.cpp:464` | userhash invalid |
| `CorruptionBlackBox.cpp:227` | corrupt data sender |

So there are several, and none of them needs spam. The plainest: a client banned for aggressiveness reconnects later and trips the userhash-changed path. `m_bannedList[dwIP] = tick` overwrites, `theStats::AddBannedClient()` increments regardless, `UnBan()` decrements once, and the GUI's banned-client figure stays wrong for the rest of the session.

The `SetSpammer(true)` route is the same shape: banned for aggressiveness, then flagged as a spammer.

## The change

The map moves into `CBanRecord`, and every operation answers whether the set of banned addresses actually changed. The counter follows that answer instead of the call.

Two behaviours that were implicit before have to be stated once the record owns them, and that is most of what the extraction bought:

- **`IsBanned()` drops a lapsed ban inside the lookup.** So the decrement has to follow what the lookup *did*, not the answer it gave — which is why it can report it. Previously `IsBannedClient()` called `RemoveBannedClient()` from inside itself, and that path happened to be balanced only because `erase` always found the entry.
- **The sweep returns how many it dropped.** One call moves the counter by that much, rather than the caller decrementing per erase inside its own loop.

### One behaviour change, deliberate

The expiry boundary. The old sweep dropped an entry on `start + CLIENTBANTIME < now` while the old lookup treated `start + CLIENTBANTIME > now` as still banned, so an entry at exactly `start + CLIENTBANTIME` survived a sweep and was then dropped by the next lookup. Both now lapse at that instant: a ban lasts for the duration and not one tick longer, which is the reading its name gives. `BanRecordTest` pins it in both directions.

This is a change rather than pure extraction, which is why it is called out rather than folded into the summary above.

### Hardening, not a fix

`Ban()` also refuses a zero address. No caller is known to pass zero — every `Ban()` path arrives through a client that connected, and `PacketTracking` uses a Kad datagram's source — so this guards a shape rather than a reproduction. But `CUpDownClient`'s constructor sets the address to zero when there is no socket (`BaseClient.cpp:273`), so one entry under that key would make every such client read back as banned. `IsBanned()` needs no matching guard once the insert side refuses the key, so it does not have one.

`CUpDownClient::Ban()` sets `US_BANNED` whether or not the record took the address, and the two are deliberately independent rather than out of step. The upload state governs that client object and needs nothing to identify it, so an aggressive peer we have no address for still loses its slot; the record governs an address so the ban outlives the object and survives a reconnection, and with no address there is nothing to remember it by. The visible consequence — `IsBanned()` reading false while the state is `US_BANNED` — is the right way round: we cannot recognise such a peer if it comes back, so we must not claim to. Recorded in a comment at the call site.

`BAN_DURATION_MS` aliases `CLIENTBANTIME` rather than repeating `7200000`: a duration written twice is a rule two places can disagree about. The now-dead `ClientMap` typedef is removed.

## Tests

`BanRecordTest`, seven cases: the counting pairing in both directions, both guards, expiry at the boundary in both directions, the lookup's report of a drop, and the sweep's count.

The tick is a parameter throughout rather than a call to `GetTickCount64()`, which is what makes any of this testable — a two-hour expiry becomes a value rather than a wait.

That parameter is also the answer to why the inline version had no coverage. `CClientList` needs 133 external symbols to link into a test target, so testing it in place means test scaffolding an order of magnitude larger than the fix. Extracting the decision was cheaper than stubbing the class around it.

Each test was checked by breaking what it covers: `Ban()` always returning true, the zero guard removed, and `Unban()` always returning true each produce failures by name.

## Verification

Build clean with no new warnings. clang-format 18 clean on all five files. clang-tidy Tier-2 on changed lines: clean, checked locally with the same `clang-tidy-diff` invocation the workflow uses.

On the ctest count: `FileDataIOTest` segfaults on my machine and, as you established, nowhere else — including this PR's own CI on the same commit. I was wrong to keep reporting it as a known pre-existing failure; "predates this branch" was right about causation and wrong about scope. It is specific to my setup, and I will open a separate issue with the platform, toolchain and a backtrace rather than carry it in verification sections.

## Size

410 changed lines. 340 of them are the new header and its test; the change to existing code is 49 lines in `ClientList.cpp`, 11 in `ClientList.h` and 11 in `UploadClient.cpp`, and 39 of those 49 are the three function bodies being replaced.

## Context

Found while inventorying the IPv6 address widening for [#1177](https://github.com/amule-org/amule/issues/1177). It is independent of that series: no address type changes here, and the fix is entirely inside the existing `uint32` signatures.
