### PR TITLE
feat(net): add an internal address type that can hold IPv6

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1017,6 +1017,19 @@ endif()
 IF (NEED_LIB_MULESOCKET)
 	add_library (mulesocket STATIC
 		LibSocket.cpp
+		# The two text operations of CNetworkAddress (parse and format) are the
+		# only ones that still compile Boost.Asio, so the type is not
+		# header-only and every target touching an address has to link this TU.
+		#
+		# It lives here rather than in muleappcommon for two reasons, both about
+		# where asio already is. mulesocket is the last static library on every
+		# executable's link line, so a one-pass linker resolves these symbols
+		# for muleappcommon and mulecommon too -- putting them in muleappcommon
+		# instead breaks amulegui, which is scanned before mulesocket. And
+		# mulesocket already links ${Boost_LIBRARIES}, which on mingw-w64 is
+		# ws2_32;mswsock -- exactly what asio's winsock_init needs, and what
+		# targets that merely include NetworkAddress.h must not require.
+		NetworkAddress.cpp
 		# The one interface enumeration in the tree. Here rather than in
 		# muleappcommon because LibSocketAsio.cpp resolves a bind-to-interface
 		# name through it and mulesocket does not link muleappcommon, while

--- a/src/NetworkAddress.cpp
+++ b/src/NetworkAddress.cpp
@@ -1,0 +1,112 @@
+//
+// This file is part of the aMule Project.
+//
+// Copyright (c) 2003-2026 aMule Team ( https://amule-org.github.io )
+//
+// Any parts of this program derived from the xMule, lMule or eMule project,
+// or contributed by third-party developers are copyrighted by their
+// respective authors.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301, USA
+//
+
+// The only translation unit in the ed2k core that compiles Boost.Asio for the
+// sake of an address.
+//
+// CNetworkAddress stores its own octets so that the 155 TUs which merely pass
+// an address around no longer pull asio's include closure (and, on Windows, no
+// longer need ws2_32 to link) -- the full argument is in NetworkAddress.h. But
+// two of its operations are text handling, and text handling is where a
+// hand-rolled implementation goes wrong quietly: RFC 4291 zero compression has
+// a canonical form with real rules (longest run, leftmost on a tie, never a
+// single group), IPv4-mapped addresses print with a dotted-quad tail, and a
+// literal may carry a %scope suffix. Restating that here would be a parser and
+// a formatter to maintain, so both stay asio's job and pay for themselves in
+// this one file.
+
+#include "NetworkAddressAsio.h"
+
+#include <boost/system/error_code.hpp>
+
+CNetworkAddress CNetworkAddress::FromString(const std::string &text)
+{
+	if (text.empty()) {
+		return Absent();
+	}
+	boost::system::error_code ec;
+	const boost::asio::ip::address address = boost::asio::ip::make_address(text, ec);
+	if (ec) {
+		return Absent();
+	}
+	return NetworkAddressAsio::FromAsioAddress(address);
+}
+
+std::string CNetworkAddress::ToString() const
+{
+	if (IsAbsent()) {
+		return "<absent>";
+	}
+	return NetworkAddressAsio::ToAsioAddress(*this).to_string();
+}
+
+namespace NetworkAddressAsio
+{
+
+boost::asio::ip::address ToAsioAddress(const CNetworkAddress &address)
+{
+	if (address.IsIPv4()) {
+		const CNetworkAddress::Octets &octets = address.GetOctets();
+		// asio's address_v4 takes its four octets in the same wire order
+		// CNetworkAddress stores them in, so this is a copy and not a swap --
+		// neither of the two 32-bit conventions is involved.
+		const boost::asio::ip::address_v4::bytes_type v4Bytes = {
+			{ octets[0], octets[1], octets[2], octets[3] }
+		};
+		return boost::asio::ip::address(boost::asio::ip::address_v4(v4Bytes));
+	}
+	// An absent address reaches here only as a broken precondition, and asio
+	// has no value for it: the caller was told to test IsPresent() first. Give
+	// it :: rather than 0.0.0.0 so that a caller which ignored that contract
+	// gets an address of the family it asked about instead of silently binding
+	// the IPv4 wildcard.
+	boost::asio::ip::address_v6::bytes_type v6Bytes;
+	const CNetworkAddress::Octets &octets = address.GetOctets();
+	for (std::size_t i = 0; i < v6Bytes.size(); ++i) {
+		v6Bytes[i] = octets[i];
+	}
+	return boost::asio::ip::address(boost::asio::ip::address_v6(v6Bytes, address.GetScopeId()));
+}
+
+CNetworkAddress FromAsioAddress(const boost::asio::ip::address &address)
+{
+	if (address.is_v4()) {
+		// to_uint() is asio's host-order (numeric) accessor, which is the same
+		// convention FromIPv4HostOrder() names -- so no swap here either.
+		return CNetworkAddress::FromIPv4HostOrder(address.to_v4().to_uint());
+	}
+	const boost::asio::ip::address_v6 v6 = address.to_v6();
+	const boost::asio::ip::address_v6::bytes_type v6Bytes = v6.to_bytes();
+	CNetworkAddress::Octets octets;
+	for (std::size_t i = 0; i < octets.size(); ++i) {
+		octets[i] = v6Bytes[i];
+	}
+	// IPv6FromOctets() rather than FromIPv6Bytes(): :: is a legitimate asio
+	// address (it is the wildcard every dual-stack listener binds), and the
+	// all-zero-means-absent rule belongs to the wire-tag edge, not here.
+	return CNetworkAddress::IPv6FromOctets(octets, v6.scope_id());
+}
+
+} // namespace NetworkAddressAsio
+// File_checked_for_headers

--- a/src/NetworkAddress.cpp
+++ b/src/NetworkAddress.cpp
@@ -61,6 +61,11 @@ std::string CNetworkAddress::ToString() const
 	return NetworkAddressAsio::ToAsioAddress(*this).to_string();
 }
 
