### PR TITLE
chore(kademlia): trim verbose comment blocks

### DIFF
--- a/src/kademlia/kademlia/AICHHashList.h
+++ b/src/kademlia/kademlia/AICHHashList.h
@@ -47,14 +47,14 @@ typedef std::array<uint8_t, KAD_AICH_HASH_SIZE> CKadAICHHash;
 // The AICH root hashes reported for one indexed keyword entry, each with the
 // number of publishers that reported it.
 //
-// Kad protocol version 0x09 added AICH hashes to keyword storage.  A publisher
-// at 0x09 or above sends its file's AICH root hash in TAG_KADAICHHASHPUB
-// ("\x36", BSOB of KAD_AICH_HASH_SIZE bytes) inside KADEMLIA2_PUBLISH_KEY_REQ;
-// the indexing node accumulates those hashes per entry and reports them back in
-// TAG_KADAICHHASHRESULT ("\x37", BSOB) on KADEMLIA2_SEARCH_RES.  The publisher
-// count is the interesting part: an honest file has exactly one AICH hash, so
-// several competing hashes -- or one hash with a single publisher against a
-// popular file -- is the signal a searcher wants.
+// Kad protocol version 0x09 added AICH hashes to keyword storage: a publisher at
+// 0x09 or above sends its file's AICH root hash in TAG_KADAICHHASHPUB (BSOB of
+// KAD_AICH_HASH_SIZE bytes) inside KADEMLIA2_PUBLISH_KEY_REQ, and the indexing
+// node accumulates those per entry and reports them in TAG_KADAICHHASHRESULT on
+// KADEMLIA2_SEARCH_RES. The publisher count is the interesting part: an honest
+// file has exactly one AICH hash, so several competing hashes -- or one hash
+// with a single publisher against a popular file -- is the signal a searcher
+// wants.
 //
 // Slots are never removed once created, because publishers hold their hash by
 // index; DropReferenceAt() only decrements the popularity counter, and

