### PR TITLE
feat(gui): offer the stats-server lookup on downloads and shared files

### DIFF
--- a/po/amule.pot
+++ b/po/amule.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-08 15:40+0200\n"
+"POT-Creation-Date: 2026-09-09 11:05+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1855,6 +1855,11 @@ msgstr ""
 
 #: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Copy feedback to clipboard"
+msgstr ""
+
+#: src/DownloadListCtrl.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#, c-format
+msgid "Get %s for this file"
 msgstr ""
 
 #: src/DownloadListCtrl.cpp
@@ -6552,11 +6557,6 @@ msgstr ""
 
 #: src/SearchListCtrl.cpp
 msgid "Collapse all"
-msgstr ""
-
-#: src/SearchListCtrl.cpp
-#, c-format
-msgid "Get %s for this file"
 msgstr ""
 
 #: src/SearchListCtrl.cpp

--- a/po/ar.po
+++ b/po/ar.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-08 15:40+0200\n"
+"POT-Creation-Date: 2026-09-09 11:05+0200\n"
 "PO-Revision-Date: 2026-09-08 15:33+0000\n"
 "Last-Translator: saleh alhathal <hathalsal@hotmail.com>\n"
 "Language-Team: \n"
@@ -1894,6 +1894,11 @@ msgstr ""
 #: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Copy feedback to clipboard"
 msgstr ""
+
+#: src/DownloadListCtrl.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#, fuzzy, c-format
+msgid "Get %s for this file"
+msgstr "طلب ملف اخر"
 
 #: src/DownloadListCtrl.cpp
 msgid "unassign"
@@ -6672,11 +6677,6 @@ msgstr ""
 #: src/SearchListCtrl.cpp
 msgid "Collapse all"
 msgstr ""
-
-#: src/SearchListCtrl.cpp
-#, fuzzy, c-format
-msgid "Get %s for this file"
-msgstr "طلب ملف اخر"
 
 #: src/SearchListCtrl.cpp
 msgid "Search related files (eD2k, local server)"

--- a/po/ast.po
+++ b/po/ast.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-08 15:40+0200\n"
+"POT-Creation-Date: 2026-09-09 11:05+0200\n"
 "PO-Revision-Date: 2026-09-08 15:33+0000\n"
 "Last-Translator: astur <malditoastur@gmail.com>\n"
 "Language-Team: Language ast <malditoastur@gmail.com>\n"
@@ -1914,6 +1914,11 @@ msgstr "Copiar l'en&llaz eD2k al cartafueyos."
 #: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Copy feedback to clipboard"
 msgstr "Copiar rempuesta al cartafueyos"
+
+#: src/DownloadListCtrl.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#, fuzzy, c-format
+msgid "Get %s for this file"
+msgstr "Amestar URLs opcionales pa esti ficheru"
 
 #: src/DownloadListCtrl.cpp
 msgid "unassign"
@@ -6785,11 +6790,6 @@ msgstr ""
 #, fuzzy
 msgid "Collapse all"
 msgstr "Zarrar toles llingüetes"
-
-#: src/SearchListCtrl.cpp
-#, fuzzy, c-format
-msgid "Get %s for this file"
-msgstr "Amestar URLs opcionales pa esti ficheru"
 
 #: src/SearchListCtrl.cpp
 msgid "Search related files (eD2k, local server)"

--- a/po/bg.po
+++ b/po/bg.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-08 15:40+0200\n"
+"POT-Creation-Date: 2026-09-09 11:05+0200\n"
 "PO-Revision-Date: 2026-09-08 15:33+0000\n"
 "Last-Translator: Sebastiano Pistore <SebastianoPistore.info@protonmail.ch>\n"
 "Language-Team: Bulgarian <dict@linux.zonebg.com>\n"
@@ -1887,6 +1887,11 @@ msgstr ""
 #: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Copy feedback to clipboard"
 msgstr ""
+
+#: src/DownloadListCtrl.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#, fuzzy, c-format
+msgid "Get %s for this file"
+msgstr "Поискан му е друг файл"
 
 #: src/DownloadListCtrl.cpp
 msgid "unassign"
@@ -6661,11 +6666,6 @@ msgstr ""
 #: src/SearchListCtrl.cpp
 msgid "Collapse all"
 msgstr ""
-
-#: src/SearchListCtrl.cpp
-#, fuzzy, c-format
-msgid "Get %s for this file"
-msgstr "Поискан му е друг файл"
 
 #: src/SearchListCtrl.cpp
 msgid "Search related files (eD2k, local server)"

--- a/po/bn.po
+++ b/po/bn.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-08 15:40+0200\n"
+"POT-Creation-Date: 2026-09-09 11:05+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -1854,6 +1854,11 @@ msgstr ""
 
 #: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Copy feedback to clipboard"
+msgstr ""
+
+#: src/DownloadListCtrl.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#, c-format
+msgid "Get %s for this file"
 msgstr ""
 
 #: src/DownloadListCtrl.cpp
@@ -6551,11 +6556,6 @@ msgstr ""
 
 #: src/SearchListCtrl.cpp
 msgid "Collapse all"
-msgstr ""
-
-#: src/SearchListCtrl.cpp
-#, c-format
-msgid "Get %s for this file"
 msgstr ""
 
 #: src/SearchListCtrl.cpp

--- a/po/ca.po
+++ b/po/ca.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-08 15:40+0200\n"
+"POT-Creation-Date: 2026-09-09 11:05+0200\n"
 "PO-Revision-Date: 2026-09-08 15:34+0000\n"
 "Last-Translator: minterior <minterior@gmail.com>\n"
 "Language-Team: Català\n"
@@ -1899,6 +1899,11 @@ msgstr "Copia &l'enllaç eD2k al porta-retalls"
 #: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Copy feedback to clipboard"
 msgstr "Copia la &informació al porta-retalls"
+
+#: src/DownloadListCtrl.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#, c-format
+msgid "Get %s for this file"
+msgstr "Obté %s per aquest fitxer"
 
 #: src/DownloadListCtrl.cpp
 msgid "unassign"
@@ -6693,11 +6698,6 @@ msgstr "Desplega-ho tot"
 #: src/SearchListCtrl.cpp
 msgid "Collapse all"
 msgstr "Plega-ho tot"
-
-#: src/SearchListCtrl.cpp
-#, c-format
-msgid "Get %s for this file"
-msgstr "Obté %s per aquest fitxer"
 
 #: src/SearchListCtrl.cpp
 msgid "Search related files (eD2k, local server)"

--- a/po/cs.po
+++ b/po/cs.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-08 15:40+0200\n"
+"POT-Creation-Date: 2026-09-09 11:05+0200\n"
 "PO-Revision-Date: 2026-09-08 15:34+0000\n"
 "Last-Translator: David Watzke <david@watzke.cz>\n"
 "Language-Team: cs <cs@li.org>\n"
@@ -1910,6 +1910,11 @@ msgstr "Zkopírovat eD2k &odkaz do schránky"
 #: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Copy feedback to clipboard"
 msgstr "Uložit odezvu do schránky"
+
+#: src/DownloadListCtrl.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#, c-format
+msgid "Get %s for this file"
+msgstr "Získat %s pro tento soubor"
 
 #: src/DownloadListCtrl.cpp
 msgid "unassign"
