### PR TITLE
feat(net): add the stream buffering a uTP transport needs

### DIFF
--- a/src/StreamTransport.h
+++ b/src/StreamTransport.h
@@ -1,0 +1,85 @@
+//
+// This file is part of the aMule Project.
+//
+// Copyright (c) 2003-2026 aMule Team ( https://amule-org.github.io )
+//
+// Any parts of this program derived from the xMule, lMule or eMule project,
+// or contributed by third-party developers are copyrighted by their
+// respective authors.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301, USA
+//
+
+#ifndef STREAMTRANSPORT_H
+#define STREAMTRANSPORT_H
+
+#include <cstddef>
+#include <cstdint>
+
+/**
+ * What a byte stream has to do to stand in for a TCP socket here.
+ *
+ * The eD2k stack above -- CEMSocket and everything it carries -- is written
+ * against CLibSocket, so a second transport is only possible if it answers the
+ * same questions. This is that set of questions, named once, so a transport can
+ * be written and tested without a socket, a peer, or the app.
+ *
+ * The contract that matters is the would-block one, because CEMSocket depends
+ * on it rather than merely tolerating it:
+ *
+ *   - a read or write that cannot proceed returns 0, sets the matching Blocks
+ *     flag, and leaves LastError() at 0;
+ *   - a transport that returns 0 with an error set is reporting a dead
+ *     connection, and the stack drops the peer.
+ *
+ * Returning 0 and an error for a full send window is therefore not a cosmetic
+ * mistake: it disconnects a peer whose window will open a millisecond later.
+ *
+ * Deliberately free of Boost.Asio and of libutp. Both exist below this line;
+ * neither belongs in the include closure of the code that only wants bytes.
+ */
+class IStreamTransport
+{
+public:
+	virtual ~IStreamTransport() = default;
+
+	//! Whether the stream has completed its handshake and not yet ended.
+	virtual bool IsConnected() const = 0;
+
+	//! Whether the stream is usable. False once it has failed or been closed.
+	virtual bool IsOk() const = 0;
+
+	//! Bytes moved into @a buffer. 0 with BlocksRead() means "not yet", not "never".
+	virtual uint32_t Read(void *buffer, uint32_t length) = 0;
+
+	//! Bytes accepted from @a buffer. 0 with BlocksWrite() means "not yet", not "never".
+	virtual uint32_t Write(const void *buffer, uint32_t length) = 0;
+
+	//! Ends the stream. Calling it twice must be harmless.
+	virtual void Close() = 0;
+
+	virtual bool BlocksRead() const = 0;
+	virtual bool BlocksWrite() const = 0;
+
+	//! 0 unless the stream actually failed. Never set for a would-block.
+	virtual int LastError() const = 0;
+
+	//! Peer address in aMule's host-order-agnostic 32-bit form, and its port.
+	virtual uint32_t GetPeerAddress() const = 0;
+	virtual uint16_t GetPeerPort() const = 0;
+};
+
+#endif // STREAMTRANSPORT_H
+// File_checked_for_headers

--- a/src/StreamTransport.h
+++ b/src/StreamTransport.h
@@ -25,6 +25,8 @@
 #ifndef STREAMTRANSPORT_H
 #define STREAMTRANSPORT_H
 
+#include "NetworkAddress.h"
+
 #include <cstddef>
 #include <cstdint>
 
@@ -73,11 +75,31 @@ public:
 	virtual bool BlocksRead() const = 0;
 	virtual bool BlocksWrite() const = 0;
 
-	//! 0 unless the stream actually failed. Never set for a would-block.
+	/**
+	 * Zero unless the stream actually failed. Never set for a would-block.
+	 *
+	 * Only its truthiness is defined: the value is opaque and carries no
+	 * meaning a caller may act on. It shares its name and type with the
+	 * wx-backed `CLibSocket::LastError()`, so the trap this warns about is a
+	 * call site reaching for a `wxSOCKET_*` comparison and matching by
+	 * coincidence. Implementations keep their values outside that range so
+	 * such a comparison cannot accidentally succeed; ask the transport for
+	 * the reason instead.
+	 */
 	virtual int LastError() const = 0;
 
-	//! Peer address in aMule's host-order-agnostic 32-bit form, and its port.
-	virtual uint32_t GetPeerAddress() const = 0;
+	/**
+	 * The peer's address, full width.
+	 *
+	 * Deliberately not the 32-bit form `CLibSocket::GetPeerInt()` returns,
+	 * even though mirroring it would make substitution simpler: this series
+	 * exists because a peer's identity does not fit in 32 bits, and a new
+	 * interface that narrows by construction would put back exactly what
+	 * NetworkAddress.h was added to remove. A call site that genuinely needs
+	 * the eD2k wire form narrows with ToIPv4NetworkOrder() and handles the
+	 * failure, which is the point of that API.
+	 */
+	virtual CNetworkAddress GetPeerAddress() const = 0;
 	virtual uint16_t GetPeerPort() const = 0;
 };
 

--- a/src/StreamTransport.h
+++ b/src/StreamTransport.h
@@ -79,12 +79,12 @@ public:
 	 * Zero unless the stream actually failed. Never set for a would-block.
 	 *
 	 * Only its truthiness is defined: the value is opaque and carries no
-	 * meaning a caller may act on. It shares its name and type with the
-	 * wx-backed `CLibSocket::LastError()`, so the trap this warns about is a
-	 * call site reaching for a `wxSOCKET_*` comparison and matching by
-	 * coincidence. Implementations keep their values outside that range so
-	 * such a comparison cannot accidentally succeed; ask the transport for
-	 * the reason instead.
+	 * meaning a caller may act on. It shares its name and type with
+	 * `CLibSocket::LastError()`, which returns a boost error_code value, so
+	 * the trap this warns about is a call site comparing against an errno or
+	 * WinSock constant and matching by coincidence. Implementations keep
+	 * their values outside those ranges so such a comparison cannot
+	 * accidentally succeed; ask the transport for the reason instead.
 	 */
 	virtual int LastError() const = 0;
 

--- a/src/UtpStream.h
+++ b/src/UtpStream.h
@@ -126,11 +126,17 @@ public:
 	//! What libutp's read-buffer-size callback should report.
 	size_t ReadBufferSize() const { return m_readBuffer.size(); }
 
-	//! The occupancy above which libutp should stop advertising window.
+	/**
+	 * The value the acceptor passes to utp_setsockopt(UTP_RCVBUF).
+	 *
+	 * libutp applies the bound itself: get_rcv_window() advertises
+	 * opt_rcvbuf minus what ReadBufferSize() reports, so a reader that falls
+	 * behind shrinks the window to zero and the peer stops. Nothing here
+	 * compares the two, because a predicate over them would only be useful
+	 * for refusing a payload, and refusing one drops bytes the peer already
+	 * paid to send.
+	 */
 	size_t ReadBound() const { return m_readBound; }
-
-	//! Whether the reader is behind far enough to want the peer to slow down.
-	bool ReadBufferAboveBound() const { return m_readBuffer.size() >= m_readBound; }
 
 	//! True once per drain, for the caller that owns the libutp notification.
 	bool ConsumeReadDrainedEdge()

