### PR TITLE
feat(net): carry uTP datagrams on the shared UDP port

### DIFF
--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -276,20 +276,10 @@ if (NEED_LIB_MULEAPPCOMMON OR BUILD_WEBSERVER)
 	option (ENABLE_UPNP "enable UPnP support in aMule" ON)
 endif()
 
-# Builds the vendored libutp and nothing else. It does not enable a transport,
-# a protocol byte or any behaviour a peer can observe: no aMule source links
-# Utp::Utp yet, so an ENABLE_UTP=YES build and a default one ship the same
-# binaries. The switch exists so the uTP work can arrive as reviewable pieces
-# rather than as a transport and its dependency in one diff.
-#
-# In AMULE_EXPERIMENTAL_OPTIONS below, which is what gets the 5,000-odd vendored
-# lines compiled by the CI jobs that ask for the whole set. The compile
-# definition that membership adds is read by nothing today; that is a smaller
-# problem than a snapshot no job compiles, and it stops being inert when the
-# transport arrives.
-#
-# ON requires CMake 3.12 -- see cmake/libutp.cmake.
-option (ENABLE_UTP "build the vendored libutp (dependency only; enables no uTP behaviour yet)" OFF)
+# Experimental IPv4 uTP datagram framing in amule/amuled only. No stream
+# acceptance, dialing, or capability advertisement. Requires CMake 3.12;
+# see cmake/libutp.cmake.
+option (ENABLE_UTP "enable experimental uTP datagram framing (no stream transport)" OFF)
 
 # Master switch for the in-app "check for a new aMule version" feature: the
 # startup notification, the "Check for new version at startup" preference, and

--- a/cmake/source-vars.cmake
+++ b/cmake/source-vars.cmake
@@ -54,6 +54,10 @@ if (BUILD_MONOLITHIC OR BUILD_DAEMON)
 		ThreadTasks.cpp
 	)
 
+	if (ENABLE_UTP)
+		list (APPEND CORE_SOURCES UtpLibraryAdapter.cpp)
+	endif()
+
 	# Only compiled in when the switch is on. Every call site is behind the
 	# same guard, so with the switch off these two would be dead weight in
 	# the binary; the unit tests compile them directly, so gating them here

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -253,6 +253,11 @@ if (BUILD_DAEMON)
 		)
 	endif()
 
