### PR TITLE
feat(gui): offer Artist, Album and Title columns on search and shared files

### DIFF
--- a/src/SearchListCtrl.cpp
+++ b/src/SearchListCtrl.cpp
@@ -164,6 +164,27 @@ CSearchListCtrl::CSearchListCtrl(
 		80,
 		wxALIGN_LEFT,
 		wxDATAVIEW_COL_RESIZABLE | wxDATAVIEW_COL_SORTABLE);
+	// Visible like the three media columns above rather than hidden like the
+	// shared-files list's: a search result is read once, and a user hunting a
+	// track by artist wants the answer without opening the column picker.
+	AddTextColumn(_("Artist"),
+		CSearchListModel::COL_ARTIST,
+		"a",
+		120,
+		wxALIGN_LEFT,
+		wxDATAVIEW_COL_RESIZABLE | wxDATAVIEW_COL_SORTABLE);
+	AddTextColumn(_("Album"),
+		CSearchListModel::COL_ALBUM,
+		"b",
+		120,
+		wxALIGN_LEFT,
+		wxDATAVIEW_COL_RESIZABLE | wxDATAVIEW_COL_SORTABLE);
+	AddTextColumn(_("Title"),
+		CSearchListModel::COL_TITLE,
+		"t",
+		140,
+		wxALIGN_LEFT,
+		wxDATAVIEW_COL_RESIZABLE | wxDATAVIEW_COL_SORTABLE);
 	// Directories is almost always empty (only populated when the result
 	// came from a "view shared files" request, rare in practice), so put
 	// it at the end with the other usually-empty columns.
@@ -417,6 +438,26 @@ int CSearchListCtrl::GetSelectedItemCount() const
 	return static_cast<int>(GetSelectedFiles().size());
 }
 
