### PR TITLE
fix(gui): paint download rows in their category's colour again

### DIFF
--- a/src/DownloadListCtrl.cpp
+++ b/src/DownloadListCtrl.cpp
@@ -972,6 +972,34 @@ bool CDownloadListCtrl::GetItemIcon(wxUIntPtr item, unsigned column, wxIcon &ico
 	return true;
 }
 
+bool CDownloadListCtrl::GetItemAttr(wxUIntPtr item, unsigned WXUNUSED(column), wxDataViewItemAttr &attr) const
+{
+	const CPartFile *file = reinterpret_cast<const CPartFile *>(item);
+
+	// Category 0 is "all"; a file in it has no category of its own to take a
+	// colour from, which is the test the pre-wxDataView code used too.
+	const uint8 cat = file->GetCategory();
+	if (!cat) {
+		return false;
+	}
+
+	// A category keeps colour 0 until the user picks one (Preferences writes
+	// "Color" as 0 for a new one), so 0 means unset rather than black. The old
+	// code painted those rows black because it predates the dark themes, where
+	// black on a dark list is unreadable.
+	const uint32 colour = theApp->glob_prefs->GetCatColor(cat);
+	if (!colour) {
+		return false;
+	}
+
+	// Selected rows keep the system highlight colour: wx overrides a custom
+	// foreground while a row is selected -- in common/datavcmn.cpp for the
+	// generic renderers, and explicitly in the macOS backend -- for the same
+	// readability reason the old OnDrawItem() skipped highlighted rows.
+	attr.SetColour(CMuleColour(colour));
+	return true;
+}
+
 void CDownloadListCtrl::GetItemBarFill(wxUIntPtr item, unsigned column, CBarFillSpec &out) const
 {
 	if (column != COLUMN_DL_PROGRESS || !thePrefs::ShowProgBar()) {

--- a/src/DownloadListCtrl.h
+++ b/src/DownloadListCtrl.h
@@ -210,6 +210,15 @@ protected:
 	/// Rating/comment smiley on the File Name column, nothing elsewhere.
 	bool GetItemIcon(wxUIntPtr item, unsigned column, wxIcon &icon) const override;
 
+	/**
+	 * Paints a row in its category's colour, the behaviour the pre-wxDataView
+	 * list had in OnDrawItem() and the port dropped (issue #1346).
+	 *
+	 * Whole row rather than one column, so `column` is unused: the old code
+	 * set the DC foreground once before its column loop.
+	 */
+	bool GetItemAttr(wxUIntPtr item, unsigned column, wxDataViewItemAttr &attr) const override;
+
 	/// Chunk/gap-bar spans for the Progress column.
 	void GetItemBarFill(wxUIntPtr item, unsigned column, CBarFillSpec &out) const override;
 


### PR DESCRIPTION
Fixes #1346.

Porting `CDownloadListCtrl` to `wxDataViewCtrl` (#848) dropped the line that gave a row the colour of its category:

```cpp
dc->SetTextForeground(CMuleColour(theApp->glob_prefs->GetCatColor(file->GetCategory())));
```

Nothing replaced it, so `GetCatColor()` has had no caller anywhere in the tree since. The colour is still chosen in the category dialog, still saved to config, and still sent over EC as `EC_TAG_CATEGORY_COLOR` - it just stopped being painted.

### The fix

`wxDataViewCtrl` asks the model for per-row attributes rather than letting the control draw the row, and `CMuleVirtualDataViewCtrl` already routes that through a `GetItemAttr()` hook that `CSearchListModel` uses. Restoring the behaviour is implementing it for the download list; no new plumbing.

### Two deliberate differences from the removed code

**Colour 0 now means "unset" rather than black.** `Preferences` writes `Color=0` for a category until the user picks one, and the old line painted those rows literally black. That predates the dark themes, where black on a dark list is unreadable.

**No focus special case.** The old guard was `if (!highlighted || !GetFocus())`, so a selected row in an *unfocused* list kept its category colour; wx keys on selected alone, so that one case now shows the highlight colour.

Selected rows stay readable either way, which is what that guard was protecting. wx overrides a custom foreground while a row is selected - in `common/datavcmn.cpp` for the generic renderers ("*override custom foreground with the standard one for the selected items because ... custom colours may be unreadable on it*") and explicitly in the macOS backend ("*We don't apply the text or background colours if the cell is selected*"). GTK sets `foreground-rgba` on the cell renderer and lets the theme paint the selection. So the protection now lives in the library rather than in our drawing code, on all three backends.

### Verification

Built clean; clang-format 18 whole-file clean and idempotent; clang-tidy Tier-1 and Tier-2 clean, 0 compiler errors on both. Awaiting confirmation from the reporter against a packaged build before merge.