+	if (ENABLE_UTP)
+		target_link_libraries (amuled PRIVATE Utp::Utp)
+		target_compile_definitions (amuled PRIVATE AMULE_UTP_TRANSPORT)
+	endif()
+
 	target_compile_definitions (amuled
 		PRIVATE AMULE_DAEMON
 		PRIVATE wxUSE_GUI=0
@@ -363,6 +368,11 @@ if (BUILD_MONOLITHIC)
 		target_sources (amule
 			PRIVATE ${CMAKE_BINARY_DIR}/version.rc ${CMAKE_SOURCE_DIR}/amule.rc
 		)
+	endif()
+
+	if (ENABLE_UTP)
+		target_link_libraries (amule PRIVATE Utp::Utp)
+		target_compile_definitions (amule PRIVATE AMULE_UTP_TRANSPORT)
 	endif()
 
 	target_link_libraries (amule

--- a/src/ClientUDPSocket.cpp
+++ b/src/ClientUDPSocket.cpp
@@ -49,6 +49,9 @@
 #include "kademlia/utils/KadUDPKey.h"
 #include <zlib.h>
 #include "EncryptedDatagramSocket.h"
+#ifdef AMULE_UTP_TRANSPORT
+#include "UtpLibraryAdapter.h"
+#endif
 
 //
 // CClientUDPSocket -- Extended eMule UDP socket
@@ -56,11 +59,35 @@
 
 CClientUDPSocket::CClientUDPSocket(const amuleIPV4Address &address, const CProxyData *ProxyData)
 : CMuleUDPSocket("Client UDP-Socket", ID_CLIENTUDPSOCKET_EVENT, address, ProxyData)
+#ifdef AMULE_UTP_TRANSPORT
+, m_utp(CreateUtpLibrary(), *this)
+#endif
 {
 	if (!thePrefs::IsUDPDisabled()) {
 		Open();
 	}
 }
+
+#ifdef AMULE_UTP_TRANSPORT
+void CClientUDPSocket::Close()
+{
+	wxASSERT(wxIsMainThread());
+	m_utp.Destroy();
+	CMuleUDPSocket::Close();
+}
+
+void CClientUDPSocket::TickUtp()
+{
+	wxASSERT(wxIsMainThread());
+	m_utp.Tick();
+}
+
+void CClientUDPSocket::SendUtpDatagram(const uint8_t *payload, size_t length, uint32_t ip, uint16_t port)
+{
+	wxASSERT(wxIsMainThread());
+	QueueUtpDatagram<CPacket>(*this, payload, length, ip, port);
+}
+#endif
 
 void CClientUDPSocket::OnReceive(int errorCode)
 {
@@ -201,16 +228,30 @@ void CClientUDPSocket::ProcessReservedProt2Frame(
 		break;
 	}
 
-	// The five registered types. Every one of them belongs to a transport
-	// this build does not have, so each is dropped here rather than in a
-	// shared fallthrough: the change that ships a transport replaces its own
-	// case and nothing else, and until then a peer's NAT-T attempt is a
-	// recognised frame aMule cannot serve rather than malformed traffic.
+	// The registered types. Each is dropped in its own case rather than in a
+	// shared fallthrough, so that the change which ships a transport replaces
+	// its own case and nothing else -- which is what the uTP case below now is.
+	// The other four still belong to transports this build does not have, and a
+	// peer's attempt at one of them is a recognised frame aMule cannot serve
+	// rather than malformed traffic.
 	switch (classified.type) {
 	case OP_NATT_FRAME_UTP:
+#ifdef AMULE_UTP_TRANSPORT
+		wxASSERT(wxIsMainThread());
+		if (ProcessUtpFrame(m_utp, classified, ip, port)) {
+			return;
+		}
+		// Reached only when libutp has seen the datagram and disclaimed it:
+		// it belongs to no connection it holds. A different reason from the
+		// types below, so it does not borrow their message.
+		AddDebugLogLineN(logClientUDP,
+			CFormat("Dropping uTP frame from %s:%u: not for any open uTP connection") %
+				Uint32toStringIP(ip) % port);
+#else
 		AddDebugLogLineN(logClientUDP,
 			CFormat("Ignoring uTP NAT-T frame from %s:%u: no uTP transport in this build") %
 				Uint32toStringIP(ip) % port);
+#endif
 		break;
 
 	case OP_NATT_FRAME_QUIC:

--- a/src/ClientUDPSocket.cpp
+++ b/src/ClientUDPSocket.cpp
@@ -91,8 +91,8 @@ void CClientUDPSocket::SendUtpDatagram(const uint8_t *payload, size_t length, ui
 		length,
 		ip,
 		port,
-		peer != NULL && peer->ShouldReceiveCryptUDPPackets(),
-		peer != NULL ? peer->GetUserHash().GetHash() : NULL);
+		peer != nullptr && peer->ShouldReceiveCryptUDPPackets(),
+		peer != nullptr ? peer->GetUserHash().GetHash() : nullptr);
 }
 #endif
 

--- a/src/ClientUDPSocket.cpp
+++ b/src/ClientUDPSocket.cpp
@@ -85,7 +85,14 @@ void CClientUDPSocket::TickUtp()
 void CClientUDPSocket::SendUtpDatagram(const uint8_t *payload, size_t length, uint32_t ip, uint16_t port)
 {
 	wxASSERT(wxIsMainThread());
-	QueueUtpDatagram<CPacket>(*this, payload, length, ip, port);
+	const auto *peer = theApp->clientlist->FindClientByIP(ip, port);
+	QueueUtpDatagram<CPacket>(*this,
+		payload,
+		length,
+		ip,
+		port,
+		peer != NULL && peer->ShouldReceiveCryptUDPPackets(),
+		peer != NULL ? peer->GetUserHash().GetHash() : NULL);
 }
 #endif
 

--- a/src/ClientUDPSocket.h
+++ b/src/ClientUDPSocket.h
@@ -29,16 +29,32 @@
 #include "MuleUDPSocket.h"
 #include "ReservedProtocolFrames.h" // Needed for CUnknownFrameLogThrottle
 
+#ifdef AMULE_UTP_TRANSPORT
+#include "UtpContext.h"
+#endif
+
 class CClientUDPSocket : public CMuleUDPSocket
+#ifdef AMULE_UTP_TRANSPORT
+,
+			 private IUtpDatagramSink
+#endif
 {
 public:
 	CClientUDPSocket(const amuleIPV4Address &address, const CProxyData *ProxyData = NULL);
+#ifdef AMULE_UTP_TRANSPORT
+	void Close() override;
+	void TickUtp();
+#endif
 
 protected:
-	void OnReceive(int errorCode);
+	void OnReceive(int errorCode) override;
 
 private:
-	void OnPacketReceived(uint32 ip, uint16 port, uint8_t *buffer, size_t length);
+#ifdef AMULE_UTP_TRANSPORT
+	void SendUtpDatagram(const uint8_t *payload, size_t length, uint32_t ip, uint16_t port) override;
+	CUtpContext m_utp;
+#endif
+	void OnPacketReceived(uint32 ip, uint16 port, uint8_t *buffer, size_t length) override;
 	void ProcessPacket(uint8_t *packet, int16 size, int8 opcode, uint32 host, uint16 port);
 
 	/**

--- a/src/MuleUDPSocket.h
+++ b/src/MuleUDPSocket.h
@@ -85,7 +85,7 @@ public:
 	 * The socket can be reopened by calling Open. Closing a
 	 * already closed socket is an illegal operation.
 	 */
-	void Close();
+	virtual void Close();
 
 	/** This function is called by aMule when the socket may send. */
 	virtual void OnSend(int errorCode);

--- a/src/MuleUDPSocket.h
+++ b/src/MuleUDPSocket.h
@@ -85,6 +85,8 @@ public:
 	 * The socket can be reopened by calling Open. Closing a
 	 * already closed socket is an illegal operation.
 	 */
+	// Gating virtual would make class layout depend on a define in this widely included header.
+	// The only other subclass, CServerUDPSocket, declares no Close().
 	virtual void Close();
 
 	/** This function is called by aMule when the socket may send. */

--- a/src/UtpContext.h
+++ b/src/UtpContext.h
@@ -126,19 +126,19 @@ inline bool ProcessUtpFrame(
 //
 // Taken as a bool rather than a sockaddr so this stays free of socket headers
 // and testable without one; the adapter does the sa_family comparison.
-constexpr unsigned kUtpEnvelopeBytes = 2;
+constexpr std::uint64_t kUtpEnvelopeBytes = 2;
 
 constexpr std::uint64_t UtpUdpMtu(bool isIPv6)
 {
 	// IPv4:   1500 ethernet - 20 IPv4 - 8 UDP - 24 GRE - 8 PPPoE - 2 MPPE - 36 fudge.
 	// Teredo: 1280 - 40 IPv6 - 8 UDP.
-	return (isIPv6 ? 1232u : 1402u) - kUtpEnvelopeBytes;
+	return (isIPv6 ? UINT64_C(1232) : UINT64_C(1402)) - kUtpEnvelopeBytes;
 }
 
 constexpr std::uint64_t UtpUdpOverhead(bool isIPv6)
 {
 	// IPv4: 20 + 8. Teredo: that, plus 40 IPv6 + 8 UDP again.
-	return (isIPv6 ? 76u : 28u) + kUtpEnvelopeBytes;
+	return (isIPv6 ? UINT64_C(76) : UINT64_C(28)) + kUtpEnvelopeBytes;
 }
 
 // Keep CPacket's application types out of the libutp translation unit.

--- a/src/UtpContext.h
+++ b/src/UtpContext.h
@@ -1,0 +1,129 @@
+//
+// This file is part of the aMule Project.
+//
+// Copyright (c) 2003-2026 aMule Team ( https://amule-org.github.io )
+//
+// Any parts of this program derived from the xMule, lMule or eMule project,
+// or contributed by third-party developers are copyrighted by their
+// respective authors.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301, USA
+//
+
+#ifndef UTP_CONTEXT_H
+#define UTP_CONTEXT_H
+
+#include "ReservedProtocolFrames.h"
+#include <memory>
+#include <utility>
+
+// IPv4 uses aMule's low-byte-first integer representation; ports are host order.
+class IUtpDatagramSink
+{
+public:
+	virtual ~IUtpDatagramSink() = default;
+	virtual void SendUtpDatagram(const uint8_t *payload, size_t length, uint32_t ip, uint16_t port) = 0;
+};
+
+class IUtpContext
+{
+public:
+	virtual ~IUtpContext() = default;
+	virtual bool Configure() = 0;
+	virtual void Destroy() = 0;
+	virtual bool ProcessDatagram(const uint8_t *payload, size_t length, uint32_t ip, uint16_t port) = 0;
+	virtual void Tick() = 0;
+};
+
+// Library seam: no libutp types or stream operations escape the adapter.
+class IUtpLibrary
+{
+public:
+	virtual ~IUtpLibrary() = default;
+	virtual bool Create(IUtpDatagramSink &sink) = 0;
+	virtual void Destroy() = 0;
+	virtual bool ProcessDatagram(const uint8_t *payload, size_t length, uint32_t ip, uint16_t port) = 0;
+	virtual void IssueDeferredAcks() = 0;
+	virtual void CheckTimeouts() = 0;
+};
+
+// Main-thread only. Tick never recreates state abandoned by socket Close().
+class CUtpContext final : public IUtpContext
+{
+public:
+	CUtpContext(std::unique_ptr<IUtpLibrary> library, IUtpDatagramSink &sink)
+	: m_library(std::move(library))
+	, m_sink(sink)
+	{
+	}
+	~CUtpContext() override { Destroy(); }
+	bool Configure() override
+	{
+		if (!m_active) {
+			m_active = m_library->Create(m_sink);
+		}
+		return m_active;
+	}
+	void Destroy() override
+	{
+		if (m_active) {
+			m_library->Destroy();
+			m_active = false;
+		}
+	}
+	bool ProcessDatagram(const uint8_t *payload, size_t length, uint32_t ip, uint16_t port) override
+	{
+		return Configure() && m_library->ProcessDatagram(payload, length, ip, port);
+	}
+	void Tick() override
+	{
+		if (m_active) {
+			m_library->IssueDeferredAcks();
+			m_library->CheckTimeouts();
+		}
+	}
+
+private:
+	std::unique_ptr<IUtpLibrary> m_library;
+	IUtpDatagramSink &m_sink;
+	bool m_active = false;
+};
+
+inline bool ProcessUtpFrame(
+	IUtpContext &context, const SReservedProt2Frame &frame, uint32_t ip, uint16_t port)
+{
+	return frame.disposition == RP2_KNOWN_TYPE && frame.type == OP_NATT_FRAME_UTP &&
+	       context.ProcessDatagram(frame.payload, frame.payloadLength, ip, port);
+}
+
+// Keep CPacket's application types out of the libutp translation unit.
+// The real socket and fake queue exercise this same plaintext send path.
+template <typename Packet, typename Socket>
+void QueueUtpDatagram(Socket &socket, const uint8_t *payload, size_t length, uint32_t ip, uint16_t port)
+{
+	// Maximum IPv4 UDP payload, less the aMule envelope.
+	if (length > 65507 - 2 || (length != 0 && payload == nullptr)) {
+		return;
+	}
+	auto packet = std::make_unique<Packet>(
+		OP_NATT_FRAME_UTP, static_cast<uint32_t>(length), OP_UDPRESERVEDPROT2);
+	if (length != 0) {
+		packet->CopyToDataBuffer(0, payload, static_cast<unsigned int>(length));
+	}
+	socket.SendPacket(packet.release(), ip, port, false, nullptr, false, 0);
+}
+
+#endif // UTP_CONTEXT_H
+// File_checked_for_headers

--- a/src/UtpContext.h
+++ b/src/UtpContext.h
@@ -85,7 +85,12 @@ public:
 	}
 	bool ProcessDatagram(const uint8_t *payload, size_t length, uint32_t ip, uint16_t port) override
 	{
-		return Configure() && m_library->ProcessDatagram(payload, length, ip, port);
+		if (!Configure()) {
+			return false;
+		}
+		const bool claimed = m_library->ProcessDatagram(payload, length, ip, port);
+		m_library->IssueDeferredAcks();
+		return claimed;
 	}
 	void Tick() override
 	{
@@ -109,9 +114,14 @@ inline bool ProcessUtpFrame(
 }
 
 // Keep CPacket's application types out of the libutp translation unit.
-// The real socket and fake queue exercise this same plaintext send path.
 template <typename Packet, typename Socket>
-void QueueUtpDatagram(Socket &socket, const uint8_t *payload, size_t length, uint32_t ip, uint16_t port)
+void QueueUtpDatagram(Socket &socket,
+	const uint8_t *payload,
+	size_t length,
+	uint32_t ip,
+	uint16_t port,
+	bool encrypt,
+	const uint8_t *hash)
 {
 	// Maximum IPv4 UDP payload, less the aMule envelope.
 	if (length > 65507 - 2 || (length != 0 && payload == nullptr)) {
@@ -122,7 +132,7 @@ void QueueUtpDatagram(Socket &socket, const uint8_t *payload, size_t length, uin
 	if (length != 0) {
 		packet->CopyToDataBuffer(0, payload, static_cast<unsigned int>(length));
 	}
-	socket.SendPacket(packet.release(), ip, port, false, nullptr, false, 0);
+	socket.SendPacket(packet.release(), ip, port, encrypt, hash, false, 0);
 }
 
 #endif // UTP_CONTEXT_H

--- a/src/UtpContext.h
+++ b/src/UtpContext.h
@@ -26,6 +26,8 @@
 #define UTP_CONTEXT_H
 
 #include "ReservedProtocolFrames.h"
+
+#include <cstdint>
 #include <memory>
 #include <utility>
 
@@ -111,6 +113,32 @@ inline bool ProcessUtpFrame(
 {
 	return frame.disposition == RP2_KNOWN_TYPE && frame.type == OP_NATT_FRAME_UTP &&
 	       context.ProcessDatagram(frame.payload, frame.payloadLength, ip, port);
+}
+
+// UDP sizing for libutp, accounting for the two-byte aMule envelope.
+//
+// libutp's own defaults (utp_default_get_udp_mtu / _overhead in utp_utils.cpp)
+// branch on the address family and know nothing of the envelope, so overriding
+// them is what makes libutp size packets that do not fragment. Branching the
+// same way is what keeps the family awareness those defaults had: an IPv6 peer
+// costs 20 more header bytes than IPv4, and libutp assumes Teredo because it
+// cannot know the local interface either.
+//
+// Taken as a bool rather than a sockaddr so this stays free of socket headers
+// and testable without one; the adapter does the sa_family comparison.
+constexpr unsigned kUtpEnvelopeBytes = 2;
+
+constexpr std::uint64_t UtpUdpMtu(bool isIPv6)
+{
+	// IPv4:   1500 ethernet - 20 IPv4 - 8 UDP - 24 GRE - 8 PPPoE - 2 MPPE - 36 fudge.
+	// Teredo: 1280 - 40 IPv6 - 8 UDP.
+	return (isIPv6 ? 1232u : 1402u) - kUtpEnvelopeBytes;
+}
+
+constexpr std::uint64_t UtpUdpOverhead(bool isIPv6)
+{
+	// IPv4: 20 + 8. Teredo: that, plus 40 IPv6 + 8 UDP again.
+	return (isIPv6 ? 76u : 28u) + kUtpEnvelopeBytes;
 }
 
 // Keep CPacket's application types out of the libutp translation unit.

--- a/src/UtpLibraryAdapter.cpp
+++ b/src/UtpLibraryAdapter.cpp
@@ -89,14 +89,13 @@ private:
 		sink->SendUtpDatagram(args->buf, args->len, ip, ntohs(address->sin_port));
 		return 0;
 	}
-	static uint64 GetUdpMtu(utp_callback_arguments *)
+	static uint64 GetUdpMtu(utp_callback_arguments *args)
 	{
-		// Vendored libutp's conservative IPv4 UDP MTU (1402), less the aMule envelope.
-		return 1402 - 2;
+		return UtpUdpMtu(args->address->sa_family == AF_INET6);
 	}
-	static uint64 GetUdpOverhead(utp_callback_arguments *)
+	static uint64 GetUdpOverhead(utp_callback_arguments *args)
 	{
-		return 20 + 8 + 2; // IPv4 + UDP + aMule envelope.
+		return UtpUdpOverhead(args->address->sa_family == AF_INET6);
 	}
 	utp_context *m_context = nullptr;
 };

--- a/src/UtpLibraryAdapter.cpp
+++ b/src/UtpLibraryAdapter.cpp
@@ -1,0 +1,109 @@
+//
+// This file is part of the aMule Project.
+//
+// Copyright (c) 2003-2026 aMule Team ( https://amule-org.github.io )
+//
+// Any parts of this program derived from the xMule, lMule or eMule project,
+// or contributed by third-party developers are copyrighted by their
+// respective authors.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301, USA
+//
+
+#include "UtpLibraryAdapter.h"
+#include <libutp/utp.h>
+
+namespace
+{
+class CUtpLibraryAdapter final : public IUtpLibrary
+{
+public:
+	~CUtpLibraryAdapter() override { Destroy(); }
+	bool Create(IUtpDatagramSink &sink) override
+	{
+		if (m_context) {
+			return true;
+		}
+		m_context = utp_init(2);
+		if (!m_context) {
+			return false;
+		}
+		utp_context_set_userdata(m_context, &sink);
+		utp_set_callback(m_context, UTP_SENDTO, SendTo);
+		utp_set_callback(m_context, UTP_GET_UDP_MTU, GetUdpMtu);
+		utp_set_callback(m_context, UTP_GET_UDP_OVERHEAD, GetUdpOverhead);
+		// Leaving UTP_ON_ACCEPT unset refuses inbound SYNs, so this slice cannot serve streams.
+		return true;
+	}
+	void Destroy() override
+	{
+		if (m_context) {
+			utp_destroy(m_context);
+			m_context = nullptr;
+		}
+	}
+	bool ProcessDatagram(const uint8_t *payload, size_t length, uint32_t ip, uint16_t port) override
+	{
+		sockaddr_in address{};
+		address.sin_family = AF_INET;
+		address.sin_port = htons(port);
+		auto *bytes = reinterpret_cast<uint8_t *>(&address.sin_addr.s_addr);
+		for (unsigned i = 0; i < 4; ++i) {
+			bytes[i] = static_cast<uint8_t>(ip >> (8 * i));
+		}
+		return utp_process_udp(m_context,
+			       payload,
+			       length,
+			       reinterpret_cast<const sockaddr *>(&address),
+			       sizeof(address)) != 0;
+	}
+	void IssueDeferredAcks() override { utp_issue_deferred_acks(m_context); }
+	void CheckTimeouts() override { utp_check_timeouts(m_context); }
+
+private:
+	static uint64 SendTo(utp_callback_arguments *args)
+	{
+		if (!args->address || args->address->sa_family != AF_INET ||
+			args->address_len < sizeof(sockaddr_in)) {
+			return 0;
+		}
+		const auto *address = reinterpret_cast<const sockaddr_in *>(args->address);
+		const auto *bytes = reinterpret_cast<const uint8_t *>(&address->sin_addr.s_addr);
+		uint32_t ip = 0;
+		for (unsigned i = 0; i < 4; ++i) {
+			ip |= static_cast<uint32_t>(bytes[i]) << (8 * i);
+		}
+		auto *sink = static_cast<IUtpDatagramSink *>(utp_context_get_userdata(args->context));
+		sink->SendUtpDatagram(args->buf, args->len, ip, ntohs(address->sin_port));
+		return 0;
+	}
+	static uint64 GetUdpMtu(utp_callback_arguments *)
+	{
+		// Vendored libutp's conservative IPv4 UDP MTU (1402), less the aMule envelope.
+		return 1402 - 2;
+	}
+	static uint64 GetUdpOverhead(utp_callback_arguments *)
+	{
+		return 20 + 8 + 2; // IPv4 + UDP + aMule envelope.
+	}
+	utp_context *m_context = nullptr;
+};
+} // namespace
+
+std::unique_ptr<IUtpLibrary> CreateUtpLibrary()
+{
+	return std::make_unique<CUtpLibraryAdapter>();
+}
+// File_checked_for_headers

--- a/src/UtpLibraryAdapter.h
+++ b/src/UtpLibraryAdapter.h
@@ -1,0 +1,33 @@
+//
+// This file is part of the aMule Project.
+//
+// Copyright (c) 2003-2026 aMule Team ( https://amule-org.github.io )
+//
+// Any parts of this program derived from the xMule, lMule or eMule project,
+// or contributed by third-party developers are copyrighted by their
+// respective authors.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301, USA
+//
+
+#ifndef UTP_LIBRARY_ADAPTER_H
+#define UTP_LIBRARY_ADAPTER_H
+
+#include "UtpContext.h"
+
+std::unique_ptr<IUtpLibrary> CreateUtpLibrary();
+
+#endif // UTP_LIBRARY_ADAPTER_H
+// File_checked_for_headers

--- a/src/amule.cpp
+++ b/src/amule.cpp
@@ -2033,9 +2033,11 @@ void CamuleApp::OnCoreTimer(CTimerEvent &WXUNUSED(evt))
 	recurse = true;
 
 #ifdef AMULE_UTP_TRANSPORT
-	if (clientudp) {
-		clientudp->TickUtp();
-	}
+	// Unguarded like the queues below: ReinitializeNetwork() always constructs
+	// clientudp, disabled UDP included -- it simply leaves it unopened. A null
+	// check here would also tell the static analyser that the Kad recovery's
+	// clientudp->Close() further down can be reached with a null pointer.
+	clientudp->TickUtp();
 #endif
 
 	uploadqueue->Process();

--- a/src/amule.cpp
+++ b/src/amule.cpp
@@ -2032,6 +2032,12 @@ void CamuleApp::OnCoreTimer(CTimerEvent &WXUNUSED(evt))
 	}
 	recurse = true;
 
+#ifdef AMULE_UTP_TRANSPORT
+	if (clientudp) {
+		clientudp->TickUtp();
+	}
+#endif
+
 	uploadqueue->Process();
 	downloadqueue->Process();
 	// theApp->clientcredits->Process();

--- a/unittests/tests/CMakeLists.txt
+++ b/unittests/tests/CMakeLists.txt
@@ -1,3 +1,22 @@
+if (ENABLE_UTP)
+	add_executable (UtpContextTest
+		UtpContextTest.cpp
+		${CMAKE_SOURCE_DIR}/src/Packet.cpp
+		${CMAKE_SOURCE_DIR}/src/Tag.cpp
+		${CMAKE_SOURCE_DIR}/src/MemFile.cpp
+		${CMAKE_SOURCE_DIR}/src/SafeFile.cpp
+		${CMAKE_SOURCE_DIR}/src/libs/common/Format.cpp
+		${CMAKE_SOURCE_DIR}/src/libs/common/strerror_r.c
+	)
+	target_include_directories (UtpContextTest PRIVATE
+		${CMAKE_BINARY_DIR}
+		${CMAKE_SOURCE_DIR}/src
+		${CMAKE_SOURCE_DIR}/src/include
+	)
+	target_link_libraries (UtpContextTest muleunit ZLIB::ZLIB)
+	add_test (NAME UtpContextTest COMMAND UtpContextTest)
+endif()
+
 add_executable (CTagTest
 	CTagTest.cpp
 	${CMAKE_SOURCE_DIR}/src/SafeFile.cpp

--- a/unittests/tests/UtpContextTest.cpp
+++ b/unittests/tests/UtpContextTest.cpp
@@ -1,0 +1,238 @@
+//
+// This file is part of the aMule Project.
+//
+// Copyright (c) 2003-2026 aMule Team ( https://amule-org.github.io )
+//
+// Any parts of this program derived from the xMule, lMule or eMule project,
+// or contributed by third-party developers are copyrighted by their
+// respective authors.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301, USA
+//
+
+#include <muleunit/test.h>
+#include "UtpContext.h"
+#include "Packet.h"
+#include <vector>
+
+using namespace muleunit;
+DECLARE_SIMPLE(UtpContext)
+
+namespace
+{
+struct State
+{
+	int creates = 0, destroys = 0, receives = 0, acks = 0, timeouts = 0;
+	bool claimed = true, createSucceeds = true;
+	uint32_t ip = 0;
+	uint16_t port = 0;
+	std::vector<uint8_t> payload;
+	IUtpDatagramSink *sink = nullptr;
+};
+
+class FakeLibrary : public IUtpLibrary
+{
+public:
+	explicit FakeLibrary(State &state)
+	: s(state)
+	{
+	}
+	bool Create(IUtpDatagramSink &sink) override
+	{
+		++s.creates;
+		s.sink = &sink;
+		return s.createSucceeds;
+	}
+	void Destroy() override
+	{
+		++s.destroys;
+		s.payload.clear();
+		s.sink = nullptr;
+	}
+	bool ProcessDatagram(const uint8_t *data, size_t len, uint32_t ip, uint16_t port) override
+	{
+		++s.receives;
+		s.payload.assign(data, data + len);
+		s.ip = ip;
+		s.port = port;
+		return s.claimed;
+	}
+	void IssueDeferredAcks() override { ++s.acks; }
+	void CheckTimeouts() override { ++s.timeouts; }
+
+private:
+	State &s;
+};
+
+class Sink : public IUtpDatagramSink
+{
+public:
+	std::vector<uint8_t> wire;
+	uint32_t ip = 0;
+	uint16_t port = 0;
+	bool encrypted = true, kad = true, hasHash = true;
+	uint32_t key = 1;
+	void SendUtpDatagram(const uint8_t *data, size_t len, uint32_t address, uint16_t service) override
+	{
+		QueueUtpDatagram<CPacket>(*this, data, len, address, service);
+	}
+	void SendPacket(CPacket *raw,
+		uint32_t address,
+		uint16_t service,
+		bool encrypt,
+		const uint8_t *hash,
+		bool isKad,
+		uint32_t verifyKey)
+	{
+		std::unique_ptr<CPacket> packet(raw);
+		wire.assign(packet->GetUDPHeader(), packet->GetUDPHeader() + 2);
+		wire.insert(wire.end(),
+			packet->GetDataBuffer(),
+			packet->GetDataBuffer() + packet->GetPacketSize());
+		ip = address;
+		port = service;
+		encrypted = encrypt;
+		kad = isKad;
+		hasHash = hash != nullptr;
+		key = verifyKey;
+	}
+};
+} // namespace
+
+TEST(UtpContext, ClassifiedPayloadAndClaimArePreserved)
+{
+	State state;
+	Sink sink;
+	CUtpContext context(std::make_unique<FakeLibrary>(state), sink);
+	const uint8_t wire[] = { 0xB2, 0x00, 0x41, 0x00, 0xFF, 0xB2 };
+	const auto frame = ClassifyReservedProt2Frame(wire + 1, sizeof(wire) - 1);
+	ASSERT_TRUE(ProcessUtpFrame(context, frame, 0x04030201, 4665));
+	ASSERT_EQUALS(4, (int)state.payload.size());
+	for (size_t i = 0; i < state.payload.size(); ++i) {
+		ASSERT_EQUALS((int)wire[i + 2], (int)state.payload[i]);
+	}
+	ASSERT_EQUALS(0x04030201u, state.ip);
+	ASSERT_EQUALS(4665, (int)state.port);
+	state.claimed = false;
+	ASSERT_FALSE(ProcessUtpFrame(context, frame, state.ip, state.port));
+	ASSERT_EQUALS(1, state.creates);
+}
+
+TEST(UtpContext, OtherTypesNeverReachLibrary)
+{
+	State state;
+	Sink sink;
+	CUtpContext context(std::make_unique<FakeLibrary>(state), sink);
+	for (unsigned type = 1; type <= 255; ++type) {
+		const uint8_t frame[] = { static_cast<uint8_t>(type), 0x41 };
+		ASSERT_FALSE(
+			ProcessUtpFrame(context, ClassifyReservedProt2Frame(frame, sizeof(frame)), 1, 2));
+	}
+	ASSERT_FALSE(ProcessUtpFrame(context, ClassifyReservedProt2Frame(nullptr, 0), 1, 2));
+	ASSERT_EQUALS(0, state.creates);
+	ASSERT_EQUALS(0, state.receives);
+}
+
+TEST(UtpContext, LibrarySendUsesLiteralPlaintextEnvelope)
+{
+	State state;
+	Sink sink;
+	CUtpContext context(std::make_unique<FakeLibrary>(state), sink);
+	ASSERT_TRUE(context.Configure());
+	const uint8_t payload[] = { 0x41, 0x00, 0xFF, 0xB2 };
+	state.sink->SendUtpDatagram(payload, sizeof(payload), 0x04030201, 65535);
+	ASSERT_EQUALS(6, (int)sink.wire.size());
+	ASSERT_EQUALS(0xB2, (int)sink.wire[0]);
+	ASSERT_EQUALS(0x00, (int)sink.wire[1]);
+	for (size_t i = 0; i < sizeof(payload); ++i) {
+		ASSERT_EQUALS((int)payload[i], (int)sink.wire[i + 2]);
+	}
+	ASSERT_EQUALS(0x04030201u, sink.ip);
+	ASSERT_EQUALS(65535, (int)sink.port);
+	ASSERT_FALSE(sink.encrypted);
+	ASSERT_FALSE(sink.kad);
+	ASSERT_FALSE(sink.hasHash);
+	ASSERT_EQUALS(0u, sink.key);
+}
+
+TEST(UtpContext, TickAndCloseAbandonStateUntilNextDatagram)
+{
+	State state;
+	Sink sink;
+	{
+		CUtpContext context(std::make_unique<FakeLibrary>(state), sink);
+		context.Tick();
+		ASSERT_EQUALS(0, state.creates);
+		ASSERT_EQUALS(0, state.acks);
+		const uint8_t payload[] = { 0x41 };
+		ASSERT_TRUE(context.ProcessDatagram(payload, sizeof(payload), 1, 2));
+		context.Tick();
+		ASSERT_EQUALS(1, state.acks);
+		ASSERT_EQUALS(1, state.timeouts);
+		context.Destroy(); // The operation used by CClientUDPSocket::Close.
+		ASSERT_EQUALS(1, state.destroys);
+		ASSERT_TRUE(state.payload.empty());
+		context.Destroy();
+		context.Tick();
+		ASSERT_EQUALS(1, state.destroys);
+		ASSERT_EQUALS(1, state.acks);
+		ASSERT_EQUALS(1, state.timeouts);
+		ASSERT_TRUE(context.ProcessDatagram(payload, sizeof(payload), 3, 4));
+		ASSERT_EQUALS(2, state.creates);
+	}
+	ASSERT_EQUALS(2, state.destroys);
+}
+
+TEST(UtpContext, EmptyPayloadIsHandedToLibraryWithoutEnvelope)
+{
+	State state;
+	state.claimed = false;
+	Sink sink;
+	CUtpContext context(std::make_unique<FakeLibrary>(state), sink);
+	const uint8_t wire[] = { 0xB2, 0x00 };
+	ASSERT_FALSE(ProcessUtpFrame(context, ClassifyReservedProt2Frame(wire + 1, sizeof(wire) - 1), 1, 2));
+	ASSERT_EQUALS(1, state.receives);
+	ASSERT_TRUE(state.payload.empty());
+}
+
+TEST(UtpContext, OutgoingEmptyAndInvalidPayloads)
+{
+	Sink sink;
+	sink.SendUtpDatagram(nullptr, 0, 1, 2);
+	ASSERT_EQUALS(2, (int)sink.wire.size());
+	ASSERT_EQUALS(0xB2, (int)sink.wire[0]);
+	ASSERT_EQUALS(0x00, (int)sink.wire[1]);
+	sink.wire.clear();
+	sink.SendUtpDatagram(nullptr, 1, 1, 2);
+	ASSERT_TRUE(sink.wire.empty());
+	const uint8_t payload[] = { 0x41 };
+	sink.SendUtpDatagram(payload, 65506, 1, 2);
+	ASSERT_TRUE(sink.wire.empty());
+}
+
+TEST(UtpContext, FailedCreationDropsWithoutMaintenance)
+{
+	State state;
+	state.createSucceeds = false;
+	Sink sink;
+	CUtpContext context(std::make_unique<FakeLibrary>(state), sink);
+	const uint8_t frame[] = { 0x00 };
+	ASSERT_FALSE(ProcessUtpFrame(context, ClassifyReservedProt2Frame(frame, sizeof(frame)), 1, 2));
+	context.Tick();
+	ASSERT_EQUALS(0, state.receives);
+	ASSERT_EQUALS(0, state.acks);
+	ASSERT_EQUALS(0, state.timeouts);
+}
+// File_checked_for_headers

--- a/unittests/tests/UtpContextTest.cpp
+++ b/unittests/tests/UtpContextTest.cpp
@@ -79,14 +79,20 @@ private:
 class Sink : public IUtpDatagramSink
 {
 public:
-	std::vector<uint8_t> wire;
+	std::vector<uint8_t> wire, peerHash, sentHash;
 	uint32_t ip = 0;
 	uint16_t port = 0;
 	bool encrypted = true, kad = true, hasHash = true;
 	uint32_t key = 1;
 	void SendUtpDatagram(const uint8_t *data, size_t len, uint32_t address, uint16_t service) override
 	{
-		QueueUtpDatagram<CPacket>(*this, data, len, address, service);
+		QueueUtpDatagram<CPacket>(*this,
+			data,
+			len,
+			address,
+			service,
+			!peerHash.empty(),
+			peerHash.empty() ? nullptr : peerHash.data());
 	}
 	void SendPacket(CPacket *raw,
 		uint32_t address,
@@ -106,6 +112,10 @@ public:
 		encrypted = encrypt;
 		kad = isKad;
 		hasHash = hash != nullptr;
+		sentHash.clear();
+		if (hash) {
+			sentHash.assign(hash, hash + 16);
+		}
 		key = verifyKey;
 	}
 };
@@ -145,7 +155,7 @@ TEST(UtpContext, OtherTypesNeverReachLibrary)
 	ASSERT_EQUALS(0, state.receives);
 }
 
-TEST(UtpContext, LibrarySendUsesLiteralPlaintextEnvelope)
+TEST(UtpContext, LibrarySendIsPlaintextWhenNoPeerKnown)
 {
 	State state;
 	Sink sink;
@@ -167,6 +177,45 @@ TEST(UtpContext, LibrarySendUsesLiteralPlaintextEnvelope)
 	ASSERT_EQUALS(0u, sink.key);
 }
 
+TEST(UtpContext, LibrarySendIsEncryptedWithHashWhenPeerKnown)
+{
+	State state;
+	Sink sink;
+	sink.peerHash = { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16 };
+	CUtpContext context(std::make_unique<FakeLibrary>(state), sink);
+	ASSERT_TRUE(context.Configure());
+	const uint8_t payload[] = { 0x41, 0x00, 0xFF, 0xB2 };
+	state.sink->SendUtpDatagram(payload, sizeof(payload), 0x04030201, 65535);
+	ASSERT_EQUALS(6, (int)sink.wire.size());
+	ASSERT_EQUALS(0xB2, (int)sink.wire[0]);
+	ASSERT_EQUALS(0x00, (int)sink.wire[1]);
+	for (size_t i = 0; i < sizeof(payload); ++i) {
+		ASSERT_EQUALS((int)payload[i], (int)sink.wire[i + 2]);
+	}
+	ASSERT_EQUALS(0x04030201u, sink.ip);
+	ASSERT_EQUALS(65535, (int)sink.port);
+	ASSERT_TRUE(sink.encrypted);
+	ASSERT_TRUE(sink.hasHash);
+	ASSERT_TRUE(sink.sentHash == sink.peerHash);
+	ASSERT_FALSE(sink.kad);
+	ASSERT_EQUALS(0u, sink.key);
+}
+
+TEST(UtpContext, ProcessingIssuesDeferredAcksWithoutTick)
+{
+	State state;
+	Sink sink;
+	CUtpContext context(std::make_unique<FakeLibrary>(state), sink);
+	const uint8_t payload[] = { 0x41 };
+	ASSERT_TRUE(context.ProcessDatagram(payload, sizeof(payload), 1, 2));
+	ASSERT_EQUALS(1, state.acks);
+	ASSERT_EQUALS(0, state.timeouts);
+	state.claimed = false;
+	ASSERT_FALSE(context.ProcessDatagram(payload, sizeof(payload), 1, 2));
+	ASSERT_EQUALS(2, state.acks);
+	ASSERT_EQUALS(0, state.timeouts);
+}
+
 TEST(UtpContext, TickAndCloseAbandonStateUntilNextDatagram)
 {
 	State state;
@@ -179,7 +228,7 @@ TEST(UtpContext, TickAndCloseAbandonStateUntilNextDatagram)
 		const uint8_t payload[] = { 0x41 };
 		ASSERT_TRUE(context.ProcessDatagram(payload, sizeof(payload), 1, 2));
 		context.Tick();
-		ASSERT_EQUALS(1, state.acks);
+		ASSERT_EQUALS(2, state.acks);
 		ASSERT_EQUALS(1, state.timeouts);
 		context.Destroy(); // The operation used by CClientUDPSocket::Close.
 		ASSERT_EQUALS(1, state.destroys);
@@ -187,7 +236,7 @@ TEST(UtpContext, TickAndCloseAbandonStateUntilNextDatagram)
 		context.Destroy();
 		context.Tick();
 		ASSERT_EQUALS(1, state.destroys);
-		ASSERT_EQUALS(1, state.acks);
+		ASSERT_EQUALS(2, state.acks);
 		ASSERT_EQUALS(1, state.timeouts);
 		ASSERT_TRUE(context.ProcessDatagram(payload, sizeof(payload), 3, 4));
 		ASSERT_EQUALS(2, state.creates);

--- a/unittests/tests/UtpContextTest.cpp
+++ b/unittests/tests/UtpContextTest.cpp
@@ -284,4 +284,22 @@ TEST(UtpContext, FailedCreationDropsWithoutMaintenance)
 	ASSERT_EQUALS(0, state.acks);
 	ASSERT_EQUALS(0, state.timeouts);
 }
+TEST(UtpContext, UdpSizingKeepsTheFamilyAwarenessLibutpHad)
+{
+	// libutp's own defaults branch on the address family; overriding them for the
+	// two-byte envelope must not flatten that, or an IPv6 peer gets IPv4 numbers
+	// and libutp sizes packets 20 bytes too large.
+	ASSERT_EQUALS(1400ull, UtpUdpMtu(false));
+	ASSERT_EQUALS(1230ull, UtpUdpMtu(true));
+	ASSERT_EQUALS(30ull, UtpUdpOverhead(false));
+	ASSERT_EQUALS(78ull, UtpUdpOverhead(true));
+
+	// The envelope is what the override exists for: each is libutp's own
+	// constant moved by exactly two bytes, in the direction that leaves room.
+	ASSERT_EQUALS(1402ull - kUtpEnvelopeBytes, UtpUdpMtu(false));
+	ASSERT_EQUALS(1232ull - kUtpEnvelopeBytes, UtpUdpMtu(true));
+	ASSERT_EQUALS(28ull + kUtpEnvelopeBytes, UtpUdpOverhead(false));
+	ASSERT_EQUALS(76ull + kUtpEnvelopeBytes, UtpUdpOverhead(true));
+}
+
 // File_checked_for_headers


### PR DESCRIPTION
Refs #1177

Second of the uTP pieces, on top of the vendoring in #1353. `0xB2 0x00` frames
stop being dropped and reach libutp; libutp's outgoing datagrams go back out
under the same two bytes, on the UDP port aMule already has.

## Still not a transport

`UTP_ON_ACCEPT` is deliberately left unset, which is what makes this reviewable
on its own: vendored libutp refuses an inbound SYN when that callback is absent,
so this carries datagrams for a connection and serves none. No ed2k stream, no
`CLibSocket` substitution, no outbound dial, no capability bit, no
`CAPS`/`CAPS_ACK`, no rendezvous, no QUIC, no IPv6.

Nothing advertises uTP, so no peer will start one. What this establishes is the
carrier and its lifetime, which is the part the stream PR should not have to
argue about at the same time as socket ownership.

## Where it hooks in

At the existing `case OP_NATT_FRAME_UTP` — after decryption, after
`ClassifyReservedProt2Frame` — so the classifier stays the single place that
reads the envelope. The payload handed over excludes the two envelope bytes.
The other four reserved types keep their exact messages and drop paths; the
change replaces one case, which is the shape the comment there predicted.

A datagram libutp disclaims falls through to a drop, but with its own message:
"not for any open uTP connection" is a different fact from "no uTP transport in
this build", and with the switch on the second one would be untrue.

## Lifetime and threading

The context is a member of `CClientUDPSocket`, so it dies with the socket
object — which covers `ReinitializeNetwork()` recreating it. `Close()` is now
virtual and overridden to destroy the context first, so the Kad recovery
`Close(); Open();` cycle abandons uTP state with the socket rather than keeping
connections whose NAT mapping is gone. It is recreated lazily.

Main thread only: the UDP receive callback and `OnCoreTimer`, which services
deferred ACKs and timeouts. `UTP_SENDTO` never transmits — it queues a `CPacket`
through the existing `SendPacket` path, so the socket and the throttler keep
owning transmission.

## Shape

`UtpContext.h` is libutp-free and holds the seam; `UtpLibraryAdapter.cpp` is the
only translation unit that includes `<libutp/utp.h>`. Only `UTP_SENDTO`,
`UTP_GET_UDP_MTU` and `UTP_GET_UDP_OVERHEAD` are set, the last two accounting
for the two-byte envelope so libutp does not size packets that fragment. Those
two branch on the address family the way libutp's own defaults do, so
overriding them for the envelope does not cost an IPv6 peer the correct
header sizes. Everything else libutp needs, the clock and the RNG included,
comes from the defaults its context constructor installs.

## Tests and verification

`UtpContextTest`, ten cases on the fake seam: the payload arrives without the
envelope and byte-exact, address and port survive, a claimed datagram does not
reach the drop path while an unclaimed one does, processing a datagram issues
deferred ACKs without waiting for a tick, an outgoing datagram is plaintext
when no peer is known and encrypted with the peer's hash when one is,
`Tick()` issues deferred ACKs and timeout checks, `Close()` abandons the
context, and the UDP sizing keeps a distinct answer per address family.

| Configuration | Apps | ctest |
| --- | --- | --- |
| default | amule, amuled, amulegui | 60/60 |
| `-DENABLE_UTP=YES` | amule, amuled, amulegui | 61/61 |

`amulegui` is `CLIENT_GUI` and has no core, so it is excluded by construction —
measured, not assumed: with the switch on, its link line contains no libutp, it
gets no `AMULE_UTP_TRANSPORT`, and `UtpLibraryAdapter.cpp.o` is not in its
object list, while both `amule` and `amuled` have all three.

clang-format 18, `git diff --check` and `check-potfiles.sh` clean.

## Not covered

The fake seam proves our framing and lifetime, not that the vendored library
works through these callbacks — no test drives real libutp end to end here. The
natural place for that is the PR that serves a stream, where a loopback test can
assert a transfer rather than a handshake. Say if you would rather have it now.

