### PR TITLE
fix(amuleapi): spell peer reachability `connected` on every resource

### DIFF
--- a/docs/api/EVENTS.md
+++ b/docs/api/EVENTS.md
@@ -328,7 +328,7 @@ Downloads only, but it rides the `comments` channel, not `downloads` -- `?channe
 
 #### `shared_added` / `shared_updated`
 
-Identical to the REST [`/api/v0/shared`](REFERENCE.md#get-apiv0shared) list-item shape. `_updated` fires on any field-level change including `priority`, `priority_auto`, `uploaded_bytes_session`, `uploaded_bytes_total`, `requests.*`, `accepts.*` and `hashed_part_count` — clients see live upload counters (and priority changes, and a running hash) without polling.
+Identical to the REST [`/api/v0/shared`](REFERENCE.md#get-apiv0shared) list-item shape. `_updated` fires on any field-level change including `priority`, `priority_auto`, `uploaded_bytes_session`, `uploaded_bytes_total`, `request_count_*`, `accepted_request_count_*` and `hashed_part_count` — clients see live upload counters (and priority changes, and a running hash) without polling.
 
 ```json
 {
@@ -424,7 +424,7 @@ Identical to the REST [`/api/v0/friends`](REFERENCE.md#get-apiv0friends) list-it
   "ip":           "203.0.113.42",
   "port":         4662,
   "client_ecid":  4382,
-  "online":       true,
+  "connected":    true,
   "friend_slot":  false
 }
 ```

--- a/docs/api/REFERENCE.md
+++ b/docs/api/REFERENCE.md
@@ -317,7 +317,7 @@ Rows added or removed *during* a sweep are not missed: both emit an SSE event, s
 | `GET /known_clients`  | **`user_hash`** (id), `name`, `software`, `first_seen_at`, `last_seen_at`, `session_count`, `uploaded_bytes_total`, `downloaded_bytes_total` |
 | `GET /shared`         | **`hash`** (id), `name`, `size_bytes`, `uploaded_bytes_total`, `upload_speed_bytes_per_second` |
 | `GET /servers`        | **`ecid`** (id), `name`, `user_count`, `ping_ms`, `file_count` |
-| `GET /friends`        | **`ecid`** (id), `name`, `online` |
+| `GET /friends`        | **`ecid`** (id), `name`, `connected` |
 | `GET /chats`          | **`client_ecid`** (id), `last_message_at`, `name` |
 | `GET /search/{id}/results` | **`hash`** (id), `name`, `size_bytes`, `sources.total`, `rating`, `directory` |
 | `GET /search`         | **`search_id`** (id), `query`, `started_at`, `result_count` |
@@ -360,7 +360,7 @@ A key is **omitted** only where absence itself is the meaning: something the dae
 
 So: `null` means "no value", an absent key means "not reported", and neither is ever spelled `0` or `-1`.
 
-The rule now reaches the whole surface rather than just the download and shared objects. Keys that used to disappear and are `null` instead: `name`, `ip`, `port`, `kad_port`, `country_code`, `software`, `software_version`, `source_origin`, `obfuscation_state`, `first_seen_at` and `session_count` on [`GET /known_clients`](#get-apiv0known_clients); `part_progress_percent` and `parts_offered_count` on the client rows and the `client_*` events; `client_ecid` on [`GET /search`](#get-apiv0search), [`GET /friends`](#get-apiv0friends) and the `friend_*` events; `last_message` on [`GET /chats`](#get-apiv0chats); `token`, `label_value` and `extra` on the statistics tree; and `media` everywhere it appears. The same pass reached the remaining address fields: `port` on [`GET /friends`](#get-apiv0friends) and the `friend_*` events, `ed2k.public_ip` and `ed2k.server_ip` on [`GET /status`](#get-apiv0status), and `public_ip` on [`GET /kad`](#get-apiv0kad); and `server_ip` / `server_port` on [`GET /clients/{ecid}`](#get-apiv0clientsecid), which used `""` for the same "unknown" its own snapshot field documents. Completing that sweep: `ip` and `port` on [`GET /clients`](#get-apiv0clients) and the client detail row, which the `client_*` events already nulled, and `ed2k.server_port` on [`GET /status`](#get-apiv0status), which stayed a bare `0` beside its own nulled `server_ip`. The `status_changed` event nulls `ed2k.public_ip`, `ed2k.server_ip` and `ed2k.server_port` to match the REST row. Continuing it: `kad_port` on [`GET /api/v0/clients/{ecid}`](#get-apiv0clientsecid), which stayed a raw `0` beside the `ip`/`port` it is nulled with everywhere else; `last_received_at` on [`GET /api/v0/downloads/{hash}`](#get-apiv0downloadshash), which read as 1970 for a partfile that had received nothing; and `node_id` on [`GET /api/v0/kad`](#get-apiv0kad), the last `""` sentinel in an object whose every other field already answered `null`. And closing the connected-server triple: `server_name` on [`GET /status`](#get-apiv0status) and [`GET /clients/{ecid}`](#get-apiv0clientsecid), which stayed a raw `""` beside the `server_ip` and `server_port` it is nulled with, so one object spelled "not on a server" two ways. `status_changed` nulls it too. Finishing the client objects themselves: `name`, `software`, `software_version`, `reported_os`, `download_file_name`, `upload_file_name`, `upload_file_hash`, `download_file_hash`, `obfuscation_state`, `source_origin` and `client_mod_name` on [`GET /clients`](#get-apiv0clients), the client detail row and the `client_*` events, which spelled "unknown" as a raw `""` while [`GET /known_clients`](#get-apiv0known_clients) already nulled the same keys, so one peer described by both objects disagreed with itself. And the reachability fields: `online` on [`GET /friends`](#get-apiv0friends), [`GET /chats`](#get-apiv0chats) and [`GET /known_clients`](#get-apiv0known_clients), plus the new `connected` on the client objects, are `null` on a daemon that does not report peer connectivity - unknown, rather than a guessed "offline".
+The rule now reaches the whole surface rather than just the download and shared objects. Keys that used to disappear and are `null` instead: `name`, `ip`, `port`, `kad_port`, `country_code`, `software`, `software_version`, `source_origin`, `obfuscation_state`, `first_seen_at` and `session_count` on [`GET /known_clients`](#get-apiv0known_clients); `part_progress_percent` and `parts_offered_count` on the client rows and the `client_*` events; `client_ecid` on [`GET /search`](#get-apiv0search), [`GET /friends`](#get-apiv0friends) and the `friend_*` events; `last_message` on [`GET /chats`](#get-apiv0chats); `token`, `label_value` and `extra` on the statistics tree; and `media` everywhere it appears. The same pass reached the remaining address fields: `port` on [`GET /friends`](#get-apiv0friends) and the `friend_*` events, `ed2k.public_ip` and `ed2k.server_ip` on [`GET /status`](#get-apiv0status), and `public_ip` on [`GET /kad`](#get-apiv0kad); and `server_ip` / `server_port` on [`GET /clients/{ecid}`](#get-apiv0clientsecid), which used `""` for the same "unknown" its own snapshot field documents. Completing that sweep: `ip` and `port` on [`GET /clients`](#get-apiv0clients) and the client detail row, which the `client_*` events already nulled, and `ed2k.server_port` on [`GET /status`](#get-apiv0status), which stayed a bare `0` beside its own nulled `server_ip`. The `status_changed` event nulls `ed2k.public_ip`, `ed2k.server_ip` and `ed2k.server_port` to match the REST row. Continuing it: `kad_port` on [`GET /api/v0/clients/{ecid}`](#get-apiv0clientsecid), which stayed a raw `0` beside the `ip`/`port` it is nulled with everywhere else; `last_received_at` on [`GET /api/v0/downloads/{hash}`](#get-apiv0downloadshash), which read as 1970 for a partfile that had received nothing; and `node_id` on [`GET /api/v0/kad`](#get-apiv0kad), the last `""` sentinel in an object whose every other field already answered `null`. And closing the connected-server triple: `server_name` on [`GET /status`](#get-apiv0status) and [`GET /clients/{ecid}`](#get-apiv0clientsecid), which stayed a raw `""` beside the `server_ip` and `server_port` it is nulled with, so one object spelled "not on a server" two ways. `status_changed` nulls it too. Finishing the client objects themselves: `name`, `software`, `software_version`, `reported_os`, `download_file_name`, `upload_file_name`, `upload_file_hash`, `download_file_hash`, `obfuscation_state`, `source_origin` and `client_mod_name` on [`GET /clients`](#get-apiv0clients), the client detail row and the `client_*` events, which spelled "unknown" as a raw `""` while [`GET /known_clients`](#get-apiv0known_clients) already nulled the same keys, so one peer described by both objects disagreed with itself. And the reachability field: `connected` on [`GET /friends`](#get-apiv0friends), [`GET /chats`](#get-apiv0chats), [`GET /known_clients`](#get-apiv0known_clients) and the client objects, is `null` on a daemon that does not report peer connectivity - unknown, rather than a guessed "offline". One quantity, one key on every resource that carries it (R6).
 
 `media` is the one place this reaches an **object** rather than a scalar, so a client tests `media === null` before reaching into it -- which it had to do regardless, since the object's own fields can be absent.
 
@@ -467,7 +467,7 @@ Every path segment, query parameter and JSON key on this surface follows the rul
 | **R1** | `snake_case` for every path segment, query parameter and JSON key. |
 | **R2** | **Units live in the name, spelled out.** `_bytes`, `_bytes_per_second`, `_seconds`, `_minutes`, `_ms`, `_percent` (always 0-100). A bare number is only acceptable for a dimensionless count. See the note below on why rates are spelled out rather than abbreviated. |
 | **R3** | **Timestamps are integer unix seconds and end in `_at`.** One representation, not two: no parallel ISO-8601 twin. Formatting is a client concern. |
-| **R4** | **Booleans carry no `is_`/`has_`/`can_` prefix.** A boolean already reads as a predicate: an adjective or past participle (`online`, `incomplete`, `recursive`), or an `_enabled`/`_supported` suffix on a stateful noun. A boolean is never a field holding a count, a bare command-verb that reads as an imperative, or a reserved word. |
+| **R4** | **Booleans carry no `is_`/`has_`/`can_` prefix.** A boolean already reads as a predicate: an adjective or past participle (`connected`, `incomplete`, `recursive`), or an `_enabled`/`_supported` suffix on a stateful noun. A boolean is never a field holding a count, a bare command-verb that reads as an imperative, or a reserved word. |
 | **R5** | **Counts end in `_count`** — except inside an object that already names the thing being counted, where the parent carries it (`sources.total`, `sources.transferring`). The pagination envelope keeps `total` for "matching items before the window". |
 | **R6** | **One concept, one key, everywhere.** The same quantity does not get one name on one resource and another on the next. |
 | **R7** | **A `sort` value *is* the response key it orders by**, spelled identically, dotted for nested keys (`sort=sources.total`). No stripped suffixes and no per-endpoint mapping table. |
@@ -1303,7 +1303,7 @@ The last five were originally detail-only and were promoted onto this row (and o
 
 Every one of them falls back to `"unknown"` for a code the daemon does not map, so a client can treat `"unknown"` as its default branch and never has to handle an unexpected token. Three of them are also nullable on the live client objects: `software`, `obfuscation_state` and `source_origin` are `null` when the daemon never reported the field at all, which is a different thing from reporting a code we could not map. `upload_state`, `download_state` and `ident_state` are never `null` — the daemon always answers those. Note the two distinct sentinels on `obfuscation_state`: `"undefined"` is *the client has not told us yet*, `"unknown"` is *the daemon received a code it does not recognise*. The authoritative mappings are the `Client*Name()` / `SourceOriginName()` functions in `src/webapi/Refresher.cpp`.
 
-`connected` says whether a socket to this peer is up right now. A row existing in this list does not answer that: the daemon holds a client object from the first contact attempt, so a peer it is still trying to reach - or can never reach - appears here with `connected: false`. It is `null` on a daemon that does not report peer connectivity. The `online` fields on [`GET /friends`](#get-apiv0friends), [`GET /chats`](#get-apiv0chats) and [`GET /known_clients`](#get-apiv0known_clients) are the same fact reached by their own keys.
+`connected` says whether a socket to this peer is up right now. A row existing in this list does not answer that: the daemon holds a client object from the first contact attempt, so a peer it is still trying to reach - or can never reach - appears here with `connected: false`. It is `null` on a daemon that does not report peer connectivity. [`GET /friends`](#get-apiv0friends), [`GET /chats`](#get-apiv0chats) and [`GET /known_clients`](#get-apiv0known_clients) carry the same fact under the same key, so joining any of them against this list does not meet it under a second name.
 
 `protocol_extensions` is the set of protocol extensions the peer claimed in its handshake, as stable tokens: `extended_source_exchange`, `nat_traversal_utp`, `ipv6`, `serving_buddy_pull`, `nat_traversal_quic`. A list rather than one token because a peer claims any combination of them, and tokens rather than the `EC_TAG_CLIENT_MOD_CAPABILITIES` bitfield they arrive in so no consumer has to carry its own copy of aMule's bit meanings. The order is stable. The daemon has already dropped every extension it does not define, so a token here is one aMule names, and an extension aMule does not name is absent rather than unknown. `[]` means the peer claimed nothing, which is what nearly every peer on the network does — a peer that sent no capability tag and one that sent an all-zero word are the same state on the wire and report the same here. The desktop GUI renders the same set as its *Protocol extensions* row.
 
@@ -1439,7 +1439,7 @@ curl -s -H "Authorization: Bearer $TOKEN" \
 
 Lists every client the daemon has ever exchanged data with, from its credit store.
 
-Distinct from [`GET /clients`](#get-apiv0clients), which lists the clients connected **right now**. The two differ in identity as well as content: a live client is keyed by `ecid`, which is meaningful only within one daemon process, while a known client is keyed by `user_hash` and survives daemon restarts. Correlate the two on `user_hash`; the `online` field says whether we are actually connected to that peer at this moment.
+Distinct from [`GET /clients`](#get-apiv0clients), which lists the clients connected **right now**. The two differ in identity as well as content: a live client is keyed by `ecid`, which is meaningful only within one daemon process, while a known client is keyed by `user_hash` and survives daemon restarts. Correlate the two on `user_hash`; the `connected` field, the same key the live rows carry, says whether we are actually connected to that peer at this moment.
 
 Standard [list envelope](#list-pagination-and-sorting) under the `known_clients` key, with `limit` / `offset` / `sort` / `order`.
 
@@ -1467,7 +1467,7 @@ curl -s -H "Authorization: Bearer $TOKEN" \
       "last_seen_at": 1786652714,
       "first_seen_at": 1786652714,
       "session_count": 1,
-      "online": false
+      "connected": false
     }
   ],
   "total": 392, "offset": 0, "limit": 2
@@ -1486,16 +1486,16 @@ curl -s -H "Authorization: Bearer $TOKEN" \
 | `uploaded_bytes_total`, `downloaded_bytes_total` | Lifetime bytes, from the credit record. Always present. |
 | `last_seen_at` | Unix seconds. Always present. For a client that is connected this is *now* — it is being seen — so the connected records are the most recent in the store under `sort=last_seen_at&order=desc`. A client that left during the current tick carries the same timestamp and ties with them; ties keep a stable order across requests. |
 | `first_seen_at`, `session_count` | `null` together, and non-null only for a record the daemon holds metadata for. |
-| `online` | Whether a connection to this peer is up right now, correlated by `user_hash`. `null` when the daemon does not report peer connectivity. Not the same as having a row in [`GET /clients`](#get-apiv0clients): the daemon holds a client object from the first contact attempt, including for a peer it never reaches. |
+| `connected` | Whether a connection to this peer is up right now, correlated by `user_hash`. Same key and same quantity as on [`GET /clients`](#get-apiv0clients), so a join by `user_hash` does not meet it under a second name. `null` when the daemon does not report peer connectivity. Not the same as having a row in [`GET /clients`](#get-apiv0clients): the daemon holds a client object from the first contact attempt, including for a peer it never reaches. |
 
 **Optional fields are `null`, never omitted and never emitted empty.** Every key above is written through `Write*OrNull`, so the shape of a row does not change with what the daemon knows: a record written before the daemon kept per-client metadata carries the hash, the totals and `last_seen_at` as values and the rest as `null`, which is how a consumer tells "never recorded" from "recorded as empty". On a long-lived node most records are of that kind. This follows the surface-wide rule in [Unknown values](#unknown-values); `GET /search` is the documented exception where absence itself is the meaning.
 
 The store is read from the daemon **once**, on the first request, and maintained from there: every refresher tick folds the connected clients back in, so later requests never touch EC at all. That is sound rather than a shortcut — a record whose client is not connected cannot change, since credit totals only move during a transfer and `last_seen_at` is written at disconnect. What the maintenance covers:
 
 - a client that connects is added, with `first_seen_at` and `session_count` set to what the daemon recorded when it said hello;
-- a connected client's `online`, `uploaded_bytes_total` and `downloaded_bytes_total` track the live client state;
+- a connected client's `connected`, `uploaded_bytes_total` and `downloaded_bytes_total` track the live client state;
 - a bare record gains its name, address, software and origin once its client identifies;
-- a connected client's `last_seen_at` is now, and a client that leaves has `online` cleared with `last_seen_at` stamped at the moment it went.
+- a connected client's `last_seen_at` is now, and a client that leaves has `connected` cleared with `last_seen_at` stamped at the moment it went.
 
 The cost is one EC roundtrip per amuleapi process, and the store stays resident from first use.
 
@@ -2090,7 +2090,7 @@ The friends list amuled persists to `emfriends.met`. The daemon ships the whole 
       "ip": "203.0.113.42",
       "port": 4662,
       "client_ecid": 4382,
-      "online": true,
+      "connected": true,
       "friend_slot": false
     }
   ],
@@ -2100,7 +2100,7 @@ The friends list amuled persists to `emfriends.met`. The daemon ships the whole 
 }
 ```
 
-`client_ecid` is the live client this friend is currently linked to, joinable against [`GET /api/v0/clients`](#get-apiv0clients), and `null` when no client object is held for the friend. `online` is a different question and answers it directly: whether a connection to the peer is up. A friend can have a `client_ecid` and be `false` here, which is the ordinary state for one the daemon is trying, or failing, to reach. `null` means the daemon does not report peer connectivity. `user_hash` is `""` for a friend added by address only; `ip` and `port` are `null` for a zero address, and the `friend_*` events emit the same nulls.
+`client_ecid` is the live client this friend is currently linked to, joinable against [`GET /api/v0/clients`](#get-apiv0clients), and `null` when no client object is held for the friend. `connected` is a different question and answers it directly: whether a connection to the peer is up. A friend can have a `client_ecid` and be `false` here, which is the ordinary state for one the daemon is trying, or failing, to reach. `null` means the daemon does not report peer connectivity. `user_hash` is `""` for a friend added by address only; `ip` and `port` are `null` for a zero address, and the `friend_*` events emit the same nulls.
 
 `friend_slot` reads `false` against a daemon predating the tag that carries it, the same way `friend` and `credit_ratio` degrade on `/clients`.
 
@@ -3178,7 +3178,7 @@ curl -s -H "Authorization: Bearer $TOKEN" "http://$HOST/api/v0/chats"
       "name":            "alice",
       "client_ecid":     4382,
       "friend_ecid":     12,
-      "online":          true,
+      "connected":       true,
       "message_count":   14,
       "last_message_id":     91,
       "last_message_at": 1786652714,
@@ -3189,7 +3189,7 @@ curl -s -H "Authorization: Bearer $TOKEN" "http://$HOST/api/v0/chats"
 }
 ```
 
-`name` falls back to `"IP: <ip> Port: <port>"` when the core has no nickname for the client, matching what the desktop shows; the same string appears in the SSE payload. `client_ecid` is `null` when the client is offline and `friend_ecid` is `null` when the client is not a friend — join either against [`GET /clients`](#get-apiv0clients) and [`GET /friends`](#get-apiv0friends). `online` says whether a connection to the peer is actually up, which is not the same as `client_ecid` being non-null: the daemon holds a client object from the first contact attempt, so a conversation opened against an unreachable address has an ecid and is not online. `null` means the daemon does not report peer connectivity.
+`name` falls back to `"IP: <ip> Port: <port>"` when the core has no nickname for the client, matching what the desktop shows; the same string appears in the SSE payload. `client_ecid` is `null` when the client is offline and `friend_ecid` is `null` when the client is not a friend — join either against [`GET /clients`](#get-apiv0clients) and [`GET /friends`](#get-apiv0friends). `connected` says whether a connection to the peer is actually up, which is not the same as `client_ecid` being non-null: the daemon holds a client object from the first contact attempt, so a conversation opened against an unreachable address has an ecid and is not online. `null` means the daemon does not report peer connectivity.
 
 `last_message` is `null` for a conversation that holds none; the key is always present. The full transcript is deliberately **not** on the list: 50 conversations at 200 messages each would be 10 000 objects per read. Use the messages endpoint below.
 

--- a/src/webapi/Api.cpp
+++ b/src/webapi/Api.cpp
@@ -3295,9 +3295,14 @@ void WriteKnownClientObject(CJsonWriter &w, const webapi::KnownClientSnapshot &c
 	// Correlate with /clients by user_hash to reach the live peer. The value
 	// is reachability, not presence in that list: the daemon holds a client
 	// object from the first contact ATTEMPT, so a peer it can never reach used
-	// to read "online" here. null when the core predates
+	// to read as reachable here. null when the core predates
 	// EC_TAG_CLIENT_CONNECTED -- unknown, not offline.
-	WriteBoolOrNull(w, "online", c.has_online, c.online);
+	//
+	// `connected`, the same key the live rows carry: this is the same
+	// EC_TAG_CLIENT_CONNECTED bit reaching a persisted row by correlation, and
+	// a client joining the two by user_hash should not meet it under a second
+	// name on the far side of the join (R6).
+	WriteBoolOrNull(w, "connected", c.has_connected, c.connected);
 	w.EndObject();
 }
 
@@ -6086,15 +6091,15 @@ void WriteFriendObject(CJsonWriter &w, const webapi::FriendSnapshot &f)
 	WriteIntOrNull(w, "port", !f.ip.empty(), static_cast<int64_t>(f.port));
 	// The live peer this friend is linked to, joinable against /clients. null
 	// when the friend is not connected, which is the common case and which
-	// `online` also reports. Deliberately not the 0 it used to be: the surface
+	// `connected` also reports. Deliberately not the 0 it used to be: the surface
 	// spells "no value" as null and never as 0 or -1, and a client joining
 	// naively on the raw value was building GET /clients/0 and taking a 404.
 	WriteIntOrNull(w, "client_ecid", f.client_ecid != 0, static_cast<int64_t>(f.client_ecid));
 	// Whether a socket to the peer is actually up, not whether the daemon
 	// holds a client object for it -- which it does from the first contact
-	// ATTEMPT, so this used to call an unroutable peer online. null when the
+	// ATTEMPT, so this used to call an unroutable peer reachable. null when the
 	// daemon predates EC_TAG_CLIENT_CONNECTED: unknown, not offline.
-	WriteBoolOrNull(w, "online", f.has_connected, f.connected);
+	WriteBoolOrNull(w, "connected", f.has_connected, f.connected);
 	w.Key("friend_slot");
 	w.ValueBool(f.friend_slot);
 	w.EndObject();
@@ -6356,7 +6361,7 @@ void WriteChatObject(CJsonWriter &w, const webapi::ChatSessionSnapshot &s)
 	WriteIntOrNull(w, "client_ecid", s.client_ecid != 0, static_cast<int64_t>(s.client_ecid));
 	WriteIntOrNull(w, "friend_ecid", s.friend_ecid != 0, static_cast<int64_t>(s.friend_ecid));
 	// Same rule as the /friends row: reachability, not object existence.
-	WriteBoolOrNull(w, "online", s.has_connected, s.connected);
+	WriteBoolOrNull(w, "connected", s.has_connected, s.connected);
 	w.Key("message_count");
 	w.ValueInt(static_cast<int64_t>(s.messages.size()));
 	w.Key("last_message_id");
@@ -6815,7 +6820,7 @@ CHttpServer::Response CApiDispatcher::HandleFriends(const CHttpServer::Request &
 		// cares about, not the order a UI table does.
 		{ "ecid", SORT_BY(ecid), ANCHOR_ON_NUM(ecid) },
 		{ "name", SORT_BY(name) },
-		{ "online",
+		{ "connected",
 			[](const webapi::FriendSnapshot &a, const webapi::FriendSnapshot &b) {
 				return (a.client_ecid != 0) < (b.client_ecid != 0);
 			} },
@@ -7696,7 +7701,7 @@ void WriteStatsValue(CJsonWriter &w, const webapi::StatsTreeValue &v)
 	}
 	// Additive, locale-independent token for well-known sentinel values
 	// ("never"/"not_available"); the English "value" above is kept so old
-	// clients keep working. Omitted when the value is not a sentinel.
+	// clients keep working.
 	// `token`, not `enum`: `enum` is a reserved word in C++, C#, Java, Rust,
 	// PHP and Swift, so a generated client cannot name a field after the key.
 	// null when the value is not a sentinel -- there is no token, which is a

--- a/src/webapi/EventDiff.cpp
+++ b/src/webapi/EventDiff.cpp
@@ -329,7 +329,7 @@ std::string ToJson(const FriendSnapshot &f)
 	  << ",\"ip\":" << (f.ip.empty() ? std::string("null") : "\"" + EscJson(f.ip) + "\"")
 	  << ",\"port\":" << (f.ip.empty() ? std::string("null") : std::to_string(f.port))
 	  << ",\"client_ecid\":" << (f.client_ecid ? std::to_string(f.client_ecid) : std::string("null"))
-	  << ",\"online\":" << JsonBoolOrNull(f.has_connected, f.connected)
+	  << ",\"connected\":" << JsonBoolOrNull(f.has_connected, f.connected)
 	  << ",\"friend_slot\":" << (f.friend_slot ? "true" : "false") << "}";
 	return o.str();
 }

--- a/src/webapi/State.cpp
+++ b/src/webapi/State.cpp
@@ -53,8 +53,8 @@ std::uint16_t SharedHashingProgress(const FileSnapshot &f)
 // Completeness of the file we download FROM this peer: parts the peer has over
 // that file's part count. Only the download link carries a meaningful
 // denominator -- a peer that merely downloads from us has no percent. Left at
-// its < 0 sentinel when not computable, which is how the writers know to omit
-// the field.
+// its < 0 sentinel when not computable, which is how the writers know to emit
+// the field as null. The sentinel never reaches the wire.
 void ComputePartProgressPercent(const CState &state, ClientSnapshot &cli)
 {
 	if (!cli.has_parts_offered_count || cli.download_file_hash.empty()) {
@@ -678,7 +678,7 @@ void CState::SetKnownClients(std::vector<KnownClientSnapshot> &&rows)
 	std::unique_lock<std::shared_timed_mutex> lock(m_mu);
 	m_known_clients = std::move(rows);
 	m_known_of_hash.clear();
-	m_known_online.clear();
+	m_known_connected.clear();
 	for (std::size_t i = 0; i < m_known_clients.size(); ++i)
 		m_known_of_hash[m_known_clients[i].user_hash] = i;
 	m_known_loaded = true;
@@ -737,11 +737,11 @@ void CState::ReconcileKnownClientsLocked()
 		// Reachability, echoed from the live row. A client object exists from
 		// the first contact ATTEMPT, so presence in the list is not the same
 		// question -- an unroutable peer sat here reading "Online now".
-		// Read before the assignment: k.online still holds last tick's answer,
+		// Read before the assignment: k.connected still holds last tick's answer,
 		// which is what the session edge below is measured against.
-		const bool was_connected = k.online;
-		k.online = c.has_connected && c.connected;
-		k.has_online = c.has_connected;
+		const bool was_connected = k.connected;
+		k.connected = c.has_connected && c.connected;
+		k.has_connected = c.has_connected;
 		// Not-connected to connected is a new session, which is what the
 		// daemon counts: UpdateMeta() bumps it once per client object at the
 		// hello, and a hello needs a connection. This used to fire on the peer
@@ -752,8 +752,8 @@ void CState::ReconcileKnownClientsLocked()
 		//
 		// It can still over-count by one if a peer drops out of the update for
 		// a tick and returns -- an EC hiccup rather than a real reconnect --
-		// because the departure sweep below clears online for it.
-		if (!was_connected && k.online)
+		// because the departure sweep below clears connected for it.
+		if (!was_connected && k.connected)
 			k.session_count++;
 		// A peer in front of us was last seen now, not whenever it previously
 		// disconnected. Leaving the stored value would report a peer that is
@@ -780,23 +780,23 @@ void CState::ReconcileKnownClientsLocked()
 		}
 	}
 
-	// Whoever was online last tick and is not in this one has gone. Found
-	// through the online set, so this costs the number of departures rather
+	// Whoever was connected last tick and is not in this one has gone. Found
+	// through the connected set, so this costs the number of departures rather
 	// than a walk of the store.
-	for (const std::size_t idx : m_known_online) {
+	for (const std::size_t idx : m_known_connected) {
 		if (still_online.count(idx) != 0)
 			continue;
 		// Gone from the client list entirely: the daemon holds no object for
 		// it, so it is definitively not connected. Known, not unknown.
-		m_known_clients[idx].online = false;
-		m_known_clients[idx].has_online = true;
+		m_known_clients[idx].connected = false;
+		m_known_clients[idx].has_connected = true;
 		// Seen until this moment, which is what the core writes to the record
 		// at its own disconnect handling. The stored value is the *previous*
 		// disconnect, so leaving it would show a peer that was here a second
 		// ago as last seen months back.
 		m_known_clients[idx].last_seen_at = now;
 	}
-	m_known_online.swap(still_online);
+	m_known_connected.swap(still_online);
 }
 
 bool CState::FindDownload(const std::string &hash_hex, FileSnapshot &out) const

--- a/src/webapi/State.h
+++ b/src/webapi/State.h
@@ -347,11 +347,15 @@ struct KnownClientSnapshot
 	//! This peer is connected right now, correlated by user hash against the
 	//! live client list. Never by ECID: those mean nothing across daemon
 	//! restarts, while the hash is what the credit store is keyed on.
-	bool online = false;
+	//!
+	//! Named for the same quantity the live rows carry, and spelled the same
+	//! on the wire: this is EC_TAG_CLIENT_CONNECTED reaching a persisted row
+	//! by correlation rather than a second concept (R6).
+	bool connected = false;
 	//! The daemon answered the reachability question. False means unknown (a
 	//! core that predates EC_TAG_CLIENT_CONNECTED), which is null on the wire
 	//! rather than a guessed "offline".
-	bool has_online = false;
+	bool has_connected = false;
 };
 
 //! amuled substitutes this for the queue position when the peer's queue is
@@ -2111,9 +2115,9 @@ private:
 	// peer a second row.
 	std::map<std::string, std::size_t> m_known_of_hash;
 	bool m_known_loaded = false;
-	//! Rows currently flagged online, so a peer that left is found without
+	//! Rows currently flagged connected, so a peer that left is found without
 	//! walking the store.
-	std::set<std::size_t> m_known_online;
+	std::set<std::size_t> m_known_connected;
 	//! MUST be called with m_mu held for writing.
 	void ReconcileKnownClientsLocked();
 	std::map<std::uint32_t, ServerSnapshot> m_servers;

--- a/src/webapi/static/js/chats.js
+++ b/src/webapi/static/js/chats.js
@@ -168,7 +168,7 @@ async function adopt() {
       const cEcid = s.client_ecid || 0, fEcid = s.friend_ecid || 0;
       if (cEcid !== cur.clientEcid) { cur.clientEcid = cEcid; added = true; }
       if (fEcid !== cur.friendEcid) { cur.friendEcid = fEcid; added = true; }
-      const onl = s.online === true;
+      const onl = s.connected === true;
       if (onl !== cur.online) { cur.online = onl; added = true; }
       if (cur.loaded && s.last_message_id > cur.lastMsgId) loadMessages(s.address);
       continue;
@@ -176,7 +176,7 @@ async function adopt() {
     const conv = newConv({
       peer: s.address, ip: s.ip, port: s.port, name: s.name,
       clientEcid: s.client_ecid || 0, friendEcid: s.friend_ecid || 0,
-      online: s.online === true,
+      online: s.connected === true,
     });
     conv.known = true;
     convs.set(s.address, conv);
@@ -250,13 +250,17 @@ function onMessage(p) {
     conv = newConv({
       peer: p.address, ip: p.ip, port: p.port, name: p.name,
       clientEcid: p.client_ecid || 0, friendEcid: p.friend_ecid || 0,
-      online: p.online === true,
+      // No reachability here: chat_message carries address/ip/port/name/
+      // client_ecid/friend_ecid/message and nothing else. Defaults to false
+      // until GET /chats or a friend_updated says otherwise.
     });
     convs.set(p.address, conv);
   } else {
     conv.name = betterName(conv, p.name);
     conv.clientEcid = p.client_ecid || 0;
-    conv.online = p.online === true;
+    // Deliberately not touching conv.online: the event carries no reachability
+    // field, so `p.online === true` was always false and a message arriving
+    // from a peer we knew to be up marked it offline.
     conv.friendEcid = p.friend_ecid || 0;
   }
   conv.known = true;

--- a/src/webapi/static/js/views/messages.js
+++ b/src/webapi/static/js/views/messages.js
@@ -80,16 +80,16 @@ function FriendsPane({ friends, isGuest, activePeer, onAdd }) {
     // A real <button>, not an <li> click handler, for keyboard/a11y.
     return html`
       <li class=${"friend-row" + (peer && peer === activePeer ? " active" : "")} key=${f.ecid}>
-        <button type="button" class=${"friend-open" + (f.online ? " online" : "")} disabled=${!peer}
-                title=${f.name + (peer ? " — " + peer : "") + " · " + (f.online ? t("messages_online") : t("messages_offline"))}
+        <button type="button" class=${"friend-open" + (f.connected ? " online" : "")} disabled=${!peer}
+                title=${f.name + (peer ? " — " + peer : "") + " · " + (f.connected ? t("messages_online") : t("messages_offline"))}
                 onClick=${() => chats.open({ peer, ip: f.ip, port: f.port, name: f.name, friendEcid: f.ecid, clientEcid: f.client_ecid || 0 })}>
-          <span class=${"friend-dot" + (f.online ? " online" : "")}></span>
+          <span class=${"friend-dot" + (f.connected ? " online" : "")}></span>
           <span class="friend-name">${f.name}</span>
         </button>
         ${isGuest ? null : html`
           <span class="row-actions admin-only">
             <button class=${"btn btn-icon btn-sm" + (f.friend_slot ? " active" : "")}
-                    title=${t("messages_friend_slot")} disabled=${!f.online}
+                    title=${t("messages_friend_slot")} disabled=${!f.connected}
                     onClick=${() => toggleSlot(f)}><${Icon} name="star" /></button>
             <button class="btn btn-icon btn-sm" title=${t("messages_view_files")}
                     onClick=${() => viewFiles(f)}><${Icon} name="search" /></button>

--- a/unittests/curl-tests/amuleapi/33-known-clients.sh
+++ b/unittests/curl-tests/amuleapi/33-known-clients.sh
@@ -17,7 +17,7 @@
 #   * every `sort` key the endpoint advertises is accepted and an
 #     unknown one is a 400,
 #   * each record carries the fields that are always recorded (user_hash,
-#     the totals, last_seen_at, online) and omits — rather than empties —
+#     the totals, last_seen_at, connected) and omits — rather than empties —
 #     the ones a pre-metadata record has no value for,
 #   * `user_hash` is a 32-char lowercase MD4, so it correlates with
 #     /clients `user_hash` directly,
@@ -163,7 +163,7 @@ _assert_status 200 "sort=last_seen_at&order=desc is accepted"
 if [ "${TOTAL:-0}" -gt 0 ]; then
 	_curl "$HOST/api/v0/known_clients?limit=1"
 
-	for k in user_hash uploaded_bytes_total downloaded_bytes_total last_seen_at online; do
+	for k in user_hash uploaded_bytes_total downloaded_bytes_total last_seen_at connected; do
 		if [ "$(_jq ".known_clients[0] | has(\"$k\")")" = "true" ]; then
 			_pass "record always carries $k"
 		else
@@ -179,11 +179,18 @@ if [ "${TOTAL:-0}" -gt 0 ]; then
 	fi
 
 	# boolean, or null on a daemon that does not report peer connectivity.
-	ONLINE_TYPE=$(_jq '.known_clients[0].online | type')
-	if [ "$ONLINE_TYPE" = "boolean" ] || [ "$ONLINE_TYPE" = "null" ]; then
-		_pass "online is a boolean or null"
+	# The pre-rename spelling must be absent, not merely shadowed: a client
+	# reading `online` would silently see undefined rather than a boolean.
+	if [ "$(_jq '.known_clients[0].online | type')" = "null" ]; then
+		_pass "known_clients no longer emits the old online key"
 	else
-		_fail "online" "expected boolean or null, got: $ONLINE_TYPE"
+		_fail "known_clients online" "the retired key is still present"
+	fi
+	ONLINE_TYPE=$(_jq '.known_clients[0].connected | type')
+	if [ "$ONLINE_TYPE" = "boolean" ] || [ "$ONLINE_TYPE" = "null" ]; then
+		_pass "connected is a boolean or null"
+	else
+		_fail "connected" "expected boolean or null, got: $ONLINE_TYPE"
 	fi
 
 	# Optional fields are omitted, never emitted empty: a record written
@@ -220,7 +227,7 @@ fi
 # large store contains no online records at all, and the check would skip
 # itself forever while looking like it had run.
 _curl "$HOST/api/v0/known_clients?sort=last_seen_at&order=desc&limit=500"
-ACTIVE_HASH=$(_jq '[.known_clients[] | select(.online)][0].user_hash')
+ACTIVE_HASH=$(_jq '[.known_clients[] | select(.connected)][0].user_hash')
 if [ -n "$ACTIVE_HASH" ] && [ "$ACTIVE_HASH" != "null" ]; then
 	BEFORE=$(_jq "[.known_clients[] | select(.user_hash == \"$ACTIVE_HASH\")][0]
 		| .downloaded_bytes_total + .uploaded_bytes_total")
@@ -277,11 +284,11 @@ if [ -n "$LIVE_HASHES" ]; then
 	fi
 
 	# And they are flagged as connected, not merely present.
-	ONLINE_N=$(_jq '[.known_clients[] | select(.online)] | length')
+	ONLINE_N=$(_jq '[.known_clients[] | select(.connected)] | length')
 	if [ "${ONLINE_N:-0}" -gt 0 ]; then
-		_pass "connected peers are flagged online ($ONLINE_N)"
+		_pass "connected peers are flagged connected ($ONLINE_N)"
 	else
-		_fail "online flag" "no record is flagged online while peers are connected"
+		_fail "connected flag" "no record is flagged connected while peers are connected"
 	fi
 elif [ "${LIVE_TOTAL:-0}" -gt 0 ]; then
 	# Connected, but nothing to look up: every peer is still on the
@@ -331,7 +338,7 @@ _cross_check_online() {
 	_curl "$HOST/api/v0/known_clients?limit=200"
 	local online_hashes connected_hashes h missing=""
 	online_hashes=$(printf '%s' "$CURL_BODY" \
-		| jq -r '[.known_clients[] | select(.online == true) | .user_hash] | .[]')
+		| jq -r '[.known_clients[] | select(.connected == true) | .user_hash] | .[]')
 	[ -z "$online_hashes" ] && { echo "__NONE__"; return; }
 	_curl "$HOST/api/v0/clients?limit=1000"
 	# Flattened to one space-separated line: the membership test below is a
@@ -379,11 +386,11 @@ for i in $(seq 1 8); do
 	sleep 1
 done
 if [ "$PERSISTENT" = "__NONE__" ]; then
-	_skip "no known client is online; cannot cross-check against /clients"
+	_skip "no known client is connected; cannot cross-check against /clients"
 elif [ -z "$PERSISTENT" ]; then
-	_pass "every online known client has a connected /clients counterpart"
+	_pass "every connected known client has a connected /clients counterpart"
 else
-	_fail "known_clients online" \
+	_fail "known_clients connected" \
 		"no connected /clients row for:$PERSISTENT (in every one of 8 samples)"
 fi
 

--- a/unittests/curl-tests/amuleapi/34-friends.sh
+++ b/unittests/curl-tests/amuleapi/34-friends.sh
@@ -17,7 +17,7 @@
 #   * both advertised sort keys are accepted and an unknown one is a 400,
 #   * a friend added by address round-trips: the POST is a bodyless 202
 #     (EC's FRIEND op never returns the record it made) and the friend
-#     then appears in the list with the address given, `online` false
+#     then appears in the list with the address given, `connected` false
 #     while nothing is linked,
 #   * `user_hash` is either empty or a 32-char lowercase MD4, so it
 #     correlates with /clients `user_hash` directly,
@@ -133,7 +133,7 @@ for bad in "limit=abc" "limit=-1" "offset=-1" "order=sideways"; do
 	_assert_status 400 "GET /friends?$bad is rejected"
 done
 
-for key in name online; do
+for key in name connected; do
 	_curl "$HOST/api/v0/friends?sort=$key&order=desc"
 	_assert_status 200 "sort=$key is accepted"
 done
@@ -175,9 +175,9 @@ NEW=$(echo "$CURL_BODY" | jq -r --argjson e "$NEW_ECID" \
 	&& _pass "ip round-trips" || _fail "ip" "got $(echo "$NEW" | jq -r .ip)"
 [ "$(echo "$NEW" | jq -r .port)" = "$TEST_PORT" ] \
 	&& _pass "port round-trips" || _fail "port" "got $(echo "$NEW" | jq -r .port)"
-[ "$(echo "$NEW" | jq -r .online)" = "false" ] \
+[ "$(echo "$NEW" | jq -r .connected)" = "false" ] \
 	&& _pass "a friend with no linked peer is offline" \
-	|| _fail "online" "expected false, got $(echo "$NEW" | jq -r .online)"
+	|| _fail "connected" "expected false, got $(echo "$NEW" | jq -r .connected)"
 # ...and reports that as null, not as the 0 sentinel it used to send. 0 is not
 # how this surface spells "no value" anywhere else, and a client joining
 # naively on the raw number was building GET /clients/0 and taking a 404.
@@ -291,15 +291,15 @@ FINAL=$(_jq '.total')
 # runs one way only: online true requires a live peer, but a live peer does
 # not make the friend online.
 _curl "$HOST/api/v0/friends?limit=200"
-if [ "$(_jq '[.friends[] | select((.online | type) as $t | $t != "boolean" and $t != "null")] | length')" = "0" ]; then
-	_pass "every friend online is a boolean or null"
+if [ "$(_jq '[.friends[] | select((.connected | type) as $t | $t != "boolean" and $t != "null")] | length')" = "0" ]; then
+	_pass "every friend connected is a boolean or null"
 else
-	_fail "friends online type" "a row has online neither boolean nor null: $CURL_BODY"
+	_fail "friends connected type" "a row has connected neither boolean nor null: $CURL_BODY"
 fi
-if [ "$(_jq '[.friends[] | select(.online == true and .client_ecid == null)] | length')" = "0" ]; then
-	_pass "no friend is online without a client_ecid"
+if [ "$(_jq '[.friends[] | select(.connected == true and .client_ecid == null)] | length')" = "0" ]; then
+	_pass "no friend is connected without a client_ecid"
 else
-	_fail "friends online" "a row claims online with client_ecid null: $CURL_BODY"
+	_fail "friends connected" "a row claims connected with client_ecid null: $CURL_BODY"
 fi
 
 # --- Summary -------------------------------------------------------

--- a/unittests/curl-tests/amuleapi/38-chat.sh
+++ b/unittests/curl-tests/amuleapi/38-chat.sh
@@ -163,13 +163,13 @@ _assert_json_eq '.port'               "$PEER_PORT" 'row carries the split port'
 # while trying. That is the whole point of the field: `online` is
 # reachability, and it used to be inferred from client_ecid merely existing,
 # which is true from the first contact ATTEMPT.
-_assert_json_eq '.online'             false        'unrouted peer is offline'
+_assert_json_eq '.connected'          false        'unrouted peer is offline'
 # client_ecid is deliberately NOT asserted null here any more. The daemon
 # legitimately holds a client object for a peer it is trying to reach, so
 # pinning it to null asserted the very conflation `online` now avoids. What
 # must hold is the implication: online can only be true with a live peer.
-_assert_json_eq '(.online == true) and (.client_ecid == null) | not' true \
-	'online is never true without a client_ecid'
+_assert_json_eq '(.connected == true) and (.client_ecid == null) | not' true \
+	'connected is never true without a client_ecid'
 _assert_json_eq '.client_ecid | type | test("^(number|null)$")' true \
 	'client_ecid is a number or null, never a 0 sentinel'
 _assert_json_eq '.friend_ecid'        null         'a non-friend peer has friend_ecid null, not a 0 sentinel'

--- a/unittests/tests/EventDiffTest.cpp
+++ b/unittests/tests/EventDiffTest.cpp
@@ -1871,7 +1871,7 @@ TEST(EventDiff, FriendEventReportsReachabilityNotClientObjectExistence)
 		f.ecid = 91;
 		f.name = "linked-but-unreachable";
 		// A live client object exists -- the daemon is trying -- but no
-		// socket is up. The old rule called this online.
+		// socket is up. The old rule called this connected.
 		f.client_ecid = 4242;
 		f.connected = false;
 		f.has_connected = true;
@@ -1888,14 +1888,17 @@ TEST(EventDiff, FriendEventReportsReachabilityNotClientObjectExistence)
 			payload = e.data;
 	}
 	ASSERT_TRUE(!payload.empty());
-	ASSERT_TRUE(payload.find("\"online\":false") != std::string::npos);
+	ASSERT_TRUE(payload.find("\"connected\":false") != std::string::npos);
+	// The retired spelling must be gone, not shadowed (R6: one key for the
+	// quantity /clients, /known_clients and /chats also carry).
+	ASSERT_TRUE(payload.find("\"online\"") == std::string::npos);
 	// The live peer is still reported, so a consumer can still join on it.
 	ASSERT_TRUE(payload.find("\"client_ecid\":4242") != std::string::npos);
 }
 
 // A daemon that does not report connectivity leaves it unknown: null, not a
 // guessed false. R10 -- an unknown value is null and never a sentinel.
-TEST(EventDiff, FriendEventNullsOnlineWhenTheDaemonNeverReportedIt)
+TEST(EventDiff, FriendEventNullsConnectedWhenTheDaemonNeverReportedIt)
 {
 	CState state;
 	state.MutateFriends([](std::map<std::uint32_t, FriendSnapshot> &friends) {
@@ -1917,7 +1920,8 @@ TEST(EventDiff, FriendEventNullsOnlineWhenTheDaemonNeverReportedIt)
 			payload = e.data;
 	}
 	ASSERT_TRUE(!payload.empty());
-	ASSERT_TRUE(payload.find("\"online\":null") != std::string::npos);
+	ASSERT_TRUE(payload.find("\"connected\":null") != std::string::npos);
+	ASSERT_TRUE(payload.find("\"online\"") == std::string::npos);
 }
 
 // The connected flag has to be in Equal too, or a peer that finishes


### PR DESCRIPTION
Four items from #1327.

**§1.** `EC_TAG_CLIENT_CONNECTED` was `connected` on `/clients` and its `client_*` events, and `online` on `/known_clients`, `/friends`, `/chats` and the `friend_*` events. Both are legal R4 predicates, so this was purely R6. Sharpest exactly where it hurt: the known-client writer's own comment tells clients to correlate against `/clients` by `user_hash`, and the reachability bit was spelled differently on the far side of that join.

Unified on **`connected`**, not the three-resource majority the issue suggested. It states what is measured, a socket being up, rather than a status a reader may take as "appears in the list"; the known-client writer had to spend a comment saying exactly that. It also puts the wire key back in step with the code: `ClientSnapshot`, `FriendSnapshot` and `ChatSessionSnapshot` were **already** named `connected` and merely emitted `online`, so three of the four fields needed no rename at all. Only `KnownClientSnapshot::online` follows the key.

**§2, §3.** Two comments contradicting the code beside them. `ComputePartProgressPercent` said the writers "omit" a field both emit as `null`, with the REST writer saying "null, not omitted" a few lines away; `WriteStatsValue`'s `token` block opened with "Omitted when the value is not a sentinel" and closed with "null when the value is not a sentinel". The wrong sentence is deleted.

**§4.** `EVENTS.md`'s `shared_updated` prose still listed `requests.*` / `accepts.*`, flattened away by the R11 sweep, while its own example three lines below used the flat keys.

**A bug found while rewiring the Web UI.** `chat_message` carries `address`, `ip`, `port`, `name`, `client_ecid`, `friend_ecid` and `message`, and no reachability field, but `chats.js` read one off it. `p.online === true` was therefore always false, so a message arriving from a peer we knew to be up marked it offline. The assignment is dropped rather than renamed.

§5's borderlines are deliberate keeps and stay.

**Verified:** build clean; ctest 58/58, where the existing `EventDiffTest` friend cases caught the rename and are updated, with an added assertion that the retired spelling is gone from the payload. clang-format 18 clean, clang-tidy Tier-1 and Tier-2 clean with 0 compiler errors, `check-i18n` clean. Curl phases 22, 28, 33, 34 and 38 green against a daemon connected to ed2k and Kad (30/30, 283/283, 39 assertions, 48/48, 51/51), including `sort=connected` and a new guard that `/known_clients` no longer emits `online`. A live check with a connected peer confirmed `connected: true` and no `online` key on both `/clients` and `/known_clients`. Three skips in phase 33 need an inbound peer, which a firewalled LowID rig cannot reliably attract; they skipped identically before this change.

`/api/v0` has no consumers outside this repository, so the rename is applied rather than aliased.

Closes #1327.
