### PR TITLE
fix(gui): keep the splash above aMule instead of above every application

### DIFF
--- a/src/SplashScreen.cpp
+++ b/src/SplashScreen.cpp
@@ -105,13 +105,13 @@ wxBEGIN_EVENT_TABLE(CSplashScreen, wxFrame)
 	EVT_TIMER(wxID_ANY, CSplashScreen::OnCloseTimer)
 wxEND_EVENT_TABLE()
 
-CSplashScreen::CSplashScreen()
-: wxFrame(nullptr,
+CSplashScreen::CSplashScreen(wxWindow *parent)
+: wxFrame(parent,
 	  wxID_ANY,
 	  wxEmptyString,
 	  wxDefaultPosition,
 	  wxDefaultSize,
-	  wxFRAME_NO_TASKBAR | wxSTAY_ON_TOP | wxBORDER_NONE)
+	  wxFRAME_NO_TASKBAR | wxBORDER_NONE)
 , m_percent(0)
 , m_shownAt(0)
 , m_lastPaint(0)
@@ -122,7 +122,10 @@ CSplashScreen::CSplashScreen()
 	SetClientSize(FromDIP(wxSize(kSplashWidth, kSplashHeight)));
 	SetBackgroundStyle(wxBG_STYLE_PAINT);
 	RenderBackdrop();
-	Centre();
+	// Explicitly on the screen rather than on the parent: with a parent set,
+	// Centre() would centre on a main window that is not on screen yet, and
+	// its saved geometry can put the splash anywhere or off-screen entirely.
+	CentreOnScreen();
 }
 
 bool CSplashScreen::Show(bool show)

--- a/src/SplashScreen.h
+++ b/src/SplashScreen.h
@@ -45,7 +45,12 @@
 class CSplashScreen : public wxFrame
 {
 public:
-	CSplashScreen();
+	// Parented to the main window, so the window manager keeps it above
+	// aMule and nothing else. It used to be a parentless wxSTAY_ON_TOP
+	// frame, which is a desktop-global level: it covered every other
+	// application, and since it also has no taskbar button there was
+	// nothing to raise over it or dismiss it with.
+	explicit CSplashScreen(wxWindow *parent);
 
 	// Update the phase text and the bar. Cheap to call often: repainting is
 	// rate-limited internally, so callers can report every file scanned

--- a/src/amule.cpp
+++ b/src/amule.cpp
@@ -930,7 +930,7 @@ bool CamuleApp::OnInit()
 	// enough that the main window -- already created by InitGui -- never gets
 	// painted. Shown here rather than earlier so it does not outlive a failed
 	// GUI init.
-	CSplashScreen *splash = new CSplashScreen();
+	CSplashScreen *splash = new CSplashScreen(theApp->amuledlg);
 	m_splash = splash;
 	splash->Show();
 


### PR DESCRIPTION
`CSplashScreen` was a parentless `wxSTAY_ON_TOP` frame. That flag is a desktop-global level, not "above aMule", so the splash sat over every other application for the whole of startup. It also carries `wxFRAME_NO_TASKBAR`, so there was no button to raise anything over it or dismiss it with: bringing a browser or a terminal to the front left it drawn on top regardless. On a large share that is tens of seconds of an unavoidable window in the middle of the screen.

Parenting it to the main window and dropping the flag gives the window manager the relationship it needs to keep the splash above its parent and nothing else. That is all the splash requires, since it exists to explain why aMule itself is not responding yet.

Centring is now explicit. `Centre()` on a parented top-level window centres on the parent, and at this point the main window exists but has not been shown, so its restored geometry could place the splash anywhere, including off-screen if the monitor layout changed since. `CentreOnScreen()` preserves the previous behaviour.

Reported in #1299, where the reporter has "Start minimized" set and the splash was therefore the only thing on screen. The splash still appears in that case, deliberately: with part-file loading taking 20 to 60 seconds on their setup, a start with no window and no splash would leave someone opening aMule from the tray with an unresponsive window and nothing explaining it.

Build and both clang-tidy tiers clean on the diff; no functional change beyond window stacking.
