### PR TITLE
ci: keep clang-tidy Tier-2 out of the vendored subtree

### DIFF
--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -248,7 +248,15 @@ jobs:
           key: clang-tidy-ccache-${{ github.run_id }}
       - name: clang-tidy Tier-2 on changed lines
         run: |
-          git diff -U0 "${{ steps.base.outputs.sha }}"...HEAD -- 'src/**' \
+          # src/extern is vendored: src/extern/.clang-tidy exempts it with
+          # Checks: '-*', but -config-file below overrides per-directory
+          # discovery entirely, so that exemption has no effect in this job
+          # (it does work in Tier-1, which uses discovery). Excluded here
+          # rather than filtered out of the output, so the checks are not run
+          # only to be discarded. Without this, vendoring a dependency lands a
+          # gate demanding edits to third-party sources that the provenance
+          # notes say not to touch.
+          git diff -U0 "${{ steps.base.outputs.sha }}"...HEAD -- 'src/**' ':(exclude)src/extern/**' \
             | clang-tidy-diff-${LLVM_VERSION}.py \
                 -clang-tidy-binary clang-tidy-${LLVM_VERSION} \
                 -p1 -path build -config-file .clang-tidy-new-code -quiet 2>&1 \


### PR DESCRIPTION
`src/extern/.clang-tidy` exempts the vendored subtree with `Checks: '-*'`, and that exemption has no effect in the Tier-2 job. Reported in #1316.

`clang-tidy-diff` is invoked with `-config-file .clang-tidy-new-code`, and `-config-file` overrides per-directory `.clang-tidy` discovery entirely. Verified rather than taken from the documentation, same file and compile database, only the flag differing:

```
discovery only, finds a subdirectory .clang-tidy with Checks: '-*'  ->  0 warnings
--config-file pointing elsewhere                                    ->  1 warning
```

Tier-1 is unaffected: `run-clang-tidy` is invoked with no config flag, so discovery works there and the exemption applies.

## Why it has never mattered, and when it will

`src/extern/` currently holds nothing but the `.clang-tidy` itself, and Tier-2 only looks at changed lines, so an exemption that does not work costs nothing while the subtree is inert.

It stops being inert the moment a dependency is vendored. Measured against `libutp`, the subtree the uTP piece of #1177 needs, Tier-2 reports 35 findings, all `modernize-use-nullptr` and `bugprone-narrowing-conversions` in sources whose provenance note says not to reformat or clean them up. That would arrive as a gate demanding edits to third-party code, with the exemption written to prevent exactly that sitting there not working.

## The change

One pathspec on the diff:

```diff
-git diff -U0 "${{ steps.base.outputs.sha }}"...HEAD -- 'src/**' \
+git diff -U0 "${{ steps.base.outputs.sha }}"...HEAD -- 'src/**' ':(exclude)src/extern/**' \
```

Excluded at the diff rather than filtered out of the diagnostics, so the checks are not run only to be discarded, and the scope stays expressed in one place next to `'src/**'`.

## Why not the alternative

Dropping `-config-file` and letting discovery apply `.clang-tidy-new-code` sounds cleaner, and does not work: discovery would find the root `.clang-tidy`, which is Tier-1's baseline. Tier-2 would silently start running Tier-1's checks on changed lines and stop running the modernize and performance set it exists for. Making that work needs both configs renamed so discovery can tell them apart, which is a larger change than this problem justifies.

## Verification

The pathspec was checked against a scratch commit touching both `src/Demo.cpp` and `src/extern/demo/x.cpp`: without the exclusion the diff carries both files, with it only the former. The workflow YAML parses with both jobs intact.