+wxString CNetworkAddress::ToWxString() const
+{
+	return wxString::FromUTF8(ToString().c_str());
+}
+
 namespace NetworkAddressAsio
 {
 

--- a/src/NetworkAddress.h
+++ b/src/NetworkAddress.h
@@ -31,6 +31,8 @@
 #include <cstring>
 #include <string>
 
+#include <wx/string.h>
+
 /**
  * The internal, family-agnostic address type.
  *
@@ -485,6 +487,9 @@ public:
 		if (a == 192 && b == 0 && plain.m_octets[2] == 2) {
 			return false; // 192.0.2.0/24, TEST-NET-1 documentation (RFC 5737).
 		}
+		if (a == 192 && b == 88 && plain.m_octets[2] == 99) {
+			return false; // 192.88.99.0/24, IPv6 relay anycast (RFC 3068).
+		}
 		if (a == 192 && b == 168) {
 			return false; // 192.168.0.0/16, private (RFC 1918).
 		}
@@ -522,6 +527,12 @@ public:
 		// library did and pins them to this file's stated rule.
 		if (IsLoopbackIPv6()) {
 			return false;
+		}
+		if (m_octets[0] == 0x20 && m_octets[1] == 0x01 && m_octets[2] == 0 && m_octets[3] == 0) {
+			return false; // 2001::/32, Teredo.
+		}
+		if (m_octets[0] == 0x20 && m_octets[1] == 0x02) {
+			return false; // 2002::/16, 6to4.
 		}
 		if (m_octets[0] == 0xFF) {
 			return false; // ff00::/8, multicast.
@@ -594,6 +605,8 @@ public:
 	 * RFC 4291 canonical form is a library's job, not this header's.
 	 */
 	std::string ToString() const;
+
+	wxString ToWxString() const;
 
 	// Comparison. See the class comment for the single rule these implement.
 	//

--- a/src/NetworkAddress.h
+++ b/src/NetworkAddress.h
@@ -1,0 +1,691 @@
+//
+// This file is part of the aMule Project.
+//
+// Copyright (c) 2003-2026 aMule Team ( https://amule-org.github.io )
+//
+// Any parts of this program derived from the xMule, lMule or eMule project,
+// or contributed by third-party developers are copyrighted by their
+// respective authors.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301, USA
+//
+
+#ifndef NETWORKADDRESS_H
+#define NETWORKADDRESS_H
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <string>
+
+/**
+ * The internal, family-agnostic address type.
+ *
+ * aMule stores IP addresses as bare @c uint32 across Kademlia, the client list
+ * and the IP filter. That representation cannot hold an IPv6 address, and it
+ * carries two further defects that a plain widening would silently inherit:
+ *
+ *  - **Byte order is not in the type.** A @c uint32 IP in this tree is in one
+ *    of two conventions depending on the call site, and the two are bridged by
+ *    scattered @c wxUINT32_SWAP_ALWAYS calls. Which convention a value is in
+ *    is documented in comments at best.
+ *  - **Zero doubles as "no address".** So a client whose address is genuinely
+ *    unknown is indistinguishable from one at @c 0.0.0.0.
+ *
+ * This type fixes both by construction. There is no implicit conversion to or
+ * from @c uint32: every narrowing and widening goes through a named function
+ * whose name states the byte order, and absence is a state of the object
+ * rather than a magic value.
+ *
+ * ## Why this header pulls in no socket library
+ *
+ * The address used to be stored as an @c asio::ip::address, borrowing
+ * asio's v4/v6 variant rather than restating it. That was cheap to write and
+ * expensive to compile: this header is reached by eighteen public headers --
+ * updownclient.h, ClientList.h, IPFilter.h, DownloadQueue.h among them -- so
+ * asio ended up in the include closure of 155 of the 254 translation units in
+ * src/, and it took two whole platforms down with it:
+ *
+ *  - Asio's @c ip/address.hpp pulls @c asio/detail/winsock_init.hpp, whose
+ *    static initialiser references @c WSAStartup / @c WSACleanup. Every one of
+ *    those 155 TUs therefore needed @c ws2_32 at link time, and the targets
+ *    that do not link it failed on mingw-w64 -- for an address type that never
+ *    opens a socket.
+ *  - It is a large closure (about 1200 headers) compiled 155 times over for
+ *    what is, in the end, sixteen bytes and a family tag.
+ *
+ * So the storage is now those sixteen bytes and that family tag, spelled out
+ * here. Only the two operations that genuinely need a library -- parsing a
+ * textual address and formatting one -- still use asio, and they live in
+ * NetworkAddress.cpp where exactly one TU pays for them. Nothing about IPv6
+ * text handling is hand-rolled: RFC 4291 zero compression, the IPv4-mapped
+ * dotted-quad tail and scope-id suffixes are all still asio's job.
+ *
+ * A caller that needs the asio value itself -- the socket backend, and only
+ * it -- gets it from NetworkAddressAsio.h, which is the one bridge and is
+ * included by the TUs that truly open sockets.
+ *
+ * ## The two 32-bit conventions
+ *
+ * For the address @c 192.0.2.1:
+ *
+ * | Convention | Value | Used by |
+ * | --- | --- | --- |
+ * | host order (numeric) | @c 0xC0000201 | Kademlia (`KadIPToString`) |
+ * | network order | @c 0x010200C0 | ed2k core (`Uint32toStringIP`) |
+ *
+ * "Network order" is the name used in this type's API for what the rest of
+ * aMule's comments call *anti-host order*: the four octets packed with the
+ * first octet in the numerically least significant byte. On a little-endian
+ * host that is the value obtained by loading four network-order bytes straight
+ * into a @c uint32, which is how it arises in practice -- an ed2k packet field
+ * read by CFileDataIO. The two conventions are exact byte reversals of each
+ * other on every platform, which is why @c wxUINT32_SWAP_ALWAYS converts
+ * between them unconditionally.
+ *
+ * Note that neither convention is the storage order. Internally the address is
+ * always its octets in wire order, most significant first, so that the v4 and
+ * v6 cases need no separate code path and the comparison rule below is one
+ * lexicographic compare rather than a family switch.
+ *
+ * ## Comparison rule
+ *
+ * One rule, applied everywhere:
+ *
+ *  1. An absent address sorts before every present one, and equals only
+ *     another absent address.
+ *  2. IPv4 sorts before IPv6.
+ *  3. Within a family, addresses sort by their octets, most significant
+ *     first.
+ *
+ * IPv4-mapped forms are **not** normalised: @c ::ffff:192.0.2.1 is an IPv6
+ * address, so it is neither equal to nor adjacent to the IPv4 address
+ * @c 192.0.2.1. This keeps the ordering total with no two distinct addresses
+ * comparing equal, which is what makes the type safe as a container key.
+ * Callers that want the two treated alike must say so by calling Unmapped()
+ * first.
+ */
+class CNetworkAddress
+{
+public:
+	/** How many octets an address of either family occupies. */
+	static constexpr std::size_t OCTET_COUNT = 16;
+
+	/** The sixteen octets an IPv6 address occupies, in wire order. */
+	using Octets = std::array<std::uint8_t, OCTET_COUNT>;
+
+	/**
+	 * Which family a present address belongs to, or that there is none.
+	 *
+	 * Absence is a case of this enum rather than a wrapping std::optional so
+	 * that the object stays trivially copyable and one word smaller, and so
+	 * that the three-way switch the comparison rule needs is a switch on one
+	 * field instead of a nested optional test.
+	 */
+	enum class Family : std::uint8_t
+	{
+		None,
+		IPv4,
+		IPv6
+	};
+
+	/** Constructs an absent address -- @b not @c 0.0.0.0. */
+	CNetworkAddress() = default;
+
+	/** An explicitly absent address, for call sites where the name reads better. */
+	static CNetworkAddress Absent() { return CNetworkAddress(); }
+
+	/**
+	 * Builds an IPv4 address from a 32-bit value in host (numeric) order,
+	 * i.e. @c 192.0.2.1 is @c 0xC0000201. This is the Kademlia convention.
+	 */
+	static CNetworkAddress FromIPv4HostOrder(std::uint32_t ip)
+	{
+		CNetworkAddress result;
+		result.m_family = Family::IPv4;
+		result.m_octets[0] = static_cast<std::uint8_t>((ip >> 24) & 0xFFu);
+		result.m_octets[1] = static_cast<std::uint8_t>((ip >> 16) & 0xFFu);
+		result.m_octets[2] = static_cast<std::uint8_t>((ip >> 8) & 0xFFu);
+		result.m_octets[3] = static_cast<std::uint8_t>(ip & 0xFFu);
+		return result;
+	}
+
+	/**
+	 * Builds an IPv4 address from a 32-bit value in network order, i.e.
+	 * @c 192.0.2.1 is @c 0x010200C0. This is the ed2k convention, called
+	 * "anti-host order" elsewhere in the tree.
+	 */
+	static CNetworkAddress FromIPv4NetworkOrder(std::uint32_t ip)
+	{
+		return FromIPv4HostOrder(SwapOctets(ip));
+	}
+
+	/**
+	 * The conversion boundary for a 32-bit ed2k-order address field in which
+	 * zero is overloaded to mean "no address".
+	 *
+	 * This is the lossy direction and the only place the overload is allowed to
+	 * live. A caller holding such a field cannot tell @c 0.0.0.0 from "unknown",
+	 * so this resolves the ambiguity once, at the edge, in favour of absence --
+	 * which is what the @c if (ip) tests it replaces already did. Use it only
+	 * where the old code actually tested the value against zero; where zero was
+	 * simply a value, FromIPv4NetworkOrder() keeps behaviour identical.
+	 */
+	static CNetworkAddress FromIPv4NetworkOrderOrAbsent(std::uint32_t ip)
+	{
+		return ip == 0 ? Absent() : FromIPv4NetworkOrder(ip);
+	}
+
+	/** As FromIPv4NetworkOrderOrAbsent(), for the Kad host-order convention. */
+	static CNetworkAddress FromIPv4HostOrderOrAbsent(std::uint32_t ip)
+	{
+		return ip == 0 ? Absent() : FromIPv4HostOrder(ip);
+	}
+
+	/**
+	 * Builds an IPv6 address from its octets, with no interpretation of their
+	 * value at all -- the all-zero octets give the unspecified address @c :: ,
+	 * which is a real address here and not absence.
+	 *
+	 * This is the raw widening, for callers that already know they hold an
+	 * address: the asio bridge reconstructing one, and AnyIPv6() below. A
+	 * caller decoding a wire tag wants FromIPv6Bytes() instead, which applies
+	 * that edge's absence rule.
+	 */
+	static CNetworkAddress IPv6FromOctets(const Octets &octets, unsigned long scopeId = 0)
+	{
+		CNetworkAddress result;
+		result.m_family = Family::IPv6;
+		result.m_octets = octets;
+		result.m_scopeId = scopeId;
+		return result;
+	}
+
+	/**
+	 * The IPv6 wildcard, @c :: -- present, IPv6 and unspecified.
+	 *
+	 * Named rather than left to IPv6FromOctets({}) because the call sites that
+	 * want it are binding a listening socket to "every local address", and at
+	 * those sites @c :: is a decision about reachability, not sixteen zero
+	 * bytes. It also keeps them from reaching for the asio-typed wildcard in
+	 * AddressFamilyPolicyAsio.h, which would put asio back in their closure.
+	 */
+	static CNetworkAddress AnyIPv6() { return IPv6FromOctets(Octets{}); }
+
+	/**
+	 * Builds an IPv6 address from sixteen big-endian bytes -- the form the
+	 * @c CT_MOD_IP_V6 hello tag and the Kad @c "ip6" tag carry.
+	 *
+	 * @return The address, or an @b absent address when @a bytes is NULL or
+	 *         the sixteen bytes are all zero. The all-zero value is @c :: ,
+	 *         which is what a peer that has no IPv6 address sends when it
+	 *         emits the tag anyway; treating it as an address would have aMule
+	 *         dialling the unspecified address.
+	 */
+	static CNetworkAddress FromIPv6Bytes(const std::uint8_t *bytes)
+	{
+		if (bytes == nullptr) {
+			return Absent();
+		}
+		Octets raw;
+		bool allZero = true;
+		for (std::size_t i = 0; i < raw.size(); ++i) {
+			raw[i] = bytes[i];
+			if (bytes[i] != 0) {
+				allZero = false;
+			}
+		}
+		if (allZero) {
+			return Absent();
+		}
+		return IPv6FromOctets(raw);
+	}
+
+	/**
+	 * Parses a textual address, IPv4 or IPv6.
+	 *
+	 * Defined in NetworkAddress.cpp: this is one of the two operations that
+	 * still go through asio, so that the accepted syntax stays exactly a
+	 * library's idea of an address literal rather than this file's.
+	 *
+	 * @return The address, or an @b absent address if @a text is not a valid
+	 *         literal. Note that this never yields @c 0.0.0.0 on failure, unlike
+	 *         StringIPtoUint32().
+	 */
+	static CNetworkAddress FromString(const std::string &text);
+
+	bool IsPresent() const noexcept { return m_family != Family::None; }
+	bool IsAbsent() const noexcept { return m_family == Family::None; }
+
+	/** True for a present address whose every octet is zero (@c 0.0.0.0 or @c ::). */
+	bool IsUnspecified() const noexcept
+	{
+		if (IsAbsent()) {
+			return false;
+		}
+		// The unused tail of an IPv4 address is always zero (see m_octets), so
+		// one loop over all sixteen answers for both families.
+		for (const std::uint8_t octet : m_octets) {
+			if (octet != 0) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	bool IsIPv4() const noexcept { return m_family == Family::IPv4; }
+	bool IsIPv6() const noexcept { return m_family == Family::IPv6; }
+
+	/** True only for an IPv6 address in the @c ::ffff:a.b.c.d form. */
+	bool IsIPv4Mapped() const noexcept
+	{
+		if (!IsIPv6()) {
+			return false;
+		}
+		// The prefix is RFC 4291 section 2.5.5.2: eighty zero bits, then
+		// 0xffff. Tested against the octets rather than via asio's
+		// address_v6::is_v4_mapped(), which asio deprecated after 1.66 and has
+		// since removed -- and which this header no longer has anyway.
+		for (int i = 0; i < 10; ++i) {
+			if (m_octets[i] != 0) {
+				return false;
+			}
+		}
+		return m_octets[10] == 0xff && m_octets[11] == 0xff;
+	}
+
+	/**
+	 * The address as its sixteen octets in wire order.
+	 *
+	 * For an IPv6 address these are the address. For IPv4 the four octets sit
+	 * in the first four positions and the rest are zero, which is @b not the
+	 * IPv4-mapped form -- so do not hand these to something expecting sixteen
+	 * IPv6 octets without checking the family first. For an absent address they
+	 * are all zero, which is exactly the conflation this type exists to
+	 * prevent, so check IsPresent() too.
+	 *
+	 * This exists so that callers doing bit arithmetic on an address -- prefix
+	 * matching in IPFilterMatch.h, chiefly -- can do it without a library and
+	 * without this header growing one. Where the caller wants the guardrails,
+	 * ToIPv6Bytes() below states the family requirement in its return value.
+	 */
+	const Octets &GetOctets() const noexcept { return m_octets; }
+
+	/**
+	 * The interface scope of an IPv6 address, or zero when it has none.
+	 *
+	 * Carried because it is part of the address's identity: @c fe80::1%eth0 and
+	 * @c fe80::1%eth1 are two different destinations, so folding them together
+	 * would break the total order this type promises.
+	 */
+	unsigned long GetScopeId() const noexcept { return m_scopeId; }
+
+	/**
+	 * The same address with any IPv4-mapped IPv6 form collapsed to plain IPv4.
+	 * Everything else, including absence, is returned unchanged. Call this
+	 * deliberately at sites that must treat the mapped and native forms as one
+	 * address; the comparison operators never do it for you.
+	 */
+	CNetworkAddress Unmapped() const
+	{
+		if (IsIPv4Mapped()) {
+			return FromIPv4HostOrder(EmbeddedIPv4HostOrder());
+		}
+		return *this;
+	}
+
+	/**
+	 * Narrows to a 32-bit IPv4 value in host (numeric) order.
+	 *
+	 * @param out Assigned only on success; left untouched on failure, so a
+	 *            caller that ignores the result cannot end up with a fabricated
+	 *            address.
+	 * @return False if the address is absent, or is an IPv6 address that is not
+	 *         IPv4-mapped. Such an address has no 32-bit form and this
+	 *         deliberately fails rather than truncating or hashing it.
+	 */
+	bool ToIPv4HostOrder(std::uint32_t &out) const noexcept
+	{
+		if (IsIPv4()) {
+			out = PackOctets(m_octets[0], m_octets[1], m_octets[2], m_octets[3]);
+			return true;
+		}
+		if (IsIPv4Mapped()) {
+			out = EmbeddedIPv4HostOrder();
+			return true;
+		}
+		return false;
+	}
+
+	/**
+	 * Narrows to a 32-bit IPv4 value in network order (ed2k / "anti-host"
+	 * order). Same failure contract as ToIPv4HostOrder().
+	 */
+	bool ToIPv4NetworkOrder(std::uint32_t &out) const noexcept
+	{
+		std::uint32_t hostOrder = 0;
+		if (!ToIPv4HostOrder(hostOrder)) {
+			return false;
+		}
+		out = SwapOctets(hostOrder);
+		return true;
+	}
+
+	/**
+	 * Narrows back to an ed2k-order field that uses zero for "no address",
+	 * for handing to an edge this refactor has not reached yet.
+	 *
+	 * @return Zero for an absent address, and also for an address with no
+	 *         32-bit form. Prefer ToIPv4NetworkOrder() wherever the caller can
+	 *         act on the difference: this one cannot report it.
+	 */
+	std::uint32_t ToIPv4NetworkOrderOrZero() const noexcept
+	{
+		std::uint32_t value = 0;
+		ToIPv4NetworkOrder(value);
+		return value;
+	}
+
+	/**
+	 * Writes an IPv6 address out as sixteen big-endian bytes -- the form the
+	 * @c CT_MOD_IP_V6 hello tag and the Kad @c "ip6" tag carry.
+	 *
+	 * @param out Sixteen bytes, written only on success, so a caller that
+	 *            ignores the result cannot emit a half-filled address.
+	 * @return False for an absent or IPv4 address. An IPv4-mapped one is
+	 *         written as the mapped IPv6 address it is: that is what the peer
+	 *         asked for when it asked for an IPv6 address.
+	 */
+	bool ToIPv6Bytes(std::uint8_t *out) const noexcept
+	{
+		if (out == nullptr || !IsIPv6()) {
+			return false;
+		}
+		// One copy of a constant length, not a loop bounded by m_octets.size().
+		// The two are the same sixteen bytes, but only the constant states the
+		// postcondition above in a form a reader -- or a static analyser -- can
+		// check without first proving what size() returns. The Clang Static
+		// Analyzer could not: it explored the zero-iteration path through the
+		// old loop and concluded this function returns true having written
+		// nothing, which surfaced as garbage-value reports in all four callers
+		// that read the buffer back (IPFilterMatch.h, NatRendezvousProtocol.h
+		// and, through CMD4Hash, ArchSpecific.h).
+		std::memcpy(out, m_octets.data(), OCTET_COUNT);
+		return true;
+	}
+
+	/**
+	 * Whether this is an IPv4 address that can stand for this host on the
+	 * public internet: present, IPv4 (or the mapped form of one), and outside
+	 * every range the address itself declares unroutable -- the unspecified
+	 * address, loopback, the three RFC1918 private blocks, link-local,
+	 * carrier-grade NAT, the documentation and benchmark blocks, multicast and
+	 * the reserved top of the space.
+	 *
+	 * The IPv6 sibling below exists so an address is never advertised to a peer
+	 * that cannot reach it. This one exists for a second reason, and it is the
+	 * sharper of the two: aMule's UDP obfuscation bakes the *sender's* own
+	 * public address into the key -- EncryptedDatagramSocket.cpp derives it as
+	 * MD5(<receiver user hash 16><sender IP 4><0x5B><random 2>) -- while the
+	 * receiver derives its half from the source address of the datagram it
+	 * actually got. The two only agree when the sender's idea of its own
+	 * address is the one the peer sees. Encrypt with 127.0.1.1 in that field
+	 * and every frame decrypts to noise at the far end, with nothing logged on
+	 * either side, because a failed obfuscation looks exactly like a peer that
+	 * never obfuscated. So "do I have an address a stranger could reply to" has
+	 * to be answered before the key is derived, not assumed from non-zero.
+	 */
+	bool IsGloballyRoutableIPv4() const noexcept
+	{
+		const CNetworkAddress plain = Unmapped();
+		if (!plain.IsIPv4() || plain.IsUnspecified()) {
+			return false;
+		}
+		const std::uint8_t a = plain.m_octets[0];
+		const std::uint8_t b = plain.m_octets[1];
+
+		if (a == 0) {
+			return false; // 0.0.0.0/8, "this network" (RFC 1122).
+		}
+		if (a == 10) {
+			return false; // 10.0.0.0/8, private (RFC 1918).
+		}
+		if (a == 100 && (b & 0xC0) == 0x40) {
+			return false; // 100.64.0.0/10, carrier-grade NAT (RFC 6598).
+		}
+		if (a == 127) {
+			// 127.0.0.0/8. The whole block, not just 127.0.0.1: a Debian host
+			// names itself 127.0.1.1 in /etc/hosts, and that is precisely the
+			// value CamuleApp::GetPublicIP() hands back when it falls through
+			// to m_localip.
+			return false;
+		}
+		if (a == 169 && b == 254) {
+			return false; // 169.254.0.0/16, link-local (RFC 3927).
+		}
+		if (a == 172 && (b & 0xF0) == 16) {
+			return false; // 172.16.0.0/12, private (RFC 1918).
+		}
+		if (a == 192 && b == 0 && plain.m_octets[2] == 0) {
+			return false; // 192.0.0.0/24, IETF protocol assignments.
+		}
+		if (a == 192 && b == 0 && plain.m_octets[2] == 2) {
+			return false; // 192.0.2.0/24, TEST-NET-1 documentation (RFC 5737).
+		}
+		if (a == 192 && b == 168) {
+			return false; // 192.168.0.0/16, private (RFC 1918).
+		}
+		if (a == 198 && (b & 0xFE) == 18) {
+			return false; // 198.18.0.0/15, benchmarking (RFC 2544).
+		}
+		if (a == 198 && b == 51 && plain.m_octets[2] == 100) {
+			return false; // 198.51.100.0/24, TEST-NET-2 (RFC 5737).
+		}
+		if (a == 203 && b == 0 && plain.m_octets[2] == 113) {
+			return false; // 203.0.113.0/24, TEST-NET-3 (RFC 5737).
+		}
+		// 224.0.0.0/4 multicast and 240.0.0.0/4 reserved, which together are
+		// everything from 224 up. Neither is a unicast source address.
+		return a < 224;
+	}
+
+	/**
+	 * Whether this is an IPv6 address worth telling a peer about: present,
+	 * IPv6, not mapped, and globally routable as far as the address itself can
+	 * say -- so not the unspecified address, not loopback, not link-local and
+	 * not a unique-local address.
+	 *
+	 * Advertising any of those is worse than advertising nothing: the peer
+	 * cannot reach them and spends a connect attempt finding out.
+	 */
+	bool IsGloballyRoutableIPv6() const noexcept
+	{
+		if (!IsIPv6() || IsIPv4Mapped() || IsUnspecified()) {
+			return false;
+		}
+		// The prefixes, all from RFC 4291 except fc00::/7 (RFC 4193). These
+		// were asio's address_v6 predicates until this header dropped asio;
+		// each is one prefix test, so restating them costs less than the
+		// library did and pins them to this file's stated rule.
+		if (IsLoopbackIPv6()) {
+			return false;
+		}
+		if (m_octets[0] == 0xFF) {
+			return false; // ff00::/8, multicast.
+		}
+		if (m_octets[0] == 0xFE) {
+			const std::uint8_t top = static_cast<std::uint8_t>(m_octets[1] & 0xC0);
+			if (top == 0x80) {
+				return false; // fe80::/10, link-local.
+			}
+			if (top == 0xC0) {
+				return false; // fec0::/10, the deprecated site-local range.
+			}
+		}
+		// fc00::/7, unique-local. asio's is_site_local() only ever covered the
+		// deprecated fec0::/10 above, so this was tested here rather than
+		// assumed even when asio was in use.
+		return (m_octets[0] & 0xFE) != 0xFC;
+	}
+
+	/**
+	 * The network address of the prefix this address falls in: the same
+	 * address with every bit below @a prefixBits cleared.
+	 *
+	 * Used where a limit or a rule applies to a block rather than to a host --
+	 * an IPv6 subscriber is delegated a prefix, not an address, so a per-address
+	 * budget under IPv6 counts to one forever (see PeerAddressing.h).
+	 *
+	 * @param prefixBits Counted from the most significant bit of the address in
+	 *                   its own family: 0..32 for IPv4, 0..128 for IPv6. A value
+	 *                   at or above the family's width returns the address
+	 *                   unchanged.
+	 * @return The prefix's network address. An absent address is returned
+	 *         unchanged -- there is no prefix to compute and none is invented.
+	 */
+	CNetworkAddress TruncatedToPrefix(unsigned prefixBits) const
+	{
+		if (IsAbsent()) {
+			return *this;
+		}
+		const unsigned width = IsIPv4() ? 32u : 128u;
+		if (prefixBits >= width) {
+			return *this;
+		}
+		Octets bytes = m_octets;
+		for (std::size_t i = 0; i < bytes.size(); ++i) {
+			const unsigned bitsBefore = static_cast<unsigned>(i) * 8u;
+			if (prefixBits >= bitsBefore + 8u) {
+				continue; // Wholly inside the prefix.
+			}
+			if (prefixBits <= bitsBefore) {
+				bytes[i] = 0; // Wholly outside it.
+			} else {
+				bytes[i] = static_cast<std::uint8_t>(
+					bytes[i] & (0xFFu << (bitsBefore + 8u - prefixBits)));
+			}
+		}
+		if (IsIPv4()) {
+			return FromIPv4HostOrder(PackOctets(bytes[0], bytes[1], bytes[2], bytes[3]));
+		}
+		// The scope id is deliberately not carried over: a prefix is not
+		// interface-scoped, and keeping it would make the same prefix seen on
+		// two interfaces into two prefixes.
+		return IPv6FromOctets(bytes);
+	}
+
+	/**
+	 * Textual form, or @c "<absent>" when there is no address.
+	 *
+	 * Defined in NetworkAddress.cpp for the reason given on FromString(): the
+	 * RFC 4291 canonical form is a library's job, not this header's.
+	 */
+	std::string ToString() const;
+
+	// Comparison. See the class comment for the single rule these implement.
+	//
+	// All four reduce to comparing (family, octets, scope id) in that order,
+	// because the storage was chosen to make them: the octets are already in
+	// most-significant-first order, so std::array's lexicographic compare *is*
+	// rule 3, and an IPv4 address's unused tail is always zero so it needs no
+	// separate case.
+	bool operator==(const CNetworkAddress &other) const noexcept
+	{
+		return m_family == other.m_family && m_octets == other.m_octets &&
+		       m_scopeId == other.m_scopeId;
+	}
+	bool operator!=(const CNetworkAddress &other) const noexcept { return !(*this == other); }
+
+	bool operator<(const CNetworkAddress &other) const noexcept
+	{
+		if (IsAbsent() || other.IsAbsent()) {
+			// Absent sorts first; two absents are equal, so neither is less.
+			return IsAbsent() && other.IsPresent();
+		}
+		if (m_family != other.m_family) {
+			return m_family == Family::IPv4; // IPv4 before IPv6
+		}
+		if (m_octets != other.m_octets) {
+			return m_octets < other.m_octets;
+		}
+		// Same octets: order by scope id so two distinct addresses never tie.
+		return m_scopeId < other.m_scopeId;
+	}
+	bool operator>(const CNetworkAddress &other) const noexcept { return other < *this; }
+	bool operator<=(const CNetworkAddress &other) const noexcept { return !(other < *this); }
+	bool operator>=(const CNetworkAddress &other) const noexcept { return !(*this < other); }
+
+	/**
+	 * Reverses the four octets of a 32-bit IPv4 value, converting between the
+	 * host-order and network-order conventions in either direction.
+	 *
+	 * Equivalent to @c wxUINT32_SWAP_ALWAYS, spelled out here so this header
+	 * stays free of wxWidgets and can be unit tested on its own.
+	 */
+	static std::uint32_t SwapOctets(std::uint32_t value) noexcept
+	{
+		return ((value & 0x000000FFu) << 24) | ((value & 0x0000FF00u) << 8) |
+		       ((value & 0x00FF0000u) >> 8) | ((value & 0xFF000000u) >> 24);
+	}
+
+private:
+	/** Four octets, most significant first, into a host-order 32-bit value. */
+	static std::uint32_t PackOctets(
+		std::uint8_t a, std::uint8_t b, std::uint8_t c, std::uint8_t d) noexcept
+	{
+		return (static_cast<std::uint32_t>(a) << 24) | (static_cast<std::uint32_t>(b) << 16) |
+		       (static_cast<std::uint32_t>(c) << 8) | static_cast<std::uint32_t>(d);
+	}
+
+	/**
+	 * The IPv4 address embedded in an IPv4-mapped IPv6 address, in host order.
+	 * @pre IsIPv4Mapped().
+	 */
+	std::uint32_t EmbeddedIPv4HostOrder() const noexcept
+	{
+		return PackOctets(m_octets[12], m_octets[13], m_octets[14], m_octets[15]);
+	}
+
+	/** @c ::1 -- fifteen zero octets then a one. */
+	bool IsLoopbackIPv6() const noexcept
+	{
+		for (int i = 0; i < 15; ++i) {
+			if (m_octets[i] != 0) {
+				return false;
+			}
+		}
+		return m_octets[15] == 1;
+	}
+
+	/**
+	 * The octets, in wire order (most significant first) whatever the family.
+	 *
+	 * An IPv4 address occupies the first four and leaves the rest zero. That
+	 * invariant is what lets the comparison operators, IsUnspecified() and
+	 * TruncatedToPrefix() treat both families with one loop, so every factory
+	 * above must preserve it: never write past index 3 for an IPv4 address.
+	 */
+	Octets m_octets{};
+
+	//! Zero for an IPv4 or absent address; only IPv6 addresses carry a scope.
+	unsigned long m_scopeId = 0;
+
+	//! None when unset. Never conflated with the all-zero address.
+	Family m_family = Family::None;
+};
+
+#endif // NETWORKADDRESS_H
+// File_checked_for_headers

--- a/src/NetworkAddressAsio.h
+++ b/src/NetworkAddressAsio.h
@@ -27,24 +27,7 @@
 
 #include "NetworkAddress.h"
 
-// Boost.Asio's socket headers redeclare constexpr static members out of line
-// and give several classes a user-provided destructor alongside an implicit
-// copy constructor. Both are deprecated in C++17 and both are diagnosed by
-// Clang, so with the -Werror=deprecated gate in src/CMakeLists.txt they fail
-// the build -- in third-party code this tree does not own. Same pragma-wrap
-// convention as CryptoPP_Inc.h and the wx wraps from #341, and the same
-// reason: the headers are discovered without -isystem, so the gate reaches
-// them. Kept to exactly these two diagnostics rather than a blanket
-// -Wno-deprecated, so a genuine deprecation in aMule's own code still fails.
-#if defined(__clang__)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-copy-with-user-provided-dtor"
-#pragma clang diagnostic ignored "-Wdeprecated-redundant-constexpr-static-def"
-#endif
 #include <boost/asio/ip/address.hpp>
-#if defined(__clang__)
-#pragma clang diagnostic pop
-#endif
 
 /**
  * The one bridge between CNetworkAddress and Boost.Asio.

--- a/src/NetworkAddressAsio.h
+++ b/src/NetworkAddressAsio.h
@@ -1,0 +1,100 @@
+//
+// This file is part of the aMule Project.
+//
+// Copyright (c) 2003-2026 aMule Team ( https://amule-org.github.io )
+//
+// Any parts of this program derived from the xMule, lMule or eMule project,
+// or contributed by third-party developers are copyrighted by their
+// respective authors.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301, USA
+//
+
+#ifndef NETWORKADDRESSASIO_H
+#define NETWORKADDRESSASIO_H
+
+#include "NetworkAddress.h"
+
+// Boost.Asio's socket headers redeclare constexpr static members out of line
+// and give several classes a user-provided destructor alongside an implicit
+// copy constructor. Both are deprecated in C++17 and both are diagnosed by
+// Clang, so with the -Werror=deprecated gate in src/CMakeLists.txt they fail
+// the build -- in third-party code this tree does not own. Same pragma-wrap
+// convention as CryptoPP_Inc.h and the wx wraps from #341, and the same
+// reason: the headers are discovered without -isystem, so the gate reaches
+// them. Kept to exactly these two diagnostics rather than a blanket
+// -Wno-deprecated, so a genuine deprecation in aMule's own code still fails.
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-copy-with-user-provided-dtor"
+#pragma clang diagnostic ignored "-Wdeprecated-redundant-constexpr-static-def"
+#endif
+#include <boost/asio/ip/address.hpp>
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+
+/**
+ * The one bridge between CNetworkAddress and Boost.Asio.
+ *
+ * CNetworkAddress deliberately stores its own sixteen octets rather than an
+ * asio address, so that the 155 translation units that merely pass an address
+ * around stop compiling asio's ~1200-header closure and stop needing @c ws2_32
+ * at link time (see the class comment in NetworkAddress.h). The socket backend
+ * still has to hand a real @c asio::ip::address to a real socket, so the
+ * conversion lives here -- in a header that says asio in its name, and that
+ * only the TUs actually opening sockets include.
+ *
+ * Include this from a TU that talks to asio. Do @b not include it from a public
+ * header: doing so re-establishes exactly the coupling this file exists to
+ * confine, and nothing will warn you about it until macOS and mingw-w64 CI do.
+ */
+
+/**
+ * Both conversions are namespaced rather than free at global scope. They take a
+ * boost::asio::ip::address, which makes an unqualified pair argument-dependent
+ * lookup candidates for every call in a translation unit that mentions an asio
+ * address -- and the call sites this type is for will include this header
+ * widely. Nothing collides today; the namespace is here because it is cheap
+ * now and awkward once those call sites exist.
+ */
+namespace NetworkAddressAsio
+{
+
+/**
+ * Widens a CNetworkAddress into the asio value a socket call needs.
+ *
+ * @pre @a address.IsPresent(). Absence has no asio equivalent -- asio's own
+ *      default-constructed address is @c 0.0.0.0, which is exactly the
+ *      conflation CNetworkAddress exists to prevent, so an absent address must
+ *      be handled by the caller rather than silently becoming the wildcard.
+ */
+boost::asio::ip::address ToAsioAddress(const CNetworkAddress &address);
+
+/**
+ * Narrows an asio address into a CNetworkAddress, preserving the family, the
+ * octets and the IPv6 scope id exactly.
+ *
+ * Every asio address is a present address: there is no value of the argument
+ * that yields absence, @c 0.0.0.0 included. A caller that wants asio's
+ * all-zero address treated as "no address" must test for that itself, at the
+ * edge where it knows the overload applies.
+ */
+CNetworkAddress FromAsioAddress(const boost::asio::ip::address &address);
+
+} // namespace NetworkAddressAsio
+
+#endif // NETWORKADDRESSASIO_H
+// File_checked_for_headers

--- a/unittests/tests/CMakeLists.txt
+++ b/unittests/tests/CMakeLists.txt
@@ -197,6 +197,40 @@ target_link_libraries (BanRecordTest
 	mulecommon
 )
 
+# The internal address type: byte order in the signature, absence distinct
+# from 0.0.0.0, explicit failure instead of truncation, and a total order so
+# the type can be a map key. The type stores its own sixteen octets and a
+# family tag rather than an asio address, which is what keeps this target
+# free of the app and the daemon -- only NetworkAddress.cpp below still
+# compiles Boost.Asio.
+add_executable (NetworkAddressTest
+	NetworkAddressTest.cpp
+	${CMAKE_SOURCE_DIR}/src/libs/common/Format.cpp
+	${CMAKE_SOURCE_DIR}/src/libs/common/strerror_r.c
+	# CNetworkAddress::FromString/ToString live in NetworkAddress.cpp: they are
+	# the only part of the type that still compiles Boost.Asio, and keeping them
+	# out of the header is what stops asio reaching most of src/. Every target
+	# that touches an address therefore has to link this TU -- the type is no
+	# longer header-only.
+	${CMAKE_SOURCE_DIR}/src/NetworkAddress.cpp
+)
+
+add_test (NAME NetworkAddressTest
+	COMMAND NetworkAddressTest
+)
+
+target_include_directories (NetworkAddressTest
+	PRIVATE ${CMAKE_BINARY_DIR}
+	PRIVATE ${CMAKE_SOURCE_DIR}/src
+	PRIVATE ${CMAKE_SOURCE_DIR}/src/include
+	PRIVATE ${Boost_INCLUDE_DIR}
+)
+
+target_link_libraries (NetworkAddressTest
+	muleunit
+	${Boost_LIBRARIES}
+)
+
 add_executable (CUInt128Test
 	CUInt128Test.cpp
 	${CMAKE_SOURCE_DIR}/src/kademlia/utils/UInt128.cpp

--- a/unittests/tests/NetworkAddressTest.cpp
+++ b/unittests/tests/NetworkAddressTest.cpp
@@ -53,8 +53,8 @@ TEST(NetworkAddress, ByteOrderIsInTheSignature)
 	const CNetworkAddress fromNetwork = CNetworkAddress::FromIPv4NetworkOrder(TEST_IP_ED2K_ORDER);
 
 	// Both name the same address, reached through the convention each caller has.
-	ASSERT_EQUALS(wxString("192.0.2.1"), wxString(fromHost.ToString()));
-	ASSERT_EQUALS(wxString("192.0.2.1"), wxString(fromNetwork.ToString()));
+	ASSERT_EQUALS(wxString("192.0.2.1"), fromHost.ToWxString());
+	ASSERT_EQUALS(wxString("192.0.2.1"), fromNetwork.ToWxString());
 	ASSERT_TRUE(fromHost == fromNetwork);
 
 	// And they round-trip back into the convention that is asked for, not into
@@ -75,8 +75,20 @@ TEST(NetworkAddress, ByteOrderIsInTheSignature)
 	// Feeding a value in the wrong convention cannot be a silent no-op: it
 	// yields a different, visibly wrong address. Nothing stops a caller doing
 	// that, but nothing hides it either.
-	ASSERT_EQUALS(wxString("1.2.0.192"),
-		wxString(CNetworkAddress::FromIPv4HostOrder(TEST_IP_ED2K_ORDER).ToString()));
+	ASSERT_EQUALS(
+		wxString("1.2.0.192"), CNetworkAddress::FromIPv4HostOrder(TEST_IP_ED2K_ORDER).ToWxString());
+}
+
+TEST(NetworkAddress, TextualFormsPreserveUtf8)
+{
+	const CNetworkAddress ipv4 = CNetworkAddress::FromString("1.2.3.4");
+	const CNetworkAddress ipv6 = CNetworkAddress::FromString("2001:db8::1");
+	const CNetworkAddress absent = CNetworkAddress::Absent();
+
+	ASSERT_EQUALS(wxString("1.2.3.4"), ipv4.ToWxString());
+	ASSERT_EQUALS(wxString("2001:db8::1"), ipv6.ToWxString());
+	ASSERT_EQUALS(wxString("<absent>"), absent.ToWxString());
+	ASSERT_EQUALS(std::string("1.2.3.4"), ipv4.ToString());
 }
 
 TEST(NetworkAddress, MappedAndNativeAreDistinct)
@@ -156,11 +168,11 @@ TEST(NetworkAddress, AbsenceIsNotTheAllZeroAddress)
 	ASSERT_TRUE(zero.IsPresent());
 	ASSERT_TRUE(zero.IsUnspecified());
 	ASSERT_TRUE(zero.IsIPv4());
-	ASSERT_EQUALS(wxString("0.0.0.0"), wxString(zero.ToString()));
+	ASSERT_EQUALS(wxString("0.0.0.0"), zero.ToWxString());
 
 	// The whole point: these two are different values.
 	ASSERT_TRUE(absent != zero);
-	ASSERT_EQUALS(wxString("<absent>"), wxString(absent.ToString()));
+	ASSERT_EQUALS(wxString("<absent>"), absent.ToWxString());
 
 	// 0.0.0.0 narrows to zero; an absent address refuses to narrow at all, and
 	// again leaves the caller's variable untouched.
@@ -233,11 +245,11 @@ TEST(NetworkAddress, OrderingIsTotalAndUsableAsAKey)
 	// The order is the one documented, in order.
 	std::set<CNetworkAddress>::const_iterator it = keys.begin();
 	ASSERT_TRUE((it++)->IsAbsent());
-	ASSERT_EQUALS(wxString("0.0.0.0"), wxString((it++)->ToString()));
-	ASSERT_EQUALS(wxString("10.0.0.1"), wxString((it++)->ToString()));
-	ASSERT_EQUALS(wxString("192.0.2.1"), wxString((it++)->ToString()));
+	ASSERT_EQUALS(wxString("0.0.0.0"), (it++)->ToWxString());
+	ASSERT_EQUALS(wxString("10.0.0.1"), (it++)->ToWxString());
+	ASSERT_EQUALS(wxString("192.0.2.1"), (it++)->ToWxString());
 	ASSERT_TRUE((it++)->IsIPv4Mapped());
-	ASSERT_EQUALS(wxString("2001:db8::1"), wxString((it++)->ToString()));
+	ASSERT_EQUALS(wxString("2001:db8::1"), (it++)->ToWxString());
 	ASSERT_TRUE(it == keys.end());
 
 	// Lookup by an equal address built the other way round still hits.
@@ -257,35 +269,28 @@ TEST(NetworkAddress, TruncatedToPrefixClearsHostBits)
 	// implementation computes it -- a symmetric off-by-one in a shift would
 	// cancel out and pass.
 	ASSERT_EQUALS(wxString("192.0.2.0"),
-		wxString(CNetworkAddress::FromString("192.0.2.130").TruncatedToPrefix(24).ToString()));
+		CNetworkAddress::FromString("192.0.2.130").TruncatedToPrefix(24).ToWxString());
 	ASSERT_EQUALS(wxString("192.0.0.0"),
-		wxString(CNetworkAddress::FromString("192.0.2.130").TruncatedToPrefix(16).ToString()));
+		CNetworkAddress::FromString("192.0.2.130").TruncatedToPrefix(16).ToWxString());
 	ASSERT_EQUALS(wxString("0.0.0.0"),
-		wxString(CNetworkAddress::FromString("192.0.2.130").TruncatedToPrefix(0).ToString()));
+		CNetworkAddress::FromString("192.0.2.130").TruncatedToPrefix(0).ToWxString());
 	// A prefix at or beyond the family width is the address itself, not an
 	// undefined shift.
 	ASSERT_EQUALS(wxString("192.0.2.130"),
-		wxString(CNetworkAddress::FromString("192.0.2.130").TruncatedToPrefix(32).ToString()));
+		CNetworkAddress::FromString("192.0.2.130").TruncatedToPrefix(32).ToWxString());
 	ASSERT_EQUALS(wxString("192.0.2.130"),
-		wxString(CNetworkAddress::FromString("192.0.2.130").TruncatedToPrefix(128).ToString()));
+		CNetworkAddress::FromString("192.0.2.130").TruncatedToPrefix(128).ToWxString());
 
 	// IPv6, including a prefix that ends mid-byte -- /60 keeps the high nibble
 	// of the eighth byte and clears the low one.
 	ASSERT_EQUALS(wxString("2001:db8:1::"),
-		wxString(CNetworkAddress::FromString("2001:db8:1:2:3:4:5:6")
-				 .TruncatedToPrefix(48)
-				 .ToString()));
+		CNetworkAddress::FromString("2001:db8:1:2:3:4:5:6").TruncatedToPrefix(48).ToWxString());
 	ASSERT_EQUALS(wxString("2001:db8:1:f0::"),
-		wxString(CNetworkAddress::FromString("2001:db8:1:f2:3:4:5:6")
-				 .TruncatedToPrefix(60)
-				 .ToString()));
+		CNetworkAddress::FromString("2001:db8:1:f2:3:4:5:6").TruncatedToPrefix(60).ToWxString());
 	ASSERT_EQUALS(wxString("2001:db8:1:2::"),
-		wxString(CNetworkAddress::FromString("2001:db8:1:2:3:4:5:6")
-				 .TruncatedToPrefix(64)
-				 .ToString()));
+		CNetworkAddress::FromString("2001:db8:1:2:3:4:5:6").TruncatedToPrefix(64).ToWxString());
 	ASSERT_EQUALS(wxString("::"),
-		wxString(
-			CNetworkAddress::FromString("2001:db8:1:2:3:4:5:6").TruncatedToPrefix(0).ToString()));
+		CNetworkAddress::FromString("2001:db8:1:2:3:4:5:6").TruncatedToPrefix(0).ToWxString());
 	ASSERT_TRUE(CNetworkAddress::FromString("2001:db8:1:2:3:4:5:6").TruncatedToPrefix(128) ==
 		    CNetworkAddress::FromString("2001:db8:1:2:3:4:5:6"));
 