@@ -6746,11 +6751,6 @@ msgstr ""
 #, fuzzy
 msgid "Collapse all"
 msgstr "Zavřít všechny taby"
-
-#: src/SearchListCtrl.cpp
-#, c-format
-msgid "Get %s for this file"
-msgstr "Získat %s pro tento soubor"
 
 #: src/SearchListCtrl.cpp
 msgid "Search related files (eD2k, local server)"

--- a/po/da.po
+++ b/po/da.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-08 15:40+0200\n"
+"POT-Creation-Date: 2026-09-09 11:05+0200\n"
 "PO-Revision-Date: 2026-09-08 15:35+0000\n"
 "Last-Translator: Alex Thomsen Leth <alexl@stofanet.dk>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -1897,6 +1897,11 @@ msgstr ""
 #: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Copy feedback to clipboard"
 msgstr ""
+
+#: src/DownloadListCtrl.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#, fuzzy, c-format
+msgid "Get %s for this file"
+msgstr "Indtast nyt navn for denne fil:"
 
 #: src/DownloadListCtrl.cpp
 msgid "unassign"
@@ -6693,11 +6698,6 @@ msgstr ""
 #, fuzzy
 msgid "Collapse all"
 msgstr "Luk alle tabs"
-
-#: src/SearchListCtrl.cpp
-#, fuzzy, c-format
-msgid "Get %s for this file"
-msgstr "Indtast nyt navn for denne fil:"
 
 #: src/SearchListCtrl.cpp
 msgid "Search related files (eD2k, local server)"

--- a/po/de.po
+++ b/po/de.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-08 15:40+0200\n"
+"POT-Creation-Date: 2026-09-09 11:05+0200\n"
 "PO-Revision-Date: 2026-09-08 15:35+0000\n"
 "Last-Translator: Werner Mahr <werner@vollstreckernet.de>\n"
 "Language-Team: German <>\n"
@@ -1917,6 +1917,11 @@ msgstr "Kopiere eD2k &Link in die Zwischenablage"
 #: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Copy feedback to clipboard"
 msgstr "Feedback in die Zwischenablage kopieren"
+
+#: src/DownloadListCtrl.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#, c-format
+msgid "Get %s for this file"
+msgstr "%s für diese Datei erhalten"
 
 #: src/DownloadListCtrl.cpp
 msgid "unassign"
@@ -6755,11 +6760,6 @@ msgstr ""
 #, fuzzy
 msgid "Collapse all"
 msgstr "Alle Reiter schließen"
-
-#: src/SearchListCtrl.cpp
-#, c-format
-msgid "Get %s for this file"
-msgstr "%s für diese Datei erhalten"
 
 #: src/SearchListCtrl.cpp
 msgid "Search related files (eD2k, local server)"

--- a/po/el.po
+++ b/po/el.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-08 15:40+0200\n"
+"POT-Creation-Date: 2026-09-09 11:05+0200\n"
 "PO-Revision-Date: 2026-09-08 15:35+0000\n"
 "Last-Translator: Dimitris <dgalanak@yahoo.com>\n"
 "Language-Team: Greek\n"
@@ -1922,6 +1922,11 @@ msgstr "Αντιγραφή του συνδέσμου eD2k στο πρόχειρ�
 #: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Copy feedback to clipboard"
 msgstr "Αντιγραφή των συμβουλών στην πρόχειρη μνήμη"
+
+#: src/DownloadListCtrl.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#, fuzzy, c-format
+msgid "Get %s for this file"
+msgstr "Προσθήκη προαιρετικών URL για αυτό το αρχείο"
 
 #: src/DownloadListCtrl.cpp
 msgid "unassign"
@@ -6797,11 +6802,6 @@ msgstr ""
 #, fuzzy
 msgid "Collapse all"
 msgstr "Κλείσιμο όλων των καρτελών"
-
-#: src/SearchListCtrl.cpp
-#, fuzzy, c-format
-msgid "Get %s for this file"
-msgstr "Προσθήκη προαιρετικών URL για αυτό το αρχείο"
 
 #: src/SearchListCtrl.cpp
 msgid "Search related files (eD2k, local server)"

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-08 15:40+0200\n"
+"POT-Creation-Date: 2026-09-09 11:05+0200\n"
 "PO-Revision-Date: 2020-03-04 14:43+0100\n"
 "Last-Translator: Dévai Tamás <devait@vnet.hu>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -1855,6 +1855,11 @@ msgstr ""
 
 #: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Copy feedback to clipboard"
+msgstr ""
+
+#: src/DownloadListCtrl.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#, c-format
+msgid "Get %s for this file"
 msgstr ""
 
 #: src/DownloadListCtrl.cpp
@@ -6552,11 +6557,6 @@ msgstr ""
 
 #: src/SearchListCtrl.cpp
 msgid "Collapse all"
-msgstr ""
-
-#: src/SearchListCtrl.cpp
-#, c-format
-msgid "Get %s for this file"
 msgstr ""
 
 #: src/SearchListCtrl.cpp

--- a/po/es.po
+++ b/po/es.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-08 15:40+0200\n"
+"POT-Creation-Date: 2026-09-09 11:05+0200\n"
 "PO-Revision-Date: 2026-09-08 15:36+0000\n"
 "Last-Translator: Diego Heras <ngosang@hotmail.es>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/amule/amule-application/es/>\n"
@@ -1904,6 +1904,11 @@ msgstr "Copiar el en&lace eD2k al portapapeles"
 #: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Copy feedback to clipboard"
 msgstr "Copiar la respuesta al portapapeles"
+
+#: src/DownloadListCtrl.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#, c-format
+msgid "Get %s for this file"
+msgstr "Obtener %s para este archivo"
 
 #: src/DownloadListCtrl.cpp
 msgid "unassign"
@@ -6704,11 +6709,6 @@ msgstr "Expandir todo"
 #: src/SearchListCtrl.cpp
 msgid "Collapse all"
 msgstr "Cerrar todas"
-
-#: src/SearchListCtrl.cpp
-#, c-format
-msgid "Get %s for this file"
-msgstr "Obtener %s para este archivo"
 
 #: src/SearchListCtrl.cpp
 msgid "Search related files (eD2k, local server)"

--- a/po/et_EE.po
+++ b/po/et_EE.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-08 15:40+0200\n"
+"POT-Creation-Date: 2026-09-09 11:05+0200\n"
 "PO-Revision-Date: 2026-09-08 15:36+0000\n"
 "Last-Translator: \n"
 "Language-Team: Estonian <kde-i18n-doc@kde.org>\n"
@@ -1910,6 +1910,11 @@ msgstr "Kopeeri eD2k &link lõikepuhvrisse"
 #: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Copy feedback to clipboard"
 msgstr "Kopeeri tagasiside lõikepuhvrisse"
+
+#: src/DownloadListCtrl.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#, fuzzy, c-format
+msgid "Get %s for this file"
+msgstr "Lisa selle faili alternatiivsed URL'id"
 
 #: src/DownloadListCtrl.cpp
 msgid "unassign"
@@ -6762,11 +6767,6 @@ msgstr ""
 #, fuzzy
 msgid "Collapse all"
 msgstr "Sulge kõik lehed"
