### PR TITLE
feat(net): add the addressing decisions peer identity needs

### DIFF
--- a/src/NetworkAddress.h
+++ b/src/NetworkAddress.h
@@ -33,6 +33,44 @@
 
 #include <wx/string.h>
 
+namespace NetworkAddressPolicy
+{
+struct IPv6ExcludedPrefix
+{
+	std::array<std::uint8_t, 16> bytes;
+	unsigned bits;
+	const char *name;
+};
+
+constexpr IPv6ExcludedPrefix kIPv6ExcludedPrefixes[] = { { {}, 128, "Unspecified" },
+	{ { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1 }, 128, "Loopback" },
+	{ { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xff, 0xff }, 96, "IPv4-mapped" },
+	{ { 0x00, 0x64, 0xff, 0x9b }, 96, "Well-known NAT64" },
+	{ { 0x00, 0x64, 0xff, 0x9b, 0x00, 0x01 }, 48, "Local-use NAT64" },
+	{ { 0x01, 0x00 }, 64, "Discard-only" },
+	{ { 0x20, 0x01 }, 32, "Teredo" },
+	{ { 0x20, 0x01, 0x00, 0x20 }, 28, "ORCHIDv2" },
+	{ { 0x20, 0x01, 0x0d, 0xb8 }, 32, "Documentation" },
+	{ { 0x20, 0x02 }, 16, "6to4" },
+	{ { 0x5f, 0x00 }, 16, "Segment routing SIDs" },
+	{ { 0xfc }, 7, "Unique-local" },
+	{ { 0xfe, 0x80 }, 10, "Link-local" },
+	{ { 0xfe, 0xc0 }, 10, "Deprecated site-local" },
+	{ { 0xff }, 8, "Multicast" } };
+
+inline bool MatchesPrefix(
+	const std::array<std::uint8_t, 16> &address, const IPv6ExcludedPrefix &prefix) noexcept
+{
+	for (unsigned bit = 0; bit < prefix.bits; ++bit) {
+		const unsigned mask = 0x80u >> (bit % 8);
+		if ((address[bit / 8] & mask) != (prefix.bytes[bit / 8] & mask)) {
+			return false;
+		}
+	}
+	return true;
+}
+} // namespace NetworkAddressPolicy
+
 /**
  * The internal, family-agnostic address type.
  *
@@ -518,38 +556,15 @@ public:
 	 */
 	bool IsGloballyRoutableIPv6() const noexcept
 	{
-		if (!IsIPv6() || IsIPv4Mapped() || IsUnspecified()) {
+		if (!IsIPv6()) {
 			return false;
 		}
-		// The prefixes, all from RFC 4291 except fc00::/7 (RFC 4193). These
-		// were asio's address_v6 predicates until this header dropped asio;
-		// each is one prefix test, so restating them costs less than the
-		// library did and pins them to this file's stated rule.
-		if (IsLoopbackIPv6()) {
-			return false;
-		}
-		if (m_octets[0] == 0x20 && m_octets[1] == 0x01 && m_octets[2] == 0 && m_octets[3] == 0) {
-			return false; // 2001::/32, Teredo.
-		}
-		if (m_octets[0] == 0x20 && m_octets[1] == 0x02) {
-			return false; // 2002::/16, 6to4.
-		}
-		if (m_octets[0] == 0xFF) {
-			return false; // ff00::/8, multicast.
-		}
-		if (m_octets[0] == 0xFE) {
-			const std::uint8_t top = static_cast<std::uint8_t>(m_octets[1] & 0xC0);
-			if (top == 0x80) {
-				return false; // fe80::/10, link-local.
-			}
-			if (top == 0xC0) {
-				return false; // fec0::/10, the deprecated site-local range.
+		for (const auto &prefix : NetworkAddressPolicy::kIPv6ExcludedPrefixes) {
+			if (NetworkAddressPolicy::MatchesPrefix(m_octets, prefix)) {
+				return false;
 			}
 		}
-		// fc00::/7, unique-local. asio's is_site_local() only ever covered the
-		// deprecated fec0::/10 above, so this was tested here rather than
-		// assumed even when asio was in use.
-		return (m_octets[0] & 0xFE) != 0xFC;
+		return true;
 	}
 
 	/**
@@ -670,17 +685,6 @@ private:
 	std::uint32_t EmbeddedIPv4HostOrder() const noexcept
 	{
 		return PackOctets(m_octets[12], m_octets[13], m_octets[14], m_octets[15]);
-	}
-
-	/** @c ::1 -- fifteen zero octets then a one. */
-	bool IsLoopbackIPv6() const noexcept
-	{
-		for (int i = 0; i < 15; ++i) {
-			if (m_octets[i] != 0) {
-				return false;
-			}
-		}
-		return m_octets[15] == 1;
 	}
 
 	/**

--- a/src/PeerAddressing.h
+++ b/src/PeerAddressing.h
@@ -32,20 +32,17 @@
 /**
  * What identifies a peer, once a peer can be IPv6.
  *
- * aMule identified a peer by a 32-bit address, so an inbound IPv6 peer was
- * accepted by the socket and then dropped: `CClientList` had nothing to index
- * it under, and the ed2k UDP handlers had nothing to look it up by. The
- * decisions that widening needs are collected here, away from the app classes
- * that carry them out, so each one is a value function with a test rather than a
- * condition buried in a 3000-line file.
+ * These value policies prepare peer-address widening without changing production
+ * call sites. Socket-ingress normalization belongs to the later call-sites PR;
+ * local unmapping here defensively handles both native and mapped IPv4.
  *
  * Three separate questions live here, and they deliberately give different
  * answers for the same address:
  *
  *  - **Identity.** Two peers are the same peer iff they have the same index
- *    key. Aggregating distinct hosts here would merge them -- the failure this
- *    tree has already had once, when an absent address was banned as the key
- *    0.0.0.0 and every client with an unknown address read back as banned.
+ *    key. Aggregating distinct hosts here would merge them. Keeping absence
+ *    separate from 0.0.0.0 is a prevention/hardening invariant, not a claim
+ *    that #1314 shipped an unknown-address ban bug.
  *  - **Rate limiting.** A budget is per *subscriber*, which under IPv6 is not
  *    per address. Aggregating is the point here, and the amount of aggregation
  *    is a decision, not a detail.
@@ -125,16 +122,13 @@ inline bool HasEd2kWireForm(const CNetworkAddress &address) noexcept
  */
 inline bool SupportsEd2kUdpObfuscation(const CNetworkAddress &address) noexcept
 {
-	// Same test as HasEd2kWireForm() and deliberately a separate name: these
-	// are two different protocol facts that happen to have the same boundary,
-	// and a caller that means one should not read as meaning the other.
-	return HasEd2kWireForm(address);
+	return address.IsIPv4() || address.IsIPv4Mapped();
 }
 
 /** How far an inbound datagram from a given peer can be routed. */
 enum class EUdpRoute
 {
-	//! Not a usable peer address: absent, or the unspecified address.
+	//! Not a usable endpoint: absent/unspecified address, or zero port.
 	Reject,
 	//! Full service. Everything ed2k and Kad can do for a 32-bit peer.
 	Ed2kAndKad,
@@ -142,22 +136,26 @@ enum class EUdpRoute
 	Ed2kOnly
 };
 
+/** A UDP peer's address and advertised or observed UDP port. */
+struct UdpEndpoint
+{
+	CNetworkAddress address;
+	std::uint16_t port = 0;
+};
+
 /**
- * Classifies an inbound datagram's peer address.
+ * Classifies an inbound datagram's endpoint for future call sites.
  *
- * The @c Ed2kOnly case is the one this change adds. Before it, a native IPv6
- * datagram was dropped at the socket with a logged reason, because the handlers
- * below identified a peer by a 32-bit address. They no longer do, so the
- * datagram is now handled -- except by Kad, whose @c uint32 interface is a
- * documented conversion boundary (see the amule-address-widening design) and is
- * not widened here.
+ * This value policy is not wired into production handlers yet. Kad retains its
+ * IPv4 conversion boundary; native IPv6 can only select the ed2k route.
  *
  * Reject does not distinguish absent from unspecified: the caller holds the
  * address and can say which in its log, exactly as CMuleUDPSocket already does.
  */
-inline EUdpRoute ClassifyUdpPeer(const CNetworkAddress &address) noexcept
+inline EUdpRoute ClassifyUdpPeer(const UdpEndpoint &endpoint) noexcept
 {
-	if (address.IsAbsent() || address.IsUnspecified()) {
+	const CNetworkAddress address = endpoint.address.Unmapped();
+	if (endpoint.port == 0 || address.IsAbsent() || address.IsUnspecified()) {
 		return EUdpRoute::Reject;
 	}
 	return SupportsEd2kUdpObfuscation(address) ? EUdpRoute::Ed2kAndKad : EUdpRoute::Ed2kOnly;
@@ -165,7 +163,7 @@ inline EUdpRoute ClassifyUdpPeer(const CNetworkAddress &address) noexcept
 
 /**
  * Whether a client's advertised UDP port names it as the sender of a datagram
- * that arrived from @p sourcePort.
+ * that arrived from @p source, comparing both the address and UDP port.
  *
  * A peer advertises two ports and they are not the same number: the ed2k TCP
  * port it accepts connections on, and the UDP port it accepts datagrams on. A
@@ -184,12 +182,11 @@ inline EUdpRoute ClassifyUdpPeer(const CNetworkAddress &address) noexcept
  * closed instead, which costs nothing: a peer that advertised no UDP port could
  * not have been matched by an exact comparison either.
  */
-inline bool MatchesUdpSourcePort(std::uint16_t advertisedPort, std::uint16_t sourcePort) noexcept
+inline bool MatchesUdpSource(const UdpEndpoint &advertised, const UdpEndpoint &source) noexcept
 {
-	if (advertisedPort == 0 || sourcePort == 0) {
-		return false;
-	}
-	return advertisedPort == sourcePort;
+	return ClassifyUdpPeer(advertised) != EUdpRoute::Reject &&
+	       ClassifyUdpPeer(source) != EUdpRoute::Reject && advertised.port == source.port &&
+	       advertised.address.Unmapped() == source.address.Unmapped();
 }
 
 /**
@@ -199,6 +196,9 @@ inline bool MatchesUdpSourcePort(std::uint16_t advertisedPort, std::uint16_t sou
  * is the smallest unit that behaves like "one customer". Larger aggregation
  * (/56, /48) would put unrelated subscribers of one provider in a single
  * bucket, where one of them could exhaust the budget for the others.
+ * The eMuleQt /128 alternative is consciously rejected: rotating addresses
+ * within a delegated /64 would evade per-host accounting. This /64 policy is
+ * accounting only, never identity, index, ban or routing policy.
  */
 constexpr unsigned kIPv6RateLimitPrefixBits = 64;
 

--- a/src/PeerAddressing.h
+++ b/src/PeerAddressing.h
@@ -154,7 +154,7 @@ struct UdpEndpoint
  */
 inline EUdpRoute ClassifyUdpPeer(const UdpEndpoint &endpoint) noexcept
 {
-	const CNetworkAddress address = endpoint.address.Unmapped();
+	const CNetworkAddress address = IndexKey(endpoint.address);
 	if (endpoint.port == 0 || address.IsAbsent() || address.IsUnspecified()) {
 		return EUdpRoute::Reject;
 	}
@@ -186,7 +186,7 @@ inline bool MatchesUdpSource(const UdpEndpoint &advertised, const UdpEndpoint &s
 {
 	return ClassifyUdpPeer(advertised) != EUdpRoute::Reject &&
 	       ClassifyUdpPeer(source) != EUdpRoute::Reject && advertised.port == source.port &&
-	       advertised.address.Unmapped() == source.address.Unmapped();
+	       IndexKey(advertised.address) == IndexKey(source.address);
 }
 
 /**

--- a/src/PeerAddressing.h
+++ b/src/PeerAddressing.h
@@ -1,0 +1,256 @@
+//
+// This file is part of the aMule Project.
+//
+// Copyright (c) 2003-2026 aMule Team ( https://amule-org.github.io )
+//
+// Any parts of this program derived from the xMule, lMule or eMule project,
+// or contributed by third-party developers are copyrighted by their
+// respective authors.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301, USA
+//
+
+#ifndef PEERADDRESSING_H
+#define PEERADDRESSING_H
+
+#include "NetworkAddress.h"
+
+#include <cstdint>
+
+/**
+ * What identifies a peer, once a peer can be IPv6.
+ *
+ * aMule identified a peer by a 32-bit address, so an inbound IPv6 peer was
+ * accepted by the socket and then dropped: `CClientList` had nothing to index
+ * it under, and the ed2k UDP handlers had nothing to look it up by. The
+ * decisions that widening needs are collected here, away from the app classes
+ * that carry them out, so each one is a value function with a test rather than a
+ * condition buried in a 3000-line file.
+ *
+ * Three separate questions live here, and they deliberately give different
+ * answers for the same address:
+ *
+ *  - **Identity.** Two peers are the same peer iff they have the same index
+ *    key. Aggregating distinct hosts here would merge them -- the failure this
+ *    tree has already had once, when an absent address was banned as the key
+ *    0.0.0.0 and every client with an unknown address read back as banned.
+ *  - **Rate limiting.** A budget is per *subscriber*, which under IPv6 is not
+ *    per address. Aggregating is the point here, and the amount of aggregation
+ *    is a decision, not a detail.
+ *  - **Routing an inbound datagram.** Some subsystems cannot represent an IPv6
+ *    peer at all -- Kad by design, ed2k UDP obfuscation by protocol. Those
+ *    boundaries are reported, never crossed with a fabricated address.
+ *
+ * Nothing here fabricates an address. Every function that cannot answer for an
+ * address says so; an absent address stays absent all the way through.
+ */
+namespace PeerAddressing
+{
+
+/**
+ * Whether a peer with this address can be recorded in an address index.
+ *
+ * Only absence disqualifies. @c 0.0.0.0 and @c :: are odd addresses but they are
+ * addresses: a peer claiming one is a peer whose claim we know, which is not the
+ * same thing as a peer whose address we do not know. Keeping those two apart is
+ * the reason CNetworkAddress exists.
+ */
+inline bool IsIndexable(const CNetworkAddress &address) noexcept
+{
+	return address.IsPresent();
+}
+
+/**
+ * The key a peer is indexed under.
+ *
+ * IPv4-mapped forms are collapsed to plain IPv4 here, once. A peer that
+ * connects as @c 192.0.2.1 and later as @c ::ffff:192.0.2.1 is one peer over
+ * one family, and giving it two identities would let it hold two queue slots,
+ * two ban states and two credit records. CNetworkAddress deliberately does not
+ * normalise on comparison -- that keeps its ordering total -- so the
+ * normalisation is spelled out at the one place identity is decided.
+ *
+ * Everything else is returned unchanged, absence included: this never invents a
+ * key for a peer that has no address.
+ */
+inline CNetworkAddress IndexKey(const CNetworkAddress &address)
+{
+	return address.Unmapped();
+}
+
+/**
+ * Whether this peer can be named in an ed2k wire field or an on-disk record
+ * that holds a 32-bit address.
+ *
+ * The ed2k protocol carries a peer's address as 32 bits: source exchange, the
+ * server protocol, the relayed callback, the @c .part.met.seeds file. A native
+ * IPv6 peer has no such form, so it cannot be published or persisted through
+ * them -- and must be @b omitted rather than written as a zero, which would
+ * publish "0.0.0.0" to every peer that asked for sources.
+ *
+ * Widening those formats is a protocol change and needs its own capability bit,
+ * so this predicate is the boundary until one exists.
+ */
+inline bool HasEd2kWireForm(const CNetworkAddress &address) noexcept
+{
+	std::uint32_t unused = 0;
+	return address.ToIPv4NetworkOrder(unused);
+}
+
+/**
+ * Whether an inbound ed2k UDP datagram from this peer can be de-obfuscated.
+ *
+ * The ed2k UDP obfuscation key is MD5 over our user hash, a 32-bit address and
+ * a magic byte -- see CEncryptedDatagramSocket::DecryptReceivedClient(), where
+ * the receiver derives it from the sender's address, and EncryptSendClient(),
+ * where the sender derives it from its own public IPv4. The protocol has no
+ * IPv6 input to that key, so an obfuscated ed2k datagram from a native IPv6
+ * peer is undecryptable by any implementation, not just by this one.
+ *
+ * Feeding the derivation a zero would produce a wrong key, the packet would
+ * fail its magic-value check and be handled as junk, and nothing would record
+ * why. So the boundary is reported here instead.
+ */
+inline bool SupportsEd2kUdpObfuscation(const CNetworkAddress &address) noexcept
+{
+	// Same test as HasEd2kWireForm() and deliberately a separate name: these
+	// are two different protocol facts that happen to have the same boundary,
+	// and a caller that means one should not read as meaning the other.
+	return HasEd2kWireForm(address);
+}
+
+/** How far an inbound datagram from a given peer can be routed. */
+enum class EUdpRoute
+{
+	//! Not a usable peer address: absent, or the unspecified address.
+	Reject,
+	//! Full service. Everything ed2k and Kad can do for a 32-bit peer.
+	Ed2kAndKad,
+	//! ed2k only. Kad keeps its documented IPv4 interface.
+	Ed2kOnly
+};
+
+/**
+ * Classifies an inbound datagram's peer address.
+ *
+ * The @c Ed2kOnly case is the one this change adds. Before it, a native IPv6
+ * datagram was dropped at the socket with a logged reason, because the handlers
+ * below identified a peer by a 32-bit address. They no longer do, so the
+ * datagram is now handled -- except by Kad, whose @c uint32 interface is a
+ * documented conversion boundary (see the amule-address-widening design) and is
+ * not widened here.
+ *
+ * Reject does not distinguish absent from unspecified: the caller holds the
+ * address and can say which in its log, exactly as CMuleUDPSocket already does.
+ */
+inline EUdpRoute ClassifyUdpPeer(const CNetworkAddress &address) noexcept
+{
+	if (address.IsAbsent() || address.IsUnspecified()) {
+		return EUdpRoute::Reject;
+	}
+	return SupportsEd2kUdpObfuscation(address) ? EUdpRoute::Ed2kAndKad : EUdpRoute::Ed2kOnly;
+}
+
+/**
+ * Whether a client's advertised UDP port names it as the sender of a datagram
+ * that arrived from @p sourcePort.
+ *
+ * A peer advertises two ports and they are not the same number: the ed2k TCP
+ * port it accepts connections on, and the UDP port it accepts datagrams on. A
+ * lookup that identifies the sender of a datagram by the first of those matches
+ * nothing at all in the field, and does so silently -- it looks exactly like
+ * "we do not know this peer", which is also the honest answer for a stranger.
+ * Naming the port dimension in one predicate is what keeps the two apart at the
+ * call sites.
+ *
+ * Zero on either side is @b unknown, not a port, and never matches. A client we
+ * know by address carries a zero UDP port when it never advertised one, and
+ * treating that as a value to compare would make every such client a candidate
+ * for a datagram whose source port is also zero. Behind a carrier NAT one
+ * address is many peers, so that match would name an arbitrary one of them --
+ * and the rendezvous relay vouches for whoever this lookup returns. It fails
+ * closed instead, which costs nothing: a peer that advertised no UDP port could
+ * not have been matched by an exact comparison either.
+ */
+inline bool MatchesUdpSourcePort(std::uint16_t advertisedPort, std::uint16_t sourcePort) noexcept
+{
+	if (advertisedPort == 0 || sourcePort == 0) {
+		return false;
+	}
+	return advertisedPort == sourcePort;
+}
+
+/**
+ * How much of an IPv6 address a rate limit is counted against.
+ *
+ * A /64 is the smallest prefix an IPv6 subscriber is normally delegated, so it
+ * is the smallest unit that behaves like "one customer". Larger aggregation
+ * (/56, /48) would put unrelated subscribers of one provider in a single
+ * bucket, where one of them could exhaust the budget for the others.
+ */
+constexpr unsigned kIPv6RateLimitPrefixBits = 64;
+
+/**
+ * The address a per-peer rate limit is counted against.
+ *
+ * IPv4 counts per address, which is what the 32-bit throttles did, so an IPv4
+ * peer's budget is unchanged. IPv6 counts per /64.
+ *
+ * That asymmetry is the whole decision. An IPv4 address is roughly a host, so
+ * per-address is per-host. An IPv6 /128 is not: a subscriber delegated a /64
+ * can source every request from a fresh address, so a per-/128 limit counts to
+ * one forever and throttles nothing at all. Applying the IPv4 shape unchanged
+ * would therefore have been the same as removing the limit for IPv6.
+ *
+ * A mapped IPv4 address shares the IPv4 budget -- a peer must not double its
+ * allowance by respelling its address -- and absence has no budget, because it
+ * identifies nobody.
+ */
+inline CNetworkAddress RateLimitScope(const CNetworkAddress &address)
+{
+	const CNetworkAddress unmapped = address.Unmapped();
+	if (!unmapped.IsIPv6()) {
+		// IPv4, or absent. Either way this is already the scope.
+		return unmapped;
+	}
+	return unmapped.TruncatedToPrefix(kIPv6RateLimitPrefixBits);
+}
+
+/**
+ * Whether this address alone establishes that the peer accepts inbound
+ * connections.
+ *
+ * Answers only for native IPv6, and only for globally routable addresses.
+ *
+ * LowID is an IPv4 concept: it is inferred from the ed2k ID a server issued,
+ * and it means "behind something that will not accept an inbound connection".
+ * An IPv6 peer has no ed2k ID, so the ID carries no information about it -- and
+ * a peer whose ID field is zero would otherwise be read as firewalled and sent
+ * down the callback path, which for an IPv6 peer cannot work: the callback goes
+ * through an ed2k server or a Kad buddy, both of which speak 32-bit addresses.
+ *
+ * A link-local, unique-local, loopback or unspecified address proves nothing --
+ * aMule cannot dial it from here -- so those keep the existing rule rather than
+ * overriding it.
+ */
+inline bool IsDirectlyReachable(const CNetworkAddress &address) noexcept
+{
+	return address.IsGloballyRoutableIPv6();
+}
+
+} // namespace PeerAddressing
+
+#endif // PEERADDRESSING_H
+// File_checked_for_headers

--- a/unittests/tests/CMakeLists.txt
+++ b/unittests/tests/CMakeLists.txt
@@ -231,6 +231,39 @@ target_link_libraries (NetworkAddressTest
 	${Boost_LIBRARIES}
 )
 
+# Peer identity: what makes two peers the same peer once a peer can be IPv6, how
+# much of an IPv6 address a rate limit counts against, and how far an inbound
+# datagram can be routed. All decision logic over CNetworkAddress, so it is
+# testable without an app -- which is why it lives in a header of its own rather
+# than inside CClientList.
+add_executable (PeerAddressingTest
+	PeerAddressingTest.cpp
+	${CMAKE_SOURCE_DIR}/src/libs/common/Format.cpp
+	${CMAKE_SOURCE_DIR}/src/libs/common/strerror_r.c
+	# CNetworkAddress::FromString/ToString live in NetworkAddress.cpp: they are
+	# the only part of the type that still compiles Boost.Asio, and keeping them
+	# out of the header is what stops asio reaching most of src/. Every target
+	# whose include closure touches NetworkAddress.h therefore has to link this
+	# TU -- the type is no longer header-only.
+	${CMAKE_SOURCE_DIR}/src/NetworkAddress.cpp
+)
+
+add_test (NAME PeerAddressingTest
+	COMMAND PeerAddressingTest
+)
+
+target_include_directories (PeerAddressingTest
+	PRIVATE ${CMAKE_BINARY_DIR}
+	PRIVATE ${CMAKE_SOURCE_DIR}/src
+	PRIVATE ${CMAKE_SOURCE_DIR}/src/include
+	PRIVATE ${Boost_INCLUDE_DIR}
+)
+
+target_link_libraries (PeerAddressingTest
+	muleunit
+	${Boost_LIBRARIES}
+)
+
 add_executable (CUInt128Test
 	CUInt128Test.cpp
 	${CMAKE_SOURCE_DIR}/src/kademlia/utils/UInt128.cpp

--- a/unittests/tests/NetworkAddressTest.cpp
+++ b/unittests/tests/NetworkAddressTest.cpp
@@ -405,9 +405,72 @@ TEST(NetworkAddress, GloballyRoutableIPv4RejectsEveryUnroutableRange)
 // connect attempt on the far side.
 TEST(NetworkAddress, GloballyRoutableIPv6RejectsEveryUnreachableRange)
 {
-	// Routable: a documentation prefix (2001:db8::/32) is a global unicast
-	// address as far as the address itself can say.
-	ASSERT_TRUE(CNetworkAddress::FromString("2001:db8::1").IsGloballyRoutableIPv6());
+	ASSERT_FALSE(CNetworkAddress::FromString("2001:db8::1").IsGloballyRoutableIPv6());
+	for (const auto &prefix : NetworkAddressPolicy::kIPv6ExcludedPrefixes) {
+		ASSERT_TRUE(prefix.name[0] != '\0');
+		ASSERT_TRUE(prefix.bits > 0 && prefix.bits <= 128);
+		const auto first = CNetworkAddress::IPv6FromOctets(prefix.bytes);
+		auto lastBytes = prefix.bytes;
+		for (unsigned bit = prefix.bits; bit < 128; ++bit) {
+			lastBytes[bit / 8] |= static_cast<std::uint8_t>(0x80u >> (bit % 8));
+		}
+		ASSERT_FALSE(first.IsGloballyRoutableIPv6());
+		ASSERT_FALSE(CNetworkAddress::IPv6FromOctets(lastBytes).IsGloballyRoutableIPv6());
+		ASSERT_TRUE(NetworkAddressPolicy::MatchesPrefix(first.GetOctets(), prefix));
+		ASSERT_TRUE(NetworkAddressPolicy::MatchesPrefix(lastBytes, prefix));
+		// Flip each prefix bit: none may be ignored, including partial bytes.
+		for (unsigned bit = 0; bit < prefix.bits; ++bit) {
+			auto outside = prefix.bytes;
+			outside[bit / 8] ^= static_cast<std::uint8_t>(0x80u >> (bit % 8));
+			ASSERT_FALSE(NetworkAddressPolicy::MatchesPrefix(outside, prefix));
+		}
+	}
+	// Literal bounds are independent of the production exclusion table: removing
+	// an entry or changing its prefix length must not change these expectations.
+	const struct
+	{
+		const char *before;
+		const char *first;
+		const char *last;
+		const char *after;
+	} excludedRanges[] = {
+		// 64:ff9b::/96
+		{ "64:ff9a:ffff:ffff:ffff:ffff:ffff:ffff",
+			"64:ff9b::",
+			"64:ff9b::ffff:ffff",
+			"64:ff9b::1:0:0" },
+		// 64:ff9b:1::/48
+		{ "64:ff9b:0:ffff:ffff:ffff:ffff:ffff",
+			"64:ff9b:1::",
+			"64:ff9b:1:ffff:ffff:ffff:ffff:ffff",
+			"64:ff9b:2::" },
+		// 100::/64
+		{ "ff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+			"100::",
+			"100::ffff:ffff:ffff:ffff",
+			"100:0:0:1::" },
+		// 2001:20::/28
+		{ "2001:1f:ffff:ffff:ffff:ffff:ffff:ffff",
+			"2001:20::",
+			"2001:2f:ffff:ffff:ffff:ffff:ffff:ffff",
+			"2001:30::" },
+		// 2001:db8::/32
+		{ "2001:db7:ffff:ffff:ffff:ffff:ffff:ffff",
+			"2001:db8::",
+			"2001:db8:ffff:ffff:ffff:ffff:ffff:ffff",
+			"2001:db9::" },
+		// 5f00::/16
+		{ "5eff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+			"5f00::",
+			"5f00:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+			"5f01::" },
+	};
+	for (const auto &range : excludedRanges) {
+		ASSERT_TRUE(CNetworkAddress::FromString(range.before).IsGloballyRoutableIPv6());
+		ASSERT_FALSE(CNetworkAddress::FromString(range.first).IsGloballyRoutableIPv6());
+		ASSERT_FALSE(CNetworkAddress::FromString(range.last).IsGloballyRoutableIPv6());
+		ASSERT_TRUE(CNetworkAddress::FromString(range.after).IsGloballyRoutableIPv6());
+	}
 	ASSERT_TRUE(CNetworkAddress::FromString("2606:4700::1111").IsGloballyRoutableIPv6());
 
 	// Not an IPv6 address at all.

--- a/unittests/tests/PeerAddressingTest.cpp
+++ b/unittests/tests/PeerAddressingTest.cpp
@@ -1,0 +1,409 @@
+//
+// This file is part of the aMule Project.
+//
+// Copyright (c) 2003-2026 aMule Team ( https://amule-org.github.io )
+//
+// Any parts of this program derived from the xMule, lMule or eMule project,
+// or contributed by third-party developers are copyrighted by their
+// respective authors.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301, USA
+//
+
+// Peer identity: what identifies a peer once a peer can be IPv6.
+//
+// Before this change a peer was a 32-bit address, so an inbound IPv6 peer was
+// accepted by the socket and then dropped -- there was nothing to index it
+// under. Widening that identity has three failure modes worth pinning, and only
+// one of them is about IPv6:
+//
+//   1. Merging two peers that are not the same peer. The exact bug this guards
+//      against already happened once in this tree: the banned-client list
+//      accepted an absent address, banned it as the key 0.0.0.0, and every
+//      client with an unknown address then read back as banned. Any new
+//      address-keyed container can recreate it.
+//   2. Silently changing IPv4 behaviour. The characterisation half of this file
+//      records what an IPv4 peer's identity does today, at the value level the
+//      unit tests can reach, so a regression in the widening is loud.
+//   3. Handing a subsystem an address it cannot represent. Kad is IPv4 behind a
+//      documented conversion boundary, and ed2k UDP obfuscation derives its key
+//      from a 32-bit address, so an inbound datagram has to be routed by what
+//      its peer address can actually reach.
+
+#include <muleunit/test.h>
+
+#include <PeerAddressing.h>
+
+#include <map>
+
+using namespace muleunit;
+using namespace PeerAddressing;
+
+DECLARE_SIMPLE(PeerAddressing)
+
+// ---------------------------------------------------------------------------
+// Indexability
+// ---------------------------------------------------------------------------
+
+TEST(PeerAddressing, AbsentIsNeverIndexable)
+{
+	// The whole point of the type: absence is not an address, so it is not a
+	// group in any index. 0.0.0.0 and :: are addresses -- odd ones, but a peer
+	// claiming one is a peer, not an unknown.
+	ASSERT_FALSE(IsIndexable(CNetworkAddress::Absent()));
+	ASSERT_TRUE(IsIndexable(CNetworkAddress::FromString("0.0.0.0")));
+	ASSERT_TRUE(IsIndexable(CNetworkAddress::FromString("::")));
+	ASSERT_TRUE(IsIndexable(CNetworkAddress::FromString("192.0.2.1")));
+	ASSERT_TRUE(IsIndexable(CNetworkAddress::FromString("2001:db8::1")));
+}
+
+TEST(PeerAddressing, AbsentAndAllZeroAreDifferentKeys)
+{
+	// This is the regression that already shipped once, in a different map. An
+	// index keyed on the address type must not let the two share a bucket, and
+	// the "absent" one must not have a bucket at all.
+	std::multimap<CNetworkAddress, int> index;
+
+	const CNetworkAddress absent = CNetworkAddress::Absent();
+	const CNetworkAddress allZeroV4 = CNetworkAddress::FromString("0.0.0.0");
+	const CNetworkAddress allZeroV6 = CNetworkAddress::FromString("::");
+
+	ASSERT_TRUE(absent != allZeroV4);
+	ASSERT_TRUE(absent != allZeroV6);
+	ASSERT_TRUE(allZeroV4 != allZeroV6);
+
+	index.insert(std::make_pair(allZeroV4, 1));
+	index.insert(std::make_pair(allZeroV6, 2));
+
+	ASSERT_EQUALS((size_t)1, index.count(allZeroV4));
+	ASSERT_EQUALS((size_t)1, index.count(allZeroV6));
+	// Nothing was recorded under absence, so nothing reads back under it --
+	// which is what makes "unknown address" un-bannable rather than banned.
+	ASSERT_EQUALS((size_t)0, index.count(absent));
+}
+
+TEST(PeerAddressing, MappedAndNativeIPv4AreTheSamePeer)
+{
+	// A blocked IPv4 peer reconnecting as ::ffff:a.b.c.d is the same peer, and
+	// the index must not give it a second identity. The address type does not
+	// normalise on comparison by design, so the index key is normalised
+	// deliberately, once, here -- and the test says so rather than assuming it.
+	const CNetworkAddress native = CNetworkAddress::FromString("192.0.2.1");
+	const CNetworkAddress mapped = CNetworkAddress::FromString("::ffff:192.0.2.1");
+
+	ASSERT_TRUE(native != mapped);
+	ASSERT_TRUE(IndexKey(native) == IndexKey(mapped));
+	ASSERT_TRUE(IndexKey(mapped).IsIPv4());
+
+	// An absent address has no key, and asking for one does not invent one.
+	ASSERT_TRUE(IndexKey(CNetworkAddress::Absent()).IsAbsent());
+
+	// A native IPv6 address keys as itself, unchanged.
+	const CNetworkAddress v6 = CNetworkAddress::FromString("2001:db8::1");
+	ASSERT_TRUE(IndexKey(v6) == v6);
+}
+
+TEST(PeerAddressing, DistinctIPv6PeersNeverShareAKey)
+{
+	// Two peers in the same /64 are two peers. The rate-limit scope aggregates
+	// them on purpose (below); the identity index must not.
+	static const char *const addresses[] = {
+		"2001:db8::1", "2001:db8::2", "2001:db8:0:0:1::1", "2001:db8:1::1", "fe80::1", "::1", "::"
+	};
+	static const size_t count = sizeof(addresses) / sizeof(addresses[0]);
+
+	std::multimap<CNetworkAddress, int> index;
+	for (size_t i = 0; i < count; ++i) {
+		const CNetworkAddress address = CNetworkAddress::FromString(addresses[i]);
+		ASSERT_TRUE(address.IsPresent());
+		index.insert(std::make_pair(IndexKey(address), (int)i));
+	}
+
+	for (size_t i = 0; i < count; ++i) {
+		const CNetworkAddress address = CNetworkAddress::FromString(addresses[i]);
+		ASSERT_EQUALS((size_t)1, index.count(IndexKey(address)));
+	}
+	ASSERT_EQUALS(count, index.size());
+}
+
+// ---------------------------------------------------------------------------
+// IPv4 characterisation -- must not change
+// ---------------------------------------------------------------------------
+
+TEST(PeerAddressing, IPv4RoundTripThroughIdentityIsExact)
+{
+	// A client's address used to be an ed2k-order uint32 and the accessors
+	// still hand one out. Every IPv4 value must survive the wider storage
+	// unchanged, or an IPv4 peer's identity, its wire encoding and its Kad
+	// conversion all shift together and no interface changes.
+	static const uint32_t values[] = {
+		0x0100007Fu, 0x010200C0u, 0xFFFFFFFFu, 0x00000001u, 0x01000000u, 0x2A2A2A2Au
+	};
+	static const size_t count = sizeof(values) / sizeof(values[0]);
+
+	for (size_t i = 0; i < count; ++i) {
+		const CNetworkAddress address = CNetworkAddress::FromIPv4NetworkOrderOrAbsent(values[i]);
+		ASSERT_TRUE(address.IsPresent());
+		ASSERT_TRUE(IsIndexable(address));
+		ASSERT_EQUALS(values[i], address.ToIPv4NetworkOrderOrZero());
+		// And the identity key of an IPv4 peer is the IPv4 address itself:
+		// grouping is byte-for-byte what the 32-bit multimap did.
+		ASSERT_TRUE(IndexKey(address) == address);
+	}
+
+	// Zero still means "unknown" at the 32-bit boundary, and reads back as
+	// zero on the way out. This is the pre-existing behaviour of a client with
+	// no address, and it is unchanged by having somewhere wider to store one.
+	const CNetworkAddress unknown = CNetworkAddress::FromIPv4NetworkOrderOrAbsent(0);
+	ASSERT_TRUE(unknown.IsAbsent());
+	ASSERT_FALSE(IsIndexable(unknown));
+	ASSERT_EQUALS(0u, unknown.ToIPv4NetworkOrderOrZero());
+}
+
+TEST(PeerAddressing, NativeIPv6HasNoThirtyTwoBitForm)
+{
+	// The guarantee that stops a fabricated address reaching Kad, the ed2k wire
+	// or an obfuscation key: the narrowing fails and leaves the caller's
+	// variable alone.
+	const CNetworkAddress v6 = CNetworkAddress::FromString("2001:db8::1");
+	uint32_t scratch = 0xDEADBEEFu;
+	ASSERT_FALSE(v6.ToIPv4NetworkOrder(scratch));
+	ASSERT_EQUALS(0xDEADBEEFu, scratch);
+	ASSERT_FALSE(v6.ToIPv4HostOrder(scratch));
+	ASSERT_EQUALS(0xDEADBEEFu, scratch);
+}
+
+// ---------------------------------------------------------------------------
+// Inbound datagram routing
+// ---------------------------------------------------------------------------
+
+TEST(PeerAddressing, DatagramRoutingTable)
+{
+	// No address at all, or one this build cannot parse: nothing to route to.
+	ASSERT_TRUE(ClassifyUdpPeer(CNetworkAddress::Absent()) == EUdpRoute::Reject);
+
+	// A peer claiming the unspecified address. Rejected, and distinguishable
+	// from the absent case at the call site so the log can say which.
+	ASSERT_TRUE(ClassifyUdpPeer(CNetworkAddress::FromString("0.0.0.0")) == EUdpRoute::Reject);
+	ASSERT_TRUE(ClassifyUdpPeer(CNetworkAddress::FromString("::")) == EUdpRoute::Reject);
+
+	// IPv4, and the mapped spelling of IPv4: everything is reachable.
+	ASSERT_TRUE(ClassifyUdpPeer(CNetworkAddress::FromString("192.0.2.1")) == EUdpRoute::Ed2kAndKad);
+	ASSERT_TRUE(
+		ClassifyUdpPeer(CNetworkAddress::FromString("::ffff:192.0.2.1")) == EUdpRoute::Ed2kAndKad);
+
+	// Native IPv6: the ed2k handlers can identify this peer now, Kad cannot.
+	// Kad's 32-bit interface is a documented boundary, not an oversight, so the
+	// route says so instead of narrowing and hoping.
+	ASSERT_TRUE(ClassifyUdpPeer(CNetworkAddress::FromString("2001:db8::1")) == EUdpRoute::Ed2kOnly);
+	ASSERT_TRUE(ClassifyUdpPeer(CNetworkAddress::FromString("fe80::1")) == EUdpRoute::Ed2kOnly);
+}
+
+TEST(PeerAddressing, Ed2kUdpObfuscationNeedsAThirtyTwoBitPeer)
+{
+	// The ed2k UDP obfuscation key is MD5 over our user hash, a 32-bit address
+	// and a magic byte (EncryptedDatagramSocket.cpp). There is no IPv6 input to
+	// that key in the protocol, so an obfuscated ed2k datagram from a native
+	// IPv6 peer cannot be decrypted -- by anyone, not just by this build. The
+	// boundary is reported rather than papered over with a zero, which would
+	// derive a wrong key and read the packet as junk without saying why.
+	ASSERT_TRUE(SupportsEd2kUdpObfuscation(CNetworkAddress::FromString("192.0.2.1")));
+	ASSERT_TRUE(SupportsEd2kUdpObfuscation(CNetworkAddress::FromString("::ffff:192.0.2.1")));
+	ASSERT_FALSE(SupportsEd2kUdpObfuscation(CNetworkAddress::FromString("2001:db8::1")));
+	ASSERT_FALSE(SupportsEd2kUdpObfuscation(CNetworkAddress::Absent()));
+}
+
+// ---------------------------------------------------------------------------
+// Rate-limit scope
+// ---------------------------------------------------------------------------
+
+TEST(PeerAddressing, IPv4RateLimitScopeIsTheAddress)
+{
+	// Unchanged from the 32-bit throttle: one address, one budget. Neighbours
+	// are not aggregated, so a shared IPv4 address is the only thing that
+	// shares a budget -- which is what it meant before.
+	const CNetworkAddress a = CNetworkAddress::FromString("192.0.2.1");
+	const CNetworkAddress b = CNetworkAddress::FromString("192.0.2.2");
+
+	ASSERT_TRUE(RateLimitScope(a) == a);
+	ASSERT_TRUE(RateLimitScope(a) != RateLimitScope(b));
+
+	// The mapped spelling shares the IPv4 budget: it is the same host over the
+	// same family, and a peer must not double its allowance by respelling.
+	ASSERT_TRUE(RateLimitScope(CNetworkAddress::FromString("::ffff:192.0.2.1")) == a);
+
+	// Absence has no budget, because it identifies nobody.
+	ASSERT_TRUE(RateLimitScope(CNetworkAddress::Absent()).IsAbsent());
+}
+
+TEST(PeerAddressing, IPv6RateLimitScopeAggregatesAtSixtyFour)
+{
+	// The decision this change had to make. A /128 budget under IPv6 throttles
+	// nothing: a subscriber holding a /64 sources each request from a fresh
+	// address and every one of them looks like a first offence. Aggregating at
+	// /64 restores the IPv4 meaning of the limit -- one subscriber, one budget.
+	ASSERT_EQUALS(64u, kIPv6RateLimitPrefixBits);
+
+	const CNetworkAddress first = CNetworkAddress::FromString("2001:db8:1:2::1");
+	const CNetworkAddress second = CNetworkAddress::FromString("2001:db8:1:2:ffff:ffff:ffff:ffff");
+	const CNetworkAddress neighbour = CNetworkAddress::FromString("2001:db8:1:3::1");
+
+	// Same /64: one budget.
+	ASSERT_TRUE(RateLimitScope(first) == RateLimitScope(second));
+	// The scope is the prefix itself, host bits cleared.
+	ASSERT_TRUE(RateLimitScope(first) == CNetworkAddress::FromString("2001:db8:1:2::"));
+
+	// A different /64 is a different subscriber and keeps its own budget. This
+	// is the other half of the decision: aggregating at /48 or /56 would put
+	// unrelated customers of one provider in a single bucket, where one of them
+	// could lock out the rest.
+	ASSERT_TRUE(RateLimitScope(first) != RateLimitScope(neighbour));
+
+	// An IPv6 scope never collides with an IPv4 one.
+	ASSERT_TRUE(RateLimitScope(first) != RateLimitScope(CNetworkAddress::FromString("192.0.2.1")));
+}
+
+// ---------------------------------------------------------------------------
+// Direct reachability
+// ---------------------------------------------------------------------------
+
+TEST(PeerAddressing, GlobalIPv6PeerIsDirectlyReachable)
+{
+	// LowID is an IPv4-with-NAT concept: it means a peer that cannot accept an
+	// inbound connection, inferred from an ed2k ID a server issued. An IPv6
+	// peer has no ed2k ID at all, so the ID says nothing about it, and a
+	// globally routable IPv6 address is exactly the case where a callback is
+	// neither needed nor possible.
+	ASSERT_TRUE(IsDirectlyReachable(CNetworkAddress::FromString("2001:db8::1")));
+
+	// Addresses aMule cannot dial from here, so they prove nothing about
+	// reachability and must not suppress the callback path.
+	ASSERT_FALSE(IsDirectlyReachable(CNetworkAddress::FromString("fe80::1")));
+	ASSERT_FALSE(IsDirectlyReachable(CNetworkAddress::FromString("fc00::1")));
+	ASSERT_FALSE(IsDirectlyReachable(CNetworkAddress::FromString("::1")));
+	ASSERT_FALSE(IsDirectlyReachable(CNetworkAddress::FromString("::")));
+	ASSERT_FALSE(IsDirectlyReachable(CNetworkAddress::Absent()));
+
+	// IPv4, mapped or not, is left to the existing ed2k ID rule: this predicate
+	// answers only for the family the ID cannot describe.
+	ASSERT_FALSE(IsDirectlyReachable(CNetworkAddress::FromString("192.0.2.1")));
+	ASSERT_FALSE(IsDirectlyReachable(CNetworkAddress::FromString("::ffff:192.0.2.1")));
+}
+
+TEST(PeerAddressing, RateLimitScopeMembersAreContiguousInTheIndexOrder)
+{
+	// CClientList counts a peer's slots by starting at its scope's network
+	// address and walking while the scope holds. That is only correct if every
+	// member of a prefix occupies one contiguous run of the ordering -- if it
+	// did not, the walk would stop early and the limit would under-count, which
+	// is a limit that silently does not apply. The ordering is octet-wise, most
+	// significant first, so it does; asserted here because the scan depends on
+	// it and the ordering lives in another file.
+	std::multimap<CNetworkAddress, int> index;
+
+	static const char *const addresses[] = { // Inside the /64 under test, deliberately out of order.
+		"2001:db8:1:2:ffff:ffff:ffff:ffff",
+		"2001:db8:1:2::",
+		"2001:db8:1:2:8000::1",
+		// Immediately outside it, on both sides.
+		"2001:db8:1:1:ffff:ffff:ffff:ffff",
+		"2001:db8:1:3::",
+		// Far away, and in the other family.
+		"2001:db8:9::1",
+		"192.0.2.1",
+		"255.255.255.255"
+	};
+	static const size_t count = sizeof(addresses) / sizeof(addresses[0]);
+	for (size_t i = 0; i < count; ++i) {
+		const CNetworkAddress address = CNetworkAddress::FromString(addresses[i]);
+		ASSERT_TRUE(address.IsPresent());
+		index.insert(std::make_pair(IndexKey(address), (int)i));
+	}
+
+	const CNetworkAddress scope = RateLimitScope(CNetworkAddress::FromString("2001:db8:1:2::5"));
+	ASSERT_TRUE(scope == CNetworkAddress::FromString("2001:db8:1:2::"));
+
+	size_t visited = 0;
+	for (std::multimap<CNetworkAddress, int>::const_iterator it = index.lower_bound(scope);
+		it != index.end();
+		++it) {
+		if (RateLimitScope(it->first) != scope) {
+			break;
+		}
+		++visited;
+	}
+	// Exactly the three members, and the walk was not cut short by the
+	// neighbouring /64 sorting in between them.
+	ASSERT_EQUALS((size_t)3, visited);
+}
+
+TEST(PeerAddressing, Ed2kWireFormIsWhatMayBePublished)
+{
+	// Source exchange, the .part.met.seeds record and the relayed callback all
+	// carry a peer as a 32-bit address. A native IPv6 peer has none, and the
+	// only correct thing to do with it in those formats is to leave it out: a
+	// zero there would publish 0.0.0.0 as a source to every peer that asked,
+	// and persist it for the next start to dial.
+	//
+	// This matters more after the widening than before it. An IPv6 peer used to
+	// be excluded from those paths incidentally, by having no ed2k id and so
+	// reading as LowID. It is now correctly HighID, so the exclusion has to be
+	// this explicit test instead.
+	ASSERT_TRUE(HasEd2kWireForm(CNetworkAddress::FromString("192.0.2.1")));
+	ASSERT_TRUE(HasEd2kWireForm(CNetworkAddress::FromString("0.0.0.0")));
+	ASSERT_TRUE(HasEd2kWireForm(CNetworkAddress::FromString("::ffff:192.0.2.1")));
+	ASSERT_FALSE(HasEd2kWireForm(CNetworkAddress::FromString("2001:db8::1")));
+	ASSERT_FALSE(HasEd2kWireForm(CNetworkAddress::Absent()));
+
+	// A peer that may be published is published with exactly the bytes it had
+	// before the widening -- the mapped spelling included, which narrows to its
+	// embedded IPv4 rather than to something new.
+	uint32_t wire = 0;
+	ASSERT_TRUE(CNetworkAddress::FromString("192.0.2.1").ToIPv4NetworkOrder(wire));
+	ASSERT_EQUALS(0x010200C0u, wire);
+	uint32_t mappedWire = 0;
+	ASSERT_TRUE(CNetworkAddress::FromString("::ffff:192.0.2.1").ToIPv4NetworkOrder(mappedWire));
+	ASSERT_EQUALS(wire, mappedWire);
+}
+
+// ---------------------------------------------------------------------------
+// UDP source ports
+// ---------------------------------------------------------------------------
+
+TEST(PeerAddressing, UnknownUDPPortIdentifiesNobody)
+{
+	// A client we know by address has a UDP port only if it advertised one, and
+	// zero is how "it never did" is spelled. Comparing that zero for equality
+	// would make every such client a candidate for a datagram whose source port
+	// is also zero -- and behind a carrier NAT one address is many peers, so
+	// the match would name an arbitrary one of them. The rendezvous relay
+	// vouches for whoever this lookup returns, so the unknown side has to lose.
+	ASSERT_FALSE(MatchesUdpSourcePort(0, 0));
+	ASSERT_FALSE(MatchesUdpSourcePort(0, 4672));
+	ASSERT_FALSE(MatchesUdpSourcePort(4672, 0));
+}
+
+TEST(PeerAddressing, AdvertisedUDPPortMatchesOnlyItself)
+{
+	// The ordinary case, and the reason this predicate exists at all: the port
+	// a peer advertised for UDP is not the ed2k TCP port it also advertised,
+	// so a lookup that compares the wrong one of the two answers "unknown peer"
+	// for every real peer while looking like it works.
+	ASSERT_TRUE(MatchesUdpSourcePort(4672, 4672));
+	ASSERT_FALSE(MatchesUdpSourcePort(4672, 4662));
+	ASSERT_TRUE(MatchesUdpSourcePort(65535, 65535));
+}
+
+// File_checked_for_headers

--- a/unittests/tests/PeerAddressingTest.cpp
+++ b/unittests/tests/PeerAddressingTest.cpp
@@ -29,11 +29,9 @@
 // under. Widening that identity has three failure modes worth pinning, and only
 // one of them is about IPv6:
 //
-//   1. Merging two peers that are not the same peer. The exact bug this guards
-//      against already happened once in this tree: the banned-client list
-//      accepted an absent address, banned it as the key 0.0.0.0, and every
-//      client with an unknown address then read back as banned. Any new
-//      address-keyed container can recreate it.
+//   1. Merging two peers that are not the same peer. Keeping absence separate
+//      from 0.0.0.0 is prevention/hardening, not a bug observed in #1314.
+//      Any new address-keyed container must preserve this invariant.
 //   2. Silently changing IPv4 behaviour. The characterisation half of this file
 //      records what an IPv4 peer's identity does today, at the value level the
 //      unit tests can reach, so a regression in the widening is loud.
@@ -71,9 +69,8 @@ TEST(PeerAddressing, AbsentIsNeverIndexable)
 
 TEST(PeerAddressing, AbsentAndAllZeroAreDifferentKeys)
 {
-	// This is the regression that already shipped once, in a different map. An
-	// index keyed on the address type must not let the two share a bucket, and
-	// the "absent" one must not have a bucket at all.
+	// Prevention invariant: absence must not share an address bucket or acquire
+	// a bucket of its own.
 	std::multimap<CNetworkAddress, int> index;
 
 	const CNetworkAddress absent = CNetworkAddress::Absent();
@@ -191,24 +188,35 @@ TEST(PeerAddressing, NativeIPv6HasNoThirtyTwoBitForm)
 
 TEST(PeerAddressing, DatagramRoutingTable)
 {
-	// No address at all, or one this build cannot parse: nothing to route to.
-	ASSERT_TRUE(ClassifyUdpPeer(CNetworkAddress::Absent()) == EUdpRoute::Reject);
-
-	// A peer claiming the unspecified address. Rejected, and distinguishable
-	// from the absent case at the call site so the log can say which.
-	ASSERT_TRUE(ClassifyUdpPeer(CNetworkAddress::FromString("0.0.0.0")) == EUdpRoute::Reject);
-	ASSERT_TRUE(ClassifyUdpPeer(CNetworkAddress::FromString("::")) == EUdpRoute::Reject);
-
-	// IPv4, and the mapped spelling of IPv4: everything is reachable.
-	ASSERT_TRUE(ClassifyUdpPeer(CNetworkAddress::FromString("192.0.2.1")) == EUdpRoute::Ed2kAndKad);
-	ASSERT_TRUE(
-		ClassifyUdpPeer(CNetworkAddress::FromString("::ffff:192.0.2.1")) == EUdpRoute::Ed2kAndKad);
-
-	// Native IPv6: the ed2k handlers can identify this peer now, Kad cannot.
-	// Kad's 32-bit interface is a documented boundary, not an oversight, so the
-	// route says so instead of narrowing and hoping.
-	ASSERT_TRUE(ClassifyUdpPeer(CNetworkAddress::FromString("2001:db8::1")) == EUdpRoute::Ed2kOnly);
-	ASSERT_TRUE(ClassifyUdpPeer(CNetworkAddress::FromString("fe80::1")) == EUdpRoute::Ed2kOnly);
+	const struct
+	{
+		const char *address;
+		std::uint16_t port;
+		EUdpRoute expected;
+	} cases[] = { { "", 4672, EUdpRoute::Reject },
+		{ "0.0.0.0", 4672, EUdpRoute::Reject },
+		{ "::", 4672, EUdpRoute::Reject },
+		{ "0:0:0:0:0:0:0:0", 4672, EUdpRoute::Reject },
+		{ "::0.0.0.0", 4672, EUdpRoute::Reject },
+		{ "::ffff:0.0.0.0", 4672, EUdpRoute::Reject },
+		{ "::ffff:0:0", 4672, EUdpRoute::Reject },
+		{ "0:0:0:0:0:ffff:0:0", 4672, EUdpRoute::Reject },
+		{ "::%1", 4672, EUdpRoute::Reject },
+		{ "::ffff:0.0.0.0%1", 4672, EUdpRoute::Reject },
+		{ "192.0.2.1", 0, EUdpRoute::Reject },
+		{ "::ffff:192.0.2.1", 0, EUdpRoute::Reject },
+		{ "2606:4700::1111", 0, EUdpRoute::Reject },
+		{ "192.0.2.1", 4672, EUdpRoute::Ed2kAndKad },
+		{ "::ffff:192.0.2.1", 65535, EUdpRoute::Ed2kAndKad },
+		{ "2606:4700::1111", 4672, EUdpRoute::Ed2kOnly },
+		{ "fe80::1", 4672, EUdpRoute::Ed2kOnly } };
+	for (const auto &entry : cases) {
+		const auto address = CNetworkAddress::FromString(entry.address);
+		if (entry.address[0] != '\0') {
+			ASSERT_TRUE(address.IsPresent());
+		}
+		ASSERT_TRUE(ClassifyUdpPeer({ address, entry.port }) == entry.expected);
+	}
 }
 
 TEST(PeerAddressing, Ed2kUdpObfuscationNeedsAThirtyTwoBitPeer)
@@ -286,7 +294,8 @@ TEST(PeerAddressing, GlobalIPv6PeerIsDirectlyReachable)
 	// peer has no ed2k ID at all, so the ID says nothing about it, and a
 	// globally routable IPv6 address is exactly the case where a callback is
 	// neither needed nor possible.
-	ASSERT_TRUE(IsDirectlyReachable(CNetworkAddress::FromString("2001:db8::1")));
+	ASSERT_TRUE(IsDirectlyReachable(CNetworkAddress::FromString("2606:4700::1111")));
+	ASSERT_FALSE(IsDirectlyReachable(CNetworkAddress::FromString("2001:db8::1")));
 
 	// Addresses aMule cannot dial from here, so they prove nothing about
 	// reachability and must not suppress the callback path.
@@ -390,9 +399,10 @@ TEST(PeerAddressing, UnknownUDPPortIdentifiesNobody)
 	// is also zero -- and behind a carrier NAT one address is many peers, so
 	// the match would name an arbitrary one of them. The rendezvous relay
 	// vouches for whoever this lookup returns, so the unknown side has to lose.
-	ASSERT_FALSE(MatchesUdpSourcePort(0, 0));
-	ASSERT_FALSE(MatchesUdpSourcePort(0, 4672));
-	ASSERT_FALSE(MatchesUdpSourcePort(4672, 0));
+	const auto address = CNetworkAddress::FromString("192.0.2.1");
+	ASSERT_FALSE(MatchesUdpSource({ address, 0 }, { address, 0 }));
+	ASSERT_FALSE(MatchesUdpSource({ address, 0 }, { address, 4672 }));
+	ASSERT_FALSE(MatchesUdpSource({ address, 4672 }, { address, 0 }));
 }
 
 TEST(PeerAddressing, AdvertisedUDPPortMatchesOnlyItself)
@@ -401,9 +411,25 @@ TEST(PeerAddressing, AdvertisedUDPPortMatchesOnlyItself)
 	// a peer advertised for UDP is not the ed2k TCP port it also advertised,
 	// so a lookup that compares the wrong one of the two answers "unknown peer"
 	// for every real peer while looking like it works.
-	ASSERT_TRUE(MatchesUdpSourcePort(4672, 4672));
-	ASSERT_FALSE(MatchesUdpSourcePort(4672, 4662));
-	ASSERT_TRUE(MatchesUdpSourcePort(65535, 65535));
+	const auto address = CNetworkAddress::FromString("192.0.2.1");
+	const auto mapped = CNetworkAddress::FromString("::ffff:192.0.2.1");
+	const auto other = CNetworkAddress::FromString("192.0.2.2");
+	ASSERT_TRUE(MatchesUdpSource({ address, 4672 }, { address, 4672 }));
+	ASSERT_FALSE(MatchesUdpSource({ address, 4672 }, { address, 4662 }));
+	ASSERT_TRUE(MatchesUdpSource({ address, 65535 }, { address, 65535 }));
+	ASSERT_TRUE(MatchesUdpSource({ address, 4672 }, { mapped, 4672 }));
+	ASSERT_TRUE(MatchesUdpSource({ mapped, 4672 }, { address, 4672 }));
+	ASSERT_FALSE(MatchesUdpSource({ address, 4672 }, { other, 4672 }));
+	ASSERT_FALSE(MatchesUdpSource({ CNetworkAddress::Absent(), 4672 }, { address, 4672 }));
+	for (const char *text : { "", "0.0.0.0", "::", "::ffff:0.0.0.0" }) {
+		const auto invalid = CNetworkAddress::FromString(text);
+		ASSERT_FALSE(MatchesUdpSource({ invalid, 4672 }, { invalid, 4672 }));
+	}
+	const auto v6 = CNetworkAddress::FromString("2606:4700::1111");
+	ASSERT_TRUE(MatchesUdpSource({ v6, 4672 }, { v6, 4672 }));
+	ASSERT_FALSE(MatchesUdpSource({ v6, 4672 }, { address, 4672 }));
+	ASSERT_FALSE(MatchesUdpSource({ CNetworkAddress::FromString("fe80::1%1"), 4672 },
+		{ CNetworkAddress::FromString("fe80::1%2"), 4672 }));
 }
 
 // File_checked_for_headers


### PR DESCRIPTION
Refs #1177

Second of the three sequential PRs for piece 3, the identity widening. #1318
added the type; this one adds the decisions that widening needs, and nothing
else. `AddressFamilyPolicy` follows, then the call sites.

## What the header decides

`src/PeerAddressing.h` collects the questions the widening has to answer, away
from the app classes that carry them out, so each one is a value function with a
test rather than a condition buried in a 3000-line file.

Three of those questions deliberately give **different answers for the same
address**, which is the reason they are named separately rather than folded into
one "normalise" helper:

| Question | Function | Aggregates? |
| --- | --- | --- |
| Are these the same peer? | `IndexKey()` | No — never |
| Whose budget does this spend? | `RateLimitScope()` | Yes, IPv6 at /64 |
| How far can this datagram go? | `ClassifyUdpPeer()` | n/a |

- **Identity.** Two peers are the same peer iff they have the same index key.
  Aggregating distinct hosts here would merge them — the failure this tree has
  already had once, when an absent address was banned as the key `0.0.0.0` and
  every client with an unknown address read back as banned (#1314).
- **Rate limiting.** A budget is per *subscriber*, which under IPv6 is not per
  address. A per-/128 budget throttles nothing at all: a residential allocation
  is a /64 at worst. Aggregating is the point here, and how much is a decision,
  not a detail.
- **Routing an inbound datagram.** Some subsystems cannot represent an IPv6 peer
  at all — Kad by design, ed2k UDP obfuscation by protocol. `EUdpRoute` reports
  those boundaries; nothing crosses them with a fabricated address.

`HasEd2kWireForm()` and `IsDirectlyReachable()` are the two remaining edges:
what may be published into a 32-bit protocol field, and whether a peer needs a
callback at all. The second matters because LowID is an ed2k concept — a native
IPv6 peer has no ed2k ID, so left to the ID alone it would read as firewalled
and be sent down a callback path that cannot carry its address.

Nothing here fabricates an address. Every function that cannot answer for an
address says so, and an absent address stays absent all the way through.

## Inertness

**Nothing calls it.** 833 insertions and 42 deletions. Review moved this off
"zero deletions": `IsGloballyRoutableIPv6()` now walks a prefix table instead of
an `if` chain, which rewrites existing lines in `src/NetworkAddress.h`. The
safety argument is therefore the stronger claim rather than the diffstat one -
**no caller on master**. Nothing in the tree calls `IsGloballyRoutableIPv6()` or
`IsGloballyRoutableIPv4()`, so the rewrite reaches no code path. Alongside it,
`unittests/tests/CMakeLists.txt` gains one suite and `NetworkAddressTest.cpp`
gains the cases pinning the new prefixes.

The header includes `NetworkAddress.h` and `<cstdint>` and nothing else, so it
adds no include-closure weight anywhere — and since nothing includes it yet, it
compiles in exactly one translation unit: its own test. No shipped binary
behaves differently.

`NetworkAddress.cpp` is linked by the test target because `FromString`/`ToString`
live there, which is the arrangement #1318 established.

## Tests

`PeerAddressingTest`, 15 cases. The ones worth naming:

- `AbsentAndAllZeroAreDifferentKeys` — the distinction that #1314's root cause
  turned on. `0.0.0.0` is an odd address but it is an address; "we do not know"
  is not.
- `MappedAndNativeIPv4AreTheSamePeer` — a peer that reaches us mapped and later
  natively must not index twice.
- `DistinctIPv6PeersNeverShareAKey` and
  `RateLimitScopeMembersAreContiguousInTheIndexOrder` — the two halves of the
  aggregation rule, pinned in both directions: identity never merges, and the
  /64 a budget merges is a contiguous run in the index order, so a scope can be
  swept as a range.
- `DatagramRoutingTable` — every `EUdpRoute` outcome, so a new family cannot be
  added without deciding where its datagrams may go.
- `AdvertisedUDPPortMatchesOnlyItself` / `UnknownUDPPortIdentifiesNobody` — an
  unknown advertised port must not match every sender.

Checked by perturbation, not by inspection: widening the rate-limit prefix from
/64 to /48, and making `IndexKey()` stop unmapping, each fail by the case that
covers them.

## Verification

- Builds monolithic, daemon and remotegui: 0 errors, no new warnings.
- `ctest`: **59/59**, on Ubuntu 22.04 / gcc 11.4 / wx 3.2.12, aarch64.
- clang-format 18 clean on both new files; `git diff --check` clean.
- `scripts/check-potfiles.sh` clean — the header has no translatable strings, so
  it takes no `POTFILES.in` entry.

## Size

833 lines, of which the test is the largest part and 256 are the header. Under the shape agreed
on #1177: a piece small enough to review in one pass, with the call sites held
back for the PR after `AddressFamilyPolicy`.