@@ -357,13 +362,15 @@ TEST(NetworkAddress, GloballyRoutableIPv4RejectsEveryUnroutableRange)
 	ASSERT_TRUE(CNetworkAddress::FromString("172.15.255.255").IsGloballyRoutableIPv4());
 	ASSERT_TRUE(CNetworkAddress::FromString("172.32.0.0").IsGloballyRoutableIPv4());
 
-	// 192.0.0.0/24 protocol assignments, 192.0.2.0/24 TEST-NET-1, and
-	// 192.168.0.0/16 private -- three separate rules under one first octet,
-	// so 192.0.1.0 in between them stays routable.
+	// The /24 exclusions under 192.0/16, and private 192.168/16.
 	ASSERT_FALSE(CNetworkAddress::FromString("192.0.0.1").IsGloballyRoutableIPv4());
 	ASSERT_FALSE(CNetworkAddress::FromString("192.0.2.1").IsGloballyRoutableIPv4());
+	ASSERT_FALSE(CNetworkAddress::FromString("192.88.99.0").IsGloballyRoutableIPv4());
+	ASSERT_FALSE(CNetworkAddress::FromString("192.88.99.255").IsGloballyRoutableIPv4());
 	ASSERT_FALSE(CNetworkAddress::FromString("192.168.1.1").IsGloballyRoutableIPv4());
 	ASSERT_TRUE(CNetworkAddress::FromString("192.0.1.1").IsGloballyRoutableIPv4());
