### PR TITLE
fix(gui): say what the startup phase estimate counts, and what it missed

### DIFF
--- a/src/amule.cpp
+++ b/src/amule.cpp
@@ -1065,7 +1065,12 @@ bool CamuleApp::OnInit()
 	// spends it.
 	const int scanBandEnd = (sharedEstimate > 0) ? kScanBandEnd : tempBandEnd;
 	splash->SetProgress(_("Loading shared files"), tempBandEnd, true);
+	// Kept for the log line below: the scan reports its running count to the
+	// splash but had no way to report the final one, so the estimate was
+	// printed with nothing to compare it against.
+	size_t sharedScanned = 0;
 	sharedfiles->Reload([&](size_t scanned) {
+		sharedScanned = scanned;
 		int percent = tempBandEnd;
 		if (sharedEstimate > 0) {
 			// Clamped below the band end: an estimate that undershoots must
@@ -1082,11 +1087,17 @@ bool CamuleApp::OnInit()
 	// Normal level, not debug: these are the numbers the phase weighting
 	// above is meant to be tuned from, and a measurement that needs verbose
 	// logging turned on first is one nobody will report back.
+	// Both phases report count then duration, and the estimate says what it
+	// estimates. It is a file count taken from known.met, but it used to be
+	// printed as a bare number straight after a millisecond figure, which
+	// reads as an estimated duration -- and without the count the scan
+	// actually reached there was nothing to compare it to, so the one thing
+	// the number exists for could not be judged from the line carrying it.
 	AddLogLineN(CFormat(LOG_DIAGNOSTIC("Startup phases: network %lld ms, %u part files %lld ms, shared "
-					   "scan ") "%lld ms (estimate was %u)") %
+					   "scan %u files ") "%lld ms (estimated %u files)") %
 		    (networkDoneAt - splashPhaseStart).GetValue() % partFilesLoaded %
-		    (tempDoneAt - networkDoneAt).GetValue() % (sharedDoneAt - tempDoneAt).GetValue() %
-		    sharedEstimate);
+		    (tempDoneAt - networkDoneAt).GetValue() % sharedScanned %
+		    (sharedDoneAt - tempDoneAt).GetValue() % sharedEstimate);
 
 	// The scan has everything it is going to have: the files it recognised are
 	// listed, and the ones it did not are now queued for hashing. That drain is


### PR DESCRIPTION
The line read `shared scan 861 ms (estimate was 1800)`. A bare number straight after a millisecond figure reads as an estimated duration, so the natural conclusion is that the scan was predicted to take 1800 ms and beat it by half. It is not a duration: it is the `known.met` file count from the previous session, which stands in for the total the scan cannot know up front and drives the shared-scan band of the progress bar.

The count the scan actually reached was also never printed, so the estimate had nothing to be compared against. Whether `known.met` predicts the scan well enough to weight the bar is the only reason the number is in the line, and that is exactly what the line could not answer.

This reports the scanned count and names the unit, so both phases read count then duration, the way part files already did:

```
Startup phases: network 4 ms, 1151 part files 6098 ms, shared scan 1743 files 861 ms (estimated 1800 files)
```

Reported in #1299, where the reporter has been pasting these lines to help diagnose a slow startup.

Logging only, no behaviour change.