-
-#: src/SearchListCtrl.cpp
-#, fuzzy, c-format
-msgid "Get %s for this file"
-msgstr "Lisa selle faili alternatiivsed URL'id"
 
 #: src/SearchListCtrl.cpp
 msgid "Search related files (eD2k, local server)"

--- a/po/eu.po
+++ b/po/eu.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-08 15:40+0200\n"
+"POT-Creation-Date: 2026-09-09 11:05+0200\n"
 "PO-Revision-Date: 2026-09-08 15:36+0000\n"
 "Last-Translator: Piarres Beobide <pi@beobide.net>\n"
 "Language-Team: Euskara <librezale@librezale.org>\n"
@@ -1911,6 +1911,11 @@ msgstr "Kopiatu eD2k &lotura arbelera"
 #: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Copy feedback to clipboard"
 msgstr "Kopiatu berrelikadura arbelera"
+
+#: src/DownloadListCtrl.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#, c-format
+msgid "Get %s for this file"
+msgstr "Eskuratu %s fitxategi honentzat"
 
 #: src/DownloadListCtrl.cpp
 msgid "unassign"
@@ -6762,11 +6767,6 @@ msgstr ""
 #, fuzzy
 msgid "Collapse all"
 msgstr "Itxi fitxa guztiak"
-
-#: src/SearchListCtrl.cpp
-#, c-format
-msgid "Get %s for this file"
-msgstr "Eskuratu %s fitxategi honentzat"
 
 #: src/SearchListCtrl.cpp
 msgid "Search related files (eD2k, local server)"

--- a/po/fi.po
+++ b/po/fi.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-08 15:40+0200\n"
+"POT-Creation-Date: 2026-09-09 11:05+0200\n"
 "PO-Revision-Date: 2026-09-08 15:37+0000\n"
 "Last-Translator: Tapio Rantala <tapio.rantala@iki.fi>\n"
 "Language-Team: aMule Team <https://github.com/amule-org/amule>\n"
@@ -1911,6 +1911,11 @@ msgstr "Kopioi eD2k-&linkki leikepöydälle"
 #: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Copy feedback to clipboard"
 msgstr "Kopioi palaute leikepöydälle"
+
+#: src/DownloadListCtrl.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#, c-format
+msgid "Get %s for this file"
+msgstr "Hanki %s tälle tiedostolle"
 
 #: src/DownloadListCtrl.cpp
 msgid "unassign"
@@ -6762,11 +6767,6 @@ msgstr ""
 #, fuzzy
 msgid "Collapse all"
 msgstr "Sulje kaikki välilehdet"
-
-#: src/SearchListCtrl.cpp
-#, c-format
-msgid "Get %s for this file"
-msgstr "Hanki %s tälle tiedostolle"
 
 #: src/SearchListCtrl.cpp
 msgid "Search related files (eD2k, local server)"

--- a/po/fr.po
+++ b/po/fr.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-08 15:40+0200\n"
+"POT-Creation-Date: 2026-09-09 11:05+0200\n"
 "PO-Revision-Date: 2026-09-08 15:37+0000\n"
 "Last-Translator: Dylan Aïssi <bob.dybian@gmail.com>\n"
 "Language-Team: Français\n"
@@ -1903,6 +1903,11 @@ msgstr "Copier le &lien eD2k dans le presse-papiers"
 #: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Copy feedback to clipboard"
 msgstr "Copier le rapport dans le presse-papiers"
+
+#: src/DownloadListCtrl.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#, c-format
+msgid "Get %s for this file"
+msgstr "Obtenir %s pour ce fichier"
 
 #: src/DownloadListCtrl.cpp
 msgid "unassign"
@@ -6697,11 +6702,6 @@ msgstr "Tout développer"
 #: src/SearchListCtrl.cpp
 msgid "Collapse all"
 msgstr "Tout réduire"
-
-#: src/SearchListCtrl.cpp
-#, c-format
-msgid "Get %s for this file"
-msgstr "Obtenir %s pour ce fichier"
 
 #: src/SearchListCtrl.cpp
 msgid "Search related files (eD2k, local server)"

--- a/po/gl.po
+++ b/po/gl.po
@@ -24,7 +24,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-08 15:40+0200\n"
+"POT-Creation-Date: 2026-09-09 11:05+0200\n"
 "PO-Revision-Date: 2026-09-08 15:37+0000\n"
 "Last-Translator: Pablo <parodper@gmail.com>\n"
 "Language-Team: http://forum.amule.org/index.php?topic=13883\n"
@@ -1930,6 +1930,11 @@ msgstr "Copiar &ligazón eD2k ao portapapeis"
 #: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Copy feedback to clipboard"
 msgstr "Copiar comentarios ao portapapeis"
+
+#: src/DownloadListCtrl.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#, c-format
+msgid "Get %s for this file"
+msgstr "Obter %s para este ficheiro"
 
 #: src/DownloadListCtrl.cpp
 msgid "unassign"
@@ -6769,11 +6774,6 @@ msgstr ""
 #, fuzzy
 msgid "Collapse all"
 msgstr "Pechar todas as lapelas"
-
-#: src/SearchListCtrl.cpp
-#, c-format
-msgid "Get %s for this file"
-msgstr "Obter %s para este ficheiro"
 
 #: src/SearchListCtrl.cpp
 msgid "Search related files (eD2k, local server)"

--- a/po/he.po
+++ b/po/he.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-08 15:40+0200\n"
+"POT-Creation-Date: 2026-09-09 11:05+0200\n"
 "PO-Revision-Date: 2026-09-08 15:38+0000\n"
 "Last-Translator: Peace Kramer <kpeace1@gmail.com>\n"
 "Language-Team: Hebrew\n"
@@ -1903,6 +1903,11 @@ msgstr ""
 #: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Copy feedback to clipboard"
 msgstr "העתק משוב ללוח"
+
+#: src/DownloadListCtrl.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#, fuzzy, c-format
+msgid "Get %s for this file"
+msgstr "הוסף כתובות URL אופתינליות לקובץ זה"
 
 #: src/DownloadListCtrl.cpp
 msgid "unassign"
@@ -6723,11 +6728,6 @@ msgstr ""
 #: src/SearchListCtrl.cpp
 msgid "Collapse all"
 msgstr ""
-
-#: src/SearchListCtrl.cpp
-#, fuzzy, c-format
-msgid "Get %s for this file"
-msgstr "הוסף כתובות URL אופתינליות לקובץ זה"
 
 #: src/SearchListCtrl.cpp
 msgid "Search related files (eD2k, local server)"

--- a/po/hr.po
+++ b/po/hr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-08 15:40+0200\n"
+"POT-Creation-Date: 2026-09-09 11:05+0200\n"
 "PO-Revision-Date: 2026-09-08 15:38+0000\n"
 "Last-Translator: Sebastiano Pistore <sebastiano.pistore.info@aol.com>\n"
 "Language-Team: https://github.com/amule-org/amule <forum@aMule.org>\n"
@@ -1907,6 +1907,11 @@ msgstr ""
 #: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Copy feedback to clipboard"
 msgstr ""
+
+#: src/DownloadListCtrl.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#, fuzzy, c-format
+msgid "Get %s for this file"
+msgstr "Upitao za drugi fajl"
 
 #: src/DownloadListCtrl.cpp
 msgid "unassign"