+	ASSERT_TRUE(CNetworkAddress::FromString("192.88.98.255").IsGloballyRoutableIPv4());
+	ASSERT_TRUE(CNetworkAddress::FromString("192.88.100.0").IsGloballyRoutableIPv4());
 	ASSERT_TRUE(CNetworkAddress::FromString("192.167.1.1").IsGloballyRoutableIPv4());
 	ASSERT_TRUE(CNetworkAddress::FromString("192.169.1.1").IsGloballyRoutableIPv4());
 
@@ -424,6 +431,18 @@ TEST(NetworkAddress, GloballyRoutableIPv6RejectsEveryUnreachableRange)
 	ASSERT_FALSE(CNetworkAddress::FromString("fec0::1").IsGloballyRoutableIPv6());
 	ASSERT_FALSE(CNetworkAddress::FromString("feff:ffff::1").IsGloballyRoutableIPv6());
 
+	// Teredo 2001::/32 and 6to4 2002::/16.
+	ASSERT_FALSE(CNetworkAddress::FromString("2001::").IsGloballyRoutableIPv6());
+	ASSERT_FALSE(CNetworkAddress::FromString("2001::ffff:ffff:ffff:ffff").IsGloballyRoutableIPv6());
+	ASSERT_TRUE(CNetworkAddress::FromString("2000:ffff:ffff:ffff:ffff:ffff:ffff:ffff")
+			.IsGloballyRoutableIPv6());
+	ASSERT_FALSE(CNetworkAddress::FromString("2002::").IsGloballyRoutableIPv6());
+	ASSERT_FALSE(CNetworkAddress::FromString("2002:ffff:ffff:ffff:ffff:ffff:ffff:ffff")
+			.IsGloballyRoutableIPv6());
+	ASSERT_TRUE(CNetworkAddress::FromString("2001:ffff:ffff:ffff:ffff:ffff:ffff:ffff")
+			.IsGloballyRoutableIPv6());
+	ASSERT_TRUE(CNetworkAddress::FromString("2003::").IsGloballyRoutableIPv6());
+
 	// fc00::/7, unique-local. Both halves: fc00::/8 and fd00::/8.
 	ASSERT_FALSE(CNetworkAddress::FromString("fc00::1").IsGloballyRoutableIPv6());
 	ASSERT_FALSE(CNetworkAddress::FromString("fd12:3456::1").IsGloballyRoutableIPv6());
