### PR TITLE
feat(net): add address family policy

### DIFF
--- a/src/AddressFamilyPolicy.h
+++ b/src/AddressFamilyPolicy.h
@@ -1,0 +1,142 @@
+//
+// This file is part of the aMule Project.
+//
+// Copyright (c) 2003-2026 aMule Team ( https://amule-org.github.io )
+//
+// Any parts of this program derived from the xMule, lMule or eMule project,
+// or contributed by third-party developers are copyrighted by their
+// respective authors.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301, USA
+//
+
+#ifndef ADDRESSFAMILYPOLICY_H
+#define ADDRESSFAMILYPOLICY_H
+
+#include "NetworkAddress.h"
+
+#include <atomic>
+
+/**
+ * The single place that decides which address families aMule uses.
+ *
+ * The Asio backend used to answer that question with a literal
+ * @c ip::tcp::v4() at every socket-opening site, which meant the family was not
+ * a decision at all -- it was five independent constants. This namespace makes
+ * it one decision, derived either from configuration or from the target
+ * address, so that enabling IPv6 later is a change to Configured() and not a
+ * hunt through LibSocketAsio.cpp.
+ *
+ * The configured answer is dual stack as of amule-dual-stack-reachability, and
+ * it is now a runtime value rather than a compile-time constant: a host with no
+ * IPv6 stack must keep working exactly as it did, and that is decided when the
+ * listeners are bound, not when the tree is compiled.
+ *
+ * What dual stack does @b not mean here: Kademlia stays IPv4. Its wire format
+ * carries 32-bit addresses and its routing table keys on them, so widening the
+ * socket layer gives Kad nothing to widen into. That boundary is deliberate and
+ * is documented in openspec/specs/network-addressing/spec.md.
+ */
+namespace AddressFamilyPolicy
+{
+
+enum class Families
+{
+	IPv4Only,
+	IPv6Only,
+	DualStack
+};
+
+/**
+ * The configured family set.
+ *
+ * Atomic because it is read from the Asio thread pool (socket opening, name
+ * resolution) and written once from the main thread during startup. Relaxed
+ * ordering is enough: nothing else is published with it, and a socket opened in
+ * the same instant as a reconfiguration is allowed to see either value.
+ */
+inline std::atomic<Families> &ConfiguredStorage() noexcept
+{
+	static std::atomic<Families> families{ Families::DualStack };
+	return families;
+}
+
+inline Families Configured() noexcept
+{
+	return ConfiguredStorage().load(std::memory_order_relaxed);
+}
+
+/**
+ * Sets the configured family set. Called once from startup with what the user
+ * asked for; also used by tests to reach the branches a given host cannot.
+ *
+ * Sockets already open are unaffected -- this decides what the @b next socket
+ * does, exactly like the bind-interface setting next to it.
+ */
+inline void SetConfigured(Families families) noexcept
+{
+	ConfiguredStorage().store(families, std::memory_order_relaxed);
+}
+
+inline bool PermitsIPv4() noexcept
+{
+	return Configured() != Families::IPv6Only;
+}
+
+inline bool PermitsIPv6() noexcept
+{
+	return Configured() != Families::IPv4Only;
+}
+
+/**
+ * Whether a socket may be opened towards @a target at all.
+ *
+ * An IPv4-mapped IPv6 target counts as IPv4: it narrows losslessly, so an
+ * IPv4-only configuration can reach it.
+ */
+inline bool Permits(const CNetworkAddress &target) noexcept
+{
+	if (target.IsAbsent()) {
+		return false;
+	}
+	if (target.IsIPv4() || target.IsIPv4Mapped()) {
+		return PermitsIPv4();
+	}
+	return PermitsIPv6();
+}
+
+/*
+ * The rest of this policy -- the TCP protocol for a target, the resolver
+ * protocol, and the wildcard addresses -- is in AddressFamilyPolicyAsio.h.
+ *
+ * Those five functions are the ones whose return type is a Boost.Asio type,
+ * and keeping them here meant this header included <boost/asio/ip/tcp.hpp>.
+ * That include reached 93 translation units, and unlike asio's ip/address.hpp
+ * it drags in asio's executor machinery (the boost/asio/execution headers), which
+ * redeclares constexpr static members out of line -- deprecated in C++17, and
+ * an error under the -Werror=deprecated gate in src/CMakeLists.txt on every
+ * Clang build. So 93 TUs failed on macOS to answer a question that, for all
+ * but the socket backend, is just "which family".
+ *
+ * What stayed here needs no library: Configured(), the two Permits predicates
+ * and Families are the decision itself. Include the Asio twin only from a TU
+ * that opens sockets; a caller that only needs the IPv6 wildcard as a value
+ * should use CNetworkAddress::AnyIPv6() instead and stay asio-free.
+ */
+
+} // namespace AddressFamilyPolicy
+
+#endif // ADDRESSFAMILYPOLICY_H
+// File_checked_for_headers

