### PR TITLE
chore(webapi): trim verbose comment blocks

### DIFF
--- a/src/webapi/AmuleApiConfig.cpp
+++ b/src/webapi/AmuleApiConfig.cpp
@@ -114,11 +114,10 @@ wxString JoinPath(const wxString &dir, const wxString &leaf)
 	return fn.GetFullPath();
 }
 
-// Thin wx wrapper over webcommon::WriteFileAtomic0600 so the call sites
-// here can keep passing wxString paths. The writer itself is shared with
-// the credential store and with amuled, which writes the EC token into the
-// same config dir -- one implementation, so the permission and atomicity
-// guarantees cannot drift between them.
+// Thin wx wrapper over webcommon::WriteFileAtomic0600 so the call sites here
+// can keep passing wxString paths. The writer itself is shared with the
+// credential store and with amuled, so the permission and atomicity guarantees
+// cannot drift between them.
 bool WriteFileAtomic0600(const wxString &target_path, const std::string &body)
 {
 	return webcommon::WriteFileAtomic0600(std::string(target_path.utf8_str()), body);
@@ -185,24 +184,20 @@ bool CAmuleApiConfig::LoadAmuleapiConf(const wxString &path)
 			       "MaxConcurrentFileResponses=6\n";
 
 	if (!wxFileExists(path)) {
-		// First-run: write mode-0600 defaults file. EC password stays
-		// empty; amuleapi refuses to connect until it's filled in.
-		// amuleapi.conf carries `[EC]/Password=` in cleartext (base
-		// class wants hashable plaintext), so owner-only mode matches
-		// jwt-secret and passwords files.
-		//
-		// WriteFileAtomic0600 (write-temp, fsync, rename) so a crash
-		// mid-write can't leave a truncated config that the next
-		// start would happily load as partial → silent default flip.
+		// First-run: write a mode-0600 defaults file. The EC password stays empty
+		// and amuleapi refuses to connect until it is filled in; amuleapi.conf
+		// carries `[EC]/Password=` in cleartext, so owner-only mode matches the
+		// jwt-secret and passwords files. WriteFileAtomic0600 (write-temp, fsync,
+		// rename) so a crash mid-write cannot leave a truncated config the next
+		// start would load as partial.
 		if (!WriteFileAtomic0600(path, std::string(defaults))) {
 			m_lastError = "cannot create amuleapi.conf: " + std::string(path.utf8_str());
 			return false;
 		}
 	}
 
-	// Enforce 0600 on every load so a hand-edit (or a `cp` from a
-	// loose-permission source) doesn't silently widen the EC
-	// password's exposure.
+	// Enforce 0600 on every load so a hand-edit, or a `cp` from a
+	// loose-permission source, does not silently widen the password's exposure.
 	if (!EnforceOwnerOnly(path))
 		return false;
 
@@ -272,21 +267,17 @@ bool CAmuleApiConfig::LoadAmuleapiConf(const wxString &path)
 		m_auth.token_lockout_seconds = static_cast<unsigned>(n);
 	}
 
-	// `[Streaming]/EventBusRingCapacity`. Below the CEventBus floor
-	// is silently clamped up by the bus itself; we just accept any
-	// positive value here.
+	// `[Streaming]/EventBusRingCapacity`. Anything below the CEventBus floor is
+	// clamped up by the bus itself, so any positive value is accepted here.
 	if (cfg.Read("/Streaming/EventBusRingCapacity", &n) && n > 0) {
 		m_streaming.event_bus_ring_capacity = static_cast<unsigned>(n);
 	}
 
-	// `[Streaming]/MaxConcurrentFileResponses`. Bounded on both sides
-	// rather than merely positive, the way `/Server/Port` is: unlike the
-	// ring above -- which the bus clamps for us -- nothing downstream
-	// second-guesses this one, and every slot it grants pins a file
-	// descriptor and a 64 KiB buffer until the peer drains. 256 is already
-	// far past any plausible household deployment and keeps the worst case
-	// in the tens of megabytes; anything outside the band is a typo, and a
-	// typo gets the default rather than a number the operator did not mean.
+	// `[Streaming]/MaxConcurrentFileResponses`. Bounded on both sides rather than
+	// merely positive: unlike the ring above, nothing downstream second-guesses
+	// this one, and every slot it grants pins a file descriptor and a 64 KiB
+	// buffer until the peer drains. 256 keeps the worst case in the tens of
+	// megabytes; anything outside the band is a typo, and a typo gets the default.
 	if (cfg.Read("/Streaming/MaxConcurrentFileResponses", &n) && n > 0 && n <= 256) {
 		m_streaming.max_concurrent_file_responses = static_cast<unsigned>(n);
 	}
@@ -296,14 +287,9 @@ bool CAmuleApiConfig::LoadAmuleapiConf(const wxString &path)
 
 bool CAmuleApiConfig::LoadJwtSecret(const wxString &path)
 {
-	// Rotation is operator-manual today: delete amuleapi-jwt-secret
-	// and restart amuleapi, which auto-generates a fresh secret and
-	// invalidates every previously-issued token. A `--rotate-jwt-
-	// secret` CLI subcommand that does the file replacement + a
-	// SIGHUP reload without a full restart is roadmapped for 3.1
-	// (would let the daemon keep accepting old-keyed tokens for a
-	// grace window). Until then, the manual flow is documented in
-	// the amuleapi(1) FILES section.
+	// Rotation is operator-manual: delete amuleapi-jwt-secret and restart
+	// amuleapi, which auto-generates a fresh secret and invalidates every
+	// previously-issued token. Documented in the amuleapi(1) FILES section.
 	if (!wxFileExists(path)) {
 		// Auto-generate 32 random bytes. The new file is 0600 from
 		// the moment it lands on disk (open + chmod before any data).
@@ -326,9 +312,8 @@ bool CAmuleApiConfig::LoadJwtSecret(const wxString &path)
 		return false;
 	}
 	const wxFileOffset sz = f.Length();
-	// 64 hex chars + optional trailing newline. Cap generously to
-	// catch "someone pasted a 2 KB blob" without truncating valid
-	// edits.
+	// 64 hex chars + optional trailing newline. Capped generously to catch
+	// "someone pasted a 2 KB blob" without truncating valid edits.
 	if (sz < 64 || sz > 4096) {
 		m_lastError = "amuleapi-jwt-secret has unexpected size; "
 			      "expected 64 hex chars (256-bit secret)";
@@ -358,12 +343,9 @@ bool CAmuleApiConfig::LoadPasswords(const wxString &path)
 	const std::string dir(m_configDir.utf8_str());
 
 	if (!wxFileExists(path)) {
-		// Auto-create empty so the operator sees the file exists, with
-		// the right mode bits. First-run flow:
-		//  amuleapi --set-admin-pass=<plain>
-		// hashes + writes the admin record; the daemon then accepts
-		// logins. amulegui and the preferences dialog write the same
-		// file for the same effect.
+		// Auto-create empty so the operator sees the file exists, with the right
+		// mode bits. `amuleapi --set-admin-pass=<plain>` then hashes and writes the
+		// admin record; amulegui and the preferences dialog write the same file.
 		std::string err;
 		if (!webcommon::SaveCredentialsFile(dir, m_credentials, err)) {
 			m_lastError = "cannot create amuleapi-passwords: " + err;
@@ -390,10 +372,9 @@ bool CAmuleApiConfig::HasAnyCredential() const
 
 std::time_t CAmuleApiConfig::CredentialsChangedAt() const
 {
-	// Second granularity, which leaves a token minted in the same second
-	// as a password change alive. Bounded and self-correcting: the next
-	// change moves the cutoff again, and a one-second window is far
-	// inside the time it takes to notice a leak and react to it.
+	// Second granularity, which leaves a token minted in the same second as a
+	// password change alive. Bounded and self-correcting: the next change moves
+	// the cutoff again, and one second is far inside the time to notice a leak.
 	wxFileName fn(JoinPath(m_configDir, "amuleapi-passwords"));
 	if (!fn.FileExists()) {
 		return 0;
@@ -438,10 +419,9 @@ CAmuleApiConfig::MatchedRole CAmuleApiConfig::VerifyPassword(const std::string &
 
 void CAmuleApiConfig::RehashInPlace(webcommon::CredentialRole role, const std::string &md5_hex)
 {
-	// Re-storing the same password at the current cost is housekeeping,
-	// not a rotation, so the file's modification time must not move: that
-	// timestamp is what invalidates sessions, and nobody should be signed
-	// out because their password was quietly re-hashed on the way in.
+	// Re-storing the same password at the current cost is housekeeping, not a
+	// rotation, so the file's modification time must not move: that timestamp is
+	// what invalidates sessions.
 	wxFileName fn(JoinPath(m_configDir, "amuleapi-passwords"));
 	const bool had_file = fn.FileExists();
 	wxDateTime access, modified, created;

--- a/src/webapi/AmuleApiConfig.h
+++ b/src/webapi/AmuleApiConfig.h
@@ -65,11 +65,10 @@ public:
 		unsigned port = 4713;
 		bool allow_cors = false;
 		std::vector<std::string> cors_origin_allowlist;
-		// Filesystem root of a bundled web frontend. Empty (default) =
-		// API-only deployment: non-/api/ paths return 404. Non-empty =
-		// the daemon serves GET/HEAD requests for paths outside /api/
-		// from this directory, with an index.html SPA fallback for
-		// extension-less misses. See ServeStaticFile in Api.cpp.
+		// Filesystem root of a bundled web frontend. Empty (default) = API-only
+		// deployment, so non-/api/ paths return 404. Non-empty = the daemon serves
+		// GET/HEAD for paths outside /api/ from here, with an index.html SPA
+		// fallback for extension-less misses.
 		std::string static_root;
 	};
 
@@ -78,9 +77,8 @@ public:
 		std::string host = "127.0.0.1";
 		unsigned port = 4712;
 		std::string password; // matches amuled's [ExternalConnect]/Password
-		// Offer EC transport encryption. On by default for every
-		// destination; only the client knows what it dialed, so the
-		// choice lives here rather than in amuled.
+		// Offer EC transport encryption. On by default for every destination; only
+		// the client knows what it dialed, so the choice lives here, not in amuled.
 		bool encryption = true;
 	};
 
@@ -90,12 +88,9 @@ public:
 		unsigned login_failure_threshold = 5;
 		unsigned login_lockout_seconds = 300;
 		// The generic 401 limiter, counting every rejected token on any
-		// authenticated route rather than password failures on /auth/login.
-		// It was hard-coded while the three above were documented knobs, so an
-		// operator tuning what the docs described changed only one of the two
-		// limiters -- and could not loosen the one a browser tab left open
-		// overnight actually trips, spending 30 requests on a stale token
-		// before a five-minute lockout.
+		// authenticated route rather than password failures on /auth/login. It was
+		// hard-coded while the three above were documented knobs, so an operator
+		// could not loosen the one a browser tab left open overnight actually trips.
 		unsigned token_failure_window_seconds = 60;
 		unsigned token_failure_threshold = 30;
 		unsigned token_lockout_seconds = 300;
@@ -103,33 +98,25 @@ public:
 
 	struct Streaming
 	{
-		// SSE ring capacity. Sized for a cold-start tick on a busy
-		// node (5K downloads + 5K shared can publish ~10K `*_added`
-		// in one tick before any subscriber drains). Values below
-		// the CEventBus::kMinCapacity floor are clamped up at the
-		// bus level so an operator can't accidentally disable
-		// replay. Operators with very heavy nodes can raise this;
-		// memory ≈ capacity × ~1 KB JSON payload.
+		// SSE ring capacity. Sized for a cold-start tick on a busy node (5K
+		// downloads + 5K shared can publish ~10K `*_added` in one tick before any
+		// subscriber drains). Values below CEventBus::kMinCapacity are clamped up
+		// at the bus level. Memory is roughly capacity x ~1 KB of JSON payload.
 		unsigned event_bus_ring_capacity = 16384;
 
-		// Concurrent file-backed responses allowed on
-		// `GET /shared/{hash}/content`; over it the transport answers
-		// 503 + Retry-After. Six suits one mechanical disk shared with
-		// the hasher and the ed2k uploader, but it is a GLOBAL budget:
-		// behind a reverse proxy every client arrives from one address,
-		// so there is no per-user fairness in it and a household with
-		// several devices on an SSD-backed NAS can raise it. The upper
-		// bound is the transport's, not a taste: each slot pins a file
-		// descriptor and a 64 KiB buffer for as long as the peer takes
-		// to drain, so a four-digit value would trade the RSS ceiling
-		// the streaming path exists to hold for nothing.
+		// Concurrent file-backed responses allowed on `GET /shared/{hash}/content`;
+		// over it the transport answers 503 + Retry-After. Six suits one mechanical
+		// disk shared with the hasher and the ed2k uploader, but it is a GLOBAL
+		// budget: behind a reverse proxy every client arrives from one address, so
+		// there is no per-user fairness in it. Each slot pins a file descriptor and
+		// a 64 KiB buffer for as long as the peer takes to drain, so a four-digit
+		// value would trade away the RSS ceiling the streaming path exists to hold.
 		unsigned max_concurrent_file_responses = 6;
 	};
 
-	// Bring everything into memory from `config_dir`. Returns true on
-	// success; false on missing required field, mode-bit failure, or
-	// malformed INI. On failure, the human-readable reason is left in
-	// LastError() so the caller can surface it via Show(...).
+	// Bring everything into memory from `config_dir`. Returns false on a missing
+	// required field, a mode-bit failure, or malformed INI, leaving the
+	// human-readable reason in LastError().
 	bool Load(const wxString &config_dir);
 
 	const wxString &ConfigDir() const { return m_configDir; }
@@ -143,11 +130,10 @@ public:
 	const std::vector<unsigned char> &JwtSecret() const { return m_jwtSecret; }
 
 	// Stored credential records for the two roles, in whatever form
-	// amuleapi-passwords holds them (see webcommon/Credentials.h — a PHC
-	// string normally, a bare MD5 for a config predating the KDF). Empty
-	// when the role is unset: `/auth/login` returns `login_disabled`.
-	// These are NOT digests to compare an input against — for that, and
-	// for the file-freshness check that comes with it, use VerifyPassword.
+	// amuleapi-passwords holds them (a PHC string normally, a bare MD5 for a
+	// config predating the KDF). Empty when the role is unset. These are NOT
+	// digests to compare an input against -- use VerifyPassword for that, which
+	// also brings the file-freshness check with it.
 	const std::string &AdminCredential() const { return m_credentials.admin; }
 	const std::string &GuestCredential() const { return m_credentials.guest; }
 
@@ -165,40 +151,33 @@ public:
 
 	// Verifies an MD5 hex digest against both roles, admin first.
 	//
-	// Not const, for two reasons. It re-reads amuleapi-passwords first, so
-	// a password set by amuled (pushed over EC from amulegui) or by
-	// aMule's preferences dialog takes effect without restarting amuleapi
-	// — which also means HasAnyCredential() is up to date immediately
-	// after this call, and stale before it. And a record that verified but
-	// predates the current KDF parameters is rewritten at the current
-	// cost, so the upgrade needs no operator step.
+	// Not const, for two reasons. It re-reads amuleapi-passwords first, so a
+	// password set by amuled or by aMule's preferences dialog takes effect
+	// without restarting amuleapi -- which also means HasAnyCredential() is up
+	// to date immediately after this call and stale before it. And a record that
+	// verified but predates the current KDF parameters is rewritten at the
+	// current cost, so the upgrade needs no operator step.
 	MatchedRole VerifyPassword(const std::string &md5_hex);
 
-	// Sets or clears one role and persists it, leaving the other role as
-	// it stands on disk. `md5_hex` empty clears the role — that is how the
-	// guest role is disabled. Returns false with LastError() set on a
-	// malformed digest or a write failure.
+	// Sets or clears one role and persists it, leaving the other as it stands on
+	// disk. `md5_hex` empty clears the role -- that is how the guest role is
+	// disabled. False with LastError() set on a malformed digest or write failure.
 	bool SetPassword(webcommon::CredentialRole role, const std::string &md5_hex);
 
-	// Modification time of amuleapi-passwords, or 0 when there is no file
-	// (nothing configured, so nothing to invalidate). Used to reject
-	// sessions older than the last password change, whoever made it.
+	// Modification time of amuleapi-passwords, or 0 when there is no file. Used
+	// to reject sessions older than the last password change, whoever made it.
 	std::time_t CredentialsChangedAt() const;
 
 	const std::string &LastError() const { return m_lastError; }
 
-	// Re-reads amuleapi-passwords, keeping the current values if the read
-	// fails so a transient error can't lock everyone out.
+	// Re-reads amuleapi-passwords, keeping the current values if the read fails
+	// so a transient error cannot lock everyone out.
 	//
-	// Unconditional rather than gated on a stat: mtime is second-
-	// granularity on every platform here, and two writes inside one
-	// second produce records of identical length, so a
-	// timestamp-plus-size check would miss a rotation *permanently*, not
-	// just briefly. The file is under 4 KB and this runs once per login
-	// attempt, behind the rate limiter and in front of a PBKDF2 — the
-	// read does not show up next to either. VerifyPassword calls it first;
-	// a caller that just wrote the file calls it directly so the state it
-	// reports back is the state it stored.
+	// Unconditional rather than gated on a stat: mtime is second-granularity on
+	// every platform here, and two writes inside one second produce records of
+	// identical length, so a timestamp-plus-size check would miss a rotation
+	// *permanently*. The file is under 4 KB and this runs once per login
+	// attempt, behind the rate limiter and in front of a PBKDF2.
 	void ReloadCredentials();
 
 private:
@@ -206,18 +185,17 @@ private:
 	// Load()'s first-run path -- callers get the secret via JwtSecret().
 	bool WriteJwtSecretFile(const wxString &config_dir, const std::vector<unsigned char> &secret_32);
 
-	// Rewrites one role's record at the current KDF cost without moving
-	// the file's modification time — an upgrade is not a password change,
-	// and only a password change should end sessions.
+	// Rewrites one role's record at the current KDF cost without moving the
+	// file's modification time -- an upgrade is not a password change, and only
+	// a password change should end sessions.
 	void RehashInPlace(webcommon::CredentialRole role, const std::string &md5_hex);
 
 	bool LoadAmuleapiConf(const wxString &path);
 	bool LoadJwtSecret(const wxString &path);
 	bool LoadPasswords(const wxString &path);
 
-	// POSIX-only mode check. Returns true on Windows (no enforcement
-	// possible) or when the file matches 0600. Sets m_lastError on
-	// failure.
+	// POSIX-only mode check. Returns true on Windows (no enforcement possible) or
+	// when the file matches 0600. Sets m_lastError on failure.
 	bool EnforceOwnerOnly(const wxString &path);
 
 	wxString m_configDir;

--- a/src/webapi/Api.cpp
+++ b/src/webapi/Api.cpp
@@ -26,7 +26,6 @@
 #include "JsonDepthScan.h" // webapi::JsonNestingWithinLimit
 
 #include "ClientTagNames.h" // Needed for the shared client-tag token decoders
-// Shared server capability-bit tables, decoded to JSON
 #include "ServerFlagNames.h"
 
 #include "config.h" // AMULEAPI_STATIC_DIR (compile-time install path)
@@ -80,9 +79,8 @@
 #include <cstdlib>
 #include <sys/stat.h>
 
-// strncasecmp lives in <strings.h> on POSIX (glibc also exposes it
-// via <string.h>, but musl/BSDs don't). Match the shim
-// libwebcommon/HeaderParse.cpp ships.
+// strncasecmp is in <strings.h> on POSIX; glibc also exposes it via
+// <string.h>, but musl and the BSDs do not.
 #ifdef _WIN32
 #define strncasecmp _strnicmp
 #else
@@ -117,15 +115,9 @@ void SplitPathAndQuery(const std::string &target, std::string &path, std::string
 	}
 }
 
-// Serialise the writer's buffer into the response body. Every JSON response in
-// this file goes through here -- open-coding it is how nine handlers came to
-// hold a stale copy of the conversion.
-// Emit `key` as a number, or as null when the value is not known.
-//
-// Six sites spelled this out as a four-line if/else, which is how one response
-// family came to carry four different spellings of "I don't know". The rule is
-// in REFERENCE.md under `Unknown values`; this is the one place that implements
-// it, so a seventh nullable field cannot quietly pick -1 or 0 instead.
+// Emit `key` as a number, or null when the value is not known. The rule lives
+// in REFERENCE.md under `Unknown values`; this is the one implementation, so a
+// new nullable field cannot quietly pick -1 or 0 instead.
 void WriteIntOrNull(CJsonWriter &w, const char *key, bool known, std::int64_t value)
 {
 	w.Key(key);
@@ -144,14 +136,9 @@ void WriteUIntOrNull(CJsonWriter &w, const char *key, bool known, std::uint64_t 
 		w.ValueNull();
 }
 
-// Siblings of WriteIntOrNull for the other two shapes the rule reaches.
-// Callers pass the predicate rather than letting this guess from the value,
-// because "empty" and "unknown" are not always the same question: a count of 0
-// is a real answer (parts_offered_count), while "" on an address field is a
-// sentinel the rule spells null.
-// Bool half of the OrNull family. `false` and "not measured" are different
-// answers for a firewall verdict or a LAN-mode flag, and only one of them is
-// something a consumer should act on.
+// Callers pass the predicate rather than letting this guess from the value:
+// `false` and "not measured" are different answers for a firewall verdict, and
+// a count of 0 is real where "" on an address field is a null sentinel.
 void WriteBoolOrNull(CJsonWriter &w, const char *key, bool known, bool value)
 {
 	w.Key(key);
@@ -172,11 +159,10 @@ void WriteStringOrNull(CJsonWriter &w, const char *key, bool known, const std::s
 
 void FinalizeJsonBody(CJsonWriter &w, CHttpServer::Response &r)
 {
-	// The writer already holds UTF-8, so this is a move, not a convert+copy.
-	// Never route it through wxString: amuleapi calls neither setlocale nor
-	// wxLocale, so it runs in the "C" locale whatever LANG says, and
-	// wxString's std::string ctor decodes with the locale -- turning a body
-	// with any non-ASCII byte into an empty one.
+	// The writer already holds UTF-8, so this is a move. Never route it through
+	// wxString: amuleapi calls neither setlocale nor wxLocale, so it runs in the
+	// "C" locale and wxString's std::string ctor decodes with the locale, turning
+	// a body with any non-ASCII byte into an empty one.
 	r.body = w.TakeBuffer();
 }
 
@@ -199,14 +185,9 @@ CHttpServer::Response ErrorResponse(unsigned status, const char *code, const cha
 	return r;
 }
 
-// 405 with the `Allow` header RFC 9110 §15.5.6 requires ("The origin server
-// MUST generate an Allow header field in a 405 response containing a list of
-// the target resource's currently supported methods"). The accepted methods
-// were already spelled out in the human-readable message at every rejection
-// site; generic tooling and capability discovery read the header instead, so
-// the same list is now emitted both ways. `allow` is the machine-readable
-// form -- comma-separated, in RFC order -- and includes HEAD wherever GET is
-// served, which several of the messages omit.
+// RFC 9110 15.5.6 requires an Allow header on a 405. `allow` is the
+// machine-readable list, comma-separated in RFC order, and includes HEAD
+// wherever GET is served.
 CHttpServer::Response MethodNotAllowed(const char *allow, const char *message)
 {
 	CHttpServer::Response r = ErrorResponse(405, "method_not_allowed", message);
@@ -214,15 +195,9 @@ CHttpServer::Response MethodNotAllowed(const char *allow, const char *message)
 	return r;
 }
 
-// Common preamble for every auth-protected endpoint. Pulls the JWT
-// out of either the Authorization header or the cookie, verifies it,
-// rejects revoked tokens, and exposes the resulting VerifyResult.
-// Returns 401 on any failure.
-//
-// Token precedence: Authorization header wins over the cookie when
-// both are present. This mirrors the convention browsers and SDKs
-// already converge on — a client that explicitly attached a bearer
-// header signalled intent that overrides the implicit cookie.
+// Pulls the JWT from the Authorization header or the session cookie, verifies
+// it and rejects revoked tokens. The header wins when both are present: an
+// explicit bearer header signals intent over an implicit cookie.
 AuthOutcome AuthenticateRequest(const CHttpServer::Request &req,
 	CJwt &jwt,
 	webapi::CRevocationSet &revocations,
@@ -234,10 +209,8 @@ AuthOutcome AuthenticateRequest(const CHttpServer::Request &req,
 	std::string token;
 	auto auth_it = req.headers.find("Authorization");
 	if (auth_it == req.headers.end()) {
-		// Case-tolerant fallback: HTTP header names are case-insensitive,
-		// but Beast preserves whatever the client sent — so a lowercase
-		// `authorization:` from a curl `-H` slips past the literal find.
-		// Walk the map once to recover.
+		// Header names are case-insensitive but Beast preserves what the client
+		// sent, so a lowercase `authorization:` slips past the literal find.
 		for (const auto &h : req.headers) {
 			if (h.first.size() == 13 && strncasecmp(h.first.c_str(), "Authorization", 13) == 0) {
 				auth_it = req.headers.find(h.first);
@@ -249,9 +222,6 @@ AuthOutcome AuthenticateRequest(const CHttpServer::Request &req,
 		token = webapi::ExtractBearerToken(auth_it->second);
 	}
 	if (token.empty()) {
-		// No Authorization → fall through to the cookie. Browser-driven
-		// session-cookie clients land here; bearer-only API clients
-		// already have their token from the header path above.
 		auto ck_it = req.headers.find("Cookie");
 		if (ck_it == req.headers.end()) {
 			for (const auto &h : req.headers) {
@@ -277,13 +247,10 @@ AuthOutcome AuthenticateRequest(const CHttpServer::Request &req,
 		out.rejection = ErrorResponse(401, "unauthorized", "token has been revoked");
 		return out;
 	}
-	// A password change ends the sessions the old password opened —
-	// otherwise rotating a leaked password would leave whoever leaked it
-	// logged in for up to a day. The cutoff is the credential file's own
-	// mtime, so this holds however the change was made: over REST, from
-	// the amuleapi CLI, from aMule's preferences dialog, or pushed to
-	// amuled from amulegui. It also survives a restart, because the
-	// timestamp is a property of the file rather than of this process.
+	// A password change ends the sessions the old password opened. The cutoff is
+	// the credential file's own mtime, so it holds however the change was made --
+	// REST, the CLI, the preferences dialog, amulegui -- and survives a restart,
+	// being a property of the file rather than of this process.
 	if (credentials_changed_at > 0 && out.verified.iat < credentials_changed_at) {
 		out.rejection =
 			ErrorResponse(401, "unauthorized", "credentials changed; please sign in again");
@@ -293,10 +260,7 @@ AuthOutcome AuthenticateRequest(const CHttpServer::Request &req,
 	return out;
 }
 
-// Admin role gate. Drop-in for the standard ` if (!a.ok) return
-// a.rejection;` pattern; callers chain ` if (auto r = RequireAdmin(a))
-// return *r;` immediately after. Used by every mutation handler and by
-// the /auth/passwords pair.
+// Admin gate: `if (auto r = RequireAdmin(a)) return *r;`
 std::unique_ptr<CHttpServer::Response> RequireAdmin(const AuthOutcome &a)
 {
 	if (a.verified.role != Role::ADMIN) {
@@ -306,13 +270,9 @@ std::unique_ptr<CHttpServer::Response> RequireAdmin(const AuthOutcome &a)
 	return nullptr;
 }
 
-// First-snapshot gate, the counterpart to RequireAdmin above and used the
-// same way: ` if (auto r = RequireSnapshot(m_state)) return *r;`.
-//
-// Until the first EC snapshot lands there is nothing to answer from, and
-// every handler that touches cached state has to say so identically -- the
-// status, the code and the sentence are part of the API contract, not local
-// wording. Thirty handlers had spelled the same four lines out by hand.
+// First-snapshot gate, used like RequireAdmin. Until the first EC snapshot
+// lands there is nothing to answer from, and the status, the code and the
+// sentence are API contract rather than local wording.
 std::unique_ptr<CHttpServer::Response> RequireSnapshot(const webapi::CState &state)
 {
 	if (!state.HasFirstSnapshot()) {
@@ -322,11 +282,8 @@ std::unique_ptr<CHttpServer::Response> RequireSnapshot(const webapi::CState &sta
 	return nullptr;
 }
 
-// The URL carries a file hash in whatever case the caller typed; the snapshot
-// keys everything lowercase. Canonicalising was open-coded at seventeen call
-// sites as the same four lines, so it lives here now -- and the two lookups
-// that always follow it come with it, since "lower-case then find" is the
-// whole operation every one of those sites wanted.
+// The URL carries a hash in whatever case the caller typed; the snapshot keys
+// everything lowercase. The two lookups that always follow come with it.
 std::string LowerHexKey(const std::string &key)
 {
 	std::string out = key;
@@ -346,14 +303,10 @@ bool FindSharedByKey(const webapi::CState &state, const std::string &key, webapi
 	return state.FindShared(LowerHexKey(key), out);
 }
 
-// Wrapper that pipes AuthenticateRequest through a per-IP failure
-// counter. Every 401 (missing token / bad sig / expired / revoked)
-// counts against the calling IP; once the bucket fills the IP gets
-// 429 with Retry-After until the lockout window expires. Pre-checks
-// the bucket BEFORE Verify() so a locked-out IP can't burn CPU on
-// MAC compares either. Used by every auth-protected handler — login
-// keeps its own m_rateLimiter for the dedicated password-failure
-// path.
+// AuthenticateRequest behind a per-IP failure counter: every 401 counts, and a
+// filled bucket gets 429 with Retry-After. The bucket is checked BEFORE
+// Verify() so a locked-out IP cannot burn CPU on MAC compares. Login keeps its
+// own limiter for the password-failure path.
 AuthOutcome AuthenticateRequestRateLimited(const CHttpServer::Request &req,
 	CJwt &jwt,
 	webapi::CRevocationSet &revocations,
@@ -387,33 +340,20 @@ AuthOutcome AuthenticateRequestRateLimited(const CHttpServer::Request &req,
 	return out;
 }
 
-// `Set-Cookie: <name>=<value>; HttpOnly; SameSite=Strict; Path=/api/v0;
-//             Max-Age=<lifetime>`
+// `<name>=<value>; HttpOnly; SameSite=Strict; Path=/api/v0; Max-Age=<lifetime>`
 //
-// No `Secure`: amuleapi serves HTTP by design (operator terminates
-// TLS in front). Documented in QUICKSTART.
-//
-// Attributes shared by Set-Cookie (login) + clear-cookie (logout):
-// RFC 6265 §5.3 requires (name, path, domain) match to delete, so
-// one shared constant keeps the two paths from drifting.
+// No `Secure`: amuleapi serves HTTP by design, with TLS terminated in front.
+// Shared with the clear-cookie path because RFC 6265 5.3 requires (name, path,
+// domain) to match for a delete.
 const char *const kSessionCookieAttrs = "; HttpOnly; SameSite=Strict; Path=/api/v0";
 
 std::string MakeSetCookie(const std::string &name, const std::string &value, std::time_t expires_at)
 {
 	const std::time_t now = std::time(nullptr);
-	// Boundary case: an already-expired `expires_at` produces
-	// `Max-Age=0`, which makes the browser delete the cookie on
-	// receipt (RFC 6265 §5.2.2). That's the right behaviour — issuing
-	// an expired token's cookie shouldn't grant the client a working
-	// session — so we emit it deliberately rather than clamping to
-	// some positive minimum.
+	// An already-expired `expires_at` yields Max-Age=0, which deletes the cookie
+	// on receipt (RFC 6265 5.2.2). Deliberate: an expired token's cookie should
+	// not grant a working session.
 	const std::time_t lifetime = expires_at > now ? expires_at - now : 0;
-	// std::string instead of a fixed snprintf buffer. The previous
-	// 256-byte buffer fit today's ~189-byte HS256 JWT plus the
-	// attribute boilerplate with room to spare, but any future
-	// payload extension (extra claim, longer secret, switch to a
-	// longer alg) would silently truncate. std::string sizes
-	// itself.
 	std::string out;
 	out.reserve(name.size() + value.size() + 80);
 	out += name;
@@ -425,10 +365,8 @@ std::string MakeSetCookie(const std::string &name, const std::string &value, std
 	return out;
 }
 
-// `Set-Cookie: <name>=; ... Max-Age=0` — invalidates whatever was
-// set on a prior login. Used by /auth/logout. MUST use the same
-// (name, path, domain) tuple as MakeSetCookie or the browser
-// won't drop the original.
+// Max-Age=0 invalidates whatever a prior login set. MUST use the same
+// (name, path, domain) tuple as MakeSetCookie or the browser keeps the original.
 std::string MakeClearCookie(const std::string &name)
 {
 	std::string out;
@@ -440,20 +378,16 @@ std::string MakeClearCookie(const std::string &name)
 	return out;
 }
 
-// `amuleapi_token` namespacing keeps the cookie distinct from
-// amuleweb's legacy `amule_token` so the two daemons can coexist
-// behind the same host without a Set-Cookie tug-of-war.
+// Namespaced apart from amuleweb's `amule_token` so the two daemons can
+// coexist behind one host without a Set-Cookie tug-of-war.
 const char *const kSessionCookieName = "amuleapi_token";
 
-// Hard ceiling for individual static-asset reads. Frontend bundles are
-// kilobytes to a few MB; 16 MiB is comfortable headroom while keeping a
-// malformed StaticRoot pointing at /dev/zero or a multi-GB log file
-// from exhausting daemon RAM.
+// Ceiling for one static-asset read: keeps a StaticRoot pointing at /dev/zero
+// or a multi-GB log file from exhausting daemon RAM.
 constexpr std::size_t kStaticMaxFileBytes = 16 * 1024 * 1024;
 
-// Map file extension to Content-Type. Unknown → application/octet-stream
-// (no XSS amplification from a wrong-type response on an attacker-named
-// file).
+// Extension to Content-Type; unknown maps to application/octet-stream, so a
+// wrong-type response on an attacker-named file cannot amplify XSS.
 std::string StaticContentType(const std::string &path)
 {
 	const std::size_t dot = path.find_last_of('.');
@@ -495,10 +429,9 @@ std::string StaticContentType(const std::string &path)
 	return "application/octet-stream";
 }
 
-// Slurp `fs_path` into `out`. Returns false if the path is not a
-// regular file, exceeds kStaticMaxFileBytes, or any read error. `st`
-// is populated on success so the caller can derive an ETag from
-// mtime + size without re-stat'ing.
+// Slurp into `out`; false on a non-regular file, oversize, or read error. `st`
+// is filled on success so the caller can ETag from mtime + size without
+// re-stat'ing.
 bool ReadStaticFile(const std::string &fs_path, std::string &out, struct stat &st)
 {
 	if (::stat(fs_path.c_str(), &st) != 0)
@@ -577,19 +510,15 @@ std::string ResolveDefaultStaticDir()
 	}
 #endif // __WXMAC__
 
-	// A copy sitting next to the binary that is running. This is what the
-	// Linux static tarball ships: three binaries and an `amuleapi-static/`
-	// directory beside them, extracted wherever the operator chose, with no
-	// install step and no conf edit. None of the other candidates can find
-	// that -- each resolves through a *resources* directory (a macOS bundle,
-	// a compile-time prefix, wxStandardPaths' platform-adjusted share tree),
-	// and a relocatable bundle has none of them.
+	// Beside the running binary: the Linux static tarball's layout (binaries
+	// plus amuleapi-static/, extracted anywhere, no install step). Every other
+	// candidate resolves through a resources directory, which a relocatable
+	// bundle has none of.
 	//
-	// The executable's own directory, deliberately NOT the working
-	// directory: a daemon is commonly started from ~ or /, and resolving
-	// assets against cwd would make what it serves depend on where it
-	// happened to be launched from -- and would let a directory an
-	// unprivileged user can create decide what a root daemon serves.
+	// The executable's directory, not the working directory: a daemon is
+	// commonly started from ~ or /, and resolving against cwd would let a
+	// directory an unprivileged user can create decide what a root daemon
+	// serves.
 	{
 		const wxString exe = wxStandardPaths::Get().GetExecutablePath();
 		if (!exe.empty()) {
@@ -608,13 +537,13 @@ std::string ResolveDefaultStaticDir()
 	}
 #endif
 
-	// wxStandardPaths fallback. Same platform adjustments amuleweb
-	// applies for its `webserver/` lookup (WebInterface.cpp:211-225).
+	// wxStandardPaths fallback, with the same platform adjustments amuleweb
+	// applies for its `webserver/` lookup.
 	wxString dir = wxStandardPaths::Get().GetResourcesDir();
 #if defined(__WINDOWS__)
 	// Installer layout: bin\amuleapi.exe + share\amule\amuleapi-static\.
-	// wxStandardPaths returns the exe directory on Windows, so go up
-	// one level and into the FHS-style share/amule/ tree.
+	// wxStandardPaths returns the exe directory on Windows, so climb into the
+	// FHS-style share/amule/ tree.
 	dir = wxFileName(dir, "..").GetFullPath();
 	dir = wxFileName(dir, "share").GetFullPath();
 	dir = wxFileName(dir, "amule").GetFullPath();
@@ -640,13 +569,10 @@ CApiDispatcher::CApiDispatcher(CAmuleApiConfig &config, CJwt &jwt, webapi::CStat
 	  config.AuthCfg().login_failure_threshold,
 	  config.AuthCfg().login_lockout_seconds })
 ,
-// Generic-401 limiter: a crash-pad against credential-
-// stuffing across every authenticated endpoint, counting
-// rejected tokens rather than bad passwords. Its three
-// `[Auth]/Token*` keys default to 30 failures within 60 s
-// and a 5-minute lockout, mirroring the login limiter's
-// keys above -- this is the one a browser tab left open
-// overnight trips, so it has to be tunable too.
+// Generic-401 limiter against credential stuffing across every authenticated
+// endpoint, counting rejected TOKENS rather than bad passwords. Tunable via the
+// `[Auth]/Token*` keys because this is the one a browser tab left open
+// overnight trips.
 m_authRateLimiter(webapi::CRateLimiter::Config{ config.AuthCfg().token_failure_window_seconds,
 	config.AuthCfg().token_failure_threshold,
 	config.AuthCfg().token_lockout_seconds })
@@ -656,9 +582,8 @@ m_authRateLimiter(webapi::CRateLimiter::Config{ config.AuthCfg().token_failure_w
 namespace
 {
 
-// Case-tolerant header lookup. Beast preserves the wire-form casing
-// the client sent, so a literal `req.headers.find("If-None-Match")`
-// misses lowercased headers. Walks the map once on miss to recover.
+// Beast preserves the wire-form casing the client sent, so a literal find
+// misses lowercased headers. Walks the map once on a miss.
 std::string FindHeaderCaseInsensitive(
 	const std::map<std::string, std::string> &headers, const std::string &name)
 {
@@ -674,15 +599,13 @@ std::string FindHeaderCaseInsensitive(
 	return std::string();
 }
 
-// resolve the CORS Origin echo for this request. Returns the verbatim
-// Origin to put in `Access-Control-Allow-Origin` plus whether the
-// allowlist named it, or an empty origin when CORS is disabled, the
-// request had no Origin (same-origin browser navigation; non-browser
-// caller), or the allowlist rejected the value.
+// Resolve the CORS Origin echo: the verbatim Origin for
+// `Access-Control-Allow-Origin` plus whether the allowlist named it. Empty when
+// CORS is off, the request carried no Origin, or the allowlist rejected it.
 //
-// Wildcard semantics: `allow_cors=1` with an empty allowlist echoes the
-// request's Origin verbatim, which is `*`-equivalent. Credentials are
-// NOT granted on that path -- see ApplyCorsHeaders.
+// `allow_cors=1` with an empty allowlist echoes verbatim, which is
+// `*`-equivalent. Credentials are NOT granted on that path; see
+// ApplyCorsHeaders.
 struct CorsDecision
 {
 	std::string origin;
@@ -706,11 +629,9 @@ CorsDecision ResolveCorsOrigin(const CHttpServer::Request &req, const CAmuleApiC
 	return CorsDecision{};
 }
 
-// stamp the resolved CORS headers onto a response. `Vary:
-// Origin` is ALWAYS added when CORS is enabled (even on rejected
-// origins) so intermediaries don't cache a cross-origin response
-// against a same-origin cache key. The auth + content headers go
-// on iff the origin was actually allowed.
+// `Vary: Origin` is added whenever CORS is enabled, even for a rejected
+// origin, so an intermediary cannot cache a cross-origin response against a
+// same-origin key. The auth and content headers go on only if it was allowed.
 void ApplyCorsHeaders(
 	std::map<std::string, std::string> &headers, const CorsDecision &cors, bool cors_enabled)
 {
@@ -720,49 +641,40 @@ void ApplyCorsHeaders(
 	if (cors.origin.empty())
 		return;
 	headers["Access-Control-Allow-Origin"] = cors.origin;
-	// Credentials only for an origin the operator named. With an empty
-	// allowlist the echo is `*`-equivalent, and granting credentials there
-	// would let any site the user happens to visit call this API with their
-	// session cookie and read the replies -- the exact thing the same-origin
-	// policy exists to stop. An anonymous cross-origin read still works;
-	// a credentialed one needs an allowlist entry.
+	// Credentials only for an origin the operator named. With an empty allowlist
+	// the echo is `*`-equivalent, and granting credentials there would let any
+	// site the user visits call this API with their session cookie and read the
+	// replies. An anonymous cross-origin read still works.
 	if (cors.allowlisted)
 		headers["Access-Control-Allow-Credentials"] = "true";
-	// Header names the client may read from `fetch().headers.get(...)`
-	// — by default the Fetch spec only exposes the CORS-safelisted
-	// response headers (Cache-Control, Content-Language, Content-Type,
-	// Expires, Last-Modified, Pragma). amuleapi clients want to read
-	// ETag for cache validation; SSE clients don't need this list.
+	// What a client may read from `fetch().headers.get(...)`: the Fetch spec
+	// exposes only the CORS-safelisted response headers by default, and amuleapi
+	// clients need ETag for cache validation.
 	headers["Access-Control-Expose-Headers"] = "ETag, Allow, Retry-After";
 }
 
-// The Kad `network` rollup, byte-identical on GET /status (nested
-// under `kad`) and on GET /kad. Both read the same KadSnapshot from
-// the same Dashboard() acquisition, so there is one set of counters
-// and one place that names them.
+// The Kad `network` rollup, byte-identical under `kad` on GET /status and on
+// GET /kad: both read the same KadSnapshot from one Dashboard() acquisition.
 void WriteKadNetworkObject(CJsonWriter &w, const webapi::KadSnapshot &k)
 {
 	w.Key("network");
 	w.BeginObject();
-	// null unless Kad is connected. `user_count`/`file_count` are the last
-	// estimate and survive into `connecting`; `node_count` is our own
-	// routing-table size and was
+	// null unless Kad is connected. user_count/file_count are the last estimate
+	// and survive into `connecting`; node_count is our own routing-table size,
 	// measured at 2 with Kad fully stopped, so not even the terminal state
-	// reaches 0. A number here would be a claim about a network we are not on.
+	// reaches 0. A number here would claim knowledge of a network we are not on.
 	WriteIntOrNull(w, "user_count", k.has_network, static_cast<int64_t>(k.users));
 	WriteIntOrNull(w, "file_count", k.has_network, static_cast<int64_t>(k.files));
 	WriteIntOrNull(w, "node_count", k.has_network, static_cast<int64_t>(k.nodes));
 	w.EndObject();
 }
 
-// The {id} path segment of every search-scoped route. Accepts a plain
-// non-negative decimal that fits a uint32 and is not 0.
+// The {id} segment of every search-scoped route: a non-zero decimal fitting a
+// uint32.
 //
-// Zero is rejected rather than treated as "no search": it used to be the
-// sentinel that meant "whichever search this session started last", and
-// letting it through would quietly resurrect exactly the implicit-target
-// behaviour these routes exist to remove. A non-numeric segment is rejected
-// for the same reason -- it must never fall back to some other search.
+// Zero is rejected rather than read as "no search": it used to mean "whichever
+// search this session started last", and letting it through would resurrect the
+// implicit-target behaviour these routes exist to remove.
 const char *const kBadSearchIdMessage = "`{id}` must be a positive decimal search_id (see GET /search)";
 
 bool ParseSearchIdSegment(const std::string &seg, std::uint32_t &out)
@@ -781,17 +693,13 @@ bool ParseSearchIdSegment(const std::string &seg, std::uint32_t &out)
 	return true;
 }
 
-// Forward declaration so HandleLogin (which sits above the helper's
-// definition) can share the depth-cap defence. The definition lives
-// near the other mutation-body parsers further down the file.
 bool ParseJsonObjectBody(const std::string &body, picojson::value &out, std::string &err);
 
 } // namespace
 
 // Did the caller present credentials at all? Mirrors what Authenticate()
-// accepts -- an Authorization header, or the session cookie the WebUI uses --
-// without verifying them: an invalid or expired credential still means the
-// response was computed for a specific caller and must not be shared.
+// accepts, without verifying them: an invalid or expired credential still means
+// the response was computed for a specific caller and must not be shared.
 bool RequestCarriesCredentials(const CHttpServer::Request &req, const std::string &cookie_name)
 {
 	if (!FindHeaderCaseInsensitive(req.headers, "Authorization").empty()) {
@@ -809,12 +717,9 @@ CHttpServer::Response CApiDispatcher::Dispatch(const CHttpServer::Request &req)
 	const bool cors_enabled = m_config.ServerCfg().allow_cors;
 	const CorsDecision cors_org = ResolveCorsOrigin(req, m_config);
 
-	// CORS preflight short-circuit. OPTIONS requests with
-	// `Access-Control-Request-Method` are browser preflights — they
-	// don't carry credentials and shouldn't run the auth gate or the
-	// route handler. Reply with 204 and the CORS bundle (or 204 +
-	// `Vary: Origin` only when the origin is rejected — the browser
-	// blocks the subsequent real request).
+	// Browser preflights carry no credentials, so they skip the auth gate and the
+	// route handler: 204 plus the CORS bundle, or 204 with `Vary: Origin` alone
+	// when the origin is rejected, which makes the browser block the real request.
 	if (req.method == "OPTIONS" &&
 		!FindHeaderCaseInsensitive(req.headers, "Access-Control-Request-Method").empty()) {
 		CHttpServer::Response pre;
@@ -824,9 +729,8 @@ CHttpServer::Response CApiDispatcher::Dispatch(const CHttpServer::Request &req)
 		if (!cors_org.origin.empty()) {
 			pre.headers["Access-Control-Allow-Methods"] =
 				"GET, HEAD, POST, PUT, PATCH, DELETE, OPTIONS";
-			// Headers actual requests may send. Authorization for
-			// bearer; If-None-Match for ETag conditional GET;
-			// Last-Event-ID for SSE replay.
+			// Headers actual requests may send: Authorization for bearer,
+			// If-None-Match for conditional GET, Last-Event-ID for SSE replay.
 			pre.headers["Access-Control-Allow-Headers"] =
 				"Authorization, Content-Type, If-None-Match, Last-Event-ID";
 			pre.headers["Access-Control-Max-Age"] = "86400";
@@ -834,48 +738,34 @@ CHttpServer::Response CApiDispatcher::Dispatch(const CHttpServer::Request &req)
 		return pre;
 	}
 
-	// post-process every response with an ETag stamp +
-	// `If-None-Match` → 304 swap, but only on GET/HEAD that come back
-	// 200. Mutations (POST/PATCH/DELETE) and error paths are passed
-	// through unchanged — there's no benefit to ETag-caching a 4xx
-	// body, and a mutation's response carries the post-mutation
-	// state which the client always wants delivered.
-	// Sampled BEFORE the handler runs, and again after. The memo pairs an
-	// ETag with a revision, and the body is serialized inside the handler
-	// under its own read lock which it has dropped by the time we get here
-	// -- so reading the revision only afterwards can pair etag(old body)
-	// with the NEW revision if a write lands in that window, and every
-	// later hit then serves a validator that describes neither. Two
-	// samples make the window observable: if anything moved, this response
-	// is not attributable to a revision and is simply not memoized.
+	// ETag + If-None-Match -> 304, on GET/HEAD 200 only: a mutation's response
+	// carries post-mutation state the client always wants delivered.
+	//
+	// The revision is sampled before AND after the handler. The body was
+	// serialized under a read lock already dropped, so reading the revision
+	// only afterwards can pair etag(old body) with the NEW revision, and every
+	// later hit then serves a validator describing neither. If anything moved,
+	// the response is simply not memoized.
 	const std::uint64_t rev_before = m_state.SnapshotRevision();
 	CHttpServer::Response resp = DispatchToHandler(req);
 	const std::uint64_t rev_after = m_state.SnapshotRevision();
 
 	const bool is_safe_method = (req.method == "GET" || req.method == "HEAD");
-	// A handler that computed its own validator owns it. Stamping the
-	// body hash over the top would hand out two different ETags for one
-	// resource depending on which branch answered -- which is what the
-	// static path did, since it clears the body for HEAD and so only the
-	// GET reached the hashing branch below.
+	// A handler that computed its own validator owns it. Stamping the body hash
+	// over the top would yield two ETags for one resource depending on which
+	// branch answered -- as the static path did, since it clears the body for HEAD
+	// so only the GET reached the hashing branch.
 	const bool handler_set_etag = (resp.headers.find("ETag") != resp.headers.end());
 	if (webapi::ShouldStampEtag(is_safe_method, handler_set_etag, resp.status, resp.body.empty())) {
-		// Skip the MD5 over a (potentially multi-MB) body when
-		// nothing has changed since we last hashed it. The key is
-		// (target, snapshot revision): the revision is advanced by
-		// every writer of an eligible body, so unlike a timestamp it
-		// cannot stand still through a mutation, cannot collapse two
-		// changes inside one second, and does not depend on any
-		// caller remembering to stamp it.
+		// Skip the MD5 over a multi-MB body when nothing has changed. The key
+		// is (target, snapshot revision): a revision advances on every eligible
+		// write, so unlike a timestamp it cannot stand still through a mutation
+		// or collapse two changes inside one second.
 		//
-		// Eligibility is opt-in -- see MemoizableTarget -- and covers
-		// only /downloads and /shared, which is where skipping a hash
-		// is worth anything. Everything else hashes per request and is
-		// immune to a mispaired validator by construction.
-		//
-		// Revision stability is the other half, and MemoUsable carries
-		// it: without it the key says which revision was current when
-		// we looked, not which one this body came from.
+		// Opt-in per target (MemoizableTarget), covering only /downloads and
+		// /shared. MemoUsable is the other half: without it the key says which
+		// revision was current when we looked, not which one this body came
+		// from.
 		const std::uint64_t snap = rev_after;
 		const bool memoizable = webapi::MemoUsable(req.target, rev_before, rev_after);
 		std::string etag;
@@ -891,9 +781,8 @@ CHttpServer::Response CApiDispatcher::Dispatch(const CHttpServer::Request &req)
 			if (memoizable) {
 				std::lock_guard<std::mutex> g(m_etagCacheMu);
 				if (m_etagCache.size() >= kEtagCacheCapacity) {
-					// Crude memory backstop. Real workload is a few
-					// dozen unique targets; the wholesale clear is
-					// cheaper than a real LRU machinery.
+					// Crude memory backstop: the real workload is a few dozen
+					// targets, so a wholesale clear beats real LRU machinery.
 					m_etagCache.clear();
 				}
 				EtagCacheEntry e;
@@ -902,14 +791,13 @@ CHttpServer::Response CApiDispatcher::Dispatch(const CHttpServer::Request &req)
 				m_etagCache[req.target] = std::move(e);
 			}
 		}
-		// RFC 7232 §2.3 — the header value MUST be quoted.
-		// Which representation is this validator naming? The transport
-		// appends the coding when it compresses, but a 304 carries no
-		// body for it to compress, so the answer has to be worked out
-		// here -- while the body is still present to measure -- and it
-		// has to be the SAME answer. A client that cached the gzip form
-		// and gets the identity ETag back can never match its stored
-		// response again.
+		// RFC 7232 2.3: the value MUST be quoted.
+		//
+		// Which representation does this validator name? The transport appends the
+		// coding when it compresses, but a 304 carries no body to compress, so the
+		// answer is worked out here while the body is still present -- and must be
+		// the SAME answer, or a client that cached the gzip form and gets the
+		// identity ETag can never match its stored response again.
 		const bool coded = WillCompressBody(
 			AcceptsGzip(FindHeaderCaseInsensitive(req.headers, "Accept-Encoding")),
 			resp.body.size(),
@@ -918,12 +806,9 @@ CHttpServer::Response CApiDispatcher::Dispatch(const CHttpServer::Request &req)
 		const std::string wire_etag = webcommon::WithCodingSuffix(etag, coded);
 		resp.headers["ETag"] = "\"" + wire_etag + "\"";
 
-		// Against wire_etag, which names the representation THIS request
-		// selected. Matching either coding would defeat the suffix
-		// entirely: a client holding the gzip bytes and asking for
-		// identity would be told its copy is current, and one holding
-		// identity bytes would be handed a 304 stamped with the gzip
-		// validator, matching nothing it stored.
+		// Against wire_etag, which names the representation THIS request selected.
+		// Matching either coding would defeat the suffix: a client holding gzip
+		// bytes and asking for identity would be told its copy is current.
 		const std::string inm = FindHeaderCaseInsensitive(req.headers, "If-None-Match");
 		if (webcommon::IfNoneMatchHits(inm, wire_etag)) {
 			// 304 carries no body and no Content-Type, but the ETag
@@ -934,41 +819,28 @@ CHttpServer::Response CApiDispatcher::Dispatch(const CHttpServer::Request &req)
 			resp.content_type.clear();
 		}
 	}
-	// HEAD carries no content, on ANY status. The strip used to live
-	// inside the 200-only block above, so every HEAD that ended in 4xx or
-	// 5xx shipped the JSON error envelope as content -- content RFC 9110
-	// §9.3.2 says must not be there, and bytes a client that correctly
-	// stops reading after the headers leaves in the socket to corrupt the
-	// next response on a keep-alive connection. It is not stripped here
-	// either: the transport writes headers only, so Content-Length still
-	// reports what the equivalent GET would return.
+	// HEAD carries no content on ANY status. The strip used to sit inside the
+	// 200-only block, so a HEAD ending in 4xx shipped the JSON error envelope --
+	// content RFC 9110 9.3.2 forbids, and bytes a correct client leaves in the
+	// socket to corrupt the next response on a keep-alive connection.
+	// Content-Length is left reporting what the equivalent GET would return.
 
-	// A response produced for a caller who presented credentials is that
-	// caller's, and must not be stored where another caller can be served
-	// it. Authenticate() takes a bearer token OR a session cookie, and the
-	// browser WebUI uses the cookie -- so these requests carry no
-	// Authorization header, and RFC 9111 3.5's shared-cache prohibition
-	// never engages on them. Without an explicit expiry a shared cache may
-	// keep a 200 under heuristic freshness, and with Cookie absent from
-	// Vary two users share a cache key.
+	// A response produced for a credentialed caller must not be stored where
+	// another caller can be served it. Authenticate() takes a bearer token or a
+	// session cookie, and the WebUI uses the cookie -- so these carry no
+	// Authorization header and RFC 9111 3.5's shared-cache prohibition never
+	// engages. Without an explicit policy a shared cache may keep the 200 under
+	// heuristic freshness, on a key that does not include Cookie.
 	//
-	// Stamped here rather than in each handler so a new authenticated
-	// route cannot forget it, and only when the caller actually presented
-	// credentials: an unauthenticated public probe like /health stays
-	// cacheable and keeps its conditional GET. A handler that set its own
-	// policy -- the static assets' public, no-cache, the country flags'
-	// public, max-age, /auth/session's private, no-store, the SSE
-	// no-cache -- is left alone.
+	// Stamped centrally so a new authenticated route cannot forget it, and only
+	// when credentials were actually presented: an unauthenticated probe like
+	// /health stays cacheable. Handlers that set their own policy are untouched.
 	//
-	// `private` and NOT `no-store`: no-store forbids the client's OWN
-	// cache, so no browser would ever hold an entry to revalidate and no
-	// authenticated route would ever see an If-None-Match -- which throws
-	// away the whole point of the validator and memo machinery here, and
-	// makes the WebUI re-transfer the full download list on every load. It
-	// also lands on 304s, telling a cache to drop the entry it has just
-	// been told is good. `private` alone is what answers the concern:
-	// RFC 9111 3.5 stops a SHARED cache storing it, which is the cache
-	// that could serve one user's list to another.
+	// private, NOT no-store: no-store forbids the client's own cache too, so no
+	// If-None-Match would ever arrive and the validator and memo machinery here
+	// would be dead weight; it also lands on 304s, telling a cache to drop the
+	// entry it was just told is good. private alone stops a SHARED cache
+	// storing it, which is the one that could serve one user's list to another.
 	if (RequestCarriesCredentials(req, kSessionCookieName) &&
 		resp.headers.find("Cache-Control") == resp.headers.end()) {
 		resp.headers["Cache-Control"] = "private";
@@ -976,8 +848,7 @@ CHttpServer::Response CApiDispatcher::Dispatch(const CHttpServer::Request &req)
 		AppendHeaderToken(resp.headers, "Vary", "Cookie");
 	}
 
-	// stamp CORS on every response (success and error paths)
-	// so browsers can read the body in the 4xx/5xx case too.
+	// On every response, success or error, so a browser can read a 4xx body too.
 	ApplyCorsHeaders(resp.headers, cors_org, cors_enabled);
 	return resp;
 }
@@ -987,19 +858,15 @@ CHttpServer::Response CApiDispatcher::DispatchToHandler(const CHttpServer::Reque
 	std::string path, query;
 	SplitPathAndQuery(req.target, path, query);
 
-	// Defence-in-depth: reject NUL / encoded NUL / encoded `..` /
-	// literal `..` segments before routing. Today's byte-exact
-	// routes 404 these requests organically, but adding a future
-	// endpoint that admits path captures (file-by-name, log-by-
-	// label, …) would silently inherit a traversal surface without
-	// this gate.
+	// Defence in depth: reject NUL, encoded NUL and `..` segments before routing.
+	// Today's byte-exact routes 404 these organically, but a future endpoint with
+	// a path capture would silently inherit a traversal surface without this.
 	if (web_api_path::LooksMalicious(path)) {
 		return ErrorResponse(400, "bad_request", "path contains a traversal/injection token");
 	}
 
-	// `/api/v0/status/` and `/api/v0/status` name the same resource, so
-	// route them the same way. Confined to the API prefix on purpose: the
-	// static fallthrough below maps a path onto a filesystem, where a
+	// `/api/v0/status/` and `/api/v0/status` name one resource. Confined to the
+	// API prefix: the static fallthrough maps a path onto a filesystem, where a
 	// trailing slash is a directory rather than a spelling.
 	if (path.compare(0, 5, "/api/") == 0) {
 		path = web_api_path::StripTrailingSlash(path);
@@ -1057,12 +924,9 @@ CHttpServer::Response CApiDispatcher::DispatchToHandler(const CHttpServer::Reque
 		return MethodNotAllowed("GET, HEAD, PATCH", "only GET or PATCH on /auth/passwords");
 	}
 
-	// /events reaches the dispatcher only on a method the streaming
-	// resolver declined, since it diverts GET and HEAD before this point.
-	// Without an arm here the request fell through to the catch-all 404,
-	// so the one endpoint a client is most likely to probe reported that
-	// it does not exist -- and it was the only route to escape the Allow
-	// sweep, while the docs promise the header on every 405.
+	// /events reaches the dispatcher only on a method the streaming resolver
+	// declined, since it diverts GET and HEAD earlier. Without an arm here it fell
+	// to the catch-all 404 and was the one route to escape the Allow sweep.
 	if (path == "/api/v0/events") {
 		return MethodNotAllowed("GET, HEAD", "only GET / HEAD on /events");
 	}
@@ -1079,22 +943,18 @@ CHttpServer::Response CApiDispatcher::DispatchToHandler(const CHttpServer::Reque
 			return HandleDownloads(req);
 		}
 		if (req.method == "POST") {
-			// add a download by ed2k link.
 			return HandleDownloadAdd(req);
 		}
 		if (req.method == "PATCH") {
-			// bulk pause/resume/priority/category over {hashes:[...]}.
 			return HandleDownloadsBulkPatch(req);
 		}
 		if (req.method == "DELETE") {
-			// bulk cancel+remove over {hashes:[...]}.
 			return HandleDownloadsBulkDelete(req);
 		}
 		return MethodNotAllowed("GET, HEAD, POST, PATCH, DELETE",
 			"only GET / HEAD / POST / PATCH / DELETE on /downloads");
 	}
 
-	// bulk clear-completed.
 	if (path == "/api/v0/downloads_clear_completed") {
 		if (req.method != "POST") {
 			return MethodNotAllowed("POST", "only POST on /downloads_clear_completed");
@@ -1102,9 +962,8 @@ CHttpServer::Response CApiDispatcher::DispatchToHandler(const CHttpServer::Reque
 		return HandleDownloadsClearCompleted(req);
 	}
 
-	// /clients is the whole peer surface: every upload_state, including
-	// queue waiters and download peers. Consumers filter client-side by
-	// upload_state rather than asking for a pre-filtered view.
+	// The whole peer surface, every upload_state including queue waiters.
+	// Consumers filter client-side rather than asking for a pre-filtered view.
 	if (path == "/api/v0/clients") {
 		if (req.method != "GET" && req.method != "HEAD") {
 			return MethodNotAllowed("GET, HEAD", "only GET on /clients");
@@ -1112,12 +971,10 @@ CHttpServer::Response CApiDispatcher::DispatchToHandler(const CHttpServer::Reque
 		return HandleClients(req);
 	}
 
-	// /known_clients — the daemon's credit store, every peer it has ever
-	// exchanged data with. A separate resource rather than a sub-path of
-	// /clients: these are keyed by user hash, outlive the daemon process that
-	// would have issued an ECID, and carry stored history instead of live
-	// transfer state. Matched before /clients/{ecid} regardless, since that
-	// pattern accepts any single segment.
+	// The daemon's credit store: every peer it has ever exchanged data with. Its
+	// own resource rather than a sub-path of /clients because these are keyed by
+	// user hash, outlive the ECID-issuing process, and carry stored history.
+	// Matched before /clients/{ecid}, which accepts any single segment.
 	if (path == "/api/v0/known_clients") {
 		if (req.method != "GET" && req.method != "HEAD") {
 			return MethodNotAllowed("GET, HEAD", "only GET on /known_clients");
@@ -1125,8 +982,7 @@ CHttpServer::Response CApiDispatcher::DispatchToHandler(const CHttpServer::Reque
 		return HandleKnownClients(req);
 	}
 
-	// /clients/{ecid} — single-peer detail (issue #422). GET/HEAD only;
-	// {ecid} is the EC connection id (unique per live connection).
+	// Single-peer detail. {ecid} is unique per live EC connection.
 	{
 		static const auto client_detail = web_api_path::ParsePattern("/api/v0/clients/{ecid}");
 		const auto path_segs = web_api_path::SplitPath(path);
@@ -1139,8 +995,7 @@ CHttpServer::Response CApiDispatcher::DispatchToHandler(const CHttpServer::Reque
 		}
 	}
 
-	// /clients/{ecid}/shared_files — browse ("View Files") the peer's shared
-	// file list (#399). POST starts the browse and returns a search_id.
+	// Browse the peer's shared files; POST starts it and returns a search_id.
 	{
 		static const auto client_browse =
 			web_api_path::ParsePattern("/api/v0/clients/{ecid}/shared_files");
@@ -1159,7 +1014,6 @@ CHttpServer::Response CApiDispatcher::DispatchToHandler(const CHttpServer::Reque
 			return HandleSharedList(req);
 		}
 		if (req.method == "PATCH") {
-			// bulk upload-priority PATCH over {hashes:[...], priority}.
 			return HandleSharedBulkPatch(req);
 		}
 		return MethodNotAllowed("GET, HEAD, PATCH", "only GET / HEAD / PATCH on /shared");
@@ -1172,9 +1026,8 @@ CHttpServer::Response CApiDispatcher::DispatchToHandler(const CHttpServer::Reque
 		return HandleSharedReload(req);
 	}
 
-	// /shared/media/refresh — re-extract media metadata for the whole share.
-	// Literal path, so it has to be matched before the /shared/{hash} patterns
-	// below or "media" would be captured as a hash.
+	// Literal path, so it must be matched before the /shared/{hash} patterns or
+	// "media" would be captured as a hash.
 	if (path == "/api/v0/shared/media/refresh") {
 		if (req.method != "POST") {
 			return MethodNotAllowed("POST", "only POST on /shared/media/refresh");
@@ -1182,10 +1035,9 @@ CHttpServer::Response CApiDispatcher::DispatchToHandler(const CHttpServer::Reque
 		return HandleSharedMediaRefresh(req);
 	}
 
-	// /share_directories — the configured share roots, as opposed to /shared
-	// which lists the files those roots produced. It used to be /shared/
-	// directories, one segment away from being read as a file hash; its own
-	// top-level path is why no ordering against /shared/{hash} is needed here.
+	// The configured share roots, as opposed to /shared, which lists the files
+	// those roots produced. Its own top-level path, so no ordering against
+	// /shared/{hash} is needed.
 	if (path == "/api/v0/share_directories") {
 		if (req.method == "GET" || req.method == "HEAD") {
 			return HandleSharedDirectories(req);
@@ -1208,7 +1060,6 @@ CHttpServer::Response CApiDispatcher::DispatchToHandler(const CHttpServer::Reque
 			return HandleServers(req);
 		}
 		if (req.method == "POST") {
-			// add a server by host:port.
 			return HandleServerAdd(req);
 		}
 		return MethodNotAllowed("GET, HEAD, POST", "only GET / HEAD / POST on /servers");
@@ -1224,9 +1075,8 @@ CHttpServer::Response CApiDispatcher::DispatchToHandler(const CHttpServer::Reque
 		return MethodNotAllowed("GET, HEAD, POST", "only GET / HEAD / POST on /friends");
 	}
 
-	// One friend by ECID: remove, set the friend slot, or browse their shared
-	// files. The browse form is checked first, same ordering rationale as the
-	// server routes above.
+	// One friend by ECID. The browse form is checked first, same ordering
+	// rationale as the server routes.
 	{
 		static const auto friend_browse =
 			web_api_path::ParsePattern("/api/v0/friends/{ecid}/shared_files");
@@ -1257,9 +1107,8 @@ CHttpServer::Response CApiDispatcher::DispatchToHandler(const CHttpServer::Reque
 		return MethodNotAllowed("GET, HEAD", "only GET / HEAD on /chats");
 	}
 
-	// One conversation, keyed on "<ip>:<port>". The messages sub-resource is
-	// matched first, same ordering rationale as the server / friend routes:
-	// the longer pattern would otherwise be shadowed.
+	// One conversation keyed "<ip>:<port>". The messages sub-resource matches
+	// first or the longer pattern would be shadowed.
 	{
 		static const auto chat_messages =
 			web_api_path::ParsePattern("/api/v0/chats/{address}/messages");
@@ -1284,9 +1133,8 @@ CHttpServer::Response CApiDispatcher::DispatchToHandler(const CHttpServer::Reque
 		}
 	}
 
-	// Address a conversation by ECID instead of ip:port, for a caller holding
-	// a peer or friend row and no wish to compose the key. The friend form is
-	// the one that reaches an OFFLINE friend.
+	// Address a conversation by ECID, for a caller holding a peer or friend row.
+	// The friend form is the one that reaches an OFFLINE friend.
 	{
 		static const auto friend_messages =
 			web_api_path::ParsePattern("/api/v0/friends/{ecid}/messages");
@@ -1315,12 +1163,10 @@ CHttpServer::Response CApiDispatcher::DispatchToHandler(const CHttpServer::Reque
 		return HandleServerUpdateFromUrl(req);
 	}
 
-	// server connect & remove, by ECID or by address. The two forms share their
-	// handlers and differ only in how they look the server up, so they live in
-	// one block. The address patterns are tried FIRST because they have the same
-	// segment count as their ECID counterparts: a request for the address form
-	// with "connect" as the address would otherwise match the ECID+connect
-	// pattern with `ecid == "by-address"`, and the literal segment has to win.
+	// Server connect and remove, by ECID or by address; the forms share handlers
+	// and differ only in the lookup. Address patterns are tried FIRST because they
+	// have the same segment count: the address form with "connect" as the address
+	// would otherwise match the ECID pattern with `ecid == "by-address"`.
 	{
 		static const auto server_connect =
 			web_api_path::ParsePattern("/api/v0/servers/{ecid}/connect");
@@ -1331,11 +1177,9 @@ CHttpServer::Response CApiDispatcher::DispatchToHandler(const CHttpServer::Reque
 			web_api_path::ParsePattern("/api/v0/servers/by-address/{address}");
 		const auto path_segs = web_api_path::SplitPath(path);
 		std::map<std::string, std::string> caps;
-		// The address form has its own path rather than sharing {ecid}.
-		// One capture with two identity domains, disambiguated by sniffing
-		// for a colon, is a dispatch rule invisible from outside -- and it
-		// forecloses ever accepting an IPv6 literal here, since those are
-		// all colons.
+		// The address form has its own path rather than sharing {ecid}: one capture
+		// with two identity domains, sniffed apart by a colon, is a dispatch rule
+		// invisible from outside and forecloses ever accepting an IPv6 literal.
 		if (web_api_path::Match(server_addr_connect, path_segs, caps)) {
 			if (req.method != "POST") {
 				return MethodNotAllowed(
@@ -1374,7 +1218,6 @@ CHttpServer::Response CApiDispatcher::DispatchToHandler(const CHttpServer::Reque
 		return HandleKad(req);
 	}
 
-	// connection control.
 	if (path == "/api/v0/networks/connect") {
 		if (req.method != "POST") {
 			return MethodNotAllowed("POST", "only POST on /networks/connect");
@@ -1387,10 +1230,6 @@ CHttpServer::Response CApiDispatcher::DispatchToHandler(const CHttpServer::Reque
 		}
 		return HandleNetworksDisconnect(req);
 	}
-	// /api/v0/kad/connect and /api/v0/kad/disconnect were dropped in
-	// favour of /networks/{connect,disconnect} with `{"network":"kad"}`
-	// — the two were strict aliases and the granular-selector form on
-	// /networks/* makes the dedicated shortcut redundant.
 	if (path == "/api/v0/kad/update") {
 		if (req.method != "POST") {
 			return MethodNotAllowed("POST", "only POST on /kad/update");
@@ -1587,13 +1426,11 @@ CHttpServer::Response CApiDispatcher::DispatchToHandler(const CHttpServer::Reque
 		return HandleSearchStart(req);
 	}
 
-	// The two hash-addressed routes are matched before anything capturing
-	// {id}. They cannot actually collide (different segment counts, and {id}
-	// is numeric), but ordering them first keeps that independent of the
-	// matcher's internals. Both are deliberately search-AGNOSTIC: the daemon
-	// resolves a download by hash against its whole search list, and a Kad
-	// note fetched for a hash is fanned out to every result carrying it.
-	// Nesting them under {id} would advertise a scoping that does not exist.
+	// Matched before anything capturing {id}. They cannot collide (different
+	// segment counts, {id} numeric), but ordering keeps that independent of the
+	// matcher's internals. Both are search-AGNOSTIC: the daemon resolves a hash
+	// against its whole search list, so nesting them under {id} would advertise a
+	// scoping that does not exist.
 	{
 		static const auto search_download =
 			web_api_path::ParsePattern("/api/v0/search/results/{hash}/download");
@@ -1608,12 +1445,9 @@ CHttpServer::Response CApiDispatcher::DispatchToHandler(const CHttpServer::Reque
 		}
 	}
 
-	// /search/results/{hash}/comments — community ratings/comments for a search
-	// result (issue #434). POST triggers an on-demand Kad NOTES lookup; GET
-	// returns the notes retrieved so far plus the running flag. The result's
-	// `comments` also ride the results list, but this per-result path mirrors
-	// /downloads/{hash}/comments for polling a single hash. Matched before
-	// /search/results/{hash}/download (distinct trailing segment).
+	// Community ratings for a search result. POST triggers an on-demand Kad NOTES
+	// lookup; GET returns what has arrived plus the running flag. Matched before
+	// the /download sibling (distinct trailing segment).
 	{
 		static const auto search_comments =
 			web_api_path::ParsePattern("/api/v0/search/results/{hash}/comments");
@@ -1685,9 +1519,8 @@ CHttpServer::Response CApiDispatcher::DispatchToHandler(const CHttpServer::Reque
 		}
 	}
 
-	// /stats/graphs/{graph} — path-pattern matches the four allowed
-	// graph names ("download_speed" / "upload_speed" / "connections" /
-	// "kad_nodes" -- HandleStatsGraph rejects anything else).
+	// Path-pattern matches the four allowed graph names; HandleStatsGraph
+	// rejects anything else.
 	{
 		static const auto graph_pattern = web_api_path::ParsePattern("/api/v0/stats/graphs/{graph}");
 		const auto segs = web_api_path::SplitPath(path);
@@ -1700,8 +1533,7 @@ CHttpServer::Response CApiDispatcher::DispatchToHandler(const CHttpServer::Reque
 		}
 	}
 
-	// /downloads/{hash}/comments — per-source comments/ratings list
-	// (issue #419). Downloads-only: needs a live source list. Matched
+	// Per-source comments. Downloads-only: needs a live source list. Matched
 	// before /downloads/{hash} (more segments).
 	{
 		static const auto dl_comments =
@@ -1710,8 +1542,7 @@ CHttpServer::Response CApiDispatcher::DispatchToHandler(const CHttpServer::Reque
 		std::map<std::string, std::string> caps;
 		if (web_api_path::Match(dl_comments, path_segs, caps)) {
 			if (req.method == "POST") {
-				// POST triggers an on-demand Kad NOTES lookup; retrieved
-				// community ratings/comments then appear on GET (issue #434).
+				// POST triggers an on-demand Kad NOTES lookup.
 				return HandleDownloadCommentsKadSearch(req, caps["hash"]);
 			}
 			if (req.method != "GET" && req.method != "HEAD") {
@@ -1722,8 +1553,7 @@ CHttpServer::Response CApiDispatcher::DispatchToHandler(const CHttpServer::Reque
 		}
 	}
 
-	// /downloads/{hash}/filenames — source-reported filenames + counts
-	// (issue #420). Downloads-only.
+	// Source-reported filenames and counts. Downloads-only.
 	{
 		static const auto dl_filenames =
 			web_api_path::ParsePattern("/api/v0/downloads/{hash}/filenames");
@@ -1738,8 +1568,7 @@ CHttpServer::Response CApiDispatcher::DispatchToHandler(const CHttpServer::Reque
 		}
 	}
 
-	// /downloads/{hash}/a4af — A4AF swap actions (POST). Downloads-only
-	// (issue #421).
+	// A4AF swap actions. Downloads-only.
 	{
 		static const auto dl_a4af = web_api_path::ParsePattern("/api/v0/downloads/{hash}/a4af");
 		const auto path_segs = web_api_path::SplitPath(path);
@@ -1748,12 +1577,9 @@ CHttpServer::Response CApiDispatcher::DispatchToHandler(const CHttpServer::Reque
 			if (req.method == "POST") {
 				return HandleDownloadA4afAction(req, caps["hash"]);
 			}
-			// POST only. A4AF sources are rows of /downloads/{hash}/clients,
-			// carrying the whole peer object rather than a bare ECID, and
-			// `a4af_auto` is on the download detail object, so there is
-			// nothing for a GET here to add. The swap actions have no
-			// equivalent on those routes, and this reply is still the A4AF
-			// view.
+			// POST only: A4AF sources are rows of /downloads/{hash}/clients carrying
+			// the whole peer object, and `a4af_auto` is on the download detail, so a
+			// GET here would add nothing.
 			return MethodNotAllowed("POST", "only POST on /downloads/{hash}/a4af");
 		}
 	}
@@ -1773,10 +1599,8 @@ CHttpServer::Response CApiDispatcher::DispatchToHandler(const CHttpServer::Reque
 		}
 	}
 
-	// /downloads/{hash} — single-resource detail (GET / HEAD) and the
-	// mutation surface (PATCH for status/priority/category, DELETE for
-	// clear-completed single). `{hash}` is the lowercase 32-char hex
-	// MD4 hash (dispatcher lower-cases input on the way in).
+	// Single-resource detail plus the mutation surface. `{hash}` is the
+	// lowercase 32-char hex MD4; the dispatcher lower-cases input on the way in.
 	{
 		static const auto download_detail = web_api_path::ParsePattern("/api/v0/downloads/{hash}");
 		const auto path_segs = web_api_path::SplitPath(path);
@@ -1796,11 +1620,9 @@ CHttpServer::Response CApiDispatcher::DispatchToHandler(const CHttpServer::Reque
 		}
 	}
 
-	// Country-flag artwork. Sits ahead of the static fallthrough so the
-	// route answers identically whether or not StaticRoot is set — the
-	// bytes are compiled in, not read from disk. Deliberately outside
-	// /api/v0/: it is an image an <img src> points at, not a JSON
-	// resource, and it carries no per-installation data.
+	// Ahead of the static fallthrough so the route answers identically whether or
+	// not StaticRoot is set: the bytes are compiled in. Outside /api/v0 because it
+	// is an image an <img src> points at, carrying no per-installation data.
 	if (path.compare(0, 7, "/flags/") == 0) {
 		if (req.method != "GET" && req.method != "HEAD") {
 			return MethodNotAllowed("GET, HEAD", "only GET / HEAD on /flags/{code}.png");
@@ -1808,13 +1630,10 @@ CHttpServer::Response CApiDispatcher::DispatchToHandler(const CHttpServer::Reque
 		return ServeCountryFlag(req, path);
 	}
 
-	// Static-frontend fallthrough. Anything that didn't match an
-	// /api/v0/* route and is a safe-method request for a non-API path
-	// is a candidate. ServeStaticFile is a no-op (404) when StaticRoot
-	// is unset, so API-only deployments keep their historical
-	// behaviour. Auth is intentionally NOT required here — the shell
-	// itself is public; the API calls it makes still go through the
-	// per-handler role gates.
+	// Anything that matched no /api/v0 route and is a safe method for a non-API
+	// path. ServeStaticFile 404s when StaticRoot is unset, so API-only deployments
+	// are unaffected. Auth is deliberately NOT required: the shell is public, and
+	// the API calls it makes still pass the per-handler role gates.
 	if ((req.method == "GET" || req.method == "HEAD") && path.compare(0, 5, "/api/") != 0) {
 		return ServeStaticFile(req, path);
 	}
@@ -1825,12 +1644,9 @@ CHttpServer::Response CApiDispatcher::DispatchToHandler(const CHttpServer::Reque
 CHttpServer::Response CApiDispatcher::ServeStaticFile(
 	const CHttpServer::Request &req, const std::string &url_path)
 {
-	// Resolve once per process. Conf override wins; otherwise we walk
-	// the install-path discovery chain. std::call_once because handlers
-	// now run concurrently on the HTTP worker pool — a plain lazy bool
-	// would race the string assignment on the first concurrent requests.
-	// The answer is stable for the daemon's lifetime (operators editing
-	// amuleapi.conf at runtime restart the daemon).
+	// Resolved once per process, conf override first. std::call_once because
+	// handlers run concurrently on the worker pool and a plain lazy bool would
+	// race the string assignment on the first concurrent requests.
 	std::call_once(m_static_root_once, [this]() {
 		m_static_root_cache = m_config.ServerCfg().static_root;
 		if (m_static_root_cache.empty()) {
@@ -1843,9 +1659,8 @@ CHttpServer::Response CApiDispatcher::ServeStaticFile(
 		return ErrorResponse(404, "not_found", "no such endpoint");
 	}
 
-	// Map "/" → SPA entry. Strip leading slash so the join is relative;
-	// `LooksMalicious` (run at the top of DispatchToHandler) already
-	// rejected NUL / encoded NUL / encoded `..` / literal `..` segments.
+	// Map "/" to the SPA entry; strip the leading slash so the join is relative.
+	// LooksMalicious has already rejected NUL and `..` segments.
 	std::string rel =
 		(url_path == "/" || url_path.empty()) ? std::string("index.html") : url_path.substr(1);
 
@@ -1856,11 +1671,9 @@ CHttpServer::Response CApiDispatcher::ServeStaticFile(
 	std::string body;
 	bool found = webapi::ResolveWithinRoot(root, rel, fs_path) && ReadStaticFile(fs_path, body, st);
 
-	// SPA fallback: an extension-less path that didn't resolve is
-	// treated as a client-side route and served the entry document so
-	// a deep-linked reload still boots the app. Paths that look like
-	// an asset (carry an extension) 404 honestly so a missing JS/CSS
-	// failure is visible rather than masked by an HTML response.
+	// An extension-less path that did not resolve is a client-side route, so the
+	// entry document is served and a deep-linked reload still boots. Paths that
+	// look like an asset 404 honestly, so a missing JS/CSS is visible.
 	if (!found && rel.find('.') == std::string::npos) {
 		if (webapi::ResolveWithinRoot(root, "index.html", fs_path) &&
 			ReadStaticFile(fs_path, body, st)) {
@@ -1875,32 +1688,22 @@ CHttpServer::Response CApiDispatcher::ServeStaticFile(
 
 	const std::string etag = BuildStaticEtag(st);
 
-	// Conditional GET: client sent If-None-Match → 304 with no body
-	// when the ETag matches. ETag is mtime+size, so a rebuild of the
-	// frontend invalidates without manual cache-busting.
-	// Case-insensitive: Beast preserves the client's wire casing, so a
-	// lowercase `if-none-match` -- what an HTTP/2-shaped client library
-	// produces -- used to miss here and silently lose conditional GET.
-	// Through the shared matcher, not a string compare: the header may be
-	// `*`, a comma-separated list, or a weak `W/"..."` validator (which is
-	// what an nginx in front of us emits once it gzips). The outer layer
-	// used to supply that grammar for the GET path; now that it steps aside
-	// whenever a handler set its own ETag, this path has to speak it.
+	// ETag is mtime+size, so a frontend rebuild invalidates without cache-busting.
+	// Case-insensitive because Beast preserves the client's wire casing, and via
+	// the shared matcher rather than a string compare: the header may be `*`, a
+	// comma-separated list, or a weak `W/"..."` validator, which is what an nginx
+	// in front emits once it gzips.
 	const std::string inm_val = FindHeaderCaseInsensitive(req.headers, "If-None-Match");
-	// A 304 has no body for the transport to compress, so which
-	// representation this validator names is decided here, while the body
-	// is still present to measure -- and the comparison uses that same
-	// value, so a client is only told "unchanged" about the representation
-	// it actually asked for.
+	// A 304 has no body to compress, so which representation this validator names
+	// is decided here while the body is still present, and the comparison uses the
+	// same value.
 	const bool coded =
 		WillCompressBody(AcceptsGzip(FindHeaderCaseInsensitive(req.headers, "Accept-Encoding")),
 			body.size(),
 			StaticContentType(rel),
 			/*already_encoded=*/false);
-	// Through the shared helper, which takes the quoted form this path
-	// carries as readily as the bare form the API path does. Three separate
-	// hand-rolled spellings of "put the suffix on" is how the transport
-	// ended up with one that could not take it back off again.
+	// The shared helper takes the quoted form this path carries as readily as the
+	// bare form the API path does.
 	const std::string wire_static_etag = webcommon::WithCodingSuffix(etag, coded);
 	const std::string wire_static_bare =
 		(wire_static_etag.size() >= 2 && wire_static_etag.front() == '"' &&
@@ -1910,11 +1713,9 @@ CHttpServer::Response CApiDispatcher::ServeStaticFile(
 	if (webcommon::IfNoneMatchHits(inm_val, wire_static_bare)) {
 		CHttpServer::Response r;
 		r.status = 304;
-		// Response::content_type defaults to application/json, which on a
-		// 304 for an HTML or CSS asset is simply wrong. Cleared rather
-		// than corrected: a 304 carries no content, the transport omits
-		// the header when it is empty, and this matches what the API 304
-		// path already does.
+		// content_type defaults to application/json, which is wrong on a 304 for an
+		// HTML or CSS asset. Cleared rather than corrected: a 304 carries no content
+		// and the transport omits an empty header.
 		r.content_type.clear();
 		r.headers["ETag"] = wire_static_etag;
 		// Same policy the 200 carries, or a cache is told the shell is
@@ -1926,45 +1727,25 @@ CHttpServer::Response CApiDispatcher::ServeStaticFile(
 	CHttpServer::Response r;
 	r.status = 200;
 	r.content_type = StaticContentType(rel);
-	// The body is kept for HEAD too. The transport writes headers only,
-	// so nothing reaches the wire, and keeping it is what lets
-	// Content-Length report the real size instead of 0 -- and what stops
-	// HEAD and GET disagreeing about this resource's validator, since the
-	// outer layer skips stamping whenever a handler set its own ETag.
+	// Kept for HEAD too: the transport writes headers only, so nothing reaches the
+	// wire, and keeping it lets Content-Length report the real size and stops HEAD
+	// and GET disagreeing about the validator.
 	r.body = std::move(body);
 	r.headers["ETag"] = etag;
-	// The WebUI shell is the same bytes for everyone, so it carries its own
-	// policy rather than inheriting the authenticated default -- without
-	// this it was stamped private and re-fetched per session.
+	// The shell is the same bytes for everyone, so it overrides the authenticated
+	// default.
 	//
-	// no-cache, NOT a max-age. These filenames carry no content hash:
-	// index.html, app.js and app.css keep their names across a rebuild. A
-	// freshness lifetime therefore buys nothing that the ETag does not
-	// already give -- and costs correctness, because must-revalidate only
-	// governs what a cache may do once the entry is ALREADY stale
-	// (RFC 9111 5.2.2.2). Inside the lifetime the browser serves the copy
-	// it has without asking, so an upgraded daemon would keep handing out
-	// the old shell for the rest of the window, and since each asset
-	// expires on its own clock a new shell can be paired with an old
-	// bundle -- breakage that looks like a bug rather than a stale page.
+	// no-cache rather than a max-age: index.html, app.js and app.css keep their
+	// names across a rebuild, so inside a freshness lifetime the browser would not
+	// ask, an upgraded daemon would serve the old shell, and per-asset expiry could
+	// pair a new shell with an old bundle. no-cache still lets the copy be stored,
+	// so an unchanged bundle costs one conditional GET answered 304.
 	//
-	// no-cache means revalidate every time, not "do not store": the copy
-	// stays in the cache and an unchanged bundle costs one conditional GET
-	// answered 304 with no body. Reserve a long max-age for content-hashed
-	// filenames, where the URL changes when the bytes do.
-	//
-	// public is load-bearing alongside it, not decoration. RFC 9111 3.5
-	// bars a shared cache from reusing a response to a request that
-	// carried an AUTHORIZATION HEADER unless the response carries one of
-	// public, must-revalidate or s-maxage, and no-cache is not on that
-	// list. The browser WebUI is not the case that engages it -- it
-	// authenticates by cookie, which is exactly why the credential stamp
-	// above needs Vary: Cookie instead. A bearer-token client fetching the
-	// same shell is: its request does carry the header. Without public, a
-	// proxy in front of the daemon must then hold a per-token copy of a
-	// file identical for every caller. It changes nothing for a client
-	// that is not a shared cache: no-cache still forces revalidation on
-	// every use.
+	// public is load-bearing: RFC 9111 3.5 bars a shared cache from reusing a
+	// response to an Authorization-bearing request unless it is public,
+	// must-revalidate or s-maxage. That is the bearer-token client, not the
+	// cookie-authenticated WebUI, which is why the credential stamp above needs
+	// Vary: Cookie instead.
 	r.headers["Cache-Control"] = "public, no-cache";
 	return r;
 }
@@ -1983,26 +1764,22 @@ CHttpServer::Response CApiDispatcher::ServeCountryFlag(
 	const std::string code =
 		url_path.substr(kPrefix.size(), url_path.size() - kPrefix.size() - kSuffix.size());
 
-	// Two lowercase ASCII letters — the shape `country_code` arrives in
-	// — plus the one literal name the set ships alongside the alpha-2
-	// files: "unknown", the "??" placeholder CCountryFlags falls back
-	// to for an empty or unrecognised code, offered here so a frontend
-	// can match the desktop instead of inventing its own.
+	// Two lowercase ASCII letters, the shape `country_code` arrives in, plus the
+	// one literal name the set ships alongside them: "unknown", the "??"
+	// placeholder CCountryFlags falls back to, offered so a frontend can match the
+	// desktop.
 	//
-	// The art id is built by concatenation, so this whitelist is what
-	// stops a crafted code from naming a non-flag entry in the shared
-	// icon table ("/flags/../amule.png" and friends — LooksMalicious
-	// already rejects those upstream, but the lookup must not depend
-	// on that).
+	// The art id is built by concatenation, so this whitelist is what stops a
+	// crafted code naming a non-flag entry in the shared icon table. LooksMalicious
+	// rejects those upstream, but the lookup must not depend on it.
 	const bool is_alpha2 =
 		code.size() == 2 && code[0] >= 'a' && code[0] <= 'z' && code[1] >= 'a' && code[1] <= 'z';
 	if (!is_alpha2 && code != "unknown") {
 		return ErrorResponse(404, "not_found", "no such flag");
 	}
 
-	// The famfamfam set covers 248 of the ~300 assignable alpha-2
-	// codes, and GeoIP can resolve one it has no artwork for, so a
-	// well-formed miss is a normal 404 rather than an error.
+	// The famfamfam set covers 248 of the ~300 assignable alpha-2 codes and GeoIP
+	// can resolve one it has no artwork for, so a well-formed miss is a 404.
 	const struct AMuleIconEntry *icon = amule_find_icon(("flag_" + code).c_str());
 	if (!icon || icon->png_data == nullptr || icon->png_len == 0) {
 		return ErrorResponse(404, "not_found", "no such flag");
@@ -2011,36 +1788,27 @@ CHttpServer::Response CApiDispatcher::ServeCountryFlag(
 	CHttpServer::Response r;
 	r.status = 200;
 	r.content_type = "image/png";
-	// The ETag / If-None-Match -> 304 swap is applied to every 200
-	// GET/HEAD by Dispatch(), and a HEAD is written as headers only by the
-	// transport rather than stripped here, so this handler only has to
-	// produce the bytes. (Dispatch no longer strips the body: keeping it
-	// is what lets Content-Length report what a GET would return.)
+	// Dispatch() applies the ETag and 304 swap to every 200 GET/HEAD, and the
+	// transport writes a HEAD as headers only, so this handler just produces bytes.
 	r.body.assign(reinterpret_cast<const char *>(icon->png_data), icon->png_len);
-	// The artwork is compiled in: it can only change with a new build,
-	// and a peer list is a page full of <img> tags pointing here. A day
-	// of freshness turns those into cache hits instead of one
-	// conditional request per distinct country per reload, while still
-	// bounding how long an upgraded daemon keeps serving stale art.
+	// The artwork is compiled in and can only change with a new build, while a
+	// peer list is a page full of <img> tags pointing here. A day of freshness
+	// turns those into cache hits, while bounding how long an upgraded daemon
+	// serves stale art.
 	r.headers["Cache-Control"] = "public, max-age=86400";
 	return r;
 }
 
-// GET /health. The surface had no liveness probe, so `/version` was being used
-// as one -- a document whose body changes over time, whose name says something
-// else, and which reported the daemon's update state to an unauthenticated
-// caller.
+// GET /health.
 //
-// Liveness, not readiness: always 200 while the HTTP server is answering, so a
-// container or load-balancer probe never restarts a healthy process just
-// because amuled went away. Readiness is in the body instead, where a caller
-// that wants it can key on the two flags without the status code moving under
-// a caller that does not.
+// Liveness, not readiness: always 200 while the HTTP server answers, so a
+// container or load-balancer probe never restarts a healthy process because
+// amuled went away. Readiness is in the body, where a caller that wants it can
+// key on the two flags without the status code moving under one that does not.
 //
-// No EC roundtrip. amuleapi serialises EC through one worker, so a probe that
+// No EC roundtrip: amuleapi serialises EC through one worker, so a probe that
 // waited on the daemon could block behind an unrelated slow mutation and time
-// out at the read deadline, reporting the service as down when it is merely
-// busy. Both flags are process-local reads.
+// out, reporting the service down when it is merely busy.
 CHttpServer::Response CApiDispatcher::HandleHealth(const CHttpServer::Request &)
 {
 	CHttpServer::Response r;
@@ -2052,9 +1820,9 @@ CHttpServer::Response CApiDispatcher::HandleHealth(const CHttpServer::Request &)
 	w.ValueString(wxT("ok"));
 	w.Key("ec_connected");
 	w.ValueBool(m_state.EcConnected());
-	// `snapshot_ready`, not `snapshot`: a bare noun reads as "here is a
-	// snapshot (object)" rather than as the readiness state it reports,
-	// and this is the first response most clients ever parse (R4).
+	// `snapshot_ready`, not `snapshot`: a bare noun reads as "here is a snapshot"
+	// rather than the readiness state it reports, on the first response most
+	// clients parse (R4).
 	w.Key("snapshot_ready");
 	w.ValueBool(m_state.HasFirstSnapshot());
 	w.EndObject();
@@ -2064,28 +1832,21 @@ CHttpServer::Response CApiDispatcher::HandleHealth(const CHttpServer::Request &)
 
 CHttpServer::Response CApiDispatcher::HandleVersion(const CHttpServer::Request &req)
 {
-	// The identity fields stay unauthenticated: version negotiation has to work
-	// before anyone holds a token. This is NOT the liveness probe, though it was
-	// used as one before there was a better answer -- /health owns that now, see
-	// HandleHealth.
+	// Identity stays unauthenticated: version negotiation has to work before
+	// anyone holds a token. Liveness is /health's job, not this endpoint's.
 	//
-	// The `update` block does NOT stay unauthenticated, because it reports
-	// whether THIS daemon is running an outdated build, and that is not
-	// something an unauthenticated caller on a deliberately reachable interface
-	// should learn. A client that shows an "update available" banner is already
-	// authenticated when it does.
+	// The `update` block does not, because it reports whether THIS daemon is
+	// outdated, which an unauthenticated caller on a reachable interface should
+	// not learn.
 	//
-	// Auth here is OPTIONAL, which is why this does not call Authenticate()
-	// unconditionally: that wrapper counts every 401 against the generic
-	// limiter, and a request with no credential is this endpoint's documented
-	// unauthenticated use rather than an auth failure. Counting it would let an
-	// anonymous poller -- or, behind a reverse proxy, one poller on the address
-	// every client shares -- spend the bucket in 30 requests and lock real
-	// sessions out of the whole authenticated surface for the lockout window.
-	// A credential that IS presented and rejected still counts: the `update`
-	// block appearing is an oracle a token guesser could otherwise read for
-	// free, and the wrapper's lockout pre-check keeps a locked-out address off
-	// the verify path.
+	// Auth is OPTIONAL here, which is why Authenticate() is not called
+	// unconditionally: that wrapper counts every 401 against the generic limiter,
+	// and a request with no credential is this endpoint's documented use rather
+	// than a failure. Counting it would let an anonymous poller -- or one poller
+	// behind a reverse proxy, on the address every client shares -- spend the
+	// bucket in 30 requests and lock real sessions out of the authenticated
+	// surface. A credential that IS presented and rejected still counts: the
+	// `update` block is an oracle a token guesser could otherwise read for free.
 	AuthOutcome auth;
 	if (RequestCarriesCredentials(req, kSessionCookieName)) {
 		auth = Authenticate(req);
@@ -2096,35 +1857,26 @@ CHttpServer::Response CApiDispatcher::HandleVersion(const CHttpServer::Request &
 	r.content_type = "application/json";
 	CJsonWriter w;
 	w.BeginObject();
-	// `service`, not `name`: "name" of what? The value is the constant
-	// "amuleapi", so the key should say which thing it names.
+	// `service`, not `name`: the value is the constant "amuleapi".
 	w.Key("service");
 	w.ValueString(wxT("amuleapi"));
 	w.Key("api_version");
 	w.ValueString(wxT("v0"));
-	// `amuleapi_version`, not `amule_version`: this is the VERSION the
-	// amuleapi binary was built from, which need not match the aMule daemon
-	// it is talking to. The old name said the opposite of what it holds.
+	// `amuleapi_version`, not `amule_version`: the version the amuleapi binary was
+	// built from, which need not match the daemon it talks to.
 	w.Key("amuleapi_version");
-	// Same short form the daemon reports for itself, so the two stay
-	// comparable: bare VERSION is the literal "GIT" on a development
-	// build, which would make this differ from daemon_version on every
-	// such build even when both come from the same tree.
+	// The short form the daemon reports for itself, so the two stay comparable:
+	// bare VERSION is the literal "GIT" on a development build.
 	w.ValueString(GetShortMuleVersion());
-	// Version of the connected amuled, from the EC handshake. Empty
-	// string when EC is not (yet) connected or the daemon predates the
-	// EC_TAG_SERVER_VERSION tag. Distinct from amuleapi_version above,
-	// which is amuleapi's own build version.
+	// Version of the connected amuled from the EC handshake; empty when EC is not
+	// connected or the daemon predates EC_TAG_SERVER_VERSION.
 	w.Key("daemon_version");
 	w.ValueString(m_app.GetDaemonVersion());
 
-	// Update-availability, relayed from the connected daemon (never checked
-	// by amuleapi itself). All fields are English / C-locale per the API
-	// contract. When the daemon can't check -- built without
-	// ENABLE_VERSION_CHECK, the check_new_version pref off, or a pre-3.1
-	// daemon that emits none of these tags -- check_enabled is false and a
-	// client should show nothing. `available`, `latest_version` and
-	// `last_checked_at` are null until a check has completed.
+	// Relayed from the connected daemon, never checked by amuleapi itself, and
+	// English/C-locale per the API contract. When the daemon cannot check (built
+	// without ENABLE_VERSION_CHECK, the pref off, or a pre-3.1 daemon emitting
+	// none of these tags) check_enabled is false and a client shows nothing.
 	if (auth.ok) {
 		const auto prefs = m_state.Preferences();
 		const auto status = m_state.Status();
@@ -2136,14 +1888,12 @@ CHttpServer::Response CApiDispatcher::HandleVersion(const CHttpServer::Request &
 		w.ValueBool(check_enabled);
 		w.Key("checked");
 		w.ValueBool(checked);
-		// null rather than "" before a check completes: R10, and its two
-		// siblings on this object already answer that way.
+		// null rather than "" before a check completes (R10).
 		WriteStringOrNull(w,
 			"latest_version",
 			checked && !status.version_check_latest.empty(),
 			status.version_check_latest);
-		// `available`, not `update_available`: it stutters inside its own
-		// `update` object.
+		// `available`, not `update_available`: it stutters inside its own object.
 		w.Key("available");
 		if (checked) {
 			w.ValueBool(status.version_check_outdated);
@@ -2165,9 +1915,8 @@ CHttpServer::Response CApiDispatcher::HandleLogin(const CHttpServer::Request &re
 {
 	const std::string &ip = req.remote_addr;
 
-	// Rate-limit BEFORE we touch the credential path. A locked-out
-	// IP burns no MD5 cycles and can't drive a side-channel that
-	// would distinguish "lockout in effect" from "wrong password".
+	// Before the credential path: a locked-out IP burns no MD5 cycles and cannot
+	// drive a side channel distinguishing lockout from wrong password.
 	const auto decision = m_rateLimiter.Check(ip);
 	if (decision.locked_out) {
 		CHttpServer::Response r =
@@ -2181,12 +1930,9 @@ CHttpServer::Response CApiDispatcher::HandleLogin(const CHttpServer::Request &re
 		return r;
 	}
 
-	// Parse `{"password": "<plain>"}`. Anything else gets a 400.
-	// Route through ParseJsonObjectBody so the pre-auth login path
-	// shares the same depth-cap defence the rest of the body
-	// parses get; without it a deeply-nested `{"a":{"a":...}}` would
-	// blow the worker thread's stack via picojson's recursive
-	// descent — and login is reachable unauthenticated.
+	// Through ParseJsonObjectBody so this pre-auth path shares the depth cap:
+	// without it a deeply nested body would blow the worker stack via picojson's
+	// recursive descent, and login is reachable unauthenticated.
 	picojson::value v;
 	std::string err;
 	if (!ParseJsonObjectBody(req.body, v, err)) {
@@ -2200,14 +1946,11 @@ CHttpServer::Response CApiDispatcher::HandleLogin(const CHttpServer::Request &re
 	const wxString plain = wxString::FromUTF8(pw_it->second.get<std::string>().c_str());
 	const std::string md5_hex(MD5Sum(plain).GetHash().utf8_str());
 
-	// Admin first, then guest. The comparison itself is constant time
-	// inside webcommon; what is visible from outside is the PBKDF2 cost,
-	// which is why the rate limiter above runs first. This is also the
-	// point where amuleapi picks up a password another process wrote —
-	// aMule's preferences dialog, or amuled applying an EC push from
-	// amulegui — and where a record predating the current KDF cost gets
-	// upgraded. Empty roles skip the KDF entirely, so the
-	// nothing-configured case below costs nothing to reach.
+	// Admin first, then guest. The comparison is constant time inside webcommon;
+	// what is visible from outside is the PBKDF2 cost, which is why the limiter
+	// runs first. This is also where amuleapi picks up a password another process
+	// wrote, and where a record predating the current KDF cost is upgraded. Empty
+	// roles skip the KDF entirely.
 	Role role = Role::GUEST;
 	const CAmuleApiConfig::MatchedRole matched = m_config.VerifyPassword(md5_hex);
 	if (matched == CAmuleApiConfig::MatchedRole::Admin) {
@@ -2215,12 +1958,10 @@ CHttpServer::Response CApiDispatcher::HandleLogin(const CHttpServer::Request &re
 	}
 
 	if (matched == CAmuleApiConfig::MatchedRole::None) {
-		// Distinguish "nothing is configured" from "wrong password" —
-		// otherwise every login silently fails and the operator
-		// debugging "why isn't login working" suspects the JWT. Read
-		// after VerifyPassword, which is what refreshes it from disk.
-		// A misconfiguration is not a failed guess, so it does not
-		// count against the rate limiter.
+		// Distinguish "nothing configured" from "wrong password", or every login
+		// silently fails and the operator suspects the JWT. Read after
+		// VerifyPassword, which refreshes it from disk. A misconfiguration is not a
+		// failed guess, so it does not count against the limiter.
 		if (!m_config.HasAnyCredential()) {
 			return ErrorResponse(503,
 				"login_disabled",
@@ -2232,18 +1973,16 @@ CHttpServer::Response CApiDispatcher::HandleLogin(const CHttpServer::Request &re
 			401, "invalid_credentials", "password does not match any configured role");
 	}
 
-	// Deliberately NO NoteSuccess() here. One bucket, keyed by IP, guards
-	// both passwords: VerifyPassword tries admin then guest. Clearing it on
-	// any match lets a guest-credential holder erase the admin-password
-	// failure streak at will -- four wrong admin guesses, one good guest
-	// login, repeat -- so the one control protecting the admin password
-	// never fires. The stamps age out on their own (window_seconds, pruned
-	// by both Check and NoteFailure), which is what keeps a legitimate
-	// user's earlier typos from accumulating.
+	// Deliberately NO NoteSuccess(). One bucket, keyed by IP, guards both
+	// passwords, since VerifyPassword tries admin then guest. Clearing it on any
+	// match would let a guest-credential holder erase the admin failure streak at
+	// will -- four wrong admin guesses, one good guest login, repeat -- so the one
+	// control protecting the admin password never fires. Stamps age out on their
+	// own.
 	//
-	// The clear in HandleAuthPasswords below is a different case: it is
-	// admin-gated and verifies the current password, so its success is on
-	// the very credential the bucket protects.
+	// The clear in HandleAuthPasswords is a different case: admin-gated and
+	// verifying the current password, so its success is on the very credential the
+	// bucket protects.
 
 	CHttpServer::Response r;
 	r.status = 200;
@@ -2258,28 +1997,21 @@ CHttpServer::Response CApiDispatcher::HandleLogin(const CHttpServer::Request &re
 }
 
 // Issues a session for `role`, attaches the cookie to `r`, and writes the
-// standard session fields into the object `w` is currently building.
-//
-// Shared by /auth/login and by the password change, which re-issues so
-// that changing a password does not sign the caller out of the request
-// they are in the middle of making.
+// standard session fields into the object `w` is building. Shared with the
+// password change, which re-issues so that changing a password does not sign
+// the caller out of the request they are making.
 void CApiDispatcher::BeginSession(
 	const CHttpServer::Request &req, Role role, CHttpServer::Response &r, CJsonWriter &w)
 {
 	const CJwt::IssuedToken issued = m_jwt.Issue(role);
 	r.headers["Set-Cookie"] = MakeSetCookie(kSessionCookieName, issued.token, issued.expires_at);
 
-	// Default (cookie-auth, browser): the HttpOnly+SameSite cookie
-	// carries the token. Echoing it into the JSON body would defeat
-	// HttpOnly — any XSS that `fetch('/auth/login', ...)` could read
-	// the body and exfiltrate the bearer. So the default response is
-	// deliberately token-less.
+	// Cookie-auth default: the HttpOnly+SameSite cookie carries the token, and
+	// echoing it into the body would defeat HttpOnly -- any XSS that could call
+	// fetch('/auth/login') could read and exfiltrate the bearer.
 	//
-	// Token opt-in (SDK / curl / no cookie jar): client passes
-	// `Accept: application/jwt` or `?include_token=true` to get `token` in
-	// the body as well. The cookie still ships; token clients can ignore it.
-	// Everything else on this response is unconditional -- `include_token`
-	// adds the one key it names and nothing else.
+	// Opt-in for SDK and curl clients with no cookie jar: `Accept: application/jwt`
+	// or `?include_token=true` adds `token` to the body and nothing else.
 	bool wants_bearer = false;
 	{
 		const std::string accept = FindHeaderCaseInsensitive(req.headers, "Accept");
@@ -2292,8 +2024,7 @@ void CApiDispatcher::BeginSession(
 			if (qpos != std::string::npos)
 				q = req.target.substr(qpos + 1);
 			const auto qmap = web_api_path::ParseQuery(q);
-			// `include_token=true`, not `type=bearer`: "type" named no
-			// axis, and the parameter only ever added one key.
+			// `include_token=true`, not `type=bearer`: "type" named no axis.
 			const auto it = qmap.find("include_token");
 			if (it != qmap.end() && it->second == "true") {
 				wants_bearer = true;
@@ -2308,21 +2039,19 @@ void CApiDispatcher::BeginSession(
 	w.Key("role");
 	w.ValueString(role == Role::ADMIN ? wxT("admin") : wxT("guest"));
 	// One `expires_at`, unix seconds, like every other `_at` on the surface.
-	// It used to ship twice -- ISO here and unix as `expires_at_unix`.
 	w.Key("expires_at");
 	w.ValueInt(static_cast<int64_t>(issued.expires_at));
-	// `session_id`, not `jti` (a JWT internal), and emitted unconditionally:
-	// it used to appear only in the token shape, so every cookie-auth login
-	// lacked the id that /auth/session returns for the same session.
+	// `session_id`, not `jti` (a JWT internal), and unconditional: it used to
+	// appear only in the token shape, so cookie-auth logins lacked the id
+	// /auth/session returns for the same session.
 	w.Key("session_id");
 	w.ValueString(wxString::FromUTF8(issued.jti.c_str()));
 }
 
 CHttpServer::Response CApiDispatcher::HandleLogout(const CHttpServer::Request &req)
 {
-	// Generic-401 cap applies to logout too — repeat 401s here are a
-	// credential-stuffing signal even on the idempotent path. Locked-
-	// out IPs short-circuit before any MAC compare.
+	// The generic-401 cap applies here too: repeat 401s are a credential-stuffing
+	// signal even on an idempotent path, and locked-out IPs short-circuit.
 	const std::string &ip = req.remote_addr;
 	{
 		const auto decision = m_authRateLimiter.Check(ip);
@@ -2339,15 +2068,11 @@ CHttpServer::Response CApiDispatcher::HandleLogout(const CHttpServer::Request &r
 		}
 	}
 
-	// Logout is idempotent. A revoked-but-not-yet-expired token
-	// should still get a 204 noop — the operation it requested has
-	// already happened. Without this, a browser tab that does
-	// `fetch('/auth/logout', ...)` twice in quick succession (page
-	// reload during the request, double-tap on the menu, etc.) sees
-	// a 401 on the second attempt and renders a confusing "session
-	// expired" toast. Inline a softer flow than AuthenticateRequest:
-	// reject only on bad-sig/expired/missing, treat revoked as a
-	// noop.
+	// Logout is idempotent: a revoked-but-unexpired token still gets a 204,
+	// because what it asked for has already happened. Otherwise a tab that fires
+	// logout twice in quick succession sees a 401 and renders a spurious "session
+	// expired". Softer than AuthenticateRequest: reject only bad-sig, expired or
+	// missing; treat revoked as a noop.
 	std::string token;
 	auto auth_it = req.headers.find("Authorization");
 	if (auth_it == req.headers.end()) {
@@ -2387,17 +2112,15 @@ CHttpServer::Response CApiDispatcher::HandleLogout(const CHttpServer::Request &r
 	// Already revoked → 204 noop (don't re-revoke, don't re-emit a
 	// clear-cookie that might race with the browser's own delete).
 	if (!m_revocations.IsRevoked(v.jti)) {
-		// Add the jti to the revocation set with the JWT's own exp as
-		// the TTL — once the token would have expired anyway, the GC
-		// drops the entry.
+		// TTL is the JWT's own exp, so the GC drops the entry once the token
+		// would have expired anyway.
 		m_revocations.Revoke(v.jti, v.exp);
 	}
 	m_authRateLimiter.NoteSuccess(ip);
 
 	CHttpServer::Response r;
-	// 204 with no body. Everything this used to echo came from the request
-	// URL, and `ok` restated the status code -- see the mutation-response
-	// rule in REFERENCE.md.
+	// 204 with no body: everything this used to echo came from the request URL,
+	// and `ok` restated the status code.
 	r.status = 204;
 	r.content_type.clear();
 	r.headers["Set-Cookie"] = MakeClearCookie(kSessionCookieName);
@@ -2434,17 +2157,15 @@ CHttpServer::Response CApiDispatcher::HandleSession(const CHttpServer::Request &
 	w.Key("expires_at");
 	w.ValueInt(static_cast<int64_t>(a.verified.exp));
 	w.EndObject();
-	// Per-principal document: a shared cache must not hand one caller
-	// another's session. Our own ETag memo excludes this target for the
-	// same reason; this is the half that binds anything in front of us.
+	// Per-principal document: a shared cache must not hand one caller another's
+	// session. The ETag memo excludes this target for the same reason.
 	r.headers["Cache-Control"] = "private, no-store";
 	FinalizeJsonBody(w, r);
 	return r;
 }
 
-// GET /auth/passwords — what is configured, never the credentials
-// themselves. Admin-only: whether a guest account exists is not something
-// a guest session needs to know.
+// What is configured, never the credentials. Admin-only: whether a guest
+// account exists is not something a guest session needs to know.
 CHttpServer::Response CApiDispatcher::HandleAuthPasswords(const CHttpServer::Request &req)
 {
 	auto a = Authenticate(req);
@@ -2468,16 +2189,13 @@ CHttpServer::Response CApiDispatcher::HandleAuthPasswords(const CHttpServer::Req
 	return r;
 }
 
-// PATCH /auth/passwords — change the admin password, and turn the guest
-// role on/off or change its password.
+// Change the admin password, and turn the guest role on/off or change its
+// password.
 //
-// `current_password` is mandatory even though the caller already holds an
-// admin token: a stolen token should not be enough to lock the real
-// operator out of their own daemon. It goes through the same rate limiter
-// as /auth/login, so this is not a softer place to guess passwords.
-//
-// Fields are omitted rather than nulled to mean "leave alone" — see
-// webcommon::CredentialChange, which every entry point shares.
+// `current_password` is mandatory even though the caller holds an admin token:
+// a stolen token should not be enough to lock the operator out of their own
+// daemon. It shares /auth/login's rate limiter, so this is not a softer place
+// to guess. Fields are omitted rather than nulled to mean "leave alone".
 CHttpServer::Response CApiDispatcher::HandleAuthPasswordsPatch(const CHttpServer::Request &req)
 {
 	auto a = Authenticate(req);
@@ -2542,9 +2260,8 @@ CHttpServer::Response CApiDispatcher::HandleAuthPasswordsPatch(const CHttpServer
 			guest_access_enabled = it->second.get<bool>();
 		}
 	}
-	// Setting a guest password while switching the role off is
-	// contradictory; guessing at which half was meant would silently do
-	// the wrong one.
+	// Setting a guest password while switching the role off is contradictory, and
+	// guessing which half was meant would silently do the wrong one.
 	if (has_guest && !guest_new.empty() && has_guest_access_enabled && !guest_access_enabled) {
 		return ErrorResponse(400,
 			"bad_request",
@@ -2575,8 +2292,7 @@ CHttpServer::Response CApiDispatcher::HandleAuthPasswordsPatch(const CHttpServer
 	m_rateLimiter.NoteSuccess(ip);
 
 	webcommon::CredentialChange change;
-	// `change` belongs to libwebcommon's credential file format, shared with
-	// amuleweb, so its member keeps the name the file uses.
+	// The member keeps the name libwebcommon's credential file uses.
 	change.guest_enabled = guest_access_enabled;
 	if (has_admin) {
 		change.admin_md5 = std::string(
@@ -2607,12 +2323,10 @@ CHttpServer::Response CApiDispatcher::HandleAuthPasswordsPatch(const CHttpServer
 	w.ValueBool(!m_config.AdminCredential().empty());
 	w.Key("guest_access_enabled");
 	w.ValueBool(!m_config.GuestCredential().empty());
-	// Writing the file invalidated every token issued before it, this
-	// caller's included. Re-issue theirs in the same response so the
-	// operator who changed the password stays signed in while everyone
-	// else is signed out — which is the point of changing it. That is
-	// unconditional, so it carried no information as a key and the
-	// always-true `other_sessions_revoked` is gone; the reference says it.
+	// Writing the file invalidated every token issued before it, this caller's
+	// included. Re-issuing theirs here keeps the operator who changed the password
+	// signed in while everyone else is signed out, which is the point of changing
+	// it.
 	BeginSession(req, Role::ADMIN, r, w);
 	w.EndObject();
 	FinalizeJsonBody(w, r);
@@ -2621,26 +2335,20 @@ CHttpServer::Response CApiDispatcher::HandleAuthPasswordsPatch(const CHttpServer
 
 CHttpServer::Response CApiDispatcher::HandleStatus(const CHttpServer::Request &req)
 {
-	// Read endpoints: any authenticated role is enough (admin OR
-	// guest). mutating endpoints will gate on `admin` only.
+	// Any authenticated role; mutating endpoints gate on admin only.
 	auto a = Authenticate(req);
 	if (!a.ok)
 		return a.rejection;
 
-	// Until the refresher has completed at least one tick, the cache
-	// is empty. Return 503 with a structured code so clients can
-	// retry rather than guessing — saves a round of confused log-
-	// reading when the daemon just came up.
+	// 503 with a structured code until the refresher has completed a tick, so
+	// clients retry rather than guess.
 	if (auto r = RequireSnapshot(m_state))
 		return *r;
 
-	// Single shared_lock for the whole composite read. Dashboard()
-	// returns a (status, kad, snapshot_at, ec_connected) tuple in
-	// one m_state lock acquisition, so a refresher tick cannot land
-	// between sub-snapshots and produce an inconsistent rollup
-	// (kad.network from tick N+1 while ed2k.* / speeds.* are from
-	// tick N). Caller-side aliases keep the rest of the function
-	// reading the same way the four-accessor version did.
+	// One shared_lock for the whole composite read: Dashboard() returns status,
+	// kad, snapshot_at and ec_connected in a single acquisition, so a refresher
+	// tick cannot land between sub-snapshots and produce an inconsistent rollup
+	// (kad.network from tick N+1 beside ed2k.* from tick N).
 	const webapi::CState::DashboardSnapshot d = m_state.Dashboard();
 	const webapi::StatusSnapshot &s = d.status;
 	const webapi::KadSnapshot &k = d.kad;
@@ -2653,11 +2361,10 @@ CHttpServer::Response CApiDispatcher::HandleStatus(const CHttpServer::Request &r
 
 	CJsonWriter w;
 	w.BeginObject();
-	// No snapshot timestamp in the envelope: a value that moves every tick
-	// changes the body bytes and defeats the ETag, so list endpoints would
-	// never see a cache hit. `ec_connected` is the staleness signal, flipping
-	// false when the refresher tick fails, and the HTTP `Date:` header
-	// carries wall-clock for any consumer that needs it.
+	// No snapshot timestamp in the envelope: a value that moves every tick changes
+	// the body bytes and defeats the ETag, so list endpoints would never see a
+	// cache hit. `ec_connected` is the staleness signal, and the HTTP Date header
+	// carries wall-clock for anyone who needs it.
 	w.Key("ec_connected");
 	w.ValueBool(ec);
 	(void)ts;
@@ -2666,35 +2373,29 @@ CHttpServer::Response CApiDispatcher::HandleStatus(const CHttpServer::Request &r
 	w.BeginObject();
 	w.Key("state");
 	w.ValueString(wxString::FromUTF8(s.ed2k_state.c_str()));
-	// Positive sense, matching the peer-side high_id on /clients/{ecid}.
-	// False for a LowID and while disconnected alike, so read it together
-	// with `state` before treating it as a firewall verdict.
+	// Positive sense, matching the peer-side high_id on /clients/{ecid}. False for
+	// a LowID and while disconnected alike, so read it with `state`.
 	w.Key("high_id");
 	w.ValueBool(s.ed2k_high_id);
-	// Our server-assigned id; a HighID (>= 16777216) is our public address
-	// packed LSB-first, which is where public_ip comes from. Both are 0 /
-	// empty while disconnected. Not the same encoding as the peer-side
-	// ed2k_user_id on /clients/{ecid}: that one byte-swaps a HighID, so
-	// the two must not be compared or fed through each other's decoder.
+	// Our server-assigned id; a HighID (>= 16777216) is our public address packed
+	// LSB-first, which is where public_ip comes from. NOT the same encoding as the
+	// peer-side ed2k_user_id on /clients/{ecid}, which byte-swaps a HighID, so the
+	// two must not be fed through each other's decoder.
 	w.Key("user_id");
 	w.ValueInt(static_cast<int64_t>(s.ed2k_user_id));
 	WriteStringOrNull(w, "public_ip", !s.ed2k_public_ip.empty(), s.ed2k_public_ip);
 	// 0 when not connected -- gate on ed2k.state, not on this being nonzero.
 	w.Key("connected_since_at");
 	w.ValueInt(static_cast<int64_t>(s.ed2k_connected_since));
-	// Null when not connected, name and port with the address: ed2k.state
-	// already says whether there is a server, so "" here only ever meant
-	// "not connected", and a port on its own describes nothing. The name was
-	// the odd one out, spelling the same absence as "" beside two nulls in
-	// the object it shares.
+	// Null when not connected: ed2k.state already says whether there is a server,
+	// so "" only ever meant "not connected", and a port on its own describes
+	// nothing.
 	const bool has_server = !s.server_ip.empty();
 	WriteStringOrNull(w, "server_name", has_server, s.server_name);
 	WriteStringOrNull(w, "server_ip", has_server, s.server_ip);
 	WriteIntOrNull(w, "server_port", has_server, static_cast<int64_t>(s.server_port));
-	// Network rollup, symmetric with kad.network below. Aggregate
-	// user + file counts across all connected ed2k servers, taken
-	// from the same EC_OP_STAT_REQ response the kad counters ride
-	// on — no extra round-trip.
+	// Aggregate user and file counts across all connected ed2k servers, from the
+	// same EC_OP_STAT_REQ response the kad counters ride on.
 	w.Key("network");
 	w.BeginObject();
 	// null unless eD2k is connected: these sum the whole known server list, not
@@ -2708,33 +2409,23 @@ CHttpServer::Response CApiDispatcher::HandleStatus(const CHttpServer::Request &r
 	w.BeginObject();
 	w.Key("state");
 	w.ValueString(wxString::FromUTF8(s.kad_state.c_str()));
-	// TCP half of the firewall verdict. Named for the transport because
-	// GET /kad reports it beside firewalled_udp, which is a separate
-	// measurement rather than a refinement of this one.
+	// Named for the transport because GET /kad reports it beside firewalled_udp,
+	// a separate measurement rather than a refinement of this one.
 	WriteBoolOrNull(w, "firewalled_tcp", s.has_kad_firewalled_tcp, s.kad_firewalled_tcp);
 	// 0 when not connected -- gate on kad.state, not on this being nonzero.
 	w.Key("connected_since_at");
 	w.ValueInt(static_cast<int64_t>(s.kad_connected_since));
-	// Network rollup — same numbers GET /kad serves under
-	// `network.{users,files,nodes}`, written by the same helper so
-	// the two endpoints cannot drift. Surfaced here so /status is a
-	// one-call dashboard view (matches the RFC contract §4.1
-	// `kad.network: {users, files}`; we ship `nodes` too because it
-	// costs nothing extra and the desktop GUI shows it in the same
-	// place). `k` was snapshotted at the top of the handler in the
-	// same shared_lock batch as `s`, so these counters describe the
-	// same refresher tick as ed2k.* / speeds.* above.
+	// The same numbers GET /kad serves under `network`, through the same helper so
+	// the two cannot drift. `k` was snapshotted in the same lock batch as `s`, so
+	// these counters describe the same refresher tick as ed2k.* above.
 	WriteKadNetworkObject(w, k);
 	w.EndObject();
 
 	w.Key("speeds");
 	w.BeginObject();
-	// `download_speed_bytes_per_second`, not `download_bytes_per_second`:
-	// the `speeds` wrapper does not rename the quantity. Every other live
-	// rate on the surface spells it with `speed` (download rows, client
-	// rows, shared rows, the graph enum), and the short form read close
-	// enough to the cumulative `downloaded_bytes_total` to be misread as
-	// one.
+	// `download_speed_bytes_per_second`, not `download_bytes_per_second`: the
+	// `speeds` wrapper does not rename the quantity, and the short form reads close
+	// enough to the cumulative `downloaded_bytes_total` to be misread as one.
 	w.Key("download_speed_bytes_per_second");
 	w.ValueInt(static_cast<int64_t>(s.download_bytes_per_second));
 	w.Key("upload_speed_bytes_per_second");
@@ -2747,10 +2438,8 @@ CHttpServer::Response CApiDispatcher::HandleStatus(const CHttpServer::Request &r
 	w.ValueInt(static_cast<int64_t>(s.upload_overhead_bytes_per_second));
 	w.EndObject();
 
-	// null rather than a number when the daemon has no figure. Emitting the
-	// -1 sentinel as an unsigned value would read as 17 exabytes free, and
-	// 0 would read as a full disk -- the desktop hides the label for the
-	// same reason.
+	// null rather than a number when the daemon has no figure: the -1 sentinel as
+	// an unsigned value would read as 17 exabytes free, and 0 as a full disk.
 	w.Key("disk");
 	w.BeginObject();
 	WriteIntOrNull(
@@ -2778,21 +2467,16 @@ CHttpServer::Response CApiDispatcher::HandleStatus(const CHttpServer::Request &r
 namespace
 {
 
-// Write a single download object. Used both inline (in the list
-// endpoint, iterated) and as the body of the detail endpoint (bare,
-// per Q3). The `include_envelope_keys` flag controls whether we
-// emit the snapshot_at envelope around it — list mode wraps in its
-// own envelope, detail mode is the bare object.
-// The chunk size and the part-count arithmetic both live in State.h now
-// (webapi::kPartSizeBytes / webapi::PartCountForSize). They used to be a
-// literal here plus six separately open-coded ceiling divisions, which is
-// the duplication that mattered; the constant still cannot come from
-// `protocol/ed2k/Constants.h` directly, because that header is written
-// against amule's legacy typedefs (see the note beside the definition).
+// Write a single download object, used inline by the list endpoint and as the
+// bare body of the detail endpoint; `include_envelope_keys` picks which.
+//
+// The chunk size and part-count arithmetic live in State.h
+// (webapi::kPartSizeBytes / webapi::PartCountForSize). The constant still
+// cannot come from `protocol/ed2k/Constants.h` directly, because that header is
+// written against amule's legacy typedefs.
 
-// Render the per-part state array from the decoded gap list +
-// per-part source counts. Algorithm cribbed from the reference REST
-// branch's `EmitProgressParts` (WebServerApi.cpp:897-952):
+// Render the per-part state array from the decoded gap list and per-part
+// source counts:
 //  - count = ceil(size / PARTSIZE)
 //  - mark a part "has gap" if any byte-range in `gaps` covers it
 //  - state = "complete"    (no gap) /
@@ -2826,9 +2510,8 @@ void WriteProgressParts(CJsonWriter &w, const webapi::FileSnapshot &f)
 		const std::uint16_t sources = (static_cast<std::size_t>(i) < part_sources.size())
 						      ? part_sources[static_cast<std::size_t>(i)]
 						      : static_cast<std::uint16_t>(0);
-		// "pending": we lack it and a source has it. "unavailable": we lack
-		// it and no source does. The old spellings ("incomplete" /
-		// "missing") both read as "we lack it" and hid which one it was.
+		// "pending": we lack it and a source has it. "unavailable": we lack it and
+		// none does. The old spellings both read as "we lack it".
 		const char *state = !has_gap[static_cast<std::size_t>(i)]
 					    ? "complete"
 					    : (sources > 0 ? "pending" : "unavailable");
@@ -2842,25 +2525,21 @@ void WriteProgressParts(CJsonWriter &w, const webapi::FileSnapshot &f)
 	w.EndArray();
 }
 
-// Per-part source availability backing the shared "Obtained Parts" bar.
-// A complete known file carries its own vector, decoded from the
-// EC_TAG_KNOWNFILE tag; a shared partfile is emitted by amuled as
-// EC_TAG_PARTFILE only, so its vector lands on the download side. Same
-// server-side encoder either way, so the fallback is the same numbers,
-// not an approximation.
+// Per-part source availability behind the shared "Obtained Parts" bar. A
+// complete known file carries its own vector from EC_TAG_KNOWNFILE; a shared
+// partfile is emitted as EC_TAG_PARTFILE only, so its vector lands on the
+// download side. Same server-side encoder, so the fallback is the same numbers.
 const std::vector<std::uint16_t> &SharedPartSources(const webapi::FileSnapshot &f)
 {
 	return f.shared.decoded_part_sources.empty() ? f.download.decoded_part_sources
 						     : f.shared.decoded_part_sources;
 }
 
-// `parts` for the shared detail endpoint: one `{sources}` per part, in
-// file order, always exactly `part_count` long. Deliberately NOT the
-// downloads shape -- `state` there encodes local completeness, which is
-// meaningless for a share and would invite a progress-bar renderer. The key
-// is always present and null when nothing has been decoded yet (R10), which
-// keeps "no data" distinguishable from "no sources for any part" without a
-// client having to probe for the key.
+// One `{sources}` per part, in file order, always exactly `part_count` long.
+// Deliberately NOT the downloads shape: `state` there encodes local
+// completeness, meaningless for a share and an invitation to render a progress
+// bar. Always present, null when nothing has been decoded (R10), which keeps
+// "no data" distinct from "no sources for any part".
 void WriteSharedAvailabilityParts(CJsonWriter &w, const webapi::FileSnapshot &f)
 {
 	const std::vector<std::uint16_t> &part_sources = SharedPartSources(f);
@@ -2884,14 +2563,12 @@ void WriteSharedAvailabilityParts(CJsonWriter &w, const webapi::FileSnapshot &f)
 	w.EndArray();
 }
 
-// Emit the `media` object (issue #418), or null when the file carries no
-// probed audio/video metadata. Shared by the download and shared detail
-// writers, and by the search-result writer.
+// The `media` object, or null when the file carries no probed metadata. Shared
+// by the download, shared and search-result writers.
 //
-// null rather than omitted so the key is always there. This is the one place
+// null rather than omitted so the key is always there: this is the one place
 // the unknown-value rule reaches an object rather than a scalar, so a client
-// tests `media === null` before reaching into it -- which it had to do anyway,
-// since the object's own fields can be absent.
+// tests `media === null` before reaching into it.
 void WriteMediaIfPresent(CJsonWriter &w, const webapi::FileSnapshot &f)
 {
 	if (!f.has_media) {
@@ -2961,27 +2638,22 @@ void WriteDownloadObject(
 		WriteProgressParts(w, f);
 	}
 	w.EndObject();
-	// True while an on-demand Kad notes lookup is in flight (issue #434). Kept in
-	// the shared object so list, detail and the SSE download event stay identical;
-	// clients can watch download_updated for the start -> finish transition.
+	// True while an on-demand Kad notes lookup is in flight. In the shared object
+	// so list, detail and the SSE download event stay identical.
 	w.Key("kad_comment_lookup_running");
 	w.ValueBool(f.download.kad_comment_searching);
-	// On the list, not detail-only: a client rendering a hashing indicator
-	// needs it wherever the file appears, and it only moves while a hash is
-	// actually running. Parts hashed so far, not an index -- 0 when idle.
+	// On the list, not detail-only: a hashing indicator needs it wherever the file
+	// appears. Parts hashed so far, not an index; 0 when idle.
 	w.Key("hashed_part_count");
 	w.ValueInt(static_cast<int64_t>(f.download.hashed_part_count));
-	// Its denominator, on the list for the same reason. A rising count with
-	// no total beside it cannot be rendered: fed straight to a progress bar
-	// it shows 3% for three parts of a hundred and 300% for three hundred of
-	// a thousand. Computed, not decoded -- there is no EC tag for it.
+	// Its denominator, on the list for the same reason: a rising count with no
+	// total cannot be rendered. Computed, not decoded -- there is no EC tag.
 	const std::int64_t total_part_count = static_cast<std::int64_t>(webapi::PartCountForSize(f.size));
 	w.Key("total_part_count");
 	w.ValueInt(total_part_count);
-	// On the list, not detail-only, so the SSE download event carries it:
-	// A4AF is a client-to-file relation, the one thing a per-file client
-	// list needs that the `clients` channel cannot say. Same spelling as on
-	// POST /downloads/{hash}/a4af (R6).
+	// On the list so the SSE download event carries it: A4AF is a client-to-file
+	// relation, the one thing a per-file client list needs that the `clients`
+	// channel cannot say.
 	w.Key("source_ecids");
 	w.BeginArray();
 	for (const std::uint32_t ecid : f.download.a4af_sources) {
@@ -2989,14 +2661,10 @@ void WriteDownloadObject(
 	}
 	w.EndArray();
 	if (detail) {
-		// Detail-only fields (GET /downloads/{hash}); omitted from the
-		// list. `remaining_seconds` is computed here from the snapshot --
-		// no EC tag exists for it.
-		// ETA seconds, or null when stalled/paused (speed ~0) and there is
-		// nothing to compute from. It was -1, which a client had to know
-		// meant "unknown" while the neighbouring unknowns on this surface
-		// used 0, an omitted key, and null. One rule: nullable field,
-		// unknown is null.
+		// Detail-only fields, omitted from the list. `remaining_seconds` is
+		// computed here -- no EC tag exists -- and is null when stalled or paused,
+		// where there is nothing to compute from. It was -1, which a client had to
+		// know meant unknown.
 		bool has_remaining_seconds = false;
 		std::int64_t remaining_seconds = 0;
 		if (f.download.speed_bytes_per_second > 0) {
@@ -3007,17 +2675,14 @@ void WriteDownloadObject(
 								    f.download.speed_bytes_per_second)
 					: 0;
 		}
-		// Null rather than 0 for "no complete copy has ever been seen",
-		// the same rule `last_upload` / `shared_since` follow: a unix
-		// timestamp of 0 reads as 1970, not as "never".
+		// Null rather than 0 for "no complete copy has ever been seen": a unix
+		// timestamp of 0 reads as 1970, not as never.
 		WriteIntOrNull(w,
 			"last_seen_complete_at",
 			f.download.last_seen_complete_at != 0,
 			static_cast<std::int64_t>(f.download.last_seen_complete_at));
-		// Same rule as the timestamp above: 0 is "no byte has arrived yet",
-		// which is not a 1970 date. It defaults to 0 and is only set when
-		// amuled ships the tag, so a partfile that has received nothing
-		// would otherwise date to the epoch.
+		// Same rule: 0 is "no byte has arrived yet", not a 1970 date. It is only
+		// set when amuled ships the tag.
 		WriteIntOrNull(w,
 			"last_received_at",
 			f.download.last_received_at != 0,
@@ -3033,20 +2698,16 @@ void WriteDownloadObject(
 		w.ValueInt(static_cast<int64_t>(f.download.gained_by_compression_bytes));
 		w.Key("ich_recovered_packet_count");
 		w.ValueInt(static_cast<int64_t>(f.download.ich_recovered_packet_count));
-		// null, not "": the AICH hashset does not exist until the file has
-		// been hashed, and R10 spells an absent value null rather than an
-		// empty string a client has to know is a sentinel.
+		// null, not "": the AICH hashset does not exist until the file has been
+		// hashed, and R10 spells an absent value null.
 		WriteStringOrNull(w, "aich_hash", !f.aich_hash.empty(), f.aich_hash);
-		// The ".part" control-file basename, omitted once the download
-		// completes. A completed file structurally has no partfile, which
-		// is the absent-key case rather than the `null` of "the daemon did
-		// not report it" -- the same distinction that keeps `result_count`
-		// off a /search row that has not started. It used to be a manufactured
-		// "" a client had to read as "completed", the one sentinel the
-		// aich_hash comment above exists to argue against.
+		// The ".part" control-file basename, omitted once the download completes: a
+		// completed file structurally has no partfile, which is the absent-key case
+		// rather than the null of "not reported". It used to be a manufactured "" a
+		// client had to read as "completed".
 		//
-		// There is nothing to surface either way: on a completed file the
-		// daemon reuses the _FILENAME tag to carry the directory path (#417).
+		// Nothing to surface either way: on a completed file the daemon reuses the
+		// _FILENAME tag to carry the directory path.
 		if (f.download.status != "completed") {
 			w.Key("part_file_name");
 			w.ValueString(wxString::FromUTF8(f.part_met_basename.c_str()));
@@ -3068,23 +2729,19 @@ void WriteDownloadObject(
 	w.EndObject();
 }
 
-// Base (list-level) client fields. Emits keys into an already-open
-// object (no Begin/End) so both the list writer and the detail writer
-// share one definition of the A-field set.
+// Base (list-level) client fields, emitted into an already-open object so the
+// list and detail writers share one definition of the set.
 void WriteClientBaseFields(CJsonWriter &w, const webapi::ClientSnapshot &c)
 {
 	w.Key("ecid");
 	w.ValueInt(static_cast<int64_t>(c.ecid));
-	// Null, not "", for every optional string below: an unknown value is null
-	// per R10, and WriteKnownClientObject already nulls the keys the two
-	// objects share. user_hash and the *_state enums stay unconditional --
-	// see the note above the states.
+	// Null, not "", for every optional string below (R10), matching
+	// WriteKnownClientObject. user_hash and the *_state enums stay unconditional.
 	WriteStringOrNull(w, "name", !c.client_name.empty(), c.client_name);
 	w.Key("user_hash");
 	w.ValueString(wxString::FromUTF8(c.user_hash.c_str()));
-	// Nulled together, keyed on the address: a port without one describes
-	// nothing. Matches the SSE row this promises key parity with, and
-	// WriteKnownClientObject, which nulls ip/port/kad_port the same way.
+	// Nulled together, keyed on the address: a port without one describes nothing.
+	// Matches the SSE row and WriteKnownClientObject.
 	const bool has_addr = !c.ip.empty();
 	WriteStringOrNull(w, "ip", has_addr, c.ip);
 	WriteIntOrNull(w, "port", has_addr, static_cast<int64_t>(c.port));
@@ -3106,10 +2763,9 @@ void WriteClientBaseFields(CJsonWriter &w, const webapi::ClientSnapshot &c)
 	WriteStringOrNull(w, "upload_file_name", !c.upload_file_name.empty(), c.upload_file_name);
 	WriteStringOrNull(w, "upload_file_hash", !c.upload_file_hash.empty(), c.upload_file_hash);
 	WriteStringOrNull(w, "download_file_hash", !c.download_file_hash.empty(), c.download_file_hash);
-	// R11: flattened out of the old `xfer` wrapper. A sub-object earns its
-	// place by grouping DIFFERENT quantities; this grouped one quantity split
-	// by time window, which belongs in the key. It also meant `xfer` named a
-	// 4-field up/down pair here and an upload-only pair on /shared.
+	// R11: flattened out of the old `xfer` wrapper. A sub-object earns its place
+	// by grouping DIFFERENT quantities; this grouped one quantity split by time
+	// window, which belongs in the key.
 	w.Key("uploaded_bytes_session");
 	w.ValueInt(static_cast<int64_t>(c.uploaded_bytes_session));
 	w.Key("downloaded_bytes_session");
@@ -3125,10 +2781,9 @@ void WriteClientBaseFields(CJsonWriter &w, const webapi::ClientSnapshot &c)
 	w.Key("upload_queue_position");
 	w.ValueInt(static_cast<int64_t>(c.upload_queue_position));
 	// 0xffff is amuled's "that peer's queue is full" sentinel
-	// (ECSpecialCoreTags.cpp: IsRemoteQueueFull() ? 0xffff : rank), not a
-	// position. Relayed verbatim it renders as "position 65535", and a client
-	// sorting by queue position buries full queues at the far end as though
-	// they were merely very distant.
+	// (ECSpecialCoreTags.cpp), not a position. Relayed verbatim it renders as
+	// "position 65535", and sorting by it buries full queues at the far end as
+	// though they were merely very distant.
 	WriteIntOrNull(w,
 		"remote_queue_position",
 		c.remote_queue_position != webapi::kRemoteQueueFullSentinel,
@@ -3139,17 +2794,13 @@ void WriteClientBaseFields(CJsonWriter &w, const webapi::ClientSnapshot &c)
 	// Being in this list means the daemon holds a client object, which starts
 	// at the first contact attempt. This says whether a socket is actually up.
 	WriteBoolOrNull(w, "connected", c.has_connected, c.connected);
-	// The protocol extensions the peer claimed, as tokens rather than as the
-	// EC_TAG_CLIENT_MOD_CAPABILITIES word they arrived in. An integer here
-	// would make every consumer carry its own copy of the bit table -- the
-	// Web UI in JS, and each third-party client again -- with nothing keeping
-	// those copies in step with src/PeerCapabilities.h, which is the only
-	// place the bits are actually defined. A list rather than one token
-	// because a peer claims any combination of them.
+	// The extensions the peer claimed, as tokens rather than the
+	// EC_TAG_CLIENT_MOD_CAPABILITIES word: an integer would make every consumer
+	// carry its own copy of the bit table, with nothing keeping those in step with
+	// src/PeerCapabilities.h. A list because a peer claims any combination.
 	//
-	// An empty array is what nearly every peer on the network produces: it
-	// claimed nothing. A peer that sent no capability tag at all and one that
-	// sent an all-zero word are the same state on the wire and the same here.
+	// An empty array is what nearly every peer produces. A peer that sent no
+	// capability tag and one that sent an all-zero word are the same state.
 	w.Key("protocol_extensions");
 	w.BeginArray();
 	{
@@ -3162,17 +2813,14 @@ void WriteClientBaseFields(CJsonWriter &w, const webapi::ClientSnapshot &c)
 	w.EndArray();
 	w.Key("friend_slot");
 	w.ValueBool(c.friend_slot);
-	// Promoted out of the detail object (issue #984): the desktop's per-file
-	// peer panels render Origin and "Shares File List" as list columns, so a
-	// caller should not have to fetch each peer individually to draw a table.
-	// Anything added here also reaches the SSE payload -- see ToJson AND Equal
-	// in EventDiff.cpp; a field in one but not the other never updates.
+	// On the list because the desktop's per-file peer panels render Origin and
+	// "Shares File List" as columns. Anything added here must also reach the SSE
+	// payload -- both ToJson AND Equal in EventDiff.cpp; a field in one but not
+	// the other never updates.
 	WriteStringOrNull(w, "source_origin", !c.source_origin.empty(), c.source_origin);
-	// Gated on the flag the refresher sets when the tag actually arrives.
-	// Emitted unconditionally, a peer that never reported its part map was
-	// indistinguishable from one reporting zero parts -- and zero is a real
-	// answer here, being what a fresh source looks like before its map turns
-	// up.
+	// Gated on the flag the refresher sets when the tag actually arrives: emitted
+	// unconditionally, a peer that never reported its part map was
+	// indistinguishable from one reporting zero, and zero is a real answer.
 	WriteIntOrNull(w,
 		"parts_offered_count",
 		c.has_parts_offered_count,
@@ -3201,12 +2849,11 @@ void WriteClientObject(CJsonWriter &w, const webapi::ClientSnapshot &c)
 
 // One EC_TAG_CLIENT entry of an EC_OP_CLIENT_HISTORY reply.
 //
-// Tag-absent means "the daemon has no such record for this peer", not "empty":
-// a record written before per-peer metadata existed carries only the hash, the
-// totals and a last-seen, and the fields below simply stay unset so the writer
-// emits them as null. The numeric codes go through the same decoders the refresher
-// uses for live peers (ClientTagNames.h), so a consumer switching on "kad" or
-// "emule" gets the same token whichever endpoint produced it.
+// Tag-absent means "the daemon has no such record", not "empty": a record
+// written before per-peer metadata existed carries only the hash, the totals
+// and a last-seen, and the fields below stay unset so the writer emits null.
+// The numeric codes go through the decoders the refresher uses for live peers
+// (ClientTagNames.h), so a consumer gets the same token from either endpoint.
 webapi::KnownClientSnapshot DecodeKnownClient(const CECTag &entry)
 {
 	webapi::KnownClientSnapshot c;
@@ -3246,23 +2893,20 @@ webapi::KnownClientSnapshot DecodeKnownClient(const CECTag &entry)
 	return c;
 }
 
-// One credit-store record (GET /known_clients).
+// One credit-store record.
 //
-// Optional fields are emitted as null rather than omitted: a record written
-// before the daemon kept per-peer metadata genuinely has no name, address or
-// software, and a consumer should be able to tell "not recorded" from "recorded
-// as empty" without also having to test whether the key is there at all. The
-// hash, the totals and last_seen_at are always present.
+// Optional fields are null rather than omitted: a record written before the
+// daemon kept per-peer metadata genuinely has no name, address or software, and
+// a consumer should tell "not recorded" from "recorded as empty" without
+// testing for the key. Hash, totals and last_seen_at are always present.
 void WriteKnownClientObject(CJsonWriter &w, const webapi::KnownClientSnapshot &c)
 {
 	w.BeginObject();
 	w.Key("user_hash");
 	w.ValueString(wxString::FromUTF8(c.user_hash.c_str()));
-	// Eleven keys behind seven guards used to be omitted here. The rule in
-	// REFERENCE.md is that an unknown value is null and a key is omitted only
-	// where absence itself is the meaning -- which is not the case for any of
-	// these: "the daemon did not report this peer's IP" is a value, and the
-	// client should not have to distinguish it from a key that never existed.
+	// An unknown value is null; a key is omitted only where absence itself is the
+	// meaning, which is not the case for any of these. "The daemon did not report
+	// this peer's IP" is a value.
 	WriteStringOrNull(w, "name", !c.client_name.empty(), c.client_name);
 	const bool has_addr = !c.ip.empty();
 	WriteStringOrNull(w, "ip", has_addr, c.ip);
@@ -3279,36 +2923,31 @@ void WriteKnownClientObject(CJsonWriter &w, const webapi::KnownClientSnapshot &c
 	w.ValueUInt(static_cast<uint64_t>(c.uploaded_bytes_total));
 	w.Key("downloaded_bytes_total");
 	w.ValueUInt(static_cast<uint64_t>(c.downloaded_bytes_total));
-	// Bare, not nulled like the two below, because 0 cannot reach here.
-	// `nLastSeen` predates the clients.met metadata trailer, so it is in
-	// the fixed credit record every accepted file version carries: written
-	// unconditionally, stamped by CClientCreditsList::GetCredit on both the
-	// create and the lookup branch, and any record loading with a value
-	// older than the 150-day expiry (0 included) is dropped rather than
-	// kept. The metadata-derived fields have no such guarantee, which is
-	// what first_seen_at gates on.
+	// Bare, not nulled like the two below, because 0 cannot reach here. nLastSeen
+	// predates the clients.met metadata trailer, so it lives in the fixed credit
+	// record every accepted file version carries, is stamped by GetCredit on both
+	// branches, and any record loading below the 150-day expiry is dropped. The
+	// metadata-derived fields have no such guarantee, which is what first_seen_at
+	// gates on.
 	w.Key("last_seen_at");
 	w.ValueUInt(static_cast<uint64_t>(c.last_seen_at));
 	const bool has_first_seen = c.first_seen_at != 0;
 	WriteUIntOrNull(w, "first_seen_at", has_first_seen, static_cast<uint64_t>(c.first_seen_at));
 	WriteUIntOrNull(w, "session_count", has_first_seen, static_cast<uint64_t>(c.session_count));
-	// Correlate with /clients by user_hash to reach the live peer. The value
-	// is reachability, not presence in that list: the daemon holds a client
-	// object from the first contact ATTEMPT, so a peer it can never reach used
-	// to read as reachable here. null when the core predates
+	// Correlate with /clients by user_hash to reach the live peer. This is
+	// reachability, not presence in that list: the daemon holds a client object
+	// from the first contact ATTEMPT. null when the core predates
 	// EC_TAG_CLIENT_CONNECTED -- unknown, not offline.
 	//
-	// `connected`, the same key the live rows carry: this is the same
-	// EC_TAG_CLIENT_CONNECTED bit reaching a persisted row by correlation, and
-	// a client joining the two by user_hash should not meet it under a second
-	// name on the far side of the join (R6).
+	// Same key as the live rows: the same bit reaching a persisted row by
+	// correlation should not meet a client under a second name on the far side of
+	// the join (R6).
 	WriteBoolOrNull(w, "connected", c.has_connected, c.connected);
 	w.EndObject();
 }
 
-// Single-client detail object (GET /clients/{ecid}, issue #422): the
-// full A-field set plus the detail-only B fields. A superset of the
-// list object, so the list schema is unaffected.
+// Single-client detail: the full list field set plus the detail-only ones, so
+// the list schema is unaffected.
 void WriteClientDetailObject(CJsonWriter &w, const webapi::ClientSnapshot &c)
 {
 	w.BeginObject();
@@ -3317,27 +2956,22 @@ void WriteClientDetailObject(CJsonWriter &w, const webapi::ClientSnapshot &c)
 	w.ValueUInt(static_cast<uint64_t>(c.ed2k_user_id));
 	w.Key("high_id");
 	w.ValueBool(c.high_id);
-	// Paired and nulled together, like ip/port/kad_port on the base row.
-	// ClientSnapshot::server_ip is documented as `"" when unknown/0`, so the
-	// empty string here is the unknown case the R10 rule spells null -- and
-	// "" is not a value an address field can legitimately take, unlike the 0
-	// that parts_offered_count uses as a real answer.
+	// Paired and nulled together, like ip/port/kad_port. server_ip is "" when
+	// unknown, and "" is not a value an address field can legitimately take,
+	// unlike the 0 parts_offered_count uses as a real answer.
 	const bool has_server = !c.server_ip.empty();
 	WriteStringOrNull(w, "server_ip", has_server, c.server_ip);
 	WriteStringOrNull(w, "server_name", has_server, c.server_name);
 	WriteIntOrNull(w, "server_port", has_server, static_cast<int64_t>(c.server_port));
-	// Nulled on the same condition WriteClientBaseFields nulls ip/port, and
-	// the same one WriteKnownClientObject uses: a client with no recorded
-	// address has no recorded Kad port either, and a raw 0 here would spell
-	// absence differently from the very fields it is paired with.
+	// Nulled on the same condition as ip/port: a client with no recorded address
+	// has no recorded Kad port either, and a raw 0 would spell absence differently
+	// from the fields it is paired with.
 	WriteIntOrNull(w, "kad_port", !c.ip.empty(), static_cast<int64_t>(c.kad_port));
-	// Friend status + the credit-system modifier (issue #423). `friend` is
-	// friends-list membership, distinct from the `friend_slot` reserved
-	// upload slot above.
+	// Friends-list membership, distinct from the `friend_slot` reserved upload
+	// slot above.
 	//
-	// The key drops the `is_` prefix per R4; the C++ member cannot follow it,
-	// because `friend` is a keyword. This is the one place on the surface
-	// where key and member deliberately differ.
+	// The key drops the `is_` prefix per R4; the C++ member cannot, because
+	// `friend` is a keyword. The one place key and member deliberately differ.
 	w.Key("friend");
 	w.ValueBool(c.is_friend);
 	w.Key("credit_ratio");
@@ -3345,13 +2979,12 @@ void WriteClientDetailObject(CJsonWriter &w, const webapi::ClientSnapshot &c)
 	w.EndObject();
 }
 
-// Base shared-file fields, shared by the list writer and the detail
-// writer. Emits keys into an already-open object (no Begin/End).
+// Base shared-file fields, emitted into an already-open object so the list and
+// detail writers share one definition.
 //
-// `detail` widens the `sources` group with the estimated range, which only
-// the detail endpoint carries. It is a parameter rather than a second
-// `w.Key("sources")` block in the detail writer because a JSON object has to
-// be emitted in one piece.
+// `detail` widens the `sources` group with the estimated range. It is a
+// parameter rather than a second block in the detail writer because a JSON
+// object has to be emitted in one piece.
 void WriteSharedBaseFields(CJsonWriter &w, const webapi::FileSnapshot &f, bool detail = false)
 {
 	w.Key("hash");
@@ -3366,18 +2999,16 @@ void WriteSharedBaseFields(CJsonWriter &w, const webapi::FileSnapshot &f, bool d
 	w.ValueString(wxString::FromUTF8(f.shared.priority.c_str()));
 	w.Key("priority_auto");
 	w.ValueBool(f.shared.priority_auto);
-	// A stated exception to R11: this wraps a single quantity on the list.
-	// The identical figure is `sources.complete` on a search result, so one
-	// access path works on every endpoint that has the concept -- cross-
-	// endpoint predictability beats R11's anti-wrapping default here.
+	// A stated exception to R11: this wraps a single quantity. The identical
+	// figure is `sources.complete` on a search result, so one access path works on
+	// every endpoint that has the concept.
 	w.Key("sources");
 	w.BeginObject();
 	w.Key("complete");
 	w.ValueInt(static_cast<int64_t>(f.shared.complete_sources));
 	if (detail) {
-		// The estimated range of that same count, so it belongs beside it
-		// rather than in the separate `complete_sources_range` object it used
-		// to occupy.
+		// The estimated range of that same count, so it belongs beside it rather
+		// than in a separate object.
 		w.Key("complete_min");
 		w.ValueInt(static_cast<int64_t>(f.shared.complete_sources_low));
 		w.Key("complete_max");
@@ -3398,10 +3029,10 @@ void WriteSharedBaseFields(CJsonWriter &w, const webapi::FileSnapshot &f, bool d
 	w.ValueInt(static_cast<int64_t>(f.shared.accepted_request_count_session));
 	w.Key("accepted_request_count_total");
 	w.ValueInt(static_cast<int64_t>(f.shared.accepted_request_count_total));
-	// Live upload activity (issue #466). `upload_speed_bytes_per_second` + `uploading`
-	// refresh every tick; `last_upload` / `shared_since` are unix seconds,
-	// null when unknown -- never uploaded, or a known.met entry that predates
-	// the field. They were 0, which reads as 1970 rather than "no idea".
+	// `upload_speed_bytes_per_second` and `uploading` refresh every tick;
+	// `last_upload` / `shared_since` are unix seconds, null when unknown -- never
+	// uploaded, or a known.met entry predating the field. They were 0, which reads
+	// as 1970 rather than "no idea".
 	w.Key("upload_speed_bytes_per_second");
 	w.ValueInt(static_cast<int64_t>(f.shared.upload_speed_bytes_per_second));
 	// Read as a boolean, held an integer.
@@ -3415,9 +3046,9 @@ void WriteSharedBaseFields(CJsonWriter &w, const webapi::FileSnapshot &f, bool d
 		"shared_since_at",
 		f.shared.shared_since != 0,
 		static_cast<std::int64_t>(f.shared.shared_since));
-	// Parts hashed so far by a Verify Local Data or an AICH hashset rebuild
-	// over this share; 0 when idle. Goes through the accessor so a shared
-	// download, which amuled reports as a partfile, still reads correctly.
+	// Parts hashed so far by a Verify Local Data or an AICH rebuild; 0 when idle.
+	// Through the accessor so a shared download, which amuled reports as a
+	// partfile, still reads correctly.
 	w.Key("hashed_part_count");
 	w.ValueInt(static_cast<int64_t>(webapi::SharedHashingProgress(f)));
 }
@@ -3426,19 +3057,16 @@ void WriteSharedObject(CJsonWriter &w, const webapi::FileSnapshot &f)
 {
 	w.BeginObject();
 	WriteSharedBaseFields(w, f);
-	// Media rides the list item, not just the detail endpoint, because the
-	// shared_added / shared_updated payload is documented to match this object
-	// byte-for-byte -- that is what lets a subscriber skip the re-GET. The
-	// event has to carry media (a metadata re-extraction is otherwise
-	// invisible: the refresh endpoints answer 202 with no result), so the list
-	// carries it too or the guarantee stops being true. Six small scalars,
-	// unlike the per-part arrays the list deliberately omits.
+	// Media rides the list item because the shared_added / shared_updated payload
+	// is documented to match this object byte-for-byte, which is what lets a
+	// subscriber skip the re-GET. The event has to carry media -- a re-extraction
+	// is otherwise invisible, since the refresh endpoints answer 202 with no
+	// result -- so the list carries it too.
 	WriteMediaIfPresent(w, f);
 	w.EndObject();
 }
 
-// GET /shared/{hash} detail: every list field plus the shared-table gaps
-// + shared-applicable identity fields. See issue #417 Part B.
+// Every list field plus the shared-table gaps and shared-applicable identity.
 void WriteSharedDetailObject(CJsonWriter &w, const webapi::FileSnapshot &f)
 {
 	w.BeginObject();
@@ -3450,17 +3078,14 @@ void WriteSharedDetailObject(CJsonWriter &w, const webapi::FileSnapshot &f)
 		f.size > 0 ? static_cast<double>(f.shared.uploaded_bytes_total) / static_cast<double>(f.size)
 			   : 0.0);
 	w.Key("directory");
-	// The on-disk directory (Temp while downloading, destination once
-	// completed) -- the same value /downloads/{hash} reports for this file.
-	// This was once masked with a placeholder while the file was incomplete,
-	// which hid nothing -- the sibling endpoint served the real value for the
-	// same file on the same tick -- and cost clients a usable field.
-	// `incomplete` below carries that state explicitly instead.
+	// The on-disk directory (Temp while downloading, destination once completed),
+	// the same value /downloads/{hash} reports. It was once masked with a
+	// placeholder while incomplete, which hid nothing and cost clients a usable
+	// field; `incomplete` below carries that state explicitly.
 	w.ValueString(wxString::FromUTF8(f.on_disk_dir.c_str()));
 	w.Key("incomplete");
-	// Always present, so clients can test it rather than probe for absence.
-	// Detail-only, like `path`: the list object and the shared_updated diff
-	// deliberately carry neither, so the SSE event rate is unaffected.
+	// Always present, so clients test it rather than probe for absence.
+	// Detail-only, like `path`, so the SSE event rate is unaffected.
 	w.ValueBool(f.IsIncompletePartfile());
 	WriteStringOrNull(w, "aich_hash", !f.aich_hash.empty(), f.aich_hash);
 	w.Key("total_part_count");
@@ -3476,18 +3101,14 @@ void WriteSharedDetailObject(CJsonWriter &w, const webapi::FileSnapshot &f)
 	w.EndObject();
 }
 
-// --- List pagination + sorting (issue #357) ---------------------------
-// Server-side window shared by every list endpoint. `limit` (default 100,
-// accepted up to 1e9), `offset`, `sort` (an endpoint-defined field) and `order`
-// (asc|desc), `after` (keyset anchor). `total`, `offset` and `limit` metadata
-// are always emitted so a paging consumer can size its requests.
+// Server-side window shared by every list endpoint: `limit` (default 100),
+// `offset`, `sort`, `order` (asc|desc) and `after` (keyset anchor). `total`,
+// `offset` and `limit` are always emitted so a paging consumer can size its
+// requests.
 //
 // `limit` DEFAULTS rather than meaning "everything when omitted". The old rule
-// was not monotonic -- 500 rows, then an error at 501, then the whole
-// collection at zero -- and it capped the explicit caller while leaving the
-// naive one unbounded, which is backwards from what a cap is for. A caller
-// that wants the whole set now says so, and an operator can see it in the
-// access log.
+// was not monotonic -- 500 rows, an error at 501, the whole collection at zero
+// -- and it capped the explicit caller while leaving the naive one unbounded.
 struct ListParams
 {
 	static const std::size_t kDefaultLimit = 100;
@@ -3502,18 +3123,15 @@ struct ListParams
 //
 // `less` is the ascending comparator. `after_less` is what makes the column
 // usable as a KEYSET anchor: given the raw `?after=` token and a row, is the
-// token ordered before that row. Only an IDENTITY column provides one --
-// anchoring on a mutable column is meaningless, because the anchor's own value
-// moves between two page requests and the window silently skips or repeats.
+// token ordered before it. Only an IDENTITY column provides one -- anchoring
+// on a mutable column is meaningless, because the anchor's own value moves
+// between two page requests and the window silently skips or repeats rows.
 //
-// Why keyset at all, when `offset` already pages: `offset` is a position, and a
-// position shifts whenever the set changes size BELOW the cursor. Delete one
-// row from an already-fetched page and every later index slides down by one,
-// so the next request starts one row late and that row is never fetched -- by
-// anything. It was not added, updated or removed, so no SSE event mentions it
-// either, which is what makes the loss permanent rather than eventually
-// repaired. Anchoring on a value instead of a count removes the arithmetic
-// that fails: `after=<hash>` means the same rows whatever happened before it.
+// Keyset rather than `offset` because an offset is a position, and a position
+// shifts whenever the set changes size BELOW the cursor: delete one row from an
+// already-fetched page and the next request starts one row late, so that row is
+// never fetched by anything. It was not added, updated or removed, so no SSE
+// event mentions it either, which makes the loss permanent.
 template <class T> struct ListSortColumn
 {
 	const char *name;
@@ -3521,14 +3139,13 @@ template <class T> struct ListSortColumn
 	std::function<bool(const std::string &, const T &)> after_less; // null == not anchorable
 };
 
-// Endpoint-specific sortable fields, in definition order. A vector (not a map)
-// so the definition site reads as an ordered list and an unknown `sort` value
-// is simply a lookup miss -> 400.
+// Endpoint-specific sortable fields, in definition order. A vector, not a map,
+// so an unknown `sort` value is simply a lookup miss and a 400.
 template <class T> using ListComparators = std::vector<ListSortColumn<T>>;
 
-// One member (possibly nested: SORT_BY(download.percent)) in ascending order.
-// Collapses what was a five-line lambda per column; the column tables are
-// long enough that the boilerplate hid what they actually sort on.
+// One member (possibly nested: SORT_BY(download.percent)) ascending. The column
+// tables are long enough that a five-line lambda per column hid what they sort
+// on.
 #define SORT_BY(field) [](const auto &a, const auto &b) { return a.field < b.field; }
 
 // The anchor half, for an identity column. Same member the column sorts on --
@@ -3536,9 +3153,8 @@ template <class T> using ListComparators = std::vector<ListSortColumn<T>>;
 #define ANCHOR_ON(field) [](const std::string &tok, const auto &r) { return tok < r.field; }
 
 // Numeric identity (an ECID). The token is parsed once per upper_bound probe,
-// which is O(log n) for the whole seek rather than per row. A token that is
-// not a number sorts before everything, so a malformed `after` yields the
-// first page instead of an error -- the same shape as an out-of-range offset.
+// so the seek is O(log n) rather than per row. A non-numeric token sorts before
+// everything, so a malformed `after` yields the first page rather than an error.
 #define ANCHOR_ON_NUM(field) \
 	[](const std::string &tok, const auto &r) { \
 		char *end = nullptr; \
@@ -3546,9 +3162,6 @@ template <class T> using ListComparators = std::vector<ListSortColumn<T>>;
 		return (end == tok.c_str()) ? true : v < static_cast<unsigned long long>(r.field); \
 	}
 
-// Sort keys for peer rows, shared by /clients and by the per-file client
-// routes -- the latter derive theirs from this set, so a key added here shows
-// up on every peer list rather than only the one it was added to.
 // One row of GET /search. The listing is built from a live EC response rather
 // than a snapshot vector, so it needs a materialised row before it can go
 // through the same envelope every other collection uses. Absent values stay
@@ -3571,9 +3184,8 @@ struct SearchListRow
 void WriteSearchListRow(CJsonWriter &w, const SearchListRow &row)
 {
 	w.BeginObject();
-	// `search_id`, the same key the SSE payloads and the results envelope
-	// already use for this value -- one spelling for a search's id across the
-	// whole surface, so a client never has to read it under two names.
+	// `search_id`, the same key the SSE payloads and the results envelope use, so
+	// a client never reads a search's id under two names.
 	w.Key("search_id");
 	w.ValueInt(static_cast<int64_t>(row.search_id));
 	w.Key("query");
@@ -3594,9 +3206,8 @@ void WriteSearchListRow(CJsonWriter &w, const SearchListRow &row)
 	w.EndObject();
 }
 
-// Sort keys for /search. The daemon hands its searches back id-ascending and id
-// order is not recency (Kad ids carry SEARCH_ID_KAD_MASK and always sort above
-// ed2k ones), so a client had nothing to rank the list by.
+// The daemon hands searches back id-ascending, and id order is not recency:
+// Kad ids carry SEARCH_ID_KAD_MASK and always sort above ed2k ones.
 const ListComparators<SearchListRow> &SearchListComparators()
 {
 	static const ListComparators<SearchListRow> kComps = {
@@ -3608,10 +3219,9 @@ const ListComparators<SearchListRow> &SearchListComparators()
 	return kComps;
 }
 
-// Sort keys for /categories. The tenth list endpoint was also the only one
-// that never parsed ?limit/&offset/&sort/&order, so the same query string was a
-// hard error on /downloads and a silent no-op here -- while the response still
-// carried the page-meta trio a caller could not influence.
+// /categories was the only list endpoint that never parsed
+// ?limit/&offset/&sort/&order, so the same query string was a hard error on
+// /downloads and a silent no-op here.
 const ListComparators<webapi::CategorySnapshot> &CategoryComparators()
 {
 	static const ListComparators<webapi::CategorySnapshot> kComps = {
@@ -3621,18 +3231,19 @@ const ListComparators<webapi::CategorySnapshot> &CategoryComparators()
 	return kComps;
 }
 
+// Sort keys for peer rows, shared by /clients and the per-file client routes,
+// which derive theirs from this set: a key added here reaches every peer list.
 const ListComparators<webapi::ClientSnapshot> &ClientComparators()
 {
 	static const ListComparators<webapi::ClientSnapshot> kComps = {
-		// Identity column: immutable, so it is the one a keyset sweep can
-		// anchor on. Listed first because that is the order a paging client
-		// cares about, not the order a UI table does.
+		// Identity column: immutable, so it is the one a keyset sweep can anchor
+		// on. Listed first because that is the order a paging client cares about.
 		{ "ecid", SORT_BY(ecid), ANCHOR_ON_NUM(ecid) },
 		{ "name", SORT_BY(client_name) },
 		{ "software", SORT_BY(software) },
-		// R7: each value is spelled exactly like the response key it orders
-		// by. Only keys this row actually emits -- /known_clients can also
-		// sort by session_count / last_seen_at, which are not on a live peer.
+		// R7: each value is spelled exactly like the response key it orders by, and
+		// only keys this row emits. /known_clients can also sort by session_count
+		// and last_seen_at, which are not on a live peer.
 		{ "uploaded_bytes_total", SORT_BY(uploaded_bytes_total) },
 		{ "downloaded_bytes_total", SORT_BY(downloaded_bytes_total) },
 		{ "upload_speed_bytes_per_second", SORT_BY(upload_speed_bytes_per_second) },
@@ -3648,17 +3259,14 @@ std::unique_ptr<CHttpServer::Response> BadRequestPtr(const char *message)
 
 // Optional unsigned query parameter, with an inclusive upper bound.
 //
-// One parser for every count on the surface. The seven written by hand
-// disagreed about the two questions that decide what a client sees -- what an
-// unparseable value does, and what an out-of-range one does -- so a typo was a
-// hard error on `interval` and a silent behaviour change on `width`, on the
-// same endpoint. Rejecting both, here, is the only version of "consistent" a
-// tenth call site cannot quietly opt out of, and the status, the code and the
-// sentence are contract rather than local wording.
+// One parser for every count on the surface: the seven written by hand
+// disagreed about what an unparseable value does and what an out-of-range one
+// does, so the same typo was a hard error on `interval` and a silent behaviour
+// change on `width`.
 //
 // Absent leaves `out` untouched, so the caller's default stands. `min` and
-// `max` are inclusive; the running value is bounded inside the loop, so a long
-// digit string cannot wrap before the range check sees it.
+// `max` are inclusive, and the running value is bounded inside the loop so a
+// long digit string cannot wrap before the range check sees it.
 std::unique_ptr<CHttpServer::Response> ParseUintParam(const std::map<std::string, std::string> &qmap,
 	const char *name,
 	std::uint64_t min,
@@ -3676,12 +3284,11 @@ std::unique_ptr<CHttpServer::Response> ParseUintParam(const std::map<std::string
 	return nullptr;
 }
 
-// Optional boolean query parameter. Accepts 1/0, true/false and yes/no, and
-// rejects anything else. Every boolean goes through here so the vocabulary
-// cannot drift per call site: `include_completed` (since replaced by
-// `status=`) used to read every other value as false while its neighbour
-// `include_parts` answered 400, so the same typo was silent on one endpoint
-// and fatal on the next.
+// Optional boolean query parameter: 1/0, true/false, yes/no, and 400 on
+// anything else. One vocabulary for the whole surface -- `include_completed`
+// used to read every other value as false while its neighbour `include_parts`
+// answered 400, so the same typo was silent on one endpoint and fatal on the
+// next.
 std::unique_ptr<CHttpServer::Response> ParseBoolParam(
 	const std::map<std::string, std::string> &qmap, const char *name, bool &out)
 {
@@ -3701,14 +3308,13 @@ std::unique_ptr<CHttpServer::Response> ParseBoolParam(
 std::unique_ptr<CHttpServer::Response> ParseListParams(const std::string &query, ListParams &out)
 {
 	const auto qmap = web_api_path::ParseQuery(query);
-	// 1e9 on both, matching each other. Past any collection that can exist, so
-	// it reads as "no upper bound" to a caller, while still rejecting a
-	// fat-fingered limit rather than treating it as "everything".
+	// 1e9 on both, past any collection that can exist, so it reads as "no upper
+	// bound" while still rejecting a fat-fingered limit.
 	//
-	// Not SIZE_MAX / UINT64_MAX: `offset + limit` has to stay inside a 32-bit
-	// size_t for the 32-bit builds, and 1e9 + 1e9 is the largest round pair
-	// that does. It is also inside JS's exact-integer range (2^53-1), so a
-	// browser client can send the ceiling and get back the number it sent.
+	// Not SIZE_MAX: `offset + limit` has to stay inside a 32-bit size_t for the
+	// 32-bit builds, and 1e9 + 1e9 is the largest round pair that does. It is also
+	// inside JS's exact-integer range, so a browser can send the ceiling and get
+	// back the number it sent.
 	if (qmap.count("limit")) {
 		std::uint64_t v = 0;
 		if (auto r = ParseUintParam(qmap, "limit", 0, 1000000000ull, v))
@@ -3739,10 +3345,9 @@ std::unique_ptr<CHttpServer::Response> ParseListParams(const std::string &query,
 	return nullptr;
 }
 
-// Stable-sort the full set (if `params.sort` is set) then slice to the
-// requested window. `out_window` is filled with pointers into `items`
-// (no element copies) and `out_total` with the pre-slice count. Returns
-// a 400 when `params.sort` is set but absent from `comparators`.
+// Stable-sort the full set then slice to the window. `out_window` is filled
+// with pointers into `items` (no copies), `out_total` with the pre-slice count.
+// 400 when `params.sort` is set but absent from `comparators`.
 template <class T>
 std::unique_ptr<CHttpServer::Response> BuildListWindowFromPtrs(std::vector<const T *> &ptrs,
 	const ListParams &params,
@@ -3766,13 +3371,12 @@ std::unique_ptr<CHttpServer::Response> BuildListWindowFromPtrs(std::vector<const
 		});
 	}
 
-	// Keyset seek. Anchored on a value, so nothing that happened to the rows
-	// before it can move the window -- see ListSortColumn.
+	// Keyset seek, anchored on a value, so nothing that happened to the rows
+	// before it can move the window.
 	//
-	// Rejected rather than ignored on a column that cannot anchor: silently
-	// falling back to the whole set would hand a paging client the first page
-	// forever, which reads as "the collection never grows" rather than as an
-	// error it can fix.
+	// Rejected rather than ignored on a column that cannot anchor: falling back to
+	// the whole set would hand a paging client the first page forever, which reads
+	// as "the collection never grows" rather than as a fixable error.
 	std::size_t seek = 0;
 	if (!params.after.empty()) {
 		if (!col || !col->after_less)
@@ -3797,11 +3401,10 @@ std::unique_ptr<CHttpServer::Response> BuildListWindowFromPtrs(std::vector<const
 	return nullptr;
 }
 
-// Sort + window a list the caller owns as values. Thin wrapper over the
-// pointer form above: an endpoint whose records are not all in one contiguous
-// vector -- /known_clients, which serves most rows straight out of a shared
-// cache and only materialises the few it has to patch -- addresses that one
-// directly instead of copying the whole set to get a vector.
+// Sort and window a list the caller owns as values. An endpoint whose records
+// are not all in one contiguous vector -- /known_clients serves most rows out
+// of a shared cache and materialises only the few it patches -- uses the
+// pointer form above instead of copying the whole set.
 template <class T>
 std::unique_ptr<CHttpServer::Response> BuildListWindow(const std::vector<T> &items,
 	const ListParams &params,
@@ -3816,15 +3419,12 @@ std::unique_ptr<CHttpServer::Response> BuildListWindow(const std::vector<T> &ite
 	return BuildListWindowFromPtrs(ptrs, params, comparators, out_window, out_total);
 }
 
-// Emit the `total` / `offset` / `limit` pagination metadata. `limit` echoes
-// the page size the caller asked for, and is null when they asked for none.
+// Emit the `total` / `offset` / `limit` pagination metadata.
 //
-// It used to report the row count instead, which is not a page size and could
-// not be used as one: a caller that stored it pinned its window to whatever
-// the first response happened to hold, and re-sending it is a 400 as soon as
-// the list is longer than the 500 cap -- the envelope handing back a value the
-// endpoint then rejects. null says what is true, that no window was applied;
-// `total` is where the row count already lives.
+// `limit` echoes the page size the caller asked for. It used to report the row
+// count instead, which is not a page size and could not be used as one: a
+// caller that stored it pinned its window to whatever the first response held,
+// and re-sending it was a 400 once the list outgrew the cap.
 void WritePageMeta(CJsonWriter &w, std::size_t total, const ListParams &params)
 {
 	w.Key("total");
@@ -3845,14 +3445,13 @@ std::string QueryOf(const CHttpServer::Request &req)
 	return query;
 }
 
-// Helper for every list endpoint's envelope: the list under its named
-// key plus #357 pagination metadata. ec_unavailable + 503 is emitted here
-// so each handler doesn't repeat the check.
-// Envelope over records the caller addresses as pointers, so an endpoint whose
-// rows are not all in one vector does not have to build one. See
-// BuildListWindowFromPtrs.
+// Envelope for every list endpoint: the list under its named key plus the
+// pagination metadata, with ec_unavailable + 503 handled here so no handler
+// repeats it. Records are addressed as pointers, so an endpoint whose rows are
+// not all in one vector need not build one.
+//
 // State-free: takes no lock of its own, so a caller already holding CState's
-// read lock can build a response inside it. m_mu is not recursive -- a second
+// read lock can build a response inside it. m_mu is NOT recursive -- a second
 // shared_lock taken while a writer is queued deadlocks -- so anything reached
 // from under WithKnownClients() must not touch the state again.
 template <class T, class WriterFn>
@@ -3901,10 +3500,8 @@ CHttpServer::Response ListResponse(const webapi::CState &state,
 	CHttpServer::Response r;
 	r.status = 200;
 	r.content_type = "application/json";
-	// envelope responses dropped snapshot_at_* — they were
-	// defeating the ETag cache by churning the body bytes
-	// every refresher tick. The ETag is now the cache
-	// validator; HTTP `Date:` is the wall-clock.
+	// No snapshot_at_* in the envelope: it churned the body bytes every refresher
+	// tick and defeated the ETag cache. The ETag is the validator now.
 	CJsonWriter w;
 	w.BeginObject();
 	w.Key(plural_key);
@@ -3920,31 +3517,24 @@ CHttpServer::Response ListResponse(const webapi::CState &state,
 
 } // namespace
 
-// ===================================================================
-// Mutation helpers — shared by every Handle{Resource}{Patch,Add,
-// Delete} below. Every mutation handler follows:
+// Mutation helpers. Every mutation handler follows:
 //  1. AuthenticateRequest (bearer or cookie)
-//  2. RequireAdmin (mutations are admin-only)
-//  3. Parse JSON body
-//  4. Send EC mutation packet via SendRecvSerialized
-//  5. EC_OP_NOOP = success; EC_OP_FAILED carries amuled's rejection
-//  6. Run RefresherTick inline on the HTTP thread so the response
-//     sees post-mutation state (vs. next refresher tick ~1 s later)
-//  7. Return the updated resource (or 201 / 204 per HTTP convention)
-// ===================================================================
+//  2. RequireAdmin
+//  3. parse the JSON body
+//  4. SendRecvSerialized the EC packet
+//  5. EC_OP_NOOP is success; EC_OP_FAILED carries amuled's rejection
+//  6. run RefresherTick inline so the response sees post-mutation state
+//  7. return the updated resource, or 201 / 204 per HTTP convention
 
 namespace
 {
 
-// JSON body parser. Returns true on success; false + `err` on
-// failure. Non-object roots are rejected.
+// JSON body parser: true on success, false + `err` otherwise. Non-object roots
+// are rejected.
 //
-// Pre-parse depth cap, so a deeply nested body cannot exhaust the
-// handler thread's stack inside picojson's recursive descent. The
-// scanner and the reasoning behind it live in JsonDepthScan.h, which
-// keeps it reachable from JsonDepthScanTest. CJwt::Verify caps its
-// own parses for the same reason, by a cruder count that suits the
-// payloads it sees -- see the note there.
+// The depth cap runs before the parse, so a deeply nested body cannot exhaust
+// the handler thread's stack inside picojson's recursive descent. The scanner
+// lives in JsonDepthScan.h, which keeps it reachable from its test.
 bool ParseJsonObjectBody(const std::string &body, picojson::value &out, std::string &err)
 {
 	if (!webapi::JsonNestingWithinLimit(body)) {
@@ -3963,11 +3553,9 @@ bool ParseJsonObjectBody(const std::string &body, picojson::value &out, std::str
 	return true;
 }
 
-// Surfaces the EC_OP_FAILED reply shape from amuled. The standard
-// amuled failure response carries one or more EC_TAG_STRING children
-// with the rejection message; we relay the first one to the client.
-// Returns true if the response was an error (caller short-circuits);
-// false on EC_OP_NOOP or any other "success" shape.
+// Relay the EC_OP_FAILED reply shape: amuled carries the rejection message in
+// EC_TAG_STRING children, and the first is passed to the client. True means the
+// caller short-circuits.
 bool IsEcFailedResponse(const CECPacket *resp, std::string &out_msg)
 {
 	if (!resp)
@@ -3985,21 +3573,16 @@ bool IsEcFailedResponse(const CECPacket *resp, std::string &out_msg)
 	return true;
 }
 
-// The two category ops answer EC_OP_FAILED for a *partial success*, not a
-// failure: amuled created or updated the category and then found it could not
-// use the path, so it kept another one -- the incoming directory for a create,
-// the previous path for an update -- and returns that path in
-// EC_TAG_CATEGORY_PATH beside the category index (ExternalConn.cpp,
-// EC_OP_CREATE_CATEGORY / EC_OP_UPDATE_CATEGORY, and the rewrite in
-// CEC_Category_Tag::Create / ::Apply). An update keeps name, comment, colour
-// and priority in that case; only the path is refused.
+// The two category ops answer EC_OP_FAILED for a PARTIAL SUCCESS, not a
+// failure: amuled created or updated the category, found it could not use the
+// path, kept another one -- the incoming directory for a create, the previous
+// path for an update -- and returns that in EC_TAG_CATEGORY_PATH beside the
+// index. An update keeps name, comment, colour and priority; only the path is
+// refused.
 //
-// The desktop reads exactly this: CCatHandler::HandlePacket corrects its local
-// copy from the tag and tells the user "keeping directory ...". Relaying it as
-// a 400 instead says the request failed while the category exists, and throws
-// away the one field that says what happened.
-//
-// A reply carrying no such tag is a genuine failure.
+// Relaying it as a 400 would say the request failed while the category exists,
+// and discard the one field that says what happened. A reply carrying no such
+// tag is a genuine failure.
 bool EcCategoryPathKept(const CECPacket *resp, std::string &kept_path)
 {
 	if (!resp || resp->GetOpCode() != EC_OP_FAILED)
@@ -4011,28 +3594,20 @@ bool EcCategoryPathKept(const CECPacket *resp, std::string &kept_path)
 	return true;
 }
 
-// Map our wire-string priorities back to amule's PR_* encoding -- the inverse of
-// PriorityName in Refresher.cpp, which is likewise one function for all three
-// resources. PR_AUTO=5 is the magic value stored as High plus the auto flag.
-// The one place the file-priority vocabulary is declared.
+// Map our wire-string priorities back to amule's PR_* encoding, the inverse of
+// PriorityName in Refresher.cpp. PR_AUTO=5 is the magic value stored as High
+// plus the auto flag. The one place the file-priority vocabulary is declared.
 //
-// /downloads, /shared and /categories all speak the PR_* code space and differ
-// only in which names they accept, which is how three near-identical converters
-// came to exist: adding or renaming a level was a multi-site edit with no
-// compiler help, and each call site additionally spelled its accepted set out
-// again in a rejection string.
+// /downloads, /shared and /categories share the PR_* code space and differ only
+// in which names they accept, and those differences are deliberate. The
+// .part.met loader clamps anything but PR_LOW/PR_NORMAL/PR_HIGH back to Normal
+// on restart, so very_low and release are upload-side levels and are refused on
+// the download path. Categories apply their priority to member files as a
+// download priority (CDownloadQueue::SetCatPrio), so they inherit that set.
 //
-// The differences in what each accepts are deliberate and stay. The .part.met
-// loader clamps anything but PR_LOW/PR_NORMAL/PR_HIGH back to Normal on
-// restart, so very_low and release are upload-side levels only and are refused
-// on the download path on purpose. Categories apply their priority to member
-// files as a download priority (CDownloadQueue::SetCatPrio ->
-// CPartFile::SetDownPriority), so they inherit the download set.
-//
-// Servers are deliberately NOT in this table. SRV_PR_* is a different code
-// space in which the same word means a different number -- `low` is 0 for a
-// file and 2 for a server -- so folding them together would produce one table
-// that lies about half its rows. ServerPriorityCode stays where it is.
+// Servers are deliberately NOT here: SRV_PR_* is a different code space in
+// which the same word means a different number -- `low` is 0 for a file and 2
+// for a server -- so one table would lie about half its rows.
 enum PriorityDomain : unsigned
 {
 	kPrioDownload = 1u << 0,
@@ -4048,11 +3623,10 @@ struct FilePriorityLevel
 };
 
 const FilePriorityLevel kFilePriorities[] = {
-	// R9: a writable field accepts the values the same field returns. A
-	// category's `priority` is rendered by PriorityName(), which can answer
-	// very_low and release, so the write side has to admit them -- it used to
-	// reject exactly the two values a round-trip could hand back. The download
-	// domain stays narrow because its read side cannot produce them either.
+	// R9: a writable field accepts the values the same field returns. A category's
+	// `priority` is rendered by PriorityName(), which can answer very_low and
+	// release, so the write side must admit them. The download domain stays narrow
+	// because its read side cannot produce them.
 	{ "very_low", PR_VERY_LOW, kPrioShared | kPrioCategory },
 	{ "low", PR_LOW, kPrioDownload | kPrioShared | kPrioCategory },
 	{ "normal", PR_NORMAL, kPrioDownload | kPrioShared | kPrioCategory },
@@ -4072,9 +3646,9 @@ bool FilePriorityToCode(const std::string &name, unsigned domain, std::uint8_t &
 	return false;
 }
 
-// The rejection names exactly what this domain accepts, built from the table
-// rather than restated at each call site -- five sites had their own copy, so a
-// new level would have been announced in some of them and not others.
+// The rejection names exactly what this domain accepts, built from the table:
+// five sites had their own copy, so a new level would have been announced in
+// some and not others.
 std::string FilePriorityAccepted(unsigned domain)
 {
 	std::string out;
@@ -4088,12 +3662,10 @@ std::string FilePriorityAccepted(unsigned domain)
 	return "`priority` must be one of " + out;
 }
 
-// The three "fetch a list from a URL" endpoints — /servers_update,
-// /kad/update and /ipfilter/update — are the same operation over three
-// different lists: take one http(s) URL, hand it to amuled in a single
-// string tag, echo the effective URL back with a 202. amuled persists the
-// URL into the matching preference itself in all three cases, so none of
-// them also PATCHes it here.
+// /servers_update, /kad/update and /ipfilter/update are the same operation over
+// three lists: take one http(s) URL, hand it to amuled in a single string tag,
+// echo the effective URL back with a 202. amuled persists the URL into the
+// matching preference itself, so none of them also PATCHes it here.
 struct UrlFetchSpec
 {
 	// JSON body field carrying the URL, and the key echoed in the reply.
@@ -4106,21 +3678,18 @@ struct UrlFetchSpec
 	// false: an absent field falls back to the configured URL the caller
 	// passes in, instead of being a 400.
 	bool url_required;
-	// Run an inline RefresherTick so the caches (and the SSE diff built
-	// from them) pick up whatever already landed. Only worth it where the
-	// result shows up in a cache this process holds.
+	// Run an inline RefresherTick so the caches, and the SSE diff built from them,
+	// pick up whatever already landed.
 	bool refresh_after;
 };
 
-// Pull the URL out of the request body per `spec`, falling back to
-// `configured` when the body omits it and the spec allows that. Returns
-// false with `rejection` filled on any rejection.
+// Pull the URL out of the body per `spec`, falling back to `configured` when
+// the body omits it and the spec allows it.
 //
-// `configured` is null when there is no fallback to offer — always for a
-// url_required spec, and for the others while amuleapi has no preferences
-// snapshot yet. A request that carries its own URL is unaffected either
-// way; one that needs the fallback then gets a 503 rather than a 400
-// blaming a URL that simply has not been read yet.
+// `configured` is null when there is no fallback: always for a url_required
+// spec, and for the others while amuleapi has no preferences snapshot yet. A
+// request needing the fallback then gets a 503 rather than a 400 blaming a URL
+// that simply has not been read yet.
 bool ResolveFetchUrl(const CHttpServer::Request &req,
 	const UrlFetchSpec &spec,
 	const std::string *configured,
@@ -4169,19 +3738,17 @@ bool ResolveFetchUrl(const CHttpServer::Request &req,
 				(field + " was omitted and no URL is configured").c_str());
 			return false;
 		}
-		// A configured URL predates this request — it came in over
-		// PATCH /preferences or amuled's own config file — so it is not
-		// re-validated here. Sending it is what the desktop button does.
+		// A configured URL predates this request, arriving over PATCH /preferences
+		// or amuled's config, so it is not re-validated here.
 		return true;
 	}
 	if (out_url.empty()) {
 		rejection = ErrorResponse(400, "bad_request", (field + " must not be empty").c_str());
 		return false;
 	}
-	// Light hygiene check — amuled hands the string straight to the HTTP
-	// downloader, so a bad scheme would otherwise fail asynchronously with
-	// nowhere to report it. Rejecting here also gives a clearer error than
-	// the EC "amuled rejected" wrapper.
+	// amuled hands the string straight to the HTTP downloader, so a bad scheme
+	// would fail asynchronously with nowhere to report it. Rejecting here also
+	// beats the EC "amuled rejected" wrapper for clarity.
 	if (out_url.compare(0, 7, "http://") != 0 && out_url.compare(0, 8, "https://") != 0) {
 		rejection = ErrorResponse(
 			400, "bad_request", (field + " must be an http:// or https:// URL").c_str());
@@ -4219,20 +3786,18 @@ CHttpServer::Response UrlFetchOp(
 	return r;
 }
 
-// JSON has one number type and picojson hands every one of them over as a
-// double, so a body field documented as an integer has to say so itself:
-// without this, `{"min_size_bytes": 2.9}` is accepted and silently truncated
-// to 2. One helper rather than a cast per site: `v != (double)(int)v` cannot
-// judge a byte count above INT_MAX, which is exactly the range the size
-// fields live in.
+// JSON has one number type and picojson hands every one over as a double, so a
+// field documented as an integer must say so: without this,
+// `{"min_size_bytes": 2.9}` is accepted and silently truncated. One helper
+// rather than a cast per site, because `v != (double)(int)v` cannot judge a
+// byte count above INT_MAX, which is the range these fields live in.
 inline bool IsIntegralJsonNumber(double v)
 {
 	return std::isfinite(v) && v == std::floor(v);
 }
 
-// MD4 hex string → CMD4Hash. Returns false if the string isn't 32
-// lowercase-or-uppercase hex chars (we tolerate both cases; the
-// route already lowercases what comes off the URL).
+// MD4 hex to CMD4Hash; false unless 32 hex chars. Either case is tolerated --
+// the route already lowercases what comes off the URL.
 bool HashFromHex(const std::string &hex, CMD4Hash &out)
 {
 	if (hex.size() != 32)
@@ -4240,14 +3805,11 @@ bool HashFromHex(const std::string &hex, CMD4Hash &out)
 	return out.Decode(wxString::FromAscii(hex.c_str()));
 }
 
-// The {hash} twin of RequireEcidPath: a path hash that is not 32 hex
-// characters is a malformed request, not a missing file. The find-based
-// routes used to skip the format check and fall through to their own 404,
-// so a client could not tell "not a hash" from "valid hash, no such file" --
-// and the split ran through a single route, GET
-// /search/results/{hash}/comments answering 404 where its own POST answered
-// 400. Same reason RequireEcidPath exists: the status, the code and the
-// sentence are contract, not local wording.
+// The {hash} twin of RequireEcidPath: a path hash that is not 32 hex characters
+// is a malformed request, not a missing file. The find-based routes used to
+// skip the check and fall through to their own 404, so a client could not tell
+// "not a hash" from "valid hash, no such file" -- and the split ran through a
+// single route, whose GET answered 404 where its own POST answered 400.
 std::unique_ptr<CHttpServer::Response> RequireHashPath(const std::string &hash)
 {
 	CMD4Hash parsed;
@@ -4265,22 +3827,16 @@ CHttpServer::Response CApiDispatcher::HandleDownloads(const CHttpServer::Request
 	if (!a.ok)
 		return a.rejection;
 
-	// `?status=` selects which part of the queue to list. amuled holds
-	// finished downloads in `m_completedDownloads` as a separate
-	// "awaiting clear" list, so a caller reading "what is currently
-	// transferring" and one reading "what finished" want different rows.
+	// `?status=` selects which part of the queue to list: amuled holds finished
+	// downloads in m_completedDownloads as a separate "awaiting clear" list, so
+	// "what is transferring" and "what finished" are different row sets.
 	//
-	// This replaces `?include_completed=`, a boolean over an axis with three
-	// states: it could say active-only and active-plus-completed, but there
-	// was no way to ask for completed-only, which is the third state the
-	// collection has and the one a Finished view needs. It also named the
-	// mechanism rather than the axis -- a client reading
-	// include_completed=false could not tell whether the excluded rows were
-	// hidden or absent. `status` is the key the download object already
-	// reports, so the filter and the field now agree.
+	// It replaced `?include_completed=`, a boolean over a three-state axis:
+	// there was no way to ask for completed-only, which is what a Finished view
+	// needs. `status` is the key the download object already reports, so filter
+	// and field agree.
 	//
-	// The detail endpoint GET /downloads/{hash} is unaffected: the caller
-	// asked for that specific file.
+	// GET /downloads/{hash} is unaffected: the caller named the file.
 	enum class DownloadsFilter
 	{
 		Active,
@@ -4319,14 +3875,12 @@ CHttpServer::Response CApiDispatcher::HandleDownloads(const CHttpServer::Request
 	if (auto err = ParseListParams(QueryOf(req), params))
 		return *err;
 	static const ListComparators<webapi::FileSnapshot> kComps = {
-		// Identity column: immutable, so it is the one a keyset sweep can
-		// anchor on. Listed first because that is the order a paging client
-		// cares about, not the order a UI table does.
+		// Identity column: immutable, so it is what a keyset sweep anchors on.
+		// Listed first because that is the order a paging client cares about.
 		{ "hash", SORT_BY(hash), ANCHOR_ON(hash) },
 		{ "name", SORT_BY(name) },
-		// R7: each value is spelled exactly like the response key it orders
-		// by, dotted for a nested one, so a field rename can never orphan a
-		// sort value and the reference needs no mapping table.
+		// R7: each value is spelled exactly like the response key it orders by,
+		// dotted for a nested one, so a field rename cannot orphan a sort value.
 		{ "size_bytes", SORT_BY(size) },
 		{ "progress.percent", SORT_BY(download.percent) },
 		{ "speed_bytes_per_second", SORT_BY(download.speed_bytes_per_second) },
@@ -4355,9 +3909,8 @@ CHttpServer::Response CApiDispatcher::HandleDownloads(const CHttpServer::Request
 			"downloads",
 			ptrs,
 			[](CJsonWriter &w, const webapi::FileSnapshot &d) {
-				// List mode — omit `progress.parts` (Q2 + the per-list
-				// shape: omitting parts keeps the list response compact,
-				// detail endpoint is where parts ship).
+				// List mode omits `progress.parts`; the detail endpoint is where
+				// parts ship.
 				WriteDownloadObject(w, d, /*include_parts=*/false);
 			},
 			params,
@@ -4377,11 +3930,9 @@ struct FileClientRow
 	bool a4af = false;
 	std::vector<bool> parts;
 	bool has_parts = false;
-	// Whether each index actually addresses a chunk of THIS file that this
-	// row also carries a bitmap for. Resolved in the handler, which is the
-	// only place that knows part_count; false here means the key goes out as
-	// null. Not a copy of `include_parts` -- that is the same on every row,
-	// so it is passed to WriteFileClientRow rather than stored per row.
+	// Whether each index actually addresses a chunk of THIS file that this row
+	// also carries a bitmap for. Resolved in the handler, the only place that
+	// knows part_count; false means the key goes out as null.
 	bool next_requested_part_known = false;
 	bool last_downloading_part_known = false;
 };
@@ -4391,11 +3942,9 @@ struct FileClientRow
 const ListComparators<FileClientRow> &FileClientComparators()
 {
 	static const ListComparators<FileClientRow> kComps = [] {
-		// Both halves are lifted, not just the comparator: a column that can
-		// anchor a keyset page on /clients has to anchor one here too, or the
-		// two surfaces drift in exactly the way this derivation exists to
-		// prevent -- and the drift would only show up as a paging client
-		// silently missing rows on one of them.
+		// Both halves are lifted, not just the comparator: a column that can anchor
+		// a keyset page on /clients must anchor one here too, or the two surfaces
+		// drift and it shows up only as a paging client silently missing rows.
 		ListComparators<FileClientRow> out;
 		for (const auto &col : ClientComparators()) {
 			auto less = col.less;
@@ -4419,16 +3968,14 @@ void WriteFileClientRow(CJsonWriter &w, const FileClientRow &row, bool include_p
 {
 	w.BeginObject();
 	WriteClientBaseFields(w, row.client);
-	// This client's relation to THIS file, which the global /clients row
-	// cannot express: "downloading_from" means we pull the file from it,
-	// "uploading_to" means it pulls the file from us, "both" is each way, and
-	// "none" is a row that exists only because it is parked here as an A4AF
-	// source.
+	// This client's relation to THIS file, which the global /clients row cannot
+	// express: "downloading_from" is we pull from it, "uploading_to" is it pulls
+	// from us, "both" is each way, and "none" is a row that exists only because it
+	// is parked here as an A4AF source.
 	w.Key("role");
 	w.ValueString(wxString::FromUTF8(row.role.c_str()));
 	// Orthogonal to role on purpose: a peer can be parked on another file and
-	// still be pulling this one from us, which a fourth role value could not
-	// represent.
+	// still be pulling this one from us, which a fourth role value could not say.
 	w.Key("a4af");
 	w.ValueBool(row.a4af);
 	if (row.has_parts) {
@@ -4439,21 +3986,16 @@ void WriteFileClientRow(CJsonWriter &w, const FileClientRow &row, bool include_p
 		}
 		w.EndArray();
 	}
-	// The two chunks the desktop's source bar paints on top of the bitmap:
-	// the one in flight and the one queued behind it
-	// (GenericClientListCtrl.cpp: crPending and crNextPending). They live on
-	// the row rather than in WriteClientBaseFields for the same reason
-	// `parts` does -- they describe a peer's relation to ONE file, not the
-	// peer -- which also keeps them out of the shared SSE client payload,
-	// where a value that moves every tick would be noise no listener renders.
+	// The two chunks the desktop's source bar paints on the bitmap: the one in
+	// flight and the one queued behind it (GenericClientListCtrl.cpp, crPending
+	// and crNextPending). They sit on the row rather than in
+	// WriteClientBaseFields because they describe a peer's relation to ONE file,
+	// which also keeps them out of the shared SSE client payload where a value
+	// moving every tick would be noise.
 	//
-	// Gated on include_parts because an index is meaningless without the
-	// bitmap it indexes: a caller that did not ask for `parts` does not know
-	// the file's part count and has no bar to paint the stripe on. Under the
-	// flag both keys are always present -- null, never omitted, on a row
-	// where the index does not apply -- so one query yields one row shape.
-	// Unlike `parts`, whose absence is the only way to say "no bitmap of the
-	// right length exists", these have a null to say it with.
+	// Gated on include_parts: an index is meaningless without the bitmap it
+	// indexes. Under the flag both keys are always present, null rather than
+	// omitted where the index does not apply, so one query yields one row shape.
 	if (include_parts) {
 		WriteIntOrNull(w,
 			"next_requested_part_index",
@@ -4467,11 +4009,10 @@ void WriteFileClientRow(CJsonWriter &w, const FileClientRow &row, bool include_p
 	w.EndObject();
 }
 
-// Resolve one peer's bitmap for `part_count` chunks of the file this row is
-// about, following the two wire conventions: an "all" flag means the core sent
-// an empty tag for a full source, and a decoded bitmap that cannot cover the
-// file is dropped rather than padded (its tail beyond part_count is the
-// buffer's byte padding, which is fine to trim).
+// Resolve one peer's bitmap for `part_count` chunks, following the two wire
+// conventions: an "all" flag means the core sent an empty tag for a full
+// source, and a bitmap that cannot cover the file is dropped rather than
+// padded.
 bool ResolvePartBitmap(const std::vector<bool> &bits,
 	bool all,
 	bool present,
@@ -4493,12 +4034,10 @@ bool ResolvePartBitmap(const std::vector<bool> &bits,
 }
 } // namespace
 
-// Serves both /downloads/{hash}/clients and /shared/{hash}/clients. The rows
-// are the same object out of the same cache either way -- the relation to the
-// file is a field, not a path -- so the two routes differ only in which role
-// the hash must already have, which is what makes each a sub-resource of its
-// own collection. A partfile with at least one completed chunk is in both
-// collections at once and answers identically on both.
+// Serves both /downloads/{hash}/clients and /shared/{hash}/clients: the rows
+// are the same object out of the same cache, since the relation to the file is
+// a field rather than a path. The routes differ only in which role the hash
+// must already have. A partfile with one completed chunk is in both at once.
 CHttpServer::Response CApiDispatcher::HandleFileClients(
 	const CHttpServer::Request &req, const std::string &key, bool require_downloading)
 {
@@ -4547,42 +4086,33 @@ CHttpServer::Response CApiDispatcher::HandleFileClients(
 		}
 
 		FileClientRow row;
-		// R12: named by direction. The old pair was `source` / `peer`, which is
-		// not even one axis -- `source` names a relation to the file, `peer`
-		// names the entity -- and `peer` was the last contract-level use of that
-		// word outside /chats.
+		// R12: named by direction. The old pair was `source` / `peer`, which is not
+		// one axis -- `source` names a relation to the file, `peer` the entity.
 		row.role = is_source && is_peer
 				   ? "both"
 				   : (is_source ? "downloading_from" : (is_peer ? "uploading_to" : "none"));
 		row.a4af = is_a4af;
 		ComputePartProgressPercent(m_state, client);
 		if (include_parts) {
-			// Which bitmap belongs to this row follows its direction: the
-			// download map describes the file we pull from the peer, the
-			// upload map the file it pulls from us, and for a "both" row
-			// those are this same file seen from each side. A pure A4AF row
-			// has no bitmap for this file at all.
+			// Which bitmap belongs to this row follows its direction: the download map
+			// is the file we pull from the peer, the upload map the file it pulls from
+			// us. A pure A4AF row has no bitmap for this file at all.
 			if (is_source) {
 				row.has_parts = ResolvePartBitmap(client.part_status,
 					client.part_status_all,
 					client.has_part_status,
 					part_count,
 					row.parts);
-				// The two part indices are indices into that download
-				// map, so they address this file only on a source row.
-				// On a pure "peer" or A4AF row they belong to whatever
-				// else the peer is pulling and must not be relayed as
-				// though they described this one -- left false, they go
-				// out as null.
+				// Both indices address the download map, so they describe
+				// THIS file only on a source row. On a pure peer or A4AF row
+				// they belong to whatever else the peer is pulling; left
+				// false, they go out as null.
 				//
-				// `row.has_parts` is part of the test, not just the
-				// role: ResolvePartBitmap declines a source that has
-				// sent no part status yet, and one whose decoded bitmap
-				// cannot cover the file. Either way the row ships no
-				// `parts`, and a stripe coordinate with no bar to paint
-				// it on is the exact thing the gating exists to prevent.
-				// Ordering matters -- both reads happen after the
-				// ResolvePartBitmap call above has set it.
+				// has_parts is part of the test, not just the role:
+				// ResolvePartBitmap declines a source that has sent no part
+				// status, or whose bitmap cannot cover the file, and a stripe
+				// coordinate with no bar to paint it on is what the gating
+				// exists to prevent. Both reads must follow that call.
 				row.next_requested_part_known =
 					row.has_parts &&
 					webapi::UsablePartIndex(client.has_next_requested_part,
@@ -4623,20 +4153,12 @@ CHttpServer::Response CApiDispatcher::HandleClients(const CHttpServer::Request &
 	if (!a.ok)
 		return a.rejection;
 
-	// Optional `?activity=uploading | downloading | active` query parameter.
-	// `activity`, not `filter`: "filter" named the mechanism rather than the
-	// axis being filtered on, and every list endpoint filters somehow. The
-	// values are client states, so they are spelled the way the client's own
-	// `upload_state` / `download_state` spell them rather than as plural
-	// nouns for the transfers.
-	// `uploading`   → clients actively transferring TO us (upload_state ==
-	//                "uploading"). Subset that maps to the legacy
-	//                amuleweb "Uploads" page.
-	// `downloading` → clients we're actively pulling FROM (download_state
-	//                == "downloading").
-	// `active`      → union of the two; everything currently moving
-	//                bytes either direction.
-	// No activity → every client the daemon knows about (the default).
+	// Optional `?activity=uploading | downloading | active`.
+	//
+	// `activity`, not `filter`: "filter" named the mechanism rather than the axis,
+	// and every list endpoint filters somehow. The values are client states, so
+	// they are spelled the way `upload_state` / `download_state` spell them.
+	// `active` is the union of the two; absent means every client the daemon knows.
 	std::string activity;
 	{
 		std::string query;
@@ -4672,10 +4194,9 @@ CHttpServer::Response CApiDispatcher::HandleClients(const CHttpServer::Request &
 			clients.end());
 	}
 
-	// Same derived field the per-file rows and the detail object carry. It
-	// was omitted here, which left the SSE payload (which always carries it)
-	// contradicting both EVENTS.md's "same field set as the /clients list
-	// row" and REFERENCE.md's claim that it is detail-only.
+	// Same derived field the per-file rows and the detail object carry. Omitted
+	// here, it left the SSE payload contradicting EVENTS.md's "same field set as
+	// the /clients list row".
 	for (auto &client : clients) {
 		ComputePartProgressPercent(m_state, client);
 	}
@@ -4696,29 +4217,24 @@ CHttpServer::Response CApiDispatcher::HandleSharedList(const CHttpServer::Reques
 	if (auto err = ParseListParams(QueryOf(req), params))
 		return *err;
 	static const ListComparators<webapi::FileSnapshot> kComps = {
-		// Identity column: immutable, so it is the one a keyset sweep can
-		// anchor on. Listed first because that is the order a paging client
-		// cares about, not the order a UI table does.
+		// Identity column: immutable, so it is what a keyset sweep anchors on.
+		// Listed first because that is the order a paging client cares about.
 		{ "hash", SORT_BY(hash), ANCHOR_ON(hash) },
 		{ "name", SORT_BY(name) },
-		// R7: spelled like the response key it orders by. The upload-side
-		// pair rather than /downloads' progress.percent / status: those
-		// describe a transfer this row does not report.
+		// R7: spelled like the response key it orders by. The upload-side pair
+		// rather than /downloads' progress.percent, which this row does not report.
 		{ "size_bytes", SORT_BY(size) },
 		{ "uploaded_bytes_total", SORT_BY(shared.uploaded_bytes_total) },
 		{ "upload_speed_bytes_per_second", SORT_BY(shared.upload_speed_bytes_per_second) },
 	};
 	if (auto r = RequireSnapshot(m_state))
 		return *r;
-	// Pointers into the live map rather than copies -- this was the single
-	// biggest allocation the daemon made per request. Serialising inside the
-	// read lock is safe because WriteSharedObject reads only the snapshot it is
-	// handed, so ListResponseFromPtrsUnlocked's "must not re-enter CState"
-	// contract holds.
+	// Pointers into the live map rather than copies -- the single biggest
+	// allocation the daemon made per request. Safe inside the read lock because
+	// WriteSharedObject reads only the snapshot it is handed.
 	CHttpServer::Response resp;
-	// Named captures rather than [&]: [&] would pull `this` in, putting
-	// m_state within reach of a callback that must not touch it. kComps is
-	// static, so it is in scope without being captured.
+	// Named captures rather than [&]: [&] would pull `this` in, putting m_state
+	// within reach of a callback that must not touch it.
 	m_state.WithFiles([&resp, &params](const webapi::FileMap &files) {
 		std::vector<const webapi::FileSnapshot *> ptrs;
 		ptrs.reserve(files.size());
@@ -4744,22 +4260,18 @@ CHttpServer::Response CApiDispatcher::HandleDownloadDetail(
 	if (auto r = RequireSnapshot(m_state))
 		return *r;
 
-	// {hash} is the 32-char lowercase-hex MD4. URL is case-tolerant;
-	// State writes lowercase, so we down-case the capture before the
-	// O(1) m_hash_to_ecid lookup.
+	// {hash} is the 32-char MD4. The URL is case-tolerant and State keys are
+	// lowercase, so down-case before the O(1) lookup.
 	webapi::FileSnapshot d;
 	if (!FindDownloadByKey(m_state, key, d)) {
 		return ErrorResponse(404, "not_found", "no download with that hash");
 	}
 
-	// Bare object per Q3: list endpoint envelopes, detail endpoint
-	// is the resource itself. No `snapshot_at` here — clients that
-	// need freshness metadata can read the list endpoint.
+	// Bare object: list endpoints carry an envelope, a detail endpoint is the
+	// resource itself.
 	//
-	// `include_parts=true` adds `progress.parts: [...]` to the
-	// response. List endpoint omits this — `parts` can be 100K+
-	// entries for a multi-TiB download (Q2: no cap), which clients
-	// don't need to walk through when paging the queue overview.
+	// `include_parts=true` adds `progress.parts`, which the list omits: it can be
+	// 100K+ entries for a multi-TiB download, uncapped.
 	CHttpServer::Response r;
 	r.status = 200;
 	r.content_type = "application/json";
@@ -4782,17 +4294,15 @@ CHttpServer::Response CApiDispatcher::HandleSharedDetail(
 	if (auto r = RequireSnapshot(m_state))
 		return *r;
 
-	// {hash} is the 32-char MD4; URL is case-tolerant, State keys are
-	// lowercase — down-case before the O(1) lookup (mirrors the download
-	// detail handler).
+	// {hash} is the 32-char MD4; down-case before the O(1) lookup, mirroring the
+	// download detail handler.
 	webapi::FileSnapshot s;
 	if (!FindSharedByKey(m_state, key, s)) {
 		return ErrorResponse(404, "not_found", "no shared file with that hash");
 	}
 
-	// Bare object (the detail resource itself), same shape contract as
-	// GET /downloads/{hash}: every GET /shared list field plus the
-	// Part-B detail fields.
+	// Bare object, same shape contract as GET /downloads/{hash}: every list field
+	// plus the detail-only ones.
 	CHttpServer::Response r;
 	r.status = 200;
 	r.content_type = "application/json";
@@ -4827,8 +4337,7 @@ CHttpServer::Response CApiDispatcher::HandleDownloadComments(
 	w.BeginObject();
 	w.Key("total");
 	w.ValueInt(static_cast<int64_t>(d.download.source_comments.size()));
-	// True while an on-demand Kad notes lookup is in flight (issue #434); poll
-	// this endpoint until it flips back to false to observe retrieved notes.
+	// True while an on-demand Kad notes lookup is in flight; poll until it flips.
 	w.Key("kad_comment_lookup_running");
 	w.ValueBool(d.download.kad_comment_searching);
 	w.Key("comments");
@@ -4851,10 +4360,9 @@ CHttpServer::Response CApiDispatcher::HandleDownloadComments(
 	return r;
 }
 
-// POST /downloads/{hash}/comments — trigger an on-demand Kad NOTES lookup for
-// this download (issue #434). The lookup is asynchronous on amuled (up to ~45s);
-// retrieved community ratings/comments subsequently appear via GET on the same
-// path, alongside per-source comments. Returns 202 Accepted.
+// Trigger an on-demand Kad NOTES lookup for this download. Asynchronous on
+// amuled (up to ~45s); retrieved ratings appear via GET on the same path,
+// alongside per-source comments.
 CHttpServer::Response CApiDispatcher::HandleDownloadCommentsKadSearch(
 	const CHttpServer::Request &req, const std::string &key)
 {
@@ -4897,11 +4405,9 @@ CHttpServer::Response CApiDispatcher::HandleDownloadCommentsKadSearch(
 	delete ec_resp;
 
 	CHttpServer::Response r;
-	// 202 with no body. The field it used to carry could hold exactly one
-	// value, so it said nothing the status code had not already said -- and
-	// `status` everywhere else on this surface is a transfer state
-	// (downloading, paused, hashing), so a client switching on it had to know
-	// which kind of object it was holding first.
+	// 202 with no body. The field it used to carry could hold exactly one value,
+	// so it said nothing the status code had not -- and `status` everywhere else
+	// on this surface is a transfer state.
 	r.status = 202;
 	r.content_type.clear();
 	return r;
@@ -4951,9 +4457,8 @@ CHttpServer::Response CApiDispatcher::HandleDownloadFilenames(
 namespace
 {
 
-// Defined further down beside its FindServerByEcid / FindFriendByEcid
-// siblings; declared here so the A4AF handlers below can validate a
-// `client_ecid` without moving the helper away from its family or copying it.
+// Defined below beside its FindServerByEcid / FindFriendByEcid siblings;
+// declared here so the A4AF handlers can validate a `client_ecid`.
 bool FindClientByEcid(const webapi::CState &state, std::uint32_t ecid, webapi::ClientSnapshot &out);
 
 void WriteA4afObject(CJsonWriter &w, const webapi::FileSnapshot &d)
@@ -5008,11 +4513,9 @@ CHttpServer::Response CApiDispatcher::HandleDownloadA4afAction(
 	else if (action == "swap_others")
 		op = EC_OP_PARTFILE_SWAP_A4AF_OTHERS;
 	else if (action == "swap_this_auto") {
-		// Was a third action here, and it was the odd one out: the other two
-		// move sources, while this flipped a flag the download object
-		// reports. A flip cannot be retried safely, so it is now
-		// `PATCH /downloads/{hash} {"a4af_auto": <bool>}` -- named value in,
-		// same value out, no matter how many times it arrives.
+		// A third action here was the odd one out: the other two move sources,
+		// while this flipped a flag the download object reports. A flip cannot be
+		// retried safely, so it is now PATCH /downloads/{hash} {"a4af_auto":...}.
 		return ErrorResponse(400,
 			"bad_request",
 			"`swap_this_auto` is not accepted; set the flag with PATCH "
@@ -5021,11 +4524,10 @@ CHttpServer::Response CApiDispatcher::HandleDownloadA4afAction(
 		return ErrorResponse(400, "bad_request", "`action` must be one of swap_this, swap_others");
 	}
 
-	// `client_ecid` narrows swap_this from "every A4AF source of this file" to
-	// one named source, which is what the desktop's per-peer "Swap to this
-	// file" does. The core has no per-source form of the other two actions, so
-	// pairing it with them is a request that cannot be honoured rather than one
-	// that quietly does something else.
+	// `client_ecid` narrows swap_this from "every A4AF source of this file" to one
+	// named source, which is what the desktop's per-peer swap does. The core has
+	// no per-source form of the other two, so pairing it with them is a request
+	// that cannot be honoured rather than one that quietly does something else.
 	bool per_source = false;
 	std::uint32_t client_ecid = 0;
 	if (const auto cit = obj.find("client_ecid"); cit != obj.end()) {
@@ -5092,11 +4594,9 @@ CHttpServer::Response CApiDispatcher::HandleDownloadA4afAction(
 namespace
 {
 
-// --- Bulk mutation results (issue #358) -------------------------------
-// Every bulk mutation (POST /downloads, PATCH/DELETE /downloads,
-// PATCH /shared) reports one entry per input item under a unified
-// `results` array, so a client that submits N items learns the fate of
-// each without parallel arrays or a first-error-only summary.
+// Every bulk mutation reports one entry per input item under a unified
+// `results` array, so a client submitting N items learns the fate of each
+// without parallel arrays or a first-error-only summary.
 struct BulkItem
 {
 	std::string id; // the item key: ed2k link or MD4 hash
@@ -5212,19 +4712,15 @@ CHttpServer::Response CApiDispatcher::HandleVersionCheck(const CHttpServer::Requ
 	if (auto rej = RequireAdmin(a))
 		return *rej;
 
-	// Before the first EC snapshot there are no preferences to read, and
-	// version_check_available defaults to false -- so the capability check
-	// below used to answer 409 "disabled or unavailable on the connected
-	// daemon" during the window every client hits at startup, blaming the
-	// daemon's configuration for amuleapi not having read it yet. Every other
-	// handler that reads cached state answers 503 ec_unavailable there, which
-	// is the condition a client can retry.
+	// Before the first EC snapshot there are no preferences to read and
+	// version_check_available defaults to false, so the capability check below
+	// used to answer 409 "disabled on the connected daemon" during the window
+	// every client hits at startup. 503 ec_unavailable is the retryable answer.
 	if (auto r = RequireSnapshot(m_state))
 		return *r;
 
-	// The daemon owns the check; amuleapi only triggers it. Reject early
-	// when the daemon can't check, so we never send an EC op that will fail
-	// and never expose the daemon's localized reason (English-only contract).
+	// The daemon owns the check; amuleapi only triggers it. Rejecting early avoids
+	// an EC op that will fail and never exposes the daemon's localized reason.
 	const auto prefs = m_state.Preferences();
 	if (!(prefs.version_check_available && prefs.version_check_enabled)) {
 		return ErrorResponse(409,
@@ -5241,24 +4737,21 @@ CHttpServer::Response CApiDispatcher::HandleVersionCheck(const CHttpServer::Requ
 	const bool failed = ec_resp->GetOpCode() == EC_OP_FAILED;
 	delete ec_resp;
 	if (failed) {
-		// The only expected failure past the gate above is the daemon's
-		// throttle. Report an English code; the daemon's message is not relayed.
+		// The only expected failure past the gate above is the daemon's throttle,
+		// reported with an English code.
 		//
-		// Its own code, not the auth limiter's `rate_limited`: both answer 429,
-		// and a client that cannot tell them apart has to treat a throttled
-		// update check as a lost session. The Web UI did exactly that and logged
-		// the user out on "Check now".
+		// Its own code, not the auth limiter's `rate_limited`: both answer 429, and
+		// a client that cannot tell them apart treats a throttled update check as a
+		// lost session. The Web UI did exactly that and logged the user out.
 		return ErrorResponse(429,
 			"version_check_throttled",
 			"version check was throttled by the daemon; try again shortly");
 	}
 
-	// Accepted. The check runs asynchronously on the daemon; the result
-	// (latest_version / available / last_checked_at) appears on a
-	// subsequent GET /api/v0/version once it completes.
+	// The check runs asynchronously; the result appears on a subsequent
+	// GET /version.
 	CHttpServer::Response r;
-	// 202 with no body; see the comment on the comments routes. "started" is
-	// what the status code says.
+	// 202 with no body: "started" is what the status code says.
 	r.status = 202;
 	r.content_type.clear();
 	return r;
@@ -5275,12 +4768,7 @@ CHttpServer::Response CApiDispatcher::HandleDownloadAdd(const CHttpServer::Reque
 	if (auto r = RequireSnapshot(m_state))
 		return *r;
 
-	// Body shape, one form:
-	//  {"links": ["ed2k://|file|...|/", ...], "category_index": 0}
-	// A singular `ed2k_link` was accepted alongside it and is now refused
-	// with a message naming the replacement: one input with two spellings,
-	// on the endpoint that already answers with the bulk `results` envelope
-	// for a single item.
+	// Body shape: {"links": ["ed2k://|file|...|/", ...], "category_index": 0}.
 	picojson::value root;
 	std::string parse_err;
 	if (!ParseJsonObjectBody(req.body, root, parse_err)) {
@@ -5290,12 +4778,10 @@ CHttpServer::Response CApiDispatcher::HandleDownloadAdd(const CHttpServer::Reque
 
 	std::vector<std::string> links;
 	{
-		// `links` only. This took `ed2k_link` as a singular alias too, so one
-		// input had two spellings on the one endpoint that already answers
-		// with the bulk `results` envelope even for a single item -- and every
-		// future field that varies by arity would have inherited the question.
-		// `links: ["..."]` covers the single case at the cost of two
-		// characters.
+		// `links` only. A singular `ed2k_link` alias meant one input with two
+		// spellings on the endpoint that already answers with the bulk `results`
+		// envelope even for a single item, and every future field varying by arity
+		// would have inherited the question.
 		const auto it_array = obj.find("links");
 		if (obj.find("ed2k_link") != obj.end()) {
 			return ErrorResponse(400,
@@ -5355,17 +4841,11 @@ CHttpServer::Response CApiDispatcher::HandleDownloadAdd(const CHttpServer::Reque
 		}
 	}
 
-	// Build one EC_OP_ADD_LINK packet per link. amuled's add-link op
-	// is single-link-only on the wire; we batch at the HTTP layer so
-	// clients only pay one round-trip. We accumulate accepted /
-	// failed / disconnected-mid-batch into separate lists and report
-	// the whole picture at the end — never short-circuit on an EC
-	// blip mid-batch (an unconditional 503 would silently throw away
-	// the links amuled already queued from earlier iterations).
-	// Unified per-item envelope (#358): one `results` entry per submitted
-	// link, keyed by the link itself. amuleapi is not yet shipped, so this
-	// deliberately replaces the previous ok/accepted/failed counter shape
-	// rather than extending it -- there are no released clients to break.
+	// One EC_OP_ADD_LINK packet per link: amuled's add-link op is single-link on
+	// the wire, so the batching is ours and clients pay one round-trip. Accepted,
+	// failed and disconnected-mid-batch are accumulated separately and reported
+	// together -- an unconditional 503 on an EC blip would silently discard the
+	// links amuled had already queued.
 	std::vector<BulkItem> results;
 	results.reserve(links.size());
 	for (const auto &link : links) {
@@ -5389,30 +4869,23 @@ CHttpServer::Response CApiDispatcher::HandleDownloadAdd(const CHttpServer::Reque
 		results.push_back(BulkOk(link));
 	}
 
-	// Inline-refresh the cache so the response sees post-mutation
-	// state. amuled's ADD_LINK is asynchronous (the partfile gets
-	// allocated + hashed before it shows up in m_filelist), so the
-	// new entry may not surface until the *next* tick — we'd still
-	// return 202 Accepted with an empty resource. For now: refresh,
-	// then return {ok: true} and leave the GET /downloads to surface
-	// the new entry.
+	// Inline-refresh so the response sees post-mutation state. amuled's ADD_LINK
+	// is asynchronous -- the partfile is allocated and hashed before it appears in
+	// m_filelist -- so the new entry may not surface until the next tick, and
+	// GET /downloads is what surfaces it.
 	(void)RefresherTick(m_app, m_state);
 
-	// All accepted -> 202 (async: amuled allocates + hashes the partfile
-	// before it surfaces in GET /downloads, typically within one tick); a
-	// mix -> 207; every link blocked by an EC disconnect -> 503.
+	// All accepted -> 202 (async); a mix -> 207; every link blocked by an EC
+	// disconnect -> 503.
 	return BulkResultsResponse(results, 202);
 }
 
 namespace
 {
-// Handle the optional `my_comment`+`my_rating` pair shared by PATCH
-// /downloads/{hash} and PATCH /shared/{hash} (issue #419). Both must be
-// present together or neither. Sends EC_OP_SHARED_FILE_SET_COMMENT, which
-// amuled resolves against the shared-files registry — so the file must be
-// shared. Returns false and fills `err` on any problem; sets `applied`
-// when a valid pair was written. A body with neither field is a no-op
-// (returns true, applied=false).
+// The optional `my_comment` + `my_rating` pair shared by PATCH /downloads/{hash}
+// and PATCH /shared/{hash}. Both must be present or neither. Sends
+// EC_OP_SHARED_FILE_SET_COMMENT, which amuled resolves against the shared-files
+// registry, so the file must be shared. A body with neither field is a no-op.
 bool TrySetCommentRating(CamuleapiApp &app,
 	const picojson::object &obj,
 	const webapi::FileSnapshot &f,
@@ -5479,13 +4952,10 @@ bool TrySetCommentRating(CamuleapiApp &app,
 	return true;
 }
 
-// Handle the optional `name` (rename) field shared by PATCH
-// /downloads/{hash} and PATCH /shared/{hash} (issue #420). Maps to
-// EC_OP_RENAME_FILE. Rejects empty names and names containing path
-// separators — amuled's RenameFile JoinPaths()es the value, so a
-// separator would let the rename escape the file's directory. Returns
-// false + fills `err` on a problem; sets `applied` when a rename was
-// sent. Absent `name` is a no-op (returns true, applied=false).
+// The optional `name` (rename) field shared by PATCH /downloads/{hash} and
+// PATCH /shared/{hash}, mapping to EC_OP_RENAME_FILE. Empty names and names
+// containing path separators are rejected: amuled's RenameFile JoinPaths()es
+// the value, so a separator would let the rename escape the file's directory.
 bool TryRename(CamuleapiApp &app,
 	const picojson::object &obj,
 	const webapi::FileSnapshot &f,
@@ -5568,9 +5038,9 @@ CHttpServer::Response CApiDispatcher::HandleDownloadPatch(
 		return ErrorResponse(500, "internal_error", "failed to decode partfile hash");
 	}
 
-	// Each field present in the body fires one EC mutation. We
-	// process them in a fixed order (status, priority, category) so
-	// the wire effect is deterministic regardless of JSON key order.
+	// Each field present in the body fires one EC mutation, in a fixed order
+	// (status, priority, category) so the wire effect does not depend on JSON key
+	// order.
 	auto send_op = [&](ec_opcode_t op,
 			       bool has_inner,
 			       ec_tagname_t inner_name,
@@ -5598,9 +5068,8 @@ CHttpServer::Response CApiDispatcher::HandleDownloadPatch(
 
 	bool any_change = false;
 
-	// action: "pause" | "resume" | "stop" -- a command, not a state. The read
-	// side's `status` has eleven values (DownloadStatusName), of which this
-	// accepted three, in a different tense.
+	// action: a command, not a state. The read side's `status` has eleven values,
+	// of which this accepted three, in a different tense.
 	{
 		const auto it = obj.find("action");
 		if (it != obj.end()) {
@@ -5629,9 +5098,8 @@ CHttpServer::Response CApiDispatcher::HandleDownloadPatch(
 		}
 	}
 
-	// priority: "low"|"normal"|"high"|"auto" -- the kPrioDownload domain.
-	// "very_low" and "release" are upload-side only (kPrioShared) and are
-	// refused here with a 400, by design; see kFilePriorities.
+	// priority: the kPrioDownload domain. "very_low" and "release" are upload-side
+	// only and are refused here by design; see kFilePriorities.
 	{
 		const auto it = obj.find("priority");
 		if (it != obj.end()) {
@@ -5677,20 +5145,13 @@ CHttpServer::Response CApiDispatcher::HandleDownloadPatch(
 		}
 	}
 
-	// a4af_auto: boolean
+	// a4af_auto: a SET, not a toggle.
 	//
-	// A set, not a toggle. EC_OP_PARTFILE_SWAP_A4AF_THIS_AUTO flips the flag,
-	// which is what the desktop menu item wants and what an HTTP API must not
-	// expose: a client library or a browser can retry a request without the
-	// caller knowing, and a retried flip lands on the opposite value. Reaching
-	// a named value takes EC_OP_PARTFILE_SET_A4AF_AUTO, which carries the
-	// value; the core stores it and marks the file changed only if it moved,
-	// so re-sending the same body is a no-op rather than an undo.
-	//
-	// A PATCH field rather than another `action` on POST /downloads/{hash}
-	// /a4af: this sets a field the download object already reports, and the
-	// two remaining actions there (swap_this, swap_others) move sources one
-	// way, which is a different kind of operation.
+	// EC_OP_PARTFILE_SWAP_A4AF_THIS_AUTO flips the flag, which is what the desktop
+	// menu wants and what an HTTP API must not expose: a client library can retry
+	// a request without the caller knowing, and a retried flip lands on the
+	// opposite value. EC_OP_PARTFILE_SET_A4AF_AUTO carries the value instead, so
+	// re-sending the same body is a no-op rather than an undo.
 	{
 		const auto it = obj.find("a4af_auto");
 		if (it != obj.end()) {
@@ -5707,9 +5168,8 @@ CHttpServer::Response CApiDispatcher::HandleDownloadPatch(
 		}
 	}
 
-	// comment + rating (both required together; issue #419). Only
-	// settable on a file that is shared (a downloading partfile with
-	// ≥1 complete chunk); otherwise TrySetCommentRating returns 409.
+	// comment + rating, both required together. Only settable on a file that is
+	// shared; otherwise TrySetCommentRating returns 409.
 	{
 		bool applied = false;
 		CHttpServer::Response cr_err;
@@ -5739,10 +5199,8 @@ CHttpServer::Response CApiDispatcher::HandleDownloadPatch(
 	// Inline refresh so the response below sees post-mutation state.
 	(void)RefresherTick(m_app, m_state);
 
-	// Re-read the snapshot — fall back to the prior copy if the
-	// cache evicted it between mutations and this read (vanishingly
-	// rare; would mean amuled removed it between our SendRecv and
-	// the refresh).
+	// Re-read the snapshot, falling back to the prior copy if the cache evicted it
+	// between the mutation and this read.
 	webapi::FileSnapshot d_after;
 	if (!m_state.FindDownload(d.hash, d_after))
 		d_after = d;
@@ -5751,11 +5209,10 @@ CHttpServer::Response CApiDispatcher::HandleDownloadPatch(
 	r.status = 200;
 	r.content_type = "application/json";
 	CJsonWriter w;
-	// Same shape GET /downloads/{hash} returns, not the narrower list row.
-	// A client that PATCHes and stores the response used to hold a different
-	// object than one that PATCHes and re-GETs -- missing progress.parts and
-	// sixteen other keys -- which is a difference nothing in the API
-	// announced.
+	// The same shape GET /downloads/{hash} returns, not the narrower list row: a
+	// client that PATCHed and stored the response used to hold a different object
+	// than one that PATCHed and re-GETed, missing progress.parts and sixteen other
+	// keys.
 	WriteDownloadObject(w, d_after, /*include_parts=*/true, /*detail=*/true);
 	FinalizeJsonBody(w, r);
 	return r;
@@ -5781,16 +5238,12 @@ CHttpServer::Response CApiDispatcher::HandleDownloadDelete(
 		return ErrorResponse(404, "not_found", "no download with that hash");
 	}
 
-	// DELETE only handles ACTIVE downloads (anything not "completed").
-	// Completed entries live in amuled's m_completedDownloads
-	// staging list, and the only EC op that touches that list is
-	// EC_OP_CLEAR_COMPLETED — which doesn't delete the on-disk file
-	// from Incoming, it just acks the post-completion notification.
-	// Conflating the two under one verb confused operators who
-	// reasonably expected DELETE to remove a file from disk. Route
-	// the completed case through POST /downloads_clear_completed
-	// (which accepts an optional {hash} body for per-entry clears)
-	// so the verb-vs-disk-semantic mapping stays unambiguous.
+	// DELETE handles ACTIVE downloads only. Completed entries live in amuled's
+	// m_completedDownloads staging list, and the only EC op that touches it is
+	// EC_OP_CLEAR_COMPLETED, which acks the notification rather than deleting the
+	// file from Incoming. Conflating the two under one verb confused operators who
+	// expected DELETE to remove a file from disk, so the completed case goes
+	// through POST /downloads_clear_completed.
 	if (d.download.status == "completed") {
 		return ErrorResponse(409,
 			"download_completed",
@@ -5819,15 +5272,13 @@ CHttpServer::Response CApiDispatcher::HandleDownloadDelete(
 	}
 	delete ec_resp;
 
-	// Inline refresh — the next GET /downloads must not show the
-	// deleted entry. The cache eviction happens via FILE_REMOVED in
-	// the GET_UPDATE response.
+	// Inline refresh: the next GET /downloads must not show the deleted entry.
+	// Eviction happens via FILE_REMOVED in the GET_UPDATE response.
 	(void)RefresherTick(m_app, m_state);
 
 	CHttpServer::Response r;
-	// 204 with no body. Everything this used to echo came from the request
-	// URL, and `ok` restated the status code -- see the mutation-response
-	// rule in REFERENCE.md.
+	// 204 with no body: everything this used to echo came from the request URL,
+	// and `ok` restated the status code.
 	r.status = 204;
 	r.content_type.clear();
 	return r;
@@ -5844,14 +5295,11 @@ CHttpServer::Response CApiDispatcher::HandleDownloadsClearCompleted(const CHttpS
 	if (auto r = RequireSnapshot(m_state))
 		return *r;
 
-	// Two shapes share this endpoint:
-	//  * no body (or all-whitespace body) → bulk clear every
-	//    completed entry. Original shape.
-	//  * `{"hash": "<md4hex>"}` → clear that single completed entry.
-	//    Hash must currently match a download with status=="completed";
-	//    active / unknown hashes return 404.
-	// The response envelope is identical in both branches so a client
-	// that wraps the call doesn't need to fork on its own input.
+	// Two shapes share this endpoint: no body clears every completed entry, and
+	// {"hash": "<md4hex>"} clears that one, which must currently be a download
+	// with status=="completed" (active or unknown hashes 404). The response
+	// envelope is identical either way, so a client wrapping the call need not
+	// fork on its own input.
 	std::string target_hash;
 	bool body_has_content = false;
 	for (char c : req.body) {
@@ -5878,9 +5326,8 @@ CHttpServer::Response CApiDispatcher::HandleDownloadsClearCompleted(const CHttpS
 				target_hash.begin(),
 				[](unsigned char c) { return std::tolower(c); });
 		}
-		// Future-proof: silently ignore unknown keys rather than 400
-		// so adding a flag later (e.g. {"hash": "...", "force": true})
-		// doesn't break old clients.
+		// Unknown keys are ignored rather than 400, so adding a flag later does
+		// not break old clients.
 	}
 
 	// Collect target ECID(s). For the by-hash form, only one entry;
@@ -5915,14 +5362,13 @@ CHttpServer::Response CApiDispatcher::HandleDownloadsClearCompleted(const CHttpS
 	}
 
 	if (ecids.empty()) {
-		// Nothing to do. An empty `results` array is the no-op, and it stays
-		// distinguishable from "amuled rejected" -- which is a 4xx with an
-		// error envelope -- without needing a shape of its own.
+		// Nothing to do. An empty `results` array is the no-op, and stays distinct
+		// from "amuled rejected", which is a 4xx with an error envelope.
 		return BulkResultsResponse({}, 200);
 	}
 
 	// One EC roundtrip with all ECIDs (per amulegui's pattern at
-	// amule-remote-gui.cpp:2238-2246).
+	// amule-remote-gui.cpp).
 	std::unique_ptr<CECPacket> ec_req(new CECPacket(EC_OP_CLEAR_COMPLETED));
 	for (std::uint32_t ecid : ecids) {
 		ec_req->AddTag(CECTag(EC_TAG_ECID, ecid));
@@ -5942,10 +5388,9 @@ CHttpServer::Response CApiDispatcher::HandleDownloadsClearCompleted(const CHttpS
 	// show the post-clear state.
 	(void)RefresherTick(m_app, m_state);
 
-	// One entry per hash, in the envelope every other multi-item mutation
-	// uses. `cleared` was a count and `cleared_hashes` a bare array, so a
-	// per-entry failure had nowhere to appear; the daemon clears them in one
-	// roundtrip today, but the shape no longer assumes that.
+	// One entry per hash, in the envelope every other multi-item mutation uses.
+	// `cleared` was a count and `cleared_hashes` a bare array, so a per-entry
+	// failure had nowhere to appear.
 	std::vector<BulkItem> results;
 	results.reserve(hashes_cleared.size());
 	for (const auto &h : hashes_cleared) {
@@ -5959,9 +5404,7 @@ CHttpServer::Response CApiDispatcher::HandleDownloadsClearCompleted(const CHttpS
 namespace
 {
 
-// Dotted-quad IPv4 -> host-order uint32, the encoding EC_TAG_*_IP uses.
-// Three call sites parsed this inline with the same sscanf; the friends add
-// path made it four.
+// Dotted-quad IPv4 to host-order uint32, the encoding EC_TAG_*_IP uses.
 bool ParseIpv4Dotted(const std::string &text, std::uint32_t &out_he)
 {
 	unsigned a = 0, b = 0, c = 0, d = 0;
@@ -5976,25 +5419,20 @@ bool ParseIpv4Dotted(const std::string &text, std::uint32_t &out_he)
 void WriteServerObject(CJsonWriter &w, const webapi::ServerSnapshot &s)
 {
 	w.BeginObject();
-	// `ecid` is the URL key for /servers/{ecid}/connect and
-	// /servers/{ecid}. intentionally surfaced
-	// it on /clients for the same reason; servers got it later.
+	// `ecid` is the URL key for /servers/{ecid} and /servers/{ecid}/connect. The
+	// same key is surfaced on /clients for the same reason; servers got it later.
 	w.Key("ecid");
 	w.ValueInt(static_cast<int64_t>(s.ecid));
 	w.Key("name");
 	w.ValueString(wxString::FromUTF8(s.name.c_str()));
 	w.Key("description");
 	w.ValueString(wxString::FromUTF8(s.description.c_str()));
-	// `software_version`, not `version`: every version on this surface is
-	// named for its subject (`api_version`, `amuleapi_version`,
-	// `daemon_version`, and `software_version` on the client and
-	// known-client rows), and a bare `version` beside them reads as the
-	// API's own.
+	// `software_version`, not `version`: every version on this surface is named
+	// for its subject, and a bare `version` beside them reads as the API's own.
 	//
-	// null, not "", for the same reason the two peer writers null it: a
-	// server that never reported a version is unknown, and a client
-	// normalizing `software_version` across /servers, /clients and
-	// /known_clients should not have to learn the rule twice (R10).
+	// null, not "", for the reason the two peer writers null it: a server that
+	// never reported one is unknown, and a client normalizing this key across
+	// /servers, /clients and /known_clients should not learn the rule twice (R10).
 	WriteStringOrNull(w, "software_version", !s.version.empty(), s.version);
 	w.Key("address");
 	w.ValueString(wxString::FromUTF8(s.address.c_str()));
@@ -6012,9 +5450,8 @@ void WriteServerObject(CJsonWriter &w, const webapi::ServerSnapshot &s)
 	w.ValueInt(static_cast<int64_t>(s.max_users));
 	w.Key("file_count");
 	w.ValueInt(static_cast<int64_t>(s.files));
-	// 0 means the server has not reported a limit yet, not a limit of zero;
-	// the sentinel is documented so a UI can render it blank the way the
-	// desktop's Soft/Hard Files columns do.
+	// 0 means the server has not reported a limit yet, not a limit of zero, so a
+	// UI can render it blank the way the desktop's Soft/Hard Files columns do.
 	w.Key("soft_file_limit");
 	w.ValueInt(static_cast<int64_t>(s.soft_file_limit));
 	w.Key("hard_file_limit");
@@ -6025,14 +5462,12 @@ void WriteServerObject(CJsonWriter &w, const webapi::ServerSnapshot &s)
 	w.ValueInt(static_cast<int64_t>(s.ping_ms));
 	w.Key("failed_count");
 	w.ValueInt(static_cast<int64_t>(s.failed_count));
-	// `permanent`, not `static`: `static` is a reserved word in C++, Java,
-	// C# and TypeScript-adjacent codegen, so a generated client has to
-	// mangle it.
+	// `permanent`, not `static`: `static` is a reserved word in C++, Java and C#,
+	// so a generated client has to mangle it.
 	w.Key("permanent");
 	w.ValueBool(s.is_static);
-	// Decoded capability bits. Written as a pre-built fragment from the shared
-	// tables so this object and the SSE payload in EventDiff.cpp -- two
-	// different writers, one documented shape -- cannot drift apart.
+	// Written as a pre-built fragment from the shared tables so this object and
+	// the SSE payload in EventDiff.cpp cannot drift apart.
 	w.Key("tcp_flags");
 	w.ValueRaw(webapi::ServerTcpFlagsJson(s.tcp_flags));
 	w.Key("udp_flags");
@@ -6073,10 +5508,9 @@ void WriteCategoryObject(CJsonWriter &w, const webapi::CategorySnapshot &c)
 void WriteFriendObject(CJsonWriter &w, const webapi::FriendSnapshot &f)
 {
 	w.BeginObject();
-	// The friend's own EC handle, so it is spelled `ecid` like every other
-	// self-handle; `client_ecid` below points OUT of this object, which is
-	// what the prefix is for. Like every ECID it does not survive an amuled
-	// restart -- `user_hash` is the durable reference, when the friend has one.
+	// The friend's own EC handle; `client_ecid` below points OUT of this
+	// object. Like every ECID it does not survive an amuled restart --
+	// `user_hash` is the durable reference, when the friend has one.
 	w.Key("ecid");
 	w.ValueInt(static_cast<int64_t>(f.ecid));
 	w.Key("name");
@@ -6086,19 +5520,15 @@ void WriteFriendObject(CJsonWriter &w, const webapi::FriendSnapshot &f)
 	// null rather than "" when the daemon has not reported an address (R10).
 	WriteStringOrNull(w, "ip", !f.ip.empty(), f.ip);
 	// Paired with ip, the way WriteKnownClientObject nulls ip/port/kad_port
-	// together: a 0 port on an address-less friend is the sentinel R10 removed
-	// everywhere else.
+	// together: a 0 port on an address-less friend is the R10 sentinel.
 	WriteIntOrNull(w, "port", !f.ip.empty(), static_cast<int64_t>(f.port));
 	// The live peer this friend is linked to, joinable against /clients. null
-	// when the friend is not connected, which is the common case and which
-	// `connected` also reports. Deliberately not the 0 it used to be: the surface
-	// spells "no value" as null and never as 0 or -1, and a client joining
-	// naively on the raw value was building GET /clients/0 and taking a 404.
+	// rather than 0 when not connected: a client joining naively on the raw
+	// value was building GET /clients/0 and taking a 404.
 	WriteIntOrNull(w, "client_ecid", f.client_ecid != 0, static_cast<int64_t>(f.client_ecid));
-	// Whether a socket to the peer is actually up, not whether the daemon
-	// holds a client object for it -- which it does from the first contact
-	// ATTEMPT, so this used to call an unroutable peer reachable. null when the
-	// daemon predates EC_TAG_CLIENT_CONNECTED: unknown, not offline.
+	// Whether a socket to the peer is actually up, not whether the daemon holds
+	// a client object for it -- which it does from the first contact ATTEMPT.
+	// null when the daemon predates EC_TAG_CLIENT_CONNECTED: unknown, not offline.
 	WriteBoolOrNull(w, "connected", f.has_connected, f.connected);
 	w.Key("friend_slot");
 	w.ValueBool(f.friend_slot);
@@ -6115,9 +5545,7 @@ CHttpServer::Response CApiDispatcher::HandleServers(const CHttpServer::Request &
 	if (auto err = ParseListParams(QueryOf(req), params))
 		return *err;
 	static const ListComparators<webapi::ServerSnapshot> kComps = {
-		// Identity column: immutable, so it is the one a keyset sweep can
-		// anchor on. Listed first because that is the order a paging client
-		// cares about, not the order a UI table does.
+		// Identity column: immutable, so a keyset sweep can anchor on it.
 		{ "ecid", SORT_BY(ecid), ANCHOR_ON_NUM(ecid) },
 		{ "name", SORT_BY(name) },
 		// R7: spelled like the response keys they order by.
@@ -6131,20 +5559,17 @@ CHttpServer::Response CApiDispatcher::HandleServers(const CHttpServer::Request &
 namespace
 {
 
-// Parse an integer ECID from a path capture. Returns false on
-// negative, overflow, or non-digit content (the API expects positive
-// 32-bit ECIDs from the URL).
+// Parse an integer ECID from a path capture. Returns false on negative,
+// overflow, or non-digit content.
 bool ParseEcidPath(const std::string &s, std::uint32_t &out)
 {
 	if (s.empty())
 		return false;
 	char *end = nullptr;
-	// strtoull (not strtoul) because `unsigned long` is 32-bit on
-	// Windows — there the `v > 0xFFFFFFFFu` overflow guard below
-	// would be a tautology and an out-of-range path-segment like
-	// `99999999999` would saturate to ULONG_MAX = 0xFFFFFFFF, then
-	// silently match an actual ECID 0xFFFFFFFF. strtoull is 64-bit
-	// everywhere so the cap is meaningful regardless of platform.
+	// strtoull (not strtoul) because `unsigned long` is 32-bit on Windows --
+	// there the `v > 0xFFFFFFFFu` guard below would be a tautology and an
+	// out-of-range segment like `99999999999` would saturate to 0xFFFFFFFF,
+	// silently matching an actual ECID 0xFFFFFFFF.
 	errno = 0;
 	const unsigned long long v = std::strtoull(s.c_str(), &end, 10);
 	if (end == s.c_str() || *end != '\0')
@@ -6158,12 +5583,8 @@ bool ParseEcidPath(const std::string &s, std::uint32_t &out)
 }
 
 // Path-capture counterpart to RequireSnapshot above, used the same way:
-// ` if (auto r = RequireEcidPath(caps["ecid"], ecid)) return *r;`.
-//
-// Nine handlers had spelled out the same parse-and-reject, and the status,
-// the code and the sentence are part of the API contract rather than local
-// wording -- a tenth route inheriting a different one is how a surface stops
-// being predictable.
+// ` if (auto r = RequireEcidPath(caps["ecid"], ecid)) return *r;`. The status,
+// the code and the sentence are part of the API contract, not local wording.
 std::unique_ptr<CHttpServer::Response> RequireEcidPath(const std::string &s, std::uint32_t &out)
 {
 	if (!ParseEcidPath(s, out)) {
@@ -6172,8 +5593,8 @@ std::unique_ptr<CHttpServer::Response> RequireEcidPath(const std::string &s, std
 	return nullptr;
 }
 
-// Look up a server in the State cache by ECID. Returns false if
-// no match — the handler then 404s.
+// The FindXByEcid family. The EC remove/slot ops are idempotent about unknown
+// ids, so handlers look the id up first and 404 rather than answer a cheerful 200.
 bool FindServerByEcid(const webapi::CState &state, std::uint32_t ecid, webapi::ServerSnapshot &out)
 {
 	const auto all = state.Servers();
@@ -6186,8 +5607,6 @@ bool FindServerByEcid(const webapi::CState &state, std::uint32_t ecid, webapi::S
 	return false;
 }
 
-// Look up a client in the State cache by ECID (issue #422). Mirrors
-// FindServerByEcid; the handler 404s on false.
 bool FindClientByEcid(const webapi::CState &state, std::uint32_t ecid, webapi::ClientSnapshot &out)
 {
 	const auto all = state.Clients();
@@ -6200,38 +5619,18 @@ bool FindClientByEcid(const webapi::CState &state, std::uint32_t ecid, webapi::C
 	return false;
 }
 
-// Same shape again for friends. The EC remove/slot ops are idempotent about
-// unknown ids, but a REST caller who mistypes one should get a 404 rather than
-// a cheerful 200, so every /friends/{ecid} handler looks the id up first.
 // The category set as a client sees it, which is not quite what amuled holds.
 //
 // amuled's EC suppresses the whole `EC_TAG_PREFS_CATEGORIES` block when no
 // custom categories exist, and starts including index 0 once the first custom
-// one is added. Faithful at the wire layer, but a client iterating /categories
-// expecting at least the default has to special-case the empty case, so a
-// synthetic index-0 entry is injected when missing. `priority_code` PR_LOW is
-// the amuled default for `defaultcat->prio` in CPreferences::LoadCats.
+// one is added, so a synthetic index-0 entry is injected when missing.
+// amuled's `defaultcat` is also constructed with an empty title and path, so
+// the name and `directories.incoming_path` are filled in here -- unconditionally,
+// or /categories/0 would answer "Default" on a daemon with no custom categories
+// and "" as soon as the operator added one.
 //
-// Category 0 is also given a name and a path, whether it arrived from the
-// daemon or was synthesised here. amuled holds neither -- `defaultcat` is
-// constructed with an empty title and path -- so a client rendering a category
-// picker got a blank row it had to label itself, and had nowhere to show where
-// an uncategorised download lands. Neither value is invented: "Default" names
-// the row every client already has to describe somehow, and the path is
-// `directories.incoming_path`, which is genuinely where a file with no category is
-// saved.
-//
-// Filling both in unconditionally is the point. Doing it only for the
-// synthetic row would mean /categories/0 answered "Default" on a daemon with
-// no custom categories and "" as soon as the operator added one, which is a
-// response shape that depends on unrelated state.
-//
-// Both read routes go through here. The collection did this inline and the
-// member route added later read the raw snapshot instead, so /categories
-// listed a category 0 that /categories/0 reported as absent. Mutations
-// deliberately do NOT use this: the synthetic entry is a read-shape
-// convenience rather than something the daemon holds, so there is nothing
-// there to PATCH or DELETE.
+// Both read routes go through here; mutations deliberately do not, since the
+// synthetic entry is a read-shape convenience with nothing behind it to PATCH.
 std::vector<webapi::CategorySnapshot> CategoriesWithDefault(const webapi::CState &state)
 {
 	std::vector<webapi::CategorySnapshot> cats = state.Categories();
@@ -6254,9 +5653,8 @@ std::vector<webapi::CategorySnapshot> CategoriesWithDefault(const webapi::CState
 	return cats;
 }
 
-// Category counterpart to the FindXByEcid family above. Three handlers walked
-// m_state.Categories() with the same loop, and the read route added below would
-// have been a fourth.
+// Category counterpart to the FindXByEcid family above; three handlers walked
+// m_state.Categories() with the same loop.
 bool FindCategoryByIndex(const webapi::CState &state, std::uint8_t index, webapi::CategorySnapshot &out)
 {
 	for (const auto &c : state.Categories()) {
@@ -6282,10 +5680,6 @@ bool FindFriendByEcid(const webapi::CState &state, std::uint32_t ecid, webapi::F
 
 } // namespace
 
-// GET /api/v0/clients/{ecid} (issue #422) — the full detail object for
-// one peer: every list field plus the detail-only B fields. Bare
-// object (no list envelope), mirroring HandleDownloadDetail. 404 when
-// the ecid isn't in the current snapshot.
 // --- Chat (issue #971) -------------------------------------------------
 //
 // Conversations are keyed on "<ip>:<port>", the readable form of the GUI_ID
@@ -6297,8 +5691,7 @@ namespace
 {
 
 // Parse "<ip>:<port>" back into a GUI_ID. Strict on purpose: anything that is
-// not four dotted octets plus a port is a client bug, and accepting it would
-// address some other conversation.
+// not four dotted octets plus a port would address some other conversation.
 bool ParseChatPeerKey(const std::string &peer, std::uint64_t &out_gui_id)
 {
 	const std::size_t colon = peer.rfind(':');
@@ -6355,9 +5748,8 @@ void WriteChatObject(CJsonWriter &w, const webapi::ChatSessionSnapshot &s)
 	w.ValueInt(static_cast<int64_t>(s.port));
 	w.Key("name");
 	w.ValueString(wxString::FromUTF8(s.DisplayName().c_str()));
-	// null rather than 0 for "no live connection" / "not a friend", for the
-	// same reason as the /friends row above: 0 is not how this surface spells
-	// absence, and /clients/0 is a 404 waiting to happen.
+	// null rather than 0 for "no live connection" / "not a friend": 0 is not how
+	// this surface spells absence, and /clients/0 is a 404 waiting to happen.
 	WriteIntOrNull(w, "client_ecid", s.client_ecid != 0, static_cast<int64_t>(s.client_ecid));
 	WriteIntOrNull(w, "friend_ecid", s.friend_ecid != 0, static_cast<int64_t>(s.friend_ecid));
 	// Same rule as the /friends row: reachability, not object existence.
@@ -6374,8 +5766,7 @@ void WriteChatObject(CJsonWriter &w, const webapi::ChatSessionSnapshot &s)
 		static_cast<int64_t>(s.messages.empty() ? 0 : s.messages.back().timestamp));
 	// The transcript itself is deliberately NOT on the list: a 50-session
 	// store at 200 messages each would be 10 000 objects per list read.
-	// null, not omitted: a session with no messages yet has no last message,
-	// which is a value rather than something the daemon failed to report.
+	// null, not omitted: a session with no messages yet has no last message.
 	w.Key("last_message");
 	if (!s.messages.empty())
 		WriteChatMessageObject(w, s.messages.back());
@@ -6419,15 +5810,10 @@ CHttpServer::Response CApiDispatcher::HandleKnownClients(const CHttpServer::Requ
 		return *err;
 
 	// One fetch per process. From here the refresher maintains it: every tick
-	// folds the connected peers back in, which is the whole of what can
-	// change -- a record whose peer is away cannot move, since credit totals
-	// only grow during a transfer and last-seen is written at disconnect. The
-	// remaining difference a re-read would show is the expiry prune the core
-	// applies when *it* starts, and amuleapi does not outlive a core restart.
-	//
-	// Two concurrent first requests can both fetch; the second simply replaces
-	// the first with an equivalent store. Not worth a lock held across an EC
-	// roundtrip to avoid.
+	// folds the connected peers back in, which is the whole of what can change
+	// -- credit totals only grow during a transfer and last-seen is written at
+	// disconnect. Two concurrent first requests can both fetch; the second
+	// replaces the first with an equivalent store, which is not worth a lock.
 	if (!m_state.KnownClientsLoaded()) {
 		std::vector<webapi::KnownClientSnapshot> rows;
 		std::unique_ptr<CECPacket> req_ec(new CECPacket(EC_OP_GET_CLIENT_HISTORY));
@@ -6448,10 +5834,8 @@ CHttpServer::Response CApiDispatcher::HandleKnownClients(const CHttpServer::Requ
 		if (!got_history) {
 			// An answer we cannot read latches nothing: the store is loaded
 			// once and never re-read, so installing an empty one here would
-			// serve an empty history for the life of the process. There is no
-			// reachable path today -- the daemon always answers this opcode
-			// and older ones are refused above -- but the cost of being wrong
-			// is permanent, and retrying next request is free.
+			// serve an empty history for the life of the process. No reachable
+			// path today, but the cost of being wrong is permanent.
 			return ErrorResponse(502,
 				"amuled_response_invalid",
 				"the core answered the history request with an unknown reply");
@@ -6460,9 +5844,7 @@ CHttpServer::Response CApiDispatcher::HandleKnownClients(const CHttpServer::Requ
 	}
 
 	static const ListComparators<webapi::KnownClientSnapshot> kComps = {
-		// Identity column: immutable, so it is the one a keyset sweep can
-		// anchor on. Listed first because that is the order a paging client
-		// cares about, not the order a UI table does.
+		// Identity column: immutable, so a keyset sweep can anchor on it.
 		{ "user_hash", SORT_BY(user_hash), ANCHOR_ON(user_hash) },
 		{ "name", SORT_BY(client_name) },
 		{ "software", SORT_BY(software) },
@@ -6532,14 +5914,11 @@ CHttpServer::Response CApiDispatcher::HandleChats(const CHttpServer::Request &re
 		return *err;
 
 	// Served straight from the refresher snapshot -- no EC roundtrip per
-	// request. The daemon's own order is most-recently-active first, which is
-	// the order a client wants by default.
+	// request. The daemon's order is most-recently-active first.
 	const std::vector<webapi::ChatSessionSnapshot> chats = m_state.Chats();
 
 	static const ListComparators<webapi::ChatSessionSnapshot> kComps = {
-		// Identity column: immutable, so it is the one a keyset sweep can
-		// anchor on. Listed first because that is the order a paging client
-		// cares about, not the order a UI table does.
+		// Identity column: immutable, so a keyset sweep can anchor on it.
 		{ "client_ecid", SORT_BY(client_ecid), ANCHOR_ON_NUM(client_ecid) },
 		{ "last_message_at",
 			[](const webapi::ChatSessionSnapshot &x, const webapi::ChatSessionSnapshot &y) {
@@ -6592,11 +5971,9 @@ CHttpServer::Response CApiDispatcher::HandleChatMessages(
 		since_id = static_cast<std::uint32_t>(v);
 	}
 	{
-		// `tail`, not `limit`. This selects the last N of the window
-		// rather than a page of it, which is what the log endpoints
-		// already call `tail` -- naming it `limit` gave the surface two
-		// meanings for one word, and the paginated one is the meaning a
-		// client meets on nine other collections.
+		// `tail`, not `limit`. This selects the last N of the window rather
+		// than a page of it, which is what the log endpoints already call
+		// `tail`; `limit` is the paginated meaning on nine other collections.
 		std::uint64_t v = tail;
 		if (auto r = ParseUintParam(qmap, "tail", 0, 100000, v))
 			return *r;
@@ -6637,9 +6014,8 @@ CHttpServer::Response CApiDispatcher::HandleChatMessages(
 }
 
 // Shared by all three send forms. `target` is the already-built EC tag naming
-// the recipient -- a GUI_ID, a live peer's ECID, or a friend's ECID. The
-// friend form is the one that reaches an OFFLINE friend, resolved by the
-// daemon through the friend's stored ip:port.
+// the recipient -- a GUI_ID, a live peer's ECID, or a friend's ECID. The friend
+// form is the one that reaches an OFFLINE friend, via the stored ip:port.
 CHttpServer::Response CApiDispatcher::SendChatMessageTo(const CHttpServer::Request &req, const CECTag &target)
 {
 	picojson::value root;
@@ -6683,18 +6059,13 @@ CHttpServer::Response CApiDispatcher::SendChatMessageTo(const CHttpServer::Reque
 	delete ec_resp;
 
 	// 202, not 200: the core acknowledges that it queued the message on the
-	// peer connection, not that the peer received it. An unreachable peer is
-	// not an error -- the desktop behaves the same, optimistically printing
-	// *** Connecting to Client ***.
+	// peer connection, not that the peer received it. An unreachable peer is not
+	// an error -- the desktop optimistically prints *** Connecting to Client ***.
 	CJsonWriter w;
 	w.BeginObject();
-	// `ok` dropped. The nested `message` object stays: it is the created
-	// resource, carrying the id and direction the daemon assigned. Built
-	// through the same writer GET /chats and GET /chats/{address}/messages
-	// use, so the row a client optimistically appends has the shape it will
-	// read back. `sent_at` is null here and only here: EC_OP_CHAT_SEND
-	// answers with the client and message ids and no timestamp, and the core
-	// is the only thing entitled to stamp one.
+	// The nested `message` object is the created resource, built through the
+	// same writer GET /chats/{address}/messages uses. `sent_at` is null here
+	// and only here: EC_OP_CHAT_SEND answers with ids and no timestamp.
 	w.Key("address");
 	w.ValueString(wxString::FromUTF8(webapi::ChatPeerKeyFromGuiId(gui_id).c_str()));
 	w.Key("message");
@@ -6797,8 +6168,6 @@ CHttpServer::Response CApiDispatcher::HandleChatClose(
 	}
 	delete ec_resp;
 
-	// 204 with no body: `peer` came from the request and `ok` restated the
-	// status code.
 	CHttpServer::Response r;
 	r.status = 204;
 	r.content_type.clear();
@@ -6815,9 +6184,7 @@ CHttpServer::Response CApiDispatcher::HandleFriends(const CHttpServer::Request &
 	if (auto err = ParseListParams(QueryOf(req), params))
 		return *err;
 	static const ListComparators<webapi::FriendSnapshot> kComps = {
-		// Identity column: immutable, so it is the one a keyset sweep can
-		// anchor on. Listed first because that is the order a paging client
-		// cares about, not the order a UI table does.
+		// Identity column: immutable, so a keyset sweep can anchor on it.
 		{ "ecid", SORT_BY(ecid), ANCHOR_ON_NUM(ecid) },
 		{ "name", SORT_BY(name) },
 		{ "connected",
@@ -6875,9 +6242,8 @@ CHttpServer::Response CApiDispatcher::HandleFriendAdd(const CHttpServer::Request
 		}
 		addtag.AddTag(CECTag(EC_TAG_CLIENT, client_ecid));
 	} else {
-		// Manual add, the desktop's "Add a Friend" dialog. The EC handler
-		// wants all four tags present, so an omitted hash is sent empty and
-		// an omitted name defaults to the address -- same as the dialog.
+		// Manual add. The EC handler wants all four tags present, so an omitted
+		// hash is sent empty and an omitted name defaults to the address.
 		std::string ip_str;
 		{
 			const auto it = obj.find("ip");
@@ -6958,11 +6324,9 @@ CHttpServer::Response CApiDispatcher::HandleFriendAdd(const CHttpServer::Request
 	(void)RefresherTick(m_app, m_state);
 
 	CHttpServer::Response r;
-	// 202 with no body. EC's FRIEND op answers success or failure and never
-	// returns the created object, so the only way to name it here was to
-	// diff the snapshot against a pre-add copy and hope the inline refresh
-	// had already surfaced it -- the object when the scan won, a bare {ok}
-	// when it lost. The caller re-reads /friends, which it had to do anyway.
+	// 202 with no body: EC's FRIEND op answers success or failure and never
+	// returns the created object, so naming it here would mean diffing the
+	// snapshot against a pre-add copy and hoping the inline refresh won.
 	r.status = 202;
 	r.content_type.clear();
 	return r;
@@ -7007,9 +6371,7 @@ CHttpServer::Response CApiDispatcher::HandleFriendRemove(
 	(void)RefresherTick(m_app, m_state);
 
 	CHttpServer::Response r;
-	// 204 with no body. Everything this used to echo came from the request
-	// URL, and `ok` restated the status code -- see the mutation-response
-	// rule in REFERENCE.md.
+	// 204 with no body -- see the mutation-response rule in REFERENCE.md.
 	r.status = 204;
 	r.content_type.clear();
 	return r;
@@ -7139,16 +6501,12 @@ CHttpServer::Response CApiDispatcher::HandleServerAdd(const CHttpServer::Request
 	}
 	delete ec_resp;
 
-	// Inline refresh — the new server should be in the next /servers
-	// response without waiting on the regular tick.
+	// Inline refresh so the new server is in the next /servers response.
 	(void)RefresherTick(m_app, m_state);
 
 	CHttpServer::Response r;
-	// 202 with no body. amuled's EC op answers success or failure and does
-	// not return the created object, so anything this reported would be a
-	// reconstruction from the snapshot after an inline refresh -- a guess
-	// that can silently come back short. The client re-reads the
-	// collection, which is what it had to do anyway.
+	// 202 with no body: amuled's EC op answers success or failure and does not
+	// return the created object, so anything reported here would be a guess.
 	r.status = 202;
 	r.content_type.clear();
 	return r;
@@ -7174,7 +6532,7 @@ CHttpServer::Response CApiDispatcher::HandleServerConnect(
 	}
 
 	// EC_OP_SERVER_CONNECT routes through Get_EC_Response_Server,
-	// which looks up the server by IPv4 lookup (ExternalConn.cpp:1266).
+	// which looks up the server by IPv4 lookup (ExternalConn.cpp).
 	// Build EC_TAG_SERVER with the IPv4 + port from our cache.
 	std::unique_ptr<CECPacket> ec_req(new CECPacket(EC_OP_SERVER_CONNECT));
 	ec_req->AddTag(CECTag(EC_TAG_SERVER, EC_IPv4_t(srv.ip, srv.port)));
@@ -7190,14 +6548,11 @@ CHttpServer::Response CApiDispatcher::HandleServerConnect(
 	}
 	delete ec_resp;
 
-	// Connection state is observable via /status.ed2k.state — the
-	// refresher tick will surface the change. Inline refresh so
-	// /status reflects "connecting" immediately.
+	// Inline refresh so /status reflects "connecting" immediately.
 	(void)RefresherTick(m_app, m_state);
 
 	CHttpServer::Response r;
-	// 202 with no body: `ecid` came from the request and the connect is
-	// asynchronous -- the outcome shows up on /status and the SSE stream.
+	// 202: the connect is asynchronous -- the outcome shows up on /status and SSE.
 	r.status = 202;
 	r.content_type.clear();
 	return r;
@@ -7239,9 +6594,7 @@ CHttpServer::Response CApiDispatcher::HandleServerDelete(
 	(void)RefresherTick(m_app, m_state);
 
 	CHttpServer::Response r;
-	// 204 with no body. Everything this used to echo came from the request
-	// URL, and `ok` restated the status code -- see the mutation-response
-	// rule in REFERENCE.md.
+	// 204 with no body -- see the mutation-response rule in REFERENCE.md.
 	r.status = 204;
 	r.content_type.clear();
 	return r;
@@ -7255,11 +6608,9 @@ CHttpServer::Response CApiDispatcher::HandleServerUpdateFromUrl(const CHttpServe
 	if (auto rej = RequireAdmin(a))
 		return *rej;
 
-	// amuled streams the new server list into its CServerList
-	// asynchronously over the next few ticks (download + parse + merge
-	// in CServerList::UpdateServerMetFromURL). The inline RefresherTick
-	// grabs whatever's already there; the `server_added` SSE events keep
-	// firing on subsequent natural ticks as more entries land.
+	// amuled streams the new server list into its CServerList asynchronously
+	// over the next few ticks (CServerList::UpdateServerMetFromURL), so the
+	// `server_added` SSE events keep firing on subsequent natural ticks.
 	static const UrlFetchSpec kSpec = {
 		"url", EC_OP_SERVER_UPDATE_FROM_URL, EC_TAG_SERVERS_UPDATE_URL, true, true
 	};
@@ -7271,11 +6622,9 @@ CHttpServer::Response CApiDispatcher::HandleServerUpdateFromUrl(const CHttpServe
 	return UrlFetchOp(m_app, m_state, kSpec, url);
 }
 
-// One "<ip>:<port>" selector, parsed. Split out from the lookup so a
-// selector that cannot be parsed is distinguishable from one that parses
-// but names no server we know -- those are a 400 and a 404, and the old
-// single-uint32 return collapsed them, and every other failure, onto 0.
-// Separate also so the parsing is testable without a populated cache.
+// One "<ip>:<port>" selector, parsed. Split out from the lookup so a selector
+// that cannot be parsed is distinguishable from one that parses but names no
+// server we know -- a 400 and a 404 respectively.
 struct IpPortSelector
 {
 	std::uint32_t ip_he; // host order, as ServerSnapshot::ip holds it
@@ -7284,13 +6633,10 @@ struct IpPortSelector
 
 // Accepts a dotted quad and a port in 1..65535, nothing else.
 //
-// Hostname forms are deliberately rejected: an earlier version fell back to
-// matching ServerSnapshot::address, which amuled fills from the wire "name"
-// tag -- that can be a hostname OR a synthetic display string ("Eserver
-// No.1"), so a DELETE by address could match a colliding label and remove
-// the wrong row. An exact IP + port has no such ambiguity.
-// boost::optional, not std::optional: this file already uses the boost form
-// (PreflightEvents), so it is the house spelling here.
+// Hostname forms are deliberately rejected: matching ServerSnapshot::address
+// would match the wire "name" tag, which can be a synthetic display string
+// ("Eserver No.1"), so a DELETE by address could remove the wrong row.
+// boost::optional, not std::optional: the house spelling in this file.
 boost::optional<IpPortSelector> ParseIpPortSelector(const std::string &ip_port)
 {
 	const auto colon = ip_port.rfind(':');
@@ -7307,13 +6653,9 @@ boost::optional<IpPortSelector> ParseIpPortSelector(const std::string &ip_port)
 	if (end == port_str.c_str() || *end != '\0' || port == 0 || port > 0xFFFF)
 		return boost::none;
 
-	// ParseIpv4Dotted rather than a second sscanf of our own: it landed on
-	// master while this was in review and does exactly this job, with three
-	// other callers already relying on it.
-	//
-	// Only genuine syntax failures are reported here. 0.0.0.0 parses fine
-	// and is rejected by the caller instead, so the two get error messages
-	// that describe what actually happened.
+	// Only genuine syntax failures are reported here. 0.0.0.0 parses fine and
+	// is rejected by the caller instead, so the two get error messages that
+	// describe what actually happened.
 	IpPortSelector sel;
 	sel.ip_he = 0;
 	if (!ParseIpv4Dotted(ip_str, sel.ip_he))
@@ -7323,12 +6665,9 @@ boost::optional<IpPortSelector> ParseIpPortSelector(const std::string &ip_port)
 	return sel;
 }
 
-// Resolve a selector to a server ECID, in the same shape as RequireAdmin
-// and RequireSnapshot: nullptr means @a ecid is set and the caller may
-// proceed, otherwise it is the response to return. Mapping the outcomes
-// here rather than at each call site is what keeps the three
-// /servers/{ip:port} routes from drifting apart, and no caller compares an
-// ECID against a magic value any more.
+// Resolve a selector to a server ECID, in the same shape as RequireAdmin and
+// RequireSnapshot: nullptr means @a ecid is set and the caller may proceed,
+// otherwise it is the response to return.
 std::unique_ptr<CHttpServer::Response> ResolveServerEcid(
 	const webapi::CState &state, const std::string &ip_port, std::uint32_t &ecid)
 {
@@ -7338,15 +6677,11 @@ std::unique_ptr<CHttpServer::Response> ResolveServerEcid(
 			"bad_request",
 			"malformed ip:port selector: expected a dotted quad and a port in 1..65535"));
 	}
-	// 0.0.0.0 is well-formed but is not a server address, and it must not be
-	// allowed to reach the lookup below: a ServerSnapshot whose
-	// EC_TAG_SERVER_IP the daemon did not ship keeps `ip == 0`
-	// (Refresher.cpp, which notes that `address` then reads "0.0.0.0:0"), so
-	// a 0.0.0.0 selector would otherwise resolve to whichever such row
-	// happened to share the port -- acting on a server the caller never
-	// named. Rejected with its own message rather than folded into the
-	// syntax error above, which would claim a malformed quad that the caller
-	// can see is not malformed.
+	// 0.0.0.0 is well-formed but is not a server address, and must not reach
+	// the lookup below: a ServerSnapshot whose EC_TAG_SERVER_IP the daemon did
+	// not ship keeps `ip == 0`, so a 0.0.0.0 selector would resolve to
+	// whichever such row happened to share the port -- acting on a server the
+	// caller never named.
 	if (sel->ip_he == 0) {
 		return std::make_unique<CHttpServer::Response>(
 			ErrorResponse(400, "bad_request", "0.0.0.0 is not a server address"));
@@ -7375,24 +6710,21 @@ CHttpServer::Response CApiDispatcher::HandleServerConnectByAddress(
 	std::uint32_t ecid = 0;
 	if (auto r = ResolveServerEcid(m_state, ip_port, ecid))
 		return *r;
-	// Delegate to the ECID-keyed handler; passing the resolved ECID as
-	// a decimal string keeps the contract uniform.
+	// Delegate to the ECID-keyed handler, passing the resolved ECID as a decimal string.
 	std::ostringstream os;
 	os << ecid;
 	return HandleServerConnect(req, os.str());
 }
 
-// PATCH /servers/{ecid} — priority and/or static flag (#692).
+// PATCH /servers/{ecid} -- priority and/or static flag (#692).
 //
 // EC_OP_SERVER_SET_STATIC_PRIO carries EC_TAG_SERVER as a plain ECID integer,
-// unlike EC_OP_SERVER_REMOVE next door which carries an EC_IPv4_t. It also
-// applies each of EC_TAG_SERVER_PRIO / EC_TAG_SERVER_STATIC only when present,
-// so a partial update is native to the wire and this handler simply forwards
-// whichever fields the body carried.
+// unlike EC_OP_SERVER_REMOVE next door which carries an EC_IPv4_t. It applies
+// EC_TAG_SERVER_PRIO / EC_TAG_SERVER_STATIC only when present, so a partial
+// update is native to the wire.
 //
-// amuled answers EC_OP_NOOP whether or not the ECID resolved, so an unknown
-// server is indistinguishable from success at the EC layer — the 404 has to
-// come from checking the snapshot here.
+// amuled answers EC_OP_NOOP whether or not the ECID resolved, so the 404 has
+// to come from checking the snapshot here.
 CHttpServer::Response CApiDispatcher::HandleServerPatch(
 	const CHttpServer::Request &req, const std::string &ecid_str)
 {
@@ -7468,14 +6800,11 @@ CHttpServer::Response CApiDispatcher::HandleServerPatch(
 	}
 	delete ec_resp;
 
-	// Inline refresh so the next GET /servers and the SSE stream both show
-	// the new values, matching the sibling server mutations.
+	// Inline refresh so the next GET /servers and the SSE stream show the new values.
 	(void)RefresherTick(m_app, m_state);
 
-	// A mutation answers with the resource, in the shape GET on this URL
-	// returns -- not an id the caller already had. See the mutation-response
-	// rule in REFERENCE.md. The inline refresh above is what makes the
-	// re-read see the values just written.
+	// A mutation answers with the resource -- see REFERENCE.md. The inline
+	// refresh above is what makes the re-read see the values just written.
 	webapi::ServerSnapshot s_after;
 	if (!FindServerByEcid(m_state, ecid, s_after)) {
 		// The server went away between the patch and the re-read. Nothing
@@ -7536,15 +6865,7 @@ CHttpServer::Response CApiDispatcher::HandleCategories(const CHttpServer::Reques
 	auto a = Authenticate(req);
 	if (!a.ok)
 		return a.rejection;
-	// amuled's EC suppresses the whole `EC_TAG_PREFS_CATEGORIES`
-	// block when no custom categories exist, and starts including
-	// index 0 once the first custom one is added. Faithful at the
-	// wire layer, but a client iterating /categories expecting at
-	// least the default has to special-case the empty case. Inject
-	// a synthetic index-0 entry when missing so clients see the same
-	// shape regardless of category count, and gives category 0 the
-	// name and path amuled does not hold for it -- see
-	// CategoriesWithDefault.
+	// Injects the synthetic index-0 category -- see CategoriesWithDefault.
 	std::vector<webapi::CategorySnapshot> cats = CategoriesWithDefault(m_state);
 	ListParams params;
 	if (auto r = ParseListParams(QueryOf(req), params))
@@ -7560,12 +6881,9 @@ CHttpServer::Response CApiDispatcher::HandleKad(const CHttpServer::Request &req)
 	if (auto r = RequireSnapshot(m_state))
 		return *r;
 
-	// Dashboard() rather than Kad(): `connected_since` below lives on
-	// the status snapshot (the refresher already parses it there for
-	// GET /status), and taking both halves in one shared_lock keeps
-	// the timestamp describing the same tick as the rest of the
-	// payload. Parsing the tag a second time into KadSnapshot would
-	// duplicate state for no gain.
+	// Dashboard() rather than Kad(): `connected_since` below lives on the
+	// status snapshot, and taking both halves in one shared_lock keeps the
+	// timestamp describing the same tick as the rest of the payload.
 	const webapi::CState::DashboardSnapshot d = m_state.Dashboard();
 	const webapi::KadSnapshot &k = d.kad;
 	CHttpServer::Response r;
@@ -7576,21 +6894,15 @@ CHttpServer::Response CApiDispatcher::HandleKad(const CHttpServer::Request &req)
 	// Bare object (Q3 — Kad is a single resource, not a list).
 	w.Key("state");
 	w.ValueString(wxString::FromUTF8(k.state.c_str()));
-	// Our own Kademlia node id, null while Kad is not running (i.e.
-	// exactly when `state` is "disabled"). Persisted by the daemon,
-	// so unlike every other identifier for the local node it is
-	// stable across restarts. Null rather than "": every other field
-	// in this object spells absence that way, and an empty string is
-	// not a value a node id can take.
+	// Our own Kademlia node id, null while Kad is not running. Persisted by
+	// the daemon, so unlike every other identifier for the local node it is
+	// stable across restarts.
 	WriteStringOrNull(w, "node_id", !k.node_id.empty(), k.node_id);
 	// Two independent measurements, not a verdict and a refinement.
 	// firewalled_tcp is a vote needing two peers to confirm reachability;
 	// firewalled_udp is a directed test. LAN mode forces both to false.
-	//
-	// All three are null unless Kad is connected. They used to answer
-	// `true`/`false` regardless -- firewalled_tcp from a connstate bit that
-	// outlives the disconnect, the other two from their struct defaults -- so a
-	// stopped Kad reported a reachability verdict it had not measured.
+	// All three are null unless Kad is connected: firewalled_tcp comes from a
+	// connstate bit that outlives the disconnect, the others from defaults.
 	WriteBoolOrNull(w, "firewalled_tcp", k.has_firewalled_tcp, k.firewalled_tcp);
 	WriteBoolOrNull(w, "firewalled_udp", k.has_firewalled_udp, k.firewalled_udp);
 	WriteBoolOrNull(w, "lan_mode", k.has_lan_mode, k.lan_mode);
@@ -7598,8 +6910,7 @@ CHttpServer::Response CApiDispatcher::HandleKad(const CHttpServer::Request &req)
 	// not connected, so gate on `state` rather than on a nonzero.
 	w.Key("connected_since_at");
 	w.ValueInt(static_cast<int64_t>(d.status.kad_connected_since));
-	// Ours, as opposed to `buddy.ip` below — which is why this one
-	// is not called plain `ip`.
+	// Ours, as opposed to `buddy.ip` below -- which is why it is not plain `ip`.
 	WriteStringOrNull(w, "public_ip", !k.public_ip.empty(), k.public_ip);
 	WriteKadNetworkObject(w, k);
 	// Both objects are null-valued unless Kad is connected: amuled only ships
@@ -7627,12 +6938,9 @@ namespace
 {
 
 // `?tail=N` parser. An absent parameter yields 0, which is every caller's
-// contract for "return everything".
-// 100k lines is the cap: a bogus `?tail=2147483647` would otherwise try to
-// serialise the entire wxString through the JSON escaper. Non-numeric and
-// out-of-range values are a 400, like every other count on the surface; it used
-// to clamp silently, which meant a client asking for more got fewer with
-// nothing saying so.
+// contract for "return everything". 100k lines is the cap: a bogus
+// `?tail=2147483647` would otherwise try to serialise the entire wxString
+// through the JSON escaper. Out-of-range values are a 400, never a silent clamp.
 std::unique_ptr<CHttpServer::Response> ParseTailParam(const std::string &query, std::size_t &out)
 {
 	const auto qmap = web_api_path::ParseQuery(query);
@@ -7643,8 +6951,7 @@ std::unique_ptr<CHttpServer::Response> ParseTailParam(const std::string &query, 
 	return nullptr;
 }
 
-// Return a copy of `all` containing at most `tail` trailing lines.
-// `tail == 0` means "all lines" (no tailing).
+// Return a copy of `all` with at most `tail` trailing lines; 0 means all.
 std::vector<std::string> SliceTail(const std::vector<std::string> &all, std::size_t tail)
 {
 	if (tail == 0 || all.size() <= tail)
@@ -7652,16 +6959,12 @@ std::vector<std::string> SliceTail(const std::vector<std::string> &all, std::siz
 	return std::vector<std::string>(all.begin() + (all.size() - tail), all.end());
 }
 
-// For a single-string log (e.g. /logs/server_info), `?tail=N` slices
-// at line boundaries from the END so the first line of the response
-// is always whole. tail=0 returns the input verbatim.
+// For a single-string log, `?tail=N` slices at line boundaries from the END so
+// the first line of the response is always whole. tail=0 returns it verbatim.
 std::string TailString(const std::string &text, std::size_t tail_lines)
 {
 	if (tail_lines == 0 || text.empty())
 		return text;
-	// Walk backwards counting newlines until we've found `tail_lines`
-	// of them; whatever's after the last seen newline becomes the
-	// response.
 	std::size_t pos = text.size();
 	std::size_t seen = 0;
 	while (pos > 0 && seen < tail_lines) {
@@ -7669,8 +6972,7 @@ std::string TailString(const std::string &text, std::size_t tail_lines)
 		if (text[pos] == '\n')
 			++seen;
 	}
-	// Advance past the leading '\n' so the response doesn't start
-	// with a blank line.
+	// Advance past the leading '\n' so the response does not start blank.
 	if (pos < text.size() && text[pos] == '\n')
 		++pos;
 	return text.substr(pos);
@@ -7700,15 +7002,11 @@ void WriteStatsValue(CJsonWriter &w, const webapi::StatsTreeValue &v)
 	}
 	// Additive, locale-independent token for well-known sentinel values
 	// ("never"/"not_available"); the English "value" above is kept so old
-	// clients keep working.
-	// `token`, not `enum`: `enum` is a reserved word in C++, C#, Java, Rust,
-	// PHP and Swift, so a generated client cannot name a field after the key.
-	// null when the value is not a sentinel -- there is no token, which is a
-	// value rather than something the daemon failed to send.
+	// clients keep working. `token`, not `enum`: `enum` is reserved in C++, C#,
+	// Java, Rust, PHP and Swift, so a generated client could not name a field it.
 	WriteStringOrNull(w, "token", !v.enum_token.empty(), v.enum_token);
-	// Optional nested sub-value. Three different quantities depending on
-	// the node -- percentage of parent, packet count, or all-time total --
-	// so a client formats it from its `type`, not from its position.
+	// Optional nested sub-value: percentage of parent, packet count, or
+	// all-time total depending on the node, so a client formats it from `type`.
 	w.Key("extra");
 	if (!v.extra.empty())
 		WriteStatsValue(w, v.extra.front());
@@ -7721,21 +7019,16 @@ void WriteStatsNode(CJsonWriter &w, const webapi::StatsTreeNode &n)
 {
 	w.BeginObject();
 	// Stable machine key, when the daemon provides one. OMITTED rather than
-	// null when absent, and deliberately: absence here means a daemon too old
-	// to send it, which REFERENCE.md's unknown-value rule keeps distinct from
-	// "there is no key" -- the same distinction that keeps `result_count`
-	// omitted on /search.
+	// null when absent: absence means a daemon too old to send it, which
+	// REFERENCE.md's unknown-value rule keeps distinct from "there is no key".
 	if (!n.key.empty()) {
 		w.Key("key");
 		w.ValueString(wxString::FromUTF8(n.key.c_str()));
 	}
-	// Raw machine value (client version / OS string) for data-labelled
-	// nodes; omitted when absent so clients read it without parsing `label`.
+	// Raw machine value (client version / OS string) for data-labelled nodes.
 	// `label_value`, not `raw`: for a row whose label is itself data
-	// ("v0.70b: %s") this carries the datum. "raw" says unprocessed without
-	// saying of what, and sits next to values[] where a reader would look for
-	// a raw value. null on a node whose label is not data -- there is no
-	// datum, as against the daemon not having sent one.
+	// ("v0.70b: %s") this carries the datum. null on a node whose label is not
+	// data -- there is no datum, as against the daemon not having sent one.
 	WriteStringOrNull(w, "label_value", !n.raw.empty(), n.raw);
 	w.Key("label");
 	w.ValueString(wxString::FromUTF8(n.label.c_str()));
@@ -7745,9 +7038,8 @@ void WriteStatsNode(CJsonWriter &w, const webapi::StatsTreeNode &n)
 		WriteStatsValue(w, v);
 	w.EndArray();
 	// Raw numeric UL:DL ratio (download-per-upload), for the ratio node only.
-	// Flat rather than wrapped by window: R11 puts the window in the key, the
-	// way uploaded_bytes_session / _total do everywhere else. Each is emitted
-	// only when computable, so a legacy daemon yields neither key.
+	// R11 puts the window in the key, the way uploaded_bytes_session / _total
+	// do. Each is emitted only when computable, so a legacy daemon yields neither.
 	if (n.has_ratio_session || n.has_ratio_total) {
 		if (n.has_ratio_session) {
 			w.Key("ratio_session");
@@ -7766,15 +7058,12 @@ void WriteStatsNode(CJsonWriter &w, const webapi::StatsTreeNode &n)
 	w.EndObject();
 }
 
-// Render an array of (t, value) points walking backwards from
-// snapshot_at. Earliest sample sits at points[start] and corresponds
-// to `snapshot_at - (samples.size()-1)*interval`; most recent sits
-// at `snapshot_at`.
+// Render an array of (t, value) points walking backwards from snapshot_at:
+// the earliest sample corresponds to `snapshot_at - (samples.size()-1)*interval`.
 // `extra_a` / `extra_b` are optional series point-aligned with `samples`,
-// emitted under `key_a` / `key_b` beside each `value`. Used by the
-// connections graph for its active-uploads / active-downloads lines; null or
-// short (an amuled predating the tag reports neither) leaves the keys off
-// entirely, so a consumer can tell "not reported" from "zero".
+// emitted under `key_a` / `key_b` beside each `value`. null or short (an amuled
+// predating the tag reports neither) leaves the keys off entirely, so a
+// consumer can tell "not reported" from "zero".
 void WritePointArray(CJsonWriter &w,
 	const std::vector<std::uint32_t> &samples,
 	std::time_t snapshot_at,
@@ -7799,9 +7088,7 @@ void WritePointArray(CJsonWriter &w,
 			snapshot_at - static_cast<std::time_t>((samples.size() - 1 - i) * interval);
 		w.BeginObject();
 		// One representation, unix seconds, named `_at` like every other time
-		// on the surface (R3). The ISO twin is dropped: formatting is a client
-		// concern, and it cost a key plus ~22 bytes on every point of an array
-		// that runs to max_points.
+		// on the surface (R3). Formatting is a client concern.
 		w.Key("at");
 		w.ValueInt(static_cast<int64_t>(t));
 		w.Key("value");
@@ -7833,12 +7120,10 @@ void WriteSearchObject(CJsonWriter &w, const webapi::SearchResult &r)
 
 namespace
 {
-// Reverse of SearchTypeFromString (below, further down this file).
-// EC_SEARCH_LOCAL/GLOBAL/KAD share their numeric values with CSearchList's
-// own SearchType (LocalSearch/GlobalSearch/KadSearch), which is what
-// EC_TAG_SEARCH_LIFECYCLE_KIND carries on the wire (see ExternalConn.cpp's
-// Get_EC_Response_Search_List), so a plain uint8 in is enough -- no
-// separate SearchType include needed here.
+// Reverse of SearchTypeFromString below. EC_SEARCH_LOCAL/GLOBAL/KAD share their
+// numeric values with CSearchList's own SearchType, which is what
+// EC_TAG_SEARCH_LIFECYCLE_KIND carries on the wire, so a plain uint8 in is
+// enough -- no separate SearchType include needed here.
 wxString SearchKindToString(std::uint8_t kind)
 {
 	switch (kind) {
@@ -7847,9 +7132,8 @@ wxString SearchKindToString(std::uint8_t kind)
 	case EC_SEARCH_KAD:
 		return wxString::FromAscii("kad");
 	case EC_SEARCH_BROWSE:
-		// A "View Files" browse of one peer's share. Reported, never
-		// accepted by SearchTypeFromString: browses are not started
-		// through the search endpoint.
+		// A "View Files" browse of one peer's share. Reported, never accepted
+		// by SearchTypeFromString: browses are not started through /search.
 		return wxString::FromAscii("browse");
 	case EC_SEARCH_GLOBAL:
 	default:
@@ -7858,11 +7142,9 @@ wxString SearchKindToString(std::uint8_t kind)
 }
 
 // Shared by HandleSearchResults' `progress.state` and HandleSearchList's
-// `state`, so the two endpoints cannot drift into reporting different
-// strings for the same search's lifecycle. state_val is a raw
-// CSearchList::SearchLifecycleState numeric value (IDLE=0/RUNNING=1/
-// FINISHED=2); ExternalConn.cpp's static_assert next to
-// Get_EC_Response_Search_List keeps that alignment honest at compile time.
+// `state`, so the two cannot drift. state_val is a raw
+// CSearchList::SearchLifecycleState numeric (IDLE=0/RUNNING=1/FINISHED=2);
+// a static_assert in ExternalConn.cpp keeps that alignment honest.
 wxString SearchLifecycleStateToString(std::uint8_t state_val)
 {
 	switch (state_val) {
@@ -7882,11 +7164,9 @@ CHttpServer::Response CApiDispatcher::HandleStatsTree(const CHttpServer::Request
 	if (!a.ok)
 		return a.rejection;
 
-	// ?max_client_versions=N — caps how many per-software version rows the
-	// daemon serializes (EC_TAG_STATTREE_CAPPING). 0 is unlimited, which
-	// stays the default so a caller that never passes it sees today's tree.
-	// Only the version lists are affected; the OS breakdown and the fixed
-	// skeleton nodes are not.
+	// ?max_client_versions=N -- caps how many per-software version rows the
+	// daemon serializes (EC_TAG_STATTREE_CAPPING). 0 is unlimited. Only the
+	// version lists are affected, not the OS breakdown or skeleton nodes.
 	std::uint8_t max_client_versions = 0;
 	{
 		std::string query;
@@ -7900,12 +7180,10 @@ CHttpServer::Response CApiDispatcher::HandleStatsTree(const CHttpServer::Request
 		max_client_versions = static_cast<std::uint8_t>(v);
 	}
 
-	// lazy-fetch with 1 s TTL coalescing. The fetcher runs
-	// the EC roundtrip under m_app's m_ec_mtx (SendRecvSerialized);
-	// concurrent burst reads serialize on m_stats_tree_cache's mutex
-	// and the second waiter reads the just-stored value. As with the graph
-	// bundle, the cache is unkeyed, so an entry fetched at a different cap
-	// counts as a miss.
+	// Lazy-fetch with 1 s TTL coalescing. The fetcher runs the EC roundtrip
+	// under m_app's m_ec_mtx (SendRecvSerialized); concurrent burst reads
+	// serialize on m_stats_tree_cache's mutex. The cache is unkeyed, so an
+	// entry fetched at a different cap counts as a miss.
 	auto pair = m_stats_tree_cache.GetOrFetch(
 		std::chrono::milliseconds(1000),
 		[this, max_client_versions]() -> TtlPair_StatsTree {
@@ -7937,10 +7215,8 @@ CHttpServer::Response CApiDispatcher::HandleStatsTree(const CHttpServer::Request
 	CHttpServer::Response r;
 	r.status = 200;
 	r.content_type = "application/json";
-	// No snapshot_at: the ETag is the cache validator
-	// as the cache validator. The TtlPair_StatsTree still tracks the
-	// fetched-at time internally (drives the 1 s TTL coalescer) — it
-	// just isn't surfaced any more.
+	// No snapshot_at: the ETag is the cache validator. TtlPair_StatsTree still
+	// tracks the fetched-at time internally to drive the 1 s TTL coalescer.
 	(void)ts;
 	CJsonWriter w;
 	w.BeginObject();
@@ -7985,27 +7261,23 @@ CHttpServer::Response CApiDispatcher::HandleStatsGraph(
 		query = req.target.substr(q + 1);
 	const auto qmap = web_api_path::ParseQuery(query);
 
-	// ?interval_seconds=N — seconds between samples, passed through as
-	// EC_TAG_STATSGRAPH_SCALE. Rejected rather than clamped: 0 makes the
-	// daemon answer EC_OP_FAILED, which would reach the caller as an
-	// unexplained empty graph, and past an hour almost every point falls
-	// off the start of the session (the daemon's ranges hold ~63 h in
-	// total) — besides, SCALE is a uint16 on the wire.
+	// ?interval_seconds=N -- seconds between samples, passed through as
+	// EC_TAG_STATSGRAPH_SCALE. Rejected rather than clamped: 0 makes the daemon
+	// answer EC_OP_FAILED, which would reach the caller as an unexplained empty
+	// graph, and SCALE is a uint16 on the wire.
 	std::uint32_t interval = 1;
 	{
 		std::uint64_t v = interval;
-		// Named for its unit, and named the same on the way in as on the
-		// way out: the response has always echoed `interval_seconds`, so
-		// a client had to write one spelling and read back another.
+		// Named for its unit, and the same on the way in as on the way out:
+		// the response has always echoed `interval_seconds`.
 		if (auto r = ParseUintParam(qmap, "interval_seconds", 1, 3600, v))
 			return *r;
 		interval = static_cast<std::uint32_t>(v);
 	}
 
 	// Lazy-fetch the full graph bundle (one EC call serves all four named
-	// graphs, so the cache shares across concurrent requests for different
-	// graph names). The cache is unkeyed, so an entry fetched at another
-	// interval has to count as a miss — see CTtlCache's validated overload.
+	// graphs). The cache is unkeyed, so an entry fetched at another interval
+	// has to count as a miss -- see CTtlCache's validated overload.
 	auto pair = m_stats_graphs_cache.GetOrFetch(
 		std::chrono::milliseconds(1000),
 		[this, interval]() -> TtlPair_StatsGraphs {
@@ -8043,10 +7315,9 @@ CHttpServer::Response CApiDispatcher::HandleStatsGraph(
 		series = &g.kad_nodes;
 	}
 
-	// ?width=N — tail the sample count returned. 0 / absent means
-	// "everything we have". Applied after the fetch, deliberately: the EC
-	// request always asks for the full window, so one cached bundle still
-	// answers every (graph, width) combination.
+	// ?width=N -- tail the sample count returned. Applied after the fetch,
+	// deliberately: the EC request always asks for the full window, so one
+	// cached bundle still answers every (graph, width) combination.
 	std::size_t width = 0;
 	{
 		std::uint64_t v = 0;
@@ -8071,12 +7342,9 @@ CHttpServer::Response CApiDispatcher::HandleStatsGraph(
 	// repeating records. `points` is never longer than this.
 	w.Key("max_points");
 	w.ValueInt(static_cast<int64_t>(g.max_points));
-	// No snapshot_at in the response. WritePointArray
-	// still consumes `ts` to compute per-point timestamps (anchoring
-	// the time-series backwards from the fetch wall-clock).
-	//
-	// The two extra series exist only on the connections graph, and only
-	// when the daemon sent the second data blob.
+	// No snapshot_at in the response; WritePointArray still consumes `ts` to
+	// anchor per-point timestamps backwards from the fetch wall-clock. The two
+	// extra series exist only on the connections graph.
 	w.Key("points");
 	if (graph == "connections") {
 		WritePointArray(w,
@@ -8091,15 +7359,12 @@ CHttpServer::Response CApiDispatcher::HandleStatsGraph(
 	} else {
 		WritePointArray(w, *series, ts, g.interval_seconds, width);
 	}
-	// Session totals tag along — clients showing "this session: X GB
-	// down" don't need a separate roundtrip. Divide any of the three by
-	// duration_seconds for the session average the desktop plots.
+	// Session totals tag along -- no separate roundtrip. Divide any of the
+	// three by duration_seconds for the session average the desktop plots.
 	w.Key("session");
 	w.BeginObject();
-	// Past tense, like `downloaded_bytes_session` / `uploaded_bytes_session`
-	// on the client and shared rows: these are bytes already moved, not a
-	// rate and not a plan. The `session` wrapper scopes them; it does not
-	// license a second spelling of the same quantity.
+	// Past tense, like `downloaded_bytes_session` elsewhere: bytes already
+	// moved, not a rate. The `session` wrapper scopes them.
 	w.Key("downloaded_bytes");
 	w.ValueInt(static_cast<int64_t>(g.session_download_bytes));
 	w.Key("uploaded_bytes");
@@ -8121,18 +7386,11 @@ CHttpServer::Response CApiDispatcher::HandleSearchResults(
 	if (!a.ok)
 		return a.rejection;
 
-	// Read straight from the refresher-maintained state. POST /search
-	// flips the active flag; RefresherTick polls amuled while active and
-	// reads the daemon's unambiguous EC_TAG_SEARCH_LIFECYCLE_* tags
-	// (state + unified percent) — see RefresherTick.cpp + SearchList.cpp.
-	// The state stores the normalized (kind, percent, complete, active);
-	// no further interpretation here. The `progress` object carries the
-	// same state/kind/percent as the `search_progress` SSE event (the
-	// event additionally ships a results count, since it has no results
-	// array beside it).
-	// The search is named in the path. An id that names no live slot (never
-	// started, freed, or evicted from the daemon's ring) is a 404 — distinct
-	// from a known-but-empty search, which returns an idle/empty envelope.
+	// Read straight from the refresher-maintained state: POST /search flips the
+	// active flag, RefresherTick polls amuled while active and stores the
+	// normalized (kind, percent, complete, active). An id that names no live
+	// slot (never started, freed, or evicted from the daemon's ring) is a 404,
+	// distinct from a known-but-empty search, which returns an idle envelope.
 	if (auto rej = RequireSearch(search_id))
 		return *rej;
 	// A FINISHED search is not polled by the tick, so its cached results
@@ -8142,26 +7400,21 @@ CHttpServer::Response CApiDispatcher::HandleSearchResults(
 	const std::vector<webapi::SearchResult> results_vec = m_state.Search(search_id);
 	const webapi::SearchProgressSnapshot progress = m_state.SearchProgress(search_id);
 
-	// #357 pagination/sort. This endpoint keeps its own envelope (the
-	// `progress` object rides alongside `results`), so it can't call
-	// ListResponse, but it shares the window + page-meta helpers.
+	// This endpoint keeps its own envelope (`progress` rides alongside
+	// `results`), so it cannot call ListResponse, but it shares the helpers.
 	ListParams params;
 	if (auto err = ParseListParams(QueryOf(req), params))
 		return *err;
 	static const ListComparators<webapi::SearchResult> kComps = {
-		// Identity column: immutable, so it is the one a keyset sweep can
-		// anchor on. Listed first because that is the order a paging client
-		// cares about, not the order a UI table does.
+		// Identity column: immutable, so a keyset sweep can anchor on it.
 		{ "hash", SORT_BY(hash), ANCHOR_ON(hash) },
 		{ "name", SORT_BY(name) },
 		// R7: spelled like the response keys they order by.
 		{ "size_bytes", SORT_BY(size) },
 		{ "sources.total", SORT_BY(source_count) },
 		{ "rating", SORT_BY(rating) },
-		// Browse listings are read folder by folder, which is how the
-		// desktop sorts its Directories column too. Empty on server/Kad
-		// hits, so sorting a non-browse search by it is a stable no-op
-		// rather than an error.
+		// Browse listings are read folder by folder. Empty on server/Kad hits,
+		// so sorting a non-browse search by it is a stable no-op.
 		{ "directory", SORT_BY(directory) },
 	};
 	std::vector<const webapi::SearchResult *> window;
@@ -8180,21 +7433,16 @@ CHttpServer::Response CApiDispatcher::HandleSearchResults(
 		WriteSearchObject(w, *item);
 	w.EndArray();
 	WritePageMeta(w, total, params);
-	// The search these results belong to. Echoed even though the caller put
-	// it in the path: clients key their tabs on it and it costs nothing.
+	// Echoed even though the caller put it in the path: clients key tabs on it.
 	w.Key("search_id");
 	w.ValueInt(static_cast<int64_t>(search_id));
-	// What was searched for. Without it a client that adopted an id (from
-	// GET /search, or from another client) would have to cross-reference the
-	// list endpoint just to label the tab it is already reading. For a browse
-	// this is the peer's name rather than a query string.
+	// What was searched for, so a client that adopted an id need not
+	// cross-reference /search to label its tab. For a browse, the peer's name.
 	w.Key("query");
 	w.ValueString(wxString::FromUTF8(m_state.SearchQuery(search_id).c_str()));
-	// Mirrors the `search_progress` SSE event field-for-field. `state`
-	// is canonical and encodes the full lifecycle (running / finished /
-	// idle), so we don't also emit redundant `active` / `complete`
-	// booleans — consumers derive them from `state` and read the same
-	// shape whether they poll here or subscribe to the stream.
+	// Mirrors the `search_progress` SSE event field-for-field. `state` encodes
+	// the full lifecycle, so no redundant `active` / `complete` booleans --
+	// consumers derive them and read the same shape polling or streaming.
 	w.Key("progress");
 	w.BeginObject();
 	w.Key("state");
@@ -8225,32 +7473,23 @@ std::unique_ptr<CHttpServer::Response> CApiDispatcher::RequireSearch(std::uint32
 
 void CApiDispatcher::RefreshSearchIfStale(std::uint32_t search_id)
 {
-	// ClaimSearchRefresh does the gating: it returns true only for a slot
-	// that exists, is not active (the tick already covers those every
-	// second), and has not been fetched within the TTL -- and it stamps the
-	// slot as it hands out the claim, so two readers racing on the same
-	// finished search cost one roundtrip, not two.
+	// ClaimSearchRefresh does the gating: it returns true only for a slot that
+	// exists, is not active, and has not been fetched within the TTL -- and it
+	// stamps the slot as it hands out the claim, so racing readers cost one
+	// roundtrip.
 	static constexpr std::chrono::milliseconds kSearchRefreshTtl{ 1000 };
 	if (!m_state.ClaimSearchRefresh(search_id, kSearchRefreshTtl))
 		return;
 	// A failed roundtrip leaves the cached results in place: serving the
-	// previous set is strictly better than failing a read that has a
-	// perfectly good answer. An expiry is left to the tick's own retirement
-	// path rather than duplicated here.
+	// previous set beats failing a read that has a good answer.
 	//
-	// Deliberately the per-search FULL fetch and not the union, even though
-	// the union would refresh every stale search in one roundtrip. The union
-	// is a differential stream keyed on what the daemon has already sent this
-	// connection, so it tolerates exactly one issuer: with the refresher
-	// thread issuing it every tick, a second issuer here could have its reply
-	// applied out of order and leave a row no later poll can correct, because
-	// by then the daemon considers every field of it unchanged. A FULL reply
-	// carries the whole search and is idempotent, so it races nothing.
-	//
-	// Kept even though the tick now polls finished searches too: this covers
-	// the sub-tick window a client hits when it GETs immediately after
-	// starting a Kad notes lookup, which is what the poll-until-false loop in
-	// the reference does.
+	// Deliberately the per-search FULL fetch and not the union. The union is a
+	// differential stream keyed on what the daemon has already sent this
+	// connection, so it tolerates exactly one issuer: with the refresher thread
+	// issuing it every tick, a second issuer here could have its reply applied
+	// out of order and leave a row no later poll can correct, because by then
+	// the daemon considers every field of it unchanged. A FULL reply carries
+	// the whole search and is idempotent, so it races nothing.
 	(void)webapi::FetchOneSearchFull(m_app, m_state, search_id);
 }
 
@@ -8268,22 +7507,17 @@ bool CApiDispatcher::DiscoverSearchIfHeldByCore(std::uint32_t search_id)
 		if (static_cast<std::uint32_t>(entry.GetInt()) != search_id)
 			continue;
 		const CECTag *kindTag = entry.GetTagByName(EC_TAG_SEARCH_LIFECYCLE_KIND);
-		// The list entry carries the daemon's name for the search, which is
-		// the query string (or, for a browse, the peer's nickname). Taking it
-		// here is what lets an adopted search report its own `query` instead
-		// of an empty one.
+		// The list entry carries the daemon's name for the search -- the query
+		// string, or for a browse the peer's nickname.
 		const CECTag *nameTag = entry.GetTagByName(EC_TAG_SEARCH_NAME);
-		// ...and its lifecycle state, which was being dropped and replaced
-		// with an assumed "active". A finished search seeded as running is
-		// not just cosmetic: POST /search/{id}/more rejects a finished
-		// search, so it would have accepted one until the next tick
-		// corrected the flag, and answered 202 for a request amuled turns
-		// into a no-op. 1 = running, 2 = finished (SearchLifecycleStateToString).
+		// ...and its lifecycle state. A finished search seeded as running is
+		// not cosmetic: POST /search/{id}/more rejects a finished search, so it
+		// would answer 202 for a request amuled turns into a no-op.
+		// 1 = running, 2 = finished (SearchLifecycleStateToString).
 		const CECTag *stateTag = entry.GetTagByName(EC_TAG_SEARCH_LIFECYCLE_STATE);
 		const std::uint8_t state_val = stateTag ? static_cast<std::uint8_t>(stateTag->GetInt()) : 0;
-		// ...and the percent, when the daemon reports one. -1 means it did
-		// not, which is what an older daemon looks like; the seed then falls
-		// back to deriving it from the lifecycle state.
+		// ...and the percent, when the daemon reports one. -1 means it did not
+		// (an older daemon); the seed then derives it from the lifecycle state.
 		const CECTag *pctTag = entry.GetTagByName(EC_TAG_SEARCH_LIFECYCLE_PERCENT);
 		const int reported_pct = pctTag ? static_cast<int>(pctTag->GetInt()) : -1;
 		m_state.MarkSearchDiscovered(search_id,
@@ -8301,23 +7535,17 @@ bool CApiDispatcher::DiscoverSearchIfHeldByCore(std::uint32_t search_id)
 	if (found) {
 		// Seed the slot's results immediately, at EC_DETAIL_FULL. Waiting for
 		// the next union poll would leave it permanently empty: the union
-		// responder walks every search the core holds, so it has very likely
-		// already offered this search's results to this connection, found no
-		// slot for them, and dropped them -- and having sent them once, it
-		// will elide them from here on. This is the only chance to read them.
+		// responder has very likely already offered these results, found no
+		// slot, dropped them, and will elide them from here on.
 		(void)webapi::FetchOneSearchFull(m_app, m_state, search_id);
 	}
 	return found;
 }
 
-// Reachability fix (amule-org/amule#641): enumerates every search the
-// daemon currently holds via EC_OP_SEARCH_LIST, rather than reading the
-// Refresher-cached m_state (which -- like m_curr_search on amulegui --
-// only ever knows about searches THIS session started with POST /search).
-// A direct one-off EC round trip, same pattern HandleSearchStart already
-// uses for SEARCH_START; no Refresher/m_state changes needed to make a
-// search started by another client (or, once persistence lands, restored
-// from disk) discoverable here.
+// Enumerates every search the daemon currently holds via EC_OP_SEARCH_LIST,
+// rather than reading the Refresher-cached m_state, which only ever knows about
+// searches THIS session started with POST /search. That is what makes a search
+// started by another client discoverable here (amule-org/amule#641).
 CHttpServer::Response CApiDispatcher::HandleSearchList(const CHttpServer::Request &req)
 {
 	auto a = Authenticate(req);
@@ -8345,16 +7573,14 @@ CHttpServer::Response CApiDispatcher::HandleSearchList(const CHttpServer::Reques
 		const CECTag *stateTag = entry.GetTagByName(EC_TAG_SEARCH_LIFECYCLE_STATE);
 		row.state = SearchLifecycleStateToString(
 			stateTag ? static_cast<std::uint8_t>(stateTag->GetInt()) : 0);
-		// Browse ("View Files") entries carry the browsed peer's ecid. Without
-		// it a consumer sees `kind: "browse"` with no way to tell WHOSE share
-		// it is listing. Absent on an ordinary search, which never carries it.
+		// Browse ("View Files") entries carry the browsed peer's ecid -- without
+		// it a consumer cannot tell WHOSE share it is listing. Absent otherwise.
 		if (const CECTag *clientTag = entry.GetTagByName(EC_TAG_CLIENT)) {
 			row.has_client_ecid = true;
 			row.client_ecid = static_cast<std::uint32_t>(clientTag->GetInt());
 		}
-		// When THIS amuleapi started the search. Absent for one this process
-		// did not start -- another client's, or one the daemon restored from
-		// disk -- because a 0 would read as 1970 rather than "no idea".
+		// When THIS amuleapi started the search. Absent for one this process did
+		// not start, because a 0 would read as 1970 rather than "no idea".
 		row.started_at = m_state.SearchStartedAt(row.search_id);
 		// The same number GET /search/{id}/results reports as `total`. Absent
 		// when the daemon is older than the tag, so that "does not report"
@@ -8376,8 +7602,7 @@ CHttpServer::Response CApiDispatcher::HandleLogAmule(const CHttpServer::Request 
 	if (!a.ok)
 		return a.rejection;
 
-	// Extract the query string from the raw target (request.target is
-	// the literal URI, e.g. "/api/v0/logs/amule?tail=200").
+	// request.target is the literal URI, e.g. "/api/v0/logs/amule?tail=200".
 	std::string path, query;
 	const size_t q = req.target.find('?');
 	if (q != std::string::npos) {
@@ -8401,7 +7626,6 @@ CHttpServer::Response CApiDispatcher::HandleLogAmule(const CHttpServer::Request 
 		w.ValueString(wxString::FromUTF8(line.c_str()));
 	}
 	w.EndArray();
-	// Operator-debug metadata: total cached + how many we returned.
 	// Lets a client paging through history know what it missed.
 	w.Key("total_lines");
 	w.ValueInt(static_cast<int64_t>(all.size()));
@@ -8433,11 +7657,9 @@ CHttpServer::Response CApiDispatcher::HandleLogAmuleReset(const CHttpServer::Req
 	delete ec_resp;
 
 	// Drop the in-process mirror. This also bumps the log's clear-generation,
-	// which is what the next refresher tick reads to publish a `resync` for
-	// every subscriber rather than a log event -- the lines this channel
-	// promised are gone, so "re-read" is the honest signal. Publishing it here
-	// instead is not open to us: the bus has a single-publisher invariant and
-	// this is the HTTP thread.
+	// which the next refresher tick reads to publish a `resync` for every
+	// subscriber. Publishing it here is not open to us: the bus has a
+	// single-publisher invariant and this is the HTTP thread.
 	m_state.ClearAmuleLog();
 
 	CHttpServer::Response r;
@@ -8461,9 +7683,8 @@ CHttpServer::Response CApiDispatcher::HandleLogServerinfo(const CHttpServer::Req
 	if (auto r = ParseTailParam(query, tail))
 		return *r;
 
-	// Lazy-fetch via TtlCache. EC_OP_GET_SERVERINFO ships one
-	// EC_TAG_STRING with the whole accumulated text — amuled rotates
-	// it server-side so the size stays bounded.
+	// Lazy-fetch via TtlCache. EC_OP_GET_SERVERINFO ships one EC_TAG_STRING
+	// with the whole accumulated text; amuled rotates it server-side.
 	auto pair = m_server_info_cache.GetOrFetch(
 		std::chrono::milliseconds(1000), [this]() -> TtlPair_ServerInfo {
 			std::unique_ptr<CECPacket> req_ec(new CECPacket(EC_OP_GET_SERVERINFO));
@@ -8497,8 +7718,7 @@ CHttpServer::Response CApiDispatcher::HandleLogServerinfo(const CHttpServer::Req
 	w.BeginObject();
 	w.Key("text");
 	w.ValueString(wxString::FromUTF8(text.c_str()));
-	// The total length lets a client decide whether to re-poll
-	// with a smaller `?tail=` for incremental display.
+	// Lets a client decide whether to re-poll with a smaller `?tail=`.
 	w.Key("total_bytes");
 	w.ValueInt(static_cast<int64_t>(log.text.size()));
 	w.Key("returned_bytes");
@@ -8545,11 +7765,9 @@ namespace
 // (PrefsSchema.cpp). Shared by the GET handler and the PATCH echo so the
 // response shape is defined exactly once.
 //
-// Categories whose name contains a dot are nested one level under their
-// prefix (remote_controls.webserver -> "remote_controls": {"webserver": {...}}),
-// which is how the two remote-control subsystems avoid prefixing every field.
-// Write-only rows (passwords) and Rejected rows are
-// never emitted.
+// Categories whose name contains a dot are nested one level under their prefix
+// (remote_controls.webserver -> "remote_controls": {"webserver": {...}}).
+// Write-only rows (passwords) and Rejected rows are never emitted.
 void WritePrefFieldValue(CJsonWriter &w, const webapi::PrefField &f, const webapi::PreferencesSnapshot &p)
 {
 	// The accessor takes a non-const snapshot; emitting never mutates it.
@@ -8610,9 +7828,7 @@ void WritePreferencesBody(CJsonWriter &w, const webapi::PreferencesSnapshot &p)
 
 		w.Key(top.c_str());
 		w.BeginObject();
-		// Fields sitting directly on the top-level category.
 		WritePrefCategoryFields(w, top.c_str(), p);
-		// Then each nested sub-object, in table order.
 		for (std::size_t s = 0; s < webapi::PrefCategoryCount(); ++s) {
 			const char *sub = webapi::PrefCategories()[s].name;
 			if (std::strncmp(sub, top.c_str(), top.size()) != 0 || sub[top.size()] != '.')
@@ -8651,11 +7867,9 @@ CHttpServer::Response CApiDispatcher::HandlePreferences(const CHttpServer::Reque
 namespace
 {
 
-// Helpers that pull (& validate) optional fields from a JSON object.
-// Each returns true and writes `out` if the field is present and the
-// right shape; returns false on absence. On wrong shape, writes
-// `err_label` for the caller to relay to the client and returns false
-// as well (errors take priority via the err_label out-param).
+// Helpers that pull (& validate) optional fields from a JSON object. Each
+// returns true and writes `out` when present and the right shape; on wrong
+// shape it writes `err_label` for the caller to relay and returns false.
 struct PrefsParseError
 {
 	bool is_error = false;
@@ -8670,16 +7884,12 @@ struct PrefsParseError
 // --- Generic optional-field extractors for the #437 categories -------
 //
 // Each pulls one optional key from a sub-object into the EC group tag,
-// validating its JSON type. Returns false and sets `err` on a type/
-// range error; returns true (and leaves `group` untouched) when the
-// key is simply absent. `any` is set true when a field is written.
-// Booleans always pack as a value tag (uint8 0/1): CEC_Prefs_Packet::
-// Apply reads `GetInt()!=0` under EC_DETAIL_FULL, so an empty presence
-// tag would be read as false.
-// `scale` converts the API value to the unit EC carries (see
-// PrefField::ec_scale); 0 means the two already agree. `max` is checked
-// against the value the caller sent, before scaling, so the error names the
-// number they actually wrote.
+// validating its JSON type. Returns true (leaving `group` untouched) when the
+// key is simply absent. Booleans always pack as a value tag (uint8 0/1):
+// CEC_Prefs_Packet::Apply reads `GetInt()!=0` under EC_DETAIL_FULL, so an
+// empty presence tag would be read as false. `scale` converts the API value to
+// the unit EC carries; `max` is checked before scaling, so the error names the
+// number the caller actually wrote.
 bool PrefTakeUint(const picojson::object &o,
 	CECTag &group,
 	const char *key,
@@ -8700,28 +7910,22 @@ bool PrefTakeUint(const picojson::object &o,
 	}
 	const double v = it->second.get<double>();
 	// Reject a fractional value rather than truncating it at the cast below.
-	// Every numeric preference routes through this setter, so without the
-	// check `100.5` was accepted and stored as `100` on all of them, under an
-	// error string that already promised "non-negative integer". The step
-	// modulo further down is not a substitute: it runs on the already-
-	// truncated value, so it tests the floor's alignment and never
-	// integrality, and a field with no step skips it entirely.
+	// The step modulo further down is not a substitute: it runs on the already-
+	// truncated value, so it tests the floor's alignment and never integrality,
+	// and a field with no step skips it entirely.
 	if (!IsIntegralJsonNumber(v)) {
 		err = std::string(key) + " must be a non-negative integer";
 		return false;
 	}
 	if (v < 0 || v > static_cast<double>(max) || v < static_cast<double>(min)) {
 		// Name the bounds. These domains are narrower than the field's type for
-		// reasons a caller cannot infer -- a uint8 behind a byte count, a clamp
-		// that does not run until the next daemon start -- so "out of range"
-		// alone leaves them guessing which end they hit and by how much.
+		// reasons a caller cannot infer, so "out of range" alone leaves them guessing.
 		err = std::string(key) + " out of range (" + std::to_string(min) + "-" + std::to_string(max) +
 		      ")";
 		return false;
 	}
 	// Quantised rows: the core's setter divides, so a value between two steps
-	// is truncated on the way in. Rejected rather than silently rounded, so the
-	// value a client writes is always the value stored.
+	// is truncated on the way in. Rejected rather than silently rounded.
 	if (step && (static_cast<std::uint64_t>(v) % step) != 0) {
 		err = std::string(key) + " must be a multiple of " + std::to_string(step);
 		return false;
@@ -8757,11 +7961,10 @@ bool PrefTakeBool(const picojson::object &o,
 	return true;
 }
 
-// Enum field (#655): the API spells the value out ("socks5", "friends", ...)
-// while EC carries the bare ordinal. `names` lists the accepted strings in
-// wire order, so a name's index is exactly the value the daemon's Apply()
-// casts back to its enum. Shared by connection.proxy_type,
-// security.shared_files_visibility and geoip.source.
+// Enum field: the API spells the value out ("socks5", "friends", ...) while EC
+// carries the bare ordinal. `names` lists the accepted strings in wire order,
+// so a name's index is exactly the value the daemon's Apply() casts back to
+// its enum.
 bool PrefTakeEnum(const picojson::object &o,
 	CECTag &group,
 	const char *key,
@@ -8844,9 +8047,8 @@ bool PrefTakeStringArray(const picojson::object &o,
 	return true;
 }
 
-// Write-only password: hash the plaintext with MD5 (matching how the
-// daemon stores WS/amuleapi passwords) and pack the 16-byte digest as
-// the given hash tag. Never round-trips on GET.
+// Write-only password: hash the plaintext with MD5 (matching how the daemon
+// stores WS/amuleapi passwords) and pack the 16-byte digest. Never on GET.
 bool PrefTakePassword(const picojson::object &o,
 	CECTag &group,
 	const char *key,
@@ -8905,14 +8107,10 @@ CHttpServer::Response CApiDispatcher::HandlePreferencesPatch(const CHttpServer::
 	const auto &obj = root.get<picojson::object>();
 
 	// Body shape mirrors the GET: one optional sub-object per category, every
-	// field within optional, fields not present left unchanged. Categories and
-	// their fields both come from the schema table (#655), so the accepted
-	// shape cannot drift from the emitted one.
-	//
-	// Build at EC_DETAIL_FULL: amuled's Apply() gates ApplyBoolean on
-	// detail == FULL, so booleans are only honoured at that level. That is
-	// also why every bool below is written as a value tag rather than the
-	// presence tag the daemon uses when serializing in the other direction.
+	// field within optional. Both come from the schema table, so the accepted
+	// shape cannot drift from the emitted one. Built at EC_DETAIL_FULL because
+	// amuled's Apply() gates ApplyBoolean on it -- which is also why every bool
+	// below is a value tag rather than the presence tag the daemon serializes.
 	std::unique_ptr<CECPacket> ec_req(new CECPacket(EC_OP_SET_PREFERENCES, EC_DETAIL_FULL));
 	bool any_change = false;
 	// Names of read-only fields the body carried, so a request naming only
@@ -8962,8 +8160,7 @@ CHttpServer::Response CApiDispatcher::HandlePreferencesPatch(const CHttpServer::
 	for (std::size_t i = 0; i < webapi::PrefSchemaSize(); ++i) {
 		const webapi::PrefField &f = webapi::PrefSchema()[i];
 
-		// Locate this field's category object; skip the whole row when the
-		// client did not send that category at all.
+		// Skip the whole row when the client did not send that category at all.
 		const picojson::object *src = nullptr;
 		for (std::size_t c = 0; c < webapi::PrefCategoryCount(); ++c) {
 			if (std::strcmp(webapi::PrefCategories()[c].name, f.category) == 0) {
@@ -8974,18 +8171,12 @@ CHttpServer::Response CApiDispatcher::HandlePreferencesPatch(const CHttpServer::
 		if (!src || src->find(f.key) == src->end())
 			continue;
 
-		// Read-only fields (daemon capabilities, live status) are ignored
-		// rather than rejected: the read-modify-write round trip -- GET the
-		// object, flip one value, PATCH it back -- necessarily sends them
-		// back, and failing that would make the obvious way to use this
-		// endpoint the wrong one. Bespoke fields are applied by dedicated
-		// code further down.
+		// Read-only fields (daemon capabilities, live status) are ignored rather
+		// than rejected: the read-modify-write round trip necessarily sends them
+		// back. Bespoke fields are applied further down.
 		//
-		// Remember the names, though. A body naming ONLY non-writable fields
-		// used to fall through to "did not include any known pref fields",
-		// which is untrue of a field this same endpoint emitted a moment ago
-		// -- and made the same key behave differently depending on whether a
-		// writable field happened to travel with it.
+		// Remember the names, though: a body naming ONLY non-writable fields
+		// would otherwise fall through to "did not include any known pref fields".
 		if (f.access == webapi::PrefAccess::ReadOnly || f.access == webapi::PrefAccess::Bespoke) {
 			if (f.access == webapi::PrefAccess::ReadOnly) {
 				if (!skipped_read_only.empty())
@@ -9063,12 +8254,11 @@ CHttpServer::Response CApiDispatcher::HandlePreferencesPatch(const CHttpServer::
 	}
 
 	// --- The one field pair the table cannot describe. ------------------
-	// remote_controls.webserver.guest_enabled and .guest_password share a
-	// single EC tag: EC_TAG_WEBSERVER_GUEST carries the enable bool as its
-	// value and the password hash as a child. There is no 1:1 field-to-tag
-	// mapping to put in the schema, so the packing stays hand-written. When
-	// only the password is given, the enable bit falls back to the current
-	// snapshot value.
+	// remote_controls.webserver.guest_enabled and .guest_password share a single
+	// EC tag: EC_TAG_WEBSERVER_GUEST carries the enable bool as its value and the
+	// password hash as a child, so there is no 1:1 field-to-tag mapping to put in
+	// the schema. When only the password is given, the enable bit falls back to
+	// the current snapshot value.
 	{
 		const picojson::object *ws = nullptr;
 		for (std::size_t c = 0; c < webapi::PrefCategoryCount(); ++c) {
@@ -9133,13 +8323,10 @@ CHttpServer::Response CApiDispatcher::HandlePreferencesPatch(const CHttpServer::
 	}
 	delete ec_resp;
 
-	// Inline refresh — the GET below + the next /preferences must
-	// reflect the post-mutation state without waiting on the regular
-	// tick.
+	// Inline refresh so the GET below reflects the post-mutation state.
 	(void)RefresherTick(m_app, m_state);
 
-	// Return the updated /preferences shape so consumers can confirm
-	// what landed without a follow-up GET.
+	// Return the updated shape so consumers need no follow-up GET.
 	const webapi::PreferencesSnapshot p = m_state.Preferences();
 	CHttpServer::Response r;
 	r.status = 200;
@@ -9153,16 +8340,11 @@ CHttpServer::Response CApiDispatcher::HandlePreferencesPatch(const CHttpServer::
 namespace
 {
 
-// Issue a single-shot mutation EC packet (no body), check the
-// response, run RefresherTick inline, return `{message?: "..."}` -- the
-// daemon's own account of what it did, and nothing else. (`ok` was dropped
-// when mutation responses collapsed onto the status code; see the body
-// below.) Used by every connection-control endpoint where the EC op is
-// parameterless.
-//
-// Callers pass 202, not 200: the request is handed to the daemon over EC and
-// returns before the effect is observable, which is as true of a disconnect
-// as of a connect.
+// Issue a single-shot mutation EC packet (no body), check the response, run
+// RefresherTick inline, return `{message?: "..."}` -- the daemon's own account
+// of what it did. Used by every connection-control endpoint whose EC op is
+// parameterless. Callers pass 202, not 200: the request returns before the
+// effect is observable, which is as true of a disconnect as of a connect.
 CHttpServer::Response SimpleConnControlOp(
 	CamuleapiApp &app, webapi::CState &state, ec_opcode_t op, unsigned http_status)
 {
@@ -9176,9 +8358,8 @@ CHttpServer::Response SimpleConnControlOp(
 		delete ec_resp;
 		return ErrorResponse(400, "amuled_rejected", ec_err_msg.c_str());
 	}
-	// amuled's CONNECT/DISCONNECT return EC_OP_STRINGS with a status
-	// message. We surface the message verbatim so consumers see what
-	// amuled would have shown in its UI.
+	// amuled's CONNECT/DISCONNECT return EC_OP_STRINGS with a status message,
+	// surfaced verbatim so consumers see what amuled would have shown.
 	std::string message;
 	if (ec_resp) {
 		for (CECPacket::const_iterator it = ec_resp->begin(); it != ec_resp->end(); ++it) {
@@ -9196,12 +8377,9 @@ CHttpServer::Response SimpleConnControlOp(
 
 	CHttpServer::Response r;
 	r.status = http_status;
-	// `ok` dropped: the status code already said it. `message` stays -- it is
-	// the daemon's own explanation of what it did with the request, which is
-	// not recoverable from any subsequent read. With nothing to say, no body
-	// at all rather than `{}`: the URL-fetch triggers beside these answer the
-	// same 202 with no body, and `ipfilter/reload` vs `ipfilter/update` is
-	// otherwise two shapes for the same fire-and-forget shrug.
+	// `message` is the daemon's own explanation of what it did, not recoverable
+	// from any subsequent read. With nothing to say, no body at all rather than
+	// `{}`: the URL-fetch triggers beside these answer the same 202 with no body.
 	if (message.empty()) {
 		r.content_type.clear();
 		return r;
@@ -9226,10 +8404,8 @@ CHttpServer::Response CApiDispatcher::HandleNetworksConnect(const CHttpServer::R
 	if (auto rej = RequireAdmin(a))
 		return *rej;
 
-	// Optional `{"network": "ed2k" | "kad" | "both"}` selector — same
-	// shape as /networks/disconnect. Default "both" preserves the
-	// original parameterless contract (every connector-aware client
-	// kept working when this body was added).
+	// Optional `{"network": "ed2k" | "kad" | "both"}` selector -- same shape as
+	// /networks/disconnect. Default "both" preserves the parameterless contract.
 	std::string network = "both";
 	if (!req.body.empty()) {
 		picojson::value root;
@@ -9271,10 +8447,8 @@ CHttpServer::Response CApiDispatcher::HandleNetworksDisconnect(const CHttpServer
 	if (auto rej = RequireAdmin(a))
 		return *rej;
 
-	// Optional `{"network": "ed2k" | "kad" | "both"}` selector. Default
-	// "both" (preserves the original parameterless contract). Empty
-	// body is fine — that's the most common shape and matches the v0
-	// contract callers built against.
+	// Optional `{"network": "ed2k" | "kad" | "both"}` selector; default "both",
+	// and an empty body is fine -- that is the v0 contract callers built against.
 	std::string network = "both";
 	if (!req.body.empty()) {
 		picojson::value root;
@@ -9310,24 +8484,14 @@ CHttpServer::Response CApiDispatcher::HandleNetworksDisconnect(const CHttpServer
 	return SimpleConnControlOp(m_app, m_state, EC_OP_DISCONNECT, 202);
 }
 
-// HandleKadConnect / HandleKadDisconnect were removed — strict
-// aliases of HandleNetworksConnect / HandleNetworksDisconnect with
-// `{"network":"kad"}`. The Kad bootstrap handler below is genuinely
-// distinct (single-contact bootstrap from an explicit IP+port) and
-// stays.
-
-// POST /kad/update — refresh the Kad node list from a nodes.dat URL (#693).
+// POST /kad/update -- refresh the Kad node list from a nodes.dat URL (#693).
 //
-// Shares ResolveFetchUrl / UrlFetchOp with /servers_update and
-// /ipfilter/update: same validation, same 202. The EC handler
-// (EC_OP_KAD_UPDATE_FROM_URL) persists the URL into preferences itself via
-// SetKadNodesUrl(), so this deliberately does NOT also patch
-// kad.update_url — doing both would diverge from the ed2k path and could
-// race it.
+// The EC handler (EC_OP_KAD_UPDATE_FROM_URL) persists the URL into preferences
+// itself via SetKadNodesUrl(), so this deliberately does NOT also patch
+// kad.update_url -- doing both would diverge from the ed2k path and could race it.
 //
 // Side effect worth knowing: once the download completes amuled stops Kad,
-// swaps nodes.dat in, and starts Kad again. The desktop GUI warns before
-// firing this; API callers get the same behaviour without the prompt.
+// swaps nodes.dat in, and starts Kad again, with no prompt.
 CHttpServer::Response CApiDispatcher::HandleKadUpdateFromUrl(const CHttpServer::Request &req)
 {
 	auto a = Authenticate(req);
@@ -9336,9 +8500,7 @@ CHttpServer::Response CApiDispatcher::HandleKadUpdateFromUrl(const CHttpServer::
 	if (auto rej = RequireAdmin(a))
 		return *rej;
 
-	// No inline RefresherTick: nothing observable has changed yet. Once
-	// the download completes amuled stops Kad, swaps nodes.dat in and
-	// starts Kad again, and the natural tick reports that.
+	// No inline RefresherTick: nothing observable has changed yet.
 	static const UrlFetchSpec kSpec = {
 		"url", EC_OP_KAD_UPDATE_FROM_URL, EC_TAG_KADEMLIA_UPDATE_URL, true, false
 	};
@@ -9350,15 +8512,12 @@ CHttpServer::Response CApiDispatcher::HandleKadUpdateFromUrl(const CHttpServer::
 	return UrlFetchOp(m_app, m_state, kSpec, url);
 }
 
-// POST /ipfilter/reload — re-read ipfilter.dat + ipfilter_static.dat from
-// amuled's config directory into the live filter. The desktop client's
-// "Reload List" button, and the same EC op amulegui sends for it.
+// POST /ipfilter/reload -- re-read ipfilter.dat + ipfilter_static.dat from
+// amuled's config directory into the live filter.
 //
-// amuled queues a CIPFilterTask and keeps the current filter live until the
-// new one has finished loading, so this is accepted, never completed; the
-// outcome is only ever an amule log line ("Loading IP filters ...",
-// "IP filter is ready"), read back through /logs/amule or the SSE log
-// channel.
+// amuled queues a CIPFilterTask and keeps the current filter live until the new
+// one has loaded, so this is accepted, never completed; the outcome is only ever
+// an amule log line, read back through /logs/amule or the SSE log channel.
 CHttpServer::Response CApiDispatcher::HandleIpfilterReload(const CHttpServer::Request &req)
 {
 	auto a = Authenticate(req);
@@ -9369,17 +8528,14 @@ CHttpServer::Response CApiDispatcher::HandleIpfilterReload(const CHttpServer::Re
 	return SimpleConnControlOp(m_app, m_state, EC_OP_IPFILTER_RELOAD, 202);
 }
 
-// POST /ipfilter/update — download ipfilter.dat from a URL, swap it in and
-// reload. The desktop client's "Update now" button.
+// POST /ipfilter/update -- download ipfilter.dat from a URL, swap it in and reload.
 //
-// Unlike its two siblings the URL is optional: with no body amuleapi
-// resolves security.ipfilter_update_url from its own preferences snapshot
-// and sends that, so the behaviour does not depend on which amuled build
-// answers. With neither, this is a 400 rather than a request the core turns
-// into a silent no-op (CIPFilter::Update() returns immediately on an empty
-// URL). The snapshot trails amuled by up to one refresher tick, so a
-// PATCH /preferences immediately followed by a bodyless update can still
-// send the previous URL — pass it explicitly to be sure which one runs.
+// Unlike its two siblings the URL is optional: with no body amuleapi resolves
+// security.ipfilter_update_url from its own preferences snapshot. With neither,
+// this is a 400 rather than a request the core turns into a silent no-op
+// (CIPFilter::Update() returns immediately on an empty URL). The snapshot trails
+// amuled by up to one refresher tick, so a PATCH /preferences immediately
+// followed by a bodyless update can still send the previous URL.
 CHttpServer::Response CApiDispatcher::HandleIpfilterUpdate(const CHttpServer::Request &req)
 {
 	auto a = Authenticate(req);
@@ -9392,9 +8548,8 @@ CHttpServer::Response CApiDispatcher::HandleIpfilterUpdate(const CHttpServer::Re
 	// No inline RefresherTick: the download is asynchronous and lands in
 	// amuled's filter, not in a cache this process holds.
 	static const UrlFetchSpec kSpec = { "url", EC_OP_IPFILTER_UPDATE, EC_TAG_STRING, false, false };
-	// Named local: Preferences() hands back a snapshot by value. Offer it as
-	// the fallback only once there is a snapshot to read — before the first
-	// one the defaults would look like "no URL configured".
+	// Offer the snapshot as the fallback only once there is one -- before the
+	// first, the defaults would look like "no URL configured".
 	const bool have_prefs = m_state.HasFirstSnapshot();
 	const std::string configured =
 		have_prefs ? m_state.Preferences().security.ipfilter_update_url : std::string();
@@ -9408,20 +8563,12 @@ CHttpServer::Response CApiDispatcher::HandleIpfilterUpdate(const CHttpServer::Re
 
 // POST /geoip/update -- fetch a fresh GeoIP database now.
 //
-// This used to be `geoip.update_now`, a write-only boolean inside
-// PATCH /preferences. It is an action, not a setting: nothing reads it back,
-// writing `false` means nothing, and the value never survives the request.
-// It is a route now, alongside /servers_update, /kad/update and
-// /ipfilter/update -- the other three "go fetch a list" operations (#1189).
-//
-// Unlike those three it takes no URL: which database to fetch comes from
-// geoip.source and geoip.custom_update_url, which stay ordinary preferences.
-// So the body is empty and the whole request is the verb.
+// Unlike the three sibling fetch routes it takes no URL: which database to
+// fetch comes from geoip.source and geoip.custom_update_url, which stay
+// ordinary preferences, so the body is empty and the whole request is the verb.
 //
 // The core has no EC opcode for it -- the trigger is a preferences tag -- so
-// the packet is still EC_OP_SET_PREFERENCES carrying that one tag. That is
-// an implementation detail of the daemon's side, not of the API's, which is
-// exactly why it should not have been visible as a preference key.
+// the packet is still EC_OP_SET_PREFERENCES carrying that one tag.
 CHttpServer::Response CApiDispatcher::HandleGeoipUpdate(const CHttpServer::Request &req)
 {
 	auto a = Authenticate(req);
@@ -9452,10 +8599,8 @@ CHttpServer::Response CApiDispatcher::HandleGeoipUpdate(const CHttpServer::Reque
 	(void)RefresherTick(m_app, m_state);
 
 	// 202 with no body, like the three sibling fetch routes (UrlFetchOp): the
-	// download runs in the daemon after the reply. Progress is observable on
-	// GET /preferences as geoip.download_in_progress, and the outcome as
-	// geoip.last_update_status. This used to emit `{}`, which made four
-	// interchangeable routes answer in two different shapes.
+	// download runs in the daemon after the reply. Progress is observable on GET
+	// /preferences as geoip.download_in_progress, the outcome as last_update_status.
 	CHttpServer::Response r;
 	r.status = 202;
 	r.content_type.clear();
@@ -9478,16 +8623,10 @@ CHttpServer::Response CApiDispatcher::HandleKadBootstrap(const CHttpServer::Requ
 	const auto &obj = root.get<picojson::object>();
 
 	// Body: {"ip": "1.2.3.4", "port": <uint16>}. A dotted quad, and only that.
-	//
-	// This also took a host-order uint32, matching the EC tag's wire shape,
-	// and the two forms disagreed about byte order: ParseIpv4Dotted() packs
-	// a.b.c.d least-significant byte first (matching Uint32toStringIP), while
-	// the integer branch took the JSON value verbatim -- so 2130706433
-	// (0x7F000001, what a client computing an IPv4 integer the conventional
-	// big-endian way writes for 127.0.0.1) bootstrapped 1.0.0.127. Rather
-	// than pick a byte order for a spelling no other field on this surface
-	// uses, the spelling is gone: every IP the API reads or writes is a quad,
-	// and the conversion to the integer EC wants happens here.
+	// The integer form is gone: ParseIpv4Dotted() packs a.b.c.d least-significant
+	// byte first, while the integer branch took the JSON value verbatim, so
+	// 2130706433 (0x7F000001, the conventional big-endian spelling of 127.0.0.1)
+	// bootstrapped 1.0.0.127.
 	std::uint32_t ip_he = 0;
 	{
 		const auto it = obj.find("ip");
@@ -9511,9 +8650,8 @@ CHttpServer::Response CApiDispatcher::HandleKadBootstrap(const CHttpServer::Requ
 			return ErrorResponse(400, "bad_request", "required integer field `port` is missing");
 		}
 		const double v = it->second.get<double>();
-		// Same contract as the `port` on POST /friends: one spelling, one
-		// range. 0 used to be accepted here, which no Kad contact can be
-		// reached on -- the probe was sent and silently went nowhere.
+		// Same contract as the `port` on POST /friends. 0 used to be accepted
+		// here, which no Kad contact can be reached on.
 		if (!IsIntegralJsonNumber(v) || v < 1 || v > 65535) {
 			return ErrorResponse(400, "bad_request", "`port` must be an integer in 1..65535");
 		}
@@ -9542,11 +8680,9 @@ CHttpServer::Response CApiDispatcher::HandleKadBootstrap(const CHttpServer::Requ
 	r.content_type = "application/json";
 	CJsonWriter w;
 	w.BeginObject();
-	// `ok` dropped. `ip`/`port` stay as the documented exception to the
-	// no-body rule for actions: the echo reports which address the daemon
-	// actually parsed, which the caller cannot recover anywhere else. It is a
-	// quad, the same spelling the request used and the one every other IP on
-	// this surface uses, so a caller can post the reply straight back.
+	// `ip`/`port` stay as the documented exception to the no-body rule for
+	// actions: the echo reports which address the daemon actually parsed, which
+	// the caller cannot recover anywhere else.
 	w.Key("ip");
 	w.ValueString(Uint32toStringIP(ip_he));
 	w.Key("port");
@@ -9557,11 +8693,9 @@ CHttpServer::Response CApiDispatcher::HandleKadBootstrap(const CHttpServer::Requ
 }
 
 // `priority` here mirrors the /shared[].priority enum: bare upload levels plus
-// "auto". Setting "auto" hands level selection to amuled -- it derives the level
-// from the upload queue and reports it back as `priority` plus a true
-// `priority_auto` -- so to pin a fixed level, send the bare name. The combined
-// "*_auto" strings are deliberately NOT accepted as input: "auto" is the level
-// the daemon computes, and a caller cannot pin it.
+// "auto". Setting "auto" hands level selection to amuled, which reports it back
+// as `priority` plus a true `priority_auto`. The combined "*_auto" strings are
+// deliberately NOT accepted as input: a caller cannot pin a computed level.
 CHttpServer::Response CApiDispatcher::HandleSharedPatch(
 	const CHttpServer::Request &req, const std::string &key)
 {
@@ -9660,23 +8794,19 @@ CHttpServer::Response CApiDispatcher::HandleSharedPatch(
 	r.status = 200;
 	r.content_type = "application/json";
 	CJsonWriter w;
-	// Same writer GET /shared/{hash} uses, for the same reason as the
-	// download PATCH above: the list row is a narrower object, and answering
-	// a mutation with it made PATCH-and-store differ from PATCH-and-re-GET.
+	// Same writer GET /shared/{hash} uses: the list row is a narrower object,
+	// and answering a mutation with it made PATCH-and-store differ from re-GET.
 	WriteSharedDetailObject(w, s_after);
 	FinalizeJsonBody(w, r);
 	return r;
 }
 
 // --- Bulk mutations (issue #358) -------------------------------------
-// PATCH/DELETE /downloads and PATCH /shared take a `hashes` array and
-// apply the same op to each, reporting per-item outcomes under `results`
-// (see BulkResultsResponse). Best-effort per item -- each hash is an
-// independent EC roundtrip, so a mid-batch failure doesn't abort the
-// rest. One RefresherTick runs after the whole batch. All-ok is 200
-// (the mutations complete synchronously, unlike the async POST /downloads
-// add which is 202); a mix is 207 Multi-Status; an all-unreachable batch
-// collapses to 503.
+// PATCH/DELETE /downloads and PATCH /shared take a `hashes` array and apply the
+// same op to each, reporting per-item outcomes under `results`. Best-effort per
+// item -- each hash is an independent EC roundtrip, so a mid-batch failure does
+// not abort the rest. One RefresherTick runs after the whole batch. All-ok is
+// 200, a mix is 207 Multi-Status, an all-unreachable batch collapses to 503.
 
 CHttpServer::Response CApiDispatcher::HandleDownloadsBulkPatch(const CHttpServer::Request &req)
 {
@@ -9699,10 +8829,9 @@ CHttpServer::Response CApiDispatcher::HandleDownloadsBulkPatch(const CHttpServer
 	if (!ParseBulkHashes(obj, hashes, bad))
 		return bad;
 
-	// Validate the patch ONCE -- the same op list applies to every hash, so
-	// a malformed patch is a 400 for the whole request; per-hash problems
-	// (not found, amuled rejection) surface per item. Fixed order
-	// (status, priority, category) keeps the wire effect deterministic.
+	// Validate the patch ONCE -- the same op list applies to every hash, so a
+	// malformed patch is a 400 for the whole request; per-hash problems surface
+	// per item. Fixed order (status, priority, category) keeps the effect deterministic.
 	struct PatchOp
 	{
 		ec_opcode_t op;
@@ -9971,11 +9100,9 @@ CHttpServer::Response CApiDispatcher::HandleSharedVerify(
 	}
 
 	// Partfiles have no verify implementation: the hashing task bails out on
-	// IsPartFile(), and amuled's EC handler answers NOOP either way, so a
-	// caller would be told the re-hash was accepted and then never see a
-	// report. Reject up front instead -- a download that has completed but is
-	// still listed is a knownfile by then, and so a legitimate verify target,
-	// which is exactly what IsIncompletePartfile() excludes.
+	// IsPartFile(), and amuled's EC handler answers NOOP either way, so a caller
+	// would be told the re-hash was accepted and never see a report. A completed
+	// but still-listed download is a knownfile, and so a legitimate target.
 	if (s.IsIncompletePartfile()) {
 		return ErrorResponse(
 			409, "partfile_unsupported", "verify local data is not supported on a partfile");
@@ -10001,14 +9128,9 @@ CHttpServer::Response CApiDispatcher::HandleSharedVerify(
 	delete ec_resp;
 
 	// 202, not 200: amuled queues a CVerifyLocalDataTask and answers NOOP
-	// immediately, so the re-hash is still in flight here. The verdict is
-	// only ever reported as an amule log line (CVerifyLocalDataTask::
-	// PrintReport -> "Verify Local Data (...): Result OK" / "ERRORS
-	// FOUND!"), which clients read back through /logs/amule or the SSE log
-	// channel. No RefresherTick: nothing observable has changed yet.
-	// 202 with no body. The verify is asynchronous and its outcome arrives
-	// on the log channel, so there is nothing to report here that the status
-	// code has not said.
+	// immediately, so the re-hash is still in flight. The verdict is only ever
+	// an amule log line (CVerifyLocalDataTask::PrintReport), read back through
+	// /logs/amule or the SSE log channel. No RefresherTick, and no body.
 	CHttpServer::Response r;
 	r.status = 202;
 	r.content_type.clear();
@@ -10020,40 +9142,23 @@ namespace
 // The set of directories this endpoint is willing to serve bytes out of.
 //
 // Read off the preferences snapshot rather than fetched with an
-// EC_OP_GET_SHARED_DIRS roundtrip, for two reasons. The cheap one is cost:
-// the refresher already pulls EC_PREFS_DIRECTORIES on every 5 s tick
-// (RefresherTick.cpp:347-362), so this costs a mutex instead of a roundtrip
-// on a route a seeking media player hits once per range. The correctness one
-// is coverage: GET_SHARED_DIRS serialises only the two *intent* lists
-// (ExternalConn.cpp:1648-1655), which on a default install are both empty --
-// Incoming is shared implicitly and appears in neither. Containment against
-// that list alone would 404 every file in the one directory aMule always
-// shares. `directories.shared` is the runtime union the core keeps
-// (explicit + expanded recursive, ECSpecialMuleTags.cpp:399-403), and
-// `incoming` is the implicit root it omits; together they are the real
-// answer.
-//
-// Staleness is bounded by the same tick that produced the file list this
-// request resolved against, so a directory the user has just un-shared
-// disappears from /shared and from here on the same frame rather than one
-// outliving the other.
+// EC_OP_GET_SHARED_DIRS roundtrip. GET_SHARED_DIRS serialises only the two
+// *intent* lists (ExternalConn.cpp), which on a default install are both empty
+// -- Incoming is shared implicitly and appears in neither, so containment
+// against that list alone would 404 every file in the one directory aMule
+// always shares. `directories.shared` is the runtime union the core keeps
+// (explicit + expanded recursive) and `incoming` is the implicit root it omits.
 //
 // The category paths are the third root and are just as implicit as Incoming:
-// CSharedFileList::Reload seeds its scan list with GetIncomingDir() followed by
-// GetCatPath(i) for every category (SharedFileList.cpp:434-438) BEFORE it
-// appends the explicit shares, so a download that completed into a category's
-// own directory is shared by the core and listed by /shared while appearing in
-// neither `shared_paths` nor `incoming_path`. Without them containment rejects
-// that file, and because the joined path stats fine the remote-EC probe below
-// falls through to 404 -- the endpoint would answer "no such hash" about a file
-// sitting on its own disk, which is what anyone using categories hits on their
-// very first download.
+// CSharedFileList::Reload seeds its scan list with GetIncomingDir() and
+// GetCatPath(i) for every category BEFORE the explicit shares, so a download
+// that completed into a category's own directory is shared by the core and
+// listed by /shared while appearing in neither `shared_paths` nor
+// `incoming_path`.
 //
 // The one thing the core auto-shares that is deliberately NOT a root here is
-// the part-file set (SharedFileList.cpp:420-429): those live in the temp
-// directory and are only ever reachable through this handler as a partfile,
-// which it has already refused with 409 before containment runs. Adding temp
-// as a root would widen the boundary for bytes this route will never serve.
+// the part-file set: those live in the temp directory and are only reachable
+// through this handler as a partfile, which it has already refused with 409.
 std::vector<std::string> ShareRootsFromPrefs(
 	const webapi::PreferencesSnapshot &p, const std::vector<webapi::CategorySnapshot> &cats)
 {
@@ -10066,10 +9171,9 @@ std::vector<std::string> ShareRootsFromPrefs(
 	if (!p.directories.incoming_path.empty()) {
 		roots.push_back(p.directories.incoming_path);
 	}
-	// Empty paths are skipped rather than defaulted: amuled holds an empty
-	// path for a category that saves to Incoming, and Incoming is already a
-	// root above. An empty string here would be a root that contains
-	// everything.
+	// Empty paths are skipped rather than defaulted: amuled holds an empty path
+	// for a category that saves to Incoming, which is already a root above. An
+	// empty string here would be a root that contains everything.
 	for (const webapi::CategorySnapshot &c : cats) {
 		if (!c.path.empty())
 			roots.push_back(c.path);
@@ -10084,17 +9188,12 @@ std::vector<std::string> ShareRootsFromPrefs(
 // GET / HEAD only, and the only route in this file whose response body is not
 // materialised in memory: it hands the transport a path plus a byte window
 // (CHttpServer::Response::file) and the 64 KiB streaming body does the rest.
-// That is the entire reason this handler exists rather than a `body =
-// ReadStaticFile(...)` one-liner -- the share routinely holds files larger
-// than the daemon's address space is willing to hold sixteen times over.
 CHttpServer::Response CApiDispatcher::HandleSharedContent(
 	const CHttpServer::Request &req, const std::string &key)
 {
-	// There is no auth middleware in this codebase: every route gates itself.
-	// A content route that forgot this line would publish the whole share to
-	// the internet and nothing would flag it, which is why it is first.
-	// Authenticate but NOT RequireAdmin -- reading a file the user already
-	// chose to share is a read, and the guest role can already list it.
+	// There is no auth middleware in this codebase: every route gates itself, so
+	// a content route that forgot this line would publish the whole share.
+	// Authenticate but NOT RequireAdmin -- the guest role can already list it.
 	auto a = Authenticate(req);
 	if (!a.ok)
 		return a.rejection;
@@ -10110,23 +9209,19 @@ CHttpServer::Response CApiDispatcher::HandleSharedContent(
 		return ErrorResponse(404, "not_found", "no shared file with that hash");
 	}
 
-	// Completed files only, and IsIncompletePartfile() is exactly that test --
-	// same guard, same code as /shared/{hash}/verify. A partfile's bytes on
-	// disk are a gapped .part file whose offsets do not correspond to the
-	// file's own, so a byte range served out of it would be silently wrong
-	// rather than merely unavailable.
+	// Completed files only, and IsIncompletePartfile() is exactly that test. A
+	// partfile's bytes on disk are a gapped .part file whose offsets do not
+	// correspond to the file's own, so a range out of it would be silently wrong.
 	if (s.IsIncompletePartfile()) {
 		return ErrorResponse(
 			409, "partfile_unsupported", "content download is not supported on a partfile");
 	}
 
-	// The directory rides EC_TAG_KNOWNFILE_PATH, which amuled emits only
-	// outside EC_DETAIL_UPDATE (ECSpecialCoreTags.cpp:375-392) and, being on
-	// the valuemap path, only on the frames where it changed. A snapshot
-	// taken before the first such frame therefore has the file but not its
-	// location. That resolves itself on the next full frame, which is what
-	// makes this a 503-with-Retry-After rather than a 404: the resource
-	// exists, we just cannot address it yet.
+	// The directory rides EC_TAG_KNOWNFILE_PATH, which amuled emits only outside
+	// EC_DETAIL_UPDATE and, being on the valuemap path, only on the frames where
+	// it changed. A snapshot taken before the first such frame therefore has the
+	// file but not its location. That resolves on the next full frame, which is
+	// what makes this a 503-with-Retry-After rather than a 404.
 	if (s.on_disk_dir.empty()) {
 		CHttpServer::Response r =
 			ErrorResponse(503, "path_unavailable", "the file's on-disk path is not known yet");
@@ -10134,27 +9229,21 @@ CHttpServer::Response CApiDispatcher::HandleSharedContent(
 		return r;
 	}
 
-	// Resolution and the containment check are the HANDLER's job -- the
-	// transport opens whatever path it is given (HttpServer.h:120-127). Every
-	// rejection below collapses into one 404 with the same message the
-	// unknown-hash branch used, so the reply cannot be used to probe whether
-	// a path exists, what the share layout is, or where the boundary sits
-	// (the discipline StaticFs.h:28-33 states).
+	// Resolution and the containment check are the HANDLER's job -- the transport
+	// opens whatever path it is given. Every rejection below collapses into one
+	// 404 with the same message the unknown-hash branch used, so the reply cannot
+	// be used to probe the share layout or where the boundary sits.
 	const std::vector<std::string> roots =
 		ShareRootsFromPrefs(m_state.Preferences(), m_state.Categories());
 
 	std::string fs_path;
 	if (!webapi::ResolveSharedContentPath(roots, s.on_disk_dir, s.name, fs_path)) {
-		// One case inside that failure is emphatically NOT the client's
-		// fault and must not be reported as a missing hash: amuleapi is not
-		// guaranteed to share a filesystem with amuled. The EC endpoint is
-		// configurable (AmuleApiConfig.h:78-79), and the desktop remote GUI
-		// carries a whole path-mapping layer (Preferences.h:497-518) for
-		// precisely this split -- amuleapi has no equivalent, so a remote
-		// deployment resolves the daemon's paths against the wrong
-		// filesystem and finds nothing. Distinguishing it costs one stat of
-		// the joined path, and leaks nothing the caller can steer: the path
-		// comes from the daemon's own metadata, never from the request.
+		// One case inside that failure is not the client's fault and must not be
+		// reported as a missing hash: amuleapi is not guaranteed to share a
+		// filesystem with amuled. The EC endpoint is configurable and amuleapi
+		// has no equivalent of the remote GUI's path-mapping layer, so a remote
+		// deployment resolves the daemon's paths against the wrong filesystem.
+		// Distinguishing it costs one stat, and the path comes from the daemon.
 		std::string joined;
 		struct stat probe
 		{
@@ -10168,10 +9257,9 @@ CHttpServer::Response CApiDispatcher::HandleSharedContent(
 		return ErrorResponse(404, "not_found", "no shared file with that hash");
 	}
 
-	// Re-stat the RESOLVED path for the numbers the response is built from.
-	// ResolveSharedContentPath already proved it is a regular file, but it
-	// does not hand back the stat, and the window, the Content-Length and the
-	// validator all have to come from one observation of one path.
+	// Re-stat the RESOLVED path. ResolveSharedContentPath does not hand back its
+	// stat, and the window, the Content-Length and the validator all have to come
+	// from one observation of one path.
 	struct stat st
 	{
 	};
@@ -10181,16 +9269,12 @@ CHttpServer::Response CApiDispatcher::HandleSharedContent(
 			"the file is not present on the filesystem running amuleapi");
 	}
 
-	// The other half of the same remote-EC hazard, and the more dangerous
-	// half: the path resolved and something regular is sitting there, but it
-	// is not the file the hash names. On a split deployment the daemon's
-	// /srv/share/foo.iso and this host's /srv/share/foo.iso are unrelated
-	// files that merely agree on a name, and serving the local one under the
-	// remote one's hash would hand the caller bytes it did not ask for while
-	// telling it they matched. Size is the cheap invariant that catches it --
-	// a knownfile's size is fixed at hash time and never changes afterwards,
-	// so a disagreement is never benign. Same 503: the deployment is
-	// misconfigured, the request was fine.
+	// The other half of the same remote-EC hazard, and the more dangerous half:
+	// the path resolved and something regular is sitting there, but it is not the
+	// file the hash names. On a split deployment two unrelated files can agree on
+	// a name, and serving the local one under the remote one's hash would hand
+	// the caller bytes it did not ask for. A knownfile's size is fixed at hash
+	// time, so a disagreement is never benign. Same 503.
 	if (static_cast<std::uint64_t>(st.st_size) != s.size) {
 		return ErrorResponse(
 			503, "ec_content_mismatch", "the file on disk does not match the shared file's size");
@@ -10200,54 +9284,37 @@ CHttpServer::Response CApiDispatcher::HandleSharedContent(
 
 	CHttpServer::Response r;
 	// Hard-coded, never derived from the extension -- StaticContentType is
-	// deliberately NOT reused here. Completed downloads land in Incoming,
-	// which is itself shared, so both the bytes and the filename came from
-	// strangers on the ed2k network; amuleapi serves the Web UI from this
-	// same origin. A shared evil.html or a scripted .svg returned as its
-	// "real" type would therefore execute against the user's own session.
-	// octet-stream + attachment + nosniff + a sandbox CSP is four
-	// independent reasons the browser will not run it.
+	// deliberately NOT reused here. Completed downloads land in Incoming, so both
+	// the bytes and the filename came from strangers on the ed2k network, and
+	// amuleapi serves the Web UI from this same origin. octet-stream +
+	// attachment + nosniff + a sandbox CSP is four reasons a browser will not run it.
 	r.content_type = "application/octet-stream";
 	r.headers["Content-Disposition"] = webapi::BuildContentDisposition(s.name);
 	r.headers["X-Content-Type-Options"] = "nosniff";
-	// Scoped to this response only. A global CSP would change every route in
-	// the server including the Web UI itself, which is a separate decision
-	// and a separate change; this one just makes the sandbox explicit for the
-	// one response that carries attacker-authored bytes.
+	// Scoped to this response only: a global CSP would change every route
+	// including the Web UI, which is a separate decision.
 	r.headers["Content-Security-Policy"] = "default-src 'none'; sandbox";
-	// Set by the handler so Dispatch stands aside (Api.cpp:825-828) instead
-	// of MD5-ing the body to derive a validator -- there is no body here to
-	// hash, and hashing a multi-GB file per request is not a slow path but an
-	// unusable one.
+	// Set by the handler so Dispatch stands aside instead of MD5-ing the body to
+	// derive a validator -- there is no body here to hash, and hashing a multi-GB
+	// file per request is not a slow path but an unusable one.
 	const std::string content_etag = webapi::BuildContentEtag(
 		static_cast<std::uint64_t>(st.st_mtime), static_cast<std::uint64_t>(st.st_size));
 	r.headers["ETag"] = content_etag;
 
 	// Conditional GET, answered HERE and not by Dispatch. Taking the
 	// handler-set-ETag escape above also takes on this obligation: the whole
-	// If-None-Match block in Dispatch sits inside ShouldStampEtag, which
-	// returns false the moment a handler owns the validator, so a route that
-	// sets its own ETag and does not do this hands out a validator no client
-	// can ever revalidate against. The static path states the same rule at
-	// Api.cpp:1841-1845 and answers it the same way.
+	// If-None-Match block in Dispatch sits inside ShouldStampEtag, which returns
+	// false the moment a handler owns the validator, so a route that sets its own
+	// ETag and does not do this hands out a validator no client can revalidate.
 	//
-	// Through the shared matcher rather than a string compare, because the
-	// header may be `*`, a comma-separated list, or a weak `W/"..."` form --
-	// which is exactly what an nginx in front of us emits. IfNoneMatchHits
-	// wants the BARE validator, so the quotes BuildContentEtag adds for the
-	// wire come off for the comparison.
-	//
-	// No coding suffix, unlike the static path: the transport never deflates
-	// a file response (HttpServer.h:141-144), so this route has exactly one
-	// representation and there is nothing for a suffix to disambiguate.
-	// Calling WillCompressBody here would be dead logic asserting a
-	// negotiation that cannot happen.
+	// Through the shared matcher rather than a string compare, because the header
+	// may be `*`, a comma-separated list, or a weak `W/"..."` form -- which is
+	// what an nginx in front of us emits. IfNoneMatchHits wants the BARE
+	// validator, so the quotes BuildContentEtag adds come off for the comparison.
 	//
 	// Evaluated BEFORE the Range header, per RFC 9110 13.2.2: a matching
 	// precondition wins outright, so a conditional request carrying a Range
-	// answers 304 and never 206. If-Range is a second precondition with a
-	// different comparison rule; it is applied below, after this one has
-	// had its say.
+	// answers 304 and never 206.
 	const std::string inm_val = FindHeaderCaseInsensitive(req.headers, "If-None-Match");
 	const std::string content_etag_bare =
 		(content_etag.size() >= 2 && content_etag.front() == '"' && content_etag.back() == '"')
@@ -10258,9 +9325,7 @@ CHttpServer::Response CApiDispatcher::HandleSharedContent(
 		nm.status = 304;
 		// A 304 carries no content, so no content_type (the default is
 		// application/json, which would be a lie here), no body, no
-		// Response::file, and none of the range headers -- only the
-		// validator RFC 7232 4.1 requires so the client can re-stamp its
-		// cached copy.
+		// Response::file, and only the validator RFC 7232 4.1 requires.
 		nm.content_type.clear();
 		nm.headers["ETag"] = content_etag;
 		return nm;
@@ -10270,21 +9335,16 @@ CHttpServer::Response CApiDispatcher::HandleSharedContent(
 	std::uint64_t last = 0;
 	std::string range_hdr = FindHeaderCaseInsensitive(req.headers, "Range");
 
-	// If-Range, RFC 9110 13.1.5. Only meaningful next to a Range -- on its
-	// own there is nothing to condition -- so the lookup is skipped
-	// entirely when there is no Range to guard.
+	// If-Range, RFC 9110 13.1.5. Only meaningful next to a Range, so the lookup
+	// is skipped entirely when there is none.
 	//
-	// A failed precondition DROPS the Range rather than rejecting the
-	// request, which is what the section says to do and also what the
-	// caller needs: it asked for a window of a representation it no longer
-	// holds, and the whole current one is the answer that leaves it with a
-	// correct file. Dropping it here rather than after parsing also keeps a
-	// stale validator from turning into a 416, which would be an error
-	// about the OLD file's length.
+	// A failed precondition DROPS the Range rather than rejecting the request:
+	// the caller asked for a window of a representation it no longer holds, and
+	// the whole current one leaves it with a correct file. Dropping it here also
+	// keeps a stale validator from turning into a 416 about the OLD file's length.
 	//
-	// Note the comparison is NOT IfNoneMatchHits: 13.1.5 requires the
-	// strong form, and that function deliberately matches the weak one --
-	// see SharedContent.h for why the two cannot share an implementation.
+	// The comparison is NOT IfNoneMatchHits: 13.1.5 requires the strong form and
+	// that function deliberately matches the weak one -- see SharedContent.h.
 	if (!range_hdr.empty()) {
 		const std::string ifr_val = FindHeaderCaseInsensitive(req.headers, "If-Range");
 		if (!webapi::IfRangeAllowsRange(ifr_val, content_etag)) {
@@ -10295,10 +9355,9 @@ CHttpServer::Response CApiDispatcher::HandleSharedContent(
 	const webapi::RangeResult rr = webapi::ParseSingleByteRange(range_hdr, file_size, first, last);
 
 	if (rr == webapi::RangeResult::kUnsatisfiable) {
-		// 416 carries the error envelope rather than a file window, so it
-		// goes down the ordinary buffered path. Content-Range in the
-		// unsatisfied form is what RFC 9110 §14.4 requires so the client can
-		// learn the current length and re-ask.
+		// 416 carries the error envelope rather than a file window, so it goes
+		// down the ordinary buffered path. Content-Range in the unsatisfied form
+		// is what RFC 9110 14.4 requires so the client can re-ask.
 		CHttpServer::Response err = ErrorResponse(
 			416, "range_not_satisfiable", "the requested range lies outside the file");
 		err.headers["Content-Range"] = "bytes */" + std::to_string(file_size);
@@ -10306,10 +9365,9 @@ CHttpServer::Response CApiDispatcher::HandleSharedContent(
 		return err;
 	}
 
-	// A zero-length file has no valid byte window at all, so there is nothing
-	// for Response::file to describe -- the transport rejects [0, 0] on an
-	// empty file rather than clamping it (HttpServer.h:128-135). An empty
-	// buffered body is the honest 200 for it.
+	// A zero-length file has no valid byte window, so there is nothing for
+	// Response::file to describe -- the transport rejects [0, 0] on an empty file
+	// rather than clamping it. An empty buffered body is the honest 200 for it.
 	if (file_size == 0) {
 		r.status = 200;
 		r.headers["Accept-Ranges"] = "bytes";
@@ -10323,10 +9381,8 @@ CHttpServer::Response CApiDispatcher::HandleSharedContent(
 	} else {
 		// kAbsent (no header) and kIgnore (unsupported, malformed, or a
 		// multi-range set) both answer 200 with the whole file. kIgnore is
-		// RFC 7233 §3.1's explicit permission being used as the
-		// CVE-2011-3192 mitigation -- see SharedContent.h:84-94. A 200 is
-		// also the answer least likely to make a client retry the same
-		// header, which an error would invite.
+		// RFC 7233 3.1's explicit permission being used as the CVE-2011-3192
+		// mitigation -- see SharedContent.h.
 		r.status = 200;
 		first = 0;
 		last = file_size - 1;
@@ -10340,8 +9396,7 @@ CHttpServer::Response CApiDispatcher::HandleSharedContent(
 	r.file = fs;
 	// HEAD needs the window too: the transport runs the serializer in split
 	// mode, so it never reads a byte, but Content-Length still comes from
-	// RangeFileBody::size and so reports exactly what the equivalent GET
-	// would send (HttpServer.cpp:1214-1219, 1288-1292).
+	// RangeFileBody::size and reports what the equivalent GET would send.
 	return r;
 }
 
@@ -10361,8 +9416,7 @@ struct SharedDirEntry
 // the protocol has no compare-and-set — so that stays last-write-wins.)
 std::mutex s_sharedDirsMutex;
 
-// Read the current roots. Returns false and fills `err` when EC is unreachable
-// or refuses; the caller turns that into an HTTP error.
+// Returns false and fills `err` when EC is unreachable or refuses.
 bool FetchSharedDirs(CamuleapiApp &app, std::vector<SharedDirEntry> &out, std::string &err)
 {
 	std::unique_ptr<CECPacket> ec_req(new CECPacket(EC_OP_GET_SHARED_DIRS));
@@ -10390,9 +9444,8 @@ bool FetchSharedDirs(CamuleapiApp &app, std::vector<SharedDirEntry> &out, std::s
 	delete ec_resp;
 	return true;
 }
-// Replace the core's roots with `dirs` and render the outcome. The core applies
-// every path that validates and reports the rest, so a single bad entry does not
-// discard the edit.
+// Replace the core's roots with `dirs`. The core applies every path that
+// validates and reports the rest, so one bad entry does not discard the edit.
 CHttpServer::Response ApplySharedDirs(CamuleapiApp &app, const std::vector<SharedDirEntry> &dirs)
 {
 	std::unique_ptr<CECPacket> ec_req(new CECPacket(EC_OP_SET_SHARED_DIRS));
@@ -10415,9 +9468,8 @@ CHttpServer::Response ApplySharedDirs(CamuleapiApp &app, const std::vector<Share
 	}
 
 	// One entry per submitted path, in the envelope every other multi-item
-	// mutation uses. It reported only the rejects, in a shape of its own, so a
-	// caller could not tell an applied path from one the response simply did
-	// not mention. The reasons are still rendered here rather than shipped as
+	// mutation uses, so a caller can tell an applied path from one the response
+	// simply did not mention. Reasons are rendered here rather than shipped as
 	// text from a core whose locale is not the caller's.
 	std::map<std::string, std::string> rejected; // path -> reason code
 	for (const CECTag &tag : *ec_resp) {
@@ -10448,9 +9500,8 @@ CHttpServer::Response ApplySharedDirs(CamuleapiApp &app, const std::vector<Share
 } // namespace
 
 // The core's configured share roots: the explicit ones and the recursive ones,
-// each with the flag that says which. This is the *intent*, not the expansion —
-// a recursive root yields one entry here however many subdirectories it covers,
-// while /shared lists the files that expansion produced.
+// each with the flag that says which. This is the *intent*, not the expansion --
+// a recursive root is one entry here however many subdirectories it covers.
 CHttpServer::Response CApiDispatcher::HandleSharedDirectories(const CHttpServer::Request &req)
 {
 	auto a = Authenticate(req);
@@ -10495,11 +9546,9 @@ CHttpServer::Response CApiDispatcher::HandleSharedDirectories(const CHttpServer:
 }
 
 // Replace the whole set of roots. A full replace rather than add/remove verbs
-// because that is exactly what the core's EC op does — expressing it as PUT
-// keeps the API honest and avoids a read-modify-write race between two clients.
-// The core validates each path (a REST client cannot stat the core's
-// filesystem), applies the ones that pass and reports the rest, so a single bad
-// entry does not discard the whole edit.
+// because that is exactly what the core's EC op does. The core validates each
+// path (a REST client cannot stat the core's filesystem), applies the ones that
+// pass and reports the rest.
 CHttpServer::Response CApiDispatcher::HandleSharedDirectoriesPut(const CHttpServer::Request &req)
 {
 	auto a = Authenticate(req);
@@ -10603,9 +9652,8 @@ CHttpServer::Response CApiDispatcher::HandleSharedDirectoriesAdd(const CHttpServ
 }
 
 // Remove one root. The path arrives as a query parameter rather than a path
-// segment because it is an absolute filesystem path and would otherwise have to
-// survive being spliced into the URL path. Unknown paths are a 404 so a typo is
-// visible instead of silently succeeding.
+// segment because it is an absolute filesystem path. Unknown paths are a 404 so
+// a typo is visible instead of silently succeeding.
 CHttpServer::Response CApiDispatcher::HandleSharedDirectoriesDelete(const CHttpServer::Request &req)
 {
 	auto a = Authenticate(req);
@@ -10652,11 +9700,8 @@ namespace
 // Send EC_OP_REFRESH_MEDIA_METADATA and turn the reply into a response.
 // `hashTag` is null for the whole-share form.
 //
-// The op is deliberately not behind a capability tag, so a daemon that
-// predates it answers EC_OP_FAILED rather than being detectable in advance.
-// That is reported as 501, not 400: the request was well-formed and the
-// server simply does not implement it, and a client that gets 501 knows to
-// stop offering the action rather than to fix its input.
+// The op is deliberately not behind a capability tag, so a daemon that predates
+// it answers EC_OP_FAILED rather than being detectable in advance.
 CHttpServer::Response SendMediaRefresh(CamuleapiApp &app, const CECTag *hashTag, const char *what)
 {
 	auto ec_req = std::make_unique<CECPacket>(EC_OP_REFRESH_MEDIA_METADATA);
@@ -10689,18 +9734,14 @@ CHttpServer::Response SendMediaRefresh(CamuleapiApp &app, const CECTag *hashTag,
 	delete ec_resp;
 
 	// 202, not 200: amuled queues the probes on its media-probe worker and
-	// answers immediately, so nothing has been re-extracted yet. `queued` is
-	// how many files were accepted for probing -- files the scheduler dropped
-	// (not audio/video, an incomplete download, missing on disk) are not
-	// counted. Progress is observable through the amule log and, as each
-	// probe lands, the shared_updated SSE events.
+	// answers immediately, so nothing has been re-extracted yet. `queued` is how
+	// many files were accepted for probing; files the scheduler dropped (not
+	// audio/video, incomplete, missing on disk) are not counted.
 	CHttpServer::Response r;
 	r.status = 202;
 	r.content_type = "application/json";
 	CJsonWriter w;
 	w.BeginObject();
-	// `ok` dropped; `scope` and the count stay -- the count is a real number
-	// of rescans this triggered, so R5 spells it out.
 	w.Key("scope");
 	w.ValueString(wxString::FromAscii(what));
 	w.Key("queued_file_count");
@@ -10741,10 +9782,8 @@ CHttpServer::Response CApiDispatcher::HandleSharedMediaRefreshOne(
 	if (!FindSharedByKey(m_state, key, s)) {
 		return ErrorResponse(404, "not_found", "no shared file with that hash");
 	}
-	// Same exclusion the daemon's Refresh mode applies: an in-progress
-	// download has no complete file to read. Rejected here so the caller is
-	// told why, rather than getting a 202 for a probe that was silently
-	// dropped.
+	// Same exclusion the daemon's Refresh mode applies: an in-progress download
+	// has no complete file to read. Rejected here so the caller is told why.
 	if (s.IsIncompletePartfile()) {
 		return ErrorResponse(409,
 			"partfile_unsupported",
@@ -10765,36 +9804,27 @@ CHttpServer::Response CApiDispatcher::HandleSharedReload(const CHttpServer::Requ
 		return a.rejection;
 	if (auto rej = RequireAdmin(a))
 		return *rej;
-	// EC_OP_SHAREDFILES_RELOAD: amuled schedules a re-walk of every
-	// configured share root and answers immediately, so 202 is literal --
-	// accepted and scheduled, not completed. The walk starts on amuled's
-	// next Process() tick (within about a second) and repeated calls while
-	// one is pending or running coalesce into a single walk.
+	// EC_OP_SHAREDFILES_RELOAD: amuled schedules a re-walk of every configured
+	// share root and answers immediately, so 202 is literal. The walk starts on
+	// amuled's next Process() tick and repeated calls while one is pending
+	// coalesce into a single walk.
 	//
-	// This used to be synchronous on amuled's side, on the assumption that
-	// the walk "completes in well under a second". That is exactly the
-	// assumption that fails on the trees where it matters -- a large or
-	// network-mounted share -- and because our EC lane is one serialised
-	// worker, the blocked roundtrip held the in-flight slot, filled the
-	// queue and turned unrelated endpoints into 503s.
+	// This used to be synchronous on amuled's side, on the assumption that the
+	// walk "completes in well under a second" -- exactly the assumption that
+	// fails on a large or network-mounted share, and because our EC lane is one
+	// serialised worker, the blocked roundtrip held the in-flight slot, filled
+	// the queue and turned unrelated endpoints into 503s.
 	//
-	// Completion is observable through the amule log (GET /logs/amule, or
-	// the log_appended SSE event) and the shared_added / shared_removed
-	// events, not through this response.
-	//
-	// SimpleConnControlOp still runs an inline RefresherTick. For this
-	// endpoint it now snapshots state from before the walk, so it buys
-	// nothing -- but it is harmless (a few EC roundtrips) and shared with
-	// the connect/disconnect endpoints, so it stays as-is.
+	// Completion is observable through the amule log and the shared_added /
+	// shared_removed events, not through this response.
 	return SimpleConnControlOp(m_app, m_state, EC_OP_SHAREDFILES_RELOAD, 202);
 }
 
 namespace
 {
 
-// Parse a uint8 index from a URL capture. Categories are 0..255 (the
-// EC tag stores them as uint8). Returns false on overflow, negative,
-// or non-digit content.
+// Parse a uint8 index from a URL capture. Categories are 0..255 (the EC tag
+// stores them as uint8). Returns false on overflow, negative or non-digits.
 bool ParseCategoryIndex(const std::string &s, std::uint8_t &out)
 {
 	if (s.empty())
@@ -10809,18 +9839,13 @@ bool ParseCategoryIndex(const std::string &s, std::uint8_t &out)
 	return true;
 }
 
-// Build the CEC_Category_Tag-shaped tag amuled expects. The shape is:
-//  parent tag EC_TAG_CATEGORY with the index as the int payload,
-//  nested children:
-//    EC_TAG_CATEGORY_TITLE   (string, "name" in our API)
-//    EC_TAG_CATEGORY_PATH    (string, "path")
-//    EC_TAG_CATEGORY_COMMENT (string, "comment")
-//    EC_TAG_CATEGORY_COLOR   (uint32)
-//    EC_TAG_CATEGORY_PRIO    (uint8)
+// Build the CEC_Category_Tag-shaped tag amuled expects: parent EC_TAG_CATEGORY
+// with the index as the int payload, and children EC_TAG_CATEGORY_TITLE
+// ("name" in our API), _PATH ("path"), _COMMENT ("comment"), _COLOR (uint32),
+// _PRIO (uint8).
 //
-// For CREATE the index is `0xFFFFFFFF` (sentinel: amuled assigns the
-// next free slot). For UPDATE we pass the actual index. For DELETE
-// the tag is just `(EC_TAG_CATEGORY, index)` — no children needed.
+// For CREATE the index is 0xFFFFFFFF (amuled assigns the next free slot); for
+// UPDATE the actual index; for DELETE just (EC_TAG_CATEGORY, index).
 CECTag BuildCategoryTag(std::uint32_t index,
 	const std::string &name,
 	const std::string &path,
@@ -10837,11 +9862,9 @@ CECTag BuildCategoryTag(std::uint32_t index,
 	return t;
 }
 
-// Helper to extract optional name/path/comment/color/priority from a
-// JSON object. Populates the out-params; returns an error response
-// on shape violations. The `is_create` flag enables required-field
-// enforcement: CREATE needs a name, UPDATE/PATCH treat all as
-// optional.
+// Extract optional name/path/comment/color/priority from a JSON object. The
+// `is_create` flag enables required-field enforcement: CREATE needs a name,
+// UPDATE/PATCH treat all as optional.
 struct CategoryFields
 {
 	std::string name;
@@ -10981,21 +10004,15 @@ CHttpServer::Response CApiDispatcher::HandleCategoryCreate(const CHttpServer::Re
 	(void)RefresherTick(m_app, m_state);
 
 	CHttpServer::Response r;
-	// 202 with no body. amuled's EC op answers success or failure and does
-	// not return the index it assigned, so naming the new category here meant
-	// scanning the snapshot for one with a matching name and falling back to
-	// a 201 with no index when the scan came up short -- a guess that can
-	// silently answer the wrong shape. The client re-reads the collection,
-	// which is what it had to do anyway.
+	// 202 with no body: amuled's EC op does not return the index it assigned, so
+	// naming the new category here meant scanning the snapshot for a matching
+	// name -- a guess that can silently answer the wrong shape.
 	r.status = 202;
 	r.content_type.clear();
 	return r;
 }
 
-// GET /categories/{index}. Every other resource with a member path has a member
-// GET; this one had PATCH and DELETE only, so a client that had just created a
-// category and wanted the stored result had to re-fetch the whole collection
-// and search it by index. GUEST, matching the collection read.
+// GET /categories/{index}. GUEST, matching the collection read.
 CHttpServer::Response CApiDispatcher::HandleCategoryOne(
 	const CHttpServer::Request &req, const std::string &index_str)
 {
@@ -11050,9 +10067,8 @@ CHttpServer::Response CApiDispatcher::HandleCategoryUpdate(
 	if (auto r = RequireSnapshot(m_state))
 		return *r;
 
-	// Find the existing category — we need its current values for any
-	// field the PATCH body doesn't override (CEC_Category_Tag is
-	// not delta-friendly; we always send the full tag).
+	// Find the existing category -- CEC_Category_Tag is not delta-friendly, so
+	// we always send the full tag and need current values for unset fields.
 	webapi::CategorySnapshot current;
 	if (!FindCategoryByIndex(m_state, idx, current)) {
 		return ErrorResponse(404, "not_found", "no category with that index");
@@ -11085,9 +10101,8 @@ CHttpServer::Response CApiDispatcher::HandleCategoryUpdate(
 	}
 	std::string ec_err_msg;
 	if (IsEcFailedResponse(ec_resp, ec_err_msg)) {
-		// As on create: a kept-path reply is a partial success. The name,
-		// comment, colour and priority in this request all landed, and the
-		// echoed object below reports the path that was actually kept.
+		// As on create: a kept-path reply is a partial success. Everything else
+		// in this request landed, and the echoed object reports the kept path.
 		std::string kept_path;
 		const bool kept = EcCategoryPathKept(ec_resp, kept_path);
 		delete ec_resp;
@@ -11100,7 +10115,6 @@ CHttpServer::Response CApiDispatcher::HandleCategoryUpdate(
 
 	(void)RefresherTick(m_app, m_state);
 
-	// Return the post-mutation category object.
 	webapi::CategorySnapshot after = current;
 	(void)FindCategoryByIndex(m_state, idx, after);
 
@@ -11138,9 +10152,8 @@ CHttpServer::Response CApiDispatcher::HandleCategoryDelete(
 		return ErrorResponse(404, "not_found", "no category with that index");
 	}
 
-	// CEC_Category_Tag CMD-detail shape: just `(EC_TAG_CATEGORY, idx)`,
-	// no children (amule-remote-gui.cpp:1043 uses `CEC_Category_Tag(cat,
-	// EC_DETAIL_CMD)`). We replicate that with a bare CECTag.
+	// CEC_Category_Tag CMD-detail shape: just `(EC_TAG_CATEGORY, idx)`, no
+	// children, replicating amule-remote-gui.cpp's CEC_Category_Tag(cat, EC_DETAIL_CMD).
 	std::unique_ptr<CECPacket> ec_req(new CECPacket(EC_OP_DELETE_CATEGORY));
 	ec_req->AddTag(CECTag(EC_TAG_CATEGORY, static_cast<std::uint32_t>(idx)));
 
@@ -11181,9 +10194,7 @@ CHttpServer::Response CApiDispatcher::HandleCategoryDelete(
 	});
 
 	CHttpServer::Response r;
-	// 204 with no body. Everything this used to echo came from the request
-	// URL, and `ok` restated the status code -- see the mutation-response
-	// rule in REFERENCE.md.
+	// 204 with no body -- see the mutation-response rule in REFERENCE.md.
 	r.status = 204;
 	r.content_type.clear();
 	return r;
@@ -11192,9 +10203,8 @@ CHttpServer::Response CApiDispatcher::HandleCategoryDelete(
 namespace
 {
 
-// Map wire-string search types to amule's EC_SEARCH_TYPE enum.
-// "local" / "global" / "kad" matches amulegui's UI labels +
-// amule-remote-gui.cpp:2406-2410's switch.
+// Map wire-string search types to amule's EC_SEARCH_TYPE enum. "local" /
+// "global" / "kad" matches amulegui's UI labels.
 bool SearchTypeFromString(const std::string &s, std::uint8_t &out)
 {
 	if (s == "local") {
@@ -11224,12 +10234,11 @@ CHttpServer::Response CApiDispatcher::HandleFriendBrowse(
 	return HandleBrowse(req, ecid_str, /*by_friend=*/true);
 }
 
-// Shared by /clients/{ecid}/shared_files and /friends/{ecid}/shared_files.
-// Same opcode and reply shape either way; only the sub-tag differs, which is
-// what tells the daemon whether the id names a live peer or a friend record.
-// The friend form is the more capable of the two: a friend carries a stored
-// ip:port, so the daemon can build a client for it and browse a friend that is
-// not currently connected.
+// Shared by /clients/{ecid}/shared_files and /friends/{ecid}/shared_files. Same
+// opcode and reply shape either way; only the sub-tag differs, which is what
+// tells the daemon whether the id names a live peer or a friend record. The
+// friend form is the more capable: a friend carries a stored ip:port, so the
+// daemon can browse one that is not currently connected.
 CHttpServer::Response CApiDispatcher::HandleBrowse(
 	const CHttpServer::Request &req, const std::string &ecid_str, bool by_friend)
 {
@@ -11245,9 +10254,8 @@ CHttpServer::Response CApiDispatcher::HandleBrowse(
 
 	// Ask amuled to browse this peer's shared file list. In multi-search mode
 	// (amuleapi always is) the daemon allocates a browse search_id, echoes it in
-	// the reply, and files the returned listing under it — so results, progress
-	// and SSE all address the browse exactly like a search. MarkSearchStarted
-	// then drives the refresher's per-id polling.
+	// the reply, and files the listing under it -- so results, progress and SSE
+	// all address the browse exactly like a search.
 	std::unique_ptr<CECPacket> ec_req(new CECPacket(EC_OP_FRIEND));
 	CECEmptyTag sharedtag(EC_TAG_FRIEND_SHARED);
 	sharedtag.AddTag(CECTag(by_friend ? EC_TAG_FRIEND : EC_TAG_CLIENT, ecid));
@@ -11272,18 +10280,13 @@ CHttpServer::Response CApiDispatcher::HandleBrowse(
 		return ErrorResponse(502, "amuled_rejected", "daemon did not return a search_id for browse");
 	}
 
-	// A browse's "query" is the peer whose share is being listed -- that is
-	// what the daemon names the search, and what GET /search reports for it.
-	// Take the nickname from the snapshot that actually owns this ECID so the
-	// results envelope can label the tab; a peer we have no snapshot for
-	// simply leaves it empty, same as any slot seeded before its name was
-	// observed.
+	// A browse's "query" is the peer whose share is being listed -- that is what
+	// the daemon names the search, and what GET /search reports for it.
 	//
-	// Which collection depends on how the browse was addressed. CECID hands
-	// out one global counter, so a CFriend's ECID never collides with a
-	// client's -- but it never *matches* one either, and searching the client
-	// list for it silently found nothing: every friend browse stored an empty
-	// name while GET /search reported the real nick for the same id.
+	// Which collection to take the nickname from depends on how the browse was
+	// addressed. CECID hands out one global counter, so a CFriend's ECID never
+	// collides with a client's -- but it never *matches* one either, and
+	// searching the client list for it silently found nothing.
 	std::string peer_name;
 	if (by_friend) {
 		for (const auto &f : m_state.Friends()) {
@@ -11302,12 +10305,8 @@ CHttpServer::Response CApiDispatcher::HandleBrowse(
 	}
 	m_state.MarkSearchStarted(search_id, "browse", peer_name);
 
-	// A creation answers with the created resource and a Location, because
-	// here the daemon really does hand one back: SEARCH_START returns
-	// EC_TAG_SEARCH_ID, and this handler already treats its absence as a
-	// hard error. The three creations that get a bare 202 instead are the
-	// ones where EC answers success or failure and nothing more.
-	//
+	// A creation answers with the created resource and a Location, because here
+	// the daemon really does hand one back: SEARCH_START returns EC_TAG_SEARCH_ID.
 	// The row is the same shape GET /search lists, written through the same
 	// writer, so a client can drop it straight into the collection it keeps.
 	SearchListRow row;
@@ -11342,14 +10341,10 @@ CHttpServer::Response CApiDispatcher::HandleSearchStart(const CHttpServer::Reque
 	}
 	const auto &obj = root.get<picojson::object>();
 
-	// Body shape:
-	//  { "query": "...", required string
-	//    "type":  "local" | "global" | "kad" (default "global"),
-	//    "file_type":  string (optional, amule file-type label),
-	//    "extension":  string (optional, e.g. "mkv"),
-	//    "min_size_bytes":    uint64 (optional, default 0),
-	//    "max_size_bytes":    uint64 (optional, default 0 = no cap),
-	//    "min_source_count":  uint32 (optional, default 0) }
+	// Body: { "query": required string, "type": "local"|"global"|"kad" (default
+	// "global"), "file_type": optional label, "extension": optional (e.g. "mkv"),
+	// "min_size_bytes"/"max_size_bytes": optional uint64 (0 = no cap),
+	// "min_source_count": optional uint32 }
 	std::string query;
 	{
 		const auto it = obj.find("query");
@@ -11476,10 +10471,9 @@ CHttpServer::Response CApiDispatcher::HandleSearchStart(const CHttpServer::Reque
 		delete ec_resp;
 		return ErrorResponse(400, "amuled_rejected", ec_err_msg.c_str());
 	}
-	// The daemon (in multi-search mode) allocates a globally-unique search_id
-	// and echoes it in the START reply; every subsequent results/stop/more
-	// call for this search is addressed by that id, so a reply without one
-	// leaves the caller nothing to address and is reported as such.
+	// The daemon (in multi-search mode) allocates a globally-unique search_id and
+	// echoes it in the START reply; every subsequent results/stop/more call is
+	// addressed by it, so a reply without one leaves the caller nothing to address.
 	std::uint32_t search_id = 0;
 	if (const CECTag *t = ec_resp->GetTagByName(EC_TAG_SEARCH_ID)) {
 		search_id = static_cast<std::uint32_t>(t->GetInt());
@@ -11491,21 +10485,13 @@ CHttpServer::Response CApiDispatcher::HandleSearchStart(const CHttpServer::Reque
 	}
 
 	// Seed this search's slot: the refresher polls EC_OP_SEARCH_RESULTS +
-	// _PROGRESS for it (addressed by search_id) each tick until the daemon
-	// reports completion. This is the single fetcher, so SSE
-	// search_result_added / search_progress fire on the same delta a polling
-	// consumer would observe. The query rides along so the results envelope
-	// can report what this search was for.
+	// _PROGRESS for it each tick until the daemon reports completion. This is the
+	// single fetcher, so SSE search_result_added / search_progress fire on the
+	// same delta a polling consumer would observe.
 	m_state.MarkSearchStarted(search_id, search_kind, query);
 
-	// A creation answers with the created resource and a Location, because
-	// here the daemon really does hand one back: SEARCH_START returns
-	// EC_TAG_SEARCH_ID, and this handler already treats its absence as a
-	// hard error. The three creations that get a bare 202 instead are the
-	// ones where EC answers success or failure and nothing more.
-	//
-	// The row is the same shape GET /search lists, written through the same
-	// writer, so a client can drop it straight into the collection it keeps.
+	// Same creation shape as the browse handler above: the daemon hands back
+	// EC_TAG_SEARCH_ID, so the response carries the resource and a Location.
 	SearchListRow row;
 	row.search_id = search_id;
 	row.query = wxString::FromUTF8(query.c_str());
@@ -11524,16 +10510,14 @@ CHttpServer::Response CApiDispatcher::HandleSearchStart(const CHttpServer::Reque
 }
 
 // The three per-search actions share one EC exchange: address the search by
-// EC_TAG_SEARCH_ID, send, and turn a failure reply into a 400. Only the
-// opcode, the optional close flag and the success shape differ, so the
-// exchange itself lives here rather than three times over.
+// EC_TAG_SEARCH_ID, send, and turn a failure reply into a 400. Only the opcode,
+// the optional close flag and the success shape differ.
 CHttpServer::Response CApiDispatcher::SendSearchOp(
 	ec_opcode_t opcode, std::uint32_t search_id, bool close, int success_status, int *out_more_reaskable)
 {
 	std::unique_ptr<CECPacket> ec_req(new CECPacket(opcode));
-	// Always addressed. The old no-id form let the daemon decide what "stop"
-	// meant when the caller had no current search; a concrete id is the only
-	// way to stop the right one when several are running.
+	// Always addressed. A concrete id is the only way to stop the right search
+	// when several are running.
 	ec_req->AddTag(CECTag(EC_TAG_SEARCH_ID, search_id));
 	if (close) {
 		ec_req->AddTag(CECEmptyTag(EC_TAG_SEARCH_CLOSE));
@@ -11558,9 +10542,7 @@ CHttpServer::Response CApiDispatcher::SendSearchOp(
 
 	CHttpServer::Response r;
 	r.status = success_status;
-	// No body on any of the three: the status code is the whole answer, and a
-	// 204 must not carry one at all per RFC 9110. Clearing the content type
-	// explicitly is what the other bodiless handlers do -- a
+	// No body on any of the three: a 204 must not carry one per RFC 9110, and a
 	// default-constructed Response does not necessarily start empty.
 	r.content_type.clear();
 	return r;
@@ -11577,13 +10559,9 @@ CHttpServer::Response CApiDispatcher::HandleSearchStop(
 	if (auto rej = RequireSearch(search_id))
 		return *rej;
 
-	// Stop only: the results stay readable -- amuled keeps them until the
-	// search is closed or evicted -- so a consumer viewing this search sees
-	// the same set it was just looking at. Siblings are untouched.
-	//
-	// 204, matching DELETE /search/{id}: with `ok` gone there is nothing left
-	// to say, and a 200 whose body is empty is the one shape a client cannot
-	// parse either way.
+	// Stop only: the results stay readable -- amuled keeps them until the search
+	// is closed or evicted -- so a consumer sees the same set it was looking at.
+	// 204, matching DELETE /search/{id}.
 	return SendSearchOp(EC_OP_SEARCH_STOP, search_id, /*close=*/false, 204);
 }
 
@@ -11621,11 +10599,9 @@ CHttpServer::Response CApiDispatcher::HandleSearchMore(
 		return *rej;
 
 	// The desktop "More" button re-asks already-queried Kad peers for a wider
-	// result frontier. Both constraints below mirror what that button does
-	// rather than what the core tolerates: CSearchManager::RequestMoreResults
-	// returns false for a non-Kad id and the GUI greys the button out once the
-	// search finishes, so forwarding either case would turn a user's request
-	// into a silent no-op with a 202 on top of it.
+	// result frontier. Both constraints below mirror what that button does rather
+	// than what the core tolerates: CSearchManager::RequestMoreResults returns
+	// false for a non-Kad id, and the GUI greys the button out once the search ends.
 	const webapi::SearchProgressSnapshot progress = m_state.SearchProgress(search_id);
 	if (progress.kind != "kad") {
 		return ErrorResponse(400, "bad_request", "`more` applies to Kad searches only");
@@ -11637,14 +10613,11 @@ CHttpServer::Response CApiDispatcher::HandleSearchMore(
 
 	// The daemon logs what actually happened and answers with the other half:
 	// whether a LATER press could still widen this search. False is terminal --
-	// the reask budget of 4 is spent, or the search is inside the stopping
-	// window Kad enters 20 s before a keyword search ends, which is most of the
-	// second half of its life. Reporting that as 202 is what let a client press
-	// "More" five times while the daemon did nothing.
+	// the reask budget of 4 is spent, or the search is inside the stopping window
+	// Kad enters 20 s before a keyword search ends.
 	//
-	// A press that simply has no responded peer left to reask *yet* still gets
-	// 202: it clears as soon as another peer answers, and retrying is genuinely
-	// the right next action.
+	// A press with no responded peer left to reask *yet* still gets 202: it
+	// clears as soon as another peer answers.
 	int reaskable = -1;
 	CHttpServer::Response r =
 		SendSearchOp(EC_OP_SEARCH_REQUEST_MORE, search_id, /*close=*/false, 202, &reaskable);
@@ -11668,25 +10641,20 @@ CHttpServer::Response CApiDispatcher::HandleSearchDownload(
 	if (auto rej = RequireAdmin(a))
 		return *rej;
 
-	// Canonicalise the URL hash to lowercase.
 	const std::string needle = LowerHexKey(hash);
 
 	CMD4Hash file_hash;
 	if (!HashFromHex(needle, file_hash)) {
-		// Same wording as every other {hash} route. RequireHashPath owns the
-		// message; it is called only here, on the path where it is certain to
-		// return a response, so the hash is not parsed twice in the good case.
+		// RequireHashPath owns the message; it is called only here, where it is
+		// certain to return a response, so the hash is not parsed twice.
 		return *RequireHashPath(needle);
 	}
 
-	// Optional body: {"category_index": uint8, "ecid": uint32}. amulegui's
-	// CDownQueueRem::AddSearchToDownload defaults to category 0
-	// when none is supplied; we mirror that. The body itself is
-	// optional — clients that don't care about category POST with
-	// no body and get the default download path. `ecid` (issue #431)
-	// selects one same-hash/different-name grouped child (from a result's
-	// `children[].ecid`) so it downloads under that chosen filename;
-	// omitted => the parent (first result matching the hash).
+	// Optional body: {"category_index": uint8, "ecid": uint32}. Defaults to
+	// category 0 when none is supplied, matching amulegui's
+	// CDownQueueRem::AddSearchToDownload. `ecid` selects one same-hash/
+	// different-name grouped child (from a result's `children[].ecid`) so it
+	// downloads under that filename; omitted => the parent.
 	std::uint8_t category = 0;
 	bool has_ecid = false;
 	std::uint32_t ecid = 0;
@@ -11732,11 +10700,9 @@ CHttpServer::Response CApiDispatcher::HandleSearchDownload(
 		}
 	}
 
-	// amuled accepts the result hash as the partfile-tag's int
-	// payload (matches amule-remote-gui.cpp:2230). amuled looks up
-	// the hash in its searchlist; if not present, returns FAILED. When
-	// an `ecid` selector is supplied, it rides as an EC_TAG_SEARCHFILE
-	// child and amuled downloads that specific grouped result instead.
+	// amuled accepts the result hash as the partfile-tag's int payload and looks
+	// it up in its searchlist, returning FAILED when absent. An `ecid` selector
+	// rides as an EC_TAG_SEARCHFILE child to pick a specific grouped result.
 	std::unique_ptr<CECPacket> ec_req(new CECPacket(EC_OP_DOWNLOAD_SEARCH_RESULT));
 	CECTag hash_tag(EC_TAG_PARTFILE, file_hash);
 	hash_tag.AddTag(CECTag(EC_TAG_PARTFILE_CAT, category));
@@ -11756,9 +10722,8 @@ CHttpServer::Response CApiDispatcher::HandleSearchDownload(
 	}
 	delete ec_resp;
 
-	// Inline refresh so /downloads sees the new partfile (subject
-	// to amuled's async allocate-and-hash; same caveat as POST
-	// /downloads — the partfile surfaces within 1-2 ticks).
+	// Inline refresh so /downloads sees the new partfile, subject to amuled's
+	// async allocate-and-hash -- it surfaces within 1-2 ticks.
 	(void)RefresherTick(m_app, m_state);
 
 	CHttpServer::Response r;
@@ -11769,9 +10734,8 @@ CHttpServer::Response CApiDispatcher::HandleSearchDownload(
 	return r;
 }
 
-// GET /search/results/{hash}/comments — community ratings/comments for one
-// search result (issue #434): the Kad notes retrieved so far plus the running
-// flag. Mirrors GET /downloads/{hash}/comments for single-hash polling.
+// GET /search/results/{hash}/comments -- community ratings/comments for one
+// search result: the Kad notes retrieved so far plus the running flag.
 CHttpServer::Response CApiDispatcher::HandleSearchComments(
 	const CHttpServer::Request &req, const std::string &hash)
 {
@@ -11787,27 +10751,22 @@ CHttpServer::Response CApiDispatcher::HandleSearchComments(
 
 	const std::string needle = LowerHexKey(hash);
 
-	// Locate the result carrying this hash across ALL open searches — the
-	// comments endpoints are search-agnostic (the same file may appear in
-	// several searches). Grouped children share the parent's hash, so the
-	// parent, which owns any fetched notes, matches first.
+	// Locate the result carrying this hash across ALL open searches -- the
+	// comments endpoints are search-agnostic. Grouped children share the
+	// parent's hash, so the parent, which owns any fetched notes, matches first.
 	webapi::SearchResult hit;
 	std::uint32_t owner_search_id = 0;
 	if (!m_state.FindSearchResultByHash(needle, hit, &owner_search_id)) {
 		return ErrorResponse(404, "not_found", "no search result with that hash");
 	}
 	// This is THE polling path for a Kad notes lookup: the notes only reach
-	// amuleapi through the owning search's result fetch, and a finished
-	// search is never fetched by the tick. Without this refresh a lookup
-	// started after the search completed -- which is when a user actually
-	// reads a result list -- would leave `kad_comment_lookup_running` stuck
-	// and `comments` empty forever. Re-read the hit afterwards so the
-	// response reflects the refresh rather than the snapshot before it.
+	// amuleapi through the owning search's result fetch, and a finished search
+	// is never fetched by the tick. Without this refresh a lookup started after
+	// the search completed would leave `kad_comment_lookup_running` stuck.
 	RefreshSearchIfStale(owner_search_id);
-	// A refresh can drop the hit -- the daemon frees a search's results when
-	// it is closed, and the set is rebuilt wholesale rather than merged. The
-	// bool was discarded here, so that case answered 200 from the pre-refresh
-	// copy: a result the daemon no longer has, reported as if it did.
+	// A refresh can drop the hit -- the daemon frees a search's results when it
+	// is closed, and the set is rebuilt wholesale rather than merged. The bool
+	// was discarded here, so that case answered 200 from the pre-refresh copy.
 	if (!m_state.FindSearchResultByHash(needle, hit, nullptr)) {
 		return ErrorResponse(404, "not_found", "no search result with that hash");
 	}
@@ -11841,10 +10800,9 @@ CHttpServer::Response CApiDispatcher::HandleSearchComments(
 	return r;
 }
 
-// POST /search/results/{hash}/comments — trigger an on-demand Kad NOTES lookup
-// for a search result the user has not downloaded (issue #434). Asynchronous on
-// amuled (up to ~45s); retrieved notes then appear via GET here and on the
-// /search/results list. Returns 202 Accepted.
+// POST /search/results/{hash}/comments -- trigger an on-demand Kad NOTES lookup
+// for a search result the user has not downloaded. Asynchronous on amuled (up
+// to ~45s); retrieved notes then appear via GET here and on /search/results.
 CHttpServer::Response CApiDispatcher::HandleSearchCommentsKadSearch(
 	const CHttpServer::Request &req, const std::string &hash)
 {
@@ -11864,16 +10822,14 @@ CHttpServer::Response CApiDispatcher::HandleSearchCommentsKadSearch(
 
 	CMD4Hash file_hash;
 	if (!HashFromHex(needle, file_hash)) {
-		// Same wording as every other {hash} route. RequireHashPath owns the
-		// message; it is called only here, on the path where it is certain to
-		// return a response, so the hash is not parsed twice in the good case.
+		// RequireHashPath owns the message; it is called only here, where it is
+		// certain to return a response, so the hash is not parsed twice.
 		return *RequireHashPath(needle);
 	}
 
-	// Must be a live search result in some open search (mirrors the download
-	// endpoint's 404). The daemon runs one Kad NOTES lookup per hash and fans
-	// the notes out to every same-hash result, so the specific search doesn't
-	// matter here.
+	// Must be a live search result in some open search. The daemon runs one Kad
+	// NOTES lookup per hash and fans the notes out to every same-hash result,
+	// so the specific search does not matter here.
 	webapi::SearchResult known_hit;
 	std::uint32_t owner_search_id = 0;
 	if (!m_state.FindSearchResultByHash(needle, known_hit, &owner_search_id)) {
@@ -11893,35 +10849,22 @@ CHttpServer::Response CApiDispatcher::HandleSearchCommentsKadSearch(
 	delete ec_resp;
 
 	// Refresh AFTER the lookup has been started, for the same reason the GET
-	// refreshes at all: a finished search is otherwise frozen, and the flag
-	// this POST turns on would never be observed turning off again.
+	// refreshes at all: a finished search is otherwise frozen, and the flag this
+	// POST turns on would never be observed turning off again.
 	//
-	// Order matters. Refreshing first cached a pre-lookup snapshot and spent
-	// the one-second ClaimSearchRefresh token on it, so a GET issued straight
-	// afterwards fell inside the TTL and reported
-	// `kad_comment_lookup_running: false` for a lookup that had just begun --
-	// breaking the poll-until-false loop the docs prescribe.
+	// Order matters. Refreshing first cached a pre-lookup snapshot and spent the
+	// one-second ClaimSearchRefresh token on it, so a GET issued straight after
+	// reported `kad_comment_lookup_running: false` for a lookup just begun.
 	RefreshSearchIfStale(owner_search_id);
 
 	CHttpServer::Response r;
-	// 202 with no body. The field it used to carry could hold exactly one
-	// value, so it said nothing the status code had not already said -- and
-	// `status` everywhere else on this surface is a transfer state
-	// (downloading, paused, hashing), so a client switching on it had to know
-	// which kind of object it was holding first.
+	// 202 with no body: the field it used to carry could hold exactly one value,
+	// so it said nothing the status code had not already said.
 	r.status = 202;
 	r.content_type.clear();
 	return r;
 }
 
-// SSE runs on a worker thread the HTTP server spawns per connection.
-// Auth is enforced in PreflightEvents (synchronous, before head
-// write and worker spawn); failures use the regular JSON error
-// envelope. The 15 s heartbeat is a `: keepalive\n\n` SSE comment
-// (RFC 6202) — proxies and many browsers drop idle TCP after ~30 s.
-//
-// DispatchStreaming reads head out-params ONCE before writing, so
-// one function here sets the head AND runs the drain loop.
 // CORS for the replies the transport builds without a parsed request: the
 // read-side limits and the request timeout. Takes the raw Origin header
 // because at that point there is no Request to resolve one from.
@@ -11938,19 +10881,14 @@ void CApiDispatcher::StampCorsForTransport(
 
 boost::optional<CHttpServer::Response> CApiDispatcher::PreflightEvents(const CHttpServer::Request &req)
 {
-	// Same bearer/cookie check the live handler used to do, but run
-	// on the I/O thread BEFORE a worker thread is spawned and BEFORE
-	// the 32-slot SSE budget is touched. Unauth/locked-out peers
-	// get a normal request/response 401/429 and never reach the
-	// streaming path; the slot stays free for legitimate
-	// subscribers.
+	// Same bearer/cookie check the live handler used to do, but run on the I/O
+	// thread BEFORE a worker is spawned and BEFORE the 32-slot SSE budget is
+	// touched, so the slot stays free for legitimate subscribers.
 	auto a = Authenticate(req);
 	if (!a.ok) {
-		// CORS on the rejection too. The HEAD probe below was moved
-		// into this function to pick the bundle up, and leaving the
-		// 401/403/429 without it means a cross-origin SSE client sees
-		// an opaque fetch failure exactly when it most needs to read
-		// why it was turned away.
+		// CORS on the rejection too: leaving the 401/403/429 without it means a
+		// cross-origin SSE client sees an opaque fetch failure exactly when it
+		// most needs to read why it was turned away.
 		{
 			const CorsDecision cors_org = ResolveCorsOrigin(req, m_config);
 			ApplyCorsHeaders(a.rejection.headers, cors_org, m_config.ServerCfg().allow_cors);
@@ -11958,22 +10896,17 @@ boost::optional<CHttpServer::Response> CApiDispatcher::PreflightEvents(const CHt
 		return a.rejection;
 	}
 	// A HEAD here asks what a GET would answer with, not for the stream.
-	// Answered in the dispatcher rather than in the transport so it picks
-	// up the same CORS bundle the stream itself carries -- built in the
-	// transport it had none, and a credentialed cross-origin HEAD was
-	// blocked by the browser while the GET succeeded.
+	// Answered in the dispatcher rather than the transport so it picks up the
+	// same CORS bundle the stream carries.
 	if (req.method == "HEAD") {
 		CHttpServer::Response probe;
 		probe.status = 200;
 		probe.content_type = "text/event-stream";
 		probe.headers["Cache-Control"] = "no-cache";
 		probe.headers["X-Accel-Buffering"] = "no";
-		// Mirror the encoding the GET would negotiate. The probe body
-		// is empty, so nothing downstream will compress it and the
-		// header has to be stated: without it a HEAD says identity
-		// while the stream it stands for arrives gzipped, which is the
-		// same divergence that makes a HEAD on any other route unsafe
-		// to cache against.
+		// Mirror the encoding the GET would negotiate. The probe body is empty,
+		// so nothing downstream will compress it and the header has to be
+		// stated: without it a HEAD says identity while the stream is gzipped.
 		if (AcceptsGzip(FindHeaderCaseInsensitive(req.headers, "Accept-Encoding"))) {
 			probe.headers["Content-Encoding"] = "gzip";
 		}
@@ -11989,22 +10922,14 @@ boost::optional<CHttpServer::Response> CApiDispatcher::PreflightEvents(const CHt
 	}
 
 	// `?channels=` is a 400, not "no filter". The surface's own query rule
-	// already says an empty value is an error rather than an omission, and
-	// this is the parameter that would otherwise be its exception: a client
-	// joining an empty selection list produces exactly this URL, so a UI with
-	// every category unchecked was handed the full firehose instead of a
-	// complaint. Omitting the parameter remains the spelling for "every
-	// channel", so nothing is lost by refusing the empty one.
+	// already says an empty value is an error rather than an omission, and this
+	// is the parameter that would otherwise be its exception: a client joining
+	// an empty selection list produces exactly this URL, so a UI with every
+	// category unchecked was handed the full firehose. Omitting the parameter
+	// remains the spelling for "every channel".
 	//
-	// Reading it as the empty set would be the tidier set semantics and the
-	// worse failure: a stream that opens, heartbeats and then delivers
-	// nothing forever is indistinguishable from a broken one, so the client
-	// that built the URL by accident would get a debugging session rather
-	// than an error message.
-	//
-	// Checked here rather than in the streaming handler because that one
-	// returns void -- by the time it parses the query the response has
-	// already been committed to.
+	// Checked here rather than in the streaming handler because that one returns
+	// void -- by the time it parses the query the response is already committed.
 	{
 		std::string query;
 		const std::size_t q = req.target.find('?');
@@ -12021,74 +10946,64 @@ boost::optional<CHttpServer::Response> CApiDispatcher::PreflightEvents(const CHt
 	return boost::none;
 }
 
+// SSE runs on a worker thread the HTTP server spawns per connection. Auth is
+// enforced in PreflightEvents, synchronously, before the head write and the
+// worker spawn. The 15 s heartbeat is a `: keepalive\n\n` SSE comment (RFC 6202)
+// -- proxies and many browsers drop idle TCP after ~30 s. DispatchStreaming
+// reads head out-params ONCE before writing, so this one function sets the head
+// AND runs the drain loop.
 void CApiDispatcher::DispatchEvents(const CHttpServer::Request &req,
 	CHttpServer::Writer &writer,
 	unsigned &http_status,
 	std::string &content_type,
 	std::map<std::string, std::string> &response_headers)
 {
-	// Auth ran inside PreflightEvents on the I/O thread before this
-	// worker spawned, so we can assume an authenticated principal
-	// here. Re-running Verify on the worker thread would just burn
-	// one HMAC compare per connection for no security gain.
+	// Auth ran inside PreflightEvents on the I/O thread before this worker
+	// spawned, so an authenticated principal can be assumed here.
 	auto a = Authenticate(req);
 	if (!a.ok) {
-		// Defence in depth — if PreflightEvents was bypassed for any
-		// reason (test harness, future routing change) we still
-		// reject here, just not as cheaply.
+		// Defence in depth: if PreflightEvents was bypassed (test harness, future
+		// routing change) we still reject here, just not as cheaply.
 		http_status = a.rejection.status;
 		content_type = "application/json";
 		writer.Write(a.rejection.body);
 		return;
 	}
-	// SSE doesn't need admin role — reads are guest-friendly. The
-	// channel multiplexes every event type clients want to subscribe
-	// to. Admin-gated mutations don't ship over SSE; SSE is a read-
-	// only push.
+	// SSE does not need admin: reads are guest-friendly and SSE is a read-only
+	// push -- admin-gated mutations do not ship over it.
 
 	http_status = 200;
 	content_type = "text/event-stream";
 	response_headers["Cache-Control"] = "no-cache";
 	response_headers["X-Accel-Buffering"] = "no"; // disable nginx buffering
 
-	// CORS on the SSE response too. EventSource sends
-	// `Origin` and reads only the standard CORS bundle for credentialed
-	// cross-origin streams. No Expose-Headers needed (SSE clients don't
-	// read response headers programmatically).
+	// CORS on the SSE response too: EventSource sends `Origin` and reads the
+	// standard bundle for credentialed cross-origin streams. No Expose-Headers.
 	{
 		const CorsDecision cors_org = ResolveCorsOrigin(req, m_config);
 		ApplyCorsHeaders(response_headers, cors_org, m_config.ServerCfg().allow_cors);
 	}
-	// Also disable Connection: keep-alive override — chunked +
-	// streaming requires the default. (HttpServer adds chunked
-	// transfer-encoding automatically.)
+	// No Connection: keep-alive override -- chunked + streaming requires the
+	// default, and HttpServer adds chunked transfer-encoding automatically.
 
-	// Initial reassurance chunk so the client knows the channel is
-	// open. Some browser EventSource impls don't fire `onopen` until
-	// at least one chunk lands.
+	// Initial reassurance chunk: some browser EventSource impls do not fire
+	// `onopen` until at least one chunk lands.
 	if (!writer.Write(": connected\n\n"))
 		return;
 
-	// Optional `?channels=<csv>` query: limit the event types
-	// delivered to a comma-separated subset. The mapping from
-	// EventBus event name → channel is prefix-based:
-	//  download_*  → "downloads"
-	//  shared_*    → "shared"
-	//  server_*    → "servers"
-	//  client_*    → "clients"
-	//  status_*    → "status"
-	//  log_*       → "logs"
-	// The synthetic per-subscriber `resync` event is ALWAYS
-	// delivered regardless of filter — its purpose is to signal a
-	// cache invalidation the client cannot opt out of.
-	// Unknown channel names in the query are silently ignored (allow
-	// forward-compatibility with future event families).
+	// Optional `?channels=<csv>`: limit the event types delivered. The mapping
+	// from EventBus event name to channel is prefix-based -- download_* ->
+	// "downloads", shared_* -> "shared", server_* -> "servers", client_* ->
+	// "clients", status_* -> "status", log_* -> "logs".
+	//
+	// The synthetic per-subscriber `resync` event is ALWAYS delivered regardless
+	// of filter: a cache invalidation the client cannot opt out of. Unknown
+	// channel names are silently ignored, for forward-compatibility.
 	std::set<std::string> channel_filter;
 	bool channels_set = false;
 	{
-		// Cap unique channel tokens at 32 (six today + headroom)
-		// so a 1 MB `channels=` query can't build a 1M-entry set in
-		// the SSE worker.
+		// Cap unique channel tokens at 32 so a 1 MB `channels=` query cannot
+		// build a 1M-entry set in the SSE worker.
 		constexpr std::size_t kMaxChannelTokens = 32;
 		std::string query;
 		const std::size_t q = req.target.find('?');
@@ -12123,14 +11038,11 @@ void CApiDispatcher::DispatchEvents(const CHttpServer::Request &req,
 		}
 	}
 	auto event_channel = [](const std::string &name) -> std::string {
-		// Event naming convention: every bus event MUST contain at
-		// least one underscore — the prefix before the first `_`
-		// identifies the channel. The only no-underscore name is
-		// `resync`, which the caller bypasses by name: it reaches the
-		// wire both synthesised per subscriber and published on the
-		// bus, and a cache invalidation is not opt-out-able either
-		// way. Future bare-token events need explicit channel mapping
-		// or must always bypass like `resync`.
+		// Event naming convention: every bus event MUST contain at least one
+		// underscore -- the prefix before the first `_` identifies the channel.
+		// The only no-underscore name is `resync`, which the caller bypasses by
+		// name. Future bare-token events need explicit channel mapping or must
+		// always bypass like `resync`.
 		const auto us = name.find('_');
 		if (us == std::string::npos)
 			return name;
@@ -12169,23 +11081,18 @@ void CApiDispatcher::DispatchEvents(const CHttpServer::Request &req,
 		return channel_filter.count(event_channel(name)) > 0;
 	};
 
-	// Drain blocks up to the heartbeat interval (15 s); on timeout we
-	// emit `: keepalive` so the connection stays warm.
-	//
-	// `since_id` resolution per RFC 6202 §4 reconnect:
-	//  - absent / unparseable → start from NewestId (events fired
-	//    AFTER connect only)
-	//  - in-range (parsed+1 >= OldestId) → resume from `parsed`; the
-	//    first Drain returns the missed range immediately
-	//  - gap (parsed+1 < OldestId) → events evicted before this
-	//    client read them; emit `resync` (reason=gap) so the client
-	//    invalidates + re-GETs REST collections, then start from
-	//    NewestId
-	//  - parsed > NewestId → stale id from a prior daemon process
-	//    (ids reset to 1 on restart); emit `resync` (reason=restart)
-	//    and start from NewestId.
 	// Registers this session for the life of the stream, so the refresher knows
-	// to resume diffing.
+	// to resume diffing. Drain blocks up to the heartbeat interval (15 s); on
+	// timeout we emit `: keepalive`.
+	//
+	// `since_id` resolution per RFC 6202 4 reconnect:
+	//  - absent / unparseable -> start from NewestId (post-connect events only)
+	//  - in-range (parsed+1 >= OldestId) -> resume from `parsed`; the first
+	//    Drain returns the missed range immediately
+	//  - gap (parsed+1 < OldestId) -> events evicted before this client read
+	//    them; emit `resync` (reason=gap), then start from NewestId
+	//  - parsed > NewestId -> stale id from a prior daemon process (ids reset
+	//    to 1 on restart); emit `resync` (reason=restart), start from NewestId.
 	webapi::CEventBus::Subscription subscription(m_app.EventBus());
 
 	std::uint64_t since_id;
@@ -12201,9 +11108,8 @@ void CApiDispatcher::DispatchEvents(const CHttpServer::Request &req,
 		if (end == lei.c_str() || *end != '\0') {
 			since_id = newest;
 		} else if (parsed > newest) {
-			// Per-subscriber synthetic event — not on the bus. id is
-			// the current newest so the client's EventSource resumes
-			// from there on the next reconnect (no resync loop).
+			// Per-subscriber synthetic event -- not on the bus. id is the current
+			// newest so the client's EventSource resumes there (no resync loop).
 			std::ostringstream frame;
 			frame << "event: resync\n"
 			      << "id: " << newest << "\n"
@@ -12225,22 +11131,17 @@ void CApiDispatcher::DispatchEvents(const CHttpServer::Request &req,
 			since_id = newest;
 		}
 	}
-	// Heartbeat is wall-clock driven, not Drain-timeout driven —
-	// a busy bus + `?channels=` that filters every drained event
-	// would otherwise leave the wire silent (Drain returns
-	// immediately, loop swallows + re-enters, keepalive never
-	// fires). NAT/proxies/EventSource clients drop idle TCP after
-	// ~30–60 s, so emit `: keepalive` whenever last-write falls
-	// behind the 15 s budget.
+	// Heartbeat is wall-clock driven, not Drain-timeout driven: a busy bus plus a
+	// `?channels=` that filters every drained event would otherwise leave the
+	// wire silent (Drain returns immediately, the loop swallows and re-enters,
+	// keepalive never fires). NAT/proxies drop idle TCP after ~30-60 s.
 	const auto heartbeat_interval = std::chrono::seconds(15);
 	auto last_write_at = std::chrono::steady_clock::now();
 	std::vector<webapi::Event> drained;
 	while (writer.Alive()) {
-		// Shutdown poll. The Shutdown() flag is set by the App on
-		// OnExit, and Drain() returns immediately when it's
-		// observed. If the daemon is going down, drop this client
-		// cleanly so the dispatcher reset() doesn't race a worker
-		// still holding `m_app` references.
+		// Shutdown poll. The flag is set by the App on OnExit and Drain() returns
+		// immediately once observed, so this client is dropped cleanly before the
+		// dispatcher reset() races a worker still holding `m_app` references.
 		if (m_app.EventBus().IsShutdown())
 			break;
 		drained.clear();
@@ -12250,11 +11151,10 @@ void CApiDispatcher::DispatchEvents(const CHttpServer::Request &req,
 		if (m_app.EventBus().IsShutdown())
 			break;
 
-		// Live-path gap detection. Reconnect handler above only
-		// catches gaps at session start; once running, a burst that
-		// fills + evicts the ring between Drains would silently drop
-		// the missed range. Check OldestId after each Drain — on
-		// cursor fall-off emit a typed resync and restart at newest.
+		// Live-path gap detection. The reconnect handler above only catches gaps
+		// at session start; once running, a burst that fills and evicts the ring
+		// between Drains would silently drop the missed range. On cursor
+		// fall-off emit a typed resync and restart at newest.
 		const std::uint64_t oldest_now = m_app.EventBus().OldestId();
 		const std::uint64_t newest_now = m_app.EventBus().NewestId();
 		if (oldest_now > 0 && since_id + 1 < oldest_now) {
@@ -12267,31 +11167,26 @@ void CApiDispatcher::DispatchEvents(const CHttpServer::Request &req,
 				break;
 			last_write_at = std::chrono::steady_clock::now();
 			since_id = newest_now;
-			// Drop the events the Drain returned — the client is
-			// about to re-fetch the REST collections (that's the
-			// `resync` contract) so any partial pre-resync events
-			// would be confusing noise.
+			// Drop the events the Drain returned -- the client is about to
+			// re-fetch the REST collections, which is the `resync` contract.
 			continue;
 		}
 
-		// Apply ?channels= filter before emission. We still advance
-		// since_id over EVERY drained event (filtered or not) so the
-		// client doesn't re-see them on reconnect; reconnect replay is
-		// id-based, not channel-based.
+		// Apply ?channels= filter before emission. since_id still advances over
+		// EVERY drained event, filtered or not, so the client does not re-see
+		// them on reconnect: replay is id-based, not channel-based.
 		std::ostringstream frame;
 		bool wrote_any = false;
 		for (const auto &ev : drained) {
 			if (!event_passes_filter(ev.name))
 				continue;
 			// SSE frame:  event: <name>\nid: <id>\ndata: <data>\n\n
-			// Per RFC 6202 §4 `data:` lines are single-line; our JSON
-			// payloads never contain literal newlines (EventDiff
-			// escapes them), so one `data:` line per event suffices.
+			// Per RFC 6202 4 `data:` lines are single-line; our JSON payloads
+			// never contain literal newlines (EventDiff escapes them).
 			//
-			// `ev.name` is NOT escaped — every event name on the bus
-			// is a server-controlled compile-time literal. A future
-			// publisher taking a name from external input MUST
-			// sanitize CR/LF/`\0` at its call site.
+			// `ev.name` is NOT escaped -- every event name on the bus is a
+			// server-controlled compile-time literal. A future publisher taking a
+			// name from external input MUST sanitize CR/LF/`\0` at its call site.
 			frame << "event: " << ev.name << "\n"
 			      << "id: " << ev.id << "\n"
 			      << "data: " << ev.data << "\n\n";
@@ -12304,15 +11199,11 @@ void CApiDispatcher::DispatchEvents(const CHttpServer::Request &req,
 			since_id = new_high;
 		} else {
 			if (!drained.empty()) {
-				// Every drained event got filtered out — advance the
-				// cursor silently so the next Drain doesn't re-read
-				// them.
+				// Advance the cursor silently so the next Drain does not re-read them.
 				since_id = new_high;
 			}
-			// drained.empty() (Drain hit its timeout with nothing
-			// new) OR all-events-filtered-out (the channel-filter
-			// drop). In either case, emit a heartbeat IFF we
-			// haven't written anything in the heartbeat window.
+			// Drain timed out with nothing new, or everything was filtered out.
+			// Either way, heartbeat IFF nothing was written in the window.
 			const auto now = std::chrono::steady_clock::now();
 			if (now - last_write_at >= heartbeat_interval) {
 				if (!writer.Write(": keepalive\n\n"))

--- a/src/webapi/Api.h
+++ b/src/webapi/Api.h
@@ -59,14 +59,12 @@ namespace webapi
 class CState;
 }
 
-// Request dispatcher for the `/api/v0/*` surface. Lives between the
-// transport (CHttpServer) and the per-endpoint handlers. Owns the
-// CJwt instance, the revocation set, and the rate limiter.
+// Request dispatcher for the `/api/v0/*` surface. Lives between the transport
+// (CHttpServer) and the per-endpoint handlers. Owns the CJwt instance, the
+// revocation set, and the rate limiter.
 //
-// References (not copies) of the config + jwt machinery: the App
-// constructs them once at startup and outlives every Request.
-// CRevocationSet + CRateLimiter live by-value inside the dispatcher
-// because they're amuleapi-owned state with no external consumer.
+// Config + jwt are held by reference: the App constructs them once at startup
+// and outlives every Request.
 
 class CApiDispatcher
 {
@@ -75,37 +73,32 @@ public:
 
 	CHttpServer::Response Dispatch(const CHttpServer::Request &req);
 
-	// streaming entry point. Called by HttpServer when the
-	// streaming_resolver matches `/api/v0/events`. The handler runs
-	// the SSE loop until the writer goes dead (peer disconnect) or
-	// returns voluntarily.
+	// Streaming entry point, called by HttpServer when the streaming_resolver
+	// matches `/api/v0/events`. Runs the SSE loop until the writer goes dead
+	// (peer disconnect) or it returns voluntarily.
 	void DispatchEvents(const CHttpServer::Request &req,
 		CHttpServer::Writer &writer,
 		unsigned &http_status,
 		std::string &content_type,
 		std::map<std::string, std::string> &response_headers);
 
-	// Synchronous preflight for the SSE path. Runs on the I/O thread
-	// BEFORE the worker thread is spawned and BEFORE the 32-slot
-	// streaming-session budget is touched. Returns boost::none to
-	// admit the connection; returns a 401/403/429 Response to short-
-	// circuit unauth peers without burning a slot.
+	// Synchronous preflight for the SSE path. Runs on the I/O thread BEFORE the
+	// worker thread is spawned and BEFORE the streaming-session budget is
+	// touched. boost::none admits; a 401/403/429 short-circuits without a slot.
 	boost::optional<CHttpServer::Response> PreflightEvents(const CHttpServer::Request &req);
 	// CORS for transport-built replies (408 / 413 / 431); see the .cpp.
 	void StampCorsForTransport(
 		std::map<std::string, std::string> &headers, const std::string &origin_header);
 
 private:
-	// Inner routing — picks the right Handle*() based on path/method,
-	// returns a fully-formed response. The public Dispatch wraps this
-	// with the ETag stamp + If-None-Match → 304 conversion
-	// (GET/HEAD on a 200 only).
+	// Inner routing -- picks the right Handle*() based on path/method. The public
+	// Dispatch wraps this with the ETag stamp and the If-None-Match -> 304
+	// conversion (GET/HEAD on a 200 only).
 	CHttpServer::Response DispatchToHandler(const CHttpServer::Request &req);
 
 public:
-	// Test-visible accessors; the auth-state containers are exposed
-	// so AuthTest can drive the rate-limit and revocation paths
-	// without standing up a full HTTP server.
+	// Test-visible accessors: the auth-state containers are exposed so AuthTest
+	// can drive the rate-limit and revocation paths without an HTTP server.
 	webapi::CRevocationSet &Revocations() { return m_revocations; }
 	webapi::CRateLimiter &RateLimiter() { return m_rateLimiter; }
 
@@ -118,11 +111,9 @@ private:
 	CHttpServer::Response HandleAuthPasswords(const CHttpServer::Request &);
 	CHttpServer::Response HandleAuthPasswordsPatch(const CHttpServer::Request &);
 
-	// The one way every protected handler authenticates. Applies the
-	// bearer/cookie lookup, signature and expiry checks, the per-IP
-	// failure limiter, the revocation list, and the rule that a token
-	// older than the last credential change is dead. Handlers call this
-	// and nothing else, so none of those can be forgotten at a call site.
+	// The one way every protected handler authenticates: bearer/cookie lookup,
+	// signature and expiry, per-IP failure limiter, revocation list, and the
+	// rule that a token older than the last credential change is dead.
 	AuthOutcome Authenticate(const CHttpServer::Request &req);
 
 	void BeginSession(
@@ -137,9 +128,8 @@ private:
 		const CHttpServer::Request &, const std::string &key);
 	// source-reported filenames + counts. `key` = 32-char MD4 hash.
 	CHttpServer::Response HandleDownloadFilenames(const CHttpServer::Request &, const std::string &key);
-	// A4AF swap action (POST). `key` = 32-char MD4 hash. The source rows
-	// come from GET /downloads/{hash}/clients, which flags each one with
-	// `a4af`.
+	// A4AF swap action (POST). `key` = 32-char MD4 hash; the source rows come
+	// from GET /downloads/{hash}/clients, which flags each one with `a4af`.
 	CHttpServer::Response HandleDownloadA4afAction(const CHttpServer::Request &, const std::string &key);
 	// download lifecycle mutations.
 	CHttpServer::Response HandleDownloadAdd(const CHttpServer::Request &);
@@ -160,14 +150,12 @@ private:
 	CHttpServer::Response HandleServerConnect(const CHttpServer::Request &, const std::string &ecid_str);
 	CHttpServer::Response HandleServerDelete(const CHttpServer::Request &, const std::string &ecid_str);
 	CHttpServer::Response HandleServerPatch(const CHttpServer::Request &, const std::string &ecid_str);
-	// Refresh the server list from a `server.met` URL — operator-
-	// curated server-list update, same EC op the desktop GUI's "Update
-	// from URL" button uses.
+	// Refresh the server list from a `server.met` URL -- the same EC op the
+	// desktop GUI's "Update from URL" button uses.
 	CHttpServer::Response HandleServerUpdateFromUrl(const CHttpServer::Request &);
-	// Address-keyed aliases that resolve {ip}:{port} to the ECID and
-	// delegate to HandleServerConnect / HandleServerDelete. Lets
-	// clients work without first having to GET /servers to learn the
-	// ECID for a known address.
+	// Address-keyed aliases that resolve {ip}:{port} to the ECID and delegate to
+	// HandleServerConnect / HandleServerDelete, so clients need not GET /servers
+	// first to learn the ECID for a known address.
 	CHttpServer::Response HandleServerConnectByAddress(
 		const CHttpServer::Request &, const std::string &ip_port);
 	CHttpServer::Response HandleServerPatchByAddress(
@@ -181,15 +169,13 @@ private:
 	CHttpServer::Response HandleNetworksDisconnect(const CHttpServer::Request &);
 	CHttpServer::Response HandleKadBootstrap(const CHttpServer::Request &);
 	CHttpServer::Response HandleKadUpdateFromUrl(const CHttpServer::Request &);
-	// IP-filter actions: re-read the on-disk filter files
-	// (EC_OP_IPFILTER_RELOAD), and download a fresh ipfilter.dat from a
-	// URL (EC_OP_IPFILTER_UPDATE). The update's URL is optional — it
-	// falls back to the configured security.ipfilter_update_url.
+	// IP-filter actions: re-read the on-disk filter files, and download a fresh
+	// ipfilter.dat from a URL. The update's URL is optional -- it falls back to
+	// the configured security.ipfilter_update_url.
 	CHttpServer::Response HandleIpfilterReload(const CHttpServer::Request &);
 	CHttpServer::Response HandleIpfilterUpdate(const CHttpServer::Request &);
-	// POST /geoip/update — fetch a fresh GeoIP database now. An action, so
-	// it is a route rather than the write-only `geoip.update_now` boolean
-	// it used to be inside PATCH /preferences.
+	// POST /geoip/update -- fetch a fresh GeoIP database now. An action, so it is
+	// a route rather than a write-only boolean inside PATCH /preferences.
 	CHttpServer::Response HandleGeoipUpdate(const CHttpServer::Request &);
 	// single shared-file detail (GET / HEAD). `key` = 32-char MD4 hash.
 	CHttpServer::Response HandleSharedDetail(const CHttpServer::Request &, const std::string &key);
@@ -197,47 +183,35 @@ private:
 	CHttpServer::Response HandleSharedPatch(const CHttpServer::Request &, const std::string &key);
 	// bulk shared-priority PATCH over a `hashes` array (#358).
 	CHttpServer::Response HandleSharedBulkPatch(const CHttpServer::Request &);
-	// re-hash a shared file against its on-disk data (EC_OP_VERIFY_LOCAL_DATA).
-	// `key` = 32-char MD4 hash. amuled schedules the hashing task and answers
-	// immediately, so this is accepted rather than completed.
+	// Re-hash a shared file against its on-disk data (EC_OP_VERIFY_LOCAL_DATA).
+	// amuled schedules the task and answers immediately, so this is accepted.
 	CHttpServer::Response HandleSharedVerify(const CHttpServer::Request &, const std::string &key);
-	// the bytes of one completed shared file (GET / HEAD). `key` = 32-char
-	// MD4 hash. The only handler that answers with a streamed file window
-	// rather than a buffered body: it resolves and containment-checks the
-	// path itself, then hands the transport a CHttpServer::Response::file.
-	// Honours a single byte Range (206), ignores multi-range sets per RFC
-	// 7233 3.1, and refuses partfiles with 409.
+	// The bytes of one completed shared file (GET / HEAD). The only handler that
+	// answers with a streamed file window rather than a buffered body: it
+	// resolves and containment-checks the path itself. Honours a single byte
+	// Range (206), ignores multi-range sets per RFC 7233 3.1, refuses partfiles.
 	CHttpServer::Response HandleSharedContent(const CHttpServer::Request &, const std::string &key);
 
 	// Static-frontend fallthrough. Resolves `url_path` under
-	// ServerCfg().static_root, returns the file with a content-type
-	// derived from its extension. Returns 404 when static serving is
-	// disabled (StaticRoot empty), when the file is absent, or when
-	// the resolved path escapes static_root (realpath containment).
-	// Falls back to index.html for extension-less paths so SPA deep
-	// links work. Supports If-None-Match → 304 via mtime+size ETag.
-	// Never requires auth — the shell is public; the API calls it
-	// makes still hit the per-handler role gates.
+	// ServerCfg().static_root and returns the file with a content-type derived
+	// from its extension. 404 when static serving is disabled, the file is
+	// absent, or the resolved path escapes static_root (realpath containment).
+	// Falls back to index.html for extension-less paths so SPA deep links work.
+	// Never requires auth -- the shell is public, its API calls still gated.
 	CHttpServer::Response ServeStaticFile(const CHttpServer::Request &, const std::string &url_path);
-	// Country-flag artwork for `country_code` (/clients, /servers and
-	// their SSE diffs carry the code; the flag image is what a frontend
-	// still needs to draw it). `url_path` is the full request path and
-	// must be "/flags/<cc>.png" with two lowercase ASCII letters, or
-	// "/flags/unknown.png" for the "??" placeholder; the bytes come
-	// from the embedded icon table's "flag_<cc>" entry, so nothing
-	// touches the file system. Returns 404 for any other shape and for
-	// codes the famfamfam set has no artwork for. Never requires auth
-	// — same rationale as ServeStaticFile, and the artwork is public
-	// either way.
+	// Country-flag artwork for `country_code`. `url_path` must be
+	// "/flags/<cc>.png" with two lowercase ASCII letters, or
+	// "/flags/unknown.png" for the "??" placeholder; the bytes come from the
+	// embedded icon table's "flag_<cc>" entry, so nothing touches the file
+	// system. 404 for any other shape and for codes the famfamfam set has no
+	// artwork for. Never requires auth -- the artwork is public either way.
 	CHttpServer::Response ServeCountryFlag(const CHttpServer::Request &, const std::string &url_path);
-	// Rescan shared directories — amuled re-walks the configured share
-	// roots and re-publishes whatever's there. Parameterless EC op
-	// (EC_OP_SHAREDFILES_RELOAD).
+	// Rescan shared directories -- amuled re-walks the configured share roots.
+	// Parameterless EC op (EC_OP_SHAREDFILES_RELOAD).
 	CHttpServer::Response HandleSharedReload(const CHttpServer::Request &);
 
 	// Re-extract media metadata: the whole share, or one file by hash. Both
-	// answer 202 -- the probes are queued on amuled's media-probe worker and
-	// the response says how many, never what they found.
+	// answer 202 -- the probes are queued and the response says how many.
 	CHttpServer::Response HandleSharedMediaRefresh(const CHttpServer::Request &);
 	CHttpServer::Response HandleSharedMediaRefreshOne(
 		const CHttpServer::Request &, const std::string &hash);
@@ -255,29 +229,21 @@ private:
 	CHttpServer::Response HandleCategoryDelete(
 		const CHttpServer::Request &, const std::string &index_str);
 	// search.
-	// Cache miss on a search_id: ask the core once (EC_OP_SEARCH_LIST)
-	// whether it holds this id anyway -- a search another client, or the
-	// monolithic GUI, started. Seeds the local slot via
-	// CState::MarkSearchDiscovered and returns true when found. Shared by
-	// every endpoint that addresses a search by id, so none of them can
-	// 404 on an id GET /api/v0/search just enumerated (got3nks, PR #680
-	// review): that contradiction was fixed once for /search/results and
-	// then found again in /search/stop, which is what made it a helper
-	// rather than a second copy. Deliberately a one-off round trip on the
-	// miss, not a per-tick refresher poll -- discovery is rare, so paying
-	// only when actually asked keeps the steady-state EC cost at zero.
+	// Cache miss on a search_id: ask the core once (EC_OP_SEARCH_LIST) whether
+	// it holds this id anyway -- a search another client, or the monolithic GUI,
+	// started. Seeds the local slot and returns true when found. Shared by every
+	// endpoint that addresses a search by id, so none of them can 404 on an id
+	// GET /api/v0/search just enumerated. Deliberately a one-off roundtrip on
+	// the miss, not a per-tick poll: discovery is rare.
 	bool DiscoverSearchIfHeldByCore(std::uint32_t search_id);
-	// Resolve a path-supplied search_id to a live slot, seeding it from the
-	// core on a cache miss. Returns an error response when nothing holds it.
-	// Every search-scoped handler starts with this, so they cannot disagree
-	// on what a 404 means.
+	// Resolve a path-supplied search_id to a live slot, seeding it from the core
+	// on a cache miss. Every search-scoped handler starts with this, so they
+	// cannot disagree on what a 404 means.
 	std::unique_ptr<CHttpServer::Response> RequireSearch(std::uint32_t search_id);
-	// Refresh one search's cached results if it is finished and its last
-	// fetch has aged out. The tick only polls ACTIVE searches, so without
-	// this a finished search's results are a frozen snapshot: a Kad notes
-	// lookup started on one of its hits would never report back, and a hit
-	// downloaded from it would keep claiming `status: "new"`. No-op (and no
-	// EC traffic) for an active search, or for a repeat read inside the TTL.
+	// Refresh one search's cached results if it is finished and its last fetch
+	// has aged out. The tick only polls ACTIVE searches, so without this a Kad
+	// notes lookup started on one of its hits would never report back, and a hit
+	// downloaded from it would keep claiming `status: "new"`.
 	void RefreshSearchIfStale(std::uint32_t search_id);
 	CHttpServer::Response HandleSearchList(const CHttpServer::Request &);
 	CHttpServer::Response HandleSearchStart(const CHttpServer::Request &);
@@ -287,12 +253,10 @@ private:
 	// POST /search/{id}/more: the desktop "More" button, Kad-only.
 	CHttpServer::Response HandleSearchMore(const CHttpServer::Request &, std::uint32_t search_id);
 	// One addressed EC exchange for stop / close / more: they differ only in
-	// opcode, the close flag and the success status, so the packet build,
-	// the EC_OP_FAILED mapping and the `{ok:true}` body live in one place.
-	// `out_more_reaskable`, when given, receives the EC_TAG_SEARCH_MORE_REASKABLE
-	// bit from the reply as 1 or 0, or stays -1 when the daemon sent no such
-	// tag. Only EC_OP_SEARCH_REQUEST_MORE carries it; -1 is what an older
-	// daemon looks like and must never be read as "exhausted".
+	// opcode, the close flag and the success status. `out_more_reaskable`, when
+	// given, receives the EC_TAG_SEARCH_MORE_REASKABLE bit as 1 or 0, or stays
+	// -1 when the daemon sent no such tag -- which is what an older daemon looks
+	// like and must never be read as "exhausted".
 	CHttpServer::Response SendSearchOp(ec_opcode_t opcode,
 		std::uint32_t search_id,
 		bool close,
@@ -310,11 +274,10 @@ private:
 	CHttpServer::Response HandleClientDetail(const CHttpServer::Request &, const std::string &ecid_str);
 	CHttpServer::Response HandleKnownClients(const CHttpServer::Request &);
 
-	// --- Chat (issue #971) -------------------------------------------------
-	// All six gate on m_app.IsServerChatActive() and answer 503
-	// ec_unsupported otherwise: a daemon predating the chat ops asserts on
-	// the unknown opcode rather than answering EC_OP_FAILED, so the request
-	// must never go out.
+	// --- Chat -------------------------------------------------
+	// All six gate on m_app.IsServerChatActive() and answer 503 ec_unsupported
+	// otherwise: a daemon predating the chat ops asserts on the unknown opcode
+	// rather than answering EC_OP_FAILED, so the request must never go out.
 	CHttpServer::Response HandleChats(const CHttpServer::Request &);
 	CHttpServer::Response HandleChatMessages(const CHttpServer::Request &, const std::string &peer);
 	CHttpServer::Response HandleChatSend(const CHttpServer::Request &, const std::string &peer);
@@ -322,15 +285,13 @@ private:
 	// Shared body of all three send forms; `target` is the EC tag naming the
 	// recipient (GUI_ID, client ECID or friend ECID).
 	CHttpServer::Response SendChatMessageTo(const CHttpServer::Request &, const CECTag &target);
-	// Address a conversation by friend / peer ECID instead of ip:port. The
-	// friend form is the one that reaches an OFFLINE friend, through their
-	// stored address.
+	// Address a conversation by friend / peer ECID instead of ip:port. The friend
+	// form is the one that reaches an OFFLINE friend, through their stored address.
 	CHttpServer::Response HandleFriendMessageSend(const CHttpServer::Request &, const std::string &ecid);
 	CHttpServer::Response HandleClientMessageSend(const CHttpServer::Request &, const std::string &ecid);
-	// POST /clients/{ecid}/shared_files — browse a peer's shared file list
-	// ("View Files", #399). Returns a search_id addressed like any search:
-	// results via GET /search/{id}/results, progress + SSE via the standard
-	// search machinery. (The old ?search_id= query form is a 404 since #996.)
+	// POST /clients/{ecid}/shared_files -- browse a peer's shared file list
+	// ("View Files"). Returns a search_id addressed like any search: results via
+	// GET /search/{id}/results, progress + SSE via the standard machinery.
 	CHttpServer::Response HandleClientBrowse(const CHttpServer::Request &, const std::string &ecid_str);
 	// Shared by the /clients and /friends browse routes; `by_friend` selects
 	// which sub-tag addresses the target.
@@ -343,46 +304,37 @@ private:
 	CHttpServer::Response HandlePreferences(const CHttpServer::Request &);
 	CHttpServer::Response HandleLogAmule(const CHttpServer::Request &);
 	CHttpServer::Response HandleLogServerinfo(const CHttpServer::Request &);
-	// Log reset mutations. Both clear the corresponding buffer on
-	// amuled's side via the EC_OP_RESET_LOG / EC_OP_CLEAR_SERVERINFO
-	// opcodes and invalidate / clear amuleapi's local mirror so the
-	// next GET reflects the post-reset state immediately (the
-	// refresher's incremental append-only path can't shrink the
-	// amule-log cache, and the server-info lazy cache would otherwise
-	// keep serving stale text until its TTL elapses).
+	// Log reset mutations. Both clear the corresponding buffer on amuled's side
+	// and invalidate amuleapi's local mirror so the next GET reflects the
+	// post-reset state: the refresher's append-only path cannot shrink the
+	// amule-log cache, and the server-info lazy cache would serve stale text.
 	CHttpServer::Response HandleLogAmuleReset(const CHttpServer::Request &);
 	CHttpServer::Response HandleLogServerinfoReset(const CHttpServer::Request &);
 	CHttpServer::Response HandleStatsTree(const CHttpServer::Request &);
 	CHttpServer::Response HandleStatsGraph(const CHttpServer::Request &, const std::string &graph);
 	CHttpServer::Response HandleSearchResults(const CHttpServer::Request &, std::uint32_t search_id);
 
-	// Not const: the credential endpoints write through the config, and
-	// verifying re-reads amuleapi-passwords (so a change made elsewhere
-	// takes effect without a restart) and upgrades a stale-cost record
-	// after a successful match.
+	// Not const: the credential endpoints write through the config, and verifying
+	// re-reads amuleapi-passwords (so a change made elsewhere takes effect
+	// without a restart) and upgrades a stale-cost record after a match.
 	CAmuleApiConfig &m_config;
 	CJwt &m_jwt;
 	webapi::CState &m_state;
 	CamuleapiApp &m_app;
 	webapi::CRevocationSet m_revocations;
 
-	// Cached resolution of the static-frontend root. Conf-side
-	// `[Server]/StaticRoot` wins; an empty conf value falls back to
-	// the install-path discovery chain (ResolveDefaultStaticDir).
-	// Resolved on first ServeStaticFile call, then memoized for the
-	// daemon's lifetime — operators editing the conf at runtime are
-	// expected to restart amuleapi.
+	// Cached resolution of the static-frontend root. `[Server]/StaticRoot` wins;
+	// an empty conf value falls back to the install-path discovery chain.
+	// Resolved on first ServeStaticFile call, then memoized for the daemon's
+	// lifetime -- editing the conf at runtime needs a restart.
 	mutable std::string m_static_root_cache;
 	mutable std::once_flag m_static_root_once;
 
-	// ETag memoization keyed on (request target, snapshot version).
-	// Every 200 GET/HEAD runs MD5 over the whole body for ETag — on a
-	// 10K-shared-file daemon /downloads is multi-MB and this is the
-	// dominant CPU cost of the safe-method path. Cache against
-	// `CState::SnapshotAt()` so two GETs for the same target between
-	// ticks return identical bodies + ETags. On overflow the cache
-	// is cleared wholesale (typical working set is well below cap;
-	// the bound is just a memory backstop).
+	// ETag memoization keyed on (request target, snapshot version). Every 200
+	// GET/HEAD runs MD5 over the whole body for the ETag, and on a 10K-file
+	// daemon /downloads is multi-MB, which is the dominant CPU cost of the
+	// safe-method path. On overflow the cache is cleared wholesale -- the bound
+	// is a memory backstop, not a working-set estimate.
 	mutable std::mutex m_etagCacheMu;
 	struct EtagCacheEntry
 	{
@@ -392,41 +344,32 @@ private:
 	};
 	std::map<std::string, EtagCacheEntry> m_etagCache;
 	static constexpr std::size_t kEtagCacheCapacity = 512;
-	// Login-specific failure counter. Tight thresholds (driven by
-	// the operator's `[Auth]/Login*` config) — humans typing
-	// passwords rarely fail >5 times in 60 s, so a tight cap is
-	// the right shape for password-guessing defence.
+	// Login-specific failure counter, with tight thresholds from the operator's
+	// `[Auth]/Login*` config: humans typing passwords rarely fail >5 times in
+	// 60 s, so a tight cap is the right shape for password-guessing defence.
 	webapi::CRateLimiter m_rateLimiter;
-	// Generic 401 failure counter — covers logout, session, events,
-	// and every mutation endpoint. Looser thresholds than login
-	// because a misconfigured CI runner or a tab whose cookie just
-	// expired shouldn't lock the user out for five minutes after
-	// a handful of requests, but a credential-stuffing attempt that
-	// burns through stolen bearer tokens DOES need a brake. Default
-	// 30 failures in 60 s → 5 min lockout (set in the dispatcher
-	// ctor below).
+	// Generic 401 failure counter -- logout, session, events, and every mutation
+	// endpoint. Looser than login because a misconfigured CI runner or a tab
+	// whose cookie just expired should not lock the user out, but a
+	// credential-stuffing attempt burning through stolen bearer tokens DOES
+	// need a brake. Default 30 failures in 60 s -> 5 min lockout.
 	webapi::CRateLimiter m_authRateLimiter;
 
-	// Lazy-fetch TTL caches. Each cache stores the
-	// snapshot value PLUS the wall-clock time at fetch so handlers
-	// can render `snapshot_at` against the actual freshness, not the
-	// refresher's tick boundary. TTL coalesces concurrent burst reads
-	// (1 s default; per design call). Fetcher lambdas
-	// acquire `m_app.m_ec_mtx` AFTER the cache's own mutex — single
-	// flight: a second concurrent miss waits on the cache mutex and
-	// reads the just-stored value.
+	// Lazy-fetch TTL caches. Each stores the snapshot value PLUS the wall-clock
+	// time at fetch, so handlers render `snapshot_at` against actual freshness
+	// rather than the refresher's tick boundary. The TTL coalesces concurrent
+	// burst reads, and the fetcher lambdas acquire m_app.m_ec_mtx AFTER the
+	// cache's own mutex -- single flight, so a second miss reads the stored value.
 	using TtlPair_StatsTree = std::pair<webapi::StatsTreeNode, std::time_t>;
 	using TtlPair_StatsGraphs = std::pair<webapi::StatsGraphs, std::time_t>;
 	using TtlPair_ServerInfo = std::pair<webapi::ServerInfoLog, std::time_t>;
 	webapi::CTtlCache<TtlPair_StatsTree> m_stats_tree_cache;
 	webapi::CTtlCache<TtlPair_StatsGraphs> m_stats_graphs_cache;
 	webapi::CTtlCache<TtlPair_ServerInfo> m_server_info_cache;
-	// /known_clients is NOT cached here. Its store is fetched once on first
-	// request and then maintained by the refresher (CState::ReconcileKnown
-	// Clients), so there is nothing to expire and nothing to re-read.
-	// /search/results is no longer cached here — the refresher owns
-	// the polling while a search is active (see CState::SearchProgress
-	// + RefresherTick). POST /search calls m_state.MarkSearchStarted.
+	// /known_clients is NOT cached here: its store is fetched once on first
+	// request and then maintained by the refresher, so there is nothing to
+	// expire. /search/results is not either -- the refresher owns the polling
+	// while a search is active.
 };
 
 #endif // WEBAPI_API_H

--- a/src/webapi/App.cpp
+++ b/src/webapi/App.cpp
@@ -103,17 +103,14 @@ void HandleEcConnectionLost()
 // RSS once per pool thread.
 //
 // 2 reserves nothing for the refresher -- reuse_arena() rotates main_arena in
-// too -- it buys a second lock domain and half the churn in an mmap'd arena
-// madvise can reclaim. An explicit MALLOC_ARENA_MAX or glibc.malloc.arena_max
-// wins; a zero or empty one does not, since glibc rejects it (minval 1) and
-// falls back to its own default.
+// too -- it buys a second lock domain and half the churn. An explicit
+// MALLOC_ARENA_MAX wins; a zero or empty one does not, since glibc rejects it.
 void CapMallocArenas()
 {
 #if defined(M_ARENA_MAX)
 	// Base 0, not 10: glibc's tunable parser takes hex and octal, so a base-10
-	// read of MALLOC_ARENA_MAX=0x8 gives 0 and we would cap over an operator
-	// who set 8. A value glibc itself rejects still parses as 0 here, which is
-	// what makes the cap apply to it.
+	// read of MALLOC_ARENA_MAX=0x8 gives 0 and we would cap over an operator who
+	// set 8. A value glibc itself rejects still parses as 0 here.
 	const char *env = std::getenv("MALLOC_ARENA_MAX");
 	if (env && std::strtol(env, nullptr, 0) > 0) {
 		return;
@@ -131,12 +128,11 @@ void CapMallocArenas()
 #endif
 }
 
-// glibc shrinks an arena's top on free (systrim / heap_trim) but never the
-// free space fragmented below it, which is what a tick decoding the whole
-// daemon state leaves. malloc_trim walks every arena's free chunks instead.
-//
-// M_TRIM_THRESHOLD, not __GLIBC__ alone: the macro comes from <malloc.h>,
-// included conditionally above, so it is what says the declaration is in scope.
+// glibc shrinks an arena's top on free (systrim / heap_trim) but never the free
+// space fragmented below it, which is what a tick decoding the whole daemon
+// state leaves. malloc_trim walks every arena's free chunks instead.
+// M_TRIM_THRESHOLD, not __GLIBC__ alone: that macro is what says <malloc.h> is
+// actually in scope.
 void TrimMallocArenas()
 {
 #if defined(__GLIBC__) && defined(M_TRIM_THRESHOLD)
@@ -151,9 +147,8 @@ CamuleapiApp::~CamuleapiApp() = default;
 
 void CamuleapiApp::OnInitCmdLine(wxCmdLineParser &parser)
 {
-	// Pulls in --host / --port / --password / --config-dir / --quiet /
-	// --verbose / --locale. The base appname becomes the executable
-	// name in usage text.
+	// Pulls in --host / --port / --password / --config-dir / --quiet / --verbose
+	// / --locale. The base appname becomes the executable name in usage text.
 	CaMuleExternalConnector::OnInitCmdLine(parser, "amuleapi");
 
 	parser.AddOption("",
@@ -185,9 +180,7 @@ void CamuleapiApp::OnInitCmdLine(wxCmdLineParser &parser)
 		wxCMD_LINE_VAL_STRING,
 		wxCMD_LINE_PARAM_OPTIONAL);
 	parser.AddSwitch("", "foreground", _("Stay in the foreground; default."), wxCMD_LINE_PARAM_OPTIONAL);
-	// --daemon was reserved but never read — landed as a no-op switch.
-	// Dropped to avoid implying detach support that isn't here yet.
-	// Operators wanting fork-into-background today wrap amuleapi in
+	// No --daemon: operators wanting fork-into-background wrap amuleapi in
 	// systemd/launchd/`nohup` like any other long-running CLI.
 }
 
@@ -208,15 +201,11 @@ bool CamuleapiApp::OnCmdLineParsed(wxCmdLineParser &parser)
 	if (parser.Found("set-guest-pass", &m_cliSetGuestPass)) {
 		m_cliHasSetGuestPass = true;
 	}
-	// The base class reads --host / --port / --password into m_host /
-	// m_port / m_password before we get here, but it offers no "did
-	// the user actually pass this?" predicate of its own — m_host
-	// defaults to "127.0.0.1" unconditionally and m_port to 4712. We
-	// poll the parser directly here so LoadAmuleapiConfig() can tell
-	// "operator explicitly passed --host=127.0.0.1" apart from
-	// "operator passed nothing and the base class filled in the
-	// default", and only apply the amuleapi.conf override in the
-	// second case. Same shape as the bind / http-port branches above.
+	// The base class reads --host / --port / --password into m_host / m_port /
+	// m_password before we get here, but offers no "did the user actually pass
+	// this?" predicate -- m_host defaults to "127.0.0.1" unconditionally. Polling
+	// the parser directly lets LoadAmuleapiConfig() tell an explicit
+	// --host=127.0.0.1 apart from the base class's filled-in default.
 	m_cliHasEcHost = parser.Found("host");
 	m_cliHasEcPort = parser.Found("port");
 	m_cliHasEcEncryption = parser.Found("disable-ec-encryption");
@@ -234,17 +223,14 @@ bool CamuleapiApp::OnInit()
 		return false;
 	}
 
-	// Resolve the config dir: explicit --config-dir wins, otherwise take
-	// what the base class resolved in OnCmdLineParsed via the core's
-	// GetConfigDir(). That is always set by the time we get here, so there
-	// is no third fallback -- amuleapi and amuled run the same resolver
-	// rather than each having their own idea of where config lives.
+	// Resolve the config dir: explicit --config-dir wins, otherwise what the base
+	// class resolved in OnCmdLineParsed via the core's GetConfigDir(). Always set
+	// by now, so there is no third fallback -- one resolver for both daemons.
 	const wxString config_dir = m_cliConfigDirOverride.IsEmpty() ? m_configDir : m_cliConfigDirOverride;
 
 	// Tee stdout/stderr into a log file (unless --no-log-file), as early as
 	// possible so config-load errors, EC warnings and a crash backtrace are all
-	// captured. Default path is in the resolved config dir; create that dir
-	// first so the very first run can open the file.
+	// captured. Create the config dir first so the very first run can open it.
 	if (!m_noLogFile) {
 		if (!wxDirExists(config_dir)) {
 			wxFileName::Mkdir(config_dir, 0700, wxPATH_MKDIR_FULL);
@@ -262,11 +248,10 @@ bool CamuleapiApp::OnInit()
 		}
 	}
 
-	// Route wxWidgets' own log channel (wxLogError/wxLogWarning, emitted by wx
-	// internals) to stderr. amuleapi is a wxApp with the GUI core linked, so the
-	// default target is wxLogGui -- message boxes, which are useless on a
-	// headless daemon and never reach the log. wxLogStderr sends them to stderr,
-	// where the tee above picks them up (and no dialog is ever attempted).
+	// Route wxWidgets' own log channel to stderr. amuleapi is a wxApp with the GUI
+	// core linked, so the default target is wxLogGui -- message boxes, useless on
+	// a headless daemon and never reaching the log. wxLogStderr sends them where
+	// the tee above picks them up.
 	delete wxLog::SetActiveTarget(new wxLogStderr);
 
 	if (!LoadAmuleapiConfig()) {
@@ -274,20 +259,16 @@ bool CamuleapiApp::OnInit()
 		return false;
 	}
 
-	// Construct the SSE bus once the operator-tunable capacity is
-	// known. Below the floor is clamped by CEventBus itself.
+	// Constructed once the operator-tunable capacity is known; CEventBus clamps.
 	m_event_bus = std::unique_ptr<webapi::CEventBus>(
 		new webapi::CEventBus(m_apiConfig.StreamingCfg().event_bus_ring_capacity));
 
 	// CLI override hooks. set-*-pass exits immediately after writing.
 	if (m_cliHasSetAdminPass || m_cliHasSetGuestPass) {
-		// Both options run as one-shot CLI flows. Operators script
-		// these like `amuleapi --set-admin-pass=... && systemctl
-		// restart amuleapi` — they MUST see the non-zero exit code on
-		// disk-full / mode-bit rejection / etc., otherwise the
-		// chain runs against the half-written file. Returning false
-		// from OnInit() would cancel wxApp::OnRun() but still exit 0,
-		// so we std::exit() here with the real return code.
+		// Both options run as one-shot CLI flows. Operators script these like
+		// `amuleapi --set-admin-pass=... && systemctl restart amuleapi`, so they
+		// MUST see a non-zero exit code on failure. Returning false from OnInit()
+		// would cancel wxApp::OnRun() but still exit 0, so std::exit() here.
 		const int rc = m_cliHasSetAdminPass ? RunSetAdminPass() : RunSetGuestPass();
 		std::exit(rc);
 	}
@@ -305,14 +286,10 @@ bool CamuleapiApp::LoadAmuleapiConfig()
 		return false;
 	}
 
-	// Wire the EC connection params into the base-class fields that
-	// ConnectAndRun reads. CLI --host/--port/--password (captured via
-	// wxCmdLineParser::Found() in OnCmdLineParsed) win over
-	// amuleapi.conf. The old "is the field still at the default
-	// value?" heuristic conflated "operator didn't pass" with
-	// "operator explicitly passed the default" — so a literal
-	// `amuleapi --host=127.0.0.1` would be silently overwritten by
-	// the config file. The has-flag predicates are unambiguous.
+	// Wire the EC connection params into the base-class fields ConnectAndRun
+	// reads. CLI --host/--port/--password win over amuleapi.conf, decided by the
+	// has-flag predicates: the old "is the field still at its default?" heuristic
+	// silently overwrote a literal `amuleapi --host=127.0.0.1`.
 	if (!m_cliHasEcHost) {
 		const auto &h = m_apiConfig.EcCfg().host;
 		if (!h.empty())
@@ -323,48 +300,36 @@ bool CamuleapiApp::LoadAmuleapiConfig()
 	}
 	if (!m_cliHasEcEncryption) {
 		// amuleapi.conf is the only config file amuleapi reads (see
-		// UsesConnectorConfigFile), so this is the sole source below the
-		// command line -- same shape as host/port/password above.
+		// UsesConnectorConfigFile), so it is the sole source below the command line.
 		m_ECEncryption = m_apiConfig.EcCfg().encryption;
 	}
 	if (!m_apiConfig.EcCfg().password.empty()) {
-		// amuleapi.conf [EC]/Password is plaintext; the base class
-		// expects an MD5-hashed CMD4Hash (because that's what amuled
-		// stores). MD5-hash here so a one-line amuleapi.conf edit
-		// gives the operator a working setup.
+		// amuleapi.conf [EC]/Password is plaintext; the base class expects an
+		// MD5-hashed CMD4Hash, because that is what amuled stores. Hash here so a
+		// one-line amuleapi.conf edit gives the operator a working setup.
 		const wxString plain = wxString::FromUTF8(m_apiConfig.EcCfg().password.c_str());
 		m_password.Decode(MD5Sum(plain).GetHash());
 	}
 
-	// Ephemeral EC token, if the aMule core that spawned us left one. Both
-	// sides derive the name from webcommon rather than passing a path,
-	// because argv is world-readable via ps: telling every local user
-	// where the secret is for as long as it exists would undo the point of
-	// writing it 0600.
+	// Ephemeral EC token, if the aMule core that spawned us left one. Both sides
+	// derive the name from webcommon rather than passing a path, because argv is
+	// world-readable via ps: telling every local user where the secret is would
+	// undo the point of writing it 0600.
 	//
 	// Wins over amuleapi.conf: when the core issued a token, that is the
-	// credential it wants us to use. Nothing overrides it: there is no
-	// --password to override it with, so the token and amuleapi.conf are
-	// the only two sources.
+	// credential it wants us to use. There is no --password to override it with,
+	// so the token and amuleapi.conf are the only two sources.
 	//
-	// This is what replaced --amule-config-file. That flag handed us the
-	// hashed EC password straight out of amule.conf, and in this protocol
-	// the stored value IS the credential -- so a network-facing daemon was
-	// holding something equivalent to the user's password, for its whole
-	// run. The token is equivalent for connecting and worthless once the
-	// daemon it belongs to has exited.
-	//
-	// Deleted on read, not after connecting. A failed connection retries
-	// from memory, so holding the file until the handshake completes would
-	// only widen the window in which the secret is at rest for nothing.
+	// Deleted on read, not after connecting. A failed connection retries from
+	// memory, so holding the file until the handshake completes would only widen
+	// the window in which the secret is at rest, for nothing.
 	{
 		const std::string tokenPath = webcommon::EcTokenFilePath(std::string(config_dir.utf8_str()));
 		std::string token;
 		if (webcommon::ReadAndConsumeEcToken(tokenPath, token)) {
 			m_password.Decode(wxString::FromUTF8(token.c_str()));
-			// Worth one line: it tells an operator which credential this
-			// instance is actually using, and it is what the "no token
-			// left on disk" check looks for after startup.
+			// Worth one line: it tells an operator which credential this instance is
+			// using, and is what the "no token left on disk" check looks for.
 			Show("amuleapi: using the ephemeral EC token from the core.\n");
 		}
 	}
@@ -404,14 +369,13 @@ int CamuleapiApp::RunSetGuestPass()
 
 int CamuleapiApp::OnRun()
 {
-	// Install signal handlers before the HTTP server starts so a
-	// signal during bring-up doesn't default-terminate the daemon.
+	// Install signal handlers before the HTTP server starts so a signal during
+	// bring-up does not default-terminate the daemon.
 	//
-	// sigaction (not std::signal) — std::signal's "reset to SIG_DFL
-	// after firing" is implementation-defined (musl/Alpine, older
-	// BSDs trip it), so a second SIGINT would terminate mid-shutdown.
-	// SA_RESTART so blocking syscalls on the EC socket don't return
-	// EINTR. Windows lacks sigaction; fall back to std::signal there.
+	// sigaction, not std::signal: the latter's "reset to SIG_DFL after firing" is
+	// implementation-defined (musl/Alpine and older BSDs trip it), so a second
+	// SIGINT would terminate mid-shutdown. SA_RESTART so blocking syscalls on the
+	// EC socket do not return EINTR. Windows lacks sigaction; std::signal there.
 #ifndef _WIN32
 	struct sigaction sa;
 	std::memset(&sa, 0, sizeof(sa));
@@ -426,20 +390,16 @@ int CamuleapiApp::OnRun()
 	::sigaction(SIGINT, &sa, nullptr);
 	::sigaction(SIGTERM, &sa, nullptr);
 #ifdef SIGHUP
-	// SIGHUP is the "config reload" signal in long-running daemons.
-	// has no reload story (configs are read at startup only);
-	// treat SIGHUP as a soft shutdown so a systemd reload doesn't
-	// leave the daemon in a half-state.
+	// SIGHUP is the "config reload" signal in long-running daemons. amuleapi has
+	// no reload story (configs are read at startup only), so treat it as a soft
+	// shutdown rather than leave the daemon in a half-state on a systemd reload.
 	::sigaction(SIGHUP, &sa, nullptr);
 #endif
 #ifdef SIGPIPE
-	// SSE peers that disappear mid-write make Linux raise SIGPIPE on
-	// the next asio::write to the closed fd. We don't pass
-	// MSG_NOSIGNAL on any of the SSE socket writes (HttpServer.cpp),
-	// so without ignoring SIGPIPE here the default disposition kills
-	// the daemon on every dropped EventSource. Ignore it process-
-	// wide; the writes return EPIPE and the streaming-handler loop
-	// bails on the next writer.Alive() poll.
+	// SSE peers that disappear mid-write make Linux raise SIGPIPE on the next
+	// asio::write to the closed fd, and none of the SSE socket writes pass
+	// MSG_NOSIGNAL, so the default disposition would kill the daemon on every
+	// dropped EventSource. The writes then return EPIPE and the loop bails.
 	struct sigaction sa_ign;
 	std::memset(&sa_ign, 0, sizeof(sa_ign));
 	sa_ign.sa_handler = SIG_IGN;
@@ -452,36 +412,28 @@ int CamuleapiApp::OnRun()
 	std::signal(SIGTERM, RequestShutdown);
 #endif
 
-	// Turn a dropped EC connection into this daemon's orderly shutdown rather
-	// than the hard _exit() the EC client does by default: the handler flips the
-	// main-loop shutdown flag so OnExit runs (HTTP/EC/log-tee all torn down
-	// cleanly). Registered before ConnectAndRun so a drop during bring-up is
-	// covered too.
+	// Turn a dropped EC connection into this daemon's orderly shutdown rather than
+	// the hard _exit() the EC client does by default: the handler flips the
+	// main-loop shutdown flag so OnExit runs. Registered before ConnectAndRun so
+	// a drop during bring-up is covered too.
 	SetEcConnectionLostHandler(&HandleEcConnectionLost);
 
-	// amuleapi addresses searches by daemon-allocated ID (several concurrent
-	// searches, one REST search_id each), so advertise the multi-search
-	// capability at EC login. ConnectAndRun forwards this to the EC client
-	// before it sends the login packet, which puts the daemon connection into
-	// multi-search mode (it allocates and returns an EC_TAG_SEARCH_ID per
-	// start, and addresses results/progress/stop by that ID). amuleapi is new
-	// in 3.1.0 and always pairs with a matching daemon, so there is no
-	// single-search fallback to maintain.
+	// amuleapi addresses searches by daemon-allocated ID, so it advertises the
+	// multi-search capability at EC login. ConnectAndRun forwards this before the
+	// login packet, which puts the daemon connection into multi-search mode: it
+	// allocates and returns an EC_TAG_SEARCH_ID per start, and addresses
+	// results/progress/stop by that ID. There is no single-search fallback.
 	m_canMultiSearch = true;
 
 	// Chat: amuleapi serves /chats from the daemon's session store, so it
-	// advertises EC_TAG_CAN_CHAT_SESSIONS at login and the daemon echoes it
-	// back when it serves those ops. The
-	// echo is what every chat endpoint gates on -- against a daemon that
-	// predates the ops, an unknown opcode asserts rather than failing, so
-	// they must answer 503 ec_unsupported instead of asking.
+	// advertises EC_TAG_CAN_CHAT_SESSIONS at login and the daemon echoes it back.
+	// The echo is what every chat endpoint gates on -- against a daemon that
+	// predates the ops, an unknown opcode asserts rather than failing.
 	m_canChat = true;
 
-	// ConnectAndRun does the EC bring-up (CRemoteConnect, ConnectToCore)
-	// and then calls TextShell — which we've overridden so the daemon's
-	// main loop runs there. On EC failure ConnectAndRun returns without
-	// ever entering TextShell, which is the correct outcome for a
-	// daemon that has nothing to do without amuled.
+	// ConnectAndRun does the EC bring-up (CRemoteConnect, ConnectToCore) and then
+	// calls TextShell, which is overridden so the daemon's main loop runs there.
+	// On EC failure it returns without ever entering TextShell.
 	ConnectAndRun(wxT("amuleapi"), wxString::FromAscii(VERSION));
 
 	// Non-zero when we stopped because EC died, so a supervisor restarts us.
@@ -500,14 +452,10 @@ void CamuleapiApp::TextShell(const wxString & /*prompt*/)
 		port = static_cast<unsigned>(m_cliHttpPort);
 	}
 
-	// Bind-time hard gate against the "listening publicly with no
-	// password configured" footgun. A daemon bound to a routable
-	// interface before the operator runs `amuleapi --set-admin-pass`
-	// would still answer the unauth surface (/api/v0/version) — and
-	// any future read-without-auth surface — even though logins
-	// return 503. Refuse to start instead.
-	//
-	// Loopback bind + empty passwords is fine; first-run flow IS
+	// Bind-time hard gate against the "listening publicly with no password
+	// configured" footgun: a daemon bound to a routable interface before the
+	// operator runs `amuleapi --set-admin-pass` would still answer the unauth
+	// surface. Loopback bind + empty passwords is fine -- the first-run flow IS
 	// "start on loopback, then run --set-admin-pass".
 	const bool non_loopback = (bind != "127.0.0.1" && bind != "::1" && bind != "localhost");
 	if (non_loopback && !m_apiConfig.HasAnyCredential()) {
@@ -520,26 +468,23 @@ void CamuleapiApp::TextShell(const wxString & /*prompt*/)
 		return;
 	}
 
-	// Build the JWT machinery from the loaded secret + a dispatcher
-	// that holds the rate-limiter + revocation set by value. The
-	// dispatcher reaches the State cache through CamuleapiApp; the
-	// lambda below pins the dispatcher's lifetime to App's.
+	// Build the JWT machinery from the loaded secret plus a dispatcher holding the
+	// rate-limiter and revocation set by value. The dispatcher reaches the State
+	// cache through CamuleapiApp; the lambda below pins its lifetime to App's.
 	m_jwt = std::unique_ptr<CJwt>(new CJwt(m_apiConfig.JwtSecret()));
 	m_dispatcher =
 		std::unique_ptr<CApiDispatcher>(new CApiDispatcher(m_apiConfig, *m_jwt, m_state, *this));
 	CApiDispatcher *const dispatcher = m_dispatcher.get();
 	auto handler = [dispatcher](const CHttpServer::Request &req) { return dispatcher->Dispatch(req); };
 
-	// streaming resolver + handler for /api/v0/events. The
-	// resolver picks every GET that matches the path (auth is
-	// enforced inside the streaming handler — same role gate as
-	// regular handlers).
+	// Streaming resolver + handler for /api/v0/events. The resolver picks every
+	// GET that matches the path; auth is enforced inside the streaming handler,
+	// under the same role gate as regular handlers.
 	auto streaming_resolver = [](const CHttpServer::Request &req) {
 		if (req.method != "GET" && req.method != "HEAD")
 			return false;
-		// Tolerate optional ?query / trailing slash. Both are handled
-		// the same way the dispatcher handles them, so a request that
-		// streams here is exactly the set that would route there.
+		// Tolerate optional ?query / trailing slash, the same way the dispatcher
+		// does, so what streams here is exactly the set that would route there.
 		const std::string &t = req.target;
 		const std::size_t q = t.find('?');
 		const std::string path = (q == std::string::npos) ? t : t.substr(0, q);
@@ -552,26 +497,23 @@ void CamuleapiApp::TextShell(const wxString & /*prompt*/)
 					 std::map<std::string, std::string> &response_headers) {
 		dispatcher->DispatchEvents(req, writer, http_status, content_type, response_headers);
 	};
-	// Preflight runs synchronously before the SSE worker thread is
-	// spawned: short-circuit unauth requests with the standard 401
-	// body so they can't tie up a streaming slot for the read-
-	// timeout window.
+	// Preflight runs synchronously before the SSE worker thread is spawned:
+	// short-circuit unauth requests with the standard 401 body so they cannot
+	// tie up a streaming slot for the read-timeout window.
 	auto streaming_preflight =
 		[dispatcher](const CHttpServer::Request &req) -> boost::optional<CHttpServer::Response> {
 		return dispatcher->PreflightEvents(req);
 	};
 
-	// Start the EC worker before the HTTP server accepts and before the
-	// refresher loop below — both are producers into it. The EC connection
-	// is already up (ConnectAndRun logged in before calling TextShell), so
-	// from here the worker thread is the sole user of the socket.
+	// Start the EC worker before the HTTP server accepts and before the refresher
+	// loop below -- both are producers into it. The EC connection is already up,
+	// so from here the worker thread is the sole user of the socket.
 	m_ec_service.Start([this](const CECPacket *r) { return SendRecvMsg_v2(r); });
 
 	m_http = std::unique_ptr<CHttpServer>(new CHttpServer());
 	// Before Start(), which is the whole contract: the cap is read by the
-	// io_context thread on every file response, and the only thing that
-	// makes an unsynchronised publish safe here is that the listener does
-	// not exist yet, so there is no reader to race.
+	// io_context thread on every file response, and what makes an unsynchronised
+	// publish safe here is that the listener does not exist yet.
 	CHttpServer::SetMaxConcurrentFileResponses(
 		static_cast<int>(m_apiConfig.StreamingCfg().max_concurrent_file_responses));
 	// Lets the transport stamp CORS on the replies it builds itself (408 /
@@ -597,42 +539,33 @@ void CamuleapiApp::TextShell(const wxString & /*prompt*/)
 	Show(CFormat(_("amuleapi: config dir %s\n")) % m_apiConfig.ConfigDir());
 	Show(CFormat(_("amuleapi: aMule version %s; api v0\n")) % wxString::FromAscii(VERSION));
 
-	// Refresher loop. One tick per second; HTTP threads read State
-	// concurrently. EC roundtrips run on this thread (CRemoteConnect's
-	// owner) but go through `SendRecvSerialized` so HTTP-thread
-	// mutations can also call it under m_ec_mtx.
+	// Refresher loop. One tick per second; HTTP threads read State concurrently.
+	// EC roundtrips run on this thread but go through `SendRecvSerialized` so
+	// HTTP-thread mutations can also call it under m_ec_mtx.
 	//
-	// `was_failed` tracks the success/failure edge so we wipe list
-	// caches on the rising edge (failed → succeeded). The server's
-	// CValueMap was reset across the disconnect; clearing first stops
-	// stale entries lingering forever in the INC-delta path.
+	// `was_failed` tracks the success/failure edge so list caches are wiped on
+	// the rising edge: the server's CValueMap was reset across the disconnect,
+	// and clearing first stops stale entries lingering in the INC-delta path.
 	bool was_failed = false;
-	// Target 1 s wall-clock between tick starts. Measure the tick,
-	// sleep the remainder; warn if a tick overruns the 3 s budget
-	// (typically signals an EC stall or runaway SendRecvSerialized).
-	// Fixed `tick + 4 × 250 ms sleep` drifts under EC-mutex contention.
+	// Target 1 s wall-clock between tick starts. Measure the tick, sleep the
+	// remainder; warn if one overruns the 3 s budget, which typically signals an
+	// EC stall. A fixed `tick + 4 x 250 ms sleep` drifts under mutex contention.
 	constexpr auto kTargetCycle = std::chrono::seconds(1);
 	constexpr auto kSliceMs = std::chrono::milliseconds(250);
 	constexpr auto kOverrunWarn = std::chrono::seconds(3);
-	// Fail-loud on a sustained EC blackout. RefresherTick returns
-	// false on any null packet from SendRecvSerialized — typically
-	// amuled crashed, was killed, or the EC socket dropped. Today
-	// the loop just retries forever; the daemon stays up serving
-	// 503 ec_unavailable from every endpoint. After ~30 s of
-	// failed ticks, log a sharp WARN so the operator's journal
-	// shows it; after ~5 min, exit cleanly so a process supervisor
-	// (systemd, launchd, docker restart=always) can bring the
-	// whole pair back up. Reset on the first success.
+	// Fail-loud on a sustained EC blackout. RefresherTick returns false on any
+	// null packet from SendRecvSerialized -- amuled crashed, was killed, or the
+	// socket dropped. After ~30 s of failed ticks, log a sharp WARN; after
+	// ~5 min, exit cleanly so a process supervisor brings the whole pair back
+	// up. Reset on the first success.
 	constexpr unsigned kEcFailWarnAfter = 30;
 	constexpr unsigned kEcFailExitAfter = 300;
 	unsigned ec_consecutive_failures = 0;
 	bool ec_warn_logged = false;
-	// Diffing stops only after a few consecutive ticks with nothing
-	// subscribed. A client that drops and comes straight back -- a page
-	// reload, a proxy hiccup -- must not suspend anything: resuming costs it
-	// the `resync` below, and re-seeding every collection is the most
-	// expensive thing this daemon can be asked to do. Ticks inside the grace
-	// keep publishing, so the returning client replays them instead.
+	// Diffing stops only after a few consecutive ticks with nothing subscribed. A
+	// client that drops and comes straight back -- a page reload, a proxy hiccup
+	// -- must not suspend anything: resuming costs it the `resync` below, and
+	// re-seeding every collection is the most expensive thing this daemon does.
 	constexpr unsigned kIdleTicksBeforeSuspend = 5;
 	unsigned idle_ticks = 0;
 	// Off the per-tick path: the call takes every arena's lock. Lands ~61 s
@@ -650,15 +583,11 @@ void CamuleapiApp::TextShell(const wxString & /*prompt*/)
 			was_failed = false;
 			ec_consecutive_failures = 0;
 			ec_warn_logged = false;
-			// Sole writer of m_last_seen. SSE-event publication runs
-			// here, NOT inside RefresherTick — so mutation handlers
-			// calling RefresherTick inline from the HTTP thread
-			// don't race with this loop's diff walk.
-			//
-			// Skipped once nothing has been subscribed for a while --
-			// see CEventBus's subscriber accounting. The first tick
-			// back re-baselines silently and then announces, instead
-			// of emitting one event per record.
+			// Sole writer of m_last_seen. SSE-event publication runs here, NOT inside
+			// RefresherTick, so mutation handlers calling RefresherTick inline from the
+			// HTTP thread do not race this loop's diff walk. Skipped once nothing has
+			// been subscribed for a while; the first tick back re-baselines silently
+			// and then announces, instead of emitting one event per record.
 			if (m_event_bus->SubscriberCount() == 0) {
 				if (idle_ticks < kIdleTicksBeforeSuspend) {
 					++idle_ticks;
@@ -714,19 +643,18 @@ void CamuleapiApp::TextShell(const wxString & /*prompt*/)
 				   "stalled SendRecvSerialized.\n";
 		}
 
-		// Deliberately not gated on "nobody subscribed": that gets it wrong
-		// both ways -- never firing while a browser tab holds the stream, and
-		// firing mid-load for a client that only polls REST.
+		// Deliberately not gated on "nobody subscribed": that gets it wrong both
+		// ways -- never while a browser tab holds the stream, and mid-load for a
+		// client that only polls REST.
 		if (trim_countdown > 0) {
 			--trim_countdown;
 		} else {
 			TrimMallocArenas();
 			trim_countdown = kTrimEveryTicks;
 		}
-		// Sleep the REMAINDER of the target cycle in small slices so
-		// shutdown latency stays bounded. A tick that already
-		// consumed >= the budget skips the sleep entirely so the
-		// next cycle starts immediately.
+		// Sleep the REMAINDER of the target cycle in small slices so shutdown
+		// latency stays bounded. A tick that already consumed the whole budget
+		// skips the sleep so the next cycle starts immediately.
 		auto deadline = cycle_start + kTargetCycle;
 		while (true) {
 			if (g_shutdownRequested.load(std::memory_order_acquire))
@@ -744,25 +672,22 @@ void CamuleapiApp::TextShell(const wxString & /*prompt*/)
 
 const CECPacket *CamuleapiApp::SendRecvSerialized(const CECPacket *request)
 {
-	// Route every roundtrip through the EC worker (sole socket owner,
-	// bounded FIFO queue). Block for the reply; the worker fulfils the
-	// future, or returns nullptr on backpressure (queue full while a
-	// roundtrip is stalled) or EC failure — both of which every caller
-	// already maps to 503. The wait is bounded by the EC read timeout.
+	// Route every roundtrip through the EC worker (sole socket owner, bounded
+	// FIFO queue). Block for the reply; the worker fulfils the future, or returns
+	// nullptr on backpressure or EC failure -- both of which every caller already
+	// maps to 503. The wait is bounded by the EC read timeout.
 	return m_ec_service.Submit(request).get();
 }
 
 bool CamuleapiApp::IsServerPartialUpdateActive()
 {
-	// Inherited from CaMuleExternalConnector. No mutex needed —
-	// it's a const bool snapshot taken at login.
+	// Inherited from CaMuleExternalConnector: a const bool snapshot taken at login.
 	return CaMuleExternalConnector::IsServerPartialUpdateActive();
 }
 
 bool CamuleapiApp::IsServerClientHistoryActive()
 {
-	// Same shape as IsServerPartialUpdateActive(): a const bool snapshot
-	// taken at login, so no mutex.
+	// Same shape as IsServerPartialUpdateActive(): a login snapshot, no mutex.
 	return CaMuleExternalConnector::IsServerClientHistoryActive();
 }
 
@@ -782,26 +707,21 @@ wxString CamuleapiApp::GetDaemonVersion()
 
 int CamuleapiApp::OnExit()
 {
-	// Tear down in reverse construction order: HTTP server first
-	// (no in-flight Dispatch can reach a dangling dispatcher), then
-	// dispatcher (references m_jwt), then m_jwt.
-	//
-	// Wake SSE drainers BEFORE Stop() returns so workers blocked on
-	// the 15 s heartbeat bail out and release their dispatcher refs.
-	// Without this, `m_dispatcher.reset()` below would race a
-	// drainer mid-write against a destroyed dispatcher → UAF in the
-	// signal-driven shutdown. m_http->Stop()'s join is then bounded.
+	// Tear down in reverse construction order: HTTP server first (no in-flight
+	// Dispatch can reach a dangling dispatcher), then dispatcher (references
+	// m_jwt), then m_jwt. Wake SSE drainers BEFORE Stop() returns so workers
+	// blocked on the 15 s heartbeat bail out and release their dispatcher refs --
+	// otherwise `m_dispatcher.reset()` below races a drainer mid-write.
 	if (m_event_bus)
 		m_event_bus->Shutdown();
 	if (m_http) {
 		m_http->Stop();
 		m_http.reset();
 	}
-	// HTTP is fully stopped, so no handler can submit anymore. Stop the EC
-	// worker (joins — bounded by the read timeout if a roundtrip is in
-	// flight) before the base tears down m_ECClient, which the worker uses.
-	// Any refresher-loop submit already returned: TextShell's loop exited
-	// before OnExit runs.
+	// HTTP is fully stopped, so no handler can submit any more. Stop the EC worker
+	// (joins, bounded by the read timeout if a roundtrip is in flight) before the
+	// base tears down m_ECClient, which the worker uses. Any refresher-loop
+	// submit already returned: TextShell's loop exited before OnExit runs.
 	m_ec_service.Stop();
 	m_dispatcher.reset();
 	m_jwt.reset();
@@ -818,9 +738,8 @@ int CamuleapiApp::OnExit()
 void CamuleapiApp::OnFatalException()
 {
 	// Point stderr straight at the log file so the base's backtrace is written
-	// synchronously to the file, even if the tee's forwarding thread is never
-	// scheduled again before the process dies. The console loses the backtrace
-	// on a crash, but the file -- the thing we ask users to send -- keeps it.
+	// synchronously, even if the tee's forwarding thread is never scheduled again
+	// before the process dies. The console loses it; the file keeps it.
 	if (m_logTee) {
 		m_logTee->RedirectStderrToFileForCrash();
 	}
@@ -829,10 +748,8 @@ void CamuleapiApp::OnFatalException()
 #endif
 
 // Stub functions needed by the linker because ExternalConnector.cpp
-// transitively references MuleNotify (via the EC tag handlers); the
-// daemon-side bodies live in the monolithic amule binary, and console
-// builds (amulecmd, amuleapi) supply no-ops since they never raise
-// GUI notifications.
+// transitively references MuleNotify via the EC tag handlers. The daemon-side
+// bodies live in the monolithic amule binary; console builds supply no-ops.
 namespace MuleNotify
 {
 class CMuleNotiferBase;

--- a/src/webapi/App.h
+++ b/src/webapi/App.h
@@ -80,20 +80,16 @@ public:
 	void OnFatalException() override;
 #endif
 
-	// Serialized EC roundtrip. Takes the EC lock, calls
-	// SendRecvMsg_v2, releases. Callable from any thread; the
-	// refresher and mutation handlers funnel every EC call
-	// through here so amule's wx-socket-driven CRemoteConnect stays
-	// single-reader by construction.
-	//
-	// Returns the response packet on success or nullptr if EC has
-	// disconnected. Caller owns the returned packet.
+	// Serialized EC roundtrip: takes the EC lock, calls SendRecvMsg_v2,
+	// releases. Callable from any thread; the refresher and mutation handlers
+	// funnel every EC call through here so amule's wx-socket-driven
+	// CRemoteConnect stays single-reader by construction. Returns nullptr if EC
+	// has disconnected; the caller owns the returned packet.
 	const CECPacket *SendRecvSerialized(const CECPacket *request);
 
-	// True when amuled advertised EC_TAG_CAN_PARTIAL_UPDATE during
-	// login. Refresher uses this to decide between "trust the
-	// EC_TAG_FILE_REMOVED markers" and the legacy "bulk-delete
-	// entries we didn't see this tick" path.
+	// True when amuled advertised EC_TAG_CAN_PARTIAL_UPDATE during login. The
+	// refresher uses this to decide between trusting the EC_TAG_FILE_REMOVED
+	// markers and the legacy bulk-delete path.
 	bool IsServerPartialUpdateActive();
 
 	// True when amuled advertised EC_TAG_CAN_CLIENT_HISTORY during login,
@@ -105,74 +101,62 @@ public:
 	bool IsServerChatActive();
 
 	// Version string of the connected amuled, captured from the
-	// EC_TAG_SERVER_VERSION tag of the AUTH_OK handshake. Empty string
-	// when EC is not (yet) connected, or when talking to a daemon old
-	// enough to omit the tag. Read under m_ec_mtx since m_ECClient is
-	// torn down / rebuilt across reconnects.
+	// EC_TAG_SERVER_VERSION tag of the AUTH_OK handshake. Empty when EC is not
+	// (yet) connected, or when the daemon is old enough to omit the tag. Read
+	// under m_ec_mtx, since m_ECClient is torn down / rebuilt across reconnects.
 	wxString GetDaemonVersion();
 
 	// Refresher needs the cache. Single CState instance per process.
 	webapi::CState &State() { return m_state; }
 
-	// Per-partfile RLE decoder state, persisted across ticks. amule's
-	// EC server sends GAP_STATUS / PART_STATUS as differentially-
-	// encoded blobs (each frame is XOR-deltaed against the previous
-	// decoded buffer) so the decoder MUST retain state across calls.
-	// Keyed by partfile ECID; entry erased when the file is removed.
+	// Per-partfile RLE decoder state, persisted across ticks. amule's EC server
+	// sends GAP_STATUS / PART_STATUS as differentially-encoded blobs (each frame
+	// XOR-deltaed against the previous decoded buffer), so the decoder MUST
+	// retain state across calls. Keyed by partfile ECID; erased on removal.
 	//
-	// **Concurrency:** mutated only under `CState::m_mu` held
-	// EXCLUSIVE — typically inside a `MutateDownloads` writer lambda.
-	// `m_ec_mtx` is incidentally held across the same call stack
-	// (`SendRecvSerialized` takes it) but the State write lock is
-	// the actual serializer. The method name encodes the
-	// precondition so a code-review reader notices it.
+	// Mutated only under `CState::m_mu` held EXCLUSIVE, typically inside a
+	// MutateDownloads writer lambda. `m_ec_mtx` is incidentally held across the
+	// same call stack, but the State write lock is the actual serializer -- the
+	// method name encodes the precondition so a reviewer notices it.
 	std::map<std::uint32_t, PartFileEncoderData> &PartfileRleStateRequireStateWriteLock()
 	{
 		return m_partfile_rle;
 	}
 
-	// SSE event bus. The refresher publishes events after
-	// each successful tick; streaming-handler threads drain from
-	// here. Exposed by raw reference — CEventBus is internally
-	// thread-safe. Lazy-constructed in OnInit so the operator-
-	// configured ring capacity from amuleapi.conf is honored.
+	// SSE event bus. The refresher publishes events after each successful tick;
+	// streaming-handler threads drain from here. Exposed by raw reference --
+	// CEventBus is internally thread-safe. Lazy-constructed in OnInit so the
+	// operator-configured ring capacity is honoured.
 	webapi::CEventBus &EventBus() { return *m_event_bus; }
 
-	// prior-tick snapshot used to compute event deltas.
-	// Owned by the App; mutated AFTER each successful refresher
-	// tick by `EmitDiffsAndUpdate`. Exposed so RefresherTick can
-	// reach it without re-routing through CState (which is read-
-	// only from the refresher's perspective post-tick).
+	// Prior-tick snapshot used to compute event deltas. Owned by the App, mutated
+	// AFTER each successful refresher tick by EmitDiffsAndUpdate. Exposed so
+	// RefresherTick can reach it without re-routing through CState.
 	webapi::LastSeenState &LastSeenForEvents() { return m_last_seen; }
 
 private:
 	void OnInitCmdLine(wxCmdLineParser &parser) override;
 	bool OnCmdLineParsed(wxCmdLineParser &parser) override;
 
-	// Loads amuleapi.conf + amuleapi-jwt-secret + amuleapi-passwords.
-	// Returns false on any unrecoverable error (missing required file,
-	// wrong mode bits on POSIX, malformed INI). The error has already
-	// been printed via Show() at the point of return.
+	// Loads amuleapi.conf + amuleapi-jwt-secret + amuleapi-passwords. Returns
+	// false on any unrecoverable error, having already printed it via Show().
 	bool LoadAmuleapiConfig();
 
-	// CLI-only flows. Both write the requested file under
-	// m_amuleapiConfigDir with mode 0600 and exit immediately —
-	// they never start the HTTP server or connect to EC.
+	// CLI-only flows. Both write the requested file under m_amuleapiConfigDir
+	// with mode 0600 and exit immediately -- no HTTP server, no EC connection.
 	int RunSetAdminPass();
 	int RunSetGuestPass();
 
-	// TextShell override drives the refresher loop and the HTTP
-	// server. Called by CaMuleExternalConnector::ConnectAndRun after
-	// the EC connection is established; we override it so the daemon
-	// never enters the interactive readline path that amulecmd uses.
+	// TextShell override drives the refresher loop and the HTTP server. Called by
+	// CaMuleExternalConnector::ConnectAndRun once EC is established; overridden
+	// so the daemon never enters the interactive readline path amulecmd uses.
 	void TextShell(const wxString &prompt) override;
 
 	CAmuleApiConfig m_apiConfig;
 	webapi::CState m_state;
-	// All EC roundtrips run on this service's single worker thread (bounded
-	// FIFO queue). Sole owner of the EC socket after login, so it also
-	// serialises m_ECClient — the reason m_ec_mtx below is now only needed
-	// for the immutable-after-login version accessor.
+	// All EC roundtrips run on this service's single worker thread (bounded FIFO
+	// queue). Sole owner of the EC socket after login, so it also serialises
+	// m_ECClient -- m_ec_mtx below is only for the version accessor now.
 	webapi::CEcService m_ec_service;
 	std::mutex m_ec_mtx; // serializes m_ECClient
 	std::unique_ptr<CJwt> m_jwt;
@@ -186,11 +170,9 @@ private:
 	webapi::LastSeenState m_last_seen;
 
 	// CLI capture: --bind / --http-port override the matching keys in
-	// amuleapi.conf when present. --set-*-pass and --foreground are
-	// runtime-mode toggles. The `m_cliHas*` flags discriminate between
-	// "operator passed nothing" and "operator passed the default
-	// value verbatim" — the base class' m_host / m_port / m_password
-	// fields have no such predicate of their own.
+	// amuleapi.conf when present. The `m_cliHas*` flags discriminate between
+	// "operator passed nothing" and "operator passed the default value
+	// verbatim" -- the base class fields have no such predicate of their own.
 	wxString m_cliBindAddress;
 	long m_cliHttpPort = 0;
 	wxString m_cliConfigDirOverride;
@@ -203,21 +185,18 @@ private:
 	// Did the operator pass --host / --port / --password explicitly?
 	bool m_cliHasEcHost = false;
 	bool m_cliHasEcPort = false;
-	/// amuleapi owns amuleapi.conf and must not also read remote.conf: two
-	/// files describing the same EC connection, with load order deciding the
-	/// winner, is a trap. Turning this off drops --config-file,
-	/// --write-config and --create-config-from too, since all three only
-	/// exist to manage that file.
+	/// amuleapi owns amuleapi.conf and must not also read remote.conf: two files
+	/// describing the same EC connection, with load order deciding the winner, is
+	/// a trap. Turning this off drops --config-file, --write-config and
+	/// --create-config-from too, since all three only exist to manage that file.
 	bool UsesConnectorConfigFile() const override { return false; }
-	// No -P/--password: it would put the EC secret in argv, where ps
-	// exposes it to every local user. amuleapi gets the credential from
-	// the token the core writes when it spawns us, or from [EC]/Password
-	// in amuleapi.conf.
+	// No -P/--password: it would put the EC secret in argv, where ps exposes it
+	// to every local user. amuleapi gets the credential from the token the core
+	// writes when it spawns us, or from [EC]/Password in amuleapi.conf.
 	bool UsesEcPasswordOption() const override { return false; }
 
-	// amuleapi keeps its settings in amuleapi.conf and never reads or
-	// writes remote.conf, so amuleapi.conf is what marks a portable
-	// amuleapi. amulecmd / amuleweb keep the remote.conf default.
+	// amuleapi keeps its settings in amuleapi.conf and never reads or writes
+	// remote.conf, so amuleapi.conf is what marks a portable amuleapi.
 	wxString PortableProbeFile() const override { return "amuleapi.conf"; }
 
 	bool m_cliHasEcEncryption = false;

--- a/src/webapi/Auth.cpp
+++ b/src/webapi/Auth.cpp
@@ -77,14 +77,10 @@ std::size_t CRevocationSet::Size() const
 
 void CRevocationSet::GcExpired() const
 {
-	// O(n) sweep over the revoked map, fired from every Revoke() and
-	// every Contains() check. Fine at amuleapi's expected scale (a
-	// single operator, a handful of admin/guest sessions per day);
-	// the map stays in the low hundreds even under aggressive
-	// re-login. If multi-tenant deployments ever raise the revoked
-	// population into the thousands, swap this for a min-heap keyed
-	// by `exp` so the GC pops a constant prefix per call instead of
-	// walking the whole structure.
+	// O(n) sweep over the revoked map, fired from every Revoke() and every
+	// Contains() check. Fine at amuleapi's expected scale -- a single operator,
+	// a handful of sessions per day -- so the map stays in the low hundreds
+	// even under aggressive re-login.
 	const std::time_t now = std::time(nullptr);
 	for (auto it = m_revoked.begin(); it != m_revoked.end();) {
 		if (it->second <= now) {
@@ -99,9 +95,8 @@ void CRevocationSet::GcExpired() const
 
 std::string ExtractBearerToken(const std::string &authorization_header)
 {
-	// `Authorization: Bearer <jwt>` per RFC 6750 §2.1. Scheme name is
-	// case-insensitive; the token itself is the bare base64url
-	// triplet our own CJwt emits.
+	// `Authorization: Bearer <jwt>` per RFC 6750 2.1. The scheme name is
+	// case-insensitive; the token is the bare base64url triplet CJwt emits.
 	const char *prefix = "Bearer ";
 	const size_t plen = std::strlen(prefix);
 	if (authorization_header.size() <= plen)
@@ -123,9 +118,8 @@ std::string ExtractBearerToken(const std::string &authorization_header)
 
 std::string ExtractCookieValue(const std::string &cookie_header, const std::string &cookie_name)
 {
-	// Delegate to libwebcommon's pointer-arithmetic helper so the
-	// parsing rules (case-insensitive name match, `;` separators,
-	// OWS trimming) stay in one place.
+	// Delegate to libwebcommon's helper so the parsing rules (case-insensitive
+	// name match, `;` separators, OWS trimming) stay in one place.
 	const auto v =
 		webcommon::FindCookieValue(cookie_header.c_str(), cookie_header.size(), cookie_name.c_str());
 	if (!v.first || v.second == 0)

--- a/src/webapi/Auth.h
+++ b/src/webapi/Auth.h
@@ -50,19 +50,14 @@
 namespace webapi
 {
 
-// Server-side bearer-token revocation list. JWTs are stateless by
-// design; for /auth/logout to actually invalidate a token, the server
-// has to remember "this jti is dead until the JWT's exp".
+// Server-side bearer-token revocation list. JWTs are stateless by design; for
+// /auth/logout to actually invalidate a token, the server has to remember
+// "this jti is dead until the JWT's exp".
 //
-// Memory cost: one entry per logged-out-but-still-unexpired token.
-// `jti` is 22 base64url chars (~24 bytes once the std::string SSO
-// boundary kicks in) + the exp timestamp + map overhead — call it
-// ~64 bytes per revoked token. Bounded by max-concurrent-users ×
-// 24 h (the JWT lifetime).
-//
-// GC: lazy on Revoke() — sweeps entries whose exp has already
-// passed. Cheap (~O(log n) lookup per sweep) and amortizes the work
-// across calls instead of needing a periodic timer.
+// One entry per logged-out-but-still-unexpired token, roughly 64 bytes each,
+// bounded by max-concurrent-users x the 24 h JWT lifetime. GC is lazy on
+// Revoke(), sweeping entries whose exp has already passed, which amortizes the
+// work across calls instead of needing a periodic timer.
 class CRevocationSet
 {
 public:
@@ -80,16 +75,14 @@ private:
 	mutable std::map<std::string, std::time_t> m_revoked;
 };
 
-// The per-IP failure rate limiter now lives in mulecommon, shared with the
-// External Connection password exchange, which needs the same protection but
-// cannot link the webapi library. Re-exported here so existing
-// `webapi::CRateLimiter` uses keep resolving.
+// The per-IP failure rate limiter lives in mulecommon, shared with the External
+// Connection password exchange, which needs the same protection but cannot link
+// the webapi library. Re-exported here so `webapi::CRateLimiter` still resolves.
 using ::CRateLimiter;
 
-// HTTP `Authorization: Bearer <jwt>` extractor. Returns the empty
-// string if the header is absent, doesn't start with `Bearer `, or
-// has no value past the space. Case-insensitive scheme compare
-// per RFC 6750 §2.1.
+// HTTP `Authorization: Bearer <jwt>` extractor. Returns the empty string if the
+// header is absent, does not start with `Bearer `, or has no value past the
+// space. Case-insensitive scheme compare per RFC 6750 2.1.
 std::string ExtractBearerToken(const std::string &authorization_header);
 
 // Extracts `<cookie_name>=<value>` from a Cookie header. Returns the

--- a/src/webapi/EcService.h
+++ b/src/webapi/EcService.h
@@ -65,9 +65,8 @@ namespace webapi
 class CEcService
 {
 public:
-	// Runs one EC roundtrip (send request, block for reply); returns the
-	// reply packet (caller-owned) or nullptr on EC failure. Bound to
-	// CaMuleExternalConnector::SendRecvMsg_v2.
+	// Runs one EC roundtrip (send request, block for reply); returns the reply
+	// packet (caller-owned) or nullptr on EC failure.
 	using Roundtrip = std::function<const CECPacket *(const CECPacket *)>;
 
 	explicit CEcService(std::size_t max_depth = 8)
@@ -107,9 +106,9 @@ public:
 		return fut;
 	}
 
-	// Stop the worker. Idempotent. Fulfils any queued (not-yet-started)
-	// jobs with nullptr so their callers unblock, then joins — bounded by
-	// the EC read timeout if a roundtrip is in flight.
+	// Stop the worker. Idempotent. Fulfils any queued (not-yet-started) jobs with
+	// nullptr so their callers unblock, then joins -- bounded by the EC read
+	// timeout if a roundtrip is in flight.
 	void Stop()
 	{
 		{

--- a/src/webapi/EventBus.cpp
+++ b/src/webapi/EventBus.cpp
@@ -51,23 +51,19 @@ void CEventBus::Publish(const std::string &name, const std::string &data)
 	ev.data = data;
 	{
 		std::lock_guard<std::mutex> g(m_mu);
-		// ID assignment INSIDE the lock. With fetch_add outside,
-		// two concurrent publishers can swap their lock-order vs
-		// their id-order: thread A gets id=N, thread B gets id=N+1,
-		// then thread B grabs the lock first and pushes id=N+1
-		// before thread A pushes id=N. The drainer then iterates
-		// the deque (which is publish order, NOT id order) and
-		// reports `id=N+1, id=N` — failing the strict-monotonicity
-		// invariant every subscriber depends on.
-		// Single-lock-section publish keeps fetch+push atomic.
+		// ID assignment INSIDE the lock. With fetch_add outside, two concurrent
+		// publishers can swap their lock-order against their id-order: A gets
+		// id=N and B id=N+1, then B grabs the lock first and pushes N+1 before A
+		// pushes N. The drainer iterates the deque, which is publish order and
+		// NOT id order, and reports `id=N+1, id=N` -- failing the strict
+		// monotonicity every subscriber depends on.
 		ev.id = m_next_id.fetch_add(1, std::memory_order_relaxed);
 		if (m_ring.size() >= m_capacity)
 			m_ring.pop_front();
 		m_ring.push_back(std::move(ev));
 	}
-	// notify_all so every blocked drainer wakes and races to its
-	// own copy-out. The mutex critical section is short (just walks
-	// the deque) so contention is negligible.
+	// notify_all so every blocked drainer wakes and races to its own copy-out.
+	// The critical section is short, so contention is negligible.
 	m_cv.notify_all();
 }
 
@@ -77,13 +73,10 @@ void CEventBus::PublishBatch(const std::vector<std::pair<std::string, std::strin
 		return;
 	{
 		std::lock_guard<std::mutex> g(m_mu);
-		// Same id-monotonicity invariant as Publish: assign + push
-		// inside the lock. Doing the whole batch under one lock
-		// also collapses N notify_all wake-ups into one — the cold
-		// start tick on a 5K-download library used to fire 5K
-		// individual notify_all cycles inside the refresher loop
-		// (each going through every drainer's cv mutex), which
-		// dominated the tick's wall-clock.
+		// Same id-monotonicity invariant as Publish: assign + push inside the lock.
+		// Doing the whole batch under one lock also collapses N notify_all
+		// wake-ups into one -- the cold-start tick on a 5K-download library used
+		// to fire 5K of them inside the refresher loop, dominating the tick.
 		for (const auto &kv : events) {
 			Event ev;
 			ev.name = kv.first;
@@ -113,10 +106,8 @@ std::uint64_t CEventBus::Drain(
 		       (!m_ring.empty() && m_ring.back().id > since_id);
 	};
 	if (!has_newer()) {
-		// Wait up to `timeout` for someone to publish OR for the
-		// shutdown latch to fire. wait_for returns no_timeout on a
-		// notify, timeout otherwise. We re-check the predicate
-		// either way.
+		// Wait up to `timeout` for someone to publish OR for the shutdown latch to
+		// fire. The predicate is re-checked either way.
 		m_cv.wait_for(lk, timeout, has_newer);
 	}
 
@@ -159,10 +150,9 @@ void CEventBus::ResetForTest()
 
 void CEventBus::Shutdown()
 {
-	// Latch the shutdown flag and broadcast. Drain callers wake on
-	// the cv either way (even with no events pending) and exit the
-	// predicate. notify_all under the lock so a drainer that's
-	// about to wait_for can't miss the wake.
+	// Latch the shutdown flag and broadcast. Drain callers wake on the cv either
+	// way and exit the predicate. notify_all under the lock, so a drainer about
+	// to wait_for cannot miss the wake.
 	{
 		std::lock_guard<std::mutex> g(m_mu);
 		m_shutdown.store(true, std::memory_order_release);

--- a/src/webapi/EventBus.h
+++ b/src/webapi/EventBus.h
@@ -54,31 +54,24 @@ struct Event
 	std::string data; // JSON payload (typed per `name`)
 };
 
-// In-memory SSE event bus. One instance per amuleapi process; the
-// refresher publishes events as cache deltas surface and SSE
-// sessions drain them.
+// In-memory SSE event bus. One instance per amuleapi process; the refresher
+// publishes events as cache deltas surface and SSE sessions drain them.
 //
-// **Concurrency:** all public methods are safe for any thread. The
-// refresher publishes from the wxApp thread (during a tick);
-// streaming-handler threads drain. Internal lock is a regular
-// std::mutex — drain operations only hold it long enough to
-// copy out the events they want, never across a wire write.
+// All public methods are safe for any thread. The refresher publishes from the
+// wxApp thread during a tick; streaming-handler threads drain. The internal
+// lock is a plain std::mutex -- drains hold it only long enough to copy the
+// events out, never across a wire write.
 //
-// **Capacity:** runtime-configured ring (see `[Streaming]/
-// EventBusRingCapacity` in amuleapi.conf; default 16 384). When the
-// buffer fills, the oldest event is dropped and clients whose
-// Last-Event-ID fell off the ring get a typed `resync` instead of a
-// partial replay. The default is sized for a cold-start tick on a
-// heavy node (5K downloads + 5K shared can publish ~10K `*_added`
-// in a single tick before any subscriber has had a chance to
-// drain); worst-case memory ≈ capacity × ~1 KB JSON payload, so
-// 16 384 ≈ 16 MB.
+// Runtime-configured ring (`[Streaming]/EventBusRingCapacity`, default 16 384).
+// When the buffer fills the oldest event is dropped, and a client whose
+// Last-Event-ID fell off the ring gets a typed `resync` instead of a partial
+// replay. The default is sized for a cold-start tick on a heavy node; worst-case
+// memory is roughly capacity x ~1 KB of JSON payload.
 class CEventBus
 {
 public:
-	// Compile-time floor + default. Capacity is settable at
-	// construction; values below kMinCapacity are clamped up to the
-	// floor. Floor exists so an operator can't accidentally
+	// Compile-time floor + default. Capacity is settable at construction and
+	// values below kMinCapacity are clamped up, so an operator cannot
 	// effectively disable SSE replay by setting capacity=1.
 	static constexpr std::size_t kDefaultCapacity = 16384;
 	static constexpr std::size_t kMinCapacity = 16;
@@ -97,14 +90,11 @@ public:
 	// is full.
 	void Publish(const std::string &name, const std::string &data);
 
-	// Batch-publish. One lock acquisition + one notify_all for the
-	// whole batch, vs N of each from per-event Publish loops. Used
-	// by the cold-start tick where a 5K-download library emits one
-	// `_added` per item — the per-item Publish was holding the
-	// refresher loop for tens of milliseconds (every notify_all
-	// goes through cv->mutex wake/sleep cycles on every drainer).
-	// Each (name, data) pair is treated identically to a Publish
-	// call: monotonic id assignment, evict-oldest if the ring fills.
+	// Batch-publish: one lock acquisition and one notify_all for the whole
+	// batch, against N of each from a per-event Publish loop. Used by the
+	// cold-start tick where a 5K-download library emits one `_added` per item,
+	// which was holding the refresher loop for tens of milliseconds. Each pair
+	// is treated exactly as a Publish call.
 	void PublishBatch(const std::vector<std::pair<std::string, std::string>> &events);
 
 	// Drain every event with `id > since_id` into `out`. Returns
@@ -114,28 +104,23 @@ public:
 	std::uint64_t Drain(
 		std::uint64_t since_id, std::chrono::milliseconds timeout, std::vector<Event> &out);
 
-	// The id of the bus's oldest currently-stored event, or 0 if the
-	// bus is empty. Used by the Last-Event-ID reconnect path: if
-	// `Last-Event-ID < OldestId()` the client missed events that
-	// have already been evicted and should be sent `resync` instead
-	// of an empty replay.
+	// The id of the bus's oldest currently-stored event, or 0 if empty. Used by
+	// the Last-Event-ID reconnect path: below this the client missed events that
+	// have already been evicted and should be sent `resync`.
 	std::uint64_t OldestId() const;
 
-	// The id of the most recently published event, or 0 if nothing
-	// has been published yet. The reconnect path uses this to
-	// compute "did I miss anything".
+	// The id of the most recently published event, or 0 if nothing has been
+	// published. The reconnect path uses this to compute "did I miss anything".
 	std::uint64_t NewestId() const;
 
 	// Reset the bus. Wakes any blocked drainers. Used by tests; not
 	// called from production code.
 	void ResetForTest();
 
-	// Atomically wake every blocked Drain caller and mark the bus as
-	// "shutting down". Subsequent Drain calls return immediately
-	// (with an empty out vector). Used by the shutdown path:
-	// detached SSE worker threads sit inside Drain() blocked on the
-	// 15 s heartbeat; without this they'd hold references to the
-	// dispatcher across its destruction → UAF. Latches once; idempotent.
+	// Atomically wake every blocked Drain caller and mark the bus as shutting
+	// down; later Drain calls return immediately. Detached SSE worker threads sit
+	// inside Drain() blocked on the heartbeat, and without this they would hold
+	// references to the dispatcher across its destruction. Latches once.
 	void Shutdown();
 
 	// True if Shutdown() has been called. SSE worker loops poll this
@@ -144,18 +129,17 @@ public:
 
 	// --- Subscriber accounting ---------------------------------------
 	//
-	// A tick's diff means snapshotting every collection and comparing it with
-	// the previous tick, which on a large library is most of the refresher's
-	// work. Once nothing has been subscribed for a few ticks there is nobody to
-	// send the result to, so the refresher skips it and records that
-	// (MarkSuspended). Nothing is lost -- subscribers read the same state over
-	// REST -- but no collection change is represented on the bus for that
-	// period, and a client reconnecting with a Last-Event-ID cannot tell: its
-	// cursor can even still be in range, since the chat publisher runs outside
-	// this gate and keeps ids moving. The tick that resumes publishes a
-	// `resync` for that, after re-baselining, so a client re-GETs against a
-	// baseline that is already current -- emitting it at connect instead would
-	// leave a tick's worth of changes in neither the GET nor an event.
+	// A tick's diff means snapshotting every collection and comparing it with the
+	// previous tick, which on a large library is most of the refresher's work.
+	// Once nothing has been subscribed for a few ticks there is nobody to send
+	// the result to, so the refresher skips it and records that (MarkSuspended).
+	//
+	// Nothing is lost -- subscribers read the same state over REST -- but no
+	// collection change is represented on the bus for that period, and a client
+	// reconnecting with a Last-Event-ID cannot tell: its cursor can even still be
+	// in range, since the chat publisher runs outside this gate. The tick that
+	// resumes publishes a `resync` AFTER re-baselining, so the client re-GETs
+	// against a baseline that is already current.
 
 	// RAII registration for one SSE session.
 	class Subscription

--- a/src/webapi/EventDiff.cpp
+++ b/src/webapi/EventDiff.cpp
@@ -97,43 +97,33 @@ std::string EscJson(const std::string &s)
 	return out;
 }
 
-// Each ToJson emits the SAME shape as the corresponding REST list-item
-// writer in Api.cpp (WriteDownloadObject / WriteSharedObject /
-// WriteServerObject / WriteClientObject / HandleStatus). The contract
-// is "an SSE _added/_updated event carries the full resource — clients
-// don't need to re-GET to see the moved counters". The matching Equal
-// functions below compare every field included here so any movement
-// fires `_updated`. If REST or SSE drifts in the future, the doc-
-// alignment check in run-all.sh phase11 should catch it.
+// Each ToJson emits the SAME shape as the corresponding REST list-item writer
+// in Api.cpp. The contract is "an SSE _added/_updated event carries the full
+// resource -- clients do not need to re-GET to see the moved counters". The
+// matching Equal functions below compare every field included here, so any
+// movement fires `_updated`.
 
-// `null` when the string was never populated, matching WriteStringOrNull on
-// the REST side. Takes the same (known, value) shape as JsonNumOrNull below so
-// the three read alike at the call site; an empty string is the usual reason a
-// value is unknown here, but the caller decides, because some fields are keyed
-// on a sibling (server_name on server_ip, ip/port on the address).
+// `null` when the string was never populated, matching WriteStringOrNull on the
+// REST side. Takes the same (known, value) shape as JsonNumOrNull below; the
+// caller decides what "known" means, since some fields key on a sibling.
 std::string JsonStrOrNull(bool known, const std::string &v)
 {
 	return known ? "\"" + EscJson(v) + "\"" : std::string("null");
 }
 
 // `null` when the value was never measured, matching WriteIntOrNull /
-// WriteBoolOrNull on the REST side. The two bodies are promised to be
-// byte-identical, so the disconnected fields have to print `null` here too --
-// and the comparators below have to treat null<->value as a change, or the
-// event stops firing on the very edge that flips them.
+// WriteBoolOrNull on the REST side. The comparators below have to treat
+// null<->value as a change, or the event stops firing on the edge that flips it.
 std::string JsonNumOrNull(bool known, std::uint64_t v)
 {
 	return known ? std::to_string(v) : std::string("null");
 }
 
 // The protocol extensions as the API's token array, from the same table the
-// daemon and the desktop GUI read (src/PeerCapabilities.h). Rendered here
-// rather than stored on the row so there is one definition of the mapping:
-// a second copy in this file would be free to drift from the one bit that
-// actually arrived on the wire.
+// daemon and the desktop GUI read (src/PeerCapabilities.h). Rendered here rather
+// than stored on the row so there is one definition of the mapping.
 //
-// Empty array, not null: the peer claimed nothing, which is a known answer
-// rather than a missing one, and it is what nearly every peer produces.
+// Empty array, not null: the peer claimed nothing, which is a known answer.
 std::string JsonProtocolExtensions(std::uint32_t bits)
 {
 	CPeerCapabilities caps;
@@ -190,17 +180,13 @@ std::string ToJsonDownloadEvent(const FileSnapshot &f)
 	return o.str();
 }
 
-// comments_updated event payload — the GET /downloads/{hash}/comments body
-// plus `hash`. Covers both retrieved Kad notes and comments reported by
-// connected ed2k sources (they share source_comments).
+// comments_updated event payload -- the GET /downloads/{hash}/comments body plus
+// `hash`. Covers both retrieved Kad notes and comments reported by connected
+// ed2k sources (they share source_comments).
 //
-// A strict superset of the endpoint, deliberately: the event needs `hash`
-// because nothing else in the frame identifies the file, and it needs
-// `kad_comment_lookup_running` because that flag is exactly what a client
-// wants while a POST /downloads/{hash}/comments lookup is in flight. It used
-// to carry the first and not the second, so a client that followed the docs
-// and fed the event into the view it built from the endpoint silently lost
-// the in-flight indicator.
+// A strict superset of the endpoint, deliberately: nothing else in the frame
+// identifies the file, and `kad_comment_lookup_running` is exactly what a
+// client wants while a POST lookup is in flight.
 std::string ToJsonCommentsEvent(const FileSnapshot &f)
 {
 	std::ostringstream o;
@@ -233,9 +219,8 @@ std::string ToJsonSharedEvent(const FileSnapshot &f)
 	  << ",\"priority_auto\":"
 	  << (f.shared.priority_auto ? "true" : "false")
 	  // Nested to match the REST row: a stated exception to R11, so that
-	  // `sources.complete` is one access path across every endpoint that has
-	  // the concept. The list shape carries `complete` only; the range is
-	  // detail-only and does not ride the event.
+	  // `sources.complete` is one access path across every endpoint that has the
+	  // concept. The range is detail-only and does not ride the event.
 	  << ",\"sources\":{\"complete\":" << f.shared.complete_sources
 	  << "}"
 	  // Flattened (R11), same as the REST row this promises key parity with.
@@ -249,12 +234,8 @@ std::string ToJsonSharedEvent(const FileSnapshot &f)
 	  << ",\"uploading_client_count\":"
 	  << f.shared.uploading_client_count
 	  // Unix seconds, null when unknown -- never uploaded, or a known.met entry
-	  // that predates the field. 0 reads as 1970 rather than "no idea", and the
-	  // REST row this event promises key parity with has always sent null here
-	  // (WriteIntOrNull in the shared list writer). A subscriber that hydrates
-	  // from REST and live-updates from this saw its null flip to 0 on the
-	  // first tick the file changed. Never-uploaded is the common case, so this
-	  // was the routine reading, not an edge one.
+	  // that predates the field. 0 reads as 1970 rather than "no idea", and a
+	  // subscriber that hydrates from REST would see its null flip to 0.
 	  << ",\"last_upload_at\":";
 	if (f.shared.last_upload != 0)
 		o << f.shared.last_upload;
@@ -267,12 +248,9 @@ std::string ToJsonSharedEvent(const FileSnapshot &f)
 		o << "null";
 	o << ",\"hashed_part_count\":" << SharedHashingProgress(f);
 	// Media metadata rides the event because a metadata re-extraction is
-	// otherwise invisible to a subscriber: the refresh endpoints answer 202
-	// with no result, so this is how a client learns a probe landed. Six
-	// small scalars, unlike the per-part arrays the list endpoints omit.
-	//
-	// null rather than absent when the file has none, matching the REST row
-	// this event promises key parity with -- a subscriber diffing the two
+	// otherwise invisible to a subscriber: the refresh endpoints answer 202 with
+	// no result, so this is how a client learns a probe landed. null rather than
+	// absent when the file has none, since a subscriber diffing REST against SSE
 	// must not find a key on one side only.
 	o << ",\"media\":";
 	if (f.has_media) {
@@ -321,11 +299,9 @@ std::string ToJson(const FriendSnapshot &f)
 	  << "\"ecid\":" << f.ecid << ",\"name\":\"" << EscJson(f.name) << "\""
 	  << ",\"user_hash\":\"" << EscJson(f.user_hash)
 	  << "\""
-	  // null, not "" / 0, when the daemon has not reported an address: the
-	  // REST row this event promises key parity with emits null for both
-	  // (WriteFriendObject), and a subscriber hydrating from GET /friends
-	  // would otherwise see ip flip null -> "" on the first tick that
-	  // touches the row, with no real change behind it.
+	  // null, not "" / 0, when the daemon has not reported an address: a
+	  // subscriber hydrating from GET /friends would otherwise see ip flip
+	  // null -> "" on the first tick that touches the row, with no real change.
 	  << ",\"ip\":" << (f.ip.empty() ? std::string("null") : "\"" + EscJson(f.ip) + "\"")
 	  << ",\"port\":" << (f.ip.empty() ? std::string("null") : std::to_string(f.port))
 	  << ",\"client_ecid\":" << (f.client_ecid ? std::to_string(f.client_ecid) : std::string("null"))
@@ -345,17 +321,15 @@ std::string ToJson(const ClientSnapshot &c)
 	  // has_addr, which nulls ip/port/kad_port together.
 	  << ",\"ip\":" << JsonStrOrNull(!c.ip.empty(), c.ip)
 	  << ",\"country_code\":"
-	  // null, not "", when the lookup has not resolved -- the REST row this
-	  // event promises key parity with emits null here.
+	  // null, not "", when the lookup has not resolved.
 	  << JsonStrOrNull(!c.country_code.empty(), c.country_code)
 	  << ",\"port\":" << (c.ip.empty() ? std::string("null") : std::to_string(c.port))
 	  << ",\"software\":" << JsonStrOrNull(!c.software.empty(), c.software)
 	  << ",\"software_version\":" << JsonStrOrNull(!c.software_version.empty(), c.software_version)
 	  << ",\"reported_os\":"
 	  << JsonStrOrNull(!c.reported_os.empty(), c.reported_os)
-	  // The three *_state values are enum labels, not free text: the daemon
-	  // always answers, and an answer it does not recognise is the "unknown"
-	  // member. Empty is unreachable, so there is nothing to null.
+	  // The three *_state values are enum labels, not free text: the daemon always
+	  // answers, and an unrecognised answer is the "unknown" member.
 	  << ",\"upload_state\":\"" << EscJson(c.upload_state) << "\""
 	  << ",\"download_state\":\"" << EscJson(c.download_state) << "\""
 	  << ",\"ident_state\":\"" << EscJson(c.ident_state) << "\""
@@ -364,8 +338,7 @@ std::string ToJson(const ClientSnapshot &c)
 	  << ",\"upload_file_hash\":" << JsonStrOrNull(!c.upload_file_hash.empty(), c.upload_file_hash)
 	  << ",\"download_file_hash\":"
 	  << JsonStrOrNull(!c.download_file_hash.empty(), c.download_file_hash)
-	  // Flattened out of the old `xfer` wrapper (R11), same as the REST row
-	  // this payload promises key parity with.
+	  // Flattened out of the old `xfer` wrapper (R11).
 	  << ",\"uploaded_bytes_session\":" << c.uploaded_bytes_session
 	  << ",\"downloaded_bytes_session\":" << c.downloaded_bytes_session
 	  << ",\"uploaded_bytes_total\":" << c.uploaded_bytes_total
@@ -385,13 +358,11 @@ std::string ToJson(const ClientSnapshot &c)
 	  << (c.has_parts_offered_count ? std::to_string(c.parts_offered_count) : std::string("null"))
 	  << ",\"client_mod_name\":" << JsonStrOrNull(!c.client_mod_name.empty(), c.client_mod_name)
 	  << ",\"shared_files_browsable\":" << (c.view_shared_disabled ? "false" : "true");
-	// null, not omitted, matching the REST row: the field only means
-	// something for a peer we are downloading from, and -1 is the
-	// in-process sentinel that must never reach the wire. Formatted
-	// through the shared writer rather than `<<`: the stream default is 6
-	// significant digits (so SSE read 33.3333 where REST read
-	// 33.333333333333336) and it honours LC_NUMERIC, which on an it/de/fr
-	// locale would emit a comma and break the frame's JSON outright.
+	// null, not omitted: the field only means something for a peer we are
+	// downloading from, and -1 is the in-process sentinel that must never reach
+	// the wire. Formatted through the shared writer rather than `<<`: the stream
+	// default is 6 significant digits and it honours LC_NUMERIC, which on an
+	// it/de/fr locale would emit a comma and break the frame's JSON outright.
 	o << ",\"part_progress_percent\":"
 	  << (c.part_progress_percent >= 0.0 ? JsonDoubleToString(c.part_progress_percent)
 					     : std::string("null"));
@@ -399,24 +370,20 @@ std::string ToJson(const ClientSnapshot &c)
 	return o.str();
 }
 
-// Status event payload mirrors the REST /status envelope nesting
-// (ed2k.*, kad.* including the kad.network rollup, speeds.*, queue.*,
-// plus the top-level ec_connected flag). Takes a triple because the
-// REST nesting groups data from StatusSnapshot AND KadSnapshot AND
-// the dashboard's ec_connected bit — all three are read in one
-// shared_lock by state.Dashboard() at the call site.
-// A free-space figure renders as a JSON number, or as null when the daemon
-// has none (-1). Kept beside the REST handler's identical rule so the SSE
-// payload and the REST body cannot drift apart.
+// A free-space figure renders as a JSON number, or as null when the daemon has
+// none (-1). Kept beside the REST handler's identical rule so the SSE payload
+// and the REST body cannot drift apart.
 std::string JsonFreeSpace(std::int64_t v)
 {
 	return v < 0 ? std::string("null") : std::to_string(v);
 }
 
 // Mirrors HandleStatus key for key -- EVENTS.md promises this payload is
-// identical to the REST /status envelope, and 22-sse-diff-emission.sh asserts
-// it. Both connected_since_at values are 0 while not connected, same rule as
-// there: gate on state rather than trusting a 0 timestamp.
+// identical to the REST /status envelope, and 22-sse-diff-emission.sh asserts it.
+// Takes a triple because that nesting groups data from StatusSnapshot AND
+// KadSnapshot AND the dashboard's ec_connected bit, all three read in one
+// shared_lock by state.Dashboard() at the call site. Both connected_since_at
+// values are 0 while not connected: gate on state, not on the timestamp.
 std::string ToJsonStatusEvent(const StatusSnapshot &s, const KadSnapshot &k, bool ec_connected)
 {
 	std::ostringstream o;
@@ -425,8 +392,7 @@ std::string ToJsonStatusEvent(const StatusSnapshot &s, const KadSnapshot &k, boo
 	  << "\"state\":\"" << EscJson(s.ed2k_state) << "\""
 	  << ",\"high_id\":" << (s.ed2k_high_id ? "true" : "false") << ",\"user_id\":"
 	  << s.ed2k_user_id
-	  // null, not "", for the addresses: the REST row this event promises key
-	  // parity with nulls them, and server_port nulls with its address.
+	  // null, not "", for the addresses; server_port nulls with its address.
 	  << ",\"public_ip\":"
 	  << (s.ed2k_public_ip.empty() ? std::string("null") : "\"" + EscJson(s.ed2k_public_ip) + "\"")
 	  << ",\"connected_since_at\":" << s.ed2k_connected_since
@@ -460,23 +426,15 @@ std::string ToJsonStatusEvent(const StatusSnapshot &s, const KadSnapshot &k, boo
 	return o.str();
 }
 
-// Coarse equality — every field. For we treat any change as
-// "_updated" (emit the full new snapshot). v0.2 could introduce
-// per-field deltas if a real consumer reports wanting them.
-// Equal compares every field that ToJson emits. Any movement fires
-// `_updated`. Field sets here are the same as the matching ToJson
-// above; if one drifts from the other clients will see stale
-// values until the next ROW-level field changes.
-// download_* / shared_* event diffs compare the FIELDS THAT THE
-// CORRESPONDING ToJson emits, not the full FileSnapshot. The download
-// side ignores shared.* and is_shared, the shared side ignores
-// download.* and is_downloading — a tick that flips one role doesn't
-// fire the other role's _updated.
+// Equal compares every field the matching ToJson emits, and any movement fires
+// `_updated` with the full new snapshot. If one set drifts from the other,
+// clients see stale values until the next field that IS compared changes.
 //
-// ecid is in both JSON shapes; if amuled gets restarted while
-// amuleapi keeps running, the same hash will surface with a fresh
-// ECID, and clients keyed on ECID need the _updated to invalidate
-// their cached id.
+// The download side ignores shared.* and is_shared, the shared side ignores
+// download.* and is_downloading, so a tick that flips one role does not fire
+// the other role's _updated. ecid is in both shapes: an amuled restart under a
+// running amuleapi resurfaces the same hash with a fresh ECID, and clients
+// keyed on ECID need the _updated to invalidate their cached id.
 bool EqualDownload(const FileSnapshot &a, const FileSnapshot &b)
 {
 	return a.ecid == b.ecid && a.hash == b.hash && a.name == b.name && a.ed2k_link == b.ed2k_link &&
@@ -494,9 +452,8 @@ bool EqualDownload(const FileSnapshot &a, const FileSnapshot &b)
 	       a.download.percent == b.download.percent &&
 	       a.download.kad_comment_searching == b.download.kad_comment_searching &&
 	       a.download.hashed_part_count == b.download.hashed_part_count &&
-	       // The membership, not the `sources_a4af` count beside it: a swap
-	       // moves one client out and another in, so the count never budges
-	       // and comparing it would publish nothing.
+	       // The membership, not the `sources_a4af` count beside it: a swap moves
+	       // one client out and another in, so the count never budges.
 	       a.download.a4af_sources == b.download.a4af_sources;
 }
 
@@ -504,11 +461,9 @@ bool EqualDownload(const FileSnapshot &a, const FileSnapshot &b)
 // change drives the separate comments_updated event, not download_updated).
 bool EqualComments(const FileSnapshot &a, const FileSnapshot &b)
 {
-	// The in-flight flag is part of the payload, so it has to be part of
-	// the comparison: without it the true->false edge at the end of a Kad
-	// lookup fires no event at all, and a `?channels=comments` subscriber
-	// is left with its spinner stuck on. Every field the event emits must
-	// be compared here or the event cannot announce it changing.
+	// The in-flight flag is part of the payload, so it has to be part of the
+	// comparison: without it the true->false edge at the end of a Kad lookup
+	// fires no event, and a `?channels=comments` subscriber keeps its spinner.
 	if (a.download.kad_comment_searching != b.download.kad_comment_searching)
 		return false;
 	const auto &ca = a.download.source_comments;
@@ -539,18 +494,15 @@ bool EqualShared(const FileSnapshot &a, const FileSnapshot &b)
 	       a.shared.last_upload == b.shared.last_upload &&
 	       a.shared.shared_since == b.shared.shared_since &&
 	       // Media metadata, so a re-extraction emits shared_updated at all.
-	       // Without these a file whose metadata just changed compares EQUAL
-	       // and the refresh is invisible to every subscriber -- which is the
-	       // only progress signal the 202-returning refresh endpoints have.
-	       // These change once per probe, not per tick, so they cost nothing
-	       // in event volume.
+	       // Without these a file whose metadata just changed compares EQUAL and
+	       // the refresh is invisible -- the only progress signal the 202-returning
+	       // refresh endpoints have. These change once per probe, not per tick.
 	       a.has_media == b.has_media && a.media.duration_seconds == b.media.duration_seconds &&
 	       a.media.bitrate_kilobits_per_second == b.media.bitrate_kilobits_per_second &&
 	       a.media.codec == b.media.codec && a.media.artist == b.media.artist &&
 	       a.media.album == b.media.album && a.media.title == b.media.title &&
-	       // Through the accessor, not the raw field: a shared download's
-	       // progress lives on the download side, and comparing the raw
-	       // field would hold every tick of it back from shared_updated.
+	       // Through the accessor, not the raw field: a shared download's progress
+	       // lives on the download side, which the raw field would hold back.
 	       SharedHashingProgress(a) == SharedHashingProgress(b);
 }
 bool Equal(const ServerSnapshot &a, const ServerSnapshot &b)
@@ -564,11 +516,9 @@ bool Equal(const ServerSnapshot &a, const ServerSnapshot &b)
 }
 bool Equal(const FriendSnapshot &a, const FriendSnapshot &b)
 {
-	// client_ecid is part of the identity here on purpose: it going to 0 is
-	// the friend losing its live peer, which a subscriber needs to hear about.
-	// connected is compared alongside it, not instead of it: a peer can go
-	// from linked-but-unreachable to connected without the ecid moving, and
-	// that transition IS the connected indicator flipping.
+	// client_ecid is part of the identity here on purpose: it going to 0 is the
+	// friend losing its live peer. connected is compared alongside it, not
+	// instead: a peer can go from linked-but-unreachable to connected unmoved.
 	return a.name == b.name && a.user_hash == b.user_hash && a.ip == b.ip && a.port == b.port &&
 	       a.client_ecid == b.client_ecid && a.friend_slot == b.friend_slot &&
 	       a.connected == b.connected && a.has_connected == b.has_connected;
@@ -598,11 +548,10 @@ bool Equal(const ClientSnapshot &a, const ClientSnapshot &b)
 	       // zero) compares equal and the row never updates.
 	       a.has_parts_offered_count == b.has_parts_offered_count &&
 	       a.client_mod_name == b.client_mod_name && a.view_shared_disabled == b.view_shared_disabled &&
-	       // Derived from parts_offered_count and the linked file's part count,
-	       // so it normally moves only when a compared field does. The case
-	       // that needs it in its own right is the file going away: the
-	       // percent drops back to its sentinel while every other field
-	       // holds, and without this the payload would change with no event.
+	       // Derived from parts_offered_count and the linked file's part count, so
+	       // it normally moves only when a compared field does. The case that needs
+	       // it in its own right is the file going away: the percent drops back to
+	       // its sentinel while every other field holds.
 	       a.part_progress_percent == b.part_progress_percent;
 }
 bool Equal(const StatusSnapshot &a, const StatusSnapshot &b)
@@ -621,18 +570,16 @@ bool Equal(const StatusSnapshot &a, const StatusSnapshot &b)
 	       a.temp_free_bytes == b.temp_free_bytes && a.incoming_free_bytes == b.incoming_free_bytes &&
 	       a.ul_queue_len == b.ul_queue_len && a.total_src_count == b.total_src_count &&
 	       // The has_ flags are part of the comparison, not just the values: a
-	       // disconnect flips these to null while the underlying ints keep
-	       // their last reading, so comparing the ints alone would miss the
-	       // edge and the event would stop firing exactly when it matters.
+	       // disconnect flips these to null while the underlying ints keep their
+	       // last reading, so comparing the ints alone would miss the edge.
 	       a.has_ed2k_network == b.has_ed2k_network && a.ed2k_users == b.ed2k_users &&
 	       a.ed2k_files == b.ed2k_files && a.has_kad_firewalled_tcp == b.has_kad_firewalled_tcp;
 }
 bool Equal(const KadSnapshot &a, const KadSnapshot &b)
 {
-	// This is the SEPARATE gate for the kad half of status_changed -- the
-	// status comparator above does not cover these. has_network is compared
-	// first because it is the field that changes on a connect/disconnect edge
-	// while users/files/nodes keep their last values underneath.
+	// The SEPARATE gate for the kad half of status_changed -- the status
+	// comparator above does not cover these. has_network is compared first
+	// because it is what changes on a connect/disconnect edge.
 	return a.has_network == b.has_network && a.users == b.users && a.files == b.files &&
 	       a.nodes == b.nodes;
 }
@@ -642,13 +589,9 @@ bool Equal(const KadSnapshot &a, const KadSnapshot &b)
 //  - `<base>_added`   for keys in new missing from old (full ToJson)
 //  - `<base>_updated` for shared keys whose values differ (full ToJson)
 //
-// `removed_id_payload_fn` formats the identity-only `_removed` payload
-// — `{"hash": "..."}` for hash-keyed (downloads, shared) or
-// `{"ecid": N}` for ECID-keyed (servers, clients).
-//
-// Coalesced into one PublishBatch (one lock acquisition, one
-// notify_all) so a cold-start diff on a 5K-download library doesn't
-// fire 5K notify_all cycles inside the refresher loop.
+// Coalesced into one PublishBatch (one lock acquisition, one notify_all) so a
+// cold-start diff on a 5K-download library does not fire 5K notify_all cycles
+// inside the refresher loop.
 template <class Map, class IdentityFn>
 void DiffMap(CEventBus &bus,
 	const std::string &base,
@@ -677,26 +620,21 @@ void DiffMap(CEventBus &bus,
 	bus.PublishBatch(batch);
 }
 
-// For hash-keyed file events emit removed payloads as
-// `{"hash":"..."}` so consumers can drop the cache entry without
-// needing the old object.
+// Hash-keyed file events emit removed payloads as `{"hash":"..."}` so consumers
+// can drop the cache entry without needing the old object.
 std::string RemovedHashPayload(const std::string &hash)
 {
 	return "{\"hash\":\"" + EscJson(hash) + "\"}";
 }
 
-// Every ECID-keyed collection identifies a removed entry the same way, now
-// that each object names its own handle `ecid` (issue #976): one shape, one
-// function, rather than a per-type overload that only differed in the key it
-// spelled.
+// Every ECID-keyed collection identifies a removed entry the same way, now that
+// each object names its own handle `ecid`.
 template <class Snapshot> std::string RemovedEcidPayload(const Snapshot &item)
 {
 	// The per-type overloads this replaced could only be called with an
-	// ECID-keyed snapshot; an unconstrained template accepts anything with
-	// an `.ecid` member, and FileSnapshot has one (State.h) while its
-	// collections are hash-keyed and their consumers expect {"hash":...}.
-	// Wiring one through DiffMap would otherwise compile and emit the wrong
-	// shape at runtime.
+	// ECID-keyed snapshot; an unconstrained template accepts anything with an
+	// `.ecid` member, and FileSnapshot has one while its collections are
+	// hash-keyed. Wiring one through DiffMap would compile and emit the wrong shape.
 	static_assert(!std::is_same<Snapshot, FileSnapshot>::value,
 		"file collections are hash-keyed -- use RemovedHashPayload");
 	std::ostringstream o;
@@ -704,11 +642,9 @@ template <class Snapshot> std::string RemovedEcidPayload(const Snapshot &item)
 	return o.str();
 }
 
-// Build an ECID-keyed map from the vector view that CState exposes.
-// The cache's internal layout is std::map<ECID, Snapshot>; the public
-// accessor returns std::vector<Snapshot>. For diffing we want
-// random-access-by-ECID, so we lift it back into a map. Cheap — O(N)
-// with N typically <1000 per substruct.
+// Build an ECID-keyed map from the vector view CState exposes. The cache's
+// internal layout is std::map<ECID, Snapshot> but the accessor returns a vector,
+// and diffing wants random access by ECID. O(N), N typically <1000.
 template <class Snap> std::map<std::uint32_t, Snap> ByEcid(const std::vector<Snap> &v)
 {
 	std::map<std::uint32_t, Snap> m;
@@ -722,14 +658,11 @@ template <class Snap> std::map<std::uint32_t, Snap> ByEcid(const std::vector<Sna
 namespace
 {
 
-// Single-writer invariant: only the wxApp refresher tick mutates
-// LastSeenState + publishes diffs. Anything else (a future inline-
-// refresh-then-publish, a debug recompute, etc.) is a silent
-// concurrency bug — events get duplicated/dropped depending on
-// which order the threads landed. Capture the first caller's
-// thread id and abort hard on any subsequent caller from a
-// different thread. Hard-abort (not assert) so the check survives
-// -DNDEBUG and ships in every Release / RelWithDebInfo binary.
+// Single-writer invariant: only the wxApp refresher tick mutates LastSeenState
+// and publishes diffs. Anything else is a silent concurrency bug -- events get
+// duplicated or dropped depending on which order the threads landed. Capture
+// the first caller's thread id and abort hard on any later caller from another
+// thread; hard-abort, not assert, so the check survives -DNDEBUG.
 std::atomic<std::thread::id> g_publisher_thread;
 
 void EnforceSinglePublisher()
@@ -750,11 +683,8 @@ void EnforceSinglePublisher()
 // Every file event resolves its payload through `prev.files` after the locked
 // walk, which holds only because nothing erases from that map in between: the
 // `gone` sweep runs after the batch is built, and `gone` is disjoint from
-// everything the walk recorded. Unreachable today -- but a dropped event is
-// invisible, and a lost `shared_removed` leaves a ghost row on every client
-// until something else happens to touch that file. Hard-abort for the same
-// reason EnforceSinglePublisher does: the check has to survive -DNDEBUG,
-// because that is where the ordering will actually get broken.
+// everything the walk recorded. Unreachable today, but a dropped event is
+// invisible and a lost `shared_removed` leaves a ghost row on every client.
 [[noreturn]] void AbortOnMissingBaseline(const char *event_name, std::uint32_t ecid)
 {
 	std::cerr << "amuleapi: file diff lost the baseline entry for ECID " << ecid << " while building "
@@ -765,17 +695,13 @@ void EnforceSinglePublisher()
 } // namespace
 
 // One chat message as the `message` object both the SSE payload and
-// GET /chats/{address}/messages expose. Written here in the same string-building
-// style as the other event payloads in this file; the REST side renders the
-// identical shape through CJsonWriter.
+// GET /chats/{address}/messages expose. The REST side renders the identical
+// shape through CJsonWriter.
 //
-// `sent_at` nulls on 0 the way WriteIntOrNull does on the REST side. Nothing
-// the core reports today is unstamped -- CChatSessionStore::Append stamps
-// every message it stores, and the history reply carries the tag
-// unconditionally -- so this is the two writers agreeing on a shape rather
-// than a value that flips in the field. It is written down because the
-// snapshot field defaults to 0 and the two serializers are promised to be
-// byte-identical: a core that ever omits the tag must not make them diverge.
+// `sent_at` nulls on 0 the way WriteIntOrNull does. Nothing the core reports
+// today is unstamped, so this is the two writers agreeing on a shape rather
+// than a value that flips in the field -- but the snapshot field defaults to 0,
+// and a core that ever omits the tag must not make them diverge.
 std::string ChatMessageJson(const ChatMessageSnapshot &msg)
 {
 	return "{\"id\":" + std::to_string(msg.id) + ",\"direction\":\"" + (msg.outgoing ? "out" : "in") +
@@ -820,60 +746,46 @@ void PublishChatEvents(CEventBus &bus,
 void EmitDiffsAndUpdate(CEventBus &bus, LastSeenState &prev, const CState &state)
 {
 	EnforceSinglePublisher();
-	// Snapshot the current state under its read locks. Each accessor takes the
-	// shared_timed_mutex shared, copies, and returns. Files are the exception,
+	// Snapshot the current state under its read locks. Files are the exception,
 	// walked in place further down: the diff needs the unified map, not a
-	// role-filtered view of it, so it can see a file that flipped is_shared
-	// false→true on an existing ECID and fire `shared_added` for it even though
-	// the entry was there all along.
+	// role-filtered view, so it can see a file that flipped is_shared false->true
+	// on an existing ECID and fire `shared_added` for it.
 	auto new_servers = ByEcid(state.Servers());
 	auto new_friends = ByEcid(state.Friends());
 	auto new_clients = ByEcid(state.Clients());
-	// part_progress_percent is derived, not refreshed: it needs the part count
-	// of the file the peer is a source for, which lives in a different
-	// snapshot, so the refresher leaves it at its sentinel and the REST
-	// handlers fill it in per request. Do the same here, or the event would
-	// be the one payload a subscriber has to re-GET to complete -- the exact
-	// thing EVENTS.md promises it never has to. Computed on the copies before
-	// both the Equal() comparison and the serialiser see them, so the
-	// baseline and the payload always agree.
+	// part_progress_percent is derived, not refreshed: it needs the part count of
+	// the file the peer is a source for, which lives in a different snapshot, so
+	// the refresher leaves it at its sentinel and the REST handlers fill it in
+	// per request. Do the same here, or the event becomes the one payload a
+	// subscriber has to re-GET to complete. Computed before Equal() and the
+	// serialiser see the copies, so baseline and payload always agree.
 	for (auto &kv : new_clients) {
 		ComputePartProgressPercent(state, kv.second);
 	}
-	// Read the full dashboard for status_changed — the event payload
-	// mirrors the REST /status nested envelope which pulls from
-	// StatusSnapshot + KadSnapshot + ec_connected. Dashboard() takes
-	// the State lock once for all three, so the rollup is coherent
-	// (kad.network can't be from tick N+1 while ed2k.* is from tick
-	// N).
+	// Read the full dashboard for status_changed -- the payload mirrors the REST
+	// /status nested envelope, which pulls from StatusSnapshot + KadSnapshot +
+	// ec_connected. Dashboard() takes the State lock once for all three, so
+	// kad.network cannot be from tick N+1 while ed2k.* is from tick N.
 	auto new_dashboard = state.Dashboard();
 	const StatusSnapshot &new_status = new_dashboard.status;
 	const KadSnapshot &new_kad = new_dashboard.kad;
 	const bool new_ec = new_dashboard.ec_connected;
 
-	// Files: role-flag-aware diff, run against the live map rather than a copy
-	// of it. download_* fires on is_downloading transitions, shared_* on
-	// is_shared transitions, and a single tick can fire both for the same file
-	// (a partfile becoming shared while its download side also moved).
+	// Files: role-flag-aware diff, run against the live map rather than a copy.
+	// download_* fires on is_downloading transitions, shared_* on is_shared, and
+	// a single tick can fire both for the same file.
 	//
 	// prev.files is a comparison baseline, not a mirror: an entry is rewritten
-	// exactly when a predicate below reports a difference, so the fields those
-	// predicates read stay fresh and others may lag. A new predicate has to go
-	// into the write-back condition too, not only the emit condition.
+	// exactly when a predicate below reports a difference, so a new predicate has
+	// to go into the write-back condition too, not only the emit condition.
 	{
-		// Decided under the read lock, serialised after it. The payloads are
-		// the full snapshot shape, so a cold-start tick or a shared-files
-		// reload builds one per file; doing that inside the lock would queue
-		// the refresher's own writer and every reader behind it, which is the
-		// cost this change exists to remove. What the walk records instead is
-		// the event and its subject: a hash for a removal, an ECID for
-		// everything else, resolved against `prev.files` once the lock is
-		// released -- the write-back below leaves that entry equal to the live
-		// one, so it is the same object the payload would have been built from.
-		// Removals name their subject by ECID for the same reason: copying the
-		// hash out would put one string allocation per removed file back under
-		// the lock, and `prev.files` still holds the entry -- the `gone` erase
-		// is deferred until the batch is built.
+		// Decided under the read lock, serialised after it. The payloads are the
+		// full snapshot shape, so a cold-start tick or a shared-files reload builds
+		// one per file; doing that inside the lock would queue the refresher's own
+		// writer and every reader behind it. What the walk records instead is the
+		// event and its subject -- a hash for a removal, an ECID for everything
+		// else -- resolved against `prev.files` once the lock is released, which
+		// the write-back below leaves equal to the live entry.
 		enum class Change
 		{
 			DownloadAdded,
@@ -916,14 +828,10 @@ void EmitDiffsAndUpdate(CEventBus &bus, LastSeenState &prev, const CState &state
 				if (now.is_downloading) {
 					if (!was_downloading) {
 						changed.emplace_back(Change::DownloadAdded, entry.first);
-						// The flag counts as comment state, exactly as
-						// it does in EqualComments. Gating on the list
-						// alone means a download first seen with a Kad
-						// lookup already in flight never announces the
-						// lookup at all -- the mirror of the edge where
-						// a finished lookup never announced its end,
-						// leaving the same indicator wrong in the
-						// opposite direction.
+						// The flag counts as comment state, exactly as it does in
+						// EqualComments. Gating on the list alone means a download
+						// first seen with a Kad lookup already in flight never
+						// announces the lookup at all.
 						if (!now.download.source_comments.empty() ||
 							now.download.kad_comment_searching) {
 							changed.emplace_back(
@@ -935,8 +843,8 @@ void EmitDiffsAndUpdate(CEventBus &bus, LastSeenState &prev, const CState &state
 								Change::DownloadUpdated, entry.first);
 							moved = true;
 						}
-						// Independent of download_updated: fires for Kad notes AND
-						// comments reported by connected sources (issue #434 / #419).
+						// Independent of download_updated: Kad notes AND source
+						// comments.
 						if (!EqualComments(it->second, now)) {
 							changed.emplace_back(
 								Change::CommentsUpdated, entry.first);
@@ -1013,12 +921,10 @@ void EmitDiffsAndUpdate(CEventBus &bus, LastSeenState &prev, const CState &state
 		return RemovedEcidPayload(f);
 	});
 
-	// /status: one event when anything in the dashboard envelope
-	// changes (StatusSnapshot fields OR Kad network rollup OR
-	// ec_connected). Cold start is its own branch, gated on
-	// `status_initialised`: it publishes exactly one status_changed and
-	// seeds the baseline, so the comparison below never runs against an
-	// empty prev and mistakes every field for a change.
+	// /status: one event when anything in the dashboard envelope changes
+	// (StatusSnapshot fields OR Kad network rollup OR ec_connected). Cold start
+	// is its own branch, gated on `status_initialised`, so the comparison below
+	// never runs against an empty prev and mistakes every field for a change.
 	if (!prev.status_initialised) {
 		bus.Publish("status_changed", ToJsonStatusEvent(new_status, new_kad, new_ec));
 		prev.status_initialised = true;
@@ -1036,15 +942,11 @@ void EmitDiffsAndUpdate(CEventBus &bus, LastSeenState &prev, const CState &state
 	prev.ec_connected = new_ec;
 
 	// The stable-but-mutable field set for `search_result_updated`. A hit's
-	// identity fields (hash, name, size, type, directory, media, children)
-	// never change for a given ECID, and its source counts churn every tick
-	// while the search runs -- where `search_progress` is already the re-read
-	// cue. What is left is the set that can change AFTER a search finishes,
-	// when no other signal exists: download state (`status` /
-	// `already_downloaded`), and the Kad-notes cluster (`comments[]`, the
-	// in-flight flag, and `rating`, which aggregates from the comments).
-	// Comparing only these keeps the search channel quiet on a running
-	// search instead of firing per-result frames on source-count churn.
+	// identity fields never change for a given ECID, and its source counts churn
+	// every tick while the search runs -- where `search_progress` is already the
+	// re-read cue. What is left is the set that can change AFTER a search
+	// finishes, when no other signal exists: download state, and the Kad-notes
+	// cluster. Comparing only these keeps the channel quiet on a running search.
 	const auto result_mutated = [](const SearchResult &a, const SearchResult &b) {
 		if (a.status != b.status || a.already_downloaded != b.already_downloaded ||
 			a.rating != b.rating || a.kad_comment_searching != b.kad_comment_searching ||
@@ -1060,17 +962,12 @@ void EmitDiffsAndUpdate(CEventBus &bus, LastSeenState &prev, const CState &state
 		return false;
 	};
 
-	// Search events. `search_result_added` per new ECID in the results
-	// map; `search_result_updated` when one of a held result's
-	// stable-but-mutable fields changes (see result_mutated above);
-	// `search_progress` on any percent change while running and on
-	// the running→finished edge. The finished frame (state="finished",
-	// percent=100) is just the terminal search_progress — there is no
-	// separate search_finished event. The refresher's state machine
-	// (AdvanceSearchProgress) drives both — POST /search seeds the active
-	// flag; subsequent ticks either grow the results map, advance the
-	// percent, or flip complete. First tick after MarkSearchStarted
-	// bootstraps the baseline so we don't double-emit on first observation.
+	// Search events. `search_result_added` per new ECID; `search_result_updated`
+	// when one of a held result's stable-but-mutable fields changes;
+	// `search_progress` on any percent change while running and on the
+	// running->finished edge. The finished frame (state="finished", percent=100)
+	// IS that terminal search_progress -- there is no separate search_finished.
+	// The first tick after MarkSearchStarted bootstraps the baseline.
 	{
 		// Multi-search: diff every open search independently, keyed by
 		// search_id, and stamp that id on each event so subscribers demux.
@@ -1079,12 +976,10 @@ void EmitDiffsAndUpdate(CEventBus &bus, LastSeenState &prev, const CState &state
 			const auto search_now = ByEcid(state.Search(sid));
 			const auto progress_now = state.SearchProgress(sid);
 
-			// Cold start (first tick ever): baseline every pre-existing
-			// search silently so history isn't replayed as events. A
-			// search that appears LATER has no prev entry, so its
-			// generation (0) differs from the live one — the progress
-			// edge below fires its initial "running" frame, and its
-			// results stream in as ordinary additions.
+			// Cold start (first tick ever): baseline every pre-existing search
+			// silently so history is not replayed as events. A search that appears
+			// LATER has no prev entry, so its generation (0) differs from the live
+			// one and the progress edge below fires its initial "running" frame.
 			if (!prev.search_initialised) {
 				auto &b = prev.searches[sid];
 				b.results = search_now;
@@ -1095,15 +990,11 @@ void EmitDiffsAndUpdate(CEventBus &bus, LastSeenState &prev, const CState &state
 			}
 
 			auto &pstate = prev.searches[sid];
-			// Results do leave an attached search: the union merge erases an
-			// ECID the daemon stopped reporting, and RebuildFoldedResults drops
-			// a row that has since been folded into a parent's
-			// alternate_names[]. Emitted before the additions below, the order
-			// DiffMap uses, and identity-only like every other _removed.
-			//
-			// Without this the row stays on every subscriber's screen for the
-			// life of the search: a finished one publishes no further
-			// search_progress, so nothing even hints that a re-read is due.
+			// Results do leave an attached search: the union merge erases an ECID the
+			// daemon stopped reporting, and RebuildFoldedResults drops a row folded
+			// into a parent. Without this the row stays on every subscriber's screen
+			// for the life of the search: a finished one publishes no further
+			// search_progress, so nothing hints that a re-read is due.
 			for (const auto &kv : pstate.results) {
 				if (search_now.find(kv.first) != search_now.end())
 					continue;
@@ -1118,24 +1009,14 @@ void EmitDiffsAndUpdate(CEventBus &bus, LastSeenState &prev, const CState &state
 				const bool is_new = pit == pstate.results.end();
 				if (!is_new && !result_mutated(pit->second, kv.second))
 					continue;
-				// `search_id` routes the event to a tab/view; every
-				// field after it comes from the same writer
-				// GET /search/{id}/results uses, which is what makes
-				// the documented "byte-for-byte identical to a
-				// results-list entry" promise hold by construction
-				// rather than by review.
+				// `search_id` routes the event to a tab/view; every field after it
+				// comes from the same writer GET /search/{id}/results uses, which
+				// is what makes the documented "byte-for-byte identical to a
+				// results-list entry" promise hold by construction.
 				//
-				// `search_result_updated` carries the identical payload
-				// under its own name, rather than re-firing _added with
-				// upsert semantics: a consumer that only handles _added
-				// keeps exactly the behaviour it had, and one that wants
-				// live rows opts in by handling the new event. It is the
-				// close of the one window where a client could not know:
-				// a finished search stops emitting search_progress, yet a
-				// hit downloaded from it flips status / already_downloaded, and
-				// a Kad notes lookup lands comments / rating after the
-				// fact. (Those fields are polled at all because the union
-				// keeps finished searches in the per-tick poll set.)
+				// `search_result_updated` carries the identical payload under its
+				// own name rather than re-firing _added with upsert semantics, so a
+				// consumer that only handles _added keeps the behaviour it had.
 				CJsonWriter w;
 				w.BeginObject();
 				w.Key("search_id");
@@ -1145,13 +1026,11 @@ void EmitDiffsAndUpdate(CEventBus &bus, LastSeenState &prev, const CState &state
 				bus.Publish(is_new ? "search_result_added" : "search_result_updated",
 					w.TakeBuffer());
 			}
-			// search_progress: a percent change while running, the
-			// running→finished edge (complete false→true), or a
-			// generation bump (new POST /search, or the first observation
-			// of this search_id). The generation trigger catches
-			// back-to-back searches whose whole lifecycle fits inside one
-			// refresher tick — the percent+complete comparison would see
-			// 100→100 / true→true and emit nothing.
+			// search_progress: a percent change while running, the running->finished
+			// edge, or a generation bump (new POST /search, or first observation of
+			// this search_id). The generation trigger catches back-to-back searches
+			// whose whole lifecycle fits inside one refresher tick -- the
+			// percent+complete comparison would see 100->100 / true->true.
 			const bool generation_bumped = progress_now.generation != pstate.generation;
 			const bool finished_edge = progress_now.complete && !pstate.complete;
 			const bool percent_moved = progress_now.percent != pstate.percent;
@@ -1176,15 +1055,13 @@ void EmitDiffsAndUpdate(CEventBus &bus, LastSeenState &prev, const CState &state
 		}
 		prev.search_initialised = true;
 		// Prune baselines for searches that vanished (closed / EC reset) so
-		// prev.searches can't grow without bound, and tell subscribers.
-		// Without the event a consumer holding one tab per search only finds
-		// out on its next read, and with SSE live it may never read again.
+		// prev.searches cannot grow without bound, and tell subscribers --
+		// without the event a consumer holding one tab per search only finds out
+		// on its next read, and with SSE live it may never read again.
 		//
-		// This fires only when the SLOT is gone -- DELETE /search/{id}, the
-		// slot cap evicting an old finished search, or an EC reset. A search
-		// the daemon evicted from its own ring is retired as finished and
-		// kept locally for late reads, so that case is a terminal
-		// search_progress above, never a search_closed.
+		// This fires only when the SLOT is gone. A search the daemon evicted from
+		// its own ring is retired as finished and kept locally for late reads,
+		// so that case is a terminal search_progress above, never a search_closed.
 		for (auto it = prev.searches.begin(); it != prev.searches.end();) {
 			if (std::find(ids.begin(), ids.end(), it->first) == ids.end()) {
 				std::ostringstream payload;
@@ -1198,27 +1075,22 @@ void EmitDiffsAndUpdate(CEventBus &bus, LastSeenState &prev, const CState &state
 	}
 
 	// log_appended. The refresher only ever appends, so a size that grew means
-	// the tail is new. First tick records the baseline silently — clients GET
-	// /api/v0/logs/amule for the history; this channel is the live tail only.
+	// the tail is new. First tick records the baseline silently -- clients GET
+	// /logs/amule for the history; this channel is the live tail only.
 	//
 	// `DELETE /logs/amule` empties the buffer, and the clear-generation is what
 	// says so. A shrunk size was the old signal and it misses the case that
 	// matters: cleared and refilled past the old count between two ticks, the
-	// size only grows, so the append branch would publish a mid-buffer slice
-	// as though it were the tail and never publish what came before it.
+	// size only grows, so the append branch would publish a mid-buffer slice.
 	//
-	// On that edge subscribers get `resync`, not a log event: lines are gone
-	// that this channel promised to deliver, so the honest signal is "your
-	// copy is stale, re-read", which is exactly what resync means. It bypasses
-	// `?channels=`, so a log-only subscriber is told too -- and the HTTP
-	// thread could not have published it from the DELETE handler anyway, the
-	// bus having a single-publisher invariant that only this tick satisfies.
+	// On that edge subscribers get `resync`, which bypasses `?channels=` so a
+	// log-only subscriber is told too -- and which the HTTP thread could not
+	// have published from the DELETE handler anyway, the bus having a
+	// single-publisher invariant only this tick satisfies.
 	//
-	// Size and tail in one read: the history is uncapped, so asking AmuleLog()
-	// for a `.size()` that is unchanged on almost every tick copies all of it
-	// -- and splitting the two would let that DELETE land in between, pairing
-	// a pre-truncation size with an empty tail. The generation rides along for
-	// the same reason.
+	// Size and tail come from one read: the history is uncapped, so asking
+	// AmuleLog() for a `.size()` that is unchanged on almost every tick copies
+	// all of it -- and splitting the two would let that DELETE land in between.
 	std::size_t log_size = 0;
 	std::uint64_t log_generation = 0;
 	const auto tail = state.AmuleLogFrom(prev.amule_log_count, log_size, &log_generation);
@@ -1232,8 +1104,7 @@ void EmitDiffsAndUpdate(CEventBus &bus, LastSeenState &prev, const CState &state
 		prev.amule_log_generation = log_generation;
 	} else if (log_size < prev.amule_log_count) {
 		// No generation bump, so this is not a clear: the buffer is capped
-		// elsewhere or the daemon replaced it wholesale. Re-point and stay
-		// quiet, as before.
+		// elsewhere or the daemon replaced it wholesale. Re-point and stay quiet.
 		prev.amule_log_count = log_size;
 	} else if (!tail.empty()) {
 		std::ostringstream payload;

--- a/src/webapi/EventDiff.h
+++ b/src/webapi/EventDiff.h
@@ -41,35 +41,30 @@ class CEventBus;
 // entry (cold start); subsequent ticks fire only the deltas.
 struct LastSeenState
 {
-	// `files` is a comparison baseline against CState::m_files (unified
-	// ECID-keyed map with `is_downloading` / `is_shared` flags), not a mirror
-	// of it: an entry is rewritten exactly when one of EventDiff's predicates
+	// `files` is a comparison baseline against CState::m_files, not a mirror of
+	// it: an entry is rewritten exactly when one of EventDiff's predicates
 	// reports a difference, so the fields those predicates read stay fresh and
 	// others may lag. Adding a predicate means adding its field to the
 	// write-back condition too, not only to the emit condition.
 	//
-	// Role-flag transitions false→true emit the corresponding `_added` event,
-	// true→false the `_removed`; a file may participate in both views and emit
-	// both event families.
+	// Role-flag transitions false->true emit the corresponding `_added` event,
+	// true->false the `_removed`; a file may emit both event families.
 	std::map<std::uint32_t, FileSnapshot> files;
 	std::map<std::uint32_t, ServerSnapshot> servers;
 	std::map<std::uint32_t, ClientSnapshot> clients;
 	std::map<std::uint32_t, FriendSnapshot> friends;
-	// Status event payload mirrors the REST /status envelope, which
-	// pulls from THREE sources (StatusSnapshot + KadSnapshot +
-	// ec_connected flag). All three must be diffed against the prior
-	// tick to decide whether to fire `status_changed`.
+	// The status event payload mirrors the REST /status envelope, which pulls
+	// from THREE sources (StatusSnapshot + KadSnapshot + ec_connected). All
+	// three must be diffed against the prior tick to decide on `status_changed`.
 	StatusSnapshot status;
 	KadSnapshot kad;
 	bool ec_connected = false;
 	bool status_initialised = false;
 
-	// log-tail tracking for the `log_appended` event. `amule_log_count` is how
-	// many lines the previous tick had accounted for, and is what the next one
-	// passes to CState::AmuleLogFrom() as its cursor: a non-empty tail is what
-	// gets published. First-tick cold-start is gated by
-	// `amule_log_initialised` so we don't dump every historical line as one
-	// event — clients can GET /api/v0/logs/amule for the history.
+	// Log-tail tracking for `log_appended`. `amule_log_count` is how many lines
+	// the previous tick accounted for, and is what the next passes to
+	// CState::AmuleLogFrom() as its cursor. First-tick cold-start is gated by
+	// `amule_log_initialised` so history is not dumped as one event.
 	std::size_t amule_log_count = 0;
 	bool amule_log_initialised = false;
 	// Last clear-generation seen. A bump means DELETE /logs/amule emptied the
@@ -77,12 +72,10 @@ struct LastSeenState
 	std::uint64_t amule_log_generation = 0;
 
 	// Per-search event baseline (multi-search). One entry per open search_id,
-	// diffed against that search's state each tick: new result ECIDs →
-	// search_result_added; a percent change, the running→finished edge, or a
-	// generation bump → search_progress (the terminal frame, state="finished",
-	// supersedes the old standalone search_finished event). Every emitted event
-	// carries its `search_id`. Entries for searches no longer present (closed /
-	// reset) are pruned each tick.
+	// diffed against that search's state each tick: new result ECIDs ->
+	// search_result_added; a percent change, the running->finished edge, or a
+	// generation bump -> search_progress. Every emitted event carries its
+	// `search_id`, and entries for searches no longer present are pruned.
 	struct SearchDiffState
 	{
 		std::map<std::uint32_t, SearchResult> results;
@@ -97,34 +90,24 @@ struct LastSeenState
 	bool search_initialised = false;
 };
 
-// Walk every (old vs current) substruct, publish typed events for
-// each delta, then overwrite `prev` with the current snapshot so the
-// next tick diffs against the freshest baseline.
+// Walk every (old vs current) substruct, publish typed events for each delta,
+// then overwrite `prev` with the current snapshot so the next tick diffs
+// against the freshest baseline.
 //
-// Wire event names: download_{added,updated,removed},
-// shared_{added,updated,removed}, server_{added,updated,removed},
-// client_{added,updated,removed}, status_changed.
-//
-// `_added` / `_updated` payload: the full snapshot object (matches
-// the REST list-item shape byte-for-byte; clients overwrite their
-// cache slot from the new object).
-// `_removed` payload: `{"ecid": N}` for ECID-keyed types,
-// `{"hash": "..."}` for hash-keyed (downloads + shared).
-// `status_changed` payload: the nested REST /status envelope
-// (ed2k.*, kad.* with kad.network rollup, speeds.*, queue.*, plus
-// top-level ec_connected). Pulled from state.Dashboard() so all
-// three pieces stay consistent within a tick.
+// `_added` / `_updated` payload: the full snapshot object, matching the REST
+// list-item shape byte for byte, so clients overwrite their cache slot from it.
+// `_removed` payload: `{"ecid": N}` for ECID-keyed types, `{"hash": "..."}` for
+// hash-keyed ones. `status_changed` payload: the nested REST /status envelope,
+// pulled from state.Dashboard() so all three pieces stay consistent.
 void EmitDiffsAndUpdate(CEventBus &bus, LastSeenState &prev, const CState &state);
 
 // Chat events, published straight from the refresher's chat roundtrip rather
 // than by diffing a prior snapshot: the walker already knows exactly what is
-// new (only messages past the cursor come back) and which sessions vanished,
-// so a diff would re-derive what the wire just told us.
+// new (only messages past the cursor come back) and which sessions vanished.
 //
-// One `chat_message` per message, inbound AND outbound alike -- an outbound
-// one is how a message sent from amulegui, or from another web tab, reaches
-// every other viewer. A session that did not exist is implied by the first
-// message carrying its `peer`; there is no separate "session started" event.
+// One `chat_message` per message, inbound AND outbound alike -- an outbound one
+// is how a message sent from amulegui reaches every other viewer. A session
+// that did not exist is implied by the first message carrying its `peer`.
 void PublishChatEvents(CEventBus &bus,
 	const std::vector<ChatSessionSnapshot> &new_messages,
 	const std::vector<std::uint64_t> &closed);

--- a/src/webapi/HttpServer.cpp
+++ b/src/webapi/HttpServer.cpp
@@ -48,11 +48,8 @@
 #include "../WarningsPop.h"
 
 // strncasecmp lives in <strings.h> on POSIX (glibc also exposes it via
-// <string.h>, but musl/BSDs don't), and MSVC spells it _strnicmp. The same
-// shim Api.cpp and libwebcommon/HeaderParse.cpp carry: this file reads a
-// header name case-insensitively on the transport error paths, and it should
-// not depend on the declaration arriving transitively through someone else's
-// include.
+// <string.h>, but musl/BSDs do not), and MSVC spells it _strnicmp. The same
+// shim Api.cpp and libwebcommon/HeaderParse.cpp carry.
 #ifdef _WIN32
 #define strncasecmp _strnicmp
 #else
@@ -80,11 +77,9 @@ using tcp = boost::asio::ip::tcp;
 
 // See HttpServer.h.
 //
-// Factored out deliberately. This logic existed in three places -- the regular
-// response writer, the SSE head writer, and the dispatcher's CORS pass -- and
-// two consecutive rounds of fixes each landed in a different two of the three,
-// leaving the untouched copy with the old overwrite behaviour. One definition
-// means a fix cannot land in only some of the writers.
+// Factored out deliberately: this logic existed in three places -- the regular
+// response writer, the SSE head writer, and the dispatcher's CORS pass -- and two
+// consecutive rounds of fixes each landed in a different two of the three.
 void AppendHeaderToken(std::map<std::string, std::string> &headers, const char *name, const char *token)
 {
 	auto it = headers.find(name);
@@ -112,18 +107,15 @@ void AppendHeaderToken(std::map<std::string, std::string> &headers, const char *
 	it->second = cur + ", " + token;
 }
 
-// Bodies smaller than this are sent uncompressed. Below ~250 bytes the
-// gzip header (~10 bytes) + trailer (~8 bytes) plus the deflate block
-// framing eats most of any ratio gain, and error/heartbeat payloads
-// are common in that size range.
+// Bodies smaller than this are sent uncompressed. Below ~250 bytes the gzip
+// header (~10 bytes) + trailer (~8 bytes) plus the deflate block framing eats
+// most of any ratio gain, and error/heartbeat payloads are common there.
 constexpr size_t kGzipMinBodyBytes = 256;
 
-// Media types whose payload is already entropy-coded. Running deflate
-// over a PNG / JPEG / WebP / GIF / woff2 buys a percent at best and
-// routinely grows the body, so the flag artwork and any future binary
-// asset ship as-is. Prefix match on the type token — the check runs
-// before any "; charset=" parameter would matter, and none of these
-// carry one.
+// Media types whose payload is already entropy-coded. Running deflate over a
+// PNG / JPEG / WebP / GIF / woff2 buys a percent at best and routinely grows the
+// body. Prefix match on the type token -- the check runs before any
+// "; charset=" parameter would matter, and none of these carry one.
 bool IsPrecompressedType(const std::string &content_type)
 {
 	static const char *const kTypes[] = { "image/png",
@@ -150,13 +142,10 @@ bool WillCompressBody(
 	       !IsPrecompressedType(content_type);
 }
 
-// Case-insensitive token search for "gzip" in an Accept-Encoding header
-// value. Real clients (curl, browsers) send "gzip, deflate, br" or
-// "gzip;q=1.0" — no legitimate client sends "gzip;q=0" (which per
-// RFC 9110 means "explicitly not gzip") so we don't parse q-values;
-// presence of the token is treated as accept. The `x-gzip` legacy
-// alias is not honoured, which is fine because no client emitting it
-// today would fail to also accept plain identity.
+// Case-insensitive token search for "gzip" in an Accept-Encoding header value.
+// No legitimate client sends "gzip;q=0" (which per RFC 9110 means "explicitly
+// not gzip") so q-values are not parsed; presence of the token is accept. The
+// legacy `x-gzip` alias is not honoured.
 bool AcceptsGzip(const std::string &accept_encoding)
 {
 	if (accept_encoding.empty()) {
@@ -182,117 +171,81 @@ bool AcceptsGzip(const std::string &accept_encoding)
 namespace
 {
 
-// Per-connection session. Reads one request, hands it to the user
-// handler, writes the response, closes. No keep-alive — the API
-// surface is too small to benefit, and the one-shot model keeps the
-// state machine trivially auditable. If the streaming_resolver
-// matches the parsed request, the session takes a different path:
-// writes the response head and runs the streaming handler on a
-// worker thread, which can push chunks indefinitely via the Writer
-// interface until the handler returns or the peer disconnects.
-//
-// Process-wide cap on concurrent SSE subscribers. Each session
-// spawns one OS thread, so without a cap a non-loopback bind turns
-// the thread-per-connection model into a DoS amplifier. The cap is
-// sized for the single-operator dashboard pattern: a handful of
-// browser tabs + the odd shell script. Refused sessions get
-// `503 Service Unavailable` + a `Retry-After` hint inside the
-// streaming dispatch path before the worker thread is created.
+// Process-wide cap on concurrent SSE subscribers. Each session spawns one OS
+// thread, so without a cap a non-loopback bind turns the thread-per-connection
+// model into a DoS amplifier. Refused sessions get 503 + a Retry-After hint
+// inside the streaming dispatch path, before the worker thread is created.
 constexpr int kMaxConcurrentStreamingSessions = 32;
 
 // Size of the handler worker pool. Non-streaming request handlers run here
-// instead of on the single io_context thread, so a handler that blocks — a
-// synchronous EC roundtrip stalled up to the EC read timeout — can never
-// freeze accept or other connections. Sized with headroom over amuleapi's
-// typical concurrency (a handful of clients) so non-EC requests keep a free
-// worker even while several handlers are parked on a stalled EC roundtrip.
+// instead of on the single io_context thread, so a handler that blocks -- a
+// synchronous EC roundtrip stalled up to the EC read timeout -- can never freeze
+// accept or other connections.
 constexpr int kHandlerPoolThreads = 16;
 std::atomic<int> g_streaming_session_count{ 0 };
 
-// Process-wide cap on concurrent file-backed responses (Response::file), which
-// is a budget of its own -- independent of both the 16 handler-pool threads and
-// the 32 SSE slots, because it protects a different resource from either.
+// Process-wide cap on concurrent file-backed responses (Response::file), a
+// budget of its own -- independent of both the 16 handler-pool threads and the
+// 32 SSE slots, because it protects a different resource from either.
 //
 // Unlike the SSE path this costs no OS thread: the body is written by
-// async_write on the io_context, so a file response in flight holds a socket
-// and a 64 KiB buffer and nothing else. That is the whole reason serving
-// multi-GB content out of amuleapi is affordable at all, and it is also why the
-// number here is NOT about threads. What it is about is that these responses
-// read from the same spindles the hasher and the ed2k uploader are already
-// using, and push bytes down the same NIC; six concurrent whole-file reads is
-// roughly where a single mechanical disk stops doing sequential I/O and starts
-// seeking between streams. Small enough to keep aMule's own transfers usable,
-// large enough for a browser (which opens a handful of parallel range requests
-// per media element) plus a second client.
+// async_write on the io_context, so a file response in flight holds a socket and
+// a 64 KiB buffer and nothing else. What the number is about is that these
+// responses read from the same spindles the hasher and the ed2k uploader are
+// already using; six concurrent whole-file reads is roughly where a single
+// mechanical disk stops doing sequential I/O and starts seeking between streams.
+// Over the cap the transport answers 503 + Retry-After.
 //
-// Over the cap the transport answers 503 + Retry-After, exactly as the SSE
-// dispatch refuses a 33rd subscriber.
-//
-// Six is the right DEFAULT and the wrong ceiling. The reasoning above is a
-// single-spindle one, and it is also a per-address one that a reverse proxy
-// erases: behind nginx every client arrives from one remote_addr, so this is a
-// global budget with no per-user fairness in it. A NAS with an SSD and four
-// household devices wants more; a Pi serving off the same USB disk it downloads
-// to may want less. So the number is `[Streaming]/MaxConcurrentFileResponses`
-// in amuleapi.conf, defaulting here.
+// Six is the right DEFAULT and the wrong ceiling: the reasoning is
+// single-spindle, and it is per-address in a way a reverse proxy erases (behind
+// nginx every client arrives from one remote_addr). So the number is
+// `[Streaming]/MaxConcurrentFileResponses` in amuleapi.conf, defaulting here.
 constexpr int kDefaultMaxConcurrentFileResponses = 6;
 // Written once by SetMaxConcurrentFileResponses before Start() binds the
-// listener, and only read afterwards. Atomic rather than plain int because the
-// reader is the io_context thread while the writer is whatever thread
-// configured the server; the ordering is established by the listener not
-// existing yet, but the object still has to be race-free to be well-defined.
+// listener, and only read afterwards. Atomic because the reader is the
+// io_context thread while the writer is whatever thread configured the server.
 std::atomic<int> g_max_concurrent_file_responses{ kDefaultMaxConcurrentFileResponses };
 std::atomic<int> g_file_response_count{ 0 };
 
-// Largest request header block we accept. The read buffer below is sized
-// from this: the whole header has to sit in the buffer at once, so a buffer
-// smaller than the parser's header_limit means the buffer overflows first
-// and the limit never fires. They were 8 KiB and 16 KiB respectively, which
-// made the documented 16 KiB cap unreachable and the header_limit branch
-// dead code.
+// Largest request header block we accept. The read buffer below is sized from
+// this: the whole header has to sit in the buffer at once, so a buffer smaller
+// than the parser's header_limit means the buffer overflows first and the limit
+// never fires -- which is what made the documented 16 KiB cap unreachable.
 constexpr std::size_t kMaxHeaderBytes = 16 * 1024;
 // Slack for the request line and the parser's own bookkeeping.
 constexpr std::size_t kReadBufferBytes = kMaxHeaderBytes + 2 * 1024;
 
 // Ceiling on how much of a rejected upload we read and throw away before
-// closing. Enough to clear the in-flight window for a normal client that
-// wrote its body before reading our answer, without letting a peer that
-// keeps pumping hold the session open.
+// closing. Enough to clear the in-flight window for a normal client that wrote
+// its body before reading our answer, without letting a peer that keeps pumping
+// hold the session open.
 constexpr std::size_t kMaxDrainBytes = 4 * 1024 * 1024;
 
 // Idle deadline on a file response: the longest a file transfer may go without
-// the socket accepting a single further byte before the transport gives up and
-// closes, releasing the concurrency slot the response holds.
+// the socket accepting a single further byte before the transport gives up.
 //
 // A PROGRESS deadline, not a total one. The 20 s request expiry cannot be left
 // armed across a file body -- a legitimate multi-GB download over a slow link
-// runs for hours -- but leaving the stream on expires_never() means a peer that
-// advertises a zero receive window and then stops reading pins its slot until
-// the process restarts: TCP does not time that out on its own, it just keeps
-// probing with the persist timer, and neither TCP_USER_TIMEOUT nor keepalive is
-// set on these sockets. Six such peers -- a phone that slept mid-download will
-// do it, no malice required -- would permanently 503 the endpoint. Re-arming
-// per write attempt bounds the stalled peer while a slow one, which by
-// definition keeps making progress, resets the clock every time it does.
+// runs for hours -- but expires_never() means a peer that advertises a zero
+// receive window and then stops reading pins its slot until the process
+// restarts: TCP does not time that out on its own, and neither TCP_USER_TIMEOUT
+// nor keepalive is set on these sockets. Re-arming per write attempt bounds the
+// stalled peer while a slow one, which by definition keeps making progress,
+// resets the clock every time it does.
 //
-// 120 s is deliberately far past any real link. Each async_write_some completes
-// as soon as the socket accepts ANY bytes of the pending chunk, so exceeding
-// this means the peer's window stayed shut for two full minutes; even the
-// pessimistic reading, a whole 64 KiB chunk taking longer than this, works out
-// to under 4.5 kbit/s of goodput, well below dial-up. It is a stall detector,
-// not a rate limit.
+// 120 s is deliberately far past any real link: each async_write_some completes
+// as soon as the socket accepts ANY bytes, so a whole 64 KiB chunk taking
+// longer works out to under 4.5 kbit/s. It is a stall detector, not a rate limit.
 constexpr std::chrono::seconds kFileWriteIdleTimeout{ 120 };
 
-// One-shot gzip encoder for regular (non-streaming) response bodies.
-// Returns false on any zlib error; the caller then serves the response
-// uncompressed rather than 500ing, since a transient zlib failure
-// shouldn't turn into a user-visible outage.
+// One-shot gzip encoder for regular (non-streaming) response bodies. Returns
+// false on any zlib error; the caller then serves the response uncompressed
+// rather than 500ing.
 bool GzipOnce(const std::string &in, std::string &out)
 {
 	z_stream zs{};
-	// windowBits = 15 + 16 → deflate with gzip wrapper (header + CRC
-	// trailer). mem_level 8, default strategy — matches HTTP server
-	// convention (nginx, Apache mod_deflate ship these defaults).
+	// windowBits = 15 + 16 -> deflate with gzip wrapper (header + CRC trailer).
+	// mem_level 8, default strategy -- the nginx / mod_deflate defaults.
 	if (deflateInit2(&zs, Z_DEFAULT_COMPRESSION, Z_DEFLATED, 15 + 16, 8, Z_DEFAULT_STRATEGY) != Z_OK) {
 		return false;
 	}
@@ -316,23 +269,18 @@ bool GzipOnce(const std::string &in, std::string &out)
 }
 
 // Streaming gzip encoder for SSE bodies. One instance per SSE session;
-// Z_SYNC_FLUSH after each Compress() call emits the deflate block
-// boundary immediately so the browser sees events live rather than
-// after a compression buffer fills.
-//
-// The deflate dictionary is shared across events, so repeated JSON
-// keys / hash prefixes / priority strings across events compress
-// against the same reference — this is where the big ratio comes
-// from on delta-heavy SSE streams.
+// Z_SYNC_FLUSH after each Compress() call emits the deflate block boundary
+// immediately so the browser sees events live rather than after a buffer fills.
+// The deflate dictionary is shared across events, so repeated JSON keys / hash
+// prefixes compress against the same reference -- the big ratio win on
+// delta-heavy SSE streams.
 class SseGzipStream
 {
 public:
 	SseGzipStream() = default;
-	// Non-copyable / non-movable: `m_z` holds internal pointers that
-	// zlib manages; a copy would double-free at destruction, and a
-	// move would leave the source in a state deflateEnd can't safely
-	// handle. Owned by SocketWriter (held via shared_ptr elsewhere),
-	// so no copy or move is needed in practice.
+	// Non-copyable / non-movable: `m_z` holds internal pointers zlib manages, so
+	// a copy would double-free at destruction and a move would leave the source
+	// in a state deflateEnd cannot handle.
 	SseGzipStream(const SseGzipStream &) = delete;
 	SseGzipStream &operator=(const SseGzipStream &) = delete;
 	SseGzipStream(SseGzipStream &&) = delete;
@@ -384,10 +332,9 @@ public:
 		return true;
 	}
 
-	// Emit any pending Z_FINISH trailer bytes (gzip CRC + length).
-	// Called from the SSE worker's exit path before the chunked-
-	// terminator so the browser sees a complete gzip stream. Safe to
-	// call multiple times — subsequent calls return empty output.
+	// Emit any pending Z_FINISH trailer bytes (gzip CRC + length). Called from
+	// the SSE worker's exit path before the chunked terminator so the browser
+	// sees a complete gzip stream. Safe to call multiple times.
 	bool Finish(std::string &out)
 	{
 		if (!m_inited || m_finished) {
@@ -419,14 +366,20 @@ private:
 
 class Session;
 
-// Live SSE session registry. Listener::Stop walks this on shutdown
-// to cancel each session's socket I/O — without it, a worker
-// blocked in a synchronous Beast write to a slow peer never sees
-// the io_context.stop() and the daemon hangs forever on exit.
-// weak_ptrs so dead sessions self-clean.
+// Live SSE session registry. Listener::Stop walks this on shutdown to cancel
+// each session's socket I/O -- without it, a worker blocked in a synchronous
+// Beast write to a slow peer never sees io_context.stop() and the daemon hangs
+// forever on exit. weak_ptrs so dead sessions self-clean.
 std::mutex g_live_streams_mu;
 std::vector<std::weak_ptr<Session>> g_live_streams;
 
+// Per-connection session. Reads one request, hands it to the user handler,
+// writes the response, closes. No keep-alive -- the API surface is too small to
+// benefit, and the one-shot model keeps the state machine trivially auditable.
+// If the streaming_resolver matches the parsed request, the session instead
+// writes the response head and runs the streaming handler on a worker thread,
+// which can push chunks indefinitely via the Writer interface until the handler
+// returns or the peer disconnects.
 class Session : public std::enable_shared_from_this<Session>
 {
 public:
@@ -450,16 +403,12 @@ public:
 
 	~Session()
 	{
-		// Worker captures `shared_from_this()` and sets
-		// `m_worker_exited` true on the way out (via the RAII
-		// WorkerExitMarker below). By the time this dtor runs the
-		// last ref must have been dropped, so the worker must have
-		// exited; join() from inside the worker's own call stack
-		// would deadlock, detach() is safe.
-		//
-		// Hand-rolled if + std::abort instead of assert() so the
-		// invariant is enforced in Release too (NDEBUG strips
-		// assert).
+		// Worker captures `shared_from_this()` and sets `m_worker_exited` true on
+		// the way out (via the RAII WorkerExitMarker below). By the time this dtor
+		// runs the last ref must have been dropped, so the worker must have
+		// exited; join() from inside the worker's own call stack would deadlock.
+		// Hand-rolled if + std::abort instead of assert() so the invariant is
+		// enforced in Release too.
 		if (m_stream_worker.joinable()) {
 			if (!m_worker_exited.load(std::memory_order_acquire)) {
 				std::cerr << "amuleapi: FATAL Session dtor reached "
@@ -473,14 +422,11 @@ public:
 		if (m_session_slot_held) {
 			g_streaming_session_count.fetch_sub(1, std::memory_order_acq_rel);
 		}
-		// Same accounting for the file-response budget, and released from
-		// the same place for the same reason: the destructor is the ONE
-		// point every exit path funnels through. A file write can end by
-		// completing, by erroring mid-body, by the peer vanishing, or by
-		// Listener::Stop closing the socket underneath it -- releasing the
-		// slot in the write completion handler would cover the first of
-		// those and leak on the rest, and a leaked slot here is permanent,
-		// since nothing ever resets the counter.
+		// Same accounting for the file-response budget, released from the same
+		// place for the same reason: the destructor is the ONE point every exit
+		// path funnels through. A file write can end by completing, by erroring
+		// mid-body, by the peer vanishing, or by Listener::Stop closing the socket
+		// underneath it, and a leaked slot is permanent -- nothing resets the counter.
 		if (m_file_slot_held) {
 			g_file_response_count.fetch_sub(1, std::memory_order_acq_rel);
 		}
@@ -488,14 +434,11 @@ public:
 
 	void Start() { DoRead(); }
 
-	// Called by Listener::Stop from a foreign thread to cancel any
-	// in-flight Beast write. Posts the close onto the stream's own
-	// executor so we don't race the worker thread's last write —
-	// boost::asio::tcp::socket is NOT thread-safe outside its
-	// strand. The post is fire-and-forget; we don't wait for the
-	// close to complete. The worker's writer.Alive() check picks up
-	// the dead m_stream_alive flag, returns, and the session's last
-	// shared_ptr ref drops, triggering destruction.
+	// Called by Listener::Stop from a foreign thread to cancel any in-flight
+	// Beast write. Posts the close onto the stream's own executor so it does not
+	// race the worker thread's last write -- asio::tcp::socket is NOT thread-safe
+	// outside its strand. Fire-and-forget: the worker's writer.Alive() check
+	// picks up the dead m_stream_alive flag and returns.
 	void RequestCancel()
 	{
 		// Atomic flip first so writer.Alive() observes the cancel
@@ -511,52 +454,39 @@ public:
 private:
 	void DoRead()
 	{
-		// Reset the parser each request — without it, calling DoRead a
-		// second time on the same stream blocks forever with a partial
-		// state. only reads one request, but leaving the reset
-		// in keeps the read loop forward-compatible if keep-alive is
-		// turned on later.
-		// Per-request, like the parser. m_answered decides which of the
-		// timeout timer and the read handler gets to answer; the rest
-		// describe how THIS request must be written and drained. All of
-		// them are latched today only because a connection serves one
-		// request -- the moment the keep-alive path above is turned on,
-		// a stale m_answered drops every later request, a stale
-		// m_drain_before_close makes an ordinary response drain, a
-		// stale m_head_probe_chunked mislabels its framing, and a
-		// stale m_drained shortens the next drain budget. Reset them
-		// together so the set cannot drift apart again.
+		// Reset the parser each request -- without it, calling DoRead a second time
+		// on the same stream blocks forever with a partial state.
+		//
+		// The flags below are per-request too. m_answered decides which of the
+		// timeout timer and the read handler gets to answer; the rest describe how
+		// THIS request must be written and drained. All are latched today only
+		// because a connection serves one request -- turn keep-alive on and a
+		// stale m_answered drops every later request, a stale m_drain_before_close
+		// makes an ordinary response drain, a stale m_head_probe_chunked mislabels
+		// its framing. Reset them together so the set cannot drift apart.
 		m_answered.store(false, std::memory_order_relaxed);
 		m_head_only = false;
 		m_head_probe_chunked = false;
 		m_drain_before_close = false;
 		m_drained = 0;
 		m_parser.emplace();
-		// 1 MiB request cap — bigger than any sensible REST POST body
-		// (login JSON is ~64 bytes, etc.) but well under "someone is
-		// trying to exhaust memory by upload-pumping us".
+		// 1 MiB request cap -- bigger than any sensible REST POST body but well
+		// under "someone is trying to exhaust memory by upload-pumping us".
 		m_parser->body_limit(1024 * 1024);
-		// 16 KiB header cap. Beast's default header_limit varies
-		// across versions (8 KiB in current upstream, larger on
-		// older releases). A drip-feed attacker who slowly streams
-		// header lines can otherwise grow the flat_buffer until the
-		// 10 s read timeout catches them — but that's 10 s × pool
-		// of concurrent peers. Cap headers explicitly so the
-		// per-peer memory ceiling is fixed regardless of upstream
-		// defaults: 16 KiB is well over any legitimate request
-		// (Authorization + a few Accept headers is < 2 KiB) and
-		// catches the drip-feed within ~1 KiB instead of ~MB.
+		// 16 KiB header cap. Beast's default header_limit varies across versions,
+		// and a drip-feed attacker who slowly streams header lines can otherwise
+		// grow the flat_buffer until the read timeout catches them -- which is that
+		// timeout times the pool of concurrent peers. Capping explicitly fixes the
+		// per-peer memory ceiling regardless of upstream defaults.
 		m_parser->header_limit(kMaxHeaderBytes);
-		// 10 s read budget. amuleapi runs against localhost/LAN; a
-		// real client never takes 10 s to send a 1 KiB request.
+		// 10 s read budget. amuleapi runs against localhost/LAN; a real client
+		// never takes 10 s to send a 1 KiB request.
 		//
-		// Two timers, deliberately. beast::tcp_stream's own expiry
-		// CLOSES the socket, so by the time the read handler sees
-		// beast::error::timeout there is nothing left to answer on --
-		// which is why a stalled request used to look identical to a
-		// crashed daemon. Our own timer fires first and gets to send a
-		// 408; the stream's expiry stays as the hard backstop for the
-		// case where writing that 408 also stalls.
+		// Two timers, deliberately. beast::tcp_stream's own expiry CLOSES the
+		// socket, so by the time the read handler sees beast::error::timeout there
+		// is nothing left to answer on -- which is why a stalled request used to
+		// look identical to a crashed daemon. Our own timer fires first and sends
+		// a 408; the stream's expiry stays as the hard backstop.
 		m_stream.expires_after(std::chrono::seconds(20));
 		m_request_timer.expires_after(std::chrono::seconds(10));
 		{
@@ -568,22 +498,17 @@ private:
 					return;
 				if (self->m_answered.exchange(true))
 					return;
-				// Same method recovery as the limit paths: this
-				// path never reaches Dispatch(), where
-				// m_head_only is normally set, so without it a
-				// HEAD drip-feeding its headers gets the 408
-				// envelope as content.
+				// Same method recovery as the limit paths: this path never reaches
+				// Dispatch(), where m_head_only is normally set, so without it a HEAD
+				// drip-feeding its headers gets the 408 envelope as content.
 				if (self->m_parser->get().method() == http::verb::head) {
 					self->m_head_only = true;
 				}
-				// No drain here: http::async_read is still
-				// outstanding on this socket, and a second
-				// read alongside it is an overlapping read.
-				// Retire it instead -- writing the envelope
-				// does not, and a peer that ignores the FIN
-				// would otherwise pin this Session and its fd
-				// until the stream backstop, which is twice
-				// the budget the single timer used to enforce.
+				// No drain here: http::async_read is still outstanding on this
+				// socket, and a second read alongside it is an overlapping read.
+				// Retire it instead -- a peer that ignores the FIN would otherwise
+				// pin this Session and its fd until the stream backstop, twice the
+				// budget the single timer used to enforce.
 				{
 					beast::error_code cancel_ec;
 					self->m_stream.socket().cancel(cancel_ec);
@@ -610,25 +535,18 @@ private:
 					return;
 				}
 				if (ec) {
-					// Recover the method from whatever the parser
-					// managed to read before it gave up. Dispatch()
-					// is where m_head_only is normally set and these
-					// paths never reach it, so without this a HEAD
-					// rejected at the body or header cap answers with
-					// the error envelope as content -- the exact
-					// violation this commit removes everywhere else.
+					// Recover the method from whatever the parser managed to read
+					// before it gave up. Dispatch() is where m_head_only is normally
+					// set and these paths never reach it, so without this a HEAD
+					// rejected at the body or header cap answers with the envelope.
 					if (self->m_parser->get().method() == http::verb::head) {
 						self->m_head_only = true;
 					}
-					// Three of these are limits WE imposed, and a
-					// caller cannot tell a silent close from "daemon
-					// crashed" or "firewall ate it" — every other
-					// rejection on this surface is a typed JSON
-					// envelope, so answer these the same way before
-					// closing. Any other read error (peer vanished,
-					// framing garbage) stays quiet: there is nobody
-					// left to tell, and health-check probes would
-					// otherwise cost a log line per connection.
+					// Three of these are limits WE imposed, and a caller cannot tell a
+					// silent close from "daemon crashed" -- every other rejection on this
+					// surface is a typed JSON envelope, so answer these the same way
+					// before closing. Any other read error stays quiet: there is nobody
+					// left to tell, and probes would cost a log line per connection.
 					if (ec == http::error::body_limit) {
 						self->WriteAndClose(413,
 							"payload_too_large",
@@ -636,10 +554,8 @@ private:
 							/*drain=*/true);
 						return;
 					}
-					// buffer_overflow is the same condition seen
-					// from the buffer's side: whichever of the two
-					// binds first, the caller sent more header than
-					// we accept.
+					// buffer_overflow is the same condition seen from the buffer's side:
+					// whichever binds first, the caller sent more header than we accept.
 					if (ec == http::error::header_limit ||
 						ec == http::error::buffer_overflow) {
 						self->WriteAndClose(431,
@@ -666,20 +582,16 @@ private:
 		for (const auto &h : req) {
 			r.headers.emplace(std::string(h.name_string()), std::string(h.value()));
 		}
-		// Content-Encoding negotiation is per-request state, not per-
-		// response. Sample once here so both the regular WriteResponse
-		// path and the streaming SocketWriter see the same decision;
-		// the header can't legally change between the two.
+		// Content-Encoding negotiation is per-request state, not per-response.
+		// Sample once here so both WriteResponse and the streaming SocketWriter
+		// see the same decision; the header cannot legally change between them.
 		m_accepts_gzip = AcceptsGzip(std::string(req[http::field::accept_encoding]));
 		// HEAD is answered with the GET headers and no content. Recorded
 		// here because WriteResponse runs after the parser has moved on.
 		m_head_only = (r.method == "HEAD");
-		// Remote endpoint for rate-limiting. `.address()` returns a
-		// boost::asio::ip::address which `.to_string()`-es to the
-		// canonical IPv4 / IPv6 form ("192.0.2.1", "::1", "fe80::%lo0"...).
-		// Wrapped in an error_code overload so a half-closed socket
-		// doesn't throw — empty `remote_addr` falls through to "no
-		// per-IP bucket" in the rate limiter, which is the safe default.
+		// Remote endpoint for rate-limiting. Wrapped in an error_code overload so
+		// a half-closed socket does not throw -- an empty `remote_addr` falls
+		// through to "no per-IP bucket", which is the safe default.
 		{
 			beast::error_code ec;
 			const auto ep = m_stream.socket().remote_endpoint(ec);
@@ -687,22 +599,18 @@ private:
 				r.remote_addr = ep.address().to_string();
 		}
 
-		// streaming dispatch. The streaming_resolver is
-		// invoked synchronously and short-circuits the standard
-		// request→response→close path when it returns true.
+		// Streaming dispatch. The streaming_resolver is invoked synchronously and
+		// short-circuits the standard request/response/close path when it returns true.
 		if (m_streaming_resolver && m_streaming_handler && m_streaming_resolver(r)) {
 			DispatchStreaming(std::move(r));
 			return;
 		}
 
-		// Run the handler on the worker pool, NOT the io_context thread, so
-		// a handler that blocks (a synchronous EC roundtrip stalled up to
-		// the EC read timeout) can never freeze accept or other sessions.
-		// Disarm the read timeout first: the handler may legitimately take
-		// up to the EC read-timeout budget, and the 10 s read timer would
-		// otherwise close the socket out from under it. The response is
-		// posted back to the session strand (m_stream's executor) so all
-		// socket I/O stays on the io_context thread.
+		// Run the handler on the worker pool, NOT the io_context thread, so a
+		// handler that blocks can never freeze accept or other sessions. Disarm the
+		// read timeout first: the handler may legitimately take up to the EC
+		// read-timeout budget. The response is posted back to the session strand
+		// (m_stream's executor) so all socket I/O stays on the io_context thread.
 		m_stream.expires_never();
 		auto self = shared_from_this();
 		auto reqp = std::make_shared<CHttpServer::Request>(std::move(r));
@@ -711,23 +619,18 @@ private:
 			try {
 				resp = self->m_handler(*reqp);
 			} catch (const std::exception &e) {
-				// Handler exceptions become 500s; body shape matches the
-				// rest of the error contract.
-				//
-				// Info-disclosure: e.what() can carry caller-supplied
-				// bytes (picojson echoes the offending input character;
-				// a future header-driven throw could reflect
-				// Authorization or Cookie fragments). Keep the body
-				// generic; log detail to stderr.
+				// Handler exceptions become 500s; body shape matches the rest of the
+				// error contract. e.what() can carry caller-supplied bytes (picojson
+				// echoes the offending input character; a future header-driven throw
+				// could reflect Authorization fragments), so keep the body generic
+				// and log the detail to stderr.
 				std::cerr << "amuleapi: 500 from handler: " << e.what() << "\n";
 				resp.status = 500;
 				resp.content_type = "application/json";
 				resp.body = "{\"error\":{\"code\":\"internal_error\","
 					    "\"message\":\"internal server error\"}}";
-				// The dispatcher's CORS pass died with the handler,
-				// so stamp it here: a cross-origin client should be
-				// able to read a 500 for the same reason it can read
-				// a 4xx.
+				// The dispatcher's CORS pass died with the handler, so stamp it here: a
+				// cross-origin client should be able to read a 500 as it can a 4xx.
 				if (self->m_cors_stamper) {
 					self->m_cors_stamper(
 						resp.headers, self->FindHeaderCaseInsensitiveRaw("Origin"));
@@ -739,22 +642,15 @@ private:
 		});
 	}
 
-	// Streaming path. Writes the response head, then spawns a worker
-	// thread for the streaming handler. Session stays alive across
-	// the worker via the `shared_from_this()` capture; when the
-	// worker exits, the lambda releases the last ref and Session
-	// destructs (joining a thread that has already exited, a no-op).
-	//
-	// Short 503 for concurrent-session cap + other exhaustion paths.
+	// Short 503 for the concurrent-session cap and other exhaustion paths.
 	void WriteCapRefusal()
 	{
 		CHttpServer::Response refused;
 		refused.status = 503;
 		refused.content_type = "application/json";
 		refused.headers["Retry-After"] = "10";
-		// Transport-built, so the dispatcher never sees it. Without the
-		// stamp this is one more reply a cross-origin client cannot
-		// read -- the same defect just fixed for 408/413/431.
+		// Transport-built, so the dispatcher never sees it. Without the stamp this
+		// is one more reply a cross-origin client cannot read.
 		if (m_cors_stamper) {
 			m_cors_stamper(refused.headers, FindHeaderCaseInsensitiveRaw("Origin"));
 		}
@@ -764,16 +660,17 @@ private:
 		WriteResponse(std::move(refused));
 	}
 
+	// Streaming path. Writes the response head, then spawns a worker thread for
+	// the streaming handler. The Session stays alive across the worker via the
+	// `shared_from_this()` capture; when the worker exits, the lambda releases
+	// the last ref and the Session destructs.
 	void DispatchStreaming(CHttpServer::Request r)
 	{
-		// Preflight runs synchronously on the I/O thread BEFORE the
-		// slot is claimed and BEFORE a worker thread is spawned. If
-		// it rejects (returns a Response), unauthenticated peers
-		// can't tie up a streaming slot for the read-timeout window:
-		// 32 unauth TCP holds × 10 s read timeout = a 320-session-
-		// second pool stall. With preflight, an unauth request
-		// burns one short HTTP exchange and goes away. Empty
-		// preflight (default) preserves the prior contract.
+		// Preflight runs synchronously on the I/O thread BEFORE the slot is claimed
+		// and BEFORE a worker thread is spawned. Without it, unauthenticated peers
+		// can tie up a streaming slot for the read-timeout window: 32 unauth TCP
+		// holds x 10 s = a 320-session-second pool stall. Empty preflight (the
+		// default) preserves the prior contract.
 		if (m_streaming_preflight) {
 			boost::optional<CHttpServer::Response> rej = m_streaming_preflight(r);
 			if (rej) {
@@ -782,10 +679,9 @@ private:
 			}
 		}
 
-		// Acquire a session slot before doing any thread-spawn or
-		// long-lived work. fetch_add returns the OLD value, so we
-		// hold the slot iff that old value was strictly below the
-		// cap. Otherwise we roll back and refuse the connection.
+		// Acquire a session slot before any thread-spawn or long-lived work.
+		// fetch_add returns the OLD value, so the slot is held iff that value was
+		// strictly below the cap; otherwise roll back and refuse.
 		const int prior_count = g_streaming_session_count.fetch_add(1, std::memory_order_acq_rel);
 		if (prior_count >= kMaxConcurrentStreamingSessions) {
 			g_streaming_session_count.fetch_sub(1, std::memory_order_acq_rel);
@@ -797,67 +693,51 @@ private:
 		m_stream.expires_never();
 		m_stream_alive.store(true, std::memory_order_release);
 
-		// Register the session so Listener::Stop can cancel its
-		// socket on shutdown. A worker blocked inside a synchronous
-		// Beast write to a slow peer otherwise pins the daemon at
-		// exit — the io_context.stop() doesn't unblock a write
-		// already in flight. Closing the underlying socket from
-		// outside makes the write fail with EPIPE and the worker
-		// returns to its writer.Alive() check, exits, releases the
-		// last ref.
+		// Register the session so Listener::Stop can cancel its socket on shutdown.
+		// A worker blocked inside a synchronous Beast write to a slow peer
+		// otherwise pins the daemon at exit -- io_context.stop() does not unblock
+		// a write already in flight. Closing the socket from outside makes the
+		// write fail with EPIPE and the worker returns to its Alive() check.
 		{
 			std::lock_guard<std::mutex> g(g_live_streams_mu);
 			g_live_streams.emplace_back(shared_from_this());
 		}
 
-		// Spawn the worker thread that runs the streaming handler.
-		// The worker captures `self` so the Session stays alive
-		// across its run, and references to the head out-params (held
-		// on the heap so the SocketWriter can read them at first-
-		// write time).
+		// Spawn the worker thread that runs the streaming handler. It captures
+		// `self` so the Session stays alive across its run, plus references to the
+		// head out-params (heap-held so the SocketWriter can read them later).
 		auto handler = m_streaming_handler;
 		auto self = shared_from_this();
-		// Head data — owned by the worker thread, referenced by the
-		// SocketWriter (via SocketWriter::HeadData). Defaults set
-		// here; handler can overwrite before calling writer.Write
-		// the first time.
+		// Head data -- owned by the worker thread, referenced by the SocketWriter
+		// (via SocketWriter::HeadData). Defaults set here; the handler can
+		// overwrite before calling writer.Write the first time.
 		auto head = std::make_shared<SocketWriter::HeadData>();
 		head->headers["Cache-Control"] = "no-cache";
-		// Not keep-alive. DoClose() writes the chunked terminator and
-		// then shuts the socket down, so a client that reads the stream
-		// to its clean end and returns the socket to a pool fails its
-		// next request on it -- the same reason every ordinary response
-		// says close. It also kept the HEAD probe, which does say
-		// close, contradicting the GET it stands for.
+		// Not keep-alive. DoClose() writes the chunked terminator and then shuts
+		// the socket down, so a client that reads the stream to its clean end and
+		// returns the socket to a pool fails its next request on it -- the same
+		// reason every ordinary response says close.
 		head->headers["Connection"] = "close";
-		// nginx (and many other reverse proxies) buffer response
-		// bodies by default when they detect chunked-transfer +
-		// text-ish content, which stalls SSE delivery entirely — the
-		// operator sees "events show up in bursts every N seconds"
-		// with N depending on how large the proxy's default buffer
-		// is. `X-Accel-Buffering: no` is nginx's opt-out (also
-		// respected by ingress-nginx / OpenResty); harmless on
-		// backends that don't recognise it. Emitted regardless of
-		// gzip status because the buffering problem is orthogonal.
+		// nginx and many other reverse proxies buffer response bodies by default
+		// when they detect chunked-transfer + text-ish content, which stalls SSE
+		// delivery entirely. `X-Accel-Buffering: no` is nginx's opt-out (also
+		// respected by ingress-nginx / OpenResty) and harmless elsewhere. Emitted
+		// regardless of gzip status because the buffering problem is orthogonal.
 		head->headers["X-Accel-Buffering"] = "no";
 
 		auto writer = std::make_shared<SocketWriter>(self, head, m_accepts_gzip);
 
-		// One std::thread per streaming session — cheap at expected
-		// scale (1–5 concurrent SSE subscribers) and keeps the drain
-		// synchronous so `since_id` ordering is trivial.
+		// One std::thread per streaming session -- cheap at expected scale and
+		// keeps the drain synchronous so `since_id` ordering is trivial.
 		//
-		// **The default `BindAddress=127.0.0.1` is load-bearing.**
-		// Non-loopback bind + unauth peer = thread-per-connection DoS
-		// amplifier. PreflightEvents (auth before slot claim, before
-		// thread spawn) bounds pre-auth cost to one HTTP exchange.
+		// The default BindAddress=127.0.0.1 is load-bearing: non-loopback bind +
+		// unauth peer = thread-per-connection DoS amplifier. PreflightEvents
+		// bounds pre-auth cost to one HTTP exchange.
 		m_stream_worker = std::thread([self, handler, writer, head, r = std::move(r)]() mutable {
-			// RAII guard: tip the worker-exited flag on EVERY exit
-			// path out of this lambda, including a future refactor
-			// that adds an early `return` after the catch block.
-			// The Session destructor's std::abort() guard only
-			// fires if this flag is true, so missing the flip on
-			// some path would tear down a still-running thread.
+			// RAII guard: tip the worker-exited flag on EVERY exit path out of this
+			// lambda, including a future refactor that adds an early return. The
+			// Session destructor's std::abort() guard only fires if this flag is
+			// true, so missing the flip would tear down a still-running thread.
 			struct WorkerExitMarker
 			{
 				std::shared_ptr<Session> s;
@@ -872,26 +752,22 @@ private:
 				// Streaming handler exceptions are silent — close
 				// quietly.
 			}
-			// If the handler returned without writing anything (e.g.
-			// auth-rejected on a HEAD probe), still emit the head so
-			// the client sees the right status code.
+			// If the handler returned without writing anything (auth-rejected on a
+			// HEAD probe, say), still emit the head so the client sees the status.
 			writer->EnsureHeadWritten();
-			// Emit gzip trailer (Z_FINISH) if compressing, BEFORE
-			// DoClose writes the chunked-terminator. Otherwise the
-			// browser's gzip decoder sees a truncated stream at
-			// end-of-response and raises a decoding error.
+			// Emit the gzip trailer (Z_FINISH) if compressing, BEFORE DoClose writes
+			// the chunked terminator -- otherwise the browser's gzip decoder sees a
+			// truncated stream and raises a decoding error.
 			writer->Finalize();
 			self->DoClose();
-			// `marker` runs here, flipping m_worker_exited and
-			// dropping `self` only AFTER the flag is set — so the
-			// dtor's check observes the post-exit state.
+			// `marker` runs here, flipping m_worker_exited and dropping `self` only
+			// AFTER the flag is set, so the dtor's check observes the post-exit state.
 		});
 	}
 
-	// Per-streaming-session Writer that marshals writes onto the
-	// socket. Defers writing the HTTP response head until the first
-	// Write call — that's when the streaming handler has finalised
-	// status / content_type / headers via the out-params we pass it.
+	// Per-streaming-session Writer that marshals writes onto the socket. Defers
+	// writing the HTTP response head until the first Write call -- that is when
+	// the handler has finalised status / content_type / headers.
 	class SocketWriter : public CHttpServer::Writer
 	{
 	public:
@@ -920,28 +796,18 @@ private:
 				return false;
 			}
 
-			// SSE wire shape uses chunked transfer encoding; each
-			// "chunk" written here is a single HTTP/1.1 chunk frame:
-			//  <hex-size-of-chunk>\r\n<chunk-bytes>\r\n
-			//
-			// Zero-length chunks would terminate the message (per
-			// RFC 7230 §4.1) so we skip them — the heartbeat path
-			// always passes at least ": keepalive\n\n" anyway.
+			// SSE uses chunked transfer encoding; each "chunk" written here is a
+			// single HTTP/1.1 chunk frame: <hex-size>\r\n<bytes>\r\n. Zero-length
+			// chunks would terminate the message (RFC 7230 4.1) so they are skipped
+			// -- the heartbeat path always passes at least ": keepalive\n\n" anyway.
 			if (chunk.empty()) {
 				return true;
 			}
-			// gzip path: run the SSE bytes through the persistent
-			// deflate stream with Z_SYNC_FLUSH so the block is
-			// emitted immediately (browser sees the event live) and
-			// the dictionary carries across events (repeated JSON
-			// keys / hash prefixes compress to a few bits). On a
-			// deflate error we fall through to the uncompressed
-			// path for THIS chunk — but zlib doesn't recover its
-			// stream state after an error mid-session, so future
-			// chunks would also be broken; we tear the session
-			// down by returning false rather than silently emit a
-			// mid-stream encoding mismatch that the browser would
-			// abort on anyway.
+			// gzip path: run the SSE bytes through the persistent deflate stream with
+			// Z_SYNC_FLUSH so the block is emitted immediately and the dictionary
+			// carries across events. zlib does not recover its stream state after an
+			// error mid-session, so a deflate failure tears the session down rather
+			// than emitting a mid-stream encoding mismatch the browser would abort on.
 			const std::string *payload = &chunk;
 			std::string compressed;
 			if (m_wants_gzip) {
@@ -968,12 +834,10 @@ private:
 			return true;
 		}
 
-		// Emit any Z_FINISH trailer bytes (gzip CRC + length) as a
-		// final chunked frame. Called from the SSE worker's exit
-		// path BEFORE DoClose so the browser sees a well-terminated
-		// gzip stream when it expected one. Safe on non-gzip
-		// sessions (no-op), safe to call multiple times (idempotent
-		// via SseGzipStream::m_finished).
+		// Emit any Z_FINISH trailer bytes (gzip CRC + length) as a final chunked
+		// frame. Called from the SSE worker's exit path BEFORE DoClose so the
+		// browser sees a well-terminated gzip stream. No-op on non-gzip sessions,
+		// idempotent via SseGzipStream::m_finished.
 		void Finalize()
 		{
 			if (!m_wants_gzip) {
@@ -1003,28 +867,23 @@ private:
 			return m_session->m_stream_alive.load(std::memory_order_acquire);
 		}
 
-		// Idempotent: writes the head once, on first call. Returns
-		// false if the underlying socket write failed.
+		// Idempotent: writes the head once, on first call. Returns false if the
+		// underlying socket write failed.
 		//
-		// We build the head as raw bytes rather than going through
-		// Beast's response<empty_body> + prepare_payload() — that
-		// path emits `Content-Length: 0` and silently strips our
-		// `Transfer-Encoding: chunked`, which forecloses the
-		// streaming body that the SSE channel needs. Direct
-		// string-formatted head dodges the conflict and is short
-		// enough to audit at a glance.
+		// The head is built as raw bytes rather than through Beast's
+		// response<empty_body> + prepare_payload(): that path emits
+		// `Content-Length: 0` and silently strips `Transfer-Encoding: chunked`,
+		// which forecloses the streaming body the SSE channel needs.
 		bool EnsureHeadWritten()
 		{
 			if (m_head_written.exchange(true, std::memory_order_acq_rel)) {
 				return true;
 			}
-			// Late gzip init + header injection. Deferred to here so
-			// a) SocketWriter's ctor stays trivial, and b) the
-			// handler had a chance to override head->headers between
-			// construction and first Write. If deflateInit2 itself
-			// fails we downgrade to identity encoding for this
-			// session rather than 500 the whole SSE — the head
-			// hasn't gone out yet, so it's safe to erase the flag.
+			// Late gzip init + header injection, deferred to here so the ctor stays
+			// trivial and the handler had a chance to override head->headers between
+			// construction and first Write. If deflateInit2 itself fails we downgrade
+			// to identity encoding for this session rather than 500 the whole SSE --
+			// the head has not gone out yet, so erasing the flag is safe.
 			if (m_wants_gzip) {
 				if (m_gzip.Init()) {
 					m_head->headers["Content-Encoding"] = "gzip";
@@ -1032,14 +891,11 @@ private:
 					m_wants_gzip = false;
 				}
 			}
-			// Outside the gzip branch on purpose. Vary describes what
-			// the RESPONSE VARIES ON, not what this particular response
-			// was encoded as, so it belongs on the identity reply too --
-			// otherwise a cache keyed on the non-gzip answer serves it
-			// to a client that asked for gzip. WriteResponse adds it
-			// unconditionally, so leaving it inside the branch also put
-			// a plain SSE GET at odds with the HEAD probe for the same
-			// URL, which goes through that writer.
+			// Outside the gzip branch on purpose. Vary describes what the RESPONSE
+			// VARIES ON, not what this particular response was encoded as, so it
+			// belongs on the identity reply too -- otherwise a cache keyed on the
+			// non-gzip answer serves it to a client that asked for gzip. WriteResponse
+			// adds it unconditionally, so the HEAD probe would otherwise disagree.
 			AppendHeaderToken(m_head->headers, "Vary", "Accept-Encoding");
 			std::ostringstream head;
 			head << "HTTP/1.1 " << m_head->status << " ";
@@ -1063,13 +919,11 @@ private:
 			head << "\r\n";
 			head << "Server: amuleapi\r\n";
 			head << "Content-Type: " << m_head->content_type << "\r\n";
-			// Chunked when the body will actually stream — i.e.
-			// success path. Error responses (401 / 403) are single-
-			// shot: the handler emits one chunk-as-error-body then
-			// returns, and we'd rather close-on-FIN than dangle a
-			// chunked half-message. For those we omit
-			// Transfer-Encoding so the response simply terminates
-			// at connection close.
+			// Chunked only when the body will actually stream, i.e. the success path.
+			// Error responses (401 / 403) are single-shot: the handler emits one
+			// chunk-as-error-body then returns, and close-on-FIN beats dangling a
+			// chunked half-message, so Transfer-Encoding is omitted for those and the
+			// response simply terminates at connection close.
 			const bool chunked = (m_head->status >= 200 && m_head->status < 300);
 			if (chunked) {
 				head << "Transfer-Encoding: chunked\r\n";
@@ -1094,21 +948,18 @@ private:
 		std::shared_ptr<Session> m_session;
 		std::shared_ptr<HeadData> m_head;
 		std::atomic<bool> m_head_written{ false };
-		// Sampled once at construction from the request's Accept-
-		// Encoding. Cleared at head-write time if deflateInit2
-		// fails, so subsequent Write calls fall through to the
-		// identity path without leaking a partially-init'd stream.
+		// Sampled once at construction from the request's Accept-Encoding. Cleared
+		// at head-write time if deflateInit2 fails, so subsequent Write calls fall
+		// through to the identity path without leaking a partly-init'd stream.
 		bool m_wants_gzip;
 		SseGzipStream m_gzip;
 	};
 
-	// Typed error straight from the transport layer, for the read-side
-	// limits that never reach a handler. Hand-built rather than routed
-	// through the dispatcher's ErrorResponse: at this point the request
-	// was never parsed, so there is no route and no auth context.
-	// Origin off the parser rather than a parsed Request: on these paths
-	// the request never got far enough to build one. Returns "" when the
-	// header block never arrived, which the stamper treats as no-origin.
+	// Typed error straight from the transport layer, for the read-side limits
+	// that never reach a handler. Hand-built rather than routed through the
+	// dispatcher's ErrorResponse: at this point the request was never parsed, so
+	// there is no route and no auth context. Returns "" when the header block
+	// never arrived, which the stamper treats as no-origin.
 	std::string FindHeaderCaseInsensitiveRaw(const char *name) const
 	{
 		if (!m_parser) {
@@ -1125,6 +976,12 @@ private:
 		return std::string();
 	}
 
+	// `drain` only where the composed read has already completed. The size limits
+	// fire while the peer may still be writing, and closing with unread data
+	// queued lets the stack emit an RST that discards the response just written --
+	// the caller then sees a connection reset instead of the 413 explaining it.
+	// The timeout path is the opposite case: http::async_read is still outstanding
+	// there, and a second read on the same socket is an overlapping read.
 	void WriteAndClose(unsigned status, const char *code, const char *message, bool drain)
 	{
 		CHttpServer::Response r;
@@ -1132,50 +989,32 @@ private:
 		r.content_type = "application/json";
 		r.body = std::string("{\"error\":{\"code\":\"") + code + "\",\"message\":\"" + message +
 			 "\"}}";
-		// `drain` only where the composed read has already completed.
-		// The size limits fire while the peer may still be writing (a
-		// client that sends its whole body before reading anything is
-		// the normal case for a POST), and closing with unread data
-		// queued lets the stack emit an RST that discards the response
-		// just written -- the caller then sees a connection reset
-		// instead of the 413 explaining it. The timeout path is the
-		// opposite case: http::async_read is still outstanding there,
-		// and a second read on the same socket is an overlapping read,
-		// which asio forbids.
-		// The only replies on the surface built without a parsed request,
-		// so the dispatcher's CORS pass never sees them. Stamp here or a
-		// cross-origin browser client gets an opaque failure instead of
-		// the typed envelope the docs promise.
+		// The only replies on the surface built without a parsed request, so the
+		// dispatcher's CORS pass never sees them. Stamp here or a cross-origin
+		// browser client gets an opaque failure instead of the typed envelope.
 		if (m_cors_stamper) {
 			m_cors_stamper(r.headers, FindHeaderCaseInsensitiveRaw("Origin"));
 		}
 		m_drain_before_close = drain;
-		// Tell the peer not to reuse this connection. Without it a
-		// pooling client can read the error, keep the socket, and
-		// leave us parked in the drain read with nothing to collect.
+		// Tell the peer not to reuse this connection. Without it a pooling client
+		// can read the error, keep the socket, and park us in the drain read.
 		r.headers["Connection"] = "close";
 		WriteResponse(std::move(r));
 	}
 
-	// Read and discard whatever the peer is still sending, then close.
-	// Bounded three ways: the stream's expiry (which is why this reads
-	// through the stream rather than the socket), a byte cap, and the
-	// `Connection: close` the error carries.
-	// Arms the drain deadline and starts the loop. The deadline is set
-	// ONCE, here: expires_after inside the loop would re-arm on every
-	// read and bound only the gap between them, so a peer trickling a
-	// byte just under the limit apart could hold the Session and its fd
-	// until the byte cap -- effectively forever.
+	// Read and discard whatever the peer is still sending, then close. Bounded
+	// three ways: the stream's expiry (which is why this reads through the
+	// stream rather than the socket), a byte cap, and the `Connection: close`
+	// the error carries. The deadline is set ONCE, here: expires_after inside
+	// the loop would re-arm on every read and bound only the gap between them,
+	// so a peer trickling a byte just under the limit apart could hold the fd.
 	void StartDrainThenClose()
 	{
-		// Short budget of its own, not the request budget. The point of
-		// the drain is to collect what is ALREADY in flight so the
-		// close does not RST away the error we just wrote -- not to
-		// wait for a peer that has finished talking. A client that sent
-		// an oversized header has said everything it intends to and is
-		// now waiting on us, so draining to EOF would have both sides
-		// waiting until the request expiry broke the tie, which reads
-		// to the caller as a hang rather than a 431.
+		// Short budget of its own, not the request budget. The point of the drain
+		// is to collect what is ALREADY in flight so the close does not RST away
+		// the error just written -- not to wait for a peer that has finished
+		// talking. Draining to EOF would leave both sides waiting until the
+		// request expiry broke the tie, which reads to the caller as a hang.
 		m_stream.expires_after(std::chrono::seconds(1));
 		DrainThenClose();
 	}
@@ -1183,10 +1022,9 @@ private:
 	void DrainThenClose()
 	{
 		auto self = shared_from_this();
-		// Through the beast stream, not the raw socket: the raw socket
-		// ignores the stream's expiry, so a peer that neither sends nor
-		// closes would park this read forever and leak the Session with
-		// its fd.
+		// Through the beast stream, not the raw socket: the raw socket ignores the
+		// stream's expiry, so a peer that neither sends nor closes would park this
+		// read forever and leak the Session with its fd.
 		m_stream.async_read_some(
 			m_drain_buffer.prepare(4096), [self](beast::error_code ec, std::size_t n) {
 				self->m_drained += n;
@@ -1202,14 +1040,10 @@ private:
 	}
 
 	// Transport-built error reply for the file path. Kept separate from the
-	// handler's own error shapes because these are written after the handler
-	// has already returned a perfectly good response, and the body must still
-	// match the error contract the rest of the surface uses.
-	//
-	// The CORS stamp matters for the same reason it does on 408/413/431: the
-	// dispatcher's pass never ran on a reply the transport invented, and
-	// without it these are the only answers on the surface a cross-origin
-	// browser client sees as an opaque failure instead of a typed envelope.
+	// handler's own error shapes because these are written after the handler has
+	// already returned a perfectly good response. The CORS stamp matters for the
+	// same reason it does on 408/413/431: the dispatcher's pass never ran on a
+	// reply the transport invented.
 	void WriteFileTransportError(unsigned status, const char *code, const char *message, bool retry_after)
 	{
 		CHttpServer::Response err;
@@ -1230,25 +1064,19 @@ private:
 
 	// File-backed response: serialise a bounded byte window straight off disk
 	// instead of out of resp.body. Split from WriteResponse rather than folded
-	// into it because almost none of that function applies -- there is no body
-	// in memory to deflate, nothing to reconcile an ETag against, and the
-	// message type differs, which decides the serializer at compile time.
-	//
-	// Everything else about the reply is deliberately identical to the normal
-	// path: same Server header, same Connection: close default, same handler
-	// header pass, same Vary, same close-after-write.
+	// into it because almost none of that function applies -- no body in memory
+	// to deflate, nothing to reconcile an ETag against, and a different message
+	// type, which decides the serializer at compile time. Everything else about
+	// the reply is deliberately identical to the normal path.
 	void WriteFileResponse(CHttpServer::Response &&resp)
 	{
-		// A HEAD is exempt from the concurrency budget. The cap exists to
-		// bound concurrent BYTES off the disk and onto the NIC, and a HEAD
-		// moves none: the serializer runs in split mode, so writer::get is
-		// never called and the file is opened and seeked but never read.
-		// Spending a download slot on a metadata probe would let a burst of
-		// HEADs lock out the transfers the cap is there to protect.
+		// A HEAD is exempt from the concurrency budget. The cap bounds concurrent
+		// BYTES off the disk and onto the NIC, and a HEAD moves none: the
+		// serializer runs in split mode, so the file is opened and seeked but
+		// never read. A burst of HEADs must not lock out real transfers.
 		if (!m_head_only) {
-			// Claim the slot before opening anything. fetch_add returns
-			// the OLD value, so the slot is ours iff that value was
-			// strictly below the cap; otherwise roll back and refuse.
+			// Claim the slot before opening anything. fetch_add returns the OLD
+			// value, so the slot is ours iff that value was below the cap.
 			const int prior = g_file_response_count.fetch_add(1, std::memory_order_acq_rel);
 			if (prior >= g_max_concurrent_file_responses.load(std::memory_order_relaxed)) {
 				g_file_response_count.fetch_sub(1, std::memory_order_acq_rel);
@@ -1258,9 +1086,8 @@ private:
 					true);
 				return;
 			}
-			// From here on the destructor owns the release. Set the flag
-			// BEFORE anything that can fail, so an early return below
-			// still gives the slot back.
+			// From here on the destructor owns the release. Set the flag BEFORE
+			// anything that can fail, so an early return still gives the slot back.
 			m_file_slot_held = true;
 		}
 
@@ -1268,19 +1095,16 @@ private:
 		auto &out = *m_file_response;
 
 		// The handler already resolved and containment-checked the path; the
-		// transport opens it blindly. Both failures below are 500s and not
-		// something more specific on purpose -- a 404 here would mean the
-		// handler said yes to a path that then vanished, which is a race or a
-		// bug, not a client error. They are still safe to answer, because
-		// nothing has been written to the socket yet: the headers are
-		// committed at the first async_write below, not before.
+		// transport opens it blindly. Both failures below are 500s on purpose -- a
+		// 404 here would mean the handler said yes to a path that then vanished,
+		// which is a race or a bug. They are still safe to answer, because the
+		// headers are committed at the first async_write below, not before.
 		beast::error_code ec;
 		out.body().Open(resp.file->fs_path.c_str(), ec);
 		if (!ec) {
-			// Rejects, rather than clamps, a window that does not fit the
-			// file. The handler has usually already put a Content-Range on
-			// the response describing exactly this window, and shipping a
-			// different one would make the reply contradict itself.
+			// Rejects, rather than clamps, a window that does not fit the file. The
+			// handler has usually already put a Content-Range describing exactly this
+			// window on the response, and shipping a different one would contradict it.
 			out.body().SetWindow(resp.file->first, resp.file->last, ec);
 		}
 		if (ec) {
@@ -1290,11 +1114,10 @@ private:
 			return;
 		}
 
-		// Emitted even though a file response never varies by encoding: the
-		// same URL can legitimately answer from the buffered path too (a 304,
-		// a 416, an error envelope), and those DO vary. An intermediary that
-		// cached this one without the dimension would then serve it in place
-		// of a form that differs.
+		// Emitted even though a file response never varies by encoding: the same
+		// URL can legitimately answer from the buffered path too (a 304, a 416, an
+		// error envelope), and those DO vary. An intermediary that cached this one
+		// without the dimension would serve it in place of a form that differs.
 		AppendHeaderToken(resp.headers, "Vary", "Accept-Encoding");
 
 		out.version(11);
@@ -1306,16 +1129,12 @@ private:
 			out.set(http::field::connection, "close");
 		}
 		// Same opt-out the SSE head sets, for the mirror-image reason. nginx
-		// buffers proxied responses by default and spools anything larger
-		// than `proxy_buffers` to disk, up to `proxy_max_temp_file_size` --
-		// 1 GB out of the box. On this path that means the proxy writes a
-		// second copy of the file to its own disk before the client sees the
-		// first byte, which both delays the response and moves the I/O cost
-		// this transport was built to avoid onto the proxy host. Set here
-		// rather than by the handler because it is a property of streaming a
-		// large body off disk, not of one route: any future file-serving
-		// endpoint inherits it. Written before the handler's own header pass
-		// below, so a handler that has a reason to buffer can still override.
+		// buffers proxied responses by default and spools anything larger than
+		// `proxy_buffers` to disk, up to `proxy_max_temp_file_size` -- 1 GB out of
+		// the box -- so the proxy writes a second copy of the file to its own disk
+		// before the client sees the first byte. Set here rather than by the
+		// handler because it is a property of streaming a large body off disk, and
+		// written before the handler's header pass so a handler can override.
 		out.set("X-Accel-Buffering", "no");
 		if (!resp.content_type.empty()) {
 			out.set(http::field::content_type, resp.content_type);
@@ -1323,37 +1142,29 @@ private:
 		for (const auto &h : resp.headers) {
 			out.set(h.first, h.second);
 		}
-		// Content-Length comes from RangeFileBody::size, i.e. the WINDOW
-		// length rather than the file length or the bytes-to-EOF that stock
-		// file_body would have reported. This is the number a HEAD has to
-		// answer with as well, and it gets it from the same call.
+		// Content-Length comes from RangeFileBody::size, i.e. the WINDOW length
+		// rather than the file length or the bytes-to-EOF stock file_body would
+		// have reported. A HEAD has to answer with the same number, from the same call.
 		out.prepare_payload();
 
-		// The read timeout was disarmed in Dispatch (m_stream.expires_never()
-		// before the handler ran), and the body is NOT written back under it:
-		// a legitimate multi-GB download over a slow link takes far longer
-		// than the 20 s stream expiry, so a total deadline would kill exactly
-		// the transfers this endpoint exists for.
-		//
-		// What bounds a stall instead is kFileWriteIdleTimeout, re-armed by
-		// WriteFileChunk before every write attempt -- which is why the body
-		// goes out as a WriteFileChunk loop over async_write_some rather than
-		// as one async_write: a single async_write offers no per-chunk hook to
-		// re-arm from. See the constant for why a progress deadline is
-		// required here and why TCP does not supply one.
+		// The read timeout was disarmed in Dispatch, and the body is NOT written
+		// back under it: a legitimate multi-GB download over a slow link takes far
+		// longer than the 20 s stream expiry, so a total deadline would kill
+		// exactly the transfers this endpoint exists for. What bounds a stall
+		// instead is kFileWriteIdleTimeout, re-armed by WriteFileChunk before every
+		// write attempt -- which is why the body goes out as a WriteFileChunk loop
+		// over async_write_some: a single async_write offers no per-chunk hook.
 		auto self = shared_from_this();
 		m_file_serializer.emplace(out);
 		if (m_head_only) {
-			// RFC 9110 9.3.2 again: headers only, on any status. split(true)
-			// stops the serializer after the header, so writer::get never
-			// runs and not one byte of the file is read -- while
-			// Content-Length still reports what the GET would have sent,
-			// which is what 40-http-conformance.sh asserts.
+			// RFC 9110 9.3.2 again: headers only, on any status. split(true) stops the
+			// serializer after the header, so writer::get never runs and not one byte
+			// of the file is read -- while Content-Length still reports what the GET
+			// would have sent.
 			m_file_serializer->split(true);
-			// Same deadline on the header-only write. It is a few hundred
-			// bytes, but a peer that opens a connection, sends HEAD and
-			// then refuses to read holds a file-response slot just as
-			// firmly as one that stalls a GET.
+			// Same deadline on the header-only write. It is a few hundred bytes, but a
+			// peer that sends HEAD and then refuses to read holds a file-response slot
+			// just as firmly as one that stalls a GET.
 			m_stream.expires_after(kFileWriteIdleTimeout);
 			http::async_write_header(
 				m_stream, *m_file_serializer, [self](beast::error_code ec, std::size_t) {
@@ -1372,27 +1183,20 @@ private:
 	// One turn of the file-body write loop: re-arm the progress deadline, hand
 	// the serializer's next buffer to the socket, and come back for the rest.
 	//
-	// This is what `http::async_write` does internally, unrolled so the
-	// deadline can be re-armed between turns. async_write_some completes as
-	// soon as the socket accepts any bytes at all, so each turn is a real
-	// observation that the peer is still draining its receive window, and the
-	// deadline measures the gap between two such observations -- the definition
-	// of a progress deadline. A peer that stops reading never completes a turn,
-	// its expiry fires, beast::tcp_stream closes the socket underneath the
-	// pending write, the handler runs with beast::error::timeout, and the slot
-	// goes back with ~Session.
+	// This is what `http::async_write` does internally, unrolled so the deadline
+	// can be re-armed between turns. async_write_some completes as soon as the
+	// socket accepts any bytes at all, so each turn is a real observation that
+	// the peer is still draining its receive window.
 	void WriteFileChunk()
 	{
 		auto self = shared_from_this();
 		m_stream.expires_after(kFileWriteIdleTimeout);
 		http::async_write_some(
 			m_stream, *m_file_serializer, [self](beast::error_code ec, std::size_t) {
-				// `ec` discarded as on the buffered path: a peer that
-				// walked away mid-download is the normal end of a media
-				// request, not something to log -- and so is the timeout
-				// above, which is the same event with a slower peer. The
-				// slot this response holds is released by ~Session when
-				// `self` drops at the end of the chain.
+				// `ec` discarded as on the buffered path: a peer that walked away
+				// mid-download is the normal end of a media request, and so is the
+				// timeout above, which is the same event with a slower peer. The slot
+				// is released by ~Session when `self` drops at the end of the chain.
 				if (!ec && !self->m_file_serializer->is_done()) {
 					self->WriteFileChunk();
 					return;
@@ -1407,43 +1211,28 @@ private:
 
 	void WriteResponse(CHttpServer::Response &&resp)
 	{
-		// A file-backed response shares none of the machinery below: it must
-		// not be gzipped (deflating a byte range breaks the accounting its
-		// Content-Range describes, and shared content is normally already
-		// entropy-coded), and it has no in-memory body for the ETag
-		// reconciliation to measure. Branch before any of it runs, so the
-		// deflate path below cannot be reached with a body that is not there.
+		// A file-backed response shares none of the machinery below: it must not be
+		// gzipped (deflating a byte range breaks the accounting its Content-Range
+		// describes) and it has no in-memory body for the ETag reconciliation to
+		// measure. Branch before any of it runs.
 		if (resp.file) {
 			WriteFileResponse(std::move(resp));
 			return;
 		}
 
-		// Regular (non-streaming) response gzip encoding. Gated by:
-		//  * client Accept-Encoding contains gzip,
-		//  * body is at or above kGzipMinBodyBytes -- the bound is
-		//    inclusive; header overhead is a significant fraction of
-		//    anything smaller,
-		//  * handler didn't already set Content-Encoding (a future
-		//    pre-gzipped static asset path would use that hook),
-		//  * body isn't already entropy-coded (PNG flags, images and
-		//    fonts out of the static tree).
-		// deflate() fallback: on any zlib error we ship the original
-		// uncompressed body rather than 500 — better degraded than
-		// broken. Content-Length is set correctly by
-		// prepare_payload() based on the post-swap body.
+		// Regular (non-streaming) response gzip encoding. Gated on the client
+		// accepting gzip, the body being at or above kGzipMinBodyBytes (inclusive),
+		// the handler not having already set Content-Encoding, and the body not
+		// being entropy-coded already. On any zlib error the original uncompressed
+		// body ships rather than a 500; prepare_payload() sizes Content-Length from
+		// the post-swap body either way.
 		//
-		// Vary: Accept-Encoding is added regardless of whether *this*
-		// response was compressed, so any intermediary cache keys the
-		// entry correctly across clients that do / don't send the
-		// header.
-		// HEAD is compressed too, even though the bytes are then
-		// discarded. Skipping it saves a deflate per probe and costs
-		// correctness: HEAD must describe what the equivalent GET would
-		// return, so with Accept-Encoding: gzip that means the SAME
-		// Content-Encoding and the SAME Content-Length. Diverging binds
-		// one strong ETag to two codings and, per RFC 9111 4.3.5, lets
-		// each probe invalidate the stored gzip response. The deflate
-		// is the cheaper of the two.
+		// HEAD is compressed too, even though the bytes are then discarded.
+		// Skipping it saves a deflate per probe and costs correctness: HEAD must
+		// describe what the equivalent GET would return, so with Accept-Encoding:
+		// gzip that means the SAME Content-Encoding and Content-Length. Diverging
+		// binds one strong ETag to two codings and, per RFC 9111 4.3.5, lets each
+		// probe invalidate the stored gzip response.
 		if (WillCompressBody(m_accepts_gzip,
 			    resp.body.size(),
 			    resp.content_type,
@@ -1454,42 +1243,34 @@ private:
 				resp.body = std::move(compressed);
 				resp.headers["Content-Encoding"] = "gzip";
 			}
-			// Reconcile the validator with the coding that ACTUALLY
-			// shipped. The hash upstream is taken before compression,
-			// so without a marker both codings of a resource carry the
-			// same strong ETag; the dispatcher stamps it in advance
-			// because a 304 has no body left here to measure. When
-			// that prediction holds this is a no-op. When deflate
-			// fails the body ships as identity and the prediction is
-			// now wrong, and this takes the suffix back off -- leaving
-			// it would bind a gzip validator to identity bytes, which
-			// is the exact mispairing the suffix exists to prevent.
+			// Reconcile the validator with the coding that ACTUALLY shipped. The hash
+			// upstream is taken before compression, so without a marker both codings
+			// carry the same strong ETag; the dispatcher stamps it in advance because
+			// a 304 has no body left to measure. When deflate fails the body ships as
+			// identity and this takes the suffix back off -- leaving it would bind a
+			// gzip validator to identity bytes.
 			auto et = resp.headers.find("ETag");
 			if (et != resp.headers.end())
 				et->second = webcommon::WithCodingSuffix(et->second, gzipped);
 		}
 		// Append, never overwrite: the dispatcher may already have set
-		// `Vary: Origin` for CORS, and replacing it would drop the
-		// encoding dimension from a response whose ETag was computed
-		// before compression.
+		// `Vary: Origin` for CORS, and replacing it would drop the encoding
+		// dimension from a response whose ETag was computed before compression.
 		AppendHeaderToken(resp.headers, "Vary", "Accept-Encoding");
 
 		m_response.emplace();
 		m_response->version(11);
 		m_response->result(resp.status);
 		m_response->set(http::field::server, "amuleapi");
-		// One request per connection: DoClose() shuts the socket down
-		// after every response, so HTTP/1.1's default persistence is a
-		// promise this server does not keep. Say so on every reply
-		// instead of on the handful that happened to set it, or a
-		// pooling client keeps the socket and fails its next request on
-		// it. Handlers that set it themselves are left alone.
+		// One request per connection: DoClose() shuts the socket down after every
+		// response, so HTTP/1.1's default persistence is a promise this server does
+		// not keep. Say so on every reply or a pooling client keeps the socket and
+		// fails its next request on it. Handlers that set it themselves are left alone.
 		if (resp.headers.find("Connection") == resp.headers.end()) {
 			m_response->set(http::field::connection, "close");
 		}
-		// A Content-Type whose value is not a media type is malformed, so
-		// omit the header entirely on the bodiless replies (204, 304)
-		// whose handlers deliberately cleared it.
+		// A Content-Type whose value is not a media type is malformed, so omit the
+		// header entirely on the bodiless replies (204, 304) that cleared it.
 		if (!resp.content_type.empty()) {
 			m_response->set(http::field::content_type, resp.content_type);
 		}
@@ -1504,36 +1285,29 @@ private:
 		m_response->body() = std::move(resp.body);
 		m_response->prepare_payload();
 		if (m_head_probe_chunked) {
-			// Mirror the framing a GET on this endpoint advertises.
-			// prepare_payload() sizes from the (empty) body and stamps
-			// `Content-Length: 0`, which would describe a zero-length
-			// document rather than the unbounded stream the caller
-			// asked about; chunked() ahead of it does not survive,
-			// since the body size is known. Set the framing directly,
-			// after. Only the header is written, so nothing has to
-			// honour it.
+			// Mirror the framing a GET on this endpoint advertises. prepare_payload()
+			// sizes from the (empty) body and stamps `Content-Length: 0`, which would
+			// describe a zero-length document rather than the unbounded stream the
+			// caller asked about; chunked() ahead of it does not survive, since the
+			// body size is known. Set the framing directly, after.
 			m_response->erase(http::field::content_length);
 			m_response->set(http::field::transfer_encoding, "chunked");
 		}
 
 		auto self = shared_from_this();
 		if (m_head_only) {
-			// RFC 9110 §9.3.2 — a HEAD response carries no content, on
-			// any status. prepare_payload() has already sized
-			// Content-Length from the full body, so serializing the
-			// header alone reports what a GET would return without
-			// putting a byte of it on the wire.
+			// RFC 9110 9.3.2 -- a HEAD response carries no content, on any status.
+			// prepare_payload() has already sized Content-Length from the full body,
+			// so serializing the header alone reports what a GET would return.
 			m_serializer.emplace(*m_response);
 			m_serializer->split(true);
 			http::async_write_header(
 				m_stream, *m_serializer, [self](beast::error_code ec, std::size_t) {
 					(void)ec;
-					// Same drain as the body path. A HEAD rejected at
-					// the header cap has just as much unread data
-					// queued as a GET does, and closing on top of it
-					// lets the RST discard the 431 that was just
-					// written -- intermittently, which is why a single
-					// probe can pass and hide it.
+					// Same drain as the body path. A HEAD rejected at the header cap has
+					// just as much unread data queued as a GET does, and closing on top
+					// of it lets the RST discard the 431 just written -- intermittently,
+					// which is why a single probe can pass and hide it.
 					if (self->m_drain_before_close) {
 						self->StartDrainThenClose();
 						return;
@@ -1554,20 +1328,17 @@ private:
 
 	void DoClose()
 	{
-		// Drop the request timer first. It holds a shared_ptr to this
-		// Session, so leaving it armed keeps a closed connection alive
-		// for the rest of its 10 s and delays process teardown by the
-		// same amount. Posted rather than cancelled inline: DoClose also
-		// runs on the SSE worker thread, and the timer belongs to the
-		// io_context executor -- every other foreign-thread touch in
-		// this file goes through asio::post for the same reason.
+		// Drop the request timer first. It holds a shared_ptr to this Session, so
+		// leaving it armed keeps a closed connection alive for the rest of its
+		// budget and delays process teardown by the same amount. Posted rather
+		// than cancelled inline: DoClose also runs on the SSE worker thread, and
+		// the timer belongs to the io_context executor.
 		{
 			auto self = shared_from_this();
 			asio::post(m_stream.get_executor(), [self]() { self->m_request_timer.cancel(); });
 		}
-		// If we were streaming, write the chunked-encoding terminator
-		// (0-size chunk) before shutting down. Idempotent — if the
-		// peer already closed, the write fails silently.
+		// If we were streaming, write the chunked-encoding terminator (0-size
+		// chunk) before shutting down. Idempotent: a closed peer just fails.
 		if (m_stream_alive.exchange(false, std::memory_order_acq_rel)) {
 			std::lock_guard<std::mutex> g(m_socket_mu);
 			beast::error_code ec;
@@ -1584,8 +1355,8 @@ private:
 	// answered instead of silently dropped; see DoRead.
 	asio::steady_timer m_request_timer;
 	// Worker pool that runs the (non-streaming) request handler off the
-	// io_context thread. Shared with the server; declared before m_handler
-	// so the init list stays in declaration order.
+	// io_context thread. Declared before m_handler so the init list stays in
+	// declaration order.
 	std::shared_ptr<asio::thread_pool> m_handler_pool;
 	beast::flat_buffer m_buffer{ kReadBufferBytes };
 	boost::optional<http::request_parser<http::string_body>> m_parser;
@@ -1594,18 +1365,15 @@ private:
 	// reports the GET size while no content reaches the wire.
 	boost::optional<http::response_serializer<http::string_body>> m_serializer;
 	// The file-backed alternative to the pair above, engaged only when the
-	// handler set Response::file. Two separate pairs rather than a variant
-	// body because the message type is baked into the serializer at compile
-	// time; only one of the two is ever engaged on a given connection.
+	// handler set Response::file. Two separate pairs rather than a variant body
+	// because the message type is baked into the serializer at compile time.
 	//
-	// Both optionals reserve their storage INLINE in every Session whether or
-	// not they are ever engaged, and response_serializer holds its `writer` by
-	// value -- so while the writer kept its 64 KiB read buffer as a member
-	// array, every session on the process paid for it, an hours-long SSE
-	// connection included. sizeof(Session) was 67432 bytes; the writer now
-	// heap-allocates that buffer on first get() (RangeFileBody.h) and it is
-	// 1904. Anything added to RangeFileBody::writer lands here again, by value,
-	// on every connection.
+	// Both optionals reserve their storage INLINE in every Session whether or not
+	// they are ever engaged, and response_serializer holds its `writer` by value
+	// -- so while the writer kept its 64 KiB read buffer as a member array,
+	// every session paid for it, an hours-long SSE connection included.
+	// sizeof(Session) was 67432 bytes; it is now 1904. Anything added to
+	// RangeFileBody::writer lands here again, by value, on every connection.
 	boost::optional<http::response<RangeFileBody>> m_file_response;
 	boost::optional<http::response_serializer<RangeFileBody>> m_file_serializer;
 	// Whether this session is accounted against g_file_response_count; see
@@ -1619,25 +1387,19 @@ private:
 	CHttpServer::StreamingPreflight m_streaming_preflight;
 	CHttpServer::CorsStamper m_cors_stamper;
 	std::atomic<bool> m_stream_alive{ false };
-	// Set true by the worker on exit. The Session destructor asserts
-	// on it before detach()ing the thread handle (Session is shared-
-	// ptr-owned by the worker, so dtor only runs after the last ref
-	// drops — and that ref is held by the worker lambda, which only
-	// releases it as a final statement).
+	// Set true by the worker on exit. The Session destructor asserts on it
+	// before detach()ing the thread handle -- the dtor only runs after the last
+	// ref drops, and that ref is held by the worker lambda.
 	std::atomic<bool> m_worker_exited{ false };
 	std::mutex m_socket_mu;
 	std::thread m_stream_worker;
-	// Whether this session is accounted against
-	// g_streaming_session_count. Set in DispatchStreaming after a
-	// successful slot acquisition; the dtor decrements iff this is
-	// true so refused-cap sessions don't double-account.
+	// Whether this session is accounted against g_streaming_session_count. Set
+	// in DispatchStreaming after a successful slot acquisition; the dtor
+	// decrements iff this is true, so refused-cap sessions do not double-account.
 	bool m_session_slot_held = false;
-	// Sampled from the request's Accept-Encoding header in Dispatch.
-	// Read by WriteResponse (single-shot body compression) and by
-	// DispatchStreaming (per-event Z_SYNC_FLUSH on the SSE socket
-	// writer). Kept as a plain bool because both readers run either on
-	// the same thread that populated it or on a worker spawned after
-	// the write, so no atomic is needed.
+	// Sampled from the request's Accept-Encoding header in Dispatch. Read by
+	// WriteResponse and by DispatchStreaming. A plain bool because both readers
+	// run either on the thread that populated it or on a worker spawned after.
 	bool m_accepts_gzip = false;
 	bool m_head_only = false;
 	// The /events HEAD probe answers for a chunked stream, so it is framed
@@ -1705,12 +1467,10 @@ public:
 	{
 		beast::error_code ec;
 		m_acceptor.close(ec);
-		// Cancel every live SSE session's socket so workers blocked
-		// inside synchronous Beast writes return promptly. Without
-		// this, a slow peer holds its worker thread inside the
-		// write call until the kernel TCP timeout (~minutes) and
-		// CHttpServer::Stop joins the io_context thread, which
-		// joins indefinitely waiting for the workers.
+		// Cancel every live SSE session's socket so workers blocked inside
+		// synchronous Beast writes return promptly. Without this a slow peer holds
+		// its worker thread inside the write call until the kernel TCP timeout,
+		// and CHttpServer::Stop then joins the io_context thread indefinitely.
 		std::vector<std::shared_ptr<Session>> live;
 		{
 			std::lock_guard<std::mutex> g(g_live_streams_mu);
@@ -1765,7 +1525,7 @@ private:
 struct CHttpServer::Impl
 {
 	asio::io_context ioc{ 1 };
-	// Handlers run here, off the single io_context thread — see
+	// Handlers run here, off the single io_context thread -- see
 	// kHandlerPoolThreads. shared_ptr so Sessions can keep it alive for an
 	// in-flight handler; joined explicitly in Stop().
 	std::shared_ptr<asio::thread_pool> handler_pool;
@@ -1781,23 +1541,20 @@ CHttpServer::~CHttpServer()
 	Stop();
 }
 
-// Every callback here is a sink: taken by value, std::move()d into Listener,
-// which moves it on into its member. A const reference would force a copy at
-// that member instead. performance-unnecessary-value-param flags four of the
-// five anyway -- exactly the four carrying a default argument, including the
-// two this change never touched -- so the suppression covers the whole list
-// rather than singling out the two whose line numbers happened to move.
 void CHttpServer::SetMaxConcurrentFileResponses(int max_responses)
 {
-	// Silently ignoring a bad value rather than clamping it: the config
-	// layer has already rejected everything outside the sane band and fallen
-	// back to the default, so anything that still gets here is a programming
-	// error, and the default is a better answer to that than zero.
+	// Silently ignoring a bad value rather than clamping it: the config layer
+	// has already rejected everything outside the sane band and fallen back to
+	// the default, so anything that still gets here is a programming error.
 	if (max_responses > 0) {
 		g_max_concurrent_file_responses.store(max_responses, std::memory_order_relaxed);
 	}
 }
 
+// Every callback here is a sink: taken by value, std::move()d into Listener,
+// which moves it on into its member. A const reference would force a copy at
+// that member instead, and performance-unnecessary-value-param flags four of
+// the five anyway -- exactly the four carrying a default argument.
 // NOLINTBEGIN(performance-unnecessary-value-param)
 bool CHttpServer::Start(const std::string &bind_address,
 	unsigned port,
@@ -1823,16 +1580,12 @@ bool CHttpServer::Start(const std::string &bind_address,
 	}
 	tcp::endpoint endpoint(addr, static_cast<unsigned short>(port));
 
-	// Bind hygiene warning. amuleapi's HTTP server uses a thread-
-	// per-streaming-session model bounded by a process-wide cap
-	// (kMaxConcurrentStreamingSessions). On loopback this is fine
-	// — the only callers are the operator's own clients. Off
-	// loopback, the same model is a DoS amplifier: any peer can
-	// open enough preauth connections to consume the cap and lock
-	// out legitimate subscribers. Surface a one-time WARN on
-	// startup so an operator switching the bind catches this in
-	// the daemon log; the SSE session cap still enforces the
-	// upper bound regardless.
+	// Bind hygiene warning. amuleapi's HTTP server uses a thread-per-streaming-
+	// session model bounded by a process-wide cap. On loopback this is fine; off
+	// loopback the same model is a DoS amplifier, since any peer can open enough
+	// preauth connections to consume the cap and lock out legitimate
+	// subscribers. Surface a one-time WARN so an operator switching the bind
+	// catches it in the daemon log.
 	if (!addr.is_loopback()) {
 		std::cerr << "amuleapi: WARN BindAddress=" << bind_address
 			  << " is not loopback. SSE sessions are capped at "
@@ -1864,10 +1617,9 @@ bool CHttpServer::Start(const std::string &bind_address,
 		try {
 			m_impl->ioc.run();
 		} catch (const std::exception &e) {
-			// io_context exception propagation: the server thread dies
-			// quietly. Catch + log to stderr so an operator running in
-			// foreground sees a one-line cause; daemon mode loses the
-			// message.
+			// io_context exception propagation: the server thread dies quietly.
+			// Catch + log to stderr so an operator running in foreground sees a
+			// one-line cause; daemon mode loses the message.
 			std::cerr << "amuleapi: HTTP I/O loop exited on exception: " << e.what() << '\n';
 		}
 		m_impl->running.store(false, std::memory_order_release);
@@ -1884,12 +1636,10 @@ void CHttpServer::Stop()
 	m_impl->ioc.stop();
 	if (m_impl->thread.joinable())
 		m_impl->thread.join();
-	// Drain the handler pool after the io_context thread is gone. stop()
-	// abandons not-yet-started handler tasks; join() lets any in-flight
-	// handler finish (bounded by the EC read timeout). Their response
-	// trampolines were posted to the now-stopped io_context and are simply
-	// discarded when it is destroyed in m_impl.reset() below — each Session
-	// stays alive via the captured shared_ptr until then.
+	// Drain the handler pool after the io_context thread is gone. stop() abandons
+	// not-yet-started handler tasks; join() lets any in-flight handler finish
+	// (bounded by the EC read timeout). Their response trampolines were posted to
+	// the now-stopped io_context and are discarded when it is destroyed below.
 	if (m_impl->handler_pool) {
 		m_impl->handler_pool->stop();
 		m_impl->handler_pool->join();

--- a/src/webapi/HttpServer.h
+++ b/src/webapi/HttpServer.h
@@ -50,36 +50,27 @@ class io_context;
 }
 } // namespace boost
 
-// Does this Accept-Encoding value ask for gzip? Token search, so
-// "gzip, deflate, br" and "gzip;q=1.0" both match and a longer name
-// containing the letters does not.
-//
-// Shared rather than reimplemented: the dispatcher has to answer the same
-// question when it describes what a GET would return, and a second copy of
-// this parser is how the header-merge logic ended up in three places.
+// Does this Accept-Encoding value ask for gzip? Token search, so "gzip,
+// deflate, br" and "gzip;q=1.0" both match and a longer name containing the
+// letters does not. Shared rather than reimplemented: the dispatcher has to
+// answer the same question when it describes what a GET would return.
 bool AcceptsGzip(const std::string &accept_encoding);
 
 // Will a response with this body be gzipped on the way out?
 //
 // Shared because two places have to agree: the transport, which compresses and
 // stamps the coding onto the validator, and the 304 paths, which must echo the
-// SAME validator the equivalent 200 would have sent. They cannot each carry
-// their own copy of the rule -- when they disagreed, a client that cached the
-// gzip form was handed the identity ETag on revalidation and could never match
-// its stored response again.
-//
-// `already_encoded` is true when a handler set Content-Encoding itself.
+// SAME validator the equivalent 200 would have sent. When they disagreed, a
+// client that cached the gzip form was handed the identity ETag on
+// revalidation and could never match its stored response again.
 bool WillCompressBody(
 	bool accepts_gzip, std::size_t body_size, const std::string &content_type, bool already_encoded);
 
 // Add one token to a comma-separated header without dropping what is already
 // there and without duplicating it. Comparison is token-by-token, so a short
-// name cannot match inside a longer one.
-//
-// Declared here because every writer that merges a header has to share one
-// definition: the logic previously existed in three copies, two consecutive
-// rounds of fixes each reached a different two of them, and the copy nobody
-// touched kept the old overwrite behaviour.
+// name cannot match inside a longer one. Declared here because every writer
+// that merges a header has to share one definition -- this logic previously
+// existed in three copies and two rounds of fixes each reached a different two.
 void AppendHeaderToken(std::map<std::string, std::string> &headers, const char *name, const char *token);
 
 class CHttpServer
@@ -94,9 +85,8 @@ public:
 		std::string target; // raw URI: "/api/v0/version?x=1"
 		std::map<std::string, std::string> headers;
 		std::string body;
-		// Client IP as observed by the accept socket. amuleapi rate-
-		// limits by this string verbatim; the `X-Forwarded-For` honor
-		// toggle is a deferred follow-up (		// implementation notes).
+		// Client IP as observed by the accept socket. amuleapi rate-limits by this
+		// string verbatim; an `X-Forwarded-For` honour toggle is a follow-up.
 		std::string remote_addr;
 	};
 
@@ -109,111 +99,86 @@ public:
 
 		// Serve the body straight off disk instead of out of `body`.
 		//
-		// Exists because the buffered `body` above is a memory hazard for
-		// shared content: the handler pool is 16 threads wide, so a
-		// multi-GB file answered through a std::string is up to 16 x
-		// filesize resident. When `file` is set the transport streams the
-		// window through a fixed 64 KiB buffer (see RangeFileBody.h) and
-		// `body` is ignored entirely.
+		// Exists because the buffered `body` above is a memory hazard for shared
+		// content: the handler pool is 16 threads wide, so a multi-GB file answered
+		// through a std::string is up to 16 x filesize resident. When `file` is set
+		// the transport streams the window through a fixed 64 KiB buffer.
 		struct FileSource
 		{
-			// Absolute path. The HANDLER owns resolution and the
-			// containment check -- by the time the transport gets here
-			// it opens the path blindly, and its only failure answer is
-			// a 500, because a rejection at this depth may already be
-			// too late to say anything more specific. Anything that
-			// should have been a 403 or a 404 has to have been decided
-			// upstream.
+			// Absolute path. The HANDLER owns resolution and the containment check
+			// -- by the time the transport gets here it opens the path blindly, and
+			// its only failure answer is a 500. Anything that should have been a
+			// 403 or a 404 has to have been decided upstream.
 			std::string fs_path;
-			// Inclusive window, RFC 9110 byte-range semantics: `last`
-			// is the index of the last byte SENT, so a whole file of N
-			// bytes is [0, N-1]. Both must lie inside the file; the
-			// transport answers 500 rather than silently clamping,
-			// since the handler has usually already described the
-			// window in a `Content-Range` header. A zero-length file
-			// has no valid window at all and belongs on the `body`
-			// path.
+			// Inclusive window, RFC 9110 byte-range semantics: `last` is the index of
+			// the last byte SENT, so a whole file of N bytes is [0, N-1]. Both must
+			// lie inside the file; the transport answers 500 rather than clamping,
+			// since the handler has usually already described the window in a
+			// Content-Range. A zero-length file belongs on the `body` path.
 			std::uint64_t first = 0;
 			std::uint64_t last = 0;
 		};
-		// Setting this opts the response out of two things it would
-		// otherwise get for free:
-		//  * gzip. The transport never deflates a file response --
-		//    compressing a range would break the byte accounting the
-		//    Content-Range describes, and shared content is generally
-		//    already entropy-coded anyway.
-		//  * the dispatcher's whole-body ETag, which is computed by
-		//    hashing `body`. There is no body here to hash, so a
-		//    validator for a file response has to be built by the
-		//    handler out of something cheap (size + mtime), and the
-		//    dispatcher's gzip-coding suffix must not be applied to it.
+		// Setting this opts the response out of two things it would otherwise get
+		// for free:
+		//  * gzip. Compressing a range would break the byte accounting the
+		//    Content-Range describes, and shared content is generally already
+		//    entropy-coded anyway.
+		//  * the dispatcher's whole-body ETag, computed by hashing `body`. There
+		//    is none here, so the handler builds one from size + mtime instead.
 		boost::optional<FileSource> file;
 	};
 
 	using Handler = std::function<Response(const Request &)>;
 
-	// long-lived streaming responses (SSE). The streaming
-	// handler is given a `Writer` it can use to push chunks at will;
-	// the connection stays open until the writer signals close or
-	// the peer disconnects.
+	// Long-lived streaming responses (SSE). The streaming handler is given a
+	// `Writer` it can use to push chunks at will; the connection stays open
+	// until the writer signals close or the peer disconnects.
 	class Writer
 	{
 	public:
-		// Write a chunk of bytes to the connection. Returns false if
-		// the connection has been torn down (peer disconnect or
-		// shutdown) — caller should stop pushing and let the session
-		// die. Thread-safe: implementations post the write to the
-		// io_context strand, so a caller on any thread is safe.
+		// Write a chunk of bytes to the connection. Returns false if the connection
+		// has been torn down -- the caller should stop pushing and let the session
+		// die. Thread-safe: implementations post the write to the io_context
+		// strand, so a caller on any thread is safe.
 		virtual bool Write(const std::string &chunk) = 0;
-		// True if the peer is still connected. Cheap to poll; useful
-		// for the per-stream heartbeat timer to bail when the client
-		// has hung up between pushes.
+		// True if the peer is still connected. Cheap to poll, so the per-stream
+		// heartbeat timer can bail when the client hung up between pushes.
 		virtual bool Alive() const = 0;
 		virtual ~Writer() = default;
 	};
 
-	// StreamingHandler returns the response head (status, content_type,
-	// initial headers) AND keeps writing chunks via the Writer until it
-	// returns. The session's lifetime extends as long as the handler
-	// hasn't returned AND the connection is alive — typical impls run
-	// an event loop inside the handler and exit when the connection
-	// closes (which Writer::Alive surfaces).
+	// StreamingHandler returns the response head (status, content_type, initial
+	// headers) AND keeps writing chunks via the Writer until it returns. The
+	// session lives as long as the handler has not returned AND the connection
+	// is alive, which Writer::Alive surfaces.
 	using StreamingHandler = std::function<void(const Request &,
 		Writer &writer,
 		unsigned &http_status,
 		std::string &content_type,
 		std::map<std::string, std::string> &response_headers)>;
 
-	// Optional resolver: tells the HTTP server whether an incoming
-	// request should be dispatched to the streaming handler (true) or
-	// the normal Handler (false). The current wiring matches "GET
-	// /api/v0/events"; other endpoints stay request/response.
+	// Optional resolver: tells the HTTP server whether an incoming request goes
+	// to the streaming handler (true) or the normal Handler (false). The current
+	// wiring matches "GET /api/v0/events".
 	using StreamingResolver = std::function<bool(const Request &)>;
 
-	// Optional preflight: runs synchronously on the I/O thread BEFORE
-	// the per-session worker thread is spawned and BEFORE the 32-slot
-	// concurrency budget is claimed. Returns boost::none to admit the
-	// connection; returns a populated Response to reject it (the
-	// response is written verbatim and the connection closes). Used
-	// to push the SSE auth check off the worker thread so an
-	// unauthenticated peer can't tie up a slot for the read-timeout
-	// window. Empty preflight (default) preserves the pre-existing
-	// "auth inside the handler" behaviour.
+	// Optional preflight: runs synchronously on the I/O thread BEFORE the
+	// per-session worker thread is spawned and BEFORE the concurrency budget is
+	// claimed. boost::none admits; a populated Response is written verbatim and
+	// the connection closes. This is what stops an unauthenticated peer tying up
+	// a slot for the read-timeout window.
 	using StreamingPreflight = std::function<boost::optional<Response>(const Request &)>;
 
-	// Stamps the CORS bundle on a response the transport built itself --
-	// the 408 / 413 / 431 replies, which are written before any request
-	// reaches a handler. Without it those are the only replies on the
-	// surface a cross-origin browser client cannot read: it sees an opaque
-	// fetch failure instead of the typed envelope. Takes the raw Origin
-	// header, since at that point there is no parsed Request to hand over.
+	// Stamps the CORS bundle on a response the transport built itself -- the
+	// 408 / 413 / 431 replies, written before any request reaches a handler.
+	// Without it those are the only replies a cross-origin browser client cannot
+	// read. Takes the raw Origin header, there being no parsed Request yet.
 	using CorsStamper = std::function<void(
 		std::map<std::string, std::string> &headers, const std::string &origin_header)>;
 
-	// Bind + listen on `bind_address`:`port`. Returns false (and
-	// populates LastError) on bind failure — the most common reason
-	// is the port being in use by another amuleapi instance or a
-	// stale TIME_WAIT socket.
+	// Bind + listen on `bind_address`:`port`. Returns false (and populates
+	// LastError) on bind failure -- most commonly the port being in use by
+	// another amuleapi instance or a stale TIME_WAIT socket.
 	bool Start(const std::string &bind_address,
 		unsigned port,
 		Handler handler,
@@ -222,17 +187,13 @@ public:
 		StreamingPreflight streaming_preflight = nullptr,
 		CorsStamper cors_stamper = nullptr);
 
-	// Process-wide cap on concurrent file-backed responses
-	// (`Response::file`), from `[Streaming]/MaxConcurrentFileResponses`.
-	// Zero or negative is ignored, so a caller that has not read a
-	// configuration file cannot accidentally close the route.
+	// Process-wide cap on concurrent file-backed responses (`Response::file`),
+	// from `[Streaming]/MaxConcurrentFileResponses`. Zero or negative is ignored,
+	// so a caller that has not read a configuration file cannot close the route.
 	//
 	// Must be called BEFORE Start(): the value is published without
-	// synchronisation beyond the atomic itself, and what makes that safe is
-	// that no connection -- and therefore no reader -- exists yet. A setter
-	// rather than an eighth Start() parameter, five of which already carry
-	// defaults; this is a tunable, not part of the wiring a caller must get
-	// right to have a working server.
+	// synchronisation beyond the atomic itself, and what makes that safe is that
+	// no connection -- and therefore no reader -- exists yet.
 	static void SetMaxConcurrentFileResponses(int max_responses);
 
 	// Stops the io_context, joins the thread. Safe to call from any
@@ -241,11 +202,10 @@ public:
 
 	const std::string &LastError() const { return m_lastError; }
 
-	// PIMPL — `Impl` holds the boost::asio io_context + the std::thread.
-	// Constructor / destructor are declared but defined out-of-line in
-	// HttpServer.cpp so callers don't need Boost.Asio's headers on the
-	// include path and `std::is_destructible<CHttpServer>` doesn't probe
-	// the incomplete `Impl` from foreign translation units.
+	// PIMPL -- `Impl` holds the boost::asio io_context + the std::thread. Ctor and
+	// dtor are declared but defined out-of-line so callers do not need
+	// Boost.Asio's headers, and `std::is_destructible<CHttpServer>` does not
+	// probe the incomplete `Impl` from foreign translation units.
 	CHttpServer();
 	~CHttpServer();
 

--- a/src/webapi/LogTee.cpp
+++ b/src/webapi/LogTee.cpp
@@ -288,8 +288,8 @@ bool CLogTee::Install(const std::string &logPath, std::size_t maxBytes)
 	m_pipeErrRead = perr[0];
 
 	// On a TTY stdout was line-buffered; once fd 1 is a pipe libc switches it to
-	// full (block) buffering, which would delay console + file output until 4-8
-	// KB accumulate. Force line buffering back. stderr stays unbuffered.
+	// full buffering, which would delay console and file output until 4-8 KB
+	// accumulate. Force line buffering back; stderr stays unbuffered.
 	std::setvbuf(stdout, nullptr, _IOLBF, 0);
 	std::setvbuf(stderr, nullptr, _IONBF, 0);
 

--- a/src/webapi/LogTee.h
+++ b/src/webapi/LogTee.h
@@ -80,12 +80,9 @@ private:
 // original console streams intact (a "tee"). It works at the file-descriptor
 // level -- fd 1 and fd 2 are routed through pipes and a forwarding thread copies
 // each chunk to both the saved console fd and the log file -- so it captures C
-// stdio (printf/fprintf), C++ streams (std::cout/std::cerr) and anything else
-// that writes to those descriptors, including the fatal-signal backtrace.
-//
-// Cross-platform: POSIX pipe/dup2/read and the Windows _pipe/_dup2/_read
-// equivalents. amuleapi installs a single instance at startup; the other EC
-// connectors do not use it.
+// stdio, C++ streams and anything else that writes to those descriptors,
+// including the fatal-signal backtrace. Cross-platform via the POSIX and
+// Windows pipe/dup2/read equivalents.
 class CLogTee
 {
 public:
@@ -97,16 +94,15 @@ public:
 
 	// Opens logPath (append, capped at maxBytes), redirects fd 1 and 2 through
 	// pipes and starts the forwarding threads. On any failure it restores the
-	// descriptors and returns false, leaving the process's stdout/stderr
-	// untouched.
+	// descriptors and returns false, leaving stdout/stderr untouched.
 	bool Install(const std::string &logPath, std::size_t maxBytes);
 
 	// Restores the original descriptors, drains and joins the forwarding
 	// threads and closes the file. Idempotent; also called by the destructor.
 	void Uninstall();
 
-	// Crash path: point fd 2 straight at the log file so a backtrace emitted by
-	// the fatal handler is written synchronously, without depending on the
+	// Crash path: point fd 2 straight at the log file so a backtrace from the
+	// fatal handler is written synchronously, without depending on the
 	// forwarding thread being scheduled before the process dies.
 	void RedirectStderrToFileForCrash();
 
@@ -114,9 +110,8 @@ public:
 
 private:
 	// One forwarding worker per stream: blocking-reads a pipe and writes each
-	// chunk to its console fd and the log file. Two threads (rather than one
-	// poll() loop) so the same code runs on Windows, which cannot poll() pipe
-	// descriptors.
+	// chunk to its console fd and the log file. Two threads rather than one
+	// poll() loop so the same code runs on Windows, which cannot poll() pipes.
 	void Pump(int readFd, int consoleFd);
 
 	bool m_installed = false;

--- a/src/webapi/PartIndex.h
+++ b/src/webapi/PartIndex.h
@@ -48,16 +48,13 @@ constexpr const char *kDownloadStateDownloading = "downloading";
 
 //! True when a reported part index can actually address a chunk of a file with
 //! `part_count` chunks. Three things make it unusable: the peer never reported
-//! one (`present` false), kNoPartPendingSentinel, and any index left over from
-//! a peer whose request file is not this one. Relayed raw, either of the last
-//! two would draw a stripe on a chunk nothing is happening to.
+//! one (`present` false), kNoPartPendingSentinel, and any index left over from a
+//! peer whose request file is not this one.
 //!
-//! The sentinel is tested by name rather than left to fall out of the bounds
-//! check, which only filters it while `part_count <= 0xffff`. Above that -- a
-//! file larger than 65535 * kPartSizeBytes, about 637 GB -- 65535 is a real
-//! chunk, so the bound alone would pass the sentinel through as an index on
-//! exactly the files a source bar is most useful on. Part 65535 of such a file
-//! is then unreportable, which is what the desktop already accepts.
+//! The sentinel is tested by name rather than left to the bounds check, which
+//! only filters it while `part_count <= 0xffff`. Above that -- a file larger
+//! than about 637 GB -- 65535 is a real chunk, so the bound alone would pass
+//! the sentinel through on exactly the files a source bar is most useful on.
 inline bool UsablePartIndex(bool present, std::uint16_t part, std::uint64_t part_count)
 {
 	return present && part != kNoPartPendingSentinel && static_cast<std::uint64_t>(part) < part_count;
@@ -65,23 +62,19 @@ inline bool UsablePartIndex(bool present, std::uint16_t part, std::uint64_t part
 
 //! The same test for `last_downloading_part`, plus the download-state guard the
 //! bounds check cannot supply: the core initialises m_lastDownloadingPart to 0
-//! (BaseClient.cpp: CUpDownClient::Init) and ECSpecialCoreTags.cpp ships it with
-//! AddTag rather than AddDiffTag, so it arrives on every frame whether or not
-//! the peer is transferring. A connected-but-queued source therefore reports a
-//! perfectly in-range 0, indistinguishable from one actually feeding chunk 0 --
-//! and since most sources in a list are queued rather than transferring, a
-//! renderer would mark chunk 0 as "downloading now" on nearly every row. The
-//! desktop guards it the same way (GenericClientListCtrl.cpp: lastDownloadingPart
-//! is forced to 0xffff unless GetDownloadState() == DS_DOWNLOADING); doing it in
-//! the serializer instead means every API client gets it right once rather than
-//! each rediscovering the rule.
+//! and ECSpecialCoreTags.cpp ships it with AddTag rather than AddDiffTag, so it
+//! arrives on every frame whether or not the peer is transferring. A
+//! connected-but-queued source therefore reports a perfectly in-range 0,
+//! indistinguishable from one actually feeding chunk 0 -- and most sources in a
+//! list are queued, so a renderer would mark chunk 0 as "downloading now" on
+//! nearly every row. The desktop guards it the same way; doing it in the
+//! serializer means every API client gets it right once.
 //!
 //! Takes the state string and the two scalars rather than a ClientSnapshot, so
 //! this header needs neither State.h nor anything State.h reaches.
 //!
 //! Deliberately NOT applied to next_requested_part, exactly as the desktop does
-//! not apply it either: 0xffff is that field's own "no block pending" answer, so
-//! an idle peer already falls out through UsablePartIndex.
+//! not: 0xffff is that field's own "no block pending" answer.
 inline bool UsableLastDownloadingPart(
 	const std::string &download_state, bool present, std::uint16_t part, std::uint64_t part_count)
 {

--- a/src/webapi/PrefsSchema.cpp
+++ b/src/webapi/PrefsSchema.cpp
@@ -42,9 +42,8 @@ const char *const kIp2CountrySources[] = { "dbip", "maxmind", "custom", nullptr 
 // Everything from here to the matching `clang-format on` is a data table, not
 // code, and is kept one row per field so it reads as a specification.
 // ColumnLimit is 110 and the longest row is ~184 characters, so the formatter
-// would otherwise break every row across seven lines -- which costs the
-// property this table exists for: renaming or adding a preference stays a
-// one-line diff a reviewer can take in at a glance.
+// would break every row across seven lines -- costing the property this table
+// exists for: adding a preference stays a one-line diff.
 //
 // clang-format off
 
@@ -82,8 +81,7 @@ const char *const kIp2CountrySources[] = { "dbip", "maxmind", "custom", nullptr 
 
 // Numeric rows whose real domain is narrower than their type. `minv`/`maxv` are
 // both inclusive and both rejected with a 400; `stepv` is the granularity the
-// core stores at, 0 when the row is not quantised. See the notes on
-// PrefField::min and ::step for why this is declared rather than clamped.
+// core stores at, 0 when the row is not quantised.
 #define PREF_U32_DOMAIN(cat, key, tag, minv, maxv, stepv, acc, memb) \
 	{cat, key, tag, PrefType::Uint32, PrefEnc::Value, false, acc, maxv, nullptr, nullptr, \
 		PREF_MEMBER(memb, std::uint32_t), 0, 0, minv, stepv}
@@ -124,9 +122,8 @@ const char *const kIp2CountrySources[] = { "dbip", "maxmind", "custom", nullptr 
 const PrefField kSchema[] = {
 	// [general]
 	// Value, not Presence: the core emits EC_TAG_GENERAL_CHECK_NEW_VERSION
-	// unconditionally as a value tag, so presence-decoding it pinned the
-	// answer to true and a read-modify-write of any other preference
-	// silently re-enabled version checking.
+	// unconditionally as a value tag, so presence-decoding it pinned the answer
+	// to true and a read-modify-write of any other preference re-enabled it.
 	PREF_BOOL("general", "version_check_enabled", EC_TAG_GENERAL_CHECK_NEW_VERSION, PrefEnc::Value, false, PrefAccess::ReadWrite, version_check_enabled),
 	PREF_STR("general", "daemon_host_name", EC_TAG_USER_HOST, PrefAccess::ReadOnly, daemon_host_name),
 	PREF_STR("general", "nickname", EC_TAG_USER_NICK, PrefAccess::ReadWrite, nickname),
@@ -261,10 +258,9 @@ const PrefField kSchema[] = {
 	// [online_signature]
 	PREF_STR("online_signature", "directory", EC_TAG_ONLINESIG_DIRECTORY, PrefAccess::ReadWrite, online_signature.directory),
 	PREF_BOOL("online_signature", "enabled", EC_TAG_ONLINESIG_ENABLED, PrefEnc::Presence, false, PrefAccess::ReadWrite, online_signature.enabled),
-	// 65535, not the uint32 ceiling: CPreferences::SetOSUpdate takes a uint16
-	// (Preferences.h), so anything larger wraps on the way in -- 86400 (daily)
-	// became 20864 and the PATCH still reported success. Capping here turns a
-	// silent rewrite into the 400 every other numeric preference answers.
+	// 65535, not the uint32 ceiling: CPreferences::SetOSUpdate takes a uint16, so
+	// anything larger wraps on the way in -- 86400 (daily) became 20864 and the
+	// PATCH still reported success.
 	PREF_U32("online_signature", "update_frequency_seconds", EC_TAG_ONLINESIG_UPDATE, 65535u, PrefAccess::ReadWrite, online_signature.update_frequency_seconds),
 
 	// [advanced] (EC group: CORETWEAKS)
@@ -300,9 +296,9 @@ const PrefField kSchema[] = {
 	PREF_STR("geoip", "maxmind_license", EC_TAG_IP2COUNTRY_MAXMIND_LICENSE, PrefAccess::ReadWrite, geoip.maxmind_license),
 	PREF_ENUM("geoip", "source", EC_TAG_IP2COUNTRY_SOURCE, kIp2CountrySources, PrefAccess::ReadWrite, geoip.source),
 	PREF_BOOL("geoip", "supported", EC_TAG_IP2COUNTRY_SUPPORTED, PrefEnc::Value, false, PrefAccess::ReadOnly, geoip.supported),
-	// `update_now` was a write-only boolean here; it is POST /geoip/update
-	// now (#1189), an action rather than a setting. The row stays as a
-	// Rejected one so a client still sending it is told where it went.
+	// `update_now` was a write-only boolean here; it is POST /geoip/update now,
+	// an action rather than a setting. The row stays Rejected so a client still
+	// sending it is told where it went.
 	PREF_REJECT("geoip", "update_now"),
 };
 
@@ -318,9 +314,8 @@ const PrefCategory kCategories[] = {
 	{"remote_controls.webserver", EC_TAG_PREFS_REMOTECTRL},
 	{"remote_controls.amuleapi", EC_TAG_PREFS_REMOTECTRL},
 	{"online_signature", EC_TAG_PREFS_ONLINESIG},
-	// `advanced`, not `core_tweaks`: there is no such amule.conf section,
-	// "core" means nothing to an API consumer, verbose_logging is not a
-	// tweak, and the desktop tab holding these settings is called Advanced.
+	// `advanced`, not `core_tweaks`: there is no such amule.conf section, "core"
+	// means nothing to an API consumer, and the desktop tab is called Advanced.
 	{"advanced", EC_TAG_PREFS_CORETWEAKS},
 	// Everything else in the API says kad.
 	{"kad", EC_TAG_PREFS_KADEMLIA},

--- a/src/webapi/PrefsSchema.h
+++ b/src/webapi/PrefsSchema.h
@@ -59,10 +59,9 @@ enum class PrefType
 };
 
 // How EC encodes a boolean *on the read path*. The core serializer emits most
-// bools as a bare CECEmptyTag only when true (presence == true) but a handful
-// as a value tag every time. Writes are always value tags: amuleapi sends
-// SET_PREFERENCES at EC_DETAIL_FULL, where amuled's ApplyBoolean reads
-// GetInt() != 0. Only `Bool` rows consult this.
+// bools as a bare CECEmptyTag only when true (presence == true) but a handful as
+// a value tag every time. Writes are always value tags, since amuleapi sends
+// SET_PREFERENCES at EC_DETAIL_FULL where ApplyBoolean reads GetInt() != 0.
 enum class PrefEnc
 {
 	Presence,
@@ -78,10 +77,9 @@ enum class PrefAccess
 	Bespoke,   // emitted on GET, PATCH handled by dedicated code (see below)
 };
 
-// `Bespoke` exists for exactly one field. remote_controls.webserver.guest_enabled
-// and its guest_password share a single EC tag (EC_TAG_WEBSERVER_GUEST carries
-// the enable bool as its value and the password hash as a child), so there is no
-// 1:1 field-to-tag mapping for the table to express. Its GET emission is still
+// `Bespoke` exists for exactly one field: remote_controls.webserver.guest_enabled
+// and its guest_password share a single EC tag, so there is no 1:1
+// field-to-tag mapping for the table to express. Its GET emission is still
 // table-driven; only the PATCH packing is hand-written.
 
 struct PrefField
@@ -102,43 +100,37 @@ struct PrefField
 	// Address of the backing member. The row's PrefType fixes the cast; the
 	// PREF_* macros static_assert the two agree, so a mismatch is a build error.
 	void *(*member)(PreferencesSnapshot &);
-	// EC group this field's tag actually lives in, when that is not the group
-	// its JSON category maps to. 0 means "the category's own group". Exactly
-	// one field needs it: connection.upnp_supported is a daemon capability the
-	// core serializes into [General], but the API surfaces it next to the other
-	// UPnP settings under `connection`.
+	// EC group this field's tag actually lives in, when that is not the group its
+	// JSON category maps to. 0 means "the category's own group". Exactly one
+	// field needs it: connection.upnp_supported is a daemon capability the core
+	// serializes into [General], but the API surfaces it under `connection`.
 	ec_tagname_t read_group;
-	// Divisor between the EC value and the API value, when the two use
-	// different units. 0 means "same unit", which is every row but three.
+	// Divisor between the EC value and the API value, when the two use different
+	// units. 0 means "same unit", which is every row but three.
 	//
-	// The core stores these three as whole minutes and its accessors
-	// multiply by 60000 on the way out (Preferences.h:
-	// `s_sourceReaskMins * 60000`), so EC carries milliseconds that are
-	// always a multiple of 60000. Exposing that verbatim meant a client
-	// writing 90000 read back 60000 and one writing 30000 read back 0 --
-	// accepted, reported as success, changed underneath. The API therefore
-	// speaks the unit the daemon can actually hold, and converts here.
+	// The core stores those three as whole minutes and its accessors multiply by
+	// 60000 on the way out, so EC carries milliseconds that are always a
+	// multiple of 60000. Exposing that verbatim meant a client writing 90000
+	// read back 60000 and one writing 30000 read back 0 -- accepted, reported
+	// as success, changed underneath.
 	std::uint32_t ec_scale;
 	// Inclusive lower bound for Uint16 / Uint32, checked with `max` against the
 	// value the caller sent. 0 for a row with no floor, which is most of them.
 	//
 	// `max` alone is not a domain. A core member narrower than the declared
 	// ceiling wraps, and a setter that divides truncates, so a value inside
-	// [0, max] can still be rewritten on the way in -- and three of these
-	// fields are clamped by CPreferences::LoadAllItems() at the NEXT daemon
-	// start, which no amount of read-back checking after the PATCH can see.
-	// The bound belongs here, declaratively, where it cannot race a snapshot.
+	// [0, max] can still be rewritten on the way in -- and three of these fields
+	// are clamped by CPreferences::LoadAllItems() at the NEXT daemon start,
+	// which no read-back check after the PATCH can see.
 	std::uint32_t min;
 	// Granularity the core can actually store, when its setter divides. A value
 	// that is not a multiple is a 400 naming the step, rather than a silent
 	// truncation: SetFileBufferSize() is `val / 15000` into a uint8, so 20000
 	// becomes 15000 and 14999 becomes 0. 0 means the row is not quantised.
 	//
-	// Rejecting rather than renaming the field to its stored unit is deliberate
-	// and is the opposite of what #1159 chose for the three `_minutes` rows.
-	// Those quantised to a unit a user already thinks in, so the rename cost
-	// nothing; nobody thinks in 15000-byte blocks, and `file_buffer_blocks`
-	// would push an implementation detail into the API's vocabulary.
+	// Rejecting rather than renaming the field to its stored unit is deliberate,
+	// and the opposite of what the three `_minutes` rows do: those quantise to a
+	// unit a user already thinks in, while nobody thinks in 15000-byte blocks.
 	std::uint32_t step;
 };
 

--- a/src/webapi/RangeFileBody.h
+++ b/src/webapi/RangeFileBody.h
@@ -68,18 +68,12 @@
 
 // BOOST FLOOR
 // -----------
-// Everything used here must exist in Boost 1.70 (`MIN_BOOST_VERSION`,
-// CMakeLists.txt:4), which is close to what ubuntu:22.04's libboost-dev ships
-// and therefore what the AppImage actually compiles amuleapi against
-// (appimage/build.sh:43) — unlike the Flatpak, it does not build the pinned
-// 1.87 from source, and packaging.yml only fires on push to master, so a
-// too-new API breaks AFTER merge with nothing on the PR to catch it. Two such
-// traps have already been hit and are documented at their use sites:
-// `BOOST_BEAST_ASSIGN_EC` (a private beast/core/detail header, absent in 1.70)
-// and `http::error::short_read` (added in 1.73). The rest of the surface this
-// file touches — `beast::file` / `file_mode` / `is_file`, `beast::error_code`,
-// `http::error::bad_field`, `http::error::partial_message`, the Body/writer
-// concept itself and `boost::optional` — is all present in 1.70.
+// Everything used here must exist in Boost 1.70 (MIN_BOOST_VERSION), which is
+// close to what ubuntu:22.04's libboost-dev ships and therefore what the
+// AppImage actually compiles amuleapi against -- unlike the Flatpak, it does
+// not build the pinned 1.87 from source, and packaging.yml only fires on push
+// to master, so a too-new API breaks AFTER merge with nothing on the PR to
+// catch it. Two such traps are documented at their use sites below.
 
 #include <boost/asio/buffer.hpp>
 #include <boost/assert.hpp>
@@ -98,20 +92,15 @@
 #include <utility>
 
 // Size of the writer's read buffer, and therefore the largest single chunk
-// handed to the socket. 64 KiB is picked to be comfortably larger than a
-// typical 16-64 KiB socket send buffer — so the syscall count is bounded by the
-// socket, not by us — while still being small enough that a handful can be in
-// flight at once at the file-response concurrency cap the transport enforces.
-// The point of the whole type is that this number, not the file size, is what
-// the process pays.
-//
-// It is heap-allocated by the writer on first use rather than held inline (see
-// writer::m_buf), so a connection that never streams a file never allocates it.
+// handed to the socket. 64 KiB is comfortably larger than a typical 16-64 KiB
+// socket send buffer -- so the syscall count is bounded by the socket, not by
+// us -- while still small enough that a handful can be in flight at the file-
+// response concurrency cap. It is heap-allocated by the writer on first use,
+// so a connection that never streams a file never allocates it.
 constexpr std::size_t kRangeFileReadChunkBytes = 64 * 1024;
 
 // Boost.Beast Body concept implementation. `File` is the Beast file abstraction
-// to use; the default `boost::beast::file` resolves to the native POSIX or
-// Win32 implementation, matching what `beast::http::file_body` picks.
+// to use; the default resolves to the native POSIX or Win32 implementation.
 template <class File = boost::beast::file> struct BasicRangeFileBody
 {
 	static_assert(boost::beast::is_file<File>::value, "File type requirements not met");
@@ -122,9 +111,8 @@ template <class File = boost::beast::file> struct BasicRangeFileBody
 	class writer;
 	// No `reader`: see the SCOPE note at the top of this file.
 
-	// Called from message::payload_size, which is what prepare_payload() uses
-	// to stamp Content-Length. Returns the size of the WINDOW, not of the
-	// file — the entire reason this type exists.
+	// Called from message::payload_size, which is what prepare_payload() uses to
+	// stamp Content-Length. Returns the size of the WINDOW, not of the file.
 	static std::uint64_t size(const value_type &body) { return body.size(); }
 };
 
@@ -137,14 +125,12 @@ template <class File> class BasicRangeFileBody<File>::value_type
 
 	File m_file;
 	// Size of the file as observed at open() time. Cached because the window
-	// validation below has to compare against something stable: the file can
-	// grow or shrink under us while we serialise, and answering a Range with
-	// a Content-Length derived from a moving size is how a response ends up
-	// contradicting its own framing.
+	// validation below needs something stable to compare against: answering a
+	// Range with a Content-Length derived from a moving size is how a response
+	// ends up contradicting its own framing.
 	std::uint64_t m_file_size = 0;
 	// Inclusive window. Only meaningful once SetWindow() has succeeded;
-	// m_have_window keeps a caller that forgot from silently serialising
-	// byte 0 alone.
+	// m_have_window keeps a caller that forgot from serialising byte 0 alone.
 	std::uint64_t m_first = 0;
 	std::uint64_t m_last = 0;
 	bool m_have_window = false;
@@ -189,25 +175,16 @@ public:
 
 	const std::string &Path() const { return m_path; }
 
-	// Set the inclusive byte window to serialise. Rejects anything that does
-	// not describe at least one real byte of the file, rather than clamping:
-	// a caller that computed a window from a stale size has already put a
-	// `Content-Range` on the response describing the window it asked for, and
-	// quietly shipping a different one would make the response lie about
-	// itself. Failing here lets the transport answer 500 while the headers
-	// are still ours to change.
+	// Set the inclusive byte window to serialise. Rejects anything that does not
+	// describe at least one real byte of the file, rather than clamping: the
+	// caller has already put a `Content-Range` on the response describing the
+	// window it asked for. Failing here leaves the headers still ours to change.
 	void SetWindow(std::uint64_t first, std::uint64_t last, boost::beast::error_code &ec)
 	{
 		if (!m_file.is_open() || first > last || first >= m_file_size || last >= m_file_size) {
-			// Plain assignment rather than BOOST_BEAST_ASSIGN_EC: that macro
-			// lives in boost/beast/core/detail/config.hpp, i.e. it is a private
-			// Beast implementation detail, and it does not exist at all in the
-			// 1.70 this project declares as its floor (CMakeLists.txt:4) -- the
-			// AppImage really does build against ubuntu:22.04's libboost-dev
-			// (appimage/build.sh:43), and packaging.yml only fires on push to
-			// master, so nothing on a PR would have caught it. On the branch
-			// without source locations the macro expands to exactly this
-			// assignment; only the diagnostic location is lost.
+			// Plain assignment rather than BOOST_BEAST_ASSIGN_EC: that macro is a
+			// private Beast detail header and does not exist in 1.70 -- see the BOOST
+			// FLOOR note at the top. Only the diagnostic location is lost.
 			ec = boost::beast::http::error::bad_field;
 			m_have_window = false;
 			return;
@@ -218,9 +195,9 @@ public:
 		ec = {};
 	}
 
-	// Number of bytes this body will put on the wire — the inclusive window
-	// length. Zero before SetWindow(), which makes a forgotten call show up
-	// as an empty response rather than as an unbounded one.
+	// Number of bytes this body will put on the wire -- the inclusive window
+	// length. Zero before SetWindow(), so a forgotten call shows up as an empty
+	// response rather than an unbounded one.
 	std::uint64_t size() const { return m_have_window ? (m_last - m_first + 1) : 0; }
 
 	std::uint64_t First() const { return m_first; }
@@ -237,24 +214,19 @@ template <class File> class BasicRangeFileBody<File>::writer
 	// Bytes of the window not yet handed to the serializer.
 	std::uint64_t m_remain;
 	// Heap, not `char m_buf[kRangeFileReadChunkBytes]`. `response_serializer`
-	// stores its `writer wr_` BY VALUE (beast/http/serializer.hpp), and the
-	// transport parks that serializer in a `boost::optional` member of every
-	// Session, which reserves its storage inline whether or not it is ever
-	// engaged. An inline array therefore charged 64 KiB to every connection --
-	// including an SSE stream that lives for hours and never touches this type
-	// at all. Allocated lazily in get(), so the cost lands only on a connection
-	// that actually streams file bytes: init() runs for HEAD too (see below) but
-	// get() does not, so a HEAD still costs no allocation.
+	// stores its `writer wr_` BY VALUE, and the transport parks that serializer
+	// in a `boost::optional` member of every Session, which reserves its storage
+	// inline whether or not it is ever engaged -- so an inline array charged
+	// 64 KiB to every connection, an hours-long SSE stream included. Allocated
+	// lazily in get(), which a HEAD never reaches.
 	std::unique_ptr<char[]> m_buf;
 
 public:
 	using const_buffers_type = boost::asio::const_buffer;
 
-	// The message is taken by non-const reference because reading advances
-	// the file cursor: logically non-const even though it is bitwise const.
-	// Same trade stock file_body makes — one thread may serialise a given
-	// body at a time, which is exactly how the transport uses it (one
-	// response, one session, one strand).
+	// The message is taken by non-const reference because reading advances the
+	// file cursor: logically non-const even though it is bitwise const. Same
+	// trade stock file_body makes -- one thread may serialise a given body.
 	template <bool isRequest, class Fields>
 	writer(boost::beast::http::header<isRequest, Fields> &h, value_type &b)
 	: m_body(b)
@@ -264,15 +236,12 @@ public:
 		BOOST_ASSERT(m_body.m_file.is_open());
 	}
 
-	// Runs before any body byte is produced. This is where the file cursor
-	// is placed at the start of the window.
+	// Runs before any body byte is produced. This is where the file cursor is
+	// placed at the start of the window.
 	//
-	// NOTE FOR HEAD: `serializer::next` calls init() even in split mode, i.e.
-	// even when only `async_write_header` will ever run. That is fine and
-	// intended — a seek moves a cursor, it reads nothing — and it is the
-	// reason a HEAD on a file response costs one open + one lseek and not a
-	// single byte of I/O, while still reporting the Content-Length a GET
-	// would have produced (that number comes from Body::size, not from here).
+	// NOTE FOR HEAD: `serializer::next` calls init() even in split mode. That is
+	// intended -- a seek moves a cursor, it reads nothing -- and it is why a HEAD
+	// costs one open + one lseek and not a single byte of I/O.
 	void init(boost::beast::error_code &ec)
 	{
 		m_body.m_file.seek(m_body.m_first, ec);
@@ -282,29 +251,25 @@ public:
 		ec = {};
 	}
 
-	// Called repeatedly until it returns boost::none. Reads at most whatever
-	// is left of the window, so the last chunk is naturally partial and we
-	// can never over-read past `last` even though the file continues.
+	// Called repeatedly until it returns boost::none. Reads at most whatever is
+	// left of the window, so we can never over-read past `last`.
 	boost::optional<std::pair<const_buffers_type, bool>> get(boost::beast::error_code &ec)
 	{
 		const std::size_t amount = m_remain > kRangeFileReadChunkBytes
 						   ? kRangeFileReadChunkBytes
 						   : static_cast<std::size_t>(m_remain);
 
-		// Window fully served. (Also the degenerate zero-length case, which
-		// SetWindow refuses to create but a defaulted value_type still has.)
-		// Tested before the allocation below, so the no-bytes case stays
-		// allocation-free.
+		// Window fully served, or the degenerate zero-length case. Tested before
+		// the allocation below, so the no-bytes case stays allocation-free.
 		if (amount == 0) {
 			ec = {};
 			return boost::none;
 		}
 
 		if (!m_buf) {
-			// Throwing new, not nothrow: a failed 64 KiB allocation is a
-			// process already past saving, and the bad_alloc propagates out of
-			// the async op into the same connection teardown the read-error
-			// branch below produces.
+			// Throwing new, not nothrow: a failed 64 KiB allocation is a process
+			// already past saving, and the bad_alloc propagates out of the async op
+			// into the same connection teardown the read-error branch produces.
 			m_buf.reset(new char[kRangeFileReadChunkBytes]);
 		}
 
@@ -312,20 +277,13 @@ public:
 		if (ec) {
 			return boost::none;
 		}
-		// A short read is legal and handled by simply returning fewer bytes;
-		// a ZERO-length read is not, because we asked for bytes the cached
-		// size said were there. That means the file was truncated under us
-		// mid-response, and there is no honest way to finish a body whose
-		// Content-Length is already on the wire — so surface it as an error
-		// and let the transport tear the connection down, which is the only
-		// signal a client can still read at that point.
+		// A short read is legal and handled by returning fewer bytes; a ZERO-length
+		// read is not, because we asked for bytes the cached size said were there.
+		// That means the file was truncated under us mid-response, and there is no
+		// honest way to finish a body whose Content-Length is already on the wire.
 		//
 		// `partial_message` and not the more descriptive `short_read`: that
-		// enumerator was only added to http::error in Boost 1.73, and this
-		// project's floor is 1.70 (CMakeLists.txt:4) -- same trap as the
-		// BOOST_BEAST_ASSIGN_EC note in SetWindow above. Nothing reads the
-		// value: WriteFileResponse's completion handler discards `ec` and
-		// closes the connection, which is the whole of the contract here.
+		// enumerator arrived in Boost 1.73 -- see the BOOST FLOOR note at the top.
 		if (nread == 0) {
 			ec = boost::beast::http::error::partial_message;
 			return boost::none;

--- a/src/webapi/Refresher.cpp
+++ b/src/webapi/Refresher.cpp
@@ -172,11 +172,10 @@ const char *KadStateString(const CEC_ConnState_Tag *conn)
 	return "connecting";
 }
 
-// As above, but an unset address formats as empty rather than "0.0.0.0".
-// The peer and server fields use 0 for "not known" and emit the key as null on it,
-// whereas the Kad fields report the quad verbatim — which is the only
-// difference there has ever been between these two, and the reason the
-// distinction is a wrapper rather than a second formatter.
+// As above, but an unset address formats as empty rather than "0.0.0.0". The
+// peer and server fields use 0 for "not known" and emit the key as null on it,
+// whereas the Kad fields report the quad verbatim -- which is the only
+// difference there has ever been between these two.
 std::string FormatClientIpv4(std::uint32_t ip_lsb_first)
 {
 	return ip_lsb_first == 0 ? std::string() : IPv4ToDotted(ip_lsb_first);
@@ -226,14 +225,10 @@ void ParseStatusFromPacket(const CECPacket *resp, StatusSnapshot &out)
 				if (name) {
 					out.server_name = std::string(name->GetStringData().utf8_str());
 				}
-				// Not StringIP(): every overload of it appends ":port"
-				// and wraps the result in brackets, so `server_ip` used
-				// to read "[77.42.68.79:4232]" -- contradicting both its
-				// name and its declared "dotted-quad" contract, and
-				// giving a client that joins it with `server_port` the
-				// nonsense "[77.42.68.79:4232]:4232". Format from the
-				// raw address the way every other IP on this surface is
-				// formatted; the port stays in `server_port`.
+				// Not StringIP(): every overload of it appends ":port" and wraps
+				// the result in brackets, so `server_ip` used to read
+				// "[77.42.68.79:4232]" -- contradicting its declared dotted-quad
+				// contract. The port stays in `server_port`.
 				out.server_ip = FormatClientIpv4(server->GetIPv4Data().IP());
 				out.server_port = server->GetIPv4Data().m_port;
 			}
@@ -256,8 +251,8 @@ void ParseStatusFromPacket(const CECPacket *resp, StatusSnapshot &out)
 	if (const CECTag *t = resp->GetTagByName(EC_TAG_STATS_UL_SPEED)) {
 		out.upload_bytes_per_second = static_cast<std::uint64_t>(t->GetInt());
 	}
-	// Overhead rates and free space ride the same EC_DETAIL_FULL response.
-	// The two disk figures are cast through int64 on purpose: amuled's
+	// Overhead rates and free space ride the same EC_DETAIL_FULL response. The
+	// two disk figures are cast through int64 on purpose: amuled's
 	// FREE_SPACE_UNKNOWN is -1 and the serializer casts it to uint64, so an
 	// unsigned read would turn "unknown" into 18446744073709551615.
 	if (const CECTag *t = resp->GetTagByName(EC_TAG_STATS_UP_OVERHEAD)) {
@@ -278,18 +273,13 @@ void ParseStatusFromPacket(const CECPacket *resp, StatusSnapshot &out)
 	if (const CECTag *t = resp->GetTagByName(EC_TAG_STATS_TOTAL_SRC_COUNT)) {
 		out.total_src_count = static_cast<std::uint32_t>(t->GetInt());
 	}
-	// ed2k network aggregate — the same EC_OP_STAT_REQ response
-	// already carries KAD_USERS / KAD_FILES (parsed further down in
-	// ParseKadFromPacket), plus ED2K_USERS / ED2K_FILES sitting right
-	// next to them (ExternalConn.cpp:762-768). Read them here so
-	// /status can surface ed2k.network.{users,files} symmetric with
-	// kad.network.{users,files,nodes} — no extra EC round-trip.
+	// ed2k network aggregate -- the same EC_OP_STAT_REQ response already carries
+	// KAD_USERS / KAD_FILES, plus ED2K_USERS / ED2K_FILES next to them, so
+	// /status can surface ed2k.network.{users,files} with no extra roundtrip.
 	//
-	// Gated on being connected. amuled emits these tags unconditionally, above
-	// its own `if (IsConnected())` block, and CServerList::GetUserFileStatus
-	// sums the whole known server list rather than the server we are attached
-	// to -- so nothing zeroes them on disconnect. Measured: a disconnected
-	// daemon kept reporting the identical figures it had while connected.
+	// Gated on being connected: amuled emits these tags unconditionally, above
+	// its own `if (IsConnected())` block, and CServerList::GetUserFileStatus sums
+	// the whole known server list, so nothing zeroes them on disconnect.
 	if (out.ed2k_state == "connected") {
 		if (const CECTag *t = resp->GetTagByName(EC_TAG_STATS_ED2K_USERS)) {
 			out.ed2k_users = static_cast<std::uint32_t>(t->GetInt());
@@ -299,9 +289,8 @@ void ParseStatusFromPacket(const CECPacket *resp, StatusSnapshot &out)
 		}
 		out.has_ed2k_network = true;
 	}
-	// Version-check result (present only once the daemon has completed a
-	// check). LATEST carries the release string; its presence means a check
-	// is done. OUTDATED is an empty marker present only for a newer release.
+	// Version-check result, present only once the daemon has completed a check.
+	// LATEST carries the release string; OUTDATED is an empty presence marker.
 	if (const CECTag *t = resp->GetTagByName(EC_TAG_GENERAL_VERSION_CHECK_LATEST)) {
 		out.version_check_done = true;
 		out.version_check_latest = std::string(t->GetStringData().utf8_str());
@@ -311,31 +300,25 @@ void ParseStatusFromPacket(const CECPacket *resp, StatusSnapshot &out)
 			out.version_check_timestamp = static_cast<std::uint64_t>(ts->GetInt());
 		}
 	}
-	// Nickname intentionally absent: it isn't shipped in the
-	// EC_OP_STAT_REQ response. amuled returns it from
-	// EC_OP_GET_PREFERENCES / EC_OP_GET_STATSTREE@DETAIL_WEB; the
-	// /preferences endpoint exposes it instead.
+	// Nickname intentionally absent: it is not shipped in the EC_OP_STAT_REQ
+	// response, and /preferences exposes it instead.
 }
 
 namespace
 {
 
-// PartFile status code (PS_*, see Constants.h) → wire string. amule
-// has more codes than the API surface — we collapse "completing"/
-// "complete"/"hashing" etc. to the names a curl-tests reader would
-// recognise. "downloading" is overloaded: it covers PS_READY (the
-// daemon's "transferring" state) AND PS_EMPTY (no sources right now
-// but the file isn't paused) — clients distinguish by reading
+// PartFile status code (PS_*, Constants.h) -> wire string. amule has more codes
+// than the API surface. "downloading" is overloaded: it covers PS_READY (the
+// daemon's "transferring" state) AND PS_EMPTY (no sources right now but the
+// file is not paused) -- clients distinguish by reading
 // `speed_bytes_per_second` and `sources.transferring`.
 const char *DownloadStatusName(std::uint8_t ps_code, bool stopped)
 {
-	// PS_COMPLETE / PS_COMPLETING take priority over `stopped` —
-	// amuled holds finished downloads in `m_completedDownloads` with
-	// the EC_TAG_PARTFILE_STOPPED flag set, so a naive `if (stopped)
-	// return "paused"` early-out masks every cleared-pending file
-	// as still-paused. The "completed" wire string is reserved for
-	// the precise semantic "in m_completedDownloads, awaiting clear"
-	// — consumers (and the /downloads default filter) rely on it.
+	// PS_COMPLETE / PS_COMPLETING take priority over `stopped`: amuled holds
+	// finished downloads in `m_completedDownloads` with EC_TAG_PARTFILE_STOPPED
+	// set, so a naive `if (stopped) return "paused"` early-out masks every
+	// cleared-pending file as still-paused. The "completed" wire string is
+	// reserved for "in m_completedDownloads, awaiting clear".
 	if (ps_code == PS_COMPLETE)
 		return "completed";
 	if (ps_code == PS_COMPLETING)
@@ -370,26 +353,17 @@ const char *DownloadStatusName(std::uint8_t ps_code, bool stopped)
 	}
 }
 
-// The auto-priority flag is encoded as `prio + 10`, NOT bit-7
-// (`& 0x80`). Pattern lifted from amule-remote-gui.cpp:1424:
-//
-// if (m_iUpPriorityEC >= 10) {
-//      m_iUpPriority    = m_iUpPriorityEC - 10;
-//      m_bAutoUpPriority = true;
-//  }
-//
-// Same encoding for `EC_TAG_KNOWNFILE_PRIO` (shared, up-side) and
-// `EC_TAG_PARTFILE_PRIO` (downloads, down-side). Using bit-7 here
-// silently mis-labels every auto-priority entry as "normal" because
-// the PR_* enum values are tiny and never overlap with the 0x80 bit.
+// The auto-priority flag is encoded as `prio + 10`, NOT bit-7 (`& 0x80`) --
+// the pattern amule-remote-gui.cpp uses. Same encoding for
+// EC_TAG_KNOWNFILE_PRIO (shared, up-side) and EC_TAG_PARTFILE_PRIO (downloads,
+// down-side). Using bit-7 here silently mis-labels every auto-priority entry as
+// "normal", because the PR_* enum values are tiny and never overlap 0x80.
 constexpr std::uint8_t kAutoPriorityOffset = 10;
 
 // Decodes the shared `+ 10` auto-flag offset carried by both
-// `EC_TAG_PARTFILE_PRIO` (download, down-side) and
-// `EC_TAG_KNOWNFILE_PRIO` (shared, up-side): a raw code >= 10 is an
-// auto entry whose base level is `raw - 10`. Returns the base level as
-// a wire string and reports the auto flag via `auto_out`, so downloads
-// and shared surface priority identically (`priority` + `priority_auto`).
+// EC_TAG_PARTFILE_PRIO and EC_TAG_KNOWNFILE_PRIO: a raw code >= 10 is an auto
+// entry whose base level is `raw - 10`. Returns the base level as a wire string
+// and reports the auto flag via `auto_out`.
 const char *PriorityName(std::uint8_t pr_code_raw, bool &auto_out)
 {
 	std::uint8_t pr;
@@ -432,24 +406,10 @@ std::string TagHashLower(const CEC_SharedFile_Tag *sf)
 	return h;
 }
 
-// Merge a CEC_PartFile_Tag's PRESENT child tags into an existing
-// FileSnapshot. Absent tags leave the corresponding field unchanged
-// — that's the point of INC mode.
-//
-// Identity (name, ed2k_link, size, priority) lives at the top level
-// because both walkers populate it; download-specific stats land in
-// `f.download`. The caller is responsible for setting f.ecid + f.hash
-// on first encounter and for flipping f.is_downloading=true.
-//
-// `is_new` distinguishes first-encounter from INC update — used only
-// for the status-string re-derive (idle-on-status-suppressed shouldn't
-// silently lose the prior status).
-
-// Decode the base CKnownFile detail tags carried by BOTH EC_TAG_PARTFILE
-// and EC_TAG_KNOWNFILE (via the CEC_SharedFile_Tag base ctor), so the
-// download and shared detail endpoints share one decode. Detail-only;
-// absent from the list payloads. INC-safe: only assigns when a tag is
-// present this frame, otherwise the prior value is retained.
+// Decode the base CKnownFile detail tags carried by BOTH EC_TAG_PARTFILE and
+// EC_TAG_KNOWNFILE (via the CEC_SharedFile_Tag base ctor), so the download and
+// shared detail endpoints share one decode. Detail-only, and INC-safe: only
+// assigns when a tag is present this frame.
 void MergeKnownFileDetail(const CECTag *t, FileSnapshot &f)
 {
 	if (const CECTag *aich = t->GetTagByName(EC_TAG_KNOWNFILE_AICH_MASTERHASH))
@@ -467,9 +427,8 @@ void MergeKnownFileDetail(const CECTag *t, FileSnapshot &f)
 	std::uint32_t rt = 0;
 	if (t->AssignIfExist(EC_TAG_KNOWNFILE_RATING, rt))
 		f.rating = static_cast<std::int32_t>(rt);
-	// Audio/video media metadata (issue #418). amuled emits these only
-	// for probed files, so any one present this frame marks the file as
-	// having media (INC-safe: absent tags keep the prior value).
+	// Audio/video media metadata. amuled emits these only for probed files, so
+	// any one present this frame marks the file as having media.
 	{
 		std::uint32_t v = 0;
 		if (t->AssignIfExist(EC_TAG_KNOWNFILE_MEDIA_LENGTH, v)) {
@@ -494,13 +453,18 @@ void MergeKnownFileDetail(const CECTag *t, FileSnapshot &f)
 	// Derived from what the snapshot now holds rather than latched true by
 	// whichever tag happened to arrive. A zero / empty value is the daemon
 	// clearing that field, so latching would report has_media on a file whose
-	// every field has since been cleared -- and assigning the empty value
-	// above is what makes a clear propagate at all.
+	// every field has since been cleared.
 	f.has_media = f.media.duration_seconds != 0 || f.media.bitrate_kilobits_per_second != 0 ||
 		      !f.media.codec.empty() || !f.media.artist.empty() || !f.media.album.empty() ||
 		      !f.media.title.empty();
 }
 
+// Merge a CEC_PartFile_Tag's PRESENT child tags into an existing FileSnapshot.
+// Absent tags leave the corresponding field unchanged -- that is the point of
+// INC mode. Identity (name, ed2k_link, size, priority) lives at the top level
+// because both walkers populate it; download-specific stats land in
+// `f.download`. The caller sets f.ecid + f.hash on first encounter and flips
+// f.is_downloading. `is_new` is used only for the status-string re-derive.
 void MergePartFileTag(const CEC_PartFile_Tag *pf, FileSnapshot &f, bool is_new)
 {
 	wxString fn;
@@ -555,11 +519,9 @@ void MergePartFileTag(const CEC_PartFile_Tag *pf, FileSnapshot &f, bool is_new)
 	}
 	{
 		// Upload priority also rides on the partfile tag (the base
-		// CEC_SharedFile_Tag ctor adds EC_TAG_KNOWNFILE_PRIO). Capture
-		// it here, from the file's first downloading tick, so a partfile
-		// that starts sharing only later still has a shared `priority`:
-		// by then amuled has CValueMap-suppressed the unchanged tag and
-		// the shared walker would never see it (empty-priority bug).
+		// CEC_SharedFile_Tag ctor adds EC_TAG_KNOWNFILE_PRIO). Capture it here,
+		// from the file's first downloading tick, so a partfile that starts sharing
+		// only later still has a shared `priority`: by then the tag is suppressed.
 		std::uint8_t up_raw = 0;
 		if (pf->AssignIfExist(EC_TAG_KNOWNFILE_PRIO, up_raw)) {
 			bool up_auto = false;
@@ -609,11 +571,10 @@ void MergePartFileTag(const CEC_PartFile_Tag *pf, FileSnapshot &f, bool is_new)
 		if (pf->AssignIfExist(EC_TAG_PARTFILE_GAINED_COMPRESSION, v))
 			f.download.gained_by_compression_bytes = v;
 	}
-	// Per-source comments/ratings (issue #419). The EC container packs
-	// four children per source, evaluated by index: username, filename,
-	// rating (int8; -1 = unrated), comment. Rebuild the list whenever the
-	// container is present (CValueMap-suppressed when unchanged, so an
-	// absent container keeps the prior list).
+	// Per-source comments/ratings. The EC container packs four children per
+	// source, evaluated by index: username, filename, rating (int8; -1 =
+	// unrated), comment. Rebuild whenever the container is present -- it is
+	// CValueMap-suppressed when unchanged, so absent keeps the prior list.
 	if (const CECTag *cont = pf->GetTagByName(EC_TAG_PARTFILE_COMMENTS)) {
 		std::vector<const CECTag *> kids;
 		for (const CECTag &kid : *cont)
@@ -633,12 +594,10 @@ void MergePartFileTag(const CEC_PartFile_Tag *pf, FileSnapshot &f, bool is_new)
 	if (const CECTag *ks = pf->GetTagByName(EC_TAG_PARTFILE_KAD_COMMENT_SEARCHING)) {
 		f.download.kad_comment_searching = ks->GetInt() != 0;
 	}
-	// Source-reported filenames (issue #420). amuled delta-encodes the
-	// container keyed by a stable per-name id: a child carrying a name
-	// subtag is a new/updated entry; a child with COUNTS==0 and no name
-	// is a removal; otherwise it's a count update. The container is only
-	// sent when something changed (HasChildTags gate on the daemon), so
-	// an absent container keeps the accumulated map.
+	// Source-reported filenames. amuled delta-encodes the container keyed by a
+	// stable per-name id: a child carrying a name subtag is a new/updated entry,
+	// a child with COUNTS==0 and no name is a removal, otherwise a count update.
+	// The container is only sent when something changed.
 	if (const CECTag *names = pf->GetTagByName(EC_TAG_PARTFILE_SOURCE_NAMES)) {
 		for (const CECTag &child : *names) {
 			const std::uint32_t id = static_cast<std::uint32_t>(child.GetInt());
@@ -681,10 +640,9 @@ void MergePartFileTag(const CEC_PartFile_Tag *pf, FileSnapshot &f, bool is_new)
 					  : 0.0;
 }
 
-// State-code → wire-string decoders for the four enums amule ships
-// on `EC_TAG_CLIENT_*_STATE`. Wire forms are snake_case names of our
-// own, not the Constants.h identifiers lowercased. All decoders fall
-// back to "unknown" for codes outside the enum.
+// State-code -> wire-string decoders for the four enums amule ships on
+// EC_TAG_CLIENT_*_STATE. Wire forms are snake_case names of our own, not the
+// Constants.h identifiers lowercased, and all fall back to "unknown".
 
 const char *ClientUploadStateName(std::uint8_t code)
 {
@@ -772,27 +730,18 @@ const char *ClientIdentStateName(std::uint8_t code)
 //
 // Two shapes on the wire, and the empty one is the trap: for
 // EC_TAG_CLIENT_PART_STATUS the core sends a tag with no payload when the peer
-// holds EVERY part (ECSpecialCoreTags.cpp), so an empty tag means "full", not
-// "unknown". The caller learns that through `out_all` because the true length
-// is the file's part count, which is known only where the row is rendered.
+// holds EVERY part, so an empty tag means "full", not "unknown". The caller
+// learns that through `out_all` because the true length is the file's part
+// count, which is known only where the row is rendered.
 //
 // The shorthand is download-side ONLY. EC_TAG_CLIENT_UPLOAD_PART_STATUS is
-// always sent as a buffer, with no AllTrue() branch, so a full uploader
-// arrives as an all-ones bitmap instead. Both are normalised to the same
-// fixed-length array by the renderer, so nothing downstream sees the
-// difference -- but do not read the two tags as symmetrical.
-//
-// An empty UPLOAD tag is not impossible, just narrow: the core emits it when
-// `upPartStatus.size() == file->GetPartCount()` and SizeBuffer() is 0, which
-// needs both to be zero, i.e. a zero-byte file (CKnownFile sets part count 0
-// for one). It decodes to `out_all` here and is then dropped by the
-// renderer's `part_count == 0` guard rather than becoming a bogus all-true
-// bitmap -- so that guard is load-bearing, not dead code.
+// always sent as a buffer, so a full uploader arrives as an all-ones bitmap.
+// An empty UPLOAD tag is narrow but possible -- a zero-byte file, for which
+// CKnownFile sets part count 0 -- and is dropped by the renderer's
+// `part_count == 0` guard, which is therefore load-bearing, not dead code.
 //
 // The buffer holds ceil(bits/8) bytes, so decoding yields a multiple of 8 and
-// the tail beyond the file's part count is padding to be trimmed by the
-// renderer -- which also rejects a bitmap too short for the file rather than
-// padding it out.
+// the tail beyond the file's part count is padding for the renderer to trim.
 void DecodePartStatusTag(const CECTag *client_tag,
 	ec_tagname_t tag_name,
 	std::vector<bool> &out_bits,
@@ -818,13 +767,9 @@ void DecodePartStatusTag(const CECTag *client_tag,
 	}
 }
 
-// Format an IP from EC_TAG_CLIENT_USER_IP. The EC tag holds a
-// 32-bit host-order IPv4; we render it dotted-quad. Returns "" for
-// zero IPs (commonly the case for clients we've never confirmed).
-// Merge a `CEC_UpDownClient_Tag` into an existing ClientSnapshot.
-// On a cache-miss the caller pre-populates ecid + hashes; on a hit
-// the AssignIfExist pattern leaves cached values intact when the
-// tag is CValueMap-suppressed by amuled.
+// Merge a `CEC_UpDownClient_Tag` into an existing ClientSnapshot. On a
+// cache-miss the caller pre-populates ecid + hashes; on a hit the AssignIfExist
+// pattern leaves cached values intact when the tag is CValueMap-suppressed.
 void MergeClientTag(const CEC_UpDownClient_Tag *c, ClientSnapshot &cs, bool is_new, const FileMap &files)
 {
 	if (const CECTag *t = c->GetTagByName(EC_TAG_CLIENT_NAME)) {
@@ -852,28 +797,20 @@ void MergeClientTag(const CEC_UpDownClient_Tag *c, ClientSnapshot &cs, bool is_n
 	if (c->AssignIfExist(EC_TAG_CLIENT_SOFTWARE, soft_code))
 		cs.software = ClientSoftwareName(soft_code);
 
-	// software_version: the daemon formats this with gettext -- an
-	// unidentified peer yields _("Unknown"), which is "Desconocido" on a
-	// Spanish daemon and would leak the daemon locale into the English-only
-	// API (#359). amuleapi runs in its own process and can't reverse the
-	// translation, so we key off the locale-independent numeric software
-	// code instead of the string: a client the daemon couldn't identify
-	// (SO_UNKNOWN, which is exactly the branch that sets the translated
-	// "Unknown") never has the string read at all, and is left empty.
-	//
-	// Empty then reaches the wire as null rather than as an "unknown"
-	// sentinel. software_version is free text, not an enum -- unlike
-	// `software`, there is no member to fall back to -- and R10 wants an
-	// unknown value spelled null. It also matches WriteKnownClientObject,
-	// which nulls this key rather than inventing a value for it.
+	// software_version: the daemon formats this with gettext -- an unidentified
+	// peer yields _("Unknown"), which is "Desconocido" on a Spanish daemon and
+	// would leak the daemon locale into the English-only API. So we key off the
+	// locale-independent numeric software code instead: a peer the daemon could
+	// not identify (SO_UNKNOWN, exactly the branch that sets the translated
+	// string) never has the string read at all, and is left empty -- which
+	// reaches the wire as null, since software_version is free text, not an enum.
 	if (soft_code != static_cast<std::uint32_t>(SO_UNKNOWN)) {
 		if (const CECTag *t = c->GetTagByName(EC_TAG_CLIENT_SOFT_VER_STR)) {
 			cs.software_version = std::string(t->GetStringData().utf8_str());
 		}
 	}
 	// reported_os is the peer's own self-reported OS string (raw external data,
-	// not gettext-translated by our daemon), so it carries no locale-leak;
-	// it is frequently empty because most clients don't send it.
+	// not gettext-translated), so it carries no locale leak. Often empty.
 	if (const CECTag *t = c->GetTagByName(EC_TAG_CLIENT_OS_INFO)) {
 		cs.reported_os = std::string(t->GetStringData().utf8_str());
 	}
@@ -903,8 +840,7 @@ void MergeClientTag(const CEC_UpDownClient_Tag *c, ClientSnapshot &cs, bool is_n
 	}
 	{
 		// Tag-present is the daemon's answer either way; tag-absent leaves the
-		// cached value alone, the incremental-update rule the rest of this
-		// function follows. has_connected stays false only for a daemon that
+		// cached value alone. has_connected stays false only for a daemon that
 		// never sends it at all, and that reaches the wire as null.
 		bool v = false;
 		if (c->AssignIfExist(EC_TAG_CLIENT_CONNECTED, v)) {
@@ -913,32 +849,26 @@ void MergeClientTag(const CEC_UpDownClient_Tag *c, ClientSnapshot &cs, bool is_n
 		}
 	}
 	// REMOTE_FILENAME = the file we are downloading from this peer
-	// (`m_clientFilename` is set from OP_REQFILENAMEANSWER; see
-	// DownloadClient.cpp:350). Live only at INC_UPDATE detail.
+	// (`m_clientFilename`, set from OP_REQFILENAMEANSWER). INC_UPDATE only.
 	wxString fn;
 	if (c->RemoteFilename(fn)) {
 		cs.download_file_name = std::string(fn.utf8_str());
 	}
 	// UPLOAD_FILE / REQUEST_FILE carry amuled-side ECIDs (the unified
-	// m_FileEncoder map's IDs), which is what `files` is keyed by, so
-	// resolve to MD4 hashes with a lookup per transferring peer. Empty
-	// hash if the ECID isn't there — file may have been removed between
-	// the file walkers and this client walker.
+	// m_FileEncoder map's IDs), which is what `files` is keyed by, so resolve to
+	// MD4 hashes with a lookup per transferring peer. Empty hash if the ECID is
+	// not there -- the file may have been removed between the file walkers and
+	// this one.
 	//
-	// A zero ECID is the core saying "no file", not "unchanged":
-	// ECSpecialCoreTags.cpp:438-443 emits `file->ECID()` or a literal 0 for
-	// both tags. Reading 0 as absent left the last hash cached forever, so a
-	// peer that finished downloading kept its `role: "source"` row in
-	// /downloads/{hash}/clients for as long as it stayed in clientlist.
+	// A zero ECID is the core saying "no file", not "unchanged". Reading 0 as
+	// absent left the last hash cached forever, so a peer that finished
+	// downloading kept its `role: "source"` row for as long as it stayed in
+	// clientlist.
 	//
-	// Whenever the hash moves, the matching per-part bitmap has to go with
-	// it. CUpDownClient::SetReqFile clears m_downPartStatus without
-	// repopulating it (DownloadClient.cpp:1683) and the core then sends no
-	// PART_STATUS until the peer answers for the new file, so a bitmap kept
-	// across the change describes the OLD file -- reported either as "holds
-	// every part" or as the old bitmap truncated to the new part count.
-	// amulegui re-zeroes its bitvector on the same transition; this decoder
-	// now does too.
+	// Whenever the hash moves, the matching per-part bitmap has to go with it:
+	// CUpDownClient::SetReqFile clears m_downPartStatus without repopulating it
+	// and the core then sends no PART_STATUS until the peer answers for the new
+	// file, so a bitmap kept across the change describes the OLD file.
 	{
 		std::uint32_t v = 0;
 		if (c->AssignIfExist(EC_TAG_CLIENT_UPLOAD_FILE, v)) {
@@ -999,9 +929,8 @@ void MergeClientTag(const CEC_UpDownClient_Tag *c, ClientSnapshot &cs, bool is_n
 			cs.upload_speed_bytes_per_second = v;
 	}
 	{
-		// EC_TAG_CLIENT_DOWN_SPEED is emitted as a double-encoded
-		// CECTag (see ECSpecialCoreTags.cpp:289-291 — KBps as a
-		// double). AssignIfExist with a uint won't pick it up cleanly;
+		// EC_TAG_CLIENT_DOWN_SPEED is emitted as a double-encoded CECTag (KBps as a
+		// double). AssignIfExist with a uint will not pick it up cleanly, so
 		// extract via the typed read and convert.
 		if (const CECTag *t = c->GetTagByName(EC_TAG_CLIENT_DOWN_SPEED)) {
 			const double kBps = t->GetDoubleData();
@@ -1030,10 +959,10 @@ void MergeClientTag(const CEC_UpDownClient_Tag *c, ClientSnapshot &cs, bool is_n
 		}
 	}
 	{
-		// Taken as delivered. The daemon already dropped the bits it does
-		// not know (CPeerCapabilities::SetFromWire), and re-masking here
-		// would put a second copy of that mask in the tree, free to drift
-		// from the one that actually saw the handshake.
+		// Taken as delivered. The daemon already dropped the bits it does not know
+		// (CPeerCapabilities::SetFromWire), and re-masking here would put a second
+		// copy of that mask in the tree, free to drift from the one that saw the
+		// handshake.
 		std::uint32_t v = cs.protocol_extensions;
 		if (c->AssignIfExist(EC_TAG_CLIENT_MOD_CAPABILITIES, v))
 			cs.protocol_extensions = v;
@@ -1044,16 +973,14 @@ void MergeClientTag(const CEC_UpDownClient_Tag *c, ClientSnapshot &cs, bool is_n
 			cs.friend_slot = v;
 	}
 
-	// --- Detail-only fields (issue #422) -----------------------------
-	// All already on the INC_UPDATE wire (ECSpecialCoreTags.cpp) but not
-	// surfaced by the list; the detail endpoint serializes them.
+	// --- Detail-only fields -----------------------------
+	// All already on the INC_UPDATE wire but not surfaced by the list.
 	{
 		std::uint32_t v = 0;
 		if (c->AssignIfExist(EC_TAG_CLIENT_USER_ID, v)) {
 			cs.ed2k_user_id = v;
-			// A LowID peer has a hybrid id below 0x1000000 (IsLowID(),
-			// NetworkFunctions.h); inline the ed2k-stable ceiling rather
-			// than drag the core header into the webapi decoder.
+			// A LowID peer has a hybrid id below 0x1000000 (IsLowID()); inline the
+			// ed2k-stable ceiling rather than drag the core header in here.
 			const std::uint32_t kLowIdCeiling = 16777216u;
 			cs.high_id = v >= kLowIdCeiling;
 		}
@@ -1082,17 +1009,14 @@ void MergeClientTag(const CEC_UpDownClient_Tag *c, ClientSnapshot &cs, bool is_n
 			cs.source_origin = SourceOriginName(v);
 	}
 	// PARTFILE_NAME rides inside the client tag only while the peer is
-	// downloading from us (ECSpecialCoreTags.cpp:331); leave the cached
-	// value when absent.
+	// downloading from us; leave the cached value when absent.
 	if (const CECTag *t = c->GetTagByName(EC_TAG_PARTFILE_NAME)) {
 		cs.upload_file_name = std::string(t->GetStringData().utf8_str());
 	}
 	// Per-part bitmaps. Both tags carry a raw BitVector buffer, bit i at
 	// buffer[i / 8] & (1 << (i & 7)) -- LSB-first within each byte, matching
-	// BitVector::s_posMask. An EMPTY tag is the core's shorthand for "has
-	// every part" on the DOWNLOAD tag only; see DecodePartStatusTag. Absent
-	// means unchanged, per the tagmap convention the rest of this decoder
-	// follows, so the has_ flags only ever go from false to true.
+	// BitVector::s_posMask. An EMPTY tag is the core's shorthand for "has every
+	// part" on the DOWNLOAD tag only; see DecodePartStatusTag.
 	DecodePartStatusTag(
 		c, EC_TAG_CLIENT_PART_STATUS, cs.part_status, cs.part_status_all, cs.has_part_status);
 	DecodePartStatusTag(c,
@@ -1130,10 +1054,8 @@ void MergeClientTag(const CEC_UpDownClient_Tag *c, ClientSnapshot &cs, bool is_n
 			cs.view_shared_disabled = v;
 	}
 
-	// --- Friend status + DL/UP modifier (issue #423, new EC tags) ----
-	// Absent when talking to a core built before #423 (older peers just
-	// don't send them); the AssignIfExist / GetTagByName guards leave
-	// the defaults in place.
+	// --- Friend status + DL/UP modifier ----
+	// Absent on an older core; the AssignIfExist guards leave the defaults.
 	{
 		bool v = false;
 		if (c->AssignIfExist(EC_TAG_CLIENT_IS_FRIEND, v))
@@ -1201,11 +1123,10 @@ void MergeSharedTag(const CEC_SharedFile_Tag *sf, FileSnapshot &f)
 		if (sf->AssignIfExist(EC_TAG_KNOWNFILE_COMPLETE_SOURCES_HIGH, v))
 			f.shared.complete_sources_high = v;
 
-		// Parts hashed so far by a Verify Local Data or an AICH hashset
-		// rebuild over this complete share. Rides every update tick,
-		// CValueMap-suppressed when unchanged, so it moves only while a
-		// hash is actually running. The partfile equivalent is decoded
-		// into download.hashed_part_count above.
+		// Parts hashed so far by a Verify Local Data or an AICH hashset rebuild
+		// over this complete share. Rides every update tick, CValueMap-suppressed
+		// when unchanged, so it moves only while a hash is running. The partfile
+		// equivalent is decoded into download.hashed_part_count above.
 		if (sf->AssignIfExist(EC_TAG_KNOWNFILE_HASHED_PART_COUNT, v))
 			f.shared.hashing_progress = v;
 	}
@@ -1249,12 +1170,10 @@ void MergeSharedTag(const CEC_SharedFile_Tag *sf, FileSnapshot &f)
 namespace
 {
 
-// Apply the stateful RLE decode for the gap + part-status blobs on
-// one partfile tag. Allocates `rle_state[ecid]` if absent; mutates
-// it on each call (XOR-deltas against the prior decoded buffer).
-// Output lands in `f.download.decoded_gaps` + `f.download
-// .decoded_part_sources`. HTTP handlers read those without touching
-// the decoder state.
+// Apply the stateful RLE decode for the gap + part-status blobs on one partfile
+// tag. Allocates `rle_state[ecid]` if absent; mutates it on each call
+// (XOR-deltas against the prior decoded buffer). HTTP handlers read the output
+// without touching the decoder state.
 void DecodeRleBlobsForPartFile(
 	const CEC_PartFile_Tag *pf, FileSnapshot &f, std::map<std::uint32_t, PartFileEncoderData> &rle_state)
 {
@@ -1273,16 +1192,13 @@ void DecodeRleBlobsForPartFile(
 	}
 }
 
-// Same stateful decode for the availability blob on one *knownfile*
-// tag -- a complete shared file, which carries EC_TAG_PARTFILE_PART_STATUS
-// but no gap/req blobs (CKnownFile_Encoder::Encode emits only the part
-// status). Output lands in `f.shared.decoded_part_sources`, backing the
-// shared "Obtained Parts" bar.
+// Same stateful decode for the availability blob on one *knownfile* tag -- a
+// complete shared file, which carries EC_TAG_PARTFILE_PART_STATUS but no
+// gap/req blobs. Output backs the shared "Obtained Parts" bar.
 //
-// Shares `rle_state` with the partfile decoder above on purpose; see the
-// note on ApplyGetUpdateToShared in Refresher.h for why one map per ECID
-// is the correct mirror of the daemon's encoder set rather than a
-// collision waiting to happen.
+// Shares `rle_state` with the partfile decoder above on purpose; see the note
+// on ApplyGetUpdateToShared in Refresher.h for why one map per ECID is the
+// correct mirror of the daemon's encoder set.
 void DecodeRleBlobsForSharedFile(const CEC_SharedFile_Tag *sf,
 	FileSnapshot &f,
 	std::map<std::uint32_t, PartFileEncoderData> &rle_state)
@@ -1295,12 +1211,11 @@ void DecodeRleBlobsForSharedFile(const CEC_SharedFile_Tag *sf,
 	f.shared.decoded_part_sources.assign(parts.begin(), parts.end());
 }
 
-// Clear the shared *session statistics* on a share-role-off transition
-// while preserving the upload priority. The stats (xfer/requests/accepts
-// counters) are per-share-session and must not survive; the upload
-// priority is a persistent file attribute that amuled CValueMap-
-// suppresses once sent, so wiping it here would strand a partfile that
-// re-shares later with an empty `priority`.
+// Clear the shared *session statistics* on a share-role-off transition while
+// preserving the upload priority. The stats are per-share-session and must not
+// survive; the upload priority is a persistent file attribute that amuled
+// CValueMap-suppresses once sent, so wiping it here would strand a partfile
+// that re-shares later with an empty `priority`.
 void ClearSharedRoleKeepPriority(FileSnapshot &f)
 {
 	std::string prio = std::move(f.shared.priority);
@@ -1319,10 +1234,10 @@ void ApplyGetUpdateToDownloads(
 		return;
 
 	// Walk the response top level. Three tag-name dispatches:
-	//  * EC_TAG_PARTFILE     → set is_downloading + merge download side
-	//  * EC_TAG_FILE_REMOVED → clear download role; drop entry if it
-	//                          had no shared role either
-	//  * everything else     → handled by sibling Shared/Servers walkers
+	//  * EC_TAG_PARTFILE     -> set is_downloading + merge download side
+	//  * EC_TAG_FILE_REMOVED -> clear download role; drop entry if it had no
+	//                          shared role either
+	//  * everything else     -> handled by the sibling walkers
 	for (CECPacket::const_iterator it = resp->begin(); it != resp->end(); ++it) {
 		const CECTag *t = &*it;
 		const ec_tagname_t name = t->GetTagName();
@@ -1332,10 +1247,9 @@ void ApplyGetUpdateToDownloads(
 			auto fit = cache.find(ecid);
 			if (fit != cache.end()) {
 				cache.SetDownloading(fit, false);
-				// Reset the download sub-block so a future role-true
-				// transition (or even a stale FindDownload lookup
-				// after the role flag was checked) can't surface
-				// stale stats from this dead downloading period.
+				// Reset the download sub-block so a future role-true transition (or
+				// even a stale FindDownload lookup after the role flag was checked)
+				// cannot surface stats from this dead downloading period.
 				fit->second.download = FileSnapshot::DownloadSide{};
 				if (!fit->second.is_shared)
 					cache.erase(fit);
@@ -1351,9 +1265,8 @@ void ApplyGetUpdateToDownloads(
 
 		auto map_it = cache.find(ecid);
 		if (map_it == cache.end()) {
-			// Brand-new ECID. INC_UPDATE ships HASH/NAME/SIZE on first
-			// encounter (no two-pass needed) so the insert is fully
-			// populated in one pass.
+			// Brand-new ECID. INC_UPDATE ships HASH/NAME/SIZE on first encounter,
+			// so the insert is fully populated in one pass.
 			FileSnapshot f;
 			f.ecid = ecid;
 			f.hash = TagHashLower(pf);
@@ -1375,21 +1288,15 @@ void ApplyGetUpdateToShared(
 	if (!resp)
 		return;
 
-	// amuled's "shared files" surface is the union of completed
-	// knownfiles (`theApp->sharedfiles` → EC_TAG_KNOWNFILE, always
-	// shared) and partfiles with `IsShared()==true` (≥1 chunk complete
-	// → EC_TAG_PARTFILE with `EC_TAG_PARTFILE_SHARED` child tag).
-	// CEC_PartFile_Tag derives from CEC_SharedFile_Tag (same identity
-	// + stat tag names) so we cast and pass through MergeSharedTag.
+	// amuled's "shared files" surface is the union of completed knownfiles
+	// (EC_TAG_KNOWNFILE, always shared) and partfiles with IsShared()==true
+	// (>=1 chunk complete -> EC_TAG_PARTFILE with an EC_TAG_PARTFILE_SHARED
+	// child). CEC_PartFile_Tag derives from CEC_SharedFile_Tag, so we cast and
+	// pass through MergeSharedTag.
 	//
 	// EC_TAG_PARTFILE_SHARED is CValueMap-suppressed when unchanged:
-	// present-and-true → set is_shared + merge; present-and-false →
-	// clear is_shared (file stays in m_files if still downloading);
-	// absent → preserve prior is_shared state.
-	//
-	// EC_TAG_FILE_REMOVED markers can target either a partfile or
-	// knownfile ECID (unified server-side); we clear the shared role
-	// + drop the entry if it had no downloading role either.
+	// present-and-true -> set is_shared + merge; present-and-false -> clear it
+	// (the file stays in m_files if still downloading); absent -> preserve.
 	for (CECPacket::const_iterator it = resp->begin(); it != resp->end(); ++it) {
 		const CECTag *t = &*it;
 		const ec_tagname_t name = t->GetTagName();
@@ -1417,13 +1324,10 @@ void ApplyGetUpdateToShared(
 			if (shared_flag) {
 				const bool is_shared = (shared_flag->GetInt() != 0);
 				if (!is_shared) {
-					// Partfile is_shared transitioned false (or
-					// arrived for the first time unshared).
-					// Reset the shared session stats; entry stays
-					// in m_files because downloading role may still
-					// hold it. If it doesn't, the downloads-walker
-					// FILE_REMOVED will drop it. Upload priority is
-					// preserved (persistent file attribute).
+					// Partfile is_shared transitioned false, or arrived unshared. Reset
+					// the shared session stats; the entry stays in m_files because the
+					// downloading role may still hold it, and if it does not the
+					// downloads-walker FILE_REMOVED will drop it.
 					auto fit = cache.find(ecid);
 					if (fit != cache.end()) {
 						cache.SetShared(fit, false);
@@ -1443,9 +1347,8 @@ void ApplyGetUpdateToShared(
 
 		auto map_it = cache.find(ecid);
 		if (map_it == cache.end()) {
-			// Brand-new ECID to the unified map (knownfile arriving
-			// without a prior downloads-walker tick — its first
-			// frame ships HASH unconditionally).
+			// Brand-new ECID to the unified map (a knownfile arriving without a
+			// prior downloads-walker tick -- its first frame ships HASH).
 			FileSnapshot f;
 			f.ecid = ecid;
 			f.hash = TagHashLower(sf);
@@ -1455,10 +1358,9 @@ void ApplyGetUpdateToShared(
 				DecodeRleBlobsForSharedFile(sf, f, rle_state);
 			cache.emplace(ecid, std::move(f));
 		} else {
-			// Existing entry — flip is_shared on, merge fields.
-			// If hash arrived (e.g. KNOWNFILE first frame) and we
-			// don't already have one (rare path: prior partfile-
-			// walker had hash suppressed), capture it now.
+			// Existing entry -- flip is_shared on, merge fields. If hash arrived and
+			// we do not already have one (rare: a prior partfile-walker tick had it
+			// suppressed), capture it now.
 			if (map_it->second.hash.empty()) {
 				const std::string h = TagHashLower(sf);
 				if (!h.empty())
@@ -1466,10 +1368,9 @@ void ApplyGetUpdateToShared(
 			}
 			cache.SetShared(map_it, true);
 			MergeSharedTag(sf, map_it->second);
-			// PARTFILE tags are decoded by the downloads walker, which
-			// already ran on this same response; decoding them again
-			// here would apply the XOR delta twice and desync the
-			// decoder for good.
+			// PARTFILE tags are decoded by the downloads walker, which already ran on
+			// this same response; decoding them again would apply the XOR delta twice
+			// and desync the decoder for good.
 			if (name == EC_TAG_KNOWNFILE)
 				DecodeRleBlobsForSharedFile(sf, map_it->second, rle_state);
 		}
@@ -1488,13 +1389,11 @@ void ApplyGetUpdateToClients(
 	if (!container)
 		return;
 
-	// Walk the per-client children. Every alive client in
-	// theApp->clientlist surfaces here every tick (the outer
-	// per-client tag is added unconditionally — only the children
-	// are CValueMap-suppressed when unchanged). So we use the
-	// "seen this tick = keep, absent = evict" pattern (same shape
-	// as the servers walker above). There's no FILE_REMOVED
-	// equivalent for clients on the server side.
+	// Walk the per-client children. Every alive client in theApp->clientlist
+	// surfaces here every tick -- the outer per-client tag is added
+	// unconditionally, only the children are CValueMap-suppressed. So this uses
+	// "seen this tick = keep, absent = evict": there is no FILE_REMOVED
+	// equivalent for clients.
 	std::set<std::uint32_t> seen;
 	for (CECTag::const_iterator it = container->begin(); it != container->end(); ++it) {
 		const CECTag *t = &*it;
@@ -1515,9 +1414,8 @@ void ApplyGetUpdateToClients(
 		}
 	}
 
-	// Evict cache entries not seen this tick — they're gone from the
-	// amuled side (peer disconnected, dropped from queue, banned out
-	// of the visible set, etc.).
+	// Evict cache entries not seen this tick -- gone from the amuled side (peer
+	// disconnected, dropped from queue, banned out of the visible set).
 	for (auto it = cache.begin(); it != cache.end();) {
 		if (seen.find(it->first) == seen.end()) {
 			it = cache.erase(it);
@@ -1548,10 +1446,6 @@ const char *KadBuddyStatusName(std::uint32_t status_code)
 		return "unknown";
 	}
 }
-
-// Render a host-byte-order uint32 IP as dotted-quad. amuled emits the
-// Kad address with network bytes already swapped (see
-// `ExternalConn.cpp:761` — `wxUINT32_SWAP_ALWAYS`).
 
 } // namespace
 
@@ -1598,14 +1492,11 @@ void ParseKadFromPacket(const CECPacket *resp, KadSnapshot &out)
 			out.firewalled_tcp = conn->IsKadFirewalled();
 			out.has_firewalled_tcp = true;
 		}
-		// Our own node id. amuled ships EC_TAG_KAD_ID only while Kad
-		// is running, which is the same condition KadStateString()
-		// reports as anything other than "disabled" -- so an absent
-		// sub-tag leaves the field empty rather than emitting a zero
-		// id that would read as a real (all-zero) identity.
-		// Lowercased to match every other hex identifier this API
-		// emits (user_hash, the MD4 file hashes); the desktop panel
-		// renders the same value uppercase.
+		// Our own node id. amuled ships EC_TAG_KAD_ID only while Kad is running,
+		// which is the same condition KadStateString() reports as anything other
+		// than "disabled" -- so an absent sub-tag leaves the field empty rather
+		// than emitting a zero id that would read as a real (all-zero) identity.
+		// Lowercased to match every other hex identifier this API emits.
 		CUInt128 kadID;
 		if (conn->GetKadID(kadID)) {
 			out.node_id = std::string(kadID.ToHexString().Lower().utf8_str());
@@ -1615,8 +1506,7 @@ void ParseKadFromPacket(const CECPacket *resp, KadSnapshot &out)
 	// Gated on `connected`, unlike the tags below, which amuled already gates
 	// itself. These three ship unconditionally: `users`/`files` are the last
 	// persisted estimate and survive into `connecting`, and `nodes` is our own
-	// routing-table size -- measured at 2 with Kad fully stopped, so not even
-	// the terminal state reaches 0.
+	// routing-table size -- measured at 2 with Kad fully stopped.
 	if (out.state == "connected") {
 		if (const CECTag *t = resp->GetTagByName(EC_TAG_STATS_KAD_USERS)) {
 			out.users = static_cast<std::uint32_t>(t->GetInt());
@@ -1631,7 +1521,7 @@ void ParseKadFromPacket(const CECPacket *resp, KadSnapshot &out)
 	}
 
 	// These ship only when Kad is connected (server gates them at
-	// ExternalConn.cpp:755 `if (Kademlia::CKademlia::IsConnected())`).
+	// ExternalConn.cpp `if (Kademlia::CKademlia::IsConnected())`).
 	if (const CECTag *t = resp->GetTagByName(EC_TAG_STATS_KAD_FIREWALLED_UDP)) {
 		out.firewalled_udp = (t->GetInt() != 0);
 		out.has_firewalled_udp = true;
@@ -1679,11 +1569,9 @@ void ParseAmuleLogFromPacket(const CECPacket *resp, std::vector<std::string> &ou
 	out_new_lines.clear();
 	if (!resp)
 		return;
-	// `EC_TAG_STATS_LOGGER_MESSAGE` is a parent tag with child
-	// `EC_TAG_STRING` entries, one per new log line drained from
-	// the per-connection CLoggerAccess cursor on the server side
-	// (`ExternalConn.cpp:700-715`). Absent when there's nothing
-	// new since our last tick.
+	// `EC_TAG_STATS_LOGGER_MESSAGE` is a parent tag with child EC_TAG_STRING
+	// entries, one per new log line drained from the per-connection
+	// CLoggerAccess cursor. Absent when there is nothing new since our last tick.
 	const CECTag *logger = resp->GetTagByName(EC_TAG_STATS_LOGGER_MESSAGE);
 	if (!logger)
 		return;
@@ -1697,12 +1585,11 @@ void ParseAmuleLogFromPacket(const CECPacket *resp, std::vector<std::string> &ou
 
 // --- /servers (rides on GET_UPDATE response) ---------------------------
 
-// SRV_PR_* constants live in `Server.h`. Note the values aren't monotone with
-// priority (NORMAL=0, HIGH=1, LOW=2) — using the named macros instead of
-// literal 0/1/2 saves anyone reading this from re-checking Server.h to
-// remember the order. The two directions are kept adjacent, and covered by a
-// round-trip test, because that non-monotone order is exactly the kind of
-// thing a second implementation elsewhere would get wrong.
+// SRV_PR_* constants live in Server.h. Note the values are not monotone with
+// priority (NORMAL=0, HIGH=1, LOW=2), which is why the named macros are used
+// instead of literal 0/1/2. The two directions are kept adjacent, and covered
+// by a round-trip test, because that order is what a second implementation
+// elsewhere would get wrong.
 const char *ServerPriorityName(std::uint32_t prio_code)
 {
 	switch (prio_code) {
@@ -1734,10 +1621,9 @@ bool ServerPriorityCode(const std::string &name, std::uint32_t &out_code)
 namespace
 {
 
-// Build (or merge into) a ServerSnapshot from one per-server tag.
-// Identity-only tags (name/description/version/IPv4) are subject to
-// CValueMap suppression at the server side, so for an existing entry
-// we leave the cached value alone when the source string is empty.
+// Build (or merge into) a ServerSnapshot from one per-server tag. Identity-only
+// tags (name/description/version/IPv4) are subject to CValueMap suppression, so
+// for an existing entry the cached value is left alone when the source is empty.
 void MergeServerTag(const CEC_Server_Tag *st, ServerSnapshot &s, bool is_new)
 {
 	s.ecid = st->ID();
@@ -1765,16 +1651,14 @@ void MergeServerTag(const CEC_Server_Tag *st, ServerSnapshot &s, bool is_new)
 		s.country_code = std::string(t->GetStringData().utf8_str());
 	}
 	// IP + port shipping shape varies by EC detail level:
-	//  * FULL/WEB/UPDATE (webserver, amulecmd) pack them into the
-	//    OUTER tag as IPv4 data (st->GetIPv4Data()).
-	//  * INC_UPDATE / GET_UPDATE (amulegui, amuleapi) ship them as
-	//    CHILD tags EC_TAG_SERVER_IP + EC_TAG_SERVER_PORT
-	//    (ECSpecialCoreTags.cpp:112-113); the outer tag carries the
-	//    ECID instead, so GetIPv4Data() returns all-zeros and
-	//    /servers[].address silently degrades to "0.0.0.0:0".
-	//
-	// Try the child-tag shape first; fall back to GetIPv4Data() so
-	// any future use of FULL detail still works.
+	//  * FULL/WEB/UPDATE (webserver, amulecmd) pack them into the OUTER tag as
+	//    IPv4 data (st->GetIPv4Data()).
+	//  * INC_UPDATE / GET_UPDATE (amulegui, amuleapi) ship them as CHILD tags
+	//    EC_TAG_SERVER_IP + EC_TAG_SERVER_PORT; the outer tag carries the ECID
+	//    instead, so GetIPv4Data() returns all-zeros and /servers[].address
+	//    silently degrades to "0.0.0.0:0".
+	// Try the child-tag shape first; fall back to GetIPv4Data() so any future
+	// use of FULL detail still works.
 	{
 		std::uint32_t ip_he = 0;
 		std::uint16_t port = 0;
@@ -1799,16 +1683,10 @@ void MergeServerTag(const CEC_Server_Tag *st, ServerSnapshot &s, bool is_new)
 				s.address = buf;
 			}
 		}
-		// The FULL-detail fallback that used to read st->GetIPv4Data()
-		// here was removed: amuleapi's refresher only ever asks for
-		// EC_DETAIL_INC_UPDATE (RefresherTick.cpp), so the child-tag
-		// shape above is the only one we observe in production. The
-		// fallback also triggered a libec Debug-build assertion on
-		// non-IPv4 outer tags (RefresherTest fixtures pack the ECID
-		// as a uint32 in the EC_TAG_SERVER slot), aborting the test
-		// process before any assertion in our own code could run.
-		// Resurrect the fallback alongside a public type predicate on
-		// CECTag if a future detail-level shift makes it relevant.
+		// No FULL-detail fallback to st->GetIPv4Data() here: the refresher only
+		// ever asks for EC_DETAIL_INC_UPDATE, and reading it trips a libec
+		// Debug-build assertion on non-IPv4 outer tags -- which aborts the test
+		// process before any assertion in our own code can run.
 	}
 	{
 		std::uint32_t v = 0;
@@ -1835,10 +1713,9 @@ void MergeServerTag(const CEC_Server_Tag *st, ServerSnapshot &s, bool is_new)
 		if (st->AssignIfExist(EC_TAG_SERVER_FILES, v))
 			s.files = v;
 	}
-	// Publishing limits and wire capability flags. Both server-tag builders
-	// emit all four (ECSpecialCoreTags.cpp), so the initial list and the
-	// incremental updates carry them alike; a tick where CValueMap suppresses
-	// an unchanged tag leaves the cached value intact, as above.
+	// Publishing limits and wire capability flags. Both server-tag builders emit
+	// all four, so the initial list and the incremental updates carry them
+	// alike; a suppressed unchanged tag leaves the cached value intact.
 	{
 		std::uint32_t v = 0;
 		if (st->AssignIfExist(EC_TAG_SERVER_FILES_SOFT, v))
@@ -1877,9 +1754,9 @@ void MergeServerTag(const CEC_Server_Tag *st, ServerSnapshot &s, bool is_new)
 } // namespace
 
 // Same container shape as the servers walker above: GET_UPDATE wraps every
-// friend in one EC_TAG_FRIEND container, per-field values are CValueMap-
-// suppressed when unchanged, and the container is always the complete list --
-// so "not seen this tick" means the friend was removed on the daemon side.
+// friend in one EC_TAG_FRIEND container, per-field values are suppressed when
+// unchanged, and the container is always the complete list -- so "not seen this
+// tick" means the friend was removed on the daemon side.
 static void MergeFriendTag(const CEC_Friend_Tag *ft, FriendSnapshot &f, bool is_new)
 {
 	f.ecid = ft->ID();
@@ -1891,9 +1768,8 @@ static void MergeFriendTag(const CEC_Friend_Tag *ft, FriendSnapshot &f, bool is_
 	{
 		CMD4Hash hash;
 		if (ft->UserHash(hash)) {
-			// A friend added by ip:port carries an empty hash; keep it empty
-			// rather than writing out 32 zeroes, which would read as a real
-			// hash to a client.
+			// A friend added by ip:port carries an empty hash; keep it empty rather
+			// than writing out 32 zeroes, which would read as a real hash.
 			f.user_hash = hash.IsEmpty() ? std::string()
 						     : std::string(hash.Encode().Lower().utf8_str());
 		}
@@ -2078,24 +1954,19 @@ void ApplyGetUpdateToServers(const CECPacket *resp, std::map<std::uint32_t, Serv
 {
 	if (!resp)
 		return;
-	// Find the EC_TAG_SERVER container at top level. Unlike the
-	// legacy `EC_OP_GET_SERVER_LIST` shape (one EC_TAG_SERVER per
-	// server at the response root), GET_UPDATE wraps the per-server
-	// tags in one CECEmptyTag container — same `EC_TAG_SERVER` name
-	// for the container itself. We iterate INTO the container.
+	// Find the EC_TAG_SERVER container at top level. Unlike the legacy
+	// EC_OP_GET_SERVER_LIST shape (one EC_TAG_SERVER per server at the response
+	// root), GET_UPDATE wraps them in one container of the same name.
 	const CECTag *container = resp->GetTagByName(EC_TAG_SERVER);
 	if (!container)
 		return;
 
-	// The container always carries the FULL current server list (no
-	// FILE_REMOVED markers for servers on the server side — see
-	// ExternalConn.cpp:985-994), but individual per-server fields are
-	// CValueMap-suppressed on unchanged values. Two consequences:
-	//  1. Servers absent from the response are gone on amuled's
-	//     side — we evict by "not seen this tick".
-	//  2. For servers we already cache, identity tags may be absent
-	//     this tick; MergeServerTag leaves cached values intact
-	//     (the `if (is_new || !n.empty())` guard).
+	// The container always carries the FULL current server list (no FILE_REMOVED
+	// markers for servers), but individual per-server fields are
+	// CValueMap-suppressed on unchanged values. Two consequences: servers absent
+	// from the response are gone on amuled's side, so evict by "not seen this
+	// tick"; and for servers already cached, identity tags may be absent this
+	// tick, which MergeServerTag leaves alone.
 	std::set<std::uint32_t> seen;
 	for (CECTag::const_iterator it = container->begin(); it != container->end(); ++it) {
 		const CECTag *t = &*it;
@@ -2115,9 +1986,8 @@ void ApplyGetUpdateToServers(const CECPacket *resp, std::map<std::uint32_t, Serv
 		}
 	}
 
-	// Evict cache entries we didn't see this tick — they're gone on
-	// the amuled side (operator removed them, or a fresh connection
-	// is rebuilding the list from a different serverlist source).
+	// Evict cache entries not seen this tick -- gone on the amuled side, or a
+	// fresh connection is rebuilding the list from a different serverlist source.
 	for (auto it = cache.begin(); it != cache.end();) {
 		if (seen.find(it->first) == seen.end()) {
 			it = cache.erase(it);
@@ -2132,19 +2002,17 @@ void ApplyGetUpdateToServers(const CECPacket *resp, std::map<std::uint32_t, Serv
 namespace
 {
 
-// EC value type -> stable lowercase API string. Mirrors the EC_VALUE_* enum
-// (ECCodes.h); the numeric value is carried raw (seconds, bytes, bytes/s, …)
-// so clients format and localize.
+// EC value type -> stable lowercase API string. Mirrors the EC_VALUE_* enum;
+// the numeric value is carried raw so clients format and localize.
 const char *ECStatValueTypeName(int type)
 {
 	switch (type) {
 	case EC_VALUE_INTEGER:
 		return "integer";
 	case EC_VALUE_ISTRING:
-		// Both ISTRING and ISHORT are plain integers that the desktop
-		// happens to render abbreviated ("12.5k"). The distinction is a
-		// wx formatter choice with nothing a REST client can act on, so
-		// they collapse onto the token an untyped value already resolves to.
+		// Both ISTRING and ISHORT are plain integers the desktop happens to render
+		// abbreviated ("12.5k"). That is a wx formatter choice with nothing a REST
+		// client can act on, so they collapse onto the same token.
 		return "integer";
 	case EC_VALUE_BYTES:
 		return "bytes";
@@ -2163,9 +2031,8 @@ const char *ECStatValueTypeName(int type)
 	}
 }
 
-// Extract one EC_TAG_STAT_NODE_VALUE as a typed value, raw and untranslated
-// (mirrors ECSpecialTags::FormatValue but without wxGetTranslation / unit
-// formatting). Recurses one level for the optional nested "(total …)" value.
+// Extract one EC_TAG_STAT_NODE_VALUE as a typed value, raw and untranslated.
+// Recurses one level for the optional nested "(total ...)" value.
 void ExtractStatsValue(const CECTag *v, StatsTreeValue &out)
 {
 	const CECTag *vt = v->GetTagByName(EC_TAG_STAT_VALUE_TYPE);
@@ -2187,9 +2054,8 @@ void ExtractStatsValue(const CECTag *v, StatsTreeValue &out)
 		out.num = v->GetInt();
 		break;
 	}
-	// Locale-independent sentinel token, when the daemon tagged this value
-	// (e.g. "never"/"not_available"). Additive: the English string above is
-	// left intact; enum_token stays empty and is dropped otherwise.
+	// Locale-independent sentinel token, when the daemon tagged this value.
+	// Additive: the English string above is left intact.
 	const CECTag *et = v->GetTagByName(EC_TAG_STAT_VALUE_ENUM);
 	if (et) {
 		out.enum_token = std::string(et->GetStringData().utf8_str());
@@ -2206,8 +2072,7 @@ void ParseStatsTreeNode(const CECTag *node, StatsTreeNode &out)
 {
 	const CEC_StatTree_Node_Tag *n = static_cast<const CEC_StatTree_Node_Tag *>(node);
 	// Untranslated English label template exactly as EC carries it (e.g.
-	// "Uptime: %s"); NOT GetDisplayString(), which translates and locale-formats
-	// in the amuleapi process and would make output depend on --locale.
+	// "Uptime: %s"); NOT GetDisplayString(), which translates and locale-formats.
 	out.label = std::string(n->GetStringData().utf8_str());
 	// Stable machine key, if the daemon set one. Legacy daemons omit the
 	// tag; out.key stays empty and is dropped from the JSON.
@@ -2255,11 +2120,9 @@ void ParseStatsTreeFromPacket(const CECPacket *resp, StatsTreeNode &out)
 	out.children.clear();
 	if (!resp)
 		return;
-	// amuled emits a single root EC_TAG_STATTREE_NODE; its label is
-	// always an unlabeled container, so we drop it and surface its
-	// direct children at the top level. This matches what amuleweb's
-	// `am_load_stats_tree.php` does and what the reference REST
-	// branch's /stats/tree handler does.
+	// amuled emits a single root EC_TAG_STATTREE_NODE whose label is always an
+	// unlabeled container, so it is dropped and its direct children surface at
+	// the top level -- what amuleweb's am_load_stats_tree.php does too.
 	const CECTag *root = resp->GetTagByName(EC_TAG_STATTREE_NODE);
 	if (!root)
 		return;
@@ -2277,13 +2140,10 @@ void ParseStatsTreeFromPacket(const CECPacket *resp, StatsTreeNode &out)
 namespace
 {
 
-// EC_TAG_STATSGRAPH_DATA is a binary blob of N interleaved uint32
-// channels, each value pre-converted to network byte order via
-// `ENDIAN_HTONL` on the amuled side (Statistics.cpp:621-624). We
-// have to byte-swap back to host order before consumption — `ntohl`
-// is a no-op on big-endian hosts and the canonical 4-byte swap on
-// little-endian, which is what every modern target (x86_64, arm64)
-// runs.
+// EC_TAG_STATSGRAPH_DATA is a binary blob of N interleaved uint32 channels,
+// each value pre-converted to network byte order via ENDIAN_HTONL on the
+// amuled side (Statistics.cpp), so it has to be swapped back to host order
+// before consumption.
 std::uint32_t BigEndianToHost32(const std::uint8_t *p)
 {
 	return (static_cast<std::uint32_t>(p[0]) << 24) | (static_cast<std::uint32_t>(p[1]) << 16) |
@@ -2330,7 +2190,7 @@ void ParseGraphsFromPacket(const CECPacket *resp, StatsGraphs &out)
 
 	if (const CECTag *t = resp->GetTagByName(EC_TAG_STATSGRAPH_DATA)) {
 		// 4 interleaved channels per amuled-side layout
-		// (Statistics.cpp:621-624):
+		// (Statistics.cpp):
 		//  ch0 = kBpsDownCur * 1024  (bytes per second)
 		//  ch1 = kBpsUpCur   * 1024  (bytes per second)
 		//  ch2 = cntConnections      (active client connections)
@@ -2348,9 +2208,8 @@ void ParseGraphsFromPacket(const CECPacket *resp, StatsGraphs &out)
 		}
 	}
 	if (const CECTag *t = resp->GetTagByName(EC_TAG_STATSGRAPH_DATA_CONN)) {
-		// 2 interleaved channels, filled by the same amuled loop and from
-		// the same records as EC_TAG_STATSGRAPH_DATA, so index i lines up
-		// across both blobs (Statistics.cpp, GetHistoryForGui):
+		// 2 interleaved channels, filled by the same amuled loop and from the same
+		// records as EC_TAG_STATSGRAPH_DATA, so index i lines up across both:
 		//  ch0 = cntUploads   (peers we are pushing to)
 		//  ch1 = cntDownloads (peers we are pulling from)
 		std::vector<std::vector<std::uint32_t>> channels;
@@ -2364,11 +2223,10 @@ void ParseGraphsFromPacket(const CECPacket *resp, StatsGraphs &out)
 		}
 	}
 
-	// How many records a resolution range holds. Ask for more and the
-	// daemon repeats records instead of failing, which the caller cannot
-	// detect since no timestamps are on the wire -- so this bounds every
-	// series below. Absent on daemons predating the tag; the default in
-	// StatsGraphs matches what current builds report.
+	// How many records a resolution range holds. Ask for more and the daemon
+	// repeats records instead of failing, which the caller cannot detect since
+	// no timestamps are on the wire -- so this bounds every series below. Absent
+	// on daemons predating the tag.
 	{
 		std::uint16_t depth = 0;
 		if (resp->AssignIfExist(EC_TAG_STATSGRAPH_DEPTH, depth) && depth > 0) {
@@ -2377,8 +2235,7 @@ void ParseGraphsFromPacket(const CECPacket *resp, StatsGraphs &out)
 	}
 
 	// The daemon divides both byte counters by 1024 before sending
-	// (Statistics.cpp, RecordHistory: kBytesSent / kBytesReceived), so
-	// scale back to make the reported unit true.
+	// (Statistics.cpp, RecordHistory), so scale back to make the unit true.
 	if (resp->AssignIfExist(EC_TAG_STATSGRAPH_SESSION_DL, out.session_download_bytes)) {
 		out.session_download_bytes *= 1024;
 	}
@@ -2390,11 +2247,9 @@ void ParseGraphsFromPacket(const CECPacket *resp, StatsGraphs &out)
 	resp->AssignIfExist(EC_TAG_STATSGRAPH_SESSION_KAD, out.session_kad_node_seconds);
 	resp->AssignIfExist(EC_TAG_STATSGRAPH_SESSION_TIMESPAN, out.session_duration_seconds);
 
-	// Drop anything past the daemon's per-range depth. Beyond it the walk
-	// hands back repeated records, and reconstructing a time axis over
-	// those draws them as distinct samples -- silently compressing time
-	// across the older part of the plot. A no-op where the request width
-	// and the reported depth agree, which is the current-build case.
+	// Drop anything past the daemon's per-range depth. Beyond it the walk hands
+	// back repeated records, and reconstructing a time axis over those draws
+	// them as distinct samples -- silently compressing time across the plot.
 	TruncateToLast(out.download_bytes_per_second, out.max_points);
 	TruncateToLast(out.upload_bytes_per_second, out.max_points);
 	TruncateToLast(out.connections, out.max_points);
@@ -2441,8 +2296,7 @@ std::string FileTypeToken(const std::string &name)
 	});
 	// GetFiletypeDesc() returns UI labels, and lowercasing them left three
 	// problems in one enum: plurals where the token names ONE file's type, a
-	// hyphen where every other enum token on the surface is snake_case, and
-	// "any" meaning "unknown". Normalise rather than expose the label.
+	// hyphen where every other enum token is snake_case, and "any" for unknown.
 	static const std::map<std::string, std::string> kNormalised = {
 		{ "videos", "video" },
 		{ "audio", "audio" },
@@ -2464,18 +2318,14 @@ std::string FileTypeToken(const std::string &name)
 //
 // This is the whole contract of the incremental union poll: the daemon diffs a
 // result against what it last sent us and emits only what moved, so an absent
-// field means "unchanged", never "cleared". Every write below is therefore
-// guarded on its tag being present -- including the ones a full fetch could
-// take unconditionally, because their accessors go through GetTagByNameSafe
-// and answer 0 / "" for a tag that is not there.
+// field means "unchanged", never "cleared".
 void MergeSearchResultTag(const CEC_SearchFile_Tag *sf, SearchResult &r)
 {
 	r.ecid = sf->ID();
-	// Identity and the immutable descriptors. Under INC_UPDATE these
-	// travel once and are diffed away afterwards, and the accessors
-	// answer through GetTagByNameSafe -- an absent tag reads as an empty
-	// string or 0, which would wipe the field rather than leave it. So
-	// each one is written only when its tag is actually on this packet.
+	// Identity and the immutable descriptors. Under INC_UPDATE these travel once
+	// and are diffed away afterwards, and the accessors go through
+	// GetTagByNameSafe -- an absent tag reads as "" or 0, which would wipe the
+	// field. So each is written only when its tag is actually on this packet.
 	if (sf->GetTagByName(EC_TAG_PARTFILE_HASH)) {
 		std::string h(sf->FileHashString().utf8_str());
 		std::transform(
@@ -2498,9 +2348,8 @@ void MergeSearchResultTag(const CEC_SearchFile_Tag *sf, SearchResult &r)
 		if (sf->AssignIfExist(EC_TAG_PARTFILE_SOURCE_COUNT_XFER, v))
 			r.complete_source_count = v;
 	}
-	// Grouping (issue #431): a child hit carries its parent's ECID in
-	// EC_TAG_SEARCH_PARENT. Recorded here; folded into the parent's
-	// children[] in the second pass below.
+	// Grouping: a child hit carries its parent's ECID in EC_TAG_SEARCH_PARENT.
+	// Folded into the parent's children[] in the second pass below.
 	{
 		std::uint32_t v = 0;
 		if (sf->AssignIfExist(EC_TAG_SEARCH_PARENT, v)) {
@@ -2513,14 +2362,10 @@ void MergeSearchResultTag(const CEC_SearchFile_Tag *sf, SearchResult &r)
 		if (sf->AssignIfExist(EC_TAG_KNOWNFILE_RATING, v))
 			r.rating = v;
 	}
-	// Download status (issue #429): amuled packs the CSearchFile
-	// status in EC_TAG_PARTFILE_STATUS on every search-result tag.
-	// Download status (issue #429): amuled packs the CSearchFile status
-	// in EC_TAG_PARTFILE_STATUS. `already_downloaded` is not its own field on
-	// the wire -- AlreadyHave() reads the same tag -- so both move
-	// together, and both are left alone when the tag is diffed away.
-	// Writing the absent case as status 0 would report every unchanged
-	// result as "new" on the very polls that say nothing changed.
+	// Download status: amuled packs the CSearchFile status in
+	// EC_TAG_PARTFILE_STATUS. `already_downloaded` is not its own field on the
+	// wire -- AlreadyHave() reads the same tag -- so both move together. Writing
+	// the absent case as status 0 would report every unchanged result as "new".
 	{
 		std::uint32_t v = 0;
 		if (sf->AssignIfExist(EC_TAG_PARTFILE_STATUS, v)) {
@@ -2528,27 +2373,22 @@ void MergeSearchResultTag(const CEC_SearchFile_Tag *sf, SearchResult &r)
 			r.already_downloaded = sf->AlreadyHave();
 		}
 	}
-	// File type, computed from the filename (no EC data needed).
 	// Derived from the filename, so it is recomputed whenever the name is.
 	if (!r.name.empty()) {
 		r.type = FileTypeToken(r.name);
 	}
-	// Browse-only: the folder this file sits in inside the peer's
-	// share. The core attaches it to results filed from a shared-file
-	// listing and to nothing else, so an ordinary server/Kad hit
-	// simply leaves it empty.
+	// Browse-only: the folder this file sits in inside the peer's share. The core
+	// attaches it to results filed from a shared-file listing and nothing else,
+	// so an ordinary server/Kad hit leaves it empty.
 	if (const CECTag *x = sf->GetTagByName(EC_TAG_SEARCHFILE_DIRECTORY)) {
 		r.directory = std::string(x->GetStringData().utf8_str());
 	}
-	// Media metadata (issue #430): present when the hit carried
-	// FT_MEDIA_* tags. On a locally known/probed file those are our
-	// own probe's values; on a remote hit they are whatever the
-	// responding server advertised, which is not validated anywhere
-	// and can contradict the file (a .pdf with a runtime and an xvid
-	// codec is a real observed result). Passed through as sent -- the
-	// API documents the search-result `media` as unverified rather
-	// than second-guessing the server. Any present tag marks
-	// has_media so the API emits the `media` object.
+	// Media metadata, present when the hit carried FT_MEDIA_* tags. On a locally
+	// known file those are our own probe's values; on a remote hit they are
+	// whatever the responding server advertised, which is not validated anywhere
+	// and can contradict the file (a .pdf with a runtime and an xvid codec is a
+	// real observed result). Passed through as sent -- the API documents the
+	// search-result `media` as unverified.
 	{
 		std::uint32_t v = 0;
 		if (sf->AssignIfExist(EC_TAG_KNOWNFILE_MEDIA_LENGTH, v)) {
@@ -2570,27 +2410,22 @@ void MergeSearchResultTag(const CEC_SearchFile_Tag *sf, SearchResult &r)
 	if (const CECTag *x = sf->GetTagByName(EC_TAG_KNOWNFILE_MEDIA_TITLE)) {
 		r.media.title = std::string(x->GetStringData().utf8_str());
 	}
-	// Derived from the fields, exactly as MergeKnownFileDetail does for a
-	// shared file. Both paths share AddMediaTagsPresent on the daemon
-	// side, so either can be sent a zero / empty "this field is gone" tag
-	// -- latching on any tag being present would mark a result as having
-	// media with every field blank.
+	// Derived from the fields, exactly as MergeKnownFileDetail does for a shared
+	// file. Both paths share AddMediaTagsPresent on the daemon side, so either
+	// can be sent a zero / empty "this field is gone" tag -- latching on any tag
+	// being present would mark a result as having media with every field blank.
 	r.has_media = r.media.duration_seconds != 0 || r.media.bitrate_kilobits_per_second != 0 ||
 		      !r.media.codec.empty() || !r.media.artist.empty() || !r.media.album.empty() ||
 		      !r.media.title.empty();
-	// On-demand Kad community ratings/comments (issue #434). Same
-	// 4-children-per-entry positional container the download side uses
-	// (username, filename, rating, comment); a search hit's comments are
-	// purely Kad notes.
-	// The comments container is the one field where absence is a value,
-	// not silence: it is built only when there are notes and is added
-	// without the valuemap, so it is never diffed away. An absent one
-	// therefore means "no notes", and a present one replaces the set
-	// rather than appending to it.
+	// On-demand Kad community ratings/comments. Same 4-children-per-entry
+	// positional container the download side uses (username, filename, rating,
+	// comment).
 	//
-	// The searching flag beside it is NOT in that category -- it goes
-	// through the valuemap like every other field, so it follows the
-	// ordinary absent-means-unchanged rule below.
+	// This container is the one field where absence is a value, not silence: it
+	// is built only when there are notes and is added without the valuemap, so
+	// it is never diffed away. An absent one means "no notes", and a present one
+	// replaces the set rather than appending. The searching flag beside it goes
+	// through the valuemap like everything else.
 	r.comments.clear();
 	if (const CECTag *cont = sf->GetTagByName(EC_TAG_PARTFILE_COMMENTS)) {
 		std::vector<const CECTag *> kids;
@@ -2617,9 +2452,7 @@ void MergeSearchResultTag(const CEC_SearchFile_Tag *sf, SearchResult &r)
 //
 // Kept as a pass over `raw` rather than merged into directly: a grouped child
 // is addressable by its own ECID on the wire and gets diffed tags of its own,
-// so it has to stay in `raw`, while every reader wants it nested in its
-// parent. Rebuilding is O(n) in one search's results and runs only when that
-// search actually changed.
+// so it has to stay in `raw`, while every reader wants it nested in its parent.
 void RebuildFoldedResults(
 	const std::map<std::uint32_t, SearchResult> &raw, std::map<std::uint32_t, SearchResult> &out)
 {
@@ -2629,11 +2462,10 @@ void RebuildFoldedResults(
 		if (!kv.second.has_parent)
 			out.emplace(kv.first, kv.second);
 	}
-	// Then fold each child into its parent's children[] (issue #431), so the
-	// API serves one row per hash+size with the alternative filenames nested.
-	// A child whose parent is not in the set -- which should not happen, the
-	// core emits the parent first -- is promoted to a top-level row instead,
-	// so nothing is silently lost.
+	// Then fold each child into its parent's children[], so the API serves one row
+	// per hash+size with the alternative filenames nested. A child whose parent
+	// is not in the set -- which should not happen -- is promoted to a top-level
+	// row instead, so nothing is silently lost.
 	for (const auto &kv : raw) {
 		const SearchResult &child = kv.second;
 		if (!child.has_parent)
@@ -2657,18 +2489,15 @@ void RebuildFoldedResults(
 // Apply one incremental multi-search union reply across every search slot.
 //
 // The reply is not per-search: it carries every result of every search the
-// daemon holds, and it carries them incrementally. Two consequences drive the
-// shape here.
+// daemon holds, and it carries them incrementally. Two consequences.
 //
 // First, EC_TAG_SEARCH_ID travels only the first time the daemon tells us
 // about a result -- after that the tag is diffed away, because a result never
-// changes owner. So a tag without one is attributed through `owner`, the index
-// this function is responsible for keeping in step with the slots.
+// changes owner. So a tag without one is attributed through `owner`.
 //
-// Second, absence no longer means deletion. A result the daemon still holds
-// but has nothing new to say about is omitted entirely; removal is explicit,
-// as one EC_TAG_FILE_REMOVED per gone ECID. Sweeping "anything missing is
-// gone" here would delete the whole result set on the first quiet poll.
+// Second, absence no longer means deletion: removal is explicit, as one
+// EC_TAG_FILE_REMOVED per gone ECID. Sweeping "anything missing is gone" here
+// would delete the whole result set on the first quiet poll.
 void ApplySearchUnion(const CECPacket *resp,
 	std::map<std::uint32_t, SearchSlot> &slots,
 	std::map<std::uint32_t, std::uint32_t> &owner,
@@ -2694,11 +2523,10 @@ void ApplySearchUnion(const CECPacket *resp,
 				continue;
 			}
 			if (sit->second.detached) {
-				// The daemon evicted this whole search and is tombstoning
-				// its results on the way out. Retirement deliberately keeps
-				// them for late reads, so the removals are ignored -- and
-				// the index entries with them, since nothing else will
-				// re-establish them.
+				// The daemon evicted this whole search and is tombstoning its results
+				// on the way out. Retirement deliberately keeps them for late reads,
+				// so the removals are ignored -- and the index entries with them,
+				// since nothing else will re-establish them.
 				continue;
 			}
 			if (sit->second.raw.erase(ecid) != 0)
@@ -2714,12 +2542,9 @@ void ApplySearchUnion(const CECPacket *resp,
 
 		// Present on a result's first appearance, diffed away afterwards.
 		//
-		// The index is written only once this tag is known to be applicable,
-		// below: a slot that turns out to be missing or detached takes an
-		// early exit, and an entry written ahead of those would outlive the
-		// slot it points at -- eviction drops index entries by walking the
-		// slot's own results, so one that never made it there is never
-		// cleaned up.
+		// The index is written only once this tag is known to be applicable: a
+		// slot that turns out to be missing or detached takes an early exit, and
+		// an entry written ahead of those would outlive the slot it points at.
 		std::uint32_t sid = 0;
 		bool sid_is_new = false;
 		if (const CECTag *x = sf->GetTagByName(EC_TAG_SEARCH_ID)) {
@@ -2733,11 +2558,9 @@ void ApplySearchUnion(const CECPacket *resp,
 		} else {
 			const auto oit = owner.find(ecid);
 			if (oit == owner.end()) {
-				// A diffed tag for a result we have no record of. Only
-				// reachable if our slot went away while the daemon still
-				// believed we held it -- there is nothing to apply it to,
-				// and inventing a slot would produce a search with no
-				// lifecycle state behind it.
+				// A diffed tag for a result we have no record of. Only reachable if our
+				// slot went away while the daemon still believed we held it, and
+				// inventing a slot would produce a search with no lifecycle state.
 				continue;
 			}
 			sid = oit->second;
@@ -2745,19 +2568,12 @@ void ApplySearchUnion(const CECPacket *resp,
 
 		const auto sit = slots.find(sid);
 		if (sit == slots.end()) {
-			// Results for a search this session has no slot for -- one
-			// started in amulegui or the monolithic GUI, since the union
-			// responder walks every search the core holds. Dropped rather
-			// than auto-created: MarkSearchStarted / discovery own slot
-			// creation, and they also set the lifecycle state that
-			// GET /search reports.
-			//
-			// The drop is not the loss it would otherwise be, because the
-			// daemon has now marked these ECIDs sent and will elide them
-			// from every later poll. Whoever creates the slot re-reads the
-			// search in full instead: DiscoverSearchIfHeldByCore seeds it
-			// via FetchOneSearchFull, which bypasses the differential
-			// stream entirely.
+			// Results for a search this session has no slot for -- one started in
+			// amulegui or the monolithic GUI, since the union responder walks every
+			// search the core holds. Dropped rather than auto-created:
+			// MarkSearchStarted / discovery own slot creation and the lifecycle
+			// state. Whoever creates the slot re-reads the search in full instead,
+			// via FetchOneSearchFull, which bypasses the differential stream.
 			owner.erase(ecid);
 			continue;
 		}
@@ -2771,12 +2587,10 @@ void ApplySearchUnion(const CECPacket *resp,
 		auto &slot_results = sit->second.raw;
 		const auto existing = slot_results.find(ecid);
 		if (existing == slot_results.end()) {
-			// First sight of this result. Seed the fields whose "absent"
-			// reading differs between a fresh row and a diff: status has no
-			// sensible empty value, and the daemon's own default for a hit
-			// it has said nothing about is the zero code. Merging onto a
-			// default-constructed SearchResult would leave it "", which is
-			// not a state any consumer knows.
+			// First sight of this result. Seed the fields whose "absent" reading
+			// differs between a fresh row and a diff: status has no sensible empty
+			// value, and merging onto a default-constructed SearchResult would leave
+			// it "", which is not a state any consumer knows.
 			SearchResult fresh;
 			fresh.ecid = ecid;
 			fresh.status = SearchStatusName(0);
@@ -2806,9 +2620,8 @@ void ApplySearchFullReply(const CECPacket *resp,
 	if (sit == slots.end())
 		return;
 	if (replace) {
-		// Drop the old rows AND their index entries: the reply below re-adds
-		// an entry for every result it carries, so anything not re-added is a
-		// row the daemon no longer holds.
+		// Drop the old rows AND their index entries: the reply below re-adds an
+		// entry for every result it carries, so anything not re-added is gone.
 		for (const auto &entry : sit->second.raw)
 			owner.erase(entry.first);
 		sit->second.raw.clear();
@@ -2817,27 +2630,24 @@ void ApplySearchFullReply(const CECPacket *resp,
 	sit = slots.find(search_id);
 	if (sit == slots.end())
 		return;
-	// ApplySearchUnion only refolds slots it touched, and an empty reply
-	// touches nothing -- which is exactly the case where the stale fold has to
-	// be cleared rather than kept.
+	// ApplySearchUnion only refolds slots it touched, and an empty reply touches
+	// nothing -- exactly the case where the stale fold has to be cleared.
 	if (replace) {
 		RebuildFoldedResults(sit->second.raw, sit->second.results);
-		// Only a replace answers the question the flag asks. A merge re-reads
-		// every row the daemon still has, but it cannot remove one it has
-		// dropped -- the tombstones for those went out in the union reply that
-		// was lost, and the daemon will not mention them again. Clearing the
-		// flag here would leave those rows in place for the life of the slot.
+		// Only a replace answers the question the flag asks. A merge re-reads every
+		// row the daemon still has, but it cannot remove one it has dropped -- the
+		// tombstones went out in the union reply that was lost. Clearing the flag
+		// here would leave those rows in place for the life of the slot.
 		sit->second.needs_resync = false;
 	}
 }
 
 // --- Search-progress, daemon-supplied lifecycle path -------------------
 //
-// Reads EC_TAG_SEARCH_LIFECYCLE_STATE from the EC_OP_SEARCH_PROGRESS
-// response — the unambiguous lifecycle tag landed alongside this PR.
-// No sentinel decode, no `saw_in_progress` tracking, no defensive
-// timeout: the daemon's flag is the source of truth. amuleapi pins a
-// daemon version that carries the new tags, so this is the only path.
+// Reads EC_TAG_SEARCH_LIFECYCLE_STATE from the EC_OP_SEARCH_PROGRESS response.
+// No sentinel decode, no `saw_in_progress` tracking, no defensive timeout: the
+// daemon's flag is the source of truth, and amuleapi pins a version that
+// carries the tag.
 SearchProgressSnapshot AdvanceSearchProgress(
 	const SearchProgressSnapshot &prev, std::uint32_t lifecycle_state, std::uint32_t pct_now)
 {
@@ -2849,9 +2659,8 @@ SearchProgressSnapshot AdvanceSearchProgress(
 	} else if (lifecycle_state == 1 /* SEARCH_LIFECYCLE_RUNNING */) {
 		next.complete = false;
 		next.active = true;
-		// Unified 0..100 the daemon already computed for this search kind
-		// (global = real server-queue percent; Kad = cosmetic time-ramp;
-		// local = instantaneous). No kind special-casing here anymore.
+		// Unified 0..100 the daemon already computed for this search kind (global
+		// = real server-queue percent; Kad = cosmetic time-ramp; local = instant).
 		next.percent = (pct_now > 100) ? 100 : pct_now;
 	} else {
 		// SEARCH_LIFECYCLE_IDLE — refresher shouldn't be calling us
@@ -2871,17 +2680,15 @@ namespace
 void ParseCategoryTag(const CECTag *cat_tag, CategorySnapshot &c)
 {
 	const CEC_Category_Tag *ct = static_cast<const CEC_Category_Tag *>(cat_tag);
-	// Category index lives in the tag's int payload (set by
-	// `CECTag(name, cat_index)` at construction — see
-	// `ECSpecialCoreTags.cpp` category ctor).
+	// Category index lives in the tag's int payload, set by CECTag(name,
+	// cat_index) at construction (ECSpecialCoreTags.cpp category ctor).
 	c.index = static_cast<std::uint32_t>(ct->GetInt());
 	c.name = std::string(ct->Name().utf8_str());
 	c.path = std::string(ct->Path().utf8_str());
 	c.comment = std::string(ct->Comment().utf8_str());
 	c.color = ct->Color();
 	c.priority_code = ct->Prio();
-	// Reuse the download-priority namer — categories use the same
-	// PR_* code space.
+	// Reuse the download-priority namer -- categories share the PR_* code space.
 	{
 		bool _ignore = false;
 		c.priority = PriorityName(c.priority_code, _ignore);
@@ -2932,9 +2739,8 @@ void ParseConnectionPrefs(const CECTag *conn, PreferencesSnapshot &out)
 	if (const CECTag *t = conn->GetTagByName(EC_TAG_CONN_UDP_PORT)) {
 		out.udp_port = static_cast<std::uint16_t>(t->GetInt());
 	}
-	// The EmptyTag markers (presence = true, absence = false).
-	// Positive sense: the daemon emits EC_TAG_CONN_UDP_DISABLE only when the
-	// extended UDP port is off, so absence = enabled.
+	// EmptyTag markers (presence = true, absence = false). Positive sense: the
+	// daemon emits EC_TAG_CONN_UDP_DISABLE only when the port is off.
 	out.extended_udp_port_enabled = conn->GetTagByName(EC_TAG_CONN_UDP_DISABLE) == nullptr;
 	out.autoconnect = conn->GetTagByName(EC_TAG_CONN_AUTOCONNECT) != nullptr;
 	out.reconnect_on_connection_loss = conn->GetTagByName(EC_TAG_CONN_RECONNECT) != nullptr;
@@ -2998,18 +2804,16 @@ void ParseConnectionPrefs(const CECTag *conn, PreferencesSnapshot &out)
 	}
 }
 
-// --- Extended EC-carried preference categories (issue #437, #655) ------
+// --- Extended EC-carried preference categories ------
 //
 // One walk over the declarative field table in PrefsSchema.cpp replaces the
-// twelve hand-written per-category parsers this used to be. The table records
-// each field's EC tag and how the core serializer encodes it; everything
-// below is the generic decode for those encodings.
+// twelve hand-written per-category parsers this used to be.
 //
 // Boolean encoding follows the core serializer (ECSpecialMuleTags.cpp): most
 // bools are emitted as a bare CECEmptyTag only when true, so presence == true
 // and absence must actively write `false`; a few are emitted as a value tag
-// every time, and those (like every non-bool) leave the member at its default
-// when the tag is missing. That difference is the PrefEnc column.
+// every time, and those leave the member at its default when the tag is
+// missing. That difference is the PrefEnc column.
 
 void ApplyPrefFieldFromTag(const PrefField &f, const CECTag *group, PreferencesSnapshot &out)
 {
@@ -3020,8 +2824,7 @@ void ApplyPrefFieldFromTag(const PrefField &f, const CECTag *group, PreferencesS
 
 	if (f.type == PrefType::Bool && f.enc == PrefEnc::Presence) {
 		// Presence tags carry their answer in absence too, so this assigns
-		// unconditionally. `invert` covers the one negatively-named EC tag
-		// (EC_TAG_CONN_UDP_DISABLE) the API exposes positively.
+		// unconditionally. `invert` covers EC_TAG_CONN_UDP_DISABLE.
 		const bool present = (t != nullptr);
 		*static_cast<bool *>(f.member(out)) = f.invert ? !present : present;
 		return;
@@ -3040,10 +2843,9 @@ void ApplyPrefFieldFromTag(const PrefField &f, const CECTag *group, PreferencesS
 		*static_cast<std::uint16_t *>(f.member(out)) = static_cast<std::uint16_t>(t->GetInt());
 		break;
 	case PrefType::Uint32: {
-		// ec_scale != 0 means EC and the API use different units; see
-		// PrefField::ec_scale. Division is exact for the three rows that
-		// use it -- the core stores whole minutes and multiplies on the
-		// way out -- so nothing is lost here.
+		// ec_scale != 0 means EC and the API use different units. Division is exact
+		// for the three rows that use it -- the core stores whole minutes and
+		// multiplies on the way out -- so nothing is lost here.
 		const std::uint64_t raw = static_cast<std::uint64_t>(t->GetInt());
 		*static_cast<std::uint32_t *>(f.member(out)) =
 			static_cast<std::uint32_t>(f.ec_scale ? raw / f.ec_scale : raw);
@@ -3066,12 +2868,10 @@ void ApplyPrefFieldFromTag(const PrefField &f, const CECTag *group, PreferencesS
 		break;
 	}
 	case PrefType::Enum: {
-		// The wire carries the index into the row's name table. An
-		// out-of-range value leaves the default rather than inventing a
-		// member the daemon never named.
-		// GetInt() is unsigned, so keep the index unsigned too: a signed
-		// copy would narrow, and the >= 0 half of the range check would
-		// be dead anyway.
+		// The wire carries the index into the row's name table. An out-of-range
+		// value leaves the default rather than inventing a member the daemon never
+		// named. GetInt() is unsigned, so the index stays unsigned: a signed copy
+		// would narrow, and the >= 0 half of the range check would be dead.
 		const std::uint64_t idx = t->GetInt();
 		std::uint64_t n = 0;
 		while (f.enum_names[n] != nullptr)
@@ -3102,9 +2902,8 @@ void ParsePreferencesFromPacket(
 	}
 
 	// Capability flag that is not a /preferences field: it is reported by
-	// /version, so it has no schema row. 3.1+ daemons always send it (true
-	// when built with ENABLE_VERSION_CHECK); absent means a pre-3.1 daemon
-	// that cannot relay a result over EC anyway, so it stays false.
+	// /version, so it has no schema row. Absent means a pre-3.1 daemon that
+	// cannot relay a result over EC anyway, so it stays false.
 	if (const CECTag *gen = resp->GetTagByName(EC_TAG_PREFS_GENERAL)) {
 		if (const CECTag *t = gen->GetTagByName(EC_TAG_GENERAL_VERSION_CHECK_AVAILABLE))
 			out_prefs.version_check_available = (t->GetInt() != 0);

--- a/src/webapi/Refresher.h
+++ b/src/webapi/Refresher.h
@@ -68,9 +68,7 @@ enum class SearchFetchOutcome
 // Pull one search's full result set from the daemon and merge it into that
 // search's slot. Shared by the per-tick poll of ACTIVE searches and by the
 // on-demand refresh the read paths use for a FINISHED one, so both issue the
-// identical request (EC_DETAIL_FULL plus the EC_TAG_SEARCH_PARENT grouping
-// flag) and feed the identical applier — a results list read through either
-// route has the same shape.
+// identical request and feed the identical applier.
 SearchFetchOutcome FetchSearchResults(CamuleapiApp &app, CState &state);
 
 // Re-fetch one search at EC_DETAIL_FULL. The union has no resync opcode, so
@@ -80,12 +78,10 @@ SearchFetchOutcome FetchSearchResults(CamuleapiApp &app, CState &state);
 SearchFetchOutcome FetchOneSearchFull(
 	CamuleapiApp &app, CState &state, std::uint32_t search_id, bool replace = false);
 
-// Single-threaded SSE diff emission. Called ONLY from the wxApp
-// refresher loop after a successful RefresherTick so that the
-// LastSeenState walk (which mutates app.LastSeenForEvents()) is
-// single-writer. Inline-from-HTTP RefresherTick call sites
-// deliberately skip it — SSE subscribers see the post-mutation
-// diff on the next 1-second tick instead of immediately.
+// Single-threaded SSE diff emission. Called ONLY from the wxApp refresher loop
+// after a successful RefresherTick so that the LastSeenState walk is
+// single-writer. Inline-from-HTTP RefresherTick call sites deliberately skip
+// it -- SSE subscribers see the post-mutation diff on the next tick.
 void EmitDiffsForEventBus(CamuleapiApp &app, const CState &state);
 
 // Bring the diff baseline up to the current state without publishing. Used on
@@ -93,10 +89,9 @@ void EmitDiffsForEventBus(CamuleapiApp &app, const CState &state);
 // per record; whoever subscribed during the gap gets `resync` instead.
 void PrimeDiffBaseline(CamuleapiApp &app, const CState &state);
 
-// Sub-tick helpers exposed for testing. The Refresher uses these
-// internally; the unit test calls them against hand-crafted
-// CECPacket fixtures to pin the EC-tag-to-State mapping without
-// standing up a real amuled.
+// Sub-tick helpers exposed for testing. The Refresher uses these internally;
+// the unit test calls them against hand-crafted CECPacket fixtures to pin the
+// EC-tag-to-State mapping without standing up a real amuled.
 
 struct StatusSnapshot;
 struct FileSnapshot;
@@ -110,132 +105,96 @@ struct PreferencesSnapshot;
 class FileMap;
 
 void ParseStatusFromPacket(const CECPacket *resp, StatusSnapshot &out);
-// Kad detail rides the same STAT_REQ response — saves a roundtrip
-// since amuled bundles `EC_TAG_STATS_KAD_*` into the standard CMD-
-// level stats packet. /status calls ParseStatus then /kad calls
-// this against the same packet pointer.
+// Kad detail rides the same STAT_REQ response -- amuled bundles
+// EC_TAG_STATS_KAD_* into the standard CMD-level stats packet, so /status calls
+// ParseStatus and /kad calls this against the same packet pointer.
 void ParseKadFromPacket(const CECPacket *resp, KadSnapshot &out);
 
-// Drain new amule-log lines from the STAT_REQ response. amule's EC
-// server piggybacks them inside an `EC_TAG_STATS_LOGGER_MESSAGE`
-// parent tag with child `EC_TAG_STRING` tags, but ONLY when the
-// STAT_REQ was issued at `EC_DETAIL_FULL` (or INC_UPDATE). The
-// refresher calls this on the same packet as ParseStatus / ParseKad,
-// then `state.AppendAmuleLog(...)` to fold them into the cache.
+// Drain new amule-log lines from the STAT_REQ response. amule's EC server
+// piggybacks them inside an EC_TAG_STATS_LOGGER_MESSAGE parent tag with child
+// EC_TAG_STRING tags, but ONLY when the STAT_REQ was issued at EC_DETAIL_FULL
+// (or INC_UPDATE).
 void ParseAmuleLogFromPacket(const CECPacket *resp, std::vector<std::string> &out_new_lines);
 
-// Union `EC_OP_SEARCH_PROGRESS` response → {search id: {percent, lifecycle
+// Union EC_OP_SEARCH_PROGRESS response -> {search id: {percent, lifecycle
 // state}} for every search the daemon reported.
 //
-// Returns false unless the reply really is an `EC_OP_SEARCH_PROGRESS`, and the
-// caller MUST honour that: absence from a union reply is how a search is
-// learnt to have expired, so treating a reply this could not parse as an empty
-// union would retire every search the caller is tracking in one pass --
-// active=false, terminal snapshot, a final search_progress SSE frame to every
-// subscriber. The per-id form this replaces cannot do that: it expires only on
-// an explicit `EC_TAG_SEARCH_EXPIRED`, and an unexpected reply just leaves the
-// values alone. An `EC_OP_FAILED` (the daemon has ~30 paths that emit one)
-// must therefore fall back to per-id polling, not be read as "all gone".
+// Returns false unless the reply really is an EC_OP_SEARCH_PROGRESS, and the
+// caller MUST honour that: absence from a union reply is how a search is learnt
+// to have expired, so treating an unparseable reply as an empty union would
+// retire every search the caller is tracking in one pass. An EC_OP_FAILED must
+// therefore fall back to per-id polling, not be read as "all gone".
 //
 // An *empty* union with the right opcode is NOT malformed -- it is the daemon
-// legitimately saying it holds none of the searches asked about -- so the
-// opcode, not the child count, is the discriminator.
+// legitimately saying it holds none of the searches asked about.
 bool ParseSearchProgressUnion(
 	const CECPacket *resp, std::map<std::uint32_t, std::pair<std::uint32_t, std::uint32_t>> &out);
 
-// `EC_OP_GET_PREFERENCES` response → flat prefs + bundled categories
-// (the EC packet carries categories under `EC_TAG_PREFS_CATEGORIES`).
-// One roundtrip populates both /preferences and /categories.
+// EC_OP_GET_PREFERENCES response -> flat prefs + bundled categories (the packet
+// carries categories under EC_TAG_PREFS_CATEGORIES), so one roundtrip populates
+// both /preferences and /categories.
 void ParsePreferencesFromPacket(
 	const CECPacket *resp, PreferencesSnapshot &out_prefs, std::vector<CategorySnapshot> &out_cats);
 
-// Locale-independent file-type token from a filename: the desktop's own
-// category label (GetFiletypeByName, untranslated) lowercased -- "audio",
-// "video", "cd-images", "any". Reuses the GUI categorization rather than
-// duplicating the extension table.
-//
-// One owner. This lived twice, character for character, as FileTypeToken in
-// Api.cpp (feeding `file_type` on /shared/{hash}) and SearchTypeToken in
-// Refresher.cpp (feeding `type` on a search result), with neither file
-// mentioning the other -- so a change to the token set could land in one and
-// not the other and the two keys would drift apart silently.
+// Locale-independent file-type token from a filename: the desktop's own category
+// label (GetFiletypeByName, untranslated) lowercased -- "audio", "video",
+// "cd-images", "any". Reuses the GUI categorization rather than duplicating
+// the extension table. One owner, because this lived twice character for
+// character and the two keys could drift apart silently.
 std::string FileTypeToken(const std::string &name);
 
-// `EC_OP_GET_UPDATE` at `EC_DETAIL_INC_UPDATE` is the consolidated
-// fetch backing downloads + shared + servers in a single roundtrip.
-// Response shape (ExternalConn.cpp:869):
-//  * top-level interleaved `EC_TAG_PARTFILE` (downloads) and
-//    `EC_TAG_KNOWNFILE` (shared) — full identity on first encounter,
-//    stat-only deltas on subsequent ticks via server-side valuemap.
-//  * top-level `EC_TAG_FILE_REMOVED` markers for both caches (the
-//    encoder map is unified server-side).
-//  * `EC_TAG_SERVER` container — full list every tick, valuemap-
-//    suppressed unchanged per-server fields.
-//  * `EC_TAG_CLIENT` container — IGNORED in favour of
-//    `EC_OP_GET_ULOAD_QUEUE` so /uploads stays bound to the upload-
-//    queue semantic (the GET_UPDATE clients block is filtered by
-//    the global `TransmitOnlyUploadingClients` pref which would
-//    pollute amuleweb/amulegui's view).
-//  * `EC_TAG_FRIEND` container — IGNORED.
+// EC_OP_GET_UPDATE at EC_DETAIL_INC_UPDATE is the consolidated fetch backing
+// downloads + shared + servers in a single roundtrip. Response shape:
+//  * top-level interleaved EC_TAG_PARTFILE (downloads) and EC_TAG_KNOWNFILE
+//    (shared) -- full identity on first encounter, stat-only deltas on
+//    subsequent ticks via the server-side valuemap.
+//  * top-level EC_TAG_FILE_REMOVED markers for both caches (the encoder map is
+//    unified server-side).
+//  * EC_TAG_SERVER container -- full list every tick, valuemap-suppressed
+//    unchanged per-server fields.
+//  * EC_TAG_CLIENT container -- consumed into /clients. Filtered server-side by
+//    the global TransmitOnlyUploadingClients pref; /uploads stays bound to the
+//    upload-queue semantic via EC_OP_GET_ULOAD_QUEUE.
+//  * EC_TAG_FRIEND container -- consumed into /friends.
 //
-// Why INC_UPDATE instead of per-substruct UPDATE: the per-substruct
-// paths at `EC_DETAIL_UPDATE` strip identity (ECSpecialCoreTags.cpp:
-// 244-246's early-return), forcing the second FULL-detail roundtrip
-// the old refresher used. INC_UPDATE doesn't hit that early-return —
-// identity arrives in one shot, no follow-up needed, no #713 / #808
-// defences (those wire-level races only exist at EC_DETAIL_UPDATE).
-//
-// The three helpers below each iterate the same response once,
-// filtering for their tag type. Called under three distinct CState
-// mutator acquisitions; snapshot_at is set after the whole tick
-// succeeds, so cross-substruct consistency is best-effort.
+// Why INC_UPDATE instead of per-substruct UPDATE: the per-substruct paths at
+// EC_DETAIL_UPDATE strip identity via an early return in ECSpecialCoreTags.cpp,
+// forcing a second FULL-detail roundtrip. INC_UPDATE does not hit that, so
+// identity arrives in one shot with no follow-up needed.
 
-// Merges download-walker state (EC_TAG_PARTFILE children) into the
-// unified file map. Sets `is_downloading=true` on touched entries,
-// writes only the download sub-block. FILE_REMOVED clears the
-// download role (and drops the entry entirely if `is_shared` was
-// also false). See FileSnapshot in State.h for the unified-map
-// rationale.
+// Merges download-walker state (EC_TAG_PARTFILE children) into the unified file
+// map. Sets `is_downloading=true` on touched entries and writes only the
+// download sub-block. FILE_REMOVED clears the download role, and drops the
+// entry entirely if `is_shared` was also false.
 void ApplyGetUpdateToDownloads(
 	const CECPacket *resp, FileMap &cache, std::map<std::uint32_t, PartFileEncoderData> &rle_state);
 
-// Merges shared-walker state (EC_TAG_KNOWNFILE / EC_TAG_PARTFILE with
-// SHARED flag) into the same unified map. Sets `is_shared=true`,
-// updates the shared sub-block, and clears the shared role on
-// PARTFILE_SHARED=false / FILE_REMOVED. The dl_identity_fallback
-// parameter is gone: when the shared walker sees a partfile whose
-// hash tag was CValueMap-suppressed, the entry already carries hash
-// + name from the downloads walker on the same tick (same unified
-// map), so the shared walker just flips its flag and merges its own
-// fields. No fallback hop needed.
-// `rle_state` is the same per-ECID decoder map the downloads walker
-// uses, and deliberately so: amuled keeps exactly one encoder per ECID
+// Merges shared-walker state (EC_TAG_KNOWNFILE / EC_TAG_PARTFILE with the SHARED
+// flag) into the same unified map. Sets `is_shared=true`, updates the shared
+// sub-block, and clears the shared role on PARTFILE_SHARED=false /
+// FILE_REMOVED.
+//
+// `rle_state` is the same per-ECID decoder map the downloads walker uses, and
+// deliberately so: amuled keeps exactly one encoder per ECID
 // (CFileEncoderMap::UpdateEncoders) and emits it as EC_TAG_PARTFILE or
-// EC_TAG_KNOWNFILE, never both, so a single decoder map mirrors the
-// daemon's encoder set 1:1. This walker feeds only the KNOWNFILE half;
-// the downloads walker feeds the PARTFILE half and already evicts on
-// EC_TAG_FILE_REMOVED, which is the only way an ECID's encoder is torn
-// down and rebuilt (a completing download keeps its CPartFile_Encoder
-// until CDownloadQueue::ClearCompleted renews its ECID outright).
+// EC_TAG_KNOWNFILE, never both, so a single decoder map mirrors the daemon's
+// encoder set 1:1. The downloads walker already evicts on EC_TAG_FILE_REMOVED,
+// which is the only way an ECID's encoder is torn down and rebuilt.
 void ApplyGetUpdateToShared(
 	const CECPacket *resp, FileMap &cache, std::map<std::uint32_t, PartFileEncoderData> &rle_state);
 
 void ApplyGetUpdateToServers(const CECPacket *resp, std::map<std::uint32_t, ServerSnapshot> &cache);
 
 // Consumes the EC_TAG_FRIEND container the daemon appends to every
-// EC_OP_GET_UPDATE reply (ExternalConn.cpp, "Add friends"), so /friends is
-// served from the tick we already run rather than a roundtrip of its own.
+// EC_OP_GET_UPDATE reply, so /friends is served from the tick we already run.
 void ApplyGetUpdateToFriends(const CECPacket *resp, std::map<std::uint32_t, FriendSnapshot> &cache);
 
 // EC_OP_CHAT_SESSIONS -> the /chats snapshot. `cursor` is read as the value
 // sent with the request and written back with the store's current last id.
 //
 // The reply is the daemon's COMPLETE session set, so this replaces the vector
-// rather than merging into it: a session missing from a reply was closed (by
-// another client, or evicted), and that absence is the only signal a close
-// produces. Messages, by contrast, arrive incrementally -- only those newer
-// than the cursor -- so they are appended to the session they belong to,
-// carrying over what the previous tick already held.
+// rather than merging: a session missing from a reply was closed, and that
+// absence is the only signal a close produces. Messages arrive incrementally.
 void ApplyChatSessions(const CECPacket *resp,
 	std::vector<ChatSessionSnapshot> &cache,
 	std::uint32_t &cursor,
@@ -244,37 +203,29 @@ void ApplyChatSessions(const CECPacket *resp,
 
 // ed2k server priority, both directions. The SRV_PR_* wire values are not
 // monotone (NORMAL=0, HIGH=1, LOW=2), so callers must never assume a name's
-// position in a list is its code. ServerPriorityCode returns false for an
-// unknown name, leaving out_code untouched.
+// position in a list is its code.
 const char *ServerPriorityName(std::uint32_t prio_code);
 bool ServerPriorityCode(const std::string &name, std::uint32_t &out_code);
 
-// /stats/tree (EC_OP_GET_STATSTREE response). Recursive walk —
-// every EC_TAG_STATTREE_NODE that contains children becomes a
-// branch; leaves get `children.empty()`. The top-level `root` is
-// an unnamed container; we skip the root and emit its direct
-// children as the visible tree (matches amuleweb's
-// `am_load_stats_tree.php` behaviour).
+// /stats/tree (EC_OP_GET_STATSTREE response). Recursive walk -- every
+// EC_TAG_STATTREE_NODE with children becomes a branch. The top-level root is an
+// unnamed container, skipped so its direct children are the visible tree.
 struct StatsTreeNode;
 void ParseStatsTreeFromPacket(const CECPacket *resp, StatsTreeNode &out);
 
-// /stats/graphs/{graph} (EC_OP_GET_STATSGRAPHS response). amuled
-// packs the four time-series (download/upload/connections+kad as
-// two interleaved channels in EC_TAG_STATSGRAPH_DATA + a separate
-// EC_TAG_STATSGRAPH_DATA_CONN) into byte blobs. Parser un-packs
-// them into the four separate vectors of `StatsGraphs`.
+// /stats/graphs/{graph} (EC_OP_GET_STATSGRAPHS response). amuled packs the four
+// time-series into byte blobs (two interleaved channels in
+// EC_TAG_STATSGRAPH_DATA plus a separate EC_TAG_STATSGRAPH_DATA_CONN).
 struct StatsGraphs;
 void ParseGraphsFromPacket(const CECPacket *resp, StatsGraphs &out);
 
-// /search/results (EC_OP_SEARCH_RESULTS response). Full-state fetch
-// per tick; like /servers, no INC path exists for the search list.
-// Cache is keyed by ECID; cleared on each refresher tick before
-// applying.
+// /search/results (EC_OP_SEARCH_RESULTS response). Full-state fetch per tick;
+// like /servers, no INC path exists for the search list. Keyed by ECID.
 struct SearchResult;
 struct SearchSlot;
 // Merge one EC_TAG_SEARCHFILE onto a result, writing only the fields the tag
-// carries. Exposed for the unit tests, which drive it directly to pin the
-// absent-means-unchanged contract field by field.
+// carries. Exposed for the unit tests, which pin the absent-means-unchanged
+// contract field by field.
 void MergeSearchResultTag(const CEC_SearchFile_Tag *sf, SearchResult &r);
 
 // Rebuild the folded view from the flat merge target: children nested into
@@ -282,13 +233,11 @@ void MergeSearchResultTag(const CEC_SearchFile_Tag *sf, SearchResult &r);
 void RebuildFoldedResults(
 	const std::map<std::uint32_t, SearchResult> &raw, std::map<std::uint32_t, SearchResult> &out);
 
-// Apply one incremental multi-search union reply across every slot, keeping
-// the ECID -> search_id index in step. See the definition for why absence
-// cannot mean deletion here.
-// `default_sid` attributes tags that carry no EC_TAG_SEARCH_ID of their own.
-// Zero for the union reply, where a missing id means "already known" and the
-// index answers it; set for a per-search reply, where the whole packet belongs
-// to one search and the responder never stamps an id.
+// Apply one incremental multi-search union reply across every slot, keeping the
+// ECID -> search_id index in step. See the definition for why absence cannot
+// mean deletion here. `default_sid` attributes tags that carry no
+// EC_TAG_SEARCH_ID of their own: zero for the union reply, where a missing id
+// means "already known"; set for a per-search reply, which never stamps one.
 void ApplySearchUnion(const CECPacket *resp,
 	std::map<std::uint32_t, SearchSlot> &slots,
 	std::map<std::uint32_t, std::uint32_t> &owner,
@@ -296,16 +245,11 @@ void ApplySearchUnion(const CECPacket *resp,
 
 // Apply one per-search EC_DETAIL_FULL reply to a single slot.
 //
-// `replace` swaps the slot's results for what the daemon reports now instead
-// of merging onto them, which is what a re-seed after a lost union reply
-// needs: a FULL reply carries no tombstones, so a merge cannot express a row
-// the daemon has dropped. It is also the only mode that discharges
-// SearchSlot::needs_resync -- a merge leaves exactly the rows the flag exists
-// to clear, so clearing it there would strand them permanently.
-//
-// Split out of FetchOneSearchFull so the bookkeeping is reachable from the
-// tests: RefresherTick.cpp is kept out of the test target for its CamuleapiApp
-// dependency, and this is where the resync contract actually lives.
+// `replace` swaps the slot's results for what the daemon reports now instead of
+// merging onto them, which is what a re-seed after a lost union reply needs: a
+// FULL reply carries no tombstones, so a merge cannot express a row the daemon
+// has dropped. It is also the only mode that discharges
+// SearchSlot::needs_resync -- clearing it after a merge would strand them.
 void ApplySearchFullReply(const CECPacket *resp,
 	std::map<std::uint32_t, SearchSlot> &slots,
 	std::map<std::uint32_t, std::uint32_t> &owner,
@@ -313,30 +257,22 @@ void ApplySearchFullReply(const CECPacket *resp,
 	bool replace);
 
 // Search-progress derivation from the EC_TAG_SEARCH_LIFECYCLE_* tags.
-// `lifecycle_state` is the uint8 enum value (0=idle, 1=running,
-// 2=finished). `pct_now` is the EC_TAG_SEARCH_LIFECYCLE_PERCENT value —
-// the daemon's unified 0..100 for every search kind (global = real,
-// Kad = cosmetic ramp, finished = 100), passed straight through (no
-// per-kind masking). Pure function: no I/O, no globals — RefresherTest
-// exercises every branch without standing up a daemon.
+// `lifecycle_state` is the uint8 enum value (0=idle, 1=running, 2=finished).
+// `pct_now` is the daemon's unified 0..100 for every search kind, passed
+// straight through with no per-kind masking. Pure function: no I/O, no globals.
 struct SearchProgressSnapshot;
 SearchProgressSnapshot AdvanceSearchProgress(
 	const SearchProgressSnapshot &prev, std::uint32_t lifecycle_state, std::uint32_t pct_now);
 
-// `ApplyGetUpdateToClients` consumes the EC_TAG_CLIENT container
-// from the consolidated GET_UPDATE response. The walker uses
-// "seen-this-tick = keep, absent = evict" semantics: every alive
-// client surfaces every tick via the outer per-client tag (CValueMap
-// suppression operates on the tag's *children*, not on the entity
-// itself), so cache entries not seen in this response are gone on
-// amuled's side (peer disconnected, dropped from queue, banned).
+// `ApplyGetUpdateToClients` consumes the EC_TAG_CLIENT container from the
+// consolidated GET_UPDATE response, with "seen-this-tick = keep, absent =
+// evict" semantics: every alive client surfaces every tick via the outer
+// per-client tag, since CValueMap suppression operates on the tag's *children*.
+//
 // `files` lets the walker resolve EC_TAG_CLIENT_UPLOAD_FILE /
-// EC_TAG_CLIENT_REQUEST_FILE (raw amuled ECIDs) into MD4 hashes at
-// walker time, so ClientSnapshot can surface the hash directly. It is
-// the live map, keyed by the same ECIDs, so pass it via
-// CState::MutateClientsWithFiles AFTER the downloads/shared walkers
-// have run on the same tick. Empty map = correlator hashes stay empty
-// (matches "not currently transferring" semantics).
+// EC_TAG_CLIENT_REQUEST_FILE (raw amuled ECIDs) into MD4 hashes at walker time.
+// It is the live map, so pass it via CState::MutateClientsWithFiles AFTER the
+// downloads/shared walkers have run on the same tick.
 void ApplyGetUpdateToClients(
 	const CECPacket *resp, std::map<std::uint32_t, ClientSnapshot> &cache, const FileMap &files);
 

--- a/src/webapi/RefresherTick.cpp
+++ b/src/webapi/RefresherTick.cpp
@@ -96,28 +96,22 @@ SearchFetchOutcome FetchSearchResults(CamuleapiApp &app, CState &state)
 // Re-fetch ONE search at EC_DETAIL_FULL, bypassing the union entirely.
 //
 // The union is a stateful differential stream: the daemon records what it has
-// sent this connection and then sends only changes, with no opcode for "send
-// it all again". That makes it the wrong tool twice over, and this is the
-// escape hatch for both.
+// sent this connection and then sends only changes, with no opcode for "send it
+// all again". This is the escape hatch, needed three ways.
 //
-// Seeding a newly discovered slot. The union responder walks
-// GetKnownSearchIds() -- every search the core holds, including ones started
-// in amulegui or the monolithic GUI. ApplySearchUnion drops results for a
-// search it has no slot for, but the daemon has already marked those ECIDs
-// delivered and seeded its valuemap, so on the next poll they are unchanged
-// and elided: dropped once means dropped forever. A slot created later by
-// discovery would stay empty. This fetch is what fills it.
+// Seeding a newly discovered slot: the union responder walks every search the
+// core holds, ApplySearchUnion drops results for a search it has no slot for,
+// and the daemon has already marked those ECIDs delivered -- dropped once means
+// dropped forever, so a slot created later by discovery would stay empty.
 //
-// Serving the HTTP thread. The union must have exactly one issuer, or two
+// Serving the HTTP thread: the union must have exactly one issuer, or two
 // replies can be applied out of order and leave a ghost row no later poll can
-// clear. A FULL reply is self-contained, but it is not ordered against the
-// union's one-shot tombstones, so this shares g_search_stream_mtx with the
-// union rather than relying on idempotence alone.
+// clear. A FULL reply is self-contained but not ordered against the union's
+// one-shot tombstones, so this shares g_search_stream_mtx with it.
 //
-// Re-seeding after a lost union reply, with `replace`. A merge cannot express
-// a deletion, and a FULL reply carries no tombstones, so a plain merge would
-// leave behind rows the daemon has since dropped. In replace mode the slot's
-// results are swapped wholesale for what the daemon reports now.
+// Re-seeding after a lost union reply, with `replace`: a merge cannot express a
+// deletion and a FULL reply carries no tombstones, so replace mode swaps the
+// slot's results wholesale for what the daemon reports now.
 SearchFetchOutcome FetchOneSearchFull(CamuleapiApp &app, CState &state, std::uint32_t search_id, bool replace)
 {
 	std::lock_guard<std::mutex> stream_lock(g_search_stream_mtx);
@@ -132,9 +126,9 @@ SearchFetchOutcome FetchOneSearchFull(CamuleapiApp &app, CState &state, std::uin
 		outcome = SearchFetchOutcome::Expired;
 	} else {
 		// Same merge the union uses. The per-search responder builds its tags
-		// without a valuemap, so every field of every result is present and
-		// the merge's absent-means-unchanged rule simply never fires. The
-		// reply carries no EC_TAG_SEARCH_ID of its own, hence the explicit id.
+		// without a valuemap, so every field is present and the merge's
+		// absent-means-unchanged rule never fires. The reply carries no
+		// EC_TAG_SEARCH_ID of its own, hence the explicit id.
 		state.MutateAllSearches([&](std::map<std::uint32_t, SearchSlot> &slots,
 						std::map<std::uint32_t, std::uint32_t> &owner) {
 			ApplySearchFullReply(resp, slots, owner, search_id, replace);
@@ -152,24 +146,17 @@ SearchFetchOutcome FetchOneSearchFull(CamuleapiApp &app, CState &state, std::uin
 
 bool RefresherTick(CamuleapiApp &app, CState &state)
 {
-	// Per-tick budget: a few EC ops via SendRecvSerialized
-	// (m_ec_mtx-serialised). Any failure bails the whole tick so the
-	// cache stays internally consistent — we never expose
-	// partially-refreshed snapshots. STAT_REQ runs first because
-	// it's the cheapest probe: if EC dropped between ticks, STAT_REQ
-	// catches it before we burn roundtrips on the larger queries.
+	// Per-tick budget: a few EC ops via SendRecvSerialized (m_ec_mtx-serialised).
+	// Any failure bails the whole tick so the cache stays internally consistent.
+	// STAT_REQ runs first because it is the cheapest probe: if EC dropped between
+	// ticks, it catches that before we burn roundtrips on the larger queries.
 
 	// /status + /kad + /logs/amule share one STAT_REQ packet.
 	//
-	// Detail level CMD → FULL because amuled only piggybacks
-	// `EC_TAG_STATS_LOGGER_MESSAGE` (the incremental-log channel) at
-	// FULL or INC_UPDATE (ExternalConn.cpp:722-730). FULL is also what
-	// carries STATS_UP_OVERHEAD / STATS_DOWN_OVERHEAD and the two
-	// free-space tags, which /status reports — so this is load-bearing
-	// now, not a harmless over-request: dropping it to CMD would silently
-	// empty those fields along with the log channel. STATS_BANNED_COUNT,
-	// STATS_TOTAL_*_BYTES and STATS_SHARED_FILE_COUNT still arrive
-	// unconsumed.
+	// Detail level CMD -> FULL because amuled only piggybacks
+	// EC_TAG_STATS_LOGGER_MESSAGE at FULL or INC_UPDATE. FULL is also what
+	// carries STATS_UP_OVERHEAD / STATS_DOWN_OVERHEAD and the two free-space
+	// tags, so dropping to CMD would silently empty those fields as well.
 	{
 		std::unique_ptr<CECPacket> req(new CECPacket(EC_OP_STAT_REQ, EC_DETAIL_FULL));
 		const CECPacket *resp = app.SendRecvSerialized(req.get());
@@ -189,23 +176,15 @@ bool RefresherTick(CamuleapiApp &app, CState &state)
 		delete resp;
 	}
 
-	// /downloads + /shared + /servers in a single GET_UPDATE roundtrip
-	// at EC_DETAIL_INC_UPDATE. Replaces an earlier per-substruct
-	// fetch (GET_DLOAD_QUEUE + GET_SHARED_FILES + GET_SERVER_LIST,
-	// each with its own UPDATE+FULL two-pass split). Response packet
-	// shape and the "why INC_UPDATE works in one tick" rationale
-	// (identity short-circuit at EC_DETAIL_UPDATE only) are documented
-	// next to ApplyGetUpdateToDownloads in Refresher.h.
+	// /downloads + /shared + /servers in a single GET_UPDATE roundtrip at
+	// EC_DETAIL_INC_UPDATE. The response packet shape and the "why INC_UPDATE
+	// works in one tick" rationale are documented next to
+	// ApplyGetUpdateToDownloads in Refresher.h.
 	//
 	// The response also carries EC_TAG_CLIENT (filtered server-side by
-	// `TransmitOnlyUploadingClients`) and EC_TAG_FRIEND containers. Both are
-	// consumed below, into /clients and /friends respectively — /uploads
-	// stays bound to the upload-queue semantic via EC_OP_GET_ULOAD_QUEUE.
-	//
-	// Six exclusive acquisitions in this block: five Mutate calls (downloads,
-	// shared, servers, friends, clients+files) plus ReconcileKnownClients at
-	// the end — snapshot_at is set after the whole tick succeeds; per-substruct
-	// atomicity was already best-effort.
+	// TransmitOnlyUploadingClients) and EC_TAG_FRIEND containers, consumed below
+	// into /clients and /friends -- /uploads stays bound to the upload-queue
+	// semantic via EC_OP_GET_ULOAD_QUEUE.
 	{
 		std::unique_ptr<CECPacket> req(new CECPacket(EC_OP_GET_UPDATE, EC_DETAIL_INC_UPDATE));
 		const CECPacket *resp = app.SendRecvSerialized(req.get());
@@ -213,11 +192,8 @@ bool RefresherTick(CamuleapiApp &app, CState &state)
 			return false;
 		auto &rle = app.PartfileRleStateRequireStateWriteLock();
 
-		// Snapshot the cache's pre-tick ECID set so we can evict
-		// rle_state entries for any partfile that gets removed during
-		// the walk (the walker erases from rle_state on FILE_REMOVED,
-		// but we also want to cover the case where ApplyGetUpdate*
-		// itself evicts in some future hardening path).
+		// Snapshot the cache's pre-tick ECID set so rle_state entries can be
+		// evicted for any partfile removed during the walk.
 		std::set<std::uint32_t> ecids_before;
 		state.MutateDownloads([&](FileMap &cache) {
 			for (const auto &kv : cache) {
@@ -225,9 +201,8 @@ bool RefresherTick(CamuleapiApp &app, CState &state)
 					ecids_before.insert(kv.first);
 			}
 			ApplyGetUpdateToDownloads(resp, cache, rle);
-			// Evict RLE state for ECIDs that no longer carry the
-			// downloading role after the apply. The walker handles
-			// FILE_REMOVED already; this is defence in depth.
+			// Evict RLE state for ECIDs that no longer carry the downloading role.
+			// The walker handles FILE_REMOVED already; this is defence in depth.
 			for (auto ecid : ecids_before) {
 				auto it = cache.find(ecid);
 				if (it == cache.end() || !it->second.is_downloading) {
@@ -236,17 +211,14 @@ bool RefresherTick(CamuleapiApp &app, CState &state)
 			}
 		});
 
-		// Shared walker reads + writes the same unified m_files map.
-		// No more dl_identity_fallback compose: when the shared walker
-		// sees a partfile whose hash was CValueMap-suppressed, the
-		// entry in `cache` already carries hash + name from the
-		// downloads walker above. See FileSnapshot in State.h for the
-		// shared-storage rationale.
+		// Shared walker reads and writes the same unified m_files map: when it
+		// sees a partfile whose hash was CValueMap-suppressed, the entry already
+		// carries hash + name from the downloads walker above.
+		//
 		// Same `rle` map: the shared walker decodes the availability blob on
-		// EC_TAG_KNOWNFILE tags, the downloads walker the EC_TAG_PARTFILE
-		// ones, and amuled emits exactly one of the two per ECID. The
-		// eviction sweep above only ever touches ECIDs that were downloading,
-		// so it cannot drop a knownfile's decoder state.
+		// EC_TAG_KNOWNFILE tags and the downloads walker the EC_TAG_PARTFILE ones,
+		// and amuled emits exactly one of the two per ECID. The eviction sweep
+		// above only touches ECIDs that were downloading.
 		state.MutateShared([&](FileMap &cache) { ApplyGetUpdateToShared(resp, cache, rle); });
 
 		state.MutateServers([&](std::map<std::uint32_t, ServerSnapshot> &cache) {
@@ -257,30 +229,27 @@ bool RefresherTick(CamuleapiApp &app, CState &state)
 			ApplyGetUpdateToFriends(resp, cache);
 		});
 
-		// /clients — every alive peer in theApp->clientlist (download
-		// sources, upload slots, queue waiters, etc.). The walker turns each
-		// peer's file ECID into an MD4 hash as it goes — the wire contract is
-		// hash-only — so it needs the map the downloads/shared walkers just
-		// wrote: one acquisition hands it both.
+		// /clients -- every alive peer in theApp->clientlist. The walker turns each
+		// peer's file ECID into an MD4 hash as it goes, the wire contract being
+		// hash-only, so it needs the map the downloads/shared walkers just wrote:
+		// one acquisition hands it both.
 		state.MutateClientsWithFiles(
 			[&](std::map<std::uint32_t, ClientSnapshot> &cache, const FileMap &files) {
 				ApplyGetUpdateToClients(resp, cache, files);
 			});
 		delete resp;
 
-		// Fold this tick's peers into the known-clients store, so it stays
-		// current from the update we already have rather than being re-read.
-		// A no-op until something has asked for /known_clients, so a daemon
-		// nobody queries never pays for it; after that it costs one hash
+		// Fold this tick's peers into the known-clients store, so it stays current
+		// from the update we already have rather than being re-read. A no-op until
+		// something has asked for /known_clients; after that it costs one hash
 		// lookup per connected peer, bounded by MaxConnections.
 		state.ReconcileKnownClients();
 	}
 
-	// /chats — one roundtrip carrying the cursor from the previous tick, so
-	// the daemon replies with the session list plus only the messages we do
-	// not have. Gated on the capability and skipped entirely otherwise: a
-	// daemon predating the chat ops reaches the unknown-opcode branch of
-	// ProcessRequest2(), which asserts rather than answering EC_OP_FAILED.
+	// /chats -- one roundtrip carrying the cursor from the previous tick, so the
+	// daemon replies with the session list plus only the messages we do not have.
+	// Gated on the capability: a daemon predating the chat ops reaches the
+	// unknown-opcode branch of ProcessRequest2(), which asserts.
 	if (app.IsServerChatActive()) {
 		std::unique_ptr<CECPacket> req(new CECPacket(EC_OP_GET_CHAT_SESSIONS));
 		const std::uint32_t cursor = state.ChatCursor();
@@ -290,9 +259,8 @@ bool RefresherTick(CamuleapiApp &app, CState &state)
 		const CECPacket *resp = app.SendRecvSerialized(req.get());
 		if (!resp)
 			return false;
-		// Collected under the write lock, published after it: emitting SSE
-		// frames from inside the lambda would hold CState exclusively across
-		// the event bus.
+		// Collected under the write lock, published after it: emitting SSE frames
+		// from inside the lambda would hold CState exclusively across the bus.
 		std::vector<webapi::ChatSessionSnapshot> new_messages;
 		std::vector<std::uint64_t> closed;
 		state.MutateChats([&](std::vector<webapi::ChatSessionSnapshot> &cache, std::uint32_t &cur) {
@@ -302,53 +270,38 @@ bool RefresherTick(CamuleapiApp &app, CState &state)
 		PublishChatEvents(app.EventBus(), new_messages, closed);
 	}
 
-	// /logs/server_info, /stats/tree, /stats/graphs/{graph} are NOT
-	// fetched per-tick — they're lazy-fetched on first GET via
-	// CTtlCache (1 s TTL coalesces burst reads). HTTP handlers in
-	// Api.cpp drive their own EC roundtrips under m_ec_mtx. Per-tick
-	// refresh would have been pure waste when nothing is listening.
+	// /logs/server_info, /stats/tree and /stats/graphs/{graph} are NOT fetched
+	// per-tick -- they are lazy-fetched on first GET via CTtlCache (1 s TTL
+	// coalesces burst reads), driven by the handlers under m_ec_mtx.
 
-	// Searches this session never started itself (another EC client, or
-	// the monolithic GUI) are NOT discovered here per-tick -- that would
-	// pay an EC_OP_SEARCH_LIST roundtrip every tick forever to serve
-	// something that happens rarely. Instead, HandleSearchResults in
-	// Api.cpp does a one-off EC_OP_SEARCH_LIST check on a cache miss and
-	// seeds the slot via MarkSearchDiscovered right there; from the next
-	// tick on, the loop below picks it up like any other active search.
+	// Searches this session never started itself are NOT discovered here
+	// per-tick -- that would pay an EC_OP_SEARCH_LIST roundtrip every tick
+	// forever. HandleSearchResults does a one-off check on a cache miss and
+	// seeds the slot; from the next tick the loop below picks it up.
 
-	// /search/results — poll each ACTIVE search independently (amuleapi runs
-	// several at once). POST /search seeds a slot with active=true; the
-	// daemon's per-id EC_TAG_SEARCH_LIFECYCLE_STATE tells us when to flip it
-	// back. amuleapi pins a daemon carrying the lifecycle tags, so we read them
-	// directly with no sentinel-decode fallback. Each request addresses its
-	// search by EC_TAG_SEARCH_ID; a search evicted from the daemon's ring comes
-	// back as EC_TAG_SEARCH_EXPIRED, which we resolve to a terminal snapshot.
-	// Progress for every active search in ONE roundtrip when the daemon
-	// advertises the union: an id-less EC_OP_SEARCH_PROGRESS answers with one
-	// child per search it holds. Matters more here than in amuleGUI because
+	// /search/results -- poll each ACTIVE search independently. POST /search seeds
+	// a slot with active=true; the daemon's per-id EC_TAG_SEARCH_LIFECYCLE_STATE
+	// says when to flip it back. A search evicted from the daemon's ring comes
+	// back as EC_TAG_SEARCH_EXPIRED, resolved to a terminal snapshot.
+	//
+	// Progress for every active search comes in ONE roundtrip when the daemon
+	// advertises the union. That matters more here than in amuleGUI because
 	// SendRecvSerialized is synchronous and process-wide mutexed, so N searches
-	// meant N serialized round trips inside a single tick. Absence from the
-	// union is the daemon saying it no longer holds that search, which is the
-	// same verdict the per-id form reports as EC_TAG_SEARCH_EXPIRED.
+	// meant N serialized round trips inside a single tick.
 	std::map<std::uint32_t, std::pair<std::uint32_t, std::uint32_t>> union_progress;
 	bool have_union = false;
 	const std::vector<std::uint32_t> active_sids = state.ActiveSearchIds();
-	// Every slot the daemon could still speak for, finished ones included.
-	// A finished search is never polled for progress -- there is none left to
-	// report -- but it still has to be watched for EXPIRY, because the ring
-	// evicting it is what tombstones its results, and a slot that is not
-	// detached by then has them erased by the union below. That is the whole
-	// point of detaching: keep the last-known results for late reads.
+	// Every slot the daemon could still speak for, finished ones included. A
+	// finished search is never polled for progress, but it still has to be
+	// watched for EXPIRY: the ring evicting it is what tombstones its results,
+	// and a slot not detached by then has them erased by the union below.
 	//
-	// Naming these ids is also what stops the eviction happening so soon.
-	// The daemon touches its LRU for exactly the ids a client names, so
-	// leaving finished searches out made them the least-recently-used and the
-	// first victims of anyone's next search -- amuleapi stopped refreshing
-	// precisely the searches it had decided to keep.
+	// Naming these ids is also what stops the eviction happening so soon. The
+	// daemon touches its LRU for exactly the ids a client names, so leaving
+	// finished searches out made them the first victims of anyone's next search.
 	const std::vector<std::uint32_t> attached_sids = state.AttachedSearchIds();
-	// Nothing attached means nothing to ask about. Without this guard the
-	// union would cost a roundtrip every tick forever on an idle daemon,
-	// where the per-id loop below simply had nothing to iterate.
+	// Nothing attached means nothing to ask about. Without this guard the union
+	// would cost a roundtrip every tick forever on an idle daemon.
 	if (app.IsServerSearchProgressUnionActive() && !attached_sids.empty()) {
 		std::unique_ptr<CECPacket> req(new CECPacket(EC_OP_SEARCH_PROGRESS));
 		// Name the searches we track so the daemon bumps exactly those in its
@@ -360,26 +313,23 @@ bool RefresherTick(CamuleapiApp &app, CState &state)
 		if (!resp)
 			return false;
 		// Only trust a reply that really is a union. Anything else -- an
-		// EC_OP_FAILED, a packet with no search children -- must fall through
-		// to the per-id polling below rather than be read as an empty union:
-		// absence is the expiry signal, so a misread would retire every
-		// tracked search in one pass. Slower, but correct.
+		// EC_OP_FAILED, a packet with no search children -- must fall through to
+		// the per-id polling below rather than be read as an empty union: absence
+		// is the expiry signal, so a misread would retire every tracked search.
 		have_union = ParseSearchProgressUnion(resp, union_progress);
 		delete resp;
 	}
 
-	// Per-search lifecycle, off the progress union fetched above (or one
-	// roundtrip each against an older daemon). Runs BEFORE the results poll
-	// below so an eviction is seen, and the slot frozen, while its results
-	// are still there to keep -- see the `expired` branch.
+	// Per-search lifecycle, off the progress union fetched above (or one roundtrip
+	// each against an older daemon). Runs BEFORE the results poll below so an
+	// eviction is seen, and the slot frozen, while its results are still there.
 	for (std::uint32_t sid : attached_sids) {
 		std::uint32_t percent = 0;
 		std::uint32_t lifecycle_state = 0;
 		bool expired = false;
-		// A finished slot is here for the expiry verdict only. Its progress
-		// is terminal and must not be re-derived: AdvanceSearchProgress reads
-		// a missing lifecycle tag as IDLE and would reset complete/percent
-		// back to 0, turning a finished search into an idle one.
+		// A finished slot is here for the expiry verdict only. Its progress is
+		// terminal and must not be re-derived: AdvanceSearchProgress reads a
+		// missing lifecycle tag as IDLE and would reset complete/percent to 0.
 		const bool was_active =
 			std::find(active_sids.begin(), active_sids.end(), sid) != active_sids.end();
 		if (have_union) {
@@ -392,10 +342,10 @@ bool RefresherTick(CamuleapiApp &app, CState &state)
 				lifecycle_state = found->second.second;
 			}
 		} else if (was_active) {
-			// No union on this daemon: fall back to one roundtrip per search,
-			// and only for the active ones. Paying a roundtrip per FINISHED
-			// slot every tick to learn about an eviction that may never come
-			// is the trade the union makes cheap and this form does not.
+			// No union on this daemon: fall back to one roundtrip per search, and
+			// only for the active ones. Paying a roundtrip per FINISHED slot every
+			// tick to learn about an eviction that may never come is the trade the
+			// union makes cheap and this form does not.
 			std::unique_ptr<CECPacket> req(new CECPacket(EC_OP_SEARCH_PROGRESS));
 			req->AddTag(CECTag(EC_TAG_SEARCH_ID, sid));
 			const CECPacket *resp = app.SendRecvSerialized(req.get());
@@ -418,19 +368,15 @@ bool RefresherTick(CamuleapiApp &app, CState &state)
 			}
 		}
 		if (expired) {
-			// The daemon evicted this search (its ring is capped). Retire the
-			// slot as finished + inactive so we stop polling it but keep the
-			// last-known results for late reads; the terminal state also drives
-			// a final search_progress SSE frame for subscribers.
+			// The daemon evicted this search (its ring is capped). Retire the slot as
+			// finished + inactive so we stop polling it but keep the last-known
+			// results for late reads; the terminal state also drives a final
+			// search_progress SSE frame.
 			//
-			// Detaching is what makes "keep the last-known results" true. The
-			// same eviction makes the union emit an EC_TAG_FILE_REMOVED for
-			// every one of this search's results, which would erase precisely
-			// what is being kept -- so the slot is frozen here, before the
-			// union below is fetched, and ApplySearchUnion then leaves it be.
-			// Hence this loop running ahead of the results poll: the progress
-			// union it reads was fetched separately, above, so the order is
-			// free.
+			// Detaching is what makes "keep the last-known results" true: the same
+			// eviction makes the union emit an EC_TAG_FILE_REMOVED for every one of
+			// this search's results. Hence this loop running ahead of the results
+			// poll -- the progress union it reads was fetched separately, above.
 			state.DetachSearch(sid);
 			SearchProgressSnapshot fin = state.SearchProgress(sid);
 			fin.active = false;
@@ -449,79 +395,54 @@ bool RefresherTick(CamuleapiApp &app, CState &state)
 		state.WriteSearchProgress(sid, next);
 	}
 
-	// Results for every search in one roundtrip.
-	//
-	// Gated on there being any search at all, not on which ones are active. A
-	// finished search still changes -- a hit gets downloaded, a Kad notes
-	// lookup lands -- and now costs nothing to keep polling, which is what
-	// lets those changes be seen rather than only appearing on a client's
-	// next read. What is not worth paying for is the empty case: a daemon
-	// holding no searches would otherwise take a roundtrip a second forever
-	// to be told so.
-	//
-	// Deliberately NOT gated on SSE subscribers. The diff walk is (see
-	// CEventBus's subscriber accounting), but the fetch cannot be: a REST
-	// client polling GET /search/{id}/results reads this cache, and for an
-	// active search nothing else refreshes it -- ClaimSearchRefresh covers
-	// only slots that are not active. Skipping the fetch when nobody is
-	// subscribed would hand that client frozen results.
-	//
-	// The gate asks about OUR slots -- specifically the ones the daemon could
-	// still speak for, since a detached slot's search has already been
-	// evicted core-side and polling for it would never return anything. It
-	// does not ask about the daemon's searches, and the daemon never tells us
-	// about one unasked: a slot exists only because
-	// this process started the search or because a read discovered it
-	// (RequireSearch -> DiscoverSearchIfHeldByCore, a one-off
-	// EC_OP_SEARCH_LIST on a cache miss). A search begun in amulegui or the
-	// monolithic GUI therefore leaves this false, and the union is not sent.
-	//
-	// Skipping the poll is not merely an optimisation there, it is the point.
-	// ApplySearchUnion drops results for a search it has no slot for, and the
-	// daemon marks them sent regardless, so polling with nothing to apply
-	// them to would burn through a foreign search's results once and elide
-	// them forever after. Neither discovery route runs through here:
-	// GET /search goes straight to EC_OP_SEARCH_LIST every call, and a by-id
-	// read seeds the slot in full via FetchOneSearchFull before this opens.
 	// Anything the last failed union reply covered is unrecoverable from the
 	// stream itself, so re-seed those slots in full before polling again.
 	// Ordered after the retirement loop so a slot the daemon has dropped is
-	// already detached by the time this runs, and SearchesNeedingResync skips
-	// it: the ordering alone only makes the slot detached, it does not keep it
-	// out of the list.
+	// already detached and SearchesNeedingResync skips it.
 	for (std::uint32_t sid : state.SearchesNeedingResync()) {
 		if (FetchOneSearchFull(app, state, sid, /*replace=*/true) == SearchFetchOutcome::EcFailed) {
 			return false;
 		}
 	}
-	// The same set the progress union above asked about, reused rather than
-	// recomputed against a second spelling of the same !detached test. A slot
-	// an HTTP thread created since is missed for this one tick and picked up
-	// by the next, which is the poll interval either way.
+	// Results for every search in one roundtrip.
+	//
+	// Gated on there being any attached search at all, not on which ones are
+	// active: a finished search still changes -- a hit gets downloaded, a Kad
+	// notes lookup lands -- and costs nothing to keep polling. What is not worth
+	// paying for is the empty case.
+	//
+	// Deliberately NOT gated on SSE subscribers, unlike the diff walk: a REST
+	// client polling GET /search/{id}/results reads this cache, and for an active
+	// search nothing else refreshes it (ClaimSearchRefresh covers only inactive
+	// slots), so skipping the fetch would hand that client frozen results.
+	//
+	// The gate asks about OUR slots, not the daemon's searches. Skipping the poll
+	// when we hold none is the point, not an optimisation: ApplySearchUnion drops
+	// results for a search it has no slot for and the daemon marks them sent
+	// regardless, so polling with nothing to apply them to would burn through a
+	// foreign search's results once and elide them forever after.
+	//
+	// The set is the same one the progress union above asked about, reused rather
+	// than recomputed against a second spelling of the same !detached test. A
+	// slot an HTTP thread created since is picked up by the next tick.
 	if (!attached_sids.empty()) {
 		if (FetchSearchResults(app, state) == SearchFetchOutcome::EcFailed) {
-			// The daemon commits its differential state while building the
-			// reply, so what this one carried is already gone from its point
-			// of view. Flag the slots for a full re-seed above on the next
-			// tick; without it every result that reply covered would be
-			// elided from every later poll.
+			// The daemon commits its differential state while building the reply, so
+			// what this one carried is already gone from its point of view. Flag the
+			// slots for a full re-seed above on the next tick; without it every
+			// result that reply covered would be elided from every later poll.
 			state.MarkAllSearchesNeedResync();
-			// Same rule as every other step in the tick: a failed roundtrip
-			// bails the whole tick rather than exposing a half-refreshed
-			// cache.
+			// Same rule as every other step in the tick: a failed roundtrip bails the
+			// whole tick rather than exposing a half-refreshed cache.
 			return false;
 		}
 	}
 
-	// /preferences + /categories — one EC roundtrip populates both.
-	// Selection bitmask requests every category the endpoint exposes
-	// (issue #437 widened this from GENERAL|CONNECTIONS to all EC-
-	// carried groups). Using the named enums (rather than hex literals)
-	// so a future bit shuffle in ECCodes.h doesn't silently zero out a
-	// section — bit-positional bugs here are hard to spot in JSON
-	// (empty defaults look like "0 KB/s" not "field not requested").
-	// STATISTICS is intentionally omitted (its serialize block is empty
-	// — the 0x1B* tags carry live graph data, not stored prefs).
+	// /preferences + /categories -- one EC roundtrip populates both. The
+	// selection bitmask requests every category the endpoint exposes, spelled
+	// with the named enums rather than hex literals so a future bit shuffle in
+	// ECCodes.h cannot silently zero out a section. STATISTICS is intentionally
+	// omitted: its serialize block is empty, the 0x1B* tags being live graph data.
 	{
 		const std::uint32_t selection =
 			EC_PREFS_CATEGORIES | EC_PREFS_GENERAL | EC_PREFS_CONNECTIONS | EC_PREFS_DIRECTORIES |
@@ -541,29 +462,23 @@ bool RefresherTick(CamuleapiApp &app, CState &state)
 		delete resp;
 	}
 
-	// EmitDiffsAndUpdate is intentionally NOT called here. Mutation
-	// handlers invoke RefresherTick() inline on HTTP threads so the
-	// response sees post-mutation state, and LastSeenState has no
-	// internal lock — concurrent std::map mutation from the wxApp
-	// refresher loop and an HTTP thread is UB. Only the wxApp loop
-	// in App.cpp calls EmitDiffsForEventBus() (below) after a
-	// successful tick; HTTP callers skip it and SSE subscribers see
-	// the diff on the next natural 1 s tick.
+	// EmitDiffsAndUpdate is intentionally NOT called here. Mutation handlers
+	// invoke RefresherTick() inline on HTTP threads so the response sees
+	// post-mutation state, and LastSeenState has no internal lock -- concurrent
+	// std::map mutation from the wxApp refresher loop and an HTTP thread is UB.
 	//
-	// The ETag memo key rides on this, so it has to be bumped HERE and
-	// not in MarkTickSuccess: the background loop calls that, but the
-	// mutating handlers refresh inline and never do, so a mutation moved
-	// the body while the key stood still and the next conditional GET was
-	// answered 304 for content that had just changed.
+	// The ETag memo key rides on this, so it has to be bumped HERE and not in
+	// MarkTickSuccess: the background loop calls that, but the mutating handlers
+	// refresh inline and never do, so a mutation moved the body while the key
+	// stood still and the next conditional GET was answered 304.
 	state.BumpSnapshotRevision();
 	return true;
 }
 
 void EmitDiffsForEventBus(CamuleapiApp &app, const CState &state)
 {
-	// Sole writer of `app.LastSeenForEvents()`. ONLY the wxApp
-	// refresher loop calls this; HTTP-server inline RefresherTick
-	// call sites do NOT.
+	// Sole writer of `app.LastSeenForEvents()`. ONLY the wxApp refresher loop
+	// calls this; the HTTP-server inline RefresherTick call sites do NOT.
 	EmitDiffsAndUpdate(app.EventBus(), app.LastSeenForEvents(), state);
 }
 

--- a/src/webapi/SearchJson.cpp
+++ b/src/webapi/SearchJson.cpp
@@ -65,11 +65,10 @@ void WriteSearchResultFields(CJsonWriter &w, const SearchResult &r)
 	// never carries the tag.
 	w.Key("directory");
 	w.ValueString(wxString::FromUTF8(r.directory.c_str()));
-	// Media metadata (issue #430) -- same shape as the file-detail `media`
-	// object, and null when the hit carries no media tags. null rather than
-	// omitted so the key is always present: this is the one place the
-	// unknown-value rule reaches an object instead of a scalar, so a client
-	// tests `media === null` before reaching into it.
+	// Media metadata, same shape as the file-detail `media` object, and null
+	// when the hit carries no media tags. null rather than omitted so the key is
+	// always present -- the one place the unknown-value rule reaches an object
+	// instead of a scalar, so a client tests `media === null` before indexing it.
 	if (r.has_media) {
 		w.Key("media");
 		w.BeginObject();
@@ -90,14 +89,12 @@ void WriteSearchResultFields(CJsonWriter &w, const SearchResult &r)
 		w.Key("media");
 		w.ValueNull();
 	}
-	// Result grouping (issue #431): the same-hash/same-size hit's
-	// alternative filenames. Always emitted (empty array when the hit was
-	// seen under a single name) so clients can render the expandable tree
-	// without a presence check. Each child shares the parent's `hash`; the
-	// distinct `ecid` selects it for download-under-that-name (see
-	// POST /search/results/{hash}/download).
-	// Not `children`: there is no hierarchy, only one file advertised under
-	// several names. Each entry's hash is by construction this result's.
+	// Result grouping: the same-hash/same-size hit's alternative filenames.
+	// Always emitted (empty array when the hit was seen under a single name) so
+	// clients can render the expandable tree without a presence check. Each
+	// child shares the parent's `hash`; the distinct `ecid` selects it for
+	// download-under-that-name. Not `children`: there is no hierarchy, only one
+	// file advertised under several names.
 	w.Key("alternate_names");
 	w.BeginArray();
 	for (const auto &c : r.children) {
@@ -118,10 +115,9 @@ void WriteSearchResultFields(CJsonWriter &w, const SearchResult &r)
 		w.EndObject();
 	}
 	w.EndArray();
-	// On-demand Kad community ratings/comments (issue #434). `kad_comment_lookup_running`
-	// is true while a lookup started via POST /search/results/{hash}/comments is
-	// in flight; `comments` carries the Kad notes retrieved so far (empty until
-	// then). Both are always present so clients need no presence check.
+	// On-demand Kad community ratings/comments. `kad_comment_lookup_running` is
+	// true while a lookup started via POST /search/results/{hash}/comments is in
+	// flight; `comments` carries the Kad notes retrieved so far. Always present.
 	w.Key("kad_comment_lookup_running");
 	w.ValueBool(r.kad_comment_searching);
 	w.Key("comments");

--- a/src/webapi/SharedContent.cpp
+++ b/src/webapi/SharedContent.cpp
@@ -49,14 +49,11 @@ bool ContainsNul(const std::string &s)
 // Parse an unsigned decimal with an explicit overflow guard.
 //
 // Not strtoull(): it signals overflow through errno plus a saturated
-// ULLONG_MAX, which callers forget to check and which cannot be told
-// apart from a genuine ULLONG_MAX. For a range bound, saturating is
-// worse than wrapping — "bytes=<30 digits>-" would silently become a
-// perfectly satisfiable read near EOF. It has to be a rejection.
-//
-// Requires at least one digit and rejects every non-digit byte, so
-// signs, whitespace and hex prefixes fail here instead of being
-// half-consumed.
+// ULLONG_MAX, which callers forget to check and which cannot be told apart
+// from a genuine ULLONG_MAX. For a range bound, saturating is worse than
+// wrapping -- "bytes=<30 digits>-" would silently become a perfectly
+// satisfiable read near EOF. Requires at least one digit and rejects every
+// non-digit byte, so signs, whitespace and hex prefixes fail here.
 bool ParseU64(const std::string &s, std::uint64_t &out)
 {
 	if (s.empty())
@@ -87,23 +84,17 @@ std::string TrimOws(const std::string &s)
 	return s.substr(b, e - b);
 }
 
-// Canonicalise `candidate` (an ABSOLUTE path) and accept it only if it
-// names a regular file.
+// Canonicalise `candidate` (an ABSOLUTE path) and accept it only if it names a
+// regular file.
 //
-// Split from the containment test below, and deliberately: the candidate
-// is the same path whichever root it is being compared against, but
-// realpath() is a full path walk that stat()s every component. Recomputing
-// it per root made an N-root share pay up to 2N of those walks on every
-// range request, and the category paths just raised N. Resolving once and
-// comparing the result against each root decides exactly the same thing —
-// the boundary rule below is a pure string comparison over two paths that
-// are already canonical.
+// Split from the containment test below, and deliberately: the candidate is the
+// same path whichever root it is compared against, but realpath() is a full
+// path walk that stat()s every component. Recomputing it per root made an
+// N-root share pay up to 2N of those walks on every range request. The boundary
+// rule below is then a pure string comparison over two canonical paths.
 //
-// The regular-file test rides along here rather than after containment
-// because it is a property of the candidate alone. Running it before the
-// roots are walked cannot change the verdict: a non-regular file is
-// refused whichever root it sits under, and the refusal is the same
-// opaque false either way.
+// The regular-file test rides along here because it is a property of the
+// candidate alone, and running it first cannot change the verdict.
 bool CanonicaliseRegularFile(const std::string &candidate, std::string &fs_out)
 {
 	if (candidate.empty())
@@ -111,10 +102,9 @@ bool CanonicaliseRegularFile(const std::string &candidate, std::string &fs_out)
 
 	char fs_real[PATH_MAX];
 #ifdef _WIN32
-	// _fullpath() is lexical-only (no reparse-point resolution). Same
-	// trade-off StaticFs documents: on Windows symlinks require
-	// elevation, so lexical containment covers the operator-misconfig
-	// case this check targets.
+	// _fullpath() is lexical-only (no reparse-point resolution). Same trade-off
+	// StaticFs documents: on Windows symlinks require elevation, so lexical
+	// containment covers the operator-misconfig case this check targets.
 	if (!_fullpath(fs_real, candidate.c_str(), PATH_MAX))
 		return false;
 #else
@@ -122,9 +112,9 @@ bool CanonicaliseRegularFile(const std::string &candidate, std::string &fs_out)
 		return false;
 #endif
 
-	// A directory (or a device, or a fifo) is not content. Checked here
-	// rather than left to the caller's open() so that "it exists but is
-	// not servable" produces the same opaque failure as everything else.
+	// A directory (or a device, or a fifo) is not content. Checked here rather
+	// than left to the caller's open() so "exists but is not servable" produces
+	// the same opaque failure as everything else.
 	struct stat st
 	{
 	};
@@ -139,18 +129,14 @@ bool CanonicaliseRegularFile(const std::string &candidate, std::string &fs_out)
 
 // Does the already-canonical `fs_real` land inside `root`?
 //
-// StaticFs::ResolveWithinRoot cannot be reused here: it joins root and
-// the caller's path (`root_real + "/" + rel`), which is exactly right
-// for a URL path but produces "/srv/share//srv/share/f" for an absolute
-// candidate. The shared-file case has no relative form to offer — the
-// directory arrives from EC_TAG_KNOWNFILE_PATH already absolute, and
-// making it relative would mean a lexical prefix strip, i.e. deciding
-// containment before checking it.
+// StaticFs::ResolveWithinRoot cannot be reused: it joins root and the caller's
+// path, which is right for a URL path but produces "/srv/share//srv/share/f"
+// for an absolute candidate. The shared-file case has no relative form to
+// offer -- the directory arrives from EC_TAG_KNOWNFILE_PATH already absolute.
 //
-// So this is a sibling, not a weakening: same realpath()-based
-// canonicalisation, and byte-for-byte the same boundary rule (the
-// character at root_len must be a separator or the terminator, which is
-// what stops "/srv/share-evil" from passing as "/srv/share").
+// So this is a sibling, not a weakening: same realpath()-based canonicalisation
+// and byte-for-byte the same boundary rule (the character at root_len must be a
+// separator or the terminator, which stops "/srv/share-evil" passing).
 bool CanonicalWithinRoot(const std::string &root, const std::string &fs_real)
 {
 	if (root.empty() || fs_real.empty())
@@ -165,9 +151,8 @@ bool CanonicalWithinRoot(const std::string &root, const std::string &fs_real)
 		return false;
 #endif
 
-	// _fullpath() preserves a trailing separator from its input, which
-	// then breaks the prefix comparison; POSIX realpath() strips them.
-	// Normalise so the boundary check is platform-agnostic.
+	// _fullpath() preserves a trailing separator from its input, which then breaks
+	// the prefix comparison; POSIX realpath() strips them.
 	std::size_t root_len = std::strlen(root_real);
 	while (root_len > 1 && (root_real[root_len - 1] == '/' || root_real[root_len - 1] == '\\')) {
 		root_real[--root_len] = '\0';
@@ -184,8 +169,8 @@ bool CanonicalWithinRoot(const std::string &root, const std::string &fs_real)
 }
 
 // RFC 5987 attr-char, the set RFC 6266's filename* may carry unencoded.
-// Everything else — including every byte of a UTF-8 sequence, and every
-// byte that could terminate a header — becomes %XX.
+// Everything else -- including every byte of a UTF-8 sequence, and every byte
+// that could terminate a header -- becomes %XX.
 bool IsAttrChar(unsigned char c)
 {
 	if ((c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9'))
@@ -209,19 +194,18 @@ bool IsAttrChar(unsigned char c)
 	}
 }
 
-// Reduce a remote filename to something safe to sit between quotes in a
-// header. Two different treatments on purpose:
+// Reduce a remote filename to something safe to sit between quotes in a header.
+// Three different treatments on purpose:
 //
-//  - Control characters and DEL are DROPPED. They carry no meaning in a
-//    filename, and dropping them is what lets an all-control name
-//    collapse to empty and trigger the fallback below.
+//  - Control characters and DEL are DROPPED, so an all-control name collapses
+//    to empty and triggers the fallback below.
 //  - Structural characters (quote, backslash, both path separators) are
-//    REPLACED with '_', so the name keeps its shape and length. A quote
-//    would close filename="..." early; a separator is honoured as a path
-//    by some clients.
-//  - Non-ASCII is replaced too: the quoted form has no encoding, so a
-//    raw UTF-8 byte there is at the mercy of the client's guess. The
-//    real name travels in filename*.
+//    REPLACED with '_', keeping the name's shape: a quote would close
+//    filename="..." early, and a separator is honoured as a path by some
+//    clients.
+//  - Non-ASCII is replaced too: the quoted form has no encoding, so a raw
+//    UTF-8 byte there is at the mercy of the client's guess. The real name
+//    travels in filename*.
 std::string SanitiseQuotedName(const std::string &filename)
 {
 	std::string out;
@@ -263,14 +247,12 @@ bool JoinSharedPath(const std::string &dir, const std::string &name, std::string
 {
 	if (dir.empty() || name.empty())
 		return false;
-	// An embedded NUL makes the string we validate a different thing
-	// from the path we would open, so nothing after this point can be
-	// trusted about it.
+	// An embedded NUL makes the string we validate a different thing from the
+	// path we would open, so nothing after this point can be trusted about it.
 	if (ContainsNul(dir) || ContainsNul(name))
 		return false;
-	// `name` is a basename by contract. Rejected rather than sanitised:
-	// stripping the directory part would invent a path the caller never
-	// asked about, and there is no benign source for a separator here.
+	// `name` is a basename by contract. Rejected rather than sanitised: stripping
+	// the directory part would invent a path the caller never asked about.
 	if (name.find('/') != std::string::npos || name.find('\\') != std::string::npos)
 		return false;
 	if (name == "." || name == "..")
@@ -295,17 +277,15 @@ bool ResolveSharedContentPath(const std::vector<std::string> &roots,
 	if (!JoinSharedPath(dir, name, candidate))
 		return false;
 
-	// Resolved ONCE, before the roots are walked, rather than inside the
-	// loop: this is the walk, and the roots only ever compare against its
-	// result.
+	// Resolved ONCE, before the roots are walked: this is the walk, and the roots
+	// only ever compare against its result.
 	std::string fs_real;
 	if (!CanonicaliseRegularFile(candidate, fs_real))
 		return false;
 
-	// Inside ANY root is enough — aMule's share is a list of separately
-	// added directories, so there is no single tree to be inside of. An
-	// empty list therefore shares nothing, which is the correct reading
-	// of "the user has configured no shares".
+	// Inside ANY root is enough -- aMule's share is a list of separately added
+	// directories, so there is no single tree to be inside of. An empty list
+	// therefore shares nothing, which is the correct reading.
 	for (const std::string &root : roots) {
 		if (CanonicalWithinRoot(root, fs_real)) {
 			fs_out.swap(fs_real);
@@ -328,9 +308,8 @@ RangeResult ParseSingleByteRange(const std::string &header_value,
 	if (eq == std::string::npos)
 		return RangeResult::kIgnore;
 
-	// bytes-unit is a token and tokens are case-insensitive. Anything
-	// else is a unit we do not implement; ignoring it serves the whole
-	// file, which is always a correct answer.
+	// bytes-unit is a token and tokens are case-insensitive. Anything else is a
+	// unit we do not implement; ignoring it serves the whole file.
 	std::string unit = TrimOws(value.substr(0, eq));
 	for (char &c : unit) {
 		if (c >= 'A' && c <= 'Z')
@@ -358,14 +337,11 @@ RangeResult ParseSingleByteRange(const std::string &header_value,
 	const std::string first_str = set.substr(0, dash);
 	const std::string last_str = set.substr(dash + 1);
 
-	// Deliberate whitespace policy: RFC 7233's byte-range-spec contains
-	// no OWS at all — the only OWS the grammar allows is around the
-	// commas of the `#rule`, and we reject every comma anyway. So the
-	// tolerance stops at the field value's own edges (already trimmed
-	// above, and stripped by HTTP field parsing regardless) and at the
-	// "=" separating the unit. Inside the spec, ParseU64's digits-only
-	// rule rejects any space, which is what makes "bytes=0 - 9"
-	// unparseable rather than quietly read as "bytes=0-9".
+	// Deliberate whitespace policy: RFC 7233's byte-range-spec contains no OWS at
+	// all -- the only OWS the grammar allows is around the commas of the `#rule`,
+	// and every comma is rejected anyway. So tolerance stops at the field value's
+	// own edges and at the "=". Inside the spec, ParseU64's digits-only rule
+	// makes "bytes=0 - 9" unparseable rather than quietly read as "bytes=0-9".
 
 	if (first_str.empty()) {
 		// suffix-byte-range-spec: "-N" means the last N bytes.
@@ -401,10 +377,9 @@ RangeResult ParseSingleByteRange(const std::string &header_value,
 	std::uint64_t last = 0;
 	if (!ParseU64(last_str, last))
 		return RangeResult::kIgnore;
-	// first > last is well-formed but meaningless, which RFC 7233 §2.1
-	// makes an invalid byte-range-set rather than an unsatisfiable one —
-	// so it is a 200, not a 416. A 416 would invite the client to retry
-	// the same header after re-reading Content-Range.
+	// first > last is well-formed but meaningless, which RFC 7233 2.1 makes an
+	// invalid byte-range-set rather than an unsatisfiable one -- so it is a 200,
+	// not a 416. A 416 would invite a retry of the same header.
 	if (first > last)
 		return RangeResult::kIgnore;
 	if (file_size == 0 || first >= file_size)
@@ -418,11 +393,9 @@ RangeResult ParseSingleByteRange(const std::string &header_value,
 std::string BuildContentDisposition(const std::string &filename)
 {
 	std::string quoted = SanitiseQuotedName(filename);
-	// If nothing printable survived, both forms name the file rather
-	// than leaving the client to invent something from the URL. Using
-	// the fallback for filename* too keeps the two halves agreeing —
-	// a client that prefers the extended form should not end up with a
-	// different name than one that does not.
+	// If nothing printable survived, both forms name the file rather than leaving
+	// the client to invent something from the URL. Using the fallback for
+	// filename* too keeps the two halves agreeing.
 	const bool usable = !quoted.empty();
 	if (!usable)
 		quoted = kFallbackName;
@@ -435,7 +408,7 @@ std::string BuildContentDisposition(const std::string &filename)
 
 std::string BuildContentEtag(std::uint64_t mtime, std::uint64_t size)
 {
-	// Same "mtime-size" hex shape BuildStaticEtag emits (Api.cpp:501-507),
+	// Same "mtime-size" hex shape BuildStaticEtag emits (Api.cpp),
 	// strong-form quoted per RFC 7232.
 	std::ostringstream oss;
 	oss << '"' << std::hex << mtime << '-' << size << '"';
@@ -450,25 +423,20 @@ bool IfRangeAllowsRange(const std::string &if_range, const std::string &etag)
 	if (value.empty())
 		return true;
 
-	// RFC 9110 §13.1.5 says a valid entity-tag is told apart from a valid
-	// HTTP-date by looking at the first two characters for a DQUOTE, and
-	// that only the STRONG form may match. Both rejections land here: a
-	// weak `W/"..."` starts with 'W', and every HTTP-date starts with a
-	// day name, so neither reaches the comparison below.
+	// RFC 9110 13.1.5 says a valid entity-tag is told apart from a valid HTTP-date
+	// by looking at the first two characters for a DQUOTE, and that only the
+	// STRONG form may match. Both rejections land here: a weak `W/"..."` starts
+	// with 'W', and every HTTP-date starts with a day name.
 	//
 	// The date form is not implemented, and the fall-through is the safe
-	// direction rather than a shortcut. A date validator has one-second
-	// resolution, so a representation replaced twice inside the same
-	// second compares EQUAL to the copy the client holds — precisely the
-	// race this header exists to close. Treating a date as "does not
-	// match" costs a full transfer the client may not have needed;
-	// honouring it can cost a silently spliced file.
+	// direction: a date validator has one-second resolution, so a representation
+	// replaced twice inside the same second compares EQUAL to the client's copy
+	// -- precisely the race this header exists to close.
 	if (value[0] != '"')
 		return false;
 
-	// Opaque octet-for-octet equality, quotes included. No list to walk
-	// and no `*` to special-case: unlike If-None-Match, If-Range carries
-	// exactly one validator by grammar.
+	// Opaque octet-for-octet equality, quotes included. No list to walk and no `*`
+	// to special-case: unlike If-None-Match, If-Range carries exactly one.
 	return value == etag;
 }
 

--- a/src/webapi/SharedContent.h
+++ b/src/webapi/SharedContent.h
@@ -16,7 +16,7 @@
 // response header. All four are the kind of decision that wants a test
 // per branch rather than a read-through, so they live in their own TU
 // that links without wx, Boost.Beast or EC — same rationale as StaticFs
-// (see StaticFs.h:12-16), and the same reason SharedContentTest can link
+// (see StaticFs.h), and the same reason SharedContentTest can link
 // them standalone.
 //
 // The transport half (chunked/ranged writing, 206 assembly, the handler
@@ -53,17 +53,14 @@ namespace webapi
 // Returns false without touching `out` on any rejection.
 bool JoinSharedPath(const std::string &dir, const std::string &name, std::string &out);
 
-// Resolve a shared file to a canonical path that provably sits inside at
-// least one configured share root, or fail.
+// Resolve a shared file to a canonical path that provably sits inside at least
+// one configured share root, or fail.
 //
-// `roots` is a vector because aMule's share is a *list* of directories,
-// not one root — the user adds each shared directory separately, so
-// containment is "inside any one of them", not "inside the one".
-//
-// Any failure — bad join, missing file, canonical path outside every
-// root — returns false, and the caller is expected to answer with the
-// same opaque 404 for all of them, so the on-disk layout stays
-// non-enumerable from outside (same discipline as StaticFs.h:28-33).
+// `roots` is a vector because aMule's share is a *list* of directories, not one
+// root -- the user adds each shared directory separately, so containment is
+// "inside any one of them". Any failure returns false, and the caller answers
+// the same opaque 404 for all of them, so the on-disk layout stays
+// non-enumerable from outside (same discipline as StaticFs.h).
 bool ResolveSharedContentPath(const std::vector<std::string> &roots,
 	const std::string &dir,
 	const std::string &name,
@@ -78,20 +75,15 @@ enum class RangeResult
 	kOk             // Serve 206 for [first_out, last_out].
 };
 
-// Parse a *single* byte range out of a Range header value.
+// Parse a *single* byte range out of a Range header value. `last_out` is
+// INCLUSIVE, matching the wire format, so the byte count is (last - first + 1).
 //
-// `last_out` is INCLUSIVE, matching the wire format, so the byte count
-// is (last - first + 1).
-//
-// RFC 7233 §3.1 permits a server to ignore a Range header it does not
-// wish to honour, and that permission is doing real work here: any range
-// set with more than one range returns kIgnore and gets a plain 200.
-// That is the deliberate neutralisation of the CVE-2011-3192 shape (the
-// "Apache Killer"), where a few hundred overlapping ranges in one header
-// make the server materialise a multipart body far larger than the file.
-// We never assemble multipart/byteranges at all, so there is nothing to
-// amplify. It is not an error either — an error would tempt a client
-// into retrying the same header.
+// RFC 7233 3.1 permits a server to ignore a Range header it does not wish to
+// honour, and that permission is doing real work here: any range set with more
+// than one range returns kIgnore and gets a plain 200. That is the deliberate
+// neutralisation of the CVE-2011-3192 shape, where a few hundred overlapping
+// ranges in one header make the server materialise a multipart body far larger
+// than the file. It is not an error, which would tempt a client into retrying.
 RangeResult ParseSingleByteRange(const std::string &header_value,
 	std::uint64_t file_size,
 	std::uint64_t &first_out,
@@ -99,59 +91,49 @@ RangeResult ParseSingleByteRange(const std::string &header_value,
 
 // Build a complete Content-Disposition header *value* per RFC 6266.
 //
-// These filenames arrive from strangers on the ed2k network, which makes
-// this the one place in the endpoint where remote input is written into
-// a response header. A name containing CR or LF would end the header and
-// let the sender append arbitrary headers — or a whole second response —
-// so the quoted form is reduced to a conservative printable-ASCII subset
-// and the filename* form percent-encodes everything outside RFC 6266's
-// attr-char set. Neither form can carry a byte that terminates a header.
+// These filenames arrive from strangers on the ed2k network, which makes this
+// the one place in the endpoint where remote input is written into a response
+// header. A name containing CR or LF would end the header and let the sender
+// append arbitrary headers -- or a whole second response -- so the quoted form
+// is reduced to a conservative printable-ASCII subset and the filename* form
+// percent-encodes everything outside RFC 6266's attr-char set.
 //
 // Always `attachment`, never `inline`: both the bytes and the name are
-// attacker-chosen, amuleapi serves the Web UI from this same origin, and
-// there is currently no Content-Security-Policy anywhere in src/webapi.
-// `inline` would therefore let a shared .html file script the Web UI's
-// origin. `attachment` costs a download prompt and closes that off.
+// attacker-chosen and amuleapi serves the Web UI from this same origin, so
+// `inline` would let a shared .html file script the Web UI's origin. The
+// handler also stamps a sandbox CSP on the response; `attachment` is the half
+// that does not depend on the client honouring one.
 std::string BuildContentDisposition(const std::string &filename);
 
-// "mtime-size" hex ETag, quoted — the same shape BuildStaticEtag
-// produces (src/webapi/Api.cpp:501-507), so the dispatcher's
-// ETag/If-None-Match/304 machinery behaves identically for this route.
+// "mtime-size" hex ETag, quoted -- the same shape BuildStaticEtag produces, so
+// the dispatcher's ETag/If-None-Match/304 machinery behaves identically here.
 //
-// The reason to compute one at all is that CApiDispatcher::Dispatch
-// otherwise MD5s the entire response body to derive a validator
-// (State.cpp:530-533 + Api.cpp:854). For a multi-GB shared file that is
-// not a slow path, it is an unusable one. A handler-set ETag makes
-// Dispatch step aside (Api.cpp:825-828), so we pay a stat() instead of a
-// full-file hash.
+// The reason to compute one at all is that CApiDispatcher::Dispatch otherwise
+// MD5s the entire response body to derive a validator. For a multi-GB shared
+// file that is not a slow path, it is an unusable one; a handler-set ETag makes
+// Dispatch step aside, so we pay a stat() instead of a full-file hash.
 std::string BuildContentEtag(std::uint64_t mtime, std::uint64_t size);
 
-// Does an If-Range precondition permit the accompanying Range to be
-// honoured? `etag` is the quoted wire form BuildContentEtag returns.
+// Does an If-Range precondition permit the accompanying Range to be honoured?
+// `etag` is the quoted wire form BuildContentEtag returns.
 //
-// RFC 9110 §13.1.5, and the reason it is not optional: a client resuming
-// an interrupted download sends the validator it already holds next to
+// RFC 9110 13.1.5, and the reason it is not optional: a client resuming an
+// interrupted download sends the validator it already holds next to
 // `Range: bytes=N-`, precisely so that a representation which changed
-// underneath it answers 200 with the whole new file instead of a window
-// of it. A server that honours the Range regardless returns a 206 of the
-// NEW bytes, and the client — reading that 206 as confirmation its
-// validator held — appends them to its copy of the OLD representation.
-// The result is a file spliced from two versions that passes every
-// length check the client can make. Immutability makes that rare here,
-// not impossible, and silent rarely-wrong is the worst failure shape
-// there is.
+// underneath it answers 200 with the whole new file. A server that honours the
+// Range regardless returns a 206 of the NEW bytes, and the client -- reading
+// that 206 as confirmation its validator held -- appends them to its copy of
+// the OLD representation, producing a file spliced from two versions that
+// passes every length check it can make.
 //
 // STRONG comparison, which is the one thing this cannot borrow from
-// webcommon::IfNoneMatchHits: that function accepts the weak `W/"..."`
-// form, correctly, because If-None-Match asks whether two
-// representations are equivalent. A byte range needs them
-// byte-identical, so a weak validator must never match here. Reusing it
-// would be the bug.
+// webcommon::IfNoneMatchHits: that function accepts the weak `W/"..."` form,
+// correctly, because If-None-Match asks whether two representations are
+// equivalent. A byte range needs them byte-identical.
 //
-// An absent (empty) header returns true: no precondition, nothing to
-// fail. A non-matching one returns false, and the caller is expected to
-// drop the Range and serve the whole representation — §13.1.5 says to
-// ignore the Range, not to reject the request.
+// An absent (empty) header returns true: no precondition, nothing to fail. A
+// non-matching one returns false, and the caller drops the Range and serves the
+// whole representation -- 13.1.5 says to ignore the Range, not reject the request.
 bool IfRangeAllowsRange(const std::string &if_range, const std::string &etag);
 
 } // namespace webapi

--- a/src/webapi/State.cpp
+++ b/src/webapi/State.cpp
@@ -52,19 +52,17 @@ std::uint16_t SharedHashingProgress(const FileSnapshot &f)
 
 // Completeness of the file we download FROM this peer: parts the peer has over
 // that file's part count. Only the download link carries a meaningful
-// denominator -- a peer that merely downloads from us has no percent. Left at
-// its < 0 sentinel when not computable, which is how the writers know to emit
-// the field as null. The sentinel never reaches the wire.
+// denominator. Left at its < 0 sentinel when not computable, which never
+// reaches the wire -- the writers emit the field as null instead.
 void ComputePartProgressPercent(const CState &state, ClientSnapshot &cli)
 {
 	if (!cli.has_parts_offered_count || cli.download_file_hash.empty()) {
 		return;
 	}
-	// DownloadPartCount, not FindDownload: this runs once per source per
-	// tick on the SSE path and once per row on two REST paths, and the part
-	// count is the only thing wanted. FindDownload would deep-copy the whole
-	// FileSnapshot each time, repeating the identical copy for every source
-	// of the same file.
+	// DownloadPartCount, not FindDownload: this runs once per source per tick on
+	// the SSE path and once per row on two REST paths, and the part count is the
+	// only thing wanted. FindDownload would deep-copy the whole FileSnapshot
+	// each time, repeating the identical copy for every source of the same file.
 	const std::uint64_t part_count = state.DownloadPartCount(cli.download_file_hash);
 	if (part_count == 0) {
 		return;
@@ -107,11 +105,9 @@ KadSnapshot CState::Kad() const
 
 CState::DashboardSnapshot CState::Dashboard() const
 {
-	// Single shared_lock acquisition: callers of /api/v0/status get
-	// a coherent (status, kad, snapshot_at, ec_connected) tuple
-	// instead of the four-separate-lock dance, which can interleave
-	// with a refresher tick and make `kad.network` describe a
-	// different tick than `ed2k.*` / `speeds.*`.
+	// Single shared_lock acquisition: callers of /api/v0/status get a coherent
+	// (status, kad, snapshot_at, ec_connected) tuple instead of a four-lock
+	// dance that can interleave with a refresher tick.
 	std::shared_lock<std::shared_timed_mutex> lock(m_mu);
 	DashboardSnapshot out;
 	out.status = m_status;
@@ -316,11 +312,9 @@ void CState::MarkSearchStarted(std::uint32_t search_id, const std::string &kind,
 	// the daemon allocates fresh ids) keeps it climbing so EventDiff still fires.
 	const auto next_generation = slot.progress.generation + 1;
 	// Both maps, and the ECID index that points at them. `raw` is the merge
-	// target the union applies diffed tags to, so a stale entry left here
-	// would have the previous search's fields show through wherever the new
-	// one's tag happens not to carry that field -- and RebuildFoldedResults
-	// would then put the ghost straight back into `results`, however many
-	// times that gets cleared.
+	// target the union applies diffed tags to, so a stale entry left here would
+	// have the previous search's fields show through -- and RebuildFoldedResults
+	// would put the ghost straight back into `results`.
 	for (const auto &entry : slot.raw)
 		m_resultOwner.erase(entry.first);
 	slot.raw.clear();
@@ -346,36 +340,27 @@ void CState::MarkSearchDiscovered(std::uint32_t search_id,
 	std::unique_lock<std::shared_timed_mutex> lock(m_mu);
 	auto known = m_searches.find(search_id);
 	if (known != m_searches.end()) {
-		// Already known (self-started, or discovered on an earlier
-		// cache-miss check): leave its accumulated results/progress
-		// alone. Re-seeding here would stomp whatever
-		// WriteSearchProgress/ApplySearchUnion already recorded for it
-		// this session. The query is the one exception — a slot seeded
-		// before the daemon reported a name has an empty one, and
-		// filling it in loses nothing.
+		// Already known (self-started, or discovered on an earlier cache-miss
+		// check): leave its accumulated results/progress alone, or this would
+		// stomp whatever the session already recorded. The query is the one
+		// exception -- a slot seeded before the daemon reported a name has none.
 		if (known->second.query.empty())
 			known->second.query = query;
 		return;
 	}
 	SearchSlot &slot = m_searches[search_id];
 	slot.seq = ++m_search_seq;
-	// The daemon's own lifecycle state for this search, not an assumption.
-	// A finished search seeded as active reads as running until the next
-	// tick corrects it, and POST /search/{id}/more gates on exactly that.
-	// `started_at` stays 0: this session did not start it, and the daemon
-	// ships no timestamp to borrow.
+	// The daemon's own lifecycle state for this search, not an assumption. A
+	// finished search seeded as active reads as running until the next tick
+	// corrects it, and POST /search/{id}/more gates on exactly that.
 	slot.progress.active = active;
 	slot.progress.complete = complete;
 	// Seeded here or never. A slot discovered as finished is not in
-	// ActiveSearchIds(), so the tick never polls it and WriteSearchProgress
-	// is never called for it -- the percent would sit at its 0 default for
-	// the life of the slot, contradicting the "finished" state in the very
-	// same envelope.
-	//
-	// Prefer the daemon's own number when the listing carried one. Without it
-	// (an older daemon) derive: 100 for a finished search, true by
-	// definition; 0 for a running one, which IS polled and is corrected
-	// within a tick, where inventing a number would flash a wrong one.
+	// ActiveSearchIds(), so the tick never polls it and WriteSearchProgress is
+	// never called -- the percent would sit at its 0 default for the life of the
+	// slot, contradicting the "finished" state in the same envelope. Prefer the
+	// daemon's own number; without it, derive 100 for a finished search and 0
+	// for a running one, which is corrected within a tick.
 	slot.progress.percent =
 		reported_percent >= 0 ? static_cast<std::uint32_t>(reported_percent) : (complete ? 100u : 0u);
 	slot.progress.kind = kind;
@@ -407,11 +392,10 @@ std::vector<std::uint32_t> CState::SearchesNeedingResync() const
 	std::shared_lock<std::shared_timed_mutex> lock(m_mu);
 	std::vector<std::pair<std::uint64_t, std::uint32_t>> pending;
 	for (const auto &kv : m_searches) {
-		// Same exemption the flag's writer applies, and for the same reason:
-		// a slot detached after it was flagged has had its search dropped by
-		// the daemon, so a full re-read would only come back expired. Asking
-		// anyway costs a roundtrip per slot, and a replace-mode apply against
-		// a detached slot would clear the results the detach exists to keep.
+		// Same exemption the flag's writer applies: a slot detached after it was
+		// flagged has had its search dropped by the daemon, so a full re-read would
+		// come back expired -- and a replace-mode apply would clear the results the
+		// detach exists to keep.
 		if (kv.second.needs_resync && !kv.second.detached)
 			pending.emplace_back(kv.second.seq, kv.first);
 	}
@@ -443,9 +427,8 @@ void CState::EvictSurplusSearchSlotsLocked(std::uint32_t exempt_id)
 			// Never the slot the caller is in the middle of seeding.
 			if (exempt_id != 0 && it->first == exempt_id)
 				continue;
-			// A detached slot always outranks an attached one, however much
-			// younger: the daemon no longer holds it, so evicting it drops
-			// nothing that could still be re-read.
+			// A detached slot always outranks an attached one, however much younger:
+			// the daemon no longer holds it, so evicting it drops nothing re-readable.
 			if (victim == m_searches.end() || (it->second.detached && !victim->second.detached) ||
 				(it->second.detached == victim->second.detached &&
 					it->second.seq < victim->second.seq)) {
@@ -484,10 +467,9 @@ void CState::CloseSearch(std::uint32_t search_id)
 	const auto it = m_searches.find(search_id);
 	if (it == m_searches.end())
 		return;
-	// The index mirrors this slot's result map, so it has to lose the same
-	// ECIDs in the same locked step. Walking the slot's own results is what
-	// keeps that exact: erasing by value over the whole index would be O(n)
-	// in every search rather than this one.
+	// The index mirrors this slot's result map, so it loses the same ECIDs in the
+	// same locked step. Walking the slot's own results is what keeps that exact:
+	// erasing by value over the whole index would be O(n) in every search.
 	for (const auto &kv : it->second.raw)
 		m_resultOwner.erase(kv.first);
 	m_searches.erase(it);
@@ -508,9 +490,8 @@ void CState::WriteGraphs(StatsGraphs g)
 void CState::AppendAmuleLog(std::vector<std::string> new_lines)
 {
 	std::unique_lock<std::shared_timed_mutex> lock(m_mu);
-	// No cap — see State.h comment above the `m_amule_log_lines`
-	// declaration. Operators can truncate via DELETE /logs/amule
-	// .
+	// No cap -- see the `m_amule_log_lines` declaration in State.h. Operators
+	// truncate via DELETE /logs/amule.
 	m_amule_log_lines.insert(m_amule_log_lines.end(),
 		std::make_move_iterator(new_lines.begin()),
 		std::make_move_iterator(new_lines.end()));
@@ -603,18 +584,14 @@ std::string IPv4ToDotted(std::uint32_t ip_lsb_first)
 bool MemoizableTarget(const std::string &target)
 {
 	const std::string path = target.substr(0, target.find('?'));
-	// OPT-IN, and deliberately so. This was an exclusion list, and an
-	// exclusion list has to be right about every route that exists now and
-	// every route anyone adds later -- it was wrong four separate times,
-	// each for a different reason. Inverting it makes the failure mode
-	// "we hash a body we did not have to", which costs microseconds,
-	// instead of "we serve a 304 for content that changed".
+	// OPT-IN, and deliberately so. This was an exclusion list, and an exclusion
+	// list has to be right about every route that exists now and every route
+	// anyone adds later. Inverting it makes the failure mode "we hash a body we
+	// did not have to", which costs microseconds, instead of "we serve a 304 for
+	// content that changed".
 	//
-	// Only the two collections the memo was built for are listed. They are
-	// the multi-MB bodies where skipping an MD5 is worth anything; every
-	// other target hashes per request and is immune by construction.
-	// Before adding one, it must be BOTH governed by the refresher
-	// snapshot AND identical for every caller -- see State.h.
+	// Before adding a target it must be BOTH governed by the refresher snapshot
+	// AND identical for every caller -- see State.h.
 	return path == "/api/v0/downloads" || path == "/api/v0/shared";
 }
 
@@ -702,28 +679,21 @@ void CState::ReconcileKnownClientsLocked()
 
 	for (const auto &kv : m_clients) {
 		const ClientSnapshot &c = kv.second;
-		// An all-zero hash is not an identity: it is what a peer that has not
-		// sent its hash yet reports, and every such peer would otherwise
-		// collapse into one fabricated record -- sharing a session count and
-		// a first-seen between unrelated clients. The daemon never writes one
-		// either; it creates a credit record from the hash in the hello. They
-		// get a row of their own once they identify.
+		// An all-zero hash is not an identity: it is what a peer that has not sent
+		// its hash yet reports, and every such peer would otherwise collapse into
+		// one fabricated record, sharing a session count and a first-seen between
+		// unrelated clients. They get a row of their own once they identify.
 		if (c.user_hash.empty() || c.user_hash.find_first_not_of('0') == std::string::npos)
 			continue;
 
 		auto it = m_known_of_hash.find(c.user_hash);
 		if (it == m_known_of_hash.end()) {
-			// A peer met since the store was read. The daemon wrote its
-			// credit record when the peer said hello, stamping first-seen
-			// and counting the session, so this reconstructs what it wrote
-			// rather than inventing anything.
+			// A peer met since the store was read. The daemon wrote its credit record
+			// when the peer said hello, so this reconstructs what it wrote.
 			//
-			// sessions is left at zero deliberately: the not-connected to
-			// connected transition below is what counts it. That is this
-			// tick if the peer is already connected, and a later one if we
-			// are still reaching it -- which is the point, since the daemon
-			// counts at the hello and not at the attempt. Setting it here
-			// too would count the same session twice.
+			// sessions is left at zero deliberately: the not-connected to connected
+			// transition below is what counts it, matching the daemon counting at the
+			// hello and not at the attempt. Setting it here would double-count.
 			KnownClientSnapshot k;
 			k.user_hash = c.user_hash;
 			k.first_seen_at = now;
@@ -734,39 +704,31 @@ void CState::ReconcileKnownClientsLocked()
 
 		KnownClientSnapshot &k = m_known_clients[it->second];
 		still_online.insert(it->second);
-		// Reachability, echoed from the live row. A client object exists from
-		// the first contact ATTEMPT, so presence in the list is not the same
-		// question -- an unroutable peer sat here reading "Online now".
+		// Reachability, echoed from the live row. A client object exists from the
+		// first contact ATTEMPT, so presence in the list is not the same question.
 		// Read before the assignment: k.connected still holds last tick's answer,
 		// which is what the session edge below is measured against.
 		const bool was_connected = k.connected;
 		k.connected = c.has_connected && c.connected;
 		k.has_connected = c.has_connected;
-		// Not-connected to connected is a new session, which is what the
-		// daemon counts: UpdateMeta() bumps it once per client object at the
-		// hello, and a hello needs a connection. This used to fire on the peer
-		// merely APPEARING in the client list, which is earlier than the hello
-		// and also happens for a peer that never connects at all -- so the
-		// count ran ahead of the daemon's, and did so permanently, since the
-		// credit store is read once and never re-read.
-		//
-		// It can still over-count by one if a peer drops out of the update for
-		// a tick and returns -- an EC hiccup rather than a real reconnect --
-		// because the departure sweep below clears connected for it.
+		// Not-connected to connected is a new session, which is what the daemon
+		// counts: UpdateMeta() bumps it once per client object at the hello, and a
+		// hello needs a connection. This used to fire on the peer merely APPEARING
+		// in the client list, which is earlier and also happens for a peer that
+		// never connects -- so the count ran ahead of the daemon's, permanently.
+		// It can still over-count by one if a peer drops out of the update for a
+		// tick and returns, because the departure sweep clears connected for it.
 		if (!was_connected && k.connected)
 			k.session_count++;
 		// A peer in front of us was last seen now, not whenever it previously
-		// disconnected. Leaving the stored value would report a peer that is
-		// connected as last seen months ago, and now is what the core writes
-		// to the record at its own disconnect handling anyway.
+		// disconnected -- and now is what the core writes to the record at its own
+		// disconnect handling anyway.
 		k.last_seen_at = now;
 		k.uploaded_bytes_total = c.uploaded_bytes_total;
 		k.downloaded_bytes_total = c.downloaded_bytes_total;
-		// Identity, when the peer in front of us knows more than the record.
-		// A record only gains a name once the core writes its metadata, so a
-		// peer we have never finished a session with is otherwise nameless.
-		// Guarded on the live name being known: a peer mid-handshake has none
-		// and must not blank a stored one.
+		// Identity, when the peer in front of us knows more than the record. A
+		// record only gains a name once the core writes its metadata. Guarded on
+		// the live name being known: a peer mid-handshake must not blank a stored one.
 		if (!c.client_name.empty()) {
 			k.client_name = c.client_name;
 			k.ip = c.ip;
@@ -790,10 +752,9 @@ void CState::ReconcileKnownClientsLocked()
 		// it, so it is definitively not connected. Known, not unknown.
 		m_known_clients[idx].connected = false;
 		m_known_clients[idx].has_connected = true;
-		// Seen until this moment, which is what the core writes to the record
-		// at its own disconnect handling. The stored value is the *previous*
-		// disconnect, so leaving it would show a peer that was here a second
-		// ago as last seen months back.
+		// Seen until this moment, which is what the core writes at its own
+		// disconnect handling. The stored value is the *previous* disconnect, so
+		// leaving it would show a peer that was here a second ago as months old.
 		m_known_clients[idx].last_seen_at = now;
 	}
 	m_known_connected.swap(still_online);
@@ -864,22 +825,19 @@ bool CState::FindSharedByEcid(std::uint32_t ecid, FileSnapshot &out) const
 	return true;
 }
 
-// MutateDownloads + MutateShared both lock + hand out m_files. Both
-// walkers operate on the same unified map (and the same lock acquisition,
-// when chained from a single tick); the callback decides which role
-// flag to set or clear. The FileMap wrapper keeps its hash→ECID index
-// in sync as the walker emplaces / erases, so there's no rebuild pass
-// at the end of the mutate window.
+// MutateDownloads + MutateShared both lock and hand out m_files. Both walkers
+// operate on the same unified map, and the callback decides which role flag to
+// set or clear. The FileMap wrapper keeps its hash->ECID index in sync as the
+// walker emplaces / erases, so there is no rebuild pass at the end.
 void CState::MutateDownloads(const std::function<void(FileMap &)> &fn)
 {
 	const ReentryGuard guard(this);
 	std::unique_lock<std::shared_timed_mutex> lock(m_mu);
 	fn(m_files);
-	// Bumped by the writer, not by its callers. The ETag memo keys on this,
-	// and every previous attempt to advance it from the outside missed a
-	// path: first the inline refreshes that mutating handlers run, then a
-	// tick that failed partway after already writing. A writer cannot
-	// forget to say that it wrote.
+	// Bumped by the writer, not by its callers. The ETag memo keys on this, and
+	// every previous attempt to advance it from the outside missed a path: first
+	// the inline refreshes mutating handlers run, then a tick that failed partway
+	// after already writing. A writer cannot forget to say that it wrote.
 	++m_snapshot_rev;
 }
 
@@ -894,9 +852,8 @@ void CState::MutateShared(const std::function<void(FileMap &)> &fn)
 
 void CState::MutateClients(const std::function<void(std::map<std::uint32_t, ClientSnapshot> &)> &fn)
 {
-	// Forwards rather than repeating the guard-plus-lock body: the two differ
-	// only in what they hand the callback. Still exactly one acquisition, so
-	// a caller that does not need the files pays nothing for the convenience.
+	// Forwards rather than repeating the guard-plus-lock body: the two differ only
+	// in what they hand the callback, and this is still exactly one acquisition.
 	MutateClientsWithFiles(
 		[&fn](std::map<std::uint32_t, ClientSnapshot> &clients, const FileMap &) { fn(clients); });
 }
@@ -912,37 +869,31 @@ void CState::MutateClientsWithFiles(
 void CState::ResetLists()
 {
 	std::unique_lock<std::shared_timed_mutex> lock(m_mu);
-	// A wholesale wipe on a failed tick is as much a body change as any
-	// mutation, and it runs on the failure path -- exactly where the key
-	// used to freeze while the bodies moved underneath it.
+	// A wholesale wipe on a failed tick is as much a body change as any mutation,
+	// and it runs on the failure path -- exactly where the key used to freeze.
 	++m_snapshot_rev;
 	m_files.clear();
 	m_clients.clear();
 	m_servers.clear();
 	m_categories.clear();
 	// Search slots and the ECID->search_id index that mirrors them are
-	// deliberately NOT cleared, for the same reason as the credit store
-	// below and then some. This runs when a tick failed against a socket
-	// that is still up -- an actual dropped connection sets
-	// g_shutdownRequested via HandleEcConnectionLost() and this loop exits
-	// instead -- so the daemon's per-connection search registry is very much
-	// alive, along with its record of which results it has already sent us
-	// and the valuemap it diffs against. Wiping our side of that would not
-	// resync anything: results the daemon considers delivered are elided from
-	// then on, so every search would come back permanently short by whatever
-	// it held at the moment one tick returned null. The collections above are
-	// safe to wipe precisely because their EC_DETAIL_UPDATE streams resend in
+	// deliberately NOT cleared. This runs when a tick failed against a socket
+	// that is still up -- an actual dropped connection sets g_shutdownRequested
+	// via HandleEcConnectionLost() and this loop exits instead -- so the daemon's
+	// per-connection search registry is very much alive, along with its record of
+	// which results it has already sent us. Wiping our side would not resync
+	// anything: results the daemon considers delivered are elided from then on,
+	// so every search would come back permanently short. The collections above
+	// are safe to wipe precisely because their EC_DETAIL_UPDATE streams resend in
 	// full; this one does not.
 	//
-	// The credit store is dropped for the same reason -- refetching the whole
-	// thing after one null tick is the cost this endpoint exists to avoid. It
-	// cannot go stale across a daemon restart either: amuleapi shuts down the
-	// moment the socket drops, so the process never attaches to a second
-	// core.
-	// Logs + stats_tree + graphs survive EC reconnects on purpose —
-	// operator can see "EC disconnected at HH:MM" alongside earlier
-	// graph traffic; stats_tree's counters are amuled-uptime not
-	// amuleapi-tick scoped.
+	// The credit store is kept for the same reason -- refetching the whole thing
+	// after one null tick is the cost that endpoint exists to avoid, and it
+	// cannot go stale across a daemon restart, since amuleapi shuts down the
+	// moment the socket drops.
+	//
+	// Logs + stats_tree + graphs survive EC reconnects on purpose: the operator
+	// can see "EC disconnected at HH:MM" alongside earlier graph traffic.
 }
 
 void CState::BumpSnapshotRevision()
@@ -962,31 +913,24 @@ void CState::MarkTickSuccess()
 	std::unique_lock<std::shared_timed_mutex> lock(m_mu);
 	m_has_first_snapshot = true;
 	m_ec_connected = true;
-	// `m_snapshot_at` is stamped at tick-END (here), not tick-start.
-	// Clients reading `snapshot_at` therefore see "the wall-clock
-	// moment the daemon finished assembling this snapshot", with the
-	// tick's own duration as the implicit skew (typically 50-200 ms,
-	// up to multi-second under EC-mutex contention). For coarse
-	// freshness checks ("is this stale by more than 5 s?") that's
-	// fine; if a future caller wants sub-second precision, document
-	// the skew or stamp both tick_started_at and tick_ended_at.
+	// `m_snapshot_at` is stamped at tick-END, not tick-start, so `snapshot_at` is
+	// the wall-clock moment the daemon finished assembling the snapshot, with the
+	// tick's own duration as the implicit skew (typically 50-200 ms, more under
+	// EC-mutex contention). Fine for coarse freshness checks, not sub-second ones.
 	m_snapshot_at = std::time(nullptr);
 }
 
 void CState::MarkTickFailure()
 {
 	std::unique_lock<std::shared_timed_mutex> lock(m_mu);
-	// Deliberately preserve m_snapshot_at — clients see stale
-	// `snapshot_at` next to `ec_connected=false`, so they can tell
-	// how stale the cache is. Resetting it to `now` would lie.
+	// Deliberately preserve m_snapshot_at: clients see a stale `snapshot_at` next
+	// to `ec_connected=false` and can tell how stale the cache is. Resetting it
+	// to `now` would lie.
 	//
-	// Tick-atomicity: on failure CState may hold partial mutations
-	// from earlier in the tick. The "tick = transaction" model is
-	// atomic for events (EmitDiffsForEventBus is skipped on failure,
-	// next-tick diff is against the prior-success baseline in
-	// LastSeenState) but NOT atomic for state — no rollback. CState
-	// is a best-effort cache for /status freshness; LastSeenState
-	// is the authoritative event baseline.
+	// On failure CState may hold partial mutations from earlier in the tick. The
+	// "tick = transaction" model is atomic for events but NOT for state -- there
+	// is no rollback. CState is a best-effort cache; LastSeenState is the
+	// authoritative event baseline.
 	m_ec_connected = false;
 }
 

--- a/src/webapi/State.h
+++ b/src/webapi/State.h
@@ -43,50 +43,35 @@
 // drifts.
 #include "PartIndex.h"
 
-// Cached snapshot of amuled state. One instance lives inside
-// CamuleapiApp for the whole process; the refresher (wxApp thread)
-// writes; the HTTP server (Boost.Asio thread) reads.
+// Cached snapshot of amuled state. One instance lives inside CamuleapiApp for
+// the whole process; the refresher (wxApp thread) writes, the HTTP server
+// (Boost.Asio thread) reads.
 //
-// **Concurrency model.** A single `std::shared_timed_mutex` guards
-// every member field. The refresher takes it exclusive once per
-// tick to swap each substruct (the swap is a `std::move`, never
-// the EC roundtrip itself). HTTP read handlers take it shared,
-// copy the relevant substruct, release, then serialise JSON
-// outside the critical section — multiple clients stack with no
-// per-handler bottleneck.
+// A single `std::shared_timed_mutex` guards every member. The refresher takes it
+// exclusive once per tick to swap each substruct (a `std::move`, never the EC
+// roundtrip itself). Read handlers take it shared, copy the substruct, release,
+// then serialise JSON outside the critical section.
 
 namespace webapi
 {
 
-// One per file in amuled's state — keyed by ECID. Each file may
-// participate in either or both of two roles:
+// One per file in amuled's state, keyed by ECID. Each file may participate in
+// either or both of two roles:
 //
-//   * `is_downloading` — the file is a partfile in `downloadqueue`
-//     (still acquiring chunks). Drives `/downloads`. The walker that
-//     populates this side consumes `EC_TAG_PARTFILE_*` children.
-//   * `is_shared`      — the file is uploadable: a fully-completed
-//     knownfile, OR a partfile with ≥1 chunk done (amuled flags via
-//     `EC_TAG_PARTFILE_SHARED=true`). Drives `/shared`. Populated
+//   * `is_downloading` -- a partfile in `downloadqueue`, still acquiring chunks.
+//     Drives `/downloads`, populated from `EC_TAG_PARTFILE_*` children.
+//   * `is_shared` -- uploadable: a completed knownfile, OR a partfile with >=1
+//     chunk done (`EC_TAG_PARTFILE_SHARED=true`). Drives `/shared`, populated
 //     from `EC_TAG_KNOWNFILE_*` children.
 //
-// Both flags can be true simultaneously for a partfile that's
-// currently downloading AND uploading completed chunks.
+// Keying both roles on one ECID avoids the "shared cache has a ghost row with
+// empty hash" bug: on a partfile-becoming-shared tick the server's CValueMap
+// suppresses `EC_TAG_PARTFILE_HASH` because it was sent on a prior tick, but the
+// unified entry already has hash + name from the downloads walker.
 //
-// The unified-keyed-by-ECID design mirrors amulegui's
-// `CKnownFilesRem::m_items_hash` (amule-remote-gui.cpp:1507). It
-// avoids the "shared cache has a ghost row with empty hash" bug
-// (see #201 review): on a partfile-becoming-shared tick the server's
-// CValueMap suppresses `EC_TAG_PARTFILE_HASH` because it was sent on
-// a prior partfile-walker tick, but the unified entry already has
-// hash + name from the downloads walker, so the shared walker just
-// flips `is_shared=true` and merges its own fields. No fallback.
-//
-// Role-specific state lives in sub-blocks. When a role transitions
-// true→false (partfile completes → ECID dies; or shared partfile
-// loses every chunk → `is_shared` flips off; or knownfile is un-
-// shared), the refresher resets that side's sub-block to default so
-// `/downloads` or `/shared` can never serve stale stats from a
-// previous active period.
+// Role-specific state lives in sub-blocks. On a role transition true->false the
+// refresher resets that side's sub-block, so neither endpoint can serve stale
+// stats from a previous active period.
 struct FileSnapshot
 {
 	// Identity / shared metadata (always populated).
@@ -99,25 +84,20 @@ struct FileSnapshot
 	bool is_downloading = false;
 	bool is_shared = false;
 
-	// File-level attributes carried by the base CKnownFile EC tags, so
-	// they're available on both the download and shared detail endpoints.
-	// Detail-only (the list endpoints don't emit them).
+	// File-level attributes carried by the base CKnownFile EC tags, so they are
+	// available on both detail endpoints. Detail-only.
 	std::string aich_hash;          // AICH master hash (hex); "" if none
 	std::uint32_t queued_count = 0; // clients on this file's upload queue
 	std::string comment;            // the user's own file comment
 	std::int32_t rating = 0;        // the user's own rating, 0-5 (0 = unrated)
 
-	// Audio/video media metadata (issue #418). amuled emits each field only
-	// when that field has a value -- deliberately NOT gated on the aggregate
-	// GetMetaDataVer(), which would send length 0 / bitrate 0 for a file that
-	// probed to a codec and no duration, and a displayed zero is a claim where
-	// absence is not. A zero / empty value is amuled saying the field is GONE,
-	// which is how a re-probe's clear reaches us at all.
+	// Audio/video media metadata. amuled emits each field only when that field
+	// has a value -- deliberately NOT gated on the aggregate GetMetaDataVer(),
+	// which would send length 0 / bitrate 0 for a file that probed to a codec
+	// and no duration. A zero / empty value is amuled saying the field is GONE.
 	//
-	// `has_media` is therefore DERIVED from the fields below rather than being
-	// something amuled sent: latching it on any tag arriving would report
-	// media on a file whose every field has since been cleared. It gates the
-	// `media` object on the detail endpoints -- emitted as null when false.
+	// `has_media` is therefore DERIVED from the fields below: latching it on any
+	// tag arriving would report media on a file whose fields have since cleared.
 	bool has_media = false;
 	struct Media
 	{
@@ -130,21 +110,18 @@ struct FileSnapshot
 	} media;
 
 	// The partfile's control-file basename (e.g. `001.part`), from
-	// EC_TAG_KNOWNFILE_FILENAME. Meaningful only while the file is still
-	// an incomplete partfile — once it completes, the daemon reuses that
-	// EC tag to carry the directory path, so `part_file_name` on /downloads is
-	// gated on the download status (empty once completed). See #417.
+	// EC_TAG_KNOWNFILE_FILENAME. Meaningful only while the file is still an
+	// incomplete partfile -- once it completes the daemon reuses that EC tag to
+	// carry the directory path, so /downloads gates it on the download status.
 	std::string part_met_basename;
 
-	// The file's on-disk directory, from EC_TAG_KNOWNFILE_PATH — the Temp
-	// dir while downloading, the destination dir once completed. Always a
-	// directory (never the `.part` basename), so it feeds an unambiguous
-	// `path` on both /downloads/{hash} and /shared/{hash} (#417).
+	// The file's on-disk directory, from EC_TAG_KNOWNFILE_PATH -- the Temp dir
+	// while downloading, the destination dir once completed. Always a directory,
+	// never the `.part` basename.
 	std::string on_disk_dir;
 
-	// Download-side state — meaningful when `is_downloading` is true,
-	// reset to default on the true→false transition (and never read
-	// by `/downloads` when the flag is false).
+	// Download-side state -- meaningful when `is_downloading` is true, reset to
+	// default on the true->false transition.
 	struct DownloadSide
 	{
 		std::uint64_t completed_bytes = 0;
@@ -163,9 +140,8 @@ struct FileSnapshot
 		std::uint32_t sources_transferring = 0;
 		std::uint32_t sources_a4af = 0;
 
-		// Detail-only fields (GET /downloads/{hash}); the list endpoint
-		// omits them. All decoded from tags CEC_PartFile_Tag already
-		// emits under INC_UPDATE.
+		// Detail-only fields (GET /downloads/{hash}). All decoded from tags
+		// CEC_PartFile_Tag already emits under INC_UPDATE.
 		std::uint32_t last_seen_complete_at = 0;       // unix ts; 0 = unknown
 		std::uint32_t last_received_at = 0;            // unix ts of last change
 		std::uint32_t active_seconds = 0;              // seconds downloading
@@ -192,11 +168,9 @@ struct FileSnapshot
 		// Lets clients poll GET .../comments until the search finishes.
 		bool kad_comment_searching = false;
 
-		// Source-reported filenames (GET /downloads/{hash}/filenames,
-		// issue #420). amuled delta-encodes these keyed by a stable id
-		// (new = name+count, count 0 = removed, else count update); the
-		// refresher accumulates into this map across ticks. Reset with
-		// the rest of DownloadSide when the download role drops.
+		// Source-reported filenames. amuled delta-encodes these keyed by a stable
+		// id (new = name+count, count 0 = removed, else count update); the
+		// refresher accumulates into this map across ticks.
 		struct SourceName
 		{
 			std::string name;
@@ -204,20 +178,16 @@ struct FileSnapshot
 		};
 		std::map<std::uint32_t, SourceName> source_names;
 
-		// A4AF (asked-for-another-file) source scheduling (issue #421).
-		// `a4af_auto` is the auto-swap flag; `a4af_sources` are the client
-		// ECIDs currently parked as A4AF sources for this download (full
-		// list re-sent by amuled when it changes).
+		// A4AF (asked-for-another-file) source scheduling. `a4af_auto` is the
+		// auto-swap flag; `a4af_sources` are the client ECIDs currently parked as
+		// A4AF sources (full list re-sent by amuled when it changes).
 		bool a4af_auto = false;
 		std::vector<std::uint32_t> a4af_sources;
 
-		// Decoded per-part state, populated by the refresher's RLE
-		// decoder pass on EC_TAG_PARTFILE_GAP_STATUS +
-		// EC_TAG_PARTFILE_PART_STATUS. Both arrays are sized to
-		// ceil(size / PARTSIZE) once a successful decode has landed;
-		// the list endpoint omits them, the detail endpoint emits
-		// `progress.parts: [{state, sources}, ...]` by walking them
-		// in parallel.
+		// Decoded per-part state, populated by the refresher's RLE decoder pass on
+		// EC_TAG_PARTFILE_GAP_STATUS + EC_TAG_PARTFILE_PART_STATUS. Both arrays
+		// are sized to ceil(size / PARTSIZE) once a successful decode has landed;
+		// the detail endpoint walks them in parallel.
 		std::vector<std::uint64_t> decoded_gaps;
 		std::vector<std::uint16_t> decoded_part_sources;
 	} download;
@@ -226,9 +196,8 @@ struct FileSnapshot
 	// reset on the true→false transition.
 	struct SharedSide
 	{
-		// Upload priority level, distinct from the download-side value —
-		// a partfile that is both downloading and shared carries two
-		// independent priorities, so each side stores its own.
+		// Upload priority level, distinct from the download-side value: a partfile
+		// that is both downloading and shared carries two independent priorities.
 		std::string priority; // upload priority: "very_low" | "low"
 				      // | "normal" | "high" | "release" | "auto"
 		// Upload-side auto-priority flag, mirroring `download.priority_auto`;
@@ -242,46 +211,37 @@ struct FileSnapshot
 		std::uint32_t accepted_request_count_total = 0;
 		std::uint32_t complete_sources = 0;
 
-		// Detail-only (GET /shared/{hash}). The complete-sources range
-		// backs the desktop `< N` / `N - M` display; the scalar
-		// `complete_sources` above stays as-is.
+		// Detail-only. The complete-sources range backs the desktop `< N` / `N - M`
+		// display; the scalar `complete_sources` above stays as-is.
 		std::uint16_t complete_sources_low = 0;
 		std::uint16_t complete_sources_high = 0;
 
-		// Per-part source availability backing the shared "Obtained
-		// Parts" bar, decoded by the refresher from
-		// EC_TAG_PARTFILE_PART_STATUS on the EC_TAG_KNOWNFILE tag.
-		// Sized to ceil(size / PARTSIZE) once a decode has landed and
-		// empty until then, which the detail endpoint reports as
-		// `parts: null` -- "no data yet" and "no sources for any part"
-		// stay distinguishable.
+		// Per-part source availability backing the shared "Obtained Parts" bar,
+		// decoded from EC_TAG_PARTFILE_PART_STATUS on the EC_TAG_KNOWNFILE tag.
+		// Sized to ceil(size / PARTSIZE) once a decode has landed and empty until
+		// then, which the detail endpoint reports as `parts: null` -- "no data yet"
+		// and "no sources for any part" stay distinguishable.
 		//
 		// A shared *partfile* never populates this: amuled emits it as
-		// EC_TAG_PARTFILE only (one encoder per ECID), so its vector
-		// lands in `download.decoded_part_sources` instead. The detail
-		// writer falls back to that one.
-		//
-		// Values are the daemon's raw per-part source counts, clamped
-		// to 255 by the RLE encoder's uint8 buffer.
+		// EC_TAG_PARTFILE only (one encoder per ECID), so its vector lands in
+		// `download.decoded_part_sources` and the detail writer falls back to that.
+		// Values are clamped to 255 by the RLE encoder's uint8 buffer.
 		std::vector<std::uint16_t> decoded_part_sources;
 
-		// Parts hashed so far by a pass running over this complete share --
-		// Verify Local Data, or an AICH hashset rebuild -- decoded from
-		// EC_TAG_KNOWNFILE_HASHED_PART_COUNT on the EC_TAG_KNOWNFILE tag.
-		// A count, not an index: the tasks report part + 1. 0 means idle,
-		// which both tasks restore when they finish or abort.
+		// Parts hashed so far by a pass running over this complete share -- Verify
+		// Local Data, or an AICH hashset rebuild -- from
+		// EC_TAG_KNOWNFILE_HASHED_PART_COUNT. A count, not an index: the tasks
+		// report part + 1. 0 means idle.
 		//
-		// A download that is also shared arrives as EC_TAG_PARTFILE, so its
-		// progress lands in download.hashed_part_count and this stays 0 --
-		// read both through SharedHashingProgress() rather than this field
-		// directly, the same fallback decoded_part_sources needs.
+		// A download that is also shared arrives as EC_TAG_PARTFILE, so its progress
+		// lands in download.hashed_part_count and this stays 0 -- read both through
+		// SharedHashingProgress() rather than this field directly.
 		std::uint16_t hashing_progress = 0;
 
-		// Live upload activity (issue #466), the upload-side analogue of
-		// the download stats. `upload_speed_bytes_per_second` + `uploading_client_count` are
-		// live (refresh every tick); `last_upload` / `shared_since` are
-		// unix timestamps, 0 = unknown (a file that has never uploaded, or
-		// a known.met entry that predates the feature).
+		// Live upload activity, the upload-side analogue of the download stats.
+		// The speed and client count are live; `last_upload` / `shared_since` are
+		// unix timestamps, 0 = unknown (never uploaded, or a known.met entry that
+		// predates the feature).
 		std::uint32_t upload_speed_bytes_per_second = 0;
 		std::uint16_t uploading_client_count = 0;
 		std::uint32_t last_upload = 0;
@@ -291,30 +251,22 @@ struct FileSnapshot
 	// True while the file is genuinely an incomplete partfile: still in the
 	// download queue, and not the "finished but not yet cleared" state.
 	//
-	// The distinction matters because a completed download keeps
-	// `is_downloading` set until the user clears it, while already being a
-	// knownfile whose data sits in its destination directory -- so
-	// `is_downloading` alone would misreport it. "completing" is incomplete
-	// on purpose: the data is still in the temp directory until the move
-	// finishes.
+	// A completed download keeps `is_downloading` set until the user clears it,
+	// while already being a knownfile in its destination directory, so
+	// `is_downloading` alone would misreport it. "completing" is incomplete on
+	// purpose: the data is still in the temp directory until the move finishes.
 	bool IsIncompletePartfile() const { return is_downloading && download.status != "completed"; }
 };
 
-// One per peer (CUpDownClient) in the daemon's active client list.
-// Populated from the EC_TAG_CLIENT subtree inside the GET_UPDATE
-// response.
+// One per peer (CUpDownClient) in the daemon's active client list, populated
+// from the EC_TAG_CLIENT subtree inside the GET_UPDATE response.
 //
-// "Client" here is amule's bidirectional peer: a remote ed2k peer
-// that's connected to us in EITHER role — uploader (we are downloading
-// from them), uploadee (we are uploading to them), queue waiter,
-// banned, etc. The cache holds ALL of them; consumer endpoints filter
-// by role:
-//  * /uploads → filter by upload_state == US_UPLOADING
-//  * /clients → no filter, full set surfaced
-//  * /downloads/{hash}/clients and /shared/{hash}/clients → the peers
-//    related to one file, selected by download_file_hash /
-//    upload_file_hash (plus that download's A4AF sources), each row
-//    carrying the direction as a `role` field.
+// "Client" here is amule's bidirectional peer: a remote ed2k peer connected to
+// us in EITHER role -- uploader, uploadee, queue waiter, banned. The cache
+// holds ALL of them and consumer endpoints filter by role: /uploads by
+// upload_state == US_UPLOADING, /clients not at all, and the per-file routes by
+// download_file_hash / upload_file_hash plus that download's A4AF sources, each
+// row carrying the direction as a `role` field.
 /**
  * One peer from the daemon's credit store — GET /known_clients.
  *
@@ -346,11 +298,8 @@ struct KnownClientSnapshot
 	std::uint32_t session_count = 0;
 	//! This peer is connected right now, correlated by user hash against the
 	//! live client list. Never by ECID: those mean nothing across daemon
-	//! restarts, while the hash is what the credit store is keyed on.
-	//!
-	//! Named for the same quantity the live rows carry, and spelled the same
-	//! on the wire: this is EC_TAG_CLIENT_CONNECTED reaching a persisted row
-	//! by correlation rather than a second concept (R6).
+	//! restarts, while the hash is what the credit store is keyed on. Spelled
+	//! the same on the wire as the live rows carry it (R6).
 	bool connected = false;
 	//! The daemon answered the reachability question. False means unknown (a
 	//! core that predates EC_TAG_CLIENT_CONNECTED), which is null on the wire
@@ -376,9 +325,8 @@ struct ClientSnapshot
 	// the IP does not resolve.
 	std::string country_code;
 
-	// Software identity. EC_TAG_CLIENT_SOFTWARE ships a numeric code
-	// (SO_AMULE / SO_EMULE / etc); we decode it server-side into a
-	// short label here so consumers don't need the lookup table.
+	// Software identity. EC_TAG_CLIENT_SOFTWARE ships a numeric code (SO_AMULE /
+	// SO_EMULE / etc), decoded server-side into a short label here.
 	std::string software;         // "amule" | "emule" | "edonkey" | "mldonkey" | ...
 	std::string software_version; // free-form string from EC_TAG_CLIENT_SOFT_VER_STR
 	std::string reported_os;      // free-form (CLIENT_OS_INFO)
@@ -391,22 +339,16 @@ struct ClientSnapshot
 	std::string ident_state; // "not_available" | "id_needed" | "identified" | "id_failed" | "bad_guy" |
 				 // "unknown"
 
-	// File context — different per direction. Both correlators are
-	// 32-char lowercase MD4 hashes resolved by the refresher from
-	// EC_TAG_CLIENT_UPLOAD_FILE / EC_TAG_CLIENT_REQUEST_FILE (which
-	// amuled ships as ECIDs) against the unified m_files map. Consumers
-	// correlate against /downloads[].hash or /shared[].hash.
-	//  * upload_file_hash: partfile this peer is downloading FROM
-	//    us. Empty when not uploading to them, or when amuled's ECID
-	//    didn't resolve to a known file this tick.
-	//  * download_file_hash + download_file_name: file we are
-	//    downloading FROM this peer + the filename the peer
-	//    advertised (OP_REQFILENAMEANSWER). Empty when not in
-	//    download role.
-	//  * upload_file_name: partfile this peer is downloading FROM us,
-	//    resolved locally (we know our own partfiles' names, unlike
-	//    the peer-advertised download_file_name above). Empty when
-	//    not in upload role, or when upload_file_hash didn't resolve.
+	// File context -- different per direction. Both correlators are 32-char
+	// lowercase MD4 hashes resolved by the refresher from
+	// EC_TAG_CLIENT_UPLOAD_FILE / EC_TAG_CLIENT_REQUEST_FILE (which amuled ships
+	// as ECIDs) against the unified m_files map.
+	//  * upload_file_hash / upload_file_name: the partfile this peer is
+	//    downloading FROM us, the name resolved locally.
+	//  * download_file_hash / download_file_name: the file we are downloading
+	//    FROM this peer, the name as the peer advertised it
+	//    (OP_REQFILENAMEANSWER).
+	// Empty when not in that role, or when amuled's ECID did not resolve.
 	std::string upload_file_hash;   // EC_TAG_CLIENT_UPLOAD_FILE resolved
 	std::string download_file_hash; // EC_TAG_CLIENT_REQUEST_FILE resolved
 	std::string download_file_name; // EC_TAG_CLIENT_REMOTE_FILENAME
@@ -425,42 +367,32 @@ struct ClientSnapshot
 	// Upload queue position (for peers in US_ONUPLOADQUEUE).
 	// 0 when not queued.
 	std::uint32_t upload_queue_position = 0;
-	// Remote queue rank — our position in THE PEER's upload queue
-	// (i.e. how many other ed2k clients they're going to upload to
-	// before us). 0xFFFF when their queue is full.
-	//! Carries amuled's queue-full sentinel as well as a real position; see
-	//! kRemoteQueueFullSentinel.
+	// Remote queue rank -- our position in THE PEER's upload queue. Carries
+	// amuled's queue-full sentinel as well as a real position; see
+	// kRemoteQueueFullSentinel.
 	std::uint16_t remote_queue_position = 0;
 
 	std::uint32_t score = 0; // EC_TAG_CLIENT_SCORE
 	// Complete set, see ClientObfuscationName() in Refresher.cpp:
 	std::string obfuscation_state; // "undefined" | "enabled" | "supported" | "not_supported" |
 				       // "disabled" | "unknown"
-	//! EC_TAG_CLIENT_MOD_CAPABILITIES: the peer's eMuleAI vendor capability
-	//! word, already limited to the bits aMule knows by
-	//! CPeerCapabilities::SetFromWire() in the daemon. Held as the word the
-	//! daemon sent, not re-masked here: a second mask in this process would
-	//! be free to disagree with the daemon's, and the surface would then
-	//! report something no client ever claimed. Bit meanings live in
-	//! src/PeerCapabilities.h. 0 for a peer that claims nothing and for one
-	//! that sent no capability tag -- the same state, as on the wire.
+	//! EC_TAG_CLIENT_MOD_CAPABILITIES: the peer's eMuleAI vendor capability word,
+	//! already limited to the bits aMule knows by CPeerCapabilities::SetFromWire()
+	//! in the daemon. Held as the word the daemon sent, not re-masked here: a
+	//! second mask in this process would be free to disagree. Bit meanings live in
+	//! src/PeerCapabilities.h. 0 covers both "claims nothing" and "sent no tag".
 	std::uint32_t protocol_extensions = 0;
 	bool friend_slot = false;
 	// Whether a socket to this peer is up right now (EC_TAG_CLIENT_CONNECTED,
-	// from CUpDownClient::IsConnected). A row existing here only means the
-	// daemon holds a client object, which it does from the first contact
-	// ATTEMPT -- so presence in this list is not reachability, and every
-	// consumer that treated it as such called an unroutable peer online.
-	// has_connected false = the daemon never said, which is null on the wire.
+	// from CUpDownClient::IsConnected). A row existing here only means the daemon
+	// holds a client object, which it does from the first contact ATTEMPT -- so
+	// presence in this list is not reachability. has_connected false = never said.
 	bool connected = false;
 	bool has_connected = false;
 
-	// --- Extra fields decoded off the INC_UPDATE wire (issue #422) ----
-	// Originally detail-only. Five of them -- source_origin,
-	// parts_offered_count, client_mod_name, view_shared_disabled and the derived
-	// part_progress_percent -- were since promoted to the /clients list row
-	// and the SSE client_* payloads (#995, #1015); the rest are still
-	// serialized only by GET /clients/{ecid}.
+	// --- Extra fields decoded off the INC_UPDATE wire ----------------
+	// Serialized by GET /clients/{ecid}; five of them are also on the /clients
+	// list row and the SSE client_* payloads.
 	std::uint32_t ed2k_user_id = 0; // EC_TAG_CLIENT_USER_ID (hybrid eD2k id)
 	bool high_id = false;           // derived: !IsLowID(ed2k_user_id)
 	std::string server_ip;          // dotted-quad; "" when unknown/0
@@ -473,46 +405,34 @@ struct ClientSnapshot
 	std::string client_mod_name;           // EC_TAG_CLIENT_MOD_VERSION
 	bool view_shared_disabled = false;     // peer forbids viewing its shared files
 	// Completeness of the linked download for this peer, as a percent
-	// (parts_offered_count / file part count). < 0 => not computable (no
-	// linked file / no part count). Derived rather than decoded: filled in
-	// by ComputePartProgressPercent at every site that serializes a client
-	// -- the list, the per-file rows, the detail object and the SSE
-	// payload -- since it needs a second snapshot to resolve.
+	// (parts_offered_count / file part count). < 0 => not computable. Derived
+	// rather than decoded: filled in by ComputePartProgressPercent at every site
+	// that serializes a client, since it needs a second snapshot to resolve.
 	double part_progress_percent = -1.0;
 
 	// Per-part bitmaps, one bit per chunk of the file the relation names:
 	// `part_status` is what the peer holds of the file WE PULL FROM IT,
 	// `upload_part_status` what it holds of the file IT PULLS FROM US. A peer
-	// doing both at once has two different files' bitmaps here, so a consumer
-	// must pick by direction rather than assume they describe the same file.
+	// doing both at once has two different files' bitmaps here.
 	//
-	// The core sends an EMPTY tag to mean "has every part" rather than
-	// spending bytes on an all-ones buffer, and omits the tag entirely when
-	// its length would disagree with the file's part count. `*_all` carries
-	// the first case; the vector is then left empty and sized by whoever
-	// renders it, which is the only place the part count is known.
+	// The core sends an EMPTY tag to mean "has every part" rather than spending
+	// bytes on an all-ones buffer, and omits the tag entirely when its length
+	// would disagree with the file's part count. `*_all` carries the first case.
 	std::vector<bool> part_status;
 	std::vector<bool> upload_part_status;
 	bool part_status_all = false;
 	bool upload_part_status_all = false;
 	bool has_part_status = false;
 	bool has_upload_part_status = false;
-	// Indices into the download bitmap; absent from the wire means unchanged,
-	// so the has_ flags distinguish "never reported" from "reported as 0".
+	// Indices into the download bitmap of the peer's request file; absent from
+	// the wire means unchanged, so the has_ flags distinguish "never reported"
+	// from "reported as 0". They address one file, not the peer as a whole.
 	//
-	// Both are indices into the *download* bitmap of the peer's request
-	// file (ECSpecialCoreTags.cpp emits them inside the `pfile` guard, next
-	// to EC_TAG_CLIENT_PART_STATUS), so they address one file, not the peer
-	// as a whole. Surfaced by the per-file client rows only --
-	// `next_requested_part_index` / `downloading_part_index` on
-	// GET /downloads/{hash}/clients under `include_parts` -- which is why
-	// no comparator sorts on them and no SSE payload carries them. Values
-	// are relayed raw and validated by the serializer rather than here,
-	// because only the endpoint knows the file: kNoPartPendingSentinel is
-	// the core's "nothing pending" answer, any index past the file's part
-	// count is unusable, the row needs the bitmap the index indexes, and
-	// last_downloading_part is a stale 0 (BaseClient.cpp inits it so, and
-	// the tag is sent unconditionally) unless download_state is
+	// Values are relayed raw and validated by the serializer rather than here,
+	// because only the endpoint knows the file: kNoPartPendingSentinel is the
+	// core's "nothing pending" answer, any index past the file's part count is
+	// unusable, and last_downloading_part is a stale 0 (BaseClient.cpp inits it
+	// so, and the tag is sent unconditionally) unless download_state is
 	// "downloading" -- all of which come out as null.
 	std::uint16_t next_requested_part = 0;
 	std::uint16_t last_downloading_part = 0;
@@ -524,11 +444,10 @@ struct ClientSnapshot
 	double credit_ratio = 0.0; // CUpDownClient::GetScoreRatio() ("DL/UP modifier")
 };
 
-// One per eD2k server in the configured server list. Identity is
-// the EC ECID (stable per amuled process lifetime). Servers are
-// fetched at full-state per refresher tick (`EC_OP_GET_SERVER_LIST`
-// has no two-phase INC equivalent — see `ExternalConn.cpp:2023`),
-// so the refresher rebuilds the whole map each cycle.
+// One per eD2k server in the configured server list. Identity is the EC ECID
+// (stable per amuled process lifetime). Servers are fetched at full-state per
+// refresher tick (EC_OP_GET_SERVER_LIST has no two-phase INC equivalent), so
+// the refresher rebuilds the whole map each cycle.
 struct ServerSnapshot
 {
 	std::uint32_t ecid = 0;
@@ -548,10 +467,8 @@ struct ServerSnapshot
 	std::uint32_t files = 0;
 	// Per-user publishing limits the server advertises: below the soft limit a
 	// client may publish every file, between soft and hard only its rarest,
-	// above the hard limit nothing. Both arrive only once a UDP status reply
-	// has come back, so 0 means "the server has not told us", not "the limit
-	// is zero" -- the desktop renders that as a blank cell, as it does for
-	// Users and Files.
+	// above the hard limit nothing. Both arrive only once a UDP status reply has
+	// come back, so 0 means "the server has not told us", not "the limit is zero".
 	std::uint32_t soft_file_limit = 0;
 	std::uint32_t hard_file_limit = 0;
 	// Bitmasks of the eD2k wire capabilities the server announced, decoded to
@@ -564,8 +481,7 @@ struct ServerSnapshot
 };
 
 // /friends endpoint. The daemon ships the whole friends list inside every
-// EC_OP_GET_UPDATE reply, so this is filled from the tick we already run and
-// no endpoint here costs an extra roundtrip.
+// EC_OP_GET_UPDATE reply, so no endpoint here costs an extra roundtrip.
 struct FriendSnapshot
 {
 	std::uint32_t ecid = 0;
@@ -578,23 +494,20 @@ struct FriendSnapshot
 	std::uint32_t client_ecid = 0; // live peer this friend is linked to, 0 = offline
 	// Whether a socket to that peer is actually up. Distinct from client_ecid
 	// being non-zero, which is true from the first contact attempt. has_
-	// companion because a daemon that predates EC_TAG_CLIENT_CONNECTED says
-	// nothing, and unknown is null on the wire rather than a guessed false.
+	// companion because a daemon predating EC_TAG_CLIENT_CONNECTED says nothing.
 	bool connected = false;
 	bool has_connected = false;
-	// Reported by cores that serialize EC_TAG_FRIEND_FRIENDSLOT. An older
-	// daemon omits the tag and this stays false, the same way is_friend and
-	// credit_ratio degrade on /clients.
+	// Reported by cores that serialize EC_TAG_FRIEND_FRIENDSLOT. An older daemon
+	// omits the tag and this stays false.
 	bool friend_slot = false;
 };
 
-// /chats endpoints. One conversation with one peer, mirrored from the
-// daemon's CChatSessionStore over EC_OP_GET_CHAT_SESSIONS.
+// /chats endpoints. One conversation with one peer, mirrored from the daemon's
+// CChatSessionStore over EC_OP_GET_CHAT_SESSIONS.
 //
 // Keyed on the GUI_ID the wire already uses -- (ip << 16) | port -- which the
-// REST layer renders as the readable "<ip>:<port>" conversation key. Stable
-// across peer reconnects, unlike an ECID, and converts straight back to the
-// GUI_ID the EC ops want.
+// REST layer renders as the readable "<ip>:<port>" conversation key: stable
+// across peer reconnects, unlike an ECID.
 struct ChatMessageSnapshot
 {
 	std::uint32_t id = 0; //!< monotonic per daemon process; a safe `since_id` cursor
@@ -621,10 +534,9 @@ struct ChatSessionSnapshot
 	//! The REST conversation key, "<ip>:<port>".
 	std::string PeerKey() const { return ip + ":" + std::to_string(port); }
 
-	//! Display name, falling back to the desktop's own rendering when the
-	//! core has no nick for the peer (CChatSelector builds the same string).
-	//! Shared by the list, the detail read and the SSE payload so a client
-	//! never sees a blank name from one and a real one from another.
+	//! Display name, falling back to the desktop's own rendering when the core
+	//! has no nick for the peer (CChatSelector builds the same string). Shared by
+	//! the list, the detail read and the SSE payload so they cannot disagree.
 	std::string DisplayName() const
 	{
 		return name.empty() ? ("IP: " + ip + " Port: " + std::to_string(port)) : name;
@@ -632,28 +544,23 @@ struct ChatSessionSnapshot
 };
 
 // Renders an IPv4 address that arrives LSB-first -- the layout
-// EC_TAG_CLIENT_USER_IP, the Kad address tags and the eD2k id all share, and
-// what Uint32toStringIP() renders on the desktop side. Lives here rather than
-// in the refresher because the snapshot layer needs it too (a chat peer key
-// is built from a GUI_ID, with no walker involved).
+// EC_TAG_CLIENT_USER_IP, the Kad address tags and the eD2k id all share. Lives
+// here rather than in the refresher because the snapshot layer needs it too (a
+// chat peer key is built from a GUI_ID, with no walker involved).
 std::string IPv4ToDotted(std::uint32_t ip_lsb_first);
 
 // Is this request target eligible for the response-ETag memo?
 //
-// OPT-IN. The memo key is (target, snapshot revision) and nothing else, which
-// makes two demands on anything eligible; a route that fails either one gets
-// answered 304 for content that has changed:
+// OPT-IN, because the memo key is (target, snapshot revision) and nothing else,
+// which makes two demands on anything eligible; a route that fails either one
+// gets answered 304 for content that has changed:
 //
-//  1. Its body must move only when the state moves, so the revision covers
-//     it. Endpoints with their own TTL cache, an append-only mirror, a
+//  1. Its body must move only when the state moves, so the revision covers it.
+//     Endpoints with their own TTL cache, an append-only mirror, a
 //     refresh-on-read, or a live EC roundtrip per request do not qualify.
 //  2. Its body must be identical for every caller. The key carries no
 //     principal, so a per-caller document would share one validator between
 //     whoever asked first.
-//
-// This was an exclusion list and it was wrong four times over, each time for
-// a different reason. The eligible set is now spelled out instead, so the
-// cost of overlooking a route is a wasted hash rather than a stale 304.
 bool MemoizableTarget(const std::string &target);
 
 // Whether a response may be read from, or written to, the ETag memo. Two
@@ -663,12 +570,10 @@ bool MemoizableTarget(const std::string &target);
 //  2. The snapshot revision did not move while the handler ran. The body is
 //     serialized inside the handler under its own read lock, dropped before
 //     the caller can sample again; if a write lands in that window the body
-//     belongs to `rev_before` while the key would claim `rev_after`, and every
-//     later hit serves a validator describing neither.
+//     belongs to `rev_before` while the key would claim `rev_after`.
 //
 // Condition 2 guards a race, so nothing in a sequential test notices when it
-// is removed. It lives here, as a decision separate from the dispatch that
-// makes it, so that removing it fails a test instead of nothing.
+// is removed -- which is why it lives here rather than inline in the dispatch.
 bool MemoUsable(const std::string &target, std::uint64_t rev_before, std::uint64_t rev_after);
 
 // Whether the dispatcher should hash the body and stamp its own ETag.
@@ -676,8 +581,6 @@ bool MemoUsable(const std::string &target, std::uint64_t rev_before, std::uint64
 // `handler_set_etag` is the half worth spelling out: a handler that computed
 // its own validator owns it, and stamping the body hash over the top hands out
 // two different ETags for one resource depending on which branch answered.
-// That is exactly what the static path did before -- it clears the body for
-// HEAD, so only the GET reached the hashing branch.
 bool ShouldStampEtag(bool is_safe_method, bool handler_set_etag, unsigned status, bool body_empty);
 
 // The same key built straight from a GUI_ID, for paths that only have the id
@@ -685,38 +588,26 @@ bool ShouldStampEtag(bool is_safe_method, bool handler_set_etag, unsigned status
 // ChatSessionSnapshot left to ask). GUI_ID is (ip << 16) | port.
 std::string ChatPeerKeyFromGuiId(std::uint64_t gui_id);
 
-// /kad endpoint. Single composite snapshot pulled from the STAT_REQ
-// response we're already fetching for /status — saves a roundtrip
-// since amuled's `EC_OP_STAT_REQ` at `EC_DETAIL_CMD` ships every
-// `EC_TAG_STATS_KAD_*` we want here.
+// /kad endpoint. Single composite snapshot pulled from the STAT_REQ response
+// already fetched for /status -- amuled's EC_OP_STAT_REQ at EC_DETAIL_CMD ships
+// every EC_TAG_STATS_KAD_* wanted here.
 struct KadSnapshot
 {
 	std::string state; // "disabled" | "connecting" | "connected"
-	// Our own 128-bit Kademlia node id, 32 lowercase hex chars.
-	// Empty while Kad is not running -- amuled gates the
-	// EC_TAG_KAD_ID sub-tag on Kademlia::CKademlia::IsRunning(),
-	// which is exactly the condition `state == "disabled"` covers.
-	// Unlike the session-scoped ECIDs and the server-assigned eD2k
-	// id, this one is persisted (preferencesKad.dat) and survives
-	// daemon restarts.
+	// Our own 128-bit Kademlia node id, 32 lowercase hex chars. Empty while Kad
+	// is not running -- amuled gates EC_TAG_KAD_ID on CKademlia::IsRunning(),
+	// exactly the condition `state == "disabled"` covers. Unlike the ECIDs and
+	// the eD2k id, this one is persisted (preferencesKad.dat).
 	std::string node_id;
 	// Everything below is emitted as `null` unless Kad is CONNECTED, and the
-	// `has_*` flags are what carries that -- one per JSON object rather than
-	// one per field, since they share a single gate.
+	// `has_*` flags are what carries that -- one per JSON object rather than one
+	// per field, since they share a single gate.
 	//
-	// These used to be plain values with a `0`/`false` default, so a
-	// disconnected daemon answered with numbers that looked live. Measured on a
-	// real node with Kad stopped: `nodes` reported 2 and `firewalled_tcp`
-	// reported true -- claims about a network we are not on. `nodes` is the
-	// worst, because it is the size of our OWN routing table rather than
-	// anything network-wide, and contacts outlive the disconnect.
-	//
-	// REFERENCE.md's "Unknown values" rule is explicit that an unknown value is
-	// `null` and "neither is ever spelled `0` or `-1`". A count for a network
-	// we are not connected to is precisely unknown: `0` reads as "the network
-	// is empty" and a stale figure reads as "this is current" -- both worse
-	// than `null`, because both are syntactically valid answers a consumer will
-	// happily plot.
+	// These used to be plain values with a `0`/`false` default, so a disconnected
+	// daemon answered with numbers that looked live: measured on a real node with
+	// Kad stopped, `nodes` reported 2 and `firewalled_tcp` true. `nodes` is the
+	// worst, being the size of our OWN routing table, whose contacts outlive the
+	// disconnect.
 	//
 	// Safe as a default-false flag because RefresherTick builds a fresh
 	// KadSnapshot every tick, so an ungated field keeps its default rather than
@@ -736,38 +627,28 @@ struct KadSnapshot
 	std::uint32_t indexed_notes = 0;
 	std::uint32_t indexed_load = 0;
 	bool has_indexed = false; // gates the four indexed_* together
-	// Our externally-visible address as a remote Kad contact reported
-	// it back, dotted-quad. Named to match the JSON and to keep it
-	// apart from `buddy_ip` below, which is somebody else's. Empty
-	// while Kad is not connected (amuled only ships the tag then),
-	// and "0.0.0.0" while connected but not yet told our address by
-	// any contact -- amuled sends GetPrefs()->GetIPAddress() as-is,
-	// which is what the desktop panel renders too.
+	// Our externally-visible address as a remote Kad contact reported it back,
+	// dotted-quad. Empty while Kad is not connected (amuled only ships the tag
+	// then), and "0.0.0.0" while connected but not yet told our address by any
+	// contact -- amuled sends GetPrefs()->GetIPAddress() as-is.
 	std::string public_ip;
-	// Buddy is the LowID-buddy state (for NAT-T peers). Most users see
-	// "no_buddy"; networks behind aggressive NAT see "connected".
-	// Defaulted rather than left empty: amuled ships
-	// EC_TAG_STATS_BUDDY_STATUS only while Kad is connected, and both
-	// the core (CClientList's `m_nBuddyStatus = Disconnected`) and
-	// amulegui (GetTagByNameSafe()->GetInt() == 0 on an absent tag)
-	// read that absence as `Disconnected`. An empty string would be a
-	// fourth value outside the endpoint's own enum.
+	// Buddy is the LowID-buddy state (for NAT-T peers). Defaulted rather than
+	// left empty: amuled ships EC_TAG_STATS_BUDDY_STATUS only while Kad is
+	// connected, and both the core and amulegui read that absence as
+	// `Disconnected`. An empty string would be a fourth value outside the enum.
 	std::string buddy_status = "no_buddy"; // "no_buddy" | "connecting" | "connected"
 	bool has_buddy = false;                // gates buddy_status/ip/port together
-	// The buddy's address, dotted-quad. "0.0.0.0"/0 while Kad is
-	// connected with no buddy (amuled ships the tags as 0), empty
-	// while Kad is not connected at all -- same "not known" split as
-	// public_ip above. Only meaningful when buddy_status is
-	// "connected".
+	// The buddy's address, dotted-quad. "0.0.0.0"/0 while Kad is connected with
+	// no buddy (amuled ships the tags as 0), empty while Kad is not connected at
+	// all -- same "not known" split as public_ip above.
 	std::string buddy_ip;
 	std::uint16_t buddy_port = 0;
 };
 
-// One per download category (categories live in amuled's preferences;
-// the EC packet bundles them under `EC_PREFS_CATEGORIES`). Index 0
-// is the implicit "All" category. Refresher fetches the full set on
-// each tick — categories rarely change but the cost is bounded by
-// the typical 0-10 entry count.
+// One per download category (categories live in amuled's preferences, bundled
+// under EC_PREFS_CATEGORIES). Index 0 is the implicit "All" category. The
+// refresher fetches the full set each tick; the cost is bounded by the
+// typical 0-10 entry count.
 struct CategorySnapshot
 {
 	std::uint32_t index = 0;
@@ -779,19 +660,17 @@ struct CategorySnapshot
 	std::string priority; // human-readable (very_low/low/normal/high/release/auto)
 };
 
-// One typed value carried by a stats-tree node. The EC packet transports
-// the untranslated English label template plus one or more typed values
+// One typed value carried by a stats-tree node. The EC packet transports the
+// untranslated English label template plus one or more typed values
 // (EC_TAG_STAT_NODE_VALUE), so the API exposes them structurally rather than
-// flattening through GetDisplayString() (which translates and locale-formats
-// in the amuleapi process). `type` is the EC value type as a stable lowercase
+// flattening through GetDisplayString(), which translates and locale-formats in
+// the amuleapi process. `type` is the EC value type as a stable lowercase
 // string; the raw value lands in exactly one of num/dbl/str per `kind`.
-// `extra` holds the optional nested sub-value — at most one level deep,
-// matching the EC encoding. It is whatever the desktop prints in
-// parentheses, which is three different quantities depending on the node:
-// a percentage of the parent (CStatTreeItemCounterTmpl with stShowPercent),
-// a packet count beside a byte total (CStatTreeItemPackets), or the all-time
-// total beside a session figure (CStatTreeItemUlDlCounter). It is `type`-
-// tagged, so a client formats it from `type` rather than from its position.
+//
+// `extra` holds the optional nested sub-value, at most one level deep. It is
+// whatever the desktop prints in parentheses -- a percentage of the parent, a
+// packet count beside a byte total, or an all-time total beside a session
+// figure -- so a client formats it from `type`, not from its position.
 struct StatsTreeValue
 {
 	enum Kind
@@ -808,18 +687,15 @@ struct StatsTreeValue
 	std::string str;
 	// Locale-independent token for a well-known sentinel value
 	// (EC_TAG_STAT_VALUE_ENUM, e.g. "never"/"not_available"). Empty when the
-	// value is not a sentinel; surfaced as an additive "token" field so
-	// clients need not match the English `value`/`str`.
+	// value is not a sentinel, so clients need not match the English `value`.
 	std::string enum_token;
 	std::vector<StatsTreeValue> extra;
 };
 
-// One node in the recursive stats tree (amuled's "Statistics" panel
-// contents — counters, ratios, uptime, transfer aggregates, etc.).
-// `label` is the untranslated English template exactly as EC carries it
-// (e.g. "Uptime: %s"); `values` are the typed raw values that fill it, so
-// clients do their own formatting/localization. The API contract is English
-// text + C-locale numbers, independent of the amuleapi/amuled --locale.
+// One node in the recursive stats tree. `label` is the untranslated English
+// template exactly as EC carries it (e.g. "Uptime: %s"); `values` are the typed
+// raw values that fill it. The API contract is English text + C-locale numbers,
+// independent of the amuleapi/amuled --locale.
 struct StatsTreeNode
 {
 	// The EC_TAG_STATTREE_CAPPING value this tree was fetched at. Only
@@ -830,41 +706,35 @@ struct StatsTreeNode
 	// Stable, untranslated machine key (EC_TAG_STAT_NODE_KEY). Empty when
 	// the node carries no key; omitted from JSON in that case.
 	std::string key;
-	// Raw, untranslated machine value for data-labelled nodes (client
-	// version / OS string), from EC_TAG_STAT_NODE_RAW. Empty when absent;
-	// surfaced as "raw" so clients need not parse it out of `label`.
+	// Raw, untranslated machine value for data-labelled nodes (client version /
+	// OS string), from EC_TAG_STAT_NODE_RAW. Empty when absent.
 	std::string raw;
 	std::string label;
 	std::vector<StatsTreeValue> values;
 	std::vector<StatsTreeNode> children;
 
-	// Raw numeric UL:DL ratio (download-per-upload) for the ratio node,
-	// parsed from EC_TAG_STAT_NODE_RATIO[_TOTAL]. Present only on that node
-	// and only when the daemon could compute it (both sides > 0); surfaced
-	// as a "ratio" object so clients need not parse the composite string.
+	// Raw numeric UL:DL ratio (download-per-upload) for the ratio node, parsed
+	// from EC_TAG_STAT_NODE_RATIO[_TOTAL]. Present only on that node and only
+	// when the daemon could compute it (both sides > 0).
 	bool has_ratio_session = false;
 	double ratio_session = 0.0;
 	bool has_ratio_total = false;
 	double ratio_total = 0.0;
 };
 
-// Time-series data for /stats/graphs/{graph}. amuled keeps a
-// circular buffer of uint32 samples per series at 1-sec cadence;
-// the refresher pulls the most recent `kRefreshWindow` samples per
-// tick and stores them here, with the most recent sample at
-// `points.back()` corresponding to the snapshot wall-clock at
-// `snapshot_at` (CState::SnapshotAt()).
+// Time-series data for /stats/graphs/{graph}. amuled keeps a circular buffer of
+// uint32 samples per series at 1-sec cadence; the refresher pulls the most
+// recent `kRefreshWindow` samples per tick, the most recent at `points.back()`
+// corresponding to the snapshot wall-clock at `snapshot_at`.
 //
-// Four series fan out from a single `EC_OP_GET_STATSGRAPHS` packet
-// (download, upload, connections, kad). Handler picks the one named
-// in the `{graph}` path segment.
+// Four series fan out from a single EC_OP_GET_STATSGRAPHS packet (download,
+// upload, connections, kad); the handler picks the one named in `{graph}`.
 struct StatsGraphs
 {
 	// Seconds between samples, as actually requested of amuled via
-	// EC_TAG_STATSGRAPH_SCALE. Reported as `interval_seconds` and used to
-	// space the reconstructed timestamps, so it has to be the value that
-	// was asked for rather than an assumption. Also the cache key: an
-	// entry fetched at one interval must not answer a request for another.
+	// EC_TAG_STATSGRAPH_SCALE -- it spaces the reconstructed timestamps, so it
+	// has to be the value asked for. Also the cache key: an entry fetched at one
+	// interval must not answer a request for another.
 	std::uint32_t interval_seconds = 1;
 
 	std::vector<std::uint32_t> download_bytes_per_second;
@@ -872,26 +742,22 @@ struct StatsGraphs
 	std::vector<std::uint32_t> connections;
 	std::vector<std::uint32_t> kad_nodes;
 
-	// Second data blob (EC_TAG_STATSGRAPH_DATA_CONN), point-aligned with
-	// the four above and only meaningful on the connections graph. Empty
-	// when the daemon predates the tag -- which is why these are reported
-	// as absent rather than as zeros: "not reported" and "nothing was
-	// transferring" are different answers.
+	// Second data blob (EC_TAG_STATSGRAPH_DATA_CONN), point-aligned with the four
+	// above and only meaningful on the connections graph. Empty when the daemon
+	// predates the tag -- which is why these are reported as absent rather than
+	// as zeros: "not reported" and "nothing was transferring" differ.
 	std::vector<std::uint32_t> active_uploads;
 	std::vector<std::uint32_t> active_downloads;
 
-	// Records amuled holds per resolution range (EC_TAG_STATSGRAPH_DEPTH).
-	// Asking for more points than this makes the daemon repeat records
-	// rather than fail, and no timestamps travel on the wire, so the
-	// caller cannot spot it -- every series is truncated to this.
+	// Records amuled holds per resolution range (EC_TAG_STATSGRAPH_DEPTH). Asking
+	// for more points than this makes the daemon repeat records rather than fail,
+	// and no timestamps travel on the wire, so every series is truncated to this.
 	std::uint32_t max_points = 1800;
 
-	// Session running totals — reported alongside the time-series so the
-	// panel can show "this session total" without a separate roundtrip.
-	//
-	// The daemon divides the two byte counters by 1024 before sending
-	// (Statistics.cpp, RecordHistory), so these are scaled back on parse
-	// and really are bytes, to 1 KiB granularity.
+	// Session running totals, reported alongside the time-series so the panel can
+	// show "this session total" without a separate roundtrip. The daemon divides
+	// the two byte counters by 1024 before sending (Statistics.cpp), so these are
+	// scaled back on parse and really are bytes, to 1 KiB granularity.
 	std::uint64_t session_download_bytes = 0;
 	std::uint64_t session_upload_bytes = 0;
 
@@ -906,10 +772,9 @@ struct StatsGraphs
 	double session_duration_seconds = 0.0;
 };
 
-// One result from a /search/results poll. Identity is the file's
-// MD4 hash. amuled accumulates results in its `searchlist`
-// singleton as packets come in from servers/Kad; the client polls
-// EC_OP_SEARCH_RESULTS to drain.
+// One result from a /search/results poll. Identity is the file's MD4 hash.
+// amuled accumulates results in its `searchlist` singleton as packets come in
+// from servers/Kad; the client polls EC_OP_SEARCH_RESULTS to drain.
 struct SearchResult
 {
 	std::uint32_t ecid = 0;
@@ -928,19 +793,15 @@ struct SearchResult
 	// `file_type`), e.g. "video"/"audio"; "" if the name has no extension.
 	std::string type;
 	// The folder this file sits in inside the browsed peer's share
-	// (EC_TAG_SEARCHFILE_DIRECTORY). The core emits it for results filed
-	// from a peer's shared-file list and for nothing else, so it is empty
-	// on every ordinary server/Kad hit. Per-result rather than per-search:
-	// two copies of one file in different folders of the same share group
-	// under a single parent, each keeping its own folder, exactly as the
-	// desktop's Directories column shows them.
+	// (EC_TAG_SEARCHFILE_DIRECTORY). The core emits it for results filed from a
+	// peer's shared-file list and for nothing else, so it is empty on every
+	// ordinary server/Kad hit. Per-result, so two copies of one file in different
+	// folders of the same share group each keep their own folder.
 	std::string directory;
-	// Audio/video media metadata (issue #430), same shape as the file
-	// detail endpoints' `media` object. `has_media` gates it, and like the
-	// file-side flag above it is DERIVED from the field values rather than
-	// from which tags arrived -- a hit carrying an FT_MEDIA_* tag whose value
-	// is empty reads as no media, which is what the daemon means by sending
-	// one. Emitted as null when false (most remote results).
+	// Audio/video media metadata, same shape as the file detail endpoints'
+	// `media` object. Like the file-side flag above, `has_media` is DERIVED from
+	// the field values rather than from which tags arrived -- a hit carrying an
+	// FT_MEDIA_* tag whose value is empty reads as no media.
 	bool has_media = false;
 	struct Media
 	{
@@ -952,12 +813,10 @@ struct SearchResult
 		std::string title;
 	} media;
 
-	// Result grouping (issue #431): same-hash/same-size hits advertised
-	// under different filenames. `parent_ecid`/`has_parent` are set on a
-	// child during decode; the refresher then folds children into their
-	// parent's `children` list and drops them from the top-level set, so
-	// the API emits one parent row per hash+size with the alternative
-	// names nested. `children` is empty for a hit seen under one name.
+	// Result grouping: same-hash/same-size hits advertised under different
+	// filenames. `parent_ecid`/`has_parent` are set on a child during decode; the
+	// refresher then folds children into their parent's `children` list and drops
+	// them from the top-level set, so one parent row is emitted per hash+size.
 	std::uint32_t parent_ecid = 0;
 	bool has_parent = false;
 	struct Child
@@ -973,12 +832,10 @@ struct SearchResult
 	};
 	std::vector<Child> children;
 
-	// On-demand Kad community ratings/comments for this result (issue #434),
-	// same shape as a download's `comments`. A search hit has no connected
-	// sources, so these are purely the Kad notes. `kad_comment_searching` stays
-	// true while a lookup started via POST /search/results/{hash}/comments is in
-	// flight, so clients can poll until it finishes. `rating` -1 means a comment
-	// with no rating.
+	// On-demand Kad community ratings/comments for this result, same shape as a
+	// download's `comments`. A search hit has no connected sources, so these are
+	// purely the Kad notes. `kad_comment_searching` stays true while a lookup
+	// started via POST /search/results/{hash}/comments is in flight.
 	struct Comment
 	{
 		std::string username;
@@ -990,10 +847,9 @@ struct SearchResult
 	bool kad_comment_searching = false;
 };
 
-// Refresher-tracked lifecycle of the currently-active (or last-finished)
-// search. The refresher reads EC_TAG_SEARCH_LIFECYCLE_STATE (added in the
-// EC protocol cleanup landed earlier in this PR) and maps it directly
-// here — no sentinel decode, no state machine, no defensive timeout.
+// Refresher-tracked lifecycle of the currently-active (or last-finished) search.
+// The refresher reads EC_TAG_SEARCH_LIFECYCLE_STATE and maps it directly here --
+// no sentinel decode, no state machine, no defensive timeout.
 struct SearchProgressSnapshot
 {
 	// True between POST /search and the daemon-reported finished state.
@@ -1010,55 +866,45 @@ struct SearchProgressSnapshot
 				   // 100 on finished)
 	bool complete = false;     // true exactly once on the lifecycle
 				   // RUNNING → FINISHED edge
-	// Monotonically-increasing per POST /search. MarkSearchStarted
-	// bumps it; the refresher copies it through unchanged. EventDiff
-	// treats a generation change as a guaranteed emit trigger so the
-	// terminal `search_progress` frame can't be lost when a search
-	// starts and finishes inside a single refresher tick (a race
-	// against the tick boundary; see @ngosang's PR review).
+	// Monotonically-increasing per POST /search. MarkSearchStarted bumps it; the
+	// refresher copies it through unchanged. EventDiff treats a generation change
+	// as a guaranteed emit trigger so the terminal `search_progress` frame cannot
+	// be lost when a search starts and finishes inside a single refresher tick.
 	std::uint64_t generation = 0;
 };
 
 // The byte width of one partfile chunk. Authoritative copy is PARTSIZE in
-// `protocol/ed2k/Constants.h`, which is deliberately NOT included here: that
-// header is written against amule's legacy `uint64`/`uint32` typedefs from
-// src/Types.h, and dragging those into the webapi layer (and into its unit
-// tests) costs more than one restated number. amule has never changed
-// PARTSIZE since the ed2k spec was frozen.
-//
-// One copy, in one place, is the point: the literal used to sit in Api.cpp
-// beside six separately open-coded ceiling divisions.
+// protocol/ed2k/Constants.h, deliberately NOT included here: that header is
+// written against amule's legacy uint64/uint32 typedefs from src/Types.h, and
+// dragging those into the webapi layer (and its unit tests) costs more than one
+// restated number. amule has never changed PARTSIZE since the spec was frozen.
 constexpr std::uint64_t kPartSizeBytes = 9728000ull;
 
 // Number of eD2k chunks a file of `size` bytes is split into: ceil(size /
 // kPartSizeBytes), and 0 for an empty file.
 //
-// Matches CKnownFile::SetFileSize's m_iPartCount, which reaches the same
-// answer the long way round (floor + 1, then decremented back on an exact
-// multiple) -- worth knowing, because a mismatch here would silently trim
-// or pad every per-part bitmap.
+// Matches CKnownFile::SetFileSize's m_iPartCount, which reaches the same answer
+// the long way round -- worth knowing, because a mismatch here would silently
+// trim or pad every per-part bitmap.
 std::uint64_t PartCountForSize(std::uint64_t size);
 
 // Parts hashed so far by a pass running over `f` as a complete share -- Verify
 // Local Data, or an AICH hashset rebuild. 0 when no such pass is running.
 //
 // The fallback is why this is a function: amuled emits one tag kind per ECID,
-// so a download that is also shared arrives as EC_TAG_PARTFILE and its
-// progress lands on the download side. SharedPartSources in Api.cpp needs the
-// identical fallback for the identical reason. Every shared-side consumer --
-// the JSON writer, the SSE writer and the equality test -- goes through here,
-// so all three agree about which file is hashing.
+// so a download that is also shared arrives as EC_TAG_PARTFILE and its progress
+// lands on the download side. Every shared-side consumer goes through here, so
+// the JSON writer, the SSE writer and the equality test cannot disagree.
 std::uint16_t SharedHashingProgress(const FileSnapshot &f);
 
-// Fill in ClientSnapshot::part_progress_percent, which is derived rather
-// than refreshed: it needs the part count of the file this peer is a source
-// for, which lives in a different snapshot. Left at its < 0 sentinel when
-// not computable, which is how the writers know to emit the field as null.
+// Fill in ClientSnapshot::part_progress_percent, which is derived rather than
+// refreshed: it needs the part count of the file this peer is a source for,
+// which lives in a different snapshot. Left at its < 0 sentinel when not
+// computable, which is how the writers know to emit the field as null.
 //
-// Shared rather than owned by the REST layer because the SSE client payload
-// has to carry the same value: EVENTS.md promises an `_updated` subscriber
-// gets the full new state and never has to re-GET, and this field was the
-// one exception to that.
+// Shared rather than owned by the REST layer because the SSE client payload has
+// to carry the same value: EVENTS.md promises an `_updated` subscriber gets the
+// full new state and never has to re-GET.
 class CState;
 void ComputePartProgressPercent(const CState &state, ClientSnapshot &cli);
 
@@ -1067,65 +913,49 @@ void ComputePartProgressPercent(const CState &state, ClientSnapshot &cli);
 // daemon-allocated search_id (see m_searches).
 struct SearchSlot
 {
-	// What the daemon last told us, flat: every result ECID it has sent for
-	// this search, parents and grouped children alike, exactly as they
-	// arrived. This is the merge target for the incremental union poll --
-	// a diffed tag names one ECID and carries only the fields that moved, so
-	// there has to be somewhere addressable by ECID to apply it to.
+	// What the daemon last told us, flat: every result ECID it has sent for this
+	// search, parents and grouped children alike. This is the merge target for
+	// the incremental union poll, which names one ECID per diffed tag.
 	std::map<std::uint32_t, SearchResult> raw;
-	// The view every reader uses: `raw` with each child folded into its
-	// parent's children[] and dropped from the top level, so the API serves
-	// one row per hash+size. Rebuilt from `raw` after each merge rather than
-	// merged into directly, which keeps every consumer (Search(),
-	// FindSearchResultByHash, EventDiff) on exactly the shape it had before
-	// incremental polling existed.
+	// The view every reader uses: `raw` with each child folded into its parent's
+	// children[] and dropped from the top level, so the API serves one row per
+	// hash+size. Rebuilt from `raw` after each merge rather than merged into
+	// directly, which keeps every consumer on the shape it had before.
 	std::map<std::uint32_t, SearchResult> results;
 	SearchProgressSnapshot progress;
-	// What was searched for, so a consumer reading one search's results
-	// does not have to cross-reference GET /search for the string. For a
-	// browse ("View Files") the daemon's name for the search is the peer's
-	// nickname, not a query. Empty only for a slot seeded by discovery
-	// before its name was observed.
+	// What was searched for, so a consumer reading one search's results need not
+	// cross-reference GET /search. For a browse the daemon's name for the search
+	// is the peer's nickname. Empty only for a slot seeded by discovery.
 	std::string query;
-	// Wall-clock second this session started the search, for ranking the
-	// entries GET /search returns: that listing comes straight off
-	// EC_OP_SEARCH_LIST, which walks a std::map keyed by search_id and
-	// carries no timestamp, so it arrives id-ascending -- and id order is
-	// not recency, since Kad ids carry SEARCH_ID_KAD_MASK (0x80000000) and
-	// therefore always sort above ed2k ones. 0 for a search this session did
-	// not start (another client's, or one the daemon restored from disk),
-	// which is unknowable here rather than zero-valued.
+	// Wall-clock second this session started the search, for ranking the entries
+	// GET /search returns: that listing comes straight off EC_OP_SEARCH_LIST,
+	// which walks a std::map keyed by search_id and carries no timestamp, so it
+	// arrives id-ascending -- and id order is not recency, since Kad ids carry
+	// SEARCH_ID_KAD_MASK (0x80000000) and always sort above ed2k ones. 0 for a
+	// search this session did not start, which is unknowable rather than zero.
 	std::time_t started_at = 0;
 	// When this slot's results were last pulled from the daemon. The tick
-	// refreshes active searches every second; a FINISHED search is never
-	// polled again, so reads of it refresh on demand instead, coalesced by
-	// this stamp. Default-constructed (epoch) means "never fetched", which
-	// is always stale.
+	// refreshes active searches every second; a FINISHED search is never polled
+	// again, so reads of it refresh on demand, coalesced by this stamp.
 	std::chrono::steady_clock::time_point last_fetch{};
-	// The daemon no longer holds this search: its EC ring evicted it, or it
-	// was closed core-side. Set by the tick when EC_OP_SEARCH_PROGRESS comes
-	// back expired, before that same tick applies the results union -- which
-	// would otherwise tombstone away exactly the results the retirement path
-	// means to keep for late reads, since the union emits EC_TAG_FILE_REMOVED
-	// for every result of an evicted search.
+	// The daemon no longer holds this search: its EC ring evicted it, or it was
+	// closed core-side. Set by the tick when EC_OP_SEARCH_PROGRESS comes back
+	// expired, BEFORE that same tick applies the results union -- which would
+	// otherwise tombstone away exactly the results the retirement path keeps for
+	// late reads, since the union emits EC_TAG_FILE_REMOVED for every result of
+	// an evicted search.
 	//
-	// A detached slot is frozen: ApplySearchUnion skips it for merges and
-	// tombstones alike, since nothing about it can change any more. It is
-	// also the preferred eviction victim, because it is the only kind whose
-	// eviction costs nothing -- the daemon has nothing left to re-send.
+	// A detached slot is frozen and is the preferred eviction victim: the daemon
+	// has nothing left to re-send, so evicting it costs nothing.
 	bool detached = false;
-	// Set when a union roundtrip failed against a live socket, and cleared
-	// once this slot has been re-seeded in full.
+	// Set when a union roundtrip failed against a live socket, and cleared once
+	// this slot has been re-seeded in full.
 	//
 	// The daemon commits its differential state while BUILDING the reply --
-	// Get_EC_Response_Search_Results_Union swaps io_lastSentResultIds and
-	// writes the valuemap before the packet reaches the socket -- so a reply
-	// we never apply is not re-sent, it is lost. Every later poll elides the
-	// results it covered. Nothing else recovers them: ResetLists deliberately
-	// keeps the search state (wiping it would resync nothing), and
-	// ClaimSearchRefresh refuses an active slot because the tick is supposed
-	// to be covering it. This flag is what turns that dead end into one FULL
-	// re-seed on the next tick.
+	// Get_EC_Response_Search_Results_Union swaps io_lastSentResultIds and writes
+	// the valuemap before the packet reaches the socket -- so a reply we never
+	// apply is not re-sent, it is lost, and every later poll elides the results
+	// it covered. This flag is what turns that dead end into one FULL re-seed.
 	bool needs_resync = false;
 	// Insertion order, for oldest-first eviction. Not started_at: that is 0
 	// for a discovered slot, which would make every adopted search tie for
@@ -1133,33 +963,25 @@ struct SearchSlot
 	std::uint64_t seq = 0;
 };
 
-// `m_amule_log_lines` in CState caches /logs/amule. amule's EC
-// server piggybacks new lines on STAT_REQ at `EC_DETAIL_FULL` (see
-// `AddLoggerTag` in ExternalConn.cpp:700-715) via a per-EC-connection
-// cursor (CLoggerAccess) — each call returns ONLY lines emitted
-// since the previous STAT_REQ from the same connection. Clients
-// tail with `?tail=N`.
+// `m_amule_log_lines` in CState caches /logs/amule. amule's EC server piggybacks
+// new lines on STAT_REQ at EC_DETAIL_FULL (AddLoggerTag in ExternalConn.cpp) via
+// a per-EC-connection cursor (CLoggerAccess) -- each call returns ONLY lines
+// emitted since the previous STAT_REQ from the same connection.
 //
-// **No cap on history.** Per operator preference, every line stays
-// in memory until amuleapi restarts; log volume is bounded by
-// operator habits (idle ~tens of KB/day; busy ~hundreds).
+// No cap on history: per operator preference every line stays in memory until
+// amuleapi restarts.
 
-// /logs/server_info. amule has no incremental EC op for this log
-// (no equivalent of CLoggerAccess for ServerInfoLog), so the
-// refresher fetches the entire string via EC_OP_GET_SERVERINFO each
-// tick and the cache stores the latest snapshot. Server-info logs
-// are small (a few KB at most — just server connection chatter), so
-// the per-tick rebuild cost is negligible.
+// /logs/server_info. amule has no incremental EC op for this log (no equivalent
+// of CLoggerAccess for ServerInfoLog), so the refresher fetches the entire
+// string via EC_OP_GET_SERVERINFO each tick. Server-info logs are a few KB at
+// most, so the per-tick rebuild cost is negligible.
 struct ServerInfoLog
 {
 	std::string text;
 };
 
-// amuled preferences subset surfaced via /preferences. The amuled
-// preferences corpus is enormous (every UI panel has its own
-// section); for v0.1 we ship the common-case fields:
-// nick, transfer limits, ports, connection toggles. / later
-// can extend this if a real client reports needing more.
+// amuled preferences subset surfaced via /preferences: nick, transfer limits,
+// ports, connection toggles.
 struct PreferencesSnapshot
 {
 	// [General]
@@ -1168,9 +990,8 @@ struct PreferencesSnapshot
 	std::string daemon_host_name;
 	bool version_check_enabled = false;
 	// Capability: the connected daemon is built with ENABLE_VERSION_CHECK
-	// (emits EC_TAG_GENERAL_VERSION_CHECK_AVAILABLE). False for OS-package
-	// or pre-3.1 daemons; combined with version_check_enabled to decide whether
-	// update checking is active. See /version's "update" object.
+	// (emits EC_TAG_GENERAL_VERSION_CHECK_AVAILABLE). False for OS-package or
+	// pre-3.1 daemons; combined with version_check_enabled by /version's "update".
 	bool version_check_available = false;
 
 	// [Connection]
@@ -1197,31 +1018,27 @@ struct PreferencesSnapshot
 	// Proxy the daemon routes P2P + HTTP through. proxy_password is
 	// write-only (accepted on PATCH, never surfaced here / on GET).
 	bool proxy_enabled = false;
-	// Serialized enum "socks5" / "socks4" / "http" / "socks4a" (#655): the
-	// EC layer carries the wire ints 0..3, the API spells them out so a
-	// client needs no magic-number table. Empty for CProxyType PROXY_NONE
-	// (-1, the "no proxy configured" state the daemon always serializes),
-	// which has no enum string and cannot be set back over PATCH --
-	// proxy_enabled is the off switch.
+	// Serialized enum "socks5" / "socks4" / "http" / "socks4a": the EC layer
+	// carries the wire ints 0..3, the API spells them out. Empty for CProxyType
+	// PROXY_NONE (-1, the "no proxy configured" state the daemon always
+	// serializes), which cannot be set back over PATCH -- proxy_enabled is that.
 	std::string proxy_type;
 	std::string proxy_host;
 	std::uint16_t proxy_port = 0;
 	bool proxy_auth_enabled = false;
 	std::string proxy_user;
-	// UPnP. upnp_enabled toggles router forwarding of the P2P ports (which
-	// are tcp_port / udp_port themselves); upnp_control_point_port is the UPnP control
-	// point's own local port (0 = auto), not a forwarded port. upnp_supported
-	// is a read-only capability: the daemon advertises whether it was built
-	// with UPnP (false on a core built -DENABLE_UPNP=OFF).
+	// UPnP. upnp_enabled toggles router forwarding of the P2P ports;
+	// upnp_control_point_port is the control point's own local port (0 = auto),
+	// not a forwarded port. upnp_supported is a read-only capability: whether
+	// the daemon was built with UPnP.
 	bool upnp_supported = false;
 	bool upnp_enabled = false;
 	std::uint16_t upnp_control_point_port = 0;
 
-	// --- Extended EC-carried categories (issue #437) -----------------
-	// Every field below maps 1:1 to an EC tag the daemon already
-	// serializes in CEC_Prefs_Packet and applies in Apply(); the webapi
-	// just requests the wider selection bitmask and plumbs them through.
-	// Nested sub-structs mirror the nested JSON the endpoint emits.
+	// --- Extended EC-carried categories -----------------
+	// Every field below maps 1:1 to an EC tag the daemon already serializes in
+	// CEC_Prefs_Packet and applies in Apply(); the webapi requests the wider
+	// selection bitmask and plumbs them through.
 
 	// [Directories] EC_TAG_PREFS_DIRECTORIES
 	struct DirectoriesPrefs
@@ -1249,22 +1066,18 @@ struct PreferencesSnapshot
 		bool on_finished_start_next_in_same_category = false;
 		bool save_sources_for_rare_files = false;
 		bool preallocate_full_file_size = false;
-		// Memory-mapped file I/O (#565). mmap_supported is a read-only daemon
-		// capability (mirrors upnp_supported): true only when the core was built
-		// with mmap support. mmap_enabled is the runtime preference and is only
-		// accepted on PATCH when mmap_supported is true.
+		// Memory-mapped file I/O. mmap_supported is a read-only daemon capability
+		// (mirrors upnp_supported): true only when the core was built with mmap
+		// support. mmap_enabled is only accepted on PATCH when it is true.
 		bool mmap_supported = false;
 		bool mmap_enabled = false;
 		bool stop_on_low_disk_space = false;
 		std::uint32_t min_free_space_mebibytes = 0;
-		// Positive sense (#655): true = part files are created sparse, so
-		// blocks are allocated on demand. The core stores exactly this
-		// (s_createFilesSparse, default on); it is only the EC layer that
-		// carries the negation, as EC_TAG_FILES_CREATE_NORMAL present ==
-		// "not sparse". The schema's `invert` column undoes that on both
-		// the read and the write path. Only does real work when the core
-		// runs on Windows -- on POSIX both branches create the part file
-		// identically.
+		// Positive sense: true = part files are created sparse. The core stores
+		// exactly this (s_createFilesSparse, default on); only the EC layer
+		// carries the negation, as EC_TAG_FILES_CREATE_NORMAL present == "not
+		// sparse", which the schema's `invert` column undoes on both paths. Only
+		// does real work on Windows -- on POSIX both branches are identical.
 		bool create_sparse_files = true;
 		bool on_finished_start_next_alphabetically = false;
 		bool endgame_mode_enabled = false;
@@ -1293,10 +1106,9 @@ struct PreferencesSnapshot
 	// [Security] EC_TAG_PREFS_SECURITY
 	struct SecurityPrefs
 	{
-		// Serialized enum "everybody" / "friends" / "nobody" (#655). The EC
-		// layer carries the 3-state int (EC_TAG_SECURITY_CAN_SEE_SHARES /
-		// s_iSeeShares: 0 = everybody, 1 = friends only, 2 = nobody); the
-		// API spells it out, and the name says it is not a yes/no question.
+		// Serialized enum "everybody" / "friends" / "nobody". The EC layer carries
+		// the 3-state int (EC_TAG_SECURITY_CAN_SEE_SHARES / s_iSeeShares: 0 =
+		// everybody, 1 = friends only, 2 = nobody); the API spells it out.
 		std::string shared_files_visibility = "everybody";
 		bool ipfilter_clients_enabled = false;
 		bool ipfilter_servers_enabled = false;
@@ -1326,14 +1138,11 @@ struct PreferencesSnapshot
 		std::string comment_keywords;
 	} message_filter;
 
-	// [RemoteControls] EC_TAG_PREFS_REMOTECTRL. Passwords are
-	// write-only (set via PATCH, never serialized here).
+	// [RemoteControls] EC_TAG_PREFS_REMOTECTRL. Passwords are write-only.
 	//
-	// Two unrelated remote-control subsystems live under one EC category, so
-	// the JSON nests them (#655) instead of prefixing every field:
-	// remote_controls.webserver.{...} / remote_controls.amuleapi.{...}. Both
-	// sub-objects still pack into the single EC_TAG_PREFS_REMOTECTRL group on
-	// the write path -- the nesting is an API-shape choice, not an EC one.
+	// Two unrelated remote-control subsystems live under one EC category, so the
+	// JSON nests them instead of prefixing every field. Both sub-objects still
+	// pack into the single EC_TAG_PREFS_REMOTECTRL group on the write path.
 	struct RemoteControlsPrefs
 	{
 		struct WebserverPrefs
@@ -1382,15 +1191,12 @@ struct PreferencesSnapshot
 		std::string update_url;
 	} kad;
 
-	// [geoip] (EC group: IP2COUNTRY, #440). The daemon only emits
-	// this category on a GeoIP-capable build, so an absent category leaves
-	// `supported` false (mirrors version_check_available: a capability the
-	// connected daemon advertises, not a stored setting). `source` is the
-	// serialized enum "dbip" / "maxmind" / "custom" (next-download
-	// selector). The trailing status fields are read-only daemon state.
-	// `maxmind_license` round-trips plainly — it is a config string the
-	// core already serializes and the desktop GeoIP panel shows, not a
-	// masked password like the [RemoteControls] ones.
+	// [geoip] (EC group: IP2COUNTRY). The daemon only emits this category on a
+	// GeoIP-capable build, so an absent category leaves `supported` false -- a
+	// capability the daemon advertises, not a stored setting. `source` is the
+	// serialized enum "dbip" / "maxmind" / "custom". `maxmind_license`
+	// round-trips plainly: it is a config string the core already serializes,
+	// not a masked password like the [RemoteControls] ones.
 	struct GeoipPrefs
 	{
 		bool supported = false;
@@ -1409,19 +1215,13 @@ struct PreferencesSnapshot
 
 struct StatusSnapshot
 {
-	// "connected" / "connecting" / "disconnected" — the literal
-	// string the API returns. Done at parse time rather than
-	// emit time so the snapshot is self-describing (debug-dump-
-	// friendly) and the emit path stays one-liner trivial.
+	// "connected" / "connecting" / "disconnected" -- the literal string the API
+	// returns, decoded at parse time so the snapshot is self-describing.
 	std::string ed2k_state = "disconnected";
 	std::string kad_state = "disabled";
 
-	// Nickname is intentionally NOT a /status field — it lives in the
-	// preferences EC namespace, not the STAT_REQ response. amuleapi
-	// surfaces it via /api/v0/preferences where it belongs
-	// semantically (it's a user-edited value, not a connection-state
-	// observation). Same call /status that PHP's am_status template
-	// makes.
+	// Nickname is intentionally NOT a /status field -- it lives in the preferences
+	// EC namespace, not the STAT_REQ response, and is surfaced by /preferences.
 
 	// Server the daemon is currently connected to (eD2k only — Kad
 	// has no equivalent). Empty when ed2k_state != "connected".
@@ -1429,38 +1229,32 @@ struct StatusSnapshot
 	std::string server_ip;
 	std::uint32_t server_port = 0;
 
-	// True when our eD2k id is a HighID (>= HIGHEST_LOWID_ED2K_KAD). False
-	// for a LowID *and* whenever we are not connected at all -- there is no
-	// id then, so gate on ed2k_state == "connected" before reading this as
-	// a firewall verdict. Positive sense so it matches the peer-side
-	// high_id on /clients/{ecid}, and so the disconnected case does not
-	// read as an alarming "low id".
+	// True when our eD2k id is a HighID (>= HIGHEST_LOWID_ED2K_KAD). False for a
+	// LowID *and* whenever we are not connected at all -- there is no id then, so
+	// gate on ed2k_state == "connected" before reading this as a firewall
+	// verdict. Positive sense so it matches the peer-side high_id on /clients.
 	bool ed2k_high_id = false;
 
-	// Our eD2k id as assigned by the connected server. 0 when not
-	// connected; the 0xffffffff "connect in flight" sentinel is normalized
-	// to 0 rather than surfaced. Packed LSB-first, unlike the peer-side
-	// ed2k_user_id on CUpDownClient, which byte-swaps a HighID.
+	// Our eD2k id as assigned by the connected server. 0 when not connected; the
+	// 0xffffffff "connect in flight" sentinel is normalized to 0. Packed
+	// LSB-first, unlike the peer-side ed2k_user_id, which byte-swaps a HighID.
 	std::uint32_t ed2k_user_id = 0;
 
-	// Our public IPv4 in dotted-quad form, derived from ed2k_user_id when that
-	// is a HighID -- a HighID *is* the address. Empty for a LowID or while
-	// disconnected, where no address exists. Formatted here rather than in
-	// the handler, matching every other address in these snapshots.
+	// Our public IPv4 in dotted-quad form, derived from ed2k_user_id when that is
+	// a HighID -- a HighID *is* the address. Empty for a LowID or while
+	// disconnected, where no address exists.
 	std::string ed2k_public_ip;
-	// True when Kad is running but firewalled for TCP. The verdict is a
-	// vote: two peers must confirm reachability over an incoming TCP
-	// connection before it clears. Distinct from the UDP test, which is
-	// a different mechanism -- see KadSnapshot::firewalled_udp.
+	// True when Kad is running but firewalled for TCP. The verdict is a vote: two
+	// peers must confirm reachability over an incoming TCP connection before it
+	// clears. Distinct from the UDP test -- see KadSnapshot::firewalled_udp.
 	bool kad_firewalled_tcp = false;
 	// `null` unless Kad is connected: IsKadFirewalled() reads a connstate bit
 	// that survives the disconnect, so this answered `true` on a stopped Kad.
 	bool has_kad_firewalled_tcp = false;
 
-	// Unix timestamp of the most recent connect (amule-org/amule#174),
-	// from EC_TAG_CONNSTATE's optional {ED2K,KAD}_CONNECTED_SINCE
-	// sub-tags. 0 when not connected -- gate on ed2k_state/kad_state
-	// rather than trust a 0 timestamp alone.
+	// Unix timestamp of the most recent connect, from EC_TAG_CONNSTATE's optional
+	// {ED2K,KAD}_CONNECTED_SINCE sub-tags. 0 when not connected -- gate on
+	// ed2k_state/kad_state rather than trust a 0 timestamp alone.
 	std::uint64_t ed2k_connected_since = 0;
 	std::uint64_t kad_connected_since = 0;
 
@@ -1469,10 +1263,9 @@ struct StatusSnapshot
 	std::uint64_t download_bytes_per_second = 0;
 	std::uint64_t upload_bytes_per_second = 0;
 
-	// Protocol/control-traffic overhead, bytes/second. ADDITIVE to the two
-	// rates above rather than a subset of them -- amuled keeps them as
-	// separate counters and the desktop renders them as a second figure in
-	// parentheses. 0 when the daemon reports nothing.
+	// Protocol/control-traffic overhead, bytes/second. ADDITIVE to the two rates
+	// above rather than a subset of them -- amuled keeps separate counters and
+	// the desktop renders them as a second figure in parentheses.
 	std::uint64_t download_overhead_bytes_per_second = 0;
 	std::uint64_t upload_overhead_bytes_per_second = 0;
 
@@ -1481,67 +1274,52 @@ struct StatusSnapshot
 	std::uint32_t total_src_count = 0;
 
 	// Free bytes on the filesystems holding the part files and the finished
-	// downloads. SIGNED, with -1 meaning "the daemon has no figure" -- the
-	// state before CFreeSpaceThread publishes its first sample, and the
-	// permanent state of a directory it cannot stat.
+	// downloads. SIGNED, with -1 meaning "the daemon has no figure" -- before
+	// CFreeSpaceThread publishes its first sample, and permanently for a
+	// directory it cannot stat.
 	//
-	// amuled's FREE_SPACE_UNKNOWN is -1 and the EC serializer casts it
-	// straight to uint64, so the wire carries 0xFFFFFFFFFFFFFFFF. Storing
-	// that unsigned and emitting it would report 17 exabytes free -- the
-	// exact opposite of the truth -- so it is read back as a signed -1 and
-	// serialised as JSON null.
+	// amuled's FREE_SPACE_UNKNOWN is -1 and the EC serializer casts it straight
+	// to uint64, so the wire carries 0xFFFFFFFFFFFFFFFF. Storing that unsigned
+	// would report 17 exabytes free, so it is read back signed and emitted null.
 	std::int64_t temp_free_bytes = -1;
 	std::int64_t incoming_free_bytes = -1;
 
-	// ed2k network-wide totals (all connected servers). Surfaced in
-	// /status as ed2k.network.{users,files} — symmetric with
-	// kad.network.{users,files,nodes} on KadSnapshot. Populated from
-	// EC_TAG_STATS_ED2K_{USERS,FILES}, present in the same
-	// EC_OP_STAT_REQ response we already parse.
+	// ed2k network-wide totals (all connected servers), from
+	// EC_TAG_STATS_ED2K_{USERS,FILES} in the EC_OP_STAT_REQ response already
+	// parsed. Surfaced as /status ed2k.network.{users,files}.
 	//
 	// `null` unless eD2k is connected. These are summed over the whole known
-	// SERVER LIST rather than the server we are attached to, and nothing zeroes
-	// them on disconnect: measured on a real node, a disconnected daemon kept
-	// reporting the identical figures it had while connected, indefinitely. A
-	// consumer cannot tell that from live data, which is what makes it worse
-	// than a `0`.
+	// SERVER LIST rather than the attached server, and nothing zeroes them on
+	// disconnect: a disconnected daemon keeps reporting the figures it had while
+	// connected, indefinitely, which a consumer cannot tell from live data.
 	std::uint32_t ed2k_users = 0;
 	std::uint32_t ed2k_files = 0;
 	bool has_ed2k_network = false; // gates ed2k_users/ed2k_files together
 
 	// Version-check result, relayed on the same EC_OP_STATS round-trip
-	// (EC_TAG_GENERAL_VERSION_CHECK_*). done == a check has completed;
-	// latest is the release string; outdated == a newer release exists;
-	// timestamp is the unix time the check completed. Surfaced in
-	// /version's "update" object. Absent (done == false) on daemons that
-	// have not checked yet or were built without ENABLE_VERSION_CHECK.
+	// (EC_TAG_GENERAL_VERSION_CHECK_*). done == a check has completed; latest is
+	// the release string; outdated == a newer release exists. Absent (done ==
+	// false) on daemons that have not checked or lack ENABLE_VERSION_CHECK.
 	bool version_check_done = false;
 	bool version_check_outdated = false;
 	std::string version_check_latest;
 	std::uint64_t version_check_timestamp = 0;
 };
 
-// ECID-keyed file map + hash→ECID index in lockstep. The index is
-// maintained inline on every emplace/erase so the obvious lookup
-// directions both stay O(1) avg without a per-tick rebuild pass:
-//  * ECID → entry via std::unordered_map::find (file_map[]).
-//  * 32-char hex MD4 hash + role → ECID via FindDownloadEcidByHash /
+// ECID-keyed file map + hash->ECID index in lockstep. The index is maintained
+// inline on every emplace/erase so both lookup directions stay O(1) avg without
+// a per-tick rebuild:
+//  * ECID -> entry via std::unordered_map::find (file_map[]).
+//  * 32-char hex MD4 hash + role -> ECID via FindDownloadEcidByHash /
 //    FindSharedEcidByHash (one index per role).
 //
 // One index per role, not one overall, because a hash does NOT name a single
 // file here. A part file and the completed copy someone dropped into a shared
 // folder are two amuled objects with two ECIDs and the same hash, and this map
-// holds both. aMule keeps them apart by having a list per role
-// (CKnownFileList and CSharedFileList are each hash-keyed and de-duplicate on
-// insert, so neither ever holds two files under one hash); this map merges the
-// roles, so it has to carry the role in the key instead. With a single index
-// whichever entry was filed last won the slot and the other became
-// unreachable while still sitting in the map (#1161, reported as #1157).
-//
-// Walkers reach in via find()/emplace()/erase()/begin()/end() — the
-// same surface they had when this was a raw std::map<uint32_t,
-// FileSnapshot>&. The wrapper intercepts the two mutations that move
-// hashes around and keeps the index consistent.
+// holds both. aMule keeps them apart with a list per role; this map merges the
+// roles, so it carries the role in the key instead. With a single index
+// whichever entry was filed last won the slot and the other became unreachable
+// while still sitting in the map (#1161, reported as #1157).
 //
 // Invariant: `hash`, `is_downloading` and `is_shared` are what the indexes are
 // built from, so they are not assigned through the iterator -- go through
@@ -1550,8 +1328,7 @@ struct StatusSnapshot
 //
 // Invariant: an entry's key IS its FileSnapshot::ecid, enforced by emplace()
 // rather than left to the caller. A snapshot filed under one id but carrying
-// another silently breaks every reader that resolves via find() and then
-// trusts what it gets back -- /clients' file hashes among them.
+// another silently breaks every reader that resolves via find().
 class FileMap
 {
 public:
@@ -1568,9 +1345,9 @@ public:
 	std::size_t size() const { return m_files.size(); }
 	bool empty() const { return m_files.empty(); }
 
-	// By-value param so callers can pass either an lvalue (copies) or
-	// rvalue (moves) with the same call site — std::unordered_map's
-	// variadic emplace is too liberal for our index-keeping discipline.
+	// By-value param so callers can pass either an lvalue (copies) or rvalue
+	// (moves) with the same call site -- std::unordered_map's variadic emplace
+	// is too liberal for our index-keeping discipline.
 	std::pair<iterator, bool> emplace(std::uint32_t ecid, FileSnapshot f)
 	{
 		// The key wins -- readers resolve by it. See the invariant above.
@@ -1582,9 +1359,9 @@ public:
 		return r;
 	}
 
-	//! Assign `hash` on an existing entry and re-file it. The refresher can
-	//! learn a hash after the insert (a partfile frame with HASH suppressed,
-	//! then a knownfile frame carrying it), and the index has to follow.
+	//! Assign `hash` on an existing entry and re-file it. The refresher can learn
+	//! a hash after the insert (a partfile frame with HASH suppressed, then a
+	//! knownfile frame carrying it), and the index has to follow.
 	void SetHash(iterator it, std::string hash)
 	{
 		if (it == m_files.end() || it->second.hash == hash)
@@ -1687,34 +1464,29 @@ private:
 	index_type m_shared_by_hash;
 };
 
-// One State instance per amuleapi process. The mutex protects every
-// member field; refresh swaps the whole struct under it, handlers
-// read the substructs they need under it.
+// One State instance per amuleapi process. The mutex protects every member;
+// refresh swaps the whole struct under it, handlers read what they need.
 class CState
 {
 public:
-	// True once the refresher has completed at least one successful
-	// tick. Until then, the /status endpoint returns 503 with
-	// `ec_unavailable` so clients can tell "amuleapi is up but amuled
-	// isn't responding" apart from a hard 5xx.
+	// True once the refresher has completed at least one successful tick. Until
+	// then /status returns 503 with `ec_unavailable`, so clients can tell
+	// "amuleapi is up but amuled is not responding" apart from a hard 5xx.
 	bool HasFirstSnapshot() const;
 
-	// Wall-clock at which the last successful tick completed. Used
-	// to populate `snapshot_at` / `snapshot_at_unix` on every list
-	// response.
+	// Wall-clock at which the last successful tick completed. Populates
+	// `snapshot_at` / `snapshot_at_unix` on every list response.
 	std::time_t SnapshotAt() const;
 
-	// True iff the most recent tick succeeded. False after a tick
-	// failed (EC timeout / disconnect); the refresher keeps the
-	// stale snapshot for clients but flips this flag.
+	// True iff the most recent tick succeeded. The refresher keeps the stale
+	// snapshot for clients after a failed tick but flips this flag.
 	bool EcConnected() const;
 
 	StatusSnapshot Status() const;
 	KadSnapshot Kad() const;
-	// One-shot snapshot of the four scalars /api/v0/status composes
-	// from. Taken under a single shared_lock so the four pieces
-	// describe the same refresher tick — no risk of `status` and
-	// `kad` straddling a tick boundary.
+	// One-shot snapshot of the four scalars /api/v0/status composes from, taken
+	// under a single shared_lock so they describe the same refresher tick -- no
+	// risk of `status` and `kad` straddling a tick boundary.
 	struct DashboardSnapshot
 	{
 		StatusSnapshot status;
@@ -1724,59 +1496,37 @@ public:
 	};
 	DashboardSnapshot Dashboard() const;
 	PreferencesSnapshot Preferences() const;
-	// Full snapshot of the amule log lines (oldest-first). API
-	// handlers slice the tail before serialising via the
-	// `?tail=N` query param.
+	// Full snapshot of the amule log lines (oldest-first). Handlers slice the
+	// tail before serialising via `?tail=N`.
 	std::vector<std::string> AmuleLog() const;
 	//! The lines from `first` on, plus the current total, under one lock. A
 	//! `first` past the end gives an empty tail, which with `total` is how the
-	//! caller sees a truncation. Copies nothing when nothing was appended,
-	//! which the per-tick log diff needs and AmuleLog() cannot do.
-	//! `generation`, when asked for, is read under the same lock as the window
-	//! and is bumped by every ClearAmuleLog(). Size alone cannot detect a
-	//! clear: a buffer cleared and refilled past its old length between two
-	//! ticks looks like growth, and the diff would then publish a mid-buffer
-	//! slice as a tail. Taking it here rather than from a second call is what
-	//! keeps a concurrent DELETE from tearing the pair.
+	//! caller sees a truncation. Copies nothing when nothing was appended.
+	//!
+	//! `generation`, when asked for, is read under the same lock and is bumped by
+	//! every ClearAmuleLog(). Size alone cannot detect a clear: a buffer cleared
+	//! and refilled past its old length between two ticks looks like growth, and
+	//! the diff would then publish a mid-buffer slice as a tail.
 	std::vector<std::string> AmuleLogFrom(
 		std::size_t first, std::size_t &total, std::uint64_t *generation = nullptr) const;
 	ServerInfoLog ServerInfo() const;
 
-	// Flat list views. Reads the ECID-keyed map under shared_lock and
-	// returns a copy of the snapshot values in unordered_map iteration
-	// order — bucket-dependent, NOT stable across ticks. Consumers
-	// that want a specific order sort on their side (by name / date /
-	// progress / etc.).
-	//
-	// The role-filtered views are gone: no reader wanted whole snapshots copied
-	// out. Filter `m_files` on the role flag inside WithFiles() instead.
-	//! Read the unified file map in place, under the shared lock. Same contract
-	//! as WithKnownClients: the callback must not call back into CState, nor
-	//! retain the reference. For readers wanting a few fields per file, or
-	//! pointers to sort and page -- a FileSnapshot is 848 bytes plus a heap
-	//! allocation per string, so copying the collection out is never cheap.
 	// Re-entrancy detector for the callback accessors below.
 	//
 	// Every WithX() / MutateX() runs a caller-supplied callback while holding
 	// m_mu. Calling back into the same CState from inside one takes that
-	// non-recursive std::shared_timed_mutex a second time: undefined
-	// behaviour, and in practice a hang -- immediately on the exclusive
-	// paths, and on the shared ones as soon as a writer is queued, because
-	// the implementation stops admitting new readers to avoid starving it.
+	// non-recursive std::shared_timed_mutex a second time: undefined behaviour,
+	// and in practice a hang -- immediately on the exclusive paths, and on the
+	// shared ones as soon as a writer is queued, because the implementation
+	// stops admitting new readers to avoid starving it.
 	//
-	// The rule was documentation only, so a violation surfaced as a wedged
-	// daemon under load rather than as a test failure -- the callbacks are
-	// pure today, but nothing stopped the next edit from reaching for
-	// m_state. Enforced in Release as well as Debug, and aborting rather
-	// than returning, for the reason the Session dtor gives in
-	// HttpServer.cpp: assert() is stripped by NDEBUG, and the alternative
-	// here is not a wrong answer but a process that stops responding with
-	// nothing in the log. The thread would deadlock on the next line
-	// regardless; this way it leaves a message and a core instead.
+	// Enforced in Release as well as Debug, and aborting rather than returning:
+	// assert() is stripped by NDEBUG, and the failure here is not a wrong answer
+	// but a process that stops responding with nothing in the log.
 	//
-	// Constructed BEFORE the lock, deliberately. A re-entrant call blocks on
-	// the mutex it can never obtain, so a guard placed after the lock would
-	// never run for the one case it exists to catch.
+	// Constructed BEFORE the lock, deliberately. A re-entrant call blocks on the
+	// mutex it can never obtain, so a guard placed after the lock would never run
+	// for the one case it exists to catch.
 	class ReentryGuard
 	{
 	public:
@@ -1789,6 +1539,10 @@ public:
 		const CState *m_prev;
 	};
 
+	//! Read the unified file map in place, under the shared lock. The callback
+	//! must not call back into CState, nor retain the reference. A FileSnapshot
+	//! is 848 bytes plus a heap allocation per string, so copying the collection
+	//! out is never cheap.
 	template <class F> void WithFiles(F &&fn) const
 	{
 		const ReentryGuard guard(this);
@@ -1796,27 +1550,21 @@ public:
 		fn(static_cast<const FileMap &>(m_files));
 	}
 
-	// Full peer list (all upload_state values, including queue
-	// waiters, idle peers, and banned). Backs /clients.
-	// Consumers query /clients and filter by role on their side rather
-	// than asking for a pre-filtered upload view.
+	// Full peer list (all upload_state values, including queue waiters, idle
+	// peers and banned). Backs /clients; consumers filter by role.
 	std::vector<ClientSnapshot> Clients() const;
 
 	// --- Known clients (the daemon's credit store) -------------------------
 	//
-	// Fetched once, then maintained: the refresher folds every tick's live
-	// peers in, so the store stays current without ever being re-read. What
-	// only a refetch could give is the expiry prune the core applies at its
-	// own startup, and that cannot happen underneath us: HandleEcConnectionLost
-	// shuts amuleapi down the moment the EC socket drops, so the process never
-	// attaches to a second core. The store therefore lives for the life of the
-	// process, with no invalidation path -- deliberately, since the obvious
-	// place to add one (ResetLists, which fires on a failed tick against a live
-	// socket) would refetch the whole store for a single null tick.
+	// Fetched once, then maintained: the refresher folds every tick's live peers
+	// in, so the store stays current without ever being re-read. What only a
+	// refetch could give is the expiry prune the core applies at its own startup,
+	// and that cannot happen underneath us: HandleEcConnectionLost shuts amuleapi
+	// down the moment the EC socket drops, so the process never attaches to a
+	// second core. The store therefore lives for the life of the process.
 	//
-	// Held rather than copied out: this is the whole store, tens of thousands
-	// of records, so a by-value accessor would cost more per request than the
-	// EC roundtrip it saves. Readers run under the shared lock instead.
+	// Held rather than copied out: this is the whole store, tens of thousands of
+	// records, so a by-value accessor would cost more than the roundtrip it saves.
 	bool KnownClientsLoaded() const;
 	//! Install the first fetch and reconcile it against the current peers.
 	void SetKnownClients(std::vector<KnownClientSnapshot> &&rows);
@@ -1854,8 +1602,7 @@ public:
 	// when nothing came back, so evicted ids are not re-requested forever.
 	std::uint32_t ChatCursor() const;
 	// Results / progress for one search. Every caller names a concrete
-	// daemon-allocated id — there is no implicit "current search" — and an
-	// unknown id yields an empty list / idle progress. HasSearch
+	// daemon-allocated id -- there is no implicit "current search". HasSearch
 	// distinguishes "unknown id" (404) from "known but empty".
 	std::vector<SearchResult> Search(std::uint32_t search_id) const;
 	SearchProgressSnapshot SearchProgress(std::uint32_t search_id) const;
@@ -1871,44 +1618,34 @@ public:
 	std::time_t SearchStartedAt(std::uint32_t search_id) const;
 	// Slots the refresher must still poll (progress.active).
 	std::vector<std::uint32_t> ActiveSearchIds() const;
-	// Every slot the daemon could still speak for: attached, active or not.
-	// The tick polls THIS set for expiry, not ActiveSearchIds(), because a
-	// finished search is exactly the one the daemon's ring drops first and
-	// the one whose results we are keeping. Naming them in the progress
-	// union also refreshes their LRU entry daemon-side, which is what the
-	// daemon means by "the searches a client still has open".
+	// Every slot the daemon could still speak for: attached, active or not. The
+	// tick polls THIS set for expiry, not ActiveSearchIds(), because a finished
+	// search is exactly the one the daemon's ring drops first and the one whose
+	// results we are keeping. Naming them in the progress union also refreshes
+	// their LRU entry daemon-side.
 	//
-	// Empty is also the gate for both union polls: with no attached slot
-	// there is nothing the daemon could answer about, and sending either
-	// request would be a roundtrip a second that can never return anything.
-	// This replaced a separate HasAnySearch() predicate -- the same
-	// !detached test spelled a second way, which is what drifts -- and the
-	// vector it was introduced to avoid is now built for the progress union
-	// regardless.
+	// Empty is also the gate for both union polls: with no attached slot there is
+	// nothing the daemon could answer about.
 	std::vector<std::uint32_t> AttachedSearchIds() const;
 	// Every live slot id, for the SSE per-search diff.
 	std::vector<std::uint32_t> AllSearchIds() const;
 	// Find a result carrying this (already-lowercased) hash across ALL open
-	// searches — the hash-keyed comments endpoints are search-agnostic. The
+	// searches -- the hash-keyed comments endpoints are search-agnostic. The
 	// parent owns any fetched Kad notes, so it matches ahead of its children.
-	// `owner_search_id` reports which slot the hit came from, so the caller
-	// can refresh that slot before reading (see ClaimSearchRefresh).
+	// `owner_search_id` reports which slot the hit came from.
 	bool FindSearchResultByHash(
 		const std::string &hash_hex, SearchResult &out, std::uint32_t *owner_search_id) const;
-	// Take the right to refresh one search's results from the daemon, for
-	// the read paths that must not serve a frozen snapshot.
+	// Take the right to refresh one search's results from the daemon, for the
+	// read paths that must not serve a frozen snapshot.
 	//
 	// Returns true (and stamps the slot as fetched NOW) only when the slot
-	// exists, is NOT active, and its last fetch is older than `ttl`. Active
-	// slots are excluded because the tick already refreshes them every
-	// second. Stamping before the fetch rather than after is deliberate: it
-	// is what makes this a claim, so two concurrent readers of the same
-	// finished search issue one EC roundtrip between them, not two.
+	// exists, is NOT active, and its last fetch is older than `ttl`. Stamping
+	// before the fetch is what makes this a claim: two concurrent readers of the
+	// same finished search issue one EC roundtrip between them, not two.
 	bool ClaimSearchRefresh(std::uint32_t search_id, std::chrono::milliseconds ttl);
 
-	// Categories aren't ECID-keyed (they come in via the
-	// preferences packet as an indexed array); keep them as a plain
-	// vector copied out under the shared lock.
+	// Categories are not ECID-keyed (they arrive in the preferences packet as an
+	// indexed array), so they stay a plain vector copied out under the lock.
 	std::vector<CategorySnapshot> Categories() const;
 
 	// /stats/tree returns the recursive tree as a single bare object.
@@ -1916,75 +1653,61 @@ public:
 	// /stats/graphs/{graph} reads one series out of the bundle.
 	StatsGraphs Graphs() const;
 
-	// Look up a single file by 32-char hex hash, then check the role.
-	// Returns true on hit + role match, false on miss; on miss `out`
-	// is left untouched. Used by /downloads/{hash} (download role) and
-	// /shared/{hash} (shared role) — both inspect the same m_files map.
+	// Look up a single file by 32-char hex hash, then check the role. Returns
+	// true on hit + role match; on miss `out` is left untouched. /downloads/{hash}
+	// and /shared/{hash} both inspect the same m_files map through these.
 	bool FindDownload(const std::string &hash_hex, FileSnapshot &out) const;
-	// Part count of the download with this hash, or 0 when there is none (or
-	// it has no size yet). Exists so a per-client loop can ask the cheap
-	// question without FindDownload's full FileSnapshot copy -- strings plus
-	// the gap / source / comment vectors, per source, per tick.
+	// Part count of the download with this hash, or 0 when there is none (or it
+	// has no size yet). Exists so a per-client loop can ask the cheap question
+	// without FindDownload's full FileSnapshot copy, per source, per tick.
 	std::uint64_t DownloadPartCount(const std::string &hash_hex) const;
 	bool FindShared(const std::string &hash_hex, FileSnapshot &out) const;
 
-	// ECID-keyed counterparts. Used internally — there is no
-	// /downloads/{ecid} or /shared/{ecid} path; the wire surface is
-	// hash-only. CClientList::ApplyGetUpdate also reaches in here when
-	// resolving EC_TAG_CLIENT_UPLOAD_FILE.
+	// ECID-keyed counterparts, used internally -- there is no /downloads/{ecid}
+	// or /shared/{ecid} path. CClientList::ApplyGetUpdate also reaches in here
+	// when resolving EC_TAG_CLIENT_UPLOAD_FILE.
 	bool FindDownloadByEcid(std::uint32_t ecid, FileSnapshot &out) const;
 	bool FindSharedByEcid(std::uint32_t ecid, FileSnapshot &out) const;
 
-	// INC-mode delta application. The refresher takes the unique_lock
-	// once per EC roundtrip, then calls a callback with a mutable
-	// reference to the unified ECID-keyed map; the callback walks the
-	// EC response and upserts/removes individual entries plus role
-	// flags. One unique acquisition per tick rather than N — reader
-	// latency stays bounded by the parse loop, not by N independent
-	// acquisitions. Both MutateDownloads and MutateShared operate on
-	// the SAME m_files map; the callback decides which role to flip.
-	// MutateDownloads/Shared hand out the FileMap wrapper, which keeps
-	// its internal hash→ECID index in sync on every emplace/erase.
+	// INC-mode delta application. The refresher takes the unique_lock once per EC
+	// roundtrip, then calls a callback with a mutable reference to the unified
+	// ECID-keyed map. One unique acquisition per tick rather than N, so reader
+	// latency stays bounded by the parse loop. Both MutateDownloads and
+	// MutateShared operate on the SAME m_files map; the callback decides which
+	// role to flip, and FileMap keeps its hash->ECID index in sync.
 	void MutateDownloads(const std::function<void(FileMap &)> &fn);
 	void MutateShared(const std::function<void(FileMap &)> &fn);
 	//! Clients only. Reach for MutateClientsWithFiles below when the callback
 	//! also needs the file map, rather than pairing this with WithFiles: that
-	//! pair is two acquisitions where one does, which is what the clients
-	//! walker was moved off.
+	//! pair is two acquisitions where one does.
 	void MutateClients(const std::function<void(std::map<std::uint32_t, ClientSnapshot> &)> &fn);
 	//! Clients plus a read-only view of the file map, under the one acquisition
 	//! this was already taking. The clients walker resolves ECIDs against the
-	//! files but cannot fetch them itself: m_mu is a single non-recursive
-	//! mutex, so reaching back into CState from inside the callback trips
-	//! ReentryGuard. Second argument carries the same borrow contract as
-	//! WithFiles -- valid for the call only, never retained.
+	//! files but cannot fetch them itself: m_mu is a single non-recursive mutex,
+	//! so reaching back into CState from the callback trips ReentryGuard.
 	void MutateClientsWithFiles(
 		const std::function<void(std::map<std::uint32_t, ClientSnapshot> &, const FileMap &)> &fn);
 	void MutateServers(const std::function<void(std::map<std::uint32_t, ServerSnapshot> &)> &fn);
 	void MutateFriends(const std::function<void(std::map<std::uint32_t, FriendSnapshot> &)> &fn);
-	// The walker replaces the whole session vector each tick rather than
-	// merging: the daemon's reply IS the complete set, and a session missing
-	// from it was closed (that absence is exactly how every client learns of
-	// a close, so merging would resurrect closed conversations).
+	// The walker replaces the whole session vector each tick rather than merging:
+	// the daemon's reply IS the complete set, and a session missing from it was
+	// closed -- merging would resurrect closed conversations.
 	void MutateChats(
 		const std::function<void(std::vector<ChatSessionSnapshot> &, std::uint32_t &cursor)> &fn);
 	// Mutate one search's result map (the refresher's per-tick full-fetch
 	// overwrite). No-op if the id names no live slot.
 	void MutateSearch(std::uint32_t search_id,
 		const std::function<void(std::map<std::uint32_t, SearchResult> &)> &fn);
-	// Mutate every search slot and the ECID->search_id index together, under
-	// one exclusive lock. The incremental union poll needs both: a diffed tag
-	// names no search, so the index resolves it, and a result that moves or
-	// disappears has to leave the map and the index in step. Handing out both
-	// halves to one callback is what makes that atomic.
+	// Mutate every search slot and the ECID->search_id index together, under one
+	// exclusive lock. The incremental union poll needs both: a diffed tag names
+	// no search, so the index resolves it, and a result that moves or disappears
+	// has to leave the map and the index in step.
 	void MutateAllSearches(const std::function<void(std::map<std::uint32_t, SearchSlot> &,
 			std::map<std::uint32_t, std::uint32_t> &)> &fn);
 
-	// Wholesale reset paths. Called by the refresher after a
-	// MarkTickFailure → MarkTickSuccess transition (the server's
-	// CValueMap was reset on reconnect; stale entries that vanished
-	// during the disconnect window would otherwise live forever in
-	// the cache).
+	// Wholesale reset paths. Called by the refresher after a MarkTickFailure ->
+	// MarkTickSuccess transition: the server's CValueMap was reset on reconnect,
+	// so stale entries that vanished during the disconnect would live forever.
 	void ResetLists();
 
 	// Refresher-side write paths.
@@ -1992,47 +1715,34 @@ public:
 	void WriteKad(KadSnapshot k);
 	void WritePreferences(PreferencesSnapshot p);
 	void WriteCategories(std::vector<CategorySnapshot> c);
-	// Append one or more new amule-log lines to the ring; trims oldest
-	// entries when capacity is exceeded. Called once per refresher
-	// tick with the lines drained from EC_TAG_STATS_LOGGER_MESSAGE.
+	// Append one or more new amule-log lines to the ring, trimming oldest entries
+	// when capacity is exceeded. Once per refresher tick.
 	void AppendAmuleLog(std::vector<std::string> new_lines);
-	// Drop every cached amule-log line. Called by DELETE /logs/amule
-	// after the EC_OP_RESET_LOG roundtrip — the refresher only appends
-	// (it has no equivalent of "shrink to amuled's current count"), so
-	// the in-process cache MUST be cleared explicitly or the next GET
-	// will keep returning the pre-reset lines. The next refresher tick
-	// resumes appending from amuled's now-empty buffer.
+	// Drop every cached amule-log line. Called by DELETE /logs/amule after the
+	// EC_OP_RESET_LOG roundtrip -- the refresher only appends, with no equivalent
+	// of "shrink to amuled's current count", so the in-process cache MUST be
+	// cleared explicitly or the next GET keeps returning the pre-reset lines.
 	void ClearAmuleLog();
 	void WriteServerInfo(ServerInfoLog s);
 	// Called by POST /search with the daemon-allocated search_id. Creates (or
-	// resets) that search's slot: clears its results and marks it active=true
-	// with the requested `kind` and `query`. The refresher then polls
-	// EC_OP_SEARCH_RESULTS / _PROGRESS for it each tick, mapping
-	// EC_TAG_SEARCH_LIFECYCLE_STATE into `complete` / `active`.
+	// resets) that search's slot and marks it active. The refresher then polls
+	// EC_OP_SEARCH_RESULTS / _PROGRESS for it each tick.
 	void MarkSearchStarted(std::uint32_t search_id, const std::string &kind, const std::string &query);
-	// Seeds a slot for a search this session did NOT start itself -- a
-	// search another client, or the monolithic GUI, started. Called
-	// on-demand from the read paths on a cache miss, after a one-off
-	// EC_OP_SEARCH_LIST confirms the core actually holds it (deliberately
-	// NOT a per-tick refresher poll: that would pay an EC roundtrip every
-	// tick, forever, to serve something that happens rarely). Unlike
-	// MarkSearchStarted it is idempotent -- a search already known
-	// (self-started or previously discovered) is left untouched rather than
-	// having its accumulated results/progress reset.
+	// Seeds a slot for a search this session did NOT start -- another client's,
+	// or the monolithic GUI's. Called on-demand from the read paths on a cache
+	// miss, after a one-off EC_OP_SEARCH_LIST confirms the core holds it
+	// (deliberately NOT a per-tick poll: that would pay an EC roundtrip every
+	// tick, forever, for something that happens rarely). Unlike
+	// MarkSearchStarted it is idempotent.
+	//
 	// `active` / `complete` come from the lifecycle state the same
 	// EC_OP_SEARCH_LIST entry carries. Seeding them rather than assuming
 	// "active" matters because callers gate on them: POST /search/{id}/more
-	// rejects a finished search, and would otherwise accept one for the tick
-	// or so it took to be corrected. A slot seeded inactive is not polled by
-	// the tick, which is fine -- the read paths refresh an inactive slot on
-	// demand (ClaimSearchRefresh).
+	// rejects a finished search, and would otherwise accept one until corrected.
 	//
-	// `reported_percent` is the daemon's own percent for this search when the
-	// EC_OP_SEARCH_LIST entry carried one, and -1 when it did not. A daemon
-	// older than that tag reports nothing, and the fallback then has to be
-	// derived: 100 for a finished search (true by definition), 0 for a
-	// running one (the tick corrects it within a second, and inventing a
-	// number would flash a wrong one meanwhile).
+	// `reported_percent` is the daemon's own percent when the entry carried one,
+	// and -1 when it did not. The fallback is then derived: 100 for a finished
+	// search, 0 for a running one (the tick corrects it within a second).
 	/**
 	 * Mark a slot as no longer backed by the daemon. Freezes its results:
 	 * see SearchSlot::detached. Idempotent; a no-op for an unknown id.
@@ -2065,14 +1775,12 @@ public:
 	void WriteStatsTree(StatsTreeNode t);
 	void WriteGraphs(StatsGraphs g);
 	void MarkTickSuccess();
-	// Monotonic counter advanced by every successful refresh, from the
-	// background loop and from the inline refreshes that mutating handlers
-	// run. `snapshot_at` cannot play this role: it is whole seconds, so two
-	// refreshes inside one second are indistinguishable, and it is stamped
-	// only by the loop, so a mutation could change a body while it stood
-	// still -- which answered the next conditional GET with 304 for content
-	// that had just changed. Anything keyed on "has the state moved" wants
-	// this, not the timestamp.
+	// Monotonic counter advanced by every successful refresh, from the background
+	// loop and from the inline refreshes mutating handlers run. `snapshot_at`
+	// cannot play this role: it is whole seconds, so two refreshes inside one
+	// second are indistinguishable, and it is stamped only by the loop, so a
+	// mutation could change a body while it stood still -- answering the next
+	// conditional GET with 304 for content that had just changed.
 	void BumpSnapshotRevision();
 	std::uint64_t SnapshotRevision() const;
 	void MarkTickFailure();
@@ -2093,12 +1801,10 @@ private:
 	KadSnapshot m_kad;
 	PreferencesSnapshot m_preferences;
 	std::vector<CategorySnapshot> m_categories;
-	// Unified ECID-keyed file map. A single entry may participate in
-	// the /downloads view (`is_downloading`), the /shared view
-	// (`is_shared`), or both. See FileSnapshot's header comment for
-	// why the two views share storage. FileMap also owns a hash→ECID
-	// index, maintained inline on every emplace/erase so /downloads/{hash}
-	// + /shared/{hash} lookups stay O(1) avg without a per-tick rebuild.
+	// Unified ECID-keyed file map. A single entry may participate in the
+	// /downloads view (`is_downloading`), the /shared view (`is_shared`), or
+	// both -- see FileSnapshot's header comment. FileMap also owns the hash->ECID
+	// index, maintained inline on every emplace/erase.
 	FileMap m_files;
 
 	std::map<std::uint32_t, ClientSnapshot> m_clients;
@@ -2106,13 +1812,11 @@ private:
 	// and genuinely empty" from "never fetched".
 	std::vector<KnownClientSnapshot> m_known_clients;
 	// Indices, deliberately, not pointers: the reconcile appends while it
-	// iterates, and a reallocation would dangle anything holding addresses.
-	// Rows are only ever appended for the same reason -- an erase would
-	// invalidate every index past it.
+	// iterates, and a reallocation would dangle anything holding addresses. Rows
+	// are only ever appended for the same reason.
 	//
 	// Keyed on the same lowercase hex the live snapshot uses (both go through
-	// CMD4Hash::Encode().Lower()); a case mismatch would silently give every
-	// peer a second row.
+	// CMD4Hash::Encode().Lower()); a case mismatch would give every peer two rows.
 	std::map<std::string, std::size_t> m_known_of_hash;
 	bool m_known_loaded = false;
 	//! Rows currently flagged connected, so a peer that left is found without
@@ -2144,29 +1848,26 @@ private:
 	std::map<std::uint32_t, std::uint32_t> m_resultOwner;
 	//! Monotonic source for SearchSlot::seq.
 	std::uint64_t m_search_seq = 0;
-	// Ceiling on retained slots. A client that never DELETEs its searches,
-	// or one watching a busy monolithic GUI, would otherwise accumulate a
-	// slot and its whole result map per search for the life of the process:
-	// the daemon's own kMaxEcSearches bounds only the searches it holds for
-	// *this* connection, and detached slots outlive even those.
+	// Ceiling on retained slots. A client that never DELETEs its searches, or one
+	// watching a busy monolithic GUI, would otherwise accumulate a slot and its
+	// whole result map per search for the life of the process: the daemon's own
+	// kMaxEcSearches bounds only the searches it holds for *this* connection.
 	//
-	// Eviction is recoverable, which is why a cap is affordable at all: a
-	// later read of an evicted id misses the cache, re-discovers it via
-	// EC_OP_SEARCH_LIST and re-seeds it in full through FetchOneSearchFull.
-	// Detached slots are preferred as victims anyway, since for those the
-	// daemon has nothing left to re-send and nothing is lost.
+	// Eviction is recoverable, which is why a cap is affordable at all: a later
+	// read of an evicted id misses the cache, re-discovers it via
+	// EC_OP_SEARCH_LIST and re-seeds it through FetchOneSearchFull.
 	//
-	// A soft cap, not a hard bound: an active slot is never a victim, so a
-	// burst of more than this many concurrent searches sits above the cap
-	// until they finish. That is deliberate -- evicting a search still being
-	// polled would drop results the daemon has already marked delivered.
+	// A soft cap, not a hard bound: an active slot is never a victim, so a burst
+	// of more than this many concurrent searches sits above the cap until they
+	// finish -- evicting a search still being polled would drop results the
+	// daemon has already marked delivered.
 	static constexpr std::size_t kMaxSearchSlots = 64;
-	// Trim m_searches back to kMaxSearchSlots, and drop the evicted slots'
-	// entries from m_resultOwner with them. Caller holds the write lock.
+	// Trim m_searches back to kMaxSearchSlots, dropping the evicted slots' entries
+	// from m_resultOwner with them. Caller holds the write lock.
 	//
 	// `exempt_id` is never chosen as a victim: callers evict straight after
-	// inserting, and with every other slot active the freshly-inserted one is
-	// the only eligible victim, so it would evict what it just seeded.
+	// inserting, and with every other slot active the freshly-inserted one would
+	// be the only eligible victim.
 	void EvictSurplusSearchSlotsLocked(std::uint32_t exempt_id = 0);
 };
 

--- a/src/webapi/StaticFs.cpp
+++ b/src/webapi/StaticFs.cpp
@@ -42,11 +42,9 @@ bool ResolveWithinRoot(const std::string &root, const std::string &rel, std::str
 	char root_real[PATH_MAX];
 	char fs_real[PATH_MAX];
 #ifdef _WIN32
-	// _fullpath() is lexical-only (no reparse-point resolution). On
-	// Windows the symlink containment threat model is weaker — symlinks
-	// require elevation and are functionally exotic, so lexical
-	// containment is sufficient for the operator-misconfig case the
-	// rejection step targets.
+	// _fullpath() is lexical-only (no reparse-point resolution). On Windows the
+	// symlink containment threat model is weaker -- symlinks require elevation
+	// -- so lexical containment covers the operator-misconfig case this targets.
 	if (!_fullpath(root_real, root.c_str(), PATH_MAX))
 		return false;
 	const std::string joined = std::string(root_real) + "\\" + rel;
@@ -62,10 +60,9 @@ bool ResolveWithinRoot(const std::string &root, const std::string &rel, std::str
 	if (!realpath(joined.c_str(), fs_real))
 		return false;
 #endif
-	// _fullpath() on Windows preserves a trailing path separator from
-	// its input, which then breaks the prefix comparison below. POSIX
-	// realpath() strips them. Normalise here so the containment check
-	// is platform-agnostic.
+	// _fullpath() on Windows preserves a trailing path separator from its input,
+	// which then breaks the prefix comparison below; POSIX realpath() strips
+	// them. Normalise here so the containment check is platform-agnostic.
 	std::size_t root_len = std::strlen(root_real);
 	while (root_len > 1 && (root_real[root_len - 1] == '/' || root_real[root_len - 1] == '\\')) {
 		root_real[--root_len] = '\0';

--- a/src/webapi/TtlCache.h
+++ b/src/webapi/TtlCache.h
@@ -62,28 +62,23 @@ template <class T> class CTtlCache
 public:
 	using clock_t = std::chrono::steady_clock;
 
-	// Returns a copy of the freshest value. If the cache is fresh,
-	// returns immediately under a brief lock. If stale-or-unset:
-	// one caller becomes the "inflight" worker (drops the lock,
-	// runs fetch, re-takes the lock, stores, broadcasts);
-	// concurrent callers wait on the condvar until inflight clears
-	// and then read the stored value.
+	// Returns a copy of the freshest value. On a hit, immediately under a brief
+	// lock. On a miss, one caller becomes the "inflight" worker (drops the lock,
+	// runs fetch, re-takes it, stores, broadcasts) while concurrent callers wait
+	// on the condvar and then read the stored value.
 	template <class Fetcher> T GetOrFetch(std::chrono::milliseconds ttl, Fetcher fetch)
 	{
 		return GetOrFetch(ttl, fetch, [](const T &) { return true; });
 	}
 
-	// As above, plus a validity predicate on the cached value. A fresh
-	// entry that fails it counts as a miss and is refetched.
+	// As above, plus a validity predicate on the cached value: a fresh entry that
+	// fails it counts as a miss and is refetched.
 	//
-	// This is for endpoints whose EC request is parameterised by the
-	// caller: the cache is unkeyed, so an entry fetched at one parameter
-	// must not be served to a request asking for another. Storing the
-	// parameter inside the cached value and rejecting a mismatch keeps
-	// the single-entry cache -- a caller with a fixed parameter (every
-	// real one) still pays one round trip per TTL, while callers
-	// alternating parameters each pay their own. The alternative, a map
-	// keyed by a caller-supplied value, is unbounded by construction.
+	// This is for endpoints whose EC request is parameterised by the caller: the
+	// cache is unkeyed, so an entry fetched at one parameter must not be served
+	// to a request asking for another. Storing the parameter inside the cached
+	// value keeps the single-entry cache; a map keyed by a caller-supplied value
+	// would be unbounded by construction.
 	template <class Fetcher, class Validator>
 	T GetOrFetch(std::chrono::milliseconds ttl, Fetcher fetch, Validator is_valid)
 	{
@@ -95,18 +90,15 @@ public:
 				return m_value;
 			}
 			if (m_inflight) {
-				// Another caller is doing the EC roundtrip. Wait
-				// for them to finish, then re-check freshness in
-				// case yet another fetch is needed (e.g. the
-				// inflight result raced our TTL clamp because
-				// fetch was slow).
+				// Another caller is doing the EC roundtrip. Wait for them to finish,
+				// then re-check freshness in case yet another fetch is needed -- the
+				// inflight result can race our TTL clamp when fetch was slow.
 				m_cv.wait(lk, [this] { return !m_inflight; });
 				continue;
 			}
-			// We're the inflight worker. Claim the slot, drop the
-			// lock, do the fetch unguarded so peers can park on
-			// the condvar without our long EC call serialising
-			// them on the cache mutex.
+			// We are the inflight worker. Claim the slot, drop the lock, and fetch
+			// unguarded so peers can park on the condvar rather than serialising on
+			// the cache mutex behind our long EC call.
 			m_inflight = true;
 			lk.unlock();
 			T fetched;
@@ -129,10 +121,9 @@ public:
 				m_inflight = false;
 			}
 			m_cv.notify_all();
-			// Re-acquire to read the value under the lock so
-			// the contract (returned T is a stable copy of the
-			// just-stored snapshot) holds in the face of a racing
-			// Invalidate.
+			// Re-acquire to read the value under the lock, so the contract (the
+			// returned T is a stable copy of the just-stored snapshot) holds in the
+			// face of a racing Invalidate.
 			std::lock_guard<std::mutex> g(m_mu);
 			return m_value;
 		}


### PR DESCRIPTION
Comment-only sweep of `src/webapi`: 31 files, 9551 -> 6928 comment lines (-2623, -27.5%). Figures are over the touched files only; licence headers are untouched and form a floor in every count.

Part of a tree-wide pass split by scope. The scopes touch disjoint files, so this one merges independently of the others.

**What came out**

- Stale claims corrected against the code: `SendMediaRefresh` documented a 501 where the handler answers 503; `Refresher.h` said the `EC_TAG_CLIENT` and `EC_TAG_FRIEND` containers were ignored, when both are consumed into `/clients` and `/friends`; `SharedContent.h` said there was no Content-Security-Policy anywhere in `src/webapi`, which `Api.cpp` sets.
- An orphaned block sitting immediately before `} // namespace` with no function under it.
- Review-thread leftovers, such as "landed earlier in this PR" and author/PR annotations.
- Long restatements of the adjacent code.

**What stayed**

Anything recording something the code cannot tell you by itself: a protocol constraint, a wire-format rule, a platform quirk, the reason a guard exists, the why behind a non-obvious default.

**Verification**

- Every file mechanically checked comment-only: comments stripped and whitespace normalised on both sides, then diffed against master. 31/31 identical, so no code changes.
- clang-format 18, the version CI pins, clean over all of `src/` and `unittests/`.
- Builds clean on macOS. Nothing here changes code, so the build cannot differ per scope.

**Reviewing**

`git diff master -w` is the whole change; there is no code to read.