@@ -6725,11 +6730,6 @@ msgstr ""
 #, fuzzy
 msgid "Collapse all"
 msgstr "Zatvori sve oznake"
-
-#: src/SearchListCtrl.cpp
-#, fuzzy, c-format
-msgid "Get %s for this file"
-msgstr "Upitao za drugi fajl"
 
 #: src/SearchListCtrl.cpp
 msgid "Search related files (eD2k, local server)"

--- a/po/hu.po
+++ b/po/hu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-08 15:40+0200\n"
+"POT-Creation-Date: 2026-09-09 11:05+0200\n"
 "PO-Revision-Date: 2026-09-08 15:38+0000\n"
 "Last-Translator: Dévai Tamás <gonosztopi@amule.org>\n"
 "Language-Team: Hungarian <hu@li.org>\n"
@@ -1901,6 +1901,11 @@ msgstr "eD2k hivatkozás másolása a vágólapra"
 #: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Copy feedback to clipboard"
 msgstr "Visszajelzés másolása a vágólapra"
+
+#: src/DownloadListCtrl.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#, c-format
+msgid "Get %s for this file"
+msgstr "%s lekérése ehez a fájlhoz"
 
 #: src/DownloadListCtrl.cpp
 msgid "unassign"
@@ -6726,11 +6731,6 @@ msgstr ""
 #, fuzzy
 msgid "Collapse all"
 msgstr "Az összes fül bezárása"
-
-#: src/SearchListCtrl.cpp
-#, c-format
-msgid "Get %s for this file"
-msgstr "%s lekérése ehez a fájlhoz"
 
 #: src/SearchListCtrl.cpp
 msgid "Search related files (eD2k, local server)"

--- a/po/it.po
+++ b/po/it.po
@@ -19,7 +19,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule 2.3.3\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-08 15:40+0200\n"
+"POT-Creation-Date: 2026-09-09 11:05+0200\n"
 "PO-Revision-Date: 2026-09-08 15:39+0000\n"
 "Last-Translator: got3nks <got3nks@users.noreply.github.com>\n"
 "Language-Team: SebastianoPistore.info@protonmail.ch\n"
@@ -1910,6 +1910,11 @@ msgstr "Copia il &link eD2k negli appunti"
 #: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Copy feedback to clipboard"
 msgstr "Copia feedback negli appunti"
+
+#: src/DownloadListCtrl.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#, c-format
+msgid "Get %s for this file"
+msgstr "Ottieni %s per questo file"
 
 #: src/DownloadListCtrl.cpp
 msgid "unassign"
@@ -6704,11 +6709,6 @@ msgstr "Espandi tutto"
 #: src/SearchListCtrl.cpp
 msgid "Collapse all"
 msgstr "Comprimi tutto"
-
-#: src/SearchListCtrl.cpp
-#, c-format
-msgid "Get %s for this file"
-msgstr "Ottieni %s per questo file"
 
 #: src/SearchListCtrl.cpp
 msgid "Search related files (eD2k, local server)"

--- a/po/ja.po
+++ b/po/ja.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-08 15:40+0200\n"
+"POT-Creation-Date: 2026-09-09 11:05+0200\n"
 "PO-Revision-Date: 2026-09-08 15:39+0000\n"
 "Last-Translator: \n"
 "Language-Team: Japanese\n"
@@ -1905,6 +1905,11 @@ msgstr ""
 #: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Copy feedback to clipboard"
 msgstr "フィードバックをクリップボードにコピーする"
+
+#: src/DownloadListCtrl.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#, fuzzy, c-format
+msgid "Get %s for this file"
+msgstr "このファイルにオプショナルURLを追加する"
 
 #: src/DownloadListCtrl.cpp
 msgid "unassign"
@@ -6746,11 +6751,6 @@ msgstr ""
 #, fuzzy
 msgid "Collapse all"
 msgstr "全てのタブを閉める"
-
-#: src/SearchListCtrl.cpp
-#, fuzzy, c-format
-msgid "Get %s for this file"
-msgstr "このファイルにオプショナルURLを追加する"
 
 #: src/SearchListCtrl.cpp
 msgid "Search related files (eD2k, local server)"

--- a/po/ko_KR.po
+++ b/po/ko_KR.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-08 15:40+0200\n"
+"POT-Creation-Date: 2026-09-09 11:05+0200\n"
 "PO-Revision-Date: 2026-09-08 15:39+0000\n"
 "Last-Translator: Hyunju Kang <rexington@gmail.com>\n"
 "Language-Team: Korean <hoenny@daum.net>\n"
@@ -1919,6 +1919,11 @@ msgstr ""
 #: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Copy feedback to clipboard"
 msgstr "반응을 클립보드에 복사"
+
+#: src/DownloadListCtrl.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#, fuzzy, c-format
+msgid "Get %s for this file"
+msgstr "이 파일의 추가주소를 더합니다."
 
 #: src/DownloadListCtrl.cpp
 msgid "unassign"
@@ -6789,11 +6794,6 @@ msgstr ""
 #, fuzzy
 msgid "Collapse all"
 msgstr "모든 탭 닫기"
-
-#: src/SearchListCtrl.cpp
-#, fuzzy, c-format
-msgid "Get %s for this file"
-msgstr "이 파일의 추가주소를 더합니다."
 
 #: src/SearchListCtrl.cpp
 msgid "Search related files (eD2k, local server)"

--- a/po/lt.po
+++ b/po/lt.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-08 15:40+0200\n"
+"POT-Creation-Date: 2026-09-09 11:05+0200\n"
 "PO-Revision-Date: 2026-09-08 15:39+0000\n"
 "Last-Translator: Dovydas Sankauskas <laisve@gmail.com>\n"
 "Language-Team: Lithuanian <komp_lt@konf.lt>\n"
@@ -1932,6 +1932,11 @@ msgstr "Kopijuoti eD2k &nuorodą į talpyklę"
 #: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Copy feedback to clipboard"
 msgstr "Kopijuoti atsakymą į talpyklę"
+
+#: src/DownloadListCtrl.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#, fuzzy, c-format
+msgid "Get %s for this file"
+msgstr "Šiam failui įdėti papildomus URL"
 
 #: src/DownloadListCtrl.cpp
 msgid "unassign"
@@ -6822,11 +6827,6 @@ msgstr ""
 #, fuzzy
 msgid "Collapse all"
 msgstr "Užverti visas korteles"
-
-#: src/SearchListCtrl.cpp
-#, fuzzy, c-format
-msgid "Get %s for this file"
-msgstr "Šiam failui įdėti papildomus URL"
 
 #: src/SearchListCtrl.cpp
 msgid "Search related files (eD2k, local server)"

--- a/po/lv.po
+++ b/po/lv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-08 15:40+0200\n"
+"POT-Creation-Date: 2026-09-09 11:05+0200\n"
 "PO-Revision-Date: 2026-09-08 15:45+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -1876,6 +1876,11 @@ msgstr "Kopēt eD2k saiti starp&liktuvē"
 
 #: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Copy feedback to clipboard"
+msgstr ""
+
+#: src/DownloadListCtrl.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#, c-format
+msgid "Get %s for this file"
 msgstr ""
 
 #: src/DownloadListCtrl.cpp