+namespace
+{
+// Media tag columns sort empty last whichever way the column is sorted, so the
+// results that carry the tag stay together rather than being buried under the
+// ones that do not. Shared by all four of them.
+int CompareMediaStr(const wxString &a, const wxString &b, int modifier)
+{
+	if (a.IsEmpty() && b.IsEmpty()) {
+		return 0;
+	}
+	if (a.IsEmpty()) {
+		return 1;
+	}
+	if (b.IsEmpty()) {
+		return -1;
+	}
+	return modifier * CmpAny(a, b);
+}
+} // namespace
+
 int CSearchListCtrl::CompareFilesByColumn(
 	const CSearchFile *f1, const CSearchFile *f2, unsigned column, bool alt, int modifier) const
 {
@@ -510,17 +551,20 @@ int CSearchListCtrl::CompareFilesByColumn(
 	case CSearchListModel::COL_CODEC: {
 		const wxString c1 = FormatMediaCodec(f1->GetStrTagValue(FT_MEDIA_CODEC));
 		const wxString c2 = FormatMediaCodec(f2->GetStrTagValue(FT_MEDIA_CODEC));
-		if (c1.IsEmpty() && c2.IsEmpty()) {
-			return 0;
-		}
-		if (c1.IsEmpty()) {
-			return 1;
-		}
-		if (c2.IsEmpty()) {
-			return -1;
-		}
-		return modifier * CmpAny(c1, c2);
+		return CompareMediaStr(c1, c2, modifier);
 	}
+
+	case CSearchListModel::COL_ARTIST:
+		return CompareMediaStr(
+			f1->GetStrTagValue(FT_MEDIA_ARTIST), f2->GetStrTagValue(FT_MEDIA_ARTIST), modifier);
+
+	case CSearchListModel::COL_ALBUM:
+		return CompareMediaStr(
+			f1->GetStrTagValue(FT_MEDIA_ALBUM), f2->GetStrTagValue(FT_MEDIA_ALBUM), modifier);
+
+	case CSearchListModel::COL_TITLE:
+		return CompareMediaStr(
+			f1->GetStrTagValue(FT_MEDIA_TITLE), f2->GetStrTagValue(FT_MEDIA_TITLE), modifier);
 	}
 
 	return 0;

--- a/src/SearchListModel.cpp
+++ b/src/SearchListModel.cpp
@@ -303,6 +303,22 @@ void CSearchListModel::GetValue(wxVariant &variant, const wxDataViewItem &item, 
 		break;
 	}
 
+	// Artist / album / title ride in on the same result tags as the three
+	// above -- CSearchFile keeps every tag it does not consume itself -- and
+	// are published by both the ed2k offer and Kad. Shown verbatim: unlike
+	// codec there is no vocabulary to normalise.
+	case COL_ARTIST:
+		variant = file->GetStrTagValue(FT_MEDIA_ARTIST);
+		break;
+
+	case COL_ALBUM:
+		variant = file->GetStrTagValue(FT_MEDIA_ALBUM);
+		break;
+
+	case COL_TITLE:
+		variant = file->GetStrTagValue(FT_MEDIA_TITLE);
+		break;
+
 	case COL_DIRECTORY:
 		variant = file->GetDirectory();
 		break;

--- a/src/SearchListModel.h
+++ b/src/SearchListModel.h
@@ -164,6 +164,9 @@ public:
 		COL_LENGTH,
 		COL_BITRATE,
 		COL_CODEC,
+		COL_ARTIST,
+		COL_ALBUM,
+		COL_TITLE,
 		COL_DIRECTORY,
 		//! Always empty. macOS sizes the trailing column to the leftover
 		//! space, collapsing it to nothing once the columns are wider than

--- a/src/SharedFilesCtrl.cpp
+++ b/src/SharedFilesCtrl.cpp
@@ -174,6 +174,9 @@ CSharedFilesCtrl::CSharedFilesCtrl(wxWindow *parent, int id, const wxPoint &pos,
 	AddTextColumn(_("Length"), COLUMN_SHARED_MEDIA_LENGTH, "l", 80, wxALIGN_LEFT, colFlags);
 	AddTextColumn(_("Bitrate"), COLUMN_SHARED_MEDIA_BITRATE, "b", 80, wxALIGN_LEFT, colFlags);
 	AddTextColumn(_("Codec"), COLUMN_SHARED_MEDIA_CODEC, "c", 80, wxALIGN_LEFT, colFlags);
+	AddTextColumn(_("Artist"), COLUMN_SHARED_MEDIA_ARTIST, "a", 120, wxALIGN_LEFT, colFlags);
+	AddTextColumn(_("Album"), COLUMN_SHARED_MEDIA_ALBUM, "m", 120, wxALIGN_LEFT, colFlags);
+	AddTextColumn(_("Title"), COLUMN_SHARED_MEDIA_TITLE, "i", 140, wxALIGN_LEFT, colFlags);
 
 	AppendSpacerColumn(COLUMN_SHARED_SPACER);
 
@@ -193,6 +196,9 @@ CSharedFilesCtrl::CSharedFilesCtrl(wxWindow *parent, int id, const wxPoint &pos,
 	SetColumnHidden(COLUMN_SHARED_MEDIA_LENGTH, true, 0);
 	SetColumnHidden(COLUMN_SHARED_MEDIA_BITRATE, true, 0);
 	SetColumnHidden(COLUMN_SHARED_MEDIA_CODEC, true, 0);
+	SetColumnHidden(COLUMN_SHARED_MEDIA_ARTIST, true, 0);
+	SetColumnHidden(COLUMN_SHARED_MEDIA_ALBUM, true, 0);
+	SetColumnHidden(COLUMN_SHARED_MEDIA_TITLE, true, 0);
 
 	m_columnStore.SetTableName("Shared");
 	LoadColumnSettings();
@@ -701,6 +707,16 @@ wxString CSharedFilesCtrl::GetItemColumnText(wxUIntPtr item, unsigned column) co
 		const wxString &codec = file->GetStrTagValue(FT_MEDIA_CODEC);
 		return codec.IsEmpty() ? wxString() : FormatMediaCodec(codec);
 	}
+
+	// Shown verbatim: unlike codec there is no vocabulary to normalise.
+	case COLUMN_SHARED_MEDIA_ARTIST:
+		return file->GetStrTagValue(FT_MEDIA_ARTIST);
+
+	case COLUMN_SHARED_MEDIA_ALBUM:
+		return file->GetStrTagValue(FT_MEDIA_ALBUM);
+
+	case COLUMN_SHARED_MEDIA_TITLE:
+		return file->GetStrTagValue(FT_MEDIA_TITLE);
 
 	default:
 		return wxEmptyString;
@@ -1214,6 +1230,20 @@ namespace
 {
 // Empty (never probed) sorts last whichever way the column is sorted, so the
 // rows that do have a value stay together at the top.
+int CompareMediaStr(const wxString &a, const wxString &b, int modifier)
+{
+	if (a.IsEmpty() && b.IsEmpty()) {
+		return 0;
+	}
+	if (a.IsEmpty()) {
+		return 1;
+	}
+	if (b.IsEmpty()) {
+		return -1;
+	}
+	return modifier * a.CmpNoCase(b);
+}
+
 int CompareMediaInt(uint32 v1, uint32 v2, int modifier)
 {
 	if (!v1 && !v2) {
@@ -1326,20 +1356,22 @@ int CSharedFilesCtrl::CompareItemData(
 			file2->GetIntTagValue(FT_MEDIA_BITRATE),
 			mod);
 
-	case COLUMN_SHARED_MEDIA_CODEC: {
-		const wxString c1 = FormatMediaCodec(file1->GetStrTagValue(FT_MEDIA_CODEC));
-		const wxString c2 = FormatMediaCodec(file2->GetStrTagValue(FT_MEDIA_CODEC));
-		if (c1.IsEmpty() && c2.IsEmpty()) {
-			return 0;
-		}
-		if (c1.IsEmpty()) {
-			return 1;
-		}
-		if (c2.IsEmpty()) {
-			return -1;
-		}
-		return mod * c1.CmpNoCase(c2);
-	}
+	case COLUMN_SHARED_MEDIA_CODEC:
+		return CompareMediaStr(FormatMediaCodec(file1->GetStrTagValue(FT_MEDIA_CODEC)),
+			FormatMediaCodec(file2->GetStrTagValue(FT_MEDIA_CODEC)),
+			mod);
+
+	case COLUMN_SHARED_MEDIA_ARTIST:
+		return CompareMediaStr(
+			file1->GetStrTagValue(FT_MEDIA_ARTIST), file2->GetStrTagValue(FT_MEDIA_ARTIST), mod);
+
+	case COLUMN_SHARED_MEDIA_ALBUM:
+		return CompareMediaStr(
+			file1->GetStrTagValue(FT_MEDIA_ALBUM), file2->GetStrTagValue(FT_MEDIA_ALBUM), mod);
+
+	case COLUMN_SHARED_MEDIA_TITLE:
+		return CompareMediaStr(
+			file1->GetStrTagValue(FT_MEDIA_TITLE), file2->GetStrTagValue(FT_MEDIA_TITLE), mod);
 
 	default:
 		return 0;

--- a/src/SharedFilesCtrl.h
+++ b/src/SharedFilesCtrl.h
@@ -49,9 +49,12 @@
 #define COLUMN_SHARED_MEDIA_LENGTH 14
 #define COLUMN_SHARED_MEDIA_BITRATE 15
 #define COLUMN_SHARED_MEDIA_CODEC 16
+#define COLUMN_SHARED_MEDIA_ARTIST 17
+#define COLUMN_SHARED_MEDIA_ALBUM 18
+#define COLUMN_SHARED_MEDIA_TITLE 19
 //! Always empty. Absorbs the macOS trailing-column sizing; see
 //! CMuleDataViewCtrl::AppendSpacerColumn().
-#define COLUMN_SHARED_SPACER 17
+#define COLUMN_SHARED_SPACER 20
 
 class CSharedFileList;
 class CKnownFile;

--- a/src/webapi/static/js/views/search.js
+++ b/src/webapi/static/js/views/search.js
@@ -143,8 +143,8 @@ function ResultsPane({ tab, categories }) {
   const browse = tab.kind === "browse";
   const { sortKey, sortDir, hidden, widths, toggleSort, toggleCol, setWidth, resetPrefs } =
     useTablePrefs(browse ? "search-browse" : "search", browse
-      ? { sortKey: "directory", sortDir: 1, hidden: ["sources", "rating", "status", "length", "bitrate_kilobits_per_second", "codec"] }
-      : { sortKey: "sources", sortDir: -1, hidden: ["directory", "length", "bitrate_kilobits_per_second", "codec"] });
+      ? { sortKey: "directory", sortDir: 1, hidden: ["sources", "rating", "status", "length", "bitrate_kilobits_per_second", "codec", "artist", "album", "media_title"] }
+      : { sortKey: "sources", sortDir: -1, hidden: ["directory", "length", "bitrate_kilobits_per_second", "codec", "artist", "album", "media_title"] });
 
   // Selection, filters and per-row choices belong to the TAB, not to this
   // component: switching tabs and coming back must restore them.
@@ -285,6 +285,12 @@ function ResultsPane({ tab, categories }) {
       cell: (r) => (r.media && r.media.bitrate_kilobits_per_second) ? formatInt(r.media.bitrate_kilobits_per_second) : "" },
     { key: "codec", label: t("downloads_detail_media_codec"), width: "90px", sortable: true,
       sortVal: (r) => (r.media && r.media.codec) || "", cell: (r) => (r.media && r.media.codec) || "" },
+    { key: "artist", label: t("downloads_detail_media_artist"), width: "130px", sortable: true,
+      sortVal: (r) => (r.media && r.media.artist) || "", cell: (r) => (r.media && r.media.artist) || "" },
+    { key: "album", label: t("downloads_detail_media_album"), width: "130px", sortable: true,
+      sortVal: (r) => (r.media && r.media.album) || "", cell: (r) => (r.media && r.media.album) || "" },
+    { key: "media_title", label: t("downloads_detail_media_title"), width: "150px", sortable: true,
+      sortVal: (r) => (r.media && r.media.title) || "", cell: (r) => (r.media && r.media.title) || "" },
     { key: "actions", label: t("search_actions"), cls: "row-actions", width: "220px",
       cell: (r) => html`
         <span class="admin-only">

--- a/src/webapi/static/js/views/shared.js
+++ b/src/webapi/static/js/views/shared.js
@@ -19,11 +19,8 @@ const PRIORITIES = ["auto", "very_low", "low", "normal", "high", "release"]
 
 const STATUS_FILTERS = [["all", t("shared_status_all")], ["uploading", t("shared_status_uploading")]];
 
-// Columns the picker offers but the list does not lead with. The timestamps are
-// rarely what a share is scanned for; the media columns are only filled for
-// files ffprobe has been run over, so on a share that has never been probed
-// they would be three empty columns for everyone.
-const DEFAULT_HIDDEN = ["last_upload", "shared_since", "media_length", "media_bitrate", "media_codec"];
+const DEFAULT_HIDDEN = ["last_upload", "shared_since", "media_length", "media_bitrate", "media_codec",
+  "media_artist", "media_album", "media_title"];
 
 export default function Shared({ isGuest }) {
   // undefined until the first snapshot lands, [] once the share is known
@@ -172,9 +169,6 @@ export default function Shared({ isGuest }) {
       sortVal: (s) => s.last_upload_at || 0, cell: (s) => formatTimestamp(s.last_upload_at) },
     { key: "shared_since", label: t("shared_shared_since"), width: "160px", sortable: true,
       sortVal: (s) => s.shared_since_at || 0, cell: (s) => formatTimestamp(s.shared_since_at) },
-    // Media metadata, same source and wording as the detail panel's Media
-    // section. `media` is null on the API when nothing has been probed, so
-    // every accessor goes through it defensively.
     { key: "media_length", label: t("downloads_detail_media_length"), num: true, width: "90px", sortable: true,
       sortVal: (s) => (s.media && s.media.duration_seconds) || 0,
       cell: (s) => (s.media && s.media.duration_seconds) ? formatDuration(s.media.duration_seconds) : "" },
@@ -184,6 +178,15 @@ export default function Shared({ isGuest }) {
     { key: "media_codec", label: t("downloads_detail_media_codec"), width: "100px", sortable: true,
       sortVal: (s) => (s.media && s.media.codec) || "",
       cell: (s) => (s.media && s.media.codec) || "" },
+    { key: "media_artist", label: t("downloads_detail_media_artist"), width: "130px", sortable: true,
+      sortVal: (s) => (s.media && s.media.artist) || "",
+      cell: (s) => (s.media && s.media.artist) || "" },
+    { key: "media_album", label: t("downloads_detail_media_album"), width: "130px", sortable: true,
+      sortVal: (s) => (s.media && s.media.album) || "",
+      cell: (s) => (s.media && s.media.album) || "" },
+    { key: "media_title", label: t("downloads_detail_media_title"), width: "150px", sortable: true,
+      sortVal: (s) => (s.media && s.media.title) || "",
+      cell: (s) => (s.media && s.media.title) || "" },
     { key: "priority", label: t("shared_priority"), width: "160px", sortable: true,
       sortVal: (s) => s.priority || "", cell: (s) => isGuest
         ? prioLabel(s)


### PR DESCRIPTION
Closes #1109.

Adds the three remaining media columns to both lists in both UIs. Each new column follows whatever its Length / Bitrate / Codec neighbours already do in that list, which is not the same everywhere:

| List | Length / Bitrate / Codec | Artist / Album / Title |
|---|---|---|
| Desktop search | visible | visible |
| Web UI search | hidden | hidden |
| Desktop shared | hidden (#1343) | hidden |
| Web UI shared | hidden (#1343) | hidden |

The desktop/Web UI disagreement on the search list predates this and is left as it is rather than changed silently in either direction.

Worth knowing before merging: on ed2k these three are usually empty. Measured against a live global search, 241 of 500 results carried media, with duration and bitrate on all 241 but codec on 13 and artist, album and title on none. Kad publishes all six explicitly (`_aMetaTags[]` in `Search.cpp`), so Kad results are where they actually appear - and our own shares carry them once ffprobe has run, so a peer on current aMule publishes them too.

### Already probed, published and transported

Nothing new is fetched or sent. `MediaProbe.cpp` already asks ffprobe for `format_tags=artist,title,album` and `stream_tags=artist,title,album`. `CKnownFile::CreateOfferedFilePacket()` already publishes all six media tags to servers and peers, and Kad does too. `AddMediaTagsPresent()` already puts all six on the EC wire for both `CEC_SharedFile_Tag` and `CEC_SearchFile_Tag`, and `SearchJson.cpp` already emits `artist`, `album` and `title` in the REST search response.

On the search side the tags survive because `CSearchFile`'s parser keeps every tag it does not consume itself (`default: AddTagUnique(tag)`), which is the same route the existing three columns read through. So this is display only, on all four surfaces.

### No new strings

`_("Artist")`, `_("Album")` and `_("Title")` are already translated for the file-detail dialog, and the Web UI already has `downloads_detail_media_artist/_album/_title`. Catalogues untouched; `check-i18n.mjs` unchanged at 993 keys.

### Sorting rule factored out

The empty-last comparison the codec column used is now a `CompareMediaStr()` helper in each control, and the existing codec comparators are switched to it. That replaces what would otherwise have been five copies of the same block with one per file.

### Comment removal

This also drops the two comment blocks #1343 added to `shared.js`. The Web UI convention is that the JS carries no comment where the code says what it does, and `DEFAULT_HIDDEN` plus the column definitions do.

### Verification

Desktop and Web UI built clean; clang-format 18 whole-file clean and idempotent; clang-tidy Tier-1 and Tier-2 clean, 0 compiler errors on both.