--- a/src/AddressFamilyPolicy.h
+++ b/src/AddressFamilyPolicy.h
@@ -30,24 +30,13 @@
 #include <atomic>
 
 /**
- * The single place that decides which address families aMule uses.
+ * Address-family decisions derived from configuration and target addresses.
  *
- * The Asio backend used to answer that question with a literal
- * @c ip::tcp::v4() at every socket-opening site, which meant the family was not
- * a decision at all -- it was five independent constants. This namespace makes
- * it one decision, derived either from configuration or from the target
- * address, so that enabling IPv6 later is a change to Configured() and not a
- * hunt through LibSocketAsio.cpp.
+ * IPv4-only is the default. Dual stack requires an explicit SetConfigured()
+ * call; providing this policy does not enable IPv6 or change existing sockets.
  *
- * The configured answer is dual stack as of amule-dual-stack-reachability, and
- * it is now a runtime value rather than a compile-time constant: a host with no
- * IPv6 stack must keep working exactly as it did, and that is decided when the
- * listeners are bound, not when the tree is compiled.
- *
- * What dual stack does @b not mean here: Kademlia stays IPv4. Its wire format
- * carries 32-bit addresses and its routing table keys on them, so widening the
- * socket layer gives Kad nothing to widen into. That boundary is deliberate and
- * is documented in openspec/specs/network-addressing/spec.md.
+ * Kademlia remains IPv4: its wire format carries 32-bit addresses and its
+ * routing table keys on them. A socket-family policy cannot widen that format.
  */
 namespace AddressFamilyPolicy
 {
@@ -62,14 +51,14 @@ enum class Families
 /**
  * The configured family set.
  *
- * Atomic because it is read from the Asio thread pool (socket opening, name
- * resolution) and written once from the main thread during startup. Relaxed
+ * Atomic to allow reads from socket-opening and name-resolution threads while
+ * configuration is set from the main thread. Relaxed
  * ordering is enough: nothing else is published with it, and a socket opened in
  * the same instant as a reconfiguration is allowed to see either value.
  */
 inline std::atomic<Families> &ConfiguredStorage() noexcept
 {
-	static std::atomic<Families> families{ Families::DualStack };
+	static std::atomic<Families> families{ Families::IPv4Only };
 	return families;
 }
 
@@ -79,8 +68,7 @@ inline Families Configured() noexcept
 }
 
 /**
- * Sets the configured family set. Called once from startup with what the user
- * asked for; also used by tests to reach the branches a given host cannot.
+ * Sets the configured family set explicitly, including opting into dual stack.
  *
  * Sockets already open are unaffected -- this decides what the @b next socket
  * does, exactly like the bind-interface setting next to it.
@@ -118,22 +106,9 @@ inline bool Permits(const CNetworkAddress &target) noexcept
 }
 
 /*
- * The rest of this policy -- the TCP protocol for a target, the resolver
- * protocol, and the wildcard addresses -- is in AddressFamilyPolicyAsio.h.
- *
- * Those five functions are the ones whose return type is a Boost.Asio type,
- * and keeping them here meant this header included <boost/asio/ip/tcp.hpp>.
- * That include reached 93 translation units, and unlike asio's ip/address.hpp
- * it drags in asio's executor machinery (the boost/asio/execution headers), which
- * redeclares constexpr static members out of line -- deprecated in C++17, and
- * an error under the -Werror=deprecated gate in src/CMakeLists.txt on every
- * Clang build. So 93 TUs failed on macOS to answer a question that, for all
- * but the socket backend, is just "which family".
- *
- * What stayed here needs no library: Configured(), the two Permits predicates
- * and Families are the decision itself. Include the Asio twin only from a TU
- * that opens sockets; a caller that only needs the IPv6 wildcard as a value
- * should use CNetworkAddress::AnyIPv6() instead and stay asio-free.
+ * Socket protocols, resolver-family selection, and wildcard addresses live in
+ * AddressFamilyPolicyAsio.h. Keeping the socket-specific API separate avoids
+ * pulling Boost.Asio's executor machinery into consumers of family predicates.
  */
 
 } // namespace AddressFamilyPolicy