--- a/src/UtpStream.h
+++ b/src/UtpStream.h
@@ -49,19 +49,30 @@
 class CUtpStream
 {
 public:
-	/**
-	 * Default bound on unsent bytes. One eD2k block plus headroom.
-	 *
-	 * A function rather than a static const member because under C++14 the
-	 * latter still needs an out-of-line definition the moment anything
-	 * odr-uses it -- binding it to a reference, which std::min() does -- and
-	 * the failure is a link error in the caller's translation unit rather
-	 * than anything visible here.
-	 */
-	static constexpr size_t DefaultWriteBound() { return 256 * 1024; }
+	//! Default bound on unsent bytes. One eD2k block plus headroom.
+	static constexpr size_t kDefaultWriteBound = 256 * 1024;
 
-	explicit CUtpStream(size_t writeBound = DefaultWriteBound())
+	/**
+	 * Default bound on buffered received bytes.
+	 *
+	 * @b Not a cap that drops bytes: libutp can deliver more than this in one
+	 * callback and received data is never discarded, because a byte thrown
+	 * away here is a hole in a file the peer already paid to send. It is the
+	 * number UTP_GET_READ_BUFFER_SIZE reports, which is how libutp decides to
+	 * stop advertising receive window -- so the bound is applied by the peer
+	 * slowing down, one round trip later, rather than by this class refusing
+	 * anything.
+	 *
+	 * Inert until the acceptor wires that callback. It is decided here so the
+	 * acceptor inherits a value rather than inventing one, and so both
+	 * directions are bounded: an unbounded read buffer is how a peer that
+	 * sends faster than the application reads grows memory without limit.
+	 */
+	static constexpr size_t kDefaultReadBound = 64 * 1024;
+
+	explicit CUtpStream(size_t writeBound = kDefaultWriteBound, size_t readBound = kDefaultReadBound)
 	: m_writeBound(writeBound)
+	, m_readBound(readBound)
 	{
 	}
 
@@ -114,6 +125,12 @@ public:
 
 	//! What libutp's read-buffer-size callback should report.
 	size_t ReadBufferSize() const { return m_readBuffer.size(); }
+
+	//! The occupancy above which libutp should stop advertising window.
+	size_t ReadBound() const { return m_readBound; }
+
+	//! Whether the reader is behind far enough to want the peer to slow down.
+	bool ReadBufferAboveBound() const { return m_readBuffer.size() >= m_readBound; }
 
 	//! True once per drain, for the caller that owns the libutp notification.
 	bool ConsumeReadDrainedEdge()
@@ -185,8 +202,20 @@ public:
 	EUtpTransportFailure Failure() const { return m_failure; }
 	bool IsTerminal() const { return IsUtpTerminal(m_failure); }
 
-	//! Nonzero only for a real failure. EOF and destroying are ends, not errors.
-	int LastError() const { return IsUtpFailure(m_failure) ? static_cast<int>(m_failure) : 0; }
+	/**
+	 * Nonzero only for a real failure. EOF and destroying are ends, not errors.
+	 *
+	 * The value is opaque: only its truthiness is defined. It is offset past
+	 * the wxSocketError range on purpose, because this stands in for the
+	 * wx-backed CLibSocket::LastError() under the same name and type, and a
+	 * call site reaching for `== wxSOCKET_INVOP` would otherwise match by
+	 * coincidence -- wrong, and silent. Callers wanting the reason ask
+	 * Failure().
+	 */
+	int LastError() const
+	{
+		return IsUtpFailure(m_failure) ? kErrorBase + static_cast<int>(m_failure) : 0;
+	}
 
 	bool BlocksRead() const { return m_blocksRead; }
 	bool BlocksWrite() const { return m_blocksWrite; }
@@ -196,9 +225,13 @@ public:
 	bool CloseTaken() const { return m_close.Taken(); }
 
 private:
+	//! Past every wxSocketError, so a stray comparison against one cannot match.
+	static constexpr int kErrorBase = 0x7500;
+
 	std::deque<uint8_t> m_readBuffer;
 	std::deque<uint8_t> m_writeBuffer;
 	size_t m_writeBound;
+	size_t m_readBound;
 	bool m_blocksRead = false;
 	bool m_blocksWrite = false;
 	bool m_readDrainedDue = false;

--- a/src/UtpStream.h
+++ b/src/UtpStream.h
@@ -27,7 +27,8 @@
 
 #include "UtpTransportFailure.h"
 
-#include <cstring>
+#include <cstddef>
+#include <cstdint>
 #include <deque>
 #include <vector>
 
@@ -47,10 +48,18 @@
 class CUtpStream
 {
 public:
-	//! Default bound on unsent bytes. One eD2k block plus headroom.
-	static const size_t kDefaultWriteBound = 256 * 1024;
+	/**
+	 * Default bound on unsent bytes. One eD2k block plus headroom.
+	 *
+	 * A function rather than a static const member because under C++14 the
+	 * latter still needs an out-of-line definition the moment anything
+	 * odr-uses it -- binding it to a reference, which std::min() does -- and
+	 * the failure is a link error in the caller's translation unit rather
+	 * than anything visible here.
+	 */
+	static constexpr size_t DefaultWriteBound() { return 256 * 1024; }
 
-	explicit CUtpStream(size_t writeBound = kDefaultWriteBound)
+	explicit CUtpStream(size_t writeBound = DefaultWriteBound())
 	: m_writeBound(writeBound)
 	{
 	}

--- a/src/UtpStream.h
+++ b/src/UtpStream.h
@@ -27,6 +27,7 @@
 
 #include "UtpTransportFailure.h"
 
+#include <algorithm>
 #include <cstddef>
 #include <cstdint>
 #include <deque>
@@ -95,11 +96,11 @@ public:
 			return 0;
 		}
 		const size_t taken = available < length ? available : length;
-		uint8_t *out = static_cast<uint8_t *>(buffer);
-		for (size_t i = 0; i < taken; ++i) {
-			out[i] = m_readBuffer[i];
-		}
-		m_readBuffer.erase(m_readBuffer.begin(), m_readBuffer.begin() + taken);
+		const auto consumed = static_cast<std::deque<uint8_t>::difference_type>(taken);
+		std::copy(m_readBuffer.begin(),
+			m_readBuffer.begin() + consumed,
+			static_cast<uint8_t *>(buffer));
+		m_readBuffer.erase(m_readBuffer.begin(), m_readBuffer.begin() + consumed);
 		m_blocksRead = false;
 		if (m_readBuffer.empty()) {
 			// libutp stops delivering while the application is behind, and

--- a/src/UtpStream.h
+++ b/src/UtpStream.h
@@ -170,13 +170,29 @@ public:
 
 	size_t WriteBufferSize() const { return m_writeBuffer.size(); }
 
-	//! Hands the queued bytes to the caller that will pass them to libutp.
-	std::vector<uint8_t> TakeQueuedBytes()
+	//! The queued bytes, for the caller that will offer them to libutp.
+	std::vector<uint8_t> PeekQueuedBytes() const
 	{
-		std::vector<uint8_t> bytes(m_writeBuffer.begin(), m_writeBuffer.end());
-		m_writeBuffer.clear();
-		m_blocksWrite = false;
-		return bytes;
+		return std::vector<uint8_t>(m_writeBuffer.begin(), m_writeBuffer.end());
+	}
+
+	/**
+	 * Drops the bytes libutp accepted and keeps the rest queued.
+	 *
+	 * utp_write() returns how much it took, which is less than it was offered
+	 * as soon as the congestion window is full and zero while the socket is
+	 * not connected. Handing the whole queue out and clearing it would leave
+	 * the caller holding the refused tail with nowhere to put it back, so it
+	 * would need a second queue that WriteBufferSize() cannot see and
+	 * m_writeBound does not bound. Peek, offer, then consume what was taken.
+	 */
+	void ConsumeQueuedBytes(size_t accepted)
+	{
+		const size_t queued = m_writeBuffer.size();
+		const size_t drop = accepted < queued ? accepted : queued;
+		m_writeBuffer.erase(m_writeBuffer.begin(),
+			m_writeBuffer.begin() + static_cast<std::deque<uint8_t>::difference_type>(drop));
+		m_blocksWrite = m_writeBuffer.size() >= m_writeBound;
 	}
 
 	//! The peer's window opened again.
@@ -203,14 +219,26 @@ public:
 	bool IsTerminal() const { return IsUtpTerminal(m_failure); }
 
 	/**
+	 * Whether the stream is still usable, as IStreamTransport::IsOk() means it.
+	 *
+	 * A clean EOF ends the stream without failing it, so Write() refuses with
+	 * 0 while BlocksWrite() and LastError() are both still 0. Those two alone
+	 * describe a would-block, which this is not, so the difference has to be
+	 * askable rather than inferred from the pair.
+	 */
+	bool IsOk() const { return !IsTerminal(); }
+
+	/**
 	 * Nonzero only for a real failure. EOF and destroying are ends, not errors.
 	 *
-	 * The value is opaque: only its truthiness is defined. It is offset past
-	 * the wxSocketError range on purpose, because this stands in for the
-	 * wx-backed CLibSocket::LastError() under the same name and type, and a
-	 * call site reaching for `== wxSOCKET_INVOP` would otherwise match by
-	 * coincidence -- wrong, and silent. Callers wanting the reason ask
-	 * Failure().
+	 * The value is opaque: only its truthiness is defined. It is offset out of
+	 * the way on purpose, because this stands in for CLibSocket::LastError()
+	 * under the same name and type and a call site comparing against a known
+	 * constant would otherwise match by coincidence -- wrong, and silent.
+	 * CLibSocket::LastError() returns a boost error_code value (see
+	 * m_ErrorCode in LibSocketAsio.cpp), so the range to clear is errno on
+	 * POSIX and the WinSock codes on Windows, not wxSocketError. Callers
+	 * wanting the reason ask Failure().
 	 */
 	int LastError() const
 	{
@@ -225,7 +253,8 @@ public:
 	bool CloseTaken() const { return m_close.Taken(); }
 
 private:
-	//! Past every wxSocketError, so a stray comparison against one cannot match.
+	//! Above errno, the WinSock range (10000-11999) and wxSocketError alike,
+	//! so a stray comparison against any of them cannot match.
 	static constexpr int kErrorBase = 0x7500;
 
 	std::deque<uint8_t> m_readBuffer;

--- a/src/UtpStream.h
+++ b/src/UtpStream.h
@@ -1,0 +1,200 @@
+//
+// This file is part of the aMule Project.
+//
+// Copyright (c) 2003-2026 aMule Team ( https://amule-org.github.io )
+//
+// Any parts of this program derived from the xMule, lMule or eMule project,
+// or contributed by third-party developers are copyrighted by their
+// respective authors.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301, USA
+//
+
+#ifndef UTPSTREAM_H
+#define UTPSTREAM_H
+
+#include "UtpTransportFailure.h"
+
+#include <cstring>
+#include <deque>
+#include <vector>
+
+/**
+ * The buffering a uTP stream needs, with no libutp in sight.
+ *
+ * libutp hands bytes up in a callback and takes bytes down through a call, and
+ * neither happens when the eD2k stack above wants it to. This holds the two
+ * queues in between and answers the would-block questions CEMSocket asks, so
+ * the state machine can be tested without a library, a socket or a peer.
+ *
+ * It calls nothing. Read-drained and window notifications are the transport's
+ * to send, from the main thread; this only reports when they are due, because a
+ * class that both buffers bytes and re-enters libutp is the one that deadlocks
+ * when libutp calls back into it.
+ */
+class CUtpStream
+{
+public:
+	//! Default bound on unsent bytes. One eD2k block plus headroom.
+	static const size_t kDefaultWriteBound = 256 * 1024;
+
+	explicit CUtpStream(size_t writeBound = kDefaultWriteBound)
+	: m_writeBound(writeBound)
+	{
+	}
+
+	// -- inbound ------------------------------------------------------
+
+	//! Bytes arrived from the peer. Called from libutp's read callback.
+	void OnPayload(const uint8_t *data, size_t length)
+	{
+		if (data == nullptr || length == 0) {
+			return;
+		}
+		m_readBuffer.insert(m_readBuffer.end(), data, data + length);
+		m_blocksRead = false;
+	}
+
+	/**
+	 * Moves buffered bytes out.
+	 *
+	 * An empty buffer is a would-block, not an end: 0 bytes, BlocksRead() set,
+	 * LastError() still 0. Once the peer has sent EOF an empty buffer is the
+	 * end of the stream instead, and that is the one case where 0 means no
+	 * more bytes are coming.
+	 */
+	uint32_t Read(void *buffer, uint32_t length)
+	{
+		if (buffer == nullptr || length == 0) {
+			return 0;
+		}
+		const size_t available = m_readBuffer.size();
+		if (available == 0) {
+			m_blocksRead = !IsTerminal();
+			return 0;
+		}
+		const size_t taken = available < length ? available : length;
+		uint8_t *out = static_cast<uint8_t *>(buffer);
+		for (size_t i = 0; i < taken; ++i) {
+			out[i] = m_readBuffer[i];
+		}
+		m_readBuffer.erase(m_readBuffer.begin(), m_readBuffer.begin() + taken);
+		m_blocksRead = false;
+		if (m_readBuffer.empty()) {
+			// libutp stops delivering while the application is behind, and
+			// resumes on utp_read_drained(). Owed exactly once per drain:
+			// sending it again with an already-empty buffer is a wakeup for
+			// nothing, and never sending it stalls the peer permanently.
+			m_readDrainedDue = true;
+		}
+		return static_cast<uint32_t>(taken);
+	}
+
+	//! What libutp's read-buffer-size callback should report.
+	size_t ReadBufferSize() const { return m_readBuffer.size(); }
+
+	//! True once per drain, for the caller that owns the libutp notification.
+	bool ConsumeReadDrainedEdge()
+	{
+		const bool due = m_readDrainedDue;
+		m_readDrainedDue = false;
+		return due;
+	}
+
+	// -- outbound -----------------------------------------------------
+
+	/**
+	 * Queues bytes for the peer.
+	 *
+	 * A full queue is a would-block: 0 bytes, BlocksWrite() set, no error. The
+	 * bound exists because libutp accepts writes into its own send buffer
+	 * without limit, so an unbounded queue here would let a stalled peer grow
+	 * memory until the upload thread noticed, which it has no way to do.
+	 */
+	uint32_t Write(const void *buffer, uint32_t length)
+	{
+		if (IsTerminal() || buffer == nullptr || length == 0) {
+			return 0;
+		}
+		const size_t queued = m_writeBuffer.size();
+		if (queued >= m_writeBound) {
+			m_blocksWrite = true;
+			return 0;
+		}
+		const size_t room = m_writeBound - queued;
+		const size_t taken = room < length ? room : length;
+		const uint8_t *in = static_cast<const uint8_t *>(buffer);
+		m_writeBuffer.insert(m_writeBuffer.end(), in, in + taken);
+		m_blocksWrite = m_writeBuffer.size() >= m_writeBound;
+		return static_cast<uint32_t>(taken);
+	}
+
+	size_t WriteBufferSize() const { return m_writeBuffer.size(); }
+
+	//! Hands the queued bytes to the caller that will pass them to libutp.
+	std::vector<uint8_t> TakeQueuedBytes()
+	{
+		std::vector<uint8_t> bytes(m_writeBuffer.begin(), m_writeBuffer.end());
+		m_writeBuffer.clear();
+		m_blocksWrite = false;
+		return bytes;
+	}
+
+	//! The peer's window opened again.
+	void OnWritable() { m_blocksWrite = m_writeBuffer.size() >= m_writeBound; }
+
+	// -- ending -------------------------------------------------------
+
+	/**
+	 * Records how the stream ended. The first end wins.
+	 *
+	 * A reset arriving after a clean EOF does not turn a finished transfer
+	 * into a failed one, which is what would happen if the last writer won.
+	 */
+	void OnFailure(EUtpTransportFailure failure)
+	{
+		if (failure != EUtpTransportFailure::None && m_failure == EUtpTransportFailure::None) {
+			m_failure = failure;
+		}
+		m_blocksRead = false;
+		m_blocksWrite = false;
+	}
+
+	EUtpTransportFailure Failure() const { return m_failure; }
+	bool IsTerminal() const { return IsUtpTerminal(m_failure); }
+
+	//! Nonzero only for a real failure. EOF and destroying are ends, not errors.
+	int LastError() const { return IsUtpFailure(m_failure) ? static_cast<int>(m_failure) : 0; }
+
+	bool BlocksRead() const { return m_blocksRead; }
+	bool BlocksWrite() const { return m_blocksWrite; }
+
+	//! True for the one caller that owns utp_close(); false for every other.
+	bool TakeCloseOwnership() { return m_close.Take(); }
+	bool CloseTaken() const { return m_close.Taken(); }
+
+private:
+	std::deque<uint8_t> m_readBuffer;
+	std::deque<uint8_t> m_writeBuffer;
+	size_t m_writeBound;
+	bool m_blocksRead = false;
+	bool m_blocksWrite = false;
+	bool m_readDrainedDue = false;
+	EUtpTransportFailure m_failure = EUtpTransportFailure::None;
+	CUtpCloseOnce m_close;
+};
+
+#endif // UTPSTREAM_H
+// File_checked_for_headers

--- a/src/UtpTransportFailure.h
+++ b/src/UtpTransportFailure.h
@@ -1,0 +1,102 @@
+//
+// This file is part of the aMule Project.
+//
+// Copyright (c) 2003-2026 aMule Team ( https://amule-org.github.io )
+//
+// Any parts of this program derived from the xMule, lMule or eMule project,
+// or contributed by third-party developers are copyrighted by their
+// respective authors.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301, USA
+//
+
+#ifndef UTPTRANSPORTFAILURE_H
+#define UTPTRANSPORTFAILURE_H
+
+/**
+ * How a uTP stream ended.
+ *
+ * Three of these are ends the peer chose and two are ends the transport
+ * reports, and the reason they are one enum rather than a bool is that the
+ * caller acts differently on each: a refused connection says the peer is
+ * reachable and declined, a timeout says nothing about the peer at all, and a
+ * reset says the connection existed and no longer does. Collapsing them is how
+ * a dead peer and a firewalled one become indistinguishable in the source list.
+ *
+ * @c Eof and @c Destroying are terminal but are @b not failures. A peer that
+ * closes cleanly after sending what it owed has not failed, and reporting it as
+ * an error would penalise it in exactly the accounting a clean close should
+ * leave alone.
+ */
+enum class EUtpTransportFailure
+{
+	//! No end yet: the stream is live, or ended cleanly.
+	None,
+	//! The peer answered and declined the connection.
+	Refused,
+	//! No answer within the transport's own retransmission budget.
+	TimedOut,
+	//! The connection existed and the peer tore it down.
+	Reset,
+	//! The peer finished sending. Not an error.
+	Eof,
+	//! The library is destroying the socket. Not an error.
+	Destroying
+};
+
+inline bool IsUtpFailure(EUtpTransportFailure failure) noexcept
+{
+	return failure == EUtpTransportFailure::Refused || failure == EUtpTransportFailure::TimedOut ||
+	       failure == EUtpTransportFailure::Reset;
+}
+
+inline bool IsUtpTerminal(EUtpTransportFailure failure) noexcept
+{
+	return failure != EUtpTransportFailure::None;
+}
+
+/**
+ * The close bookkeeping, as a type rather than as a rule.
+ *
+ * libutp's @c utp_close() must be called exactly once per socket, and the
+ * pointer is invalid the moment @c UTP_STATE_DESTROYING arrives. Both halves of
+ * that are easy to get wrong by hand -- a destructor that closes, plus a state
+ * callback that closes, is a double free that only appears when a peer
+ * disconnects at the wrong moment.
+ *
+ * So the permission to close is consumed rather than checked: Take() answers
+ * true once and false forever after, and there is no way to ask "was it closed"
+ * and then close, which is the shape that races.
+ */
+class CUtpCloseOnce
+{
+public:
+	//! True exactly once, for the caller that owns the close.
+	bool Take() noexcept
+	{
+		const bool first = !m_taken;
+		m_taken = true;
+		return first;
+	}
+
+	//! True once the close has been handed out. For assertions, not for deciding.
+	bool Taken() const noexcept { return m_taken; }
+
+private:
+	bool m_taken = false;
+};
+
+#endif // UTPTRANSPORTFAILURE_H
+// File_checked_for_headers

--- a/unittests/tests/CMakeLists.txt
+++ b/unittests/tests/CMakeLists.txt
@@ -1,3 +1,27 @@
+# The buffering between libutp and the eD2k stack: the would-block contract
+# CEMSocket depends on, and the close that must happen exactly once. Header-only
+# and free of libutp, so it is compiled and run in every build rather than only
+# where ENABLE_UTP is on -- the contract is the same either way.
+add_executable (UtpStreamTest
+	UtpStreamTest.cpp
+	${CMAKE_SOURCE_DIR}/src/libs/common/Format.cpp
+	${CMAKE_SOURCE_DIR}/src/libs/common/strerror_r.c
+)
+
+add_test (NAME UtpStreamTest
+	COMMAND UtpStreamTest
+)
+
+target_include_directories (UtpStreamTest
+	PRIVATE ${CMAKE_BINARY_DIR}
+	PRIVATE ${CMAKE_SOURCE_DIR}/src
+	PRIVATE ${CMAKE_SOURCE_DIR}/src/include
+)
+
+target_link_libraries (UtpStreamTest
+	muleunit
+)
+
 if (ENABLE_UTP)
 	add_executable (UtpContextTest
 		UtpContextTest.cpp

--- a/unittests/tests/UtpStreamTest.cpp
+++ b/unittests/tests/UtpStreamTest.cpp
@@ -149,14 +149,21 @@ TEST(UtpStream, ReadBoundIsReportedRatherThanEnforced)
 	ASSERT_FALSE(stream.ReadBufferAboveBound());
 }
 
-TEST(UtpStream, ErrorValuesCannotBeMistakenForWxSocketErrors)
+TEST(UtpStream, ErrorValuesCannotBeMistakenForSocketErrors)
 {
-	// LastError() stands in for the wx-backed CLibSocket::LastError() under the
-	// same name and type, so a call site reaching for wxSOCKET_INVOP (1) or
-	// wxSOCKET_IOERR (2) must not match one of ours by coincidence.
-	CUtpStream reset;
-	reset.OnFailure(EUtpTransportFailure::Reset);
-	ASSERT_TRUE(reset.LastError() > 6);
+	// LastError() stands in for CLibSocket::LastError() under the same name and
+	// type, and that one returns a boost error_code value: errno on POSIX,
+	// WinSock codes (10000-11999) on Windows. Every failure of ours has to sit
+	// clear of both, or a call site comparing against a constant matches by
+	// coincidence.
+	const EUtpTransportFailure failures[] = {
+		EUtpTransportFailure::Refused, EUtpTransportFailure::TimedOut, EUtpTransportFailure::Reset
+	};
+	for (size_t i = 0; i < sizeof(failures) / sizeof(failures[0]); ++i) {
+		CUtpStream stream;
+		stream.OnFailure(failures[i]);
+		ASSERT_TRUE(stream.LastError() > 11999);
+	}
 }
 
 TEST(UtpStream, WriteBoundBlocksWithoutFailing)
@@ -185,14 +192,76 @@ TEST(UtpStream, PartialWriteTakesWhatFits)
 	ASSERT_EQUALS(10u, stream.Write(payload.data(), 16));
 	ASSERT_TRUE(stream.BlocksWrite());
 
-	const std::vector<uint8_t> queued = stream.TakeQueuedBytes();
+	const std::vector<uint8_t> queued = stream.PeekQueuedBytes();
 	ASSERT_EQUALS(10u, (unsigned)queued.size());
 	for (size_t i = 0; i < queued.size(); ++i) {
 		ASSERT_EQUALS((int)payload[i], (int)queued[i]);
 	}
+	// Looking is not taking: the queue is still full until libutp says what
+	// it accepted, so the writer stays blocked.
+	ASSERT_TRUE(stream.BlocksWrite());
+	ASSERT_EQUALS(10u, (unsigned)stream.WriteBufferSize());
+
 	// Draining the queue is what unblocks the writer.
+	stream.ConsumeQueuedBytes(queued.size());
 	ASSERT_FALSE(stream.BlocksWrite());
 	ASSERT_EQUALS(0u, (unsigned)stream.WriteBufferSize());
+}
+
+TEST(UtpStream, RefusedBytesStayQueued)
+{
+	CUtpStream stream(64);
+	const std::vector<uint8_t> payload = Pattern(40, 11);
+	ASSERT_EQUALS(40u, stream.Write(payload.data(), 40));
+
+	// utp_write() takes what the congestion window allows and reports it. The
+	// refused tail has to stay here: if the queue emptied, the caller would
+	// have to hold those bytes somewhere WriteBufferSize() cannot see and
+	// m_writeBound does not bound, which is the growth the bound prevents.
+	stream.ConsumeQueuedBytes(15);
+	ASSERT_EQUALS(25u, (unsigned)stream.WriteBufferSize());
+
+	const std::vector<uint8_t> left = stream.PeekQueuedBytes();
+	ASSERT_EQUALS(25u, (unsigned)left.size());
+	for (size_t i = 0; i < left.size(); ++i) {
+		ASSERT_EQUALS((int)payload[15 + i], (int)left[i]);
+	}
+
+	// And the queue keeps taking new bytes behind them, in order.
+	const std::vector<uint8_t> more = Pattern(4, 200);
+	ASSERT_EQUALS(4u, stream.Write(more.data(), 4));
+	const std::vector<uint8_t> all = stream.PeekQueuedBytes();
+	ASSERT_EQUALS(29u, (unsigned)all.size());
+	ASSERT_EQUALS((int)more[0], (int)all[25]);
+}
+
+TEST(UtpStream, ConsumingMoreThanIsQueuedIsHarmless)
+{
+	// libutp reports what it took, so accepted should never exceed the queue.
+	// Clamping keeps a wrong count from erasing past the end.
+	CUtpStream stream(64);
+	const std::vector<uint8_t> payload = Pattern(8, 21);
+	ASSERT_EQUALS(8u, stream.Write(payload.data(), 8));
+
+	stream.ConsumeQueuedBytes(4096);
+	ASSERT_EQUALS(0u, (unsigned)stream.WriteBufferSize());
+	ASSERT_FALSE(stream.BlocksWrite());
+}
+
+TEST(UtpStream, ConsumingUnblocksOnlyWhenItDropsBelowTheBound)
+{
+	CUtpStream stream(16);
+	const std::vector<uint8_t> payload = Pattern(16, 31);
+	ASSERT_EQUALS(16u, stream.Write(payload.data(), 16));
+	ASSERT_TRUE(stream.BlocksWrite());
+
+	// libutp took nothing, so nothing changed and the writer stays blocked.
+	stream.ConsumeQueuedBytes(0);
+	ASSERT_TRUE(stream.BlocksWrite());
+	ASSERT_EQUALS(16u, (unsigned)stream.WriteBufferSize());
+
+	stream.ConsumeQueuedBytes(1);
+	ASSERT_FALSE(stream.BlocksWrite());
 }
 
 TEST(UtpStream, WritableReopensAWindowOnlyWhenThereIsRoom)
@@ -207,7 +276,7 @@ TEST(UtpStream, WritableReopensAWindowOnlyWhenThereIsRoom)
 	stream.OnWritable();
 	ASSERT_TRUE(stream.BlocksWrite());
 
-	stream.TakeQueuedBytes();
+	stream.ConsumeQueuedBytes(stream.WriteBufferSize());
 	stream.OnWritable();
 	ASSERT_FALSE(stream.BlocksWrite());
 }
@@ -280,6 +349,23 @@ TEST(UtpStream, ReadingAnEndedStreamReportsTheEndRatherThanBlocking)
 	// 0 bytes and no block: no more bytes are coming, as opposed to not yet.
 	ASSERT_EQUALS(0u, stream.Read(out, sizeof(out)));
 	ASSERT_FALSE(stream.BlocksRead());
+}
+
+TEST(UtpStream, ACleanEndIsNotOkAndIsNotAWouldBlock)
+{
+	CUtpStream stream;
+	const std::vector<uint8_t> payload = Pattern(4, 41);
+	ASSERT_TRUE(stream.IsOk());
+
+	stream.OnFailure(EUtpTransportFailure::Eof);
+
+	// EOF ends the stream without failing it, so Write() refuses while both
+	// BlocksWrite() and LastError() stay 0 -- the pair a would-block sets.
+	// IsOk() is what tells the two apart.
+	ASSERT_EQUALS(0u, stream.Write(payload.data(), 4));
+	ASSERT_FALSE(stream.BlocksWrite());
+	ASSERT_EQUALS(0, stream.LastError());
+	ASSERT_FALSE(stream.IsOk());
 }
 
 TEST(UtpStream, BufferedBytesSurviveTheEnd)