--- a/src/kademlia/kademlia/Entry.cpp
+++ b/src/kademlia/kademlia/Entry.cpp
@@ -79,27 +79,22 @@ CEntry *CEntry::Copy() const
 
 void CEntry::AddTag(CTag *tag, uint32_t dbgSourceIP)
 {
-	// Filter tags which are for sending query results only and should never be stored (or even
-	// worse sent within the taglist). TAG_PUBLISHINFO is one we build when answering a keyword
-	// search, out of our own count of distinct publishers and how much we trust them; stored, a
-	// peer-supplied one travels back out of CKeyEntry::WriteTagListWithPublishInfo() alongside
-	// our genuine value.
+	// Filter tags that exist for sending query results only and should never be
+	// stored, let alone sent within the taglist. TAG_PUBLISHINFO is one we build
+	// when answering a keyword search, out of our own count of distinct publishers
+	// and how much we trust them; stored, a peer-supplied one travels back out of
+	// CKeyEntry::WriteTagListWithPublishInfo() alongside our genuine value.
 	//
-	// TAG_KADAICHHASHRESULT is the same shape of tag and belongs in the same
-	// branch: we build it when answering a keyword search, out of the AICH
-	// hashes publishers gave us and how many gave each one. A stored
-	// peer-supplied one leaves by the same route and reads as our own
-	// assessment. Deliberately ungated: the guard's value is that it is one
-	// unconditional branch covering every caller, and filtering a tag this
-	// build never emits costs nothing. It also covers the three storing paths
-	// a handler-side filter does not -- source and notes publishing, and
-	// CIndexed::ReadFile(), which rebuilds every entry from key_index.dat
-	// with its raw taglist, so a node poisoned before this fix would reload
-	// the tag on restart and keep serving it.
+	// TAG_KADAICHHASHRESULT is the same shape of tag and belongs in the same branch.
+	// Deliberately ungated: the guard's value is that it is one unconditional
+	// branch covering every caller, and filtering a tag this build never emits costs
+	// nothing. It also covers the three storing paths a handler-side filter does not
+	// -- source and notes publishing, and CIndexed::ReadFile(), which rebuilds every
+	// entry from key_index.dat with its raw taglist, so a node poisoned before this
+	// fix would reload the tag on restart and keep serving it.
 	//
-	// TAG_KADAICHHASHPUB is not here: that one is consumed into a member
-	// rather than filtered, which is the split 0.70b, 0.72a, eMuleAI and
-	// emule-qt all use.
+	// TAG_KADAICHHASHPUB is not here: that one is consumed into a member rather than
+	// filtered, which is the split 0.70b, 0.72a, eMuleAI and emule-qt all use.
 	if (!tag->GetName().Cmp(TAG_PUBLISHINFO) || !tag->GetName().Cmp(TAG_KADAICHHASHRESULT)) {
 		AddDebugLogLineN(logKadEntryTracking,
 			CFormat("Filtered result-only tag on storing, source %s") %
@@ -142,11 +137,10 @@ wxString CEntry::GetStrTagValue(const wxString &tagname) const
 
 void CEntry::SetFileName(const wxString &name)
 {
-	// Empty filenames are protocol garbage -- a peer publishing a Kad note
-	// or keyword with an empty FT_FILENAME tag should never end up in
-	// m_filenames at all.  Without this guard the empty entry takes the
-	// popularity slot, GetCommonFileName returns "" and trips its own
-	// !empty-or-list-empty invariant on the next call (issue #674).
+	// Empty filenames are protocol garbage: a peer publishing a Kad note or keyword
+	// with an empty FT_FILENAME tag should never reach m_filenames. Without this
+	// guard the empty entry takes the popularity slot, GetCommonFileName returns ""
+	// and trips its own invariant on the next call (issue #674).
 	if (name.IsEmpty()) {
 		return;
 	}
@@ -160,29 +154,18 @@ void CEntry::SetFileName(const wxString &name)
 
 wxString CEntry::GetCommonFileName() const
 {
-	// Return the filename most publishers agreed on (by popularity
-	// index).  The index isn't the actual count of publishers — just
-	// a relative number for comparing entries — so the choice is
-	// approximate.
+	// Return the filename most publishers agreed on, by popularity index. The index
+	// is not the actual count of publishers, just a relative number for comparing
+	// entries, so the choice is approximate.
 	//
-	// Seed the running max from the first entry (rather than 0) so
-	// that an all-zero m_filenames still yields a non-empty result.
-	// Our own code never produces a popularity-0 entry -- SetFileName
-	// creates at 1 and the merge path only ever increments -- but two
-	// paths we don't control can land one in m_filenames anyway:
-	// (a) a remote publisher could send a popularity-0 entry over the
-	// wire (no validation on ReadUInt32), and (b) on-disk data from
-	// any node that ran an older build doing popularity decay can
-	// load back at 0 here.  The previous "highest > 0"-style loop
-	// would then leave the result iterator at end() and return an
-	// empty string -- silently dropping TAG_FILENAME from search
-	// responses (Entry.h GetTagCount), making SearchTermsMatch
-	// return false for every term, and tripping the
-	// GetCommonFileName().IsEmpty() reject path in
-	// CIndexed::AddKeyword.  Picking the first entry as a
-	// deterministic fallback preserves the protocol invariant
-	// "non-empty m_filenames yields a non-empty common name" without
-	// changing behaviour for any case where a real winner exists.
+	// The running max is seeded from the first entry rather than 0, so an all-zero
+	// m_filenames still yields a non-empty result. Our own code never produces a
+	// popularity-0 entry, but two paths we do not control can: a remote publisher
+	// sending one over the wire (ReadUInt32 does not validate), and on-disk data
+	// from a node that ran an older build doing popularity decay. A "highest > 0"
+	// loop would then leave the result iterator at end() and return an empty string,
+	// silently dropping TAG_FILENAME from search responses, making SearchTermsMatch
+	// false for every term and tripping the reject path in CIndexed::AddKeyword.
 	if (m_filenames.empty()) {
 		return wxString("");
 	}
@@ -200,7 +183,6 @@ wxString CEntry::GetCommonFileName() const
 
 void CEntry::WriteTagListInc(CFileDataIO *data, uint32_t increaseTagNumber)
 {
-	// write taglist and add name + size tag
 	wxCHECK_RET(data != NULL, "data must not be NULL");
 
 	uint32_t count =
@@ -246,7 +228,6 @@ CKeyEntry::~CKeyEntry()
 
 bool CKeyEntry::SearchTermsMatch(const SSearchTerm *searchTerm) const
 {
-	// boolean operators
 	if (searchTerm->type == SSearchTerm::AND) {
 		return SearchTermsMatch(searchTerm->left) && SearchTermsMatch(searchTerm->right);
 	}
@@ -422,11 +403,11 @@ void CKeyEntry::AdjustGlobalPublishTracking(uint32_t ip, bool increase, const wx
 
 void CKeyEntry::MergeIPsAndFilenames(CKeyEntry *fromEntry)
 {
-	// this is called when replacing a stored entry with a refreshed one.
-	// we want to take over the tracked IPs and the different filenames from the old entry, the rest is
-	// still "overwritten" with the refreshed values. This might be not perfect for the taglist in some
-	// cases, but we can't afford to store hundreds of taglists to figure out the best one like we do for
-	// the filenames now
+	// Called when replacing a stored entry with a refreshed one: the tracked IPs and
+	// the different filenames are taken over from the old entry, and the rest is
+	// overwritten with the refreshed values. Not perfect for the taglist in some
+	// cases, but storing hundreds of taglists to pick the best one -- as is done for
+	// the filenames -- is not affordable.
 	if (m_publishingIPs !=
 		NULL) { // This instance needs to be a new entry, otherwise we don't want/need to merge
 		wxASSERT(fromEntry == NULL);
@@ -447,16 +428,12 @@ void CKeyEntry::MergeIPsAndFilenames(CKeyEntry *fromEntry)
 	bool refresh = false;
 	if (fromEntry == NULL || fromEntry->m_publishingIPs == NULL) {
 		wxASSERT(fromEntry == NULL);
-		// if called with NULL, this is a complete new entry and we need to initialize our lists
 		if (m_publishingIPs == NULL) {
 			m_publishingIPs = new PublishingIPList();
 		}
-		// update the global track map below
 	} else {
-		// take over the AICH hashes the stored entry accumulated
 		m_aichHashes = fromEntry->m_aichHashes;
 
-		// merge the tracked IPs, add this one if not already on the list
 		m_publishingIPs = fromEntry->m_publishingIPs;
 		fromEntry->m_publishingIPs = NULL;
 		bool fastRefresh = false;
@@ -505,11 +482,9 @@ void CKeyEntry::MergeIPsAndFilenames(CKeyEntry *fromEntry)
 			}
 		}
 
-		// copy over trust value, in case we don't want to recalculate
 		m_trustValue = fromEntry->m_trustValue;
 		m_lastTrustValueCalc = fromEntry->m_lastTrustValueCalc;
 
-		// copy over the different names, if they are different the one we have right now
 		wxASSERT(m_filenames.size() ==
 			 1); // we should have only one name here, since it's the entry from one single source
 		sFileNameEntry currentName = { "", 0 };
@@ -518,25 +493,18 @@ void CKeyEntry::MergeIPsAndFilenames(CKeyEntry *fromEntry)
 			m_filenames.pop_front();
 		}
 
-		// Cap m_filenames so a single CKeyEntry can't accumulate
-		// unbounded filename variants. A popular file collects one
-		// sFileNameEntry per distinct publisher-chosen name (renames,
-		// language variants, mirror prefixes, trailing-paren copies,
-		// case differences); without a cap the list grows monotonically
-		// for the lifetime of the entry, which on a long-running
-		// shareset shows up as a steady ~MB/hour RSS climb in amuled.
-		// 100 matches the m_publishingIPs cap below and is comfortably
-		// above the count of variants any honest publisher set produces
-		// for a single hash — GetCommonFileName already picks the
-		// highest-popularity entry, so the cap is shaped to keep
-		// popularity-ordered survivors.
+		// Cap m_filenames so a single CKeyEntry cannot accumulate unbounded filename
+		// variants. A popular file collects one sFileNameEntry per distinct
+		// publisher-chosen name -- renames, language variants, mirror prefixes, case
+		// differences -- and without a cap the list grows monotonically for the
+		// lifetime of the entry, showing up as a steady ~MB/hour RSS climb in amuled.
+		// 100 matches the m_publishingIPs cap below and is comfortably above any
+		// honest publisher set.
 		const size_t MAX_FILENAMES = 100;
 
-		// Compare-and-skip insertion (per irwir's review of #314): if
-		// we're already at the cap, only accept the new entry when its
-		// popularity beats the weakest survivor — otherwise drop it on
-		// the floor instead of pushing then immediately re-evicting.
-		// O(N) per insert via std::min_element; no global sort needed.
+		// Compare-and-skip insertion: at the cap, a new entry is only accepted when
+		// its popularity beats the weakest survivor, rather than pushing and then
+		// immediately re-evicting. O(N) per insert via std::min_element.
 		auto pushBounded = [&](const sFileNameEntry &candidate) {
 			if (m_filenames.size() < MAX_FILENAMES) {
 				m_filenames.push_back(candidate);
@@ -559,10 +527,8 @@ void CKeyEntry::MergeIPsAndFilenames(CKeyEntry *fromEntry)
 			it != fromEntry->m_filenames.end();
 			++it) {
 			sFileNameEntry nameToCopy = *it;
-			// Defence-in-depth: even though SetFileName now rejects empty
-			// names, an older on-disk Kad index could still hold one from
-			// before that guard landed.  Drop it here too rather than
-			// propagating into our m_filenames.
+			// Defence-in-depth: SetFileName now rejects empty names, but an older
+			// on-disk Kad index could still hold one from before that guard landed.
 			if (nameToCopy.m_filename.IsEmpty()) {
 				continue;
 			}
@@ -584,7 +550,6 @@ void CKeyEntry::MergeIPsAndFilenames(CKeyEntry *fromEntry)
 		}
 	}
 
-	// if this was a refresh done, otherwise update the global track map
 	if (!refresh) {
 		wxASSERT(m_uIP != 0);
 		uint16_t aichHashIdx = hasNewAICHHash ? m_aichHashes.AddReference(newAICHHash)
@@ -592,7 +557,6 @@ void CKeyEntry::MergeIPsAndFilenames(CKeyEntry *fromEntry)
 		sPublishingIP add = { m_uIP, time(nullptr), aichHashIdx };
 		m_publishingIPs->push_back(add);
 
-		// add the publisher to the tacking list
 		AdjustGlobalPublishTracking(m_uIP, true, "new publisher");
 
 		// we keep track of max 100 IPs, in order to avoid too much time for
@@ -604,7 +568,6 @@ void CKeyEntry::MergeIPsAndFilenames(CKeyEntry *fromEntry)
 			AdjustGlobalPublishTracking(curEntry.m_ip, false, "more than 100 publishers purge");
 		}
 
-		// since we added a new publisher, we want to (re)calculate the trust value for this entry
 		ReCalculateTrustValue();
 	}
 	AddDebugLogLineN(logKadEntryTracking,
@@ -617,24 +580,20 @@ void CKeyEntry::MergeIPsAndFilenames(CKeyEntry *fromEntry)
 void CKeyEntry::ReCalculateTrustValue()
 {
 #define PUBLISHPOINTSSPERSUBNET 10.0
-	// The trustvalue is supposed to be an indicator how trustworthy/important (or spammy) this entry is
-	// and lies between 0 and ~10000, but mostly we say everything below 1 is bad, everything above 1 is
-	// good. It is calculated by looking at how many different IPs/24 have published this entry and how
-	// many entries each of those IPs have. Each IP/24 has x (say 3) points. This means if one IP
-	// publishes 3 different entries without any other IP publishing those entries, each of those entries
-	// will have 3 / 3 = 1 Trustvalue. That's fine. If it publishes 6 alone, each entry has 3 / 6 = 0.5
-	// trustvalue - not so good However if there is another publisher for entry 5, which only publishes
-	// this entry then we have 3/6 + 3/1 = 3.5 trustvalue for this entry
+	// The trust value indicates how trustworthy or spammy this entry is. It lies
+	// between 0 and ~10000, but the useful reading is that below 1 is bad and above
+	// 1 is good. It comes from how many different IPs/24 published this entry and
+	// how many entries each of those IPs has: each IP/24 has 3 points, so one IP
+	// publishing 3 entries alone gives each 3/3 = 1, publishing 6 gives each 0.5,
+	// and a second publisher of one of them raises that one to 3/6 + 3/1 = 3.5.
 	//
-	// What's the point? With this rating we try to avoid getting spammed with entries for a given keyword
-	// by a small IP range, which blends out all other entries for this keyword do to its amount as well
-	// as giving an indicator for the searcher. So if we are the node to index "Knoppix", and someone from
-	// 1 IP publishes 500 times "knoppix casino 500% bonus.txt", all those entries will have a trustvalue
-	// of 0.006 and we make sure that on search requests for knoppix, those entries are only returned
-	// after all entries with a trustvalue > 1 were sent (if there is still space).
+	// The point is to avoid being spammed for a given keyword by a small IP range,
+	// which would otherwise blot out every other entry. If we index "Knoppix" and
+	// one IP publishes 500 variants of "knoppix casino 500% bonus.txt", those score
+	// 0.006 and are only returned after everything above 1.
 	//
-	// Its important to note that entry with < 1 do NOT get ignored or singled out, this only comes into
-	// play if we have 300 more results for a search request rating > 1
+	// Entries below 1 are NOT ignored or singled out; the rating only comes into
+	// play once there are more results for a request than there is space for.
 	wxCHECK_RET(m_publishingIPs != NULL, "No publishing IPs?");
 
 	m_lastTrustValueCalc = ::GetTickCount64();
@@ -675,7 +634,6 @@ void CKeyEntry::CleanUpTrackedPublishers()
 
 	time_t now = time(NULL);
 	while (!m_publishingIPs->empty()) {
-		// entries are ordered, older ones first
 		sPublishingIP curEntry = m_publishingIPs->front();
 		if (now - curEntry.m_lastPublish > KADEMLIAREPUBLISHTIMEK) {
 			AdjustGlobalPublishTracking(curEntry.m_ip, false, "cleanup");

--- a/src/kademlia/kademlia/Indexed.cpp
+++ b/src/kademlia/kademlia/Indexed.cpp
@@ -149,8 +149,8 @@ void CIndexed::ReadFile()
 												if (tag->IsBsob() &&
 													(tag->GetBsobSize() ==
 														8)) {
-													// We've
-													// previously
+													// Older
+													// builds
 													// wrongly
 													// saved
 													// BSOB
@@ -158,17 +158,13 @@ void CIndexed::ReadFile()
 													// to
 													// key_index.dat,
 													// so
-													// we'll
+													// those
 													// have
 													// to
-													// handle
-													// those
+													// be
+													// handled
 													// here
-													// as
-													// well.
-													// Too
-													// bad
-													// ...
+													// too.
 													toAdd->m_uSize = PeekUInt64(
 														tag->GetBsob());
 												} else {

--- a/src/kademlia/kademlia/Kademlia.cpp
+++ b/src/kademlia/kademlia/Kademlia.cpp
@@ -99,34 +99,24 @@ void CKademlia::Start(CPrefs *prefs)
 
 	AddDebugLogLineN(logKadMain, "Starting Kademlia");
 
-	// Init jump start timer.
 	m_nextSearchJumpStart = time(NULL);
-	// Force a FindNodeComplete within the first 3 minutes.
 	m_nextSelfLookup = time(NULL) + MIN2S(3);
-	// Init status timer.
 	m_statusUpdate = time(NULL);
-	// Init big timer for Zones
 	m_bigTimer = time(NULL);
 	// First Firewall check is done on connect, init next check.
 	m_nextFirewallCheck = time(NULL) + (HR2S(1));
 	// Find a buddy after the first 5mins of starting the client.
 	// We wait just in case it takes a bit for the client to determine firewall status..
 	m_nextFindBuddy = time(NULL) + (MIN2S(5));
-	// Init contact consolidate timer;
 	m_consolidate = time(NULL) + (MIN2S(45));
-	// Look up our extern port
 	m_externPortLookup = time(NULL);
-	// Init bootstrap time.
 	m_bootstrap = 0;
-	// Init our random seed.
 	srand((uint32_t)time(NULL));
-	// Create our Kad objects.
 	instance = new CKademlia();
 	instance->m_prefs = prefs;
 	instance->m_indexed = new CIndexed();
 	instance->m_routingZone = new CRoutingZone();
 	instance->m_udpListener = new CKademliaUDPListener();
-	// Mark Kad as running state.
 	m_running = true;
 }
 
@@ -139,16 +129,12 @@ void CKademlia::Stop()
 
 	AddDebugLogLineN(logKadMain, "Stopping Kademlia");
 
-	// Mark Kad as being in the stop state to make sure nothing else is used.
 	m_running = false;
 
-	// Reset Firewallstate
 	CUDPFirewallTester::Reset();
 
-	// Remove all active searches.
 	CSearchManager::StopAllSearches();
 
-	// Delete all Kad Objects.
 	delete instance->m_udpListener;
 	instance->m_udpListener = NULL;
 
@@ -169,7 +155,6 @@ void CKademlia::Stop()
 	}
 	s_bootstrapList.clear();
 
-	// Make sure all zones are removed.
 	m_events.clear();
 
 #ifdef ENABLE_KAD_NODE_PROTECTION
@@ -180,8 +165,6 @@ void CKademlia::Stop()
 	safeKad.Clear();
 	fastKad.Clear();
 #endif
-
-	//	theApp->ShowConnectionState();
 }
 
 void CKademlia::Process()
@@ -294,7 +277,6 @@ void CKademlia::Process()
 	theStats::SetKadBannedAddresses((uint32)safeKad.GetBannedAddressCount());
 #endif
 
-	// Try to consolidate any zones that are close to empty.
 	if (m_consolidate <= now) {
 		uint32_t mergedCount = instance->m_routingZone->Consolidate();
 		if (mergedCount) {
@@ -303,7 +285,6 @@ void CKademlia::Process()
 		m_consolidate = MIN2S(45) + now;
 	}
 
-	// Update user count only if changed.
 	if (updateUserFile) {
 		if (maxUsers != instance->m_prefs->GetKademliaUsers()) {
 			instance->m_prefs->SetKademliaUsers(maxUsers);
@@ -385,7 +366,6 @@ bool CKademlia::FindNodeIDByIP(CKadClientSearcher& requester, uint32_t ip, uint1
 {
 	wxCHECK(IsRunning() && instance && GetUDPListener() && GetRoutingZone(), false);
 
-	// first search our known contacts if we can deliver a result without asking, otherwise forward the request
 	CContact* contact;
 	if ((contact = GetRoutingZone()->GetContact(wxUINT32_SWAP_ALWAYS(ip), tcpPort, true)) != NULL) {
 		uint8_t nodeID[16];

--- a/src/kademlia/kademlia/Search.cpp
+++ b/src/kademlia/kademlia/Search.cpp
@@ -106,7 +106,6 @@ CSearch::CSearch()
 	m_searchTermsDataSize = 0;
 	m_nodeSpecialSearchRequester = NULL;
 	m_closestDistantFound = 0;
-	// m_requestedMoreNodes default-constructs empty
 }
 
 CSearch::~CSearch()
@@ -131,14 +130,11 @@ CSearch::~CSearch()
 	}
 
 	if (m_nodeSpecialSearchRequester != NULL) {
-		// inform requester that our search failed
 		m_nodeSpecialSearchRequester->KadSearchIPByNodeIDResult(KCSR_NOTFOUND, 0, 0);
 	}
 
-	// Check if a source search is currently being done.
 	CPartFile *temp = theApp->downloadqueue->GetFileByKadFileSearchID(GetSearchID());
 
-	// Reset the searchID if a source search is currently being done.
 	if (temp) {
 		temp->SetKadFileSearchID(0);
 	}
@@ -150,12 +146,9 @@ CSearch::~CSearch()
 		m_target.ToByteArray(fileid);
 		const CMD4Hash fileHash(fileid);
 		// Clear the running flag on EVERY local object that shares this hash. The
-		// lookup may have been triggered from a search result while the same file
-		// is also downloading/shared (two objects, one hash), and the flag was
-		// set on whichever one the user used. Clearing only the first match left
-		// the other stuck reporting "a note lookup is already running", so it
-		// could never be searched again — hence two independent `if`s, not an
-		// `else if`.
+		// lookup may have been triggered from a search result while the same file is
+		// also downloading or shared (two objects, one hash), and the flag was set on
+		// whichever one the user used -- so two independent `if`s, not an `else if`.
 		CKnownFile *knownFile = theApp->sharedfiles->GetFileByID(fileHash);
 		if (!knownFile) {
 			knownFile = theApp->downloadqueue->GetFileByID(fileHash);
@@ -168,11 +161,10 @@ CSearch::~CSearch()
 			// skips an unchanged partfile).
 			knownFile->MarkECChanged();
 		}
-		// Clear the flag on EVERY search result sharing this hash, not just the
-		// first: the same file can be shown in several open searches at once
-		// (one CSearchFile each), and all were marked running when the lookup
-		// started. Search files carry no EC change-generation, so the cleared
-		// flag simply rides the next periodic search-results poll.
+		// Clear the flag on EVERY search result sharing this hash: the same file can
+		// be shown in several open searches at once, and all were marked running.
+		// Search files carry no EC change-generation, so the cleared flag rides the
+		// next periodic search-results poll.
 		std::vector<CSearchFile *> searchFiles;
 		theApp->searchlist->GetAllSearchFilesByID(fileHash, searchFiles);
 		for (CSearchFile *searchFile : searchFiles) {
@@ -180,12 +172,10 @@ CSearch::~CSearch()
 		}
 	}
 
-	// Decrease the use count for any contacts that are in our contact list.
 	for (ContactMap::iterator it = m_inUse.begin(); it != m_inUse.end(); ++it) {
 		it->second->DecUse();
 	}
 
-	// Delete any temp contacts...
 	for (ContactList::const_iterator it = m_delete.begin(); it != m_delete.end(); ++it) {
 		if (!(*it)->InUse()) {
 			delete *it;
@@ -222,24 +212,18 @@ void CSearch::Go()
 	}
 
 	if (!m_possible.empty()) {
-		// Lets keep our contact list entries in mind to dec the inUse flag.
 		for (ContactMap::iterator it = m_possible.begin(); it != m_possible.end(); ++it) {
 			m_inUse[it->first] = it->second;
 		}
 
 		wxASSERT(m_possible.size() == m_inUse.size());
 
-		// Take top ALPHA_QUERY to start search with.
 		int count = m_type == NODE ? 1 : min(ALPHA_QUERY, (int)m_possible.size());
 
-		// Send initial packets to start the search.
 		ContactMap::iterator it = m_possible.begin();
 		for (int i = 0; i < count; i++) {
 			CContact *c = it->second;
-			// Move to tried
 			m_tried[it->first] = c;
-			// Send the KadID so other side can check if I think it has the right KadID.
-			// Send request
 			SendFindValue(c);
 			++it;
 		}
@@ -249,12 +233,10 @@ void CSearch::Go()
 // If we allow about a 15 sec delay before deleting, we won't miss a lot of delayed returning packets.
 void CSearch::PrepareToStop() noexcept
 {
-	// Check if already stopping.
 	if (m_stopping) {
 		return;
 	}
 
-	// Set basetime by search type.
 	uint32_t baseTime = 0;
 	switch (m_type) {
 	case NODE:
@@ -300,15 +282,14 @@ void CSearch::PrepareToStop() noexcept
 void CSearch::JumpStart()
 {
 #ifdef ENABLE_KAD_NODE_PROTECTION
-	// How long to wait on an outstanding request before treating the search
-	// as stalled.  Derived from the response times we have actually observed
-	// (CFastKad) rather than fixed at 3 seconds: on a fast link the old
-	// constant wasted seconds on nodes that were never going to answer, and
-	// on a congested one it abandoned nodes that answered just too late.
+	// How long to wait on an outstanding request before treating the search as
+	// stalled. Derived from the response times actually observed (CFastKad) rather
+	// than fixed at 3 seconds: on a fast link the old constant wasted seconds on
+	// nodes that were never going to answer, and on a congested one it abandoned
+	// nodes that answered just too late.
 	//
-	// Background store operations keep the old fixed 3 seconds.  They are not
-	// latency-sensitive -- nobody is waiting on a publish -- and holding them
-	// to a tight adaptive deadline would only add republish traffic.
+	// Background store operations keep the fixed 3 seconds: nobody is waiting on a
+	// publish, and a tight deadline would only add republish traffic.
 	const uint32_t maxPending = (m_type == STOREFILE || m_type == STOREKEYWORD || m_type == STORENOTES)
 					    ? SEC2MS(3)
 					    : fastKad.GetEstMaxResponseTime();
@@ -332,19 +313,15 @@ void CSearch::JumpStart()
 		return;
 	}
 #else
-	// Gate off: the fixed 3-second ceiling, at the second granularity it has
-	// always had, so the moment a jumpstart goes out is unchanged.
-	//
-	// Cast m_lastResponse to time_t before adding so the addition happens in
-	// time_t, not in uint32_t -- the latter would wrap near the 2106 32-bit
-	// time boundary and reorder the comparison silently.  Eighty years out,
-	// but cheap to write correctly.
+	// Gate off: the fixed 3-second ceiling at its usual second granularity, so the
+	// moment a jumpstart goes out is unchanged. m_lastResponse is cast to time_t
+	// before the addition, which in uint32_t would wrap near the 2106 boundary and
+	// silently reorder the comparison.
 	if ((time_t)m_lastResponse + SEC(3) > time(NULL)) {
 		return;
 	}
 #endif
 
-	// If we ran out of contacts, stop search.
 	if (m_possible.empty()) {
 		PrepareToStop();
 		return;
@@ -381,24 +358,16 @@ void CSearch::JumpStart()
 		}
 	}
 
-	// Search for contacts that can be used to jumpstart a stalled search.
 	while (!m_possible.empty()) {
-		// Get a contact closest to our target.
 		CContact *c = m_possible.begin()->second;
 
-		// Have we already tried to contact this node.
 		if (m_tried.count(m_possible.begin()->first) > 0) {
-			// Did we get a response from this node, if so, try to store or get info.
 			if (m_responded.count(m_possible.begin()->first) > 0) {
 				StorePacket();
 			}
-			// Remove from possible list.
 			m_possible.erase(m_possible.begin());
 		} else {
-			// Add to tried list.
 			m_tried[m_possible.begin()->first] = c;
-			// Send the KadID so other side can check if I think it has the right KadID.
-			// Send request
 			SendFindValue(c);
 			break;
 		}
@@ -411,7 +380,6 @@ void CSearch::ProcessResponse(uint32_t fromIP, uint16_t fromPort, ContactList *r
 		logKadSearch, "Processing search response from " + KadIPPortToString(fromIP, fromPort));
 
 	ContactList::iterator response;
-	// Remember the contacts to be deleted when finished
 	for (response = results->begin(); response != results->end(); ++response) {
 		m_delete.push_back(*response);
 	}
@@ -421,7 +389,6 @@ void CSearch::ProcessResponse(uint32_t fromIP, uint16_t fromPort, ContactList *r
 	m_lastResponseTick = ::GetTickCount64();
 #endif
 
-	// Find contact that is responding.
 	CUInt128 fromDistance(0u);
 	CContact *fromContact = NULL;
 	for (ContactMap::const_iterator it = m_tried.begin(); it != m_tried.end(); ++it) {
@@ -449,12 +416,10 @@ void CSearch::ProcessResponse(uint32_t fromIP, uint16_t fromPort, ContactList *r
 			m_pendingRequests.erase(pending);
 		}
 
-		// The contact may have gone bad since we sent the request. This
-		// is the point at which we know the node stands behind this
-		// identity, so it is the right place to check it -- and
-		// onlyOneNodePerIP is off here because the contact is already in
-		// our routing table and a second port on the address is the
-		// routing table's problem, not this answer's.
+		// The contact may have gone bad since we sent the request, and this is the
+		// point at which we know the node stands behind this identity.
+		// onlyOneNodePerIP is off here because the contact is already in our routing
+		// table, so a second port on the address is that table's problem.
 		if (safeKad.IsBadNode(fromIP,
 			    fromPort,
 			    fromContact->GetClientID(),
@@ -492,9 +457,7 @@ void CSearch::ProcessResponse(uint32_t fromIP, uint16_t fromPort, ContactList *r
 	// Not interested in responses for FIND_NODE, will be added to contacts by udp listener
 	if (m_type == NODE) {
 		AddDebugLogLineN(logKadSearch, "Node type search result, discarding.");
-		// Note that we got an answer.
 		m_answers++;
-		// We clear the possible list to force the search to stop.
 		m_possible.clear();
 		return;
 	}
@@ -506,18 +469,14 @@ void CSearch::ProcessResponse(uint32_t fromIP, uint16_t fromPort, ContactList *r
 		// A node is not allowed to answer with contacts to itself
 		receivedIPs[fromIP] = 1;
 		receivedSubnets[fromIP & 0xFFFFFF00] = 1;
-		// Loop through their responses
 		for (ContactList::iterator it = results->begin(); it != results->end(); ++it) {
-			// Get next result
 			CContact *c = *it;
-			// calc distance this result is to the target
 			CUInt128 distance(c->GetClientID() ^ m_target);
 
 			if (distance < fromDistance) {
 				providedCloserContacts = true;
 			}
 
-			// Ignore this contact if already known or tried it.
 			if (m_possible.count(distance) > 0) {
 				AddDebugLogLineN(
 					logKadSearch, "Search result from already known client: ignore");
@@ -562,12 +521,9 @@ void CSearch::ProcessResponse(uint32_t fromIP, uint16_t fromPort, ContactList *r
 				receivedSubnets[c->GetIPAddress() & 0xFFFFFF00] = 1;
 			}
 
-			// Add to possible
 			m_possible[distance] = c;
 
-			// Verify if the result is closer to the target than the one we just checked.
 			if (distance < fromDistance) {
-				// The top ALPHA_QUERY of results are used to determine if we send a request.
 				bool top = false;
 				if (m_best.size() < ALPHA_QUERY) {
 					top = true;
@@ -576,7 +532,6 @@ void CSearch::ProcessResponse(uint32_t fromIP, uint16_t fromPort, ContactList *r
 					ContactMap::iterator worst = m_best.end();
 					--worst;
 					if (distance < worst->first) {
-						// Prevent having more than ALPHA_QUERY within the Best list.
 						m_best.erase(worst);
 						m_best[distance] = c;
 						top = true;
@@ -584,20 +539,14 @@ void CSearch::ProcessResponse(uint32_t fromIP, uint16_t fromPort, ContactList *r
 				}
 
 				if (top) {
-					// We determined this contact is a candidate for a request.
-					// Add to tried
 					m_tried[distance] = c;
-					// Send the KadID so other side can check if I think it has the right
-					// KadID. Send request
 					SendFindValue(c);
 				}
 			}
 		}
 
-		// Add to list of people who responded.
 		m_responded[fromDistance] = providedCloserContacts;
 
-		// Complete node search, just increment the counter.
 		if (m_type == NODECOMPLETE || m_type == NODESPECIAL) {
 			AddDebugLogLineN(logKadSearch,
 				wxString("Search result type: Node") +
@@ -611,7 +560,6 @@ void CSearch::StorePacket()
 {
 	wxASSERT(!m_possible.empty());
 
-	// This method is currently only called by jumpstart so only use best possible.
 	ContactMap::const_iterator possible = m_possible.begin();
 	CUInt128 fromDistance(possible->first);
 	CContact *from = possible->second;
@@ -620,20 +568,17 @@ void CSearch::StorePacket()
 		m_closestDistantFound = fromDistance;
 	}
 
-	// Make sure this is a valid node to store.
 	if (fromDistance.Get32BitChunk(0) > SEARCHTOLERANCE &&
 		!::IsLanIP(wxUINT32_SWAP_ALWAYS(from->GetIPAddress()))) {
 		return;
 	}
 
-	// What kind of search are we doing?
 	switch (m_type) {
 	case FILE: {
 		AddDebugLogLineN(logKadSearch, "Search request type: File");
 		CMemFile searchTerms;
 		searchTerms.WriteUInt128(m_target);
 		if (from->GetVersion() >= 3) {
-			// Find file we are storing info about.
 			uint8_t fileid[16];
 			m_target.ToByteArray(fileid);
 			CKnownFile *file = theApp->downloadqueue->GetFileByID(CMD4Hash(fileid));
@@ -731,7 +676,6 @@ void CSearch::StorePacket()
 	}
 	case NOTES: {
 		AddDebugLogLineN(logKadSearch, "Search request type: Notes");
-		// Write complete packet.
 		CMemFile searchTerms;
 		searchTerms.WriteUInt128(m_target);
 		if (from->GetVersion() >= 3) {
@@ -796,7 +740,6 @@ void CSearch::StorePacket()
 			break;
 		}
 
-		// Find the file we are trying to store as a source to.
 		uint8_t fileid[16];
 		m_target.ToByteArray(fileid);
 		CKnownFile *file = theApp->sharedfiles->GetFileByID(CMD4Hash(fileid));
@@ -804,17 +747,12 @@ void CSearch::StorePacket()
 			// We store this mostly for GUI reasons.
 			m_fileName = file->GetFileName().GetPrintable();
 
-			// Get our clientID for the packet.
 			CUInt128 id(CKademlia::GetPrefs()->GetClientHash());
 			TagPtrList taglist;
 
-			// We can use type for different types of sources.
-			// 1 HighID sources..
-			// 2 cannot be used as older clients will not work.
-			// 3 Firewalled Kad Source.
-			// 4 >4GB file HighID Source.
-			// 5 >4GB file Firewalled Kad source.
-			// 6 Firewalled source with Direct Callback (supports >4GB)
+			// Source types: 1 HighID, 3 firewalled Kad, 4 >4GB HighID, 5 >4GB
+			// firewalled Kad, 6 firewalled with direct callback (supports >4GB).
+			// 2 cannot be used, as older clients will not work with it.
 
 			bool directCallback = false;
 			if (theApp->IsFirewalled()) {
@@ -881,10 +819,8 @@ void CSearch::StorePacket()
 			taglist.push_back(
 				new CTagInt8(TAG_ENCRYPTION, CPrefs::GetMyConnectOptions(true, true)));
 
-			// Send packet
 			CKademlia::GetUDPListener()->SendPublishSourcePacket(*from, m_target, id, taglist);
 			m_totalRequestAnswers++;
-			// Delete all tags.
 			deleteTagPtrListEntries(&taglist);
 		} else {
 			PrepareToStop();
@@ -929,13 +865,11 @@ void CSearch::StorePacket()
 				++itListFileID;
 			}
 
-			// Correct file count.
 			uint64_t current_pos = packetdata.GetPosition();
 			packetdata.Seek(16);
 			packetdata.WriteUInt16(packetCount);
 			packetdata.Seek(current_pos);
 
-			// Send packet
 			if (from->GetVersion() >= 6) {
 				DebugSend(Kad2PublishKeyReq, from->GetIPAddress(), from->GetUDPPort());
 				CUInt128 clientID = from->GetClientID();
@@ -963,19 +897,15 @@ void CSearch::StorePacket()
 	}
 	case STORENOTES: {
 		AddDebugLogLineN(logKadSearch, "Search request type: StoreNotes");
-		// Find file we are storing info about.
 		uint8_t fileid[16];
 		m_target.ToByteArray(fileid);
 		CKnownFile *file = theApp->sharedfiles->GetFileByID(CMD4Hash(fileid));
 
 		if (file) {
 			CMemFile packetdata(1024 * 2);
-			// Send the hash of the file we're storing info about.
 			packetdata.WriteUInt128(m_target);
-			// Send our ID with the info.
 			packetdata.WriteUInt128(CKademlia::GetPrefs()->GetKadID());
 
-			// Create our taglist.
 			TagPtrList taglist;
 			taglist.push_back(new CTagString(TAG_FILENAME, file->GetFileName().GetPrintable()));
 			if (file->GetFileRating() != 0) {
@@ -989,7 +919,6 @@ void CSearch::StorePacket()
 			}
 			packetdata.WriteTagPtrList(taglist);
 
-			// Send packet
 			if (from->GetVersion() >= 6) {
 				DebugSend(Kad2PublishNotesReq, from->GetIPAddress(), from->GetUDPPort());
 				CUInt128 clientID = from->GetClientID();
@@ -1012,7 +941,6 @@ void CSearch::StorePacket()
 				wxFAIL;
 			}
 			m_totalRequestAnswers++;
-			// Delete all tags.
 			deleteTagPtrListEntries(&taglist);
 		} else {
 			PrepareToStop();
@@ -1032,9 +960,7 @@ void CSearch::StorePacket()
 		// Send the ID we used to find our buddy. Used for checks later and allows users to callback
 		// someone if they change buddies.
 		packetdata.WriteUInt128(m_target);
-		// Send client hash so they can do a callback.
 		packetdata.WriteUInt128(CKademlia::GetPrefs()->GetClientHash());
-		// Send client port so they can do a callback.
 		packetdata.WriteUInt16(thePrefs::GetPort());
 
 		DebugSend(KadFindBuddyReq, from->GetIPAddress(), from->GetUDPPort());
@@ -1068,7 +994,6 @@ void CSearch::StorePacket()
 		}
 
 		CMemFile packetdata(34);
-		// This is the ID that the person we want to contact used to find a buddy.
 		packetdata.WriteUInt128(m_target);
 		if (m_fileIDs.size() != 1) {
 			throw wxString("Kademlia.CSearch.processResponse: m_fileIDs.size() != 1");
@@ -1076,9 +1001,7 @@ void CSearch::StorePacket()
 		// Currently, we limit the type of callbacks for sources. We must know a file this person has
 		// for it to work.
 		packetdata.WriteUInt128(m_fileIDs.front());
-		// Send our port so the callback works.
 		packetdata.WriteUInt16(thePrefs::GetPort());
-		// Send packet
 		DebugSend(KadCallbackReq, from->GetIPAddress(), from->GetUDPPort());
 		if (from->GetVersion() >= 6) {
 			CUInt128 clientID = from->GetClientID();
@@ -1405,13 +1328,11 @@ void CSearch::ProcessResultKeyword(
 #endif
 #ifdef ENABLE_KAD_PROTOCOL_10
 		} else if (tag->GetName() == TAG_KADAICHHASHRESULT) {
-			// AICH hashes on keyword storage arrived with Kad protocol
-			// version 0x09.  A sender below that cannot have produced
-			// this tag itself, so it is filtered rather than trusted.
-			//
-			// Gated with the rest: with the switch off we never publish
-			// an AICH hash, so acting on one a peer reports would be a
-			// behaviour upstream does not have.
+			// AICH hashes on keyword storage arrived with Kad protocol version
+			// 0x09, so a sender below that cannot have produced this tag itself
+			// and it is filtered rather than trusted. Gated with the rest: with
+			// the switch off we never publish an AICH hash, so acting on one a
+			// peer reports would be behaviour upstream does not have.
 			if (CKadAICHHashList::PeerSupportsAICHKeywordStorage(fromKadVersion) &&
 				tag->IsBsob()) {
 				if (!CKadAICHHashList::DecodeResultTag(
@@ -1454,11 +1375,10 @@ void CSearch::ProcessResultKeyword(
 	if (!title.IsEmpty()) {
 		taglist.push_back(new CTagString(TAG_MEDIA_TITLE, title));
 	}
-	// The codec was read off the wire and then never mentioned again -- the
-	// local it filled occurred exactly twice in this file, the declaration and
-	// the assignment -- so every Kad result showed an empty Codec column and
-	// the value never reached a download started from it. Being a wxString,
-	// the dead store was not something -Wunused-but-set-variable could flag.
+	// The codec was read off the wire and then never mentioned again, so every Kad
+	// result showed an empty Codec column and the value never reached a download
+	// started from it. Being a wxString, the dead store was not something
+	// -Wunused-but-set-variable could flag.
 	if (!codec.IsEmpty()) {
 		taglist.push_back(new CTagString(TAG_MEDIA_CODEC, codec));
 	}
@@ -1491,29 +1411,25 @@ void CSearch::ProcessResultKeyword(
 	theApp->searchlist->KademliaSearchKeyword(
 		m_searchID, &answer, name, size, type, publishInfo, taglist);
 
-	// Free tags memory
 	deleteTagPtrListEntries(&taglist);
 }
 
 void CSearch::SendFindValue(CContact *contact, bool reaskMore)
 {
-	// Found a node that we think has contacts closer to our target.
 	try {
 		if (m_stopping) {
 			return;
 		}
 
 		CMemFile packetdata(33);
-		// The number of returned contacts is based on the type of search.
 		uint8_t contactCount = GetRequestContactCount();
 
 		if (reaskMore) {
-			// Either the JumpStart dead-nodes-fallback or
-			// CSearch::RequestMoreResults() asked us to send the wider
-			// KADEMLIA_FIND_VALUE_MORE variant to this contact.  Track
-			// the contact's ClientID so ProcessResponse's "more results
-			// than requested" check accepts the larger response, and so
-			// RequestMoreResults() won't reask the same peer twice.
+			// Either the JumpStart dead-nodes fallback or RequestMoreResults() asked
+			// us to send the wider KADEMLIA_FIND_VALUE_MORE variant to this contact.
+			// Tracking its ClientID makes ProcessResponse's "more results than
+			// requested" check accept the larger response, and stops
+			// RequestMoreResults() reasking the same peer twice.
 			wxASSERT(contactCount == KADEMLIA_FIND_VALUE);
 			m_requestedMoreNodes.insert(contact->GetClientID());
 			contactCount = KADEMLIA_FIND_VALUE_MORE;
@@ -1525,9 +1441,7 @@ void CSearch::SendFindValue(CContact *contact, bool reaskMore)
 			return;
 		}
 
-		// Put the target we want into the packet.
 		packetdata.WriteUInt128(m_target);
-		// Add the ID of the contact we're contacting for sanity checks on the other end.
 		packetdata.WriteUInt128(contact->GetClientID());
 		if (contact->GetVersion() >= 2) {
 			if (contact->GetVersion() >= 6) {
@@ -1631,18 +1545,14 @@ bool CSearch::CanReaskMore() const
 
 bool CSearch::RequestMoreResults()
 {
-	// Walk m_responded (sorted by distance to target) for the closest
-	// peer we have not yet asked for KADEMLIA_FIND_VALUE_MORE, and
-	// dispatch the wider variant to it.  Each reask returns up to 11
-	// closer contacts (vs the default 2), which the existing
-	// ProcessResponse cascade then queries with FIND_VALUE — surfacing
-	// additional file matches from one extra ring of the routing-table
-	// neighbourhood.
+	// Walk m_responded (sorted by distance to target) for the closest peer not yet
+	// asked for KADEMLIA_FIND_VALUE_MORE, and dispatch the wider variant to it.
+	// Each reask returns up to 11 closer contacts instead of 2, which the
+	// ProcessResponse cascade then queries -- surfacing more file matches from one
+	// extra ring of the routing-table neighbourhood.
 	//
-	// Bounded by KADEMLIA_FIND_VALUE_MORE_REASKS to limit per-search
-	// network impact: past 4 reasks the local neighbourhood for a
-	// given keyword is typically exhausted and additional reasks are
-	// wasted UDP traffic.
+	// Bounded by KADEMLIA_FIND_VALUE_MORE_REASKS: past 4 reasks the local
+	// neighbourhood for a keyword is typically exhausted.
 
 	if (m_stopping) {
 		return false;
@@ -1684,24 +1594,19 @@ bool CSearch::RequestMoreResults()
 // TODO: Redundant metadata checks
 void CSearch::PreparePacketForTags(CMemFile *bio, CKnownFile *file, uint8_t targetKadVersion)
 {
-	// We're going to publish a keyword, set up the tag list
 	TagPtrList taglist;
 
 	try {
 		if (file && bio) {
-			// Name, Size
 			taglist.push_back(new CTagString(TAG_FILENAME, file->GetFileName().GetPrintable()));
 			taglist.push_back(new CTagVarInt(TAG_FILESIZE, file->GetFileSize()));
 			taglist.push_back(new CTagVarInt(TAG_SOURCES, file->m_nCompleteSourcesCount));
 
 #ifdef ENABLE_KAD_PROTOCOL_10
-			// AICH root hash, added to keyword storage by Kad protocol
-			// version 0x09.  A node at 0x08 has no handling for this tag,
-			// so it is omitted for it: the entry it stores simply carries
-			// no AICH hash, and it stays usable for search and routing.
-			//
-			// Gated: this is a tag on an outgoing packet, so it is the
-			// clearest thing in this change that is not inert.
+			// AICH root hash, added to keyword storage by Kad protocol version
+			// 0x09. A node at 0x08 has no handling for this tag, so it is omitted
+			// for it: the entry it stores simply carries no AICH hash and stays
+			// usable for search and routing.
 			if (CKadAICHHashList::PeerSupportsAICHKeywordStorage(targetKadVersion) &&
 				file->HasProperAICHHashSet()) {
 				const CAICHHash &aichHash = file->GetAICHHashset()->GetMasterHash();
@@ -1723,21 +1628,18 @@ void CSearch::PreparePacketForTags(CMemFile *bio, CKnownFile *file, uint8_t targ
 
 			// Additional meta data (Artist, Album, Codec, Length, ...).
 			//
-			// This used to claim it sends only VERIFIED metadata. It does not,
-			// and did not before either: a download inherits its source's tags
-			// as a during-download preview, and GetMetaDataVer() answers "has
-			// any FT_MEDIA_* tag", not "was locally probed". So a partfile
-			// republishes what its search result advertised until its own
-			// completion probe corrects it. Distinguishing the two needs a
-			// locally-probed flag on the file, which is a design change rather
-			// than a comment fix -- left for its own issue.
+			// NOT only verified metadata, despite what this used to claim: a download
+			// inherits its source's tags as a during-download preview, and
+			// GetMetaDataVer() answers "has any FT_MEDIA_* tag", not "was locally
+			// probed". So a partfile republishes what its search result advertised
+			// until its own completion probe corrects it. Telling the two apart needs
+			// a locally-probed flag on the file.
 			if (file->GetMetaDataVer() > 0) {
 				// Looked up by id ALONE, not by (id, type). The old exact
-				// `GetTag(id, TAGTYPE_UINT32)` was safe only while everything
-				// reaching a CKnownFile locally happened to be a CTagInt32;
-				// now that a download can inherit a narrower integer from a
-				// Kad hit, it would silently stop publishing the moment such a
-				// tag was stored.
+				// GetTag(id, TAGTYPE_UINT32) was safe only while everything reaching a
+				// CKnownFile locally happened to be a CTagInt32; now that a download
+				// can inherit a narrower integer from a Kad hit, it would silently
+				// stop publishing the moment such a tag was stored.
 				static const uint8_t _aMetaTags[] = { FT_MEDIA_ARTIST,
 					FT_MEDIA_ALBUM,
 					FT_MEDIA_TITLE,

--- a/src/kademlia/kademlia/Search.h
+++ b/src/kademlia/kademlia/Search.h
@@ -116,31 +116,26 @@ public:
 		m_nodeSpecialSearchRequester = requester;
 	}
 
-	// User-triggered widening of the Kad result set.  Walks m_responded for
-	// the closest contact we have not already reasked, and sends it
-	// SendFindValue with reaskMore=true (i.e. KADEMLIA_FIND_VALUE_MORE on
-	// the wire instead of KADEMLIA_FIND_VALUE — peers return up to 11
-	// closer contacts instead of 2).  Subsequent FIND_VALUE queries against
-	// those contacts surface additional file matches that the search's
-	// initial alpha=ALPHA_QUERY frontier missed.  Bounded internally by
-	// m_requestedMoreNodes.size() < KADEMLIA_FIND_VALUE_MORE_REASKS to
-	// limit per-search network impact.  Returns true if a reask was
-	// dispatched, false if no eligible candidate remains.
+	// User-triggered widening of the Kad result set. Walks m_responded for the
+	// closest contact not already reasked and sends it SendFindValue with
+	// reaskMore=true, so peers return up to 11 closer contacts instead of 2.
+	// Subsequent FIND_VALUE queries against those contacts surface matches the
+	// search's initial alpha=ALPHA_QUERY frontier missed. Bounded internally by
+	// KADEMLIA_FIND_VALUE_MORE_REASKS.
 	bool RequestMoreResults();
 
 	// Whether this search could still be widened by a future reask, ignoring
 	// whether one is dispatchable right now.
 	//
-	// The distinction is the point. RequestMoreResults() returns false both
-	// when the search is finished with reasking for good (it is stopping, or
-	// the reask budget is spent) and when it simply has no un-reasked peer to
-	// send to *yet* -- and those want opposite answers from a UI. The first
-	// is terminal, so the "More" control should go away; the second clears as
-	// soon as another peer responds, so the control must stay.
+	// The distinction is the point: RequestMoreResults() returns false both when
+	// the search is finished with reasking for good and when it simply has no
+	// un-reasked peer to send to YET, and those want opposite answers from a UI.
+	// The first is terminal, so the "More" control should go away; the second
+	// clears as soon as another peer responds.
 	//
-	// Callers pair the two as `fired || CanReaskMore()`. The `fired ||` is
-	// not optional: the reask that consumes the last of the budget really
-	// happens, and this predicate is already false by the time it returns.
+	// Callers pair the two as `fired || CanReaskMore()`, and the `fired ||` is not
+	// optional: the reask that consumes the last of the budget really happens, and
+	// this predicate is already false by the time it returns.
 	bool CanReaskMore() const;
 
 	enum

--- a/src/kademlia/kademlia/SearchManager.cpp
+++ b/src/kademlia/kademlia/SearchManager.cpp
@@ -65,7 +65,6 @@ SearchMap CSearchManager::m_searches;
 
 bool CSearchManager::IsSearching(uint32_t searchID) noexcept
 {
-	// Check if this searchID is within the searches
 	for (SearchMap::const_iterator it = m_searches.begin(); it != m_searches.end(); ++it) {
 		if (it->second->GetSearchID() == searchID) {
 			return true;
@@ -104,15 +103,12 @@ bool CSearchManager::IsKadSearch(uint32_t searchID)
 {
 	for (SearchMap::const_iterator it = m_searches.begin(); it != m_searches.end(); ++it) {
 		// Skip searches that were never given an id. Their m_searchID is the
-		// constructor's 0xFFFFFFFF, which is also the single bucket every EC
-		// client predating multi-search reuses for all of its searches -- so
-		// without this an ordinary node lookup, buddy lookup or UDP firewall
-		// check answers "yes, that is a running Kad search" for a legacy
-		// client's ed2k search. The whole per-id lifecycle then follows: the
-		// search is reported as kind Kad, RUNNING, and its percent comes from
-		// the Kad time-ramp (pinned at 99) until the unrelated internal search
-		// happens to end. Only PrepareFindKeywords and PrepareLookup assign an
-		// id; the three FindNode* paths do not.
+		// constructor's 0xFFFFFFFF, which is also the single bucket every EC client
+		// predating multi-search reuses for all of its searches -- so without this an
+		// ordinary node lookup, buddy lookup or UDP firewall check answers "yes, that
+		// is a running Kad search" for a legacy client's ed2k search, and the whole
+		// per-id lifecycle follows from there. Only PrepareFindKeywords and
+		// PrepareLookup assign an id.
 		if (!it->second->HasSearchID()) {
 			continue;
 		}
@@ -125,17 +121,15 @@ bool CSearchManager::IsKadSearch(uint32_t searchID)
 
 void CSearchManager::StopSearch(uint32_t searchID, bool delayDelete)
 {
-	// Stop a specific searchID
 	for (SearchMap::iterator it = m_searches.begin(); it != m_searches.end(); ++it) {
 		if (it->second->GetSearchID() == searchID) {
 			// Do not delete as we want to get a chance for late packets to be processed.
 			if (delayDelete) {
 				it->second->PrepareToStop();
 			} else {
-				// Delete this search now.
-				// If this method is changed to continue looping, take care of the iterator as
-				// we will already be pointing to the next entry and the for-loop could cause
-				// you to iterate past the end.
+				// Delete this search now. If this method is changed to continue
+				// looping, take care of the iterator: it already points at the next
+				// entry, so the for-loop could iterate past the end.
 				delete it->second;
 				m_searches.erase(it++);
 			}
@@ -146,13 +140,11 @@ void CSearchManager::StopSearch(uint32_t searchID, bool delayDelete)
 
 void CSearchManager::StopAllSearches()
 {
-	// Stop and delete all searches.
 	DeleteContents(m_searches);
 }
 
 bool CSearchManager::StartSearch(CSearch *search)
 {
-	// A search object was created, now try to start the search.
 	if (AlreadySearchingFor(search->GetTarget())) {
 		// There was already a search in progress with this target.
 		delete search;

--- a/src/kademlia/kademlia/SearchManager.h
+++ b/src/kademlia/kademlia/SearchManager.h
@@ -97,21 +97,19 @@ public:
 		return m_searches.count(target) > 0;
 	}
 
-	// Find a CSearch by searchID (m_searches is keyed by target hash;
-	// this iterates) and invoke its RequestMoreResults().
+	// Find a CSearch by searchID (m_searches is keyed by target hash, so this
+	// iterates) and invoke its RequestMoreResults().
 	//
 	// Returns whether the search can still be widened by a later press --
-	// `fired || CanReaskMore()`, i.e. false only when reasking is over for
-	// good (the search is stopping, its reask budget is spent, or no live
-	// search carries that id at all). NOT "did a reask go out": a press made
-	// while no responded peer is left to reask *yet* still returns true,
-	// because that clears as soon as another peer answers and a UI must keep
-	// its control.
+	// `fired || CanReaskMore()` -- so false only when reasking is over for good.
+	// NOT "did a reask go out": a press made while no responded peer is left to
+	// reask YET still returns true, because that clears as soon as another peer
+	// answers and a UI must keep its control.
 	//
-	// `out_fired`, when given, receives whether a reask actually went out on
-	// this call. The two genuinely differ -- the reask that spends the last
-	// of the budget fires and leaves the search un-widenable -- and a log
-	// line wants the second, a control's enabled state the first.
+	// `out_fired`, when given, receives whether a reask actually went out. The two
+	// genuinely differ -- the reask spending the last of the budget fires and
+	// leaves the search un-widenable -- and a log line wants the second, a
+	// control's enabled state the first.
 	static bool RequestMoreResults(uint32_t searchID, bool *out_fired = nullptr);
 
 	// True if the given searchID corresponds to an active Kad search.
@@ -119,12 +117,10 @@ public:
 	// the currently-selected tab being a Kad search (vs ED2K).
 	static bool IsKadSearch(uint32_t searchID);
 
-	// Advances m_nextID past a restored Kad search's persisted id (issue
-	// #641 Phase 3), so the next Kad search started this session can't be
-	// handed the same id -- m_nextID restarts at SEARCH_ID_KAD_MASK every
-	// launch, so without this a restored search and the first new Kad
-	// search after a restart collide deterministically. No-op if id is
-	// already at or below the current counter.
+	// Advances m_nextID past a restored Kad search's persisted id, so the next Kad
+	// search this session cannot be handed the same one: m_nextID restarts at
+	// SEARCH_ID_KAD_MASK every launch, so without this a restored search and the
+	// first new Kad search after a restart collide deterministically.
 	static void ReserveSearchId(uint32_t id)
 	{
 		if (id > m_nextID) {

--- a/src/kademlia/kademlia/UDPFirewallTester.cpp
+++ b/src/kademlia/kademlia/UDPFirewallTester.cpp
@@ -94,13 +94,11 @@ void CUDPFirewallTester::SetUDPFWCheckResult(
 				m_lastSucceededTime + SEC2MS(10) > ::GetTickCount64() &&
 				incomingPort == CKademlia::GetPrefs()->GetInternKadPort() &&
 				CKademlia::GetPrefs()->GetUseExternKadPort()) {
-				// our test finished already in the last 10 seconds with being open because we
-				// received a proper result packet before however we now receive another
-				// answer packet on our incoming port (which is not unusual as both
-				// resultpackets are sent nearly at the same time and UDP doesn't cares if the
-				// order stays), while the one before was received on our extern port Because
-				// a proper forwarded intern port is more reliable to stay open than an extern
-				// port set by the NAT, we prefer intern ports and change the setting.
+				// Our test already finished in the last 10 seconds as open, but another
+				// answer packet has now arrived on our incoming port -- not unusual,
+				// since both result packets are sent at nearly the same time and UDP
+				// does not preserve order. A properly forwarded intern port is more
+				// reliable than an extern port set by the NAT, so prefer it.
 				CKademlia::GetPrefs()->SetUseExternKadPort(false);
 				AddDebugLogLineN(logKadUdpFwTester,
 					CFormat("Corrected UDP firewall result: Using open internal (%u) "
@@ -133,14 +131,11 @@ void CUDPFirewallTester::SetUDPFWCheckResult(
 	}
 
 	if (m_fwChecksRunningUDP == 0) {
-		// A response arrived for a check we no longer believe to be
-		// running. Most commonly this is a late UDP packet that
-		// straddles a Kad restart (system suspend/resume, see #384),
-		// where ReCheckFirewallUDP zeroed the counter while the
-		// previous test's responses were still in flight. Dropping
-		// the response avoids mutating m_firewalledUDP /
-		// m_fwChecksFinishedUDP based on stale state — the new test
-		// cycle will produce its own results.
+		// A response arrived for a check we no longer believe to be running, most
+		// commonly a late UDP packet straddling a Kad restart (#384), where
+		// ReCheckFirewallUDP zeroed the counter while the previous test's responses
+		// were still in flight. Dropping it avoids mutating m_firewalledUDP /
+		// m_fwChecksFinishedUDP from stale state.
 		AddDebugLogLineN(logKadUdpFwTester,
 			wxString::Format("Ignoring late UDP FW result from %s",
 				(const char *)KadIPToString(fromIP).mb_str()));

--- a/src/kademlia/net/FastKad.h
+++ b/src/kademlia/net/FastKad.h
@@ -40,39 +40,33 @@ namespace Kademlia
 // fixed constant.
 //
 // A fixed timeout is wrong in both directions: on a fast link it wastes seconds
-// waiting for a node that was never going to answer, and on a slow or congested
-// one it discards contacts that would have answered just after the deadline.
-// This keeps a bounded window of the most recent per-address response times and
-// estimates the ceiling as mean + 2 standard deviations (about the 95th
-// percentile of a normal distribution), plus a small margin.
+// waiting for a node that was never going to answer, and on a slow one it
+// discards contacts that would have answered just after the deadline. This keeps
+// a bounded window of the most recent per-address response times and estimates
+// the ceiling as mean + 2 standard deviations, plus a small margin.
 //
 // Two deliberate biases keep a cold or lucky window from producing an
 // aggressively short timeout:
 //
-//  - The mean and variance are always divided by the *full* window size, with
-//    every unfilled slot counted as the default response time. A handful of
-//    fast samples therefore cannot pull the estimate far below the default;
-//    it takes a full window of fast samples to earn a short timeout.
-//  - Entries younger than MIN_EVICTION_AGE_MS are never evicted to make room,
-//    so a burst of new addresses cannot churn the whole window at once.
+//  - The mean and variance are always divided by the FULL window size, with
+//    every unfilled slot counted as the default response time, so it takes a
+//    full window of fast samples to earn a short timeout.
+//  - Entries younger than MIN_EVICTION_AGE_MS are never evicted to make room, so
+//    a burst of new addresses cannot churn the whole window at once.
 //
 // All time values are in milliseconds and "now" is always passed in, which is
 // what lets the estimator be tested without waiting on a real clock.
 //
-// Two places where this deliberately does not match eMuleAI, so that the next
-// person holding the two side by side reads them as decisions rather than as
-// transcription slips:
+// Two deliberate divergences from eMuleAI:
 //
 //  - eMuleAI accumulates `missing * CLOCKS_PER_SEC` into its sum of squares,
-//    which adds a raw time to a sum of squared times: the units do not agree,
-//    and the unfilled-slot term is then far too small to hold the estimate up.
-//    Here the squared deviation is added, so an unfilled slot biases the
-//    variance the way the comment above says it does. emule-qt reached the
-//    same correction independently.
-//  - eMuleAI reads the clock with clock(), which on POSIX is CPU time, not
-//    wall time: a mostly-idle client barely advances it, so response times
+//    adding a raw time to a sum of squared times: the units do not agree, and
+//    the unfilled-slot term is then far too small to hold the estimate up. Here
+//    the squared deviation is added. emule-qt reached the same correction.
+//  - eMuleAI reads the clock with clock(), which on POSIX is CPU time, not wall
+//    time, so a mostly-idle client barely advances it and response times
 //    measured against it are far too short. Passing the tick in avoids the
-//    question entirely, and is what makes the estimator testable.
+//    question and is what makes the estimator testable.
 class CFastKad
 {
 public:

--- a/src/kademlia/net/KademliaUDPListener.cpp
+++ b/src/kademlia/net/KademliaUDPListener.cpp
@@ -127,7 +127,6 @@ void CKademliaUDPListener::SendMyDetails(uint8_t opcode,
 	if (kadVersion > 1) {
 		packetdata.WriteUInt16(thePrefs::GetPort());
 		packetdata.WriteUInt8(KADEMLIA_VERSION);
-		// Tag Count.
 		uint8_t tagCount = 0;
 		if (!CKademlia::GetPrefs()->GetUseExternKadPort()) {
 			tagCount++;
@@ -469,7 +468,6 @@ bool CKademliaUDPListener::AddContact2(const uint8_t *data,
 	for (FetchNodeIDList::iterator it = m_fetchNodeIDRequests.begin(); it != m_fetchNodeIDRequests.end();
 		++it) {
 		if (it->ip == ip && it->tcpPort == tport) {
-			// AddDebugLogLineN(logKadMain, "Result Addcontact: " + id.ToHexString());
 			uint8_t uchID[16];
 			id.ToByteArray(uchID);
 			it->requester->KadSearchNodeIDByIPResult(KCSR_SUCCEEDED, uchID);
@@ -479,11 +477,10 @@ bool CKademliaUDPListener::AddContact2(const uint8_t *data,
 	}
 
 	if (fromHelloReq && version >= 8) {
-		// this is just for statistic calculations. We try to determine the ratio of (UDP) firewalled
-		// users, by counting how many of all nodes which have us in their routing table (our own
-		// routing table is supposed to have no UDP firewalled nodes at all) and support the
-		// firewalled tag are firewalled themself. Obviously this only works if we are not firewalled
-		// ourself
+		// Statistics only: the ratio of UDP-firewalled users is estimated by counting
+		// how many of the nodes that have us in their routing table -- our own is
+		// supposed to hold no UDP-firewalled nodes -- report themselves firewalled.
+		// Only works while we are not firewalled ourselves.
 		CKademlia::GetPrefs()->StatsIncUDPFirewalledNodes(udpFirewalled);
 		CKademlia::GetPrefs()->StatsIncTCPFirewalledNodes(tcpFirewalled);
 	}
@@ -502,7 +499,6 @@ bool CKademliaUDPListener::AddContact2(const uint8_t *data,
 // Used only for Kad2.0
 void CKademliaUDPListener::Process2BootstrapRequest(uint32_t ip, uint16_t port, const CKadUDPKey &senderKey)
 {
-	// Get some contacts to return
 	ContactList contacts;
 	uint16_t numContacts = (uint16_t)CKademlia::GetRoutingZone()->GetBootstrapContacts(&contacts, 20);
 
@@ -515,7 +511,6 @@ void CKademliaUDPListener::Process2BootstrapRequest(uint32_t ip, uint16_t port, 
 	packetdata.WriteUInt16(thePrefs::GetPort());
 	packetdata.WriteUInt8(KADEMLIA_VERSION);
 
-	// Write packet info
 	packetdata.WriteUInt16(numContacts);
 	CContact *contact;
 	for (ContactList::const_iterator it = contacts.begin(); it != contacts.end(); ++it) {
@@ -527,7 +522,6 @@ void CKademliaUDPListener::Process2BootstrapRequest(uint32_t ip, uint16_t port, 
 		packetdata.WriteUInt8(contact->GetVersion());
 	}
 
-	// Send response
 	DebugSend(Kad2BootstrapRes, ip, port);
 	SendPacket(packetdata, KADEMLIA2_BOOTSTRAP_RES, ip, port, senderKey, NULL);
 }
@@ -545,7 +539,6 @@ void CKademliaUDPListener::Process2BootstrapResponse(const uint8_t *packetData,
 
 	CRoutingZone *routingZone = CKademlia::GetRoutingZone();
 
-	// How many contacts were given
 	CMemFile bio(packetData, lenPacket);
 	CUInt128 contactID = bio.ReadUInt128();
 	uint16_t tport = bio.ReadUInt16();
@@ -559,7 +552,6 @@ void CKademliaUDPListener::Process2BootstrapResponse(const uint8_t *packetData,
 		routingZone->Add(
 			contactID, ip, port, tport, version, senderKey, validReceiverKey, true, false);
 	}
-	// AddDebugLogLineN(logClientKadUDP, "Inc Kad2 Bootstrap packet from " + KadIPToString(ip));
 
 	uint16_t numContacts = bio.ReadUInt16();
 	while (numContacts) {
@@ -756,7 +748,6 @@ void CKademliaUDPListener::ProcessKademlia2Request(const uint8_t *packetData,
 	uint16_t port,
 	const CKadUDPKey &senderKey)
 {
-	// Get target and type
 	CMemFile bio(packetData, lenPacket);
 	uint8_t type = bio.ReadUInt8();
 	type &= 0x1F;
@@ -765,9 +756,7 @@ void CKademliaUDPListener::ProcessKademlia2Request(const uint8_t *packetData,
 			       wxString::FromAscii(__FUNCTION__));
 	}
 
-	// This is the target node trying to be found.
 	CUInt128 target = bio.ReadUInt128();
-	// Convert Target to Distance as this is how we store contacts.
 	CUInt128 distance(CKademlia::GetPrefs()->GetKadID());
 	distance ^= target;
 
@@ -775,7 +764,6 @@ void CKademliaUDPListener::ProcessKademlia2Request(const uint8_t *packetData,
 	// KadID.
 	CUInt128 check = bio.ReadUInt128();
 	if (CKademlia::GetPrefs()->GetKadID() == check) {
-		// Get required number closest to target
 		ContactMap results;
 		CKademlia::GetRoutingZone()->GetClosestTo(2, target, distance, type, &results);
 		uint8_t count = (uint8_t)results.size();
@@ -812,10 +800,8 @@ void CKademliaUDPListener::ProcessKademlia2Response(const uint8_t *packetData,
 {
 	CHECK_TRACKED_PACKET(KADEMLIA2_REQ);
 
-	// Used Pointers
 	CRoutingZone *routingZone = CKademlia::GetRoutingZone();
 
-	// What search does this relate to
 	CMemFile bio(packetData, lenPacket);
 	CUInt128 target = bio.ReadUInt128();
 	uint8_t numContacts = bio.ReadUInt8();
@@ -835,7 +821,6 @@ void CKademliaUDPListener::ProcessKademlia2Response(const uint8_t *packetData,
 		}
 		return; // we do not actually care for its other content
 	}
-	// Verify packet is expected size
 	CHECK_PACKET_EXACT_SIZE(16 + 1 + (16 + 4 + 2 + 2 + 1) * numContacts);
 
 	// is this a search for firewallcheck ips?
@@ -860,14 +845,12 @@ void CKademliaUDPListener::ProcessKademlia2Response(const uint8_t *packetData,
 					!(contactPort == 53 &&
 						version <= 5) /*No DNS Port without encryption*/) {
 					if (isFirewallUDPCheckSearch) {
-						// UDP FirewallCheck searches are special. The point is we
-						// need an IP which we didn't sent a UDP message yet (or in
-						// the near future), so we do not try to add those contacts to
-						// our routingzone and we also don't deliver them back to the
-						// searchmanager (because he would UDP-ask them for further
-						// results), but only report them to FirewallChecker - this
-						// will of course cripple the search but that's not the point,
-						// since we only care for IPs and not the random set target
+						// UDP FirewallCheck searches are special: they need an IP
+						// we have not sent a UDP message to, so these contacts are
+						// neither added to the routing zone nor handed back to the
+						// search manager, which would UDP-ask them for further
+						// results. Reporting them only to FirewallChecker cripples
+						// the search, which does not matter: only the IPs do.
 						CUDPFirewallTester::AddPossibleTestContact(id,
 							contactIP,
 							contactPort,
@@ -947,14 +930,11 @@ SSearchTerm *CKademliaUDPListener::CreateSearchExpressionTree(CMemFile &bio, int
 	uint8_t op = bio.ReadUInt8();
 	if (op == 0x00) {
 		uint8_t boolop = bio.ReadUInt8();
-		// The recursive children below read from `bio` and can throw
-		// CEOFException on a truncated packet. Without a guard the
-		// parent node and the already-built left subtree (if any)
-		// leak during stack unwinding -- `~SSearchTerm` doesn't
-		// recurse into left/right, only the explicit `Free()` walk
-		// does, and `Free()` is only reached on the success/NULL-
-		// return paths. Wrap each boolean-node body so any throw
-		// frees the partial subtree before re-raising (#884).
+		// The recursive children below read from `bio` and can throw CEOFException on
+		// a truncated packet. Without a guard the parent node and the already-built
+		// left subtree leak during unwinding: ~SSearchTerm does not recurse into
+		// left/right, only the explicit Free() walk does, and that is only reached on
+		// the success and NULL-return paths (#884).
 		if (boolop == 0x00) { // AND
 			SSearchTerm *pSearchTerm = new SSearchTerm;
 			pSearchTerm->type = SSearchTerm::AND;
@@ -1038,12 +1018,10 @@ SSearchTerm *CKademliaUDPListener::CreateSearchExpressionTree(CMemFile &bio, int
 
 		return pSearchTerm;
 	} else if (op == 0x02) { // Meta tag
-		// read tag value
 		wxString strValue(bio.ReadString(true));
 		// Make lowercase, the search code expects lower case strings!
 		strValue.MakeLower();
 
-		// read tag name
 		wxString strTagName = bio.ReadString(false);
 
 		SSearchTerm *pSearchTerm = new SSearchTerm;
@@ -1064,10 +1042,8 @@ SSearchTerm *CKademliaUDPListener::CreateSearchExpressionTree(CMemFile &bio, int
 			{ SSearchTerm::OpNotEqual, "<>" }      // mmop=0x05
 		};
 
-		// read tag value
 		uint64_t ullValue = (op == 0x03) ? bio.ReadUInt32() : bio.ReadUInt64();
 
-		// read integer operator
 		uint8_t mmop = bio.ReadUInt8();
 		if (mmop >= itemsof(_aOps)) {
 			AddDebugLogLineN(logKadSearch,
@@ -1076,7 +1052,6 @@ SSearchTerm *CKademliaUDPListener::CreateSearchExpressionTree(CMemFile &bio, int
 			return NULL;
 		}
 
-		// read tag name
 		wxString strTagName = bio.ReadString(false);
 
 		SSearchTerm *pSearchTerm = new SSearchTerm;
@@ -1135,13 +1110,10 @@ void CKademliaUDPListener::Process2SearchSourceRequest(const uint8_t *packetData
 
 void CKademliaUDPListener::ProcessSearchResponse(CMemFile &bio, uint32_t fromIP, uint16_t fromPort)
 {
-	// What search does this relate to
 	CUInt128 target = bio.ReadUInt128();
 
-	// How many results..
 	uint16_t count = bio.ReadUInt16();
 	while (count > 0) {
-		// What is the answer
 		CUInt128 answer = bio.ReadUInt128();
 
 		// Get info about answer
@@ -1162,7 +1134,6 @@ void CKademliaUDPListener::ProcessSearchResponse(CMemFile &bio, uint32_t fromIP,
 void CKademliaUDPListener::ProcessSearchResponse(
 	const uint8_t *packetData, uint32_t lenPacket, uint32_t fromIP, uint16_t fromPort)
 {
-	// Verify packet is expected size
 	CHECK_PACKET_MIN_SIZE(37);
 
 	CMemFile bio(packetData, lenPacket);
@@ -1179,7 +1150,6 @@ void CKademliaUDPListener::Process2SearchResponse(const uint8_t *packetData,
 {
 	CMemFile bio(packetData, lenPacket);
 
-	// Who sent this packet.
 	bio.ReadUInt128();
 
 	ProcessSearchResponse(bio, ip, port);
@@ -1193,7 +1163,6 @@ void CKademliaUDPListener::Process2PublishKeyRequest(const uint8_t *packetData,
 	uint16_t port,
 	const CKadUDPKey &senderKey)
 {
-	// Used Pointers
 	CIndexed *indexed = CKademlia::GetIndexed();
 
 	// check if we are UDP firewalled
@@ -1252,18 +1221,14 @@ void CKademliaUDPListener::Process2PublishKeyRequest(const uint8_t *packetData,
 						delete tag; // tag is no longer stored, but membervar is used
 #ifdef ENABLE_KAD_PROTOCOL_10
 					} else if (!tag->GetName().Cmp(TAG_KADAICHHASHPUB)) {
-						// AICH root hash of the published file (Kad
-						// protocol version 0x09).  Kept as a member
-						// rather than a tag: MergeIPsAndFilenames()
-						// attaches it to this publisher and maintains
-						// the popularity counts of the stored entry.
+						// AICH root hash of the published file (Kad protocol version
+						// 0x09). Kept as a member rather than a tag:
+						// MergeIPsAndFilenames() attaches it to this publisher and
+						// maintains the popularity counts of the stored entry.
 						//
-						// Gated: upstream has no branch for this tag, so
-						// it falls through to AddTag() and is relayed
-						// verbatim in later search answers.  Consuming
-						// it here removes it from that answer, which is
-						// a different packet on the wire -- exactly what
-						// the switch being off has to rule out.
+						// Gated: upstream has no branch for this tag, so it falls
+						// through to AddTag() and is relayed verbatim in later search
+						// answers. Consuming it here removes it from that answer.
 						if (tag->IsBsob() &&
 							tag->GetBsobSize() == KAD_AICH_HASH_SIZE) {
 							if (entry->GetAICHHashCount() == 0) {
@@ -1299,7 +1264,6 @@ void CKademliaUDPListener::Process2PublishKeyRequest(const uint8_t *packetData,
 			}
 #endif
 		} catch (...) {
-			// DebugClientOutput("CKademliaUDPListener::Process2PublishKeyRequest",ip,port,packetData,lenPacket);
 			delete entry;
 			throw;
 		}
@@ -1332,7 +1296,6 @@ void CKademliaUDPListener::Process2PublishSourceRequest(const uint8_t *packetDat
 	uint16_t port,
 	const CKadUDPKey &senderKey)
 {
-	// Used Pointers
 	CIndexed *indexed = CKademlia::GetIndexed();
 
 	// check if we are UDP firewalled
@@ -1420,7 +1383,6 @@ void CKademliaUDPListener::Process2PublishSourceRequest(const uint8_t *packetDat
 		}
 #endif
 	} catch (...) {
-		// DebugClientOutput("CKademliaUDPListener::Process2PublishSourceRequest",ip,port,packetData,lenPacket);
 		delete entry;
 		throw;
 	}
@@ -1449,7 +1411,6 @@ void CKademliaUDPListener::Process2PublishSourceRequest(const uint8_t *packetDat
 // Used only by Kad1.0
 void CKademliaUDPListener::ProcessPublishResponse(const uint8_t *packetData, uint32_t lenPacket, uint32_t ip)
 {
-	// Verify packet is expected size
 	CHECK_PACKET_MIN_SIZE(16);
 	CHECK_TRACKED_PACKET(KADEMLIA_PUBLISH_REQ);
 
@@ -1514,11 +1475,9 @@ void CKademliaUDPListener::Process2SearchNotesRequest(const uint8_t *packetData,
 void CKademliaUDPListener::ProcessSearchNotesResponse(
 	const uint8_t *packetData, uint32_t lenPacket, uint32_t ip, uint16_t port)
 {
-	// Verify packet is expected size
 	CHECK_PACKET_MIN_SIZE(37);
 	CHECK_TRACKED_PACKET(KADEMLIA_SEARCH_NOTES_REQ);
 
-	// What search does this relate to
 	CMemFile bio(packetData, lenPacket);
 	ProcessSearchResponse(bio, ip, port);
 }
@@ -1578,7 +1537,6 @@ void CKademliaUDPListener::Process2PublishNotesRequest(const uint8_t *packetData
 			tags--;
 		}
 	} catch (...) {
-		// DebugClientOutput("CKademliaUDPListener::Process2PublishNotesRequest",ip,port,packetData,lenPacket);
 		delete entry;
 		entry = NULL;
 		throw;
@@ -1604,7 +1562,6 @@ void CKademliaUDPListener::ProcessFirewalledRequest(const uint8_t *packetData,
 	uint16_t port,
 	const CKadUDPKey &senderKey)
 {
-	// Verify packet is expected size
 	CHECK_PACKET_EXACT_SIZE(2);
 
 	CMemFile bio(packetData, lenPacket);
@@ -1616,7 +1573,6 @@ void CKademliaUDPListener::ProcessFirewalledRequest(const uint8_t *packetData,
 		return; // cancelled for some reason, don't send a response
 	}
 
-	// Send response
 	CMemFile packetdata(4);
 	packetdata.WriteUInt32(ip);
 	DebugSend(KadFirewalledRes, ip, port);
@@ -1631,7 +1587,6 @@ void CKademliaUDPListener::ProcessFirewalled2Request(const uint8_t *packetData,
 	uint16_t port,
 	const CKadUDPKey &senderKey)
 {
-	// Verify packet is expected size
 	CHECK_PACKET_MIN_SIZE(19);
 
 	CMemFile bio(packetData, lenPacket);
@@ -1645,7 +1600,6 @@ void CKademliaUDPListener::ProcessFirewalled2Request(const uint8_t *packetData,
 		return; // cancelled for some reason, don't send a response
 	}
 
-	// Send response
 	CMemFile packetdata(4);
 	packetdata.WriteUInt32(ip);
 	DebugSend(KadFirewalledRes, ip, port);

--- a/src/kademlia/net/SafeKad.h
+++ b/src/kademlia/net/SafeKad.h
@@ -71,10 +71,9 @@ struct SKadNodeAddress
 // A bounded map whose entries are evicted by last-reference age.
 //
 // The plain map alone would need an O(n) scan to find the least recently
-// referenced entry, which is exactly the wrong complexity for a table that only
-// evicts while under a flood. The parallel set, keyed on (last reference, key),
-// makes both the oldest-first walk in Cleanup() and the make-room eviction
-// O(log n).
+// referenced entry, which is the wrong complexity for a table that only evicts
+// while under a flood. The parallel set, keyed on (last reference, key), makes
+// both the oldest-first walk in Cleanup() and the make-room eviction O(log n).
 //
 // `Entry` must expose a `time_t m_lastReferenced`; every mutation goes through
 // Set() so the two containers cannot drift apart.
@@ -134,61 +133,51 @@ private:
 // Identity and address protections layered on top of the standard 0.49b Kad
 // defences, which stay exactly as they are.
 //
-// What this adds over CPacketTracking and the UDP key challenge:
+// What this adds: CPacketTracking rate-limits PACKETS per IP and opcode, and
+// says nothing about a node that behaves politely while presenting a new Kad ID
+// every few minutes -- which is how a routing table fills with sybils that each
+// look individually reasonable. The UDP key challenge proves an address controls
+// its own traffic, but does not remember that the same address failed us five
+// minutes ago. The tracked-node table, the one-hour minimum identity-change
+// interval and the problematic list cover those two gaps.
 //
-//  - CPacketTracking rate-limits *packets* per IP and opcode. It says nothing
-//    about a node that behaves politely while presenting a new Kad ID every
-//    few minutes, which is how a routing table gets flooded with sybils that
-//    each look individually reasonable. That is what the tracked-node table
-//    and the one-hour minimum identity-change interval cover.
-//  - The UDP key challenge proves an address controls its own traffic. It does
-//    not remember that the same address failed us five minutes ago, which is
-//    what the problematic list is for.
-//
-// The escalation ladder mirrors CPacketTracking's own drop-then-ban shape:
-// first identity rotation marks the address problematic (300 s), a rotation
-// while already problematic bans it (4 h). The ban is Kad-routing-local and
-// deliberately separate from CClientList's eD2k-wide ban, which has its own
-// lifetime and its own triggers.
+// The escalation ladder mirrors CPacketTracking's drop-then-ban shape: a first
+// identity rotation marks the address problematic (300 s), a rotation while
+// already problematic bans it (4 h). The ban is Kad-routing-local, separate from
+// CClientList's eD2k-wide ban.
 //
 // Every table is bounded and evicts by last-reference age, so sustained inbound
-// traffic costs a fixed amount of memory. All entry points take `now` so that
-// the whole ladder is testable without waiting on a real clock.
-// Seven places where this deliberately does not match eMuleAI, listed so the
-// next person holding the two side by side reads them as decisions rather than
-// as transcription slips. emule-qt agrees with eMuleAI on all seven.
+// traffic costs a fixed amount of memory. All entry points take `now`, so the
+// whole ladder is testable without waiting on a real clock.
 //
-//  - eMuleAI bans on the FIRST verified sub-hour identity change; the ladder
-//    above needs two inside 300 s. Bans are per address while tracking is per
-//    (address, port), so under CGNAT a carrier reusing one external port for
-//    different subscribers makes a single tracked entry legitimately see
-//    different Kad IDs, and eMuleAI's rule would take out every aMule user
-//    behind that address for four hours on the first sighting.
-//  - eMuleAI gates banning on a user preference, IsBanBadKadNodes(). The
-//    compile switch stands in for it while this is experimental; a runtime
-//    equivalent is a precondition for ever defaulting the switch ON.
+// Seven deliberate divergences from eMuleAI, listed so they read as decisions
+// rather than transcription slips (emule-qt agrees with eMuleAI on all seven):
+//
+//  - eMuleAI bans on the FIRST verified sub-hour identity change; this needs two
+//    inside 300 s. Bans are per address while tracking is per (address, port),
+//    so under CGNAT a carrier reusing one external port for different
+//    subscribers legitimately shows different Kad IDs, and eMuleAI's rule would
+//    take out every aMule user behind that address for four hours.
+//  - eMuleAI gates banning on a user preference. The compile switch stands in
+//    for it while this is experimental; a runtime equivalent is a precondition
+//    for ever defaulting the switch ON.
 //  - TrackNode() returns whether it accepted, and IsBadNode() refuses on a
-//    rejected rotation. eMuleAI's TrackNode() is void and IsBadNode() answers
-//    IsBanned() alone, so upstream ACCEPTS the first rejected rotation and only
-//    refuses once a ban lands. Refusing immediately is what makes a rotation
-//    cost the sender its rotation, which is the half that has to hold given the
-//    slower ladder above.
+//    rejected rotation. Upstream's TrackNode() is void and IsBadNode() answers
+//    IsBanned() alone, so it ACCEPTS the first rejected rotation. Refusing at
+//    once is what makes a rotation cost the sender its rotation.
 //  - A full table evicts its oldest entry; eMuleAI returns without acting once
 //    the tracked table reaches 10000 or the ban table 1000, so a flood that
-//    fills the table lets every later abuser through, which inverts the
-//    protection exactly when it is needed.
-//  - BanAddress() drops the banned address's tracked ports. eMuleAI leaves them
-//    behind, where they are unreachable state for an address nothing may talk
-//    to.
+//    fills the table lets every later abuser through.
+//  - BanAddress() drops the banned address's tracked ports, which eMuleAI leaves
+//    behind as unreachable state.
 //  - The verified flag is also upgraded on a matching-ID sighting in
-//    IsBadNode(); eMuleAI upgrades it only inside TrackNode(). It moves in one
-//    direction only, and the one caller that hardcodes verified=false is
-//    AddUnfiltered(), so a peer cannot drive the upgrade for somebody else.
+//    IsBadNode(), not only inside TrackNode(). It moves one way only, and the
+//    one caller hardcoding verified=false is AddUnfiltered(), so a peer cannot
+//    drive the upgrade for somebody else.
 //  - The last-reference time is not refreshed on the refused path. eMuleAI
-//    refreshes on every lookup, which lets an attacker's own traffic decide
-//    which entries survive age-based eviction; here such an entry ages out
-//    instead. The trade is real in both directions: forgetting a rotator also
-//    gives it a clean slate.
+//    refreshes on every lookup, letting an attacker's own traffic decide which
+//    entries survive eviction; here such an entry ages out instead, which also
+//    means forgetting a rotator gives it a clean slate.
 class CSafeKad
 {
 public:
@@ -206,14 +195,11 @@ public:
 	// A problematic address is ignored for 300 s.
 	static const time_t MAX_PROBLEMATIC_TIME = 300;
 
-	// Lowest advertised Kad version whose three-way handshake can prove
-	// which UDP port a node listens on (eMule 0.49b). Below it an
-	// unverified identity change cannot be told from a spoof, so it is
-	// refused outright instead of merely rate-limited.
-	//
-	// Written out here rather than taken from the protocol version table:
-	// this class adds nothing to the wire, so it has no business depending
-	// on the header that defines what we advertise.
+	// Lowest advertised Kad version whose three-way handshake can prove which UDP
+	// port a node listens on (eMule 0.49b). Below it an unverified identity change
+	// cannot be told from a spoof, so it is refused outright rather than merely
+	// rate-limited. Written out here rather than taken from the protocol version
+	// table: this class adds nothing to the wire.
 	static const uint8_t MIN_PORT_VERIFIABLE_VERSION = 0x08;
 
 	// Eviction horizons for Cleanup(): an entry nothing has referenced for

--- a/src/kademlia/routing/RoutingBin.cpp
+++ b/src/kademlia/routing/RoutingBin.cpp
@@ -68,7 +68,6 @@ bool CRoutingBin::AddContact(CContact *contact)
 	wxASSERT(contact != NULL);
 
 	uint32_t sameSubnets = 0;
-	// Check if we already have a contact with this ID in the list.
 	for (ContactList::const_iterator it = m_entries.begin(); it != m_entries.end(); ++it) {
 		if (contact->GetClientID() == (*it)->GetClientID()) {
 			return false;
@@ -77,10 +76,10 @@ bool CRoutingBin::AddContact(CContact *contact)
 			sameSubnets++;
 		}
 	}
-	// Several checks to make sure that we don't store multiple contacts from the same IP or too many
-	// contacts from the same subnet This is supposed to add a bit of protection against several attacks
-	// and raise the resource needs (IPs) for a successful contact on the attacker side Such IPs are not
-	// banned from Kad, they still can index, search, etc so multiple KAD clients behind one IP still work
+	// Several checks so we do not store multiple contacts from the same IP, or too
+	// many from the same subnet. This raises the resource needs (IPs) for a
+	// successful attack; such IPs are not banned from Kad, so multiple clients
+	// behind one IP still index, search and so on.
 
 	if (!CheckGlobalIPLimits(contact->GetIPAddress(), contact->GetUDPPort())) {
 		return false;
@@ -96,7 +95,6 @@ bool CRoutingBin::AddContact(CContact *contact)
 		return false;
 	}
 
-	// If not full, add to the end of list
 	if (m_entries.size() < K) {
 		m_entries.push_back(contact);
 		AdjustGlobalTracking(contact->GetIPAddress(), true);
@@ -108,27 +106,21 @@ bool CRoutingBin::AddContact(CContact *contact)
 void CRoutingBin::SetAlive(CContact *contact)
 {
 	wxASSERT(contact != NULL);
-	// Check if we already have a contact with this ID in the list.
 	CContact *test = GetContact(contact->GetClientID());
 	wxASSERT(contact == test);
 	if (test) {
-		// Mark contact as being alive.
 		test->UpdateType();
-		// Move to the end of the list
 		PushToBottom(test);
 	}
 }
 
 void CRoutingBin::SetTCPPort(uint32_t ip, uint16_t port, uint16_t tcpPort)
 {
-	// Find contact with IP/Port
 	for (ContactList::iterator it = m_entries.begin(); it != m_entries.end(); ++it) {
 		CContact *c = *it;
 		if ((ip == c->GetIPAddress()) && (port == c->GetUDPPort())) {
-			// Set TCPPort and mark as alive.
 			c->SetTCPPort(tcpPort);
 			c->UpdateType();
-			// Move to the end of the list
 			PushToBottom(c);
 			break;
 		}
@@ -173,12 +165,10 @@ void CRoutingBin::GetNumContacts(
 
 void CRoutingBin::GetEntries(ContactList *result, bool emptyFirst) const
 {
-	// Clear results if requested first.
 	if (emptyFirst) {
 		result->clear();
 	}
 
-	// Append all entries to the results.
 	if (!m_entries.empty()) {
 		result->insert(result->end(), m_entries.begin(), m_entries.end());
 	}
@@ -191,12 +181,10 @@ void CRoutingBin::GetClosestTo(uint32_t maxType,
 	bool emptyFirst,
 	bool inUse) const
 {
-	// Empty list if requested.
 	if (emptyFirst) {
 		result->clear();
 	}
 
-	// No entries, no closest.
 	if (m_entries.empty()) {
 		return;
 	}

--- a/src/kademlia/routing/RoutingZone.cpp
+++ b/src/kademlia/routing/RoutingZone.cpp
@@ -87,30 +87,23 @@ CRoutingZone::CRoutingZone()
 	// Can only create routing zone after prefs
 	// Set our KadID for creating the contact tree
 	me = CKademlia::GetPrefs()->GetKadID();
-	// Set the preference file name.
 	m_filename = thePrefs::GetConfigDir() + "nodes.dat";
 	Init(NULL, 0, CUInt128((uint32_t)0));
 }
 
 void CRoutingZone::Init(CRoutingZone *super_zone, int level, const CUInt128 &zone_index)
 {
-	// Init all Zone vars
 	// Set this zone's parent
 	m_superZone = super_zone;
-	// Set this zone's level
 	m_level = level;
-	// Set this zone's CUInt128 index
 	m_zoneIndex = zone_index;
-	// Mark this zone as having no leafs.
 	m_subZones[0] = NULL;
 	m_subZones[1] = NULL;
-	// Create a new contact bin as this is a leaf.
 	m_bin = new CRoutingBin();
 
 	// Set timer so that zones closer to the root are processed earlier.
 	m_nextSmallTimer = time(NULL) + m_zoneIndex.Get32BitChunk(3);
 
-	// Start this zone.
 	StartTimer();
 
 	// If we are initializing the root node, read in our saved contact list.
@@ -126,11 +119,9 @@ CRoutingZone::~CRoutingZone()
 		WriteFile();
 	}
 
-	// If this zone is a leaf, delete our contact bin.
 	if (IsLeaf()) {
 		delete m_bin;
 	} else {
-		// If this zone is a branch, delete its leafs.
 		delete m_subZones[0];
 		delete m_subZones[1];
 	}
@@ -144,7 +135,6 @@ void CRoutingZone::ReadFile(const wxString &specialNodesdat)
 	}
 
 	bool doHaveVerifiedContacts = false;
-	// Read in the saved contact list
 	try {
 		uint32_t validContacts = 0;
 		CFile file;
@@ -253,14 +243,13 @@ void CRoutingZone::ReadFile(const wxString &specialNodesdat)
 
 void CRoutingZone::ReadBootstrapNodesDat(CFileDataIO &file)
 {
-	// Bootstrap versions of nodes.dat files are in the style of version 1 nodes.dats. The difference is
-	// that they will contain more contacts, 500-1000 instead of 50, and those contacts are not added into
-	// the routing table but used to sent Bootstrap packets to. The advantage is that on a list with a
-	// high ratio of dead nodes, we will be able to bootstrap faster than on a normal nodes.dat and more
-	// important, if we would deliver a normal nodes.dat with eMule, those 50 nodes would be kinda DDOSed
-	// because everyone adds them to their routing table, while with this style, we don't actually add any
-	// of the contacts to our routing table in the end and we ask only one of those 1000 contacts one time
-	// (well or more until we find an alive one).
+	// Bootstrap versions of nodes.dat are in the style of version 1 nodes.dats, but
+	// contain 500-1000 contacts instead of 50, and those contacts are not added to
+	// the routing table -- they are only sent Bootstrap packets. On a list with a
+	// high ratio of dead nodes that bootstraps faster, and it avoids the DDOS that
+	// shipping a normal nodes.dat would cause, where everyone adds the same 50 nodes
+	// to their routing table. Here we ask one of the 1000 contacts, until one is
+	// alive.
 	if (!CKademlia::s_bootstrapList.empty()) {
 		wxFAIL;
 		return;
@@ -280,10 +269,9 @@ void CRoutingZone::ReadBootstrapNodesDat(CFileDataIO &file)
 					!(udpPort == 53 && contactVersion <= 5) &&
 					(contactVersion > 1)) // only kad2 nodes
 				{
-					// we want the 50 nodes closest to our own ID (provides randomness
-					// between different users and gets has good chances to get a
-					// bootstrap with close Nodes which is a nice start for our routing
-					// table)
+					// The 50 nodes closest to our own ID: that provides randomness
+					// between different users and gives a good chance of bootstrapping
+					// with close nodes, which is a nice start for our routing table.
 					CUInt128 distance = me;
 					distance ^= id;
 					validContacts++;
@@ -363,9 +351,7 @@ void CRoutingZone::WriteFile()
 		unsigned int count = 0;
 		CFile file;
 		if (file.Open(m_filename, CFile::write_safe)) {
-			// Start file with 0 to prevent older clients from reading it.
 			file.WriteUInt32(0);
-			// Now tag it with a version which happens to be 2.
 			file.WriteUInt32(2);
 			// file.WriteUInt32(0); // if we would use version >= 3 this would mean that this is a
 			// normal nodes.dat
@@ -400,11 +386,9 @@ void CRoutingZone::WriteBootstrapFile()
 {
 	AddDebugLogLineC(logKadRouting, "Writing special bootstrap nodes.dat - not intended for normal use");
 	try {
-		// Write a saved contact list.
 		CUInt128 id;
 		CFile file;
 		if (file.Open(m_filename, CFile::write)) {
-			// The bootstrap method gets a very nice sample of contacts to save.
 			ContactMap mapContacts;
 			CUInt128 random(CUInt128((uint32_t)0), 0);
 			CUInt128 distance = random;
@@ -418,9 +402,7 @@ void CRoutingZone::WriteBootstrapFile()
 					mapContacts.erase(itCur);
 				}
 			}
-			// Start file with 0 to prevent older clients from reading it.
 			file.WriteUInt32(0);
-			// Now tag it with a version which happens to be 3.
 			file.WriteUInt32(3);
 			file.WriteUInt32(1); // using version >= 3, this means that this is not a normal nodes.dat
 			file.WriteUInt32((uint32_t)mapContacts.size());
@@ -446,12 +428,10 @@ void CRoutingZone::WriteBootstrapFile()
 
 bool CRoutingZone::CanSplit() const noexcept
 {
-	// Max levels allowed.
 	if (m_level >= 127) {
 		return false;
 	}
 
-	// Check if this zone is allowed to split.
 	return ((m_zoneIndex < KK || m_level < KBASE) && m_bin->GetSize() == K);
 }
 
@@ -489,26 +469,21 @@ bool CRoutingZone::AddUnfiltered(const CUInt128 &id,
 {
 	if (id != me) {
 #ifdef ENABLE_KAD_NODE_PROTECTION
-		// Kad identity protections. This is the routing table's front door,
-		// so it is where an address that rotates Kad IDs faster than once
-		// an hour, or one banned for having done so, has to be turned away.
+		// Kad identity protections. This is the routing table's front door, so it is
+		// where an address that rotates Kad IDs faster than once an hour, or one
+		// banned for having done so, has to be turned away.
 		//
-		// No upstream counterpart: eMuleAI and emule-qt each call IsBadNode()
-		// in exactly one place, the search answer, and neither gates routing
-		// table admission with it. This is ours, and it is the reason the
-		// switch must not default to ON without evidence: the table deciding
-		// who may enter is what Kad health rests on, and a heuristic that is
-		// even slightly too eager fails quietly, as a node that gradually
-		// stops finding peers with nothing in the log to say why. Measure
-		// routing table size and contact churn against a control node before
-		// changing the default.
+		// No upstream counterpart: eMuleAI and emule-qt each call IsBadNode() in
+		// exactly one place, the search answer, and neither gates routing table
+		// admission with it. That is why the switch must not default to ON without
+		// evidence: the table deciding who may enter is what Kad health rests on, and
+		// a heuristic even slightly too eager fails quietly, as a node that gradually
+		// stops finding peers. Measure routing table size and contact churn against a
+		// control node before changing the default.
 		//
-		// onlyOneNodePerIP is deliberately off: CRoutingBin already caps
-		// the routing table at MAX_CONTACTS_IP (1) Kad ID per address plus
-		// MAX_CONTACTS_SUBNET (10) per /24, and duplicating that here would
-		// add a second, weaker copy of a rule the bin already enforces
-		// better. CSafeKad's own per-IP rule exists for callers outside the
-		// routing table.
+		// onlyOneNodePerIP is deliberately off: CRoutingBin already caps the table at
+		// MAX_CONTACTS_IP Kad ID per address plus MAX_CONTACTS_SUBNET per /24, and
+		// duplicating that here would be a second, weaker copy of the same rule.
 		if (safeKad.IsBadNode(ip, port, id, version, ipVerified, false, time(nullptr))) {
 			AddDebugLogLineN(logKadRouting,
 				"Ignored kad contact (IP=" + KadIPPortToString(ip, port) +
@@ -534,12 +509,10 @@ bool CRoutingZone::AddUnfiltered(const CUInt128 &id,
 
 bool CRoutingZone::Add(CContact *contact, bool &update, bool &outIpVerified)
 {
-	// If we're not a leaf, call add on the correct branch.
 	if (!IsLeaf()) {
 		return m_subZones[contact->GetDistance().GetBitNumber(m_level)]->Add(
 			contact, update, outIpVerified);
 	} else {
-		// Do we already have a contact with this KadID?
 		CContact *contactUpdate = m_bin->GetContact(contact->GetClientID());
 		if (contactUpdate) {
 			if (update) {
@@ -547,11 +520,10 @@ bool CRoutingZone::Add(CContact *contact, bool &update, bool &outIpVerified)
 					contactUpdate->GetUDPKey().GetKeyValue(theApp->GetPublicIP(false)) !=
 						contact->GetUDPKey().GetKeyValue(
 							theApp->GetPublicIP(false))) {
-					// if our existing contact has a UDPSender-Key (which should be the
-					// case for all > = 0.49a clients) except if our IP has changed
-					// recently, we demand that the key is the same as the key we received
-					// from the packet which wants to update this contact in order to make
-					// sure this is not a try to hijack this entry
+					// If the existing contact has a UDPSender-Key -- which every >= 0.49a
+					// client should, unless our IP changed recently -- demand that it
+					// matches the key from the packet wanting to update it, so this is
+					// not a try at hijacking the entry.
 					AddDebugLogLineN(logKadRouting,
 						"Sender (" + KadIPToString(contact->GetIPAddress()) +
 							") tried to update contact entry but failed to "
@@ -567,11 +539,11 @@ bool CRoutingZone::Add(CContact *contact, bool &update, bool &outIpVerified)
 				} else if (contactUpdate->GetVersion() >= 1 &&
 					   contactUpdate->GetVersion() < 6 &&
 					   contactUpdate->GetReceivedHelloPacket()) {
-					// legacy kad2 contacts are allowed only to update their RefreshTimer
-					// to avoid having them hijacked/corrupted by an attacker (kad1
-					// contacts do not have this restriction as they might turn out as
-					// kad2 later on) only exception is if we didn't received a HELLO
-					// packet from this client yet
+					// Legacy kad2 contacts may only update their RefreshTimer, so an
+					// attacker cannot hijack or corrupt them. kad1 contacts have no such
+					// restriction, as they might turn out to be kad2 later on; the only
+					// other exception is not having received a HELLO from this client
+					// yet.
 					if (contactUpdate->GetIPAddress() == contact->GetIPAddress() &&
 						contactUpdate->GetTCPPort() == contact->GetTCPPort() &&
 						contactUpdate->GetVersion() == contact->GetVersion() &&
@@ -599,8 +571,7 @@ bool CRoutingZone::Add(CContact *contact, bool &update, bool &outIpVerified)
 					}
 				} else {
 #ifdef __DEBUG__
-					// just for outlining, get removed anyway
-					// debug logging stuff - remove later
+					// just for outlining, gets removed anyway
 					if (contact->GetUDPKey().GetKeyValue(theApp->GetPublicIP(false)) ==
 						0) {
 						if (contact->GetVersion() >= 6 && contact->GetType() < 2) {
@@ -657,10 +628,8 @@ bool CRoutingZone::Add(CContact *contact, bool &update, bool &outIpVerified)
 			return false;
 		} else if (m_bin->GetRemaining()) {
 			update = false;
-			// This bin is not full, so add the new contact
 			return m_bin->AddContact(contact);
 		} else if (CanSplit()) {
-			// This bin was full and split, call add on the correct branch.
 			Split();
 			return m_subZones[contact->GetDistance().GetBitNumber(m_level)]->Add(
 				contact, update, outIpVerified);
@@ -712,7 +681,6 @@ void CRoutingZone::GetClosestTo(uint32_t maxType,
 	bool emptyFirst,
 	bool inUse) const
 {
-	// If leaf zone, do it here
 	if (IsLeaf()) {
 		m_bin->GetClosestTo(maxType, target, maxRequired, result, emptyFirst, inUse);
 		return;
@@ -886,7 +854,6 @@ uint32_t CRoutingZone::EstimateCount() const
 
 	CRoutingZone *curZone = m_superZone->m_superZone->m_superZone;
 
-	// Find out how full this part of the tree is.
 	float modify = ((float)curZone->GetNumContacts()) / (float)(K * 2);
 
 	// First calculate users assuming the tree is full.


### PR DESCRIPTION
Comment-only sweep of `src/kademlia`: 14 files, 1876 -> 1580 comment lines (-296, -15.8%). Figures are over the touched files only; licence headers are untouched and form a floor in every count.

Part of a tree-wide pass split by scope. The scopes touch disjoint files, so this one merges independently of the others.

**What came out**

- eMule-era line-by-line narration ("Get next result", "Add to possible", "Send packet") directly above the code it restates.
- Author and PR-review annotations.
- Long restatements. The protocol notes, the trust-value rationale and the recorded divergences from eMuleAI are kept.

**What stayed**

Anything recording something the code cannot tell you by itself: a protocol constraint, a wire-format rule, a platform quirk, the reason a guard exists, the why behind a non-obvious default.

**Verification**

- Every file mechanically checked comment-only: comments stripped and whitespace normalised on both sides, then diffed against master. 14/14 identical, so no code changes.
- clang-format 18, the version CI pins, clean over all of `src/` and `unittests/`.
- Builds clean on macOS. Nothing here changes code, so the build cannot differ per scope.

**Reviewing**

`git diff master -w` is the whole change; there is no code to read.
