### PR TITLE
fix(gui): fetch the statistics tree on the first poll of a connection

### DIFF
--- a/src/amule-remote-gui.cpp
+++ b/src/amule-remote-gui.cpp
@@ -334,7 +334,6 @@ void CamuleRemoteGuiApp::OnAssertFailure(
 void CamuleRemoteGuiApp::OnPollTimer(wxTimerEvent &)
 {
 	static int request_step = 0;
-	static uint32 msPrevStats = 0;
 
 	// Reply watchdog. EC has no application-level keepalive, and the daemon
 	// always answers, so requests outstanding with nothing coming back means
@@ -449,10 +448,24 @@ void CamuleRemoteGuiApp::OnPollTimer(wxTimerEvent &)
 		// points for graph."); the tree request honors
 		// thePrefs::GetStatsInterval().
 		{
-			int sStatsUpdate = thePrefs::GetStatsInterval();
-			uint32 msCur = theStats::GetUptimeMillis();
-			if ((sStatsUpdate > 0) && ((int)(msCur - msPrevStats) > sStatsUpdate * 1000)) {
-				msPrevStats = msCur;
+			const uint32 sStatsUpdate = thePrefs::GetStatsInterval();
+			const uint32 msCur = theStats::GetUptimeMillis();
+			// Unsigned throughout on purpose. The subtraction is modular, so
+			// it yields the true elapsed time even across the point where a
+			// 32-bit millisecond counter wraps. Casting it to int, as this
+			// did, threw that away: a difference above INT_MAX reads as
+			// negative and the comparison is false, so the tree would stop
+			// refreshing rather than refresh late.
+			//
+			// The elapsed test also cannot be the whole condition: on the
+			// first poll of a connection nothing has elapsed, so it is false
+			// and the tree stays empty for a full interval (30 s by default)
+			// before its first fetch. m_statsTreePolled makes that first
+			// fetch unconditional; the interval governs every one after it.
+			const bool dueByInterval = (msCur - m_msPrevStatsTree) > sStatsUpdate * 1000;
+			if ((sStatsUpdate > 0) && (!m_statsTreePolled || dueByInterval)) {
+				m_statsTreePolled = true;
+				m_msPrevStatsTree = msCur;
 				stattree->DoRequery();
 			}
 			statgraphs->DoRequery();
@@ -1020,6 +1033,10 @@ void CamuleRemoteGuiApp::FinishReconnect(int result)
 			// so scroll and selection survive.
 			knownfiles->ArmReconnectReconcile();
 		}
+		// The tree on screen belongs to the connection that just ended;
+		// fetch a fresh one on the next poll rather than after an interval
+		// measured against the old one.
+		ResetStatsTreePoll();
 		if (poll_timer) {
 			poll_timer->Start(EC_POLL_INTERVAL_MS);
 		}
@@ -1225,6 +1242,7 @@ void CamuleRemoteGuiApp::Startup()
 	knownfiles->DoRequery(EC_OP_GET_UPDATE, EC_TAG_KNOWNFILE);
 
 	// Start the Poll Timer
+	ResetStatsTreePoll();
 	poll_timer->Start(EC_POLL_INTERVAL_MS);
 	amuledlg->StartGuiTimer();
 

--- a/src/amule-remote-gui.h
+++ b/src/amule-remote-gui.h
@@ -1014,6 +1014,29 @@ class CamuleRemoteGuiApp : public wxApp, public CamuleGuiBase, public CamuleAppC
 	// no visible window while TCP SYN silently times out over minutes.
 	wxTimer *connect_timeout_timer;
 
+	// --- Statistics-tree poll cadence ---
+	// The tree is fetched on a timer of its own (thePrefs::GetStatsInterval(),
+	// 30 s by default) rather than on every poll, because it is the one EC
+	// request here that is a full snapshot instead of a delta.
+	//
+	// m_statsTreePolled says whether that has happened yet *on this
+	// connection*. Without it the elapsed-time test alone is false on the
+	// first tick -- nothing has elapsed yet -- so a freshly started
+	// amulegui showed an empty Statistics tree for a whole interval, and a
+	// reconnect kept showing the previous daemon's tree for the remainder
+	// of one. ResetStatsTreePoll() clears it wherever a connection begins.
+	bool m_statsTreePolled = false;
+	uint32 m_msPrevStatsTree = 0;
+
+	// Called wherever a connection begins, so the next poll fetches the tree
+	// straight away instead of waiting out an interval that measures time
+	// spent on a connection that is no longer the current one.
+	void ResetStatsTreePoll()
+	{
+		m_statsTreePolled = false;
+		m_msPrevStatsTree = 0;
+	}
+
 	// --- Reconnect-after-loss (issue #444) ---
 	// When the EC connection drops after startup (e.g. the machine slept),
 	// amulegui no longer exits: it freezes the UI behind a modal dialog and


### PR DESCRIPTION
amuleGUI showed an empty Statistics tree for the first 30 seconds after connecting. The graphs beside it populated immediately, which is what makes it look like a loading bug rather than a timer.

### Mechanism

The tree is fetched on its own cadence - `thePrefs::GetStatsInterval()`, 30 s by default - because unlike everything else polled here it is a full snapshot rather than a delta. The gate was:

```cpp
static uint32 msPrevStats = 0;
uint32 msCur = theStats::GetUptimeMillis();
if ((sStatsUpdate > 0) && ((int)(msCur - msPrevStats) > sStatsUpdate * 1000)) {
```

`GetUptimeMillis()` is `GetTickCount64() - s_start_time`, measured from amuleGUI's **own** start, so it begins near zero - and `msPrevStats` is seeded to zero. On the first poll the test asks whether more than an interval has elapsed when nothing has elapsed at all, so it is false and the tree waits out a full interval before it is ever requested. `statgraphs->DoRequery()` on the next line is unconditional, which is why only the tree looked broken.

### Fix

An explicit "has this connection fetched the tree yet" flag makes the first fetch unconditional; the interval governs every fetch after it. `sStatsUpdate > 0` still short-circuits, so setting the interval to zero disables polling exactly as before.

The state also moves off a function-local `static` and onto the app object, which fixes a second symptom of the same cause: the static survived a disconnect, so after a reconnect the tree kept showing the **previous** daemon's snapshot until an interval measured against the old connection expired. `ResetStatsTreePoll()` is called wherever a connection begins - `Startup()` and `FinishReconnect()` - alongside the existing `knownfiles->ArmReconnectReconcile()`, which handles the same concern for the file lists.

### Second fix in the same block

The elapsed comparison is now unsigned throughout rather than casting the difference to `int`.

The subtraction is modular, so it yields the true elapsed time even across the point where a 32-bit millisecond counter wraps - `0x00000100 - 0xFFFFFF00` is 512 ms, which is exactly why tick deltas are compared unsigned. The cast threw that away: a difference above `INT_MAX` reads as negative, the comparison is false, and the tree would **stop refreshing** rather than refresh late.

Reachable only by disabling polling for some 25 days and then re-enabling it without reconnecting, so this is not a bug anyone has hit - but the cast bought nothing, and the reason it has to be unsigned is now recorded in a comment so it does not come back.

### Verification

Built clean, no new warnings. Tested by connecting amuleGUI to a remote core: the Statistics tree is populated on the first poll instead of after 30 s. clang-format 18 whole-file clean; clang-tidy Tier-1 and Tier-2 clean on changed lines, 0 compiler errors on both.