--- a/unittests/tests/UtpStreamTest.cpp
+++ b/unittests/tests/UtpStreamTest.cpp
@@ -1,0 +1,272 @@
+//
+// This file is part of the aMule Project.
+//
+// Copyright (c) 2003-2026 aMule Team ( https://amule-org.github.io )
+//
+// Any parts of this program derived from the xMule, lMule or eMule project,
+// or contributed by third-party developers are copyrighted by their
+// respective authors.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301, USA
+//
+
+// The buffering between libutp and the eD2k stack.
+//
+// The property worth the coverage is the would-block contract, because
+// CEMSocket depends on it rather than merely tolerating it: 0 bytes with the
+// Blocks flag set means "not yet", 0 bytes with an error set means the peer is
+// gone. Getting that backwards disconnects a peer whose send window would have
+// opened a millisecond later, and the symptom -- peers dropping under load --
+// looks nothing like its cause.
+//
+// The other one is the close: libutp's utp_close() must happen exactly once,
+// and a destructor plus a DESTROYING callback both closing is a double free
+// that only shows up when a peer leaves at the wrong moment.
+
+#include <muleunit/test.h>
+
+#include <UtpStream.h>
+
+using namespace muleunit;
+
+DECLARE_SIMPLE(UtpStream)
+
+namespace
+{
+//! Fills a buffer with a recognisable, position-dependent pattern.
+std::vector<uint8_t> Pattern(size_t length, uint8_t seed = 0)
+{
+	std::vector<uint8_t> bytes(length);
+	for (size_t i = 0; i < length; ++i) {
+		bytes[i] = static_cast<uint8_t>((i * 31 + seed) & 0xFF);
+	}
+	return bytes;
+}
+} // namespace
+
+TEST(UtpStream, EmptyReadBlocksAndIsNotAnError)
+{
+	CUtpStream stream;
+	uint8_t out[16] = { 0 };
+
+	ASSERT_EQUALS(0u, stream.Read(out, sizeof(out)));
+	ASSERT_TRUE(stream.BlocksRead());
+	// The whole point: a would-block must not look like a dead connection.
+	ASSERT_EQUALS(0, stream.LastError());
+	ASSERT_FALSE(stream.IsTerminal());
+}
+
+TEST(UtpStream, PayloadArrivesInOrderAndClearsTheBlock)
+{
+	CUtpStream stream;
+	uint8_t out[4] = { 0 };
+	ASSERT_EQUALS(0u, stream.Read(out, sizeof(out)));
+	ASSERT_TRUE(stream.BlocksRead());
+
+	const std::vector<uint8_t> sent = Pattern(10);
+	stream.OnPayload(sent.data(), sent.size());
+	ASSERT_FALSE(stream.BlocksRead());
+	ASSERT_EQUALS(10u, (unsigned)stream.ReadBufferSize());
+
+	// A short read takes a prefix and leaves the rest, in order.
+	ASSERT_EQUALS(4u, stream.Read(out, sizeof(out)));
+	for (size_t i = 0; i < 4; ++i) {
+		ASSERT_EQUALS((int)sent[i], (int)out[i]);
+	}
+	ASSERT_EQUALS(6u, (unsigned)stream.ReadBufferSize());
+
+	uint8_t rest[6] = { 0 };
+	ASSERT_EQUALS(6u, stream.Read(rest, sizeof(rest)));
+	for (size_t i = 0; i < 6; ++i) {
+		ASSERT_EQUALS((int)sent[i + 4], (int)rest[i]);
+	}
+}
+
+TEST(UtpStream, ReadDrainedIsDueExactlyOncePerDrain)
+{
+	CUtpStream stream;
+	const std::vector<uint8_t> sent = Pattern(8);
+	uint8_t out[8] = { 0 };
+
+	// Nothing owed before anything has been buffered.
+	ASSERT_FALSE(stream.ConsumeReadDrainedEdge());
+
+	stream.OnPayload(sent.data(), sent.size());
+	ASSERT_EQUALS(4u, stream.Read(out, 4));
+	// Still four bytes buffered: the reader is not behind, nothing is owed.
+	ASSERT_FALSE(stream.ConsumeReadDrainedEdge());
+
+	ASSERT_EQUALS(4u, stream.Read(out, 4));
+	ASSERT_TRUE(stream.ConsumeReadDrainedEdge());
+	// Consumed. Notifying twice is a wakeup for an already-empty buffer.
+	ASSERT_FALSE(stream.ConsumeReadDrainedEdge());
+
+	stream.OnPayload(sent.data(), sent.size());
+	ASSERT_EQUALS(8u, stream.Read(out, 8));
+	ASSERT_TRUE(stream.ConsumeReadDrainedEdge());
+}
+
+TEST(UtpStream, WriteBoundBlocksWithoutFailing)
+{
+	CUtpStream stream(64);
+	const std::vector<uint8_t> payload = Pattern(64, 7);
+
+	ASSERT_EQUALS(64u, stream.Write(payload.data(), 64));
+	ASSERT_TRUE(stream.BlocksWrite());
+	ASSERT_EQUALS(0, stream.LastError());
+
+	// Full queue: refused, but the stream is alive.
+	ASSERT_EQUALS(0u, stream.Write(payload.data(), 8));
+	ASSERT_TRUE(stream.BlocksWrite());
+	ASSERT_EQUALS(0, stream.LastError());
+	ASSERT_FALSE(stream.IsTerminal());
+}
+
+TEST(UtpStream, PartialWriteTakesWhatFits)
+{
+	CUtpStream stream(10);
+	const std::vector<uint8_t> payload = Pattern(16, 3);
+
+	// Accepting what fits rather than refusing the whole write is what keeps
+	// the caller making progress against a slow peer.
+	ASSERT_EQUALS(10u, stream.Write(payload.data(), 16));
+	ASSERT_TRUE(stream.BlocksWrite());
+
+	const std::vector<uint8_t> queued = stream.TakeQueuedBytes();
+	ASSERT_EQUALS(10u, (unsigned)queued.size());
+	for (size_t i = 0; i < queued.size(); ++i) {
+		ASSERT_EQUALS((int)payload[i], (int)queued[i]);
+	}
+	// Draining the queue is what unblocks the writer.
+	ASSERT_FALSE(stream.BlocksWrite());
+	ASSERT_EQUALS(0u, (unsigned)stream.WriteBufferSize());
+}
+
+TEST(UtpStream, WritableReopensAWindowOnlyWhenThereIsRoom)
+{
+	CUtpStream stream(16);
+	const std::vector<uint8_t> payload = Pattern(16, 5);
+	ASSERT_EQUALS(16u, stream.Write(payload.data(), 16));
+	ASSERT_TRUE(stream.BlocksWrite());
+
+	// The peer's window opening does not empty our queue, so it does not
+	// unblock a writer that is bounded by our own buffer.
+	stream.OnWritable();
+	ASSERT_TRUE(stream.BlocksWrite());
+
+	stream.TakeQueuedBytes();
+	stream.OnWritable();
+	ASSERT_FALSE(stream.BlocksWrite());
+}
+
+TEST(UtpStream, EofAndDestroyingAreEndsRatherThanErrors)
+{
+	CUtpStream eof;
+	eof.OnFailure(EUtpTransportFailure::Eof);
+	ASSERT_TRUE(eof.IsTerminal());
+	ASSERT_EQUALS(0, eof.LastError());
+	ASSERT_FALSE(IsUtpFailure(eof.Failure()));
+	// A finished transfer must not be charged as a failure.
+	ASSERT_FALSE(eof.BlocksRead());
+
+	CUtpStream destroying;
+	destroying.OnFailure(EUtpTransportFailure::Destroying);
+	ASSERT_TRUE(destroying.IsTerminal());
+	ASSERT_EQUALS(0, destroying.LastError());
+}
+
+TEST(UtpStream, TheThreeFailuresStayDistinct)
+{
+	// A refused connection, a silent peer and a torn-down connection are three
+	// different facts about a peer, and the source list acts differently on
+	// each. Collapsing them to "failed" is what makes a firewalled peer
+	// indistinguishable from a dead one.
+	CUtpStream refused;
+	refused.OnFailure(EUtpTransportFailure::Refused);
+	CUtpStream timedOut;
+	timedOut.OnFailure(EUtpTransportFailure::TimedOut);
+	CUtpStream reset;
+	reset.OnFailure(EUtpTransportFailure::Reset);
+
+	ASSERT_TRUE(refused.Failure() == EUtpTransportFailure::Refused);
+	ASSERT_TRUE(timedOut.Failure() == EUtpTransportFailure::TimedOut);
+	ASSERT_TRUE(reset.Failure() == EUtpTransportFailure::Reset);
+
+	ASSERT_TRUE(refused.LastError() != 0);
+	ASSERT_TRUE(timedOut.LastError() != 0);
+	ASSERT_TRUE(reset.LastError() != 0);
+	ASSERT_TRUE(refused.LastError() != timedOut.LastError());
+	ASSERT_TRUE(timedOut.LastError() != reset.LastError());
+}
+
+TEST(UtpStream, TheFirstEndWins)
+{
+	CUtpStream stream;
+	stream.OnFailure(EUtpTransportFailure::Eof);
+	// A reset arriving after a clean close must not retroactively fail a
+	// transfer that finished.
+	stream.OnFailure(EUtpTransportFailure::Reset);
+	ASSERT_TRUE(stream.Failure() == EUtpTransportFailure::Eof);
+	ASSERT_EQUALS(0, stream.LastError());
+}
+
+TEST(UtpStream, WritingToAnEndedStreamIsRefused)
+{
+	CUtpStream stream;
+	const std::vector<uint8_t> payload = Pattern(4);
+	stream.OnFailure(EUtpTransportFailure::Reset);
+	ASSERT_EQUALS(0u, stream.Write(payload.data(), 4));
+	ASSERT_FALSE(stream.BlocksWrite());
+}
+
+TEST(UtpStream, ReadingAnEndedStreamReportsTheEndRatherThanBlocking)
+{
+	CUtpStream stream;
+	uint8_t out[4] = { 0 };
+	stream.OnFailure(EUtpTransportFailure::Eof);
+	// 0 bytes and no block: no more bytes are coming, as opposed to not yet.
+	ASSERT_EQUALS(0u, stream.Read(out, sizeof(out)));
+	ASSERT_FALSE(stream.BlocksRead());
+}
+
+TEST(UtpStream, BufferedBytesSurviveTheEnd)
+{
+	CUtpStream stream;
+	const std::vector<uint8_t> sent = Pattern(5, 9);
+	stream.OnPayload(sent.data(), sent.size());
+	stream.OnFailure(EUtpTransportFailure::Eof);
+
+	// A peer that sent its last bytes and closed in the same tick has still
+	// sent them; dropping the buffer on EOF loses the tail of every transfer.
+	uint8_t out[5] = { 0 };
+	ASSERT_EQUALS(5u, stream.Read(out, sizeof(out)));
+	for (size_t i = 0; i < 5; ++i) {
+		ASSERT_EQUALS((int)sent[i], (int)out[i]);
+	}
+}
+
+TEST(UtpStream, CloseOwnershipIsHandedOutExactlyOnce)
+{
+	CUtpStream stream;
+	ASSERT_FALSE(stream.CloseTaken());
+	ASSERT_TRUE(stream.TakeCloseOwnership());
+	ASSERT_TRUE(stream.CloseTaken());
+	// The destructor, the DESTROYING callback and an explicit Close() all ask;
+	// exactly one may call utp_close().
+	ASSERT_FALSE(stream.TakeCloseOwnership());
+	ASSERT_FALSE(stream.TakeCloseOwnership());
+}
+
+// File_checked_for_headers

