### PR TITLE
ci: stop a merge from cancelling the previous merge's clang-tidy run

### DIFF
--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -24,10 +24,22 @@ on:
       - '.clang-tidy-new-code'
       - '.github/workflows/clang-tidy.yml'
 
-# A push to a PR branch fires both `push` and `pull_request`; cancel superseded
-# runs so we don't analyze the same ref twice concurrently.
+# Supersede an older run only when a newer push makes it pointless, which means
+# within one branch or one PR. The default branch is the exception: every commit
+# on master is its own thing to gate, and merges land minutes apart while Tier-1
+# takes ten. A group shared by all of master therefore had each merge cancel the
+# run of the merge before it, so that commit was never gated and never wrote the
+# ccache/ctcache that only master runs save -- leaving the next run colder too.
+#
+# Keying master runs on the commit gives each its own group, so nothing cancels
+# them and bursts of merges analyze in parallel. Turning cancellation off for
+# master instead would not do: GitHub keeps at most one pending run per group,
+# so a third merge would still discard the second.
+#
+# The two events do not share a group and never did: a PR branch push fires
+# `push` at refs/heads/<branch> and `pull_request` at refs/pull/<n>/merge.
 concurrency:
-  group: clang-tidy-${{ github.workflow }}-${{ github.ref }}
+  group: clang-tidy-${{ github.workflow }}-${{ github.ref }}-${{ github.ref == 'refs/heads/master' && github.sha || '' }}
   cancel-in-progress: true
 
 permissions:


### PR DESCRIPTION
Every push to master shared one concurrency group, so with `cancel-in-progress` the next merge killed the previous one. Tier-1 takes about ten minutes and merges land closer together than that:

| Cancelled | Killed by | Gap |
|---|---|---|
| `63bfd054c` (#1313) | `62c7d1550` | 5 min |
| `2506b14df` (#1286) | `502752ad4` (#1323) | 6 min |

Both commits are on master with no clang-tidy verdict.

The cost is not only the missing verdict. The ccache and ctcache save steps run only on master pushes, so the run that gets cancelled is the one that would have rolled those caches forward, and the next run starts colder than it needed to.

Master runs are keyed on the commit now, which gives each its own group, so nothing cancels them and a burst of merges analyzes in parallel. Branch and PR runs keep the shared group and still supersede on a newer push, which is the case cancellation is actually for.

Setting `cancel-in-progress: false` for master instead would not fix it: GitHub keeps at most one pending run per group, so a third merge would discard the second while the first was still running.

The old comment claimed the group deduplicated the `push` and `pull_request` runs a PR branch fires. It never did, and could not: those events carry `refs/heads/<branch>` and `refs/pull/<n>/merge`, so they land in different groups either way. Replaced with what the block actually does.

Diff is the concurrency block alone. YAML parses; the expression yields the SHA on master and an empty string elsewhere. This PR touches the workflow file, which is in its own `paths` filter, so the changed workflow gates itself.

Trade-off worth naming: on master this exchanges cancellation for parallelism, so a burst of N merges now runs N Tier-1 jobs at once instead of one. That is the intent, since each commit gets gated, but it raises peak runner use during a merge train.
