### PR TITLE
fix(download): walk the file list as a snapshot where the count and the fetch can disagree

### DIFF
--- a/src/DownloadQueue.cpp
+++ b/src/DownloadQueue.cpp
@@ -219,15 +219,19 @@ void CDownloadQueue::SetUDPServer(CServer *server)
 
 void CDownloadQueue::SaveSourceSeeds()
 {
-	for (uint16 i = 0; i < GetFileCount(); i++) {
-		GetFileByIndex(i)->SaveSourceSeeds();
+	std::vector<CPartFile *> files;
+	CopyFileList(files);
+	for (CPartFile *file : files) {
+		file->SaveSourceSeeds();
 	}
 }
 
 void CDownloadQueue::LoadSourceSeeds()
 {
-	for (uint16 i = 0; i < GetFileCount(); i++) {
-		GetFileByIndex(i)->LoadSourceSeeds();
+	std::vector<CPartFile *> files;
+	CopyFileList(files);
+	for (CPartFile *file : files) {
+		file->LoadSourceSeeds();
 	}
 }
 
@@ -843,9 +847,14 @@ bool CDownloadQueue::RemoveSource(CUpDownClient *toremove, bool WXUNUSED(updatew
 	bool removed = false;
 	toremove->DeleteAllFileRequests();
 
-	for (uint16 i = 0; i < GetFileCount(); i++) {
-		CPartFile *cur_file = GetFileByIndex(i);
-
+	// Over a snapshot rather than index-and-count: GetFileCount() and
+	// GetFileByIndex() take m_mutex separately, so the pair is not atomic and
+	// an index valid at the test can be out of range at the fetch -- where
+	// GetFileByIndex() returns NULL and this loop dereferenced it. One lock
+	// for the whole walk also costs less than two per file.
+	std::vector<CPartFile *> files;
+	CopyFileList(files);
+	for (CPartFile *cur_file : files) {
 		// Remove from source-list
 		if (cur_file->DelSource(toremove)) {
 
@@ -1246,9 +1255,9 @@ void CDownloadQueue::ResetCatParts(uint8 cat)
 
 void CDownloadQueue::SetCatPrio(uint8 cat, uint8 newprio)
 {
-	for (uint16 i = 0; i < GetFileCount(); i++) {
-		CPartFile *file = GetFileByIndex(i);
-
+	std::vector<CPartFile *> files;
+	CopyFileList(files);
+	for (CPartFile *file : files) {
 		if (!cat || file->GetCategory() == cat) {
 			if (newprio == PR_AUTO) {
 				file->SetAutoDownPriority(true);

--- a/src/SharedFileList.cpp
+++ b/src/SharedFileList.cpp
@@ -417,10 +417,13 @@ void CSharedFileList::FindSharedFiles(const ReloadYieldCb &yieldCb, bool &aborte
 		m_listGeneration.fetch_add(1, std::memory_order_relaxed);
 	}
 
-	// All part files are automatically shared.
-	for (uint32 i = 0; i < theApp->downloadqueue->GetFileCount(); ++i) {
-		CPartFile *file = theApp->downloadqueue->GetFileByIndex(i);
-
+	// All part files are automatically shared. Walked as a snapshot: the
+	// queue's count and index accessors take its mutex separately, so an
+	// index valid at the test can be out of range at the fetch, where the
+	// fetch returns NULL.
+	std::vector<CPartFile *> queued;
+	theApp->downloadqueue->CopyFileList(queued);
+	for (CPartFile *file : queued) {
 		if (file->GetStatus(true) == PS_READY) {
 			AddLogLineNS(
 				CFormat(_("Adding file %s to shares")) % file->GetFullName().GetPrintable());


### PR DESCRIPTION
`CDownloadQueue::GetFileCount()` and `GetFileByIndex()` each take `m_mutex` separately, so the pair is not atomic. Five loops used them together as `for (i = 0; i < GetFileCount(); i++) { ... GetFileByIndex(i)->... }` and dereferenced the result without a check. An index that is valid at the test can be out of range at the fetch, and `GetFileByIndex()` answers that with `NULL` - guarded only by a `wxFAIL`, which is a no-op in a release build.

Each loop now walks a snapshot from the existing `CopyFileList()`, which takes the lock once. That removes the out-of-range case rather than checking for it, and replaces two lock acquisitions per file with one per walk.

| Converted | |
|---|---|
| `RemoveSource` | the one on a client-teardown path |
| `SaveSourceSeeds` / `LoadSourceSeeds` | shutdown and startup |
| `SetCatPrio` | category priority changes |
| `CSharedFileList::FindSharedFiles` | the part-file walk during a reload |

Two callers already test the result and are left alone: `BaseClient.cpp:3355` and `UploadQueue.cpp:729`. `CSharedFileList::GetFileByIndex` is a different accessor and needs nothing - it bounds-checks under its own lock and both call sites test for `NULL`.

### What this does not claim

This is hardening. It is **not** a fix for #1338, and it should not be read as one. That backtrace crashes inside `RemoveSource`, and this is the only unguarded dereference in that function, so the shapes match - but I have not identified a thread that mutates `m_filelist` concurrently, and without that the race is unproven. Landing this on the theory that it might help would be guessing; landing it because a lock-free index into a mutex-guarded list is wrong on its own terms is not.

### Verification

Built clean. Exercised on a live daemon: two part files queued and reloaded across a restart (`SaveSourceSeeds` / `LoadSourceSeeds`), the shared-files walk during that reload, and `RemoveSource` on the teardown path; EC still serves the queue and shutdown is clean. clang-format 18 whole-file clean on both files; clang-tidy Tier-1 and Tier-2 clean on changed lines, 0 compiler errors on both.
