### PR TITLE
ci: skip the vendored subtree in Tier-1, and check the pragma stack balances

### DIFF
--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -35,3 +35,25 @@ jobs:
         with:
           clang-format-version: '18'
           check-path: 'unittests'
+      - name: Check warning-suppression blocks are balanced
+        run: |
+          # WarningsPush_*.h and WarningsPop.h wrap third-party includes, and
+          # clang's diagnostic stack needs one pop per push. The headers carry
+          # no include guard on purpose, so a second include really does push
+          # again -- guarding them would silently unbalance the stack instead.
+          #
+          # An unbalanced block fails silently and in the worst direction: the
+          # suppression stays open to the end of the translation unit, so our
+          # own code stops being diagnosed and nothing says so.
+          status=0
+          while IFS= read -r f; do
+            push=$(grep -c 'include ".*WarningsPush_' "$f" || true)
+            pop=$(grep -c 'include ".*WarningsPop\.h"' "$f" || true)
+            if [ "$push" -ne "$pop" ]; then
+              echo "::error file=$f::$push WarningsPush_* include(s) but $pop WarningsPop.h"
+              status=1
+            fi
+          done < <(grep -rl 'WarningsPush_\|WarningsPop\.h' src unittests \
+                     --include='*.h' --include='*.cpp' \
+                   | grep -v '^src/Warnings')
+          exit $status

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -167,13 +167,17 @@ jobs:
           CTCACHE_CLANG_TIDY: clang-tidy-${{ env.LLVM_VERSION }}
         run: |
           # Analyze every src/ translation unit except the generated lexers
-          # and parsers, and the vendored subtree, none of which are ours to
-          # lint. src/extern/.clang-tidy already disables every check there,
-          # so analysing those TUs only ever produced an empty report at full
-          # cost -- and each one is a permanent ctcache miss on first sight.
+          # and parsers, and the two subtrees that carry a Checks: '-*'
+          # .clang-tidy of their own: src/extern and src/webserver/src.
+          #
+          # Feeding those to clang-tidy only ever produced "Error: no checks
+          # enabled" and a usage dump, at the full cost of parsing the TU, and
+          # each is a permanent ctcache miss because a digest is only stored
+          # for a TU that emits nothing. If a third subtree is ever excluded
+          # the same way, add it here too.
           mapfile -t files < <(jq -r '.[].file' build/compile_commands.json \
             | grep -E '/src/' \
-            | grep -vE '/src/extern/' \
+            | grep -vE '/src/(extern|webserver/src)/' \
             | grep -vE '/(Scanner|Parser|IPFilterScanner)\.cpp$' \
             | sort -u)
           echo "Analyzing ${#files[@]} translation units"

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -167,9 +167,13 @@ jobs:
           CTCACHE_CLANG_TIDY: clang-tidy-${{ env.LLVM_VERSION }}
         run: |
           # Analyze every src/ translation unit except the generated lexers
-          # and parsers, which are not ours to lint.
+          # and parsers, and the vendored subtree, none of which are ours to
+          # lint. src/extern/.clang-tidy already disables every check there,
+          # so analysing those TUs only ever produced an empty report at full
+          # cost -- and each one is a permanent ctcache miss on first sight.
           mapfile -t files < <(jq -r '.[].file' build/compile_commands.json \
             | grep -E '/src/' \
+            | grep -vE '/src/extern/' \
             | grep -vE '/(Scanner|Parser|IPFilterScanner)\.cpp$' \
             | sort -u)
           echo "Analyzing ${#files[@]} translation units"


### PR DESCRIPTION
Two changes, both at the third-party edges, and independent of each other.

## Tier-1 was analysing code it had already been told to ignore

The whole-tree job feeds every `src/` translation unit to clang-tidy, including the two subtrees that carry a `Checks: '-*'` `.clang-tidy` of their own: `src/extern` and `src/webserver/src`.

Those do not produce an empty report. They produce an error. Every one of them logs:

```
Error: no checks enabled.
USAGE: clang-tidy-21 [options] <source0> [... <sourceN>]
```

14 of them per run, 6 from the vendored libutp and 8 from the webserver subtree, each at the full cost of parsing the translation unit. The usage dumps in the job log have been there as long as those `.clang-tidy` files have; they are cosmetic rather than a broken invocation, and the run is otherwise healthy at 271/271 TUs and 305 `warnings generated` lines. But they are the visible symptom of work that was never going to yield anything.

They are also permanent ctcache misses. The cache only stores a digest for a TU that emits nothing, and a first-seen TU has no entry, so each run paid for them again.

### On runtime: no measurable effect, and I am withdrawing that claim

I opened this expecting it to recover time, because Tier-1 durations rose after the vendoring landed. Measured against this PR's own run, it does not:

| Commit | Exclusions | Tier-1 |
|---|---|---|
| `9d8227b0e` (this PR) | both | 35 min |
| `296f2ada1` | none | 46 min |
| `c0003fb79` | none | 31 min |
| `55e2f7a0f` | none | 19 min |

35 minutes sits inside the range of runs without the change. 14 translation units out of 271 is about 5%, comfortably below the run-to-run variance, so the earlier rise was noise or something else and this does not fix it.

The change still stands on its own terms: it stops producing 14 error blocks per run, stops parsing 14 TUs to reach a foregone conclusion, and stops burning 14 permanent ctcache misses. Those are real, just small. If Tier-1 runtime is worth attacking, it needs a different investigation.

## A guard for the shared suppression headers

#1360 replaced ten copies of the same pragma block with `WarningsPush_CryptoPP.h`, `WarningsPush_Asio.h` and a shared `WarningsPop.h`. Those drive clang's diagnostic stack, which needs exactly one pop per push.

The headers carry no include guard, deliberately: a second include must push again, so guarding them would unbalance the stack rather than protect it. That makes balance a property nothing enforces.

It fails silently and in the worst direction. With two pushes and one pop the suppression stays open to the end of the translation unit, so our own code stops being diagnosed. I checked this rather than assumed it: a deliberate `~T() {}` copy bug after an unbalanced block compiled with **zero** errors under the full `-Werror=deprecated` gate.

The check greps each file's push and pop counts and fails with a file annotation if they differ. Verified both ways: clean tree passes, and deleting one `WarningsPop.h` include reports `1 push / 0 pop` and exits non-zero.

It lives in the clang-format workflow because that job is the cheap lint pass and already triggers on `src/**` and `unittests/**`.

## Verification

`clang-format.yml` and `clang-tidy.yml` both parse as YAML. The balance check was run against the current tree (all ten sites balanced) and against a deliberately broken one. The Tier-1 change is a `grep -v` in the file list; the real measurement of its effect is this PR's own Tier-1 run.