@@ -6608,11 +6613,6 @@ msgstr "Izvērst visu"
 #: src/SearchListCtrl.cpp
 msgid "Collapse all"
 msgstr "Sakļaut visu"
-
-#: src/SearchListCtrl.cpp
-#, c-format
-msgid "Get %s for this file"
-msgstr ""
 
 #: src/SearchListCtrl.cpp
 msgid "Search related files (eD2k, local server)"

--- a/po/nl.po
+++ b/po/nl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-08 15:40+0200\n"
+"POT-Creation-Date: 2026-09-09 11:05+0200\n"
 "PO-Revision-Date: 2026-09-08 15:40+0000\n"
 "Last-Translator: Marcel Pol <marcel@timelord.nl>\n"
 "Language-Team: Dutch <nl@li.org>\n"
@@ -1899,6 +1899,11 @@ msgstr "Kopieer eD2k &link naar klembord"
 #: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Copy feedback to clipboard"
 msgstr "Kopieer feedback naar klembord"
+
+#: src/DownloadListCtrl.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#, c-format
+msgid "Get %s for this file"
+msgstr "Verkrijg %s voor dit bestand"
 
 #: src/DownloadListCtrl.cpp
 msgid "unassign"
@@ -6695,11 +6700,6 @@ msgstr "Vouw alles uit"
 #: src/SearchListCtrl.cpp
 msgid "Collapse all"
 msgstr "Vouw alles in"
-
-#: src/SearchListCtrl.cpp
-#, c-format
-msgid "Get %s for this file"
-msgstr "Verkrijg %s voor dit bestand"
 
 #: src/SearchListCtrl.cpp
 msgid "Search related files (eD2k, local server)"

--- a/po/nn.po
+++ b/po/nn.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-08 15:40+0200\n"
+"POT-Creation-Date: 2026-09-09 11:05+0200\n"
 "PO-Revision-Date: 2026-09-08 15:40+0000\n"
 "Last-Translator: Hallvor Brunstad <Hallvor_1976@yahoo.com>\n"
 "Language-Team: <i18n-nn@lister.ping.uio.no>\n"
@@ -1920,6 +1920,11 @@ msgstr "Kopier eD2k &lenka til utklippstavla"
 #: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Copy feedback to clipboard"
 msgstr "Kopiér tilbakemelding til utklippstavla"
+
+#: src/DownloadListCtrl.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#, fuzzy, c-format
+msgid "Get %s for this file"
+msgstr "Legg til valfrie URL`ar for denne fila"
 
 #: src/DownloadListCtrl.cpp
 msgid "unassign"
@@ -6790,11 +6795,6 @@ msgstr ""
 #, fuzzy
 msgid "Collapse all"
 msgstr "Stengje alle faneblad"
-
-#: src/SearchListCtrl.cpp
-#, fuzzy, c-format
-msgid "Get %s for this file"
-msgstr "Legg til valfrie URL`ar for denne fila"
 
 #: src/SearchListCtrl.cpp
 msgid "Search related files (eD2k, local server)"

--- a/po/pl.po
+++ b/po/pl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-08 15:40+0200\n"
+"POT-Creation-Date: 2026-09-09 11:05+0200\n"
 "PO-Revision-Date: 2026-09-08 15:40+0000\n"
 "Last-Translator: Michał Trzebiatowski <hippie_1968@hotmail.com>\n"
 "Language-Team: translationproject.org/team/pl.html <translation-team-pl@lists.sourceforge.net>\n"
@@ -1923,6 +1923,11 @@ msgstr "Kopiuj &link eD2k do schowka"
 #: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Copy feedback to clipboard"
 msgstr "Kopiuj informację zwrotną do schowka"
+
+#: src/DownloadListCtrl.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#, fuzzy, c-format
+msgid "Get %s for this file"
+msgstr "Dodaj opcjonalny URL dla tego pliku"
 
 #: src/DownloadListCtrl.cpp
 msgid "unassign"
@@ -6803,11 +6808,6 @@ msgstr ""
 #, fuzzy
 msgid "Collapse all"
 msgstr "Zamknij wszystkie karty"
-
-#: src/SearchListCtrl.cpp
-#, fuzzy, c-format
-msgid "Get %s for this file"
-msgstr "Dodaj opcjonalny URL dla tego pliku"
 
 #: src/SearchListCtrl.cpp
 msgid "Search related files (eD2k, local server)"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-08 15:40+0200\n"
+"POT-Creation-Date: 2026-09-09 11:05+0200\n"
 "PO-Revision-Date: 2026-09-08 15:41+0000\n"
 "Last-Translator: Marcelo Jimenez <mroberto@users.sourceforge.com>\n"
 "Language-Team: Português (Brasileiro) <pt@li.org>\n"
@@ -1904,6 +1904,11 @@ msgstr "Copiar &link eD2k para área de transferência"
 #: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Copy feedback to clipboard"
 msgstr "Copiar retorno para a Área de Transferência"
+
+#: src/DownloadListCtrl.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#, c-format
+msgid "Get %s for this file"
+msgstr "Obtendo %s para este arquivo"
 
 #: src/DownloadListCtrl.cpp
 msgid "unassign"
@@ -6704,11 +6709,6 @@ msgstr "Espandir tudo"
 #: src/SearchListCtrl.cpp
 msgid "Collapse all"
 msgstr "Colapsar tudo"
-
-#: src/SearchListCtrl.cpp
-#, c-format
-msgid "Get %s for this file"
-msgstr "Obtendo %s para este arquivo"
 
 #: src/SearchListCtrl.cpp
 msgid "Search related files (eD2k, local server)"

--- a/po/pt_PT.po
+++ b/po/pt_PT.po
@@ -17,7 +17,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-08 15:40+0200\n"
+"POT-Creation-Date: 2026-09-09 11:05+0200\n"
 "PO-Revision-Date: 2026-09-08 15:41+0000\n"
 "Last-Translator: Luís Picciochi Oliveira <Pitxyoki@Gmail.com>\n"
 "Language-Team: Portuguese <traduz@debianpt.org>\n"
@@ -1917,6 +1917,11 @@ msgstr "Copiar &ligação eD2k para a área de transferência"
 #: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Copy feedback to clipboard"
 msgstr "Copiar comentários para a área de transferência"
+
+#: src/DownloadListCtrl.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#, c-format
+msgid "Get %s for this file"
+msgstr "Obter %s para este ficheiro"
 
 #: src/DownloadListCtrl.cpp
 msgid "unassign"
@@ -6769,11 +6774,6 @@ msgstr ""
 #, fuzzy
 msgid "Collapse all"
 msgstr "Fechar todos os separadores"
-
-#: src/SearchListCtrl.cpp
-#, c-format
-msgid "Get %s for this file"
-msgstr "Obter %s para este ficheiro"
 
 #: src/SearchListCtrl.cpp
 msgid "Search related files (eD2k, local server)"

--- a/po/ro.po
+++ b/po/ro.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-08 15:40+0200\n"
+"POT-Creation-Date: 2026-09-09 11:05+0200\n"
 "PO-Revision-Date: 2026-09-08 15:41+0000\n"
 "Last-Translator: Angelescu Constantin <titus0818@yahoo.com>\n"
 "Language-Team: English <kde-i18n-doc@kde.org>\n"