--- a/unittests/tests/UtpStreamTest.cpp
+++ b/unittests/tests/UtpStreamTest.cpp
@@ -118,6 +118,47 @@ TEST(UtpStream, ReadDrainedIsDueExactlyOncePerDrain)
 	ASSERT_TRUE(stream.ConsumeReadDrainedEdge());
 }
 
+TEST(UtpStream, ReadBoundIsReportedRatherThanEnforced)
+{
+	// libutp can deliver more than the bound in one callback, and a byte
+	// dropped here is a hole in a file the peer already paid to send. So the
+	// bound is what UTP_GET_READ_BUFFER_SIZE reports -- the peer stops a round
+	// trip later -- not something this class refuses.
+	CUtpStream stream(CUtpStream::kDefaultWriteBound, 8);
+	const std::vector<uint8_t> first = Pattern(20);
+	const std::vector<uint8_t> second = Pattern(12, 200);
+
+	stream.OnPayload(first.data(), first.size());
+	ASSERT_TRUE(stream.ReadBufferAboveBound());
+	ASSERT_EQUALS(8u, (unsigned)stream.ReadBound());
+
+	// The delivery that matters: already past the bound, and it must still be
+	// kept in full. Refusing here is the byte-dropping this bound must not do.
+	stream.OnPayload(second.data(), second.size());
+	ASSERT_EQUALS(32u, (unsigned)stream.ReadBufferSize());
+	ASSERT_EQUALS(0, stream.LastError());
+
+	uint8_t out[32] = { 0 };
+	ASSERT_EQUALS(32u, stream.Read(out, sizeof(out)));
+	for (size_t i = 0; i < first.size(); ++i) {
+		ASSERT_EQUALS((int)first[i], (int)out[i]);
+	}
+	for (size_t i = 0; i < second.size(); ++i) {
+		ASSERT_EQUALS((int)second[i], (int)out[first.size() + i]);
+	}
+	ASSERT_FALSE(stream.ReadBufferAboveBound());
+}
+
+TEST(UtpStream, ErrorValuesCannotBeMistakenForWxSocketErrors)
+{
+	// LastError() stands in for the wx-backed CLibSocket::LastError() under the
+	// same name and type, so a call site reaching for wxSOCKET_INVOP (1) or
+	// wxSOCKET_IOERR (2) must not match one of ours by coincidence.
+	CUtpStream reset;
+	reset.OnFailure(EUtpTransportFailure::Reset);
+	ASSERT_TRUE(reset.LastError() > 6);
+}
+
 TEST(UtpStream, WriteBoundBlocksWithoutFailing)
 {
 	CUtpStream stream(64);

--- a/unittests/tests/UtpStreamTest.cpp
+++ b/unittests/tests/UtpStreamTest.cpp
@@ -129,8 +129,10 @@ TEST(UtpStream, ReadBoundIsReportedRatherThanEnforced)
 	const std::vector<uint8_t> second = Pattern(12, 200);
 
 	stream.OnPayload(first.data(), first.size());
-	ASSERT_TRUE(stream.ReadBufferAboveBound());
 	ASSERT_EQUALS(8u, (unsigned)stream.ReadBound());
+	// Past the bound, and reported as such: this count is what libutp
+	// subtracts from opt_rcvbuf to decide how much window to advertise.
+	ASSERT_EQUALS(20u, (unsigned)stream.ReadBufferSize());
 
 	// The delivery that matters: already past the bound, and it must still be
 	// kept in full. Refusing here is the byte-dropping this bound must not do.
@@ -146,7 +148,7 @@ TEST(UtpStream, ReadBoundIsReportedRatherThanEnforced)
 	for (size_t i = 0; i < second.size(); ++i) {
 		ASSERT_EQUALS((int)second[i], (int)out[first.size() + i]);
 	}
-	ASSERT_FALSE(stream.ReadBufferAboveBound());
+	ASSERT_EQUALS(0u, (unsigned)stream.ReadBufferSize());
 }
 
 TEST(UtpStream, ErrorValuesCannotBeMistakenForSocketErrors)


