### PR TITLE
build: pin the language standard to C++17

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,21 @@ set (DEFAULT_BUILD_TYPE "Release")
 set (RECONF_COMMAND ${CMAKE_COMMAND})
 set (CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
+# Pin the language standard rather than inheriting each compiler's default.
+#
+# Unpinned, the tree compiled as C++17 on Ubuntu (gcc 15, clang 21) and mingw
+# clang 22, and as C++14 on AppleClang 21 -- so the same source was a different
+# language depending on who built it. That is not a theoretical hazard: a
+# `static constexpr` member is implicitly inline from C++17 and needs an
+# out-of-line definition before it, so code that links on Linux fails on macOS
+# with an undefined symbol in the caller's translation unit rather than
+# anything visible at the declaration.
+#
+# 17 rather than 14 because three of the four toolchains already default to it,
+# it is nine years old, and pinning 14 would move three platforms backwards.
+set (CMAKE_CXX_STANDARD 17)
+set (CMAKE_CXX_STANDARD_REQUIRED ON)
+
 # Set the possible values of build type for cmake-gui
 if (CMAKE_CONFIGURATION_TYPES)
 	set (CMAKE_CONFIGURATION_TYPES "Debug;Release" CACHE

--- a/cmake/libutp.cmake
+++ b/cmake/libutp.cmake
@@ -40,12 +40,11 @@ if (NOT TARGET libutp)
 		"in ${AMULE_LIBUTP_DIR} is not the pinned upstream revision.")
 endif()
 
-# Upstream sets the language standard only for a standalone build, and aMule
-# sets CMAKE_CXX_STANDARD nowhere, so vendored the library would compile with no
-# -std at all -- its C++17 if-init statements surviving only as a compiler
-# extension. Upstream marks the standard REQUIRED when standalone, so C++17 is
-# its requirement rather than its preference; this states it for the one target
-# instead of imposing it on aMule.
+# Upstream sets the language standard only for a standalone build, deferring to
+# the parent otherwise. aMule now pins C++17 tree-wide, so this would inherit
+# the right standard anyway; it stays because upstream marks the standard
+# REQUIRED when standalone, making C++17 its requirement rather than ours to
+# lend. If the tree-wide pin ever moves, this target must not move with it.
 set_target_properties (libutp PROPERTIES
 	CXX_STANDARD 17
 	CXX_STANDARD_REQUIRED ON)

--- a/src/AddressFamilyPolicyAsio.h
+++ b/src/AddressFamilyPolicyAsio.h
@@ -29,20 +29,9 @@
 
 #include <boost/optional.hpp>
 
-// Reviewer measurement with AppleClang 21 and Boost 1.92: without both
-// suppressions, ip/tcp.hpp produces 29 errors under -Werror=deprecated:
-// 27 redundant constexpr static definitions and 2 deprecated copies with a
-// user-provided destructor. Each suppression is independently necessary;
-// restrict both to this Boost include.
-#if defined(__clang__)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-copy-with-user-provided-dtor"
-#pragma clang diagnostic ignored "-Wdeprecated-redundant-constexpr-static-def"
-#endif
+#include "WarningsPush_Asio.h"
 #include <boost/asio/ip/tcp.hpp>
-#if defined(__clang__)
-#pragma clang diagnostic pop
-#endif
+#include "WarningsPop.h"
 
 /**
  * Socket-specific address-family policy and Boost.Asio values.

--- a/src/CryptoPP_Inc.h
+++ b/src/CryptoPP_Inc.h
@@ -47,12 +47,7 @@
 // Clang builds today; the pragma is scoped to Clang-known sub-flags
 // only for that reason. Local to cryptopp includes; nothing else on
 // the translation unit is affected.
-#if defined(__clang__)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-copy-with-user-provided-dtor"
-#pragma clang diagnostic ignored "-Wdeprecated-copy-with-user-provided-copy"
-#pragma clang diagnostic ignored "-Wdeprecated-dynamic-exception-spec"
-#endif
+#include "WarningsPush_CryptoPP.h"
 
 #include CRYPTO_HEADER(config.h)
 #include CRYPTO_HEADER(md4.h)
@@ -86,8 +81,6 @@
 #include CRYPTO_HEADER(cpu.h)
 #endif
 
-#if defined(__clang__)
-#pragma clang diagnostic pop
-#endif
+#include "WarningsPop.h"
 
 #endif /* CRYPTOPP_INC_H */

--- a/src/LibSocketAsio.cpp
+++ b/src/LibSocketAsio.cpp
@@ -48,26 +48,11 @@
 #include <poll.h> // Bounded readability wait for the sync-read no-progress timeout
 #endif
 
-// Boost 1.92's asio declares several exception types with a user-provided
-// destructor and no matching copy constructor, which is the P0806 deprecation
-// -Wdeprecated-copy-with-user-provided-dtor reports. The build promotes it to
-// an error, so from that release on this header set fails the compile on its
-// own. Suppressed only across these includes, exactly as CryptoPP_Inc.h does
-// for the same warning: nothing about our own translation unit is affected.
-#if defined(__clang__)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-copy-with-user-provided-dtor"
-// asio's execution headers define constexpr statics out of line, which C++17
-// makes redundant and deprecates. Only reachable now that the standard is
-// pinned: under the old C++14 default those definitions were still required.
-#pragma clang diagnostic ignored "-Wdeprecated-redundant-constexpr-static-def"
-#endif
+#include "WarningsPush_Asio.h"
 #include <boost/asio.hpp>
 #include <boost/asio/steady_timer.hpp>
 #include <boost/version.hpp>
-#if defined(__clang__)
-#pragma clang diagnostic pop
-#endif
+#include "WarningsPop.h"
 
 //
 // Do away with building Boost.System, adding lib paths...

--- a/src/LibSocketAsio.cpp
+++ b/src/LibSocketAsio.cpp
@@ -57,6 +57,10 @@
 #if defined(__clang__)
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-copy-with-user-provided-dtor"
+// asio's execution headers define constexpr statics out of line, which C++17
+// makes redundant and deprecates. Only reachable now that the standard is
+// pinned: under the old C++14 default those definitions were still required.
+#pragma clang diagnostic ignored "-Wdeprecated-redundant-constexpr-static-def"
 #endif
 #include <boost/asio.hpp>
 #include <boost/asio/steady_timer.hpp>

--- a/src/PublicIPv6Corroboration.h
+++ b/src/PublicIPv6Corroboration.h
@@ -209,11 +209,8 @@ public:
 		Candidate *candidate = Find(value);
 		if (candidate == nullptr) {
 			// emplace_back() rather than push_back(Candidate()), which
-			// clang-tidy flags. Its return value is not used: it only
-			// returns a reference from C++17, and the unit-test targets
-			// take clang's default of C++14.
-			m_candidates.emplace_back();
-			candidate = &m_candidates.back();
+			// clang-tidy flags. It returns a reference from C++17.
+			candidate = &m_candidates.emplace_back();
 			candidate->value = value;
 		}
 

--- a/src/WarningsPop.h
+++ b/src/WarningsPop.h
@@ -1,0 +1,33 @@
+//
+// This file is part of the aMule Project.
+//
+// Copyright (c) 2003-2026 aMule Team ( https://amule-org.github.io )
+//
+// Any parts of this program derived from the xMule, lMule or eMule project,
+// or contributed by third-party developers are copyrighted by their
+// respective authors.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301, USA
+//
+
+// Closes a block opened by WarningsPush_CryptoPP.h or WarningsPush_Asio.h.
+//
+// Deliberately unguarded: a translation unit opens and closes one of these
+// blocks per third-party include group, so this file has to be includable
+// more than once.
+
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif

--- a/src/WarningsPush_Asio.h
+++ b/src/WarningsPush_Asio.h
@@ -1,0 +1,48 @@
+//
+// This file is part of the aMule Project.
+//
+// Copyright (c) 2003-2026 aMule Team ( https://amule-org.github.io )
+//
+// Any parts of this program derived from the xMule, lMule or eMule project,
+// or contributed by third-party developers are copyrighted by their
+// respective authors.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301, USA
+//
+
+// Silences the deprecation diagnostics Boost.Asio's headers trip, across the
+// includes that follow and nothing else. Close with WarningsPop.h.
+//
+// Asio gives several exception types a user-provided destructor alongside an
+// implicit copy constructor, and its execution headers define constexpr
+// statics out of line, which C++17 makes redundant. Both are deprecated and
+// the -Werror=deprecated gate reaches them. Named exactly rather than a
+// blanket suppression, for the reason in WarningsPush_CryptoPP.h.
+//
+// Measured with AppleClang 21 and Boost 1.92: without both suppressions
+// ip/tcp.hpp produces 29 errors under -Werror=deprecated, 27 redundant
+// constexpr static definitions and 2 deprecated copies with a user-provided
+// destructor. Each suppression is independently necessary.
+//
+// Only the wider closures need this: <boost/asio/ip/address.hpp> alone trips
+// neither, measured at zero, which is why NetworkAddressAsio.h has no wrap.
+//
+// Deliberately unguarded: see WarningsPop.h.
+
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-copy-with-user-provided-dtor"
+#pragma clang diagnostic ignored "-Wdeprecated-redundant-constexpr-static-def"
+#endif

--- a/src/WarningsPush_CryptoPP.h
+++ b/src/WarningsPush_CryptoPP.h
@@ -1,0 +1,48 @@
+//
+// This file is part of the aMule Project.
+//
+// Copyright (c) 2003-2026 aMule Team ( https://amule-org.github.io )
+//
+// Any parts of this program derived from the xMule, lMule or eMule project,
+// or contributed by third-party developers are copyrighted by their
+// respective authors.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301, USA
+//
+
+// Silences the deprecation diagnostics Crypto++'s headers trip, across the
+// includes that follow and nothing else. Close with WarningsPop.h.
+//
+// Crypto++ gives several classes a user-provided copy or destructor alongside
+// an implicit counterpart, and still carries dynamic exception specifications.
+// All three are deprecated in C++17 and the -Werror=deprecated gate in
+// src/CMakeLists.txt reaches them, because the headers are discovered without
+// -isystem. A deprecation-warning audit build surfaces roughly 200 warnings
+// from cryptopp headers alone. Named exactly, rather than a blanket
+// -Wno-deprecated, so a genuine deprecation in aMule's own code still fails
+// the build.
+//
+// Clang-only by necessity as well as by choice: GCC's -Wdeprecated-copy does
+// not decompose into the -with-user-provided-* sub-cases, so there is nothing
+// for it to suppress.
+//
+// Deliberately unguarded: see WarningsPop.h.
+
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-copy-with-user-provided-copy"
+#pragma clang diagnostic ignored "-Wdeprecated-copy-with-user-provided-dtor"
+#pragma clang diagnostic ignored "-Wdeprecated-dynamic-exception-spec"
+#endif

--- a/src/kademlia/kademlia/AICHHashList.cpp
+++ b/src/kademlia/kademlia/AICHHashList.cpp
@@ -85,10 +85,7 @@ const CKadAICHHash &CKadAICHHashList::GetHashAt(uint16_t index) const
 
 std::vector<uint16_t> CKadAICHHashList::BuildCompactionMap() const
 {
-	// uint16_t(...) rather than INVALID_INDEX: the fill constructor takes a
-	// const reference, which would ODR-use the member and need an
-	// out-of-line definition -- ill-formed for a constexpr member in C++17.
-	std::vector<uint16_t> map(m_hashes.size(), uint16_t(INVALID_INDEX));
+	std::vector<uint16_t> map(m_hashes.size(), INVALID_INDEX);
 	uint16_t next = 0;
 	for (size_t i = 0; i < m_hashes.size(); ++i) {
 		if (m_popularity[i] > 0) {

--- a/src/kademlia/kademlia/AICHHashList.h
+++ b/src/kademlia/kademlia/AICHHashList.h
@@ -64,8 +64,6 @@ class CKadAICHHashList
 public:
 	// The index value meaning "this publisher reported no AICH hash".  It is
 	// the same 0xFFFF sentinel that travels in the on-disk keyword index.
-	// Never bound to a reference: see the copy at the fill constructor in
-	// BuildCompactionMap(), which keeps this free of an out-of-line definition.
 	static constexpr uint16_t INVALID_INDEX = 0xFFFF;
 
 	// Kad BSOB tags carry a uint8 length.  eMule holds the encoded

--- a/src/libwebcommon/Credentials.cpp
+++ b/src/libwebcommon/Credentials.cpp
@@ -27,21 +27,11 @@
 #include "AtomicFile.h"
 #include "ConstantTime.h"
 
-// cryptopp headers pull in deprecated implicit copy ctors + throw()
-// specs (P0806 + C++17). Same wrap as Jwt.cpp; see CryptoPP_Inc.h for
-// the full rationale.
-#if defined(__clang__)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-copy-with-user-provided-dtor"
-#pragma clang diagnostic ignored "-Wdeprecated-copy-with-user-provided-copy"
-#pragma clang diagnostic ignored "-Wdeprecated-dynamic-exception-spec"
-#endif
+#include "../WarningsPush_CryptoPP.h"
 #include <cryptopp/osrng.h>
 #include <cryptopp/pwdbased.h>
 #include <cryptopp/sha.h>
-#if defined(__clang__)
-#pragma clang diagnostic pop
-#endif
+#include "../WarningsPop.h"
 
 #include <cctype>
 #include <cstdio>

--- a/src/libwebcommon/Etag.cpp
+++ b/src/libwebcommon/Etag.cpp
@@ -26,17 +26,9 @@
 
 #include <cstring>
 
-// See CryptoPP_Inc.h for pragma rationale.
-#if defined(__clang__)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-copy-with-user-provided-dtor"
-#pragma clang diagnostic ignored "-Wdeprecated-copy-with-user-provided-copy"
-#pragma clang diagnostic ignored "-Wdeprecated-dynamic-exception-spec"
-#endif
+#include "../WarningsPush_CryptoPP.h"
 #include <cryptopp/sha.h>
-#if defined(__clang__)
-#pragma clang diagnostic pop
-#endif
+#include "../WarningsPop.h"
 
 namespace webcommon
 {

--- a/src/libwebcommon/Jwt.cpp
+++ b/src/libwebcommon/Jwt.cpp
@@ -28,20 +28,11 @@
 
 #include "PicoJson_Inc.h"
 
-// cryptopp headers pull in deprecated implicit copy ctors + throw()
-// specs (P0806 + C++17). See CryptoPP_Inc.h for the full rationale.
-#if defined(__clang__)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-copy-with-user-provided-dtor"
-#pragma clang diagnostic ignored "-Wdeprecated-copy-with-user-provided-copy"
-#pragma clang diagnostic ignored "-Wdeprecated-dynamic-exception-spec"
-#endif
+#include "../WarningsPush_CryptoPP.h"
 #include <cryptopp/hmac.h>
 #include <cryptopp/osrng.h>
 #include <cryptopp/sha.h>
-#if defined(__clang__)
-#pragma clang diagnostic pop
-#endif
+#include "../WarningsPop.h"
 
 #include <cstdio>
 #include <cstdint>

--- a/src/libwebcommon/Jwt.h
+++ b/src/libwebcommon/Jwt.h
@@ -29,17 +29,9 @@
 #include <string>
 #include <vector>
 
-// See CryptoPP_Inc.h for pragma rationale.
-#if defined(__clang__)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-copy-with-user-provided-dtor"
-#pragma clang diagnostic ignored "-Wdeprecated-copy-with-user-provided-copy"
-#pragma clang diagnostic ignored "-Wdeprecated-dynamic-exception-spec"
-#endif
+#include "../WarningsPush_CryptoPP.h"
 #include <cryptopp/secblock.h>
-#if defined(__clang__)
-#pragma clang diagnostic pop
-#endif
+#include "../WarningsPop.h"
 
 #include "Role.h"
 

--- a/src/webapi/AmuleApiConfig.cpp
+++ b/src/webapi/AmuleApiConfig.cpp
@@ -34,17 +34,9 @@
 #include <wx/utils.h>
 #include <wx/wfstream.h>
 
-// See CryptoPP_Inc.h for pragma rationale.
-#if defined(__clang__)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-copy-with-user-provided-dtor"
-#pragma clang diagnostic ignored "-Wdeprecated-copy-with-user-provided-copy"
-#pragma clang diagnostic ignored "-Wdeprecated-dynamic-exception-spec"
-#endif
+#include "../WarningsPush_CryptoPP.h"
 #include <cryptopp/osrng.h>
-#if defined(__clang__)
-#pragma clang diagnostic pop
-#endif
+#include "../WarningsPop.h"
 
 #include <cctype>
 #include <cerrno>

--- a/src/webapi/Api.cpp
+++ b/src/webapi/Api.cpp
@@ -7289,9 +7289,8 @@ struct IpPortSelector
 // tag -- that can be a hostname OR a synthetic display string ("Eserver
 // No.1"), so a DELETE by address could match a colliding label and remove
 // the wrong row. An exact IP + port has no such ambiguity.
-// boost::optional, not std::optional: the tree builds as C++14 and this file
-// already uses the boost form (PreflightEvents), so it is the house spelling
-// as well as the available one.
+// boost::optional, not std::optional: this file already uses the boost form
+// (PreflightEvents), so it is the house spelling here.
 boost::optional<IpPortSelector> ParseIpPortSelector(const std::string &ip_port)
 {
 	const auto colon = ip_port.rfind(':');

--- a/src/webapi/HttpServer.cpp
+++ b/src/webapi/HttpServer.cpp
@@ -31,11 +31,13 @@
 #include <wx/string.h>
 
 // See the note in LibSocketAsio.cpp: Boost 1.92's asio trips
-// -Wdeprecated-copy-with-user-provided-dtor, which this build treats as an
-// error. Suppressed across the includes only.
+// -Wdeprecated-copy-with-user-provided-dtor, and its execution headers define
+// constexpr statics out of line, which C++17 makes redundant and deprecates.
+// This build treats both as errors. Suppressed across the includes only.
 #if defined(__clang__)
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-copy-with-user-provided-dtor"
+#pragma clang diagnostic ignored "-Wdeprecated-redundant-constexpr-static-def"
 #endif
 #include <boost/asio/io_context.hpp>
 #include <boost/asio/ip/tcp.hpp>
@@ -310,9 +312,7 @@ bool GzipOnce(const std::string &in, std::string &out)
 	// to resize once and slice.
 	const uLong bound = deflateBound(&zs, static_cast<uLong>(in.size()));
 	out.resize(bound);
-	// std::string::data() is const-qualified pre-C++17; `&out[0]` is
-	// non-const in every standard we build against.
-	zs.next_out = reinterpret_cast<Bytef *>(&out[0]);
+	zs.next_out = reinterpret_cast<Bytef *>(out.data());
 	zs.avail_out = static_cast<uInt>(bound);
 	const int rc = deflate(&zs, Z_FINISH);
 	if (rc != Z_STREAM_END) {

--- a/src/webapi/HttpServer.cpp
+++ b/src/webapi/HttpServer.cpp
@@ -30,15 +30,7 @@
 
 #include <wx/string.h>
 
-// See the note in LibSocketAsio.cpp: Boost 1.92's asio trips
-// -Wdeprecated-copy-with-user-provided-dtor, and its execution headers define
-// constexpr statics out of line, which C++17 makes redundant and deprecates.
-// This build treats both as errors. Suppressed across the includes only.
-#if defined(__clang__)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-copy-with-user-provided-dtor"
-#pragma clang diagnostic ignored "-Wdeprecated-redundant-constexpr-static-def"
-#endif
+#include "../WarningsPush_Asio.h"
 #include <boost/asio/io_context.hpp>
 #include <boost/asio/ip/tcp.hpp>
 #include <boost/asio/post.hpp>
@@ -53,9 +45,7 @@
 // the lines above do, and reaching them first from an unguarded include would
 // resurrect the -Wdeprecated-copy-with-user-provided-dtor error.
 #include "RangeFileBody.h"
-#if defined(__clang__)
-#pragma clang diagnostic pop
-#endif
+#include "../WarningsPop.h"
 
 // strncasecmp lives in <strings.h> on POSIX (glibc also exposes it via
 // <string.h>, but musl/BSDs don't), and MSVC spells it _strnicmp. The same

--- a/src/webserver/src/WebServer.cpp
+++ b/src/webserver/src/WebServer.cpp
@@ -28,18 +28,10 @@
 #include <wx/math.h> // Needed for cos, M_PI
 #include <string>    // Do_not_auto_remove (g++-4.0.1)
 
-// CryptoPP::AutoSeededRandomPool, for the session-token CSPRNG. See
-// CryptoPP_Inc.h for pragma rationale.
-#if defined(__clang__)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-copy-with-user-provided-dtor"
-#pragma clang diagnostic ignored "-Wdeprecated-copy-with-user-provided-copy"
-#pragma clang diagnostic ignored "-Wdeprecated-dynamic-exception-spec"
-#endif
+// CryptoPP::AutoSeededRandomPool, for the session-token CSPRNG.
+#include "../../WarningsPush_CryptoPP.h"
 #include <cryptopp/osrng.h>
-#if defined(__clang__)
-#pragma clang diagnostic pop
-#endif
+#include "../../WarningsPop.h"
 
 #include <wx/datetime.h>
 


### PR DESCRIPTION
aMule never set a language standard, so every compiler picked its own. Measured with `__cplusplus` on each toolchain we build with:

| Toolchain | `__cplusplus` | Standard |
|---|---|---|
| AppleClang 21 (macOS) | `201402` | **C++14** |
| g++ 15 (Ubuntu) | `201703` | C++17 |
| clang++ 21 (Ubuntu) | `201703` | C++17 |
| clang 22 (mingw-w64) | `201703` | C++17 |

The same source has been a different language depending on who built it, with macOS the odd one out.

## Why this is worth fixing

A `static constexpr` member is implicitly inline from C++17. Before that, odr-using one (binding a reference, which `std::min()` does) needs an out-of-line definition, and a header-only class has nowhere to put it:

| Declaration | C++14 | C++17 |
|---|---|---|
| `static const size_t k = ...;` | link error | link error |
| `static constexpr size_t k = ...;` | **link error** | links |
| `static constexpr size_t Fn() { ... }` | links | links |

Code in that middle row links on three platforms and fails on the fourth, as an undefined symbol in the *caller's* translation unit rather than anything pointing at the declaration. CI catches it, since macOS is in the matrix, but the message tells you almost nothing.

It has cost us twice already: the vendored libutp in #1353 compiled with no `-std` at all, its C++17 `if`-init statements surviving only as a compiler extension, and #1359 works around the odr-use rule with a `constexpr` function because a member could not be relied on.

## Why 17 and not 14

Three of the four toolchains already default to C++17, so pinning it moves only macOS while pinning 14 would move three platforms backwards. C++17 is nine years old, fully supported since Clang 7, GCC 9 and MSVC 15.7. Our CMake floor of 3.10 is well past the 3.8 that added `CXX_STANDARD 17`.

## What changed

**The pin**, in the top-level `CMakeLists.txt`: `CMAKE_CXX_STANDARD 17` with `CXX_STANDARD_REQUIRED ON`.

**Two suppressions the pin requires.** Boost.Asio's execution headers define constexpr statics out of line, which C++17 makes redundant and deprecates, tripping the `-Werror=deprecated` gate. `LibSocketAsio.cpp` and `webapi/HttpServer.cpp` already wrapped their asio includes for the sibling diagnostic and now cover this one too. Under the old C++14 default those definitions were still *required*, which is why this appears only now. `NetworkAddressAsio.h` needs nothing: `ip/address.hpp` does not reach the execution headers, measured at zero errors.

**Five workarounds the split forced, now removed**, along with the comments justifying them:

| Site | Before | After |
|---|---|---|
| `AICHHashList.cpp/.h` | `uint16_t(INVALID_INDEX)` cast, to avoid odr-using a `constexpr` member | bound directly |
| `PublicIPv6Corroboration.h` | discarded `emplace_back()`'s return, "the unit-test targets take clang's default of C++14" | uses the returned reference |
| `webapi/HttpServer.cpp` | `&out[0]`, since "`data()` is const-qualified pre-C++17" | `out.data()` |
| `webapi/Api.cpp` | `boost::optional` justified partly by "the tree builds as C++14" | unchanged in code; the false clause is gone, house style stands on its own |
| `cmake/libutp.cmake` | comment: "aMule sets `CMAKE_CXX_STANDARD` nowhere" | corrected. Its own `CXX_STANDARD 17` stays, because that is upstream's requirement rather than ours to lend |

**A refactor, in its own commit so it can be dropped.** Ten files each spelled out the same pragma block around their third-party includes, in two variants: three flags for Crypto++, two for Boost.Asio. The pin would have made it eleven. `WarningsPush_CryptoPP.h` and `WarningsPush_Asio.h` now hold one copy of each set, closed by a shared `WarningsPop.h`. All three are deliberately unguarded, since a translation unit opens and closes a block per include group.

A push/pop pair rather than one wrapper that includes everything, because the sites include narrow subsets on purpose: `CryptoPP_Inc.h` pulls wider than libwebcommon wants, and #1350 split `AddressFamilyPolicyAsio.h` out specifically to keep asio out of most of `src/`. Routing them through a common include would undo both.

They are included by path relative to each file rather than by name, because the `webcommon` target compiles with only `-I src/libwebcommon` and a bare name resolves nowhere there. A quoted include searches the includer's directory first, so the relative form works whatever a target's `-I` list happens to be.

## Verification

| Build | Result |
|---|---|
| macOS, `BUILD_EVERYTHING` + testing + `ENABLE_UTP`, all 12 binaries | 0 errors, **61/61**, one pre-existing `-Wswitch` |
| Ubuntu gcc 15, monolithic + remotegui + daemon | 0 errors, **60/60** |
| `KadAICHHashListTest`, covering the file the cast was removed from | passes |

Compile lines carry `-std=gnu++17`. clang-format 18 clean on every changed file, `git diff --check` clean.

## Effect on the lint gates

| Tier | C++14 | C++17 |
|---|---|---|
| Tier-1, whole-tree gate | 6 findings | 6, unchanged |
| Tier-2, changed lines | 594 | 688 across six files |

Tier-1 does not move. Tier-2's increase is **not new check categories** (diffing the check names shows none appears only under C++17), just more instances of checks already enabled, and it only ever gates changed lines.

## Side effect worth having

Under C++14 macOS emitted roughly ninety `-Wc++17-extensions` warnings from Crypto++ headers using C++17 `static_assert` without a message. Those disappear by definition. The full build now produces one warning in total.