@@ -1920,6 +1920,11 @@ msgstr "Coiază link-ul eD2k în memoria temporară"
 #: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Copy feedback to clipboard"
 msgstr "Copiază feedback-ul în memoria temporară"
+
+#: src/DownloadListCtrl.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#, c-format
+msgid "Get %s for this file"
+msgstr "Obține %s pentru acest fișier"
 
 #: src/DownloadListCtrl.cpp
 msgid "unassign"
@@ -6787,11 +6792,6 @@ msgstr ""
 #, fuzzy
 msgid "Collapse all"
 msgstr "Închide toate ferestrele"
-
-#: src/SearchListCtrl.cpp
-#, c-format
-msgid "Get %s for this file"
-msgstr "Obține %s pentru acest fișier"
 
 #: src/SearchListCtrl.cpp
 msgid "Search related files (eD2k, local server)"

--- a/po/ru.po
+++ b/po/ru.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-08 15:40+0200\n"
+"POT-Creation-Date: 2026-09-09 11:05+0200\n"
 "PO-Revision-Date: 2026-09-08 15:42+0000\n"
 "Last-Translator: Radist Morse <radist.morse@gmail.com>\n"
 "Language-Team: Russian <kde-russian@lists.kde.ru>\n"
@@ -1922,6 +1922,11 @@ msgstr "Копировать &ссылку eD2k в буфер"
 #: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Copy feedback to clipboard"
 msgstr "Копировать сведения в буфер обмена"
+
+#: src/DownloadListCtrl.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#, c-format
+msgid "Get %s for this file"
+msgstr "Получить %s для этого файла"
 
 #: src/DownloadListCtrl.cpp
 msgid "unassign"
@@ -6756,11 +6761,6 @@ msgstr "Развернуть всё"
 #: src/SearchListCtrl.cpp
 msgid "Collapse all"
 msgstr "Свернуть всё"
-
-#: src/SearchListCtrl.cpp
-#, c-format
-msgid "Get %s for this file"
-msgstr "Получить %s для этого файла"
 
 #: src/SearchListCtrl.cpp
 msgid "Search related files (eD2k, local server)"

--- a/po/sl.po
+++ b/po/sl.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-08 15:40+0200\n"
+"POT-Creation-Date: 2026-09-09 11:05+0200\n"
 "PO-Revision-Date: 2026-09-08 15:42+0000\n"
 "Last-Translator: Jure Repinc <jlp@holodeck1.com>\n"
 "Language-Team: Slovenian\n"
@@ -1936,6 +1936,11 @@ msgstr "Skopiraj &povezavo eD2k na odložišče"
 #: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Copy feedback to clipboard"
 msgstr "Skopiraj odziv na odložišče"
+
+#: src/DownloadListCtrl.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#, c-format
+msgid "Get %s for this file"
+msgstr "Dobi %s za to datoteko"
 
 #: src/DownloadListCtrl.cpp
 msgid "unassign"
@@ -6831,11 +6836,6 @@ msgstr ""
 #, fuzzy
 msgid "Collapse all"
 msgstr "Zapri vse zavihke"
-
-#: src/SearchListCtrl.cpp
-#, c-format
-msgid "Get %s for this file"
-msgstr "Dobi %s za to datoteko"
 
 #: src/SearchListCtrl.cpp
 msgid "Search related files (eD2k, local server)"

--- a/po/sq.po
+++ b/po/sq.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-08 15:40+0200\n"
+"POT-Creation-Date: 2026-09-09 11:05+0200\n"
 "PO-Revision-Date: 2026-09-08 15:43+0000\n"
 "Last-Translator: Fation <dj_barthezz@linuxmail.org lushnja_corps@hotmail.Language-Team:\n"
 "Language: sq\n"
@@ -1917,6 +1917,11 @@ msgstr ""
 #: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Copy feedback to clipboard"
 msgstr "Kopjo feedback ne shenimet"
+
+#: src/DownloadListCtrl.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#, fuzzy, c-format
+msgid "Get %s for this file"
+msgstr "Shtoni URLs opsionale per kete fail"
 
 #: src/DownloadListCtrl.cpp
 msgid "unassign"
@@ -6781,11 +6786,6 @@ msgstr ""
 #, fuzzy
 msgid "Collapse all"
 msgstr "Mbylli te gjitha tabelat"
-
-#: src/SearchListCtrl.cpp
-#, fuzzy, c-format
-msgid "Get %s for this file"
-msgstr "Shtoni URLs opsionale per kete fail"
 
 #: src/SearchListCtrl.cpp
 msgid "Search related files (eD2k, local server)"

--- a/po/sv.po
+++ b/po/sv.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-08 15:40+0200\n"
+"POT-Creation-Date: 2026-09-09 11:05+0200\n"
 "PO-Revision-Date: 2026-09-08 15:43+0000\n"
 "Last-Translator: raffe <raffe@localhost.se>\n"
 "Language-Team: Swedish <tp-sv@listor.tp-sv.se>\n"
@@ -1909,6 +1909,11 @@ msgstr "Kopiera eD2k &link till urklipp"
 #: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Copy feedback to clipboard"
 msgstr "Kopiera återkoppling till urklipp"
+
+#: src/DownloadListCtrl.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#, c-format
+msgid "Get %s for this file"
+msgstr "Hämta %s för den här filen:"
 
 #: src/DownloadListCtrl.cpp
 msgid "unassign"
@@ -6758,11 +6763,6 @@ msgstr ""
 #, fuzzy
 msgid "Collapse all"
 msgstr "Stäng alla flikar"
-
-#: src/SearchListCtrl.cpp
-#, c-format
-msgid "Get %s for this file"
-msgstr "Hämta %s för den här filen:"
 
 #: src/SearchListCtrl.cpp
 msgid "Search related files (eD2k, local server)"

--- a/po/ta.po
+++ b/po/ta.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-08 15:40+0200\n"
+"POT-Creation-Date: 2026-09-09 11:05+0200\n"
 "PO-Revision-Date: 2026-09-08 15:46+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -1854,6 +1854,11 @@ msgstr ""
 
 #: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Copy feedback to clipboard"
+msgstr ""
+
+#: src/DownloadListCtrl.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#, c-format
+msgid "Get %s for this file"
 msgstr ""
 
 #: src/DownloadListCtrl.cpp
@@ -6551,11 +6556,6 @@ msgstr ""
 
 #: src/SearchListCtrl.cpp
 msgid "Collapse all"
-msgstr ""
-
-#: src/SearchListCtrl.cpp
-#, c-format
-msgid "Get %s for this file"
 msgstr ""
 
 #: src/SearchListCtrl.cpp

--- a/po/tr.po
+++ b/po/tr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-08 15:40+0200\n"
+"POT-Creation-Date: 2026-09-09 11:05+0200\n"
 "PO-Revision-Date: 2026-09-08 15:43+0000\n"
 "Last-Translator: \n"
 "Language-Team: Turkish <li@li.org>\n"
@@ -1896,6 +1896,11 @@ msgstr "eD2k bağlantısını panoya kopya&la"
 #: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Copy feedback to clipboard"
 msgstr "Geri beslemeyi panoya kopyala"