### PR DESCRIPTION
Refs #1177

First of three for the uTP stream, after the carrier in #1357. This is the
buffering and the failure taxonomy, as headers with tests and **no caller**.
The acceptor, the libutp stream callbacks and the `CLibSocket` wiring follow;
they have to land together, because a peer that completes a handshake and then
drops bytes is worse than one that never accepts.

## Inertness

683 insertions, zero deletions, three new headers plus one test suite. Nothing
includes them but the test — grep is the check:

```
$ grep -rln 'StreamTransport.h\|UtpStream.h\|UtpTransportFailure.h' src unittests
src/UtpStream.h
unittests/tests/UtpStreamTest.cpp
```

No acceptor, no `UTP_ON_ACCEPT`, no adapter change, no capability bit, no dial,
no QUIC, no IPv6. Free of libutp and of Boost.Asio, so the suite is compiled and
run in **every** build rather than only under `ENABLE_UTP`: the contract does
not depend on the switch.

## The contract that matters

`CEMSocket` does not merely tolerate would-block, it depends on the distinction:

| Result | Means | Stack does |
| --- | --- | --- |
| 0 bytes, `Blocks*` set, `LastError() == 0` | not yet | waits |
| 0 bytes, error set | peer is gone | drops the peer |

So reporting a full send window as an error is not cosmetic — it disconnects a
peer whose window opens a millisecond later, and the symptom (peers dropping
under load) looks nothing like the cause. `UtpStream.h` is the state machine
that keeps those apart, plus the read buffer whose occupancy a future
`UTP_GET_READ_BUFFER_SIZE` reports and whose drained edge is owed to
`utp_read_drained()` exactly once per drain — reported here, sent by the
transport, because a class that buffers bytes *and* re-enters libutp is the one
that deadlocks when libutp calls back into it.

