### PR TITLE
fix(web-ui): render a dash for an unstamped chat message time

### DIFF
--- a/src/webapi/static/js/views/messages.js
+++ b/src/webapi/static/js/views/messages.js
@@ -244,7 +244,10 @@ function ChatPane({ reg, active, isGuest }) {
 
 const two = (n) => (n < 10 ? "0" + n : String(n));
 // From the message's own core timestamp, not the wall clock the wx GUI stamps.
+// An unstamped message (sent_at null, or the legacy 0) has no time to show:
+// render a dash rather than a false 1970.
 function hhmmss(ts) {
+  if (!ts) return "—";
   const d = new Date(ts * 1000);
   return two(d.getHours()) + ":" + two(d.getMinutes()) + ":" + two(d.getSeconds());
 }


### PR DESCRIPTION
hhmmss() built a Date from sent_at directly, so a null or 0 timestamp produced new Date(0) and rendered the 1970 epoch in the chat log. The chat_message SSE event can now carry sent_at: null (mirroring the REST row), so guard hhmmss() and return the "—" empty-value placeholder the rest of the Web UI already uses. The if (!ts) check covers null, undefined and the legacy 0 sentinel at once.