+
+#: src/DownloadListCtrl.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#, c-format
+msgid "Get %s for this file"
+msgstr "Bu dosya için %s iste"
 
 #: src/DownloadListCtrl.cpp
 msgid "unassign"
@@ -6690,11 +6695,6 @@ msgstr "Tümünü genişlet"
 #: src/SearchListCtrl.cpp
 msgid "Collapse all"
 msgstr "Tümünü daralt"
-
-#: src/SearchListCtrl.cpp
-#, c-format
-msgid "Get %s for this file"
-msgstr "Bu dosya için %s iste"
 
 #: src/SearchListCtrl.cpp
 msgid "Search related files (eD2k, local server)"

--- a/po/uk.po
+++ b/po/uk.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-08 15:40+0200\n"
+"POT-Creation-Date: 2026-09-09 11:05+0200\n"
 "PO-Revision-Date: 2026-09-08 15:44+0000\n"
 "Last-Translator: Oleksandr Kovalenko <alx.kovalenko@gmail.com>\n"
 "Language-Team: Ukrainian <translation@linux.org.ua>\n"
@@ -1928,6 +1928,11 @@ msgstr "Скопіювати eD2k-посилання до буферу обмі�
 #: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Copy feedback to clipboard"
 msgstr "Скопіювати інформацію відгуку до буферу обміну"
+
+#: src/DownloadListCtrl.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#, fuzzy, c-format
+msgid "Get %s for this file"
+msgstr "Додати додаткові URL-адреси для цього файлу"
 
 #: src/DownloadListCtrl.cpp
 msgid "unassign"
@@ -6826,11 +6831,6 @@ msgstr ""
 #, fuzzy
 msgid "Collapse all"
 msgstr "Закрити всі вкладки"
-
-#: src/SearchListCtrl.cpp
-#, fuzzy, c-format
-msgid "Get %s for this file"
-msgstr "Додати додаткові URL-адреси для цього файлу"
 
 #: src/SearchListCtrl.cpp
 msgid "Search related files (eD2k, local server)"

--- a/po/vi.po
+++ b/po/vi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule GIT\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-08 15:40+0200\n"
+"POT-Creation-Date: 2026-09-09 11:05+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: none\n"
@@ -1848,6 +1848,11 @@ msgstr ""
 
 #: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Copy feedback to clipboard"
+msgstr ""
+
+#: src/DownloadListCtrl.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#, c-format
+msgid "Get %s for this file"
 msgstr ""
 
 #: src/DownloadListCtrl.cpp
@@ -6541,11 +6546,6 @@ msgstr ""
 
 #: src/SearchListCtrl.cpp
 msgid "Collapse all"
-msgstr ""
-
-#: src/SearchListCtrl.cpp
-#, c-format
-msgid "Get %s for this file"
 msgstr ""
 
 #: src/SearchListCtrl.cpp

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-08 15:40+0200\n"
+"POT-Creation-Date: 2026-09-09 11:05+0200\n"
 "PO-Revision-Date: 2026-09-08 15:44+0000\n"
 "Last-Translator: Mike Akiba <mike2718@gmail.com>\n"
 "Language-Team: Chinese Simplified <kde-i18n-doc@kde.org>\n"
@@ -1900,6 +1900,11 @@ msgstr "复制 eD2k 链接到剪贴板 (&L)"
 #: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Copy feedback to clipboard"
 msgstr "复制反馈信息到剪贴板"
+
+#: src/DownloadListCtrl.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#, c-format
+msgid "Get %s for this file"
+msgstr "获取此文件的 %s"
 
 #: src/DownloadListCtrl.cpp
 msgid "unassign"
@@ -6694,11 +6699,6 @@ msgstr "全部展开"
 #: src/SearchListCtrl.cpp
 msgid "Collapse all"
 msgstr "折叠所有"
-
-#: src/SearchListCtrl.cpp
-#, c-format
-msgid "Get %s for this file"
-msgstr "获取此文件的 %s"
 
 #: src/SearchListCtrl.cpp
 msgid "Search related files (eD2k, local server)"

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: aMule\n"
 "Report-Msgid-Bugs-To: https://github.com/amule-org/amule/issues\n"
-"POT-Creation-Date: 2026-09-08 15:40+0200\n"
+"POT-Creation-Date: 2026-09-09 11:05+0200\n"
 "PO-Revision-Date: 2026-09-08 15:44+0000\n"
 "Last-Translator: Wayne Su <mstarmstar@gmail.com>\n"
 "Language-Team: \n"
@@ -1905,6 +1905,11 @@ msgstr "複製 eD2k 連結到剪貼簿(&L)"
 #: src/DownloadListCtrl.cpp src/SharedFilesCtrl.cpp
 msgid "Copy feedback to clipboard"
 msgstr "複製傳輸狀況到剪貼簿"
+
+#: src/DownloadListCtrl.cpp src/SearchListCtrl.cpp src/SharedFilesCtrl.cpp
+#, c-format
+msgid "Get %s for this file"
+msgstr "取得這個檔案的 %s"
 
 #: src/DownloadListCtrl.cpp
 msgid "unassign"
@@ -6736,11 +6741,6 @@ msgstr ""
 #, fuzzy
 msgid "Collapse all"
 msgstr "關閉所有分頁"
-
-#: src/SearchListCtrl.cpp
-#, c-format
-msgid "Get %s for this file"
-msgstr "取得這個檔案的 %s"
 
 #: src/SearchListCtrl.cpp
 msgid "Search related files (eD2k, local server)"

--- a/src/DownloadListCtrl.cpp
+++ b/src/DownloadListCtrl.cpp
@@ -180,6 +180,7 @@ wxBEGIN_EVENT_TABLE(CDownloadListCtrl, CMuleVirtualDataViewCtrl)
 
 	EVT_MENU(MP_GETMAGNETLINK, CDownloadListCtrl::OnGetLink)
 	EVT_MENU(MP_GETED2KLINK, CDownloadListCtrl::OnGetLink)
+	EVT_MENU(MP_RAZORSTATS, CDownloadListCtrl::OnRazorStatsCheck)
 
 	EVT_MENU(MP_METINFO, CDownloadListCtrl::OnViewFileInfo)
 	EVT_MENU(MP_VIEW, CDownloadListCtrl::OnPreviewFile)
@@ -486,6 +487,18 @@ void CDownloadListCtrl::OnItemRightClicked(wxDataViewEvent &event)
 	m_menu->Append(MP_WS, _("Copy feedback to clipboard"));
 	m_menu->AppendSeparator();
 