--- a/src/AddressFamilyPolicy.h
+++ b/src/AddressFamilyPolicy.h
@@ -106,9 +106,12 @@ inline bool Permits(const CNetworkAddress &target) noexcept
 }
 
 /*
- * Socket protocols, resolver-family selection, and wildcard addresses live in
- * AddressFamilyPolicyAsio.h. Keeping the socket-specific API separate avoids
- * pulling Boost.Asio's executor machinery into consumers of family predicates.
+ * Socket protocols, resolver-family selection and wildcard addresses live in
+ * AddressFamilyPolicyAsio.h, because their return types are Boost.Asio values
+ * and naming those here would pull asio's executor machinery into every TU
+ * that only wants to ask which family is permitted. What stays here needs no
+ * library: Configured(), the two Permits predicates and Families are the
+ * decision itself.
  */
 
 } // namespace AddressFamilyPolicy

--- a/src/AddressFamilyPolicyAsio.h
+++ b/src/AddressFamilyPolicyAsio.h
@@ -29,10 +29,11 @@
 
 #include <boost/optional.hpp>
 
-// See NetworkAddressAsio.h for why this wrap is here and why it is scoped to
-// exactly these two diagnostics. ip/tcp.hpp is the heavier of the two asio
-// headers this tree includes: it reaches boost/asio/execution/*.hpp, which is
-// where the redundant constexpr static definitions live.
+// Reviewer measurement with AppleClang 21 and Boost 1.92: without both
+// suppressions, ip/tcp.hpp produces 29 errors under -Werror=deprecated:
+// 27 redundant constexpr static definitions and 2 deprecated copies with a
+// user-provided destructor. Each suppression is independently necessary;
+// restrict both to this Boost include.
 #if defined(__clang__)
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-copy-with-user-provided-dtor"
@@ -44,15 +45,11 @@
 #endif
 
 /**
- * The half of AddressFamilyPolicy whose answers are Boost.Asio values.
+ * Socket-specific address-family policy and Boost.Asio values.
  *
- * Split out of AddressFamilyPolicy.h so that the 93 translation units which
- * only need to know *whether* a family is permitted stop compiling asio's
- * socket headers to find out; the reasoning is spelled out at the bottom of
- * that file. Include this only from a TU that actually opens a socket or
- * resolves a name -- today that is LibSocketAsio.cpp and the tests that pin
- * these decisions. Including it from a public header puts asio back into the
- * closure of most of src/, which is what this split undoes.
+ * Keeping this separate avoids compiling Asio socket headers in consumers that
+ * only need family predicates. Include it only where socket protocols or name
+ * resolution are needed.
  */
 namespace AddressFamilyPolicy
 {
@@ -76,25 +73,31 @@ inline boost::optional<boost::asio::ip::tcp> TcpProtocolForTarget(const CNetwork
 	return boost::asio::ip::tcp::v6();
 }
 
+/** An explicit lookup-family restriction; Any means unrestricted, not refusal. */
+enum class ResolverFamily
+{
+	Any,
+	IPv4Only,
+	IPv6Only
+};
+
 /**
- * The protocol to restrict a name lookup to.
+ * The family restriction for a name lookup.
  *
- * getaddrinfo() with an unrestricted family answers with AAAA records on any
- * host, whether or not it has IPv6 connectivity, so the query has to state the
- * family it wants. Under a dual-stack configuration there is nothing to state
- * and the caller should query unrestricted, hence the empty result.
+ * Dual stack requests an unrestricted lookup. A single-family configuration
+ * restricts results to that family; DNS results do not establish connectivity.
  */
-inline boost::optional<boost::asio::ip::tcp> TcpResolverProtocol() noexcept
+inline ResolverFamily TcpResolverProtocol() noexcept
 {
 	switch (Configured()) {
 	case Families::IPv4Only:
-		return boost::asio::ip::tcp::v4();
+		return ResolverFamily::IPv4Only;
 	case Families::IPv6Only:
-		return boost::asio::ip::tcp::v6();
+		return ResolverFamily::IPv6Only;
 	case Families::DualStack:
-		break;
+		return ResolverFamily::Any;
 	}
-	return boost::none;
+	return ResolverFamily::IPv4Only;
 }
 
 /** The IPv4 wildcard, @c 0.0.0.0. */
@@ -116,15 +119,10 @@ inline boost::asio::ip::address AnyIPv6Address() noexcept
  * The wildcard "any address of this machine" for a caller that has not said
  * which family it wants.
  *
- * This stays the IPv4 wildcard whenever IPv4 is permitted, dual stack included,
- * and that is deliberate. The callers are the ones that bind a single socket
- * and are not part of the ed2k dual-stack work: the external-connection
- * listener and the web server. Handing them @c :: because the ed2k listener now
- * wants both families would silently move the daemon's control channel onto
- * another family -- a change to what an EC client must dial, made as a side
- * effect. A caller that genuinely wants both families says so by asking for
- * AnyIPv6Address() and clearing @c IPV6_V6ONLY, which is what the ed2k
- * listeners do; see DualStackListeners.h.
+ * Prefer the IPv4 wildcard whenever IPv4 is permitted, including dual stack,
+ * to avoid implicitly moving a single-socket service to another family.
+ * Accepting both families on an IPv6 socket requires explicitly choosing
+ * AnyIPv6Address() and clearing @c IPV6_V6ONLY.
  */
 inline boost::asio::ip::address AnyAddress() noexcept
 {

--- a/src/AddressFamilyPolicyAsio.h
+++ b/src/AddressFamilyPolicyAsio.h
@@ -47,9 +47,14 @@
 /**
  * Socket-specific address-family policy and Boost.Asio values.
  *
- * Keeping this separate avoids compiling Asio socket headers in consumers that
- * only need family predicates. Include it only where socket protocols or name
- * resolution are needed.
+ * Split from AddressFamilyPolicy.h so that a translation unit which only needs
+ * to know @b whether a family is permitted does not compile asio's socket
+ * headers to find out. Unlike asio's ip/address.hpp, ip/tcp.hpp reaches the
+ * boost/asio/execution headers, which do not survive this tree's
+ * -Werror=deprecated gate unmodified -- see the measurement above the include.
+ * Include this only from a TU that opens a socket or resolves a name;
+ * including it from a public header puts asio back into the closure of most of
+ * src/, which is what the split undoes.
  */
 namespace AddressFamilyPolicy
 {
@@ -87,7 +92,7 @@ enum class ResolverFamily
  * Dual stack requests an unrestricted lookup. A single-family configuration
  * restricts results to that family; DNS results do not establish connectivity.
  */
-inline ResolverFamily TcpResolverProtocol() noexcept
+inline ResolverFamily ResolverFamilyForLookup() noexcept
 {
 	switch (Configured()) {
 	case Families::IPv4Only:

--- a/src/AddressFamilyPolicyAsio.h
+++ b/src/AddressFamilyPolicyAsio.h
@@ -1,0 +1,140 @@
+//
+// This file is part of the aMule Project.
+//
+// Copyright (c) 2003-2026 aMule Team ( https://amule-org.github.io )
+//
+// Any parts of this program derived from the xMule, lMule or eMule project,
+// or contributed by third-party developers are copyrighted by their
+// respective authors.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301, USA
+//
+
+#ifndef ADDRESSFAMILYPOLICYASIO_H
+#define ADDRESSFAMILYPOLICYASIO_H
+
+#include "AddressFamilyPolicy.h"
+
+#include <boost/optional.hpp>
+
+// See NetworkAddressAsio.h for why this wrap is here and why it is scoped to
+// exactly these two diagnostics. ip/tcp.hpp is the heavier of the two asio
+// headers this tree includes: it reaches boost/asio/execution/*.hpp, which is
+// where the redundant constexpr static definitions live.
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-copy-with-user-provided-dtor"
+#pragma clang diagnostic ignored "-Wdeprecated-redundant-constexpr-static-def"
+#endif
+#include <boost/asio/ip/tcp.hpp>
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+
+/**
+ * The half of AddressFamilyPolicy whose answers are Boost.Asio values.
+ *
+ * Split out of AddressFamilyPolicy.h so that the 93 translation units which
+ * only need to know *whether* a family is permitted stop compiling asio's
+ * socket headers to find out; the reasoning is spelled out at the bottom of
+ * that file. Include this only from a TU that actually opens a socket or
+ * resolves a name -- today that is LibSocketAsio.cpp and the tests that pin
+ * these decisions. Including it from a public header puts asio back into the
+ * closure of most of src/, which is what this split undoes.
+ */
+namespace AddressFamilyPolicy
+{
+
+/**
+ * The TCP protocol a socket towards @a target must be opened in.
+ *
+ * @return The protocol, or no value when @a target is absent or its family is
+ *         not permitted by the configuration. There is no fallback: opening a
+ *         v4 socket for a v6 target is how a truncated address turns into a
+ *         connection to the wrong host.
+ */
+inline boost::optional<boost::asio::ip::tcp> TcpProtocolForTarget(const CNetworkAddress &target) noexcept
+{
+	if (!Permits(target)) {
+		return boost::none;
+	}
+	if (target.IsIPv4() || target.IsIPv4Mapped()) {
+		return boost::asio::ip::tcp::v4();
+	}
+	return boost::asio::ip::tcp::v6();
+}
+
+/**
+ * The protocol to restrict a name lookup to.
+ *
+ * getaddrinfo() with an unrestricted family answers with AAAA records on any
+ * host, whether or not it has IPv6 connectivity, so the query has to state the
+ * family it wants. Under a dual-stack configuration there is nothing to state
+ * and the caller should query unrestricted, hence the empty result.
+ */
+inline boost::optional<boost::asio::ip::tcp> TcpResolverProtocol() noexcept
+{
+	switch (Configured()) {
+	case Families::IPv4Only:
+		return boost::asio::ip::tcp::v4();
+	case Families::IPv6Only:
+		return boost::asio::ip::tcp::v6();
+	case Families::DualStack:
+		break;
+	}
+	return boost::none;
+}
+
+/** The IPv4 wildcard, @c 0.0.0.0. */
+inline boost::asio::ip::address AnyIPv4Address() noexcept
+{
+	return boost::asio::ip::address(boost::asio::ip::address_v4::any());
+}
+
+/**
+ * The IPv6 wildcard, @c ::. With @c IPV6_V6ONLY off it also accepts IPv4 peers,
+ * which arrive in IPv4-mapped form.
+ */
+inline boost::asio::ip::address AnyIPv6Address() noexcept
+{
+	return boost::asio::ip::address(boost::asio::ip::address_v6::any());
+}
+
+/**
+ * The wildcard "any address of this machine" for a caller that has not said
+ * which family it wants.
+ *
+ * This stays the IPv4 wildcard whenever IPv4 is permitted, dual stack included,
+ * and that is deliberate. The callers are the ones that bind a single socket
+ * and are not part of the ed2k dual-stack work: the external-connection
+ * listener and the web server. Handing them @c :: because the ed2k listener now
+ * wants both families would silently move the daemon's control channel onto
+ * another family -- a change to what an EC client must dial, made as a side
+ * effect. A caller that genuinely wants both families says so by asking for
+ * AnyIPv6Address() and clearing @c IPV6_V6ONLY, which is what the ed2k
+ * listeners do; see DualStackListeners.h.
+ */
+inline boost::asio::ip::address AnyAddress() noexcept
+{
+	if (PermitsIPv4()) {
+		return AnyIPv4Address();
+	}
+	return AnyIPv6Address();
+}
+
+} // namespace AddressFamilyPolicy
+
+#endif // ADDRESSFAMILYPOLICYASIO_H
+// File_checked_for_headers

--- a/unittests/tests/AddressFamilyPolicyTest.cpp
+++ b/unittests/tests/AddressFamilyPolicyTest.cpp
@@ -1,0 +1,195 @@
+//
+// This file is part of the aMule Project.
+//
+// Copyright (c) 2003-2026 aMule Team ( https://amule-org.github.io )
+//
+// Any parts of this program derived from the xMule, lMule or eMule project,
+// or contributed by third-party developers are copyrighted by their
+// respective authors.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301, USA
+//
+
+// Which address families aMule opens sockets in.
+//
+// Two properties here are worth pinning for reasons that outlast this PR:
+//
+//   1. The default is IPv4-only. Piece 4 of the widening is gated so that
+//      nothing advertises IPv6 until a switch is deliberately turned on. A
+//      default of DualStack would hand the first caller dual stack with no
+//      switch thrown, leaving the gate in place but guarding nothing.
+//   2. Refusal never falls back. Opening a v4 socket towards a v6 target is
+//      how a truncated address becomes a connection to the wrong host, so a
+//      target the configuration forbids yields no protocol at all.
+//
+// The configured family is process-global mutable state, so every case below
+// restores what it found. The default is captured at static-initialisation
+// time rather than read inside a test, which is what keeps the first assertion
+// independent of the order the cases run in.
+
+#include <muleunit/test.h>
+
+#include <AddressFamilyPolicyAsio.h>
+
+using namespace muleunit;
+using namespace AddressFamilyPolicy;
+
+DECLARE_SIMPLE(AddressFamilyPolicy)
+
+//! Read before main(), so no test can have perturbed it.
+static const Families g_processDefault = Configured();
+
+namespace
+{
+//! Restores the configured family, so one case cannot leak into the next.
+class ScopedFamilies
+{
+public:
+	explicit ScopedFamilies(Families families)
+	: m_previous(Configured())
+	{
+		SetConfigured(families);
+	}
+	~ScopedFamilies() { SetConfigured(m_previous); }
+
+private:
+	Families m_previous;
+};
+
+CNetworkAddress Addr(const char *text)
+{
+	return CNetworkAddress::FromString(text);
+}
+} // namespace
+
+TEST(AddressFamilyPolicy, DefaultIsIPv4Only)
+{
+	// Captured before any case ran. If this fails, the widening advertises a
+	// family the gate was supposed to withhold.
+	ASSERT_TRUE(g_processDefault == Families::IPv4Only);
+}
+
+TEST(AddressFamilyPolicy, PermitsFollowsTheConfiguredFamilies)
+{
+	const CNetworkAddress v4 = Addr("192.0.2.1");
+	const CNetworkAddress v6 = Addr("2001:db8::1");
+	{
+		ScopedFamilies scope(Families::IPv4Only);
+		ASSERT_TRUE(Permits(v4));
+		ASSERT_FALSE(Permits(v6));
+	}
+	{
+		ScopedFamilies scope(Families::IPv6Only);
+		ASSERT_FALSE(Permits(v4));
+		ASSERT_TRUE(Permits(v6));
+	}
+	{
+		ScopedFamilies scope(Families::DualStack);
+		ASSERT_TRUE(Permits(v4));
+		ASSERT_TRUE(Permits(v6));
+	}
+}
+
+TEST(AddressFamilyPolicy, MappedIPv4IsIPv4ForPolicy)
+{
+	// It narrows losslessly, so an IPv4-only configuration can reach it -- and
+	// an IPv6-only one must not, or the policy would contradict IndexKey(),
+	// which collapses the two spellings to one peer.
+	const CNetworkAddress mapped = Addr("::ffff:192.0.2.1");
+	{
+		ScopedFamilies scope(Families::IPv4Only);
+		ASSERT_TRUE(Permits(mapped));
+	}
+	{
+		ScopedFamilies scope(Families::IPv6Only);
+		ASSERT_FALSE(Permits(mapped));
+	}
+}
+
+TEST(AddressFamilyPolicy, AbsentIsNeverPermitted)
+{
+	const CNetworkAddress absent = CNetworkAddress::Absent();
+	ScopedFamilies scope(Families::DualStack);
+	ASSERT_FALSE(Permits(absent));
+	ASSERT_FALSE(TcpProtocolForTarget(absent));
+}
+
+TEST(AddressFamilyPolicy, RefusalNeverFallsBackToTheOtherFamily)
+{
+	const CNetworkAddress v4 = Addr("192.0.2.1");
+	const CNetworkAddress v6 = Addr("2001:db8::1");
+	{
+		ScopedFamilies scope(Families::IPv4Only);
+		ASSERT_TRUE(TcpProtocolForTarget(v4) == boost::asio::ip::tcp::v4());
+		// Not v4() as a fallback: no protocol at all.
+		ASSERT_FALSE(TcpProtocolForTarget(v6));
+	}
+	{
+		ScopedFamilies scope(Families::IPv6Only);
+		ASSERT_FALSE(TcpProtocolForTarget(v4));
+		ASSERT_TRUE(TcpProtocolForTarget(v6) == boost::asio::ip::tcp::v6());
+	}
+	{
+		ScopedFamilies scope(Families::DualStack);
+		ASSERT_TRUE(TcpProtocolForTarget(v4) == boost::asio::ip::tcp::v4());
+		ASSERT_TRUE(TcpProtocolForTarget(v6) == boost::asio::ip::tcp::v6());
+		ASSERT_TRUE(TcpProtocolForTarget(Addr("::ffff:192.0.2.1")) == boost::asio::ip::tcp::v4());
+	}
+}
+
+TEST(AddressFamilyPolicy, ResolverIsUnrestrictedOnlyUnderDualStack)
+{
+	// Any means "do not restrict the lookup", not "refuse it". That distinction
+	// is why this returns its own enum rather than an optional protocol.
+	{
+		ScopedFamilies scope(Families::IPv4Only);
+		ASSERT_TRUE(ResolverFamilyForLookup() == ResolverFamily::IPv4Only);
+	}
+	{
+		ScopedFamilies scope(Families::IPv6Only);
+		ASSERT_TRUE(ResolverFamilyForLookup() == ResolverFamily::IPv6Only);
+	}
+	{
+		ScopedFamilies scope(Families::DualStack);
+		ASSERT_TRUE(ResolverFamilyForLookup() == ResolverFamily::Any);
+	}
+}
+
+TEST(AddressFamilyPolicy, AnyAddressStaysIPv4WhereverIPv4IsPermitted)
+{
+	// Including dual stack. Handing :: to the single-socket services (the EC
+	// listener, the web server) would move the daemon's control channel to
+	// another family as a side effect of the ed2k work.
+	{
+		ScopedFamilies scope(Families::IPv4Only);
+		ASSERT_TRUE(AnyAddress() == AnyIPv4Address());
+	}
+	{
+		ScopedFamilies scope(Families::DualStack);
+		ASSERT_TRUE(AnyAddress() == AnyIPv4Address());
+	}
+	{
+		ScopedFamilies scope(Families::IPv6Only);
+		ASSERT_TRUE(AnyAddress() == AnyIPv6Address());
+	}
+}
+
+TEST(AddressFamilyPolicy, WildcardsAreTheUnspecifiedAddresses)
+{
+	ASSERT_EQUALS(wxString("0.0.0.0"), wxString(AnyIPv4Address().to_string()));
+	ASSERT_EQUALS(wxString("::"), wxString(AnyIPv6Address().to_string()));
+}
+
+// File_checked_for_headers

--- a/unittests/tests/CMakeLists.txt
+++ b/unittests/tests/CMakeLists.txt
@@ -264,6 +264,33 @@ target_link_libraries (PeerAddressingTest
 	${Boost_LIBRARIES}
 )
 
+# Address families: which families sockets are opened in, and the refusal that
+# never falls back to the other family. Header-only policy over CNetworkAddress,
+# so it is testable without an app; NetworkAddress.cpp is linked for
+# FromString/ToString exactly as the two suites above do.
+add_executable (AddressFamilyPolicyTest
+	AddressFamilyPolicyTest.cpp
+	${CMAKE_SOURCE_DIR}/src/libs/common/Format.cpp
+	${CMAKE_SOURCE_DIR}/src/libs/common/strerror_r.c
+	${CMAKE_SOURCE_DIR}/src/NetworkAddress.cpp
+)
+
+add_test (NAME AddressFamilyPolicyTest
+	COMMAND AddressFamilyPolicyTest
+)
+
+target_include_directories (AddressFamilyPolicyTest
+	PRIVATE ${CMAKE_BINARY_DIR}
+	PRIVATE ${CMAKE_SOURCE_DIR}/src
+	PRIVATE ${CMAKE_SOURCE_DIR}/src/include
+	PRIVATE ${Boost_INCLUDE_DIR}
+)
+
+target_link_libraries (AddressFamilyPolicyTest
+	muleunit
+	${Boost_LIBRARIES}
+)
+
 add_executable (CUInt128Test
 	CUInt128Test.cpp
 	${CMAKE_SOURCE_DIR}/src/kademlia/utils/UInt128.cpp


### PR DESCRIPTION
Refs #1177

Third and final preparatory PR for piece 3. #1318 introduced the address value
type; #1345 made peer-address decisions explicit. This adds the policy that the
later socket call-sites will consult when they stop hard-coding IPv4.

## What this adds

Two header-only layers, with **no includes and no callers added elsewhere**:

- `AddressFamilyPolicy.h` is the Asio-free decision layer. It owns the configured
  family set (`IPv4Only`, `IPv6Only`, `DualStack`) and answers whether an address
  is permitted. It defaults to **IPv4-only**: piece 4 is the explicit gate that
  may opt into dual stack. Its storage is atomic because socket work reads it
  from Asio threads while startup will set it on the main thread.
- `AddressFamilyPolicyAsio.h` is the deliberately narrow Boost.Asio companion.
  It maps the policy and a target to an `ip::tcp` protocol, a named resolver
  family (`Any`, `IPv4Only`, `IPv6Only`) and wildcard bind addresses. The named
  resolver result avoids using an empty optional for both “refuse” and “query
  without a family constraint”.

Mapped IPv4 is explicitly IPv4 policy-wise. An absent target is never permitted.
Kad remains IPv4-only by design; this policy does not change that boundary.

## Inertness

This is two new headers plus a test suite that compiles them. No production
translation unit includes either header, and no socket, resolver, listener or
connection behavior changes. The later call-sites PR will add the
existing `LibSocketAsio.cpp` uses together, after the policy has had a focused
review.

The headers need the `CNetworkAddress` API already merged through #1345, which is
why this follows it.

## Boost warning containment

`ip/tcp.hpp` reaches Boost.Asio executor headers that are not reached through
`ip/address.hpp`. On AppleClang 21 with Boost 1.92, including it without the
local suppression produces 29 errors: 27 redundant `constexpr static` deprecation
errors and 2 copy-with-user-provided-destructor errors. Each suppression is
independently necessary; the pragma is intentionally local to this one include.

## Verification

- A C++14 syntax-only translation unit including both headers instantiated every
  public policy function/type for IPv4, native IPv6, mapped IPv4, absent targets,
  all configured families and all resolver-family values: clean.
- clang-format 18 and whitespace checks clean; `check-potfiles.sh` clean.
- `ctest` 60/60.
- The branch is based on current `master` after #1345.

No production target compiles the policy yet, which is the inertness boundary.
`AddressFamilyPolicyTest` compiles and exercises it without crossing that line,
the same arrangement #1318 and #1345 used: eight cases over the default, the
family predicates, refusal, resolver families and the wildcards, each checked
by perturbation. That also puts the headers in front of every CI toolchain
rather than clang-format alone.