@@ -475,7 +494,7 @@ TEST(NetworkAddress, OctetsAreWireOrderAndLeaveTheIPv4TailZero)
 	ASSERT_TRUE(CNetworkAddress::AnyIPv6().IsPresent());
 	ASSERT_TRUE(CNetworkAddress::AnyIPv6().IsIPv6());
 	ASSERT_TRUE(CNetworkAddress::AnyIPv6().IsUnspecified());
-	ASSERT_EQUALS(wxString("::"), wxString(CNetworkAddress::AnyIPv6().ToString()));
+	ASSERT_EQUALS(wxString("::"), CNetworkAddress::AnyIPv6().ToWxString());
 	const std::uint8_t allZero[16] = { 0 };
 	ASSERT_TRUE(CNetworkAddress::FromIPv6Bytes(allZero).IsAbsent());
 	ASSERT_TRUE(CNetworkAddress::AnyIPv6() != CNetworkAddress::Absent());
@@ -548,17 +567,16 @@ TEST(NetworkAddress, AsioBridgeRoundTripsWithoutLosingAnything)
 		ASSERT_TRUE(roundTripped == address);
 		// Not just equal -- the same text, so a family or octet swap that
 		// happened to compare equal would still be caught.
-		ASSERT_EQUALS(wxString(address.ToString()), wxString(roundTripped.ToString()));
+		ASSERT_EQUALS(address.ToWxString(), roundTripped.ToWxString());
 	}
 
 	// The 32-bit conventions survive the crossing: asio's to_uint() is host
 	// order, which is the convention FromIPv4HostOrder() names.
 	ASSERT_EQUALS(wxString("192.0.2.1"),
-		wxString(NetworkAddressAsio::FromAsioAddress(boost::asio::ip::make_address("192.0.2.1"))
-				 .ToString()));
+		NetworkAddressAsio::FromAsioAddress(boost::asio::ip::make_address("192.0.2.1")).ToWxString());
 	std::uint32_t hostOrder = 0;
 	ASSERT_TRUE(NetworkAddressAsio::FromAsioAddress(boost::asio::ip::make_address("192.0.2.1"))
-			    .ToIPv4HostOrder(hostOrder));
+			.ToIPv4HostOrder(hostOrder));
 	ASSERT_EQUALS(TEST_IP_HOST_ORDER, hostOrder);
 
 	// A scope id is part of the address's identity, so it crosses too. Without
@@ -576,7 +594,7 @@ TEST(NetworkAddress, AsioBridgeRoundTripsWithoutLosingAnything)
 	ASSERT_TRUE(
 		NetworkAddressAsio::FromAsioAddress(boost::asio::ip::make_address("0.0.0.0")).IsPresent());
 	ASSERT_TRUE(NetworkAddressAsio::FromAsioAddress(boost::asio::ip::make_address("0.0.0.0"))
-			    .IsUnspecified());
+			.IsUnspecified());
 }
 
 // File_checked_for_headers

--- a/unittests/tests/NetworkAddressTest.cpp
+++ b/unittests/tests/NetworkAddressTest.cpp
@@ -435,12 +435,12 @@ TEST(NetworkAddress, GloballyRoutableIPv6RejectsEveryUnreachableRange)
 	ASSERT_FALSE(CNetworkAddress::FromString("2001::").IsGloballyRoutableIPv6());
 	ASSERT_FALSE(CNetworkAddress::FromString("2001::ffff:ffff:ffff:ffff").IsGloballyRoutableIPv6());
 	ASSERT_TRUE(CNetworkAddress::FromString("2000:ffff:ffff:ffff:ffff:ffff:ffff:ffff")
-			.IsGloballyRoutableIPv6());
+			    .IsGloballyRoutableIPv6());
 	ASSERT_FALSE(CNetworkAddress::FromString("2002::").IsGloballyRoutableIPv6());
 	ASSERT_FALSE(CNetworkAddress::FromString("2002:ffff:ffff:ffff:ffff:ffff:ffff:ffff")
-			.IsGloballyRoutableIPv6());
+			     .IsGloballyRoutableIPv6());
 	ASSERT_TRUE(CNetworkAddress::FromString("2001:ffff:ffff:ffff:ffff:ffff:ffff:ffff")
-			.IsGloballyRoutableIPv6());
+			    .IsGloballyRoutableIPv6());
 	ASSERT_TRUE(CNetworkAddress::FromString("2003::").IsGloballyRoutableIPv6());
 
 	// fc00::/7, unique-local. Both halves: fc00::/8 and fd00::/8.
@@ -576,7 +576,7 @@ TEST(NetworkAddress, AsioBridgeRoundTripsWithoutLosingAnything)
 		NetworkAddressAsio::FromAsioAddress(boost::asio::ip::make_address("192.0.2.1")).ToWxString());
 	std::uint32_t hostOrder = 0;
 	ASSERT_TRUE(NetworkAddressAsio::FromAsioAddress(boost::asio::ip::make_address("192.0.2.1"))
-			.ToIPv4HostOrder(hostOrder));
+			    .ToIPv4HostOrder(hostOrder));
 	ASSERT_EQUALS(TEST_IP_HOST_ORDER, hostOrder);
 
 	// A scope id is part of the address's identity, so it crosses too. Without
@@ -594,7 +594,7 @@ TEST(NetworkAddress, AsioBridgeRoundTripsWithoutLosingAnything)
 	ASSERT_TRUE(
 		NetworkAddressAsio::FromAsioAddress(boost::asio::ip::make_address("0.0.0.0")).IsPresent());
 	ASSERT_TRUE(NetworkAddressAsio::FromAsioAddress(boost::asio::ip::make_address("0.0.0.0"))
-			.IsUnspecified());
+			    .IsUnspecified());
 }
 
 // File_checked_for_headers

