### PR TITLE
feat(gui): offer Length, Bitrate and Codec columns on shared files

### DIFF
--- a/src/SharedFilesCtrl.cpp
+++ b/src/SharedFilesCtrl.cpp
@@ -51,7 +51,8 @@
 #include "DownloadQueue.h"    // Needed for CDownloadQueue
 #include "TransferWnd.h"      // Needed for CTransferWnd
 #include "Logger.h"           // Needed for AddLogLine
-#include "OtherFunctions.h"   // Needed for FormatLocalDateTime, IsMediaProbeCandidate
+#include "OtherFunctions.h"   // Needed for FormatLocalDateTime, CastSecondsToHM, FormatMediaCodec
+#include <tags/FileTags.h>    // Needed for FT_MEDIA_LENGTH / _BITRATE / _CODEC
 
 namespace
 {
@@ -167,6 +168,12 @@ CSharedFilesCtrl::CSharedFilesCtrl(wxWindow *parent, int id, const wxPoint &pos,
 	AddTextColumn(_("Shared since"), COLUMN_SHARED_SINCE, "H", 130, wxALIGN_LEFT, colFlags);
 	AddTextColumn(_("Last upload"), COLUMN_SHARED_LASTUP, "L", 130, wxALIGN_LEFT, colFlags);
 	AddTextColumn(_("Directory Path"), COLUMN_SHARED_PATH, "D", 430, wxALIGN_LEFT, colFlags);
+	// Media metadata, the same FT_MEDIA_* tags and wording the search list
+	// uses. Keys are lowercase because "L" and "C" are already taken above by
+	// Last upload and Complete Sources, and the store is case-sensitive.
+	AddTextColumn(_("Length"), COLUMN_SHARED_MEDIA_LENGTH, "l", 80, wxALIGN_LEFT, colFlags);
+	AddTextColumn(_("Bitrate"), COLUMN_SHARED_MEDIA_BITRATE, "b", 80, wxALIGN_LEFT, colFlags);
+	AddTextColumn(_("Codec"), COLUMN_SHARED_MEDIA_CODEC, "c", 80, wxALIGN_LEFT, colFlags);
 
 	AppendSpacerColumn(COLUMN_SHARED_SPACER);
 
@@ -175,6 +182,17 @@ CSharedFilesCtrl::CSharedFilesCtrl(wxWindow *parent, int id, const wxPoint &pos,
 	// Default sort is by name, ascending; LoadColumnSettings() replaces it
 	// when the config has something saved.
 	ApplySorting(COLUMN_SHARED_NAME, 0);
+
+	// The media columns are only filled for files ffprobe has been run over,
+	// so a share that has never been probed would gain three empty columns
+	// for everyone. Listed in the header menu, hidden until asked for --
+	// widths above are what they get when enabled, which is why they are not
+	// registered as zero-width. Set before LoadColumnSettings() so anything
+	// the user saved wins, the same ordering CServerListCtrl uses for its
+	// wire-flag columns.
+	SetColumnHidden(COLUMN_SHARED_MEDIA_LENGTH, true, 0);
+	SetColumnHidden(COLUMN_SHARED_MEDIA_BITRATE, true, 0);
+	SetColumnHidden(COLUMN_SHARED_MEDIA_CODEC, true, 0);
 
 	m_columnStore.SetTableName("Shared");
 	LoadColumnSettings();
@@ -666,6 +684,23 @@ wxString CSharedFilesCtrl::GetItemColumnText(wxUIntPtr item, unsigned column) co
 		// destination once completed (EC_TAG_KNOWNFILE_PATH in
 		// the remote GUI).
 		return file->GetFilePath().GetPrintable();
+
+	// Media tags, rendered exactly as the search list renders them so the
+	// same file reads the same in both. Empty when never probed.
+	case COLUMN_SHARED_MEDIA_LENGTH: {
+		uint32 lenSec = file->GetIntTagValue(FT_MEDIA_LENGTH);
+		return lenSec ? CastSecondsToHM(lenSec) : wxString();
+	}
+
+	case COLUMN_SHARED_MEDIA_BITRATE: {
+		uint32 bitrate = file->GetIntTagValue(FT_MEDIA_BITRATE);
+		return bitrate ? wxString(CFormat(wxT("%u kbps")) % bitrate) : wxString();
+	}
+
+	case COLUMN_SHARED_MEDIA_CODEC: {
+		const wxString &codec = file->GetStrTagValue(FT_MEDIA_CODEC);
+		return codec.IsEmpty() ? wxString() : FormatMediaCodec(codec);
+	}
 
 	default:
 		return wxEmptyString;
@@ -1175,6 +1210,25 @@ void CSharedFilesCtrl::OnEditComment(wxCommandEvent &WXUNUSED(event))
 	}
 }
 
+namespace
+{
+// Empty (never probed) sorts last whichever way the column is sorted, so the
+// rows that do have a value stay together at the top.
+int CompareMediaInt(uint32 v1, uint32 v2, int modifier)
+{
+	if (!v1 && !v2) {
+		return 0;
+	}
+	if (!v1) {
+		return 1;
+	}
+	if (!v2) {
+		return -1;
+	}
+	return modifier * CmpAny(v1, v2);
+}
+} // namespace
+
 int CSharedFilesCtrl::CompareItemData(
 	wxUIntPtr data1, wxUIntPtr data2, unsigned column, bool alt, int modifier) const
 {
@@ -1259,6 +1313,33 @@ int CSharedFilesCtrl::CompareItemData(
 	// Directory path asc (status-agnostic: the Temp dir for a partfile)
 	case COLUMN_SHARED_PATH:
 		return mod * CmpAny(file1->GetFilePath(), file2->GetFilePath());
+
+	// Media tags. Unprobed files sort last in both directions rather than
+	// counting as zero, which would bury the probed rows under them on an
+	// ascending sort -- the same rule the search list applies.
+	case COLUMN_SHARED_MEDIA_LENGTH:
+		return CompareMediaInt(
+			file1->GetIntTagValue(FT_MEDIA_LENGTH), file2->GetIntTagValue(FT_MEDIA_LENGTH), mod);
+
+	case COLUMN_SHARED_MEDIA_BITRATE:
+		return CompareMediaInt(file1->GetIntTagValue(FT_MEDIA_BITRATE),
+			file2->GetIntTagValue(FT_MEDIA_BITRATE),
+			mod);
+
+	case COLUMN_SHARED_MEDIA_CODEC: {
+		const wxString c1 = FormatMediaCodec(file1->GetStrTagValue(FT_MEDIA_CODEC));
+		const wxString c2 = FormatMediaCodec(file2->GetStrTagValue(FT_MEDIA_CODEC));
+		if (c1.IsEmpty() && c2.IsEmpty()) {
+			return 0;
+		}
+		if (c1.IsEmpty()) {
+			return 1;
+		}
+		if (c2.IsEmpty()) {
+			return -1;
+		}
+		return mod * c1.CmpNoCase(c2);
+	}
 
 	default:
 		return 0;

--- a/src/SharedFilesCtrl.h
+++ b/src/SharedFilesCtrl.h
@@ -43,9 +43,15 @@
 #define COLUMN_SHARED_SINCE 11
 #define COLUMN_SHARED_LASTUP 12
 #define COLUMN_SHARED_PATH 13
+//! Media metadata from FT_MEDIA_*, the same tags the search list shows.
+//! Populated only for files ffprobe has been run over, so these start
+//! hidden; see the SetColumnHidden() calls in the constructor.
+#define COLUMN_SHARED_MEDIA_LENGTH 14
+#define COLUMN_SHARED_MEDIA_BITRATE 15
+#define COLUMN_SHARED_MEDIA_CODEC 16
 //! Always empty. Absorbs the macOS trailing-column sizing; see
 //! CMuleDataViewCtrl::AppendSpacerColumn().
-#define COLUMN_SHARED_SPACER 14
+#define COLUMN_SHARED_SPACER 17
 
 class CSharedFileList;
 class CKnownFile;

--- a/src/webapi/static/js/views/shared.js
+++ b/src/webapi/static/js/views/shared.js
@@ -9,7 +9,7 @@ import { data } from "../events.js";
 import { html, useState, useEffect, useStore } from "../dom.js";
 import { checkCell, listPlaceholder, toast, confirmDialog } from "../components.js";
 import { VirtualTable, sortRows, textMatcher, useTablePrefs, ColumnPicker } from "../table.js";
-import { formatBytes, formatFreeSpace, formatInt, formatSpeed, formatTimestamp, twin } from "../format.js";
+import { formatBytes, formatDuration, formatFreeSpace, formatInt, formatSpeed, formatTimestamp, twin } from "../format.js";
 import { t, tn, terr } from "../i18n.js";
 import { SharedDetail } from "./shared-detail.js";
 import { SplitDetail } from "./split-detail.js";
@@ -18,6 +18,12 @@ const PRIORITIES = ["auto", "very_low", "low", "normal", "high", "release"]
   .map((v) => [v, t("shared_prio_" + v)]);
 
 const STATUS_FILTERS = [["all", t("shared_status_all")], ["uploading", t("shared_status_uploading")]];
+
+// Columns the picker offers but the list does not lead with. The timestamps are
+// rarely what a share is scanned for; the media columns are only filled for
+// files ffprobe has been run over, so on a share that has never been probed
+// they would be three empty columns for everyone.
+const DEFAULT_HIDDEN = ["last_upload", "shared_since", "media_length", "media_bitrate", "media_codec"];
 
 export default function Shared({ isGuest }) {
   // undefined until the first snapshot lands, [] once the share is known
@@ -28,7 +34,7 @@ export default function Shared({ isGuest }) {
   const disk = (useStore("status") || {}).disk || {};
   const [selection, setSelection] = useState(() => new Set());
   const { sortKey, sortDir, hidden, widths, toggleSort, toggleCol, setWidth, resetPrefs } =
-    useTablePrefs("shared", { sortKey: "name", sortDir: 1, hidden: ["last_upload", "shared_since"] });
+    useTablePrefs("shared", { sortKey: "name", sortDir: 1, hidden: DEFAULT_HIDDEN });
   const [filterStatus, setFilterStatus] = useState("all");
   const [filterText, setFilterText] = useState("");
   const [verifying, setVerifying] = useState(false);
@@ -166,6 +172,18 @@ export default function Shared({ isGuest }) {
       sortVal: (s) => s.last_upload_at || 0, cell: (s) => formatTimestamp(s.last_upload_at) },
     { key: "shared_since", label: t("shared_shared_since"), width: "160px", sortable: true,
       sortVal: (s) => s.shared_since_at || 0, cell: (s) => formatTimestamp(s.shared_since_at) },
+    // Media metadata, same source and wording as the detail panel's Media
+    // section. `media` is null on the API when nothing has been probed, so
+    // every accessor goes through it defensively.
+    { key: "media_length", label: t("downloads_detail_media_length"), num: true, width: "90px", sortable: true,
+      sortVal: (s) => (s.media && s.media.duration_seconds) || 0,
+      cell: (s) => (s.media && s.media.duration_seconds) ? formatDuration(s.media.duration_seconds) : "" },
+    { key: "media_bitrate", label: t("downloads_detail_media_bitrate"), num: true, width: "100px", sortable: true,
+      sortVal: (s) => (s.media && s.media.bitrate_kilobits_per_second) || 0,
+      cell: (s) => (s.media && s.media.bitrate_kilobits_per_second) ? formatInt(s.media.bitrate_kilobits_per_second) : "" },
+    { key: "media_codec", label: t("downloads_detail_media_codec"), width: "100px", sortable: true,
+      sortVal: (s) => (s.media && s.media.codec) || "",
+      cell: (s) => (s.media && s.media.codec) || "" },
     { key: "priority", label: t("shared_priority"), width: "160px", sortable: true,
       sortVal: (s) => s.priority || "", cell: (s) => isGuest
         ? prioLabel(s)


### PR DESCRIPTION
Closes #1120.

The shared-files list gains the three media columns the search-results list already has, in both the desktop GUI and the Web UI. They are **hidden by default** and enabled from the column picker.

### No new data, and no new plumbing

The metadata was already travelling. `AddMediaTagsPresent()` puts `FT_MEDIA_*` into `CEC_SharedFile_Tag`, so amuleGUI already decoded it; `WriteSharedObject()` already emits `media` in the REST **list** response, not only the detail one, and the SSE diff already carries it. Both clients already displayed it one click deeper - the desktop file-detail dialog and the Web UI's shared-detail Media section.

So this is display only: no EC change, no REST field, no extra daemon work. The performance concern raised on the issue does not arise, because nothing additional is fetched or transmitted.

### No new strings either

`Length`, `Bitrate` and `Codec` are already translated for the search list and the detail dialog, and the Web UI already has `downloads_detail_media_*`. Both reuse those, so translators see nothing new and the catalogues are untouched.

### Hidden by default

Desktop follows `CServerListCtrl`'s wire-flag pattern: normal width in `AddTextColumn()` so the column has a sensible size when enabled, then `SetColumnHidden(..., true, 0)` **before** `LoadColumnSettings()`, so a saved user choice always wins. Web UI follows the clients view's `TAB_HIDDEN` convention with a named `DEFAULT_HIDDEN` set.

Unprobed files show an empty cell rather than a placeholder, and sort **last in both directions** - counting them as zero would bury the probed rows under them on an ascending sort. That is the rule the search list already applies.

### Verification

Desktop confirmed in aMuleGUI. Web UI confirmed against a live daemon with a real share: 1000 files returned, 28 carrying media, values populating all three columns (`dur=6267 kbps=2250 codec=avc`) and blank elsewhere.

Build clean; clang-format 18 whole-file clean and idempotent; clang-tidy Tier-1 and Tier-2 clean; `check-i18n.mjs` unchanged at 993 keys.
