### PR TITLE
chore(src): trim verbose comment blocks in the core and GUI

### DIFF
--- a/src/AppImageIntegration.cpp
+++ b/src/AppImageIntegration.cpp
@@ -51,10 +51,9 @@
 namespace
 {
 
-// AppImage's AppRun exports both env vars: APPIMAGE = the original .AppImage
-// path the user invoked; APPDIR = the squashfs mount point. We need both —
-// APPIMAGE for the rewritten Exec= line so launcher-clicks invoke the image
-// at its real on-disk path, APPDIR to find the bundled .desktop and icons.
+// AppRun exports both env vars: APPIMAGE is the original .AppImage path the user
+// invoked, APPDIR the squashfs mount point. Both are needed -- APPIMAGE for the
+// rewritten Exec= line, APPDIR to find the bundled .desktop and icons.
 wxString GetAppImagePath()
 {
 	const char *env = getenv("APPIMAGE");
@@ -67,10 +66,9 @@ wxString GetAppDir()
 	return env ? wxString::FromUTF8(env) : wxString();
 }
 
-// Resolve the XDG user data dir per the basedir spec. Don't derive from
-// wxStandardPaths::GetUserDataDir() — wx returns "$HOME/.<appname>" for
-// aMule (legacy dot-prefixed dir), not the canonical XDG location, so
-// any path arithmetic on top of it lands in the wrong tree.
+// Resolve the XDG user data dir per the basedir spec. Not derived from
+// wxStandardPaths::GetUserDataDir(), which returns the legacy "$HOME/.<appname>"
+// for aMule rather than the canonical XDG location.
 wxString GetUserDataHome()
 {
 	const char *xdg = getenv("XDG_DATA_HOME");
@@ -119,12 +117,11 @@ bool InstallDesktopFile(
 	for (size_t i = 0; i < in.GetLineCount(); ++i) {
 		wxString line = in[i];
 		if (line.StartsWith(wxT("Exec="))) {
-			// Quote the AppImage path so spaces survive. %U (URL list)
-			// matches the shipped org.amule.aMule.desktop; aMule accepts
-			// ed2k:// / magnet: URLs (via scheme handler clicks) plus
-			// .emulecollection paths and file:// URLs, and takes any
-			// number of them. Must stay in step with the shipped file:
-			// it was %F once, which silently swallowed URL clicks.
+			// Quote the AppImage path so spaces survive. %U matches the shipped
+			// org.amule.aMule.desktop: aMule accepts ed2k:// and magnet: URLs plus
+			// .emulecollection paths and file:// URLs, any number of them. Must stay
+			// in step with the shipped file, which was %F once and silently
+			// swallowed URL clicks.
 			line = wxT("Exec=\"") + appimagePath + wxT("\" %U");
 		} else if (line.StartsWith(wxT("TryExec="))) {
 			line = wxT("TryExec=") + appimagePath;
@@ -185,13 +182,11 @@ bool InstallIcons(const wxString &appdir, const wxString &userIconsDir)
 	return anyOk;
 }
 
-// Copy the bundled shared-mime-info package into
-// ~/.local/share/mime/packages so the desktop learns what a
-// .emulecollection is. Without it the file is sniffed as text/plain or
-// application/octet-stream, the MimeType= line in the installed .desktop
-// never matches, and aMule is absent from the file manager's "Open With".
-// A system package install gets this from CMake instead; an AppImage has
-// no packager, so we do it ourselves.
+// Copy the bundled shared-mime-info package into ~/.local/share/mime/packages so
+// the desktop learns what a .emulecollection is. Without it the file is sniffed
+// as text/plain or application/octet-stream, the MimeType= line never matches,
+// and aMule is absent from the file manager's "Open With". A system package gets
+// this from CMake; an AppImage has no packager.
 bool InstallMimePackage(const wxString &appdir, const wxString &userMimePackagesDir)
 {
 	const wxString source = appdir + wxT("/usr/share/mime/packages/org.amule.aMule.xml");
@@ -214,14 +209,13 @@ bool InstallMimePackage(const wxString &appdir, const wxString &userMimePackages
 	return true;
 }
 
-// Run a helper with its arguments passed as an argv vector rather than as
-// one command string.
+// Run a helper with its arguments passed as an argv vector rather than as one
+// command string.
 //
 // The string form of wxExecute does its own tokenising and hands the quote
-// characters through to the program, so `cmd "/home/me/dir"` arrives as a
-// path that literally starts with a quote and the helper fails with
-// "directory does not exist". Quoting was there to survive spaces in $HOME;
-// argv gives us that for free and without a shell.
+// characters through to the program, so `cmd "/home/me/dir"` arrives as a path
+// that literally starts with a quote. Quoting was there to survive spaces in
+// $HOME; argv gives that for free and without a shell.
 static void RunHelper(const wxString &program, const wxArrayString &args)
 {
 	std::vector<wxCharBuffer> storage;
@@ -236,13 +230,11 @@ static void RunHelper(const wxString &program, const wxArrayString &args)
 	}
 	argv.push_back(nullptr);
 
-	// These are system binaries, and AppRun has put the AppImage's own
-	// library directory at the front of LD_LIBRARY_PATH for our sake. A
-	// child inheriting that loads our bundled glib rather than the host's
-	// and dies before doing any work: update-mime-database exits with
-	// "undefined symbol: g_string_free_and_steal" against a host glib newer
-	// than the bundled copy. Same class of failure as #334, so reuse the
-	// helper written for it rather than stripping the paths again here.
+	// These are system binaries, and AppRun has put the AppImage's own library
+	// directory at the front of LD_LIBRARY_PATH for our sake. A child inheriting
+	// that loads our bundled glib rather than the host's and dies before doing any
+	// work -- update-mime-database exits with "undefined symbol:
+	// g_string_free_and_steal". Same class of failure as #334, so reuse its helper.
 	wxExecuteEnv execEnv;
 	const bool sanitized = AppImageEnv::GetSanitizedExecEnv(execEnv);
 	const int flags = wxEXEC_SYNC | wxEXEC_NODISABLE | wxEXEC_NOEVENTS;
@@ -250,16 +242,15 @@ static void RunHelper(const wxString &program, const wxArrayString &args)
 	wxExecute(argv.data(), flags, nullptr, sanitized ? &execEnv : nullptr);
 }
 
-// update-desktop-database, gtk-update-icon-cache and update-mime-database
-// exist on every desktop distro that ships a .desktop file system, and we
-// don't fail integration if they're missing.
+// update-desktop-database, gtk-update-icon-cache and update-mime-database exist
+// on every desktop distro that ships a .desktop file system, and integration
+// does not fail if they are missing.
 //
-// The .desktop and icon caches have a safety net - desktop environments
-// watch those directories and rebuild on their own within seconds - which
-// is exactly why the broken quoting above went unnoticed for so long. The
-// shared-mime-info database has no such watcher: if update-mime-database
-// does not run, the collection type stays unknown and a double-click opens
-// whatever handles text/plain.
+// The .desktop and icon caches have a safety net -- desktop environments watch
+// those directories and rebuild within seconds, which is why the broken quoting
+// above went unnoticed for so long. The shared-mime-info database has no such
+// watcher: without update-mime-database the collection type stays unknown and a
+// double-click opens whatever handles text/plain.
 void RefreshSystemCaches(
 	const wxString &userAppsDir, const wxString &userIconsDir, const wxString &userMimeDir)
 {
@@ -290,13 +281,11 @@ wxString GetUserBinDir()
 	return wxGetUserHome() + wxT("/.local/bin");
 }
 
-// True if `path` names an existing symlink (broken or intact). Distinct
-// from wxFileExists which returns true for a symlink pointing at a
-// non-existent target BUT ALSO returns true for a regular file - we
-// need to know the difference before deciding whether it's safe to
-// replace with our own symlink. POSIX-only; MinGW-w64 (Windows) has
-// neither lstat nor S_ISLNK, and the whole AppImage integration path
-// is a no-op there anyway (ShouldPrompt returns false on non-GTK).
+// True if `path` names an existing symlink, broken or intact. Distinct from
+// wxFileExists, which is also true for a regular file and for a symlink pointing
+// at a missing target -- the difference decides whether it is safe to replace
+// with our own symlink. POSIX-only; MinGW-w64 has neither lstat nor S_ISLNK, and
+// the whole AppImage path is a no-op there anyway.
 #ifdef __WXGTK__
 bool IsSymlink(const wxString &path)
 {
@@ -305,10 +294,9 @@ bool IsSymlink(const wxString &path)
 }
 #endif
 
-// The names AppRun's argv[0]-dispatch case knows about. Any name that
-// AppRun doesn't recognize falls back to `amule`, so a stale symlink
-// to a since-removed binary still launches the monolithic GUI —
-// never a hard failure. Order matches the AppRun case statement.
+// The names AppRun's argv[0]-dispatch case knows about. Any name AppRun does not
+// recognize falls back to `amule`, so a stale symlink to a since-removed binary
+// still launches the monolithic GUI. Order matches the AppRun case statement.
 const wxString kAppRunNames[] = {
 	wxT("amule"),
 	wxT("amuled"),
@@ -323,16 +311,12 @@ const wxString kAppRunNames[] = {
 	wxT("alcc"),
 };
 
-// Create ~/.local/bin/<name> symlinks for each AppRun-dispatched
-// binary that this AppImage actually bundles. Returns the count
-// created. Refuses to clobber a pre-existing regular file at any of
-// these paths (protects e.g. a user's distro-packaged amule binary if
-// it somehow lives under ~/.local/bin); existing symlinks ARE replaced
-// so a re-install of a new AppImage refreshes the targets.
-// POSIX-only (uses symlink(2) and IsSymlink() which use lstat/S_ISLNK).
-// The AppImage integration flow is inherently Linux-only; ShouldPrompt
-// returns false on Windows / macOS, so this function is never actually
-// called on those platforms - but it still needs to compile.
+// Create ~/.local/bin/<name> symlinks for each AppRun-dispatched binary this
+// AppImage actually bundles, returning the count created. Refuses to clobber a
+// pre-existing regular file at any of these paths, protecting a user's
+// distro-packaged binary; existing symlinks ARE replaced, so re-installing a new
+// AppImage refreshes the targets. POSIX-only, and never called on Windows or
+// macOS (ShouldPrompt returns false there), but it still has to compile.
 #ifdef __WXGTK__
 int InstallCommandSymlinks(const wxString &appdir, const wxString &appimagePath)
 {
@@ -459,12 +443,9 @@ void PromptAndInstall(wxWindow *parent)
 		return;
 	}
 
-	// Shell-command shortcuts first: the amulegui .desktop file
-	// installed below points at ~/.local/bin/amulegui to route
-	// clicks to the correct AppRun dispatch. If that symlink doesn't
-	// materialise the .gui .desktop's Exec= still resolves via PATH
-	// lookup, but a fresh installation with an untouched
-	// ~/.local/bin/ path is the happy case we design for here.
+	// Shell-command shortcuts first: the amulegui .desktop file installed below
+	// points at ~/.local/bin/amulegui to route clicks to the correct AppRun
+	// dispatch. Without that symlink the Exec= still resolves via PATH lookup.
 	const int symlinkCount = InstallCommandSymlinks(appdir, appimagePath);
 
 	// Install org.amule.aMule.desktop (monolithic amule). Exec= points
@@ -480,12 +461,10 @@ void PromptAndInstall(wxWindow *parent)
 		return;
 	}
 
-	// Install org.amule.aMule.gui.desktop (remote-GUI amulegui). Exec=
-	// points at the ~/.local/bin/amulegui symlink so AppRun's basename
-	// dispatch picks amulegui rather than the default amule. Only
-	// attempt if the AppImage actually bundles amulegui AND the
-	// symlink was created; otherwise silently skip (a
-	// TESTING=OFF-only build has no amulegui).
+	// Install org.amule.aMule.gui.desktop (remote-GUI amulegui). Exec= points at
+	// the ~/.local/bin/amulegui symlink so AppRun's basename dispatch picks
+	// amulegui rather than the default amule. Attempted only if the AppImage
+	// bundles amulegui AND the symlink was created.
 	const wxString guiSource = appdir + wxT("/usr/share/applications/org.amule.aMule.gui.desktop");
 	const wxString guiSymlink = GetUserBinDir() + wxT("/amulegui");
 	if (wxFileExists(guiSource) && wxFileExists(guiSymlink)) {
@@ -524,10 +503,9 @@ void PromptAndInstall(wxWindow *parent)
 		return;
 	}
 
-	// Spawn a detached shell that polls our PID and re-execs the AppImage
-	// once we fully exit. This gives aMule's normal shutdown path time to
-	// save partfiles, release the EC port, etc., before the new instance
-	// tries to grab the same locks.
+	// Spawn a detached shell that polls our PID and re-execs the AppImage once we
+	// fully exit, so aMule's normal shutdown has time to save partfiles and release
+	// the EC port before the new instance grabs the same locks.
 	const wxString relaunchCmd =
 		wxString::Format(wxT("sh -c 'while kill -0 %d 2>/dev/null; do sleep 0.2; done; exec \"%s\"'"),
 			static_cast<int>(getpid()),

--- a/src/AutostartManager.cpp
+++ b/src/AutostartManager.cpp
@@ -63,11 +63,9 @@ bool BackendRemove();
 
 wxString AutostartManager::GetCanonicalExecutablePath()
 {
-	// wxStandardPaths::GetExecutablePath() wraps the OS native call
-	// (GetModuleFileNameW on Windows, _NSGetExecutablePath on macOS,
-	// /proc/self/exe readlink on Linux), then on POSIX we resolve
-	// any intermediate symlinks via realpath() so AppImage / .app
-	// bundle moves are detected correctly.
+	// wxStandardPaths::GetExecutablePath() wraps the OS native call; on POSIX we
+	// then resolve intermediate symlinks via realpath(), so AppImage / .app bundle
+	// moves are detected correctly.
 	wxString raw = wxStandardPaths::Get().GetExecutablePath();
 
 #ifndef __WXMSW__
@@ -79,9 +77,8 @@ wxString AutostartManager::GetCanonicalExecutablePath()
 	if (realpath(raw.mb_str(wxConvUTF8), resolved) != NULL) {
 		return wxString::FromUTF8(resolved);
 	}
-	// realpath failed (binary unlinked? permission?) — fall through
-	// to the raw path; the autostart entry will still work as long
-	// as the OS can resolve it.
+	// realpath failed (binary unlinked? permission?) -- fall through to the raw
+	// path, which still works as long as the OS can resolve it.
 #endif
 
 	return raw;
@@ -129,10 +126,8 @@ void AutostartManager::SelfHealOnStartup()
 		return;
 	}
 
-	// Path drifted (user moved AppImage / .app / install dir, or
-	// upgraded via a tool that didn't rewrite the entry). Rewrite
-	// to match the current canonical path so the next login launches
-	// the right binary.
+	// Path drifted (moved AppImage / .app / install dir, or an upgrade tool that
+	// did not rewrite the entry), so rewrite it to the current canonical path.
 	wxLogDebug(wxT("AutostartManager::SelfHealOnStartup: rewriting autostart entry from '%s' to '%s'"),
 		registered.c_str(),
 		canonical.c_str());
@@ -148,10 +143,9 @@ namespace
 
 #if defined(__WXMSW__)
 
-// Windows: per-user "Run on login" registry key. HKCU (not HKLM)
-// so autostart is a per-user choice on shared machines and toggling
-// never needs elevation. The same key Task Manager → Startup tab
-// reads.
+// Windows: per-user "Run on login" registry key. HKCU rather than HKLM, so
+// autostart is a per-user choice on shared machines and toggling never needs
+// elevation. The same key Task Manager's Startup tab reads.
 static const wchar_t *RUN_KEY = L"Software\\Microsoft\\Windows\\CurrentVersion\\Run";
 static const wchar_t *RUN_VALUE_NAME = L"aMule";
 
@@ -183,10 +177,9 @@ wxString BackendReadTargetPath()
 
 	wxString raw(buf.data());
 
-	// Windows stores Run entries either bare ("C:\Foo\bar.exe")
-	// or quoted ('"C:\Foo\bar.exe" --some-flag'). Strip surrounding
-	// quotes and discard any argument tail so the path comparison
-	// in SelfHealOnStartup matches the unadorned canonical path.
+	// Windows stores Run entries either bare or quoted with an argument tail, so
+	// strip surrounding quotes and discard any arguments -- the path comparison in
+	// SelfHealOnStartup matches the unadorned canonical path.
 	if (!raw.empty() && raw[0] == wxT('"')) {
 		size_t closing = raw.find(wxT('"'), 1);
 		if (closing != wxString::npos) {
@@ -236,10 +229,9 @@ bool BackendRemove()
 
 #elif defined(__WXMAC__) || defined(__WXOSX__)
 
-// macOS: per-user LaunchAgent. Registered command is
-// `/usr/bin/open -a <aMule.app>` rather than launching the bare
-// Mach-O directly — sidesteps Gatekeeper / quarantine warnings
-// when launchd activates us at login.
+// macOS: per-user LaunchAgent. The registered command is
+// `/usr/bin/open -a <aMule.app>` rather than the bare Mach-O, which sidesteps
+// Gatekeeper / quarantine warnings when launchd activates us at login.
 static const wxString PLIST_LABEL = wxT("org.amule.amule");
 
 static wxString PlistPath()
@@ -262,13 +254,9 @@ wxString BackendReadTargetPath()
 	f.ReadAll(&content, wxConvUTF8);
 	f.Close();
 
-	// ProgramArguments array layout we write below:
-	//   <string>/usr/bin/open</string>
-	//   <string>-a</string>
-	//   <string>/path/to/aMule.app</string>
-	// Take the third <string> as the registered target. Plist
-	// XML is simple enough that regex extraction is safer than
-	// pulling in a full plist parser dependency.
+	// The ProgramArguments array written below is /usr/bin/open, -a, then the
+	// .app path, so the third <string> is the registered target. Plist XML is
+	// simple enough that regex extraction beats a full parser dependency.
 	wxRegEx re(wxT("<string>([^<]+)</string>"), wxRE_ADVANCED);
 	if (!re.IsValid()) {
 		return wxEmptyString;
@@ -290,10 +278,8 @@ wxString BackendReadTargetPath()
 
 bool BackendWrite(const wxString &canonicalExe)
 {
-	// Convert the canonical exe path to its containing .app
-	// bundle: `/Applications/aMule.app/Contents/MacOS/amule`
-	// → `/Applications/aMule.app`. Strip the last two path
-	// components plus the basename.
+	// Convert the canonical exe path to its containing .app bundle:
+	// `/Applications/aMule.app/Contents/MacOS/amule` -> `/Applications/aMule.app`.
 	wxString appBundle = canonicalExe;
 	int idx = appBundle.Find(wxT(".app/"));
 	if (idx != wxNOT_FOUND) {
@@ -323,9 +309,8 @@ bool BackendWrite(const wxString &canonicalExe)
 	xml << wxT("    </array>\n");
 	xml << wxT("    <key>RunAtLoad</key>\n");
 	xml << wxT("    <true/>\n");
-	// KeepAlive=false so user-quit means quit. launchd would
-	// otherwise treat us as a service to be respawned, which
-	// fights the user's deliberate close.
+	// KeepAlive=false so a user quit means quit: launchd would otherwise treat us
+	// as a service to be respawned, fighting the user's deliberate close.
 	xml << wxT("    <key>KeepAlive</key>\n");
 	xml << wxT("    <false/>\n");
 	xml << wxT("</dict>\n");
@@ -351,10 +336,9 @@ bool BackendRemove()
 
 #else // assumed Linux / *BSD with XDG-compliant desktop env
 
-// Linux: XDG Autostart spec. $XDG_CONFIG_HOME (falls back to
-// ~/.config) is where the DE's "Startup Applications" GUI looks,
-// so users can see and toggle the entry without touching a
-// terminal. systemd user units don't show up in those GUIs.
+// Linux: XDG Autostart spec. $XDG_CONFIG_HOME (falling back to ~/.config) is
+// where the DE's "Startup Applications" GUI looks, so users can see and toggle
+// the entry without a terminal -- systemd user units do not show up there.
 // https://specifications.freedesktop.org/autostart-spec/latest/
 
 static wxString XdgAutostartDir()
@@ -386,10 +370,9 @@ wxString BackendReadTargetPath()
 	f.ReadAll(&content, wxConvUTF8);
 	f.Close();
 
-	// Parse the Exec= line. .desktop syntax allows the field-code
-	// expansion (%U, %f etc.) after the executable; the path is
-	// always the first whitespace-delimited token and may be
-	// quoted with double-quotes for paths containing spaces.
+	// Parse the Exec= line. .desktop syntax allows field-code expansion (%U, %f)
+	// after the executable; the path is always the first whitespace-delimited
+	// token, and may be double-quoted for paths containing spaces.
 	wxStringTokenizer lines(content, wxT("\n"));
 	while (lines.HasMoreTokens()) {
 		wxString line = lines.GetNextToken().Trim(false).Trim(true);
@@ -419,9 +402,8 @@ bool BackendWrite(const wxString &executable)
 {
 	wxString dir = XdgAutostartDir();
 	if (!wxFileName::DirExists(dir)) {
-		// Mkdir -p; the XDG dir may not exist yet on a fresh
-		// install or on minimal DEs that don't ship anything
-		// there by default.
+		// Mkdir -p: the XDG dir may not exist yet on a fresh install or on minimal
+		// DEs that ship nothing there.
 		if (!wxFileName::Mkdir(dir, 0755, wxPATH_MKDIR_FULL)) {
 			return false;
 		}
@@ -431,10 +413,9 @@ bool BackendWrite(const wxString &executable)
 	// survive the .desktop Exec= parser's tokenisation.
 	wxString quotedExec = wxT("\"") + executable + wxT("\"");
 
-	// Standard XDG Autostart fields. X-GNOME-Autostart-enabled
-	// is widely-recognised even outside GNOME and makes the
-	// entry trivially toggleable from the user's DE settings GUI
-	// without us having to rewrite the file.
+	// Standard XDG Autostart fields. X-GNOME-Autostart-enabled is widely recognised
+	// even outside GNOME and makes the entry toggleable from the DE settings GUI
+	// without us rewriting the file.
 	wxString content;
 	content << wxT("[Desktop Entry]\n");
 	content << wxT("Type=Application\n");

--- a/src/BaseClient.cpp
+++ b/src/BaseClient.cpp
@@ -694,22 +694,19 @@ bool CUpDownClient::ProcessHelloTypePacket(const CMemFile &data)
 			break;
 
 		case CT_MOD_YOUR_IP:
-			// The address this peer says it saw us arrive from. Only the
-			// hash form is read: eMuleAI also accepts an integer form and
-			// sets its own public IPv4 from it, which lets a single
-			// unverified peer decide what this client believes its own
-			// address to be. emule-qt ignores the integer form, and this
-			// follows emule-qt.
+			// The address this peer says it saw us arrive from. Only the hash form
+			// is read: eMuleAI also accepts an integer form and sets its own public
+			// IPv4 from it, which lets a single unverified peer decide what this
+			// client believes its own address to be. emule-qt ignores the integer
+			// form, and this follows emule-qt.
 			//
-			// Even the hash form is not believed on one peer's word. It
-			// goes to a tracker that first checks the value is an address
-			// this machine actually holds -- so peers can never make us
-			// adopt a foreign one, only disambiguate between our own -- and
-			// then requires several distinct *observed* addresses to agree
-			// within a time window, keyed on where the packet actually came
-			// from rather than on the peer's self-declared user hash: a hash
-			// costs nothing to invent, a routable address does not. Nothing
-			// consumes the result yet; recognition only.
+			// Even the hash form is not believed on one peer's word. It goes to a
+			// tracker that first checks the value is an address this machine
+			// actually holds -- so peers can only disambiguate between our own,
+			// never make us adopt a foreign one -- and then requires several
+			// distinct *observed* addresses to agree within a time window, keyed on
+			// where the packet actually came from rather than on the peer's
+			// self-declared user hash. Nothing consumes the result yet.
 			if (temptag.IsHash()) {
 				ObservedPublicIPv6().AddClaim(
 					GetConnectIP(), temptag.GetHash().GetHash(), ::GetTickCount64());
@@ -717,11 +714,10 @@ bool CUpDownClient::ProcessHelloTypePacket(const CMemFile &data)
 			break;
 
 		default:
-			// An unrecognised tag is not a broken handshake. The switch
-			// has always fallen through silently for tags aMule does not
-			// know; the only thing added here is visibility for the
-			// vendor range, because a new CT_MOD_* tag arriving in the
-			// wild is worth knowing about and is otherwise invisible.
+			// An unrecognised tag is not a broken handshake. The switch has always
+			// fallen through silently for tags aMule does not know; the only thing
+			// added here is visibility for the vendor range, because a new CT_MOD_*
+			// tag arriving in the wild is worth knowing about.
 			if (temptag.GetNameID() >= 0xA0 && temptag.GetNameID() <= 0xAF) {
 				AddDebugLogLineN(logClient,
 					CFormat("Ignoring unknown vendor tag 0x%02X in hello from %s") %
@@ -794,9 +790,9 @@ bool CUpDownClient::ProcessHelloTypePacket(const CMemFile &data)
 	// A friend record can already be linked to this client from before the
 	// handshake, matched on address alone, and an address gets recycled. Now
 	// that the peer has said who it is, a record that turns out to be about
-	// somebody else has to let go: clearing only this client's side would
-	// leave that record pointing here and showing its friend as connected.
-	// Unlink first, because UnLinkClient() clears m_Friend as it goes.
+	// somebody else has to let go: clearing only this client's side would leave
+	// that record pointing here and showing its friend as connected. Unlink
+	// first, because UnLinkClient() clears m_Friend as it goes.
 	CFriend *previous = m_Friend;
 	CFriend *found = theApp->friendlist->FindFriend(m_UserHash, m_dwUserIP, m_nUserPort);
 	if (previous != nullptr && previous != found) {
@@ -813,16 +809,15 @@ bool CUpDownClient::ProcessHelloTypePacket(const CMemFile &data)
 
 	ReGetClientSoft();
 
-	// Everything worth remembering about this peer is populated by now: the
-	// name came out of the hello tags above, the address from the connection,
-	// and ReGetClientSoft() has just resolved the software and version. The
-	// credit record is the only thing that outlives the connection, so this is
-	// where a peer stops being anonymous in the history.
+	// Everything worth remembering about this peer is populated by now: the name
+	// came out of the hello tags above, the address from the connection, and
+	// ReGetClientSoft() has just resolved the software and version. The credit
+	// record is the only thing that outlives the connection, so this is where a
+	// peer stops being anonymous in the history.
 	//
 	// The session count is taken once per client object rather than once per
-	// call: an outgoing connection processes a hello answer as well as a
-	// hello, and a count that rose per packet would measure traffic instead of
-	// visits.
+	// call: an outgoing connection processes a hello answer as well as a hello,
+	// and a count that rose per packet would measure traffic instead of visits.
 	if (credits != nullptr) {
 		credits->UpdateMeta(m_Username,
 			m_dwUserIP,
@@ -979,12 +974,10 @@ bool CUpDownClient::ProcessMuleInfoPacket(const uint8_t *pachPacket, uint32 nSiz
 
 	const CMemFile data(pachPacket, nSize);
 
-	// The version number part of this packet will soon be useless since
-	// it is only able to go to v.99. Why the version is a uint8 and why
-	// it was not done as a tag like the eDonkey hello packet is not known.
-	// Therefore, sooner or later, we are going to have to switch over to
-	// using the eDonkey hello packet to set the version. No sense making
-	// a third value sent for versions.
+	// The version number part of this packet will soon be useless, since it can
+	// only go to v.99. Why the version is a uint8 rather than a tag like the
+	// eDonkey hello packet is not known -- sooner or later this has to switch to
+	// setting the version from the eDonkey hello packet instead.
 	uint8 mule_version = data.ReadUInt8();
 	protocol_version = data.ReadUInt8();
 	uint32 tagcount = data.ReadUInt32();
@@ -1282,16 +1275,15 @@ void CUpDownClient::SendHelloTypePacket(CMemFile *data)
 	// eMuleAI vendor capabilities (CT_MOD_MISCOPTIONS).
 	//
 	// Nothing is written, and that is the whole of the emit side for now:
-	// LocalAdvertisedModMiscOptions() is zero because aMule implements none
-	// of the five features, and eMuleAI treats an absent tag and an all-zero
-	// word identically. Advertising a capability aMule does not have is
-	// strictly worse than advertising none -- the peer opens a handshake that
-	// cannot complete and neither side logs a reason.
+	// LocalAdvertisedModMiscOptions() is zero because aMule implements none of
+	// the five features, and eMuleAI treats an absent tag and an all-zero word
+	// identically. Advertising a capability aMule does not have is strictly
+	// worse than advertising none -- the peer opens a handshake that cannot
+	// complete and neither side logs a reason.
 	//
 	// A later change that ships one of these transports turns its bit on in
 	// LocalAdvertisedModMiscOptions(), emits the tag here, and adds one to
-	// `tagcount` above. Both must happen together: the tagcount is written
-	// before the tags and a mismatch desynchronises the reader.
+	// `tagcount` above. Both must happen together.
 	static_assert(LocalAdvertisedModMiscOptions() == 0,
 		"a non-zero advertised capability word needs the CT_MOD_MISCOPTIONS tag emitted here "
 		"and tagcount incremented above");
@@ -1550,25 +1542,20 @@ bool CUpDownClient::TryToConnect(bool bIgnoreMaxCon)
 }
 
 // Re-check the standing reasons to refuse this peer, disconnecting it on a hit:
-// incompatible obfuscation settings, a filtered IP, a banned IP.
-//
-// Returns Contacting when the peer is clean -- "carry on" rather than "we sent
-// something" -- and ClientDeleted or Declined otherwise, matching what the
-// callers already do with those.
+// incompatible obfuscation settings, a filtered IP, a banned IP. Returns
+// Contacting when the peer is clean -- "carry on" rather than "we sent
+// something" -- and ClientDeleted or Declined otherwise.
 //
 // Extracted so it can run on both routes to a peer: TryToContact, which is
 // about to open a connection, and the already-connected browse path, which is
-// not. All three share one property that makes them belong here rather than at
-// connect time only -- each is settings-derived and every one of those settings
-// is changeable while a connection is open. A peer admitted before the filter
-// list grew, or before "require obfuscation" was switched on, keeps its socket,
-// and a browse used to be one of the places that noticed. The max-sockets check
-// above is NOT here on purpose: it governs opening a new socket, which is
-// exactly what a peer we are already connected to does not need.
+// not. All three checks are settings-derived and every one of those settings is
+// changeable while a connection is open, so a peer admitted before the filter
+// list grew, or before "require obfuscation" was switched on, keeps its socket.
+// The max-sockets check is NOT here on purpose: it governs opening a new
+// socket, which a peer we are already connected to does not need.
 //
 // Keeping the Disconnected / Safe_Delete handling in one place matters more
-// than the two call sites: it can delete `this`, and the callers have to agree
-// on how that is reported.
+// than the two call sites: it can delete `this`.
 EContactResult CUpDownClient::CheckContactPreconditions()
 {
 	if ((RequiresCryptLayer() && !thePrefs::IsClientCryptLayerSupported()) ||
@@ -1730,10 +1717,10 @@ EContactResult CUpDownClient::TryToContact(bool bIgnoreMaxCon)
 			0);
 	} else if (HasLowID()) { // LOWID
 		// Set where a packet actually goes out. Several of the paths below reach
-		// the end having sent nothing -- a source we are merely queued at, a
-		// peer that is not a download source, a Kad lookup that fails to start --
-		// and reporting those as Contacting is what let a browse of them wait out
-		// the whole silence timeout instead of failing at once.
+		// the end having sent nothing -- a source we are merely queued at, a peer
+		// that is not a download source, a Kad lookup that fails to start -- and
+		// reporting those as Contacting let a browse of them wait out the whole
+		// silence timeout instead of failing at once.
 		bool contacted = false;
 		if (GetDownloadState() == DS_CONNECTING) {
 			SetDownloadState(DS_WAITCALLBACK);
@@ -1873,17 +1860,15 @@ bool CUpDownClient::Connect()
 // Put the browse's ask on the wire, if this browse is still waiting for it.
 //
 // One implementation, two callers: ConnectionEstablished (the ask follows the
-// connect) and RequestSharedFileList (the peer was already on the line, so
-// there is no connect to follow). Extracted rather than duplicated because the
-// packet is the smaller half of what has to happen -- the guard and the clock
-// below are the rest of it, and a copy that dropped either would either spam
-// the peer or charge it for our connect time.
+// connect) and RequestSharedFileList (the peer was already on the line).
+// Extracted rather than duplicated because the packet is the smaller half of
+// what has to happen -- the guard and the clock below are the rest, and a copy
+// that dropped either would spam the peer or charge it for our connect time.
 //
 // The guard: ConnectionEstablished runs on every reconnect, and a browsed peer
 // that is also a download source reconnects often -- re-asking each time put
-// unrequested packets on the wire and an error line in the peer's log. Note it
-// only makes the ask single-shot for a DIRECTORY browse; a flat one stays
-// askable for its whole life, deliberately (see BrowseStore::AwaitingDirectoryList).
+// unrequested packets on the wire and an error line in the peer's log. It only
+// makes the ask single-shot for a DIRECTORY browse; a flat one stays askable.
 void CUpDownClient::SendSharedFilesRequest()
 {
 	if (!theApp->browsemanager->AwaitingDirectoryList(this)) {
@@ -1896,8 +1881,7 @@ void CUpDownClient::SendSharedFilesRequest()
 	// Re-base the silence deadline: Store::Start already set one, but from the
 	// click, and the connect that got us here may have taken a while. Without
 	// this the peer is charged for our connect time and the browse can expire
-	// early -- most visibly on the ConnectionEstablished path, where the gap
-	// is a whole connection attempt.
+	// early -- most visibly on the ConnectionEstablished path.
 	theApp->browsemanager->OnRequestSent(this, ::GetTickCount64());
 #ifdef __DEBUG__
 	if (m_fSharedDirectories) {
@@ -2229,24 +2213,20 @@ void CUpDownClient::RequestSharedFileList()
 	}
 	AddDebugLogLineN(logClient, wxString("Requesting shared files from ") + GetUserName());
 
-	// Allocate the ID before the request goes out, for a local browse as much
-	// as an EC one. It used to be assigned when the first result arrived, so
-	// until then the browse was keyed on this client's pointer -- which left
-	// state behind that nothing pruned, and collided when an address was
-	// reused. The EC handler pins the ID it allocated before calling here.
-	// Use the ID the EC handler pinned for this browse, once. Otherwise this
-	// peer keeps the ID it was browsed under before: AllocateEd2kId is a
-	// monotonic counter that never reissues, so an ID we were given stays
-	// ours, and reusing it keeps one tab and one result bucket per peer
-	// however many times the user asks. Allocating afresh each time -- which
-	// is what replacing the old reuse condition did -- left the previous
-	// registration, results and browse record behind with nothing to free
-	// them, since only the newest ID ever reaches RemoveResults when the tab
-	// is closed.
+	// Allocate the ID before the request goes out, for a local browse as much as
+	// an EC one. It used to be assigned when the first result arrived, so until
+	// then the browse was keyed on this client's pointer -- which left state
+	// behind that nothing pruned, and collided when an address was reused.
+	//
+	// Otherwise this peer keeps the ID it was browsed under before:
+	// AllocateEd2kId is a monotonic counter that never reissues, so an ID we
+	// were given stays ours, and reusing it keeps one tab and one result bucket
+	// per peer however many times the user asks. Allocating afresh each time
+	// left the previous registration, results and browse record behind with
+	// nothing to free them.
 	//
 	// The previous record has to go before the new one can take its place:
-	// Store::Start refuses an ID it still holds, to protect whatever that
-	// record is still answering for.
+	// Store::Start refuses an ID it still holds.
 	if (m_browsePinned) {
 		m_browsePinned = false;
 	} else {
@@ -2269,12 +2249,11 @@ void CUpDownClient::RequestSharedFileList()
 		return;
 	}
 	// Describe it before any result arrives, so it is listable as a browse of
-	// this peer rather than as a nameless search -- but only when the ID is
-	// ours to describe. A caller that pinned one has already registered it,
-	// under the identity IT considers authoritative: the friend path keys on
-	// the friend's ECID, and re-registering here would overwrite that with
-	// this client's, which is a different number from the same counter. An
-	// adopting GUI would then open a second tab under a different name.
+	// this peer rather than as a nameless search -- but only when the ID is ours
+	// to describe. A caller that pinned one has already registered it under the
+	// identity IT considers authoritative: the friend path keys on the friend's
+	// ECID, and re-registering here would overwrite that with this client's,
+	// which is a different number from the same counter.
 	if (!m_browseEcInitiated) {
 		theApp->searchlist->RegisterBrowseSearch(m_browseSearchId, GetUserName(), ECID());
 	}
@@ -2286,39 +2265,31 @@ void CUpDownClient::RequestSharedFileList()
 	// Already on the line: ask over the socket we have, and skip TryToContact
 	// entirely.
 	//
-	// TryToContact answers a reachability question -- can we reach this peer
-	// if we are not already talking to it -- and for a LowID peer it answers
-	// Declined before it ever looks at the socket (the CanDoCallback block).
-	// Two of those declines do not imply we are unreachable at all: a LowID
-	// peer on our own server with Kad open, and being connected to neither
-	// network, both of which leave an established socket working. A browse
-	// over such a socket was failed on the spot even though the ask would
-	// have gone out fine.
+	// TryToContact answers a reachability question -- can we reach this peer if
+	// we are not already talking to it -- and for a LowID peer it answers
+	// Declined before it ever looks at the socket. Two of those declines do not
+	// imply we are unreachable at all: a LowID peer on our own server with Kad
+	// open, and being connected to neither network, both of which leave an
+	// established socket working. A browse over such a socket was failed on the
+	// spot even though the ask would have gone out fine.
 	//
 	// Deliberately narrow: TryToContact keeps its behaviour for every other
-	// caller. Hoisting the connected case inside it would also turn a
-	// connected LowID source's DS_LOWTOLOWIP into a SendFileRequest(), which
-	// is a download-path change with no business riding along here.
+	// caller. Hoisting the connected case inside it would also turn a connected
+	// LowID source's DS_LOWTOLOWIP into a SendFileRequest(), which is a
+	// download-path change with no business riding along here.
 	//
-	// Note what this caller gives up. A connected peer used to reach
+	// Note what this caller gives up: a connected peer used to reach
 	// TryToContact's `else` branch and so ConnectionEstablished(), which does
-	// far more than send the ask: Kad fw-check transitions, chat
-	// MS_CONNECTING -> MS_CHATTING with its pending-message flush,
-	// DS_WAITCALLBACK -> DS_CONNECTED plus SendFileRequest(), the upload
-	// OP_ACCEPTUPLOADREQ, and the m_WaitingPackets_list drain. Not taking that
-	// branch is the point rather than a side effect: re-running connection
-	// setup because someone clicked "View Files" is the odd behaviour, and the
-	// states it drives are unreachable over a live socket anyway --
-	// DS_WAITCALLBACK means we are waiting for a connection we already have.
-	// The ask is the only part a browse needs, and it is what stays.
+	// far more than send the ask -- Kad fw-check transitions, the chat
+	// MS_CONNECTING -> MS_CHATTING flush, DS_WAITCALLBACK -> DS_CONNECTED plus
+	// SendFileRequest(), the upload OP_ACCEPTUPLOADREQ, and the waiting-packet
+	// drain. Not taking that branch is the point rather than a side effect.
 	if (IsConnected()) {
-		// Re-validate first. TryToContact does this before it looks at the
-		// socket, so skipping straight past it would let a peer that became
-		// unacceptable since the connection came up -- filtered, banned, or
-		// incompatible with an obfuscation setting switched on meanwhile --
-		// be browsed and be sent a packet, where the old path would have
-		// severed the connection.
-		// ClientDeleted means `this` is gone; the browse died with it.
+		// Re-validate first. TryToContact does this before it looks at the socket,
+		// so skipping straight past it would let a peer that became unacceptable
+		// since the connection came up -- filtered, banned, or incompatible with
+		// an obfuscation setting switched on meanwhile -- be browsed and be sent a
+		// packet. ClientDeleted means `this` is gone; the browse died with it.
 		switch (CheckContactPreconditions()) {
 		case EContactResult::ClientDeleted:
 			return;
@@ -2333,12 +2304,10 @@ void CUpDownClient::RequestSharedFileList()
 		// return. The two callers want opposite things from it: on
 		// ConnectionEstablished a false guard is the reconnect suppression
 		// working, while here it would mean returning with the tab already
-		// announced, nothing on the wire and no terminal path -- the browse
-		// that waits out its deadline, which #1074 and #1088 removed.
-		// Start() guarantees the state, so this is a can't-happen -- and it
-		// has to be greppable as one, because in the log a bare Fail() here
-		// is indistinguishable from an ordinary browse failure, which is the
-		// one case worth spotting.
+		// announced, nothing on the wire and no terminal path -- the browse that
+		// waits out its deadline. Start() guarantees the state, so this is a
+		// can't-happen, and it has to be greppable as one: in the log a bare
+		// Fail() here is indistinguishable from an ordinary browse failure.
 		if (!theApp->browsemanager->AwaitingDirectoryList(this)) {
 			AddDebugLogLineC(logClient,
 				CFormat("Browse of user %s (%u): the request guard was unset immediately "
@@ -2359,11 +2328,11 @@ void CUpDownClient::RequestSharedFileList()
 		return;
 	case EContactResult::Declined:
 	case EContactResult::ConnectNotStarted:
-		// Nothing was sent, so no terminal path downstream will ever run.
-		// The deadline would catch it eventually; saying so now is both
-		// correct and cheaper. This used to be inferred from the client's
-		// side effects, because the bool could not distinguish "I tried" from
-		// "I decided not to" -- and the inference was wrong twice.
+		// Nothing was sent, so no terminal path downstream will ever run. The
+		// deadline would catch it eventually; saying so now is both correct and
+		// cheaper. This used to be inferred from the client's side effects,
+		// because the bool could not distinguish "I tried" from "I decided not
+		// to" -- and the inference was wrong twice.
 		theApp->browsemanager->Fail(this);
 		return;
 	case EContactResult::Contacting:
@@ -2841,13 +2810,12 @@ uint8 CUpDownClient::GetSecureIdentState()
 {
 	if (m_SecureIdentState != IS_UNAVAILABLE) {
 		if (!SecIdentSupRec) {
-			// This can be caused by a 0.30x based client which sends the old
-			// style Hello packet, and the mule info packet, but between them they
-			// send a secure ident state packet (after a hello but before we have
-			// the SUI capabilities). This is a misbehaving client, and somehow I
-			// feel like it should be dropped. But then again, it won't harm to use
-			// this SUI state if they are reporting no SUI (won't be used) and if
-			// they report using SUI on the mule info packet, it's ok to use it.
+			// This can be caused by a 0.30x based client which sends the old style
+			// Hello packet and the mule info packet, but sends a secure ident state
+			// packet between them, after a hello but before we have the SUI
+			// capabilities. A misbehaving client, but it does no harm to use this
+			// SUI state: if they report no SUI it will not be used, and if they
+			// report using SUI on the mule info packet, it is fine to use it.
 
 			AddDebugLogLineN(logClient,
 				"A client sent secure ident state before telling us the SUI capabilities");
@@ -2955,15 +2923,14 @@ void CUpDownClient::UpdateStats()
 
 // All five go through GetCurrentIdentState(), which is the one place that
 // decides what a missing credits object means (IS_NOTAVAILABLE). Testing
-// `credits &&` here instead made the boolean set unable to express that
-// state: with credits still NULL -- its value from construction until the
-// peer's user hash resolves -- every predicate answered false, including
-// SUINotSupported(), while the accessor on the same object was reporting
-// exactly IS_NOTAVAILABLE.
+// `credits &&` here instead made the boolean set unable to express that state:
+// with credits still NULL -- its value from construction until the peer's user
+// hash resolves -- every predicate answered false, including SUINotSupported(),
+// while the accessor on the same object reported exactly IS_NOTAVAILABLE.
 //
-// Only SUINotSupported() changes behaviour. For the other four the guard
-// was redundant: a NULL credits yields IS_NOTAVAILABLE, which already
-// compares unequal to the state each of them asks about.
+// Only SUINotSupported() changes behaviour: for the other four the guard was
+// redundant, since a NULL credits yields IS_NOTAVAILABLE, which already
+// compares unequal to the state each asks about.
 bool CUpDownClient::IsIdentified() const
 {
 	return GetCurrentIdentState() == IS_IDENTIFIED;
@@ -3105,11 +3072,11 @@ void CUpDownClient::ProcessCaptchaReqRes(uint8 nStatus)
 #endif // AMULE_DAEMON
 
 // Shared by both builds. The advanced spam filter (captcha + URL heuristic) is
-// GUI-only — CCaptchaGenerator lives in the monolithic target and the spam path
-// touches the chat window — so it is compiled out on the daemon, which relays
-// incoming messages to amulegui with the message filter alone.
+// GUI-only -- CCaptchaGenerator lives in the monolithic target and the spam
+// path touches the chat window -- so it is compiled out on the daemon, which
+// relays incoming messages to amulegui with the message filter alone.
 // By-value to match the header signature: the non-daemon path reassigns
-// `message` (captcha), so the parameter can't be const-ref.
+// `message` (captcha), so the parameter cannot be const-ref.
 // NOLINTNEXTLINE(performance-unnecessary-value-param)
 void CUpDownClient::ProcessChatMessage(wxString message)
 {

--- a/src/BrowseListModel.cpp
+++ b/src/BrowseListModel.cpp
@@ -31,24 +31,23 @@
 
 namespace
 {
-//! Canonical form of a peer's directory string: runs of separators collapsed
-//! to one, and a trailing separator dropped.
+//! Canonical form of a peer's directory string: runs of separators collapsed to
+//! one, and a trailing separator dropped.
 //!
 //! The nodes are keyed by this string, so anything left un-normalised is a
 //! spelling that gets its own folder: "Shared/Movies", "Shared//Movies" and
-//! "Shared/Movies/" all name one directory, and keying them apart would draw
-//! a sibling row per spelling, all three showing "Movies". A trailing
-//! separator additionally leaves the last segment empty, which is the blank
-//! row. A string of nothing but separators normalises to empty, which is no
-//! directory at all.
+//! "Shared/Movies/" all name one directory, and keying them apart would draw a
+//! sibling row per spelling. A trailing separator additionally leaves the last
+//! segment empty, which is the blank row, and a string of nothing but separators
+//! normalises to empty, which is no directory at all.
 //!
-//! Which separator survives a mixed run is whichever came first; the peer's
-//! own choice is not knowable from the packet either way.
+//! Which separator survives a mixed run is whichever came first; the peer's own
+//! choice is not knowable from the packet either way.
 //!
-//! Collapsing runs also rewrites the one string where a doubled separator
-//! means something: a UNC name arrives as "\\server\share" and is keyed as
-//! "\server\share". It is a label here and nothing resolves it, so this
-//! costs a backslash in a folder row rather than a wrong lookup.
+//! Collapsing runs also rewrites the one string where a doubled separator means
+//! something: a UNC name arrives as "\\server\share" and is keyed as
+//! "\server\share". It is a label here and nothing resolves it, so this costs a
+//! backslash in a folder row rather than a wrong lookup.
 wxString NormalizeDirectory(const wxString &path)
 {
 	wxString normalized;
@@ -88,16 +87,14 @@ CBrowseFolderNode *CBrowseListModel::EnsureFolder(const wxString &path, size_t d
 		return existing->second.get();
 	}
 
-	// Split off the last segment: whichever separator appears last is the
-	// one this peer uses, so a name containing the other one stays intact.
+	// Split off the last segment: whichever separator appears last is the one this
+	// peer uses, so a name containing the other one stays intact.
 	//
-	// Two bounds apply, and they stop different things. The depth argument
-	// caps this function's own recursion, which one long string drives. The
-	// node's depth caps the tree, which many strings drive between them: the
-	// early return above hands back a node with the parents it already has,
-	// so without that check a peer could add a capped run per packet and
-	// nest for as long as it kept sending. Where either bites, the remainder
-	// stays one folder name instead of being split further.
+	// Two bounds apply, and they stop different things. The depth argument caps this
+	// function's own recursion, which one long string drives. The node's depth caps
+	// the tree, which many strings drive between them: the early return above hands
+	// back a node with the parents it already has, so without it a peer could add a
+	// capped run per packet and nest for as long as it kept sending.
 	const size_t slash = path.find_last_of("/\\");
 	CBrowseFolderNode *parent = nullptr;
 	wxString name = path;
@@ -131,11 +128,10 @@ CBrowseFolderNode *CBrowseListModel::EnsureFolder(const wxString &path, size_t d
 
 void CBrowseListModel::RebuildFolders() const
 {
-	// Once per change, not once per query. The control asks for the root's
-	// children several times per rebuild -- twice from OnIdleHook alone, to
-	// save and restore expansion around a Cleared() -- and this walks every
-	// result, which on a large share is the cost the browse throttle exists
-	// to keep down (issue #898).
+	// Once per change, not once per query. The control asks for the root's children
+	// several times per rebuild -- twice from OnIdleHook alone, to save and restore
+	// expansion around a Cleared() -- and this walks every result, which on a large
+	// share is the cost the browse throttle exists to keep down (issue #898).
 	const unsigned generation = GetContentGeneration();
 	const wxUIntPtr searchId = m_owner->GetSearchId();
 	if (m_foldersValid && m_foldersGeneration == generation && m_foldersSearchId == searchId) {
@@ -162,10 +158,9 @@ void CBrowseListModel::RebuildFolders() const
 			continue;
 		}
 
-		// The one place a directory string is normalised, because this is
-		// the one place it becomes a key. GetParent() reads the answer
-		// back from m_fileParents rather than deriving it again, so there
-		// is no second spelling of this to keep in step.
+		// The one place a directory string is normalised, because this is the one
+		// place it becomes a key. GetParent() reads the answer back from
+		// m_fileParents rather than deriving it again.
 		const wxString directory = NormalizeDirectory(file->GetDirectory());
 		if (directory.IsEmpty()) {
 			m_looseFiles.push_back(file);
@@ -177,15 +172,13 @@ void CBrowseListModel::RebuildFolders() const
 		m_fileParents.emplace(file, folder);
 	}
 
-	// Relink the hierarchy. Done as a second pass rather than while
-	// creating the nodes, because the links are cleared on every rebuild
-	// while the nodes outlive it: a folder created for an earlier refresh
-	// still has to be reattached to its parent on this one.
+	// Relink the hierarchy as a second pass rather than while creating the nodes,
+	// because the links are cleared on every rebuild while the nodes outlive it: a
+	// folder created for an earlier refresh still has to be reattached.
 	//
-	// Unconditionally, empty or not. Whether a folder is worth drawing
-	// depends on what is under it at any depth, which is not knowable until
-	// every link exists -- so that question is asked at GetChildren() time
-	// instead, once the tree is whole.
+	// Unconditionally, empty or not: whether a folder is worth drawing depends on
+	// what is under it at any depth, which is not knowable until every link exists,
+	// so that question is asked at GetChildren() time instead.
 	for (const auto &entry : m_folders) {
 		CBrowseFolderNode *node = entry.second.get();
 		if (node->GetParent()) {
@@ -230,10 +223,9 @@ unsigned int CBrowseListModel::GetChildren(const wxDataViewItem &item, wxDataVie
 	}
 
 	if (IsFolder(item)) {
-		// Here too, not only on the root branch: this is the path that
-		// reads the cached CSearchFile pointers, so it is the one that has
-		// to see a generation bump. The call is a comparison once the
-		// grouping is current.
+		// Here too, not only on the root branch: this is the path that reads the
+		// cached CSearchFile pointers, so it is the one that has to see a generation
+		// bump. The call is a comparison once the grouping is current.
 		RebuildFolders();
 
 		const CBrowseFolderNode *folder = ToFolder(item);
@@ -271,11 +263,11 @@ wxDataViewItem CBrowseListModel::GetParent(const wxDataViewItem &item) const
 		return CSearchListModel::GetParent(item);
 	}
 
-	// Read back from the grouping walk rather than re-derived from the
-	// directory string. This is the traversal path and wx asks per item, so
-	// it does no string work at all: RebuildFolders() knew the node when it
-	// filed the result, and a result the peer gave no directory is simply
-	// absent, which is the invisible root.
+	// Read back from the grouping walk rather than re-derived from the directory
+	// string. This is the traversal path and wx asks per item, so it does no string
+	// work at all: RebuildFolders() knew the node when it filed the result, and a
+	// result the peer gave no directory is simply absent, which is the invisible
+	// root.
 	RebuildFolders();
 
 	const auto it = m_fileParents.find(file);
@@ -331,9 +323,8 @@ bool CBrowseListModel::GetAttr(const wxDataViewItem &item, unsigned int col, wxD
 		return CSearchListModel::GetAttr(item, col, attr);
 	}
 
-	// The colours the base model picks encode a result's download state,
-	// which a folder does not have. Bold instead, so the grouping reads as
-	// structure rather than as a result in some unexplained state.
+	// The colours the base model picks encode a result's download state, which a
+	// folder does not have. Bold instead, so the grouping reads as structure.
 	attr.SetBold(true);
 	return true;
 }
@@ -345,9 +336,9 @@ int CBrowseListModel::Compare(
 	const bool folder2 = IsFolder(item2);
 
 	if (folder1 != folder2) {
-		// Folders first, whatever the sort column and direction: they are
-		// the structure the results sit in, and interleaving them with the
-		// loose results would read as an ordering accident.
+		// Folders first, whatever the sort column and direction: they are the
+		// structure the results sit in, and interleaving them would read as an
+		// ordering accident.
 		return folder1 ? -1 : 1;
 	}
 

--- a/src/BrowseListModel.h
+++ b/src/BrowseListModel.h
@@ -225,18 +225,12 @@ private:
 	//! folders.
 	mutable std::vector<CSearchFile *> m_looseFiles;
 
-	//! Which folder RebuildFolders() filed each shown result under, recorded
-	//! as it files them. GetParent() is on the traversal path rather than
-	//! the rebuild path and wx asks it per item, so it resolves through this
-	//! instead of re-deriving the key from the result's directory string.
-	//!
-	//! Written by the grouping walk itself, so it cannot come to describe a
-	//! different grouping than the one drawn. A result the peer gave no
-	//! directory is absent rather than present-and-null: it has no folder,
-	//! which is what a missing entry already means.
-	//!
-	//! Costs an entry per shown result, on top of the same pointer already
-	//! held in its folder's m_files.
+	//! Which folder RebuildFolders() filed each shown result under, recorded as it
+	//! files them. GetParent() is on the traversal path rather than the rebuild
+	//! path and wx asks it per item, so it resolves through this instead of
+	//! re-deriving the key from the result's directory string. Written by the
+	//! grouping walk itself, so it cannot describe a different grouping than the
+	//! one drawn; a result with no directory is simply absent.
 	mutable std::unordered_map<const CSearchFile *, CBrowseFolderNode *> m_fileParents;
 };
 

--- a/src/CFile.cpp
+++ b/src/CFile.cpp
@@ -227,9 +227,8 @@ bool CFile::Open(const CPath &fileName, OpenMode mode, int accessMode)
 	m_safeWrite = false;
 	m_filePath = fileName;
 	m_writeBufferPending = 0;
-	// Buffer writes for any mode that can actually write. Read-only
-	// stays unbuffered so a misuse (like writing to a read-opened
-	// file) still fails immediately at the doWrite call site,
+	// Buffer writes for any mode that can actually write. Read-only stays
+	// unbuffered so a misuse still fails immediately at the doWrite call site,
 	// preserving FileDataIOTest's CFile.Constructor contract.
 	m_canBuffer = (mode != read);
 
@@ -348,9 +347,9 @@ sint64 CFile::doRead(void *buffer, size_t count) const
 
 	size_t totalRead = 0;
 	while (totalRead < count) {
-		// m_mutex is this CFile's own lock guarding its buffer/fd; holding it
-		// across the blocking read is intended -- it serialises access to this
-		// single file object, not a shared global section.
+		// m_mutex is this CFile's own lock guarding its buffer and fd; holding it
+		// across the blocking read is intended, since it serialises access to this
+		// one file object rather than a shared global section.
 		// NOLINTNEXTLINE(clang-analyzer-unix.BlockInCriticalSection)
 		int current = ::read(m_fd, (char *)buffer + totalRead, count - totalRead);
 
@@ -396,13 +395,9 @@ sint64 CFile::doWrite(const void *buffer, size_t nCount)
 
 	std::lock_guard<std::recursive_mutex> lock(m_mutex);
 
-	// Read-only files: the kernel will reject the write with EBADF;
-	// surface that immediately by going direct, the same way the
-	// pre-buffering version did.
-	//
-	// Single payload that doesn't fit in the buffer at all also goes
-	// direct — no point splitting into 64 KB chunks just to copy
-	// through the buffer first. Drain pending bytes (if any) so
+	// Read-only files: the kernel rejects the write with EBADF, so go direct and
+	// surface that immediately, as the pre-buffering version did. A single payload
+	// too large for the buffer also goes direct, draining pending bytes first so
 	// ordering is preserved.
 	if (!m_canBuffer || nCount >= kWriteBufferSize) {
 		DrainWriteBuffer();
@@ -425,9 +420,8 @@ sint64 CFile::doWrite(const void *buffer, size_t nCount)
 		DrainWriteBuffer();
 	}
 
-	// Lazy-allocate on first buffered write: a CFile that's opened
-	// write-capable but never written to (e.g. construct-then-close
-	// on an early error path) shouldn't pay for the buffer.
+	// Lazy-allocate on first buffered write: a CFile opened write-capable but never
+	// written to should not pay for the buffer.
 	if (!m_writeBuffer) {
 		m_writeBuffer.reset(new char[kWriteBufferSize]);
 	}
@@ -447,10 +441,9 @@ sint64 CFile::doSeek(sint64 offset) const
 
 	std::lock_guard<std::recursive_mutex> lock(m_mutex);
 
-	// Pending bytes belong at the pre-seek position; flush before
-	// changing the fd's offset so writes don't end up in the wrong
-	// place. (CSafeFile / known.met save uses Seek() to back-patch
-	// the header after writing the body, so this matters in practice.)
+	// Pending bytes belong at the pre-seek position, so flush before changing the
+	// fd's offset. CSafeFile / the known.met save Seek()s back to patch the header
+	// after writing the body, so this matters in practice.
 	DrainWriteBuffer();
 
 	sint64 result = SEEK_FD(m_fd, offset, SEEK_SET);
@@ -503,10 +496,9 @@ uint64 CFile::GetLength() const
 
 uint64 CFile::GetAvailable() const
 {
-	// Lock around both calls so length/position are taken atomically;
-	// otherwise a concurrent write could land between and skew the
-	// reported "available" count. Recursive so the inner GetLength /
-	// GetPosition calls (which lock again) don't deadlock.
+	// Lock around both calls so length and position are taken atomically, or a
+	// concurrent write could land between them and skew the reported "available"
+	// count. Recursive, so the inner GetLength / GetPosition calls do not deadlock.
 	std::lock_guard<std::recursive_mutex> lock(m_mutex);
 
 	const uint64 length = GetLength();

--- a/src/CFile.h
+++ b/src/CFile.h
@@ -227,10 +227,9 @@ private:
 	CFile &operator=(const CFile &);
 	//@}
 
-	//! Flush any data in the userspace write buffer to the kernel.
-	//! No-op when the buffer is empty (e.g. read-only files). Called
-	//! from any path that needs the file's on-disk state to reflect
-	//! preceding writes — Close, Flush, doSeek, doRead, GetPosition,
+	//! Flush any data in the userspace write buffer to the kernel. A no-op when the
+	//! buffer is empty. Called from any path that needs the on-disk state to
+	//! reflect preceding writes: Close, Flush, doSeek, doRead, GetPosition,
 	//! GetLength.
 	void DrainWriteBuffer() const;
 
@@ -243,27 +242,20 @@ private:
 	//! Are we using safe write mode?
 	bool m_safeWrite;
 
-	//! Userspace write buffer. CFile::doWrite was previously a thin
-	//! wrapper over ::write(), which made every CFileDataIO::WriteTag
-	//! call (and its many small WriteString / Write underneath) round-
-	//! trip through the kernel. CKnownFileList::Save() with hundreds
-	//! of thousands of files emitted ~26k write() syscalls per second
-	//! and stalled shutdown for many minutes (#562 — slrslr's report).
-	//! Buffering doWrite into 64 KB chunks collapses millions of
-	//! syscalls into a few thousand. Members are mutable so the const-
-	//! qualified read / seek / position / length paths can drain the
-	//! buffer transparently.
+	//! Userspace write buffer. CFile::doWrite was a thin wrapper over ::write(), so
+	//! every CFileDataIO::WriteTag call and its small writes underneath round-tripped
+	//! through the kernel: CKnownFileList::Save() with hundreds of thousands of
+	//! files emitted ~26k write() syscalls per second and stalled shutdown for
+	//! minutes (#562). Buffering into 64 KB chunks collapses millions of syscalls
+	//! into a few thousand. The members are mutable so the const-qualified read /
+	//! seek / position / length paths can drain transparently.
 	//!
-	//! Heap-allocated (lazy) rather than embedded as a fixed array,
-	//! because CFile is regularly stack-allocated inside worker-thread
-	//! call chains (e.g. CHashingTask → CAICHHashSet::SaveHashSet
-	//! stack-allocates two CFile-shaped objects). musl's default
-	//! pthread stack is 128 KiB; two embedded 64 KiB buffers consume
-	//! the whole stack and the next stack-using call (in practice the
-	//! wxString → char conversion inside wxFile::Exists) crosses the
-	//! guard page and SIGSEGVs. The unique_ptr brings sizeof(CFile)
-	//! back to ~32 bytes and pays the 64 KiB only on first write,
-	//! which means read-only opens stay free.
+	//! Heap-allocated lazily rather than embedded as a fixed array, because CFile is
+	//! regularly stack-allocated inside worker-thread call chains. musl's default
+	//! pthread stack is 128 KiB, and two embedded 64 KiB buffers consume the whole
+	//! stack, so the next stack-using call crosses the guard page and SIGSEGVs. The
+	//! unique_ptr brings sizeof(CFile) back to ~32 bytes and pays the 64 KiB only on
+	//! first write, leaving read-only opens free.
 	enum
 	{
 		kWriteBufferSize = 64 * 1024
@@ -271,40 +263,28 @@ private:
 	mutable std::unique_ptr<char[]> m_writeBuffer;
 	mutable size_t m_writeBufferPending;
 
-	//! True when the file was opened in a write-capable mode and
-	//! buffering is safe. Read-only files bypass the buffer so that
-	//! a stray write() through doWrite still fails immediately at
-	//! the call site (preserves CFileDataIO's error contract — see
-	//! FileDataIOTest's CFile.Constructor "ASSERT_RAISES(...,
-	//! file.WriteUInt8(0))" for a read-only fd).
+	//! True when the file was opened in a write-capable mode and buffering is safe.
+	//! Read-only files bypass the buffer, so a stray write() through doWrite still
+	//! fails immediately at the call site, preserving CFileDataIO's error contract.
 	bool m_canBuffer;
 
-	//! Serializes access to the userspace write buffer + fd state.
-	//! Without it, paths that drain the buffer (Close, Flush, doSeek,
-	//! doRead, GetPosition, GetLength, SetLength) can race against
-	//! concurrent doWrite/drain calls: two threads both pass the
-	//! `pending != 0` check before either resets pending to 0, and
-	//! since ::write advances the fd offset atomically per call, the
-	//! same N bytes end up written at fd_pos AND fd_pos + N — the
-	//! second write clobbers whatever lived there (typically the
-	//! previously-written block's data).
+	//! Serializes access to the userspace write buffer and fd state. Without it,
+	//! paths that drain the buffer (Close, Flush, doSeek, doRead, GetPosition,
+	//! GetLength, SetLength) race against concurrent doWrite/drain calls: two
+	//! threads both pass the `pending != 0` check before either resets pending to 0,
+	//! and since ::write advances the fd offset atomically per call, the same N
+	//! bytes land at fd_pos AND fd_pos + N.
 	//!
-	//! Hit in production on CPartFile::m_hpartfile: CPartFile::FlushBuffer
-	//! calls m_hpartfile.GetLength()/SetLength() and CPartFile::
-	//! GetNeededSpace() calls GetLength(), all from the main thread
-	//! without taking m_hpartfileMutex. Pre-#562 this was safe because
-	//! GetLength was just fstat — independent of fd position. After
-	//! #562 it drains the buffer, which is what triggers the race
-	//! against CPartFileWriteThread's FlushAt (held under
-	//! m_hpartfileMutex but contending against unlocked main-thread
-	//! drains). Manifests as 1-3 corrupt blocks per part, with AICH
-	//! recovering ~98% of each part.
+	//! Hit in production on CPartFile::m_hpartfile: FlushBuffer calls
+	//! GetLength()/SetLength() and GetNeededSpace() calls GetLength(), all from the
+	//! main thread without taking m_hpartfileMutex. Before #562 that was safe, since
+	//! GetLength was just fstat; afterwards it drains the buffer, racing
+	//! CPartFileWriteThread's FlushAt. Manifests as 1-3 corrupt blocks per part,
+	//! with AICH recovering ~98% of each.
 	//!
-	//! Recursive so Open() → Close() (and Reopen → Open → Close) don't
-	//! deadlock. Cost is ~30-50 ns per public-method call versus the
-	//! ~1 µs floor of any I/O syscall it's serializing — well within
-	//! noise. Mutable because const-qualified methods (doRead, doSeek,
-	//! GetLength, GetPosition) need to lock it.
+	//! Recursive so Open() -> Close() does not deadlock, and cheap against the ~1 us
+	//! floor of the I/O syscalls it serializes. Mutable because the const-qualified
+	//! methods need to lock it.
 	mutable std::recursive_mutex m_mutex;
 };
 

--- a/src/ClientContextActions.cpp
+++ b/src/ClientContextActions.cpp
@@ -102,10 +102,10 @@ public:
 	FriendListBatch &operator=(const FriendListBatch &) = delete;
 };
 
-// Above this a bulk action asks before running. One row must never cost a
-// click and a few is plainly deliberate, but Clients -> Known lists every peer
-// we have credit for, so a select-all there is thousands of rows and each one
-// costs an outbound connection or a rewrite of the friend list.
+// Above this a bulk action asks before running. One row must never cost a click
+// and a few is plainly deliberate, but Clients -> Known lists every peer we have
+// credit for, so a select-all there is thousands of rows, each costing an
+// outbound connection or a rewrite of the friend list.
 const size_t kBulkPeerActionPrompt = 10;
 
 // Only one friend slot exists, so a wider selection loses all but the first.
@@ -132,12 +132,10 @@ wxMenu *BuildPeerContextMenu(const PeerIdentity &peer)
 	}
 
 	// Friendship and the friend slot are ours, not the peer's: both live in
-	// emfriends.met and apply next time it connects.
-	//
-	// FriendFor(), so this agrees with whatever the action will decide.
-	// It reaches LookupFriend() rather than FindFriend(): the latter adopts
-	// the hash onto an address-only record and saves the file, and merely
-	// opening a menu must not write to disk.
+	// emfriends.met and apply next time it connects. FriendFor() reaches
+	// LookupFriend() rather than FindFriend(), which would adopt the hash onto an
+	// address-only record and save the file -- opening a menu must not write to
+	// disk.
 	CFriend *known = FriendFor(peer);
 
 	wxMenu *menu = new wxMenu(_("Clients"));
@@ -155,16 +153,14 @@ wxMenu *BuildPeerContextMenu(const PeerIdentity &peer)
 	menu->Append(MP_SHOWLIST, _("View Files"));
 	menu->Append(MP_SENDMESSAGE, _("Send message"));
 
-	// Both open a connection, so both need somewhere to open it to. Whether
-	// the peer forbids browsing is live state we do not have, and an unknown
-	// is not a refusal, so View Files stays offered on that count.
+	// Both open a connection, so both need somewhere to open it to. Whether the
+	// peer forbids browsing is live state we do not have, and an unknown is not a
+	// refusal, so View Files stays offered on that count.
 	//
-	// Only browsing is out of amulegui's reach, because EC names a browse
-	// target by ECID and this peer has no daemon-side object. Chat addresses
-	// by GUI_ID, which is the address itself, so it works in both builds.
-	// Friending is unaffected either way: it is a property of our own list.
-	// Unfriending only needs the record we already have; friending needs an
-	// address to store, and both connection entries need somewhere to dial.
+	// Only browsing is out of amulegui's reach, because EC names a browse target by
+	// ECID and this peer has no daemon-side object; chat addresses by GUI_ID, which
+	// is the address itself. Unfriending needs only the record we have, friending
+	// needs an address to store.
 	menu->Enable(MP_ADDFRIEND, known != nullptr || peer.CanBeFriended());
 	menu->Enable(MP_SENDMESSAGE, peer.CanOpenConnection());
 	menu->Enable(MP_SHOWLIST, peer.CanOpenConnection() && PeerBrowseIsPossible(peer));
@@ -174,23 +170,21 @@ wxMenu *BuildPeerContextMenu(const PeerIdentity &peer)
 
 // Whether this build can browse a peer it is not already connected to.
 //
-// Monolithic aMule owns its client list and can make one from an address.
-// amulegui cannot: EC names a browse target by ECID, and a peer that is
+// Monolithic aMule owns its client list and can make one from an address;
+// amulegui cannot, since EC names a browse target by ECID and a peer that is
 // neither connected nor a friend has no daemon-side object to have one.
 //
-// Chat is deliberately NOT covered by this. EC_OP_CHAT_SEND takes a bare
-// GUI_ID, which is built from the address alone, so messaging a peer we only
-// hold an address for works in both builds.
+// Chat is deliberately NOT covered: EC_OP_CHAT_SEND takes a bare GUI_ID, built
+// from the address alone, so it works in both builds.
 bool PeerBrowseIsPossible(const PeerIdentity &peer)
 {
 #ifndef CLIENT_GUI
 	(void)peer;
 	return true;
 #else
-	// EC names a browse target by ECID. A peer we are connected to has one as
-	// a client, and a friend has one as a friend record, and CFriendListRem
-	// already browses both. Only a peer that is neither has no daemon-side
-	// object to name, which is the case this cannot reach.
+	// EC names a browse target by ECID. A connected peer has one as a client and a
+	// friend has one as a friend record, both of which CFriendListRem already
+	// browses; only a peer that is neither has nothing to name.
 	return peer.client.IsLinked() || PeerIsFriend(peer);
 #endif
 }
@@ -215,10 +209,9 @@ bool PeerActionViewFiles(const PeerIdentity &peer)
 	// leaving the caller to assume the browse was asked for.
 	return false;
 #else
-	// Only now is a client made and a connection opened: the user asked to
-	// browse, which cannot be answered from the stored record. Passing the
-	// hash lets the call reuse the client it made last time instead of
-	// stacking up a new one per click.
+	// Only now is a client made and a connection opened: the user asked to browse,
+	// which cannot be answered from the stored record. Passing the hash lets the
+	// call reuse the client it made last time instead of stacking up a new one.
 	ClientActionViewFiles(
 		{ theApp->clientlist->CreateForAddress(peer.hash, peer.ip, peer.port, peer.name) });
 	return true;
@@ -234,14 +227,12 @@ void PeerActionSendMessage(const PeerIdentity &peer)
 	if (!peer.CanOpenConnection()) {
 		return;
 	}
-	// The address is the whole target: monolithic looks the client up by it,
-	// and amulegui sends the GUI_ID over EC for the daemon to resolve. Either
-	// way CClientList::SendChatMessage() makes the client if there is none,
-	// so there is nothing to pre-create here.
+	// The address is the whole target: monolithic looks the client up by it, and
+	// amulegui sends the GUI_ID over EC for the daemon to resolve. Either way
+	// CClientList::SendChatMessage() makes the client if there is none.
 	//
-	// The hash stands in for a missing name here, and only here: this label
-	// titles the chat tab and is not stored anywhere, unlike the name that
-	// goes into a friend record.
+	// The hash stands in for a missing name here, and only here: this label titles
+	// the chat tab and is not stored anywhere.
 	PromptAndSendChatMessage(
 		peer.name.IsEmpty() ? peer.hash.Encode() : peer.name, GUI_ID(peer.ip, peer.port));
 }
@@ -249,9 +240,9 @@ void PeerActionSendMessage(const PeerIdentity &peer)
 CFriend *FriendForClient(const CClientRef &client)
 {
 	// Linkage first, then the client's own identity. The linkage alone is not
-	// enough: CFriendList::AddFriend(hash, ip, port, name) stores a record
-	// without calling LinkClient(), so a friend added from the dialog while
-	// its peer is connected is a friend that IsFriend() denies.
+	// enough: CFriendList::AddFriend(hash, ip, port, name) stores a record without
+	// calling LinkClient(), so a friend added from the dialog while its peer is
+	// connected is a friend that IsFriend() denies.
 	CClientRef &live = const_cast<CClientRef &>(client);
 	if (CFriend *linked = live.GetFriend()) {
 		return linked;
@@ -261,9 +252,9 @@ CFriend *FriendForClient(const CClientRef &client)
 
 CFriend *FriendFor(const PeerIdentity &peer)
 {
-	// One step for every caller, menu and action alike: deciding this per
-	// caller is how a menu entry and the thing it triggers end up disagreeing
-	// about whether a peer is already a friend, and an "Add" that removes.
+	// One step for every caller, menu and action alike: deciding this per caller is
+	// how a menu entry and the thing it triggers end up disagreeing about whether a
+	// peer is already a friend, and an "Add" that removes.
 	if (peer.client.IsLinked()) {
 		return FriendForClient(peer.client);
 	}
@@ -307,14 +298,12 @@ void ReportFriendSkips(size_t skipped)
 
 bool ConfirmBrowseAction(wxWindow *parent, size_t count)
 {
-	// The connection line is stated unconditionally, because whether a browse
-	// dials is a property of each peer rather than of the list asking. A peer
-	// we hold no socket for is contacted: RequestSharedFileList() uses an
-	// existing connection only when IsConnected(), and otherwise calls
-	// TryToContact. Every one of these lists can hold such a peer, queued and
-	// A4AF sources in the per-file lists and stored rows in the history one,
-	// and no caller could answer it anyway: each takes its count before the
-	// selection is resolved, deliberately.
+	// The connection line is stated unconditionally, because whether a browse dials
+	// is a property of each peer rather than of the list asking. A peer we hold no
+	// socket for is contacted: RequestSharedFileList() uses an existing connection
+	// only when IsConnected(), and otherwise calls TryToContact. Every one of these
+	// lists can hold such a peer, and no caller could answer it anyway -- each takes
+	// its count before the selection is resolved.
 	wxString message = CFormat(wxPLURAL("Request the shared files of %u client?",
 				   "Request the shared files of %u clients?",
 				   count)) %
@@ -349,21 +338,20 @@ bool PeerIsFriend(const PeerIdentity &peer)
 
 size_t PeerActionSetFriends(const std::vector<PeerIdentity> &peers, bool addThem)
 {
-	// One write for the whole run. CFriendList saves after every add and
-	// remove, so without this a large selection rewrites emfriends.met once
-	// per row, on the GUI thread, with the file growing as it goes.
+	// One write for the whole run. CFriendList saves after every add and remove, so
+	// without this a large selection rewrites emfriends.met once per row, on the GUI
+	// thread, with the file growing as it goes.
 	//
 	// Scoped, not a bare pair of calls: a batch left open makes every later
-	// SaveList() a silent no-op, including the one in ~CFriendList(), so a
-	// single escape from this loop would lose the friend list on exit.
+	// SaveList() a silent no-op, the one in ~CFriendList() included.
 	size_t skipped = 0;
 	FriendListBatch batch;
 	for (const PeerIdentity &peer : peers) {
 		CFriend *known = FriendFor(peer);
-		// One direction for the whole run, taken from the entry the user
-		// picked. Toggling per row means a selection holding both friends and
-		// strangers does the opposite of its own label to half of it, and
-		// removing a friend is the loss of something they curated.
+		// One direction for the whole run, taken from the entry the user picked.
+		// Toggling per row means a selection holding both friends and strangers does
+		// the opposite of its own label to half of it, and removing a friend is the
+		// loss of something they curated.
 		if (addThem) {
 			if (known != nullptr) {
 				continue;
@@ -376,11 +364,10 @@ size_t PeerActionSetFriends(const std::vector<PeerIdentity> &peers, bool addThem
 				continue;
 			}
 			if (peer.client.IsLinked()) {
-				// The client-aware overload, which links the record to the
-				// live client. Storing the address alone leaves the friend
-				// looking offline for the rest of a session we are already
-				// talking through, and leaves its friend slot unsettable,
-				// because that entry is gated on the linkage.
+				// The client-aware overload, which links the record to the live
+				// client. Storing the address alone leaves the friend looking
+				// offline for the rest of a session we are already talking through,
+				// and its friend slot unsettable, that entry being gated on linkage.
 				theApp->friendlist->AddFriend(peer.client);
 			} else {
 				theApp->friendlist->AddFriend(peer.hash, peer.ip, peer.port, peer.name);
@@ -394,12 +381,11 @@ size_t PeerActionSetFriends(const std::vector<PeerIdentity> &peers, bool addThem
 
 void PeerActionSetFriendSlot(wxWindow *parent, const PeerIdentity &peer, bool checked, size_t selected)
 {
-	// Resolve the friend the same way the menu decided whether to offer this
-	// entry: through the live client's own linkage when there is one, and
-	// from the stored record otherwise. Resolving it differently is how the
-	// menu ends up describing one peer while the action runs on another.
-	// Either way the slot is a property of our own list, so it is settable
-	// on a peer that is not connected, which is the case this list covers.
+	// Resolve the friend the same way the menu decided whether to offer this entry:
+	// through the live client's linkage when there is one, and from the stored
+	// record otherwise. Resolving it differently is how the menu ends up describing
+	// one peer while the action runs on another. Either way the slot is a property
+	// of our own list, so it is settable on a peer that is not connected.
 	theApp->friendlist->SetFriendSlot(FriendFor(peer), checked);
 
 	WarnIfMultipleFriendSlot(parent, selected);
@@ -408,9 +394,8 @@ void PeerActionSetFriendSlot(wxWindow *parent, const PeerIdentity &peer, bool ch
 void ClientActionViewFiles(const std::vector<CClientRef> &clients)
 {
 	// Browse each selected peer, opening one result tab per peer. If a peer's
-	// listing is already open in the Search panel, switch to that tab instead
-	// of re-requesting -- a second request would duplicate the results in the
-	// existing tab. Only once the tab is closed does a fresh request go out.
+	// listing is already open in the Search panel, switch to that tab rather than
+	// re-requesting, which would duplicate the results in it.
 	for (const CClientRef &client : clients) {
 		CClientRef &c = const_cast<CClientRef &>(client);
 		if (!(theApp->amuledlg && theApp->amuledlg->m_searchwnd &&

--- a/src/ClientCreditsList.cpp
+++ b/src/ClientCreditsList.cpp
@@ -83,9 +83,8 @@ const char kMetaMagic[8] = { 'A', 'M', 'U', 'L', 'E', 'M', 'D', '1' };
 const uint8 kMetaVersion = 1;
 //! Names are attacker-supplied; cap what we store rather than what we read.
 //! Counted in characters, because that is what wxString::Left() takes -- a
-//! multi-byte name can therefore occupy more than this many bytes on disk,
-//! which the uint16 length field has ample room for. The cap is storage
-//! sanity, not a bound the format depends on.
+//! multi-byte name can occupy more bytes on disk, which the uint16 length field
+//! has ample room for. Storage sanity, not a bound the format depends on.
 const size_t kMetaMaxNameChars = 64;
 } // namespace
 
@@ -112,7 +111,6 @@ void CClientCreditsList::LoadList()
 
 		bool bCreateBackup = TRUE;
 		if (bakFileName.FileExists()) {
-			// Ok, the backup exist, get the size
 			CFile hBakFile(bakFileName);
 			if (hBakFile.GetLength() > file.GetLength()) {
 				// the size of the backup was larger then the
@@ -135,7 +133,6 @@ void CClientCreditsList::LoadList()
 				AddDebugLogLineC(
 					logCredits, CFormat("Could not create backup file '%s'") % fileName);
 			}
-			// reopen file
 			if (!file.Open(fileName, CFile::read)) {
 				AddDebugLogLineC(logCredits, "Failed to load creditfile");
 				return;
@@ -204,11 +201,10 @@ void CClientCreditsList::LoadList()
 
 void CClientCreditsList::LoadMetaTrailer(CFile &file)
 {
-	// Optional by construction: a file written by any older build simply ends
-	// after the last record. Everything here is best-effort -- the credits are
-	// already loaded and must survive whatever this finds, so a trailer that is
-	// absent, truncated or unrecognised is dropped rather than treated as a
-	// corrupt file.
+	// Optional by construction: a file written by any older build simply ends after
+	// the last record. Everything here is best-effort -- the credits are already
+	// loaded and must survive whatever this finds, so a trailer that is absent,
+	// truncated or unrecognised is dropped rather than treated as corruption.
 	try {
 		const uint64 remaining = file.GetLength() - file.GetPosition();
 		if (remaining < sizeof(kMetaMagic) + 1 + 4) {
@@ -284,7 +280,6 @@ void CClientCreditsList::SaveList()
 			uint32 count = 0;
 
 			file.WriteUInt8(CREDITFILE_VERSION);
-			// Temporary place-holder for number of structs
 			file.WriteUInt32(0);
 
 			ClientMap::iterator it = m_mapClients.begin();
@@ -307,7 +302,6 @@ void CClientCreditsList::SaveList()
 				}
 			}
 
-			// Write the actual number of structs
 			file.Seek(1);
 			file.WriteUInt32(count);
 
@@ -364,12 +358,11 @@ void CClientCreditsList::SaveMetaTrailer(CFile &file)
 			file.WriteUInt8(meta.clientSoft);
 			file.WriteUInt8(meta.sourceFrom);
 			file.WriteUInt8(meta.obfuscation);
-			// Two length bytes because CFileDataIO supports 0, 2 or 4 and
-			// rejects anything else -- a 1-byte prefix throws
-			// "Invalid length for string-length field" from inside the
-			// write, which the handler below would then swallow, leaving a
-			// trailer truncated mid-entry. The cap is enforced here, not by
-			// the field width.
+			// Two length bytes because CFileDataIO supports 0, 2 or 4 and rejects
+			// anything else: a 1-byte prefix throws "Invalid length for
+			// string-length field" from inside the write, which the handler below
+			// would swallow, leaving a trailer truncated mid-entry. The cap is
+			// enforced here, not by the field width.
 			file.WriteString(meta.name.Left(kMetaMaxNameChars), utf8strRaw, sizeof(uint16));
 		}
 	} catch (const CIOFailureException &e) {
@@ -426,11 +419,7 @@ bool CClientCreditsList::CreateKeyPair()
 		privkey.DEREncode(*privkeysink);
 		privkeysink->MessageEnd();
 
-		// Do not delete these pointers or it will blow in your face.
-		// cryptopp semantics is giving ownership of these objects.
-		//
-		// delete privkeysink;
-		// delete fileSink;
+		// Do not delete these pointers: cryptopp takes ownership of them.
 
 		AddDebugLogLineN(logCredits, "Created new RSA keypair");
 	} catch (const CryptoPP::Exception &e) {
@@ -454,7 +443,6 @@ void CClientCreditsList::InitalizeCrypting()
 	}
 
 	try {
-		// check if keyfile is there
 		if (wxFileExists(thePrefs::GetConfigDir() + CRYPTKEY_FILENAME)) {
 			off_t keySize = CPath::GetFileSize(thePrefs::GetConfigDir() + CRYPTKEY_FILENAME);
 
@@ -471,12 +459,10 @@ void CClientCreditsList::InitalizeCrypting()
 			CreateKeyPair();
 		}
 
-		// load private key
 		CryptoPP::FileSource filesource(filename2char(thePrefs::GetConfigDir() + CRYPTKEY_FILENAME),
 			true,
 			new CryptoPP::Base64Decoder);
 		m_pSignkey = new CryptoPP::RSASSA_PKCS1v15_SHA_Signer(filesource);
-		// calculate and store public key
 		CryptoPP::RSASSA_PKCS1v15_SHA_Verifier pubkey(
 			*static_cast<CryptoPP::RSASSA_PKCS1v15_SHA_Signer *>(m_pSignkey));
 		CryptoPP::ArraySink asink(m_abyMyPublicKey, 80);
@@ -506,7 +492,6 @@ uint8 CClientCreditsList::CreateSignature(CClientCredits *pTarget,
 	if (signer == NULL)
 		signer = static_cast<CryptoPP::RSASSA_PKCS1v15_SHA_Signer *>(m_pSignkey);
 
-	// create a signature of the public key from pTarget
 	wxASSERT(pTarget);
 	wxASSERT(pachOutput);
 
@@ -629,7 +614,6 @@ bool CClientCreditsList::CryptoAvailable() const
 #ifdef _DEBUG
 bool CClientCreditsList::Debug_CheckCrypting()
 {
-	// create random key
 	CryptoPP::AutoSeededX917RNG<CryptoPP::DES_EDE3> rng;
 
 	CryptoPP::RSASSA_PKCS1v15_SHA_Signer priv(rng, 384);
@@ -646,7 +630,6 @@ bool CClientCreditsList::Debug_CheckCrypting()
 	CClientCredits newcredits(newcstruct);
 	newcredits.SetSecureIdent(m_abyMyPublicKey, m_nMyPublicKeyLen);
 	newcredits.m_dwCryptRndChallengeFrom = challenge;
-	// create signature with fake priv key
 	uint8_t pachSignature[200];
 	memset(pachSignature, 0, 200);
 	uint8 sigsize = CreateSignature(&newcredits, pachSignature, 200, 0, false, &priv);
@@ -656,10 +639,8 @@ bool CClientCreditsList::Debug_CheckCrypting()
 	CClientCredits newcredits2(newcstruct2);
 	newcredits2.m_dwCryptRndChallengeFor = challenge;
 
-	// if you uncomment one of the following lines the check has to fail
-	// abyPublicKey[5] = 34;
-	// m_abyMyPublicKey[5] = 22;
-	// pachSignature[5] = 232;
+	// Uncommenting any of abyPublicKey[5] = 34, m_abyMyPublicKey[5] = 22 or
+	// pachSignature[5] = 232 makes the check below fail, as it should.
 
 	newcredits2.SetSecureIdent(abyPublicKey, PublicKeyLen);
 

--- a/src/ClientDetailDialog.cpp
+++ b/src/ClientDetailDialog.cpp
@@ -78,10 +78,9 @@ ClientDetailInfo ClientDetailInfoFromClient(const CClientRef &client)
 void CClientDetailDialog::Build()
 {
 	wxSizer *content = clientDetails(this, true);
-	// The Close button uses ID_CLOSEWND rather than wxID_CANCEL, so
-	// wxDialog doesn't auto-bind Escape to it. Tell wxDialog to treat
-	// ID_CLOSEWND as the escape target so pressing Escape dismisses
-	// the dialog the same way clicking Close does.
+	// The Close button uses ID_CLOSEWND rather than wxID_CANCEL, so wxDialog does
+	// not auto-bind Escape to it; name it as the escape target so Escape dismisses
+	// the dialog the way clicking Close does.
 	SetEscapeId(ID_CLOSEWND);
 	OnInitDialog();
 	content->SetSizeHints(this);
@@ -116,38 +115,32 @@ bool CClientDetailDialog::OnInitDialog()
 	// measurement, and these are the absence of one.
 	static const wxString kNoValue = "-";
 
-	// Username and hash are reported independently. A credit record keeps a
-	// hash long before it has a name, because the core only writes the name
-	// out at disconnect, so the two are not known together and the list row
-	// is already showing that hash beside this dialog.
+	// Username and hash are reported independently: a credit record keeps a hash
+	// long before it has a name, because the core only writes the name out at
+	// disconnect, so the two are not known together.
 	CastChild(ID_DNAME, wxStaticText)
 		->SetLabel(m_info.userName.IsEmpty() ? _("Unknown") : m_info.userName);
 	CastChild(ID_DHASH, wxStaticText)
 		->SetLabel(m_info.userHash.IsEmpty() ? _("Unknown") : m_info.userHash.Encode());
 
-	// Client Software
 	if (!m_info.osInfo.IsEmpty()) {
 		CastChild(ID_DSOFT, wxStaticText)->SetLabel(m_info.softStr + " (" + m_info.osInfo + ")");
 	} else {
 		CastChild(ID_DSOFT, wxStaticText)->SetLabel(m_info.softStr);
 	}
 
-	// Client Version
 	CastChild(ID_DVERSION, wxStaticText)->SetLabel(m_info.softVerStr);
 
-	// User ID
 	CastChild(ID_DID, wxStaticText)
 		->SetLabel(m_info.hasSession ? wxString(CFormat("%u (%s)") % m_info.userIdHybrid %
 							(m_info.lowId ? _("LowID") : _("HighID")))
 					     : kNoValue);
 
-	// Client IP/Port
 	CastChild(ID_DIP, wxStaticText)
 		->SetLabel(m_info.fullIp.IsEmpty()
 				   ? kNoValue
 				   : wxString(CFormat("%s:%i") % m_info.fullIp % m_info.userPort));
 
-	// Server IP/Port/Name
 	if (m_info.serverIp) {
 		wxString srvaddr = Uint32toStringIP(m_info.serverIp);
 		CastChild(ID_DSIP, wxStaticText)->SetLabel(CFormat("%s:%i") % srvaddr % m_info.serverPort);

--- a/src/ClientHistoryListCtrl.cpp
+++ b/src/ClientHistoryListCtrl.cpp
@@ -141,12 +141,11 @@ size_t CClientHistoryListCtrl::AppendLiveRow(const CMD4Hash &hash, const LiveCli
 	row.clientSoft = live.clientSoft;
 	row.sourceFrom = live.sourceFrom;
 	row.nameCell = live.nameCell;
-	// The core wrote this peer's metadata when it said hello -- CClientCredits
-	// ::UpdateMeta() from ProcessHelloTypePacket(), which stamps first-seen the
-	// first time a peer gets a record. The history snapshot predates that, so
-	// the value is not in our rows; it is simply "now", which is what the core
-	// recorded a moment ago. hasMeta stays false because the *store* did not
-	// hold this peer when we loaded, and the columns key on the values.
+	// The core wrote this peer's metadata when it said hello, stamping first-seen
+	// the first time a peer gets a record. The history snapshot predates that, so
+	// the value is not in our rows; it is simply "now". hasMeta stays false because
+	// the STORE did not hold this peer when we loaded, and the columns key on the
+	// values.
 	row.firstSeen = static_cast<uint32>(wxDateTime::GetTimeNow());
 	row.sessions = 1;
 	row.hasMeta = false;
@@ -199,19 +198,15 @@ void CClientHistoryListCtrl::ReconcileLive(const std::unordered_map<CMD4Hash, Li
 		row.upSpeed = entry.second.upSpeed;
 		row.downSpeed = entry.second.downSpeed;
 
-		// Identity, when the peer in front of us knows more than the record
-		// does. A record only gains a name when the core writes its metadata
-		// at disconnect, so a peer we have never finished a session with shows
-		// as its hash -- which used to resolve on the next load and now would
-		// never resolve at all, since the tab loads once. A connected peer can
-		// simply say who it is.
+		// Identity, when the peer in front of us knows more than the record does. A
+		// record only gains a name when the core writes its metadata at disconnect,
+		// so a peer we have never finished a session with shows as its hash -- which
+		// used to resolve on the next load and now never would, the tab loading once.
 		//
 		// Guarded on the live name being known: a peer whose handshake has not
-		// completed yet has none, and an empty one must not overwrite a stored
-		// name we already have. Beyond that the test covers every field the
-		// body copies -- the badges in particular move while the name and
-		// address stay put, so a narrower test would freeze them for the life
-		// of the session.
+		// completed has none, and an empty one must not overwrite a stored name.
+		// Beyond that the test covers every field the body copies -- the badges move
+		// while the name and address stay put, so a narrower test would freeze them.
 		if (!entry.second.name.IsEmpty() &&
 			(row.name != entry.second.name || row.version != entry.second.version ||
 				row.ip != entry.second.ip || row.port != entry.second.port ||
@@ -229,12 +224,10 @@ void CClientHistoryListCtrl::ReconcileLive(const std::unordered_map<CMD4Hash, Li
 			changed = true;
 		}
 
-		// A record we loaded before this peer had any metadata -- everything
-		// written before #902 existed, which on a real store is nearly all of
-		// it. The core stamped first-seen at this peer's hello, the same as for
-		// a peer we had never met; only a record that already carries one is
-		// left alone, since for that the stored value is the truth and ours
-		// would just be the current session.
+		// A record loaded before this peer had any metadata -- everything written
+		// before #902, which on a real store is nearly all of it. The core stamped
+		// first-seen at this peer's hello, as for one we had never met; a record that
+		// already carries one is left alone, its stored value being the truth.
 		if (row.firstSeen == 0) {
 			row.firstSeen = static_cast<uint32>(wxDateTime::GetTimeNow());
 			if (row.sessions == 0) {
@@ -254,10 +247,9 @@ void CClientHistoryListCtrl::ReconcileLive(const std::unordered_map<CMD4Hash, Li
 	for (const size_t index : m_onlineRows) {
 		if (stillOnline.count(index) == 0) {
 			m_rows[index].online = false;
-			// Seen until this moment, which is what the core will write to
-			// the record at its own disconnect handling. Leaving the stored
-			// value would show the previous disconnect as the last contact,
-			// months ago for a peer that was here a second before.
+			// Seen until this moment, which is what the core will write to the
+			// record at its own disconnect handling. Leaving the stored value would
+			// show the previous disconnect as the last contact.
 			m_rows[index].lastSeen = static_cast<uint32>(wxDateTime::GetTimeNow());
 			// Nothing is moving for a peer that is gone.
 			m_rows[index].upSpeed = 0;
@@ -316,23 +308,21 @@ bool CClientHistoryListCtrl::PeerForItem(wxUIntPtr data, PeerIdentity &out) cons
 	// would be read as belonging to this row.
 	out = PeerIdentity();
 	// Identity comes from the row, so a peer we are not connected to is still
-	// named: the hash, name, address and port the store kept are enough to
-	// friend it, and enough to open a connection if the user asks for one.
+	// named: the hash, name, address and port the store kept are enough to friend
+	// it, and enough to open a connection if asked.
 	//
-	// The live client is attached when there is one, matched by user hash
-	// rather than ECID: a history row outlives the daemon process whose ECIDs
-	// would have named the peer, and the hash is what the credit store is
-	// keyed on.
+	// The live client is attached when there is one, matched by user hash rather
+	// than ECID: a history row outlives the daemon process whose ECIDs would have
+	// named the peer.
 	const ClientHistoryRow *row = RowFor(data);
 	if (row == nullptr || row->hash.IsEmpty()) {
 		return false;
 	}
 	out.hash = row->hash;
-	// The record's own name, not the Name column's fallback. This one is
-	// written to disk by AddFriend() and set on the live client by
-	// CreateForAddress(), so a placeholder here would persist a hex hash as
-	// somebody's name. Empty is meaningful: CFriend renders it as "?" until
-	// the peer tells us what it is called.
+	// The record's own name, not the Name column's fallback. This one is written to
+	// disk by AddFriend() and set on the live client by CreateForAddress(), so a
+	// placeholder here would persist a hex hash as somebody's name. Empty is
+	// meaningful: CFriend renders it as "?" until the peer says otherwise.
 	out.name = row->name;
 	out.ip = row->ip;
 	out.port = row->port;
@@ -406,9 +396,8 @@ wxString CClientHistoryListCtrl::GetItemColumnText(wxUIntPtr item, unsigned colu
 			       : FormatLocalDateTime(wxDateTime(static_cast<time_t>(row->firstSeen)));
 
 	case COLUMN_HISTORY_LAST_SEEN:
-		// A date is the wrong answer for a peer that is here now -- and the
-		// stored last-seen for a connected peer is whenever it previously
-		// disconnected, which reads as though it were long gone.
+		// A date is the wrong answer for a peer that is here now, and the stored
+		// last-seen for a connected peer is whenever it previously disconnected.
 		if (row->online) {
 			return _("Online now");
 		}
@@ -463,9 +452,9 @@ int CClientHistoryListCtrl::CompareItemData(
 	case COLUMN_HISTORY_FIRST_SEEN:
 		return modifier * CmpAny(r1->firstSeen, r2->firstSeen);
 	case COLUMN_HISTORY_LAST_SEEN:
-		// Peers that are here now sort as the most recent thing there is, so
-		// the column reads as "when was this peer last around" throughout
-		// instead of stranding the live ones at their stale timestamps.
+		// Peers that are here now sort as the most recent thing there is, so the
+		// column reads as "when was this peer last around" throughout instead of
+		// stranding the live ones at their stale timestamps.
 		if (r1->online != r2->online) {
 			return modifier * (r1->online ? 1 : -1);
 		}

--- a/src/ClientList.cpp
+++ b/src/ClientList.cpp
@@ -157,25 +157,20 @@ CClientRef CClientList::CreateForAddress(const CMD4Hash &hash, uint32 ip, uint16
 	// saving itself, a menu deciding whether it can message -- sees 0.0.0.0.
 	client->SetIP(ip);
 	client->SetUserName(name);
-	// The hash is deliberately NOT seeded. This client has never connected,
-	// so it carries no credits and reports zero for every lifetime total,
-	// while a hash is exactly what makes the Clients page treat it as a peer
-	// whose totals are known: it would publish those zeroes over the stored
-	// Total Up / Down of the row that asked for it, and mark that row online.
-	// The handshake sets the real hash when the peer answers, and the lookup
-	// above finds this object again in the meantime.
+	// The hash is deliberately NOT seeded. This client has never connected, so it
+	// carries no credits and reports zero for every lifetime total, while a hash is
+	// exactly what makes the Clients page treat it as a peer whose totals are
+	// known: it would publish those zeroes over the stored Total Up / Down of the
+	// row that asked for it, and mark that row online. The handshake sets the real
+	// hash when the peer answers.
 	AddClient(client);
 	return CCLIENTREF(client, wxT("CClientList::CreateForAddress"));
 }
 
 void CClientList::AddClient(CUpDownClient *toadd)
 {
-	// Ensure that only new clients can be added to the list
 	if (toadd->GetClientState() == CS_NEW) {
-		// Update the client-state
 		toadd->m_clientState = CS_LISTED;
-
-		// Notify_ClientCtrlAddClient( toadd );
 
 		// We always add the ID/ptr pair, regardless of the actual ID value
 		m_clientList.insert(IDMapPair(toadd->GetUserIDHybrid(),
@@ -210,7 +205,6 @@ void CClientList::RemoveClient(CUpDownClient *client)
 	}
 
 	if (RemoveIDFromList(client)) {
-		// Also remove the ip and hash entries
 		RemoveIPFromList(client);
 		RemoveHashFromList(client);
 	}
@@ -218,24 +212,19 @@ void CClientList::RemoveClient(CUpDownClient *client)
 
 void CClientList::UpdateClientID(CUpDownClient *client, uint32 newID)
 {
-	// Sanity check
 	if ((client->GetClientState() != CS_LISTED) || (client->GetUserIDHybrid() == newID))
 		return;
 
-	// First remove the ID entry
 	RemoveIDFromList(client);
 
-	// Add the new entry
 	m_clientList.insert(IDMapPair(newID, CCLIENTREF(client, "CClientList::UpdateClientID")));
 }
 
 void CClientList::UpdateClientIP(CUpDownClient *client, uint32 newIP)
 {
-	// Sanity check
 	if ((client->GetClientState() != CS_LISTED) || (client->GetIP() == newIP))
 		return;
 
-	// Remove the old IP entry
 	RemoveIPFromList(client);
 
 	if (newIP) {
@@ -245,14 +234,11 @@ void CClientList::UpdateClientIP(CUpDownClient *client, uint32 newIP)
 
 void CClientList::UpdateClientHash(CUpDownClient *client, const CMD4Hash &newHash)
 {
-	// Sanity check
 	if ((client->GetClientState() != CS_LISTED) || (client->GetUserHash() == newHash))
 		return;
 
-	// Remove the old entry
 	RemoveHashFromList(client);
 
-	// And add the new one if valid
 	if (!newHash.IsEmpty()) {
 		m_hashList.insert(HashMapPair(newHash, CCLIENTREF(client, "CClientList::UpdateClientHash")));
 	}
@@ -262,7 +248,6 @@ bool CClientList::RemoveIDFromList(CUpDownClient *client)
 {
 	bool result = false;
 
-	// First remove the ID entry
 	std::pair<IDMap::iterator, IDMap::iterator> range =
 		m_clientList.equal_range(client->GetUserIDHybrid());
 
@@ -282,12 +267,10 @@ bool CClientList::RemoveIDFromList(CUpDownClient *client)
 
 void CClientList::RemoveIPFromList(CUpDownClient *client)
 {
-	// Check if we need to look for the IP entry
 	if (!client->GetIP()) {
 		return;
 	}
 
-	// Remove the IP entry
 	std::pair<IDMap::iterator, IDMap::iterator> range = m_ipList.equal_range(client->GetIP());
 
 	for (; range.first != range.second; ++range.first) {
@@ -302,12 +285,10 @@ void CClientList::RemoveIPFromList(CUpDownClient *client)
 
 void CClientList::RemoveHashFromList(CUpDownClient *client)
 {
-	// Nothing to remove
 	if (!client->HasValidHash()) {
 		return;
 	}
 
-	// Find all items with the specified hash
 	std::pair<HashMap::iterator, HashMap::iterator> range = m_hashList.equal_range(client->GetUserHash());
 
 	for (; range.first != range.second; ++range.first) {
@@ -403,17 +384,14 @@ CUpDownClient *CClientList::FindMatchingClient(CUpDownClient *client)
 
 	// If anything else fails, then we look at hashes
 	if (client->HasValidHash()) {
-		// Find all items with the specified hash
 		std::pair<HashMap::iterator, HashMap::iterator> range =
 			m_hashList.equal_range(client->GetUserHash());
 
-		// Just return the first item if any
 		if (range.first != range.second) {
 			return range.first->second.GetClient();
 		}
 	}
 
-	// Nothing found, must be a new client
 	return NULL;
 }
 
@@ -489,12 +467,10 @@ bool CClientList::AttachToAlreadyKnown(CUpDownClient **client, CClientTCPSocket 
 
 CUpDownClient *CClientList::FindClientByIP(uint32 clientip, uint16 port)
 {
-	// Find all items with the specified ip
 	std::pair<IDMap::iterator, IDMap::iterator> range = m_ipList.equal_range(clientip);
 
 	for (; range.first != range.second; ++range.first) {
 		CUpDownClient *cur_client = range.first->second.GetClient();
-		// Check if it's actually the client we want
 		if (cur_client->GetUserPort() == port) {
 			return cur_client;
 		}
@@ -505,7 +481,6 @@ CUpDownClient *CClientList::FindClientByIP(uint32 clientip, uint16 port)
 
 CUpDownClient *CClientList::FindClientByIP(uint32 clientip)
 {
-	// Find all items with the specified ip
 	std::pair<IDMap::iterator, IDMap::iterator> range = m_ipList.equal_range(clientip);
 
 	return (range.first != range.second) ? range.first->second.GetClient() : NULL;
@@ -524,7 +499,6 @@ CUpDownClient *CClientList::FindClientByECID(uint32 ecid) const
 
 bool CClientList::IsIPAlreadyKnown(uint32_t ip)
 {
-	// Find all items with the specified ip
 	std::pair<IDMap::iterator, IDMap::iterator> range = m_ipList.equal_range(ip);
 	return range.first != range.second;
 }
@@ -562,13 +536,11 @@ void CClientList::AddTrackClient(CUpDownClient *toadd)
 		CDeletedClient::PaHList::iterator it2 = pResult->m_ItemsList.begin();
 		for (; it2 != pResult->m_ItemsList.end(); ++it2) {
 			if (it2->nPort == toadd->GetUserPort()) {
-				// already tracked, update
 				it2->pHash = toadd->GetCreditsHash();
 				return;
 			}
 		}
 
-		// New client for that IP, add an entry
 		CDeletedClient::PortAndHash porthash = { toadd->GetUserPort(), toadd->GetCreditsHash() };
 		pResult->m_ItemsList.push_back(porthash);
 	} else {
@@ -606,10 +578,9 @@ void CClientList::Process()
 		}
 	}
 
-	// We need to try to connect to the clients in m_KadList
-	// If connected, remove them from the list and send a message back to Kad so we can send a ACK.
-	// If we don't connect, we need to remove the client..
-	// The sockets timeout should delete this object.
+	// Try to connect to the clients in m_KadList. If connected, remove them from
+	// the list and send a message back to Kad so we can send an ACK; if not, the
+	// client is removed and the socket timeout deletes the object.
 
 	// buddy is just a flag that is used to make sure we are still connected or connecting to a buddy.
 	buddyState buddy = Disconnected;
@@ -680,12 +651,10 @@ void CClientList::Process()
 			break;
 
 		case KS_QUEUED_BUDDY:
-			// We are firewalled and want to request this client to be a buddy.
-			// But first we check to make sure we are not already trying another client.
-			// If we are not already trying. We try to connect to this client.
-			// If we are already connected to a buddy, we set this client to KS_NONE and it's
-			// removed next cycle. If we are trying to connect to a buddy, we just ignore as the
-			// one we are trying may fail and we can then try this one.
+			// We are firewalled and want this client as a buddy, but only if we
+			// are not already trying another. Already connected to a buddy: set
+			// KS_NONE and it goes next cycle. Already trying one: ignore this
+			// client, since the attempt in flight may still fail.
 			if (m_nBuddyStatus == Disconnected) {
 				buddy = Connecting;
 				m_nBuddyStatus = Connecting;
@@ -700,11 +669,9 @@ void CClientList::Process()
 			break;
 
 		case KS_CONNECTING_BUDDY:
-			// We are trying to connect to this client.
-			// Although it should NOT happen, we make sure we are not already connected to a
-			// buddy. If we are we set to KS_NONE and it's removed next cycle. But if we are not
-			// already connected, make sure we set the flag to connecting so we know things are
-			// working correctly.
+			// We are trying to connect to this client. It should not happen, but
+			// make sure we are not already connected to a buddy -- if we are, set
+			// KS_NONE for next cycle -- and otherwise flag connecting.
 			if (m_nBuddyStatus == Connected) {
 				cur_client->SetKadState(KS_NONE);
 			} else {
@@ -755,12 +722,10 @@ void CClientList::Process()
 		// we only need a buddy if direct callback is not available
 		if (Kademlia::CKademlia::IsFirewalled() &&
 			Kademlia::CUDPFirewallTester::IsFirewalledUDP(true)) {
-			// TODO: Kad buddies won't work with RequireCrypt, so it is disabled for now, but
-			// should (and will) be fixed in later version Update: buddy connections themselves
-			// support obfuscation properly since eMule 0.49a and aMule SVN 2008-05-09 (this makes
-			// it work fine if our buddy uses require crypt), however callback requests don't
-			// support it yet so we wouldn't be able to answer callback requests with
-			// RequireCrypt, protocolchange intended for eMule 0.49b
+			// Kad buddies do not work with RequireCrypt, so it is disabled here.
+			// Buddy connections themselves have supported obfuscation since eMule
+			// 0.49a, but callback requests do not, so we could not answer one
+			// under RequireCrypt.
 			if (m_nBuddyStatus == Disconnected &&
 				Kademlia::CKademlia::GetPrefs()->GetFindBuddy() &&
 				!thePrefs::IsClientCryptLayerRequired()) {
@@ -771,19 +736,17 @@ void CClientList::Process()
 					    true,
 					    Kademlia::CUInt128(true) ^
 						    (Kademlia::CKademlia::GetPrefs()->GetKadID()))) {
-					// This search ID was already going. Most likely reason is that
-					// we found and lost our buddy very quickly and the last search hadn't
-					// had time to be removed yet. Go ahead and set this to happen again
-					// next time around.
+					// This search ID was already going, most likely because we
+					// found and lost a buddy quickly and the last search has
+					// not been removed yet. Set it to happen again next time.
 					Kademlia::CKademlia::GetPrefs()->SetFindBuddy();
 				}
 			}
 		} else {
 			if (m_pBuddy.IsLinked()) {
-				// Lets make sure that if we have a buddy, they are firewalled!
-				// If they are also not firewalled, then someone must have fixed their
-				// firewall or stopped saturating their line.. We just set the state of this
-				// buddy to KS_NONE and things will be cleared up with the next cycle.
+				// If a buddy is not firewalled either, someone has fixed their
+				// firewall or stopped saturating their line, so set KS_NONE and
+				// let the next cycle clear it up.
 				if (!m_pBuddy.HasLowID()) {
 					m_pBuddy.GetClient()->SetKadState(KS_NONE);
 				}
@@ -804,11 +767,11 @@ void CClientList::Process()
 
 void CClientList::AddBannedClient(uint32 dwIP)
 {
-	// Counted only when the address was not already banned. Ban() overwrote
-	// the tick on an address already present and counted it again, and
-	// CUpDownClient::SetSpammer(true) calls Ban() with no IsBanned() check --
-	// so a client banned for aggressiveness and later flagged as a spammer
-	// counted twice for one banned address, while UnBan() gave back one.
+	// Counted only when the address was not already banned. Ban() overwrote the
+	// tick on an address already present and counted it again, and
+	// CUpDownClient::SetSpammer(true) calls Ban() with no IsBanned() check, so a
+	// client banned for aggressiveness and later flagged as a spammer counted
+	// twice while UnBan() gave back one.
 	if (m_bannedList.Ban(dwIP, ::GetTickCount64())) {
 		theStats::AddBannedClient();
 	}
@@ -837,7 +800,6 @@ void CClientList::RemoveBannedClient(uint32 dwIP)
 
 void CClientList::FilterQueues()
 {
-	// Filter client list
 	for (IDMap::iterator it = m_ipList.begin(); it != m_ipList.end();) {
 		IDMap::iterator tmp = it++; // Don't change this to a ++it!
 		CUpDownClient *client = tmp->second.GetClient();
@@ -852,7 +814,6 @@ CClientList::SourceList CClientList::GetClientsByHash(const CMD4Hash &hash)
 {
 	SourceList results;
 
-	// Find all items with the specified hash
 	std::pair<HashMap::iterator, HashMap::iterator> range = m_hashList.equal_range(hash);
 
 	for (; range.first != range.second; ++range.first) {
@@ -866,7 +827,6 @@ CClientList::SourceList CClientList::GetClientsByIP(unsigned long ip)
 {
 	SourceList results;
 
-	// Find all items with the specified hash
 	std::pair<IDMap::iterator, IDMap::iterator> range = m_ipList.equal_range(ip);
 
 	for (; range.first != range.second; range.first++) {
@@ -908,13 +868,11 @@ bool CClientList::SendChatMessage(uint64 client_id, const wxString &message)
 				"Creating") %
 				client_id % Uint32toStringIP(IP_FROM_GUI_ID(client_id)) %
 				PORT_FROM_GUI_ID(client_id));
-		// Through CreateForAddress(), which seeds GetIP() and reuses any
-		// client we already hold for this peer. Constructing one here
-		// directly leaves GetIP() at 0, so AddClient() keeps it out of the
-		// address index and the lookup above misses it next time: one
-		// unreachable client for every message sent. Both builds arrive
-		// here, amulegui by way of EC_OP_CHAT_SEND, so this is the place
-		// to get it right rather than at either call site.
+		// Through CreateForAddress(), which seeds GetIP() and reuses any client we
+		// already hold for this peer. Constructing one here directly leaves GetIP()
+		// at 0, so AddClient() keeps it out of the address index and the lookup
+		// above misses it next time: one unreachable client per message sent. Both
+		// builds arrive here, amulegui by way of EC_OP_CHAT_SEND.
 		CClientRef ref = CreateForAddress(
 			CMD4Hash(), IP_FROM_GUI_ID(client_id), PORT_FROM_GUI_ID(client_id), wxEmptyString);
 		if (!ref.IsLinked()) {
@@ -922,12 +880,10 @@ bool CClientList::SendChatMessage(uint64 client_id, const wxString &message)
 		}
 		client = ref.GetClient();
 	}
-	// Record before sending, and record regardless of the result: a false
-	// return from CUpDownClient::SendChatMessage means "queued while
-	// connecting", not "failed" (the desktop optimistically prints
-	// *** Connecting to Client *** and keeps the line in the transcript), so
-	// gating the store on it would drop exactly the messages a slow peer
-	// receives a moment later.
+	// Record before sending, and regardless of the result: a false return from
+	// CUpDownClient::SendChatMessage means "queued while connecting", not
+	// "failed", so gating the store on it would drop exactly the messages a slow
+	// peer receives a moment later.
 	if (theApp->chatsessions) {
 		theApp->chatsessions->AddOutgoing(client_id, message);
 	}
@@ -963,7 +919,6 @@ bool CClientList::RequestTCP(Kademlia::CContact *contact, uint8_t connectOptions
 			      // with it
 	}
 
-	// Add client to the lists to be processed.
 	pNewClient->SetKadPort(contact->GetUDPPort());
 	pNewClient->SetKadState(KS_QUEUED_FWCHECK);
 	if (contact->GetClientID() != 0) {
@@ -973,7 +928,6 @@ bool CClientList::RequestTCP(Kademlia::CContact *contact, uint8_t connectOptions
 		pNewClient->SetConnectOptions(connectOptions, true, false);
 	}
 	AddToKadList(pNewClient); // This was a direct adding, but I like to check duplicates
-	// This method checks if this is a dup already.
 	AddClient(pNewClient);
 	return true;
 }
@@ -999,7 +953,6 @@ void CClientList::RequestBuddy(Kademlia::CContact *contact, uint8_t connectOptio
 		return;
 	}
 
-	// Add client to the lists to be processed.
 	pNewClient->SetKadPort(contact->GetUDPPort());
 	pNewClient->SetKadState(KS_QUEUED_BUDDY);
 	uint8_t ID[16];
@@ -1007,7 +960,6 @@ void CClientList::RequestBuddy(Kademlia::CContact *contact, uint8_t connectOptio
 	pNewClient->SetUserHash(CMD4Hash(ID));
 	pNewClient->SetConnectOptions(connectOptions, true, false);
 	AddToKadList(pNewClient);
-	// This method checks if this is a dup already.
 	AddClient(pNewClient);
 }
 
@@ -1029,7 +981,6 @@ bool CClientList::IncomingBuddy(Kademlia::CContact *contact, Kademlia::CUInt128 
 		return false; // don't connect ourself
 	}
 
-	// Add client to the lists to be processed.
 	CUpDownClient *pNewClient =
 		new CUpDownClient(contact->GetTCPPort(), contact->GetIPAddress(), 0, 0, NULL, false, true);
 	pNewClient->SetKadPort(contact->GetUDPPort());
@@ -1071,11 +1022,10 @@ bool CClientList::DoRequestFirewallCheckUDP(const Kademlia::CContact &contact)
 	if (IsIPAlreadyKnown(wxUINT32_SWAP_ALWAYS(contact.GetIPAddress()))) {
 		return false;
 	}
-	// fine, just create the client object, set the state and wait
-	// TODO: We don't know the client's userhash, this means we cannot build an obfuscated connection,
-	// which again mean that the whole check won't work on "Require Obfuscation" setting, which is not a
-	// huge problem, but certainly not nice. Only somewhat acceptable way to solve this is to use the
-	// KadID instead.
+	// Just create the client object, set the state and wait.
+	// TODO: we do not know the client's userhash, so no obfuscated connection can
+	// be built and the check does not work under "Require Obfuscation". The only
+	// somewhat acceptable fix is to use the KadID instead.
 	CUpDownClient *pNewClient =
 		new CUpDownClient(contact.GetTCPPort(), contact.GetIPAddress(), 0, 0, NULL, false, true);
 	pNewClient->SetKadState(KS_QUEUED_FWCHECK_UDP);
@@ -1089,15 +1039,12 @@ bool CClientList::DoRequestFirewallCheckUDP(const Kademlia::CContact &contact)
 
 void CClientList::CleanUpClientList()
 {
-	// We remove clients which are not needed any more by time
-	// this check is also done on CUpDownClient::Disconnected, however it will not catch all
-	// cases (if a client changes the state without being connected
-	//
-	// Adding this check directly to every point where any state changes would be more effective,
-	// is however not compatible with the current code, because there are points where a client has
-	// no state for some code lines and the code is also not prepared that a client object gets
-	// invalid while working with it (aka setting a new state)
-	// so this way is just the easy and safe one to go (as long as amule is basically single threaded)
+	// Remove clients that are no longer needed, by time. CUpDownClient::Disconnected
+	// does this check too, but misses the cases where a client changes state without
+	// being connected. Doing it at every state change would be more effective but is
+	// not compatible with the current code: there are points where a client has no
+	// state for a few lines, and nothing is prepared for a client object going
+	// invalid while being worked on.
 	const uint64 cur_tick = ::GetTickCount64();
 	if (m_dwLastClientCleanUp + CLIENTLIST_CLEANUP_TIME < cur_tick) {
 		m_dwLastClientCleanUp = cur_tick;
@@ -1221,8 +1168,6 @@ void CClientList::ProcessDirectCallbackList()
 		CUpDownClient *curClient = it2->GetClient();
 		if (curClient->GetDirectCallbackTimeout() < cur_tick) {
 			wxASSERT(curClient->GetDirectCallbackTimeout() != 0);
-			// TODO LOGREMOVE
-			// DebugLog(_T("DirectCallback timed out (%s)"), pCurClient->DbgGetClientInfo());
 			m_currentDirectCallbacks.erase(it2);
 			if (curClient->Disconnected("Direct Callback Timeout")) {
 				curClient->Safe_Delete();

--- a/src/ClientRowListCtrl.cpp
+++ b/src/ClientRowListCtrl.cpp
@@ -90,10 +90,9 @@ void CClientRowListCtrl::OnItemActivated(wxDataViewEvent &event)
 	ShowDetailsForSelection();
 }
 
-// Opening details is a read-only act: it never creates a client and never
-// opens a connection. A peer we are talking to is snapshotted live, because
-// that knows strictly more; otherwise the row's own record is rendered and
-// the session fields show as absent.
+// Opening details is a read-only act: it never creates a client and never opens
+// a connection. A peer we are talking to is snapshotted live, since that knows
+// strictly more; otherwise the row's own record is rendered.
 void CClientRowListCtrl::ShowDetailsForSelection()
 {
 	// Counted first: resolving the selection to discover it holds more than
@@ -128,13 +127,11 @@ void CClientRowListCtrl::OnItemRightClicked(wxDataViewEvent &event)
 		}
 	}
 
-	// A peer we are not connected to still gets a menu. Friending and the
-	// friend slot are persistent and need no connection at all; browsing and
-	// messaging open one when the user picks them.
-	//
-	// Only the row under the cursor is resolved. The menu describes that one,
-	// and building the whole selection to read its first entry would resolve
-	// every other selected row for nothing.
+	// A peer we are not connected to still gets a menu: friending and the friend
+	// slot are persistent and need no connection, while browsing and messaging open
+	// one when the user picks them. Only the row under the cursor is resolved --
+	// the menu describes that one, and building the whole selection to read its
+	// first entry would resolve every other row for nothing.
 	if (!event.GetItem().IsOk()) {
 		return;
 	}
@@ -153,13 +150,11 @@ void CClientRowListCtrl::OnItemRightClicked(wxDataViewEvent &event)
 	delete menu;
 }
 
-// Both lists are multi-select (CMuleDataViewCtrl forces wxDV_MULTIPLE) and the
-// connected-client paths act on the whole selection, so these do too. But the
-// history list is the entire credit store rather than the handful of peers we
-// happen to be talking to, and the menu is built for one row while the action
-// runs on all of them, so a large selection says so first. Same shape as the
-// shared-files media refresh: one row never costs a click, and what is about to
-// happen is stated in full.
+// Both lists are multi-select and the connected-client paths act on the whole
+// selection, so these do too. But the history list is the entire credit store
+// rather than the handful of peers we happen to be talking to, and the menu is
+// built for one row while the action runs on all of them, so a large selection
+// says so first.
 void CClientRowListCtrl::OnViewFiles(wxCommandEvent &WXUNUSED(event))
 {
 	// Counted from the control, not from resolving the rows: resolving is the

--- a/src/ClientTCPSocket.cpp
+++ b/src/ClientTCPSocket.cpp
@@ -114,14 +114,12 @@ bool CClientTCPSocket::InitNetworkData()
 
 bool CClientTCPSocket::IsDownloadThrottled() const
 {
-	// Inbound peer connection whose source IP is the ed2k server we're
-	// currently connected (or trying to connect) to -- this is the
-	// server's HighID-callback probe, not real peer download traffic.
-	// Skip the global download throttler so a saturated peer-side
-	// budget doesn't delay the probe's read path past the server's
-	// verification timer (#778). Same shape as CServerSocket's
-	// permanent bypass (#393 / 356a59c96), just gated on IP-match
-	// instead of being unconditional.
+	// An inbound peer connection whose source IP is the ed2k server we are
+	// connected (or connecting) to is the server's HighID-callback probe, not peer
+	// download traffic. Skip the global download throttler so a saturated peer-side
+	// budget cannot delay the probe's read path past the server's verification
+	// timer (#778). Same shape as CServerSocket's permanent bypass, gated on
+	// IP-match instead of being unconditional.
 	if (m_remoteip != 0 && theApp->serverconnect && theApp->serverconnect->IsServerIP(m_remoteip)) {
 		return false;
 	}
@@ -135,18 +133,14 @@ void CClientTCPSocket::ResetTimeOutTimer()
 
 bool CClientTCPSocket::CheckTimeOut()
 {
-	// 0.42x
 	uint64 uTimeout = GetTimeOut();
 	if (m_client) {
 
 		if (m_client->GetKadState() == KS_CONNECTED_BUDDY) {
-			// We originally ignored the timeout here for buddies.
-			// This was a stupid idea on my part. There is now a ping/pong system
-			// for buddies. This ping/pong system now prevents timeouts.
-			// This release will allow lowID clients with KadVersion 0 to remain connected.
-			// But a soon future version needs to allow these older clients to time out to prevent
-			// dead connections from continuing. JOHNTODO: Don't forget to remove backward support
-			// in a future release.
+			// The timeout used to be ignored for buddies; the ping/pong system
+			// now prevents those timeouts instead. lowID clients with KadVersion 0
+			// are still allowed to remain connected, but a future version needs to
+			// let them time out so dead connections do not persist.
 			if (m_client->GetKadVersion() == 0) {
 				return false;
 			}
@@ -179,7 +173,6 @@ void CClientTCPSocket::SetClient(CUpDownClient *pClient)
 
 void CClientTCPSocket::OnClose(int nErrorCode)
 {
-	// 0.42x
 	wxASSERT(theApp->listensocket->IsValidSocket(this));
 	CEMSocket::OnClose(nErrorCode);
 	if (nErrorCode) {
@@ -194,9 +187,8 @@ void CClientTCPSocket::Disconnect(const wxString &strReason)
 	byConnected = ES_DISCONNECTED;
 	if (m_client) {
 		if (m_client->Disconnected(strReason, true)) {
-			// Somehow, Safe_Delete() is being called by Disconnected(),
-			// or any other function that sets m_client to NULL,
-			// so we must check m_client first.
+			// Safe_Delete() can be reached from Disconnected(), or anything else
+			// that sets m_client to NULL, so check m_client first.
 			if (m_client) {
 				m_client->SetSocket(NULL);
 				m_client->Safe_Delete();
@@ -232,7 +224,6 @@ void CClientTCPSocket::Safe_Delete_Client()
 bool CClientTCPSocket::ProcessPacket(const uint8_t *buffer, uint32 size, uint8 opcode)
 {
 #ifdef __PACKET_RECV_DUMP__
-	// printf("Rec: OPCODE %x \n",opcode);
 	DumpMem(buffer, size);
 #endif
 	if (!m_client && opcode != OP_HELLO) {
@@ -248,9 +239,8 @@ bool CClientTCPSocket::ProcessPacket(const uint8_t *buffer, uint32 size, uint8 o
 		theStats::AddDownOverheadOther(size);
 		m_client->ProcessHelloAnswer(buffer, size);
 
-		// start secure identification, if
-		//  - we have received OP_EMULEINFO and OP_HELLOANSWER (old eMule)
-		//	- we have received eMule-OP_HELLOANSWER (new eMule)
+		// Start secure identification once both info packets have arrived:
+		// OP_EMULEINFO + OP_HELLOANSWER (old eMule), or eMule-OP_HELLOANSWER (new).
 		if (m_client->GetInfoPacketsReceived() == IP_BOTH) {
 			m_client->InfoPacketsReceived();
 		}
@@ -272,7 +262,6 @@ bool CClientTCPSocket::ProcessPacket(const uint8_t *buffer, uint32 size, uint8 o
 		theStats::AddDownOverheadOther(size);
 		bool bNewClient = !m_client;
 		if (bNewClient) {
-			// create new client to save standard information
 			m_client = new CUpDownClient(this);
 		}
 
@@ -320,19 +309,16 @@ bool CClientTCPSocket::ProcessPacket(const uint8_t *buffer, uint32 size, uint8 o
 
 		wxASSERT(m_client);
 
-		// now we check if we know this client already. if yes this socket will
-		// be attached to the known client, the new client will be deleted
-		// and the var. "client" will point to the known client.
-		// if not we keep our new-constructed client ;)
+		// If we already know this client the socket is attached to the known one,
+		// the new client is deleted and m_client points at the known client;
+		// otherwise the freshly constructed one is kept.
 		if (theApp->clientlist->AttachToAlreadyKnown(&m_client, this)) {
-			// update the old client information
 			bIsMuleHello = m_client->ProcessHelloPacket(buffer, size);
 		} else {
 			theApp->clientlist->AddClient(m_client);
 			m_client->SetCommentDirty();
 		}
 		Notify_SharedCtrlRefreshClient(m_client->ECID(), AVAILABLE_SOURCE);
-		// send a response packet with standard information
 		if ((m_client->GetHashType() == SO_EMULE) && !bIsMuleHello) {
 			m_client->SendMuleInfoPacket(false);
 		}
@@ -342,8 +328,8 @@ bool CClientTCPSocket::ProcessPacket(const uint8_t *buffer, uint32 size, uint8 o
 			m_client->SendHelloAnswer();
 		}
 
-		// Kry - If the other side supports it, send OS_INFO
-		// Client might die from Sending in SendHelloAnswer, so check
+		// Send OS_INFO if the other side supports it. Sending may kill the client,
+		// so it is re-checked.
 		if (m_client && m_client->GetOSInfoSupport()) {
 			m_client->SendMuleInfoPacket(
 				false, true); // Send the OS Info tag on the recycled Mule Info
@@ -394,7 +380,6 @@ bool CClientTCPSocket::ProcessPacket(const uint8_t *buffer, uint32 size, uint8 o
 				}
 			}
 
-			// check to see if this is a new file they are asking for
 			if (m_client->GetUploadFileID() != reqfilehash) {
 				m_client->SetCommentDirty();
 			}
@@ -402,7 +387,6 @@ bool CClientTCPSocket::ProcessPacket(const uint8_t *buffer, uint32 size, uint8 o
 			m_client->SetUploadFileID(reqfile);
 			m_client->ProcessExtendedInfo(&data_in, reqfile);
 
-			// send filename etc
 			CMemFile data_out(128);
 			data_out.WriteHash(reqfile->GetFileHash());
 
@@ -436,7 +420,6 @@ bool CClientTCPSocket::ProcessPacket(const uint8_t *buffer, uint32 size, uint8 o
 			break;
 		}
 
-		// DbT:FileRequest
 		if (size == 16) {
 			if (!m_client->GetWaitStartTime()) {
 				m_client->SetWaitStartTime();
@@ -458,13 +441,11 @@ bool CClientTCPSocket::ProcessPacket(const uint8_t *buffer, uint32 size, uint8 o
 				}
 			}
 
-			// check to see if this is a new file they are asking for
 			if (m_client->GetUploadFileID() != fileID) {
 				m_client->SetCommentDirty();
 			}
 
 			m_client->SetUploadFileID(reqfile);
-			// send filestatus
 			CMemFile data(16 + 16);
 			data.WriteHash(reqfile->GetFileHash());
 			if (reqfile->IsPartFile()) {
@@ -481,7 +462,6 @@ bool CClientTCPSocket::ProcessPacket(const uint8_t *buffer, uint32 size, uint8 o
 		}
 		throw wxString("Invalid OP_FILEREQUEST packet size");
 		break;
-		// DbT:End
 	}
 
 	case OP_FILEREQANSNOFIL: { // 0.43b protocol, lacks ZZ's download manager on swap
@@ -789,7 +769,6 @@ bool CClientTCPSocket::ProcessPacket(const uint8_t *buffer, uint32 size, uint8 o
 			throw wxString("invalid message packet");
 		}
 
-		// limit message length
 		static const uint16 MAX_CLIENT_MSG_LEN = 450;
 
 		if (length > MAX_CLIENT_MSG_LEN) {
@@ -834,7 +813,6 @@ bool CClientTCPSocket::ProcessPacket(const uint8_t *buffer, uint32 size, uint8 o
 				}
 			}
 
-			// create a packet and send it
 			CPacket *replypacket = new CPacket(tempfile, OP_EDONKEYPROT, OP_ASKSHAREDFILESANSWER);
 			AddDebugLogLineN(logLocalClient,
 				"Local Client: OP_ASKSHAREDFILESANSWER to " + m_client->GetFullIP());
@@ -882,7 +860,6 @@ bool CClientTCPSocket::ProcessPacket(const uint8_t *buffer, uint32 size, uint8 o
 			AddLogLineC(
 				CFormat(_("User %s (%u) requested your shareddirectories-list -> Accepted")) %
 				m_client->GetUserName() % m_client->GetUserIDHybrid());
-			// send the list of shared directories
 			m_client->SendSharedDirectories();
 		} else {
 			AddLogLineC(
@@ -925,7 +902,6 @@ bool CClientTCPSocket::ProcessPacket(const uint8_t *buffer, uint32 size, uint8 o
 						(unsigned)(data.GetLength() - data.GetPosition()) %
 						m_client->GetFullIP());
 			}
-			// send the list of shared files for the requested directory
 			m_client->SendSharedFilesOfDirectory(strReqDir);
 		} else {
 			AddLogLineC(CFormat(_("User %s (%u) requested your sharedfiles-list for directory "
@@ -1038,18 +1014,14 @@ bool CClientTCPSocket::ProcessPacket(const uint8_t *buffer, uint32 size, uint8 o
 bool CClientTCPSocket::ProcessExtPacket(const uint8_t *buffer, uint32 size, uint8 opcode)
 {
 #ifdef __PACKET_RECV_DUMP__
-	// printf("Rec: OPCODE %x \n",opcode);
 	DumpMem(buffer, size);
 #endif
 
-	// 0.42e - except the catches on mem exception and file exception
 	if (!m_client) {
 		throw wxString("Unknown clients sends extended protocol packet");
 	}
 	/*
 	if (!client->CheckHandshakeFinished()) {
-		// Here comes an extended packet without finishing the handshake.
-		// IMHO, we should disconnect the client.
 		throw wxString("Client send extended packet before finishing handshake");
 	}
 	*/
@@ -1070,8 +1042,6 @@ bool CClientTCPSocket::ProcessExtPacket(const uint8_t *buffer, uint32 size, uint
 		}
 
 		if (!m_client->CheckHandshakeFinished()) {
-			// Here comes an extended packet without finishing the handshake.
-			// IMHO, we should disconnect the client.
 			throw wxString("Client send OP_MULTIPACKET before finishing handshake");
 		}
 
@@ -1124,7 +1094,6 @@ bool CClientTCPSocket::ProcessExtPacket(const uint8_t *buffer, uint32 size, uint
 					static_cast<CPartFile *>(reqfile), m_client);
 			}
 		}
-		// check to see if this is a new file they are asking for
 		if (m_client->GetUploadFileID() != reqfilehash) {
 			m_client->SetCommentDirty();
 		}
@@ -1247,15 +1216,12 @@ bool CClientTCPSocket::ProcessExtPacket(const uint8_t *buffer, uint32 size, uint
 		}
 
 		if (!m_client->CheckHandshakeFinished()) {
-			// Here comes an extended packet without finishing the handshake.
-			// IMHO, we should disconnect the client.
 			throw wxString("Client send OP_MULTIPACKETANSWER before finishing handshake");
 		}
 
 		CMemFile data_in(buffer, size);
 		CMD4Hash reqfilehash = data_in.ReadHash();
 		const CPartFile *reqfile = theApp->downloadqueue->GetFileByID(reqfilehash);
-		// Make sure we are downloading this file.
 		if (!reqfile) {
 			throw wxString(" Wrong File ID: (OP_MULTIPACKETANSWER; reqfile==NULL)");
 		}
@@ -1343,8 +1309,6 @@ bool CClientTCPSocket::ProcessExtPacket(const uint8_t *buffer, uint32 size, uint
 			logRemoteClient, "Remote Client: OP_SECIDENTSTATE from " + m_client->GetFullIP());
 
 		if (!m_client->CheckHandshakeFinished()) {
-			// Here comes an extended packet without finishing the handshake.
-			// IMHO, we should disconnect the client.
 			throw wxString("Client send OP_SECIDENTSTATE before finishing handshake");
 		}
 		m_client->ProcessSecIdentStatePacket(buffer, size);
@@ -1373,8 +1337,6 @@ bool CClientTCPSocket::ProcessExtPacket(const uint8_t *buffer, uint32 size, uint
 		}
 
 		if (!m_client->CheckHandshakeFinished()) {
-			// Here comes an extended packet without finishing the handshake.
-			// IMHO, we should disconnect the client.
 			throw wxString("Client send OP_PUBLICKEY before finishing handshake");
 		}
 
@@ -1386,8 +1348,6 @@ bool CClientTCPSocket::ProcessExtPacket(const uint8_t *buffer, uint32 size, uint
 			logRemoteClient, "Remote Client: OP_SIGNATURE from " + m_client->GetFullIP());
 
 		if (!m_client->CheckHandshakeFinished()) {
-			// Here comes an extended packet without finishing the handshake.
-			// IMHO, we should disconnect the client.
 			throw wxString("Client send OP_COMPRESSEDPART before finishing handshake");
 		}
 
@@ -1409,8 +1369,6 @@ bool CClientTCPSocket::ProcessExtPacket(const uint8_t *buffer, uint32 size, uint
 				"Remote Client: OP_COMPRESSEDPART from " + m_client->GetFullIP());
 
 		if (!m_client->CheckHandshakeFinished()) {
-			// Here comes an extended packet without finishing the handshake.
-			// IMHO, we should disconnect the client.
 			throw wxString("Client send OP_COMPRESSEDPART before finishing handshake");
 		}
 
@@ -1484,8 +1442,6 @@ bool CClientTCPSocket::ProcessExtPacket(const uint8_t *buffer, uint32 size, uint
 		theStats::AddDownOverheadOther(size);
 
 		if (!m_client->CheckHandshakeFinished()) {
-			// Here comes an extended packet without finishing the handshake.
-			// IMHO, we should disconnect the client.
 			throw wxString("Client send OP_QUEUERANKING before finishing handshake");
 		}
 
@@ -1506,8 +1462,6 @@ bool CClientTCPSocket::ProcessExtPacket(const uint8_t *buffer, uint32 size, uint
 		theStats::AddDownOverheadSourceExchange(size);
 
 		if (!m_client->CheckHandshakeFinished()) {
-			// Here comes an extended packet without finishing the handshake.
-			// IMHO, we should disconnect the client.
 			throw wxString("Client send OP_REQUESTSOURCES before finishing handshake");
 		}
 
@@ -1530,13 +1484,11 @@ bool CClientTCPSocket::ProcessExtPacket(const uint8_t *buffer, uint32 size, uint
 				file = theApp->downloadqueue->GetFileByID(fileID);
 			}
 			if (file) {
-				// There are some clients which do not follow the correct protocol procedure
-				// of sending the sequence OP_REQUESTFILENAME, OP_SETREQFILEID,
-				// OP_REQUESTSOURCES. If those clients are doing this, they will not get the
-				// optimal set of sources which we could offer if they would follow the above
-				// noted protocol sequence. They better do it the right way or they will get
-				// just a random set of sources because we do not know their download part
-				// status which may get cleared with the call of 'SetUploadFileID'.
+				// Some clients do not follow the OP_REQUESTFILENAME,
+				// OP_SETREQFILEID, OP_REQUESTSOURCES sequence. Those get a
+				// random set of sources rather than the optimal one, because
+				// we do not know their download part status -- which
+				// SetUploadFileID may clear.
 				m_client->SetUploadFileID(file);
 
 				uint64 dwTimePassed = ::GetTickCount64() - m_client->GetLastSrcReqTime() +
@@ -1575,8 +1527,6 @@ bool CClientTCPSocket::ProcessExtPacket(const uint8_t *buffer, uint32 size, uint
 		theStats::AddDownOverheadSourceExchange(size);
 
 		if (!m_client->CheckHandshakeFinished()) {
-			// Here comes an extended packet without finishing the handshake.
-			// IMHO, we should disconnect the client.
 			throw wxString("Client send OP_ANSWERSOURCES before finishing handshake");
 		}
 
@@ -1585,9 +1535,7 @@ bool CClientTCPSocket::ProcessExtPacket(const uint8_t *buffer, uint32 size, uint
 		CKnownFile *file = theApp->downloadqueue->GetFileByID(hash);
 		if (file) {
 			if (file->IsPartFile()) {
-				// set the client's answer time
 				m_client->SetLastSrcAnswerTime();
-				// and set the file's last answer time
 				static_cast<CPartFile *>(file)->SetLastAnsweredTime();
 				static_cast<CPartFile *>(file)->AddClientSources(&data,
 					SF_SOURCE_EXCHANGE,
@@ -1599,12 +1547,9 @@ bool CClientTCPSocket::ProcessExtPacket(const uint8_t *buffer, uint32 size, uint
 		break;
 	}
 	case OP_ANSWERSOURCES2: {
-		// printf("Received OP_ANSWERSOURCES2\n");
 		theStats::AddDownOverheadSourceExchange(size);
 
 		if (!m_client->CheckHandshakeFinished()) {
-			// Here comes an extended packet without finishing the handshake.
-			// IMHO, we should disconnect the client.
 			throw wxString("Client send OP_ANSWERSOURCES2 before finishing handshake");
 		}
 
@@ -1614,9 +1559,7 @@ bool CClientTCPSocket::ProcessExtPacket(const uint8_t *buffer, uint32 size, uint
 		CKnownFile *file = theApp->downloadqueue->GetFileByID(hash);
 		if (file) {
 			if (file->IsPartFile()) {
-				// set the client's answer time
 				m_client->SetLastSrcAnswerTime();
-				// and set the file's last answer time
 				static_cast<CPartFile *>(file)->SetLastAnsweredTime();
 				static_cast<CPartFile *>(file)->AddClientSources(
 					&data, SF_SOURCE_EXCHANGE, byVersion, true, m_client);
@@ -1630,8 +1573,6 @@ bool CClientTCPSocket::ProcessExtPacket(const uint8_t *buffer, uint32 size, uint
 		theStats::AddDownOverheadFileRequest(size);
 
 		if (!m_client->CheckHandshakeFinished()) {
-			// Here comes an extended packet without finishing the handshake.
-			// IMHO, we should disconnect the client.
 			throw wxString("Client send OP_FILEDESC before finishing handshake");
 		}
 
@@ -1682,12 +1623,10 @@ bool CClientTCPSocket::ProcessExtPacket(const uint8_t *buffer, uint32 size, uint
 		AddDebugLogLineN(
 			logRemoteClient, "Remote Client: OP_AICHREQUEST from " + m_client->GetFullIP());
 		theStats::AddDownOverheadOther(size);
-		// Each OP_AICHREQUEST triggers an O(N) walk of known2.met
-		// via ProcessAICHRequest -> CreatePartRecoveryData ->
-		// LoadHashSet. Without rate-limiting, a hostile peer can
-		// hammer this with 16-byte packets and force the seeder to
-		// burn disk + CPU on each one. Treat repeated requests the
-		// same way the file-request paths do.
+		// Each OP_AICHREQUEST triggers an O(N) walk of known2.met via
+		// ProcessAICHRequest -> CreatePartRecoveryData -> LoadHashSet. Unlimited, a
+		// hostile peer can hammer this with 16-byte packets and force the seeder to
+		// burn disk and CPU on each one, so treat repeats like the file-request paths.
 		m_client->CheckForAggressive();
 		if (m_client->IsBanned()) {
 			break;
@@ -1843,16 +1782,12 @@ bool CClientTCPSocket::ProcessExtPacket(const uint8_t *buffer, uint32 size, uint
 			if (hash == sender->GetUploadFileID()) {
 				sender->AddAskedCount();
 				sender->SetLastUpRequest();
-				// I messed up when I first added extended info to UDP
-				// I should have originally used the entire ProcessExtenedInfo the first time.
-				// So now I am forced to check UDPVersion to see if we are sending all the
-				// extended info. For now on, we should not have to change anything here if we
-				// change anything to the extended info data as this will be taken care of in
-				// ProcessExtendedInfo() Update extended info.
+				// UDPVersion has to be checked because the first version of
+				// extended UDP info did not go through ProcessExtendedInfo.
+				// Later changes to the extended info need no change here.
 				if (sender->GetUDPVersion() > 3) {
 					sender->ProcessExtendedInfo(&data_in, reqfile);
 				} else if (sender->GetUDPVersion() > 2) {
-					// Update our complete source counts.
 					uint16 nCompleteCountLast = sender->GetUpCompleteSourcesCount();
 					uint16 nCompleteCountNew = data_in.ReadUInt16();
 					sender->SetUpCompleteSourcesCount(nCompleteCountNew);
@@ -1960,7 +1895,6 @@ bool CClientTCPSocket::ProcessExtPacket(const uint8_t *buffer, uint32 size, uint
 bool CClientTCPSocket::ProcessED2Kv2Packet(const uint8_t *buffer, uint32 size, uint8 opcode)
 {
 #ifdef __PACKET_RECV_DUMP__
-	// printf("Rec: OPCODE %x ED2Kv2\n",opcode);
 	DumpMem(buffer, size);
 #endif
 
@@ -2007,10 +1941,8 @@ void CClientTCPSocket::OnConnect(int nErrorCode)
 	if (nErrorCode) {
 		OnError(nErrorCode);
 	} else if (!m_client) {
-		// and now? Disconnect? not?
 		AddDebugLogLineN(logClient, "Couldn't send hello packet (Client deleted!)");
 	} else if (!m_client->SendHelloPacket()) {
-		// and now? Disconnect? not?
 		AddDebugLogLineN(
 			logClient, "Couldn't send hello packet (Client deleted by SendHelloPacket!)");
 	} else {
@@ -2044,8 +1976,7 @@ void CClientTCPSocket::OnReceive(int nErrorCode)
 
 void CClientTCPSocket::OnError(int nErrorCode)
 {
-	// printf("* Called OnError for %p\n",this);
-	//  0.42e + Kry changes for handling of socket lost events
+	// 0.42e + Kry changes for handling of socket lost events
 	wxString strError;
 
 	if ((nErrorCode == 0) || (nErrorCode == 7) || (nErrorCode == 0xFEFF)) {
@@ -2096,7 +2027,6 @@ void CClientTCPSocket::OnError(int nErrorCode)
 
 bool CClientTCPSocket::PacketReceived(CPacket *packet)
 {
-	// 0.42e
 	bool bResult = false;
 	uint32 uRawSize = packet->GetPacketSize();
 

--- a/src/ClientUDPSocket.cpp
+++ b/src/ClientUDPSocket.cpp
@@ -174,17 +174,14 @@ void CClientUDPSocket::OnPacketReceived(uint32 ip, uint16 port, uint8_t *buffer,
 				break;
 
 			case OP_UDPRESERVEDPROT2:
-				// eMuleAI NAT traversal. Not an eD2k opcode: the byte
-				// after the protocol byte is a frame type. Dispatched
-				// here rather than through ProcessPacket() above, whose
-				// second argument is an opcode.
+				// eMuleAI NAT traversal. Not an eD2k opcode: the byte after the
+				// protocol byte is a frame type, so it is dispatched here rather
+				// than through ProcessPacket(), whose second argument is an opcode.
 				//
-				// This branch reaches no packet accounting at all, which
-				// is what keeps a dropped frame from feeding a ban:
-				// CPacketTracking is only entered from the Kad listener
-				// (kademlia/net/KademliaUDPListener.cpp:263), and an
-				// eMuleAI peer's NAT-T traffic would otherwise arrive
-				// here as an unknown protocol and read as malformed.
+				// This branch reaches no packet accounting at all, which is what
+				// keeps a dropped frame from feeding a ban: CPacketTracking is only
+				// entered from the Kad listener, and an eMuleAI peer's NAT-T traffic
+				// would otherwise read as malformed.
 				ProcessReservedProt2Frame(decryptedBuffer + 1, packetLen - 1, ip, port);
 				break;
 
@@ -235,12 +232,11 @@ void CClientUDPSocket::ProcessReservedProt2Frame(
 		break;
 	}
 
-	// The registered types. Each is dropped in its own case rather than in a
-	// shared fallthrough, so that the change which ships a transport replaces
-	// its own case and nothing else -- which is what the uTP case below now is.
-	// The other four still belong to transports this build does not have, and a
-	// peer's attempt at one of them is a recognised frame aMule cannot serve
-	// rather than malformed traffic.
+	// The registered types. Each is dropped in its own case rather than in a shared
+	// fallthrough, so the change that ships a transport replaces its own case and
+	// nothing else -- which is what the uTP case below now is. The other four belong
+	// to transports this build does not have, so a peer's attempt at one is a
+	// recognised frame aMule cannot serve rather than malformed traffic.
 	switch (classified.type) {
 	case OP_NATT_FRAME_UTP:
 #ifdef AMULE_UTP_TRANSPORT
@@ -283,10 +279,9 @@ void CClientUDPSocket::ProcessReservedProt2Frame(
 		break;
 
 	default:
-		// Unreachable: ClassifyReservedProt2Frame only reports
-		// RP2_KNOWN_TYPE for the five cases above. Kept so that adding a
-		// type there without a case here fails loudly rather than
-		// silently taking the drop path.
+		// Unreachable: ClassifyReservedProt2Frame only reports RP2_KNOWN_TYPE for
+		// the five cases above. Kept so that adding a type there without a case here
+		// fails loudly rather than silently taking the drop path.
 		wxFAIL;
 		break;
 	}

--- a/src/ClientsWnd.cpp
+++ b/src/ClientsWnd.cpp
@@ -48,9 +48,8 @@
 #include "PartFile.h" // Needed for CPartFile (CKnownFile::GetFileName)
 // CUpDownClient. MUST match the build's client class: the reduced EC client for
 // amulegui, the full one for monolithic. The two have different layouts, so the
-// wrong header here reads every member of a live peer at the wrong offset --
-// blank names, a zero IP and nonsense totals, then a crash once a wrong offset
-// lands on something that is not a string. Same trap as GenericClientListCtrl.
+// wrong header reads every member of a live peer at the wrong offset -- blank
+// names, a zero IP, then a crash. Same trap as GenericClientListCtrl.
 #ifdef CLIENT_GUI
 #include "UpDownClientEC.h"
 #else
@@ -69,19 +68,16 @@ CClientsWnd::CClientsWnd(wxWindow *parent)
 , m_historyHandler(this)
 #endif
 {
-	// Two tabs rather than a split: the lists answer different questions --
-	// "who am I talking to now" and "who have I ever talked to" -- and share
-	// most of their columns, so showing both at once would mostly duplicate
-	// the same headers down the page.
+	// Two tabs rather than a split: the lists answer different questions -- "who am
+	// I talking to now" and "who have I ever talked to" -- and share most of their
+	// columns, so showing both at once would mostly duplicate headers.
 	wxNotebook *book = new wxNotebook(this, -1);
 	const long listStyle = wxDV_MULTIPLE | wxDV_ROW_LINES | wxDV_VERT_RULES;
 
-	// Split rather than one list: a peer is either giving us a file or taking
-	// one, and often both at once, so a single list has to render each row's
-	// direction into a column and leaves the reader to sort it out. Two panes
-	// state it structurally -- and a peer swapping with us simply appears in
-	// both, once as a source and once as a destination, which is exactly what
-	// is happening.
+	// Split rather than one list: a peer is either giving us a file or taking one,
+	// and often both, so a single list has to render each row's direction into a
+	// column. Two panes state it structurally, and a peer swapping with us appears
+	// in both, once as a source and once as a destination.
 	wxSplitterWindow *split = new wxSplitterWindow(
 		book, ID_CLIENTSSPLITTER, wxDefaultPosition, wxDefaultSize, wxSP_LIVE_UPDATE | wxSP_3DSASH);
 	split->SetMinimumPaneSize(60);
@@ -110,9 +106,8 @@ CClientsWnd::CClientsWnd(wxWindow *parent)
 
 	// Only offered when there is a history to show. A daemon that does not
 	// advertise EC_TAG_CAN_CLIENT_HISTORY cannot answer the request, so the tab
-	// would sit there permanently empty with nothing to say why -- better not
-	// to promise it. Decided once here because amulegui rebuilds this dialog on
-	// every (re)connect, so a later connection to a newer daemon gets the tab.
+	// would sit permanently empty with nothing to say why. Decided once here,
+	// because amulegui rebuilds this dialog on every reconnect.
 #ifdef CLIENT_GUI
 	const bool historyAvailable =
 		theApp->m_connect != nullptr && theApp->m_connect->ServerSupportsClientHistory();
@@ -125,9 +120,8 @@ CClientsWnd::CClientsWnd(wxWindow *parent)
 		book->AddPage(historylistctrl, _("Known"), false);
 	}
 
-	// Rebuilt on every switch to the Known tab rather than once, so a peer
-	// that has reconnected since you last looked shows its new totals and
-	// last-seen instead of the values it had months ago.
+	// Rebuilt on every switch to the Known tab rather than once, so a peer that has
+	// reconnected since you last looked shows its new totals and last-seen.
 	book->Bind(wxEVT_NOTEBOOK_PAGE_CHANGED, [this](wxBookCtrlEvent &event) {
 		if (event.GetSelection() == 1 && historylistctrl != nullptr) {
 			EnsureHistoryLoaded();
@@ -157,9 +151,9 @@ void FillHistoryNameCell(ClientHistoryRow &row)
 	row.nameCell.clientSoft = row.clientSoft;
 	row.nameCell.obfuscation = row.obfuscation;
 #ifdef GEOIP_GUI
-	// Same call the live lists make: amulegui takes the code the core resolved
-	// from the last address we saw the peer at, monolithic resolves it itself.
-	// Records with no metadata carry no address, and get no flag.
+	// Same call the live lists make: amulegui takes the code the core resolved from
+	// the last address we saw the peer at, monolithic resolves it itself. Records
+	// with no metadata carry no address, and get no flag.
 	wxString code;
 	if (GetDisplayCountryCode(row.countryFromCore, row.country, row.ip, code)) {
 		row.nameCell.countryCode = code;
@@ -220,24 +214,22 @@ void CClientsWnd::LoadHistory()
 			row.clientSoft = meta.clientSoft;
 			row.sourceFrom = meta.sourceFrom;
 			row.obfuscation = meta.obfuscation;
-			// Rendered the same way the live list renders it, so one peer is
-			// not listed under two different versions depending on whether it
-			// happens to be online.
+			// Rendered the way the live list renders it, so one peer is not listed
+			// under two different versions depending on whether it is online.
 			row.version = FormatPackedClientVersion(meta.clientSoft, meta.version);
 		}
-		// Correlate with the live list by hash. Not by ECID: those mean
-		// nothing outside one daemon process, whereas this is the same
-		// identity the credit store itself is keyed on.
+		// Correlate with the live list by hash, not by ECID: those mean nothing
+		// outside one daemon process, whereas this is the identity the credit store
+		// itself is keyed on.
 		row.online = !theApp->clientlist->GetClientsByHash(row.hash).empty();
 		FillHistoryNameCell(row);
 		rows.push_back(row);
 	}
 	historylistctrl->SetRows(std::move(rows));
 #else
-	// amulegui: the credit store lives on the other side of the link, so ask
-	// for it. Against a daemon too old to know the request this comes back
-	// EC_OP_FAILED and the tab simply stays empty -- there is nothing to
-	// negotiate in advance, the failure says it.
+	// amulegui: the credit store lives on the other side of the link, so ask for
+	// it. Against a daemon too old to know the request this comes back EC_OP_FAILED
+	// and the tab stays empty.
 	if (theApp->m_connect != nullptr && theApp->m_connect->ServerSupportsClientHistory()) {
 		CECPacket request(EC_OP_GET_CLIENT_HISTORY);
 		theApp->m_connect->SendRequest(&m_historyHandler, &request);
@@ -249,15 +241,13 @@ void CClientsWnd::LoadHistory()
 void CClientsWnd::CHistoryHandler::HandlePacket(const CECPacket *packet)
 {
 	if (packet->GetOpCode() != EC_OP_CLIENT_HISTORY) {
-		// EC_OP_FAILED from a core that predates the request. Leave the tab
-		// as it is rather than blanking it -- an older core is not a reason
-		// to throw away what is already on screen.
+		// EC_OP_FAILED from a core that predates the request. Leave the tab as it
+		// is rather than blanking it.
 		return;
 	}
 
-	// The live peers, by hash. Same reasoning as the monolithic path: an
-	// ECID says nothing across daemon processes, the user hash is the
-	// identity the credit store itself is keyed on.
+	// The live peers, by hash: an ECID says nothing across daemon processes, while
+	// the user hash is the identity the credit store is keyed on.
 	std::set<CMD4Hash> onlineHashes;
 	if (theApp->clientlist != nullptr) {
 		for (const auto &entry : *theApp->clientlist) {
@@ -283,9 +273,9 @@ void CClientsWnd::CHistoryHandler::HandlePacket(const CECPacket *packet)
 		if (const CECTag *t = tag->GetTagByName(EC_TAG_CLIENT_LAST_SEEN)) {
 			row.lastSeen = t->GetInt();
 		}
-		// Everything below is absent for a peer the core has no metadata
-		// for -- an older record, or a core that never kept any. The row
-		// still carries a hash, totals and a date; the rest renders blank.
+		// Everything below is absent for a peer the core has no metadata for -- an
+		// older record, or a core that never kept any. The row still carries a hash,
+		// totals and a date.
 		if (const CECTag *t = tag->GetTagByName(EC_TAG_CLIENT_FIRST_SEEN)) {
 			row.firstSeen = t->GetInt();
 			row.hasMeta = true;
@@ -332,23 +322,20 @@ CClientsWnd::~CClientsWnd() = default;
 
 void CClientsWnd::UpdateAll()
 {
-	// Rebuild the row set from the live container rather than maintaining it
-	// from add/remove notifications.
+	// Rebuild the row set from the live container rather than maintaining it from
+	// add/remove notifications.
 	//
-	// Those notifications are queued whenever they are raised off the main
-	// thread, which is exactly what CUpDownClientListRem does -- so an add
-	// could arrive after its client's allocation had been reused (rows full
-	// of blank peers whose values never moved), and a removal could arrive
-	// after the object was freed, leaving the list to repaint a dangling
-	// pointer once a second until it crashed inside drawing.
+	// Those notifications are queued whenever they are raised off the main thread,
+	// which is what CUpDownClientListRem does -- so an add could arrive after its
+	// client's allocation had been reused, and a removal after the object was
+	// freed, leaving the list repainting a dangling pointer once a second until it
+	// crashed inside drawing. Holding CClientRefs instead would fix the lifetime and
+	// create a worse problem: they are owning, so the list would keep every peer it
+	// ever saw alive. Enumerating what is live has neither failure mode, and the set
+	// is bounded by MaxConnections.
 	//
-	// Holding CClientRefs instead would fix the lifetime and create a worse
-	// problem: those are owning, so the list would keep every peer it ever
-	// saw alive. Enumerating what is live, when we draw, has neither failure
-	// mode, and the set is bounded by MaxConnections.
-	// Copy each peer's values here, while we know they are alive. The list
-	// is painted later, and a peer freed in between would otherwise be read
-	// through a dangling pointer at draw time.
+	// Each peer's values are copied here, while we know they are alive: the list is
+	// painted later.
 	std::vector<CClientsListCtrl::Row> downRows;
 	std::vector<CClientsListCtrl::Row> upRows;
 	// Every connected peer, for the history reconcile below -- not just the
@@ -361,12 +348,10 @@ void CClientsWnd::UpdateAll()
 		if (c == nullptr) {
 			return;
 		}
-		// Built at most once per peer, and only if something asks for it. It
-		// is the most expensive thing here -- a country lookup and several
-		// string copies -- and it used to be built twice for every peer, once
-		// for the history entry and again for the pane row. Lazily, because a
-		// peer that neither pane shows and that the history does not want
-		// should not pay for one at all (issue #920).
+		// Built at most once per peer, and only if something asks for it. It is the
+		// most expensive thing here -- a country lookup and several string copies --
+		// and used to be built twice per peer, once for the history entry and again
+		// for the pane row (issue #920).
 		ClientNameCell cell;
 		bool haveCell = false;
 		auto nameCell = [&]() -> const ClientNameCell & {
@@ -395,13 +380,11 @@ void CClientsWnd::UpdateAll()
 			entry.nameCell.showState = false;
 			live[c->GetUserHash()] = entry;
 		}
-		// Which pane(s) this peer belongs in. A peer holds at most one file in
-		// each direction, and a peer swapping with us holds one of each -- so
-		// it is listed twice, once as a source and once as a destination,
-		// rather than being forced into a single row that has to explain
-		// itself. Membership is the relationship, not whether bytes are moving
-		// this second: a queued source is still someone we are downloading
-		// from, and the speed columns already say whether it is live.
+		// Which pane(s) this peer belongs in. A peer holds at most one file in each
+		// direction, and a peer swapping with us holds one of each, so it is listed
+		// twice rather than forced into a single row that has to explain itself.
+		// Membership is the relationship, not whether bytes are moving this second:
+		// a queued source is still someone we are downloading from.
 		const CKnownFile *requested = c->GetRequestFile();
 		const CKnownFile *uploading = c->GetUploadFile();
 		if (requested == nullptr && uploading == nullptr) {
@@ -451,19 +434,18 @@ void CClientsWnd::UpdateAll()
 	downclientsctrl->SetClients(std::move(downRows));
 	upclientsctrl->SetClients(std::move(upRows));
 
-	// Fold this tick's peers into the history, so the rows for peers that are
-	// connected keep up instead of standing at whatever they were when the tab
-	// was opened. Costs one lookup per connected peer; the stored records for
-	// everyone else cannot change while their peer is away.
+	// Fold this tick's peers into the history, so rows for connected peers keep up
+	// instead of standing at whatever they were when the tab was opened. One lookup
+	// per connected peer; stored records for everyone else cannot change.
 	if (wantLive) {
 		historylistctrl->ReconcileLive(live);
 	}
 
-	// Only ever a re-check: EnsureHistoryLoaded() returns immediately unless
-	// the daemon session changed, and the m_historyLoaded guard means sitting
-	// on the Active tab never triggers the first, expensive load. Without it a
-	// core that restarted while the Known tab was open would keep showing rows
-	// belonging to a process that no longer exists.
+	// Only ever a re-check: EnsureHistoryLoaded() returns immediately unless the
+	// daemon session changed, and the m_historyLoaded guard means sitting on the
+	// Active tab never triggers the first, expensive load. Without it a core that
+	// restarted while the Known tab was open would keep showing rows from a process
+	// that no longer exists.
 	if (m_historyLoaded) {
 		EnsureHistoryLoaded();
 	}

--- a/src/DirectoryTreeCtrl.cpp
+++ b/src/DirectoryTreeCtrl.cpp
@@ -72,9 +72,8 @@ CDirectoryTreeCtrl::CDirectoryTreeCtrl(wxWindow *parent, int id, const wxPoint &
 
 wxFont CDirectoryTreeCtrl::GetRecursiveFont()
 {
-	// Cache: GetFont() can be a non-trivial wx call on some backends,
-	// and AddChildItem hits this once per tree item during the lazy
-	// expand pass.
+	// Cached: GetFont() is a non-trivial wx call on some backends, and AddChildItem
+	// hits this once per tree item during the lazy expand pass.
 	if (!m_fontRecursiveRoot.IsOk()) {
 		m_fontRecursiveRoot = GetFont().MakeBold().MakeItalic();
 	}
@@ -86,17 +85,12 @@ void CDirectoryTreeCtrl::ApplyRecursiveMark(wxTreeItemId hItem, bool isRecursive
 	if (isRecursive) {
 		SetItemFont(hItem, GetRecursiveFont());
 	} else {
-		// Revert to the tree's default font. SetItemBold is the
-		// orthogonal axis (plain bold for explicit / inside-recursive
-		// shares); clearing the custom font here doesn't drop that
-		// attribute -- IsBold-based logic continues to work.
+		// Revert to the tree's default font. SetItemBold is the orthogonal axis, so
+		// clearing the custom font here does not drop it.
 		//
-		// Pass GetFont() rather than wxNullFont: on wxMSW 3.2,
-		// wxTreeCtrl::SetItemFont calls wxFont::WXAdjustToPPI() on
-		// the supplied font for DPI adjustment, and WXAdjustToPPI
-		// dereferences the font's refdata without a null check.
-		// wxNullFont has no refdata -> access violation. The tree's
-		// own font has valid refdata, so we route through it. (#827)
+		// Pass GetFont() rather than wxNullFont: on wxMSW 3.2
+		// wxTreeCtrl::SetItemFont calls wxFont::WXAdjustToPPI(), which dereferences
+		// the font's refdata with no null check, and wxNullFont has none (#827).
 		SetItemFont(hItem, GetFont());
 	}
 }
@@ -123,19 +117,16 @@ void CDirectoryTreeCtrl::Rebuild()
 
 void CDirectoryTreeCtrl::Init()
 {
-	// already done ?
 	if (m_IsInit) {
 		return;
 	}
 	m_IsInit = true;
 
-	// init image(s)
 	wxImageList *images = new wxImageList(16, 16);
 	// wxImageList::Add() wants a flat wxBitmap, not a bundle -- it's a
 	// raster cache with no per-DPI resolution of its own.
 	images->Add(wxArtProvider::GetBitmap("amule:folder", wxART_OTHER, wxSize(16, 16)));
 	images->Add(wxArtProvider::GetBitmap("amule:folder_shared", wxART_OTHER, wxSize(16, 16)));
-	// Gives wxTreeCtrl ownership of the list
 	AssignImageList(images);
 
 	// Create an empty root item, which we can
@@ -146,9 +137,7 @@ void CDirectoryTreeCtrl::Init()
 #ifndef __WINDOWS__
 		AddChildItem(m_root, CPath("/"));
 #else
-		// this might take awhile, so change the cursor
 		::wxSetCursor(*wxHOURGLASS_CURSOR);
-		// retrieve bitmask of all drives available
 		uint32 drives = GetLogicalDrives();
 		drives >>= 1;
 		for (char drive = 'C'; drive <= 'Z'; drive++) {
@@ -204,7 +193,6 @@ void CDirectoryTreeCtrl::OnItemExpanding(wxTreeEvent &evt)
 {
 	wxTreeItemId hItem = evt.GetItem();
 
-	// Force reloading of the path
 	DeleteChildren(hItem);
 	AddSubdirectories(hItem, GetFullPath(hItem));
 
@@ -217,13 +205,11 @@ void CDirectoryTreeCtrl::OnItemActivated(wxTreeEvent &evt)
 		return;
 	}
 	const wxTreeItemId hItem = evt.GetItem();
-	// A descendant of a recursive-share root cannot be individually
-	// un-shared via this UI: the apply task will re-flatten the root's
-	// subtree at commit time, so a left-click here would just un-bold
-	// the item visually and have the entry reappear after Apply. Block
-	// the action with a message so the user understands what to do
-	// (drop the recursive marker on the root, or right-click an
-	// ancestor) rather than silently appearing to ignore their click.
+	// A descendant of a recursive-share root cannot be individually un-shared from
+	// this UI: the apply task re-flattens the root's subtree at commit time, so a
+	// left-click here would only un-bold the item and have the entry reappear after
+	// Apply. Block it with a message saying what to do instead (drop the recursive
+	// marker on the root, or right-click an ancestor).
 	if (IsInsideRecursiveShare(GetFullPath(hItem))) {
 		wxMessageBox(_("This directory is part of a recursive share. "
 			       "To remove it, un-share or modify the recursive "
@@ -244,32 +230,25 @@ void CDirectoryTreeCtrl::OnRButtonDown(wxTreeEvent &evt)
 		return;
 	}
 
-	// Right-click is the "recursive share" gesture. Historically the
-	// handler eagerly walked the entire subtree (expanding every
-	// directory it had never opened, then marking each one as
-	// shared) which on large roots like /home produced multi-minute
-	// UI freezes with no progress indicator and no way to cancel —
-	// see issue #592.
+	// Right-click is the "recursive share" gesture. The handler used to eagerly
+	// walk the entire subtree, expanding every directory it had never opened, which
+	// on large roots like /home produced multi-minute UI freezes with no progress
+	// and no cancel (issue #592).
 	//
-	// We now record the intent on the right-clicked item only.
-	// PrefsUnifiedDlg::OnOk flattens the recursive-share roots into
-	// concrete subdirectory paths on a background thread with a
-	// progress dialog and a cancel button. Already-expanded
-	// descendants are still toggled visually here so the tree
-	// reflects what the user sees, but no new directory enumeration
-	// is performed; collapsed subtrees retain their current visual
-	// state and will be correctly bolded the next time they are
-	// expanded (AddChildItem checks IsInsideRecursiveShare).
+	// The intent is now recorded on the right-clicked item only, and
+	// PrefsUnifiedDlg::OnOk flattens the recursive roots into concrete
+	// subdirectory paths on a background thread with a progress dialog.
+	// Already-expanded descendants are still toggled visually, but nothing new is
+	// enumerated: collapsed subtrees keep their visual state and are bolded the
+	// next time they are expanded (AddChildItem checks IsInsideRecursiveShare).
 	const wxTreeItemId hItem = evt.GetItem();
 	const bool wasBold = IsBold(hItem);
 	const CPath fullPath = GetFullPath(hItem);
 
-	// A descendant of an existing recursive root is already covered
-	// by that root's expansion. Right-clicking it to add or remove
-	// its own recursive marker is meaningless -- either redundant
-	// (the descendant's subtree is already shared via the ancestor)
-	// or impotent (DelRecursiveShare on a non-root is a no-op).
-	// Block both with the same explanatory message.
+	// A descendant of an existing recursive root is already covered by that root,
+	// so its own recursive marker is either redundant or impotent
+	// (DelRecursiveShare on a non-root is a no-op). Block both with the same
+	// explanatory message.
 	if (IsInsideRecursiveShare(fullPath)) {
 		wxMessageBox(_("This directory is part of a recursive share. "
 			       "To remove it, un-share or modify the recursive "
@@ -281,33 +260,28 @@ void CDirectoryTreeCtrl::OnRButtonDown(wxTreeEvent &evt)
 	}
 
 	if (wasBold) {
-		// Unshare. Clean both the recursive intent and any
-		// m_lstShared entries that live underneath this path —
-		// the latter is what removes the flat descendants that a
-		// previous Prefs session may have committed from a
-		// recursive share. Doing it as an in-memory map sweep
-		// catches subdirs that aren't currently rendered in the
-		// tree without having to expand them all from disk.
+		// Unshare. Clean both the recursive intent and any m_lstShared entries
+		// underneath this path -- the latter removes the flat descendants a previous
+		// Prefs session may have committed from a recursive share. An in-memory map
+		// sweep catches subdirs that are not currently rendered without expanding
+		// them from disk.
 		DelRecursiveShare(fullPath);
 		DelSharesUnder(fullPath);
 	} else {
 		AddRecursiveShare(fullPath);
 	}
 
-	// Walk only the *already-loaded* descendants so the in-tree
-	// visual stays consistent without forcing any disk I/O.
-	// CheckChanged inside this walk resets hItem's per-item font to
-	// match the new bold state (plain when unsharing, bold when
-	// sharing), so the recursive-off path needs no separate font
-	// revert.
+	// Walk only the ALREADY-LOADED descendants, so the in-tree visual stays
+	// consistent without forcing disk I/O. CheckChanged inside this walk resets
+	// hItem's per-item font to match the new bold state, so the recursive-off path
+	// needs no separate font revert.
 	MarkChildren(hItem, !wasBold, false);
 
 	if (!wasBold) {
-		// Overlay the bold-italic marker so the user can tell at a
-		// glance which item carries the recursive intent (vs the
-		// descendants which inherit it visually as plain bold).
-		// Must run *after* MarkChildren so CheckChanged's plain-bold
-		// per-item font on hItem doesn't clobber the italic marker.
+		// Overlay the bold-italic marker so the item carrying the recursive intent
+		// is distinguishable from descendants that inherit it as plain bold. After
+		// MarkChildren, or CheckChanged's plain-bold per-item font on hItem would
+		// clobber the italic.
 		ApplyRecursiveMark(hItem, true);
 	}
 	HasChanged = true;
@@ -315,12 +289,10 @@ void CDirectoryTreeCtrl::OnRButtonDown(wxTreeEvent &evt)
 
 void CDirectoryTreeCtrl::MarkChildren(wxTreeItemId hChild, bool mark, bool recursed)
 {
-	// Touch only the children that are *already* loaded into the
-	// tree control. We no longer enumerate collapsed subtrees here —
-	// that would re-introduce the unbounded directory walk OnRButton-
-	// Down used to do. Collapsed subtrees stay as-is and are
-	// re-evaluated on demand by AddChildItem (which consults the
-	// recursive-share intent) the next time the user expands them.
+	// Touch only the children ALREADY loaded into the tree control; enumerating
+	// collapsed subtrees would re-introduce the unbounded directory walk. They stay
+	// as they are and are re-evaluated on demand by AddChildItem the next time the
+	// user expands them.
 	wxTreeItemIdValue cookie;
 	wxTreeItemId hChild2 = GetFirstChild(hChild, cookie);
 	if (hChild2.IsOk()) {
@@ -352,21 +324,17 @@ void CDirectoryTreeCtrl::AddChildItem(wxTreeItemId hBranch, const CPath &item)
 	// here.
 	SetItemText(treeItem, item.GetPrintable());
 
-	// Bold means "this directory is part of the pending share set",
-	// covering both the explicit-share case (m_lstShared) and the
-	// implicit case where the item is a descendant of a recursive-
-	// share root (m_lstSharedRecursive). The latter check is what
-	// keeps the tree visually consistent after a right-click whose
-	// recursive expansion is now deferred to commit time — the
-	// subtree gets bolded lazily as the user opens it.
+	// Bold means "this directory is part of the pending share set", covering both
+	// the explicit case (m_lstShared) and a descendant of a recursive-share root
+	// (m_lstSharedRecursive). The latter is what keeps the tree consistent after a
+	// right-click whose expansion is deferred to commit time: the subtree is bolded
+	// lazily as the user opens it.
 	const bool isRecursiveRoot = IsRecursiveShare(fullPath);
 	if (IsShared(fullPath) || isRecursiveRoot || IsInsideRecursiveShare(fullPath)) {
 		SetItemBold(treeItem, true);
 	}
-	// A recursive root gets bold-italic to distinguish it from
-	// plain explicit shares and from descendants covered by an
-	// inherited recursive expansion (which would otherwise all look
-	// identical in plain bold).
+	// A recursive root gets bold-italic, so it is distinguishable from plain
+	// explicit shares and from descendants covered by an inherited expansion.
 	if (isRecursiveRoot) {
 		ApplyRecursiveMark(treeItem, true);
 	}
@@ -461,12 +429,10 @@ void CDirectoryTreeCtrl::SetRecursiveSharedDirectories(PathList *list)
 		m_lstSharedRecursive.insert(SharedMapItem(GetKey(*it), *it));
 	}
 
-	// Mirror SetSharedDirectories: refresh the tree so a recursive
-	// root reloaded from shareddir-recursive.dat at prefs-open is
-	// rendered bold straight away rather than only after the user
-	// happens to expand its branch. PrefsUnifiedDlg calls this and
-	// SetSharedDirectories back-to-back; without this refresh, only
-	// the explicit set would have been visualised on first paint.
+	// Mirror SetSharedDirectories: refresh the tree so a recursive root reloaded
+	// from shareddir-recursive.dat at prefs-open is bold straight away rather than
+	// only once the user expands its branch. PrefsUnifiedDlg calls both
+	// back-to-back, and without this only the explicit set is visualised.
 	if (m_IsInit) {
 		UpdateSharedDirectories();
 	}
@@ -478,10 +444,9 @@ wxString CDirectoryTreeCtrl::GetKey(const CPath &path)
 		return path.GetRaw();
 	}
 
-	// Sanity check, see IsSameAs() in Path.cpp.  Skip wxGetCwd() when
-	// the path is already absolute — Normalize ignores cwd in that
-	// case, and wxGetCwd() emits a wxLogSysError for every call when
-	// the process's recorded CWD has been removed.
+	// Sanity check, see IsSameAs() in Path.cpp. Skip wxGetCwd() when the path is
+	// already absolute: Normalize ignores cwd then, and wxGetCwd() emits a
+	// wxLogSysError on every call once the process's recorded CWD is gone.
 	wxString cwd;
 	wxFileName fn(path.GetRaw());
 	if (!fn.IsAbsolute()) {
@@ -515,12 +480,10 @@ void CDirectoryTreeCtrl::UpdateSharedDirectories()
 	wxTreeItemId hChild = GetFirstChild(GetRootItem(), cookie);
 
 	while (hChild.IsOk()) {
-		// Does this drive have shared subfolders?
 		if (HasSharedSubdirectory(GetFullPath(hChild))) {
 			SetHasSharedSubdirectory(hChild, true);
 		}
 
-		// Is this drive shared?
 		if (IsShared(GetFullPath(hChild))) {
 			SetItemBold(hChild, true);
 		}
@@ -531,10 +494,8 @@ void CDirectoryTreeCtrl::UpdateSharedDirectories()
 
 bool CDirectoryTreeCtrl::HasSharedSubdirectory(const CPath &path)
 {
-	// 1. An explicit-share entry lives below `path`. This is the
-	// original logic and covers the "user ticked /Pictures/2024"
-	// case where /Pictures should advertise that it contains a
-	// shared subdir.
+	// 1. An explicit-share entry lives below `path`: the "user ticked
+	// /Pictures/2024" case, where /Pictures should advertise a shared subdir.
 	{
 		SharedMap::iterator it =
 			m_lstShared.upper_bound(GetKey(path) + wxFileName::GetPathSeparator());
@@ -543,21 +504,16 @@ bool CDirectoryTreeCtrl::HasSharedSubdirectory(const CPath &path)
 		}
 	}
 
-	// 2. `path` itself is (or sits below) a recursive root. The
-	// recursive expansion implicitly shares every descendant of
-	// such a root, so by construction the folder has shared
-	// subdirs. Without this branch, recursive-only roots loaded
-	// from shareddir-recursive.dat would show plain bold without
-	// the "has shared subdirs" icon -- the m_lstShared check above
-	// returns false because the descendants live exclusively in
-	// the recursive expansion path, not in shareddir-explicit.dat.
+	// 2. `path` itself is, or sits below, a recursive root, which implicitly shares
+	// every descendant. Without this branch a recursive-only root loaded from
+	// shareddir-recursive.dat would show plain bold without the "has shared
+	// subdirs" icon, because its descendants live only in the recursive expansion.
 	if (IsRecursiveShare(path) || IsInsideRecursiveShare(path)) {
 		return true;
 	}
 
-	// 3. A recursive root sits below `path` (i.e. `path` is an
-	// ancestor of a marked root). Some descendant of `path` is
-	// shared via that root, so the icon should be on.
+	// 3. A recursive root sits below `path`, so some descendant is shared via that
+	// root and the icon should be on.
 	{
 		SharedMap::iterator it =
 			m_lstSharedRecursive.upper_bound(GetKey(path) + wxFileName::GetPathSeparator());
@@ -578,14 +534,10 @@ void CDirectoryTreeCtrl::CheckChanged(wxTreeItemId hItem, bool bChecked, bool re
 {
 	if (IsBold(hItem) != bChecked) {
 		SetItemBold(hItem, bChecked);
-		// Mirror the bold state into the per-item font. wxMSW honors
-		// a per-item font over TVIS_BOLD, so leaving a plain-font
-		// override in place would make a subsequent SetItemBold(true)
-		// render as plain (#827 fallout: after the recursive marker
-		// is cleared the per-item font becomes plain GetFont(); a
-		// later double-click would set TVIS_BOLD but display unbold).
-		// No-op on wxGTK/wxOSX where TVIS_BOLD overlays the per-item
-		// font.
+		// Mirror the bold state into the per-item font. wxMSW honours a per-item
+		// font over TVIS_BOLD, so leaving a plain-font override in place would make a
+		// later SetItemBold(true) render as plain (#827 fallout). No-op on
+		// wxGTK/wxOSX, where TVIS_BOLD overlays the per-item font.
 		SetItemFont(hItem, bChecked ? GetFont().Bold() : GetFont());
 
 		const CPath fullPath = GetFullPath(hItem);
@@ -594,27 +546,21 @@ void CDirectoryTreeCtrl::CheckChanged(wxTreeItemId hItem, bool bChecked, bool re
 			AddShare(fullPath);
 		} else {
 			DelShare(fullPath);
-			// Double-clicking a recursive-share root must also drop
-			// the recursive intent, otherwise the expansion task at
-			// commit time would re-flatten the subtree and the user
-			// would see the files reappear in the shared list. Calls
-			// from MarkChildren on descendants of a recursive root
-			// are harmless no-ops here (only the root is keyed in
-			// m_lstSharedRecursive).
+			// Double-clicking a recursive-share root must also drop the recursive
+			// intent, or the expansion task would re-flatten the subtree at commit
+			// time and the files would reappear in the shared list. Calls from
+			// MarkChildren on descendants are harmless no-ops: only the root is
+			// keyed in m_lstSharedRecursive.
 			wasRecursive = IsRecursiveShare(fullPath);
 			DelRecursiveShare(fullPath);
 		}
 
 		if (!recursed) {
 			UpdateParentItems(hItem, bChecked);
-			// If we just dropped the recursive marker on this item,
-			// the already-rendered descendants are still painted
-			// bold via IsInsideRecursiveShare from the original
-			// AddChildItem pass. That state isn't re-evaluated on
-			// its own when the marker disappears, so the user sees
-			// a "ghost selection" of grayed-out-but-bold subdirs.
-			// Walk the descendants and unbold them to keep the tree
-			// visually consistent with the now-empty state.
+			// Dropping the recursive marker leaves the already-rendered descendants
+			// painted bold from the original AddChildItem pass, which nothing
+			// re-evaluates -- a "ghost selection" of bold subdirs. Walk them and
+			// unbold to match the now-empty state.
 			if (!bChecked && wasRecursive) {
 				MarkChildren(hItem, false, true);
 			}
@@ -694,10 +640,9 @@ void CDirectoryTreeCtrl::DelSharesUnder(const CPath &root)
 		return;
 	}
 
-	// Compare on the normalized form, with a trailing separator so
-	// /home doesn't also match /home2. If the root happens to end in
-	// a separator already (e.g. the Windows drive root "C:\"), we
-	// use it as-is.
+	// Compare on the normalized form, with a trailing separator so /home does not
+	// also match /home2. A root that already ends in one (the Windows drive root
+	// "C:\") is used as-is.
 	wxString prefix = GetKey(root);
 	if (prefix.empty()) {
 		return;

--- a/src/DirectoryTreeCtrl.h
+++ b/src/DirectoryTreeCtrl.h
@@ -48,25 +48,22 @@ public:
 	// set list of explicitly-shared directories
 	void SetSharedDirectories(PathList *list);
 
-	// Recursive-share intents: roots the user wants to share together
-	// with every descendant. The actual descendant enumeration is now
-	// deferred to the PrefsUnifiedDlg apply path (formerly happened
-	// synchronously inside OnRButtonDown and froze the UI on large
-	// trees like /home).
+	// Recursive-share intents: roots the user wants to share along with every
+	// descendant. The descendant enumeration is deferred to the PrefsUnifiedDlg
+	// apply path, having once run synchronously inside OnRButtonDown and frozen the
+	// UI on large trees.
 	void GetRecursiveSharedDirectories(PathList *list);
 	void SetRecursiveSharedDirectories(PathList *list);
 
 	// User made any changes to list?
 	bool HasChanged;
 
-	//! Re-create an already-built tree from the current shared roots. Needed
-	//! when those roots change underneath us: UpdateSharedDirectories only
-	//! re-marks the root's immediate children, so anything already expanded
-	//! would keep the marks it was built with and show stale state. Rebuilds
-	//! straight away rather than deferring to the next Init(), because the
-	//! dialog can reopen directly on the Directories page, where no page-change
-	//! event fires and a deferred rebuild would leave the tree empty. A tree
-	//! that was never built is left alone, so first use stays lazy.
+	//! Re-create an already-built tree from the current shared roots. Needed when
+	//! those change underneath us: UpdateSharedDirectories only re-marks the root's
+	//! immediate children, so anything already expanded would keep the marks it was
+	//! built with. Rebuilds straight away rather than deferring to the next Init(),
+	//! because the dialog can reopen directly on the Directories page where no
+	//! page-change event fires. A tree that was never built is left alone.
 	void Rebuild();
 
 	//! True when the tree was painted from roots other than these, i.e. the
@@ -75,13 +72,10 @@ public:
 	//! backing maps alone leaves already-expanded nodes showing old state.
 	bool NeedsRepaintFor(const PathList &explicitDirs, const PathList &recursiveDirs) const;
 
-	// initialize control
 	void Init();
 
 private:
-	// add a new item
 	void AddChildItem(wxTreeItemId hBranch, const CPath &item);
-	// add subdirectory items
 	void AddSubdirectories(wxTreeItemId hBranch, const CPath &path);
 	// returns true if folder has at least one subdirectory
 	bool HasSubdirectories(const CPath &path);
@@ -91,7 +85,6 @@ private:
 	void CheckChanged(wxTreeItemId hItem, bool bChecked, bool recursed);
 	// returns true if a subdirectory of strDir is shared
 	bool HasSharedSubdirectory(const CPath &path);
-	// set shared directories according to list
 	void UpdateSharedDirectories();
 	// when sharing a directory, make all parent directories red
 	void UpdateParentItems(wxTreeItemId hChild, bool add);
@@ -110,12 +103,10 @@ private:
 	bool IsInsideRecursiveShare(const CPath &path);
 	void AddRecursiveShare(const CPath &path);
 	void DelRecursiveShare(const CPath &path);
-	// Sweep all m_lstShared entries that are descendants of `root`.
-	// Used by OnRButtonDown's unshare path so that a recursive share
-	// whose flat descendants survived from a previous Prefs session
-	// (loaded from shareddir.dat) is fully removed by right-clicking
-	// the root again — without forcing the tree to expand every
-	// subdir in the UI just to find them.
+	// Sweep all m_lstShared entries that are descendants of `root`. Used by
+	// OnRButtonDown's unshare path, so a recursive share whose flat descendants
+	// survived from a previous Prefs session is fully removed by right-clicking the
+	// root again, without expanding every subdir in the UI to find them.
 	void DelSharesUnder(const CPath &root);
 
 	void OnItemExpanding(wxTreeEvent &evt);
@@ -142,15 +133,11 @@ private:
 
 	wxTreeItemId m_root;
 
-	// Font used to render recursive-share roots. Bold-italic, so the
-	// user can distinguish "this is the recursive root" from "this
-	// is a plain explicit share" or "this is a descendant covered by
-	// a recursive expansion" -- all three would otherwise look
-	// identical (plain bold). Constructed lazily on first paint via
-	// MakeRecursiveFont because the tree control's default font
-	// isn't fully resolved until after the ctor runs (on macOS
-	// especially, GetFont() inside the ctor returns a default-system
-	// font that's later overridden by the layout pass).
+	// Font used to render recursive-share roots. Bold-italic, so "this is the
+	// recursive root" is distinguishable from a plain explicit share and from a
+	// descendant covered by a recursive expansion -- all three would otherwise look
+	// identical. Constructed lazily on first paint, because the tree control's
+	// default font is not fully resolved until after the ctor runs.
 	wxFont GetRecursiveFont();
 	// Toggle the italic-bold marker on a single tree item. Called
 	// from AddChildItem on initial render and from the right-click

--- a/src/DownloadBandwidthThrottler.h
+++ b/src/DownloadBandwidthThrottler.h
@@ -23,31 +23,25 @@ class CEMSocket;
 // Global token bucket that enforces thePrefs::GetMaxDownload() as a literal
 // byte/sec cap across all downloading sockets.
 //
-// Mirrors UploadBandwidthThrottler in role, but intentionally simpler:
-// download is a PULL model where the kernel tells us when bytes are ready
-// (asio OnReceive fires from the I/O thread), so there's no need for a
-// dedicated throttler thread + condvar like the upload side. A shared
-// atomic budget that every CEMSocket consults before each Read() is
-// enough.
+// Mirrors UploadBandwidthThrottler in role, but intentionally simpler: download
+// is a PULL model where the kernel tells us when bytes are ready, so there is no
+// need for a dedicated throttler thread and condvar -- a shared atomic budget
+// every CEMSocket consults before each Read() is enough.
 //
-// Replaces the old per-peer ratio controller (DownloadQueue::Process +
-// CUpDownClient::SetDownloadLimit), which never enforced MaxDownload as a
-// literal cap and instead nudged each peer's transfer rate by ~5%/tick
-// against its own current speed. With a single global bucket, fast peers
-// can claim unused capacity from slow peers within the same tick
-// (demand-aware redistribution); the only constraint is the global cap.
+// Replaces the old per-peer ratio controller, which never enforced MaxDownload
+// as a literal cap and instead nudged each peer's rate by ~5%/tick against its
+// own current speed. With a single global bucket, fast peers can claim unused
+// capacity from slow ones within the same tick.
 class CDownloadBandwidthThrottler
 {
 public:
 	static CDownloadBandwidthThrottler &Get();
 
-	// Refill the bucket at the start of each DownloadQueue tick.
-	//   maxDownloadKBps == 0  -> unlimited mode (Reserve returns the full
-	//                            request, no decrement).
-	// Leftover from the previous tick is discarded: the cap is strict, not
-	// burst-friendly. A burst-friendly accumulating bucket would let a
-	// quiet period bank capacity and overshoot MaxDownload after data
-	// resumes -- that's exactly the surprise the PR is trying to remove.
+	// Refill the bucket at the start of each DownloadQueue tick;
+	// maxDownloadKBps == 0 is unlimited mode, where Reserve returns the full
+	// request. Leftover from the previous tick is discarded: the cap is strict, not
+	// burst-friendly, since an accumulating bucket would let a quiet period bank
+	// capacity and overshoot MaxDownload once data resumes.
 	void RefillBudget(uint32 maxDownloadKBps, uint32 tickPeriodMs);
 
 	// Reserve up to wantBytes from the shared budget. Returns the actual
@@ -62,32 +56,30 @@ public:
 	// the unused capacity stays available to other peers in the same tick.
 	void Refund(uint32 bytes);
 
-	// A socket that suspended its read because Reserve() came back empty,
-	// and the counterpart for one that goes away while suspended.
+	// A socket that suspended its read because Reserve() came back empty, and the
+	// counterpart for one that goes away while suspended.
 	//
-	// The throttler is what stopped these reads, so it is what has to
-	// restart them. Leaving that to whoever happens to tick the socket means
-	// a socket nobody ticks -- one we are browsing rather than downloading
-	// from -- never reads again: its half-received packet never completes,
-	// and the peer looks like it answered nothing at all.
-	// Registration is on an empty bucket, not on what the socket is doing,
-	// so under a saturated cap this also collects sockets a part file will
-	// wake anyway. Those get a second, cheap wake per tick (WakeIfPaused()
-	// is a bool test when nothing is pending); telling the two apart from
-	// here would mean teaching the throttler about download sources.
+	// The throttler is what stopped these reads, so it is what has to restart them.
+	// Leaving that to whoever happens to tick the socket means a socket nobody
+	// ticks -- one we are browsing rather than downloading from -- never reads
+	// again: its half-received packet never completes, and the peer looks like it
+	// answered nothing.
+	//
+	// Registration is on an empty bucket rather than on what the socket is doing,
+	// so under a saturated cap this also collects sockets a part file will wake
+	// anyway. Those get a second, cheap wake per tick.
 	void PauseUntilRefill(CEMSocket *socket);
 	void Forget(CEMSocket *socket);
 
 	// Restart the reads suspended before this call. Run once per tick after
 	// RefillBudget(), and OUTSIDE any lock the read path can reach: waking
-	// re-enters CEMSocket::OnReceive(), which parses packets and can run
-	// most of the core.
+	// re-enters CEMSocket::OnReceive(), which parses packets and can run most of
+	// the core.
 	//
-	// Only the sockets already waiting when it starts are woken. A socket
-	// that exhausts the refilled bucket suspends again immediately, and
-	// waking it a second time in the same pass would achieve nothing but
-	// spin the main loop until the next refill, which cannot arrive while
-	// that loop is blocked.
+	// Only the sockets already waiting when it starts are woken. One that exhausts
+	// the refilled bucket suspends again immediately, and waking it twice in the
+	// same pass would only spin the main loop until the next refill -- which cannot
+	// arrive while that loop is blocked.
 	void WakePaused();
 
 private:

--- a/src/DownloadClient.cpp
+++ b/src/DownloadClient.cpp
@@ -57,7 +57,6 @@
 bool CUpDownClient::Compare(const CUpDownClient *tocomp, bool bIgnoreUserhash) const
 {
 	if (!tocomp) {
-		// should we wxASSERT here?
 		return false;
 	}
 
@@ -69,13 +68,10 @@ bool CUpDownClient::Compare(const CUpDownClient *tocomp, bool bIgnoreUserhash) c
 	if (HasLowID()) {
 		// User is firewalled.. Must do two checks..
 		if (GetIP() != 0 && GetIP() == tocomp->GetIP()) {
-			// The IP of both match
 			if (GetUserPort() != 0 && GetUserPort() == tocomp->GetUserPort()) {
-				// IP-UserPort matches
 				return true;
 			}
 			if (GetKadPort() != 0 && GetKadPort() == tocomp->GetKadPort()) {
-				// IP-KadPort Matches
 				return true;
 			}
 		}
@@ -83,28 +79,23 @@ bool CUpDownClient::Compare(const CUpDownClient *tocomp, bool bIgnoreUserhash) c
 		if (GetUserIDHybrid() != 0 && GetUserIDHybrid() == tocomp->GetUserIDHybrid() &&
 			GetServerIP() != 0 && GetServerIP() == tocomp->GetServerIP() &&
 			GetServerPort() != 0 && GetServerPort() == tocomp->GetServerPort()) {
-			// Both have the same lowID, Same serverIP and Port..
 			return true;
 		}
 
-		// Both IP, and Server do not match..
 		return false;
 	}
 
 	// User is not firewalled.
 	if (GetUserPort() != 0) {
-		// User has a Port, lets check the rest.
 		if (GetIP() != 0 && tocomp->GetIP() != 0) {
 			// Both clients have a verified IP..
 			if (GetIP() == tocomp->GetIP() && GetUserPort() == tocomp->GetUserPort()) {
-				// IP and UserPort match..
 				return true;
 			}
 		} else {
 			// One of the two clients do not have a verified IP
 			if (GetUserIDHybrid() == tocomp->GetUserIDHybrid() &&
 				GetUserPort() == tocomp->GetUserPort()) {
-				// ID and Port Match..
 				return true;
 			}
 		}
@@ -115,27 +106,23 @@ bool CUpDownClient::Compare(const CUpDownClient *tocomp, bool bIgnoreUserhash) c
 		if (GetIP() != 0 && tocomp->GetIP() != 0) {
 			// Both clients have a verified IP.
 			if (GetIP() == tocomp->GetIP() && GetKadPort() == tocomp->GetKadPort()) {
-				// IP and KadPort Match..
 				return true;
 			}
 		} else {
 			// One of the users do not have a verified IP.
 			if (GetUserIDHybrid() == tocomp->GetUserIDHybrid() &&
 				GetKadPort() == tocomp->GetKadPort()) {
-				// ID and KadProt Match..
 				return true;
 			}
 		}
 	}
 
-	// No Matches..
 	return false;
 }
 #endif
 
 bool CUpDownClient::AskForDownload()
 {
-	// 0.42e
 	if (theApp->listensocket->TooManySockets()) {
 		if (!m_socket) {
 			if (GetDownloadState() != DS_TOOMANYCONNS) {
@@ -158,7 +145,6 @@ bool CUpDownClient::AskForDownload()
 
 void CUpDownClient::SendStartupLoadReq()
 {
-	// 0.42e
 	if (m_socket == NULL || m_reqfile == NULL) {
 		return;
 	}
@@ -173,8 +159,6 @@ void CUpDownClient::SendStartupLoadReq()
 
 bool CUpDownClient::IsSourceRequestAllowed()
 {
-	// #warning REWRITE - Source swapping from eMule.
-	//  0.42e
 	uint64 dwTickCount = ::GetTickCount64() + CONNECTION_LATENCY;
 	uint64 nTimePassedClient = dwTickCount - GetLastSrcAnswerTime();
 	uint64 nTimePassedFile = dwTickCount - m_reqfile->GetLastAnsweredTime();
@@ -186,7 +170,6 @@ bool CUpDownClient::IsSourceRequestAllowed()
 		ExtProtocolAvailable() && (SupportsSourceExchange2() || GetSourceExchange1Version() > 1) &&
 		// AND if we need more sources
 		thePrefs::GetMaxSourcePerFileSoft() > uSources &&
-		// AND if...
 		(
 			// source is not complete and file is very rare
 			(!m_bCompleteSource &&
@@ -222,7 +205,6 @@ void CUpDownClient::SendFileRequest()
 
 		dataFileReq.WriteUInt8(OP_REQUESTFILENAME);
 		DEBUG_ONLY(sent_opcodes += "|RFNM|";)
-		// Extended information
 		if (GetExtendedRequestsVersion() > 0) {
 			m_reqfile->WritePartStatus(&dataFileReq);
 		}
@@ -265,7 +247,6 @@ void CUpDownClient::SendFileRequest()
 				sent_opcodes % GetFullIP());
 		SendPacket(packet, true);
 	} else {
-		// This is extended information
 		if (GetExtendedRequestsVersion() > 0) {
 			m_reqfile->WritePartStatus(&dataFileReq);
 		}
@@ -276,12 +257,6 @@ void CUpDownClient::SendFileRequest()
 		theStats::AddUpOverheadFileRequest(packet->GetPacketSize());
 		AddDebugLogLineN(logLocalClient, "Local Client: OP_REQUESTFILENAME to " + GetFullIP());
 		SendPacket(packet, true);
-
-		// 26-Jul-2003: removed requesting the file status for files <= PARTSIZE for better
-		// compatibility with ed2k protocol (eDonkeyHybrid). if the remote client answers the
-		// OP_REQUESTFILENAME with OP_REQFILENAMEANSWER the file is shared by the remote client. if we
-		// know that the file is shared, we know also that the file is complete and don't need to
-		// request the file status.
 
 		// Sending the packet could have deleted the client, check m_reqfile
 		if (m_reqfile && (m_reqfile->GetPartCount() > 1)) {
@@ -335,7 +310,6 @@ void CUpDownClient::SendFileRequest()
 
 void CUpDownClient::ProcessFileInfo(const CMemFile *data, const CPartFile *file)
 {
-	// 0.42e
 	if (file == NULL) {
 		throw wxString("ERROR: Wrong file ID (ProcessFileInfo; file==NULL)");
 	}
@@ -348,10 +322,9 @@ void CUpDownClient::ProcessFileInfo(const CMemFile *data, const CPartFile *file)
 
 	m_clientFilename = data->ReadString((GetUnicodeSupport() != utf8strNone));
 
-	// 26-Jul-2003: removed requesting the file status for files <= PARTSIZE for better compatibility with
-	// ed2k protocol (eDonkeyHybrid). if the remote client answers the OP_REQUESTFILENAME with
-	// OP_REQFILENAMEANSWER the file is shared by the remote client. if we know that the file is shared,
-	// we know also that the file is complete and don't need to request the file status.
+	// The file status is not requested for files <= PARTSIZE, for compatibility
+	// with eDonkeyHybrid: an OP_REQFILENAMEANSWER already means the remote client
+	// shares the file, and so has it complete.
 	if (m_reqfile->GetPartCount() == 1) {
 		m_nPartCount = m_reqfile->GetPartCount();
 
@@ -387,7 +360,6 @@ void CUpDownClient::ProcessFileInfo(const CMemFile *data, const CPartFile *file)
 
 void CUpDownClient::ProcessFileStatus(bool bUdpPacket, const CMemFile *data, const CPartFile *file)
 {
-	// 0.42e
 	wxString strReqFileNull("ERROR: Wrong file ID (ProcessFileStatus; m_reqfile==NULL)");
 
 	if (!m_reqfile || file != m_reqfile) {
@@ -409,7 +381,6 @@ void CUpDownClient::ProcessFileStatus(bool bUdpPacket, const CMemFile *data, con
 		bPartsNeeded = true;
 		m_bCompleteSource = true;
 	} else {
-		// Somehow this happened.
 		if (!m_reqfile) {
 			throw strReqFileNull;
 		}
@@ -519,7 +490,6 @@ void CUpDownClient::SetDownloadState(uint8 byNewState)
 {
 	if (m_nDownloadState != byNewState) {
 		if (m_reqfile) {
-			// Notify the client that this source has changed its state
 			m_reqfile->ClientStateChanged(m_nDownloadState, byNewState);
 
 			if (byNewState == DS_DOWNLOADING) {
@@ -593,35 +563,29 @@ void CUpDownClient::SendBlockRequests()
 	}
 
 	// RTT/BDP-adaptive request-pipeline depth. The number of outstanding block
-	// requests needed to keep a link busy is the bandwidth-delay product:
-	// bytes_in_flight = rate * RTT. On a low-latency link (LAN) the BDP is a
-	// fraction of a 180 KB block, so we stay shallow and avoid the burst/starve
-	// oscillation a deep pipeline provokes against a fast local peer; on a
-	// high-latency link the BDP is large, so we go deep and hide the round-trip.
-	// Unlike a speed-only ladder this distinguishes a fast LAN peer from a fast
-	// WAN peer -- the thing that actually determines the depth needed. m_minRTT is
-	// the min-filtered request->first-byte round-trip (see ProcessBlockPacket).
+	// requests needed to keep a link busy is the bandwidth-delay product,
+	// rate * RTT: on a LAN that is a fraction of a 180 KB block, so we stay shallow
+	// and avoid the burst/starve oscillation a deep pipeline provokes against a
+	// fast local peer; on a high-latency link it is large, so we go deep and hide
+	// the round-trip. Unlike a speed-only ladder this tells a fast LAN peer from a
+	// fast WAN one. m_minRTT is the min-filtered request->first-byte round-trip
+	// (see ProcessBlockPacket).
 	//
-	// The flat cap-24 clamp is deliberate, not a placeholder. Benchmarking showed the
-	// WAN ceiling is the OS TCP socket-buffer autotune limit (~4 MB by default), which
-	// pins throughput near 40 MB/s at 100 ms RTT no matter how deep the request
-	// pipeline runs -- and cap 24 (24 * 180 KB = 4.3 MB of authorised in-flight data)
-	// already covers that. A deeper pipe buys no throughput, and 24 still sits inside
-	// eMule's own pending range (its gate is 2*blockCount = 18, with a top-up batch
-	// reaching ~27); lifting the OS buffer is host tuning, not a client concern. (The
-	// 2x overshoot factor below is still an empirical constant.)
+	// The flat cap of 24 is deliberate: the WAN ceiling is the OS TCP socket-buffer
+	// autotune limit (~4 MB by default), which pins throughput near 40 MB/s at
+	// 100 ms RTT however deep the pipeline runs, and 24 blocks is already 4.3 MB of
+	// authorised in-flight data. A deeper pipe buys no throughput, and 24 still
+	// sits inside eMule's own pending range.
 	const float rttMs = (m_minRTT > 0) ? (float)m_minRTT : 1.0f;
 	const float bdpBlocks = ((float)GetKBpsDown() * 1024.0f) * (rttMs / 1000.0f) / (float)EMBLOCKSIZE;
 	// 2x overshoot + margin: sizing the pipe to exactly the current BDP is
-	// self-limiting (the measured rate is itself capped by the current pipe, so it
-	// can never grow past a low equilibrium). Over-provisioning gives headroom for
-	// the rate to climb until it hits the link's real ceiling, at which point the
-	// BDP -- and thus the depth -- settles at the bandwidth-delay product.
+	// self-limiting, since the measured rate is itself capped by the current pipe
+	// and can never grow past a low equilibrium. Over-provisioning lets the rate
+	// climb to the link's real ceiling, where the depth settles at the BDP.
 	size_t pendingCap = 2 * (size_t)bdpBlocks + STANDARD_BLOCKS_REQUEST;
 	if (pendingCap < STANDARD_BLOCKS_REQUEST) {
-		// The floor doubles as the slow-source guard: a trickle source -- or one with
-		// no RTT sample yet (rttMs defaults to 1) -- has a near-zero BDP and is held at
-		// the 3-block minimum, never handed a deep pipe.
+		// The floor doubles as the slow-source guard: a trickle source, or one with
+		// no RTT sample yet, has a near-zero BDP and is never handed a deep pipe.
 		pendingCap = STANDARD_BLOCKS_REQUEST;
 	} else if (pendingCap > 24) {
 		pendingCap = 24; // OS-buffer ceiling (see above); still within eMule's pending range
@@ -629,10 +593,8 @@ void CUpDownClient::SendBlockRequests()
 
 	// Smooth continuous refill: top the in-flight + staged block count up to
 	// pendingCap by the exact shortfall each call, never in bursts. Bursty refill
-	// makes the leecher emit requests in clusters that overfill then starve a fast
-	// peer's send queue, leaving it idle between bursts (and tanking throughput on
-	// a low-latency link). Requests still ride the wire 3 to an OP_REQUESTPARTS
-	// packet, emitted across successive calls (see below).
+	// emits requests in clusters that overfill and then starve a fast peer's send
+	// queue. Requests still ride the wire 3 to an OP_REQUESTPARTS packet.
 	{
 		const size_t inSystem = m_PendingBlocks_list.size() + m_DownloadBlocks_list.size();
 		if (inSystem < pendingCap) {
@@ -679,10 +641,6 @@ void CUpDownClient::SendBlockRequests()
 		if (!slower_client->GetSentCancelTransfer()) {
 			CPacket *packet = new CPacket(OP_CANCELTRANSFER, 0, OP_EDONKEYPROT);
 			theStats::AddUpOverheadFileRequest(packet->GetPacketSize());
-			//			if (slower_client != this) {
-			//				printf("Dropped client %p to allow client %p to
-			// download\n",slower_client, this);
-			//			}
 			slower_client->ClearDownloadBlockRequests();
 			slower_client->SendPacket(packet, true, true);
 			slower_client->SetSentCancelTransfer(1);
@@ -696,7 +654,6 @@ void CUpDownClient::SendBlockRequests()
 		}
 
 		if (slower_client != this) {
-			// Re-request freed blocks.
 			AddDebugLogLineN(logLocalClient,
 				"Local Client: OP_CANCELTRANSFER (faster source eager to transfer) to " +
 					slower_client->GetFullIP());
@@ -739,7 +696,6 @@ void CUpDownClient::SendBlockRequests()
 				return;
 			}
 		} else {
-			// Drop this one.
 			AddDebugLogLineN(logLocalClient,
 				"Local Client: OP_CANCELTRANSFER (no free blocks) to " + GetFullIP());
 			// #warning Kry - Would be nice to swap A4AF here.
@@ -747,19 +703,15 @@ void CUpDownClient::SendBlockRequests()
 		}
 	}
 
-	// Collect up to 3 pending blocks that have not yet been written to a
-	// REQUESTPARTS packet (fQueued == 0). OP_REQUESTPARTS / OP_REQUESTPARTS_I64
-	// carry exactly 3 <start,end> pairs on the wire (see ProcessRequestPartsPacket
-	// in UploadClient.cpp, which unconditionally reads 3 pairs); asking for more
-	// in one packet corrupts the wire format and the sender ignores us. Pad with
-	// zero-pairs if we have fewer than 3 unqueued blocks.
+	// Collect up to 3 pending blocks not yet written to a REQUESTPARTS packet
+	// (fQueued == 0). OP_REQUESTPARTS / OP_REQUESTPARTS_I64 carry exactly 3
+	// <start,end> pairs on the wire (ProcessRequestPartsPacket in UploadClient.cpp
+	// unconditionally reads 3), so asking for more in one packet corrupts the wire
+	// format and the sender ignores us; pad with zero-pairs instead.
 	//
-	// To take more than 3 blocks in flight we emit one 3-block packet per call to
-	// SendBlockRequests() and let the caller's existing re-invocation loop (after
-	// each OP_SENDINGPART, OP_ACCEPTUPLOADREQ, etc.) issue further packets until
-	// m_PendingBlocks_list is fully queued -- the same pattern eMule uses
-	// (eMule0.70b srchybrid/DownloadClient.cpp ::CreateBlockRequests +
-	// ::SendBlockRequests).
+	// More than 3 blocks in flight means one 3-block packet per call, with the
+	// caller's re-invocation loop (after each OP_SENDINGPART, OP_ACCEPTUPLOADREQ,
+	// ...) issuing further packets until m_PendingBlocks_list is fully queued.
 	std::vector<Pending_Block_Struct *> toRequest;
 	bool bHasLongBlocks = false;
 	const size_t perPacketLimit = STANDARD_BLOCKS_REQUEST;
@@ -802,10 +754,9 @@ void CUpDownClient::SendBlockRequests()
 
 	CPacket *packet = NULL;
 
-	// OP_REQUESTPARTS / OP_REQUESTPARTS_I64: always 3 blocks on the wire. Pad
-	// missing entries with zero <start,end> pairs; the upload-side parser
-	// (UploadClient.cpp ProcessRequestPartsPacket) silently skips entries with
-	// end <= start, so zero pairs are inert.
+	// Always 3 blocks on the wire; pad missing entries with zero <start,end>
+	// pairs. The upload-side parser silently skips entries with end <= start, so
+	// the padding is inert.
 	const size_t kWireBlocks = STANDARD_BLOCKS_REQUEST;
 	const size_t offsetSize = bHasLongBlocks ? 8 : 4;
 	CMemFile data(16 + kWireBlocks * offsetSize * 2);
@@ -884,20 +835,15 @@ void CUpDownClient::ProcessBlockPacket(const uint8_t *packet, uint32 size, bool 
 	uint32 nBlockSize = 0;
 	uint32 lenUnzipped = 0;
 
-	// Update stats
 	m_dwLastBlockReceived = ::GetTickCount64();
 
 	try {
 
-		// Read data from packet
 		const CMemFile data(packet, size);
 
-		// Check that this data is for the correct file
 		if ((!m_reqfile) || data.ReadHash() != m_reqfile->GetFileHash()) {
 			throw wxString("Wrong fileid sent (ProcessBlockPacket)");
 		}
-
-		// Find the start & end positions, and size of this chunk of data
 
 		if (largeblocks) {
 			nStartPos = data.ReadUInt64();
@@ -933,22 +879,18 @@ void CUpDownClient::ProcessBlockPacket(const uint8_t *packet, uint32 size, bool 
 		// Move end back one, should be inclusive
 		nEndPos--;
 
-		// Loop through to find the reserved block that this is within
 		std::list<Pending_Block_Struct *>::iterator it = m_PendingBlocks_list.begin();
 		for (; it != m_PendingBlocks_list.end(); ++it) {
 			Pending_Block_Struct *cur_block = *it;
 
 			if ((cur_block->block->StartOffset <= nStartPos) &&
 				(cur_block->block->EndOffset >= nStartPos)) {
-				// Found reserved block
 
 				if (cur_block->block->StartOffset == nStartPos) {
-					// This block just started transferring. Set the start time.
 					m_last_block_start = ::GetTickCount64();
-					// RTT sample: the matched request->first-byte round-trip for
-					// this block. Min-filtered so pipeline queuing delay never
-					// inflates the estimate (BBR-style min-RTT floor); used to size
-					// the request pipeline to the bandwidth-delay product.
+					// RTT sample: the matched request->first-byte round-trip
+					// for this block. Min-filtered so pipeline queuing delay
+					// never inflates the estimate; sizes the request pipeline.
 					if (cur_block->sentTime != 0) {
 						uint64 sample = m_last_block_start - cur_block->sentTime;
 						if (m_minRTT == 0 || sample < m_minRTT) {
@@ -976,7 +918,6 @@ void CUpDownClient::ProcessBlockPacket(const uint8_t *packet, uint32 size, bool 
 				// This will be 0 in these cases, or the length written otherwise
 				uint32 lenWritten = 0;
 
-				// Handle differently depending on whether packed or not
 				if (!packed) {
 					// security sanitize check
 					if (nEndPos > cur_block->block->EndOffset) {
@@ -1003,7 +944,6 @@ void CUpDownClient::ProcessBlockPacket(const uint8_t *packet, uint32 size, bool 
 						cur_block->block,
 						this);
 				} else {
-					// Packed
 					wxASSERT((long int)size > 0);
 					// Create space to store unzipped data, the size is
 					// only an initial guess, will be resized in unzip()
@@ -1015,7 +955,6 @@ void CUpDownClient::ProcessBlockPacket(const uint8_t *packet, uint32 size, bool 
 					}
 					uint8_t *unzipped = new uint8_t[lenUnzipped];
 
-					// Try to unzip the packet
 					int result = unzip(cur_block,
 						(uint8_t *)(packet + header_size),
 						(size - header_size),
@@ -1026,7 +965,6 @@ void CUpDownClient::ProcessBlockPacket(const uint8_t *packet, uint32 size, bool 
 					// erroneous.
 					if (result == Z_OK && ((int)lenUnzipped >= 0)) {
 
-						// Write any unzipped data to disk
 						if (lenUnzipped > 0) {
 							wxASSERT((int)lenUnzipped > 0);
 
@@ -1048,7 +986,6 @@ void CUpDownClient::ProcessBlockPacket(const uint8_t *packet, uint32 size, bool 
 									cur_block->block->StartOffset,
 									cur_block->block->EndOffset);
 							} else {
-								// Write uncompressed data to file
 								lenWritten = m_reqfile->WriteToBuffer(
 									size - header_size,
 									unzipped,
@@ -1084,21 +1021,17 @@ void CUpDownClient::ProcessBlockPacket(const uint8_t *packet, uint32 size, bool 
 							cur_block->zStream = NULL;
 						}
 
-						// Although we can't further use the current zstream, there is
-						// no need to disconnect the sending client because the next
-						// zstream (a series of 10K-blocks which build a 180K-block)
-						// could be valid again. Just ignore all further blocks for
-						// the current zstream.
+						// No need to disconnect the sending client: the next
+						// zstream (a series of 10K-blocks building a 180K-block)
+						// may be valid again, so just ignore the rest of this one.
 						cur_block->fZStreamError = 1;
 						cur_block->totalUnzipped = 0; // bluecow's fix
 					}
 					delete[] unzipped;
 				}
-				// These checks only need to be done if any data was written
 				if (lenWritten > 0) {
 					m_nTransferredDown += lenWritten;
 
-					// If finished reserved block
 					if (nEndPos == cur_block->block->EndOffset) {
 
 						// Save last average speed based on data and time.
@@ -1127,11 +1060,9 @@ void CUpDownClient::ProcessBlockPacket(const uint8_t *packet, uint32 size, bool 
 						delete cur_block;
 						m_PendingBlocks_list.erase(it);
 
-						// Request next block
 						SendBlockRequests();
 					}
 				}
-				// Stop looping and exit method
 				return;
 			}
 		}
@@ -1155,16 +1086,13 @@ int CUpDownClient::unzip(Pending_Block_Struct *block,
 {
 	int err = Z_DATA_ERROR;
 
-	// Save some typing
 	z_stream *zS = block->zStream;
 
 	// Is this the first time this block has been unzipped
 	if (zS == NULL) {
-		// Create stream
 		block->zStream = new z_stream;
 		zS = block->zStream;
 
-		// Initialise stream values
 		zS->zalloc = (alloc_func)0;
 		zS->zfree = (free_func)0;
 		zS->opaque = (voidpf)0;
@@ -1173,14 +1101,12 @@ int CUpDownClient::unzip(Pending_Block_Struct *block,
 		zS->next_out = (*unzipped);
 		zS->avail_out = (*lenUnzipped);
 
-		// Initialise the z_stream
 		err = inflateInit(zS);
 		if (err != Z_OK) {
 			return err;
 		}
 	}
 
-	// Use whatever input is provided
 	zS->next_in = zipped;
 	zS->avail_in = lenZipped;
 
@@ -1190,13 +1116,11 @@ int CUpDownClient::unzip(Pending_Block_Struct *block,
 		zS->avail_out = (*lenUnzipped);
 	}
 
-	// Try to unzip the data
 	err = inflate(zS, Z_SYNC_FLUSH);
 
 	// Is zip finished reading all currently available input and writing
 	// all generated output
 	if (err == Z_STREAM_END) {
-		// Finish up
 		err = inflateEnd(zS);
 		if (err != Z_OK) {
 			return err;
@@ -1211,7 +1135,6 @@ int CUpDownClient::unzip(Pending_Block_Struct *block,
 		// Output array was not big enough,
 		// call recursively until there is enough space
 
-		// What size should we try next
 		uint32 newLength = (*lenUnzipped) *= 2;
 		if (newLength == 0) {
 			newLength = lenZipped * 2;
@@ -1228,7 +1151,6 @@ int CUpDownClient::unzip(Pending_Block_Struct *block,
 		zS->next_out = (*unzipped) + (zS->total_out - block->totalUnzipped);
 		zS->avail_out = (*lenUnzipped) - (zS->total_out - block->totalUnzipped);
 
-		// Try again
 		err = unzip(block, zS->next_in, zS->avail_in, unzipped, lenUnzipped, iRecursion + 1);
 	} else if ((err == Z_OK) && (zS->avail_in == 0)) {
 		// All available input has been processed, everything ok.
@@ -1258,10 +1180,8 @@ int CUpDownClient::unzip(Pending_Block_Struct *block,
 	return err;
 }
 
-// Speed is now updated only when data was received, calculated as
-// (data received) / (time since last reception)
-// and slightly filtered (10s average).
-// Result is quite precise now and makes the DownloadRateAdjust workaround obsolete.
+// Updated only when data was received: (data received) / (time since last
+// reception), lightly filtered over a 10 s average.
 
 float CUpDownClient::CalculateKBpsDown()
 {
@@ -1279,9 +1199,6 @@ float CUpDownClient::CalculateKBpsDown()
 		} else {
 			kBpsDown = (kBpsDown * (tAverage - dt) + kBpsDownCur * dt) / tAverage;
 		}
-		// AddDebugLogLineN(logLocalClient, CFormat("CalculateKBpsDown %p kbps %.1f kbpsCur %.1f dt
-		// %.3f rcv %d ") 			% this % kBpsDown  % kBpsDownCur % dt %
-		// bytesReceivedCycle);
 		bytesReceivedCycle = 0;
 		msReceivedPrev = msCur;
 	}
@@ -1324,7 +1241,6 @@ void CUpDownClient::SetRemoteQueueRank(uint16 nr)
 
 void CUpDownClient::UDPReaskACK(uint16 nNewQR)
 {
-	// 0.42e
 	m_bUDPPending = false;
 	SetRemoteQueueRank(nNewQR);
 	m_dwLastAskedTime = ::GetTickCount64();
@@ -1434,7 +1350,6 @@ void CUpDownClient::UDPReaskForDownload()
 	}
 }
 
-// Get the next part that is requested
 uint16 CUpDownClient::GetNextRequestedPart() const
 {
 	uint16 part = 0xffff;
@@ -1454,10 +1369,8 @@ void CUpDownClient::UpdateDisplayedInfo(bool force)
 {
 	uint64 curTick = ::GetTickCount64();
 	if (force || curTick - m_lastRefreshedDLDisplay > MINWAIT_BEFORE_DLDISPLAY_WINDOWUPDATE) {
-		// Check if we actually need to notify of changes
 		bool update = m_reqfile && m_reqfile->ShowSources();
 
-		// Check A4AF files only if needed
 		if (!update) {
 			A4AFList::iterator it = m_A4AF_list.begin();
 			for (; it != m_A4AF_list.end(); ++it) {
@@ -1468,7 +1381,6 @@ void CUpDownClient::UpdateDisplayedInfo(bool force)
 			}
 		}
 
-		// And finnaly trigger an event if there's any reason
 		if (update) {
 			SourceItemType type;
 			switch (GetDownloadState()) {
@@ -1522,7 +1434,6 @@ uint8 CUpDownClient::GetObfuscationStatus() const
 bool CUpDownClient::SwapToAnotherFile(
 	bool bIgnoreNoNeeded, bool ignoreSuspensions, bool bRemoveCompletely, CPartFile *toFile)
 {
-	// Fail if m_reqfile is invalid
 	if (m_reqfile == NULL) {
 		return false;
 	}
@@ -1532,17 +1443,14 @@ bool CUpDownClient::SwapToAnotherFile(
 		return false;
 	}
 
-	// The iterator of the final target
 	A4AFList::iterator target = m_A4AF_list.end();
 
-	// Do we want to swap to a specific file?
 	if (toFile != NULL) {
 		A4AFList::iterator it = m_A4AF_list.find(toFile);
 		if (it != m_A4AF_list.end()) {
 
 			// We force ignoring of timestamps
 			if (IsValidSwapTarget(it, bIgnoreNoNeeded, true)) {
-				// Set the target
 				target = it;
 			}
 		}
@@ -1561,11 +1469,9 @@ bool CUpDownClient::SwapToAnotherFile(
 				if (it->second.NeededParts)
 					cur_priority += 10;
 
-				// Change target if the current file has a higher rate than the previous
 				if (cur_priority > priority) {
 					priority = cur_priority;
 
-					// Set the new target
 					target = it;
 
 					// Break on the first High-priority file with needed parts
@@ -1577,7 +1483,6 @@ bool CUpDownClient::SwapToAnotherFile(
 		}
 	}
 
-	// Try to swap if we found a valid target
 	if (target != m_A4AF_list.end()) {
 
 		// Sanity check, if reqfile doesn't own the source, then something
@@ -1596,7 +1501,6 @@ bool CUpDownClient::SwapToAnotherFile(
 			if (!bRemoveCompletely) {
 				m_reqfile->AddA4AFSource(this);
 
-				// Set the status of the old file
 				m_A4AF_list[m_reqfile].NeededParts = (GetDownloadState() != DS_NONEEDEDPARTS);
 
 				// Avoid swapping to this file for a while
@@ -1660,7 +1564,6 @@ bool CUpDownClient::IsValidSwapTarget(A4AFList::iterator it, bool ignorenoneeded
 		}
 	}
 
-	// Final checks to see if the client is a valid target
 	CPartFile *cur_file = it->first;
 	if ((cur_file != m_reqfile && !cur_file->IsStopped()) &&
 		(cur_file->GetStatus() == PS_READY || cur_file->GetStatus() == PS_EMPTY) &&
@@ -1744,7 +1647,6 @@ void CUpDownClient::ProcessAICHAnswer(const uint8_t *packet, uint32 size)
 			ahMasterHash == pPartFile->GetAICHHashset()->GetMasterHash()) {
 			if (pPartFile->GetAICHHashset()->ReadRecoveryData(
 				    request.m_nPart * PARTSIZE, &data)) {
-				// finally all checks passed, everything seems to be fine
 				AddDebugLogLineN(logAICHTransfer,
 					"AICH Packet Answer: Succeeded to read and validate received "
 					"recoverydata");

--- a/src/DownloadListCtrl.cpp
+++ b/src/DownloadListCtrl.cpp
@@ -95,11 +95,10 @@ private:
 		const bool bFlat = thePrefs::UseFlatBar();
 		const wxRect barRect = InsetForBar(cell, bFlat);
 
-		// The completed-progress strip only makes sense for a file still
-		// assembling from gaps/pending blocks: DrawFileStatusBar's completed
-		// and hashing branches already fill the whole bar solid, so the strip
-		// would be redundant there (and, while hashing, actively wrong -- that
-		// fill tracks hashed bytes, not completed bytes).
+		// The completed-progress strip only makes sense for a file still assembling
+		// from gaps and pending blocks: DrawFileStatusBar's completed and hashing
+		// branches already fill the bar solid, and while hashing that fill tracks
+		// hashed bytes rather than completed ones.
 		const bool showStrip = !file->IsCompleted() && file->GetStatus() != PS_COMPLETING &&
 				       file->GetHashingProgress() == 0;
 		if (showStrip && barRect.GetWidth() > 0) {
@@ -108,12 +107,9 @@ private:
 							   static_cast<double>(file->GetCompletedSize()));
 			if (bFlat) {
 				// Deliberately no outline: master drew this strip into a fresh
-				// wxMemoryDC, whose default black pen gave it one, but that was
-				// incidental -- nothing set the pen on purpose, so it would
-				// have carried over whatever the list's own DC last used had
-				// this been drawn there instead. Transparent is the
-				// intentional, deterministic choice; wxBLACK_PEN would
-				// reproduce the old look if that turns out to be preferred.
+				// wxMemoryDC, whose default black pen gave it one incidentally.
+				// Transparent is the deterministic choice; wxBLACK_PEN would
+				// reproduce the old look.
 				dc->SetPen(*wxTRANSPARENT_PEN);
 				dc->SetBrush(crFlatProgress.GetBrush());
 				dc->DrawRectangle(barRect.x, barRect.y, width, 3);
@@ -248,12 +244,11 @@ void CDownloadListCtrl::AddFile(CPartFile *file, bool deferView)
 {
 	wxASSERT(file);
 
-	// Avoid duplicate entries of files
 	if (m_files.insert(file).second) {
-		// During a bulk load (remote GUI first sync) the caller defers the
-		// display: showing and, above all, re-sorting the list on every one
-		// of thousands of files is O(n^2) and freezes the GUI (issue #414).
-		// ShowFileList() shows and sorts the whole list once afterwards.
+		// During a bulk load (remote GUI first sync) the caller defers the display:
+		// showing and above all re-sorting the list on every one of thousands of
+		// files is O(n^2) and freezes the GUI (issue #414). ShowFileList() shows and
+		// sorts the whole list once afterwards.
 		if (deferView) {
 			return;
 		}
@@ -263,10 +258,9 @@ void CDownloadListCtrl::AddFile(CPartFile *file, bool deferView)
 			if (file->IsCompleted()) {
 				CastByID(ID_BTNCLRCOMPL, GetParent(), wxButton)->Enable(true);
 			}
-			// During a batch update (a reconnect resync -- issue #444) the row
-			// is still appended, but the per-item sort is deferred to
-			// EndBatchUpdate()'s single SortList() so a large add stays
-			// O(n log n) instead of O(n^2).
+			// During a batch update (a reconnect resync, issue #444) the row is
+			// still appended, but the per-item sort is deferred to
+			// EndBatchUpdate()'s single SortList(), keeping a large add O(n log n).
 			if (!m_batchUpdate) {
 				SortList();
 			}
@@ -276,10 +270,9 @@ void CDownloadListCtrl::AddFile(CPartFile *file, bool deferView)
 
 void CDownloadListCtrl::BeginBatchUpdate()
 {
-	// Coalesce a burst of AddFile()/UpdateItem() calls into a single repaint
-	// (Freeze) and suppress the per-item SortList; EndBatchUpdate() sorts
-	// once. Used when reconciling the whole list against a fresh server
-	// snapshot after a reconnect (issue #444).
+	// Coalesce a burst of AddFile()/UpdateItem() calls into a single repaint and
+	// suppress the per-item SortList; EndBatchUpdate() sorts once. Used when
+	// reconciling the list against a fresh snapshot after a reconnect (issue #444).
 	Freeze();
 	// Same reason as CSharedFilesCtrl::BeginBatchUpdate(): rows land unsorted
 	// and EndBatchUpdate() sorts once, while a live sort key makes macOS
@@ -487,11 +480,10 @@ void CDownloadListCtrl::OnItemRightClicked(wxDataViewEvent &event)
 	m_menu->Append(MP_WS, _("Copy feedback to clipboard"));
 	m_menu->AppendSeparator();
 
-	// Same entry the search list offers, on the same gate: a partfile's hash is
-	// the completed file's and is known from the link, so the lookup works
-	// before a single byte has arrived -- which is when sources and history are
-	// worth checking. Hidden, not greyed, when no stats server is configured,
-	// because an empty preference means the feature is off rather than
+	// Same entry the search list offers, on the same gate: a partfile's hash is the
+	// completed file's and is known from the link, so the lookup works before a
+	// single byte has arrived. Hidden rather than greyed when no stats server is
+	// configured, because an empty preference means the feature is off rather than
 	// unavailable for this row.
 	const wxString &statsServer = thePrefs::GetStatsServerName();
 	if (!statsServer.IsEmpty()) {
@@ -771,9 +763,8 @@ void CDownloadListCtrl::OnItemActivated(wxDataViewEvent &event)
 	if (!event.GetItem().IsOk()) {
 		return;
 	}
-	// Read the row straight off the event, the way GetRowLabel() does --
-	// touching the selection here (as an earlier version of this did) would
-	// discard whatever multi-selection the user already had, and firing
+	// Read the row straight off the event, the way GetRowLabel() does: touching the
+	// selection here would discard the user's multi-selection, and firing
 	// EVT_DATAVIEW_SELECTION_CHANGED as a side effect of a double-click would
 	// rebuild the sources panel for no reason.
 	const long row = GetModelRow(event.GetItem());
@@ -783,14 +774,11 @@ void CDownloadListCtrl::OnItemActivated(wxDataViewEvent &event)
 	}
 	CPartFile *file = reinterpret_cast<CPartFile *>(data);
 
-	// One rule for both file tables: a completed file opens whatever type it
-	// is, an unfinished one only once enough of the media is on disk to play
-	// -- PreviewAvailable()'s own test, the classic eMule gesture, and what
-	// the menu's Preview entry offers for the same row. IsPartFile() is
-	// exactly "not complete" (PartFile.h), so finishing a download no longer
-	// narrows what a double-click does to it; from that moment the same file
-	// is also in Shared Files, where CSharedFilesCtrl::OnItemActivated opens
-	// it whatever its type. Anything else opens the file-details modal.
+	// One rule for both file tables: a completed file opens whatever type it is, an
+	// unfinished one only once enough of the media is on disk to play -- the classic
+	// eMule gesture, and what the menu's Preview entry offers for the same row.
+	// IsPartFile() is exactly "not complete", so finishing a download never narrows
+	// what a double-click does to it. Anything else opens the file-details modal.
 	if ((!file->IsPartFile() || file->PreviewAvailable()) && FileLaunch::CanOpen(file)) {
 		FileLaunch::Open(file, this);
 	} else {
@@ -984,18 +972,16 @@ bool CDownloadListCtrl::GetItemAttr(wxUIntPtr item, unsigned WXUNUSED(column), w
 	}
 
 	// A category keeps colour 0 until the user picks one (Preferences writes
-	// "Color" as 0 for a new one), so 0 means unset rather than black. The old
-	// code painted those rows black because it predates the dark themes, where
-	// black on a dark list is unreadable.
+	// "Color" as 0 for a new one), so 0 means unset rather than black. The old code
+	// painted those rows black, which predates the dark themes.
 	const uint32 colour = theApp->glob_prefs->GetCatColor(cat);
 	if (!colour) {
 		return false;
 	}
 
 	// Selected rows keep the system highlight colour: wx overrides a custom
-	// foreground while a row is selected -- in common/datavcmn.cpp for the
-	// generic renderers, and explicitly in the macOS backend -- for the same
-	// readability reason the old OnDrawItem() skipped highlighted rows.
+	// foreground while a row is selected, for the same readability reason the old
+	// OnDrawItem() skipped highlighted rows.
 	attr.SetColour(CMuleColour(colour));
 	return true;
 }
@@ -1032,7 +1018,6 @@ void CDownloadListCtrl::GetItemBarFill(wxUIntPtr item, unsigned column, CBarFill
 		return;
 	}
 
-	// Part availability (of missing parts).
 	const CGapList &gaplist = file->GetGapList();
 	uint64 lastGapEnd = 0;
 	for (CGapList::const_iterator it = gaplist.begin(); it != gaplist.end(); ++it) {
@@ -1046,17 +1031,14 @@ void CDownloadListCtrl::GetItemBarFill(wxUIntPtr item, unsigned column, CBarFill
 			end = file->GetPartCount();
 		}
 
-		// Place each gap, one PART at a time.
 		for (uint64 i = start; i < end; ++i) {
 			CMuleColour colour;
 			if (i < file->m_SrcpartFrequency.size() && file->m_SrcpartFrequency[i]) {
-				// The same fade the shared-files bar draws. This used to be a
-				// linear ramp of its own, saturating one source later, written
-				// into the green channel through a local called "blue" while
-				// the blue channel stayed at 255 -- so the same file read as
-				// differently shared depending on which list you looked at.
-				// The suite greps this file for that ramp, which is why it is
-				// described here rather than quoted.
+				// The same fade the shared-files bar draws. This used to be a linear
+				// ramp of its own, saturating one source later and written into the
+				// green channel through a local called "blue" while the blue channel
+				// stayed at 255, so the same file read as differently shared
+				// depending on which list you looked at.
 				colour = ToMuleColour(
 					partbar::SourceAvailabilityColour(file->m_SrcpartFrequency[i]));
 			} else {
@@ -1209,10 +1191,9 @@ void CDownloadListCtrl::SetTotalSize(uint64 total)
 {
 	m_shownSize = total;
 
-	// This label lives in the sources pane (the bottom of the transfer
-	// splitter), a different window from the download list, so reach it via
-	// the transfer window rather than GetParent(). Guard the early calls
-	// before the transfer window is fully constructed.
+	// This label lives in the sources pane, a different window from the download
+	// list, so reach it via the transfer window rather than GetParent(). Guarded
+	// for the early calls before that window is fully constructed.
 	if (!theApp->amuledlg || !theApp->amuledlg->m_transferwnd) {
 		return;
 	}
@@ -1228,9 +1209,8 @@ void CDownloadListCtrl::UpdateFreeSpace()
 	if (!theApp->amuledlg || !theApp->amuledlg->m_transferwnd) {
 		return;
 	}
-	// Resolved once: this runs on the GUI timer, and the label outlives
-	// every call -- it belongs to the transfer window, which is built with
-	// the main dialog and torn down with it.
+	// Resolved once: this runs on the GUI timer, and the label outlives every call,
+	// belonging to the transfer window.
 	if (!m_freeSpaceLabel) {
 		m_freeSpaceLabel =
 			CastByName("downloadsFreeSpace", theApp->amuledlg->m_transferwnd, wxStaticText);
@@ -1245,15 +1225,14 @@ void CDownloadListCtrl::UpdateFreeSpace()
 
 	const sint64 freeSpace = theStats::GetTempFreeSpace();
 
-	// What the queue still has to write, over every category. Completed
-	// files are already out of temp, and the bytes a part file holds are
-	// already off the free-space figure, so what is left to download is
-	// exactly what the filesystem still has to find room for. Paused and
-	// stopped files count too: they are space the queue will need as soon
-	// as they resume.
+	// What the queue still has to write, over every category. Completed files are
+	// already out of temp, and the bytes a part file holds are already off the
+	// free-space figure, so what is left to download is exactly what the filesystem
+	// still has to find room for. Paused and stopped files count too: they are space
+	// the queue will need as soon as they resume.
 	//
-	// Skipped when there is no figure to compare against: without one there
-	// is nothing to warn about, and this walks the whole queue.
+	// Skipped when there is no figure to compare against -- nothing to warn about,
+	// and this walks the whole queue.
 	uint64 remaining = 0;
 	if (freeSpace != FREE_SPACE_UNKNOWN) {
 		for (CPartFile *file : m_files) {

--- a/src/DownloadQueue.cpp
+++ b/src/DownloadQueue.cpp
@@ -108,7 +108,6 @@ void CDownloadQueue::LoadMetFiles(const CPath &path, const LoadProgressCb &progr
 
 	std::vector<CPath> files;
 
-	// Locate part-files to be loaded
 	CDirIterator TempDir(path);
 	CPath fileName = TempDir.GetFirstFile(CDirIterator::File, "*.part.met");
 	while (fileName.IsOk()) {
@@ -121,7 +120,6 @@ void CDownloadQueue::LoadMetFiles(const CPath &path, const LoadProgressCb &progr
 	// file is broken in case of crashes, or the like.
 	std::sort(files.begin(), files.end());
 
-	// Load part-files
 	for (size_t i = 0; i < files.size(); i++) {
 		AddLogLineNS(CFormat(_("Loading PartFile %u of %u")) % (i + 1) % files.size());
 		if (progressCb) {
@@ -131,7 +129,6 @@ void CDownloadQueue::LoadMetFiles(const CPath &path, const LoadProgressCb &progr
 		CPartFile *toadd = new CPartFile();
 		bool result = toadd->LoadPartFile(path, fileName) != 0;
 		if (!result) {
-			// Try from backup
 			result = toadd->LoadPartFile(path, fileName, true) != 0;
 		}
 		if (result && !IsFileExisting(toadd->GetFileHash())) {
@@ -158,7 +155,6 @@ void CDownloadQueue::LoadMetFiles(const CPath &path, const LoadProgressCb &progr
 			}
 			AddLogLineCS(msg);
 
-			// Delete the partfile object in the end.
 			delete toadd;
 		}
 	}
@@ -257,7 +253,6 @@ void CDownloadQueue::AddSearchToDownload(CSearchFile *toadd, uint8 category)
 
 	if (newfile && newfile->GetStatus() != PS_ERROR) {
 		AddDownload(newfile, thePrefs::AddNewFilesPaused(), category);
-		// Add any possible sources
 		if (toadd->GetClientID() && toadd->GetClientPort()) {
 			CMemFile sources(1 + 4 + 2);
 			sources.WriteUInt8(1);
@@ -313,7 +308,6 @@ struct SFindBestPF
 				// happen if they have same name)
 				m_result = file;
 			} else {
-				// Lower priority file
 			}
 		}
 	}
@@ -335,20 +329,16 @@ void CDownloadQueue::StartNextFile(CPartFile *oldfile)
 			wxMutexLocker lock(m_mutex);
 
 			if (thePrefs::StartNextFileSame()) {
-				// Get a download in the same category
 				visitor.m_category = oldfile->GetCategory();
 
 				visitor = std::for_each(m_filelist.begin(), m_filelist.end(), visitor);
 			}
 
 			if (visitor.m_result == NULL) {
-				// Get a download, regardless of category
 				visitor.m_category = -1;
 
 				visitor = std::for_each(m_filelist.begin(), m_filelist.end(), visitor);
 			}
-
-			// Alpha doesn't need special cases
 		}
 
 		if (visitor.m_result) {
@@ -397,16 +387,15 @@ bool CDownloadQueue::IsFileExisting(const CMD4Hash &fileid, const wxString &requ
 			// manually reload the shares to download a file again.
 			CPath fullpath = file->GetFilePath().JoinPaths(file->GetFileName());
 			if (!fullpath.FileExists()) {
-				// The file is no longer available, unshare it
 				theApp->sharedfiles->RemoveFile(file);
 
 				return false;
 			}
 
 			// Files are matched by hash, so the already-present file can carry a
-			// different name than the one requested. Surface the requested name
-			// too when it differs, so the log can be correlated with the search
-			// result or ed2k link the download was started from.
+			// different name than the one requested. Surface the requested name too
+			// when it differs, so the log can be correlated with the search result
+			// or ed2k link the download started from.
 			if (!requestedName.IsEmpty() && requestedName != file->GetFileName().GetPrintable()) {
 				AddLogLineC(CFormat(_("You already have the file '%s' (requested as '%s')")) %
 					    fullpath % requestedName);
@@ -418,11 +407,10 @@ bool CDownloadQueue::IsFileExisting(const CMD4Hash &fileid, const wxString &requ
 		return true;
 	} else if ((file = GetFileByID(fileid))) {
 		// GetFileByID() also returns finished downloads still lingering in
-		// m_completedDownloads (kept so a remote GUI can act on them). Such an
-		// entry is not an active download, so if its file was deleted from disk
-		// it must not keep blocking a re-download. The shared-file branch above
-		// already allows that, but a prior shares rescan removes the file from
-		// the shared list and leaves only this entry, which had no such check.
+		// m_completedDownloads (kept so a remote GUI can act on them). Such an entry
+		// is not an active download, so a file deleted from disk must not keep
+		// blocking a re-download -- a prior shares rescan removes it from the shared
+		// list and leaves only this entry, which had no such check.
 		CPartFile *part = static_cast<CPartFile *>(file);
 		if (part->IsCompleted()) {
 			CPath fullpath = part->GetFilePath().JoinPaths(part->GetFileName());
@@ -445,26 +433,21 @@ bool CDownloadQueue::IsFileExisting(const CMD4Hash &fileid, const wxString &requ
 
 void CDownloadQueue::Process()
 {
-	// send src requests to local server
 	ProcessLocalRequests();
 	const uint64 curTick = ::GetTickCount64();
 
-	// Refill the global download bucket for this tick. The previous per-peer
-	// ratio controller (50-200% adaptive against the observed aggregate
-	// datarate) never actually enforced MaxDownload as a literal byte/sec
-	// cap. The throttler is a single shared atomic budget that every
-	// CEMSocket consults before each Read(); fast peers can claim unused
-	// capacity from slow ones within the same tick (demand-aware
-	// redistribution), and the global cap is the only constraint.
-	// MaxDownload=0 (UNLIMITED) sets the throttler to bypass mode.
+	// Refill the global download bucket for this tick. The throttler is a single
+	// shared atomic budget every CEMSocket consults before each Read(), so fast
+	// peers can claim unused capacity from slow ones within a tick and the global
+	// cap is the only constraint; the previous per-peer ratio controller never
+	// enforced MaxDownload as a literal byte/sec cap. MaxDownload=0 is bypass mode.
 	//
-	// Both of these run before the lock, and the wake runs immediately after
-	// the refill, because the part-file walk below reads from every
-	// downloading socket synchronously while holding the lock. Refilling
-	// inside that block and waking after it hands the whole tick's budget to
-	// the peers we are downloading from, and a socket parked mid-packet --
-	// the browse or chat answer this wake exists for -- finds an empty bucket
-	// again every tick and never finishes reading.
+	// Both calls run before the lock, and the wake immediately after the refill,
+	// because the part-file walk below reads from every downloading socket
+	// synchronously while holding the lock. Refilling inside that block and waking
+	// after it hands the whole tick's budget to the peers we are downloading from,
+	// so a socket parked mid-packet -- the browse or chat answer this wake exists
+	// for -- finds an empty bucket every tick and never finishes reading.
 	CDownloadBandwidthThrottler::Get().RefillBudget(thePrefs::GetMaxDownload(), CORE_TIMER_PERIOD);
 	// Outside the lock on purpose: this re-enters CEMSocket::OnReceive(),
 	// which parses packets and can reach back into the download queue.
@@ -498,16 +481,14 @@ void CDownloadQueue::Process()
 				file->StopPausedFile();
 
 				// Drain leftover Phase 3 hash work for paused files: their
-				// Process() doesn't run (gated above), but pre-pause
-				// m_aChangedPart entries still need verification.
+				// Process() does not run, but pre-pause m_aChangedPart entries
+				// still need verification.
 				//
-				// PS_INSUFFICIENT is intentionally excluded — driving
-				// FlushBuffer for a disk-full file re-enters its disk-space
-				// check at PartFile.cpp:3083 every tick, which logs
-				// "Not enough free disk-space" and re-pauses on every call,
-				// producing tens of log lines per second.  The destructor
-				// sync-hash drain still covers leftover dirty parts of
-				// disk-full files at shutdown.
+				// PS_INSUFFICIENT is excluded on purpose: driving FlushBuffer
+				// for a disk-full file re-enters its disk-space check every
+				// tick, logging "Not enough free disk-space" and re-pausing tens
+				// of times a second. The destructor's sync-hash drain still
+				// covers their leftover dirty parts at shutdown.
 				if (status == PS_PAUSED && file->HasPendingHashWork()) {
 					file->FlushBuffer();
 				}
@@ -536,7 +517,6 @@ void CDownloadQueue::Process()
 			PlatformSpecific::AllowSleepMode();
 		}
 
-		// Set the source rarity thresholds
 		int nSourceGroups = m_sourcecountlist.size();
 		if (nSourceGroups) {
 			m_sourcecountlist.sort();
@@ -598,7 +578,6 @@ void CDownloadQueue::Process()
 		if ((curTick - m_lastsorttime) > 10000) {
 			DoSortByPriority();
 		}
-		// Check if any paused files can be resumed
 
 		CheckDiskspace(thePrefs::GetTempDir());
 	}
@@ -699,7 +678,6 @@ void CDownloadQueue::CheckAndAddSource(CPartFile *sender, CUpDownClient *source)
 		return;
 	}
 
-	// Find all clients with the same hash
 	if (source->HasValidHash()) {
 		CClientList::SourceList found = theApp->clientlist->GetClientsByHash(source->GetUserHash());
 
@@ -707,13 +685,10 @@ void CDownloadQueue::CheckAndAddSource(CPartFile *sender, CUpDownClient *source)
 		for (; it != found.end(); ++it) {
 			CKnownFile *file = it->GetRequestFile();
 
-			// Only check files on the download-queue
 			if (file) {
 				// Is the found source queued for something else?
 				if (file != sender) {
-					// Try to add a request for the other file
 					if (it->GetClient()->AddRequestForAnotherFile(sender)) {
-						// Add it to downloadlistctrl
 						Notify_SourceCtrlAddSource(sender, *it, A4AF_SOURCE);
 					}
 				}
@@ -724,19 +699,17 @@ void CDownloadQueue::CheckAndAddSource(CPartFile *sender, CUpDownClient *source)
 		}
 	}
 
-	// Our new source is real new but maybe it is already uploading to us?
-	// If yes the known client will be attached to the var "source" and the old
-	// source-client will be deleted. However, if the request file of the known
-	// source is NULL, then we have to treat it almost like a new source and if
-	// it isn't NULL and not "sender", then we shouldn't move it, but rather add
-	// a request for the new file.
+	// The source may be new to us but already uploading to us. If so the known
+	// client is attached to `source` and the old source-client is deleted. A known
+	// source whose request file is NULL is treated almost like a new one; if it is
+	// neither NULL nor `sender`, add a request for the new file rather than moving
+	// it.
 	ESourceFrom nSourceFrom = source->GetSourceFrom();
 	if (theApp->clientlist->AttachToAlreadyKnown(&source, 0)) {
 		// Already queued for another file?
 		if (source->GetRequestFile()) {
 			// If we're already queued for the right file, then there's nothing to do
 			if (sender != source->GetRequestFile()) {
-				// Add the new file to the request list
 				source->AddRequestForAnotherFile(sender);
 			}
 		} else {
@@ -754,7 +727,6 @@ void CDownloadQueue::CheckAndAddSource(CPartFile *sender, CUpDownClient *source)
 				UNAVAILABLE_SOURCE);
 		}
 	} else {
-		// Unknown client, add it to the clients list
 		source->SetRequestFile(sender);
 
 		theApp->clientlist->AddClient(source);
@@ -772,7 +744,6 @@ void CDownloadQueue::CheckAndAddSource(CPartFile *sender, CUpDownClient *source)
 
 void CDownloadQueue::CheckAndAddKnownSource(CPartFile *sender, CUpDownClient *source)
 {
-	// Kad reviewed
 
 	if (sender->IsStopped()) {
 		return;
@@ -783,13 +754,10 @@ void CDownloadQueue::CheckAndAddKnownSource(CPartFile *sender, CUpDownClient *so
 		return;
 	}
 
-	// "Filter LAN IPs" -- this may be needed here in case we are connected to the internet and are also
-	// connected to a LAN and some client from within the LAN connected to us. Though this situation may
-	// be supported in future by adding that client to the source list and filtering that client's LAN IP
-	// when sending sources to a client within the internet.
-	//
-	// "IPfilter" is not needed here, because that "known" client was already IPfiltered when receiving
-	// OP_HELLO.
+	// "Filter LAN IPs" is needed here for the case where we are on the internet
+	// and also on a LAN, and a client from within the LAN connects to us.
+	// "IPfilter" is not, because that known client was already IPfiltered when
+	// receiving OP_HELLO.
 	if (!source->HasLowID()) {
 		uint32 nClientIP = wxUINT32_SWAP_ALWAYS(source->GetUserIDHybrid());
 		if (!IsGoodIP(nClientIP,
@@ -846,10 +814,8 @@ bool CDownloadQueue::RemoveSource(CUpDownClient *toremove, bool WXUNUSED(updatew
 	for (uint16 i = 0; i < GetFileCount(); i++) {
 		CPartFile *cur_file = GetFileByIndex(i);
 
-		// Remove from source-list
 		if (cur_file->DelSource(toremove)) {
 
-			// Remove from sourcelist widget
 			Notify_SourceCtrlRemoveSource(toremove->ECID(), cur_file);
 
 			cur_file->RemoveDownloadingSource(toremove);
@@ -859,7 +825,6 @@ bool CDownloadQueue::RemoveSource(CUpDownClient *toremove, bool WXUNUSED(updatew
 			}
 		}
 
-		// Remove from A4AF-list
 		cur_file->RemoveA4AFSource(toremove);
 	}
 
@@ -893,18 +858,17 @@ void CDownloadQueue::RemoveFile(CPartFile *file, bool keepAsCompleted)
 
 void CDownloadQueue::ClearCompleted(const ListOfUInts32 &ecids)
 {
-	// This used to walk and erase m_completedDownloads with m_mutex unheld,
-	// unlike every other mutator, while CopyFileList reads that same list
-	// under the lock. It mattered less when the EC file-list reconcile ran
-	// unconditionally: a reconcile that raced an erase healed on the next
-	// poll a second later. It matters now that the reconcile is skipped while
-	// the list generation is unchanged -- an erase observed as "already seen"
-	// is never reconciled at all, and the entry stays in the client's list
-	// for the life of the connection.
+	// This used to walk and erase m_completedDownloads with m_mutex unheld, unlike
+	// every other mutator, while CopyFileList reads that same list under the lock.
+	// It mattered less when the EC file-list reconcile ran unconditionally: a
+	// reconcile that raced an erase healed on the next poll. It matters now that
+	// the reconcile is skipped while the list generation is unchanged -- an erase
+	// observed as "already seen" is never reconciled, and the entry stays in the
+	// client's list for the life of the connection.
 	//
-	// Holding the lock across Notify_DownloadCtrlRemoveFile is safe here:
-	// m_mutex is constructed wxMUTEX_RECURSIVE, so a notify handler that
-	// re-enters the queue re-acquires it rather than deadlocking.
+	// Holding the lock across Notify_DownloadCtrlRemoveFile is safe: m_mutex is
+	// wxMUTEX_RECURSIVE, so a notify handler that re-enters the queue re-acquires
+	// it rather than deadlocking.
 	wxMutexLocker lock(m_mutex);
 	for (ListOfUInts32::const_iterator it1 = ecids.begin(); it1 != ecids.end(); ++it1) {
 		uint32 ecid = *it1;
@@ -961,7 +925,6 @@ bool CDownloadQueue::SendNextUDPPacket()
 		return false;
 	}
 
-	// Start monitoring the server and the files list
 	if (!m_queueServers.IsActive()) {
 		AddObserver(&m_queueFiles);
 
@@ -970,7 +933,6 @@ bool CDownloadQueue::SendNextUDPPacket()
 
 	bool packetSent = false;
 	while (!packetSent) {
-		// Get max files ids per packet for current server
 		int filesAllowed = GetMaxFilesPerUDPServerPacket();
 
 		if (filesAllowed < 1 || !m_udpserver || IsConnectedServer(m_udpserver)) {
@@ -1028,17 +990,13 @@ bool CDownloadQueue::SendNextUDPPacket()
 			}
 		}
 
-		// See if we have anything to send
 		if (hashlist.GetLength()) {
 			packetSent = SendGlobGetSourcesUDPPacket(hashlist);
 		}
 
-		// Check if we've covered every file
 		if (file == NULL) {
-			// Reset the list of asked files so that the loop will start over
 			m_queueFiles.Reset();
 
-			// Unset the server so that the next server will be used
 			m_udpserver = NULL;
 		}
 	}
@@ -1067,10 +1025,8 @@ void CDownloadQueue::DoStopUDPRequests()
 static bool ComparePartFiles(const CPartFile *file1, const CPartFile *file2)
 {
 	if (file1->GetDownPriority() != file2->GetDownPriority()) {
-		// To place high-priority files before low priority files we have to
-		// invert this test, since PR_LOW is lower than PR_HIGH, and since
-		// placing a PR_LOW file before a PR_HIGH file would mean that
-		// the PR_LOW file gets sources before the PR_HIGH file ...
+		// Inverted on purpose: PR_LOW is numerically lower than PR_HIGH, and
+		// placing a PR_LOW file first would give it sources before a PR_HIGH one.
 		return (file1->GetDownPriority() > file2->GetDownPriority());
 	} else {
 		int sourcesA = file1->GetSourceCount();
@@ -1176,13 +1132,11 @@ void CDownloadQueue::ProcessLocalRequests()
 					AddDebugLogLineN(logDownloadQueue,
 						CFormat("Creating local sources request packet for '%s'") %
 							cur_file->GetFileName());
-					// create request packet
 					CMemFile data(16 + (cur_file->IsLargeFile() ? 8 : 4));
 					data.WriteHash(cur_file->GetFileHash());
-					// Kry - lugdunum extended protocol on 17.3 to handle filesize
-					// properly. There is no need to check anything, old server ignore the
-					// extra 4 bytes. As of 17.9, servers accept a 0 32-bits size and then
-					// a 64bits size
+					// lugdunum's extended protocol handles filesize from 17.3
+					// on; older servers ignore the extra 4 bytes. From 17.9
+					// servers accept a 0 32-bit size followed by a 64-bit one.
 					if (cur_file->IsLargeFile()) {
 						wxASSERT(bServerSupportsLargeFiles);
 						data.WriteUInt32(0);
@@ -1366,7 +1320,6 @@ void CDownloadQueue::CheckDiskspace(const CPath &path)
 				file->ResumeFile();
 			}
 		} else if (free < min && !file->IsPaused()) {
-			// No space left, stop the files.
 			file->PauseFile(true);
 		}
 	}
@@ -1376,7 +1329,6 @@ int CDownloadQueue::GetMaxFilesPerUDPServerPacket() const
 {
 	if (m_udpserver) {
 		if (m_udpserver->GetUDPFlags() & SRV_UDPFLG_EXT_GETSOURCES) {
-			// get max. file ids per packet
 			if (m_cRequestsSentToServer < MAX_REQUESTS_PER_SERVER) {
 				return std::min(MAX_FILES_PER_UDP_PACKET,
 					MAX_REQUESTS_PER_SERVER - m_cRequestsSentToServer);
@@ -1422,7 +1374,6 @@ void CDownloadQueue::AddToResolve(const CMD4Hash &fileid,
 	Hostname_Entry entry = { fileid, pszHostname, port, hash, cryptoptions };
 	m_toresolve.push_front(entry);
 
-	// Check if there are other DNS lookups on queue
 	if (m_toresolve.size() == 1) {
 		// Check if it is a simple dot address
 		uint32 ip = StringIPtoUint32(pszHostname);
@@ -1570,7 +1521,6 @@ bool CDownloadQueue::AddED2KLink(const CED2KFileLink *link, uint8 category)
 {
 	CPartFile *file = NULL;
 	if (IsFileExisting(link->GetHashKey(), link->GetName())) {
-		// Must be a shared file if we are to add hashes or sources
 		if ((file = GetFileByID(link->GetHashKey())) == NULL) {
 			return false;
 		}
@@ -1712,9 +1662,7 @@ void CDownloadQueue::KademliaSearchFile(uint32_t searchID,
 		}
 		ctemp = new CUpDownClient(tcp, ip, 0, 0, temp, false, true);
 		ctemp->SetSourceFrom(SF_KADEMLIA);
-		// not actually sent or needed for HighID sources
-		// ctemp->SetServerIP(serverip);
-		// ctemp->SetServerPort(serverport);
+		// Server IP and port are not actually sent or needed for HighID sources.
 		ctemp->SetKadPort(udp);
 		uint8_t cID[16];
 		pcontactID->ToByteArray(cID);
@@ -1769,7 +1717,6 @@ void CDownloadQueue::KademliaSearchFile(uint32_t searchID,
 	}
 
 	if (ctemp) {
-		// add encryption settings
 		ctemp->SetConnectOptions(byCryptOptions);
 
 		AddDebugLogLineN(logKadSearch,

--- a/src/ECSpecialCoreTags.cpp
+++ b/src/ECSpecialCoreTags.cpp
@@ -96,18 +96,17 @@ CEC_Server_Tag::CEC_Server_Tag(const CServer *server, EC_DETAIL_LEVEL detail_lev
 			AddTag(CECTag(EC_TAG_SERVER_FILES, tmpInt));
 		}
 		// Per-user publishing limits (issue #840). Sent from both server-tag
-		// builders: this detail-level one carries the initial list, the valuemap
-		// one below carries updates, and a tag added to only one of them leaves
-		// the remote GUI's column permanently blank.
+		// builders -- this one carries the initial list, the valuemap one below
+		// carries updates -- since a tag in only one leaves the remote GUI's column
+		// permanently blank.
 		if ((tmpInt = server->GetSoftFiles()) != 0) {
 			AddTag(CECTag(EC_TAG_SERVER_FILES_SOFT, tmpInt));
 		}
 		if ((tmpInt = server->GetHardFiles()) != 0) {
 			AddTag(CECTag(EC_TAG_SERVER_FILES_HARD, tmpInt));
 		}
-		// Wire capability flags. Diagnostics, and hidden by default in release
-		// builds, but the remote GUI offers the same columns as the monolithic
-		// app so it needs the same data behind them.
+		// Wire capability flags: diagnostics, hidden by default in release builds,
+		// but the remote GUI offers the same columns as the monolithic app.
 		if ((tmpInt = server->GetTCPFlags()) != 0) {
 			AddTag(CECTag(EC_TAG_SERVER_TCP_FLAGS, tmpInt));
 		}
@@ -182,12 +181,9 @@ CEC_ConnState_Tag::CEC_ConnState_Tag(EC_DETAIL_LEVEL detail_level)
 			}
 		}
 		AddTag(CECTag(EC_TAG_ED2K_ID, theApp->GetED2KID()));
-		// GetTicks() (a possibly-64-bit time_t) truncated to uint32 --
-		// fine until 2106, matching EC_TAG_ED2K_ID's own uint32 id
-		// space this tag already sits next to. Only sent while actually
-		// connected, so amulegui/amuleapi never have to distinguish
-		// "never connected" from "connected at the unix epoch"
-		// (amule-org/amule#174).
+		// GetTicks() truncated to uint32 -- fine until 2106, and matching the uint32
+		// id space of EC_TAG_ED2K_ID next to it. Sent only while connected, so no
+		// consumer has to tell "never connected" from "connected at the epoch".
 		if (theApp->GetED2KConnectedSince().IsValid()) {
 			AddTag(CECTag(EC_TAG_ED2K_CONNECTED_SINCE,
 				(uint32)theApp->GetED2KConnectedSince().GetTicks()));
@@ -266,26 +262,21 @@ namespace
 // NOT gated on GetMetaDataVer(): that predicate answers "has this file been
 // probed", and using it to mean "all six fields are present" sends
 // MEDIA_LENGTH=0 and MEDIA_BITRATE=0 for a file that probed to a codec and no
-// duration -- a raw elementary stream, a truncated capture. Downstream that
-// renders as Length 0:00 / Bitrate 0 kbps and reports has_media alongside
-// length_s: 0, where the honest answer is N/A. A displayed zero is a claim;
-// absence is not.
+// duration -- a raw elementary stream, a truncated capture -- which renders as
+// Length 0:00 / Bitrate 0 kbps where the honest answer is N/A. A displayed zero
+// is a claim; absence is not.
 //
-// Shared by the shared-file and search-result tag builders, which had
-// diverged: the search one already emitted per field, the shared one gated
-// all six on the aggregate.
+// Shared by the shared-file and search-result tag builders, which had diverged.
 void AddMediaTagsPresent(CECTag &target, const CAbstractFile *file, CValueMap *valuemap)
 {
-	// Present -> send the value. Absent, but we sent one before -> send an
-	// explicit zero / empty so the remote drops it. Absent and never sent ->
-	// send nothing, so a field that never had a value is reported as absent
-	// rather than as a zero.
+	// Present -> send the value. Absent but sent before -> send an explicit zero /
+	// empty so the remote drops it. Absent and never sent -> send nothing, so a
+	// field that never had a value is reported as absent rather than as a zero.
 	//
-	// The middle case is not optional. A tag that is simply not offered reads
-	// as UNCHANGED to a CValueMap peer, and both receivers are add-only, so
-	// omitting a CLEARED field would leave amulegui and the web UI serving the
-	// stale value -- including an unverified one inherited from a search
-	// result, which is exactly what the completion re-probe exists to correct.
+	// The middle case is not optional: a tag that is not offered reads as UNCHANGED
+	// to a CValueMap peer, and both receivers are add-only, so omitting a CLEARED
+	// field leaves the stale value in place -- including one inherited from a
+	// search result, which is what the completion re-probe exists to correct.
 	const auto emitInt = [&](ec_tagname_t ecId, uint32 value) {
 		if (value) {
 			target.AddTag(CECTag(ecId, value), valuemap);
@@ -342,9 +333,8 @@ CEC_SharedFile_Tag::CEC_SharedFile_Tag(
 	}
 	AddTag(EC_TAG_KNOWNFILE_ON_QUEUE, file->GetQueuedCount(), valuemap);
 
-	// Live upload activity (issue #466). Emitted before the UPDATE
-	// early-return so they refresh every tick like the download-side
-	// speed/source counts. The speed + uploading count are computed from
+	// Live upload activity (issue #466), emitted before the UPDATE early-return so
+	// they refresh every tick like the download-side counts. Computed from
 	// m_ClientUploadList (core-only); amulegui receives them over EC.
 #ifndef CLIENT_GUI
 	AddTag(EC_TAG_KNOWNFILE_UPLOAD_SPEED, file->GetUploadDatarate(), valuemap);
@@ -352,13 +342,11 @@ CEC_SharedFile_Tag::CEC_SharedFile_Tag(
 #endif
 	AddTag(EC_TAG_KNOWNFILE_LAST_UPLOAD, (uint32)file->GetLastUpload(), valuemap);
 
-	// Community ratings/comments + the on-demand Kad-notes running flag, shared
-	// by downloads AND shared files via the virtual GetRatingAndComments (a
-	// partfile prepends its connected-source comments; a plain shared file
-	// carries just its Kad notes). Emitted before the UPDATE early-return so the
-	// flag's start -> finish and notes streaming in are visible on every poll;
-	// the valuemap suppresses unchanged values, so idle files cost nothing after
-	// the first send.
+	// Community ratings/comments plus the on-demand Kad-notes running flag, shared
+	// by downloads and shared files via the virtual GetRatingAndComments. Emitted
+	// before the UPDATE early-return so the flag's start -> finish and notes
+	// streaming in are visible on every poll; the valuemap suppresses unchanged
+	// values, so idle files cost nothing after the first send.
 	CECEmptyTag sc(EC_TAG_PARTFILE_COMMENTS);
 	FileRatingList list;
 	file->GetRatingAndComments(list);
@@ -384,11 +372,10 @@ CEC_SharedFile_Tag::CEC_SharedFile_Tag(
 		file->IsPartFile() ? static_cast<const CPartFile *>(file)->GetCachedPartMetBasename()
 				   : file->GetFilePath().GetPrintable(),
 		valuemap);
-	// The on-disk directory, always — the Temp dir for a partfile, the
-	// destination dir once completed. Unlike _FILENAME (which doubles as
-	// the ".part" basename for partfiles), this never changes meaning
-	// across the completed transition, so the REST API can expose an
-	// unambiguous `path` on /downloads and /shared (issue #417).
+	// The on-disk directory, always -- the Temp dir for a partfile, the destination
+	// dir once completed. Unlike _FILENAME, which doubles as the ".part" basename,
+	// this never changes meaning across the completed transition, so the REST API
+	// can expose an unambiguous `path` (issue #417).
 	AddTag(EC_TAG_KNOWNFILE_PATH, file->GetFilePath().GetPrintable(), valuemap);
 
 	// When the file was completed / first shared (issue #466). Static once
@@ -397,10 +384,9 @@ CEC_SharedFile_Tag::CEC_SharedFile_Tag(
 
 	AddTag(EC_TAG_PARTFILE_SIZE_FULL, file->GetFileSize(), valuemap);
 
-	// Cached path: ed2k:// link construction is the single hottest item on
-	// the EC dispatch chain for big shared-file libraries (#713 profile).
-	// The cache holds the rare-changing base form; the dynamic source
-	// suffix is appended live.
+	// Cached: ed2k:// link construction is the single hottest item on the EC
+	// dispatch chain for big shared-file libraries (#713). The cache holds the
+	// rare-changing base form; the dynamic source suffix is appended live.
 	AddTag(EC_TAG_PARTFILE_ED2K_LINK,
 		file->GetED2kLinkForEC(theApp->IsConnectedED2K() && !theApp->serverconnect->IsLowID()),
 		valuemap);
@@ -408,10 +394,9 @@ CEC_SharedFile_Tag::CEC_SharedFile_Tag(
 	AddTag(EC_TAG_KNOWNFILE_COMMENT, file->GetFileComment(), valuemap);
 	AddTag(EC_TAG_KNOWNFILE_RATING, file->GetFileRating(), valuemap);
 
-	// Audio/video media metadata (issue #418). Emitted per FIELD -- see
-	// AddMediaTagsPresent for why the aggregate GetMetaDataVer() gate it used
-	// to sit behind was wrong. Emitted by this shared base ctor, so both
-	// /shared and /downloads (partfiles) carry it with no per-role code.
+	// Audio/video media metadata (issue #418), emitted per FIELD -- see
+	// AddMediaTagsPresent for why the aggregate GetMetaDataVer() gate was wrong.
+	// From this shared base ctor, so /shared and /downloads both carry it.
 	AddMediaTagsPresent(*this, file, valuemap);
 }
 
@@ -429,15 +414,15 @@ CEC_UpDownClient_Tag::CEC_UpDownClient_Tag(
 	AddDiffTag(this, EC_TAG_CLIENT_USER_IP, client->GetIP(), valuemap);
 	AddDiffTag(this, EC_TAG_CLIENT_USER_PORT, client->GetUserPort(), valuemap);
 #ifdef ENABLE_IP2COUNTRY
-	// Peer country ISO code resolved core-side (#439). Emitted whenever GeoIP
-	// is enabled + supported — even empty for an IP that doesn't resolve — so
-	// a frontend can treat tag-present as authoritative (possibly "unknown")
-	// and tag-absent as "no daemon GeoIP".
+	// Peer country ISO code resolved core-side (#439). Emitted whenever GeoIP is
+	// enabled and supported, even empty for an IP that does not resolve, so a
+	// frontend can read tag-present as authoritative and tag-absent as "no daemon
+	// GeoIP".
 	if (theApp->GetIP2Country() && theApp->GetIP2Country()->IsEnabled()) {
-		// Numeric-IP overload: memoised, and it skips formatting the IP into
-		// a string on the hit path. This runs for every peer on every EC
-		// poll, and a peer's country cannot change while its IP does not.
-		// It returns a const reference, which AddDiffTag takes without a copy.
+		// Numeric-IP overload: memoised, and it skips formatting the IP into a
+		// string on the hit path. This runs for every peer on every EC poll, and a
+		// peer's country cannot change while its IP does not. Returns a const
+		// reference, which AddDiffTag takes without a copy.
 		AddDiffTag(this,
 			EC_TAG_CLIENT_COUNTRY,
 			theApp->GetIP2Country()->GetCountryCode(client->GetFullIPNumeric()),
@@ -462,18 +447,13 @@ CEC_UpDownClient_Tag::CEC_UpDownClient_Tag(
 	AddDiffTag(this, EC_TAG_CLIENT_UPLOAD_STATE, client->GetUploadState(), valuemap);
 	AddDiffTag(this, EC_TAG_CLIENT_DOWNLOAD_STATE, client->GetDownloadState(), valuemap);
 	AddDiffTag(this, EC_TAG_CLIENT_IDENT_STATE, (uint64)client->GetCurrentIdentState(), valuemap);
-	// Whether a socket to this peer is actually up, as opposed to a client
-	// object merely existing for it. A consumer that inferred "online" from
-	// the ECID alone called a peer online from the moment we started TRYING to
-	// reach it -- including one we can never reach.
+	// Whether a socket to this peer is actually up, as opposed to a client object
+	// merely existing for it. A consumer inferring "online" from the ECID alone
+	// called a peer online from the moment we started TRYING to reach it.
 	AddDiffTag(this, EC_TAG_CLIENT_CONNECTED, client->IsConnected(), valuemap);
 	AddDiffTag(this, EC_TAG_CLIENT_EXT_PROTOCOL, client->ExtProtocolAvailable(), valuemap);
-	// These are not needed atm. Keep them for now, maybe columns get reintroduced in client view.
-	// AddTag(CECTag(EC_TAG_CLIENT_WAIT_TIME, client->GetWaitTime()), valuemap);
-	// AddTag(CECTag(EC_TAG_CLIENT_XFER_TIME, client->GetUpStartTimeDelay()), valuemap);
-	// AddTag(CECTag(EC_TAG_CLIENT_QUEUE_TIME, (uint64)(::GetTickCount() - client->GetWaitStartTime())),
-	// valuemap); AddTag(CECTag(EC_TAG_CLIENT_LAST_TIME, (uint64)(::GetTickCount() -
-	// client->GetLastUpRequest())), valuemap);
+	// Not needed at the moment; kept in case the columns return to the client view.
+	// EC_TAG_CLIENT_WAIT_TIME, _XFER_TIME, _QUEUE_TIME and _LAST_TIME.
 	AddDiffTag(this, EC_TAG_CLIENT_WAITING_POSITION, client->GetUploadQueueWaitingPosition(), valuemap);
 	AddDiffTag(this,
 		EC_TAG_CLIENT_REMOTE_QUEUE_RANK,
@@ -549,10 +529,10 @@ CEC_SearchFile_Tag::CEC_SearchFile_Tag(
 	const CSearchFile *file, EC_DETAIL_LEVEL detail_level, CValueMap *valuemap, uint32 searchID)
 : CECTag(EC_TAG_SEARCHFILE, file->ECID())
 {
-	// Multi-search union poll (amulegui): the owning search's ID so the client
-	// routes this result to the right tab. Emitted unconditionally (no
-	// valuemap, before the UPDATE early-return) so a result object (re)created
-	// on any poll can always be attributed. 0 => omitted (legacy / non-union).
+	// Multi-search union poll (amulegui): the owning search's ID, so the client
+	// routes this result to the right tab. Emitted unconditionally (no valuemap,
+	// before the UPDATE early-return) so a result object recreated on any poll can
+	// always be attributed. 0 means omitted.
 	if (searchID) {
 		AddTag(CECTag(EC_TAG_SEARCH_ID, searchID));
 	}
@@ -561,49 +541,39 @@ CEC_SearchFile_Tag::CEC_SearchFile_Tag(
 	AddTag(CECTag(EC_TAG_PARTFILE_STATUS, (uint32)file->GetDownloadStatus()), valuemap);
 
 	// On-demand Kad community ratings/comments for this result, reusing the
-	// partfile tags (CSearchFile borrows EC_TAG_PARTFILE_* above). Emitted before
-	// the UPDATE early-return so the flag's start -> finish and the notes
-	// streaming in are visible on every poll.
+	// partfile tags. Emitted before the UPDATE early-return so the flag's start ->
+	// finish and the notes streaming in are visible on every poll.
 	//
-	// Deliberately WITHOUT the valuemap: unlike a download, a search result has
-	// no EC change-generation and its reply builder
-	// (Get_EC_Response_Search_Results) never resets the per-connection valuemap
-	// when amulegui (re)creates the result object. Diffing here would send the
-	// comments container exactly once per ECID for the connection's lifetime, so
-	// a result object created before the notes arrived — the common case, since
-	// the user opens the dialog on an existing result — would be deduped out and
-	// the comments dialog would stay empty. Sending them raw keeps delivery
-	// reliable; the block is gated on the built list so idle results cost nothing
-	// and an empty container never clears the remote list.
+	// Deliberately WITHOUT the valuemap: unlike a download, a search result has no
+	// EC change-generation, and Get_EC_Response_Search_Results never resets the
+	// per-connection valuemap when amulegui recreates the result object. Diffing
+	// would send the comments container once per ECID for the connection's
+	// lifetime, so a result created before the notes arrived -- the common case --
+	// would be deduped out and the dialog would stay empty. The block is gated on
+	// the built list, so idle results cost nothing.
 	FileRatingList list;
 	file->GetRatingAndComments(list);
-	// Always emitted, and through the valuemap -- the same shape the download
-	// side has always used for this tag (CEC_PartFile_Tag above).
+	// Always emitted, and through the valuemap -- the same shape the download side
+	// uses for this tag.
 	//
-	// It used to be emitted only while the lookup was running or had notes to
-	// show, so "finished, found nothing" was signalled by the tag going away.
-	// That cannot survive the incremental union: a result whose only change is
-	// a tag no longer being built produces a tag with no children, which
-	// Get_EC_Response_Search_Results_Union drops as unchanged. The transition
-	// was therefore invisible to every incremental client -- amulegui latched
-	// the flag on, and so did amuleapi -- and only a full re-read cleared it.
-	//
-	// Through the valuemap the 1 -> 0 transition is itself a child tag, so the
-	// result is not elided and every client sees the lookup end. A steady
-	// state still costs nothing: unchanged, it is diffed away as before.
+	// It used to be emitted only while the lookup was running or had notes, so
+	// "finished, found nothing" was signalled by the tag going away. That cannot
+	// survive the incremental union: a result whose only change is a tag no longer
+	// being built produces a childless tag, which the union drops as unchanged, so
+	// the transition was invisible to every incremental client. Through the
+	// valuemap the 1 -> 0 transition is itself a child tag, and a steady state
+	// still costs nothing.
 	AddTag(EC_TAG_PARTFILE_KAD_COMMENT_SEARCHING,
 		(uint64)(file->IsKadCommentSearchRunning() ? 1 : 0),
 		valuemap);
 	// The container itself stays gated on there being notes, and stays off the
-	// valuemap: an empty one must never be sent, because a client reads its
-	// absence as "no notes" rather than as "unchanged".
+	// valuemap: an empty one must never be sent, because a client reads its absence
+	// as "no notes" rather than as "unchanged".
 	//
-	// One consequence worth naming, since it looks like a bug from the other
-	// end: a result that HAS notes is never elided by the multi-search union.
-	// The union skips a result whose tag came out childless, and this
-	// container is a child that off-valuemap means it is re-emitted on every
-	// poll, unchanged or not. That is the correct trade -- the alternative
-	// silently drops notes -- and it is bounded by how few results carry any.
+	// One consequence, since it looks like a bug from the other end: a result that
+	// HAS notes is never elided by the multi-search union, because off-valuemap
+	// this child is re-emitted on every poll. That is the correct trade -- the
+	// alternative silently drops notes -- and few results carry any.
 	if (!list.empty()) {
 		CECEmptyTag sc(EC_TAG_PARTFILE_COMMENTS);
 		for (FileRatingList::const_iterator it = list.begin(); it != list.end(); ++it) {
@@ -628,8 +598,7 @@ CEC_SearchFile_Tag::CEC_SearchFile_Tag(
 	}
 	// Browse ("View Files") source info: the peer this listing came from and the
 	// shared folder the file lives in. Set only on results filed from a peer's
-	// shared-file list (CSearchList::ProcessSharedFileList), so ordinary
-	// server/Kad hits — which never set these — emit nothing here.
+	// shared-file list, so ordinary server/Kad hits emit nothing here.
 	if (file->GetClientID()) {
 		AddTag(CECTag(EC_TAG_SEARCHFILE_CLIENT_ID, file->GetClientID()), valuemap);
 		AddTag(CECTag(EC_TAG_SEARCHFILE_CLIENT_PORT, file->GetClientPort()), valuemap);
@@ -640,10 +609,9 @@ CEC_SearchFile_Tag::CEC_SearchFile_Tag(
 	if (file->HasRating()) {
 		AddTag(CECTag(EC_TAG_KNOWNFILE_RATING, (uint8)file->UserRating()), valuemap);
 	}
-	// Media metadata (issue #430). A hit carries FT_MEDIA_* tags only when
-	// the file is known/probed locally; emit each EC_TAG_KNOWNFILE_MEDIA_*
-	// (defined by issue #418) only when its value is present, so results
-	// without media cost nothing.
+	// Media metadata (issue #430). A hit carries FT_MEDIA_* tags only when the file
+	// is known or probed locally, so each EC_TAG_KNOWNFILE_MEDIA_* is emitted only
+	// when its value is present and results without media cost nothing.
 	AddMediaTagsPresent(*this, file, valuemap);
 }
 
@@ -659,17 +627,15 @@ CEC_Friend_Tag::CEC_Friend_Tag(const CFriend *Friend, CValueMap *valuemap)
 	AddTag(EC_TAG_FRIEND_PORT, Friend->GetPort(), valuemap);
 	const CClientRef &linkedClient = Friend->GetLinkedClient();
 	AddTag(EC_TAG_FRIEND_CLIENT, linkedClient.IsLinked() ? linkedClient.ECID() : 0, valuemap);
-	// Echoed from the linked client so a consumer does not have to join
-	// against the client list -- and could not join reliably anyway, since a
-	// friend's client need not be in the list the consumer holds. Linked but
-	// not connected is the ordinary case for an offline friend.
+	// Echoed from the linked client so a consumer does not have to join against the
+	// client list -- and could not join reliably anyway, since a friend's client
+	// need not be in the list the consumer holds.
 	AddTag(EC_TAG_CLIENT_CONNECTED,
 		linkedClient.IsLinked() && linkedClient.GetClient()->IsConnected(),
 		valuemap);
-	// The slot is settable over EC (EC_TAG_FRIEND_FRIENDSLOT on the request
-	// side) but was never reported back, so every EC client read it as false
-	// -- amulegui's "Establish Friend Slot" check mark could not follow the
-	// state it had just set. Same tag id in both directions.
+	// The slot is settable over EC but was never reported back, so every EC client
+	// read it as false and amulegui's "Establish Friend Slot" check mark could not
+	// follow the state it had just set. Same tag id in both directions.
 	AddTag(EC_TAG_FRIEND_FRIENDSLOT, Friend->HasFriendSlot(), valuemap);
 }
 

--- a/src/ECSpecialMuleTags.cpp
+++ b/src/ECSpecialMuleTags.cpp
@@ -64,15 +64,12 @@ CEC_Category_Tag::CEC_Category_Tag(
 
 bool CEC_Category_Tag::Apply()
 {
-	// The index arrives from an EC client and the protocol does not constrain
-	// it: the tag admits any uint8 while only GetCatCount() categories exist.
-	// Refusing here rather than only inside UpdateCategory, because BOTH calls
-	// below index with this value -- the failure branch reads GetCatPath(),
-	// which is guarded by a wxASSERT that aborts a debug build and vanishes in
-	// a release one. Left unchecked, UpdateCategory indexed m_CatList (a
-	// std::vector) out of range and dereferenced the result comparing paths,
-	// which took the daemon down with SIGABRT and every transfer with it
-	// (amule-org/amule#1227).
+	// The index arrives from an EC client and the protocol does not constrain it:
+	// the tag admits any uint8 while only GetCatCount() categories exist. Refused
+	// here rather than only inside UpdateCategory, because BOTH calls below index
+	// with it -- the failure branch reads GetCatPath(), guarded by a wxASSERT that
+	// vanishes in a release build. Unchecked, UpdateCategory indexed m_CatList out
+	// of range and took the daemon down with SIGABRT (#1227).
 	if (GetInt() >= theApp->glob_prefs->GetCatCount()) {
 		// The EC_OP_UPDATE_CATEGORY handler turns false into EC_OP_FAILED
 		// carrying the category and the client's own path, which is the
@@ -122,13 +119,11 @@ CEC_Prefs_Packet::CEC_Prefs_Packet(
 		user_prefs.AddTag(CECTag(EC_TAG_USER_HASH, thePrefs::GetUserHash()));
 		user_prefs.AddTag(CECTag(EC_TAG_USER_HOST, thePrefs::GetYourHostname()));
 		user_prefs.AddTag(CECTag(EC_TAG_GENERAL_CHECK_NEW_VERSION, thePrefs::GetCheckNewVersion()));
-		// Capability signal: whether this build can actually perform version
-		// checks (ENABLE_VERSION_CHECK). Emitted as a bool by every 3.1+
-		// daemon — true when compiled in, false when compiled out — so a
-		// client can tell "compiled out" (false) apart from an old daemon
-		// that predates the tag (absent). Distinct from the CHECK_NEW_VERSION
-		// *preference* above; a client treats update checking as active only
-		// when (available AND pref).
+		// Capability signal: whether this build can perform version checks. Emitted
+		// as a bool by every 3.1+ daemon, so a client can tell "compiled out"
+		// (false) from an old daemon predating the tag (absent). Distinct from the
+		// CHECK_NEW_VERSION PREFERENCE above: update checking is active only when
+		// available AND the pref is set.
 #ifdef ENABLE_VERSION_CHECK
 		const bool versionCheckAvailable = true;
 #else
@@ -175,10 +170,10 @@ CEC_Prefs_Packet::CEC_Prefs_Packet(
 		}
 		connPrefs.AddTag(CECTag(EC_TAG_CONN_BIND_ADDRESS, thePrefs::GetAddress()));
 		connPrefs.AddTag(CECTag(EC_TAG_CONN_BIND_INTERFACE, thePrefs::GetNetworkInterface()));
-		// Proxy: the daemon routes P2P + its HTTP fetches through this; the
-		// remote GUI must be able to read + set it. The password rides plainly
-		// (it is a plaintext auth credential, not a hash) so amulegui can show
-		// it -- the amuleapi surface keeps it write-only.
+		// Proxy: the daemon routes P2P and its HTTP fetches through this, and the
+		// remote GUI must be able to read and set it. The password rides plainly (it
+		// is a plaintext credential, not a hash) so amulegui can show it; the
+		// amuleapi surface keeps it write-only.
 		const CProxyData *proxy = thePrefs::GetProxyData();
 		connPrefs.AddTag(CECTag(EC_TAG_PROXY_ENABLE, proxy->m_proxyEnable));
 		connPrefs.AddTag(CECTag(EC_TAG_PROXY_TYPE, static_cast<uint32>(proxy->m_proxyType)));
@@ -187,11 +182,9 @@ CEC_Prefs_Packet::CEC_Prefs_Packet(
 		connPrefs.AddTag(CECTag(EC_TAG_PROXY_AUTH, proxy->m_enablePassword));
 		connPrefs.AddTag(CECTag(EC_TAG_PROXY_USER, proxy->m_userName));
 		connPrefs.AddTag(CECTag(EC_TAG_PROXY_PASSWORD, proxy->m_password));
-		// UPnP: the enable toggle forwards the P2P ports (which are the
-		// tcp_port/udp_port tags above); UPnPTCPPort is the control point's own
-		// local port (libupnp), not a forwarded port. Web-server and EC-port
-		// UPnP are intentionally not carried (amuleweb is deprecated; the EC
-		// port is not a P2P port).
+		// UPnP: the enable toggle forwards the P2P ports above, while UPnPTCPPort is
+		// the control point's own local port, not a forwarded one. Web-server and
+		// EC-port UPnP are deliberately not carried.
 		connPrefs.AddTag(CECTag(EC_TAG_CONN_UPNP_ENABLED, thePrefs::GetUPnPEnabled()));
 		connPrefs.AddTag(CECTag(EC_TAG_CONN_UPNP_TCP_PORT, thePrefs::GetUPnPTCPPort()));
 		AddTag(connPrefs);
@@ -258,10 +251,9 @@ CEC_Prefs_Packet::CEC_Prefs_Packet(
 		rc_prefs.AddTag(CECTag(EC_TAG_AMULEAPI_BIND, thePrefs::GetAmuleApiBindAddress()));
 
 		// amuleapi's credentials are stored salted and stretched in
-		// amuleapi-passwords, so unlike the webserver's there is no digest
-		// to put on the wire — the daemon could not produce one if it
-		// wanted to. Both tags therefore carry a *request* when a client
-		// sends them and a *state* when the daemon does:
+		// amuleapi-passwords, so unlike the webserver's there is no digest to put on
+		// the wire. Both tags therefore carry a REQUEST from a client and a STATE
+		// from the daemon:
 		//
 		//   admin absent          leave the stored password alone
 		//   admin present, empty  a password is set (daemon -> client)
@@ -271,10 +263,9 @@ CEC_Prefs_Packet::CEC_Prefs_Packet(
 		//   guest present, empty  guest access on, password unchanged
 		//   guest present + hash  guest access on with this password
 		//
-		// Guest is the same container-plus-optional-child shape as
-		// EC_TAG_WEBSERVER_GUEST above, and for the same reason: absence
-		// has to be able to mean "off". Admin has no off state on purpose
-		// — clearing it from a stray prefs push would leave a non-loopback
+		// Guest has the same container-plus-optional-child shape as
+		// EC_TAG_WEBSERVER_GUEST, so absence can mean "off". Admin has no off state
+		// on purpose: clearing it from a stray prefs push would leave a non-loopback
 		// deployment with no way back in.
 		if (!thePrefs::GetAmuleApiPass().IsEmpty()) {
 			CECEmptyTag adminTag(EC_TAG_AMULEAPI_PASSWD);
@@ -379,10 +370,10 @@ CEC_Prefs_Packet::CEC_Prefs_Packet(
 		if (thePrefs::GetAllocFullFile()) {
 			filePrefs.AddTag(CECEmptyTag(EC_TAG_FILES_ALLOC_FULL_SIZE));
 		}
-		// mmap capability negotiation: advertise support (tag presence) plus
-		// the current value. Gated on the *runtime* capability flag rather than
-		// #ifdef MMAP_SUPPORTED so a remote GUI on a platform without mmap can
-		// still relay the value to a daemon that has it.
+		// mmap capability negotiation: advertise support (tag presence) plus the
+		// current value. Gated on the RUNTIME capability rather than #ifdef
+		// MMAP_SUPPORTED, so a remote GUI on a platform without mmap can still relay
+		// the value to a daemon that has it.
 		if (thePrefs::GetMMapSupported()) {
 			filePrefs.AddTag(CECEmptyTag(EC_TAG_FILES_MMAP_SUPPORTED));
 			if (thePrefs::GetMMapEnabled()) {
@@ -501,11 +492,9 @@ CEC_Prefs_Packet::CEC_Prefs_Packet(
 
 	if (selection & EC_PREFS_IP2COUNTRY) {
 		CECEmptyTag ip2cPrefs(EC_TAG_PREFS_IP2COUNTRY);
-		// SUPPORTED tells a remote GUI whether *this* build has GeoIP compiled
-		// in at all (the daemon may be built without libmaxminddb). amulegui
-		// gates its whole GeoIP config panel on this. The settings below are
-		// plain prefs and always sent so the panel can populate; ignored by a
-		// GeoIP-less daemon on apply.
+		// SUPPORTED tells a remote GUI whether THIS build has GeoIP compiled in at
+		// all; amulegui gates its whole GeoIP config panel on it. The settings below
+		// are plain prefs and always sent so the panel can populate.
 #ifdef GEOIP_GUI
 		ip2cPrefs.AddTag(CECTag(EC_TAG_IP2COUNTRY_SUPPORTED, true));
 #else
@@ -517,16 +506,14 @@ CEC_Prefs_Packet::CEC_Prefs_Packet(
 		ip2cPrefs.AddTag(
 			CECTag(EC_TAG_IP2COUNTRY_MAXMIND_LICENSE, thePrefs::GetGeoIPMaxMindLicense()));
 		ip2cPrefs.AddTag(CECTag(EC_TAG_IP2COUNTRY_AUTO_UPDATE, thePrefs::IsGeoIPAutoUpdate()));
-		// Read-only live status, filled only where a resolver exists (the
-		// daemon / monolithic amule) so a remote GUI can render the status line
-		// and disable buttons while a refresh runs (#440 remote config). NULL
-		// on amulegui, which has no local resolver and only receives these.
+		// Read-only live status, filled only where a resolver exists, so a remote GUI
+		// can render the status line and disable buttons while a refresh runs. NULL
+		// on amulegui, which only receives these.
 #ifndef CLIENT_GUI
-		// Resolver-owning builds (daemon / monolithic) only. amulegui has no
-		// CIP2Country instance (GetIP2Country() is always NULL there) and doesn't
-		// link the resolver, so referencing its out-of-line methods here would
-		// break the amulegui link. The live status flows the other way for
-		// amulegui — it *receives* these tags in Apply().
+		// Resolver-owning builds only: amulegui has no CIP2Country instance and does
+		// not link the resolver, so referencing its out-of-line methods here would
+		// break its link. The live status flows the other way there -- it RECEIVES
+		// these tags in Apply().
 		if (CIP2Country *ip2c = theApp->GetIP2Country()) {
 			ip2cPrefs.AddTag(CECTag(EC_TAG_IP2COUNTRY_DB_PATH, ip2c->GetDatabasePath()));
 			ip2cPrefs.AddTag(CECTag(EC_TAG_IP2COUNTRY_DB_LOADED, ip2c->IsEnabled()));
@@ -536,10 +523,9 @@ CEC_Prefs_Packet::CEC_Prefs_Packet(
 				CECTag(EC_TAG_IP2COUNTRY_LOADED_SOURCE, thePrefs::GetGeoIPLoadedSource()));
 		}
 #endif
-		// Transient "Update now" trigger set by amulegui's prefs panel (which has
-		// no local resolver). Carried on the outgoing prefs packet so the daemon's
-		// Apply() kicks off a manual refresh. Only ever set on amulegui; the
-		// daemon never requests it, so its own outbound prefs never emit the tag.
+		// Transient "Update now" trigger set by amulegui's prefs panel, carried on the
+		// outgoing packet so the daemon's Apply() kicks off a manual refresh. Only
+		// ever set on amulegui, so the daemon's own outbound prefs never emit it.
 		if (thePrefs::IsGeoIPUpdateRequested()) {
 			ip2cPrefs.AddTag(CECTag(EC_TAG_IP2COUNTRY_UPDATE_NOW, true));
 		}
@@ -592,11 +578,10 @@ void CEC_Prefs_Packet::Apply() const
 			thePrefs::SetCheckNewVersion(oneTag->GetInt() != 0);
 		}
 #ifdef CLIENT_GUI
-		// Capability of the connected daemon. 3.1+ daemons always send this
-		// bool (true = can check, false = ENABLE_VERSION_CHECK compiled out).
-		// A pre-3.1 daemon omits it but still supports the NewVersionCheck
-		// preference, so treat "absent" as available (keep the checkbox) —
-		// only an explicit false hides it.
+		// Capability of the connected daemon: 3.1+ daemons always send this bool. A
+		// pre-3.1 daemon omits it but still supports the NewVersionCheck preference,
+		// so absent means available (keep the checkbox) and only an explicit false
+		// hides it.
 		if (const CECTag *vc = thisTab->GetTagByName(EC_TAG_GENERAL_VERSION_CHECK_AVAILABLE)) {
 			thePrefs::SetVersionCheckAvailable(vc->GetInt() != 0);
 		} else {
@@ -728,19 +713,15 @@ void CEC_Prefs_Packet::Apply() const
 		if ((oneTag = thisTab->GetTagByName(EC_TAG_AMULEAPI_BIND)) != nullptr) {
 			thePrefs::SetAmuleApiBindAddress(oneTag->GetStringData());
 		}
-		// See the emit side for the encoding. The pending-password prefs
-		// start empty and are cleared again by AmuleApiCredentials::
-		// ApplyPrefs, so "tag present but carrying no hash" correctly
-		// leaves the stored password untouched.
+		// See the emit side for the encoding. The pending-password prefs start empty
+		// and are cleared again by AmuleApiCredentials::ApplyPrefs, so "tag present
+		// but carrying no hash" correctly leaves the stored password untouched.
 		//
 		// The guest toggle goes through ApplyBoolean for the same reason
-		// EC_TAG_WEBSERVER_GUEST below does: this method serves two
-		// callers with opposite conventions. amulegui sends the whole
-		// group at EC_DETAIL_UPDATE, where an absent tag means "off";
-		// amuleapi's PATCH /preferences sends only the fields the client
-		// named, at EC_DETAIL_FULL, where an absent tag means "leave
-		// alone". Reading absence as "off" unconditionally would let any
-		// unrelated preference change wipe the guest credential.
+		// EC_TAG_WEBSERVER_GUEST does: this method serves two callers with opposite
+		// conventions. amulegui sends the whole group at EC_DETAIL_UPDATE, where an
+		// absent tag means "off"; amuleapi's PATCH /preferences sends only the named
+		// fields at EC_DETAIL_FULL, where absent means "leave alone".
 		thePrefs::SetAmuleApiPass(wxEmptyString);
 		if ((oneTag = thisTab->GetTagByName(EC_TAG_AMULEAPI_PASSWD)) != nullptr) {
 			thePrefs::SetAmuleApiAdminIsSet(true);
@@ -871,9 +852,8 @@ void CEC_Prefs_Packet::Apply() const
 			thePrefs::SetFollowSymlinksInShares,
 			EC_TAG_DIRECTORIES_FOLLOW_SYMLINKS);
 
-		// Shared-file exclusion filter. Compare each incoming tag against the
-		// current value so we only recompile + rescan when the remote GUI
-		// actually changed something.
+		// Shared-file exclusion filter. Each incoming tag is compared against the
+		// current value so a recompile and rescan happen only on a real change.
 		bool excludeChanged = false;
 		if ((oneTag = thisTab->GetTagByName(EC_TAG_DIRECTORIES_EXCLUDE_PATTERNS)) != nullptr) {
 			if (oneTag->GetStringData() != thePrefs::GetExcludeSharePatterns()) {
@@ -897,20 +877,17 @@ void CEC_Prefs_Packet::Apply() const
 		// take effect.
 		if (theApp->sharedfiles) {
 			theApp->sharedfiles->EnableDirectoryWatcher(thePrefs::AutoRescanSharedDirs());
-			// Same for a changed exclusion filter: re-walk so newly excluded
-			// files leave the shareset and un-excluded ones return. Scheduled
-			// rather than inline -- this runs inside the EC request handler.
+			// Same for a changed exclusion filter: re-walk so newly excluded files
+			// leave the shareset and un-excluded ones return. Scheduled rather than
+			// inline, since this runs inside the EC request handler.
 			if (excludeChanged) {
 				theApp->sharedfiles->RequestReload();
 			}
 		}
 	}
 
-	// EC_TAG_PREFS_STATISTICS arrives but is unhandled. The prior
-	// assignment to thisTab was dead-stored (caught on lint as
-	// clang-analyzer-deadcode.DeadStores) since thisTab is overwritten
-	// by the next if block. Keep the existence-check shape so future
-	// work has an obvious home.
+	// EC_TAG_PREFS_STATISTICS arrives but is unhandled. The existence check is kept
+	// so future work has an obvious home.
 	if (GetTagByName(EC_TAG_PREFS_STATISTICS) != NULL) {
 		// #warning TODO
 	}
@@ -979,11 +956,10 @@ void CEC_Prefs_Packet::Apply() const
 	}
 
 	if ((thisTab = GetTagByName(EC_TAG_PREFS_IP2COUNTRY)) != nullptr) {
-		// SUPPORTED is the core's capability flag, flowing daemon → GUI only:
-		// amulegui records it to show/hide its GeoIP page. The daemon must NOT
-		// apply an incoming SUPPORTED (an amulegui SET carries the GUI's own
-		// value, which would clobber the daemon's real capability), so this is
-		// CLIENT_GUI-only.
+		// SUPPORTED is the core's capability flag, flowing daemon -> GUI only:
+		// amulegui records it to show or hide its GeoIP page. The daemon must NOT
+		// apply an incoming SUPPORTED, which would carry the GUI's own value, so this
+		// is CLIENT_GUI-only.
 #ifdef CLIENT_GUI
 		if ((oneTag = thisTab->GetTagByName(EC_TAG_IP2COUNTRY_SUPPORTED)) != nullptr) {
 			thePrefs::SetGeoIPSupported(oneTag->GetInt() != 0);
@@ -1018,24 +994,21 @@ void CEC_Prefs_Packet::Apply() const
 		if ((oneTag = thisTab->GetTagByName(EC_TAG_IP2COUNTRY_AUTO_UPDATE)) != nullptr) {
 			thePrefs::SetGeoIPAutoUpdate(oneTag->GetInt() != 0);
 		}
-		// Apply live: on the daemon this (re)creates / enables / disables the
-		// resolver for the new settings. No-op on amulegui (no local resolver),
-		// which merely absorbs the daemon's settings into its prefs for display.
-		// Remote prefs-apply: do NOT auto-download here. An explicit "Update now"
-		// (UPDATE_NOW below) carries that intent; otherwise every amulegui OK
-		// would fetch, and together with UPDATE_NOW it fires twice.
+		// Apply live: on the daemon this creates, enables or disables the resolver for
+		// the new settings; a no-op on amulegui, which merely absorbs the settings for
+		// display. Do NOT auto-download here -- an explicit "Update now" below carries
+		// that intent, and doing both fires twice.
 		theApp->EnableIP2Country(false);
 #ifndef CLIENT_GUI
-		// Explicit "Update now" trigger from a remote GUI (#440): re-download the
-		// DB from the (just-applied) source. Daemon / monolithic only — amulegui
-		// sends this tag but never receives it, and doesn't link the resolver, so
-		// the CIP2Country::Update reference is guarded out of the amulegui build.
+		// Explicit "Update now" trigger from a remote GUI: re-download the DB from the
+		// just-applied source. Daemon and monolithic only, since amulegui sends this
+		// tag but never receives it and does not link the resolver.
 		if ((oneTag = thisTab->GetTagByName(EC_TAG_IP2COUNTRY_UPDATE_NOW)) != nullptr &&
 			oneTag->GetInt() != 0) {
 			if (theApp->GetIP2Country()) {
-				// Remote trigger: no progress dialog (showProgress=false) — the
-				// requesting amulegui can't render EC download progress, and on a
-				// monolithic-app-as-backend the dialog would pop on the core.
+				// Remote trigger: no progress dialog -- the requesting amulegui cannot
+				// render EC download progress, and on a monolithic-app-as-backend the
+				// dialog would pop on the core.
 				theApp->GetIP2Country()->Update(true, false);
 			}
 		}

--- a/src/EMSocket.cpp
+++ b/src/EMSocket.cpp
@@ -175,7 +175,6 @@ void CEMSocket::OnReceive(int nErrorCode)
 		}
 	}
 
-	// Check current connection state
 	if (byConnected == ES_DISCONNECTED) {
 		return;
 	} else {
@@ -206,16 +205,12 @@ void CEMSocket::OnReceive(int nErrorCode)
 			readMax = CPacket::GetPacketSizeFromHeader(pendingHeader) - pendingPacketSize;
 		}
 
-		// Reserve from the global download budget only when we actually
-		// intend to read something. readMax can legitimately be 0 here
-		// for empty-payload packets (some ED2K control packets carry no
-		// payload past the header) -- the do-while iteration still has
-		// to fall through to the packet-processing block below to
-		// finalise the packet, so don't let Reserve(0) -> 0 -> early
-		// return short-circuit that path. Sockets that opt out of the
-		// download throttler via IsDownloadThrottled() (server control
-		// sockets) skip the reservation entirely and read whatever's
-		// available; their traffic doesn't count against the cap.
+		// Reserve from the global download budget only when we actually intend to
+		// read something. readMax can legitimately be 0 here for empty-payload
+		// packets, and the do-while iteration still has to fall through to the
+		// packet-processing block below, so Reserve(0) must not short-circuit that
+		// path. Sockets that opt out via IsDownloadThrottled() (server control
+		// sockets) skip the reservation and do not count against the cap.
 		const bool throttled = IsDownloadThrottled();
 		uint32 grantedBytes = 0;
 		ret = 0;
@@ -223,11 +218,10 @@ void CEMSocket::OnReceive(int nErrorCode)
 			if (throttled) {
 				grantedBytes = CDownloadBandwidthThrottler::Get().Reserve(readMax);
 				if (grantedBytes == 0) {
-					// Bucket exhausted; resume on next tick refill.
-					// Register for that wake-up rather than relying on
-					// something else to tick this socket: a socket we
-					// are only browsing belongs to no download, so
-					// nothing else would.
+					// Bucket exhausted; resume on the next tick refill. Register
+					// for that wake-up rather than relying on something else to
+					// tick this socket: a socket we are only browsing belongs to
+					// no download, so nothing else would.
 					pendingOnReceive = true;
 					CDownloadBandwidthThrottler::Get().PauseUntilRefill(this);
 					return;
@@ -284,7 +278,6 @@ void CEMSocket::OnReceive(int nErrorCode)
 					return;
 				}
 
-				// Process packet
 				PacketReceived(packet.get());
 			}
 		} else {
@@ -296,10 +289,9 @@ void CEMSocket::OnReceive(int nErrorCode)
 void CEMSocket::WakeIfPaused()
 {
 	if (pendingOnReceive) {
-		// Re-enter the read loop. OnReceive() will consult the global
-		// CDownloadBandwidthThrottler for fresh budget; if the bucket
-		// is still empty, pendingOnReceive stays set and we'll retry
-		// next tick.
+		// Re-enter the read loop. OnReceive() consults the global
+		// CDownloadBandwidthThrottler for fresh budget; if the bucket is still
+		// empty, pendingOnReceive stays set and we retry next tick.
 		OnReceive(0);
 	}
 }
@@ -327,11 +319,9 @@ void CEMSocket::WakeIfPaused()
  */
 void CEMSocket::SendPacket(CPacket *packet, bool delpacket, bool controlpacket, uint32 actualPayloadSize)
 {
-	// printf("* SendPacket called on socket %p\n", this);
 	std::lock_guard<std::mutex> lock(m_sendLocker);
 
 	if (byConnected == ES_DISCONNECTED) {
-		// printf("* Disconnected, drop packet\n");
 		if (delpacket) {
 			delete packet;
 		}
@@ -341,13 +331,11 @@ void CEMSocket::SendPacket(CPacket *packet, bool delpacket, bool controlpacket, 
 		}
 
 		if (controlpacket) {
-			// printf("* Adding a control packet\n");
 			m_control_queue.push_back(packet);
 
 			// queue up for controlpacket
 			theApp->uploadBandwidthThrottler->QueueForSendingControlPacket(this, HasSent());
 		} else {
-			// printf("* Adding a normal packet to the queue\n");
 			bool first = !((sendbuffer && !m_currentPacket_is_controlpacket) ||
 				       !m_standard_queue.empty());
 			StandardPacketQueueEntry queueEntry = { actualPayloadSize, packet };
@@ -402,10 +390,10 @@ uint64 CEMSocket::GetSentPayloadSinceLastCallAndReset()
 	return sentBytes;
 }
 
-// Non-resetting peek at bytes sent since the last GetSentPayloadSinceLastCallAndReset() call.
-// Used by the disk I/O thread to get a fresh view of sent bytes without consuming the counter
-// that SendBlockData() drains every CORE_TIMER_PERIOD ms.
-// Lock order: must not be called while m_sendLocker is already held by the caller.
+// Non-resetting peek at bytes sent since the last
+// GetSentPayloadSinceLastCallAndReset(). Used by the disk I/O thread for a fresh
+// view without consuming the counter SendBlockData() drains every
+// CORE_TIMER_PERIOD. Must not be called with m_sendLocker already held.
 uint64 CEMSocket::PeekSentPayload()
 {
 	std::lock_guard<std::mutex> lock(m_sendLocker);
@@ -464,14 +452,10 @@ SocketSentBytes CEMSocket::Send(
 {
 	std::lock_guard<std::mutex> lock(m_sendLocker);
 
-	// printf("* Attempt to send a packet on socket %p\n", this);
-
 	if (byConnected == ES_DISCONNECTED) {
-		// printf("* Disconnected socket %p\n", this);
 		SocketSentBytes returnVal = { false, 0, 0 };
 		return returnVal;
 	} else if (m_bBusy && onlyAllowedToSendControlPacket) {
-		// printf("* Busy socket %p\n", this);
 		SocketSentBytes returnVal = { true, 0, 0 };
 		return returnVal;
 	}
@@ -482,8 +466,6 @@ SocketSentBytes CEMSocket::Send(
 
 	if (byConnected == ES_CONNECTED && IsEncryptionLayerReady() &&
 		(!m_bBusy || onlyAllowedToSendControlPacket)) {
-
-		// printf("* Internal attemptto send on %p\n", this);
 
 		if (minFragSize < 1) {
 			minFragSize = 1;
@@ -532,13 +514,11 @@ SocketSentBytes CEMSocket::Send(
 			if (sendbuffer == NULL) {
 				CPacket *curPacket = NULL;
 				if (!m_control_queue.empty()) {
-					// There's a control packet to send
 					m_currentPacket_is_controlpacket = true;
 					curPacket = m_control_queue.front();
 					m_control_queue.pop_front();
 				} else if (!m_standard_queue
 						    .empty() /*&& onlyAllowedToSendControlPacket == false*/) {
-					// There's a standard packet to send
 					m_currentPacket_is_controlpacket = false;
 					StandardPacketQueueEntry queueEntry = m_standard_queue.front();
 					m_standard_queue.pop_front();
@@ -633,13 +613,11 @@ SocketSentBytes CEMSocket::Send(
 
 				uint32 result = CEncryptedStreamSocket::Write(sendbuffer + sent, tosend);
 
-				// Advance 'sent' before checking BlocksWrite().  BlocksWrite()
-				// reflects "any async_write currently in flight", not "did
-				// this Write() succeed".  A previous iteration's pending
-				// write may still be in flight when the current Write()
-				// succeeds, so BlocksWrite() returns true even though we
-				// just dispatched more data.  Advancing first prevents
-				// 'sent' from lagging and the same bytes being re-sent.
+				// Advance 'sent' before checking BlocksWrite(), which reflects "any
+				// async_write currently in flight" rather than "did this Write()
+				// succeed": a previous iteration's pending write may still be in
+				// flight when the current one succeeds, so advancing first keeps
+				// 'sent' from lagging and the same bytes from being re-sent.
 				if (result > 0) {
 					m_hasSent = true;
 					sent += result;
@@ -693,15 +671,11 @@ SocketSentBytes CEMSocket::Send(
 
 	if (onlyAllowedToSendControlPacket &&
 		(!m_control_queue.empty() || (sendbuffer != NULL && m_currentPacket_is_controlpacket))) {
-		// enter control packet send queue
-		// we might enter control packet queue several times for the same package,
-		// but that costs very little overhead. Less overhead than trying to make sure
-		// that we only enter the queue once.
-		// printf("* Requeueing control packet on %p\n", this);
+		// Enter the control packet send queue. We might enter it several times for
+		// the same package, but that costs less overhead than ensuring we enter it
+		// only once.
 		theApp->uploadBandwidthThrottler->QueueForSendingControlPacket(this, HasSent());
 	}
-
-	// printf("* Finishing send debug on %p\n",this);
 
 	SocketSentBytes returnVal = {
 		!anErrorHasOccured, sentStandardPacketBytesThisCall, sentControlPacketBytesThisCall

--- a/src/EncryptedDatagramSocket.cpp
+++ b/src/EncryptedDatagramSocket.cpp
@@ -228,27 +228,12 @@ int CEncryptedDatagramSocket::DecryptReceivedClient(uint8_t *bufIn,
 
 	if (value == MAGICVALUE_UDP_SYNC_CLIENT) {
 		// yup this is an encrypted packet
-		//		// debugoutput notices
-		//		// the following cases are "allowed" but shouldn't happen given that there is
-		// only our implementation yet 		if (bKad && (pbyBufIn[0] & 0x01) != 0)
-		// DebugLog(_T("Received obfuscated UDP packet from clientIP: %s with wrong key marker bits
-		// (kad packet, ed2k bit)"), ipstr(dwIP)); 		else if (bKad && !bKadRecvKeyUsed &&
-		// (pbyBufIn[0] & 0x02) != 0) 			DebugLog(_T("Received obfuscated UDP packet
-		// from clientIP: %s
-		// with wrong key marker bits (kad packet, nodeid key, recvkey bit)"), ipstr(dwIP));
-		// else if (bKad
-		//&& bKadRecvKeyUsed && (pbyBufIn[0] & 0x02) == 0) 			DebugLog(_T("Received
-		// obfuscated UDP packet from clientIP: %s with wrong key marker bits (kad packet, recvkey
-		// key,
-		// nodeid bit)"), ipstr(dwIP));
 
 		uint8_t padLen;
 		receivebuffer.RC4Crypt(bufIn + 7, (uint8_t *)&padLen, 1);
 		result -= CRYPT_HEADER_WITHOUTPADDING;
 
 		if (result <= padLen) {
-			// DebugLogError(_T("Invalid obfuscated UDP packet from clientIP: %s, Paddingsize (%u)
-			// larger than received bytes"), ipstr(dwIP), byPadLen);
 			return bufLen; // pass through, let the Receivefunction do the errorhandling on this
 				       // junk
 		}
@@ -261,8 +246,6 @@ int CEncryptedDatagramSocket::DecryptReceivedClient(uint8_t *bufIn,
 
 		if (kad) {
 			if (result <= 8) {
-				// DebugLogError(_T("Obfuscated Kad packet with mismatching size (verify keys
-				// missing) received from clientIP: %s"), ipstr(dwIP));
 				return bufLen; // pass through, let the Receivefunction do the errorhandling
 					       // on this junk;
 			}
@@ -284,8 +267,6 @@ int CEncryptedDatagramSocket::DecryptReceivedClient(uint8_t *bufIn,
 		theStats::AddDownOverheadCrypt(bufLen - result);
 		return result; // done
 	} else {
-		// DebugLogWarning(_T("Obfuscated packet expected but magicvalue mismatch on UDP packet from
-		// clientIP: %s"), ipstr(dwIP));
 		return bufLen; // pass through, let the Receivefunction do the errorhandling on this junk
 	}
 }
@@ -323,15 +304,11 @@ int CEncryptedDatagramSocket::EncryptSendClient(uint8_t **buf,
 			PokeUInt32(keyData, receiverVerifyKey);
 			PokeUInt16(keyData + 4, randomKeyPart);
 			md5.Calculate(keyData, sizeof(keyData));
-			// DEBUG_ONLY( DebugLog(_T("Creating obfuscated Kad packet encrypted by ReceiverKey
-			// (%u)"), nReceiverVerifyKey) );
 		} else if (clientHashOrKadID != NULL && !CMD4Hash(clientHashOrKadID).IsEmpty()) {
 			uint8_t keyData[18];
 			md4cpy(keyData, clientHashOrKadID);
 			PokeUInt16(keyData + 16, randomKeyPart);
 			md5.Calculate(keyData, sizeof(keyData));
-			// DEBUG_ONLY( DebugLog(_T("Creating obfuscated Kad packet encrypted by Hash/NodeID
-			// %s"), md4str(pachClientHashOrKadID)) );
 		} else {
 			delete[] cryptedBuffer;
 			wxFAIL;

--- a/src/EncryptedStreamSocket.cpp
+++ b/src/EncryptedStreamSocket.cpp
@@ -267,7 +267,6 @@ void CEncryptedStreamSocket::SetConnectionEncryption(
 		m_pfiReceiveBuffer.SetKey(md5);
 
 	} else if (bServerConnection && bEnabled) {
-		// printf("->Server crypt\n");
 		m_bServerCrypt = true;
 		m_StreamCryptState = ECS_PENDING_SERVER;
 	} else {
@@ -282,7 +281,6 @@ void CEncryptedStreamSocket::SetConnectionEncryption(
 // together with the fact that each byte must pass the keystream only once
 int CEncryptedStreamSocket::Write(const void *lpBuf, uint32_t nBufLen)
 {
-	// printf("Starting write for %s\n", (const char*) unicode2char(GetPeer()));
 	if (!IsEncryptionLayerReady()) {
 		wxFAIL;
 		return 0;
@@ -303,11 +301,8 @@ int CEncryptedStreamSocket::Write(const void *lpBuf, uint32_t nBufLen)
 		// this happens when the encryption option was not set on an outgoing connection
 		// or if we try to send before receiving on an incoming connection - both shouldn't happen
 		m_StreamCryptState = ECS_NONE;
-		// DebugLogError(_T("CEncryptedStreamSocket: Overwriting State ECS_UNKNOWN with ECS_NONE
-		// because of premature Send() (%s)"), GetPeer());
 	}
 
-	// printf("Writing %i bytes of data\n", nBufLen);
 	return CSocketClientProxy::Write(lpBuf, nBufLen);
 }
 
@@ -315,9 +310,6 @@ int CEncryptedStreamSocket::Read(void *lpBuf, uint32_t nBufLen)
 {
 	m_nObfusicationBytesReceived = CSocketClientProxy::Read(lpBuf, nBufLen);
 	m_bFullReceive = m_nObfusicationBytesReceived == (uint32)nBufLen;
-
-	// printf("Read %i bytes on %s, socket %p\n", m_nObfusicationBytesReceived, (const char*)
-	// unicode2char(GetPeer()), this);
 
 	if (m_nObfusicationBytesReceived == (uint32_t)SOCKET_ERROR || m_nObfusicationBytesReceived <= 0) {
 		return m_nObfusicationBytesReceived;
@@ -328,14 +320,10 @@ int CEncryptedStreamSocket::Read(void *lpBuf, uint32_t nBufLen)
 		return m_nObfusicationBytesReceived;
 	case ECS_PENDING:
 	case ECS_PENDING_SERVER:
-		// printf("Received %i bytes before sending?\n", m_nObfusicationBytesReceived);
 		wxFAIL;
-		// DebugLogError(_T("CEncryptedStreamSocket Received data before sending on outgoing
-		// connection"));
 		m_StreamCryptState = ECS_NONE;
 		return m_nObfusicationBytesReceived;
 	case ECS_UNKNOWN: {
-		// printf("Receiving encrypted data on ECS_UNKNOWN\n");
 		uint32_t nRead = 1;
 		bool bNormalHeader = false;
 		switch (((uint8_t *)lpBuf)[0]) {
@@ -347,7 +335,6 @@ int CEncryptedStreamSocket::Read(void *lpBuf, uint32_t nBufLen)
 		}
 
 		if (!bNormalHeader) {
-			// printf("Not a normal header, negotiating encryption\n");
 			StartNegotiation(false);
 			const uint32 nNegRes =
 				Negotiate((uint8_t *)lpBuf + nRead, m_nObfusicationBytesReceived - nRead);
@@ -356,34 +343,25 @@ int CEncryptedStreamSocket::Read(void *lpBuf, uint32_t nBufLen)
 			}
 			nRead += nNegRes;
 			if (nRead != (uint32_t)m_nObfusicationBytesReceived) {
-				// this means we have more data then the current negotiation step required (or
-				// there is a bug) and this should never happen (note: even if it just
-				// finished the handshake here, there still can be no data left, since the
-				// other client didn't receive our response yet)
-				// DebugLogError(_T("CEncryptedStreamSocket: Client %s sent more data then
-				// expected while negotiating, disconnecting (1)"), GetPeer()); printf("On
-				// error: encryption\n");
+				// More data than the current negotiation step required (or a bug): this
+				// should never happen, since even a handshake that just finished here can
+				// have no data left -- the other client has not received our response yet.
 				OnError(ERR_ENCRYPTION);
 			}
 			return 0;
 		} else {
 			// doesn't seem to be encrypted
-			// printf("Encrypted data doesn't seem to be encrypted\n");
 			m_StreamCryptState = ECS_NONE;
 
-			// if we require an encrypted connection, cut the connection here. This shouldn't
-			// happen that often at least with other up-to-date eMule clients because they check
-			// for incompability before connecting if possible
+			// If we require an encrypted connection, cut it here. Rare against
+			// up-to-date eMule clients, which check for incompatibility before
+			// connecting where they can.
 			if (thePrefs::IsClientCryptLayerRequired()) {
-				// TODO: Remove me when I have been solved
-				// Even if the Require option is enabled, we currently have to accept
-				// unencrypted connection which are made for lowid/firewall checks from
-				// servers and other from us selected client. Otherwise, this option would
-				// always result in a lowid/firewalled status. This is of course not nice, but
-				// we can't avoid this workaround until servers and kad completely support
-				// encryption too, which will at least for kad take a bit only exception is
-				// the .ini option ClientCryptLayerRequiredStrict which will even ignore test
-				// connections Update: New server now support encrypted callbacks
+				// Even with Require enabled we still have to accept the unencrypted
+				// connections used for lowid/firewall checks by servers and by clients
+				// we selected ourselves; refusing them would always result in a
+				// lowid/firewalled status. The .ini option ClientCryptLayerRequiredStrict
+				// is the only exception, ignoring even test connections.
 				uint32_t ip = GetPeerInt();
 				if (thePrefs::IsClientCryptLayerRequiredStrict() ||
 					(!theApp->serverconnect->AwaitingTestFromIP(ip) &&
@@ -391,9 +369,6 @@ int CEncryptedStreamSocket::Read(void *lpBuf, uint32_t nBufLen)
 					OnError(ERR_ENCRYPTION_NOTALLOWED);
 					return 0;
 				} else {
-					// AddDebugLogLine(DLP_DEFAULT, false, _T("Incoming unencrypted
-					// firewallcheck connection permitted despite RequireEncryption
-					// setting  - %s"), GetPeer() );
 				}
 			}
 			return m_nObfusicationBytesReceived; // buffer was unchanged, we can just pass it
@@ -401,37 +376,26 @@ int CEncryptedStreamSocket::Read(void *lpBuf, uint32_t nBufLen)
 		}
 	}
 	case ECS_ENCRYPTING:
-		// printf("Encryption enabled on data receiving, decrypting and passing along\n");
-		//  basic obfusication enabled and set, so decrypt and pass along
+		// basic obfusication enabled and set, so decrypt and pass along
 		m_pfiReceiveBuffer.RC4Crypt((uint8_t *)lpBuf, (uint8_t *)lpBuf, m_nObfusicationBytesReceived);
-		// DumpMem(lpBuf, m_nObfusicationBytesReceived, "Directly decrypted data:");
 		return m_nObfusicationBytesReceived;
 	case ECS_NEGOTIATING: {
-		// printf("Negotiating on data receive\n");
 		const uint32_t nRead = Negotiate((uint8_t *)lpBuf, m_nObfusicationBytesReceived);
 		if (nRead == (uint32_t)(-1)) {
-			// printf("-> Encryption read error on negotiation\n");
 			return 0;
 		} else if (nRead != (uint32_t)m_nObfusicationBytesReceived &&
 			   m_StreamCryptState != ECS_ENCRYPTING) {
-			// printf("-> Too much data, bailing out of negotiation step\n");
-			//  this means we have more data then the current negotiation step required (or there
-			//  is a bug) and this should never happen
-			// DebugLogError(_T("CEncryptedStreamSocket: Client %s sent more data then expected
-			// while negotiating, disconnecting (2)"), GetPeer());
+			// More data than the current negotiation step required (or a bug), which
+			// should never happen.
 			OnError(ERR_ENCRYPTION);
 			return 0;
 		} else if (nRead != (uint32_t)m_nObfusicationBytesReceived &&
 			   m_StreamCryptState == ECS_ENCRYPTING) {
-			// printf("-> Handshake negotiation finished\n");
-			//  we finished the handshake and if we this was an outgoing connection it is allowed
-			//  (but strange and unlikely) that the client sent payload
-			// DebugLogWarning(_T("CEncryptedStreamSocket: Client %s has finished the handshake
-			// but also sent payload on a outgoing connection"), GetPeer());
+			// We finished the handshake; on an outgoing connection it is allowed
+			// (though strange and unlikely) that the client also sent payload.
 			memmove(lpBuf, (uint8_t *)lpBuf + nRead, m_nObfusicationBytesReceived - nRead);
 			return m_nObfusicationBytesReceived - nRead;
 		} else {
-			// printf("-> Negotiation went probably ok\n");
 			return 0;
 		}
 	}
@@ -445,8 +409,6 @@ void CEncryptedStreamSocket::OnSend(int)
 {
 	// if the socket just connected and this is outgoing, we might want to start the handshake here
 	if (m_StreamCryptState == ECS_PENDING || m_StreamCryptState == ECS_PENDING_SERVER) {
-		// printf("Starting connection negotiation on OnSend for %s\n", (const char*)
-		// unicode2char(GetPeer()));
 		StartNegotiation(true);
 		return;
 	}
@@ -468,14 +430,9 @@ void CEncryptedStreamSocket::CryptPrepareSendData(uint8 *pBuffer, uint32 nLen)
 		// this happens when the encryption option was not set on an outgoing connection
 		// or if we try to send before receiving on an incoming connection - both shouldn't happen
 		m_StreamCryptState = ECS_NONE;
-		// DebugLogError(_T("CEncryptedStreamSocket: Overwriting State ECS_UNKNOWN with ECS_NONE
-		// because of premature Send() (%s)"), GetPeer());
 	}
 	if (m_StreamCryptState == ECS_ENCRYPTING) {
-		// printf("Preparing crypt data on %s\n", (const char*) unicode2char(GetPeer()));
-		// DumpMem(pBuffer, nLen, "Before crypt prepare:\n");
 		m_pfiSendBuffer.RC4Crypt(pBuffer, pBuffer, nLen);
-		// DumpMem(pBuffer, nLen, "After crypt prepare:\n");
 	}
 }
 
@@ -491,14 +448,11 @@ bool CEncryptedStreamSocket::IsEncryptionLayerReady()
 
 void CEncryptedStreamSocket::StartNegotiation(bool bOutgoing)
 {
-	// printf("Starting socket negotiation\n");
 	if (!bOutgoing) {
-		// printf("Incoming connection negotiation on %s\n", (const char*) unicode2char(GetPeer()));
 		m_NegotiatingState = ONS_BASIC_CLIENTA_RANDOMPART;
 		m_StreamCryptState = ECS_NEGOTIATING;
 		m_nReceiveBytesWanted = 4;
 	} else if (m_StreamCryptState == ECS_PENDING) {
-		// printf("Socket is client.pending on negotiation\n");
 		CMemFile fileRequest(29);
 		const uint8_t bySemiRandomNotProtocolMarker = GetSemiRandomNotProtocolMarker();
 		fileRequest.WriteUInt8(bySemiRandomNotProtocolMarker);
@@ -520,7 +474,6 @@ void CEncryptedStreamSocket::StartNegotiation(bool bOutgoing)
 
 		SendNegotiatingData(fileRequest.GetRawBuffer(), (uint32_t)fileRequest.GetLength(), 5);
 	} else if (m_StreamCryptState == ECS_PENDING_SERVER) {
-		// printf("Socket is server.pending on negotiation\n");
 		CMemFile fileRequest(113);
 		const uint8_t bySemiRandomNotProtocolMarker = GetSemiRandomNotProtocolMarker();
 		fileRequest.WriteUInt8(bySemiRandomNotProtocolMarker);
@@ -562,22 +515,16 @@ void CEncryptedStreamSocket::StartNegotiation(bool bOutgoing)
 int CEncryptedStreamSocket::Negotiate(const uint8 *pBuffer, uint32 nLen)
 {
 	uint32_t nRead = 0;
-	// Hitting Negotiate() with m_nReceiveBytesWanted == 0 means the
-	// negotiation state machine has consumed everything it was expecting
-	// for the current step but somebody (the kernel buffer flushing on
-	// a teardown, late bytes from a server we're switching away from,
-	// etc.) still posted a Read on this socket while it's stuck in
-	// ECS_NEGOTIATING. wxASSERT used to abort debug builds and silently
-	// UB in release (entering the while loop below with bogus byte
-	// math). wxCHECK_MSG returns the same -1 sentinel both call sites
-	// already check for (see Read() at the ECS_NEGOTIATING case and the
-	// "non-normal header" branch), so the caller cleanly aborts the
-	// connection instead. #778.
+	// Reaching Negotiate() with m_nReceiveBytesWanted == 0 means the state machine
+	// has consumed everything the current step expected, but somebody still posted
+	// a Read while the socket sits in ECS_NEGOTIATING -- a kernel buffer flushing
+	// on teardown, late bytes from a server we are switching away from. wxCHECK_MSG
+	// returns the -1 sentinel both call sites already check for, so the caller
+	// cleanly aborts the connection instead of entering the loop with bogus byte
+	// math (#778).
 	wxCHECK_MSG(m_nReceiveBytesWanted > 0,
 		-1,
 		"CEncryptedStreamSocket::Negotiate: called with m_nReceiveBytesWanted == 0");
-
-	// DumpMem(pBuffer, nLen, "Negotiate buffer: ");
 
 	try {
 		while (m_NegotiatingState != ONS_COMPLETE && m_nReceiveBytesWanted > 0) {
@@ -587,9 +534,6 @@ int CEncryptedStreamSocket::Negotiate(const uint8 *pBuffer, uint32 nLen)
 			}
 
 			const uint32_t nToRead = std::min(nLen - nRead, m_nReceiveBytesWanted);
-			// printf("Reading %i bytes, add from %i position on %i position\n",nToRead, nRead,
-			// (int)m_pfiReceiveBuffer.GetPosition()); DumpMem(pBuffer + nRead, nToRead, "Recv
-			// Buffer: ");
 			m_pfiReceiveBuffer.Write(pBuffer + nRead, nToRead);
 			nRead += nToRead;
 			m_nReceiveBytesWanted -= nToRead;
@@ -600,8 +544,6 @@ int CEncryptedStreamSocket::Negotiate(const uint8 *pBuffer, uint32 nLen)
 			if (m_NegotiatingState != ONS_BASIC_CLIENTA_RANDOMPART &&
 				m_NegotiatingState != ONS_BASIC_SERVER_DHANSWER) {
 				// We have the keys, decrypt
-				// printf("We have the keys, so decrypt away on %s\n", (const char*)
-				// unicode2char(GetPeer()));
 				m_pfiReceiveBuffer.Encrypt();
 			}
 
@@ -612,9 +554,7 @@ int CEncryptedStreamSocket::Negotiate(const uint8 *pBuffer, uint32 nLen)
 				wxFAIL;
 				return 0;
 			case ONS_BASIC_CLIENTA_RANDOMPART: {
-				// printf("We are on ONS_BASIC_CLIENTA_RANDOMPART, create the keys on %s\n",
-				// (const char*) unicode2char(GetPeer()));
-				//  This creates the send/receive keys.
+				// This creates the send/receive keys.
 
 				uint8_t achKeyData[21];
 				md4cpy(achKeyData, thePrefs::GetUserHash().GetHash());
@@ -622,10 +562,7 @@ int CEncryptedStreamSocket::Negotiate(const uint8 *pBuffer, uint32 nLen)
 
 				achKeyData[16] = MAGICVALUE_REQUESTER;
 
-				// DumpMem(achKeyData, sizeof(achKeyData), "ach:");
-
 				MD5Sum md5(achKeyData, sizeof(achKeyData));
-				// DumpMem(md5.GetRawHash(), 16, "Md5:");
 				m_pfiReceiveBuffer.SetKey(md5);
 
 				achKeyData[16] = MAGICVALUE_SERVER;
@@ -638,45 +575,28 @@ int CEncryptedStreamSocket::Negotiate(const uint8 *pBuffer, uint32 nLen)
 			}
 			case ONS_BASIC_CLIENTA_MAGICVALUE: {
 				// Check the magic value to confirm encryption works.
-				// printf("Creating magic value on negotiate on %s\n", (const char*)
-				// unicode2char(GetPeer()));
 
 				uint32_t dwValue = m_pfiReceiveBuffer.ReadUInt32();
 
 				if (dwValue == MAGICVALUE_SYNC) {
-					// yup, the one or the other way it worked, this is an encrypted
-					// stream
-					// DEBUG_ONLY( DebugLog(_T("Received proper magic value, clientIP:
-					// %s"), GetPeer()) );
-					// set the receiver key
-					// printf("Magic value works on %s\n", (const char*)
-					// unicode2char(GetPeer()));
+					// It worked one way or the other, so this is an encrypted
+					// stream. Set the receiver key.
 					m_NegotiatingState = ONS_BASIC_CLIENTA_METHODTAGSPADLEN;
 					m_nReceiveBytesWanted = 3;
 				} else {
-					// printf("Wrong magic value: 0x%x != 0x%x on %s\n",dwValue,
-					// MAGICVALUE_SYNC, (const char*)unicode2char(GetPeer()));
-					// DebugLogError(_T("CEncryptedStreamSocket: Received wrong magic
-					// value from clientIP %s on a supposly encrypted stream / Wrong
-					// Header"), GetPeer());
 					OnError(ERR_ENCRYPTION);
 					return (-1);
 				}
 				break;
 			}
 			case ONS_BASIC_CLIENTA_METHODTAGSPADLEN: {
-				// Get encryption method and padding.
-				// Might fall back to padding process, but the bytes will be ignored.
-				// printf("Getting encryption method on negotiation\n");
+				// Get encryption method and padding. Might fall back to the padding
+				// process, but the bytes will be ignored.
 
 				m_dbgbyEncryptionSupported = m_pfiReceiveBuffer.ReadUInt8();
 				m_dbgbyEncryptionRequested = m_pfiReceiveBuffer.ReadUInt8();
 
 				if (m_dbgbyEncryptionRequested != ENM_OBFUSCATION) {
-					// printf("Unsupported encryption method!\n");
-					//						AddDebugLogLine(DLP_LOW,
-					// false, _T("CEncryptedStreamSocket: Client %s preferred unsupported
-					// encryption method (%i)"), GetPeer(), m_dbgbyEncryptionRequested);
 				}
 
 				m_nReceiveBytesWanted = m_pfiReceiveBuffer.ReadUInt8();
@@ -689,8 +609,7 @@ int CEncryptedStreamSocket::Negotiate(const uint8 *pBuffer, uint32 nLen)
 			}
 			/* fall through */
 			case ONS_BASIC_CLIENTA_PADDING: {
-				// printf("Negotiating on padding, completing\n");
-				//  ignore the random bytes, send the response, set status complete
+				// ignore the random bytes, send the response, set status complete
 				CMemFile fileResponse(26);
 				fileResponse.WriteUInt32(MAGICVALUE_SYNC);
 				const uint8_t bySelectedEncryptionMethod =
@@ -713,16 +632,10 @@ int CEncryptedStreamSocket::Negotiate(const uint8 *pBuffer, uint32 nLen)
 					fileResponse.GetRawBuffer(), (uint32_t)fileResponse.GetLength());
 				m_NegotiatingState = ONS_COMPLETE;
 				m_StreamCryptState = ECS_ENCRYPTING;
-				// DEBUG_ONLY( DebugLog(_T("CEncryptedStreamSocket: Finished Obufscation
-				// handshake with client %s (incoming)"), GetPeer()) );
 				break;
 			}
 			case ONS_BASIC_CLIENTB_MAGICVALUE: {
-				// printf("Negotiating on magic value\n");
 				if (m_pfiReceiveBuffer.ReadUInt32() != MAGICVALUE_SYNC) {
-					// DebugLogError(_T("CEncryptedStreamSocket: EncryptedstreamSyncError:
-					// Client sent wrong Magic Value as answer, cannot complete handshake
-					// (%s)"), GetPeer());
 					OnError(ERR_ENCRYPTION);
 					return (-1);
 				}
@@ -731,12 +644,8 @@ int CEncryptedStreamSocket::Negotiate(const uint8 *pBuffer, uint32 nLen)
 				break;
 			}
 			case ONS_BASIC_CLIENTB_METHODTAGSPADLEN: {
-				// printf("Negotiating on client B pad length\n");
 				m_dbgbyEncryptionMethodSet = m_pfiReceiveBuffer.ReadUInt8();
 				if (m_dbgbyEncryptionMethodSet != ENM_OBFUSCATION) {
-					// DebugLogError( _T("CEncryptedStreamSocket: Client %s set
-					// unsupported encryption method (%i), handshake failed"), GetPeer(),
-					// m_dbgbyEncryptionMethodSet);
 					OnError(ERR_ENCRYPTION);
 					return (-1);
 				}
@@ -748,12 +657,9 @@ int CEncryptedStreamSocket::Negotiate(const uint8 *pBuffer, uint32 nLen)
 			}
 			/* fall through */
 			case ONS_BASIC_CLIENTB_PADDING:
-				// printf("Negotiating on client B padding, handshake complete\n");
-				//  ignore the random bytes, the handshake is complete
+				// ignore the random bytes, the handshake is complete
 				m_NegotiatingState = ONS_COMPLETE;
 				m_StreamCryptState = ECS_ENCRYPTING;
-				// DEBUG_ONLY( DebugLog(_T("CEncryptedStreamSocket: Finished Obufscation
-				// handshake with client %s (outgoing)"), GetPeer()) );
 				break;
 			case ONS_BASIC_SERVER_DHANSWER: {
 				wxASSERT(!m_cryptDHA.IsZero());
@@ -766,7 +672,6 @@ int CEncryptedStreamSocket::Negotiate(const uint8 *pBuffer, uint32 nLen)
 					a_exp_b_mod_c(cryptDHAnswer, m_cryptDHA, cryptDHPrime);
 
 				m_cryptDHA = 0;
-				// DEBUG_ONLY( ZeroMemory(aBuffer, sizeof(aBuffer)) );
 				wxASSERT(cryptResult.MinEncodedSize() <= PRIMESIZE_BYTES);
 
 				// create the keys
@@ -785,16 +690,11 @@ int CEncryptedStreamSocket::Negotiate(const uint8 *pBuffer, uint32 nLen)
 			case ONS_BASIC_SERVER_MAGICVALUE: {
 				uint32_t dwValue = m_pfiReceiveBuffer.ReadUInt32();
 				if (dwValue == MAGICVALUE_SYNC) {
-					// yup, the one or the other way it worked, this is an encrypted
-					// stream
-					// DebugLog(_T("Received proper magic value after DH-Agreement from
-					// Serverconnection IP: %s"), GetPeer());
-					// set the receiver key
+					// It worked one way or the other, so this is an encrypted
+					// stream. Set the receiver key.
 					m_NegotiatingState = ONS_BASIC_SERVER_METHODTAGSPADLEN;
 					m_nReceiveBytesWanted = 3;
 				} else {
-					// DebugLogError(_T("CEncryptedStreamSocket: Received wrong magic
-					// value after DH-Agreement from Serverconnection"), GetPeer());
 					OnError(ERR_ENCRYPTION);
 					return (-1);
 				}
@@ -804,9 +704,6 @@ int CEncryptedStreamSocket::Negotiate(const uint8 *pBuffer, uint32 nLen)
 				m_dbgbyEncryptionSupported = m_pfiReceiveBuffer.ReadUInt8();
 				m_dbgbyEncryptionRequested = m_pfiReceiveBuffer.ReadUInt8();
 				if (m_dbgbyEncryptionRequested != ENM_OBFUSCATION) {
-					//					AddDebugLogLine(DLP_LOW,
-					// false, _T("CEncryptedStreamSocket: Server %s preferred unsupported
-					// encryption method (%i)"), GetPeer(), m_dbgbyEncryptionRequested);
 				}
 				m_nReceiveBytesWanted = m_pfiReceiveBuffer.ReadUInt8();
 				m_NegotiatingState = ONS_BASIC_SERVER_PADDING;
@@ -839,8 +736,6 @@ int CEncryptedStreamSocket::Negotiate(const uint8 *pBuffer, uint32 nLen)
 					0,
 					true); // don't actually send it right now, store it in our sendbuffer
 				m_StreamCryptState = ECS_ENCRYPTING;
-				// DEBUG_ONLY( DebugLog(_T("CEncryptedStreamSocket: Finished DH Obufscation
-				// handshake with Server %s"), GetPeer()) );
 				break;
 			}
 			default:
@@ -851,8 +746,6 @@ int CEncryptedStreamSocket::Negotiate(const uint8 *pBuffer, uint32 nLen)
 		return nRead;
 	} catch (...) {
 		// can only be caused by a bug in negationhandling, not by the datastream
-		// error->Delete();
-		// printf("Bug on negotiation?\n");
 		wxFAIL;
 		OnError(ERR_ENCRYPTION);
 		m_pfiReceiveBuffer.ResetData();
@@ -866,7 +759,6 @@ int CEncryptedStreamSocket::SendNegotiatingData(
 	wxASSERT(m_StreamCryptState == ECS_NEGOTIATING || m_StreamCryptState == ECS_ENCRYPTING);
 	wxASSERT(nStartCryptFromByte <= nBufLen);
 	wxASSERT(m_NegotiatingState == ONS_BASIC_SERVER_DELAYEDSENDING || !bDelaySend);
-	// printf("Send negotiation data on %s\n", (const char*) unicode2char(GetPeer()));
 	uint8_t *pBuffer = NULL;
 	bool bProcess = false;
 	if (lpBuf != NULL) {
@@ -880,13 +772,9 @@ int CEncryptedStreamSocket::SendNegotiatingData(
 		}
 
 		if (nBufLen > nStartCryptFromByte) {
-			// printf("Crypting negotiation data on %s starting on byte %i\n", (const char*)
-			// unicode2char(GetPeer()), nStartCryptFromByte); DumpMem(lpBuf, nBufLen,
-			// "Pre-encryption:");
 			m_pfiSendBuffer.RC4Crypt((uint8 *)lpBuf + nStartCryptFromByte,
 				pBuffer + nStartCryptFromByte,
 				nBufLen - nStartCryptFromByte);
-			// DumpMem(pBuffer, nBufLen, "Post-encryption:");
 		}
 
 		if (!m_pfiSendBuffer.IsEmpty()) {
@@ -918,9 +806,7 @@ int CEncryptedStreamSocket::SendNegotiatingData(
 
 	uint32_t result = 0;
 	if (!bDelaySend) {
-		// printf("Writing negotiation data on %s: ", (const char*) unicode2char(GetPeer()));
 		result = CSocketClientProxy::Write(pBuffer, nBufLen);
-		// printf("Wrote %i bytes\n",result);
 	}
 
 	if (result == (uint32_t)SOCKET_ERROR || bDelaySend) {
@@ -930,8 +816,6 @@ int CEncryptedStreamSocket::SendNegotiatingData(
 	} else {
 		if (result < nBufLen) {
 			// Store the partial data pending
-			// printf("Partial negotiation pending on %s\n", (const char*)
-			// unicode2char(GetPeer()));
 			m_pfiSendBuffer.Write(pBuffer + result, nBufLen - result);
 		}
 		delete[] pBuffer;

--- a/src/ExternalConn.cpp
+++ b/src/ExternalConn.cpp
@@ -83,25 +83,21 @@ class CKnownFile_Encoder
 	RLE_Data m_enc_data;
 
 	// Reconcile epoch, stamped by CFileEncoderMap::UpdateEncoders on every
-	// encoder whose file is still listed. Encoders left carrying an older
-	// stamp have lost their file and are swept. Replaces the per-call set of
-	// live ECIDs that used to serve the same purpose -- see UpdateEncoders.
+	// encoder whose file is still listed. Encoders left carrying an older stamp
+	// have lost their file and are swept.
 	uint64 m_seenEpoch;
 
 	// Whether `Get_EC_Response_GetUpdate` has already sent this file to the
-	// client carrying its identifying fields. False on a freshly-built
-	// encoder, which is what makes a re-created encoder re-send full detail
-	// without the caller having to erase anything.
+	// client carrying its identifying fields. False on a freshly-built encoder,
+	// which is what makes a re-created encoder re-send full detail without the
+	// caller having to erase anything.
 	//
-	// Deliberately specific to that one response path rather than a general
-	// "the client has this file": a path that has never sent the identity
-	// must not take the unchanged-file shortcut, or the client is left with a
-	// child-less tag it turns into a ghost entry (#808). The two amuleweb
-	// handlers answer the same question from their own sets instead, because
-	// they iterate a CopyFileList snapshot rather than the encoder map and
-	// reaching the encoder would cost the lookup this exists to avoid. That
-	// is why this is one flag and not a per-path bitmask -- a second bit
-	// would have no writer.
+	// Deliberately specific to that one response path rather than a general "the
+	// client has this file": a path that has never sent the identity must not
+	// take the unchanged-file shortcut, or the client is left with a child-less
+	// tag it turns into a ghost entry. The two amuleweb handlers answer the same
+	// question from their own sets, because they iterate a CopyFileList snapshot
+	// rather than the encoder map.
 	bool m_sentOnUpdatePath;
 
 protected:
@@ -184,18 +180,15 @@ public:
 	virtual bool IsPartFile_Encoder() { return true; }
 };
 
-// The encoders for the files this connection has told its client about, held
-// in ECID order.
+// The encoders for the files this connection has told its client about, held in
+// ECID order.
 //
-// A sorted vector rather than a std::map. The response walk touches every
-// entry on every poll and does very little per entry, so its cost was
-// dominated by chasing red-black-tree pointers around the heap rather than by
-// the work itself -- a linear scan of a contiguous array is something the
-// prefetcher can follow, a tree traversal is not. Lookup becomes a binary
-// search, which is now the rarer operation: #775 removed the per-file lookups,
-// leaving only the reconcile below and two amuleweb call sites. Structural
-// change is rarer still, so paying O(n) to merge new entries or compact away
-// dead ones is the right side of the trade.
+// A sorted vector rather than a std::map. The response walk touches every entry
+// on every poll and does very little per entry, so its cost was dominated by
+// chasing red-black-tree pointers around the heap -- a linear scan of a
+// contiguous array is something the prefetcher can follow, a tree traversal is
+// not. Lookup becomes a binary search, which is now the rarer operation, and
+// structural change is rarer still.
 class CFileEncoderMap
 {
 	typedef std::set<uint32> IDSet;
@@ -221,11 +214,11 @@ public:
 	// dereferenced.
 	CKnownFile_Encoder *operator[](uint32 id);
 
-	// If freshEcids is non-null, receives the ECIDs whose encoder was
-	// (re-)created this call. Freshly-created encoders signal that the
-	// caller's per-ECID EC caches (CObjTagMap valuemap, and the encoder's
-	// own sent-with-detail flag) are stale w.r.t. the client's local view
-	// and must be dropped so INC_UPDATE emissions re-send identifying fields.
+	// If freshEcids is non-null, receives the ECIDs whose encoder was (re-)created
+	// this call. A freshly-created encoder signals that the caller's per-ECID EC
+	// caches (the CObjTagMap valuemap, and the encoder's own sent-with-detail
+	// flag) are stale w.r.t. the client's view and must be dropped, so
+	// INC_UPDATE emissions re-send identifying fields.
 	void UpdateEncoders(IDSet *freshEcids = nullptr);
 
 private:
@@ -238,10 +231,10 @@ private:
 		bool operator()(uint32 id, const value_type &b) const { return id < b.first; }
 	};
 
-	// Entries created during a reconcile, merged in once the pass that made
-	// them is done. Appending here rather than inserting into the middle of
-	// m_entries keeps a first poll -- where every file is new -- from paying
-	// a memmove of the whole array per file.
+	// Entries created during a reconcile, merged in once the pass that made them
+	// is done. Appending here rather than inserting into the middle of m_entries
+	// keeps a first poll -- where every file is new -- from paying a memmove of
+	// the whole array per file.
 	Storage m_pending;
 	void FlushPending();
 
@@ -249,24 +242,19 @@ private:
 	// it appends each ECID it passes to the list the removal merge consumes.
 	Storage m_entries;
 
-	// The list generations this map was last reconciled against. When both
-	// still match, the lists have not gained or lost a file and the reconcile
-	// is a no-op -- see the early return in UpdateEncoders. `m_haveListGen`
-	// distinguishes "never reconciled" from "reconciled when both counters
-	// happened to be zero", which is the state at startup and would otherwise
-	// skip the very first pass and leave the map permanently empty.
+	// The list generations this map was last reconciled against. When both still
+	// match, the lists have not gained or lost a file and the reconcile is a
+	// no-op. `m_haveListGen` distinguishes "never reconciled" from "reconciled
+	// when both counters happened to be zero", which is the state at startup.
 	uint64 m_lastSharedGen = 0;
 	uint64 m_lastDownloadGen = 0;
 	bool m_haveListGen = false;
 
-	// Monotonic reconcile counter; see UpdateEncoders. Two things make a
-	// stamp comparison safe. The counter is a member of this map, and the map
-	// belongs to one CECServerSocket, so it is per-connection and encoders
-	// are never shared across clients -- there is no cross-client collision
-	// to reason about. And every UpdateEncoders call takes a fresh value
-	// before stamping anything, so no encoder can be carrying the value the
-	// current call is about to use. 64-bit on top of that, so it also cannot
-	// wrap back onto a live encoder's stamp within any plausible uptime.
+	// Monotonic reconcile counter; see UpdateEncoders. Two things make a stamp
+	// comparison safe: the map belongs to one CECServerSocket, so encoders are
+	// never shared across clients, and every UpdateEncoders call takes a fresh
+	// value before stamping anything, so no encoder can already carry the value
+	// the current call is about to use.
 	uint64 m_epoch = 0;
 };
 
@@ -313,32 +301,26 @@ void CFileEncoderMap::FlushPending()
 // or if we have new files without encoder yet.
 void CFileEncoderMap::UpdateEncoders(IDSet *freshEcids)
 {
-	// Nothing has entered or left either list since the last reconcile, so
-	// the encoder map already mirrors them and the whole pass below -- two
-	// O(n) CopyFileList snapshots, a lookup and a stamp per file, and a sweep
-	// -- would end exactly where it started. On a library that is not
-	// churning, which is the normal case, that is every poll for every
-	// connected client.
+	// Nothing has entered or left either list since the last reconcile, so the
+	// encoder map already mirrors them and the whole pass below would end where
+	// it started. On a library that is not churning, that is every poll for
+	// every connected client.
 	//
 	// Read the counters BEFORE the snapshots, never after. Read first and the
-	// values can only be older than what CopyFileList goes on to see: a file
-	// arriving in between leaves us recording a stale generation, so the next
-	// poll reconciles again and picks it up one cycle late. Read after, and a
-	// change that landed between the copy and the read would be recorded as
-	// already seen and never reconciled at all -- a file that silently never
-	// appears, or never disappears, for the life of the connection.
+	// values can only be older than what CopyFileList goes on to see, so a file
+	// arriving in between is picked up one cycle late. Read after, and a change
+	// that landed between the copy and the read is recorded as already seen and
+	// never reconciled at all.
 	const uint64 sharedGen = theApp->sharedfiles->GetListGeneration();
 	const uint64 downloadGen = theApp->downloadqueue->GetListGeneration();
 	if (m_haveListGen && sharedGen == m_lastSharedGen && downloadGen == m_lastDownloadGen) {
 		return;
 	}
 
-	// Stamp every encoder whose file is still listed with this epoch; the
-	// sweep below then takes anything left behind. This used to build a set
-	// of the live ECIDs instead, which cost a red-black-tree insertion per
-	// file plus a lookup per encoder in the sweep -- on every poll, for every
-	// connected client, to find the handful of files that actually came or
-	// went. The stamp is a store through a pointer each loop already holds.
+	// Stamp every encoder whose file is still listed with this epoch; the sweep
+	// below then takes anything left behind. This used to build a set of the live
+	// ECIDs instead, costing a tree insertion per file plus a lookup per encoder
+	// in the sweep, on every poll, to find the handful of files that moved.
 	const uint64 epoch = ++m_epoch;
 	// Downloads
 	std::vector<CPartFile *> downloads;
@@ -357,11 +339,10 @@ void CFileEncoderMap::UpdateEncoders(IDSet *freshEcids)
 			it->second->SetSeenEpoch(epoch);
 		}
 	}
-	// Merge before the shares pass, not after both. A partfile appears in
-	// both lists, and the check below asks whether this reconcile has already
-	// reached it -- which it answers with find(). Leaving the new entries
-	// unmerged would hide them from that lookup and build a second encoder
-	// for the same ECID.
+	// Merge before the shares pass, not after both. A partfile appears in both
+	// lists, and the check below asks whether this reconcile has already reached
+	// it -- which it answers with find(). Leaving the new entries unmerged would
+	// hide them from that lookup and build a second encoder for the same ECID.
 	FlushPending();
 	// Shares
 	std::vector<CKnownFile *> shares;
@@ -390,10 +371,8 @@ void CFileEncoderMap::UpdateEncoders(IDSet *freshEcids)
 	FlushPending();
 
 	// Anything still carrying an older stamp has lost its file. Delete those
-	// encoders and close the gaps in one pass, preserving order. This used to
-	// collect the dead into a set and then erase them one at a time, each
-	// erase being a fresh lookup; compacting in place is a single sweep and
-	// keeps the array contiguous for the walk that reads it next.
+	// encoders and close the gaps in one pass, preserving order. Collecting the
+	// dead into a set and erasing one at a time made every erase a fresh lookup.
 	iterator out = m_entries.begin();
 	for (iterator it = m_entries.begin(); it != m_entries.end(); ++it) {
 		if (it->second->GetSeenEpoch() != epoch) {
@@ -407,25 +386,20 @@ void CFileEncoderMap::UpdateEncoders(IDSet *freshEcids)
 	}
 	m_entries.erase(out, m_entries.end());
 
-	// Record what this pass reconciled against, so the next one can tell
-	// whether anything moved. Set here rather than next to the read above so
-	// an exception part-way through leaves the map looking un-reconciled and
-	// the next poll redoes it.
+	// Record what this pass reconciled against, so the next one can tell whether
+	// anything moved. Set here rather than next to the read above, so an
+	// exception part-way through leaves the map looking un-reconciled.
 	m_lastSharedGen = sharedGen;
 	m_lastDownloadGen = downloadGen;
 	m_haveListGen = true;
 
 	// The GET_UPDATE walk relies on this order to feed the removal merge, and
 	// getting it wrong loses or invents removals silently. Debug-only, and
-	// rejects duplicate ECIDs as well as misordering -- a duplicate would mean
-	// two encoders for one file.
+	// rejects duplicate ECIDs as well as misordering.
 	//
-	// adjacent_find rather than is_sorted: is_sorted requires its comparator to
-	// be a strict weak ordering, and the `<=` needed to reject equal neighbours
-	// is not irreflexive. Hardened standard libraries check exactly that and
-	// abort -- which would land on the debug build this change is verified
-	// against. adjacent_find takes a plain binary predicate with no such
-	// contract.
+	// adjacent_find rather than is_sorted: is_sorted requires a strict weak
+	// ordering, and the `<=` needed to reject equal neighbours is not
+	// irreflexive. Hardened standard libraries check exactly that and abort.
 	assert(std::adjacent_find(
 		       m_entries.begin(), m_entries.end(), [](const value_type &a, const value_type &b) {
 			       return a.first >= b.first;
@@ -466,11 +440,10 @@ private:
 
 	uint64_t m_passwd_salt;
 
-	// The credential this connection authenticated with -- the configured
-	// EC password, or the ephemeral token the core issued to the amuleapi
-	// it spawned. Per-socket precisely because two clients may be using
-	// different credentials at the same time; ActivateAEAD() keys the
-	// session from this rather than re-reading preferences.
+	// The credential this connection authenticated with -- the configured EC
+	// password, or the ephemeral token the core issued to the amuleapi it
+	// spawned. Per-socket precisely because two clients may be using different
+	// credentials at once; ActivateAEAD() keys the session from this.
 	wxString m_authSecret;
 
 	// Transport encryption, chosen during EC_OP_AUTH_REQ and only turned on
@@ -479,8 +452,7 @@ private:
 	uint8_t m_aeadCipher;
 	// Set when the client offered encryption (CAN_AEAD + a nonce) but sent no
 	// usable public key. Such a peer is provably new enough to send one, so the
-	// offer is malformed and the login is refused rather than degraded to clear
-	// even on a permissive daemon.
+	// offer is malformed and the login is refused rather than degraded to clear.
 	bool m_aeadOfferMalformed;
 	std::vector<uint8_t> m_aeadServerNonce;
 	std::vector<uint8_t> m_aeadClientNonce;
@@ -488,8 +460,8 @@ private:
 
 	// The X25519 shared secret, and the only thing the channel key is derived
 	// from. Our ephemeral private key is wiped as soon as this exists, and this
-	// is wiped once the keys are derived, so an unauthenticated peer that never
-	// gets past the password check leaves nothing behind either.
+	// is wiped once the keys are derived, so a peer that never gets past the
+	// password check leaves nothing behind.
 	std::vector<uint8_t> m_aeadShared;
 
 	/// Run the key exchange, pick a cipher, and add our half of the salt.
@@ -519,77 +491,63 @@ private:
 	// queue. See WriteDoneAndQueueEmpty for the full reasoning.
 	int m_notification_dispatch_depth;
 
-	// EC INC_UPDATE skip-unchanged state. `m_lastEcGenSeen*` values are
-	// the highest `CKnownFile::s_globalEcGen` already reflected in the
-	// client's view *for that particular request path* — files with a
-	// smaller `m_ecGen` did not change since the last response of that
-	// path and can be skipped this cycle. Three independent counters
-	// because the request paths interleave on different schedules:
-	//   * `m_lastEcGenSeen`        — `EC_OP_GET_UPDATE`        (amulegui)
-	//   * `m_lastEcGenSeenShared`  — `EC_OP_GET_SHARED_FILES`  (amuleweb)
-	//   * `m_lastEcGenSeenPart`    — `EC_OP_GET_DLOAD_QUEUE`   (amuleweb)
+	// EC INC_UPDATE skip-unchanged state. `m_lastEcGenSeen*` values are the
+	// highest `CKnownFile::s_globalEcGen` already reflected in the client's view
+	// *for that particular request path* -- files with a smaller `m_ecGen` did
+	// not change since that path's last response and are skipped. Three
+	// independent counters because the request paths interleave on different
+	// schedules: GET_UPDATE (amulegui), GET_SHARED_FILES and GET_DLOAD_QUEUE
+	// (both amuleweb).
 	uint64 m_lastEcGenSeen;
 	uint64 m_lastEcGenSeenShared;
 	uint64 m_lastEcGenSeenPart;
 
-	// Client opted in to partial-update protocol at auth time (advertised
-	// `EC_TAG_CAN_PARTIAL_UPDATE`). When set, `Get_EC_Response_GetUpdate`
-	// skips unchanged files entirely and emits explicit `EC_TAG_FILE_REMOVED`
-	// markers for files that disappeared since the previous cycle; the
-	// client mirrors this by skipping its bulk deletion loop. When *not*
-	// set, the server falls back to emitting empty "alive marker" tags for
-	// unchanged files so old clients (which infer deletion from absence)
-	// keep working unchanged — see `Get_EC_Response_GetUpdate`.
+	// Client opted in to the partial-update protocol at auth time (advertised
+	// `EC_TAG_CAN_PARTIAL_UPDATE`). When set, Get_EC_Response_GetUpdate skips
+	// unchanged files entirely and emits explicit EC_TAG_FILE_REMOVED markers;
+	// the client mirrors this by skipping its bulk deletion loop. When not set,
+	// the server emits empty "alive marker" tags for unchanged files so old
+	// clients, which infer deletion from absence, keep working.
 	bool m_partialUpdateActive;
 
 	// Client negotiated `EC_TAG_CAN_PARTIAL_SEARCH`: the multi-search results
 	// union may skip results whose exported fields are unchanged and report
-	// removals with explicit `EC_TAG_FILE_REMOVED` tombstones. Separate from
-	// `m_partialUpdateActive` on purpose -- see EC_TAG_CAN_PARTIAL_SEARCH in
-	// RemoteConnect.cpp for why reusing that flag would break an older
-	// amuleGUI, which advertises it but still deletes any result absent from
-	// the reply.
+	// removals with explicit EC_TAG_FILE_REMOVED tombstones. Separate from
+	// m_partialUpdateActive on purpose -- reusing that flag would break an older
+	// amuleGUI, which advertises it but still deletes any absent result.
 	bool m_partialSearchActive;
 	// Client opted in to the multi-search protocol at auth time (advertised
 	// `EC_TAG_CAN_MULTI_SEARCH`). When set, the EC search handlers allocate a
-	// distinct daemon-side search ID per `EC_OP_SEARCH_START` (returned via
-	// `EC_TAG_SEARCH_ID`) and address results/progress/stop by that ID, so the
-	// client can run several concurrent searches. When *not* set, the legacy
-	// single-search path runs verbatim (the `0xffffffff` sentinel bucket,
-	// wipe-on-start, parameterless stop) so old clients keep working.
+	// distinct daemon-side search ID per EC_OP_SEARCH_START and address
+	// results/progress/stop by it. When not set, the legacy single-search path
+	// runs verbatim (0xffffffff sentinel bucket, wipe-on-start, parameterless
+	// stop) so old clients keep working.
 	bool m_multiSearchActive;
 	// Set when the client advertised `EC_TAG_CAN_SEARCH_PROGRESS_UNION`: an
-	// `EC_OP_SEARCH_PROGRESS` carrying no `EC_TAG_SEARCH_ID` reports every
-	// search this connection could hold a tab for, one child per search,
-	// instead of a single search's progress. Only consulted together with
-	// `m_multiSearchActive` — a single-search client's id-less request keeps
-	// meaning "the current search" (amulecmd's `search progress`).
+	// EC_OP_SEARCH_PROGRESS carrying no EC_TAG_SEARCH_ID reports every search
+	// this connection could hold a tab for, one child each. Only consulted
+	// together with m_multiSearchActive -- a single-search client's id-less
+	// request keeps meaning "the current search".
 	bool m_searchProgressUnionActive;
 	// Set when the client advertised EC_TAG_CAN_CHAT: it speaks the chat
 	// session ops (EC_OP_GET_CHAT_SESSIONS and friends). A client that omits
 	// the tag never sees the capability echoed and must never send those
 	// opcodes — an unknown opcode asserts before the EC_OP_FAILED path.
 	bool m_chatActive;
-	// File ECIDs sent in the previous response for each EC request path.
-	// Diffed against the current snapshot to compute the removal list emitted
-	// to partial-update-capable clients. Tracked per-path because amulegui
-	// uses `EC_OP_GET_UPDATE` (mixed shared + partfile, served by
-	// `Get_EC_Response_GetUpdate`) while amuleweb drives two separate
-	// INC_UPDATE streams via `EC_OP_GET_SHARED_FILES` and
-	// `EC_OP_GET_DLOAD_QUEUE` (each served by its own handler).
+	// File ECIDs sent in the previous response for each EC request path, diffed
+	// against the current snapshot to compute the removal list emitted to
+	// partial-update-capable clients. Tracked per-path because amulegui uses
+	// EC_OP_GET_UPDATE while amuleweb drives two separate INC_UPDATE streams.
 	//
 	// `m_lastSentFileIds` is held sorted ascending in a vector rather than a
-	// std::set: `Get_EC_Response_GetUpdate` walks the encoder map, which is
-	// keyed by ECID, so the current IDs come out already in order and the
-	// diff is a linear merge over two contiguous arrays -- where the set
-	// cost a tree insertion per file to build and a tree lookup per file to
-	// diff, on every poll, whether or not anything had changed.
+	// std::set: Get_EC_Response_GetUpdate walks the encoder map, which is keyed
+	// by ECID, so the current IDs come out already in order and the diff is a
+	// linear merge over two contiguous arrays -- where the set cost a tree
+	// insertion per file to build and a lookup per file to diff, on every poll.
 	//
-	// The other two keep the set. Their handlers iterate a CopyFileList
-	// snapshot, which is neither ECID-ordered nor necessarily the whole
-	// list (`queryitems` filters it), so neither the ordering the merge
-	// needs nor the encoder-in-hand the mask below needs is available
-	// without paying for a lookup that would cancel the saving out.
+	// The other two keep the set: their handlers iterate a CopyFileList snapshot,
+	// which is neither ECID-ordered nor necessarily the whole list, so the
+	// ordering the merge needs is not available without paying for a lookup.
 	std::vector<uint32> m_lastSentFileIds;
 	std::set<uint32> m_lastSentSharedFileIds;
 	std::set<uint32> m_lastSentPartFileIds;
@@ -597,38 +555,29 @@ private:
 	// path), which addresses one search at a time.
 	std::set<uint32> m_lastSentSearchIds;
 
-	// Result ECIDs last sent on the `EC_DETAIL_INC_UPDATE` union poll
-	// (amulegui), so `Get_EC_Response_Search_Results_Union` can emit
-	// `EC_TAG_FILE_REMOVED` for results that are gone instead of relying on
-	// absence. Separate from `m_lastSentSearchIds` above: that one belongs
-	// to amuleweb's per-search `EC_DETAIL_UPDATE` path and tracks a
-	// different set on a different schedule.
+	// Result ECIDs last sent on the EC_DETAIL_INC_UPDATE union poll (amulegui),
+	// so Get_EC_Response_Search_Results_Union can emit EC_TAG_FILE_REMOVED for
+	// results that are gone instead of relying on absence. Separate from
+	// m_lastSentSearchIds, which belongs to amuleweb's per-search path.
 	//
-	// Only populated for clients that negotiated `EC_TAG_CAN_PARTIAL_UPDATE`.
-	// A legacy client keeps the bulk "anything missing == deleted" rule, so
-	// the union must keep re-sending every result to it and there is nothing
-	// to track.
+	// Only populated for clients that negotiated EC_TAG_CAN_PARTIAL_UPDATE: a
+	// legacy client keeps the bulk "anything missing == deleted" rule, so the
+	// union must keep re-sending every result and there is nothing to track.
 	std::set<uint32> m_lastSentSearchResultIds;
 
-	// Which file ECIDs have already been sent to the client with full detail
-	// (EC_DETAIL_INC_UPDATE / EC_DETAIL_UPDATE payload, not the legacy
-	// childless alive-marker or the partial-update skip-silently path) now
+	// Whether a file has already been sent to the client with full detail now
 	// lives as a flag on the encoder itself -- see
-	// CKnownFile_Encoder::WasSentOnUpdatePath. It used to be three per-path
-	// sets here, each costing a tree lookup per file on every poll to answer
-	// a question the encoder was already in a position to answer.
+	// CKnownFile_Encoder::WasSentOnUpdatePath. It used to be three per-path sets
+	// here, each costing a tree lookup per file on every poll to answer a
+	// question the encoder was already in a position to answer.
 	//
-	// Keeping it on the encoder also bounds it. The sets were only ever
-	// inserted into: an ECID whose file went away stayed in them for the life
-	// of the connection, so a long-lived client on a churning library grew
-	// them without limit. An encoder is destroyed with its file, and a
-	// re-created one starts at zero, which is exactly the "re-send full
-	// detail" state the freshEcids handling used to arrange by erasing.
+	// Keeping it on the encoder also bounds it. The sets were only ever inserted
+	// into, so an ECID whose file went away stayed for the life of the
+	// connection. An encoder is destroyed with its file, and a re-created one
+	// starts at zero -- exactly the "re-send full detail" state wanted.
 	//
 	// The two amuleweb paths keep their sets, for the reason given on
-	// `m_lastSentSharedFileIds` above: they iterate a snapshot rather than
-	// the encoder map, so reaching the encoder to read a mask would cost the
-	// lookup the mask exists to avoid.
+	// m_lastSentFileIds above.
 	std::set<uint32> m_sentWithDetailIdsShared;
 	std::set<uint32> m_sentWithDetailIdsPart;
 };
@@ -694,9 +643,8 @@ void CECServerSocket::NegotiateAEAD(const CECPacket *request, CECPacket *respons
 	if (clientPubTag == nullptr || clientPubTag->GetTagDataLen() != ECCrypt::X25519_KEY_LEN) {
 		// Not an older client -- encryption has never shipped, so anything that
 		// offers it at all is new enough to send a key. A keyless offer is
-		// therefore malformed (or a middlebox that stripped the key), and the
-		// login is refused in the auth decision rather than degraded to clear,
-		// even on a permissive daemon.
+		// therefore malformed, or a middlebox stripped the key, and the login is
+		// refused rather than degraded to clear.
 		m_aeadOfferMalformed = true;
 		AddDebugLogLineN(logEC, "AEAD: offer without a usable public key, refusing the login");
 		return;
@@ -705,10 +653,9 @@ void CECServerSocket::NegotiateAEAD(const CECPacket *request, CECPacket *respons
 	const uint8_t *offered = (const uint8_t *)offer->GetTagData();
 	const uint16_t offeredLen = offer->GetTagDataLen();
 
-	// The client prefers Cipher_ChaCha20_Poly1305, probably because it doesn't support
-	// hardware AES, let's make our client happy.
-	// If a third cipher is ever added, please update all the logic below and SupportedCiphers()
-	// to make sure you send and select the intended ciphers
+	// The client prefers Cipher_ChaCha20_Poly1305, probably because it has no
+	// hardware AES. If a third cipher is ever added, update all the logic below
+	// and SupportedCiphers() to match.
 	if (offeredLen && offered[0] == ECCrypt::Cipher_ChaCha20_Poly1305 &&
 		ECCrypt::IsCipherSupported(ECCrypt::Cipher_ChaCha20_Poly1305))
 		m_aeadCipher = ECCrypt::Cipher_ChaCha20_Poly1305;
@@ -739,9 +686,9 @@ void CECServerSocket::NegotiateAEAD(const CECPacket *request, CECPacket *respons
 		return;
 	}
 
-	// Our ephemeral half. Generated per connection and never stored: that is
-	// what makes a recording of this session unreadable later, even to someone
-	// who by then holds the EC password.
+	// Our ephemeral half. Generated per connection and never stored: that is what
+	// makes a recording of this session unreadable later, even to someone who by
+	// then holds the EC password.
 	std::vector<uint8_t> ephPriv;
 	std::vector<uint8_t> ephPub;
 	if (!ECCrypt::GenerateX25519KeyPair(ephPriv, ephPub)) {
@@ -769,10 +716,10 @@ void CECServerSocket::NegotiateAEAD(const CECPacket *request, CECPacket *respons
 	const uint8_t *clientNonceData = (const uint8_t *)clientNonceTag->GetTagData();
 	m_aeadClientNonce.assign(clientNonceData, clientNonceData + clientNonceTag->GetTagDataLen());
 
-	// Transcript: everything both sides exchanged, taken exactly as it reached
-	// us. If any of it was edited in flight our derivation differs from the
-	// client's and the first sealed packet fails, instead of the session
-	// dropping to whatever the attacker preferred.
+	// Transcript: everything both sides exchanged, taken exactly as it reached us.
+	// If any of it was edited in flight our derivation differs from the client's
+	// and the first sealed packet fails, instead of the session dropping to
+	// whatever the attacker preferred.
 	const std::vector<uint8_t> offeredVec(offered, offered + offeredLen);
 	m_aeadTranscript = ECCrypt::BuildTranscript(
 		offeredVec, m_aeadCipher, m_aeadClientNonce, m_aeadServerNonce, clientPub, ephPub);
@@ -832,11 +779,9 @@ void CECServerSocket::ActivateAEAD()
 		return;
 	}
 	// Keyed from the ephemeral exchange and nothing else. It used to be keyed
-	// from whichever credential this connection authenticated with, which is
-	// what made a session recorded today readable by anyone who learns the
-	// password tomorrow. The credential still has to be proved -- by the
-	// password check and the confirmation tags -- but it no longer opens the
-	// channel.
+	// from whichever credential this connection authenticated with, which made a
+	// session recorded today readable by anyone who learns the password tomorrow.
+	// The credential still has to be proved, but it no longer opens the channel.
 	if (!SetupAEAD(m_aeadCipher,
 		    m_aeadShared,
 		    m_aeadServerNonce,
@@ -875,14 +820,12 @@ const CECPacket *CECServerSocket::OnPacketReceived(const CECPacket *packet, uint
 		reply = Authenticate(packet);
 	} else {
 		if (IsCryptReady() && !WasLastPacketEncrypted()) {
-			// The session negotiated encryption, so every packet past the
-			// handshake must arrive sealed. A cleartext packet here is an
-			// injection attempt: our sealed replies stay confidential, but
-			// executing an unauthenticated cleartext command with this
-			// session's authority is not something to allow. Drop the
-			// connection rather than process it. The one legitimate clear
-			// packet, a terminal AUTH_FAIL, only ever arrives before
-			// CONN_ESTABLISHED.
+			// The session negotiated encryption, so every packet past the handshake
+			// must arrive sealed. A cleartext packet here is an injection attempt:
+			// our sealed replies stay confidential, but executing an
+			// unauthenticated cleartext command with this session's authority is
+			// not something to allow. The one legitimate clear packet, a terminal
+			// AUTH_FAIL, only ever arrives before CONN_ESTABLISHED.
 			AddDebugLogLineN(logEC, "EC: cleartext packet on an encrypted session, dropping");
 			CloseSocket();
 			return nullptr;
@@ -907,44 +850,32 @@ void CECServerSocket::WriteDoneAndQueueEmpty()
 	}
 
 	// CECSocket::OnOutput drains the per-socket output queue, then calls
-	// WriteDoneAndQueueEmpty to pull the next notification packet. The
-	// chain runs synchronously on the main thread:
+	// WriteDoneAndQueueEmpty to pull the next notification packet. The chain runs
+	// synchronously on the main thread:
 	//
 	//   WriteDoneAndQueueEmpty -> SendPacket -> WritePacket + OnOutput
 	//     -> OnOutput drains queue -> WriteDoneAndQueueEmpty -> ...
 	//
-	// On a busy amuled (many peers / files generating notifications) the
-	// ECNotifier always has the next packet ready, so the recursion never
-	// bottoms out. The main thread stays inside this chain processing the
-	// notifier feed and never yields back to the wx event loop. That
-	// starves every other event -- including LibSocketLost from a
-	// half-closed EC peer, which is what CECServerSocket::OnLost needs
-	// to fire so it can tear the dead socket down.
+	// On a busy amuled the ECNotifier always has the next packet ready, so the
+	// recursion never bottoms out: the main thread stays inside this chain and
+	// never yields back to the wx event loop, starving every other event --
+	// including the LibSocketLost a half-closed EC peer needs to be torn down.
+	// With the peer in kernel CLOSE-WAIT, writes silently succeed against the
+	// dead buffer and amuled spins indefinitely flushing to nowhere.
 	//
-	// In the wedged-amuleweb scenario reported in #666, the peer is in
-	// kernel CLOSE-WAIT, writes silently succeed against the dead
-	// kernel buffer, and amuled spins indefinitely flushing the
-	// notifier to nowhere -- amulegui can't connect because the main
-	// thread is permanently occupied.
-	//
-	// Cap the dispatch depth so the chain returns to the event loop
-	// every MAX_DEPTH packets. The pending asio LibSocketSend
-	// completions (or LibSocketLost, if the peer has gone away) get
-	// processed in between; on a healthy peer the loop simply resumes
-	// when OnSend re-enters via the next completion.
+	// Cap the dispatch depth so the chain returns to the event loop every
+	// MAX_DEPTH packets. Pending asio completions get processed in between; on a
+	// healthy peer the loop resumes when OnSend re-enters via the next one.
 	static const int MAX_DEPTH = 8;
 	if (m_notification_dispatch_depth >= MAX_DEPTH) {
 		return;
 	}
 
-	// ECNotifier::GetNextPacket returns a fresh new CECPacket(...) and
-	// the caller owns it; SendPacket(const CECPacket*) only serialises
-	// it into the per-socket output queue and never deletes.  Hand the
-	// raw pointer to a smart pointer so the CECPacket (and its CECTag
-	// tree) get freed at scope exit instead of leaking on every
-	// notification dispatch.  Pre-fix, the EC notification path was
-	// the dominant retained-bytes leak on long-running amuled with
-	// connected amulegui / amuleweb peers (#765).
+	// ECNotifier::GetNextPacket returns a fresh new CECPacket and the caller owns
+	// it; SendPacket only serialises it into the per-socket output queue and
+	// never deletes. Hand the raw pointer to a smart pointer so the packet and
+	// its CECTag tree are freed at scope exit -- pre-fix this path was the
+	// dominant retained-bytes leak on a long-running amuled with peers attached.
 	CSmartPtr<CECPacket> packet(m_ec_notifier->GetNextPacket(this));
 	if (!packet) {
 		return;
@@ -966,12 +897,9 @@ ExternalConn::ExternalConn(amuleIPV4Address addr, wxString *msg)
 // Defaults are ten failures a minute, then five minutes out -- deliberately
 // looser than amuleapi's five, because an EC client retries on its own:
 // amulegui reconnects on a dropped link, so a saved password that has gone
-// stale burns attempts with no human in the loop, and a tight threshold would
-// lock out someone who never typed anything. Ten still caps a guesser at nine
-// attempts a minute against the thousands per second possible before this.
-//
-// Read once at construction, so changing them takes a restart -- the same as
-// every other setting on this listener, which is rebuilt at startup anyway.
+// stale burns attempts with no human in the loop. Ten still caps a guesser at
+// nine attempts a minute. Read once at construction, so changing them takes a
+// restart -- the same as every other setting on this listener.
 : m_authRateLimiter(CRateLimiter::Config{ thePrefs::ECAuthFailureWindowSeconds(),
 	  thePrefs::ECAuthFailureThreshold(),
 	  thePrefs::ECAuthLockoutSeconds() })
@@ -1064,15 +992,12 @@ void CExternalConnListener::OnAccept()
 	// non-blocking accept (although if we got here, there
 	// should ALWAYS be a pending connection).
 	if (AcceptWith(*sock, false)) {
-		// Apply the EC socket options on the freshly-accepted
-		// server-side socket, symmetrically with what the client just
-		// enabled on its end: keepalive so amuled detects a half-open
-		// EC client (gui process killed, network blip, FIN lost)
-		// instead of sitting on the dead connection for the default
-		// ~2h TCP retransmit timeout, holding the CECServerSocket and
-		// its m_ec_notifier reference; and TCP_NODELAY, which only
-		// removes the ~40 ms Nagle/delayed-ACK stall on the replies we
-		// send if it is set on this end too.
+		// Apply the EC socket options on the freshly-accepted server-side socket,
+		// symmetrically with what the client just enabled on its end: keepalive,
+		// so amuled detects a half-open EC client instead of sitting on the dead
+		// connection for the ~2h TCP retransmit timeout while holding the
+		// CECServerSocket and its notifier reference; and TCP_NODELAY, which only
+		// removes the ~40 ms Nagle stall if it is set on this end too.
 		sock->ApplyEcSocketOptions();
 		AddLogLineN(_("New external connection accepted"));
 	} else {
@@ -1138,10 +1063,10 @@ const CECPacket *CECServerSocket::Authenticate(const CECPacket *request)
 				response = new CECPacket(EC_OP_AUTH_SALT);
 				response->AddTag(CECTag(EC_TAG_PASSWD_SALT, m_passwd_salt));
 				m_conn_state = CONN_SALT_SENT;
-				// Transport encryption. Pick the first cipher we can do from
-				// the client's list -- its order is its preference -- and
-				// answer with our half of the derivation salt. Keys are only
-				// derived once the password checks out, below.
+				// Transport encryption. Pick the first cipher we can do from the
+				// client's list -- its order is its preference -- and answer with our
+				// half of the derivation salt. Keys are only derived once the password
+				// checks out, below.
 				NegotiateAEAD(request, response);
 				//
 				// So far ok, check capabilities of client
@@ -1149,18 +1074,14 @@ const CECPacket *CECServerSocket::Authenticate(const CECPacket *request)
 				if (request->GetTagByName(EC_TAG_CAN_ZLIB)) {
 					m_my_flags |= EC_FLAG_ZLIB;
 				}
-				// Honour the client's prefer-no-ZLIB hint: when set, the
-				// client believes transit between us is fast (loopback /
-				// LAN) and per-packet deflate/inflate is wasted CPU. The
-				// decision lives on the client because only the client
-				// knows the IP it dialed; the server's peer-IP view
-				// would misclassify e.g. WireGuard tunnel endpoints as
-				// "local" when the underlying transit is anything but.
-				// CECSocket::WritePacket honours the resulting
-				// `m_isLocalPeer` flag per packet, falling back to ZLIB
-				// for payloads above `kLocalPeerZlibBypassMax` so very
-				// large responses still stay inside the receiver's
-				// 256 MB ReadHeader gate.
+				// Honour the client's prefer-no-ZLIB hint: when set, the client believes
+				// transit between us is fast (loopback / LAN) and per-packet deflate is
+				// wasted CPU. The decision lives on the client because only the client
+				// knows the IP it dialed; the server's peer-IP view would misclassify a
+				// WireGuard tunnel endpoint as "local". CECSocket::WritePacket honours
+				// the resulting `m_isLocalPeer` flag per packet, falling back to ZLIB
+				// above kLocalPeerZlibBypassMax so large responses stay inside the
+				// receiver's 256 MB ReadHeader gate.
 				if (request->GetTagByName(EC_TAG_PREFER_NO_ZLIB)) {
 					SetLocalPeer(true);
 					AddDebugLogLineN(logEC,
@@ -1172,20 +1093,17 @@ const CECPacket *CECServerSocket::Authenticate(const CECPacket *request)
 					m_my_flags |= EC_FLAG_UTF8_NUMBERS;
 				}
 				if (request->GetTagByName(EC_TAG_CAN_LARGE_TAG_COUNT)) {
-					// Client can decode the sentinel-extended children-
-					// count format in CECTag::WriteChildren (#199). Only
-					// new clients send this tag; old clients omit it
-					// and we keep the wire format capped at uint16.
+					// Client can decode the sentinel-extended children-count format in
+					// CECTag::WriteChildren. Only new clients send this tag; old ones
+					// omit it and the wire format stays capped at uint16.
 					m_my_flags |= EC_FLAG_LARGE_TAG_COUNT;
 				}
 				if (request->GetTagByName(EC_TAG_CAN_PARTIAL_UPDATE)) {
 					// Client understands the partial-update protocol:
-					// `Get_EC_Response_GetUpdate` may omit unchanged
-					// files and emit explicit `EC_TAG_FILE_REMOVED`
-					// markers instead of relying on absence-implies-
-					// deletion. Old clients omit this tag and we keep
-					// the backward-compat alive-marker path active for
-					// them — see `Get_EC_Response_GetUpdate`.
+					// Get_EC_Response_GetUpdate may omit unchanged files and emit
+					// explicit EC_TAG_FILE_REMOVED markers instead of relying on
+					// absence-implies-deletion. Old clients omit this tag and keep the
+					// backward-compat alive-marker path.
 					m_partialUpdateActive = true;
 				}
 				if (request->GetTagByName(EC_TAG_CAN_PARTIAL_SEARCH)) {
@@ -1195,30 +1113,25 @@ const CECPacket *CECServerSocket::Authenticate(const CECPacket *request)
 					m_partialSearchActive = true;
 				}
 				if (request->GetTagByName(EC_TAG_CAN_MULTI_SEARCH)) {
-					// Client understands the multi-search protocol: EC
-					// searches are addressed by a daemon-allocated
-					// `EC_TAG_SEARCH_ID` (returned on start) instead of the
-					// single `0xffffffff` sentinel, so several can run at
-					// once. Old clients omit this tag and keep the legacy
-					// single-search sentinel path — see the search handlers.
+					// Client understands the multi-search protocol: EC searches are
+					// addressed by a daemon-allocated EC_TAG_SEARCH_ID instead of the
+					// single 0xffffffff sentinel, so several can run at once. Old clients
+					// omit this tag and keep the legacy sentinel path.
 					m_multiSearchActive = true;
 				}
 				if (request->GetTagByName(EC_TAG_CAN_SEARCH_PROGRESS_UNION)) {
-					// Client reads an id-less EC_OP_SEARCH_PROGRESS as "every
-					// open search", each reported as a child tag, so it polls
-					// once instead of once per search. Only honoured together
-					// with multi-search: for a single-search client an id-less
-					// request still means "the current search", which is what
-					// amulecmd's `search progress` with no argument expects.
+					// Client reads an id-less EC_OP_SEARCH_PROGRESS as "every open
+					// search", each reported as a child tag, so it polls once instead of
+					// once per search. Only honoured together with multi-search: for a
+					// single-search client an id-less request still means "the current
+					// search", which amulecmd's `search progress` expects.
 					m_searchProgressUnionActive = true;
 				}
 				if (request->GetTagByName(EC_TAG_CAN_CHAT_SESSIONS)) {
 					// Client speaks the chat session ops. Its own tag, NOT
-					// EC_TAG_CAN_CHAT: that one is echoed by daemons which
-					// predate these opcodes, so a client gating on it would
-					// send EC_OP_GET_CHAT_SESSIONS to a core that asserts on
-					// it. A client that omits this tag never sees the echo
-					// and must never send those opcodes.
+					// EC_TAG_CAN_CHAT: that one is echoed by daemons which predate these
+					// opcodes, so a client gating on it would send
+					// EC_OP_GET_CHAT_SESSIONS to a core that asserts on it.
 					m_chatActive = true;
 				}
 				m_haveNotificationSupport = request->GetTagByName(EC_TAG_CAN_NOTIFY) != NULL;
@@ -1245,19 +1158,16 @@ const CECPacket *CECServerSocket::Authenticate(const CECPacket *request)
 		const CECTag *passwd = request->GetTagByName(EC_TAG_PASSWD_HASH);
 		CMD4Hash passh;
 
-		// Brute-force guard, ahead of every credential path. Keyed on the
-		// address alone rather than address+port, or each reconnect would
-		// look like a new client and reset the count -- which is precisely
-		// what a guesser does between attempts.
+		// Brute-force guard, ahead of every credential path. Keyed on the address
+		// alone rather than address+port, or each reconnect would look like a new
+		// client and reset the count -- which is what a guesser does anyway.
 		const std::string peerIp(wxString(GetIP()).ToStdString());
 		const CRateLimiter::Decision throttle =
 			theApp->ECServerHandler->AuthRateLimiter().Check(peerIp);
 		if (throttle.locked_out) {
-			// Say so explicitly instead of reusing "wrong password": the
-			// client is being refused for a different reason, and a user
-			// who has just fixed their password deserves to know why it
-			// still fails. It tells an attacker nothing they cannot infer
-			// from being refused anyway.
+			// Say so explicitly instead of reusing "wrong password": a user who has
+			// just fixed their password deserves to know why it still fails, and it
+			// tells an attacker nothing they cannot infer from being refused.
 			const wxString err = CFormat(wxGetTranslation(wxTRANSLATE(
 						     "Too many failed connection attempts; try again "
 						     "in %d seconds."))) %
@@ -1277,30 +1187,22 @@ const CECPacket *CECServerSocket::Authenticate(const CECPacket *request)
 
 			passh.Decode(MD5Sum(thePrefs::ECPassword().Lower() + saltHash).GetHash());
 
-			// Second accepted credential: the ephemeral token the core
-			// issued to the amuleapi it spawned, so that daemon never
-			// needs the password-equivalent value out of amule.conf.
-			//
-			// Empty when no token was issued, and an empty token must
-			// never authenticate anyone -- so the emptiness is tested
-			// here rather than relying on a digest of "" failing to
-			// collide.
+			// Second accepted credential: the ephemeral token the core issued to the
+			// amuleapi it spawned, so that daemon never needs the
+			// password-equivalent value out of amule.conf. Empty when no token was
+			// issued, and an empty token must never authenticate anyone -- so the
+			// emptiness is tested here rather than relying on a digest of "".
 			const wxString &ecToken = theApp->GetEcToken();
 			CMD4Hash tokenh;
 			const bool tokenUsable = !ecToken.IsEmpty() &&
 						 tokenh.Decode(MD5Sum(ecToken.Lower() + saltHash).GetHash());
 
 			// Compare against both without short-circuiting. The naive
-			// `if (pw) ... else if (token) ...` leaks which credential
-			// matched through timing, and -- more usefully to an attacker
-			// -- whether a token is live at all. Both branches are
-			// evaluated and the results OR'd, so acceptance is one
-			// decision.
-			//
-			// The per-comparison timing is not itself a concern: the
-			// digests are salted per connection, so anything learned about
-			// one is stale on the next, and the rate limiter above bounds
-			// attempts regardless.
+			// `if (pw) ... else if (token) ...` leaks which credential matched
+			// through timing, and -- more usefully to an attacker -- whether a
+			// token is live at all. Both branches are evaluated and OR'd, so
+			// acceptance is one decision. The per-comparison timing is not itself
+			// a concern: the digests are salted per connection.
 			const bool matchedPassword = passwd && passwd->GetMD4Data() == passh;
 			const bool matchedToken = passwd && tokenUsable && passwd->GetMD4Data() == tokenh;
 			const bool credentialOk = matchedPassword || matchedToken;
@@ -1309,29 +1211,23 @@ const CECPacket *CECServerSocket::Authenticate(const CECPacket *request)
 			// to be checked against the token and not the configured password.
 			const wxString authSecret = matchedPassword ? thePrefs::ECPassword() : ecToken;
 
-			// Whether that same client also ran the key exchange we completed.
-			// The password check cannot tell us: a relay forwards the challenge
-			// response untouched and passes it, but it has to run its own
-			// exchange with each of us, so its two transcripts differ and this
-			// tag cannot be right on both legs. Vacuously true on a session
-			// with no encryption, where there is no exchange to confirm.
+			// Whether that same client also ran the key exchange we completed. The
+			// password check cannot tell us: a relay forwards the challenge response
+			// untouched and passes it, but it has to run its own exchange with each
+			// of us, so its two transcripts differ and this tag cannot be right on
+			// both legs. Vacuously true on a session with no encryption.
 			const bool confirmOk = !credentialOk || m_aeadCipher == ECCrypt::Cipher_None ||
 					       VerifyClientConfirm(request, authSecret);
 
-			// Operator policy: refuse anything that did not negotiate
-			// encryption. Checked ahead of the password so the client gets
-			// the real reason rather than a misleading "wrong password",
-			// and it costs an unauthenticated peer nothing it could not
-			// discover by simply trying. Deliberately flat rather than
-			// keyed on the peer address: only the client knows what it
-			// dialed, and this side's view misclassifies tunnels.
+			// Operator policy: refuse anything that did not negotiate encryption.
+			// Checked ahead of the password so the client gets the real reason
+			// rather than a misleading "wrong password". Deliberately flat rather
+			// than keyed on the peer address: only the client knows what it dialed.
 			if (m_aeadOfferMalformed) {
 				// The client offered encryption but sent no usable public key.
-				// Encryption has never shipped, so a peer that offers it at all
-				// is new enough to send a key: a keyless offer is malformed, or
-				// an on-path attacker stripping the key, not an older client.
-				// Refuse rather than let it degrade to clear even on a
-				// permissive daemon.
+				// Encryption has never shipped, so a peer that offers it at all is new
+				// enough to send a key: a keyless offer is malformed, or an on-path
+				// attacker stripping the key, not an older client.
 				const wxString err = wxTRANSLATE(
 					"Authentication failed: the client offered an encrypted External "
 					"Connection but sent no usable key.");
@@ -1346,10 +1242,9 @@ const CECPacket *CECServerSocket::Authenticate(const CECPacket *request)
 				response = new CECPacket(EC_OP_AUTH_FAIL);
 				response->AddTag(CECTag(EC_TAG_STRING, err));
 			} else if (credentialOk && !confirmOk) {
-				// Right credential, wrong handshake. Refused rather than
-				// continued in clear: a client that negotiated encryption and
-				// cannot confirm it is either being relayed or is not the
-				// client it claims to be, and neither deserves a session.
+				// Right credential, wrong handshake. Refused rather than continued in
+				// clear: a client that negotiated encryption and cannot confirm it is
+				// either being relayed or is not the client it claims to be.
 				ECCrypt::SecureWipe(m_aeadShared);
 				const wxString err = wxTRANSLATE(
 					"Authentication failed: the client could not confirm the encrypted "
@@ -1358,33 +1253,28 @@ const CECPacket *CECServerSocket::Authenticate(const CECPacket *request)
 				response = new CECPacket(EC_OP_AUTH_FAIL);
 				response->AddTag(CECTag(EC_TAG_STRING, err));
 			} else if (passwd && credentialOk) {
-				// One of the two accepted credentials matched, so both ends
-				// hold the same secret and the keys will match. Switch on now
-				// rather than after the reply: EC_OP_AUTH_OK is then itself
-				// sealed, which proves to the client that its peer really does
-				// know the secret -- something the plain challenge never
-				// established.
+				// One of the two accepted credentials matched, so both ends hold the
+				// same secret and the keys will match. Switch on now rather than after
+				// the reply: EC_OP_AUTH_OK is then itself sealed, which proves to the
+				// client that its peer really does know the secret.
 				//
-				// Remember WHICH one for ActivateAEAD: the client keys its
-				// half from the credential it presented, so keying ours from
-				// the configured password regardless would break every
-				// token-authenticated session the moment it was sealed.
+				// Remember WHICH one for ActivateAEAD: the client keys its half from the
+				// credential it presented, so keying ours from the configured password
+				// regardless would break every token-authenticated session.
 				m_authSecret = authSecret;
 				// Clear the bucket: a legitimate user who mistyped a few
 				// times must not carry that streak into their next
 				// connection.
 				theApp->ECServerHandler->AuthRateLimiter().NoteSuccess(peerIp);
-				// Computed before ActivateAEAD wipes what it derives from --
-				// the tag depends only on the transcript, but keeping the
-				// order explicit avoids that becoming a trap later.
+				// Computed before ActivateAEAD wipes what it derives from -- the tag
+				// depends only on the transcript, but keeping the order explicit avoids
+				// that becoming a trap later.
 				const std::vector<uint8_t> serverConfirm = ServerConfirm(authSecret);
 				ActivateAEAD();
 				response = new CECPacket(EC_OP_AUTH_OK);
-				// Short form rather than bare VERSION: on a development
-				// build VERSION is the literal "GIT", so every snapshot
-				// would identify itself identically and a client could
-				// not tell which revision it is talking to. No change on
-				// a tagged release, where GITDATE is undefined.
+				// Short form rather than bare VERSION: on a development build VERSION is
+				// the literal "GIT", so every snapshot would identify itself
+				// identically. No change on a tagged release, where GITDATE is undefined.
 				response->AddTag(CECTag(EC_TAG_SERVER_VERSION, GetShortMuleVersion()));
 				// Our half of the proof. Travels inside the now-sealed
 				// AUTH_OK, so the client learns both that we hold the
@@ -1392,27 +1282,20 @@ const CECPacket *CECServerSocket::Authenticate(const CECPacket *request)
 				response->AddTag(CECTag(EC_TAG_AEAD_SERVER_CONFIRM,
 					serverConfirm.size(),
 					serverConfirm.data()));
-				// Echo the negotiated large-tag-count capability so
-				// the client mirrors EC_FLAG_LARGE_TAG_COUNT into its
-				// own m_my_flags. Without this echo, client wouldn't
-				// know the server supports the extended wire format
-				// and would never set the flag in its outgoing
-				// per-packet headers (#199).
+				// Echo the negotiated large-tag-count capability so the client mirrors
+				// EC_FLAG_LARGE_TAG_COUNT into its own m_my_flags. Without the echo it
+				// would never set the flag in its outgoing per-packet headers.
 				if (m_my_flags & EC_FLAG_LARGE_TAG_COUNT) {
 					response->AddTag(CECEmptyTag(EC_TAG_CAN_LARGE_TAG_COUNT));
 				}
-				// Identifies this daemon *process*. ECIDs come from a
-				// counter that restarts with the process (CECID), so
-				// after a daemon restart the same numbers are handed
-				// out again, in whatever order files load this time --
-				// and a client that kept its objects across the
-				// reconnect would pair them up by number and quietly
-				// describe one file with another's data. A client that
-				// sees a different value here knows its ECIDs mean
-				// nothing any more and starts over. Old clients ignore
-				// the tag; new clients that don't see it (old daemon)
-				// fall back to starting over on every reconnect, which
-				// is correct if wasteful.
+				// Identifies this daemon *process*. ECIDs come from a counter that
+				// restarts with the process, so after a daemon restart the same numbers
+				// are handed out again in whatever order files load this time -- and a
+				// client that kept its objects across the reconnect would pair them up
+				// by number and quietly describe one file with another's data. A
+				// client that sees a different value here starts over. Old clients
+				// ignore the tag; new clients against an old daemon start over every
+				// reconnect, which is correct if wasteful.
 				response->AddTag(CECTag(EC_TAG_SESSION_ID, GetEcSessionId()));
 				if (m_partialUpdateActive) {
 					// Confirm partial-update mode so the client switches
@@ -1421,17 +1304,14 @@ const CECPacket *CECServerSocket::Authenticate(const CECPacket *request)
 					response->AddTag(CECEmptyTag(EC_TAG_CAN_PARTIAL_UPDATE));
 				}
 				if (m_partialSearchActive) {
-					// Confirm the search half too. The client must not stop
-					// deleting on absence until it knows the daemon actually
-					// skips unchanged results -- against an older daemon that
-					// never skips, absence still means the result is gone.
+					// Confirm the search half too. The client must not stop deleting on
+					// absence until it knows the daemon actually skips unchanged results
+					// -- against an older daemon absence still means the result is gone.
 					response->AddTag(CECEmptyTag(EC_TAG_CAN_PARTIAL_SEARCH));
 				}
-				// Unconditional: this daemon answers
-				// EC_OP_GET_CLIENT_HISTORY, and a client that does
-				// not see the echo must not send the request --
-				// against a daemon that predates it the unknown
-				// opcode asserts before the EC_OP_FAILED path.
+				// Unconditional: this daemon answers EC_OP_GET_CLIENT_HISTORY, and a
+				// client that does not see the echo must not send the request -- against
+				// a daemon that predates it the unknown opcode asserts.
 				response->AddTag(CECEmptyTag(EC_TAG_CAN_CLIENT_HISTORY));
 				if (m_chatActive) {
 					// Confirm the chat session ops so the client starts
@@ -1444,29 +1324,23 @@ const CECPacket *CECServerSocket::Authenticate(const CECPacket *request)
 					// legacy single-search sentinel.
 					response->AddTag(CECEmptyTag(EC_TAG_CAN_MULTI_SEARCH));
 					if (m_searchProgressUnionActive) {
-						// Confirm the union form of EC_OP_SEARCH_PROGRESS:
-						// the client then sends one id-less request per poll
-						// instead of one per open search tab. Nested inside
-						// the multi-search echo on purpose -- the union
-						// addresses its children by search ID, which only
+						// Confirm the union form of EC_OP_SEARCH_PROGRESS: the client
+						// then sends one id-less request per poll instead of one per
+						// open tab. Nested inside the multi-search echo on purpose --
+						// the union addresses its children by search ID, which only
 						// exists in that mode.
 						response->AddTag(
 							CECEmptyTag(EC_TAG_CAN_SEARCH_PROGRESS_UNION));
 					}
 				}
-				// Confirm we serve EC_OP_GET/SET_SHARED_DIRS, so a remote
-				// GUI can present an editable shared-folders panel instead
-				// of one whose edits it could never deliver. Unconditional:
-				// unlike the flags above this needs no per-connection state,
-				// the ops are always available once authenticated.
+				// Confirm we serve EC_OP_GET/SET_SHARED_DIRS, so a remote GUI can present
+				// an editable shared-folders panel instead of one whose edits it could
+				// never deliver. Unconditional: the ops need no per-connection state.
 				response->AddTag(CECEmptyTag(EC_TAG_CAN_SHAREDDIRS_CONFIG));
-				// Confirm we serve EC_OP_SEARCH_LIST, so a remote GUI can
-				// enumerate searches it did not start itself. Unconditional,
-				// for the same reason as the tag above: the op needs no
-				// per-connection state. A client that gets no echo (this
-				// daemon predates #680) must not send the opcode at all --
-				// there is no case for it, so it would land in
-				// ProcessRequest2's unknown-opcode branch and assert.
+				// Confirm we serve EC_OP_SEARCH_LIST, so a remote GUI can enumerate
+				// searches it did not start itself. Unconditional, for the same reason.
+				// A client that gets no echo must not send the opcode at all -- it would
+				// land in ProcessRequest2's unknown-opcode branch and assert.
 				response->AddTag(CECEmptyTag(EC_TAG_CAN_SEARCH_LIST));
 			} else {
 				wxString err;
@@ -1476,10 +1350,9 @@ const CECPacket *CECServerSocket::Authenticate(const CECPacket *request)
 					err = wxTRANSLATE("Authentication failed: missing password.");
 				}
 
-				// Both branches are a failed credential attempt: a client
-				// that omits the hash entirely is guessing just as much as
-				// one that sends a wrong hash, and letting the omission go
-				// uncounted would hand an attacker an unmetered path.
+				// Both branches are a failed credential attempt: a client that omits the
+				// hash entirely is guessing just as much as one that sends a wrong hash,
+				// and letting the omission go uncounted would be an unmetered path.
 				theApp->ECServerHandler->AuthRateLimiter().NoteFailure(peerIp);
 
 				response = new CECPacket(EC_OP_AUTH_FAIL);
@@ -1515,14 +1388,12 @@ const CECPacket *CECServerSocket::Authenticate(const CECPacket *request)
 	return response;
 }
 
-// Make a Logger tag (if there are any logging messages) and add it to the response
-// Max log lines packed into a single EC stats response. Kept bounded so a
-// large first-sync backlog (a remote GUI attaching to a daemon with a big
-// accumulated logfile — issue #445) drains in a handful of polls without any
-// one poll hauling multiple MB: the log rides on the same response as the
-// live stats, and the client renders each poll's batch in one go. The wire
-// format itself imposes no such limit (ec_taglen_t is uint32 and the tag
-// count is uint32-extensible) — this is purely a per-poll responsiveness cap.
+// Make a Logger tag (if there are any logging messages) and add it to the
+// response. Max log lines packed into a single EC stats response, kept bounded
+// so a large first-sync backlog drains in a handful of polls without any one
+// poll hauling multiple MB: the log rides on the same response as the live
+// stats, and the client renders each poll's batch in one go. The wire format
+// imposes no such limit -- this is purely a per-poll responsiveness cap.
 static const int EC_LOG_LINES_PER_MESSAGE = 5000;
 
 static void AddLoggerTag(CECPacket *response, CLoggerAccess &LoggerAccess)
@@ -1560,11 +1431,10 @@ static CECPacket *Get_EC_Response_StatRequest(const CECPacket *request, CLoggerA
 		response->AddTag(
 			CECTag(EC_TAG_STATS_TOTAL_RECEIVED_BYTES, theStats::GetTotalReceivedBytes()));
 		response->AddTag(CECTag(EC_TAG_STATS_SHARED_FILE_COUNT, theStats::GetSharedFileCount()));
-		// Disk space for the Downloads and Shared Files panels. Only the
-		// core can answer: the GUI may be on another machine entirely, and
-		// even where it mounts the same share it can see a different size
-		// or quota. Both getters are cache-backed, so a stats poll never
-		// costs a filesystem round trip (Statistics.h).
+		// Disk space for the Downloads and Shared Files panels. Only the core can
+		// answer: the GUI may be on another machine entirely, and even where it
+		// mounts the same share it can see a different size or quota. Both getters
+		// are cache-backed, so a stats poll never costs a filesystem round trip.
 		response->AddTag(CECTag(EC_TAG_STATS_TEMP_FREE_SPACE, (uint64)theStats::GetTempFreeSpace()));
 		response->AddTag(
 			CECTag(EC_TAG_STATS_INCOMING_FREE_SPACE, (uint64)theStats::GetIncomingFreeSpace()));
@@ -1643,11 +1513,10 @@ static CECPacket *Get_EC_Response_StatRequest(const CECPacket *request, CLoggerA
 }
 
 // Serialise the daemon's shared-directory configuration: one EC_TAG_SHAREDDIR
-// per configured root, the path as its string value, with an
-// EC_TAG_SHAREDDIR_RECURSIVE subtag on the roots whose entire subtree is
-// shared. Only the two *intent* lists travel — shareddir.dat is the runtime
-// union (explicit + expanded recursive) that the daemon regenerates itself, so
-// sending it would just invite a remote client to edit a derived artefact.
+// per configured root, with an EC_TAG_SHAREDDIR_RECURSIVE subtag on the roots
+// whose entire subtree is shared. Only the two *intent* lists travel --
+// shareddir.dat is the runtime union the daemon regenerates itself, so sending
+// it would invite a remote client to edit a derived artefact.
 static CECPacket *Get_EC_Response_GetSharedDirs()
 {
 	CECPacket *response = new CECPacket(EC_OP_GET_SHARED_DIRS);
@@ -1666,11 +1535,10 @@ static CECPacket *Get_EC_Response_GetSharedDirs()
 
 // Replace the shared-directory configuration with the client's list, persist
 // both intent files and rescan. Paths are validated here because a remote GUI
-// cannot browse this host's filesystem to check them — a typo would otherwise
-// become a silently dead share. Rejected paths are reported back individually
-// (EC_TAG_SHAREDDIR_REJECTED + a numeric reason the client translates, so the
-// daemon's locale never leaks into the user's UI); every path that *did*
-// validate is still applied, so one bad entry doesn't discard the whole edit.
+// cannot browse this host's filesystem -- a typo would otherwise become a
+// silently dead share. Rejected paths are reported back individually with a
+// numeric reason the client translates, so the daemon's locale never leaks;
+// every path that did validate is still applied.
 namespace
 {
 
@@ -1683,8 +1551,8 @@ uint32 ChatCursorFrom(const CECPacket *request)
 }
 
 // One EC_TAG_CHAT_SESSION container: identity, plus every message newer than
-// `cursor`. A session with nothing new still encodes (with no message
-// children) — that is how a late-connecting client learns it exists.
+// `cursor`. A session with nothing new still encodes, with no message children
+// -- that is how a late-connecting client learns it exists.
 CECTag EncodeChatSession(const CChatSessionStore::Session &session, uint32 cursor)
 {
 	CECTag tag(EC_TAG_CHAT_SESSION, session.gui_id);
@@ -1697,10 +1565,9 @@ CECTag EncodeChatSession(const CChatSessionStore::Session &session, uint32 curso
 	if (const CUpDownClient *client = theApp->clientlist->FindClientByIP(session.ip, session.port)) {
 		tag.AddTag(CECTag(EC_TAG_CLIENT, client->ECID()));
 		// Sent whenever the client is, so "we are talking to a peer that is
-		// actually reachable" is answerable without inferring it from the
-		// ECID being present -- which is true from the first contact
-		// ATTEMPT, so a chat opened against an unroutable address read as
-		// online.
+		// actually reachable" is answerable without inferring it from the ECID
+		// being present -- which is true from the first contact ATTEMPT, so a
+		// chat opened against an unroutable address read as online.
 		tag.AddTag(CECTag(EC_TAG_CLIENT_CONNECTED, client->IsConnected()));
 	}
 	if (const CFriend *f = theApp->friendlist->FindFriend(CMD4Hash(), session.ip, session.port)) {
@@ -1722,9 +1589,8 @@ CECTag EncodeChatSession(const CChatSessionStore::Session &session, uint32 curso
 
 // Resolve an EC_OP_CHAT_SEND target to a GUI_ID. Three addressing modes so a
 // caller can reply without a lookup (CHAT_CLIENT_ID), address a live peer it
-// already has (CLIENT), or reach a friend who is currently OFFLINE (FRIEND) —
-// the last one resolves through the friend's stored ip:port, which is what
-// makes messaging an offline friend work at all.
+// already has (CLIENT), or reach a friend who is currently OFFLINE (FRIEND) --
+// the last resolves through the friend's stored ip:port.
 bool ResolveChatTarget(const CECPacket *request, uint64 &out_gui_id)
 {
 	if (const CECTag *tag = request->GetTagByName(EC_TAG_CHAT_CLIENT_ID)) {
@@ -1790,10 +1656,8 @@ static CECPacket *Get_EC_Response_SetSharedDirs(const CECPacket *request)
 	theApp->glob_prefs->shareddir_recursive_list = recursiveDirs;
 	// The union (shareddir.dat) has to be refreshed here too, not just the two
 	// intent lists. ReloadSharedFolders reconciles against the union on disk and
-	// drops any explicit root missing from it — that is how it honours external
-	// edits — so leaving a stale union would make it trim the roots we just
-	// added and persist the trimmed result. Seed it with the roots; the reload
-	// re-expands the recursive ones and regenerates the full union.
+	// drops any explicit root missing from it -- that is how it honours external
+	// edits -- so a stale union would make it trim the roots we just added.
 	CPreferences::PathList unionDirs = explicitDirs;
 	unionDirs.insert(unionDirs.end(), recursiveDirs.begin(), recursiveDirs.end());
 	theApp->glob_prefs->shareddir_list = unionDirs;
@@ -1826,21 +1690,18 @@ static CECPacket *Get_EC_Response_GetSharedFiles(const CECPacket *request,
 
 	encoders.UpdateEncoders();
 
-	// Skip-unchanged + EC_TAG_FILE_REMOVED is wired only for the
-	// `EC_DETAIL_UPDATE` polling path that amuleweb uses (`EC_OP_GET_
-	// SHARED_FILES` re-issued each cycle with an encoder-retained diff
-	// state) and only when the client opted into the partial-update
-	// protocol at auth. `EC_DETAIL_FULL` callers (amulecmd `show shared`,
-	// any one-shot query) still get every alive file as a full tag.
+	// Skip-unchanged + EC_TAG_FILE_REMOVED is wired only for the EC_DETAIL_UPDATE
+	// polling path that amuleweb uses, and only when the client opted into the
+	// partial-update protocol at auth. EC_DETAIL_FULL callers (amulecmd
+	// `show shared`, any one-shot query) still get every alive file in full.
 	const bool skip_unchanged_path = partial_update_active && detail_level == EC_DETAIL_UPDATE;
 	const uint64 ec_snapshot = skip_unchanged_path ? CKnownFile::GetGlobalECGen() : 0;
 	const uint64 ec_threshold = io_lastEcGenSeen;
 
 	// Snapshot the shared-file list once. GetFileByIndex() does an O(N)
-	// std::advance over the underlying std::map and re-acquires list_mut
-	// on every call -- looping it N times is O(N^2) and pegs the main
-	// thread for tens of minutes on users with tens of thousands of
-	// shared files (issue #666).
+	// std::advance over the underlying std::map and re-acquires list_mut on
+	// every call -- looping it N times is O(N^2) and pegs the main thread for
+	// tens of minutes on users with tens of thousands of shared files.
 	std::vector<CKnownFile *> snapshot;
 	theApp->sharedfiles->CopyFileList(snapshot);
 
@@ -1857,12 +1718,10 @@ static CECPacket *Get_EC_Response_GetSharedFiles(const CECPacket *request,
 		if (skip_unchanged_path) {
 			current_file_ids.insert(ecid);
 			if (cur_file->GetECGen() <= ec_threshold && io_sentWithDetailIds.count(ecid)) {
-				// Client already has the latest exported view of
-				// this file; absence here is "no change", not
-				// "deleted" — see `EC_TAG_FILE_REMOVED` emission
-				// below. The `io_sentWithDetailIds` gate prevents
-				// silently skipping ECIDs the client has never
-				// received with full detail (#808-class ghost).
+				// Client already has the latest exported view of this file; absence
+				// here is "no change", not "deleted" -- see the EC_TAG_FILE_REMOVED
+				// emission below. The sent-with-detail gate prevents silently skipping
+				// ECIDs the client has never received in full.
 				continue;
 			}
 		}
@@ -1870,14 +1729,11 @@ static CECPacket *Get_EC_Response_GetSharedFiles(const CECPacket *request,
 		CEC_SharedFile_Tag filetag(cur_file, detail_level);
 		CKnownFile_Encoder *enc = encoders[ecid];
 		if (!enc) {
-			// UpdateEncoders reads the list generations unlocked, so a file
-			// added on a worker thread (PartFileConvert's import, a completing
-			// partfile) between that read and this handler's own snapshot can
-			// be present here with no encoder built for it yet. Skip it this
-			// cycle -- it stays in current_file_ids, so it is not reported as
-			// removed -- and the next poll's reconcile sees the bumped
-			// generation and builds it. Dereferencing NULL here would crash
-			// the daemon.
+			// UpdateEncoders reads the list generations unlocked, so a file added on a
+			// worker thread between that read and this handler's own snapshot can be
+			// present here with no encoder built for it yet. Skip it this cycle -- it
+			// stays in current_file_ids, so it is not reported as removed -- and the
+			// next poll's reconcile builds it. Dereferencing NULL would crash amuled.
 			continue;
 		}
 		if (detail_level != EC_DETAIL_UPDATE) {
@@ -1943,22 +1799,20 @@ static CECPacket *Get_EC_Response_ClientHistory()
 			entry.AddTag(CECTag(EC_TAG_CLIENT_USER_PORT, meta.lastPort));
 			entry.AddTag(CECTag(EC_TAG_CLIENT_KAD_PORT, meta.kadPort));
 			entry.AddTag(CECTag(EC_TAG_CLIENT_SOFTWARE, meta.clientSoft));
-			// The same per-software rendering the live path uses. This used
-			// to be a generic major.minor.update built here, on the reasoning
-			// that only lPhant and eMule+ have a bespoke format -- which
-			// overlooked plain eMule, whose update component is a letter, so
-			// every eMule in the history read as v0.70.1 rather than v0.70b.
+			// The same per-software rendering the live path uses. This used to be a
+			// generic major.minor.update built here, on the reasoning that only
+			// lPhant and eMule+ have a bespoke format -- which overlooked plain
+			// eMule, whose update component is a letter, so every eMule in the
+			// history read as v0.70.1 rather than v0.70b.
 			entry.AddTag(CECTag(EC_TAG_CLIENT_SOFT_VER_STR,
 				FormatPackedClientVersion(meta.clientSoft, meta.version)));
 			entry.AddTag(CECTag(EC_TAG_CLIENT_FROM, meta.sourceFrom));
 			entry.AddTag(CECTag(EC_TAG_CLIENT_OBFUSCATION_STATUS, meta.obfuscation));
 #ifdef ENABLE_IP2COUNTRY
-			// Resolved here for the same reason live peers are (see
-			// CEC_UpDownClient_Tag): amulegui has no GeoIP database of its
-			// own, so a country it is not told is a country it cannot show.
-			// Emitted even when empty, so tag-present means "the daemon
-			// looked" and tag-absent means "the daemon has no GeoIP" --
-			// only for records that carry an address to look up.
+			// Resolved here for the same reason live peers are: amulegui has no GeoIP
+			// database of its own, so a country it is not told is a country it cannot
+			// show. Emitted even when empty, so tag-present means "the daemon looked"
+			// and tag-absent means "the daemon has no GeoIP".
 			if (theApp->GetIP2Country() && theApp->GetIP2Country()->IsEnabled()) {
 				entry.AddTag(CECTag(EC_TAG_CLIENT_COUNTRY,
 					theApp->GetIP2Country()->GetCountryCode(meta.lastIP)));
@@ -1978,25 +1832,20 @@ static CECPacket *Get_EC_Response_GetUpdate(CFileEncoderMap &encoders,
 {
 	CECPacket *response = new CECPacket(EC_OP_SHARED_FILES);
 
-	// Snapshot the global EC generation now. Any file whose `m_ecGen`
-	// exceeds the caller's `m_lastEcGenSeen` has been touched by a
-	// `MarkECChanged()` hook since the last response for this client and
-	// is sent through the encoder; anything older is unchanged from the
-	// client's point of view and skipped. Reading the snapshot before the
-	// iteration means files that change mid-loop are picked up on the
-	// next request (their `m_ecGen` will exceed our snapshot).
+	// Snapshot the global EC generation now. Any file whose `m_ecGen` exceeds the
+	// caller's `m_lastEcGenSeen` has been touched by a MarkECChanged() hook
+	// since the last response for this client and is sent through the encoder.
+	// Reading the snapshot before the iteration means files that change mid-loop
+	// are picked up on the next request.
 	const uint64 ec_snapshot = CKnownFile::GetGlobalECGen();
 	const uint64 ec_threshold = io_lastEcGenSeen;
 
-	// Freshly-created encoders this cycle. Every entry is an ECID whose
-	// prior encoder was either destroyed (file dropped from m_Files_map /
-	// downloadqueue) or never existed. In both cases the peer's mirrored
-	// state for that ECID is empty, so any INC_UPDATE the ctor would
-	// suppress against a cached value in `tagmap.GetValueMap(ecid)` produces
-	// a hash-less tag that the client rejects (`amule-remote-gui.cpp` #808
-	// guard). Drop the cache so the file re-appears in full detail on this
-	// response. The encoder's own sent-with-detail mask needs no clearing:
-	// a freshly-built encoder starts at zero by construction.
+	// Freshly-created encoders this cycle. Every entry is an ECID whose prior
+	// encoder was either destroyed or never existed, so the peer's mirrored
+	// state for it is empty and any INC_UPDATE the ctor would suppress against a
+	// cached value produces a hash-less tag the client rejects. Drop the cache
+	// so the file re-appears in full detail on this response; the encoder's own
+	// sent-with-detail flag starts at zero by construction.
 	std::set<uint32> freshEcids;
 	encoders.UpdateEncoders(&freshEcids);
 	for (uint32 ecid : freshEcids) {
@@ -2004,16 +1853,14 @@ static CECPacket *Get_EC_Response_GetUpdate(CFileEncoderMap &encoders,
 	}
 
 	// The IDs of all files currently alive on the server, ascending -- the
-	// encoder map is keyed by ECID, so iterating it below appends them in
-	// order. Used by the partial-update path to diff against the previous
-	// cycle and synthesize `EC_TAG_FILE_REMOVED` markers; a legacy client
-	// infers removal from absence instead, so for one of those this is never
-	// read and is not worth building.
-	// The removal merge needs that list ascending, and it gets it for free
-	// only because the encoder map is ordered by ECID. That guarantee lives on
-	// the container: CFileEncoderMap keeps its entries sorted by ECID and
-	// asserts that invariant at the end of every reconcile, so the ordering
-	// is checked where it is established rather than assumed here.
+	// encoder map is keyed by ECID, so iterating it below appends them in order.
+	// Used by the partial-update path to diff against the previous cycle and
+	// synthesize EC_TAG_FILE_REMOVED markers; a legacy client infers removal
+	// from absence instead, so for one of those this is never read.
+	//
+	// The ordering the merge needs is guaranteed by the container:
+	// CFileEncoderMap keeps its entries sorted by ECID and asserts that at the
+	// end of every reconcile, so it is checked where it is established.
 	std::vector<uint32> current_file_ids;
 	if (partial_update_active) {
 		current_file_ids.reserve(encoders.size());
@@ -2027,38 +1874,29 @@ static CECPacket *Get_EC_Response_GetUpdate(CFileEncoderMap &encoders,
 		}
 
 		if (cur_file->GetECGen() <= ec_threshold && it->second->WasSentOnUpdatePath()) {
-			// Nothing exported has changed since the client's last
-			// view of this file AND the client has previously
-			// received this ECID with full detail. Two paths
-			// depending on whether the client negotiated partial-
-			// update at auth time:
+			// Nothing exported has changed since the client's last view of this file
+			// AND the client has previously received this ECID with full detail.
 			if (partial_update_active) {
-				// New protocol: skip the file entirely. The client
-				// only deletes when it sees an explicit
-				// `EC_TAG_FILE_REMOVED` (emitted below), so absence
-				// here is correctly interpreted as "no change".
+				// New protocol: skip the file entirely. The client only deletes when it
+				// sees an explicit EC_TAG_FILE_REMOVED, emitted below, so absence here
+				// is correctly read as "no change".
 				continue;
 			}
-			// Legacy clients (amulegui / amuleweb on master) treat
-			// any file missing from the response as deleted, then
-			// re-add it on the next full-sweep cycle — wedging the
-			// GUI on big libraries (#713). Emit a 5-byte alive
-			// marker (`EC_TAG_KNOWNFILE` / `EC_TAG_PARTFILE` with
-			// the ECID and no children); the client's
-			// `if (tag->HasChildTags()) ProcessItemUpdate(...)`
-			// already treats childless tags as a no-op update but
-			// still records the file as present.
+			// Legacy clients treat any file missing from the response as deleted,
+			// then re-add it on the next full-sweep cycle -- wedging the GUI on big
+			// libraries. Emit a 5-byte alive marker (EC_TAG_KNOWNFILE /
+			// EC_TAG_PARTFILE with the ECID and no children): the client's
+			// `if (tag->HasChildTags())` already treats a childless tag as a no-op
+			// update, but still records the file as present.
 			const ec_tagname_t tagname =
 				it->second->IsPartFile_Encoder() ? EC_TAG_PARTFILE : EC_TAG_KNOWNFILE;
 			response->AddTag(CECTag(tagname, ecid));
 			continue;
 		}
-		// Fall-through path: either m_ecGen > ec_threshold (file
-		// changed since the client's last view) OR the ECID is new
-		// to this client. In both cases the client needs the full
-		// payload — alive-markers / silent skip would produce a
-		// ghost entry (#808) when the metadata never reached the
-		// client.
+		// Fall-through: either the file changed since the client's last view, or
+		// the ECID is new to this client. In both cases the client needs the full
+		// payload -- an alive marker or a silent skip would produce a ghost entry
+		// whose metadata never reached the client.
 		CValueMap &valuemap = tagmap.GetValueMap(ecid);
 		// Completed cleared Partfiles are still stored as CPartfile,
 		// but encoded as KnownFile, so we have to check the encoder type
@@ -2083,10 +1921,9 @@ static CECPacket *Get_EC_Response_GetUpdate(CFileEncoderMap &encoders,
 	}
 
 	if (partial_update_active) {
-		// Partial-update protocol: emit one `EC_TAG_FILE_REMOVED` per
-		// file that was in the previous response but is no longer
-		// alive on the server. Replaces the legacy client's bulk
-		// "anything missing == deleted" inference.
+		// Partial-update protocol: emit one EC_TAG_FILE_REMOVED per file that was
+		// in the previous response but is no longer alive on the server, replacing
+		// the legacy client's bulk "anything missing == deleted" inference.
 		std::vector<uint32> removed;
 		ComputeRemovedIds(io_lastSentFileIds, current_file_ids, removed);
 		for (uint32 ecid : removed) {
@@ -2187,17 +2024,15 @@ static CECPacket *Get_EC_Response_GetDownloadQueue(const CECPacket *request,
 
 	encoders.UpdateEncoders();
 
-	// Skip-unchanged + EC_TAG_FILE_REMOVED is wired only for the
-	// `EC_DETAIL_UPDATE` polling path that amuleweb uses, and only when
-	// the client opted into the partial-update protocol at auth. Other
-	// callers still get every alive file as a full tag.
+	// Skip-unchanged + EC_TAG_FILE_REMOVED is wired only for the EC_DETAIL_UPDATE
+	// polling path that amuleweb uses, and only when the client opted into the
+	// partial-update protocol at auth. Other callers get every alive file.
 	const bool skip_unchanged_path = partial_update_active && detail_level == EC_DETAIL_UPDATE;
 	const uint64 ec_snapshot = skip_unchanged_path ? CKnownFile::GetGlobalECGen() : 0;
 	const uint64 ec_threshold = io_lastEcGenSeen;
 
-	// Snapshot once to avoid re-locking downloadqueue's mutex on every
-	// iteration (see Get_EC_Response_GetSharedFiles for the matching
-	// shared-files fix in issue #666).
+	// Snapshot once to avoid re-locking downloadqueue's mutex on every iteration
+	// -- see Get_EC_Response_GetSharedFiles for the matching shared-files fix.
 	std::vector<CPartFile *> snapshot;
 	theApp->downloadqueue->CopyFileList(snapshot);
 
@@ -2213,13 +2048,10 @@ static CECPacket *Get_EC_Response_GetDownloadQueue(const CECPacket *request,
 		if (skip_unchanged_path) {
 			current_file_ids.insert(ecid);
 			if (cur_file->GetECGen() <= ec_threshold && io_sentWithDetailIds.count(ecid)) {
-				// Client already has the latest exported view of
-				// this partfile; absence here is "no change",
-				// not "deleted" — see `EC_TAG_FILE_REMOVED`
-				// emission below. The `io_sentWithDetailIds`
-				// gate prevents silently skipping ECIDs the
-				// client has never received with full detail
-				// (#808-class ghost).
+				// Client already has the latest exported view of this partfile; absence
+				// here is "no change", not "deleted" -- see the EC_TAG_FILE_REMOVED
+				// emission below. The sent-with-detail gate prevents silently skipping
+				// ECIDs the client has never received in full.
 				continue;
 			}
 		}
@@ -2257,9 +2089,8 @@ static CECPacket *Get_EC_Response_GetDownloadQueue(const CECPacket *request,
 }
 
 // Build a CEC_SharedFile_Tag for the per-file cache. The output is
-// self-contained — the encoder is reset before each Encode call in
-// FULL mode (see Get_EC_Response_GetSharedFiles), so a local encoder
-// suffices. Caller owns the returned tag.
+// self-contained -- the encoder is reset before each Encode call in FULL mode
+// -- so a local encoder suffices. Caller owns the returned tag.
 static CECTag *BuildSharedFileCacheTag(const void *file_v)
 {
 	const CKnownFile *cur_file = static_cast<const CKnownFile *>(file_v);
@@ -2281,11 +2112,10 @@ static CECTag *BuildPartFileCacheTag(const void *file_v)
 	return filetag;
 }
 
-// Two daemon-wide caches. Each holds one pre-serialized blob per file
-// in its domain, freshness-stamped with the file's m_ecGen at build
-// time. A request rebuilds only entries whose file gen has advanced
-// past the cached gen — the same per-file freshness primitive the
-// INC_UPDATE path uses.
+// Two daemon-wide caches. Each holds one pre-serialized blob per file in its
+// domain, freshness-stamped with the file's m_ecGen at build time. A request
+// rebuilds only entries whose file gen has advanced past the cached gen -- the
+// same per-file freshness primitive the INC_UPDATE path uses.
 static CECFullResponseCache s_sharedFilesFullCache(BuildSharedFileCacheTag);
 static CECFullResponseCache s_downloadQueueFullCache(BuildPartFileCacheTag);
 
@@ -2319,19 +2149,13 @@ static CECPacket *Get_EC_Response_PartFile_Cmd(const CECPacket *request)
 			CoreNotify_PartFile_Swap_A4AF_Auto(pfile);
 			break;
 		case EC_OP_PARTFILE_SET_A4AF_AUTO:
-			// Set, rather than flip. The op above cannot express "make it
-			// true": a caller that cannot see the current value cannot ask
-			// for a particular one, and a repeated request undoes itself.
-			// That is fine for the GUI menu item driving it, and wrong for
-			// an HTTP API, where a library or a browser may retry without
-			// the caller knowing.
-			//
-			// SetA4AFAuto() only marks the file EC-changed when the value
-			// actually moves, so re-sending the value it already holds
-			// costs nothing and pushes no update.
-			//
-			// Value rides as a child of EC_TAG_PARTFILE, the same shape
-			// EC_OP_PARTFILE_SET_CAT and _PRIO_SET use.
+			// Set, rather than flip. The op above cannot express "make it true": a
+			// caller that cannot see the current value cannot ask for a particular
+			// one, and a repeated request undoes itself. That is fine for the GUI
+			// menu item driving it, and wrong for an HTTP API, where a library may
+			// retry without the caller knowing. SetA4AFAuto() only marks the file
+			// EC-changed when the value actually moves, so re-sending the value it
+			// already holds costs nothing.
 			pfile->SetA4AFAuto(hashtag.GetFirstTagSafe()->GetInt() != 0);
 			break;
 		case EC_OP_PARTFILE_SWAP_A4AF_OTHERS:
@@ -2398,9 +2222,8 @@ static CECPacket *Get_EC_Response_Server_Add(const CECPacket *request)
 		response = new CECPacket(EC_OP_NOOP);
 	} else {
 		response = new CECPacket(EC_OP_FAILED);
-		// wxTRANSLATE (not _()) so the wire string stays English; the API
-		// contract is English text / C-locale numbers, and webapi relays this
-		// verbatim. Consistent with the other EC_OP_FAILED replies here.
+		// wxTRANSLATE (not _()) so the wire string stays English: the API contract
+		// is English text / C-locale numbers, and webapi relays this verbatim.
 		response->AddTag(CECTag(EC_TAG_STRING, wxTRANSLATE("Server not added")));
 		delete toadd;
 	}
@@ -2464,15 +2287,14 @@ static CECPacket *Get_EC_Response_Server(const CECPacket *request)
 }
 
 // Allocate + register a browse ("View Files") search ID in the shared EC search
-// ring (defined below, after the registry). Reuses the ed2k bottom-half
-// allocator: a browse is just another addressable result set, so it draws from
-// the same disjoint id space and LRU eviction as a normal search — no separate
-// range needed. Defined after s_ecSearches.
+// ring. Reuses the ed2k bottom-half allocator: a browse is just another
+// addressable result set, so it draws from the same disjoint id space and LRU
+// eviction as a normal search.
+//
 // The one invariant this file's kind reporting rests on: SearchType is cast
 // straight to uint8 for EC_TAG_SEARCH_LIFECYCLE_KIND, so its members have to
-// carry the EC_SEARCH_TYPE numbers. A comment saying so is what let a browse
-// nearly be given 3, which is EC_SEARCH_WEB -- state it where the compiler
-// checks it instead.
+// carry the EC_SEARCH_TYPE numbers -- stated where the compiler checks it,
+// because a comment saying so is what let a browse nearly be given 3.
 static_assert(static_cast<int>(LocalSearch) == EC_SEARCH_LOCAL,
 	"SearchType and EC_SEARCH_TYPE must agree: LocalSearch");
 static_assert(static_cast<int>(GlobalSearch) == EC_SEARCH_GLOBAL,
@@ -2486,8 +2308,7 @@ static uint32 AllocateBrowseSearchId();
 // Undo an AllocateBrowseSearchId() whose browse never started. Drops the
 // results and the registry's own bookkeeping together: RemoveResults() alone
 // leaves the dead id as Current(), so id-less result polls target a freed
-// bucket, and it keeps one of the twenty ring slots until it evicts a live
-// search.
+// bucket, and it keeps one of the ring slots until it evicts a live search.
 static void ReleaseBrowseSearchId(uint32 id);
 
 // Reply to a browse request. Multi-search clients get the allocated search ID
@@ -2542,12 +2363,10 @@ static CECPacket *Get_EC_Response_Friend(const CECPacket *request, bool multiSea
 			if (Friend) {
 				theApp->friendlist->RemoveFriend(Friend);
 			}
-			// Idempotent: the desired end state of REMOVE is "friend
-			// not in the list", which is already true if FindFriend
-			// returned null (transient sync skew between amulegui's
-			// local view and the daemon's m_FriendList). Returning
-			// EC_OP_FAILED here forces the GUI into a resend / hang
-			// loop on the stale ECID.
+			// Idempotent: the desired end state of REMOVE is "friend not in the
+			// list", already true if FindFriend returned null (transient sync skew
+			// between amulegui's local view and m_FriendList). Returning
+			// EC_OP_FAILED forces the GUI into a resend / hang loop on a stale ECID.
 			response = new CECPacket(EC_OP_NOOP);
 		}
 	} else if ((tag = request->GetTagByName(EC_TAG_FRIEND_FRIENDSLOT))) {
@@ -2563,21 +2382,18 @@ static CECPacket *Get_EC_Response_Friend(const CECPacket *request, bool multiSea
 		// Browse ("View Files") over EC. For a multi-search-capable client the
 		// daemon allocates a real, wire-safe search ID, registers it in the ring
 		// and pins it on the target client so ProcessSharedFileList files the
-		// returned listing under it; the reply carries that ID (echoing the
-		// GUI's optimistic EC_TAG_SEARCH_REF) so amuleGUI rekeys its browse tab.
-		// Legacy clients keep the old fire-and-forget EC_OP_NOOP (they can't
-		// display a browse anyway).
+		// returned listing under it; the reply carries that ID, echoing the GUI's
+		// optimistic EC_TAG_SEARCH_REF, so amuleGUI rekeys its browse tab. Legacy
+		// clients keep the old fire-and-forget EC_OP_NOOP.
 		//
-		// The ID is allocated per branch, once the target peer is known and
-		// only if it has no browse running -- see browseInFlightId below.
+		// The ID is allocated per branch, once the target peer is known and only
+		// if it has no browse running -- see browseInFlightId below.
 		const CECTag *reftag = tag->GetTagByName(EC_TAG_SEARCH_REF);
-		// A browse failure needs the correlation token for the same reason a
-		// failed search start does: amuleGUI created its optimistic browse tab
-		// (EnsureBrowseTab) before sending and has no other way to tell which
-		// browse this verdict answers, so without the echo the tab is stranded.
-		// "Client not found." is the ordinary case -- the peer gets reaped
-		// between the user seeing the row and clicking View Files (got3nks,
-		// PR #680 review).
+		// A browse failure needs the correlation token for the same reason a failed
+		// search start does: amuleGUI created its optimistic browse tab before
+		// sending and has no other way to tell which browse this verdict answers.
+		// "Client not found." is the ordinary case -- the peer gets reaped between
+		// the user seeing the row and clicking View Files.
 		auto browseFailure = [reftag](const wxString &msg) {
 			CECPacket *fail = new CECPacket(EC_OP_FAILED);
 			fail->AddTag(CECTag(EC_TAG_STRING, msg));
@@ -2588,24 +2404,20 @@ static CECPacket *Get_EC_Response_Friend(const CECPacket *request, bool multiSea
 			return fail;
 		};
 		// A browse of a peer that is already being browsed joins that browse
-		// instead of minting a second identity for it. CUpDownClient::
-		// RequestSharedFileList() declines to re-ask a peer that is still
-		// answering, so a freshly allocated ID would never be stamped with a
-		// lifecycle -- while PinBrowseSearchId has already repointed every
-		// later status write away from the first ID, leaving that one
-		// BROWSE_IN_PROGRESS with nothing able to terminalize it. There is
-		// exactly one browse per client, so there can only be one ID to
-		// report on. Returns 0 when the peer has no browse running, i.e. when
-		// the caller should allocate as usual.
+		// instead of minting a second identity for it.
+		// CUpDownClient::RequestSharedFileList() declines to re-ask a peer that is
+		// still answering, so a freshly allocated ID would never be stamped with a
+		// lifecycle -- while PinBrowseSearchId has already repointed every later
+		// status write away from the first ID, leaving it BROWSE_IN_PROGRESS with
+		// nothing able to terminalize it. Returns 0 when the peer has no browse
+		// running, i.e. when the caller should allocate as usual.
 		auto browseInFlightId = [](const CUpDownClient *peer) -> uint32 {
 			return peer != nullptr ? theApp->browsemanager->SearchIdFor(peer) : 0;
 		};
 		// Same reply as a fresh browse, pointing at the browse that is really
 		// running: no allocation (the second ID would be stranded), no
-		// RegisterBrowseSearch (it would restamp m_searchStartTimes), no
-		// repoint, no re-request. A legacy client still gets its historical
-		// EC_OP_NOOP -- and, unlike before, no longer clears the pinned ID of
-		// a multi-search client's in-flight browse on its way past.
+		// RegisterBrowseSearch (it would restamp m_searchStartTimes), no repoint,
+		// no re-request. A legacy client still gets its historical EC_OP_NOOP.
 		auto joinBrowse = [&](uint32 inFlightId) {
 			return BuildBrowseReply(multiSearch ? inFlightId : 0, reftag);
 		};
@@ -2642,12 +2454,12 @@ static CECPacket *Get_EC_Response_Friend(const CECPacket *request, bool multiSea
 						if (browseId) {
 							ReleaseBrowseSearchId(browseId);
 						}
-						// The callee resolves its client by hash, which can
-						// find one the check above could not: it looked at the
-						// record's linkage, which is empty for a friend added
-						// by address. Ask again now that linking has happened,
-						// so a browse already running is joined rather than
-						// reported as a missing address.
+						// The callee resolves its client by hash, which can find one
+						// the check above could not: that looked at the record's
+						// linkage, which is empty for a friend added by address. Ask
+						// again now that linking has happened, so a browse already
+						// running is joined rather than reported as a missing
+						// address.
 						const CClientRef &nowLinked = Friend->GetLinkedClient();
 						const uint32 running = browseInFlightId(
 							nowLinked.IsLinked() ? nowLinked.GetClient()
@@ -2701,9 +2513,8 @@ namespace
 // Global multi-search registry, shared across all EC connections (EC runs
 // synchronously on the main thread, so no locking is needed). Bounds the
 // daemon's retained EC searches to kMaxEcSearches, evicting the
-// least-recently-touched — which also stops a still-running Kad search via
-// RemoveResults. Legacy (non-multi) clients bypass this entirely and keep
-// using the single 0xffffffff sentinel bucket.
+// least-recently-touched -- which also stops a still-running Kad search via
+// RemoveResults. Legacy clients bypass this and keep the sentinel bucket.
 constexpr std::size_t kMaxEcSearches = 20;
 
 class CEcSearchRegistry
@@ -2735,10 +2546,10 @@ public:
 
 	bool Has(uint32 id) const { return std::find(m_lru.begin(), m_lru.end(), id) != m_lru.end(); }
 
-	// Drop id from the ring/current without touching core search state.
-	// For a search this registry tracks, call alongside the caller's own
-	// (unconditional) CSearchList::RemoveResults, instead of Close(), when
-	// the id may or may not be one this registry knows about.
+	// Drop id from the ring/current without touching core search state. For a
+	// search this registry tracks, call alongside the caller's own unconditional
+	// CSearchList::RemoveResults, instead of Close(), when the id may or may not
+	// be one this registry knows about.
 	void Forget(uint32 id)
 	{
 		m_lru.remove(id);
@@ -2795,25 +2606,20 @@ static CECPacket *Get_EC_Response_Search_Results(const CECPacket *request,
 	// request can contain list of queried items
 	CTagSet<uint32, EC_TAG_SEARCHFILE> queryitems(request);
 
-	// `EC_TAG_FILE_REMOVED` tombstoning is wired only for the
-	// `EC_DETAIL_UPDATE` polling path that amuleweb uses, and only when
-	// the client opted into the partial-update protocol at auth. The
-	// `EC_DETAIL_INC_UPDATE` dispatch (amulegui) takes the tagmap
-	// overload below; `EC_DETAIL_FULL` callers (amulecmd `search` and
-	// amuleweb's Phase-3 follow-up `req_full`, which defaults to FULL)
-	// remain unchanged. The `queryitems.empty()` check excludes
-	// per-ID subset queries: tombstoning is meaningful only when the
-	// client is polling the whole set.
+	// EC_TAG_FILE_REMOVED tombstoning is wired only for the EC_DETAIL_UPDATE
+	// polling path that amuleweb uses, and only when the client opted into the
+	// partial-update protocol at auth. The EC_DETAIL_INC_UPDATE dispatch
+	// (amulegui) takes the tagmap overload below; EC_DETAIL_FULL callers are
+	// unchanged. The queryitems.empty() check excludes per-ID subset queries:
+	// tombstoning is meaningful only when polling the whole set.
 	const bool tombstone_path =
 		partial_update_active && detail_level == EC_DETAIL_UPDATE && queryitems.empty();
 
-	// Result grouping (issue #431): a caller that wants the same-hash/
-	// same-size-but-different-filename children (the expandable tree the
-	// GUI shows) opts in by adding an empty `EC_TAG_SEARCH_PARENT` flag
-	// to the request. Without it this path stays parents-only, so
-	// amulecmd `search` and amuleweb are unchanged. Children carry their
-	// parent's ECID via `EC_TAG_SEARCH_PARENT` in CEC_SearchFile_Tag, so
-	// the client can rebuild the tree.
+	// Result grouping: a caller that wants the same-hash/same-size-but-different-
+	// filename children (the expandable tree the GUI shows) opts in by adding an
+	// empty EC_TAG_SEARCH_PARENT flag to the request. Without it this path stays
+	// parents-only, so amulecmd and amuleweb are unchanged. Children carry their
+	// parent's ECID via EC_TAG_SEARCH_PARENT so the client can rebuild the tree.
 	const bool want_children = request->GetTagByName(EC_TAG_SEARCH_PARENT) != nullptr;
 
 	std::set<uint32> current_ids;
@@ -2840,15 +2646,12 @@ static CECPacket *Get_EC_Response_Search_Results(const CECPacket *request,
 	}
 
 	if (tombstone_path) {
-		// One `EC_TAG_FILE_REMOVED` per result that was in the previous
-		// response but is no longer in the daemon's searchlist —
-		// typically because the user started a new search, which clears
-		// the list via `EC_OP_SEARCH_START` → `searchlist->RemoveResults`.
-		// Without these markers, amuleweb's
-		// `UpdatableItemsContainer::ProcessUpdate` takes the partial-
-		// update branch (it expects explicit deletions) and sees no
-		// signal to drop the old results, so they accumulate across
-		// searches (#31, regression from ee1d92b75).
+		// One EC_TAG_FILE_REMOVED per result that was in the previous response
+		// but is no longer in the daemon's searchlist -- typically because the
+		// user started a new search, which clears the list. Without these
+		// markers amuleweb's ProcessUpdate takes the partial-update branch,
+		// which expects explicit deletions, and sees no signal to drop the old
+		// results, so they accumulate across searches.
 		for (std::set<uint32>::const_iterator i = io_lastSentSearchIds.begin();
 			i != io_lastSentSearchIds.end();
 			++i) {
@@ -2885,41 +2688,34 @@ static CECPacket *Get_EC_Response_Search_Results(CObjTagMap &tagmap, wxUIntPtr s
 }
 
 // Multi-search INC_UPDATE union poll (amulegui): amulegui runs every open
-// search through a single result container, so emit the results of *all* active
-// searches in one reply, tagging each with its EC_TAG_SEARCH_ID. The client
-// routes each result to the right tab by that ID (mirrors the monolithic GUI,
-// which demuxes by search ID), and its container's bulk-delete-on-poll works
-// correctly across the union. Only reached for m_multiSearchActive clients.
+// search through a single result container, so emit the results of *all*
+// active searches in one reply, tagging each with its EC_TAG_SEARCH_ID. Only
+// reached for m_multiSearchActive clients.
 //
 // Enumerates CSearchList::GetKnownSearchIds() -- every search AND "View Files"
 // browse tab the core holds, started by the monolithic GUI or by any EC client
-// -- rather than s_ecSearches.ActiveIds(),
-// which only ever holds EC-initiated searches (Register() is called from
-// exactly one place, the EC_OP_SEARCH_START handler). A monolithic-started
-// search's results would otherwise never reach amulegui even once
-// Get_EC_Response_Search_List (below) learned to enumerate it: the two have
-// to agree on the same set, or a discovered tab appears and never fills.
-// Browses need no second source here any more: every one of them reaches
-// RegisterBrowseSearch before its request goes out, so m_searchStrings holds
-// them alongside real searches and GetKnownSearchIds() covers both. It used
-// to be absent from that map, and the second source was what stopped a
-// browse's own STRINGS reply (BuildBrowseReply) promising results this union
-// would then never send (got3nks, PR #680 review). s_ecSearches keeps governing EC-client lifecycle and
-// eviction only -- folding monolithic searches into that 20-entry LRU would
-// let unrelated EC traffic evict, and so stop, a local user's own
-// still-running Kad search.
+// -- rather than s_ecSearches.ActiveIds(), which only ever holds EC-initiated
+// searches. A monolithic-started search's results would otherwise never reach
+// amulegui even once Get_EC_Response_Search_List learned to enumerate it: the
+// two have to agree on the same set, or a discovered tab appears and never
+// fills. Browses need no second source: every one reaches RegisterBrowseSearch
+// before its request goes out, so m_searchStrings holds them alongside real
+// searches.
+//
+// s_ecSearches keeps governing EC-client lifecycle and eviction only -- folding
+// monolithic searches into that 20-entry LRU would let unrelated EC traffic
+// evict, and so stop, a local user's own still-running Kad search.
 static CECPacket *Get_EC_Response_Search_Results_Union(
 	CObjTagMap &tagmap, bool partial_update_active, std::set<uint32> &io_lastSentResultIds)
 {
 	CECPacket *response = new CECPacket(EC_OP_SEARCH_RESULTS);
 	// Incremental: unchanged fields are diffed out via the per-connection
-	// valuemap (keyed by the globally-unique ECID). Safe now that amulegui's
-	// container retains its items across searches (it no longer flushes on a
-	// new search), so a result is never re-created from a diffed tag — no
-	// ghosts.
+	// valuemap, keyed by the globally-unique ECID. Safe because amulegui's
+	// container retains its items across searches, so a result is never
+	// re-created from a diffed tag.
 	//
-	// Every result the client is currently believed to hold, so the
-	// partial-update path below can synthesize removals by diffing against
+	// `current_ids` is every result the client is currently believed to hold, so
+	// the partial-update path below can synthesize removals by diffing against
 	// the previous cycle instead of relying on absence.
 	std::set<uint32> current_ids;
 
@@ -2929,19 +2725,17 @@ static CECPacket *Get_EC_Response_Search_Results_Union(
 		const bool known = io_lastSentResultIds.count(ecid) != 0;
 		CValueMap &valuemap = tagmap.GetValueMap(ecid);
 		// The owning search ID never changes for a result, so it only has to
-		// travel once per connection -- but only once removal is explicit.
-		// A legacy client deletes anything missing from the reply and would
-		// then re-create the item from a later diffed tag, which must still
-		// carry the ID to be attributable to a tab.
+		// travel once per connection -- but only once removal is explicit. A
+		// legacy client deletes anything missing from the reply and would then
+		// re-create the item from a later diffed tag, which must still carry the
+		// ID to be attributable to a tab.
 		const uint32 attribute_sid = (partial_update_active && known) ? 0 : sid;
 		CEC_SearchFile_Tag tag(sf, EC_DETAIL_INC_UPDATE, &valuemap, attribute_sid);
 		if (partial_update_active && known && !tag.HasChildTags()) {
-			// Nothing about this result changed since the client's last view.
-			// Absence no longer implies deletion for this client (it deletes
-			// only on an explicit EC_TAG_FILE_REMOVED emitted below), so the
-			// whole tag can go. This is what makes an idle search cost
-			// nothing: previously every result re-sent its envelope plus its
-			// search ID on every poll, forever.
+			// Nothing about this result changed since the client's last view. Absence
+			// no longer implies deletion for this client, so the whole tag can go.
+			// This is what makes an idle search cost nothing: previously every
+			// result re-sent its envelope and its search ID on every poll, forever.
 			return;
 		}
 		response->AddTag(tag);
@@ -2960,27 +2754,22 @@ static CECPacket *Get_EC_Response_Search_Results_Union(
 	};
 	// GetKnownSearchIds() covers browses too: RequestSharedFileList registers
 	// every one of them, by either route, before the request goes out, and
-	// RemoveResults drops the registration and the browse together. The second
-	// source this loop used to have emitted each browse a second time.
+	// RemoveResults drops the registration and the browse together.
 	for (const auto &entry : theApp->searchlist->GetKnownSearchIds()) {
 		emitResultsFor(entry.first);
 	}
 
 	if (partial_update_active) {
-		// One EC_TAG_FILE_REMOVED per result the client was told about that
-		// the core no longer holds -- a closed or evicted search, or a
-		// results list replaced by a new search on the same ID. Reuses the
-		// knownfile tombstone rather than inventing a second one: the
-		// meaning ("this ECID is gone") and the payload (the ECID) are
-		// identical, and the search container reads it the same way.
+		// One EC_TAG_FILE_REMOVED per result the client was told about that the core
+		// no longer holds -- a closed or evicted search, or a results list replaced
+		// by a new search on the same ID. Reuses the knownfile tombstone rather
+		// than inventing a second one: the meaning and the payload are identical.
 		for (uint32 id : io_lastSentResultIds) {
 			if (!current_ids.count(id)) {
 				response->AddTag(CECTag(EC_TAG_FILE_REMOVED, id));
 				// Drop the diff state with the result. ECIDs are handed out
-				// monotonically so reuse is not expected, but a stale
-				// valuemap would diff away the very fields a re-created
-				// result needs, leaving the client a tag it cannot use --
-				// the same hazard `freshEcids` guards on the file path.
+				// monotonically so reuse is not expected, but a stale valuemap would
+				// diff away the very fields a re-created result needs.
 				tagmap.EraseValueMap(id);
 			}
 		}
@@ -2989,30 +2778,24 @@ static CECPacket *Get_EC_Response_Search_Results_Union(
 	return response;
 }
 
-// Enumerates every search the core currently holds
-// (CSearchList::GetKnownSearchIds()) so a client that never started any of
-// them locally -- a freshly (re)connected amulegui, a stateless amuleapi
-// request, or a search typed directly into the monolithic GUI -- can discover
+// Enumerates every search the core currently holds so a client that never
+// started any of them locally -- a freshly (re)connected amulegui, a stateless
+// amuleapi request, or a search typed into the monolithic GUI -- can discover
 // what to ask about and build tabs for it. One entry per known search:
 // EC_TAG_SEARCH_ID as the entry's own value, with name/kind/state as children.
-// Only reached for m_multiSearchActive clients (see the EC_OP_SEARCH_LIST case
-// below): a legacy client has no concept of more than the single 0xffffffff
-// sentinel search, so there is nothing meaningful to enumerate for it.
+// Only reached for m_multiSearchActive clients: a legacy client has no concept
+// of more than the single sentinel search.
 //
-// Browses are enumerated here too. This reverses PR #680, which kept them out
-// on the grounds that a browse is inherently per-request and could only
-// surface as a bogus, nameless search tab: PR #914 gave a browse a name, a
+// Browses are enumerated here too, because a browse now carries a name, a
 // recorded kind and its peer's ECID (RegisterBrowseSearch), which is exactly
-// what lets a remote GUI rebuild it as a browse tab instead
-// (CSearchListRem::HandlePacket in amule-remote-gui.cpp branches on
-// BrowseSearch + EC_TAG_CLIENT), and made a local browse discoverable at all.
-// RegisterBrowseSearch writing m_searchStrings is what puts them in reach of
-// GetKnownSearchIds(); it is deliberate, not incidental.
-// amuleapi's SearchKindToString/SearchLifecycleStateToString (Api.cpp) decode
-// the two wire values written below from raw numeric literals, since amuleapi
-// cannot include SearchList.h. This file can see both CSearchList's enums and
-// the EC ones, so it is the one place that can catch a reorder at compile
-// time instead of amuleapi silently mislabelling a search.
+// what lets a remote GUI rebuild it as a browse tab rather than a nameless
+// search. RegisterBrowseSearch writing m_searchStrings is what puts them in
+// reach of GetKnownSearchIds(); it is deliberate, not incidental.
+//
+// amuleapi decodes the two wire values written below from raw numeric
+// literals, since it cannot include SearchList.h. This file can see both
+// CSearchList's enums and the EC ones, so it is the one place that can catch a
+// reorder at compile time instead of amuleapi silently mislabelling a search.
 static_assert(CSearchList::SEARCH_LIFECYCLE_IDLE == 0 && CSearchList::SEARCH_LIFECYCLE_RUNNING == 1 &&
 		      CSearchList::SEARCH_LIFECYCLE_FINISHED == 2,
 	"CSearchList::SearchLifecycleState numeric values must stay in sync with "
@@ -3050,17 +2833,13 @@ static CECPacket *Get_EC_Response_Search_List()
 				static_cast<uint8>(theApp->searchlist->GetSearchLifecycleStateById(sid))));
 		// How many hits this search is holding. A client that adopts the whole
 		// listing and fetches results per tab on activation has no other way to
-		// label a tab it has not opened yet -- and eagerly fetching every
-		// search's results to learn one integer each is the thing the lazy
-		// fetch exists to avoid. Same tag, same number, as the progress and
-		// results replies already carry (an O(1) map lookup on the index).
+		// label a tab it has not opened yet -- and eagerly fetching every search's
+		// results to learn one integer each is what the lazy fetch avoids.
 		entry.AddTag(CECTag(EC_TAG_SEARCH_RESULT_COUNT,
 			static_cast<uint32>(theApp->searchlist->GetSearchResults(sid).size())));
-		// And the percent, so a client discovering a *running* search reports
-		// the daemon's real ramp from first sight rather than 0 until the next
-		// poll. Both tags are already allocated and already emitted on the
-		// per-id progress reply; this listing was simply the one reply that
-		// left them out.
+		// And the percent, so a client discovering a *running* search reports the
+		// daemon's real ramp from first sight rather than 0 until the next poll.
+		// Both tags are already emitted on the per-id progress reply.
 		entry.AddTag(CECTag(EC_TAG_SEARCH_LIFECYCLE_PERCENT,
 			theApp->searchlist->GetSearchLifecyclePercentById(sid)));
 		response->AddTag(entry);
@@ -3070,21 +2849,16 @@ static CECPacket *Get_EC_Response_Search_List()
 }
 
 // Emit one search's progress into `out`: the reply packet itself for a request
-// naming a single `EC_TAG_SEARCH_ID`, or one child entry per search for the
-// union form below. Both callers share this function so the two shapes cannot
-// drift -- whatever a per-id poll reports is exactly what a union child
-// reports, which is what lets a client switch between them without any
-// second decode path.
+// naming a single EC_TAG_SEARCH_ID, or one child entry per search for the union
+// form below. Both callers share this function so the two shapes cannot drift.
 //
 // A browse ("View Files") ID is not a CSearchList search: report its lifecycle
-// from the persisted browse state (browsing / finished / failed) + bar, keyed
-// by search ID, plus the running result count so amuleGUI's tab marker and hit
-// count update. Reading the persisted state -- rather than the browsing client,
-// which is transient and, for a browse that fails on disconnect, reaped before
-// the next poll -- means the terminal "failed" still reaches amuleGUI so its
-// tab marker flips instead of sticking at "browsing".
-// EC_TAG_SEARCH_BROWSE_STATUS is the discriminator the GUI branches on before
-// the normal progress decode.
+// from the persisted browse state (browsing / finished / failed) plus the bar,
+// keyed by search ID, and the running result count. Reading the persisted state
+// -- rather than the browsing client, which is transient and, for a browse that
+// fails on disconnect, reaped before the next poll -- means the terminal
+// "failed" still reaches amuleGUI so its tab marker flips.
+// EC_TAG_SEARCH_BROWSE_STATUS is the discriminator the GUI branches on.
 //
 // EC_TAG_SEARCH_STATUS MUST be added first in both branches: the GUI reads the
 // reply's (or the entry's) first tag via GetFirstTagSafe.
@@ -3109,11 +2883,10 @@ static void AppendSearchProgress(CECTag &out, wxUIntPtr sid)
 		out.AddTag(EC_TAG_SEARCH_NAME, theApp->searchlist->GetSearchStringById(sid));
 		out.AddTag(CECTag(EC_TAG_SEARCH_RESULT_COUNT,
 			static_cast<uint32>(theApp->searchlist->GetSearchResults(sid).size())));
-		// Also emit the standard lifecycle tags (mapped from the browse
-		// status) so amuleapi / amuleweb consume a browse through their
-		// existing SEARCH_PROGRESS handling with no special-casing:
-		// browsing -> RUNNING, finished/failed -> FINISHED. Percent is the
-		// dir-based bar value (0..100), snapped to 100 once terminal.
+		// Also emit the standard lifecycle tags, mapped from the browse status, so
+		// amuleapi / amuleweb consume a browse through their existing
+		// SEARCH_PROGRESS handling with no special-casing: browsing -> RUNNING,
+		// finished/failed -> FINISHED. Percent is the dir-based bar value.
 		const bool browsing = browseStatus == BROWSE_IN_PROGRESS;
 		out.AddTag(CECTag(EC_TAG_SEARCH_LIFECYCLE_STATE,
 			static_cast<uint8>(browsing ? CSearchList::SEARCH_LIFECYCLE_RUNNING
@@ -3127,16 +2900,15 @@ static void AppendSearchProgress(CECTag &out, wxUIntPtr sid)
 	const CSearchList::SearchLifecycleState st = theApp->searchlist->GetSearchLifecycleStateById(sid);
 	const uint8 pct = theApp->searchlist->GetSearchLifecyclePercentById(sid);
 	// EC_TAG_SEARCH_STATUS: the overloaded sentinel the GUI decodes in
-	// Search_Update_Progress — a finished Kad search reports 0xfffe (clears the
-	// "!" marker + resets the bar), a finished ed2k search 0xffff, otherwise the
-	// running percent. Shared with the monolithic bar via GetSearchBarStatusById.
+	// Search_Update_Progress -- a finished Kad search reports 0xfffe (clears the
+	// "!" marker and resets the bar), a finished ed2k search 0xffff, otherwise
+	// the running percent. Shared with the monolithic bar.
 	out.AddTag(CECTag(EC_TAG_SEARCH_STATUS, theApp->searchlist->GetSearchBarStatusById(sid)));
 	// Echo the ID so the client can confirm which search this is for.
 	out.AddTag(CECTag(EC_TAG_SEARCH_ID, static_cast<uint32>(sid)));
 	// ...and the query it was started with, so a progress reply is readable on
-	// its own. The search list carries the same tag from the same source; a
-	// client that polls progress per tab should not have to fetch the list as
-	// well just to label it.
+	// its own: a client that polls progress per tab should not have to fetch the
+	// list as well just to label it.
 	out.AddTag(EC_TAG_SEARCH_NAME, theApp->searchlist->GetSearchStringById(sid));
 	out.AddTag(CECTag(EC_TAG_SEARCH_LIFECYCLE_STATE, static_cast<uint8>(st)));
 	// Per-id kind (not the scalar): a multi-search client polls each tab by id
@@ -3153,11 +2925,8 @@ static void AppendSearchProgress(CECTag &out, wxUIntPtr sid)
 // per search, so a client with N open tabs polls once instead of N times.
 //
 // Enumerates searches *and* browse ids -- unlike Get_EC_Response_Search_List,
-// which is deliberately narrow because it drives tab *discovery* and folding
-// browses in there would invent a bogus search tab per open browse. Nothing is
-// discovered here: a client only ever looks up ids it already has tabs for, so
-// including browses is exactly right and is what lets a "View Files" tab share
-// the one poll.
+// which is deliberately narrow because it drives tab *discovery*. Nothing is
+// discovered here: a client only ever looks up ids it already has tabs for.
 //
 // There is no EC_TAG_SEARCH_EXPIRED in the union. The per-id form needs it
 // because a reply about one id is otherwise indistinguishable from silence;
@@ -3169,11 +2938,9 @@ static CECPacket *Get_EC_Response_Search_Progress_Union(const CECPacket *request
 	CECPacket *response = new CECPacket(EC_OP_SEARCH_PROGRESS);
 
 	// The ids the client is actually tracking, when it names them. It costs
-	// nothing to carry -- they ride in the one request either way -- and it
-	// keeps the LRU meaning exactly what it meant before: Touch marks the
-	// searches a client still has open. Touching everything the daemon holds
-	// instead would make an abandoned search as protected as a live tab, so the
-	// search evicted by an overflowing ring stops being the least-used one.
+	// nothing to carry and it keeps the LRU meaning what it meant before: Touch
+	// marks the searches a client still has open. Touching everything the daemon
+	// holds would make an abandoned search as protected as a live tab.
 	std::vector<uint32> wanted;
 	for (const CECTag &tag : *request) {
 		if (tag.GetTagName() == EC_TAG_SEARCH_ID) {
@@ -3182,9 +2949,8 @@ static CECPacket *Get_EC_Response_Search_Progress_Union(const CECPacket *request
 	}
 
 	auto emitOne = [&](wxUIntPtr sid) {
-		// Same guard as the per-id path: Touch() on an id the registry does
-		// not know would silently insert it, growing the ring past
-		// kMaxEcSearches for ids Register() never admitted.
+		// Same guard as the per-id path: Touch() on an id the registry does not
+		// know would silently insert it, growing the ring past kMaxEcSearches.
 		if (s_ecSearches.Has(static_cast<uint32>(sid))) {
 			s_ecSearches.Touch(static_cast<uint32>(sid));
 		}
@@ -3194,12 +2960,11 @@ static CECPacket *Get_EC_Response_Search_Progress_Union(const CECPacket *request
 	};
 
 	if (!wanted.empty()) {
-		// Answer about the ids the client named, resolving each one exactly as
-		// the per-id form does. Deliberately NOT a walk of the daemon's own
-		// maps filtered by these ids: a Kad search is addressed by an id with
-		// the high bit set (0x80000001...), which is not the key those maps are
-		// stored under, so filtering silently dropped every Kad search from the
-		// reply and the client read that absence as an expiry.
+		// Answer about the ids the client named, resolving each exactly as the
+		// per-id form does. Deliberately NOT a walk of the daemon's own maps
+		// filtered by these ids: a Kad search is addressed by an id with the high
+		// bit set, which is not the key those maps are stored under, so filtering
+		// silently dropped every Kad search and the client read that as expiry.
 		for (uint32 want : wanted) {
 			// The gate the per-id path uses -- the core's own knowledge, which
 			// covers browse ids too (see IsKnownSearchId). An id that fails it
@@ -3252,25 +3017,20 @@ static CECPacket *Get_EC_Response_Search_Stop(const CECPacket *request, bool mul
 {
 	CECPacket *reply = new CECPacket(EC_OP_MISC_DATA);
 	if (multiSearch) {
-		// Per-ID stop. No ID => the most-recently-started search. Gate on the
-		// core's own knowledge (CSearchList::IsKnownSearchId), not
-		// s_ecSearches: a monolithic-started search is known to the core but
-		// was never Register()'d into that EC-only registry, so gating on
-		// the registry alone silently no-ops both Stop and Close for it --
-		// the search never actually goes away and reappears as a tab on the
-		// next connect.
+		// Per-ID stop. No ID means the most-recently-started search. Gate on the
+		// core's own knowledge (CSearchList::IsKnownSearchId), not s_ecSearches: a
+		// monolithic-started search is known to the core but was never Register()'d
+		// into that EC-only registry, so gating on the registry alone silently
+		// no-ops both Stop and Close for it.
 		const CECTag *idTag = request->GetTagByName(EC_TAG_SEARCH_ID);
 		uint32 sid = idTag ? static_cast<uint32>(idTag->GetInt()) : s_ecSearches.Current();
 		if (sid != 0 && theApp->searchlist->IsKnownSearchId(sid)) {
 			if (request->GetTagByName(EC_TAG_SEARCH_CLOSE)) {
-				// Tab close: stop activity, free results, drop from the ring.
-				// Free the core's state unconditionally -- that is what
-				// actually stops a running Kad search and erases the
-				// per-id maps (including m_searchStrings, which is what
-				// stops the search reappearing as a discovered tab). Only
-				// touch the registry's own bookkeeping (LRU/current) when
-				// it's a search the registry actually tracks -- same
-				// discipline as guarding Touch() behind Has() last round.
+				// Tab close: stop activity, free results, drop from the ring. Free the
+				// core's state unconditionally -- that is what actually stops a running
+				// Kad search and erases the per-id maps, including m_searchStrings,
+				// which is what stops the search reappearing as a discovered tab. Only
+				// touch the registry's own bookkeeping for a search it tracks.
 				theApp->searchlist->RemoveResults(sid);
 				if (s_ecSearches.Has(sid)) {
 					s_ecSearches.Forget(sid);
@@ -3289,17 +3049,13 @@ static CECPacket *Get_EC_Response_Search_Stop(const CECPacket *request, bool mul
 static CECPacket *Get_EC_Response_Search_Request_More(const CECPacket *request, bool multiSearch)
 {
 	// "More" button (Kad-only): re-ask already-queried peers for a wider result
-	// frontier for one search. RequestMoreResults logs what actually happened
-	// (the single source of truth shared with the monolithic GUI) and that line
-	// is forwarded back to amuleGUI over EC; the reply carries the other half,
-	// whether a LATER press could still widen the search, which is what a
-	// client greys its control on.
+	// frontier for one search. RequestMoreResults logs what actually happened,
+	// and that line is forwarded back over EC; the reply carries the other half,
+	// whether a LATER press could still widen the search.
 	CECPacket *reply = new CECPacket(EC_OP_MISC_DATA);
-	// Per-ID. No ID => the most-recently-started search. Gate on the core's
-	// own knowledge (CSearchList::IsKnownSearchId), not s_ecSearches -- see
-	// the matching comment in Get_EC_Response_Search_Stop: a monolithic-
-	// started Kad search's "More results" button would otherwise silently
-	// do nothing.
+	// Per-ID. No ID means the most-recently-started search. Gate on the core's
+	// own knowledge, not s_ecSearches -- see Get_EC_Response_Search_Stop: a
+	// monolithic-started Kad search's "More results" would otherwise do nothing.
 	const CECTag *idTag = request->GetTagByName(EC_TAG_SEARCH_ID);
 	uint32 sid =
 		idTag ? static_cast<uint32>(idTag->GetInt()) : (multiSearch ? s_ecSearches.Current() : 0);
@@ -3307,14 +3063,12 @@ static CECPacket *Get_EC_Response_Search_Request_More(const CECPacket *request, 
 	if (sid != 0 && (!multiSearch || theApp->searchlist->IsKnownSearchId(sid))) {
 		reaskable = theApp->searchlist->RequestMoreResults(sid);
 	}
-	// Emitted on BOTH paths, including the unknown-id early-out above (which
+	// Emitted on BOTH paths, including the unknown-id early-out above, which
 	// leaves it false -- a search the core does not hold is terminal by
-	// definition). That way an absent tag means exactly one thing to the
-	// client: a daemon older than this reply, whose answer is unknown rather
-	// than "exhausted".
+	// definition. That way an absent tag means exactly one thing: a daemon
+	// older than this reply, whose answer is unknown rather than "exhausted".
 	reply->AddTag(CECTag(EC_TAG_SEARCH_MORE_REASKABLE, static_cast<uint8>(reaskable ? 1 : 0)));
-	// Echo which search the verdict is about. The request may not have named
-	// one (a client without multi-search leaves it to s_ecSearches.Current()),
+	// Echo which search the verdict is about. The request may not have named one,
 	// and a client with several tabs open cannot attribute a bare reply to any
 	// of them -- the replies are not correlated any other way.
 	if (sid != 0) {
@@ -3356,15 +3110,13 @@ static CECPacket *Get_EC_Response_Search(const CECPacket *request, bool multiSea
 										: LocalSearch;
 
 		if (multiSearch) {
-			// START is additive — it does not stop sibling searches. But
-			// ed2k (local/global) share a single in-flight slot and file
-			// their results under the scalar m_currentSearch, so starting a
-			// NEW ed2k search must finalize any in-flight ed2k search first;
-			// otherwise its late UDP results would land in the new search's
-			// bucket. A Kad search uses its own ID and its own machinery, so
-			// it must NOT disturb a running ed2k search — the two coexist
-			// (starting a Kad search here used to kill an in-flight global
-			// search, which then returned zero results).
+			// START is additive -- it does not stop sibling searches. But ed2k
+			// (local/global) share a single in-flight slot and file their results
+			// under the scalar m_currentSearch, so starting a NEW ed2k search must
+			// finalize any in-flight one first, or its late UDP results land in the
+			// new search's bucket. A Kad search uses its own ID and machinery, so it
+			// must NOT disturb a running ed2k search -- doing so used to kill an
+			// in-flight global search, which then returned zero results.
 			if (core_search_type != KadSearch) {
 				theApp->searchlist->StopInFlightEd2kSearch();
 			}
@@ -3405,16 +3157,13 @@ static CECPacket *Get_EC_Response_Search(const CECPacket *request, bool multiSea
 		reply->AddTag(CECTag(EC_TAG_SEARCH_ID, search_id));
 	}
 	if (multiSearch) {
-		// Echo the client's correlation token (if any) on BOTH outcomes, not
-		// just success: the client created its optimistic tab before sending
-		// and has no other way to tell which start this verdict answers. On
-		// failure it needs the token to drop that phantom tab and release the
-		// discovery deferral -- otherwise the id sits in m_pendingSearchStarts
-		// until the user happens to close exactly that tab, with an
-		// EC_OP_SEARCH_LIST round trip every tick and discovery off in the
-		// meantime. Same principle as echoing the id on EC_TAG_SEARCH_EXPIRED:
-		// a verdict the client cannot correlate is one it cannot act on
-		// (got3nks, PR #680 review).
+		// Echo the client's correlation token (if any) on BOTH outcomes, not just
+		// success: the client created its optimistic tab before sending and has no
+		// other way to tell which start this verdict answers. On failure it needs
+		// the token to drop that phantom tab and release the discovery deferral --
+		// otherwise the id sits in m_pendingSearchStarts until the user happens to
+		// close exactly that tab, with an EC_OP_SEARCH_LIST round trip every tick
+		// and discovery off in the meantime.
 		const CECTag *ref = request->GetTagByName(EC_TAG_SEARCH_REF);
 		if (ref) {
 			reply->AddTag(CECTag(EC_TAG_SEARCH_REF, static_cast<uint32>(ref->GetInt())));
@@ -3450,14 +3199,10 @@ static CECPacket *Get_EC_Response_Set_SharedFile_Prio(const CECPacket *request)
 
 void CPartFile_Encoder::Encode(CECTag *parent)
 {
-	//
 	// Source part frequencies
-	//
 	CKnownFile_Encoder::Encode(parent);
 
-	//
 	// Gaps
-	//
 	const CGapList &gaplist = m_PartFile()->GetGapList();
 	const size_t gap_list_size = gaplist.size();
 	ArrayOfUInts64 gaps;
@@ -3476,9 +3221,7 @@ void CPartFile_Encoder::Encode(CECTag *parent)
 	}
 	delete[] gap_enc_data;
 
-	//
 	// Requested blocks
-	//
 	ArrayOfUInts64 req_buffer;
 	const CPartFile::CReqBlockPtrList &requestedblocks = m_PartFile()->GetRequestedBlockList();
 	CPartFile::CReqBlockPtrList::const_iterator curr_pos2 = requestedblocks.begin();
@@ -3495,11 +3238,7 @@ void CPartFile_Encoder::Encode(CECTag *parent)
 	}
 	delete[] req_enc_data;
 
-	//
-	// Source names
-	//
-	// First count occurrence of all source names
-	//
+	// Source names -- first count occurrence of all source names
 	CECEmptyTag sourceNames(EC_TAG_PARTFILE_SOURCE_NAMES);
 	typedef std::map<wxString, int> strIntMap;
 	strIntMap nameMap;
@@ -3517,9 +3256,7 @@ void CPartFile_Encoder::Encode(CECTag *parent)
 			itm->second++;
 		}
 	}
-	//
 	// Go through our last list
-	//
 	for (SourcenameItemMap::iterator it1 = m_sourcenameItemMap.begin();
 		it1 != m_sourcenameItemMap.end();) {
 		SourcenameItemMap::iterator it2 = it1++;
@@ -3543,9 +3280,7 @@ void CPartFile_Encoder::Encode(CECTag *parent)
 			nameMap.erase(itm);
 		}
 	}
-	//
 	// Add new names
-	//
 	for (strIntMap::iterator it3 = nameMap.begin(); it3 != nameMap.end(); ++it3) {
 		int id = ++m_sourcenameID;
 		CECIntTag tag(EC_TAG_PARTFILE_SOURCE_NAMES, id);
@@ -3569,10 +3304,7 @@ void CPartFile_Encoder::ResetEncoder()
 
 void CKnownFile_Encoder::Encode(CECTag *parent)
 {
-	//
-	// Source part frequencies
-	//
-	// Reference to the availability list
+	// Source part frequencies. Reference to the availability list.
 	const ArrayOfUInts16 &list = m_file->IsPartFile()
 					     ? static_cast<const CPartFile *>(m_file)->m_SrcpartFrequency
 					     : m_file->m_AvailPartFrequency;
@@ -3624,17 +3356,17 @@ static CECPacket *GetStatsGraphs(const CECPacket *request)
 				EC_TAG_STATSGRAPH_DATA_CONN, 2 * numPoints * sizeof(uint32), connData));
 			delete[] graphData;
 			delete[] connData;
-			// Latest session totals — let amulegui compute the same
-			// kBytesReceived / sTimestamp session average monolithic
-			// shows, instead of falling back to a GUI-local integral.
+			// Latest session totals -- let amulegui compute the same
+			// kBytesReceived / sTimestamp session average monolithic shows,
+			// instead of falling back to a GUI-local integral.
 			response->AddTag(CECTag(EC_TAG_STATSGRAPH_SESSION_DL, sessionDl));
 			response->AddTag(CECTag(EC_TAG_STATSGRAPH_SESSION_UL, sessionUl));
 			response->AddTag(CECTag(EC_TAG_STATSGRAPH_SESSION_KAD, sessionKad));
 			response->AddTag(CECTag(EC_TAG_STATSGRAPH_SESSION_TIMESPAN, sessionTimespan));
-			// How deep we can actually answer at the requested scale, so
-			// the client can cap its next request instead of guessing.
-			// Over-asking gets a record repeated rather than an error,
-			// and without timestamps on the wire the client cannot see it.
+			// How deep we can actually answer at the requested scale, so the client
+			// can cap its next request instead of guessing. Over-asking gets a
+			// record repeated rather than an error, and without timestamps on the
+			// wire the client cannot see it.
 			response->AddTag(
 				CECTag(EC_TAG_STATSGRAPH_DEPTH, (uint16)CStatistics::GetPointsPerRange()));
 			response->AddTag(CECTag(EC_TAG_STATSGRAPH_LAST, dTimestamp));
@@ -3671,9 +3403,7 @@ CECPacket *CECServerSocket::ProcessRequest2(const CECPacket *request)
 	CECPacket *response = NULL;
 
 	switch (request->GetOpCode()) {
-	//
 	// Misc commands
-	//
 	case EC_OP_SHUTDOWN:
 		if (!theApp->IsOnShutDown()) {
 			response = new CECPacket(EC_OP_NOOP);
@@ -3693,10 +3423,9 @@ CECPacket *CECServerSocket::ProcessRequest2(const CECPacket *request)
 		}
 		break;
 	case EC_OP_ADD_LINK: {
-		// Aggregate the per-link results into a single response: until
-		// #206 was filed, every iteration overwrote the previous response,
-		// so a batch of N-1 successes followed by one failure looked like
-		// a total failure to the caller (and vice versa).
+		// Aggregate the per-link results into a single response: every iteration
+		// used to overwrite the previous one, so a batch of N-1 successes
+		// followed by one failure looked like a total failure, and vice versa.
 		int successCount = 0;
 		int failCount = 0;
 		for (CECPacket::const_iterator it = request->begin(); it != request->end(); ++it) {
@@ -3730,18 +3459,16 @@ CECPacket *CECServerSocket::ProcessRequest2(const CECPacket *request)
 		}
 		break;
 	}
-	//
 	// Status requests
-	//
 	case EC_OP_STAT_REQ:
 		response = Get_EC_Response_StatRequest(request, m_LoggerAccess);
 		response->AddTag(CEC_ConnState_Tag(request->GetDetailLevel()));
 		break;
 	case EC_OP_VERSION_CHECK:
 		// On-demand version check trigger (amuleapi's POST /version/check).
-		// Fire-and-forget: StartVersionCheck() kicks off the async fetch and
-		// the result is relayed later via the stats response. EC_OP_NOOP =
-		// accepted; EC_OP_FAILED = throttled or (compiled out) unavailable.
+		// Fire-and-forget: StartVersionCheck() kicks off the async fetch and the
+		// result is relayed later via the stats response. EC_OP_NOOP = accepted;
+		// EC_OP_FAILED = throttled or compiled out.
 #ifdef ENABLE_VERSION_CHECK
 		if (theApp->StartVersionCheck()) {
 			response = new CECPacket(EC_OP_NOOP);
@@ -3760,19 +3487,14 @@ CECPacket *CECServerSocket::ProcessRequest2(const CECPacket *request)
 		response = new CECPacket(EC_OP_MISC_DATA);
 		response->AddTag(CEC_ConnState_Tag(request->GetDetailLevel()));
 		break;
-	//
-	//
-	//
 	case EC_OP_GET_SHARED_FILES:
 		if (request->GetDetailLevel() == EC_DETAIL_FULL &&
 			CTagSet<uint32, EC_TAG_KNOWNFILE>(request).empty() &&
 			(m_my_flags & EC_FLAG_UTF8_NUMBERS) && (m_my_flags & EC_FLAG_LARGE_TAG_COUNT)) {
-			// Per-file bytes cache. Daemon-wide map<ECID, bytes>
-			// keyed off CKnownFile::s_globalEcGen; rebuilds only
-			// per-file entries whose gen advanced since last use.
-			// Concatenated and written through the connection's
-			// socket with the same per-connection compression
-			// machinery WritePacket uses.
+			// Per-file bytes cache: a daemon-wide map<ECID, bytes> keyed off
+			// CKnownFile::s_globalEcGen, rebuilding only entries whose gen advanced
+			// since last use. Concatenated and written through the connection's
+			// socket with the same per-connection compression WritePacket uses.
 			std::vector<CKnownFile *> snapshot;
 			theApp->sharedfiles->CopyFileList(snapshot);
 			std::vector<CECFullResponseCache::FileRef> refs;
@@ -3837,9 +3559,7 @@ CECPacket *CECServerSocket::ProcessRequest2(const CECPacket *request)
 		response = Get_EC_Response_ClientHistory();
 		break;
 
-	//
 	// This will evolve into an update-all for inc tags
-	//
 	case EC_OP_GET_UPDATE:
 		if (request->GetDetailLevel() == EC_DETAIL_INC_UPDATE) {
 			response = Get_EC_Response_GetUpdate(m_FileEncoder,
@@ -3919,13 +3639,10 @@ CECPacket *CECServerSocket::ProcessRequest2(const CECPacket *request)
 		break;
 	}
 	case EC_OP_CLIENT_SWAP_TO_ANOTHER_FILE: {
-		// Report what happened rather than answering NOOP either way. The swap
-		// is best-effort in the core -- it refuses a peer that is actively
-		// sending, and a peer that is not an A4AF source of the target has
-		// nowhere to go -- and a caller that cannot tell those apart from
-		// success can only guess. amulegui registers a null handler for this
-		// op and discards the reply whatever its opcode, so nothing on that
-		// side needs to change.
+		// Report what happened rather than answering NOOP either way. The swap is
+		// best-effort in the core -- it refuses a peer that is actively sending,
+		// and a peer that is not an A4AF source of the target has nowhere to go --
+		// and a caller that cannot tell those apart from success can only guess.
 		uint32 idClient = request->GetTagByNameSafe(EC_TAG_CLIENT)->GetInt();
 		CUpDownClient *client = theApp->clientlist->FindClientByECID(idClient);
 		CMD4Hash idFile = request->GetTagByNameSafe(EC_TAG_PARTFILE)->GetMD4Data();
@@ -3979,12 +3696,11 @@ CECPacket *CECServerSocket::ProcessRequest2(const CECPacket *request)
 			file = theApp->searchlist->GetSearchFileByID(hash);
 		}
 		if (file && file->RequestKadNoteSearch()) {
-			// One Kad NOTES lookup runs per hash, but the same file can be shown
-			// in several open search tabs (one CSearchFile each).
-			// RequestKadNoteSearch set the running flag only on the object it ran
-			// on; mirror it onto every same-hash search result so each tab shows
-			// the in-flight lookup. The flag is cleared on all of them when the
-			// CSearch ends, and the retrieved notes fan out the same way.
+			// One Kad NOTES lookup runs per hash, but the same file can be shown in
+			// several open search tabs (one CSearchFile each). RequestKadNoteSearch
+			// set the running flag only on the object it ran on; mirror it onto every
+			// same-hash search result so each tab shows the in-flight lookup. The
+			// flag is cleared on all of them when the CSearch ends.
 			std::vector<CSearchFile *> searchFiles;
 			theApp->searchlist->GetAllSearchFilesByID(hash, searchFiles);
 			for (CSearchFile *sf : searchFiles) {
@@ -3995,9 +3711,7 @@ CECPacket *CECServerSocket::ProcessRequest2(const CECPacket *request)
 		break;
 	}
 
-	//
 	// Server commands
-	//
 	case EC_OP_SERVER_ADD:
 		response = Get_EC_Response_Server_Add(request);
 		break;
@@ -4046,16 +3760,12 @@ CECPacket *CECServerSocket::ProcessRequest2(const CECPacket *request)
 		response = new CECPacket(EC_OP_NOOP);
 		break;
 	}
-	//
 	// Friends
-	//
 	case EC_OP_FRIEND:
 		response = Get_EC_Response_Friend(request, m_multiSearchActive);
 		break;
 
-	//
 	// IPFilter
-	//
 	case EC_OP_IPFILTER_RELOAD:
 		NotifyAlways_IPFilter_Reload();
 		response = new CECPacket(EC_OP_NOOP);
@@ -4070,9 +3780,7 @@ CECPacket *CECServerSocket::ProcessRequest2(const CECPacket *request)
 		response = new CECPacket(EC_OP_NOOP);
 		break;
 	}
-	//
 	// Search
-	//
 	case EC_OP_SEARCH_START:
 		response = Get_EC_Response_Search(request, m_multiSearchActive);
 		break;
@@ -4108,11 +3816,10 @@ CECPacket *CECServerSocket::ProcessRequest2(const CECPacket *request)
 		if (m_multiSearchActive) {
 			const CECTag *idTag = request->GetTagByName(EC_TAG_SEARCH_ID);
 			uint32 want = idTag ? static_cast<uint32>(idTag->GetInt()) : s_ecSearches.Current();
-			// Gate on the core's own knowledge (CSearchList::IsKnownSearchId),
-			// not s_ecSearches: that registry only ever holds EC-initiated
-			// searches (Register() runs from the EC_OP_SEARCH_START handler
-			// alone), so gating on it reports a monolithic-started search as
-			// expired even while it is still running.
+			// Gate on the core's own knowledge (CSearchList::IsKnownSearchId), not
+			// s_ecSearches: that registry only ever holds EC-initiated searches, so
+			// gating on it reports a monolithic-started search as expired even while
+			// it is still running.
 			if (want == 0 || !theApp->searchlist->IsKnownSearchId(want)) {
 				// Evicted or never-known: tell the client it expired rather
 				// than returning a misleading empty result set.
@@ -4120,11 +3827,10 @@ CECPacket *CECServerSocket::ProcessRequest2(const CECPacket *request)
 				response->AddTag(CECEmptyTag(EC_TAG_SEARCH_EXPIRED));
 				break;
 			}
-			// Only bump the EC-session LRU for a search that registry
-			// actually tracks -- Touch() on an id it doesn't know would
-			// silently insert it (push_front has no "was it found" guard),
-			// growing the ring past kMaxEcSearches for ids Register() never
-			// admitted through its own eviction loop.
+			// Only bump the EC-session LRU for a search the registry actually tracks
+			// -- Touch() on an id it does not know would silently insert it
+			// (push_front has no "was it found" guard), growing the ring past
+			// kMaxEcSearches for ids Register() never admitted.
 			if (s_ecSearches.Has(want)) {
 				s_ecSearches.Touch(want);
 			}
@@ -4143,9 +3849,8 @@ CECPacket *CECServerSocket::ProcessRequest2(const CECPacket *request)
 		// Union form, decided before anything is allocated. A client that
 		// advertised EC_TAG_CAN_SEARCH_PROGRESS_UNION always gets the union
 		// shape: naming ids narrows which searches come back, it does not opt
-		// back into the single-search reply. Gating this on "no ids named"
-		// instead would answer such a client about its FIRST id only and leave
-		// every other search out, which it reads as an expiry.
+		// back into the single-search reply. Gating on "no ids named" instead
+		// would answer such a client about its FIRST id only.
 		if (m_multiSearchActive && m_searchProgressUnionActive) {
 			response = Get_EC_Response_Search_Progress_Union(request);
 			break;
@@ -4160,17 +3865,13 @@ CECPacket *CECServerSocket::ProcessRequest2(const CECPacket *request)
 			// monolithic-started search's progress isn't reported as expired.
 			if (want == 0 || !theApp->searchlist->IsKnownSearchId(want)) {
 				response->AddTag(CECEmptyTag(EC_TAG_SEARCH_EXPIRED));
-				// Echo the id this verdict is about. amulegui reads the
-				// whole progress reply under `if (idTag)` -- it has to,
-				// since it polls several searches and the replies are not
-				// correlated any other way -- so an EXPIRED carrying no id
-				// was silently unreadable: the tab for a search the core
-				// had already freed stayed open forever, its results
-				// dropped by the next union poll, leaving a tab whose rows
-				// point at nothing (sorting/scrolling it does nothing).
-				// `want` is safe to echo even for an unknown id: it is the
-				// value the client itself just asked about (got3nks, PR
-				// #680 review).
+				// Echo the id this verdict is about. amulegui reads the whole progress
+				// reply under `if (idTag)` -- it has to, since it polls several
+				// searches and the replies are not correlated any other way -- so an
+				// EXPIRED carrying no id was silently unreadable: the tab for a search
+				// the core had already freed stayed open forever, its results dropped
+				// by the next union poll. `want` is safe to echo even for an unknown
+				// id: it is the value the client itself just asked about.
 				if (want != 0) {
 					response->AddTag(CECTag(EC_TAG_SEARCH_ID, want));
 				}
@@ -4204,21 +3905,17 @@ CECPacket *CECServerSocket::ProcessRequest2(const CECPacket *request)
 	case EC_OP_DOWNLOAD_SEARCH_RESULT:
 		response = Get_EC_Response_Search_Results_Download(request);
 		break;
-	//
 	// Preferences
-	//
 	case EC_OP_GET_PREFERENCES:
 		response = new CEC_Prefs_Packet(
 			request->GetTagByNameSafe(EC_TAG_SELECT_PREFS)->GetInt(), request->GetDetailLevel());
 		break;
 	case EC_OP_SET_PREFERENCES: {
 		static_cast<const CEC_Prefs_Packet *>(request)->Apply();
-		// Apply() left any amuleapi password the client sent sitting in
-		// the preferences as a pending request; this is what turns it
-		// into a stored, stretched record in amuleapi-passwords. Logged
-		// rather than returned as an EC error: the rest of the
-		// preferences applied fine, and failing the whole call would
-		// misreport that.
+		// Apply() left any amuleapi password the client sent sitting in the
+		// preferences as a pending request; this is what turns it into a stored,
+		// stretched record in amuleapi-passwords. Logged rather than returned as
+		// an EC error: the rest of the preferences applied fine.
 		wxString credentialError;
 		if (!AmuleApiCredentials::ApplyPrefs(credentialError)) {
 			AddLogLineC(CFormat(_("Could not save the amuleapi password: %s")) % credentialError);
@@ -4262,14 +3959,12 @@ CECPacket *CECServerSocket::ProcessRequest2(const CECPacket *request)
 			CEC_Category_Tag tag(
 				*static_cast<const CEC_Category_Tag *>(request->GetFirstTagSafe()));
 			if (tag.GetInt() >= theApp->glob_prefs->GetCatCount()) {
-				// No such category. Deliberately WITHOUT
-				// EC_TAG_CATEGORY_PATH: on a failed update that tag means
-				// "everything but the path was applied, and here is the
-				// path kept instead", which clients answer as a success
-				// (amule-org/amule#1213). Emitting it here would report a
-				// category that does not exist as updated. The index is
-				// whatever the client sent -- it used to be indexed
-				// straight into m_CatList (amule-org/amule#1227).
+				// No such category. Deliberately WITHOUT EC_TAG_CATEGORY_PATH: on a
+				// failed update that tag means "everything but the path was applied,
+				// and here is the path kept instead", which clients answer as a
+				// success. Emitting it here would report a category that does not
+				// exist as updated. The index is whatever the client sent -- it used
+				// to be indexed straight into m_CatList.
 				response = new CECPacket(EC_OP_FAILED);
 				response->AddTag(CECTag(EC_TAG_CATEGORY, tag.GetInt()));
 				response->AddTag(CECTag(EC_TAG_STRING, wxTRANSLATE("No such category.")));
@@ -4290,11 +3985,11 @@ CECPacket *CECServerSocket::ProcessRequest2(const CECPacket *request)
 		}
 		break;
 	case EC_OP_DELETE_CATEGORY:
-		// Rejections answer EC_OP_FAILED, not the blanket EC_OP_NOOP this used
-		// to send: the guards downstream discard these silently, so a client
-		// could not tell a completed delete from a discarded one
-		// (amule-org/amule#1231). Never attach EC_TAG_CATEGORY_PATH -- on a
-		// failed category command clients read it as success (#1213).
+		// Rejections answer EC_OP_FAILED, not the blanket EC_OP_NOOP this used to
+		// send: the guards downstream discard these silently, so a client could
+		// not tell a completed delete from a discarded one. Never attach
+		// EC_TAG_CATEGORY_PATH -- on a failed category command clients read it
+		// as success.
 		if (request->GetTagCount() != 1) {
 			response = new CECPacket(EC_OP_FAILED);
 			response->AddTag(CECTag(EC_TAG_STRING, wxTRANSLATE("Malformed category request.")));
@@ -4318,9 +4013,7 @@ CECPacket *CECServerSocket::ProcessRequest2(const CECPacket *request)
 		}
 		break;
 
-	//
 	// Logging
-	//
 	case EC_OP_ADDLOGLINE:
 		// cppcheck-suppress duplicateBranch
 		if (request->GetTagByName(EC_TAG_LOG_TO_STATUS) != NULL) {
@@ -4396,15 +4089,14 @@ CECPacket *CECServerSocket::ProcessRequest2(const CECPacket *request)
 		break;
 	}
 	case EC_OP_REFRESH_MEDIA_METADATA: {
-		// Re-extract media metadata: for one file when the request names a
-		// hash, otherwise for the whole share. Answers immediately with how
-		// many probes were queued -- the work happens on the media-probe
-		// worker, so a large library does not block this EC lane.
-		// Disabled is not the same answer as "nothing was eligible", and both
-		// used to arrive as queued = 0. A caller cannot act on that: a share
-		// with no media in it legitimately queues nothing. Answered first, and
-		// as a failure, so REST turns it into an error naming the reason
-		// instead of a cheerful 202 that did nothing.
+		// Re-extract media metadata: for one file when the request names a hash,
+		// otherwise for the whole share. Answers immediately with how many probes
+		// were queued -- the work happens on the media-probe worker.
+		//
+		// Disabled is not the same answer as "nothing was eligible", and both used
+		// to arrive as queued = 0. A caller cannot act on that: a share with no
+		// media in it legitimately queues nothing. Answered first, and as a
+		// failure, so REST turns it into an error naming the reason.
 		if (!thePrefs::GetMediaMetadataEnabled()) {
 			response = new CECPacket(EC_OP_FAILED);
 			response->AddTag(CECTag(EC_TAG_STRING,
@@ -4426,11 +4118,9 @@ CECPacket *CECServerSocket::ProcessRequest2(const CECPacket *request)
 		} else if (!hashes.empty()) {
 			const CMD4Hash hash = hashes.front();
 			if (!theApp->sharedfiles->RefreshMediaMetadata(hash)) {
-				// The caller already resolved the hash against its own
-				// snapshot, so "no such file" is not the reason by the time
-				// this runs -- what is left is a file whose extension is not
-				// audio/video, or an in-progress download. Say that, rather
-				// than a message whose first half can no longer be true.
+				// The caller already resolved the hash against its own snapshot, so "no
+				// such file" is not the reason by the time this runs -- what is left is
+				// a file whose extension is not audio/video, or an in-progress download.
 				response = new CECPacket(EC_OP_FAILED);
 				response->AddTag(CECTag(EC_TAG_STRING,
 					wxTRANSLATE("File is not eligible for media metadata "
@@ -4457,10 +4147,9 @@ CECPacket *CECServerSocket::ProcessRequest2(const CECPacket *request)
 		// them forever.
 		response->AddTag(CECTag(EC_TAG_CHAT_MSG_ID, theApp->chatsessions->LastMsgId()));
 		for (const CChatSessionStore::Session *session : theApp->chatsessions->Sessions()) {
-			// Sessions with nothing new are still listed, with no message
-			// children: that is how a client that connected late learns the
-			// session exists, and how every client learns a session it is
-			// tracking was closed elsewhere (absence from this reply).
+			// Sessions with nothing new are still listed, with no message children:
+			// that is how a client that connected late learns the session exists, and
+			// how every client learns a session it is tracking was closed elsewhere.
 			response->AddTag(EncodeChatSession(*session, cursor));
 		}
 		break;
@@ -4480,9 +4169,9 @@ CECPacket *CECServerSocket::ProcessRequest2(const CECPacket *request)
 			break;
 		}
 		// Deliberately ignoring the bool: a false return means "queued while
-		// connecting", not "failed" — the desktop optimistically prints
-		// *** Connecting to Client *** — so turning it into EC_OP_FAILED
-		// would report an error for a message that arrives moments later.
+		// connecting", not "failed" -- the desktop optimistically prints
+		// *** Connecting to Client *** -- so turning it into EC_OP_FAILED would
+		// report an error for a message that arrives moments later.
 		theApp->clientlist->SendChatMessage(gui_id, text);
 		response = new CECPacket(EC_OP_NOOP);
 		response->AddTag(CECTag(EC_TAG_CHAT_CLIENT_ID, gui_id));
@@ -4510,9 +4199,7 @@ CECPacket *CECServerSocket::ProcessRequest2(const CECPacket *request)
 		response = new CECPacket(EC_OP_NOOP);
 		break;
 	}
-	//
 	// Statistics
-	//
 	case EC_OP_GET_STATSGRAPHS:
 		response = GetStatsGraphs(request);
 		break;
@@ -4534,9 +4221,7 @@ CECPacket *CECServerSocket::ProcessRequest2(const CECPacket *request)
 		break;
 	}
 
-	//
 	// Kad
-	//
 	case EC_OP_KAD_START:
 		if (thePrefs::GetNetworkKademlia()) {
 			response = new CECPacket(EC_OP_NOOP);
@@ -4579,10 +4264,7 @@ CECPacket *CECServerSocket::ProcessRequest2(const CECPacket *request)
 		}
 		break;
 
-	//
-	// Networks
-	// These requests are currently used only in the text client
-	//
+	// Networks. These requests are currently used only in the text client.
 	case EC_OP_CONNECT:
 		if (thePrefs::GetNetworkED2K()) {
 			response = new CECPacket(EC_OP_STRINGS);
@@ -4897,9 +4579,7 @@ CECPacket *ECClientMsgSource::GetNextPacket()
 	return 0;
 }
 
-//
 // Notification iface per-client
-//
 ECNotifier::ECNotifier() {}
 
 ECNotifier::~ECNotifier()
@@ -4911,9 +4591,7 @@ ECNotifier::~ECNotifier()
 CECPacket *ECNotifier::GetNextPacket(ECUpdateMsgSource *msg_source_array[])
 {
 	CECPacket *packet = 0;
-	//
 	// priority 0 is highest
-	//
 	for (int i = 0; i < EC_STATUS_LAST_PRIO; i++) {
 		if ((packet = msg_source_array[i]->GetNextPacket()) != 0) {
 			break;
@@ -4924,10 +4602,7 @@ CECPacket *ECNotifier::GetNextPacket(ECUpdateMsgSource *msg_source_array[])
 
 CECPacket *ECNotifier::GetNextPacket(CECServerSocket *sock)
 {
-	//
-	// OnOutput is called for a first time before
-	// socket is registered
-	//
+	// OnOutput is called for a first time before socket is registered
 	if (m_msg_source.count(sock)) {
 		ECUpdateMsgSource **notifier_array = m_msg_source[sock];
 		if (!notifier_array) {
@@ -4941,9 +4616,7 @@ CECPacket *ECNotifier::GetNextPacket(CECServerSocket *sock)
 	}
 }
 
-//
 // Interface to notification macros
-//
 void ECNotifier::DownloadFile_SetDirty(const CPartFile *file)
 {
 	for (std::map<CECServerSocket *, ECUpdateMsgSource **>::iterator i = m_msg_source.begin();
@@ -5051,10 +4724,9 @@ void ECNotifier::NextPacketToSocket()
 		CECServerSocket *sock = i->first;
 		if (sock->HaveNotificationSupport() && !sock->DataPending()) {
 			ECUpdateMsgSource **notifier_array = i->second;
-			// Same ownership contract as WriteDoneAndQueueEmpty: the
-			// CECPacket from GetNextPacket is caller-owned and
-			// SendPacket only serialises it.  Wrap so it's freed at
-			// scope exit (#765).
+			// Same ownership contract as WriteDoneAndQueueEmpty: the CECPacket from
+			// GetNextPacket is caller-owned and SendPacket only serialises it, so
+			// wrap it to be freed at scope exit.
 			CSmartPtr<CECPacket> packet(GetNextPacket(notifier_array));
 			if (packet) {
 				// printf("[EC] sending update packet; opcode=%x\n",packet->GetOpCode());

--- a/src/ExternalConnector.cpp
+++ b/src/ExternalConnector.cpp
@@ -279,11 +279,10 @@ CaMuleExternalConnector::~CaMuleExternalConnector()
 {
 	delete m_configFile;
 	delete m_locale;
-	// new'd in ConnectAndRun, DestroySocket'd at the end of that
-	// method but never delete'd -- process-exit reclaimed it, LSan
-	// flags the ~3 KB one-shot leak (CRemoteConnect + CECSocket /
-	// CQueuedData buffers). Ctor sets this to NULL so the delete is
-	// a no-op when ConnectAndRun was never entered. #704.
+	// new'd in ConnectAndRun and DestroySocket'd at the end of that method, but
+	// never delete'd -- process exit reclaimed it and LSan flagged the ~3 KB
+	// one-shot leak (#704). The ctor sets this to NULL, so the delete is a no-op
+	// when ConnectAndRun was never entered.
 	delete m_ECClient;
 	free(m_strFullVersion);
 	free(m_strOSDescription);
@@ -305,12 +304,10 @@ void CaMuleExternalConnector::OnInitCommandSet()
 void CaMuleExternalConnector::Show(const wxString &s)
 {
 	if (!m_KeepQuiet) {
-		// `utf8_str()` instead of `unicode2char()` so non-ASCII output
-		// (server messages, file names) doesn't collapse to `?` /
-		// U+FFFD when the connector is invoked in a `C` locale (#40).
-		// Connectors do call `setlocale(LC_ALL, "")` below, but in
-		// minimal container environments without `LANG`/`LC_ALL`
-		// exported, the C locale still falls back to `C`.
+		// `utf8_str()` instead of `unicode2char()`, so non-ASCII output does not
+		// collapse to `?` when the connector runs in a `C` locale (#40). Connectors
+		// do call setlocale(LC_ALL, "") below, but in minimal containers without
+		// LANG or LC_ALL exported the C locale still falls back to `C`.
 		printf("%s", (const char *)s.utf8_str());
 #ifdef __WINDOWS__
 		fflush(stdout);
@@ -442,7 +439,6 @@ void CaMuleExternalConnector::ConnectAndRun(const wxString &ProgName, const wxSt
 	Show(CFormat(_("This is %s %s\n")) % wxString::FromAscii(m_appname) % VERSION);
 #endif
 
-	// HostName, Port and Password
 	if (m_password.IsEmpty()) {
 		m_password = GetPassword(true);
 		// MD5 hash for an empty string, according to rfc1321.
@@ -453,7 +449,6 @@ void CaMuleExternalConnector::ConnectAndRun(const wxString &ProgName, const wxSt
 
 	if (!m_password.IsEmpty()) {
 
-		// Create the socket
 		Show(_("\nCreating client...\n"));
 		m_ECClient = new CRemoteConnect(NULL);
 		m_ECClient->SetCapabilities(m_ZLIB, true, false); // ZLIB, UTF8 numbers, notification
@@ -461,17 +456,14 @@ void CaMuleExternalConnector::ConnectAndRun(const wxString &ProgName, const wxSt
 		m_ECClient->SetCanAEAD(m_ECEncryption);
 		m_ECClient->SetCanMultiSearch(m_canMultiSearch);
 		m_ECClient->SetCanChatSessions(m_canChat);
-		// Bound the blocking EC connect so a wrong or unreachable host
-		// fails fast instead of hanging on the OS TCP connect timeout
-		// (which can be minutes). The GUI clients have their own async
-		// connect watchdog; this covers the synchronous CLI/EC clients.
-		// 15s matches the amulegui watchdog budget.
+		// Bound the blocking EC connect so a wrong or unreachable host fails fast
+		// instead of hanging out the OS TCP connect timeout, which can be minutes.
+		// The GUI clients have their own async watchdog; 15 s matches its budget.
 		m_ECClient->SetConnectTimeout(15000);
 
-		// ConnectToCore is blocking since m_ECClient was initialized with NULL
-		// m_port is parsed as a long (the option parser's type) and the EC
-		// client takes an int; the value is range-checked when it is read,
-		// so the cast is a narrowing the compiler should not have to guess at.
+		// ConnectToCore is blocking, m_ECClient having been initialized with NULL.
+		// m_port is a long (the option parser's type) and the EC client takes an
+		// int; the value is range-checked when read, so the cast is deliberate.
 		if (!m_ECClient->ConnectToCore(
 			    m_host, static_cast<int>(m_port), m_password.Encode(), ProgName, ProgVersion)) {
 			// no connection => close gracefully
@@ -480,9 +472,6 @@ void CaMuleExternalConnector::ConnectAndRun(const wxString &ProgName, const wxSt
 			}
 			Show(CFormat(_("Connection Failed. Unable to connect to %s:%d\n")) % m_host % m_port);
 		} else {
-			// Authenticate ourselves
-			// ConnectToCore() already authenticated for us.
-			// m_ECClient->ConnectionEstablished();
 			Show(m_ECClient->GetServerReply() + "\n");
 			if (m_ECClient->IsSocketConnected()) {
 				if (m_interactive) {
@@ -662,11 +651,9 @@ bool CaMuleExternalConnector::OnCmdLineParsed(wxCmdLineParser &parser)
 	parser.Found("log-file", &m_logFile);
 	m_noLogFile = parser.Found("no-log-file");
 
-	// Wire --verbose to the console logger gate so AddDebugLogLine* output
-	// from this binary obeys the CLI flag the same way amuled obeys its
-	// VerboseDebug pref. LoadAmuleConfig may have already set the gate
-	// from /eMule/VerboseDebug above; --verbose acts as an explicit
-	// runtime override when present.
+	// Wire --verbose to the console logger gate, so AddDebugLogLine* output from
+	// this binary obeys the CLI flag the way amuled obeys its VerboseDebug pref.
+	// LoadAmuleConfig may already have set the gate; --verbose overrides it.
 	if (m_Verbose) {
 		theLogger.SetVerbose(true);
 	}
@@ -693,15 +680,12 @@ void CaMuleExternalConnector::LoadConfigFile()
 		// password, and the stored value is what authenticates.
 		RestrictToOwner(CPath(m_configFileName));
 		m_language = m_configFile->Read("/Locale", "");
-		// Match the default across amulecmd / amuleweb / amulegui.
-		// Use the literal loopback address rather than "localhost":
-		// on Windows, "localhost" lookups can fail intermittently
-		// (IPv4 vs IPv6 stack ordering, Hosts file shape, ...),
-		// reported on #822 — `Connection Failed. Unable to connect
-		// to localhost:4712`. 127.0.0.1 is portable across every
-		// supported OS and unambiguous. The OnCmdLineParsed runtime
-		// fallback below keeps the "no config file at all" path
-		// covered as a safety net. (#821, #822)
+		// Match the default across amulecmd / amuleweb / amulegui. The literal
+		// loopback address rather than "localhost": on Windows those lookups can
+		// fail intermittently (IPv4 vs IPv6 stack ordering, Hosts file shape), which
+		// showed up as `Connection Failed. Unable to connect to localhost:4712`
+		// (#822). 127.0.0.1 is portable and unambiguous, and the OnCmdLineParsed
+		// fallback covers the "no config file at all" path.
 		m_host = m_configFile->Read("/EC/Host", "127.0.0.1");
 		m_port = m_configFile->Read("/EC/Port", 4712l);
 		m_configFile->ReadHash("/EC/Password", &m_password);
@@ -725,11 +709,9 @@ void CaMuleExternalConnector::SaveConfigFile()
 		m_configFile->Write("/EC/Host", m_host);
 		m_configFile->Write("/EC/Port", m_port);
 		m_configFile->WriteHash("/EC/Password", m_password);
-		// ZLIB was previously read in LoadConfigFile but never written
-		// here — toggling --disable-zlib at the command line would not
-		// persist, and any value in the config file silently reset to
-		// the 1 (enabled) default on every save. Persist it so the
-		// field actually round-trips. (#817)
+		// ZLIB was read in LoadConfigFile but never written here, so toggling
+		// --disable-zlib did not persist and any value in the config file silently
+		// reset to the enabled default on every save (#817).
 		m_configFile->Write("/EC/ZLIB", m_ZLIB ? 1l : 0l);
 		m_configFile->Write("/EC/ForceZLIB", m_forceZLIB ? 1l : 0l);
 		m_configFile->Write("/EC/Encryption", m_ECEncryption ? 1l : 0l);
@@ -740,30 +722,24 @@ bool CaMuleExternalConnector::OnInit()
 {
 #ifndef __WINDOWS__
 #if wxUSE_ON_FATAL_EXCEPTION
-	// catch fatal exceptions
 	wxHandleFatalExceptions(true);
 #endif
 #endif
 
-	// Pull the libc locale from the environment (LANG / LC_ALL / etc.)
-	// before any wxString -> char* conversion runs via unicode2char().
-	// Otherwise the process stays on the default "C" locale and
-	// wxConvLibc collapses every non-ASCII codepoint to '?' on output.
-	// readline does its own setlocale on first read, so paths that go
-	// through readline appear to work; non-interactive paths (e.g.
-	// amulecmd -c "...") don't and need the explicit init here.
-	// The helper also forces LC_NUMERIC back to "C" so libc printf/scanf
-	// decimal handling stays portable.
+	// Pull the libc locale from the environment before any wxString -> char*
+	// conversion runs via unicode2char(). Otherwise the process stays on the
+	// default "C" locale and wxConvLibc collapses every non-ASCII codepoint to '?'.
+	// readline does its own setlocale on first read, so paths through it appear to
+	// work; non-interactive paths do not. The helper also forces LC_NUMERIC back to
+	// "C" so libc printf/scanf decimal handling stays portable.
 	aMuleInitLocale();
 
-	// If we didn't know that OnInit is called only once when creating the
-	// object, it could cause a memory leak. The two pointers below should
-	// be free()'d before assigning the new value.
+	// OnInit is called only once when creating the object; the two pointers below
+	// would otherwise need free()ing before the new value is assigned.
 	// cppcheck-suppress publicAllocationError
 	m_strFullVersion = strdup((const char *)unicode2char(GetMuleVersion()));
 	m_strOSDescription = strdup((const char *)unicode2char(wxGetOsDescription()));
 
-	// Handle uncaught exceptions
 	InstallMuleExceptionHandler();
 
 	bool retval = wxApp::OnInit();
@@ -772,13 +748,10 @@ bool CaMuleExternalConnector::OnInit()
 	SetLocale(m_language);
 
 #ifdef HAVE_LIBREADLINE
-	// Allow conditional parsing of the ~/.inputrc file.
-	//
-	// OnInitCmdLine() is called from wxApp::OnInit() above,
-	// thus m_appname is already set.
-	// macOS libedit's rl_readline_name is char* (not const char*) and
-	// rl_completion_entry_function is Function* (not rl_compentry_func_t*).
-	// GNU readline on Linux has the correct const types.
+	// Allow conditional parsing of the ~/.inputrc file. OnInitCmdLine() is called
+	// from wxApp::OnInit() above, so m_appname is already set. macOS libedit's
+	// rl_readline_name is char* and rl_completion_entry_function is Function*,
+	// where GNU readline on Linux has the const types.
 #ifdef __WXMAC__
 	rl_readline_name = const_cast<char *>(m_appname);
 	theCommands = &m_commands;

--- a/src/ExternalConnector.h
+++ b/src/ExternalConnector.h
@@ -221,19 +221,17 @@ public:
 	{
 		return m_ECClient && m_ECClient->ServerSupportsSearchProgressUnion();
 	}
-	// True when amuled answers EC_OP_GET_CLIENT_HISTORY. Null-checked for the
-	// same reason as the union accessor above -- and the check is not optional
-	// even beyond that: a daemon predating the request reaches the
-	// unknown-opcode branch of ProcessRequest2(), which asserts rather than
-	// answering EC_OP_FAILED, so asking an old core takes it down.
+	// True when amuled answers EC_OP_GET_CLIENT_HISTORY. Null-checked for the same
+	// reason as the union accessor above, and the check is load-bearing beyond
+	// that: a daemon predating the request reaches the unknown-opcode branch of
+	// ProcessRequest2(), which asserts rather than answering EC_OP_FAILED.
 	bool IsServerClientHistoryActive() const
 	{
 		return m_ECClient && m_ECClient->ServerSupportsClientHistory();
 	}
-	// True when amuled serves the chat session ops (EC_OP_GET_CHAT_SESSIONS
-	// and friends). Same null-check-is-load-bearing reasoning as above: a
-	// daemon predating them asserts on the unknown opcode instead of
-	// answering EC_OP_FAILED, so every chat request must be gated on this.
+	// True when amuled serves the chat session ops. Same load-bearing null check:
+	// a daemon predating them asserts on the unknown opcode instead of answering
+	// EC_OP_FAILED, so every chat request must be gated on this.
 	bool IsServerChatActive() const { return m_ECClient && m_ECClient->ServerSupportsChatSessions(); }
 	// Version string of the connected core, from the EC AUTH_OK handshake.
 	// Empty when not connected (m_ECClient null) or when the daemon is old
@@ -268,12 +266,10 @@ protected:
 	wxString m_host;
 	CMD4Hash m_password;
 	bool m_ZLIB;
-	// Force ZLIB regardless of dialed-IP locality (#728 follow-up).
-	// Set by `/EC/ForceZLIB=1` in the config or `--force-zlib` on the
-	// CLI. Use case: a WireGuard tunnel endpoint that resolves to an
-	// RFC1918 IP but whose transit is slow Internet — the locality
-	// check would otherwise strip ZLIB and the user loses the perf
-	// they actually want.
+	// Force ZLIB regardless of dialed-IP locality, via `/EC/ForceZLIB=1` or
+	// `--force-zlib`. For a WireGuard endpoint that resolves to an RFC1918 IP but
+	// whose transit is slow Internet, where the locality check would otherwise
+	// strip ZLIB.
 	bool m_forceZLIB;
 
 	// Offer EC transport encryption. On by default: the daemon only encrypts

--- a/src/FileArea.cpp
+++ b/src/FileArea.cpp
@@ -41,22 +41,22 @@
 
 #include <atomic> // std::atomic<bool> for the cross-thread MMapEnabled toggle
 
-// MMAP_SUPPORTED is set by cmake (glib21.cmake) only when the whole mmap
-// file-I/O path is available on this platform: mmap / munmap / sysconf /
-// _SC_PAGESIZE / sigaction all present.  It gates the code below, the
-// preferences checkbox and the EC tag.  Whether mmap is actually *used* is the
-// runtime MMapEnabled preference (s_mmapEnabled), which defaults to off.
+// MMAP_SUPPORTED is set by cmake only when the whole mmap file-I/O path is
+// available on this platform (mmap / munmap / sysconf / _SC_PAGESIZE /
+// sigaction). It gates the code below, the preferences checkbox and the EC tag;
+// whether mmap is actually USED is the runtime MMapEnabled preference, which
+// defaults to off.
 
-// Runtime switch for the mmap path (the MMapEnabled preference). Written from
-// the main thread when the preference changes, read from the block-receive and
-// upload-I/O threads at ReadAt()/StartWriteAt() time. A plain atomic bool is
-// sufficient: the decision is captured per CFileArea in m_mmap_buffer, so a
-// concurrent flip only changes the mode of *subsequent* operations.
+// Runtime switch for the mmap path. Written from the main thread when the
+// preference changes, read from the block-receive and upload-I/O threads at
+// ReadAt()/StartWriteAt() time. A plain atomic bool suffices: the decision is
+// captured per CFileArea in m_mmap_buffer, so a concurrent flip only changes the
+// mode of SUBSEQUENT operations.
 //
-// The store uses release / the loads use acquire so that the SIGSEGV/SIGBUS
-// handler installed inside SetMMapEnabled(true) (below, once the handler class
-// is declared) is guaranteed visible to any I/O thread that observes the flag
-// as enabled -- i.e. the handler is always up before the first faultable map.
+// The store uses release and the loads acquire, so the SIGSEGV/SIGBUS handler
+// installed inside SetMMapEnabled(true) is guaranteed visible to any I/O thread
+// that observes the flag as enabled -- the handler is always up before the first
+// faultable map.
 static std::atomic<bool> s_mmapEnabled{ false };
 
 bool CFileArea::GetMMapEnabled()
@@ -166,11 +166,8 @@ void CFileAreaSigHandler::Init()
 	if (initialized)
 		return;
 
-	// Set our new signal handler.
-	// Note that we safe old handlers (probably wx ones) in order
-	// to be able to call them if signal not handled as desired.
-	// These handler will be removed by wx code when wx will restore
-	// old ones
+	// Save the old handlers (probably wx's) so they can be called when a signal is
+	// not handled as desired here. wx removes these when it restores its own.
 	struct sigaction sa;
 	memset(&sa, 0, sizeof(sa));
 	sigemptyset(&sa.sa_mask);
@@ -209,14 +206,12 @@ void CFileAreaSigHandler::Remove(CFileArea &area)
 
 void CFileArea::SetMMapEnabled(bool enabled)
 {
-	// Install the SIGSEGV/SIGBUS recovery handler once, when mmap is first
-	// turned on, rather than per read/write (which would take a mutex on every
-	// block). Off builds -- and runs that never enable mmap -- never touch the
-	// signal-handler chain, keeping them clear of sanitizers/debuggers/crash
-	// reporters. CFileAreaSigHandler::Init() is idempotent and a no-op where
-	// MMAP_SUPPORTED is not defined. The install happens-before the release
-	// store, so any I/O thread that later sees the flag set (acquire) is
-	// guaranteed the handler is already in place.
+	// Install the SIGSEGV/SIGBUS recovery handler once, when mmap is first turned
+	// on, rather than per read/write, which would take a mutex on every block. Off
+	// builds -- and runs that never enable mmap -- never touch the signal-handler
+	// chain, keeping them clear of sanitizers and crash reporters. Init() is
+	// idempotent, and a no-op without MMAP_SUPPORTED. The install happens-before
+	// the release store, so a thread that later sees the flag set has the handler.
 	if (enabled) {
 		CFileAreaSigHandler::Init();
 	}
@@ -231,11 +226,6 @@ CFileArea::CFileArea()
 , m_file(NULL)
 , m_error(false)
 {
-	// The SIGSEGV/SIGBUS recovery handler is installed lazily, at the first
-	// actual mmap() (see ReadAt/StartWriteAt), rather than here. That keeps
-	// builds running with MMapEnabled=off (the default) from ever touching the
-	// signal-handler chain, so they don't collide with sanitizers, debuggers
-	// or crash reporters.
 }
 
 CFileArea::~CFileArea()

--- a/src/FileDetailDialog.cpp
+++ b/src/FileDetailDialog.cpp
@@ -38,7 +38,6 @@
 
 #define ID_MY_TIMER 1652
 
-// IMPLEMENT_DYNAMIC(CFileDetailDialog, CDialog)
 wxBEGIN_EVENT_TABLE(CFileDetailDialog, wxDialog)
 	EVT_BUTTON(ID_CLOSEWNDFD, CFileDetailDialog::OnClosewnd)
 	EVT_BUTTON(IDC_BUTTONSTRIP, CFileDetailDialog::OnBnClickedButtonStrip)
@@ -55,11 +54,10 @@ wxEND_EVENT_TABLE()
 
 namespace
 {
-// Registry of open CFileDetailDialog instances. See CCommentDialog.cpp
-// for the rationale — the broadcast handler in GuiEvents.cpp iterates
-// this on every CKnownFile destruction. UAF would otherwise fire from
-// the 5-second update-timer's deref of m_file (issue #755, same family
-// as #748).
+// Registry of open CFileDetailDialog instances; see CCommentDialog.cpp for the
+// rationale. The broadcast handler in GuiEvents.cpp iterates this on every
+// CKnownFile destruction, since a UAF would otherwise fire from the 5-second
+// update timer's deref of m_file (issue #755).
 std::set<CFileDetailDialog *> &OpenInstances()
 {
 	static std::set<CFileDetailDialog *> instances;
@@ -92,12 +90,10 @@ CFileDetailDialog::~CFileDetailDialog()
 {
 	OpenInstances().erase(this);
 	m_timer.Stop();
-	// Drop the rows before freeing what they point at. The list control is a
-	// child window and so outlives this body, and the base states the rule
-	// plainly: it has to be told before the caller frees the item data.
-	// Nothing can currently paint or sort in between -- both call sites are
-	// stack temporaries, so destruction is synchronous -- but that is a
-	// property of wx's teardown rather than something this code should rest on.
+	// Drop the rows before freeing what they point at: the list control is a child
+	// window and so outlives this body, and the base has to be told before the
+	// caller frees the item data. Nothing can currently paint or sort in between,
+	// but that is a property of wx's teardown rather than something to rest on.
 	if (CFileDetailListCtrl *list = CastChild(IDC_LISTCTRLFILENAMES, CFileDetailListCtrl)) {
 		list->ClearSources();
 	}
@@ -109,13 +105,10 @@ CFileDetailDialog::~CFileDetailDialog()
 void CFileDetailDialog::DropReferencesTo(const CKnownFile *file)
 {
 	for (CFileDetailDialog *d : OpenInstances()) {
-		// Strip the file from m_files first so Next/Prev navigation
-		// doesn't re-select it. m_files is a reference to the
-		// caller's vector (CDownloadListCtrl's stack-allocated list
-		// of selected files), so erasing here mutates the caller's
-		// state too — that's fine; the caller holds it only for the
-		// duration of the modal dialog and the dialog is what owns
-		// the visible UI sourcing from it.
+		// Strip the file from m_files first, so Next/Prev navigation does not
+		// re-select it. m_files is a reference to the caller's vector, so erasing
+		// here mutates the caller's state too -- fine, since the caller holds it only
+		// for the duration of the modal dialog.
 		for (std::vector<CKnownFile *>::iterator it = d->m_files.begin(); it != d->m_files.end();
 			/* manual ++ */) {
 			if (*it == file) {
@@ -133,9 +126,8 @@ void CFileDetailDialog::DropReferencesTo(const CKnownFile *file)
 				++it;
 			}
 		}
-		// Dismiss if the active file vanished. Stop the update
-		// timer first so the next tick doesn't try to deref
-		// m_file before EndModal unwinds.
+		// Dismiss if the active file vanished. Stop the update timer first so the
+		// next tick cannot deref m_file before EndModal unwinds.
 		if (d->m_file == file) {
 			d->m_file = NULL;
 			d->m_timer.Stop();
@@ -159,10 +151,9 @@ void CFileDetailDialog::UpdateData(bool resetFilename)
 	wxString bufferS;
 
 	// A file is "downloading" only while it is an incomplete partfile.
-	// CPartFile::IsPartFile() already returns false once complete (the object
-	// itself may linger as a CPartFile until the next restart), so this is the
-	// authoritative test — not the concrete type. Works in amulegui too, where
-	// the proxy CPartFile overrides IsPartFile() identically.
+	// CPartFile::IsPartFile() already returns false once complete, even though the
+	// object may linger as a CPartFile until the next restart, so it is the
+	// authoritative test rather than the concrete type. Works in amulegui too.
 	CPartFile *part = m_file->IsPartFile() ? static_cast<CPartFile *>(m_file) : nullptr;
 
 	// --- Common fields (present on every CKnownFile) ---
@@ -253,16 +244,14 @@ void CFileDetailDialog::UpdateData(bool resetFilename)
 	}
 	CastChild(IDC_FD_SHARE_LASTUP, wxControl)->SetLabel(bufferS);
 
-	// Media Info (issue #418): populate from FT_MEDIA_* when the file has
-	// probed metadata; the labels stay at their "N/A" default otherwise.
-	// Works identically in the monolithic and remote (amulegui) builds —
-	// the remote proxy stores the same FT_MEDIA_* tags off EC.
-	// Per field, NOT gated on GetMetaDataVer(): that predicate answers "has
-	// this been probed", and a file can be probed and still have no duration
-	// (a raw elementary stream, a truncated capture). Filling every label on
-	// the aggregate would show Length 0:00 and Bitrate 0 kbps for such a file,
-	// where the truthful answer is the N/A default. A displayed zero is a
-	// claim; absence is not.
+	// Media Info (issue #418): populated from FT_MEDIA_* when the file has probed
+	// metadata, with the labels left at their "N/A" default otherwise. Identical in
+	// the monolithic and remote builds, the remote proxy storing the same tags.
+	//
+	// Per field, NOT gated on GetMetaDataVer(): that predicate answers "has this
+	// been probed", and a probed file can still have no duration. Filling every
+	// label on the aggregate would show Length 0:00 and Bitrate 0 kbps where the
+	// truthful answer is N/A.
 	if (uint32 len = m_file->GetIntTagValue(FT_MEDIA_LENGTH)) {
 		CastChild(IDC_FD_MEDIA_LENGTH, wxControl)->SetLabel(CastSecondsToHM(len));
 	}
@@ -286,10 +275,9 @@ void CFileDetailDialog::UpdateData(bool resetFilename)
 		}
 	}
 
-	// --- Section visibility, driven by the file's own state (not by which list
-	//     opened the dialog). Download rows show only for an in-progress
-	//     partfile; sharing rows show for any file that actually shares data
-	//     (every completed file, or a partfile with at least one complete part). ---
+	// Section visibility, driven by the file's own state rather than by which list
+	// opened the dialog: download rows show only for an in-progress partfile,
+	// sharing rows for any file that actually shares data.
 	bool showDownload = (part != nullptr);
 	bool showSharing = (part == nullptr) || (part->GetCompletedSize() > 0);
 	bool relayout = false;
@@ -309,10 +297,10 @@ void CFileDetailDialog::UpdateData(bool resetFilename)
 	}
 
 	setEnableForApplyButton();
-	// "Show all comments" opens the ratings/comments dialog for this file —
-	// works for a shared file as well as an in-progress download, since a Kad
-	// notes lookup only needs the file's hash+size. Enable it whenever there are
-	// comments already or Kad is connected (so it can still be queried) (#434).
+	// "Show all comments" opens the ratings/comments dialog, which works for a
+	// shared file as well as an in-progress download since a Kad notes lookup only
+	// needs the file's hash and size. Enabled whenever there are comments already
+	// or Kad is connected (#434).
 	FileRatingList list;
 	m_file->GetRatingAndComments(list);
 	CastChild(IDC_CMTBT, wxControl)->Enable(!list.empty() || theApp->IsConnectedKad());
@@ -326,10 +314,9 @@ void CFileDetailDialog::FillSourcenameList()
 {
 	CFileDetailListCtrl *pmyListCtrl = CastChild(IDC_LISTCTRLFILENAMES, CFileDetailListCtrl);
 
-	// The source-name list is a download-only view (how sources name the file).
-	// A plain shared file has none, so clear any rows a prior file left behind
-	// (Next/Prev) — freeing their item data — and bail before the partfile-only
-	// source accessors below.
+	// The source-name list is a download-only view of how sources name the file. A
+	// plain shared file has none, so clear any rows a prior file left behind,
+	// freeing their item data, and bail before the partfile-only accessors below.
 	CPartFile *part = m_file->IsPartFile() ? static_cast<CPartFile *>(m_file) : nullptr;
 	if (!part) {
 		// Rows first, then the objects they point at -- same rule as the
@@ -342,13 +329,11 @@ void CFileDetailDialog::FillSourcenameList()
 		return;
 	}
 
-	// reset
 	for (const auto &entry : m_sourcenames) {
 		entry.second->count = 0;
 	}
 	bool inserted = false;
 
-	// update
 #ifdef CLIENT_GUI
 	const SourcenameItemMap &sources = part->GetSourcenameItemMap();
 	for (SourcenameItemMap::const_iterator it = sources.begin(); it != sources.end(); ++it) {
@@ -396,21 +381,16 @@ void CFileDetailDialog::FillSourcenameList()
 		}
 	}
 
-	// Counts are zeroed above and then rewritten in place, so while this runs
-	// the list is not ordered by the column it is sorted on -- and AddSource()
-	// places a new row with a binary search, which needs that ordering to
-	// hold. So an insertion leaves rows in arbitrary positions and has to be
-	// repaired here, exactly as the pre-port code did.
+	// Counts are zeroed above and rewritten in place, so while this runs the list
+	// is not ordered by the column it is sorted on -- and AddSource() places a new
+	// row with a binary search, which needs that ordering. An insertion therefore
+	// leaves rows in arbitrary positions and has to be repaired here.
 	//
-	// Only on insertion, though. A count that merely changed is what the
-	// live-sort preference governs: RefreshSource() re-sorts when it is on,
-	// and when it is off the row is meant to stay where it is rather than move
-	// under the user. Sorting unconditionally would quietly override that
-	// setting for this list.
+	// Only on insertion: a count that merely changed is what the live-sort
+	// preference governs, and sorting unconditionally would override that setting.
 	if (inserted) {
 		pmyListCtrl->SortList();
 	}
-	// no need to call Layout() here, it's called in UpdateData()
 }
 
 void CFileDetailDialog::OnBnClickedShowComment(wxCommandEvent &WXUNUSED(evt))
@@ -571,13 +551,9 @@ void CFileDetailDialog::OnBnClickedButtonStrip(wxCommandEvent &WXUNUSED(evt))
 	filename.Replace("_", " ");
 	filename.Replace("%20", " ");
 
-	// Some additional formatting
 	filename.Replace("hYPNOTiC", "");
 	filename.MakeLower();
 	filename.Replace("xxx", "XXX");
-	//	filename.Replace("xdmnx", "");
-	//	filename.Replace("pmp", "");
-	//	filename.Replace("dws", "");
 	filename.Replace("www pornreactor com", "");
 	filename.Replace("sharereactor", "");
 	filename.Replace("found via www filedonkey com", "");

--- a/src/FileLaunch.cpp
+++ b/src/FileLaunch.cpp
@@ -54,9 +54,7 @@ namespace
 // Hand an argument vector to the desktop, with the AppImage-safe environment
 // when we are inside a bundle: AppRun prepends the bundle's lib/bin directories
 // to the child's search paths, and a host program that inherits them loads our
-// older bundled libraries instead of the system ones and dies on an undefined
-// symbol (#334). Outside an AppImage this is a no-op and the child inherits as
-// usual.
+// older bundled libraries and dies on an undefined symbol (#334).
 //
 // A vector rather than a command string on purpose: the path crosses untouched,
 // so a name with spaces or quotes needs no escaping and cannot be re-split by
@@ -81,12 +79,11 @@ bool RunDetached(const wxString &description, const std::vector<wxString> &args)
 	try {
 		ret = wxExecute(argv.data(), wxEXEC_ASYNC, process, sanitized ? &execEnv : nullptr);
 	} catch (...) {
-		// wxExecute throws, rather than returning an error, when the environment
-		// it has to hand the child is unusable -- a working directory that no
-		// longer exists, for one. Uncaught it unwinds out of the menu handler and
-		// wx terminates the application: a *clean* exit, so no signal, no
-		// backtrace and no crash report, which makes it near-undiagnosable. A
-		// failed launch is not worth losing the session over.
+		// wxExecute throws, rather than returning an error, when the environment it
+		// has to hand the child is unusable -- a working directory that no longer
+		// exists, for one. Uncaught it unwinds out of the menu handler and wx
+		// terminates the application cleanly: no signal, no backtrace, no crash
+		// report.
 		delete process;
 		return false;
 	}
@@ -94,11 +91,10 @@ bool RunDetached(const wxString &description, const std::vector<wxString> &args)
 		delete process;
 		return false;
 	}
-	// True means the child was spawned, not that it did anything useful: an
-	// async wxExecute returns the pid as soon as the fork succeeds, so a failed
-	// exec (no xdg-open installed, say) is not reported here. macOS and Windows
-	// do surface a failure, because neither goes through this path for the
-	// desktop opener.
+	// True means the child was spawned, not that it did anything useful: an async
+	// wxExecute returns the pid as soon as the fork succeeds, so a failed exec (no
+	// xdg-open installed, say) is not reported here. macOS and Windows do surface a
+	// failure, since neither reaches the desktop opener this way.
 	return true;
 }
 
@@ -115,17 +111,16 @@ void Fail(const wxString &message, wxWindow *parent, bool reportModally)
 // Hand the path to the user's configured player.
 //
 // The template is split into arguments ONCE, with wxCmdLineParser, and the
-// placeholders are then substituted inside the resulting arguments -- so the
-// path and the bare name each cross as a single argv entry no matter what they
-// contain. The old code appended the path to a command string and let wxExecute
-// re-split it, which meant a remote-supplied filename could inject arguments:
-// `x\' --script=/tmp/evil.lua \'.avi` becomes a separate --script argument, and
-// players like mpv and vlc execute scripts given that way. Escaping the quotes
-// was the previous defence and was itself bypassable with a backslash; not
-// building a string in the first place removes the class.
+// placeholders are substituted inside the resulting arguments -- so the path and
+// the bare name each cross as a single argv entry whatever they contain. The old
+// code appended the path to a command string and let wxExecute re-split it, so a
+// remote-supplied filename could inject arguments: `x\' --script=/tmp/evil.lua
+// \'.avi` becomes a separate --script argument, and mpv and vlc execute scripts
+// given that way. Escaping the quotes was the previous defence and was itself
+// bypassable; not building a string removes the class.
+//
 // `reportModally` is for the caller that has nothing to fall back to: a failure
-// it only logs is, from the user's side, the same silent nothing this is meant
-// to remove. The caller that can fall back leaves it false and stays quiet.
+// it only logs is, from the user's side, the same silent nothing this removes.
 bool LaunchWithPlayer(const wxString &player, const CPath &path, wxWindow *parent, bool reportModally)
 {
 	const wxString target = path.GetRaw();
@@ -133,9 +128,9 @@ bool LaunchWithPlayer(const wxString &player, const CPath &path, wxWindow *paren
 
 	// ConvertStringToArgs defaults to DOS rules, which is wrong everywhere but
 	// Windows: it leaves single quotes literal and does not honour backslash
-	// escapes, so an existing `mpv -fs '%PARTFILE'` or a path with an escaped
-	// space silently stops working. Windows genuinely needs DOS, since UNIX
-	// rules would eat the backslashes in C:\Program Files\...
+	// escapes, so an existing `mpv -fs '%PARTFILE'` silently stops working. Windows
+	// genuinely needs DOS, since UNIX rules would eat the backslashes in C:\Program
+	// Files\...
 #ifdef __WINDOWS__
 	wxArrayString parts = wxCmdLineParser::ConvertStringToArgs(player, wxCMD_LINE_SPLIT_DOS);
 #else
@@ -148,23 +143,18 @@ bool LaunchWithPlayer(const wxString &player, const CPath &path, wxWindow *paren
 		return false;
 	}
 
-	// An absolute program path that is not a runnable file is worth catching
-	// here. IsFileExecutable covers both halves: a path that is absent, and one
-	// that exists without the exec bit -- a data file, or a wrapper script that
-	// was never chmod +x -- which would otherwise fail the same way.
-	// wxExecute cannot report it: the async form returns the pid as soon as the
-	// fork succeeds and execvp then fails in the child, so the caller sees
-	// success while the user sees only wx's "execvp ... failed with error 2".
-	// That is the normal state of affairs inside a Flatpak, where a host player
-	// such as /usr/bin/vlc is simply not on the sandbox's filesystem.
+	// An absolute program path that is not a runnable file is worth catching here.
+	// IsFileExecutable covers both halves: a path that is absent, and one that
+	// exists without the exec bit. wxExecute cannot report it -- the async form
+	// returns the pid as soon as the fork succeeds and execvp then fails in the
+	// child, so the caller sees success while the user sees only wx's "execvp ...
+	// failed with error 2". That is the normal state of affairs inside a Flatpak,
+	// where a host player is simply not on the sandbox's filesystem.
 	//
-	// A bare command name is left alone: resolving it would mean reimplementing
-	// the PATH search that the exec does anyway.
-	//
-	// Windows paths never match this test, and do not need to: there wxExecute
-	// goes through CreateProcess, which fails synchronously, so the launch
-	// returns 0 and the error path below already reports it. Only the POSIX
-	// fork/exec pair can succeed at the fork and fail out of sight in the child.
+	// A bare command name is left alone: resolving it would mean reimplementing the
+	// PATH search the exec does anyway. Windows paths never match this test and do
+	// not need to: CreateProcess fails synchronously, so the error path below
+	// already reports it.
 	if (parts[0].StartsWith("/") && !wxFileName::IsFileExecutable(parts[0])) {
 		Fail(CFormat(_("The configured video player was not found: %s")) % parts[0],
 			parent,
@@ -255,15 +245,12 @@ bool ResolvePath(const CKnownFile *file, CPath &out)
 	}
 
 #ifdef CLIENT_GUI
-	// Rewrite a remote daemon's path into this machine's, per the user's
-	// configured mappings (issue #843) -- e.g. the daemon's
-	// /downloads/incoming reachable here as D:\Downloads\aMule\incoming via
-	// a Samba mount. String substitution on the raw daemon path, done
-	// before it becomes part of a CPath: ApplyPathMapping() never assumes
-	// the remote side uses this host's separator convention. A no-op
-	// (returns the input unchanged) whenever no configured mapping's prefix
-	// matches, including the common case of an empty mapping list -- so
-	// this is a genuine copy only for a build that can actually change it.
+	// Rewrite a remote daemon's path into this machine's, per the user's configured
+	// mappings (issue #843) -- the daemon's /downloads/incoming reachable here as
+	// D:\Downloads\aMule\incoming over a Samba mount, say. String substitution on
+	// the raw daemon path, before it becomes part of a CPath, since the remote side
+	// need not use this host's separator convention. Returns the input unchanged
+	// when no mapping's prefix matches, the empty mapping list included.
 	const CPath directory = CPath(theApp->glob_prefs->ApplyPathMapping(rawDirectory.GetRaw()));
 #else
 	// The monolithic app is its own core: never remapped, so no copy.
@@ -324,11 +311,10 @@ void Open(CKnownFile *file, wxWindow *parent)
 	const bool media = (type == ftVideo || type == ftAudio);
 	const wxString &player = thePrefs::GetVideoPlayer();
 
-	// An unfinished download is "NNNN.part" on disk. No desktop registers a
-	// handler for that extension, so the platform opener cannot do anything
-	// with it -- it would answer with its own "no application set to open this
-	// document" dialog. Previewing one only works by handing the path to a
-	// player, so when there is none, say so instead of failing twice.
+	// An unfinished download is "NNNN.part" on disk, and no desktop registers a
+	// handler for that extension, so the platform opener would answer with its own
+	// "no application set to open this document" dialog. Previewing one only works
+	// by handing the path to a player, so when there is none, say so.
 	if (incomplete) {
 		if (player.IsEmpty()) {
 			if (parent != nullptr) {
@@ -348,11 +334,10 @@ void Open(CKnownFile *file, wxWindow *parent)
 	}
 
 	// Completed: the configured player is for watching media, so it is used for
-	// media and deliberately not for anything else -- which is what used to send
-	// an archive to the video player.
-	// A player that could not be launched should not cost the user the action:
-	// for a finished file the desktop handler is a reasonable second choice, and
-	// inside a Flatpak that is the portal, which reaches the host's application.
+	// media and deliberately not for anything else -- which is what used to send an
+	// archive to the video player. A player that could not be launched should not
+	// cost the user the action: for a finished file the desktop handler is a
+	// reasonable second choice, and inside a Flatpak that is the portal.
 	if (media && !player.IsEmpty() && LaunchWithPlayer(player, path, parent, false)) {
 		return;
 	}
@@ -379,10 +364,9 @@ void Reveal(const CKnownFile *file, wxWindow *WXUNUSED(parent))
 
 	bool ok = false;
 #if defined(__WXMAC__)
-	// NSWorkspace rather than spawning `open -R`: it selects the file in its
-	// folder, which is what "Show in Finder" means, and it needs no subprocess
-	// -- so nothing about the caller's environment (an unreadable working
-	// directory, for one) can perturb it.
+	// NSWorkspace rather than spawning `open -R`: it selects the file in its folder,
+	// which is what "Show in Finder" means, and needs no subprocess, so nothing
+	// about the caller's environment can perturb it.
 	ok = mac_reveal_in_finder(path.GetRaw().utf8_str());
 #elif defined(__WXMSW__)
 	// Explorer wants the path glued to the switch by a comma, and it exits

--- a/src/FirstRunWizard.cpp
+++ b/src/FirstRunWizard.cpp
@@ -50,29 +50,23 @@
 
 namespace
 {
-// A predefined connection profile. Each profile carries two distinct
-// pairs of kByte/s values:
-//   * the suggested rate *limits* (uploadKBs / downloadKBs, 0 ==
-//     unlimited), which fill the two spin controls and become
-//     MaxUpload / MaxDownload; and
-//   * the raw line *capacity* (uploadCapKBs / downloadCapKBs), which
-//     becomes MaxGraphUploadRate / MaxGraphDownloadRate -- the value
-//     that scales the statistics graphs and feeds the dynamic-upload
-//     logic. Capacity is never 0, so a fast (unlimited-limit) line
-//     still gets sensibly scaled graphs instead of the old default.
-// The upload limit is ~80% of the raw upstream capacity (leaving ACK /
-// protocol headroom), while the download limit is left unlimited (0)
-// and only the download capacity carries the line's raw downstream rate.
+// A predefined connection profile, carrying two distinct pairs of kByte/s
+// values:
+//   * the suggested rate LIMITS (uploadKBs / downloadKBs, 0 == unlimited), which
+//     fill the two spin controls and become MaxUpload / MaxDownload; and
+//   * the raw line CAPACITY (uploadCapKBs / downloadCapKBs), which becomes
+//     MaxGraphUploadRate / MaxGraphDownloadRate -- the value that scales the
+//     statistics graphs and feeds the dynamic-upload logic. Capacity is never 0,
+//     so a fast unlimited-limit line still gets sensibly scaled graphs.
+// The upload limit is ~80% of raw upstream capacity, leaving ACK and protocol
+// headroom; the download limit is left unlimited.
 //
 // Each profile also carries its own peer limits (maxConnections /
-// maxConnectionsPer5Sec / maxSourcesPerFile). A slow uplink can only
-// usefully feed a handful of peers, so a modest line keeps fewer
-// sources and connections rather than being swamped by half-open
-// connection overhead, while a fat uplink is allowed many more. These
-// are scaled to each line's *upstream capacity* directly here, instead
-// of being re-derived from the upload-limit field through coarse
-// kByte/s buckets — modern presets all sit far above the old top
-// bucket, so every line would otherwise collapse onto the same maximum.
+// maxConnectionsPer5Sec / maxSourcesPerFile). A slow uplink can only usefully
+// feed a handful of peers, so a modest line keeps fewer sources and connections
+// rather than drowning in half-open overhead. They are scaled to each line's
+// upstream CAPACITY here rather than re-derived from the upload-limit field
+// through coarse buckets, which modern presets all sit above.
 struct ConnectionProfile
 {
 	const char *label;
@@ -105,10 +99,9 @@ struct DerivedLimits
 	int maxSourcesPerFile;
 };
 
-// Keep the connection count within the OS-aware ceiling: on legacy
-// Windows the half-open-connection limit makes a flat 500 (plus a hot
-// 50-per-5s) too aggressive, so the recommendation pulls the top end
-// back down to something the platform can actually sustain.
+// Keep the connection count within the OS-aware ceiling: on legacy Windows the
+// half-open-connection limit makes a flat 500 (plus a hot 50-per-5s) too
+// aggressive.
 DerivedLimits ClampLimits(DerivedLimits d)
 {
 	const int recommended = thePrefs::GetRecommendedMaxConnections();
@@ -118,13 +111,11 @@ DerivedLimits ClampLimits(DerivedLimits d)
 	return d;
 }
 
-// Recommended peer limits for the current upload setting. A preset
-// carries its own per-line numbers (see the table above); for a
-// manually-entered upload limit ("Other") we still bucket, but on a
-// modern kByte/s scale rather than the old <4/7/13/25/50 tiers — those
-// all fall below today's typical uplinks, so every line would otherwise
-// land in the top bucket. An unlimited (0) upload limit is treated as a
-// fast line. The caller clamps the result through ClampLimits().
+// Recommended peer limits for the current upload setting. A preset carries its
+// own per-line numbers; a manually-entered upload limit ("Other") is still
+// bucketed, but on a modern kByte/s scale rather than the old <4/7/13/25/50
+// tiers, which today's uplinks all exceed. An unlimited (0) upload limit is
+// treated as a fast line. The caller clamps the result through ClampLimits().
 DerivedLimits DeriveLimits(int uploadKBs)
 {
 	const int up = (uploadKBs <= 0) ? 100000 : uploadKBs;
@@ -424,13 +415,11 @@ wxWizardPageSimple *CFirstRunWizard::BuildBootstrapPage()
 			0);
 	}
 
-	// Recurring refresh, distinct from the one-time download above: keep the
-	// eD2k server list fresh by re-fetching it from the configured URL on every
-	// start (the AutoServerlist pref, off by default and otherwise only reachable
-	// on the Server preferences tab). Shown whether or not a bootstrap download
-	// is offered, and checked so a first-run user gets an up-to-date list without
-	// hunting for the setting. Label reused verbatim from the Server tab so no new
-	// translation is needed.
+	// Recurring refresh, distinct from the one-time download above: re-fetch the
+	// eD2k server list from the configured URL on every start (the AutoServerlist
+	// pref, off by default and otherwise only on the Server tab). Shown whether or
+	// not a bootstrap download is offered, and checked so a first-run user gets an
+	// up-to-date list without hunting for the setting.
 	m_autoUpdateServerCtrl = new wxCheckBox(page, wxID_ANY, _("Auto-update server list at startup"));
 	m_autoUpdateServerCtrl->SetValue(true);
 	sizer->Add(m_autoUpdateServerCtrl, 0, wxTOP, 8);
@@ -453,22 +442,19 @@ wxWizardPageSimple *CFirstRunWizard::BuildIntegrationsPage()
 		wxBOTTOM,
 		12);
 
-	// All three checkboxes reuse the exact strings introduced by the
-	// Preferences panel so translators only see them once. The three
-	// backends (AutostartManager, ProtocolHandlerManager for ed2k,
-	// same for magnet) all live in the OS, not in aMule.conf.
+	// All three checkboxes reuse the exact strings from the Preferences panel so
+	// translators only see them once. The three backends all live in the OS, not in
+	// aMule.conf.
 	m_autostartCtrl = new wxCheckBox(page, wxID_ANY, _("Start aMule automatically when I log in"));
 	m_autostartCtrl->SetValue(AutostartManager::IsEnabled());
 	// Wider gap than the 4 used between rows: autostart is its own thing,
 	// and the three registration toggles below read as a group.
 	sizer->Add(m_autostartCtrl, 0, wxBOTTOM, 12);
 
-	// On macOS the "un-register" path is a no-op (LaunchServices
-	// deliberately blocks programmatic reset), so once aMule already
-	// holds the scheme registration we skip creating the checkbox
-	// entirely — it would be a dead control. On Linux and Windows,
-	// Disable actually works, so the box is always created and simply
-	// reflects live state. Same rationale as the Preferences panel.
+	// On macOS the un-register path is a no-op (LaunchServices blocks programmatic
+	// reset), so once aMule already holds the scheme registration the checkbox is
+	// not created at all rather than being dead. On Linux and Windows Disable works,
+	// so the box is always created and reflects live state.
 	bool magnetEnabled = ProtocolHandlerManager::IsEnabled(HandlerTarget::MagnetScheme);
 #ifdef __WXMAC__
 	const bool showEd2kBox = !ProtocolHandlerManager::IsEnabled(HandlerTarget::Ed2kScheme);
@@ -490,10 +476,9 @@ wxWizardPageSimple *CFirstRunWizard::BuildIntegrationsPage()
 
 	if (showMagnetBox) {
 		m_registerMagnetCtrl = new wxCheckBox(page, wxID_ANY, _("Register aMule for magnet: links"));
-		// Default OFF: aMule only handles the eD2k-compatible subset of
-		// magnets; leaving this off in the wizard avoids silently
-		// stealing BitTorrent magnet clicks from a BT client. Preserve
-		// the current state if the user has already opted in elsewhere.
+		// Default OFF: aMule only handles the eD2k-compatible subset of magnets, so
+		// leaving this off avoids silently stealing BitTorrent magnet clicks.
+		// Preserves the current state if the user opted in elsewhere.
 		m_registerMagnetCtrl->SetValue(magnetEnabled);
 		sizer->Add(m_registerMagnetCtrl, 0, wxBOTTOM, 2);
 		// wxLEFT only: the 20 is the indent under the checkbox. Applying it
@@ -510,11 +495,10 @@ wxWizardPageSimple *CFirstRunWizard::BuildIntegrationsPage()
 	}
 
 	if (showAssocBox) {
-		// Third section break, so the page reads as autostart / link
-		// handling / file handling. 8 here plus the 4 trailing the block
-		// above adds up to the same 12 that follows autostart - and when
-		// the magnet block is hidden (macOS, already registered) the 4
-		// after the ed2k row gets us to 12 just the same.
+		// Third section break, so the page reads as autostart / link handling /
+		// file handling. 8 plus the 4 trailing the block above is the same 12 that
+		// follows autostart, and with the magnet block hidden the 4 after the ed2k
+		// row gets there just the same.
 		sizer->AddSpacer(8);
 		// String reused verbatim from the Preferences panel so translators
 		// only ever see it once.
@@ -642,14 +626,12 @@ void CFirstRunWizard::Apply(FirstRunWizard::Result &res)
 	thePrefs::SetMaxUpload(up);
 	thePrefs::SetMaxDownload(down);
 
-	// Line capacity (MaxGraphUploadRate / MaxGraphDownloadRate) is a
-	// separate value from the limits above: it scales the statistics
-	// graphs and feeds the dynamic-upload logic. If a preset is still
-	// selected, take its raw line capacity; otherwise the user typed
-	// values by hand, so estimate from the limits (upload limits sit
-	// ~80% below the raw rate, i.e. cap = limit / 0.8 = limit * 5 / 4).
-	// A 0 (unlimited) manual limit tells us nothing, so the existing
-	// capacity is kept rather than zeroing it.
+	// Line capacity is a separate value from the limits above: it scales the
+	// statistics graphs and feeds the dynamic-upload logic. A still-selected preset
+	// supplies its raw capacity; otherwise the user typed values by hand, so it is
+	// estimated from the limits (upload limits sit ~80% below the raw rate, so
+	// cap = limit * 5 / 4). A 0 manual limit tells us nothing, so the existing
+	// capacity is kept rather than zeroed.
 	int upCap = 0;
 	int downCap = 0;
 	const int sel = m_speedCtrl->GetSelection();
@@ -697,13 +679,11 @@ void CFirstRunWizard::Apply(FirstRunWizard::Result &res)
 		thePrefs::SetTempDir(CPath(tmp));
 	}
 
-	// Integrations page. All three writes go straight to the OS
-	// (registry / mimeapps.list / LaunchServices / autostart store);
-	// none touch aMule.conf, so glob_prefs->Save() below doesn't
-	// cover them. Silent Enable/Disable — on a fresh install the
-	// "another handler is currently registered" prompt is normally
-	// irrelevant, and if it fires the user is already choosing
-	// aMule as their client in the wizard.
+	// Integrations page. All three writes go straight to the OS (registry /
+	// mimeapps.list / LaunchServices / autostart store) and none touch aMule.conf,
+	// so glob_prefs->Save() below does not cover them. Enable/Disable silently: on a
+	// fresh install the "another handler is registered" prompt is normally
+	// irrelevant, and the user is already choosing aMule here.
 	if (m_autostartCtrl) {
 		if (m_autostartCtrl->GetValue()) {
 			AutostartManager::Enable();
@@ -733,10 +713,9 @@ void CFirstRunWizard::Apply(FirstRunWizard::Result &res)
 		}
 	}
 
-	// Record that the wizard ran to completion, so it is not shown again
-	// on the next launch. This is only reached when the user pressed
-	// Finish (Run() calls Apply() only then), so a cancelled run leaves
-	// the flag false and the wizard reappears next time.
+	// Record that the wizard ran to completion so it is not shown again. Only
+	// reached when the user pressed Finish, so a cancelled run leaves the flag false
+	// and the wizard reappears.
 	thePrefs::SetFirstRunWizardDone(true);
 
 	if (theApp->glob_prefs) {
@@ -761,12 +740,10 @@ Result Run(wxWindow *parent, bool needServerMet, bool needNodesDat)
 	if (res.finished) {
 		wizard.Apply(res);
 	} else {
-		// The user cancelled. Only Finish records FirstRunWizardDone, so
-		// without this the wizard would reappear on every launch with no
-		// way to dismiss it for good. Offer the same persistent
-		// "don't show again" choice the AppImage integration prompt uses
-		// (see AppImageIntegration.cpp / AppImageIntegrationDeclined). Yes
-		// (re-show) is the safe default; No remembers the dismissal.
+		// The user cancelled. Only Finish records FirstRunWizardDone, so without
+		// this the wizard would reappear on every launch with no way to dismiss it
+		// for good. Offers the same persistent "don't show again" choice the AppImage
+		// integration prompt uses; re-show is the safe default.
 		wxMessageDialog ask(parent,
 			_("Show this setup wizard again the next time you start aMule?"),
 			_("Setup not finished"),

--- a/src/FriendListCtrl.cpp
+++ b/src/FriendListCtrl.cpp
@@ -145,10 +145,9 @@ int CFriendListCtrl::CompareItemData(
 void CFriendListCtrl::OnItemActivated(wxDataViewEvent &event)
 {
 	// Open a session with the activated row alone, whatever else was selected.
-	// event.GetItem()'s ID is the row-addressed model's row index, not the
-	// item data -- see the "item identity is not row identity" note in
-	// MuleVirtualDataViewCtrl.h -- so the friend has to be resolved through
-	// the selection rather than cast directly from the item.
+	// event.GetItem()'s ID is the row-addressed model's row index, not the item
+	// data, so the friend has to be resolved through the selection rather than cast
+	// directly from the item.
 	if (event.GetItem().IsOk()) {
 		UnselectAll();
 		Select(event.GetItem());
@@ -190,14 +189,11 @@ void CFriendListCtrl::OnItemRightClicked(wxDataViewEvent &event)
 		menu->Append(MP_REMOVEFRIEND, _("Remove Friend"));
 		menu->Append(MP_MESSAGE, _("Send &Message"));
 		menu->Append(MP_SHOWLIST, _("View Files"));
-		// No connection gate: the slot is a property of the CFriend
-		// record, not of a live session. CFriendList::SetFriendSlot
-		// persists it through CFriend::SetPersistentFriendSlot and only
-		// additionally pokes the live client when one is linked, and
-		// CFriend::LinkClient applies the stored flag when the friend
-		// reconnects. Granting it in advance to a friend who is offline
-		// is therefore the case it is most useful for, and was the one
-		// case this menu refused.
+		// No connection gate: the slot is a property of the CFriend record, not of a
+		// live session. CFriendList::SetFriendSlot persists it and only additionally
+		// pokes the live client when one is linked, and CFriend::LinkClient applies
+		// the stored flag when the friend reconnects -- so granting it in advance to
+		// an offline friend is the case it is most useful for.
 		menu->AppendCheckItem(MP_FRIENDSLOT, _("Establish Friend Slot"));
 		menu->Check(MP_FRIENDSLOT, cur_friend->HasFriendSlot());
 	}
@@ -213,10 +209,10 @@ void CFriendListCtrl::MessageFriend(CFriend *cur_friend)
 	}
 // #warning CORE/GUI!
 #ifndef CLIENT_GUI
-	// Resolve the peer before opening the tab, not after. This finds a client
-	// we already hold for the friend's hash even when the record carries no
-	// address, and CFriend::LinkClient then writes that address back to the
-	// record -- which is what the tab is keyed on.
+	// Resolve the peer before opening the tab, not after: this finds a client we
+	// already hold for the friend's hash even when the record carries no address,
+	// and CFriend::LinkClient then writes that address back to the record, which is
+	// what the tab is keyed on.
 	theApp->friendlist->StartChatSession(cur_friend);
 #endif
 	if (!theApp->amuledlg->m_chatwnd->StartSession(cur_friend)) {
@@ -243,14 +239,11 @@ void CFriendListCtrl::OnRemoveFriend(wxCommandEvent &WXUNUSED(event))
 
 	if (wxMessageBox(question, _("Cancel"), wxICON_QUESTION | wxYES_NO | wxNO_DEFAULT, this) == wxYES) {
 		// Collect the selected friends first, then remove them. On amuleGUI
-		// RemoveFriend() is asynchronous (it only sends an EC request; the row is
-		// dropped later, when the daemon pushes the updated friend list), so the
-		// removed friend stays selected in the list when RemoveFriend() returns.
-		// Re-querying the selection in the loop would then keep finding the same
-		// friend and resend the request forever, pegging the CPU (the tight loop
-		// never yields to process the daemon's update). Snapshot the selection up
-		// front so removal is correct whether it is synchronous (monolithic) or
-		// asynchronous (remote GUI).
+		// RemoveFriend() is asynchronous -- it only sends an EC request, and the row
+		// is dropped when the daemon pushes the updated list -- so the removed friend
+		// is still selected when it returns. Re-querying the selection in the loop
+		// would keep finding the same friend and resend forever, in a tight loop that
+		// never yields to process the update.
 		const std::vector<wxUIntPtr> selected = GetSelectedItemData();
 
 		for (wxUIntPtr data : selected) {
@@ -278,17 +271,14 @@ void CFriendListCtrl::OnViewFiles(wxCommandEvent &WXUNUSED(event))
 {
 	for (wxUIntPtr data : GetSelectedItemData()) {
 		CFriend *cur_friend = reinterpret_cast<CFriend *>(data);
-		// If this friend's listing is already open in the Search panel, switch
-		// to that tab instead of re-requesting -- a second request would
-		// duplicate the results in the existing tab.
+		// If this friend's listing is already open in the Search panel, switch to
+		// that tab rather than re-requesting, which would duplicate the results.
 		//
-		// Which ECID keys that tab depends on who opened it, so both are
-		// tried. The monolithic opens it from Notify_Browse_Started, which
-		// carries the browsed CLIENT's ECID; amulegui opens it from
-		// SendBrowseRequest, which has only the FRIEND's -- a friend need not
-		// be linked to a client at the moment the browse is asked for. They
-		// are different numbers from one counter, so matching on the client
-		// alone never found amulegui's tab, and every click re-asked the peer.
+		// Which ECID keys that tab depends on who opened it, so both are tried: the
+		// monolithic opens it from Notify_Browse_Started, carrying the browsed
+		// CLIENT's ECID, while amulegui opens it from SendBrowseRequest with only the
+		// FRIEND's -- a friend need not be linked to a client when the browse is
+		// asked for. Matching on the client alone never found amulegui's tab.
 		CSearchDlg *const searchwnd = theApp->amuledlg ? theApp->amuledlg->m_searchwnd : nullptr;
 		const CClientRef &linked = cur_friend->GetLinkedClient();
 		const uint32 clientEcid = linked.IsLinked() ? linked.ECID() : 0;

--- a/src/GapList.cpp
+++ b/src/GapList.cpp
@@ -62,8 +62,6 @@ void CGapList::AddGap(uint64 gapstart, uint64 gapend)
 		return;
 	}
 
-	//	AddDebugLogLineN(logPartFile, CFormat("  AddGap: %5d - %5d") % gapstart % gapend);
-
 	// mark involved part(s) as incomplete
 	uint16 partlast = gapend / PARTSIZE;
 	for (uint16 part = gapstart / PARTSIZE; part <= partlast; part++) {
@@ -128,8 +126,6 @@ void CGapList::FillGap(uint64 partstart, uint64 partend)
 	if (!ArgCheck(partstart, partend)) {
 		return;
 	}
-
-	//	AddDebugLogLineN(logPartFile, CFormat("  FillGap: %5d - %5d") % partstart % partend);
 
 	// mark involved part(s) to be reexamined for completeness
 	uint16 partlast = partend / PARTSIZE;

--- a/src/GenericClientListCtrl.cpp
+++ b/src/GenericClientListCtrl.cpp
@@ -53,9 +53,9 @@
 #include "SharedFileList.h" // Needed for CSharedFileList
 #include "ClientRef.h"      // Needed for CClientRef
 // CUpDownClient (country accessors, #439). MUST match the build's client class:
-// the reduced EC client for amulegui, the full one for monolithic. Including the
-// wrong header gives this TU a different CUpDownClient layout than the rest of
-// the (remote) GUI, so member reads land at the wrong offset (garbage country).
+// the reduced EC client for amulegui, the full one for monolithic. The wrong
+// header gives this TU a different CUpDownClient layout than the rest of the
+// GUI, so member reads land at the wrong offset.
 #ifdef CLIENT_GUI
 #include "UpDownClientEC.h"
 #else
@@ -238,10 +238,9 @@ void CGenericClientListCtrl::InitColumnData()
 			AddBarColumn(title, i, key, width, baseFlags, CreateProgressBarRenderer());
 			break;
 		case ColumnUserAvailable:
-			// No Compare() case exists for this column (matches the
-			// pre-port behaviour, where it was never sortable either) --
-			// SORTABLE is deliberately left off so no non-functional sort
-			// caret is shown.
+			// No Compare() case exists for this column, as in the pre-port
+			// behaviour, so SORTABLE is left off rather than showing a
+			// non-functional sort caret.
 			AddBarColumn(title, i, key, width, wxDATAVIEW_COL_RESIZABLE, nullptr);
 			break;
 		default:
@@ -250,10 +249,10 @@ void CGenericClientListCtrl::InitColumnData()
 		}
 	}
 
-	// Absorbs the macOS trailing-column sizing, which would otherwise fall on
-	// the last real column and collapse it once the columns are wider than the
-	// control. n_columns is the id to use: the model answers every column past
-	// its own table with an empty value already.
+	// Absorbs the macOS trailing-column sizing, which would otherwise fall on the
+	// last real column and collapse it once the columns outgrow the control.
+	// n_columns is the id to use: the model already answers every column past its
+	// own table with an empty value.
 	AppendSpacerColumn(m_columndata.n_columns);
 
 	AssociateVirtualModel();
@@ -279,9 +278,8 @@ void CGenericClientListCtrl::RawAddSource(CKnownFile *owner, CClientRef source, 
 
 	m_ListItems.insert(ListItemsPair(source.ECID(), newitem));
 
-	// Append at the end (unsorted); ShowSources() sorts once at the end of a
-	// bulk add, a single runtime add just shows at the bottom -- same as the
-	// old InsertItem(GetItemCount()) behaviour.
+	// Append at the end, unsorted: ShowSources() sorts once at the end of a bulk
+	// add, and a single runtime add just shows at the bottom.
 	AppendItemDataNow(reinterpret_cast<wxUIntPtr>(newitem));
 }
 
@@ -290,7 +288,6 @@ void CGenericClientListCtrl::AddSource(CKnownFile *owner, const CClientRef &sour
 	wxCHECK_RET(owner, "NULL owner in CGenericClientListCtrl::AddSource");
 	wxCHECK_RET(source.IsLinked(), "Unlinked source in CGenericClientListCtrl::AddSource");
 
-	// Update the other instances of this source
 	bool bFound = false;
 	ListIteratorPair rangeIt = m_ListItems.equal_range(source.ECID());
 	for (ListItems::iterator it = rangeIt.first; it != rangeIt.second; ++it) {
@@ -333,7 +330,6 @@ void CGenericClientListCtrl::RawRemoveSource(ListItems::iterator &it)
 
 	delete item;
 
-	// Remove it from the m_ListItems
 	m_ListItems.erase(it);
 }
 
@@ -342,7 +338,6 @@ void CGenericClientListCtrl::RemoveSource(uint32 source, const CKnownFile *owner
 	// A NULL owner means remove it no matter what.
 	wxCHECK_RET(source, "NULL source in CGenericClientListCtrl::RemoveSource");
 
-	// Retrieve all entries matching the source
 	ListIteratorPair rangeIt = m_ListItems.equal_range(source);
 
 	int removedItems = 0;
@@ -363,7 +358,6 @@ void CGenericClientListCtrl::RemoveSource(uint32 source, const CKnownFile *owner
 
 void CGenericClientListCtrl::UpdateItem(uint32 toupdate, SourceItemType type)
 {
-	// Retrieve all entries matching the source
 	ListIteratorPair rangeIt = m_ListItems.equal_range(toupdate);
 
 	if (rangeIt.first != rangeIt.second) {
@@ -400,15 +394,13 @@ void CGenericClientListCtrl::ShowSources(const CKnownFileVector &files)
 		}
 	}
 
-	// This will call again SetShowSources in files that were in both vectors. Right now
-	// that function is just a inline setter, so any way to prevent it would be wasteful,
-	// but this must be reviewed if that fact changes.
+	// This calls SetShowSources again for files that were in both vectors. That is
+	// an inline setter today, so preventing it would be wasteful -- revisit if that
+	// changes.
 
 	for (unsigned i = 0; i < files.size(); ++i) {
 		SetShowSources(files[i], true);
 	}
-
-	// We must cleanup sources that are not in the received files.
 
 	int itemDiff = 0;
 
@@ -417,7 +409,6 @@ void CGenericClientListCtrl::ShowSources(const CKnownFileVector &files)
 		ListItems::iterator tmp = it++;
 		ClientCtrlItem_Struct *item = tmp->second;
 		if (!std::binary_search(files.begin(), files.end(), item->GetOwner())) {
-			// Remove it from the m_ListItems
 			RawRemoveSource(tmp);
 			--itemDiff;
 		}
@@ -442,7 +433,6 @@ void CGenericClientListCtrl::ShowSources(const CKnownFileVector &files)
 					const CKnownFile::SourceSet &a4afSources =
 						(dynamic_cast<CPartFile *>(file))->GetA4AFList();
 
-					// Adding normal sources
 					for (it = normSources.begin(); it != normSources.end(); ++it) {
 						switch (it->GetDownloadState()) {
 						case DS_DOWNLOADING:
@@ -457,7 +447,6 @@ void CGenericClientListCtrl::ShowSources(const CKnownFileVector &files)
 						}
 					}
 
-					// Adding A4AF sources
 					for (it = a4afSources.begin(); it != a4afSources.end(); ++it) {
 						// Only add if the A4AF file is not in the shown list.
 						if (!std::binary_search(files.begin(),
@@ -468,7 +457,6 @@ void CGenericClientListCtrl::ShowSources(const CKnownFileVector &files)
 						}
 					}
 				} else {
-					// Known file
 					const CKnownFile::SourceSet &sources = file->m_ClientUploadList;
 					for (it = sources.begin(); it != sources.end(); ++it) {
 						switch (it->GetUploadState()) {
@@ -499,27 +487,23 @@ void CGenericClientListCtrl::ShowSources(const CKnownFileVector &files)
 
 void CGenericClientListCtrl::RemoveKnownFile(CKnownFile *file)
 {
-	// Pure pointer-value comparison — `file` may already be freed by
-	// the destruction site that fired Notify_KnownFileBeingDestroyed.
-	// We must never dereference it; we only need its value as a key
-	// to drop from m_knownfiles and m_ListItems. See
-	// MuleNotify::KnownFileBeingDestroyed in GuiEvents.cpp.
+	// Pure pointer-value comparison: `file` may already be freed by the destruction
+	// site that fired Notify_KnownFileBeingDestroyed, so it is never dereferenced --
+	// only used as a key to drop from m_knownfiles and m_ListItems.
 	if (file == nullptr) {
 		return;
 	}
 
-	// Drop the cached "currently showing sources for" entry. This is
-	// #755's crash site: without this, the next ShowSources() loop
-	// would walk the dangling entry and write into the recycled heap
-	// region via SetShowSources(file, false).
+	// Drop the cached "currently showing sources for" entry. This is #755's crash
+	// site: without it the next ShowSources() loop walks the dangling entry and
+	// writes into the recycled heap region via SetShowSources(file, false).
 	CKnownFileVector::iterator kf = std::find(m_knownfiles.begin(), m_knownfiles.end(), file);
 	if (kf != m_knownfiles.end()) {
 		m_knownfiles.erase(kf);
 	}
 
-	// Strip any per-row state whose m_owner matches. We have to walk
-	// the multimap once because m_ListItems is keyed by client ECID,
-	// not by file.
+	// Strip any per-row state whose m_owner matches. The multimap has to be walked
+	// once because m_ListItems is keyed by client ECID, not by file.
 	for (ListItems::iterator it = m_ListItems.begin(); it != m_ListItems.end(); /* manual ++ */) {
 		ClientCtrlItem_Struct *item = it->second;
 		if (item && item->GetOwner() == file) {
@@ -589,12 +573,10 @@ void CGenericClientListCtrl::OnViewFiles(wxCommandEvent &WXUNUSED(event))
 
 void CGenericClientListCtrl::OnAddFriend(wxCommandEvent &WXUNUSED(event))
 {
-	// The direction comes from the first selected client, which is the row the
-	// menu was built for. Read from the live selection rather than the pointer
-	// stashed at popup time: PopupMenu() runs a nested event loop, a source
-	// removal during it deletes the ClientCtrlItem_Struct, and nothing clears
-	// that pointer. The selection cannot go stale the same way, because the
-	// control maintains it.
+	// The direction comes from the first selected client, which is the row the menu
+	// was built for. Read from the live selection rather than a pointer stashed at
+	// popup time: PopupMenu() runs a nested event loop, a source removal during it
+	// deletes the ClientCtrlItem_Struct, and nothing clears that pointer.
 	const std::vector<CClientRef> clients = SelectedClients(GetSelectedItemData());
 	if (clients.empty()) {
 		return;
@@ -660,9 +642,8 @@ int CGenericClientListCtrl::FindBarLegendColumn() const
 		if (partbar::LegendForColumn(m_columndata.columns[i].cid) == partbar::BarLegendKind::None) {
 			continue;
 		}
-		// A bar the user has hidden is not on screen to be explained. Model
-		// id and view position coincide here -- InitColumnState() requires
-		// it -- so one index answers both.
+		// A bar the user has hidden is not on screen to be explained. Model id and
+		// view position coincide here -- InitColumnState() requires it.
 		if (!IsColumnHidden(i)) {
 			return i;
 		}
@@ -680,9 +661,8 @@ void CGenericClientListCtrl::ShowBarLegend(partbar::BarLegendKind kind, const wx
 
 void CGenericClientListCtrl::OnShowBarLegend(wxCommandEvent &WXUNUSED(event))
 {
-	// Resolved again rather than remembered from when the menu was built: the
-	// entry only exists on menus built while a bar column was on screen, and
-	// re-asking costs a walk over at most a couple of dozen columns.
+	// Resolved again rather than remembered from when the menu was built: the entry
+	// only exists on menus built while a bar column was on screen.
 	const int column = FindBarLegendColumn();
 	if (column < 0) {
 		return;
@@ -711,22 +691,17 @@ void CGenericClientListCtrl::OnItemRightClicked(wxDataViewEvent &event)
 	CClientRef &client = item->GetSource();
 
 	delete m_menu;
-	// Same menu the global clients list offers.
 	m_menu = BuildClientContextMenu(client);
 
-	// Both of these are appended here rather than inside
-	// BuildClientContextMenu(): that builder is shared with CClientRowListCtrl,
-	// the Clients tab, which has no file in context and draws no chunk bar, so
-	// neither entry can mean anything there.
+	// Both are appended here rather than inside BuildClientContextMenu(): that
+	// builder is shared with the Clients tab, which has no file in context and draws
+	// no chunk bar.
 	//
-	// Swapping is a download notion: it moves a source off whatever it is
-	// currently downloading and onto this file, and A4AF only means anything
-	// among a download's sources. The shared-files peer list shows clients
-	// downloading FROM us, so there is nothing to swap and the entry is
-	// omitted rather than shown dead -- the same rule the Clients tab follows.
-	//
-	// Disabled for a non-A4AF source, where the peer is already on the file it
-	// would swap to: "not right now" rather than "never here".
+	// Swapping is a download notion -- it moves a source off whatever it is
+	// downloading and onto this file -- and the shared-files peer list shows clients
+	// downloading FROM us, so there is nothing to swap and the entry is omitted
+	// rather than shown dead. It is disabled for a non-A4AF source, where the peer
+	// is already on the file it would swap to: "not right now" rather than "never".
 	if (IsShowingDownloadSources()) {
 		m_menu->Append(MP_CHANGE2FILE, _("Swap to this file"));
 		m_menu->Enable(MP_CHANGE2FILE, item->GetType() == A4AF_SOURCE);
@@ -928,9 +903,8 @@ void CGenericClientListCtrl::GetItemBarFill(wxUIntPtr data, unsigned column, CBa
 		return;
 
 	case ColumnUserProgress: {
-		// Gate mirrors DrawClientItem's ColumnUserProgress case: nothing is
-		// computed (or drawn, including the A4AF badge) with the pref off --
-		// see CSourceBarRenderer::Render() for the matching gate.
+		// Gate mirrors DrawClientItem's ColumnUserProgress case: nothing is computed
+		// or drawn, the A4AF badge included, with the pref off.
 		if (!thePrefs::ShowProgBar()) {
 			return;
 		}
@@ -970,9 +944,8 @@ void CGenericClientListCtrl::GetItemBarFill(wxUIntPtr data, unsigned column, CBa
 				}
 				CMuleColour colour = ToMuleColour(partbar::SourcePartColour(state, bFlat));
 				if (stopped) {
-					// Not in the legend: a dimmed swatch out of
-					// context reads as a sixth state rather than as
-					// the same five turned down.
+					// Not in the legend: a dimmed swatch out of context reads
+					// as a sixth state rather than the same five turned down.
 					colour.Blend(50);
 				}
 				spans.push_back({ uStart, uEnd, colour });
@@ -1119,9 +1092,8 @@ int CGenericClientListCtrl::CompareByCid(
 	case ColumnUserSharedFiles:
 		return CmpAny(client1.HasDisabledSharedFiles(), client2.HasDisabledSharedFiles());
 
-	// ColumnUserAvailable intentionally has no case: unsortable, matching
-	// the pre-port behaviour (see InitColumnData()'s SORTABLE-less
-	// registration for this column).
+	// ColumnUserAvailable intentionally has no case: unsortable, matching the
+	// pre-port behaviour.
 	default:
 		return 0;
 	}
@@ -1133,12 +1105,10 @@ int CGenericClientListCtrl::CompareItemData(
 	ClientCtrlItem_Struct *item1 = reinterpret_cast<ClientCtrlItem_Struct *>(data1);
 	ClientCtrlItem_Struct *item2 = reinterpret_cast<ClientCtrlItem_Struct *>(data2);
 
-	// Available sources first, if we have both an available and an
-	// unavailable one -- the order is fixed regardless of sort direction, so
-	// `modifier` is deliberately not applied here. Runs identically at every
-	// level of a multi-column sort chain (CompareItemsFull calls this once
-	// per level with the same two items); harmless, since it always agrees
-	// with itself.
+	// Available sources first when we have both kinds. The order is fixed
+	// regardless of sort direction, so `modifier` is deliberately not applied.
+	// CompareItemsFull calls this once per level of a multi-column chain, which is
+	// harmless since it always agrees with itself.
 	const int typeOrder = item2->GetType() - item1->GetType();
 	if (typeOrder) {
 		return typeOrder;

--- a/src/GuiEvents.cpp
+++ b/src/GuiEvents.cpp
@@ -125,16 +125,13 @@ void ShowUserCount(wxString NOT_ON_DAEMON(str))
 #endif
 }
 
-// Fired by the core version check (CamuleApp::CheckNewVersion) on the
-// monolithic app so the outdated-version popup is driven from the shared
-// engine instead of a separate GUI-only CVersionCheck. A no-op on the
-// daemon (headless) and never fired in amulegui (which runs its own
-// CVersionCheck and has no CamuleApp engine).
+// Fired by the core version check on the monolithic app so the outdated-version
+// popup is driven from the shared engine instead of a GUI-only CVersionCheck. A
+// no-op on the daemon, and never fired in amulegui, which runs its own check.
 //
-// `latest` is by value because MuleNotify stores every argument by value
-// (CMuleNotifier2::m_arg1, via DeepCopy) and invokes the handler with it; a
-// const& parameter would leave that stored member a dangling reference. This
-// matches every other notify handler, so the value-param check is suppressed.
+// `latest` is by value because MuleNotify stores every argument by value and
+// invokes the handler with it, so a const& parameter would leave that stored
+// member a dangling reference.
 // NOLINTNEXTLINE(performance-unnecessary-value-param)
 void VersionCheckResult(wxString NOT_ON_DAEMON(latest), bool NOT_ON_DAEMON(outdated))
 {
@@ -174,13 +171,11 @@ void Search_Update_Progress(uint32 NOT_ON_DAEMON(val))
 void DownloadCtrlUpdateItem(const void *item)
 {
 #ifndef CLIENT_GUI
-	// Notify can fire from PartFile load during early OnInit (#268
-	// crash from a wx2.8.12 / pre-ASIO build) and from background
-	// threads during shutdown after `delete ECServerHandler`.
-	// Master's OnInit currently builds ECServerHandler before
-	// LoadMetFiles, so the early-init crash is fixed by ordering;
-	// guard the dereference anyway so future reorders or
-	// shutdown races can't reintroduce the segfault.
+	// Notify can fire from PartFile load during early OnInit and from background
+	// threads during shutdown after `delete ECServerHandler`. OnInit currently
+	// builds ECServerHandler before LoadMetFiles, so the early-init crash (#268) is
+	// fixed by ordering; the guard keeps a future reorder or shutdown race from
+	// reintroducing the segfault.
 	if (theApp->ECServerHandler && theApp->ECServerHandler->m_ec_notifier) {
 		theApp->ECServerHandler->m_ec_notifier->DownloadFile_SetDirty(
 			static_cast<const CPartFile *>(item));
@@ -196,12 +191,10 @@ void DownloadCtrlUpdateItem(const void *item)
 void DownloadCtrlDoItemSelectionChanged()
 {
 #ifndef AMULE_DAEMON
-	// Checks the dialog itself, unlike its siblings: this one is queued
-	// through DoNotifyAlways(), so CMuleGUIEvent::IsAlways() is set and the
-	// handler runs even with no main window -- the exemption that lets the
-	// socket layer through during connect. Everything else on that path is a
-	// socket notification that never touches the GUI; these two are the
-	// exceptions, so they carry the test themselves.
+	// Checks the dialog itself, unlike its siblings: this one is queued through
+	// DoNotifyAlways(), so the handler runs even with no main window -- the
+	// exemption that lets the socket layer through during connect. Everything else
+	// on that path never touches the GUI, so these two carry the test themselves.
 	if (theApp->amuledlg && theApp->amuledlg->m_transferwnd &&
 		theApp->amuledlg->m_transferwnd->downloadlistctrl) {
 		theApp->amuledlg->m_transferwnd->downloadlistctrl->DoItemSelectionChanged();
@@ -226,10 +219,9 @@ void ServersURLChanged(wxString NOT_ON_DAEMON(url))
 void ShowGUI()
 {
 #ifndef AMULE_DAEMON
-	// Triggered by a duplicate-launch RAISE_DIALOG signal, which the
-	// running instance picks up via ED2KLinks polling. The signal can
-	// arrive before the main window exists -- the second launch only has
-	// to beat the first one to the point where it builds its GUI.
+	// Triggered by a duplicate-launch RAISE_DIALOG signal, which the running
+	// instance picks up via ED2KLinks polling. It can arrive before the main window
+	// exists: the second launch only has to beat the first one to building its GUI.
 	if (theApp->amuledlg) {
 		theApp->amuledlg->RestoreMainWindow();
 	}
@@ -400,11 +392,9 @@ void KnownFile_Comment_Set(CKnownFile *file, wxString comment, int8 rating)
 void Download_Set_Cat_Prio(uint8 cat, uint8 newprio)
 {
 	// EC has no per-category bulk priority opcode. Mirror the daemon's
-	// CDownloadQueue::SetCatPrio predicate (all files if cat == 0, else
-	// exact category match) and send one EC_OP_PARTFILE_PRIO_SET per
-	// file using the existing per-file helpers. Without this stub being
-	// filled in, amulegui's category-tab right-click priority items
-	// silently no-op'd (#697 sibling of the status case below).
+	// CDownloadQueue::SetCatPrio predicate (all files if cat == 0, else exact
+	// category match) and send one EC_OP_PARTFILE_PRIO_SET per file. Unfilled, this
+	// stub made amulegui's category-tab right-click priority items silently no-op.
 	std::vector<CPartFile *> targets;
 	for (CDownQueueRem::iterator it = theApp->downloadqueue->begin(); it != theApp->downloadqueue->end();
 		++it) {
@@ -425,13 +415,11 @@ void Download_Set_Cat_Prio(uint8 cat, uint8 newprio)
 void Download_Set_Cat_Status(uint8 cat, int newstatus)
 {
 	// EC has no per-category bulk status opcode. Mirror the daemon's
-	// CDownloadQueue::SetCatStatus: snapshot files that
-	// CheckShowItemInGivenCat() admits for this (cat, AllcatFilter)
-	// pair, then send one per-file EC command. Snapshot first so a
-	// late-arriving EC response can't mutate the queue mid-iteration.
-	// #697: previously empty -- tab-right-click Stop/Pause/Resume/
-	// Cancel silently no-op'd in amulegui (only the remote GUI, not
-	// the monolithic amule, hit this stub).
+	// CDownloadQueue::SetCatStatus: snapshot the files CheckShowItemInGivenCat()
+	// admits for this (cat, AllcatFilter) pair, then send one per-file EC command.
+	// Snapshot first so a late-arriving EC response cannot mutate the queue
+	// mid-iteration. Unfilled, this stub made tab-right-click
+	// Stop/Pause/Resume/Cancel silently no-op in amulegui.
 	ec_tagname_t cmd = 0;
 	switch (newstatus) {
 	case MP_CANCEL:
@@ -550,12 +538,10 @@ void DownloadCtrlRemoveFile(CPartFile *file)
 void DownloadCtrlSort()
 {
 #ifndef AMULE_DAEMON
-	// Checks the dialog itself, unlike its siblings: this one is queued
-	// through DoNotifyAlways(), so CMuleGUIEvent::IsAlways() is set and the
-	// handler runs even with no main window -- the exemption that lets the
-	// socket layer through during connect. Everything else on that path is a
-	// socket notification that never touches the GUI; these two are the
-	// exceptions, so they carry the test themselves.
+	// Checks the dialog itself, unlike its siblings: this one is queued through
+	// DoNotifyAlways(), so the handler runs even with no main window -- the
+	// exemption that lets the socket layer through during connect. Everything else
+	// on that path never touches the GUI, so these two carry the test themselves.
 	if (theApp->amuledlg && theApp->amuledlg->m_transferwnd &&
 		theApp->amuledlg->m_transferwnd->downloadlistctrl) {
 		theApp->amuledlg->m_transferwnd->downloadlistctrl->SortList();
@@ -703,21 +689,19 @@ void Browse_Status(uint64 NOT_ON_DAEMON(searchID), uint32 NOT_ON_DAEMON(status))
 #endif
 }
 
-// `name` is intentionally taken by value: the notify functor (CMuleNotifier3)
-// stores each argument by the handler's parameter type and deep-copies into it,
-// so a const-ref parameter would dangle. This mirrors every other wxString
-// notify handler here.
+// `name` is taken by value because the notify functor stores each argument by
+// the handler's parameter type and deep-copies into it, so a const-ref parameter
+// would dangle.
 // NOLINTNEXTLINE(performance-unnecessary-value-param)
 void Chat_SessionRemoved(uint64 NOT_ON_DAEMON(gui_id))
 {
 #ifndef AMULE_DAEMON
 	if (theApp->amuledlg && theApp->amuledlg->m_chatwnd) {
-		// EndSessionFromCore, not EndSession: the core has already dropped
-		// this session, so the tab must close WITHOUT its page-closing
-		// handler originating a close of its own. Without the distinction a
-		// close from one client makes every other client echo a redundant
-		// close back -- which the daemon answers EC_OP_FAILED, the session
-		// being gone already.
+		// EndSessionFromCore, not EndSession: the core has already dropped this
+		// session, so the tab must close WITHOUT its page-closing handler
+		// originating a close of its own -- otherwise a close from one client makes
+		// every other client echo a redundant close back, which the daemon answers
+		// EC_OP_FAILED.
 		theApp->amuledlg->m_chatwnd->EndSessionFromCore(gui_id);
 	}
 #endif
@@ -748,12 +732,10 @@ void Browse_Started(uint32 NOT_ON_DAEMON(ecid), wxString NOT_ON_DAEMON(name), ui
 {
 #ifndef AMULE_DAEMON
 	if (theApp->amuledlg && theApp->amuledlg->m_searchwnd) {
-		// Reveal only what this user started. The notification carries no such
-		// flag and CMuleNotifier stops at three arguments, but the client it
-		// names already knows -- so ask it rather than widen the notifier for
-		// one bool. CLIENT_GUI has neither this lookup nor a path that raises
-		// this notification (it is sent from CUpDownClient, which is core
-		// only), so there is nothing to answer there.
+		// Reveal only what this user started. The notification carries no such flag
+		// and CMuleNotifier stops at three arguments, but the client it names already
+		// knows, so ask it rather than widen the notifier for one bool. CLIENT_GUI
+		// has neither the lookup nor a path that raises this notification.
 		bool reveal = true;
 #ifndef CLIENT_GUI
 		const CUpDownClient *browsed = theApp->clientlist->FindClientByECID(ecid);
@@ -773,16 +755,14 @@ void ChatConnResult(bool NOT_ON_DAEMON(success), uint64 NOT_ON_DAEMON(id), wxStr
 #endif
 }
 
-// MuleNotify stores the notify args by value (CMuleNotifier DeepCopy), so a
-// `const wxString &` param would dangle — keep it by value like every other
-// notify handler. (NOLINT must sit on the line directly above the signature.)
+// MuleNotify stores the notify args by value, so a `const wxString &` param
+// would dangle -- keep it by value like every other notify handler.
 // NOLINTNEXTLINE(performance-unnecessary-value-param)
 void ChatProcessMsg(uint64 sender, wxString message)
 {
-	// No EC relay here any more: CUpDownClient::ProcessChatMessage records
-	// the message in the core store before this notify fires, and every EC
-	// client reads it from there. The built-in GUI below still handles its
-	// own local display.
+	// No EC relay here any more: CUpDownClient::ProcessChatMessage records the
+	// message in the core store before this notify fires, and every EC client reads
+	// it from there. The built-in GUI below still handles its own local display.
 #ifndef AMULE_DAEMON
 	if (theApp->amuledlg->m_chatwnd) {
 		theApp->amuledlg->m_chatwnd->ProcessMessage(sender, message);
@@ -1004,31 +984,24 @@ void ConvertReaddAllJobs()
 
 #endif // #ifndef CLIENT_GUI
 
-// Broadcast called from every CKnownFile destruction site BEFORE
-// the `delete file`. Subscribers MUST only compare the file pointer
-// by value (==) to entries they already hold — never dereference it.
-// By the time a subscriber on the main thread processes this event
-// the bytes pointed at by `file` may already have been recycled.
+// Broadcast from every CKnownFile destruction site BEFORE the `delete file`.
+// Subscribers MUST only compare the file pointer by value, never dereference it:
+// by the time a subscriber on the main thread processes this event, the bytes
+// pointed at may already have been recycled.
 //
-// Defined outside the CLIENT_GUI / non-CLIENT_GUI split so the same
-// function compiles into both `amule` and `amulegui`. The branches
-// inside select the right subscriber set per target.
+// Defined outside the CLIENT_GUI split so the same function compiles into both
+// `amule` and `amulegui`; the branches inside select the subscriber set.
 //
-// Sites that fire this:
-//   - CPartFile::Delete()                  (user cancel)
-//   - CKnownFileList::PruneDuplicates       (TTL eviction)
-//   - CKnownFileList::~CKnownFileList       (shutdown / via Clear())
-//   - CSharedFileList::Reload()             (rebuild)
-//   - CKnownFilesRem::DeleteItem            (amulegui EC_TAG_FILE_REMOVED)
+// Fired by CPartFile::Delete(), CKnownFileList::PruneDuplicates,
+// ~CKnownFileList, CSharedFileList::Reload() and CKnownFilesRem::DeleteItem.
 void KnownFileBeingDestroyed(CKnownFile *file)
 {
 #ifndef AMULE_DAEMON
 	// GUI subscribers (linked into `amule` and `amulegui`).
 	if (theApp->amuledlg) {
-		// #1: CGenericClientListCtrl in the transfer window's
-		// downloads pane caches selected files in m_knownfiles;
-		// stale entries crash on the next selection change
-		// (issue #755).
+		// #1: CGenericClientListCtrl in the transfer window's downloads pane
+		// caches selected files in m_knownfiles; stale entries crash on the next
+		// selection change (issue #755).
 		if (theApp->amuledlg->m_transferwnd && theApp->amuledlg->m_transferwnd->clientlistctrl) {
 			theApp->amuledlg->m_transferwnd->clientlistctrl->RemoveKnownFile(file);
 		}
@@ -1037,11 +1010,10 @@ void KnownFileBeingDestroyed(CKnownFile *file)
 		if (theApp->amuledlg->m_sharedfileswnd && theApp->amuledlg->m_sharedfileswnd->peerslistctrl) {
 			theApp->amuledlg->m_sharedfileswnd->peerslistctrl->RemoveKnownFile(file);
 		}
-		// #3, #4, #5: open modal dialogs that captured the file
-		// pointer at construction time (CommentDialog,
-		// CommentDialogLst, FileDetailDialog). Each class keeps
-		// its own static registry of live instances so the
-		// broadcast can iterate without needing a friend.
+		// #3, #4, #5: open modal dialogs that captured the file pointer at
+		// construction (CommentDialog, CommentDialogLst, FileDetailDialog). Each
+		// keeps its own static registry of live instances, so the broadcast can
+		// iterate without needing a friend.
 		CCommentDialog::DropReferencesTo(file);
 		CCommentDialogLst::DropReferencesTo(file);
 		CFileDetailDialog::DropReferencesTo(file);
@@ -1056,14 +1028,12 @@ void KnownFileBeingDestroyed(CKnownFile *file)
 	}
 #endif
 #ifndef CLIENT_GUI
-	// Daemon-side subscribers — drop pending requests/writes naming
-	// this file. Both lists are kept by background-thread machinery
-	// and would otherwise leave dangling pointers after the file is
-	// freed (see audit table in the PR description).
+	// Daemon-side subscribers: drop pending requests and writes naming this file.
+	// Both lists are kept by background-thread machinery and would otherwise leave
+	// dangling pointers.
 	//
-	// #5: AICH static recovery-request list. Strip-by-pointer; the
-	// existing RequestAICHRecovery() guard at SHAHashSet.cpp:990 can
-	// be spoofed by allocator reuse, which this prevents.
+	// #5: AICH static recovery-request list. Strip-by-pointer; the existing
+	// RequestAICHRecovery() guard can be spoofed by allocator reuse.
 	CAICHHashSet::DropReferencesTo(file);
 	// #8: pending writes the CPartFileWriteThread hasn't drained yet.
 	// Without this, ~CPartFile would race the write loop.
@@ -1076,15 +1046,13 @@ void KnownFileBeingDestroyed(CKnownFile *file)
 void SearchFileBeingDestroyed(CSearchFile *file)
 {
 #ifndef AMULE_DAEMON
-	// GUI subscribers (linked into `amule` and `amulegui`): a comments dialog
-	// opened on a search result must drop the pointer before the result is
-	// freed (a new search or result-list rebuild deletes CSearchFile objects
-	// while a modal Kad-notes lookup may still be open on one).
+	// GUI subscribers: a comments dialog opened on a search result must drop the
+	// pointer before the result is freed, since a new search or list rebuild deletes
+	// CSearchFile objects while a modal Kad-notes lookup may still be open.
 	CCommentDialogLst::DropReferencesTo(file);
-	// The search models hold arriving results between the notification and
-	// the idle that flushes them, and nothing unlinks a child from its
-	// parent's list -- so this is the only signal that one of those pointers
-	// has stopped being one.
+	// The search models hold arriving results between the notification and the idle
+	// that flushes them, and nothing unlinks a child from its parent's list, so this
+	// is the only signal that one of those pointers has stopped being one.
 	CSearchListModel::DropReferencesTo(file);
 #else
 	(void)file;

--- a/src/GuiEvents.h
+++ b/src/GuiEvents.h
@@ -101,24 +101,18 @@ void SharedCtrlAddClient(CKnownFile *owner, CClientRef client, SourceItemType ty
 void SharedCtrlRefreshClient(uint32 client, SourceItemType type);
 void SharedCtrlRemoveClient(uint32 client, const CKnownFile *owner);
 
-// Broadcast: a CKnownFile (or CPartFile, which is-a CKnownFile) is
-// about to be destroyed. Every component that holds a raw
-// CKnownFile* / CPartFile* outside the canonical owner containers
-// (CKnownFileList / CSharedFileList / CDownloadQueue / EC mirrors)
+// Broadcast: a CKnownFile (or CPartFile, which is-a CKnownFile) is about to be
+// destroyed. Every component holding a raw pointer outside the canonical owner
+// containers (CKnownFileList / CSharedFileList / CDownloadQueue / EC mirrors)
 // must subscribe and drop its reference before the delete returns.
 //
-// Contract for subscribers: handle the event using ONLY pointer-
-// value comparison (==), never dereference the pointer. By the
-// time a subscriber on the main thread sees the event, the file
-// has typically already been freed by the destruction site that
-// fired the broadcast. The pointer value is meaningful as a
-// stable key; the bytes it points at are not.
+// Contract for subscribers: use ONLY pointer-value comparison, never dereference.
+// By the time a subscriber on the main thread sees the event the file has
+// typically already been freed -- the pointer value is a stable key, the bytes it
+// points at are not.
 //
-// Fired from every CKnownFile / CPartFile destruction site BEFORE
-// the delete: CKnownFileList::~CKnownFileList, PruneDuplicates,
-// CPartFile::Delete(), CSharedFileList::Reload() (when destroying
-// stale entries during rebuild), and CKnownFilesRem::DeleteItem
-// in the amulegui build.
+// Fired BEFORE the delete from ~CKnownFileList, PruneDuplicates,
+// CPartFile::Delete(), CSharedFileList::Reload() and CKnownFilesRem::DeleteItem.
 void KnownFileBeingDestroyed(CKnownFile *file);
 
 // The other end of the same peer's life: CClientList has accepted it, so the
@@ -133,36 +127,31 @@ void KnownFileBeingDestroyed(CKnownFile *file);
 // its pointer instead of dangling. See CCommentDialogLst::DropReferencesTo.
 void SearchFileBeingDestroyed(CSearchFile *file);
 
-// Fired from CSearchList::RemoveResults, once per search whose bucket is
-// freed, so a tab still open on it closes instead of outliving the results.
-// Needed the moment closing a tab genuinely frees the search (got3nks, PR
-// #680 review): in a monolithic build the GUI and core share the same
-// CSearchFile objects, which CSearchListCtrl holds as raw pointers via
-// SetItemPtrData and in m_filteredOut, so a tab left open over a freed
-// bucket faults on the next repaint, sort, scroll or click. It also gives
-// the monolithic GUI the local counterpart of amulegui's remote-driven tab
-// close, rather than two mechanisms for one idea.
+// Fired from CSearchList::RemoveResults, once per search whose bucket is freed,
+// so a tab still open on it closes instead of outliving the results. Needed the
+// moment closing a tab genuinely frees the search: in a monolithic build the GUI
+// and core share the same CSearchFile objects, which CSearchListCtrl holds as raw
+// pointers, so a tab left open over a freed bucket faults on the next repaint,
+// sort, scroll or click. It also gives the monolithic GUI the local counterpart
+// of amulegui's remote-driven tab close.
 void Search_Removed(wxUIntPtr searchID);
 
-// A chat session was dropped from the core store, by whichever client asked.
-// The mirror of Search_Removed, and closing follows the same rule searches
-// already do: the core state is destroyed for everyone and each client is
-// TOLD, rather than left showing a tab the core no longer has. The monolithic
-// GUI closes its notebook page here; EC clients learn it from the session's
-// absence in the next EC_OP_CHAT_SESSIONS reply.
+// A chat session was dropped from the core store, by whichever client asked. The
+// mirror of Search_Removed, and closing follows the same rule: the core state is
+// destroyed for everyone and each client is TOLD, rather than left showing a tab
+// the core no longer has. The monolithic GUI closes its page here; EC clients
+// learn it from the session's absence in the next EC_OP_CHAT_SESSIONS reply.
 void Chat_SessionRemoved(uint64 gui_id);
 
 // Fired from CSearchList::StartNewSearch, once per search the core begins,
-// whoever asked for it. The mirror of Search_Removed: it lets the monolithic
-// GUI show a tab for a search started by an EC client (amulegui, amulecmd,
-// amuleapi), which until now it could not see at all -- amulegui and amuleapi
-// already discover each other's searches over EC_OP_SEARCH_LIST, so this is
-// the last direction left (amule-org/amule#703).
+// whoever asked for it. The mirror of Search_Removed: it lets the monolithic GUI
+// show a tab for a search started by an EC client, which it could not see at all
+// before -- amulegui and amuleapi already discover each other's searches over
+// EC_OP_SEARCH_LIST (#703).
 //
-// The tab is created unselected: it appears on its own, so it must not pull
-// the selection away from whatever the local user is doing, possibly
-// mid-typing. `kind` is the CSearchList::SearchType of the new search, used
-// only to seed the Kad "!" marker the way a locally-started tab does.
+// The tab is created unselected: it appears on its own, so it must not pull the
+// selection away from whatever the local user is doing. `kind` is the new
+// search's SearchType, used only to seed the Kad "!" marker.
 void Search_Added(wxUIntPtr searchID, wxString name, uint32 kind);
 
 void ServerAdd(CServer *server);

--- a/src/HTTPDownload.cpp
+++ b/src/HTTPDownload.cpp
@@ -107,11 +107,10 @@ public:
 	}
 
 private:
-	// Unlink from the request owner and cancel it. Fire-and-forget: the
-	// owner will self-destroy when wxWebRequest reports State_Cancelled
-	// on the main loop. We must NOT delete the owner here — doing so
-	// while a request is in flight leaves the wxWebRequest backend
-	// calling into a dead sink.
+	// Unlink from the request owner and cancel it. Fire-and-forget: the owner
+	// self-destroys when wxWebRequest reports State_Cancelled on the main loop.
+	// Deleting it here, with a request in flight, would leave the wxWebRequest
+	// backend calling into a dead sink.
 	void StopDownload()
 	{
 		if (m_owner) {
@@ -159,17 +158,14 @@ wxDEFINE_EVENT(wxEVT_HTTP_SHUTDOWN, wxEvent);
 
 // Apply the current proxy prefs to the given wxWebSession.
 //
-// wxWebProxy / wxWebSession::SetProxy are wx 3.3+ only. On wx 3.2 there is
-// no programmatic way to set a proxy on wxWebRequest, so we rely on the
-// backend defaults: on Linux wxWebRequest is backed by libcurl, which
-// honours the standard http_proxy / https_proxy / all_proxy environment
-// variables. Users of the aMule Proxy pref on wx 3.2 are no worse off than
-// with the legacy wxHTTP::SetProxyMode(bool) path, which only toggled a
-// boolean and never actually consumed the host / port / auth fields either.
+// wxWebProxy / wxWebSession::SetProxy are wx 3.3+ only. On wx 3.2 there is no
+// programmatic way to set a proxy on wxWebRequest, so we rely on the backend
+// defaults: libcurl honours http_proxy / https_proxy / all_proxy. That leaves wx
+// 3.2 users no worse off than the legacy wxHTTP::SetProxyMode(bool) path, which
+// only toggled a boolean and never consumed the host / port / auth fields.
 //
-// SOCKS proxies are intentionally skipped even when SetProxy is available:
-// wx 3.3's wxWebProxy is HTTP-only. A libcurl backend would be required if
-// SOCKS support mattered — that is out of scope for this fix.
+// SOCKS proxies are skipped even where SetProxy is available: wx 3.3's
+// wxWebProxy is HTTP-only.
 static void ApplyProxyToSession(wxWebSession &session)
 {
 #if wxCHECK_VERSION(3, 3, 0)
@@ -197,47 +193,43 @@ static void ApplyProxyToSession(wxWebSession &session)
 #endif
 }
 
-// HTTP-on-curl is what lets us bind egress to an interface (via the sockopt
-// hook below). We select it on Linux and macOS but deliberately NOT on Windows:
+// HTTP-on-curl is what lets us bind egress to an interface (via the sockopt hook
+// below). Selected on Linux and macOS but deliberately NOT on Windows:
 //
-//   Linux  : curl is already the default backend — use it.
-//   macOS  : the default is the native URLSession backend (whose handle isn't a
-//            CURL*), so request curl explicitly to get a bindable handle.
-//   Windows: the wxMSW libcurl backend is broken — a forced curl request never
-//            progresses and hangs (verified with a standalone wxWebRequest, not
-//            just amuled). WinHTTP (the default) works but has no interface-bind
-//            API, so on Windows HTTP simply stays on WinHTTP and is not bound.
+//   Linux  : curl is already the default backend.
+//   macOS  : the default is the native URLSession backend, whose handle is not a
+//            CURL*, so curl is requested explicitly to get a bindable handle.
+//   Windows: the wxMSW libcurl backend is broken -- a forced curl request never
+//            progresses and hangs. WinHTTP works but has no interface-bind API,
+//            so HTTP stays on WinHTTP there and is not bound.
 //
 // P2P traffic is bound on all platforms regardless; only the Windows HTTP
-// side-channels (version check, IP2Country, server.met) are left unbound.
+// side-channels are left unbound.
 #if wxUSE_WEBREQUEST_CURL && !defined(__WINDOWS__)
 #define AMULE_HTTP_CURL_BIND 1
 #endif
 
-// Returns the session aMule HTTP should use, and reports via `isCurlBackend`
-// whether that session is libcurl-backed. This matters because the caller must
-// only treat wxWebRequest::GetNativeHandle() as a CURL* when curl is the backend
-// that actually served the request. The compile-time wxUSE_WEBREQUEST_CURL says
-// only that curl is *available*, not that it *backs the default session* — on
-// macOS the default is the native NSURLSession, whose native handle is an
-// NSURLSessionTask*. Casting that to CURL* and calling curl_easy_setopt() on it
-// corrupts the Obj-C object and crashes on startup (amule-org/amule#601).
+// Returns the session aMule HTTP should use, and reports through `isCurlBackend`
+// whether it is libcurl-backed. The caller may only treat
+// wxWebRequest::GetNativeHandle() as a CURL* when curl actually served the
+// request: wxUSE_WEBREQUEST_CURL says only that curl is AVAILABLE, not that it
+// BACKS the default session. On macOS that default is NSURLSession, whose native
+// handle is an NSURLSessionTask*, and calling curl_easy_setopt() on it corrupts
+// the Obj-C object and crashes on startup (#601).
 static wxWebSession &GetAmuleWebSession(bool &isCurlBackend)
 {
 	isCurlBackend = false;
 #ifdef AMULE_HTTP_CURL_BIND
-	// Switch to the curl backend only when an interface is actually bound —
-	// curl is just the means to make HTTP bindable. Forcing it otherwise would
-	// needlessly change the HTTP stack for users who don't use this feature (on
-	// macOS the default is the native URLSession backend, with its own TLS /
-	// proxy handling). No behavioural change on Linux, where the default is
-	// already curl.
+	// Switch to the curl backend only when an interface is actually bound -- curl
+	// is just the means to make HTTP bindable. Forcing it otherwise would change
+	// the HTTP stack for users who do not use this feature, including macOS's
+	// native URLSession with its own TLS and proxy handling.
 	if (!thePrefs::GetNetworkInterface().IsEmpty() &&
 		wxWebSession::IsBackendAvailable(wxWebSessionBackendCURL)) {
-		// Proxy applied here, at construction, and never again -- see the note
-		// on the default session below. Function-local statics are initialised
-		// once and thread-safely, which matters because HTTP requests are
-		// created from CHTTPDownloadThread as well as the main thread.
+		// Proxy applied here, at construction, and never again -- see the note on
+		// the default session below. Function-local statics are initialised once and
+		// thread-safely, which matters because requests are created from
+		// CHTTPDownloadThread as well as the main thread.
 		static wxWebSession curlSession = [] {
 			wxWebSession session = wxWebSession::New(wxWebSessionBackendCURL);
 			ApplyProxyToSession(session);
@@ -255,20 +247,15 @@ static wxWebSession &GetAmuleWebSession(bool &isCurlBackend)
 	isCurlBackend = true;
 #endif
 #endif
-	// Once per session, not once per request. WinHTTP builds its session handle
-	// on the first request, and wx asserts if SetProxy() is called after that:
+	// Once per session, not once per request. WinHTTP builds its session handle on
+	// the first request and wx asserts if SetProxy() is called after that:
 	//
 	//   webrequest_winhttp.cpp:SetProxy: assert '!m_handle' failed.
-	//   Proxy must be set before the first request is made
 	//
-	// aMule makes several HTTP requests in a session (version check, geoip,
-	// server.met), so applying the proxy on each one meant every request after
-	// the first asserted -- a modal dialog during startup, with the download it
-	// interrupted left hanging behind it.
-	//
-	// The cost is that a proxy preference change now takes effect on the next
-	// run rather than the next request. That is what the WinHTTP backend allows
-	// in any case, and applying it per request never worked there anyway.
+	// aMule makes several HTTP requests per session, so applying the proxy on each
+	// one meant every request after the first raised a modal assert during startup.
+	// The cost is that a proxy preference change takes effect on the next run
+	// rather than the next request, which is all the WinHTTP backend allows anyway.
 	static const bool defaultSessionProxyApplied = [] {
 		ApplyProxyToSession(wxWebSession::GetDefault());
 		return true;
@@ -294,27 +281,23 @@ extern "C" int amuleHttpSockoptCallback(void *, curl_socket_t curlfd, curlsockty
 #endif
 
 // Tune the libcurl handle backing an HTTP request: CURLOPT_NOSIGNAL so the
-// synchronous-resolver fallback doesn't raise SIGALRM in this multi-threaded
-// process, CURLOPT_CONNECTTIMEOUT_MS so the connect phase (incl. DNS) gives up
-// after 30 s instead of the full OS resolver timeout, and — when an interface
-// is configured — CURLOPT_SOCKOPTFUNCTION to bind egress to it. The caller must
-// only invoke this when curl actually backs the request (see GetAmuleWebSession);
-// on the macOS NSURLSession backend GetNativeHandle() is not a CURL*.
+// synchronous-resolver fallback does not raise SIGALRM in this multi-threaded
+// process, CURLOPT_CONNECTTIMEOUT_MS so the connect phase gives up after 30 s
+// instead of the full OS resolver timeout, and CURLOPT_SOCKOPTFUNCTION to bind
+// egress when an interface is configured. Only call this when curl actually
+// backs the request (see GetAmuleWebSession).
 static void CustomizeCurlRequest(wxWebRequest &request)
 {
 #if defined(AMULE_HAVE_LIBCURL) && defined(AMULE_HTTP_CURL_BIND)
 	if (CURL *curl = static_cast<CURL *>(request.GetNativeHandle())) {
 		curl_easy_setopt(curl, CURLOPT_NOSIGNAL, 1L);
 		curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT_MS, 30000L);
-		// Stall guard: abort a transfer that averages under 1 byte/s for 60 s
-		// once connected. CURLOPT_CONNECTTIMEOUT only covers the connect phase,
-		// so without this a server that accepts the connection then stops
-		// sending would leave the request hanging indefinitely (harmless to the
-		// event loop since it is async, but it leaks a pending request — and it
-		// matters more for the unattended periodic version check). A total
-		// CURLOPT_TIMEOUT is deliberately avoided so large but legitimately slow
-		// downloads (IP2Country DB, server.met) are not capped; the low-speed
-		// limit only fires on a genuine stall, not on slow-but-progressing ones.
+		// Stall guard: abort a transfer that averages under 1 byte/s for 60 s once
+		// connected. CURLOPT_CONNECTTIMEOUT only covers the connect phase, so without
+		// this a server that accepts the connection and then stops sending leaves a
+		// pending request forever -- which matters most for the unattended periodic
+		// version check. A total CURLOPT_TIMEOUT is avoided on purpose so large but
+		// legitimately slow downloads are not capped.
 		curl_easy_setopt(curl, CURLOPT_LOW_SPEED_LIMIT, 1L);
 		curl_easy_setopt(curl, CURLOPT_LOW_SPEED_TIME, 60L);
 		if (!thePrefs::GetNetworkInterface().IsEmpty()) {
@@ -390,10 +373,10 @@ CHTTPDownloadThread::CHTTPDownloadThread(const wxString &url,
 		return;
 	}
 
-	// Curl-backed session + proxy + interface bind, all in one place (shared
-	// with the version check). The threaded-resolver caveat still applies: the
-	// CONNECTTIMEOUT set inside bounds the visible delay before Failed fires,
-	// but not the cleanup-time pthread_join on libcurl's threaded resolver.
+	// Curl-backed session + proxy + interface bind, all in one place. The
+	// threaded-resolver caveat still applies: the CONNECTTIMEOUT set inside bounds
+	// the visible delay before Failed fires, but not the cleanup-time pthread_join
+	// on libcurl's threaded resolver.
 	m_request = CreateAmuleWebRequest(this, m_url);
 	if (!m_request.IsOk()) {
 		AddLogLineC(CFormat(_("Failed to create HTTP request for %s")) % m_url);
@@ -401,12 +384,11 @@ CHTTPDownloadThread::CHTTPDownloadThread(const wxString &url,
 		return;
 	}
 
-	// Storage_File: wx streams the response body to an internal temp file
-	// and hands us the path on completion. We then rename it to the
-	// caller-supplied m_tempfile. Redirects (incl. HTTP→HTTPS) are
-	// followed by wx transparently — the whole recursive GetInputStream()
-	// redirect handler of the legacy code path is gone, which is the
-	// actual fix for the upstream startup crash (amule-project/amule#455).
+	// Storage_File: wx streams the response body to an internal temp file and hands
+	// us the path on completion, which we then rename to m_tempfile. Redirects
+	// (including HTTP to HTTPS) are followed transparently, so the legacy recursive
+	// GetInputStream() redirect handler is gone -- the actual fix for the upstream
+	// startup crash.
 	m_request.SetStorage(wxWebRequest::Storage_File);
 
 	if (m_lastmodified.IsValid()) {
@@ -440,13 +422,10 @@ void CHTTPDownloadThread::OnStateEvent(wxWebRequestEvent &evt)
 		// Periodic progress notification during the download.
 		if (m_companion) {
 #ifndef AMULE_DAEMON
-			// GetBytesExpectedToReceive() returns wxInvalidOffset (-1)
-			// when the server omits Content-Length. Forwarding -1 into
-			// the dialog ends up in wxGauge::SetRange(-1), which flips
-			// m_rangeMax invalid and trips an assertion on the next
-			// repaint (./src/gtk/gauge.cpp:90). Clamp to 0 here so the
-			// dialog treats it as "unknown" (skips the range + value
-			// update) until a real total shows up.
+			// GetBytesExpectedToReceive() returns wxInvalidOffset (-1) when the
+			// server omits Content-Length, and forwarding -1 reaches
+			// wxGauge::SetRange(-1), which flips m_rangeMax invalid and asserts on the
+			// next repaint. Clamp to 0 so the dialog treats it as "unknown".
 			wxFileOffset expected = m_request.GetBytesExpectedToReceive();
 			CMuleInternalEvent prog(wxEVT_HTTP_PROGRESS);
 			prog.SetInt((int)m_request.GetBytesReceived());
@@ -469,10 +448,9 @@ void CHTTPDownloadThread::OnStateEvent(wxWebRequestEvent &evt)
 			AddDebugLogLineN(logHTTP, "Skipped download because requested file is not newer.");
 			FinishAndDestroy(HTTP_Skipped);
 		} else if (m_response >= 200 && m_response < 300) {
-			// Success. wx wrote the body to its own temp file; move it
-			// to the caller-supplied m_tempfile. A plain rename may
-			// fail across filesystems (wx's temp dir vs the aMule
-			// config dir), so fall back to copy + delete.
+			// Success. wx wrote the body to its own temp file; move it to the
+			// caller-supplied m_tempfile. A plain rename may fail across filesystems, so
+			// fall back to copy + delete.
 			const wxString wxTmp = response.GetDataFile();
 			if (wxTmp.IsEmpty() || !wxFileExists(wxTmp)) {
 				AddLogLineC(CFormat(_("HTTP download: empty response body for %s")) % m_url);

--- a/src/IP2Country.cpp
+++ b/src/IP2Country.cpp
@@ -49,11 +49,9 @@ CIP2Country::CIP2Country(const wxString &configDir)
 	m_DataBaseName = "geoip.mmdb";
 	m_DataBasePath = configDir + m_DataBaseName;
 
-	// One-shot migration: the v2.x file lived at GeoLite2-Country.mmdb.
-	// If that legacy file exists and the new canonical geoip.mmdb does
-	// not, move it across so an upgrading user doesn't lose flag display
-	// silently. If both exist (e.g. they followed the new docs while
-	// keeping the old file around) leave each alone.
+	// One-shot migration: the v2.x file lived at GeoLite2-Country.mmdb. If that
+	// exists and the canonical geoip.mmdb does not, move it across so an upgrading
+	// user does not silently lose flag display; if both exist, leave each alone.
 	const wxString legacyPath = configDir + "GeoLite2-Country.mmdb";
 	if (CPath::FileExists(legacyPath) && !CPath::FileExists(m_DataBasePath)) {
 		if (wxRenameFile(legacyPath, m_DataBasePath)) {
@@ -80,11 +78,11 @@ void CIP2Country::Enable()
 
 	m_db->Open(m_DataBasePath);
 
-	// The Update() above is only reached when the file is *missing*, so a
-	// geoip.mmdb that exists but will not open (corrupt, or a legacy libGeoIP
-	// .dat) blocks its own replacement. Discard it and the next start takes the
-	// missing-file path. No Update() from here: DownloadFinished() calls
-	// Enable(), so retrying an unreadable file would loop forever.
+	// The Update() above is only reached when the file is MISSING, so a geoip.mmdb
+	// that exists but will not open (corrupt, or a legacy libGeoIP .dat) blocks its
+	// own replacement. Discard it and the next start takes the missing-file path.
+	// No Update() from here: DownloadFinished() calls Enable(), so retrying an
+	// unreadable file would loop forever.
 	if (!m_db->IsOpen()) {
 		AddLogLineC(CFormat(_("%s is not a readable MaxMindDB file - discarding it. "
 				      "A fresh copy will be downloaded on the next start, or now via "
@@ -94,12 +92,10 @@ void CIP2Country::Enable()
 		return;
 	}
 
-	// One-shot backfill: files written by builds older than the
-	// source-aware prefs have no LoadedSource recorded, which would
-	// leave the prefs status line attribution-less. Best-effort guess:
-	// attribute the existing file to the currently configured source
-	// so the status line shows *something* meaningful. The user can
-	// always click "Update now" to overwrite with the real source.
+	// One-shot backfill: files written by builds older than the source-aware prefs
+	// have no LoadedSource recorded, leaving the prefs status line without
+	// attribution. Best-effort guess: attribute the existing file to the configured
+	// source, which "Update now" overwrites with the real one.
 	if (thePrefs::GetGeoIPLoadedSource().IsEmpty()) {
 		thePrefs::SetGeoIPLoadedSource(thePrefs::GetGeoIPSource());
 	}
@@ -146,9 +142,9 @@ void CIP2Country::StartDownload(int monthOffset)
 	AddLogLineN(CFormat(_("Download new %s from %s")) % m_DataBaseName % url);
 	m_downloading = true;
 	// showDialog = m_showProgress: shown for a local monolithic "Update now",
-	// suppressed for a remote (amulegui/EC) trigger — EC carries no progress and
-	// on a monolithic-app-as-backend it would pop on the core (#440). No-op on a
-	// headless daemon. checkDownloadNewer stays true (honour If-Modified).
+	// suppressed for a remote trigger, where EC carries no progress and on a
+	// monolithic-app-as-backend the dialog would pop on the core. checkDownloadNewer
+	// stays true, honouring If-Modified.
 	CHTTPDownloadThread *downloader = new CHTTPDownloadThread(
 		url, m_DataBasePath + ".download", m_DataBasePath, HTTP_GeoIP, m_showProgress, true);
 	downloader->Create();
@@ -165,9 +161,8 @@ void CIP2Country::Disable()
 
 void CIP2Country::DownloadFinished(uint32 result)
 {
-	// Snapshot + clear the manual flag up front so any early return
-	// below doesn't leave it set for the next StartDownload (e.g. a
-	// subsequent auto-update would inherit the popup behaviour).
+	// Snapshot and clear the manual flag up front, so an early return below cannot
+	// leave it set for the next StartDownload.
 	const bool manual = m_ManualUpdate;
 	m_ManualUpdate = false;
 	// The download finished; the DB-IP early-month retry below re-arms this.
@@ -175,10 +170,8 @@ void CIP2Country::DownloadFinished(uint32 result)
 
 	if (result == HTTP_Success) {
 		Disable();
-		// download succeeded. Switch over to new database.
 		wxString newDat = m_DataBasePath + ".download";
 
-		// Try to unpack the file, might be an archive
 		wxScopedCharBuffer dataBaseName = m_DataBaseName.utf8_str();
 		const char *geoip_files[] = { dataBaseName, NULL };
 

--- a/src/IP2Country.h
+++ b/src/IP2Country.h
@@ -51,13 +51,12 @@
 
 class CMaxMindDBDatabase;
 
-// Headless GeoIP resolver. Maps an IP to an ISO 3166-1 alpha-2 country code
-// via the on-disk MaxMind DB and manages downloading/updating that DB from the
-// user-configured source (thePrefs). Deliberately free of any GUI dependency
-// (no wxImage / flags / prefs-dialog) so it can live in the core (CamuleApp)
-// and run headless in amuled — the flag presentation is a separate GUI concern
-// (see CCountryFlags), and manual-update failure popups are delegated to the
-// GUI via SetUpdateFailedNotifier().
+// Headless GeoIP resolver. Maps an IP to an ISO 3166-1 alpha-2 country code via
+// the on-disk MaxMind DB, and manages downloading and updating that DB from the
+// user-configured source. Deliberately free of any GUI dependency so it can live
+// in the core and run headless in amuled: flag presentation is a separate GUI
+// concern (CCountryFlags), and manual-update failure popups are delegated via
+// SetUpdateFailedNotifier().
 class CIP2Country
 {
 public:
@@ -71,36 +70,34 @@ public:
 
 	// Same, from the numeric IP the callers already hold, and memoised.
 	//
-	// The returned reference is valid until the next call on this object, or
-	// any Enable()/Disable(): the cache is cleared wholesale on overflow and
-	// on either of those, and clear() invalidates references. Copy it if you
-	// need it to outlive the call -- in particular do not pass two of these
-	// into one expression.
+	// The returned reference is valid until the next call on this object, or any
+	// Enable()/Disable(): the cache is cleared wholesale on overflow and on either
+	// of those. Copy it if you need it to outlive the call, and in particular do
+	// not pass two of these into one expression.
 	//
-	// #439 moved this resolution from GUI paint into the core. Paint hid the
-	// cost: it ran only for visible rows, only while the list was on screen,
-	// only with someone watching. The EC client tag now resolves EVERY peer
-	// on EVERY poll -- roughly every 3 s, headless, forever -- and a peer's
-	// country cannot change while its IP does not. Measured at ~7.5us per
-	// peer per poll on a live daemon, about 37% of the client tag build.
+	// #439 moved this resolution from GUI paint into the core. Paint hid the cost:
+	// it ran only for visible rows, only while the list was on screen. The EC
+	// client tag now resolves EVERY peer on EVERY poll, headless, forever -- and a
+	// peer's country cannot change while its IP does not. Measured at ~7.5us per
+	// peer per poll, about 37% of the client tag build.
 	//
-	// Keyed on the numeric IP so the caller need not format a string first
-	// (Uint32toStringIP allocates); the string is only built on a miss.
+	// Keyed on the numeric IP so the caller need not format a string first; the
+	// string is only built on a miss.
 	const wxString &GetCountryCode(uint32 ip);
 
 	void Enable();
 	void Disable();
 	// Refresh the on-disk MMDB from the configured source.
-	// manualUpdate=true is set by the prefs "Update now" button so that
-	// failures (no credential, bad URL, HTTP error) surface via the
-	// update-failed notifier (a GUI popup) in addition to the network log;
-	// auto-update (startup) stays silent so users don't get a popup every
-	// cold boot if their chosen source is briefly down.
-	// showProgress=true renders the HTTP progress dialog — appropriate for a
-	// LOCAL monolithic "Update now". It is false for a REMOTE (amulegui, over
-	// EC) trigger: EC carries no download progress, so the dialog would be
-	// blank/unhelpful, and on a monolithic-app-as-backend it would pop on the
-	// core rather than the remote GUI. (No-op on a headless daemon either way.)
+	//
+	// manualUpdate=true is set by the prefs "Update now" button, so failures (no
+	// credential, bad URL, HTTP error) surface via the update-failed notifier as
+	// well as the network log; auto-update stays silent, or a briefly-down source
+	// would pop a dialog on every cold boot.
+	//
+	// showProgress=true renders the HTTP progress dialog, which suits a LOCAL
+	// monolithic "Update now". It is false for a REMOTE trigger: EC carries no
+	// download progress, and on a monolithic-app-as-backend the dialog would pop on
+	// the core rather than the remote GUI.
 	void Update(bool manualUpdate = false, bool showProgress = true);
 	bool IsEnabled();
 	void DownloadFinished(uint32 result);
@@ -109,10 +106,9 @@ public:
 	// preferences panel can show the status line ("Loaded — <path>"),
 	// without re-deriving the config-dir + filename convention.
 	const wxString &GetDatabasePath() const { return m_DataBasePath; }
-	// Live status for the prefs panel (local, and carried to amulegui over EC,
-	// #440 remote config). IsDownloading() is true while a refresh is in
-	// flight; GetLastResult() is a short human string describing the outcome
-	// of the last completed update (empty until the first one runs).
+	// Live status for the prefs panel, local and carried to amulegui over EC.
+	// IsDownloading() is true while a refresh is in flight; GetLastResult() is a
+	// short human string describing the last completed update.
 	bool IsDownloading() const { return m_downloading; }
 
 	const wxString &GetLastResult() const { return m_lastResult; }
@@ -128,19 +124,18 @@ public:
 private:
 	// Drop every memoised resolution. Called wherever the answer could change
 	// underneath the cache: enable and disable, which between them also cover a
-	// completed database refresh (DownloadFinished routes through both).
-	// Without this a headless daemon is the worst case -- entries resolved
-	// while GeoIP was off would stay empty forever, with no repaint to force a
-	// re-read and nobody watching to notice.
+	// completed database refresh. A headless daemon is the worst case without it --
+	// entries resolved while GeoIP was off would stay empty forever, with no repaint
+	// to force a re-read and nobody watching.
 	void InvalidateCountryCache();
 
-	// Numeric IP -> ISO code. Bounded: peers churn, so an unbounded map on a
-	// long-lived daemon would grow without limit. On overflow the whole map is
-	// dropped rather than evicting cleverly -- a rebuild costs one lookup per
-	// live peer, which is what a single poll cost before this existed.
+	// Numeric IP -> ISO code. Bounded, because peers churn and an unbounded map on
+	// a long-lived daemon would grow without limit. On overflow the whole map is
+	// dropped rather than evicting cleverly: a rebuild costs one lookup per live
+	// peer, which is what a single poll cost before this existed.
 	//
-	// Not synchronised. Like the rest of this class it is touched from the main
-	// thread only; a concurrent reader during a clear() would be a race.
+	// Not synchronised: like the rest of this class it is touched from the main
+	// thread only.
 	std::unordered_map<uint32, wxString> m_countryCache;
 	static const size_t kMaxCountryCacheEntries = 8192;
 
@@ -148,11 +143,10 @@ private:
 	wxString m_DataBaseName;
 	wxString m_DataBasePath;
 
-	// DB-IP fallback retry tracking. The first attempt fetches the
-	// current month's URL; if that fails (commonly a 404 in the first
-	// few days of a month before DB-IP publishes the new dataset), the
-	// download callback retries with monthOffset=-1. Reset to false on
-	// every Update() entry.
+	// DB-IP fallback retry tracking. The first attempt fetches the current month's
+	// URL; on failure -- commonly a 404 in the first few days of a month, before
+	// DB-IP publishes the new dataset -- the download callback retries with
+	// monthOffset=-1. Reset on every Update() entry.
 	bool m_TriedPreviousMonth;
 
 	// Set by Update(true) (the "Update now" button) so the failure

--- a/src/IPFilter.cpp
+++ b/src/IPFilter.cpp
@@ -125,9 +125,8 @@ private:
 
 		uint8 accessLevel = thePrefs::GetIPFilterLevel();
 		uint32 size = m_result.size();
-		// Reserve a little more so we don't have to resize the vector later.
-		// (Map ranges can exist that have to be stored in several parts.)
-		// Extra memory will be freed in the end.
+		// Reserve a little more so the vector does not have to resize later: a map
+		// range can need storing in several parts. The extra is freed at the end.
 		m_rangeIPs.reserve(size + 1000);
 		m_rangeLengths.reserve(size + 1000);
 		if (m_storeDescriptions) {
@@ -135,14 +134,11 @@ private:
 		}
 		for (IPMap::iterator it = m_result.begin(); it != m_result.end(); ++it) {
 			if (it->AccessLevel < accessLevel) {
-				// Calculate range "length"
-				// (which is included-end - start and thus length - 1)
-				// Encoding:
-				// 0      - 0x7fff	same
-				// 0x8000 - 0xffff	0xfff	- 0x07ffffff
-				// that means: remove msb, shift left by 12 bit, add 0xfff
-				// so it can cover 8 consecutive class A nets
-				// larger ranges (or theoretical ranges with uneven ends) have to be split
+				// Range "length" is included-end - start, so length - 1. Encoded as
+				// 0 - 0x7fff for itself, and 0x8000 - 0xffff for 0xfff - 0x07ffffff:
+				// remove the msb, shift left 12 bits, add 0xfff, which covers 8
+				// consecutive class A nets. Larger ranges, and theoretical ones with
+				// uneven ends, have to be split.
 				uint32 startIP = it.keyStart();
 				uint32 realLength = it.keyEnd() - it.keyStart() + 1;
 #ifdef __DEBUG__
@@ -186,9 +182,8 @@ private:
 				}
 			}
 		}
-		// Numbers are probably different:
-		// - ranges from map that are not blocked because of their level are not added to the table
-		// - some ranges from the map have to be split for the table
+		// The numbers usually differ: ranges not blocked because of their level are
+		// not added to the table, and some map ranges have to be split for it.
 		AddDebugLogLineN(logIPFilter,
 			CFormat("Ranges in map: %d  blocked ranges in table: %d") % size % m_rangeIPs.size());
 
@@ -275,10 +270,9 @@ private:
 			return 0;
 		}
 
-		// An empty file is a valid "no ranges" list (e.g. a user who cleared it,
-		// or an auto-update that has not populated it yet). Treat it as 0 ranges
-		// instead of letting the format detector below report "unknown format"
-		// on a 0-byte file (issue #580).
+		// An empty file is a valid "no ranges" list -- a user who cleared it, or an
+		// auto-update that has not populated it yet -- so treat it as 0 ranges rather
+		// than letting the format detector report "unknown format" (issue #580).
 		if (path.GetFileSize() == 0) {
 			return 0;
 		}
@@ -288,8 +282,6 @@ private:
 #endif
 
 		const char *ipfilter_files[] = { "ipfilter.dat", "guardian.p2p", "guarding.p2p", NULL };
-
-		// Try to unpack the file, might be an archive
 
 		if (UnpackArchive(path, ipfilter_files).second != EFT_Text) {
 			AddLogLineC(CFormat(_("Failed to load ipfilter.dat file '%s', unknown format "
@@ -357,7 +349,6 @@ wxEND_EVENT_TABLE()
  */
 static bool CreateDummyFile(const wxString &filename, const wxString &text)
 {
-	// Create template files
 	if (!wxFileExists(filename)) {
 		CTextFile file;
 
@@ -480,17 +471,15 @@ void CIPFilter::Update(const wxString &strURL)
 {
 	if (!strURL.IsEmpty()) {
 		m_URL = strURL;
-		// "Update from this URL" and "remember this URL" are one action for
-		// the other two list downloads: the EC handlers for the ed2k server
-		// list and for the Kad node list both store their URL before starting
-		// the download. This one belongs here rather than in the EC handler
-		// because this function is the single funnel for every caller -- the
-		// EC op, the Preferences "Update now" button and the startup
-		// auto-update. Without it a URL used for a manual update is forgotten
-		// and the next auto-update silently falls back to the old one.
+		// "Update from this URL" and "remember this URL" are one action, as they
+		// already are for the ed2k server list and the Kad node list. It belongs here
+		// rather than in the EC handler because this function is the single funnel
+		// for every caller -- the EC op, the Preferences "Update now" button and the
+		// startup auto-update. Without it a URL used for a manual update is forgotten
+		// and the next auto-update falls back to the old one.
 		//
 		// Assign from m_URL, not strURL: the auto-update path hands us
-		// thePrefs::IPFilterURL() itself, so this would be a self-assignment.
+		// thePrefs::IPFilterURL() itself, so that would be a self-assignment.
 		thePrefs::SetIPFilterURL(m_URL);
 
 		wxString filename = thePrefs::GetConfigDir() + "ipfilter.download";
@@ -507,7 +496,6 @@ void CIPFilter::DownloadFinished(uint32 result)
 {
 	wxString datName = "ipfilter.dat";
 	if (result == HTTP_Success) {
-		// download succeeded. proceed with ipfilter loading
 		wxString newDat = thePrefs::GetConfigDir() + "ipfilter.download";
 		wxString oldDat = thePrefs::GetConfigDir() + datName;
 
@@ -529,7 +517,6 @@ void CIPFilter::DownloadFinished(uint32 result)
 	}
 
 	if (result == HTTP_Success) {
-		// Reload both ipfilter files on success
 		Reload();
 	}
 }
@@ -554,13 +541,11 @@ void CIPFilter::OnIPFilterEvent(CIPFilterEvent &evt)
 	if (thePrefs::IsFilteringServers()) {
 		theApp->serverlist->FilterServers();
 	}
-	// Now start networks we didn't start earlier
 	StartPendingNetworks();
 	theApp->ShowConnectionState(true); // refresh connection status
 	if (thePrefs::GetSrcSeedsOn()) {
 		theApp->downloadqueue->LoadSourceSeeds();
 	}
-	// Trigger filter update if configured
 	if (m_updateAfterLoading) {
 		m_updateAfterLoading = false;
 		Update(thePrefs::IPFilterURL());

--- a/src/InstanceLock.cpp
+++ b/src/InstanceLock.cpp
@@ -135,16 +135,14 @@ InstanceLock::Result InstanceLock::Acquire(
 	}
 	m_anotherRunning = m_wxImpl->IsAnotherRunning();
 
-	// The mutex answers "is another instance running" but says nothing about
-	// WHICH: amuled shares this name with the monolithic GUI, and only one of
-	// them has a window to raise. wxSingleInstanceChecker keeps no file, so
-	// the same two facts POSIX writes into the lock file are written beside
-	// the mutex here, for the same reason and in the same format.
+	// The mutex answers "is another instance running" but says nothing about WHICH:
+	// amuled shares this name with the monolithic GUI, and only one of them has a
+	// window to raise. wxSingleInstanceChecker keeps no file, so the two facts POSIX
+	// writes into the lock file are written beside the mutex here.
 	//
-	// No liveness check is needed on this side: the OS releases a named mutex
-	// when its owner dies, so a held mutex is proof of a live holder, and a
-	// file left behind by a crash is overwritten by the next acquire -- which
-	// by definition is the process that just won the mutex.
+	// No liveness check is needed on this side: the OS releases a named mutex when
+	// its owner dies, so a held mutex proves a live holder, and a file left by a
+	// crash is overwritten by the next acquire.
 	if (m_anotherRunning) {
 		ReadHolderFile(m_path, m_holderPid, m_holderKind);
 		return LOCK_HELD;
@@ -168,10 +166,10 @@ void InstanceLock::Release()
 InstanceLock::Result InstanceLock::Acquire(
 	const wxString &filename, const wxString &dir, const wxString &selfKind)
 {
-	// Idempotent-caller contract (see header). Drop any existing fd first
-	// without unlinking - the file will be replaced on the open() below;
-	// unlink()-ing here would create a race window during which no lock
-	// file exists on disk, and a concurrent third instance could slip in.
+	// Idempotent-caller contract (see header). Drop any existing fd first without
+	// unlinking -- the file is replaced by the open() below, and unlinking here
+	// would leave a window with no lock file on disk for a third instance to slip
+	// through.
 	if (m_fd != -1) {
 		(void)close(m_fd);
 		m_fd = -1;
@@ -186,9 +184,8 @@ InstanceLock::Result InstanceLock::Acquire(
 		return LOCK_ERROR;
 	}
 
-	// Defense against a planted lock file with wrong owner (matches
-	// wxSingleInstanceChecker's paranoia). If someone dropped a
-	// world-writable muleLock into ~/.aMule/ we don't want to touch it.
+	// Defense against a planted lock file with the wrong owner: a world-writable
+	// muleLock dropped into ~/.aMule/ is not one to touch.
 	struct stat st;
 	if (fstat(m_fd, &st) == 0 && st.st_uid != getuid()) {
 		(void)close(m_fd);

--- a/src/KnownFile.cpp
+++ b/src/KnownFile.cpp
@@ -142,26 +142,21 @@ std::atomic<uint64> CKnownFile::s_globalEcGen{ 0 };
 
 uint32 CKnownFile::GetMetaDataVer() const
 {
-	// Derived from tag presence, no separate m_uMetaDataVer field.
+	// Derived from tag presence, with no separate m_uMetaDataVer field.
 	//
 	// ANY FT_MEDIA_* tag counts, not FT_MEDIA_LENGTH alone. The premise the
 	// length-only test rested on -- that a successful probe always yields a
 	// duration -- is false: MediaProbe succeeds on a duration OR a codec, so a
-	// file ffprobe can identify but not time (a raw elementary stream, a
-	// truncated capture) gets a codec and no length. That put the four
-	// consumers of this predicate in disagreement: the ed2k publisher, which
-	// checks each tag individually, advertised the codec to every peer, while
-	// Kad, EC and the file-detail dialog all reported the file as having no
-	// metadata at all. The same tag was good enough for strangers and not for
-	// the person who owns the file.
+	// file ffprobe can identify but not time gets a codec and no length. That put
+	// the four consumers of this predicate in disagreement: the ed2k publisher
+	// checks each tag individually and advertised the codec to every peer, while
+	// Kad, EC and the file-detail dialog all reported no metadata at all. It also
+	// drives the "already probed" gate in CSharedFileList, so those files were
+	// re-probed on every startup, forever.
 	//
-	// It also drives the "already probed" gate in CSharedFileList, so those
-	// files used to be re-probed on every single startup, forever, for a
-	// result that was already known and would be discarded again.
-	// One pass over m_taglist rather than six Get*TagValue calls, each of
-	// which scans it end to end. This runs per file per EC update, and the
-	// worst case is the common one: a non-media file matches nothing, so all
-	// six scans would run to completion every time.
+	// One pass over m_taglist rather than six Get*TagValue calls, each of which
+	// scans it end to end: this runs per file per EC update, and the worst case
+	// is the common one -- a non-media file matches nothing.
 	for (const CTag &tag : m_taglist) {
 		switch (tag.GetNameID()) {
 		case FT_MEDIA_LENGTH:
@@ -348,17 +343,15 @@ void CAbstractFile::AddTagUnique(const CTag &rTag)
 
 bool CAbstractFile::RemoveTag(uint8 tagname)
 {
-	// Matches on the numeric id alone, unlike AddTagUnique's (id, type) pair:
-	// the caller wants the field gone whatever width or encoding it was stored
-	// with, and a media tag inherited from a search result can legitimately
-	// arrive as a narrower integer type than the one a local probe writes.
+	// Matches on the numeric id alone, unlike AddTagUnique's (id, type) pair: the
+	// caller wants the field gone whatever width or encoding it was stored with,
+	// and a media tag inherited from a search result can legitimately arrive as a
+	// narrower integer type than a local probe writes.
 	//
-	// Erases EVERY match, not just the first. AddTagUnique replaces only when
-	// the type matches too, so two tags with one id and different types can
-	// legitimately coexist; stopping at the first would leave the other behind
-	// and quietly break the promise this comment makes. No current writer
-	// produces that pair -- they all normalise to CTagInt32 / CTagString --
-	// but "clear this field" should not depend on that staying true.
+	// Erases EVERY match, not just the first. AddTagUnique replaces only when the
+	// type matches too, so two tags with one id and different types can
+	// legitimately coexist. No current writer produces that pair, but "clear
+	// this field" should not depend on that staying true.
 	const size_t before = m_taglist.size();
 	m_taglist.erase(std::remove_if(m_taglist.begin(),
 				m_taglist.end(),
@@ -450,12 +443,11 @@ CKnownFile::CKnownFile(const CSearchFile &searchFile)
 
 void CKnownFile::Init()
 {
-	// Stamp the EC generation immediately so any newly-constructed file
-	// (search-result import, partfile creation, hashed-and-added shared
-	// file) is naturally `> 0` from every existing connection's
-	// `m_lastEcGenSeen` perspective. Without this, the first INC_UPDATE
-	// cycle within the 60 s backstop window after a file is added would
-	// skip it because its default-zero gen looked unchanged.
+	// Stamp the EC generation immediately so any newly-constructed file is
+	// naturally `> 0` from every existing connection's `m_lastEcGenSeen`
+	// perspective. Without this, the first INC_UPDATE cycle within the 60 s
+	// backstop window after a file is added would skip it, its default-zero gen
+	// looking unchanged.
 	MarkECChanged();
 
 	m_showSources = false;
@@ -476,13 +468,11 @@ void CKnownFile::Init()
 	m_lastDateChanged = 0;
 	m_lastUploadDatetime = 0;
 	m_dateShared = 0;
-	// Sentinel "unknown": LoadFromFile fills this in from FT_LASTSEEN
-	// when present, else falls back to the file's own mtime
-	// (m_lastDateChanged) for migration -- so a known.met that
-	// predates this tag gets a useful aging signal on first save
-	// after upgrade rather than every record looking "fresh now"
-	// for the next TTL window. Fresh hashes (CHashingTask) bump
-	// this in CKnownFileList::Append's "newly added" branch.
+	// Sentinel "unknown": LoadFromFile fills this in from FT_LASTSEEN when
+	// present, else falls back to the file's own mtime for migration -- so a
+	// known.met that predates this tag gets a useful aging signal on the first
+	// save after upgrade rather than every record looking "fresh now" for the
+	// next TTL window. Fresh hashes bump this in CKnownFileList::Append.
 	m_lastSeen = 0;
 	m_bAutoUpPriority = thePrefs::GetNewAutoUp();
 	m_iUpPriority = (m_bAutoUpPriority) ? PR_HIGH : PR_NORMAL;
@@ -500,54 +490,18 @@ void CKnownFile::SetFileSize(uint64 nFileSize)
 	m_pAICHHashSet->SetFileSize(nFileSize);
 #endif
 
-	// Examples of parthashs, hashsets and filehashs for different filesizes
-	// according the ed2k protocol
-	//----------------------------------------------------------------------
+	// Parthashs, hashsets and filehashs for different filesizes, per the ed2k
+	// protocol. The point of the table is the boundary rule: a file whose size is
+	// an exact multiple of PARTSIZE carries one extra part hash, and that last
+	// one is always the MD4 of nothing --
+	// 31D6CFE0D16AE931B73C59D7E0C089C0, the *special part hash*.
 	//
-	// File size: 3 bytes
-	// File hash: 2D55E87D0E21F49B9AD25F98531F3724
-	// Nr. hashs: 0
-	//
-	//
-	// File size: 1*PARTSIZE
-	// File hash: A72CA8DF7F07154E217C236C89C17619
-	// Nr. hashs: 2
-	// Hash[  0]: 4891ED2E5C9C49F442145A3A5F608299
-	// Hash[  1]: 31D6CFE0D16AE931B73C59D7E0C089C0	*special part hash*
-	//
-	//
-	// File size: 1*PARTSIZE + 1 byte
-	// File hash: 2F620AE9D462CBB6A59FE8401D2B3D23
-	// Nr. hashs: 2
-	// Hash[  0]: 121795F0BEDE02DDC7C5426D0995F53F
-	// Hash[  1]: C329E527945B8FE75B3C5E8826755747
-	//
-	//
-	// File size: 2*PARTSIZE
-	// File hash: A54C5E562D5E03CA7D77961EB9A745A4
-	// Nr. hashs: 3
-	// Hash[  0]: B3F5CE2A06BF403BFB9BFFF68BDDC4D9
-	// Hash[  1]: 509AA30C9EA8FC136B1159DF2F35B8A9
-	// Hash[  2]: 31D6CFE0D16AE931B73C59D7E0C089C0	*special part hash*
-	//
-	//
-	// File size: 3*PARTSIZE
-	// File hash: 5E249B96F9A46A18FC2489B005BF2667
-	// Nr. hashs: 4
-	// Hash[  0]: 5319896A2ECAD43BF17E2E3575278E72
-	// Hash[  1]: D86EF157D5E49C5ED502EDC15BB5F82B
-	// Hash[  2]: 10F2D5B1FCB95C0840519C58D708480F
-	// Hash[  3]: 31D6CFE0D16AE931B73C59D7E0C089C0	*special part hash*
-	//
-	//
-	// File size: 3*PARTSIZE + 1 byte
-	// File hash: 797ED552F34380CAFF8C958207E40355
-	// Nr. hashs: 4
-	// Hash[  0]: FC7FD02CCD6987DCF1421F4C0AF94FB8
-	// Hash[  1]: 2FE466AF8A7C06DA3365317B75A5ACFE
-	// Hash[  2]: 873D3BF52629F7C1527C6E8E473C1C30
-	// Hash[  3]: BCE50BEE7877BB07BB6FDA56BFE142FB
-	//
+	//   3 bytes            -> 0 hashes
+	//   1*PARTSIZE         -> 2 hashes, second is the special one
+	//   1*PARTSIZE + 1     -> 2 hashes, both real
+	//   2*PARTSIZE         -> 3 hashes, third is the special one
+	//   3*PARTSIZE         -> 4 hashes, fourth is the special one
+	//   3*PARTSIZE + 1     -> 4 hashes, all real
 
 	// File size       Data parts      ED2K parts      ED2K part hashs
 	// ---------------------------------------------------------------
@@ -872,12 +826,10 @@ bool CKnownFile::LoadFromFile(const CFileDataIO *file)
 	bool ret2 = LoadHashsetFromFile(file, false);
 	bool ret3 = LoadTagsFromFile(file);
 	UpdatePartsInfo();
-	// Migration: a known.met written before FT_LASTSEEN was added
-	// leaves m_lastSeen at its Init() sentinel of 0. Fall back to
-	// the file's stored mtime as a proxy for "last known to be on
-	// disk at this name/date/size" -- accurate enough to drive the
-	// TTL prune on first save after upgrade rather than waiting a
-	// TTL window for all records to look "fresh now".
+	// Migration: a known.met written before FT_LASTSEEN was added leaves
+	// m_lastSeen at its Init() sentinel of 0. Fall back to the file's stored
+	// mtime as a proxy, accurate enough to drive the TTL prune on the first save
+	// after upgrade rather than waiting a TTL window for every record.
 	if (m_lastSeen == 0) {
 		m_lastSeen = (uint32)m_lastDateChanged;
 	}
@@ -907,15 +859,11 @@ bool CKnownFile::WriteToFile(CFileDataIO *file)
 	if (HasProperAICHHashSet()) {
 		tagcount++;
 	}
-	// Float meta tags are currently not written. All older eMule versions < 0.28a have
-	// a bug in the meta tag reading+writing code. To achieve maximum backward
-	// compatibility for met files with older eMule versions we just don't write float
-	// tags. This is OK, because we (eMule) do not use float tags. The only float tags
-	// we may have to handle is the '# Sent' tag from the Hybrid, which is pretty
-	// useless but may be received from us via the servers.
-	//
-	// The code for writing the float tags SHOULD BE ENABLED in SOME MONTHS (after most
-	// people are using the newer eMule versions which do not write broken float tags).
+	// Float meta tags are currently not written: all eMule versions < 0.28a have a
+	// bug in the meta-tag reading and writing code, and skipping them gives
+	// maximum backward compatibility. This costs nothing, because aMule does not
+	// use float tags -- the only one it may have to handle is the Hybrid's
+	// '# Sent' tag, which is useless but may arrive via the servers.
 	for (size_t j = 0; j < m_taglist.size(); ++j) {
 		if (m_taglist[j].IsInt() || m_taglist[j].IsStr()) {
 			++tagcount;

--- a/src/KnownFile.h
+++ b/src/KnownFile.h
@@ -143,35 +143,31 @@ public:
 	const CTag *GetTag(uint8 tagname, uint8 tagtype) const;
 	void AddTagUnique(const CTag &pTag);
 	// Drop the tag with this numeric id, if present. The counterpart to
-	// AddTagUnique: without it a re-probe can only add or replace, never
-	// clear, so a field the probe no longer finds keeps whatever value was
-	// there -- including one inherited unverified from a search result.
-	// Returns true if a tag was removed.
+	// AddTagUnique: without it a re-probe can only add or replace, never clear, so
+	// a field the probe no longer finds keeps whatever value was there, including
+	// one inherited unverified from a search result.
 	bool RemoveTag(uint8 tagname);
 	const ArrayOfCTag &GetTags() const { return m_taglist; }
 	void AddNote(Kademlia::CEntry *pEntry);
 	const CKadEntryPtrList &getNotes() const { return m_kadNotes; }
 
-	// Append the community ratings/comments retrieved on demand from Kad (one
-	// entry per responding node, stored by CSearch::ProcessResultNotes ->
-	// AddNote) to `list`. Shared by downloads and search results; the source-
-	// client half of a download's comments is added separately by CPartFile.
-	// Core-only: on amulegui the notes ride the EC channel as a prebuilt list.
+	// Append the community ratings/comments retrieved on demand from Kad (one entry
+	// per responding node) to `list`. Shared by downloads and search results; the
+	// source-client half of a download's comments is added by CPartFile. Core-only:
+	// on amulegui the notes ride the EC channel as a prebuilt list.
 	void GetKadNotesComments(FileRatingList &list) const;
 
-	// Collect the ratings/comments to display for this file. On the daemon the
-	// base version returns just the Kad notes (correct for a search result or a
-	// shared file), and CPartFile overrides it to prepend its connected-source
-	// comments. On amulegui every file type returns the same EC-streamed cache
-	// (m_FileRatingList) via the base, so no per-class override is needed there.
+	// Collect the ratings/comments to display for this file. On the daemon the base
+	// version returns just the Kad notes, and CPartFile overrides it to prepend its
+	// connected-source comments. On amulegui every file type returns the same
+	// EC-streamed cache through the base.
 	virtual void GetRatingAndComments(FileRatingList &list) const;
 
 #ifdef CLIENT_GUI
 	// amulegui cache of the ratings/comments the daemon streams over EC. One
-	// implementation for downloads, shared files and search results — the
-	// remote containers (CKnownFilesRem / CSearchListRem) fill it from the
-	// EC_TAG_PARTFILE_COMMENTS container, and the base GetRatingAndComments
-	// above hands it back.
+	// implementation for downloads, shared files and search results: the remote
+	// containers fill it from the EC_TAG_PARTFILE_COMMENTS container, and the base
+	// GetRatingAndComments hands it back.
 	const FileRatingList &GetFileRatingList() const { return m_FileRatingList; }
 	void ClearFileRatingList() { m_FileRatingList.clear(); }
 	void AddFileRatingList(const wxString &u, const wxString &f, sint16 r, const wxString &c)
@@ -180,12 +176,11 @@ public:
 	}
 #endif
 
-	// Start an on-demand Kad NOTES lookup to retrieve community ratings/comments
-	// for this file. Works for any file the daemon can size locally: the shared
-	// list, the download queue, or the current search results (the request
-	// builder reads the file size from there). Returns false if Kad is
-	// unavailable, a lookup is already running, or the file is not eligible. On
-	// amulegui this is a no-op stub — the GUI triggers it over EC.
+	// Start an on-demand Kad NOTES lookup for this file's community
+	// ratings/comments. Works for any file the daemon can size locally: the shared
+	// list, the download queue, or the current search results. False if Kad is
+	// unavailable, a lookup is already running, or the file is not eligible. A
+	// no-op stub on amulegui, which triggers it over EC.
 	bool RequestKadNoteSearch();
 
 	// True while an on-demand Kad NOTES lookup for this file's comments/ratings
@@ -378,12 +373,10 @@ public:
 	bool PublishSrc();
 	bool PublishNotes();
 
-	// Nonzero when this file has verified media metadata attached
-	// (probed by MediaProbe at share-add time). Derived from tag
-	// presence — a nonzero FT_MEDIA_LENGTH is the only source of
-	// this tag in aMule, so its presence is the "we've probed and
-	// have data worth publishing" signal that Kad's publisher gates
-	// on (Search.cpp:1422). No separate m_uMetaDataVer field needed.
+	// Nonzero when this file has verified media metadata attached, probed by
+	// MediaProbe at share-add time. Derived from tag presence: a nonzero
+	// FT_MEDIA_LENGTH is the only source of this tag in aMule, so its presence is
+	// the "probed, with data worth publishing" signal Kad's publisher gates on.
 	uint32 GetMetaDataVer() const;
 
 	// file sharing
@@ -431,21 +424,17 @@ public:
 
 	time_t m_lastDateChanged;
 
-	// Live upload activity (issue #466), persisted in known.met so it
-	// survives restarts. m_lastUploadDatetime is stamped whenever data is
-	// sent for this file (CFileStatistic::AddTransferred); m_dateShared is
-	// stamped once when the file is completed or first shared. 0 = unknown.
+	// Live upload activity (issue #466), persisted in known.met so it survives
+	// restarts. m_lastUploadDatetime is stamped whenever data is sent for this file;
+	// m_dateShared once, when the file is completed or first shared. 0 = unknown.
 	time_t m_lastUploadDatetime;
 	time_t m_dateShared;
 
-	// "Last time aMule saw this exact (name, date, size) match a real
-	// file." Refreshed by CKnownFileList::FindKnownFile and the
-	// "already on the list" branch in Append. Persisted via
-	// FT_LASTSEEN. Drives the TTL prune in CKnownFileList::Save --
-	// records whose lastSeen is older than the TTL window are dropped
-	// (both live and duplicate-list entries), capping known.met
-	// growth at a function of *recently active* unique hashes
-	// rather than lifetime-of-the-profile uniques.
+	// "Last time aMule saw this exact (name, date, size) match a real file."
+	// Refreshed by CKnownFileList::FindKnownFile and the "already on the list"
+	// branch in Append, persisted via FT_LASTSEEN. Drives the TTL prune in
+	// CKnownFileList::Save, capping known.met growth at a function of RECENTLY
+	// ACTIVE unique hashes rather than lifetime-of-the-profile ones.
 	uint32 GetLastSeen() const { return m_lastSeen; }
 	void SetLastSeen(uint32 t) { m_lastSeen = t; }
 

--- a/src/KnownFileList.cpp
+++ b/src/KnownFileList.cpp
@@ -44,22 +44,18 @@
 #include <common/Format.h>
 #include "Preferences.h" // Needed for thePrefs
 
-// Max duplicate-list records retained per hash. Unique hashes always
-// keep their live m_knownFileMap entry; this caps only the historical
-// (name/date) variants in m_duplicateFileList. 8 covers daily-touch /
-// weekly-snapshot / monthly-backup cycles while bounding the on-disk
-// known.met at unique_hashes × (1 + cap).
+// Max duplicate-list records retained per hash. Unique hashes always keep their
+// live m_knownFileMap entry; this caps only the historical (name/date) variants
+// in m_duplicateFileList. 8 covers daily-touch / weekly-snapshot /
+// monthly-backup cycles while bounding known.met at unique_hashes * (1 + cap).
 #define KNOWN_DUPLICATE_HASH_CAP 8
 
-// TTL after which a record (live or duplicate) whose lastSeen hasn't
-// been refreshed gets dropped. A real file currently on disk has its
-// lastSeen bumped by FindKnownFile / IsOnDuplicates / Append every
-// share-scan; anything left stale for this long either lost its file
-// or had its mtime/name change in a way that won't recur (mtime is
-// monotone-forward in practice, so a duplicate captured at an older
-// mtime will not match again). 30 days catches most pathological
-// touch loops on the next save without losing legitimate intermittent
-// matches.
+// TTL after which a record (live or duplicate) whose lastSeen has not been
+// refreshed is dropped. A file on disk has its lastSeen bumped by
+// FindKnownFile / IsOnDuplicates / Append every share-scan; anything stale this
+// long either lost its file or had its mtime/name change in a way that will not
+// recur (mtime is monotone-forward in practice). 30 days catches most
+// pathological touch loops without losing intermittent matches.
 #define KNOWN_DUPLICATE_TTL_SECS (30 * 24 * 60 * 60)
 
 // This function is inlined for performance
@@ -116,16 +112,13 @@ bool CKnownFileList::Init()
 			CFormat("Reading %i known files from file format 0x%2.2x.") % RecordsNumber %
 				version);
 
-		// Keep the size-map index live during the load. Append() is O(log N)
-		// on every record, but on each MD4 hash collision (real-world
-		// libraries hit these whenever the same content was indexed under
-		// two paths/names) it falls back to IsOnDuplicates(name, date, size).
-		// Without a duplicate-size index, IsOnDuplicates scans
-		// m_duplicateFileList linearly, so the dedup cost grows with each
-		// duplicate appended — O(N^2) over the whole load. Prebuilding the
-		// (empty) index here lets Append maintain it incrementally, giving
-		// the O(log N) equal_range fast path on every collision check.
-		// Issue #562 startup gap, ~36 s on a 200 k-file library.
+		// Keep the size-map index live during the load. Append() is O(log N) per
+		// record, but on each MD4 hash collision it falls back to
+		// IsOnDuplicates(name, date, size), which without a duplicate-size index
+		// scans m_duplicateFileList linearly -- O(N^2) over the whole load.
+		// Prebuilding the empty index lets Append maintain it incrementally, so
+		// every collision check takes the equal_range fast path (issue #562, a
+		// ~36 s startup gap on a 200 k-file library).
 		PrepareIndex();
 		for (uint32 i = 0; i < RecordsNumber; i++) {
 			CScopedPtr<CKnownFile> record;
@@ -155,31 +148,23 @@ bool CKnownFileList::Init()
 
 void CKnownFileList::Save()
 {
-	// Acquire the lock before opening the .new file. Save() is called
-	// from both the main thread (on shutdown / scheduled persist) and
-	// the hashing worker thread (CHashingTask::OnLastTask). If two
-	// callers raced past the open, both would create known.met.new at
-	// the same path, the first to Close() would rename it away, and
-	// the second's rename would fail with ENOENT -- producing the
-	// "Impossible to get permissions for file 'known.met.new'" /
-	// "couldn't be renamed 'known.met.new' -> 'known.met'" pair seen
-	// in #86. Holding list_mut around the whole save serialises the
-	// .new lifecycle. The list itself is read-only inside, so this
-	// doesn't widen the existing critical section meaningfully.
+	// Acquire the lock before opening the .new file. Save() is called from both
+	// the main thread and the hashing worker (CHashingTask::OnLastTask); if two
+	// callers raced past the open, both would create known.met.new at the same
+	// path, the first to Close() would rename it away, and the second's rename
+	// would fail with ENOENT (#86). Holding list_mut around the whole save
+	// serialises the .new lifecycle; the list is read-only inside, so the critical
+	// section is not meaningfully widened.
 	wxMutexLocker sLock(list_mut);
 
-	// Snapshot the in-use set under our own lock. Taking the snapshot
-	// before locking left a TOCTOU window where the main thread could
-	// add a CKnownFile to sharedfiles between snapshot and prune; the
-	// prune then deleted a file that sharedfiles still indexed,
-	// leaving a dangling pointer that the EC encoder map kept feeding
-	// to Get_EC_Response_GetUpdate -> use-after-free crash (#685).
+	// Snapshot the in-use set under our own lock. Taking it before locking left a
+	// TOCTOU window where the main thread could add a CKnownFile to sharedfiles
+	// between snapshot and prune; the prune then deleted a file sharedfiles still
+	// indexed, and the EC encoder map kept feeding the dangling pointer to
+	// Get_EC_Response_GetUpdate (#685).
 	//
-	// Brief overlap of knownfiles -> sharedfiles / downloadqueue locks
-	// is safe: no code path acquires those in the reverse order while
-	// holding the first. sharedfiles never calls into knownfiles under
-	// its own lock, and downloadqueue never calls into knownfiles at
-	// all.
+	// Brief overlap of the knownfiles -> sharedfiles / downloadqueue locks is
+	// safe: nothing acquires those in the reverse order while holding the first.
 	std::unordered_set<CKnownFile *> inUse;
 	if (theApp && theApp->sharedfiles) {
 		std::vector<CKnownFile *> sharedSnapshot;
@@ -245,30 +230,25 @@ size_t CKnownFileList::GetKnownFileCount() const
 
 bool CKnownFileList::IsKnownFile(const CKnownFile *file) const
 {
-	// Pointer-value scan over both lists; safe to call with a
-	// possibly-freed `file` pointer (no deref). Used by
-	// OnFinishedHashing / OnFinishedAICHHashing to validate the
-	// owner pointer survived hashing. Neither container is
-	// pointer-keyed, so we walk them — linear in shareset size but
-	// invoked only on rare events (hash completion). For 100 k+
-	// sharesets this is the cost; a per-pointer index would speed
-	// it up but isn't justified for the call rate.
+	// Pointer-value scan over both lists; safe to call with a possibly-freed
+	// `file` pointer, since nothing is dereferenced. Used by OnFinishedHashing /
+	// OnFinishedAICHHashing to validate that the owner pointer survived hashing.
+	// Neither container is pointer-keyed, so both are walked: linear in shareset
+	// size, but only on hash completion, which is rare enough not to justify a
+	// per-pointer index.
 	wxMutexLocker sLock(list_mut);
 	for (const auto &entry : m_knownFileMap) {
 		if (entry.second == file) {
 			return true;
 		}
 	}
-	// The duplicate list counts as alive: this asks whether the record
-	// still exists, not whether it is canonical. PromoteToCanonical
-	// moves a perfectly live record out of the map whenever the share
-	// scan finds a better copy for its hash, and an AICH result landing
-	// after that must not be read as "owner was destroyed" -- the
-	// result would be dropped with a log line that says the opposite of
-	// what happened, and the hashset recomputed on some later run.
-	// A record that really was freed is erased from this list by
-	// PruneDuplicates under the same lock, so the freed case still
-	// answers false, and this stays a pointer comparison either way.
+	// The duplicate list counts as alive: this asks whether the record still
+	// exists, not whether it is canonical. PromoteToCanonical moves a live record
+	// out of the map whenever the share scan finds a better copy for its hash, and
+	// an AICH result landing after that must not read as "owner was destroyed" --
+	// the result would be dropped with a log line saying the opposite of what
+	// happened. A record that really was freed is erased from this list by
+	// PruneDuplicates under the same lock, so the freed case still answers false.
 	for (const CKnownFile *record : m_duplicateFileList) {
 		if (record == file) {
 			return true;
@@ -281,15 +261,12 @@ void CKnownFileList::Clear()
 {
 	wxMutexLocker sLock(list_mut);
 
-	// Fire Notify_KnownFileBeingDestroyed for every file we're about
-	// to delete, so subscribers (list ctrls, dialogs, AICH static
-	// list, write-thread flushList, EC client-side m_uploadingfile /
-	// m_reqfile fields, etc.) strip their references before the
-	// `delete`. Pointer-value comparison only; the objects are still
-	// alive at the time of the notify, but subscribers must not
-	// deref them on the main-thread dispatch (which may run after
-	// DeleteContents has freed them). See MuleNotify::
-	// KnownFileBeingDestroyed (GuiEvents.cpp).
+	// Fire Notify_KnownFileBeingDestroyed for every file about to be deleted, so
+	// subscribers (list ctrls, dialogs, the AICH static list, the write thread's
+	// flushList, EC client-side m_uploadingfile / m_reqfile) strip their references
+	// before the delete. Pointer-value comparison only: the objects are alive at
+	// notify time, but subscribers must not deref them on the main-thread
+	// dispatch, which may run after DeleteContents has freed them.
 	for (CKnownFileMap::const_iterator it = m_knownFileMap.begin(); it != m_knownFileMap.end(); ++it) {
 		Notify_KnownFileBeingDestroyed(it->second);
 	}
@@ -321,13 +298,11 @@ void CKnownFileList::CollectLiveAICHRoots(std::unordered_set<CAICHHash> &out)
 			out.insert(f->GetAICHHashset()->GetMasterHash());
 		}
 	}
-	// Duplicate-list records can also be the only owner of an AICH
-	// master hash, because a hash-collision demote in Append parks
-	// the previous record (including its hashset) on the duplicate
-	// list while the new record takes over m_knownFileMap. If we
-	// drop the duplicate's AICH from known2_64.met and then the
-	// duplicate later gets re-promoted (mtime restore) we'd
-	// silently lose its hashset; cheap to keep both sets here.
+	// Duplicate-list records can also be the only owner of an AICH master hash,
+	// because a hash-collision demote in Append parks the previous record and its
+	// hashset on the duplicate list. Dropping the duplicate's AICH from
+	// known2_64.met would silently lose that hashset if the duplicate were later
+	// re-promoted by an mtime restore; keeping both sets is cheap.
 	for (KnownFileList::const_iterator it = m_duplicateFileList.begin(); it != m_duplicateFileList.end();
 		++it) {
 		const CKnownFile *f = *it;
@@ -364,11 +339,10 @@ CKnownFile *CKnownFileList::FindKnownFile(const CPath &filename, time_t in_date,
 		}
 	}
 
-	// Pin any duplicate-list match against this session's prune so a
-	// real on-disk file's record isn't dropped just because its hash
-	// is also held by a more-recent live entry (the dual-content-copy
-	// case: same hash in two shared paths -- one becomes m_Files_map,
-	// the other only ever appears here).
+	// Pin any duplicate-list match against this session's prune, so a real
+	// on-disk file's record is not dropped just because its hash is also held by a
+	// more-recent live entry -- the dual-content-copy case, where the same hash
+	// sits in two shared paths and only one becomes m_Files_map.
 	CKnownFile *dup = IsOnDuplicates(filename, in_date, in_size);
 	if (dup) {
 		dup->SetLastSeen(now);
@@ -420,13 +394,12 @@ void CKnownFileList::EraseFromSizeMap(KnownFileSizeMap *sizeMap, CKnownFile *rec
 {
 	// Caller must hold list_mut.
 	//
-	// The key is recomputed from the record's CURRENT size and mtime, so
-	// a record whose either value changed while it was indexed cannot be
-	// found and the erase silently leaves the old entry behind. Every
-	// caller today either indexes a record it has not mutated or sets the
-	// new values before the first insert, so nothing hits it -- but a
-	// future caller that mutates an already-indexed record has to erase
-	// under the old key first.
+	// The key is recomputed from the record's CURRENT size and mtime, so a record
+	// whose either value changed while it was indexed cannot be found and the
+	// erase silently leaves the old entry behind. Every caller today either
+	// indexes a record it has not mutated or sets the new values before the first
+	// insert, but a future caller that mutates an already-indexed record has to
+	// erase under the old key first.
 	if (!sizeMap) {
 		return;
 	}
@@ -471,28 +444,26 @@ bool CKnownFileList::PromoteToCanonical(CKnownFile *file)
 
 	CKnownFile *demoted = it->second;
 
-	// Same swap Append performs when a later known.met entry takes over
-	// a hash, minus the Kad withdrawal: `demoted` cannot be in the
-	// shared list (m_Files_map is hash-keyed and `file` holds that slot)
-	// and only CSharedFileList::AddFile publishes keywords, so it has
-	// none to remove.
+	// Same swap Append performs when a later known.met entry takes over a hash,
+	// minus the Kad withdrawal: `demoted` cannot be in the shared list (m_Files_map
+	// is hash-keyed and `file` holds that slot), and only
+	// CSharedFileList::AddFile publishes keywords, so it has none to remove.
 	m_duplicateFileList.push_back(demoted);
 	EraseFromSizeMap(m_knownSizeMap, demoted);
 	InsertIntoSizeMap(m_duplicateSizeMap, demoted);
 
-	// `file` moves the other way. It is on the duplicate list in the
-	// case this exists for, but not necessarily: an already-canonical
-	// record short-circuits above, so nothing else is assumed here.
+	// `file` moves the other way. It is on the duplicate list in the case this
+	// exists for, but not necessarily -- an already-canonical record short-circuits
+	// above.
 	m_duplicateFileList.remove(file);
 	EraseFromSizeMap(m_duplicateSizeMap, file);
 	InsertIntoSizeMap(m_knownSizeMap, file);
 	m_knownFileMap[tkey] = file;
 
-	// m_pinnedDuplicates keeps `file` on purpose. The pin records that
-	// this session matched the record against a real on-disk file,
-	// which stays true, and it only ever guards duplicate-list records
-	// -- so it costs nothing while `file` is canonical and protects it
-	// from the cap prune if some later Append demotes it again.
+	// m_pinnedDuplicates keeps `file` on purpose: the pin records that this
+	// session matched the record against a real on-disk file, which stays true. It
+	// only ever guards duplicate-list records, so it costs nothing while `file` is
+	// canonical and protects it from the cap prune if a later Append demotes it.
 
 	AddDebugLogLineN(logKnownFiles,
 		CFormat("Duplicate '%s' is now the canonical record for its hash, replacing '%s'") %
@@ -529,27 +500,21 @@ bool CKnownFileList::Append(CKnownFile *Record, bool afterHashing)
 		const CMD4Hash &tkey = Record->GetFileHash();
 		CKnownFileMap::iterator it = m_knownFileMap.find(tkey);
 		if (it == m_knownFileMap.end()) {
-			// Only stamp lastSeen=now when this is a confirmed
-			// sighting of the file on disk (post-hash via
-			// CHashingTask, or any other afterHashing=true path).
-			// During known.met load Append is called with
-			// afterHashing=false; touching lastSeen here would
-			// overwrite either the FT_LASTSEEN tag we just loaded
-			// or the m_lastDateChanged fallback that
-			// CKnownFile::LoadFromFile substitutes when the tag
-			// is absent. The latter is the only thing that lets
-			// the TTL prune do useful migration work on an old
-			// known.met -- if we trample it, every loaded record
-			// looks "fresh" and TTL never evicts anything (this
-			// is exactly what bit ngosang on the first PR test).
+			// Only stamp lastSeen=now for a confirmed sighting of the file on
+			// disk (post-hash via CHashingTask, or any other afterHashing=true
+			// path). During known.met load Append runs with afterHashing=false,
+			// and touching lastSeen there would overwrite either the FT_LASTSEEN
+			// tag just loaded or the m_lastDateChanged fallback
+			// CKnownFile::LoadFromFile substitutes when the tag is absent. That
+			// fallback is the only thing letting the TTL prune do useful
+			// migration work on an old known.met: trample it and every loaded
+			// record looks fresh, so TTL never evicts anything.
 			if (afterHashing) {
 				Record->SetLastSeen(now);
-				// Shared-since (issue #466): stamp once, only for a
-				// genuinely new file (freshly hashed from disk). Same
-				// afterHashing guard as lastSeen so a known.met load
-				// (afterHashing=false) never re-stamps — a file that
-				// predates the feature keeps 0 (unknown) rather than
-				// looking "shared just now" on first startup.
+				// Shared-since (issue #466): stamped once, and only for a
+				// genuinely new file. Same afterHashing guard as lastSeen, so a
+				// known.met load never re-stamps and a file predating the
+				// feature keeps 0 (unknown) rather than looking shared just now.
 				if (Record->GetDateShared() == 0) {
 					Record->SetDateShared(now);
 				}
@@ -580,12 +545,10 @@ bool CKnownFileList::Append(CKnownFile *Record, bool afterHashing)
 				AddDebugLogLineN(logKnownFiles,
 					CFormat("%s is on the duplicates list") %
 						Record->GetFileName().GetPrintable());
-				// Pin the duplicate only when this branch was hit
-				// because we just hashed a real on-disk file (the
-				// only case the comment above describes anyway).
-				// During load Append doesn't represent a fresh
-				// sighting -- pinning here would falsely protect
-				// stale records from the cap/TTL prune.
+				// Pin the duplicate only when this branch was reached by
+				// hashing a real on-disk file. During load Append is not a fresh
+				// sighting, and pinning would falsely protect stale records from
+				// the cap/TTL prune.
 				if (afterHashing) {
 					dup->SetLastSeen(now);
 					m_pinnedDuplicates.insert(dup);
@@ -629,21 +592,17 @@ bool CKnownFileList::Append(CKnownFile *Record, bool afterHashing)
 					// Removing the old kad keywords created with the old filename
 					theApp->sharedfiles->RemoveKeywords(existing);
 				}
-				// existing is leaving m_knownFileMap for m_duplicateFileList;
-				// drop its size-map entry so FindKnownFile doesn't return a
-				// pointer that no longer belongs to the live map.
+				// existing is leaving m_knownFileMap for m_duplicateFileList, so
+				// drop its size-map entry or FindKnownFile returns a pointer that
+				// no longer belongs to the live map.
 				EraseFromSizeMap(m_knownSizeMap, existing);
 				InsertIntoSizeMap(m_knownSizeMap, Record);
-				// On the afterHashing path the copy-existing-tags
-				// block above pulled the prior FT_LASTSEEN into
-				// Record; refresh it so the new live entry isn't
-				// born aged-out of the TTL window. During load
-				// (afterHashing=false) keep Record's own loaded
-				// lastSeen instead -- demoting an entry to the
-				// duplicate list must not stamp the replacement
-				// as "fresh now" or the migration-driven TTL pass
-				// loses its signal (every live entry would look
-				// load-time-fresh and never be evicted).
+				// On the afterHashing path the copy-existing-tags block above
+				// pulled the prior FT_LASTSEEN into Record, so refresh it or the
+				// new live entry is born aged-out of the TTL window. During load
+				// keep Record's own loaded lastSeen: stamping the replacement as
+				// fresh would make every live entry look load-time-fresh, and the
+				// migration-driven TTL pass would never evict.
 				if (afterHashing) {
 					Record->SetLastSeen(now);
 				}
@@ -658,9 +617,8 @@ bool CKnownFileList::Append(CKnownFile *Record, bool afterHashing)
 	}
 }
 
-// Make a (size, mtime) index to speed up FindKnownFile. Size + mtime
-// modulo 2^32 is enough here — same precision the rest of the file
-// uses for FindKnownFile's inputs and KnownFileMatches' comparisons.
+// A (size, mtime) index to speed up FindKnownFile. Size plus mtime modulo 2^32
+// is the same precision FindKnownFile's inputs and KnownFileMatches use.
 void CKnownFileList::PrepareIndex()
 {
 	ReleaseIndex();
@@ -686,10 +644,9 @@ void CKnownFileList::PruneDuplicates(const std::unordered_set<CKnownFile *> &inU
 {
 	// Caller must hold list_mut.
 
-	// Gate on a full share-scan having run this session -- before that,
-	// inUse is empty and m_pinnedDuplicates hasn't been populated by
-	// FindKnownFile yet, so a prune here would drop records the next
-	// scan would have legitimately pinned. Set true by
+	// Gate on a full share-scan having run this session: before that inUse is
+	// empty and FindKnownFile has not populated m_pinnedDuplicates, so a prune
+	// would drop records the next scan would legitimately have pinned. Set by
 	// MarkInitialShareScanComplete() from CSharedFileList::Reload.
 	if (!m_initialShareScanComplete) {
 		return;
@@ -702,12 +659,11 @@ void CKnownFileList::PruneDuplicates(const std::unordered_set<CKnownFile *> &inU
 		return inUse.count(r) > 0 || m_pinnedDuplicates.count(r) > 0;
 	};
 
-	// Pass 1: live entries (m_knownFileMap) past TTL. A non-refreshed
-	// live entry means no share-scan in the last TTL window produced a
-	// (name, date, size) match -- the file is no longer accessible to
-	// us. The whole hash is dead; we'll also wipe its duplicates.
-	// std::set (not unordered_set) because CMD4Hash provides operator<
-	// but no std::hash specialization.
+	// Pass 1: live entries past TTL. A non-refreshed live entry means no
+	// share-scan in the last TTL window produced a (name, date, size) match, so
+	// the file is no longer accessible and the whole hash is dead, duplicates
+	// included. std::set rather than unordered_set because CMD4Hash provides
+	// operator< but no std::hash specialization.
 	std::set<CMD4Hash> deadHashes;
 	for (CKnownFileMap::const_iterator it = m_knownFileMap.begin(); it != m_knownFileMap.end(); ++it) {
 		CKnownFile *live = it->second;
@@ -754,13 +710,11 @@ void CKnownFileList::PruneDuplicates(const std::unordered_set<CKnownFile *> &inU
 		}
 		CKnownFile *dead = kit->second;
 
-		// Final paranoid re-check: even though Save() now snapshots
-		// inUse under our own lock, the snapshot's sharedfiles /
-		// downloadqueue locks were released before the prune body
-		// ran. A concurrent SafeAddKFile (main thread) or RemoveFile
-		// (UploadDiskIOThread) could have changed membership in
-		// between. Re-query under the owner's lock, immediately
-		// before delete, to make this point-in-time correct (#685).
+		// Final re-check: Save() snapshots inUse under our own lock, but the
+		// snapshot's sharedfiles / downloadqueue locks were released before the
+		// prune body ran, so a concurrent SafeAddKFile or RemoveFile could have
+		// changed membership. Re-query under the owner's lock immediately before
+		// the delete (#685).
 		if (theApp && theApp->sharedfiles && theApp->sharedfiles->GetFileByID(*it) != NULL) {
 			continue;
 		}
@@ -785,9 +739,8 @@ void CKnownFileList::PruneDuplicates(const std::unordered_set<CKnownFile *> &inU
 			continue;
 		}
 
-		// Partition out protected entries first; the cap counts
-		// only the prunable remainder so protected records don't
-		// crowd legitimate survivors out.
+		// Partition out protected entries first, so the cap counts only the
+		// prunable remainder and protected records do not crowd out survivors.
 		std::vector<KnownFileList::iterator> prunable;
 		prunable.reserve(iters.size());
 		for (size_t i = 0; i < iters.size(); ++i) {
@@ -799,9 +752,8 @@ void CKnownFileList::PruneDuplicates(const std::unordered_set<CKnownFile *> &inU
 			continue;
 		}
 
-		// Newest mtime survives the cap. Older mtimes for the same
-		// hash are unlikely to match again in practice (mtime is
-		// monotone-forward outside explicit-restore tooling).
+		// Newest mtime survives the cap: older mtimes for the same hash are
+		// unlikely to match again, mtime being monotone-forward in practice.
 		std::sort(prunable.begin(),
 			prunable.end(),
 			[](const KnownFileList::iterator &a, const KnownFileList::iterator &b) {

--- a/src/KnownFileList.h
+++ b/src/KnownFileList.h
@@ -46,37 +46,29 @@ public:
 	CKnownFile *FindKnownFile(const CPath &filename, time_t in_date, uint64 in_size);
 	CKnownFile *FindKnownFileByID(const CMD4Hash &hash);
 
-	// Make `file` the record that hash-keyed lookups resolve to, and
-	// return whether that changed anything.
+	// Make `file` the record that hash-keyed lookups resolve to, and return whether
+	// that changed anything.
 	//
-	// m_knownFileMap holds exactly one record per hash: whichever
-	// known.met entry was loaded last, since Append demotes the
-	// earlier ones to m_duplicateFileList. For content that exists at
-	// several paths that record is not necessarily the copy the share
-	// scan found on disk, and once its own copy is deleted it is not
-	// on disk at all. FindKnownFileByID then hands out a record whose
-	// path cannot be opened, which is what broke "verify local data",
-	// the EC rename handler and the search "already known" flag for a
-	// deleted duplicate (issue #1265). The cap/TTL prune cannot heal
-	// it either: it only evicts duplicate-list records, and it keeps
-	// the dead live entry precisely because a same-hash record is
-	// shared.
+	// m_knownFileMap holds exactly one record per hash: whichever known.met entry
+	// was loaded last, since Append demotes the earlier ones to m_duplicateFileList.
+	// For content that exists at several paths that record is not necessarily the
+	// copy the share scan found on disk, and once its own copy is deleted it is not
+	// on disk at all. FindKnownFileByID then hands out a record whose path cannot be
+	// opened, which is what broke "verify local data", the EC rename handler and the
+	// search "already known" flag for a deleted duplicate (issue #1265). The
+	// cap/TTL prune cannot heal it: it only evicts duplicate-list records, and keeps
+	// the dead live entry precisely because a same-hash record is shared.
 	//
-	// Called by the share scan for each file it actually shares, so
-	// the record backed by a file we just saw wins the hash. A no-op
-	// in the common case where `file` is already canonical.
+	// Called by the share scan for each file it actually shares, so the record
+	// backed by a file we just saw wins the hash.
 	bool PromoteToCanonical(CKnownFile *file);
 
-	// Returns true iff `file` is still one of this list's records,
-	// canonical or duplicate. It answers "does this record still
-	// exist", not "is it canonical": PromoteToCanonical demotes live
-	// records, so a map-only answer would report a live file as
-	// destroyed. Pointer-value comparison only — `file` may
-	// already be freed when this is called, in which case the
-	// comparison reliably returns false without dereferencing it.
-	// Used by the async-task completion handlers (OnFinishedHashing,
-	// OnFinishedAICHHashing) to validate that an event's `owner`
-	// pointer is still live before dereffing it.
+	// Returns true iff `file` is still one of this list's records, canonical or
+	// duplicate. It answers "does this record still exist", not "is it canonical":
+	// PromoteToCanonical demotes live records, so a map-only answer would report a
+	// live file as destroyed. Pointer-value comparison only -- `file` may already be
+	// freed, in which case this returns false without dereferencing it. Used by the
+	// async-task completion handlers to validate an event's `owner` pointer.
 	bool IsKnownFile(const CKnownFile *file) const;
 
 	/**
@@ -100,13 +92,10 @@ public:
 	// populated by FindKnownFile-during-scan.
 	void MarkInitialShareScanComplete();
 
-	// Snapshot the set of AICH master hashes that are still referenced
-	// by live and duplicate-list records. Used by CAICHSyncTask to
-	// prune orphaned hashsets out of known2_64.met (entries whose
-	// owning known.met record has been TTL-evicted by PruneDuplicates
-	// and no longer appears in either map). The set is populated under
-	// list_mut to get a consistent view; CAICHHash is hashable so
-	// callers can fast-test membership during the file walk.
+	// Snapshot the AICH master hashes still referenced by live and duplicate-list
+	// records. Used by CAICHSyncTask to prune orphaned hashsets out of
+	// known2_64.met -- entries whose owning known.met record was TTL-evicted and no
+	// longer appears in either map. Populated under list_mut for a consistent view.
 	void CollectLiveAICHRoots(std::unordered_set<CAICHHash> &out);
 
 	uint16 requested;
@@ -124,13 +113,11 @@ private:
 		CKnownFile *knownFile, const CPath &filename, uint32 in_date, uint64 in_size) const;
 
 	// Drop duplicate-list records whose hash has more than
-	// KNOWN_DUPLICATE_HASH_CAP variants, keeping the newest by mtime.
-	// `inUse` is a snapshot of pointers currently held by
-	// CSharedFileList::m_Files_map: never pruned (would dangle the
-	// share-list pointer). m_pinnedDuplicates additionally protects
-	// records that FindKnownFile matched against a real on-disk file
-	// during this session even when AddFile rejected them as
-	// content-duplicates of an already-shared file.
+	// KNOWN_DUPLICATE_HASH_CAP variants, keeping the newest by mtime. `inUse` is a
+	// snapshot of pointers currently held by CSharedFileList::m_Files_map, which are
+	// never pruned. m_pinnedDuplicates additionally protects records FindKnownFile
+	// matched against a real on-disk file this session, even where AddFile rejected
+	// them as content-duplicates of an already-shared file.
 	void PruneDuplicates(const std::unordered_set<CKnownFile *> &inUse);
 
 	typedef std::list<CKnownFile *> KnownFileList;
@@ -138,27 +125,21 @@ private:
 	CKnownFileMap m_knownFileMap;
 	// The filename "known.met"
 	wxString m_filename;
-	// Speed up shared files reload. The key is (size, mtime) rather than
-	// size alone: libraries that contain many files of the same size
-	// (small text files, fixed-quality JPEGs, fixed-bitrate audio/video)
-	// would otherwise collapse FindKnownFile()'s equal_range into a
-	// large bucket that the inner KnownFileMatches loop walks linearly,
-	// turning the whole shared-list reload into O(N^2) over the same-
-	// size files. Adding mtime to the key narrows the bucket aggressively
-	// in any realistic library — files added at different times have
-	// different mtimes — while keeping the per-entry cost identical
-	// (8 bytes of key vs the previous 4).
+	// Speeds up the shared-files reload. The key is (size, mtime) rather than size
+	// alone: a library with many files of the same size would otherwise collapse
+	// FindKnownFile()'s equal_range into a large bucket that KnownFileMatches walks
+	// linearly, turning the reload into O(N^2) over the same-size files. Adding
+	// mtime narrows the bucket aggressively in any realistic library, at 8 bytes of
+	// key against the previous 4.
 	typedef std::multimap<std::pair<uint32, uint32>, CKnownFile *> KnownFileSizeMap;
 	KnownFileSizeMap *m_knownSizeMap;
 	KnownFileSizeMap *m_duplicateSizeMap;
 
-	// Drop `record`'s entry from one of the (size, mtime) indexes
-	// above. Each index mirrors a list, so a record that moves between
-	// the live map and the duplicate list has to be moved here too or
-	// FindKnownFile hands out a pointer that no longer belongs to the
-	// list it was indexed under. Takes the index rather than reading
-	// the member, because every caller moves a record in one specific
-	// direction.
+	// Drop `record`'s entry from one of the (size, mtime) indexes above. Each index
+	// mirrors a list, so a record moving between the live map and the duplicate list
+	// has to be moved here too, or FindKnownFile hands out a pointer that no longer
+	// belongs to the list it was indexed under. Takes the index rather than reading
+	// the member, because every caller moves a record in one specific direction.
 	void EraseFromSizeMap(KnownFileSizeMap *sizeMap, CKnownFile *record);
 
 	// Add `record` to one of the indexes above, keyed the same way
@@ -166,13 +147,11 @@ private:
 	// they live side by side.
 	void InsertIntoSizeMap(KnownFileSizeMap *sizeMap, CKnownFile *record);
 
-	// Duplicate-list records that FindKnownFile / IsOnDuplicates
-	// returned during this session — i.e. their (name, date, size)
-	// matched a real on-disk file. Pinned across the rest of the
-	// session so the cap-prune never drops a record that we know
-	// still represents a live file (avoids re-hashing on next
-	// restart). Cleared on Clear() / Init() so each session starts
-	// fresh.
+	// Duplicate-list records that FindKnownFile / IsOnDuplicates returned during
+	// this session, i.e. whose (name, date, size) matched a real on-disk file.
+	// Pinned for the rest of the session so the cap-prune never drops a record known
+	// to represent a live file, which would mean re-hashing on the next restart.
+	// Cleared on Clear() / Init().
 	std::unordered_set<CKnownFile *> m_pinnedDuplicates;
 
 	// Set to true by MarkInitialShareScanComplete() at the end of the

--- a/src/LibSocket.h
+++ b/src/LibSocket.h
@@ -88,11 +88,11 @@ public:
 	void Close();
 	void Destroy();
 
-	// Swap in a fresh asio socket impl on this same wrapper so the socket
-	// can be re-connected after a loss WITHOUT recreating the CLibSocket
-	// (and therefore without invalidating any pointer the app still holds
-	// to us — the remote GUI pins its CRemoteConnect in every container).
-	// The outgoing impl is detached race-safely first (see LinkSocketImpl).
+	// Swap in a fresh asio socket impl on this same wrapper, so the socket can be
+	// re-connected after a loss WITHOUT recreating the CLibSocket -- and therefore
+	// without invalidating any pointer the app still holds to us, the remote GUI
+	// pinning its CRemoteConnect in every container. The outgoing impl is detached
+	// race-safely first (see LinkSocketImpl).
 	void ResetForReconnect();
 
 	// Get last error, 0 == no error
@@ -128,35 +128,28 @@ public:
 	wxString GetPeer();
 	uint32 GetPeerInt();
 
-	// Turn on TCP keepalive with per-socket timings so a half-open
-	// connection (peer gone, FIN/RST lost or never sent) gets torn
-	// down at the TCP layer instead of sitting idle forever. Used by
-	// the EC sockets on both ends — see CECMuleSocket / CECServerSocket.
-	// Idle seconds before the kernel starts probing, the interval
-	// between probes, and how many probes before declaring the peer
-	// dead.  Effective only on POSIX (TCP_KEEPIDLE / TCP_KEEPINTVL /
-	// TCP_KEEPCNT) and Windows (SIO_KEEPALIVE_VALS; only idle +
-	// interval are settable, count uses the system default). No-op if
-	// the underlying socket is not open.
+	// Turn on TCP keepalive with per-socket timings, so a half-open connection
+	// (peer gone, FIN/RST lost or never sent) is torn down at the TCP layer instead
+	// of sitting idle forever. Used by the EC sockets on both ends. Effective only
+	// on POSIX (TCP_KEEPIDLE / TCP_KEEPINTVL / TCP_KEEPCNT) and Windows
+	// (SIO_KEEPALIVE_VALS, where only idle and interval are settable). No-op if the
+	// underlying socket is not open.
 	void EnableTcpKeepalive(int idleSec, int probeIntervalSec, int probeCount);
 
-	// Turn off Nagle. Used by the EC sockets on both ends, where a
-	// packet's trailing small write would otherwise wait out the peer's
-	// delayed-ACK timer — see CECMuleSocket::ApplyEcSocketOptions. No-op
-	// if the underlying socket is not open.
+	// Turn off Nagle. Used by the EC sockets on both ends, where a packet's
+	// trailing small write would otherwise wait out the peer's delayed-ACK timer.
+	// No-op if the underlying socket is not open.
 	void EnableTcpNoDelay();
 
 	// Handlers
 	virtual void OnConnect(int) {}
 	virtual void OnSend(int) {}
 	virtual void OnReceive(int) {}
-	// Int argument is unused — exists to give the CLibSocket-layer
-	// hook a different signature from CECSocket::OnLost(), so a class
-	// that multi-inherits from both (CECMuleSocket) can override the
-	// CLibSocket-side hook unambiguously and forward to the EC-layer
-	// OnLost().  Without that disambiguation, the Asio reactor's
-	// EOF-on-read dispatch lands on the empty CLibSocket::OnLost{}
-	// instead of CRemoteConnect / CECServerSocket overrides.
+	// The int argument is unused: it exists to give the CLibSocket-layer hook a
+	// different signature from CECSocket::OnLost(), so a class multi-inheriting
+	// from both (CECMuleSocket) can override this one unambiguously and forward.
+	// Without that, the Asio reactor's EOF-on-read dispatch lands on the empty
+	// CLibSocket::OnLost{} instead of the real overrides.
 	virtual void OnLost(int) {}
 	virtual void OnProxyEvent(int) {}
 
@@ -287,11 +280,10 @@ enum BindInterfaceStatus
 // rather than leaving traffic silently unbound.
 BindInterfaceStatus TestSocketBindInterface(const wxString &iface);
 
-// Bind an already-open raw socket to the given interface, reusing the exact
-// same per-platform logic as aMule's own sockets. For non-asio sockets such as
-// libcurl's HTTP socket (via CURLOPT_SOCKOPTFUNCTION). The fd is passed as
-// uintptr_t so a Windows SOCKET survives without truncation. Returns true if
-// bound (or nothing to do), false if the bind failed.
+// Bind an already-open raw socket to the given interface, reusing the exact same
+// per-platform logic as aMule's own sockets -- for non-asio sockets such as
+// libcurl's (via CURLOPT_SOCKOPTFUNCTION). The fd is passed as uintptr_t so a
+// Windows SOCKET survives without truncation.
 bool BindRawSocketToInterface(uintptr_t fd, const wxString &iface);
 
 #endif /* __LIBSOCKET_H__ */

--- a/src/LibSocketAsio.cpp
+++ b/src/LibSocketAsio.cpp
@@ -116,17 +116,13 @@ void SetSocketBindInterface(const wxString &iface)
 	s_bindToInterface = iface;
 }
 
+// Mark a freshly-created socket close-on-exec so subprocesses launched via
+// wxExecute() (preview-with-vlc, etc.) do not inherit and pin our listen / UDP
+// file descriptors. Without this, vlc keeps the bind alive after aMule exits
+// and the next start fails with "Address already in use" until vlc is killed.
 //
-// Mark a freshly-created socket close-on-exec so subprocesses launched
-// via wxExecute() (preview-with-vlc, etc.) don't inherit and pin our
-// listen / UDP file descriptors. Without this, vlc keeps the bind alive
-// after aMule exits, and the next aMule start fails with
-// "Address already in use" until the user kills vlc (#172).
-//
-// No-op on Windows: WinSock SOCKET handles are non-inheritable by
-// default unless the parent passes bInheritHandle=TRUE to CreateProcess,
-// which wxExecute does not do.
-//
+// No-op on Windows: WinSock SOCKET handles are non-inheritable by default
+// unless the parent passes bInheritHandle=TRUE to CreateProcess.
 template <typename Handle> static inline void SetCloexecOnSocket(Handle native)
 {
 #ifndef __WINDOWS__
@@ -139,20 +135,17 @@ template <typename Handle> static inline void SetCloexecOnSocket(Handle native)
 #endif
 }
 
-// Turn on TCP keepalive with per-socket timings. Used by the EC sockets
-// to detect a half-open connection (peer gone, FIN/RST lost or never
-// sent — common after a network blip, OOM-kill, etc.) instead of
-// sitting idle until the default ~2h TCP retransmit timeout kicks in.
+// Turn on TCP keepalive with per-socket timings. Used by the EC sockets to
+// detect a half-open connection (peer gone, FIN/RST lost or never sent --
+// common after a network blip or an OOM-kill) instead of sitting idle until the
+// default ~2h TCP retransmit timeout.
 //
-// POSIX: SO_KEEPALIVE plus the three TCP-layer timing knobs. Linux
-// names (TCP_KEEPIDLE / TCP_KEEPINTVL / TCP_KEEPCNT) are the canonical
-// set; macOS / *BSD use TCP_KEEPALIVE for the idle time and inherit
-// the system defaults for interval and count, which is acceptable as
-// a fallback.
+// POSIX: SO_KEEPALIVE plus the three TCP-layer timing knobs. The Linux names
+// are the canonical set; macOS / *BSD use TCP_KEEPALIVE for the idle time and
+// inherit the system defaults for interval and count.
 //
-// Windows: SIO_KEEPALIVE_VALS via WSAIoctl. The Windows surface only
-// exposes idle and interval; the probe count uses the system default
-// (typically 10 on modern Windows).
+// Windows: SIO_KEEPALIVE_VALS via WSAIoctl, which exposes only idle and
+// interval; the probe count uses the system default.
 template <typename Handle>
 static inline void SetTcpKeepalive(Handle native, int idleSec, int intervalSec, int count)
 {
@@ -188,13 +181,11 @@ static inline void SetTcpKeepalive(Handle native, int idleSec, int intervalSec, 
 
 #ifdef __WINDOWS__
 // Map a Windows adapter FriendlyName (what the prefs dropdown shows, e.g.
-// "Ethernet", "Wi-Fi") to its interface index. if_nametoindex() can't do this
-// on Windows — it expects the adapter's GUID-style name, not the friendly one,
-// so the enumerated dropdown value is resolved here instead. Returns 0 if not
-// found (the caller then tries a bare numeric index).
-//
-// The friendly name comes out of the same enumeration the preferences dialog
-// filled the dropdown from, so a name that was offered there resolves here.
+// "Ethernet", "Wi-Fi") to its interface index. if_nametoindex() cannot do this
+// on Windows -- it expects the adapter's GUID-style name, not the friendly one.
+// Returns 0 if not found, and the caller then tries a bare numeric index. The
+// friendly name comes out of the same enumeration the preferences dialog filled
+// the dropdown from, so a name offered there resolves here.
 static unsigned int ResolveWindowsInterfaceIndex(const wxString &friendlyName)
 {
 	for (const NetworkInterface &iface : DetectNetworkInterfaces()) {
@@ -237,24 +228,20 @@ static unsigned int ResolveBindInterfaceIndex(const wxString &ifname)
 }
 
 // Bind a raw socket's egress to a network interface. Unlike binding to a local
-// IP (SetLocal), this pins the *route*, so traffic can't leak out via the
-// default-route interface — the VPN-leak case behind amule-org/amule#173.
+// IP (SetLocal), this pins the *route*, so traffic cannot leak out via the
+// default-route interface -- the VPN-leak case.
 //
 // Each platform needs the option that is a real egress *constraint*:
 //   Linux         : SO_BINDTODEVICE. IP_UNICAST_IF is only a routing preference
-//                   here (verified: it silently falls back to the default
-//                   route), so it can't prevent leaks. SO_BINDTODEVICE may
-//                   require CAP_NET_RAW on some kernels — the caller surfaces
-//                   that instead of pretending traffic is contained.
-//   macOS / Darwin: IP_BOUND_IF / IPV6_BOUND_IF (Darwin's SO_BINDTODEVICE
-//                   equivalent; a true constraint, no privileges needed).
-//   Windows       : IP_UNICAST_IF / IPV6_UNICAST_IF (a real constraint on
-//                   Windows, unlike Linux).
+//                   here -- verified: it silently falls back to the default
+//                   route -- so it cannot prevent leaks. SO_BINDTODEVICE may
+//                   require CAP_NET_RAW on some kernels, which the caller
+//                   surfaces rather than pretending traffic is contained.
+//   macOS / Darwin: IP_BOUND_IF / IPV6_BOUND_IF, a true constraint.
+//   Windows       : IP_UNICAST_IF / IPV6_UNICAST_IF, a real constraint there.
 //
 // Returns 0 on success or an errno-style code on failure; sets *notFound when
-// the interface can't be resolved (distinct from a permission error). aMule
-// sockets are IPv4, so callers pass isV6 == false; the v6 path is kept for
-// completeness.
+// the interface cannot be resolved, which is distinct from a permission error.
 static int ApplyBindToInterface(NativeSocketHandle native, const wxString &ifname, bool isV6, bool *notFound)
 {
 	*notFound = false;
@@ -524,17 +511,14 @@ public:
 		if (wait || m_sync) {
 			error_code ec;
 			if (m_connectTimeoutMs > 0) {
-				// Bounded synchronous connect: async_connect raced
-				// against a steady_timer, both driven here on the
-				// io_service. A synchronous EC connection may use the
-				// global s_io_service before the CAsioService thread pool
-				// is started. If the synchronous operation leaves the
-				// io_context stopped, it must be restarted before run()
-				// is called. Portable
-				// across every platform through asio, with no per-OS
-				// socket-timeout handling — a wrong or unreachable host
-				// now fails in m_connectTimeoutMs instead of hanging on
-				// the OS TCP connect timeout (minutes).
+				// Bounded synchronous connect: async_connect raced against a
+				// steady_timer, both driven here on the io_service. A synchronous EC
+				// connection may use the global s_io_service before the CAsioService
+				// thread pool is started, and if the synchronous operation leaves the
+				// io_context stopped it must be restarted before run() is called.
+				// Portable through asio with no per-OS socket-timeout handling: a wrong
+				// or unreachable host fails in m_connectTimeoutMs instead of hanging on
+				// the OS TCP connect timeout.
 				ec = boost::asio::error::would_block;
 				m_socket->async_connect(
 					adr.GetEndpoint(), [&ec](const error_code &e) { ec = e; });
@@ -618,13 +602,12 @@ public:
 	// Is writing blocked?
 	bool BlocksWrite() const { return m_blocksWrite.load(std::memory_order_acquire); }
 
-	// Problem: wx sends an event when data gets available, so first there is an event, then Read() is
-	// called Asio can read async with callback, so you first read, then you get an event. Strategy:
-	// - Read some data in background into a buffer
-	// - Callback posts event when something is there
-	// - Read data from buffer
-	// - If data is exhausted, start reading more in background
-	// - If not, post another event (making sure events don't pile up though)
+	// wx sends an event when data becomes available, so first there is an event,
+	// then Read() is called; asio reads asynchronously with a callback, so you
+	// read first and then get an event. Strategy: read some data in the
+	// background into a buffer, have the callback post an event when something is
+	// there, read from the buffer, and either start another background read when
+	// it is exhausted or post another event (without piling them up).
 	uint32 Read(char *buf, uint32 bytesToRead)
 	{
 		if (bytesToRead == 0) { // huh?
@@ -707,30 +690,26 @@ public:
 		}
 	}
 
-	// See the parallel comment on CAsioUDPSocketImpl::Destroy(). The TCP path
-	// has identical wake-from-sleep risk; the fix is identical too — drop the
+	// See the parallel comment on CAsioUDPSocketImpl::Destroy(). The TCP path has
+	// identical wake-from-sleep risk, and the fix is identical too -- drop the
 	// 1-second-timer band-aid in favour of shared_from_this lifetime.
 	//
-	// TCP routes wrapper deletion through CoreNotify_LibSocketDestroy (rather
-	// than deleting inline like UDP) because TCP wrappers are reachable from
-	// many parts of the core; the GUI-thread delete preserves the existing
-	// thread affinity for that cleanup.
+	// TCP routes wrapper deletion through CoreNotify_LibSocketDestroy rather than
+	// deleting inline like UDP, because TCP wrappers are reachable from many
+	// parts of the core and the GUI-thread delete preserves that thread affinity.
 	void Destroy()
 	{
 		if (m_destroying.exchange(true, std::memory_order_acq_rel)) {
-			// Not an error: the guard is here so callers can be sloppy, and
-			// several deliberately are. CClientTCPSocket::Safe_Delete() says
-			// "Destroy may be called several times" and calls it regardless,
-			// and StopConnectionTry() destroys sockets whose connect is still
-			// in flight -- when that connect later fails, OnConnect() destroys
-			// the same socket again. The wrapper is notified once, by whichever
-			// call won the exchange, so the second is a no-op by design; the
-			// UDP twin below says the same and stays silent about it.
+			// Not an error: the guard is here so callers can be sloppy, and several
+			// deliberately are. CClientTCPSocket::Safe_Delete() says "Destroy may be
+			// called several times" and calls it regardless, and StopConnectionTry()
+			// destroys sockets whose connect is still in flight -- when that connect
+			// later fails, OnConnect() destroys the same socket again. The wrapper is
+			// notified once, by whichever call won the exchange.
 			//
-			// Logged at 'F' rather than 'C' for that reason: AddDebugLogLineC
-			// survives a release build (see Logger.h -- only the N and F forms
-			// compile out), so a critical line here reached every user's log on
-			// an ordinary peer disconnect.
+			// Logged at 'F' rather than 'C' for that reason: AddDebugLogLineC survives
+			// a release build, so a critical line here reached every user's log on an
+			// ordinary peer disconnect.
 			CLibSocket *w = m_libSocket.load(std::memory_order_acquire);
 			AddDebugLogLineF(logAsio,
 				CFormat("Destroy() already dying socket %p %p %s") % w % this % m_IP);
@@ -761,9 +740,7 @@ public:
 
 	uint32 GetPeerInt() { return m_IPint; }
 
-	//
-	// Bind socket to local endpoint if user wants to choose the local address
-	//
+	// Bind socket to local endpoint if the user wants to choose the local address
 	void SetLocal(const amuleIPV4Address &local)
 	{
 		error_code ec;
@@ -774,12 +751,9 @@ public:
 				AddDebugLogLineC(logAsio, CFormat("Can't open socket : %s") % ec.message());
 			}
 		}
-		//
-		// We are using random (OS-defined) local ports.
-		// To set a constant output port, first call
-		// m_socket->set_option(socket_base::reuse_address(true));
+		// We are using random (OS-defined) local ports. To set a constant output
+		// port, first call m_socket->set_option(socket_base::reuse_address(true))
 		// and then set the endpoint's port to it.
-		//
 		CamuleIPV4Endpoint endpoint(local.GetEndpoint());
 		endpoint.port(0);
 		m_socket->bind(endpoint, ec);
@@ -847,12 +821,9 @@ public:
 	}
 
 private:
-	//
-	// Dispatch handlers
-	// Access to m_socket is all bundled in the thread running s_io_service to avoid
-	// concurrent access to the socket from several threads.
-	// So once things are running (after connect), all access goes through one of these handlers.
-	//
+	// Dispatch handlers. Access to m_socket is all bundled in the thread running
+	// s_io_service to avoid concurrent access from several threads, so once
+	// things are running (after connect) all access goes through one of these.
 	void DispatchClose()
 	{
 		error_code ec;
@@ -868,11 +839,9 @@ private:
 	{
 		AddDebugLogLineF(logAsio, CFormat("DispatchBackgroundRead %s") % m_IP);
 		// Why async_read_some and not async_wait(wait_read): on Windows
-		// boost.asio implements async_wait via its select_reactor (a single
-		// select() loop in a dedicated thread) because IOCP has no native
-		// "ready notification" without a buffer.  async_read_some maps to
-		// WSARecv on Windows (IOCP-native) and to epoll/kqueue on POSIX, so
-		// it is the fast path on every platform.
+		// boost.asio implements async_wait via its select_reactor, because IOCP
+		// has no native "ready notification" without a buffer. async_read_some
+		// maps to WSARecv on Windows (IOCP-native) and to epoll/kqueue on POSIX.
 		if (m_readBufferSize < READ_CHUNK) {
 			delete[] m_readBuffer;
 			m_readBuffer = new char[READ_CHUNK];
@@ -884,10 +853,10 @@ private:
 				[self](const error_code &ec, std::size_t n) { self->HandleRead(ec, n); }));
 	}
 
-	// The buffer pointer is passed explicitly so each HandleSend knows
-	// which buffer it owns and must delete.  m_sendBuffer only tracks the
+	// The buffer pointer is passed explicitly so each HandleSend knows which
+	// buffer it owns and must delete. m_sendBuffer only tracks the
 	// currently-in-flight write and is cleared by HandleSend when the send
-	// completes — it cannot be used to identify the buffer to free.
+	// completes, so it cannot identify the buffer to free.
 	void DispatchWrite(char *sendBuffer, uint32 nbytes)
 	{
 		auto self = shared_from_this();
@@ -898,9 +867,7 @@ private:
 			}));
 	}
 
-	//
 	// Completion handlers for async requests
-	//
 
 	void HandleConnect(const error_code &err)
 	{
@@ -979,30 +946,25 @@ private:
 		m_readBufferContent = (uint32)bytes_transferred;
 
 		// Release, and after the buffer writes above on purpose. A reader that
-		// acquire-loads this as false is then guaranteed to see the content
-		// and pointer that were written before it.
+		// acquire-loads this as false is then guaranteed to see the content and
+		// pointer written before it.
 		//
-		// Plain stores let the two become visible out of order. The main
-		// thread would see the new content with the pending flag still set,
-		// take the "a background read is still running" branch in Read(),
-		// and return without serving data that was already sitting in the
-		// buffer -- and without arming anything. Since that branch is reached
-		// from an event that has already been consumed, nothing looks again:
-		// the socket stays open with its bytes unread and answers nothing
-		// until the peer gives up. Caught in the act on arm64, where the
-		// reordering is permitted and does happen:
+		// Plain stores let the two become visible out of order. The main thread
+		// would see the new content with the pending flag still set, take the "a
+		// background read is still running" branch in Read(), and return without
+		// serving data already sitting in the buffer -- and without arming
+		// anything. Since that branch is reached from an event already consumed,
+		// nothing looks again: the socket stays open with its bytes unread.
+		// Caught in the act on arm64, where the reordering is permitted:
 		//
 		//   handleRead(10)[c=10 p=0]   <- strand: content set, pending cleared
 		//   block(8)     [c=10 p=1]    <- main: new content, stale flag
-		//
 		m_readPending.store(false, std::memory_order_release);
 		m_blocksRead = false;
 		PostReadEvent(2);
 	}
 
-	//
 	// Other functions
-	//
 
 	void StartBackgroundRead()
 	{
@@ -1014,22 +976,19 @@ private:
 
 	void PostReadEvent(int DEBUG_ONLY(from))
 	{
-		// One atomic step, so exactly one caller can win the right to notify:
-		// a plain test-then-set lets the ASIO thread and the main thread both
-		// see it clear and post twice, or -- the damaging direction -- lets
-		// this thread see it set and skip while the main thread is about to
-		// clear it, leaving data buffered with nothing left to announce it.
+		// One atomic step, so exactly one caller can win the right to notify: a
+		// plain test-then-set lets the ASIO thread and the main thread both see it
+		// clear and post twice, or -- the damaging direction -- lets this thread
+		// see it set and skip while the main thread is about to clear it, leaving
+		// data buffered with nothing left to announce it.
 		//
-		// The exchange writes unconditionally, so even the skipping path
-		// releases everything written before it (the buffer, and the cleared
-		// m_readPending). EventProcessed acquires that same value, which is
-		// what stops the reader from then acting on a stale read state.
-		// Checked before the latch is taken, not after: with no wrapper there
-		// is nothing to deliver a notification, and EventProcessed only runs
-		// off a delivered one. Taking the latch here would leave it set for
-		// the life of the socket and make every later post skip -- the same
-		// wedge, reached from the other side. HandleRead reaches this state
-		// deliberately: it logs "wrapper gone" and carries on to post.
+		// The exchange writes unconditionally, so even the skipping path releases
+		// everything written before it. EventProcessed acquires that same value,
+		// which stops the reader acting on a stale read state.
+		//
+		// Checked before the latch is taken, not after: with no wrapper there is
+		// nothing to deliver a notification, and taking the latch here would leave
+		// it set for the life of the socket and make every later post skip.
 		CLibSocket *wrapper = m_libSocket.load(std::memory_order_acquire);
 		if (!wrapper) {
 			AddDebugLogLineF(
@@ -1059,9 +1018,7 @@ private:
 		return m_ErrorCode != errc::success;
 	}
 
-	//
 	// Synchronous sockets (amulecmd)
-	//
 	uint32 ReadSync(char *buf, uint32 bytesToRead)
 	{
 		if (m_syncReadTimeoutMs <= 0) {
@@ -1075,25 +1032,22 @@ private:
 			return received;
 		}
 
-		// No-progress bounded read. Asio's synchronous read() falls back to
-		// an *unbounded* internal poll_read(-1) on EAGAIN, so SO_RCVTIMEO
-		// can't bound it (the wedge backtrace showed exactly that poll).
-		// Instead we gate each read_some behind a poll() carrying the
-		// remaining no-progress budget, which resets whenever bytes arrive:
-		// a slow-but-progressing large transfer never trips it, but a
-		// genuinely stalled / desynced peer (a reply that never completes)
-		// does — and is then reported as a lost peer (DispatchSyncLost),
-		// so the EC layer's reconnect / fail-fast path takes over instead
-		// of hanging forever holding the caller's EC mutex.
+		// No-progress bounded read. Asio's synchronous read() falls back to an
+		// *unbounded* internal poll_read(-1) on EAGAIN, so SO_RCVTIMEO cannot
+		// bound it. Instead each read_some is gated behind a poll() carrying the
+		// remaining no-progress budget, which resets whenever bytes arrive: a
+		// slow-but-progressing large transfer never trips it, but a genuinely
+		// stalled or desynced peer does -- and is then reported as a lost peer,
+		// so the EC layer's reconnect path takes over instead of hanging forever
+		// holding the caller's EC mutex.
 		const auto fd = m_socket->native_handle();
 		uint32 received = 0;
 		while (received < bytesToRead) {
-			// Wait up to the remaining no-progress budget for readability.
-			// POSIX uses poll() (no FD_SETSIZE cap — the EC socket can get a
-			// high fd after a reconnect under load); Windows uses select()
-			// because WSAPoll needs _WIN32_WINNT >= 0x0600 and this build
-			// targets 0x0501 (see top of file), and on Winsock fd_set is
-			// count-indexed so a single socket is always in range.
+			// Wait up to the remaining no-progress budget for readability. POSIX
+			// uses poll() -- no FD_SETSIZE cap, and the EC socket can get a high fd
+			// after a reconnect under load; Windows uses select() because WSAPoll
+			// needs _WIN32_WINNT >= 0x0600 and this build targets 0x0501, and on
+			// Winsock fd_set is count-indexed so a single socket is always in range.
 			bool timed_out = false;
 			bool poll_failed = false;
 			int poll_errno = 0;
@@ -1126,14 +1080,12 @@ private:
 			}
 #endif
 			if (timed_out) {
-				// No data for the whole budget — treat as a stalled peer so
-				// the EC layer reconnects / fails fast instead of hanging.
-				// This is fatal for the synchronous EC clients (amuleapi,
-				// amulecmd, amuleweb): the caller reports the peer lost and
-				// exits. Emit it unconditionally on stderr — NOT the
-				// debug-gated logAsio category — so it is visible in release
-				// builds, right before the "External Connection lost -
-				// exiting." the EC layer prints next.
+				// No data for the whole budget -- treat as a stalled peer so the EC
+				// layer reconnects or fails fast instead of hanging. This is fatal for
+				// the synchronous EC clients: the caller reports the peer lost and
+				// exits. Emitted unconditionally on stderr, NOT the debug-gated logAsio
+				// category, so it is visible in release builds right before the
+				// "External Connection lost - exiting." the EC layer prints next.
 				wxString msg =
 					CFormat(wxT("amule: synchronous socket read made no progress for %d "
 						    "ms (peer %s) - stalled or desynced peer; dropping the "
@@ -1187,18 +1139,15 @@ private:
 		return sent;
 	}
 
-	// Sync clients (amulecmd, amuleweb) don't have an async_read pending
-	// after auth, so the EOF that fires HandleRead → PostLostEvent for
-	// async clients never gets seen. Detection happens here instead, in
-	// ReadSync / WriteSync. PostLostEvent + wxQueueEvent would round-
-	// trip through the wx event loop — which amuleweb has (wxApp::OnRun)
-	// but amulecmd doesn't (its main thread is in fgets reading stdin,
-	// not in wxApp's event loop, so queued events are never processed).
-	// Direct synchronous dispatch through the same wrapper->OnLost(0)
-	// path the async reactor uses covers both: CECMuleSocket::OnLost(int)
-	// forwards to the EC-layer CECSocket::OnLost virtual, CRemoteConnect's
-	// override fires (NULL notifier → _exit fallback) and the headless
-	// EC client exits cleanly instead of serving stale data in limp mode.
+	// Sync clients (amulecmd, amuleweb) have no async_read pending after auth,
+	// so the EOF that fires HandleRead -> PostLostEvent for async clients is
+	// never seen. Detection happens here instead, in ReadSync / WriteSync.
+	// PostLostEvent + wxQueueEvent would round-trip through the wx event loop,
+	// which amuleweb has but amulecmd does not -- its main thread is in fgets
+	// reading stdin, so queued events are never processed. Direct synchronous
+	// dispatch through the same wrapper->OnLost(0) path the async reactor uses
+	// covers both, so the headless EC client exits cleanly rather than serving
+	// stale data in limp mode.
 	void DispatchSyncLost()
 	{
 		CLibSocket *wrapper = m_libSocket.load(std::memory_order_acquire);
@@ -1207,12 +1156,10 @@ private:
 		}
 	}
 
-	//
-	// Access to even const & wxString is apparently not thread-safe.
-	// Locks are set/removed in wx and reference counts can go astray.
-	// So store our IP string in a wxString which is used nowhere.
-	// Store a pointer to its string buffer as well and use THAT everywhere.
-	//
+	// Access to even a const & wxString is apparently not thread-safe: locks are
+	// set/removed in wx and reference counts can go astray. So the IP string is
+	// stored in a wxString used nowhere, and a pointer to its string buffer is
+	// what gets used everywhere.
 	void SetIp(const amuleIPV4Address &adr)
 	{
 		m_IPstring = adr.IPAddress();
@@ -1644,9 +1591,9 @@ bool CLibSocketServer::SocketAvailable()
  * ASIO UDP socket implementation
  */
 
-// Wake-from-sleep crash (issue #384) was caused by asio completion handlers
-// firing on a freed CAsioUDPSocketImpl: pending async_receive_from ops survive
-// a long suspend, complete on wake, and re-enter HandleRead → StartBackgroundRead
+// A wake-from-sleep crash was caused by asio completion handlers firing on a
+// freed CAsioUDPSocketImpl: pending async_receive_from ops survive a long
+// suspend, complete on wake, and re-enter HandleRead -> StartBackgroundRead
 // after the impl has been destroyed by the post-resume socket-recreation path.
 // The old 1-second-timer guard in Destroy() did not survive the time jump.
 //
@@ -1654,8 +1601,7 @@ bool CLibSocketServer::SocketAvailable()
 // [self = shared_from_this()], keeping the impl alive until the last in-flight
 // callback drops its ref. The wrapper's raw back-pointer m_libSocket is atomic
 // and nulled on the strand during Destroy(), so callbacks that fire after the
-// wrapper has been notified-destroyed silently no-op instead of dereferencing
-// freed memory.
+// wrapper has been notified-destroyed silently no-op.
 class CAsioUDPSocketImpl : public std::enable_shared_from_this<CAsioUDPSocketImpl>
 {
 private:
@@ -1765,17 +1711,15 @@ public:
 		}
 	}
 
-	// Destroy() schedules a single strand task that closes the socket, nulls
-	// the back-pointer, and deletes the wrapper. The impl itself stays alive
-	// as long as any in-flight async callback holds a shared_from_this() ref
-	// — it dies cleanly when the last drains, with no risk of a pending
-	// completion firing on freed memory.
+	// Destroy() schedules a single strand task that closes the socket, nulls the
+	// back-pointer, and deletes the wrapper. The impl itself stays alive as long
+	// as any in-flight async callback holds a shared_from_this() ref, and dies
+	// cleanly when the last drains.
 	//
-	// Note: unlike the TCP path which posts CoreNotify_LibSocketDestroy to
-	// route the wrapper delete through the GUI thread, UDP deletes the
-	// wrapper directly. By contract the caller (CMuleUDPSocket) has already
-	// nulled its pointer before calling Destroy(), so nothing else is
-	// expected to reach the wrapper.
+	// Unlike the TCP path, which posts CoreNotify_LibSocketDestroy to route the
+	// wrapper delete through the GUI thread, UDP deletes the wrapper directly:
+	// by contract the caller has already nulled its pointer before calling
+	// Destroy(), so nothing else is expected to reach the wrapper.
 	void Destroy()
 	{
 		if (m_destroying.exchange(true, std::memory_order_acq_rel)) {
@@ -1813,21 +1757,15 @@ public:
 	}
 
 private:
-	//
-	// Dispatch handlers
-	// Access to m_socket is all bundled in the thread running s_io_service to avoid
-	// concurrent access to the socket from several threads.
-	// So once things are running (after connect), all access goes through one of these handlers.
-	//
+	// Dispatch handlers. Access to m_socket is all bundled in the thread running
+	// s_io_service to avoid concurrent access from several threads.
 	void DispatchClose()
 	{
-		// CreateSocket() leaves m_socket NULL on bind failure (e.g. EADDRINUSE
-		// during the post-resume recovery path, where the old socket's close
-		// hasn't yet been processed on the strand before the new bind runs).
-		// Without this guard the subsequent CMuleUDPSocket::DestroySocket()
-		// → Close() → DispatchClose chain dereferences the NULL m_socket
-		// and SIGSEGVs — exposed by #384 once the shared_from_this fix lets
-		// amuled survive the first wake-from-sleep.
+		// CreateSocket() leaves m_socket NULL on bind failure -- EADDRINUSE during
+		// the post-resume recovery path, where the old socket's close has not yet
+		// been processed on the strand before the new bind runs. Without this
+		// guard the subsequent DestroySocket() -> Close() -> DispatchClose chain
+		// dereferences the NULL m_socket and SIGSEGVs.
 		if (!m_socket) {
 			AddDebugLogLineF(logAsio, "UDP Close: socket already null (CreateSocket failed)");
 			return;
@@ -1856,9 +1794,7 @@ private:
 			}));
 	}
 
-	//
 	// Completion handlers for async requests
-	//
 
 	void HandleRead(const error_code &ec, size_t received)
 	{
@@ -1904,9 +1840,7 @@ private:
 		delete recdata;
 	}
 
-	//
 	// Other functions
-	//
 
 	void CreateSocket()
 	{
@@ -1919,12 +1853,11 @@ private:
 			// without binding".
 			m_socket = new ip::udp::socket(s_io_service);
 			m_socket->open(endpoint.protocol());
-			// SO_REUSEADDR so a post-suspend rebind (DestroySocket +
-			// CreateSocket in CMuleUDPSocket::OnReceive when a read
-			// callback returns an error) doesn't hit EADDRINUSE while
-			// the kernel still considers the previous binding live.
-			// Without this Kad and the ed2k client UDP stay broken
-			// until the user restarts amule — see #103.
+			// SO_REUSEADDR so a post-suspend rebind (DestroySocket + CreateSocket
+			// in CMuleUDPSocket::OnReceive when a read callback returns an error)
+			// does not hit EADDRINUSE while the kernel still considers the previous
+			// binding live. Without this Kad and the ed2k client UDP stay broken
+			// until the user restarts amule.
 			m_socket->set_option(socket_base::reuse_address(true));
 			SetCloexecOnSocket(m_socket->native_handle());
 			// Pin this UDP socket (ed2k client/server + Kad all funnel
@@ -1945,11 +1878,10 @@ private:
 
 	void StartBackgroundRead()
 	{
-		// Skip if Destroy() has already nulled the socket via the strand
-		// teardown lambda. Without this guard the impl's last self ref
-		// (held by the in-flight async_receive_from completion that
-		// brought us here) would try to re-queue a recv on a closed-and-
-		// nulled socket.
+		// Skip if Destroy() has already nulled the socket via the strand teardown
+		// lambda. Without this guard the impl's last self ref -- held by the
+		// in-flight completion that brought us here -- would try to re-queue a
+		// recv on a closed-and-nulled socket.
 		if (!m_socket || m_destroying.load(std::memory_order_acquire)) {
 			return;
 		}
@@ -2157,19 +2089,15 @@ bool amuleIPV4Address::Hostname(const wxString &name)
 	AddDebugLogLineN(
 		logAsio, CFormat("Hostname(\"%s\") failed, not an IP address %s") % name % ec.message());
 
-	// Try to resolve (sync). Normally not required. Unless you type in your hostname as "local IP
-	// address" or something.
+	// Try to resolve (sync). Normally not required, unless you type in your
+	// hostname as "local IP address" or something.
 	//
-	// We only want IPv4 addresses. This has to be asked for explicitly:
-	// the resolve(host, service) overload passes a default-constructed
-	// flag set (0, so not even AI_ADDRCONFIG) and leaves the family
-	// unrestricted, so getaddrinfo answers with AAAA records too — on
-	// any host, whether or not it has IPv6 connectivity. Their order is
-	// up to the platform resolver, and IPv6 routinely comes first (on
-	// Windows, even for "localhost"), so taking the first result handed
-	// back would store an IPv6 address in what the rest of aMule treats
-	// as a v4-only endpoint: IPAddress() then fails StringIPtoUint32(),
-	// and connecting a v4 socket to it fails outright.
+	// Only IPv4 addresses, asked for explicitly: the resolve(host, service)
+	// overload passes a default-constructed flag set and leaves the family
+	// unrestricted, so getaddrinfo answers with AAAA records too, on any host.
+	// Their order is up to the platform resolver and IPv6 routinely comes
+	// first, so taking the first result would store an IPv6 address in what
+	// the rest of aMule treats as a v4-only endpoint.
 	error_code ec2;
 	ip::tcp::resolver res(s_io_service);
 	ip::tcp::resolver::results_type endpoint_iterator = res.resolve(ip::tcp::v4(), sname, "", ec2);
@@ -2179,8 +2107,8 @@ bool amuleIPV4Address::Hostname(const wxString &name)
 		return false;
 	}
 	// Belt and braces: the AF_INET query above should only ever yield v4
-	// entries, but the endpoint is v4-only by contract, so scan for one
-	// rather than trusting begin() the way the unrestricted query did.
+	// entries, but the endpoint is v4-only by contract, so scan for one rather
+	// than trusting begin() the way the unrestricted query did.
 	for (const auto &entry : endpoint_iterator) {
 		if (entry.endpoint().address().is_v4()) {
 			m_endpoint->address(entry.endpoint().address());

--- a/src/Logger.cpp
+++ b/src/Logger.cpp
@@ -217,7 +217,6 @@ void CLogger::DoLines(const wxString &lines, bool critical, bool toStdout, bool 
 	// Remove newspace at end
 	wxString bufferline = lines.Strip(wxString::trailing);
 
-	// Create the timestamp
 	wxString stamp = wxDateTime::Now().FormatISODate() + " " + wxDateTime::Now().FormatISOTime()
 #ifdef CLIENT_GUI
 			 + " (remote-GUI): ";
@@ -248,28 +247,20 @@ void CLogger::DoLine(const wxString &line, bool toStdout, bool GUI_ONLY(toGUI))
 		wxMutexLocker lock(m_lineLock);
 		++m_count;
 
-		// write to logfile
 		m_ApplogBuf += line;
 		FlushApplog();
 
-		// write to Stdout
 		if (m_StdoutLog || toStdout) {
-			// `utf8_str()` instead of `unicode2char()` so non-ASCII
-			// log content (filenames, server messages, etc.) survives
-			// in stdout regardless of the process locale. `unicode2char`
-			// uses `wxConvLibc`, which collapses non-ASCII to `?` /
-			// U+FFFD when running in the default `C` locale -- common
-			// in headless / containerized deployments where amuled is
-			// invoked without `LANG`/`LC_ALL` set and never calls
-			// `setlocale(LC_ALL, "")` itself (#40). The on-disk log
-			// path already uses `wxConvUTF8` via `FlushApplog`, so
-			// switching the stdout sink to `utf8_str()` makes the two
-			// sinks consistently UTF-8.
+			// `utf8_str()` instead of `unicode2char()`, so non-ASCII log content
+			// survives in stdout regardless of the process locale: `unicode2char`
+			// uses `wxConvLibc`, which collapses non-ASCII to `?` in the default
+			// `C` locale -- common in headless deployments where amuled runs
+			// without LANG or LC_ALL and never calls setlocale itself (#40). The
+			// on-disk log already writes UTF-8, so the two sinks now agree.
 			printf("%s", (const char *)line.utf8_str());
 		}
 	}
 #ifndef AMULE_DAEMON
-	// write to Listcontrol
 	if (toGUI) {
 		theApp->AddGuiLogLine(line);
 	}
@@ -283,23 +274,18 @@ void CLogger::EmergencyLog(const wxString &message, bool closeLog)
 	// survive whatever is going wrong.
 	fprintf(stderr, "%s", (const char *)message.utf8_str());
 
-	// The logfile copy needs the same one-character severity marker DoLine
-	// puts on every line. A remote GUI reads this log back over EC and
-	// CamuleDlg::AddLogLineToView strips one leading character from each line
-	// unconditionally, so appending emergency output raw meant that strip ate
-	// a real character per line -- "Assertion failed" reaching the GUI as
-	// "ssertion failed", "Backtrace follows" as "acktrace follows". Marker
-	// "!" because this only ever carries critical output; matching DoLine, a
-	// multi-line message gets the marker on each line rather than only the
-	// first.
+	// The logfile copy needs the same one-character severity marker DoLine puts on
+	// every line. A remote GUI reads this log back over EC and strips one leading
+	// character per line unconditionally, so appending emergency output raw meant
+	// that strip ate a real character -- "Assertion failed" reaching the GUI as
+	// "ssertion failed". Marker "!", since this only ever carries critical output,
+	// and on each line rather than only the first.
 	//
-	// Done with an explicit pass rather than wxStringTokenizer: this text is
-	// crash and assert output, where the blank lines between the banners and
-	// the backtrace are deliberate structure, and the tokenizer would eat
-	// them -- wxTOKEN_DEFAULT is strtok semantics for whitespace delimiters,
-	// which skips empty tokens. One reserve and one append also keeps the
-	// work here close to what it was, which matters on the fatal-exception
-	// path where the next instruction may never run.
+	// Done with an explicit pass rather than wxStringTokenizer: this text is crash
+	// and assert output, where the blank lines between the banners and the
+	// backtrace are deliberate structure and the tokenizer would eat them. One
+	// reserve and one append also keeps the work close to what it was, which
+	// matters on a path where the next instruction may never run.
 	wxString prefixed;
 	prefixed.reserve(message.length() + 16);
 	bool atLineStart = true;
@@ -386,18 +372,14 @@ bool CLoggerAccess::HasString()
 	while (!m_ready) {
 		int c = m_logfile->GetC();
 		if (c == wxEOF) {
-			// wxFFileInputStream wraps a stdio FILE* whose EOF flag is
-			// sticky: once GetC() returns wxEOF, subsequent reads keep
-			// returning wxEOF even when amuled has appended more lines
-			// to the logfile in the meantime. The amule-project/amule#215
-			// fix re-seeked to the current position to clear it, but wx 3.3
-			// short-circuits a seek to the current offset (no fseek is
-			// issued), so EOF is never cleared and EC clients (amuleGUI,
-			// amuleweb) stop seeing new lines after the batch captured at
-			// connect time. Reopen the stream instead: a fresh
-			// wxFFileInputStream has no EOF set, and seeking back to where we
-			// left off resumes at the first newly appended byte -- independent
-			// of seek-clears-EOF semantics (amule-project/amule#215, wx 3.3).
+			// wxFFileInputStream wraps a stdio FILE* whose EOF flag is sticky:
+			// once GetC() returns wxEOF, later reads keep returning it even
+			// after amuled has appended more lines. The old fix re-seeked to the
+			// current position to clear it, but wx 3.3 short-circuits a seek to
+			// the current offset, so EOF is never cleared and EC clients stop
+			// seeing new lines after the batch captured at connect time.
+			// Reopening instead gives a stream with no EOF set, and seeking back
+			// resumes at the first newly appended byte.
 			wxFileOffset pos = m_logfile->TellI();
 			if (pos != wxInvalidOffset) {
 				delete m_logfile;

--- a/src/MediaProbe.cpp
+++ b/src/MediaProbe.cpp
@@ -72,12 +72,10 @@ constexpr int kSpawnFailed = -1;    // couldn't launch the binary at all
 constexpr int kKilled = -2;         // overran timeoutMs, or keepRunning went false
 constexpr int kOutputTooLarge = -3; // reply exceeded the read budget; see the slurp
 
-// Spawn `exe argv...`, capturing stdout to a temp file, and wait for it with
-// a `timeoutMs` wall-clock bound. The wait loop also polls `keepRunning`; when
-// it flips false (worker shutdown) the child is killed at once so the caller's
-// thread-join can return. Args are passed as a real argv vector — no shell —
-// so paths with spaces / quotes need no escaping. See the include-block note
-// for why this bypasses wxExecute/wxProcess entirely.
+// Spawn `exe argv...`, capturing stdout to a temp file, bounded by `timeoutMs`
+// wall-clock. The wait loop also polls `keepRunning`, so worker shutdown kills
+// the child at once. Real argv, no shell, so paths need no escaping. See the
+// include-block note for why this bypasses wxExecute/wxProcess entirely.
 int RunBoundedFFProbe(const wxString &exe,
 	const wxArrayString &argv,
 	unsigned timeoutMs,
@@ -108,10 +106,9 @@ int RunBoundedFFProbe(const wxString &exe,
 		return kSpawnFailed;
 	}
 
-	// Job object with kill-on-close so terminating (or closing) it takes down
-	// the whole process tree — the Windows equivalent of the POSIX
-	// process-group kill. ffprobe.exe forks nothing, but a wrapper-style path
-	// (rare on Windows) would; a plain TerminateProcess would orphan it.
+	// Kill-on-close job so terminating it takes down the whole process tree, the
+	// Windows equivalent of the POSIX process-group kill. ffprobe.exe forks
+	// nothing, but a wrapper-style path would, and TerminateProcess would orphan it.
 	HANDLE hJob = ::CreateJobObjectW(nullptr, nullptr);
 	if (hJob != nullptr) {
 		JOBOBJECT_EXTENDED_LIMIT_INFORMATION jeli;
@@ -172,9 +169,8 @@ int RunBoundedFFProbe(const wxString &exe,
 			break;
 		}
 		if (!keepRunning || static_cast<unsigned>(sw.Time()) >= timeoutMs) {
-			// Kill the whole job (wrapper + real ffprobe), mirroring the
-			// POSIX process-group kill; fall back to the bare process if the
-			// job could not be created.
+			// Kill the whole job (wrapper + real ffprobe); fall back to the bare
+			// process if the job could not be created.
 			if (hJob != nullptr) {
 				::TerminateJobObject(hJob, 1);
 			} else {
@@ -213,12 +209,10 @@ int RunBoundedFFProbe(const wxString &exe,
 		&fa, STDOUT_FILENO, tmpNative.c_str(), O_WRONLY | O_CREAT | O_TRUNC, 0600);
 	posix_spawn_file_actions_addopen(&fa, STDERR_FILENO, "/dev/null", O_WRONLY, 0);
 
-	// Put the child in its own process group so a kill can take out the
-	// whole tree. ffprobe itself forks nothing, but a wrapper-style path
-	// (snap's /snap/bin/ffprobe, a flatpak-run shim) is a shell that execs
-	// the real binary as a child — killing only the wrapper would orphan
-	// it. setpgroup(0) makes the child a group leader (pgid == pid); the
-	// kill path below signals -pid to hit the group.
+	// Own process group so a kill takes out the whole tree: ffprobe forks
+	// nothing, but a wrapper-style path (snap's /snap/bin/ffprobe, a flatpak-run
+	// shim) is a shell that execs the real binary as a child. setpgroup(0) makes
+	// the child a group leader, and the kill path below signals -pid.
 	posix_spawnattr_t attr;
 	posix_spawnattr_init(&attr);
 	posix_spawnattr_setflags(&attr, POSIX_SPAWN_SETPGROUP);
@@ -258,16 +252,11 @@ int RunBoundedFFProbe(const wxString &exe,
 	// Slurp captured stdout. On a kill the file is partial/empty, but the
 	// caller treats kKilled as failure and never reads stdoutLines then.
 	//
-	// Bounded, because the output is not purely ours any more: the entry list
-	// includes container tags, which are arbitrary attacker-chosen text of
-	// arbitrary length. Without a cap a crafted 100 MB title is written out by
-	// ffprobe, slurped whole into a wxString, copied again by the tokenizer
-	// and again on unescaping, and only then cut to kMaxTagChars -- a peak
-	// footprint several times the crafted tag, on the probe worker, for a
-	// feature that is now on by default. A legitimate reply for five fields is
-	// a few hundred bytes; 1 MiB is orders of magnitude clear of that, and
-	// anything past it is treated as a failed probe rather than truncated,
-	// since a half-read reply is not something to draw conclusions from.
+	// Bounded, because container tags are attacker-chosen text of arbitrary
+	// length: uncapped, a crafted 100 MB title is slurped whole into a wxString
+	// and copied again by the tokenizer and the unescaper before kMaxTagChars
+	// ever applies. A legitimate five-field reply is a few hundred bytes, and
+	// anything past the cap is treated as a failed probe rather than truncated.
 	const wxFileOffset kMaxProbeOutputBytes = 1024 * 1024;
 	if (exitCode >= 0) {
 		wxFFile f(tmpPath, wxT("rb"));
@@ -295,25 +284,18 @@ int RunBoundedFFProbe(const wxString &exe,
 namespace
 {
 
-// Wall-clock bound for one `-version` invocation. A working ffprobe
-// answers in milliseconds; a binary that has not by now is wedged (a
-// stale network mount, a wrapper blocked on a lock) and must not hold
-// up whoever asked. Detection walks a handful of candidates at worst,
-// and only ever the ones that exist on disk.
+// Wall-clock bound for one `-version` invocation. A working ffprobe answers in
+// milliseconds; one that has not by now is wedged (a stale network mount, a
+// wrapper blocked on a lock) and must not hold up whoever asked.
 constexpr unsigned kDetectTimeoutMs = 3000;
 
-// One-shot silent invocation. Returns true if `binary` runs cleanly
-// enough to print its own -version output. Used both as the "is on
-// PATH" probe (binary = "ffprobe") and as the "does this path work"
-// probe (binary = a resolved absolute path).
+// True if `binary` runs cleanly enough to print its own -version output. Serves
+// both as the "is ffprobe on PATH" probe and as the "does this path work" one.
 //
-// Goes through RunBoundedFFProbe for two reasons: it puts a deadline on
-// a binary that never returns, and it is callable off the main thread.
-// wxExecute is neither — see the include-block note above. Both matter
-// now that detection runs on the probe worker and not just behind the
-// Preferences "Detect" button. Bare `ffprobe` still resolves through
-// PATH: posix_spawnp and CreateProcess (with a null application name)
-// both search it.
+// Goes through RunBoundedFFProbe because that puts a deadline on a binary that
+// never returns and is callable off the main thread; wxExecute is neither (see
+// the include-block note above). Bare `ffprobe` still resolves through PATH:
+// posix_spawnp and CreateProcess with a null application name both search it.
 bool CanRun(const wxString &binary)
 {
 	// Detection is never cancelled part-way; only the timeout bounds it.
@@ -323,12 +305,9 @@ bool CanRun(const wxString &binary)
 	return RunBoundedFFProbe(binary, argv, kDetectTimeoutMs, keepRunning, out) == 0;
 }
 
-// Platform-specific well-known install locations, tried in order.
-// Only one entry per install-manager: we're looking for the first
-// existing binary, not enumerating every possible location. Order
-// matters — ARM64 Homebrew (`/opt/homebrew`) comes before Intel
-// (`/usr/local`) because a bare `ffprobe` PATH lookup on Apple
-// Silicon usually finds the ARM64 one first anyway.
+// Well-known install locations, tried in order; one entry per install-manager,
+// since we want the first existing binary rather than every possible location.
+// ARM64 Homebrew before Intel, matching what a bare PATH lookup finds first.
 wxArrayString WellKnownPaths()
 {
 	wxArrayString paths;
@@ -337,22 +316,18 @@ wxArrayString WellKnownPaths()
 	paths.Add(wxT("/usr/local/bin/ffprobe"));
 	paths.Add(wxT("/opt/local/bin/ffprobe")); // MacPorts
 #elif defined(__WXMSW__)
-	// Common Windows package-manager install roots. WinGet's per-app
-	// dir includes the package version so we can't hardcode a leaf;
-	// probing via `where.exe` (which CanRun("ffprobe") uses under the
-	// hood) is the reliable path for WinGet users. Chocolatey +
-	// scoop have stable predictable roots.
+	// WinGet's per-app dir carries the package version, so there is no leaf to
+	// hardcode -- WinGet users are found by the `where.exe` PATH probe instead.
+	// Chocolatey and scoop have stable roots.
 	paths.Add(wxT("C:\\ffmpeg\\bin\\ffprobe.exe"));
 	paths.Add(wxT("C:\\ProgramData\\chocolatey\\bin\\ffprobe.exe"));
 	if (const wxChar *home = wxGetenv(wxT("USERPROFILE"))) {
 		paths.Add(wxString(home) + wxT("\\scoop\\apps\\ffmpeg\\current\\bin\\ffprobe.exe"));
 	}
 #else
-	// Linux + OpenBSD share the same handful of standard prefixes.
-	// Snap and Flatpak users typically launch ffprobe out of their
-	// sandbox root (`/snap/bin/ffprobe`, or a flatpak-run wrapper);
-	// we cover the snap case explicitly and let flatpak users point
-	// the preference at their wrapper manually if they hit it.
+	// Snap and Flatpak users typically launch ffprobe out of their sandbox root;
+	// the snap case is covered explicitly, flatpak users point the preference at
+	// their wrapper manually.
 	paths.Add(wxT("/usr/bin/ffprobe"));
 	paths.Add(wxT("/usr/local/bin/ffprobe"));
 	paths.Add(wxT("/snap/bin/ffprobe"));
@@ -364,18 +339,14 @@ wxArrayString WellKnownPaths()
 
 wxString AutoDetectPath()
 {
-	// Fast path: unadorned `ffprobe` on the shell PATH. This is what
-	// most Linux + BSD installs give us for free (package-installed
-	// binaries land in a PATH dir). On macOS + Windows this often
-	// fails even when ffprobe IS installed, because GUI-launched
-	// processes get a minimal PATH (launchd default on macOS lacks
-	// /opt/homebrew; Windows GUI apps sometimes miss chocolatey /
-	// scoop until reboot).
+	// Fast path: bare `ffprobe` on PATH, which is what most Linux and BSD
+	// installs give for free. On macOS and Windows this often fails even when
+	// ffprobe IS installed, because GUI-launched processes get a minimal PATH
+	// (launchd's lacks /opt/homebrew; Windows GUI apps can miss choco/scoop).
 	if (CanRun(wxT("ffprobe"))) {
 		return wxT("ffprobe");
 	}
 
-	// Fallback: probe the per-platform well-known list.
 	for (const wxString &candidate : WellKnownPaths()) {
 		if (wxFileName::FileExists(candidate) && CanRun(candidate)) {
 			return candidate;
@@ -388,15 +359,12 @@ wxString AutoDetectPath()
 wxString DetectedPath(bool redetect)
 {
 	// Detection describes the machine, not a user choice, so it is derived at
-	// runtime and never written to the config file. Memoised because it costs
-	// at least one subprocess and the answer cannot change under a running
-	// daemon without someone installing ffmpeg -- which is what `redetect`
-	// (the Preferences "Detect" button) is for.
+	// runtime and never written to the config file. Memoised because it costs at
+	// least one subprocess and cannot change under a running daemon without
+	// someone installing ffmpeg -- which `redetect` is for.
 	//
-	// The lock is held across the detection itself so two callers cannot race
-	// two scans. That is a subprocess spawn's worth of blocking in the worst
-	// case; the common ones are cheap -- a missing binary fails to spawn
-	// immediately, and every well-known path is stat()ed before it is run.
+	// The lock is held across the detection itself so two callers cannot race two
+	// scans; worst case that is one subprocess spawn's worth of blocking.
 	static std::mutex mutex;
 	static bool done = false;
 	static wxString cached;
@@ -409,10 +377,9 @@ wxString DetectedPath(bool redetect)
 	done = true;
 
 	if (cached.IsEmpty()) {
-		// The one line that says the feature is inert. Not a debug line: the
-		// operator asked for metadata extraction and is getting none, and on
-		// a headless daemon this is the only place that can say why. Fires
-		// once per process -- the memo above guarantees it.
+		// Not a debug line: the operator asked for metadata extraction and is
+		// getting none, and on a headless daemon this is the only place that can
+		// say why. Fires once per process -- the memo above guarantees it.
 		AddLogLineN(_("Media metadata: no ffprobe binary found. Install ffmpeg, or set the "
 			      "ffprobe path in preferences; length, bitrate and codec will not be "
 			      "extracted."));
@@ -426,19 +393,18 @@ wxString DetectedPath(bool redetect)
 namespace
 {
 
-// ffprobe emits float durations with locale-independent `.` decimal
-// separators, so a plain strtod suffices — no wxString::ToDouble()
-// with its locale sensitivity here.
+// ffprobe emits float durations with a locale-independent `.` separator, so a
+// plain strtod suffices -- no locale-sensitive wxString::ToDouble() here.
 bool ParseSeconds(const wxString &value, uint32 &out)
 {
 	if (value.IsEmpty()) {
 		return false;
 	}
-	// Hold the UTF-8 buffer in a named local. `value.utf8_str().data()` twice
-	// would be two separate temporaries, each dead at the end of its own
-	// full-expression, so the comparison below would read a freed pointer and
-	// compare it against one from a different object -- which happens to work
-	// only because the allocator hands back the same block.
+	// Named local: `value.utf8_str().data()` twice would be two separate
+	// temporaries, each dead at the end of its own full-expression, so the
+	// comparison below would read a freed pointer and compare it against one from
+	// a different object -- which happens to work only because the allocator
+	// hands back the same block.
 	const wxScopedCharBuffer buf = value.utf8_str();
 	const char *const str = buf.data();
 	char *end = nullptr;
@@ -450,8 +416,7 @@ bool ParseSeconds(const wxString &value, uint32 &out)
 	if (d > static_cast<double>(0xFFFFFFFFu)) {
 		out = 0xFFFFFFFFu;
 	} else {
-		// Round to nearest whole second; sub-second precision has no
-		// consumer in the FT_MEDIA_LENGTH tag.
+		// Sub-second precision has no consumer in the FT_MEDIA_LENGTH tag.
 		out = static_cast<uint32>(std::llround(d));
 	}
 	return true;
@@ -485,10 +450,9 @@ bool ParseBitrateKbps(const wxString &value, uint32 &out)
 
 const wxChar *ProbeEntries()
 {
-	// Per stream: its codec_name and codec_type (so a video track's codec is
-	// preferred over an audio one, and subtitle / data streams never win), the
-	// attached_pic disposition, and its own artist/title/album tags. Per
-	// format: duration, bit_rate and the same three tags.
+	// Per stream: codec_name and codec_type (so a video track's codec beats an
+	// audio one and subtitle/data streams never win), attached_pic, and its own
+	// artist/title/album. Per format: duration, bit_rate and the same three tags.
 	return wxT("format=duration,bit_rate"
 		   ":format_tags=artist,title,album"
 		   ":stream=codec_name,codec_type"
@@ -547,28 +511,23 @@ wxString UnflattenValue(const wxString &raw)
 	return out;
 }
 
-// Longest tag value we will keep. Generous for a real artist / album / title
-// -- ed2k search indexes nothing near this -- and the point is to bound what
-// a crafted file can make this node store and publish, not to fit any real
-// metadata. A container tag is arbitrary attacker-chosen text of arbitrary
-// length, and these values go into known.met, into the log line, and into
-// every offered-file packet sent to every server and client.
+// Longest tag value we keep. Generous for a real artist/album/title; the point
+// is to bound what a crafted file can make this node store and publish, not to
+// fit any real metadata. These values go into known.met, into the log line, and
+// into every offered-file packet sent to every server and client.
 const size_t kMaxTagChars = 256;
 
 // Clean one tag value before it is allowed any further: bound the length and
 // drop control characters.
 //
-// The length cap is what keeps oversized text out of known.met, out of the log
-// line and off the wire; without it the only bound anywhere was the wire
-// format's 0xFFFF truncation, a packet-integrity guard rather than a policy,
-// which still allowed 64 KB of chosen text per field per packet. How much is
-// READ in the first place is bounded separately, at the slurp in
-// RunBoundedFFProbe.
+// The cap is what keeps oversized text out of known.met, out of the log line
+// and off the wire; without it the only bound anywhere was the wire format's
+// 0xFFFF truncation, a packet-integrity guard rather than a policy. How much is
+// READ is bounded separately, at the slurp in RunBoundedFFProbe.
 //
 // Control characters are dropped because the value reaches a log line (and
-// through it GET /api/v0/logs/amule) and several list controls; a raw newline
-// there lets one field impersonate several. `flat` already stopped the parser
-// being confused by them -- this is about everything downstream of it.
+// through it GET /api/v0/logs/amule) and several list controls, where a raw
+// newline lets one field impersonate several.
 wxString SanitiseTagValue(const wxString &value)
 {
 	wxString out;
@@ -613,10 +572,9 @@ bool ParseProbeOutput(const wxArrayString &lines, MediaInfo &out)
 	MediaInfo info;
 	bool got_duration = false;
 
-	// Keyed by the stream index ffprobe puts in the key, so ordering comes
-	// from the data rather than from the order lines happen to arrive in. A
-	// std::map also gives the streams back in index order for the selection
-	// below.
+	// Keyed by the stream index ffprobe puts in the key, so ordering comes from
+	// the data rather than from the order lines happen to arrive in; the map also
+	// hands the streams back in index order for the selection below.
 	std::map<unsigned long, ProbeStream> streams;
 	wxString formatArtist, formatAlbum, formatTitle;
 
@@ -666,26 +624,23 @@ bool ParseProbeOutput(const wxArrayString &lines, MediaInfo &out)
 		}
 	}
 
-	// Codec selection: the first video track's codec, else the first audio
-	// track's. Subtitle / data streams (e.g. a leading subrip track in an mkv)
-	// never win, so we don't advertise "subrip" as a file's codec.
+	// First video track's codec, else the first audio track's. Subtitle and data
+	// streams never win, so we don't advertise "subrip" as a file's codec.
 	wxString videoCodec, audioCodec;
-	// Tags of the stream that supplied audioCodec, the fallback source for
-	// Ogg/Opus where Vorbis comments belong to the logical stream and the
-	// format section carries nothing at all.
+	// Tags of the stream that supplied audioCodec: the fallback source for
+	// Ogg/Opus, where Vorbis comments belong to the logical stream and the format
+	// section carries nothing at all.
 	wxString streamArtist, streamAlbum, streamTitle;
-	// How many real (non-artwork) audio streams the file has. The stream-tag
-	// fallback below requires exactly one.
+	// Real (non-artwork) audio streams; the fallback below requires exactly one.
 	unsigned audioStreamCount = 0;
 
 	for (const auto &entry : streams) {
 		const ProbeStream &st = entry.second;
-		// Cover art (ID3 APIC, FLAC PICTURE, MOV covr, Matroska image
-		// attachments, ...) is reported as an ordinary video stream and is the
-		// only non-content stream that claims codec_type=video. Without this
-		// an MP3 with artwork advertises "mjpeg" as the file's codec -- to
-		// every peer, since the tag goes out on the wire. FFmpeg's own "real
-		// video" selector is the same test.
+		// Cover art (ID3 APIC, FLAC PICTURE, MOV covr, Matroska image attachments)
+		// is reported as an ordinary video stream, and is the only non-content
+		// stream claiming codec_type=video. Without this an MP3 with artwork
+		// advertises "mjpeg" as the file's codec -- to every peer, since the tag
+		// goes out on the wire. FFmpeg's own "real video" selector is the same test.
 		if (st.attached_pic || st.codec.IsEmpty()) {
 			continue;
 		}
@@ -713,23 +668,15 @@ bool ParseProbeOutput(const wxArrayString &lines, MediaInfo &out)
 	info.artist = formatArtist;
 	info.album = formatAlbum;
 	info.title = formatTitle;
-	// Stream tags are consulted only for a file with EXACTLY ONE audio stream
-	// and no video, and only where the format section gave nothing.
-	//
-	// The fallback exists for Ogg and Opus, where Vorbis comments belong to
-	// the single logical stream -- so the condition it actually needs is "one
-	// stream", not "not a video". On any multi-track container the stream tags
-	// are track LABELS ("Deutsch", "Espanol"), and publishing one as the
-	// file's title sends it to every peer over both ed2k and Kad. That is
-	// equally true of a multi-track .mka or a chained .ogg, which have no
-	// video stream at all and which a "not a video" test would let through.
-	// ...and only for the containers whose comments genuinely live on the
-	// stream. On a one-track file there is nothing structural to tell a track
-	// LABEL from a title -- a single .mka muxed with --track-name 0:Deutsch
-	// passes every other test here -- so the fallback is scoped to the Ogg
-	// family instead. Listing a codec costs the others nothing: the fallback
-	// only runs when the format section gave NOTHING, and everything else
-	// reports there.
+	// Stream tags are consulted only for a file with exactly one audio stream, no
+	// video and an Ogg-family codec, and only where the format section gave
+	// nothing. Vorbis comments belong to the single logical stream there, which is
+	// why the fallback exists at all. Anywhere else stream tags are track LABELS
+	// ("Deutsch", "Espanol"), and publishing one as the file's title sends it to
+	// every peer over ed2k and Kad; on a one-track file nothing structural tells a
+	// label from a title (a single .mka muxed with --track-name 0:Deutsch passes
+	// every other test here), so the scope is by codec rather than by "not a
+	// video". The other containers lose nothing: they report in the format section.
 	const bool streamTagCodec = (audioCodec == wxT("vorbis") || audioCodec == wxT("opus") ||
 				     audioCodec == wxT("flac") || audioCodec == wxT("speex"));
 	if (audioStreamCount == 1 && videoCodec.IsEmpty() && streamTagCodec) {
@@ -744,11 +691,11 @@ bool ParseProbeOutput(const wxArrayString &lines, MediaInfo &out)
 		}
 	}
 
-	// A zero duration is not a duration (see the format.duration branch): a
-	// container ffprobe can open and time as zero but reports no codec for
-	// would otherwise return a successful probe carrying an all-empty
-	// MediaInfo, which the authoritative apply step would treat as grounds to
-	// clear every media tag the file had.
+	// A zero duration is not a duration (see the format.duration branch), so a
+	// container ffprobe can open and time as zero while reporting no codec would
+	// otherwise be a successful probe carrying an all-empty MediaInfo -- which the
+	// authoritative apply step treats as grounds to clear every media tag the file
+	// had.
 	if (!got_duration && info.codec.IsEmpty()) {
 		return false;
 	}
@@ -768,19 +715,14 @@ ProbeOutcome Probe(const wxString &ffprobePath,
 		return ProbeOutcome::Unavailable;
 	}
 
-	// A job is queued only once hashing has finished, so the file existed
-	// moments ago -- but nothing re-checks between the queue and this worker
-	// picking the job up, and that gap widens whenever the probe queue backs
-	// up. Without this a file deleted in the meantime would be announced as
-	// being probed (issue #968) and then have a process spawned on it purely
-	// to fail. One stat is nothing against a fork+exec.
+	// A job is queued only once hashing has finished, but nothing re-checks
+	// between the queue and the worker picking the job up, and that gap widens
+	// whenever the probe queue backs up. One stat beats announcing a probe of a
+	// file deleted in the meantime and then forking on it purely to fail.
 	if (!file.FileExists()) {
-		// Info, not debug only. This used to be the one failure that printed
-		// nothing in a release build, which made it both invisible and, in the
-		// caller's accounting, indistinguishable from a file ffprobe rejected:
-		// it consumed a slot in the naming budget and landed in the failure
-		// count with no line to explain it. A share with stale known.met
-		// entries hits this on every refresh, so it has to say what happened.
+		// A share with stale known.met entries hits this on every refresh, so it
+		// has to say what happened: without a line it is indistinguishable from a
+		// file ffprobe rejected, while still consuming a naming-budget slot.
 		AddDebugLogLineN(logMediaProbe,
 			CFormat(wxT("MediaProbe: %s vanished before probing, skipping")) %
 				file.GetPrintable());
@@ -792,28 +734,23 @@ ProbeOutcome Probe(const wxString &ffprobePath,
 	}
 
 	// -show_entries constrains the output to what we care about; see
-	// ProbeEntries() for the field list and ParseProbeOutput() for what is done
-	// with it.
+	// ProbeEntries() for the field list.
 	//
-	// -of flat, and NOT the more readable `default` writer, because this
-	// request pulls attacker-controlled text into the output: a container tag
-	// is arbitrary UTF-8 and may contain newlines (Vorbis comments and
-	// Matroska tags allow them outright; nothing enforces ID3's advice against
-	// them). `default` does not escape its values, so each embedded newline
-	// becomes another key=value line inside the section the tag belongs to --
-	// a title of "Song\nduration=99999999" injects a duration line after the
-	// real one, and this parser is last-write-wins. That forged value would be
-	// attached as FT_MEDIA_LENGTH and published to every server and Kad node,
-	// defeating the whole premise that only locally verified metadata is
-	// advertised. A crafted line can move the section boundaries too.
+	// -of flat, and NOT the more readable `default` writer, because this request
+	// pulls attacker-controlled text into the output: a container tag is arbitrary
+	// UTF-8 and may contain newlines (Vorbis comments and Matroska tags allow them
+	// outright). `default` does not escape its values, so each embedded newline
+	// becomes another key=value line inside the tag's own section -- a title of
+	// "Song\nduration=99999999" injects a duration line after the real one, and
+	// this parser is last-write-wins. That forged value would be published as
+	// FT_MEDIA_LENGTH to every server and Kad node. A crafted line can move the
+	// section boundaries too.
 	//
-	// `flat` escapes \n, \r, \\ and " in values, and its dotted keys carry
-	// the section AND the stream index (format.tags.title,
-	// streams.stream.0.codec_name), so attribution comes from the key rather
-	// than from delimiter lines a value could also forge.
+	// `flat` escapes \n, \r, \\ and " in values, and its dotted keys carry the
+	// section AND the stream index, so attribution comes from the key rather than
+	// from delimiter lines a value could also forge.
 	//
-	// -v error silences informational chatter. Tokens are passed as a real
-	// argv (no shell), so the file path needs no quoting/escaping.
+	// -v error silences informational chatter.
 	wxArrayString argv;
 	argv.Add(wxT("-v"));
 	argv.Add(wxT("error"));
@@ -824,36 +761,22 @@ ProbeOutcome Probe(const wxString &ffprobePath,
 	argv.Add(file.GetRaw());
 
 	// Info level, not debug: media metadata is a feature the user explicitly
-	// enables and points at a binary, and until now got no feedback that it
-	// was being used, that the binary worked, or which file was being probed
-	// -- the debug trace this replaces is compiled out of release builds
-	// (issue #968). Emitted here, immediately before the spawn, so it fires
-	// once per actual ffprobe execution rather than once per queued job; the
-	// queue-time trace in SharedFileList stays at debug level.
+	// enables and points at a binary, so it needs feedback that the binary worked
+	// and which file was probed. Emitted immediately before the spawn, so it fires
+	// once per ffprobe execution rather than once per queued job.
 	if (!bulk) {
 		AddLogLineN(CFormat(_("Extracting media metadata with ffprobe: %s")) % file.GetPrintable());
 	}
 
 	// Bounded + killable: this runs on the dedicated CMediaProbeThread, so a
-	// slow/hung ffprobe can only ever delay other probes — never completions.
-	// The timeout and keepRunning cancel also stop a stuck child from wedging
-	// the worker itself or the shutdown join.
+	// slow or hung ffprobe can only delay other probes, never completions, and
+	// cannot wedge the worker or the shutdown join.
 	wxArrayString stdout_lines;
 	const int rc = RunBoundedFFProbe(ffprobePath, argv, timeoutMs, keepRunning, stdout_lines);
-	// Failures are info level too. Announcing the extraction and then reporting
-	// nothing when it fails is worse than the silence this feature replaced: a
-	// misconfigured or broken ffprobe would produce one confident "extracting"
-	// line per file and, in a release build where AddDebugLogLineN compiles to
-	// nothing, no error whatsoever. Whether the binary actually works is one of
-	// the questions these lines exist to answer.
-	// Failures are named even in bulk. Suppressing them was meant to stop the
-	// log scaling with the size of the media library, but that reasoning only
-	// holds for the per-file SUCCESS announcement above -- it is one line per
-	// file in the share. Failures are not: they are rare, and now that a
-	// failed file is marked and not retried (issue #1116) each one is reported
-	// once and then never again. A count with no filenames, which is what a
-	// scan used to produce, tells the user that something is wrong and
-	// withholds the only thing they need to act on it.
+	// Failures are info level and are named even in bulk. They are rare, and now
+	// that a failed file is marked and not retried each one is reported once and
+	// then never again; a count with no filenames withholds the only thing the
+	// user needs to act on.
 	if (rc == kKilled) {
 		if (logFailure) {
 			AddLogLineN(CFormat(_("Media metadata: ffprobe timed out or was cancelled for %s")) %
@@ -862,10 +785,10 @@ ProbeOutcome Probe(const wxString &ffprobePath,
 		return ProbeOutcome::Cancelled;
 	}
 	if (rc == kOutputTooLarge) {
-		// ffprobe itself succeeded; what it produced was implausible for the
-		// five fields asked for, which means the file carries a tag crafted to
-		// be enormous. Named separately so this does not report as a failure
-		// of the binary.
+		// ffprobe itself succeeded; what it produced was implausible for the five
+		// fields asked for, which means the file carries a tag crafted to be
+		// enormous. Named separately so this is not reported as a failure of the
+		// binary.
 		if (logFailure) {
 			AddLogLineN(CFormat(_("Media metadata: ignoring implausibly large ffprobe output "
 					      "for %s")) %
@@ -873,10 +796,9 @@ ProbeOutcome Probe(const wxString &ffprobePath,
 		}
 		return ProbeOutcome::OutputTooLarge;
 	}
-	// Distinguished from a non-zero exit on purpose: this one is about the
-	// binary, not the file, so it must not be recorded against the file and it
-	// needs a message that sends the user to their ffprobe setting rather than
-	// to their media.
+	// Distinguished from a non-zero exit on purpose: this one is about the binary
+	// rather than the file, so it must not be recorded against the file and needs
+	// a message that sends the user to their ffprobe setting.
 	if (rc == kSpawnFailed) {
 		if (logFailure) {
 			AddLogLineN(CFormat(_("Media metadata: could not run ffprobe (%s) -- check the "
@@ -897,12 +819,8 @@ ProbeOutcome Probe(const wxString &ffprobePath,
 	if (!ParseProbeOutput(stdout_lines, info)) {
 		// Neither a duration nor a codec came back, so there is nothing worth
 		// advertising -- report a failed probe rather than attaching empty tags.
-		//
-		// Info, not debug: AddDebugLogLineN compiles to nothing without
-		// __DEBUG__, so in every release build this -- the most likely way a
-		// file fails, since ffprobe exits 0 -- produced no output at all. The
-		// file was silently re-probed on every reload forever with nothing in
-		// the log to explain it.
+		// Named in the log because it is the most likely way a file fails (ffprobe
+		// exits 0), and the file is otherwise silently re-probed on every reload.
 		if (logFailure) {
 			AddLogLineN(CFormat(_("Media metadata: ffprobe found nothing usable in %s")) %
 				    file.GetPrintable());

--- a/src/MediaProbe.h
+++ b/src/MediaProbe.h
@@ -30,21 +30,19 @@
 
 class CPath;
 
-// Media metadata extracted from a shared file so we can advertise it
-// alongside search results via FT_MEDIA_LENGTH / _BITRATE / _CODEC
-// on the CKnownFile. Populated by ffprobe when the user has it
-// installed; fields default to 0 / empty so downstream code can gate
-// on nonzero-ness cheaply.
+// Media metadata extracted from a shared file, advertised alongside search
+// results via FT_MEDIA_LENGTH / _BITRATE / _CODEC on the CKnownFile. Populated
+// by ffprobe; fields default to 0 / empty so downstream code can gate on
+// nonzero-ness cheaply.
 struct MediaInfo
 {
 	// FT_MEDIA_LENGTH — seconds, uint32 on the wire.
 	uint32 length_seconds = 0;
 	// FT_MEDIA_BITRATE — kilobits per second, uint32 on the wire.
 	uint32 bitrate_kbps = 0;
-	// FT_MEDIA_CODEC — free-form codec name string as ffprobe
-	// reports it (e.g. "h264", "aac", "vorbis"). Displayed as-is;
-	// FormatMediaCodec() in OtherFunctions.h maps a few common
-	// FOURCCs / format strings to friendlier UI labels.
+	// FT_MEDIA_CODEC -- free-form codec name as ffprobe reports it ("h264",
+	// "aac", "vorbis"). Displayed as-is; FormatMediaCodec() maps a few common
+	// FOURCCs to friendlier UI labels.
 	wxString codec;
 	// FT_MEDIA_ARTIST / _ALBUM / _TITLE — container tags, empty when the
 	// file carries none. Read from the format section, falling back to the
@@ -57,14 +55,12 @@ struct MediaInfo
 namespace MediaProbe
 {
 
-// Parse ffprobe's `-show_entries ... -of default=nk=0` output into a
-// MediaInfo. Split out of Probe() so the parsing rules -- which carry all the
-// container-specific subtleties -- are testable without spawning a process or
-// shipping media fixtures; Probe() is then just "run the binary and call this".
+// Parse ffprobe's output into a MediaInfo. Split out of Probe() so the parsing
+// rules -- which carry all the container-specific subtleties -- are testable
+// without spawning a process or shipping media fixtures.
 //
-// Returns false when nothing usable was parsed (neither a duration nor a
-// codec), which the caller reports as a failed probe so no empty tags are
-// attached.
+// Returns false when nothing usable was parsed (neither a duration nor a codec),
+// which the caller reports as a failed probe so no empty tags are attached.
 bool ParseProbeOutput(const wxArrayString &lines, MediaInfo &out);
 
 // The `-show_entries` argument Probe() passes, exposed so a test feeds the
@@ -72,64 +68,50 @@ bool ParseProbeOutput(const wxArrayString &lines, MediaInfo &out);
 // approximation of it.
 const wxChar *ProbeEntries();
 
-// Locate an ffprobe binary. Tries in order:
-//   1. `ffprobe` on $PATH (or %PATH% on Windows) via a quick
-//      `ffprobe -version` invocation — this is the fast path when
-//      the user has ffmpeg installed in the shell PATH.
-//   2. A per-platform list of well-known install locations. Homebrew
-//      / MacPorts on macOS, scoop / chocolatey / winget on Windows,
-//      distro-standard bin paths on Linux + OpenBSD.
-// Returns an empty wxString if nothing was found.
+// Locate an ffprobe binary. Tries `ffprobe` on PATH first, via a quick
+// `-version` invocation, then a per-platform list of well-known install
+// locations (Homebrew / MacPorts, scoop / chocolatey / winget, distro bin
+// paths). Empty when nothing was found.
 //
-// Runs synchronously and spawns at least one child process, each bounded
-// by its own timeout. Cheap in the ordinary cases — the PATH probe is a
-// few dozen ms, a missing binary fails to spawn at once, and every
-// well-known path is stat()ed before it is run — but it is still a
-// subprocess walk, so prefer DetectedPath() below, which pays for it once.
+// Runs synchronously and spawns at least one child process, each bounded by its
+// own timeout. Cheap in the ordinary cases, but still a subprocess walk, so
+// prefer DetectedPath() below, which pays for it once.
 //
 // Safe to call from any thread.
 wxString AutoDetectPath();
 
-// AutoDetectPath() memoised for the life of the process, and the entry
-// point everything but the detection itself should use.
+// AutoDetectPath() memoised for the life of the process, and the entry point
+// everything but the detection itself should use.
 //
-// The result describes the machine rather than a user choice, so it is
-// derived at runtime and never persisted: an empty `ffprobe_path`
-// preference means "ask this", not "feature off". `redetect` forces a
-// fresh scan and replaces the cache — for the Preferences "Detect"
-// button, whose whole purpose is to notice an ffmpeg installed since the
-// process started.
+// The result describes the machine rather than a user choice, so it is derived at
+// runtime and never persisted: an empty `ffprobe_path` preference means "ask
+// this", not "feature off". `redetect` forces a fresh scan and replaces the
+// cache, for the Preferences "Detect" button.
 //
-// Logs the outcome exactly once: a visible line when nothing was found
-// (the only notice a headless operator gets that extraction is inert), a
-// logMediaProbe debug line naming the binary when something was.
-//
-// Safe to call from any thread; concurrent callers serialise on the
-// first scan.
+// Logs the outcome exactly once: a visible line when nothing was found (the only
+// notice a headless operator gets that extraction is inert), a debug line naming
+// the binary when something was. Safe to call from any thread.
 wxString DetectedPath(bool redetect = false);
 
-// Probe a single file. Returns true on success and populates `out`;
-// returns false on any failure — binary missing / unreadable file /
-// non-media file / ffprobe hard error / malformed output. Failures
-// emit a debug-level log line but never surface anything user-facing
-// (a file the probe can't read still gets shared, just without
-// media tags).
+// Probe a single file. Returns true on success and populates `out`; false on any
+// failure -- binary missing, unreadable or non-media file, ffprobe hard error,
+// malformed output. Failures emit a debug line but never surface anything
+// user-facing: a file the probe cannot read is still shared, without media tags.
 //
-// The probe spawns ffprobe as a child process and waits for it with a
-// `timeoutMs` wall-clock bound: if the child outlives the deadline it is
-// killed and the probe reports failure. `keepRunning` is polled during the
-// wait — when it flips false (worker shutdown) the child is killed
-// immediately so the caller's join can complete. Both bounds mean a
-// slow/hung ffprobe can never wedge the worker or the shutdown path.
+// The probe spawns ffprobe as a child and waits for it with a `timeoutMs`
+// wall-clock bound, killing it on expiry. `keepRunning` is polled during the
+// wait, so worker shutdown kills the child at once and the caller's join can
+// complete. Both bounds mean a slow or hung ffprobe can never wedge the worker.
 //
-// Callers MUST run this off the main thread — it blocks for the duration
-// of the child (typically 30-100 ms, at most `timeoutMs`).
+// Callers MUST run this off the main thread: it blocks for the duration of the
+// child, typically 30-100 ms and at most `timeoutMs`.
+
 //! Why a probe produced no metadata. The distinction matters because one of
-//! these is a statement about the FILE and the rest are statements about the
-//! environment: only the first justifies recording "this file cannot be
-//! probed" and skipping it on later scans. Marking on the others would let a
-//! mistyped ffprobe path, a spun-down disk, or a shutdown mid-scan brand every
-//! file it touched as permanently unprobeable (issue #1116).
+//! these is a statement about the FILE and the rest about the environment: only
+//! the first justifies recording "this file cannot be probed" and skipping it on
+//! later scans. Marking on the others would let a mistyped ffprobe path, a
+//! spun-down disk or a shutdown mid-scan brand every file it touched as
+//! permanently unprobeable (issue #1116).
 enum class ProbeOutcome
 {
 	Extracted,        //!< usable metadata came back
@@ -145,38 +127,32 @@ enum class ProbeOutcome
 //! machine it runs on, and so may be recorded against the file.
 inline bool IsFileVerdict(ProbeOutcome outcome)
 {
-	// UnreadableFile counts: a non-zero exit is how a WORKING ffprobe rejects
-	// a file it cannot parse, which is the ordinary broken-download case and
-	// the one users report as retried forever. A binary that cannot be
-	// launched is a different code path entirely (kSpawnFailed), so a missing
-	// or mistyped path never arrives here.
+	// UnreadableFile counts: a non-zero exit is how a WORKING ffprobe rejects a file
+	// it cannot parse, which is the ordinary broken-download case and the one users
+	// report as retried forever. A binary that cannot be launched is a different
+	// code path (kSpawnFailed), so a missing or mistyped path never arrives here.
 	//
-	// The gap: a non-zero exit cannot distinguish "ffprobe read this file and
-	// it is broken" from "ffprobe could not open it". FileExists() is a stat,
-	// so a file present but unreadable -- no read permission, or on a network
-	// mount that is away or hiccupping -- reaches a perfectly good ffprobe,
-	// exits non-zero, and is recorded as unprobeable. A share on SMB or NFS
-	// can lose a whole library's metadata to one bad moment that way, which is
-	// likelier than the other case here: a configured path pointing at some
-	// other executable that exits non-zero.
+	// The gap: a non-zero exit cannot distinguish "ffprobe read this file and it is
+	// broken" from "ffprobe could not open it". FileExists() is a stat, so a file
+	// present but unreadable -- no read permission, or a network mount hiccupping --
+	// reaches a perfectly good ffprobe, exits non-zero, and is recorded as
+	// unprobeable. An SMB or NFS share can lose a whole library's metadata to one
+	// bad moment that way.
 	//
-	// Separating the two means reading ffprobe's stderr, which currently goes
-	// to /dev/null. Until then a media refresh is the way back: it ignores the
-	// marks and clears them on success.
+	// Separating the two means reading ffprobe's stderr, which currently goes to
+	// /dev/null. Until then a media refresh is the way back: it ignores the marks
+	// and clears them on success.
 	return outcome == ProbeOutcome::NoUsableMetadata || outcome == ProbeOutcome::UnreadableFile ||
 	       outcome == ProbeOutcome::OutputTooLarge;
 }
 
-//! \param bulk true when the caller is draining a batch of queued probes (a
-//! share scan), in which case the per-file "extracting" announcement is
-//! suppressed and the caller reports one summary for the whole operation --
-//! otherwise a large media library produces one line per file, which is
-//! exactly the scale-with-the-share-size property the discovery lines were
-//! summarised to avoid. A genuine single-file event still speaks.
+//! \param bulk true when the caller is draining a batch of queued probes, in
+//! which case the per-file "extracting" announcement is suppressed and the
+//! caller reports one summary -- otherwise a large media library produces one
+//! line per file. A genuine single-file event still speaks.
 //! \param logFailure whether a failure may name its file. Failures are worth
-//! naming even in bulk (a count alone is not actionable), but a broken ffprobe
-//! fails EVERY file, so the caller caps how many it names per operation and
-//! folds the rest into the summary.
+//! naming even in bulk, since a count alone is not actionable, but a broken
+//! ffprobe fails EVERY file, so the caller caps how many it names.
 ProbeOutcome Probe(const wxString &ffprobePath,
 	const CPath &file,
 	MediaInfo &out,

--- a/src/MediaProbeThread.cpp
+++ b/src/MediaProbeThread.cpp
@@ -32,11 +32,10 @@
 
 namespace
 {
-// Wall-clock ceiling for a single ffprobe run. A local media file probes in
-// tens of milliseconds; anything approaching this is a hung/pathological
-// invocation the worker kills rather than blocking on. Also bounds how long
-// a shutdown can wait on an in-flight probe (EndThread flips m_bRun, which
-// Probe polls, so a stuck child is usually killed well before this).
+// Wall-clock ceiling for a single ffprobe run. A local media file probes in tens
+// of milliseconds; anything approaching this is a hung invocation the worker
+// kills rather than blocking on. It also bounds how long a shutdown can wait on
+// an in-flight probe.
 constexpr unsigned kProbeTimeoutMs = 30000;
 } // namespace
 
@@ -87,10 +86,10 @@ void *CMediaProbeThread::Entry()
 	// the end of the loop for why they cannot be per-drain.
 	unsigned bulkProbed = 0;
 	unsigned bulkFailed = 0;
-	// Failures are named even in bulk, because a count alone cannot be acted
-	// on -- but a broken or mistyped ffprobe fails EVERY media file, so an
-	// uncapped rule turns one misconfiguration into one line per file in the
-	// share. Name the first few of an operation and count the rest.
+	// Failures are named even in bulk, because a count alone cannot be acted on --
+	// but a broken or mistyped ffprobe fails EVERY media file, so an uncapped rule
+	// turns one misconfiguration into one line per file. Name the first few of an
+	// operation and count the rest.
 	unsigned bulkNamed = 0;
 	unsigned bulkUnnamed = 0;
 	// Vanished files are counted apart from failures: the two get separate
@@ -116,14 +115,12 @@ void *CMediaProbeThread::Entry()
 			workList.swap(m_jobList);
 		}
 
-		// Bulk-ness now rides on the job, set by whoever scheduled it. It
-		// used to be `workList.size() > 1`, which asked the wrong question:
-		// the worker swaps the whole pending list out as soon as it is
-		// signalled, so the size of a batch reflects the timing of that wake
-		// and nothing else. During one share scan some drains hold a single
-		// job and some hold dozens, so exactly which files printed a per-file
-		// line was decided by the scheduler -- one file named, the rest
-		// summarised, with nothing distinguishing them (issue #1116).
+		// Bulk-ness rides on the job, set by whoever scheduled it. It used to be
+		// `workList.size() > 1`, which asked the wrong question: the worker swaps the
+		// whole pending list out as soon as it is signalled, so a batch's size
+		// reflects the timing of that wake and nothing else. During one share scan
+		// some drains hold a single job and some dozens, so which files printed a
+		// per-file line was decided by the scheduler (issue #1116).
 		unsigned probed = 0;
 		unsigned failed = 0;
 		bool anyBulk = false;
@@ -133,44 +130,40 @@ void *CMediaProbeThread::Entry()
 			if (!m_bRun) {
 				break;
 			}
-			// An empty path means the user never pinned one, so fall back to
-			// what this machine has. DetectedPath() memoises, so only the
-			// first job in the process pays for the scan; when it finds
-			// nothing every job lands here and is dropped without a word --
-			// the one line explaining why was logged by that first call.
+			// An empty path means the user never pinned one, so fall back to what
+			// this machine has. DetectedPath() memoises, so only the first job pays
+			// for the scan; when it finds nothing every job lands here and is
+			// dropped without a word, the one line explaining why having been
+			// logged by that first call.
 			const wxString exe =
 				job.ffprobePath.IsEmpty() ? MediaProbe::DetectedPath() : job.ffprobePath;
 			if (exe.IsEmpty()) {
 				continue;
 			}
-			// Part of a bulk operation either because it was scheduled that
-			// way, or because one is still draining: the tail of a share
-			// import arrives a file at a time, long after the walk that found
-			// it, and the scheduler can no longer tell those files from a
-			// single file dropped into a shared directory. The worker can --
-			// it is still finishing the same operation. Without this a large
-			// first import ends with a handful of per-file lines for no
-			// reason the user can see.
+			// Part of a bulk operation either because it was scheduled that way, or
+			// because one is still draining: the tail of a share import arrives a
+			// file at a time, long after the walk that found it, and the scheduler
+			// can no longer tell those files from a single file dropped into a
+			// shared directory. The worker can, being still in the same operation.
+			// Without this a large first import ends with a handful of per-file
+			// lines for no reason the user can see.
 			const bool jobBulk = job.bulk || bulkProbed > 0;
 			const bool mayName = !jobBulk || bulkNamed < kMaxNamedFailures;
 			MediaInfo info;
 			const MediaProbe::ProbeOutcome outcome = MediaProbe::Probe(
 				exe, job.path, info, kProbeTimeoutMs, m_bRun, jobBulk, mayName);
-			// A file that was gone before ffprobe ran is not an extraction
-			// that failed -- nothing was extracted from and no verdict was
-			// reached -- so it is counted in neither total. It still names
-			// itself above, so it is explained rather than silently dropped.
-			// Counting it as a failure put a number in the summary that
-			// nothing in the log accounted for, on every refresh of a share
-			// with stale entries.
+			// A file that was gone before ffprobe ran is not an extraction that
+			// failed -- nothing was extracted from and no verdict was reached -- so
+			// it is counted in neither total. It still names itself above. Counting
+			// it as a failure put a number in the summary that nothing in the log
+			// accounted for, on every refresh of a share with stale entries.
 			if (outcome == MediaProbe::ProbeOutcome::Vanished) {
-				// Before the `continue`: an operation made up ENTIRELY of
-				// vanished files still has to end. Without this, anyBulk stays
-				// false, bulkProbed stays 0, the flush block below never runs
-				// and the naming budget is never reset -- so one refresh over
-				// a share whose files have moved would silence every failure
-				// for the rest of the process, which is the unnamed-failure
-				// symptom this whole change is about.
+				// Before the `continue`: an operation made up ENTIRELY of vanished
+				// files still has to end. Without this anyBulk stays false,
+				// bulkProbed stays 0, the flush block below never runs and the
+				// naming budget is never reset -- so one refresh over a share whose
+				// files have moved would silence every failure for the rest of the
+				// process.
 				anyBulk = anyBulk || jobBulk;
 				if (jobBulk) {
 					if (mayName) {
@@ -183,10 +176,9 @@ void *CMediaProbeThread::Entry()
 			}
 			++probed;
 			if (outcome == MediaProbe::ProbeOutcome::Extracted) {
-				// Marshal the result to the main thread, which
-				// resolves the hash to the CKnownFile and attaches
-				// the FT_MEDIA_* tags (doing that here would race the
-				// publish paths that read m_taglist).
+				// Marshal the result to the main thread, which resolves the hash
+				// to the CKnownFile and attaches the FT_MEDIA_* tags; doing that
+				// here would race the publish paths that read m_taglist.
 				CMediaProbeEvent evt(job.hash, info);
 				wxQueueEvent(wxTheApp, evt.Clone());
 			} else {
@@ -198,11 +190,10 @@ void *CMediaProbeThread::Entry()
 						++bulkUnnamed;
 					}
 				}
-				// Tell the main thread, so a file the probe has actually
-				// JUDGED can be marked as unprobeable and stop being re-queued
-				// on every reload and restart. Only a verdict about the file
-				// counts: a missing ffprobe, a timeout or a file that vanished
-				// says nothing about the file, and marking on those would let
+				// Tell the main thread, so a file the probe has actually JUDGED can be
+				// marked unprobeable and stop being re-queued on every reload. Only a
+				// verdict about the file counts: a missing ffprobe, a timeout or a
+				// vanished file says nothing about it, and marking on those would let
 				// one mistyped path brand a whole library permanently.
 				MediaInfo empty;
 				CMediaProbeEvent evt(job.hash,
@@ -214,14 +205,12 @@ void *CMediaProbeThread::Entry()
 			anyBulk = anyBulk || jobBulk;
 		}
 
-		// One line for the whole OPERATION, not one per drain. The worker
-		// takes whatever is queued each time it wakes, so a single share scan
-		// is drained in several batches -- which used to produce several
-		// summaries ("from 7 files", "from 33 files", "from 42 files") for
-		// what the user experienced as one action, with no way to tell they
-		// belonged together or that the last one was the last (issue #1116).
-		// The counts accumulate across consecutive bulk drains and are
-		// reported once, when nothing is left queued.
+		// One line for the whole OPERATION, not one per drain. The worker takes
+		// whatever is queued each time it wakes, so a single share scan is drained in
+		// several batches -- which used to produce several summaries ("from 7
+		// files", "from 33 files", "from 42 files") for what the user experienced as
+		// one action (issue #1116). The counts accumulate across consecutive bulk
+		// drains and are reported once, when nothing is left queued.
 		if (anyBulk) {
 			bulkProbed += probed;
 			bulkFailed += failed;
@@ -231,25 +220,21 @@ void *CMediaProbeThread::Entry()
 			wxMutexLocker lock(m_mutex);
 			queueEmpty = m_jobList.empty();
 		}
-		// An empty queue is NOT the end of the operation while files are still
-		// being hashed. A first import feeds this worker one file at a time --
-		// hashing reads the whole file, a probe reads a header -- so the queue
-		// is empty after nearly every job, and flushing on that alone would
-		// print "Finished ... from 1 shared file" once per file, which is
-		// worse than the per-drain summaries it replaced. The same hashing
-		// queue that tells the scheduler this is a mass operation tells us it
-		// is not over yet. A reload has nothing hashing, so it flushes as soon
-		// as the probes drain, which is what it should do.
-		// > 0, not > 1: while ANY file is still being hashed the import has
-		// more probes coming, and flushing on the last one leaves it outside
-		// the summary it belongs to. (The scheduler's own bulk test uses > 1
-		// because there the running task IS the single file being asked
-		// about.) Costs at most one extra 500 ms wake before the summary.
+		// An empty queue is NOT the end of the operation while files are still being
+		// hashed. A first import feeds this worker one file at a time -- hashing
+		// reads the whole file, a probe reads a header -- so the queue is empty after
+		// nearly every job, and flushing on that alone would print "Finished ... from
+		// 1 shared file" once per file. The same hashing queue that tells the
+		// scheduler this is a mass operation tells us it is not over yet; a reload
+		// has nothing hashing and flushes as soon as the probes drain.
+		//
+		// > 0, not > 1: while ANY file is still being hashed the import has more
+		// probes coming, and flushing on the last one leaves it outside the summary
+		// it belongs to. Costs at most one extra 500 ms wake.
 		const bool stillImporting = CThreadScheduler::GetPendingCount(wxT("Hashing")) > 0;
-		// bulkNamed / bulkGoneUnnamed in the guard, not just bulkProbed: an
-		// operation can consist only of vanished files, and it still has to
-		// reach the reset below. The summary itself is still printed only when
-		// something was actually probed.
+		// bulkNamed / bulkGoneUnnamed in the guard, not just bulkProbed: an operation
+		// can consist only of vanished files and still has to reach the reset below.
+		// The summary itself is printed only when something was actually probed.
 		if (queueEmpty && !stillImporting &&
 			(bulkProbed > 0 || bulkNamed > 0 || bulkGoneUnnamed > 0)) {
 			if (bulkProbed > 0) {
@@ -285,12 +270,11 @@ void *CMediaProbeThread::Entry()
 				}
 			}
 			if (bulkGoneUnnamed > 0) {
-				// Symmetric with the withheld-failures line above: past the
-				// cap a vanished file was counted nowhere and printed
-				// nowhere, so a refresh over a share that has moved named ten
-				// and said nothing about the rest. Its own line rather than
-				// the failure one, because a file that is gone did not fail
-				// to extract.
+				// Symmetric with the withheld-failures line above: past the cap a
+				// vanished file was counted nowhere and printed nowhere, so a refresh
+				// over a share that has moved named ten and said nothing about the
+				// rest. Its own line, because a file that is gone did not fail to
+				// extract.
 				AddLogLineN(CFormat(wxPLURAL("%u further shared file is gone (not listed "
 							     "individually)",
 						    "%u further shared files are gone (not listed "

--- a/src/MuleCollection.cpp
+++ b/src/MuleCollection.cpp
@@ -95,11 +95,10 @@ bool CMuleCollection::OpenBuffer(const char *data, size_t len)
 		return false;
 	}
 
-	// Skip a UTF-8 byte-order mark. Text collections are hand-made lists of
-	// links, and a Windows editor saves them with a BOM by default; without
-	// this the first link fails its "starts with ed2k://|file|" check and a
-	// single-entry collection looks empty. A binary collection never starts
-	// with one, so this only ever affects the text form.
+	// Skip a UTF-8 byte-order mark. Text collections are hand-made lists of links,
+	// and a Windows editor saves them with a BOM by default; without this the first
+	// link fails its "starts with ed2k://|file|" check and a single-entry collection
+	// looks empty. A binary collection never starts with one.
 	if (len >= 3 && static_cast<unsigned char>(data[0]) == 0xEF &&
 		static_cast<unsigned char>(data[1]) == 0xBB && static_cast<unsigned char>(data[2]) == 0xBF) {
 		data += 3;
@@ -112,16 +111,14 @@ bool CMuleCollection::OpenBuffer(const char *data, size_t len)
 	const std::string buffer(data, len);
 	std::istringstream infile(buffer, std::ios::in | std::ios::binary);
 
-	// The two formats are told apart by the leading four bytes and only one
-	// parser ever runs. A binary collection starts with a version of 1 or 2;
-	// a text one starts with "ed2k://", which as a little-endian uint32 is
-	// 0x6b326465 and so can never be mistaken for a version.
+	// The two formats are told apart by the leading four bytes and only one parser
+	// ever runs: a binary collection starts with a version of 1 or 2, a text one
+	// with "ed2k://", which as a little-endian uint32 is 0x6b326465.
 	//
-	// Never try the text parser as a fallback for a binary file. The text
-	// parser scans for anything that looks like a link, so a hostile
-	// collection could smuggle one inside a filename field, have the binary
-	// parser correctly reject the entry, and still see it harvested from the
-	// raw bytes on the second pass.
+	// Never try the text parser as a fallback for a binary file. It scans for
+	// anything that looks like a link, so a hostile collection could smuggle one
+	// inside a filename field, have the binary parser correctly reject the entry,
+	// and still see it harvested from the raw bytes on the second pass.
 	std::vector<std::string> parsed;
 	const bool isBinary = (len >= sizeof(uint32_t)) && (LooksLikeBinary(data));
 

--- a/src/MuleDataViewCtrl.cpp
+++ b/src/MuleDataViewCtrl.cpp
@@ -77,12 +77,11 @@ int CMuleDataViewCtrl::ColumnWidthAdapter::GetColumnWidth(int col) const
 	if (width > 0) {
 		return width;
 	}
-	// A visible column should never report zero -- the spacer appended on
-	// macOS exists so the trailing-column sizing lands there instead. This
-	// is the backstop if it ever does anyway: CListColumnStore reads a width
-	// <= 0 as hidden and persists it negative, so a stray zero would hide a
-	// real column on the next launch, then do the same to whichever column
-	// became last, losing one per restart.
+	// A visible column should never report zero -- the spacer appended on macOS
+	// exists so the trailing-column sizing lands there instead. This is the
+	// backstop: CListColumnStore reads a width <= 0 as hidden and persists it
+	// negative, so a stray zero would hide a real column on the next launch, then
+	// do the same to whichever column became last, losing one per restart.
 	const int cached = m_ctrl->m_columnStore.GetCachedWidth(col);
 	return (cached > 0) ? cached : m_ctrl->m_columnStore.GetColumnDefaultWidth(col);
 }
@@ -133,14 +132,12 @@ void CMuleDataViewCtrl::AddIconTextColumn(const wxString &label,
 	// every row whether or not that row has an icon -- see the class comment.
 	CMuleIconTextRenderer *renderer = new CMuleIconTextRenderer();
 	renderer->SetMode(mode);
-	// Supply the vertical half of the alignment when the caller has not.
-	// wx's own text renderer resolves a missing vertical component to its
-	// default, which is centred, but a custom renderer gets exactly what it
-	// is given -- so a plain wxALIGN_LEFT top-aligns the text while the icon
-	// drawn beside it is centred, and the name columns sit visibly higher
-	// than every other column in the same row (#867). wxALIGN_TOP is 0 and
-	// so indistinguishable from "unspecified" (wx says as much in defs.h),
-	// which is why this tests for the two bits that do carry intent.
+	// Supply the vertical half of the alignment when the caller has not. wx's own
+	// text renderer resolves a missing vertical component to centred, but a custom
+	// renderer gets exactly what it is given, so a plain wxALIGN_LEFT top-aligns
+	// the text while the icon beside it is centred (#867). wxALIGN_TOP is 0 and so
+	// indistinguishable from "unspecified", which is why this tests the two bits
+	// that do carry intent.
 	const bool hasVertical = (align & (wxALIGN_BOTTOM | wxALIGN_CENTRE_VERTICAL)) != 0;
 	renderer->SetAlignment(hasVertical ? align : (align | wxALIGN_CENTRE_VERTICAL));
 	AppendColumn(new wxDataViewColumn(label, renderer, modelColumn, width, align, flags));
@@ -169,25 +166,23 @@ unsigned CMuleDataViewCtrl::RealColumnCount() const
 
 void CMuleDataViewCtrl::InitColumnState()
 {
-	// Every appended column must sit at the view position matching its model
-	// id. Several things here index by one and are read as the other:
-	// FitColumnsToContent() walks a single index as both, m_columnHidden and
-	// the header menu are keyed by view position, and RegisterColumn() by model
-	// id. They agree only because the two orders have always coincided, so
-	// inserting a column mid-list -- which is what surfaced this -- silently
-	// sizes and hides the wrong ones. Assert rather than document it: the
-	// failure is invisible at runtime and looks like a rendering bug.
+	// Every appended column must sit at the view position matching its model id.
+	// Several things here index by one and are read as the other:
+	// FitColumnsToContent() walks a single index as both, m_columnHidden and the
+	// header menu are keyed by view position, and RegisterColumn() by model id.
+	// They agree only because the two orders have always coincided, so inserting a
+	// column mid-list silently sizes and hides the wrong ones. Asserted rather than
+	// documented: the failure looks like a rendering bug at runtime.
 	for (unsigned i = 0; i < RealColumnCount(); ++i) {
 		wxASSERT_MSG(GetColumn(i)->GetModelColumn() == i,
 			"column ids must be declared in the order the columns are appended");
 	}
 
 #ifdef __WXOSX__
-	// Forgetting the spacer costs the last column: macOS gives the leftover
-	// width to the last *resizable* one, which collapses it to nothing as soon
-	// as the columns outgrow the control. Nothing about that is visible until
-	// somebody narrows the list far enough, which is how the clients list
-	// shipped without one -- so fail loudly here instead.
+	// Forgetting the spacer costs the last column: macOS gives the leftover width
+	// to the last *resizable* one, which collapses to nothing as soon as the
+	// columns outgrow the control, and nothing shows until somebody narrows the
+	// list far enough.
 	wxASSERT_MSG(m_hasSpacer, "every list must AppendSpacerColumn() before InitColumnState()");
 #endif
 
@@ -276,25 +271,22 @@ void CMuleDataViewCtrl::ShowSortCaret(unsigned column, unsigned order, SortTrigg
 	bool ascending = !(order & SORT_DES);
 
 #ifdef __WXGTK__
-	// Two GTK quirks stack up here, and they only cancel each other out on
-	// the click path -- which is why the caret used to come back up the wrong
-	// way round after a restart, then correct itself the moment a header was
-	// clicked.
+	// Two GTK quirks stack up here, and they cancel out only on the click path --
+	// which is why the caret used to come back up the wrong way round after a
+	// restart and correct itself on the first header click.
 	//
-	// The first is the glyph: with gtk-alternative-sort-arrows off (the
-	// default) GTK draws GTK_SORT_ASCENDING as "pan-down-symbolic", so an A-Z
-	// sort gets a *down* arrow, the opposite of macOS and MSW.
+	// The first is the glyph: with gtk-alternative-sort-arrows off (the default)
+	// GTK draws GTK_SORT_ASCENDING as "pan-down-symbolic", so an A-Z sort gets a
+	// DOWN arrow, the opposite of macOS and MSW.
 	//
-	// The second is that GTK sorts on its own. wx makes every sortable column
-	// call gtk_tree_view_column_set_sort_column_id(), which leaves GTK's own
-	// handler connected: on the button *release*, after this control has
-	// already handled the button press and set the caret, GTK flips the order
-	// it finds and writes it back. Two inversions, so a clicked header ends
-	// up looking right.
+	// The second is that GTK sorts on its own: wx makes every sortable column call
+	// gtk_tree_view_column_set_sort_column_id(), which leaves GTK's handler
+	// connected, so on the button release -- after this control has handled the
+	// press and set the caret -- GTK flips the order it finds and writes it back.
+	// Two inversions, so a clicked header ends up looking right.
 	//
-	// Nothing restores a saved sort, so hand wx the flipped value there and
-	// both paths agree. Only the arrow is affected -- rows are ordered from
-	// m_sort_orders, and the model deliberately ignores wx's ascending flag.
+	// Nothing restores a saved sort, so hand wx the flipped value there and both
+	// paths agree. Only the arrow is affected: rows are ordered from m_sort_orders.
 	if (trigger == SortTrigger::Programmatic) {
 		ascending = !ascending;
 	}
@@ -378,15 +370,13 @@ void CMuleDataViewCtrl::LoadColumnSettings()
 	// Restored widths can leave the default expander column hidden.
 	UpdateExpanderColumn();
 
-	// LoadSettings() returns the orders primary-LAST: CMuleListCtrl applied
-	// them by calling SetSorting() on each in turn, and each call pushes to
-	// the front, so the last one processed ends up primary. ApplySorting()
-	// has the same semantics, so replaying them in order reproduces it.
-	// Only replace what the list installed for itself when the config actually
-	// has something stored. A profile with no saved TableOrdering for this list
-	// decodes to an empty list, and clearing unconditionally would throw away
-	// the default the list set before calling here -- CServerListCtrl sorts by
-	// name in exactly that way.
+	// LoadSettings() returns the orders primary-LAST, because each SetSorting()
+	// call pushes to the front, so the last one processed ends up primary;
+	// ApplySorting() has the same semantics, so replaying in order reproduces it.
+	// Only replace what the list installed for itself when the config has something
+	// stored: a profile with no saved TableOrdering decodes to an empty list, and
+	// clearing unconditionally would throw away the list's own default (as
+	// CServerListCtrl's name sort).
 	if (!decoded.empty()) {
 		m_sort_orders.clear();
 		for (const CListColumnStore::CColPair &pair : decoded) {
@@ -394,10 +384,10 @@ void CMuleDataViewCtrl::LoadColumnSettings()
 		}
 	}
 
-	// A list that installs no default of its own (CSearchListCtrl) still has to
-	// end up with a sort chain: with none, CompareItems() answers 0 for every
-	// pair and nothing is ordered. CMuleListCtrl::LoadSettings() has always
-	// guaranteed at least one entry; keep that guarantee here.
+	// A list that installs no default of its own (CSearchListCtrl) still has to end
+	// up with a sort chain: with none, CompareItems() answers 0 for every pair and
+	// nothing is ordered. CMuleListCtrl::LoadSettings() guaranteed at least one
+	// entry; keep that guarantee.
 	if (m_sort_orders.empty()) {
 		ApplySorting(0, 0);
 	}
@@ -514,12 +504,11 @@ void CMuleDataViewCtrl::OnIdle(wxIdleEvent &event)
 		}
 	}
 
-	// Act when the drag ends, not on every step of it. Idle fires as long as
-	// the mouse moves, so a change on this tick means the pointer is still
-	// dragging and a further change is coming; the width that matters is the
-	// one it stops at. Firing per observed change instead ran a wxConfig write
-	// and, for a search list, a full column-sync across every other open tab
-	// for each pixel of travel -- the flicker and CPU spike of issue #1022.
+	// Act when the drag ends, not on every step. Idle fires as long as the mouse
+	// moves, so a change on this tick means the pointer is still dragging and the
+	// width that matters is the one it stops at. Firing per observed change ran a
+	// wxConfig write, and for a search list a full column-sync across every other
+	// open tab, for each pixel of travel (issue #1022).
 	if (changed) {
 		m_widthsSettling = true;
 	} else if (m_widthsSettling) {
@@ -532,10 +521,10 @@ void CMuleDataViewCtrl::OnIdle(wxIdleEvent &event)
 
 void CMuleDataViewCtrl::OnChar(wxKeyEvent &evt)
 {
-	// The list gets first refusal on every key. Doing this before the
-	// WXK_START test is deliberate: WXK_DELETE is 127, well below it, so a
-	// delete-key handler placed after that test would never see it, while
-	// WXK_NUMPAD_DELETE (above it) would be skipped to the backend instead.
+	// The list gets first refusal on every key. Before the WXK_START test on
+	// purpose: WXK_DELETE is 127, well below it, so a delete-key handler after that
+	// test would never see it, while WXK_NUMPAD_DELETE would be skipped to the
+	// backend instead.
 	if (OnListKey(evt)) {
 		return;
 	}
@@ -612,17 +601,15 @@ void CMuleDataViewCtrl::OnChar(wxKeyEvent &evt)
 void CMuleDataViewCtrl::OnContextMenuKey(wxContextMenuEvent &evt)
 {
 	if (evt.GetPosition() != wxDefaultPosition) {
-		// A real right-click, which every port turns into
-		// wxEVT_DATAVIEW_ITEM_CONTEXT_MENU by itself; this handler exists only
-		// for the keyboard-origin case (Shift+F10 / the Applications key on
-		// MSW and GTK, both measured to fire this separate, dataview-agnostic
-		// event instead -- see the review on amule-org/amule#877).
+		// A real right-click is turned into wxEVT_DATAVIEW_ITEM_CONTEXT_MENU by
+		// every port; this handler exists for the keyboard-origin case (Shift+F10 /
+		// the Applications key on MSW and GTK, both of which fire this separate,
+		// dataview-agnostic event instead).
 		//
-		// Skipping is load-bearing on macOS, where it is not merely tidy: that
-		// port raises the dataview event *from* this one, in
-		// wxDataViewCtrl::OnContextMenu() (osx/dataview_osx.cpp). Our handler
-		// runs first, being the derived class, so swallowing a mouse-origin
-		// event here would leave right-click with no context menu at all.
+		// Skipping is load-bearing on macOS, where that port raises the dataview
+		// event FROM this one in wxDataViewCtrl::OnContextMenu(). Our handler runs
+		// first, so swallowing a mouse-origin event would leave right-click with no
+		// context menu at all.
 		evt.Skip();
 		return;
 	}
@@ -634,13 +621,11 @@ void CMuleDataViewCtrl::RaiseItemContextMenu()
 {
 	const wxDataViewItem item = GetCurrentItem();
 	if (item.IsOk()) {
-		// GetItemRect() answers an empty rect for a row that is not on screen
-		// (the same limitation MoveByPage() documents above), and the menu
-		// would then open in the control's top-left corner rather than at the
-		// row it acts on -- reachable by clicking a row and scrolling away
-		// before pressing the key. Bringing it into view first also shows the
-		// user what the menu is about to apply to; it does not scroll when the
-		// row is already visible.
+		// GetItemRect() answers an empty rect for a row that is not on screen, and
+		// the menu would then open in the control's top-left corner rather than at
+		// the row it acts on -- reachable by clicking a row and scrolling away before
+		// pressing the key. Bringing it into view also shows what the menu applies
+		// to, and does not scroll when the row is already visible.
 		EnsureVisible(item);
 	}
 
@@ -654,32 +639,26 @@ void CMuleDataViewCtrl::OnKeyDown(wxKeyEvent &evt)
 {
 #ifdef __WXOSX__
 	// wx's Cocoa backend has no keyboard-triggered path to
-	// wxEVT_DATAVIEW_ITEM_CONTEXT_MENU. It does handle wxEVT_CONTEXT_MENU --
-	// that is how a right-click becomes a dataview event there, see
-	// OnContextMenuKey -- but nothing on this port ever raises that event
-	// from a keystroke, and there is no AXShowMenu implementation for any
-	// control on it
-	// (wxWidgets/wxWidgets#13010, open since 2011). VoiceOver's context-menu
-	// gesture (VO+Shift+M) performs AXShowMenu, so it never reaches wx here
-	// either (amule-org/amule#180). Ctrl+Return was tried as an alternative
-	// and rejected: NSOutlineView's keyDown: treats bare Return as "activate
-	// the row" before this handler ever sees it, Control held or not.
+	// wxEVT_DATAVIEW_ITEM_CONTEXT_MENU. It does handle wxEVT_CONTEXT_MENU -- that
+	// is how a right-click becomes a dataview event there -- but nothing on this
+	// port raises that event from a keystroke, and there is no AXShowMenu
+	// implementation for any control on it (wxWidgets/wxWidgets#13010, open since
+	// 2011), so VoiceOver's VO+Shift+M never reaches wx either. Ctrl+Return was
+	// tried and rejected: NSOutlineView's keyDown: treats bare Return as "activate
+	// the row" before this handler sees it, Control held or not.
 	if (evt.ShiftDown() && evt.GetKeyCode() == WXK_F10) {
 		RaiseItemContextMenu();
 		return;
 	}
 
-	// NSOutlineView scrolls the view for these keys without touching either
-	// the selection or the cursor, so on this platform they are ours to
-	// implement -- shifted, where GTK and MSW extend the selection and the
-	// native control does nothing at all, and unshifted too.
+	// NSOutlineView scrolls the view for these keys without touching the selection
+	// or the cursor, so on this platform they are ours to implement -- shifted,
+	// where GTK and MSW extend the selection, and unshifted too.
 	//
-	// Unshifted was left to the platform at first, on the grounds that
-	// scroll-without-select is the macOS convention. It reads as broken
-	// here: the cursor stays where it was, so the next arrow key jumps the
-	// view straight back to it, and the page key looks like it did nothing.
-	// Moving the cursor with the view is what the other two ports do, and it
-	// is what makes the following arrow key continue from what is on screen.
+	// Unshifted was left to the platform at first, scroll-without-select being the
+	// macOS convention, but it reads as broken: the cursor stays put, so the next
+	// arrow key jumps the view straight back and the page key looks like it did
+	// nothing. Moving the cursor with the view is what the other two ports do.
 	{
 		const bool extend = evt.ShiftDown();
 		switch (evt.GetKeyCode()) {
@@ -734,10 +713,9 @@ void CMuleDataViewCtrl::MoveByPage(PageMotion motion, bool extend)
 		target = last;
 		break;
 	default: {
-		// GetCountPerPage() is implemented by the native macOS backend;
-		// GetItemRect() is not a substitute, since it returns an empty rect
-		// for rows that aren't currently on screen and the resulting height
-		// of zero collapses a page to a single row.
+		// GetCountPerPage() is implemented by the native macOS backend. GetItemRect()
+		// is not a substitute: it returns an empty rect for rows not on screen, and
+		// the resulting zero height collapses a page to a single row.
 		int rows = GetCountPerPage();
 		if (rows <= 0) {
 			rows = 10;

--- a/src/MuleLogCtrl.cpp
+++ b/src/MuleLogCtrl.cpp
@@ -36,10 +36,10 @@ int Luminance(const wxColour &c)
 	return (c.Red() * 299 + c.Green() * 587 + c.Blue() * 114) / 1000;
 }
 
-// Whether two colours are far enough apart in brightness for text painted in
-// one over the other to be legible. The threshold is deliberately generous: a
-// false "too close" only forgoes the theme's exact foreground for a guaranteed-
-// readable black/white, which is always preferable to invisible text.
+// Whether two colours are far enough apart in brightness for text painted in one
+// over the other to be legible. The threshold is deliberately generous: a false
+// "too close" only forgoes the theme's exact foreground for a guaranteed-readable
+// black or white.
 bool Contrasts(const wxColour &a, const wxColour &b)
 {
 	return std::abs(Luminance(a) - Luminance(b)) >= 64;
@@ -67,34 +67,28 @@ CMuleLogCtrl::CMuleLogCtrl(wxWindow *parent,
 	for (int margin = 0; margin < 3; ++margin) {
 		SetMarginWidth(margin, 0);
 	}
-	// Zeroing the numbered margins above also removes the only inset Scintilla
-	// had, so text rendered hard against the control's frame -- most visible
-	// where the theme draws a tight, high-contrast border (issue #702). These
-	// are the text-area margins, a separate concept from the numbered margins,
-	// so they restore the padding without bringing the code-editor gutters
-	// back. Scintilla draws its own text area, so this is not theme- or
-	// platform-specific; DIP-scaled so the gap keeps its size on HiDPI.
-	// Scintilla's own default here is 1px (ViewStyle::Init), which is what
-	// made the text look flush -- so this has to be visibly larger than the
-	// default to be worth anything, not a nudge above it.
+	// Zeroing the numbered margins above also removes the only inset Scintilla had,
+	// so text rendered hard against the control's frame (issue #702). These are the
+	// text-area margins, a separate concept, so they restore the padding without
+	// bringing the code-editor gutters back. DIP-scaled so the gap keeps its size on
+	// HiDPI, and visibly larger than Scintilla's own 1px default, which is what made
+	// the text look flush.
 	const int textMargin = FromDIP(5);
 	SetMarginLeft(textMargin);
 	SetMarginRight(textMargin);
 
-	// Scintilla has no vertical counterpart to the text-area margins, so the
-	// first line otherwise sits directly on the frame. extraAscent feeds
-	// lineHeight (ViewStyle::Refresh: maxAscent += extraAscent), so this is
-	// line spacing rather than a one-off top gap -- which is what we want
-	// here: the log tails to the bottom, so a fixed band at the viewport top
-	// would only show above a partially scrolled line.
+	// Scintilla has no vertical counterpart to the text-area margins, so the first
+	// line otherwise sits directly on the frame. extraAscent feeds lineHeight, so
+	// this is line spacing rather than a one-off top gap -- which is what we want:
+	// the log tails to the bottom, so a fixed band at the viewport top would only
+	// show above a partially scrolled line.
 	SetExtraAscent(FromDIP(2));
 
-	// No caret: this pane is read-only, so there is no insertion point for one
-	// to mark. Scintilla draws it regardless, at the very left of the text
-	// area -- which went unnoticed while the text also started there, but once
-	// the margins above inset the text the caret was left sitting on the frame
-	// (issue #702). Selection highlighting is independent of caret visibility,
-	// so click-drag and Ctrl+C are unaffected.
+	// No caret: this pane is read-only, so there is no insertion point for one to
+	// mark. Scintilla draws it regardless, at the very left of the text area, which
+	// went unnoticed while the text started there too -- but once the margins inset
+	// the text the caret was left sitting on the frame (issue #702). Selection
+	// highlighting is independent of caret visibility.
 	SetCaretStyle(wxSTC_CARETSTYLE_INVISIBLE);
 
 	// Word-wrap long lines, as the old wxTE_RICH2 pane did, so nothing is clipped
@@ -118,12 +112,11 @@ void CMuleLogCtrl::SetupStyles()
 	wxColour fg = wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOWTEXT);
 	const wxColour bg = wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOW);
 
-	// On macOS the window/text system colours are appearance-aware and resolved
-	// to RGB at call time; in some configurations (seen with a self-built wx 3.3
-	// on macOS -- issue #569) they come back with too little contrast, which
-	// paints the whole log invisible. Windows/GTK return static, well-contrasted
-	// values and are unaffected. When the pair is unreadable, keep the theme's
-	// background but force a legible foreground from its brightness.
+	// On macOS the window/text system colours are appearance-aware and resolved to
+	// RGB at call time, and in some configurations come back with too little
+	// contrast, painting the whole log invisible (issue #569). Windows and GTK
+	// return static, well-contrasted values. When the pair is unreadable, keep the
+	// theme's background but force a legible foreground from its brightness.
 	if (!Contrasts(fg, bg)) {
 		fg = Luminance(bg) < 128 ? *wxWHITE : *wxBLACK;
 	}
@@ -146,11 +139,11 @@ void CMuleLogCtrl::OnSysColourChanged(wxSysColourChangedEvent &event)
 
 bool CMuleLogCtrl::AtBottom()
 {
-	// Compare in *display* lines: GetFirstVisibleLine()/LinesOnScreen() count
-	// wrapped rows, while GetLineCount() counts document lines, so with wrapping
-	// on the two must be reconciled. The total display-line count is the first
-	// display row of the last doc line plus how many rows it wraps to. Generous
-	// by one so "sitting at the end" always re-tails on append.
+	// Compare in DISPLAY lines: GetFirstVisibleLine()/LinesOnScreen() count wrapped
+	// rows while GetLineCount() counts document lines, so with wrapping on the two
+	// must be reconciled. The total is the first display row of the last doc line
+	// plus how many rows it wraps to, generous by one so "sitting at the end"
+	// always re-tails on append.
 	const int lastDoc = GetLineCount() - 1;
 	const int displayLines = VisibleFromDocLine(lastDoc) + WrapCount(lastDoc);
 	return GetFirstVisibleLine() + LinesOnScreen() >= displayLines - 1;
@@ -158,13 +151,12 @@ bool CMuleLogCtrl::AtBottom()
 
 void CMuleLogCtrl::ScrollToBottom()
 {
-	// Request only -- OnInternalIdle() is the sole scroller. Keeping every scroll
-	// in one place stops the batch/live tail-scroll from racing the idle
-	// re-scroll loop: that loop tells a manual scroll from an append by watching
-	// the first-visible line, and a direct ScrollToEnd() here would move it and
-	// be misread as the user scrolling -- which aborted the catch-up mid-load, so
-	// switching to the log while it was still replaying landed short (issue #547,
-	// @ghysler). Deferring also naturally waits until the pane is on screen.
+	// Request only -- OnInternalIdle() is the sole scroller. Keeping every scroll in
+	// one place stops the tail-scroll from racing the idle re-scroll loop: that loop
+	// tells a manual scroll from an append by watching the first-visible line, and a
+	// direct ScrollToEnd() here would move it and be misread as the user scrolling,
+	// aborting the catch-up mid-load (issue #547). Deferring also waits until the
+	// pane is on screen.
 	if (!IsShownOnScreen()) {
 		// No reliable first-visible baseline while hidden; let the first scroll
 		// after the pane appears run unconditionally.
@@ -177,23 +169,20 @@ void CMuleLogCtrl::OnInternalIdle()
 {
 	wxStyledTextCtrl::OnInternalIdle();
 
-	// Sole scroller for every tail-scroll (live line, batch, or deferred while
-	// hidden). IsShownOnScreen() is only evaluated while a scroll is pending, so
-	// the common idle path stays a single bool test; a scroll requested while the
-	// pane was hidden simply waits here until it is shown.
+	// Sole scroller for every tail-scroll: live line, batch, or deferred while
+	// hidden. IsShownOnScreen() is evaluated only while a scroll is pending, so the
+	// common idle path stays a single bool test.
 	if (!m_scrollPending || !IsShownOnScreen()) {
 		return;
 	}
 
-	// With word-wrap on, Scintilla lays out wrapped lines incrementally over
-	// several idles, so a single ScrollToEnd() the moment the pane appears (or
-	// while the log is still replaying) lands short -- against a display-line
-	// count that does not yet include the still-unwrapped tail (issue #547,
-	// reported by @ghysler with wrapped lines on a narrow window). Re-scroll each
-	// idle until the position stops moving (wrap has settled at the true bottom).
-	// Appends do not move the first-visible line, so if it has moved away from
-	// where our last auto-scroll left it the user scrolled -- bail and reset, so
-	// a manual scroll is never fought and a later return to the bottom re-tails.
+	// With word-wrap on, Scintilla lays out wrapped lines incrementally over several
+	// idles, so a single ScrollToEnd() the moment the pane appears lands short,
+	// against a display-line count that does not yet include the unwrapped tail
+	// (issue #547). Re-scroll each idle until the position stops moving. Appends do
+	// not move the first-visible line, so if it has moved away from where our last
+	// auto-scroll left it the user scrolled -- bail and reset, so a manual scroll is
+	// never fought and a later return to the bottom re-tails.
 	if (m_lastAutoScrollLine != -1 && GetFirstVisibleLine() != m_lastAutoScrollLine) {
 		m_scrollPending = false;
 		m_lastAutoScrollLine = -1;

--- a/src/MuleNotebook.cpp
+++ b/src/MuleNotebook.cpp
@@ -61,7 +61,6 @@ CMuleNotebook::CMuleNotebook(wxWindow *parent,
 
 CMuleNotebook::~CMuleNotebook()
 {
-	// Ensure that all notifications gets sent
 	DeleteAllPages();
 }
 
@@ -71,15 +70,12 @@ bool CMuleNotebook::DeletePage(int nPage)
 		false,
 		"Trying to delete invalid page-index in CMuleNotebook::DeletePage");
 
-	// Send out close event
 	wxNotebookEvent evt(wxEVT_COMMAND_MULENOTEBOOK_PAGE_CLOSING, GetId(), nPage);
 	evt.SetEventObject(this);
 	ProcessEvent(evt);
 
-	// and finally remove the actual page
 	bool result = wxNotebook::DeletePage(nPage);
 
-	// Ensure a valid selection
 	if (GetPageCount() && (int)GetSelection() >= (int)GetPageCount()) {
 		SetSelection(GetPageCount() - 1);
 	}
@@ -98,7 +94,6 @@ bool CMuleNotebook::DeletePage(int nPage)
 		event.SetEventObject(this);
 		ProcessEvent(event);
 	} else {
-		// Send an event when no pages are left open
 		wxNotebookEvent event(wxEVT_COMMAND_MULENOTEBOOK_ALL_PAGES_CLOSED, GetId());
 		event.SetEventObject(this);
 		ProcessEvent(event);
@@ -134,7 +129,6 @@ void CMuleNotebook::SetPopupHandler(wxWindow *widget)
 // #warning wxMac does not support selection by right-clicking on tabs!
 void CMuleNotebook::OnRMButton(wxMouseEvent &event)
 {
-	// Cases where we shouldn't be showing a popup-menu.
 	if (!GetPageCount() || !m_popup_enable) {
 		event.Skip();
 		return;
@@ -151,11 +145,9 @@ void CMuleNotebook::OnRMButton(wxMouseEvent &event)
 		return;
 	}
 
-	// Should we send the event to a specific widget?
 	if (m_popup_widget) {
 		wxMouseEvent evt = event;
 
-		// Map the coordinates onto the parent
 		wxPoint point = evt.GetPosition();
 		point = ClientToScreen(point);
 		point = m_popup_widget->ScreenToClient(point);

--- a/src/MuleTrayIcon.cpp
+++ b/src/MuleTrayIcon.cpp
@@ -62,14 +62,11 @@ void CMuleTrayIcon::DoConnectDisconnect()
 
 void CMuleTrayIcon::DoShowHide()
 {
-	// Treat an iconized window as not-visible: minimized-to-Dock on
-	// Mac, taskbar-iconized on Windows, and Iconize() on Linux all
-	// keep IsShown()==true even though the user can't actually see
-	// the frame. Acting on plain IsShown() would make the tray menu
-	// offer "Hide aMule" in those states, and clicking would make
-	// the window vanish entirely (no Dock thumbnail / no taskbar
-	// entry) — destructive UX. Treat iconized as "not visible" so
-	// the menu offers "Show aMule" and clicking restores the frame.
+	// Treat an iconized window as not-visible: minimized-to-Dock on Mac,
+	// taskbar-iconized on Windows and Iconize() on Linux all keep IsShown()==true
+	// even though the user cannot see the frame. On plain IsShown() the menu would
+	// offer "Hide aMule" in those states, and clicking would make the window
+	// vanish entirely, with no Dock thumbnail and no taskbar entry.
 	const bool visible = theApp->amuledlg->IsVisibleToUser();
 	if (visible) {
 		theApp->amuledlg->HideToTray();
@@ -77,9 +74,8 @@ void CMuleTrayIcon::DoShowHide()
 		theApp->amuledlg->RestoreMainWindow();
 	}
 #ifdef WITH_LIBAYATANA_APPINDICATOR
-	// Refresh so the menu label flips to "Hide aMule" / "Show aMule"
-	// to match the new window state. SNI menu is static between
-	// state changes — without this poke the label would lag a click.
+	// The SNI menu is static between state changes, so without this poke the
+	// "Hide aMule" / "Show aMule" label would lag a click behind.
 	RebuildMenu();
 #endif
 }
@@ -88,16 +84,13 @@ void CMuleTrayIcon::DoShow()
 {
 	theApp->amuledlg->RestoreMainWindow();
 #ifdef WITH_LIBAYATANA_APPINDICATOR
-	// Ask the compositor to bring our window forward. The timestamp
-	// matters on Wayland: GNOME Shell's focus-stealing-prevention
-	// treats GDK_CURRENT_TIME (0) as suspicious and shows an
-	// "app is ready" notification instead of granting focus. Pull
-	// the timestamp of the actual menu-click event via
-	// gtk_get_current_event_time() so the compositor sees this as
-	// a fresh user gesture and honours the request directly. If
-	// no event is currently being processed (returns
-	// GDK_CURRENT_TIME) we still pass it through — the worst case
-	// is the focus-denial notification, which is itself clickable.
+	// Ask the compositor to bring our window forward. The timestamp matters on
+	// Wayland: GNOME Shell's focus-stealing prevention treats GDK_CURRENT_TIME (0)
+	// as suspicious and shows an "app is ready" notification instead of granting
+	// focus, so pull the timestamp of the actual menu-click event and the request
+	// reads as a fresh user gesture. With no event being processed the call
+	// returns GDK_CURRENT_TIME and we pass it through anyway -- worst case is that
+	// notification, which is itself clickable.
 	if (GtkWidget *gtkw = static_cast<GtkWidget *>(theApp->amuledlg->GetHandle())) {
 		gtk_window_present_with_time(GTK_WINDOW(gtkw), gtk_get_current_event_time());
 	}
@@ -116,9 +109,8 @@ void CMuleTrayIcon::DoHide()
 void CMuleTrayIcon::DoExit()
 {
 	if (theApp->amuledlg->IsEnabled()) {
-		// Mark as quitting so OnClose skips HideOnClose, but still
-		// pass force=false (Close()) so the confirm-exit prompt can
-		// run if enabled. If the user answers No there, the prompt
+		// Mark as quitting so OnClose skips HideOnClose, but still pass
+		// force=false so the confirm-exit prompt can run; answering No there
 		// vetoes and clears the IsQuitting flag.
 		theApp->SetQuitting();
 		theApp->amuledlg->Close();
@@ -128,9 +120,8 @@ void CMuleTrayIcon::DoExit()
 void CMuleTrayIcon::DoSetUploadLimit(long kBytesPerSec)
 {
 	// uint32, not uint16: the preference, its setter and its getter are all
-	// uint32, and a 16-bit cast here silently wrapped anything above 65535
-	// KiB/s. A preset of 125000 applied as 59464 -- under half the figure on
-	// the menu item the user clicked, with nothing logged either side.
+	// uint32, and a 16-bit cast here silently wrapped anything above 65535 KiB/s
+	// -- a preset of 125000 applied as 59464, with nothing logged either side.
 	thePrefs::SetMaxUpload(kBytesPerSec < 0 ? UNLIMITED : (uint32)kBytesPerSec);
 #ifdef CLIENT_GUI
 	theApp->glob_prefs->SendToRemote();
@@ -146,27 +137,21 @@ void CMuleTrayIcon::DoSetDownloadLimit(long kBytesPerSec)
 #endif
 }
 
-// The limit presets both tray backends offer, and their labels.
-//
-// One ladder, one set of strings. The appindicator backend builds GtkWidgets
-// and the wx backend builds a wxMenu, but what goes in them is identical, and
-// it used to be written out twice -- which is how the GTK side ended up
-// showing "Unlimited" and "KiB/s" untranslated while the wx side translated
-// both.
+// The limit presets both tray backends offer, and their labels. The
+// appindicator backend builds GtkWidgets and the wx backend a wxMenu, but what
+// goes in them is identical, and writing it out twice is how the GTK side ended
+// up showing "Unlimited" and "KiB/s" untranslated.
 //
 // The presets are fractions of the configured line capacity rather than of the
-// current limit. Scaling from the limit would mean the menu could only ever
-// lower it: with a 50 KiB/s cap in force, every entry would be at or below 50
-// and there would be no way back up. Capacity is what the line can do, so
-// fifths of it span throttled to full speed in both directions.
+// current limit: scaling from the limit would mean the menu could only ever
+// lower it, with no way back up from a throttled state.
 namespace
 {
-// Divisors applied to the line capacity, descending. Not fifths: an even
-// ladder can only ever cover one order of magnitude, so on a fast line every
-// entry lands high and there is no way to throttle hard from the tray, while
-// on a slow one they bunch together near the top. Spacing them out covers
-// full speed down to a heavy throttle from the same capacity, which is what
-// makes one setting work for a 4 Mbit line and a 200 Mbit one alike.
+// Divisors applied to the line capacity, descending. Not fifths: an even ladder
+// covers only one order of magnitude, so on a fast line every entry lands high
+// and there is no way to throttle hard from the tray, while on a slow one they
+// bunch near the top. Spread out, one setting works for a 4 Mbit line and a
+// 200 Mbit one alike.
 const unsigned int TRAY_SPEED_DIVISORS[] = { 1, 2, 4, 10, 50 };
 const int TRAY_SPEED_PRESETS = (int)(sizeof(TRAY_SPEED_DIVISORS) / sizeof(TRAY_SPEED_DIVISORS[0]));
 
@@ -208,12 +193,11 @@ wxString TraySpeedLabel(unsigned int kBytesPerSec)
 // ---------------------------------------------------------------------
 //  StatusNotifierItem (SNI) backend via libayatana-appindicator3.
 //
-//  This is what GNOME Shell with the AppIndicators extension (Ubuntu's
-//  default), KDE Plasma, Sway/Hyprland with waybar, and most other
-//  modern Linux desktops actually render. The legacy GtkStatusIcon API
-//  that wxTaskBarIcon talks was dropped in GNOME 3.26 (2017) and never
-//  implemented in wlroots-based compositors, so without this backend
-//  the tray icon is silently invisible on most current distros.
+//  What GNOME Shell with the AppIndicators extension, KDE Plasma and
+//  wlroots compositors with waybar actually render. The legacy
+//  GtkStatusIcon API wxTaskBarIcon talks was dropped in GNOME 3.26 and
+//  never implemented on wlroots, so without this backend the tray icon
+//  is silently invisible on most current distros.
 // ---------------------------------------------------------------------
 
 #include <libayatana-appindicator/app-indicator.h>
@@ -222,9 +206,9 @@ wxString TraySpeedLabel(unsigned int kBytesPerSec)
 namespace
 {
 
-// All menu items reach the C++ side through this single callback. The
-// item carries two int "action" + "arg" fields via g_object_set_data,
-// so we don't need a separate static function per menu entry.
+// All menu items reach the C++ side through this single callback: the item
+// carries int "action" and "arg" fields via g_object_set_data, so no separate
+// static function per entry is needed.
 enum TrayAction
 {
 	TRAY_ACTION_CONNECT_DISCONNECT = 1,
@@ -236,12 +220,10 @@ enum TrayAction
 	TRAY_ACTION_SET_DOWNLOAD_LIMIT,
 };
 
-// Left-click on the indicator. SNI hosts (KDE Plasma, and GNOME via the
-// AppIndicator extension) call org.kde.StatusNotifierItem.Activate for the
-// primary button; libayatana-appindicator forwards that as this signal.
-//
-// Signature comes from AppIndicatorClass::activate_event: the x/y of the
-// click, which we do not need -- the window goes wherever it already was.
+// Left-click on the indicator. SNI hosts call
+// org.kde.StatusNotifierItem.Activate for the primary button, and
+// libayatana-appindicator forwards it as this signal. The x/y of the click come
+// from AppIndicatorClass::activate_event and are not needed here.
 void on_indicator_activate(AppIndicator *, gint, gint, gpointer user_data)
 {
 	CMuleTrayIcon *tray = static_cast<CMuleTrayIcon *>(user_data);
@@ -307,10 +289,9 @@ GtkWidget *make_speed_submenu(uint32 max_speed, TrayAction action, gpointer user
 	return submenu;
 }
 
-// Append a non-clickable "info" label to the menu. SNI menus support
-// disabled items, but rendering varies between desktops — KDE shows
-// them grey, GNOME-with-AppIndicators shows them in the menu's normal
-// style. Either way they're not interactive.
+// Append a non-clickable "info" label. SNI menus support disabled items, though
+// rendering varies between desktops -- KDE greys them, GNOME shows them in the
+// normal style. Either way they are not interactive.
 void append_info(GtkWidget *menu, const wxString &text)
 {
 	GtkWidget *item = gtk_menu_item_new_with_label((const char *)text.utf8_str());
@@ -325,55 +306,44 @@ CMuleTrayIcon::CMuleTrayIcon()
 , m_menu(nullptr)
 , m_lastIconState(-1)
 {
-	// `org.amule.aMule` is both the AppStream/.desktop id and the icon
-	// name installed under share/icons/hicolor/*/apps/. AppIndicator3
-	// looks the icon up via the standard XDG icon-theme path.
+	// `org.amule.aMule` is both the AppStream/.desktop id and the icon name
+	// installed under share/icons/hicolor/*/apps/; AppIndicator3 looks it up via
+	// the standard XDG icon-theme path.
 	//
-	// AyatanaIndicators upstream split the library into
-	// libayatana-appindicator-glib (GLib-only, GMenu-based, no GTK
-	// dep) and started emitting a deprecation warning when the
-	// GTK-based libayatana-appindicator3-0.1 is loaded. Migrating
-	// to the new library is tracked as future work — -glib isn't
-	// yet packaged on Ubuntu / Fedora / openSUSE / Debian, so
-	// switching today would lock out every major distro. The
-	// warning is harmless console noise; silence it locally so a
-	// project-wide -Werror=deprecated-declarations stays useful.
+	// AyatanaIndicators split the library into libayatana-appindicator-glib and
+	// started deprecating the GTK-based libayatana-appindicator3-0.1. Migrating is
+	// future work: -glib is not yet packaged on Ubuntu, Fedora, openSUSE or
+	// Debian, so switching today would lock out every major distro. Silence the
+	// warning locally so a project-wide -Werror=deprecated-declarations stays
+	// useful.
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 	m_indicator = app_indicator_new(
 		"org.amule.aMule", "org.amule.aMule", APP_INDICATOR_CATEGORY_APPLICATION_STATUS);
 #pragma GCC diagnostic pop
 
-	// ACTIVE = visible. The user already opted in by enabling the tray
-	// icon in Preferences, so showing it immediately is the expected
-	// behaviour; SetTrayIcon below only updates the menu's
-	// Connect/Disconnect label and never re-hides the indicator.
-	// (We deliberately don't use APP_INDICATOR_STATUS_ATTENTION for
-	// the disconnected state — that requires a separately-set
-	// attention icon via app_indicator_set_attention_icon_full(), and
-	// without it some SNI hosts render the indicator as invisible.)
+	// ACTIVE = visible: the user already opted in by enabling the tray icon, and
+	// SetTrayIcon below only updates the menu label, never re-hiding the
+	// indicator. APP_INDICATOR_STATUS_ATTENTION is deliberately not used for the
+	// disconnected state -- it needs a separately-set attention icon, and without
+	// one some SNI hosts render the indicator as invisible.
 	app_indicator_set_status(m_indicator, APP_INDICATOR_STATUS_ACTIVE);
 	app_indicator_set_title(m_indicator, "aMule");
 
-	// Left-click opens the main window instead of the menu, where the
-	// installed library can tell us about it. libayatana-appindicator only
-	// grew an Activate handler in 0.6.0; before that the primary click was
-	// not exposed at all, which is why the tray has behaved this way on Linux
-	// since the SNI backend landed (discussion #1115).
+	// Left-click opens the main window instead of the menu, where the installed
+	// library can tell us about it. libayatana-appindicator only grew an Activate
+	// handler in 0.6.0; before that the primary click was not exposed at all.
 	//
-	// Looked up at RUNTIME rather than behind a build-time version check,
-	// because the two genuinely differ: a distro may ship a newer library
-	// than we built against, and our AppImage and Flatpak bundle their own.
-	// On an older library the lookup returns 0, nothing is connected, and the
-	// panel keeps opening the menu exactly as it does today. The library
-	// handles that direction too, answering the Activate D-Bus call with an
-	// error when no handler is connected so the host falls back to the menu.
-	// Nothing is logged in that case: a debug line compiles out of release
-	// builds, which is precisely where this would matter.
+	// Looked up at RUNTIME rather than behind a build-time version check, because
+	// the two genuinely differ: a distro may ship a newer library than we built
+	// against, and our AppImage and Flatpak bundle their own. On an older library
+	// the lookup returns 0, nothing is connected, and the panel keeps opening the
+	// menu; the library answers the Activate D-Bus call with an error so the host
+	// falls back to it.
 	//
 	// APP_INDICATOR_TYPE, not G_OBJECT_TYPE(m_indicator): the latter is a raw
-	// dereference and app_indicator_new can return NULL. The GObject setters
-	// above only warn on NULL, so this must not be the line that crashes.
+	// dereference and app_indicator_new can return NULL. The GObject setters above
+	// only warn on NULL, so this must not be the line that crashes.
 	g_type_class_ref(APP_INDICATOR_TYPE);
 	if (m_indicator && g_signal_lookup("activate", APP_INDICATOR_TYPE)) {
 		g_signal_connect(m_indicator, "activate", G_CALLBACK(on_indicator_activate), this);
@@ -388,57 +358,46 @@ CMuleTrayIcon::~CMuleTrayIcon()
 		g_object_unref(m_indicator);
 		m_indicator = nullptr;
 	}
-	// m_menu is owned by the indicator (set_menu took the floating ref)
-	// so we don't unref it explicitly.
+	// m_menu is owned by the indicator (set_menu took the floating ref).
 }
 
 void CMuleTrayIcon::SetTrayIcon(int Icon, uint32 /*percent*/)
 {
-	// SNI doesn't support per-frame icon overlays — the percent bar
-	// from the legacy backend is dropped on this path. We reflect the
-	// connection state purely through the menu (the Connect /
-	// Disconnect item label flips), not via the indicator's status,
-	// because flipping ACTIVE↔ATTENTION can hide the indicator on
-	// some hosts when no attention icon is configured.
+	// SNI has no per-frame icon overlays, so the legacy backend's percent bar is
+	// dropped here. Connection state shows through the menu label rather than the
+	// indicator's status, because flipping ACTIVE/ATTENTION can hide the indicator
+	// on hosts with no attention icon configured.
 	if (Icon != m_lastIconState) {
 		m_lastIconState = Icon;
-		// Rebuild so Connect/Disconnect label reflects current state.
 		RebuildMenu();
 	}
 }
 
 void CMuleTrayIcon::SetTrayToolTip(const wxString &Tip)
 {
-	// SNI doesn't surface tooltips on hover (compositors disagree on
-	// whether to render them). Use it as the accessible title — screen
-	// readers and KDE's hover popup pick it up.
+	// SNI does not surface tooltips on hover (compositors disagree on rendering
+	// them), so use it as the accessible title: screen readers and KDE's hover
+	// popup pick it up.
 	app_indicator_set_title(m_indicator, (const char *)Tip.utf8_str());
 }
 
 void CMuleTrayIcon::RebuildMenu()
 {
-	// Static layout, rebuilt only on connection-state changes
-	// (driven by SetTrayIcon below). app_indicator_set_menu posts a
-	// dbusmenu LayoutUpdated D-Bus signal which some SNI hosts react
-	// to with a brief icon redraw — so refreshing on a 2 s timer
-	// would visibly flicker. Keeping the menu lean (action items
-	// only, no live stats) means we rebuild only when state actually
-	// changes, eliminating the flicker. Live values like download /
-	// upload speed are visible in the main aMule window.
+	// Static layout, rebuilt only on connection-state changes.
+	// app_indicator_set_menu posts a dbusmenu LayoutUpdated signal that some SNI
+	// hosts answer with a brief icon redraw, so a 2 s refresh timer would visibly
+	// flicker. Keeping the menu to action items only means it rebuilds only when
+	// state changes; live speeds are in the main window.
 	GtkWidget *menu = gtk_menu_new();
 
-	// ---- Version banner ------------------------------------------
 	append_info(menu, MOD_VERSION_LONG);
 
 	gtk_menu_shell_append(GTK_MENU_SHELL(menu), gtk_separator_menu_item_new());
 
-	// Show / Hide. On a Wayland session we can't reliably detect that
-	// the window has been iconized by the OS minimize button (xdg-shell
-	// doesn't deliver the event), so a single toggle entry would mis-
-	// label itself in that state. Show two deterministic entries
-	// instead — click Show to bring the window back, click Hide to
-	// hide it. On X11 / macOS / Windows the toggle is reliable, so
-	// the single label-aware entry stays.
+	// Show / Hide. On Wayland we cannot detect that the window was iconized by
+	// the OS minimize button (xdg-shell delivers no event), so a single toggle
+	// entry would mislabel itself there; show two deterministic entries instead.
+	// Elsewhere the toggle is reliable and the label-aware entry stays.
 	if (CamuleAppCommon::IsWaylandSession()) {
 		gtk_menu_shell_append(GTK_MENU_SHELL(menu),
 			make_action_item((const char *)wxString(_("Show aMule")).utf8_str(),
@@ -462,10 +421,9 @@ void CMuleTrayIcon::RebuildMenu()
 	gtk_menu_shell_append(GTK_MENU_SHELL(menu), gtk_separator_menu_item_new());
 
 	// ---- Client information submenu ------------------------------
-	// Snapshot at the moment of the last connection-state change.
-	// Skips truly-live fields (uptime, totals, queued clients) so the
-	// menu can stay static between state changes — putting those in
-	// would force a periodic rebuild and bring back the flicker.
+	// Snapshot at the last connection-state change. Truly live fields (uptime,
+	// totals, queued clients) are skipped so the menu can stay static; including
+	// them would force a periodic rebuild and bring back the flicker.
 	{
 		GtkWidget *sub = gtk_menu_new();
 
@@ -533,8 +491,6 @@ void CMuleTrayIcon::RebuildMenu()
 
 	gtk_menu_shell_append(GTK_MENU_SHELL(menu), gtk_separator_menu_item_new());
 
-	// ---- Action items --------------------------------------------
-
 	// Upload limit submenu
 	{
 		uint32 max_ul = thePrefs::GetMaxGraphUploadRate();
@@ -571,9 +527,8 @@ void CMuleTrayIcon::RebuildMenu()
 
 	gtk_widget_show_all(menu);
 
-	// app_indicator_set_menu sinks the floating ref and unrefs any
-	// previously-set menu, so we can replace it on every rebuild
-	// without leaking.
+	// app_indicator_set_menu sinks the floating ref and unrefs any previous menu,
+	// so rebuilding does not leak.
 	app_indicator_set_menu(m_indicator, GTK_MENU(menu));
 	m_menu = menu;
 }
@@ -581,10 +536,10 @@ void CMuleTrayIcon::RebuildMenu()
 #else // !WITH_LIBAYATANA_APPINDICATOR
 
 // ---------------------------------------------------------------------
-//  Legacy wxTaskBarIcon backend. Works correctly on Windows
-//  (NOTIFYICONDATA), macOS (NSStatusItem), and on X11 desktops that
-//  still consume GtkStatusIcon. On modern Wayland desktops the icon
-//  goes nowhere — build with libayatana-appindicator3 to fix that.
+//  Legacy wxTaskBarIcon backend. Correct on Windows (NOTIFYICONDATA),
+//  macOS (NSStatusItem) and X11 desktops that still consume
+//  GtkStatusIcon; on Wayland the icon goes nowhere, which is what the
+//  libayatana-appindicator3 backend above is for.
 // ---------------------------------------------------------------------
 
 #include <algorithm> // Needed for std::max / std::min
@@ -601,10 +556,9 @@ void CMuleTrayIcon::RebuildMenu()
 
 wxBEGIN_EVENT_TABLE(CMuleTrayIcon, wxTaskBarIcon)
 #ifdef __WINDOWS__
-	// Windows convention: single-left click on the tray icon toggles
-	// the primary action (show/hide the main window). NSStatusItem
-	// on macOS opens the menu on single-click via its own default,
-	// so leave that path alone.
+	// Windows convention: a single left click toggles show/hide of the main
+	// window. NSStatusItem opens the menu on single-click by its own default, so
+	// that path is left alone.
 	EVT_TASKBAR_LEFT_UP(CMuleTrayIcon::SwitchShow)
 #endif
 	EVT_TASKBAR_LEFT_DCLICK(CMuleTrayIcon::SwitchShow)
@@ -747,24 +701,20 @@ void CMuleTrayIcon::SetTrayIcon(int Icon, uint32 percent)
 	Old_Icon = Icon;
 	Old_SpeedSize = barHeight;
 
-	// Always compose onto a copy of the untouched artwork. Composing onto the
-	// icon we produced last time loses the transparency a little more each
-	// round: converting an icon back to a bitmap returns its transparent
-	// pixels as black, so a rising transfer rate -- which never takes the
-	// rebuild-from-scratch path -- ends up with a solid black background.
+	// Always compose onto a copy of the untouched artwork. Composing onto the icon
+	// we produced last time loses transparency a little more each round -- an icon
+	// converted back to a bitmap returns its transparent pixels as black, so a
+	// rising transfer rate ends up with a solid black background.
 	//
 	// The bar is written into the image rather than drawn with a wxDC because
-	// wxMSW's DC writes the colour channels and leaves alpha alone: a bar
-	// drawn over transparent pixels keeps alpha 0 and never appears, which is
-	// what happens to any artwork that carries its own alpha channel.
+	// wxMSW's DC writes the colour channels and leaves alpha alone: a bar drawn
+	// over transparent pixels keeps alpha 0 and never appears.
 	wxImage composed = base.Copy();
 	if (barHeight > 0) {
 		const wxColour barColour = CStatisticsDlg::getColors(11);
-		// Two pixels wide, in the last two columns, growing from the bottom.
-		// It used to sit two columns further in, which the artwork of the day
-		// left clear. Newer artwork fills more of its canvas, so the bar landed
-		// on the drawing instead of beside it; the outermost columns are the
-		// ones an icon is least likely to use.
+		// Two pixels wide, in the last two columns, growing from the bottom. It
+		// used to sit two columns further in, which newer artwork fills, so the bar
+		// landed on the drawing instead of beside it.
 		const int barLeft = std::max(0, width - 2);
 		const int barRight = std::min(width, barLeft + 2);
 		for (int y = height - barHeight; y < height; ++y) {
@@ -791,7 +741,6 @@ void CMuleTrayIcon::SetTrayToolTip(const wxString &Tip)
 
 void CMuleTrayIcon::UpdateTray()
 {
-	// Icon update and Tip update
 #ifndef __WXCOCOA__
 	if (IsOk())
 #endif
@@ -809,11 +758,9 @@ wxMenu *CMuleTrayIcon::CreatePopupMenu()
 	bool showMBpsUp = (MBpsUp >= 1);
 	bool showMBpsDown = (MBpsDown >= 1);
 
-	// Dynamically creates the menu to show the user.
 	wxMenu *traymenu = new wxMenu();
 	traymenu->SetTitle(_("aMule Tray Menu"));
 
-	// Build the Top string name
 	wxString label = MOD_VERSION_LONG;
 	traymenu->Append(TRAY_MENU_INFO, label);
 	traymenu->AppendSeparator();
@@ -825,12 +772,10 @@ wxMenu *CMuleTrayIcon::CreatePopupMenu()
 		traymenu->Append(TRAY_MENU_SHOW, _("Show aMule"));
 	}
 
-	// Separator
 	traymenu->AppendSeparator();
 
 	label = wxString(_("Speed limits:")) + " ";
 
-	// Check for upload limits
 	unsigned int max_upload = thePrefs::GetMaxUpload();
 	if (max_upload == UNLIMITED) {
 		label += _("UL: None");
@@ -839,7 +784,6 @@ wxMenu *CMuleTrayIcon::CreatePopupMenu()
 	}
 	label += ", ";
 
-	// Check for download limits
 	unsigned int max_download = thePrefs::GetMaxDownload();
 	if (max_download == UNLIMITED) {
 		label += _("DL: None");
@@ -973,7 +917,6 @@ wxMenu *CMuleTrayIcon::CreatePopupMenu()
 
 	traymenu->Append(TRAY_MENU_CLIENTINFO, ClientInfoMenu->GetTitle(), ClientInfoMenu);
 
-	// Separator
 	traymenu->AppendSeparator();
 
 	// Upload Speed sub-menu
@@ -984,7 +927,6 @@ wxMenu *CMuleTrayIcon::CreatePopupMenu()
 	wxMenu *DownloadSpeedMenu = new wxMenu();
 	DownloadSpeedMenu->SetTitle(_("Download limit"));
 
-	// Upload Speed sub-menu
 	{
 		UploadSpeedMenu->Append(UPLOAD_ITEM1, _("Unlimited"));
 
@@ -996,7 +938,6 @@ wxMenu *CMuleTrayIcon::CreatePopupMenu()
 	}
 	traymenu->Append(0, UploadSpeedMenu->GetTitle(), UploadSpeedMenu);
 
-	// Download Speed sub-menu
 	{
 		DownloadSpeedMenu->Append(DOWNLOAD_ITEM1, _("Unlimited"));
 
@@ -1008,21 +949,16 @@ wxMenu *CMuleTrayIcon::CreatePopupMenu()
 	}
 
 	traymenu->Append(0, DownloadSpeedMenu->GetTitle(), DownloadSpeedMenu);
-	// Separator
 	traymenu->AppendSeparator();
 
 	if (theApp->IsConnected()) {
-		// Disconnection Speed item
 		traymenu->Append(TRAY_MENU_DISCONNECT, _("Disconnect"));
 	} else {
-		// Connect item
 		traymenu->Append(TRAY_MENU_CONNECT, _("Connect"));
 	}
 
-	// Separator
 	traymenu->AppendSeparator();
 
-	// Exit item
 	traymenu->Append(TRAY_MENU_EXIT, _("Exit"));
 
 	return traymenu;

--- a/src/MuleVirtualDataViewCtrl.cpp
+++ b/src/MuleVirtualDataViewCtrl.cpp
@@ -53,16 +53,14 @@ wxEND_EVENT_TABLE()
 // only the former is virtual in the generic backend (MSW). An index-list model
 // gets a real wxDataViewTreeNode per row hanging off a root branch, and each
 // branch caches the sort order it was last sorted under. Marking our columns
-// sortable to get the header caret sets the window's sort order without wx
-// ever sorting anything -- the list owns its own order -- so the branch cache
-// and the window disagree, and the next RowChanged() trips
-// "m_branchData->sortOrder == window->GetSortOrder()" in PutChildInSortOrder()
-// (datavgen.cpp, present in 3.2 and 3.3 alike). A virtual list model has no
-// tree nodes at all, so the code that asserts is never reached.
+// sortable to get the header caret sets the window's sort order without wx ever
+// sorting anything -- the list owns its own order -- so the branch cache and the
+// window disagree, and the next RowChanged() trips the sortOrder assert in
+// PutChildInSortOrder() (datavgen.cpp, 3.2 and 3.3 alike). A virtual list model
+// has no tree nodes, so that code is never reached.
 //
-// On macOS this is a no-op: wx typedefs wxDataViewVirtualListModel to
-// wxDataViewIndexListModel there ("better than nothing", dataview.h), which is
-// also why the assert has only ever been seen on Windows.
+// A no-op on macOS, where wx typedefs wxDataViewVirtualListModel to
+// wxDataViewIndexListModel -- which is why the assert is Windows-only.
 class CMuleVirtualDataViewCtrl::VirtualModel : public wxDataViewVirtualListModel
 {
 public:
@@ -243,10 +241,9 @@ int CMuleVirtualDataViewCtrl::CompareItemsFull(wxUIntPtr data1, wxUIntPtr data2)
 
 long CMuleVirtualDataViewCtrl::InsertPos(wxUIntPtr data) const
 {
-	// With no sort chain every comparison is equal, and lower_bound would
-	// answer begin() -- putting every arrival at the front, so the list fills
-	// in reverse. CMuleListCtrl::GetInsertPos() appends when it has no sorter;
-	// match it, so an unsorted list is at least in arrival order.
+	// With no sort chain every comparison is equal and lower_bound answers
+	// begin(), putting every arrival at the front so the list fills in reverse.
+	// CMuleListCtrl::GetInsertPos() appends when it has no sorter; match it.
 	if (m_sort_orders.empty()) {
 		return static_cast<long>(m_items.size());
 	}
@@ -294,11 +291,10 @@ void CMuleVirtualDataViewCtrl::AddItemData(wxUIntPtr data)
 	const long pos = InsertPos(data);
 
 	// Selection is re-resolved rather than kept: a wxDataViewItem from a
-	// row-addressed model would silently point at a different row once
-	// everything below the insertion shifts down. Rows above the insertion
-	// don't move, and an empty selection has nothing to preserve, so both
-	// cases skip the round-trip -- it is O(selection) and this path runs per
-	// arriving item.
+	// row-addressed model would silently point at a different row once everything
+	// below the insertion shifts down. Rows above it do not move, and an empty
+	// selection has nothing to preserve, so both skip the round-trip -- it is
+	// O(selection) and this path runs per arriving item.
 	const bool shifts = (static_cast<size_t>(pos) < m_items.size());
 	const std::vector<wxUIntPtr> selected =
 		(shifts && HasSelection()) ? GetSelectedItemData() : std::vector<wxUIntPtr>();
@@ -368,11 +364,10 @@ void CMuleVirtualDataViewCtrl::RemoveItemDataBatch(const std::vector<wxUIntPtr> 
 void CMuleVirtualDataViewCtrl::FinishBulkLoad()
 {
 	const std::vector<wxUIntPtr> selected = GetSelectedItemData();
-	// The row the user is looking at, remembered by its data. Reset() below
-	// says the model was replaced, and every backend answers that by dropping
-	// the view to the top -- so a list that rebuilds whenever a row joins it
-	// scrolled itself home under anyone reading further down (the clients
-	// lists do this on each arrival or departure).
+	// The row the user is looking at, remembered by its data. Reset() below says
+	// the model was replaced, and every backend answers that by dropping the view
+	// to the top -- so a list that rebuilds whenever a row joins it scrolled itself
+	// home under anyone reading further down.
 	long firstRow = 0;
 	long lastRow = 0;
 	wxUIntPtr anchor = GetVisibleRowRange(firstRow, lastRow) ? ItemAt(firstRow) : 0;
@@ -386,10 +381,10 @@ void CMuleVirtualDataViewCtrl::FinishBulkLoad()
 
 	SortItems();
 
-	// Reset() here, unlike SortList(): AppendItemData() adds rows without
-	// telling the control -- that is what makes a bulk load cheap -- so this
-	// is the only notification that the rows exist at all. A repaint would
-	// draw a list the control still believes is the length it was before.
+	// Reset() here, unlike SortList(): AppendItemData() adds rows without telling
+	// the control, which is what makes a bulk load cheap, so this is the only
+	// notification that the rows exist. A repaint would draw a list the control
+	// still believes is its former length.
 	m_virtualModel->Reset(static_cast<unsigned>(m_items.size()));
 
 	SetSelectedItemData(selected);
@@ -405,19 +400,17 @@ void CMuleVirtualDataViewCtrl::ScrollDataToTop(wxUIntPtr data)
 	if (row < 0) {
 		return;
 	}
-	// Reset() left the view at the top, so a row that sorted to the top is
-	// already where it belongs. This is the common case on a list nobody has
-	// scrolled, and it costs no scrolling at all.
+	// Reset() left the view at the top, so a row that sorted there is already where
+	// it belongs -- the common case on a list nobody has scrolled.
 	if (row == 0) {
 		return;
 	}
 
-	// Two calls, because EnsureVisible() scrolls the shortest distance that
-	// makes its target visible. The view is at the top after Reset(), so
-	// asking for the anchor alone would stop as soon as it appeared at the
-	// BOTTOM edge. Bringing the last row of the anchor's page into view first
-	// scrolls past it, and the second call then comes back up to it, which
-	// leaves the anchor on the top line where it was.
+	// Two calls, because EnsureVisible() scrolls the shortest distance that makes
+	// its target visible. The view is at the top after Reset(), so asking for the
+	// anchor alone would stop as soon as it appeared at the BOTTOM edge. Bringing
+	// the last row of the anchor's page into view scrolls past it, and the second
+	// call comes back up, leaving the anchor on the top line.
 	const int perPage = GetCountPerPage();
 	if (perPage > 1 && !m_items.empty()) {
 		const long last = static_cast<long>(m_items.size()) - 1;
@@ -456,31 +449,21 @@ void CMuleVirtualDataViewCtrl::RefreshItemData(wxUIntPtr data)
 		return;
 	}
 
-	// Only rows the user can actually see are worth telling the control
-	// about. Values are pulled per cell as they are drawn, so a row that is
-	// off screen -- or in a list on a panel that isn't showing -- renders
-	// current data the moment it is scrolled or switched into view, with no
-	// notification needed. wxDataViewCtrl reaches the same conclusion, but
-	// only at the very end of wxDataViewMainWindow::DoItemChanged(): before
-	// it intersects the row against the client rect it invalidates every
-	// column's cached best width (a clear + resize of a per-column vector)
-	// and constructs and dispatches a wxEVT_DATAVIEW_ITEM_VALUE_CHANGED,
-	// which no aMule handler is listening for. Measured on a reporter's
-	// 11,000-row download list, that unconditional prologue cost ~20us per
-	// row and ~300ms of every one-second poll -- and it was charged for the
-	// list on all four panels he wasn't looking at as well as the one he
-	// was (issue #867).
+	// Only rows the user can see are worth telling the control about: values are
+	// pulled per cell as they are drawn, so a row that is off screen -- or in a
+	// list on a panel that is not showing -- renders current data the moment it is
+	// scrolled into view. wxDataViewCtrl reaches the same conclusion, but only at
+	// the very end of wxDataViewMainWindow::DoItemChanged(): before intersecting
+	// the row against the client rect it invalidates every column's cached best
+	// width and dispatches a wxEVT_DATAVIEW_ITEM_VALUE_CHANGED nothing listens for.
+	// Measured on an 11,000-row download list, that prologue cost ~20us per row and
+	// ~300 ms of every one-second poll, charged for the lists on all four panels
+	// (issue #867). The vendored generic wxListCtrl tested the visible range first
+	// and returned; this restores that ordering.
 	//
-	// The pre-wxDataViewCtrl lists did not have this problem because the
-	// vendored generic wxListCtrl ordered it the other way round:
-	// wxListMainWindow::RefreshLine() tested the visible range first and
-	// returned, so an off-screen row cost two integer comparisons. This
-	// restores that ordering.
-	//
-	// Skipping the notification for a row that really is visible would
-	// leave a stale cell on screen, so both unknowns resolve towards
-	// refreshing: a backend that cannot report its viewport, and the
-	// partially visible row below the last fully visible one.
+	// Skipping the notification for a row that really is visible would leave a
+	// stale cell on screen, so both unknowns resolve towards refreshing: a backend
+	// that cannot report its viewport, and the partially visible last row.
 	long firstRow = 0;
 	long lastRow = 0;
 	const bool offScreen = !IsShownOnScreen() || (GetVisibleRowRange(firstRow, lastRow) &&
@@ -489,10 +472,9 @@ void CMuleVirtualDataViewCtrl::RefreshItemData(wxUIntPtr data)
 		m_virtualModel->RowChanged(static_cast<unsigned>(row));
 	}
 
-	// The value that just changed may be the one the list is sorted by, in
-	// which case the row has to move. Scheduled rather than done here: an
-	// update burst refreshes many rows, and re-sorting on each would be
-	// quadratic. Gated by the same preference CMuleVirtualListCtrl checks.
+	// The value that changed may be the one the list is sorted by, in which case
+	// the row has to move. Scheduled rather than done here: an update burst
+	// refreshes many rows, and re-sorting on each would be quadratic.
 	if (thePrefs::LiveListSort() && IsLiveSortColumn()) {
 		m_resortPending = true;
 		ScheduleResort();
@@ -501,12 +483,11 @@ void CMuleVirtualDataViewCtrl::RefreshItemData(wxUIntPtr data)
 
 void CMuleVirtualDataViewCtrl::ClearItemData()
 {
-	// Remembered before the rows go, for the clear-then-refill rebuild the
-	// clients list does on every arrival and departure: by the time
-	// FinishBulkLoad() runs, the control has been told it holds nothing and
-	// cannot say what was on top. Harmless for a clear that is really a clear
-	// -- the data will not be in the list afterwards, and restoring skips
-	// anything it cannot find.
+	// Remembered before the rows go, for the clear-then-refill rebuild the clients
+	// list does on every arrival and departure: by the time FinishBulkLoad() runs,
+	// the control has been told it holds nothing and cannot say what was on top.
+	// Harmless for a clear that is really a clear, since restoring skips anything
+	// it cannot find.
 	long firstRow = 0;
 	long lastRow = 0;
 	if (GetVisibleRowRange(firstRow, lastRow)) {
@@ -530,40 +511,34 @@ void CMuleVirtualDataViewCtrl::SortList()
 {
 	const std::vector<wxUIntPtr> selected = GetSelectedItemData();
 
-	// The cursor is addressed by row, like the selection, and unlike the
-	// selection nothing else puts it back. Reset() used to invalidate it
-	// along with the rest of the view; a repaint leaves it pointing at
-	// whatever item has since moved into that row -- so the next arrow key
-	// steps from the wrong place, a shifted page key extends from the wrong
-	// anchor, and the focus ring can come to rest on an unselected row.
+	// The cursor is addressed by row, like the selection, and unlike the selection
+	// nothing else puts it back. A repaint leaves it pointing at whatever item has
+	// since moved into that row, so the next arrow key steps from the wrong place,
+	// a shifted page key extends from the wrong anchor, and the focus ring can rest
+	// on an unselected row.
 	const wxDataViewItem currentItem = GetCurrentItem();
 	const wxUIntPtr currentData =
 		currentItem.IsOk() ? ItemAt(static_cast<long>(m_virtualModel->GetRow(currentItem))) : 0;
 
 	SortItems();
 
-	// Repaint, rather than Reset(). A sort reorders rows; it does not replace
-	// them, and the count is the same on both sides of the std::sort above.
-	// Reset() says the model was replaced, which makes every backend rebuild
-	// its view from scratch -- and a rebuilt view starts at the top, so an
-	// auto-sort while the user was reading further down threw them back to
-	// row 0, horizontally as well. Nothing needs telling: rows are addressed
-	// by index and their values are pulled per cell as they are drawn, so the
-	// cells simply render the new order.
+	// Repaint, rather than Reset(). A sort reorders rows, it does not replace them,
+	// and the count is the same on both sides of the std::sort above. Reset() says
+	// the model was replaced, which makes every backend rebuild its view from
+	// scratch -- and a rebuilt view starts at the top, so an auto-sort threw a user
+	// reading further down back to row 0. Nothing needs telling: rows are addressed
+	// by index and their values are pulled per cell as they are drawn.
 	Refresh();
 
 	// The control's selection is a set of rows, and the rows now mean
 	// different items, so it is re-applied from the item data either way.
 	SetSelectedItemData(selected);
 
-	// Only while the row it lands on is already on screen. Measured on GTK
-	// with wx 3.3.3: SetCurrentItem() to a visible row leaves the viewport
-	// alone, but to one off screen it clamps the view onto the cursor -- and
-	// with no row ever clicked the cursor sits at row 0, so restoring it
-	// after a sort dragged the list back to the top, which is the very thing
-	// this function exists to stop. A cursor the user cannot see is one they
-	// are not about to arrow from; a cursor they can see is the one that has
-	// to be right.
+	// Only while the row it lands on is already on screen. Measured on GTK with wx
+	// 3.3.3: SetCurrentItem() to a visible row leaves the viewport alone, but to one
+	// off screen it clamps the view onto the cursor -- and with no row ever clicked
+	// the cursor sits at row 0, so restoring it after a sort dragged the list back
+	// to the top, the very thing this function exists to stop.
 	if (currentData != 0) {
 		const long row = RowOfData(currentData);
 		long firstRow = 0;
@@ -651,18 +626,16 @@ void CMuleVirtualDataViewCtrl::MaybeResortNow()
 		m_resortPending = false;
 		return;
 	}
-	// Nobody is looking at this list, so sorting it now buys nothing. The
-	// remote GUI keeps every list fed from the same poll whether or not its
-	// panel is on screen, so without this a single reply re-sorts the
-	// downloads, shared-files, sources and peers lists in full, once or twice
-	// a second, of which at most one is visible. Measured on a 1228-row
-	// shared list: 156 sorts in a 150-poll session, 143 of them while hidden.
+	// Nobody is looking at this list, so sorting it now buys nothing. The remote
+	// GUI keeps every list fed from the same poll whether or not its panel is on
+	// screen, so without this a single reply re-sorts the downloads, shared-files,
+	// sources and peers lists in full, once or twice a second, of which at most one
+	// is visible. Measured on a 1228-row shared list: 156 sorts in a 150-poll
+	// session, 143 of them while hidden.
 	//
-	// The work is deferred rather than dropped -- m_resortPending stays set,
-	// so the next update after the panel comes back sorts it. The poll that
-	// marks rows dirty runs continuously while connected, so that is within a
-	// poll interval of becoming visible, and a list only has a sort pending
-	// at all because something changed in it.
+	// Deferred rather than dropped: m_resortPending stays set, so the next update
+	// after the panel comes back sorts it, and the poll that marks rows dirty runs
+	// continuously while connected.
 	if (!IsShownOnScreen()) {
 		return;
 	}
@@ -704,22 +677,18 @@ void CMuleVirtualDataViewCtrl::OnArrowKey(wxKeyEvent &evt)
 	}
 
 	// Swallowed. Left and right belong to the tree control: they expand and
-	// collapse, and a flat list has nothing to expand. Handed to the native
-	// control they do something worse than nothing here -- on macOS the name
-	// column repaints without each row's value being re-supplied, so every
-	// row draws the last row's text until something forces a full repaint.
+	// collapse, and a flat list has nothing to expand. Handed to the native control
+	// they do something worse than nothing here -- on macOS the name column
+	// repaints without each row's value being re-supplied, so every row draws the
+	// last row's text until something forces a full repaint.
 	//
-	// Scrolling sideways would be the useful alternative and is not
-	// available: the only portable lever is EnsureVisible(item, column),
-	// which needs to know which columns are off screen, and GetItemRect()
-	// reports a column's position in the full layout rather than in the
-	// viewport -- the same coordinates before and after a scroll. So the
-	// target cannot be worked out, and a first attempt behaved accordingly:
-	// right moved once and then stopped, left never fired at all because the
-	// x it compares against never goes negative. Doing it properly means
-	// reading the native scroll position per platform, which belongs in its
-	// own change rather than in a repaint fix.
+	// Scrolling sideways would be the useful alternative and is not available: the
+	// only portable lever is EnsureVisible(item, column), which needs to know which
+	// columns are off screen, and GetItemRect() reports a column's position in the
+	// full layout rather than in the viewport -- the same coordinates before and
+	// after a scroll. Doing it properly means reading the native scroll position
+	// per platform.
 	//
-	// Deliberately not on CMuleDataViewCtrl: the search list is a real tree
-	// where these keys expand and collapse result variants.
+	// Deliberately not on CMuleDataViewCtrl: the search list is a real tree where
+	// these keys expand and collapse result variants.
 }

--- a/src/OScopeCtrl.cpp
+++ b/src/OScopeCtrl.cpp
@@ -241,10 +241,9 @@ wxRect COScopeCtrl::ComputePlotRect(wxDC &dc) const
 	const int pad = FromDIP(4);
 	const int lineHeight = dc.GetCharHeight();
 
-	// The left gutter has to hold whichever of the three y axis labels is
-	// widest. The old code assumed 6 pixels per character and reserved room
-	// for seven of them, which was too much at small values and too little
-	// once the axis went into five digits.
+	// The left gutter has to hold whichever of the three y axis labels is widest.
+	// The old code assumed 6 pixels per character and reserved room for seven,
+	// which was too much at small values and too little past five digits.
 	int gutter = std::max(dc.GetTextExtent(GetYMaxLabel()).x, dc.GetTextExtent(GetYMinLabel()).x);
 	if (!m_strYUnits.IsEmpty()) {
 		gutter = std::max(gutter, dc.GetTextExtent(m_strYUnits).x);
@@ -347,12 +346,11 @@ void COScopeCtrl::DrawCurves(wxDC &dc, wxGraphicsContext *gc, const wxRect &rect
 			area.AddLineToPoint(xAt(cntFilled - 1), rectPlot.GetBottom());
 			area.CloseSubpath();
 
-			// Anchor the gradient to the curve's own peak, not to the top
-			// of the plot. Anchoring it to the plot would tie the shading's
-			// opacity to how much of the y range the graph happens to be
-			// using: the Kad graph grows its range to fit, so its curve
-			// rides near the top and shades fine, but a transfer rate well
-			// under the configured maximum sits low in the plot, where a
+			// Anchor the gradient to the curve's own peak, not to the top of the
+			// plot: that would tie the shading's opacity to how much of the y range
+			// the graph happens to be using. The Kad graph grows its range to fit,
+			// so its curve rides near the top and shades fine, while a transfer rate
+			// well under the configured maximum sits low in the plot, where a
 			// plot-anchored gradient has already faded to nothing.
 			double yPeak = rectPlot.GetBottom();
 			for (unsigned i = 0; i < cntFilled; ++i) {
@@ -415,14 +413,14 @@ void COScopeCtrl::DrawCurves(wxDC &dc, wxGraphicsContext *gc, const wxRect &rect
 
 wxString COScopeCtrl::FormatValue(float value) const
 {
-	// The rate graphs hand their readout to CastItoSpeed so it picks the
-	// unit, the way every other speed in the GUI is shown -- a hover on a
-	// fast download reads "2.13 MiB/s" rather than "2179.4 KiB/s". It wants
-	// bytes per second; the graphs plot KiB/s.
+	// The rate graphs hand their readout to CastItoSpeed so it picks the unit, the
+	// way every other speed in the GUI is shown -- a hover on a fast download reads
+	// "2.13 MiB/s" rather than "2179.4 KiB/s". It wants bytes per second; the
+	// graphs plot KiB/s.
 	//
-	// Keyed on the graph rather than on m_strYUnits because those units
-	// are _("KiB/s"), i.e. translated: comparing against the literal would
-	// quietly stop matching in every locale but English.
+	// Keyed on the graph rather than on m_strYUnits, because those units are
+	// _("KiB/s"): comparing against the literal would stop matching in every locale
+	// but English.
 	if (graph_type == GRAPH_DOWN || graph_type == GRAPH_UP) {
 		return CastItoSpeed((uint32)(value * 1024.0f));
 	}
@@ -440,14 +438,10 @@ bool COScopeCtrl::IsShaded() const
 		return false;
 	}
 
-	// On the rate graphs and the Kad graph the three trends are three
-	// views of one quantity -- its current value, its running average and
-	// its session average -- so shading the current one states that
-	// quantity's magnitude. The connections graph instead plots three
-	// unrelated counts (active uploads, connections, active downloads);
-	// there is no primary among them to shade, and singling one out would
-	// only be invisible today because the counts sit low against the
-	// axis range.
+	// On the rate graphs and the Kad graph the three trends are three views of one
+	// quantity -- current value, running average, session average -- so shading the
+	// current one states that quantity's magnitude. The connections graph instead
+	// plots three unrelated counts, with no primary among them to shade.
 	return graph_type != GRAPH_CONN;
 }
 
@@ -483,15 +477,15 @@ void COScopeCtrl::OnPaint(wxPaintEvent &WXUNUSED(evt))
 		return;
 	}
 
-	// Everything drawn straight onto the wxDC has to be done before the
-	// graphics context is created from it: the two share one surface and
-	// only the most recently created of them may write to it.
+	// Everything drawn straight onto the wxDC has to be done before the graphics
+	// context is created from it: the two share one surface, and only the most
+	// recently created of them may write to it.
 	DrawGrid(dc, rectPlot);
 
 #if wxUSE_GRAPHICS_CONTEXT
-	// Created here rather than inside DrawCurves because wxGraphicsContext
-	// has no overload taking the wxDC base class, and this is the last
-	// place that still knows which kind of paint DC we are holding.
+	// Created here rather than inside DrawCurves because wxGraphicsContext has no
+	// overload taking the wxDC base class, and this is the last place that knows
+	// which kind of paint DC we hold.
 	std::unique_ptr<wxGraphicsContext> gc(wxGraphicsContext::Create(dc));
 	DrawCurves(dc, gc.get(), rectPlot);
 #else
@@ -537,10 +531,9 @@ void COScopeCtrl::DrawHover(wxGraphicsContext *gc,
 		gc->DrawEllipse(x - markerRadius, y - markerRadius, markerRadius * 2, markerRadius * 2);
 	}
 
-	// Readout. The header is how far back in time this sample is, in the
-	// same units the x axis label under the graph uses. Deliberately not
-	// the word "Current" for the newest sample: one of the trends is
-	// already called that.
+	// Readout. The header is how far back in time this sample is, in the same units
+	// as the x axis label. Deliberately not the word "Current" for the newest
+	// sample: one of the trends is already called that.
 	const uint32 sAgo = (uint32)iSample * (uint32)std::floor(m_sLastPeriod + 0.5);
 	const wxString strHeader = CFormat("-%s") % CastSecondsToHM(sAgo);
 
@@ -628,9 +621,9 @@ void COScopeCtrl::OnMouseLeave(wxMouseEvent &evt)
 
 void COScopeCtrl::OnSize(wxSizeEvent &WXUNUSED(evt))
 {
-	// The plot is laid out from the client size on every paint, so a resize
-	// only has to invalidate the whole control -- a partial repaint would
-	// leave the old axis labels behind.
+	// The plot is laid out from the client size on every paint, so a resize only
+	// has to invalidate the whole control -- a partial repaint would leave the old
+	// axis labels behind.
 	Refresh(false);
 }
 

--- a/src/OtherFunctions.cpp
+++ b/src/OtherFunctions.cpp
@@ -52,12 +52,11 @@
 #include <wx/utils.h>
 #endif
 
-// Formats a filesize in bytes to make it suitable for displaying
+// Formats a filesize in bytes to make it suitable for displaying.
 //
-// IEC units, because the arithmetic below is binary: every step divides by
-// 1024, so a figure labelled "GB" was really gibibytes and read about 7%
-// high against anything measuring in powers of 1000 (issue #930). Only the
-// label changed -- no displayed size moved.
+// IEC units, because the arithmetic below is binary: every step divides by 1024,
+// so a figure labelled "GB" was really gibibytes and read about 7% high against
+// anything measuring in powers of 1000 (issue #930).
 wxString CastItoXBytes(uint64 count)
 {
 
@@ -128,10 +127,9 @@ wxString LabelWithColon(const wxString &label)
 
 wxString FormatLocalDateTime(const wxDateTime &when)
 {
-	// %x %X: both halves come from LC_TIME, so a locale that writes the day
-	// first, or separates with dots, or wants a 12-hour clock, gets what it
-	// writes -- and every timestamp in the interface agrees, because they
-	// all arrive here.
+	// %x %X: both halves come from LC_TIME, so a locale that writes the day first,
+	// or separates with dots, or wants a 12-hour clock, gets what it writes -- and
+	// every timestamp in the interface agrees, because they all arrive here.
 	return when.Format("%x %X");
 }
 
@@ -140,10 +138,9 @@ wxString FormatLocalDate(const wxDateTime &when)
 	return when.Format("%x");
 }
 
-// Codec FOURCC -> human-readable name. Mapping inspired by eMule AI's
-// MediaInfo.cpp (GPL v2+). Implementation rewritten for wx + a small
-// initial set; extend as needed. Unknown / unrecognised codec IDs
-// pass through unchanged so something useful still shows in the UI.
+// Codec FOURCC -> human-readable name, inspired by eMule AI's MediaInfo.cpp
+// (GPL v2+). Unknown codec IDs pass through unchanged so something useful still
+// shows in the UI.
 wxString FormatMediaCodec(const wxString &raw)
 {
 	if (raw.IsEmpty()) {
@@ -285,8 +282,6 @@ wxString GetFiletypeDesc(FileType type, bool translated)
 	}
 }
 
-// Returns the Typename, examining the extension of the given filename
-
 wxString GetFiletypeByName(const CPath &filename, bool translated)
 {
 	return GetFiletypeDesc(GetFiletype(filename), translated);
@@ -382,14 +377,7 @@ static wxChar base16Lookup[BASE16_LOOKUP_MAX][2] = { { '0', 0x0 },
 	{ 'E', 0xE },
 	{ 'F', 0xF } };
 
-// Returns a BASE16 encoded byte array
-//
-// [In]
-//   buffer: Pointer to byte array
-//   bufLen: Length of buffer array
-//
-// [Return]
-//   wxString object with BASE16 encoded byte array
+// Returns a BASE16 encoded byte array.
 wxString EncodeBase16(const unsigned char *buffer, unsigned int bufLen)
 {
 	wxString Base16Buff;
@@ -402,14 +390,7 @@ wxString EncodeBase16(const unsigned char *buffer, unsigned int bufLen)
 	return Base16Buff;
 }
 
-// Decodes a BASE16 string into a byte array
-//
-// [In]
-//   base16Buffer: String containing BASE16
-//   base16BufLen: Length BASE16 coded string's length
-//
-// [Out]
-//   buffer: byte array containing decoded string
+// Decodes a BASE16 string into `buffer`.
 unsigned int DecodeBase16(const wxString &base16Buffer, unsigned int base16BufLen, uint8_t *buffer)
 {
 	if (base16BufLen & 1) {
@@ -432,14 +413,7 @@ unsigned int DecodeBase16(const wxString &base16Buffer, unsigned int base16BufLe
 	return ret;
 }
 
-// Returns a BASE32 encoded byte array
-//
-// [In]
-//   buffer: Pointer to byte array
-//   bufLen: Length of buffer array
-//
-// [Return]
-//   wxString object with BASE32 encoded byte array
+// Returns a BASE32 encoded byte array.
 wxString EncodeBase32(const unsigned char *buffer, unsigned int bufLen)
 {
 	wxString Base32Buff;
@@ -469,16 +443,7 @@ wxString EncodeBase32(const unsigned char *buffer, unsigned int bufLen)
 	return Base32Buff;
 }
 
-// Decodes a BASE32 string into a byte array
-//
-// [In]
-//   base32Buffer: String containing BASE32
-//   base32BufLen: Length BASE32 coded string's length
-//
-// [Out]
-//   buffer: byte array containing decoded string
-// [Return]
-//   nDecodeLen:
+// Decodes a BASE32 string into `buffer`, returning the decoded length.
 unsigned int DecodeBase32(const wxString &base32Buffer, unsigned int base32BufLen, unsigned char *buffer)
 {
 	size_t nInputLen = base32Buffer.Length();
@@ -1411,7 +1376,6 @@ wxString DumpMemToStr(const void *buff, int n, const wxString &msg, bool ok)
 	int lines = (n + 15) / 16;
 
 	wxString result;
-	// Allocate aproximetly what is needed
 	result.Alloc((lines + 1) * 80);
 	if (!msg.IsEmpty()) {
 		result += msg + " - ok=" + (ok ? "true, " : "false, ");
@@ -1419,10 +1383,8 @@ wxString DumpMemToStr(const void *buff, int n, const wxString &msg, bool ok)
 
 	result += CFormat("%d bytes\n") % n;
 	for (int i = 0; i < lines; ++i) {
-		// Show address
 		result += CFormat("%08x  ") % (i * 16);
 
-		// Show two columns of hex-values
 		for (int j = 0; j < 2; ++j) {
 			for (int k = 0; k < 8; ++k) {
 				int pos = 16 * i + 8 * j + k;
@@ -1436,7 +1398,6 @@ wxString DumpMemToStr(const void *buff, int n, const wxString &msg, bool ok)
 			result += " ";
 		}
 		result += "|";
-		// Show a column of ascii-values
 		for (int k = 0; k < 16; ++k) {
 			int pos = 16 * i + k;
 
@@ -1483,9 +1444,9 @@ CVersionCompareResult CompareLatestReleaseVersion(const wxString &json)
 {
 	CVersionCompareResult result;
 
-	// Extract the `tag_name` string. /releases/latest excludes pre-releases,
-	// so the tag names a stable release. A regex on the one well-known field
-	// is robust against whitespace / field order without a full JSON parser.
+	// Extract the `tag_name` string. /releases/latest excludes pre-releases, so the
+	// tag names a stable release, and a regex on the one well-known field is robust
+	// against whitespace and field order without a full JSON parser.
 	wxRegEx tagRe(wxT("\"tag_name\"[[:space:]]*:[[:space:]]*\"([^\"]+)\""));
 	if (!tagRe.IsValid() || !tagRe.Matches(json)) {
 		return result; // ParseError
@@ -1580,36 +1541,25 @@ void InitLocale(wxLocale &locale, int language)
 	locale.Init(language, wxLOCALE_LOAD_DEFAULT);
 
 #if defined(__WXMAC__) || defined(__WINDOWS__)
-	// On macOS, GetDataDir() returns <bundle>/Contents/SharedSupport, while
-	// .mo catalogs live under <bundle>/Contents/Resources alongside the
-	// other bundle resources -- which is what GetResourcesDir() returns.
-	// On Windows both methods return the directory containing the .exe,
-	// so this is equivalent there.
+	// On macOS, GetDataDir() returns <bundle>/Contents/SharedSupport while the .mo
+	// catalogs live under <bundle>/Contents/Resources, which is what
+	// GetResourcesDir() returns. On Windows both return the .exe's directory.
 	locale.AddCatalogLookupPathPrefix(JoinPaths(wxStandardPaths::Get().GetResourcesDir(), "locale"));
 #elif defined(__WXGTK__) || defined(__UNIX__)
-	// On Linux/*BSD, .mo catalogs are installed under
+	// On Linux/*BSD the .mo catalogs are installed under
 	//   ${CMAKE_INSTALL_PREFIX}/share/locale/<lang>/LC_MESSAGES/amule.mo
-	// (see po/CMakeLists.txt -- DESTINATION ${CMAKE_INSTALL_LOCALEDIR}).
+	// while libintl's default lookup path is baked in at wxGTK's build time. For a
+	// system install that builds the binary and wxGTK against the same prefix the
+	// two match and translations work unaided.
 	//
-	// libintl's default lookup path is baked in at wxGTK's build time.
-	// For system installs that build the binary and wxGTK against the
-	// same prefix (typical Debian/Fedora/Arch packages), the default
-	// path matches and translations work without explicit help.
+	// In a Flatpak they do not: the bundle installs under prefix=/app while the
+	// wxGTK in the GNOME runtime was built against prefix=/usr, so libintl looks
+	// under /usr/share/locale and our catalogs sit untouched at /app/share/locale --
+	// every gettext() lookup misses and the UI runs in English regardless of LANG.
 	//
-	// In a Flatpak however, the bundle installs under prefix=/app while
-	// the wxGTK shipped inside the GNOME runtime was built against
-	// prefix=/usr -- so libintl looks for amule.mo under /usr/share/locale,
-	// and our catalogs sit at /app/share/locale, untouched. Net result:
-	// every gettext() lookup misses and the UI runs in English regardless
-	// of LANG. See amule-org/amule#18 (DaRkViVi verified the path
-	// mismatch on Fedora 44: ls /app/share/locale shows it/, ls
-	// /usr/share/locale/it/LC_MESSAGES/amule.mo is missing).
-	//
-	// Explicitly registering ${install_prefix}/share/locale as a wxLocale
-	// lookup prefix makes the binary self-sufficient: it tells libintl to
-	// also look under its own runtime install prefix, which matches the
-	// install path on Flatpak and is a harmless no-op on system installs
-	// (libintl already finds the catalog under /usr/share/locale).
+	// Registering ${install_prefix}/share/locale as a wxLocale lookup prefix makes
+	// the binary self-sufficient: it matches the Flatpak install path and is a
+	// harmless no-op on system installs.
 	locale.AddCatalogLookupPathPrefix(
 		JoinPaths(JoinPaths(wxStandardPaths::Get().GetInstallPrefix(), "share"), "locale"));
 #endif
@@ -1626,17 +1576,10 @@ int StrLang2wx(const wxString &language)
 		const wxLanguageInfo *lng = wxLocale::FindLanguageInfo(lang);
 		if (lng) {
 			int langID = lng->Language;
-			// Traditional Chinese: original Chinese, used in Taiwan, Hong Kong and Macau.
-			// Simplified Chinese: simplified Chinese characters used in Mainland China since
-			// 1950s, and in some other places such as Singapore and Malaysia.
-			//
-			// Chinese (Traditional) contains zh_TW, zh_HK and zh_MO (but there are differences in
-			// some words). Because of most Traditional Chinese user are in Taiwan, zh_TW becomes
-			// the representation of Traditional Chinese. Chinese (Simplified) contains zh_CN,
-			// zh_SG and zh_MY. In the same reason, zh_CN becomes the representation of Simplified
-			// Chinese.
-			//
-			// wx maps "Traditional Chinese" to "Chinese" however. This must me corrected:
+			// Traditional Chinese (zh_TW, zh_HK, zh_MO) is represented by zh_TW, and
+			// Simplified Chinese (zh_CN, zh_SG, zh_MY) by zh_CN, in both cases because
+			// most users are there. wx maps "Traditional Chinese" to plain "Chinese",
+			// which has to be corrected:
 			if (langID == wxLANGUAGE_CHINESE) {
 				langID = wxLANGUAGE_CHINESE_TRADITIONAL;
 			}

--- a/src/OtherFunctions.h
+++ b/src/OtherFunctions.h
@@ -249,10 +249,8 @@ wxString LabelWithColon(const wxString &label);
 wxString FormatLocalDateTime(const wxDateTime &when);
 // Date-only form of the above, for a column too narrow to carry both.
 wxString FormatLocalDate(const wxDateTime &when);
-// Maps an ed2k FT_MEDIA_CODEC FOURCC / format string to a friendlier
-// display name (e.g. "H264" -> "H.264", "XVID" -> "Xvid"). Unknown
-// values pass through unchanged. Used by SearchListCtrl to render the
-// Codec column.
+// Maps an ed2k FT_MEDIA_CODEC FOURCC / format string to a friendlier display
+// name ("H264" -> "H.264", "XVID" -> "Xvid"); unknown values pass through.
 wxString FormatMediaCodec(const wxString &raw);
 // Returns the amount of Bytes the provided size-type represents
 uint32 GetTypeSize(uint8 type);
@@ -314,15 +312,14 @@ EED2KFileType GetED2KFileTypeID(const CPath &fileName);
 //! metadata from -- audio or video by extension.
 //!
 //! Lives here, in muleappcommon, because the core and the GUI must agree on it:
-//! the scheduler uses it to decide what to probe, and the shared-files view
-//! uses it to decide whether to offer the action at all. Two copies of the same
-//! rule would eventually disagree, and the symptom would be a menu entry that
-//! is enabled and silently does nothing.
+//! the scheduler uses it to decide what to probe, and the shared-files view to
+//! decide whether to offer the action at all. Two copies of the rule would
+//! eventually disagree, and the symptom would be a menu entry that is enabled
+//! and silently does nothing.
 //!
-//! Says nothing about whether the file is COMPLETE. An in-progress download is
-//! in the shared list as a partfile with nothing readable on disk, and callers
-//! test that separately -- the core so it can log the two skips distinctly, the
-//! GUI so it can say how many of a selection it left out and why.
+//! Says nothing about whether the file is COMPLETE. An in-progress download is in
+//! the shared list as a partfile with nothing readable on disk, and callers test
+//! that separately.
 bool IsMediaProbeCandidate(const CPath &fileName);
 wxString GetED2KFileTypeSearchTerm(EED2KFileType iFileID);
 wxString GetFileTypeByName(const CPath &fileName);

--- a/src/PartBarLegend.h
+++ b/src/PartBarLegend.h
@@ -29,28 +29,24 @@
 // source-availability one in the shared-files list -- and the legends the row
 // context menu opens to explain them.
 //
-// The point of this header is that there is exactly one copy of each colour.
-// A legend that restated the palette -- in words, or in swatches filled from a
-// second set of constants -- would be free to drift away from the pixels it
-// claims to explain, and nothing would fail when it did. Here the renderer
-// (CGenericClientListCtrl::GetItemBarFill) and the legend both read
-// SourcePartColour()/PeerPartColour(), so a colour can only change for both at
-// once.
+// The point of this header is that there is exactly one copy of each colour. A
+// legend that restated the palette, in words or in swatches filled from a second
+// set of constants, would be free to drift away from the pixels it claims to
+// explain, and nothing would fail when it did. Here the renderer and the legend
+// both read SourcePartColour()/PeerPartColour(), so a colour can only change for
+// both at once.
 //
 // "One copy of each colour" is a rule about definitions, not about values. Two
 // constants may hold the same RGB when they mean different things and never
-// appear in the same legend -- kNextPending and kFlatHashPending do -- and
-// collapsing them would tie a shared-files bar to a client-list cue for no
-// reason. So the no-two-rows-alike invariant is scoped PER LEGEND: within one
-// legend a repeated colour is a distinction the reader cannot see, which is a
-// real defect; across two legends it is a coincidence.
+// appear in the same legend -- kNextPending and kFlatHashPending do -- so the
+// no-two-rows-alike invariant is scoped PER LEGEND: within one legend a repeated
+// colour is a distinction the reader cannot see; across two it is a coincidence.
 //
 // It pulls in nothing but <cstddef>/<cstdint>, ClientListColumns.h and
-// PartBarSpans.h -- itself wx-free -- so the part of the feature worth checking
-// -- which states a legend lists, in which order, in which colour, and which
-// legend a column gets -- is reachable from a unit test with no wx, no app and
-// no display session. Same rationale as webapi/PartIndex.h. What is left
-// needing a display is the drawing itself.
+// PartBarSpans.h -- itself wx-free -- so what a legend lists, in which order, in
+// which colour, and which legend a column gets is all reachable from a unit test
+// with no wx, no app and no display session. What is left needing a display is
+// the drawing itself.
 
 #include <cstddef>
 #include <cstdint>
@@ -105,9 +101,8 @@ constexpr BarColour kFlatAvailable{ 0, 0, 0 };
 
 // The part of a shared file not yet re-hashed, drawn flat. Byte-identical to
 // kNextPending and deliberately a separate constant: one is a request cue in a
-// client list, the other is unread bytes of a local file, and the only thing
-// they have in common is the shade someone picked. Merging them would mean a
-// change to either bar silently moved the other.
+// client list, the other is unread bytes of a local file, and merging them would
+// mean a change to either bar silently moved the other.
 constexpr BarColour kFlatHashPending{ 255, 255, 100 };
 
 // The shared-files availability bar. A part no source holds is its own state,
@@ -121,14 +116,12 @@ constexpr BarColour kZeroSources{ 255, 0, 0 };
 constexpr unsigned kAvailFull = 10;
 
 //! The endpoints of the fade: one source, and kAvailFull or more. Shared with
-//! the Web UI's light theme as --piece-avail-lo / --piece-avail (src/webapi/
-//! static/css/app.css:29-30); the test reads them from there, so the two
-//! surfaces cannot drift.
+//! the Web UI's light theme as --piece-avail-lo / --piece-avail, which the test
+//! reads from there, so the two surfaces cannot drift.
 //!
-//! The dark end is deeper than the pair adopted in #1282. That pair travelled
-//! about a third less than the ramp it replaced and compressed the middle of
-//! the scale, so neighbouring source counts were hard to tell apart at a
-//! glance -- the one thing the bar exists to show. The light end is unchanged.
+//! The dark end is deeper than the pair adopted in #1282, which travelled about
+//! a third less than the ramp it replaced and compressed the middle of the
+//! scale, making neighbouring source counts hard to tell apart.
 constexpr BarColour kAvailFew{ 166, 212, 238 };
 constexpr BarColour kAvailMany{ 13, 59, 102 };
 

--- a/src/PartFile.cpp
+++ b/src/PartFile.cpp
@@ -115,8 +115,7 @@ namespace
 
 // Parse the ed2k string-named "length" tag -- "h:mm:ss" or "m:ss" -- into
 // seconds. FT_MEDIA_LENGTH is a uint32 everywhere else in the tree, so the
-// string form has to be converted rather than stored raw; storing it raw is
-// what made these tags unreadable in the first place.
+// string form has to be converted rather than stored raw.
 bool ParseEd2kLengthSeconds(const wxString &text, uint32 &out)
 {
 	// Split into at most three fields, leading unit first, so "h:mm:ss" and
@@ -147,11 +146,10 @@ bool ParseEd2kLengthSeconds(const wxString &text, uint32 &out)
 		if (fields[i].IsEmpty() || !fields[i].ToULong(&part)) {
 			return false;
 		}
-		// Only the leading field is an open-ended count; everything after it
-		// is a minute or second and cannot exceed 59. Capped so a malformed
-		// "1:75:00" is dropped rather than silently re-interpreted, and so
-		// the accumulation below cannot overflow: the largest accepted value
-		// is 59999:59:59, well inside uint32.
+		// Only the leading field is an open-ended count; everything after it is a
+		// minute or second and cannot exceed 59. Capped so a malformed "1:75:00"
+		// is dropped rather than silently re-interpreted, and so the accumulation
+		// below cannot overflow.
 		const bool leading = (i == 0);
 		if (!leading && part > 59) {
 			return false;
@@ -169,26 +167,21 @@ bool ParseEd2kLengthSeconds(const wxString &text, uint32 &out)
 //
 // Both encodings a hit can carry end up here: the ed2k string-named form
 // ("Artist", "bitrate", "length" as h:mm:ss) and the numeric-id form. That
-// matters because every media consumer in the tree looks tags up by numeric
-// id -- CAbstractFile::GetStrTagValue matches on GetNameID() -- so a tag
-// pushed under its string name was written to the part file, carried for the
-// lifetime of the download, and read by nobody.
+// matters because every media consumer in the tree looks tags up by numeric id
+// -- CAbstractFile::GetStrTagValue matches on GetNameID() -- so a tag pushed
+// under its string name was written to the part file, carried for the lifetime
+// of the download, and read by nobody.
 //
-// Integer width is deliberately not checked. The ed2k publisher forces 32
-// bits, but Kad picks the narrowest type that fits the value, so a
-// three-minute song arrives as a uint8 and an episode as a uint16. An exact
-// `type == TAGTYPE_UINT32` test therefore rejected essentially every real
-// length and bitrate that came from Kad.
+// Integer width is deliberately not checked. The ed2k publisher forces 32 bits,
+// but Kad picks the narrowest type that fits the value, so a three-minute song
+// arrives as a uint8 and an episode as a uint16 -- an exact `type ==
+// TAGTYPE_UINT32` test rejected essentially every real length from Kad.
 //
-// Every path out of here stores a CTagInt32 or a CTagString -- never the
-// source tag verbatim. That normalisation is what makes the id-only lookups
-// downstream safe, in particular CSearch::PreparePacketForTags, whose Kad
-// republish reads `pTag->GetInt()` with no IsInt() guard of its own. Keep it:
-// storing a caller's tag unchanged here would let a string-typed
-// FT_MEDIA_LENGTH reach that code and go out to every peer as a garbage
-// number.
-//
-// Returns true when a tag was stored.
+// Every path out of here stores a CTagInt32 or a CTagString, never the source
+// tag verbatim. That normalisation is what makes the id-only lookups downstream
+// safe, in particular CSearch::PreparePacketForTags, whose Kad republish reads
+// `pTag->GetInt()` with no IsInt() guard: storing a caller's tag unchanged here
+// would let a string-typed FT_MEDIA_LENGTH go out to every peer as garbage.
 bool InheritMediaTag(CAbstractFile &file, uint8 id, const CTag &tag)
 {
 	if (id == FT_MEDIA_LENGTH) {
@@ -236,10 +229,9 @@ CPartFile::CPartFile(CSearchFile *searchresult)
 
 		bool bTagAdded = false;
 		if (pTag.GetNameID() == 0 && !pTag.GetName().IsEmpty() && (pTag.IsStr() || pTag.IsInt())) {
-			// The ed2k string-named encoding. These used to be pushed under
-			// their string names, which no media consumer ever looks up --
-			// stored, written to disk, carried for the whole download, read
-			// by nobody. Map each to its canonical numeric id instead.
+			// The ed2k string-named encoding. These used to be pushed under their
+			// string names, which no media consumer ever looks up -- stored, written
+			// to disk, carried for the whole download, read by nobody.
 			static const struct
 			{
 				wxString pszName;
@@ -285,11 +277,11 @@ CPartFile::CPartFile(CSearchFile *searchresult)
 					break;
 				}
 			}
-			// Media metadata (#280) advertised by the source, so a download
-			// carries FT_MEDIA_* immediately -- visible while downloading and
-			// persisted on completion -- without needing a local ffprobe. All
-			// six, and through the same helper as the string-named branch
-			// above, so both encodings converge on one set of rules.
+			// Media metadata advertised by the source, so a download carries FT_MEDIA_*
+			// immediately -- visible while downloading and persisted on completion --
+			// without needing a local ffprobe. All six, and through the same helper as
+			// the string-named branch above, so both encodings converge on one set of
+			// rules.
 			static const uint8 _aMediaIDs[] = { FT_MEDIA_LENGTH,
 				FT_MEDIA_BITRATE,
 				FT_MEDIA_CODEC,
@@ -311,18 +303,15 @@ CPartFile::CPartFile(CSearchFile *searchresult)
 		}
 
 		if (pTag.GetNameID() == FT_AICH_HASH && pTag.IsStr()) {
-			// The AICH root hash a search result carried, from an ed2k server
-			// or from Kad. Set as the master hash rather than stored as a
-			// tag: the tag copies above all end at m_taglist, and nothing
-			// reads an AICH hash back out of there. This is the whole point
-			// of carrying the hash on a result -- a download that starts
-			// already knowing its root hash never has to collect one from a
-			// pool of peers before it can recover a corrupt part.
+			// The AICH root hash a search result carried, from an ed2k server or from
+			// Kad. Set as the master hash rather than stored as a tag: the tag copies
+			// above all end at m_taglist, and nothing reads an AICH hash back out of
+			// there. This is the whole point of carrying the hash on a result -- a
+			// download that starts already knowing its root hash never has to collect
+			// one from a pool of peers before it can recover a corrupt part.
 			//
-			// AICH_VERIFIED matches the .part.met path above and the ed2k
-			// link path in DownloadQueue.cpp: in all three the hash arrived
-			// with something that vouches for it, rather than from an
-			// individual peer answering a request.
+			// AICH_VERIFIED matches the .part.met path above and the ed2k link path:
+			// in all three the hash arrived with something that vouches for it.
 			CAICHHash hash;
 			if (hash.DecodeBase32(pTag.GetStr()) == CAICHHash::GetHashSize()) {
 				m_pAICHHashSet->SetMasterHash(hash, AICH_VERIFIED);
@@ -373,9 +362,9 @@ CPartFile::~CPartFile()
 		logPartFile, CFormat("~CPartFile entered, m_inDestructor set: '%s'") % GetFileName());
 
 	// Wait for any in-flight HashJobs targeting this file to finish.
-	// CPartFileHashThread reads m_hpartfile via HashSinglePart; we must
-	// not close the file out from under it. m_inDestructor was set above
-	// so Phase 3 will not enqueue anything new.
+	// CPartFileHashThread reads m_hpartfile via HashSinglePart; we must not close
+	// the file out from under it. m_inDestructor was set above so Phase 3 will not
+	// enqueue anything new.
 	if (m_pendingHashes > 0) {
 		AddDebugLogLineN(logPartFile,
 			CFormat("~CPartFile waiting for %d pending hash job(s) of '%s'") %
@@ -394,26 +383,20 @@ CPartFile::~CPartFile()
 
 		// Sync-hash any parts still flagged dirty in m_aChangedPart.
 		//
-		// Why this is needed: in normal operation Phase 3 enqueues
-		// dirty parts to CPartFileHashThread asynchronously. But at
-		// shutdown the hash thread is torn down before downloadqueue
-		// (see CamuleApp::OnExit ordering), so async enqueue isn't
-		// available here — and a forced-quit during an active download
-		// can leave many parts harvested-but-not-yet-hashed
-		// (m_aChangedPart-true but never enqueued because the
-		// quiescent guard never opened during the receive burst).
+		// In normal operation Phase 3 enqueues dirty parts to CPartFileHashThread
+		// asynchronously. But at shutdown the hash thread is torn down before
+		// downloadqueue, so async enqueue is not available here -- and a
+		// forced-quit during an active download can leave many parts
+		// harvested-but-not-yet-hashed, because the quiescent guard never opened
+		// during the receive burst.
 		//
-		// Without this, .met would be saved with gaplist marking
-		// those parts complete and m_corrupted_list empty, so on
-		// next launch they would be treated as implicitly verified
-		// (the existing "verified iff IsComplete && !IsCorruptedPart"
-		// invariant) — even though they were never hashed.
+		// Without this, .met would be saved with the gaplist marking those parts
+		// complete and m_corrupted_list empty, so on next launch they would be
+		// treated as implicitly verified even though they were never hashed.
 		//
-		// Run the verification synchronously on the main thread.
-		// Slow shutdown is acceptable for the rare cancel-mid-download
-		// case; the common paths (natural completion, pause/resume,
-		// idle drain) keep m_aChangedPart drained throughout the
-		// session, so the loop usually has nothing to do.
+		// Run synchronously on the main thread. Slow shutdown is acceptable for
+		// the rare cancel-mid-download case; the common paths keep m_aChangedPart
+		// drained throughout the session, so the loop usually has nothing to do.
 		if (m_aChangedPart.size() == GetPartCount()) {
 			uint16 verified = 0, corrupt = 0;
 			for (uint16 i = 0; i < GetPartCount(); ++i) {
@@ -427,27 +410,24 @@ CPartFile::~CPartFile()
 					continue;
 				}
 
-				// Lock m_hpartfileMutex against CPartFileWriteThread:
-				// Phase 1 of FlushBuffer above may have queued writes
-				// that the write thread is still draining concurrently
-				// with this sync-hash loop. See m_hpartfileMutex.
+				// Lock m_hpartfileMutex against CPartFileWriteThread: Phase 1 of
+				// FlushBuffer above may have queued writes the write thread is still
+				// draining concurrently with this sync-hash loop.
 				bool ok;
 				{
 					std::lock_guard<std::mutex> lock(m_hpartfileMutex);
 					ok = HashSinglePart(i);
 				}
 				if (ok) {
-					// Part is good. If it was carried in
-					// m_corrupted_list from before, drop it so the
-					// .met save below records the new clean state.
+					// Part is good. If it was carried in m_corrupted_list from before,
+					// drop it so the .met save below records the new clean state.
 					if (IsCorruptedPart(i)) {
 						EraseFirstValue(m_corrupted_list, i);
 					}
 					++verified;
 				} else {
-					// Part is bad. Re-open the gap and record in
-					// m_corrupted_list so next launch knows to
-					// re-download + retry.
+					// Part is bad. Re-open the gap and record in m_corrupted_list so the
+					// next launch knows to re-download and retry.
 					AddGap(i);
 					if (!IsCorruptedPart(i)) {
 						m_corrupted_list.push_back(i);
@@ -813,14 +793,12 @@ uint8 CPartFile::LoadPartFile(
 			    m_partmetfilename % GetFileName());
 		AddLogLineC(_("Trying to recover file info..."));
 
-		// Safe file is that who have
-		// - FileSize
+		// A safe file has a FileSize
 		if (GetFileSize()) {
 			// We have filesize, try other needed info
 
-			// Do we need to check gaps? I think not,
-			// because they are checked below. Worst
-			// scenario will only mark file as 0 bytes downloaded.
+			// Gaps are checked below; the worst case here is the file being marked
+			// as 0 bytes downloaded.
 
 			// -Filename
 			if (!GetFileName().IsOk()) {
@@ -937,12 +915,10 @@ uint8 CPartFile::LoadPartFile(
 		m_iLostDueToCorruption = transferred - completedsize;
 	}
 
-	// In-memory state now matches the just-loaded .part.met.  Setters
-	// invoked during tag parsing (SetUpPriority, SetAutoUpPriority,
-	// SetAutoDownPriority, SetStatus, etc.) may have set m_metDirty;
-	// drop it so the first FlushBuffer tick after load does not rewrite
-	// the .met with byte-identical content.  Also seed m_lastMetSaveTick
-	// from load time so the stats-heartbeat is measured from now.
+	// In-memory state now matches the just-loaded .part.met. Setters invoked
+	// during tag parsing may have set m_metDirty; drop it so the first
+	// FlushBuffer tick after load does not rewrite the .met with byte-identical
+	// content. Also seed m_lastMetSaveTick so the heartbeat measures from now.
 	ClearMetDirty();
 	ClearStatsDirty();
 	m_lastMetSaveTick = ::GetTickCount64();
@@ -967,33 +943,23 @@ bool CPartFile::SavePartFile(bool Initial)
 
 	// Atomic-rename save.
 	//
-	// Old sequence (per partfile, every save tick):
-	//   1. CPath::BackupFile(m_fullname, ".backup") -- full content copy
-	//      of .part.met into .part.met.backup as an in-flight intermediate.
-	//   2. CPath::RemoveFile(m_fullname).
-	//   3. Write new .part.met from scratch.
-	//   4. CPath::RemoveFile(".backup") on success.
-	//   5. CPath::BackupFile(m_fullname, PARTMET_BAK_EXT) -- full content
-	//      copy of the freshly-written .part.met into .part.met.bak as the
-	//      long-term recovery backup.
-	//
-	// Three full-size content copies per save plus a delete/create dance on
-	// the live .part.met. On a sharer with hundreds of dirty partfiles per
-	// timer tick the aggregate runs the main thread continuously through
-	// disk I/O (see issue #669) -- write() syscalls are microseconds each,
+	// The old sequence made three full-size content copies per save -- a backup
+	// copy, a write-from-scratch, and a second backup copy -- plus a
+	// delete/create dance on the live .part.met. On a sharer with hundreds of
+	// dirty partfiles per timer tick the aggregate runs the main thread
+	// continuously through disk I/O: write() syscalls are microseconds each,
 	// but the loop length itself is the bottleneck.
 	//
 	// New sequence:
 	//   1. Write new content into .part.met.tmp.
-	//   2. rename(.part.met, .part.met.bak) -- O(1) metadata op, promotes
-	//      the previous .part.met to long-term backup.
-	//   3. rename(.part.met.tmp, .part.met) -- atomic install of new
-	//      content, POSIX rename guarantees the target is either fully
-	//      old-content or fully new-content at every observable moment.
+	//   2. rename(.part.met, .part.met.bak) -- O(1), promoting the previous
+	//      .part.met to the long-term backup.
+	//   3. rename(.part.met.tmp, .part.met) -- atomic install; POSIX rename
+	//      guarantees the target is either fully old or fully new content at
+	//      every observable moment.
 	//
-	// One content write plus two metadata renames. ~3x reduction in
-	// per-save disk work, and stronger crash safety because the live
-	// .part.met is never absent or partial.
+	// One content write plus two metadata renames, and stronger crash safety
+	// because the live .part.met is never absent or partial.
 	const CPath tmpName = m_fullname.AppendExt(".tmp");
 	const CPath bakName = m_fullname.AppendExt(PARTMET_BAK_EXT);
 
@@ -1048,9 +1014,9 @@ bool CPartFile::SavePartFile(bool Initial)
 
 		// #warning Kry - Where are lost by corruption and gained by compression?
 
-		// 0 (unicoded part file name)
-		// We write it with BOM to keep eMule compatibility. Note that the 'printable' filename is
-		// saved, as presently the filename does not represent an actual file.
+		// 0 (unicoded part file name). Written with BOM to keep eMule
+		// compatibility. The 'printable' filename is saved, as the filename does
+		// not presently represent an actual file.
 		CTagString(FT_FILENAME, GetFileName().GetPrintable()).WriteTagToFile(&file, utf8strOptBOM);
 		CTagString(FT_FILENAME, GetFileName().GetPrintable()).WriteTagToFile(&file); // 1
 
@@ -1156,9 +1122,9 @@ bool CPartFile::SavePartFile(bool Initial)
 
 	file.Close();
 
-	// Sanity-check the tmp before committing it as the new .part.met.
-	// If the write somehow produced a zero-length file (no exception, but
-	// disk full, fs quota, etc.) the existing .part.met must stay intact.
+	// Sanity-check the tmp before committing it as the new .part.met. If the
+	// write somehow produced a zero-length file -- no exception, but disk full
+	// or quota -- the existing .part.met must stay intact.
 	sint64 tmpLength = tmpName.GetFileSize();
 	if (tmpLength == wxInvalidOffset || tmpLength == 0) {
 		theApp->ShowAlert(
@@ -1170,13 +1136,10 @@ bool CPartFile::SavePartFile(bool Initial)
 		return false;
 	}
 
-	// Two-rename atomic install.
-	//   - The previous .part.met (if any) is promoted to .part.met.bak,
-	//     overwriting any older backup. The recovery path in
-	//     LoadPartFile(from_backup=true) reads this on next start if the
-	//     live .part.met goes missing.
-	//   - The freshly-written .part.met.tmp is renamed over the live name,
-	//     atomically.
+	// Two-rename atomic install: the previous .part.met is promoted to
+	// .part.met.bak, overwriting any older backup, which LoadPartFile reads on
+	// the next start if the live .part.met goes missing; then the
+	// freshly-written .part.met.tmp is renamed over the live name, atomically.
 	if (m_fullname.FileExists()) {
 		CPath::RenameFile(m_fullname, bakName, true /* overwrite */);
 	}
@@ -1192,17 +1155,11 @@ void CPartFile::SaveSourceSeeds()
 {
 #define MAX_SAVED_SOURCES 10
 
-	// Kry - Sources seeds
-	// Based on a Feature request, this saves the last MAX_SAVED_SOURCES
-	// sources of the file, giving a 'seed' for the next run.
-	// We save the last sources because:
-	// 1 - They could be the hardest to get
-	// 2 - They will more probably be available
-	// However, if we have downloading sources, they have preference because
-	// we probably have more credits on them.
-	// Anyway, source exchange will get us the rest of the sources
-	// This feature is currently used only on rare files (< 20 sources)
-	//
+	// Kry - Sources seeds. Saves the last MAX_SAVED_SOURCES sources of the file
+	// as a 'seed' for the next run: they could be the hardest to get, and are
+	// more probably still available. Downloading sources take preference, since
+	// we probably have more credits on them, and source exchange gets us the
+	// rest. Currently used only on rare files (< 20 sources).
 
 	if (GetSourceCount() > 20) {
 		return;
@@ -1377,11 +1334,10 @@ void CPartFile::PartFileHashFinished(CKnownFile *result)
 {
 	m_lastDateChanged = result->m_lastDateChanged;
 	bool errorfound = false;
-	// Parts that pass their per-part hash during download but fail this
-	// final full-file re-hash (e.g. a block rewritten after the part
-	// completed) are collected here so we can attempt AICH recovery once
-	// the file is back in a downloadable state, rather than only re-gapping
-	// the whole part.
+	// Parts that pass their per-part hash during download but fail this final
+	// full-file re-hash -- a block rewritten after the part completed, say --
+	// are collected here so AICH recovery can be attempted once the file is back
+	// in a downloadable state, rather than only re-gapping the whole part.
 	std::vector<uint16> corruptParts;
 	if (GetED2KPartHashCount() == 0) {
 		if (IsComplete(0, GetFileSize() - 1)) {
@@ -1400,9 +1356,8 @@ void CPartFile::PartFileHashFinished(CKnownFile *result)
 		}
 	} else {
 		for (size_t i = 0; i < m_hashlist.size(); ++i) {
-			// Kry - trel_ar's completed parts check on rehashing.
-			// Very nice feature, if a file is completed but .part.met don't believe it,
-			// update it.
+			// Kry - trel_ar's completed-parts check on rehashing: if a file is
+			// complete but .part.met does not believe it, update it.
 
 			if (!(i < result->GetHashCount() && (result->GetPartHash(i) == GetPartHash(i)))) {
 				if (IsComplete(i)) {
@@ -1422,13 +1377,11 @@ void CPartFile::PartFileHashFinished(CKnownFile *result)
 					AddGap(i);
 					errorfound = true;
 					const uint16 part = (uint16)i;
-					// Mirror the mid-download corruption path: flag the
-					// part in m_corrupted_list. It is not needed for the
-					// AICH block recovery below, but it primes the ICH
-					// fallback for when no trusted AICH hashset is
-					// available, and — since m_corrupted_list is persisted
-					// to the .met — it keeps the corrupt state across a
-					// restart that happens mid-recovery.
+					// Mirror the mid-download corruption path: flag the part in
+					// m_corrupted_list. It is not needed for the AICH block recovery
+					// below, but it primes the ICH fallback for when no trusted AICH
+					// hashset is available, and since m_corrupted_list is persisted to
+					// the .met it keeps the corrupt state across a restart mid-recovery.
 					if (!IsCorruptedPart(part)) {
 						m_corrupted_list.push_back(part);
 					}
@@ -1470,16 +1423,14 @@ void CPartFile::PartFileHashFinished(CKnownFile *result)
 	} else {
 		SetStatus(PS_READY);
 		SavePartFile();
-		// A part can pass its per-part hash during download yet fail this
-		// final full-file re-hash — e.g. a block rewritten after the part
-		// completed, as happens when endgame source rotation splices a
-		// block across two sources (amule-org/amule#225). AddGap() above
-		// re-opens the whole 9.28 MB part; when a trusted AICH hashset is
-		// available, recover it at 180 KB block granularity instead, so
-		// only the actually-corrupt blocks are re-downloaded (and the
-		// CorruptionBlackBox can pinpoint the bad block). RequestAICHRecovery
-		// is a no-op without a trusted hashset, so non-AICH files keep the
-		// existing whole-part re-download.
+		// A part can pass its per-part hash during download yet fail this final
+		// full-file re-hash -- a block rewritten after the part completed, as
+		// happens when endgame source rotation splices a block across two
+		// sources. AddGap() above re-opens the whole 9.28 MB part; when a
+		// trusted AICH hashset is available, recover it at 180 KB block
+		// granularity instead, so only the actually-corrupt blocks are
+		// re-downloaded. RequestAICHRecovery is a no-op without a trusted
+		// hashset, so non-AICH files keep the whole-part re-download.
 		for (std::vector<uint16>::const_iterator it = corruptParts.begin(); it != corruptParts.end();
 			++it) {
 			RequestAICHRecovery(*it);
@@ -1637,33 +1588,24 @@ void CPartFile::WriteCompleteSourcesCount(CMemFile *file)
 uint32 CPartFile::Process(uint8 m_icounter)
 {
 	// Partfiles have ~20 EC-exported fields that change frequently and
-	// independently (status, speed, transfer counters, source counts, gap
-	// list, hashed-part count, …). Per-field hooks have diminishing
-	// returns when the file is actively transferring anyway, so the mark
-	// here stays coarse — but it is not unconditional. "Process() ran"
-	// is not the same as "this file has new state": a queued download with
-	// no sources ticks once a second and every exported value comes back
-	// identical, and marking it anyway made Get_EC_Response_GetUpdate's
-	// change test pass for every non-paused download, every poll. With
-	// 11,000 of them that is the whole download list re-encoded and
-	// re-sent once a second, and the same again on the client applying it
-	// (issue #867).
+	// independently. Per-field hooks have diminishing returns when the file is
+	// actively transferring anyway, so the mark here stays coarse -- but it is
+	// not unconditional. "Process() ran" is not the same as "this file has new
+	// state": a queued download with no sources ticks once a second and every
+	// exported value comes back identical, and marking it anyway made
+	// Get_EC_Response_GetUpdate's change test pass for every non-paused
+	// download, every poll. With 11,000 of them that is the whole download list
+	// re-encoded and re-sent once a second, and the same again on the client.
 	//
-	// Everything else in CEC_PartFile_Tag is event-driven and marks itself
-	// where it changes (SetStatus, SetCategory, SetDownPriority, the gap
-	// and corruption paths, SetHashingProgress, …). This covers what only
-	// Process() can move.
+	// Everything else in CEC_PartFile_Tag is event-driven and marks itself where
+	// it changes. This covers what only Process() can move.
 	//
-	// GetDlActiveTime() is deliberately absent. It is wall-clock derived --
-	// m_nDlActiveTime plus the time since m_tActivated, and every
-	// PS_READY/PS_EMPTY file is activated the moment the client connects --
-	// so it advances every second whether or not the download is doing
-	// anything, and including it here would answer "changed" always and
-	// leave this test doing nothing. The cost is that an idle download's
-	// active time reaches a remote GUI only when something real about the
-	// file changes; it is read in one place, the File Details dialog, and a
-	// file that is actually transferring changes something every tick
-	// anyway.
+	// GetDlActiveTime() is deliberately absent. It is wall-clock derived, and
+	// every PS_READY/PS_EMPTY file is activated the moment the client connects,
+	// so it advances every second whether or not the download is doing anything
+	// -- including it would answer "changed" always and leave this test doing
+	// nothing. The cost is that an idle download's active time reaches a remote
+	// GUI only when something real changes; it is read in one place.
 	const std::array<uint64, 12> ecTickState = { GetStatus(),
 		GetSourceCount(),
 		GetNotCurrentSourcesCount(),
@@ -1676,14 +1618,12 @@ uint32 CPartFile::Process(uint8 m_icounter)
 		(uint64)(GetKBpsDown() * 1024),
 		GetAvailablePartCount(),
 		m_nCompleteSourcesCount,
-		// The last two are already implied by the ones above -- a block
-		// arriving moves GetTransferred(), and availability reaching
-		// complete moves GetAvailablePartCount() on the same pass. They
-		// are listed anyway because that is a coupling, not a guarantee:
-		// neither stamp marks EC-dirty of its own accord
-		// (UpdateAvailablePartCount only calls MarkMetDirty), so relying
-		// on the neighbour would leave the field to go stale the day
-		// either one moves.
+		// The last two are already implied by the ones above -- a block arriving
+		// moves GetTransferred(), and availability reaching complete moves
+		// GetAvailablePartCount() on the same pass. They are listed anyway
+		// because that is a coupling, not a guarantee: neither stamp marks
+		// EC-dirty of its own accord, so relying on the neighbour would leave
+		// the field to go stale the day either one moves.
 		(uint64)lastseencomplete,
 		(uint64)GetLastChangeDatetime() };
 	if (ecTickState != m_ecTickState) {
@@ -1708,10 +1648,9 @@ uint32 CPartFile::Process(uint8 m_icounter)
 	kBpsDown = 0.0;
 
 	if (m_icounter < 10) {
-		// Update only downloading sources.
-		// We copy the list to a temporary vector to prevent iterator invalidation
-		// (e.g. if TickDownloadAndMeasure() triggers DropSlowSources, which
-		// synchronously removes clients).
+		// Update only downloading sources. The list is copied to a temporary
+		// vector to prevent iterator invalidation -- TickDownloadAndMeasure() can
+		// trigger DropSlowSources, which removes clients synchronously.
 		std::vector<CClientRef> temp_list(
 			m_downloadingSourcesList.begin(), m_downloadingSourcesList.end());
 		for (CClientRef &ref : temp_list) {
@@ -1722,10 +1661,8 @@ uint32 CPartFile::Process(uint8 m_icounter)
 			}
 		}
 	} else {
-		// Update all sources (including downloading sources)
-		// We copy the list to a temporary vector to prevent iterator invalidation
-		// (e.g. if TickDownloadAndMeasure() triggers DropSlowSources, which
-		// synchronously removes clients).
+		// Update all sources, including downloading ones. Copied to a temporary
+		// vector to prevent iterator invalidation, as above.
 		std::vector<CClientRef> temp_list(m_SrcList.begin(), m_SrcList.end());
 		for (CClientRef &ref : temp_list) {
 			CUpDownClient *cur_src = ref.GetClient();
@@ -1949,17 +1886,14 @@ bool CPartFile::CanAddSource(uint32 userid,
 		}
 	}
 
-	// A LowID of zero has no callback semantics — server LowID
-	// assignments start at 1, so an OP_CALLBACKREQUEST aimed at LowID
-	// 0 can't be routed to anything. Source-exchange and server source
-	// lists skip the IsGoodIP filter for LowID ids, so such entries
-	// otherwise sail through, become a CUpDownClient, and burn ~60 s
-	// of idle-socket time inside listensocket's pool before
-	// CClientTCPSocket::CheckTimeOut cleans them up (#786).
+	// A LowID of zero has no callback semantics -- server LowID assignments
+	// start at 1, so an OP_CALLBACKREQUEST aimed at LowID 0 cannot be routed to
+	// anything. Source-exchange and server source lists skip the IsGoodIP filter
+	// for LowID ids, so such entries otherwise sail through, become a
+	// CUpDownClient, and burn ~60 s of idle-socket time in the listen pool.
 	//
-	// HighID 0 (IP 0.0.0.0) is intentionally left to the upstream
-	// IsGoodIP filter that already gates both callers; this guard is
-	// scoped narrowly to the LowID case.
+	// HighID 0 (IP 0.0.0.0) is left to the upstream IsGoodIP filter that already
+	// gates both callers; this guard is scoped narrowly to the LowID case.
 	if (IsLowID(hybridID) && hybridID == 0) {
 		return false;
 	}
@@ -2157,20 +2091,14 @@ void CPartFile::UpdatePartsInfo()
 			// When still a part file, adjust your guesses by 20% to what you see..
 
 			if (n < 5) {
-				// Not many sources, so just use what you see..
-				//  welcome to 'plain stupid code'
-				//  m_nCompleteSourcesCount;
+				// Not many sources, so just use what we see.
 				m_nCompleteSourcesCountLo = m_nCompleteSourcesCount;
 				m_nCompleteSourcesCountHi = m_nCompleteSourcesCount;
 			} else if (n < 20) {
-				// For low guess and normal guess count
-				//	 If we see more sources then the guessed low and normal, use what we
-				// see. 	 If we see less sources then the guessed low, adjust network
-				// accounts for 80%,
-				//  we account for 20% with what we see and make sure we are still above the
-				//  normal.
-				// For high guess
-				//  Adjust 80% network and 20% what we see.
+				// For the low and normal guesses: if we see more sources than guessed,
+				// use what we see; if fewer than the low guess, the network accounts
+				// for 80% and what we see for 20%, kept above the normal guess. The
+				// high guess is 80% network, 20% observed.
 				if (count[i] < m_nCompleteSourcesCount) {
 					m_nCompleteSourcesCountLo = m_nCompleteSourcesCount;
 				} else {
@@ -2185,16 +2113,8 @@ void CPartFile::UpdatePartsInfo()
 					m_nCompleteSourcesCountHi = m_nCompleteSourcesCount;
 				}
 			} else {
-				// Many sources
-				// ------------
-				// For low guess
-				//	 Use what we see.
-				// For normal guess
-				//	 Adjust network accounts for 80%, we account for 20% with what
-				//  we see and make sure we are still above the low.
-				// For high guess
-				//  Adjust network accounts for 80%, we account for 20% with what
-				//  we see and make sure we are still above the normal.
+				// Many sources. Low guess: use what we see. Normal and high guesses:
+				// 80% network, 20% observed, each kept above the one below it.
 
 				m_nCompleteSourcesCountLo = m_nCompleteSourcesCount;
 				m_nCompleteSourcesCount = (uint16)((float)(count[j] * .8) +
@@ -2219,29 +2139,20 @@ bool CPartFile::GetNextRequestedBlock(
 	CUpDownClient *sender, std::vector<Requested_Block_Struct *> &toadd, uint16 &count)
 {
 
-	// The purpose of this function is to return a list of blocks (~180KB) to
-	// download. To avoid a prematurely stop of the downloading, all blocks that
-	// are requested from the same source must be located within the same
-	// chunk (=> part ~9MB).
+	// Returns a list of blocks (~180KB) to download. To avoid prematurely
+	// stopping the download, all blocks requested from the same source must lie
+	// within the same chunk (part, ~9MB).
 	//
-	// The selection of the chunk to download is one of the CRITICAL parts of the
-	// edonkey network. The selection algorithm must insure the best spreading
-	// of files.
+	// Chunk selection is one of the CRITICAL parts of the edonkey network: the
+	// algorithm has to ensure the best spreading of files. It weighs four
+	// criteria -- chunk frequency (rare chunks first, so they become newly
+	// available), preview parts (first + last chunk), request state (spread
+	// requests across sources), and completion (finish partially retrieved
+	// chunks first).
 	//
-	// The selection is based on 4 criteria:
-	//  1.  Frequency of the chunk (availability), very rare chunks must be downloaded
-	//      as quickly as possible to become a new available source.
-	//  2.  Parts used for preview (first + last chunk), preview or check a
-	//      file (e.g. movie, mp3)
-	//  3.  Request state (downloading in process), try to ask each source for another
-	//      chunk. Spread the requests between all sources.
-	//  4.  Completion (shortest-to-complete), partially retrieved chunks should be
-	//      completed before starting to download other one.
-	//
-	// The frequency criterion defines three zones: very rare (<10%), rare (<50%)
-	// and common (>30%). Inside each zone, the criteria have a specific weight, used
-	// to calculate the priority of chunks. The chunk(s) with the highest
-	// priority (highest=0, lowest=0xffff) is/are selected first.
+	// Frequency defines three zones -- very rare (<10%), rare (<50%), common
+	// (>50%) -- and inside each the criteria carry different weights. The
+	// chunk(s) with the highest priority (highest=0, lowest=0xffff) go first:
 	//
 	//          very rare   (preview)       rare                      common
 	//    0% <---- +0 pt ----> 10% <----- +10000 pt -----> 50% <---- +20000 pt ----> 100%
@@ -2259,12 +2170,9 @@ bool CPartFile::GetNextRequestedBlock(
 	// 30000..3xxxx  requested rare chunks + requested preview chunks
 	// 40000..4xxxx  requested common chunks (priority to the least complete)
 	//
-	// This algorithm usually selects first the rarest chunk(s). However, partially
-	// complete chunk(s) that is/are close to completion may overtake the priority
-	// (priority inversion).
-	// For the common chunks, the algorithm tries to spread the download between
-	// the sources
-	//
+	// So the rarest chunks usually go first, except that a chunk close to
+	// completion can overtake them (priority inversion). For common chunks the
+	// algorithm tries to spread the download between sources.
 
 	// Check input parameters
 	if (sender->GetPartStatus().empty()) {
@@ -2346,10 +2254,9 @@ bool CPartFile::GetNextRequestedBlock(
 					// Offsets of chunk
 					const uint64 uStart = cur_chunk.part * PARTSIZE;
 					const uint64 uEnd = uStart + GetPartSize(cur_chunk.part) - 1;
-					// Criterion 2. Parts used for preview
-					// Remark: - We need to download the first part and the last part(s).
-					//        - When the last part is very small, it's necessary to
-					//          download the two last parts.
+					// Criterion 2. Parts used for preview: the first part and the last
+					// part(s) -- when the last part is very small the two last parts are
+					// both needed.
 					bool critPreview = false;
 					if (isPreviewEnable == true) {
 						if (cur_chunk.part == 0) {
@@ -2365,15 +2272,13 @@ bool CPartFile::GetNextRequestedBlock(
 						}
 					}
 
-					// Criterion 3. Request state (downloading in process from other
-					// source(s))
-					// => CPU load
+					// Criterion 3. Request state (downloading in progress from another
+					// source)
 					const bool critRequested = cur_chunk.frequency > veryRareBound &&
 								   IsAlreadyRequested(uStart, uEnd);
 
-					// Criterion 4. Completion
-					// PARTSIZE instead of GetPartSize() favours the last chunk - but that
-					// may be intentional
+					// Criterion 4. Completion. PARTSIZE instead of GetPartSize() favours
+					// the last chunk -- that may be intentional.
 					uint32 partSize = PARTSIZE - m_gaplist.GetGapSize(cur_chunk.part);
 					const uint16 critCompletion =
 						(uint16)(partSize / (PARTSIZE / 100)); // in [%]
@@ -2408,12 +2313,11 @@ bool CPartFile::GetNextRequestedBlock(
 								20000 +                 // Criterion 3
 								(100 - critCompletion); // Criterion 4
 						} else {
-							// 40000..4xxxx  requested common chunks
-							// Remark: The weight of the completion criterion is
-							// inversed
-							//         to spead the requests over the completing
-							//         chunks. Without this, the chunk closest to
-							//         completion will received every new sources.
+							// 40000..4xxxx  requested common chunks. The weight
+							// of the completion criterion is INVERSED here, to
+							// spread the requests over the completing chunks --
+							// without it the chunk closest to completion would
+							// receive every new source.
 							cur_chunk.rank = 40000 +           // Criterion 3
 									 (critCompletion); // Criterion 4
 						}
@@ -2511,10 +2415,8 @@ void CPartFile::CompleteFile(bool bIsHashingDone)
 		StopFile();
 		m_is_A4AF_auto = false;
 		SetStatus(PS_COMPLETING);
-		// guess I was wrong about not need to spawn a thread ...
-		// It is if the temp and incoming dirs are on different
-		// partitions/drives and the file is large...[oz]
-		//
+		// Spawn a thread: the temp and incoming dirs may be on different
+		// partitions and the file may be large. [oz]
 
 		PerformFileComplete();
 	}
@@ -2595,14 +2497,10 @@ void CPartFile::PerformFileComplete()
 	theApp->uploadqueue->SuspendUpload(GetFileHash(), false);
 	FlushBuffer();
 
-	// close permanent handle
-	//
-	// Under m_hpartfileMutex: CUploadDiskIOThread reads this handle from a
-	// worker thread via ReadData, which holds the same mutex around its
-	// Seek+Read. Closing without it can land between that Seek and Read.
-	// Holding it also makes ReadData's IsOpened check decisive -- it runs
-	// under this same lock, so the handle cannot close between that check
-	// and the read it guards.
+	// Close the permanent handle under m_hpartfileMutex: CUploadDiskIOThread
+	// reads this handle from a worker thread via ReadData, which holds the same
+	// mutex around its Seek+Read, so closing without it can land between the two.
+	// Holding it also makes ReadData's IsOpened check decisive.
 	if (m_hpartfile.IsOpened()) {
 		std::lock_guard<std::mutex> lock(m_hpartfileMutex);
 		m_hpartfile.Close();
@@ -2652,14 +2550,13 @@ void CPartFile::Delete()
 	// enqueue further hash jobs (or re-share the file) while we tear it
 	// down below.
 	m_inDestructor = true;
-	// Notify every subscriber that holds a raw CKnownFile* / CPartFile*
-	// to this object — list ctrls, comment dialogs, file-detail dialog,
-	// AICH static request list, write/hash threads, and on amulegui
-	// the CUpDownClient::m_uploadingfile / m_reqfile fields. Subscribers
-	// strip their references using pointer-value comparison only (this
-	// object is still live when the notify fires; by the time main-
-	// thread queued subscribers run, this object may already have been
-	// freed). See MuleNotify::KnownFileBeingDestroyed (GuiEvents.cpp).
+	// Notify every subscriber that holds a raw CKnownFile* / CPartFile* to this
+	// object -- list ctrls, comment dialogs, the file-detail dialog, the AICH
+	// static request list, the write/hash threads, and on amulegui the
+	// CUpDownClient::m_uploadingfile / m_reqfile fields. Subscribers strip their
+	// references using pointer-value comparison only: this object is still live
+	// when the notify fires, but by the time queued main-thread subscribers run
+	// it may already have been freed.
 	Notify_KnownFileBeingDestroyed(this);
 	// Barry - Need to tell any connected clients to stop sending the file
 	StopFile(true);
@@ -2688,15 +2585,9 @@ void CPartFile::Delete()
 	// m_hpartfile inside HashSinglePart; pulling the file out from under it
 	// crashes the worker.
 	//
-	// ~CPartFile performs the same wait, but it only runs from the
-	// `delete this` at the end of this function -- after the close and the
-	// unlink, which is far too late to help. The enqueue gate was set at the
-	// top, so the count only falls from here.
-	//
-	// Reaching this with jobs in flight needs a part to complete during an
-	// active download, which the quiescent guard used to make almost
-	// impossible; without it that is the normal case, so deleting a running
-	// download hits this every time.
+	// ~CPartFile performs the same wait, but only from the `delete this` at the
+	// end of this function -- after the close and the unlink, far too late to
+	// help. The enqueue gate was set at the top, so the count only falls here.
 	if (m_pendingHashes > 0) {
 		AddDebugLogLineN(logPartFile,
 			CFormat("Delete() waiting for %d pending hash job(s) of '%s'") %
@@ -2771,16 +2662,14 @@ bool CPartFile::HashSinglePart(uint16 partnumber)
 		uint64 offset = PARTSIZE * partnumber;
 		uint32 length = GetPartSize(partnumber);
 
-		// Drift defense: gap-tracking advances on receive, but bytes
-		// only hit disk via the buffered write path; a write failure
-		// (ENOSPC, EIO, transient I/O error) followed by a SavePartFile
-		// and an unclean shutdown leaves the .met persisted with the
-		// optimistic gap state, while the partfile is shorter than
-		// the gap-list claims. Reading past EOF would throw and trip
-		// PS_ERROR, requiring manual recovery (truncate -s <fullsize>).
-		// Detect the divergence pre-read and reopen the gap so the
-		// missing bytes are re-fetched cleanly. Also covers external
-		// truncation, partial backup restore, and FS corruption.
+		// Drift defence: gap-tracking advances on receive, but bytes only hit disk
+		// via the buffered write path. A write failure (ENOSPC, EIO, a transient
+		// I/O error) followed by a SavePartFile and an unclean shutdown leaves
+		// the .met persisted with the optimistic gap state while the partfile is
+		// shorter than the gap list claims -- reading past EOF then throws and
+		// trips PS_ERROR, requiring manual recovery. Detect the divergence
+		// pre-read and reopen the gap so the missing bytes are re-fetched. Also
+		// covers external truncation, a partial backup restore, and FS corruption.
 		const uint64 partfileLen = m_hpartfile.GetLength();
 		if (partfileLen < offset + length) {
 			AddLogLineC(
@@ -2863,12 +2752,11 @@ bool CPartFile::HasPendingHashWork() const
 			return true;
 		}
 	}
-	// Completion-pending: gaplist is closed and the file is in active
-	// state but writes haven't all been harvested yet — keep firing
-	// FlushBuffer at Process tick rate so the trailing CompleteFile
-	// check runs once the worker thread drains. Without this, a slow
-	// worker that completes the gap-closing write after the last
-	// FlushBuffer would leave us waiting for BUFFER_TIME_LIMIT (60 s).
+	// Completion-pending: the gaplist is closed and the file is in an active
+	// state but writes have not all been harvested yet -- keep firing FlushBuffer
+	// at Process tick rate so the trailing CompleteFile check runs once the
+	// worker drains. Without this, a slow worker that completes the gap-closing
+	// write after the last FlushBuffer would leave us waiting 60 s.
 	if (m_gaplist.IsComplete() && (status == PS_EMPTY || status == PS_READY) &&
 		!m_BufferedData_list.empty()) {
 		return true;
@@ -2880,10 +2768,9 @@ void CPartFile::StopFile(bool bCancel)
 {
 	// Kry - Need to set it here to get into SetStatus(status) correctly
 	m_stopped = true;
-	// EC exports IsStopped() via EC_TAG_PARTFILE_STOPPED. Process() is
-	// gated to PS_READY/PS_EMPTY (see DownloadQueue::Process), so a
-	// stopped partfile no longer auto-marks each tick — the user action
-	// must mark explicitly or amulegui/amuleweb never see the new state.
+	// EC exports IsStopped() via EC_TAG_PARTFILE_STOPPED. Process() is gated to
+	// PS_READY/PS_EMPTY, so a stopped partfile no longer auto-marks each tick --
+	// the user action must mark explicitly or remote clients never see it.
 	MarkECChanged();
 
 	// Barry - Need to tell any connected clients to stop sending the file
@@ -3024,10 +2911,8 @@ bool CPartFile::CheckFreeDiskSpace(uint64 neededSpace)
 	if (thePrefs::IsCheckDiskspaceEnabled()) {
 		neededSpace += thePrefs::GetMinFreeDiskSpace();
 
-		// Due to the the existence of sparse files, we cannot assume that
-		// writes within the file doesn't cause new blocks to be allocated.
-		// Therefore, we have to simply stop writing the moment the limit has
-		// been exceeded.
+		// Sparse files mean a write within the file can still allocate new blocks,
+		// so the only safe rule is to stop writing the moment the limit is exceeded.
 		return free >= neededSpace;
 	}
 
@@ -3485,11 +3370,10 @@ uint32 CPartFile::WriteToBuffer(uint32 transize,
 	// log transferinformation in our "blackbox"
 	m_CorruptionBlackBox->TransferredData(start, end, client->GetIP());
 
-	// Stamp for FlushBuffer's Phase 3 quiescent guard, and for the
-	// download-list "Last Reception" column. The latter must stamp on
-	// real data arrival, not on every periodic FlushBuffer call, or
-	// idle/paused/stalled files will all read "now" and the column
-	// stops being useful for spotting hopeless downloads.
+	// Stamp for FlushBuffer's Phase 3 quiescent guard, and for the download-list
+	// "Last Reception" column. The latter must stamp on real data arrival, not
+	// on every periodic FlushBuffer call, or idle/paused/stalled files all read
+	// "now" and the column stops being useful.
 	m_nLastBlockReceivedTick = GetTickCount64();
 	m_lastDateChanged = wxDateTime::GetTimeNow();
 
@@ -3674,23 +3558,19 @@ void CPartFile::FlushBuffer(bool fromAICHRecoveryDataAvailable)
 		return;
 	}
 
-	// First-share early path (#761). SafeAddKFile fires from
-	// OnAsyncHashComplete and is gated on status == PS_EMPTY -- so it
-	// only ever runs once per partfile lifetime, when the first part
-	// is verified. The bulk-drain gates below (m_iWrites > 0 and the
-	// 1 s quiescent window) sit engaged across an entire active
-	// download, which means a continuously-downloading file never
-	// gets that first verification and stays invisible in "Shared
-	// files" until the user pauses or it completes. Bypass both gates
-	// to enqueue exactly one safe candidate.
+	// First-share early path. SafeAddKFile fires from OnAsyncHashComplete and is
+	// gated on status == PS_EMPTY, so it only ever runs once per partfile
+	// lifetime, when the first part is verified. The bulk-drain gates below
+	// (m_iWrites > 0 and the 1 s quiescent window) sit engaged across an entire
+	// active download, so a continuously-downloading file never gets that first
+	// verification and stays invisible in "Shared files" until the user pauses.
+	// Bypass both gates to enqueue exactly one safe candidate.
 	//
-	// Safety: m_aChangedPart[N] && IsComplete(N) means Phase 2 has
-	// already observed at least one PB_WRITTEN for N and the gaplist
-	// has no holes in N. But FillGap runs at queue time in
-	// WriteToBuffer (line 3160), so a queued PB_PENDING/PB_READY for
-	// the same part can still exist -- hashing then would read
-	// pre-write bytes. Scan m_BufferedData_list for overlap to skip
-	// any such part.
+	// Safety: m_aChangedPart[N] && IsComplete(N) means Phase 2 has observed at
+	// least one PB_WRITTEN for N and the gaplist has no holes in N. But FillGap
+	// runs at queue time in WriteToBuffer, so a queued PB_PENDING/PB_READY for
+	// the same part can still exist and hashing would read pre-write bytes.
+	// Scan m_BufferedData_list for overlap to skip any such part.
 	if (status == PS_EMPTY && GetHashCount() == GetED2KPartHashCount() && !m_hashsetneeded &&
 		m_pendingHashes == 0 && !m_gaplist.IsComplete()) {
 		for (uint32 partNumber = 0; partNumber < partCount; ++partNumber) {
@@ -3734,11 +3614,10 @@ void CPartFile::FlushBuffer(bool fromAICHRecoveryDataAvailable)
 		return;
 	}
 
-	// Skip Phase 3 at gaplist completion: CCompletionTask re-reads
-	// the file for the ED2K root + AICH tree, subsuming Phase 3's
-	// per-part MD4. Running both is duplicate work and (for fresh
-	// downloads where every part is dirty) a 30-60 s main-thread
-	// freeze.
+	// Skip Phase 3 at gaplist completion: CCompletionTask re-reads the file for
+	// the ED2K root + AICH tree, subsuming Phase 3's per-part MD4. Running both
+	// is duplicate work and, for a fresh download where every part is dirty, a
+	// 30-60 s main-thread freeze.
 	if (m_gaplist.IsComplete()) {
 		const uint32 dirty = (uint32)std::count(m_aChangedPart.begin(), m_aChangedPart.end(), true);
 		if (dirty > 0) {
@@ -3751,15 +3630,13 @@ void CPartFile::FlushBuffer(bool fromAICHRecoveryDataAvailable)
 	} else {
 		// Async enqueue: hand each dirty completed part to CPartFileHashThread,
 		// which runs HashSinglePart on its own thread and posts a
-		// CPartFileHashResultEvent back to CamuleApp's main-thread
-		// handler — OnAsyncHashComplete then runs the AICH-recovery /
-		// SafeAddKFile branches below. Main-thread cost here is just
-		// queue inserts (microseconds per part), so even a 3000-part
-		// dirty list enqueues in milliseconds with zero hashing freeze.
+		// CPartFileHashResultEvent back to the main-thread handler.
+		// OnAsyncHashComplete then runs the AICH-recovery / SafeAddKFile
+		// branches below. Main-thread cost here is just queue inserts, so even a
+		// 3000-part dirty list enqueues in milliseconds with no hashing freeze.
 		//
-		// Disk write safety: m_iWrites <= 0 at line 3510 already guarantees
-		// that CPartFileWriteThread has flushed all pending writes to disk
-		// before we enqueue a completed part for hashing.
+		// Disk write safety: the m_iWrites <= 0 gate above already guarantees
+		// CPartFileWriteThread has flushed every pending write to disk.
 		uint32 enqueued = 0;
 		for (uint32 partNumber = 0; partNumber < partCount; ++partNumber) {
 			if (!m_aChangedPart[partNumber]) {
@@ -3767,12 +3644,10 @@ void CPartFile::FlushBuffer(bool fromAICHRecoveryDataAvailable)
 			}
 			m_aChangedPart[partNumber] = false;
 
-			// Mirror the synchronous verify loop at line 286: a write
-			// that touches a part marks it dirty, but the part may still
-			// have gaps. Hashing an incomplete part would read past the
-			// highest written offset and EOF. Future writes to this part
-			// will re-set the dirty bit; once gap-complete, the next
-			// pass enqueues it.
+			// Mirror the synchronous verify loop: a write that touches a part marks
+			// it dirty, but the part may still have gaps, and hashing an incomplete
+			// part would read past the highest written offset and EOF. Future writes
+			// re-set the dirty bit; once gap-complete, the next pass enqueues it.
 			if (!IsComplete(partNumber)) {
 				continue;
 			}
@@ -3788,18 +3663,15 @@ void CPartFile::FlushBuffer(bool fromAICHRecoveryDataAvailable)
 		}
 	} // close gaplistComplete else-branch (async enqueue)
 
-	// Update met file -- only when something has actually changed since
-	// the last save.  Two tiers:
-	//   1. Hard state (gap list, status, priority, category, etc.) sets
-	//      m_metDirty.  Saved at the next FlushBuffer tick (~60 s).
-	//   2. Soft stats (AllTimeRequests / AllTimeAccepts /
-	//      AllTimeTransferred) set m_statsDirty only.  Saved at the
-	//      STATS_HEARTBEAT_MS cadence so a popular sharer does not
-	//      rewrite its .met on every served chunk.  The heartbeat is
-	//      measured from the last successful save, so a regular dirty
-	//      save automatically resets it.
-	// If neither bit is dirty, no save fires.  An idle seeder with no
-	// activity at all writes nothing until shutdown.
+	// Update the met file, only when something has actually changed since the
+	// last save. Two tiers:
+	//   1. Hard state (gap list, status, priority, category) sets m_metDirty and
+	//      is saved at the next FlushBuffer tick (~60 s).
+	//   2. Soft stats (AllTimeRequests / Accepts / Transferred) set m_statsDirty
+	//      only, and are saved at the STATS_HEARTBEAT_MS cadence so a popular
+	//      sharer does not rewrite its .met on every served chunk.
+	// The heartbeat is measured from the last successful save, so a regular
+	// dirty save resets it. With neither bit dirty, no save fires at all.
 	const uint64 STATS_HEARTBEAT_MS = 10 * 60 * 1000;
 	if (IsMetDirty() ||
 		(IsStatsDirty() && (::GetTickCount64() - m_lastMetSaveTick > STATS_HEARTBEAT_MS))) {
@@ -3807,13 +3679,11 @@ void CPartFile::FlushBuffer(bool fromAICHRecoveryDataAvailable)
 	}
 
 	// Final PB_WRITTEN harvest. The Phase 2 loop above can race with
-	// CPartFileWriteThread::Entry(), which decrements m_iWrites and
-	// then sets PB_WRITTEN: an item Phase 2 saw as PB_PENDING (and
-	// left in the list) can transition to PB_WRITTEN before the
-	// trailing check below runs. Without this sweep, the gap-closing
-	// write at file completion would leave m_BufferedData_list
-	// non-empty, fail the trailing check, and the download would stick
-	// at 99.9% until the next BUFFER_TIME_LIMIT (60 s) tick.
+	// CPartFileWriteThread::Entry(), which decrements m_iWrites and then sets
+	// PB_WRITTEN: an item Phase 2 saw as PB_PENDING can transition to PB_WRITTEN
+	// before the trailing check below runs. Without this sweep, the gap-closing
+	// write at completion would leave m_BufferedData_list non-empty, fail the
+	// trailing check, and stick the download at 99.9% for another 60 s.
 	for (std::list<PartFileBufferedData *>::iterator it = m_BufferedData_list.begin();
 		it != m_BufferedData_list.end();) {
 		PartFileBufferedData *item = *it;
@@ -3833,25 +3703,21 @@ void CPartFile::FlushBuffer(bool fromAICHRecoveryDataAvailable)
 	}
 
 	if (theApp->IsRunning()) { // may be called during shutdown!
-		// CompleteFile is not idempotent — each call kicks off a fresh
-		// CHashingTask. Must guard:
-		//   - status PS_EMPTY or PS_READY: skip if already
-		//     PS_COMPLETING / PS_HASHING / PS_WAITING_FOR_HASH / PS_ERROR
-		//     (otherwise StopFile→FlushBuffer and PerformFileComplete→
-		//     FlushBuffer in the post-CompleteFile path would re-fire
-		//     and spawn duplicate hash tasks). Both PS_EMPTY and
-		//     PS_READY are normal in-flight states: PS_READY is set on
-		//     load (LoadPartFile, line ~757) when any part is already
-		//     complete, and in OnAsyncHashComplete after a successful
-		//     part hash. So a resumed download is PS_READY from the
-		//     moment .met is loaded — gating on PS_EMPTY alone made
-		//     CompleteFile fail to fire on every resume-then-finish.
-		//   - m_pendingHashes <= 0: don't kick off CCompletionTask while
-		//     CPartFileHashThread is still reading m_hpartfile via
-		//     HashSinglePart — PerformFileComplete closes the file and
-		//     the worker would fault. The last OnAsyncHashComplete (when
-		//     pendingHashes drops to 0) re-runs this same check and
-		//     fires CompleteFile then.
+		// CompleteFile is not idempotent -- each call kicks off a fresh
+		// CHashingTask -- so two guards:
+		//
+		//   - status PS_EMPTY or PS_READY: skip if already PS_COMPLETING /
+		//     PS_HASHING / PS_WAITING_FOR_HASH / PS_ERROR, or StopFile and
+		//     PerformFileComplete would re-fire and spawn duplicate hash tasks.
+		//     Both PS_EMPTY and PS_READY are normal in-flight states -- PS_READY
+		//     is set on load when any part is already complete -- so a resumed
+		//     download is PS_READY from the moment .met is loaded, and gating on
+		//     PS_EMPTY alone made CompleteFile miss every resume-then-finish.
+		//
+		//   - m_pendingHashes <= 0: do not start CCompletionTask while
+		//     CPartFileHashThread is still reading m_hpartfile.
+		//     PerformFileComplete closes the file and the worker would fault; the
+		//     last OnAsyncHashComplete re-runs this check and fires then.
 		if ((status == PS_EMPTY || status == PS_READY) && m_gaplist.IsComplete() && m_iWrites <= 0 &&
 			m_BufferedData_list.empty() && m_pendingHashes <= 0) {
 			CompleteFile(false);
@@ -3874,13 +3740,11 @@ void CPartFile::OnAsyncHashComplete(uint16 partNumber, bool ok, bool fromAICHRec
 
 	const uint32 partRange = GetPartSize(partNumber) - 1;
 
-	// Track whether this part's outcome changes persistent state.
-	// Only those branches need a SavePartFile flush; the success path
-	// for an already-complete part touches in-memory bookkeeping only
-	// (VerifiedData, m_corrupted_list, status), which is fine to
-	// persist on the next FlushBuffer-driven SavePartFile.  Avoids
-	// hammering the .met file on the main thread once per part —
-	// that's what made the GUI freeze on async-hash drain.
+	// Track whether this part's outcome changes persistent state. Only those
+	// branches need a SavePartFile flush; the success path for an already-
+	// complete part touches in-memory bookkeeping only, which is fine to persist
+	// on the next FlushBuffer-driven save. Avoids hammering the .met file on the
+	// main thread once per part, which is what froze the GUI on async-hash drain.
 	bool stateChanged = false;
 
 	if (IsComplete(partNumber)) {
@@ -3906,10 +3770,9 @@ void CPartFile::OnAsyncHashComplete(uint16 partNumber, bool ok, bool fromAICHRec
 
 			m_CorruptionBlackBox->VerifiedData(true, partNumber, 0, partRange);
 
-			// If this part was carried as corrupted in the .met from a
-			// prior session, removing it from m_corrupted_list IS a
-			// persistent state change — without a save, next launch
-			// would still flag it as needing recovery.
+			// If this part was carried as corrupted in the .met from a prior session,
+			// removing it from m_corrupted_list IS a persistent state change --
+			// without a save, the next launch would still flag it for recovery.
 			if (IsCorruptedPart(partNumber)) {
 				EraseFirstValue(m_corrupted_list, partNumber);
 				stateChanged = true;
@@ -3950,11 +3813,10 @@ void CPartFile::OnAsyncHashComplete(uint16 partNumber, bool ok, bool fromAICHRec
 		SavePartFile();
 	}
 
-	// Now that this part's hash has been processed, the file may be
-	// ready for completion. Mirrors the trailing CompleteFile check in
-	// FlushBuffer — accept both PS_EMPTY and PS_READY (resumed
-	// downloads are PS_READY from load), but still skip PS_COMPLETING
-	// so a duplicate CompleteFile / CHashingTask isn't spawned.
+	// Now that this part's hash has been processed, the file may be ready for
+	// completion. Mirrors the trailing CompleteFile check in FlushBuffer --
+	// accept both PS_EMPTY and PS_READY, but still skip PS_COMPLETING so a
+	// duplicate CompleteFile / CHashingTask is not spawned.
 	if ((status == PS_EMPTY || status == PS_READY) && m_gaplist.IsComplete() && m_iWrites <= 0 &&
 		m_BufferedData_list.empty() && m_pendingHashes <= 0) {
 		CompleteFile(false);
@@ -3977,26 +3839,22 @@ bool CPartFile::ReadData(CFileArea &area, uint64 offset, uint32 toread, bool *ha
 		return false;
 	}
 
-	// Lock m_hpartfileMutex against the write/hash threads. ReadAt
-	// is Seek+Read on the underlying CFileAutoClose; CFile's internal
-	// recursive_mutex (#576) serialises the individual syscalls but
-	// not the Seek+Read composition. CPartFileWriteThread::Entry holds
-	// m_hpartfileMutex around its Seek+Write -- without the matching
-	// lock here, the upload reader (CUploadDiskIOThread::Entry calls
-	// this from a worker thread) can interleave its Seek with a write
-	// thread's Seek+Write, leaving fd_pos at the upload's seek target.
-	// The write thread's Write then lands at the wrong offset, and
-	// the read returns bytes from the post-write position. See #586.
+	// Lock m_hpartfileMutex against the write/hash threads. ReadAt is Seek+Read
+	// on the underlying CFileAutoClose; CFile's internal recursive_mutex
+	// serialises the individual syscalls but not the Seek+Read composition.
+	// CPartFileWriteThread::Entry holds m_hpartfileMutex around its Seek+Write
+	// -- without the matching lock here, the upload reader can interleave its
+	// Seek with a write thread's Seek+Write, leaving fd_pos at the upload's seek
+	// target. The write then lands at the wrong offset, and the read returns
+	// bytes from the post-write position.
 	std::lock_guard<std::mutex> lock(m_hpartfileMutex);
 
-	// PerformFileComplete closes this handle under the same mutex once the
-	// file is finished, while the upload reader may still have block
-	// requests queued for it. Report that rather than seeking a closed
-	// handle: the throw would be indistinguishable from a real IO error,
-	// and the caller drops the client on those. Flagged separately from the
-	// bare false above, which is an asserted bug the caller must not treat
-	// as routine. Checked under the lock so the answer cannot change before
-	// the read.
+	// PerformFileComplete closes this handle under the same mutex once the file
+	// is finished, while the upload reader may still have block requests queued
+	// for it. Report that rather than seeking a closed handle: the throw would
+	// be indistinguishable from a real IO error, and the caller drops the client
+	// on those. Flagged separately from the bare false above, which is an
+	// asserted bug. Checked under the lock so the answer cannot change.
 	if (!m_hpartfile.IsOpened()) {
 		if (handleClosed != nullptr) {
 			*handleClosed = true;
@@ -4045,10 +3903,9 @@ void CPartFile::UpdateFileRatingCommentAvail()
 
 	if ((prevComment != m_hasComment) || (prevRating != m_iUserRating)) {
 		UpdateDisplayedInfo();
-		// EC exports EC_TAG_PARTFILE_COMMENTS (rating + comments tag
-		// tree). Sources can deliver new comments at any time via
-		// OP_MESSAGE; without a mark here amulegui would only refresh
-		// when something else on the file changes.
+		// EC exports EC_TAG_PARTFILE_COMMENTS (rating + comments tag tree).
+		// Sources can deliver new comments at any time via OP_MESSAGE; without a
+		// mark here amulegui would only refresh when something else changes.
 		MarkECChanged();
 	}
 }
@@ -4253,15 +4110,13 @@ void CPartFile::AICHRecoveryDataAvailable(uint16 nPart)
 		pVerifiedHash->GetNBaseSize());
 	try {
 		// Lock m_hpartfileMutex against the write/hash/upload threads.
-		// CreateHashFromFile is a sequence of Seek+Read inside the
-		// CFileAutoClose wrapper, and CFile's recursive_mutex (#576)
-		// serialises individual syscalls but not the composition.
-		// Without the matching lock here, the AICH-recovery read can
-		// interleave with a concurrent Seek+Write from
-		// CPartFileWriteThread, fd_pos lands in the wrong place, the
-		// recovery hash is computed over the wrong bytes -- and the
-		// recovered part gets accepted as good even though it is not.
-		// See #586.
+		// CreateHashFromFile is a sequence of Seek+Read inside the CFileAutoClose
+		// wrapper, and CFile's recursive_mutex serialises individual syscalls but
+		// not the composition. Without the matching lock here, the AICH-recovery
+		// read can interleave with a concurrent Seek+Write from
+		// CPartFileWriteThread, fd_pos lands in the wrong place, the recovery
+		// hash is computed over the wrong bytes -- and the recovered part gets
+		// accepted as good even though it is not.
 		std::lock_guard<std::mutex> lock(m_hpartfileMutex);
 		CreateHashFromFile(m_hpartfile, PARTSIZE * nPart, length, NULL, &htOurHash);
 	} catch (const CIOFailureException &e) {
@@ -4793,10 +4648,8 @@ void CPartFile::SetHashingProgress(uint16 part) const
 	if (m_hashingProgress != part) {
 		m_hashingProgress = part;
 		// EC exports the hashed-part count via
-		// EC_TAG_PARTFILE_HASHED_PART_COUNT. Hashing runs outside
-		// Process()'s PS_READY/PS_EMPTY gate, so the per-tick mark
-		// doesn't fire — explicit mark here keeps amulegui's
-		// progress bar live during hashing.
+		// EC_TAG_PARTFILE_HASHED_PART_COUNT. Hashing runs outside Process()'s
+		// PS_READY/PS_EMPTY gate, so the per-tick mark does not fire.
 		const_cast<CPartFile *>(this)->MarkECChanged();
 	}
 	Notify_DownloadCtrlUpdateItem(this);
@@ -4830,11 +4683,9 @@ bool CPartFile::IsDeadSource(const CUpDownClient *client)
 const wxString &CPartFile::GetCachedPartMetBasename() const
 {
 	if (m_cachedPartMetBasename.IsEmpty()) {
-		// One-shot evaluate: the partmet filename (e.g. "012.part.met")
-		// is set when the partfile is created and is stable for life,
-		// so cache after first use. The wxString cast collapses the
-		// CFormat round-trip that the EC tag constructor used to do
-		// per request.
+		// One-shot evaluate: the partmet filename is set when the partfile is
+		// created and is stable for life, so cache after first use. The wxString
+		// cast collapses the CFormat round trip the EC tag ctor used to do.
 		m_cachedPartMetBasename = m_partmetfilename.RemoveExt().GetPrintable();
 	}
 	return m_cachedPartMetBasename;

--- a/src/PartFile.h
+++ b/src/PartFile.h
@@ -139,11 +139,9 @@ public:
 	void ClearMetDirty() { m_metDirty = false; }
 	bool IsMetDirty() const { return m_metDirty; }
 
-	// Soft-dirty bit for upload-stat counters (AllTimeRequests,
-	// AllTimeAccepts, AllTimeTransferred).  Flipped by CFileStatistic's
-	// AddRequest / AddAccepted / AddTransferred so a popular sharer does
-	// not re-dirty the partfile on every served chunk.  See m_statsDirty
-	// in the private section.
+	// Soft-dirty bit for upload-stat counters (AllTimeRequests, AllTimeAccepts,
+	// AllTimeTransferred), flipped by CFileStatistic so a popular sharer does not
+	// re-dirty the partfile on every served chunk. See m_statsDirty.
 	void MarkStatsDirty() { m_statsDirty = true; }
 	void ClearStatsDirty() { m_statsDirty = false; }
 	bool IsStatsDirty() const { return m_statsDirty; }
@@ -233,9 +231,9 @@ public:
 	bool HasPendingHashWork() const;
 
 	// Called from CamuleApp's wxEVT_PARTFILE_HASH_RESULT handler when
-	// CPartFileHashThread reports a HashSinglePart result for this
-	// file. Runs the original Phase 3 success/failure logic (AICH
-	// recovery on bad part, SafeAddKFile on good complete part).
+	// CPartFileHashThread reports a HashSinglePart result for this file. Runs the
+	// Phase 3 success/failure logic: AICH recovery on a bad part, SafeAddKFile on a
+	// good complete one.
 	void OnAsyncHashComplete(uint16 partNumber, bool ok, bool fromAICHRecoveryDataAvailable);
 
 	// Barry - Added to prevent list containing deleted blocks on shutdown
@@ -278,9 +276,9 @@ public:
 	void SetDownPriority(uint8 newDownPriority, bool bSave = true, bool bRefresh = true);
 	bool IsAutoDownPriority() const { return m_bAutoDownPriority; }
 	// EC exports the priority with the auto flag folded in via
-	// EC_TAG_PARTFILE_PRIO; mark the change so amulegui/amuleweb see
-	// it without waiting for the next Process() tick (and at all when
-	// the file is paused/stopped — Process() doesn't run then).
+	// EC_TAG_PARTFILE_PRIO; mark the change so remote clients see it without waiting
+	// for the next Process() tick -- and at all when the file is paused or stopped,
+	// where Process() does not run.
 	void SetAutoDownPriority(bool flag)
 	{
 		if (m_bAutoDownPriority != flag) {
@@ -467,55 +465,43 @@ private:
 	// to the STATS_HEARTBEAT_MS cadence (see FlushBuffer).
 	uint64 m_lastMetSaveTick = 0;
 
-	// Soft-dirty bit for upload-stat counters that increment every time
-	// a peer requests / accepts / transfers a chunk
-	// (CFileStatistic::AddRequest / AddAccepted / AddTransferred).
-	// Promoted to a save only on the STATS_HEARTBEAT_MS cadence so a
-	// popular sharer does not write its .met on every served chunk -- a
-	// pure seeder with active uploads would otherwise re-dirty every
-	// partfile on every block served.  Cleared on a successful save.
+	// Soft-dirty bit for upload-stat counters that increment every time a peer
+	// requests, accepts or transfers a chunk. Promoted to a save only on the
+	// STATS_HEARTBEAT_MS cadence, since a pure seeder with active uploads would
+	// otherwise re-dirty every partfile on every block served. Cleared on a
+	// successful save.
 	bool m_statsDirty = false;
 
-	// True when in-memory partfile state has diverged from the on-disk
-	// .part.met since the last successful save.  Gates the periodic
-	// FlushBuffer-driven SavePartFile so idle/seeding partfiles do not
-	// rewrite their .met every 60 s with byte-identical content.
+	// True when in-memory partfile state has diverged from the on-disk .part.met
+	// since the last successful save. Gates the periodic FlushBuffer-driven
+	// SavePartFile, so idle partfiles do not rewrite their .met every 60 s with
+	// byte-identical content.
 	//
-	// Set by MarkMetDirty() at every mutation of a field that ends up
-	// in the .met (gap list, status, priorities, category, AICH state,
-	// corrupted list, lastseencomplete, filename).  Cleared by a
-	// successful SavePartFile().  Stat counters (transferred,
-	// AllTimeRequests, etc.) and download active time deliberately do
-	// NOT mark dirty -- they persist on the next hard-state change or
-	// at shutdown via the destructor's explicit save, and a session's
-	// counters surviving across a crash is best-effort by design.
+	// Set by MarkMetDirty() at every mutation of a field that ends up in the .met
+	// (gap list, status, priorities, category, AICH state, corrupted list,
+	// lastseencomplete, filename), and cleared by a successful SavePartFile().
+	// Stat counters and download active time deliberately do NOT mark dirty: they
+	// persist on the next hard-state change or at shutdown, and a session's
+	// counters surviving a crash is best-effort by design.
 	//
-	// Initialised false: the load path constructs CPartFile in a state
-	// matching the just-read .met, so nothing to flush.  LoadPartFile
-	// explicitly ClearMetDirty()s before each successful return to
-	// undo any MarkMetDirty()s incidentally produced by setters during
-	// tag parsing.  New-download path calls SavePartFile(true) which
-	// writes the initial .met and clears the flag.
+	// Initialised false, the load path constructing CPartFile in a state matching
+	// the just-read .met. LoadPartFile explicitly ClearMetDirty()s before each
+	// successful return, to undo MarkMetDirty()s produced incidentally by setters
+	// during tag parsing.
 	bool m_metDirty = false;
 
-	// Count of HashJobs in flight on CPartFileHashThread targeting
-	// this file. Incremented before enqueue, decremented by the worker
-	// after HashSinglePart and event-post complete. ~CPartFile waits
-	// for this to reach 0 so the worker is never reading m_hpartfile
-	// while the destructor is closing it.
+	// Count of HashJobs in flight on CPartFileHashThread for this file.
+	// Incremented before enqueue, decremented by the worker after HashSinglePart
+	// and the event post complete. ~CPartFile waits for it to reach 0, so the
+	// worker is never reading m_hpartfile while the destructor closes it.
 	std::atomic<int32> m_pendingHashes{ 0 };
 
-	// Serialises access to m_hpartfile across the main thread,
-	// CPartFileWriteThread and CPartFileHashThread. With ENABLE_MMAP=OFF
-	// (the default), CFileAutoClose::ReadAt / WriteAt both implement
-	// positional I/O as Seek+Read / Seek+Write on the same OS fd, so
-	// concurrent hash reads and disk writes would race on the fd's
-	// file position and corrupt one or the other. Held by:
-	//   * CPartFileWriteThread::Entry around pBuffer->area.FlushAt(...)
-	//   * CPartFileHashThread::Entry around HashSinglePart(...)
-	//   * ~CPartFile's sync-hash drain around HashSinglePart(...)
-	//   * FlushBuffer Phase 2's PB_READY synchronous fallback around
-	//     item->area.FlushAt(...)
+	// Serialises access to m_hpartfile across the main thread, CPartFileWriteThread
+	// and CPartFileHashThread. With ENABLE_MMAP=OFF (the default),
+	// CFileAutoClose::ReadAt / WriteAt are Seek+Read / Seek+Write on the same OS fd,
+	// so concurrent hash reads and disk writes would race on the file position.
+	// Held by CPartFileWriteThread::Entry, CPartFileHashThread::Entry, ~CPartFile's
+	// sync-hash drain, and FlushBuffer Phase 2's PB_READY synchronous fallback.
 	std::mutex m_hpartfileMutex;
 
 	/**

--- a/src/PartFileHashThread.cpp
+++ b/src/PartFileHashThread.cpp
@@ -89,18 +89,15 @@ void *CPartFileHashThread::Entry()
 
 	AddDebugLogLineN(logPartFile, wxT("Hash thread: started"));
 
-	// Loop until EndThread() clears m_bRun, then drain one final batch
-	// before returning. Dropping a queued job would skip its
-	// --m_pendingHashes (the only decrement), and ~CPartFile blocks on
-	// `while (m_pendingHashes > 0)` with no other decrementer — so a
-	// dropped job hangs shutdown. Draining also means the part is
-	// actually hashed rather than left unverified (its m_aChangedPart
-	// entry was already cleared at enqueue, so the sync-hash fallback
-	// won't catch it). Mirrors CPartFileWriteThread.
+	// Loop until EndThread() clears m_bRun, then drain one final batch before
+	// returning. Dropping a queued job would skip its --m_pendingHashes, the only
+	// decrement, and ~CPartFile blocks on `while (m_pendingHashes > 0)` -- so a
+	// dropped job hangs shutdown. Draining also means the part is actually hashed
+	// rather than left unverified, its m_aChangedPart entry having been cleared at
+	// enqueue. Mirrors CPartFileWriteThread.
 	for (;;) {
-		// Move queued jobs to a local work list under the lock.
-		// Mirrors CPartFileWriteThread's pattern: minimise lock hold
-		// time so the main thread can keep enqueueing.
+		// Move queued jobs to a local work list under the lock, minimising hold time
+		// so the main thread can keep enqueueing.
 		std::list<HashJob> workList;
 		bool keepRunning;
 		{
@@ -121,19 +118,15 @@ void *CPartFileHashThread::Entry()
 		for (std::list<HashJob>::iterator it = workList.begin(); it != workList.end(); ++it) {
 			const uint64 startTick = GetTickCount64();
 
-			// CPartFile::m_pendingHashes was incremented before enqueue
-			// and is the gate that ~CPartFile waits on, so the file
-			// pointer is guaranteed valid here.
+			// CPartFile::m_pendingHashes was incremented before enqueue and is the
+			// gate ~CPartFile waits on, so the file pointer is valid here.
 			//
 			// Lock m_hpartfileMutex against CPartFileWriteThread: with
-			// ENABLE_MMAP=OFF, HashSinglePart's CFileArea::ReadAt does
-			// Seek+Read on the same fd that the write thread does
-			// Seek+Write on for FlushAt; concurrent execution races
-			// on the fd's file position. The quiescent guard at
-			// enqueue time only gates dispatch — it does not prevent
-			// writes from resuming while the hash thread is still
-			// chewing through a backlog (e.g. user pause → drain →
-			// resume mid-drain). See CPartFile::m_hpartfileMutex.
+			// ENABLE_MMAP=OFF, HashSinglePart's CFileArea::ReadAt does Seek+Read on
+			// the same fd the write thread does Seek+Write on, and the two race on
+			// the file position. The quiescent guard at enqueue time only gates
+			// dispatch; it does not stop writes resuming while the hash thread is
+			// still working through a backlog.
 			bool ok;
 			{
 				std::lock_guard<std::mutex> lock(it->pFile->m_hpartfileMutex);

--- a/src/PartFileWriteThread.cpp
+++ b/src/PartFileWriteThread.cpp
@@ -30,7 +30,7 @@
 #include "Logger.h"
 #include <common/Format.h> // Needed for CFormat
 
-// eMule ref: CPartFileWriteThread::CPartFileWriteThread() — line 41
+// eMule ref: CPartFileWriteThread::CPartFileWriteThread()
 CPartFileWriteThread::CPartFileWriteThread()
 : wxThread(wxTHREAD_JOINABLE)
 , m_condition(m_mutex)
@@ -49,7 +49,7 @@ CPartFileWriteThread::~CPartFileWriteThread()
 	// EndThread() must have been called before destruction.
 }
 
-// eMule ref: CPartFileWriteThread::EndThread() — line 62
+// eMule ref: CPartFileWriteThread::EndThread()
 void CPartFileWriteThread::EndThread()
 {
 	{
@@ -61,8 +61,8 @@ void CPartFileWriteThread::EndThread()
 	Wait();
 }
 
-// eMule ref: CPartFileWriteThread::WakeUpCall() — line 230
 // Called by the main thread to queue a write item.
+// eMule ref: CPartFileWriteThread::WakeUpCall()
 void CPartFileWriteThread::QueueWrite(CPartFile *pFile, PartFileBufferedData *pBuffer)
 {
 	wxMutexLocker lock(m_mutex);
@@ -73,19 +73,14 @@ void CPartFileWriteThread::QueueWrite(CPartFile *pFile, PartFileBufferedData *pB
 
 void CPartFileWriteThread::DropReferencesTo(const CKnownFile *file)
 {
-	// Pointer-value strip of any pending write item whose pFile
-	// matches `file`. Called from MuleNotify::KnownFileBeingDestroyed
-	// before CPartFile is freed by CPartFile::Delete() — without this
-	// the write loop would deref the dangling pFile on the next tick.
+	// Pointer-value strip of any pending write item whose pFile matches `file`.
+	// Called from MuleNotify::KnownFileBeingDestroyed before CPartFile is freed, or
+	// the write loop would deref the dangling pFile on the next tick. CPartFile
+	// inherits from CKnownFile at the same address, so the cast never derefs.
 	//
-	// CPartFile inherits from CKnownFile (single inheritance, same
-	// address); the cast in the compare is no-deref.
-	//
-	// We do NOT delete pBuffer here. PartFileBufferedData ownership
-	// stays with CPartFile::m_BufferedData_list; QueueWrite() only
-	// added a reference here. `~CPartFile` (via DeleteContents on
-	// m_BufferedData_list, PartFile.cpp:334) frees the buffer; if
-	// we also deleted it, that would double-free.
+	// pBuffer is NOT deleted here: ownership stays with
+	// CPartFile::m_BufferedData_list, which ~CPartFile frees, so deleting it here
+	// too would double-free.
 	wxMutexLocker lock(m_mutex);
 	for (std::list<ToWrite>::iterator it = m_flushList.begin(); it != m_flushList.end();
 		/* manual ++ */) {
@@ -97,25 +92,21 @@ void CPartFileWriteThread::DropReferencesTo(const CKnownFile *file)
 	}
 }
 
-// eMule ref: CPartFileWriteThread::RunInternal() — line 69
-// Replaces IOCP + overlapped WriteFile with synchronous CFileArea::FlushAt().
-// The thread is dedicated to writes, so blocking on disk I/O is acceptable —
-// the key win is that the main thread no longer stalls.
+// Replaces eMule's IOCP + overlapped WriteFile with synchronous
+// CFileArea::FlushAt(). The thread is dedicated to writes, so blocking on disk
+// I/O is fine -- the win is that the main thread no longer stalls.
 void *CPartFileWriteThread::Entry()
 {
 	m_bRun = true;
 
-	// Loop until EndThread() clears m_bRun, then drain one final batch
-	// before returning. A shutdown signal must never drop queued writes:
-	// WriteToBuffer FillGap()s each range at queue time and the gaplist is
-	// persisted, so a dropped write would leave the .met claiming bytes
-	// that never reached disk — a silently corrupt part on the next
-	// launch. Each swapped batch is therefore drained in full, and the
-	// exit check happens only after that batch is on disk.
+	// Loop until EndThread() clears m_bRun, then drain one final batch before
+	// returning. A shutdown signal must never drop queued writes: WriteToBuffer
+	// FillGap()s each range at queue time and the gaplist is persisted, so a dropped
+	// write would leave the .met claiming bytes that never reached disk -- a
+	// silently corrupt part on the next launch.
 	for (;;) {
-		// Move queued items to a local work list under the lock.
-		// This minimises lock hold time — main thread can keep queueing
-		// while we process the local list.
+		// Move queued items to a local work list under the lock, so the main thread
+		// can keep queueing while we process it.
 		std::list<ToWrite> workList;
 		bool keepRunning;
 		{
@@ -138,25 +129,19 @@ void *CPartFileWriteThread::Entry()
 			PartFileBufferedData *pBuffer = it->pBuffer;
 			uint32 lenData = (uint32)(pBuffer->end - pBuffer->start + 1);
 
-			// Synchronous write via CFileArea (replaces eMule's overlapped WriteFile).
-			// CFileArea::FlushAt() writes the buffered data at the given offset.
+			// Synchronous write via CFileArea::FlushAt(), which writes the buffered
+			// data at the given offset.
 			//
-			// Lock m_hpartfileMutex against CPartFileHashThread (see
-			// CPartFile::m_hpartfileMutex): with ENABLE_MMAP=OFF the
-			// underlying CFileAutoClose::WriteAt does Seek+Write on the
-			// shared fd, and HashSinglePart on the hash thread does
-			// Seek+Read on the same fd; the two race on file position
-			// without the lock.
+			// Lock m_hpartfileMutex against CPartFileHashThread: with ENABLE_MMAP=OFF
+			// the underlying CFileAutoClose::WriteAt does Seek+Write on the shared fd
+			// while HashSinglePart does Seek+Read on the same one, and the two race on
+			// the file position without it.
 			//
-			// FlushAt can also throw CIOFailureException on a disk-full /
-			// EIO / permission failure.  Catching it here keeps the
-			// worker thread alive: an unhandled exception in Entry()
-			// propagates through wxThreadInternal::PthreadStart() to
-			// wxApp::OnUnhandledException(), which std::set_terminate's
-			// MuleDebug aborts the process.  On caught failure we mark
-			// the buffered item PB_ERROR so the main thread can retry on
-			// the next FlushBuffer (where CheckFreeDiskSpace will pause
-			// the file if disk is genuinely exhausted).
+			// FlushAt can throw CIOFailureException on a disk-full, EIO or permission
+			// failure. Catching it keeps the worker alive: an unhandled exception in
+			// Entry() reaches wxApp::OnUnhandledException(), whose terminate handler
+			// aborts the process. On failure the item is marked PB_ERROR so the main
+			// thread retries on the next FlushBuffer.
 			bool writeOk = true;
 			try {
 				std::lock_guard<std::mutex> lock(it->pFile->m_hpartfileMutex);
@@ -174,12 +159,10 @@ void *CPartFileWriteThread::Entry()
 			// so main thread can check m_iWrites at any time.
 			--it->pFile->m_iWrites;
 
-			// Mark buffer as written / errored so the main thread can harvest
-			// it.  PB_ERROR is handled in FlushBuffer Phase 2 (resets to
-			// PB_READY for retry; if the disk is genuinely full the next
-			// FlushBuffer's CheckFreeDiskSpace pauses the file before the
-			// retry loops).
-			// eMule ref: WriteCompletionRoutine — line 182
+			// Mark the buffer written or errored so the main thread can harvest it.
+			// PB_ERROR is handled in FlushBuffer Phase 2, which resets it to PB_READY
+			// for retry -- and if the disk is genuinely full, CheckFreeDiskSpace pauses
+			// the file before the retry loops.
 			pBuffer->flushed = writeOk ? PB_WRITTEN : PB_ERROR;
 		}
 

--- a/src/Preferences.cpp
+++ b/src/Preferences.cpp
@@ -843,13 +843,11 @@ public:
 			dataDir = wxStandardPaths::Get().GetResourcesDir();
 		}
 #if defined(__WINDOWS__)
-		// Windows portable layout puts amule.exe in bin\ and installable
-		// data (skins, webserver templates, ...) in ..\share\amule\.
-		// wxStandardPaths::GetDataDir() / GetResourcesDir() both return
-		// the exe directory on Windows, so relocate up one level and into
-		// the FHS-style share/amule/ tree the installer actually populates.
-		// Mirrors the BeforeLast('/') + "/amule" adjustment used on Linux
-		// below for the same purpose. (#783)
+		// Windows portable layout puts amule.exe in bin\ and installable data
+		// (skins, webserver templates, ...) in ..\share\amule\.
+		// wxStandardPaths::GetDataDir() / GetResourcesDir() both return the exe
+		// directory on Windows, so relocate up one level and into the FHS-style
+		// share/amule/ tree the installer actually populates.
 		dataDir = JoinPaths(JoinPaths(dataDir, ".."), "share");
 		dataDir = JoinPaths(dataDir, "amule");
 #elif !defined(__WXMAC__)
@@ -883,25 +881,19 @@ public:
 				id = 0;
 				m_value = defaultSelection;
 			} else if (placeholderAppended) {
-				// No real templates found and m_value doesn't match
-				// the placeholder we just appended. m_value is almost
-				// certainly a localized "no options available" string
-				// saved by a prior session under a different aMule
-				// locale (e.g. saved as "nessuna opzione disponibile"
-				// in Italian, now reopened with the locale set to
-				// English). Falling through to the cross-host preserve
-				// branch below would re-append the stale string and
-				// leave the dropdown showing two placeholders. Discard
-				// it instead — the placeholder is the only valid
-				// "selection" when no real templates exist. (#800)
+				// No real templates found and m_value does not match the placeholder
+				// just appended. m_value is almost certainly a localized "no options
+				// available" string saved by a prior session under a different aMule
+				// locale. Falling through to the cross-host preserve branch below
+				// would re-append the stale string and leave the dropdown showing two
+				// placeholders. Discard it instead.
 				id = 0;
 				m_value.Clear();
 			} else if (!m_value.IsEmpty()) {
-				// Template names are consumed by amuleweb, which may
-				// be running on a different host than amulegui or
-				// installing templates outside the GUI's scanned
-				// directories. Preserve the configured value in the
-				// dropdown so a Save round-trip doesn't erase it.
+				// Template names are consumed by amuleweb, which may be running on a
+				// different host than amulegui or installing templates outside the
+				// GUI's scanned directories. Preserve the configured value in the
+				// dropdown so a Save round-trip does not erase it.
 				id = skinSelector->Append(m_value);
 			} else {
 				id = 0;
@@ -1023,13 +1015,11 @@ CPreferences::CPreferences()
 #ifndef CLIENT_GUI
 	s_firstRun = !wxFileExists(fullpath);
 
-	// Migration for installs that predate the explicit first-run flag:
-	// they have a populated config but no /eMule/FirstRunWizardDone
-	// entry. Mark the wizard as already done for them so it never
-	// retroactively pops up. A genuine fresh install (no preferences.dat)
-	// is left alone, so the wizard runs once and then persists its own
-	// flag via FirstRunWizard::Apply(). LoadAllItems() has already run by
-	// this point, so the entry is the authoritative signal.
+	// Migration for installs that predate the explicit first-run flag: they have
+	// a populated config but no /eMule/FirstRunWizardDone entry. Mark the wizard
+	// as already done for them so it never retroactively pops up. A genuine
+	// fresh install is left alone, so the wizard runs once and then persists its
+	// own flag. LoadAllItems() has already run, so the entry is authoritative.
 	if (!s_firstRun) {
 		wxConfigBase *cfg = wxConfigBase::Get();
 		if (cfg && !cfg->HasEntry("/eMule/FirstRunWizardDone")) {
@@ -1055,11 +1045,10 @@ CPreferences::CPreferences()
 			RawPokeUInt16(s_userhash.GetHash() + (i * 2), rand());
 		}
 
-		// Persist only preferences.dat and amule.conf here. A full
-		// Save() would also call SaveSharedFolders() against
-		// still-empty in-memory lists (ReloadSharedFolders runs
-		// below), truncating any shareddir-*.dat files a pre-launch
-		// script may have populated.
+		// Persist only preferences.dat and amule.conf here. A full Save() would
+		// also call SaveSharedFolders() against still-empty in-memory lists,
+		// truncating any shareddir-*.dat files a pre-launch script may have
+		// populated.
 		CFile preffile;
 		if (!wxFileExists(fullpath)) {
 			preffile.Create(fullpath);
@@ -1293,8 +1282,7 @@ void CPreferences::BuildItemList(const wxString &appdir)
 	// network before the user has thought about it. Existing configs are
 	// untouched: aMule writes every key on save, so any config it has ever
 	// written already carries an ECAddress line, and wxConfig only applies a
-	// default when the key is *absent*. An empty value keeps meaning "any
-	// address" (see amule.cpp), so upgrades keep binding exactly as before.
+	// default when the key is *absent*. An empty value still means "any".
 	NewCfgItem(IDC_EXT_CONN_IP, (new Cfg_Str("/ExternalConnect/ECAddress", s_ECAddr, "127.0.0.1")));
 	NewCfgItem(IDC_EC_INTERFACE,
 		(new Cfg_Str("/ExternalConnect/ECNetworkInterface", s_ECNetworkInterface, "")));
@@ -1304,11 +1292,9 @@ void CPreferences::BuildItemList(const wxString &appdir)
 	NewCfgItem(IDC_UPNP_EC_ENABLED,
 		(new Cfg_Bool("/ExternalConnect/UPnPECEnabled", s_UPnPECEnabled, false)));
 	// Brute-force throttle for the EC password exchange. Config-only, with no
-	// dialog field: the defaults suit everyone who is not tuning for an
-	// unusual deployment, and a busy Remote Controls page is a poor place to
-	// explain a sliding window. amuleapi exposes the same three knobs for its
-	// own login, so an operator can now tune both front doors rather than only
-	// the narrower one.
+	// dialog field: the defaults suit everyone who is not tuning for an unusual
+	// deployment, and a busy Remote Controls page is a poor place to explain a
+	// sliding window. amuleapi exposes the same three knobs for its own login.
 	s_MiscList.push_back(
 		MkCfg_Int("/ExternalConnect/AuthFailureWindowSeconds", s_ECAuthFailureWindowSeconds, 60));
 	s_MiscList.push_back(

--- a/src/Preferences.h
+++ b/src/Preferences.h
@@ -229,47 +229,34 @@ public:
 
 	void Save();
 	void SaveCats();
-	// Read shareddir-explicit.dat, shareddir-recursive.dat, and
-	// shareddir.dat from disk; recompute shareddir_list as the union
-	// of the explicit list and the recursive expansion; reconcile any
-	// drift from external writers (e.g. a Docker entrypoint script
-	// that edits shareddir.dat directly and then calls Reload via
-	// EC); rewrite shareddir.dat as the new union. Safe to call from
-	// startup, the EC ReloadSharedFiles command, the UI Reload
-	// button, and the watcher's debounced reload.
+	// Read the three shared-dir files, recompute shareddir_list as the union of
+	// the explicit list and the recursive expansion, reconcile drift from external
+	// writers (a Docker entrypoint editing shareddir.dat directly, then calling
+	// Reload over EC) and rewrite shareddir.dat as the new union.
 	void ReloadSharedFolders();
-	// Persist all three shared-dir files: shareddir-explicit.dat,
-	// shareddir-recursive.dat (the two canonical sources of truth)
-	// and shareddir.dat (regenerated as the union, for backwards
-	// compatibility with older binaries and scripts that read it).
-	// Called by CSharedDirWatcher after it auto-appends a
-	// newly-created subdirectory so the change survives a restart
-	// without forcing a full preferences.dat write.
+	// Persist all three shared-dir files: the two canonical sources of truth plus
+	// shareddir.dat, regenerated as the union for older binaries and scripts that
+	// read it. Called by CSharedDirWatcher after it auto-appends a new subdir, so
+	// the change survives a restart without a full preferences.dat write.
 	void SaveSharedFolders();
-	// True iff `path` is in shareddir_recursive_list or is a
-	// descendant of an entry there. Used by the watcher to decide
-	// whether auto-add of a new subdir / cold-discovered subdir is
-	// authorised: non-recursive share roots do NOT auto-collect new
-	// subdirs, recursive roots do.
+	// True iff `path` is in shareddir_recursive_list or descends from an entry
+	// there. The watcher gates auto-add on this: non-recursive share roots do not
+	// collect new subdirs, recursive ones do.
 	bool IsRecursiveAncestor(const CPath &path) const;
 
 	static const wxString &GetConfigDir() { return s_configDir; }
 	static void SetConfigDir(const wxString &dir) { s_configDir = dir; }
 
-	// True when this process started without an existing
-	// preferences.dat, i.e. a fresh install / first launch. Captured
-	// once in the CPreferences constructor (before the file is
-	// created) so the first-run setup wizard can be shown exactly
-	// once. Always false in the remote GUI, which has no local config.
+	// True when this process started without an existing preferences.dat.
+	// Captured in the constructor, before the file is created, so the first-run
+	// wizard shows exactly once. Always false in the remote GUI.
 	static bool IsFirstRun() { return s_firstRun; }
 
-	// True once the first-run setup wizard has actually been completed
-	// (the user pressed Finish). Unlike IsFirstRun(), which is merely
-	// inferred from the absence of preferences.dat, this is an explicit
-	// persisted flag (/eMule/FirstRunWizardDone, written in
-	// FirstRunWizard::Apply): it distinguishes a completed run from a
-	// cancelled one and lets the wizard be re-triggered simply by
-	// clearing the flag. Always false in the remote GUI.
+	// True once the first-run wizard was actually completed (the user pressed
+	// Finish). Unlike IsFirstRun(), which is only inferred from a missing
+	// preferences.dat, this is a persisted flag (/eMule/FirstRunWizardDone), so it
+	// separates a completed run from a cancelled one and re-triggers the wizard
+	// when cleared. Always false in the remote GUI.
 	static bool IsFirstRunWizardDone() { return s_firstRunWizardDone; }
 	static void SetFirstRunWizardDone(bool val) { s_firstRunWizardDone = val; }
 
@@ -343,9 +330,9 @@ public:
 
 	static uint32 GetMaxDownload() { return s_maxdownload; }
 	static uint16 GetMaxConnections() { return s_maxconnections; }
-	// OS-aware ceiling for the connection count (accounts for the
-	// half-open-connection limit on legacy Windows). Used as the default
-	// MaxConnections and to clamp the first-run wizard's derived limits.
+	// OS-aware ceiling for the connection count (the half-open-connection limit
+	// on legacy Windows). Default MaxConnections, and the clamp on the wizard's
+	// derived limits.
 	static int32 GetRecommendedMaxConnections();
 	static uint16 GetMaxSourcePerFile() { return s_maxsourceperfile; }
 	static uint16 GetMaxSourcePerFileSoft()
@@ -450,43 +437,33 @@ public:
 	static void SetSlotAllocation(uint32 in) { s_slotallocation = (in >= 1) ? in : 1; };
 
 	typedef std::vector<CPath> PathList;
-	// The effective set of shared directories at runtime, computed at
-	// load time as `shareddir_explicit_list ∪ expand(shareddir_recursive_list)`.
-	// Persisted as the union to shareddir.dat for backwards compatibility
-	// with older binaries and external scripts that read/write that file.
-	// Live consumers (share scan, watcher) treat this as authoritative.
+	// The effective set of shared directories at runtime, computed at load time
+	// as the explicit list plus the expansion of the recursive one. Persisted as
+	// the union to shareddir.dat for older binaries and external scripts; live
+	// consumers treat it as authoritative.
 	PathList shareddir_list;
 
-	// User-explicit non-recursive share roots. Each entry shares only
-	// the files directly under it -- subdirectories are NOT followed.
-	// New subdirs created at runtime under an explicit-only root are
-	// NOT auto-shared (CSharedDirWatcher::RegisterNewSubdirectory
-	// gates on "ancestor is recursive"). Persisted to
-	// shareddir-explicit.dat. Migration: a pre-existing shareddir.dat
-	// with no shareddir-recursive.dat is loaded entirely into this
-	// list, which preserves the user's existing path set without
-	// silently upgrading anything to recursive (safer default).
+	// User-explicit non-recursive share roots: only the files directly under each
+	// entry are shared, and new subdirs created at runtime are NOT auto-shared
+	// (CSharedDirWatcher::RegisterNewSubdirectory gates on "ancestor is
+	// recursive"). A pre-existing shareddir.dat with no shareddir-recursive.dat
+	// migrates entirely into this list, so nothing is silently made recursive.
 	PathList shareddir_explicit_list;
 
-	// User-explicit recursive share roots. Each entry contributes
-	// itself AND every descendant directory to shareddir_list at
-	// load time (cold expansion). New subdirs created at runtime
-	// under a recursive root are auto-added by the watcher's HOT
-	// path. Persisted to shareddir-recursive.dat -- a separate file
-	// so older binaries that read shareddir.dat see the already-
-	// expanded union and behave correctly, while round-tripping
-	// shareddir.dat through an older binary preserves the recursive
-	// intent in this file.
+	// User-explicit recursive share roots: each contributes itself and every
+	// descendant directory to shareddir_list at load time, and new subdirs are
+	// auto-added by the watcher. Kept in a file of its own so older binaries see
+	// the already-expanded union in shareddir.dat, while round-tripping that file
+	// through an older binary still preserves the recursive intent here.
 	PathList shareddir_recursive_list;
 
 	wxArrayString addresses_list;
 
 	// A user-configured remote->local path-prefix substitution, for amuleGUI
-	// (CLIENT_GUI) against a daemon on a different machine whose filesystem is
-	// otherwise reachable (a Samba/NFS mount, say). remotePrefix is an opaque
-	// string in the daemon's own OS path syntax -- never wrapped in CPath,
-	// which has no notion of a second machine's separator convention.
-	// localPrefix is a real path on this machine, so it *is* a CPath.
+	// against a daemon on another machine whose filesystem is otherwise reachable.
+	// remotePrefix is an opaque string in the daemon's own path syntax -- never a
+	// CPath, which has no notion of a second machine's separator convention.
+	// localPrefix is a real path here, so it is a CPath.
 	struct PathMapping
 	{
 		wxString remotePrefix;
@@ -534,11 +511,10 @@ public:
 	static void SetUPnPWebServerEnabled(bool val) { s_UPnPWebServerEnabled = val; }
 	static uint16 GetUPnPTCPPort() { return s_UPnPTCPPort; }
 	static void SetUPnPTCPPort(uint16 val) { s_UPnPTCPPort = val; }
-	// Runtime capability (not persisted): whether the connected daemon is
-	// built with UPnP (ENABLE_UPNP), advertised over EC. amulegui greys the
-	// P2P-UPnP controls when the core can't forward. Set from the EC prefs
-	// apply; false by default so a pre-3.1 daemon (which never sends the tag)
-	// keeps the controls disabled instead of showing a dead toggle.
+	// Runtime capability (not persisted): whether the connected daemon is built
+	// with UPnP, advertised over EC. False by default, so a pre-3.1 daemon (which
+	// never sends the tag) keeps the P2P-UPnP controls greyed rather than showing
+	// a dead toggle.
 	static bool GetUPnPAvailable() { return s_UPnPAvailable; }
 	static void SetUPnPAvailable(bool val) { s_UPnPAvailable = val; }
 	static bool IsManualHighPrio() { return s_bmanualhighprio; }
@@ -595,31 +571,28 @@ public:
 	static const wxString &GetAmuleApiBindAddress() { return s_sAmuleApiBindAddress; }
 	static void SetAmuleApiBindAddress(const wxString &addr) { s_sAmuleApiBindAddress = addr; }
 	// amuleapi's credentials are NOT stored here. They live in
-	// amuleapi-passwords, salted and stretched, which amuleapi, amuled and
-	// monolithic aMule all read and write through webcommon/Credentials.h.
-	// See AmuleApiCredentials.h.
+	// amuleapi-passwords, salted and stretched, read and written through
+	// webcommon/Credentials.h; see AmuleApiCredentials.h.
 	//
-	// The two password fields below are pending *requests* rather than
-	// stored values: an MD5 hex digest the user just typed, waiting to be
-	// hashed into the credential file, and empty the rest of the time.
-	// Empty therefore means "leave the stored password alone", which is
-	// what lets an EC client change the port without also having to know
-	// (and resend) a password it can never read back.
+	// The two password fields below are pending *requests*: an MD5 hex digest the
+	// user just typed, waiting to be hashed into the credential file, and empty
+	// the rest of the time. Empty therefore means "leave the stored password
+	// alone", which is what lets an EC client change the port without resending a
+	// password it can never read back.
 	static const wxString &GetAmuleApiPass() { return s_sAmuleApiPassword; }
 	static void SetAmuleApiPass(const wxString &pass) { s_sAmuleApiPassword = pass; }
 	static const wxString &GetAmuleApiGuestPass() { return s_sAmuleApiGuestPassword; }
 	static void SetAmuleApiGuestPass(const wxString &pass) { s_sAmuleApiGuestPassword = pass; }
 
-	// Guest access is on exactly when a guest credential is stored, so
-	// this is a mirror of the credential file rather than a preference of
-	// its own — turning it off is what clears the stored guest password.
+	// Guest access is on exactly when a guest credential is stored, so this
+	// mirrors the credential file rather than being a preference of its own:
+	// turning it off is what clears the stored guest password.
 	static bool GetAmuleApiGuestIsEnabled() { return s_bAmuleApiGuestEnabled; }
 	static void SetAmuleApiGuestIsEnabled(bool enable) { s_bAmuleApiGuestEnabled = enable; }
 
-	// Whether an admin credential is stored. Display only — there is no
-	// setter over EC, because the digest itself can never be read back out
-	// of the credential file. On amulegui this is whatever the daemon
-	// reported; on monolithic aMule it is read from the file directly.
+	// Whether an admin credential is stored. Display only -- there is no setter
+	// over EC, because the digest can never be read back out of the credential
+	// file. On amulegui this is whatever the daemon reported.
 	static bool GetAmuleApiAdminIsSet() { return s_bAmuleApiAdminIsSet; }
 	static void SetAmuleApiAdminIsSet(bool isSet) { s_bAmuleApiAdminIsSet = isSet; }
 	static const wxString &GetAmuleApiPath() { return s_sAmuleApiPath; }
@@ -706,11 +679,10 @@ public:
 	static bool GetMMapEnabled() { return s_mmapEnabled; }
 	static void SetMMapEnabled(bool val) { s_mmapEnabled = val; }
 
-	// Runtime capability: is mmap compiled into the core we drive? On the
-	// monolithic/daemon this mirrors the local MMAP_SUPPORTED; on the remote
-	// GUI it is what the daemon advertised over EC (EC_TAG_FILES_MMAP_SUPPORTED
-	// presence). Not persisted. The prefs dialog shows the mmap checkbox and EC
-	// ships the value only when this is true.
+	// Runtime capability: is mmap compiled into the core we drive? Mirrors the
+	// local MMAP_SUPPORTED on the monolithic/daemon; on the remote GUI it is what
+	// the daemon advertised over EC. The mmap checkbox and the EC value are both
+	// gated on it.
 	static bool GetMMapSupported() { return s_mmapSupported; }
 	static void SetMMapSupported(bool val) { s_mmapSupported = val; }
 
@@ -788,16 +760,14 @@ public:
 	static bool ShareHiddenFiles() { return s_ShareHiddenFiles; }
 	static void SetShareHiddenFiles(bool val) { s_ShareHiddenFiles = val; }
 
-	// Automatic rescan of shared directories via wxFileSystemWatcher.
-	// On by default; when disabled, the user must hit "Reload shared
-	// files" manually after adding files to a share.
+	// Automatic rescan of shared directories via wxFileSystemWatcher. When
+	// disabled, the user must hit "Reload shared files" manually.
 	static bool AutoRescanSharedDirs() { return s_AutoRescanSharedDirs; }
 	static void SetAutoRescanSharedDirs(bool val) { s_AutoRescanSharedDirs = val; }
 
-	// Whether shared-folder walks should descend into symbolic links.
-	// Default true to preserve historical behaviour; turning it off
-	// passes wxDIR_NO_FOLLOW to the iterator so symlinked files and
-	// directories are skipped entirely.
+	// Whether shared-folder walks descend into symbolic links. Default true for
+	// historical behaviour; off passes wxDIR_NO_FOLLOW to the iterator, skipping
+	// symlinked files and directories entirely.
 	static bool FollowSymlinksInShares() { return s_FollowSymlinksInShares; }
 	static void SetFollowSymlinksInShares(bool val) { s_FollowSymlinksInShares = val; }
 
@@ -819,10 +789,10 @@ public:
 	{
 		return s_ShareExcludeFilter.Matches(fileName);
 	}
-	// Count how many names in the list would be excluded by a candidate
-	// (pattern, useRegex) -- used by the Directories panel's live preview,
-	// which tests the typed-but-unsaved pattern without touching the live
-	// filter. Returns wxNOT_FOUND if the regex does not compile.
+	// How many names in the list a candidate (pattern, useRegex) would exclude --
+	// for the Directories panel's live preview, which tests a typed-but-unsaved
+	// pattern without touching the live filter. wxNOT_FOUND if the regex does not
+	// compile.
 	static int PreviewExcludeCount(
 		const wxString &patterns, bool useRegex, const wxArrayString &fileNames);
 
@@ -830,18 +800,15 @@ public:
 
 	static bool GetCheckNewVersion() { return s_NewVersionCheck; }
 	static void SetCheckNewVersion(bool val) { s_NewVersionCheck = val; }
-	// Runtime-only (not persisted): whether the connected daemon can actually
-	// perform version checks (advertised via EC_TAG_GENERAL_VERSION_CHECK_AVAILABLE).
-	// Set from the EC prefs-apply; the remote GUI reads it to hide the
-	// "check for new version" checkbox against a daemon that can't check.
+	// Runtime-only (not persisted): whether the connected daemon can perform
+	// version checks. The remote GUI reads it to hide the "check for new version"
+	// checkbox against a daemon that cannot.
 	static bool GetVersionCheckAvailable() { return s_versionCheckAvailable; }
 	static void SetVersionCheckAvailable(bool val) { s_versionCheckAvailable = val; }
 
-	// Media metadata (issue #140) — probe local shared files with
-	// ffprobe so we advertise Length / Bitrate / Codec to peers.
-	// The path is empty unless the user pins one, and empty means
-	// auto-detect, not off: MediaProbe::DetectedPath() resolves it
-	// per process when the first file is probed.
+	// Media metadata (issue #140): probe local shared files with ffprobe so we
+	// advertise Length / Bitrate / Codec to peers. An empty path means
+	// auto-detect, not off -- MediaProbe::DetectedPath() resolves it per process.
 	static bool GetMediaMetadataEnabled() { return s_MediaMetadataEnabled; }
 	static void SetMediaMetadataEnabled(bool val) { s_MediaMetadataEnabled = val; }
 	static const wxString &GetMediaMetadataFFProbePath() { return s_MediaMetadataFFProbePath; }
@@ -892,10 +859,9 @@ public:
 
 	// GeoIP / IP2Country
 	//
-	// Source selector — choose which provider supplies the .mmdb. Values
-	// are persisted as strings ("dbip", "maxmind", "custom") so the config
-	// file stays human-readable across releases. See Preferences.cpp for
-	// the legacy GeoLiteCountryUpdateUrl → custom migration.
+	// Which provider supplies the .mmdb. Persisted as strings ("dbip",
+	// "maxmind", "custom") so the config file stays readable across releases; see
+	// Preferences.cpp for the legacy GeoLiteCountryUpdateUrl -> custom migration.
 	enum GeoIPSource
 	{
 		GeoIPSourceDBIP = 0,
@@ -907,14 +873,12 @@ public:
 	static void SetGeoIPEnabled(bool v) { s_GeoIPEnabled = v; }
 	static GeoIPSource GetGeoIPSource();
 	static void SetGeoIPSource(GeoIPSource v);
-	// "Source of the currently-loaded geoip.mmdb" — distinct from
-	// GetGeoIPSource() which is the *next-download* selector. Updated
-	// by CIP2Country::DownloadFinished on success so the status line
-	// can correctly attribute a loaded DB even after the user flips
-	// the dropdown to a different source they haven't yet downloaded
-	// from. Empty string ("") means the file was hand-installed by the
-	// user (or migrated from the legacy GeoLite2-Country.mmdb path), in
-	// which case the status line shows "Loaded" with no attribution.
+	// Source of the currently-loaded geoip.mmdb, as distinct from
+	// GetGeoIPSource(), which selects the NEXT download. Updated by
+	// CIP2Country::DownloadFinished so the status line still attributes a loaded
+	// DB after the user flips the dropdown to a source they have not downloaded
+	// from. Empty means hand-installed (or migrated from the legacy path), and the
+	// status line then shows "Loaded" with no attribution.
 	static const wxString &GetGeoIPLoadedSource() { return s_GeoIPLoadedSource; }
 	static void SetGeoIPLoadedSource(GeoIPSource v);
 	static const wxString &GetGeoIPMaxMindLicense() { return s_GeoIPMaxMindLicense; }
@@ -923,15 +887,13 @@ public:
 	static void SetGeoIPCustomUrl(const wxString &v) { s_GeoIPCustomUrl = v; }
 	static bool IsGeoIPAutoUpdate() { return s_GeoIPAutoUpdate; }
 	static void SetGeoIPAutoUpdate(bool v) { s_GeoIPAutoUpdate = v; }
-	// Runtime capability (not persisted): does the *core* have GeoIP compiled
-	// in? Always true for monolithic amule; set from EC_TAG_IP2COUNTRY_SUPPORTED
-	// on amulegui so its GeoIP prefs panel can disable itself against a
-	// GeoIP-less daemon (#440 remote config). Defaults true.
+	// Runtime capability (not persisted): does the *core* have GeoIP compiled in?
+	// Always true for monolithic amule; on amulegui it comes from
+	// EC_TAG_IP2COUNTRY_SUPPORTED, so the GeoIP panel can disable itself.
 	static bool IsGeoIPSupported() { return s_GeoIPSupported; }
 	static void SetGeoIPSupported(bool v) { s_GeoIPSupported = v; }
-	// Live GeoIP status mirrored from the daemon over EC (#440), for amulegui's
-	// prefs panel. Runtime-only, not persisted. Monolithic amule reads the live
-	// resolver directly and ignores these.
+	// Live GeoIP status mirrored from the daemon over EC, for amulegui's prefs
+	// panel. Monolithic amule reads the live resolver and ignores these.
 	static bool IsGeoIPStatusLoaded() { return s_GeoIPStatusLoaded; }
 	static void SetGeoIPStatusLoaded(bool v) { s_GeoIPStatusLoaded = v; }
 	static bool IsGeoIPStatusDownloading() { return s_GeoIPStatusDownloading; }
@@ -941,31 +903,25 @@ public:
 	static const wxString &GetGeoIPStatusLoadedSource() { return s_GeoIPStatusLoadedSource; }
 	static void SetGeoIPStatusLoadedSource(const wxString &v) { s_GeoIPStatusLoadedSource = v; }
 
-	// Transient "Update now" trigger. amulegui's prefs panel sets this before
-	// its SendToRemote() so the outgoing prefs packet carries an UPDATE_NOW
-	// tag, asking the daemon to refresh its GeoIP DB (the amulegui side has no
-	// local resolver). Runtime-only; cleared after the send. The daemon never
-	// sets it, so its own outbound prefs serialization never emits the tag.
+	// Transient "Update now" trigger: amulegui's prefs panel sets it before
+	// SendToRemote() so the outgoing packet carries an UPDATE_NOW tag, asking the
+	// daemon to refresh its GeoIP DB. Cleared after the send, and never set by the
+	// daemon, whose own outbound serialization therefore never emits the tag.
 	static bool IsGeoIPUpdateRequested() { return s_GeoIPUpdateRequested; }
 	static void SetGeoIPUpdateRequested(bool v) { s_GeoIPUpdateRequested = v; }
 
-	// Computes the resolved download URL from the selected source: DB-IP
-	// gets a month substituted into the template; MaxMind has credentials
-	// inserted at the URL-userinfo position; Custom is the stored URL
-	// verbatim. Returns empty if the selected source has not been
-	// configured (e.g. MaxMind with empty credentials, Custom with empty
-	// URL).
+	// Resolved download URL for the selected source: DB-IP gets a month
+	// substituted into the template, MaxMind has credentials inserted at the
+	// URL-userinfo position, Custom is the stored URL verbatim. Empty if the
+	// source is not configured.
 	//
-	// monthOffset (DB-IP only) shifts the templated month — 0 = current,
-	// -1 = previous, etc. DB-IP often publishes the new month's file a
-	// few days late, so the IP2Country update path retries with -1 on a
-	// download failure to ride out the early-of-month gap. Ignored by
-	// MaxMind and Custom (their URLs aren't month-templated).
+	// monthOffset (DB-IP only) shifts the templated month. DB-IP often publishes
+	// the new month's file a few days late, so the update path retries with -1 to
+	// ride out the early-of-month gap.
 	static wxString GetGeoIPResolvedDownloadUrl(int monthOffset = 0);
 
-	// Legacy: the v2.x single-URL setting. Kept only for the one-shot
-	// migration in CPreferences::LoadPreferences(). Do not use in new
-	// code; query GetGeoIPResolvedDownloadUrl() instead.
+	// Legacy v2.x single-URL setting, kept only for the one-shot migration in
+	// LoadPreferences(). Query GetGeoIPResolvedDownloadUrl() instead.
 	static const wxString &GetGeoIPUpdateUrl() { return s_GeoIPUpdateUrl; }
 
 	// Stats server
@@ -998,14 +954,10 @@ private:
 	void LoadPreferences();
 	void SavePreferences();
 
-	// GUI-local only: never read from or written to over EC, unlike
-	// LoadCats()/SaveCats() (daemon-owned, EC-refreshed) or
-	// LoadSharedDirsRemote()/SendSharedDirsToRemote() (daemon round-trip).
-	// Group-per-row shape mirrors SaveCats()'s /Cat#i pattern, but these
-	// read/write wxConfigBase::Get() directly rather than going through
-	// LoadAllItems()/SaveAllItems()'s Cfg_Base walk, which is what
-	// CEC_Prefs_Packet draws from -- kept separate is what keeps path
-	// mappings out of any EC exchange.
+	// GUI-local only: never read from or written to over EC, unlike LoadCats()/
+	// SaveCats() or LoadSharedDirsRemote()/SendSharedDirsToRemote(). These go
+	// straight to wxConfigBase::Get() rather than through the Cfg_Base walk that
+	// CEC_Prefs_Packet draws from, which is what keeps path mappings off EC.
 	void LoadPathMappings();
 	void SavePathMappings();
 
@@ -1095,8 +1047,8 @@ protected:
 	static bool s_startMinimized;
 	static uint16 s_MaxConperFive;
 	// Source-search tuning (see the matching accessors). Reask intervals are
-	// stored in minutes (uint64, like s_dwServerKeepAliveTimeoutMins) so the
-	// getters can widen to milliseconds without narrowing.
+	// stored in minutes so the getters can widen to milliseconds without
+	// narrowing.
 	static uint16 s_kadMaxSourceSearches;
 	static uint64 s_kadSourceReaskMins;
 	static uint64 s_sourceReaskMins;

--- a/src/PrefsUnifiedDlg.cpp
+++ b/src/PrefsUnifiedDlg.cpp
@@ -263,10 +263,9 @@ PrefsPage pages[] = { { wxTRANSLATE("General"), PreferencesGeneralTab, 13, "pref
 	{ wxTRANSLATE("Interface"), PreferencesGuiTweaksTab, 19, "prefs_interface" },
 #ifdef GEOIP_GUI
 	// Inserted between Interface and Statistics so the GeoIP / country-flag
-	// settings sit next to the related display option (the master
-	// IDC_SHOW_COUNTRY_FLAGS checkbox lives in this new tab too). Hidden
-	// from the page list when ENABLE_IP2COUNTRY is off so users who built
-	// without libmaxminddb don't see a panel that can't function.
+	// settings sit next to the related display option. Hidden from the page list
+	// when ENABLE_IP2COUNTRY is off, so users who built without libmaxminddb do
+	// not see a panel that cannot function.
 	{ wxTRANSLATE("IP2Country"), PreferencesIP2CountryTab, 13, "prefs_ip2country" },
 #endif
 	{ wxTRANSLATE("Statistics"), PreferencesStatisticsTab, 10, "prefs_statistics" },
@@ -304,15 +303,12 @@ PrefsUnifiedDlg::PrefsUnifiedDlg(wxWindow *parent)
 	m_PrefsIcons = CastChild(ID_PREFSLISTCTRL, wxDataViewListCtrl);
 	const int kPrefsIconW = 16;
 	const int kPrefsIconH = 16;
-	// Room for the gap after the icon and the cell's left/right padding.
-	// On macOS this is only the width the list is built with, since the
-	// measurement below replaces it -- but it has to be generous, because
-	// what that measurement reports is bounded by the room the control
-	// already has: ask from a column pinned to a tight estimate and the
-	// answer comes back tight, whatever the cells actually need. On GTK
-	// and MSW no measurement follows, so this is the width itself: enough
-	// for the cell's own padding, plus room after the longest label so it
-	// does not sit against the edge of the list.
+	// Room for the gap after the icon and the cell's left/right padding. On macOS
+	// this is only the width the list is built with, since the measurement below
+	// replaces it -- but it has to be generous, because what that measurement
+	// reports is bounded by the room the control already has: ask from a column
+	// pinned to a tight estimate and the answer comes back tight. On GTK and MSW
+	// no measurement follows, so this is the width itself.
 #ifdef __WXMAC__
 	const int kCellPadding = 48;
 #else
@@ -320,11 +316,10 @@ PrefsUnifiedDlg::PrefsUnifiedDlg(wxWindow *parent)
 #endif
 
 	// The page art only exists at one (16x16) size. Wrap each icon in a
-	// wxBitmapBundle with a smooth 2x upscale so DPI-aware builds render
-	// it at the correct logical size on hi-DPI screens instead of a tiny
-	// 16-physical-pixel square (same treatment as the main toolbar). The
-	// mask is turned into an alpha channel first because high-quality
-	// scaling needs it.
+	// wxBitmapBundle with a smooth 2x upscale so DPI-aware builds render it at
+	// the correct logical size on hi-DPI screens instead of a tiny
+	// 16-physical-pixel square. The mask is turned into an alpha channel first
+	// because high-quality scaling needs it.
 	auto makeIcon = [&](const wxBitmap &src) -> wxBitmapBundle {
 		wxImage img = src.ConvertToImage();
 		if (!img.HasAlpha()) {
@@ -334,12 +329,10 @@ PrefsUnifiedDlg::PrefsUnifiedDlg(wxWindow *parent)
 		return wxBitmapBundle::FromBitmaps(wxBitmap(img), wxBitmap(img2x));
 	};
 
-	// Single icon+text column. Width is computed below from the actual
-	// label text once every page's title is known -- wxDataViewColumn's
-	// own auto-size timing isn't reliably immediate across native
-	// (GTK/macOS) vs generic (MSW) backends, so this measures text
-	// extents directly instead of trusting the platform to have sized
-	// the column correctly before the dialog first lays out.
+	// Single icon+text column. Width is computed below from the actual label text
+	// once every page's title is known -- wxDataViewColumn's own auto-size timing
+	// is not reliably immediate across native (GTK/macOS) vs generic (MSW)
+	// backends, so this measures text extents directly.
 	wxDataViewColumn *iconTextCol = m_PrefsIcons->AppendIconTextColumn(
 		"", wxDATAVIEW_CELL_INERT, wxCOL_WIDTH_DEFAULT, wxALIGN_LEFT, 0);
 
@@ -351,9 +344,8 @@ PrefsUnifiedDlg::PrefsUnifiedDlg(wxWindow *parent)
 	int maxLabelWidth = 0;
 	for (unsigned int i = 0; i < itemsof(pages); ++i) {
 		// Page icons ship as SVG twins through CamuleArtProvider
-		// ("amule:prefs_<name>"), rasterized by wx at whatever size and
-		// DPI the list asks for. The legacy raster art below stays as
-		// the fallback for icons without an embedded entry.
+		// ("amule:prefs_<name>"), rasterized by wx at whatever size and DPI the
+		// list asks for. The legacy raster art below stays as the fallback.
 		wxBitmapBundle art =
 			wxArtProvider::GetBitmapBundle(CamuleArtProvider::MakeId(pages[i].m_artName),
 				wxART_LIST,
@@ -379,33 +371,30 @@ PrefsUnifiedDlg::PrefsUnifiedDlg(wxWindow *parent)
 		const wxString label = wxGetTranslation(pages[i].m_title);
 		maxLabelWidth = std::max(maxLabelWidth, m_PrefsIcons->GetTextExtent(label).GetWidth());
 
-		// Add each page to the page-list. Item data is this page's stable
-		// pages[] index (never reordered -- only which pages are visible
-		// changes), not the row's live position, so OnPrefsPageChange can
-		// always identify the selected page correctly even after the
-		// server / IP2Country row has been hidden and re-shown.
+		// Add each page to the page list. Item data is this page's stable pages[]
+		// index -- never reordered, only which pages are visible changes -- not the
+		// row's live position, so OnPrefsPageChange can always identify the
+		// selected page even after a row has been hidden and re-shown.
 		wxVector<wxVariant> values;
 		values.push_back(wxVariant(wxDataViewIconText(label, m_pageIcons[i])));
 		m_PrefsIcons->AppendItem(values, (wxUIntPtr)i);
 	}
 
 #ifdef __WXMAC__
-	// macOS 11 made the inset row style the default: it pads both ends of
-	// every row -- the same padding that draws a selected row as a rounded
-	// pill inside its cell rather than filling it -- and that padding comes
-	// out of the space the label is drawn in.
+	// macOS 11 made the inset row style the default: it pads both ends of every
+	// row -- the same padding that draws a selected row as a rounded pill inside
+	// its cell rather than filling it -- and that padding comes out of the space
+	// the label is drawn in.
 	mac_set_table_view_flush(m_PrefsIcons->GetHandle());
 #endif
 
-	// Set list-width so that there aren't any scrollers. What the cell needs
-	// beyond the label text -- the icon, the gap after it and the cell's own
-	// padding -- is the renderer's business, and only one of the three ports
-	// will say what it comes to: wxOSX answers wxCOL_WIDTH_AUTOSIZE with the
-	// width its cells want, while wxGTK and the generic implementation answer
-	// with the column's current allocation, which is the width the control
-	// was handed, echoed back. So the estimate here is what MSW and GTK get,
-	// and OnShowMeasureSidebar() replaces it on macOS once the control has
-	// been laid out and can be asked.
+	// Set the list width so there are no scrollers. What the cell needs beyond the
+	// label text -- the icon, the gap after it, the cell's own padding -- is the
+	// renderer's business, and only one of the three ports will say what it comes
+	// to: wxOSX answers wxCOL_WIDTH_AUTOSIZE with the width its cells want, while
+	// wxGTK and the generic implementation echo back the column's current
+	// allocation. So this estimate is what MSW and GTK get, and
+	// OnShowMeasureSidebar() replaces it on macOS once the control is laid out.
 	m_sidebarColumn = iconTextCol;
 	SetSidebarWidth(maxLabelWidth + FromDIP(kPrefsIconW + kCellPadding));
 #ifdef __WXMAC__
@@ -433,13 +422,10 @@ PrefsUnifiedDlg::PrefsUnifiedDlg(wxWindow *parent)
 #if defined(CLIENT_GUI)
 			// Remote GUI: this checkbox toggles the *daemon's* version-check
 			// preference, so its visibility follows the connected daemon's
-			// capability, NOT amulegui's own build. An amulegui compiled
-			// without ENABLE_VERSION_CHECK still shows it against a capable
-			// daemon — it is only a remote editor of the daemon's pref. The
-			// capability arrives via the EC tag on prefs-apply: a 3.1+ daemon
-			// built without ENABLE_VERSION_CHECK reports false (hide); a
-			// pre-3.1 daemon omits the tag and is treated as capable (show),
-			// since it still supports the preference.
+			// capability, NOT amulegui's own build. The capability arrives via the EC
+			// tag on prefs-apply: a 3.1+ daemon built without ENABLE_VERSION_CHECK
+			// reports false (hide); a pre-3.1 daemon omits the tag and is treated as
+			// capable (show), since it still supports the preference.
 			if (!thePrefs::GetVersionCheckAvailable()) {
 				if (wxWindow *vc = FindWindow(IDC_NEWVERSION)) {
 					vc->Hide();
@@ -458,23 +444,16 @@ PrefsUnifiedDlg::PrefsUnifiedDlg(wxWindow *parent)
 			CastChild(IDC_PREVIEW_NOTE, wxStaticText)
 				->SetLabel(_("The following variables will be substituted:\n    %PARTFILE - "
 					     "full path to the file\n    %PARTNAME - file name only"));
-			// Tray-icon checkboxes (IDC_ENABLETRAYICON,
-			// IDC_MINTRAY) are visible on every platform now,
-			// including macOS. wxTaskBarIcon → NSStatusItem on
-			// Mac, NOTIFYICONDATA on Windows, GtkStatusIcon /
-			// libayatana SNI on Linux. macOS users who prefer
-			// the menu-bar status-item pattern (Spotify / Slack
-			// / Discord style) can opt in.
+			// Tray-icon checkboxes are visible on every platform now, including
+			// macOS: wxTaskBarIcon maps to NSStatusItem on Mac, NOTIFYICONDATA on
+			// Windows, GtkStatusIcon / libayatana SNI on Linux.
 #if defined(__WXGTK__) && !defined(WITH_LIBAYATANA_APPINDICATOR)
-			// On Linux without libayatana-appindicator3 the only
-			// backend wxTaskBarIcon can fall back to is the legacy
-			// GtkStatusIcon API, which GNOME Shell dropped in 3.26
-			// and wlroots-based compositors never implemented — the
-			// tray icon is silently invisible. Disable the option
-			// so users don't enable a feature that does nothing.
-			// (CamuleApp::OnInit force-clears UseTrayIcon at startup
-			// for the same reason, so dependent options cascade off
-			// even before the user opens this panel.)
+			// On Linux without libayatana-appindicator3 the only backend
+			// wxTaskBarIcon can fall back to is the legacy GtkStatusIcon API, which
+			// GNOME Shell dropped in 3.26 and wlroots-based compositors never
+			// implemented -- the tray icon is silently invisible. Disable the option
+			// so users do not enable a feature that does nothing. CamuleApp::OnInit
+			// force-clears UseTrayIcon at startup for the same reason.
 			FindWindow(IDC_ENABLETRAYICON)->Enable(false);
 			FindWindow(IDC_ENABLETRAYICON)
 				->SetToolTip(_("Tray icon support requires libayatana-appindicator3 at "
@@ -482,15 +461,12 @@ PrefsUnifiedDlg::PrefsUnifiedDlg(wxWindow *parent)
 #endif
 
 #ifdef __WXGTK__
-			// xdg-shell intentionally doesn't deliver iconified-state
-			// notifications to clients, so the system minimize button
-			// on Wayland cannot trigger our hide-to-tray path. Same
-			// gap is documented across qBittorrent / Telegram /
-			// KeePassXC / Slack — none of them have a fix either.
-			// Grey out the option with a tooltip so the user
-			// understands why; the runtime sanity check in
-			// CamuleApp::OnInit keeps DoMinToTray() returning false
-			// regardless of the saved value.
+			// xdg-shell intentionally does not deliver iconified-state notifications
+			// to clients, so the system minimize button on Wayland cannot trigger our
+			// hide-to-tray path -- the same gap qBittorrent, Telegram, KeePassXC and
+			// Slack all have. Grey out the option with a tooltip so the user
+			// understands why; the runtime sanity check in CamuleApp::OnInit keeps
+			// DoMinToTray() returning false regardless of the saved value.
 			if (CamuleAppCommon::IsWaylandSession()) {
 				FindWindow(IDC_MINTRAY)
 					->SetToolTip(_("Not available on Wayland: the protocol does not "
@@ -590,9 +566,9 @@ PrefsUnifiedDlg::PrefsUnifiedDlg(wxWindow *parent)
 
 #ifdef CLIENT_GUI
 	// The shared-file exclusion preview counts against the core's in-memory
-	// shared list, which the remote GUI has no local access to (its handler
-	// is compiled out too). Remove the button and its info label here; the
-	// pattern/regex fields still work and sync to amuled over EC.
+	// shared list, which the remote GUI has no local access to. Remove the button
+	// and its info label here; the pattern/regex fields still work and sync to
+	// amuled over EC.
 	if (wxWindow *previewBtn = FindWindow(IDC_EXCLUDE_SHARE_PREVIEW)) {
 		previewBtn->Show(false);
 	}
@@ -602,8 +578,8 @@ PrefsUnifiedDlg::PrefsUnifiedDlg(wxWindow *parent)
 #endif
 
 #if !defined(__WINDOWS__) && !defined(CLIENT_GUI)
-	// Monolithic non-Windows: this build is its own core and the setting is
-	// a no-op on POSIX, so hide it. Still registered, so the value keeps
+	// Monolithic non-Windows: this build is its own core and the setting is a
+	// no-op on POSIX, so hide it. Still registered, so the value keeps
 	// round-tripping through the config and EC.
 	if (wxWindow *sparse = FindWindow(IDC_CREATEFILESSPARSE)) {
 		sparse->Show(false);
@@ -618,9 +594,8 @@ PrefsUnifiedDlg::PrefsUnifiedDlg(wxWindow *parent)
 
 #ifdef CLIENT_GUI
 	// amulegui: drop the IP2Country page from the menu when the connected core
-	// has no GeoIP support — a 3.1+ core built without ENABLE_IP2COUNTRY, or a
-	// pre-3.1 core that doesn't know the capability at all (both leave
-	// IsGeoIPSupported() false, see CPreferencesRem::LoadRemote). Mirrors how
+	// has no GeoIP support -- a 3.1+ core built without ENABLE_IP2COUNTRY, or a
+	// pre-3.1 core that does not know the capability at all. Mirrors how
 	// monolithic amule omits the page at compile time. Must run before
 	// EnableServerTab, which may delete the earlier server tab and shift this
 	// index; the page widget stays built but becomes unreachable.
@@ -640,11 +615,10 @@ PrefsUnifiedDlg::PrefsUnifiedDlg(wxWindow *parent)
 	m_choiceColor = CastChild(IDC_COLORSELECTOR, wxChoice);
 
 	// Fill the "Bind to interface" and EC "listening interface" drop-downs with
-	// what this machine actually has. Done before the Cfg->widget transfer
-	// below so the stored value (which may name an interface or address that is
-	// currently down) is preserved as typed text. In CLIENT_GUI these controls
-	// are plain wxTextCtrls (the daemon's interfaces are not this machine's),
-	// so there is nothing to enumerate.
+	// what this machine actually has. Done before the Cfg->widget transfer below
+	// so the stored value -- which may name an interface that is currently down
+	// -- is preserved as typed text. In CLIENT_GUI these are plain wxTextCtrls,
+	// since the daemon's interfaces are not this machine's.
 #ifndef CLIENT_GUI
 	// One enumeration feeds all three controls.
 	const std::vector<NetworkInterface> detectedInterfaces = DetectNetworkInterfaces();
@@ -663,8 +637,7 @@ PrefsUnifiedDlg::PrefsUnifiedDlg(wxWindow *parent)
 	// The EC listen address. 127.0.0.1 leads because it is both the default and
 	// the safe answer, and 0.0.0.0 is spelled out so that opening the external
 	// connection to every network is a deliberate choice rather than the side
-	// effect of an empty field. This machine's own addresses follow, so binding
-	// to just the LAN does not require looking one up.
+	// effect of an empty field. This machine's own addresses follow.
 	if (wxComboBox *ecAddrBox = CastChild(IDC_EXT_CONN_IP, wxComboBox)) {
 		ecAddrBox->Append("127.0.0.1");
 		ecAddrBox->Append("0.0.0.0");
@@ -700,10 +673,9 @@ PrefsUnifiedDlg::PrefsUnifiedDlg(wxWindow *parent)
 void PrefsUnifiedDlg::EnableServerTab(bool enable)
 {
 	if (enable && !m_ServerTabVisible) {
-		// turn server widget on. Item data is the page's stable pages[]
-		// index (see the constructor), not m_ServerWidget directly --
-		// OnPrefsPageChange looks the widget up from m_pageWidgets by
-		// that index, same as every other row.
+		// Turn the server widget on. Item data is the page's stable pages[] index
+		// (see the constructor), not m_ServerWidget directly -- OnPrefsPageChange
+		// looks the widget up from m_pageWidgets by that index.
 		wxVector<wxVariant> values;
 		values.push_back(wxVariant(wxDataViewIconText(
 			wxGetTranslation(pages[m_IndexServerTab].m_title), m_pageIcons[m_IndexServerTab])));
@@ -747,18 +719,17 @@ bool PrefsUnifiedDlg::TransferToWindow()
 		mmapBox->Show(thePrefs::GetMMapSupported());
 	}
 
-	// Load the user's intent (explicit non-recursive vs marked-recursive
-	// roots) into the tree control's two maps. shareddir_list itself
-	// is the runtime expansion -- not useful as UI state since it
-	// includes auto-discovered subdirs that shouldn't render as
-	// user-selected.
+	// Load the user's intent (explicit non-recursive vs marked-recursive roots)
+	// into the tree control's two maps. shareddir_list itself is the runtime
+	// expansion, which includes auto-discovered subdirs that should not render
+	// as user-selected.
 #ifdef CLIENT_GUI
 	// Remote GUI: no tree to seed. Show whatever roots we already hold and ask
 	// the core for a fresh copy; the reply repaints us via
 	// RefreshSharedDirsIfOpen. Until it lands the editor's controls stay
-	// disabled, because an edit made before it arrives is an edit against a
-	// list we have not seen -- see m_sharedDirsLoaded. Cleared here rather
-	// than at close: the dialog is created once and reused for every open.
+	// disabled, because an edit made before it arrives is an edit against a list
+	// we have not seen. Cleared here rather than at close: the dialog is created
+	// once and reused for every open.
 	m_sharedDirsLoaded = false;
 	PopulateSharedDirsList();
 	static_cast<CPreferencesRem *>(theApp->glob_prefs)->LoadSharedDirsRemote();
@@ -771,24 +742,19 @@ bool PrefsUnifiedDlg::TransferToWindow()
 	m_ShareSelector->SetRecursiveSharedDirectories(&theApp->glob_prefs->shareddir_recursive_list);
 #endif
 
-	// Autostart checkbox: state lives in the OS, never aMule.conf, so
-	// read live each time the dialog opens. The thePrefs Cfg machinery
-	// above doesn't know about it.
+	// Autostart checkbox: state lives in the OS, never aMule.conf, so read live
+	// each time the dialog opens. The thePrefs Cfg machinery does not know it.
 	wxCheckBox *autostartCb = static_cast<wxCheckBox *>(FindWindow(IDC_AUTOSTART_LOGIN));
 	if (autostartCb) {
 		autostartCb->SetValue(AutostartManager::IsEnabled());
 	}
 
-	// URL-scheme handler checkboxes: same live-OS-state model.
-	// On macOS, LaunchServices has no "clear default handler" call
-	// (see ProtocolHandlerManager.cpp:BackendRemove), so Disable is a
-	// no-op — toggling an already-checked box off doesn't change
-	// anything the user can observe. Rather than expose a dead
-	// control, hide the checkbox once aMule is the current handler:
-	// the user opted in, we're the handler, there's nothing further
-	// for them to do here. If they later switch away via macOS'
-	// native "Change All…" chooser, the checkbox reappears on next
-	// Preferences open with the "off" state, and they can opt back in.
+	// URL-scheme handler checkboxes: same live-OS-state model. On macOS,
+	// LaunchServices has no "clear default handler" call, so Disable is a no-op
+	// -- toggling an already-checked box off changes nothing the user can
+	// observe. Rather than expose a dead control, hide the checkbox once aMule
+	// is the current handler. If they later switch away via macOS' native
+	// "Change All..." chooser, the checkbox reappears on the next open.
 	wxCheckBox *ed2kCb = static_cast<wxCheckBox *>(FindWindow(IDC_PROTOCOL_ED2K));
 	if (ed2kCb) {
 		bool enabled = ProtocolHandlerManager::IsEnabled(HandlerTarget::Ed2kScheme);
@@ -818,11 +784,10 @@ bool PrefsUnifiedDlg::TransferToWindow()
 	}
 
 #ifdef GEOIP_GUI
-	// Sync the GeoIP source dropdown to the persisted source; the
-	// Cfg_ system above handles the credential / URL / auto-update
-	// fields, but the dropdown is driven through a custom handler so
-	// hide/show of the source sub-panels stays consistent. Also
-	// refresh the status block from the live CIP2Country state.
+	// Sync the GeoIP source dropdown to the persisted source. The Cfg_ system
+	// above handles the credential / URL / auto-update fields, but the dropdown
+	// is driven through a custom handler so hide/show of the source sub-panels
+	// stays consistent. Also refresh the status block from the live state.
 	wxChoice *geoipSource = CastChild(IDC_GEOIP_SOURCE, wxChoice);
 	if (geoipSource) {
 		geoipSource->SetSelection(static_cast<int>(thePrefs::GetGeoIPSource()));
@@ -830,9 +795,8 @@ bool PrefsUnifiedDlg::TransferToWindow()
 		UpdateGeoIPStatus();
 		UpdateGeoIPControlsEnabled();
 	}
-	// Snapshot the source + credential values that aren't tracked
-	// by the Cfg system, so OnOk can tell whether anything
-	// download-affecting changed during the dialog session.
+	// Snapshot the source + credential values that are not tracked by the Cfg
+	// system, so OnOk can tell whether anything download-affecting changed.
 	m_GeoIPSourceAtOpen = static_cast<int>(thePrefs::GetGeoIPSource());
 	m_GeoIPMaxMindLicenseAtOpen = thePrefs::GetGeoIPMaxMindLicense();
 	m_GeoIPCustomUrlAtOpen = thePrefs::GetGeoIPCustomUrl();
@@ -872,15 +836,14 @@ bool PrefsUnifiedDlg::TransferToWindow()
 
 	// amuleapi's stored password is salted and stretched, so unlike the web
 	// server's it cannot be loaded back into the field. The field is a
-	// write-only request ("set it to this") and empty means "leave it
-	// alone", which needs saying somewhere the user actually looks --
-	// otherwise an empty box reads as "no password configured".
+	// write-only request ("set it to this") and empty means "leave it alone",
+	// which needs saying somewhere the user looks -- otherwise an empty box
+	// reads as "no password configured".
 	SetCredentialStateLabel(IDC_AMULEAPI_PASSWD_STATE, thePrefs::GetAmuleApiAdminIsSet());
 
-	// Guest access is on exactly when a guest password is stored, so the
-	// checkbox already implies this. Spelled out anyway: an empty field
-	// beside a ticked box reads as "nothing configured" unless you happen
-	// to know that invariant.
+	// Guest access is on exactly when a guest password is stored, so the checkbox
+	// already implies this. Spelled out anyway: an empty field beside a ticked
+	// box reads as "nothing configured" unless you know that invariant.
 	m_amuleApiGuestWasSet = thePrefs::GetAmuleApiGuestIsEnabled();
 	SetCredentialStateLabel(IDC_AMULEAPI_GUEST_PASSWD_STATE, m_amuleApiGuestWasSet);
 
@@ -895,11 +858,10 @@ bool PrefsUnifiedDlg::TransferToWindow()
 		FindWindow(IDC_MEDIAMETA_FFPROBEDETECT)->Enable(mmOn);
 	}
 
-	// The tray icon is the only recovery surface for a window hidden
-	// via the close button: on Linux/Windows the option needs the tray
-	// to bring the window back, and on macOS the matching code path
-	// (NSApplicationActivationPolicyAccessory) drops the Dock icon
-	// while hidden, so the tray is also the only way back there.
+	// The tray icon is the only recovery surface for a window hidden via the
+	// close button: on Linux/Windows the option needs the tray to bring the
+	// window back, and on macOS the matching code path drops the Dock icon while
+	// hidden, so the tray is also the only way back there.
 	FindWindow(IDC_MACHIDEONCLOSE)->Enable(thePrefs::UseTrayIcon());
 
 #ifdef __WXGTK__
@@ -932,22 +894,17 @@ bool PrefsUnifiedDlg::TransferToWindow()
 		FindWindow(IDC_SELTEMPDIR)->Enable(false);
 	}
 
-	// Hide preferences that are persisted only to amulegui's local
-	// remote.conf but never sent to amuled via EC_OP_SET_PREFERENCES
-	// (i.e. not packed by CEC_Prefs_Packet at all). The widget would
-	// otherwise show amulegui's stale local default -- not amuled's
-	// real value -- and editing it would silently affect nothing on
-	// the daemon side. Same gap holds whether amulegui is on a
-	// loopback or remote connection: amuled never reads remote.conf,
-	// so the control is dead in both cases. Hide unconditionally for
-	// CLIENT_GUI. Proxy settings (ID_PROXY_*) are *not* in this list.
-	// They are packed by CEC_Prefs_Packet (EC_TAG_PROXY_*), so the remote
-	// GUI configures the daemon's proxy -- amuled routes its P2P and HTTP
-	// (server list, nodes.dat, GeoIP, version check) through it. amulegui
-	// also uses the value locally for its own version-check HTTP (the
-	// shared curl session in CVersionCheck). GeoIP, by contrast, is
-	// daemon-only -- amulegui has no local resolver, country codes arrive
-	// over EC -- so this control is meaningful either way.
+	// Hide preferences that are persisted only to amulegui's local remote.conf
+	// but never sent to amuled via EC_OP_SET_PREFERENCES -- i.e. not packed by
+	// CEC_Prefs_Packet at all. The widget would otherwise show amulegui's stale
+	// local default rather than amuled's real value, and editing it would
+	// silently affect nothing on the daemon side, on a loopback connection as
+	// much as a remote one.
+	//
+	// Proxy settings (ID_PROXY_*) are NOT in this list: they are packed by
+	// CEC_Prefs_Packet, so the remote GUI configures the daemon's proxy, and
+	// amulegui also uses the value locally for its own version-check HTTP.
+	// GeoIP, by contrast, is daemon-only -- amulegui has no local resolver.
 	const int amuledOnlyPrefs[] = {
 		// Web-server UPnP (amuleweb is deprecated) and EC-port UPnP (the EC
 		// port is not a P2P port) stay hidden; only the P2P-router UPnP is
@@ -989,13 +946,10 @@ bool PrefsUnifiedDlg::TransferToWindow()
 	::SendCheckBoxEvent(this, IDC_ENFORCE_PO_INCOMING);
 
 #ifndef GEOIP_GUI
-	// The country-flags checkbox + the rest of the IP2Country controls
-	// only live in the dedicated PreferencesIP2CountryTab, which is
-	// `#ifdef GEOIP_GUI`-gated in the pages[] table. With
-	// libmaxminddb missing, neither the tab nor any of its widgets
-	// exists, so there's nothing to disable here -- the *.NewCfgItem
-	// bindings below are gated the same way, and SetGeoIPEnabled stays
-	// at its default false.
+	// The country-flags checkbox and the rest of the IP2Country controls only
+	// live in the dedicated PreferencesIP2CountryTab, which is `#ifdef
+	// GEOIP_GUI`-gated in the pages[] table. With libmaxminddb missing, neither
+	// the tab nor any of its widgets exists, so there is nothing to disable here.
 #endif
 
 #ifdef __GIT__
@@ -1015,8 +969,8 @@ bool PrefsUnifiedDlg::TransferToWindow()
 #ifdef CLIENT_GUI
 	// Gate the P2P-router UPnP controls on the daemon's advertised capability
 	// (EC_TAG_GENERAL_UPNP_AVAILABLE), not amulegui's own ENABLE_UPNP -- the
-	// daemon is what forwards. Do NOT clobber the pref when unavailable (the
-	// value belongs to the daemon). Web-server + EC-port UPnP are hidden.
+	// daemon is what forwards. Do NOT clobber the pref when unavailable: the
+	// value belongs to the daemon.
 	if (thePrefs::GetUPnPAvailable()) {
 		FindWindow(IDC_UPNPTCPPORT)->Enable(thePrefs::GetUPnPEnabled());
 		FindWindow(IDC_UPNPTCPPORTTEXT)->Enable(thePrefs::GetUPnPEnabled());
@@ -1075,10 +1029,10 @@ bool PrefsUnifiedDlg::TransferFromWindow()
 	}
 
 	// shareddir_list is committed separately from OnOk (see
-	// CommitSharedDirsWithProgress) so that recursive-share expansion
-	// can run on a worker thread with a progress dialog and a cancel
-	// button. Doing it eagerly here would re-introduce the multi-
-	// minute UI freeze that issue #592 hit on /home-sized roots.
+	// CommitSharedDirsWithProgress) so that recursive-share expansion can run on
+	// a worker thread with a progress dialog and a cancel button. Doing it
+	// eagerly here would re-introduce the multi-minute UI freeze on
+	// /home-sized roots.
 
 	for (int i = 0; i < cntStatColors; i++) {
 		if (thePrefs::s_colors[i] != thePrefs::s_colors_ref[i]) {
@@ -1110,7 +1064,7 @@ bool PrefsUnifiedDlg::TransferFromWindow()
 	// Parity with monolithic's auto-download-on-OK: if the GeoIP source or the
 	// active source's credential changed since the panel opened, ask the daemon
 	// to re-download from the new source by piggy-backing a one-shot UPDATE_NOW
-	// on the prefs packet. Commit the credential fields to the statics first —
+	// on the prefs packet. Commit the credential fields to the statics first --
 	// SendToRemote serialises from there, not from the live widgets.
 	thePrefs::SetGeoIPMaxMindLicense(CastChild(IDC_GEOIP_MAXMIND_LIC, wxTextCtrl)->GetValue());
 	thePrefs::SetGeoIPCustomUrl(CastChild(IDC_GEOIP_CUSTOM_URL, wxTextCtrl)->GetValue());
@@ -1159,26 +1113,22 @@ void PrefsUnifiedDlg::OnOk(wxCommandEvent &WXUNUSED(event))
 {
 	TransferFromWindow();
 
-	// Commit the share list with the recursive-expand-on-worker-
-	// thread path. Done after TransferFromWindow (so other prefs
-	// are already populated in glob_prefs) but before Save() so a
-	// successful commit ends up in shareddir.dat alongside the rest.
-	// If the user cancels at the confirm or the progress dialog,
-	// bail out of OnOk *before* anything is persisted — so the prefs
-	// dialog stays open and the user can adjust their selection
-	// without losing the rest of their pending pref changes.
+	// Commit the share list with the recursive-expand-on-worker-thread path.
+	// After TransferFromWindow, so other prefs are already in glob_prefs, but
+	// before Save() so a successful commit ends up in shareddir.dat alongside
+	// the rest. If the user cancels at the confirm or the progress dialog, bail
+	// out of OnOk *before* anything is persisted, so the dialog stays open and
+	// the rest of their pending changes are not lost.
 	const SharedDirsCommitResult shareResult = CommitSharedDirsWithProgress();
 	if (shareResult == SharedDirsCommitResult::CancelledByUser) {
 		return;
 	}
 	const bool sharedDirsCommitted = (shareResult == SharedDirsCommitResult::Committed);
 
-	// Guest access ticked, nothing typed, nothing stored: "keep the
-	// current password" has nothing to keep. Caught here, before anything
-	// is persisted, so the dialog stays open on the offending field --
-	// same early return the shared-dirs cancel above uses. Reporting it
-	// after the save would leave the user reading an error about a dialog
-	// that had already closed.
+	// Guest access ticked, nothing typed, nothing stored: "keep the current
+	// password" has nothing to keep. Caught here, before anything is persisted,
+	// so the dialog stays open on the offending field -- reporting it after the
+	// save would leave the user reading an error about a closed dialog.
 	if (thePrefs::GetAmuleApiGuestIsEnabled() && thePrefs::GetAmuleApiGuestPass().IsEmpty() &&
 		!m_amuleApiGuestWasSet) {
 		wxMessageBox(_("Guest access needs a password. Type one in the guest password "
@@ -1195,10 +1145,9 @@ void PrefsUnifiedDlg::OnOk(wxCommandEvent &WXUNUSED(event))
 	// Same for external connections: enabled with no password is not a
 	// configuration aMule can act on. This used to report the problem and then
 	// quietly clear the checkbox on the way out, so the dialog closed with the
-	// user's intent discarded and the message already dismissed. Keep the
-	// dialog open on the password field instead, so the answer to the message
-	// is one field away. Wording unchanged so existing translations still
-	// apply.
+	// user's intent discarded and the message already dismissed. Keep the dialog
+	// open on the password field instead. Wording unchanged so existing
+	// translations still apply.
 	if (thePrefs::AcceptExternalConnections() && thePrefs::ECPassword().IsEmpty()) {
 		wxMessageBox(_("You have enabled external connections but have not specified a "
 			       "password.\nExternal connections cannot be enabled unless a valid "
@@ -1250,13 +1199,12 @@ void PrefsUnifiedDlg::OnOk(wxCommandEvent &WXUNUSED(event))
 		restart_needed_msg += _("- Protocol obfuscation support changed.\n");
 	}
 
-	// HTTP side-channels (version check, GeoIP, server.met, nodes.dat) go
-	// through a wxWebSession that is handed its proxy once, when it is created:
-	// wx's WinHTTP backend refuses a proxy change after the session has made
-	// its first request. See CreateAmuleWebRequest(). P2P proxying is not
-	// affected -- that runs through CProxySocket and picks the new settings up
-	// immediately -- which is why the message names HTTP specifically rather
-	// than claiming the whole setting is inert until restart.
+	// HTTP side-channels (version check, GeoIP, server.met, nodes.dat) go through
+	// a wxWebSession that is handed its proxy once, when it is created: wx's
+	// WinHTTP backend refuses a proxy change after the session's first request.
+	// P2P proxying is not affected -- that runs through CProxySocket and picks
+	// the new settings up immediately -- which is why the message names HTTP
+	// specifically rather than claiming the whole setting is inert.
 	if (CfgChanged(ID_PROXY_ENABLE_PROXY) || CfgChanged(ID_PROXY_TYPE) || CfgChanged(ID_PROXY_NAME) ||
 		CfgChanged(ID_PROXY_PORT) || CfgChanged(ID_PROXY_ENABLE_PASSWORD) ||
 		CfgChanged(ID_PROXY_USER) || CfgChanged(ID_PROXY_PASSWORD)) {
@@ -1264,14 +1212,12 @@ void PrefsUnifiedDlg::OnOk(wxCommandEvent &WXUNUSED(event))
 		restart_needed_msg += _("- Proxy settings changed (needed for HTTP transfers).\n");
 	}
 
-	// amuleapi is launched once at startup with its bind address and port,
-	// so a change to either takes effect only after aMule relaunches it.
-	// Passwords are deliberately not in this list: amuleapi re-reads
-	// amuleapi-passwords on every login, so a password change is live.
-	// Skip the prompt when external connections won't be usable, so we don't
-	// tell the user to restart for a service that will not run. In practice
-	// that means "off": enabled-without-a-password never reaches here, having
-	// returned above with the dialog still open.
+	// amuleapi is launched once at startup with its bind address and port, so a
+	// change to either takes effect only after aMule relaunches it. Passwords are
+	// deliberately not in this list: amuleapi re-reads amuleapi-passwords on
+	// every login, so a password change is live. Skip the prompt when external
+	// connections will not be usable, so we do not tell the user to restart for
+	// a service that will not run.
 	const bool ecUsable = thePrefs::AcceptExternalConnections() && !thePrefs::ECPassword().IsEmpty();
 	if (ecUsable && (CfgChanged(IDC_ENABLE_AMULEAPI) || CfgChanged(IDC_AMULEAPI_PORT) ||
 				CfgChanged(IDC_AMULEAPI_BIND))) {
@@ -1294,14 +1240,13 @@ void PrefsUnifiedDlg::OnOk(wxCommandEvent &WXUNUSED(event))
 
 #ifndef CLIENT_GUI
 	// The web server and amuleapi are EC clients of the core; without external
-	// connections they can never connect. OnCheckBoxChange already warns
-	// live and reverts the toggles, so this is a silent backstop that keeps the
-	// saved prefs consistent for a config loaded in a mismatched state.
+	// connections they can never connect. OnCheckBoxChange already warns live and
+	// reverts the toggles, so this is a silent backstop that keeps the saved
+	// prefs consistent for a config loaded in a mismatched state.
 	//
-	// amulegui (CLIENT_GUI) is itself a connected EC client, so external
-	// connections are necessarily enabled on the daemon; the local
-	// AcceptExternalConnections pref only mirrors amulegui's own remote.conf and
-	// never the daemon's real state, so this backstop must not run there.
+	// amulegui is itself a connected EC client, so external connections are
+	// necessarily enabled on the daemon; its local AcceptExternalConnections
+	// pref only mirrors remote.conf, so this backstop must not run there.
 	if ((thePrefs::GetWSIsEnabled() || thePrefs::GetAmuleApiIsEnabled()) &&
 		!thePrefs::AcceptExternalConnections()) {
 		thePrefs::SetWSIsEnabled(false);
@@ -1333,16 +1278,12 @@ void PrefsUnifiedDlg::OnOk(wxCommandEvent &WXUNUSED(event))
 		}
 	}
 #else
-	// A remote GUI has no credential file of its own — the daemon has
-	// already been handed the request by Save() and does the storing. Two
-	// things still have to happen here that the daemon cannot do for us:
-	//
-	// drop the pending digest, so it is not re-sent on every later save
-	// and does not sit in memory for the rest of the session; and
-	//
-	// remember that a password now exists, so reopening this dialog says
-	// so instead of "No password set" until the next preferences fetch
-	// happens to refresh the mirror.
+	// A remote GUI has no credential file of its own -- the daemon has already
+	// been handed the request by Save() and does the storing. Two things still
+	// have to happen here that the daemon cannot do for us: drop the pending
+	// digest, so it is not re-sent on every later save and does not sit in
+	// memory for the rest of the session; and remember that a password now
+	// exists, so reopening this dialog says so instead of "No password set".
 	if (!thePrefs::GetAmuleApiPass().IsEmpty()) {
 		thePrefs::SetAmuleApiAdminIsSet(true);
 		thePrefs::SetAmuleApiPass(wxEmptyString);
@@ -1369,13 +1310,12 @@ void PrefsUnifiedDlg::OnOk(wxCommandEvent &WXUNUSED(event))
 		restart_needed_msg += _("- ED2K network enabled.\n");
 	}
 
-	// CommitSharedDirsWithProgress already ran Reload (with progress
-	// + cancel) when shareddir_list itself changed. We only need to
-	// trigger a fresh Reload here for the other paths IDC_INCFILES /
-	// IDC_TEMPFILES affect.
-	// The three settings below each need a re-walk, and a single OK can change
-	// all three -- which used to mean up to three full walks back to back, each
-	// freezing the dialog. Collect the need and do one walk at the end instead.
+	// CommitSharedDirsWithProgress already ran Reload (with progress and cancel)
+	// when shareddir_list itself changed; this only triggers a fresh Reload for
+	// the other paths IDC_INCFILES / IDC_TEMPFILES affect. The three settings
+	// below each need a re-walk, and a single OK can change all three -- which
+	// used to mean up to three full walks back to back. Collect the need and do
+	// one walk at the end instead.
 	bool needsSharedReload = false;
 
 	if (!sharedDirsCommitted && (CfgChanged(IDC_INCFILES) || CfgChanged(IDC_TEMPFILES))) {
@@ -1422,20 +1362,17 @@ void PrefsUnifiedDlg::OnOk(wxCommandEvent &WXUNUSED(event))
 	// One walk for whichever of the three settings changed. Progress-and-yield
 	// rather than a bare Reload(): the walk costs roughly a stat per shared
 	// file, so on a large or network-mounted tree it runs for seconds to
-	// minutes, and without a yield callback CSharedFileList pumps nothing at
-	// all -- the window greys out as "not responding" with no indication why.
+	// minutes, and without a yield callback CSharedFileList pumps nothing at all
+	// -- the window greys out as "not responding" with no indication why.
 	//
-	// Pumping here is safe: wxProgressDialog's yield is restricted to UI
-	// events, so it cannot dispatch the queued socket events that carry EC
-	// requests, and no client can be answered from the transiently-empty
-	// share map the walk builds through. Same reason CommitSharedDirsWithProgress
-	// above can do this.
+	// Pumping here is safe: wxProgressDialog's yield is restricted to UI events,
+	// so it cannot dispatch the queued socket events that carry EC requests, and
+	// no client can be answered from the transiently-empty share map.
 	//
 	// No cancel button, for the same reason as the shared-files Reload button:
 	// FindSharedFiles clears the map before walking, so an abort would leave a
 	// partial share list with nothing to restore. CommitSharedDirsWithProgress
-	// can offer one only because it keeps the previous directory list to
-	// re-walk against.
+	// can offer one only because it keeps the previous directory list.
 	if (needsSharedReload) {
 		ReloadSharedFilesWithProgress(this);
 	}
@@ -1534,18 +1471,15 @@ void PrefsUnifiedDlg::OnOk(wxCommandEvent &WXUNUSED(event))
 	}
 
 #if defined(ENABLE_IP2COUNTRY) && !defined(CLIENT_GUI)
-	// Auto-download on OK when the user changed anything that affects
-	// *which* file should be on disk. Without this, switching source
-	// DB-IP→MaxMind (or pasting a new license) leaves the old file
-	// loaded until the user remembers to click Update now. We skip
-	// the download if:
-	//   * IP2Country is disabled (the file is irrelevant), or
-	//   * the user just toggled the master enable on — EnableIP2Country
-	//     above already handles missing-file → Update() in that case.
-	// Triggered as a manual update so the user sees a popup if their
-	// new credentials are bad, rather than a silent log line.
-	// Monolithic only: amulegui has no local resolver — its OK send
-	// (SendToRemote) carries the new settings and the daemon re-downloads.
+	// Auto-download on OK when the user changed anything that affects *which*
+	// file should be on disk. Without this, switching source DB-IP -> MaxMind,
+	// or pasting a new license, leaves the old file loaded until the user
+	// remembers to click Update now. Skipped when IP2Country is disabled, or
+	// when the user just toggled the master enable on -- EnableIP2Country above
+	// already handles missing-file -> Update() in that case. Triggered as a
+	// manual update so bad credentials pop up rather than a silent log line.
+	// Monolithic only: amulegui's OK send carries the new settings and the
+	// daemon re-downloads.
 	if (thePrefs::IsGeoIPEnabled() && !CfgChanged(IDC_SHOW_COUNTRY_FLAGS) && theApp->amuledlg &&
 		theApp->GetIP2Country()) {
 		const bool sourceChanged =
@@ -1626,11 +1560,10 @@ void PrefsUnifiedDlg::OnCancel(wxCommandEvent &WXUNUSED(event))
 
 void PrefsUnifiedDlg::OnAutostartToggle(wxCommandEvent &event)
 {
-	// Apply immediately. The OS is the source of truth — we don't
-	// persist intent in aMule.conf, so there's no Apply-on-OK step
-	// for this widget. If the write fails (e.g. read-only LaunchAgent
-	// dir on a sandboxed macOS install), roll the checkbox back so
-	// the UI reflects reality.
+	// Apply immediately. The OS is the source of truth -- intent is not persisted
+	// in aMule.conf, so there is no Apply-on-OK step for this widget. If the
+	// write fails (a read-only LaunchAgent dir on a sandboxed macOS install,
+	// say), roll the checkbox back so the UI reflects reality.
 	bool wanted = event.IsChecked();
 	bool ok = wanted ? AutostartManager::Enable() : AutostartManager::Disable();
 	if (!ok) {
@@ -1649,12 +1582,10 @@ void PrefsUnifiedDlg::OnAutostartToggle(wxCommandEvent &event)
 
 void PrefsUnifiedDlg::HandleProtocolToggle(HandlerTarget scheme, int checkboxId, bool wanted)
 {
-	// Same live-OS-state semantics as the autostart toggle above,
-	// with one extra gate: before Enable overwrites a pre-existing
-	// third-party handler, confirm with the user. Disable never
-	// touches a non-aMule handler (Manager contract).
-	// One dialog title for both kinds of registration, worded for the one
-	// being toggled.
+	// Same live-OS-state semantics as the autostart toggle above, with one extra
+	// gate: before Enable overwrites a pre-existing third-party handler, confirm
+	// with the user. Disable never touches a non-aMule handler. One dialog title
+	// for both kinds of registration, worded for the one being toggled.
 	const bool isFileType = (scheme == HandlerTarget::CollectionFile);
 	const wxString dialogTitle = isFileType ? _("Register file type") : _("Register URL handler");
 
@@ -1762,15 +1693,13 @@ void PrefsUnifiedDlg::OnCheckBoxChange(wxCommandEvent &event)
 		FindWindow(IDC_WEBUPNPTCPPORTTEXT)->Enable(value);
 		break;
 
-	// The web server and amuleapi are EC clients of the core: they can only
-	// run when external connections are enabled. Warn live and refuse the
-	// invalid combination instead of waiting for OK.
+	// The web server and amuleapi are EC clients of the core: they can only run
+	// when external connections are enabled. Warn live and refuse the invalid
+	// combination instead of waiting for OK.
 	//
-	// amulegui (CLIENT_GUI) is itself a connected EC client, so external
-	// connections are necessarily enabled on the daemon and the precondition is
-	// always met. The IDC_EXT_CONN_ACCEPT checkbox is hidden there and only
-	// mirrors amulegui's local remote.conf, so reading it would wrongly block
-	// the toggle -- skip the EC guard and keep just the deprecation nudge.
+	// amulegui is itself a connected EC client, so the precondition is always
+	// met. The IDC_EXT_CONN_ACCEPT checkbox is hidden there and only mirrors
+	// remote.conf, so reading it would wrongly block the toggle.
 	case IDC_ENABLE_WEB:
 	case IDC_ENABLE_AMULEAPI:
 #ifndef CLIENT_GUI
@@ -2078,13 +2007,12 @@ void PrefsUnifiedDlg::OnButtonBrowseApplication(wxCommandEvent &event)
 	wxString str = wxFileSelector(title, "", "", "", wildcard, 0, this);
 
 #ifdef __WXMAC__
-	// wxCocoa quirk: the modal NSOpenPanel steals key-window status;
-	// when it dismisses (Open OR Cancel), Cocoa returns focus + Z-order
-	// to whichever aMule window was active before Preferences opened,
-	// not to Preferences itself. IsShown() still returns true and no
-	// wxEVT_CLOSE_WINDOW fires — the dialog is alive but ordered
-	// behind the main window, which visibly reads as "Preferences
-	// closed after Browse click". Raise() restores its Z-order.
+	// wxCocoa quirk: the modal NSOpenPanel steals key-window status; when it
+	// dismisses (Open OR Cancel), Cocoa returns focus and Z-order to whichever
+	// aMule window was active before Preferences opened, not to Preferences
+	// itself. IsShown() still returns true and no wxEVT_CLOSE_WINDOW fires -- the
+	// dialog is alive but ordered behind the main window, which reads as
+	// "Preferences closed after Browse click". Raise() restores its Z-order.
 	Raise();
 #endif
 
@@ -2096,17 +2024,14 @@ void PrefsUnifiedDlg::OnButtonBrowseApplication(wxCommandEvent &event)
 
 void PrefsUnifiedDlg::OnButtonMediaMetaDetect(wxCommandEvent &WXUNUSED(evt))
 {
-	// Kick MediaProbe's autodetect and populate the path field with
-	// whatever it finds. Empty result -> tell the user politely; a
-	// path in-hand is the more useful common case so we don't try
-	// to also validate the binary here (Browse... covers that).
+	// Kick MediaProbe's autodetect and populate the path field with whatever it
+	// finds. An empty result tells the user politely; a path in hand is the more
+	// useful common case, so the binary is not also validated here.
 	//
-	// redetect=true: the point of pressing this is to notice an ffmpeg
-	// installed since aMule started, so the cached answer will not do.
-	// Going through DetectedPath() rather than AutoDetectPath() also
-	// refreshes the cache the probe worker reads, so the button and the
-	// extraction agree about what this machine has. Monolithic only --
-	// amulegui hides the button (see amuledOnlyPrefs[] above), because
+	// redetect=true: the point of pressing this is to notice an ffmpeg installed
+	// since aMule started, so the cached answer will not do. Going through
+	// DetectedPath() rather than AutoDetectPath() also refreshes the cache the
+	// probe worker reads. Monolithic only -- amulegui hides the button, because
 	// detection here would search the GUI's filesystem, not the daemon's.
 	const wxString path = MediaProbe::DetectedPath(/*redetect=*/true);
 	if (path.IsEmpty()) {
@@ -2131,8 +2056,8 @@ void PrefsUnifiedDlg::OnButtonTweaksReset(wxCommandEvent &WXUNUSED(evt))
 
 	// Walk the currently shown page's controls and reset each one that is bound
 	// to a preference. Only the widgets are updated; the change is committed on
-	// OK and discarded on Cancel. The button is shown only on the Advanced page
-	// (see OnPrefsPageChange), so m_CurrentPanel is that page.
+	// OK and discarded on Cancel. The button is shown only on the Advanced page,
+	// so m_CurrentPanel is that page.
 	if (!m_CurrentPanel) {
 		return;
 	}

--- a/src/PrefsUnifiedDlg.h
+++ b/src/PrefsUnifiedDlg.h
@@ -78,11 +78,10 @@ public:
 	// soon as the new database is loaded. No-op if no dialog is open.
 	static void RefreshIP2CountryStatusIfOpen();
 
-	// Public module hook: CIP2Country calls this on a *manual* update
-	// failure (the "Update now" button) so the user sees a modal popup,
-	// not just a buried log line. No-op if the prefs dialog isn't
-	// open — caller is expected to have already logged the same
-	// message via AddLogLineC so the failure is still recorded.
+	//! Public module hook: CIP2Country calls this on a MANUAL update failure (the
+	//! "Update now" button) so the user sees a modal popup rather than a buried log
+	//! line. No-op when the dialog is closed; the caller has already logged the
+	//! same message.
 	static void NotifyIP2CountryUpdateFailedIfOpen(const wxString &msg);
 #endif
 
@@ -117,20 +116,17 @@ protected:
 	//! edits, either by a session refresh or by a late GET_SHARED_DIRS reply.
 	bool m_sharedDirsDirty;
 
-	//! Whether this session's GET_SHARED_DIRS reply has arrived, i.e. whether
-	//! the editor is showing the daemon's list rather than whatever glob_prefs
-	//! happened to hold at open time. The edit controls stay disabled until it
-	//! is true: an edit made before the reply lands sets m_sharedDirsDirty,
-	//! which then makes RefreshSharedDirsIfOpen() discard that very reply to
-	//! protect the edit -- so OK would commit a list built without ever having
-	//! seen the daemon's, replacing its shares with the one row just added.
+	//! Whether this session's GET_SHARED_DIRS reply has arrived, i.e. whether the
+	//! editor shows the daemon's list rather than whatever glob_prefs held at open
+	//! time. The edit controls stay disabled until it is true: an edit made before
+	//! the reply lands sets m_sharedDirsDirty, which makes RefreshSharedDirsIfOpen()
+	//! discard that very reply, so OK would replace the daemon's shares with a list
+	//! built without ever having seen them.
 	bool m_sharedDirsLoaded;
 
-	//! The shared-folder rows' actual paths, indexed by the row's item data.
-	//! A list cell holds display text, and CPath's display form is not the
-	//! path -- see SetListRowPath() in the .cpp for why one cannot be rebuilt
-	//! from the other. Rebuilt by PopulateSharedDirsList(), appended to by
-	//! OnSharedDirAdd(), read back by HarvestSharedDirsList().
+	//! The shared-folder rows' actual paths, indexed by the row's item data. A list
+	//! cell holds display text, and CPath's display form is not the path -- see
+	//! SetListRowPath() in the .cpp for why one cannot be rebuilt from the other.
 	std::vector<CPath> m_sharedDirRowPaths;
 
 	//! Fill the shared-folders list widget from glob_prefs' roots.
@@ -140,11 +136,9 @@ protected:
 	void OnSharedDirAdd(wxCommandEvent &evt);
 	void OnSharedDirRemove(wxCommandEvent &evt);
 
-	//! The path-mapping rows' actual local prefixes, indexed by the row's
-	//! item data -- same rationale as m_sharedDirRowPaths (SetListRowPath()
-	//! in the .cpp): a list cell holds display text, not a round-trippable
-	//! CPath. Rebuilt by PopulatePathMappingList(), appended to by
-	//! OnPathMappingAdd(), read back by HarvestPathMappingList().
+	//! The path-mapping rows' actual local prefixes, indexed by the row's item
+	//! data. Same rationale as m_sharedDirRowPaths: a list cell holds display text,
+	//! not a round-trippable CPath.
 	std::vector<CPath> m_pathMappingRowPaths;
 
 	//! Fill the path-mapping list widget from glob_prefs' mappings (#843).
@@ -159,21 +153,18 @@ protected:
 	//! sense (it's the daemon's path, nothing here to browse to), but the
 	//! local side is a real folder on this machine.
 	void OnPathMappingBrowse(wxCommandEvent &evt);
-	//! Re-flows the explanatory paragraph above the path-mapping list when
-	//! the page is resized. Bound on the *page*, not on the paragraph:
-	//! wxStaticText::SetLabel() resizes the control to fit its label, so a
-	//! handler on the paragraph that rewrites the paragraph feeds itself
-	//! (it did -- stack exhaustion inside SetLabel). The page's width is
-	//! set by the dialog and is unmoved by anything the label does, so
-	//! driving the wrap from there cannot loop.
+	//! Re-flows the explanatory paragraph above the path-mapping list on resize.
+	//! Bound on the PAGE, not on the paragraph: wxStaticText::SetLabel() resizes the
+	//! control to fit its label, so a handler on the paragraph that rewrites the
+	//! paragraph feeds itself (stack exhaustion inside SetLabel). The page's width
+	//! is set by the dialog and unmoved by anything the label does.
 	void OnPathMappingPageResize(wxSizeEvent &evt);
 	//! Wraps that paragraph to the page's current client width.
 	void WrapPathMappingHint();
 
-	//! The paragraph with no line breaks in it. wxStaticText::Wrap() only
-	//! ever inserts breaks -- it reads the current label and treats any
-	//! newline already there as hard -- so re-flowing to a *wider* page has
-	//! to start from unwrapped text rather than from what is on screen.
+	//! The paragraph with no line breaks in it. wxStaticText::Wrap() only ever
+	//! inserts breaks and treats any newline already there as hard, so re-flowing to
+	//! a WIDER page has to start from unwrapped text.
 	wxString m_pathMappingHintText;
 	//! Width last wrapped to, so a resize that leaves the width alone (a
 	//! height-only change, say) does no work.
@@ -189,19 +180,17 @@ private:
 #endif
 
 public:
-	//! Re-seed the shared-folders editor at the start of an editing session.
-	//! The dialog is constructed once and reused, so without this it keeps
-	//! whatever it captured the first time Preferences was opened — stale the
-	//! moment anything else (amuleGUI over EC, say) changes the roots. Called
-	//! on show rather than on page change so it cannot discard edits the user
-	//! is part-way through, and skipped outright while edits are pending.
+	//! Re-seed the shared-folders editor at the start of an editing session. The
+	//! dialog is constructed once and reused, so without this it keeps whatever it
+	//! captured the first time Preferences was opened -- stale the moment anything
+	//! else changes the roots. Called on show rather than on page change so it
+	//! cannot discard edits in progress, and skipped while edits are pending.
 	void PrepareSharedDirsForSession();
 
-	//! Mark the end of an editing session: the pending-edit flags exist to stop
-	//! a refresh clobbering work in progress, so they have to be cleared when
-	//! that work is either applied or discarded. Without this they latch on the
-	//! first edit and suppress every later refresh for the dialog's lifetime —
-	//! and the dialog is never destroyed (OnClose vetoes).
+	//! Mark the end of an editing session: the pending-edit flags stop a refresh
+	//! clobbering work in progress, so they have to be cleared when that work is
+	//! applied or discarded. Otherwise they latch on the first edit and suppress
+	//! every later refresh for the dialog's lifetime -- and it is never destroyed.
 	void EndSharedDirsSession();
 
 private:
@@ -228,12 +217,11 @@ private:
 	//! when a tab (server / IP2Country) is hidden.
 	wxPanel *m_aMuleTweaksWidget = nullptr;
 	wxDataViewListCtrl *m_PrefsIcons;
-	//! `pages[]` index for every page widget, indexed by that same stable
-	//! position (never reordered -- only which pages are *visible* in
-	//! m_PrefsIcons changes). Each visible row's item data is one of these
-	//! indices, so OnPrefsPageChange identifies a page by that stable index
-	//! rather than by the row's live position in the sidebar, which shifts
-	//! whenever the server / IP2Country row is hidden or re-shown.
+	//! `pages[]` index for every page widget, by that same stable position (only
+	//! which pages are VISIBLE in m_PrefsIcons changes). Each visible row's item
+	//! data is one of these, so OnPrefsPageChange identifies a page by the stable
+	//! index rather than by the row's live position, which shifts whenever the
+	//! server / IP2Country row is hidden or re-shown.
 	std::vector<wxPanel *> m_pageWidgets;
 	//! Page icons, in `pages[]` order -- kept so EnableServerTab can
 	//! re-insert the server row's icon when the tab is re-shown.
@@ -294,13 +282,11 @@ private:
 	// callback can find an open dialog without a global pointer chain.
 	static PrefsUnifiedDlg *s_activeInstance;
 
-	// Snapshots taken at TransferToWindow so OnOk can detect "the user
-	// switched GeoIP source / pasted a new license / changed the URL
-	// during this dialog session" and kick off a download — otherwise
-	// the user has to remember to click Update now after each change.
-	// The Cfg system only tracks credential fields bound through
-	// NewCfgItem; the source dropdown is committed live, so we have
-	// to compare it manually.
+	// Snapshots taken at TransferToWindow so OnOk can tell that the user switched
+	// GeoIP source, pasted a new license or changed the URL during this session and
+	// kick off a download, rather than making them remember to click Update now.
+	// The Cfg system only tracks credential fields bound through NewCfgItem, and
+	// the source dropdown is committed live, so it is compared manually.
 	int m_GeoIPSourceAtOpen;
 	wxString m_GeoIPMaxMindLicenseAtOpen;
 	wxString m_GeoIPCustomUrlAtOpen;
@@ -313,9 +299,9 @@ public:
 	void OnProtocolEd2kToggle(wxCommandEvent &event);
 	void OnProtocolMagnetToggle(wxCommandEvent &event);
 	void OnAssocCollectionToggle(wxCommandEvent &event);
-	// Shared implementation for the two OnProtocol*Toggle handlers —
-	// same live-OS-state write model as autostart, gated by a wx
-	// confirm dialog when a non-aMule handler is currently in place.
+	// Shared implementation for the two OnProtocol*Toggle handlers: same
+	// live-OS-state write model as autostart, gated by a confirm dialog when a
+	// non-aMule handler is currently in place.
 	void HandleProtocolToggle(HandlerTarget scheme, int checkboxId, bool wanted);
 	void OnPrefsPageChange(wxDataViewEvent &event);
 	void OnToolTipDelayChange(wxSpinEvent &event);
@@ -327,14 +313,11 @@ public:
 
 	void OnInitDialog(wxInitDialogEvent &evt);
 
-	// Tri-state outcome of an attempt to commit the pending share
-	// selection. Used by OnOk to decide between three flows:
-	//   * Committed       → continue to Save() + Reload + Show(false)
-	//   * NothingToCommit → continue to Save() + Show(false), skip Reload
-	//   * CancelledByUser → return early from OnOk: keep the prefs
-	//                       dialog open so the user can adjust their
-	//                       selection without losing the rest of
-	//                       their pending pref changes
+	// Tri-state outcome of an attempt to commit the pending share selection:
+	//   * Committed       -> Save() + Reload + Show(false)
+	//   * NothingToCommit -> Save() + Show(false), skipping Reload
+	//   * CancelledByUser -> return early from OnOk, keeping the dialog open so the
+	//                        rest of the pending pref changes are not lost
 	enum class SharedDirsCommitResult
 	{
 		NothingToCommit,
@@ -342,12 +325,10 @@ public:
 		CancelledByUser,
 	};
 
-	// Commits the pending share selection from the directory tree
-	// into theApp->glob_prefs->shareddir_list. Confirms before
-	// committing recursive-share roots that look like sensitive
-	// system locations (e.g. home, /etc), then runs the recursive
-	// directory enumeration on a worker thread with a cancellable
-	// progress dialog so the UI never freezes on large roots.
+	// Commits the pending share selection from the directory tree into
+	// theApp->glob_prefs->shareddir_list. Confirms before committing recursive-share
+	// roots that look like sensitive system locations, then runs the recursive
+	// enumeration on a worker thread with a cancellable progress dialog.
 	SharedDirsCommitResult CommitSharedDirsWithProgress();
 
 	// Fills one of the amuleapi credential-state labels. A stored password
@@ -362,9 +343,8 @@ private:
 	bool m_toolbarOrientationChanged;
 
 	// Whether a guest password was stored when this dialog opened.
-	// TransferFromWindow overwrites the live preference with the
-	// checkbox's value, so OnOk cannot ask the preference itself whether
-	// anything was there to keep.
+	// TransferFromWindow overwrites the live preference with the checkbox's value,
+	// so OnOk cannot ask the preference itself.
 	bool m_amuleApiGuestWasSet = false;
 };
 

--- a/src/ProtocolHandlerManager.cpp
+++ b/src/ProtocolHandlerManager.cpp
@@ -50,12 +50,10 @@
 #include <wx/utils.h>   // Needed for wxGetEnv / wxGetUserHome
 #endif
 
-// Forward declarations for the macOS backend entry points implemented
-// in ProtocolHandlerManager_mac.mm. Declared at file scope (external
-// linkage, global namespace) so the .mm's plain-C++ definitions link
-// against them. Keeping them out of the anonymous namespace below is
-// what actually makes the linker resolution work — a static-linkage
-// declaration cannot bind to a global-scope definition.
+// Forward declarations for the macOS backend entry points implemented in
+// ProtocolHandlerManager_mac.mm. Declared at file scope (external linkage,
+// global namespace) so the .mm's plain-C++ definitions link against them: a
+// static-linkage declaration could not bind to a global-scope definition.
 #if defined(__WXMAC__) || defined(__WXOSX__)
 wxString MacReadHandler(HandlerTarget scheme);
 bool MacWrite(HandlerTarget scheme, const wxString &canonicalExe);
@@ -104,13 +102,11 @@ const char *SchemeNameUtf8(HandlerTarget target)
 }
 
 // Per-backend low-level helpers. Return raw OS state without applying
-// aMule-specific policy (identity comparison etc.). Platform-specific
-// definitions live near the bottom of this file.
+// aMule-specific policy; definitions live near the bottom of this file.
 //
-// Reads the currently-registered handler's identifier for `scheme`.
-// The identifier shape differs by OS: registry command string on
-// Windows, .desktop id / Exec= path on Linux, bundle id on macOS.
-// Empty on "no handler set".
+// Reads the currently-registered handler's identifier for `scheme`. The shape
+// differs by OS: registry command string on Windows, .desktop id on Linux,
+// bundle id on macOS. Empty on "no handler set".
 wxString BackendReadHandler(HandlerTarget scheme);
 
 // Sets aMule as the default handler for `scheme`. `canonicalExe` is
@@ -138,13 +134,10 @@ bool BackendIsUs(const wxString &raw);
 
 wxString ProtocolHandlerManager::GetCanonicalExecutablePath()
 {
-	// wxStandardPaths::GetExecutablePath() wraps the OS native call
-	// (GetModuleFileNameW on Windows, _NSGetExecutablePath on macOS,
-	// /proc/self/exe readlink on Linux). On POSIX we resolve any
-	// intermediate symlinks via realpath() so AppImage / .app bundle
-	// moves are detected correctly by SelfHealOnStartup. Same helper
-	// as AutostartManager — duplicated here so this class stays
-	// self-contained.
+	// wxStandardPaths::GetExecutablePath() wraps the OS native call. On POSIX we
+	// resolve intermediate symlinks via realpath() so AppImage / .app bundle moves
+	// are detected correctly by SelfHealOnStartup. Same helper as
+	// AutostartManager, duplicated so this class stays self-contained.
 	wxString raw = wxStandardPaths::Get().GetExecutablePath();
 
 #ifndef __WXMSW__
@@ -185,11 +178,9 @@ void ProtocolHandler_QueueLinks(const wxArrayString &links)
 
 	const wxString &cfgDir = thePrefs::GetConfigDir();
 	if (cfgDir.IsEmpty()) {
-		// Would resolve to a path relative to the launch working
-		// directory, which for a .app bundle is "/". Never happens on
-		// the wx event paths (they run after OnInit), but writing the
-		// links somewhere the app will never look is worse than
-		// dropping them with a log line.
+		// Would resolve to a path relative to the launch working directory,
+		// which for a .app bundle is "/". Writing the links somewhere the app
+		// will never look is worse than dropping them with a log line.
 		AMULE_URL_LOG(
 			wxT("queue: config dir not set yet, dropping %d link(s)"), (int)links.GetCount());
 		return;
@@ -211,12 +202,10 @@ void ProtocolHandler_QueueLinks(const wxArrayString &links)
 	} else {
 		AMULE_URL_LOG(wxT("failed to open ED2KLinks for write"));
 	}
-	// Do NOT call AddLinksFromFile here — these handlers can fire before
+	// Do NOT call AddLinksFromFile here -- these handlers can fire before
 	// theApp->downloadqueue is wired (amulegui only builds it once the EC
-	// connection is up). Instead we rely on the ~1 s polling loop in both
-	// CDownloadQueue::Process (monolithic + daemon) and
-	// CamuleRemoteGuiApp::UpdateStats (remote GUI) to drain the file
-	// through AddLinksFromFile → AddLink on the next tick.
+	// connection is up). The ~1 s polling loop in CDownloadQueue::Process and
+	// CamuleRemoteGuiApp::UpdateStats drains the file on the next tick.
 }
 
 void ProtocolHandler_QueueSchemeLink(const wxString &url)
@@ -224,11 +213,10 @@ void ProtocolHandler_QueueSchemeLink(const wxString &url)
 	if (url.empty()) {
 		return;
 	}
-	// Browsers percent-encode ed2k:// pipes; wxURI::Unescape restores
-	// the literals CMagnetED2KConverter / the eD2k parser expect. Done
-	// here rather than in QueueLinks because links read out of a
-	// collection file are not percent-encoded, and decoding them would
-	// corrupt any filename that legitimately contains a '%'.
+	// Browsers percent-encode ed2k:// pipes; wxURI::Unescape restores the literals
+	// the eD2k parser expects. Done here rather than in QueueLinks because links
+	// read out of a collection file are not percent-encoded, and decoding them
+	// would corrupt any filename that legitimately contains a '%'.
 	wxString decoded = wxURI::Unescape(url);
 	AMULE_URL_LOG(wxT("queue scheme link: '%s' -> '%s'"), url, decoded);
 
@@ -282,22 +270,19 @@ void ProtocolHandlerManager::SelfHealOnStartup()
 	for (HandlerTarget scheme : schemes) {
 		wxString raw = BackendReadHandler(scheme);
 		if (raw.empty()) {
-			// No handler set — disabling is always a deliberate
-			// user choice we don't second-guess.
+			// No handler set: disabling is a deliberate user choice.
 			continue;
 		}
 		if (!BackendIsUs(raw)) {
-			// A third-party app currently owns this scheme —
-			// leave it alone.
+			// A third-party app owns this scheme; leave it alone.
 			continue;
 		}
 		if (BackendIdentityMatches(raw, canonical)) {
-			// We own it AND the registered path already matches
-			// the running binary. Nothing to do.
+			// We own it and the registered path already matches.
 			continue;
 		}
-		// We own it but the registered path drifted (user moved
-		// AppImage / .app / install dir). Rewrite.
+		// We own it but the registered path drifted (moved AppImage / .app /
+		// install dir), so rewrite.
 		wxLogDebug(wxT("ProtocolHandlerManager::SelfHealOnStartup: rewriting %s handler from '%s' to "
 			       "'%s'"),
 			SchemeNameUtf8(scheme),
@@ -316,25 +301,24 @@ namespace
 
 #if defined(__WXMSW__)
 
-// Windows: per-user URL Protocol under HKCU\Software\Classes\<scheme>.
-// The layout LaunchServices-equivalent Windows shell uses:
+// Windows: per-user URL Protocol under HKCU\Software\Classes\<scheme>:
 //
 //   HKCU\Software\Classes\ed2k\                     (default) = "URL:eD2k Protocol"
 //                              \                   URL Protocol   = ""
 //                              \DefaultIcon\        (default) = "<amule.exe>,0"
 //                              \shell\open\command\ (default) = "\"<amule.exe>\" \"%1\""
 //
-// A file type is laid out differently — the extension key names a ProgID
-// and the ProgID carries the icon and command:
+// A file type is laid out differently: the extension key names a ProgID, and the
+// ProgID carries the icon and command:
 //
 //   HKCU\Software\Classes\.emulecollection\  (default) = "aMule.emulecollection"
-//                        \…\OpenWithProgids\ aMule.emulecollection = ""
+//                        \...\OpenWithProgids\ aMule.emulecollection = ""
 //   HKCU\Software\Classes\aMule.emulecollection\
 //                              \                   (default) = "eMule Collection"
 //                              \DefaultIcon\        (default) = "<amule.exe>,0"
 //                              \shell\open\command\ (default) = "\"<amule.exe>\" \"%1\""
 //
-// Per-user (HKCU not HKLM) so toggling never needs elevation.
+// HKCU rather than HKLM, so toggling never needs elevation.
 
 // The ProgID doubles as the registry key name for the file type, which is
 // what lets SubKey() and the read path stay common with the schemes.
@@ -386,9 +370,9 @@ static wxString ReadStringValue(HKEY root, const wchar_t *subKey, const wchar_t 
 	return wxString(buf.data());
 }
 
-// Extract the executable path from a Windows "shell\open\command"
-// value: `"C:\...\amule.exe" "%1"` → `C:\...\amule.exe`. Also handles
-// the unquoted `C:\...\amule.exe %1` form for defensiveness.
+// Extract the executable path from a Windows "shell\open\command" value:
+// `"C:\...\amule.exe" "%1"` -> `C:\...\amule.exe`. Also handles the unquoted
+// form.
 static wxString ExtractExeFromCommand(const wxString &command)
 {
 	if (command.empty()) {
@@ -419,17 +403,15 @@ wxString BackendReadHandler(HandlerTarget scheme)
 // ProgID key carry identically. `base` is Software\Classes\<scheme|progid>.
 static bool WriteIconAndCommand(const wxString &base, const wxString &canonicalExe)
 {
-	// DefaultIcon: the icon Explorer / Edge show next to the "Open
-	// with aMule?" prompt. "<exe>,0" = first icon resource in the
-	// executable.
+	// DefaultIcon: what Explorer / Edge show next to the "Open with aMule?"
+	// prompt. "<exe>,0" = first icon resource in the executable.
 	wxString iconRef = wxString::Format(wxT("\"%s\",0"), canonicalExe);
 	if (!WriteStringValue(HKEY_CURRENT_USER, (base + wxT("\\DefaultIcon")).wc_str(), nullptr, iconRef)) {
 		return false;
 	}
 
-	// The actual command — quote both the executable and %1 so paths
-	// with spaces and URIs with query strings survive Windows' command
-	// tokeniser intact.
+	// Quote both the executable and %1 so paths with spaces and URIs with query
+	// strings survive Windows' command tokeniser intact.
 	wxString command = wxString::Format(wxT("\"%s\" \"%%1\""), canonicalExe);
 	return WriteStringValue(
 		HKEY_CURRENT_USER, (base + wxT("\\shell\\open\\command")).wc_str(), nullptr, command);
@@ -462,12 +444,11 @@ bool BackendWrite(HandlerTarget target, const wxString &canonicalExe)
 		return false;
 	}
 
-	// Advertise on the extension. OpenWithProgids only adds us to the
-	// "Open with" list; the extension's default is what actually binds,
-	// and we take it only when nothing else has claimed it so an
-	// existing association survives. Note neither makes aMule the user's
-	// *chosen* default: from Windows 8 on that lives in a hash-protected
-	// UserChoice key no application may write.
+	// Advertise on the extension. OpenWithProgids only adds us to the "Open with"
+	// list; the extension's default is what binds, and we take it only when
+	// nothing else has claimed it. Neither makes aMule the user's *chosen*
+	// default: from Windows 8 on that lives in a hash-protected UserChoice key no
+	// application may write.
 	wxString extProgIds = wxString(COLLECTION_EXT_KEY) + wxT("\\OpenWithProgids");
 	if (!WriteStringValue(HKEY_CURRENT_USER, extProgIds.wc_str(), COLLECTION_PROGID, wxEmptyString)) {
 		return false;
@@ -483,9 +464,8 @@ bool BackendWrite(HandlerTarget target, const wxString &canonicalExe)
 	return true;
 }
 
-// Recursively delete a registry key and everything under it. Registry
-// APIs don't offer a one-call recursive delete on all Windows versions
-// we support, so implement it explicitly.
+// Recursively delete a registry key and everything under it: the registry APIs
+// offer no one-call recursive delete on every Windows version we support.
 static LSTATUS DeleteKeyRecursive(HKEY root, const wchar_t *subKey)
 {
 	HKEY hKey;
@@ -497,9 +477,8 @@ static LSTATUS DeleteKeyRecursive(HKEY root, const wchar_t *subKey)
 		return rc;
 	}
 
-	// Enumerate + delete subkeys first. Registry enumeration is
-	// invalidated by deletion, so we re-enumerate from index 0 each
-	// pass until no subkeys remain.
+	// Enumerate and delete subkeys first. Deletion invalidates an enumeration, so
+	// re-enumerate from index 0 each pass until no subkeys remain.
 	for (;;) {
 		wchar_t name[256];
 		DWORD cch = 256;
@@ -525,9 +504,8 @@ static LSTATUS DeleteKeyRecursive(HKEY root, const wchar_t *subKey)
 
 bool BackendRemove(HandlerTarget target)
 {
-	// Only remove if we're the current handler — protects a
-	// user's manual override or a third-party handler that happens
-	// to have written under the same key later.
+	// Only remove if we are the current handler, so a user's manual override or a
+	// third-party handler written under the same key later survives.
 	wxString current = BackendReadHandler(target);
 	if (current.empty()) {
 		return true; // already absent
@@ -538,9 +516,8 @@ bool BackendRemove(HandlerTarget target)
 
 	LSTATUS rc = DeleteKeyRecursive(HKEY_CURRENT_USER, SubKey(target).wc_str());
 	if (!IsUriScheme(target)) {
-		// Also undo the extension advertisement, mirroring BackendWrite.
-		// The default is only cleared while it still names our ProgID: a
-		// user who has since pointed .emulecollection elsewhere keeps it.
+		// Also undo the extension advertisement, mirroring BackendWrite. The
+		// default is cleared only while it still names our ProgID.
 		wxString extProgIds = wxString(COLLECTION_EXT_KEY) + wxT("\\OpenWithProgids");
 		HKEY hKey;
 		if (RegOpenKeyExW(HKEY_CURRENT_USER, extProgIds.wc_str(), 0, KEY_SET_VALUE, &hKey) ==
@@ -559,8 +536,7 @@ bool BackendRemove(HandlerTarget target)
 
 bool BackendIdentityMatches(const wxString &raw, const wxString &canonicalExe)
 {
-	// Registry values on Windows can round-trip with different case
-	// on paths (C:\Program Files\ vs c:\program files\). Compare
+	// Registry values can round-trip with different case on paths, so compare
 	// case-insensitively to match Windows filesystem semantics.
 	return raw.IsSameAs(canonicalExe, false);
 }
@@ -570,13 +546,11 @@ bool BackendIsUs(const wxString &raw)
 	if (raw.empty()) {
 		return false;
 	}
-	// "us" == the currently-running binary, keyed by basename so
-	// path drift (user moved the install dir since registering) still
-	// counts as our own registration — SelfHealOnStartup rewrites
-	// the full path in that case. Per-binary comparison is what makes
-	// the amule/amulegui differentiation work: in a remote-GUI setup
-	// the checkbox in amulegui's prefs correctly reads "unchecked"
-	// when amule.exe is the current handler, and vice versa.
+	// "us" == the currently-running binary, keyed by basename so path drift still
+	// counts as our own registration (SelfHealOnStartup rewrites the full path).
+	// Per-binary comparison is what makes the amule/amulegui differentiation work:
+	// in a remote-GUI setup amulegui's checkbox correctly reads "unchecked" while
+	// amule.exe is the current handler, and vice versa.
 	wxString ownExe = ProtocolHandlerManager::GetCanonicalExecutablePath();
 	if (ownExe.empty()) {
 		return false;
@@ -588,12 +562,10 @@ bool BackendIsUs(const wxString &raw)
 
 #elif defined(__WXMAC__) || defined(__WXOSX__)
 
-// The macOS backend is Objective-C++ (needs LSCopyDefaultHandlerForURLScheme
-// / LSSetDefaultHandlerForURLScheme from ApplicationServices).
-// Implementation lives in ProtocolHandlerManager_mac.mm; the per-scheme
-// entry points have external linkage at file scope (declared just
-// before this anonymous namespace opens) so the linker can resolve
-// them against the .mm's global-scope definitions.
+// The macOS backend is Objective-C++ (it needs LSCopyDefaultHandlerForURLScheme
+// / LSSetDefaultHandlerForURLScheme). Implementation lives in
+// ProtocolHandlerManager_mac.mm; the entry points declared above this anonymous
+// namespace have external linkage so the linker can resolve them.
 
 wxString BackendReadHandler(HandlerTarget scheme)
 {
@@ -607,32 +579,24 @@ bool BackendWrite(HandlerTarget scheme, const wxString &canonicalExe)
 
 bool BackendRemove(HandlerTarget scheme)
 {
-	// LaunchServices has no "remove default" call — the model is
-	// "some app is always the default". Best we can do on Disable
-	// is check that we're currently the default and, if so, no-op
-	// (the user has to pick another app from the OS's "Open With"
-	// prompt to actually stop us from receiving clicks). Never
-	// silently reassign to a third-party app — that would be a
-	// worse UX than leaving us bound.
+	// LaunchServices has no "remove default" call -- the model is that some app is
+	// always the default. On Disable the best we can do is check that we are
+	// currently the default and no-op; the user has to pick another app from the
+	// OS's "Open With" prompt to actually stop us receiving clicks. Silently
+	// reassigning to a third-party app would be worse than leaving us bound.
 	//
-	// Return true so the prefs toggle reads as "disable succeeded"
-	// from the user's perspective; the checkbox flipping off is the
-	// visible signal that we've stepped back. On next click of a
-	// scheme URL macOS will show the "no default handler picked
-	// yet" chooser and the user can select another app.
-	//
-	// The reality is that on Sequoia+ this is unavoidable: Apple
-	// blocked programmatic clearing of scheme handlers to prevent
-	// malicious deregistration. Documented in the class comment.
+	// Returns true so the prefs toggle reads as "disable succeeded": the checkbox
+	// flipping off is the visible signal that we have stepped back. On Sequoia+
+	// this is unavoidable anyway -- Apple blocked programmatic clearing of scheme
+	// handlers to prevent malicious deregistration.
 	return true;
 }
 
 bool BackendIdentityMatches(const wxString &raw, const wxString & /*canonicalExe*/)
 {
-	// On macOS the identifier is a bundle id string (e.g.
-	// "org.amule.amule"), not a path. Path drift doesn't apply —
-	// LaunchServices tracks the bundle by id and finds the current
-	// location automatically. Identity match is bundle-id equality.
+	// On macOS the identifier is a bundle id, not a path, so path drift does not
+	// apply: LaunchServices tracks the bundle by id and finds its current
+	// location. Identity match is bundle-id equality.
 	return raw.IsSameAs(::MacOwnBundleId(), false);
 }
 
@@ -643,26 +607,22 @@ bool BackendIsUs(const wxString &raw)
 
 #else // assumed Linux / *BSD with XDG-compliant desktop env
 
-// Linux: per-user default scheme handler in
-// $XDG_CONFIG_HOME/mimeapps.list (falls back to ~/.config/mimeapps.list).
-// [Default Applications] section maps x-scheme-handler/<scheme> to a
-// .desktop file id. The .desktop file itself must also declare
-// MimeType= including x-scheme-handler/<scheme> so file managers /
-// browsers consider it a valid handler in the first place; that is
-// shipped statically in packaging/... /org.amule.aMule.desktop.
+// Linux: per-user default scheme handler in $XDG_CONFIG_HOME/mimeapps.list
+// (falling back to ~/.config/mimeapps.list), whose [Default Applications]
+// section maps x-scheme-handler/<scheme> to a .desktop file id. The .desktop
+// file must also declare MimeType= including that pseudo-type before file
+// managers and browsers consider it a valid handler at all; that is shipped
+// statically under packaging/.
 // https://specifications.freedesktop.org/mime-apps-spec/latest/
 //
-// We do NOT depend on xdg-mime (part of xdg-utils) being installed —
-// several minimal distros / containers ship without it. Direct ini
-// write covers those.
+// We do NOT depend on xdg-mime being installed -- several minimal distros and
+// containers ship without it, so the ini is written directly.
 
-// Which .desktop id represents the currently-running binary.
-// amule (monolithic + daemon) → org.amule.aMule.desktop; amulegui
-// (remote GUI) → org.amule.aMule.gui.desktop. The daemon is not
-// user-facing but we register it against the monolithic desktop id
-// too so `amuled --configure-protocols on` still points clicks at a
-// user-visible entry that the DE can open. Basename lookup on the
-// running exe keeps this working across the install/AppImage variants.
+// Which .desktop id represents the currently-running binary: amule maps to
+// org.amule.aMule.desktop, amulegui -> org.amule.aMule.gui.desktop. The daemon
+// is not user-facing but registers against the monolithic id too, so
+// `amuled --configure-protocols on` still points clicks at an entry the DE can
+// open. Basename lookup keeps this working across the install/AppImage variants.
 static wxString OwnDesktopId()
 {
 	wxString ownExe = ProtocolHandlerManager::GetCanonicalExecutablePath();
@@ -683,9 +643,9 @@ static wxString MimeAppsPath()
 	return wxGetUserHome() + wxT("/.config/mimeapps.list");
 }
 
-// The mimeapps.list key. Schemes get the x-scheme-handler/ pseudo-type;
-// the collection is a real MIME type, so SchemeNameUtf8 already returns
-// the whole key for it.
+// The mimeapps.list key. Schemes get the x-scheme-handler/ pseudo-type; the
+// collection is a real MIME type, for which SchemeNameUtf8 already returns the
+// whole key.
 static wxString SchemeKey(HandlerTarget target)
 {
 	if (!IsUriScheme(target)) {
@@ -694,10 +654,9 @@ static wxString SchemeKey(HandlerTarget target)
 	return wxString::Format(wxT("x-scheme-handler/%s"), SchemeNameUtf8(target));
 }
 
-// Parse an ini-style file into (section, key, value) triples for
-// straightforward editing. Preserves original line order via
-// vector-of-lines so a round-trip write doesn't reorder unrelated
-// entries. Comments and blank lines are preserved as-is.
+// Parse an ini-style file into (section, key, value) triples. Original line
+// order is preserved via a vector-of-lines so a round-trip write does not
+// reorder unrelated entries; comments and blank lines survive as-is.
 struct IniLine
 {
 	wxString section; // empty for pre-first-section lines (rare)
@@ -710,9 +669,8 @@ struct IniLine
 static std::vector<IniLine> ReadIniLines(const wxString &path)
 {
 	std::vector<IniLine> lines;
-	// A missing file is the normal "not configured yet" case (e.g. no
-	// ~/.config/mimeapps.list on a headless daemon). Bail before opening so
-	// wxFile does not log a spurious "can't open file (error 2)" for it.
+	// A missing file is the normal "not configured yet" case. Bail before opening
+	// so wxFile does not log a spurious "can't open file (error 2)".
 	if (!wxFile::Exists(path)) {
 		return lines;
 	}
@@ -751,7 +709,6 @@ static std::vector<IniLine> ReadIniLines(const wxString &path)
 
 static bool WriteIniLines(const wxString &path, const std::vector<IniLine> &lines)
 {
-	// Ensure parent directory exists.
 	wxFileName fn(path);
 	if (!fn.DirExists()) {
 		if (!wxFileName::Mkdir(fn.GetPath(), 0755, wxPATH_MKDIR_FULL)) {
@@ -767,10 +724,9 @@ static bool WriteIniLines(const wxString &path, const std::vector<IniLine> &line
 		} else {
 			out << il.raw;
 		}
-		// Terminate every line, including the last. mimeapps.list is a
-		// shared file - xdg-mime and the desktop environment append to
-		// it too - and an unterminated final line silently fuses with
-		// whatever the next writer adds, breaking both entries.
+		// Terminate every line, including the last: mimeapps.list is shared with
+		// xdg-mime and the desktop environment, and an unterminated final line
+		// silently fuses with whatever the next writer appends.
 		out << wxT("\n");
 	}
 
@@ -795,9 +751,8 @@ wxString BackendReadHandler(HandlerTarget scheme)
 			continue;
 		}
 		if (il.key == needle) {
-			// mimeapps.list allows semicolon-separated fallback
-			// chains ("foo.desktop;bar.desktop;"). The first
-			// entry is the effective default.
+			// mimeapps.list allows semicolon-separated fallback chains; the
+			// first entry is the effective default.
 			wxString first = il.value.BeforeFirst(wxT(';')).Trim(false).Trim(true);
 			return first;
 		}
@@ -807,11 +762,9 @@ wxString BackendReadHandler(HandlerTarget scheme)
 
 bool BackendWrite(HandlerTarget scheme, const wxString &canonicalExe)
 {
-	// canonicalExe is unused on Linux — the mimeapps.list entry
-	// references a .desktop file id (org.amule.aMule.desktop), not
-	// an executable path. Path drift is handled at a different
-	// layer: the .desktop's Exec= line is resolved through PATH /
-	// AppImage integration by the DE at click time.
+	// canonicalExe is unused on Linux: the mimeapps.list entry references a
+	// .desktop file id, not an executable path, and path drift is handled by the
+	// DE resolving the .desktop's Exec= line at click time.
 	(void)canonicalExe;
 
 	wxString path = MimeAppsPath();
@@ -833,8 +786,8 @@ bool BackendWrite(HandlerTarget scheme, const wxString &canonicalExe)
 		}
 	}
 
-	// Not found — insert. If the section exists, insert as its last
-	// entry; otherwise append the section header + entry to the end.
+	// Not found: insert as the section's last entry, or append the section header
+	// and entry to the end.
 	IniLine entry;
 	entry.section = wxT("Default Applications");
 	entry.isEntry = true;
@@ -885,9 +838,8 @@ bool BackendRemove(HandlerTarget scheme)
 
 bool BackendIdentityMatches(const wxString &raw, const wxString & /*canonicalExe*/)
 {
-	// On Linux the identifier is a .desktop file id, not a path.
-	// Path drift is handled by the DE's .desktop lookup (XDG
-	// data-dirs walk), not by us rewriting mimeapps.list.
+	// On Linux the identifier is a .desktop file id, not a path; path drift is
+	// handled by the DE's XDG data-dirs walk, not by us rewriting mimeapps.list.
 	return raw == OwnDesktopId();
 }
 

--- a/src/ProtocolHandlerManager.h
+++ b/src/ProtocolHandlerManager.h
@@ -28,41 +28,35 @@
 #include <wx/arrstr.h>
 #include <wx/string.h>
 
-// Cross-platform "aMule is the default handler for X" toggle, where X is
-// an ed2k:// / magnet: link or an .emulecollection file. Mirrors
-// AutostartManager's shape: the OS is the source of truth, per-user, no
-// elevation. The per-OS store is:
+// Cross-platform "aMule is the default handler for X" toggle, where X is an
+// ed2k:// / magnet: link or an .emulecollection file. Mirrors AutostartManager's
+// shape: the OS is the source of truth, per-user, no elevation. The per-OS store
+// is:
 //
-//   Windows : HKCU\Software\Classes\<scheme> (URL-protocol keys,
-//             DefaultIcon + shell\open\command pointing at amule.exe).
-//             The collection file type instead uses the ProgID layout
-//             every Windows file association needs: the extension key
-//             names a ProgID, and the ProgID carries the icon and the
-//             open command.
-//   Linux   : $XDG_CONFIG_HOME/mimeapps.list [Default Applications]
-//             x-scheme-handler/<scheme>=org.amule.aMule.desktop, or
-//             application/x-emule-collection=… for the file type.
-//             The .desktop still declares MimeType= as the "advertise"
-//             layer so file managers pick us up even without a default.
-//   macOS   : LaunchServices — LSSetDefaultHandlerForURLScheme for the
-//             schemes, LSSetDefaultRoleHandlerForContentType for the
-//             collection UTI. The .app's Info.plist declares
-//             CFBundleURLTypes / CFBundleDocumentTypes so LaunchServices
-//             considers us eligible in the first place.
+//   Windows : HKCU\Software\Classes\<scheme> (URL-protocol keys, DefaultIcon +
+//             shell\open\command pointing at amule.exe). The collection file
+//             type instead uses the ProgID layout every Windows file association
+//             needs: the extension key names a ProgID, and the ProgID carries
+//             the icon and the open command.
+//   Linux   : $XDG_CONFIG_HOME/mimeapps.list [Default Applications],
+//             x-scheme-handler/<scheme>=org.amule.aMule.desktop or
+//             application/x-emule-collection=... for the file type. The
+//             .desktop still declares MimeType= as the advertise layer.
+//   macOS   : LaunchServices -- LSSetDefaultHandlerForURLScheme for the schemes,
+//             LSSetDefaultRoleHandlerForContentType for the collection UTI. The
+//             .app's Info.plist declares CFBundleURLTypes /
+//             CFBundleDocumentTypes so LaunchServices considers us eligible.
 //
-// A note on what "enable" can actually promise for the file type: from
-// Windows 8 on, the user's chosen default lives in a hash-protected
-// UserChoice key that no application may write. Enabling therefore adds
-// aMule to the "Open with" list and takes the default only when nothing
-// else has claimed the extension. macOS and Linux have no such
+// What "enable" can promise for the file type: from Windows 8 on, the user's
+// chosen default lives in a hash-protected UserChoice key no application may
+// write, so enabling adds aMule to the "Open with" list and takes the default
+// only when nothing else has claimed the extension. macOS and Linux have no such
 // restriction.
 //
-// magnet handling in aMule keeps its ed2k-compatibility requirement:
-// magnet URIs must carry xt=urn:ed2k:/urn:ed2khash: + xl= (enforced by
-// CMagnetED2KConverter in MagnetURI.cpp). BitTorrent-only magnets are
-// out of scope. This class only owns the OS registration; parsing lives
-// in CamuleAppCommon::CheckPassedLink() which already handles both
-// schemes, and in CMuleCollection for the file type.
+// magnet handling keeps its ed2k-compatibility requirement: magnet URIs must
+// carry xt=urn:ed2k:/urn:ed2khash: + xl=, enforced by CMagnetED2KConverter.
+// This class only owns the OS registration; parsing lives in
+// CamuleAppCommon::CheckPassedLink() and in CMuleCollection.
 
 // What aMule can register itself as the handler for. Named for the
 // registration, not the payload: the two schemes and the collection file
@@ -83,12 +77,10 @@ public:
 	// running binary (use SelfHealOnStartup() for that).
 	static bool IsEnabled(HandlerTarget scheme);
 
-	// Writes/overwrites the OS handler entry for `scheme` to point at
-	// the running binary's canonical path. Idempotent; returns true on
-	// success. Does NOT prompt the user before overwriting a
-	// pre-existing third-party handler — the caller (prefs toggle,
-	// wizard, CLI, installer) is responsible for the "already registered
-	// to another app, overwrite?" UX. Use GetCurrentHandler() to check.
+	// Writes or overwrites the OS handler entry for `scheme` to point at the
+	// running binary's canonical path. Idempotent. Does NOT prompt before
+	// overwriting a pre-existing third-party handler -- the caller owns the
+	// "already registered to another app, overwrite?" UX, via GetCurrentHandler().
 	static bool Enable(HandlerTarget scheme);
 
 	// Removes the OS handler entry for `scheme` if aMule is the current
@@ -96,43 +88,33 @@ public:
 	// returns true on success. Never wipes a third-party handler.
 	static bool Disable(HandlerTarget scheme);
 
-	// Returns a short human-readable name of the app currently
-	// registered as the default handler for `scheme` (e.g. "Transmission"
-	// on macOS, executable path on Windows/Linux), or empty string if
-	// no handler is set or the current handler is aMule. Used by the
-	// prefs toggle to build the "another app is currently the default,
-	// overwrite?" confirm dialog.
-	//
-	// Never used to gate Enable() — see the Enable() contract note.
+	// A short human-readable name of the app currently registered as the default
+	// handler for `scheme` ("Transmission" on macOS, an executable path on
+	// Windows/Linux), or empty when no handler is set or aMule is it. Used to build
+	// the "another app is currently the default, overwrite?" confirm dialog, never
+	// to gate Enable() -- see its contract note.
 	static wxString GetCurrentHandler(HandlerTarget scheme);
 
-	// Called once from CamuleApp::OnInit. For each scheme where aMule is
-	// currently the default handler AND the registered path differs
-	// from the canonical path of the running binary, rewrites the entry
-	// so the next click launches the right binary. Handles the
-	// "user moved the AppImage / .app / install dir" case.
-	//
-	// Does nothing if we aren't the current handler for a scheme —
-	// disabling is always a deliberate user choice we don't second-
-	// guess.
+	// Called once from CamuleApp::OnInit. For each scheme where aMule is the
+	// current default handler AND the registered path differs from the canonical
+	// path of the running binary, rewrites the entry so the next click launches the
+	// right binary -- the "user moved the AppImage / .app / install dir" case.
+	// Does nothing where we are not the current handler: disabling is a deliberate
+	// user choice.
 	static void SelfHealOnStartup();
 
-	// Resolves argv[0] to its canonical absolute path (realpath() on
-	// POSIX, GetModuleFileNameW() on Windows). Duplicates the helper
-	// in AutostartManager rather than depending on it so this class
-	// stays self-contained; the resolution is a couple of lines and
-	// both callers want the same thing.
+	// Resolves argv[0] to its canonical absolute path (realpath() on POSIX,
+	// GetModuleFileNameW() on Windows). Duplicates the AutostartManager helper
+	// rather than depending on it, so this class stays self-contained.
 	static wxString GetCanonicalExecutablePath();
 };
 
-// Queues already-validated eD2k links into the ED2KLinks file so
+// Queues already-validated eD2k links into the ED2KLinks file, so
 // CDownloadQueue::Process (or the equivalent polling loop in
-// CamuleRemoteGuiApp) picks them up on its next 1-second tick and forwards
-// them to AddLink. Build-agnostic: works from monolithic amule, remote-GUI
-// amulegui, or daemon amuled — each has its own theApp with an ED2KLinks
-// polling loop that ends up calling AddLinksFromFile on the same file we
-// write to here. Safe to call before the download queue is fully wired
-// (cold-launch case): we just write, we don't try to enqueue.
+// CamuleRemoteGuiApp) picks them up on its next 1-second tick. Build-agnostic:
+// monolithic amule, amulegui and amuled each have a polling loop that calls
+// AddLinksFromFile on the same file. Safe to call before the download queue is
+// wired, the cold-launch case: this only writes.
 //
 // The whole batch costs one open/write, and raises the window once.
 void ProtocolHandler_QueueLinks(const wxArrayString &links);

--- a/src/Proxy.cpp
+++ b/src/Proxy.cpp
@@ -145,15 +145,6 @@ bool CProxyStateMachine::Start(const amuleIPV4Address &peerAddress, CLibSocket *
 {
 	m_proxyClientSocket = proxyClientSocket;
 	m_peerAddress = new amuleIPV4Address(peerAddress);
-	// try {
-	//	const wxIPV4address &peer = dynamic_cast<const wxIPV4address &>(peerAddress);
-	//	m_peerAddress = new amuleIPV4Address(peer);
-	// } catch (const std::bad_cast& WXUNUSED(e)) {
-	//	// Should process other types of wxIPAddress before quitting
-	//	AddDebugLogLineN(logProxy, "(1)bad_cast exception!");
-	//	wxFAIL;
-	//	return false;
-	// }
 
 	// To run the state machine, return and just let the events start to happen.
 	return true;
@@ -579,7 +570,6 @@ void CSocks5StateMachine::process_process_authentication_method(bool entry)
 
 void CSocks5StateMachine::process_send_authentication_gssapi(bool)
 {
-	// TODO or not TODO? That is the question...
 	m_ok = false;
 }
 
@@ -683,7 +673,6 @@ void CSocks5StateMachine::process_process_command_reply(bool entry)
 		// Process the server's reply
 		m_ok = m_ok && m_buffer[0] == SOCKS5_VERSION && m_buffer[1] == SOCKS5_REPLY_SUCCEED;
 		if (m_ok) {
-			// Read BND.ADDR
 			unsigned int portOffset = 0;
 			switch (addressType) {
 			case SOCKS5_ATYP_IPV4_ADDRESS: {
@@ -706,18 +695,13 @@ void CSocks5StateMachine::process_process_command_reply(bool entry)
 			}
 			case SOCKS5_ATYP_IPV6_ADDRESS: {
 				portOffset = 20;
-				// TODO
-				// IPV6 not yet implemented in wx
-				// m_proxyBoundAddress.Hostname(Uint128toStringIP(
-				//	*((uint128 *)(m_buffer+addrOffset)) ));
-				// m_proxyBoundAddress = &m_proxyBoundAddressIPV6;
+				// TODO: IPv6 is not yet implemented in wx.
 				m_ok = false;
 				break;
 			}
 			}
 			// Set the packet length at last
 			m_packetLength = portOffset + 2;
-			// Read BND.PORT
 			m_proxyBoundAddress->Service(ENDIAN_NTOHS(RawPeekUInt16(m_buffer + portOffset)));
 		}
 	}
@@ -900,11 +884,9 @@ void CSocks4StateMachine::process_process_command_reply(bool entry)
 		// Process the server's reply
 		m_ok = m_ok && m_buffer[0] == SOCKS4_REPLY_CODE && m_buffer[1] == SOCKS4_REPLY_GRANTED;
 		if (m_ok) {
-			// Read BND.PORT
 			const unsigned int portOffset = 2;
 			m_ok = m_proxyBoundAddressIPV4.Service(
 				ENDIAN_NTOHS(RawPeekUInt16(m_buffer + portOffset)));
-			// Read BND.ADDR
 			const unsigned int addrOffset = 4;
 			m_ok = m_ok && m_proxyBoundAddressIPV4.Hostname(PeekUInt32(m_buffer + addrOffset));
 			m_proxyBoundAddress = &m_proxyBoundAddressIPV4;
@@ -1287,8 +1269,6 @@ uint32 CDatagramSocketProxy::RecvFrom(amuleIPV4Address &addr, void *buf, uint32 
 				break;
 			}
 			memcpy(buf, bufUDP + offset, nBytes);
-			// Uncomment here to see the buffer contents on console
-			// DumpMem(bufUDP, wxDatagramSocket::LastCount(), "RecvFrom", 3);
 
 			/* Only delete buffer if it was dynamically created */
 			if (bufUDP != m_proxyTCPSocket.GetBuffer()) {
@@ -1318,11 +1298,10 @@ uint32 CDatagramSocketProxy::SendTo(const amuleIPV4Address &addr, const void *bu
 	if (m_proxyTCPSocket.GetUseProxy()) {
 		if (m_udpSocketOk) {
 			// Mirror RecvFrom's dynamic-buffer fallback: the fixed
-			// PROXY_BUFFER_SIZE (5120) m_buffer can't hold the 10-byte
-			// SOCKS5 UDP request header plus a payload larger than
-			// PROXY_BUFFER_SIZE - PROXY_UDP_OVERHEAD_IPV4 (5110 B).
-			// Without this the memcpy below ran past the end of
-			// m_buffer for any oversized outbound datagram (#881).
+			// PROXY_BUFFER_SIZE m_buffer cannot hold the 10-byte SOCKS5 UDP
+			// request header plus a payload larger than
+			// PROXY_BUFFER_SIZE - PROXY_UDP_OVERHEAD_IPV4, so the memcpy below
+			// ran past the end of m_buffer for any oversized datagram (#881).
 			char *bufUDP = NULL;
 			if (nBytes + PROXY_UDP_OVERHEAD_IPV4 > PROXY_BUFFER_SIZE) {
 				bufUDP = new char[nBytes + PROXY_UDP_OVERHEAD_IPV4];
@@ -1338,8 +1317,6 @@ uint32 CDatagramSocketProxy::SendTo(const amuleIPV4Address &addr, const void *bu
 			memcpy(bufUDP + PROXY_UDP_OVERHEAD_IPV4, buf, nBytes);
 			nBytes += PROXY_UDP_OVERHEAD_IPV4;
 			sent = CLibUDPSocket::SendTo(m_proxyTCPSocket.GetProxyBoundAddress(), bufUDP, nBytes);
-			// Uncomment here to see the buffer contents on console
-			// DumpMem(bufUDP, nBytes, "SendTo", 3);
 
 			/* Only delete buffer if it was dynamically created */
 			if (bufUDP != m_proxyTCPSocket.GetBuffer()) {

--- a/src/Proxy.h
+++ b/src/Proxy.h
@@ -146,19 +146,12 @@ public:
 	void Clear();
 
 public:
-	//! Whether proxy is enabled or not.
 	bool m_proxyEnable;
-	//! The type of the proxy server.
 	CProxyType m_proxyType;
-	//! The proxy host name or IP address.
 	wxString m_proxyHostName;
-	//! The proxy port number.
 	unsigned short m_proxyPort;
-	//! Whether authentication should be performed.
 	bool m_enablePassword;
-	//! The user name to authenticate to the server.
 	wxString m_userName;
-	//! The password to authenticate to the server.
 	wxString m_password;
 };
 

--- a/src/PublicIPv6Corroboration.h
+++ b/src/PublicIPv6Corroboration.h
@@ -77,35 +77,32 @@
  * both run on the main thread.
  */
 
-//! How many distinct observed source addresses have to agree on the same
-//! value before it is believed.
+//! How many distinct observed source addresses have to agree on a value before
+//! it is believed.
 //!
 //! Two would be wrong: two source addresses is one dual-homed host, one host
-//! that reconnected from a new lease, or one attacker holding a second
-//! socket -- none of which is a second opinion. Three is the smallest count
-//! that forces a claimant to hold addresses it does not control alone, and it
-//! is still reachable in an ordinary session, where a handful of vendor peers
-//! connect over its lifetime.
+//! that reconnected from a new lease, or one attacker holding a second socket --
+//! none of which is a second opinion. Three is the smallest count that forces a
+//! claimant to hold addresses it does not control alone, and is still reachable
+//! in an ordinary session.
 //!
 //! It is a floor, not a proof: three addresses under one operator still agree
-//! with each other. That is what the locally-assigned filter is for -- three
-//! colluding peers can still only steer us between addresses we hold.
+//! with each other. That is what the locally-assigned filter is for -- colluding
+//! peers can still only steer us between addresses we hold.
 constexpr std::size_t PUBLIC_IPV6_CORROBORATION_THRESHOLD = 3;
 
 //! How long one observer's claim keeps counting.
 //!
-//! Without a window, "three distinct peers agree" means "three peers said so
-//! at some point since the process started", so a laptop that moved to another
-//! network hours ago still carries the votes that elected the address it had
-//! there, and no amount of fresh disagreement can unseat them. Votes that age
-//! out are what makes re-election possible at all.
+//! Without a window, "three distinct peers agree" means "three peers said so at
+//! some point since the process started", so a laptop that moved networks hours
+//! ago still carries the votes that elected the address it had there, and no
+//! amount of fresh disagreement can unseat them.
 //!
-//! Thirty minutes because hellos from distinct peers arrive sporadically --
-//! minutes apart on a quiet client -- so a window of a few minutes would
-//! expire the first vote before the third arrived and the quorum would never
-//! form. It is an upper bound on how long a stale address can survive
-//! unchallenged, and the interface refresh already covers the case where the
-//! address simply went away.
+//! Thirty minutes because hellos from distinct peers arrive sporadically, minutes
+//! apart on a quiet client, so a window of a few minutes would expire the first
+//! vote before the third arrived and the quorum would never form. It bounds how
+//! long a stale address can survive unchallenged; the interface refresh covers
+//! the case where the address simply went away.
 constexpr std::uint64_t PUBLIC_IPV6_CORROBORATION_WINDOW_MS = 30ull * 60ull * 1000ull;
 
 class CPublicIPv6Corroboration
@@ -194,15 +191,13 @@ public:
 		}
 
 		const Address value = ToAddress(claimed);
-		// Both checks, not just the second: the locally-assigned set is
-		// already filtered to global unicast, but the address family test is
-		// the invariant this class promises and it must not depend on how a
-		// caller happened to populate that set.
+		// Both checks, not just the second: the locally-assigned set is already
+		// filtered to global unicast, but the address family test is the invariant
+		// this class promises and must not depend on how a caller populated that set.
 		if (!IsGlobalUnicast(value) || !IsLocallyAssigned(value)) {
-			// Deliberately no state whatsoever for a rejected value. A
-			// rejection that allocated something would let a peer spend our
-			// memory on values it invented, which is exactly what the filter
-			// exists to prevent.
+			// Deliberately no state whatsoever for a rejected value: a rejection that
+			// allocated something would let a peer spend our memory on values it
+			// invented.
 			return IsCorroborated();
 		}
 
@@ -325,12 +320,10 @@ private:
 			Candidate fresh;
 			fresh.value = candidate.value;
 			for (const auto &observer : candidate.observers) {
-				// A tick count that appears to move backwards expires the
-				// vote rather than keeping it. The tick source is uptime and
-				// does not go backwards, so this is a defence against a
-				// caller mixing clocks -- and holding a vote we cannot date
-				// is the one outcome worth avoiding, while re-gathering one
-				// costs nothing but time.
+				// A tick count that appears to move backwards expires the vote rather
+				// than keeping it. The tick source is uptime and does not go backwards,
+				// so this defends against a caller mixing clocks: holding a vote we
+				// cannot date is the outcome worth avoiding.
 				if (nowMs >= observer.lastSeenMs &&
 					nowMs - observer.lastSeenMs <= PUBLIC_IPV6_CORROBORATION_WINDOW_MS) {
 					fresh.observers.push_back(observer);
@@ -394,14 +387,12 @@ private:
 
 	//! The addresses assigned to a local interface, global unicast only.
 	//!
-	//! There is no cap on this or on the candidate list, and there deliberately
-	//! is none. An earlier revision capped the number of tracked values because
-	//! the input was attacker-chosen; with the filter in front, a candidate can
-	//! only ever be one of the addresses in this set, which this machine's own
-	//! interfaces bound -- a handful, even with privacy addresses rotating. A
-	//! cap would now buy nothing and cost something real: occupying a slot
-	//! costs one claim while corroborating a value costs three, so refusing
-	//! entries past a limit would make permanent denial the cheaper attack.
+	//! There is deliberately no cap on this or on the candidate list. An earlier
+	//! revision capped the tracked values because the input was attacker-chosen;
+	//! with the filter in front, a candidate can only be one of the addresses this
+	//! machine's own interfaces bound. A cap would now cost something real:
+	//! occupying a slot costs one claim while corroborating a value costs three, so
+	//! refusing entries past a limit would make permanent denial the cheaper attack.
 	std::vector<Address> m_local;
 
 	std::vector<Candidate> m_candidates;

--- a/src/RangeMap.h
+++ b/src/RangeMap.h
@@ -42,13 +42,9 @@
  */
 template <typename VALUE, typename KEYTYPE> struct CRangeMapHelper
 {
-	//! Typedef specifying the type to use when a non-const pointer is expected.
 	typedef VALUE *ValuePtr;
-	//! Typedef specifying the type to use when a non-const referenecs is expected.
 	typedef VALUE &ValueRef;
-	//! Typedef specifying the type to use when a const referenecs is expected.
 	typedef const VALUE &ConstValueRef;
-	//! Typedef specifying the type to use when a const pointer is expected.
 	typedef const VALUE *ConstValuePtr;
 
 	//! Used internally by CRangeMap to specify the end of a range.
@@ -56,7 +52,6 @@ template <typename VALUE, typename KEYTYPE> struct CRangeMapHelper
 	//! Contains the value of a given range.
 	VALUE second;
 
-	//! Compares the user-values of this range with another.
 	bool operator==(const CRangeMapHelper<VALUE, KEYTYPE> &o) const { return second == o.second; }
 };
 
@@ -108,14 +103,12 @@ template <typename VALUE, typename KEYTYPE = uint64> class CRangeMap
 private:
 	//! The map uses the start-key as key and the User-value and end-key pair as value
 	typedef std::map<KEYTYPE, HELPER> RangeMap;
-	//! Shortcut for the pair used by the RangeMap.
 	typedef std::pair<KEYTYPE, HELPER> RangePair;
 
 	//! Typedefs used to distinguish between our custom iterator and the real ones.
 	typedef typename RangeMap::iterator RangeIterator;
 	typedef typename RangeMap::const_iterator ConstRangeIterator;
 
-	//! The raw map of range values.
 	RangeMap m_ranges;
 
 	/**
@@ -137,10 +130,8 @@ private:
 		{
 		}
 
-		//! Equality operator
 		bool operator==(const iterator_base &other) const { return m_it == other.m_it; }
 
-		//! Non-equality operator
 		bool operator!=(const iterator_base &other) const { return m_it != other.m_it; }
 
 		//! Returns the starting point of the range
@@ -149,7 +140,6 @@ private:
 		//! Returns the end-point of the range
 		KEYTYPE keyEnd() const { return m_it->second.first; }
 
-		//! Prefix increment.
 		iterator_base &operator++()
 		{
 			++m_it;
@@ -157,10 +147,8 @@ private:
 			return *this;
 		}
 
-		//! Postfix increment.
 		iterator_base operator++(int) { return iterator_base(m_it++); }
 
-		//!  Prefix decrement.
 		iterator_base &operator--()
 		{
 			--m_it;
@@ -168,17 +156,13 @@ private:
 			return *this;
 		}
 
-		//! Postfix decrement.
 		iterator_base operator--(int) { return iterator_base(m_it--); }
 
-		//! Deference operator, returning the user-specified value.
 		ReturnTypeRef operator*() const { return m_it->second.second; }
 
-		//! Member access operator, returning the user-specified value.
 		ReturnTypePtr operator->() const { return &m_it->second.second; }
 
 	protected:
-		//! The raw iterator
 		RealIterator m_it;
 	};
 
@@ -191,10 +175,8 @@ public:
 	typedef iterator_base<RangeIterator, ValueRef, ValuePtr> iterator;
 	typedef iterator_base<ConstRangeIterator, ConstValueRef, ConstValuePtr> const_iterator;
 
-	//! The type used to specify size, ie size().
 	typedef typename RangeMap::size_type size_type;
 
-	//! The type of user-data saved with each range.
 	typedef VALUE value_type;
 
 	/**
@@ -232,12 +214,10 @@ public:
 	 */
 	bool operator==(const CRangeMap<VALUE, KEYTYPE> &other) const
 	{
-		// Check if we are comparing with ourselves
 		if (this == &other) {
 			return true;
 		}
 
-		// Check size, must be the same
 		if (size() != other.size()) {
 			return false;
 		}
@@ -316,12 +296,9 @@ public:
 			// Thus: key < it->first, but (--it)->first <= key
 			RangeIterator it = m_ranges.upper_bound(key);
 
-			// Our target range must come before the one we found; does it exist?
 			if (it != m_ranges.begin()) {
-				// Go back to the last range which starts at or before key
 				--it;
 
-				// Check if this range covers the key
 				if (key <= it->second.first) {
 					return it;
 				}
@@ -335,7 +312,6 @@ public:
 	{
 		// Create default initialized entry, which ensures that all fields are initialized.
 		HELPER entry = HELPER();
-		// Need to set the 'end' field.
 		entry.first = endPos;
 
 		// Insert without merging, which forces the creation of an entry that

--- a/src/SHAHashSet.cpp
+++ b/src/SHAHashSet.cpp
@@ -105,7 +105,6 @@ CAICHHashTree *CAICHHashTree::FindHash(uint64 nStartPos, uint64 nSize, uint8 *nL
 	wxCHECK(nSize <= m_nDataSize, NULL);
 
 	if (nStartPos == 0 && nSize == m_nDataSize) {
-		// this is the searched hash
 		return this;
 	} else if (m_nDataSize <= m_nBaseSize) { // sanity
 		// this is already the last level, can't go deeper
@@ -262,7 +261,6 @@ void CAICHHashTree::SetBlockHash(uint64 nSize, uint64 nStartPos, CAICHHashAlgo *
 		return;
 	}
 
-	// sanity
 	if (pToInsert->m_nBaseSize != EMBLOCKSIZE || pToInsert->m_nDataSize != nSize) {
 		wxFAIL;
 		AddDebugLogLineN(
@@ -414,7 +412,6 @@ bool CAICHHashTree::SetHash(CFileDataIO *fileInput, uint32 wHashIdent, sint8 nLe
 		}
 	}
 	if (nLevel == 0) {
-		// this is the searched hash
 		if (m_bHashValid && !bAllowOverwrite) {
 			// not allowed to overwrite this hash, however move the filepointer as if we read a
 			// hash
@@ -596,23 +593,14 @@ bool CAICHHashSet::ReadRecoveryData(uint64 nPartStartPos, CMemFile *fileDataIn)
 		if (fileDataIn->GetLength() - fileDataIn->GetPosition() < nHashsToRead * (HASHSIZE + 4u) ||
 			(nHashsToRead != nHashsAvailable && nHashsAvailable != 0)) {
 			// this check is redundant, CSafememfile would catch such an error too
-			// TODO:			theApp->QueueDebugLogLine(/*DLP_VERYHIGH,*/ false,
-			// _T("Failed to read RecoveryData for %s - Received datasize/amounts of hashs was
-			// invalid (2)"), m_pOwner->GetFileName() );
 			return false;
 		}
 
-		// TODO: DEBUG_ONLY( theApp->QueueDebugLogLine(/*DLP_VERYHIGH,*/ false, _T("read RecoveryData
-		// for %s - Received packet with  %u 32bit hash identifiers)"), m_pOwner->GetFileName(),
-		// nHashsAvailable ) );
 		for (uint32 i = 0; i != nHashsToRead; i++) {
 			uint32 wHashIdent = fileDataIn->ReadUInt32();
 			if (wHashIdent == 1 /*never allow masterhash to be overwritten*/
 				|| wHashIdent > 0x400000 ||
 				!m_pHashTree.SetHash(fileDataIn, wHashIdent, (-1), false)) {
-				// TODO:		theApp->QueueDebugLogLine(/*DLP_VERYHIGH,*/ false,
-				// _T("Failed to read RecoveryData for %s - Error when trying to read hash
-				// into tree (2)"), m_pOwner->GetFileName() );
 				VerifyHashTree(true); // remove invalid hashes which we have already written
 				return false;
 			}
@@ -620,8 +608,6 @@ bool CAICHHashSet::ReadRecoveryData(uint64 nPartStartPos, CMemFile *fileDataIn)
 	}
 
 	if (nHashsAvailable == 0) {
-		// TODO:		theApp->QueueDebugLogLine(/*DLP_VERYHIGH,*/ false, _T("Failed to read
-		// RecoveryData for %s - Packet didn't contained any hashs"), m_pOwner->GetFileName() );
 		return false;
 	}
 
@@ -638,7 +624,6 @@ bool CAICHHashSet::ReadRecoveryData(uint64 nPartStartPos, CMemFile *fileDataIn)
 				return false;
 			}
 		}
-		// all done
 		return true;
 	} else {
 		AddDebugLogLineN(logSHAHashSet,
@@ -658,9 +643,9 @@ void CAICHHashSet::InvalidateRootHashCache()
 
 void CAICHHashSet::LoadRootHashCacheLocked()
 {
-	// Walk known2.met once, collecting every root hash. Replaces the
-	// per-call in-file linear scan that turned bulk-hashing N files into
-	// O(N^2) on-disk work (issue #579).
+	// Walk known2.met once, collecting every root hash. Replaces the per-call
+	// in-file linear scan that turned bulk-hashing N files into O(N^2) on-disk work
+	// (issue #579).
 	s_rootHashCache.clear();
 	s_rootHashCacheLoaded = true; // marked early so a partial read still ends the loop
 
@@ -689,9 +674,8 @@ void CAICHHashSet::LoadRootHashCacheLocked()
 			return;
 		}
 		while (file.GetPosition() < nFileSize) {
-			// Remember the byte offset of the root-hash position so
-			// LoadHashSet can seek straight here later instead of
-			// rewalking the file.
+			// Remember the byte offset of the root-hash position, so LoadHashSet
+			// can seek straight here instead of rewalking the file.
 			const uint64 entryOffset = file.GetPosition();
 			CAICHHash rootHash;
 			rootHash.Read(&file);
@@ -737,9 +721,8 @@ bool CAICHHashSet::SaveHashSet()
 		return true;
 	}
 
-	// Byte offset at which the new entry's root hash will be appended.
-	// Captured inside the try block and used after it to update the
-	// cache once the write has succeeded.
+	// Byte offset at which the new entry's root hash will be appended; used after
+	// the try block to update the cache once the write has succeeded.
 	uint64 newEntryOffset = 0;
 
 	try {
@@ -769,12 +752,10 @@ bool CAICHHashSet::SaveHashSet()
 			nExistingSize += 1;
 		}
 
-		// This is the byte offset at which the new entry's root hash
-		// will land — capture it for the cache so LoadHashSet can
-		// seek straight here later.
+		// Where the new entry's root hash will land -- captured for the cache so
+		// LoadHashSet can seek straight to it later.
 		newEntryOffset = nExistingSize;
 
-		// write hashset
 		m_pHashTree.m_Hash.Write(&file);
 		uint32 nHashCount = (PARTSIZE / EMBLOCKSIZE + ((PARTSIZE % EMBLOCKSIZE != 0) ? 1 : 0)) *
 				    (m_pHashTree.m_nDataSize / PARTSIZE);
@@ -805,9 +786,8 @@ bool CAICHHashSet::SaveHashSet()
 		return false;
 	}
 
-	// Append succeeded — record offset in the cache so the next
-	// SaveHashSet for this root hash dedups in O(1), and LoadHashSet
-	// can seek straight to it.
+	// Append succeeded, so record the offset: the next SaveHashSet for this root
+	// hash dedups in O(1), and LoadHashSet can seek straight to it.
 	s_rootHashCache.emplace(m_pHashTree.m_Hash, newEntryOffset);
 	return true;
 }
@@ -824,12 +804,10 @@ bool CAICHHashSet::LoadHashSet()
 		return false;
 	}
 
-	// O(1) cache lookup: ask the offset index where this root hash
-	// lives in known2.met. The cache was the dedup-on-write index
-	// before; here we reuse it to skip the linear scan that used to
-	// happen on every incoming OP_AICHREQUEST (issue #166). If the
-	// cache miss-and-cold-load path is taken we still pay the one-shot
-	// walk, but only once across all subsequent calls.
+	// O(1) cache lookup: the offset index says where this root hash lives in
+	// known2.met. It was the dedup-on-write index; reusing it here skips the linear
+	// scan that used to happen on every incoming OP_AICHREQUEST (issue #166). A
+	// cold load still pays the one-shot walk, but only once.
 	uint64 cachedOffset = 0;
 	bool haveCachedOffset = false;
 	{
@@ -867,12 +845,10 @@ bool CAICHHashSet::LoadHashSet()
 
 		uint64 nExistingSize = file.GetLength();
 
-		// Fast path: seek straight to the cached entry. If the offset
-		// turns out to be stale -- past EOF, or first read at that
-		// position doesn't match our root hash -- rewind once to just
-		// past the version header and fall through to a true linear
-		// scan from the top as defensive recovery against external
-		// modification of known2.met between cache load and now.
+		// Fast path: seek straight to the cached entry. A stale offset -- past EOF,
+		// or a first read there that does not match our root hash -- rewinds once to
+		// just past the version header and falls through to a true linear scan, as
+		// recovery against external modification of known2.met.
 		if (haveCachedOffset) {
 			if (cachedOffset >= nExistingSize) {
 				haveCachedOffset = false;
@@ -885,13 +861,11 @@ bool CAICHHashSet::LoadHashSet()
 		uint32 nHashCount;
 		bool cacheFallbackTriggered = false;
 		while (file.GetPosition() < nExistingSize) {
-			// Position of the root-hash at the start of the entry we're
-			// about to examine — captured pre-read so we can stamp it
-			// back into the cache when a stale-cache rewind succeeds.
+			// Position of the root hash at the start of the entry we are about to
+			// examine, captured pre-read so a stale-cache rewind can stamp it back.
 			const uint64 entryStartPos = file.GetPosition();
 			CurrentHash.Read(&file);
 			if (m_pHashTree.m_Hash == CurrentHash) {
-				// found Hashset
 				uint32 nExpectedCount =
 					(PARTSIZE / EMBLOCKSIZE + ((PARTSIZE % EMBLOCKSIZE != 0) ? 1 : 0)) *
 					(m_pHashTree.m_nDataSize / PARTSIZE);
@@ -925,21 +899,17 @@ bool CAICHHashSet::LoadHashSet()
 						"given Masterhash - hashset corrupt!");
 					return false;
 				}
-				// Self-heal: if we got here via the stale-cache rewind,
-				// update the cache so future lookups for this root hash
-				// go straight to the new correct offset instead of
-				// paying the linear-scan penalty every time.
+				// Self-heal: reached via the stale-cache rewind, so update the cache
+				// and future lookups go straight to the correct offset.
 				if (cacheFallbackTriggered) {
 					wxMutexLocker lock(s_rootHashCacheMutex);
 					s_rootHashCache[m_pHashTree.m_Hash] = entryStartPos;
 				}
 				return true;
 			}
-			// First read after seeking to the cached offset didn't match
-			// our root hash. The cache must be stale -- known2.met was
-			// modified externally between cache load and now. Rewind once
-			// to just past the version header and restart as a true linear
-			// scan from the top.
+			// The first read after seeking to the cached offset did not match our
+			// root hash, so the cache is stale -- known2.met was modified externally.
+			// Rewind once to just past the version header and restart as a linear scan.
 			if (haveCachedOffset && !cacheFallbackTriggered) {
 				cacheFallbackTriggered = true;
 				haveCachedOffset = false;
@@ -1051,11 +1021,9 @@ void CAICHHashSet::UntrustedHashReceived(const CAICHHash &Hash, uint32 dwFromIP)
 		wxFAIL;
 		return;
 	}
-	// the check if we trust any hash
 	if (thePrefs::IsTrustingEveryHash() ||
 		(nMostTrustedIPs >= MINUNIQUEIPS_TOTRUST &&
 			(100 * nMostTrustedIPs) / nSigningIPsTotal >= MINPERCENTAGE_TOTRUST)) {
-		// trusted
 		AddDebugLogLineN(logSHAHashSet,
 			CFormat("AICH Hash received (%sadded), We have now %u hash(es) from %u unique IP(s). "
 				"We trust the Hash %s from %u client(s) (%u%%). File: %s") %
@@ -1069,7 +1037,6 @@ void CAICHHashSet::UntrustedHashReceived(const CAICHHash &Hash, uint32 dwFromIP)
 			FreeHashSet();
 		}
 	} else {
-		// untrusted
 		AddDebugLogLineN(logSHAHashSet,
 			CFormat("AICH Hash received (%sadded), We have now %u hash(es) from %u unique IP(s). "
 				"Best Hash %s from %u clients (%u%%) - but we don't trust it yet. File: %s") %
@@ -1130,21 +1097,16 @@ bool CAICHHashSet::IsClientRequestPending(const CPartFile *pForFile, uint16 nPar
 
 void CAICHHashSet::DropReferencesTo(const CKnownFile *file)
 {
-	// Pointer-value strip of any in-flight AICH recovery request that
-	// names `file`. Called from MuleNotify::KnownFileBeingDestroyed
-	// (GuiEvents.cpp) before the CKnownFile / CPartFile is freed by
-	// CPartFile::Delete() or CKnownFileList::PruneDuplicates. Without
-	// this, the pending request would deref the dangling partfile
-	// when the recovery data eventually arrives (RequestAICHRecovery's
-	// existing IsPartFile() guard at line ~990 catches some cases
-	// but a freed-then-reused pointer can spoof that check and
-	// route recovery to the wrong file).
+	// Pointer-value strip of any in-flight AICH recovery request naming `file`.
+	// Called from MuleNotify::KnownFileBeingDestroyed before the CKnownFile /
+	// CPartFile is freed, since the pending request would otherwise deref the
+	// dangling partfile when the recovery data arrives (RequestAICHRecovery's
+	// IsPartFile() guard catches some cases, but a freed-then-reused pointer can
+	// spoof it and route recovery to the wrong file).
 	//
-	// CPartFile inherits from CKnownFile (single inheritance, same
-	// address), so the cast in the comparison is no-deref. Same-
-	// thread call (main thread) so no synchronisation needed on
-	// the static list beyond the normal amule single-threaded GUI
-	// contract.
+	// CPartFile inherits from CKnownFile at the same address, so the cast in the
+	// comparison never derefs. Main-thread only, so the static list needs no
+	// synchronisation.
 	for (CAICHRequestedDataList::iterator it = m_liRequestedData.begin(); it != m_liRequestedData.end();
 		/* manual ++ */) {
 		if (static_cast<const CKnownFile *>(it->m_pPartFile) == file) {
@@ -1193,11 +1155,9 @@ bool CAICHHashSet::IsPartDataAvailable(uint64 nPartStartPos)
 void CAICHHashSet::DbgTest()
 {
 #ifdef _DEBUG
-	// define TESTSIZE 4294567295
 	uint8 maxLevel = 0;
 	uint32 cHash = 1;
 	uint8 curLevel = 0;
-	// uint32 cParts = 0;
 	maxLevel = 0;
 /*	CAICHHashTree* pTest = new CAICHHashTree(TESTSIZE, true, 9728000);
 	for (uint64 i = 0; i+9728000 < TESTSIZE; i += 9728000) {
@@ -1232,15 +1192,11 @@ void CAICHHashSet::DbgTest()
 		uint32 j;
 		for (j = 0; j + EMBLOCKSIZE < 9728000; j += EMBLOCKSIZE) {
 			VERIFY(m_pHashTree.FindHash(i + j, EMBLOCKSIZE, &curLevel));
-			// TRACE("%u - %s\r\n", cHash, m_pHashTree.FindHash(i+j, EMBLOCKSIZE,
-			// &curLevel)->m_Hash.GetString());
 			maxLevel = max(curLevel, maxLevel);
 			curLevel = 0;
 			cHash++;
 		}
 		VERIFY(m_pHashTree.FindHash(i + j, 9728000 - j, &curLevel));
-		// TRACE("%u - %s\r\n", cHash, m_pHashTree.FindHash(i+j, 9728000-j,
-		// &curLevel)->m_Hash.GetString());
 		maxLevel = max(curLevel, maxLevel);
 		curLevel = 0;
 		cHash++;
@@ -1252,15 +1208,10 @@ void CAICHHashSet::DbgTest()
 	TestHashSet.FreeHashSet();
 	for (uint64 j = 0; j + EMBLOCKSIZE < TESTSIZE - i; j += EMBLOCKSIZE) {
 		VERIFY(m_pHashTree.FindHash(i + j, EMBLOCKSIZE, &curLevel));
-		// TRACE("%u - %s\r\n", cHash,m_pHashTree.FindHash(i+j, EMBLOCKSIZE,
-		// &curLevel)->m_Hash.GetString());
 		maxLevel = max(curLevel, maxLevel);
 		curLevel = 0;
 		cHash++;
 	}
-	// VERIFY( m_pHashTree.FindHash(i+j, (TESTSIZE-i)-j, &curLevel) );
-	// TRACE("%u - %s\r\n", cHash,m_pHashTree.FindHash(i+j, (TESTSIZE-i)-j,
-	// &curLevel)->m_Hash.GetString());
 	maxLevel = max(curLevel, maxLevel);
 #endif
 }

--- a/src/SHAHashSet.h
+++ b/src/SHAHashSet.h
@@ -290,12 +290,10 @@ public:
 	static void RemoveClientAICHRequest(const CUpDownClient *pClient);
 	static bool IsClientRequestPending(const CPartFile *pForFile, uint16 nPart);
 
-	// Pointer-value strip of any pending AICH-recovery request entry
-	// whose m_pPartFile == `file`. Called from MuleNotify::
-	// KnownFileBeingDestroyed before a CKnownFile / CPartFile is
-	// freed so the existing IsPartFile() guard in
-	// ClientAICHRequestFailed can't be spoofed by allocator reuse of
-	// the same address.
+	// Pointer-value strip of any pending AICH-recovery request entry whose
+	// m_pPartFile == `file`. Called from MuleNotify::KnownFileBeingDestroyed before
+	// the file is freed, so the IsPartFile() guard in ClientAICHRequestFailed
+	// cannot be spoofed by allocator reuse of the same address.
 	static void DropReferencesTo(const CKnownFile *file);
 	static CAICHRequestedData GetAICHReqDetails(const CUpDownClient *pClient);
 	void DbgTest();
@@ -308,20 +306,15 @@ public:
 	static void InvalidateRootHashCache();
 
 private:
-	// Cache mapping every root hash currently stored in known2.met to
-	// the byte offset of its entry's root-hash position in the file.
-	// Populated lazily on first SaveHashSet or LoadHashSet call (or
-	// refilled after invalidation).
+	// Cache mapping every root hash currently stored in known2.met to the byte
+	// offset of its entry's root-hash position, populated lazily on the first
+	// SaveHashSet or LoadHashSet call.
 	//
-	// - For SaveHashSet: replaces the per-call linear file walk that
-	//   made the dedup check O(N) per call / O(N^2) over a bulk-hash
-	//   batch.
-	// - For LoadHashSet (and the AICH request path that calls it):
-	//   replaces the per-call linear file walk that turned each
-	//   incoming OP_AICHREQUEST into an O(N) disk-backed scan. The
-	//   cached offset lets LoadHashSet seek straight to the matching
-	//   entry, making the AICH request path O(1) and closing the DoS
-	//   amplification noted in #166.
+	// For SaveHashSet it replaces the per-call linear file walk that made the dedup
+	// check O(N) per call and O(N^2) over a bulk-hash batch. For LoadHashSet, and
+	// the AICH request path that calls it, the cached offset lets it seek straight
+	// to the matching entry, making that path O(1) and closing the DoS
+	// amplification noted in #166.
 	static wxMutex s_rootHashCacheMutex;
 	static std::unordered_map<CAICHHash, uint64> s_rootHashCache;
 	static bool s_rootHashCacheLoaded;

--- a/src/SafeFile.cpp
+++ b/src/SafeFile.cpp
@@ -397,26 +397,13 @@ CTag *CFileDataIO::ReadTag(bool bOptACP) const
 		name = ReadString(false);
 
 		switch (type) {
-		// NOTE: This tag data type is accepted and stored only to give us the possibility to upgrade
-		// the net in some months.
-		//
-		// And still.. it doesn't work this way without breaking backward compatibility. To properly
-		// do this without messing up the network the following would have to be done:
-		//	 -	those tag types have to be ignored by any client, otherwise those tags would
-		// also be sent (and 		that's really the problem)
-		//
-		//	 -	ignoring means, each client has to read and right throw away those tags, so
-		// those tags get 		get never stored in any tag list which might be sent by that
-		// client to some other client.
-		//
-		//	 -	all calling functions have to be changed to deal with the 'nr. of tags'
-		// attribute (which was 		already parsed) correctly.. just ignoring those tags
-		// here is not enough, any taglists have to 		be built with the knowledge that the
-		// 'nr. of tags' attribute may get decreased during the tag 		reading..
-		//
-		// If those new tags would just be stored and sent to remote clients, any malicious or just
-		// bugged client could let send a lot of nodes "corrupted" packets...
-		//
+		// This tag data type is accepted and stored only to leave room for a
+		// future upgrade of the net, and even that does not work without breaking
+		// backward compatibility: doing it properly would mean every client
+		// reading and discarding these tags rather than storing them, so they are
+		// never re-sent, and every caller handling a 'nr. of tags' attribute that
+		// shrinks during the read. Storing and forwarding them instead would let a
+		// malicious or buggy client have nodes send corrupted packets.
 		case TAGTYPE_HASH16: {
 			retVal = new CTagHash(name, ReadHash());
 			break;
@@ -446,10 +433,8 @@ CTag *CFileDataIO::ReadTag(bool bOptACP) const
 			retVal = new CTagFloat(name, ReadFloat());
 			break;
 
-		// NOTE: This tag data type is accepted and stored only to give us the possibility to upgrade
-		// the net in some months.
-		//
-		// And still.. it doesn't work this way without breaking backward compatibility
+		// Same as TAGTYPE_HASH16 above: accepted and stored only to leave room for
+		// a future upgrade, which cannot happen without breaking compatibility.
 		case TAGTYPE_BSOB: {
 			uint8 size = 0;
 			CScopedArray<unsigned char> value(ReadBsob(&size));
@@ -466,19 +451,16 @@ CTag *CFileDataIO::ReadTag(bool bOptACP) const
 				       EscapeForLog(name));
 		}
 	} catch (const CMuleException &e) {
-		// Debug, not standard: this says only what went wrong, never which
-		// file or packet it went wrong in, and it is rethrown for a caller
-		// that does know. A truncated tag off the network therefore put a
-		// bare "SafeIO::EOF: Attempt to read past end of file." in the
-		// daemon log with nothing around it, while the line naming the peer
-		// and opcode sat at debug level and was compiled out (issue #961).
+		// Debug, not standard: this says only what went wrong, never which file or
+		// packet, and it is rethrown for a caller that does know. A truncated tag
+		// off the network therefore put a bare "SafeIO::EOF" in the daemon log with
+		// nothing around it, while the line naming the peer and opcode sat at debug
+		// level and was compiled out (issue #961).
 		//
-		// Every caller reports the failure itself: CIndexed::ReadFile and
-		// ~CIndexed through AddDebugLogLineC, which survives a release
-		// build, and fileview on cerr. The Kad UDP handlers report through
-		// CClientUDPSocket's AddDebugLogLineN, so a malformed packet is now
-		// silent in release -- which is the right answer for a packet that
-		// was dropped and cost nothing.
+		// Every caller reports the failure itself: CIndexed through
+		// AddDebugLogLineC, fileview on cerr, and the Kad UDP handlers through
+		// CClientUDPSocket -- so a malformed packet is silent in release, which is
+		// right for one that was dropped and cost nothing.
 		AddDebugLogLineN(logGeneral, e.what());
 		delete retVal;
 		throw;

--- a/src/SearchDlg.cpp
+++ b/src/SearchDlg.cpp
@@ -165,25 +165,17 @@ CSearchDlg::CSearchDlg(wxWindow *pParent)
 	// Clear-history button, sitting in the action row directly after "Reset
 	// Fields" -- next to the other one-shot commands rather than among the
 	// search parameters, and beside "Clear Search Results" so the two
-	// destructive actions read as a pair.
+	// destructive actions read as a pair. Anchored ahead of Clear Search
+	// Results, so the three read most to least destructive rightwards.
 	//
 	// Still built here rather than in muuli_wdr because it is not a static
-	// control: it is shown or hidden with the remember-history preference
-	// (ApplySearchHistoryPref) and enabled only while the combo holds terms
-	// (UpdateClearHistoryButton), and it backs up a right-click route that is
-	// unreachable on wxMSW (the native combobox's child EDIT window never
-	// forwards WM_CONTEXTMENU to wx -- ShouldForwardFromEditToCombo in
-	// src/msw/combobox.cpp forwards only key, focus and clipboard messages).
-	// Bound directly on the instance, so no new window id is needed.
-	// (issue #697)
+	// control: it is shown or hidden with the remember-history preference and
+	// enabled only while the combo holds terms, and it backs up a right-click
+	// route that is unreachable on wxMSW -- the native combobox's child EDIT
+	// window never forwards WM_CONTEXTMENU to wx.
 	//
 	// The separator is inserted with it and tracked so the pref-driven hide
-	// takes both away; leaving a stray divider behind would open a gap in the
-	// row wherever history is switched off.
-	// Anchored ahead of Clear Search Results, so the three read most to least
-	// destructive rightwards (issue #911). Inserting after Reset Fields, as
-	// this did, put the one that discards saved terms between the two used
-	// most.
+	// takes both away; a stray divider would open a gap in the row.
 	if (wxWindow *clearResultsBtn = FindWindow(IDC_CLEAR_RESULTS)) {
 		if (wxSizer *row = clearResultsBtn->GetContainingSizer()) {
 			size_t at = row->GetItemCount();
@@ -259,11 +251,10 @@ wxTextEntry *CSearchDlg::RebuildSearchNameField(bool wantHistory)
 	const bool haveCombo = (dynamic_cast<wxComboBox *>(current) != nullptr);
 	if (haveCombo == wantHistory) {
 		// Right control already in place, so nothing to rebuild -- but it may
-		// still need the context menu. At construction the combo here is the
-		// one muuli_wdr built, which this class never created and therefore
-		// never bound; leaving the binding to the creation path below meant
-		// the "Clear search history" item was missing until the preference
-		// was toggled off and on, since only then was a combo created here.
+		// still need the context menu. At construction the combo here is the one
+		// muuli_wdr built, which this class never created and therefore never
+		// bound; leaving the binding to the creation path below meant the "Clear
+		// search history" item was missing until the preference was toggled.
 		if (wantHistory && !m_searchNameCtxBound) {
 			dynamic_cast<wxComboBox *>(current)->Bind(
 				wxEVT_CONTEXT_MENU, &CSearchDlg::OnSearchNameContextMenu, this);
@@ -291,16 +282,16 @@ wxTextEntry *CSearchDlg::RebuildSearchNameField(bool wantHistory)
 			0,
 			nullptr,
 			wxTE_PROCESS_ENTER);
-		// The context menu is bound per instance, so a freshly created combo
-		// needs it re-attached -- unlike the id-keyed event-table entries
-		// (EVT_TEXT_ENTER / wxEVT_TEXT), which survive the swap by themselves.
+		// The context menu is bound per instance, so a freshly created combo needs
+		// it re-attached -- unlike the id-keyed event-table entries, which survive
+		// the swap by themselves.
 		combo->Bind(wxEVT_CONTEXT_MENU, &CSearchDlg::OnSearchNameContextMenu, this);
 		m_searchNameCtxBound = true;
 		replacement = combo;
 	} else {
 		// wxTE_PROCESS_ENTER kept so Enter still starts the search through the
-		// existing EVT_TEXT_ENTER(IDC_SEARCHNAME) entry. A plain text control
-		// carries no history menu, so the binding is gone with the old combo.
+		// existing EVT_TEXT_ENTER entry. A plain text control carries no history
+		// menu, so the binding is gone with the old combo.
 		m_searchNameCtxBound = false;
 		replacement = new wxTextCtrl(this,
 			IDC_SEARCHNAME,
@@ -348,12 +339,10 @@ CSearchDlg::~CSearchDlg() {}
 namespace
 {
 // Search *query* history -- the strings typed into the Name field, not the
-// results they returned (that's the separate, not-yet-implemented result
-// persistence eMule does via StoredSearches.met; see #641). Deliberately
-// not stored in amule.conf: query terms are arguably private, and putting
-// them in the main config both bloats it and makes them travel with the
-// file (config backups, the --amule-config-file push to amuleweb/amuleapi).
-// A dedicated file mirrors eMule's own AC_SearchStrings.dat.
+// results they returned. Deliberately not stored in amule.conf: query terms are
+// arguably private, and putting them in the main config both bloats it and
+// makes them travel with the file (config backups, the --amule-config-file push
+// to amuleweb/amuleapi). A dedicated file mirrors eMule's AC_SearchStrings.dat.
 wxString SearchHistoryFilePath()
 {
 	return thePrefs::GetConfigDir() + "searchhistory.dat";
@@ -362,10 +351,9 @@ wxString SearchHistoryFilePath()
 
 void CSearchDlg::LoadSearchHistory()
 {
-	// With the preference off the Name field is a plain wxTextCtrl, so there is
-	// no dropdown to fill and the cast below would be null. Guarding here (as
-	// well as at the ApplySearchHistoryPref call site) keeps every future
-	// caller safe rather than relying on each one to check first.
+	// With the preference off the Name field is a plain wxTextCtrl, so there is no
+	// dropdown to fill and the cast below would be null. Guarding here as well as
+	// at the call site keeps every future caller safe.
 	wxComboBox *combo = CastChild(IDC_SEARCHNAME, wxComboBox);
 	if (combo == nullptr || !CPreferences::RememberSearchHistory()) {
 		UpdateClearHistoryButton();
@@ -377,13 +365,10 @@ void CSearchDlg::LoadSearchHistory()
 	CTextFile file;
 	wxArrayString entries;
 	if (file.Open(SearchHistoryFilePath(), CTextFile::read)) {
-		// txtIgnoreEmptyLines|txtStripWhitespace has no single named
-		// EReadTextFile enumerator to cast to (clang-tidy
-		// clang-analyzer-optin.core.EnumCastOutOfRange, rightly --
-		// EReadTextFile isn't declared as a flag enum), and
-		// txtReadDefault also drops '#'-led lines, which would silently
-		// eat a legitimate search term. Read unfiltered and do the
-		// trim/empty-drop by hand instead.
+		// txtIgnoreEmptyLines|txtStripWhitespace has no single named EReadTextFile
+		// enumerator to cast to, and txtReadDefault also drops '#'-led lines, which
+		// would silently eat a legitimate search term. Read unfiltered and do the
+		// trim and empty-drop by hand instead.
 		for (const wxString &line : file.ReadLines(txtReadAll)) {
 			wxString trimmed = line;
 			trimmed.Trim(true).Trim(false);
@@ -478,15 +463,13 @@ void CSearchDlg::OnSearchNameContextMenu(wxContextMenuEvent &WXUNUSED(evt))
 {
 	wxComboBox *combo = CastChild(IDC_SEARCHNAME, wxComboBox);
 
-	// Overriding the field's context menu (to append the history action
-	// below) must not silently drop the standard edit actions -- a plain
-	// wxComboBox's only other context menu is this one, so without these
-	// items right-clicking the field would offer no way to paste/copy
-	// (amule-org/amule#643 review). Same custom-Paste-ID idiom as
-	// CMuleTextCtrl::OnRightDown: wxMenu auto-enables Cut/Copy off Wx's own
-	// selection tracking for the wxID_CUT/wxID_COPY stock IDs, but is too
-	// permissive about wxID_PASTE (enabled even with an empty clipboard),
-	// so Paste gets a custom ID and an explicit clipboard-content check.
+	// Overriding the field's context menu (to append the history action below)
+	// must not silently drop the standard edit actions -- a plain wxComboBox's
+	// only other context menu is this one, so without these items right-clicking
+	// the field would offer no way to paste or copy. Same custom-Paste-ID idiom
+	// as CMuleTextCtrl::OnRightDown: wxMenu auto-enables Cut/Copy off wx's own
+	// selection tracking, but is too permissive about wxID_PASTE -- enabled even
+	// with an empty clipboard -- so Paste gets a custom ID and its own check.
 	enum
 	{
 		ID_SEARCHNAME_PASTE = wxID_HIGHEST + 668
@@ -521,10 +504,10 @@ void CSearchDlg::OnSearchNameContextMenu(wxContextMenuEvent &WXUNUSED(evt))
 	menu.Bind(wxEVT_MENU, [combo](wxCommandEvent &) { combo->Copy(); }, wxID_COPY);
 	menu.Bind(wxEVT_MENU, [combo](wxCommandEvent &) { combo->Paste(); }, ID_SEARCHNAME_PASTE);
 	menu.Bind(wxEVT_MENU, [combo](wxCommandEvent &) { combo->SetSelection(-1, -1); }, wxID_SELECTALL);
-	// Deferred off the popup's own modal loop: this handler runs while
-	// PopupMenu() is still unwinding, and putting a modal dialog up before the
-	// menu has finished tearing down misbehaves on wxOSX. The button route
-	// needs no such care -- no popup is involved there.
+	// Deferred off the popup's own modal loop: this handler runs while PopupMenu()
+	// is still unwinding, and putting a modal dialog up before the menu has
+	// finished tearing down misbehaves on wxOSX. The button route needs no such
+	// care -- no popup is involved there.
 	menu.Bind(
 		wxEVT_MENU,
 		[this](wxCommandEvent &) { CallAfter(&CSearchDlg::ConfirmAndClearSearchHistory); },
@@ -729,12 +712,11 @@ bool CSearchDlg::HasRunningEd2kSearch() const
 		// running percent. Same vocabulary in both builds, different source.
 		uint32 status;
 #ifdef CLIENT_GUI
-		// Remote GUI: the daemon pushes the sentinel through
-		// UpdateSearchProgress, which caches it per tab. A tab with no entry
-		// is one nothing has reported on this session -- a search restored
-		// from disk at startup -- so it is finished, not running. Treating
-		// the absence as "running" would prompt on every first search of a
-		// session that had stored results.
+		// Remote GUI: the daemon pushes the sentinel through UpdateSearchProgress,
+		// which caches it per tab. A tab with no entry is one nothing has reported
+		// on this session -- a search restored from disk at startup -- so it is
+		// finished, not running. Treating the absence as "running" would prompt on
+		// every first search of a session that had stored results.
 		const std::map<wxUIntPtr, uint32>::const_iterator it = m_searchProgress.find(sid);
 		if (it == m_searchProgress.end()) {
 			continue;
@@ -853,19 +835,16 @@ void CSearchDlg::OnSearchClosing(wxBookCtrlEvent &evt)
 {
 	CSearchListCtrl *ctrl = dynamic_cast<CSearchListCtrl *>(m_notebook->GetPage(evt.GetSelection()));
 	wxASSERT(ctrl);
-	// Capture the ID *before* ShowResults(0), which sets m_nResultsID = 0 --
-	// so every GetSearchId() after that line returns 0, and the stop/free
-	// calls below silently addressed search 0 rather than this tab's search:
-	// no EC_OP_SEARCH_STOP was ever sent, RemoveResults(0) freed nothing, and
-	// m_searchProgress.erase(0) left the real entry behind. Predates the
-	// multi-search work -- identical on master, ordering and all -- but it is
-	// what made the daemon-side close gate look correct while the request it
-	// gates never actually arrived (got3nks, PR #680 review).
+	// Capture the ID *before* ShowResults(0), which sets m_nResultsID = 0 -- so
+	// every GetSearchId() after that line returns 0, and the stop/free calls
+	// below silently addressed search 0 rather than this tab's search: no
+	// EC_OP_SEARCH_STOP was ever sent, RemoveResults(0) freed nothing, and the
+	// progress erase left the real entry behind. That is what made the
+	// daemon-side close gate look correct while the request never arrived.
 	const wxUIntPtr searchID = ctrl->GetSearchId();
 	// RemoveResults below fires MuleNotify::Search_Removed, which routes back
-	// into CloseSearchTab for this very tab; the flag makes that a no-op
-	// instead of a recursive close (see m_inSearchClosing). Scoped so it
-	// clears on every exit path.
+	// into CloseSearchTab for this very tab; the flag makes that a no-op instead
+	// of a recursive close. Scoped so it clears on every exit path.
 	CScopedFlag closingGuard(m_inSearchClosing);
 	// Zero to avoid results added while destructing.
 	ctrl->ShowResults(0);
@@ -875,14 +854,11 @@ void CSearchDlg::OnSearchClosing(wxBookCtrlEvent &evt)
 	// life of the session.
 	m_moreExhausted.erase((uint32_t)searchID);
 #ifdef CLIENT_GUI
-	// Remote multi-search: closing a tab stops *and* frees that specific
-	// search on the daemon (leaving other tabs' searches running). On a
-	// legacy daemon this degrades to a parameterless stop of the single
-	// search — which is the same "abort on close" behaviour as before.
-	// Skipped when CloseSearchTab is the one driving this (DeletePage
-	// fires this handler synchronously): the daemon already discarded
-	// this id, so a stop request for it would be a wasted round trip
-	// (got3nks, PR #680 review).
+	// Remote multi-search: closing a tab stops *and* frees that specific search
+	// on the daemon, leaving other tabs' searches running. On a legacy daemon
+	// this degrades to a parameterless stop of the single search. Skipped when
+	// CloseSearchTab is the one driving this -- DeletePage fires this handler
+	// synchronously -- since the daemon already discarded this id.
 	if (searchID != m_expiringSearchID) {
 		theApp->searchlist->StopSearchById(searchID, true);
 	}
@@ -906,11 +882,10 @@ void CSearchDlg::OnSearchClosing(wxBookCtrlEvent &evt)
 void CSearchDlg::OnStartRejected(wxUIntPtr searchID, const wxString &error)
 {
 	// A rejected browse ("View Files") reaches this same path in amuleGUI --
-	// SendBrowseRequest sends the same EC_TAG_SEARCH_REF and the daemon echoes
-	// it on its failure exits too. It needs the tab dropped and the reason
-	// shown, but NOT the search-button reset below: the user never pressed
-	// Search, so clearing Download/Stop would disable them for whatever search
-	// tab happens to be visible. Read the tab's kind before closing it.
+	// SendBrowseRequest sends the same EC_TAG_SEARCH_REF and the daemon echoes it
+	// on its failure exits too. It needs the tab dropped and the reason shown,
+	// but NOT the search-button reset below: the user never pressed Search, so
+	// clearing Download/Stop would disable them for whatever tab is visible.
 	const CSearchListCtrl *ctrl = GetSearchList(searchID);
 	const bool wasBrowse = ctrl && ctrl->IsBrowse();
 
@@ -920,16 +895,13 @@ void CSearchDlg::OnStartRejected(wxUIntPtr searchID, const wxString &error)
 
 	if (!error.IsEmpty()) {
 		// Deferred off the current call stack: in amuleGUI this runs inside
-		// CECSocket's reply handling, and wxMessageBox spins a nested event
-		// loop that re-enters CECSocket::OnInput and clobbers its rx state --
-		// the same hazard CAddLinkHandler documents. Harmless in the
-		// monolithic build, so both go through the one path.
+		// CECSocket's reply handling, and wxMessageBox spins a nested event loop
+		// that re-enters CECSocket::OnInput and clobbers its rx state -- the same
+		// hazard CAddLinkHandler documents. Harmless in the monolithic build, so
+		// both go through the one path.
 		//
-		// `error` is captured BY VALUE, not by reference: it is a const& to
-		// the caller's string and this body runs after that caller has
-		// returned. (The capture is also why there is no named local copy --
-		// performance-unnecessary-copy-initialization flags that, while the
-		// copy itself is required.)
+		// `error` is captured BY VALUE, not by reference: it is a const& to the
+		// caller's string and this body runs after that caller has returned.
 		const wxString title = wasBrowse ? _("ERROR") : _("Search warning");
 		wxTheApp->CallAfter([error, title]() {
 			wxMessageBox(error, title, wxOK | wxCENTRE | wxICON_INFORMATION);
@@ -957,13 +929,11 @@ void CSearchDlg::OnSearchAdded(wxUIntPtr searchID, const wxString &name, uint32 
 		return; // already have a tab for it
 	}
 	// Labelled like any other tab -- "(0)" hit count, "!" for a Kad search --
-	// since it is the same kind of thing and needs no separate vocabulary
-	// (got3nks, amule-org/amule#703). Unselected: it appears unprompted, so it
-	// must not pull the selection away from what the user is doing.
-	//
-	// Synchronous, matching its mirror Search_Removed -> CloseSearchTab: both
-	// run from wherever the core changed the search set, including inside EC
-	// packet handling.
+	// since it is the same kind of thing and needs no separate vocabulary.
+	// Unselected: it appears unprompted, so it must not pull the selection away
+	// from what the user is doing. Synchronous, matching its mirror
+	// Search_Removed -> CloseSearchTab: both run from wherever the core changed
+	// the search set, including inside EC packet handling.
 	CreateNewTab(((kind == KadSearch) ? "!" : "") + name + " (0)", searchID, false);
 }
 
@@ -985,14 +955,12 @@ void CSearchDlg::CloseSearchTab(wxUIntPtr searchID)
 		if (m_notebook->GetPage(i) != ctrl) {
 			continue;
 		}
-		// DeletePage fires PAGE_CLOSING synchronously (see MuleNotebook.cpp),
-		// which re-enters OnSearchClosing on this same call stack and does
-		// all the cleanup -- ShowResults(0), m_searchProgress.erase,
-		// RemoveResults, last-tab button disabling -- itself. Setting this
-		// first tells it to skip only the StopSearchById call: the core has
-		// already discarded this id (amuleGUI got EC_TAG_SEARCH_EXPIRED for
-		// it; monolithic freed the bucket), so a stop request for it would
-		// be a wasted round trip (got3nks, PR #680 review).
+		// DeletePage fires PAGE_CLOSING synchronously, which re-enters
+		// OnSearchClosing on this same call stack and does all the cleanup --
+		// ShowResults(0), the progress erase, RemoveResults, last-tab button
+		// disabling -- itself. Setting this first tells it to skip only the
+		// StopSearchById call: the core has already discarded this id, so a stop
+		// request for it would be a wasted round trip.
 		m_expiringSearchID = searchID;
 		m_notebook->DeletePage(i);
 		break;
@@ -1056,11 +1024,9 @@ void CSearchDlg::OnBnClickedStart(wxCommandEvent &WXUNUSED(evt))
 	// Starting a second ed2k search finalises the one in flight (see
 	// HasRunningEd2kSearch for why the protocol forces that), and until now it
 	// happened silently: the first tab's progress bar simply cleared, which
-	// reads exactly like a search that finished normally. Ask first, so
-	// stopping it is the user's decision rather than a surprise.
-	//
-	// Only ed2k-over-ed2k. Starting a Kad search alongside a running ed2k one
-	// is fine, and so is the reverse -- Kad results carry their own search ID.
+	// reads exactly like a search that finished normally. Ask first, so stopping
+	// it is the user's decision. Only ed2k-over-ed2k: starting a Kad search
+	// alongside a running ed2k one is fine, and so is the reverse.
 	const int newType = GetSelectedSearchTypeCanonical();
 	if ((newType == LocalSearch || newType == GlobalSearch) && HasRunningEd2kSearch()) {
 		const int answer =
@@ -1081,15 +1047,13 @@ void CSearchDlg::OnBnClickedStart(wxCommandEvent &WXUNUSED(evt))
 	uint64 now = GetTickCount64();
 	if ((now - m_last_search_time) > 500) {
 		m_last_search_time = now;
-		// Stop previous ED2K search state only (the server has a
-		// single in-flight search packet per session and m_searchPacket
-		// has to be reset).  Do NOT stop a previous Kad search: the
-		// Kad data layer (CSearchManager::m_searches) supports multiple
-		// concurrent searches keyed by target hash, and stopping the
-		// previous one immediately deletes its CSearch (which strips
-		// the "!" tab indicator and halts result delivery).
-		// Unconditionally calling OnBnClickedStop here was the reason
-		// starting a second Kad search appeared to cancel the first.
+		// Stop previous ED2K search state only -- the server has a single
+		// in-flight search packet per session and m_searchPacket has to be reset.
+		// Do NOT stop a previous Kad search: the Kad data layer supports multiple
+		// concurrent searches keyed by target hash, and stopping the previous one
+		// immediately deletes its CSearch, which strips the "!" tab indicator and
+		// halts result delivery. An unconditional stop here is why starting a
+		// second Kad search appeared to cancel the first.
 		theApp->searchlist->StopSearch(/*globalOnly=*/true);
 		StartNewSearch();
 	}
@@ -1232,15 +1196,14 @@ uint32 CSearchDlg::s_optimisticIdCounter = 0;
 // Single source of the remote-GUI OPTIMISTIC placeholder tab id, used by both a
 // new search (StartNewSearch) and a browse. A placeholder tab is created the
 // instant the user acts, then rekeyed to the daemon's real search id when the
-// START reply arrives (RemapSearch). The daemon allocates ed2k ids from the low
-// quarter [1, 0x3fffffff] and Kad ids from the top half (>= 0x80000000), so a
-// plain low placeholder could numerically equal an earlier tab's daemon id once
-// the counters drift apart — RekeySearch would then match the WRONG tab and
-// corrupt the tab map (searches silently stop). Reserving bit 30 puts every
-// placeholder in [0x40000000, 0x7fffffff], a range no daemon allocator ever
-// produces, so a placeholder can never collide with a daemon id — while staying
-// bottom-half, clear of Kad. Search and browse share the one counter, so their
-// placeholders never collide with each other either.
+// START reply arrives.
+//
+// The daemon allocates ed2k ids from the low quarter [1, 0x3fffffff] and Kad
+// ids from the top half (>= 0x80000000), so a plain low placeholder could
+// numerically equal an earlier tab's daemon id once the counters drift apart --
+// RekeySearch would then match the WRONG tab and corrupt the tab map. Reserving
+// bit 30 puts every placeholder in [0x40000000, 0x7fffffff], a range no daemon
+// allocator ever produces, while staying bottom-half and clear of Kad.
 wxUIntPtr CSearchDlg::AllocateOptimisticId()
 {
 	s_optimisticIdCounter = (s_optimisticIdCounter + 1) & 0x7fffffff;

--- a/src/SearchDlg.h
+++ b/src/SearchDlg.h
@@ -144,12 +144,10 @@ public:
 
 	// Drop every open tab's rows, keeping the tabs themselves.
 	//
-	// For a reconnect to a RESTARTED daemon: the stored searches come back
-	// under their original ids, so the tabs still correspond to something --
-	// but every result behind them has been freed, and a tab's rows are raw
-	// CSearchFile pointers (a wxDataViewItem IS the pointer). Resetting the
-	// models makes them re-read the now-empty index instead of painting
-	// through pointers the search list just deleted.
+	// For a reconnect to a RESTARTED daemon: the stored searches come back under
+	// their original ids, so the tabs still correspond to something, but every
+	// result behind them has been freed and a tab's rows are raw CSearchFile
+	// pointers. Resetting the models makes them re-read the now-empty index.
 	void ResetResultViews();
 
 	// Multi-search (remote GUI): remap a tab's search ID from the optimistic
@@ -157,48 +155,40 @@ public:
 	void RekeySearch(wxUIntPtr oldID, wxUIntPtr newID);
 
 	// The core rejected something this dialog optimistically opened a tab for:
-	// report the reason and undo the tab. Covers both a search start and a
-	// "View Files" browse, since in amuleGUI both are optimistic and both come
-	// back as EC_OP_FAILED carrying the same EC_TAG_SEARCH_REF (got3nks, PR
-	// #680 review).
+	// report the reason and undo the tab. Covers both a search start and a "View
+	// Files" browse, since in amuleGUI both are optimistic and both come back as
+	// EC_OP_FAILED carrying the same EC_TAG_SEARCH_REF.
 	//
-	// The monolithic build calls it directly from OnBnClickedStart, which has
-	// the error string in hand; amuleGUI reaches it from the EC_OP_FAILED
-	// reply, since CSearchListRem::StartNewSearch returns "" unconditionally
-	// and the rejection only arrives later over EC. Sharing the one path is
-	// what keeps a rejected start looking the same in both builds.
+	// The monolithic build calls it from OnBnClickedStart, which has the error
+	// string in hand; amuleGUI reaches it from the EC_OP_FAILED reply, since
+	// CSearchListRem::StartNewSearch returns "" unconditionally and the rejection
+	// arrives later over EC.
 	//
-	// searchID is the optimistic tab id: amuleGUI has already created that tab
-	// and needs it dropped, the monolithic build never created one and
-	// CloseSearchTab no-ops there. The search-button reset is skipped for a
-	// browse -- the user never pressed Search, so it would wrongly disable
-	// Download/Stop for whichever search tab is visible.
+	// searchID is the optimistic tab id: amuleGUI has already created that tab and
+	// needs it dropped, while CloseSearchTab no-ops in the monolithic build. The
+	// search-button reset is skipped for a browse, where the user never pressed
+	// Search and it would wrongly disable Download/Stop for the visible tab.
 	void OnStartRejected(wxUIntPtr searchID, const wxString &error);
 
-	// The core started a search (MuleNotify::Search_Added). Creates a tab for
-	// it unless this GUI already has one, or unless it is the local user's own
-	// search still inside OnBnClickedStart -- that path creates its own tab,
-	// selected, right after StartNewSearch returns, and would otherwise end up
-	// with two (amule-org/amule#703).
+	// The core started a search (MuleNotify::Search_Added). Creates a tab unless
+	// this GUI already has one, or unless it is the local user's own search still
+	// inside OnBnClickedStart -- that path creates its own tab, selected, right
+	// after StartNewSearch returns, and would otherwise end up with two (#703).
 	void OnSearchAdded(wxUIntPtr searchID, const wxString &name, uint32 kind);
 
-	// This search's results are gone -- close its tab, since a tab left open
-	// on a freed search can only mislead (in amuleGUI "Download" would
-	// silently do nothing, the daemon's m_results no longer having the hash;
-	// in the monolithic build the rows hold raw CSearchFile pointers that
-	// have just been deleted). One entry point for both builds, since it is
-	// one idea (got3nks, PR #680 review):
-	//   - amuleGUI: EC_TAG_SEARCH_EXPIRED, i.e. another client closed the
-	//     search or the daemon's LRU evicted it.
-	//   - monolithic: MuleNotify::Search_Removed, fired by
-	//     CSearchList::RemoveResults whenever a bucket is freed.
-	// Goes through the normal DeletePage path so OnSearchClosing does the
-	// actual cleanup in one place; m_expiringSearchID tells it to skip
-	// StopSearchById, which for both callers would address a search the core
-	// has already discarded. No-op if no tab matches id (e.g. it was never
-	// opened here), or if OnSearchClosing is already on the stack -- which
-	// is what stops the monolithic close path (OnSearchClosing ->
-	// RemoveResults -> Search_Removed -> here) from recursing.
+	// This search's results are gone, so close its tab: one left open on a freed
+	// search can only mislead (in amuleGUI "Download" silently does nothing, the
+	// daemon's m_results no longer having the hash; in the monolithic build the
+	// rows hold raw CSearchFile pointers that have just been deleted). One entry
+	// point for both builds:
+	//   - amuleGUI: EC_TAG_SEARCH_EXPIRED, another client closed the search or the
+	//     daemon's LRU evicted it.
+	//   - monolithic: MuleNotify::Search_Removed from CSearchList::RemoveResults.
+	// Goes through the normal DeletePage path so OnSearchClosing does the cleanup
+	// in one place; m_expiringSearchID tells it to skip StopSearchById, which for
+	// both callers would address a search the core has already discarded. No-op if
+	// no tab matches, or if OnSearchClosing is already on the stack -- which is what
+	// stops the monolithic close path from recursing.
 	void CloseSearchTab(wxUIntPtr searchID);
 
 	// "View Files" (browse): find-or-create the tab for a peer's shared-file
@@ -220,12 +210,10 @@ public:
 	void EnsureBrowseTab(
 		uint32 peerEcid, const wxString &userName, wxUIntPtr searchID, bool reveal = true);
 
-	// "View Files": if a browse tab for this peer's ECID is already open, bring
-	// the Search panel forward, select that tab, and return true. Lets the
-	// request sites skip re-browsing a peer whose listing is still on screen --
-	// which would otherwise fire a redundant request and duplicate the results
-	// in the existing tab. Returns false (and does nothing) for ecid 0 or when
-	// no such tab is open. Shared by monolithic and amuleGUI.
+	// "View Files": if a browse tab for this peer's ECID is open, bring the Search
+	// panel forward, select that tab and return true. Lets request sites skip
+	// re-browsing a peer whose listing is still on screen, which would fire a
+	// redundant request and duplicate the results. False for ecid 0 or no such tab.
 	bool ActivateBrowseTabIfOpen(uint32 peerEcid);
 
 	// Remote GUI: allocate a fresh optimistic placeholder tab ID in the reserved
@@ -270,10 +258,9 @@ public:
 	void UpdateProgress(uint32 new_value);
 
 #ifndef CLIENT_GUI
-	// Monolithic: drive the bottom bar from the visible tab's core search
-	// lifecycle (CSearchList::GetSearchBarStatusById), so the bar follows tab
-	// switches and shows the right search's progress — the local-core analogue
-	// of the remote GUI's per-search EC progress cache.
+	// Monolithic: drive the bottom bar from the visible tab's core search lifecycle
+	// so the bar follows tab switches -- the local-core analogue of the remote
+	// GUI's per-search EC progress cache.
 	void RefreshVisibleTabProgress();
 #endif
 
@@ -291,10 +278,8 @@ private:
 	// Event handlers
 	void OnFieldChanged(wxEvent &evt);
 
-	// Search *query* history: past search terms (not their results -- see
-	// #641 for that separate, not-yet-implemented follow-up) persisted to
-	// a dedicated searchhistory.dat and shown in the IDC_SEARCHNAME combo
-	// box's dropdown.
+	// Search QUERY history: past search terms, not their results, persisted to a
+	// dedicated searchhistory.dat and shown in the IDC_SEARCHNAME combo dropdown.
 	void LoadSearchHistory();
 	void RecordSearchHistory(const wxString &term);
 	void ClearSearchHistory();
@@ -304,13 +289,11 @@ private:
 	void OnSearchNameContextMenu(wxContextMenuEvent &evt);
 
 public:
-	// Brings the whole search-history UI in line with the "Remember search
-	// history" preference: with it off the Name field is a plain wxTextCtrl
-	// (no dropdown), the Clear button is hidden and no stored terms are
-	// loaded. searchhistory.dat is deliberately left on disk, so re-enabling
-	// the preference restores the previous history rather than starting over.
-	// Called at construction and live from PrefsUnifiedDlg::OnOk when the
-	// checkbox changes, so no restart is needed (issue #697).
+	// Brings the search-history UI in line with the "Remember search history"
+	// preference: with it off the Name field is a plain wxTextCtrl, the Clear button
+	// is hidden and no stored terms are loaded. searchhistory.dat is deliberately
+	// left on disk, so re-enabling restores the previous history. Called at
+	// construction and live from PrefsUnifiedDlg::OnOk, so no restart is needed.
 	void ApplySearchHistoryPref();
 	//! Show or hide the rule above the filter row, tracking the row itself.
 	void ApplyFilterSeparator(bool shown);
@@ -321,17 +304,16 @@ private:
 	// control now in place. A no-op when the right type is already there.
 	wxTextEntry *RebuildSearchNameField(bool wantHistory);
 
-	// Whether the combo currently in the Name slot has had the context-menu
-	// handler attached. The handler is bound per instance, and the combo built
-	// by muuli_wdr is one this class never created, so binding cannot be left
-	// to the creation path alone -- that is what made the "Clear search
-	// history" item missing until the preference was toggled.
+	// Whether the combo currently in the Name slot has had the context-menu handler
+	// attached. The handler is bound per instance and the combo built by muuli_wdr
+	// is one this class never created, so binding cannot be left to the creation
+	// path alone -- which is what made "Clear search history" missing until the
+	// preference was toggled.
 	bool m_searchNameCtxBound = false;
 
-	// Clear-history button, inserted into the action row after "Reset Fields"
-	// at construction, together with the divider that precedes it. Both are
-	// held rather than looked up by id so the pref-driven show/hide stays
-	// cheap and cannot silently miss one of them.
+	// Clear-history button, inserted into the action row after "Reset Fields" at
+	// construction together with the divider before it. Both are held rather than
+	// looked up by id, so the pref-driven show/hide cannot silently miss one.
 	wxButton *m_clearHistoryBtn = nullptr;
 	wxStaticLine *m_clearHistorySep = nullptr;
 	void OnBnClickedClearHistory(wxCommandEvent &evt);
@@ -376,25 +358,22 @@ private:
 	std::map<wxUIntPtr, uint32> m_searchProgress;
 
 	// Set by CloseSearchTab immediately before DeletePage(), which fires
-	// PAGE_CLOSING synchronously and re-enters OnSearchClosing on the same
-	// call stack. Tells that handler to skip StopSearchById for this one
-	// id -- the core has already discarded it -- while still running its
-	// other cleanup (ShowResults, m_searchProgress.erase, RemoveResults,
-	// last-tab button disabling), so that cleanup exists in exactly one
-	// place (got3nks, PR #680 review). 0 the rest of the time.
+	// PAGE_CLOSING synchronously and re-enters OnSearchClosing on the same stack.
+	// Tells that handler to skip StopSearchById for this one id -- the core has
+	// already discarded it -- while still running its other cleanup, so that
+	// cleanup lives in exactly one place. 0 the rest of the time.
 	wxUIntPtr m_expiringSearchID;
 
 	// True while OnBnClickedStart is inside StartNewSearch. That call fires
-	// MuleNotify::Search_Added before it returns, and this dialog creates the
-	// tab for its own search only afterwards -- so without this the local
-	// user's every search would get two tabs (amule-org/amule#703).
+	// MuleNotify::Search_Added before it returns and this dialog creates the tab for
+	// its own search only afterwards, so without this every local search would get
+	// two tabs (#703).
 	bool m_startingLocalSearch;
 
-	// True while OnSearchClosing is on the stack. In the monolithic build
-	// that handler calls CSearchList::RemoveResults, which now fires
-	// MuleNotify::Search_Removed -> CloseSearchTab for the very tab being
-	// closed; without this the pair would recurse (and double-delete the
-	// page). Set/cleared by a scoped guard in OnSearchClosing.
+	// True while OnSearchClosing is on the stack. In the monolithic build that
+	// handler calls CSearchList::RemoveResults, which fires Search_Removed ->
+	// CloseSearchTab for the very tab being closed; without this the pair would
+	// recurse and double-delete the page.
 	bool m_inSearchClosing;
 
 	// Set the bottom progress bar from a per-search status sentinel: a finished
@@ -405,11 +384,10 @@ private:
 	// When found and outPage is non-null, outPage receives the tab's page index.
 	CSearchListCtrl *GetBrowseList(uint32 ecid, int *outPage = nullptr);
 
-	// Monotonic counter behind search/browse tab IDs. On the remote GUI both a
-	// new search and a browse draw their optimistic placeholder from it via
-	// AllocateOptimisticId, so their placeholders never collide before the daemon
-	// rekeys them; the monolithic build reuses the same counter directly for its
-	// (non-remapped) search IDs.
+	// Monotonic counter behind search/browse tab IDs. On the remote GUI both a new
+	// search and a browse draw their optimistic placeholder from it via
+	// AllocateOptimisticId, so the placeholders cannot collide before the daemon
+	// rekeys them; the monolithic build uses the counter directly.
 	static uint32 s_optimisticIdCounter;
 
 	uint64 m_last_search_time;
@@ -434,13 +412,12 @@ private:
 	 */
 	std::set<CSearchListCtrl *> m_pendingHitCount;
 
-	// Kad searches whose "More" budget is spent, by searchID. The daemon
-	// reports this once per press and it never un-spends, so it is remembered
-	// here rather than re-asked: the button's enabled state is recomputed on
-	// every tab switch and progress tick, and without this a switch away and
-	// back would silently re-enable a control that can no longer do anything.
-	// Entries die with the tab (see the erase in the close path); re-running a
-	// search yields a new searchID and so starts clean.
+	// Kad searches whose "More" budget is spent, by searchID. The daemon reports
+	// this once per press and it never un-spends, so it is remembered rather than
+	// re-asked: the button's enabled state is recomputed on every tab switch and
+	// progress tick, and without this a switch away and back would re-enable a
+	// control that can no longer do anything. Entries die with the tab, and
+	// re-running a search yields a new searchID.
 	std::set<uint32_t> m_moreExhausted;
 
 	// Whether the "More" button should be live for this search: Kad-only, and

--- a/src/SearchFile.cpp
+++ b/src/SearchFile.cpp
@@ -171,16 +171,13 @@ bool CSearchFile::WriteToFile(CFileDataIO *file) const
 {
 	file->WriteHash(m_abyFileHash);
 
-	// Fixed tags: filename, size, sources, complete-sources, and rating if
-	// ever set. Anything else already riding in m_taglist (e.g. Kad-relayed
-	// extras AddTagUnique kept) is appended after, same shape as
-	// CKnownFile::WriteToFile. Unlike CKnownFile's on-the-wire pairing of a
-	// FT_FILESIZE_HI tag alongside a 32-bit FT_FILESIZE (a server-wire
-	// idiom, see KnownFile.cpp:1327 -- two 32-bit tags used INSTEAD OF a
-	// 64-bit one, never alongside it), this format always writes the size
-	// as a single 64-bit-capable tag: CTagIntSized already stores the whole
-	// value, so a size-hi tag here would be additive rather than
-	// complementary on read.
+	// Fixed tags: filename, size, sources, complete-sources, and rating if ever set.
+	// Anything else already in m_taglist is appended after, the same shape as
+	// CKnownFile::WriteToFile. Unlike CKnownFile's on-the-wire pairing of an
+	// FT_FILESIZE_HI tag alongside a 32-bit FT_FILESIZE -- a server-wire idiom where
+	// the two are used INSTEAD OF a 64-bit tag -- this format always writes the size
+	// as a single 64-bit-capable tag, so a size-hi tag here would be additive rather
+	// than complementary on read.
 	uint32 tagcount = 4;
 	if (m_iUserRating != 0) {
 		tagcount++;
@@ -290,12 +287,10 @@ CSearchFile *CSearchFile::LoadFromFile(CFileDataIO *file, bool allowChildren)
 	uint16 childcount = file->ReadUInt16();
 	if (childcount > 0 && !allowChildren) {
 		// A real result tree is two levels deep at most -- parent plus
-		// alternative-filename children, never grandchildren (the same
-		// invariant AddChild() enforces at runtime: "A child cannot have
-		// children of its own"). A child record claiming children of its
-		// own is malformed; without this check a crafted/corrupt file
-		// nesting one child per level recurses unbounded and overflows
-		// the stack before any other validation gets a chance to run.
+		// alternative-filename children, the same invariant AddChild() enforces at
+		// runtime. A child record claiming children of its own is malformed, and
+		// without this check a crafted file nesting one child per level recurses
+		// unbounded and overflows the stack before any other validation runs.
 		return nullptr;
 	}
 	for (uint16 i = 0; i != childcount; ++i) {
@@ -303,18 +298,16 @@ CSearchFile *CSearchFile::LoadFromFile(CFileDataIO *file, bool allowChildren)
 		if (!child) {
 			return nullptr;
 		}
-		// Not AddChild(): that method also does live-search duplicate
-		// merging (matching filenames get combined, see above), which
-		// doesn't apply to restoring an already-finalized tree -- every
-		// child here was already distinct when written.
+		// Not AddChild(): that also does live-search duplicate merging, which does
+		// not apply to restoring an already-finalized tree where every child was
+		// distinct when written.
 		child->m_parent = result.get();
 		result->m_children.push_back(child);
 	}
 
-	// m_downloadStatus is deliberately left at its NEW default here --
-	// recomputing it needs theApp->downloadqueue/knownfiles/canceledfiles,
-	// which is the caller's job (see the header comment on LoadFromFile)
-	// so this stays a pure parser callable before those singletons exist.
+	// m_downloadStatus is deliberately left at its NEW default: recomputing it needs
+	// theApp->downloadqueue/knownfiles/canceledfiles, which is the caller's job, so
+	// this stays a pure parser callable before those singletons exist.
 	return result.release();
 }
 

--- a/src/SearchList.cpp
+++ b/src/SearchList.cpp
@@ -93,22 +93,10 @@ void ParsedSearchExpression(const CSearchExpr *pexpr)
 		}
 	}
 
-	// this limit (+ the additional operators which will be added later) has to match the limit in
-	// 'CreateSearchExpressionTree'
-	//	+1 Type (Audio, Video)
-	//	+1 MinSize
-	//	+1 MaxSize
-	//	+1 Avail
-	//	+1 Extension
-	//	+1 Complete sources
-	//	+1 Codec
-	//	+1 Bitrate
-	//	+1 Length
-	//	+1 Title
-	//	+1 Album
-	//	+1 Artist
-	// ---------------
-	//  12
+	// This limit (plus the operators added later) has to match the limit in
+	// CreateSearchExpressionTree: one each for Type, MinSize, MaxSize, Avail,
+	// Extension, Complete sources, Codec, Bitrate, Length, Title, Album and
+	// Artist -- 12 in total.
 	if (iOpAnd + iOpOr + iOpNot > 10) {
 		yyerror("Search expression is too complex");
 	}
@@ -117,12 +105,12 @@ void ParsedSearchExpression(const CSearchExpr *pexpr)
 
 	// optimize search expression, if no OR nor NOT specified
 	if (iOpAnd > 0 && iOpOr == 0 && iOpNot == 0) {
-		// figure out if we can use a better keyword than the one the user selected
-		// for example most user will search like this "The oxymoronaccelerator 2", which would ask
-		// the node which indexes "the" This causes higher traffic for such nodes and makes them a
-		// viable target to attackers, while the kad result should be the same or even better if we
-		// ask the node which indexes the rare keyword "oxymoronaccelerator", so we try to rearrange
-		// keywords and generally assume that the longer keywords are rarer
+		// Figure out if we can use a better keyword than the one the user
+		// selected: most users search like "The oxymoronaccelerator 2", which
+		// would ask the node indexing "the" -- higher traffic for such nodes and
+		// a viable target for attackers. Asking the node that indexes the rare
+		// keyword gives the same or better results, so keywords are rearranged on
+		// the assumption that longer keywords are rarer.
 		if (/*thePrefs::GetRearrangeKadSearchKeywords() &&*/ !s_strCurKadKeyword.IsEmpty()) {
 			for (unsigned int i = 0; i < pexpr->m_aExpr.GetCount(); i++) {
 				if (pexpr->m_aExpr[i] != SEARCHOPTOK_AND) {
@@ -314,13 +302,11 @@ void CSearchList::RemoveResults(wxUIntPtr searchID)
 	Kademlia::CSearchManager::StopSearch(searchID, true);
 
 	// Tell the GUI before the CSearchFile objects below are deleted: in a
-	// monolithic build CSearchListCtrl's model holds them as raw pointers
-	// (each row's wxDataViewItem ID is the CSearchFile*) and nothing else
-	// removes those rows, so a tab left open on this search would fault on
-	// the next repaint, sort, scroll or click. Also the local counterpart
-	// of amuleGUI's
-	// EC_TAG_SEARCH_EXPIRED-driven close, so "the search is gone" closes its
-	// tab through one path in both builds (got3nks, PR #680 review).
+	// monolithic build CSearchListCtrl's model holds them as raw pointers -- each
+	// row's wxDataViewItem ID is the CSearchFile* -- and nothing else removes
+	// those rows, so a tab left open on this search would fault on the next
+	// repaint, sort, scroll or click. Also the local counterpart of amuleGUI's
+	// EC_TAG_SEARCH_EXPIRED-driven close.
 	if (!m_shuttingDown) {
 		Notify_Search_Removed(searchID);
 	}
@@ -368,10 +354,10 @@ void CSearchList::StoreSearches() const
 	for (const auto &kv : m_searchStrings) {
 		// Browses are deliberately not persisted. They are a snapshot of one
 		// peer's share taken while that peer was connected, so restoring one
-		// resurrects a listing for someone who is very likely gone -- and a
-		// large share would spend the MAX_STORED_SEARCHES budget that exists
-		// for the user's own searches. They are in m_searchStrings only so
-		// the search list can report them by peer name while they are live.
+		// resurrects a listing for someone very likely gone -- and a large share
+		// would spend the MAX_STORED_SEARCHES budget that exists for the user's
+		// own searches. They are in m_searchStrings only so the search list can
+		// report them by peer name while they are live.
 		std::map<uint32_t, SearchType>::const_iterator kind = m_searchKinds.find(kv.first);
 		if (kind != m_searchKinds.end() && kind->second == BrowseSearch) {
 			continue;
@@ -401,10 +387,9 @@ void CSearchList::StoreSearches() const
 		}
 
 		file.WriteUInt32(id);
-		// m_searchStrings/m_searchKinds/m_searchStartTimes are written and
-		// erased together (StartNewSearch/RemoveResults), so ids is drawn
-		// from m_searchStrings, and matches this instance and the sort
-		// comparator above, this can't miss -- .at() throughout says so.
+		// m_searchStrings / m_searchKinds / m_searchStartTimes are written and
+		// erased together, so `ids` drawn from m_searchStrings cannot miss --
+		// which is what .at() throughout says.
 		file.WriteString(m_searchStrings.at(id), utf8strRaw);
 		file.WriteUInt8(static_cast<uint8>(m_searchKinds.at(id)));
 		file.WriteUInt64(static_cast<uint64>(m_searchStartTimes.at(id)));
@@ -415,9 +400,9 @@ void CSearchList::StoreSearches() const
 		}
 	}
 
-	// write_safe writes to a .new sibling; only Close() performs the rename
-	// onto the real filename (CFile.h). Without this call the .new file is
-	// left orphaned and StoredSearches.met itself is never updated.
+	// write_safe writes to a .new sibling; only Close() performs the rename onto
+	// the real filename. Without this call the .new file is left orphaned and
+	// StoredSearches.met itself is never updated.
 	file.Close();
 }
 
@@ -542,24 +527,20 @@ std::vector<uint32_t> CSearchList::LoadSearches()
 		m_searchKinds[entry.id] = entry.kind;
 		m_searchStartTimes[entry.id] = entry.startTime;
 
-		// Reserve the id so the first new search of the same kind this
-		// session can't be handed it -- both counters restart every launch,
-		// so without this a restored search collides with the next one
-		// started. Partitioned on the id's own high bit rather than the
-		// persisted `kind` byte: bit 31 is intrinsic to which counter owns
-		// the value, while `kind` is a separate field from the same record
-		// that could disagree with it if the file were corrupt. The one id
-		// that bit is wrong about is the legacy sentinel, handled first.
+		// Reserve the id so the first new search of the same kind this session
+		// cannot be handed it -- both counters restart every launch, so without
+		// this a restored search collides with the next one started. Partitioned
+		// on the id's own high bit rather than the persisted `kind` byte: bit 31
+		// is intrinsic to which counter owns the value, while `kind` is a separate
+		// field that could disagree with it if the file were corrupt.
 		if (entry.id == 0xffffffff) {
-			// The legacy single-search bucket comes from neither counter:
-			// every EC client predating multi-search reuses this one id for
-			// all of its searches, so there is no allocation to advance past.
-			// It has to be excluded explicitly because the bit-31 test below
-			// would hand an ed2k search to the Kad counter -- and since this
-			// is the largest uint32 there is, ReserveSearchId would pin
-			// m_nextID at its maximum and the next Kad allocation
-			// (++m_nextID | SEARCH_ID_KAD_MASK) would wrap to the FIRST Kad
-			// id, which is the collision this reservation exists to prevent.
+			// The legacy single-search bucket comes from neither counter: every EC
+			// client predating multi-search reuses this one id for all its searches,
+			// so there is no allocation to advance past. It has to be excluded
+			// explicitly because the bit-31 test below would hand an ed2k search to
+			// the Kad counter -- and since this is the largest uint32 there is,
+			// ReserveSearchId would pin m_nextID at its maximum and the next Kad
+			// allocation would wrap to the FIRST Kad id.
 		} else if (entry.id & 0x80000000) {
 			Kademlia::CSearchManager::ReserveSearchId(entry.id);
 		} else {
@@ -641,34 +622,27 @@ wxString CSearchList::StartNewSearch(uint32 *searchID, SearchType type, CSearchP
 	}
 
 	// The scalar m_searchType / m_currentSearch are the anchor for the single
-	// in-flight ed2k (local/global) search: its results arrive asynchronously
-	// for several seconds and are attributed via these scalars (see
-	// ProcessSearchAnswer / LocalSearchEnd). A Kad search started ALONGSIDE an
-	// in-flight ed2k search has its own per-ID machinery (results carry the Kad
-	// search ID explicitly; lifecycle is IsKadSearch/m_finishedKadSearches) and
-	// needs neither scalar — so it must not repoint them, or the ed2k search's
-	// late hits get dropped (wrong type) or misfiled (wrong bucket). Preserve
-	// the ed2k anchor in exactly that case; every other start updates it as
-	// before (a new ed2k search first finalizes the old one via
-	// StopInFlightEd2kSearch, and a lone Kad search has no ed2k in flight).
+	// in-flight ed2k (local/global) search: its results arrive asynchronously for
+	// several seconds and are attributed via these scalars. A Kad search started
+	// ALONGSIDE an in-flight ed2k search has its own per-ID machinery and needs
+	// neither scalar -- so it must not repoint them, or the ed2k search's late
+	// hits get dropped (wrong type) or misfiled (wrong bucket). Every other
+	// start updates the anchor as before.
 	const bool preserveEd2kAnchor = (type == KadSearch) && m_searchInProgress;
 	if (!preserveEd2kAnchor) {
 		m_searchType = type;
 	}
 	m_searchStart = time(NULL);
 
-	// EC clients reuse the sentinel `0xffffffff` for every search regardless
-	// of network type. `Get_EC_Response_Search` -> `RemoveResults(0xffffffff)`
-	// already soft-stops the previous Kad search via `PrepareToStop()` so it
-	// can drain in-flight packets, but those late `KademliaSearchKeyword(
-	// 0xffffffff, ...)` callbacks would then land in the *new* search's
-	// `m_results[0xffffffff]` bucket -- the Kad results contaminate an ed2k
-	// (or vice-versa) result list whenever an EC client switches search type
-	// without restarting the daemon. Hard-delete the previous Kad search
-	// before either a Kad `PrepareFindKeywords` or an ed2k server packet
-	// starts feeding the shared bucket. Native-GUI searches allocate
-	// distinct top/bottom-half IDs (`3008ada0f`) so `*searchID != 0xffffffff`
-	// for them and they are unaffected.
+	// EC clients reuse the sentinel 0xffffffff for every search regardless of
+	// network type. Get_EC_Response_Search -> RemoveResults(0xffffffff) already
+	// soft-stops the previous Kad search via PrepareToStop() so it can drain
+	// in-flight packets, but those late KademliaSearchKeyword callbacks would
+	// then land in the *new* search's bucket -- Kad results contaminating an
+	// ed2k result list, or the reverse, whenever an EC client switches search
+	// type without restarting the daemon. Hard-delete the previous Kad search
+	// first. Native-GUI searches allocate distinct top/bottom-half IDs, so they
+	// never take this branch.
 	if (*searchID == 0xffffffff) {
 		Kademlia::CSearchManager::StopSearch(0xffffffff, false);
 	}
@@ -681,10 +655,9 @@ wxString CSearchList::StartNewSearch(uint32 *searchID, SearchType type, CSearchP
 				params.strKeyword, data->GetLength(), data->GetRawBuffer(), *searchID);
 
 			*searchID = search->GetSearchID();
-			// Don't repoint the ed2k result-attribution scalar when a Kad
-			// search runs alongside an in-flight ed2k search (see the
-			// preserveEd2kAnchor note above); the Kad search is tracked by its
-			// own ID regardless.
+			// Do not repoint the ed2k result-attribution scalar when a Kad search
+			// runs alongside an in-flight ed2k search (see preserveEd2kAnchor above);
+			// the Kad search is tracked by its own ID regardless.
 			if (!preserveEd2kAnchor) {
 				m_currentSearch = *searchID;
 			}
@@ -732,13 +705,11 @@ wxString CSearchList::StartNewSearch(uint32 *searchID, SearchType type, CSearchP
 	m_searchStrings[static_cast<uint32_t>(*searchID)] = params.searchString;
 
 	// Tell the GUI a search now exists. Every producer funnels through here --
-	// the monolithic dialog and the EC_OP_SEARCH_START handler alike -- so
-	// this one call covers a search started by any client. The monolithic
-	// GUI's own searches already have a tab by this point and are filtered
-	// out on the handler side; what this adds is the tab for a search some
-	// *other* client started, the last direction of the reachability work
-	// amulegui and amuleapi already had over EC_OP_SEARCH_LIST
-	// (amule-org/amule#703).
+	// the monolithic dialog and the EC_OP_SEARCH_START handler alike -- so this
+	// one call covers a search started by any client. The monolithic GUI's own
+	// searches already have a tab by this point and are filtered out on the
+	// handler side; what this adds is the tab for a search some OTHER client
+	// started.
 	Notify_Search_Added(
 		static_cast<wxUIntPtr>(*searchID), params.searchString, static_cast<uint32>(type));
 
@@ -800,12 +771,11 @@ uint32 CSearchList::GetSearchProgress() const
 		return 0xffff;
 
 	case GlobalSearch:
-		// The sweep is not armed until the connected server answers the local
-		// part (OP_SEARCHRESULT -> LocalSearchEnd) and the first timer tick
-		// attaches the observer. Until then m_serverQueue is detached and empty,
-		// so GetRemaining() is a stale 0 that would read as 100% ("done") the
-		// instant a search starts. IsActive() is true only during the actual
-		// sweep, so report 0 (just-started) before it begins.
+		// The sweep is not armed until the connected server answers the local part
+		// and the first timer tick attaches the observer. Until then m_serverQueue
+		// is detached and empty, so GetRemaining() is a stale 0 that would read as
+		// 100% ("done") the instant a search starts. IsActive() is true only during
+		// the actual sweep, so report 0 before it begins.
 		if (!m_serverQueue.IsActive()) {
 			return 0;
 		}
@@ -880,13 +850,11 @@ uint8 CSearchList::GetSearchLifecyclePercent() const
 void CSearchList::OnGlobalSearchTimer(CTimerEvent &WXUNUSED(evt))
 {
 	if (m_awaitingServerAnswer && m_searchInProgress) {
-		// The one-shot armed at StartNewSearch: the connected server never
-		// sent OP_SEARCHRESULT, so neither kind of ed2k search has anything
-		// left that would end it. Terminalize through the finalizer the kind
-		// already has rather than leave it reporting RUNNING for good.
-		//
-		// Tested before the packet check below, which a local search would
-		// otherwise fall into: it has no search packet.
+		// The one-shot armed at StartNewSearch: the connected server never sent
+		// OP_SEARCHRESULT, so neither kind of ed2k search has anything left that
+		// would end it. Terminalize through the finalizer the kind already has,
+		// rather than leave it reporting RUNNING for good. Tested before the packet
+		// check below, which a local search would otherwise fall into.
 		AddLogLineN(_("Search timed out: the server did not answer."));
 		if (m_searchType == GlobalSearch) {
 			FinalizeGlobalSearch();
@@ -999,25 +967,22 @@ void CSearchList::ProcessSharedFileList(const uint8_t *in_packet,
 	// wire-safe search ID by now -- pinned by the EC handler for a remote one,
 	// allocated by RequestSharedFileList for a local one -- so the union and
 	// per-ID polls and the LRU ring can all address these results.
+	//
 	// A local browse used to key its results on the client pointer, which no
-	// remote client can address -- it is this process's memory, so the browse
-	// was invisible to amulegui, amuleweb and amuleapi while an EC-initiated
-	// one (which is handed a real id) showed up everywhere, including in this
-	// GUI. Give it the same kind of id so the two directions match. It is also
-	// safer: a pointer is reused once the client is freed, so two browses of
+	// remote client can address, so the browse was invisible to amulegui,
+	// amuleweb and amuleapi while an EC-initiated one showed up everywhere. A
+	// pointer is also reused once the client is freed, so two browses of
 	// different peers could collide on one key.
 	//
 	// Allocated once and pinned on the client, not per packet -- a browse
 	// arrives in several -- and registered so it is listed like any other
-	// search, with its kind and peer, which is what lets a remote GUI rebuild
-	// it as a browse tab rather than a nameless search.
-	// Whether this browse was asked for here. Read before the id is assigned
+	// search, with its kind and peer, which is what lets a remote GUI rebuild it
+	// as a browse tab.
+	//
+	// Whether this browse was asked for HERE is read before the id is assigned
 	// below, because that assignment is what makes a local browse look like an
 	// EC one afterwards. An EC-initiated browse belongs to another client, so
-	// revealing it would pull this user's panel and selection away for
-	// something they never asked for -- the same rule the discovered-search
-	// path follows. Gated with its use: there is no tab to reveal in a
-	// daemon build, and an unread value there is a dead store.
+	// revealing it would pull this user's panel and selection away.
 #ifndef AMULE_DAEMON
 	const bool ecInitiated = sender->IsBrowseEcInitiated();
 #endif
@@ -1057,19 +1022,18 @@ void CSearchList::ProcessSharedFileList(const uint8_t *in_packet,
 	}
 }
 
-// Symmetric counterpart to PR #36's Kad hard-stop on EC search-start.
-// Late ed2k server replies (TCP Local responses here, UDP Global responses
-// in ProcessUDPSearchAnswer below) keep arriving for seconds after the
-// search request is sent. When an EC client switches search type (ed2k ->
-// Kad) those late results would land in `m_results[m_currentSearch]` --
-// with the EC sentinel `0xffffffff` pinned across all EC searches, that
-// bucket is now the new Kad search's bucket, producing ed2k contamination
-// of a Kad result list. Drop late ed2k replies when the active search
-// type is no longer ed2k. Native-GUI parallel searches keep
-// `m_currentSearch` at bottom-half IDs and a Kad tab updates m_searchType
-// to KadSearch -- this gate makes late ed2k packets stop misrouting to
-// the Kad tab's bucket (a pre-existing GUI side bug that nobody noticed
-// because cross-protocol hits in a Kad tab look like noise).
+// Symmetric counterpart to the Kad hard-stop on EC search-start. Late ed2k
+// server replies -- TCP Local responses here, UDP Global responses in
+// ProcessUDPSearchAnswer below -- keep arriving for seconds after the search
+// request is sent. When an EC client switches search type (ed2k -> Kad) those
+// late results would land in `m_results[m_currentSearch]`, and with the EC
+// sentinel pinned across all EC searches that bucket is now the new Kad
+// search's, producing ed2k contamination of a Kad result list.
+//
+// Native-GUI parallel searches keep m_currentSearch at bottom-half IDs and a
+// Kad tab updates m_searchType, so this gate also stops late ed2k packets
+// misrouting to the Kad tab's bucket -- a pre-existing GUI-side bug that went
+// unnoticed because cross-protocol hits in a Kad tab look like noise.
 static inline bool IsActiveSearchTypeEd2k(SearchType t)
 {
 	return t == LocalSearch || t == GlobalSearch;
@@ -1085,9 +1049,7 @@ bool CSearchList::CanFileServerAnswer() const
 	//
 	// An explicit stop is what does not: it hands m_currentSearch back to the
 	// sentinel the EC handler pins across all its searches, and filing server
-	// hits there contaminates the bucket StartNewSearch takes care to keep
-	// clean. Test that, rather than m_searchInProgress, so nothing is dropped
-	// that had somewhere to go.
+	// hits there contaminates the bucket StartNewSearch keeps clean.
 	return IsActiveSearchTypeEd2k(m_searchType) && m_currentSearch != wxUIntPtr(-1);
 }
 
@@ -1161,15 +1123,13 @@ bool CSearchList::AddToList(CSearchFile *toadd, bool clientResponse)
 			// memory (got3nks, PR #796 review). Infer survival from whether
 			// the child count actually grew.
 			const bool survived = item->GetChildren().size() > childrenBefore;
-			// Structural change (leaf-or-nothing -> container, or a new row
-			// under an existing container) needs its own notification --
-			// Search_Update_Sources only signals that the parent's values
-			// changed, via wxDataViewModel::ItemChanged(), which some
-			// wxDataViewCtrl backends (GTK, MSW) don't treat as reason to
-			// re-check IsContainer()/re-fetch children, so the child never
-			// becomes reachable there. Native NSOutlineView survives the
-			// omission by re-querying IsContainer() on every draw, which
-			// masked this on macOS.
+			// Structural change -- leaf-or-nothing to container, or a new row under
+			// an existing container -- needs its own notification.
+			// Search_Update_Sources only signals that the parent's values changed,
+			// via wxDataViewModel::ItemChanged(), which some wxDataViewCtrl backends
+			// (GTK, MSW) do not treat as reason to re-check IsContainer() or re-fetch
+			// children, so the child never becomes reachable there. Native
+			// NSOutlineView re-queries IsContainer() on every draw, which masked it.
 			if (survived) {
 				Notify_Search_Add_Result(toadd);
 			}
@@ -1222,10 +1182,8 @@ void CSearchList::GetAllSearchFilesByID(const CMD4Hash &hash, std::vector<CSearc
 {
 	// Unlike GetSearchFileByID (first match only), collect EVERY result object
 	// that shares this hash. The same file can appear in more than one open
-	// search (an EC client such as amulegui runs several at once), and each
-	// search keeps its own CSearchFile with its own note list. On-demand Kad
-	// notes and the running flag must reach all of them, or only the first tab
-	// would show the comments.
+	// search, and each keeps its own CSearchFile with its own note list.
+	// On-demand Kad notes and the running flag must reach all of them.
 	for (const auto &entry : AllResults()) {
 		for (CSearchFile *sf : entry.second) {
 			if (sf->GetFileHash() == hash) {

--- a/src/SearchList.h
+++ b/src/SearchList.h
@@ -66,11 +66,9 @@ enum SearchType
 	GlobalSearch = 1,
 	KadSearch = 2,
 	// 3 is EC_SEARCH_WEB -- deliberately skipped, see above.
-	//! A "View Files" browse of one peer's share. Shares the id space and
-	//! the lifecycle machinery with real searches, but is started by
-	//! EnsureBrowseTab rather than a query, and is the kind a remote GUI
-	//! needs in order to rebuild the right sort of tab for a browse it did
-	//! not start itself.
+	//! A "View Files" browse of one peer's share. Shares the id space and the
+	//! lifecycle machinery with real searches, but is started by EnsureBrowseTab
+	//! rather than a query.
 	BrowseSearch = 4
 };
 
@@ -230,18 +228,17 @@ public:
 	};
 	SearchLifecycleState GetSearchLifecycleState() const;
 
-	// Per-search-ID lifecycle accessors for the multi-search EC path. For
-	// the most-recently-started search (== m_currentSearch) these delegate
-	// to the scalar accessors above (accurate live state); for older searches
-	// they infer state from the Kad manager (a still-active keyword search is
-	// RUNNING) and the retained result bucket (present => FINISHED).
+	// Per-search-ID lifecycle accessors for the multi-search EC path. For the
+	// most-recently-started search these delegate to the scalar accessors above;
+	// for older searches they infer state from the Kad manager (a still-active
+	// keyword search is RUNNING) and the retained result bucket (present means
+	// FINISHED).
 	SearchLifecycleState GetSearchLifecycleStateById(wxUIntPtr searchID) const;
 	uint8 GetSearchLifecyclePercentById(wxUIntPtr searchID) const;
-	// The overloaded progress-bar sentinel for a search: 0xffff when a finished
-	// ed2k search, 0xfffe when a finished Kad search (each resets the bar and,
-	// for Kad, clears the "!" marker on the client), otherwise the running
-	// percent. Single source of truth for the bottom bar, shared by the EC
-	// PROGRESS reply (remote GUI / amuleapi) and the monolithic search dialog.
+	// The overloaded progress-bar sentinel for a search: 0xffff for a finished ed2k
+	// search, 0xfffe for a finished Kad one (each resets the bar, and Kad also
+	// clears the "!" marker), otherwise the running percent. Single source of truth
+	// for the bottom bar, shared by the EC PROGRESS reply and the search dialog.
 	uint32 GetSearchBarStatusById(wxUIntPtr searchID) const;
 	// "View Files" browse tabs are not CSearchList searches: CBrowseManager
 	// owns their bar, and GetSearchBarStatusById consults it first, so the
@@ -250,12 +247,11 @@ public:
 	// Echoes m_searchType for the current/last search; meaningful only
 	// when state is RUNNING or FINISHED. Returns LocalSearch by default.
 	SearchType GetSearchLifecycleKind() const { return m_searchType; }
-	// Per-id search kind: the type recorded for THIS search when it started,
-	// so the EC PROGRESS reply reports the polled tab's kind rather than the
-	// scalar (most-recently-started) one — a remote GUI running several
-	// searches needs each tab's real kind (e.g. to enable the Kad-only "More"
-	// button). Kad is authoritative via IsOrWasKadSearch even if the recorded
-	// entry was pruned; unknown ids fall back to the scalar.
+	// Per-id search kind: the type recorded for THIS search when it started, so the
+	// EC PROGRESS reply reports the polled tab's kind rather than the scalar one --
+	// a remote GUI running several searches needs each tab's real kind, for the
+	// Kad-only "More" button. Kad is authoritative via IsOrWasKadSearch even if the
+	// recorded entry was pruned; unknown ids fall back to the scalar.
 	SearchType GetSearchLifecycleKindById(wxUIntPtr searchID) const;
 	/**
 	 * Records a browse under @a searchID so it appears in the search list
@@ -279,10 +275,9 @@ public:
 	// Result count for the current search; 0 if idle.
 	std::size_t GetCurrentSearchResultCount() const;
 	// Unified 0..100 completion for the current search, surfaced via
-	// EC_TAG_SEARCH_LIFECYCLE_PERCENT. Global uses the real server-queue
-	// percent; Kad — which has no measurable progress — gets a cosmetic
-	// time-ramp off the fixed keyword-search lifetime that the FINISHED
-	// lifecycle state authoritatively snaps to 100. Idle returns 0.
+	// EC_TAG_SEARCH_LIFECYCLE_PERCENT. Global uses the real server-queue percent;
+	// Kad, which has no measurable progress, gets a cosmetic time-ramp off the
+	// fixed keyword-search lifetime, which the FINISHED state snaps to 100.
 	uint8 GetSearchLifecyclePercent() const;
 
 	/** This function is called once the local (ed2k) search has ended. */
@@ -426,20 +421,17 @@ private:
 	//! On-disk name of the search-results persistence file, in the config dir.
 	static const wxChar *const s_storedSearchesFilename;
 
-	//! Ceiling on how many searches StoreSearches() writes / LoadSearches()
-	//! accepts. Matches kMaxEcSearches (ExternalConn.cpp) for consistency,
-	//! though m_searchStrings itself isn't EC-bounded -- a purely local,
-	//! monolithic-only set of open tabs could exceed it. The oldest (by
-	//! m_searchStartTimes) are dropped first, with a log line; never silent.
+	//! Ceiling on how many searches StoreSearches() writes and LoadSearches()
+	//! accepts. Matches kMaxEcSearches for consistency, though m_searchStrings
+	//! itself is not EC-bounded. The oldest are dropped first, with a log line.
 	static const std::size_t MAX_STORED_SEARCHES = 20;
 
-	//! Ceiling on how many results StoreSearches() writes / LoadSearches()
-	//! accepts per search. No existing loader (known.met, server.met) bounds
-	//! its record count, so this is a fresh, deliberately generous number --
-	//! not one mirrored from elsewhere. Unlike known.met (describes local
-	//! files), a search result describes an arbitrary remote peer's claims,
-	//! so the read side must fail closed on a record claiming more than this
-	//! rather than attempt an unbounded allocation.
+	//! Ceiling on how many results StoreSearches() writes and LoadSearches()
+	//! accepts per search. Deliberately generous, and not mirrored from any other
+	//! loader: unlike known.met, which describes local files, a search result
+	//! describes an arbitrary remote peer's claims, so the read side must fail
+	//! closed on a record claiming more than this rather than attempt an unbounded
+	//! allocation.
 	static const std::size_t MAX_STORED_RESULTS_PER_SEARCH = 5000;
 
 	/** Event-handler for global searches. */
@@ -535,11 +527,10 @@ private:
 	//! If the current search is a KAD search this signals if it is finished.
 	bool m_KadSearchFinished;
 
-	//! Per-search Kad completion (multi-search): the IDs of Kad searches that
-	//! have ended (their CSearch was destroyed on the result cap or the 45s
-	//! lifetime). Lets GetSearchLifecycleStateById report each search
-	//! independently, so one search finishing does not mark a different
-	//! still-running search as finished. Pruned in RemoveResults.
+	//! Per-search Kad completion (multi-search): the IDs of Kad searches that have
+	//! ended. Lets GetSearchLifecycleStateById report each search independently, so
+	//! one finishing does not mark a different still-running search as finished.
+	//! Pruned in RemoveResults.
 	std::set<uint32_t> m_finishedKadSearches;
 
 	//! Per-search start time (multi-search), so each search's cosmetic Kad
@@ -555,19 +546,15 @@ private:
 	//! Peer ecid per browse id; see RegisterBrowseSearch().
 	std::map<uint32_t, uint32> m_browsePeers;
 
-	//! This search's original query string, keyed by id (same lifetime as
-	//! m_searchKinds -- recorded in StartNewSearch, pruned in RemoveResults).
-	//! Needed to label a search enumerated via EC_OP_SEARCH_LIST for a
-	//! client that didn't start it locally and so has no tab-title string
-	//! of its own to fall back on.
+	//! This search's original query string, keyed by id (recorded in StartNewSearch,
+	//! pruned in RemoveResults). Needed to label a search enumerated via
+	//! EC_OP_SEARCH_LIST for a client that did not start it locally.
 	std::map<uint32_t, wxString> m_searchStrings;
 
-	//! ED2K-side counterpart of m_KadSearchFinished, covering both local
-	//! and global searches. Cleared to false in StartNewSearch when an
-	//! ED2K search is issued; set back to true in LocalSearchEnd (local)
-	//! or FinalizeGlobalSearch (global — both natural drain and
-	//! explicit abort). GetSearchLifecycleState uses this as the
-	//! RUNNING vs FINISHED signal for the ED2K branch.
+	//! ED2K-side counterpart of m_KadSearchFinished, covering both local and global
+	//! searches. Cleared in StartNewSearch when an ED2K search is issued, set again
+	//! in LocalSearchEnd or FinalizeGlobalSearch. GetSearchLifecycleState uses it as
+	//! the RUNNING vs FINISHED signal for the ED2K branch.
 	bool m_ed2kSearchFinished;
 	/**
 	 * True from an ed2k search going out until the connected server answers.
@@ -582,10 +569,9 @@ private:
 	//! GetSearchLifecyclePercent.
 	time_t m_searchStart;
 
-	//! Set by the destructor before it drains m_results, so RemoveResults
-	//! skips its MuleNotify::Search_Removed broadcast during teardown --
-	//! the GUI is being dismantled around us and there is no tab left worth
-	//! closing.
+	//! Set by the destructor before it drains m_results, so RemoveResults skips its
+	//! Search_Removed broadcast during teardown: the GUI is being dismantled around
+	//! us and there is no tab left worth closing.
 	bool m_shuttingDown;
 
 	//! Queue of servers to ask when doing global searches.

--- a/src/SearchListCtrl.cpp
+++ b/src/SearchListCtrl.cpp
@@ -88,12 +88,11 @@ CSearchListCtrl::CSearchListCtrl(
 , m_invert(false)
 , m_filterEnabled(false)
 {
-	// Without this, idle events aren't guaranteed to reach this specific
-	// window (wx's default idle-processing mode only visits windows opted
-	// in this way), so OnIdle's column-resize detection -- the only way
-	// this control learns about a user drag-resize, since there is no
-	// portable wxDataViewCtrl "column resized" event -- would silently
-	// never fire.
+	// Without this, idle events are not guaranteed to reach this window (wx's
+	// default idle-processing mode only visits windows opted in this way), so
+	// OnIdle's column-resize detection -- the only way this control learns about a
+	// drag-resize, there being no portable wxDataViewCtrl "column resized" event
+	// -- would silently never fire.
 	SetExtraStyle(GetExtraStyle() | wxWS_EX_PROCESS_IDLE);
 
 	m_model = new CSearchListModel(this);
@@ -219,14 +218,11 @@ CSearchListCtrl::CSearchListCtrl(
 
 CSearchListCtrl::~CSearchListCtrl()
 {
-	// Push this list's current widths/sort state onward before it's gone,
-	// so whichever tab happens to be closed *last* -- the one that
-	// actually gets to SaveColumnSettings() below -- reflects the most
-	// recently touched state, regardless of which tab the user last
-	// resized/re-sorted. Doesn't depend on the idle-driven live sync
-	// (CSearchListCtrl::OnIdle) ever having fired: that only keeps
-	// multiple simultaneously-open tabs visually in sync as a UX nicety,
-	// it's not what persistence correctness relies on here.
+	// Push this list's widths/sort state onward before it is gone, so whichever
+	// tab is closed LAST -- the one that reaches SaveColumnSettings() below --
+	// reflects the most recently touched state, whichever tab was resized. Does
+	// not depend on the idle-driven live sync having fired: that only keeps
+	// simultaneously-open tabs visually in step.
 	SyncOtherLists(this);
 
 	s_lists.remove(this);
@@ -245,9 +241,8 @@ bool CSearchListCtrl::PassesFilter(const CSearchFile *file) const
 
 bool CSearchListCtrl::IsFiltered(const CSearchFile *file) const
 {
-	// By default, everything is displayed. (Name kept from the original
-	// wxListCtrl-era code -- despite the name, true means "passes the
-	// filter, should be shown".)
+	// By default everything is displayed. Despite the name (kept from the
+	// wxListCtrl-era code) true means "passes the filter, should be shown".
 	bool result = true;
 
 	if (m_filterEnabled && m_filter.IsValid()) {
@@ -271,13 +266,11 @@ bool CSearchListCtrl::ShouldShow(const CSearchFile *file) const
 	if (IsFiltered(file)) {
 		return true;
 	}
-	// A parent that doesn't itself pass the filter is still shown as a
-	// container if at least one child does -- regardless of whether it's
-	// currently expanded. (This is a deliberate, flagged behaviour change
-	// from the old hand-drawn-tree version, which only kept such a parent
-	// visible while its children were already expanded-shown; with a real
-	// tree control there's no reason to couple filtering to transient
-	// expand state, and always surfacing the container is more discoverable.)
+	// A parent that does not itself pass the filter is still shown as a container
+	// if at least one child does, whether or not it is expanded. The old
+	// hand-drawn-tree version only kept such a parent visible while its children
+	// were already expanded-shown; with a real tree control there is no reason to
+	// couple filtering to transient expand state.
 	const CSearchResultList &children = file->GetChildren();
 	for (const CSearchFile *child : children) {
 		if (IsFiltered(child)) {
@@ -337,10 +330,9 @@ size_t CSearchListCtrl::GetHiddenItemCount() const
 	}
 	size_t hidden = 0;
 	const CSearchResultList &results = theApp->searchlist->GetSearchResults(m_nResultsID);
-	// Only top-level results are indexed (see CSearchResultIndex), so this
-	// counts exactly the results the list would show but for the filter. A
-	// grouped child is never "hidden" in its own right: it is reached through
-	// its parent, which surfaces as a container for it.
+	// Only top-level results are indexed (see CSearchResultIndex), so this counts
+	// exactly the results the list would show but for the filter. A grouped child
+	// is never hidden in its own right: it is reached through its parent.
 	for (CSearchFile *file : results) {
 		if (!ShouldShow(file)) {
 			++hidden;
@@ -358,18 +350,15 @@ size_t CSearchListCtrl::GetItemCount() const
 	const CSearchResultList &results = theApp->searchlist->GetSearchResults(m_nResultsID);
 	// Results, not rows: one per top-level hit, whatever is expanded.
 	//
-	// This used to add the children of expanded groups, which was right when
-	// the tab was a wxListCtrl and an expanded child really was another row --
-	// the count and the row count were the same number. Under the data view
-	// they are not: children are model nodes, nothing recomputes the label on
-	// expand or collapse (there is no handler), and the tab therefore reported
-	// whichever expansion state happened to be current when some unrelated
-	// event last refreshed it. Two clients showing identical lists disagreed
-	// by exactly the children someone had opened.
+	// Adding the children of expanded groups was right when the tab was a
+	// wxListCtrl and an expanded child really was another row. Under the data view
+	// children are model nodes, nothing recomputes the label on expand or collapse,
+	// and the tab reported whichever expansion state happened to be current when
+	// some unrelated event last refreshed it -- so two clients showing identical
+	// lists disagreed by exactly the children someone had opened.
 	//
-	// It also makes the label's own arithmetic add up: GetHiddenItemCount()
-	// has always counted top-level results only, so "shown/(shown + hidden)"
-	// was mixing rows with results.
+	// It also makes the label's arithmetic add up: GetHiddenItemCount() has always
+	// counted top-level results only.
 	for (CSearchFile *file : results) {
 		if (!file->GetParent() && ShouldShow(file)) {
 			++shown;
@@ -382,10 +371,9 @@ CSearchFile *CSearchListCtrl::GetFocusedFile() const
 {
 	wxDataViewItemArray selections;
 	GetSelections(selections);
-	// The first selected result, not the first selected item: a folder
-	// picked up alongside one would otherwise make this give up, while
-	// GetSelectedItemCount() -- which counts results -- still enables the
-	// menu entry that calls it.
+	// The first selected RESULT, not the first selected item: a folder picked up
+	// alongside one would otherwise make this give up, while GetSelectedItemCount()
+	// still enables the menu entry that calls it.
 	for (const wxDataViewItem &item : selections) {
 		if (!m_model->IsFolder(item)) {
 			return CSearchListModel::ToFile(item);
@@ -431,10 +419,9 @@ void CSearchListCtrl::SetBrowseEcid(uint32 ecid)
 
 int CSearchListCtrl::GetSelectedItemCount() const
 {
-	// Results, not rows. A browse tab has folders in the tree, and every
-	// caller of this is asking how many things it can act on -- a menu it is
-	// about to enable, a download it is about to queue. Counting a selected
-	// folder would enable an action with nothing behind it.
+	// Results, not rows. A browse tab has folders in the tree, and every caller is
+	// asking how many things it can act on, so counting a selected folder would
+	// enable an action with nothing behind it.
 	return static_cast<int>(GetSelectedFiles().size());
 }
 
@@ -599,17 +586,15 @@ void CSearchListCtrl::SyncLists(CSearchListCtrl *src, CSearchListCtrl *dst)
 	dst->UpdateExpanderColumn();
 
 	// Re-baseline what dst's idle poll compares against, so the widths just
-	// written read as the status quo rather than as a drag the user made
-	// there. Without this the mirror echoes: dst notices "its" widths moved,
-	// runs its own OnColumnWidthsChanged(), and mirrors them straight back.
+	// written read as the status quo rather than as a drag the user made there.
+	// Without this the mirror echoes: dst notices "its" widths moved and mirrors
+	// them straight back.
 	//
-	// That echo does not die out on its own. GTK clamps a column to a minimum
-	// taken from its header and contents, so a width that fits one tab comes
-	// back wider in another holding different results -- the two tabs never
-	// converge on a value and hand it back and forth indefinitely, repainting
-	// each time, long after the mouse was released. It showed up on the
-	// columns that were empty in one of the tabs, since those are the ones
-	// whose clamped minimum differs (issue #1022).
+	// The echo does not die out on its own. GTK clamps a column to a minimum taken
+	// from its header and contents, so a width that fits one tab comes back wider
+	// in another holding different results, and the two hand it back and forth
+	// indefinitely. It showed up on columns empty in one of the tabs, since those
+	// are the ones whose clamped minimum differs (issue #1022).
 	dst->ResetKnownWidths();
 
 	if (dst->m_sort_orders.empty() || src->m_sort_orders.empty() ||
@@ -668,10 +653,9 @@ void CSearchListCtrl::SetBrowseStatus(uint32 status)
 {
 	// A re-browse reuses this tab (see CSearchDlg::EnsureBrowseTab), so the
 	// rebuild threshold has to start over with it. Left standing, the previous
-	// browse's final row count becomes the bar the new one has to clear, which
-	// it never does: every burst would be skipped and the list would stay
-	// empty until the browse finished, which is the wait the throttle exists
-	// to avoid (issue #898).
+	// browse's final row count becomes the bar the new one never clears: every
+	// burst is skipped and the list stays empty until the browse finishes, which
+	// is the wait the throttle exists to avoid (issue #898).
 	if (status == BROWSE_IN_PROGRESS) {
 		m_lastRebuildRows = 0;
 	}
@@ -680,42 +664,36 @@ void CSearchListCtrl::SetBrowseStatus(uint32 status)
 
 void CSearchListCtrl::OnIdleHook()
 {
-	// One coalesced rebuild per idle for everything that arrived since the
-	// last one (got3nks, PR #796 review): mixing incremental Item*
-	// notifications with the full model reset a group formation needs left
-	// wxGTK's tree inconsistent, and neither ItemChanged() nor a
-	// delete-and-re-add worked around it -- only wxDataViewModel::Cleared()
-	// reliably makes the control re-derive container-ness.
+	// One coalesced rebuild per idle for everything that arrived since the last
+	// one: mixing incremental Item* notifications with the full model reset a group
+	// formation needs left wxGTK's tree inconsistent, and only
+	// wxDataViewModel::Cleared() reliably makes the control re-derive
+	// container-ness.
 	//
-	// That is now the fallback rather than the rule: arrivals are reported
-	// incrementally where the backends tolerate it, and only what still
-	// needs a rebuild takes the branch below. Cleared() throws away the
+	// That is the fallback rather than the rule: arrivals are reported
+	// incrementally where the backends tolerate it. Cleared() throws away the
 	// control's own view state, so selection and expansion are captured and
-	// re-applied around it -- otherwise a result landing mid-search would
-	// deselect whatever the user had picked. Items are CSearchFile*, still
-	// valid across the rebuild; ones that went away are dropped by
-	// re-checking membership against the live tree afterwards.
+	// re-applied around it, or a result landing mid-search would deselect whatever
+	// the user had picked. Items are CSearchFile*, still valid across the rebuild;
+	// ones that went away are dropped by re-checking membership afterwards.
 	if (m_model->HasPending() && !m_model->HasPendingReset()) {
-		// Incremental batch: the control keeps its scroll position, its
-		// selection and its expanded rows, so there is nothing to preserve
-		// around it. This is the path a search takes while results stream
-		// in, which is why the list no longer jumps back to the top on
-		// every burst.
+		// Incremental batch: the control keeps its scroll position, selection
+		// and expanded rows, so there is nothing to preserve around it. This is
+		// the path a search takes while results stream in, which is why the list
+		// no longer jumps back to the top on every burst.
 		m_model->FlushPending();
 	} else if (m_model->HasPending()) {
-		// A browse still streaming in is rebuilt on a growth schedule rather
-		// than on every burst.
+		// A browse still streaming in is rebuilt on a growth schedule rather than
+		// on every burst. The rebuild below is O(rows) and a browse arrives one
+		// directory at a time, so per-burst rebuilding is O(bursts x rows):
+		// browsing a 39,450-file share took 384 rebuilds totalling 232 seconds of
+		// blocked main loop (issue #898).
 		//
-		// The rebuild below is O(rows), and a browse arrives one directory at
-		// a time, so rebuilding per burst is O(bursts x rows): browsing a
-		// 39,450-file share took 384 rebuilds totalling 232 seconds of
-		// blocked main loop, the last of them 5.2 s on its own (issue #898).
-		//
-		// Waiting for the row count to grow by half means the rebuilds form a
-		// geometric series, so their total is a small multiple of the final
-		// one -- about 25 rebuilds instead of 384 here -- while results still
-		// appear as the browse runs rather than only at the end. A finished
-		// or failed browse always falls through, so the last state is exact.
+		// Waiting for the row count to grow by half makes the rebuilds a geometric
+		// series, so their total is a small multiple of the final one -- about 25
+		// instead of 384 -- while results still appear as the browse runs. A
+		// finished or failed browse always falls through, so the last state is
+		// exact.
 		if (m_browseStatus == BROWSE_IN_PROGRESS) {
 			// Counted from the indexed result list, not the model: the
 			// model would have to walk its rows to answer, which is the
@@ -732,13 +710,12 @@ void CSearchListCtrl::OnIdleHook()
 			m_lastRebuildRows = 0;
 		}
 
-		// The row the user is looking at, so the rebuild below can be put
-		// back where they left it. Cleared() drops the view to the top, and
-		// on a running search that is every idle -- measured on GTK with wx
-		// 3.3.3, EnsureVisible() afterwards lands it back on the same row
+		// The row the user is looking at, so the rebuild can be put back where
+		// they left it: Cleared() drops the view to the top, which on a running
+		// search is every idle. EnsureVisible() afterwards lands on the same row
 		// exactly, because the items here are CSearchFile pointers and stay
-		// nameable across the rebuild (the virtual lists cannot do this:
-		// their items are row numbers, which mean nothing afterwards).
+		// nameable across the rebuild (the virtual lists cannot do this: their
+		// items are row numbers).
 		const wxDataViewItem topBefore = GetTopItem();
 
 		wxDataViewItemArray selected;
@@ -800,10 +777,10 @@ void CSearchListCtrl::OnSortingChanged()
 
 void CSearchListCtrl::OnRightClick(wxDataViewEvent &event)
 {
-	// A folder row is not a result: none of the actions below apply to it,
-	// and GetSelectedItemCount() counts results, so it would otherwise get
-	// no menu at all. Remembered rather than re-derived when the handler
-	// runs, because a right-click does not select the row on every platform.
+	// A folder row is not a result: none of the actions below apply to it, and
+	// GetSelectedItemCount() counts results, so it would otherwise get no menu at
+	// all. Remembered rather than re-derived when the handler runs, because a
+	// right-click does not select the row on every platform.
 	m_contextFolder = m_model->IsFolder(event.GetItem()) ? event.GetItem() : wxDataViewItem();
 	if (m_contextFolder.IsOk()) {
 		wxMenu menu;
@@ -814,9 +791,8 @@ void CSearchListCtrl::OnRightClick(wxDataViewEvent &event)
 	}
 
 	if (GetSelectedItemCount()) {
-		// No title -- see the identical rationale in the pre-port version
-		// (wxMenu's title parameter renders inconsistently or not at all
-		// as a context-popup header across platforms, issue #767).
+		// No title: wxMenu's title parameter renders inconsistently or not at all
+		// as a context-popup header across platforms (issue #767).
 		wxMenu menu;
 		menu.Append(MP_RESUME, _("Download"));
 
@@ -839,10 +815,9 @@ void CSearchListCtrl::OnRightClick(wxDataViewEvent &event)
 		menu.Append(MP_SEARCHRELATED, _("Search related files (eD2k, local server)"));
 		menu.Append(MP_GETCOMMENTS, _("Show all comments"));
 		menu.AppendSeparator();
-		// Singular or plural to match what it will copy, the same way the
-		// server list labels it. OnPopupGetUrl has always walked the whole
-		// selection and joined the links with newlines -- it was only ever
-		// the menu that stopped it being handed more than one.
+		// Singular or plural to match what it will copy, as the server list does.
+		// OnPopupGetUrl has always walked the whole selection and joined the links
+		// with newlines -- only the menu stopped it being handed more than one.
 		const bool single = (GetSelectedItemCount() == 1);
 		menu.Append(MP_GETED2KLINK,
 			single ? _("Copy eD2k link to clipboard") : _("Copy eD2k links to clipboard"));
@@ -920,11 +895,10 @@ std::vector<wxDataViewItem> CSearchListCtrl::ContextFolders()
 	wxDataViewItemArray selection;
 	GetSelections(selection);
 
-	// The whole selection, but only when the row clicked is part of it: the
-	// rule a file manager follows, since right-clicking outside a selection
-	// addresses the row under the pointer rather than whatever happens to be
-	// selected elsewhere. A right-click does not select on every platform,
-	// which is why m_contextFolder is remembered separately (see OnRightClick).
+	// The whole selection, but only when the row clicked is part of it: the rule a
+	// file manager follows, since right-clicking outside a selection addresses the
+	// row under the pointer. A right-click does not select on every platform, which
+	// is why m_contextFolder is remembered separately (see OnRightClick).
 	bool clicked_is_selected = false;
 	for (const wxDataViewItem &item : selection) {
 		if (item == m_contextFolder) {
@@ -1019,12 +993,10 @@ void CSearchListCtrl::OnRelatedSearch(wxCommandEvent &WXUNUSED(event))
 
 void CSearchListCtrl::BuildDisplayOrder(std::vector<CSearchFile *> &ordered) const
 {
-	// The model yields top-level rows in arrival order, so they are put
-	// through this list's own comparator -- the one CSearchListModel::
-	// Compare() uses -- to match what is actually on screen under the
-	// current sort. GetItemByRow()/GetRowByItem() would be the direct
-	// route but exist only in wx's generic implementation, not on GTK or
-	// macOS.
+	// The model yields top-level rows in arrival order, so they go through this
+	// list's own comparator -- the one CSearchListModel::Compare() uses -- to match
+	// what is on screen under the current sort. GetItemByRow()/GetRowByItem() would
+	// be the direct route but exist only in wx's generic implementation.
 	const auto byDisplayOrder = [this](const CSearchFile *f1, const CSearchFile *f2) {
 		return CompareFiles(f1, f2) < 0;
 	};
@@ -1039,11 +1011,9 @@ void CSearchListCtrl::BuildDisplayOrder(std::vector<CSearchFile *> &ordered) con
 	}
 	std::sort(parents.begin(), parents.end(), byDisplayOrder);
 
-	// An expanded group's children occupy rows of their own, so they belong
-	// here too: callers count rows against what is on screen (a page is
-	// GetCountPerPage() rows, children included) and select ranges of them.
-	// Leaving them out made a page overshoot and skipped every child inside
-	// the range.
+	// An expanded group's children occupy rows of their own, so they belong here
+	// too: callers count rows against what is on screen and select ranges of them.
+	// Leaving them out made a page overshoot and skipped every child in the range.
 	ordered.clear();
 	ordered.reserve(parents.size());
 	for (CSearchFile *parent : parents) {
@@ -1079,31 +1049,27 @@ void CSearchListCtrl::DownloadSelected(int category)
 	FindWindowById(IDC_SDOWNLOAD)->Enable(false);
 
 	// -1 means "no explicit category", i.e. anything but the right-click
-	// "Download in category" action, which passes one and must keep winning.
-	// The panel's selector used to be read only while the Extended Parameters
-	// checkbox was ticked, because it lived inside that row -- so unticking the
-	// row to reclaim the screen space silently sent the download to Main
-	// instead (issue #979). The selector now sits beside the Download button
-	// and is always visible, so what the user can see is what gets used.
+	// "Download in category" action, which passes one and must keep winning. The
+	// panel's selector used to be read only while the Extended Parameters checkbox
+	// was ticked, because it lived inside that row, so unticking the row silently
+	// sent the download to Main instead (issue #979).
 	if (category == -1) {
 		category = CastByID(ID_AUTOCATASSIGN, NULL, wxChoice)->GetSelection();
 	}
 
 #ifndef CLIENT_GUI
-	// Monolithic: Search_Add_Download runs synchronously on this thread, so
-	// each selected file's Notify_DownloadCtrlAddFile -> AddFile fires a
-	// per-item resort inline. Batch the whole selection into a single sort
-	// + repaint (issue #615). The remote GUI's adds arrive later via the
-	// download-queue poll, which already batches, so this is monolithic-only.
+	// Monolithic: Search_Add_Download runs synchronously on this thread, so each
+	// file's Notify_DownloadCtrlAddFile -> AddFile fires a per-item resort inline.
+	// Batch the selection into a single sort + repaint (issue #615). The remote
+	// GUI's adds arrive via the download-queue poll, which already batches.
 	CDownloadListCtrl *downloadlist = theApp->amuledlg->m_transferwnd->downloadlistctrl;
 	downloadlist->BeginBatchUpdate();
 #endif
 
 	for (CSearchFile *file : GetSelectedFiles()) {
-		// Exempt from "Hide Known Files" before queueing, so the row
-		// survives the status change this is about to cause. Results are
-		// only grouped when their hashes match (CSearchList::AddResult), so
-		// the one insert covers a group's variants along with its parent.
+		// Exempt from "Hide Known Files" before queueing, so the row survives the
+		// status change this is about to cause. Results are grouped only when
+		// their hashes match, so the one insert covers a group's variants too.
 		m_userQueued.insert(file->GetFileHash());
 		CoreNotify_Search_Add_Download(file, category);
 	}

--- a/src/SearchListModel.h
+++ b/src/SearchListModel.h
@@ -84,11 +84,10 @@ public:
 	 */
 	unsigned GetContentGeneration() const noexcept { return m_contentGeneration; }
 
-	//! Forces the next flush to be a full Cleared(). Group formation needs
-	//! one: making an existing result a container leaves the control's tree
-	//! inconsistent on GTK/MSW under any incremental notification (got3nks,
-	//! PR #796 review, after ItemChanged() and delete+re-add both failed to
-	//! make those backends re-derive container-ness).
+	//! Forces the next flush to be a full Cleared(). Group formation needs one:
+	//! making an existing result a container leaves the control's tree inconsistent
+	//! on GTK/MSW under any incremental notification -- ItemChanged() and
+	//! delete+re-add both failed to make those backends re-derive container-ness.
 	void MarkDirty()
 	{
 		m_pendingReset = true;
@@ -150,8 +149,7 @@ public:
 	}
 
 	//! Column indices, matching the wxDataViewColumn order set up by
-	//! CSearchListCtrl -- shared with CSearchListCtrl::SortProc-equivalent
-	//! Compare() logic below.
+	//! CSearchListCtrl and shared with the Compare() logic below.
 	enum Column
 	{
 		COL_NAME = 0,

--- a/src/ServerConnect.cpp
+++ b/src/ServerConnect.cpp
@@ -94,16 +94,14 @@ void CServerConnect::TryAnotherConnectionrequest()
 							    ? _("Failed to connect to all static servers "
 								"listed.")
 							    : _("Failed to connect to all servers listed."));
-					// Wait before starting over instead of restarting the sweep
-					// here. Every server having failed says nothing about when
-					// one will answer, and with the link down they all fail the
-					// moment they are tried -- so the immediate restart this
-					// replaces meant a full pass per second, for as long as the
-					// outage lasted. The same timer the CS_FATALERROR path uses,
-					// so a caller that switched auto-reconnect off now gets what
-					// it asked for here too; it never consulted the setting
-					// before. StopConnectionTry() first: it stops the timer, so
-					// arming it earlier would be undone.
+					// Wait before starting over rather than restarting the sweep here.
+					// Every server having failed says nothing about when one will
+					// answer, and with the link down they all fail the moment they are
+					// tried -- so the immediate restart this replaces meant a full pass
+					// per second for as long as the outage lasted. The same timer the
+					// CS_FATALERROR path uses, so a caller that switched auto-reconnect
+					// off gets what it asked for. StopConnectionTry() first, since it
+					// stops the timer and would undo an earlier arm.
 					StopConnectionTry();
 					if (thePrefs::Reconnect()) {
 						AddLogLineN(
@@ -204,10 +202,10 @@ void CServerConnect::StopConnectionTry()
 	connectionattemps.clear();
 	connecting = false;
 	singleconnecting = false;
-	// Every sweep ends here, so this is where the DNS evidence expires. Outside
-	// a sweep there is nothing to have proved the resolver works, and a manual
-	// connect judged on a sweep that ran while the link was up would blame a
-	// name that cannot resolve now -- three of those delete the server.
+	// Every sweep ends here, so this is where the DNS evidence expires. Outside a
+	// sweep nothing has proved the resolver works, and a manual connect judged on a
+	// sweep that ran while the link was up would blame a name that cannot resolve
+	// now -- three of those delete the server.
 	m_hostnameResolvedThisSweep = false;
 
 	if (m_idRetryTimer.IsRunning()) {
@@ -237,15 +235,12 @@ void CServerConnect::ConnectionEstablished(CServerSocket *sender)
 		AddLogLineN(CFormat(_("Connected to %s (%s:%i)")) % sender->cur_server->GetListName() %
 			    sender->cur_server->GetFullIP() % sender->cur_server->GetPort());
 
-		// A new server connection is the moment our outward-facing address is
-		// most likely to have just changed -- a reconnect after a link came
-		// back up lands here. Peers reached through this connection will start
-		// telling us what address they see, and their claims are only ever
-		// believed against the set published here, so it has to be current
-		// before the first hello arrives.
+		// A new server connection is the moment our outward-facing address is most
+		// likely to have just changed -- a reconnect after a link came back up lands
+		// here. Peers reached through it will start telling us what address they see,
+		// and their claims are only believed against the set published here.
 		RefreshLocalPublicIPv6Addresses();
 
-		// send loginpacket
 		CServer *update = theApp->serverlist->GetServerByAddress(
 			sender->cur_server->GetAddress(), sender->cur_server->GetPort());
 		if (update) {
@@ -377,7 +372,6 @@ void CServerConnect::ConnectionFailed(CServerSocket *sender)
 		// just return, cleanup is done by the socket itself
 		return;
 	}
-	// messages
 	CServer *pServer = theApp->serverlist->GetServerByAddress(
 		sender->cur_server->GetAddress(), sender->cur_server->GetPort());
 	switch (sender->GetConnectionState()) {
@@ -554,7 +548,6 @@ CServerConnect::CServerConnect(CServerList *in_serverlist, amuleIPV4Address &add
 	m_bTryObfuscated = thePrefs::IsServerCryptLayerTCPRequested();
 	m_hostnameResolvedThisSweep = false;
 
-	// initialize socket for udp packets
 	if (thePrefs::GetNetworkED2K()) {
 		serverudpsocket = new CServerUDPSocket(address, thePrefs::GetProxyData());
 	} else {
@@ -565,12 +558,9 @@ CServerConnect::CServerConnect(CServerList *in_serverlist, amuleIPV4Address &add
 CServerConnect::~CServerConnect()
 {
 	m_idRetryTimer.Stop();
-	// stop all connections
 	StopConnectionTry();
-	// close connected socket, if any
 	DestroySocket(connectedsocket);
 	connectedsocket = NULL;
-	// close udp socket
 	delete serverudpsocket;
 }
 
@@ -619,11 +609,10 @@ bool CServerConnect::IsServerIP(uint32 ip) const
 	if (connectedsocket && connectedsocket->cur_server && connectedsocket->cur_server->GetIP() == ip) {
 		return true;
 	}
-	// Then any login still in flight.  m_lstOpenSockets includes
-	// connectedsocket too, but the early-out above keeps the common
-	// case to a single pointer chase; the loop only runs when we're
-	// actively trying multiple servers in parallel, which is bounded
-	// by max_simcons (typically 2-3) so it's negligible.
+	// Then any login still in flight. m_lstOpenSockets includes connectedsocket
+	// too, but the early-out above keeps the common case to a single pointer chase;
+	// the loop only runs while several servers are being tried in parallel, bounded
+	// by max_simcons.
 	for (SocketsList::const_iterator it = m_lstOpenSockets.begin(); it != m_lstOpenSockets.end(); ++it) {
 		const CServerSocket *sock = *it;
 		if (sock && sock->cur_server && sock->cur_server->GetIP() == ip) {

--- a/src/ServerList.cpp
+++ b/src/ServerList.cpp
@@ -63,20 +63,18 @@ CServerList::CServerList()
 
 bool CServerList::Init()
 {
-	// Load Metfile
 	bool bRes = LoadServerMet(CPath(thePrefs::GetConfigDir() + "server.met"));
 
 	// insert static servers from textfile
 	m_staticServersConfig = thePrefs::GetConfigDir() + "staticservers.dat";
 	LoadStaticServers();
 
-	// The HTTP auto-update of server.met used to be kicked from here, but
-	// that fires the libcurl request before the heavy local I/O (partfile
-	// load + shared-file scan) — the wxWebSession worker thread then
-	// competes with the saturated main thread for CPU, libcurl state
-	// machine advances less, and the DNS resolution can time out on
+	// The HTTP auto-update of server.met used to be kicked from here, but that
+	// fires the libcurl request before the heavy local I/O (partfile load +
+	// shared-file scan): the wxWebSession worker then competes with the saturated
+	// main thread, the curl state machine advances less, and DNS can time out on
 	// slower setups. The kick now lives in CamuleApp::OnInit() after
-	// sharedfiles->Reload() finishes. See StartAutoUpdate() / #714.
+	// sharedfiles->Reload() finishes (#714).
 
 	m_initialized = true;
 	return bRes;
@@ -99,7 +97,6 @@ bool CServerList::LoadServerMet(const CPath &path)
 		return false;
 	}
 
-	// Try to unpack the file, might be an archive
 	const char *mets[] = { "server.met", NULL };
 	// Try to unpack the file, might be an archive
 	if (UnpackArchive(path, mets).second != EFT_Met) {
@@ -140,7 +137,6 @@ bool CServerList::LoadServerMet(const CPath &path)
 
 			CServer *newserver = new CServer(&sbuffer);
 
-			// Load tags
 			for (uint32 i = 0; i < sbuffer.tagcount; ++i) {
 				newserver->AddTagFromFile(&servermet);
 			}
@@ -153,7 +149,6 @@ bool CServerList::LoadServerMet(const CPath &path)
 				newserver->SetPreference(SRV_PR_NORMAL);
 			}
 
-			// set listname for server
 			if (newserver->GetListName().IsEmpty()) {
 				newserver->SetListName("Server " + newserver->GetAddress());
 			}
@@ -501,14 +496,12 @@ void CServerList::LoadStaticServers()
 			name = addy;
 		}
 
-		// create server object and add it to the list
 		CServer *server = new CServer(StrToLong(port), host);
 
 		server->SetListName(name);
 		server->SetIsStaticMember(true);
 		server->SetPreference(priority);
 
-		// Try to add the server to the list
 		if (!theApp->AddServer(server)) {
 			delete server;
 			CServer *existing = GetServerByAddress(host, StrToULong(port));
@@ -568,10 +561,9 @@ struct ServerPriorityComparator
 void CServerList::Sort()
 {
 	m_servers.sort(ServerPriorityComparator());
-	// Once the list has been sorted, it doesn't really make sense to continue
-	// traversing the new order from the old position.  Plus, there's a bug in
-	// version of libstdc++ before gcc4 such that iterators that were equal to
-	// end() were left dangling.
+	// Once the list has been sorted, continuing to traverse the new order from the
+	// old position makes no sense -- and in libstdc++ before gcc4, iterators equal
+	// to end() were left dangling.
 	m_serverpos = m_servers.begin();
 	m_statserverpos = m_servers.begin();
 }
@@ -862,11 +854,9 @@ bool CServerList::DownloadFinished(uint32 result)
 	if (result == HTTP_Success) {
 		const CPath tempFilename = CPath(thePrefs::GetConfigDir() + "server.met.download");
 
-		// curl succeeded. proceed with server.met loading
 		LoadServerMet(tempFilename);
 		SaveServerMet();
 
-		// So, file is loaded and merged, and also saved
 		CPath::RemoveFile(tempFilename);
 		AddLogLineN(CFormat(_("Finished downloading the server list from %s")) % m_URLUpdate);
 		ret = true;
@@ -893,15 +883,13 @@ void CServerList::AutoUpdate()
 	// Do current URL. Callback function will take care of the others.
 	while (current_url_index < url_count) {
 		wxString URI = theApp->glob_prefs->addresses_list[current_url_index];
-		// wxURL only registers protocol handlers for http and ftp, so
-		// any https URL would come back as wxURL_NOPROTO and be rejected
-		// here — but the download itself goes through wxWebRequest,
-		// which handles https fine (#714). Validate with wxURI (RFC
-		// 3986 parser) + an explicit scheme check instead.
+		// wxURL only registers protocol handlers for http and ftp, so any https URL
+		// would come back as wxURL_NOPROTO and be rejected -- while the download
+		// itself goes through wxWebRequest, which handles https fine (#714).
+		// Validate with wxURI plus an explicit scheme check instead.
 		wxURI uri(URI);
 		const wxString scheme = uri.HasScheme() ? uri.GetScheme().Lower() : wxString();
 		if (uri.HasServer() && (scheme == "http" || scheme == "https")) {
-			// Ok, got a valid URI
 			m_URLUpdate = URI;
 			wxString strTempFilename = thePrefs::GetConfigDir() + "server_auto.met";
 			AddLogLineC(CFormat(_("Start downloading server list from %s")) % URI);
@@ -931,11 +919,9 @@ void CServerList::AutoDownloadFinished(uint32 result)
 	if (result == HTTP_Success) {
 		CPath tempFilename = CPath(thePrefs::GetConfigDir() + "server_auto.met");
 
-		// curl succeeded. proceed with server.met loading
 		LoadServerMet(tempFilename);
 		SaveServerMet();
 
-		// So, file is loaded and merged, and also saved
 		CPath::RemoveFile(tempFilename);
 	} else {
 		AddLogLineC(CFormat(_("Failed to download the server list from %s")) % m_URLUpdate);
@@ -944,7 +930,6 @@ void CServerList::AutoDownloadFinished(uint32 result)
 	++current_url_index;
 
 	if (current_url_index < theApp->glob_prefs->addresses_list.GetCount()) {
-		// Next!
 		AutoUpdate();
 	}
 }
@@ -976,11 +961,9 @@ uint32 CServerList::GetAvgFile() const
 			totalfile += curr->GetFiles();
 		}
 	}
-	// If the user count is a little low, don't send back a average..
-	// I added 50 to the count as many servers do not allow a large amount of files to be shared..
-	// Therefore the estimate here will be lower then the actual.
-	// I would love to add a way for the client to send some statistics back so we could see the real
-	// values here..
+	// If the user count is a little low, do not send back an average. 50 is added
+	// to the count because many servers do not allow a large number of files to be
+	// shared, so the estimate here is lower than the actual.
 	if (totaluser > 500000) {
 		return (totalfile / totaluser) + 50;
 	} else {

--- a/src/ServerListCtrl.cpp
+++ b/src/ServerListCtrl.cpp
@@ -123,10 +123,9 @@ CServerListCtrl::CServerListCtrl(wxWindow *parent,
 	ApplySorting(COLUMN_SERVER_NAME, 0);
 
 #ifndef __DEBUG__
-	// Wire-flag columns are diagnostics: listed in the header menu so they
-	// can be switched on, hidden by default. Set before the settings are
-	// loaded, so anything the user saved wins -- the same ordering the old
-	// InsertColumn()/SetColumnWidth(0)/LoadSettings() sequence had.
+	// Wire-flag columns are diagnostics: listed in the header menu so they can be
+	// switched on, hidden by default. Set before the settings are loaded, so
+	// anything the user saved wins.
 	SetColumnHidden(COLUMN_SERVER_TCPFLAGS, true, 0);
 	SetColumnHidden(COLUMN_SERVER_UDPFLAGS, true, 0);
 #endif
@@ -167,10 +166,10 @@ void CServerListCtrl::RemoveServer(CServer *server)
 
 void CServerListCtrl::RemoveAllServers(bool selectedOnly)
 {
-	// Collect first, delete second: the rows are a view onto the model, so
-	// removing one renumbers every row below it -- and the confirmations below
-	// run a nested event loop, during which the list can be updated underneath
-	// a row index but never underneath a server pointer.
+	// Collect first, delete second: the rows are a view onto the model, so removing
+	// one renumbers every row below it -- and the confirmations below run a nested
+	// event loop, during which the list can be updated underneath a row index but
+	// never underneath a server pointer.
 	std::vector<CServer *> candidates;
 	if (selectedOnly) {
 		for (wxUIntPtr data : GetSelectedItemData()) {
@@ -214,10 +213,9 @@ void CServerListCtrl::RemoveAllServers(bool selectedOnly)
 		}
 
 		// Drop the row before asking for the removal, not as a result of it:
-		// amulegui's CServerListRem::RemoveServer() only sends an EC command,
-		// so the row would otherwise linger until the core's next update. In
-		// the monolithic build the resulting Notify_ServerRemove() comes back
-		// here and finds the row already gone.
+		// amulegui's CServerListRem::RemoveServer() only sends an EC command, so the
+		// row would otherwise linger until the core's next update. In the monolithic
+		// build the resulting Notify_ServerRemove() finds the row already gone.
 		RemoveServer(server);
 		theApp->serverlist->RemoveServer(server);
 	}
@@ -227,7 +225,6 @@ void CServerListCtrl::RemoveAllServers(bool selectedOnly)
 
 void CServerListCtrl::RefreshServer(CServer *server)
 {
-	// Can't really refresh a NULL server
 	if (!server) {
 		return;
 	}
@@ -239,7 +236,6 @@ void CServerListCtrl::RefreshServer(CServer *server)
 		// changed, the re-sort the base class coalesces for us.
 		RefreshItemData(ptr);
 	} else {
-		// We are not sure that the server isn't in the list, so we can re-add
 		AddItemData(ptr);
 	}
 }
@@ -271,14 +267,11 @@ wxString CServerListCtrl::GetItemColumnText(wxUIntPtr item, unsigned column) con
 			return wxEmptyString;
 		}
 		// GetPing() is already milliseconds (a GetTickCount64() delta), and
-		// milliseconds is how latency is written everywhere else -- including
-		// our own REST API, which publishes it as "ping_ms". It used to go
-		// through CastSecondsToHM(), a general duration helper whose
-		// sub-minute branch prints "0.203 secs" (issue #823).
-		// The unit is translated: it is not written "ms" everywhere -- ru and
-		// uk use "мс", and it is localised in zh and ja too -- and the number
-		// is kept out of the catalog entry the way CastSecondsToHM() keeps it
-		// out of _("secs") and _("mins").
+		// milliseconds is how latency is written everywhere else, including our own
+		// REST API's "ping_ms". It used to go through CastSecondsToHM(), whose
+		// sub-minute branch prints "0.203 secs" (issue #823). The unit is translated
+		// because it is not written "ms" everywhere, and the number is kept out of
+		// the catalog entry.
 		return CFormat("%u %s") % server->GetPing() % _("ms");
 
 	case COLUMN_SERVER_USERS:
@@ -287,10 +280,9 @@ wxString CServerListCtrl::GetItemColumnText(wxUIntPtr item, unsigned column) con
 		}
 		return CFormat("%u") % server->GetUsers();
 
-	// Zero means "the server never told us", not "the limit is zero" -- these
-	// only arrive once a UDP status reply has come back, so a freshly added or
-	// UDP-silent server has nothing to show. Rendering that as 0 would read as
-	// a real limit of zero, so it stays blank, as Users and Files do.
+	// Zero means "the server never told us", not "the limit is zero": these only
+	// arrive once a UDP status reply has come back, so a freshly added or UDP-silent
+	// server has nothing to show and stays blank, as Users and Files do.
 	case COLUMN_SERVER_SOFTFILES:
 		if (!server->GetSoftFiles()) {
 			return wxEmptyString;
@@ -401,15 +393,13 @@ wxString CServerListCtrl::GetItemColumnText(wxUIntPtr item, unsigned column) con
 	}
 }
 
-// Gated with its only caller (OnGetItemColumnImage below): this reaches
-// theApp->GetCountryFlags(), which only exists under GEOIP_GUI, so compiling it
-// unconditionally broke the monolithic build at -DENABLE_IP2COUNTRY=NO.
+// Gated with its only caller: this reaches theApp->GetCountryFlags(), which only
+// exists under GEOIP_GUI, so compiling it unconditionally broke the monolithic
+// build at -DENABLE_IP2COUNTRY=NO.
 //
 // Only the definition is gated, not the declaration: GEOIP_GUI is #defined in
-// amule.h, which this file includes but ServerListCtrl.h does not -- so the
-// header cannot see the macro and gating it there would compile the
-// declaration out from under this definition. A member function that is
-// declared, never called and never defined is fine.
+// amule.h, which this file includes but ServerListCtrl.h does not, so gating it
+// there would compile the declaration out from under this definition.
 #ifdef GEOIP_GUI
 const wxIcon &CServerListCtrl::FlagIcon(const wxString &code) const
 {
@@ -516,11 +506,9 @@ void CServerListCtrl::ShowServerCount()
 
 void CServerListCtrl::FitColumnsToContent()
 {
-	// Only size a profile that has no widths of its own. Both callers -- the
-	// core's bulk-load notification and the remote GUI's first populated update
-	// -- run after LoadColumnSettings() has restored whatever was saved, so
-	// fitting unconditionally would overwrite a width the user had dragged.
-	// Harmless while drags were never persisted; not any more.
+	// Only size a profile that has no widths of its own. Both callers run after
+	// LoadColumnSettings() has restored whatever was saved, so fitting
+	// unconditionally would overwrite a width the user had dragged.
 	if (HasPersistedColumnWidths()) {
 		return;
 	}
@@ -531,10 +519,9 @@ void CServerListCtrl::FitColumnsToContent()
 	const int descMaxWidth = 300;
 
 	// Content is measured against the model rather than asked of the control:
-	// wxDataViewCtrl has no portable "size this column to its contents", and
-	// on a list that renders cells on demand there is nothing native to
-	// measure anyway. The margins reproduce what the old wxLIST_AUTOSIZE
-	// produced, so columns land where users are used to seeing them.
+	// wxDataViewCtrl has no portable "size this column to its contents", and on a
+	// list that renders cells on demand there is nothing native to measure. The
+	// margins reproduce what the old wxLIST_AUTOSIZE produced.
 	const int autosizeMargin = 10;
 	const int imageMargin = 5;
 	const int flagWidth = 16;
@@ -609,7 +596,6 @@ void CServerListCtrl::OnItemRightClicked(wxDataViewEvent &event)
 	bool enable_static_on = false;
 	bool enable_static_off = false;
 
-	// Gather information on the selected items
 	for (wxUIntPtr data : GetSelectedItemData()) {
 		CServer *server = reinterpret_cast<CServer *>(data);
 
@@ -801,11 +787,9 @@ int CServerListCtrl::CompareItemData(
 	const int mode = modifier;
 
 	switch (column) {
-	// Sort by server-name
 	case COLUMN_SERVER_NAME:
 		return mode * server1->GetListName().CmpNoCase(server2->GetListName());
 
-	// Sort by address
 	case COLUMN_SERVER_ADDR: {
 		if (server1->HasDynIP() && server2->HasDynIP()) {
 			return mode * server1->GetDynIP().CmpNoCase(server2->GetDynIP());
@@ -819,17 +803,14 @@ int CServerListCtrl::CompareItemData(
 			return mode * CmpAny(a, b);
 		}
 	}
-	// Sort by port
 	case COLUMN_SERVER_PORT:
 		return mode * CmpAny(server1->GetPort(), server2->GetPort());
-	// Sort by description
 	case COLUMN_SERVER_DESC:
 		return mode * server1->GetDescription().CmpNoCase(server2->GetDescription());
 	// Sort by Ping
 	// The -1 ensures that a value of zero (no ping known) is sorted last.
 	case COLUMN_SERVER_PING:
 		return mode * CmpAny(server1->GetPing() - 1, server2->GetPing() - 1);
-	// Sort by user-count
 	case COLUMN_SERVER_USERS:
 		return mode * CmpAny(server1->GetUsers(), server2->GetUsers());
 	case COLUMN_SERVER_SOFTFILES:
@@ -838,10 +819,8 @@ int CServerListCtrl::CompareItemData(
 		return mode * CmpAny(server1->GetHardFiles(), server2->GetHardFiles());
 	case COLUMN_SERVER_MAXUSERS:
 		return mode * CmpAny(server1->GetMaxUsers(), server2->GetMaxUsers());
-	// Sort by file-count
 	case COLUMN_SERVER_FILES:
 		return mode * CmpAny(server1->GetFiles(), server2->GetFiles());
-	// Sort by priority
 	case COLUMN_SERVER_PRIO: {
 		uint32 srv_pr1 = server1->GetPreferences();
 		uint32 srv_pr2 = server2->GetPreferences();
@@ -873,14 +852,11 @@ int CServerListCtrl::CompareItemData(
 		}
 		return mode * CmpAny(srv_pr1, srv_pr2);
 	}
-	// Sort by failure-count
 	case COLUMN_SERVER_FAILS:
 		return mode * CmpAny(server1->GetFailedCount(), server2->GetFailedCount());
-	// Sort by static servers
 	case COLUMN_SERVER_STATIC: {
 		return mode * CmpAny(server2->IsStaticMember(), server1->IsStaticMember());
 	}
-	// Sort by version
 	case COLUMN_SERVER_VERSION:
 		return mode * FuzzyStrCmp(server1->GetVersion(), server2->GetVersion());
 

--- a/src/ServerSocket.cpp
+++ b/src/ServerSocket.cpp
@@ -83,9 +83,8 @@ void CServerSocket::OnConnect(int nErrorCode)
 		if (cur_server->HasDynIP()) {
 			uint32 server_ip = GetPeerInt();
 			cur_server->SetID(server_ip);
-			// GetServerByAddress may return NULL, so we must test!
-			// This was the reason why amule would crash when trying to
-			// connect in wxWidgets 2.5.2
+			// GetServerByAddress may return NULL, so it must be tested: this was
+			// the reason aMule crashed when connecting under wxWidgets 2.5.2.
 			CServer *pServer = theApp->serverlist->GetServerByAddress(
 				cur_server->GetAddress(), cur_server->GetPort());
 			if (pServer) {
@@ -99,11 +98,10 @@ void CServerSocket::OnConnect(int nErrorCode)
 		SetConnectionState(CS_WAITFORLOGIN);
 		break;
 
-	// Only what the server itself answered counts against it, because
-	// CS_SERVERDEAD is what raises its failed count -- and a server whose
-	// count passes the "remove dead servers" threshold is deleted from the
-	// list for good. It refused the connection, or it accepted the SYN and
-	// then said nothing: either is evidence about that server.
+	// Only what the server itself answered counts against it, because CS_SERVERDEAD
+	// raises its failed count and a server past the "remove dead servers" threshold
+	// is deleted for good. A refused connection, or a SYN accepted in silence, is
+	// evidence about that server.
 	case boost::system::errc::connection_refused:
 	case boost::system::errc::timed_out:
 		m_bIsDeleting = true;
@@ -111,32 +109,25 @@ void CServerSocket::OnConnect(int nErrorCode)
 		serverconnect->DestroySocket(this);
 		return;
 
-	// Not counted against the server, but the sweep still carries on to the
-	// next candidate -- which is what separates these from the CS_FATALERROR
-	// default below.
+	// Not counted against the server, but the sweep carries on to the next
+	// candidate -- which is what separates these from the CS_FATALERROR default
+	// below.
 	//
-	// host_unreachable is the one that matters and the one that is ambiguous:
-	// a router can report it by ICMP for a remote host that genuinely no
-	// longer routes, so it is not purely a fault at our end. It is classified
-	// here anyway because of how it fails when it is ours: with the link down
-	// every server in the list answers that way within milliseconds, so the
-	// whole list used to accrue failures and then be deleted the moment
-	// connectivity returned -- RemoveDeadServers() only runs after a
-	// connection succeeds. A server that has genuinely stopped routing is
-	// still counted by the UDP status pings, which run while connected to
-	// some other server and have their own AddFailedCount(); it is no longer
-	// counted here, and the cost of the wrong call the other way is the list.
+	// host_unreachable is the ambiguous one: a router can report it by ICMP for a
+	// remote host that genuinely no longer routes. It is classified here anyway
+	// because of how it fails when the fault is ours: with the link down every
+	// server answers that way within milliseconds, so the whole list accrued
+	// failures and was deleted the moment connectivity returned --
+	// RemoveDeadServers() only runs after a connection succeeds. A server that has
+	// really stopped routing is still counted by the UDP status pings, which have
+	// their own AddFailedCount().
 	//
-	// The rest are unambiguous local socket faults -- an address in use or not
-	// available, a bad address, an invalid argument -- and were never about
-	// the server at all.
+	// The rest are unambiguous local socket faults and were never about the server.
 	//
-	// Deliberately not CS_FATALERROR: that one calls StopConnectionTry() and
-	// waits CS_RETRYCONNECTTIME before trying anything else, which is right
-	// when the whole network is gone (errc::network_unreachable and friends
-	// still land there, via default) but wrong for one unreachable host --
-	// a single stale entry would otherwise stall the sweep for 30 seconds
-	// instead of aMule moving on to the next server.
+	// Deliberately not CS_FATALERROR: that calls StopConnectionTry() and waits
+	// CS_RETRYCONNECTTIME, which is right when the whole network is gone
+	// (network_unreachable and friends still land there via default) but wrong for
+	// one unreachable host, where a stale entry would stall the sweep for 30 s.
 	case boost::system::errc::address_in_use:
 	case boost::system::errc::address_not_available:
 	case boost::system::errc::bad_address:
@@ -352,15 +343,13 @@ bool CServerSocket::ProcessPacket(const uint8_t *packet, uint32 size, int8 opcod
 						thePrefs::SetSmartIdState(state);
 					}
 				}
-				// The server explicitly assigned no client ID -- it
-				// gave up on its HighID-callback verification before
-				// we could complete it.  Pre-fix this silently broke
-				// out of OP_IDCHANGE without ever calling
-				// SetConnectionState(CS_CONNECTED), leaving the socket
-				// in limbo until the 15 s client-side timeout fired
-				// (#778).  Disconnect explicitly so the failure is
-				// surfaced as a clear log line and the next retry
-				// starts immediately instead of after the silent wait.
+				// The server explicitly assigned no client ID: it gave up on
+				// its HighID-callback verification before we could complete it.
+				// This used to break out of OP_IDCHANGE without ever calling
+				// SetConnectionState(CS_CONNECTED), leaving the socket in limbo
+				// until the 15 s client-side timeout fired (#778). Disconnect
+				// explicitly so the failure is logged and the next retry starts
+				// immediately.
 				AddLogLineC(
 					CFormat(_("Server %s (%s) rejected our login (no client ID "
 						  "assigned). Disconnecting.")) %
@@ -496,21 +485,14 @@ bool CServerSocket::ProcessPacket(const uint8_t *packet, uint32 size, int8 opcod
 
 				uint32 nTags = data.ReadUInt32();
 				for (uint32 i = 0; i < nTags; i++) {
-					// Force Unicode=true rather than relying on the
-					// server's SRV_TCPFLG_UNICODE bit: many
-					// real-world servers ship UTF-8 strings (emoji
-					// in names, non-ASCII descriptions) without
-					// advertising the capability flag, and parsing
-					// those bytes as non-Unicode mangles them.
-					// Matches the hardcoded Unicode=true already
-					// used for search-result parsing at the top
-					// of this file. The .met-file parse path
-					// (Server.cpp::AddTagFromFile) also uses
-					// hardcoded Unicode=true, so this aligns the
-					// runtime update with the load-time read and
-					// stops the "name correct on first display,
-					// garbled a few seconds later" regression.
-					// (#831)
+					// Force Unicode=true rather than relying on the server's
+					// SRV_TCPFLG_UNICODE bit: many real-world servers ship
+					// UTF-8 strings without advertising the capability, and
+					// parsing those bytes as non-Unicode mangles them. Matches
+					// the hardcoded Unicode=true used for search-result parsing
+					// and by the .met-file parse path, which is what stops the
+					// "name correct on first display, garbled a few seconds
+					// later" regression (#831).
 					CTag tag(data, true);
 					if (tag.GetNameID() == ST_SERVERNAME) {
 						update->SetListName(tag.GetStr());
@@ -528,11 +510,9 @@ bool CServerSocket::ProcessPacket(const uint8_t *packet, uint32 size, int8 opcod
 		case OP_SERVERLIST: {
 			AddDebugLogLineN(logServer, "Server: OP_SERVERLIST");
 
-			// Stack-allocated wrapper so a CEOFException out of any
-			// of the ReadUInt* calls below (empty or truncated
-			// payload from a malicious server) doesn't leak it on
-			// the way out to the function-level catch block at the
-			// end of ProcessPacket (#885).
+			// Stack-allocated wrapper so a CEOFException out of any of the
+			// ReadUInt* calls below (an empty or truncated payload from a
+			// malicious server) cannot leak it on the way out (#885).
 			CMemFile servers(packet, size);
 			uint8 count = servers.ReadUInt8();
 			if (((int32)(count * 6 + 1) > size)) {
@@ -760,10 +740,9 @@ void CServerSocket::OnHostnameResolved(uint32 ip)
 {
 
 	// ConnectToServer() calls straight in here with the address it already had
-	// whenever no lookup was needed, which is most of server.met -- and that
-	// path succeeds just as well with the link down. Only a resolver that
-	// actually answered is evidence about DNS, so record what got us here
-	// before the flag is cleared.
+	// whenever no lookup was needed, which is most of server.met, and that path
+	// succeeds just as well with the link down. Only a resolver that actually
+	// answered is evidence about DNS, so record what got us here.
 	const bool didLookup = m_IsSolving;
 	m_IsSolving = false;
 	if (ip) {
@@ -814,16 +793,14 @@ void CServerSocket::OnHostnameResolved(uint32 ip)
 		// resolve is not a socket error, and the two want opposite answers.
 		//
 		// An unresolvable hostname is the commonest way an eD2k server actually
-		// dies, so this is the main thing "remove dead servers" prunes on, and
-		// it has to keep working. But with the link down nothing resolves, and
-		// counting that against every server in turn is what emptied the list
-		// (issue #887). Blame it only once DNS has answered for something else
-		// this sweep -- then the failure is about this server, not about us.
+		// dies, so it is the main thing "remove dead servers" prunes on. But with
+		// the link down nothing resolves, and counting that against every server in
+		// turn is what emptied the list (issue #887). Blame it only once DNS has
+		// answered for something else this sweep.
 		//
-		// The first server in a sweep therefore cannot be blamed, since nothing
-		// has resolved yet; a genuinely dead entry is caught on a later sweep
-		// instead. Erring that way costs a delay, while erring the other way
-		// costs the server list.
+		// The first server in a sweep therefore cannot be blamed; a genuinely dead
+		// entry is caught on a later one. Erring that way costs a delay, while
+		// erring the other way costs the server list.
 		m_bIsDeleting = true;
 		SetConnectionState(serverconnect->HostnameResolvedThisSweep() ? CS_SERVERDEAD : CS_ERROR);
 		serverconnect->DestroySocket(this);

--- a/src/ServerUDPSocket.cpp
+++ b/src/ServerUDPSocket.cpp
@@ -124,14 +124,12 @@ void CServerUDPSocket::ProcessPacket(CMemFile &packet, uint8 opcode, uint32 ip, 
 			port % opcode);
 
 	try {
-		// Imported: OP_GLOBSEARCHRES, OP_GLOBFOUNDSOURCES & OP_GLOBSERVSTATRES
-		// This makes Server UDP Flags to be set correctly so we use less bandwidth on asking servers
-		// for sources Also we process Search results and Found sources correctly now on 16.40
-		// behaviour.
+		// Imported: OP_GLOBSEARCHRES, OP_GLOBFOUNDSOURCES and OP_GLOBSERVSTATRES.
+		// This sets the server UDP flags correctly, so less bandwidth is spent asking
+		// servers for sources, and search results and found sources are processed as
+		// 16.40 does.
 		switch (opcode) {
 		case OP_GLOBSEARCHRES: {
-
-			// process all search result packets
 
 			do {
 				theApp->searchlist->ProcessUDPSearchAnswer(packet, true, ip, port - 4);
@@ -184,7 +182,6 @@ void CServerUDPSocket::ProcessPacket(CMemFile &packet, uint8 opcode, uint32 ip, 
 		}
 
 		case OP_GLOBSERVSTATRES: {
-			// Reviewed with 0.47c
 			if (!update) {
 				throw wxString(
 					CFormat("Unknown server on a OP_GLOBSERVSTATRES packet (%s:%d)") %
@@ -253,19 +250,17 @@ void CServerUDPSocket::ProcessPacket(CMemFile &packet, uint8 opcode, uint32 ip, 
 
 			update->SetLastDescPingedCount(false);
 			if (update->GetLastDescPingedCount() < 2) {
-				// eserver 16.45+ supports a new OP_SERVER_DESC_RES answer, if the
-				// OP_SERVER_DESC_REQ contains a uint32 challenge, the server returns
-				// additional info with OP_SERVER_DESC_RES. To properly distinguish the old
-				// and new OP_SERVER_DESC_RES answer, the challenge has to be selected
-				// carefully. The first 2 bytes of the challenge (in network byte order) MUST
-				// NOT be a valid string-len-int16!
+				// eserver 16.45+ answers OP_SERVER_DESC_REQ with extra info when the
+				// request carries a uint32 challenge. To tell the old and new
+				// OP_SERVER_DESC_RES apart, the challenge has to be chosen carefully:
+				// its first 2 bytes, in network byte order, MUST NOT be a valid
+				// string-len-int16.
 				CPacket *sendpacket = new CPacket(OP_SERVER_DESC_REQ, 4, OP_EDONKEYPROT);
 				uint32 uDescReqChallenge =
 					((uint32)GetRandomUint16() << 16) +
 					INV_SERV_DESC_LEN; // 0xF0FF = an 'invalid' string length.
 				update->SetDescReqChallenge(uDescReqChallenge);
 				sendpacket->CopyUInt32ToDataBuffer(uDescReqChallenge);
-				// theStats.AddUpDataOverheadServer(packet->size);
 				AddDebugLogLineN(logServerUDP,
 					CFormat(">>> Sending OP__ServDescReq     to server %s:%u, challenge "
 						"%08x\n") %
@@ -279,7 +274,6 @@ void CServerUDPSocket::ProcessPacket(CMemFile &packet, uint8 opcode, uint32 ip, 
 			break;
 		}
 		case OP_SERVER_DESC_RES: {
-			// Reviewed with 0.47c
 			if (!update) {
 				throw(wxString("Received OP_SERVER_DESC_RES from an unknown server"));
 			}
@@ -304,15 +298,11 @@ void CServerUDPSocket::ProcessPacket(CMemFile &packet, uint8 opcode, uint32 ip, 
 
 					uint32 uTags = packet.ReadUInt32();
 					for (uint32 i = 0; i < uTags; ++i) {
-						// Force Unicode=true rather than relying on the
-						// server's SRV_TCPFLG_UNICODE bit: many real-world
-						// servers ship UTF-8 strings (emoji in names,
-						// non-ASCII descriptions) without advertising the
-						// capability flag, and parsing as non-Unicode
-						// mangles them. The OP_SERVERIDENT handler in
-						// ServerSocket.cpp does the same, and the .met
-						// load-time parse uses hardcoded Unicode=true.
-						// (#831)
+						// Force Unicode=true rather than relying on the server's
+						// SRV_TCPFLG_UNICODE bit: many real-world servers ship
+						// UTF-8 strings without advertising the capability, and
+						// parsing as non-Unicode mangles them. The OP_SERVERIDENT
+						// handler and the .met load-time parse do the same (#831).
 						CTag tag(packet, true);
 						switch (tag.GetNameID()) {
 						case ST_SERVERNAME:
@@ -342,12 +332,10 @@ void CServerUDPSocket::ProcessPacket(CMemFile &packet, uint8 opcode, uint32 ip, 
 						}
 					}
 				} else {
-					// A server sent us a new server description packet (including a
-					// challenge) although we did not ask for it. This may happen, if
-					// there are multiple servers running on the same machine with
-					// multiple IPs. If such a server is asked for a description, the
-					// server will answer 2 times, but with the same IP. ignore this
-					// packet
+					// A server sent a new-style description packet, with a challenge,
+					// although we did not ask for one. That happens when several servers
+					// run on one machine with multiple IPs: asked for a description, such
+					// a server answers twice from the same IP. Ignore this packet.
 				}
 			} else {
 				update->SetDescription(packet.ReadString(update->GetUnicodeSupport()));

--- a/src/ServerWnd.cpp
+++ b/src/ServerWnd.cpp
@@ -71,13 +71,12 @@ enum
 	kInfoListMenuCopy = wxID_HIGHEST + 1
 };
 
-// Column layout of both info lists. Column 0 is an empty spacer that exists
-// only to inset the labels: wxListCtrl has no counterpart to Scintilla's
-// SetMarginLeft, and the left cell padding comes from the platform theme, so
-// on a theme that sets none the text is drawn hard against the frame (issue
-// #702). A fixed narrow column is the one way to get that inset identically
-// on every port. Its width matches CMuleLogCtrl's text margin so the info
-// panes line up with the log panes beside them in the same notebook.
+// Column layout of both info lists. Column 0 is an empty spacer that exists only
+// to inset the labels: wxListCtrl has no counterpart to Scintilla's
+// SetMarginLeft, and the left cell padding comes from the platform theme, so on a
+// theme that sets none the text is drawn hard against the frame (issue #702). Its
+// width matches CMuleLogCtrl's text margin, so the info panes line up with the
+// log panes beside them.
 enum
 {
 	kInfoSpacerCol = 0,
@@ -86,14 +85,13 @@ enum
 };
 
 // Matches CMuleLogCtrl's FromDIP(5) text margin. Not DIP-scaled here: a
-// wxListCtrl column width is set from a plain int and this control has no
-// FromDIP of its own in scope at the call site, so the value is the same
-// physical inset the log panes use at 100% scaling.
+// wxListCtrl column width is set from a plain int, so this is the same physical
+// inset the log panes use at 100% scaling.
 constexpr int kInfoSpacerWidth = 5;
 
-// Row helpers. InsertItem() writes column 0, which is now the spacer, so a
-// row is created empty and the label goes in explicitly -- keeping that in
-// one place rather than at each of the ~20 call sites.
+// Row helpers. InsertItem() writes column 0, which is the spacer, so a row is
+// created empty and the label goes in explicitly -- in one place rather than at
+// each of the ~20 call sites.
 void InfoInsertRow(wxListCtrl *list, long row, const wxString &label)
 {
 	list->InsertItem(row, wxEmptyString);
@@ -123,25 +121,19 @@ CServerWnd::CServerWnd(wxWindow *pParent /*=NULL*/, int splitter_pos)
 	}
 #endif
 
-	// init serverlist
-	// no use now. too early.
-
 	serverlistctrl = CastChild(ID_SERVERLIST, CServerListCtrl);
 
 	CastChild(ID_SRV_SPLITTER, wxSplitterWindow)->SetSashPosition(splitter_pos, true);
-	// Default gravity (0.0) anchors the sash to the top: when the
-	// main window resizes, the server list keeps its height and the
-	// log pane absorbs the extra space. The other amule splitters
-	// (Shared/Transfer/Messages) use the same default and don't
-	// suffer the layout-recalc storm during minimize/restore that
-	// gravity 0.5 produced on Mac and Windows (#334 reproductions).
+	// Default gravity (0.0) anchors the sash to the top: on a resize the server
+	// list keeps its height and the log pane absorbs the extra space. The other
+	// amule splitters use the same default and avoid the layout-recalc storm during
+	// minimize/restore that gravity 0.5 produced on Mac and Windows.
 	CastChild(IDC_NODESLISTURL, wxTextCtrl)->SetValue(thePrefs::GetKadNodesUrl());
 	CastChild(IDC_SERVERLISTURL, wxTextCtrl)->SetValue(thePrefs::GetEd2kServersUrl());
 
-	// Three columns, no header: an empty spacer that insets the labels (see
-	// kInfoSpacerCol), then label and value. Columns must exist before any row
-	// is inserted -- adding one to a populated wxListCtrl does not shift the
-	// existing per-row data across ports.
+	// Three columns, no header: an empty spacer that insets the labels, then label
+	// and value. Columns must exist before any row is inserted -- adding one to a
+	// populated wxListCtrl does not shift the existing per-row data across ports.
 	wxListCtrl *ED2KInfoList = CastChild(ID_ED2KINFO, wxListCtrl);
 	wxASSERT(ED2KInfoList);
 	ED2KInfoList->InsertColumn(kInfoSpacerCol, "");
@@ -255,7 +247,6 @@ void CServerWnd::UpdateED2KInfo()
 	if (theApp->IsConnectedED2K()) {
 		InfoSetValue(ED2KInfoList, 0, _("Connected"));
 
-		// Connection data
 		InfoInsertRow(ED2KInfoList, 1, _("IP:Port"));
 		InfoSetValue(ED2KInfoList,
 			1,
@@ -267,21 +258,18 @@ void CServerWnd::UpdateED2KInfo()
 		// No need to test the server connect, it's already true
 		InfoSetValue(ED2KInfoList, 2, CFormat("%u") % theApp->GetED2KID());
 
-		// Previously this row was inserted with an empty label and just
-		// "LowID"/"HighID" in column 1, leaving a value with no key.
-		// Give it an explicit label so the row is self-explanatory.
+		// This row used to be inserted with an empty label and just "LowID" /
+		// "HighID" in column 1, leaving a value with no key.
 		InfoInsertRow(ED2KInfoList, 3, _("Connection Type:"));
 		InfoSetValue(ED2KInfoList, 3, theApp->serverconnect->IsLowID() ? _("LowID") : _("HighID"));
 
 		// Carried over EC as EC_TAG_CONNSTATE's optional ED2K_CONNECTED_SINCE
-		// sub-tag (amule-org/amule#174), so this reads the same on amulegui
-		// as it does locally -- no CLIENT_GUI gate needed.
+		// sub-tag, so this reads the same on amulegui as locally.
 		if (theApp->GetED2KConnectedSince().IsValid()) {
 			InfoInsertRow(ED2KInfoList, 4, _("Connected since:"));
 			InfoSetValue(ED2KInfoList, 4, FormatLocalDateTime(theApp->GetED2KConnectedSince()));
 		}
 	} else {
-		// No data
 		InfoSetValue(ED2KInfoList, 0, _("Not Connected"));
 	}
 
@@ -303,7 +291,6 @@ void CServerWnd::UpdateKadInfo()
 			next_row++,
 			(theApp->IsKadRunningInLanMode() ? _("Running in LAN mode") : _("Running")));
 
-		// Connection data
 		InfoInsertRow(KadInfoList, next_row, _("Kademlia client ID:"));
 		InfoSetValue(KadInfoList, next_row++, theApp->GetKadID().ToHexString());
 		InfoInsertRow(KadInfoList, next_row, _("Status:"));
@@ -364,7 +351,6 @@ void CServerWnd::UpdateKadInfo()
 			InfoInsertRow(KadInfoList, next_row, _("IP address:"));
 			InfoSetValue(KadInfoList, next_row++, Uint32toStringIP(theApp->GetKadIPAddress()));
 
-			// Index info
 			InfoInsertRow(KadInfoList, next_row, _("Indexed sources:"));
 			InfoSetValue(KadInfoList, next_row++, CFormat("%d") % theApp->GetKadIndexedSources());
 			InfoInsertRow(KadInfoList, next_row, _("Indexed keywords:"));
@@ -382,27 +368,21 @@ void CServerWnd::UpdateKadInfo()
 			InfoSetValue(KadInfoList, next_row, CastItoIShort(theApp->GetKadFiles()));
 		}
 	} else {
-		// No data
 		InfoSetValue(KadInfoList, next_row, _("Not running"));
 	}
 
 	FitInfoListColumns(KadInfoList);
 }
 
-// Both info notebooks (ED2K Info, Kad Info) are two-column wxListCtrls
-// where column 0 holds short labels ("eD2k Status:", "Status:", ...) and
-// column 1 holds values that can grow wide (IP:port strings, hex client
-// IDs, firewall-state sentences). The previous code called
-// `SetColumnWidth(col, wxLIST_AUTOSIZE)` on both columns, which on
-// wxGTK ends up sizing column 1 to the *current* longest item in the
-// list -- and that was sometimes narrower than the actual content, so
-// the IP:Port value got truncated (#813) even though there was free
-// horizontal space in the panel.
+// Both info notebooks are two-column wxListCtrls where column 0 holds short
+// labels and column 1 holds values that can grow wide (IP:port strings, hex
+// client IDs, firewall-state sentences). Calling SetColumnWidth(col,
+// wxLIST_AUTOSIZE) on both sized column 1 to the CURRENT longest item on wxGTK,
+// which was sometimes narrower than the actual content, truncating the IP:Port
+// value (#813) with free horizontal space still in the panel.
 //
-// Pin column 0 to autosize (its content is short and predictable) and
-// let column 1 absorb whatever client width remains. Floored at a
-// reasonable minimum so the column stays usable while the panel is
-// being resized or before the first layout pass.
+// Pin column 0 to autosize, its content being short and predictable, and let
+// column 1 absorb whatever client width remains, floored at a usable minimum.
 /* static */
 void CServerWnd::FitInfoListColumns(wxListCtrl *list)
 {
@@ -464,9 +444,8 @@ void CServerWnd::CopyInfoListToClipboard(wxListCtrl *list)
 
 void CServerWnd::OnInfoListKeyDown(wxKeyEvent &evt)
 {
-	// Ctrl+C (or Cmd+C on macOS, which wx maps to ControlDown for
-	// wxKeyEvent on standard menus). Anything else falls through to
-	// the default key handler so arrow navigation etc. still works.
+	// Ctrl+C, or Cmd+C on macOS, which wx maps to ControlDown for wxKeyEvent on
+	// standard menus. Anything else falls through to the default key handler.
 	if ((evt.GetKeyCode() == 'C' || evt.GetKeyCode() == 'c') && evt.ControlDown()) {
 		wxListCtrl *list = wxDynamicCast(evt.GetEventObject(), wxListCtrl);
 		CopyInfoListToClipboard(list);
@@ -486,9 +465,8 @@ void CServerWnd::OnInfoListContextMenu(wxContextMenuEvent &evt)
 	wxMenu menu;
 	menu.Append(kInfoListMenuCopy, _("Copy"));
 
-	// Stash the target list on the menu's client-data slot so the
-	// EVT_MENU handler knows which list control fired the event
-	// without an extra member variable.
+	// Stash the target list on the menu's client-data slot so the EVT_MENU handler
+	// knows which list control fired the event without an extra member.
 	menu.SetClientData(list);
 	menu.Bind(wxEVT_MENU, &CServerWnd::OnInfoListCopy, this, kInfoListMenuCopy);
 
@@ -514,10 +492,9 @@ void CServerWnd::OnInfoListCopy(wxCommandEvent &evt)
 
 void CServerWnd::OnSashPositionChanging(wxSplitterEvent &evt)
 {
-	// CHANGING fires only while the user is actively dragging the
-	// sash; mark the drag in flight so OnSashPositionChanged knows
-	// the next CHANGED event came from a real user gesture (and not
-	// a layout reflow during minimize/restore).
+	// CHANGING fires only while the user is actively dragging the sash, so mark the
+	// drag in flight and OnSashPositionChanged knows the next CHANGED event came
+	// from a real gesture rather than a layout reflow.
 	m_userDraggingSash = true;
 	evt.Skip();
 }
@@ -526,10 +503,9 @@ void CServerWnd::OnSashPositionChanged(wxSplitterEvent &WXUNUSED(evt))
 {
 	wxSplitterWindow *split = CastChild("SrvSplitterWnd", wxSplitterWindow);
 	if (!m_userDraggingSash) {
-		// Layout-induced sash move — don't persist. With the default
-		// sash gravity, these should be rare; previously gravity 0.5
-		// produced a storm of CHANGED events during minimize/restore
-		// reflows that pushed the sash out of the visible range.
+		// Layout-induced sash move -- do not persist. Rare with the default sash
+		// gravity; gravity 0.5 produced a storm of CHANGED events during
+		// minimize/restore reflows that pushed the sash out of visible range.
 		return;
 	}
 	m_userDraggingSash = false;

--- a/src/SharedDirWatcher.cpp
+++ b/src/SharedDirWatcher.cpp
@@ -105,22 +105,20 @@ CSharedDirWatcher::CSharedDirWatcher(CSharedFileList *parent)
 CSharedDirWatcher::~CSharedDirWatcher()
 {
 	StopTimers();
-	// Synchronous here, unlike Disable(): a CallAfter queued on a handler that
-	// is being destroyed is purged along with it, so a deferred delete would
-	// simply never run -- leaking the watcher along with its inotify fd and
-	// the event loop source wx registered for it.
+	// Synchronous here, unlike Disable(): a CallAfter queued on a handler that is
+	// being destroyed is purged along with it, so a deferred delete would never
+	// run -- leaking the watcher along with its inotify fd and the event loop
+	// source wx registered for it.
 	//
-	// This can run from inside a dispatch, so it is not a dispatch-free spot:
-	// the macOS daemon build calls OnExit() straight out of OnCoreTimer
-	// (amule.cpp:1955). It is safe there for reasons that do not generalise --
-	// macOS watches through FSEvents/CFRunLoop rather than a wxFDIOHandler, so
-	// there is no epoll source to dangle, and the call is followed by
-	// _exit(0). Treat it as that exception rather than as a guarantee.
+	// This can run from inside a dispatch: the macOS daemon build calls OnExit()
+	// straight out of OnCoreTimer. It is safe there for reasons that do not
+	// generalise -- macOS watches through FSEvents/CFRunLoop rather than a
+	// wxFDIOHandler, so there is no epoll source to dangle, and the call is
+	// followed by _exit(0). Treat it as that exception, not as a guarantee.
 	//
 	// Detach before the delete, for the reason spelled out in Disable():
 	// ~wxFileSystemWatcherBase runs RemoveAll(), which can emit a synchronous
-	// wxFSW_EVENT_WARNING -- here that would run OnFileSystemEvent() against
-	// the object under destruction.
+	// wxFSW_EVENT_WARNING against the object under destruction.
 	if (m_watcher) {
 		m_watcher->SetOwner(nullptr);
 	}
@@ -134,21 +132,17 @@ void CSharedDirWatcher::Enable()
 		return;
 	}
 
-	// wx 3.2.x's inotify backend hard-requires an active wx event loop
-	// when wxFileSystemWatcher's ctor runs — Init() checks
-	// wxEventLoopBase::GetActive() and silently leaves m_service null
-	// when there isn't one, after which every Add() returns false. The
-	// daemon's CamuleApp::OnInit() runs before the event loop starts, so
-	// the first Enable() call from there must be deferred. (FSEvents on
-	// macOS and ReadDirectoryChangesW on Windows don't have this gate;
-	// deferring is still safe there.) Subsequent calls from the prefs
-	// dialog or EC apply path already run inside an active loop, so they
-	// take the immediate branch.
+	// wx 3.2.x's inotify backend hard-requires an active wx event loop when
+	// wxFileSystemWatcher's ctor runs -- Init() checks
+	// wxEventLoopBase::GetActive() and silently leaves m_service null when there
+	// is none, after which every Add() returns false. The daemon's OnInit() runs
+	// before the event loop starts, so the first Enable() call from there must
+	// be deferred. Later calls from the prefs dialog or the EC apply path
+	// already run inside an active loop and take the immediate branch.
 	if (!wxEventLoopBase::GetActive()) {
-		// Queue on `this` (a wxEvtHandler) rather than the app, so that
-		// if Disable()/~CSharedDirWatcher() runs before the loop drains,
-		// wx purges the pending event with the handler instead of firing
-		// it against a dead object.
+		// Queue on `this` (a wxEvtHandler) rather than the app, so that if
+		// Disable() or the destructor runs before the loop drains, wx purges the
+		// pending event with the handler instead of firing it against a dead object.
 		CallAfter(&CSharedDirWatcher::Enable);
 		return;
 	}
@@ -208,32 +202,22 @@ void CSharedDirWatcher::Disable()
 		return;
 	}
 	// Detach now, destroy from the pending-event queue. ~wxFileSystemWatcher
-	// frees the wxFDIOEventLoopSourceHandler wx registered for its inotify fd
-	// (fswatcher_inotify.cpp: Init() adds the source, Close() deletes it), and
-	// wxEpollDispatcher::Dispatch walks a stack snapshot of the ready events
+	// frees the wxFDIOEventLoopSourceHandler wx registered for its inotify fd,
+	// and wxEpollDispatcher::Dispatch walks a stack snapshot of the ready events
 	// without re-checking a handler -- so freeing one from inside that loop
 	// leaves it calling OnReadWaiting() on freed memory the moment the same
 	// batch reaches this fd.
 	//
 	// No caller reaches here from inside that loop today: Disable() comes from
-	// the destructor, from the prefs dialog, from the guarded call in
-	// CamuleApp::OnInit, and from CEC_Prefs_Packet::Apply(), which the EC layer
-	// reaches through a queued wx event -- the pending-event phase that
-	// wxEventLoopManual::ProcessEvents drains *before* calling Dispatch. But
-	// fs-watcher events themselves are delivered from inside the loop
-	// (fswatcher_inotify.cpp SendEvent() does a synchronous ProcessEvent from
-	// the inotify source's OnReadWaiting), so one caller reached from
-	// OnFileSystemEvent would make this fatal. Deferring costs nothing and
-	// removes the question.
+	// the destructor, the prefs dialog, the guarded call in CamuleApp::OnInit,
+	// and CEC_Prefs_Packet::Apply(), which the EC layer reaches through a queued
+	// wx event -- the phase drained BEFORE Dispatch. But fs-watcher events
+	// themselves are delivered from inside the loop, so one caller reached from
+	// OnFileSystemEvent would make this fatal. Deferring costs nothing.
 	//
-	// Drop the owner as part of the detach: a detached watcher outlives the
-	// call, and SetOwner(nullptr) points its owner back at itself, where
-	// nothing is bound. Without that, everything it still emits before the
-	// reap lands on us -- the deltas the backend had already queued, and the
-	// wxFSW_EVENT_WARNING wxFSWatcherImplUnix::DoRemove() sends synchronously
-	// from RemoveAll() when inotify_rm_watch loses the race wx documents. That
-	// warning reads as a backend drop, so OnFileSystemEvent() would clear
-	// m_pendingEvents and force a full RequestReload() re-walk for nothing.
+	// Drop the owner as part of the detach: a detached watcher outlives the call,
+	// and SetOwner(nullptr) points its owner back at itself, where nothing is
+	// bound, so everything it still emits goes nowhere.
 	m_watcher->SetOwner(nullptr);
 	m_pendingDelete.push_back(m_watcher);
 	m_watcher = NULL;
@@ -252,14 +236,11 @@ void CSharedDirWatcher::Refresh()
 	// the typical list size (low hundreds at most).
 	m_watcher->RemoveAll();
 	RegisterAllPaths();
-	// Cold-discovery is one-shot at Enable() only. Re-running it from
-	// Refresh() risks adding duplicate entries when a runtime
-	// RegisterNewSubdirectory wrote a path in one canonical form
-	// (e.g. macOS-resolved "/private/tmp/...") while the disk walk
-	// later produces the unresolved form ("/tmp/...") -- both go in
-	// as distinct strings. Startup is the only moment we genuinely
-	// have to walk to catch up; runtime new-dirs are covered by
-	// RegisterNewSubdirectory from OnFileSystemEvent.
+	// Cold-discovery is one-shot at Enable() only. Re-running it from Refresh()
+	// risks adding duplicate entries when a runtime RegisterNewSubdirectory wrote
+	// a path in one canonical form (a macOS-resolved "/private/tmp/...") while
+	// the disk walk later produces the unresolved form -- both go in as distinct
+	// strings. Startup is the only moment a walk is genuinely needed.
 }
 
 void CSharedDirWatcher::RegisterAllPaths()

--- a/src/SharedDirWatcher.h
+++ b/src/SharedDirWatcher.h
@@ -30,23 +30,19 @@
 class CSharedFileList;
 class CPath;
 
-// Watches every directory in CPreferences::shareddir_list for file/dir
-// creation, deletion, rename and modification, and triggers a debounced
-// CSharedFileList::Reload() so newly-added files become shared without a
-// manual "Reload shared files" click.
+// Watches every directory in CPreferences::shareddir_list for file/dir creation,
+// deletion, rename and modification, and triggers a debounced
+// CSharedFileList::Reload() so newly-added files become shared without a manual
+// "Reload shared files" click.
 //
 // New subdirectories created under any watched path are auto-added to
-// shareddir_list so the watcher keeps following them, which mirrors the
-// behaviour users expect from the existing "recursive share" button —
-// once a parent is shared, anything created beneath it is shared too.
-// We do not persist a per-entry recursive flag because shareddir.dat
-// already enumerates each subdirectory individually.
+// shareddir_list so the watcher keeps following them, mirroring what the
+// "recursive share" button already does. No per-entry recursive flag is
+// persisted, because shareddir.dat enumerates each subdirectory individually.
 //
-// Backends per platform are provided by wxFileSystemWatcher: inotify on
-// Linux, FSEvents on macOS, ReadDirectoryChangesW on Windows, kqueue on
-// BSD. AddTree() handles initial recursive setup; we re-Add new subdirs
-// individually as we discover them so the watch graph keeps pace with
-// disk changes.
+// Backends come from wxFileSystemWatcher: inotify on Linux, FSEvents on macOS,
+// ReadDirectoryChangesW on Windows, kqueue on BSD. AddTree() handles the initial
+// recursive setup; new subdirs are re-Added individually as they are discovered.
 class CSharedDirWatcher : public wxEvtHandler
 {
 public:
@@ -64,10 +60,9 @@ public:
 
 	bool IsEnabled() const { return m_watcher != NULL; }
 
-	// Called from CSharedFileList::Reload() after the list has been
-	// rebuilt. Re-walks shareddir_list and updates the watcher's path
-	// set so removed dirs stop firing events and newly-added dirs
-	// start firing.
+	// Called from CSharedFileList::Reload() after the list has been rebuilt.
+	// Re-walks shareddir_list and updates the watcher's path set, so removed dirs
+	// stop firing events and newly-added ones start.
 	void Refresh();
 
 	// Event-type flags accumulated for one pending path between
@@ -83,11 +78,9 @@ private:
 	void OnFileSystemEvent(wxFileSystemWatcherEvent &event);
 	void OnDebounceTimer(wxTimerEvent &event);
 #ifdef __APPLE__
-	// macOS amuled (wxAppConsole) doesn't spin the main thread's
-	// CFRunLoop, so FSEvents callbacks scheduled by wx never deliver.
-	// A periodic non-blocking drain fixes that without spawning a
-	// dedicated thread. No-op under aMule.app whose Cocoa main loop
-	// already pumps the runloop.
+	// macOS amuled (wxAppConsole) does not spin the main thread's CFRunLoop, so
+	// FSEvents callbacks scheduled by wx never deliver; a periodic non-blocking
+	// drain fixes that without a dedicated thread. No-op under aMule.app.
 	void OnMacRunLoopPump(wxTimerEvent &event);
 #endif
 
@@ -101,12 +94,10 @@ private:
 	// new event; processing runs when the timer finally fires.
 	void ScheduleProcessing();
 
-	// Walk m_pendingEvents and apply each one to CSharedFileList via
-	// NotifyPathAdded/Removed/Modified. Skipped if a resync is owed
-	// was set by a wxFSW_EVENT_WARNING / _ERROR event since the last
-	// flush -- in that case we fall back to the bulk Reload() because
-	// the watcher backend has signalled it dropped events and we
-	// can't trust our incremental view of the tree any more.
+	// Walk m_pendingEvents and apply each one to CSharedFileList. Skipped when a
+	// resync is owed from a wxFSW_EVENT_WARNING / _ERROR since the last flush: the
+	// backend has signalled it dropped events, so the incremental view cannot be
+	// trusted and the bulk Reload() takes over.
 	void FlushPendingEvents();
 
 	// Append a newly-created directory to shareddir_list (if not
@@ -123,33 +114,25 @@ private:
 	// file event once the path is gone from disk.
 	bool IsInSharedSet(const wxString &path) const;
 
-	// Closes the inotify/kqueue race window inside RegisterNewSubdirectory:
-	// between the kernel mkdir and our wxFileSystemWatcher::Add(), any
-	// files or subdirs created inside the new directory fire on a watch
-	// that doesn't exist yet and get silently dropped. Walks `parent`
-	// after the watch is in place and feeds existing entries through
-	// NotifyPathAdded (files) and RegisterNewSubdirectory (subdirs,
-	// recursively) so the catch-up is symmetric with what the live
-	// event path would have done. Idempotent on second observation.
+	// Closes the inotify/kqueue race window inside RegisterNewSubdirectory: between
+	// the kernel mkdir and our wxFileSystemWatcher::Add(), anything created inside
+	// the new directory fires on a watch that does not exist yet and is silently
+	// dropped. Walks `parent` once the watch is in place and feeds existing entries
+	// through NotifyPathAdded and RegisterNewSubdirectory, so the catch-up matches
+	// what the live event path would have done. Idempotent.
 	void ScanNewSubdirRace(const CPath &parent);
 
-	// Recursively walk each path in shareddir_list and add any subdir
-	// not already listed. The "cold" twin of RegisterNewSubdirectory:
-	// without this, subdirs created while aMule was offline are never
-	// observed -- the watcher only fires CREATE events post-Enable(),
-	// so a /Music share whose disk grew three new albums in the
-	// interim would never see them until each gained a new file via
-	// some other path. Batches in-memory and writes shareddir.dat
-	// once at the end so a large discovery pass doesn't trigger N
-	// rewrites.
+	// Recursively walk each path in shareddir_list and add any subdir not already
+	// listed. The "cold" twin of RegisterNewSubdirectory: the watcher only fires
+	// CREATE events post-Enable(), so without this a /Music share that grew three
+	// albums while aMule was offline would never see them. Batches in memory and
+	// writes shareddir.dat once at the end.
 	void ColdDiscoverSubdirs();
 
-	// Recursive walker used by ColdDiscoverSubdirs. Visits every
-	// subdirectory of `root`; for each that is not already in
-	// `known` it inserts the path into `known` and appends to `out`.
-	// Always recurses (even through already-known subdirs) so a tree
-	// whose top layer is in shareddir.dat but whose deeper layers
-	// are not still gets fully covered in one pass.
+	// Recursive walker used by ColdDiscoverSubdirs. Visits every subdirectory of
+	// `root`, inserting each one not already in `known` into `known` and `out`.
+	// Always recurses, even through known subdirs, so a tree whose top layer is in
+	// shareddir.dat but whose deeper layers are not is still fully covered.
 	void WalkForUnknownSubdirs(const CPath &root, std::set<wxString> &known, std::vector<CPath> &out);
 
 	// Destroy the watchers Disable() detached. Queued with CallAfter() so
@@ -164,13 +147,11 @@ private:
 	CSharedFileList *m_parent;
 	wxFileSystemWatcher *m_watcher;
 	//! Watchers detached by Disable() and not yet destroyed. ~wxFileSystemWatcher
-	//! frees the wxFDIOEventLoopSourceHandler wx registered for its inotify fd,
-	//! and wxEpollDispatcher::Dispatch walks a snapshot of the ready events
-	//! without re-checking any handler -- so freeing one from inside an event
-	//! handler makes that loop call a virtual on freed memory as soon as the
-	//! same batch reaches the watcher's fd. Destruction is therefore deferred
-	//! to the pending-event queue, which the event loop drains before it
-	//! dispatches, and the destructor sweeps whatever the queue never reached.
+	//! frees the wxFDIOEventLoopSourceHandler wx registered for its inotify fd, and
+	//! wxEpollDispatcher::Dispatch walks a snapshot of the ready events without
+	//! re-checking any handler -- so freeing one from inside an event handler makes
+	//! that loop call a virtual on freed memory. Destruction is therefore deferred
+	//! to the pending-event queue, which the loop drains before it dispatches.
 	std::vector<wxFileSystemWatcher *> m_pendingDelete;
 	wxTimer m_debounceTimer;
 
@@ -182,27 +163,18 @@ private:
 
 	// Why a full-reload resync is owed; cleared once the fallback fires.
 	//
-	// ResyncDroppedEvents means the watcher backend reported overflow or drop
-	// (inotify queue overflow, kqueue race, Windows ReadDirectoryChangesW
-	// buffer exhaust). FlushPendingEvents() responds with the bulk Reload()
-	// because the per-path deltas can no longer be trusted -- a real fault,
-	// and logged as one.
+	// ResyncDroppedEvents means the backend reported overflow or drop (inotify
+	// queue overflow, kqueue race, ReadDirectoryChangesW buffer exhaust), so
+	// FlushPendingEvents() falls back to the bulk Reload() and logs a real fault.
 	//
-	// ResyncColdDiscovery means subdirectories simply appeared while aMule was
-	// not running. Nothing failed. Both reasons used to share one bool and so
-	// one message, which would have reported this routine case as a watcher
-	// failure, in red.
+	// ResyncColdDiscovery means subdirectories simply appeared while aMule was not
+	// running. Nothing failed. Both reasons used to share one bool and so one
+	// message, which reported this routine case as a watcher failure, in red.
 	//
-	// That is hard to provoke in practice: CPreferences::ReloadSharedFolders
-	// expands recursive roots into the shared-dir union and the startup Reload
-	// runs before the watcher is enabled, so ColdDiscoverSubdirs normally
-	// finds nothing left to discover -- adding subdirectories while aMule is
-	// stopped and restarting does *not* produce the wrong message (verified
-	// against the pre-change build). What remains is the narrow window where a
-	// directory appears between that Reload and Enable(), plus whatever the
-	// expansion skips. Separating the reasons is cheap and means that if the
-	// path is ever reached it says what happened rather than blaming the
-	// backend (issue #968).
+	// It is hard to provoke: ReloadSharedFolders expands recursive roots into the
+	// shared-dir union and the startup Reload runs before the watcher is enabled,
+	// so ColdDiscoverSubdirs normally finds nothing. What remains is the narrow
+	// window where a directory appears between that Reload and Enable().
 	enum ResyncReason
 	{
 		ResyncNone,

--- a/src/SharedFileList.cpp
+++ b/src/SharedFileList.cpp
@@ -213,11 +213,9 @@ protected:
 	uint32 m_tNextPublishKeywordTime;
 
 	// Secondary index: keyword string -> position in m_lstKeywords. Lets
-	// FindKeyword() do an O(log N) lookup instead of a linear scan,
-	// collapsing AddKeywords()'s hot path on large shared sets
-	// (CSharedFileList::Reload, called once per shared file at startup)
-	// from O(N²) to O(N log N). std::list iterators are stable across
-	// other inserts/erases, so caching them here is safe.
+	// FindKeyword() do an O(log N) lookup instead of a linear scan, collapsing
+	// AddKeywords()'s hot path on large shared sets from O(N^2) to O(N log N).
+	// std::list iterators are stable across other inserts/erases.
 	std::map<wxString, CKeyWordList::iterator> m_keywordIndex;
 
 	CPublishKeyword *FindKeyword(const wxString &rstrKeyword, CKeyWordList::iterator *ppos = NULL);
@@ -397,22 +395,18 @@ void CSharedFileList::FindSharedFiles(const ReloadYieldCb &yieldCb, bool &aborte
 	{
 		wxMutexLocker lock(list_mut);
 		m_Files_map.clear();
-		// The index goes with the map it mirrors. AddFile writes a key only on
-		// a fresh insert and RemoveFile erases only the one key it recomputes,
-		// so any path this walk does not re-add -- a file deleted while its
-		// root was unshared, a DELETE lost to a watcher backend overflow, a
-		// remote deletion on a network share -- would keep an entry that makes
-		// NotifyPathAdded treat the path as already shared and silently refuse
-		// to share it again, with nothing logged at any level. Clearing here
-		// cannot heal that on its own; leaving the key behind is what creates
-		// it (issue #1028).
+		// The index goes with the map it mirrors. AddFile writes a key only on a
+		// fresh insert and RemoveFile erases only the one key it recomputes, so
+		// any path this walk does not re-add -- a file deleted while its root was
+		// unshared, a DELETE lost to a watcher backend overflow, a remote deletion
+		// on a network share -- would keep an entry that makes NotifyPathAdded
+		// treat the path as already shared and silently refuse to share it again,
+		// with nothing logged at any level.
 		//
 		// Same locked scope on purpose: this puts the index under the invariant
-		// the map already has -- neither may be observed between here and the
-		// end of the walk. That is not a new constraint, it is the one that
-		// already rules out pumping the event loop during a walk (see
-		// SharedFilesReloadProgress.h). Keeping the two containers on one rule
-		// is why they are cleared together rather than separately.
+		// the map already has -- neither may be observed between here and the end
+		// of the walk, which is the rule that already forbids pumping the event
+		// loop during a walk.
 		m_pathIndex.clear();
 		m_listGeneration.fetch_add(1, std::memory_order_relaxed);
 	}
@@ -470,23 +464,16 @@ void CSharedFileList::FindSharedFiles(const ReloadYieldCb &yieldCb, bool &aborte
 	// One unconditional summary. The new-file count used to ride along as a
 	// suffix here, in one of two mutually exclusive variants, and only for this
 	// route -- the watcher reported nothing at all. It now has its own line,
-	// emitted from Process() for both routes (issue #968), so this says one
-	// thing and the two-argument variant is retired. That also drops a msgid
-	// whose plural form was selected on GetCount() rather than on the count it
-	// was actually pluralising.
+	// emitted from Process() for both routes, so this says one thing.
 	AddLogLineN(
 		CFormat(wxPLURAL("Found %i known shared file", "Found %i known shared files", GetCount())) %
 		GetCount());
 
 	if (addedFiles == 0) {
-		// Make sure the AICH-hashes are up to date. This is the startup sync
-		// run once the shared/known list is authoritative, so it opts into the
+		// Make sure the AICH hashes are up to date. This is the startup sync run
+		// once the shared/known list is authoritative, so it opts into the
 		// orphan-prune (drop known2_64.met entries no longer owned by any known
-		// file). Post-hashing syncs deliberately do not prune -- see
-		// CAICHSyncTask's ctor doc.
-		//
-		// Unchanged condition: this scheduling has nothing to do with logging
-		// and must keep firing exactly when it did before.
+		// file). Post-hashing syncs deliberately do not prune -- see CAICHSyncTask.
 		CThreadScheduler::AddTask(new CAICHSyncTask(true));
 	}
 
@@ -546,10 +533,9 @@ unsigned CSharedFileList::AddFilesFromDirectory(const CPath &directory,
 	unsigned knownFiles = 0;
 	unsigned addedFiles = 0;
 
-	// Yield to the caller every kYieldEvery files so the UI can stay
-	// responsive on big shared trees. 256 strikes a balance between
-	// progress-bar responsiveness (~4 updates/s on a 1 ms-per-file
-	// machine) and the overhead of the callback itself.
+	// Yield to the caller every kYieldEvery files so the UI stays responsive on
+	// big shared trees. 256 balances progress-bar responsiveness (~4 updates/s
+	// on a 1 ms-per-file machine) against the overhead of the callback itself.
 	constexpr size_t kYieldEvery = 256;
 
 	CDirIterator SharedDir(directory);
@@ -591,17 +577,15 @@ unsigned CSharedFileList::AddFilesFromDirectory(const CPath &directory,
 }
 
 // Per-path attach. Three outcomes:
-//   kAddPathSkipped — broken link, zero size, stat failed; do nothing.
-//   kAddPathKnown   — matched a CKnownFile in known.met and was either
-//                     newly attached to the shared list or already there.
-//   kAddPathQueued  — unknown file; a CHashingTask was pushed into
-//                     hashTasks. The shared-list attach happens later
-//                     when the hashing thread finishes and calls
-//                     SafeAddKFile() on the resulting CKnownFile.
+//   kAddPathSkipped -- broken link, zero size, stat failed; do nothing.
+//   kAddPathKnown   -- matched a CKnownFile in known.met and was either newly
+//                      attached to the shared list or already there.
+//   kAddPathQueued  -- unknown file; a CHashingTask was pushed into hashTasks.
+//                      The shared-list attach happens later, when the hashing
+//                      thread finishes and calls SafeAddKFile().
 //
-// Shared between the bulk directory walk (AddFilesFromDirectory above)
-// and the incremental watcher path (NotifyPathAdded below) so the two
-// agree on shareability rules.
+// Shared between the bulk directory walk and the incremental watcher path so
+// the two agree on shareability rules.
 CSharedFileList::AddPathResult CSharedFileList::AddPathToShares(
 	const CPath &directory, const CPath &fname, TaskList &hashTasks, bool notifyGuiOnKnownAdd)
 {
@@ -616,13 +600,11 @@ CSharedFileList::AddPathResult CSharedFileList::AddPathToShares(
 	}
 
 	// One stat for all three answers. Asking separately -- exists, then
-	// modification time, then size -- costs four filesystem round-trips per
-	// file, and the size query opens the file to measure it. Multiplied by
-	// the share, that was the larger half of a cold-cache startup walk.
-	//
-	// A false here is every reason the three separate checks used to report
-	// individually: a broken symlink, something that is not a regular file,
-	// or permissions too strict to stat.
+	// modification time, then size -- costs four filesystem round trips per
+	// file, and the size query opens the file to measure it. Multiplied by the
+	// share, that was the larger half of a cold-cache startup walk. A false here
+	// covers all three: a broken symlink, a non-regular file, or permissions too
+	// strict to stat.
 	time_t fdate;
 	sint64 fsize;
 	if (!fullPath.GetFileStat(fdate, fsize)) {
@@ -641,20 +623,16 @@ CSharedFileList::AddPathResult CSharedFileList::AddPathToShares(
 
 	CKnownFile *toadd = filelist->FindKnownFile(fname, fdate, fsize);
 	if (toadd) {
-		// Ask before stamping. SetFilePath is not a plain assignment -- it
-		// calls MarkECChanged(), which hands the file a new EC generation and
-		// so pushes it into the next INC_UPDATE. Stamping and then rolling
-		// back on a decline did that twice for a net-zero path change, sending
-		// every duplicate-content file to every EC client as "changed" on each
-		// reload, which is precisely what the generation counter exists to
-		// avoid (issue #1028).
+		// Ask before stamping. SetFilePath is not a plain assignment -- it calls
+		// MarkECChanged(), which hands the file a new EC generation and so pushes
+		// it into the next INC_UPDATE. Stamping and then rolling back on a decline
+		// did that twice for a net-zero path change, sending every
+		// duplicate-content file to every EC client as "changed" on each reload.
 		//
-		// Note the obvious guard -- stamp only when the path differs -- would
-		// not have helped: a decline with previousPath == directory is close to
-		// unreachable, because the watcher route returns on an index hit before
-		// reaching here and the bulk walk clears the map up front and visits
-		// each root once. Every decline that happens in practice has a
-		// different path, so that guard skips nothing.
+		// The obvious guard -- stamp only when the path differs -- would not have
+		// helped: a decline with previousPath == directory is close to
+		// unreachable, since the watcher route returns on an index hit before
+		// reaching here and the bulk walk visits each root once.
 		{
 			wxMutexLocker lock(list_mut);
 			if (m_Files_map.find(toadd->GetFileHash()) != m_Files_map.end()) {
@@ -664,56 +642,46 @@ CSharedFileList::AddPathResult CSharedFileList::AddPathToShares(
 			}
 		}
 
-		// Set the path BEFORE AddFile so the path index that AddFile
-		// maintains keys off the file's current GetFilePath() rather
-		// than whatever stale path was stamped on the CKnownFile by
-		// a previous shared-list membership.
+		// Set the path BEFORE AddFile so the path index that AddFile maintains keys
+		// off the file's current GetFilePath() rather than whatever stale path was
+		// stamped on the CKnownFile by a previous shared-list membership.
 		//
-		// The rollback below still stands as the fallback for the
-		// check-then-insert race: the membership test above drops the lock
-		// before AddFile retakes it, so a hashing task completing through
-		// SafeAddKFile in between can still make AddFile decline.
+		// The rollback below still stands as the fallback for the check-then-insert
+		// race: the membership test above drops the lock before AddFile retakes
+		// it, so a hashing task completing in between can still make AddFile decline.
 		const CPath previousPath = toadd->GetFilePath();
 		toadd->SetFilePath(directory);
 		if (AddFile(toadd)) {
 			AddDebugLogLineN(logKnownFiles, CFormat("Added known file '%s' to shares") % fname);
-			// This record matched a file we just saw on disk and it now
-			// owns the hash in the shared list. Give it the hash in the
-			// known-file map too: that map keeps whichever known.met
-			// entry loaded last, which for duplicated content can be a
-			// different record -- and if that record's own copy has been
-			// deleted, every hash-keyed known-file lookup resolves to a
-			// path that cannot be opened (issue #1265). Called outside
-			// AddFile's lock on purpose: nothing may enter knownfiles
-			// while holding the shared-list lock.
+			// This record matched a file we just saw on disk and it now owns the
+			// hash in the shared list. Give it the hash in the known-file map too:
+			// that map keeps whichever known.met entry loaded last, which for
+			// duplicated content can be a different record -- and if that record's
+			// own copy has been deleted, every hash-keyed lookup resolves to a path
+			// that cannot be opened. Called outside AddFile's lock on purpose:
+			// nothing may enter knownfiles while holding the shared-list lock.
 			filelist->PromoteToCanonical(toadd);
-			// The bulk-Reload caller repaints the whole view once its
-			// walk finishes; the incremental watcher caller has no such
-			// follow-up, so tell the GUI about this freshly-shared file
-			// directly (otherwise it stays invisible in the shared-files
-			// view despite being in the core share set -- see the header).
+			// The bulk-Reload caller repaints the whole view once its walk finishes;
+			// the incremental watcher caller has no such follow-up, so tell the GUI
+			// about this freshly-shared file directly.
 			if (notifyGuiOnKnownAdd) {
 				Notify_SharedFilesShowFile(toadd);
 			}
 		} else {
-			// The share set already holds this content, indexed under the
-			// path it was first found at. Put the file back on that path:
-			// the stamp above would otherwise leave GetFilePath() disagreeing
-			// with the index key, and nothing reconciles them. That skew is
-			// not cosmetic -- RemoveFile erases by a key it recomputes from
-			// GetFilePath(), so the erase silently misses and leaks the real
-			// entry, after which NotifyPathAdded short-circuits on the leaked
-			// key and the file can never be shared again without a restart.
-			// The upload worker also opens GetFilePath(), so it would read
-			// the copy the index does not know about and, on failure, invoke
-			// its own "removing from list of shared files" recovery against a
-			// file that is still present and serveable (issue #1017).
+			// The share set already holds this content, indexed under the path it was
+			// first found at. Put the file back on that path: the stamp above would
+			// otherwise leave GetFilePath() disagreeing with the index key, and
+			// nothing reconciles them. That skew is not cosmetic -- RemoveFile
+			// erases by a key it recomputes from GetFilePath(), so the erase
+			// silently misses and leaks the real entry, after which NotifyPathAdded
+			// short-circuits on the leaked key and the file can never be shared
+			// again without a restart. The upload worker also opens GetFilePath(),
+			// so it would read the copy the index does not know about.
 			//
-			// First copy found wins and stays authoritative, which is stable
-			// across reloads. Re-keying the index to follow the new path would
-			// work too, but would make "last directory walked wins" the
-			// semantics, so which physical copy serves uploads would depend on
-			// the sort order of the shared roots.
+			// First copy found wins and stays authoritative, which is stable across
+			// reloads. Re-keying the index to the new path would make "last
+			// directory walked wins" the semantics, so which physical copy serves
+			// uploads would depend on the sort order of the shared roots.
 			toadd->SetFilePath(previousPath);
 			AddDebugLogLineN(logKnownFiles, CFormat("File already shared, skipping: %s") % fname);
 			return kAddPathAlreadyShared;
@@ -728,8 +696,7 @@ CSharedFileList::AddPathResult CSharedFileList::AddPathToShares(
 	// Not counted here. CThreadScheduler::DoAddTask dedups on (type, desc) and
 	// silently drops a task already queued, so a re-walk while hashing is still
 	// pending constructs the same tasks again -- counting at construction would
-	// report those files as discovered twice. Both routes count where the
-	// scheduler actually accepts the task instead.
+	// report those files as discovered twice.
 	return kAddPathQueued;
 }
 
@@ -745,30 +712,25 @@ bool CSharedFileList::AddFile(CKnownFile *pFile)
 		/* Keywords to publish on Kad */
 		m_keywords->AddKeywords(pFile);
 		theStats::AddSharedFile(pFile->GetFileSize());
-		// Mirror into the path index so the watcher's per-event
-		// dispatch can resolve DELETE / MODIFY events to the
-		// CKnownFile* in O(1). Empty key (e.g. a CPartFile whose
-		// SetFilePath has not run yet) is harmless: it lives in
-		// m_pathIndex under "" until SafeAddKFile attaches the real
-		// path via the post-completion path. Stale entries left
-		// over from a previous shared-list membership are
-		// overwritten here.
+		// Mirror into the path index so the watcher's per-event dispatch can
+		// resolve DELETE / MODIFY events to the CKnownFile* in O(1). An empty key
+		// (a CPartFile whose SetFilePath has not run yet) is harmless: it lives in
+		// m_pathIndex under "" until SafeAddKFile attaches the real path. Stale
+		// entries from a previous shared-list membership are overwritten here.
 		const wxString key =
 			NormalizePathKey(pFile->GetFilePath().JoinPaths(pFile->GetFileName()).GetRaw());
 		m_pathIndex[key] = pFile;
 		// Two ways this is a mass operation rather than one file the user is
-		// watching. `reloading` covers the share walk itself. The hashing
-		// queue covers what the walk leaves behind: files it discovered are
-		// hashed asynchronously and only reach here when their task finishes,
-		// by which time the walk is long over -- so a first import of a large
-		// library would print one line per file with `reloading` alone, which
-		// is precisely the log flood the summary exists to prevent.
+		// watching. `reloading` covers the share walk itself; the hashing queue
+		// covers what the walk leaves behind, since files it discovered are hashed
+		// asynchronously and only reach here when their task finishes -- so a
+		// first import of a large library would print one line per file with
+		// `reloading` alone.
 		//
 		// `> 1`, not `> 0`: GetPendingCount counts the running task too, so a
-		// single file dropped into a shared directory reads as 1 while it is
-		// being hashed. Misjudging the last file of an import as singular
-		// costs one extra line; misjudging a single file as bulk would lose
-		// the only feedback that file ever produces.
+		// single dropped-in file reads as 1 while it is being hashed. Misjudging
+		// the last file of an import as singular costs one extra line; misjudging
+		// a single file as bulk would lose the only feedback it ever produces.
 		const bool massOperation = reloading || CThreadScheduler::GetPendingCount(wxT("Hashing")) > 1;
 		MaybeScheduleMediaProbe(pFile, MediaProbeMode::Normal, massOperation);
 		return true;
@@ -778,35 +740,29 @@ bool CSharedFileList::AddFile(CKnownFile *pFile)
 
 bool CSharedFileList::MaybeScheduleMediaProbe(CKnownFile *pFile, MediaProbeMode mode, bool bulk)
 {
-	// Callers must keep pFile alive for the duration of this call. AddFile
-	// holds list_mut, which does that; the refresh walk instead snapshots the
-	// pointers under the lock and schedules outside it, which is safe because
-	// both callers run on the main thread and only the main thread removes a
-	// file from the list. It is that single-thread property doing the work
-	// here, not the mutex.
-	// #140 — probe local shared audio / video files with ffprobe to populate
-	// the six FT_MEDIA_* fields (length, bitrate, codec, artist, album,
-	// title). Cost-limiting:
-	//  * on by default since #1080, and still switchable off in Preferences,
-	//  * only for files whose ED2K file-type is audio / video (cheap
-	//    extension-based filter — a .zip renamed to .mp4 gets
-	//    scheduled and ffprobe fails fast in the worker, but this
-	//    filter skips the mass of docs / archives / images in a
-	//    typical share tree),
-	//  * only when the file has no media metadata at all yet
-	//    (GetMetaDataVer() == 0), so a probed file is never re-probed.
-	// An empty ffprobe path is NOT "off": it means auto-detect.
-	// CThreadScheduler naturally throttles: it runs one task at a
-	// time at ETP_Low so hashing / completion never starve.
+	// Callers must keep pFile alive for the duration of this call. AddFile holds
+	// list_mut, which does that; the refresh walk instead snapshots the pointers
+	// under the lock and schedules outside it, which is safe because both
+	// callers run on the main thread and only the main thread removes a file
+	// from the list. It is that single-thread property doing the work, not the
+	// mutex.
+	//
+	// Probes local shared audio / video files with ffprobe to populate the six
+	// FT_MEDIA_* fields. Cost-limited three ways: only for files whose ED2K
+	// file-type is audio / video (a cheap extension filter -- a .zip renamed to
+	// .mp4 gets scheduled and ffprobe fails fast, but this skips the mass of
+	// docs / archives / images in a typical share tree), only when the file has
+	// no media metadata yet, and only one task at a time at ETP_Low so hashing
+	// and completion never starve. An empty ffprobe path is NOT "off": it means
+	// auto-detect.
 	if (!thePrefs::GetMediaMetadataEnabled()) {
 		return false;
 	}
-	// An empty preference is not "off" -- it means "whatever this machine
-	// has", which is what every place that documents the setting promises.
-	// The worker resolves it through MediaProbe::DetectedPath() and drops
-	// the job if that finds nothing; doing it there keeps the detection
-	// subprocess off this thread and pays for it once per process rather
-	// than once per file.
+	// An empty preference is not "off" -- it means "whatever this machine has",
+	// which is what every place that documents the setting promises. The worker
+	// resolves it through MediaProbe::DetectedPath() and drops the job if that
+	// finds nothing; doing it there keeps the detection subprocess off this
+	// thread and pays for it once per process rather than once per file.
 	const wxString &ffprobePath = thePrefs::GetMediaMetadataFFProbePath();
 	// Shared with the GUI's menu-enable test (IsMediaProbeCandidate, in
 	// OtherFunctions): the view must not offer an action the scheduler will
@@ -817,14 +773,12 @@ bool CSharedFileList::MaybeScheduleMediaProbe(CKnownFile *pFile, MediaProbeMode 
 	}
 	// Never probe an in-progress download. A partfile is shared while
 	// transferring, so this fires from AddFile() during the download; there is
-	// no complete file to read yet (its on-disk name is <hash>.part), and its
-	// metadata is derived exactly once -- on completion, which re-enters here
-	// with bForceReprobe set. Skipping unconditionally (not just when metadata
-	// happened to be inherited from the search result) keeps that guarantee.
-	// Only Completion lifts this, and only because a just-completed download
-	// is still a CPartFile object while its bytes are already all on disk. A
-	// Refresh walk MUST NOT inherit that licence: an in-progress download is
-	// in the shared list too, and there is nothing complete to read for it.
+	// no complete file to read yet, and its metadata is derived exactly once, on
+	// completion, which re-enters here with bForceReprobe set.
+	//
+	// Only Completion lifts this, and only because a just-completed download is
+	// still a CPartFile object while its bytes are already all on disk. A
+	// Refresh walk MUST NOT inherit that licence.
 	if (mode != MediaProbeMode::Completion && pFile->IsPartFile()) {
 		AddDebugLogLineN(logMediaProbe,
 			CFormat(wxT("MediaProbe: skip (incomplete download) %s")) % pFile->GetFileName());
@@ -842,9 +796,8 @@ bool CSharedFileList::MaybeScheduleMediaProbe(CKnownFile *pFile, MediaProbeMode 
 	// A file ffprobe already tried and could not read is not re-tried on the
 	// normal path. Nothing about it has changed since the last attempt, so a
 	// share reload would spawn ffprobe on every broken file in the library,
-	// every time, to fail identically (issue #1116). Refresh deliberately
-	// ignores this -- that is the whole point of an explicit re-extraction --
-	// and a successful probe clears the marker.
+	// every time, to fail identically. Refresh deliberately ignores this --
+	// that is the whole point of an explicit re-extraction.
 	if (mode == MediaProbeMode::Normal && pFile->GetIntTagValue(FT_MEDIA_PROBE_FAILED)) {
 		AddDebugLogLineN(logMediaProbe,
 			CFormat(wxT("MediaProbe: skip (previous probe found nothing) %s")) %
@@ -853,19 +806,14 @@ bool CSharedFileList::MaybeScheduleMediaProbe(CKnownFile *pFile, MediaProbeMode 
 	}
 	const CPath fullPath = pFile->GetFilePath().JoinPaths(pFile->GetFileName());
 	// Only probe a file that is actually on disk at this resolved path -- a
-	// stale known.met record can outlive its deleted file, and this is cheap
-	// insurance against handing ffprobe a path that cannot succeed. (In-progress
-	// downloads are already excluded by the partfile guard above.)
+	// stale known.met record can outlive its deleted file.
 	//
-	// Skipped for Refresh, which walks the WHOLE share from an EC handler on
-	// the main thread: one stat per file is cheap, N of them synchronously
-	// before the reply goes out is not, and it is the same stall the shared-
-	// files reload was deliberately made asynchronous to avoid. Nothing is
-	// lost by deferring it -- MediaProbe::Probe stats the path again on the
-	// worker before spawning ffprobe, and logs the file as vanished. The cost
-	// is that `queued` counts a file that has since been deleted, which is
-	// honest: it says how many were accepted for probing, not how many
-	// produced metadata.
+	// Skipped for Refresh, which walks the WHOLE share from an EC handler on the
+	// main thread: one stat per file is cheap, N of them synchronously before
+	// the reply goes out is not. Nothing is lost by deferring it -- Probe stats
+	// the path again on the worker and logs the file as vanished. The cost is
+	// that `queued` counts a file that has since been deleted, which is honest:
+	// it says how many were accepted for probing, not how many produced metadata.
 	if (mode != MediaProbeMode::Refresh && !fullPath.FileExists()) {
 		return false;
 	}
@@ -964,20 +912,15 @@ void CSharedFileList::SafeAddKFile(CKnownFile *toadd, bool bOnlyAdd)
 	if (AddFile(toadd)) {
 		Notify_SharedFilesShowFile(toadd);
 	} else {
-		// AddFile failed because some CKnownFile under this hash is
-		// already in m_Files_map. Two possibilities:
-		//
-		//   1. The exact same pointer was re-added — no-op.
-		//   2. CKnownFileList::Append fired the rename-during-hash
-		//      branch (same hash, same size, different name): it
-		//      demoted the prior CKnownFile to m_duplicateFileList and
-		//      installed `toadd` as the canonical entry in
-		//      m_knownFileMap. The shared-files view still points at
-		//      the demoted pointer, which has a filename that no
-		//      longer matches disk and which the duplicate-list prune
-		//      may delete later (dangling pointer in m_Files_map /
-		//      m_pathIndex). Detach the stale entry and install the
-		//      live one so the view mirrors knownfiles.
+		// AddFile failed because some CKnownFile under this hash is already in
+		// m_Files_map. Two possibilities: the exact same pointer was re-added, in
+		// which case this is a no-op; or CKnownFileList::Append fired the
+		// rename-during-hash branch (same hash, same size, different name), which
+		// demoted the prior CKnownFile to m_duplicateFileList and installed
+		// `toadd` as canonical. The shared-files view still points at the demoted
+		// pointer, whose filename no longer matches disk and which the
+		// duplicate-list prune may delete later. Detach the stale entry and
+		// install the live one so the view mirrors knownfiles.
 		CKnownFile *stale = NULL;
 		bool alreadyCanonical = false;
 		{
@@ -1002,25 +945,20 @@ void CSharedFileList::SafeAddKFile(CKnownFile *toadd, bool bOnlyAdd)
 				Notify_SharedFilesShowFile(toadd);
 			}
 		} else if (alreadyCanonical) {
-			// Same pointer, already the canonical shared entry, but its
-			// path may have moved since it was first shared: a partfile
-			// downloaded this session was keyed under the Temp dir and has
-			// just been re-added from CPartFile::CompleteFileEnded() with
-			// SetFilePath(Incoming). AddFile()'s insert no-ops here, so the
-			// index still points at the stale Temp path and the dir-watcher
-			// can't resolve a DELETE of the completed file. Re-key it.
+			// Same pointer, already the canonical shared entry, but its path may have
+			// moved since it was first shared: a partfile downloaded this session was
+			// keyed under the Temp dir and has just been re-added from
+			// CompleteFileEnded() with SetFilePath(Incoming). AddFile()'s insert
+			// no-ops here, so the index still points at the stale Temp path.
 			RefreshPathIndex(toadd);
-			// A download just completed. Because the file was shared as a
-			// partfile, its hash was already in the map, so AddFile()'s
-			// insert (which is what normally schedules the media probe) no-op'd
-			// above -- a media download would otherwise only get its FT_MEDIA_*
-			// tags on the next startup rescan. Now that it is complete on disk
-			// at its Incoming path, schedule the probe here. QueueProbe() only
-			// enqueues (it never runs ffprobe inline), so this cannot stall the
-			// completion. Completion mode bypasses BOTH gates -- the file is
-			// still a CPartFile object at this point -- so
-			// the authoritative local probe overwrites any metadata inherited
-			// from the search result, which is only a during-download preview.
+			// A download just completed. Because the file was shared as a partfile,
+			// its hash was already in the map, so AddFile()'s insert -- which is
+			// what normally schedules the media probe -- no-op'd above, and a media
+			// download would otherwise only get its FT_MEDIA_* tags on the next
+			// startup rescan. QueueProbe() only enqueues, so this cannot stall the
+			// completion. Completion mode bypasses BOTH gates -- the file is still a
+			// CPartFile object at this point -- so the authoritative local probe
+			// overwrites any metadata inherited from the search result.
 			MaybeScheduleMediaProbe(toadd, MediaProbeMode::Completion);
 		}
 	}
@@ -1039,11 +977,10 @@ void CSharedFileList::RefreshPathIndex(CKnownFile *file)
 	}
 	wxMutexLocker lock(list_mut);
 	const wxString key = NormalizePathKey(file->GetFilePath().JoinPaths(file->GetFileName()).GetRaw());
-	// Drop any stale keys pointing at this file (the pre-completion
-	// Temp/<name> entry, or the "" placeholder from a not-yet-pathed
-	// CPartFile) so the index maps only its current on-disk location.
-	// O(shared files), but only runs on the rare re-add of an
-	// already-shared file (download completion / re-share).
+	// Drop any stale keys pointing at this file (the pre-completion Temp/<name>
+	// entry, or the "" placeholder from a not-yet-pathed CPartFile) so the index
+	// maps only its current on-disk location. O(shared files), but only runs on
+	// the rare re-add of an already-shared file.
 	bool rekeyed = false;
 	for (std::unordered_map<wxString, CKnownFile *>::iterator it = m_pathIndex.begin();
 		it != m_pathIndex.end();) {
@@ -1056,15 +993,12 @@ void CSharedFileList::RefreshPathIndex(CKnownFile *file)
 	}
 	m_pathIndex[key] = file;
 	if (rekeyed) {
-		// The file moved without entering or leaving m_Files_map, so nothing
-		// else bumps the generation for it: AddFile()'s insert no-ops on a
-		// hash that is already shared. Anything caching a view of where files
-		// live has to be told, or it keeps serving the old location -- the
-		// directory grouping in GetSharedFilesByDirectory() would leave a
-		// completed download filed under Temp until some unrelated add or
-		// remove happened to invalidate it (issue #898). The pairwise walk it
-		// replaced re-read GetFilePath() every time and so never had to be
-		// told at all.
+		// The file moved without entering or leaving m_Files_map, so nothing else
+		// bumps the generation for it: AddFile()'s insert no-ops on a hash that is
+		// already shared. Anything caching a view of where files live has to be
+		// told, or it keeps serving the old location -- the directory grouping in
+		// GetSharedFilesByDirectory() would leave a completed download filed under
+		// Temp until some unrelated add or remove invalidated it.
 		m_listGeneration.fetch_add(1, std::memory_order_relaxed);
 		AddDebugLogLineN(
 			logKnownFiles, CFormat("Path index re-keyed to '%s' (file moved/completed)") % key);
@@ -1080,25 +1014,22 @@ void CSharedFileList::RemoveFile(CKnownFile *toremove)
 		m_listGeneration.fetch_add(1, std::memory_order_relaxed);
 		theStats::RemoveSharedFile(toremove->GetFileSize());
 	}
-	// Same path key we wrote into the index in AddFile(). erase() is a
-	// no-op if the entry isn't present (e.g. the file was inserted
-	// before m_pathIndex existed in an older save snapshot).
+	// Same path key we wrote into the index in AddFile(). erase() is a no-op if
+	// the entry is not present.
 	//
-	// The premise -- that the key we recompute here is the key AddFile wrote
-	// -- holds only while GetFilePath() still matches what was indexed. When
-	// it does not, this erase silently misses and leaves the real entry
-	// behind, which then makes the file permanently unshareable because
-	// NotifyPathAdded short-circuits on it. That is invisible without the
-	// diagnostic below, which is how issue #1017 survived unnoticed.
+	// The premise -- that the key recomputed here is the key AddFile wrote --
+	// holds only while GetFilePath() still matches what was indexed. When it
+	// does not, this erase silently misses and leaves the real entry behind,
+	// which then makes the file permanently unshareable because NotifyPathAdded
+	// short-circuits on it. That is invisible without the diagnostic below.
 	const wxString key =
 		NormalizePathKey(toremove->GetFilePath().JoinPaths(toremove->GetFileName()).GetRaw());
 	const size_t erasedFromIndex = m_pathIndex.erase(key);
 	// `reloading` suppresses the check for the duration of a walk. The index is
-	// cleared at the start of one and refilled as the walk proceeds, so a
-	// removal that lands mid-walk -- CUploadDiskIOThread calls RemoveFile from
-	// a worker thread -- legitimately finds nothing to erase. Without this the
-	// hardening would cry wolf on every such removal, which is worse than not
-	// having it (issue #1028).
+	// cleared at the start of one and refilled as the walk proceeds, so a removal
+	// that lands mid-walk -- CUploadDiskIOThread calls RemoveFile from a worker
+	// thread -- legitimately finds nothing to erase, and the hardening would cry
+	// wolf on every such removal.
 	if (erasedFromIndex == 0 && !m_pathIndex.empty() && !reloading) {
 		// Not fatal on its own -- the older-snapshot case above is legitimate
 		// -- but it is the signature of a desynchronised index, so say so
@@ -1112,11 +1043,10 @@ void CSharedFileList::RemoveFile(CKnownFile *toremove)
 	m_keywords->RemoveKeywords(toremove);
 }
 
-// Incremental rescan entry points used by CSharedDirWatcher.
-//
-// These exist so the watcher can apply a single fs-watcher event
-// without firing the bulk Reload() path, which on a 100 k+ file
-// shareset blocks the GUI for minutes per event. See issue #745.
+// Incremental rescan entry points used by CSharedDirWatcher. These exist so
+// the watcher can apply a single fs-watcher event without firing the bulk
+// Reload() path, which on a 100 k+ file shareset blocks the GUI for minutes
+// per event.
 
 void CSharedFileList::NotifyPathAdded(const wxString &fullPath, bool bulkScan)
 {
@@ -1124,12 +1054,11 @@ void CSharedFileList::NotifyPathAdded(const wxString &fullPath, bool bulkScan)
 		return;
 	}
 
-	// Already shared? CPartFile::CompleteFile() and SafeAddKFile() are
-	// the canonical add paths for completed downloads — by the time
-	// the watcher's CREATE event fires for a freshly-renamed file in
-	// Incoming, the CKnownFile is usually already in m_Files_map and
-	// the path index. Nothing to do in that case. Scoped lock so we
-	// drop list_mut before doing any filesystem work.
+	// Already shared? CPartFile::CompleteFile() and SafeAddKFile() are the
+	// canonical add paths for completed downloads -- by the time the watcher's
+	// CREATE event fires for a freshly-renamed file in Incoming, the CKnownFile
+	// is usually already in m_Files_map and the path index. Scoped lock so
+	// list_mut is dropped before any filesystem work.
 	{
 		wxMutexLocker existsCheck(list_mut);
 		if (m_pathIndex.find(NormalizePathKey(fullPath)) != m_pathIndex.end()) {
@@ -1160,18 +1089,15 @@ void CSharedFileList::NotifyPathAdded(const wxString &fullPath, bool bulkScan)
 		}
 		break;
 	case kAddPathKnown:
-		// A file already in known.met, moved or renamed into a shared
-		// directory: nothing is hashed and nothing is probed, so without this
-		// the file would silently become shared and be published to peers with
-		// no info-level record at all (issue #968).
+		// A file already in known.met, moved or renamed into a shared directory:
+		// nothing is hashed and nothing is probed, so without this the file would
+		// silently become shared and be published to peers with no info-level
+		// record at all.
 		//
 		// Deliberately here and not inside AddPathToShares, which the bulk walk
 		// also calls: there the already-known case is the overwhelming majority
-		// of entries, and one line per file would bury everything else under
-		// thousands of "nothing happened" lines on every rescan. The watcher
-		// path is different in kind -- it is an event, it fires at
-		// unpredictable times, its volume is bounded by real filesystem
-		// activity rather than by tree size, and no summary line covers it.
+		// of entries. The watcher path is different in kind -- it is an event, it
+		// fires at unpredictable times, and no summary line covers it.
 		if (bulkScan) {
 			// One line per file would be thousands during a tree walk; the
 			// tick prints a single summary instead.
@@ -1249,21 +1175,16 @@ void CSharedFileList::NotifyDirRemoved(const wxString &dirPath)
 		return;
 	}
 
-	// One summary line, not one per file: a removed subtree can hold thousands
-	// of files and the count is already in hand.
+	// One summary line, not one per file: a removed subtree can hold thousands of
+	// files and the count is already in hand.
 	//
 	// The count is what this call actually detached, which on some backends is
 	// only part of the subtree. macOS FSEvents delivers per-file DELETEs racing
 	// the directory DELETE, so NotifyPathRemoved above already detached some
-	// files individually (each with its own line) and only the remainder is
-	// left for this sweep -- removing a 6-file directory was observed as four
-	// per-file lines plus a summary saying two. Every file is still logged
-	// exactly once and none is double-counted, so the accounting is right even
-	// though the shape is not the single tidy line it is on a backend that
-	// coalesces the subtree into one event. Reporting the directory's original
-	// size instead would be a lie about what this call did, and suppressing the
-	// per-file lines would mean losing them whenever the directory event never
-	// arrives at all.
+	// files individually and only the remainder is left for this sweep. Every
+	// file is still logged exactly once and none is double-counted, so the
+	// accounting is right even though the shape is not the single tidy line it
+	// is on a backend that coalesces the subtree into one event.
 	AddLogLineN(CFormat(wxPLURAL("Stopped sharing %u file under removed directory: %s",
 			    "Stopped sharing %u files under removed directory: %s",
 			    static_cast<unsigned>(victims.size()))) %
@@ -1341,31 +1262,26 @@ bool CSharedFileList::Reload(ReloadYieldCb yieldCb)
 	// deltaHF - removed the old ugly button and changed the code to use the new small one
 	// Kry - bah, let's use a var.
 	if (reloading) {
-		// Already running. The walk in flight started before this caller's
-		// roots or filters were in place, so it cannot be the fresh scan they
-		// asked for -- leave a request standing so the next tick runs one.
-		// Without this a caller that commits new shared roots and reads the
-		// return as success persists them and never walks them.
-		//
-		// Surfaced to the caller as a non-abort, non-complete state: they
-		// shouldn't react as if they cancelled, but haven't completed a
-		// fresh scan either.
+		// Already running. The walk in flight started before this caller's roots or
+		// filters were in place, so it cannot be the fresh scan they asked for --
+		// leave a request standing so the next tick runs one. Without this a
+		// caller that commits new shared roots and reads the return as success
+		// persists them and never walks them. Surfaced to the caller as a
+		// non-abort, non-complete state.
 		m_reloadLatch.Request();
 		return true;
 	}
 
 	// Take any outstanding RequestReload() with us: this walk is the one that
 	// satisfies it, so a GUI caller can run it (with progress) right after
-	// something requested one without Process() running a second, redundant
-	// walk a tick later. Anything requested from here on belongs to the next
-	// walk -- this one is already past the files it would be about -- and an
-	// abort below hands this request back rather than swallowing it.
+	// something requested one without Process() running a second, redundant walk
+	// a tick later. Anything requested from here on belongs to the next walk,
+	// and an abort below hands this request back rather than swallowing it.
 	const bool servingRequest = m_reloadLatch.BeginWalk();
 
 	// Info, not debug: now that EC callers get an immediate reply instead of
-	// blocking until the walk ends, the log is how they observe it starting.
-	// The end-of-walk "Found %i known shared files" summary is already an
-	// info line, so the two form a matched pair in release builds.
+	// blocking until the walk ends, the log is how they observe it starting. The
+	// end-of-walk summary is already an info line, so the two form a pair.
 	AddLogLineN(_("Reloading shared files..."));
 	reloading = true;
 	Notify_SharedFilesRemoveAllItems();
@@ -1392,11 +1308,10 @@ bool CSharedFileList::Reload(ReloadYieldCb yieldCb)
 
 	/* Public identifiers must be erased as they might be invalid now */
 	{
-		// Under list_mut: IsShared() builds m_sharedDirKeys through a const
-		// method and takes the lock to do it, so this side has to take it too
-		// or the lock buys nothing -- a reader would still be filling the set
-		// while this clears it. The public-name map and its index are cleared
-		// in the same scope so the pair cannot be seen half-emptied.
+		// Under list_mut: IsShared() builds m_sharedDirKeys through a const method
+		// and takes the lock to do it, so this side has to take it too. The
+		// public-name map and its index are cleared in the same scope so the pair
+		// cannot be seen half-emptied.
 		wxMutexLocker lock(list_mut);
 		m_PublicSharedDirNames.clear();
 		m_publicNameByDirKey.clear();
@@ -1421,13 +1336,11 @@ bool CSharedFileList::Reload(ReloadYieldCb yieldCb)
 		m_dirWatcher->Refresh();
 	}
 
-	// Tell KnownFileList that a full scan has now run -- this
-	// gates the duplicate-list cap-prune in Save(), so the prune
-	// never fires while the pin set is unpopulated (which would
-	// drop records the scan was about to pin). Only on non-aborted
-	// scans: a cancelled mid-scan leaves the pin set partial.
-	// A cancelled walk satisfies nothing, so give the request back and let a
-	// later tick run it properly.
+	// Tell KnownFileList that a full scan has now run -- this gates the
+	// duplicate-list cap-prune in Save(), so the prune never fires while the pin
+	// set is unpopulated, which would drop records the scan was about to pin.
+	// Only on non-aborted scans: a cancelled mid-scan leaves the pin set
+	// partial, and satisfies no request, so the request is handed back.
 	m_reloadLatch.EndWalk(servingRequest, aborted);
 
 	if (!aborted && filelist) {
@@ -1499,10 +1412,9 @@ void CSharedFileList::GetSharedFilesByDirectory(const wxString &directory, CKnow
 {
 	wxMutexLocker lock(list_mut);
 
-	// Answered from the grouping rather than by walking every shared file:
-	// a browsing peer asks one directory at a time, and the walk made that
+	// Answered from the grouping rather than by walking every shared file: a
+	// browsing peer asks one directory at a time, and the walk made that
 	// O(directories x files) IsSameDir() calls, each normalising both paths.
-	// See m_dirGroups (issue #898).
 	const uint64 generation = m_listGeneration.load(std::memory_order_relaxed);
 	if (!m_dirGroupsBuilt || m_dirGroupsAt != generation) {
 		m_dirGroups.clear();
@@ -1529,12 +1441,10 @@ void CSharedFileList::ClearED2KPublishInfo()
 	m_lastPublishED2KFlag = true;
 	wxMutexLocker lock(list_mut);
 	// Suppress per-row GUI updates while we walk every shared file.
-	// SetPublishedED2K() notifies the SharedFilesCtrl which does an
-	// O(N) FindItem per call; without this, a 100k-file shared list
-	// makes every server disconnect freeze the main thread for
-	// minutes. SetPublishedED2K() is also a no-op when the value
-	// didn't change, so the genuinely-false→false majority is free.
-	// See #302.
+	// SetPublishedED2K() notifies the SharedFilesCtrl, which does an O(N)
+	// FindItem per call; without this, a 100k-file shared list makes every
+	// server disconnect freeze the main thread for minutes. SetPublishedED2K()
+	// is also a no-op when the value did not change.
 	Notify_SharedFilesBeginBulkUpdate();
 	for (CKnownFileMap::iterator pos = m_Files_map.begin(); pos != m_Files_map.end(); ++pos) {
 		cur_file = pos->second;
@@ -1631,15 +1541,12 @@ void CSharedFileList::SendListToServer()
 
 	CMemFile files;
 
-	// Files-sent count is patched in after the loop. We can't write the
-	// final number up-front because the loop body filters out >4GB files
-	// when the server doesn't advertise SRV_TCPFLG_LARGEFILES, and we
-	// only know how many actually made it into the packet once the loop
-	// has run. Pre-fix the header was hard-coded to `limit`, so the
-	// packet header claimed N files but the body could carry N-K of them
-	// for any K >4GB files in the prefix; legacy non-LF servers see a
-	// short read against the count and may reject or partially process
-	// the publish (#347).
+	// Files-sent count is patched in after the loop. The final number cannot be
+	// written up front because the loop body filters out >4GB files when the
+	// server does not advertise SRV_TCPFLG_LARGEFILES, and how many made it
+	// into the packet is only known once the loop has run. Hard-coding `limit`
+	// made the header claim N files while the body carried N-K, and a legacy
+	// non-LF server sees a short read against the count.
 	files.WriteUInt32(0);
 
 	uint32 count = 0;
@@ -1654,12 +1561,10 @@ void CSharedFileList::SendListToServer()
 		file->SetPublishedED2K(true);
 	}
 
-	// Nothing to publish to this server (e.g. every unpublished file in
-	// our prefix is >4GB and the server doesn't advertise
-	// SRV_TCPFLG_LARGEFILES). Sending an OP_OFFERFILES with count=0
-	// would just be ~28 bytes of TCP overhead per ED2KREPUBLISHTIME
-	// tick — the server gets no information from "0 offered" that it
-	// didn't already have from us being silent.
+	// Nothing to publish to this server -- e.g. every unpublished file in our
+	// prefix is >4GB and the server does not advertise SRV_TCPFLG_LARGEFILES.
+	// Sending an OP_OFFERFILES with count=0 would just be ~28 bytes of TCP
+	// overhead per republish tick.
 	if (count == 0) {
 		return;
 	}
@@ -1669,14 +1574,11 @@ void CSharedFileList::SendListToServer()
 	files.WriteUInt32(count);
 
 	CPacket *packet = new CPacket(files, OP_EDONKEYPROT, OP_OFFERFILES);
-	// compress packet
-	//   - this kind of data is highly compressible (N * (1 MD4 and at least 3 string meta data tags and 1
-	//   integer meta data tag))
-	//   - the min. amount of data needed for one published file is ~100 bytes
-	//   - this function is called once when connecting to a server and when a file becomes shareable -
-	//   so, it's called rarely.
-	//   - if the compressed size is still >= the original size, we send the uncompressed packet
-	// therefore we always try to compress the packet
+	// Compress the packet: this kind of data is highly compressible (per file, an
+	// MD4 plus at least three string meta tags and one integer one), the minimum
+	// per published file is ~100 bytes, and this is called rarely -- once on
+	// connecting to a server and when a file becomes shareable. If the
+	// compressed size is still >= the original, the uncompressed packet is sent.
 	if (server->GetTCPFlags() & SRV_TCPFLG_COMPRESSION) {
 		packet->PackPacket();
 	}
@@ -1687,21 +1589,18 @@ void CSharedFileList::SendListToServer()
 
 void CSharedFileList::Process()
 {
-	// Deferred reloads requested by callers on the core event loop (EC
-	// handlers, the watcher's dropped-events fallback) run here rather than
-	// inline in the caller. The `reloading` check means a request that
-	// arrives mid-walk stays pending and runs on a later tick instead of
-	// re-entering; Reload() would return early anyway, silently dropping it.
+	// Deferred reloads requested by callers on the core event loop (EC handlers,
+	// the watcher's dropped-events fallback) run here rather than inline in the
+	// caller. The `reloading` check means a request that arrives mid-walk stays
+	// pending and runs on a later tick instead of re-entering.
 	if (m_reloadLatch.ShouldStartFromTick(reloading)) {
 		Reload();
 	}
 
-	// Flushed after the drain above, so that when a reload runs on this tick
-	// its count is printed immediately after its own "Found N known shared
-	// files" summary rather than arriving a second later, detached from it.
-	// Only when non-zero: a pass that discovered nothing says nothing.
-	// Already-known files attached by a bulk subdirectory scan: one line for
-	// the batch, mirroring the summary the removal side emits.
+	// Flushed after the drain above, so that when a reload runs on this tick its
+	// count is printed immediately after its own "Found N known shared files"
+	// summary rather than arriving a second later, detached from it. Only when
+	// non-zero: a pass that discovered nothing says nothing.
 	if (m_attachedKnownFiles) {
 		AddLogLineN(CFormat(wxPLURAL("Now sharing %u file found in a new shared directory",
 				    "Now sharing %u files found in new shared directories",
@@ -1741,13 +1640,11 @@ void CSharedFileList::Publish()
 		if (Kademlia::CKademlia::GetTotalStoreKey() < KADEMLIATOTALSTOREKEY) {
 
 			// list_mut serialises CPublishKeywordList access against
-			// CUploadDiskIOThread's RemoveFile -> RemoveKeywords path,
-			// which mutates pPubKw->references and ref counts from a
-			// worker thread.  Without the lock the cursor advance and
-			// the GetReferences() iteration below race with that path
-			// (issue #685).  Kad's StartSearch / Go / GetClosestTo /
-			// SendFindValue do not re-enter list_mut, so the lock can
-			// be held across the Kad call.
+			// CUploadDiskIOThread's RemoveFile -> RemoveKeywords path, which mutates
+			// pPubKw->references and ref counts from a worker thread. Without the
+			// lock the cursor advance and the GetReferences() iteration below race
+			// with that path. Kad's StartSearch / Go / GetClosestTo / SendFindValue
+			// do not re-enter list_mut, so the lock can be held across the Kad call.
 			wxMutexLocker lock(list_mut);
 
 			// We are not at the max simultaneous keyword publishes
@@ -1976,16 +1873,14 @@ wxString CSharedFileList::GetPublicSharedDirName(const CPath &dir)
 		wxFAIL;
 		return "";
 	}
-	// check if the public name for the directory is cached in our Map.
-	// Keyed rather than walked: this runs once per shared directory while
-	// answering a browse, and comparing every entry with IsSameDir() made it
-	// O(directories^2) (issue #898).
+	// Check if the public name for the directory is cached in our map. Keyed
+	// rather than walked: this runs once per shared directory while answering a
+	// browse, and comparing every entry with IsSameDir() made it
+	// O(directories^2).
 	//
-	// Under list_mut, like the write further down and like IsShared(): a
-	// mutex only excludes participants who take it, so a reader outside it
-	// would make the locking on the other side worth nothing. Held for the
-	// lookup alone -- not across the IsShared() calls above and below, which
-	// take the same non-recursive mutex themselves.
+	// Under list_mut, like the write further down and like IsShared(). Held for
+	// the lookup alone -- not across the IsShared() calls above and below,
+	// which take the same non-recursive mutex themselves.
 	{
 		wxMutexLocker lock(list_mut);
 		const std::map<wxString, wxString>::const_iterator cached =

--- a/src/SharedFileList.h
+++ b/src/SharedFileList.h
@@ -61,12 +61,10 @@ public:
 	CSharedFileList(CKnownFileList *in_filelist);
 	~CSharedFileList();
 
-	// Yield/cancel hook for chunked reloads. Invoked periodically
-	// during the directory walk with the running count of files
-	// scanned so far. Returning false aborts the reload promptly and
-	// leaves whatever was added in place (partial commit). null is a
-	// no-op — kept that way for daemon-side and EC-triggered callers
-	// that don't have a UI to drive.
+	// Yield/cancel hook for chunked reloads, invoked periodically during the
+	// directory walk with the running count of files scanned. Returning false
+	// aborts the reload promptly and leaves whatever was added in place. null is a
+	// no-op, for daemon-side and EC-triggered callers with no UI to drive.
 	using ReloadYieldCb = std::function<bool(size_t /*filesScanned*/)>;
 
 	void Reload();
@@ -74,27 +72,27 @@ public:
 	// walk completed normally, false if `yieldCb` requested abort.
 	bool Reload(ReloadYieldCb yieldCb);
 
-	// Ask for a full shared-files reload to run from the next Process()
-	// tick instead of inline in the caller. Callers that sit on the core
-	// event loop -- every EC request handler, and the directory watcher's
-	// dropped-events fallback -- use this so they can answer immediately
-	// rather than blocking for the whole walk. On a large or network-
-	// mounted share tree that walk is seconds to minutes, and because
-	// amuleapi's EC lane is a single serialised worker, a blocking reload
-	// there stalls the refresher and turns unrelated endpoints into 503s.
+	// Ask for a full shared-files reload to run from the next Process() tick
+	// instead of inline in the caller. Callers that sit on the core event loop --
+	// every EC request handler, and the directory watcher's dropped-events
+	// fallback -- use this so they can answer immediately rather than blocking for
+	// the whole walk. On a large or network-mounted share tree that walk takes
+	// seconds to minutes, and since amuleapi's EC lane is a single serialised
+	// worker, a blocking reload there stalls the refresher and turns unrelated
+	// endpoints into 503s.
 	//
 	// Repeat requests before the tick coalesce into one walk, and a request
 	// arriving mid-walk keeps the flag set so it runs afterwards instead of
 	// nesting.
 	//
-	// A plain bool is deliberate: every setter and the reader run on the
-	// core event loop. If a caller off that thread ever needs this, that
-	// caller is the thing to fix -- do not make this atomic.
+	// A plain bool is deliberate: every setter and the reader run on the core
+	// event loop. A caller off that thread is the thing to fix -- do not make this
+	// atomic.
 	void RequestReload() { m_reloadLatch.Request(); }
 
-	// True when a RequestReload() is outstanding. GUI callers use this to run
-	// the owed walk themselves behind a progress dialog rather than letting it
-	// land silently on a Process() tick -- see ReloadSharedFilesWithProgress().
+	// True when a RequestReload() is outstanding. GUI callers use this to run the
+	// owed walk themselves behind a progress dialog rather than letting it land
+	// silently on a Process() tick.
 	bool IsReloadPending() const { return m_reloadLatch.IsPending(); }
 	void SafeAddKFile(CKnownFile *toadd, bool bOnlyAdd = false);
 	void RemoveFile(CKnownFile *toremove);
@@ -147,20 +145,17 @@ public:
 	bool RenameFile(CKnownFile *pFile, const CPath &newName);
 	void VerifyLocalData(const CKnownFile *file) const;
 
-	// Re-extract media metadata for every shared file, whether or not it has
-	// any already. Returns how many probes were queued.
+	// Re-extract media metadata for every shared file, whether or not it has any
+	// already. Returns how many probes were queued.
 	//
-	// This is the only way to correct a file whose metadata is wrong rather
-	// than missing: the scheduler skips anything that already carries a media
-	// tag, so a value stored by an older build -- a cover-art codec, or a
-	// preview inherited from a search result before the local probe could
-	// overwrite it -- is otherwise permanent short of deleting known.met,
-	// which would also discard the ed2k part hashes and every per-file
+	// This is the only way to correct a file whose metadata is wrong rather than
+	// missing: the scheduler skips anything that already carries a media tag, so a
+	// value stored by an older build is otherwise permanent short of deleting
+	// known.met, which would also discard the ed2k part hashes and every per-file
 	// statistic.
 	//
-	// Asynchronous: the work is queued on the media-probe worker and this
-	// returns immediately. Nothing else about a file is touched -- it is not
-	// re-hashed, its hash does not change, and it never leaves the share.
+	// Asynchronous: the work is queued on the media-probe worker. Nothing else
+	// about a file is touched -- it is not re-hashed and never leaves the share.
 	unsigned RefreshAllMediaMetadata();
 
 	// The single-file form, addressed by hash. Returns false when no shared
@@ -168,11 +163,10 @@ public:
 	// extension, or an incomplete download.
 	bool RefreshMediaMetadata(const CMD4Hash &hash);
 
-	// The batched form the GUI uses. Returns how many probes were queued.
-	// Exists so amulegui can send ONE EC request for a selection rather than
-	// one per file: its request fifo stalls the GUI's own polling past about
-	// twenty in flight, and a "select all, refresh" would otherwise put one
-	// packet per shared file into the socket in a tight loop.
+	// The batched form the GUI uses; returns how many probes were queued. Exists
+	// so amulegui can send ONE EC request for a selection: its request fifo stalls
+	// the GUI's own polling past about twenty in flight, and a "select all,
+	// refresh" would otherwise put one packet per shared file into the socket.
 	unsigned RefreshMediaMetadata(const std::vector<CMD4Hash> &hashes);
 
 	/**
@@ -213,26 +207,23 @@ public:
 	 */
 	void EnableDirectoryWatcher(bool enable);
 
-	// Incremental-rescan entry points used by CSharedDirWatcher to apply
-	// a single fs-watcher event without re-walking every shared dir.
-	// fullPath is the raw filesystem path of the affected entry.
+	// Incremental-rescan entry points used by CSharedDirWatcher to apply a single
+	// fs-watcher event without re-walking every shared dir. fullPath is the raw
+	// filesystem path of the affected entry.
 	//
-	// NotifyPathAdded queues a hashing task for an unknown file, no-ops
-	// if the file is already shared. NotifyPathRemoved looks the path up
-	// in m_pathIndex and detaches the matching CKnownFile from the
-	// shared list. NotifyPathModified treats a content-change as
-	// remove-then-add when mtime/size have shifted (otherwise no-op).
+	// NotifyPathAdded queues a hashing task for an unknown file and no-ops if the
+	// file is already shared. NotifyPathRemoved looks the path up in m_pathIndex
+	// and detaches the matching CKnownFile. NotifyPathModified treats a
+	// content-change as remove-then-add when mtime/size have shifted.
 	//
-	// All three are safe to call from the wxFileSystemWatcher event
-	// thread (i.e. wx's main thread on every supported backend), and
-	// take list_mut internally via AddFile/RemoveFile.
+	// All three are safe to call from the wxFileSystemWatcher event thread (wx's
+	// main thread on every supported backend) and take list_mut internally.
+	//
 	// bulkScan: the caller is walking a whole directory tree (the watcher's
-	// new-subdirectory race scan), not reacting to a single filesystem event.
-	// In that mode an already-known file is counted rather than announced
-	// individually -- moving a large known tree into a recursive share would
-	// otherwise emit one info line per file, thousands of them, in a single
-	// debounce flush on the core event loop. Removal already summarises, so
-	// this also keeps the two directions symmetric.
+	// new-subdirectory race scan) rather than reacting to a single event. In that
+	// mode an already-known file is counted rather than announced individually --
+	// moving a large known tree into a recursive share would otherwise emit
+	// thousands of info lines in one debounce flush on the core event loop.
 	void NotifyPathAdded(const wxString &fullPath, bool bulkScan = false);
 	void NotifyPathRemoved(const wxString &fullPath);
 	void NotifyPathModified(const wxString &fullPath);
@@ -247,70 +238,59 @@ private:
 
 	bool AddFile(CKnownFile *pFile);
 
-	// Re-key m_pathIndex for an already-shared file whose on-disk path
-	// changed since it was first added. A partfile shared while
-	// downloading is keyed under the Temp dir (or "" before SetFilePath
-	// ran); on completion it moves to Incoming with SetFilePath(), but
-	// AddFile only writes m_pathIndex on a fresh insert, so the re-add
-	// leaves the index pointing at the stale path. Drops any keys
-	// pointing at `file` and installs its current
-	// GetFilePath().JoinPaths(GetFileName()) key, so the dir-watcher can
-	// resolve a later DELETE of the completed file. Takes list_mut.
+	// Re-key m_pathIndex for an already-shared file whose on-disk path changed
+	// since it was added. A partfile shared while downloading is keyed under the
+	// Temp dir (or "" before SetFilePath ran) and moves to Incoming on completion,
+	// but AddFile only writes m_pathIndex on a fresh insert, so the re-add leaves
+	// the index pointing at the stale path. Drops any keys pointing at `file` and
+	// installs its current one, so the dir-watcher can resolve a later DELETE.
+	// Takes list_mut.
 	void RefreshPathIndex(CKnownFile *file);
 
-	// #140 — invoked by AddFile once list_mut is held. Kicks off a
-	// CMediaProbeTask when the preference is enabled and the file
-	// looks like media (audio / video by ED2K file type) and hasn't
-	// been probed yet. Returns silently if any gate fails.
+	// Invoked by AddFile once list_mut is held. Kicks off a CMediaProbeTask when
+	// the preference is enabled, the file looks like media by ED2K file type, and
+	// it has not been probed yet; returns silently if any gate fails.
 	//
 	// The mode says WHICH gates to bypass, because the two callers that bypass
 	// anything need different ones and a single "force" flag conflated them:
 	//
-	//  * Normal   -- both gates apply. Startup rescans probe each file at most
-	//                once and never touch an in-progress download.
-	//  * Completion -- both bypassed. The authoritative local probe must
-	//                overwrite metadata inherited from the search result, and
-	//                a just-completed download is STILL a CPartFile object, so
-	//                the partfile guard has to be lifted too. Safe only
-	//                because this fires exactly when the file has finished.
-	//  * Refresh  -- the metadata gate is bypassed, the partfile guard is NOT.
-	//                A whole-share walk must not inherit Completion's licence:
-	//                a genuinely incomplete download is in the shared list and
-	//                has no complete file to read.
+	//  * Normal     -- both gates apply.
+	//  * Completion -- both bypassed. The authoritative local probe must overwrite
+	//                  metadata inherited from the search result, and a
+	//                  just-completed download is STILL a CPartFile, so the
+	//                  partfile guard has to lift too. Safe only because this
+	//                  fires exactly when the file has finished.
+	//  * Refresh    -- the metadata gate is bypassed, the partfile guard is not: a
+	//                  genuinely incomplete download is in the shared list and has
+	//                  no complete file to read.
 	enum class MediaProbeMode
 	{
 		Normal,
 		Completion,
 		Refresh,
 	};
-	// Returns true when a probe was actually enqueued, so a caller can report
-	// what it did. Do NOT try to infer that from the worker's pending count:
+	// Returns true when a probe was actually enqueued, so a caller can report what
+	// it did. Do NOT infer that from the worker's pending count:
 	// CMediaProbeThread::Entry swaps the whole job list out as soon as it is
-	// signalled, so against an idle worker the count is back to zero before
-	// the caller can look and every enqueue reads as a no-op.
+	// signalled, so against an idle worker every enqueue reads as a no-op.
 	//
-	// `bulk` says whether this probe belongs to a mass operation (a share
-	// scan, a whole-share refresh) rather than to one file the user is
-	// looking at. It decides only logging verbosity, and it is passed rather
-	// than inferred downstream: the worker cannot tell, because it drains
-	// whatever happens to be queued when it wakes.
+	// `bulk` says whether this probe belongs to a mass operation rather than to
+	// one file the user is looking at. It decides logging verbosity only, and is
+	// passed rather than inferred downstream: the worker cannot tell, because it
+	// drains whatever happens to be queued when it wakes.
 	bool MaybeScheduleMediaProbe(
 		CKnownFile *pFile, MediaProbeMode mode = MediaProbeMode::Normal, bool bulk = false);
 
-	// Per-path attach: stat fname under directory, look it up in
-	// known.met, and either AddFile() the existing CKnownFile or push
-	// a CHashingTask onto hashTasks. Shared between the bulk-Reload
-	// directory walk and the per-event watcher dispatch so the two
-	// paths agree on what counts as shareable.
+	// Per-path attach: stat fname under directory, look it up in known.met, and
+	// either AddFile() the existing CKnownFile or push a CHashingTask onto
+	// hashTasks. Shared between the bulk-Reload walk and the per-event watcher
+	// dispatch so the two agree on what counts as shareable.
 	//
-	// notifyGuiOnKnownAdd: the bulk-Reload path repaints the whole
-	// shared-files view with Notify_SharedFilesShowFileList() once the
-	// walk finishes, so it leaves this false. The incremental watcher
-	// path has no such follow-up, so it passes true to get a per-file
-	// Notify_SharedFilesShowFile() when a known file is freshly attached
-	// (otherwise a re-shared file -- e.g. a rename in Incoming to a name
-	// already in known.met -- updates the core share set but never
-	// reaches the GUI view).
+	// notifyGuiOnKnownAdd: the bulk-Reload path repaints the whole view once the
+	// walk finishes, so it leaves this false. The incremental watcher path has no
+	// such follow-up and passes true, or a re-shared file (a rename in Incoming to
+	// a name already in known.met) would update the core share set but never reach
+	// the GUI view.
 	enum AddPathResult
 	{
 		//! Broken link, zero size, stat failed.
@@ -319,18 +299,17 @@ private:
 		kAddPathExcluded,
 		//! Matched a CKnownFile and was newly attached.
 		kAddPathKnown,
-		// Matched a CKnownFile that was *already* in the share set, so the add
-		// was declined -- the same content reachable from a second shared
-		// directory. (Not a repeated watcher event: NotifyPathAdded returns on
-		// an index hit before it ever reaches AddPathToShares.) Split out from
-		// kAddPathKnown because callers that announce a file becoming shared
-		// must not claim a share that did not happen.
+		// Matched a CKnownFile ALREADY in the share set, so the add was declined:
+		// the same content reachable from a second shared directory. (Not a
+		// repeated watcher event -- NotifyPathAdded returns on an index hit before
+		// reaching AddPathToShares.) Split out from kAddPathKnown so callers
+		// announcing a file becoming shared do not claim a share that did not
+		// happen.
 		//
-		// The file's path is left exactly as it was, which is load-bearing
-		// rather than incidental: AddFile writes m_pathIndex only on a fresh
-		// insert, so stamping the second directory onto the file would leave
-		// GetFilePath() disagreeing with the key it is indexed under, and
-		// nothing reconciles the two (issue #1017).
+		// The file's path is left exactly as it was, which is load-bearing:
+		// AddFile writes m_pathIndex only on a fresh insert, so stamping the
+		// second directory onto the file would leave GetFilePath() disagreeing
+		// with the key it is indexed under, and nothing reconciles the two.
 		kAddPathAlreadyShared,
 		//! Unknown file; a CHashingTask was pushed.
 		kAddPathQueued
@@ -339,9 +318,8 @@ private:
 		const CPath &fname,
 		TaskList &hashTasks,
 		bool notifyGuiOnKnownAdd = false);
-	// scanned/aborted are in/out: the caller passes a running count
-	// and a flag that the dir walker flips on abort. Lets a single
-	// counter span all paths in one Reload() pass.
+	// scanned/aborted are in/out: the caller passes a running count and a flag the
+	// dir walker flips on abort, so one counter spans every path in a Reload().
 	unsigned AddFilesFromDirectory(const CPath &directory,
 		TaskList &hashTasks,
 		const ReloadYieldCb &yieldCb,
@@ -352,21 +330,18 @@ private:
 	// Atomic: RemoveFile() reads it off the upload worker thread (issue #1028).
 	std::atomic<bool> reloading;
 	// Set by RequestReload(), drained by Process(). The rules it enforces --
-	// coalescing, a mid-walk request belonging to the next walk, and an
-	// aborted walk giving its request back -- live in the latch so they can be
-	// tested without a CSharedFileList. See RequestReload().
+	// coalescing, a mid-walk request belonging to the next walk, an aborted walk
+	// giving its request back -- live in the latch so they can be tested without a
+	// CSharedFileList.
 	CSharedFilesReloadLatch m_reloadLatch;
 
-	// New files discovered since the last Process() tick, counted at the one
-	// place discovery is actually decided (AddPathToShares' queued branch) so
-	// every route is covered without plumbing: the bulk walk, the watcher's
-	// create and rename handling, a newly appeared shared subdirectory, and
-	// the modify-treated-as-add path. Flushed once per tick, which coalesces
-	// a batch of files into a single line instead of one per file.
+	// New files discovered since the last Process() tick, counted at the one place
+	// discovery is decided (AddPathToShares' queued branch) so every route is
+	// covered without plumbing. Flushed once per tick, which coalesces a batch of
+	// files into a single line.
 	//
-	// A plain unsigned is enough: every increment and the flush run on the
-	// main thread (the bulk walk, the filesystem-watcher event handler and
-	// the core timer are all the main thread).
+	// A plain unsigned is enough: every increment and the flush run on the main
+	// thread.
 	unsigned m_discoveredNewFiles = 0;
 
 	//! Already-known files attached during a bulk subdirectory scan, summarised
@@ -407,25 +382,21 @@ private:
 	// gains or loses an entry; atomic so it can be read without the lock.
 	std::atomic<uint64> m_listGeneration{ 0 };
 	// Secondary index keyed by full path so the watcher can resolve a
-	// DELETE/RENAME event to its CKnownFile* in O(1) without walking
-	// m_Files_map. Maintained alongside m_Files_map in AddFile() and
-	// RemoveFile(); both insertion and erase happen under list_mut so
-	// the two stay consistent. Key is the file's current
-	// GetFilePath().JoinPaths(GetFileName()) raw string.
+	// DELETE/RENAME event to its CKnownFile* in O(1) without walking m_Files_map.
+	// Maintained alongside it in AddFile() and RemoveFile(), both under list_mut.
+	// Key is the file's current GetFilePath().JoinPaths(GetFileName()) raw string.
 	//
-	// The invariant is "if and only if": an entry exists for a path exactly
-	// when a file currently in m_Files_map lives there. NotifyPathAdded,
-	// NotifyPathModified and NotifyDirRemoved all read a hit as proof the
-	// file is already shared, so an entry that outlives its file makes the
-	// watcher silently refuse to share that path -- it returns before its
-	// first log statement, so nothing is reported at any level.
+	// The invariant is "if and only if": an entry exists for a path exactly when a
+	// file currently in m_Files_map lives there. NotifyPathAdded,
+	// NotifyPathModified and NotifyDirRemoved all read a hit as proof the file is
+	// already shared, so an entry that outlives its file makes the watcher
+	// silently refuse to share that path -- it returns before its first log
+	// statement, so nothing is reported at any level.
 	//
 	// This is why FindSharedFiles clears it in the same locked scope as
-	// m_Files_map rather than leaving it to accumulate: the keys a reload
-	// cannot heal are exactly the ones whose files the walk no longer finds
-	// (issue #1028). Both containers are therefore empty from that clear
-	// until the walk refills them, and neither may be observed in between --
-	// one rule covering the two, not two rules that can drift apart.
+	// m_Files_map: the keys a reload cannot heal are exactly the ones whose files
+	// the walk no longer finds (issue #1028). Both containers are empty from that
+	// clear until the walk refills them, and neither may be observed in between.
 	std::unordered_map<wxString, CKnownFile *> m_pathIndex;
 	mutable wxMutex list_mut;
 
@@ -467,9 +438,9 @@ private:
 	uint32 m_lastPublishKadSrc;
 	uint32 m_lastPublishKadNotes;
 
-	// Fs-watcher for auto-rescan of shared dirs. Owned here; created
-	// lazily on EnableDirectoryWatcher(true). Forward-declared in this
-	// header to keep wx/fswatcher.h out of public includes.
+	// Fs-watcher for auto-rescan of shared dirs. Owned here, created lazily on
+	// EnableDirectoryWatcher(true), forward-declared to keep wx/fswatcher.h out of
+	// public includes.
 	CSharedDirWatcher *m_dirWatcher;
 };
 

--- a/src/SharedFilesCtrl.cpp
+++ b/src/SharedFilesCtrl.cpp
@@ -72,14 +72,12 @@ enum class MediaRefreshEligibility
 MediaRefreshEligibility ClassifyForMediaRefresh(const CKnownFile *file)
 {
 	// First, because it decides the answer for every file at once: with the
-	// feature off the scheduler drops the job before looking at the file, so
-	// the entry would be enabled and do nothing at all -- which is exactly
-	// what happens today and gives the user no clue why.
+	// feature off the scheduler drops the job before looking at the file, so the
+	// entry would be enabled and do nothing at all, with no clue why.
 	//
-	// Correct in amulegui too. The daemon sends this preference over EC as a
-	// presence tag, and the receiving side maps an absent tag to false
-	// (ApplyBoolean in ECSpecialMuleTags), so a remote GUI reports the
-	// DAEMON's setting rather than its own default.
+	// Correct in amulegui too: the daemon sends this preference over EC as a
+	// presence tag and the receiving side maps an absent tag to false, so a
+	// remote GUI reports the DAEMON's setting rather than its own default.
 	if (!thePrefs::GetMediaMetadataEnabled()) {
 		return MediaRefreshEligibility::FeatureDisabled;
 	}
@@ -186,13 +184,11 @@ CSharedFilesCtrl::CSharedFilesCtrl(wxWindow *parent, int id, const wxPoint &pos,
 	// when the config has something saved.
 	ApplySorting(COLUMN_SHARED_NAME, 0);
 
-	// The media columns are only filled for files ffprobe has been run over,
-	// so a share that has never been probed would gain three empty columns
-	// for everyone. Listed in the header menu, hidden until asked for --
-	// widths above are what they get when enabled, which is why they are not
-	// registered as zero-width. Set before LoadColumnSettings() so anything
-	// the user saved wins, the same ordering CServerListCtrl uses for its
-	// wire-flag columns.
+	// The media columns are only filled for files ffprobe has been run over, so a
+	// share that has never been probed would gain three empty columns for
+	// everyone. Listed in the header menu, hidden until asked for -- the widths
+	// above are what they get when enabled. Set before LoadColumnSettings() so
+	// anything the user saved wins.
 	SetColumnHidden(COLUMN_SHARED_MEDIA_LENGTH, true, 0);
 	SetColumnHidden(COLUMN_SHARED_MEDIA_BITRATE, true, 0);
 	SetColumnHidden(COLUMN_SHARED_MEDIA_CODEC, true, 0);
@@ -299,15 +295,13 @@ void CSharedFilesCtrl::OnItemRightClicked(wxDataViewEvent &event)
 		m_menu->Append(MP_EXPORTCOLLECTION, _("Export selected files to an emulecollection"));
 
 		// The bar column is the only cell in this list whose colours need
-		// explaining, and it explains two unrelated things depending on the
-		// row, so the legend is chosen from the clicked file: right-click a
-		// file being re-hashed and the hashing legend opens, not the
-		// availability one.
+		// explaining, and it explains two unrelated things depending on the row,
+		// so the legend is chosen from the clicked file: right-click a file being
+		// re-hashed and the hashing legend opens, not the availability one.
 		//
 		// Guarded by IsColumnHidden() rather than by
-		// CGenericClientListCtrl::FindBarLegendColumn(), which is a member of
-		// the other list and does not reach here. Model id and view position
-		// coincide -- InitColumnState() requires it -- so COLUMN_SHARED_PART
+		// CGenericClientListCtrl::FindBarLegendColumn(), which is a member of the
+		// other list. Model id and view position coincide, so COLUMN_SHARED_PART
 		// answers both. A bar the user has hidden is not on screen to explain.
 		const partbar::BarLegendKind legend =
 			partbar::LegendForSharedFilesRow(file->GetHashingProgress(), file->GetPartCount());
@@ -316,15 +310,15 @@ void CSharedFilesCtrl::OnItemRightClicked(wxDataViewEvent &event)
 			m_menu->Append(MP_BARLEGEND, _("Colour legend"));
 		}
 
-		// Offered only when the file is reachable from this host: the shared
-		// list carries the daemon's directory in amulegui, which resolves here
-		// only on a shared filesystem, and a locally shared file can have been
-		// moved or deleted since it was hashed.
+		// Offered only when the file is reachable from this host: the shared list
+		// carries the daemon's directory in amulegui, which resolves here only on
+		// a shared filesystem, and a locally shared file can have been moved since
+		// it was hashed.
+		//
 		// CSharedFileList shares PS_READY part files, so an entry here can be an
-		// in-progress download. Gate it exactly as the Downloads list does:
-		// a finished file of any type can be opened, an unfinished one only when
+		// in-progress download. Gated exactly as the Downloads list does it: a
+		// finished file of any type can be opened, an unfinished one only when
 		// enough of the media is on disk to play.
-		// IsPartFile() establishes the dynamic type, as in FileLaunch::ResolvePath.
 		const bool previewable =
 			file->IsPartFile() ? static_cast<CPartFile *>(file)->PreviewAvailable() : true;
 		m_menu->SetLabel(
@@ -336,10 +330,9 @@ void CSharedFilesCtrl::OnItemRightClicked(wxDataViewEvent &event)
 		m_menu->Enable(MP_VIEW, previewable && canOpen);
 		m_menu->Enable(MP_SHOWINFOLDER, canReveal);
 		if (isCollection) {
-			// Reading a collection means reading its bytes on this host, so it
-			// needs the same reachability as opening the file. A part file is
-			// excluded on top of that: it is a truncated collection, not a
-			// usable one.
+			// Reading a collection means reading its bytes on this host, so it needs
+			// the same reachability as opening the file. A part file is excluded on
+			// top of that: it is a truncated collection, not a usable one.
 			m_menu->Enable(MP_ADDCOLLECTION, canOpen && !file->IsPartFile());
 		}
 		m_menu->Enable(MP_GETAICHED2KLINK, file->HasProperAICHHashSet());

--- a/src/SharedFilesCtrl.h
+++ b/src/SharedFilesCtrl.h
@@ -332,13 +332,11 @@ private:
 	//! disagree about what the action would do.
 	struct MediaRefreshSelection
 	{
-		// Hashes, not CKnownFile pointers. The confirmation dialog runs a
-		// nested event loop, and in amulegui the EC poll timer keeps running
-		// inside it -- CKnownFilesRem::DeleteItem ends in `delete file` for
-		// anything the daemon stops listing, so a pointer collected before the
-		// dialog can be dangling after it. A hash cannot dangle, and the
-		// refresh call takes one anyway; a file that went away in the meantime
-		// simply fails to resolve.
+		// Hashes, not CKnownFile pointers. The confirmation dialog runs a nested
+		// event loop, and in amulegui the EC poll timer keeps running inside it --
+		// CKnownFilesRem::DeleteItem ends in `delete file` for anything the daemon
+		// stops listing, so a pointer collected before the dialog can dangle after
+		// it. A hash cannot, and a file that went away simply fails to resolve.
 		std::vector<CMD4Hash> eligible;
 		unsigned incomplete = 0; //!< in-progress downloads, nothing complete to read
 		unsigned notMedia = 0;   //!< not audio or video

--- a/src/SharedFilesWnd.cpp
+++ b/src/SharedFilesWnd.cpp
@@ -70,9 +70,9 @@ CSharedFilesWnd::CSharedFilesWnd(wxWindow *pParent)
 	wxASSERT(peerslistctrl);
 
 	// Render the initial "Total size: 0 bytes" for an empty share.
-	// CSharedFilesCtrl::ShowFilesCount() can't do it yet: it reaches the label
-	// through theApp->amuledlg->m_sharedfileswnd, which isn't assigned until
-	// this constructor returns. The widget lives under this window.
+	// CSharedFilesCtrl::ShowFilesCount() cannot do it yet: it reaches the label
+	// through theApp->amuledlg->m_sharedfileswnd, which is not assigned until this
+	// constructor returns.
 	if (wxStaticText *totalSize = CastChild("sharedFilesTotalSize", wxStaticText)) {
 		totalSize->SetLabel(CFormat(_("Total size of Shared Files: %s")) % CastItoXBytes(0));
 	}
@@ -83,11 +83,9 @@ CSharedFilesWnd::CSharedFilesWnd(wxWindow *pParent)
 
 	wxConfigBase *config = wxConfigBase::Get();
 
-	// Check if the clientlist is hidden
 	bool show = true;
 	config->Read("/GUI/SharedWnd/ShowClientList", &show, true);
 	peerslistctrl->SetShowing(show);
-	// Load the last used splitter position
 	m_splitter = config->Read("/GUI/SharedWnd/Splitter", 463l);
 	m_clientShow = (EClientShow)config->Read("/GUI/SharedWnd/ClientShowMode", ClientShowAll);
 	SetClientShowMode(m_clientShow);
@@ -126,18 +124,14 @@ CSharedFilesWnd::~CSharedFilesWnd()
 		wxConfigBase *config = wxConfigBase::Get();
 
 		if (!peerslistctrl->GetShowing()) {
-			// Save the splitter position
 			config->Write("/GUI/SharedWnd/Splitter", m_splitter);
 
-			// Save the visible status of the list
 			config->Write("/GUI/SharedWnd/ShowClientList", false);
 		} else {
 			wxSplitterWindow *splitter = CastChild("sharedsplitterWnd", wxSplitterWindow);
 
-			// Save the splitter position
 			config->Write("/GUI/SharedWnd/Splitter", splitter->GetSashPosition());
 
-			// Save the visible status of the list
 			config->Write("/GUI/SharedWnd/ShowClientList", true);
 		}
 		config->Write("/GUI/SharedWnd/ClientShowMode", (int)m_clientShow);
@@ -150,12 +144,10 @@ CSharedFilesWnd::~CSharedFilesWnd()
 // part and only depends on the selection in ClientShowSelected mode.
 void CSharedFilesWnd::UpdateSelectionStats()
 {
-	// Bars fill with this session's share of the file's all-time activity
-	// (session / all-time -- the same two numbers as each label). Both come
-	// from the per-file EC counters, so it is reliable in the remote GUI --
-	// unlike a library-wide "total", which can't be gotten cheaply here -- and
-	// the per-mille scale keeps TB-scale byte counts inside the gauge's int
-	// range (raw bytes, even /1024, overflow it and blank the bar).
+	// Bars fill with this session's share of the file's all-time activity -- the
+	// same two numbers as each label. Both come from the per-file EC counters, so it
+	// is reliable in the remote GUI, and the per-mille scale keeps TB-scale byte
+	// counts inside the gauge's int range, which raw bytes overflow.
 	m_bar_requests->SetRange(1000);
 	m_bar_accepted->SetRange(1000);
 	m_bar_transfer->SetRange(1000);
@@ -202,17 +194,14 @@ void CSharedFilesWnd::UpdateSelectionStats()
 		uint64 pm = (uint64)1000 * sess / all;
 		return (int)(pm > 1000 ? 1000 : pm);
 	};
-	// Requests
 	m_bar_requests->SetValue(sharePerMille(session_requests, all_requests));
 	wxString labelReq = CFormat("%d / %d") % session_requests % all_requests;
 	CastChild(IDC_SREQUESTED, wxStaticText)->SetLabel(labelReq);
 
-	// Accepted requests
 	m_bar_accepted->SetValue(sharePerMille(session_accepted, all_accepted));
 	wxString labelAcc = CFormat("%d / %d") % session_accepted % all_accepted;
 	CastChild(IDC_SACCEPTED, wxStaticText)->SetLabel(labelAcc);
 
-	// Transferred
 	m_bar_transfer->SetValue(sharePerMille(session_transferred, all_transferred));
 	wxString labelTrans = CastItoXBytes(session_transferred) + " / " + CastItoXBytes(all_transferred);
 	CastChild(IDC_STRANSFERRED, wxStaticText)->SetLabel(labelTrans);
@@ -245,10 +234,10 @@ void CSharedFilesWnd::SelectionUpdated()
 		// ShowSources() requires the file vector sorted (see CGenericClientListCtrl).
 		std::sort(fileVector.begin(), fileVector.end());
 	} else {
-		// The GenericClientListCtrl is designed to show clients associated with a KnownFile.
-		// So the uploadqueue carries a special known file with all ongoing uploads in its
-		// upload list. This is a hack, but easier than trying to bend the class into a shape
-		// it was not intended for to show all clients currently uploading.
+		// CGenericClientListCtrl shows clients associated with a KnownFile, so the
+		// uploadqueue carries a special known file holding all ongoing uploads in its
+		// upload list. A hack, but easier than bending the class into a shape it was
+		// not intended for.
 #ifdef CLIENT_GUI
 		fileVector.push_back(theApp->m_allUploadingKnownFile);
 #else

--- a/src/SplashScreen.cpp
+++ b/src/SplashScreen.cpp
@@ -48,11 +48,10 @@ constexpr int kSplashWidth = 440;
 constexpr int kSplashHeight = 340;
 constexpr int kLogoSize = 128;
 
-// Gradient, matching the artwork the splash replaces: an ellipse centred on
-// the panel, falling off linearly from a lifted grey to black. The radius is
+// Gradient, matching the artwork the splash replaces: an ellipse centred on the
+// panel, falling off linearly from a lifted grey to black. The radius is
 // normalised per axis, so the ellipse follows the panel's shape rather than
-// being circular, and it reaches black past the corners (which sit at
-// r = sqrt(2) ~ 1.41) rather than exactly at them.
+// being circular, and reaches black past the corners rather than exactly at them.
 constexpr int kCentreR = 79;
 constexpr int kCentreG = 79;
 constexpr int kCentreB = 82;
@@ -60,10 +59,9 @@ constexpr double kBlackAtRadius = 1.39;
 
 // Repaint at most this often while the caller reports progress. Time-based
 // rather than every-N-items: the shared-file scan runs at wildly different
-// speeds depending on whether the files are local or on network storage, so
-// a count-based rule is either too coarse or too costly depending on the
-// share. At 10 Hz the bar looks continuous and the cost stays negligible
-// against work measured in seconds.
+// speeds depending on whether the files are local or on network storage, so a
+// count-based rule is either too coarse or too costly. At 10 Hz the bar looks
+// continuous and the cost stays negligible.
 constexpr long kRepaintIntervalMs = 100;
 
 // Minimum time on screen. A startup that beats this would otherwise show
@@ -167,10 +165,9 @@ void CSplashScreen::RenderBackdrop()
 		y += logo.GetHeight() + FromDIP(12);
 	}
 
-	// Application name and running version. The version-number macros rather
-	// than GetMuleVersion(): that one deliberately describes the build for
-	// debugging -- toolkit, Boost, snapshot revision -- which is a paragraph,
-	// not a title.
+	// Application name and running version. The version-number macros rather than
+	// GetMuleVersion(), which deliberately describes the build for debugging --
+	// toolkit, Boost, snapshot revision -- and is a paragraph, not a title.
 	wxFont title = GetFont();
 	title.SetPointSize(title.GetPointSize() + 6);
 	title.SetWeight(wxFONTWEIGHT_BOLD);
@@ -235,18 +232,14 @@ void CSplashScreen::SetProgress(const wxString &status, int percent, bool immedi
 
 	Refresh(false);
 
-	// The event loop has to run for the invalidation to reach the screen:
-	// under GTK3, Update() cannot force a synchronous repaint the way it
-	// does elsewhere -- drawing is driven by the frame clock, which only
-	// ticks from the loop. Without this the bar simply does not move, which
-	// is the whole point of showing it.
+	// The event loop has to run for the invalidation to reach the screen: under
+	// GTK3, Update() cannot force a synchronous repaint the way it does elsewhere,
+	// since drawing is driven by the frame clock, which only ticks from the loop.
 	//
-	// wxSafeYield rather than wxYield: it disables every other top-level
-	// window for the duration, so input that arrives while the application
-	// is still half-built is discarded rather than dispatched into
-	// subsystems that do not exist yet. The rate limit above bounds what
-	// this costs; Finish() logs the total so it can be checked rather than
-	// assumed.
+	// wxSafeYield rather than wxYield: it disables every other top-level window for
+	// the duration, so input arriving while the application is half-built is
+	// discarded rather than dispatched into subsystems that do not exist yet. The
+	// rate limit above bounds what this costs.
 	wxSafeYield(this, true);
 
 	m_updateMicros += (wxGetUTCTimeMillis() - now);
@@ -256,15 +249,13 @@ void CSplashScreen::Finish()
 {
 	const wxLongLong visibleMs = wxGetUTCTimeMillis() - m_shownAt;
 
-	// Debug level: this is the splash's own overhead against the work it
-	// reports on, which matters when tuning the phase weighting but is noise
-	// in a user's log. The phase timings themselves are logged normally,
-	// since those are what a "startup is slow" report needs.
+	// Debug level: this is the splash's own overhead against the work it reports
+	// on, which matters when tuning the phase weighting but is noise in a user's
+	// log. The phase timings themselves are logged normally.
 	//
-	// logGeneral, not logStandard: the latter is the -1 sentinel meaning "not
-	// a debug category" that AddLogLineN passes, so a debug line asking
-	// whether it is enabled sends it through CLogger::IsEnabled, whose index
-	// check rejects anything below zero and hits wxFAIL.
+	// logGeneral, not logStandard: the latter is the -1 sentinel meaning "not a
+	// debug category", so a debug line asking whether it is enabled reaches
+	// CLogger::IsEnabled, whose index check rejects anything below zero.
 	AddDebugLogLineN(logGeneral,
 		CFormat("Splash: %u repaints costing %lld ms, %lld ms taken from startup, "
 			"over %lld ms on screen") %

--- a/src/SplashScreen.h
+++ b/src/SplashScreen.h
@@ -31,45 +31,40 @@
 
 // Startup splash for the monolithic GUI.
 //
-// Exists because startup is slow and silent: the main window is created
-// before the shared-file scan runs, but the scan holds the main thread, so
-// nothing paints until it finishes. On a large share -- worse still on
-// network storage, where every file costs a round trip instead of a page
-// cache hit -- that is a long stretch with no sign the application is alive.
-// Under Flatpak it is also long enough for xdg-desktop-portal's background
-// monitor to conclude the app has no window and kill it.
+// Exists because startup is slow and silent: the main window is created before
+// the shared-file scan runs, but the scan holds the main thread, so nothing
+// paints until it finishes. On a large share -- worse on network storage, where
+// every file costs a round trip -- that is a long stretch with no sign the
+// application is alive, and under Flatpak long enough for xdg-desktop-portal's
+// background monitor to conclude the app has no window and kill it.
 //
 // Everything is drawn by hand rather than assembled from child controls: the
-// background is a dark gradient and native widgets on top of it would follow
+// background is a dark gradient, and native widgets on top of it would follow
 // the desktop theme instead, giving a light-on-dark gauge on most systems.
 class CSplashScreen : public wxFrame
 {
 public:
-	// Parented to the main window, so the window manager keeps it above
-	// aMule and nothing else. It used to be a parentless wxSTAY_ON_TOP
-	// frame, which is a desktop-global level: it covered every other
-	// application, and since it also has no taskbar button there was
-	// nothing to raise over it or dismiss it with.
+	// Parented to the main window, so the window manager keeps it above aMule and
+	// nothing else. As a parentless wxSTAY_ON_TOP frame it sat at a desktop-global
+	// level, covering every other application with no taskbar button to raise over
+	// it or dismiss it with.
 	explicit CSplashScreen(wxWindow *parent);
 
 	// Update the phase text and the bar. Cheap to call often: repainting is
-	// rate-limited internally, so callers can report every file scanned
-	// without deciding for themselves how much is too much.
+	// rate-limited internally, so callers can report every file scanned.
 	//
-	// Set @a immediate when the update marks a change of phase rather than
-	// progress within one, to paint it without waiting out the rate limit.
-	// It cannot be inferred from the text changing: the per-item updates
-	// carry a running count, so their text changes every single time.
+	// Set @a immediate when the update marks a change of phase rather than progress
+	// within one, to paint it without waiting out the rate limit. It cannot be
+	// inferred from the text changing, since the per-item updates carry a running
+	// count and so change their text every time.
 	void SetProgress(const wxString &status, int percent, bool immediate = false);
 
-	// Close, honouring the minimum on-screen time. A fast startup would
-	// otherwise flash the splash for a few frames, which reads as a glitch
-	// rather than as the application starting.
+	// Close, honouring the minimum on-screen time: a fast startup would otherwise
+	// flash the splash for a few frames, which reads as a glitch.
 	//
-	// Never blocks: when the floor has not been reached it schedules the
-	// close and returns. Sleeping here would freeze the main thread for up
-	// to that floor, which is the very symptom the splash exists to explain
-	// -- and on a fast startup it would do so for no reason at all.
+	// Never blocks -- when the floor has not been reached it schedules the close and
+	// returns. Sleeping here would freeze the main thread, the very symptom the
+	// splash exists to explain.
 	void Finish();
 
 	// Stamps the clock the minimum-display floor is measured from, so that

--- a/src/StatTree.h
+++ b/src/StatTree.h
@@ -182,7 +182,6 @@ public:
 		return this;
 	}
 
-	//! Returns the stable machine key for this node (empty if none).
 	const wxString &GetKey() const { return m_key; }
 
 	/**
@@ -200,7 +199,6 @@ public:
 		return this;
 	}
 
-	//! Returns the raw machine value for this node (empty if none).
 	const wxString &GetRawValue() const { return m_rawvalue; }
 #endif
 
@@ -349,10 +347,8 @@ protected:
 	const wxString m_label;
 #ifndef CLIENT_GUI
 
-	//! Parent of this node.
 	CStatTreeItemBase *m_parent;
 
-	//! Flags for the node.
 	unsigned m_flags;
 
 	//! Stable, untranslated machine key (empty = none). @see SetKey
@@ -365,10 +361,8 @@ protected:
 
 private:
 #ifndef CLIENT_GUI
-	//! Function used when sorting children by value.
 	static bool ValueSort(const CStatTreeItemBase *a, const CStatTreeItemBase *b);
 
-	//! ID of this node.
 	uint32_t m_id;
 
 	//! Counter to keep track of displayed visible items
@@ -376,13 +370,10 @@ private:
 	uint32_t m_visible_counter;
 #endif
 
-	//! Unique ID of this node.
 	uint32_t m_uniqueid;
 
-	//! Children of this node.
 	std::list<CStatTreeItemBase *> m_children;
 
-	//! Lock to protect list from simultaneous access.
 	wxMutex m_lock;
 };
 
@@ -485,11 +476,8 @@ protected:
 	 */
 	virtual void AddECValues(CECTag *tag) const;
 
-	//! Type of the value.
 	enum EValueType m_valuetype;
-	//! Display mode of the value.
 	enum EDisplayMode m_displaymode;
-	//! Union to save space.
 	union
 	{
 		uint64_t m_intvalue; ///< Integer value.
@@ -588,10 +576,8 @@ protected:
 	 */
 	virtual void AddECValues(CECTag *tag) const;
 
-	//! Actual value of the counter.
 	_Tp m_value;
 
-	//! Display mode of the value.
 	enum EDisplayMode m_displaymode;
 };
 
@@ -630,7 +616,6 @@ public:
 	virtual bool IsVisible() const { return true; }
 
 protected:
-	//! Do nothing here.
 	virtual void AddECValues(CECTag *) const {}
 };
 
@@ -731,10 +716,8 @@ protected:
 	 */
 	virtual void AddECValues(CECTag *tag) const;
 
-	//! Actual value of the counter.
 	uint32_t m_value;
 
-	//! Maximal value the counter has ever reached.
 	uint32_t m_max_value;
 };
 
@@ -782,10 +765,8 @@ protected:
 	 */
 	virtual void AddECValues(CECTag *tag) const;
 
-	//! Total number of packets.
 	uint32_t m_packets;
 
-	//! Total bytes in the packets.
 	uint64_t m_bytes;
 };
 
@@ -827,7 +808,6 @@ protected:
 	 */
 	virtual void AddECValues(CECTag *tag) const;
 
-	//! List of packet counters to sum.
 	std::vector<CStatTreeItemPackets *> m_counters;
 };
 

--- a/src/Statistics.cpp
+++ b/src/Statistics.cpp
@@ -134,8 +134,6 @@ void CStatTreeItemPeakConnections::AddECValues(CECTag *tag) const
 
 /*----- CStatistics -----*/
 
-// Static variables
-
 // Rate counters
 CPreciseRateCounter *CStatistics::s_upOverheadRate;
 CPreciseRateCounter *CStatistics::s_downOverheadRate;
@@ -192,8 +190,6 @@ CStatTreeItemSimple *CStatistics::s_avgConnections;
 // Clients
 CStatTreeItemHiddenCounter *CStatistics::s_clients;
 CStatTreeItemCounter *CStatistics::s_unknown;
-// CStatTreeItem			CStatistics::s_lowID;
-// CStatTreeItem			CStatistics::s_secIdentOnOff;
 #ifdef __DEBUG__
 CStatTreeItemNativeCounter *CStatistics::s_hasSocket;
 #endif
@@ -240,8 +236,6 @@ CStatistics::CStatistics()
 {
 	uint64 start_time = GetTickCount64();
 
-	// Init graphs
-
 	average_minutes = thePrefs::GetStatsAverageMinutes();
 
 	HR hr = { 0.0, 0.0, 0.0, 0.0, 0.0, 0, 0, 0, 0, 0 };
@@ -258,17 +252,12 @@ CStatistics::CStatistics()
 			listHR.push_back(hr);
 	}
 
-	// Init rate counters outside the tree
-
 	s_upOverheadRate = new CPreciseRateCounter(5000);
 	s_downOverheadRate = new CPreciseRateCounter(5000);
-
-	// Init Tree
 
 	InitStatsTree();
 	s_uptime->SetStartTime(start_time);
 
-	// Load saved statistics
 	Load();
 	s_statsNeedSave = false;
 }
@@ -281,10 +270,8 @@ CStatistics::~CStatistics()
 
 	delete s_statTree;
 
-	// delete items not in the tree
 	delete s_totalUploadTime;
 
-	// delete rate counters outside the tree
 	delete s_upOverheadRate;
 	delete s_downOverheadRate;
 }
@@ -358,18 +345,12 @@ a node to another place, so we have to erase and re-add nodes.
 void CStatistics::RecordHistory()
 { // First we query and compute some values, then we store them in the history list
 
-	// A few comments about the use of double and float in computations:
-	// Even on a hi-res screen our graphs will have 10 bits of resolution at most,
-	// so the 24 bits resolution of a float on 32 bit Intel processors is more than
-	// enough for all displayed values.  Rate computations however, and especially
-	// running average computations, use differences (delta bytes/ delta time), and
-	// for long uptimes the difference between two timestamps can lose too much
-	// accuracy because the large mantissa causes less significant bits to be dropped
-	// (same for the difference between two cumulative byte counts).  [We don't store
-	// these values as integers because they will be used in floating point calculations,
-	// and we want to perform the conversion only once).  Therefore timestamps and
-	// Kbyte counts are stored in the history as doubles, while computed values use
-	// float (to save space and execution time).
+	// Timestamps and Kbyte counts are stored in the history as doubles, computed
+	// values as float. A float's 24 bits are more than enough for anything the
+	// graphs display, but rate and running-average computations work on differences
+	// (delta bytes / delta time), and for long uptimes the large mantissa of a
+	// timestamp or cumulative byte count drops too many significant bits. They are
+	// not kept as integers because the conversion would then happen on every use.
 
 	/*
 		Store values; first determine the node to be recycled (using the bits in iClock)
@@ -435,10 +416,10 @@ unsigned CStatistics::GetHistory(        // Assemble arrays of sample points for
 		return (0);
 	}
 
-	// CLIENT_GUI builds start with an empty list -- unlike the monolithic
-	// constructor, which pre-allocates every record up front -- and the
-	// rbegin() below is dereferenced before the rend() test, so a paint
-	// arriving before the first graph reply would read an invalid iterator.
+	// CLIENT_GUI builds start with an empty list, unlike the monolithic
+	// constructor which pre-allocates every record, and the rbegin() below is
+	// dereferenced before the rend() test -- so a paint arriving before the first
+	// graph reply would read an invalid iterator.
 	if (listHR.empty()) {
 		return (0);
 	}
@@ -633,26 +614,20 @@ unsigned CStatistics::GetHistoryForGui(unsigned cntPoints,
 				(*connData)[2 * i] = (*connData)[2 * i + 1] = 0;
 			}
 		}
-		// Session totals are pulled from the latest sampled point so the
-		// graph's session-average line matches the daemon-side
-		// kBytesReceived / sTimestamp value monolithic amule plots —
-		// instead of forcing amulegui to integrate locally from connect
-		// time (which would diverge whenever the GUI attaches to a
-		// long-running daemon).
-		// pphr was filled walking rbegin() -> rend(), so [0] is the newest
-		// record and [cntFilled - 1] the oldest -- the reverse of the
-		// graphData loop above, which deliberately reads it backwards to
-		// emit points oldest-first. Taking [cntFilled - 1] here reported
-		// the session total as it stood at the START of the reply, which
-		// the client then treats as the total at the END and integrates
-		// backwards from: subtracting the whole span's transfer from a
-		// figure already that stale drives it negative at once, and every
-		// point but the newest reads as a session average of zero.
+		// Session totals come from the latest sampled point, so the graph's
+		// session-average line matches the kBytesReceived / sTimestamp value
+		// monolithic amule plots, rather than making amulegui integrate locally from
+		// connect time (which diverges whenever it attaches to a long-running
+		// daemon).
 		//
-		// Harmless while replies carried a point or two, since the two
-		// ends were seconds apart. A backfill makes them the width of the
-		// graph. [0] is also always a real record -- the NULL sentinel
-		// this loop can append lands at the oldest end.
+		// pphr was filled walking rbegin() -> rend(), so [0] is the NEWEST record --
+		// the reverse of the graphData loop above, which reads it backwards to emit
+		// points oldest-first. Taking [cntFilled - 1] reported the session total as
+		// it stood at the START of the reply, which the client treats as the total at
+		// the END and integrates backwards from, driving it negative at once. That
+		// was harmless while replies carried a point or two; a backfill makes the two
+		// ends the width of the graph. [0] is also always a real record, the NULL
+		// sentinel landing at the oldest end.
 		HR *latest = pphr[0];
 		if (latest) {
 			sessionDlKBytes = (uint64)latest->kBytesReceived;
@@ -925,10 +900,6 @@ void CStatistics::InitStatsTree()
 		new CStatTreeItemHiddenCounter(wxTRANSLATE("Clients"), stSortChildren | stSortByValue)));
 	s_unknown = static_cast<CStatTreeItemCounter *>(
 		s_clients->AddChild(new CStatTreeItemCounter(wxTRANSLATE("Unknown: %s")), 6));
-	// s_lowID = static_cast<CStatTreeItem*>(s_clients->AddChild(new CStatTreeItem(wxTRANSLATE("LowID: %u
-	// (%.2f%% Total %.2f%% Known)")), 5)); s_secIdentOnOff =
-	// static_cast<CStatTreeItem*>(s_clients->AddChild(new CStatTreeItem(wxTRANSLATE("SecIdent On/Off: %u
-	// (%.2f%%) : %u (%.2f%%)")), 4));
 #ifdef __DEBUG__
 	s_hasSocket = static_cast<CStatTreeItemNativeCounter *>(
 		s_clients->AddChild(new CStatTreeItemNativeCounter("HasSocket: %s"), 3));
@@ -938,10 +909,9 @@ void CStatistics::InitStatsTree()
 	s_banned = static_cast<CStatTreeItemNativeCounter *>(
 		s_clients->AddChild(new CStatTreeItemNativeCounter(wxTRANSLATE("Banned: %s")), 1));
 #ifdef ENABLE_KAD_NODE_PROTECTION
-	// Only when the protection that fills it is compiled in. Adding the row
-	// unconditionally would show every user a figure that is structurally
-	// always zero, which reads as "nothing is being banned" rather than
-	// "nothing here can ban".
+	// Only when the protection that fills it is compiled in: adding the row
+	// unconditionally would show a figure that is structurally always zero, which
+	// reads as "nothing is being banned" rather than "nothing here can ban".
 	s_kadBanned = static_cast<CStatTreeItemNativeCounter *>(s_clients->AddChild(
 		new CStatTreeItemNativeCounter(wxTRANSLATE("Kad banned addresses: %s")), 1));
 #endif
@@ -986,9 +956,8 @@ void CStatistics::InitStatsTree()
 			 wxTRANSLATE("Average file size: %s"), s_sizeOfShare, s_numberOfShared, dmBytes))
 			->SetKey("shared_avg_size"));
 
-	// Stable machine keys for API consumers (EC_TAG_STAT_NODE_KEY). Assigned
-	// here so they stay fixed regardless of label wording or translation.
-	// See docs/api/REFERENCE.md (GET /api/v0/stats/tree).
+	// Stable machine keys for API consumers (EC_TAG_STAT_NODE_KEY), assigned here so
+	// they stay fixed regardless of label wording or translation.
 	s_uptime->SetKey("uptime");
 	s_sessionUpload->SetKey("upload_data");
 	s_totalUpOverhead->SetKey("upload_total_overhead");
@@ -1271,10 +1240,8 @@ CStatistics::CStatistics(CRemoteConnect &conn)
 	HR hr = { 0.0, 0.0, 0.0, 0.0, 0.0, 0, 0, 0, 0, 0 };
 	hrInit = hr;
 
-	// Init Tree
 	s_statTree = new CStatTreeItemBase(_("Statistics"), 0);
 
-	// Clear stat data container
 	for (int i = 0; i < sdTotalItems; ++i) {
 		s_statData[i] = 0;
 	}
@@ -1288,23 +1255,21 @@ CStatistics::~CStatistics()
 
 void CStatistics::AddHistoryRecord(const HR &hr, double minSpacing)
 {
-	// Keep only what the graphs will actually plot: one record every
-	// minSpacing seconds, that being the seconds-per-point they draw at.
+	// Keep only what the graphs will actually plot: one record every minSpacing
+	// seconds, that being the seconds-per-point they draw at.
 	//
 	// Two things otherwise fill the ring with points no axis asks for.
-	// GetHistoryForGui appends a record before testing whether it is one
-	// the caller already has, so every poll returns at least the newest
-	// record again; and the daemon's newest record advances one second per
-	// poll whatever spacing was requested, so a graph drawing at 3 s was
-	// storing three records for every point it could show. Drawing never
-	// noticed -- GetHistory just skips what it does not need -- but
-	// kHistoryCap bounds the ring in records, so both effects cost real
-	// history: measured against a live daemon the graphs opened with 28
+	// GetHistoryForGui appends a record before testing whether the caller already
+	// has it, so every poll returns at least the newest record again; and the
+	// daemon's newest record advances one second per poll whatever spacing was
+	// requested, so a graph drawing at 3 s stored three records per point. Drawing
+	// never noticed, but kHistoryCap bounds the ring in RECORDS, so both effects
+	// cost real history: measured against a live daemon the graphs opened with 28
 	// minutes behind them and decayed toward 15.
 	//
-	// Safe against a daemon restart resetting its uptime clock: Startup()
-	// builds a new CStatistics (and a new CStatGraphRem) per connection,
-	// so timestamps only ever move forward within one ring's lifetime.
+	// Safe against a daemon restart resetting its uptime clock: Startup() builds a
+	// new CStatistics per connection, so timestamps only move forward within one
+	// ring's lifetime.
 	if (!listHR.empty() && hr.sTimestamp < listHR.back().sTimestamp + minSpacing) {
 		return;
 	}
@@ -1344,9 +1309,9 @@ void CStatistics::UpdateStats(const CECPacket *stats)
 		stats->GetTagByNameSafe(EC_TAG_STATS_TOTAL_RECEIVED_BYTES)->GetInt();
 	s_statData[sdSharedFileCount] = stats->GetTagByNameSafe(EC_TAG_STATS_SHARED_FILE_COUNT)->GetInt();
 
-	// Absence has to mean "unknown", not zero: a daemon older than these
-	// tags sends neither, and GetTagByNameSafe() would answer 0 for both --
-	// which the Downloads panel would read as a full disk and paint red.
+	// Absence has to mean "unknown", not zero: a daemon older than these tags sends
+	// neither, and GetTagByNameSafe() would answer 0 for both -- which the Downloads
+	// panel would read as a full disk and paint red.
 	const CECTag *tempFree = stats->GetTagByName(EC_TAG_STATS_TEMP_FREE_SPACE);
 	s_statData[sdTempFreeSpace] = tempFree ? tempFree->GetInt() : (uint64)FREE_SPACE_UNKNOWN;
 	const CECTag *incomingFree = stats->GetTagByName(EC_TAG_STATS_INCOMING_FREE_SPACE);
@@ -1354,9 +1319,9 @@ void CStatistics::UpdateStats(const CECPacket *stats)
 
 	const CECTag *LoggerTag = stats->GetTagByName(EC_TAG_STATS_LOGGER_MESSAGE);
 	if (LoggerTag) {
-		// Coalesce the whole poll's log lines into a single repaint + one
-		// scroll: a remote-GUI first-sync backlog can be thousands of lines
-		// and per-line rendering froze the GUI for minutes (issue #445).
+		// Coalesce the whole poll's log lines into a single repaint and one scroll:
+		// a remote-GUI first-sync backlog can be thousands of lines, and per-line
+		// rendering froze the GUI for minutes (issue #445).
 		theApp->BeginRemoteLogBatch();
 		for (const auto &tag : *LoggerTag) {
 			theApp->AddRemoteLogLine(tag.GetStringData());

--- a/src/Statistics.h
+++ b/src/Statistics.h
@@ -168,14 +168,12 @@ protected:
 	std::deque<uint32> m_byte_history;
 	std::deque<uint64> m_tick_history;
 	uint32_t m_timespan;
-	// Sum of every sample currently inside the window. Wide because the
-	// sum is not a byte count: with count_average the samples are rates,
-	// and the graphs' running average holds a 5 minute window of them --
-	// 100 samples at the default 3 s spacing, which passes 2^32 once the
-	// mean rate reaches about 41 MB/s. Past that it wrapped, the
-	// subtraction below drove it further under, and the trend collapsed
-	// to nothing and climbed back over a full window. The individual
-	// samples in m_byte_history are fine at 32 bits; only their sum is not.
+	// Sum of every sample currently inside the window. Wide because the sum is not
+	// a byte count: with count_average the samples are rates, and the graphs' running
+	// average holds a 5 minute window of them -- 100 samples at the default 3 s
+	// spacing, which passes 2^32 once the mean rate reaches about 41 MB/s. Past that
+	// it wrapped and the trend collapsed. The samples themselves are fine at 32
+	// bits; only their sum is not.
 	uint64_t m_total;
 	double m_rate;
 	double m_max_rate;
@@ -277,11 +275,10 @@ public:
 
 	void RecordHistory();
 	unsigned GetHistoryForWeb(unsigned cntPoints, double sStep, double *sStart, uint32 **graphData);
-	// EC_OP_STATSGRAPHS variant that also fills per-point active-up /
-	// active-down counters and the latest session totals, so amulegui
-	// can render the same 3-line Connections scope and true
-	// kBytesReceived/sTimestamp session average as monolithic amule.
-	// connData is freshly new[]'d on success (caller owns / deletes).
+	// EC_OP_STATSGRAPHS variant that also fills per-point active-up / active-down
+	// counters and the latest session totals, so amulegui can render the same
+	// 3-line Connections scope and true session average as monolithic amule.
+	// connData is freshly new[]'d on success and owned by the caller.
 	unsigned GetHistoryForGui(unsigned cntPoints,
 		double sStep,
 		double *sStart,
@@ -533,21 +530,18 @@ public:
 
 	void SetAverageMinutes(uint8 minutes) { average_minutes = minutes; }
 
-	// Records held per resolution range. The list is nHistRanges of these,
-	// each range at twice the spacing of the one before, so this sets both
-	// how far back the graphs can reach and how much of that reach is at
-	// fine resolution: at a 3 s update delay the two finest ranges are the
-	// ones a graph can plot from, giving 3 x this many seconds of history.
+	// Records held per resolution range. The list is nHistRanges of these, each
+	// range at twice the spacing of the one before, so this sets both how far back
+	// the graphs can reach and how much of that reach is at fine resolution: at a
+	// 3 s update delay the two finest ranges are the ones a graph can plot from.
 	//
-	// Was (1280 / 2) - 80 = 560, once derived from a GUI width. That put
-	// the finest usable reach at 28 minutes, which a remote GUI could
-	// exhaust in a window barely wider than half a screen. At 64 bytes a
-	// record the whole list costs 7 x this x 64 bytes -- 787 KB here,
-	// against 245 KB at the old value.
+	// Was (1280 / 2) - 80 = 560, once derived from a GUI width, which put the finest
+	// usable reach at 28 minutes -- exhaustible by a remote GUI in a window barely
+	// wider than half a screen. At 64 bytes a record the whole list costs
+	// 7 x this x 64 bytes, so 787 KB here against 245 KB at the old value.
 	//
-	// Public because it is reported to remote GUIs over EC: a client that
-	// asked for more points than a range holds would be answered with the
-	// same record repeated, and would have no way to tell.
+	// Public because it is reported to remote GUIs over EC: a client asking for more
+	// points than a range holds would be answered with the same record repeated.
 	static int GetPointsPerRange() { return 1800; }
 
 private:
@@ -592,7 +586,6 @@ private:
 
 	/* Tree-related vars */
 
-	// the tree
 	static CStatTreeItemBase *s_statTree;
 
 	// Uptime
@@ -634,8 +627,6 @@ private:
 	// Clients
 	static CStatTreeItemHiddenCounter *s_clients;
 	static CStatTreeItemCounter *s_unknown;
-	// static	CStatTreeItem			s_lowID;
-	// static	CStatTreeItem			s_secIdentOnOff;
 #ifdef __DEBUG__
 	static CStatTreeItemNativeCounter *s_hasSocket;
 #endif
@@ -726,10 +717,10 @@ private:
 	static uint64 s_statData[sdTotalItems];
 	uint8 average_minutes;
 
-	// History ring for the Statistics + Network->Kad graphs. Filled by
-	// CStatGraphRem::HandlePacket (one HR per decoded point) so the
-	// shared COScopeCtrl::PlotHistory path can replay across tab
-	// switches and auto-rescale events without a daemon round-trip.
+	// History ring for the Statistics and Network->Kad graphs. Filled by
+	// CStatGraphRem::HandlePacket, one HR per decoded point, so the shared
+	// COScopeCtrl::PlotHistory path can replay across tab switches and auto-rescale
+	// events without a daemon round-trip.
 	std::list<HR> listHR;
 	typedef std::list<HR>::iterator listPOS;
 	typedef std::list<HR>::reverse_iterator listRPOS;
@@ -752,25 +743,21 @@ public:
 		const std::vector<float *> &ppf,
 		StatsGraphType which_graph);
 
-	// CLIENT_GUI-only producer (no analogue on monolithic, where
-	// RecordHistory() does the equivalent push from local counters).
-	// Appends one HR record to listHR and caps the ring at
-	// kHistoryCap so memory stays bounded across long sessions.
-	// minSpacing is the seconds-per-point the graphs are drawing at, and
-	// records closer together than that are dropped: keeping finer data
-	// than is ever plotted just spends the ring on points no axis asks for.
+	// CLIENT_GUI-only producer, with no analogue on monolithic, where
+	// RecordHistory() does the equivalent push from local counters. Appends one HR
+	// record to listHR and caps the ring at kHistoryCap. minSpacing is the
+	// seconds-per-point the graphs are drawing at, and records closer together than
+	// that are dropped: finer data than is ever plotted just spends the ring.
 	void AddHistoryRecord(const HR &hr, double minSpacing);
 	// Drops everything. Used when the sample spacing changes, which
 	// invalidates the resolution the stored points were kept at.
 	void ClearHistory() { listHR.clear(); }
-	// Records, not seconds. One is kept per plotted point, so the useful
-	// way to read this is as a plot width: a graph draws one point per
-	// pixel, and cannot show more than this many however wide its window
-	// is. The span that covers depends on the "Update delay" preference
-	// the points were fetched at -- 3 h at a 1 s delay, a day at 8 s --
-	// but the pixel bound is the same either way, which is what matters
-	// because the Kad graph spans the whole window. At 64 bytes a record
-	// the whole ring is about 225 KB.
+	// Records, not seconds. One is kept per plotted point, so the useful way to read
+	// this is as a plot width: a graph draws one point per pixel and cannot show
+	// more than this many however wide its window. The span that covers depends on
+	// the "Update delay" preference the points were fetched at -- 3 h at 1 s, a day
+	// at 8 s -- but the pixel bound is the same either way. At 64 bytes a record the
+	// ring is about 225 KB.
 	static const size_t kHistoryCap = 3600;
 
 	static uint64 GetUptimeMillis();
@@ -789,12 +776,11 @@ public:
 
 	static uint32 GetSharedFileCount() { return s_statData[sdSharedFileCount]; }
 
-	// Free space on the daemon's filesystems, as it reported them. The
-	// figures are necessarily the core's view: the machine running the GUI
-	// may not have those directories at all, and where it does have them
-	// mounted it can see a different size, quota or share. Stored as the
-	// unsigned slot the array is made of; FREE_SPACE_UNKNOWN survives the
-	// round trip because it is the all-ones pattern either way.
+	// Free space on the daemon's filesystems, as it reported them. Necessarily the
+	// core's view: the machine running the GUI may not have those directories at
+	// all, and where it does it can see a different size, quota or share. Stored as
+	// the unsigned slot the array is made of; FREE_SPACE_UNKNOWN survives the round
+	// trip, being the all-ones pattern either way.
 	static sint64 GetTempFreeSpace() { return (sint64)s_statData[sdTempFreeSpace]; }
 	static sint64 GetIncomingFreeSpace() { return (sint64)s_statData[sdIncomingFreeSpace]; }
 

--- a/src/TextClient.cpp
+++ b/src/TextClient.cpp
@@ -106,7 +106,6 @@ enum
 
 };
 
-// method to create a SearchFile
 SearchFile::SearchFile(const CEC_SearchFile_Tag *tag)
 : nHash(tag->FileHash())
 {
@@ -155,12 +154,11 @@ static bool ParseSizeWithSuffix(const wxString &s, uint64 &out)
 	return true;
 }
 
-// Strip optional --type / --extension / --avail / --min-size / --max-size
-// flags from `args`, leaving only the search keyword(s). Each flag takes
-// exactly one whitespace-separated value. Unknown tokens are preserved as
-// part of the search query, joined by single spaces in input order.
-// Returns true on success, false if a flag is missing its value or a value
-// fails to parse; on failure the output values are undefined.
+// Strip optional --type / --extension / --avail / --min-size / --max-size flags
+// from `args`, leaving only the search keyword(s). Each flag takes exactly one
+// whitespace-separated value; unknown tokens are preserved as part of the query,
+// joined by single spaces in input order. False if a flag is missing its value
+// or a value fails to parse, in which case the outputs are undefined.
 static bool ParseSearchFilters(wxString &args,
 	wxString &type,
 	wxString &extension,
@@ -440,7 +438,6 @@ int CamulecmdApp::ProcessCommand(int CmdId)
 			wxString token;
 			CMD4Hash hash;
 
-			// Grab the entire dl queue right away
 			CECPacket request_all(EC_OP_GET_DLOAD_QUEUE, EC_DETAIL_CMD);
 			const CECPacket *reply_all = SendRecvMsg_v2(&request_all);
 
@@ -459,13 +456,11 @@ int CamulecmdApp::ProcessCommand(int CmdId)
 					wxFAIL;
 				}
 
-				// We loop through all the arguments
 				while (argsTokenizer.HasMoreTokens()) {
 					token = argsTokenizer.GetNextToken();
 
-					// If the user requested all, then we select all files and exit the
-					// loop since there is little point to add anything more to
-					// "everything"
+					// "all" selects every file, so there is nothing more to add and the
+					// loop can stop.
 					if (token == "all") {
 						for (CECPacket::const_iterator it = reply_all->begin();
 							it != reply_all->end();
@@ -482,7 +477,6 @@ int CamulecmdApp::ProcessCommand(int CmdId)
 							request->AddTag(CECTag(EC_TAG_PARTFILE, hash));
 						}
 					} else {
-						// Go through the dl queue and look at each filename
 						for (CECPacket::const_iterator it = reply_all->begin();
 							it != reply_all->end();
 							++it) {
@@ -739,7 +733,6 @@ int CamulecmdApp::ProcessCommand(int CmdId)
 				SearchFile *file = m_Results_map[id];
 				Show(CFormat(_("Download File: %lu %s\n")) % id % file->sFileName);
 				request = new CECPacket(EC_OP_DOWNLOAD_SEARCH_RESULT);
-				// get with id the hash and category=0
 				uint32 category = 0;
 				CECTag hashtag(EC_TAG_PARTFILE, file->nHash);
 				hashtag.AddTag(CECTag(EC_TAG_PARTFILE_CAT, category));
@@ -955,8 +948,8 @@ void CamulecmdApp::Process_Answer_v2(const CECPacket *response)
 			filesize = tag->SizeFull();
 			donesize = tag->SizeDone();
 			// Still two lines per entry: the newline delimits records and the
-			// leading tab marks the continuation, so splitting each line on
-			// the separator stays unambiguous.
+			// leading tab marks the continuation, so splitting each line on the
+			// separator stays unambiguous.
 			s << tag->FileHashString() << Sep(" ") << Field(tag->FileName())
 			  << (CFormat("\n\t [%.1f%%]") % ((float)donesize / ((float)filesize) * 100.0))
 			  << Sep(" ")

--- a/src/ThreadTasks.cpp
+++ b/src/ThreadTasks.cpp
@@ -50,7 +50,6 @@ const uint8_t g_emptyMD4Hash[16] = {
 // CHashingTask
 
 CHashingTask::CHashingTask(const CPath &path, const CPath &filename, const CPartFile *part)
-// GetPrintable is used to improve the readability of the log.
 : CThreadTask("Hashing", path.JoinPaths(filename).GetPrintable(), (part ? ETP_High : ETP_Normal))
 , m_path(path)
 , m_filename(filename)
@@ -68,7 +67,6 @@ CHashingTask::CHashingTask(const CPath &path, const CPath &filename, const CPart
 }
 
 CHashingTask::CHashingTask(const CKnownFile *toAICHHash)
-// GetPrintable is used to improve the readability of the log.
 : CThreadTask("AICH Hashing",
 	  toAICHHash->GetFilePath().JoinPaths(toAICHHash->GetFileName()).GetPrintable(),
 	  ETP_Low)
@@ -123,24 +121,18 @@ void CHashingTask::Entry()
 	knownfile->m_AvailPartFrequency.insert(
 		knownfile->m_AvailPartFrequency.begin(), knownfile->GetPartCount(), 0);
 
-	// Info level, not debug: AddDebugLogLineN compiles to nothing outside a
-	// debug build, so in the binaries users actually run there was no record
-	// at all that the client was reading every byte of a file (issue #968).
-	// Emitted here rather than where the task was queued, because tasks run
-	// serially on CThreadScheduler long after the directory walk that queued
-	// them -- a queue-time line would not say what is happening now. It sits
-	// after the open/length/size guards above, so a file that is skipped never
-	// claims to have been hashed.
+	// Info level, not debug: AddDebugLogLineN compiles to nothing outside a debug
+	// build, so the binaries users run had no record that the client was reading
+	// every byte of a file (issue #968). Emitted here rather than where the task was
+	// queued, because tasks run serially on CThreadScheduler long after the
+	// directory walk, and after the guards above, so a skipped file never claims to
+	// have been hashed. The full path, not m_filename: the same basename can exist
+	// in several shared directories.
 	//
-	// The full path, not m_filename: the same basename can exist in several
-	// shared directories, and "which file is it chewing on" is the question
-	// this line exists to answer.
-	// m_owner is set only when the task belongs to a partfile -- completion
-	// hashing of a finished download, or a corrupt-part re-hash. Those are
-	// real disk work and worth a line, but the path being read is an internal
-	// temp name like Temp/003.part, which means nothing to a user and does not
-	// match anything they can see in the UI. Report the download's own name
-	// instead, and say which kind of work it is.
+	// m_owner is set only for a partfile -- completion hashing or a corrupt-part
+	// re-hash. Those are real disk work, but the path being read is an internal temp
+	// name like Temp/003.part, so report the download's own name and which kind of
+	// work it is instead.
 	const bool ownedByPartfile = (m_owner != nullptr);
 	if ((m_toHash & EH_MD4) && (m_toHash & EH_AICH)) {
 		knownfile->GetAICHHashset()->FreeHashSet();
@@ -161,10 +153,9 @@ void CHashingTask::Entry()
 	} else if ((m_toHash & EH_AICH)) {
 		knownfile->GetAICHHashset()->FreeHashSet();
 		// Distinct wording: this fires for files discovered long ago whose AICH
-		// master hash is missing from known2_64.met, so calling it "hashing"
-		// would wrongly suggest the file was just found. After a known2_64.met
-		// loss this re-reads the entire library, which is exactly the silent
-		// multi-hour case worth a line.
+		// master hash is missing from known2_64.met, so "hashing" would wrongly
+		// suggest the file was just found. After a known2_64.met loss it re-reads the
+		// entire library, which is the silent multi-hour case worth a line.
 		AddLogLineN(CFormat(_("Rebuilding AICH hashset for file: %s")) % fullPath);
 		AddDebugLogLineN(
 			logHasher, CFormat("Starting to create AICH hash for file: %s") % m_filename);
@@ -173,7 +164,6 @@ void CHashingTask::Entry()
 			0, (CFormat("No hashes requested for file, skipping: %s") % m_filename).GetString());
 	}
 
-	// This loops creates the part-hashes, loop-de-loop.
 	try {
 		for (uint16 part = 0; part < knownfile->GetPartCount() && !TestDestroy(); part++) {
 			SetHashingProgress(part + 1);
@@ -208,7 +198,6 @@ void CHashingTask::Entry()
 		}
 	}
 
-	// Did we create a AICH hashset?
 	if ((m_toHash & EH_AICH) && !TestDestroy()) {
 		CAICHHashSet *AICHHashSet = knownfile->GetAICHHashset();
 
@@ -255,7 +244,6 @@ bool CHashingTask::CreateNextPartHash(CFileAutoClose &file, uint16 part, CKnownF
 	CMD4Hash *md4Hash = ((toHash & EH_MD4) ? &hash : NULL);
 	CAICHHashTree *aichHash = NULL;
 
-	// Setup for AICH hashing
 	if (toHash & EH_AICH) {
 		aichHash = owner->GetAICHHashset()->m_pHashTree.FindHash(offset, partLength);
 	}
@@ -263,13 +251,11 @@ bool CHashingTask::CreateNextPartHash(CFileAutoClose &file, uint16 part, CKnownF
 	owner->CreateHashFromFile(file, offset, partLength, md4Hash, aichHash);
 
 	if (toHash & EH_MD4) {
-		// Store the md4 hash
 		owner->m_hashlist.push_back(hash);
 
-		// This is because of the ed2k implementation for parts. A 2 * PARTSIZE
-		// file i.e. will have 3 parts (see CKnownFile::SetFileSize for comments).
-		// So we have to create the hash for the 0-size data, which will be the default
-		// md4 hash for null data: 31D6CFE0D16AE931B73C59D7E0C089C0
+		// The ed2k part implementation means a 2 * PARTSIZE file has 3 parts (see
+		// CKnownFile::SetFileSize), so a hash has to be created for the 0-size data:
+		// the default md4 hash for null data, 31D6CFE0D16AE931B73C59D7E0C089C0.
 		if ((partLength == PARTSIZE) && file.Eof()) {
 			owner->m_hashlist.push_back(CMD4Hash(g_emptyMD4Hash));
 		}
@@ -285,11 +271,10 @@ void CHashingTask::OnLastTask()
 		// explicitly save the list of hashed files here.
 		theApp->knownfiles->Save();
 
-		// Make sure the AICH-hashes are up to date. No orphan-prune here: this
-		// runs right after hashing (including a just-completed download) and
-		// races the main-thread SafeAddKFile that registers those files, so
-		// pruning could delete a hashset we just wrote. Only the startup sync
-		// prunes -- see CAICHSyncTask's ctor doc.
+		// Make sure the AICH hashes are up to date. No orphan-prune here: this runs
+		// right after hashing and races the main-thread SafeAddKFile that registers
+		// those files, so pruning could delete a hashset we just wrote. Only the
+		// startup sync prunes.
 		CThreadScheduler::AddTask(new CAICHSyncTask());
 	}
 }
@@ -309,24 +294,18 @@ void CAICHSyncTask::Entry()
 
 	AddDebugLogLineN(logAICHThread, "Synchronization thread started.");
 
-	// We collect all masterhashs which we find in the known2.met and store them in a list
 	std::list<CAICHHash> hashlist;
 	const CPath fullpath = CPath(thePrefs::GetConfigDir() + KNOWN2_MET_FILENAME);
 
-	// Snapshot of AICH master hashes still referenced by a known.met
-	// record. Used to drop orphans (entries whose owning known.met
-	// record was TTL-evicted by CKnownFileList::PruneDuplicates) from
-	// known2_64.met during the read walk. Empty set disables the prune
-	// (defensive: never wipe everything before knownfiles is loaded).
+	// Snapshot of AICH master hashes still referenced by a known.met record, used
+	// to drop orphans (entries whose owning record was TTL-evicted by
+	// PruneDuplicates) during the read walk. An empty set disables the prune, so
+	// nothing is ever wiped before knownfiles is loaded.
 	//
-	// Only the startup sync collects it: a post-hashing sync (scheduled by
-	// CHashingTask::OnLastTask) runs on a worker thread that can outrun the
-	// main-thread CamuleApp::OnFinishedHashing -> CKnownFileList::SafeAddKFile
-	// that registers the file it just hashed. That file's freshly-written
-	// hashset would then be absent from liveRoots and pruned as an orphan,
-	// leaving a newly completed download unable to load its AICH set until the
-	// next restart re-hashes it. Leaving liveRoots empty keeps the prune off on
-	// those runs; startup only prunes once the known-file list is authoritative.
+	// Only the startup sync collects it: a post-hashing sync runs on a worker thread
+	// that can outrun the main-thread SafeAddKFile registering the file it just
+	// hashed, whose freshly-written hashset would then be absent from liveRoots and
+	// pruned as an orphan.
 	std::unordered_set<CAICHHash> liveRoots;
 	if (m_pruneOrphans && theApp->knownfiles) {
 		theApp->knownfiles->CollectLiveAICHRoots(liveRoots);
@@ -353,11 +332,9 @@ void CAICHSyncTask::Entry()
 			return;
 		}
 
-		// Rewrite target. CFile::write_safe writes to "<name>.new" and
-		// renames on Close(); a partial rewrite leaves the original
-		// known2_64.met untouched, so a crash mid-prune doesn't lose
-		// data. Only opened when we actually have a live-roots set to
-		// filter against.
+		// Rewrite target. CFile::write_safe writes to "<name>.new" and renames on
+		// Close(), so a crash mid-prune leaves the original known2_64.met untouched.
+		// Opened only when there is a live-roots set to filter against.
 		const bool prune = !liveRoots.empty();
 		CFile rewriteFile;
 		bool rewriteOk = false;
@@ -387,7 +364,6 @@ void CAICHSyncTask::Entry()
 
 			uint64 nExistingSize = file.GetLength();
 			while (file.GetPosition() < nExistingSize) {
-				// Read the next hash
 				CAICHHash rootHash(&file);
 
 				uint32 nHashCount = file.ReadUInt32();
@@ -407,11 +383,9 @@ void CAICHSyncTask::Entry()
 					if (keep) {
 						rootHash.Write(&rewriteFile);
 						rewriteFile.WriteUInt32(nHashCount);
-						// Stream the hashset bytes through a small
-						// fixed buffer rather than slurping into RAM:
-						// large files can have many MB of leaf+tree
-						// SHA-1s and we don't want one entry to
-						// dictate the working set.
+						// Stream the hashset bytes through a small fixed
+						// buffer rather than slurping into RAM: large files can
+						// have many MB of leaf+tree SHA-1s.
 						uint8_t buf[64 * 1024];
 						uint64 remaining = hashsetBytes;
 						while (remaining > 0) {
@@ -430,9 +404,7 @@ void CAICHSyncTask::Entry()
 						++droppedCount;
 					}
 				} else {
-					// No rewrite in progress (prune disabled or
-					// rewrite file failed to open): just skip the
-					// hashset bytes as before.
+					// No rewrite in progress, so just skip the hashset bytes.
 					nLastVerifiedPos = file.Seek(
 						static_cast<wxFileOffset>(hashsetBytes), wxFromCurrent);
 				}
@@ -445,11 +417,10 @@ void CAICHSyncTask::Entry()
 			// Drop the SaveHashSet dedup cache: some of its entries
 			// may have just been truncated off the end of the file.
 			CAICHHashSet::InvalidateRootHashCache();
-			// Don't finalise the rewrite when the source was
-			// corrupt -- the partial .new file would replace the
-			// just-truncated source with something different. Abort
-			// the rewrite explicitly so its destructor doesn't end
-			// up renaming a stale .new over the recovered file.
+			// Do not finalise the rewrite when the source was corrupt: the
+			// partial .new file would replace the just-truncated source with
+			// something different. Abort explicitly so its destructor cannot
+			// rename a stale .new over the recovered file.
 			if (rewriteOk) {
 				rewriteFile.Close();
 				CPath::RemoveFile(CPath(fullpath.GetRaw() + wxT(".new")));
@@ -471,10 +442,9 @@ void CAICHSyncTask::Entry()
 				AddDebugLogLineN(logAICHThread,
 					CFormat("known2_64.met orphan prune: dropped %u, kept %u") %
 						(unsigned)droppedCount % (unsigned)keptCount);
-				// The dedup cache mirrored the old file. Drop it so
-				// the next SaveHashSet rebuilds against the rewritten
-				// known2_64.met instead of insisting hashes we just
-				// pruned are still "present".
+				// The dedup cache mirrored the old file. Drop it so the next
+				// SaveHashSet rebuilds against the rewritten known2_64.met rather
+				// than insisting pruned hashes are still present.
 				CAICHHashSet::InvalidateRootHashCache();
 			}
 		}
@@ -668,10 +638,9 @@ void CVerifyLocalDataTask::Entry()
 		return;
 	}
 
-	// We don't use directly the AICHHashSet from the knownFile, it is not thread-safe:
-	// While we are checking AICH hashes here, a peer could send us an OP_AICHREQUEST on the same
-	// file which will call LoadHashSet() and FreeHashSet() on the same working set...
-	// Create our own working copy here
+	// Not the knownFile's own AICHHashSet, which is not thread-safe: while we check
+	// AICH hashes here, a peer could send an OP_AICHREQUEST for the same file and
+	// call LoadHashSet()/FreeHashSet() on the same working set.
 	CKnownFile storedFile;
 	storedFile.SetFileSize(fileSize);
 	storedFile.GetAICHHashset()->SetMasterHash(aichRootHash, aichStatus);
@@ -738,9 +707,8 @@ void CVerifyLocalDataTask::Entry()
 					m_corruptedAICH.emplace_back(part, corruptedAICHinThisPart);
 			}
 
-			// For files smaller than PARTSIZE, GetPartHash is empty, and the MD4 of the part
-			// is the same as the MD4 of the file, no ID=MD4(concatenation of parts' MD4) is done
-			// Check comment in CKnownFile::SetFileSize() for further info
+			// For files smaller than PARTSIZE, GetPartHash is empty and the MD4 of the
+			// part is the MD4 of the file; see CKnownFile::SetFileSize().
 			if (storedMD4Hashes.empty()) {
 				if (md4Hash != m_fileID)
 					m_corruptedMD4.push_back(part);
@@ -765,7 +733,6 @@ void CVerifyLocalDataTask::Entry()
 // CCompletionTask
 
 CCompletionTask::CCompletionTask(const CPartFile *file)
-// GetPrintable is used to improve the readability of the log.
 : CThreadTask("Completing", file->GetFullName().GetPrintable(), ETP_High)
 , m_filename(file->GetFileName())
 , m_metPath(file->GetFullName())
@@ -798,7 +765,6 @@ void CCompletionTask::Entry()
 
 	CPath dstName = m_filename.Cleanup(true, !PlatformSpecific::CanFSHandleSpecialChars(targetPath));
 
-	// Avoid empty filenames ...
 	if (!dstName.IsOk()) {
 		dstName = CPath("Unknown");
 	}
@@ -837,7 +803,6 @@ void CCompletionTask::Entry()
 		}
 	}
 
-	// Removes the various other data-files
 	const char *otherMetExt[] = { "", PARTMET_BAK_EXT, ".seeds", NULL };
 	for (size_t i = 0; otherMetExt[i]; ++i) {
 		CPath toRemove = m_metPath.AppendExt(otherMetExt[i]);
@@ -855,7 +820,6 @@ void CCompletionTask::Entry()
 
 void CCompletionTask::OnExit()
 {
-	// Notify the app that the completion has finished for this file.
 	CCompletionEvent evt(m_error, m_owner, m_newName);
 
 	wxQueueEvent(wxTheApp, (evt).Clone());
@@ -887,7 +851,6 @@ void CCompletionTask::OnExit()
 #include <errno.h>
 
 CAllocateFileTask::CAllocateFileTask(CPartFile *file, bool pause)
-// GetPrintable is used to improve the readability of the log.
 : CThreadTask("Allocating", file->GetFullName().RemoveExt().GetPrintable(), ETP_High)
 , m_file(file)
 , m_pause(pause)
@@ -930,7 +893,6 @@ void CAllocateFileTask::Entry()
 		m_result = errno;
 	}
 #else
-	// Use kernel level routines if possible
 #ifdef HAVE_FALLOCATE
 	m_result = fallocate(file.fd(), 0, 0, m_file->GetFileSize());
 #elif defined HAVE_SYS_FALLOCATE
@@ -939,7 +901,6 @@ void CAllocateFileTask::Entry()
 		m_result = errno;
 	}
 #elif defined HAVE_POSIX_FALLOCATE
-	// otherwise use glibc implementation, if available
 	m_result = posix_fallocate(file.fd(), 0, m_file->GetFileSize());
 #endif
 
@@ -976,7 +937,6 @@ void CAllocateFileTask::Entry()
 
 void CAllocateFileTask::OnExit()
 {
-	// Notify the app that the preallocation has finished for this file.
 	CAllocFinishedEvent evt(m_file, m_pause, m_result);
 
 	wxQueueEvent(wxTheApp, (evt).Clone());
@@ -996,9 +956,9 @@ CMediaProbeEvent::CMediaProbeEvent(
 , m_succeeded(succeeded)
 , m_markUnprobeable(markUnprobeable)
 {
-	// Deep-copy every string: this event is built on the probe worker and
-	// consumed on the main thread, and wxString is refcounted, so handing the
-	// buffer over shared would race the worker's own copy going out of scope.
+	// Deep-copy every string: this event is built on the probe worker and consumed
+	// on the main thread, and wxString is refcounted, so handing the buffer over
+	// shared would race the worker's own copy going out of scope.
 	m_info.length_seconds = info.length_seconds;
 	m_info.bitrate_kbps = info.bitrate_kbps;
 	m_info.codec = wxString(info.codec.c_str(), info.codec.length());

--- a/src/ThreadTasks.h
+++ b/src/ThreadTasks.h
@@ -75,11 +75,9 @@ public:
 	CHashingTask(const CKnownFile *toAICHHash);
 
 protected:
-	//! Specifies which hashes should be calculated when the task is executed.
-	//! EH_MD4 and EH_AICH are bit flags; the combined value is named
-	//! explicitly so a bitwise OR cast doesn't produce a value outside
-	//! the enum's valid range (caught by
-	//! clang-analyzer-optin.core.EnumCastOutOfRange in the cpp ctor).
+	//! Which hashes to calculate when the task runs. EH_MD4 and EH_AICH are bit
+	//! flags; the combined value is named explicitly so a bitwise OR cast cannot
+	//! produce a value outside the enum's valid range.
 	enum EHashes
 	{
 		EH_AICH = 1,
@@ -87,10 +85,8 @@ protected:
 		EH_MD4_AND_AICH = EH_MD4 | EH_AICH
 	};
 
-	//! @see CThreadTask::OnLastTask
 	virtual void OnLastTask();
 
-	//! @see CThreadTask::Entry
 	virtual void Entry();
 
 	/**
@@ -121,10 +117,9 @@ private:
 	void SetHashingProgress(uint16 part);
 };
 
-// Media metadata probing (#140/#280) runs on the dedicated
-// CMediaProbeThread, not the shared CThreadScheduler, so a slow/hung
-// ffprobe can't stall completions. Results still arrive via the
-// CMediaProbeEvent below. See MediaProbeThread.h.
+// Media metadata probing (#140/#280) runs on the dedicated CMediaProbeThread,
+// not the shared CThreadScheduler, so a slow or hung ffprobe cannot stall
+// completions. Results still arrive via the CMediaProbeEvent below.
 
 /**
  * This task synchronizes the AICH hashlist.

--- a/src/TransferWnd.cpp
+++ b/src/TransferWnd.cpp
@@ -88,16 +88,14 @@ CTransferWnd::CTransferWnd(wxWindow *pParent)
 	clientlistctrl = CastChild(ID_CLIENTLIST, CSourceListCtrl);
 	m_dlTab = CastChild(ID_CATEGORIES, CMuleNotebook);
 
-	// Render the initial "Total size: 0 bytes" so the field is visible for an
-	// empty queue. CDownloadListCtrl::SetTotalSize() can't do it yet: it reaches
-	// the label through theApp->amuledlg->m_transferwnd, which isn't assigned
-	// until this constructor returns. The widget lives under this window, so
-	// CastChild finds it directly.
+	// Render the initial "Total size: 0 bytes" so the field is visible for an empty
+	// queue. CDownloadListCtrl::SetTotalSize() cannot do it yet: it reaches the
+	// label through theApp->amuledlg->m_transferwnd, which is not assigned until
+	// this constructor returns.
 	if (wxStaticText *totalSize = CastChild("downloadsTotalSize", wxStaticText)) {
 		totalSize->SetLabel(CFormat(_("Total queue size: %s")) % CastItoXBytes(0));
 	}
 
-	// Set disabled image for clear complete button
 	const wxBitmapBundle clrDisabled =
 		wxArtProvider::GetBitmapBundle("amule:transfer_clear_completed_disabled");
 	CastChild(ID_BTNCLRCOMPL, wxBitmapButton)->SetBitmapDisabled(clrDisabled);
@@ -105,11 +103,9 @@ CTransferWnd::CTransferWnd(wxWindow *pParent)
 	// We want to use our own popup
 	m_dlTab->SetPopupHandler(this);
 
-	// Set default category
 	theApp->glob_prefs->GetCategory(0)->title = GetCatTitle(thePrefs::GetAllcatFilter());
 	theApp->glob_prefs->GetCategory(0)->path = thePrefs::GetIncomingDir();
 
-	// Show default + userdefined categories
 	for (uint32 i = 0; i < theApp->glob_prefs->GetCatCount(); i++) {
 		m_dlTab->AddPage(new wxPanel(m_dlTab), theApp->glob_prefs->GetCategory(i)->title);
 	}
@@ -119,11 +115,9 @@ CTransferWnd::CTransferWnd(wxWindow *pParent)
 
 	wxConfigBase *config = wxConfigBase::Get();
 
-	// Check if the clientlist is hidden
 	bool show = true;
 	config->Read("/GUI/TransferWnd/ShowClientList", &show, true);
 	clientlistctrl->SetShowing(show);
-	// Load the last used splitter position
 	m_splitter = config->Read("/GUI/TransferWnd/Splitter", 463l);
 }
 
@@ -132,28 +126,22 @@ CTransferWnd::~CTransferWnd()
 	wxConfigBase *config = wxConfigBase::Get();
 
 	if (!clientlistctrl->GetShowing()) {
-		// Save the splitter position
 		config->Write("/GUI/TransferWnd/Splitter", m_splitter);
 
-		// Save the visible status of the list
 		config->Write("/GUI/TransferWnd/ShowClientList", false);
 	} else {
 		wxSplitterWindow *splitter = CastChild("splitterWnd", wxSplitterWindow);
 
-		// Save the splitter position
 		config->Write("/GUI/TransferWnd/Splitter", splitter->GetSashPosition());
 
-		// Save the visible status of the list
 		config->Write("/GUI/TransferWnd/ShowClientList", true);
 	}
 }
 
 void CTransferWnd::AddCategory(Category_Struct *category)
 {
-	// Add the initial page
 	m_dlTab->AddPage(new wxPanel(m_dlTab), category->title);
 
-	// Update the title
 	UpdateCategory(m_dlTab->GetPageCount() - 1);
 
 	theApp->amuledlg->m_searchwnd->UpdateCatChoice();

--- a/src/UPnPBase.cpp
+++ b/src/UPnPBase.cpp
@@ -144,14 +144,12 @@ static const std::string WAN_IP_Connection("urn:schemas-upnp-org:service:WANIPCo
 static const std::string WAN_PPP_Connection("urn:schemas-upnp-org:service:WANPPPConnection:1");
 } // namespace Service
 
-// Decide whether an SSDP NT/ST is something amule actually wants to learn
-// about. The whitelist is the IGW family plus upnp:rootdevice (which is
-// opaque from SSDP alone -- the description.xml has to be fetched to
-// classify it). Anything else (media renderers, mesh APs, smart speakers,
-// ...) gets dropped before amule attempts to download description.xml,
-// which keeps the libupnp ThreadPool queue from filling on busy LANs and
-// stops spurious "Error retrieving device description" log lines for
-// devices we have no use for.
+// Decide whether an SSDP NT/ST is something amule wants to learn about. The
+// whitelist is the IGW family plus upnp:rootdevice, which is opaque from SSDP
+// alone (description.xml has to be fetched to classify it). Anything else is
+// dropped before that fetch, which keeps the libupnp ThreadPool queue from
+// filling on busy LANs and stops spurious "Error retrieving device description"
+// lines for devices we have no use for.
 static bool IsWANRelatedDeviceType(const std::string &type)
 {
 	if (type.empty()) {
@@ -182,17 +180,14 @@ static bool IsWANRelatedDeviceType(const std::string &type)
 	return false;
 }
 
-// Case-insensitive match of a device/service type URN against a
-// fully-versioned reference URN, ignoring the trailing ":<version>"
-// component. IGD:2 gateways advertise their embedded devices and services
-// with a ":2" suffix (e.g. "urn:schemas-upnp-org:service:WANIPConnection:2"),
-// so classifying by an exact ":1" string would skip them even though
-// libupnp's version-tolerant M-SEARCH still reaches the device. We keep the
-// fully-versioned constants — they double as the M-SEARCH target, which must
-// carry a version — and strip the tail only for classification, prefix-
-// matching on the reference through its final ':'. The trailing ':' is
-// retained in the prefix so "WANIPConnection:" cannot match, e.g.,
-// "WANIPConnectionFoo:1".
+// Case-insensitive match of a device/service type URN against a fully-versioned
+// reference URN, ignoring the trailing ":<version>". IGD:2 gateways advertise
+// their embedded devices and services with a ":2" suffix, so classifying by an
+// exact ":1" string would skip them even though libupnp's version-tolerant
+// M-SEARCH still reaches the device. The fully-versioned constants stay (they
+// double as the M-SEARCH target, which must carry a version) and the tail is
+// stripped only for classification. The reference's final ':' is kept in the
+// prefix so "WANIPConnection:" cannot match "WANIPConnectionFoo:1".
 static bool TypeMatchesIgnoringVersion(const std::string &type, const std::string &reference)
 {
 	std::string::size_type lastColon = reference.find_last_of(':');
@@ -519,21 +514,16 @@ CUPnPService::CUPnPService(
 	    m_serviceType == UPnP::Service::Layer3_Forwarding) {
 #endif
 #if 0
-//#warning Delete this code on release.
 		if (!upnpControlPoint.WanServiceDetected()) {
 			// This condition can be used to suspend the parse
 			// of the XML tree.
 #endif
-		// #warning Delete this code when m_WanService is no longer used.
 		const_cast<CUPnPControlPoint &>(upnpControlPoint).SetWanService(this);
-		// Log it
 		msg.str("");
 		msg << "WAN Service Detected: '" << m_serviceType << "'.";
 		AddDebugLogLineN(logUPnP, msg);
-		// Subscribe
 		const_cast<CUPnPControlPoint &>(upnpControlPoint).Subscribe(*this);
 #if 0
-//#warning Delete this code on release.
 		} else {
 			msg.str("");
 			msg << "WAN service detected again: '" <<
@@ -562,7 +552,6 @@ bool CUPnPService::Execute(
 		return false;
 	}
 	std::ostringstream msgAction("Sending action ");
-	// Check for correct action name
 	ActionList::const_iterator itAction = m_SCPD->GetActionList().find(ActionName);
 	if (itAction == m_SCPD->GetActionList().end()) {
 		msg << "Invalid action name '" << ActionName << "' for service '" << GetServiceType() << "'.";
@@ -571,7 +560,6 @@ bool CUPnPService::Execute(
 	}
 	msgAction << ActionName << "(";
 	bool firstTime = true;
-	// Check for correct Argument/Value pairs
 	const CUPnPAction &action = *(itAction->second);
 	for (unsigned int i = 0; i < ArgValue.size(); ++i) {
 		ArgumentList::const_iterator itArg = action.GetArgumentList().find(ArgValue[i].GetArgument());
@@ -626,7 +614,6 @@ bool CUPnPService::Execute(
 	}
 	msgAction << ")";
 	AddDebugLogLineN(logUPnP, msgAction);
-	// Everything is ok, make the action
 	IXML_Document *ActionDoc = NULL;
 	if (!ArgValue.empty()) {
 		for (unsigned int i = 0; i < ArgValue.size(); ++i) {
@@ -649,7 +636,6 @@ bool CUPnPService::Execute(
 		}
 	}
 #if 0
-	// Send the action asynchronously
 	UpnpSendActionAsync(
 		m_UPnPControlPoint.GetUPnPClientHandle(),
 		GetAbsControlURL().c_str(),
@@ -660,7 +646,6 @@ bool CUPnPService::Execute(
 	return true;
 #endif
 
-	// Send the action synchronously
 	IXML_Document *RespDoc = NULL;
 	int ret = UpnpSendAction(m_UPnPControlPoint.GetUPnPClientHandle(),
 		GetAbsControlURL().c_str(),
@@ -676,10 +661,8 @@ bool CUPnPService::Execute(
 	}
 	IXML::Document::Free(ActionDoc);
 
-	// Check the response document
 	UPnP::ProcessActionResponse(RespDoc, action.GetName());
 
-	// Free the response document
 	IXML::Document::Free(RespDoc);
 
 	return true;
@@ -774,9 +757,7 @@ CUPnPControlPoint::CUPnPControlPoint(unsigned short udpPort)
 , m_IGWDeviceDetected(false)
 , m_WanService(NULL)
 {
-	// Pointer to self
 	s_CtrlPoint = this;
-	// Null string at first
 	std::ostringstream msg;
 
 	// Declare those here to avoid
@@ -785,7 +766,6 @@ CUPnPControlPoint::CUPnPControlPoint(unsigned short udpPort)
 	unsigned short port;
 	char *ipAddress;
 
-	// Start UPnP
 	int ret;
 	ret = UpnpInit2(0, udpPort);
 	if (ret != UPNP_E_SUCCESS) {
@@ -798,16 +778,14 @@ CUPnPControlPoint::CUPnPControlPoint(unsigned short udpPort)
 	AddDebugLogLineN(logUPnP, msg);
 	msg.str("");
 
-	// Raise the SDK's incoming content-length ceiling above libupnp's
-	// 16 KB default (DEFAULT_SOAP_CONTENT_LENGTH). Some gateways serve an
-	// SCPD/description XML slightly larger than that, which makes the
-	// blocking UpnpDownloadXmlDoc in Subscribe() fail with
-	// UPNP_E_OUTOF_BOUNDS ("Error getting SCPD Document") — the service
-	// never registers, so no port mapping happens and the user is stuck on
-	// a LowID (observed on ZTE and Sagemcom routers). 1 MB clears any real
-	// router descriptor while still bounding what a hostile LAN device can
-	// push into a blocking fetch. Must run after UpnpInit2 succeeds: the
-	// call is a no-op (UPNP_E_FINISH) until the SDK is initialised.
+	// Raise the SDK's incoming content-length ceiling above libupnp's 16 KB
+	// default. Some gateways serve an SCPD/description XML slightly larger than
+	// that, which makes the blocking UpnpDownloadXmlDoc in Subscribe() fail with
+	// UPNP_E_OUTOF_BOUNDS -- the service never registers, no port mapping happens,
+	// and the user is stuck on a LowID (seen on ZTE and Sagemcom routers). 1 MB
+	// clears any real router descriptor while still bounding what a hostile LAN
+	// device can push into a blocking fetch. Must run after UpnpInit2 succeeds:
+	// the call is a no-op until the SDK is initialised.
 	ret = UpnpSetMaxContentLength(1024 * 1024);
 	if (ret != UPNP_E_SUCCESS) {
 		msg << "warning(UpnpSetMaxContentLength): could not raise content-length limit, error code "
@@ -825,21 +803,16 @@ CUPnPControlPoint::CUPnPControlPoint(unsigned short udpPort)
 	}
 
 	// Search for the InternetGatewayDevice specifically rather than
-	// upnp:rootdevice. Searching rootdevice makes *every* UPnP speaker on
-	// the LAN answer the M-SEARCH, and our SEARCH_RESULT handler then
-	// fetches description.xml from each one synchronously on a libupnp
-	// worker thread. On a busy LAN (or one with a slow/unreachable device)
-	// that saturates libupnp's mini-server thread pool, so incoming SSDP
-	// packets back up until ThreadPoolAdd hits its cap and starts dropping
-	// jobs ("libupnp ThreadPoolAdd too many jobs"). Targeting the IGW type
-	// means only gateways answer, which is all we need for port mapping;
-	// any gateway that appears later is still caught via its periodic
-	// IGW-typed ADVERTISEMENT_ALIVE announcement, and downstream registration
-	// already filters non-IGW devices out (search for UPnP::Device::IGW below).
+	// upnp:rootdevice. Searching rootdevice makes every UPnP speaker on the LAN
+	// answer the M-SEARCH, and our SEARCH_RESULT handler then fetches
+	// description.xml from each one synchronously on a libupnp worker thread; on a
+	// busy LAN that saturates the mini-server thread pool until ThreadPoolAdd hits
+	// its cap and drops jobs. Targeting the IGW type means only gateways answer,
+	// which is all port mapping needs, and a gateway that appears later is still
+	// caught by its periodic IGW-typed ADVERTISEMENT_ALIVE.
 	//
-	// We must not search more than once, because each search produces its
-	// own UPNP_DISCOVERY_SEARCH_TIMEOUT event, and we might end with
-	// problems on the mutex.
+	// We must not search more than once: each search produces its own
+	// UPNP_DISCOVERY_SEARCH_TIMEOUT event, and two would race on the mutex.
 	ret = UpnpSearchAsync(m_UPnPClientHandle, 3, UPnP::Device::IGW.c_str(), nullptr);
 	if (ret != UPNP_E_SUCCESS) {
 		msg << "error(UpnpSearchAsync): Error sending search request: ";
@@ -848,7 +821,6 @@ CUPnPControlPoint::CUPnPControlPoint(unsigned short udpPort)
 
 	// Wait for the UPnP initialization to complete.
 	{
-		// Lock the search timeout mutex
 		m_WaitForSearchTimeoutMutex.Lock();
 
 		// Lock it again, so that we block. Unlocking will only happen
@@ -858,7 +830,6 @@ CUPnPControlPoint::CUPnPControlPoint(unsigned short udpPort)
 	}
 	return;
 
-	// Error processing
 error:
 	UpnpFinish();
 	msg << ret << ": " << UpnpGetErrorMessage(ret) << ".";
@@ -870,8 +841,6 @@ CUPnPControlPoint::~CUPnPControlPoint()
 	for (RootDeviceMap::iterator it = m_RootDeviceMap.begin(); it != m_RootDeviceMap.end(); ++it) {
 		delete it->second;
 	}
-	// Remove all first
-	// RemoveAll();
 	UpnpUnRegisterClient(m_UPnPClientHandle);
 	UpnpFinish();
 }
@@ -890,20 +859,15 @@ bool CUPnPControlPoint::AddPortMappings(std::vector<CUPnPPortMapping> &upnpPortM
 	int n = upnpPortMapping.size();
 	bool ok = false;
 
-	// Check the number of port mappings before
 	std::istringstream PortMappingNumberOfEntries(
 		m_WanService->GetStateVariable("PortMappingNumberOfEntries"));
 	unsigned long oldNumberOfEntries;
 	PortMappingNumberOfEntries >> oldNumberOfEntries;
 
-	// Add the enabled port mappings
 	for (int i = 0; i < n; ++i) {
 		if (upnpPortMapping[i].getEnabled() == "1") {
-			// Add the mapping to the control point
-			// active mappings list
 			m_ActivePortMappingsMap[upnpPortMapping[i].getKey()] = upnpPortMapping[i];
 
-			// Add the port mapping
 			PrivateAddPortMapping(upnpPortMapping[i]);
 		}
 	}
@@ -921,7 +885,6 @@ bool CUPnPControlPoint::AddPortMappings(std::vector<CUPnPPortMapping> &upnpPortM
 	m_WanService->GetStateVariable("PortMappingNumberOfEntries");
 	m_WanService->GetStateVariable("PortMappingLeaseDuration");
 
-	// Just for testing
 	std::vector<CUPnPArgumentValue> argval;
 	argval.resize(0);
 	m_WanService->Execute("GetStatusInfo", argval);
@@ -938,14 +901,12 @@ bool CUPnPControlPoint::AddPortMappings(std::vector<CUPnPPortMapping> &upnpPortM
 	m_WanService->GetStateVariable("PortMappingDescription");
 #endif
 
-	// Debug only
 	msg.str("");
 	msg << "CUPnPControlPoint::AddPortMappings: "
 	       "m_ActivePortMappingsMap.size() == "
 	    << m_ActivePortMappingsMap.size();
 	AddDebugLogLineN(logUPnP, msg);
 
-	// Not very good, must find a better test
 	PortMappingNumberOfEntries.str(m_WanService->GetStateVariable("PortMappingNumberOfEntries"));
 	unsigned long newNumberOfEntries;
 	PortMappingNumberOfEntries >> newNumberOfEntries;
@@ -962,20 +923,16 @@ void CUPnPControlPoint::RefreshPortMappings()
 		PrivateAddPortMapping(it->second);
 	}
 
-	// For testing
 	m_WanService->GetStateVariable("PortMappingNumberOfEntries");
 }
 
 bool CUPnPControlPoint::PrivateAddPortMapping(CUPnPPortMapping &upnpPortMapping)
 {
-	// Get an IP address. The UPnP server one must do.
 	std::string ipAddress(UpnpGetServerIpAddress());
 
-	// Start building the action
 	std::string actionName("AddPortMapping");
 	std::vector<CUPnPArgumentValue> argval(8);
 
-	// Action parameters
 	argval[0].SetArgument("NewRemoteHost");
 	argval[0].SetValue("");
 	argval[1].SetArgument("NewExternalPort");
@@ -993,7 +950,6 @@ bool CUPnPControlPoint::PrivateAddPortMapping(CUPnPPortMapping &upnpPortMapping)
 	argval[7].SetArgument("NewLeaseDuration");
 	argval[7].SetValue("0");
 
-	// Execute
 	bool ret = true;
 	for (ServiceMap::iterator it = m_ServiceMap.begin(); it != m_ServiceMap.end(); ++it) {
 		ret &= it->second->Execute(actionName, argval);
@@ -1016,17 +972,13 @@ bool CUPnPControlPoint::DeletePortMappings(std::vector<CUPnPPortMapping> &upnpPo
 	int n = upnpPortMapping.size();
 	bool ok = false;
 
-	// Check the number of port mappings before
 	std::istringstream PortMappingNumberOfEntries(
 		m_WanService->GetStateVariable("PortMappingNumberOfEntries"));
 	unsigned long oldNumberOfEntries;
 	PortMappingNumberOfEntries >> oldNumberOfEntries;
 
-	// Delete the enabled port mappings
 	for (int i = 0; i < n; ++i) {
 		if (upnpPortMapping[i].getEnabled() == "1") {
-			// Delete the mapping from the control point
-			// active mappings list
 			PortMappingMap::iterator it =
 				m_ActivePortMappingsMap.find(upnpPortMapping[i].getKey());
 			if (it != m_ActivePortMappingsMap.end()) {
@@ -1039,19 +991,16 @@ bool CUPnPControlPoint::DeletePortMappings(std::vector<CUPnPPortMapping> &upnpPo
 				AddDebugLogLineC(logUPnP, msg);
 			}
 
-			// Delete the port mapping
 			PrivateDeletePortMapping(upnpPortMapping[i]);
 		}
 	}
 
-	// Debug only
 	msg.str("");
 	msg << "CUPnPControlPoint::DeletePortMappings: "
 	       "m_ActivePortMappingsMap.size() == "
 	    << m_ActivePortMappingsMap.size();
 	AddDebugLogLineN(logUPnP, msg);
 
-	// Not very good, must find a better test
 	PortMappingNumberOfEntries.str(m_WanService->GetStateVariable("PortMappingNumberOfEntries"));
 	unsigned long newNumberOfEntries;
 	PortMappingNumberOfEntries >> newNumberOfEntries;
@@ -1062,11 +1011,9 @@ bool CUPnPControlPoint::DeletePortMappings(std::vector<CUPnPPortMapping> &upnpPo
 
 bool CUPnPControlPoint::PrivateDeletePortMapping(CUPnPPortMapping &upnpPortMapping)
 {
-	// Start building the action
 	std::string actionName("DeletePortMapping");
 	std::vector<CUPnPArgumentValue> argval(3);
 
-	// Action parameters
 	argval[0].SetArgument("NewRemoteHost");
 	argval[0].SetValue("");
 	argval[1].SetArgument("NewExternalPort");
@@ -1074,7 +1021,6 @@ bool CUPnPControlPoint::PrivateDeletePortMapping(CUPnPPortMapping &upnpPortMappi
 	argval[2].SetArgument("NewProtocol");
 	argval[2].SetValue(upnpPortMapping.getProtocol());
 
-	// Execute
 	bool ret = true;
 	for (ServiceMap::iterator it = m_ServiceMap.begin(); it != m_ServiceMap.end(); ++it) {
 		ret &= it->second->Execute(actionName, argval);
@@ -1083,7 +1029,6 @@ bool CUPnPControlPoint::PrivateDeletePortMapping(CUPnPPortMapping &upnpPortMappi
 	return ret;
 }
 
-// This function is static
 #if UPNP_VERSION >= 11800
 int CUPnPControlPoint::Callback(Upnp_EventType_e EventType, void *Event, void * /*Cookie*/)
 #elif UPNP_VERSION >= 11430
@@ -1098,20 +1043,17 @@ int CUPnPControlPoint::Callback(Upnp_EventType EventType, void *Event, void * /*
 {
 	std::ostringstream msg;
 	std::ostringstream msg2;
-	// Somehow, this is unreliable. UPNP_DISCOVERY_ADVERTISEMENT_ALIVE events
-	// happen with a wrong cookie and... boom!
-	// CUPnPControlPoint *upnpCP = static_cast<CUPnPControlPoint *>(Cookie);
+	// Somehow, this is unreliable: UPNP_DISCOVERY_ADVERTISEMENT_ALIVE events
+	// happen with a wrong cookie, so the cookie cannot be trusted here.
 	CUPnPControlPoint *upnpCP = CUPnPControlPoint::s_CtrlPoint;
 
-	// fprintf(stderr, "Callback: %d, Cookie: %p\n", EventType, Cookie);
 	switch (EventType) {
 	case UPNP_DISCOVERY_ADVERTISEMENT_ALIVE: {
-		// Drop unsolicited NOTIFY announcements whose NT isn't a device
-		// or service we care about. Without this filter amule fetches
-		// description.xml from every UPnP speaker, media renderer, mesh
-		// AP, etc. on the LAN -- which both burns libupnp's ThreadPool
-		// budget and produces "Error retrieving device description" log
-		// noise for devices whose endpoints amule has no business poking.
+		// Drop unsolicited NOTIFY announcements whose NT is not a device or
+		// service we care about. Without this filter amule fetches
+		// description.xml from every UPnP speaker on the LAN, which burns
+		// libupnp's ThreadPool budget and produces "Error retrieving device
+		// description" noise for endpoints amule has no business poking.
 #if UPNP_VERSION >= 10800
 		UpnpDiscovery *d_filter_event = (UpnpDiscovery *)Event;
 		const char *deviceType = UpnpDiscovery_get_DeviceType_cstr(d_filter_event);
@@ -1122,16 +1064,13 @@ int CUPnPControlPoint::Callback(Upnp_EventType EventType, void *Event, void * /*
 		if (!UPnP::IsWANRelatedDeviceType(deviceType ? deviceType : "")) {
 			break;
 		}
-		// fprintf(stderr, "Callback: UPNP_DISCOVERY_ADVERTISEMENT_ALIVE\n");
 		msg << "error(UPNP_DISCOVERY_ADVERTISEMENT_ALIVE): ";
 		msg2 << "UPNP_DISCOVERY_ADVERTISEMENT_ALIVE: ";
 		goto upnpDiscovery;
 	}
 	case UPNP_DISCOVERY_SEARCH_RESULT: {
-		// fprintf(stderr, "Callback: UPNP_DISCOVERY_SEARCH_RESULT\n");
 		msg << "error(UPNP_DISCOVERY_SEARCH_RESULT): ";
 		msg2 << "UPNP_DISCOVERY_SEARCH_RESULT: ";
-		// UPnP Discovery
 	upnpDiscovery:
 #if UPNP_VERSION >= 10800
 		UpnpDiscovery *d_event = (UpnpDiscovery *)Event;
@@ -1155,13 +1094,11 @@ int CUPnPControlPoint::Callback(Upnp_EventType EventType, void *Event, void * /*
 #else
 		const char *location = d_event->Location;
 #endif
-		// Passive ALIVE announcements arrive in dense bursts (one per
-		// service class, every few seconds per device). When the
-		// announcing device's HTTP server is unreachable each fetch
-		// blocks a libupnp worker thread for the full TCP-connect
-		// timeout. Suppress repeat fetches against a recently-failed
-		// URL on ALIVE only -- SEARCH_RESULT is an active poll
-		// initiated by us and bypasses the cache.
+		// Passive ALIVE announcements arrive in dense bursts (one per service
+		// class, every few seconds per device), and when the announcing device's
+		// HTTP server is unreachable each fetch blocks a libupnp worker for the
+		// full TCP-connect timeout. Suppress repeat fetches against a
+		// recently-failed URL on ALIVE only: SEARCH_RESULT is our own active poll.
 		if (EventType == UPNP_DISCOVERY_ADVERTISEMENT_ALIVE &&
 			upnpCP->ShouldSkipAdvertisementFetch(location ? location : "")) {
 			break;
@@ -1182,23 +1119,16 @@ int CUPnPControlPoint::Callback(Upnp_EventType EventType, void *Event, void * /*
 			AddDebugLogLineN(logUPnP, msg2);
 		}
 		if (doc) {
-			// Get the root node
 			IXML_Element *root = IXML::Document::GetRootElement(doc);
-			// Extract the URLBase
 			const std::string urlBase = IXML::Element::GetChildValueByTag(root, "URLBase");
-			// Get the root device
 			IXML_Element *rootDevice = IXML::Element::GetFirstChildByTag(root, "device");
-			// Extract the deviceType
 			std::string devType(IXML::Element::GetChildValueByTag(rootDevice, "deviceType"));
 			// Only add device if it is an InternetGatewayDevice
 			// (any version — IGD:2 advertises its root as ":2").
 			if (UPnP::TypeMatchesIgnoringVersion(devType, UPnP::Device::IGW)) {
-				// This condition can be used to auto-detect
-				// the UPnP device we are interested in.
-				// Obs.: Don't block the entry here on this
-				// condition! There may be more than one device,
-				// and the first that enters may not be the one
-				// we are interested in!
+				// Do not block entry on this condition: there may be more
+				// than one device, and the first to arrive may not be the
+				// one we want.
 				upnpCP->SetIGWDeviceDetected(true);
 				// Log it if not UPNP_DISCOVERY_ADVERTISEMENT_ALIVE,
 				// we don't want to spam our logs.
@@ -1206,7 +1136,6 @@ int CUPnPControlPoint::Callback(Upnp_EventType EventType, void *Event, void * /*
 					msg.str("Internet Gateway Device Detected.");
 					AddDebugLogLineC(logUPnP, msg);
 				}
-				// Add the root device to our list
 #if UPNP_VERSION >= 10800
 				int expires = UpnpDiscovery_get_Expires(d_event);
 				upnpCP->AddRootDevice(rootDevice, urlBase, location, expires);
@@ -1215,25 +1144,21 @@ int CUPnPControlPoint::Callback(Upnp_EventType EventType, void *Event, void * /*
 					rootDevice, urlBase, d_event->Location, d_event->Expires);
 #endif
 			}
-			// Free the XML doc tree
 			IXML::Document::Free(doc);
 		}
 		break;
 	}
 	case UPNP_DISCOVERY_SEARCH_TIMEOUT: {
-		// fprintf(stderr, "Callback: UPNP_DISCOVERY_SEARCH_TIMEOUT\n");
-		//  Search timeout
+		// Search timeout
 		msg << "UPNP_DISCOVERY_SEARCH_TIMEOUT.";
 		AddDebugLogLineN(logUPnP, msg);
 
-		// Unlock the search timeout mutex
 		upnpCP->m_WaitForSearchTimeoutMutex.Unlock();
 
 		break;
 	}
 	case UPNP_DISCOVERY_ADVERTISEMENT_BYEBYE: {
-		// fprintf(stderr, "Callback: UPNP_DISCOVERY_ADVERTISEMENT_BYEBYE\n");
-		//  UPnP Device Removed
+		// UPnP Device Removed
 #if UPNP_VERSION >= 10800
 		UpnpDiscovery *dab_event = (UpnpDiscovery *)Event;
 		int errCode = UpnpDiscovery_get_ErrCode(dab_event);
@@ -1277,8 +1202,7 @@ int CUPnPControlPoint::Callback(Upnp_EventType EventType, void *Event, void * /*
 		break;
 	}
 	case UPNP_EVENT_RECEIVED: {
-		// fprintf(stderr, "Callback: UPNP_EVENT_RECEIVED\n");
-		//  Event received
+		// Event received
 #if UPNP_VERSION >= 10800
 		UpnpEvent *e_event = (UpnpEvent *)Event;
 		int eventKey = UpnpEvent_get_EventKey(e_event);
@@ -1297,15 +1221,12 @@ int CUPnPControlPoint::Callback(Upnp_EventType EventType, void *Event, void * /*
 		break;
 	}
 	case UPNP_EVENT_SUBSCRIBE_COMPLETE:
-		// fprintf(stderr, "Callback: UPNP_EVENT_SUBSCRIBE_COMPLETE\n");
 		msg << "error(UPNP_EVENT_SUBSCRIBE_COMPLETE): ";
 		goto upnpEventRenewalComplete;
 	case UPNP_EVENT_UNSUBSCRIBE_COMPLETE:
-		// fprintf(stderr, "Callback: UPNP_EVENT_UNSUBSCRIBE_COMPLETE\n");
 		msg << "error(UPNP_EVENT_UNSUBSCRIBE_COMPLETE): ";
 		goto upnpEventRenewalComplete;
 	case UPNP_EVENT_RENEWAL_COMPLETE: {
-		// fprintf(stderr, "Callback: UPNP_EVENT_RENEWAL_COMPLETE\n");
 		msg << "error(UPNP_EVENT_RENEWAL_COMPLETE): ";
 	upnpEventRenewalComplete:
 #if UPNP_VERSION >= 10800
@@ -1343,12 +1264,10 @@ int CUPnPControlPoint::Callback(Upnp_EventType EventType, void *Event, void * /*
 		break;
 	}
 	case UPNP_EVENT_AUTORENEWAL_FAILED:
-		// fprintf(stderr, "Callback: UPNP_EVENT_AUTORENEWAL_FAILED\n");
 		msg << "error(UPNP_EVENT_AUTORENEWAL_FAILED): ";
 		msg2 << "UPNP_EVENT_AUTORENEWAL_FAILED: ";
 		goto upnpEventSubscriptionExpired;
 	case UPNP_EVENT_SUBSCRIPTION_EXPIRED: {
-		// fprintf(stderr, "Callback: UPNP_EVENT_SUBSCRIPTION_EXPIRED\n");
 		msg << "error(UPNP_EVENT_SUBSCRIPTION_EXPIRED): ";
 		msg2 << "UPNP_EVENT_SUBSCRIPTION_EXPIRED: ";
 	upnpEventSubscriptionExpired:
@@ -1413,8 +1332,7 @@ int CUPnPControlPoint::Callback(Upnp_EventType EventType, void *Event, void * /*
 		break;
 	}
 	case UPNP_CONTROL_ACTION_COMPLETE: {
-		// fprintf(stderr, "Callback: UPNP_CONTROL_ACTION_COMPLETE\n");
-		//  This is here if we choose to do this asynchronously
+		// This is here if we choose to do this asynchronously
 #if UPNP_VERSION >= 10800
 		UpnpActionComplete *a_event = (UpnpActionComplete *)Event;
 		int errCode = UpnpActionComplete_get_ErrCode(a_event);
@@ -1435,7 +1353,6 @@ int CUPnPControlPoint::Callback(Upnp_EventType EventType, void *Event, void * /*
 				a_event->ActionResult);
 #endif
 		} else {
-			// Check the response document
 			UPnP::ProcessActionResponse(
 #if UPNP_VERSION >= 10800
 				actionResult,
@@ -1450,7 +1367,6 @@ int CUPnPControlPoint::Callback(Upnp_EventType EventType, void *Event, void * /*
 		break;
 	}
 	case UPNP_CONTROL_GET_VAR_COMPLETE: {
-		// fprintf(stderr, "Callback: UPNP_CONTROL_GET_VAR_COMPLETE\n");
 		msg << "error(UPNP_CONTROL_GET_VAR_COMPLETE): ";
 #if UPNP_VERSION >= 10800
 		UpnpStateVarComplete *sv_event = (UpnpStateVarComplete *)Event;
@@ -1493,28 +1409,23 @@ int CUPnPControlPoint::Callback(Upnp_EventType EventType, void *Event, void * /*
 	}
 	// ignore these cases, since this is not a device
 	case UPNP_CONTROL_GET_VAR_REQUEST:
-		// fprintf(stderr, "Callback: UPNP_CONTROL_GET_VAR_REQUEST\n");
 		msg << "error(UPNP_CONTROL_GET_VAR_REQUEST): ";
 		goto eventSubscriptionRequest;
 	case UPNP_CONTROL_ACTION_REQUEST:
-		// fprintf(stderr, "Callback: UPNP_CONTROL_ACTION_REQUEST\n");
 		msg << "error(UPNP_CONTROL_ACTION_REQUEST): ";
 		goto eventSubscriptionRequest;
 	case UPNP_EVENT_SUBSCRIPTION_REQUEST:
-		// fprintf(stderr, "Callback: UPNP_EVENT_SUBSCRIPTION_REQUEST\n");
 		msg << "error(UPNP_EVENT_SUBSCRIPTION_REQUEST): ";
 	eventSubscriptionRequest:
 		msg << "This is not a UPnP Device, this is a UPnP Control Point, event ignored.";
 		AddDebugLogLineC(logUPnP, msg);
 		break;
 	default:
-		// Hum, this is not good, we forgot to handle something...
 		fprintf(stderr, "Callback: default... Unknown event:'%d', not good.\n", EventType);
 		msg << "error(UPnP::Callback): Event not handled:'" << EventType << "'.";
 		fprintf(stderr, "%s\n", msg.str().c_str());
 		AddDebugLogLineC(logUPnP, msg);
 		// Better not throw in the callback. Who would catch it?
-		// throw CUPnPException(msg);
 		break;
 	}
 
@@ -1546,22 +1457,17 @@ void CUPnPControlPoint::OnEventReceived(
 void CUPnPControlPoint::AddRootDevice(
 	IXML_Element *rootDevice, const std::string &urlBase, const char *location, int expires)
 {
-	// Lock the Root Device List
 	CUPnPMutexLocker lock(m_RootDeviceListMutex);
 
-	// Root node's URLBase
 	const std::string &OriginalURLBase(urlBase);
 	std::string FixedURLBase(OriginalURLBase.empty() ? location : OriginalURLBase);
 
-	// Get the UDN (Unique Device Name)
 	std::string UDN(IXML::Element::GetChildValueByTag(rootDevice, "UDN"));
 	RootDeviceMap::iterator it = m_RootDeviceMap.find(UDN);
 	bool alreadyAdded = it != m_RootDeviceMap.end();
 	if (alreadyAdded) {
-		// Just set the expires field
 		it->second->SetExpires(expires);
 	} else {
-		// Add a new root device to the root device list
 		CUPnPRootDevice *upnpRootDevice = new CUPnPRootDevice(
 			*this, rootDevice, OriginalURLBase, FixedURLBase, location, expires);
 		m_RootDeviceMap[upnpRootDevice->GetUDN()] = upnpRootDevice;
@@ -1570,10 +1476,8 @@ void CUPnPControlPoint::AddRootDevice(
 
 void CUPnPControlPoint::RemoveRootDevice(const char *udn)
 {
-	// Lock the Root Device List
 	CUPnPMutexLocker lock(m_RootDeviceListMutex);
 
-	// Remove
 	std::string UDN(udn);
 	RootDeviceMap::iterator it = m_RootDeviceMap.find(UDN);
 	if (it != m_RootDeviceMap.end()) {
@@ -1601,17 +1505,14 @@ bool CUPnPControlPoint::ShouldSkipAdvertisementFetch(const std::string &location
 void CUPnPControlPoint::RecordAdvertisementFetchResult(const std::string &location, bool /*success*/)
 {
 	CUPnPMutexLocker lock(m_failedFetchCacheMutex);
-	// Rate-limit successes the same way we rate-limit failures. The old
-	// erase-on-success path re-issued a blocking UpnpDownloadXmlDoc on
-	// every subsequent ALIVE announcement for the already-classified
-	// location; those announcements arrive in dense, repeating bursts
-	// (one per service class every few seconds per device), so on a busy
-	// LAN they alone can keep libupnp's mini-server thread pool saturated.
-	// Recording the attempt time regardless of outcome bounds ALIVE-driven
-	// downloads to one per location per FAILED_FETCH_TTL_SECS. Nothing is
-	// lost because a gateway found on the first fetch is already
-	// registered; later ALIVEs only refresh the expiry, which the TTL
-	// (5 min) comfortably covers.
+	// Rate-limit successes the same way as failures. Erasing on success re-issued
+	// a blocking UpnpDownloadXmlDoc on every subsequent ALIVE announcement for an
+	// already-classified location, and those arrive in dense repeating bursts, so
+	// on a busy LAN they alone can keep libupnp's thread pool saturated. Recording
+	// the attempt time regardless of outcome bounds ALIVE-driven downloads to one
+	// per location per FAILED_FETCH_TTL_SECS, and nothing is lost: a gateway found
+	// on the first fetch is already registered, and later ALIVEs only refresh the
+	// expiry, which the TTL covers.
 	m_failedFetchCache[location] = time(nullptr);
 }
 
@@ -1622,7 +1523,6 @@ void CUPnPControlPoint::Subscribe(CUPnPService &service)
 	IXML_Document *scpdDoc = NULL;
 	int errcode = UpnpDownloadXmlDoc(service.GetAbsSCPDURL().c_str(), &scpdDoc);
 	if (errcode == UPNP_E_SUCCESS) {
-		// Get the root node of this service (the SCPD Document)
 		IXML_Element *scpdRoot = IXML::Document::GetRootElement(scpdDoc);
 		CUPnPSCPD *scpd = new CUPnPSCPD(*this, scpdRoot, service.GetAbsSCPDURL());
 		service.SetSCPD(scpd);
@@ -1657,7 +1557,6 @@ void CUPnPControlPoint::Subscribe(CUPnPService &service)
 
 	return;
 
-	// Error processing
 error:
 	AddDebugLogLineN(logUPnP, msg);
 }

--- a/src/UploadBandwidthThrottler.cpp
+++ b/src/UploadBandwidthThrottler.cpp
@@ -183,7 +183,6 @@ void UploadBandwidthThrottler::QueueForSendingControlPacket(ThrottledControlSock
 {
 	bool wasEmpty = false;
 	{
-		// Get critical section
 		wxMutexLocker lock(m_tempQueueLocker);
 
 		if (m_doRun) {
@@ -196,24 +195,17 @@ void UploadBandwidthThrottler::QueueForSendingControlPacket(ThrottledControlSock
 		}
 	}
 
-	// Wake the throttler when the temp control queue transitions from
-	// empty to non-empty.  Without this signal the throttler's adaptive
-	// backoff (extraSleepTime *= 5 per idle tick, capped at 1 sec) lets
-	// the thread doze through newly-queued packets, adding 5–25 ms of
-	// latency to every freshly-built OP_REQUESTPARTS — which directly
-	// caps per-peer download throughput on Windows where peer ramp is
-	// already sensitive to ACK clock jitter.
+	// Wake the throttler when the temp control queue goes from empty to non-empty.
+	// Without the signal its adaptive backoff (extraSleepTime *= 5 per idle tick,
+	// capped at 1 s) lets the thread doze through newly-queued packets, adding
+	// 5-25 ms of latency to every freshly-built OP_REQUESTPARTS -- which directly
+	// caps per-peer download throughput on Windows, where peer ramp is already
+	// sensitive to ACK clock jitter.
 	//
-	// Gating on the empty→non-empty transition (rather than signaling
-	// on every queue add) matches the CBatchDrainNotifier pattern: one
-	// wake per drain cycle, not per producer add.  Bursty enqueues
-	// from the same SendBlockRequests fan-out coalesce into a single
-	// signal.
-	//
-	// The disk I/O thread already wakes the throttler the same way
-	// via NewUploadDataAvailable() when fresh file-data lands on a
-	// socket; this closes the equivalent gap for the control-packet
-	// path.
+	// Gating on that transition rather than on every queue add matches the
+	// CBatchDrainNotifier pattern: one wake per drain cycle, so bursty enqueues
+	// from one SendBlockRequests fan-out coalesce into a single signal. The disk I/O
+	// thread already wakes the throttler the same way for file data.
 	if (wasEmpty) {
 		wxMutexLocker lock(m_newDataMutex);
 		m_newDataCondition.Signal();
@@ -230,7 +222,6 @@ void UploadBandwidthThrottler::QueueForSendingControlPacket(ThrottledControlSock
 void UploadBandwidthThrottler::DoRemoveFromAllQueues(ThrottledControlSocket *socket)
 {
 	if (m_doRun) {
-		// Remove this socket from control packet queue
 		EraseValue(m_ControlQueue_list, socket);
 		EraseValue(m_ControlQueueFirst_list, socket);
 
@@ -254,7 +245,6 @@ void UploadBandwidthThrottler::RemoveFromAllQueues(ThrottledFileSocket *socket)
 	if (m_doRun) {
 		DoRemoveFromAllQueues(socket);
 
-		// And remove it from upload slots
 		RemoveFromStandardListNoLock(socket);
 	}
 }
@@ -303,7 +293,6 @@ void *UploadBandwidthThrottler::Entry()
 	while (m_doRun && !TestDestroy()) {
 		uint64 timeSinceLastLoop = GetTickCount64() - lastLoopTick;
 
-		// Calculate data rate
 		if (thePrefs::GetMaxUpload() == UNLIMITED) {
 			// MaxUpload=0 means literal unlimited — bypass the per-iteration rate cap
 			// so SendFileAndControlData() is never throttled.
@@ -334,9 +323,8 @@ void *UploadBandwidthThrottler::Entry()
 		}
 
 		if (timeSinceLastLoop < sleepTime) {
-			// eMule ref: UploadBandwidthThrottler.cpp:580 — WaitForSingleObject replaced with
-			// wxCondition::WaitTimeout Wakes early if disk I/O thread signals
-			// NewUploadDataAvailable()
+			// wxCondition::WaitTimeout in place of eMule's WaitForSingleObject.
+			// Wakes early if the disk I/O thread signals NewUploadDataAvailable().
 			wxMutexLocker lock(m_newDataMutex);
 			m_newDataCondition.WaitTimeout(sleepTime - timeSinceLastLoop);
 		}
@@ -359,11 +347,10 @@ void *UploadBandwidthThrottler::Entry()
 			timeSinceLastLoop = sleepTime + 2000;
 		}
 
-		// Calculate how many bytes we can spend
-		// In UNLIMITED mode, allowedDataRate = UINT_MAX (~4 GB/s) would overflow the
-		// sint32 bytesToSpend accumulator when multiplied by timeSinceLastLoop.
-		// Cap the budget rate at 1 GB/s — still far above any real uplink, and every
-		// real socket send() will short-circuit far below this ceiling.
+		// Calculate how many bytes we can spend. In UNLIMITED mode allowedDataRate is
+		// UINT_MAX (~4 GB/s), which would overflow the sint32 bytesToSpend accumulator
+		// once multiplied by timeSinceLastLoop, so the budget rate is capped at
+		// 1 GB/s -- still far above any real uplink.
 		const uint32 bytesToSpendRate =
 			(allowedDataRate == UNLIMITED_RATE) ? (1024u * 1024u * 1024u) : allowedDataRate;
 		bytesToSpend += (sint32)(bytesToSpendRate / 1000.0 * timeSinceLastLoop);

--- a/src/UploadClient.cpp
+++ b/src/UploadClient.cpp
@@ -53,16 +53,14 @@
 void CUpDownClient::SetUploadState(uint8 eNewState)
 {
 	if (eNewState != m_nUploadState) {
-		// Entering or leaving US_UPLOADING changes this file's live
-		// upload speed and uploading-client count (issue #466). Mark it
-		// EC-dirty so the delta protocol re-sends those tags — otherwise
-		// a file that just stopped uploading keeps a stale non-zero speed
-		// in remote clients until some other change happens to touch it.
+		// Entering or leaving US_UPLOADING changes this file's live upload speed
+		// and uploading-client count (issue #466). Mark it EC-dirty so the delta
+		// protocol re-sends those tags, or a file that just stopped uploading keeps
+		// a stale non-zero speed in remote clients.
 		if ((m_nUploadState == US_UPLOADING || eNewState == US_UPLOADING) && m_uploadingfile) {
 			m_uploadingfile->MarkECChanged();
 		}
 		if (m_nUploadState == US_UPLOADING) {
-			// Reset upload data rate computation
 			m_nUpDatarate = 0;
 			m_nSumForAvgUpDataRate = 0;
 			m_AvarageUDR_list.clear();
@@ -154,31 +152,24 @@ uint32 CUpDownClient::CalculateScoreInternal()
 	return (uint32)fBaseValue;
 }
 
-// Checks if it is next requested block from another chunk of the actual file or from another file
-//
-// [Returns]
-//   true : Next requested block is from another different chunk or file than last downloaded block
-//   false: Next requested block is from same chunk that last downloaded block
+// True when the next requested block is from a different chunk or file than the
+// last downloaded block. [Tarod 12/22/2002]
 bool CUpDownClient::IsDifferentPartBlock() const // [Tarod 12/22/2002]
 {
 	bool different_part = false;
 
-	// Check if we have good lists and proceed to check for different chunks
 	if ((!m_BlockRequests_queue.empty()) && !m_DoneBlocks_list.empty()) {
 		Requested_Block_Struct *last_done_block = NULL;
 		Requested_Block_Struct *next_requested_block = NULL;
 		uint64 last_done_part = 0xffffffff;
 		uint64 next_requested_part = 0xffffffff;
 
-		// Get last block and next pending
 		last_done_block = m_DoneBlocks_list.front();
 		next_requested_block = m_BlockRequests_queue.front();
 
-		// Calculate corresponding parts to blocks
 		last_done_part = last_done_block->StartOffset / PARTSIZE;
 		next_requested_part = next_requested_block->StartOffset / PARTSIZE;
 
-		// Test is we are asking same file and same part
 		if (last_done_part != next_requested_part) {
 			different_part = true;
 			AddDebugLogLineN(logClient, "Session ended due to new chunk.");
@@ -247,10 +238,9 @@ void CUpDownClient::ProcessExtendedInfo(const CMemFile *data, CKnownFile *tempre
 		}
 
 		if (GetExtendedRequestsVersion() > 1) {
-			// Still guarded, because this is where the count is read off the
-			// wire. The recompute it used to gate has moved below: the peer's
-			// self-reported total staying put says nothing about its part
-			// bitmap, which may well have changed in the same message.
+			// Still guarded, because this is where the count is read off the wire.
+			// The recompute it used to gate has moved below: the peer's self-reported
+			// total staying put says nothing about its part bitmap.
 			SetUpCompleteSourcesCount(data->ReadUInt16());
 		}
 	}
@@ -258,13 +248,12 @@ void CUpDownClient::ProcessExtendedInfo(const CMemFile *data, CKnownFile *tempre
 	m_uploadingfile->UpdateUpPartsFrequency(this, true); // Increment
 	// Unconditional now, where it used to be gated on the peer's self-reported
 	// complete-source total having changed -- which says nothing about its part
-	// bitmap, so the frequency vector could move without the count following
-	// (issue #1050). UpdatePartsInfo() is throttled to one real recompute a
-	// minute per file, so the extra calls cost a comparison.
+	// bitmap, so the frequency vector could move without the count following (issue
+	// #1050). UpdatePartsInfo() is throttled to one real recompute a minute per
+	// file, so the extra calls cost a comparison.
 	//
 	// On tempreqfile, as before: the UDP/v3 callers pass a reqfile that is not
-	// necessarily this client's m_uploadingfile, and this change is about when
-	// the recompute happens, not which file it runs on.
+	// necessarily this client's m_uploadingfile.
 	tempreqfile->UpdatePartsInfo();
 
 	Notify_SharedCtrlRefreshClient(ECID(), AVAILABLE_SOURCE);
@@ -277,22 +266,19 @@ void CUpDownClient::SetUploadFileID(CKnownFile *newreqfile)
 	} else if (m_uploadingfile) {
 		m_uploadingfile->RemoveUploadingClient(this);
 		m_uploadingfile->UpdateUpPartsFrequency(this, false); // Decrement
-		// The decrement side never recomputed, so the count was a high-water
-		// mark that only ever rose (issue #1050). This one call covers both the
-		// peer disconnecting (Safe_Delete -> SetUploadFileID(NULL)) and the peer
-		// switching to a different file.
+		// The decrement side never recomputed, so the count was a high-water mark
+		// that only ever rose (issue #1050). This one call covers both the peer
+		// disconnecting and the peer switching to a different file.
 		m_uploadingfile->UpdatePartsInfo();
 	}
 
 	if (newreqfile) {
-		// This is a new file! update info
 		newreqfile->AddUploadingClient(this);
 
 		if (m_requpfileid != newreqfile->GetFileHash()) {
 			m_requpfileid = newreqfile->GetFileHash();
 			m_upPartStatus.setsize(newreqfile->GetPartCount(), 0);
 		} else {
-			// this is the same file we already had assigned. Only update data.
 			newreqfile->UpdateUpPartsFrequency(this, true); // Increment
 			newreqfile->UpdatePartsInfo();
 		}
@@ -301,7 +287,6 @@ void CUpDownClient::SetUploadFileID(CKnownFile *newreqfile)
 	} else {
 		m_upPartStatus.clear();
 		m_nUpCompleteSourcesCount = 0;
-		// This clears m_uploadingfile and m_requpfileid
 		ClearUploadFileID();
 	}
 }
@@ -449,17 +434,11 @@ uint32 CUpDownClient::SendBlockData()
 
 	if (m_socket) {
 		CEMSocket *s = m_socket;
-		//		uint32 uUpStatsPort = GetUserPort();
 
-		// Extended statistics information based on which client software and which port we sent this
-		// data to... This also updates the grand total for sent bytes, etc.  And where this data came
-		// from.
+		// Extended statistics based on which client software and port we sent this
+		// data to, which also updates the grand totals.
 		sentBytesCompleteFile = s->GetSentBytesCompleteFileSinceLastCallAndReset();
 		sentBytesPartFile = s->GetSentBytesPartFileSinceLastCallAndReset();
-		//		thePrefs.Add2SessionTransferData(GetClientSoft(), uUpStatsPort, false, true,
-		// sentBytesCompleteFile, (IsFriend() && GetFriendSlot()));
-		//		thePrefs.Add2SessionTransferData(GetClientSoft(), uUpStatsPort, true, true,
-		// sentBytesPartFile, (IsFriend() && GetFriendSlot()));
 
 		m_nTransferredUp += sentBytesCompleteFile + sentBytesPartFile;
 		credits->AddUploaded(
@@ -468,9 +447,9 @@ uint32 CUpDownClient::SendBlockData()
 		sentBytesPayload = s->GetSentPayloadSinceLastCallAndReset();
 		m_nCurQueueSessionPayloadUp += sentBytesPayload;
 
-		// Wake the disk I/O thread so it can re-check its buffer condition with the
-		// freshly updated m_nCurQueueSessionPayloadUp. Without this, the thread might
-		// wait up to its WaitTimeout (100ms) before noticing curPayload advanced.
+		// Wake the disk I/O thread so it re-checks its buffer condition against the
+		// freshly updated m_nCurQueueSessionPayloadUp, rather than waiting out its
+		// 100 ms timeout before noticing curPayload advanced.
 		if (sentBytesPayload > 0 && theApp->uploadDiskIOThread) {
 			theApp->uploadDiskIOThread->SocketNeedsMoreData();
 		}
@@ -483,22 +462,19 @@ uint32 CUpDownClient::SendBlockData()
 
 	if (sentBytesCompleteFile + sentBytesPartFile > 0 || m_AvarageUDR_list.empty() ||
 		(curTick - m_AvarageUDR_list.back().timestamp) > 1 * 1000) {
-		// Store how much data we've transferred this round,
-		// to be able to calculate average speed later
-		// keep sum of all values in list up to date
+		// Store how much data was transferred this round, to calculate the average
+		// speed later, keeping the running sum up to date.
 		TransferredData newitem = { (uint32)(sentBytesCompleteFile + sentBytesPartFile), curTick };
 		m_AvarageUDR_list.push_back(newitem);
 		m_nSumForAvgUpDataRate += sentBytesCompleteFile + sentBytesPartFile;
 	}
 
-	// remove to old values in list
 	while ((!m_AvarageUDR_list.empty()) && (curTick - m_AvarageUDR_list.front().timestamp) > 10 * 1000) {
 		// keep sum of all values in list up to date
 		m_nSumForAvgUpDataRate -= m_AvarageUDR_list.front().datalen;
 		m_AvarageUDR_list.pop_front();
 	}
 
-	// Calculate average speed for this slot
 	if ((!m_AvarageUDR_list.empty()) && (curTick - m_AvarageUDR_list.front().timestamp) > 0 &&
 		GetUpStartTimeDelay() > 2 * 1000) {
 		m_nUpDatarate = ((uint64)m_nSumForAvgUpDataRate * 1000) /
@@ -508,7 +484,6 @@ uint32 CUpDownClient::SendBlockData()
 		m_nUpDatarate = 0; //-1;
 	}
 
-	// Check if it's time to update the display.
 	m_cSendblock++;
 	if (m_cSendblock == 30) {
 		m_cSendblock = 0;
@@ -522,12 +497,10 @@ void CUpDownClient::SendOutOfPartReqsAndAddToWaitingQueue()
 {
 	// Kry - this is actually taken from eMule, but makes a lot of sense ;)
 
-	// OP_OUTOFPARTREQS will tell the downloading client to go back to OnQueue..
-	// The main reason for this is that if we put the client back on queue and it goes
-	// back to the upload before the socket times out... We get a situation where the
-	// downloader thinks it already sent the requested blocks and the uploader thinks
-	// the downloader didn't send any request blocks. Then the connection times out..
-	// I did some tests with eDonkey also and it seems to work well with them also..
+	// OP_OUTOFPARTREQS tells the downloading client to go back to OnQueue. Without
+	// it, a client put back on queue that returns before the socket times out
+	// leaves the downloader thinking it already sent the requested blocks while the
+	// uploader thinks it sent none, and the connection times out.
 
 	// Send this immediately, don't queue.
 	CPacket *pPacket = new CPacket(OP_OUTOFPARTREQS, 0, OP_EDONKEYPROT);
@@ -664,17 +637,16 @@ void CUpDownClient::Ban()
 		"Client '" + GetUserName() +
 			"' seems to be an aggressive client and is banned from the uploadqueue");
 
-	// The upload state is set whether or not the record took the address, and
-	// the two are deliberately independent rather than out of step. US_BANNED
-	// governs this client object and needs nothing to identify it, so an
-	// aggressive peer we have no address for still loses its slot. The record
-	// governs an address so the ban outlives the object and survives a
-	// reconnection -- and with no address there is nothing to remember it by.
+	// The upload state is set whether or not the record took the address, and the
+	// two are deliberately independent. US_BANNED governs this client object and
+	// needs nothing to identify it, so an aggressive peer we have no address for
+	// still loses its slot; the record governs an ADDRESS, so the ban outlives the
+	// object and survives a reconnection, and with no address there is nothing to
+	// remember it by.
 	//
-	// The visible consequence is that IsBanned() reads false for such a peer
-	// while its state is US_BANNED, so it is never un-banned through the
-	// record. That is the right way round: we cannot recognise it if it comes
-	// back, so we must not claim to.
+	// The visible consequence is that IsBanned() reads false for such a peer while
+	// its state is US_BANNED, so it is never un-banned through the record. That is
+	// the right way round: we cannot recognise it if it comes back.
 	SetUploadState(US_BANNED);
 
 	Notify_SharedCtrlRefreshClient(ECID(), UNAVAILABLE_SOURCE);
@@ -689,13 +661,11 @@ void CUpDownClient::CheckForAggressive()
 {
 	uint64 cur_time = ::GetTickCount64();
 
-	// First call, initialize
 	if (!m_LastFileRequest) {
 		m_LastFileRequest = cur_time;
 		return;
 	}
 
-	// Is this an aggressive request?
 	if ((cur_time - m_LastFileRequest) < MIN_REQUESTTIME) {
 		m_Aggressiveness += 3;
 
@@ -718,7 +688,6 @@ void CUpDownClient::CheckForAggressive()
 
 void CUpDownClient::SetUploadFileID(const CMD4Hash &new_id)
 {
-	// Update the uploading file found
 	CKnownFile *uploadingfile = theApp->sharedfiles->GetFileByID(new_id);
 	if (!uploadingfile) {
 		// Can this really happen?

--- a/src/UploadDiskIOThread.cpp
+++ b/src/UploadDiskIOThread.cpp
@@ -46,12 +46,11 @@
 #include <algorithm> // Needed for std::min / std::max
 #include <zlib.h>
 
-// eMule ref: UploadDiskIOThread.cpp:43-45
 #define SLOT_COMPRESSIONCHECK_DATARATE (1024 * 150) // 150 KB/s — above this we may disable compression
 #define MAX_FINISHED_REQUESTS_COMPRESSION 15        // max queued finished reads before disabling compression
 #define BIGBUFFER_MINDATARATE (75 * 1024)           // eMule: BIGBUFFER_MINDATARATE
 
-// eMule ref: CUploadDiskIOThread::CUploadDiskIOThread() — line 49
+// eMule ref: CUploadDiskIOThread::CUploadDiskIOThread()
 CUploadDiskIOThread::CUploadDiskIOThread()
 : wxThread(wxTHREAD_JOINABLE)
 , m_condition(m_mutex)
@@ -72,7 +71,7 @@ CUploadDiskIOThread::~CUploadDiskIOThread()
 	wxASSERT(!m_bRun);
 }
 
-// eMule ref: CUploadDiskIOThread::EndThread() — line 77
+// eMule ref: CUploadDiskIOThread::EndThread()
 void CUploadDiskIOThread::EndThread()
 {
 	{
@@ -83,11 +82,10 @@ void CUploadDiskIOThread::EndThread()
 	Wait(); // join — replaces m_eventThreadEnded->Lock()
 }
 
-// eMule ref: CUploadDiskIOThread::NewBlockRequestsAvailable() — UploadDiskIOThread.h:55
-// Called by main thread when new block requests are added for a client.
-// Uses a sticky flag so the signal is not lost if the thread is between iterations
-// (not yet sleeping in WaitTimeout). Without the flag, wxCondition::Signal() is a
-// pure pulse — it is dropped if no thread is currently waiting.
+// Called by the main thread when new block requests are added for a client.
+// Uses a sticky flag so the signal is not lost when the thread is between
+// iterations: wxCondition::Signal() is a pure pulse and is dropped if no thread
+// is currently waiting.
 void CUploadDiskIOThread::NewBlockRequestsAvailable()
 {
 	wxMutexLocker lock(m_mutex);
@@ -95,8 +93,7 @@ void CUploadDiskIOThread::NewBlockRequestsAvailable()
 	m_condition.Signal();
 }
 
-// eMule ref: CUploadDiskIOThread::SocketNeedsMoreData() — UploadDiskIOThread.h:56
-// Called by throttler when it drains a socket and needs more data.
+// Called by the throttler when it drains a socket and needs more data.
 void CUploadDiskIOThread::SocketNeedsMoreData()
 {
 	wxMutexLocker lock(m_mutex);
@@ -104,14 +101,13 @@ void CUploadDiskIOThread::SocketNeedsMoreData()
 	m_condition.Signal();
 }
 
-// eMule ref: CUploadDiskIOThread::RunInternal() — line 84
+// eMule ref: CUploadDiskIOThread::RunInternal()
 void *CUploadDiskIOThread::Entry()
 {
 	m_bRun = true;
 
 	while (m_bRun) // eMule ref: line 88
 	{
-		// eMule ref: lines 92-109 — reset events, lock upload list, iterate clients
 		{
 			wxMutexLocker uploadLock(theApp->uploadqueue->GetUploadingListLock());
 			const CClientRefList &uploadList = theApp->uploadqueue->GetUploadingList();
@@ -125,9 +121,8 @@ void *CUploadDiskIOThread::Entry()
 			}
 		}
 
-		// eMule ref: lines 112-143 — drain pending IO / finished IO
-		// Simplified: reads are synchronous, so m_listPendingIO doesn't exist.
-		// All completed reads are already in m_listFinishedIO.
+		// Reads are synchronous, so there is no m_listPendingIO: every completed
+		// read is already in m_listFinishedIO.
 		while (!m_listFinishedIO.empty()) // eMule ref: line 142
 		{
 			ReadRequest_Struct *req = m_listFinishedIO.front();
@@ -135,19 +130,16 @@ void *CUploadDiskIOThread::Entry()
 			ReadCompletionRoutine(req);
 		}
 
-		// eMule ref: lines 146-149 — signal throttler if we put new data on a socket
 		if (m_bSignalThrottler && theApp->uploadBandwidthThrottler != NULL) {
 			theApp->uploadBandwidthThrottler->NewUploadDataAvailable();
 			m_bSignalThrottler = false;
 		}
 
-		// eMule ref: line 152-155 — WaitForMultipleObjects(events, 500ms)
-		// Replaced with: wxCondition::WaitTimeout(500ms) with sticky-flag check.
-		// wxCondition::Signal() is a pure pulse — it is dropped if no thread is
-		// currently blocked in WaitTimeout(). The sticky flags (m_bNewBlocksPending,
-		// m_bSocketNeedsPending) are set under m_mutex by callers, so we check them
-		// before sleeping and skip the wait if a signal arrived since last iteration.
-		// 500ms matches eMule's WaitForMultipleObjects timeout.
+		// wxCondition::WaitTimeout(500ms) in place of eMule's
+		// WaitForMultipleObjects. Signal() is a pure pulse and is dropped if no
+		// thread is blocked in WaitTimeout(), so the sticky flags
+		// (m_bNewBlocksPending, m_bSocketNeedsPending) are set under m_mutex by the
+		// callers and checked here before sleeping.
 		{
 			wxMutexLocker lock(m_mutex);
 			if (m_bRun && !m_bNewBlocksPending && !m_bSocketNeedsPending) {
@@ -158,8 +150,7 @@ void *CUploadDiskIOThread::Entry()
 		}
 	}
 
-	// Cleanup — eMule ref: lines 157-180
-	// No overlapped I/O to cancel. Just clear the open files list.
+	// Cleanup. No overlapped I/O to cancel, so just clear the open files list.
 	for (std::list<OpenFile_Struct *>::iterator it = m_listOpenFiles.begin(); it != m_listOpenFiles.end();
 		++it) {
 		delete *it;
@@ -177,26 +168,22 @@ void *CUploadDiskIOThread::Entry()
 	return NULL;
 }
 
-// eMule ref: CUploadDiskIOThread::StartCreateNextBlockPackage() — line 185
+// eMule ref: CUploadDiskIOThread::StartCreateNextBlockPackage()
 void CUploadDiskIOThread::StartCreateNextBlockPackage(CUpDownClient *client)
 {
-	// eMule ref: lines 188-189 — lock block lists
 	wxMutexLocker lockBlockLists(client->m_blockListLock);
 
-	// eMule ref: lines 192-207 — check payload buffer, early return if full
-	// eMule ref: lines 193-196 — GetQueueSessionPayloadUp() is probably outdated, so also
-	// add the value reported by the socket as sent since the last timer tick.
-	// PeekSentPayload() is non-resetting (does not consume the counter used by SendBlockData())
-	// and is protected by m_sendLocker. Calling from the disk thread is safe: we hold
-	// uploadLock (taken by Entry() before calling this function), which prevents the socket
-	// from being freed — disconnect/cleanup requires uploadLock. (eMule ref: line 187)
+	// GetQueueSessionPayloadUp() is probably outdated, so also add what the socket
+	// reports as sent since the last timer tick. PeekSentPayload() is non-resetting
+	// (it does not consume the counter SendBlockData() uses) and is protected by
+	// m_sendLocker. Calling it from the disk thread is safe: we hold uploadLock,
+	// taken by Entry() before this call, and disconnect/cleanup needs that lock.
 	sint64 nCurQueueSessionPayloadUp = client->m_nCurQueueSessionPayloadUp;
 	CClientTCPSocket *pSock = client->GetSocket();
 	if (pSock != NULL)
 		nCurQueueSessionPayloadUp += (sint64)pSock->PeekSentPayload();
 	sint64 addedPayloadQueueSession = client->m_addedPayloadQueueSession;
 
-	// eMule ref: lines 199-201
 	bool bFastUpload = client->GetUploadDatarate() > BIGBUFFER_MINDATARATE;
 	// Send-ahead depth: how many blocks this thread primes into a fast slot's async send
 	// queue (1 otherwise). This is the upload-side in-flight depth -- the mirror of the
@@ -214,14 +201,12 @@ void CUploadDiskIOThread::StartCreateNextBlockPackage(CUpDownClient *client)
 	}
 
 	try {
-		// eMule ref: lines 211-212 — buffer while below limit
 		while (!client->m_BlockRequests_queue.empty() &&
 			(addedPayloadQueueSession <= nCurQueueSessionPayloadUp ||
 				(uint32)(addedPayloadQueueSession - nCurQueueSessionPayloadUp) <
 					nBufferLimit)) {
 			Requested_Block_Struct *currentblock = client->m_BlockRequests_queue.front();
 
-			// eMule ref: lines 215-223 — check file ID switch; defer to main thread
 			if (md4cmp(currentblock->FileID, client->GetUploadFileID().GetHash()) != 0) {
 				AddDebugLogLineN(logClient,
 					"CUploadDiskIOThread::StartCreateNextBlockPackage: Switched fileid, "
@@ -229,7 +214,6 @@ void CUploadDiskIOThread::StartCreateNextBlockPackage(CUpDownClient *client)
 				return;
 			}
 
-			// eMule ref: lines 227-244 — resolve file from shared list
 			CKnownFile *srcfile =
 				theApp->sharedfiles->GetFileByID(CMD4Hash(currentblock->FileID));
 			if (srcfile == NULL) {
@@ -239,7 +223,6 @@ void CUploadDiskIOThread::StartCreateNextBlockPackage(CUpDownClient *client)
 			CPartFile *srcPartFile =
 				srcfile->IsPartFile() ? static_cast<CPartFile *>(srcfile) : NULL;
 
-			// eMule ref: lines 247-252 — validate block offsets
 			if (currentblock->EndOffset > srcfile->GetFileSize()) {
 				throw wxString(CFormat("Asked for data up to %d beyond end of file (%d)") %
 					       currentblock->EndOffset % srcfile->GetFileSize());
@@ -254,9 +237,8 @@ void CUploadDiskIOThread::StartCreateNextBlockPackage(CUpDownClient *client)
 					       (EMBLOCKSIZE * 3));
 			}
 
-			// eMule ref: lines 256-298 — find/create file struct in m_listOpenFiles
-			// In eMule this opens a HANDLE; here we track per-file metadata only.
-			// CFileArea opens the file internally as needed.
+			// In eMule this opens a HANDLE; here only per-file metadata is
+			// tracked, since CFileArea opens the file internally as needed.
 			OpenFile_Struct *pFileStruct = NULL;
 			for (std::list<OpenFile_Struct *>::iterator it = m_listOpenFiles.begin();
 				it != m_listOpenFiles.end();
@@ -275,9 +257,9 @@ void CUploadDiskIOThread::StartCreateNextBlockPackage(CUpDownClient *client)
 				m_listOpenFiles.push_back(pFileStruct);
 			}
 
-			// eMule ref: lines 301-345 — ReadFile(OVERLAPPED) → replaced with CFileArea::ReadAt()
-			// Read is synchronous on this thread; go straight to m_listFinishedIO (no pending
-			// list).
+			// CFileArea::ReadAt() in place of eMule's ReadFile(OVERLAPPED). The
+			// read is synchronous on this thread, so it goes straight to
+			// m_listFinishedIO.
 			ReadRequest_Struct *req = new ReadRequest_Struct;
 			req->pFileStruct = pFileStruct;
 			req->pClient = client;
@@ -299,19 +281,16 @@ void CUploadDiskIOThread::StartCreateNextBlockPackage(CUpDownClient *client)
 					    (uint32)togo,
 					    &handleClosed)) {
 					delete req;
-					// A closed handle means PerformFileComplete got there
-					// first: the download finished and the file is on its
-					// way to Incoming. That is not this client's fault, and
-					// throwing would set m_bIOError and have
-					// CUploadQueue::Process drop it -- undoing the graceful
-					// SuspendUpload(terminate == false) that parked it on
-					// the waiting list so it would survive the completion.
-					// Defer to the main thread, the same way the file-id
-					// switch at the top of this loop does; the client is
-					// resumed once the move is done.
+					// A closed handle means PerformFileComplete got there first:
+					// the download finished and the file is on its way to Incoming.
+					// That is not this client's fault, and throwing would set
+					// m_bIOError and have CUploadQueue::Process drop it, undoing
+					// the graceful SuspendUpload() that parked it on the waiting
+					// list to survive the completion. Defer to the main thread, as
+					// the file-id switch above does.
 					//
-					// Only for that specific failure: any other false is a
-					// real error and must still be reported as one.
+					// Only for that specific failure: any other false is a real
+					// error and must still be reported as one.
 					if (handleClosed && srcPartFile->GetStatus() == PS_COMPLETING) {
 						AddDebugLogLineN(logClient,
 							"CUploadDiskIOThread::StartCreateNextBlockPackage:"
@@ -337,14 +316,11 @@ void CUploadDiskIOThread::StartCreateNextBlockPackage(CUpDownClient *client)
 
 			pFileStruct->nInUse++;
 
-			// Set upload file ID on the client — mirrors eMule's SetUploadFileID call in the main
-			// thread path
+			// Mirrors eMule's SetUploadFileID call in the main thread path.
 			client->SetUploadFileID(srcfile);
 
-			// eMule ref: line 343 — add to m_listFinishedIO (skipping m_listPendingIO)
 			m_listFinishedIO.push_back(req);
 
-			// eMule ref: lines 347-349
 			addedPayloadQueueSession += togo;
 			client->m_addedPayloadQueueSession += togo;
 			srcfile->statistic.AddTransferred(togo);
@@ -365,7 +341,7 @@ void CUploadDiskIOThread::StartCreateNextBlockPackage(CUpDownClient *client)
 	}
 }
 
-// eMule ref: CUploadDiskIOThread::ReadCompletetionRoutine() — line 369
+// eMule ref: CUploadDiskIOThread::ReadCompletetionRoutine()
 void CUploadDiskIOThread::ReadCompletionRoutine(ReadRequest_Struct *req)
 {
 	if (req == NULL) {
@@ -375,9 +351,9 @@ void CUploadDiskIOThread::ReadCompletionRoutine(ReadRequest_Struct *req)
 
 	bool bError = false;
 
-	// eMule ref: lines 388-406 — check client is still in upload list
-	// Hold uploadLock through SendPacket to prevent the socket from being freed
-	// by a concurrent disconnect; matches eMule's design (lock scope to line 482).
+	// Check the client is still in the upload list, and hold uploadLock through
+	// SendPacket so a concurrent disconnect cannot free the socket; matches eMule's
+	// lock scope.
 	{
 		wxMutexLocker uploadLock(theApp->uploadqueue->GetUploadingListLock());
 		const CClientRefList &uploadList = theApp->uploadqueue->GetUploadingList();
@@ -397,12 +373,10 @@ void CUploadDiskIOThread::ReadCompletionRoutine(ReadRequest_Struct *req)
 			bError = true;
 		}
 
-		// eMule ref: lines 408-482 — create packets and send
 		if (!bError) {
 			CUpDownClient *client = req->pClient;
 			CClientTCPSocket *pSocket = client->GetSocket();
 
-			// eMule ref: lines 420-422 — check socket still connected
 			if (pSocket == NULL || !client->IsConnected()) {
 				AddDebugLogLineN(logClient,
 					"CUploadDiskIOThread::ReadCompletionRoutine: Client has no connected "
@@ -412,9 +386,8 @@ void CUploadDiskIOThread::ReadCompletionRoutine(ReadRequest_Struct *req)
 			}
 
 			if (!bError) {
-				// eMule ref: lines 428-447 — decide compression
-				// Disable compression if socket is starved and data rate is high.
-				// Once disabled for a client, stays disabled for the session.
+				// Disable compression if the socket is starved and the data rate is
+				// high. Once disabled for a client it stays disabled for the session.
 				bool bUseCompression = false;
 				if (!client->m_bDisableCompression && req->pFileStruct->bCompress &&
 					client->m_byDataCompVer == 1) {
@@ -432,9 +405,8 @@ void CUploadDiskIOThread::ReadCompletionRoutine(ReadRequest_Struct *req)
 					}
 				}
 
-				// eMule ref: lines 454-470 — CreateStandardPackets() or CreatePackedPackets()
-				// Build packets into a local list, then send them out.
-				// File ID was set in StartCreateNextBlockPackage when srcfile was resolved.
+				// Build packets into a local list, then send them out. The file ID was
+				// set in StartCreateNextBlockPackage when srcfile was resolved.
 				CPacketList packetList;
 				uint32 data_rate = client->GetUploadDatarate();
 				if (bUseCompression) {
@@ -453,25 +425,22 @@ void CUploadDiskIOThread::ReadCompletionRoutine(ReadRequest_Struct *req)
 						data_rate);
 				}
 
-				// eMule ref: lines 478-482 — send all packets
 				for (CPacketList::iterator it = packetList.begin(); it != packetList.end();
 					++it) {
 					theStats::AddUploadToSoft(client->GetClientSoft(), it->second);
 					pSocket->SendPacket(it->first, true, false, it->second);
 				}
 
-				// eMule ref: line 471
 				m_bSignalThrottler = true;
 			}
 		}
 	} // uploadLock released here
 
-	// eMule ref: line 493 — ReleaseOvOpenFile
 	ReleaseOpenFile(req->pFileStruct);
 	delete req;
 }
 
-// eMule ref: CUploadDiskIOThread::ReleaseOvOpenFile() — line 498
+// eMule ref: CUploadDiskIOThread::ReleaseOvOpenFile()
 bool CUploadDiskIOThread::ReleaseOpenFile(OpenFile_Struct *pFileStruct)
 {
 	for (std::list<OpenFile_Struct *>::iterator it = m_listOpenFiles.begin(); it != m_listOpenFiles.end();
@@ -479,8 +448,8 @@ bool CUploadDiskIOThread::ReleaseOpenFile(OpenFile_Struct *pFileStruct)
 		if (*it == pFileStruct) {
 			pFileStruct->nInUse--;
 			if (pFileStruct->nInUse == 0) {
-				// eMule: CloseHandle(hFile). We have no persistent handle — CFileArea already
-				// closed.
+				// eMule closes its handle here; we have no persistent one, CFileArea
+				// having already closed.
 				m_listOpenFiles.erase(it);
 				delete pFileStruct;
 			}
@@ -502,12 +471,11 @@ void CUploadDiskIOThread::CreateStandardPackets(const uint8_t *buffer,
 	uint32 togo = (uint32)(endOffset - startOffset);
 
 	CMemFile memfile(buffer, togo);
-	// Adaptive chunk size: scale with per-slot speed, floor 10 KiB, ceil EMBLOCKSIZE.
-	// /8 => ~125 ms of data per chunk; enough to saturate a TCP segment burst
-	// without making per-packet latency awful on slow peers.
-	// uploadDatarate is 0 at session start; the floor keeps behavior sane.
-	// Ceiling at EMBLOCKSIZE (180 KiB): one packet per block — no benefit
-	// in going higher since the receiver requests blocks of this size.
+	// Adaptive chunk size: scale with per-slot speed, floor 10 KiB, ceil
+	// EMBLOCKSIZE. /8 is ~125 ms of data per chunk, enough to saturate a TCP
+	// segment burst without making per-packet latency awful on slow peers, and the
+	// floor keeps it sane while uploadDatarate is still 0. Going past EMBLOCKSIZE
+	// buys nothing, since the receiver requests blocks of exactly that size.
 	const uint32 chunkSize = std::min(std::max(uploadDatarate / 8u, 10240u), (uint32)EMBLOCKSIZE);
 	uint32 nPacketSize = (togo <= chunkSize + 2600u) ? togo : chunkSize;
 
@@ -596,7 +564,6 @@ void CUploadDiskIOThread::CreatePackedPackets(const uint8_t *buffer,
 		CPacket *packet = new CPacket(
 			data, OP_EMULEPROT, (isLargeBlock ? OP_COMPRESSEDPART_I64 : OP_COMPRESSEDPART));
 
-		// approximate payload size
 		uint32 payloadSize =
 			static_cast<uint32>((static_cast<uint64>(nPacketSize) * oldSize) / newsize);
 

--- a/src/UploadQueue.cpp
+++ b/src/UploadQueue.cpp
@@ -99,16 +99,13 @@ void CUploadQueue::SortGetBestClient(CClientRef *bestClient)
 			cur_client->ClearScore();
 			continue;
 		}
-		// finished clearing
 
-		// Calculate score of current client
 		uint32 cur_score = cur_client->CalculateScore();
 		// Check if it's better than that of a previous one, and move it up then.
 		CClientRefList::iterator it1 = it2;
 		while (it1 != m_waitinglist.begin()) {
 			--it1;
 			if (cur_score > it1->GetClient()->GetScore()) {
-				// swap them
 				std::swap(*it2, *it1);
 				--it2;
 			} else {
@@ -226,7 +223,6 @@ void CUploadQueue::AddUpNextClient(CUpDownClient *directadd)
 	m_allUploadingKnownFile->AddUploadingClient(newclient);
 	theStats::AddUploadingClient();
 
-	// Statistic
 	CKnownFile *reqfile = const_cast<CKnownFile *>(newclient->GetUploadFile());
 	if (reqfile) {
 		reqfile->statistic.AddAccepted();
@@ -240,13 +236,12 @@ void CUploadQueue::Process()
 	// Check if someone's waiting, if there is a slot for him,
 	// or if we should try to free a slot for him
 	uint64 tick = GetTickCount64();
-	// Nobody waiting or upload started recently
-	// (Actually instead of "empty" it should check for "no HighID clients queued",
-	//  but the cost for that outweighs the benefit. As it is, a slot will be freed
-	//  even if it can't be taken because all of the queue is LowID. But just one,
-	//  and the kicked client will instantly get it back if he has HighID.)
-	// Also, if we are running out of sockets, don't add new clients, but also don't kick existing ones,
-	// or uploading will cease right away.
+	// Nobody waiting, or an upload started recently. (This should really check for
+	// "no HighID clients queued", but the cost outweighs the benefit: as it is, a
+	// slot is freed even when the whole queue is LowID and cannot take it -- just
+	// one, and the kicked client gets it straight back if it has HighID.) Running
+	// out of sockets stops new clients being added, but does not kick existing
+	// ones, or uploading would cease at once.
 #if EXTENDED_UPLOADQUEUE
 	if (tick - m_nLastStartUpload < 1000
 #else
@@ -289,7 +284,6 @@ void CUploadQueue::Process()
 	uint64 sentBytes = theApp->uploadBandwidthThrottler->GetNumberOfSentBytesSinceLastCallAndReset();
 	(void)theApp->uploadBandwidthThrottler->GetNumberOfSentBytesOverheadSinceLastCallAndReset();
 
-	// Update statistics
 	if (sentBytes) {
 		theStats::AddSentBytes(sentBytes);
 	}
@@ -305,11 +299,9 @@ uint32 CUploadQueue::GetMaxSlots() const
 	uint32 nMaxSlots = 0;
 	float kBpsUpPerClient = (float)thePrefs::GetSlotAllocation();
 	if (thePrefs::GetMaxUpload() == UNLIMITED) {
-		// Speed-based formula plus a floor. The raw "currentRate / slotRate + 2"
-		// is a chicken-and-egg trap: with 0 B/s observed uplink we'd cap at 2 slots,
-		// which can't carry enough parallel TCP flows to break cold-start and let
-		// the uplink ramp up. Floor at N_FLOOR slots regardless of measured rate so
-		// there is always enough concurrency for the ramp.
+		// Speed-based formula plus a floor. The raw "currentRate / slotRate + 2" is a
+		// chicken-and-egg trap: with 0 B/s observed uplink it caps at 2 slots, too
+		// few parallel TCP flows to break cold-start and let the uplink ramp up.
 		const uint32 N_FLOOR = 20;
 		float kBpsUp = theStats::GetUploadRate() / 1024.0f;
 		uint32 bySpeed = (uint32)(kBpsUp / kBpsUpPerClient) + 2;
@@ -405,7 +397,6 @@ void CUploadQueue::AddClientToQueue(CUpDownClient *client)
 	client->AddAskedCount();
 	client->SetLastUpRequest();
 
-	// Find all clients with the same user-hash
 	CClientList::SourceList found = theApp->clientlist->GetClientsByHash(client->GetUserHash());
 
 	CClientList::SourceList::iterator it = found.begin();
@@ -414,16 +405,13 @@ void CUploadQueue::AddClientToQueue(CUpDownClient *client)
 
 		if (IsOnUploadQueue(cur_client)) {
 			if (cur_client == client) {
-				// This is where LowID clients get their upload slot assigned.
-				// They can't be contacted if they reach top of the queue, so they are just
-				// marked for uploading. When they reconnect next time AddClientToQueue() is
-				// called, and they get their slot through the connection they initiated.
-				// Since at that time no slot is free they get assigned an extra slot,
-				// so then the number of slots exceeds the configured number by one.
-				// To prevent a further increase no more LowID clients get a slot, until
-				// - a HighID client has got one (which happens only after two clients
-				//   have been kicked so a slot is free again)
-				// - or there is a free slot, which means there is no HighID client on queue
+				// This is where LowID clients get their upload slot assigned. They
+				// cannot be contacted on reaching the top of the queue, so they are
+				// only marked for uploading and get their slot through the
+				// connection they initiate next time. No slot is free then, so they
+				// are assigned an extra one, taking the count one over the
+				// configured number; no further LowID client gets a slot until a
+				// HighID client has got one, or a slot really is free.
 				if (client->m_bAddNextConnect) {
 					uint32 maxSlots = GetMaxSlots();
 					if (lastupslotHighID) {
@@ -484,14 +472,11 @@ void CUploadQueue::AddClientToQueue(CUpDownClient *client)
 		}
 	}
 
-	// We do not accept more than 3 clients (currently on the upload queue) from the
-	// same IP. Only clients actually on the queue are counted (ipCount, above); we
-	// deliberately do NOT also reject based on how many clients from this IP were
-	// recently *removed* from the queue. That earlier check counted the tracked
-	// "deleted clients" list, so a client behind a shared/NAT IP that simply
-	// cancelled a few downloads got locked out of the queue for up to two hours
-	// (only cleared by a restart), even though none of those clients were still
-	// queued. Flood protection is handled separately by the aggressiveness/ban path.
+	// No more than 3 clients from the same IP may be on the upload queue. Only
+	// clients actually queued are counted: an earlier check also counted the tracked
+	// "deleted clients" list, so a client behind a shared or NAT IP that simply
+	// cancelled a few downloads was locked out for up to two hours, cleared only by
+	// a restart. Flood protection is the aggressiveness/ban path's job.
 	if (ipCount > 3) {
 		AddDebugLogLineN(logLocalClient,
 			CFormat("Rejected upload request from %s: too many clients (%d) from the same IP "
@@ -500,7 +485,6 @@ void CUploadQueue::AddClientToQueue(CUpDownClient *client)
 		return;
 	}
 
-	// statistic values
 	CKnownFile *reqfile = const_cast<CKnownFile *>(client->GetUploadFile());
 	if (reqfile) {
 		reqfile->statistic.AddRequest();
@@ -529,22 +513,18 @@ void CUploadQueue::AddClientToQueue(CUpDownClient *client)
 		AddUpNextClient(client);
 		m_nLastStartUpload = tick;
 	} else {
-		// add to waiting queue
 		m_waitinglist.push_back(
 			CCLIENTREF(client, "CUploadQueue::AddClientToQueue m_waitinglist.push_back"));
-		// and sort it to update queue ranks
 		SortGetBestClient();
 		theStats::AddWaitingClient();
 		client->ClearAskedCount();
 		client->SetUploadState(US_ONUPLOADQUEUE);
 		client->SendRankingInfo();
-		// Notify_QlistAddClient(client);
 	}
 }
 
 bool CUploadQueue::RemoveFromUploadQueue(CUpDownClient *client)
 {
-	// Keep track of this client
 	theApp->clientlist->AddTrackClient(client);
 
 	// Guard the find+erase against concurrent iteration by the disk I/O thread.
@@ -602,13 +582,11 @@ bool CUploadQueue::CheckForTimeOver(CUpDownClient *client)
 		if (vips <= GetMaxSlots() / 2) {
 			return false;
 		}
-		// Otherwise normal rules apply.
 	}
 
-	// Ordinary slots
-	// "Transfer full chunks": drop client after 10 MB upload, or after an hour.
-	// (so average UL speed should at least be 2.84 kB/s)
-	// We don't track what he is downloading, but if it's all from one chunk he gets it.
+	// Ordinary slots. "Transfer full chunks": drop a client after 10 MB uploaded or
+	// after an hour, so the average UL speed should be at least 2.84 kB/s. We do not
+	// track what it is downloading, but if it is all from one chunk it gets it.
 	if (client->GetUpStartTimeDelay() > 3600000     // time: 1h
 		|| client->GetSessionUp() > 10485760) { // data: 10MB
 		m_allowKicking = false;                 // kick max one client per cycle
@@ -643,7 +621,6 @@ uint16 CUploadQueue::SuspendUpload(const CMD4Hash &filehash, bool terminate)
 	AddLogLineN(CFormat(_("Suspending upload of file: %s")) % filehash.Encode());
 	uint16 removed = 0;
 
-	// Append the filehash to the list.
 	if (!terminate) {
 		suspendedUploadsSet.insert(filehash);
 	}
@@ -653,7 +630,6 @@ uint16 CUploadQueue::SuspendUpload(const CMD4Hash &filehash, bool terminate)
 		CUpDownClient *potential = it++->GetClient();
 		// check if the client is uploading the file we need to suspend
 		if (potential->GetUploadFileID() == filehash) {
-			// remove the unlucky client from the upload queue
 			RemoveFromUploadQueue(potential);
 			// if suspend isn't permanent add it to the waiting queue
 			if (terminate) {
@@ -700,7 +676,6 @@ void CUploadQueue::RemoveFromWaitingQueue(CClientRefList::iterator pos)
 	if (todelete->IsBanned()) {
 		todelete->UnBan();
 	}
-	// Notify_QlistRemoveClient(todelete);
 	todelete->SetUploadState(US_NONE);
 	todelete->ClearScore();
 	todelete->SetUploadQueueWaitingPosition(0);
@@ -722,7 +697,6 @@ int CUploadQueue::PopulatePossiblyWaitingList()
 	}
 	lastPopulate = tick;
 
-	// Get our downloads
 	int nrDownloads = theApp->downloadqueue->GetFileCount();
 	for (int idownload = 0; idownload < nrDownloads; idownload++) {
 		CPartFile *download = theApp->downloadqueue->GetFileByIndex(idownload);
@@ -742,7 +716,6 @@ int CUploadQueue::PopulatePossiblyWaitingList()
 			partsAvailable[i] = download->IsComplete(i);
 		}
 		for (CKnownFile::SourceSet::const_iterator it = sources.begin(); it != sources.end(); it++) {
-			// Iterate over our sources, find those where download == upload
 			CUpDownClient *client = it->GetClient();
 			if (!client || client->GetUploadFile() != download || client->HasLowID()) {
 				continue;

--- a/src/amule-gui.cpp
+++ b/src/amule-gui.cpp
@@ -97,10 +97,9 @@ wxBEGIN_EVENT_TABLE(CamuleGuiApp, wxApp)
 	// Disk space preallocation finished
 	EVT_MULE_ALLOC_FINISHED(CamuleGuiApp::OnFinishedAllocation)
 
-	// macOS Dock right-click → Quit and system session end.
-	// Normal exit paths (red X, Cmd+Q, File > Quit) go through CamuleDlg::OnClose
-	// → ShutDown → OnExit. The Dock "Quit" path on macOS skips OnClose and
-	// requires an EVT_END_SESSION handler to ensure cleanup runs.
+	// macOS Dock right-click Quit and system session end. Normal exit paths (red X,
+	// Cmd+Q, File > Quit) go through CamuleDlg::OnClose -> ShutDown -> OnExit; the
+	// Dock Quit path skips OnClose and needs EVT_END_SESSION to run the cleanup.
 	EVT_QUERY_END_SESSION(CamuleGuiApp::OnQueryEndSession)
 	EVT_END_SESSION(CamuleGuiApp::OnEndSession)
 wxEND_EVENT_TABLE()
@@ -119,10 +118,10 @@ CamuleGuiBase::CamuleGuiBase()
 	amuledlg = NULL;
 
 #ifdef GEOIP_GUI
-	// Country flag images, shared by both GUIs. Codes come from the core
-	// resolver (monolithic) or the EC tag (amulegui); this maps them to flags.
-	// The resolver's manual-update failure popup is wired later, once the
-	// core has created the resolver in OnInit (see CamuleApp::OnInit).
+	// Country flag images, shared by both GUIs. Codes come from the core resolver
+	// (monolithic) or the EC tag (amulegui); this maps them to flags. The resolver's
+	// manual-update failure popup is wired later, once the core has created the
+	// resolver in OnInit.
 	m_countryFlags = new CCountryFlags();
 #endif
 }
@@ -146,12 +145,10 @@ int CamuleGuiBase::ShowAlert(wxString msg, wxString title, int flags)
 void CamuleGuiBase::FollowSystemAppearance()
 {
 #if wxCHECK_VERSION(3, 3, 0)
-	// Every other platform follows the desktop's light/dark setting by
-	// itself; MSW is the one that has to be asked, which is why aMule looked
-	// native in dark mode on GTK and macOS but not on Windows.
-	//
-	// Not gated on __WXMSW__: Appearance::System is the right request
-	// everywhere and is a no-op where the platform already follows suit.
+	// Every other platform follows the desktop's light/dark setting by itself; MSW
+	// is the one that has to be asked, which is why aMule looked native in dark mode
+	// on GTK and macOS but not on Windows. Not gated on __WXMSW__:
+	// Appearance::System is the right request everywhere and a no-op elsewhere.
 	const wxApp::AppearanceResult appearance = wxTheApp->SetAppearance(wxApp::Appearance::System);
 	if (appearance == wxApp::AppearanceResult::Failure) {
 		AddDebugLogLineN(logStandard, "Could not follow the system light/dark appearance");
@@ -174,40 +171,31 @@ int CamuleGuiBase::InitGui(bool geometry_enabled, wxString &geom_string)
 		SetSize() function works as expected.
 		*/
 
-		// Remove possible prefix
 		if (geom_string.GetChar(0) == '=') {
 			geom_string.Remove(0, 1);
 		}
 
-		// Stupid ToLong functions forces me to use longs =(
 		long width = geometry_width;
 		long height = geometry_height;
 
-		// Get the available display area
 		wxRect display = wxGetClientDisplayRect();
 
-		// We want to place aMule inside the client area by default
 		long x = display.x;
 		long y = display.y;
 
-		// Tokenize the string
 		wxStringTokenizer tokens(geom_string, "xX+-");
 
-		// First part: Program width
 		if (tokens.GetNextToken().ToLong(&width)) {
 			wxString prefix = geom_string[tokens.GetPosition() - 1];
 			if (prefix == "x" || prefix == "X") {
-				// Second part: Program height
 				if (tokens.GetNextToken().ToLong(&height)) {
 					prefix = geom_string[tokens.GetPosition() - 1];
 					if (prefix == "+" || prefix == "-") {
-						// Third part: X-Offset
 						if (tokens.GetNextToken().ToLong(&x)) {
 							if (prefix == "-")
 								x = display.GetRight() - (width + x);
 							prefix = geom_string[tokens.GetPosition() - 1];
 							if (prefix == "+" || prefix == "-") {
-								// Fourth part: Y-Offset
 								if (tokens.GetNextToken().ToLong(&y)) {
 									if (prefix == "-")
 										y = display.GetBottom() -
@@ -229,7 +217,6 @@ int CamuleGuiBase::InitGui(bool geometry_enabled, wxString &geom_string)
 
 	ResetTitle();
 
-	// Should default/last-used position be overridden?
 	if (geometry_enabled) {
 		amuledlg = new CamuleDlg(NULL,
 			m_FrameTitle,
@@ -242,38 +229,30 @@ int CamuleGuiBase::InitGui(bool geometry_enabled, wxString &geom_string)
 	return 0;
 }
 
-// See CamuleApp::RestoreSearchTabs(). Split out of InitGui() so it can run
-// after the download queue is loaded: CSearchList::LoadSearches() computes
-// each restored result's download status against downloadqueue/knownfiles/
+// See CamuleApp::RestoreSearchTabs(). Split out of InitGui() so it can run after
+// the download queue is loaded: CSearchList::LoadSearches() computes each
+// restored result's download status against downloadqueue/knownfiles/
 // canceledfiles, and the queue is still empty while the GUI is being built
-// (#1101 -- restored results that were already downloading came back as NEW,
-// so "Hide Known Files" stopped hiding them and the daemon answered "You are
-// already trying to download the file").
+// (#1101 -- restored results that were already downloading came back as NEW).
 void CamuleGuiBase::CreateRestoredSearchTabs()
 {
 #ifndef CLIENT_GUI
-	// Create a tab for every search restored from StoredSearches.met
-	// (CSearchList::LoadSearches(), issue #641 Phase 3). Reuses the same
-	// unselected-tab path CSearchDlg::OnSearchAdded already provides for a
-	// search discovered via EC_OP_SEARCH_LIST/another client (PR #680) --
-	// a restored search is the same kind of thing, just discovered locally
-	// instead of over EC. Nothing has started a search yet at this point in
-	// startup, so every entry here is by construction a restored one.
+	// Create a tab for every search restored from StoredSearches.met. Reuses the
+	// same unselected-tab path CSearchDlg::OnSearchAdded provides for a search
+	// discovered from another client -- a restored search is the same kind of thing,
+	// discovered locally instead of over EC. Nothing has started a search yet at
+	// this point in startup, so every entry here is a restored one.
 	//
-	// Monolithic (CSearchList) only: this file is also compiled into the
-	// amuleGUI (CLIENT_GUI) target sharing CamuleGuiBase, where
-	// theApp->searchlist is CSearchListRem -- restored searches reach that
-	// build over EC_OP_SEARCH_LIST instead, once RegisterRestoredSearch()
-	// (amule.cpp) has made them visible to the registry it polls.
+	// Monolithic (CSearchList) only: this file is also compiled into the amuleGUI
+	// target, where theApp->searchlist is CSearchListRem and restored searches
+	// arrive over EC_OP_SEARCH_LIST instead.
 	for (const auto &kv : theApp->searchlist->GetKnownSearchIds()) {
 		Notify_Search_Added(static_cast<wxUIntPtr>(kv.first),
 			kv.second,
 			static_cast<uint32>(theApp->searchlist->GetSearchLifecycleKindById(kv.first)));
-		// OnSearchAdded labels the tab " (0)", right for a freshly
-		// discovered foreign search but wrong here: the restored results
-		// are already indexed (LoadSearches() ran before this call), so
-		// the tab's list is already populated -- only the label needs
-		// correcting to match.
+		// OnSearchAdded labels the tab " (0)", right for a freshly discovered
+		// foreign search but wrong here: LoadSearches() ran before this call, so the
+		// tab's list is already populated and only the label needs correcting.
 		if (theApp->amuledlg && theApp->amuledlg->m_searchwnd) {
 			if (CSearchListCtrl *page = theApp->amuledlg->m_searchwnd->GetSearchList(
 				    static_cast<wxUIntPtr>(kv.first))) {
@@ -284,7 +263,6 @@ void CamuleGuiBase::CreateRestoredSearchTabs()
 #endif
 }
 
-// Sets m_FrameTitle
 void CamuleGuiBase::ResetTitle()
 {
 #ifdef GITDATE
@@ -356,10 +334,10 @@ int CamuleGuiApp::OnExit()
 
 void CamuleGuiApp::ShutDown(wxCloseEvent &WXUNUSED(evt))
 {
-	// The tray icon's Exit runs its own menu-tracking loop and stays live
-	// while a modal dialog is open, so this can be reached with one of the
-	// list controls' dialogs still on the stack — the same hazard the remote
-	// GUI hits on an EC drop. See CamuleAppCommon::DeferShutDownToOuterLoop.
+	// The tray icon's Exit runs its own menu-tracking loop and stays live while a
+	// modal dialog is open, so this can be reached with one of the list controls'
+	// dialogs still on the stack -- the same hazard the remote GUI hits on an EC
+	// drop. See CamuleAppCommon::DeferShutDownToOuterLoop.
 	if (DeferShutDownToOuterLoop([this] {
 		    if (!IsOnShutDown() && amuledlg) {
 			    wxCloseEvent ev;
@@ -374,17 +352,14 @@ void CamuleGuiApp::ShutDown(wxCloseEvent &WXUNUSED(evt))
 	CamuleApp::ShutDown();
 }
 
-// macOS Dock right-click → Quit bypasses OnClose. wxWidgets posts a session-end
-// event for this path; drive the same ShutDown sequence so the destructor
-// chain (~CPartFile → FlushBuffer → SavePartFile) runs and download progress
-// is persisted.
+// macOS Dock right-click Quit bypasses OnClose. wx posts a session-end event for
+// this path; drive the same ShutDown sequence so the destructor chain
+// (~CPartFile -> FlushBuffer -> SavePartFile) runs and progress is persisted.
 void CamuleGuiApp::OnQueryEndSession(wxCloseEvent &evt)
 {
-	// Mark the app as quitting before letting wx propagate the close
-	// to top-level windows. CamuleDlg::OnClose checks this flag and
-	// skips its HideOnClose-veto branch when set, so a Dock right-
-	// click → Quit (or any other session-end path) actually quits
-	// instead of getting hidden to tray.
+	// Mark the app as quitting before letting wx propagate the close to top-level
+	// windows: CamuleDlg::OnClose checks this flag and skips its HideOnClose-veto
+	// branch, so a session-end path actually quits instead of hiding to tray.
 	SetQuitting();
 	evt.Skip();
 }
@@ -404,16 +379,11 @@ void CamuleGuiApp::OnEndSession(wxCloseEvent &evt)
 #ifdef __WXMAC__
 void CamuleGuiApp::MacReopenApp()
 {
-	// Fired when the user clicks the Dock icon and aMule has no
-	// visible top-level windows, and on a re-launch from Finder /
-	// Launchpad. Without this override, wxApp's default Reopen handler
-	// is a no-op when the frame is hidden, so a window hidden via the
-	// close button (HideOnClose pref = macOS-style "close hides instead
-	// of quits") stays permanently hidden — the only way to bring aMule
-	// back was to Cmd+Tab.
-	//
-	// The restore itself lives on the window, shared with the tray icon
-	// and with CamuleRemoteGuiApp's identical override.
+	// Fired when the user clicks the Dock icon with no visible top-level windows,
+	// and on a re-launch from Finder / Launchpad. Without this override wxApp's
+	// default Reopen handler is a no-op when the frame is hidden, so a window hidden
+	// via the close button (HideOnClose) stays hidden and only Cmd+Tab brings aMule
+	// back. The restore itself lives on the window, shared with the tray icon.
 	if (amuledlg) {
 		amuledlg->RestoreMainWindow();
 	}
@@ -421,14 +391,12 @@ void CamuleGuiApp::MacReopenApp()
 
 void CamuleGuiApp::MacOpenFiles(const wxArrayString &fileNames)
 {
-	// Fires for a Finder double-click, "Open With > aMule", and files
-	// dropped on the Dock icon - so most of what arrives here is not a
-	// collection at all. OpenCollectionFiles ignores those silently
-	// rather than nagging about a stray drop.
+	// Fires for a Finder double-click, "Open With > aMule", and files dropped on the
+	// Dock icon, so most of what arrives here is not a collection at all;
+	// OpenCollectionFiles ignores those silently rather than nagging.
 	//
-	// wx holds the launch event until after OnInit returns (see
-	// OSXStoreOpenFiles / wxApp::CallOnInit), so thePrefs::GetConfigDir()
-	// is set by the time this runs even on a cold launch.
+	// wx holds the launch event until after OnInit returns, so
+	// thePrefs::GetConfigDir() is set by the time this runs even on a cold launch.
 	OpenCollectionFiles(fileNames);
 }
 
@@ -455,23 +423,17 @@ bool CamuleGuiApp::OnInit()
 		return false;
 	}
 
-	// Create the Core timer
 	core_timer = new CTimer(this, ID_CORE_TIMER_EVENT);
 	if (!core_timer) {
 		AddLogLineCS(_("Fatal Error: Failed to create Core Timer"));
 		OnExit();
 	}
 
-	// Start the Core and Gui timers
-
-	// Note: wxTimer can be off by more than 10% !!!
-	// In addition to the systematic error introduced by wxTimer, we are losing
-	// timer cycles due to high CPU load.  I've observed about 0.5% random loss of cycles under
-	// low load, and more than 6% lost cycles with heavy download traffic and/or other tasks
-	// in the system, such as a video player or a VMware virtual machine.
-	// The upload queue process loop has now been rewritten to compensate for timer errors.
-	// When adding functionality, assume that the timer is only approximately correct;
-	// for measurements, always use the system clock [::GetTickCount64()].
+	// Note: wxTimer can be off by more than 10%, and timer cycles are also lost to
+	// CPU load -- about 0.5% under light load, more than 6% with heavy download
+	// traffic or another demanding process. The upload queue process loop
+	// compensates for timer error. When adding functionality assume the timer is
+	// only approximately correct, and measure with ::GetTickCount64().
 	core_timer->Start(CORE_TIMER_PERIOD);
 	amuledlg->StartGuiTimer();
 

--- a/src/amule-remote-gui.cpp
+++ b/src/amule-remote-gui.cpp
@@ -138,13 +138,11 @@ void CEConnectDlg::OnOK(wxCommandEvent &evt)
 wxDEFINE_EVENT(wxEVT_EC_INIT_DONE, wxEvent);
 
 // ----------------------------------------------------------------------
-// Reconnect-after-loss dialog (issue #444). Shown modally while amulegui
-// re-establishes a dropped EC connection: modal so the main window is
-// frozen (the user must not act on stale data or queue EC commands at a
-// dead socket), while the retry timer + socket events still pump in the
-// modal loop. The wxID_CANCEL "Abort and exit" button ends the modal
-// with wxID_CANCEL; a successful reconnect ends it with wxID_OK from
-// CamuleRemoteGuiApp::OnECConnection.
+// Reconnect-after-loss dialog. Shown modally while amulegui re-establishes a
+// dropped EC connection: modal so the main window is frozen (the user must not
+// act on stale data or queue EC commands at a dead socket), while the retry
+// timer and socket events still pump in the modal loop. The wxID_CANCEL button
+// ends the modal with wxID_CANCEL; a successful reconnect ends it with wxID_OK.
 // ----------------------------------------------------------------------
 class CReconnectDialog : public wxDialog
 {
@@ -218,28 +216,25 @@ int CamuleRemoteGuiApp::OnExit()
 
 	wxSocketBase::Shutdown(); // needed because we also called Initialize() manually
 
-	// Mirror CamuleApp::OnExit (#141): drain the pending-delete queue (where
+	// Mirror CamuleApp::OnExit: drain the pending-delete queue (where
 	// CamuleDlg::OnClose -> ShutDown parked amuledlg->Destroy()) so the frame's
 	// lazily-scheduled destructor runs, then tear down wxConfig to flush it.
 	// Otherwise the red-X + confirm path reaches here with the destroy still
-	// queued and anything that chain persists is lost (CMD+Q happens to drain
-	// naturally). The _Exit(0) below skips wx's own cleanup that normally does
-	// both, so we do it by hand here. Column widths and sort orders no longer
-	// depend on this: CMuleDataViewCtrl writes those eagerly.
+	// queued and anything that chain persists is lost. The _Exit(0) below skips
+	// wx's own cleanup that normally does both.
 	DeletePendingObjects();
 	delete wxConfigBase::Set(nullptr);
 
-	// Skip wx's static-destructor / module cleanup, exactly as the monolithic
-	// app does in CamuleGuiApp::OnExit (amule.cpp). wx's WebRequestModule
-	// teardown destroys the platform wxWebSession, whose dtor dereferences
-	// already-freed state and raise(SIGABRT)s on quit (amule-org/amule#18,
-	// PR #159). amulegui links wxWebRequest too, so it hits the identical
-	// crash. By this point our own cleanup (timer, sockets) has run; _Exit
-	// bypasses atexit + static destructors so the buggy wx dtor never runs.
-	// Remove once the upstream wx fix lands in a release we depend on.
+	// Skip wx's static-destructor / module cleanup, exactly as the monolithic app
+	// does in CamuleGuiApp::OnExit. wx's WebRequestModule teardown destroys the
+	// platform wxWebSession, whose dtor dereferences already-freed state and
+	// raise(SIGABRT)s on quit. amulegui links wxWebRequest too, so it hits the
+	// identical crash. By this point our own cleanup has run; _Exit bypasses
+	// atexit and static destructors so the buggy wx dtor never runs. Remove once
+	// the upstream wx fix lands in a release we depend on.
 	//
-	// _Exit also skips ~CamuleAppCommon, which would release the
-	// single-instance lock; drop it here so muleLockRGUI is unlinked.
+	// _Exit also skips ~CamuleAppCommon, which would release the single-instance
+	// lock; drop it here so muleLockRGUI is unlinked.
 	ReleaseSingleInstance();
 	std::_Exit(0);
 
@@ -258,8 +253,7 @@ void CamuleRemoteGuiApp::OnEndSession(wxCloseEvent &evt)
 {
 	// The Dock-Quit path can bypass OnExit, so run ShutDown (unless OnClose
 	// already did -- it nulls amuledlg) and then OnExit explicitly, so the
-	// list-control destructors + wxConfig flush run and column widths / sort
-	// orders persist. Mirrors CamuleGuiApp::OnEndSession (amule-gui.cpp).
+	// list-control destructors and wxConfig flush run and column widths persist.
 	if (amuledlg) {
 		ShutDown(evt);
 	}
@@ -270,11 +264,10 @@ void CamuleRemoteGuiApp::OnEndSession(wxCloseEvent &evt)
 #ifdef __WXMAC__
 void CamuleRemoteGuiApp::MacReopenApp()
 {
-	// Dock-icon click (and re-launch from Finder / Launchpad) while no
-	// window is visible. wxApp's default handler only de-iconizes; a frame
-	// hidden with Show(false) -- the close-button HideOnClose path and the
-	// minimize-to-tray path both end there -- is not a candidate, so
-	// without this amulegui simply never came back. Mirrors CamuleGuiApp.
+	// Dock-icon click (and re-launch from Finder / Launchpad) while no window is
+	// visible. wxApp's default handler only de-iconizes; a frame hidden with
+	// Show(false) -- both the close-button HideOnClose path and minimize-to-tray
+	// end there -- is not a candidate, so without this amulegui never came back.
 	if (amuledlg) {
 		amuledlg->RestoreMainWindow();
 	}
@@ -294,11 +287,9 @@ void CamuleRemoteGuiApp::MacOpenURL(const wxString &url)
 #endif
 
 #if wxUSE_ON_FATAL_EXCEPTION
-// Gracefully handle fatal exceptions and print backtrace if possible.
-// Mirrors CamuleApp::OnFatalException (amule.cpp) -- without this
-// override amulegui crashes produce no symbolicated amule frames,
-// which makes diagnosing GTK-callback-into-stale-widget bugs like
-// #692 a guessing game.
+// Gracefully handle fatal exceptions and print a backtrace if possible. Without
+// this override amulegui crashes produce no symbolicated amule frames, which
+// makes diagnosing GTK-callback-into-stale-widget bugs a guessing game.
 void CamuleRemoteGuiApp::OnFatalException()
 {
 	/* Print the backtrace */
@@ -323,9 +314,9 @@ void CamuleRemoteGuiApp::OnFatalException()
 void CamuleRemoteGuiApp::OnAssertFailure(
 	const wxChar *file, int line, const wxChar *func, const wxChar *cond, const wxChar *msg)
 {
-	// Unlike CamuleApp there is no app-state gate here: the remote GUI has
-	// no equivalent of IsRunning(), and its window is either up or the
-	// assert came from a thread that cannot show a dialog anyway.
+	// Unlike CamuleApp there is no app-state gate here: the remote GUI has no
+	// equivalent of IsRunning(), and its window is either up or the assert came
+	// from a thread that cannot show a dialog anyway.
 	if (ReportAssertFailure(file, line, func, cond, msg, wxThread::IsMain())) {
 		wxApp::OnAssertFailure(file, line, func, cond, msg);
 	}
@@ -335,28 +326,23 @@ void CamuleRemoteGuiApp::OnPollTimer(wxTimerEvent &)
 {
 	static int request_step = 0;
 
-	// Reply watchdog. EC has no application-level keepalive, and the daemon
-	// always answers, so requests outstanding with nothing coming back means
-	// the transport has gone quiet -- an SSH tunnel with no ServerAliveInterval,
-	// a NAT dropping an idle mapping, a proxy that stopped relaying. None of
-	// those close the socket: it stays ESTABLISHED with every queue empty and
-	// no error is ever raised, so neither OnLost nor OnError fires.
+	// Reply watchdog. EC has no application-level keepalive, and the daemon always
+	// answers, so requests outstanding with nothing coming back means the
+	// transport has gone quiet -- an SSH tunnel with no ServerAliveInterval, a
+	// NAT dropping an idle mapping, a proxy that stopped relaying. None of those
+	// close the socket: it stays ESTABLISHED with every queue empty and no error
+	// is raised, so neither OnLost nor OnError fires.
 	//
 	// Without this the failure is permanent AND silent. Once m_req_count passes
 	// m_req_fifo_thr the early-return below fires on every tick, so the client
 	// stops sending too -- and recovery would need a reply, which needs a
-	// request. The back-pressure brake becomes a deadlock the client can never
-	// leave, with a frozen UI and no message.
-	//
-	// Gated on the fifo rather than on the threshold so it trips on the real
-	// symptom (nothing answering) rather than waiting for the queue to fill.
+	// request. Gated on the fifo rather than on the threshold so it trips on the
+	// real symptom rather than waiting for the queue to fill.
 	if (m_connect->GetReqFifoSize() > 0 &&
 		m_connect->MillisecondsSinceLastReply() > EC_REPLY_TIMEOUT_MS) {
 		// Untranslated and debug-level on purpose: the user-facing messaging
-		// already comes from the path this drops into -- OnLost posts
-		// "Connection failure" and BeginReconnect announces the retry, both
-		// long since translated. Adding a new msgid here would have bought
-		// translators work for something nobody but a developer reads.
+		// already comes from the path this drops into -- OnLost posts "Connection
+		// failure" and BeginReconnect announces the retry, both long translated.
 		AddDebugLogLineN(logEC,
 			CFormat(wxT("EC reply watchdog: no reply for %u ms with %u requests "
 				    "pending -- treating the connection as dead")) %
@@ -384,13 +370,10 @@ void CamuleRemoteGuiApp::OnPollTimer(wxTimerEvent &)
 			amuledlg->m_serverwnd->IsShown()) {
 			// update downloads, shared files and servers
 			knownfiles->DoRequery(EC_OP_GET_UPDATE, EC_TAG_KNOWNFILE);
-			// Server-message log mirror: pull the cumulative
-			// server_msg buffer while the Network tab is up so the
-			// "Server Info" sub-panel reaches feature parity with
-			// the monolithic build. ed2k server messages are bursty
-			// (one-off on connect, the occasional ID-change notice,
-			// disconnect) so the natural cadence of the page step is
-			// plenty.
+			// Server-message log mirror: pull the cumulative server_msg buffer
+			// while the Network tab is up so the "Server Info" sub-panel reaches
+			// parity with the monolithic build. ed2k server messages are bursty, so
+			// the natural cadence of the page step is plenty.
 			if (amuledlg->m_serverwnd->IsShown()) {
 				CECPacket srvinfo_req(EC_OP_GET_SERVERINFO);
 				m_connect->SendRequest(&m_serverinfo_handler, &srvinfo_req);
@@ -399,69 +382,52 @@ void CamuleRemoteGuiApp::OnPollTimer(wxTimerEvent &)
 			// update both downloads and shared files
 			knownfiles->DoRequery(EC_OP_GET_UPDATE, EC_TAG_KNOWNFILE);
 		} else if (amuledlg->m_clientswnd->IsShown()) {
-			// Same request, for the peers rather than the files: the
-			// EC_TAG_CLIENT tags the clients list lives on ride along
-			// in this reply (CKnownFilesRem::ProcessUpdate) and are
-			// sent by nothing else. Without this the page shows
-			// whatever the peers looked like when the user left the
-			// last tab that did ask, and never moves again.
+			// Same request, for the peers rather than the files: the EC_TAG_CLIENT
+			// tags the clients list lives on ride along in this reply and are sent by
+			// nothing else. Without this the page shows whatever the peers looked
+			// like when the user left the last tab that did ask.
 			knownfiles->DoRequery(EC_OP_GET_UPDATE, EC_TAG_KNOWNFILE);
 		} else if (amuledlg->m_searchwnd->IsShown()) {
-			// Reachability fix (#641): ask what searches the daemon
-			// currently holds -- independent of m_curr_search, which only
-			// ever reflects a search THIS client itself started -- so a
-			// search opened by another client, or one day restored from
-			// disk, gets a tab created here (CSearchListRem::HandlePacket).
-			// Search entries are near-static (id/name/kind barely change),
-			// so unlike the results union poll below this isn't asked every
-			// tick: once on (re)connect, and again only when a result turns
-			// up bearing a search ID with no tab yet (CreateItem sets
-			// m_needSearchListRequery) -- the daemon-side registry this
-			// reads never changes without a result also arriving for it.
-			// RequestSearchList (not DoRequery) on purpose: HandlePacket's
+			// Ask what searches the daemon currently holds -- independent of
+			// m_curr_search, which only ever reflects a search THIS client started --
+			// so a search opened by another client gets a tab created here.
+			//
+			// Search entries are near-static, so unlike the results union poll below
+			// this is not asked every tick: once on (re)connect, and again only when
+			// a result turns up bearing a search ID with no tab yet.
+			//
+			// RequestSearchList, not DoRequery, on purpose: HandlePacket's
 			// EC_OP_SEARCH_LIST branch never reaches the base class's
-			// STATUS_REQ_SENT -> IDLE transition, so going through
-			// DoRequery would wedge this container's request state machine
-			// forever and silently drop every later EC_OP_SEARCH_RESULTS
-			// poll (got3nks, PR #680 review).
+			// STATUS_REQ_SENT -> IDLE transition, so DoRequery would wedge this
+			// container's request state machine and silently drop every later poll.
 			if (searchlist->m_needSearchListRequery) {
 				searchlist->RequestSearchList();
 				searchlist->m_needSearchListRequery = false;
 			}
-			// The union poll below already returns every active search's
-			// results regardless of m_curr_search (Get_EC_Response_Search_
-			// Results_Union iterates the daemon's own registry) -- the old
-			// m_curr_search-only gate just meant a client that never
-			// started a search of its own never asked at all, even once a
-			// tab existed for one it learned about above.
+			// The union poll below already returns every active search's results
+			// regardless of m_curr_search -- the old gate just meant a client that
+			// never started a search of its own never asked at all, even once a tab
+			// existed for one it learned about above.
 			searchlist->DoRequery(EC_OP_SEARCH_RESULTS, EC_TAG_SEARCHFILE);
 		}
-		// Stats polling is always on, even when the Statistics dialog
-		// isn't the active tab. statgraphs->HandlePacket() also feeds
-		// the Kad node-count graph on the Network -> Kad sub-tab via
-		// m_kademliawnd->UpdateGraph(); gating on m_statisticswnd left
-		// the Kad graph empty whenever the user wasn't sitting on
-		// Statistics, and produced a visible gap in the Statistics
-		// graph itself across any tab switch. Both requests are cheap
-		// deltas: the graph sends m_lastTimestamp and the daemon
-		// returns only points newer than that (or EC_OP_FAILED "No
-		// points for graph."); the tree request honors
-		// thePrefs::GetStatsInterval().
+		// Stats polling is always on, even when the Statistics dialog is not the
+		// active tab. statgraphs->HandlePacket() also feeds the Kad node-count
+		// graph on the Network -> Kad sub-tab, so gating on m_statisticswnd left
+		// that graph empty whenever the user was elsewhere. Both requests are
+		// cheap deltas: the graph sends m_lastTimestamp and the daemon returns
+		// only newer points; the tree request honours GetStatsInterval().
 		{
 			const uint32 sStatsUpdate = thePrefs::GetStatsInterval();
 			const uint32 msCur = theStats::GetUptimeMillis();
-			// Unsigned throughout on purpose. The subtraction is modular, so
-			// it yields the true elapsed time even across the point where a
-			// 32-bit millisecond counter wraps. Casting it to int, as this
-			// did, threw that away: a difference above INT_MAX reads as
-			// negative and the comparison is false, so the tree would stop
-			// refreshing rather than refresh late.
+			// Unsigned throughout on purpose. The subtraction is modular, so it
+			// yields the true elapsed time even across the point where a 32-bit
+			// millisecond counter wraps. Casting it to int threw that away: a
+			// difference above INT_MAX reads as negative, so the tree stopped
+			// refreshing rather than refreshing late.
 			//
-			// The elapsed test also cannot be the whole condition: on the
-			// first poll of a connection nothing has elapsed, so it is false
-			// and the tree stays empty for a full interval (30 s by default)
-			// before its first fetch. m_statsTreePolled makes that first
-			// fetch unconditional; the interval governs every one after it.
+			// The elapsed test cannot be the whole condition either: on the first
+			// poll nothing has elapsed, so the tree would stay empty for a full
+			// interval. m_statsTreePolled makes that first fetch unconditional.
 			const bool dueByInterval = (msCur - m_msPrevStatsTree) > sStatsUpdate * 1000;
 			if ((sStatsUpdate > 0) && (!m_statsTreePolled || dueByInterval)) {
 				m_statsTreePolled = true;
@@ -470,14 +436,12 @@ void CamuleRemoteGuiApp::OnPollTimer(wxTimerEvent &)
 			}
 			statgraphs->DoRequery();
 		}
-		// Chat sessions + every message newer than our cursor, in one
-		// roundtrip. Poll unconditionally — like stats above, and unlike
-		// the per-tab data — so a message that arrives while the user is
-		// on another tab still triggers the new-message blink. Cheap: an
-		// idle daemon answers with the session list and no message
-		// children. Gated on the capability; a daemon that never echoes
-		// EC_TAG_CAN_CHAT does not know these opcodes, and sending one
-		// asserts on the daemon before it can answer EC_OP_FAILED.
+		// Chat sessions plus every message newer than our cursor, in one
+		// roundtrip. Polled unconditionally -- like stats above, unlike the
+		// per-tab data -- so a message arriving while the user is on another tab
+		// still triggers the new-message blink; an idle daemon answers with the
+		// session list and no message children. Gated on the capability: a daemon
+		// that never echoes EC_TAG_CAN_CHAT asserts on these opcodes.
 		if (m_connect->ServerSupportsChatSessions()) {
 			CECPacket chat_req(EC_OP_GET_CHAT_SESSIONS);
 			if (m_chatmsg_handler.Cursor()) {
@@ -504,17 +468,16 @@ void CamuleRemoteGuiApp::OnPollTimer(wxTimerEvent &)
 
 void CamuleRemoteGuiApp::OnFinishedHTTPDownload(CMuleInternalEvent &WXUNUSED(event))
 {
-	// amulegui has no local GeoIP resolver — country codes arrive over EC from
-	// the daemon (#439 / #440) — so it never starts a GeoIP download and there
-	// is nothing to finish here.
+	// amulegui has no local GeoIP resolver -- country codes arrive over EC from
+	// the daemon -- so it never starts a GeoIP download.
 }
 
 void CamuleRemoteGuiApp::ShutDown(wxCloseEvent &WXUNUSED(evt))
 {
 	// A modal dialog (comments/ratings, file details, ...) runs its own event
-	// loop, and an EC drop is dispatched from whichever loop is current — so a
-	// shutdown can start with one of those dialogs still on the stack. Unwind
-	// to the outer loop first; Quit() resumes the teardown from there.
+	// loop, and an EC drop is dispatched from whichever loop is current -- so a
+	// shutdown can start with one of those dialogs still on the stack. Unwind to
+	// the outer loop first; Quit() resumes the teardown from there.
 	if (DeferShutDownToOuterLoop([this] { Quit(); })) {
 		return;
 	}
@@ -567,30 +530,23 @@ bool CamuleRemoteGuiApp::OnInit()
 	StartTickTimer();
 	amuledlg = NULL;
 	connect_timeout_timer = NULL;
-	// ShutDown() unconditionally deletes these, but Startup() — where they
-	// are allocated — only runs after a successful EC connect. Null them so
-	// a connect-timeout teardown doesn't delete an indeterminate pointer.
+	// ShutDown() unconditionally deletes these, but Startup() -- where they are
+	// allocated -- only runs after a successful EC connect. Null them so a
+	// connect-timeout teardown does not delete an indeterminate pointer.
 	stattree = NULL;
 	m_allUploadingKnownFile = NULL;
 
 #if defined(__WXGTK__) && !defined(__APPLE__)
-	// Set the GTK program name to the canonical app id. On Wayland,
-	// GTK derives wl_app_id (xdg_toplevel.set_app_id) from
-	// g_get_prgname(); compositors match wl_app_id against the
-	// .desktop filename to bind windows to launcher icons. Without
-	// this the binding falls back to argv[0], which differs across
-	// packaging formats (AppImage's argv[0] is "aMuleGUI", distro
-	// installs use "amulegui", Flatpak renames the .desktop entirely).
-	// On X11 the same value also feeds into WM_CLASS, matching
-	// StartupWMClass=org.amule.aMule.gui in the .desktop file. Must run
-	// before any GTK window is created — same fix the monolithic amule
-	// has in CamuleApp::OnInit; amulegui shipped without it, so on
-	// GNOME / wlroots the taskbar icon never bound to the launcher
-	// and showed the generic fallback. (#562 follow-up.)
-	// Skipped on macOS even under wxGTK (MacPorts): no Wayland or
-	// .desktop binding exists, and app identity is set via Info.plist
-	// in the .app bundle. Dropping the call lets that build skip the
-	// glib2 dep entirely (#641).
+	// Set the GTK program name to the canonical app id. On Wayland, GTK derives
+	// wl_app_id from g_get_prgname(), and compositors match wl_app_id against
+	// the .desktop filename to bind windows to launcher icons. Without this the
+	// binding falls back to argv[0], which differs across packaging formats. On
+	// X11 the same value feeds WM_CLASS, matching StartupWMClass in the
+	// .desktop file. Must run before any GTK window is created.
+	//
+	// Skipped on macOS even under wxGTK: no Wayland or .desktop binding exists,
+	// and app identity is set via Info.plist. Dropping the call lets that build
+	// skip the glib2 dependency entirely.
 	g_set_prgname("org.amule.aMule.gui");
 #endif
 
@@ -599,9 +555,9 @@ bool CamuleRemoteGuiApp::OnInit()
 	// the providers down at app exit.
 	wxArtProvider::Push(new CamuleArtProvider());
 
-	// Must happen before any window exists; the connect dialog below is the
-	// first one amulegui creates. Without this amulegui stayed light on
-	// Windows while the monolithic amule, which has always asked, went dark.
+	// Must happen before any window exists; the connect dialog below is the first
+	// one amulegui creates. Without this amulegui stayed light on Windows while
+	// the monolithic amule, which has always asked, went dark.
 	FollowSystemAppearance();
 
 	// Get theApp
@@ -634,12 +590,12 @@ bool CamuleRemoteGuiApp::OnInit()
 	wxConfig::Get()->Read("/EC/ZLIB", &enableZLIB, 1);
 	m_connect->SetCapabilities(enableZLIB != 0, true, false); // ZLIB, UTF8 numbers, notification
 	// amulegui addresses searches by daemon-allocated ID (per-tab, several at
-	// once); advertise the multi-search capability. An old daemon won't echo
-	// it and amulegui stays single-search (ServerSupportsMultiSearch()).
+	// once); advertise the multi-search capability. An old daemon will not echo
+	// it and amulegui stays single-search.
 	m_connect->SetCanMultiSearch(true);
-	// amulegui shows incoming friend/chat messages read-only; ask the daemon
-	// to relay them (polled via EC_OP_GET_CHAT_MESSAGES). An old daemon won't
-	// echo the capability and amulegui simply never polls (ServerSupportsChatSessions()).
+	// amulegui shows incoming friend/chat messages read-only; ask the daemon to
+	// relay them. An old daemon will not echo the capability and amulegui simply
+	// never polls.
 	m_connect->SetCanChatSessions(true);
 	// The ForceZLIB override is read from the connection dialog
 	// (see ShowConnectionDialog) so the user's checkbox choice in this
@@ -649,19 +605,16 @@ bool CamuleRemoteGuiApp::OnInit()
 	InitLocale(m_locale, StrLang2wx(thePrefs::GetLanguageID()));
 
 	if (ShowConnectionDialog()) {
-		// The watchdog timer is armed inside ShowConnectionDialog right
-		// before each ConnectToCore call — the retry loop re-arms it on
-		// every attempt, so OnInit doesn't need to touch it here.
+		// The watchdog timer is armed inside ShowConnectionDialog right before
+		// each ConnectToCore call -- the retry loop re-arms it on every attempt.
 		AddLogLineNS(_("Going to event loop..."));
 		return true;
 	}
 
-	// User cancelled (or ShowConnectionDialog failed before reaching the
-	// connect step). Tear down the partial init so the Asio thread pool,
-	// poll timer and remote-connect socket don't leak — wx will never
-	// call ShutDown() / OnExit() because the main loop isn't entered when
-	// OnInit() returns false, so we have to unwind manually here. Without
-	// this, wx reports "4 threads were not terminated by the application".
+	// User cancelled, or ShowConnectionDialog failed before reaching the connect
+	// step. Tear down the partial init so the Asio thread pool, poll timer and
+	// remote-connect socket do not leak: wx never calls ShutDown() / OnExit()
+	// because the main loop is not entered when OnInit() returns false.
 	if (m_AsioService) {
 		m_AsioService->Stop();
 		delete m_AsioService;
@@ -685,11 +638,9 @@ bool CamuleRemoteGuiApp::CryptoAvailable() const
 
 bool CamuleRemoteGuiApp::ShowConnectionDialog()
 {
-	// The dialog is kept alive across retry attempts so the values the
-	// user typed (host / port / password / Force-ZLIB) survive a wrong
-	// guess — they only need to fix the field that was wrong instead of
-	// re-typing everything. Destroyed in Startup() on success or below
-	// when the user cancels.
+	// The dialog is kept alive across retry attempts so the values the user typed
+	// survive a wrong guess -- they only need to fix the field that was wrong.
+	// Destroyed in Startup() on success, or below when the user cancels.
 	if (!dialog) {
 		dialog = new CEConnectDlg;
 	}
@@ -708,22 +659,19 @@ bool CamuleRemoteGuiApp::ShowConnectionDialog()
 		}
 
 		AddLogLineNS(_("Connecting..."));
-		// Watchdog on the EC connect. When the host is unreachable the
-		// TCP SYN can silently time out over several minutes while the
-		// main loop is running with no visible window, which the OS
-		// reports as "not responding". Fire a shorter timeout so we
-		// can show an error and re-prompt instead. Re-armed on every
-		// retry attempt so the user gets the same 15s budget each time.
+		// Watchdog on the EC connect. When the host is unreachable the TCP SYN can
+		// silently time out over several minutes while the main loop runs with no
+		// visible window, which the OS reports as "not responding". Fire a shorter
+		// timeout instead, re-armed on every retry so each gets the same budget.
 		delete connect_timeout_timer;
 		connect_timeout_timer = new wxTimer(this, ID_REMOTE_CONNECT_TIMEOUT_TIMER);
 		connect_timeout_timer->StartOnce(15000);
 
 		// Apply the dialog's checkbox states to the EC client before each
-		// ConnectToCore attempt (re-applied per retry so the user can
-		// toggle them between attempts if they need to). ResetEcConnect()
-		// recreates m_connect on a failed handshake and deliberately does
-		// not re-apply these two: the dialog owns them and sets them again
-		// on the fresh object right here.
+		// ConnectToCore attempt, re-applied per retry so the user can toggle them
+		// between attempts. ResetEcConnect() recreates m_connect on a failed
+		// handshake and deliberately does not re-apply these two: the dialog owns
+		// them and sets them again on the fresh object right here.
 		m_connect->SetForceZlib(dialog->ForceZlib());
 		m_connect->SetCanAEAD(dialog->Encryption());
 		if (m_connect->ConnectToCore(
@@ -733,10 +681,9 @@ bool CamuleRemoteGuiApp::ShowConnectionDialog()
 			return true;
 		}
 
-		// Sync failure (DNS / immediate connect-refused). The async
-		// path won't fire — cancel the watchdog ourselves, show the
-		// error, recreate the EC client so its half-baked socket
-		// state is gone, and loop back to the dialog.
+		// Sync failure (DNS / immediate connect-refused). The async path will not
+		// fire -- cancel the watchdog ourselves, show the error, recreate the EC
+		// client so its half-baked socket state is gone, and loop back.
 		connect_timeout_timer->Stop();
 		delete connect_timeout_timer;
 		connect_timeout_timer = NULL;
@@ -749,12 +696,11 @@ bool CamuleRemoteGuiApp::ShowConnectionDialog()
 
 void CamuleRemoteGuiApp::ResetEcConnect()
 {
-	// Tear down the busted EC client and recreate a fresh one. The
-	// CRemoteConnect's socket / auth state isn't safe to reuse after
-	// a failed handshake. glob_prefs holds a reference to m_connect
-	// so it's reborn alongside. Both objects are only fully wired
-	// into the rest of the app by Startup(), which doesn't run until
-	// a successful connect — recreating them here is safe.
+	// Tear down the busted EC client and recreate a fresh one: the
+	// CRemoteConnect's socket / auth state is not safe to reuse after a failed
+	// handshake. glob_prefs holds a reference to m_connect so it is reborn
+	// alongside. Both are only fully wired in by Startup(), which does not run
+	// until a successful connect, so recreating them here is safe.
 	delete glob_prefs;
 	glob_prefs = NULL;
 	if (m_connect) {
@@ -804,13 +750,10 @@ void CamuleRemoteGuiApp::OnECConnection(wxEvent &event)
 		// dialog stays up with the attempt count and an Abort button.
 		ScheduleNextReconnect();
 	} else if (dialog) {
-		// Connect failed during the initial attempt or a previous
-		// retry (dialog is still alive — it's only destroyed in
-		// Startup() after a successful connect). Show the error,
-		// reset the EC client, and reopen the dialog with the
-		// previous values still in place so the user can fix the
-		// wrong field and try again. If the user cancels the retry,
-		// then we shut down.
+		// Connect failed during the initial attempt or a previous retry -- the
+		// dialog is still alive, it is only destroyed in Startup() after success.
+		// Show the error, reset the EC client, and reopen the dialog with the
+		// previous values in place. If the user cancels the retry, shut down.
 		wxMessageBox((CFormat(_("Connection Failed. Unable to connect to %s:%d\n")) % dialog->Host() %
 				     dialog->Port()) +
 				     reply,
@@ -822,9 +765,9 @@ void CamuleRemoteGuiApp::OnECConnection(wxEvent &event)
 			Quit();
 		}
 	} else {
-		// Connection lost after startup (e.g. the machine slept and the
-		// EC socket dropped). Don't quit — freeze the UI and reconnect in
-		// the background until we're back or the user aborts (issue #444).
+		// Connection lost after startup (the machine slept and the EC socket
+		// dropped, say). Do not quit -- freeze the UI and reconnect in the
+		// background until we are back or the user aborts.
 		BeginReconnect();
 	}
 }
@@ -835,9 +778,9 @@ void CamuleRemoteGuiApp::OnConnectTimeout(wxTimerEvent &)
 	connect_timeout_timer = NULL;
 
 	if (m_reconnecting) {
-		// This reconnect attempt hung (host unreachable, SYN black-holed).
-		// Treat it as a failed attempt and space out the next one; the
-		// modal reconnect dialog stays up with its Abort button (#444).
+		// This reconnect attempt hung (host unreachable, SYN black-holed). Treat it
+		// as a failed attempt and space out the next one; the modal reconnect
+		// dialog stays up with its Abort button.
 		AddLogLineCS(_("Reconnect attempt timed out; retrying."));
 		ScheduleNextReconnect();
 		return;
@@ -890,19 +833,17 @@ void CamuleRemoteGuiApp::BeginReconnect()
 	AttemptReconnect();
 
 	// The dialog earns its intrusion by explaining a frozen window. With the
-	// window minimised or hidden to tray there is nothing on screen to
-	// explain, and a modal appearing over whatever the user is actually doing
-	// is worse than silence (issue #806). Retry quietly instead; the log still
-	// carries every attempt, and OnMainWindowRestored() puts the dialog up if
-	// the user comes back while this is still going.
+	// window minimised or hidden to tray there is nothing on screen to explain,
+	// and a modal appearing over whatever the user is actually doing is worse
+	// than silence. Retry quietly instead; the log still carries every attempt,
+	// and OnMainWindowRestored() puts the dialog up if the user comes back.
 	//
 	// "Visible" has to mean both halves: minimized to Dock/taskbar keeps
 	// IsShown() true with nothing on screen, and hidden to tray leaves the
-	// iconized bit clear while the frame is gone. CamuleDlg tracks the
-	// iconized half from wxIconizeEvent rather than wxFrame::IsIconized(),
-	// which lies on wxGTK mid-transition. Compositors that never report
-	// iconize at all (Wayland xdg-shell has no such notification) keep the
-	// old behaviour for the minimize case.
+	// iconized bit clear while the frame is gone. CamuleDlg tracks the iconized
+	// half from wxIconizeEvent rather than wxFrame::IsIconized(), which lies on
+	// wxGTK mid-transition. Compositors that never report iconize at all keep
+	// the old behaviour for the minimize case.
 	if (amuledlg && !amuledlg->IsVisibleToUser()) {
 		return;
 	}
@@ -917,18 +858,17 @@ void CamuleRemoteGuiApp::ShowReconnectDialog()
 	}
 
 	m_reconnectDlg = new CReconnectDialog(amuledlg, CFormat(wxT("%s:%d")) % m_ecHost % m_ecPort);
-	// The retry loop has been running without us, so open on what it is
-	// actually doing rather than on "attempt 1": mid-countdown after a failed
-	// attempt, or in the middle of one.
+	// The retry loop has been running without us, so open on what it is actually
+	// doing rather than on "attempt 1": mid-countdown after a failed attempt, or
+	// in the middle of one.
 	if (m_reconnectCountdown > 0) {
 		m_reconnectDlg->SetCountdown(m_reconnectCountdown);
 	} else {
 		m_reconnectDlg->SetAttempt(m_reconnectAttempt);
 	}
 
-	// Run it modally: the retry timer and OnECConnection pump inside
-	// ShowModal(). A success calls EndModal(wxID_OK); the Abort button ends it
-	// with wxID_CANCEL.
+	// Run it modally: the retry timer and OnECConnection pump inside ShowModal().
+	// A success calls EndModal(wxID_OK); the Abort button ends it with wxID_CANCEL.
 	const int result = m_reconnectDlg->ShowModal();
 	m_reconnectDlg->Destroy();
 	m_reconnectDlg = nullptr;
@@ -972,20 +912,17 @@ void CamuleRemoteGuiApp::FinishReconnect(int result)
 		// the version rather than leaving the pre-drop one on screen.
 		UpdateCoreVersionIndicator();
 
-		// Everything we hold is keyed by ECID, and an ECID only means
-		// something within one daemon process: CECID hands them out from a
-		// counter that restarts with the process, so a restarted daemon
-		// reissues the same numbers in whatever order it loads files this
-		// time. Reconciling in place across that pairs our objects with
-		// whatever now happens to share their number.
+		// Everything we hold is keyed by ECID, and an ECID only means something
+		// within one daemon process: CECID hands them out from a counter that
+		// restarts with the process, so a restarted daemon reissues the same
+		// numbers in whatever order it loads files this time. Reconciling in place
+		// across that pairs our objects with whatever now shares their number.
 		//
-		// EC_TAG_SESSION_ID says which process we're talking to. Same value
-		// means the socket dropped but the daemon lived (a sleeping laptop,
-		// a dead tunnel), so the in-place reconcile below is right and keeps
-		// scroll and selection. Anything else -- a different value, or none
-		// at all because the daemon predates the tag -- means we cannot
-		// trust a single ID we hold, and starting over is the only correct
-		// answer even though it costs the user their scroll position.
+		// EC_TAG_SESSION_ID says which process we are talking to. The same value
+		// means the socket dropped but the daemon lived, so the in-place reconcile
+		// below is right and keeps scroll and selection. Anything else -- a
+		// different value, or none at all -- means we cannot trust a single ID we
+		// hold, and starting over is the only correct answer.
 		const uint64 sessionId = m_connect ? m_connect->GetServerSessionId() : 0;
 		const bool sameSession = sessionId != 0 && sessionId == m_ecSessionId;
 		m_ecSessionId = sessionId;
@@ -1005,21 +942,16 @@ void CamuleRemoteGuiApp::FinishReconnect(int result)
 				friendlist->ResetForNewSession();
 			}
 			if (searchlist) {
-				// Searches survive a restart -- amuled persists them and
-				// re-registers each restored one, so the daemon hands the
-				// same results back under their original search ids. What
-				// does NOT survive is the per-result ECID: the counter
-				// restarts with the process, so every restored result
-				// arrives as an id this client has never seen and is added
+				// Searches survive a restart -- amuled persists them and re-registers
+				// each restored one, so the daemon hands the same results back under
+				// their original search ids. What does NOT survive is the per-result
+				// ECID: the counter restarts with the process, so every restored
+				// result arrives as an id this client has never seen and is added
 				// alongside the copy it already holds.
 				//
-				// Nothing reaps the stale copy on its own. The search list
-				// deletes only on an explicit EC_TAG_FILE_REMOVED tombstone
-				// (it opted out of the base class's absence sweep so an idle
-				// search costs no traffic), and a daemon that has just
-				// started never emits a tombstone for an ECID it never knew
-				// about. Both copies therefore stay -- issue #1101, where
-				// every result appears twice after a restart.
+				// Nothing reaps the stale copy on its own: the search list deletes only
+				// on an explicit EC_TAG_FILE_REMOVED tombstone, and a daemon that has
+				// just started never emits one for an ECID it never knew about.
 				searchlist->ResetForNewSession();
 				if (amuledlg && amuledlg->m_searchwnd) {
 					// Frees every result, so the tabs must drop their rows
@@ -1028,14 +960,13 @@ void CamuleRemoteGuiApp::FinishReconnect(int result)
 				}
 			}
 		} else if (knownfiles) {
-			// Same daemon: the next full poll reconciles every list against
-			// the fresh snapshot in place (update / add / prune) — no wipe,
-			// so scroll and selection survive.
+			// Same daemon: the next full poll reconciles every list against the fresh
+			// snapshot in place (update / add / prune), so scroll and selection survive.
 			knownfiles->ArmReconnectReconcile();
 		}
-		// The tree on screen belongs to the connection that just ended;
-		// fetch a fresh one on the next poll rather than after an interval
-		// measured against the old one.
+		// The tree on screen belongs to the connection that just ended; fetch a
+		// fresh one on the next poll rather than after an interval measured
+		// against the old one.
 		ResetStatsTreePoll();
 		if (poll_timer) {
 			poll_timer->Start(EC_POLL_INTERVAL_MS);
@@ -1056,9 +987,9 @@ void CamuleRemoteGuiApp::OnMainWindowRestored()
 		return;
 	}
 	// Not straight from here: this runs inside the iconize event handler, and
-	// ShowReconnectDialog() ends in either a nested modal loop or Quit(). Let
-	// the handler return first (#738 is what tearing the main window down from
-	// a nested loop costs).
+	// ShowReconnectDialog() ends in either a nested modal loop or Quit(). Let the
+	// handler return first -- tearing the main window down from a nested loop is
+	// what a crash there costs.
 	CallAfter(&CamuleRemoteGuiApp::ShowReconnectDialog);
 }
 
@@ -1073,28 +1004,26 @@ void CamuleRemoteGuiApp::AttemptReconnect()
 		     m_ecPort);
 
 	// Reset ALL layers of the reused connection: the pending-request FIFO
-	// (orphaned handlers from requests the dropped socket left unanswered
-	// would otherwise mis-pair with the new session's replies — a stats reply
-	// routed to the file-list handler wipes the download / shared lists, #444),
-	// the EC packet-reassembly state (a stale mid-packet read left over from
-	// the drop would otherwise misparse the new session's first bytes and the
-	// login would fail) and a fresh asio socket on the SAME CRemoteConnect
-	// object (keeps every remote container's m_conn pointer valid). Locally
-	// chosen capability flags persist deliberately -- SetCapabilities is not
-	// called again here, and what this end can do has not changed -- so
-	// ConnectToCore re-runs the login handshake as on first connect. Flags
-	// agreed with the previous daemon are a different matter: the next one may
-	// not support them, so they are dropped here rather than inside
-	// ResetProtocolState, which other CECSocket users share.
+	// (orphaned handlers from requests the dropped socket left unanswered would
+	// otherwise mis-pair with the new session's replies -- a stats reply routed
+	// to the file-list handler wipes the download and shared lists), the EC
+	// packet-reassembly state (a stale mid-packet read would misparse the new
+	// session's first bytes and the login would fail), and a fresh asio socket
+	// on the SAME CRemoteConnect object, which keeps every remote container's
+	// m_conn pointer valid.
+	//
+	// Locally chosen capability flags persist deliberately -- what this end can
+	// do has not changed. Flags agreed with the previous daemon are a different
+	// matter: the next one may not support them, so they are dropped here
+	// rather than inside ResetProtocolState, which other CECSocket users share.
 	m_connect->DiscardRequestQueue();
 	m_connect->ResetProtocolState();
 	m_connect->ClearPeerNegotiatedFlags();
 	m_connect->ResetForReconnect();
 
 	// Per-attempt watchdog so an attempt that hangs (host unreachable, SYN
-	// black-holed) doesn't stall the retry loop; OnConnectTimeout treats a
-	// fire as a failed attempt. Cancelled by OnECConnection when the attempt
-	// resolves either way.
+	// black-holed) does not stall the retry loop; OnConnectTimeout treats a fire
+	// as a failed attempt. Cancelled by OnECConnection when it resolves.
 	delete connect_timeout_timer;
 	connect_timeout_timer = new wxTimer(this, ID_REMOTE_CONNECT_TIMEOUT_TIMER);
 	connect_timeout_timer->StartOnce(15000);
@@ -1112,8 +1041,8 @@ void CamuleRemoteGuiApp::AttemptReconnect()
 void CamuleRemoteGuiApp::ScheduleNextReconnect()
 {
 	// Drop any pending per-attempt watchdog, then count down 5 s to the next
-	// attempt via a repeating 1 s tick that updates the dialog, so the user
-	// sees when the retry will fire and an unreachable daemon isn't hammered.
+	// attempt via a repeating 1 s tick that updates the dialog, so the user sees
+	// when the retry will fire and an unreachable daemon is not hammered.
 	delete connect_timeout_timer;
 	connect_timeout_timer = nullptr;
 	m_reconnectCountdown = 5;
@@ -1152,19 +1081,16 @@ void CamuleRemoteGuiApp::OnNotifyEvent(CMuleGUIEvent &evt)
 	//
 	// DoNotify() drives what the GUI displays. Its handlers read
 	// theApp->amuledlg->m_transferwnd and friends without checking the dialog
-	// itself, so one delivered after the window is gone dereferences null
-	// (EXC_BAD_ACCESS at 0x3c0 -- m_transferwnd's offset in CamuleDlg).
-	// amulegui destroys its dialog whenever the EC link drops, a remote core
-	// restart being the everyday way that happens, and the pending-event
-	// queue is not drained first. HandleNotification() already declines to
-	// run one of these inline when there is no window; this is the same test
-	// for the queued half.
+	// itself, so one delivered after the window is gone dereferences null.
+	// amulegui destroys its dialog whenever the EC link drops -- a remote core
+	// restart being the everyday way that happens -- and the pending-event
+	// queue is not drained first. HandleNotification() already declines to run
+	// one of these inline when there is no window; this is the queued half.
 	//
-	// DoNotifyAlways() is how the socket layer reaches the main thread
-	// (CoreNotify_LibSocketConnect and friends, posted from asio callbacks).
-	// Those must run whatever the GUI is doing -- amulegui has no main window
-	// until an EC connection has been made, so dropping them means the
-	// connection never completes and every attempt ends at the 15 s watchdog.
+	// DoNotifyAlways() is how the socket layer reaches the main thread. Those
+	// must run whatever the GUI is doing -- amulegui has no main window until
+	// an EC connection has been made, so dropping them means the connection
+	// never completes and every attempt ends at the watchdog.
 	if (evt.IsAlways() || amuledlg) {
 		evt.Notify();
 	}
@@ -1185,16 +1111,14 @@ void CamuleRemoteGuiApp::Startup()
 	m_ecHost = dialog->Host();
 	m_ecPort = dialog->Port();
 	m_ecPass = dialog->PassHash();
-	// Baseline for the reconnect comparison: which daemon process this
-	// first connection reached. Stays 0 against a daemon that doesn't send
-	// EC_TAG_SESSION_ID, which makes every later reconnect take the
-	// start-over path.
+	// Baseline for the reconnect comparison: which daemon process this first
+	// connection reached. Stays 0 against a daemon that does not send
+	// EC_TAG_SESSION_ID, which makes every later reconnect take the start-over
+	// path.
 	//
 	// Not null-guarded, deliberately: Startup() only runs on a successful
-	// connect and the lines below dereference m_connect unconditionally, so
-	// a guard here would protect nothing while claiming the pointer is
-	// optional -- which is also how the static analyser reads it, and it
-	// then reports the dereference below as reachable with null.
+	// connect and the lines below dereference m_connect unconditionally, so a
+	// guard here would protect nothing while claiming the pointer is optional.
 	m_ecSessionId = m_connect->GetServerSessionId();
 
 	dialog->Destroy();
@@ -1222,12 +1146,10 @@ void CamuleRemoteGuiApp::Startup()
 	m_allUploadingKnownFile = new CKnownFile;
 
 	// Must run before InitGui() below: the CamuleDlg constructor reads
-	// UseTrayIcon() to decide whether to create the tray icon at all, so a
-	// guard applied after it would leave the icon built for a backend that
-	// cannot show it. Nothing here waits on the EC connection -- these are
-	// amulegui's own local preferences, not packed by CEC_Prefs_Packet and
-	// with no category in the EC_PREFS_* mask -- so OnInit() would have
-	// worked equally well; this sits next to the call it has to precede.
+	// UseTrayIcon() to decide whether to create the tray icon at all, so a guard
+	// applied after it would leave the icon built for a backend that cannot show
+	// it. Nothing here waits on the EC connection -- these are amulegui's own
+	// local preferences -- so OnInit() would have worked equally well.
 	SanitiseTrayPreferences();
 
 	// Create main dialog
@@ -1246,14 +1168,13 @@ void CamuleRemoteGuiApp::Startup()
 	poll_timer->Start(EC_POLL_INTERVAL_MS);
 	amuledlg->StartGuiTimer();
 
-	// Drain any pre-connect URL queued by ProtocolHandler_QueueSchemeLink
-	// (cold-launch: click → wrote ED2KLinks → user then connects). Saves
-	// a ~1 s wait for OnPollTimer to notice the file. No-op if empty.
+	// Drain any pre-connect URL queued by ProtocolHandler_QueueSchemeLink (cold
+	// launch: click wrote ED2KLinks, the user then connects). Saves a ~1 s wait
+	// for OnPollTimer to notice the file. No-op if empty.
 	AddLinksFromFile();
 
-	// amulegui does no local GeoIP resolution: the daemon resolves country
-	// codes and sends them over EC (#439 / #440), and amulegui only renders the
-	// flags. GeoIP settings are managed against the daemon, not locally.
+	// amulegui does no local GeoIP resolution: the daemon resolves country codes
+	// and sends them over EC, and amulegui only renders the flags.
 }
 
 int CamuleRemoteGuiApp::ShowAlert(wxString msg, wxString title, int flags)
@@ -1320,21 +1241,19 @@ wxString CamuleRemoteGuiApp::GetServerLog(bool reset)
 
 void CamuleRemoteGuiApp::AddServerMessageLine(wxString &msg)
 {
-	// Drives the same CamuleDlg::AddServerMessageLine the monolithic
-	// build calls -- ID_SERVERINFO text ctrl + 500-char truncation +
-	// auto-scroll. Cumulative-log diffing happens in
-	// CServerInfoHandlerRem::HandlePacket; by the time we land here
-	// `msg` is a single new line, ready to append.
+	// Drives the same CamuleDlg::AddServerMessageLine the monolithic build calls
+	// -- ID_SERVERINFO text ctrl, 500-char truncation, auto-scroll.
+	// Cumulative-log diffing happens in CServerInfoHandlerRem::HandlePacket; by
+	// the time we land here `msg` is a single new line, ready to append.
 	amuledlg->AddServerMessageLine(msg);
 }
 
 void CServerInfoHandlerRem::HandlePacket(const CECPacket *packet)
 {
-	// amuled answers EC_OP_GET_SERVERINFO with one EC_TAG_STRING
-	// carrying the full cumulative server_msg buffer. Diff against
-	// what we've already shown so the text ctrl receives only new
-	// lines (preserves scroll position and avoids re-rendering tens
-	// of KB on every poll).
+	// amuled answers EC_OP_GET_SERVERINFO with one EC_TAG_STRING carrying the
+	// full cumulative server_msg buffer. Diff against what we have already shown
+	// so the text ctrl receives only new lines, preserving scroll position and
+	// avoiding a re-render of tens of KB on every poll.
 	const CECTag *tag = packet->GetFirstTagSafe();
 	if (!tag || !tag->IsString()) {
 		return;
@@ -1345,15 +1264,13 @@ void CServerInfoHandlerRem::HandlePacket(const CECPacket *packet)
 	if (fullLog.StartsWith(m_seenSoFar)) {
 		delta = fullLog.Mid(m_seenSoFar.length());
 	} else {
-		// amuled was restarted, or someone else issued a clear, so the
-		// remote cumulative buffer is shorter or unrelated. Wipe the
-		// local view and start fresh from the current snapshot.
-		// Guarded like every other view call reached from an EC reply: a
-		// reply can land while amulegui has no dialog -- it is destroyed
-		// whenever the link drops and rebuilt by Startup() after the next
-		// connect, and replies already in flight are not drained. The
-		// bookkeeping around these calls still has to run, so only the call
-		// into the view is skipped.
+		// amuled was restarted, or someone else issued a clear, so the remote
+		// cumulative buffer is shorter or unrelated. Wipe the local view and
+		// start fresh from the current snapshot.
+		//
+		// Guarded like every other view call reached from an EC reply: a reply can
+		// land while amulegui has no dialog. The bookkeeping around these calls
+		// still has to run, so only the call into the view is skipped.
 		if (theApp->amuledlg) {
 			theApp->amuledlg->ResetLog(ID_SERVERINFO);
 		}
@@ -1380,10 +1297,10 @@ void CChatMsgHandlerRem::HandlePacket(const CECPacket *packet)
 	}
 	CChatWnd *chatwnd = theApp->amuledlg->m_chatwnd;
 
-	// First reply of a connection backfills history rather than announcing
-	// it: replay must not light the Messages toolbar button up for messages
-	// the user already read on another client. Only what arrives after we
-	// have a cursor is genuinely new.
+	// First reply of a connection backfills history rather than announcing it:
+	// replay must not light the Messages toolbar button up for messages the user
+	// already read on another client. Only what arrives after we have a cursor
+	// is genuinely new.
 	const bool backfill = (m_cursor == 0);
 
 	std::set<uint64> present;
@@ -1402,10 +1319,9 @@ void CChatMsgHandlerRem::HandlePacket(const CECPacket *packet)
 			name = ChatPeerFallbackName(gui_id);
 		}
 
-		// Open the tab even when the session has no new messages: that is
-		// how a session started before we connected becomes visible at all.
-		// Unfocused, so a session appearing on its own cannot steal the
-		// selection from whatever the user is doing.
+		// Open the tab even when the session has no new messages: that is how a
+		// session started before we connected becomes visible at all. Unfocused,
+		// so a session appearing on its own cannot steal the selection.
 		chatwnd->StartSessionByID(gui_id, name);
 
 		for (const CECTag &msgTag : sessionTag) {
@@ -1420,9 +1336,9 @@ void CChatMsgHandlerRem::HandlePacket(const CECPacket *packet)
 	}
 
 	// A session we are tracking that is absent from the reply was closed by
-	// another client (or evicted). Drop the tab without sending a close of
-	// our own — the core has already forgotten it. Snapshot first: closing a
-	// tab mutates the set being iterated.
+	// another client, or evicted. Drop the tab without sending a close of our
+	// own -- the core has already forgotten it. Snapshot first: closing a tab
+	// mutates the set being iterated.
 	const std::set<uint64> tracked = m_sessions;
 	for (uint64 gui_id : tracked) {
 		if (!present.count(gui_id)) {
@@ -1541,9 +1457,7 @@ CPreferencesRem::CPreferencesRem(CRemoteConnect *conn)
 {
 	m_conn = conn;
 
-	//
-	// Settings queried from remote side
-	//
+	// Settings queried from the remote side
 	m_exchange_send_selected_prefs = EC_PREFS_GENERAL | EC_PREFS_CONNECTIONS | EC_PREFS_MESSAGEFILTER |
 					 EC_PREFS_ONLINESIG | EC_PREFS_SERVERS | EC_PREFS_FILES |
 					 EC_PREFS_DIRECTORIES | EC_PREFS_SECURITY | EC_PREFS_CORETWEAKS |
@@ -1582,14 +1496,12 @@ bool CPreferencesRem::LoadRemote()
 {
 #ifdef GEOIP_GUI
 	// Assume the core has NO GeoIP support until it says otherwise. A 3.1+ core
-	// built with ENABLE_IP2COUNTRY answers with EC_TAG_IP2COUNTRY_SUPPORTED (see
-	// CEC_Prefs_Packet::Apply); a pre-3.1 core (e.g. 3.0.1) omits the whole
-	// category, so leaving this default false correctly hides the IP2Country
-	// page rather than offering settings the core can't honour.
+	// built with ENABLE_IP2COUNTRY answers with EC_TAG_IP2COUNTRY_SUPPORTED; a
+	// pre-3.1 core omits the whole category, so leaving this false correctly
+	// hides the IP2Country page rather than offering settings it cannot honour.
 	thePrefs::SetGeoIPSupported(false);
 #endif
-	//
-	// override local settings with remote
+	// Override local settings with remote
 	CECPacket req(EC_OP_GET_PREFERENCES, EC_DETAIL_UPDATE);
 
 	// bring categories too
@@ -1608,9 +1520,9 @@ void CPreferencesRem::SendToRemote()
 
 // Reply handler for the shared-directory ops. Deliberately separate from
 // CPreferencesRem::HandlePacket, which static_casts every packet it is given to
-// CEC_Prefs_Packet — routing a non-prefs reply through it would be undefined
+// CEC_Prefs_Packet -- routing a non-prefs reply through it would be undefined
 // behaviour. Results are stored on glob_prefs rather than on the Preferences
-// dialog, so a reply that arrives after the user closed the dialog is harmless.
+// dialog, so a reply arriving after the user closed the dialog is harmless.
 class CSharedDirsHandler : public CECPacketHandlerBase
 {
 	void HandlePacket(const CECPacket *packet) override;
@@ -1657,9 +1569,9 @@ void CSharedDirsHandler::HandlePacket(const CECPacket *packet)
 		if (!rejected.IsEmpty()) {
 			const wxString msg =
 				CFormat(_("The core rejected these shared folders:%s")) % rejected;
-			// Deferred: a modal opened straight from a packet handler spins a
-			// nested event loop that re-enters the EC socket and corrupts its
-			// receive state (see CAddLinkHandler).
+			// Deferred: a modal opened straight from a packet handler spins a nested
+			// event loop that re-enters the EC socket and corrupts its receive state
+			// (see CAddLinkHandler).
 			wxTheApp->CallAfter([msg]() { wxMessageBox(msg, _("ERROR"), wxOK | wxICON_ERROR); });
 		}
 	}
@@ -1692,13 +1604,10 @@ void CPreferencesRem::SendSharedDirsToRemote()
 	m_conn->SendRequest(new CSharedDirsHandler(), &req);
 }
 
-// Surfaces the EC_OP_FAILED reply from amuled's EC_OP_ADD_LINK handler
-// to the user. CDownQueueRem::AddLink used to drop the reply on the
-// floor (fire-and-forget SendPacket), so a malformed ed2k link -- e.g.
-// the original #310 reproducer `ed2k::3D366ED505B977FC61C9A6EE01E96329`
-// -- silently did nothing. amuled does the right thing now (logs
-// "Unknown protocol of link" and returns EC_OP_FAILED + EC_TAG_STRING),
-// but the GUI side has to actually show the message.
+// Surfaces the EC_OP_FAILED reply from amuled's EC_OP_ADD_LINK handler to the
+// user. CDownQueueRem::AddLink used to drop the reply on the floor, so a
+// malformed ed2k link silently did nothing. amuled logs "Unknown protocol of
+// link" and returns EC_OP_FAILED + EC_TAG_STRING; the GUI side has to show it.
 class CAddLinkHandler : public CECPacketHandlerBase
 {
 	virtual void HandlePacket(const CECPacket *packet);
@@ -1707,22 +1616,19 @@ class CAddLinkHandler : public CECPacketHandlerBase
 void CAddLinkHandler::HandlePacket(const CECPacket *packet)
 {
 	if (packet->GetOpCode() == EC_OP_FAILED) {
-		// Daemon-side EC_OP_ADD_LINK always tags the failure response
-		// with an EC_TAG_STRING explaining what went wrong. Reuse that
-		// string as the fallback too (it's already in the i18n catalog
-		// at po/amule.pot:1783, so no new string needs adding here).
+		// Daemon-side EC_OP_ADD_LINK always tags the failure response with an
+		// EC_TAG_STRING explaining what went wrong. Reuse that string as the
+		// fallback too, since it is already in the i18n catalog.
 		const CECTag *tag = packet->GetFirstTagSafe();
 		wxString msg = (tag && tag->IsString())
 				       ? wxGetTranslation(tag->GetStringData())
 				       : wxGetTranslation(wxTRANSLATE("Invalid link or already on list."));
-		// Defer the modal off the OnPacketReceived call stack: wxMessageBox
-		// spins a nested wx event loop, which dispatches CoreNotify_LibSocket*
-		// events that re-enter CECSocket::OnInput on the same socket and
-		// clobber its rx state (m_curr_rx_data / m_bytes_needed / m_in_header).
-		// Under heavy notification load — a batched-link add against a
-		// big shareset — the corrupted parse trips a protocol-error
-		// CloseSocket, which is the desync amuled logs as "External
-		// connection closed" right after the AddLink batch (#757 part 1).
+		// Defer the modal off the OnPacketReceived call stack: wxMessageBox spins
+		// a nested wx event loop, which dispatches CoreNotify_LibSocket* events
+		// that re-enter CECSocket::OnInput on the same socket and clobber its rx
+		// state. Under heavy notification load the corrupted parse trips a
+		// protocol-error CloseSocket, which amuled logs as "External connection
+		// closed" right after the AddLink batch.
 		wxTheApp->CallAfter([msg]() { wxMessageBox(msg, _("ERROR"), wxOK | wxICON_ERROR); });
 	}
 	delete this;
@@ -1850,9 +1756,7 @@ bool CPreferencesRem::RequestRemoveCat(size_t cat)
 	return false;
 }
 
-//
 // Container implementation
-//
 CServerConnectRem::CServerConnectRem(CRemoteConnect *conn)
 {
 	m_CurrServer = 0;
@@ -2070,11 +1974,10 @@ void CServerListRem::ProcessItemUpdate(const CEC_Server_Tag *tag, CServer *serve
 	tag->GetMaxUsers(&server->maxusers);
 	tag->GetSoftFiles(&server->softfiles);
 	tag->GetHardFiles(&server->hardfiles);
-	// Read through the pointer, as the fields above do. The valuemap builder
-	// omits a tag whose value has not changed since the last update, and the
-	// return form yields 0 for an absent tag -- so assigning it would wipe the
-	// value on every update that did not resend it. AssignIfExist() leaves the
-	// current value alone instead.
+	// Read through the pointer, as the fields above do. The valuemap builder omits
+	// a tag whose value has not changed since the last update, and the return
+	// form yields 0 for an absent tag -- so assigning it would wipe the value on
+	// every update that did not resend it. AssignIfExist() leaves it alone.
 	uint32 tcpFlags = server->GetTCPFlags();
 	uint32 udpFlags = server->GetUDPFlags();
 	tag->GetTCPFlags(&tcpFlags);
@@ -2171,14 +2074,14 @@ unsigned CSharedFilesRem::RefreshMediaMetadata(const std::vector<CMD4Hash> &hash
 	}
 	// ONE packet carrying every hash. One request per file would push the
 	// selection through m_req_fifo a packet at a time, and OnPollTimer stops
-	// updating the GUI while that fifo is full -- on a large selection the
-	// window would go quiet for as long as it took to drain.
+	// updating the GUI while that fifo is full -- on a large selection the window
+	// would go quiet for as long as it took to drain.
 	CECPacket request(EC_OP_REFRESH_MEDIA_METADATA);
 	for (const CMD4Hash &hash : hashes) {
-		// A FRESH tag per hash, deliberately. CECTag::AddTag swaps the
-		// argument's contents into the child list and leaves the original
-		// empty, so adding the same tag object twice appends one real child
-		// and one blank -- silently sending fewer hashes than intended.
+		// A FRESH tag per hash, deliberately. CECTag::AddTag swaps the argument's
+		// contents into the child list and leaves the original empty, so adding the
+		// same tag object twice appends one real child and one blank -- silently
+		// sending fewer hashes than intended.
 		request.AddTag(CECTag(EC_TAG_KNOWNFILE, hash));
 	}
 	m_conn->SendPacket(&request);
@@ -2193,9 +2096,9 @@ bool CSharedFilesRem::RefreshMediaMetadata(const CMD4Hash &hash)
 	request.AddTag(CECTag(EC_TAG_KNOWNFILE, hash));
 	m_conn->SendPacket(&request);
 	// Sent, not probed. A daemon that predates the opcode answers EC_OP_FAILED
-	// and the reply is dropped here as it is for every other fire-and-forget
-	// request on this class; the user sees nothing happen, which is the same
-	// outcome as the action not existing.
+	// and the reply is dropped here as for every other fire-and-forget request
+	// on this class; the user sees nothing happen, which is the same outcome as
+	// the action not existing.
 	return true;
 }
 
@@ -2211,8 +2114,8 @@ void CSharedFilesRem::SetFileCommentRating(CKnownFile *file, const wxString &new
 
 void CSharedFilesRem::SearchKadNotes(CAbstractFile *file)
 {
-	// The daemon owns Kad; ask it to run the on-demand NOTES lookup for this
-	// file (a download, a shared file, or a search result — the request is keyed
+	// The daemon owns Kad; ask it to run the on-demand NOTES lookup for this file
+	// (a download, a shared file, or a search result -- the request is keyed
 	// purely by hash). Retrieved notes flow back through the comments channel.
 	CECPacket request(EC_OP_SHARED_FILE_SEARCH_KAD_NOTES);
 	request.AddTag(CECTag(EC_TAG_KNOWNFILE, file->GetFileHash()));
@@ -2231,12 +2134,10 @@ void CSharedFilesRem::CopyFileList(std::vector<CKnownFile *> &out_list) const
 void CKnownFilesRem::DeleteItem(CKnownFile *file)
 {
 	uint32 id = file->ECID();
-	// Broadcast to every subscriber that holds a raw CKnownFile* to
-	// this object — CUpDownClient::m_uploadingfile / m_reqfile (the
-	// #748 crash flow), CGenericClientListCtrl::m_knownfiles (#755),
-	// and the open-dialog registry. Subscribers strip their refs
-	// using pointer-value comparison only. See
-	// MuleNotify::KnownFileBeingDestroyed (GuiEvents.cpp).
+	// Broadcast to every subscriber that holds a raw CKnownFile* to this object --
+	// CUpDownClient::m_uploadingfile / m_reqfile, CGenericClientListCtrl's own
+	// list, and the open-dialog registry. Subscribers strip their refs using
+	// pointer-value comparison only.
 	Notify_KnownFileBeingDestroyed(file);
 
 	if (theApp->sharedfiles->count(id)) {
@@ -2257,12 +2158,10 @@ void CKnownFilesRem::DeleteItem(CKnownFile *file)
 
 void CUpDownClientListRem::DropReferencesTo(const CKnownFile *file)
 {
-	// Null out CUpDownClient::m_uploadingfile / m_reqfile on every
-	// client still pointing at `file`. Called by
-	// MuleNotify::KnownFileBeingDestroyed (the broadcast handler in
-	// GuiEvents.cpp) which is itself fired from CKnownFilesRem::
-	// DeleteItem above before the file is freed. Pointer-value
-	// comparison only — `file` may already be freed by the time
+	// Null out CUpDownClient::m_uploadingfile / m_reqfile on every client still
+	// pointing at `file`. Called by MuleNotify::KnownFileBeingDestroyed, itself
+	// fired from CKnownFilesRem::DeleteItem above before the file is freed.
+	// Pointer-value comparison only -- `file` may already be freed by the time
 	// this runs on the main thread.
 	for (iterator it = begin(); it != end(); ++it) {
 		CUpDownClient *client = (*it)->GetClient();
@@ -2292,14 +2191,12 @@ namespace
 //
 // A zero / empty value is the daemon saying the field is GONE, not a value
 // worth storing -- it only sends one for a field it previously sent a real
-// value for (see AddMediaTagsPresent). Storing it would leave the dialog
-// showing 0:00 or a blank Artist where N/A is the honest answer.
+// value for. Storing it would leave the dialog showing 0:00 or a blank Artist
+// where N/A is the honest answer.
 //
 // Shared by the known-file walker and the search-result one because the daemon
 // emits these from ONE place for both: CEC_SharedFile_Tag's base ctor, which
-// CEC_SearchFile_Tag derives from. Two copies of this loop would drift the
-// moment a seventh field appeared, and the search half is only being written
-// now because the first copy was missing there entirely.
+// CEC_SearchFile_Tag derives from.
 void DecodeMediaTags(const CECTag *tag, CAbstractFile *file)
 {
 	static const struct
@@ -2347,37 +2244,32 @@ void CKnownFilesRem::ProcessItemUpdate(const CEC_SharedFile_Tag *tag, CKnownFile
 		const uint8 *data =
 			file->m_partStatus.Decode((uint8 *)parttag->GetTagData(), parttag->GetTagDataLen());
 		// The two bounds come from different places and are not guaranteed to
-		// agree: the buffer is as long as the decoder made it from what the
-		// wire carried, while GetPartCount() is this object's own, derived
-		// from the size it currently believes the file to be. They match for
-		// as long as an ECID keeps meaning the same file -- which a daemon
-		// restart ends, because CECID hands IDs out from a counter that starts
-		// again with the process while amulegui deliberately keeps its objects
-		// across a reconnect. An ID that comes back naming a different file
-		// then pairs a short buffer with a long part count, and this loop
-		// reads off the end of the heap allocation.
+		// agree: the buffer is as long as the decoder made it from what the wire
+		// carried, while GetPartCount() is this object's own, derived from the
+		// size it currently believes the file to be. They match for as long as an
+		// ECID keeps meaning the same file -- which a daemon restart ends, because
+		// CECID hands IDs out from a counter that starts again with the process
+		// while amulegui deliberately keeps its objects across a reconnect. An ID
+		// that comes back naming a different file then pairs a short buffer with a
+		// long part count, and this loop reads off the end of the allocation.
 		//
-		// Copy what actually arrived and clear the rest, rather than trusting
-		// either bound alone: leaving the tail would show the previous file's
+		// Copy what actually arrived and clear the rest rather than trusting
+		// either bound: leaving the tail would show the previous file's
 		// availability under the new one's name.
 		const int arrived = file->m_partStatus.Size();
 		const int parts = file->GetPartCount();
 		const int copied = std::min(arrived, parts);
 		if (arrived != parts && !m_loggedPartStatusMismatch) {
-			// Says the tag and the object disagree about which file this
-			// is. The reconnect path is supposed to make that impossible
-			// by discarding everything keyed by ECID when the daemon
-			// changes underneath us, so this firing means that went
-			// wrong. Critical rather than debug: clamping the copy leaves
-			// no other trace, the rest of this update goes on applying the
-			// same mismatched tag to the same object, and what the user
-			// ends up looking at is a row describing the wrong file --
-			// which they can act on, and would otherwise have no reason to
-			// suspect.
+			// Says the tag and the object disagree about which file this is. The
+			// reconnect path is supposed to make that impossible by discarding
+			// everything keyed by ECID when the daemon changes underneath us, so
+			// this firing means that went wrong. Critical rather than debug:
+			// clamping the copy leaves no other trace, the rest of this update goes
+			// on applying the same mismatched tag, and what the user ends up
+			// looking at is a row describing the wrong file.
 			//
-			// Once per session, not once per file: if the ECID space has
-			// gone bad it has gone bad for everything, and this sits in a
-			// loop that runs over the whole library on every poll.
+			// Once per session, not once per file: if the ECID space has gone bad it
+			// has gone bad for everything, and this loop runs over the whole library.
 			m_loggedPartStatusMismatch = true;
 			AddLogLineC(CFormat(_("The remote core sent inconsistent data for \"%s\" "
 					      "(part status %d, expected %d). The file list may be "
@@ -2429,10 +2321,10 @@ void CKnownFilesRem::ProcessItemUpdate(const CEC_SharedFile_Tag *tag, CKnownFile
 
 	tag->GetOnQueue(&file->m_queuedCount);
 
-	// Live upload activity (issue #466): the daemon summarises these from its
+	// Live upload activity: the daemon summarises these from its
 	// m_ClientUploadList and ships them every update tick. Decoded into the EC
-	// mirror members so GetUploadDatarate()/GetTransferringClientCount() work
-	// in amulegui (e.g. the file-details Sharing box).
+	// mirror members so GetUploadDatarate() / GetTransferringClientCount() work
+	// in amulegui.
 	tag->GetUploadSpeed(&file->m_uploadDatarateEC);
 	tag->GetUploadingCount(&file->m_transferringClientCountEC);
 	// Share timestamps ride only in the full-detail section, not every tick, so
@@ -2451,11 +2343,10 @@ void CKnownFilesRem::ProcessItemUpdate(const CEC_SharedFile_Tag *tag, CKnownFile
 	tag->GetComment(file->m_strComment);
 	tag->GetRating(file->m_iRating);
 
-	// Community ratings/comments + the on-demand Kad-notes running flag. The
+	// Community ratings/comments plus the on-demand Kad-notes running flag. The
 	// daemon serializes these on the CEC_SharedFile_Tag base, so this one decode
-	// serves both shared files and downloads (it runs for every known file
-	// before the partfile-specific pass). The container is present only when it
-	// changed (valuemap-suppressed), so an absent tag keeps the prior list.
+	// serves both shared files and downloads. The container is present only when
+	// it changed, so an absent tag keeps the prior list.
 	const CECTag *commenttag = tag->GetTagByName(EC_TAG_PARTFILE_COMMENTS);
 	if (commenttag) {
 		file->ClearFileRatingList();
@@ -2481,12 +2372,10 @@ void CKnownFilesRem::ProcessItemUpdate(const CEC_SharedFile_Tag *tag, CKnownFile
 	}
 
 	// Media metadata rides the SHARED-FILE base tag, so it is decoded here for
-	// every known file rather than inside the partfile branch below. It used
-	// to live there, which meant a COMPLETED shared file -- the only kind the
-	// completion re-probe produces -- had all six tags dropped on the floor,
-	// and the File Details dialog showed N/A for anything not currently
-	// downloading. The same mistake the comments/ratings decode already
-	// avoids for the same reason.
+	// every known file rather than inside the partfile branch below. It used to
+	// live there, which meant a COMPLETED shared file -- the only kind the
+	// completion re-probe produces -- had all six tags dropped on the floor, and
+	// the File Details dialog showed N/A for anything not downloading.
 	DecodeMediaTags(tag, file);
 
 	if (file->IsPartFile()) {
@@ -2511,15 +2400,13 @@ void CKnownFilesRem::ArmReconnectReconcile()
 {
 	m_reconnectReconcile = true;
 
-	// A reconnect opens a fresh EC session. The daemon keeps its RLE gap/part/
-	// req-status encoders per connection (CFileEncoderMap in ExternalConn.cpp),
-	// so the new session's encoders restart from an empty baseline. Our reused
-	// CKnownFile / CPartFile objects still carry the previous session's
-	// *decoder* state; left alone, the first differential status update would
-	// XOR the daemon's from-empty diff against that stale buffer and paint
-	// garbage — all-red download progress bars and wrong shared-file
-	// availability shading (issue #444). Reset every decoder now so both ends
-	// share the same empty baseline before the first post-reconnect update.
+	// A reconnect opens a fresh EC session. The daemon keeps its RLE
+	// gap/part/req-status encoders per connection, so the new session's encoders
+	// restart from an empty baseline. Our reused CKnownFile / CPartFile objects
+	// still carry the previous session's *decoder* state; left alone, the first
+	// differential status update would XOR the daemon's from-empty diff against
+	// that stale buffer and paint garbage -- all-red progress bars and wrong
+	// shared-file availability shading.
 	for (CKnownFile *file : *this) {
 		file->m_partStatus.ResetEncoder();
 		if (file->IsPartFile()) {
@@ -2549,41 +2436,34 @@ void CKnownFilesRem::ProcessUpdate(const CECTag *reply, CECPacket *, int)
 	transferred = 0;
 	accepted = 0;
 
-	// The first poll after a reconnect re-processes the whole (potentially
-	// 10k+) library in one go (update-in-place + add + prune) — that is the
-	// reconcile case (issue #444), which drives the one-shot absence-prune
-	// below. The cold-boot m_initialUpdate path has its own batching
-	// (ShowFileList) and never overlaps — m_initialUpdate is false whenever
-	// reconcile is true.
+	// The first poll after a reconnect re-processes the whole (potentially 10k+)
+	// library in one go -- update-in-place, add, prune -- which is the reconcile
+	// case that drives the one-shot absence-prune below. The cold-boot
+	// m_initialUpdate path has its own batching and never overlaps.
 	const bool reconcile = m_reconnectReconcile;
 
 	// Batch the download list on every steady-state poll, not just a reconnect
 	// resync: an ordinary poll can surface a whole burst of freshly-added
-	// downloads at once (e.g. a hundred search results dropped into a large
-	// queue), and CDownloadListCtrl::AddFile() re-sorts the entire list on
-	// every insert. On a 10k queue that is O(n^2 log n) and freezes the GUI for
-	// seconds (issue #615). BeginBatchUpdate() suppresses the per-item sort;
-	// the single SortList() runs once at the end, and only if we actually added
-	// a file (downloadListGrew) — a pure in-place stat poll stays sort-free.
-	// The cold-boot m_initialUpdate path has its own batching (ShowFileList),
-	// so leave it alone to avoid a redundant second sort. Captured now because
-	// ProcessItemUpdate/AddFile below and the final prune all touch the ctrl.
+	// downloads at once, and CDownloadListCtrl::AddFile() re-sorts the entire
+	// list on every insert -- O(n^2 log n) on a 10k queue, which freezes the
+	// GUI for seconds. BeginBatchUpdate() suppresses the per-item sort; the
+	// single SortList() runs once at the end, and only if a file was actually
+	// added, so a pure in-place stat poll stays sort-free.
+	//
 	// The dialog is part of the condition: these Begin/End pairs and the
-	// per-item calls between them are view work, and an EC reply can arrive
-	// with no dialog at all (destroyed on link loss, rebuilt by Startup()).
+	// per-item calls between them are view work, and an EC reply can arrive with
+	// no dialog at all.
 	const bool batchDownloadList = !m_initialUpdate && theApp->amuledlg != nullptr;
 	bool downloadListGrew = false;
 	if (batchDownloadList) {
 		theApp->amuledlg->m_transferwnd->downloadlistctrl->BeginBatchUpdate();
 	}
 
-	// Same reasoning for the shared-files list: a steady-state poll can surface
-	// a burst of freshly-shared files (many downloads completing, or a shared
-	// folder added/rescanned daemon-side), and ShowFile() -> AddItemData()
-	// rebuilds the whole virtual-list row index on every insert -- O(n) each,
-	// O(n^2) on a large share. Batch every non-initial poll and sort once at the
-	// end, only if the poll actually added a file (sharedListGrew). Reconnect
-	// reconcile is one such non-initial poll, so it is covered too.
+	// Same reasoning for the shared-files list: a steady-state poll can surface a
+	// burst of freshly-shared files, and ShowFile() -> AddItemData() rebuilds the
+	// whole virtual-list row index on every insert -- O(n) each, O(n^2) on a
+	// large share. Batch every non-initial poll and sort once at the end, only
+	// if the poll actually added a file.
 	const bool batchSharedList = !m_initialUpdate && theApp->amuledlg != nullptr;
 	bool sharedListGrew = false;
 	if (batchSharedList) {
@@ -2593,14 +2473,12 @@ void CKnownFilesRem::ProcessUpdate(const CECTag *reply, CECPacket *, int)
 	// full snapshot: keep the one-shot armed instead of pruning (see #444).
 	bool deferReconcile = false;
 
-	// Partial-update protocol negotiated at auth time (see
-	// CRemoteConnect::ServerSupportsPartialUpdate). When true, the server
-	// only sends tags for files that actually changed and signals
-	// deletions explicitly via top-level `EC_TAG_FILE_REMOVED` markers —
-	// the bulk "anything missing == deleted" loop below would silently
-	// wipe most of the library every cycle (#713). When false (old
-	// server), the server emits alive-marker tags for unchanged files
-	// so the bulk-deletion path stays correct.
+	// Partial-update protocol negotiated at auth time. When true, the server only
+	// sends tags for files that actually changed and signals deletions explicitly
+	// via top-level EC_TAG_FILE_REMOVED markers -- the bulk "anything missing ==
+	// deleted" loop below would silently wipe most of the library every cycle.
+	// When false, the server emits alive-marker tags for unchanged files so the
+	// bulk-deletion path stays correct.
 	const bool partial_update = m_conn->ServerSupportsPartialUpdate();
 
 	std::set<uint32> core_files;
@@ -2615,22 +2493,20 @@ void CKnownFilesRem::ProcessUpdate(const CECTag *reply, CECPacket *, int)
 		} else if (tagname == EC_TAG_FRIEND) {
 			theApp->friendlist->ProcessUpdate(curTag, NULL, EC_TAG_FRIEND);
 		} else if (tagname == EC_TAG_FILE_REMOVED) {
-			// Explicit deletion marker from a partial-update-capable
-			// server. Buffered and processed in one pass below so we
-			// only iterate the live list when there's actually
-			// something to remove. Outside the partial-update path
-			// the server never emits this tag.
+			// Explicit deletion marker from a partial-update-capable server.
+			// Buffered and processed in one pass below so the live list is only
+			// iterated when there is something to remove. Outside the partial-update
+			// path the server never emits this tag.
 			removed_files.insert(curTag->GetInt());
 		} else if (tagname == EC_TAG_KNOWNFILE || tagname == EC_TAG_PARTFILE) {
 			const CEC_SharedFile_Tag *tag = static_cast<const CEC_SharedFile_Tag *>(curTag);
 			uint32 id = tag->ID();
 			bool isNew = true;
 			if (!m_initialUpdate) {
-				// Collect the full ID set whenever we mean to prune by
-				// absence below: a legacy server always (it emits alive
-				// markers for every file), or once right after a reconnect
-				// (m_reconnectReconcile — the fresh session sends a full
-				// snapshot we reconcile against).
+				// Collect the full ID set whenever we mean to prune by absence below:
+				// a legacy server always (it emits alive markers for every file), or
+				// once right after a reconnect, where the fresh session sends a full
+				// snapshot to reconcile against.
 				if (!partial_update || m_reconnectReconcile) {
 					core_files.insert(id);
 				}
@@ -2644,16 +2520,12 @@ void CKnownFilesRem::ProcessUpdate(const CECTag *reply, CECPacket *, int)
 				}
 			}
 			if (isNew) {
-				// An alive-marker tag carries only the ECID with no
-				// child tags; it's the compat-mode "this file still
-				// exists" signal and is only meaningful for files we
-				// already know. If we receive one for an ID we've never
-				// seen (race during bulk Reload, server diff baseline
-				// briefly out of step, etc.), constructing
-				// CKnownFile(tag) on an empty tag yields a ghost entry
-				// with no name and zero size (#808). Skip the marker
-				// and rely on a subsequent full-tag update to introduce
-				// the file.
+				// An alive-marker tag carries only the ECID with no child tags; it is
+				// the compat-mode "this file still exists" signal and is only meaningful
+				// for files we already know. For an ID never seen -- a race during bulk
+				// Reload, a server diff baseline briefly out of step -- constructing
+				// CKnownFile(tag) on an empty tag yields a ghost entry with no name and
+				// zero size. Skip the marker and rely on a later full-tag update.
 				if (!tag->HasChildTags()) {
 					AddDebugLogLineN(logEC,
 						CFormat(wxT("EC: alive-marker for unknown file ID %u; "
@@ -2661,25 +2533,16 @@ void CKnownFilesRem::ProcessUpdate(const CECTag *reply, CECPacket *, int)
 							id);
 					continue;
 				}
-				// Second variant of the same #808 ghost-entry pattern.
-				// CEC_SharedFile_Tag runs each metadata field through
-				// a per-connection CValueMap (ECSpecialTags.h) which
-				// suppresses tags whose value hasn't changed since the
-				// last cached send.  On an EC_DETAIL_INC_UPDATE for a
-				// file ID we've never seen, the server may already
-				// have cached + suppressed EC_TAG_PARTFILE_HASH /
-				// _NAME / _SIZE_FULL, in which case the tag has plenty
-				// of statistical child tags (request count, accepts,
-				// transferred, AICH masterhash, priority...) but no
-				// identifying metadata.  CKnownFile(tag) would then
-				// read empty hash + 0 size via GetTagByNameSafe and
-				// produce the same 0-byte unnamed ghost entry that the
-				// HasChildTags() guard above is shaped against -- with
-				// children but no identity.  Detect by the absence of
-				// the file hash (the canonical identity tag) and skip
-				// the same way; the next full-state poll picks the
-				// file up correctly once the server-side cache
-				// invalidation puts it back on the wire.
+				// Second variant of the same ghost-entry pattern. CEC_SharedFile_Tag
+				// runs each metadata field through a per-connection CValueMap, which
+				// suppresses tags whose value has not changed since the last cached
+				// send. On an EC_DETAIL_INC_UPDATE for a file ID we have never seen,
+				// the server may already have cached and suppressed
+				// EC_TAG_PARTFILE_HASH / _NAME / _SIZE_FULL, so the tag has plenty of
+				// statistical children but no identifying metadata -- and
+				// CKnownFile(tag) would produce the same 0-byte unnamed ghost the
+				// HasChildTags() guard above is shaped against. Detect by the absence
+				// of the file hash and skip the same way.
 				if (tag->GetTagByName(EC_TAG_PARTFILE_HASH) == NULL) {
 					AddDebugLogLineN(logEC,
 						CFormat(wxT(
@@ -2694,9 +2557,9 @@ void CKnownFilesRem::ProcessUpdate(const CECTag *reply, CECPacket *, int)
 						new CPartFile(static_cast<const CEC_PartFile_Tag *>(tag));
 					ProcessItemUpdate(tag, file);
 					(*theApp->downloadqueue)[id] = file;
-					// On the initial full sync, defer the per-item show +
-					// sort; the whole list is shown and sorted once below
-					// via ShowFileList() (issue #414 — O(n^2) otherwise).
+					// On the initial full sync, defer the per-item show + sort; the whole
+					// list is shown and sorted once below via ShowFileList(), which is
+					// O(n^2) otherwise.
 					if (theApp->amuledlg) {
 						theApp->amuledlg->m_transferwnd->downloadlistctrl->AddFile(
 							file, /*deferView=*/m_initialUpdate);
@@ -2739,23 +2602,21 @@ void CKnownFilesRem::ProcessUpdate(const CECTag *reply, CECPacket *, int)
 			}
 		}
 	} else if (reconcile && core_files.empty() && GetCount() != 0) {
-		// Defensive guard (#444): the first poll after a reconnect should
-		// carry the full library snapshot. If it came back with no file tags
-		// at all while we still hold a populated list, that reply is not a
-		// trustworthy baseline — pruning by absence here would wipe every
-		// download and shared file. Skip the prune and leave the one-shot
-		// armed so the next poll reconciles against a real snapshot instead.
+		// Defensive guard: the first poll after a reconnect should carry the full
+		// library snapshot. If it came back with no file tags at all while we
+		// still hold a populated list, that reply is not a trustworthy baseline
+		// -- pruning by absence here would wipe every download and shared file.
+		// Skip the prune and leave the one-shot armed for the next poll.
 		AddDebugLogLineN(logEC,
 			wxT("EC: post-reconnect reconcile reply carried no files; "
 			    "deferring the absence-prune to the next poll."));
 		deferReconcile = true;
 	} else {
 		// Legacy server (alive-marker protocol), OR the first poll after a
-		// reconnect (m_reconnectReconcile): anything missing from the
-		// response is deleted. On reconnect the fresh partial-update server
-		// sends a full snapshot but never re-emits FILE_REMOVED for files
-		// deleted while we were disconnected, so this one-shot prune against
-		// the full ID set is how those stale entries get cleared.
+		// reconnect: anything missing from the response is deleted. On reconnect
+		// the fresh partial-update server sends a full snapshot but never
+		// re-emits FILE_REMOVED for files deleted while we were disconnected, so
+		// this one-shot prune is how those stale entries get cleared.
 		for (iterator it = begin(); it != end();) {
 			iterator it2 = it++;
 			if (!core_files.count(GetItemID(*it2))) {
@@ -2765,16 +2626,14 @@ void CKnownFilesRem::ProcessUpdate(const CECTag *reply, CECPacket *, int)
 		}
 	}
 	if (batchDownloadList) {
-		// Sort once if the poll added a file (or on a reconnect resync, where
-		// the whole list was reconciled); otherwise the order is unchanged and
-		// EndBatchUpdate() just Thaws without a needless re-sort.
+		// Sort once if the poll added a file, or on a reconnect resync where the
+		// whole list was reconciled; otherwise EndBatchUpdate() just Thaws.
 		theApp->amuledlg->m_transferwnd->downloadlistctrl->EndBatchUpdate(
 			reconcile || downloadListGrew);
 	}
 	if (batchSharedList) {
-		// Sort once if the poll added a shared file (or on a reconnect resync,
-		// where the whole list was reconciled); otherwise the order is
-		// unchanged and EndBatchUpdate() just Thaws without a needless re-sort.
+		// Sort once if the poll added a shared file, or on a reconnect resync
+		// where the whole list was reconciled; otherwise EndBatchUpdate() Thaws.
 		theApp->amuledlg->m_sharedfileswnd->sharedfilesctrl->EndBatchUpdate(
 			reconcile || sharedListGrew);
 	}
@@ -2965,10 +2824,10 @@ void CUpDownClientListRem::ProcessItemUpdate(const CEC_UpDownClient_Tag *tag, CC
 	tag->UserID(&client->m_nUserIDHybrid);
 	tag->ClientName(&client->m_Username);
 #ifdef GEOIP_GUI
-	// Peer country from the daemon's GeoIP (#439). Check tag *presence*, not
-	// its value: a present-but-empty tag is an authoritative "unknown" and
-	// must still mark the code as core-provided so the client list doesn't
-	// try a (non-existent) local fallback.
+	// Peer country from the daemon's GeoIP. Check tag *presence*, not its value:
+	// a present-but-empty tag is an authoritative "unknown" and must still mark
+	// the code as core-provided, so the client list does not try a
+	// (non-existent) local fallback.
 	if (tag->GetTagByName(EC_TAG_CLIENT_COUNTRY)) {
 		client->SetCountryCode(tag->Country());
 	}
@@ -3169,9 +3028,9 @@ bool CDownQueueRem::AddLink(const wxString &link, uint8 cat)
 	link_tag.AddTag(CECTag(EC_TAG_PARTFILE_CAT, cat));
 	req.AddTag(link_tag);
 
-	// SendRequest registers the handler; on EC_OP_FAILED the GUI shows
-	// the wxMessageBox set up in CAddLinkHandler. Previously this was
-	// fire-and-forget and silently dropped errors (#310 follow-up).
+	// SendRequest registers the handler; on EC_OP_FAILED the GUI shows the
+	// wxMessageBox set up in CAddLinkHandler. This used to be fire-and-forget
+	// and silently dropped errors.
 	m_conn->SendRequest(new CAddLinkHandler, &req);
 	return true;
 }
@@ -3179,9 +3038,9 @@ bool CDownQueueRem::AddLink(const wxString &link, uint8 cat)
 void CDownQueueRem::AddLinks(const wxArrayString &links, uint8 cat)
 {
 	// Pack the whole batch into one EC_OP_ADD_LINK packet. The daemon-side
-	// handler (PR #551) already iterates over every child tag and emits a
-	// single aggregated response, so CAddLinkHandler fires once for the
-	// whole batch — no client-side N popups for N invalid links.
+	// handler already iterates over every child tag and emits a single
+	// aggregated response, so CAddLinkHandler fires once for the whole batch --
+	// no client-side N popups for N invalid links.
 	if (links.IsEmpty()) {
 		return;
 	}
@@ -3207,9 +3066,7 @@ void CDownQueueRem::ResetCatParts(int cat)
 
 void CKnownFilesRem::ProcessItemUpdatePartfile(const CEC_PartFile_Tag *tag, CPartFile *file)
 {
-	//
-	// update status
-	//
+	// Update status
 	tag->Speed(&file->m_kbpsDown);
 	file->kBpsDown = file->m_kbpsDown / 1024.0;
 
@@ -3247,9 +3104,7 @@ void CKnownFilesRem::ProcessItemUpdatePartfile(const CEC_PartFile_Tag *tag, CPar
 
 	file->percentcompleted = (100.0 * file->GetCompletedSize()) / file->GetFileSize();
 
-	//
 	// Copy part/gap status
-	//
 	const CECTag *gaptag = tag->GetTagByName(EC_TAG_PARTFILE_GAP_STATUS);
 	const CECTag *parttag = tag->GetTagByName(EC_TAG_PARTFILE_PART_STATUS);
 	const CECTag *reqtag = tag->GetTagByName(EC_TAG_PARTFILE_REQ_STATUS);
@@ -3310,9 +3165,9 @@ void CKnownFilesRem::ProcessItemUpdatePartfile(const CEC_PartFile_Tag *tag, CPar
 		}
 	}
 
-	// Comments/ratings + the Kad-notes running flag are decoded once for every
-	// known file in CKnownFilesRem::ProcessItemUpdate (they ride the shared-file
-	// base tag now), so there is nothing partfile-specific to do here.
+	// Comments/ratings and the Kad-notes running flag are decoded once for every
+	// known file in CKnownFilesRem::ProcessItemUpdate, so there is nothing
+	// partfile-specific to do here.
 
 	// Update A4AF sources
 	ListOfUInts32 &clientIDs = file->GetA4AFClientIDs();
@@ -3465,8 +3320,7 @@ void CFriendListRem::ProcessItemUpdate(const CEC_Friend_Tag *tag, CFriend *Frien
 	tag->Port(Friend->m_nLastUsedPort);
 	// Read the slot back rather than leaving it at its constructor false: the
 	// context menu's check mark is drawn from it, so without this it never
-	// showed which friend actually holds the slot -- not even right after
-	// this GUI set it.
+	// showed which friend actually holds the slot.
 	bool friendSlot = false;
 	if (tag->FriendSlot(friendSlot)) {
 		Friend->SetPersistentFriendSlot(friendSlot);
@@ -3559,10 +3413,9 @@ void CFriendListRem::SetFriendSlot(CFriend *Friend, bool new_state)
 // "View Files" (browse) over EC. On a multi-search daemon, open an optimistic
 // browse tab and correlate it via EC_TAG_SEARCH_REF: the daemon allocates the
 // browse's search id, echoes the ref, and CSearchListRem::HandlePacket rekeys
-// the tab (and starts polling its progress) exactly like a search START reply.
-// On a legacy daemon (no multi-search) fall back to the old fire-and-forget
-// request with no tab — the daemon can't surface browse results over EC there,
-// so opening a tab would just leave a phantom empty page. Behaviour unchanged.
+// the tab exactly like a search START reply. On a legacy daemon fall back to
+// the old fire-and-forget request with no tab -- the daemon cannot surface
+// browse results over EC there, so a tab would just be a phantom empty page.
 static void SendBrowseRequest(
 	CRemoteConnect *conn, CECEmptyTag &sharedtag, uint32 peerEcid, const wxString &peerName)
 {
@@ -3629,10 +3482,9 @@ wxString CSearchListRem::StartNewSearch(
 
 	if (m_conn->ServerSupportsMultiSearch()) {
 		// Multi-search: the daemon allocates the real search ID. Send the
-		// optimistic local tab ID as a correlation token (EC_TAG_SEARCH_REF);
-		// the daemon echoes it alongside the allocated EC_TAG_SEARCH_ID, and
-		// HandlePacket remaps the tab. Sent via SendRequest so the reply is
-		// routed back to this handler.
+		// optimistic local tab ID as a correlation token; the daemon echoes it
+		// alongside the allocated EC_TAG_SEARCH_ID and HandlePacket remaps the
+		// tab. Sent via SendRequest so the reply routes back to this handler.
 		search_req.AddTag(CECTag(EC_TAG_SEARCH_REF, *nSearchID));
 		m_conn->SendRequest(this, &search_req);
 		// See m_pendingSearchStarts's declaration: closes the window where an
@@ -3648,8 +3500,8 @@ wxString CSearchListRem::StartNewSearch(
 	// Legacy single-search wipes the one result set on the daemon at each new
 	// search, so flush the container to match. Multi-search must NOT flush: the
 	// container holds every open search's results, and clearing its item hash
-	// (without clearing the displayed rows) makes the next poll re-create every
-	// result — producing ghost rows (INC_UPDATE) or duplicate rows (FULL).
+	// without clearing the displayed rows makes the next poll re-create every
+	// result -- ghost rows under INC_UPDATE, duplicates under FULL.
 	if (!m_conn->ServerSupportsMultiSearch()) {
 		Flush();
 	}
@@ -3659,13 +3511,12 @@ wxString CSearchListRem::StartNewSearch(
 
 void CSearchListRem::StopSearch(bool globalOnly)
 {
-	// globalOnly is the new-search path (OnBnClickedStart): monolithic uses it
-	// to reset only the single in-flight ed2k slot while sparing running Kad
-	// searches. In multi-search each search is independent and the daemon
-	// finalizes any in-flight ed2k search itself, so starting a new search must
-	// NOT stop the previous one — otherwise a second Kad search cancels the
-	// first. On a legacy single-search daemon, fall through (the daemon replaces
-	// the one search anyway). globalOnly == false is the explicit Stop button.
+	// globalOnly is the new-search path: monolithic uses it to reset only the
+	// single in-flight ed2k slot while sparing running Kad searches. In
+	// multi-search each search is independent and the daemon finalizes any
+	// in-flight ed2k search itself, so starting a new search must NOT stop the
+	// previous one -- otherwise a second Kad search cancels the first. On a
+	// legacy daemon, fall through. globalOnly == false is the explicit Stop.
 	if (globalOnly && m_conn->ServerSupportsMultiSearch()) {
 		return;
 	}
@@ -3686,12 +3537,10 @@ void CSearchListRem::StopSearchById(wxUIntPtr searchID, bool andClose)
 			// Tab closed: stop tracking this search's lifecycle.
 			m_activeSearches.erase((uint32)searchID);
 			m_kadActive.erase((uint32)searchID);
-			// Also the backstop for a START whose reply never attributed
-			// itself (EC_OP_FAILED carries no ID -- see HandlePacket's
-			// EC_OP_FAILED branch): closing the tab the failed start left
-			// behind clears its entry, so the discovery deferral can't be
-			// held open for the rest of the session. A no-op for the normal
-			// case, where RemapSearch already erased it.
+			// Also the backstop for a START whose reply never attributed itself (an
+			// EC_OP_FAILED carries no ID): closing the tab the failed start left
+			// behind clears its entry, so the discovery deferral cannot be held
+			// open for the rest of the session. A no-op in the normal case.
 			m_pendingSearchStarts.erase((uint32)searchID);
 		}
 	}
@@ -3701,9 +3550,9 @@ void CSearchListRem::StopSearchById(wxUIntPtr searchID, bool andClose)
 
 bool CSearchListRem::IsKadSearch(uint32_t searchID) const
 {
-	// The "More" button applies only to a *running* Kad search (it greys out
-	// once the search completes). The flag is set from each search's per-id
-	// kind + lifecycle state in HandlePacket.
+	// The "More" button applies only to a *running* Kad search -- it greys out
+	// once the search completes. The flag is set from each search's per-id kind
+	// and lifecycle state in HandlePacket.
 	std::map<uint32, bool>::const_iterator it = m_kadActive.find(searchID);
 	return it != m_kadActive.end() && it->second;
 }
@@ -3715,14 +3564,13 @@ bool CSearchListRem::RequestMoreResults(uint32_t searchID)
 	}
 	// Ask the daemon to widen this Kad search (KADEMLIA_FIND_VALUE_MORE).
 	// SendRequest, not SendPacket: the daemon answers with EC_OP_MISC_DATA
-	// carrying EC_TAG_SEARCH_MORE_REASKABLE, and HandlePacket below greys the
-	// button for that search when it says the reasking is over for good. This
-	// used to be fire-and-forget and returned an optimistic true, so a user
-	// could press "More" repeatedly against a daemon that was doing nothing.
+	// carrying EC_TAG_SEARCH_MORE_REASKABLE, and HandlePacket greys the button
+	// for that search when the reasking is over for good. This used to be
+	// fire-and-forget with an optimistic true, so a user could press "More"
+	// repeatedly against a daemon that was doing nothing.
 	//
 	// Still returns true here: the verdict arrives asynchronously, and this
-	// return only says the request went out. The greying happens in the reply
-	// handler.
+	// return only says the request went out.
 	CECPacket req(EC_OP_SEARCH_REQUEST_MORE);
 	if (m_conn->ServerSupportsMultiSearch()) {
 		req.AddTag(CECTag(EC_TAG_SEARCH_ID, (uint32)searchID));
@@ -3734,20 +3582,17 @@ bool CSearchListRem::RequestMoreResults(uint32_t searchID)
 void CSearchListRem::RemapSearch(uint32 localID, uint32 daemonID)
 {
 	// Closes this ID's m_pendingSearchStarts window regardless of whether the
-	// local and daemon ids happen to match (the early return below is only
-	// about whether a rekey is needed, not whether the START round trip this
-	// tracks has completed). Keyed by ID, so a *browse* remap -- which also
-	// lands here, via BuildBrowseReply's own EC_OP_STRINGS -- erases nothing
-	// and can no longer lift the deferral for someone else's in-flight
-	// search start (got3nks, PR #680 review).
+	// local and daemon ids happen to match -- the early return below is only
+	// about whether a rekey is needed, not whether the START round trip has
+	// completed. Keyed by ID, so a *browse* remap, which also lands here, erases
+	// nothing and cannot lift the deferral for someone else's in-flight start.
 	m_pendingSearchStarts.erase(localID);
 	if (localID == daemonID) {
 		return;
 	}
-	// Rekey the optimistic tab (created with the local ID) to the daemon's
-	// ID so the union-poll results (tagged with the daemon ID) route to it.
-	// The START reply arrives well before any network results, so no result
-	// is misrouted in the interim.
+	// Rekey the optimistic tab (created with the local ID) to the daemon's ID so
+	// the union-poll results, tagged with the daemon ID, route to it. The START
+	// reply arrives well before any network results, so nothing is misrouted.
 	if (theApp->amuledlg && theApp->amuledlg->m_searchwnd) {
 		theApp->amuledlg->m_searchwnd->RekeySearch(localID, daemonID);
 	}
@@ -3758,12 +3603,11 @@ void CSearchListRem::RemapSearch(uint32 localID, uint32 daemonID)
 
 void CSearchListRem::RequestSearchList()
 {
-	// Capability-gated: a daemon predating #680 has no case for
-	// EC_OP_SEARCH_LIST, so the request would land in ProcessRequest2's
-	// unknown-opcode branch, which logs "invalid opcode received: 0x60" and
-	// trips a wxFAIL on the daemon. Sending nothing degrades to the pre-#680
-	// behaviour -- only searches this client started itself are listed -- which
-	// is exactly what such a daemon can support anyway.
+	// Capability-gated: an older daemon has no case for EC_OP_SEARCH_LIST, so the
+	// request would land in ProcessRequest2's unknown-opcode branch, which logs
+	// "invalid opcode received" and trips a wxFAIL on the daemon. Sending nothing
+	// degrades to listing only searches this client started, which is exactly
+	// what such a daemon can support anyway.
 	if (!m_conn->ServerSupportsSearchList()) {
 		return;
 	}
@@ -3816,9 +3660,9 @@ void CSearchListRem::ProcessUpdate(const CECTag *reply, CECPacket *full_req, int
 
 void CSearchListRem::ApplySearchProgress(const CECTag *src)
 {
-	// Per-search progress: STATUS is the first tag; EC_TAG_SEARCH_ID is
-	// echoed so we can update this specific tab's lifecycle. An expired
-	// search (evicted on the daemon) reports done so its "!" clears.
+	// Per-search progress: STATUS is the first tag; EC_TAG_SEARCH_ID is echoed so
+	// we can update this specific tab's lifecycle. An expired search, evicted on
+	// the daemon, reports done so its "!" clears.
 	const CECTag *idTag = src->GetTagByName(EC_TAG_SEARCH_ID);
 	const CECTag *browseTag = src->GetTagByName(EC_TAG_SEARCH_BROWSE_STATUS);
 	if (idTag && theApp->amuledlg && theApp->amuledlg->m_searchwnd) {
@@ -3836,31 +3680,24 @@ void CSearchListRem::ApplySearchProgress(const CECTag *src)
 		} else {
 			const bool expired = src->GetTagByName(EC_TAG_SEARCH_EXPIRED) != nullptr;
 			if (expired) {
-				// The daemon has discarded this search -- a deliberate
-				// close from another client, or LRU eviction -- so
-				// its tab here can only mislead: mapping this to the
-				// plain "finished" status (0xfffe) would make it
-				// indistinguishable from a search that ended
-				// normally, and "Download" on one of its results
-				// would silently do nothing (the daemon's m_results
-				// no longer has the hash). Close the tab locally
-				// instead -- CloseSearchTab does not send
-				// EC_OP_SEARCH_STOP, since the daemon already
-				// doesn't know this id (got3nks, PR #680 review).
-				// CSearchListRem::RemoveResults (called from there)
-				// also erases m_kadActive for this id.
+				// The daemon has discarded this search -- a deliberate close from
+				// another client, or LRU eviction -- so its tab here can only mislead:
+				// mapping this to the plain "finished" status would make it
+				// indistinguishable from a search that ended normally, and "Download"
+				// on one of its results would silently do nothing, since the daemon's
+				// m_results no longer has the hash. Close the tab locally instead --
+				// CloseSearchTab does not send EC_OP_SEARCH_STOP, since the daemon
+				// already does not know this id.
 				const uint32 sid = (uint32)idTag->GetInt();
 				m_activeSearches.erase(sid);
 				if (theApp->amuledlg && theApp->amuledlg->m_searchwnd) {
 					theApp->amuledlg->m_searchwnd->CloseSearchTab(sid);
 				}
 			} else {
-				// Cache whether this tab is a *running* Kad search so
-				// IsKadSearch can gate the "More" button — enabled
-				// only while the search runs, disabled once it
-				// completes (the progress lifecycle is the gate; no
-				// extra status). Update before the progress call,
-				// which refreshes that button for the visible tab.
+				// Cache whether this tab is a *running* Kad search so IsKadSearch can
+				// gate the "More" button -- enabled only while the search runs. Updated
+				// before the progress call, which refreshes that button for the
+				// visible tab.
 				const CECTag *kindTag = src->GetTagByName(EC_TAG_SEARCH_LIFECYCLE_KIND);
 				const CECTag *stateTag = src->GetTagByName(EC_TAG_SEARCH_LIFECYCLE_STATE);
 				if (kindTag && stateTag) {
@@ -3877,25 +3714,20 @@ void CSearchListRem::ApplySearchProgress(const CECTag *src)
 
 void CSearchListRem::HandlePacket(const CECPacket *packet)
 {
-	// Reply to EC_OP_SEARCH_REQUEST_MORE. Claimed by the TAG, not by the
-	// opcode alone: EC_OP_MISC_DATA is a generic envelope (search stop and
-	// GET_CONNSTATE use it too), and consuming every packet carrying that
-	// opcode would silently swallow any future request that both answers
-	// MISC_DATA and routes its handler here. Only a packet that actually
-	// carries the reaskable bit is ours; anything else falls through.
+	// Reply to EC_OP_SEARCH_REQUEST_MORE. Claimed by the TAG, not by the opcode
+	// alone: EC_OP_MISC_DATA is a generic envelope (search stop and
+	// GET_CONNSTATE use it too), and consuming every packet with that opcode
+	// would silently swallow any future request routed here.
 	//
-	// The tag is absent on a daemon older than it, which means "unknown",
-	// never "exhausted" -- so that case falls through too and keeps the
-	// previous optimistic behaviour. Present and false is terminal for this
-	// search: its reask budget is spent, or it is inside the stopping window
-	// Kad enters 20 s before a keyword search ends.
+	// The tag is absent on a daemon older than it, which means "unknown", never
+	// "exhausted" -- so that case falls through and keeps the previous
+	// optimistic behaviour. Present and false is terminal for this search.
 	//
-	// The id has to come off the packet rather than from the selected tab.
-	// The EC FIFO pairs replies to requests positionally, with no request id
-	// on the wire, so with two "More" presses in flight on different tabs the
-	// arrival order is the only thing distinguishing them -- and the user may
-	// have switched tabs meanwhile. The daemon echoes EC_TAG_SEARCH_ID for
-	// exactly this.
+	// The id has to come off the packet rather than from the selected tab. The
+	// EC FIFO pairs replies to requests positionally, with no request id on the
+	// wire, so with two "More" presses in flight on different tabs the arrival
+	// order is the only thing distinguishing them -- and the user may have
+	// switched tabs meanwhile.
 	if (const CECTag *reaskable = packet->GetTagByName(EC_TAG_SEARCH_MORE_REASKABLE)) {
 		const CECTag *idTag = packet->GetTagByName(EC_TAG_SEARCH_ID);
 		if (idTag && reaskable->GetInt() == 0 && theApp->amuledlg && theApp->amuledlg->m_searchwnd) {
@@ -3918,12 +3750,11 @@ void CSearchListRem::HandlePacket(const CECPacket *packet)
 					reported.insert((uint32)entry.GetInt());
 					ApplySearchProgress(&entry);
 				}
-				// The union carries no EC_TAG_SEARCH_EXPIRED: it reports the
-				// daemon's whole set, so a tab whose id is missing from it is
-				// one the daemon no longer has -- closed from another client,
-				// or evicted by the LRU. Same verdict the per-id poll reaches
-				// via the explicit tag, and it lands on the same cycle rather
-				// than whenever that particular id next gets polled.
+				// The union carries no EC_TAG_SEARCH_EXPIRED: it reports the daemon's
+				// whole set, so a tab whose id is missing from it is one the daemon no
+				// longer has -- closed from another client, or evicted by the LRU. Same
+				// verdict the per-id poll reaches via the explicit tag, and on the same
+				// cycle rather than whenever that id next gets polled.
 				//
 				// Snapshot first: CloseSearchTab erases from m_activeSearches.
 				const std::set<uint32> tracked = m_activeSearches;
@@ -3952,28 +3783,23 @@ void CSearchListRem::HandlePacket(const CECPacket *packet)
 			RemapSearch(refTag->GetInt(), idTag->GetInt());
 		}
 	} else if (packet->GetOpCode() == EC_OP_FAILED) {
-		// A rejected EC_OP_SEARCH_START or browse (EC_OP_FRIEND, via
-		// SendBrowseRequest -- both route their replies here). Both send
-		// EC_TAG_SEARCH_REF, the optimistic tab id, and the daemon now echoes
-		// it on the failure paths too, so the verdict is attributable: without
-		// it, StartNewSearch's unconditional "" return means OnBnClickedStart
-		// already took its success branch and created a tab, leaving a phantom
-		// tab plus an id stuck in m_pendingSearchStarts -- which disables
-		// discovery and costs an EC_OP_SEARCH_LIST round trip every tick until
-		// the user happens to close exactly that tab (got3nks, PR #680 review).
+		// A rejected EC_OP_SEARCH_START or browse -- both route their replies
+		// here. Both send EC_TAG_SEARCH_REF, the optimistic tab id, and the
+		// daemon echoes it on the failure paths too, so the verdict is
+		// attributable: without it, StartNewSearch's unconditional "" return
+		// means OnBnClickedStart already took its success branch and created a
+		// tab, leaving a phantom tab plus an id stuck in m_pendingSearchStarts.
 		//
 		// The branch also has to exist at all: without it an EC_OP_FAILED falls
 		// through to CRemoteContainer::HandlePacket, which hits wxFAIL in IDLE
-		// and, if a DoRequery happened to be outstanding, consumes that reply's
-		// state instead.
+		// and, if a DoRequery happened to be outstanding, consumes that reply.
 		if (const CECTag *refTag = packet->GetTagByName(EC_TAG_SEARCH_REF)) {
 			const uint32 localID = static_cast<uint32>(refTag->GetInt());
 			m_pendingSearchStarts.erase(localID);
-			// Report it and undo the optimistic tab/button state, through the
-			// same path the monolithic build uses for a rejected start. The
-			// daemon sends the reason as EC_TAG_STRING (a wxTRANSLATE'd
-			// literal, so translate it here like CAddLinkHandler does);
-			// without this the user clicks Search and nothing at all happens.
+			// Report it and undo the optimistic tab/button state, through the same
+			// path the monolithic build uses for a rejected start. The daemon sends
+			// the reason as EC_TAG_STRING (a wxTRANSLATE'd literal, so translate it
+			// here); without this the user clicks Search and nothing happens.
 			if (theApp->amuledlg && theApp->amuledlg->m_searchwnd) {
 				const CECTag *msgTag = packet->GetTagByName(EC_TAG_STRING);
 				const wxString reason = (msgTag && msgTag->IsString())
@@ -3986,24 +3812,18 @@ void CSearchListRem::HandlePacket(const CECPacket *packet)
 			// discovery branch), never by an optimistic one.
 		}
 	} else if (packet->GetOpCode() == EC_OP_SEARCH_LIST) {
-		// Reachability fix (#641): one entry per search the daemon currently
-		// holds, so a search this client never started locally -- one
-		// already open in another amulegui session, or restored from disk
-		// once persistence lands -- gets a tab here instead of silently
-		// having its results dropped by AddResult/UpdateResult (neither
-		// looks up a tab that doesn't exist yet). Skips any ID that already
-		// has a tab (a search this client itself started) rather than
-		// recreating it.
+		// One entry per search the daemon currently holds, so a search this
+		// client never started locally -- one already open in another amulegui
+		// session -- gets a tab here instead of silently having its results
+		// dropped by AddResult/UpdateResult, neither of which looks up a tab
+		// that does not exist yet. Skips any ID that already has a tab.
 		//
-		// Deferred whole, rather than per-id, while m_pendingSearchStarts
-		// is non-empty: this reply's ids reflect the daemon's state at send
-		// time, which can already include a search THIS client just
-		// started but hasn't been told the id of yet (see that member's
-		// declaration) -- and the ids in it are the client's *optimistic*
-		// ones, which by construction never match the daemon ids here, so
-		// there is nothing to match per-entry against. Re-arming for the
-		// next tick costs one extra poll, not correctness, since the set
-		// only stays non-empty for one EC round trip.
+		// Deferred whole, rather than per-id, while m_pendingSearchStarts is
+		// non-empty: this reply's ids reflect the daemon's state at send time,
+		// which can already include a search THIS client just started but has
+		// not been told the id of yet -- and the ids in that set are the
+		// client's *optimistic* ones, which never match the daemon ids here.
+		// Re-arming for the next tick costs one extra poll, not correctness.
 		if (!m_pendingSearchStarts.empty()) {
 			m_needSearchListRequery = true;
 		} else if (theApp->amuledlg && theApp->amuledlg->m_searchwnd) {
@@ -4013,35 +3833,30 @@ void CSearchListRem::HandlePacket(const CECPacket *packet)
 					continue;
 				}
 				const CECTag *nameTag = entry.GetTagByName(EC_TAG_SEARCH_NAME);
-				// "(0)" matches CSearchDlg::CreateNewTab's own callers (e.g.
-				// SearchDlg.cpp:1017) -- no leading "!" even for a Kad search:
-				// that marker is a live indicator normal callers seed only
-				// because they know at creation time they just started a Kad
-				// search, and it is only ever cleared (KadSearchEnd), never
-				// set, by the progress path below. Making this tab first-class
-				// in m_activeSearches is what lets that live path take over
-				// from here -- the "!" appears on the next progress poll if
-				// this is in fact a running Kad search, same as any other tab.
-				// Unselected: this tab appears on its own, driven by another
-				// client, so it must not pull the selection away from whatever
-				// the local user is looking at -- possibly mid-typing in the
-				// search box (got3nks, amule-org/amule#703).
-				// A browse the daemon is serving for someone else, or one
-				// still running from before this GUI attached, arrives here
-				// like any other search -- it shares the id space. Rebuild it
-				// as a browse tab rather than a search tab, which is what the
-				// kind is reported for. Daemons predating EC_SEARCH_BROWSE
-				// never send it, so the test simply fails there and the tab is
-				// built the way it always was.
+				// "(0)" matches CSearchDlg::CreateNewTab's own callers -- no leading
+				// "!" even for a Kad search: that marker is a live indicator normal
+				// callers seed only because they know at creation time they just
+				// started a Kad search, and it is only ever cleared, never set, by
+				// the progress path below. Making this tab first-class in
+				// m_activeSearches is what lets that live path take over.
+				//
+				// Unselected: this tab appears on its own, driven by another client,
+				// so it must not pull the selection away from whatever the local user
+				// is looking at -- possibly mid-typing in the search box.
+				//
+				// A browse the daemon is serving for someone else arrives here like
+				// any other search, since it shares the id space. Rebuild it as a
+				// browse tab rather than a search tab, which is what the kind is
+				// reported for. Daemons predating EC_SEARCH_BROWSE never send it, so
+				// the test simply fails there.
 				const CECTag *kindTag = entry.GetTagByName(EC_TAG_SEARCH_LIFECYCLE_KIND);
 				const CECTag *peerTag = entry.GetTagByName(EC_TAG_CLIENT);
 				const uint32 peerEcid = peerTag ? static_cast<uint32>(peerTag->GetInt()) : 0;
-				// Only with a real peer: EnsureBrowseTab keys on the ecid and
-				// an ecid of 0 is not "unknown peer", it is what every
-				// ordinary search tab carries -- GetBrowseList(0) would match
-				// the first of those and repoint it at this browse. A daemon
-				// that reports the kind without the peer therefore falls
-				// through to the plain tab, which is what it built before.
+				// Only with a real peer: EnsureBrowseTab keys on the ecid and an ecid of
+				// 0 is not "unknown peer", it is what every ordinary search tab carries
+				// -- GetBrowseList(0) would match the first of those and repoint it at
+				// this browse. A daemon that reports the kind without the peer falls
+				// through to the plain tab.
 				if (kindTag && kindTag->GetInt() == BrowseSearch && peerEcid) {
 					theApp->amuledlg->m_searchwnd->EnsureBrowseTab(peerEcid,
 						nameTag ? nameTag->GetStringData() : wxString(),
@@ -4053,21 +3868,16 @@ void CSearchListRem::HandlePacket(const CECPacket *packet)
 						sid,
 						false);
 				}
-				// Reachability fix (#641): without this, a discovered tab never
-				// gets polled for progress at all (Phase1Done only loops over
-				// m_activeSearches), so its hit count, progress bar and "!"
-				// marker would stay frozen forever -- exactly like a search
-				// this client started itself once RemapSearch runs.
+				// Without this, a discovered tab never gets polled for progress at all
+				// (Phase1Done only loops over m_activeSearches), so its hit count,
+				// progress bar and "!" marker would stay frozen forever.
 				m_activeSearches.insert(sid);
-				// Backfill (got3nks, PR #680 review): a result for this sid may
-				// already have arrived and been dropped by CreateItem (no tab
-				// existed yet to AddResult into), and the daemon's
-				// EC_DETAIL_INC_UPDATE diffing never re-sends an
-				// already-delivered result -- so without this, that result is
-				// lost permanently rather than merely delayed. The container
-				// (m_items) still holds it: CreateItem always keeps every
-				// CSearchFile it builds, tab or no tab. Walk it now, once, for
-				// this newly-discovered sid -- no extra EC traffic.
+				// Backfill: a result for this sid may already have arrived and been
+				// dropped by CreateItem, no tab existing yet to AddResult into, and the
+				// daemon's INC_UPDATE diffing never re-sends an already-delivered
+				// result -- so without this it is lost permanently rather than merely
+				// delayed. The container still holds it: CreateItem always keeps every
+				// CSearchFile it builds, tab or no tab.
 				for (CSearchFile *file : m_items) {
 					if (file->GetSearchID() == sid) {
 						theApp->amuledlg->m_searchwnd->AddResult(file);
@@ -4141,23 +3951,20 @@ CSearchFile *CSearchListRem::CreateItem(const CEC_SearchFile_Tag *tag)
 	CSearchFile *file = new CSearchFile(tag);
 	ProcessItemUpdate(tag, file);
 
-	// Reachability fix (#641): a result bearing a search ID with no tab
-	// is exactly the symptom EC_OP_SEARCH_LIST exists to fix -- ask for
-	// the list again on the next poll so a tab gets created for it
-	// (CSearchListRem::HandlePacket's EC_OP_SEARCH_LIST branch) instead
-	// of polling that op every tick regardless of whether anything new
-	// showed up.
+	// A result bearing a search ID with no tab is exactly the symptom
+	// EC_OP_SEARCH_LIST exists to fix -- ask for the list again on the next poll
+	// so a tab gets created for it, instead of polling that op every tick
+	// regardless of whether anything new showed up.
 	if (file->m_searchID != 0 && !theApp->amuledlg->m_searchwnd->GetSearchList(file->m_searchID)) {
 		m_needSearchListRequery = true;
 	}
 
 	// A result whose tag names a parent this client has not built yet cannot be
 	// grouped: the constructor's lookup came back empty, so it stays parentless
-	// and is indexed as a top-level row that nothing ever re-parents. The
-	// daemon emits a parent before its children, so this should not happen --
-	// log it rather than assert, since the trigger would be the wire order
-	// rather than a bug on this side, and losing the result would be worse than
-	// showing it ungrouped.
+	// and is indexed as a top-level row that nothing ever re-parents. The daemon
+	// emits a parent before its children, so this should not happen -- log it
+	// rather than assert, since the trigger would be the wire order rather than
+	// a bug on this side, and losing the result would be worse.
 	if (tag->ParentID() != 0 && file->GetParent() == nullptr) {
 		AddDebugLogLineN(logSearch,
 			CFormat("Search result %u names parent %u, which has not arrived; "
@@ -4165,10 +3972,10 @@ CSearchFile *CSearchListRem::CreateItem(const CEC_SearchFile_Tag *tag)
 				file->ECID() % tag->ParentID());
 	}
 
-	// Make the result visible to the GUI: the search model builds its rows
-	// from GetSearchResults(), so a result that is not indexed here shows up
-	// nowhere, however correctly it arrived over EC. Grouped children are
-	// dropped by IndexResult() itself, which is where that rule lives.
+	// Make the result visible to the GUI: the search model builds its rows from
+	// GetSearchResults(), so a result that is not indexed here shows up nowhere,
+	// however correctly it arrived over EC. Grouped children are dropped by
+	// IndexResult() itself, which is where that rule lives.
 	IndexResult(file);
 
 	theApp->amuledlg->m_searchwnd->AddResult(file);
@@ -4218,11 +4025,9 @@ void CSearchListRem::ProcessItemUpdate(const CEC_SearchFile_Tag *tag, CSearchFil
 
 	// The daemon has always sent these for search results -- CEC_SearchFile_Tag
 	// derives from CEC_SharedFile_Tag, whose base ctor emits them -- and this
-	// walker never read them back. So amulegui showed an empty Length /
-	// Bitrate / Codec for every hit while the monolithic client filled those
-	// columns in from the same server reply. CreateItem calls this immediately
-	// after constructing, so a result is decoded on arrival as well as on
-	// update.
+	// walker never read them back, so amulegui showed an empty Length / Bitrate
+	// / Codec for every hit while the monolithic client filled those columns in
+	// from the same server reply.
 	DecodeMediaTags(tag, file);
 
 	if (file->m_sourceCount != sourceCount || file->m_completeSourceCount != completeSourceCount ||
@@ -4239,15 +4044,12 @@ bool CSearchListRem::Phase1Done(const CECPacket *WXUNUSED(reply))
 	// nothing, and an unconditional union request would turn that into a
 	// roundtrip every cycle.
 	if (m_conn->ServerSupportsSearchProgressUnion() && !m_activeSearches.empty()) {
-		// One request covers every open tab: the daemon answers with one
-		// child per search. Costs a single round trip no matter how many are
-		// open, where the per-id path below sends one each -- and kept sending
-		// them for searches that had long finished, since a tab only leaves
-		// m_activeSearches when it is closed.
-		//
-		// The ids ride along so the daemon keeps bumping exactly the searches
-		// this client still has open in its LRU, as the per-id poll did. An id
-		// missing from the reply is one the daemon no longer holds.
+		// One request covers every open tab: the daemon answers with one child per
+		// search. Costs a single round trip no matter how many are open, where the
+		// per-id path below sends one each -- and kept sending them for searches
+		// that had long finished, since a tab only leaves m_activeSearches when it
+		// is closed. The ids ride along so the daemon keeps bumping exactly the
+		// searches this client still has open in its LRU.
 		CECPacket progress_req(EC_OP_SEARCH_PROGRESS);
 		for (uint32 id : m_activeSearches) {
 			progress_req.AddTag(CECTag(EC_TAG_SEARCH_ID, id));
@@ -4273,9 +4075,9 @@ bool CSearchListRem::Phase1Done(const CECPacket *WXUNUSED(reply))
 
 void CSearchListRem::RemoveResults(wxUIntPtr nSearchID)
 {
-	// The index only borrows: the CRemoteContainer owns these results and
-	// frees them through DeleteItem(), so dropping the index is all that is
-	// needed here -- deleting would double-free.
+	// The index only borrows: the CRemoteContainer owns these results and frees
+	// them through DeleteItem(), so dropping the index is all that is needed --
+	// deleting would double-free.
 	DropResultIndex(nSearchID);
 	m_kadActive.erase((uint32)nSearchID);
 }
@@ -4315,10 +4117,8 @@ wxString CAICHHash::GetString() const
 	return EncodeBase32(m_abyBuffer, HASHSIZE);
 }
 
-//
-// Those functions are virtual. So even they don't get called they must
-// be defined so linker will be happy
-//
+// These functions are virtual, so even though they are never called they must
+// be defined for the linker.
 CPacket *CKnownFile::CreateSrcInfoPacket(
 	const CUpDownClient *, uint8 /*byRequestedVersion*/, uint16 /*nRequestedOptions*/)
 {
@@ -4407,15 +4207,14 @@ void CStatTreeRem::HandlePacket(const CECPacket *p)
 
 namespace
 {
-// See the comment in DoRequery: the daemon's newest history range holds
-// this many records at its finest spacing, so this is how much it can
-// serve before the answers stop lining up with the scale we asked for.
-// Tracks CStatistics::GetPointsPerRange() and has to be raised with it.
+// See the comment in DoRequery: the daemon's newest history range holds this
+// many records at its finest spacing, so this is how much it can serve before
+// the answers stop lining up with the scale we asked for. Tracks
+// CStatistics::GetPointsPerRange() and has to be raised with it.
 //
-// Against an older daemon, whose ranges are shallower, a request this
-// deep runs off the end of the resolution it was asked for and the far
-// left of the first backfill is drawn time-compressed. It corrects
-// itself as live points replace the backfilled ones.
+// Against an older daemon, whose ranges are shallower, a request this deep runs
+// off the end of the resolution it asked for and the far left of the first
+// backfill is drawn time-compressed. It corrects itself as live points arrive.
 const uint16 kMaxHistoryPoints = 1800;
 
 } // namespace
@@ -4428,43 +4227,35 @@ void CStatGraphRem::DoRequery()
 	// response only carries points the GUI hasn't drawn yet.
 	// (GetHistoryForWeb is amuleweb's near-identical twin, not this path.)
 	request.AddTag(CECTag(EC_TAG_STATSGRAPH_LAST, m_lastTimestamp));
-	// Seconds between points. This has to be the same step the graphs are
-	// going to plot at -- COScopeCtrl gets it from the "Update delay"
-	// preference via CStatisticsDlg::SetUpdatePeriod, and asks
-	// CStatistics::GetHistory for points that far apart. Requesting a
-	// fixed 1 s here (which is what this used to do) meant amulegui
-	// honoured the preference when drawing and ignored it when fetching,
-	// so the graphs only ever had the daemon's 1-second range behind them
-	// however far back the user had asked to see. Monolithic amule has no
-	// equivalent step because it reads the same history directly.
+	// Seconds between points. This has to be the same step the graphs are going
+	// to plot at -- COScopeCtrl gets it from the "Update delay" preference and
+	// asks CStatistics::GetHistory for points that far apart. Requesting a fixed
+	// 1 s here meant amulegui honoured the preference when drawing and ignored
+	// it when fetching, so the graphs only ever had the daemon's 1-second range
+	// behind them however far back the user had asked to see.
 	const uint16 nScale = std::max<uint16>(thePrefs::GetTrafficOMeterInterval(), 1);
 	if ((double)nScale != m_sScale) {
-		// The ring keeps one record per requested interval, so what is in
-		// it is only meaningful at the scale it was fetched at: replotting
-		// 8 s records on a 3 s axis would place them at the wrong times.
-		// Drop it and let it refill at the new resolution. Deliberately
-		// without resetting m_lastTimestamp -- asking for a fresh backfill
-		// here would race the reply still in the air from the previous
-		// scale, whose points would then be timestamped with this one.
+		// The ring keeps one record per requested interval, so what is in it is
+		// only meaningful at the scale it was fetched at: replotting 8 s records
+		// on a 3 s axis would place them at the wrong times. Drop it and let it
+		// refill. Deliberately without resetting m_lastTimestamp -- asking for a
+		// fresh backfill here would race the reply still in the air from the
+		// previous scale, whose points would then be timestamped with this one.
 		theApp->m_statistics->ClearHistory();
 		m_sScale = (double)nScale;
 	}
 	request.AddTag(CECTag(EC_TAG_STATSGRAPH_SCALE, nScale));
-	// Upper bound on points per reply. In the steady state the daemon
-	// only sends what is newer than the timestamp above, i.e. one point
-	// per poll, so this bites in exactly two cases: the first poll after
-	// connecting, where m_lastTimestamp is still 0 and the daemon serves
-	// its whole history, and catching up after a stall or a reconnect.
-	// Both then arrive in a single round-trip and the graphs open with
-	// history behind them instead of filling in over the next minutes.
+	// Upper bound on points per reply. In the steady state the daemon only sends
+	// what is newer than the timestamp above, i.e. one point per poll, so this
+	// bites in exactly two cases: the first poll after connecting, where
+	// m_lastTimestamp is still 0 and the daemon serves its whole history, and
+	// catching up after a stall or a reconnect. Both then arrive in a single
+	// round trip and the graphs open with history behind them.
 	//
-	// The value is the depth of the daemon's 1-second history range:
-	// CStatistics allocates GetPointsPerRange() records per range and
-	// keeps only the newest range at 1 s spacing (the ones behind it go
-	// to 2 s, 4 s, ...). Asking for more would return records that are
-	// not 1 s apart while HandlePacket reconstructs their timestamps
-	// assuming they are, which stretches the left of the plot rather
-	// than showing more of the past.
+	// The value is the depth of the daemon's 1-second history range. Asking for
+	// more would return records that are not 1 s apart while HandlePacket
+	// reconstructs their timestamps assuming they are, which stretches the left
+	// of the plot rather than showing more of the past.
 	request.AddTag(CECTag(EC_TAG_STATSGRAPH_WIDTH, std::min(kMaxHistoryPoints, m_nDaemonDepth)));
 	m_conn->SendRequest(this, &request);
 }
@@ -4483,12 +4274,11 @@ void CStatGraphRem::HandlePacket(const CECPacket *p)
 	}
 	m_lastTimestamp = tsTag->GetDoubleData();
 
-	// How many points this daemon can answer with before it starts
-	// repeating a record. Absent from daemons predating the tag, which is
-	// exactly the case the conservative default covers. Learning that it
-	// can serve more than we asked for is worth a one-off refetch: the
-	// ring only accepts points newer than what it holds, so the deeper
-	// history would never arrive otherwise.
+	// How many points this daemon can answer with before it starts repeating a
+	// record. Absent from daemons predating the tag, which is exactly the case
+	// the conservative default covers. Learning that it can serve more than we
+	// asked for is worth a one-off refetch: the ring only accepts points newer
+	// than what it holds, so the deeper history would never arrive otherwise.
 	const CECTag *depthTag = p->GetTagByName(EC_TAG_STATSGRAPH_DEPTH);
 	if (depthTag) {
 		const uint16 nDepth = std::max<uint16>((uint16)depthTag->GetInt(), 1);
@@ -4508,10 +4298,10 @@ void CStatGraphRem::HandlePacket(const CECPacket *p)
 	size_t dataLen = dataTag->GetTagDataLen();
 	size_t numPoints = dataLen / (4 * sizeof(uint32));
 
-	// EC_TAG_STATSGRAPH_DATA_CONN (new tag, optional) carries the matching
-	// N x (cntUploads, cntDownloads) uint32 pairs so the Connections scope
-	// can show monolithic amule's 3-line breakdown. Absent when talking to
-	// a pre-extension daemon — fall back to flat 0 lines for those slots.
+	// EC_TAG_STATSGRAPH_DATA_CONN (optional) carries the matching N x
+	// (cntUploads, cntDownloads) uint32 pairs so the Connections scope can show
+	// monolithic amule's 3-line breakdown. Absent against a pre-extension
+	// daemon -- fall back to flat 0 lines for those slots.
 	const CECTag *connTag = p->GetTagByName(EC_TAG_STATSGRAPH_DATA_CONN);
 	const uint8_t *connRaw = NULL;
 	size_t connPoints = 0;
@@ -4520,9 +4310,8 @@ void CStatGraphRem::HandlePacket(const CECPacket *p)
 		connPoints = connTag->GetTagDataLen() / (2 * sizeof(uint32));
 	}
 
-	// Session totals — let amulegui compute the same
-	// kBytesReceived / sTimestamp session average monolithic plots.
-	// Absent on old daemons; fall back to 0 (Session line stays flat).
+	// Session totals -- let amulegui compute the same kBytesReceived /
+	// sTimestamp session average monolithic plots. Absent on old daemons.
 	const CECTag *sesDlTag = p->GetTagByName(EC_TAG_STATSGRAPH_SESSION_DL);
 	const CECTag *sesUlTag = p->GetTagByName(EC_TAG_STATSGRAPH_SESSION_UL);
 	const CECTag *sesKadTag = p->GetTagByName(EC_TAG_STATSGRAPH_SESSION_KAD);
@@ -4537,35 +4326,31 @@ void CStatGraphRem::HandlePacket(const CECPacket *p)
 
 	// Cumulative session counters for each point in the reply.
 	//
-	// ComputeAverages derives the session-average trend as
-	// kBytesReceived / sTimestamp, so it needs the cumulative figure as
-	// it stood at each point, while the daemon sends only the newest.
-	// The rest are reconstructed from the per-point rates this same reply
-	// carries -- a rectangle-rule integral, so it carries a few percent
-	// of error against a spiky signal.
+	// ComputeAverages derives the session-average trend as kBytesReceived /
+	// sTimestamp, so it needs the cumulative figure as it stood at each point,
+	// while the daemon sends only the newest. The rest are reconstructed from
+	// the per-point rates this same reply carries -- a rectangle-rule integral,
+	// so it carries a few percent of error against a spiky signal.
 	//
-	// Which direction to integrate matters, because that error is divided
-	// by the point's timestamp. Going backwards from the newest puts it
-	// at the oldest point, and when a reply reaches back near the start of
-	// the daemon's session that divisor is a few seconds: a 3% error on
-	// several GB then reads as tens of MB/s where the truth is nearly
-	// zero, and past the session start the divisor goes negative and the
-	// trend flips sign entirely.
+	// Which direction to integrate matters, because that error is divided by the
+	// point's timestamp. Going backwards from the newest puts it at the oldest
+	// point, and when a reply reaches back near the start of the daemon's
+	// session that divisor is a few seconds: a 3% error on several GB reads as
+	// tens of MB/s where the truth is nearly zero, and past the session start
+	// the divisor goes negative and the trend flips sign.
 	//
 	// So pick the end that is known exactly. If the reply spans the whole
-	// session the oldest point's total is zero by definition, and
-	// integrating forward from there leaves the error at the newest
-	// point, where it is divided by the full session length. Otherwise
-	// every timestamp in the window is large and backwards from the
-	// daemon's own newest figure is both exact where it starts and
-	// harmless where it ends.
+	// session the oldest point's total is zero by definition, and integrating
+	// forward leaves the error at the newest point, divided by the full session
+	// length. Otherwise every timestamp in the window is large and backwards
+	// from the daemon's own newest figure is exact where it starts.
 	std::vector<double> aKBytesDl(numPoints, 0.0);
 	std::vector<double> aKBytesUl(numPoints, 0.0);
 	std::vector<double> aKadTotal(numPoints, 0.0);
-	// Within one sample of zero means the oldest point IS the session's
-	// first sample -- the daemon answers with what it has, so a reply that
-	// reaches the start stops there rather than running past it. Testing
-	// for a timestamp at or below zero would almost never fire.
+	// Within one sample of zero means the oldest point IS the session's first
+	// sample -- the daemon answers with what it has, so a reply that reaches the
+	// start stops there rather than running past it. Testing for a timestamp at
+	// or below zero would almost never fire.
 	const double oldestTs = m_lastTimestamp - (double)(numPoints - 1) * m_sScale;
 	const bool spansSessionStart = oldestTs <= m_sScale;
 	{
@@ -4627,16 +4412,14 @@ void CStatGraphRem::HandlePacket(const CECPacket *p)
 		GraphUpdateInfo update;
 		update.timestamp = m_lastTimestamp;
 		// Slot layout matches CStatistics::GetPointsForUpdate:
-		//   downloads/uploads/kadnodes — [0] session avg, [1] running avg, [2] current.
-		//   connections — [0] cntUploads, [1] cntConnections, [2] cntDownloads.
-		// Only timestamp and kadnodes[2] are read now that the graphs draw
-		// from the history rather than from the point handed to them; the
-		// rest is filled to keep the struct's contract with the monolithic
-		// producer. In particular the running-average slots are left at
-		// their per-point value: the trend the graphs actually plot is
-		// rebuilt by CStatistics::ComputeAverages, which sizes its window
-		// from the sample step and so stays right whatever scale we asked
-		// the daemon for.
+		//   downloads/uploads/kadnodes -- [0] session avg, [1] running avg, [2] current.
+		//   connections -- [0] cntUploads, [1] cntConnections, [2] cntDownloads.
+		// Only timestamp and kadnodes[2] are read now that the graphs draw from the
+		// history rather than from the point handed to them; the rest is filled to
+		// keep the struct's contract with the monolithic producer. The
+		// running-average slots stay at their per-point value: the trend the graphs
+		// plot is rebuilt by CStatistics::ComputeAverages, which sizes its window
+		// from the sample step.
 		update.downloads[0] = sessionDl;
 		update.downloads[1] = dl_kbps;
 		update.downloads[2] = dl_kbps;
@@ -4654,31 +4437,24 @@ void CStatGraphRem::HandlePacket(const CECPacket *p)
 			m_peakConnections = conn;
 		}
 
-		// Mirror the decoded point into the client-side history ring
-		// so COScopeCtrl (which draws straight from the history, and is
-		// shared with monolithic) can replay across tab switches and
-		// auto-rescale wipes without another daemon round-trip. This has
-		// to happen before the graphs are told about the sample, which is
-		// also the order the monolithic build sees: there,
-		// CStatistics::GetPointsForUpdate reads the record back out of
-		// the history to build update. Field mapping mirrors
-		// GetPointsForUpdate so the same GetHistory + ComputeAverages
-		// code paths read it back correctly:
-		//   kBytes{Received,Sent} / kadNodesTotal are stored as
-		//   (session rate * timestamp) so ComputeAverages's
-		//   "kValueRun / sTimestamp" recovers the session-avg trend.
-		// Per-point timestamps are reconstructed from the batch by
-		// stepping back from m_lastTimestamp at 1 s spacing (matches
-		// the scale we request in DoRequery).
+		// Mirror the decoded point into the client-side history ring so
+		// COScopeCtrl -- which draws straight from the history, and is shared with
+		// monolithic -- can replay across tab switches and auto-rescale wipes
+		// without another daemon round trip. This has to happen before the graphs
+		// are told about the sample, which is also the order the monolithic build
+		// sees. Field mapping mirrors GetPointsForUpdate so the same GetHistory +
+		// ComputeAverages paths read it back correctly: kBytes{Received,Sent} /
+		// kadNodesTotal are stored as (session rate * timestamp), so
+		// "kValueRun / sTimestamp" recovers the session-avg trend. Per-point
+		// timestamps are reconstructed by stepping back from m_lastTimestamp.
 		const double pointTs = m_lastTimestamp - (double)(numPoints - 1 - i) * m_sScale;
 
-		// A reply can reach back past the moment the daemon's session
-		// began -- its history list is preallocated, so it answers with
-		// as many points as were asked for even when fewer exist. Those
-		// points reconstruct to a timestamp at or before zero, and
-		// ComputeAverages divides by it: at zero the session average is
-		// undefined and below it the whole trend changes sign. Drop them
-		// rather than store a value that cannot be drawn honestly.
+		// A reply can reach back past the moment the daemon's session began -- its
+		// history list is preallocated, so it answers with as many points as were
+		// asked for even when fewer exist. Those points reconstruct to a timestamp
+		// at or below zero, and ComputeAverages divides by it: at zero the session
+		// average is undefined and below it the whole trend changes sign. Drop
+		// them rather than store a value that cannot be drawn honestly.
 		if (pointTs <= 0.0) {
 			continue;
 		}
@@ -4704,9 +4480,7 @@ void CStatGraphRem::HandlePacket(const CECPacket *p)
 
 CamuleRemoteGuiApp *theApp;
 
-//
-// since gui is not linked with amule.cpp - define events here
-//
+// The GUI is not linked with amule.cpp, so define the events here.
 wxDEFINE_EVENT(wxEVT_CORE_FINISHED_HTTP_DOWNLOAD, wxEvent);
 wxDEFINE_EVENT(wxEVT_CORE_SOURCE_DNS_DONE, wxEvent);
 wxDEFINE_EVENT(wxEVT_CORE_UDP_DNS_DONE, wxEvent);

--- a/src/amule-remote-gui.h
+++ b/src/amule-remote-gui.h
@@ -131,20 +131,17 @@ public:
 	void SendToRemote();
 
 	// Shared-directory roots. Unlike the rest of the preferences these are a
-	// variable-length list whose apply rewrites files and triggers a rescan,
-	// so they ride their own ops rather than the prefs packet. The replies go
-	// to a dedicated handler (HandlePacket above static_casts everything it
-	// receives to CEC_Prefs_Packet); results land in this object's
-	// shareddir_*_list members, which outlive the Preferences dialog.
+	// variable-length list whose apply rewrites files and triggers a rescan, so
+	// they ride their own ops rather than the prefs packet. The replies go to a
+	// dedicated handler; results land in this object's shareddir_*_list members,
+	// which outlive the Preferences dialog.
 	void LoadSharedDirsRemote();
 	void SendSharedDirsToRemote();
 };
 
-//
-// T - type if item in container
-// I - type of id of item
+// T - type of item in the container
+// I - type of the item's id
 // G - type of tag used to create/update items
-//
 template <class T, class I, class G = CECTag> class CRemoteContainer : public CECPacketHandlerBase
 {
 protected:
@@ -534,12 +531,11 @@ public:
 	uint32 GetItemID(CClientRef *);
 	void ProcessItemUpdate(const CEC_UpDownClient_Tag *, CClientRef *);
 
-	// Null out CUpDownClient::m_uploadingfile / m_reqfile on every
-	// client still pointing at `file`. Called by the broadcast
-	// handler MuleNotify::KnownFileBeingDestroyed before a
-	// CKnownFile is freed, so the dangling pointers don't get
-	// dereffed by a later CUpDownClientListRem::DeleteItem (the
-	// #748 / #755 UAF family). Pointer-value comparison only.
+	// Null out CUpDownClient::m_uploadingfile / m_reqfile on every client still
+	// pointing at `file`. Called by the broadcast handler
+	// MuleNotify::KnownFileBeingDestroyed before a CKnownFile is freed, so the
+	// dangling pointers are not dereffed by a later DeleteItem. Pointer-value
+	// comparison only.
 	void DropReferencesTo(const CKnownFile *file);
 };
 
@@ -552,17 +548,13 @@ public:
 
 	CPartFile *GetFileByID(uint32 id);
 
-	//
 	// User actions
-	//
 	void Prio(CPartFile *file, uint8 prio);
 	void AutoPrio(CPartFile *file, bool flag);
 	void Category(CPartFile *file, uint8 cat);
 
 	void SendFileCommand(CPartFile *file, ec_tagname_t cmd);
-	//
 	// Actions
-	//
 	void StopUDPRequests() {}
 	void AddFileLinkToDownload(CED2KFileLink *, uint8);
 	bool AddLink(const wxString &link, uint8 category = 0);
@@ -584,45 +576,38 @@ public:
 
 	void SetFilePrio(CKnownFile *file, uint8 prio);
 
-	//
 	// Actions
-	//
 	void Reload(bool sendtoserver = true, bool firstload = false);
 	bool RenameFile(CKnownFile *file, const CPath &newName);
 	void SetFileCommentRating(CKnownFile *file, const wxString &newComment, int8 newRating);
 	void VerifyLocalData(const CKnownFile *file) const;
 
 	// Mirrors CSharedFileList's signature so the one call site in
-	// CSharedFilesCtrl compiles for both binaries -- muleappgui is built once
-	// and carries no build-variant defines, so the split has to live in the
-	// type of theApp->sharedfiles rather than in an #ifdef at the call site.
+	// CSharedFilesCtrl compiles for both binaries -- muleappgui is built once and
+	// carries no build-variant defines, so the split has to live in the type of
+	// theApp->sharedfiles rather than in an #ifdef at the call site.
 	//
-	// Returns true when the request was SENT, not when anything was probed:
-	// the daemon decides eligibility and reports the outcome in its own log.
-	// The monolithic form can answer for real because it schedules inline.
+	// Returns true when the request was SENT, not when anything was probed: the
+	// daemon decides eligibility and reports the outcome in its own log.
 	bool RefreshMediaMetadata(const CMD4Hash &hash);
 	unsigned RefreshMediaMetadata(const std::vector<CMD4Hash> &hashes);
 	void SearchKadNotes(CAbstractFile *file);
 	void CopyFileList(std::vector<CKnownFile *> &out_list) const;
 
-	// Remote-side shim for the daemon's cancellable-progress Reload
-	// added in the shared-dirs deferred-apply flow. The actual file
-	// walk happens on amuled; here we just fall through to the
-	// existing EC-driven Reload(sendtoserver=true) and ignore the
-	// progress callback. Returns true (never "cancelled") because
-	// the local-thread part of the operation is essentially instant.
+	// Remote-side shim for the daemon's cancellable-progress Reload. The actual
+	// file walk happens on amuled; here we fall through to the existing EC-driven
+	// Reload(sendtoserver=true) and ignore the progress callback. Returns true --
+	// never "cancelled" -- because the local-thread part is essentially instant.
 	bool Reload(std::function<bool(size_t)> /* yieldCb */)
 	{
 		Reload();
 		return true;
 	}
 
-	// Remote-side shim for the daemon's deferred-reload request. On the
-	// daemon this defers the walk to the next Process() tick so an EC
-	// handler need not block on it; here Reload() only posts
-	// EC_OP_SHAREDFILES_RELOAD and returns, so it is already the
-	// non-blocking thing RequestReload() exists to provide. amuled then
-	// defers on its own side when it receives the packet.
+	// Remote-side shim for the daemon's deferred-reload request. On the daemon
+	// this defers the walk to the next Process() tick so an EC handler need not
+	// block on it; here Reload() only posts EC_OP_SHAREDFILES_RELOAD and returns,
+	// so it is already the non-blocking thing RequestReload() exists to provide.
 	void RequestReload() { Reload(); }
 
 	// Always false on the remote side: there is no local walk to owe. When a
@@ -630,9 +615,8 @@ public:
 	// schedules its own reload; the GUI must not also run or announce one.
 	bool IsReloadPending() const { return false; }
 
-	// Remote-side no-op. The actual watcher lives on amuled and is
-	// driven there by the EC-synced AutoRescanSharedDirs pref; on the
-	// GUI side there is nothing to enable/disable locally.
+	// Remote-side no-op. The actual watcher lives on amuled and is driven there
+	// by the EC-synced AutoRescanSharedDirs pref.
 	void EnableDirectoryWatcher(bool /* enable */) {}
 };
 

--- a/src/amule.cpp
+++ b/src/amule.cpp
@@ -302,11 +302,10 @@ void CamuleApp::EnableIP2Country(bool startup)
 		}
 		m_IP2Country->Enable();
 		// Auto-update refresh from the selected source so the user sees current
-		// data without opening Preferences. Fires only at startup / a local
-		// enable toggle (startup=true) — NOT on every remote prefs-apply, which
-		// would download on each amulegui OK and, alongside an explicit "Update
-		// now", double the request. First-run / missing-file is handled inside
-		// Enable() regardless.
+		// data without opening Preferences. Fires only at startup or a local
+		// enable toggle -- NOT on every remote prefs-apply, which would download
+		// on each amulegui OK and, alongside an explicit "Update now", double the
+		// request. First-run / missing-file is handled inside Enable() regardless.
 		if (startup && thePrefs::IsGeoIPAutoUpdate() && m_IP2Country->IsEnabled()) {
 			m_IP2Country->Update();
 		}
@@ -321,9 +320,9 @@ void CamuleApp::EnableIP2Country(bool) {}
 int CamuleApp::OnExit()
 {
 	// Guard against double-entry: on macOS the EVT_END_SESSION handler calls
-	// OnExit() explicitly (so the destructor chain runs before Cocoa
-	// terminates the process), and wxEntry may also call it on event-loop
-	// teardown. Without the guard the queues would be double-freed.
+	// OnExit() explicitly, so the destructor chain runs before Cocoa terminates
+	// the process, and wxEntry may also call it on event-loop teardown. Without
+	// the guard the queues would be double-freed.
 	static bool s_exitDone = false;
 	if (s_exitDone) {
 		return 0;
@@ -335,26 +334,17 @@ int CamuleApp::OnExit()
 	}
 
 	// Flush wx's pending-delete queue before tearing down wxConfig:
-	// CamuleGuiApp::ShutDown calls amuledlg->Destroy(), which is lazy
-	// (it schedules deletion on the main-loop tail). On the CMD+Q path
-	// the event loop drains that queue naturally before OnExit runs;
-	// on the macOS Dock right-click → Quit path CamuleGuiApp::OnEndSession
-	// reaches OnExit directly, so without an explicit drain here the
-	// CamuleDlg destructor chain never runs against a live wxConfig, and
-	// whatever it still persists from there is silently lost. (Column
-	// widths and sort orders no longer rely on it: CMuleDataViewCtrl
-	// writes those eagerly on every resize, sort and show/hide.)
+	// CamuleGuiApp::ShutDown calls amuledlg->Destroy(), which is lazy. On the
+	// CMD+Q path the event loop drains that queue naturally before OnExit runs;
+	// on the macOS Dock right-click -> Quit path CamuleGuiApp::OnEndSession
+	// reaches OnExit directly, so without an explicit drain here the CamuleDlg
+	// destructor chain never runs against a live wxConfig, and whatever it
+	// still persists from there is silently lost.
 	DeletePendingObjects();
 
-	// From wxWidgets docs, wxConfigBase:
-	// ...
-	// Note that you must delete this object (usually in wxApp::OnExit)
-	// in order to avoid memory leaks, wxWidgets won't do it automatically.
-	//
-	// As it happens, you may even further simplify the procedure described
-	// above: you may forget about calling Set(). When Get() is called and
-	// there is no current object, it will create one using Create() function.
-	// To disable this behaviour DontCreateOnDemand() is provided.
+	// From the wxConfigBase docs: this object must be deleted, usually in
+	// wxApp::OnExit, or wxWidgets leaks it -- Get() creates one on demand when
+	// none is current, unless DontCreateOnDemand() was called.
 	delete wxConfigBase::Set((wxConfigBase *)NULL);
 
 	// Save credits
@@ -393,10 +383,10 @@ int CamuleApp::OnExit()
 	delete serverlist;
 	serverlist = NULL;
 
-	// Persist search results for the next startup (issue #641 Phase 3),
-	// while downloadqueue/knownfiles/canceledfiles (needed to recompute
-	// download status on the next load) and searchlist itself are all still
-	// alive -- this must run before the delete below.
+	// Persist search results for the next startup, while downloadqueue /
+	// knownfiles / canceledfiles -- needed to recompute download status on the
+	// next load -- and searchlist itself are all still alive. Must run before
+	// the delete below.
 	if (searchlist) {
 		searchlist->StoreSearches();
 	}
@@ -432,12 +422,11 @@ int CamuleApp::OnExit()
 	delete canceledfiles;
 	canceledfiles = NULL;
 
-	// Immediately before clientlist, and after everything that destroys
-	// clients on its way out -- serverconnect, listensocket, clientudp. Each
-	// of those reaps peers through CClientList::RemoveClient, which asks the
-	// manager to let go of any browse of them; deleting it earlier left that
-	// call reaching through a dangling pointer whenever a peer socket was
-	// still open at exit, which is the ordinary case.
+	// Immediately before clientlist, and after everything that destroys clients
+	// on its way out -- serverconnect, listensocket, clientudp. Each of those
+	// reaps peers through CClientList::RemoveClient, which asks the manager to
+	// let go of any browse of them; deleting it earlier left that call reaching
+	// through a dangling pointer whenever a peer socket was still open at exit.
 	delete browsemanager;
 	browsemanager = nullptr;
 
@@ -465,10 +454,9 @@ int CamuleApp::OnExit()
 		mediaProbeThread = nullptr;
 	}
 
-	// Same for the free-space worker, and for the same reason it exists:
-	// stopping it here means nothing later in this teardown can be held up
-	// by a probe waiting on an unresponsive mount. It reads no preferences
-	// of its own, so it is safe to join before thePrefs goes away.
+	// Same for the free-space worker, and for the same reason it exists: stopping
+	// it here means nothing later in this teardown can be held up by a probe
+	// waiting on an unresponsive mount. It reads no preferences of its own.
 	if (freeSpaceThread) {
 		freeSpaceThread->EndThread();
 		delete freeSpaceThread;
@@ -534,10 +522,7 @@ int CamuleApp::OnExit()
 	AddLogLineNS(_("Memory debug results for aMule exit:"));
 	// Log mem debug messages to wxLogStderr
 	wxLog *oldLog = wxLog::SetActiveTarget(new wxLogStderr);
-	// AddLogLineNS("**************Classes**************";
-	// wxDebugContext::PrintClasses();
-	// AddLogLineNS("***************Dump***************";
-	// wxDebugContext::Dump();
+	// wxDebugContext::PrintClasses() / Dump() also available here.
 	AddLogLineNS("***************Stats**************");
 	wxDebugContext::PrintStatistics(true);
 
@@ -547,37 +532,23 @@ int CamuleApp::OnExit()
 
 	StopTickTimer();
 
-	// wxWebSession's destructor is unsafe to run at wx module cleanup
-	// time on every platform we ship:
+	// wxWebSession's destructor is unsafe to run at wx module cleanup time on
+	// every platform we ship:
 	//
-	//   macOS (wxWebSessionURLSession, wx 3.3.2): releases the
-	//     NSURLSession and its delegate separately without first
-	//     calling -invalidateAndCancel. NSURLSession retains the
-	//     delegate strongly, so the session's dealloc already drops
-	//     the delegate ref; wx's subsequent release hits a freed
-	//     object and aborts with "pointer being freed was not
-	//     allocated".
+	//   macOS (wxWebSessionURLSession, wx 3.3.2): releases the NSURLSession and
+	//     its delegate separately without first calling -invalidateAndCancel.
+	//     NSURLSession retains the delegate strongly, so the session's dealloc
+	//     already drops the delegate ref; wx's subsequent release hits a freed
+	//     object and aborts with "pointer being freed was not allocated".
 	//
-	//   Linux (wxWebSessionCURL, wx 3.2.6): the dtor calls
-	//     curl_multi_cleanup, which invokes the registered socket
-	//     callback (wxWebSessionCURL::SocketCallback) to drop tracked
-	//     sockets. That callback dereferences session state that the
-	//     dtor's earlier steps have already torn down; a wxASSERT
-	//     fires and the fatal-signal handler raise(SIGABRT)s. Reported
-	//     in amule-org/amule#18 with a fully symbolicated backtrace.
+	//   Linux (wxWebSessionCURL, wx 3.2.6): the dtor calls curl_multi_cleanup,
+	//     which invokes the registered socket callback to drop tracked sockets.
+	//     That callback dereferences session state the dtor's earlier steps have
+	//     already torn down; a wxASSERT fires and the fatal-signal handler
+	//     raise(SIGABRT)s.
 	//
-	//   Windows (wxWebSessionWinHTTP): not observed to crash but the
-	//     same class of cleanup-time race is plausible.
-	//
-	// By this point in OnExit we have saved state, joined threads,
-	// and flushed logs — nothing aMule-owned remains to clean up.
-	// _Exit bypasses atexit and static destructors, so the buggy wx
-	// dtor never runs and the process terminates cleanly. Remove this
-	// once the upstream wx fix lands in a release we depend on.
-	//
-	// It also bypasses ~CamuleAppCommon, which would otherwise release the
-	// single-instance lock; drop it here so muleLock is unlinked rather than
-	// left dangling for the next run.
+	//   Windows (wxWebSessionWinHTTP): not observed to crash, but the same class
+	//     of cleanup-time race is plausible.
 	ReleaseSingleInstance();
 	std::_Exit(0);
 
@@ -593,10 +564,9 @@ int CamuleApp::InitGui(bool, wxString &)
 // Probe server.met for actual server entries rather than mere existence.
 // ~CServerList() calls SaveServerMet() unconditionally whenever eD2k is
 // enabled, so a cancelled first run with zero servers still leaves a
-// valid-but-empty file (header 0xE0 + a uint32 count of 0). Checking the
-// count — not just the file — is what keeps the bootstrap page from
-// re-offering the download after such a run. The header/count layout
-// mirrors CServerList::SaveServerMet().
+// valid-but-empty file (header 0xE0 + a uint32 count of 0). Checking the count,
+// not just the file, is what keeps the bootstrap page from re-offering the
+// download after such a run.
 static bool ServerMetHasServers(const wxString &path)
 {
 	if (!wxFileExists(path)) {
@@ -617,9 +587,7 @@ static bool ServerMetHasServers(const wxString &path)
 	}
 }
 
-//
 // Application initialization
-//
 bool CamuleApp::OnInit()
 {
 #if wxUSE_MEMORY_TRACING
@@ -629,20 +597,16 @@ bool CamuleApp::OnInit()
 #endif
 
 #if defined(__WXGTK__) && !defined(__APPLE__)
-	// Set the GTK program name to the canonical app id. On Wayland,
-	// GTK derives wl_app_id (xdg_toplevel.set_app_id) from
-	// g_get_prgname(); compositors match wl_app_id against the
-	// .desktop filename to bind windows to launcher icons. Without
-	// this the binding falls back to argv[0], which differs across
-	// packaging formats (AppImage's argv[0] is "aMule", distro
-	// installs use "amule", Flatpak renames the .desktop entirely).
-	// On X11 the same value also feeds into WM_CLASS, matching
-	// StartupWMClass=org.amule.aMule in the .desktop file. Must run
-	// before any GTK window is created.
-	// Skipped on macOS even under wxGTK (MacPorts): no Wayland or
-	// .desktop binding exists, and app identity is set via Info.plist
-	// in the .app bundle. Dropping the call lets that build skip the
-	// glib2 dep entirely (#641).
+	// Set the GTK program name to the canonical app id. On Wayland, GTK derives
+	// wl_app_id from g_get_prgname(), and compositors match wl_app_id against the
+	// .desktop filename to bind windows to launcher icons. Without this the
+	// binding falls back to argv[0], which differs across packaging formats. On
+	// X11 the same value feeds WM_CLASS, matching StartupWMClass in the .desktop
+	// file. Must run before any GTK window is created.
+	//
+	// Skipped on macOS even under wxGTK: no Wayland or .desktop binding exists,
+	// and app identity is set via Info.plist. Dropping the call lets that build
+	// skip the glib2 dependency entirely.
 	g_set_prgname("org.amule.aMule");
 #endif
 
@@ -668,13 +632,12 @@ bool CamuleApp::OnInit()
 #endif
 
 #ifdef __WINDOWS__
-	// wxWebRequest is backed by libcurl on MSYS2 (MINGW64 / CLANGARM64)
-	// builds. MSYS2 libcurl is compiled with `--with-ca-bundle=` pointing
-	// at an absolute MSYS2 path that does not exist on end-user machines,
-	// so HTTPS (and any HTTP→HTTPS redirect — e.g. SourceForge) fails
-	// with "libcurl error 77: Problem with the SSL CA cert". CMake's
-	// install step ships a ca-bundle.crt next to the .exe; point
-	// CURL_CA_BUNDLE at it here if the user has not set one explicitly.
+	// wxWebRequest is backed by libcurl on MSYS2 builds, and MSYS2 libcurl is
+	// compiled with `--with-ca-bundle=` pointing at an absolute MSYS2 path that
+	// does not exist on end-user machines, so HTTPS -- and any HTTP->HTTPS
+	// redirect -- fails with "libcurl error 77". CMake's install step ships a
+	// ca-bundle.crt next to the .exe; point CURL_CA_BUNDLE at it unless the user
+	// set one explicitly.
 	{
 		wxString existing;
 		if (!wxGetEnv("CURL_CA_BUNDLE", &existing) || existing.IsEmpty()) {
@@ -697,11 +660,10 @@ bool CamuleApp::OnInit()
 	glob_prefs = new CPreferences();
 
 	// Push the bind-to-interface preference into the socket library before any
-	// socket is opened (mulesocket can't read CPreferences itself). It's a
+	// socket is opened -- mulesocket cannot read CPreferences itself. It is a
 	// security-relevant choice (VPN-leak prevention), so make the outcome
 	// visible: confirm the bind when it applies, and warn loudly when it does
-	// not (bad name, or missing privilege on Linux) — otherwise traffic would
-	// silently stay on the default route while the user believes it is contained.
+	// not, or traffic silently stays on the default route.
 	const wxString &bindInterface = thePrefs::GetNetworkInterface();
 	SetSocketBindInterface(bindInterface);
 	switch (TestSocketBindInterface(bindInterface)) {
@@ -709,9 +671,9 @@ bool CamuleApp::OnInit()
 		break; // no interface configured — nothing to report
 	case BindIface_OK:
 #ifdef __WINDOWS__
-		// On Windows only the ed2k/Kad sockets are bound; aMule's HTTP
-		// (version check, IP2Country, server.met) uses the WinHTTP backend,
-		// which has no interface-bind API — so say so rather than overclaim.
+		// On Windows only the ed2k/Kad sockets are bound; aMule's HTTP uses the
+		// WinHTTP backend, which has no interface-bind API -- so say so rather
+		// than overclaim.
 		AddLogLineN(CFormat(_("Binding aMule's peer-to-peer traffic to interface: %s "
 				      "(HTTP updates use the default route)")) %
 			    bindInterface);
@@ -833,12 +795,10 @@ bool CamuleApp::OnInit()
 		vfile.Close();
 	}
 
-	// First launch: run the guided setup wizard before the network
-	// stack comes up, so the chosen ports, enabled networks and UPnP
-	// setting take effect when ReinitializeNetwork() runs below. The
-	// wizard applies and saves every preference it collects; it only
-	// hands back which bootstrap files to fetch, since those downloads
-	// need the (not-yet-created) server list and sockets.
+	// First launch: run the guided setup wizard before the network stack comes
+	// up, so the chosen ports, enabled networks and UPnP setting take effect
+	// when ReinitializeNetwork() runs below. The wizard applies and saves every
+	// preference it collects; it only hands back which bootstrap files to fetch.
 #ifndef AMULE_DAEMON
 	bool firstRunWizardShown = false;
 	bool wizardWantsServerMet = false;
@@ -847,11 +807,10 @@ bool CamuleApp::OnInit()
 	// inferred first-run flag: a cancelled wizard leaves the flag unset,
 	// so it reappears next launch until the user actually finishes it.
 	if (!thePrefs::IsFirstRunWizardDone()) {
-		// Only offer a bootstrap download when the corresponding data
-		// is actually missing: the wizard can reappear after a cancelled
-		// run (the "done" flag stays unset), and by then the user may
-		// already have populated server.met (probed for real entries,
-		// since a cancelled run leaves an empty one) or nodes.dat.
+		// Only offer a bootstrap download when the corresponding data is actually
+		// missing: the wizard can reappear after a cancelled run, and by then the
+		// user may already have populated server.met -- probed for real entries,
+		// since a cancelled run leaves an empty one -- or nodes.dat.
 		const bool needServerMet = thePrefs::GetNetworkED2K() &&
 					   !ServerMetHasServers(thePrefs::GetConfigDir() + "server.met");
 		const bool needNodesDat = thePrefs::GetNetworkKademlia() &&
@@ -897,14 +856,12 @@ bool CamuleApp::OnInit()
 	downloadqueue = new CDownloadQueue();
 	uploadqueue = new CUploadQueue();
 
-	// partFileWriteThread / partFileHashThread are constructed AFTER
-	// InitGui() further down — both spawn a wxThread in their ctor,
-	// and the amuled `-f` fork only carries the calling thread to the
-	// child. Constructing them here (pre-fork) would leave the C++
-	// objects alive in the daemon child with their POSIX threads gone,
-	// so FlushBuffer's PB_PENDING items would never drain and the
-	// `.part` file would stay at 0 bytes despite the network side
-	// happily receiving chunks (#849).
+	// partFileWriteThread / partFileHashThread are constructed AFTER InitGui()
+	// further down: both spawn a wxThread in their ctor, and the amuled `-f` fork
+	// only carries the calling thread to the child. Constructing them pre-fork
+	// would leave the C++ objects alive in the daemon child with their POSIX
+	// threads gone, so FlushBuffer's PB_PENDING items would never drain and the
+	// `.part` file would stay at 0 bytes while the network side received chunks.
 	ipfilter = new CIPFilter();
 
 	// Creates all needed listening sockets
@@ -914,13 +871,11 @@ bool CamuleApp::OnInit()
 		AddLogLineNS(msg);
 	}
 
-	// The GitHub version check and the server.met auto-update used to be
-	// fired from here, before the partfile load + 91k-shared-file scan
-	// run further down. On busy setups the wxWebSession worker thread
-	// then competes with the saturated main thread for CPU, libcurl's
-	// state machine advances less, and DNS resolution can time out
-	// (#714). Both startup HTTP downloads now fire after
-	// sharedfiles->Reload() returns below.
+	// The GitHub version check and the server.met auto-update used to fire from
+	// here, before the partfile load and shared-file scan below. On busy setups
+	// the wxWebSession worker then competes with the saturated main thread for
+	// CPU, libcurl's state machine advances less, and DNS resolution can time
+	// out. Both now fire after sharedfiles->Reload() returns.
 
 	// Create main dialog, or fork to background (daemon).
 	InitGui(m_geometryEnabled, m_geometryString);
@@ -935,12 +890,10 @@ bool CamuleApp::OnInit()
 	splash->Show();
 
 	// Both list controls are batched for the whole startup: part-file loading
-	// fills the download list and the scan plus hashing fill the shared list,
-	// and each individually-sorted insert rebuilds the row index, so a burst
-	// of thousands is quadratic. The same BeginBatchUpdate the remote GUI
-	// uses for its startup EC reply (#615) turns those into appends plus one
-	// sort at the end. Held until the hash queue drains, which the splash
-	// covers -- the lists are not worth showing while they are still filling.
+	// fills the download list and the scan plus hashing fill the shared list, and
+	// each individually-sorted insert rebuilds the row index, so a burst of
+	// thousands is quadratic. BeginBatchUpdate turns those into appends plus one
+	// sort at the end, held until the hash queue drains.
 	if (theApp->amuledlg && theApp->amuledlg->m_transferwnd &&
 		theApp->amuledlg->m_transferwnd->downloadlistctrl) {
 		theApp->amuledlg->m_transferwnd->downloadlistctrl->BeginBatchUpdate();
@@ -973,31 +926,28 @@ bool CamuleApp::OnInit()
 	// eMule ref: emule.cpp:748
 	uploadDiskIOThread = new CUploadDiskIOThread();
 
-	// Download disk-write and hashing threads. Same constraint as the
-	// upload disk I/O thread above: each ctor calls wxThread::Run(),
-	// and amuled's `-f` fork above only carries the calling thread to
-	// the child. Constructing them post-fork ensures the spawned
-	// POSIX threads belong to the daemon child and actually drain the
-	// PartFileBufferedData queue (#849).
+	// Download disk-write and hashing threads. Same constraint as the upload disk
+	// I/O thread above: each ctor calls wxThread::Run(), and amuled's `-f` fork
+	// only carries the calling thread to the child. Constructing them post-fork
+	// ensures the spawned POSIX threads belong to the child and actually drain
+	// the PartFileBufferedData queue.
 	partFileWriteThread = new CPartFileWriteThread();
 	partFileHashThread = new CPartFileHashThread();
-	// #280: dedicated worker for ffprobe metadata, isolated from the shared
-	// CThreadScheduler so a slow/hung probe can never stall completions.
+	// Dedicated worker for ffprobe metadata, isolated from the shared
+	// CThreadScheduler so a slow or hung probe can never stall completions.
 	mediaProbeThread = new CMediaProbeThread();
-	// #757: dedicated worker for the free-space probe, isolated for the same
-	// reason -- statvfs() blocks on the directory, and temp or incoming is
-	// commonly a network mount. Given its paths straight away so the panels
-	// have a figure without waiting for the first core tick.
+	// Dedicated worker for the free-space probe, isolated for the same reason:
+	// statvfs() blocks on the directory, and temp or incoming is commonly a
+	// network mount. Given its paths straight away so the panels have a figure
+	// without waiting for the first core tick.
 	freeSpaceThread = new CFreeSpaceThread();
 	freeSpaceThread->SetPaths(thePrefs::GetTempDir(), thePrefs::GetIncomingDir());
 
 	m_AsioService = new CAsioService;
 
-	// Start performing background tasks
-	// This will start loading the IP filter. It will start right away.
-	// Log is confusing, because log entries from background will only be printed
-	// once foreground becomes idle, and that will only be after loading
-	// of the partfiles has finished.
+	// Start performing background tasks. This starts loading the IP filter right
+	// away; the log is confusing, because background log entries only print once
+	// the foreground goes idle, which is after the partfiles have loaded.
 	CThreadScheduler::Start();
 
 	// These must be initialized after the gui is loaded.
@@ -1006,24 +956,18 @@ bool CamuleApp::OnInit()
 	// 10 000-file share: network setup came to 10 ms and 400 part files to
 	// 130 ms, against 6010 ms of scanning, so the early phases get almost
 	// nothing -- an even split would leave the bar parked at a third for the
-	// whole visible wait.
-	//
-	// The shared scan has no total until it finishes, and counting first
-	// would walk the tree twice -- expensive exactly where it hurts, on
-	// network storage. known.met is last session's view of the same tree, so
-	// it is the best estimate available without paying that cost.
+	// whole visible wait. The shared scan has no total until it finishes, and
+	// counting first would walk the tree twice; known.met is last session's view
+	// of the same tree, so it is the best estimate available.
 	const size_t sharedEstimate = knownfiles ? knownfiles->GetKnownFileCount() : 0;
 
-	// Weight the temp band by cost rather than by item count. Measured on the
-	// same share with 400 part files: 130 ms to load them against 6010 ms to
-	// scan 10 000 files, i.e. 0.33 ms each against 0.60 ms -- a part file is
-	// actually the cheaper item. Loading one reads its .met and then only
-	// stats the .part, never the downloaded data, so the cost tracks hashset
-	// and gap-list size; those measured files were freshly added and carry
-	// the smallest of both. Two rather than one leaves room for the populated
-	// ones a real Temp directory holds. Capped well short of half the bar: the
-	// scan is the phase that usually runs long, and it must keep room to
-	// show it.
+	// Weight the temp band by cost rather than by item count. On the same share
+	// with 400 part files: 130 ms to load them against 6010 ms to scan 10 000
+	// files, i.e. 0.33 ms each against 0.60 ms -- a part file is actually the
+	// cheaper item, since loading one reads its .met and only stats the .part.
+	// Two rather than one leaves room for the populated ones a real Temp
+	// directory holds. Capped well short of half the bar: the scan is the phase
+	// that usually runs long, and it must keep room to show it.
 	constexpr int kPartFileWeight = 2;
 	constexpr int kNetworkBandEnd = 2;
 	constexpr int kTempBandMaxEnd = 40;
@@ -1058,16 +1002,15 @@ bool CamuleApp::OnInit()
 	});
 	const wxLongLong tempDoneAt = wxGetUTCTimeMillis();
 
-	// With no known.met -- a first run -- there is no estimate, so the bar
-	// holds at the band start and the count in the status text carries the
-	// information instead. That is also the run where everything found needs
-	// hashing, so the held-back band is not wasted: the hashing phase below
-	// spends it.
+	// With no known.met -- a first run -- there is no estimate, so the bar holds
+	// at the band start and the count in the status text carries the information
+	// instead. That is also the run where everything found needs hashing, so the
+	// held-back band is not wasted: the hashing phase below spends it.
 	const int scanBandEnd = (sharedEstimate > 0) ? kScanBandEnd : tempBandEnd;
 	splash->SetProgress(_("Loading shared files"), tempBandEnd, true);
 	// Kept for the log line below: the scan reports its running count to the
-	// splash but had no way to report the final one, so the estimate was
-	// printed with nothing to compare it against.
+	// splash but had no way to report the final one, so the estimate was printed
+	// with nothing to compare it against.
 	size_t sharedScanned = 0;
 	sharedfiles->Reload([&](size_t scanned) {
 		sharedScanned = scanned;
@@ -1084,15 +1027,12 @@ bool CamuleApp::OnInit()
 	});
 	const wxLongLong sharedDoneAt = wxGetUTCTimeMillis();
 
-	// Normal level, not debug: these are the numbers the phase weighting
-	// above is meant to be tuned from, and a measurement that needs verbose
-	// logging turned on first is one nobody will report back.
-	// Both phases report count then duration, and the estimate says what it
-	// estimates. It is a file count taken from known.met, but it used to be
-	// printed as a bare number straight after a millisecond figure, which
-	// reads as an estimated duration -- and without the count the scan
-	// actually reached there was nothing to compare it to, so the one thing
-	// the number exists for could not be judged from the line carrying it.
+	// Normal level, not debug: these are the numbers the phase weighting above
+	// is meant to be tuned from, and a measurement that needs verbose logging
+	// turned on first is one nobody will report back. Both phases report count
+	// then duration, and the estimate says what it estimates -- it is a file
+	// count from known.met, and printing it as a bare number after a millisecond
+	// figure read as an estimated duration.
 	AddLogLineN(CFormat(LOG_DIAGNOSTIC("Startup phases: network %lld ms, %u part files %lld ms, shared "
 					   "scan %u files ") "%lld ms (estimated %u files)") %
 		    (networkDoneAt - splashPhaseStart).GetValue() % partFilesLoaded %
@@ -1103,9 +1043,8 @@ bool CamuleApp::OnInit()
 	// listed, and the ones it did not are now queued for hashing. That drain is
 	// the slowest part of a first run by a wide margin -- hashing cost scales
 	// with bytes, not files -- and it used to hold the splash up with it, so a
-	// large share of new files left the application unreachable for as long as
-	// it took (issue #853). The window goes up here instead, and the drain
-	// finishes behind it.
+	// large share of new files left the application unreachable. The window goes
+	// up here instead, and the drain finishes behind it.
 	splash->SetProgress(_("Starting up"), 100, true);
 	ShowMainWindowAfterScan();
 
@@ -1134,27 +1073,21 @@ bool CamuleApp::OnInit()
 	sharedfiles->Reload();
 #endif
 
-	// Restore search results saved on a previous clean shutdown (issue #641
-	// Phase 3, StoredSearches.met). Registering each restored search with the
-	// EC multi-search registry makes it reachable via EC_OP_SEARCH_LIST for
-	// any client (amuleGUI/amuleapi) that connects later.
+	// Restore search results saved on a previous clean shutdown
+	// (StoredSearches.met). Registering each restored search with the EC
+	// multi-search registry makes it reachable via EC_OP_SEARCH_LIST for any
+	// client that connects later.
 	//
-	// Deliberately *after* LoadMetFiles() and sharedfiles->Reload(), not
-	// merely after those objects are constructed. LoadSearches() recomputes
-	// each restored result's download status through
-	// CSearchFile::SetDownloadStatus(), which asks three lists whether it
-	// knows the hash. knownfiles and canceledfiles load in their own
-	// constructors, so they answer correctly from the moment they exist --
-	// but CDownloadQueue's constructor only makes an empty queue, and it is
-	// LoadMetFiles() that fills it. Running the restore before that meant
-	// every result asked an empty download queue and was told "no", so
-	// anything already downloading came back NEW instead of QUEUED. Nothing
-	// corrected it afterwards either: LoadMetFiles() appends to m_filelist
-	// directly rather than through AddDownload(), so the
-	// UpdateSearchFileByHash() that would have re-run the check never fires
-	// (#1101 -- "Hide Known Files" stopped hiding those results, while the
-	// daemon still refused the download with "You are already trying to
-	// download the file").
+	// Deliberately *after* LoadMetFiles() and sharedfiles->Reload(), not merely
+	// after those objects are constructed. LoadSearches() recomputes each
+	// restored result's download status through SetDownloadStatus(), which asks
+	// three lists whether they know the hash. knownfiles and canceledfiles load
+	// in their own constructors, but CDownloadQueue's constructor only makes an
+	// empty queue and it is LoadMetFiles() that fills it -- so running the
+	// restore first meant every result asked an empty download queue and came
+	// back NEW instead of QUEUED. Nothing corrected it afterwards either:
+	// LoadMetFiles() appends to m_filelist directly rather than through
+	// AddDownload(), so UpdateSearchFileByHash() never fires.
 	for (uint32_t restoredId : searchlist->LoadSearches()) {
 		RegisterRestoredSearch(restoredId);
 	}
@@ -1163,13 +1096,12 @@ bool CamuleApp::OnInit()
 	// list is still empty. No-op on the daemon.
 	RestoreSearchTabs();
 
-	// Source seeds need two things: the part files they belong to, loaded
-	// just above, and a filter to check the seeded IPs against, which the
-	// load-finished handler waits for before running this same load. When
-	// the filter wins that race the handler runs first and iterates an
-	// empty queue, dropping every seed, so run it again here. Re-adding a
-	// source already in the queue is a no-op, so the overlap is harmless
-	// when the handler ran partway through the load.
+	// Source seeds need two things: the part files they belong to, loaded just
+	// above, and a filter to check the seeded IPs against, which the
+	// load-finished handler waits for before running this same load. When the
+	// filter wins that race the handler runs first and iterates an empty queue,
+	// dropping every seed, so run it again here. Re-adding a source already in
+	// the queue is a no-op, so the overlap is harmless.
 	if (thePrefs::GetSrcSeedsOn() && ipfilter->IsReady()) {
 		downloadqueue->LoadSourceSeeds();
 	}
@@ -1178,11 +1110,9 @@ bool CamuleApp::OnInit()
 	// I/O is done — see the comment in OnInit() further up.
 #ifdef ENABLE_VERSION_CHECK
 	// Both the daemon and the monolithic app run the core version check: it
-	// updates the internal state relayed over EC (the /version "update"
-	// object) and, on the monolithic, drives the GUI popup via
-	// Notify_VersionCheckResult. amulegui is not a CamuleApp and runs its own
-	// CVersionCheck instead. The About dialog's "Check for updates" button
-	// remains on CVersionCheck for its interactive UX.
+	// updates the internal state relayed over EC and, on the monolithic, drives
+	// the GUI popup. amulegui is not a CamuleApp and runs its own CVersionCheck.
+	// The About dialog's "Check for updates" button stays on CVersionCheck.
 	if (thePrefs::GetCheckNewVersion()) {
 		StartVersionCheck();
 	}
@@ -1191,10 +1121,9 @@ bool CamuleApp::OnInit()
 		serverlist->StartAutoUpdate();
 	}
 
-	// Start the fs-watcher after the initial scan so directories exist
-	// in shareddir_list before Add() runs. The watcher itself is cheap
-	// when no events fire; gating it on the user pref keeps inotify
-	// watches off the books on hosts where the user doesn't want them.
+	// Start the fs-watcher after the initial scan so directories exist in
+	// shareddir_list before Add() runs. The watcher is cheap when no events fire;
+	// gating it on the user pref keeps inotify watches off the books.
 	if (thePrefs::AutoRescanSharedDirs()) {
 		sharedfiles->EnableDirectoryWatcher(true);
 	}
@@ -1208,14 +1137,13 @@ bool CamuleApp::OnInit()
 	// The user can start pressing buttons like mad if he feels like it.
 	m_app_state = APP_STATE_RUNNING;
 
-	// The listen socket has been bound since ReinitializeNetwork(), so a peer
-	// -- typically one that had us in its source list moments ago -- can have
+	// The listen socket has been bound since ReinitializeNetwork(), so a peer --
+	// typically one that had us in its source list moments ago -- can have
 	// connected while the rest of this ran. CListenSocket::OnAccept() declines
-	// those, because until the line above there was no loaded client list to
-	// hand them to, and declining leaves the connection sitting unread. Take
-	// it now that we are running: it re-arms the socket layer's acceptor,
-	// which otherwise would not happen before the first core timer tick, five
-	// seconds from now and well after we have asked a server for a HighID.
+	// those, because until the line above there was no loaded client list to hand
+	// them to, and declining leaves the connection sitting unread. Take it now:
+	// it re-arms the acceptor, which otherwise would not happen until the first
+	// core timer tick, well after we have asked a server for a HighID.
 	if (listensocket) {
 		listensocket->Process();
 	}
@@ -1311,18 +1239,16 @@ bool CamuleApp::OnInit()
 		if (thePrefs::GetNetworkKademlia()) {
 			ipfilter->StartKADWhenReady();
 		}
-		// It may equally have finished already: it loads on a worker
-		// thread, and the splash pumps the event loop while the local
-		// I/O above runs, so a fast filter -- a small file, or none --
-		// is dispatched long before this point, and nothing would start
-		// the networks afterwards. No-op while it is still loading.
+		// It may equally have finished already: it loads on a worker thread, and
+		// the splash pumps the event loop while the local I/O above runs, so a
+		// fast filter is dispatched long before this point and nothing would
+		// start the networks afterwards. No-op while it is still loading.
 		ipfilter->StartPendingNetworks();
 	}
 
 	// Enable GeoIP. The resolver is headless and core-owned so the daemon
-	// resolves country codes for the EC tag exactly as monolithic amule does
-	// for local display (issues #439 / #440). The flag *images* are a GUI
-	// concern layered on top (CCountryFlags / CamuleGuiBase).
+	// resolves country codes for the EC tag exactly as monolithic amule does for
+	// local display. The flag *images* are a GUI concern layered on top.
 	EnableIP2Country(true); // startup: allow the auto-update refresh
 
 	// Run webserver?
@@ -1366,15 +1292,11 @@ bool CamuleApp::OnInit()
 			AddLogLineC(CFormat(_("web server running on pid %d")) % webserver_pid);
 		} else {
 			delete p;
-			// Defer the modal until after OnInit returns. During
-			// OnInit the main window is not yet visible on Windows,
-			// so a modal ShowAlert spawns invisible and blocks the
-			// message loop waiting on input that can't be given —
-			// aMule then boots into an unresponsive white window
-			// with only the Windows error ding audible. CallAfter
-			// fires the alert once amuledlg is shown, matching the
-			// AppImage-integration prompt pattern in
-			// CamuleGuiApp::OnInit.
+			// Defer the modal until after OnInit returns. During OnInit the main
+			// window is not yet visible on Windows, so a modal ShowAlert spawns
+			// invisible and blocks the message loop waiting on input that cannot
+			// be given -- aMule then boots into an unresponsive white window with
+			// only the error ding audible.
 			CallAfter([this]() {
 				ShowAlert(_("You requested to run web server on startup, "
 					    "but the amuleweb binary cannot be run. Please "
@@ -1417,21 +1339,17 @@ bool CamuleApp::OnInit()
 		}
 #endif
 
-		// Hand the child an ephemeral EC credential instead of letting it
-		// read the password-equivalent value out of amule.conf. Written
-		// 0600 into the config dir the child is about to be pointed at,
-		// under the one name both sides derive from webcommon; the child
-		// deletes it the moment it has read it, and OnCoreTimer removes
-		// it regardless once the deadline below expires.
+		// Hand the child an ephemeral EC credential instead of letting it read
+		// the password-equivalent value out of amule.conf. Written 0600 into the
+		// config dir the child is about to be pointed at, under the one name both
+		// sides derive from webcommon; the child deletes it the moment it has
+		// read it, and OnCoreTimer removes it regardless once the deadline
+		// expires. The path is deliberately NOT on the command line: argv is
+		// world-readable via ps.
 		//
-		// The path is deliberately NOT on the command line: argv is
-		// world-readable via ps, so passing it would advertise exactly
-		// where to look for the window the file exists.
-		//
-		// A failure here is not fatal -- amuleapi still has its own
-		// configured EC password to fall back on -- but it is worth
-		// saying, because the fallback is the credential we are trying
-		// to stop using.
+		// A failure here is not fatal -- amuleapi still has its own configured EC
+		// password -- but it is worth saying, because that fallback is the
+		// credential we are trying to stop using.
 		m_ecToken = wxString::FromUTF8(webcommon::GenerateEcToken().c_str());
 		const std::string tokenPath =
 			webcommon::EcTokenFilePath(std::string(thePrefs::GetConfigDir().utf8_str()));
@@ -1444,15 +1362,12 @@ bool CamuleApp::OnInit()
 			m_ecToken.Clear();
 		}
 
-		// No --amule-config-file here, unlike amuleweb above: amuleapi
-		// takes the ephemeral token written just now instead of reading
-		// the hashed EC password out of amule.conf. It finds the token
-		// through the config dir passed below, which is also where its
-		// admin and guest credentials live (amuleapi-passwords, written
-		// by both processes). The HTTP bind address and port are passed
-		// explicitly. A non-loopback bind requires an admin password, or
-		// amuleapi refuses to start; all of this is configured in the
-		// Remote Controls preferences.
+		// No --amule-config-file here, unlike amuleweb above: amuleapi takes the
+		// ephemeral token written just now instead of reading the hashed EC
+		// password out of amule.conf. It finds the token through the config dir
+		// passed below, which is also where its admin and guest credentials live.
+		// The HTTP bind address and port are passed explicitly; a non-loopback
+		// bind requires an admin password or amuleapi refuses to start.
 		wxString cmd = QUOTE + amuleapiPath +
 			       QUOTE " " QUOTE "--config-dir=" + thePrefs::GetConfigDir() +
 			       QUOTE " " QUOTE "--bind=" + thePrefs::GetAmuleApiBindAddress() + QUOTE +
@@ -1539,18 +1454,16 @@ bool CamuleApp::ReinitializeNetwork(wxString *msg)
 	// TODO: read this from configuration file
 	amuleIPV4Address myaddr[4];
 
-	// Create the External Connections Socket.
-	// Default is 4712.
-	// Get ready to handle connections from apps like amulecmd
+	// Create the External Connections socket (default 4712), ready to handle
+	// connections from apps like amulecmd.
+	//
 	// An empty address means "any", which is a deliberate choice the user can
 	// make. A configured address that will not resolve is a different case and
 	// must not fall through to the same place: binding every interface because
-	// the requested one happens to be down right now would silently expose the
-	// external connection -- full control of the daemon -- to networks the user
-	// thought they had excluded. Interface IPs come and go (VPN not up yet,
-	// DHCP not settled, laptop on another network), so this is reachable in
-	// normal use. Fall back to loopback instead: EC keeps working locally and
-	// nothing is exposed by accident.
+	// the requested one happens to be down would silently expose full control of
+	// the daemon to networks the user thought they had excluded. Interface IPs
+	// come and go, so this is reachable in normal use -- fall back to loopback
+	// instead, where EC keeps working locally and nothing is exposed.
 	if (thePrefs::GetECAddress().IsEmpty()) {
 		myaddr[0].AnyAddress();
 	} else if (!myaddr[0].Hostname(thePrefs::GetECAddress())) {
@@ -1645,9 +1558,9 @@ void RefreshLocalPublicIPv6Addresses()
 #ifdef ENABLE_UPNP
 void CamuleApp::StartUPnP()
 {
-	// Nothing to do when UPnP is disabled, and we must never create a
-	// second control point if one already exists (e.g. the first-run
-	// bootstrap dialog enabling UPnP after ReinitializeNetwork() ran).
+	// Nothing to do when UPnP is disabled, and we must never create a second
+	// control point if one already exists -- e.g. the first-run bootstrap dialog
+	// enabling UPnP after ReinitializeNetwork() ran.
 	if (!thePrefs::GetUPnPEnabled() || m_upnp) {
 		return;
 	}
@@ -1937,10 +1850,10 @@ void CamuleApp::SetOSFiles(const wxString &new_path)
 void CamuleApp::OnAssertFailure(
 	const wxChar *file, int line, const wxChar *func, const wxChar *cond, const wxChar *msg)
 {
-	// The log copy, the backtrace and --disable-fatal are the same for every
-	// app and live in CamuleAppCommon; only the base to fall through to is
-	// ours. IsRunning() gates the dialog because wxWidgets cannot show one
-	// before the app is up or once it is tearing down.
+	// The log copy, the backtrace and --disable-fatal are the same for every app
+	// and live in CamuleAppCommon; only the base to fall through to is ours.
+	// IsRunning() gates the dialog because wxWidgets cannot show one before the
+	// app is up or once it is tearing down.
 	if (ReportAssertFailure(file, line, func, cond, msg, wxThread::IsMain() && IsRunning())) {
 		AMULE_APP_BASE::OnAssertFailure(file, line, func, cond, msg);
 	}
@@ -1992,13 +1905,11 @@ void CamuleApp::OnCoreTimer(CTimerEvent &WXUNUSED(evt))
 	if (g_shutdownSignal) {
 #ifdef AMULE_DAEMON
 #if defined(__APPLE__)
-		// wxBase 3.3.2's wxAppConsole event loop on macOS doesn't
-		// honour ExitMainLoop without a top-level window driving the
-		// close (the way wxApp does for the GUI build below). Run
-		// OnExit() directly here for clean shutdown of all subsystems,
-		// then _exit() to terminate before wx's own static destructors
-		// hit the NSURLSession-cleanup crash also handled in OnExit's
-		// __APPLE__ block.
+		// wxBase 3.3.2's wxAppConsole event loop on macOS does not honour
+		// ExitMainLoop without a top-level window driving the close. Run OnExit()
+		// directly here for a clean shutdown of all subsystems, then _exit() to
+		// terminate before wx's own static destructors hit the NSURLSession
+		// cleanup crash also handled in OnExit's __APPLE__ block.
 		static bool s_alreadyExiting = false;
 		if (!s_alreadyExiting) {
 			s_alreadyExiting = true;
@@ -2020,12 +1931,11 @@ void CamuleApp::OnCoreTimer(CTimerEvent &WXUNUSED(evt))
 #endif
 	}
 
-	// There is a theoretical chance that the core time function can recurse:
-	// if an event function gets blocked on a mutex (communicating with the
-	// UploadBandwidthThrottler) wx spawns a new event loop and processes more events.
-	// If CPU load gets high a new core timer event could be generated before the last
-	// one was finished and so recursion could occur, which would be bad.
-	// Detect this and do an early return then.
+	// There is a theoretical chance that the core time function can recurse: if
+	// an event function gets blocked on a mutex (communicating with the
+	// UploadBandwidthThrottler) wx spawns a new event loop and processes more
+	// events, so under high CPU load a new core timer event could be generated
+	// before the last one finished. Detect that and return early.
 	static bool recurse = false;
 	if (recurse) {
 		return;
@@ -2046,11 +1956,10 @@ void CamuleApp::OnCoreTimer(CTimerEvent &WXUNUSED(evt))
 	theStats::CalculateRates();
 
 	if (msCur - msPrevHist > 1000) {
-		// unlike the other loop counters in this function this one will sometimes
-		// produce two calls in quick succession (if there was a gap of more than one
-		// second between calls to TimerProc) - this is intentional!  This way the
-		// history list keeps an average of one node per second and gets thinned out
-		// correctly as time progresses.
+		// Unlike the other loop counters in this function this one will sometimes
+		// produce two calls in quick succession, if there was a gap of more than
+		// one second between calls to TimerProc. That is intentional: the history
+		// list then keeps an average of one node per second.
 		msPrevHist += 1000;
 
 		m_statistics->RecordHistory();
@@ -2059,10 +1968,10 @@ void CamuleApp::OnCoreTimer(CTimerEvent &WXUNUSED(evt))
 	if (msCur - msPrev1 > 1000) { // approximately every second
 		msPrev1 = msCur;
 
-		// Keep the free-space worker's directories current. The paths can
-		// change under the preferences dialog, and the worker must not read
-		// thePrefs itself -- no worker in the tree does, and a wxString read
-		// concurrently with an assignment is a race whatever the value.
+		// Keep the free-space worker's directories current. The paths can change
+		// under the preferences dialog, and the worker must not read thePrefs
+		// itself -- no worker in the tree does, and a wxString read concurrently
+		// with an assignment is a race whatever the value.
 		if (freeSpaceThread) {
 			freeSpaceThread->SetPaths(thePrefs::GetTempDir(), thePrefs::GetIncomingDir());
 		}
@@ -2093,12 +2002,10 @@ void CamuleApp::OnCoreTimer(CTimerEvent &WXUNUSED(evt))
 		listensocket->UpdateConnectionsStatus();
 
 #ifdef ENABLE_VERSION_CHECK
-		// Periodic re-check: once per day, so a long-running amuled or
-		// monolithic amule keeps its version state (and the EC /version
-		// "update" object) fresh instead of only checking at startup. Fires
-		// immediately the first time the preference is enabled at runtime
-		// (m_versionCheckLastAttempt == 0). StartVersionCheck() self-stamps
-		// m_versionCheckLastAttempt and skips the fetch within its own short
+		// Periodic re-check: once per day, so a long-running amuled or monolithic
+		// amule keeps its version state fresh instead of only checking at startup.
+		// Fires immediately the first time the preference is enabled at runtime.
+		// StartVersionCheck() self-stamps and skips the fetch within its own
 		// cooldown, so re-entry here is harmless.
 		if (thePrefs::GetCheckNewVersion()) {
 			const time_t nowSec = time(nullptr);
@@ -2116,9 +2023,9 @@ void CamuleApp::OnCoreTimer(CTimerEvent &WXUNUSED(evt))
 	}
 
 	// Roughly every five minutes. An interface walk is too expensive to do per
-	// peer claim and too rare to leave to startup: between the two, this is
-	// what notices a prefix renumber or a privacy-address rotation on a session
-	// that never reconnects to a server.
+	// peer claim and too rare to leave to startup: between the two, this is what
+	// notices a prefix renumber or a privacy-address rotation on a session that
+	// never reconnects to a server.
 	if (msCur - msPrevIfaces >= 5 * 60 * 1000) {
 		msPrevIfaces = msCur;
 		RefreshLocalPublicIPv6Addresses();
@@ -2141,21 +2048,21 @@ void CamuleApp::OnCoreTimer(CTimerEvent &WXUNUSED(evt))
 		msPrevKnownMet = msCur;
 	}
 
-	// Coalesced flush of media-probe tag updates (#616): OnMediaProbeFinished
-	// bumps m_mediaTagsDirtiedMs on every probe instead of saving inline; save
-	// once here when probing has been idle for 30 s. Resets the periodic timer
-	// above so we don't rewrite known.met twice in quick succession.
+	// Coalesced flush of media-probe tag updates: OnMediaProbeFinished bumps
+	// m_mediaTagsDirtiedMs on every probe instead of saving inline; save once
+	// here when probing has been idle for 30 s. Resets the periodic timer above
+	// so known.met is not rewritten twice in quick succession.
 	if (m_mediaTagsDirtiedMs && msCur - m_mediaTagsDirtiedMs >= 30000) {
 		knownfiles->Save();
 		m_mediaTagsDirtiedMs = 0;
 		msPrevKnownMet = msCur;
 	}
 
-	// Backstop for the amuleapi EC token file. The child unlinks it as
-	// soon as it has read it, so in the normal case this finds nothing
-	// left to do -- it exists for the child that never got that far, so a
-	// live secret cannot be left at rest by a crash or a failed exec. The
-	// in-memory token stays valid either way; only the file is transient.
+	// Backstop for the amuleapi EC token file. The child unlinks it as soon as it
+	// has read it, so in the normal case this finds nothing to do -- it exists
+	// for the child that never got that far, so a live secret cannot be left at
+	// rest by a crash or a failed exec. The in-memory token stays valid either
+	// way; only the file is transient.
 	if (m_ecTokenFileExpiryMs && msCur >= m_ecTokenFileExpiryMs) {
 		m_ecTokenFileExpiryMs = 0;
 		const wxString tokenPath = wxString::FromUTF8(
@@ -2191,11 +2098,10 @@ void CamuleApp::UpdateStartupHashProgress()
 					       ? theApp->amuledlg->m_sharedfileswnd->sharedfilesctrl
 					       : nullptr;
 	if (sharedList) {
-		// The count moves every tick; the order only moves when a hash
-		// finished and appended a row. Hashing cost tracks bytes, so a
-		// large file is minutes of nothing followed by one append --
-		// sorting per tick regardless would rebuild the row index and
-		// reset the model once a second for no reordering at all.
+		// The count moves every tick; the order only moves when a hash finished
+		// and appended a row. Hashing cost tracks bytes, so a large file is
+		// minutes of nothing followed by one append -- sorting per tick
+		// regardless would rebuild the row index once a second for no reordering.
 		sharedList->SetHashingCount(remaining);
 		sharedList->SortIfRowsAppended();
 	}
@@ -2214,16 +2120,16 @@ void CamuleApp::ShowMainWindowAfterScan()
 		theApp->amuledlg->m_transferwnd->downloadlistctrl->EndBatchUpdate();
 	}
 
-	// The shared list is not finished -- hashing still has files to hand it --
-	// so its batch stays open and only the freeze ends. Sorting what the scan
-	// found means the list is ordered from the moment it is visible, and the
-	// rows that arrive later are appended and sorted by the poll tick.
+	// The shared list is not finished -- hashing still has files to hand it -- so
+	// its batch stays open and only the freeze ends. Sorting what the scan found
+	// means the list is ordered from the moment it is visible, and rows arriving
+	// later are appended and sorted by the poll tick.
 	if (theApp->amuledlg && theApp->amuledlg->m_sharedfileswnd &&
 		theApp->amuledlg->m_sharedfileswnd->sharedfilesctrl) {
 		// Sort-if-dirty rather than an unconditional sort: the scan's files
 		// arrived as appends and set the flag, and the first drain tick runs
-		// moments from here -- sorting outright would leave the flag set and
-		// have that tick repeat the largest sort of the whole startup.
+		// moments from here -- sorting outright would leave the flag set and have
+		// that tick repeat the largest sort of the whole startup.
 		theApp->amuledlg->m_sharedfileswnd->sharedfilesctrl->SortIfRowsAppended();
 		theApp->amuledlg->m_sharedfileswnd->sharedfilesctrl->ThawForDisplay();
 	}
@@ -2249,14 +2155,12 @@ void CamuleApp::FinishStartupHashing()
 		// batch below closes with the model already knowing every row.
 		sharedList->SetStartupDrainMode(false);
 		sharedList->SetHashingCount(0);
-		// Ends the batch opened before the scan, without its sort: whatever
-		// was appended has just been sorted, either by the tick that brought
-		// the count to zero or, when nothing needed hashing, at the end of
-		// the scan. Nothing can append in between -- both run synchronously
-		// in one handler, and a completion still queued when the count
-		// reached zero arrives after the batch is closed, so it takes the
-		// sorted-insert path and places itself. The thaw inside is skipped
-		// too: ShowMainWindowAfterScan() already ended the freeze.
+		// Ends the batch opened before the scan, without its sort: whatever was
+		// appended has just been sorted, either by the tick that brought the count
+		// to zero or, when nothing needed hashing, at the end of the scan.
+		// Nothing can append in between -- both run synchronously in one handler.
+		// The thaw inside is skipped too: ShowMainWindowAfterScan() ended the
+		// freeze already.
 		sharedList->EndBatchUpdate(false);
 	}
 }
@@ -2280,14 +2184,12 @@ void CamuleApp::OnFinishedHashing(CHashingEvent &evt)
 	} else {
 		static uint64 bytecount = 0;
 
-		// CHashingTask runs against a stable file descriptor, so the
-		// hash completes even if the file is renamed or unlinked
-		// mid-hash. Re-check the path at completion: if the file is
-		// no longer where we hashed it from (move out of the watched
-		// tree, delete during hash, or an interim rename whose final
-		// destination is a different path), drop the result. Surfacing
-		// it would leave a shared-list entry under a filename that
-		// doesn't exist on disk, which peers cannot fetch chunks from.
+		// CHashingTask runs against a stable file descriptor, so the hash completes
+		// even if the file is renamed or unlinked mid-hash. Re-check the path at
+		// completion: if the file is no longer where we hashed it from -- moved
+		// out of the watched tree, deleted, or renamed to a different final path
+		// -- drop the result. Surfacing it would leave a shared-list entry under a
+		// filename that does not exist on disk, which peers cannot fetch from.
 		const CPath hashedFullPath = result->GetFilePath().JoinPaths(result->GetFileName());
 		if (!hashedFullPath.FileExists()) {
 			AddDebugLogLineN(logKnownFiles,
@@ -2346,13 +2248,11 @@ void CamuleApp::OnFinishedAICHHashing(CHashingEvent &evt)
 	CKnownFile *owner = const_cast<CKnownFile *>(evt.GetOwner());
 	CScopedPtr<CKnownFile> result(evt.GetResult());
 
-	// Validate the owner is still alive — AICH hashing of a multi-GB
-	// file can run for many seconds, during which the CKnownFile may
-	// have been TTL-evicted from CKnownFileList::PruneDuplicates or
-	// destroyed via CPartFile::Delete. Without this check we'd deref
-	// freed memory in the swap below. See the broadcast-hook PR
-	// (Notify_KnownFileBeingDestroyed) for the symmetric GUI-side
-	// fixes. Same defensive pattern as OnFinishedHashing above.
+	// Validate the owner is still alive -- AICH hashing of a multi-GB file can
+	// run for many seconds, during which the CKnownFile may have been
+	// TTL-evicted from PruneDuplicates or destroyed via CPartFile::Delete.
+	// Without this check the swap below would deref freed memory. Same
+	// defensive pattern as OnFinishedHashing above.
 	if (!owner || (!knownfiles->IsKnownFile(owner) && !downloadqueue->IsPartFile(owner))) {
 		AddDebugLogLineN(logKnownFiles,
 			"OnFinishedAICHHashing: owner CKnownFile was destroyed "
@@ -2387,13 +2287,10 @@ void CamuleApp::OnMediaProbeFinished(CMediaProbeEvent &evt)
 	// shared at more than one path, which on a media library is common. The
 	// probe is scheduled off the shared-list entry and its gate reads that
 	// entry, but the result was only ever applied to the known-file map's, so
-	// for such a file the tags landed on an object nothing consults: the
-	// shared entry stayed bare, still looked unprobed, and was re-queued on
-	// every reload and every restart -- succeeding every time, which is why it
-	// showed up as a repeating probe with no failures at all (issue #1116).
-	//
-	// Both objects are updated. Usually they ARE the same object and the
-	// second update is skipped.
+	// the shared entry stayed bare, still looked unprobed, and was re-queued on
+	// every reload and restart -- succeeding every time, which is why it showed
+	// up as a repeating probe with no failures. Both objects are updated now;
+	// usually they ARE the same object and the second update is skipped.
 	CKnownFile *sharedFile =
 		theApp->sharedfiles ? theApp->sharedfiles->GetFileByID(evt.GetHash()) : nullptr;
 	if (sharedFile == file) {
@@ -2404,30 +2301,25 @@ void CamuleApp::OnMediaProbeFinished(CMediaProbeEvent &evt)
 		sharedFile = nullptr;
 	}
 	if (!file) {
-		// The probe ran and its result is being thrown away. That is expected
-		// when the file was unshared mid-probe, but it is also the shape a
-		// silently-dropped result would have -- and a dropped result means the
-		// file keeps no metadata and no marker, so it is re-probed on every
-		// reload forever with nothing in the log to say why. Reported so that
-		// case is visible rather than inferred from a repeating probe count.
+		// The probe ran and its result is being thrown away. That is expected when
+		// the file was unshared mid-probe, but it is also the shape a silently
+		// dropped result would have -- and a dropped result means the file keeps
+		// no metadata and no marker, so it is re-probed on every reload forever.
 		AddLogLineN(CFormat(_("Media metadata: probed file is no longer known, result discarded "
 				      "(%s)")) %
 			    evt.GetHash().Encode());
 		return;
 	}
 
-	// A probe that produced nothing still has to leave a trace, or the gate
-	// that skips already-probed files cannot tell it from a file never tried
-	// and re-queues it on every reload and every restart (issue #1116). The
-	// existing media tags are left alone: a probe that failed has established
-	// nothing about the file, so it is no grounds to discard what an earlier
-	// successful probe stored.
+	// A probe that produced nothing still has to leave a trace, or the gate that
+	// skips already-probed files cannot tell it from a file never tried and
+	// re-queues it on every reload and restart. The existing media tags are left
+	// alone: a probe that failed has established nothing about the file.
 	if (!evt.Succeeded()) {
-		// Only a verdict about the file is recorded. A missing or broken
-		// ffprobe, a timeout, or a file that vanished between queue and probe
-		// says nothing about the file itself, and marking on those would mean
-		// one mistyped ffprobe path brands every media file in the library and
-		// nothing re-probes them once it is corrected.
+		// Only a verdict about the file is recorded. A missing or broken ffprobe,
+		// a timeout, or a file that vanished between queue and probe says nothing
+		// about the file itself, and marking on those would mean one mistyped
+		// ffprobe path brands every media file in the library.
 		if (evt.MarkUnprobeable()) {
 			file->AddTagUnique(CTagInt32(FT_MEDIA_PROBE_FAILED, 1));
 			if (sharedFile) {
@@ -2515,20 +2407,16 @@ void CamuleApp::OnMediaProbeFinished(CMediaProbeEvent &evt)
 	// The shared-list object is the one EC serves: CFileEncoderMap builds its
 	// encoders from CopyFileList(shares) keyed by ECID, so leaving it unmarked
 	// means Get_EC_Response_GetUpdate takes its unchanged shortcut and every
-	// remote client keeps showing the file bare -- the same "tags landed where
-	// nothing looked" failure this handler exists to fix, surviving on the
-	// clients.
+	// remote client keeps showing the file bare.
 	if (sharedFile) {
 		sharedFile->MarkECChanged();
 	}
-	// Coalesce the known.met save instead of rewriting the whole file per
-	// probe. CKnownFileList::Save rewrites every known file, so a per-probe
-	// save is O(files) each time -- O(N^2) when the whole library is probed at
-	// startup, which pegged a core and could re-enter Save mid-write (#616).
-	// Bump the last-change stamp on every probe; OnCoreTimer flushes a single
-	// Save once probing has been idle for 30 s, collapsing a startup burst
-	// into one write. The 30-min periodic save is the backstop if probes
-	// trickle in without ever pausing, and shutdown always flushes.
+	// Coalesce the known.met save instead of rewriting the whole file per probe.
+	// CKnownFileList::Save rewrites every known file, so a per-probe save is
+	// O(files) each time -- O(N^2) when the whole library is probed at startup,
+	// which pegged a core and could re-enter Save mid-write. Bump the
+	// last-change stamp on every probe; OnCoreTimer flushes a single Save once
+	// probing has been idle for 30 s. The 30-min periodic save is the backstop.
 	m_mediaTagsDirtiedMs = theStats::GetUptimeMillis();
 }
 
@@ -2559,11 +2447,9 @@ void CamuleApp::OnFinishedAllocation(CAllocFinishedEvent &evt)
 {
 	CPartFile *file = evt.GetFile();
 	wxCHECK_RET(file, "Allocation finished event sent for unspecified file");
-	// Preallocation can take 10+ seconds on slow disks (Windows VM
-	// full-prealloc of a 30 GB file is in this range). If the user
-	// cancels the download mid-preallocation, the CPartFile is freed
-	// before this completion event reaches the main thread. wxASSERT
-	// would be a no-op in Release; convert to a real check.
+	// Preallocation can take 10+ seconds on slow disks. If the user cancels the
+	// download mid-preallocation, the CPartFile is freed before this completion
+	// event reaches the main thread -- and wxASSERT would be a no-op in Release.
 	if (!downloadqueue->IsPartFile(file)) {
 		AddDebugLogLineN(logPartFile,
 			"OnFinishedAllocation: partfile was destroyed while "
@@ -2593,11 +2479,10 @@ void CamuleApp::OnNotifyEvent(CMuleGUIEvent &evt)
 #ifdef AMULE_DAEMON
 	evt.Notify();
 #else
-	// IsAlways() covers the socket-layer notifications, which have to run
-	// whether or not there is a window -- see CMuleGUIEvent::IsAlways(). The
-	// monolithic app builds its dialog before networking starts, so this is
-	// far less exposed than amulegui, but the window is gone again during
-	// shutdown while sockets are still closing.
+	// IsAlways() covers the socket-layer notifications, which have to run whether
+	// or not there is a window. The monolithic app builds its dialog before
+	// networking starts, so this is far less exposed than amulegui, but the
+	// window is gone again during shutdown while sockets are still closing.
 	if (evt.IsAlways() || theApp->amuledlg) {
 		evt.Notify();
 	}
@@ -2843,12 +2728,10 @@ bool CamuleApp::StartVersionCheck()
 	}
 	m_versionCheckLastAttempt = now;
 
-	// The GitHub Releases "latest" endpoint returns JSON describing the
-	// most recent non-prerelease, non-draft Release. CheckNewVersion()
-	// parses the tag_name on completion (via HTTP_VersionCheck ->
-	// OnFinishedHTTPDownload). Fire-and-forget through the download thread
-	// so no dialog pops up. Reused by OnInit (startup) and the
-	// EC_OP_VERSION_CHECK trigger.
+	// The GitHub Releases "latest" endpoint returns JSON describing the most
+	// recent non-prerelease, non-draft Release. CheckNewVersion() parses the
+	// tag_name on completion. Fire-and-forget through the download thread so no
+	// dialog pops up. Reused by OnInit and the EC_OP_VERSION_CHECK trigger.
 	CHTTPDownloadThread *version_check =
 		new CHTTPDownloadThread("https://api.github.com/repos/amule-org/amule/releases/latest",
 			thePrefs::GetConfigDir() + "last_version_check",

--- a/src/amule.h
+++ b/src/amule.h
@@ -41,11 +41,10 @@
 #include "config.h" // Needed for ENABLE_UPNP
 
 // GeoIP country DISPLAY + remote-config capability, as opposed to the resolver.
-// True for a resolver-owning build (ENABLE_IP2COUNTRY, needs libmaxminddb) OR
-// any remote GUI (amulegui / CLIENT_GUI, which receives country codes over EC
-// and links no library). Use GEOIP_GUI to gate flag rendering, the country
-// columns and the IP2Country preferences page; keep ENABLE_IP2COUNTRY for the
-// resolver itself (CIP2Country) and the monolithic local IP→code lookup.
+// True for a resolver-owning build (ENABLE_IP2COUNTRY, needs libmaxminddb) or
+// any remote GUI (amulegui, which receives country codes over EC and links no
+// library). Gate flag rendering, the country columns and the IP2Country prefs
+// page on GEOIP_GUI; keep ENABLE_IP2COUNTRY for the resolver itself.
 #if defined(ENABLE_IP2COUNTRY) || defined(CLIENT_GUI)
 #define GEOIP_GUI 1
 #endif
@@ -125,10 +124,9 @@ class CUInt128;
 #define CORE_TIMER_PERIOD 100
 #endif
 
-// How long the amuleapi EC token file may sit on disk before the core
-// removes it whether or not the child read it. Long enough to cover a
-// slow exec on a loaded machine, short enough that a secret is not
-// left at rest for anything a person would notice.
+// How long the amuleapi EC token file may sit on disk before the core removes
+// it whether or not the child read it: long enough for a slow exec on a loaded
+// machine, short enough that a secret is not left at rest.
 #define EC_TOKEN_FILE_TTL_MS 10000
 
 #define CONNECTED_ED2K (1 << 0)
@@ -158,9 +156,9 @@ public:
 		kNotACollection,
 		// The path named a collection and its links were emitted.
 		kCollectionExpanded,
-		// The path named a collection we could not read. Already
-		// logged, and deliberately not retried as a link - doing so
-		// would emit a second, misleading "invalid eD2k link" error.
+		// The path named a collection we could not read. Already logged, and
+		// deliberately not retried as a link -- that would emit a second,
+		// misleading "invalid eD2k link" error.
 		kCollectionFailed
 	};
 
@@ -232,10 +230,10 @@ protected:
 		bool dialogUsable);
 
 	void RefreshSingleInstanceChecker();
-	// Drop the single-instance lock (and unlink its file). OnExit() calls
+	// Drop the single-instance lock and unlink its file. OnExit() calls
 	// std::_Exit() to dodge the wxWebSession teardown crash, which bypasses
-	// ~CamuleAppCommon — so this must be called explicitly before the exit,
-	// or the muleLock / muleLockRGUI file lingers between runs.
+	// ~CamuleAppCommon, so this must run explicitly before the exit or the
+	// muleLock / muleLockRGUI file lingers between runs.
 	void ReleaseSingleInstance();
 
 	/**
@@ -281,21 +279,19 @@ public:
 	CamuleAppCommon();
 	~CamuleAppCommon();
 
-	// GeoIP country resolver (headless: DB + download + ISO-code lookup).
-	// The resolver lives on CamuleApp (amuled + monolithic amule); amulegui
-	// has none and receives country codes over EC, so the base returns
-	// nullptr. This lets shared model code (CServer / CUpDownClient::
-	// GetCountryCode) resolve locally where a resolver exists and use the
-	// EC-provided value where it doesn't.
+	// GeoIP country resolver (DB + download + ISO-code lookup). It lives on
+	// CamuleApp (amuled + monolithic); amulegui has none and receives country
+	// codes over EC, so the base returns nullptr. Shared model code can then
+	// resolve locally where a resolver exists and use the EC value where it does
+	// not.
 	virtual class CIP2Country *GetIP2Country() { return nullptr; }
 
-	// Apply the current GeoIP preference at runtime (creating the resolver on
-	// first enable, disabling it when turned off). No-op on amulegui, which has
-	// no local resolver and configures the daemon's GeoIP over EC. startup=true
-	// (OnInit / a local enable toggle) also kicks the auto-update refresh; it is
-	// false on a remote prefs-apply so an amulegui OK doesn't trigger a download
-	// on every save — an explicit "Update now" (EC_TAG_IP2COUNTRY_UPDATE_NOW)
-	// carries that intent instead (otherwise both fire → duplicate download).
+	// Apply the current GeoIP preference at runtime, creating the resolver on
+	// first enable and disabling it when turned off. No-op on amulegui, which
+	// configures the daemon's GeoIP over EC. startup=true also kicks the
+	// auto-update refresh; it is false on a remote prefs-apply so an amulegui OK
+	// does not download on every save -- an explicit "Update now" carries that
+	// intent, and firing both would duplicate the download.
 	virtual void EnableIP2Country(bool startup) {}
 
 	void AddLinksFromFile();
@@ -306,7 +302,6 @@ public:
 		bool use_hostname = false,
 		bool add_cryptoptions = false,
 		bool add_AICH = false);
-	// Who am I ?
 #ifdef AMULE_DAEMON
 	bool IsDaemon() const { return true; }
 #else
@@ -323,12 +318,10 @@ public:
 	const wxString GetFullMuleVersion() const;
 
 #ifdef __WXGTK__
-	// True when the process is running under a Wayland session (any
-	// distro, any compositor). xdg-shell intentionally doesn't deliver
-	// iconify-state notifications to clients, so several tray-icon
-	// features that rely on detecting "user just minimized the
-	// window" cannot work there - the call sites use this flag to
-	// disable / grey out the relevant prefs and skip the broken paths.
+	// True when the process runs under a Wayland session. xdg-shell intentionally
+	// does not deliver iconify-state notifications to clients, so tray-icon
+	// features that rely on detecting "user just minimized the window" cannot work
+	// there; call sites use this to grey out the relevant prefs.
 	static bool IsWaylandSession();
 #endif
 
@@ -346,13 +339,11 @@ public:
 	 */
 	static void SanitiseTrayPreferences();
 
-	// Set when a quit was requested out-of-band of the main-window
-	// close button (Cmd+Q, Dock right-click → Quit, tray-icon Exit).
-	// CamuleDlg::OnClose checks this so HideOnClose only hides the
-	// window for the actual red close-button gesture and never blocks
-	// an explicit quit request. Lives on the common base so both the
-	// monolithic CamuleApp and the remote-GUI CamuleRemoteGuiApp
-	// expose the same accessors.
+	// Set when a quit was requested out-of-band of the main-window close button
+	// (Cmd+Q, Dock right-click Quit, tray-icon Exit). CamuleDlg::OnClose checks it
+	// so HideOnClose only hides the window for the actual close-button gesture and
+	// never blocks an explicit quit. On the common base so both CamuleApp and
+	// CamuleRemoteGuiApp expose the same accessors.
 	bool IsQuitting() const { return m_isQuitting; }
 	void SetQuitting() { m_isQuitting = true; }
 	void ResetQuitting() { m_isQuitting = false; }
@@ -383,12 +374,11 @@ public:
 	bool ReinitializeNetwork(wxString *msg);
 
 	// The core owns the GeoIP resolver (created in OnInit, guarded by
-	// ENABLE_IP2COUNTRY + thePrefs::IsGeoIPEnabled). Serves the daemon
-	// (serialising the country EC tag) and monolithic amule (local display).
+	// ENABLE_IP2COUNTRY + thePrefs::IsGeoIPEnabled), serving the daemon's country
+	// EC tag and monolithic amule's local display.
 	CIP2Country *GetIP2Country() override { return m_IP2Country; }
 	void EnableIP2Country(bool startup) override;
 
-	// derived classes may override those
 	virtual int InitGui(bool geometry_enable, wxString &geometry_string);
 
 	/**
@@ -405,20 +395,15 @@ public:
 
 	virtual int ShowAlert(wxString msg, wxString title, int flags) = 0;
 
-	// Barry - To find out if app is running or shutting/shut down
 	bool IsRunning() const { return (m_app_state == APP_STATE_RUNNING); }
 	bool IsOnShutDown() const { return (m_app_state == APP_STATE_SHUTTINGDOWN); }
 
 	// Check ED2K and Kademlia state
 	bool IsFirewalled() const;
-	// Are we connected to at least one network?
 	bool IsConnected() const;
-	// Connection to ED2K
 	bool IsConnectedED2K() const;
 
-	// What about Kad? Is it running?
 	bool IsKadRunning() const;
-	// Connection to Kad
 	bool IsConnectedKad() const;
 	// Check Kad state (TCP)
 	bool IsFirewalledKad() const;
@@ -439,18 +424,15 @@ public:
 	uint8 GetBuddyStatus() const;
 	uint32 GetBuddyIP() const;
 	uint32 GetBuddyPort() const;
-	// Kad ID
 	const Kademlia::CUInt128 &GetKadID() const;
 
 	// Check if we should callback this client
 	bool CanDoCallback(uint32 clientServerIP, uint16 clientServerPort);
 
-	// Misc functions
 	void OnlineSig(bool zero = false);
 	void Localize_mule();
 	void Trigger_New_version(wxString newMule);
 
-	// shakraw - new EC code using wxSocketBase
 	ExternalConn *ECServerHandler;
 
 	// return current (valid) public IP or 0 if unknown
@@ -461,7 +443,6 @@ public:
 	uint32 GetED2KID() const;
 	uint32 GetID() const;
 
-	// Other parts of the interface and such
 	CPreferences *glob_prefs;
 	CDownloadQueue *downloadqueue;
 	CUploadQueue *uploadqueue;
@@ -482,9 +463,8 @@ public:
 	CBrowseManager *browsemanager;
 	CClientCreditsList *clientcredits;
 	CFriendList *friendlist;
-	// The core's chat transcript, shared by the local GUI and every EC
-	// client so all three see one conversation rather than three private
-	// ones. In-memory; emptied by a restart.
+	// The core's chat transcript, shared by the local GUI and every EC client so
+	// all three see one conversation. In-memory; emptied by a restart.
 	CChatSessionStore *chatsessions;
 	CClientUDPSocket *clientudp;
 	CStatistics *m_statistics;
@@ -495,9 +475,8 @@ public:
 #ifdef ENABLE_UPNP
 	CUPnPControlPoint *m_upnp;
 	std::vector<CUPnPPortMapping> m_upnpMappings;
-	// Build the port mappings from the current preferences and start the
-	// UPnP control point. Safe to call more than once: it is a no-op when
-	// UPnP is disabled or already running.
+	// Build the port mappings from the current preferences and start the UPnP
+	// control point. A no-op when UPnP is disabled or already running.
 	void StartUPnP();
 #endif
 	wxLocale m_locale;
@@ -522,11 +501,9 @@ public:
 	void ShowConnectionState(bool forceUpdate = false);
 
 	// Wall-clock timestamp of the most recent ed2k/Kad connect, set by
-	// ShowConnectionState() on the false->true transition it already
-	// detects. Invalid (wxDateTime::IsValid() == false) while
-	// disconnected. Feeds the "Connected since" row in the desktop
-	// ED2K/Kad Info panes (CServerWnd::UpdateED2KInfo/UpdateKadInfo) --
-	// not wired over EC, so amulegui doesn't show it (amule-org/amule#174).
+	// ShowConnectionState() on the false->true transition it already detects, and
+	// invalid while disconnected. Feeds the "Connected since" row in the desktop
+	// ED2K/Kad Info panes; not wired over EC, so amulegui does not show it.
 	const wxDateTime &GetED2KConnectedSince() const { return m_ed2kConnectedSince; }
 	const wxDateTime &GetKadConnectedSince() const { return m_kadConnectedSince; }
 
@@ -571,39 +548,36 @@ protected:
 	void OnFinishedAICHHashing(CHashingEvent &evt);
 
 #if !defined(CLIENT_GUI) && !defined(AMULE_DAEMON)
-	// Monolithic only: the daemon has no window to put a splash on, and
-	// amulegui is a separate process that does not run this startup at all.
+	// Monolithic only: the daemon has no window to put a splash on, and amulegui
+	// is a separate process that does not run this startup at all.
 	//
-	// Startup splash, kept alive past OnInit because the slowest part of a
-	// first run is the hashing of everything the scan found unknown, and
-	// that drains asynchronously long after OnInit has returned. Null once
-	// the window is up and the splash has closed -- which is now the end of
-	// the scan, not the end of hashing (#853).
+	// The splash is kept alive past OnInit because the slowest part of a first run
+	// is hashing everything the scan found unknown, which drains asynchronously.
+	// Null once the window is up and the splash has closed -- the end of the scan,
+	// not the end of hashing (#853).
 	CSplashScreen *m_splash = nullptr;
-	// Drives the hashing drain: refreshes the count on the shared-files label
-	// and sorts the rows that arrived since the last tick. Polled rather than
-	// driven from the completion handlers: the worker clears its current task
-	// after the completion event has been posted, so a handler-driven update
-	// can see the last task still pending and then never run again, leaving
-	// the batch open for good. Polling also covers tasks that finish without
-	// reaching a handler here, such as an aborted one.
+	// Drives the hashing drain: refreshes the count on the shared-files label and
+	// sorts the rows that arrived since the last tick. Polled rather than driven
+	// from the completion handlers, because the worker clears its current task
+	// after posting the completion event, so a handler-driven update can see the
+	// last task still pending and then never run again. Polling also covers tasks
+	// that finish without reaching a handler, such as an aborted one.
 	wxTimer m_splashPollTimer;
 
 	// One tick of the drain: label, sort, and finish when the queue empties.
 	void UpdateStartupHashProgress();
 	void OnSplashPollTimer(wxTimerEvent &evt);
-	// Ends the download list's batch, sorts and thaws the shared list, shows
-	// the main window and closes the splash. Called when the scan finishes,
-	// with hashing still running behind it.
+	// Ends the download list's batch, sorts and thaws the shared list, shows the
+	// main window and closes the splash. Called when the scan finishes, with
+	// hashing still running behind it.
 	void ShowMainWindowAfterScan();
 	// Ends the shared list's batch with its final sort and stops the poll
 	// timer. Safe to call when nothing needed hashing.
 	void FinishStartupHashing();
 #endif // monolithic only
 
-	// #140 - CMediaProbeTask marshals results back here so we can
-	// attach FT_MEDIA_* tags on the main thread (the worker never
-	// touches CKnownFile state).
+	// CMediaProbeTask marshals results back here so FT_MEDIA_* tags are attached
+	// on the main thread -- the worker never touches CKnownFile state.
 	void OnMediaProbeFinished(CMediaProbeEvent &evt);
 	void OnFinishedCompletion(CCompletionEvent &evt);
 	void OnFinishedAllocation(CAllocFinishedEvent &evt);
@@ -616,10 +590,9 @@ protected:
 	APPState m_app_state;
 
 	// Media-probe tag writes coalesce into one known.met save: every
-	// OnMediaProbeFinished stamps this (uptime ms), and OnCoreTimer flushes a
-	// single Save() once probing has been idle for 30 s -- avoids the O(N^2)
-	// full-file rewrite when the whole library is probed at startup (#616).
-	// 0 = nothing pending.
+	// OnMediaProbeFinished stamps this (uptime ms) and OnCoreTimer flushes a single
+	// Save() once probing has been idle for 30 s, avoiding the O(N^2) full-file
+	// rewrite when the whole library is probed at startup. 0 = nothing pending.
 	uint64 m_mediaTagsDirtiedMs = 0;
 
 	// Headless GeoIP resolver, owned by the core (created in OnInit under
@@ -631,35 +604,27 @@ protected:
 
 	uint32 m_dwPublicIP;
 
-	// PID type: `int` is wide enough for any OS pid we run on -- POSIX
-	// pid_t is typically `int`, and Windows process IDs are 32-bit
-	// DWORDs but always fit in a positive int. `long` was wrong on
-	// LLP64 only by happy accident (long is also 32-bit there), but
-	// using `int` makes the intent explicit and avoids %ld for what
-	// is really an int-sized value.
+	// PID type: `int` is wide enough for any OS pid we run on -- POSIX pid_t is
+	// typically int, and Windows process IDs are 32-bit DWORDs that always fit in
+	// a positive int. `long` was right on LLP64 only by accident.
 	int webserver_pid;
 	int amuleapi_pid;
 
-	// Ephemeral EC credential for the amuleapi we spawn. Generated fresh
-	// every start, handed over through a 0600 file in the config dir that
-	// the child deletes as soon as it has read it, and accepted by the EC
-	// server alongside the configured password for the rest of this run.
+	// Ephemeral EC credential for the amuleapi we spawn. Generated fresh every
+	// start, handed over through a 0600 file in the config dir that the child
+	// deletes as soon as it has read it, and accepted by the EC server alongside
+	// the configured password for the rest of this run.
 	//
-	// The point is that amuleapi never needs the value in amule.conf. That
-	// stored value IS the credential -- the challenge hashes it directly --
-	// so a compromised network-facing daemon holding it would hold something
-	// equivalent to the user's EC password. This holds a secret that dies
-	// with the process instead.
-	//
-	// Empty when we did not spawn amuleapi, in which case no token is
-	// accepted at all.
+	// The point is that amuleapi never needs the value in amule.conf. That stored
+	// value IS the credential -- the challenge hashes it directly -- so a
+	// compromised network-facing daemon holding it would hold the equivalent of
+	// the user's EC password. Empty when we did not spawn amuleapi, in which case
+	// no token is accepted at all.
 	wxString m_ecToken;
 
-	// Uptime-ms deadline after which the token file is removed whether or
-	// not the child read it. Without it a child that dies before reading
-	// leaves a live secret at rest, and "no token on disk after startup"
-	// stops being true. Same stamp-and-sweep shape as m_mediaTagsDirtiedMs.
-	// 0 = nothing pending.
+	// Uptime-ms deadline after which the token file is removed whether or not the
+	// child read it: a child that dies before reading would otherwise leave a live
+	// secret at rest. 0 = nothing pending.
 	uint64 m_ecTokenFileExpiryMs = 0;
 
 	wxString server_msg;
@@ -682,11 +647,10 @@ public:
 	// can show how stale the result is (checks are startup-only).
 	time_t GetVersionCheckTimestamp() const { return m_versionCheckTimestamp; }
 
-	// Kick off an async GitHub /releases/latest fetch; CheckNewVersion()
-	// stores the outcome when it completes. Reused by OnInit (startup) and
-	// the EC_OP_VERSION_CHECK trigger. Returns false when throttled (a
-	// check ran within the cooldown window) so the trigger caller can
-	// report "try again later" instead of hammering GitHub's rate limit.
+	// Kick off an async GitHub /releases/latest fetch; CheckNewVersion() stores
+	// the outcome. Used by OnInit and the EC_OP_VERSION_CHECK trigger. Returns
+	// false when throttled, so the trigger caller can report "try again later"
+	// rather than hammering GitHub's rate limit.
 	bool StartVersionCheck();
 #endif
 
@@ -726,9 +690,8 @@ public:
 	CamuleDlg *amuledlg;
 
 #ifdef GEOIP_GUI
-	// Country flag images (ISO code -> wxImage), shared by the monolithic
-	// and remote GUIs. The country *code* comes from the core resolver
-	// (monolithic) or the EC tag (amulegui); this turns it into a flag.
+	// Country flag images (ISO code -> wxImage), shared by the monolithic and
+	// remote GUIs; the code itself comes from the core resolver or the EC tag.
 	// Held by pointer so the core header stays free of <wx/image.h>.
 	CCountryFlags *GetCountryFlags() { return m_countryFlags; }
 #endif
@@ -784,11 +747,9 @@ class CamuleGuiApp : public CamuleApp, public CamuleGuiBase
 	void OnQueryEndSession(wxCloseEvent &evt);
 
 #ifdef __WXMAC__
-	// Restore the main window when the user clicks the Dock icon
-	// while no aMule windows are visible. Default wxApp::MacReopenApp
-	// behaviour is to do nothing when the frame is hidden, so a
-	// window hidden via the close button (HideOnClose pref) stays
-	// permanently hidden - the app appears stuck.
+	// Restore the main window when the user clicks the Dock icon while no aMule
+	// windows are visible. wxApp::MacReopenApp does nothing when the frame is
+	// hidden, so a window hidden via HideOnClose would stay hidden for good.
 	virtual void MacReopenApp();
 
 	// Finder "Open With" / double-click on a .emulecollection, and Dock
@@ -796,12 +757,11 @@ class CamuleGuiApp : public CamuleApp, public CamuleGuiBase
 	// the config dir is always set by the time we run.
 	virtual void MacOpenFiles(const wxArrayString &fileNames);
 
-	// ed2k:// and magnet: clicks. A safety net, not the usual path: in
-	// practice the kAEGetURL handler in ProtocolHandlerManager_mac.mm
-	// receives these. wxNSAppController registers for the same event in
-	// applicationWillFinishLaunching, and -setEventHandler: replaces per
-	// (class, id), so which one is live is a question of load order we
-	// don't control. Whichever wins, the URL is queued exactly once.
+	// ed2k:// and magnet: clicks. A safety net, not the usual path: in practice
+	// the kAEGetURL handler in ProtocolHandlerManager_mac.mm receives these.
+	// wxNSAppController registers for the same event and -setEventHandler:
+	// replaces per (class, id), so which one is live depends on load order; either
+	// way the URL is queued exactly once.
 	virtual void MacOpenURL(const wxString &url);
 #endif
 
@@ -837,12 +797,10 @@ private:
 	int OnExit();
 
 	virtual int InitGui(bool geometry_enable, wxString &geometry_string);
-	// The GTK wxApps sets its file name conversion properly
-	// in wxApp::Initialize(), while wxAppConsole::Initialize()
-	// does not, leaving wxConvFileName being set to wxConvLibc. File
-	// name conversion should be set otherwise amuled will abort to
-	// handle non-ASCII file names which monolithic amule can handle.
-	// This function are overridden to perform this.
+	// wxApp::Initialize() sets the file name conversion properly, but
+	// wxAppConsole::Initialize() leaves wxConvFileName as wxConvLibc, on which
+	// amuled aborts for the non-ASCII file names monolithic amule handles. This
+	// override sets it.
 	virtual bool Initialize(int &argc_, wxChar **argv_);
 
 public:

--- a/src/amuleAppCommon.cpp
+++ b/src/amuleAppCommon.cpp
@@ -137,21 +137,17 @@ CamuleAppCommon::~CamuleAppCommon()
 #ifdef __WXGTK__
 bool CamuleAppCommon::IsWaylandSession()
 {
-	// Explicit GDK_BACKEND=x11 forces the app onto XWayland - OS
-	// minimize events come through reliably, so treat it as X11.
-	// This is the documented user workaround for "I want MinToTray
-	// on Wayland": launch with `GDK_BACKEND=x11 amule`. Same trick
-	// Discord users adopt to get their tray icon back on Wayland.
+	// Explicit GDK_BACKEND=x11 forces the app onto XWayland, where OS minimize
+	// events come through reliably, so treat it as X11. This is the documented
+	// user workaround for "I want MinToTray on Wayland".
 	if (const char *gb = getenv("GDK_BACKEND")) {
 		if (strncmp(gb, "x11", 3) == 0) {
 			return false;
 		}
 	}
-	// WAYLAND_DISPLAY is set by Wayland servers to the socket name
-	// (e.g. "wayland-0") for any client running under that session.
-	// XDG_SESSION_TYPE is the systemd-logind hint and is also set
-	// to "wayland" on every common distro. Either non-empty match
-	// is treated as a Wayland session.
+	// WAYLAND_DISPLAY is set by Wayland servers to the socket name for any client
+	// in that session; XDG_SESSION_TYPE is the systemd-logind hint, also set to
+	// "wayland" on every common distro. Either non-empty match counts.
 	if (const char *wd = getenv("WAYLAND_DISPLAY")) {
 		if (wd[0] != '\0') {
 			return true;
@@ -169,24 +165,19 @@ bool CamuleAppCommon::IsWaylandSession()
 void CamuleAppCommon::SanitiseTrayPreferences()
 {
 #if defined(__WXGTK__) && !defined(WITH_LIBAYATANA_APPINDICATOR)
-	// On Linux without libayatana-appindicator3 the tray icon falls
-	// back to the legacy GtkStatusIcon backend, which GNOME Shell
-	// dropped in 3.26 and wlroots-based compositors never picked up
-	// — the icon is silently invisible. Force the pref off so users
-	// don't end up with the window hidden via HideOnClose and no
-	// surface to bring it back. The sanity check below will then
-	// cascade MinToTray off as well.
+	// On Linux without libayatana-appindicator3 the tray icon falls back to the
+	// legacy GtkStatusIcon backend, which GNOME Shell dropped in 3.26 and wlroots
+	// compositors never picked up -- the icon is silently invisible. Force the pref
+	// off so users do not end up with the window hidden via HideOnClose and no
+	// surface to bring it back; the sanity check below cascades MinToTray off too.
 	thePrefs::SetUseTrayIcon(false);
 #endif
 
 #ifdef __WXGTK__
-	// xdg-shell intentionally doesn't deliver iconified-state
-	// notifications to clients, so on Wayland the system minimize
-	// button cannot trigger our Show(false) hide-to-tray path.
-	// The same gap is documented in qBittorrent #17265, Telegram
-	// #2123, KeePassXC #6502 and others. Force MinToTray off when
-	// running under a Wayland session so the option doesn't appear
-	// to "do nothing" — the prefs panel also greys the checkbox.
+	// xdg-shell intentionally does not deliver iconified-state notifications to
+	// clients, so on Wayland the system minimize button cannot trigger our
+	// Show(false) hide-to-tray path. Force MinToTray off there so the option does
+	// not appear to do nothing; the prefs panel also greys the checkbox.
 	if (IsWaylandSession()) {
 		thePrefs::SetMinToTray(false);
 	}
@@ -201,14 +192,11 @@ void CamuleAppCommon::SanitiseTrayPreferences()
 
 void CamuleAppCommon::RefreshSingleInstanceChecker()
 {
-	// Reacquire after daemonization fork(). POSIX advisory locks are
-	// owned by the parent process, not inherited by the child, so the
-	// forked daemon needs to relock the same file. Historically this
-	// path was disabled on __WXMAC__ + AMULE_DAEMON because linking
-	// wxSingleInstanceChecker into a wxAppConsole (headless) binary
-	// pulled in Cocoa framework symbols. InstanceLock has no wx-GUI
-	// dependencies on POSIX (fcntl only), so amuled/Mac now has
-	// working single-instance detection too.
+	// Reacquire after the daemonization fork(). POSIX advisory locks are owned by
+	// the parent process and not inherited, so the forked daemon must relock the
+	// same file. This path used to be disabled on __WXMAC__ + AMULE_DAEMON because
+	// wxSingleInstanceChecker pulled Cocoa symbols into a headless binary;
+	// InstanceLock is fcntl-only on POSIX, so amuled/Mac now works too.
 	delete m_singleInstance;
 	m_singleInstance = new InstanceLock();
 	// Same self-description as the first acquire: the fork is the daemon, and
@@ -220,9 +208,9 @@ void CamuleAppCommon::RefreshSingleInstanceChecker()
 
 void CamuleAppCommon::ReleaseSingleInstance()
 {
-	// ~InstanceLock() -> Release() unlinks the lock file and drops the
-	// fcntl lock. Needed because OnExit() terminates via std::_Exit(),
-	// which skips ~CamuleAppCommon and so would leave the file behind.
+	// ~InstanceLock() -> Release() unlinks the lock file and drops the fcntl lock.
+	// OnExit() terminates via std::_Exit(), which skips ~CamuleAppCommon and would
+	// otherwise leave the file behind.
 	delete m_singleInstance;
 	m_singleInstance = nullptr;
 }
@@ -235,8 +223,8 @@ bool CamuleAppCommon::DeferShutDownToOuterLoop(const std::function<void()> &retr
 	}
 
 	// Exit() only asks the loop to stop, so the frames between here and the
-	// ShowModal() that started it still have to unwind before the teardown
-	// can safely run -- hence the retry rather than falling through.
+	// ShowModal() that started it still have to unwind before teardown can safely
+	// run -- hence the retry rather than falling through.
 	active->Exit();
 
 	if (!m_deferredShutDown) {
@@ -275,16 +263,14 @@ void CamuleAppCommon::AddLinksFromFile()
 		return;
 	}
 
-	// Attempt to lock the ED2KLinks file.
 	CFileLock lock((const char *)unicode2char(fullPath));
 
 	wxTextFile file(fullPath);
 	if (file.Open()) {
-		// Group the links by category and hand each group to AddLinks() in
-		// one call. A collection expands to hundreds of lines, and the
-		// per-link AddLink() path costs one EC round trip - and potentially
-		// one error dialog - per link on the remote GUI. Order within a
-		// category is preserved; categories run in first-seen order.
+		// Group the links by category and hand each group to AddLinks() in one
+		// call: a collection expands to hundreds of lines, and the per-link path
+		// costs one EC round trip (and possibly one error dialog) each on the
+		// remote GUI. Order within a category is preserved.
 		std::vector<std::pair<uint8, wxArrayString>> batches;
 
 		for (unsigned int i = 0; i < file.GetLineCount(); i++) {
@@ -328,11 +314,9 @@ void CamuleAppCommon::AddLinksFromFile()
 		AddLogLineNS(_("Failed to open ED2KLinks file."));
 	}
 
-	// Delete the file.
 	wxRemoveFile(thePrefs::GetConfigDir() + "ED2KLinks");
 }
 
-// Returns a magnet ed2k URI
 wxString CamuleAppCommon::CreateMagnetLink(const CAbstractFile *f)
 {
 	CMagnetURI uri;
@@ -352,7 +336,6 @@ wxString CamuleAppCommon::CreateMagnetLink(const CAbstractFile *f)
 	return uri.GetLink();
 }
 
-// Returns a ed2k file URL
 wxString CamuleAppCommon::CreateED2kLink(
 	const CAbstractFile *f, bool add_source, bool use_hostname, bool add_cryptoptions, bool add_AICH)
 {
@@ -361,7 +344,6 @@ wxString CamuleAppCommon::CreateED2kLink(
 	wxString strURL = CFormat("ed2k://|file|%s|%i|%s|") % f->GetFileName().Cleanup(false) %
 			  f->GetFileSize() % f->GetFileHash().Encode();
 
-	// Append the AICH info
 	if (add_AICH) {
 		const CKnownFile *kf = dynamic_cast<const CKnownFile *>(f);
 		if (kf && kf->HasProperAICHHashSet()) {
@@ -372,7 +354,6 @@ wxString CamuleAppCommon::CreateED2kLink(
 	strURL << "/";
 
 	if (add_source && theApp->IsConnected() && !theApp->IsFirewalled()) {
-		// Create the first part of the URL
 		strURL << "|sources,";
 		if (use_hostname) {
 			strURL << thePrefs::GetYourHostname();
@@ -420,34 +401,27 @@ bool CamuleAppCommon::InitCommon(int argc, wxChar **argv)
 		OSType = "Unknown";
 	}
 
-	// Parse cmdline arguments.
 	wxCmdLineParser cmdline(argc, argv);
 
-	// Handle these arguments.
 	cmdline.AddSwitch("v", "version", "Displays the current version number.");
 	cmdline.AddSwitch("h", "help", "Displays this information.");
 	cmdline.AddOption("c", "config-dir", "read config from <dir> instead of home");
-	// One-shot autostart toggle. Called by the Windows installer's
-	// Components-page checkbox and by the Preferences UI; lives in
-	// AutostartManager so the OS-specific store (Windows registry,
-	// macOS LaunchAgent, Linux XDG .desktop) is hidden from callers.
+	// One-shot autostart toggle, called by the Windows installer's Components page
+	// and by the Preferences UI. Lives in AutostartManager so the OS-specific
+	// store stays hidden from callers.
 	cmdline.AddOption("",
 		"configure-autostart",
 		"Enable or disable starting this binary on user login (on|off), then exit.");
-	// One-shot ed2k:// + magnet: URL-scheme handler toggle. Called by
-	// the Windows installer's Components-page checkboxes and by the
-	// Preferences UI / first-run wizard; lives in ProtocolHandlerManager
-	// so the OS-specific store (Windows registry, Linux mimeapps.list,
-	// macOS LaunchServices) is hidden from callers.
+	// One-shot ed2k:// + magnet: URL-scheme handler toggle, called by the Windows
+	// installer's Components page and by the Preferences UI / first-run wizard.
+	// Lives in ProtocolHandlerManager for the same reason.
 	cmdline.AddOption("",
 		"configure-protocols",
 		"Register/unregister aMule as the default handler for URL schemes, then exit. "
 		"Values: on|off (both schemes) or ed2k:on|ed2k:off|magnet:on|magnet:off "
 		"(per-scheme). The Windows installer invokes the per-scheme form.");
-	// Same one-shot shape as the two above. Called by the Windows
-	// installer's Components-page checkbox and by the Preferences UI /
-	// first-run wizard; also the way a portable or self-built copy can
-	// register itself without an installer.
+	// Same one-shot shape as the two above; also how a portable or self-built copy
+	// registers itself without an installer.
 	cmdline.AddOption("",
 		"configure-file-assoc",
 		"Register/unregister aMule as the handler for .emulecollection files, then exit. "
@@ -490,7 +464,6 @@ bool CamuleAppCommon::InitCommon(int argc, wxChar **argv)
 	cmdline.AddSwitch("i", "enable-stdin", "Do not disable stdin.");
 #endif
 
-	// Allow passing of links to the app
 	cmdline.AddOption("t", "category", "Set category for passed ED2K links.", wxCMD_LINE_VAL_NUMBER);
 	cmdline.AddParam(
 		"ED2K link", wxCMD_LINE_VAL_STRING, wxCMD_LINE_PARAM_OPTIONAL | wxCMD_LINE_PARAM_MULTIPLE);
@@ -531,21 +504,18 @@ bool CamuleAppCommon::InitCommon(int argc, wxChar **argv)
 				"configure-autostart expects 'on' or 'off' (got '%s')\n",
 				(const char *)unicode2char(autostart_arg));
 		}
-		// Exit either way - this flag is a one-shot toggle, not a
-		// "run aMule WITH autostart enabled" combo. (Caller can chain:
-		// `amule --configure-autostart on && amule`.)
-		// Return-false here propagates to OnInit returning false, which
-		// makes wxApp terminate cleanly with exit code 0/1 per `ok`.
-		// Using exit() directly would skip wx destructors.
+		// Exit either way: this flag is a one-shot toggle, not a "run aMule WITH
+		// autostart enabled" combo. Returning false propagates to OnInit, so wxApp
+		// terminates cleanly with exit code 0/1 per `ok`; exit() would skip the wx
+		// destructors.
 		return false;
 	}
 
 	wxString protocols_arg;
 	if (cmdline.Found("configure-protocols", &protocols_arg)) {
 		protocols_arg.MakeLower();
-		// Parse both the legacy bare on|off (applies to both schemes)
-		// and the per-scheme ed2k:on|ed2k:off|magnet:on|magnet:off form
-		// the Windows installer's two SecProto* sections now use.
+		// Both the legacy bare on|off (applying to both schemes) and the
+		// per-scheme ed2k:on|magnet:off form the Windows installer now uses.
 		bool doEd2k = false, doMagnet = false;
 		bool wantEnable = false;
 		bool parsed = true;
@@ -620,7 +590,6 @@ bool CamuleAppCommon::InitCommon(int argc, wxChar **argv)
 
 	wxString configdir;
 	if (cmdline.Found("config-dir", &configdir)) {
-		// Make an absolute path from the config dir
 		wxFileName fn(configdir);
 		fn.MakeAbsolute();
 		configdir = fn.GetFullPath();
@@ -632,15 +601,12 @@ bool CamuleAppCommon::InitCommon(int argc, wxChar **argv)
 		thePrefs::SetConfigDir(/*OtherFunctions::*/ GetConfigDir(m_configFile));
 	}
 
-	// Backtracing works in MSW.
-	// Problem is just that the backtraces are useless, because apparently the context gets lost
-	// in the try/catch somewhere.
-	// So leave it out.
+	// Left out on MSW: backtraces there are useless, because the context is
+	// apparently lost somewhere in the try/catch.
 #ifndef __WINDOWS__
 	m_disableFatal = cmdline.Found("disable-fatal");
 #if wxUSE_ON_FATAL_EXCEPTION
 	if (!m_disableFatal) {
-		// catch fatal exceptions
 		wxHandleFatalExceptions(true);
 	}
 #endif
@@ -650,7 +616,6 @@ bool CamuleAppCommon::InitCommon(int argc, wxChar **argv)
 #ifdef AMULE_DAEMON
 	enable_daemon_fork = cmdline.Found("full-daemon");
 	if (cmdline.Found("pid-file", &m_PidFile)) {
-		// Remove any existing PidFile
 		if (wxFileExists(m_PidFile))
 			wxRemoveFile(m_PidFile);
 	}
@@ -712,10 +677,9 @@ bool CamuleAppCommon::InitCommon(int argc, wxChar **argv)
 			for (size_t i = 0; i < linksPassed; i++) {
 				const wxString param = cmdline.GetParam(i);
 
-				// A .emulecollection argument stands for every link
-				// inside it. This is what makes a double-click in a
-				// file manager work on Linux and Windows, where the
-				// path arrives as an ordinary argument.
+				// A .emulecollection argument stands for every link inside
+				// it, which is what makes a file-manager double-click work
+				// where the path arrives as an ordinary argument.
 				wxArrayString expanded;
 				const CollectionExpansion expansion =
 					ExpandPassedCollection(param, expanded, cat);
@@ -746,16 +710,16 @@ bool CamuleAppCommon::InitCommon(int argc, wxChar **argv)
 
 	m_singleInstance = new InstanceLock();
 	wxString lockfile = IsRemoteGui() ? "muleLockRGUI" : "muleLock";
-	// Recorded in the lock file so a later launch knows whether the holder
-	// has a window. amuled shares muleLock with the monolithic GUI, and only
-	// one of the two can be brought to the front.
+	// Recorded in the lock file so a later launch knows whether the holder has a
+	// window: amuled shares muleLock with the monolithic GUI, and only one of the
+	// two can be brought to the front.
 	const wxString selfKind = IsDaemon() ? "amuled" : (IsRemoteGui() ? "amulegui" : "amule");
 	InstanceLock::Result lockResult =
 		m_singleInstance->Acquire(lockfile, thePrefs::GetConfigDir(), selfKind);
 	if (lockResult == InstanceLock::LOCK_HELD) {
-		// Neutral: something holds it. WHAT holds it is decided below, and
-		// saying "an instance is already running" before that check meant
-		// the log asserted it and then contradicted itself two lines later.
+		// Neutral: something holds it, and WHAT holds it is decided below. Saying
+		// "an instance is already running" here meant the log asserted it and then
+		// contradicted itself two lines later.
 		AddLogLineNS(
 			CFormat(LOG_PRELOCALE("(lock file: %s%s)")) % thePrefs::GetConfigDir() % lockfile);
 		if (linksPassed) {
@@ -768,25 +732,20 @@ bool CamuleAppCommon::InitCommon(int argc, wxChar **argv)
 			}
 		}
 
-		// The lock is held, but by what? Two holders have nothing to raise,
-		// and both used to end the launch in silence.
+		// The lock is held, but by what? Two holders have nothing to raise, and
+		// both used to end the launch in silence.
 		//
-		// On POSIX any process can take a write lock on the file, so a
-		// backup or indexing agent doing so is indistinguishable from here;
-		// the pid aMule records tells them apart, because a foreign holder
-		// never refreshes it. On Windows that case cannot arise: only aMule
-		// creates the named mutex, and the OS releases it when its owner
-		// dies, so a held mutex is already proof of a live aMule.
+		// On POSIX any process can take a write lock on the file, so a backup or
+		// indexing agent is indistinguishable from here; the pid aMule records
+		// tells them apart, because a foreign holder never refreshes it. On Windows
+		// that cannot arise: only aMule creates the named mutex, and the OS releases
+		// it when its owner dies. What both share is amuled, which uses the same
+		// lock as the monolithic GUI and has no window, so the raise below was
+		// always a no-op the user could not see.
 		//
-		// What both share is amuled, which uses the same lock as the
-		// monolithic GUI -- only amulegui gets one of its own. A daemon has
-		// no window, so the raise below was always a no-op the user could
-		// not see (#1351).
-		//
-		// Deliberately conservative: anything not established counts as
-		// raisable, so the only new dialog is one we are sure about. A lock
-		// record with no kind line was written by an older aMule and keeps
-		// the old behaviour exactly.
+		// Deliberately conservative: anything not established counts as raisable, so
+		// the only new dialog is one we are sure about, and a lock record with no
+		// kind line (written by an older aMule) keeps the old behaviour exactly.
 		const int holder = m_singleInstance->HolderPid();
 		const wxString holderKind = m_singleInstance->HolderKind();
 #ifdef __WINDOWS__
@@ -820,21 +779,19 @@ bool CamuleAppCommon::InitCommon(int argc, wxChar **argv)
 				      holder;
 			}
 			theApp->ShowAlert(msg, _("aMule cannot start"), wxOK | wxICON_ERROR);
-			// No raise request: nothing is going to act on it, and the line
-			// would sit in ED2KLinks until some later start consumed it and
-			// raised itself for no reason.
+			// No raise request: nothing would act on it, and the line would sit in
+			// ED2KLinks until some later start consumed it and raised itself.
 			return false;
 		}
 
 		AddLogLineCS(
 			CFormat(LOG_PRELOCALE("There is an instance of %s already running")) % m_appName);
 
-		// This is very tricky. The most secure way to communicate is via ED2K links file
+		// The ED2K links file is the most secure way to communicate this.
 		//
-		// Raise the window even when we did hand links over. It matters most
-		// for a file-manager double-click on a collection: the links land in
-		// the running instance either way, but without this the user gets no
-		// visible response at all and assumes nothing happened.
+		// Raise the window even when links were handed over. It matters most for a
+		// file-manager double-click on a collection: the links land in the running
+		// instance either way, but without this there is no visible response.
 		wxTextFile ed2kFile(thePrefs::GetConfigDir() + "ED2KLinks");
 		if (!ed2kFile.Exists()) {
 			ed2kFile.Create();
@@ -860,57 +817,46 @@ bool CamuleAppCommon::InitCommon(int argc, wxChar **argv)
 	}
 
 #ifndef __WINDOWS__
-	// Close standard-input
 	if (!cmdline.Found("enable-stdin")) {
-		// The full daemon will close all std file-descriptors by itself,
-		// so closing it here would lead to the closing on the first open
-		// file, which is the logfile opened below
+		// The full daemon closes all std file-descriptors itself, so closing here
+		// would instead close the first open file, which is the logfile below.
 		if (!enable_daemon_fork) {
 			close(0);
 		}
 	}
 #endif
 
-	// Create the CFG file we shall use and set the config object as the
-	// global cfg file. CamuleFileConfig is a wxFileConfig subclass that
-	// wraps every entry / group lookup in an LC_CTYPE="C" scope so the
-	// case-insensitive sorted-array binary searches are locale-
-	// deterministic. The initial parse below also has to run under
-	// LC_CTYPE="C" so the in-memory sort order matches what subsequent
-	// Read / Write calls will use - otherwise a session that runs under
-	// a non-C locale silently accumulates duplicate key=value lines in
-	// amule.conf (#852).
+	// Create the CFG file and set it as the global config. CamuleFileConfig wraps
+	// every entry / group lookup in an LC_CTYPE="C" scope so the case-insensitive
+	// sorted-array binary searches are locale-deterministic. The initial parse
+	// below must run under the same scope so the in-memory sort order matches what
+	// later Read / Write calls use -- otherwise a session under a non-C locale
+	// silently accumulates duplicate key=value lines in amule.conf.
 	{
 		CCtypeAsciiScope scope;
 		wxConfig::Set(new CamuleFileConfig("", "", thePrefs::GetConfigDir() + m_configFile));
 	}
 
-	// The config holds the EC password, which is the credential itself rather
-	// than a verifier -- anything that can read this file can drive the daemon.
-	// It is created with whatever the umask allows, which on Debian and Ubuntu
-	// defaults to group-writable. Tighten it here rather than at creation so
-	// configs that already exist are covered too. The .bak is a full copy and
-	// needs the same treatment.
+	// The config holds the EC password, which is the credential itself rather than
+	// a verifier -- anything that can read this file can drive the daemon. It is
+	// created with whatever the umask allows, group-writable by default on Debian
+	// and Ubuntu. Tightened here rather than at creation so existing configs are
+	// covered too; the .bak is a full copy and needs the same.
 	if (RestrictToOwner(CPath(thePrefs::GetConfigDir() + m_configFile))) {
 		AddLogLineN(CFormat(_("Restricted permissions on %s to owner-only.")) % m_configFile);
 	}
 	RestrictToOwner(CPath(thePrefs::GetConfigDir() + m_configFile + ".bak"));
 
-	// Make a backup of the log file
 	CPath logfileName = CPath(thePrefs::GetConfigDir() + m_logFile);
 	if (logfileName.FileExists()) {
 		CPath::BackupFile(logfileName, ".bak");
 	}
 
-	// Open the log file
 	if (!theLogger.OpenLogfile(logfileName.GetRaw())) {
-		// use std err as last resolt to indicate problem
 		fputs("ERROR: unable to open log file\n", stderr);
-		// failure to open log is serious problem
 		return false;
 	}
 
-	// Load Preferences
 	CPreferences::BuildItemList(thePrefs::GetConfigDir());
 	CPreferences::LoadAllItems(wxConfigBase::Get());
 
@@ -924,18 +870,14 @@ bool CamuleAppCommon::InitCommon(int argc, wxChar **argv)
 	}
 #endif
 
-	// If an autostart entry exists pointing at a stale path (user
-	// moved the AppImage / .app / install dir since they enabled the
-	// toggle), silently rewrite it to the current canonical path so
-	// the next login launches the right binary. No-op if no entry
-	// exists - disabling autostart is always a deliberate choice we
-	// don't second-guess.
+	// An autostart entry pointing at a stale path (the AppImage / .app / install
+	// dir moved since the toggle was enabled) is silently rewritten to the current
+	// canonical path. No-op when no entry exists: disabling autostart is a
+	// deliberate choice.
 	AutostartManager::SelfHealOnStartup();
 
-	// Same idea for the URL-scheme handler registration: if we're the
-	// current handler for ed2k:/magnet: but the registered path drifted
-	// (user moved the AppImage / .app / install dir), rewrite it. No-op
-	// if we aren't the current handler for a given scheme.
+	// Same for the URL-scheme handler registration: rewrite a drifted path where
+	// we are the current handler, no-op where we are not.
 	ProtocolHandlerManager::SelfHealOnStartup();
 
 	return true;
@@ -1000,17 +942,15 @@ CamuleAppCommon::CollectionExpansion CamuleAppCommon::ExpandPassedCollection(
 
 	unsigned skipped = 0;
 	for (size_t i = 0; i < collection.size(); ++i) {
-		// eMule stores collection strings as UTF-8. Fall back to raw
-		// bytes rather than dropping the entry, since FromUTF8 yields
-		// an empty string on invalid input.
+		// eMule stores collection strings as UTF-8. Fall back to raw bytes rather
+		// than dropping the entry, since FromUTF8 yields empty on invalid input.
 		wxString link = wxString::FromUTF8(collection[i].c_str());
 		if (link.IsEmpty()) {
 			link = wxString::From8BitData(collection[i].c_str());
 		}
 
-		// Route through CheckPassedLink so a collection link gets the
-		// same validation, canonicalisation and category suffix as one
-		// typed on the command line.
+		// Route through CheckPassedLink so a collection link gets the same
+		// validation, canonicalisation and category suffix as a command-line one.
 		wxString checked;
 		if (CheckPassedLink(link, checked, cat)) {
 			out.Add(checked);
@@ -1090,7 +1030,6 @@ bool CamuleAppCommon::CheckMuleDirectory(
 		msg << CFormat("Could not create the %s directory at '%s'.") % desc % directory;
 	}
 
-	// Attempt to use fallback directory.
 	const CPath fallback(alternative);
 	if (fallback.IsOk() && (directory != fallback)) {
 		msg << "\nAttempting to use default directory at location \n'" << alternative << "'.";

--- a/src/amuleDlg.cpp
+++ b/src/amuleDlg.cpp
@@ -158,11 +158,9 @@ wxEND_EVENT_TABLE()
 // (hide-to-tray on close, or start minimized) maps no window, and
 // xdg-desktop-portal's background monitor then kills it unless the "background"
 // permission was granted. aMule never asked for it, so on backends that default
-// to deny (KDE) the app was killed on close (amule-org/amule#535). Requesting it
-// registers aMule as a legitimate background app, so the permission is granted
-// (or, on KDE, prompted once and remembered). Native, non-sandboxed builds are
-// not background-monitored -- hence the FLATPAK_ID gate -- and this is a no-op
-// wherever there is no Background portal (the call just fails silently).
+// to deny (KDE) the app was killed on close. Requesting it registers aMule as a
+// legitimate background app. Native builds are not background-monitored -- hence
+// the FLATPAK_ID gate -- and this is a no-op wherever there is no portal.
 static void RequestFlatpakBackgroundPermission()
 {
 	if (g_getenv("FLATPAK_ID") == nullptr) {
@@ -187,9 +185,8 @@ static void RequestFlatpakBackgroundPermission()
 	g_variant_builder_add(&options, "{sv}", "autostart", g_variant_new_boolean(FALSE));
 
 	// Fire-and-forget: the portal grants (or on KDE prompts once) and records the
-	// permission for next launch. We don't need the returned request handle, and
-	// must not block the GUI waiting on a possible prompt -- the shared GTK main
-	// loop flushes this async call.
+	// permission for next launch. The returned request handle is not needed, and
+	// the GUI must not block waiting on a possible prompt.
 	g_dbus_connection_call(conn,
 		"org.freedesktop.portal.Desktop",
 		"/org/freedesktop/portal/desktop",
@@ -294,13 +291,11 @@ CamuleDlg::CamuleDlg(wxWindow *pParent, const wxString &title, wxPoint where, wx
 	// size the .ico already carries.
 	SetIcons(wxIconBundle("aMule", wxGetInstance()));
 #else
-	// Elsewhere the icon comes from CamuleArtProvider. A bundle, and a
-	// set of sizes rather than one: GetIcon() resolves through
-	// CreateBitmap(), which decodes the embedded PNG and nothing else, so
-	// the window manager got a single 32px raster to scale for the
-	// taskbar, the alt-tab switcher and the window frame alike. The
-	// bundle path consults the icon's SVG twin, so each size below is
-	// rendered rather than resampled.
+	// Elsewhere the icon comes from CamuleArtProvider. A bundle, and a set of
+	// sizes rather than one: GetIcon() resolves through CreateBitmap(), which
+	// decodes the embedded PNG and nothing else, so the window manager got a
+	// single 32px raster to scale for the taskbar, the alt-tab switcher and the
+	// window frame alike. The bundle path consults the icon's SVG twin instead.
 	wxIconBundle icons;
 	const wxBitmapBundle logo = wxArtProvider::GetBitmapBundle("amule:amule");
 	for (const int side : { 16, 24, 32, 48, 64, 128, 256 }) {
@@ -408,22 +403,20 @@ CamuleDlg::CamuleDlg(wxWindow *pParent, const wxString &title, wxPoint where, wx
 		CreateSystray();
 	}
 
-	// Deferred on the monolithic build, where the startup splash is up and
-	// the work it reports on -- part-file load, shared-file scan, hashing --
-	// runs on this thread. A window shown now would sit there taking clicks
-	// it cannot answer, and the first of those would raise it over the splash
-	// that was explaining the wait. CamuleApp closes the splash and calls
-	// this. amulegui has no such wait: its startup is an EC round trip.
+	// Deferred on the monolithic build, where the startup splash is up and the
+	// work it reports on -- part-file load, shared-file scan, hashing -- runs on
+	// this thread. A window shown now would sit there taking clicks it cannot
+	// answer, and the first of those would raise it over the splash that was
+	// explaining the wait. amulegui has no such wait.
 #ifdef CLIENT_GUI
 	ShowStartupWindow();
 #endif
 
 #if defined(ENABLE_VERSION_CHECK) && defined(CLIENT_GUI)
-	// amulegui only: defer the "is a newer aMule available?" check until the
-	// event loop is running (past the heavy startup I/O), then check and maybe
-	// pop up. The monolithic app drives this from the shared core engine
-	// (CamuleApp::StartVersionCheck -> Notify_VersionCheckResult) instead, so
-	// there is a single fetch that also feeds the EC version state.
+	// amulegui only: defer the "is a newer aMule available?" check until the event
+	// loop is running, past the heavy startup I/O. The monolithic app drives this
+	// from the shared core engine instead, so there is a single fetch that also
+	// feeds the EC version state.
 	CallAfter(&CamuleDlg::StartupVersionCheck);
 #endif
 
@@ -439,16 +432,13 @@ CamuleDlg::CamuleDlg(wxWindow *pParent, const wxString &title, wxPoint where, wx
 	// Set shortcut keys
 #ifdef __WXMAC__
 	// Alt+<letter> tab-switch shortcuts, exposed as real NSMenuItem key
-	// equivalents rather than wxAcceleratorEntry entries: on wxOSX
-	// (tested with wxWidgets 3.3.3 / macOS 26) an accelerator-table
-	// entry fires its wxEVT_MENU exactly once per click-to-refocus --
-	// the *first* Alt+<letter> after the window (re)gains key status
-	// switches tabs as expected, but every subsequent press is silently
-	// swallowed by Cocoa's key-equivalent dispatch until the user
-	// clicks something in the window again. Real menu key equivalents
-	// are dispatched by the OS itself and don't share that bug -- and
-	// as a bonus, VoiceOver can navigate an actual menu directly, which
-	// the (currently VoiceOver-invisible, see #180) toolbar can't offer.
+	// equivalents rather than wxAcceleratorEntry entries: on wxOSX an
+	// accelerator-table entry fires its wxEVT_MENU exactly once per
+	// click-to-refocus -- the FIRST Alt+<letter> after the window regains key
+	// status switches tabs, but every subsequent press is silently swallowed by
+	// Cocoa's key-equivalent dispatch until the user clicks in the window again.
+	// Real menu key equivalents are dispatched by the OS itself, and VoiceOver
+	// can navigate an actual menu directly.
 	wxAcceleratorEntry entries[] = { wxAcceleratorEntry(wxACCEL_CTRL, 'Q', wxID_EXIT) };
 	SetAcceleratorTable(wxAcceleratorTable(itemsof(entries), entries));
 
@@ -491,10 +481,10 @@ CamuleDlg::CamuleDlg(wxWindow *pParent, const wxString &title, wxPoint where, wx
 
 	wxASSERT(networks_notebook->GetPageCount() == 2);
 
-	// Capture the network-conditional log tabs by the control each hosts, not
-	// by index -- amulegui's tab layout differs from the monolithic build, and
-	// an index-based scheme silently dropped Kad Info when the "aMuleGUI Log"
-	// tab was added. DoNetworkRearrange() shows/hides these by identity.
+	// Capture the network-conditional log tabs by the control each hosts, not by
+	// index -- amulegui's tab layout differs from the monolithic build, and an
+	// index-based scheme silently dropped Kad Info when the "aMuleGUI Log" tab
+	// was added. DoNetworkRearrange() shows/hides these by identity.
 	m_logServerInfo = CaptureLogPage(logs_notebook, ID_SERVERINFO);
 	m_logED2KInfo = CaptureLogPage(logs_notebook, ID_ED2KINFO);
 	m_logKadInfo = CaptureLogPage(logs_notebook, ID_KADINFO);
@@ -517,16 +507,12 @@ void CamuleDlg::ShowStartupWindow()
 	Show(true);
 
 	// Workaround for wxMSW: Create_Toolbar() (and the Realize() inside
-	// Apply_Toolbar_Skin) runs before the frame is mapped at its final
-	// on-screen size. wxMSW's native toolbar control measures whether labels
-	// fit at *that* moment to pick its display mode (icon-only vs
-	// icon-with-label-below); with long-string locales (it_IT, fr_FR, ...) on
-	// amulegui (one fewer button than the monolithic GUI, so a slightly
-	// different total width) the initial measurement decides icon-only and
-	// never recovers when the frame later resizes to the saved/maximized
-	// geometry, leaving the labels clipped. Re-realize the toolbar after
-	// Show(true) so the mode is picked against the actual on-screen frame
-	// width.
+	// Apply_Toolbar_Skin) runs before the frame is mapped at its final on-screen
+	// size. wxMSW's native toolbar measures whether labels fit at *that* moment
+	// to pick its display mode, so with long-string locales the initial
+	// measurement decides icon-only and never recovers when the frame later
+	// resizes to the saved geometry, leaving the labels clipped. Re-realize the
+	// toolbar after Show(true), against the actual on-screen frame width.
 	if (m_wndToolbar) {
 		m_wndToolbar->Realize();
 	}
@@ -625,26 +611,21 @@ void CamuleDlg::CreateSystray()
 void CamuleDlg::RemoveSystray()
 {
 	// Deleted on the next idle rather than here. "Exit" on the tray menu is
-	// handled by the tray icon itself (see MuleTrayIcon.cpp's event table),
-	// and wxTaskBarIcon::PopupMenu() pushes the icon as its own window's
-	// event handler for the duration of the menu's nested event loop, popping
-	// it again only after the menu returns (msw/taskbar.cpp). Shutting down
-	// from that item therefore reaches here with the icon still pushed and
-	// its window procedure on the stack, so deleting it now destroys the
-	// window while the handler is attached -- which asserts in
-	// ~wxWindowBase(), and is undefined behaviour whether or not assertions
-	// are compiled in.
+	// handled by the tray icon itself, and wxTaskBarIcon::PopupMenu() pushes the
+	// icon as its own window's event handler for the duration of the menu's
+	// nested event loop, popping it again only after the menu returns. Shutting
+	// down from that item therefore reaches here with the icon still pushed and
+	// its window procedure on the stack, so deleting it now destroys the window
+	// while the handler is attached -- which asserts in ~wxWindowBase(), and is
+	// undefined behaviour whether or not assertions are compiled in.
 	//
-	// ScheduleForDestruction() would be the obvious tool but takes a
-	// wxObject*, and under WITH_LIBAYATANA_APPINDICATOR CMuleTrayIcon has no
-	// base class at all. CallAfter() on the dialog works in both builds.
+	// ScheduleForDestruction() would be the obvious tool but takes a wxObject*,
+	// and under WITH_LIBAYATANA_APPINDICATOR CMuleTrayIcon has no base class at
+	// all. CallAfter() on the dialog works in both builds.
 	//
-	// Clearing the member first keeps this idempotent, and the recreate path
-	// (unticking then reticking the tray-icon preference) is unaffected: each
-	// click is a separate event, so the pending deletion has run by the time
-	// CreateSystray() looks. On the shutdown path the queued call may never
-	// run at all if the main loop stops first -- the process is exiting, and
-	// the icon goes with it.
+	// Clearing the member first keeps this idempotent, and the recreate path is
+	// unaffected: each click is a separate event, so the pending deletion has run
+	// by the time CreateSystray() looks.
 	CMuleTrayIcon *icon = m_wndTaskbarNotifier;
 	m_wndTaskbarNotifier = NULL;
 	if (icon) {
@@ -654,12 +635,10 @@ void CamuleDlg::RemoveSystray()
 
 void CamuleDlg::UpdateFreeSpaceLabels()
 {
-	// Only the panel actually on screen: nobody can read a label on a panel
-	// that is behind another one or in a window hidden to the tray, and the
-	// Downloads refresh walks the whole queue to decide whether to warn.
-	// The figures themselves are free to read -- a CFreeSpaceThread sample
-	// published into an atomic -- so this skips pointless work, not a
-	// blocking call.
+	// Only the panel actually on screen: nobody can read a label on a panel that
+	// is behind another one or in a window hidden to the tray, and the Downloads
+	// refresh walks the whole queue to decide whether to warn. The figures
+	// themselves are free to read, so this skips pointless work, not a block.
 	if (!IsVisibleToUser()) {
 		return;
 	}
@@ -696,9 +675,8 @@ bool SetLabelIfChanged(wxStaticText *label, const wxString &text)
 // with the main content area, so laying the parent out re-flowed everything
 // under it -- on the main window that includes the search page and its results
 // notebook -- to make room for a few characters of text. On wxMSW that
-// invalidation erases the notebook whenever no page covers it, which is the
-// flicker reported in issue #1037. The containing sizer is the bar alone,
-// which is the only thing that ever has to move.
+// invalidation erases the notebook whenever no page covers it. The containing
+// sizer is the bar alone, which is the only thing that ever has to move.
 void RelayoutLabelStrip(wxWindow *label)
 {
 	if (wxSizer *strip = label->GetContainingSizer()) {
@@ -729,10 +707,9 @@ void CamuleDlg::SetFreeSpaceLabel(
 		return;
 	}
 
-	// Nothing to say rather than something wrong: the figure is missing
-	// when the directory could not be queried at all -- it doesn't exist,
-	// or its mount (commonly a NAS for the temp or incoming directory) is
-	// unreachable. Printing "0 bytes" there would read as a full disk.
+	// Nothing to say rather than something wrong: the figure is missing when the
+	// directory could not be queried at all -- it does not exist, or its mount
+	// (commonly a NAS) is unreachable. "0 bytes" would read as a full disk.
 	if (freeSpace == FREE_SPACE_UNKNOWN) {
 		// The separator exists only to join this figure to the field
 		// before it, so it goes when the figure does -- otherwise the
@@ -756,12 +733,10 @@ void CamuleDlg::SetFreeSpaceLabel(
 		label->Refresh();
 	}
 
-	// The separator sits in its own label and is never recoloured: a
-	// wxStaticText colours all or nothing, so a separator sharing this label
-	// turned red along with the figure whenever the warning fired. It is
-	// layout, not language, so it stays out of the catalog either way and
-	// translators are given the figure alone -- and the gaps around it are
-	// sizer border, so the bar carries no whitespace of its own.
+	// The separator sits in its own label and is never recoloured: a wxStaticText
+	// colours all or nothing, so a separator sharing this label turned red along
+	// with the figure whenever the warning fired. It is layout, not language, so
+	// it stays out of the catalog -- and the gaps around it are sizer border.
 	bool relayout = SetLabelIfChanged(separatorLabel, "|");
 	if (separatorLabel && !separatorLabel->IsShown()) {
 		separatorLabel->Show(true);
@@ -777,51 +752,44 @@ void CamuleDlg::SetFreeSpaceLabel(
 void CamuleDlg::RestoreMainWindow()
 {
 #ifdef __WXMAC__
-	// Restore the regular Dock icon before the window comes back. It has
-	// to happen first: activating a Dock-less (accessory) application
-	// gives no visible focus change, so the window would return behind
-	// whatever the user is looking at.
+	// Restore the regular Dock icon before the window comes back. It has to
+	// happen first: activating a Dock-less (accessory) application gives no
+	// visible focus change, so the window would return behind whatever the user
+	// is looking at.
 	mac_set_accessory_mode(false);
 #endif
-	// Restoring is a decision, not something to infer from events: this is
-	// the one place that knows the user asked for the window back, so the
-	// logical flag is cleared here rather than left to OnShow/OnMinimize.
+	// Restoring is a decision, not something to infer from events: this is the
+	// one place that knows the user asked for the window back, so the logical
+	// flag is cleared here rather than left to OnShow/OnMinimize.
 	//
-	// Those events do not arrive on the path that matters. On Windows, a
-	// window that is hidden *and* iconized -- which is what minimize-to-tray
-	// leaves behind -- gets neither wxEVT_SHOW nor wxEVT_ICONIZE from the
-	// sequence below: Iconize(false) restores and shows it, so the Show(true)
-	// after it sees an already-shown window and never reaches ShowWindow(),
-	// so no WM_SHOWWINDOW and no wxShowEvent. The flag then stays set for the
-	// rest of the session and IsVisibleToUser() never becomes true again,
-	// which stops the free-space refresh, keeps the tray toggle stuck on
-	// "restore", and leaves amulegui reconnecting quietly (#941, #817).
-	// Restoring a window that was only hidden does fire wxEVT_SHOW, which is
-	// why this looked intermittent.
+	// Those events do not arrive on the path that matters. On Windows, a window
+	// that is hidden *and* iconized -- what minimize-to-tray leaves behind --
+	// gets neither wxEVT_SHOW nor wxEVT_ICONIZE from the sequence below:
+	// Iconize(false) restores and shows it, so the Show(true) after it sees an
+	// already-shown window and never reaches ShowWindow(). The flag then stays
+	// set for the rest of the session and IsVisibleToUser() never becomes true
+	// again, which stops the free-space refresh and keeps the tray toggle stuck
+	// on "restore". Restoring a window that was only hidden does fire
+	// wxEVT_SHOW, which is why this looked intermittent.
 	m_iconized_logical = false;
 
 #ifdef CLIENT_GUI
-	// Same reasoning one step further: a reconnect that has been retrying
-	// quietly behind a tray-hidden window now has a window to explain itself
-	// in. OnMainWindowRestored() is otherwise reached only from OnShow() and
-	// OnMinimize(), i.e. from the two events the paragraph above explains do
-	// not arrive on this path -- so on Windows the dialog never appeared for
-	// a user who came back mid-outage, which is what issue #942 reports.
-	// Cheap to call unconditionally: it returns immediately unless a
-	// reconnect is running without a dialog, and defers the dialog itself to
-	// CallAfter, so the platforms that do deliver wxEVT_SHOW just no-op the
-	// second call.
+	// Same reasoning one step further: a reconnect that has been retrying quietly
+	// behind a tray-hidden window now has a window to explain itself in.
+	// OnMainWindowRestored() is otherwise reached only from OnShow() and
+	// OnMinimize(), i.e. from the two events that do not arrive on this path --
+	// so on Windows the dialog never appeared for a user who came back
+	// mid-outage. Cheap to call unconditionally: it returns immediately unless a
+	// reconnect is running without a dialog.
 	theApp->OnMainWindowRestored();
 #endif
 
-	// Clear the iconized bit on every platform — the window might be
-	// hidden (Show(false) via HideOnClose / minimize-to-tray) or just
-	// iconized to the OS Dock/taskbar; in either case the user wants a
-	// normal restored frame. Without this, Show(true) on a still-iconized
-	// window would leave it as a taskbar entry / Dock thumbnail without
-	// un-minimizing. Iconize(false) is idempotent on a non-iconized
-	// window — don't gate on IsIconized(), because wxGTK can report a
-	// stale value during the tray-restore transition.
+	// Clear the iconized bit on every platform -- the window might be hidden
+	// (Show(false) via HideOnClose / minimize-to-tray) or just iconized to the OS
+	// Dock/taskbar; in either case the user wants a normal restored frame.
+	// Without this, Show(true) on a still-iconized window would leave it as a
+	// taskbar entry without un-minimizing. Iconize(false) is idempotent, so do
+	// not gate on IsIconized(): wxGTK can report a stale value mid-transition.
 	Iconize(false);
 	Show(true);
 	Raise();
@@ -830,11 +798,10 @@ void CamuleDlg::RestoreMainWindow()
 void CamuleDlg::HideToTray()
 {
 #ifdef __WXMAC__
-	// Drop NSApp's activation policy to Accessory before hiding — that
-	// removes the Dock icon (and any in-flight miniaturize-to-Dock
-	// target), so hiding doesn't leave a Dock thumbnail behind. The tray
-	// icon stays as the only recovery surface; RestoreMainWindow() restores
-	// both the Dock icon and the window.
+	// Drop NSApp's activation policy to Accessory before hiding -- that removes
+	// the Dock icon, and any in-flight miniaturize-to-Dock target, so hiding does
+	// not leave a Dock thumbnail behind. The tray icon stays as the only recovery
+	// surface; RestoreMainWindow() restores both.
 	mac_set_accessory_mode(true);
 #endif
 	Show(false);
@@ -848,12 +815,10 @@ void CamuleDlg::OnToolBarButton(wxCommandEvent &ev)
 	if (m_is_safe_state) {
 
 		// Leaving the search page hides the handler again, since without
-		// GetFED2KLH() it belongs to that page only. Re-clicking the search
-		// button while already on the page used to toggle the handler
-		// instead -- a 2005 shortcut that no other toolbar button has, that
-		// nothing advertises, and that did nothing at all once
-		// "show in every window" was enabled. Clicking the page you are
-		// already on now simply stays put (amule-org/amule#1041).
+		// GetFED2KLH() it belongs to that page only. Re-clicking the search button
+		// while already on the page used to toggle the handler instead -- a 2005
+		// shortcut that no other toolbar button has, that nothing advertises, and
+		// that did nothing at all once "show in every window" was enabled.
 		if (lastbutton == ID_BUTTONSEARCH && !thePrefs::GetFED2KLH() &&
 			ev.GetId() != ID_BUTTONSEARCH) {
 			ShowED2KLinksHandler(false);
@@ -909,10 +874,9 @@ void CamuleDlg::OnToolBarButton(wxCommandEvent &ev)
 
 		// A physical click auto-toggles the clicked wxITEM_CHECK tool, so
 		// historically this only had to untoggle the *previous* one. An
-		// accelerator or menu event (Alt+<letter>, the macOS Navigate menu)
-		// doesn't click anything, so the new tab's tool never lit up that
-		// way -- leaving no toolbar button active until the next mouse
-		// click (amule-org/amule#642 review). Toggle both ends explicitly.
+		// accelerator or menu event does not click anything, so the new tab's tool
+		// never lit up that way -- leaving no toolbar button active until the next
+		// mouse click. Toggle both ends explicitly.
 		if (lastbutton != ev.GetId()) {
 			m_wndToolbar->ToggleTool(lastbutton, false);
 		}
@@ -939,11 +903,11 @@ void CamuleDlg::OnPrefButton(wxCommandEvent &WXUNUSED(ev))
 		}
 
 		m_prefsDialog->TransferToWindow();
-		// The dialog is built once and reused, so the shared-folders editor
-		// would otherwise keep the roots it captured the first time this was
-		// opened — stale as soon as anything else changes them (a remote GUI
-		// over EC, for one). Re-seed it per session; it declines while the
-		// user has edits pending so this can never discard them.
+		// The dialog is built once and reused, so the shared-folders editor would
+		// otherwise keep the roots it captured the first time this was opened --
+		// stale as soon as anything else changes them, a remote GUI over EC for
+		// one. Re-seed it per session; it declines while the user has edits
+		// pending so this can never discard them.
 		m_prefsDialog->PrepareSharedDirsForSession();
 		m_prefsDialog->Show(true);
 		m_prefsDialog->Raise();
@@ -1220,22 +1184,17 @@ void CamuleDlg::AddServerMessageLine(wxString &message)
 
 void CamuleDlg::ShowConnectionState()
 {
-	// Wipe the Server Info text ctrl on any transition that leaves it
-	// showing messages from a server we're no longer talking to:
-	//   1) connected -> disconnected
-	//   2) connected to A -> connected to B (server switch)
-	// The data side (amuled's server_msg, shared with the monolithic
-	// build) is wiped in the matching block inside
-	// CamuleApp::ShowConnectionState; here we only ResetLog the text
-	// ctrl. We deliberately don't touch the amulegui side's
-	// CServerInfoHandlerRem::m_seenSoFar snapshot: if we cleared it
-	// locally and amuled's cleanup hadn't landed yet, the next poll
-	// would replay the stale buffer through the "fullLog starts with
-	// empty seenSoFar" path. Leaving the snapshot alone lets
-	// HandlePacket's existing StartsWith-vs-else logic handle the
-	// transition naturally -- once amuled's server_msg shortens
-	// after its own clear, the prefix mismatches and the else branch
-	// resets the local view properly.
+	// Wipe the Server Info text ctrl on any transition that leaves it showing
+	// messages from a server we are no longer talking to: connected ->
+	// disconnected, or connected to A -> connected to B.
+	//
+	// The data side (amuled's server_msg) is wiped in the matching block inside
+	// CamuleApp::ShowConnectionState; here we only ResetLog the text ctrl. The
+	// amulegui side's CServerInfoHandlerRem::m_seenSoFar snapshot is
+	// deliberately left alone: clearing it locally while amuled's cleanup had
+	// not landed yet would make the next poll replay the stale buffer through
+	// the "fullLog starts with empty seenSoFar" path. Leaving it lets
+	// HandlePacket's StartsWith-vs-else logic handle the transition naturally.
 	static bool s_wasConnectedED2K = false;
 	static CServer *s_lastConnectedServer = NULL;
 	bool nowConnectedED2K = theApp->IsConnectedED2K();
@@ -1258,9 +1217,7 @@ void CamuleDlg::ShowConnectionState()
 	m_serverwnd->UpdateED2KConnectButton();
 	m_kademliawnd->UpdateConnectButton();
 
-	////////////////////////////////////////////////////////////
 	// Determine the status of the networks
-	//
 	enum ED2KState
 	{
 		ED2KOff = 0,
@@ -1371,13 +1328,11 @@ void CamuleDlg::ShowConnectionState()
 		}
 
 		// GetBitmapFor() hands back the art-provider-cached bundle's own
-		// (copy-on-write) bitmap, and a wxMemoryDC draws into that shared
-		// pixel buffer without unsharing it. Compositing the overlays
-		// straight onto it would stamp the arrows into the cached base, so
-		// they would accumulate on every later state change (and poison the
-		// base for any other consumer of the bundle). Draw into a private
-		// deep copy instead. The overlays are fetched the same way, so they
-		// share baseIcon's scale factor and line up during compositing.
+		// (copy-on-write) bitmap, and a wxMemoryDC draws into that shared pixel
+		// buffer without unsharing it. Compositing the overlays straight onto it
+		// would stamp the arrows into the cached base, so they would accumulate on
+		// every later state change. Draw into a private deep copy instead; the
+		// overlays are fetched the same way, so they share baseIcon's scale factor.
 		wxBitmap statusIcon(baseIcon.ConvertToImage(), -1, baseIcon.GetScaleFactor());
 
 		{
@@ -1399,8 +1354,7 @@ void CamuleDlg::ShowConnectionState()
 		// pixel size already matches the window DPI. Setting it on the static
 		// bitmap as-is renders the globe DPI-scale times larger than the sibling
 		// status icons, which are bundle-backed and size themselves in logical
-		// units. Stamp the window's scale factor on the composite so its logical
-		// size matches theirs (a no-op at 100% DPI).
+		// units. Stamp the window's scale factor on the composite instead.
 		statusIcon.SetScaleFactor(connBitmap->GetDPIScaleFactor());
 
 		connBitmap->SetBitmap(statusIcon);
@@ -1468,8 +1422,7 @@ void CamuleDlg::OnCoreVersionClicked(wxMouseEvent &WXUNUSED(event))
 	// stock glyphs are template symbols that take the system label colour, so
 	// they render grey and ignore a tint, and tinting is not portable either --
 	// GTK's error icon is already a red disc with a white cross, which a blanket
-	// recolour would flatten. These two are a matched pair from one set, so the
-	// states differ only in colour.
+	// recolour would flatten. These two are a matched pair from one set.
 	ShowInfoGridDialog(
 		this,
 		_("Version"),
@@ -1603,18 +1556,16 @@ void CamuleDlg::DlgShutDown()
 
 void CamuleDlg::OnClose(wxCloseEvent &evt)
 {
-	// Gated on the tray icon because on Linux and Windows it is the only
-	// way back once the frame is hidden. Deliberately a plain Show(false)
-	// rather than HideToTray(): on macOS the Dock icon stays, which is
-	// what the close button is supposed to leave behind there, and the
-	// Dock-reopen handler (CamuleGuiApp / CamuleRemoteGuiApp
-	// ::MacReopenApp) brings the window back from it.
+	// Gated on the tray icon because on Linux and Windows it is the only way back
+	// once the frame is hidden. Deliberately a plain Show(false) rather than
+	// HideToTray(): on macOS the Dock icon stays, which is what the close button
+	// is supposed to leave behind there, and the Dock-reopen handler brings the
+	// window back from it.
 	bool hideOnClose = thePrefs::HideOnClose() && thePrefs::UseTrayIcon();
-	// Quit menus (Cmd+Q, Dock right-click → Quit, tray-icon Exit) all
-	// either pass force=true to Close() (CanVeto()==false) or set the
-	// app's IsQuitting() flag from OnQueryEndSession. Either signal
-	// bypasses the hide-on-close branch so HideOnClose only governs
-	// the red close-button gesture itself.
+	// Quit menus (Cmd+Q, Dock right-click Quit, tray-icon Exit) all either pass
+	// force=true to Close() or set the app's IsQuitting() flag from
+	// OnQueryEndSession. Either signal bypasses the hide-on-close branch, so
+	// HideOnClose only governs the red close-button gesture itself.
 	if (hideOnClose && evt.CanVeto() && !theApp->IsQuitting()) {
 		Show(false);
 		evt.Veto();
@@ -1792,13 +1743,11 @@ void CamuleDlg::OnShow(wxShowEvent &evt)
 #endif
 	}
 #ifdef WITH_LIBAYATANA_APPINDICATOR
-	// SNI tray menus are static between rebuilds, so the
-	// "Show aMule"/"Hide aMule" entry's label can drift out of sync
-	// when the window is hidden via paths that don't go through
-	// CMuleTrayIcon::DoShowHide (close-button HideOnClose,
-	// minimize-to-tray, programmatic Show(false) via the tray
-	// menu's hide-and-restore). Re-tracking visibility here keeps
-	// the menu honest across every entry point.
+	// SNI tray menus are static between rebuilds, so the "Show aMule"/"Hide
+	// aMule" entry's label can drift out of sync when the window is hidden via
+	// paths that do not go through CMuleTrayIcon::DoShowHide (close-button
+	// HideOnClose, minimize-to-tray, a programmatic Show(false)). Re-tracking
+	// visibility here keeps the menu honest across every entry point.
 	if (m_wndTaskbarNotifier) {
 		m_wndTaskbarNotifier->RebuildMenu();
 	}
@@ -1808,19 +1757,16 @@ void CamuleDlg::OnShow(wxShowEvent &evt)
 
 void CamuleDlg::OnMinimize(wxIconizeEvent &evt)
 {
-	// Snapshot the iconize state straight from the event — wxFrame's
-	// IsIconized() is unreliable on wxGTK during the minimize-button
-	// transition, so consumers that need to know if the window is
-	// iconized (tray menu label, DoShowHide branch decision) read
-	// IsTrayLogicallyIconized() instead.
+	// Snapshot the iconize state straight from the event -- wxFrame's
+	// IsIconized() is unreliable on wxGTK during the minimize-button transition,
+	// so consumers that need to know read IsTrayLogicallyIconized() instead.
 	m_iconized_logical = evt.IsIconized();
 
 #ifdef CLIENT_GUI
-	// Coming back from the taskbar/Dock with a reconnect running quietly
-	// behind the window: now that there is a frozen window to explain, put the
-	// dialog up (issue #806). OnShow covers the same for the tray paths, which
-	// hide the frame without ever iconizing it. theApp is the remote-GUI app
-	// here -- this file is compiled per target, not shared via muleappgui.
+	// Coming back from the taskbar/Dock with a reconnect running quietly behind
+	// the window: now that there is a frozen window to explain, put the dialog
+	// up. OnShow covers the same for the tray paths, which hide the frame
+	// without ever iconizing it.
 	if (IsVisibleToUser()) {
 		theApp->OnMainWindowRestored();
 	}
@@ -1905,12 +1851,10 @@ void CamuleDlg::OnGUITimer(wxTimerEvent &WXUNUSED(evt))
 		m_kademliawnd->UpdateNodeCount(CStatistics::GetKadNodes());
 
 #if defined(ENABLE_VERSION_CHECK) && defined(CLIENT_GUI)
-		// amulegui periodic re-check (daily). amulegui is not a CamuleApp, so
-		// it has no core engine; it re-runs its own CVersionCheck. Fires
-		// immediately the first time the preference is enabled at runtime
-		// (m_lastGuiVersionCheck == 0). StartupVersionCheck() is a no-op while
-		// a check is already in flight. The monolithic app drives its periodic
-		// check from CamuleApp::OnCoreTimer instead.
+		// amulegui periodic re-check (daily). amulegui is not a CamuleApp, so it
+		// has no core engine and re-runs its own CVersionCheck. Fires immediately
+		// the first time the preference is enabled at runtime.
+		// StartupVersionCheck() is a no-op while a check is already in flight.
 		if (thePrefs::GetCheckNewVersion() &&
 			(m_lastGuiVersionCheck == 0 ||
 				time(nullptr) - m_lastGuiVersionCheck >= 24 * 60 * 60)) {
@@ -1922,13 +1866,11 @@ void CamuleDlg::OnGUITimer(wxTimerEvent &WXUNUSED(evt))
 	if (msCur - msPrev1 > 1000) { // every second
 		msPrev1 = msCur;
 
-		// The clients page shows live speeds and transfer totals, so it wants
-		// a per-second refresh -- and no more. This timer fires at 10 Hz, so
-		// outside this block the whole sweep ran ten times a second: every
-		// peer the core knows re-read, both panes rebuilt and the known-client
-		// store reconciled, for a display that changes once a second at most
-		// (issue #920). Only while the page is on screen: off-screen the
-		// repaint would draw nothing.
+		// The clients page shows live speeds and transfer totals, so it wants a
+		// per-second refresh -- and no more. This timer fires at 10 Hz, so outside
+		// this block the whole sweep ran ten times a second: every peer the core
+		// knows re-read, both panes rebuilt and the known-client store
+		// reconciled, for a display that changes once a second at most.
 		if (m_clientswnd && m_activewnd == static_cast<wxWindow *>(m_clientswnd)) {
 			m_clientswnd->UpdateAll();
 		}
@@ -1943,10 +1885,9 @@ void CamuleDlg::OnGUITimer(wxTimerEvent &WXUNUSED(evt))
 		}
 #ifndef CLIENT_GUI
 		// Animate the search progress bar for the visible tab while the search
-		// window is up. This is the periodic tick the cosmetic Kad ramp needs
-		// (a Kad search has no per-result notify to drive it) and refreshes a
-		// running ed2k percent too. amulegui drives the same bar from its EC
-		// progress poll instead, so it is excluded here.
+		// window is up. This is the periodic tick the cosmetic Kad ramp needs -- a
+		// Kad search has no per-result notify to drive it -- and refreshes a
+		// running ed2k percent too. amulegui drives the same bar from EC instead.
 		if (m_searchwnd && m_searchwnd->IsShown()) {
 			m_searchwnd->RefreshVisibleTabProgress();
 		}
@@ -2013,12 +1954,11 @@ bool CamuleDlg::Check_and_Init_Skin()
 
 	wxStandardPathsBase &spb(wxStandardPaths::Get());
 #ifdef __WINDOWS__
-	// Windows portable layout: amule.exe lives in bin\ and installable
-	// data (skins, ...) in ..\share\amule\.  wx returns the exe directory
-	// for both GetPluginsDir() and GetDataDir() on Windows, so relocate
-	// to the FHS-style path the installer actually populates.  Has to
-	// match the Preferences enumeration above (Preferences.cpp::TransferToWindow)
-	// or the dropdown would offer a skin we can't load.  (#783)
+	// Windows portable layout: amule.exe lives in bin\ and installable data
+	// (skins, ...) in ..\share\amule\. wx returns the exe directory for both
+	// GetPluginsDir() and GetDataDir() on Windows, so relocate to the FHS-style
+	// path the installer actually populates. Has to match the Preferences
+	// enumeration, or the dropdown would offer a skin we cannot load.
 	wxString dataDir(JoinPaths(JoinPaths(spb.GetDataDir(), ".."), "share"));
 	dataDir = JoinPaths(dataDir, "amule");
 #elif defined(__WXMAC__)
@@ -2079,27 +2019,22 @@ void CamuleDlg::Add_Skin_Icon(const wxString &iconName, const wxBitmap &stdIcon,
 	} else if (iconName.StartsWith("Toolbar_")) {
 		if (!useSkins) {
 			// The built-in toolbar art ships as an SVG twin through
-			// CamuleArtProvider ("amule:toolbar_<name>"), which wx
-			// rasterizes at whatever size/DPI the toolbar asks for.
-			// An active skin keeps full control: its PNG takes the
-			// raster path below instead.
-			// Fold "Toolbar_Foo" to the "toolbar_foo" art id.
-			// CCtypeAsciiScope pins LC_CTYPE to "C" so wxString::Lower()
-			// stays ASCII-correct: in a Turkic locale it would otherwise
-			// map 'I' to the dotless 'ı' and "Toolbar_Import" would no
-			// longer match the embedded id (same helper the GeoIP flag
-			// lookup uses).
+			// CamuleArtProvider ("amule:toolbar_<name>"), which wx rasterizes at
+			// whatever size/DPI the toolbar asks for. An active skin keeps full
+			// control: its PNG takes the raster path below instead.
+			//
+			// CCtypeAsciiScope pins LC_CTYPE to "C" so wxString::Lower() stays
+			// ASCII-correct when folding "Toolbar_Foo" to the art id: in a Turkic
+			// locale it would map 'I' to the dotless 'i'.
 			CCtypeAsciiScope asciiCtype;
 			wxBitmapBundle art = wxArtProvider::GetBitmapBundle(
 				CamuleArtProvider::MakeId(iconName.Lower()), wxART_TOOLBAR, wxSize(32, 32));
 			if (!art.IsOk()) {
-				// Every built-in toolbar icon ships embedded in
-				// icon_data.c, generated from the same src/icons/
-				// sources CamuleArtProvider reads -- this can only
-				// fail with a broken build, not a reachable runtime
-				// condition. Fall back to a generic stock icon rather
-				// than shipping a bespoke raster twin of each toolbar
-				// asset just for an error path that can't happen.
+				// Every built-in toolbar icon ships embedded in icon_data.c, generated
+				// from the same src/icons/ sources CamuleArtProvider reads -- this can
+				// only fail with a broken build, not a reachable runtime condition.
+				// Fall back to a generic stock icon rather than shipping a bespoke
+				// raster twin of each toolbar asset for an error path that cannot happen.
 				AddLogLineN(LOG_DIAGNOSTIC("Warning: Could not load built-in icon for ") +
 					    iconName);
 				art = wxArtProvider::GetBitmapBundle(

--- a/src/amuleDlg.h
+++ b/src/amuleDlg.h
@@ -319,20 +319,18 @@ public:
 
 	int m_srv_split_pos;
 
-	// Last frame geometry seen while NOT iconized. SaveGUIPrefs uses
-	// it as the fallback when the user exits from a minimized state
-	// (otherwise the iconized GetPosition() returns sentinel values
-	// like -32000,-32000 on Windows and the saved pos is unusable).
+	// Last frame geometry seen while NOT iconized. SaveGUIPrefs uses it as the
+	// fallback when the user exits from a minimized state, where the iconized
+	// GetPosition() returns sentinel values like -32000,-32000 on Windows.
 	wxPoint m_lastShownPos;
 	wxSize m_lastShownSize;
 	bool m_lastShownMaximized;
 	bool m_lastShownValid;
 
 	wxImageList m_imagelist;
-	// Toolbar icons as resolution-aware bundles (the 32x32 art plus a
-	// smooth 2x upscale). The executable is per-monitor-DPI aware, so a
-	// plain 32px wxBitmap would be drawn at 32 *physical* pixels — tiny
-	// and blurry on hi-DPI screens.
+	// Toolbar icons as resolution-aware bundles (the 32x32 art plus a smooth 2x
+	// upscale). The executable is per-monitor-DPI aware, so a plain 32px wxBitmap
+	// would be drawn at 32 PHYSICAL pixels -- tiny and blurry on hi-DPI screens.
 	std::vector<wxBitmapBundle> m_tblist;
 
 protected:
@@ -372,12 +370,10 @@ private:
 	bool m_versionPopupShown = false;
 
 #if defined(ENABLE_VERSION_CHECK) && defined(CLIENT_GUI)
-	// amulegui-only: it is not a CamuleApp and so has no core version-check
-	// engine, so the remote GUI runs its own CVersionCheck. The monolithic
-	// app instead drives the popup from the shared core engine via
-	// Notify_VersionCheckResult -> ShowVersionAvailable(). Owned; created
-	// lazily by StartupVersionCheck() when the preference is on. A periodic
-	// re-check is fired from OnGUITimer.
+	// amulegui-only: it is not a CamuleApp and has no core version-check engine, so
+	// the remote GUI runs its own CVersionCheck. The monolithic app drives the popup
+	// from the shared core engine instead. Owned, created lazily by
+	// StartupVersionCheck() when the preference is on.
 	CVersionCheck *m_startupVersionCheck = nullptr;
 	time_t m_lastGuiVersionCheck = 0;
 	void StartupVersionCheck();
@@ -385,29 +381,25 @@ private:
 #endif // ENABLE_VERSION_CHECK && CLIENT_GUI
 
 public:
-	// Show the "a new version is available" popup: at most once per session
-	// (m_versionPopupShown), and never for a version the user muted via the
-	// dialog's "Don't ask again" checkbox (recorded per-version in
-	// last_version_notified, so a newer release still asks). Called from the
-	// core engine (Notify_VersionCheckResult) in the monolithic app and from
+	// Show the "a new version is available" popup: at most once per session, and
+	// never for a version the user muted via the dialog's "Don't ask again"
+	// checkbox, which is recorded per-version so a newer release still asks. Called
+	// from the core engine in the monolithic app and from
 	// OnStartupVersionCheckDone in amulegui.
 	void ShowVersionAvailable(const wxString &latest);
 
-	// Track iconize state from wxIconizeEvent::IsIconized(), which is
-	// reliable across platforms — unlike wxFrame::IsIconized() which
-	// can return false on wxGTK after a minimize-button click while
-	// the OS still has the window iconized. Tray menu and DoShowHide
-	// consult this to decide whether the window is "visible to the
-	// user" so the "Show aMule"/"Hide aMule" label and the click
-	// action stay in sync with reality.
+	// Track iconize state from wxIconizeEvent::IsIconized(), which is reliable
+	// across platforms -- unlike wxFrame::IsIconized(), which can return false on
+	// wxGTK after a minimize click while the OS still has the window iconized. The
+	// tray menu and DoShowHide consult this to keep the "Show aMule" / "Hide aMule"
+	// label and the click action in step with reality.
 	bool IsTrayLogicallyIconized() const { return m_iconized_logical; }
 
-	/// Whether the user can actually see the window. Both halves are needed
-	/// and neither is enough: minimized to Dock/taskbar keeps IsShown() true
-	/// while nothing is on screen, and hidden to tray (tray menu, minimize-to-
-	/// tray, HideOnClose) leaves the iconized bit clear while the frame is
-	/// gone. Used by the tray menu to label Show/Hide, and by amulegui to
-	/// decide whether a modal is worth putting up (issue #806).
+	/// Whether the user can actually see the window. Both halves are needed and
+	/// neither is enough: minimized to Dock/taskbar keeps IsShown() true while
+	/// nothing is on screen, and hidden to tray leaves the iconized bit clear while
+	/// the frame is gone. Used by the tray menu to label Show/Hide, and by amulegui
+	/// to decide whether a modal is worth putting up (issue #806).
 	bool IsVisibleToUser() const { return IsShown() && !m_iconized_logical; }
 
 private:
@@ -419,12 +411,11 @@ private:
 	WX_DECLARE_STRING_HASH_MAP(wxZipEntry *, ZipCatalog);
 	ZipCatalog cat;
 
-	// Network-conditional log tabs (Server Info / ED2K Info / Kad Info),
-	// captured by the control each page hosts rather than by notebook index:
-	// the tab layout differs between the monolithic build and amulegui (which
-	// adds an "aMuleGUI Log" tab), and index-based tracking silently broke Kad
-	// Info when that tab was inserted. DoNetworkRearrange() shows/hides these by
-	// identity; the always-on tabs (aMule Log, aMuleGUI Log) are left alone.
+	// Network-conditional log tabs (Server Info / ED2K Info / Kad Info), captured by
+	// the control each page hosts rather than by notebook index: the tab layout
+	// differs between the monolithic build and amulegui, and index-based tracking
+	// silently broke Kad Info when the "aMuleGUI Log" tab was inserted.
+	// DoNetworkRearrange() shows and hides these by identity.
 	PageType m_logServerInfo;
 	PageType m_logED2KInfo;
 	PageType m_logKadInfo;

--- a/src/amuled.cpp
+++ b/src/amuled.cpp
@@ -117,15 +117,14 @@ IMPLEMENT_APP_NO_MAIN(CamuleDaemonApp)
 
 #ifndef __WINDOWS__
 // amuled's `-f`/`--full-daemon` must daemonize BEFORE wxEntry() initialises
-// wxWidgets. On macOS wxWidgets links the Cocoa core, which spins up framework
-// threads during app init; forking *after* that and then calling into ObjC from
-// the child -- the FSEvents run-loop pump, the version-check HTTP fetch, Kad
-// startup -- trips the ObjC fork-safety guard and aborts (or spins at 100% CPU).
-// Forking first lets Cocoa initialise fresh in the child and sidesteps the whole
-// fork-after-init hazard class; it's harmless on Linux/*BSD. Everything then
-// runs in the child, so the partfile/UBT worker threads constructed during
+// wxWidgets. On macOS wx links the Cocoa core, which spins up framework threads
+// during app init; forking AFTER that and then calling into ObjC from the child
+// -- the FSEvents run-loop pump, the version-check HTTP fetch, Kad startup --
+// trips the ObjC fork-safety guard and aborts or spins at 100% CPU. Forking first
+// lets Cocoa initialise fresh in the child, and is harmless on Linux/*BSD.
+// Everything then runs in the child, so the worker threads constructed during
 // OnInit() land in the daemon instead of being orphaned by a mid-init fork
-// (the reason that fork used to sit inside OnInit -- #849). Windows never forks.
+// (#849). Windows never forks.
 static bool AmuledWantsDaemonFork(int argc, char **argv)
 {
 	for (int i = 1; i < argc; ++i) {
@@ -146,18 +145,18 @@ static void AmuledDaemonizeEarly()
 	fprintf(stdout, "amuled: forking to background - see you\n");
 	fflush(stdout);
 
-	// Detach stdio to /dev/null and fork; the original process exits so the
-	// shell returns, and the child -- session leader after setsid() -- carries
-	// on into wxEntry(). The pid file is written later from InitGui() (now
-	// running in this child) with getpid().
+	// Detach stdio to /dev/null and fork; the original process exits so the shell
+	// returns, and the child -- session leader after setsid() -- carries on into
+	// wxEntry(). The pid file is written later from InitGui(), now running in this
+	// child, with getpid().
 	for (int i_fd = 0; i_fd < 3; ++i_fd) {
 		close(i_fd);
 	}
 	int fd = open("/dev/null", O_RDWR);
 	if (fd >= 0) {
-		// fd is 0 (lowest free after the closes); dup twice to reopen
-		// stdout(1) and stderr(2) on /dev/null. (Empty bodies: the dup
-		// return is intentionally ignored -- silences -Wunused-result.)
+		// fd is 0, the lowest free after the closes, so dup twice to reopen
+		// stdout(1) and stderr(2) on /dev/null. The empty bodies ignore the dup
+		// return deliberately, silencing -Wunused-result.
 		if (dup(fd)) {
 		}
 		if (dup(fd)) {
@@ -195,7 +194,6 @@ static BOOL CtrlHandler(DWORD fdwCtrlType)
 	case CTRL_C_EVENT:
 	case CTRL_CLOSE_EVENT:
 	case CTRL_BREAK_EVENT:
-		// handle these
 		AddDebugLogLineN(logStandard, "Received break event, exit main loop");
 		theApp->ExitMainLoop();
 		return TRUE;
@@ -203,7 +201,6 @@ static BOOL CtrlHandler(DWORD fdwCtrlType)
 	case CTRL_LOGOFF_EVENT:
 	case CTRL_SHUTDOWN_EVENT:
 	default:
-		// don't handle these
 		return FALSE;
 		break;
 	}
@@ -261,10 +258,8 @@ int CamuleDaemonApp::InitGui(bool, wxString &)
 	// drop the pid file with our own (post-setsid) pid.
 	theLogger.SetEnabledStdoutLog(false);
 	if (!m_PidFile.IsEmpty()) {
-		//
-		// Create a Pid file with the Pid of the daemon, so any daemon-manager
-		// can easily manage the process
-		//
+		// A pid file with the daemon's pid, so any daemon-manager can manage the
+		// process.
 		wxString temp = CFormat("%d\n") % (int)getpid();
 		wxFFile ff(m_PidFile, "w");
 		if (!ff.Error()) {
@@ -313,13 +308,11 @@ bool CamuleDaemonApp::Initialize(int &argc_, wxChar **argv_)
 	}
 
 #ifdef __WXOSX__
-	// macOS reports "Mac OS Roman" from GetSystemEncodingName() regardless
-	// of the user's locale, but HFS+/APFS file names are always UTF-8.
-	// Encoding with Mac Roman turns e.g. U+00AA into the single byte 0xAA,
-	// which the kernel rejects as invalid UTF-8 (EILSEQ) when the completed
-	// file is opened, leaving non-ASCII downloads stuck in PS_ERROR. The GUI
-	// is unaffected because it keeps wx's default (UTF-8) file-name
-	// converter; force UTF-8 here to match it.
+	// macOS reports "Mac OS Roman" from GetSystemEncodingName() regardless of the
+	// user's locale, but HFS+/APFS file names are always UTF-8. Encoding with Mac
+	// Roman turns U+00AA into the single byte 0xAA, which the kernel rejects as
+	// invalid UTF-8 when the completed file is opened, leaving non-ASCII downloads
+	// stuck in PS_ERROR. The GUI keeps wx's UTF-8 converter; force UTF-8 to match.
 	encName = "UTF-8";
 #endif
 

--- a/src/muuli_wdr.cpp
+++ b/src/muuli_wdr.cpp
@@ -128,11 +128,9 @@ wxSizer *muleDlg( wxWindow *parent, bool call_fit, bool set_sizer )
     // Connected core's version, left of the counters it heads. amulegui only:
     // this file is compiled per-executable, so CLIENT_GUI is the consuming
     // target's and monolithic aMule never builds it. Hidden until the EC
-    // handshake reports a version. Clickable, so it gets the hand cursor.
-    //
-    // 16x16 explicitly: with no size the bundle defaults to the icon's PNG
-    // twin, 256x256 for the logo. The size is logical, so it still renders
-    // from the SVG at the display's scale.
+    // handshake reports a version. Clickable, so it gets the hand cursor. 16x16
+    // explicitly: with no size the bundle defaults to the icon's PNG twin,
+    // 256x256 for the logo. The size is logical, so it still renders from SVG.
     wxStaticBitmap *coreVerIcon = new wxStaticBitmap( parent, -1, wxArtProvider::GetBitmapBundle( "amule:amule", wxART_OTHER, wxSize(16, 16) ), wxDefaultPosition, wxDefaultSize );
     coreVerIcon->SetName( "coreVersionImage" );
     coreVerIcon->SetCursor( wxCursor( wxCURSOR_HAND ) );
@@ -262,8 +260,8 @@ wxSizer *searchDlg( wxWindow *parent, bool call_fit, bool set_sizer )
     item1->Add( item3, wxSizerFlags().Expand().CenterVertical() );
     // One row: the five filters sit side by side, each preceded by a separator
     // from the second onwards -- 14 cells. They were split across two rows of
-    // eight while Category lived here; #979 took Category out and left Min Size
-    // stranded at the end of the first row, away from Max Size (issue #1035).
+    // eight while Category lived here, which left Min Size stranded at the end
+    // of the first row, away from Max Size.
     wxFlexGridSizer *item13 = new wxFlexGridSizer( 14, 0, 0 );
     s_extended_sizer = item13;
 
@@ -283,9 +281,9 @@ wxSizer *searchDlg( wxWindow *parent, bool call_fit, bool set_sizer )
     wxChoice *item15 = new wxChoice( item2, IDC_TypeSearch, wxDefaultPosition, wxDefaultSize, 8, strs15, 0 );
     item13->Add( item15, wxSizerFlags().Expand().CenterVertical().Border(wxALL, 5) );
     // The category selector used to sit here, between File Type and Extension.
-    // It is not a search filter -- nothing about it travels with the query --
-    // so it moved to the button row next to Download, whose destination it is
-    // (issue #979). Five filters remain: three on this row, two on the next.
+    // It is not a search filter -- nothing about it travels with the query -- so
+    // it moved to the button row next to Download, whose destination it is.
+    // Five filters remain: three on this row, two on the next.
     wxStaticLine *item16 = new wxStaticLine( item2, -1, wxDefaultPosition, wxSize(-1,20), wxLI_VERTICAL );
     item13->Add( item16, wxSizerFlags().Center().Border(wxALL, 5) );
     wxStaticText *item20 = new wxStaticText( item2, -1, _("Extension"), wxDefaultPosition, wxDefaultSize, 0 );
@@ -354,10 +352,10 @@ wxSizer *searchDlg( wxWindow *parent, bool call_fit, bool set_sizer )
     item34->Add( item41, wxSizerFlags().Center().Border(wxALL, 5) );
     wxCheckBox *item42 = new wxCheckBox( item2, ID_FILTER_KNOWN, _("Hide Known Files"), wxDefaultPosition, wxDefaultSize, 0 );
     item34->Add( item42, wxSizerFlags().Center().Border(wxALL, 5) );
-    // Clears the filter text and returns both checkboxes to their defaults
-    // (issue #698). Named in full rather than a bare "Reset" so it cannot be
-    // read as a second "Reset Fields": that button covers the search
-    // parameters, this one covers only the filter row it sits in.
+    // Clears the filter text and returns both checkboxes to their defaults. Named
+    // in full rather than a bare "Reset" so it cannot be read as a second "Reset
+    // Fields": that button covers the search parameters, this one covers only
+    // the filter row it sits in.
     wxStaticLine *item59 = new wxStaticLine( item2, -1, wxDefaultPosition, wxSize(-1,20), wxLI_VERTICAL );
     item34->Add( item59, wxSizerFlags().Center().Border(wxALL, 5) );
     wxButton *item60 = new wxButton( item2, ID_FILTER_RESET, _("Reset Filters"), wxDefaultPosition, wxDefaultSize, 0 );
@@ -384,12 +382,11 @@ wxSizer *searchDlg( wxWindow *parent, bool call_fit, bool set_sizer )
     wxButton *item50 = new wxButton( item2, IDC_SDOWNLOAD, _("Download"), wxDefaultPosition, wxDefaultSize, 0 );
     item50->Enable( false );
     item43->Add( item50, wxSizerFlags().Center().Border(wxALL, 5) );
-    // Where the button beside it sends the file. It sat in the extended-
-    // parameters row until issue #979, which made it read as a search filter --
-    // something neither ed2k nor Kad can do -- and let a chosen category be
-    // hidden and then silently ignored. Here it is always visible and its
-    // meaning is positional. Same wording as the right-click action that does
-    // the same thing (SearchListCtrl.cpp), so the two cannot drift.
+    // Where the button beside it sends the file. It sat in the extended-parameters
+    // row until that made it read as a search filter -- something neither ed2k
+    // nor Kad can do -- and let a chosen category be hidden and then silently
+    // ignored. Here it is always visible and its meaning is positional. Same
+    // wording as the right-click action that does the same thing.
     wxStaticText *item17 = new wxStaticText( item2, ID_AUTOCATASSIGN_LABEL, _("Download in category"), wxDefaultPosition, wxDefaultSize, 0 );
     item43->Add( item17, wxSizerFlags().Center().Border(wxALL, 5) );
     // Empty item list: UpdateCatChoice() fills it and keeps it in step with the
@@ -402,11 +399,9 @@ wxSizer *searchDlg( wxWindow *parent, bool call_fit, bool set_sizer )
     item43->Add( item51, wxSizerFlags().Center().Border(wxALL, 5) );
     // Ordered most to least destructive rightwards, so the mildest sits at the
     // edge where it is easiest to hit and the one that discards saved terms is
-    // furthest from it (issue #911). CSearchDlg inserts "Clear Search History"
-    // ahead of Clear Search Results at runtime, giving:
-    //   Clear Search History | Clear Search Results | Reset Fields
-    // Reset Fields last also puts it directly above "Reset Filters" in the row
-    // below, which is the control it parallels.
+    // furthest from it. CSearchDlg inserts "Clear Search History" ahead of Clear
+    // Search Results at runtime. Reset Fields last also puts it directly above
+    // "Reset Filters" in the row below, which is the control it parallels.
     wxButton *item54 = new wxButton( item2, IDC_CLEAR_RESULTS, _("Clear Search Results"), wxDefaultPosition, wxDefaultSize, 0 );
     item54->Enable( false );
     item43->Add( item54, wxSizerFlags().Center().Border(wxALL, 5) );
@@ -416,21 +411,20 @@ wxSizer *searchDlg( wxWindow *parent, bool call_fit, bool set_sizer )
     item52->Enable( false );
     item43->Add( item52, wxSizerFlags().Center().Border(wxALL, 5) );
     item1->Add( item43, wxSizerFlags().Center().Border(wxALL, 5) );
-    // Rule between the buttons and the filter row (issue #911): with extended
-    // parameters and filtering both on, five rows of fields run together, and
-    // this marks where the search parameters stop and what filters the results
-    // already on screen begins. Full width rather than the button row's extent
-    // -- that row is centred and sized to its contents, so tracking it would
-    // mean measuring it. Shown and hidden with the row it introduces; see
-    // CSearchDlg::ApplyFilterSeparator().
+    // Rule between the buttons and the filter row: with extended parameters and
+    // filtering both on, five rows of fields run together, and this marks where
+    // the search parameters stop and what filters the results already on screen
+    // begins. Full width rather than the button row's extent -- that row is
+    // centred and sized to its contents. Shown and hidden with the row it
+    // introduces; see CSearchDlg::ApplyFilterSeparator().
     wxStaticLine *item61 = new wxStaticLine( item2, ID_FILTER_SEPARATOR, wxDefaultPosition, wxDefaultSize, wxLI_HORIZONTAL );
     item1->Add( item61, wxSizerFlags().Expand().Border(wxLEFT|wxRIGHT, 5) );
-    // Filter row goes BELOW the action buttons (issue #698): filtering is not a
-    // search parameter -- it applies to results already on screen and is not
-    // touched by "Reset Fields" -- so grouping it with the search parameters
-    // above the buttons misrepresented it, and it sits closer to the results
-    // list here. Added after item43 purely for sizer order; the row itself is
-    // still built above so s_filter_sizer keeps its show/hide wiring.
+    // Filter row goes BELOW the action buttons: filtering is not a search
+    // parameter -- it applies to results already on screen and is not touched by
+    // "Reset Fields" -- so grouping it with the search parameters above the
+    // buttons misrepresented it, and it sits closer to the results list here.
+    // Added after item43 purely for sizer order; the row is still built above so
+    // s_filter_sizer keeps its show/hide wiring.
     item1->Add( item34, wxSizerFlags().Center().Border(wxLEFT|wxRIGHT, 5) );
     item0->Add( item1, wxSizerFlags().Expand().CenterVertical().Border(wxALL, 5) );
     wxStaticBox *item56 = new wxStaticBox( parent, -1, _("Results") );
@@ -510,29 +504,25 @@ wxSizer *transferBottomPane( wxWindow *parent, bool call_fit, bool set_sizer )
     item3->Add( item5, wxSizerFlags().CenterVertical().Border(wxLEFT|wxRIGHT, 5) );
     item1->Add( item3, wxSizerFlags().Center().Border(wxLEFT|wxRIGHT, 5) );
 
-    // Combined size of the downloads currently visible (category + text
-    // filter), followed by the free space on the filesystem holding the part
-    // files. Both right-aligned in the growable header's third column, and
-    // both in one box sizer so the header keeps its three columns. Set by
-    // CDownloadListCtrl::SetTotalSize() and ::UpdateFreeSpace(). No
-    // wxST_NO_AUTORESIZE: the labels must grow to fit their text (they start
-    // empty, so the flag would pin them 0-wide).
+    // Combined size of the downloads currently visible (category + text filter),
+    // followed by the free space on the filesystem holding the part files. Both
+    // right-aligned in the growable header's third column, and both in one box
+    // sizer so the header keeps its three columns. No wxST_NO_AUTORESIZE: the
+    // labels must grow to fit their text, and they start empty.
     wxBoxSizer *item5a = new wxBoxSizer( wxHORIZONTAL );
 
     wxStaticText *item5b = new wxStaticText( parent, -1, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxALIGN_RIGHT );
     item5b->SetName( "downloadsTotalSize" );
     item5a->Add( item5b, wxSizerFlags().CenterVertical() );
 
-    // The "|" joining the two figures, in a label of its own for the same
-    // reason the figure has one: a wxStaticText colours all or nothing, so a
-    // separator sharing the label below would turn red along with the figure
-    // whenever the warning fires. Shown and hidden by SetFreeSpaceLabel()
-    // together with that figure, never recoloured.
+    // The "|" joining the two figures, in a label of its own for the same reason
+    // the figure has one: a wxStaticText colours all or nothing, so a separator
+    // sharing the label below would turn red along with the figure whenever the
+    // warning fires.
     //
-    // The gaps around it are sizer border, not spaces in the text: a static
-    // text is sized to its text extent, which ignores trailing whitespace, so
-    // a " | " label loses the space on one side and -- right-aligned inside a
-    // box sized for three glyphs -- doubles it on the other.
+    // The gaps around it are sizer border, not spaces in the text: a static text
+    // is sized to its text extent, which ignores trailing whitespace, so a " | "
+    // label loses the space on one side and doubles it on the other.
     wxStaticText *item5c = new wxStaticText( parent, -1, wxEmptyString );
     item5c->SetName( "downloadsFreeSpaceSep" );
     // Starts hidden: the labels either side start empty, and a shown separator
@@ -594,16 +584,14 @@ namespace
 // fileDetails(), so the relocated download rows and the Sharing box stay
 // visually consistent with the hand-written rows.
 //
-// `appendColon` renders the label as "label:" at display time. The Sharing
-// rows use it so they can reuse existing bare translations (e.g. "Requests")
-// instead of minting a second, colon-suffixed catalog string for each.
+// `appendColon` renders the label as "label:" at display time. The Sharing rows
+// use it so they can reuse existing bare translations instead of minting a
+// second, colon-suffixed catalog string for each.
 //
 // The punctuation goes through the catalog rather than being concatenated in
 // C++, because where the colon sits is a property of the language, not of the
 // layout: Russian typography forbids the space this used to hard-code, while
-// French requires it (amule-org/amule#1294). One format string lets a
-// translator settle the convention for every row at once, and keeps the reuse
-// that motivated the flag.
+// French requires it.
 void AddFileDetailRow(
     wxWindow *rowParent, wxSizer *grid, const wxString &label, int valueId, bool appendColon = false )
 {
@@ -1733,17 +1721,13 @@ wxSizer *PreferencesFilesTab( wxWindow *parent, bool call_fit, bool set_sizer )
     wxCheckBox *item13 = new wxCheckBox( item6, IDC_ALLOCFULLFILE, _("Preallocate disk space for new files"), wxDefaultPosition, wxDefaultSize, 0 );
     item13->SetToolTip( _("For new files preallocates disk space for the whole file, thus reduces fragmentation") );
     item5->Add( item13, wxSizerFlags().CenterVertical().Border(wxTOP, 0) );
-    // /eMule/CreateSparseFiles was EC-wired and settable via the Web UI
-    // (files.create_normal) but had no control here or in amuleGUI --
-    // hand-editing amule.conf was the only way (amule-org/amule#653).
-    // Only does real work when the *core* runs on Windows (PlatformSpecific.cpp
-    // vs. PartFile.cpp both call CFile::Create(name, true) identically on
-    // POSIX). Always created and bound here -- amuleGUI has no EC capability
-    // tag to know the core's platform, so it always shows the control; the
-    // monolithic non-Windows build (where the answer is a compile-time
-    // certainty) hides it post-creation in PrefsUnifiedDlg's ctor instead of
-    // skipping creation, so the Cfg_Tmpl binding still has a widget to
-    // connect to.
+    // /eMule/CreateSparseFiles was EC-wired and settable via the Web UI but had
+    // no control here or in amuleGUI -- hand-editing amule.conf was the only
+    // way. Only does real work when the *core* runs on Windows. Always created
+    // and bound here: amuleGUI has no EC capability tag to know the core's
+    // platform, so it always shows the control, and the monolithic non-Windows
+    // build hides it post-creation in PrefsUnifiedDlg's ctor rather than
+    // skipping creation, so the Cfg_Tmpl binding still has a widget.
     wxCheckBox *itemCreateSparse = new wxCheckBox( item6, IDC_CREATEFILESSPARSE, _("Create new files as sparse files"), wxDefaultPosition, wxDefaultSize, 0 );
     itemCreateSparse->SetToolTip( _("Sparse part files only occupy disk space for the parts already downloaded, so free space is used up gradually as the file fills in. Turn this off to use an ordinary file instead - useful where sparse files are unsupported or slow, or where backup/de-duplication tools handle them badly. Applies only when the core runs on Windows; on Linux and macOS part files are sparse anyway and this setting has no effect.") );
     item5->Add( itemCreateSparse, wxSizerFlags().CenterVertical().Border(wxTOP, 0) );
@@ -1785,14 +1769,12 @@ wxSizer *PreferencesFilesTab( wxWindow *parent, bool call_fit, bool set_sizer )
 
     item0->Add( item1, wxSizerFlags().Expand().CenterVertical().Border(wxALL, 0) );
 
-    // Media metadata extraction (issue #140). Optional feature that
-    // runs ffprobe against each shared file at share-add / known.met
-    // load time to populate FT_MEDIA_LENGTH / _BITRATE / _CODEC on
-    // the CKnownFile; the ed2k + Kad publishers then advertise those
-    // tags automatically. The enable toggle and the path field are
-    // EC-wired and stay visible in amulegui; only "Browse" and "Detect"
-    // hide there (see PrefsUnifiedDlg's amuledOnlyPrefs[]), since both
-    // would search the GUI's filesystem rather than the daemon's.
+    // Media metadata extraction: an optional feature that runs ffprobe against
+    // each shared file at share-add / known.met load time to populate
+    // FT_MEDIA_LENGTH / _BITRATE / _CODEC on the CKnownFile; the ed2k and Kad
+    // publishers then advertise those tags automatically. The enable toggle and
+    // the path field are EC-wired and stay visible in amulegui; only "Browse"
+    // and "Detect" hide there, since both would search the GUI's filesystem.
     wxStaticBox *item22 = new wxStaticBox( parent, -1, _("Media metadata extraction") );
     wxStaticBoxSizer *item22sz = new wxStaticBoxSizer( item22, wxVERTICAL );
 
@@ -1952,13 +1934,12 @@ wxSizer *PreferencesPathMappingTab( wxWindow *parent, bool call_fit, bool set_si
     wxBoxSizer *item0 = new wxBoxSizer( wxVERTICAL );
 
     wxStaticText *itemHint = new wxStaticText( parent, IDC_PATHMAP_HINT, _("When the connected core's files live on a different machine, map a path prefix it reports to where that filesystem is reachable from here (a network share, say) so \"Open\" and \"Show in folder\" work."), wxDefaultPosition, wxDefaultSize, 0 );
-    // An unwrapped wxStaticText reports its whole single line as its best
-    // width, and the sizer turns that into the page's minimum width -- the
-    // dialog comes up as wide as this sentence. So it is wrapped here to
-    // bound that minimum, DPI-scaled rather than a raw pixel count.
-    // PrefsUnifiedDlg then re-flows it to the control's real width and keeps
-    // it current across resizes; it restores this text before each wrap,
-    // since Wrap() can only add line breaks, never remove them.
+    // An unwrapped wxStaticText reports its whole single line as its best width,
+    // and the sizer turns that into the page's minimum width -- the dialog comes
+    // up as wide as this sentence. So it is wrapped here to bound that minimum,
+    // DPI-scaled rather than a raw pixel count. PrefsUnifiedDlg then re-flows it
+    // to the control's real width and keeps it current across resizes; it
+    // restores this text before each wrap, since Wrap() can only add breaks.
     itemHint->Wrap( parent->FromDIP(380) );
     item0->Add( itemHint, wxSizerFlags().Expand().Border(wxBOTTOM, 6) );
 
@@ -2201,9 +2182,8 @@ wxSizer *PreferencesGuiTweaksTab( wxWindow *parent, bool call_fit, bool set_size
     itemLiveSort->SetValue( TRUE );
     item0->Add( itemLiveSort, wxSizerFlags().Expand().CenterVertical() );
     // The "Show country flags for clients" checkbox lives in the dedicated
-    // IP2Country preferences tab (PreferencesIP2CountryTab). The Cfg_Bool
-    // binding stays at IDC_SHOW_COUNTRY_FLAGS so amule.conf
-    // /eMule/GeoIPEnabled stays compatible across versions.
+    // IP2Country preferences tab. The Cfg_Bool binding stays at
+    // IDC_SHOW_COUNTRY_FLAGS so amule.conf /eMule/GeoIPEnabled stays compatible.
     wxStaticBox *item14 = new wxStaticBox( parent, -1, _("Download Queue Files") );
     wxStaticBoxSizer *item13 = new wxStaticBoxSizer( item14, wxVERTICAL );
 
@@ -2335,12 +2315,11 @@ wxSizer *PreferencesRemoteControlsTab( wxWindow *parent, bool call_fit, bool set
     CMuleTextCtrl *item46 = new CMuleTextCtrl( item37, IDC_AMULEAPI_PASSWD, "", wxDefaultPosition, wxDefaultSize, wxTE_PASSWORD );
     item46->SetToolTip( amuleapiPasswordHint );
     item46s->Add( item46, wxSizerFlags(1).Expand().CenterVertical() );
-    // Filled in at runtime by PrefsUnifiedDlg: the stored password is
-    // hashed and can never be shown, so this says whether one exists.
-    // Constructed with the wider of the two strings it can hold, not with
-    // "": the sizer takes its minimum width from the label present at
-    // construction, so an empty one reserves nothing and GTK then clips
-    // whatever SetLabel writes.
+    // Filled in at runtime by PrefsUnifiedDlg: the stored password is hashed and
+    // can never be shown, so this says whether one exists. Constructed with the
+    // wider of the two strings it can hold, not with "": the sizer takes its
+    // minimum width from the label present at construction, so an empty one
+    // reserves nothing and GTK then clips whatever SetLabel writes.
     wxStaticText *item46t = new wxStaticText( item37, IDC_AMULEAPI_PASSWD_STATE, _("A password is set."), wxDefaultPosition, wxDefaultSize, 0 );
     item46s->Add( item46t, wxSizerFlags().CenterVertical().Border(wxLEFT, 5) );
     item42->Add( item46s, wxSizerFlags(1).Expand().CenterVertical() );
@@ -2784,11 +2763,8 @@ wxSizer *KadDlg( wxWindow *parent, bool call_fit, bool set_sizer )
 
     // Graph, full width -- mirrors serverListDlgUp's shape (top row, then a
     // full-width primary area, then a manual-entry row below) rather than
-    // splitting the tab into two side-by-side columns (issue #402 review:
-    // "use more horizontal space for the graph"). item2 keeps the same
-    // wrapping depth around the graph box as the original two-column
-    // layout had (just added straight to item0 now, instead of via the
-    // dropped wxFlexGridSizer's first column).
+    // splitting the tab into two side-by-side columns. item2 keeps the same
+    // wrapping depth around the graph box as the original two-column layout had.
     wxBoxSizer *item2 = new wxBoxSizer( wxVERTICAL );
 
     wxStaticBox *item8 = new wxStaticBox( parent, -1, _("Nodes stats") );
@@ -2799,10 +2775,9 @@ item9->SetName("kadScope");
     wxASSERT( item9 );
     item7->Add( item9, wxSizerFlags(1).Expand() );
 
-    // Three legend entries packed tight at the left. No growable columns:
-    // the row is Expand()ed so Linux has room to draw every label (avoids
-    // clipping "Session average"), but without growable cols the entries
-    // stay next to each other instead of being spread across the width.
+    // Three legend entries packed tight at the left. No growable columns: the row
+    // is Expand()ed so Linux has room to draw every label, but without growable
+    // cols the entries stay next to each other instead of spread across.
     wxFlexGridSizer *item10 = new wxFlexGridSizer( 3, 0, 0 );
 
     wxBoxSizer *item11 = new wxBoxSizer( wxHORIZONTAL );
@@ -2834,10 +2809,8 @@ item9->SetName("kadScope");
     item0->Add( item2, wxSizerFlags(1).Expand() );
 
     // Bootstrap-from-node row, full width below the graph -- mirrors
-    // serverListDlgUp's "Add server manually" row: a single IP field (not
-    // eD2k's ID_NODE_IP1..4 four-octet split -- issue #402 review: "have
-    // the IP address in just one field, it's easier to copy") plus a port
-    // field and the Connect button.
+    // serverListDlgUp's "Add server manually" row: a single IP field, not
+    // eD2k's four-octet split, plus a port field and the Connect button.
     wxBoxSizer *item24 = new wxBoxSizer( wxHORIZONTAL );
 
     wxStaticText *item25 = new wxStaticText( parent, -1, _("Bootstrap from node: IP"), wxDefaultPosition, wxDefaultSize, wxST_NO_AUTORESIZE );

--- a/src/muuli_wdr.h
+++ b/src/muuli_wdr.h
@@ -226,13 +226,12 @@ wxSizer *statsDlg(wxWindow *parent, bool call_fit = TRUE, bool set_sizer = TRUE)
 #define ID_DSNAME 10098
 #define IDT_OBFUSCATION 10099
 #define IDT_KAD 10100
-// Peer's protocol-extension word, Client Details. Appended at the end of the
-// id space rather than next to IDT_KAD: the ids are bound implicitly and by
-// value, so inserting one here would renumber every id below it.
-//
-// The label carries an id of its own -- unlike every other label in this
-// dialog -- because the row is hidden whole when the peer claims no
-// extension, and a label with id -1 cannot be found to hide.
+// Peer's protocol-extension word, Client Details. Appended at the end of the id
+// space rather than next to IDT_KAD: the ids are bound implicitly and by value,
+// so inserting one here would renumber every id below it. The label carries an
+// id of its own -- unlike every other label in this dialog -- because the row is
+// hidden whole when the peer claims no extension, and a label with id -1 cannot
+// be found to hide.
 #define IDT_MOD_CAPABILITIES 10510
 #define IDT_MOD_CAPABILITIES_LABEL 10511
 #define ID_DDOWNLOADING 10101
@@ -329,12 +328,11 @@ wxSizer *PreferencesServerTab(wxWindow *parent, bool call_fit = TRUE, bool set_s
 #define IDC_MINDISKSPACE 10168
 #define IDC_SRCSEEDS 10169
 #define IDC_UAP 10170
-// Media metadata extraction (issue #140). Sit in the high band (>= 10420)
-// so we don't clash with an eventual wxDesigner regeneration or with
-// other in-flight branches — bind-to-interface reserves 10410, so we
-// start at 10420 leaving a 10-ID cushion. The label at IDC_MEDIAMETA_
-// FFPROBEPATHTEXT lives in the 10355+ orphan-label band with the
-// other daemon-only labels (amuleguii hides via amuledOnlyPrefs[]).
+// Media metadata extraction (issue #140). In the high band (>= 10420) to clear
+// an eventual wxDesigner regeneration and other in-flight branches:
+// bind-to-interface reserves 10410, so this starts at 10420 with a 10-ID
+// cushion. The label lives in the 10355+ orphan-label band with the other
+// daemon-only ones.
 #define IDC_MEDIAMETA_ENABLED 10420
 #define IDC_MEDIAMETA_FFPROBEPATH 10421
 #define IDC_MEDIAMETA_FFPROBEBROWSE 10422
@@ -387,10 +385,9 @@ wxSizer *PreferencesDirectoriesTab(wxWindow *parent, bool call_fit = TRUE, bool 
 wxSizer *PreferencesPathMappingTab(wxWindow *parent, bool call_fit = TRUE, bool set_sizer = TRUE);
 #endif
 
-// IP2Country (GeoIP) preferences tab. 10400+ leaves a clear gap above
-// the existing toolbar / button IDs that crowd the 10350-10354 range
-// (ID_BUTTONMESSAGES, ID_BUTTONSTATISTICS, etc. — sharing an ID with a
-// toolbar button gets the wrong event delivered into the prefs panel).
+// IP2Country (GeoIP) preferences tab. 10400+ leaves a clear gap above the
+// toolbar / button IDs that crowd 10350-10354, where sharing an ID gets the
+// wrong event delivered into the prefs panel.
 #define IDC_GEOIP_SOURCE 10400
 #define IDC_GEOIP_MAXMIND_LIC 10401
 #define IDC_GEOIP_CUSTOM_URL 10402
@@ -511,9 +508,8 @@ wxSizer *aMuleLog(wxWindow *parent, bool call_fit = TRUE, bool set_sizer = TRUE)
 // Interface (GUI Tweaks) tab: toggle live column auto-sorting of the lists.
 #define IDC_LIVELISTSORT 10483
 // Remote-GUI path-mapping editor (CLIENT_GUI only, issue #843): a
-// user-configured remote->local path-prefix table, so Open/Show-in-folder
-// work against a daemon on a different machine whose filesystem this one can
-// otherwise reach (a Samba/NFS mount, say). See CPreferences::PathMapping.
+// user-configured remote->local path-prefix table, so Open and Show-in-folder
+// work against a daemon on another machine this one can otherwise reach.
 #define IDC_PATHMAP_LIST 10496
 #define IDC_PATHMAP_REMOTE 10497
 #define IDC_PATHMAP_LOCAL 10498
@@ -664,10 +660,9 @@ wxSizer *messagePageMessages(wxWindow *parent, bool call_fit = TRUE, bool set_si
 #define ID_BUTTONNEWPREFERENCES 10352
 #define ID_BUTTONIMPORT 10353
 #define ID_ABOUT 10354
-// Appended rather than slotted between the panel buttons above: those values
-// are referenced by saved toolbar state, so renumbering them would silently
-// move a user's buttons. 10503 upwards is the first free pair -- the IDC_*
-// block runs to 10502 and the next value used anywhere is 16384.
+// Appended rather than slotted between the panel buttons above: those values are
+// referenced by saved toolbar state, so renumbering would silently move a user's
+// buttons. 10503 upwards is the first free pair.
 #define ID_BUTTONCLIENTS 10503
 #define ID_CLIENTSLIST 10504
 #define ID_CLIENTHISTORYLIST 10505

--- a/src/updownclient.h
+++ b/src/updownclient.h
@@ -91,10 +91,9 @@ enum EKadState
 	KS_CONNECTING_FWCHECK_UDP
 };
 
-// Lifecycle of a "View Files" (browse peer shared files) request. The values
-// are a wire contract: they are sent verbatim in EC_TAG_SEARCH_BROWSE_STATUS
-// (uint8) so a remote GUI can render the browse tab's marker. Both the
-// monolithic client and amuleGUI read the same enum.
+// Lifecycle of a "View Files" (browse peer shared files) request. The values are
+// a wire contract, sent verbatim in EC_TAG_SEARCH_BROWSE_STATUS so a remote GUI
+// can render the browse tab's marker.
 enum EBrowseStatus
 {
 	BROWSE_NONE = 0,    // no browse in flight for this client
@@ -136,8 +135,8 @@ enum class EContactResult
 	//! The client is still valid.
 	Declined,
 	//! Connect() declined to start, because the socket was already live. Kept
-	//! distinct only to preserve the historical bool -- callers have always
-	//! been told "false" here, and changing that is not this change's job.
+	//! distinct only to preserve the historical bool, which callers have always
+	//! been told is "false" here.
 	ConnectNotStarted,
 	//! The client was destroyed on the way out. Touching it is undefined.
 	ClientDeleted
@@ -187,7 +186,6 @@ private:
 #endif
 
 public:
-	// base
 	CUpDownClient(CClientTCPSocket *sender = 0);
 	CUpDownClient(uint16 in_port,
 		uint32 in_userid,
@@ -241,13 +239,12 @@ public:
 	wxString GetFullIP() const { return Uint32toStringIP(m_FullUserIP); }
 	// The numeric form of GetFullIP(), for callers that do not need the string.
 	// Named to be hard to confuse with it: the GeoIP resolver overloads on the
-	// argument type, so passing the string variant compiles and silently takes
-	// the uncached path.
+	// argument type, so passing the string variant compiles and silently takes the
+	// uncached path.
 	uint32 GetFullIPNumeric() const { return m_FullUserIP; }
-	// Country ISO code accessors (#439). Unconditional (libmaxminddb-free) so the
-	// shared client-list drawing code compiles regardless of the resolver gate.
-	// Unused by monolithic amule, which resolves country locally via
-	// theApp->GetIP2Country(); populated over EC on the remote-GUI client.
+	// Country ISO code accessors (#439). Unconditional, so the shared client-list
+	// drawing code compiles regardless of the resolver gate. Unused by monolithic
+	// amule, which resolves locally; populated over EC on the remote GUI.
 	const wxString &GetCountryCode() const { return m_countryCode; }
 	bool IsCountryFromCore() const { return m_countryFromCore; }
 	void SetCountryCode(const wxString &code)
@@ -360,8 +357,6 @@ public:
 	void ResetSessionUp();
 	uint32 GetUploadDatarate() const { return m_nUpDatarate; }
 
-	// uint32		GetWaitTime() const		{ return m_dwUploadTime - GetWaitStartTime();
-	// }
 	uint64 GetUpStartTimeDelay() const { return ::GetTickCount64() - m_dwUploadTime; }
 	uint64 GetWaitStartTime() const;
 
@@ -524,9 +519,8 @@ public:
 
 	// "View Files" (browse): the search ID this peer's listing is filed under.
 	// Allocated before the request goes out -- by the EC handler for a remote
-	// browse, by RequestSharedFileList itself for a local one -- so it is the
-	// single key for the browse everywhere, and CBrowseManager owns the
-	// lifecycle behind it. 0 = this client has never been browsed.
+	// browse, by RequestSharedFileList for a local one -- so it is the single key
+	// for the browse everywhere. 0 means never browsed.
 	uint32 GetBrowseSearchId() const { return m_browseSearchId; }
 	/**
 	 * Whether this browse was asked for by a remote client rather than here.
@@ -836,7 +830,6 @@ private:
 
 	CPartFile *m_reqfile;
 
-	// base
 	void Init();
 	bool ProcessHelloTypePacket(const CMemFile &data);
 	void SendHelloTypePacket(CMemFile *data);


### PR DESCRIPTION
Comment-only sweep of `src (core and GUI, top level)`: 127 files, 24721 -> 20820 comment lines (-3901, -15.8%). Figures are over the touched files only; licence headers are untouched and form a floor in every count.

Part of a tree-wide pass split by scope. The scopes touch disjoint files, so this one merges independently of the others.

**What came out**

- Dead cross-references: `// eMule ref: lines 112-143` pointers into another project's line numbers, and `// 0.42e` / `// 0.42x` version markers.
- Roughly 70 lines of commented-out `printf` / `DebugLog` debugging.
- One stale claim: `FileArea.cpp`'s constructor said the SIGSEGV/SIGBUS handler is installed lazily at the first `mmap()`, "see ReadAt/StartWriteAt". It is not - `Init()` is only reached from `SetMMapEnabled`. Removed; the accurate note already sits at the real install site.
- One corrupted comment repaired in `MediaProbe.cpp`, where a sentence broke mid-clause.
- Twelve copies of the same "extended packet without finishing the handshake" block in `ClientTCPSocket.cpp`, each directly above a `throw` that says the same thing.

**What stayed**

Anything recording something the code cannot tell you by itself: a protocol constraint, a wire-format rule, a platform quirk, the reason a guard exists, the why behind a non-obvious default.

**Verification**

- Every file mechanically checked comment-only: comments stripped and whitespace normalised on both sides, then diffed against master. 127/127 identical, so no code changes.
- clang-format 18, the version CI pins, clean over all of `src/` and `unittests/`.
- Builds clean on macOS. Nothing here changes code, so the build cannot differ per scope.

**Reviewing**

`git diff master -w` is the whole change; there is no code to read.