--- a/unittests/tests/NetworkAddressTest.cpp
+++ b/unittests/tests/NetworkAddressTest.cpp
@@ -1,0 +1,582 @@
+//
+// This file is part of the aMule Project.
+//
+// Copyright (c) 2003-2026 aMule Team ( https://amule-org.github.io )
+//
+// Any parts of this program derived from the xMule, lMule or eMule project,
+// or contributed by third-party developers are copyrighted by their
+// respective authors.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301, USA
+//
+
+// Contract of the internal address type: byte order stated in the signature,
+// absence distinguishable from the all-zero address, failed narrowing rather
+// than truncation, and a total order fit to key a container.
+//
+// This is the type every uint32 IP in the tree is being migrated onto, so its
+// contract is pinned here rather than left to the applications. None of it needs
+// a running aMule: the type is a value type over sixteen octets and a family tag.
+
+#include <muleunit/test.h>
+
+#include <NetworkAddressAsio.h>
+#include <NetworkAddress.h>
+
+#include <algorithm>
+#include <map>
+#include <set>
+
+using namespace muleunit;
+
+DECLARE_SIMPLE(NetworkAddress)
+
+// 192.0.2.1 (RFC 5737 documentation range) in each of the two conventions.
+static const uint32_t TEST_IP_HOST_ORDER = 0xC0000201u;
+static const uint32_t TEST_IP_ED2K_ORDER = 0x010200C0u;
+
+TEST(NetworkAddress, ByteOrderIsInTheSignature)
+{
+	const CNetworkAddress fromHost = CNetworkAddress::FromIPv4HostOrder(TEST_IP_HOST_ORDER);
+	const CNetworkAddress fromNetwork = CNetworkAddress::FromIPv4NetworkOrder(TEST_IP_ED2K_ORDER);
+
+	// Both name the same address, reached through the convention each caller has.
+	ASSERT_EQUALS(wxString("192.0.2.1"), wxString(fromHost.ToString()));
+	ASSERT_EQUALS(wxString("192.0.2.1"), wxString(fromNetwork.ToString()));
+	ASSERT_TRUE(fromHost == fromNetwork);
+
+	// And they round-trip back into the convention that is asked for, not into
+	// whichever one they were built from.
+	uint32_t out = 0;
+	ASSERT_TRUE(fromHost.ToIPv4HostOrder(out));
+	ASSERT_EQUALS(TEST_IP_HOST_ORDER, out);
+	ASSERT_TRUE(fromHost.ToIPv4NetworkOrder(out));
+	ASSERT_EQUALS(TEST_IP_ED2K_ORDER, out);
+	ASSERT_TRUE(fromNetwork.ToIPv4HostOrder(out));
+	ASSERT_EQUALS(TEST_IP_HOST_ORDER, out);
+
+	// The two conventions are byte reversals of each other, which is the
+	// identity wxUINT32_SWAP_ALWAYS relies on at every existing swap site.
+	ASSERT_EQUALS(TEST_IP_ED2K_ORDER, CNetworkAddress::SwapOctets(TEST_IP_HOST_ORDER));
+	ASSERT_EQUALS(TEST_IP_HOST_ORDER, CNetworkAddress::SwapOctets(TEST_IP_ED2K_ORDER));
+
+	// Feeding a value in the wrong convention cannot be a silent no-op: it
+	// yields a different, visibly wrong address. Nothing stops a caller doing
+	// that, but nothing hides it either.
+	ASSERT_EQUALS(wxString("1.2.0.192"),
+		wxString(CNetworkAddress::FromIPv4HostOrder(TEST_IP_ED2K_ORDER).ToString()));
+}
+
+TEST(NetworkAddress, MappedAndNativeAreDistinct)
+{
+	const CNetworkAddress native = CNetworkAddress::FromIPv4HostOrder(TEST_IP_HOST_ORDER);
+	const CNetworkAddress mapped = CNetworkAddress::FromString("::ffff:192.0.2.1");
+
+	ASSERT_TRUE(native.IsIPv4());
+	ASSERT_FALSE(native.IsIPv6());
+	ASSERT_FALSE(native.IsIPv4Mapped());
+
+	ASSERT_TRUE(mapped.IsIPv6());
+	ASSERT_FALSE(mapped.IsIPv4());
+	ASSERT_TRUE(mapped.IsIPv4Mapped());
+
+	// The distinction is preserved: the mapped form is an IPv6 address and is
+	// not equal to the IPv4 address it embeds.
+	ASSERT_TRUE(native != mapped);
+
+	// A caller that wants them treated alike says so.
+	ASSERT_TRUE(mapped.Unmapped() == native);
+	ASSERT_TRUE(native.Unmapped() == native);
+
+	// The mapped form still narrows losslessly, in either convention.
+	uint32_t out = 0;
+	ASSERT_TRUE(mapped.ToIPv4HostOrder(out));
+	ASSERT_EQUALS(TEST_IP_HOST_ORDER, out);
+	ASSERT_TRUE(mapped.ToIPv4NetworkOrder(out));
+	ASSERT_EQUALS(TEST_IP_ED2K_ORDER, out);
+
+	// A non-mapped v6 address is not mistaken for a mapped one, whichever end
+	// of the ::ffff: prefix differs.
+	ASSERT_FALSE(CNetworkAddress::FromString("2001:db8::1").IsIPv4Mapped());
+	ASSERT_FALSE(CNetworkAddress::FromString("::fffe:192.0.2.1").IsIPv4Mapped());
+	ASSERT_FALSE(CNetworkAddress::FromString("1::ffff:192.0.2.1").IsIPv4Mapped());
+}
+
+TEST(NetworkAddress, NarrowingAnIPv6AddressFails)
+{
+	const CNetworkAddress v6 = CNetworkAddress::FromString("2001:db8::1");
+	ASSERT_TRUE(v6.IsPresent());
+	ASSERT_TRUE(v6.IsIPv6());
+
+	// The failure is reported, and the caller's variable is left exactly as it
+	// was -- no truncation, no hash, no fabricated value even for a caller that
+	// ignores the return.
+	uint32_t out = 0xDEADBEEFu;
+	ASSERT_FALSE(v6.ToIPv4HostOrder(out));
+	ASSERT_EQUALS(0xDEADBEEFu, out);
+	ASSERT_FALSE(v6.ToIPv4NetworkOrder(out));
+	ASSERT_EQUALS(0xDEADBEEFu, out);
+
+	// The unspecified IPv6 address is not narrowable either, even though its
+	// octets would truncate to a value that happens to look valid.
+	const CNetworkAddress v6Any = CNetworkAddress::FromString("::");
+	ASSERT_TRUE(v6Any.IsPresent());
+	ASSERT_TRUE(v6Any.IsUnspecified());
+	out = 0xDEADBEEFu;
+	ASSERT_FALSE(v6Any.ToIPv4NetworkOrder(out));
+	ASSERT_EQUALS(0xDEADBEEFu, out);
+
+	// The lossy convenience form reports the same failure as a zero, which is
+	// why it is only for edges that cannot act on the difference.
+	ASSERT_EQUALS(0u, v6.ToIPv4NetworkOrderOrZero());
+}
+
+TEST(NetworkAddress, AbsenceIsNotTheAllZeroAddress)
+{
+	const CNetworkAddress absent;
+	const CNetworkAddress zero = CNetworkAddress::FromIPv4NetworkOrder(0);
+
+	ASSERT_TRUE(absent.IsAbsent());
+	ASSERT_FALSE(absent.IsPresent());
+	ASSERT_FALSE(absent.IsUnspecified()); // it is not an address at all
+	ASSERT_TRUE(absent == CNetworkAddress::Absent());
+
+	ASSERT_TRUE(zero.IsPresent());
+	ASSERT_TRUE(zero.IsUnspecified());
+	ASSERT_TRUE(zero.IsIPv4());
+	ASSERT_EQUALS(wxString("0.0.0.0"), wxString(zero.ToString()));
+
+	// The whole point: these two are different values.
+	ASSERT_TRUE(absent != zero);
+	ASSERT_EQUALS(wxString("<absent>"), wxString(absent.ToString()));
+
+	// 0.0.0.0 narrows to zero; an absent address refuses to narrow at all, and
+	// again leaves the caller's variable untouched.
+	uint32_t out = 7;
+	ASSERT_TRUE(zero.ToIPv4NetworkOrder(out));
+	ASSERT_EQUALS(0u, out);
+	out = 7;
+	ASSERT_FALSE(absent.ToIPv4NetworkOrder(out));
+	ASSERT_EQUALS(7u, out);
+
+	// The boundary conversions resolve the ed2k zero overload towards absence,
+	// and only there.
+	ASSERT_TRUE(CNetworkAddress::FromIPv4NetworkOrderOrAbsent(0).IsAbsent());
+	ASSERT_TRUE(CNetworkAddress::FromIPv4HostOrderOrAbsent(0).IsAbsent());
+	ASSERT_TRUE(CNetworkAddress::FromIPv4NetworkOrder(0).IsPresent());
+	ASSERT_TRUE(CNetworkAddress::FromIPv4HostOrder(0).IsPresent());
+	ASSERT_TRUE(CNetworkAddress::FromIPv4NetworkOrderOrAbsent(TEST_IP_ED2K_ORDER) ==
+		    CNetworkAddress::FromIPv4NetworkOrder(TEST_IP_ED2K_ORDER));
+
+	// A string that is not an address is absent, not 0.0.0.0 -- unlike
+	// StringIPtoUint32(), which cannot tell the caller the difference.
+	ASSERT_TRUE(CNetworkAddress::FromString("").IsAbsent());
+	ASSERT_TRUE(CNetworkAddress::FromString("not an address").IsAbsent());
+	ASSERT_TRUE(CNetworkAddress::FromString("192.0.2.256").IsAbsent());
+	ASSERT_TRUE(CNetworkAddress::FromString("0.0.0.0").IsPresent());
+}
+
+TEST(NetworkAddress, OrderingIsTotalAndUsableAsAKey)
+{
+	const CNetworkAddress absent;
+	const CNetworkAddress v4Zero = CNetworkAddress::FromString("0.0.0.0");
+	const CNetworkAddress v4Low = CNetworkAddress::FromString("10.0.0.1");
+	const CNetworkAddress v4High = CNetworkAddress::FromString("192.0.2.1");
+	const CNetworkAddress mapped = CNetworkAddress::FromString("::ffff:192.0.2.1");
+	const CNetworkAddress v6 = CNetworkAddress::FromString("2001:db8::1");
+
+	// Absent first, then IPv4 by value, then IPv6.
+	ASSERT_TRUE(absent < v4Zero);
+	ASSERT_TRUE(v4Zero < v4Low);
+	ASSERT_TRUE(v4Low < v4High);
+	ASSERT_TRUE(v4High < mapped);
+	ASSERT_TRUE(mapped < v6);
+
+	// Antisymmetry and irreflexivity, which is what makes it a strict weak
+	// order and therefore safe for std::map.
+	ASSERT_FALSE(v4High < v4High);
+	ASSERT_FALSE(v4High < v4Low);
+	ASSERT_TRUE(v4Low <= v4High);
+	ASSERT_TRUE(v4High >= v4Low);
+	ASSERT_TRUE(v4High > v4Low);
+	ASSERT_FALSE(absent < CNetworkAddress::Absent());
+
+	// Transitivity across the family boundary.
+	ASSERT_TRUE(absent < v6);
+	ASSERT_TRUE(v4Zero < v6);
+
+	// No two distinct addresses collide, and equal ones do not duplicate.
+	std::set<CNetworkAddress> keys;
+	keys.insert(absent);
+	keys.insert(v4Zero);
+	keys.insert(v4Low);
+	keys.insert(v4High);
+	keys.insert(mapped);
+	keys.insert(v6);
+	ASSERT_EQUALS(6u, (unsigned)keys.size());
+	keys.insert(CNetworkAddress::FromIPv4HostOrder(TEST_IP_HOST_ORDER)); // == v4High
+	keys.insert(CNetworkAddress::Absent());
+	ASSERT_EQUALS(6u, (unsigned)keys.size());
+
+	// The order is the one documented, in order.
+	std::set<CNetworkAddress>::const_iterator it = keys.begin();
+	ASSERT_TRUE((it++)->IsAbsent());
+	ASSERT_EQUALS(wxString("0.0.0.0"), wxString((it++)->ToString()));
+	ASSERT_EQUALS(wxString("10.0.0.1"), wxString((it++)->ToString()));
+	ASSERT_EQUALS(wxString("192.0.2.1"), wxString((it++)->ToString()));
+	ASSERT_TRUE((it++)->IsIPv4Mapped());
+	ASSERT_EQUALS(wxString("2001:db8::1"), wxString((it++)->ToString()));
+	ASSERT_TRUE(it == keys.end());
+
+	// Lookup by an equal address built the other way round still hits.
+	std::map<CNetworkAddress, int> byAddress;
+	byAddress[v4High] = 1;
+	byAddress[mapped] = 2;
+	ASSERT_EQUALS(2u, (unsigned)byAddress.size());
+	ASSERT_EQUALS(1, byAddress[CNetworkAddress::FromIPv4NetworkOrder(TEST_IP_ED2K_ORDER)]);
+	ASSERT_EQUALS(2, byAddress[CNetworkAddress::FromString("::ffff:c000:201")]);
+	ASSERT_EQUALS(2u, (unsigned)byAddress.size());
+}
+
+TEST(NetworkAddress, TruncatedToPrefixClearsHostBits)
+{
+	// The prefix operation a per-block limit or rule needs. Asserted against
+	// literal prefixes rather than against a mask computed the same way the
+	// implementation computes it -- a symmetric off-by-one in a shift would
+	// cancel out and pass.
+	ASSERT_EQUALS(wxString("192.0.2.0"),
+		wxString(CNetworkAddress::FromString("192.0.2.130").TruncatedToPrefix(24).ToString()));
+	ASSERT_EQUALS(wxString("192.0.0.0"),
+		wxString(CNetworkAddress::FromString("192.0.2.130").TruncatedToPrefix(16).ToString()));
+	ASSERT_EQUALS(wxString("0.0.0.0"),
+		wxString(CNetworkAddress::FromString("192.0.2.130").TruncatedToPrefix(0).ToString()));
+	// A prefix at or beyond the family width is the address itself, not an
+	// undefined shift.
+	ASSERT_EQUALS(wxString("192.0.2.130"),
+		wxString(CNetworkAddress::FromString("192.0.2.130").TruncatedToPrefix(32).ToString()));
+	ASSERT_EQUALS(wxString("192.0.2.130"),
+		wxString(CNetworkAddress::FromString("192.0.2.130").TruncatedToPrefix(128).ToString()));
+
+	// IPv6, including a prefix that ends mid-byte -- /60 keeps the high nibble
+	// of the eighth byte and clears the low one.
+	ASSERT_EQUALS(wxString("2001:db8:1::"),
+		wxString(CNetworkAddress::FromString("2001:db8:1:2:3:4:5:6")
+				 .TruncatedToPrefix(48)
+				 .ToString()));
+	ASSERT_EQUALS(wxString("2001:db8:1:f0::"),
+		wxString(CNetworkAddress::FromString("2001:db8:1:f2:3:4:5:6")
+				 .TruncatedToPrefix(60)
+				 .ToString()));
+	ASSERT_EQUALS(wxString("2001:db8:1:2::"),
+		wxString(CNetworkAddress::FromString("2001:db8:1:2:3:4:5:6")
+				 .TruncatedToPrefix(64)
+				 .ToString()));
+	ASSERT_EQUALS(wxString("::"),
+		wxString(
+			CNetworkAddress::FromString("2001:db8:1:2:3:4:5:6").TruncatedToPrefix(0).ToString()));
+	ASSERT_TRUE(CNetworkAddress::FromString("2001:db8:1:2:3:4:5:6").TruncatedToPrefix(128) ==
+		    CNetworkAddress::FromString("2001:db8:1:2:3:4:5:6"));
+
+	// A prefix of an absent address is still absent: no prefix is invented for
+	// a peer that has no address.
+	ASSERT_TRUE(CNetworkAddress::Absent().TruncatedToPrefix(64).IsAbsent());
+
+	// The truncation stays inside its family. A /24 of an IPv4 address is an
+	// IPv4 address, and no prefix width turns one family into the other.
+	ASSERT_TRUE(CNetworkAddress::FromString("192.0.2.130").TruncatedToPrefix(24).IsIPv4());
+	ASSERT_TRUE(CNetworkAddress::FromString("2001:db8::1").TruncatedToPrefix(64).IsIPv6());
+}
+
+// The IPv4 half of the same contract, and the one with the sharper failure.
+// A wrong prefix here does not advertise an unreachable address, it feeds
+// EncryptedDatagramSocket's key derivation an address the peer never sees --
+// so every frame decrypts to noise at the far end with nothing logged on
+// either side. Three of the rejections are sub-byte masks, and a mask is
+// exactly the kind of thing that is wrong in one direction only, so each is
+// pinned at both of its edges rather than at one address inside it.
+TEST(NetworkAddress, GloballyRoutableIPv4RejectsEveryUnroutableRange)
+{
+	// Routable: ordinary public unicast, and the last address before the
+	// multicast floor.
+	ASSERT_TRUE(CNetworkAddress::FromString("1.1.1.1").IsGloballyRoutableIPv4());
+	ASSERT_TRUE(CNetworkAddress::FromString("223.255.255.255").IsGloballyRoutableIPv4());
+
+	// Not an IPv4 address at all.
+	ASSERT_FALSE(CNetworkAddress::Absent().IsGloballyRoutableIPv4());
+	ASSERT_FALSE(CNetworkAddress::FromString("2001:db8::1").IsGloballyRoutableIPv4());
+	ASSERT_FALSE(CNetworkAddress::FromString("0.0.0.0").IsGloballyRoutableIPv4());
+
+	// A v4-mapped address is judged as the IPv4 address it carries, in both
+	// directions -- Unmapped() runs first, so the answer must not depend on
+	// which form the caller happened to hold.
+	ASSERT_TRUE(CNetworkAddress::FromString("::ffff:1.1.1.1").IsGloballyRoutableIPv4());
+	ASSERT_FALSE(CNetworkAddress::FromString("::ffff:10.0.0.1").IsGloballyRoutableIPv4());
+
+	// Whole first octets: "this network", RFC 1918 /8, and loopback.
+	ASSERT_FALSE(CNetworkAddress::FromString("0.1.2.3").IsGloballyRoutableIPv4());
+	ASSERT_FALSE(CNetworkAddress::FromString("10.0.0.1").IsGloballyRoutableIPv4());
+	ASSERT_FALSE(CNetworkAddress::FromString("10.255.255.255").IsGloballyRoutableIPv4());
+	// The whole 127/8 block, not just 127.0.0.1: a Debian host names itself
+	// 127.0.1.1, and that is the value GetPublicIP() falls through to.
+	ASSERT_FALSE(CNetworkAddress::FromString("127.0.0.1").IsGloballyRoutableIPv4());
+	ASSERT_FALSE(CNetworkAddress::FromString("127.0.1.1").IsGloballyRoutableIPv4());
+	ASSERT_FALSE(CNetworkAddress::FromString("127.255.255.255").IsGloballyRoutableIPv4());
+	// 126 and 128 bracket it, so the test would fail an off-by-one on the
+	// octet as well as a wrong block.
+	ASSERT_TRUE(CNetworkAddress::FromString("126.0.0.1").IsGloballyRoutableIPv4());
+	ASSERT_TRUE(CNetworkAddress::FromString("128.0.0.1").IsGloballyRoutableIPv4());
+
+	// 100.64.0.0/10, carrier-grade NAT. Mask (b & 0xC0) == 0x40, so the block
+	// runs 100.64 through 100.127 and its neighbours must stay routable.
+	ASSERT_FALSE(CNetworkAddress::FromString("100.64.0.1").IsGloballyRoutableIPv4());
+	ASSERT_FALSE(CNetworkAddress::FromString("100.127.255.255").IsGloballyRoutableIPv4());
+	ASSERT_TRUE(CNetworkAddress::FromString("100.63.255.255").IsGloballyRoutableIPv4());
+	ASSERT_TRUE(CNetworkAddress::FromString("100.128.0.0").IsGloballyRoutableIPv4());
+
+	// 169.254.0.0/16, link-local.
+	ASSERT_FALSE(CNetworkAddress::FromString("169.254.1.1").IsGloballyRoutableIPv4());
+	ASSERT_TRUE(CNetworkAddress::FromString("169.253.1.1").IsGloballyRoutableIPv4());
+	ASSERT_TRUE(CNetworkAddress::FromString("169.255.1.1").IsGloballyRoutableIPv4());
+
+	// 172.16.0.0/12, private. Mask (b & 0xF0) == 16, so 172.16 through
+	// 172.31, and 172.15 and 172.32 are public.
+	ASSERT_FALSE(CNetworkAddress::FromString("172.16.0.1").IsGloballyRoutableIPv4());
+	ASSERT_FALSE(CNetworkAddress::FromString("172.31.255.255").IsGloballyRoutableIPv4());
+	ASSERT_TRUE(CNetworkAddress::FromString("172.15.255.255").IsGloballyRoutableIPv4());
+	ASSERT_TRUE(CNetworkAddress::FromString("172.32.0.0").IsGloballyRoutableIPv4());
+
+	// 192.0.0.0/24 protocol assignments, 192.0.2.0/24 TEST-NET-1, and
+	// 192.168.0.0/16 private -- three separate rules under one first octet,
+	// so 192.0.1.0 in between them stays routable.
+	ASSERT_FALSE(CNetworkAddress::FromString("192.0.0.1").IsGloballyRoutableIPv4());
+	ASSERT_FALSE(CNetworkAddress::FromString("192.0.2.1").IsGloballyRoutableIPv4());
+	ASSERT_FALSE(CNetworkAddress::FromString("192.168.1.1").IsGloballyRoutableIPv4());
+	ASSERT_TRUE(CNetworkAddress::FromString("192.0.1.1").IsGloballyRoutableIPv4());
+	ASSERT_TRUE(CNetworkAddress::FromString("192.167.1.1").IsGloballyRoutableIPv4());
+	ASSERT_TRUE(CNetworkAddress::FromString("192.169.1.1").IsGloballyRoutableIPv4());
+
+	// 198.18.0.0/15, benchmarking. Mask (b & 0xFE) == 18, so 198.18 and
+	// 198.19 only. 198.51.100.0/24 is TEST-NET-2 under the same first octet.
+	ASSERT_FALSE(CNetworkAddress::FromString("198.18.0.1").IsGloballyRoutableIPv4());
+	ASSERT_FALSE(CNetworkAddress::FromString("198.19.255.255").IsGloballyRoutableIPv4());
+	ASSERT_TRUE(CNetworkAddress::FromString("198.17.255.255").IsGloballyRoutableIPv4());
+	ASSERT_TRUE(CNetworkAddress::FromString("198.20.0.0").IsGloballyRoutableIPv4());
+	ASSERT_FALSE(CNetworkAddress::FromString("198.51.100.1").IsGloballyRoutableIPv4());
+	ASSERT_TRUE(CNetworkAddress::FromString("198.51.99.1").IsGloballyRoutableIPv4());
+	ASSERT_TRUE(CNetworkAddress::FromString("198.51.101.1").IsGloballyRoutableIPv4());
+
+	// 203.0.113.0/24, TEST-NET-3.
+	ASSERT_FALSE(CNetworkAddress::FromString("203.0.113.1").IsGloballyRoutableIPv4());
+	ASSERT_TRUE(CNetworkAddress::FromString("203.0.112.1").IsGloballyRoutableIPv4());
+	ASSERT_TRUE(CNetworkAddress::FromString("203.0.114.1").IsGloballyRoutableIPv4());
+
+	// Everything from 224 up: multicast and reserved. Neither is a unicast
+	// source address, and the boundary is the one the predicate states.
+	ASSERT_FALSE(CNetworkAddress::FromString("224.0.0.1").IsGloballyRoutableIPv4());
+	ASSERT_FALSE(CNetworkAddress::FromString("239.255.255.255").IsGloballyRoutableIPv4());
+	ASSERT_FALSE(CNetworkAddress::FromString("240.0.0.1").IsGloballyRoutableIPv4());
+	ASSERT_FALSE(CNetworkAddress::FromString("255.255.255.255").IsGloballyRoutableIPv4());
+}
+
+// CNetworkAddress no longer stores a boost::asio::ip::address, so the three
+// predicates that used to be asio's -- loopback, link-local, unique-local --
+// are now prefix tests in NetworkAddress.h. This pins each range it must
+// reject, because getting one prefix wrong here does not fail a build: it
+// advertises an address no peer can reach, and the only symptom is a wasted
+// connect attempt on the far side.
+TEST(NetworkAddress, GloballyRoutableIPv6RejectsEveryUnreachableRange)
+{
+	// Routable: a documentation prefix (2001:db8::/32) is a global unicast
+	// address as far as the address itself can say.
+	ASSERT_TRUE(CNetworkAddress::FromString("2001:db8::1").IsGloballyRoutableIPv6());
+	ASSERT_TRUE(CNetworkAddress::FromString("2606:4700::1111").IsGloballyRoutableIPv6());
+
+	// Not an IPv6 address at all.
+	ASSERT_FALSE(CNetworkAddress::Absent().IsGloballyRoutableIPv6());
+	ASSERT_FALSE(CNetworkAddress::FromString("192.0.2.1").IsGloballyRoutableIPv6());
+	// A mapped address is reachable over IPv4, so it is not an IPv6 address to
+	// advertise as one.
+	ASSERT_FALSE(CNetworkAddress::FromString("::ffff:192.0.2.1").IsGloballyRoutableIPv6());
+
+	// The unspecified address and loopback.
+	ASSERT_FALSE(CNetworkAddress::AnyIPv6().IsGloballyRoutableIPv6());
+	ASSERT_FALSE(CNetworkAddress::FromString("::").IsGloballyRoutableIPv6());
+	ASSERT_FALSE(CNetworkAddress::FromString("::1").IsGloballyRoutableIPv6());
+
+	// fe80::/10, link-local -- both ends of the range, since the prefix is ten
+	// bits and a byte-wide test would let the upper half through.
+	ASSERT_FALSE(CNetworkAddress::FromString("fe80::1").IsGloballyRoutableIPv6());
+	ASSERT_FALSE(CNetworkAddress::FromString("febf:ffff::1").IsGloballyRoutableIPv6());
+
+	// fec0::/10, the deprecated site-local range.
+	ASSERT_FALSE(CNetworkAddress::FromString("fec0::1").IsGloballyRoutableIPv6());
+	ASSERT_FALSE(CNetworkAddress::FromString("feff:ffff::1").IsGloballyRoutableIPv6());
+
+	// fc00::/7, unique-local. Both halves: fc00::/8 and fd00::/8.
+	ASSERT_FALSE(CNetworkAddress::FromString("fc00::1").IsGloballyRoutableIPv6());
+	ASSERT_FALSE(CNetworkAddress::FromString("fd12:3456::1").IsGloballyRoutableIPv6());
+	ASSERT_FALSE(CNetworkAddress::FromString("fdff:ffff::1").IsGloballyRoutableIPv6());
+
+	// ff00::/8, multicast.
+	ASSERT_FALSE(CNetworkAddress::FromString("ff02::1").IsGloballyRoutableIPv6());
+
+	// And the addresses immediately outside those prefixes stay routable, so
+	// the tests above are pinning a prefix and not a whole leading byte.
+	ASSERT_TRUE(CNetworkAddress::FromString("fbff:ffff::1").IsGloballyRoutableIPv6());
+	ASSERT_TRUE(CNetworkAddress::FromString("fe00::1").IsGloballyRoutableIPv6());
+	ASSERT_TRUE(CNetworkAddress::FromString("fe7f:ffff::1").IsGloballyRoutableIPv6());
+}
+
+// The octets are the storage now, so what GetOctets() hands out is what every
+// bit-arithmetic caller (IPFilterMatch.h above all) works on. Two things are
+// worth pinning: the order is wire order for both families, and an IPv4
+// address leaves the tail zero rather than filling in the mapped prefix --
+// callers relying on the latter would silently match the wrong rule.
+TEST(NetworkAddress, OctetsAreWireOrderAndLeaveTheIPv4TailZero)
+{
+	// 192.0.2.1 reached through either 32-bit convention gives the same octets,
+	// most significant first -- neither convention is the storage order.
+	const CNetworkAddress v4 = CNetworkAddress::FromIPv4NetworkOrder(TEST_IP_ED2K_ORDER);
+	const CNetworkAddress::Octets v4Octets = v4.GetOctets();
+	ASSERT_EQUALS(192, static_cast<int>(v4Octets[0]));
+	ASSERT_EQUALS(0, static_cast<int>(v4Octets[1]));
+	ASSERT_EQUALS(2, static_cast<int>(v4Octets[2]));
+	ASSERT_EQUALS(1, static_cast<int>(v4Octets[3]));
+	for (int i = 4; i < 16; ++i) {
+		ASSERT_EQUALS(0, static_cast<int>(v4Octets[i]));
+	}
+	ASSERT_EQUALS(0ul, v4.GetScopeId());
+
+	// The mapped form of the same address is a different set of octets, which
+	// is the storage-level statement of MappedAndNativeAreDistinct above.
+	const CNetworkAddress::Octets mappedOctets =
+		CNetworkAddress::FromString("::ffff:192.0.2.1").GetOctets();
+	ASSERT_EQUALS(0xff, static_cast<int>(mappedOctets[10]));
+	ASSERT_EQUALS(0xff, static_cast<int>(mappedOctets[11]));
+	ASSERT_EQUALS(192, static_cast<int>(mappedOctets[12]));
+	ASSERT_EQUALS(1, static_cast<int>(mappedOctets[15]));
+	ASSERT_TRUE(v4Octets != mappedOctets);
+
+	// IPv6FromOctets() applies no absence rule, so the all-zero octets are the
+	// unspecified address and not absence -- unlike FromIPv6Bytes(), which is
+	// the wire-tag edge where all-zero does mean "this peer has no IPv6".
+	ASSERT_TRUE(CNetworkAddress::AnyIPv6().IsPresent());
+	ASSERT_TRUE(CNetworkAddress::AnyIPv6().IsIPv6());
+	ASSERT_TRUE(CNetworkAddress::AnyIPv6().IsUnspecified());
+	ASSERT_EQUALS(wxString("::"), wxString(CNetworkAddress::AnyIPv6().ToString()));
+	const std::uint8_t allZero[16] = { 0 };
+	ASSERT_TRUE(CNetworkAddress::FromIPv6Bytes(allZero).IsAbsent());
+	ASSERT_TRUE(CNetworkAddress::AnyIPv6() != CNetworkAddress::Absent());
+}
+
+// ToIPv6Bytes() is the wire-side writer: the CT_MOD_IP_V6 handshake tag, Kad's
+// "ip6" tag and the NAT endpoint hint each hand it a bare sixteen-byte buffer
+// and then read all sixteen back. Nothing pinned that it fills all sixteen, so
+// the postcondition lived only in the doc comment -- and a short write there is
+// not a cosmetic bug: the bytes it left alone become part of an address a peer
+// is told to punch at.
+TEST(NetworkAddress, ToIPv6BytesFillsAllSixteenOrWritesNothing)
+{
+	// Sentinel fill rather than zero fill: a byte still holding 0xCD afterwards
+	// is a byte the writer skipped, which a zero-filled buffer would hide behind
+	// a plausible-looking 0.
+	std::uint8_t bytes[16];
+	std::fill(std::begin(bytes), std::end(bytes), 0xCD);
+
+	const CNetworkAddress v6 = CNetworkAddress::FromString("2001:db8::1");
+	ASSERT_TRUE(v6.ToIPv6Bytes(bytes));
+	const CNetworkAddress::Octets &expected = v6.GetOctets();
+	for (std::size_t i = 0; i < expected.size(); ++i) {
+		ASSERT_EQUALS(static_cast<int>(expected[i]), static_cast<int>(bytes[i]));
+	}
+	// Stated separately for the trailing octet, because the tail is what a copy
+	// that stops early loses first. It is 1 rather than 0 here, so "skipped" and
+	// "correctly written" cannot coincide.
+	ASSERT_EQUALS(1, static_cast<int>(bytes[15]));
+
+	// A mapped IPv4 address is an IPv6 address for this writer's purposes, and it
+	// goes out as the mapped form -- all sixteen octets again, not four.
+	std::fill(std::begin(bytes), std::end(bytes), 0xCD);
+	ASSERT_TRUE(CNetworkAddress::FromString("::ffff:192.0.2.1").ToIPv6Bytes(bytes));
+	ASSERT_EQUALS(0xff, static_cast<int>(bytes[10]));
+	ASSERT_EQUALS(0xff, static_cast<int>(bytes[11]));
+	ASSERT_EQUALS(192, static_cast<int>(bytes[12]));
+	ASSERT_EQUALS(1, static_cast<int>(bytes[15]));
+
+	// The failure paths write nothing at all, so a caller that ignores the result
+	// cannot mistake a stale buffer for an address it never received.
+	std::fill(std::begin(bytes), std::end(bytes), 0xCD);
+	ASSERT_FALSE(CNetworkAddress::FromIPv4HostOrder(TEST_IP_HOST_ORDER).ToIPv6Bytes(bytes));
+	ASSERT_FALSE(CNetworkAddress::Absent().ToIPv6Bytes(bytes));
+	ASSERT_FALSE(v6.ToIPv6Bytes(nullptr));
+	for (std::size_t i = 0; i < 16; ++i) {
+		ASSERT_EQUALS(0xCD, static_cast<int>(bytes[i]));
+	}
+}
+
+// The socket backend is the one caller that still needs a real asio address, so
+// NetworkAddressAsio.h is the single bridge. It has to be exactly lossless in
+// both directions: a swapped IPv4 conversion here would connect to the wrong
+// host, and a dropped scope id would fold two distinct link-local destinations
+// into one.
+TEST(NetworkAddress, AsioBridgeRoundTripsWithoutLosingAnything)
+{
+	const CNetworkAddress cases[] = {
+		CNetworkAddress::FromIPv4NetworkOrder(TEST_IP_ED2K_ORDER),
+		CNetworkAddress::FromString("0.0.0.0"),
+		CNetworkAddress::FromString("255.255.255.254"),
+		CNetworkAddress::FromString("2001:db8::1"),
+		CNetworkAddress::FromString("::ffff:192.0.2.1"),
+		CNetworkAddress::AnyIPv6(),
+		CNetworkAddress::FromString("::1"),
+	};
+	for (const CNetworkAddress &address : cases) {
+		const CNetworkAddress roundTripped =
+			NetworkAddressAsio::FromAsioAddress(NetworkAddressAsio::ToAsioAddress(address));
+		ASSERT_TRUE(roundTripped == address);
+		// Not just equal -- the same text, so a family or octet swap that
+		// happened to compare equal would still be caught.
+		ASSERT_EQUALS(wxString(address.ToString()), wxString(roundTripped.ToString()));
+	}
+
+	// The 32-bit conventions survive the crossing: asio's to_uint() is host
+	// order, which is the convention FromIPv4HostOrder() names.
+	ASSERT_EQUALS(wxString("192.0.2.1"),
+		wxString(NetworkAddressAsio::FromAsioAddress(boost::asio::ip::make_address("192.0.2.1"))
+				 .ToString()));
+	std::uint32_t hostOrder = 0;
+	ASSERT_TRUE(NetworkAddressAsio::FromAsioAddress(boost::asio::ip::make_address("192.0.2.1"))
+			    .ToIPv4HostOrder(hostOrder));
+	ASSERT_EQUALS(TEST_IP_HOST_ORDER, hostOrder);
+
+	// A scope id is part of the address's identity, so it crosses too. Without
+	// it fe80::1%7 and fe80::1%9 would be one key in every container that uses
+	// this type.
+	const CNetworkAddress scoped =
+		NetworkAddressAsio::FromAsioAddress(boost::asio::ip::make_address("fe80::1%7"));
+	ASSERT_EQUALS(7ul, scoped.GetScopeId());
+	ASSERT_TRUE(scoped == NetworkAddressAsio::FromAsioAddress(NetworkAddressAsio::ToAsioAddress(scoped)));
+	ASSERT_TRUE(scoped != CNetworkAddress::FromString("fe80::1"));
+	ASSERT_TRUE(CNetworkAddress::FromString("fe80::1").GetScopeId() == 0ul);
+
+	// An asio address is always a present address: nothing it can hold means
+	// absence, 0.0.0.0 included. That overload belongs to the wire edges.
+	ASSERT_TRUE(
+		NetworkAddressAsio::FromAsioAddress(boost::asio::ip::make_address("0.0.0.0")).IsPresent());
+	ASSERT_TRUE(NetworkAddressAsio::FromAsioAddress(boost::asio::ip::make_address("0.0.0.0"))
+			    .IsUnspecified());
+}
+
+// File_checked_for_headers