+	// Same entry the search list offers, on the same gate: a partfile's hash is
+	// the completed file's and is known from the link, so the lookup works
+	// before a single byte has arrived -- which is when sources and history are
+	// worth checking. Hidden, not greyed, when no stats server is configured,
+	// because an empty preference means the feature is off rather than
+	// unavailable for this row.
+	const wxString &statsServer = thePrefs::GetStatsServerName();
+	if (!statsServer.IsEmpty()) {
+		m_menu->Append(MP_RAZORSTATS, CFormat(_("Get %s for this file")) % statsServer);
+		m_menu->AppendSeparator();
+	}
+
 	wxMenu *cats = new wxMenu(_("Category"));
 	if (theApp->glob_prefs->GetCatCount() > 1) {
 		for (uint32 i = 0; i < theApp->glob_prefs->GetCatCount(); i++) {
@@ -740,6 +753,17 @@ void CDownloadListCtrl::OnShowInFolder(wxCommandEvent &WXUNUSED(event))
 	if (m_menuItem != 0 && HasItemData(m_menuItem)) {
 		FileLaunch::Reveal(reinterpret_cast<CPartFile *>(m_menuItem), this);
 	}
+}
+
+void CDownloadListCtrl::OnRazorStatsCheck(wxCommandEvent &WXUNUSED(event))
+{
+	// Bound re-checked for the reason OnShowInFolder gives: PopupMenu runs a
+	// nested event loop, so the queue can drop the row while the menu is open.
+	if (m_menuItem == 0 || !HasItemData(m_menuItem)) {
+		return;
+	}
+	const CPartFile *file = reinterpret_cast<CPartFile *>(m_menuItem);
+	theApp->amuledlg->LaunchUrl(thePrefs::GetStatsServerURL() + file->GetFileHash().Encode());
 }
 
 void CDownloadListCtrl::OnItemActivated(wxDataViewEvent &event)

--- a/src/DownloadListCtrl.h
+++ b/src/DownloadListCtrl.h
@@ -279,6 +279,7 @@ private:
 	void OnViewFileComments(wxCommandEvent &event);
 	void OnPreviewFile(wxCommandEvent &event);
 	void OnShowInFolder(wxCommandEvent &event);
+	void OnRazorStatsCheck(wxCommandEvent &event);
 
 	/**
 	 * The item the context menu was built for, by identity rather than row.

--- a/src/SharedFilesCtrl.cpp
+++ b/src/SharedFilesCtrl.cpp
@@ -119,6 +119,7 @@ wxBEGIN_EVENT_TABLE(CSharedFilesCtrl, CMuleVirtualDataViewCtrl)
 	EVT_MENU(MP_EXPORTCOLLECTION, CSharedFilesCtrl::OnExportCollection)
 	EVT_MENU(MP_GETMAGNETLINK, CSharedFilesCtrl::OnCreateURI)
 	EVT_MENU(MP_GETED2KLINK, CSharedFilesCtrl::OnCreateURI)
+	EVT_MENU(MP_RAZORSTATS, CSharedFilesCtrl::OnRazorStatsCheck)
 	EVT_MENU(MP_GETSOURCEED2KLINK, CSharedFilesCtrl::OnCreateURI)
 	EVT_MENU(MP_GETCRYPTSOURCEDED2KLINK, CSharedFilesCtrl::OnCreateURI)
 	EVT_MENU(MP_GETHOSTNAMESOURCEED2KLINK, CSharedFilesCtrl::OnCreateURI)
@@ -260,6 +261,17 @@ void CSharedFilesCtrl::OnItemRightClicked(wxDataViewEvent &event)
 		m_menu->Append(MP_GETAICHED2KLINKSRC, _("Copy eD2k link to clipboard (&AICH info + Source)"));
 		m_menu->Append(MP_WS, _("Copy feedback to clipboard"));
 		m_menu->AppendSeparator();
+
+		// Same entry the search list offers, on the same gate. Every row here
+		// has a hash, partfiles included: a shared partfile is listed under the
+		// completed file's hash. Hidden, not greyed, when no stats server is
+		// configured, because an empty preference means the feature is off
+		// rather than unavailable for this row.
+		const wxString &statsServer = thePrefs::GetStatsServerName();
+		if (!statsServer.IsEmpty()) {
+			m_menu->Append(MP_RAZORSTATS, CFormat(_("Get %s for this file")) % statsServer);
+			m_menu->AppendSeparator();
+		}
 		m_menu->Append(MP_EXPORTCOLLECTION, _("Export selected files to an emulecollection"));
 
 		// The bar column is the only cell in this list whose colours need
@@ -370,6 +382,18 @@ void CSharedFilesCtrl::ShowFileDetailDialog(long focused)
 		files.push_back(FileAtRow(i));
 	}
 	CFileDetailDialog(this, files, index).ShowModal();
+}
+
+void CSharedFilesCtrl::OnRazorStatsCheck(wxCommandEvent &WXUNUSED(event))
+{
+	// Bound re-checked, for the reason OnOpenFile gives: PopupMenu runs a
+	// nested event loop, so the shared-dir watcher can drop the row while the
+	// menu is open.
+	if (m_menuItem == 0 || !HasItemData(m_menuItem)) {
+		return;
+	}
+	const CKnownFile *file = reinterpret_cast<CKnownFile *>(m_menuItem);
+	theApp->amuledlg->LaunchUrl(thePrefs::GetStatsServerURL() + file->GetFileHash().Encode());
 }
 
 void CSharedFilesCtrl::OnShowBarLegend(wxCommandEvent &WXUNUSED(event))

--- a/src/SharedFilesCtrl.h
+++ b/src/SharedFilesCtrl.h
@@ -365,6 +365,7 @@ private:
 	 * (partbar::LegendForSharedFilesRow).
 	 */
 	void OnShowBarLegend(wxCommandEvent &event);
+	void OnRazorStatsCheck(wxCommandEvent &event);
 
 	/**
 	 * Double-click / Enter on a row also opens the file-details dialog, for


### PR DESCRIPTION
Adds the stats-server entry, which existed only in the search results, to the two other lists whose rows carry an ED2k hash. For #1335.

Between these and the existing search entry the set is complete: every other list shows clients rather than files, and a client's browsed shared files are fed into the search list (`CUpDownClient::ProcessSharedFileList` -> `theApp->searchlist`), so they already had it.

**Downloads** is arguably where it earns the most. A partfile's hash is the completed file's and is known from the link before a single byte arrives, so sources and history can be checked exactly when a download is stalled or short of sources.

**Shared files** rows always carry a hash too, partfiles included, since a shared partfile is listed under the completed file's hash. Adding it to both also keeps a shared partfile from offering the entry in one window and not the other.

Details worth noting:

- Same gate as the search entry: hidden rather than greyed when no stats server name is configured, because an empty preference means the feature is off rather than unavailable for that row. Both menus are rebuilt on each right-click, so the gate is live rather than frozen at construction.
- Both handlers re-check `m_menuItem` against `HasItemData` before dereferencing, the idiom both controls already use: `PopupMenu` runs a nested event loop, so the row can be dropped by the download queue or the shared-dir watcher while the menu is open.
- `MP_RAZORSTATS` already existed in `MenuIDs.h`, so there is no new menu id.
- No new translatable string: the label reuses the msgid the search list already registers. The catalogs are still regenerated, though, and the second commit does that. `DownloadListCtrl.cpp` sorts before `SearchListCtrl.cpp` in `POTFILES.in`, so it becomes the entry's first reference and xgettext emits it earlier in `amule.pot`, which msgmerge then relocates in every catalog. Verified as a pure move: across all 41 catalogs no msgid is added or removed and no translation changes, the header aside.

### Verification

Built and exercised the monolithic GUI and amulegui from this branch (`3.0.1-864-ga0057cf44` plus the change): the entry appears in both context menus, positioned after the link-copy items, and disappears when the stats server name is cleared. clang-format 18 clean on all four changed files; clang-tidy Tier-2 clean on the changed lines with 0 compiler errors.