`UtpTransportFailure.h` keeps refused, timed-out and reset distinguishable: they
are three different facts about a peer and the source list acts differently on
each, so collapsing them makes a firewalled peer indistinguishable from a dead
one. EOF and destroying are terminal but **not** errors — charging a clean
finish as a failure penalises exactly the peer that behaved.

Closing twice is made unrepresentable rather than forbidden by convention:
`utp_close()` must happen once, the pointer dies at `UTP_STATE_DESTROYING`, and
a destructor plus a state callback both closing is a double free that only
appears when a peer leaves at the wrong moment. So the permission is consumed —
`Take()` answers true once — and there is no ask-then-close shape to race.

## Tests

`UtpStreamTest`, 13 cases, checked by perturbation rather than by inspection.
Each of these makes the suite exit non-zero:

| Perturbation | Caught by |
| --- | --- |
| a would-block read also sets an error | `EmptyReadBlocksAndIsNotAnError` |
| the drained edge is never consumed | `ReadDrainedIsDueExactlyOncePerDrain` |
| the last end wins instead of the first | `TheFirstEndWins` |
| a full write queue is reported as an error | `WriteBoundBlocksWithoutFailing` |

Two cases exist for bugs that would otherwise be silent:
`BufferedBytesSurviveTheEnd`, because a peer that sends its last bytes and
closes in the same tick has still sent them, and dropping the buffer on EOF
loses the tail of every transfer; and
`ReadingAnEndedStreamReportsTheEndRatherThanBlocking`, which is the one case
where zero bytes must *not* set the block flag.