### PR DESCRIPTION
First of the three sequential PRs for piece 3 of #1177, the identity widening. This one adds the type and nothing else.

aMule identifies a peer by a 32-bit address, so an inbound IPv6 peer is accepted by the socket and then dropped: `CClientList` has nothing to index it under, and the ed2k UDP handlers have nothing to look it up by. Widening that identity needs a type first, and reviewing the call sites is easier against something that already exists.

## Inertness

**Nothing calls it.** 1,551 insertions, zero deletions, and the only existing files touched are two `CMakeLists.txt` entries — one adding `NetworkAddress.cpp` to `mulesocket`, one registering the test target.

That is deliberate, and it is this PR's whole safety argument, since as agreed on #1177 piece 3 carries no compile-time switch. The diffstat is checkable without tooling — no line is removed anywhere — but zero deletions is not the whole argument, so here is the rest of it.

`NetworkAddress.cpp` has **no file-scope objects**, only five function definitions. That matters more than the diffstat: adding a TU to `mulesocket` puts it in every executable, and a new TU with a static initialiser would run code at startup in all of them, whatever the diff looks like. [#1315](https://github.com/amule-org/amule/issues/1315) is that exact failure mode, so it is worth stating rather than assuming.

Two things do change:

- every executable grows by five uncalled functions, and one more TU compiles Boost.Asio at build time. No new link dependencies, since `mulesocket` already links Boost;
- one more ctest target.

No shipped binary behaves differently.

## What the type decides

Four things, each because the alternative has cost this tree something already:

**Byte order is in the signature.** `FromIPv4NetworkOrder()` and `FromIPv4HostOrder()` cannot be confused at a call site, where a bare `uint32` could and did — Kad uses host order and the ed2k wire uses network order, and the same variable name carries both today.

**Absence is not the all-zero address.** They were the same zero before. That conflation is what let an absent address be banned as `0.0.0.0`, so every client with an unknown address read back as banned — the defect fixed in #1314, whose root cause was a type that could not tell the two apart.

**Narrowing fails explicitly.** `ToIPv4NetworkOrder()` reports whether an address has a 32-bit form rather than truncating one that does not, so a native IPv6 peer cannot silently become a wrong IPv4 peer.

**The ordering is total**, so the type is usable as a `std::map` key. That is the point rather than a nicety: the identity being widened *is* a map key.

## Where asio went

`FromString()` and `ToString()` are the only operations that compile Boost.Asio, and they live in the `.cpp`, so including the header does not pull asio into a translation unit. `NetworkAddressAsio.h` carries the bridge for the places that genuinely need it.

Both conversions live in a `NetworkAddressAsio` namespace rather than at global scope. They take a `boost::asio::ip::address`, which would make an unqualified pair argument-dependent lookup candidates for every call in a TU that mentions an asio address — and the piece-3 call sites will include this header widely. Nothing collides today; the namespace is here because it is cheap now and awkward once those call sites exist.

`NetworkAddress.cpp` goes into `mulesocket` rather than `muleappcommon` for two reasons, both about where asio already is: `mulesocket` is the last static library on every executable's link line, so a one-pass linker resolves these symbols for `muleappcommon` and `mulecommon` too — putting them in `muleappcommon` breaks `amulegui`, which is scanned first — and `mulesocket` already links `${Boost_LIBRARIES}`, which on mingw-w64 is `ws2_32;mswsock`, exactly what asio's winsock init needs.

## Tests

`NetworkAddressTest`, 11 cases covering the four decisions above plus prefix truncation, both routability predicates, the octet accessors and the asio round trip.

The two routability predicates are pinned range by range because a wrong prefix there does not fail a build. For IPv6 the symptom is an address no peer can reach. For IPv4 it is sharper: the value feeds `CEncryptedDatagramSocket`'s key derivation, so a mask that lets a private or CGNAT address through makes every frame decrypt to noise at the far end with nothing logged on either side. The three sub-byte masks — `100.64.0.0/10`, `172.16.0.0/12`, `198.18.0.0/15` — are pinned at *both* edges rather than at one address inside each, since a mask is the kind of thing that is wrong in one direction only.

Checked by perturbation rather than by inspection: narrowing the CGNAT mask from `/10` to `/11`, the benchmarking mask from `/15` to `/16`, and moving the multicast floor from 224 to 240 each fail by the line that covers them.

## Verification

Build clean, no new warnings. `NetworkAddressTest` passes; 58 suites with one unrelated failure — `FileDataIOTest`, which segfaults only against a statically linked wxWidgets and is [#1315](https://github.com/amule-org/amule/issues/1315), not this branch. clang-format 18 clean. clang-tidy Tier-2 on changed lines clean, and Tier-1's analyzer clean on the new sources, checked locally with the same invocations the workflows use.

## What comes next

Two more PRs, as agreed on #1177: `PeerAddressing.h` and its test, then `AddressFamilyPolicy`. Then the call sites. The eleven files on our branch that carry both the widening and unrelated transport work are held back until this lands, since a piece-3 PR carrying uTP code is not reviewable as piece 3.

## Size

1,551 lines, under the exception granted on #1177. The reason it cannot be smaller stands: `NetworkAddress.h` includes no local header, `FromString`/`ToString` are in the `.cpp`, and the test compiles that `.cpp` because it needs them, so header, implementation, asio bridge and test are one unit. A smaller cut ships either a class that does not compile or a test that pins nothing.