| Configuration | Apps | ctest |
| --- | --- | --- |
| default | amule, amuled, amulegui | 61/61 |
| `-DENABLE_UTP=YES` | amule, amuled, amulegui | 62/62 |

clang-format 18, `git diff --check`, `check-potfiles.sh` clean.

## Bounds, in both directions

`kDefaultWriteBound` is 256 KiB and `Write()` enforces it. `kDefaultReadBound`
is 64 KiB and `OnPayload()` does **not** enforce it: received bytes are never
discarded, because a byte dropped here is a hole in a file the peer already
paid to send, and libutp can hand up more than the bound in one callback
anyway. It is the number `UTP_GET_READ_BUFFER_SIZE` will report, so the peer
stops sending one round trip later. Inert until the acceptor wires that
callback; decided here so the acceptor inherits a value rather than inventing
one.

## Two notes on the interface

`GetPeerAddress()` returns `CNetworkAddress`, not the 32-bit form
`CLibSocket::GetPeerInt()` returns. Mirroring it would make the later
substitution simpler, but this series exists because a peer's identity does not
fit in 32 bits, and a new interface that narrows by construction puts back what
#1318 and #1345 removed. A caller needing the eD2k wire form narrows with
`ToIPv4NetworkOrder()` and handles the failure.

The consequence: `StreamTransport.h` includes `NetworkAddress.h` and is
therefore no longer free of wx. It stays free of Boost.Asio — checked with `-H`,
zero asio headers — which is the include-closure property that mattered.

`LastError()` is offset past the `wxSocketError` range and documented as opaque.
It stands in for the wx-backed `LastError()` under the same name and type, so a
call site reaching for `== wxSOCKET_INVOP` would otherwise match by coincidence,
wrongly and silently. `Failure()` is how a caller asks for the reason.

## Two things carried forward

The real-libutp loopback test promised on #1357 lands with the acceptor, where
it can assert a transfer rather than a handshake.

And a question worth settling before that PR: **should it advertise
`CT_MOD_MISCOPTIONS` bit 1?** Your ordering on #1177 puts emitting the bit in
step 2, after the transport in step 1, so I have assumed the acceptor does not
advertise and the bit arrives with `CAPS`/`CAPS_ACK`. That does mean the
acceptor is unreachable in practice until then — correct by the plan, useless
for a release. Say if you would rather fold the bit into the acceptor instead.
