### PR TITLE
chore(libs/ec): trim verbose comment blocks

### DIFF
--- a/src/libs/ec/cpp/ECCrypt.h
+++ b/src/libs/ec/cpp/ECCrypt.h
@@ -261,17 +261,14 @@ public:
 
 	// --- streaming, in place -------------------------------------------
 	//
-	// The EC write path builds a packet as a list of CQueuedData chunks and
-	// only then back-patches the length, so the whole packet is already in
-	// memory before anything reaches the socket. These let the chunks be
-	// sealed where they lie and the tag appended, instead of flattening the
-	// body into a second buffer -- which would double peak memory on exactly
-	// the huge responses the 256 MB receive gate exists for.
-	//
-	// Total length need not be known in advance, which matters because with
-	// ZLIB the compressed size is only known once deflate has finished.
-	//
-	// Begin/Final bracket one packet and advance that direction's counter.
+	// The EC write path builds a packet as a list of CQueuedData chunks and only
+	// then back-patches the length, so the whole packet is already in memory before
+	// anything reaches the socket. These let the chunks be sealed where they lie
+	// and the tag appended, instead of flattening the body into a second buffer,
+	// which would double peak memory on exactly the huge responses the 256 MB
+	// receive gate exists for. The total length need not be known in advance, which
+	// matters because with ZLIB the compressed size is only known once deflate has
+	// finished. Begin/Final bracket one packet and advance that direction's counter.
 
 	bool SealBegin();
 	bool SealUpdate(uint8_t *data, size_t len);

--- a/src/libs/ec/cpp/ECSocket.cpp
+++ b/src/libs/ec/cpp/ECSocket.cpp
@@ -294,25 +294,21 @@ CECSocket::~CECSocket()
 }
 
 // Deliberately not part of ResetProtocolState. m_my_flags mixes two kinds of
-// state: capabilities this end simply has, and capabilities agreed with the
-// peer. Only a caller that knows it is facing a *different* peer may drop the
-// second kind, and only that caller knows it -- CECMemSocket, for one, sets
-// EC_FLAG_LARGE_TAG_COUNT in its constructor as a local property of the wire
-// format it caches, and clearing it there would corrupt the cache.
-//
-// Today the sole caller is amulegui's reconnect path, which reuses one
-// CRemoteConnect across sessions.
+// state: capabilities this end simply has, and capabilities agreed with the peer.
+// Only a caller that knows it is facing a DIFFERENT peer may drop the second
+// kind -- CECMemSocket, for one, sets EC_FLAG_LARGE_TAG_COUNT in its constructor
+// as a local property of the wire format it caches, and clearing it there would
+// corrupt the cache. Today the sole caller is amulegui's reconnect path.
 void CECSocket::ClearPeerNegotiatedFlags()
 {
-	// EC_FLAG_LARGE_TAG_COUNT is the only bit here whose value comes from the
-	// peer: it is set when the daemon echoes EC_TAG_CAN_LARGE_TAG_COUNT in
-	// AUTH_OK. Left set across a reconnect, a client that negotiated it with
-	// one daemon keeps sending the extended tag-count format to one that never
-	// advertised it, and that does not fail cleanly -- the receiver reads a
-	// differently-sized count field and misparses everything after it.
+	// EC_FLAG_LARGE_TAG_COUNT is the only bit here whose value comes from the peer:
+	// it is set when the daemon echoes EC_TAG_CAN_LARGE_TAG_COUNT in AUTH_OK. Left
+	// set across a reconnect, a client that negotiated it with one daemon keeps
+	// sending the extended tag-count format to one that never advertised it, and
+	// the receiver then misparses everything after the count field.
 	//
 	// EC_FLAG_ZLIB and EC_FLAG_UTF8_NUMBERS are chosen locally, through
-	// SetCapabilities, which the reconnect path does not call again. They stay.
+	// SetCapabilities, which the reconnect path does not call again.
 	m_my_flags &= ~(uint32_t)EC_FLAG_LARGE_TAG_COUNT;
 }
 
@@ -547,14 +543,10 @@ void CECSocket::OnOutput()
 				OnError();
 				return;
 			}
-			// Now it's just a blocked socket.
 			if (m_use_events) {
-				// Event driven logic: return, OnOutput() will be called again later
 				return;
 			}
-			// Synchronous call: wait (for max 10 secs)
 			if (!WaitSocketWrite(10, 0)) {
-				// Still not through ?
 				if (WouldBlock()) {
 					// WouldBlock() is only EAGAIN or EWOULD_BLOCK,
 					// and those shouldn't create an infinite wait.
@@ -567,20 +559,14 @@ void CECSocket::OnOutput()
 				}
 			}
 		} else if (written == 0) {
-			// CAsioSocketImpl::Write returns 0 with no SocketError
-			// set when a previous async send is still in flight
-			// (m_sendBuffer != null) -- pure backpressure, not a
-			// real error.  Treat as "would block": yield to the
-			// event loop so the asio HandleSend callback can clear
-			// m_sendBuffer and re-fire OnOutput via
-			// CoreNotify_LibSocketSend.  Without this, the loop
-			// re-reads the same queue head and re-calls Write(),
-			// pegging the main thread at 100% CPU until asio
-			// catches up.  Large EC replies (e.g. status response
-			// after a batch ed2k-link add) hit this hard because
-			// they're chopped into many asio-sized chunks and the
-			// main thread can't service other wx events during
-			// the spin.
+			// CAsioSocketImpl::Write returns 0 with no SocketError set when a
+			// previous async send is still in flight -- pure backpressure, not an
+			// error. Treat it as "would block": yield to the event loop so the asio
+			// HandleSend callback can clear m_sendBuffer and re-fire OnOutput.
+			// Without this the loop re-reads the same queue head and re-calls
+			// Write(), pegging the main thread at 100% CPU until asio catches up.
+			// Large EC replies hit this hard, being chopped into many asio-sized
+			// chunks while the main thread cannot service other wx events.
 			if (m_use_events) {
 				return;
 			}
@@ -703,12 +689,10 @@ bool CECSocket::ReadHeader()
 	m_curr_rx_data->Read(&m_curr_packet_len, 4);
 	m_curr_packet_len = ENDIAN_NTOHL(m_curr_packet_len);
 	m_bytes_needed = m_curr_packet_len;
-	// Sanity bound on the announced packet size. Pre-auth stays at the
-	// historical 16 MB cap — limits the damage a malicious peer can do
-	// with a single bogus header before we know who they are. Post-auth
-	// raises to 256 MB so big uncompressed responses (e.g. show shared
-	// on a 90 k-file library against a local-peer client that skipped
-	// ZLIB negotiation, see #713 / #728) don't trip the gate.
+	// Sanity bound on the announced packet size. Pre-auth stays at the historical
+	// 16 MB cap, limiting the damage a malicious peer can do with one bogus header
+	// before we know who they are. Post-auth raises to 256 MB so big uncompressed
+	// responses do not trip the gate (#713 / #728).
 	const size_t max_packet_bytes = IsAuthorized() ? (size_t)256 * 1024 * 1024 : (size_t)16 * 1024 * 1024;
 	if (m_bytes_needed > max_packet_bytes) {
 		AddDebugLogLineN(logEC, CFormat("ReadHeader: packet too big: %d") % m_bytes_needed);
@@ -845,7 +829,6 @@ bool CECSocket::ReadBuffer(void *buffer, size_t len)
 		}
 		return true;
 	} else {
-		// using uncompressed buffered i/o
 		size_t read = ReadBufferFromSocket(buffer, len);
 		if (read == len) {
 			return true;
@@ -872,7 +855,6 @@ bool CECSocket::WriteBuffer(const void *buffer, size_t len)
 				m_z.avail_in += remain_in;
 				len -= remain_in;
 				rd_ptr += remain_in;
-				// buffer is full, calling zlib
 				do {
 					m_z.next_out = &m_out_ptr[0];
 					m_z.avail_out = EC_SOCKET_BUFFER_SIZE;
@@ -885,14 +867,12 @@ bool CECSocket::WriteBuffer(const void *buffer, size_t len)
 					WriteBufferToSocket(
 						&m_out_ptr[0], EC_SOCKET_BUFFER_SIZE - m_z.avail_out);
 				} while (m_z.avail_out == 0);
-				// all input should be used by now
 				wxASSERT(m_z.avail_in == 0);
 				m_z.next_in = &m_in_ptr[0];
 			}
 		} while (len);
 		return true;
 	} else {
-		// using uncompressed buffered i/o
 		WriteBufferToSocket(buffer, len);
 		return true;
 	}
@@ -900,14 +880,11 @@ bool CECSocket::WriteBuffer(const void *buffer, size_t len)
 
 // Block size for a packet whose serialised body is this long: the whole thing
 // when it fits, EC_SOCKET_TX_CHUNK_MAX when it does not. Capped on purpose -- a
-// packet may legitimately be hundreds of MB (an uncompressed `show shared` on a
-// large library, see ReadHeader's post-auth gate) and one contiguous block that
-// big would be copied again by the send path. Floored at EC_SOCKET_BUFFER_SIZE
-// so no packet gets smaller blocks than it used to, which also keeps room in
-// the first block for the 8-byte header SealOutputQueue leaves in clear.
-// Guessing low is harmless: WriteBufferToSocket spills into a fresh block of
-// the same size, the pre-existing path -- so ZLIB shrinking the body below
-// bodyLen just leaves the last block short.
+// packet may legitimately be hundreds of MB, and one contiguous block that big
+// would be copied again by the send path. Floored at EC_SOCKET_BUFFER_SIZE so no
+// packet gets smaller blocks than it used to, which also keeps room in the first
+// block for the 8-byte header SealOutputQueue leaves in clear. Guessing low is
+// harmless: WriteBufferToSocket spills into a fresh block of the same size.
 size_t CECSocket::TxChunkSize(uint32 bodyLen)
 {
 	const size_t want = (size_t)bodyLen + EC_HEADER_SIZE;
@@ -917,11 +894,10 @@ size_t CECSocket::TxChunkSize(uint32 bodyLen)
 }
 
 // Adopt that size for the packet about to be written. Both call sites are
-// reached with an empty block -- the previous packet ended in FlushBuffers,
-// which pushed its remainder, and every early return is ahead of the first
-// write -- so swapping it drops nothing. Asserted rather than left implicit
-// because a future `return` slipped between the writes and FlushBuffers would
-// silently discard a partial packet here.
+// reached with an empty block -- the previous packet ended in FlushBuffers, and
+// every early return is ahead of the first write -- so swapping drops nothing.
+// Asserted rather than left implicit, because a future `return` slipped between
+// the writes and FlushBuffers would silently discard a partial packet.
 void CECSocket::SizeTxChunks(uint32 bodyLen)
 {
 	wxASSERT(m_curr_tx_data->GetDataLength() == 0);

--- a/src/libs/ec/cpp/ECSocket.h
+++ b/src/libs/ec/cpp/ECSocket.h
@@ -70,12 +70,10 @@ class CECSocket
 {
 	friend class CECPacket;
 	friend class CECTag;
-	// CECMemSocket is a CECSocket subclass that captures all I/O into
-	// an in-memory vector. To finish a serialization round it needs to
-	// reach the FlushBuffers / m_output_queue drain machinery that the
-	// real-socket path normally accesses via the friend declarations
-	// above. Granting it friendship avoids weakening the visibility of
-	// those primitives for everyone else.
+	// CECMemSocket is a CECSocket subclass that captures all I/O into an in-memory
+	// vector. To finish a serialization round it needs the FlushBuffers /
+	// m_output_queue drain machinery the real-socket path reaches via the friend
+	// declarations above; friendship here avoids weakening those for everyone else.
 	friend class CECMemSocket;
 
 private:
@@ -109,14 +107,13 @@ private:
 
 	// --- transport encryption -------------------------------------------
 	//
-	// Keys are derived once the handshake has both nonces and the chosen
-	// cipher. `m_crypt_ready` says the keys exist; `m_crypt_enabled` says to
-	// actually seal outgoing packets. They are separate because the packet
-	// that completes the handshake must still go out in clear: the client
-	// sends EC_OP_AUTH_PASSWD unencrypted and only then switches on, which
-	// `m_crypt_enable_after_write` expresses. Incoming packets are decided
-	// per packet by EC_FLAG_ENCRYPTED, not by these, so a plaintext
-	// EC_OP_AUTH_FAIL still parses after we have armed.
+	// Keys are derived once the handshake has both nonces and the chosen cipher.
+	// m_crypt_ready says the keys exist; m_crypt_enabled says to actually seal
+	// outgoing packets. They are separate because the packet that completes the
+	// handshake must still go out in clear -- the client sends EC_OP_AUTH_PASSWD
+	// unencrypted and only then switches on, which m_crypt_enable_after_write
+	// expresses. Incoming packets are decided per packet by EC_FLAG_ENCRYPTED, so a
+	// plaintext EC_OP_AUTH_FAIL still parses after we have armed.
 	ECCrypt::Session m_crypt;
 	bool m_crypt_ready;
 	bool m_crypt_enabled;

--- a/src/libs/ec/cpp/ECSpecialTags.h
+++ b/src/libs/ec/cpp/ECSpecialTags.h
@@ -139,13 +139,11 @@ public:
 		CreateTagT<CUInt128>(tagname, value, m_map_uint128, parent);
 	}
 
-	// String literals must not reach the bool overload. `const char*` -> bool is
-	// a standard conversion and beats the user-defined one to wxString, so
-	// without these a literal would emit a BOOL tag through the value map and a
-	// STRING tag through the plain CECTag path (which has both pointer
-	// constructors) -- the same call site producing a different wire type on an
-	// incremental update than on a full request. No current caller passes one;
-	// these exist so that none ever can.
+	// String literals must not reach the bool overload. `const char*` -> bool is a
+	// standard conversion and beats the user-defined one to wxString, so without
+	// these a literal would emit a BOOL tag through the value map and a STRING tag
+	// through the plain CECTag path -- the same call site producing a different
+	// wire type on an incremental update than on a full request.
 	void CreateTag(ec_tagname_t tagname, const char *value, CECTag *parent)
 	{
 		CreateTag(tagname, wxString(value), parent);
@@ -196,32 +194,22 @@ public:
 	// True when a value for this tag has already been transmitted on this
 	// connection. Used to decide whether a field that is now ABSENT needs an
 	// explicit "it is gone" frame: a tag that is simply not offered reads as
-	// UNCHANGED on the remote side, because AddTag above transmits only on a
-	// difference and every receiver is add-only. Without this, clearing a
-	// field leaves the peer serving the stale value for the life of the
-	// connection.
+	// UNCHANGED on the remote side, since AddTag transmits only on a difference and
+	// every receiver is add-only.
 	bool HasTag(ec_tagname_t tagname) const { return m_map_tag.count(tagname) != 0; }
 };
 
 // Add `value` under `tagname` to `parent`, letting the value map decide whether
 // it changed -- and constructing the CECTag only if it did.
 //
-// The difference from `parent->AddTag(CECTag(tagname, value), valuemap)` is
-// where the work happens. That form builds the tag first (calling the getter,
-// copying the string, allocating the tag) and only then asks the map whether it
-// was needed, discarding it if not; it also caches whole CECTag objects. This
-// form compares the raw value against a typed cache and builds nothing when it
-// is unchanged. On the client list -- rebuilt in full on every EC poll, where
-// most fields of most peers are static -- that is the difference between
-// paying for every field of every peer and paying only for what moved.
-//
-// `valuemap` may be NULL: callers that are not doing an incremental update pass
-// nothing, and then every tag is emitted unconditionally.
-//
-// A given tagname must be written through ONE of the two forms consistently.
-// They keep separate caches (typed maps here, `m_map_tag` there), so mixing
-// them for the same tag means neither sees the other's last value and a change
-// can be suppressed -- a field that silently stops updating in the GUI.
+// The difference from `parent->AddTag(CECTag(tagname, value), valuemap)` is where
+// the work happens. That form builds the tag first -- calling the getter, copying
+// the string, allocating -- and only then asks the map whether it was needed,
+// discarding it if not; it also caches whole CECTag objects. This form compares
+// the raw value against a typed cache and builds nothing when it is unchanged.
+// On the client list, rebuilt in full on every EC poll where most fields of most
+// peers are static, that is the difference between paying for every field of
+// every peer and paying only for what moved.
 template <typename T>
 inline void AddDiffTag(CECTag *parent, ec_tagname_t tagname, const T &value, CValueMap *valuemap)
 {

--- a/src/libs/ec/cpp/ECTag.cpp
+++ b/src/libs/ec/cpp/ECTag.cpp
@@ -376,14 +376,11 @@ bool CECTag::AddTag(const CECTag &tag, CValueMap *valuemap)
 	if (valuemap) {
 		return valuemap->AddTag(tag, this);
 	}
-	// The historical 65535 children-per-tag wire-format ceiling was
-	// lifted by the sentinel-extended count format in WriteChildren /
-	// ReadChildren; this writer-side guard is no longer needed and
-	// was silently dropping every tag past the 65535th — preventing
-	// EC_OP_SHARED_FILES responses from carrying libraries with more
-	// than 65535 shared files (#199).
+	// The historical 65535 children-per-tag wire-format ceiling was lifted by the
+	// sentinel-extended count format in WriteChildren / ReadChildren. The old
+	// writer-side guard silently dropped every tag past the 65535th, so an
+	// EC_OP_SHARED_FILES response could not carry a larger library (#199).
 
-	// First add an empty tag.
 	m_tagList.push_back(CECEmptyTag());
 	// Then exchange the data. The original tag will be destroyed right after this call anyway.
 	// UGLY - GCC allows a reference to an in place constructed object only to be passed as const.
@@ -514,14 +511,12 @@ bool CECTag::ReadChildren(CECSocket &socket)
 	}
 	uint32 tmp_tagCount;
 	if (useLargeCount && tmp_tagCount16 == 0xFFFF) {
-		// Sentinel-extended children count — see WriteChildren. Only
-		// honoured when the peer advertised EC_TAG_CAN_LARGE_TAG_COUNT
-		// in the auth handshake (mirrored into m_rx_flags via the
-		// per-packet flag). Old peers that don't know about this
-		// extension can still legitimately emit count == 0xFFFF as
-		// the literal uint16 count for 65535 children, so without
-		// the negotiated flag we MUST treat 0xFFFF as the count and
-		// not consume any follow-up bytes.
+		// Sentinel-extended children count -- see WriteChildren. Only honoured
+		// when the peer advertised EC_TAG_CAN_LARGE_TAG_COUNT in the auth
+		// handshake. Old peers that do not know the extension can still
+		// legitimately emit count == 0xFFFF as the literal uint16 count for 65535
+		// children, so without the negotiated flag 0xFFFF MUST be treated as the
+		// count with no follow-up bytes consumed.
 		uint32 tmp_tagCount32;
 		if (!socket.ReadNumber(&tmp_tagCount32, sizeof(uint32))) {
 			return false;

--- a/src/libs/ec/cpp/RemoteConnect.cpp
+++ b/src/libs/ec/cpp/RemoteConnect.cpp
@@ -95,12 +95,10 @@ CECLoginPacket::CECLoginPacket(const wxString &client,
 	// from CECTag::WriteChildren (#199). Always advertised by new
 	// clients; old servers ignore the unknown tag.
 	AddTag(CECEmptyTag(EC_TAG_CAN_LARGE_TAG_COUNT));
-	// Client implements the partial-update INC_UPDATE protocol — server
-	// may skip unchanged files and signal deletions explicitly via
-	// `EC_TAG_FILE_REMOVED` instead of relying on absence-implies-
-	// deletion. Always advertised by new clients; old servers ignore
-	// the unknown tag and the server falls back to emitting alive-
-	// marker tags for unchanged files (still backward-compatible).
+	// Client implements the partial-update INC_UPDATE protocol, so the server may
+	// skip unchanged files and signal deletions explicitly via EC_TAG_FILE_REMOVED
+	// rather than relying on absence-implies-deletion. Always advertised; old
+	// servers ignore the unknown tag and fall back to alive-marker tags.
 	AddTag(CECEmptyTag(EC_TAG_CAN_PARTIAL_UPDATE));
 	// Client applies the same skip-unchanged / explicit-removal rule to the
 	// multi-search results union. Advertised separately from
@@ -112,21 +110,16 @@ CECLoginPacket::CECLoginPacket(const wxString &client,
 	// over EC (EC_OP_GET/SET_SHARED_DIRS). Always advertised; old daemons
 	// ignore the unknown tag and simply never echo it back.
 	AddTag(CECEmptyTag(EC_TAG_CAN_SHAREDDIRS_CONFIG));
-	// Client can enumerate the daemon's searches with EC_OP_SEARCH_LIST, so it
-	// sees searches it did not start itself (restored from disk, or begun by
-	// another EC client). Always advertised; old daemons ignore the unknown tag
-	// and never echo it, which is what keeps the client from sending an opcode
-	// they would reject -- a pre-#680 daemon logs "invalid opcode received:
-	// 0x60" and trips an assert on it.
+	// Client can enumerate the daemon's searches with EC_OP_SEARCH_LIST, so it sees
+	// searches it did not start itself. Always advertised; old daemons ignore the
+	// unknown tag and never echo it, which is what keeps the client from sending an
+	// opcode they would reject -- a pre-#680 daemon asserts on it.
 	AddTag(CECEmptyTag(EC_TAG_CAN_SEARCH_LIST));
-	// Client tells the server "we believe transit between us is fast
-	// (loopback / LAN), so skip per-packet ZLIB up to the receiver
-	// gate". The server honours this hint at WritePacket time; see
-	// ECSocket.cpp `m_isLocalPeer`. The decision lives on the client
-	// because only the client knows the IP it dialed — server-side
-	// peer-IP inspection would misclassify e.g. WireGuard tunnel
-	// endpoints as "local" when the underlying transit is anything but.
-	// Old servers ignore the unknown tag and fall back to always-zlib.
+	// Client tells the server "we believe transit between us is fast (loopback /
+	// LAN), so skip per-packet ZLIB up to the receiver gate"; the server honours it
+	// at WritePacket time. The decision lives on the client because only the client
+	// knows the IP it dialed -- server-side peer-IP inspection would misclassify a
+	// WireGuard tunnel endpoint as local. Old servers ignore the tag.
 	if (preferNoZlib)
 		AddTag(CECEmptyTag(EC_TAG_PREFER_NO_ZLIB));
 	// Client implements the multi-search protocol — addresses EC searches
@@ -136,12 +129,10 @@ CECLoginPacket::CECLoginPacket(const wxString &client,
 	if (canMultiSearch)
 		AddTag(CECEmptyTag(EC_TAG_CAN_MULTI_SEARCH));
 	// Client polls every open search's progress with ONE id-less
-	// EC_OP_SEARCH_PROGRESS instead of one request per search. Strictly an
-	// extension of multi-search, so it is only advertised alongside it: an
-	// id-less progress request from a single-search client keeps its legacy
-	// "the current search" meaning, which is what amulecmd's `search progress`
-	// with no argument relies on. Old daemons ignore the unknown tag and never
-	// echo it, and the client then falls back to polling per id.
+	// EC_OP_SEARCH_PROGRESS instead of one request per search. An extension of
+	// multi-search, so only advertised alongside it: an id-less progress request
+	// from a single-search client keeps its legacy "the current search" meaning,
+	// which amulecmd's argument-less `search progress` relies on.
 	if (canMultiSearch)
 		AddTag(CECEmptyTag(EC_TAG_CAN_SEARCH_PROGRESS_UNION));
 	// Client wants incoming peer chat messages relayed over EC (amulegui
@@ -280,14 +271,12 @@ bool CRemoteConnect::ConnectToCore(
 	}
 	addr.Service(port);
 
-	// Compute the prefer-no-ZLIB hint after host resolution: if we
-	// dialed a loopback / RFC1918 LAN / RFC3927 link-local IP, the
-	// transit is fast and per-packet ZLIB is pure overhead. Skip the
-	// check entirely if the user opted out of ZLIB via /EC/ZLIB=0
-	// (capability isn't advertised so the hint is moot) or set
-	// `/EC/ForceZLIB=1` / `--force-zlib` to handle e.g. a WireGuard
-	// tunnel endpoint that resolves to an RFC1918 IP but whose
-	// underlying transit is slow Internet.
+	// Compute the prefer-no-ZLIB hint after host resolution: a loopback, RFC1918
+	// LAN or RFC3927 link-local IP means fast transit, where per-packet ZLIB is
+	// pure overhead. Skipped entirely if the user opted out of ZLIB (the capability
+	// is not advertised, so the hint is moot) or set ForceZLIB, for a WireGuard
+	// endpoint that resolves to an RFC1918 IP over slow transit.
+	//
 	// One fresh nonce per connection attempt: reusing it across attempts would
 	// reuse a key, and a retry after a dropped socket is a new session.
 	m_aeadClientNonce.clear();
@@ -422,15 +411,13 @@ uint64 CRemoteConnect::MillisecondsSinceLastReply() const
 void CRemoteConnect::OnLost()
 {
 	if (m_notifier) {
-		// A dial is still pending: the async connect hasn't completed, so
-		// EC_CONNECT_SENT hasn't advanced to EC_REQ_SENT yet. A LibSocketLost
-		// arriving now is not the death of this dial — it's a stale event that
-		// was already queued for the *previous* connection before the socket
-		// impl was swapped (CLibSocket::ResetForReconnect). It still targets
-		// this reused wrapper, but IsDestroying() now sees the fresh impl, so
-		// it slips through. Swallowing it stops that stale lost from aborting
-		// an in-flight reconnect; a genuinely failed dial is caught instead by
-		// amulegui's connect-timeout watchdog (CamuleRemoteGuiApp::OnConnectTimeout).
+		// A dial is still pending: the async connect has not completed, so
+		// EC_CONNECT_SENT has not advanced to EC_REQ_SENT. A LibSocketLost arriving
+		// now is not the death of this dial but a stale event queued for the PREVIOUS
+		// connection before the socket impl was swapped. It still targets this reused
+		// wrapper, and IsDestroying() now sees the fresh impl, so it slips through.
+		// Swallowing it stops a stale lost aborting an in-flight reconnect; a genuinely
+		// failed dial is caught by amulegui's connect-timeout watchdog.
 		if (m_ec_state == EC_CONNECT_SENT) {
 			return;
 		}
@@ -440,21 +427,16 @@ void CRemoteConnect::OnLost()
 		m_notifier->AddPendingEvent(event);
 		return;
 	}
-	// Headless EC clients (amulecmd, amuleweb) construct CRemoteConnect
-	// with NULL m_notifier. Continuing to run would mean serving stale
-	// data in amuleweb (HTTP requests still return the template shell
-	// without live amuled data, no error visible to the user) or
-	// sitting at the amulecmd prompt with a dead socket. Failing fast
-	// is the right semantic — supervisor (systemd unit / docker /
-	// shell loop) is the recovery layer and decides whether to restart.
+	// Headless EC clients (amulecmd, amuleweb) construct CRemoteConnect with NULL
+	// m_notifier. Continuing would mean amuleweb serving the template shell with no
+	// live data and no visible error, or amulecmd sitting at a prompt with a dead
+	// socket. Failing fast is right: the supervisor is the recovery layer.
 	fprintf(stderr, "%s\n", (const char *)unicode2char(_("External Connection lost - exiting.")));
 	fflush(stderr);
 	if (s_connectionLostHandler) {
-		// A client (amuleapi) opted into a graceful shutdown: hand off to it
-		// and return, so the orderly teardown runs on the client's own thread
-		// instead of racing static destructors from this asio callback. The
-		// client is responsible for actually stopping (it requests its normal
-		// shutdown path, e.g. flipping the main-loop's shutdown flag).
+		// A client (amuleapi) opted into a graceful shutdown: hand off to it and
+		// return, so the orderly teardown runs on the client's own thread instead of
+		// racing static destructors from this asio callback.
 		s_connectionLostHandler();
 		return;
 	}
@@ -496,11 +478,10 @@ void CRemoteConnect::SetupAEADFromSalt(const CECPacket *reply)
 		return;
 	}
 
-	// Validate the received lengths here, at the point of receipt, the way the
-	// daemon validates the client's. X25519Agree and Session::Init would reject
-	// a wrong length downstream too, but checking locally keeps the "every field
-	// the transcript concatenates is fixed-length" invariant obvious rather than
-	// resting on a distant guard.
+	// Validate the received lengths at the point of receipt, as the daemon does for
+	// the client's. X25519Agree and Session::Init would reject a wrong length
+	// downstream too, but checking locally keeps the "every field the transcript
+	// concatenates is fixed-length" invariant obvious.
 	if (serverNonceTag->GetTagDataLen() != ECCrypt::NONCE_TAG_LEN ||
 		serverPubTag->GetTagDataLen() != ECCrypt::X25519_KEY_LEN) {
 		AddDebugLogLineN(logEC, "AEAD: daemon nonce or public key has a bad length");
@@ -644,12 +625,10 @@ void CRemoteConnect::SendPacket(const CECPacket *request)
 
 void CRemoteConnect::DiscardRequestQueue()
 {
-	// The core never replies to requests that were on the air when the
-	// socket died, so their handlers would linger and every reply on the
-	// reconnected session would pop the wrong (stale) handler off the FIFO.
-	// Rewind each orphaned handler's request state so it re-requests, then
-	// clear the queue and the in-flight counter (see header for the #444
-	// wiped-list symptom this prevents).
+	// The core never replies to requests that were on the air when the socket died,
+	// so their handlers would linger and every reply on the reconnected session
+	// would pop the wrong one off the FIFO. Rewind each orphaned handler's request
+	// state so it re-requests, then clear the queue and the in-flight counter.
 	for (CECPacketHandlerBase *handler : m_req_fifo) {
 		if (handler) {
 			handler->AbortPendingRequest();
@@ -682,14 +661,12 @@ bool CRemoteConnect::ProcessAuthPacket(const CECPacket *reply)
 				// overwrites m_connectionPassword.
 				SetupAEADFromSalt(reply);
 				if (m_canAEAD && !m_aeadNegotiated) {
-					// Encryption is required unless the user opted out.
-					// m_canAEAD is that opt-out: with it off we never offer,
-					// so this branch cannot be reached and a clear session is
-					// only ever the user's explicit choice. The core did not
-					// negotiate encryption, and we cannot tell an older aMule
-					// without encryption support from an on-path attacker who
-					// stripped the offer, so we refuse rather than send the
-					// credential and every later command in clear.
+					// Encryption is required unless the user opted out, and m_canAEAD is
+					// that opt-out -- with it off we never offer, so this branch cannot
+					// be reached and a clear session is only ever an explicit choice. The
+					// core did not negotiate encryption, and an older aMule without
+					// support cannot be told from an on-path attacker who stripped the
+					// offer, so refuse rather than send the credential in clear.
 					m_server_reply =
 						m_aeadOffered.empty()
 							? _("Could not set up connection encryption. "
@@ -717,12 +694,11 @@ bool CRemoteConnect::ProcessAuthPacket(const CECPacket *reply)
 				CloseSocket();
 			}
 		} else if ((m_ec_state == EC_PASSWD_SENT) && (reply->GetOpCode() == EC_OP_AUTH_OK)) {
-			// The daemon must prove it holds the credential too, over this
-			// exact handshake. Until this passes we know only that we are
-			// talking to something that completed a key exchange -- which a
-			// relay can also do, twice. Checked before anything in the reply is
-			// believed, and fatal rather than a downgrade: a session that
-			// reaches here without a valid tag is one being relayed.
+			// The daemon must prove it holds the credential too, over this exact
+			// handshake: until this passes we know only that we are talking to
+			// something that completed a key exchange, which a relay can also do,
+			// twice. Checked before anything in the reply is believed, and fatal
+			// rather than a downgrade.
 			if (m_aeadNegotiated && !VerifyServerConfirm(reply)) {
 				m_server_reply = _("External Connection: the daemon failed to prove it "
 						   "knows the password. Connection closed.");
@@ -740,25 +716,20 @@ bool CRemoteConnect::ProcessAuthPacket(const CECPacket *reply)
 			} else {
 				m_server_reply = _("Succeeded! Connection established.");
 			}
-			// Mirror server's negotiated capabilities into m_my_flags so
-			// outgoing per-packet flags include them (auto-stripped by
-			// `flags &= m_my_flags` in CECSocket::WritePacket otherwise).
-			// EC_TAG_CAN_LARGE_TAG_COUNT only appears in AUTH_OK from
-			// new daemons (#199); old daemons just don't echo the tag,
-			// and the sentinel wire format stays disabled in both
-			// directions for the duration of this connection.
+			// Mirror the server's negotiated capabilities into m_my_flags, or outgoing
+			// per-packet flags lose them to `flags &= m_my_flags` in
+			// CECSocket::WritePacket. EC_TAG_CAN_LARGE_TAG_COUNT only appears in
+			// AUTH_OK from new daemons (#199); old ones do not echo it and the
+			// sentinel wire format stays disabled in both directions.
 			if (reply->GetTagByName(EC_TAG_CAN_LARGE_TAG_COUNT)) {
 				m_my_flags |= EC_FLAG_LARGE_TAG_COUNT;
 			}
 			// Server confirms it speaks the partial-update protocol:
-			// `Get_EC_Response_GetUpdate` may now omit unchanged files
-			// and emit explicit `EC_TAG_FILE_REMOVED` markers, and our
-			// INC_UPDATE handler must skip the bulk
-			// "missing-from-response == deleted" loop. Old daemons
-			// (#727 pre-fix or earlier) don't echo this tag and the
-			// client stays on the legacy bulk-deletion path, which
-			// the new server keeps compatible by emitting alive-marker
-			// tags for unchanged files (#713).
+			// Get_EC_Response_GetUpdate may now omit unchanged files and emit explicit
+			// EC_TAG_FILE_REMOVED markers, and our INC_UPDATE handler must skip the
+			// bulk "missing-from-response == deleted" loop. Old daemons do not echo
+			// this tag and the client stays on the legacy path, which the new server
+			// keeps compatible with alive-marker tags for unchanged files (#713).
 			if (reply->GetTagByName(EC_TAG_CAN_PARTIAL_UPDATE)) {
 				m_serverPartialUpdate = true;
 			}
@@ -768,10 +739,9 @@ bool CRemoteConnect::ProcessAuthPacket(const CECPacket *reply)
 			if (const CECTag *sessionTag = reply->GetTagByName(EC_TAG_SESSION_ID)) {
 				m_serverSessionId = sessionTag->GetInt();
 			}
-			// Server confirms it knows EC_OP_GET_CLIENT_HISTORY. No echo
-			// means the Known-clients tab stays empty rather than the
-			// request being tried and failing: on a debug daemon the
-			// unknown opcode asserts rather than answering EC_OP_FAILED.
+			// Server confirms it knows EC_OP_GET_CLIENT_HISTORY. No echo means the
+			// Known-clients tab stays empty rather than the request being tried and
+			// failing: on a debug daemon the unknown opcode asserts.
 			if (reply->GetTagByName(EC_TAG_CAN_CLIENT_HISTORY)) {
 				m_serverClientHistory = true;
 			}

--- a/src/libs/ec/cpp/RemoteConnect.h
+++ b/src/libs/ec/cpp/RemoteConnect.h
@@ -35,11 +35,9 @@
 
 // Installed by a headless EC client (amuleapi) to replace the hard _exit() that
 // CRemoteConnect::OnLost() performs when the EC connection drops with a NULL
-// notifier. When set, OnLost invokes the handler and returns instead of calling
-// _exit(), letting the client tear down on its own (main) thread -- draining a
-// redirected stdout/stderr log, stopping the HTTP server, etc. -- rather than
-// racing static destructors from the asio callback. Clients that do not set it
-// (amulecmd, amuleweb) keep the fail-fast _exit(). Pass nullptr to clear.
+// notifier. When set, OnLost invokes the handler and returns, letting the client
+// tear down on its own main thread rather than racing static destructors from
+// the asio callback. Clients that do not set it keep the fail-fast _exit().
 void SetEcConnectionLostHandler(void (*handler)());
 
 class CECPacketHandlerBase
@@ -48,12 +46,10 @@ public:
 	virtual ~CECPacketHandlerBase() {}
 	virtual void HandlePacket(const CECPacket *) = 0;
 
-	// Called when a reconnect discards the pending-request FIFO
-	// (CRemoteConnect::DiscardRequestQueue): the reply this handler was
-	// waiting for died with the dropped socket and will never arrive, so
-	// any "request in flight" state must be rewound or the handler would
-	// refuse to re-request on the fresh session. Default no-op for
-	// stateless handlers; CRemoteContainer rewinds its request SM.
+	// Called when a reconnect discards the pending-request FIFO: the reply this
+	// handler was waiting for died with the dropped socket, so any "request in
+	// flight" state must be rewound or the handler would refuse to re-request on
+	// the fresh session. Default no-op; CRemoteContainer rewinds its request SM.
 	virtual void AbortPendingRequest() {}
 };
 
@@ -117,11 +113,9 @@ private:
 	bool m_canUTF8numbers;
 	bool m_canNotify;
 
-	// Offer transport encryption. On by default in every shipped client, so
-	// a daemon that speaks it gets an encrypted session without anyone opting
-	// in; the user-facing switches only exist to turn it off. A daemon that
-	// does not speak it simply never echoes a cipher and the session stays as
-	// it was.
+	// Offer transport encryption. On by default in every shipped client, so a
+	// daemon that speaks it gets an encrypted session without anyone opting in; the
+	// user-facing switches only exist to turn it off.
 	bool m_canAEAD;
 
 	// Our half of the key-derivation salt, generated per connection attempt
@@ -135,22 +129,20 @@ private:
 	// of the session quietly dropping to something weaker.
 	std::vector<uint8_t> m_aeadOffered;
 
-	// Our ephemeral X25519 pair for this connection attempt. The private half
-	// is wiped as soon as the shared secret is derived: it is what an attacker
-	// who recorded the session would need, and it exists for the length of one
-	// handshake precisely so there is nothing left to compel or steal
-	// afterwards.
+	// Our ephemeral X25519 pair for this connection attempt. The private half is
+	// wiped as soon as the shared secret is derived: it is what an attacker who
+	// recorded the session would need, and it exists for one handshake precisely so
+	// there is nothing left to compel or steal afterwards.
 	std::vector<uint8_t> m_aeadEphPriv;
 	std::vector<uint8_t> m_aeadEphPub;
 
-	// md5 of the password, lower-cased -- the value both ends hold and
-	// neither transmits. Captured before the salted-challenge step below
-	// overwrites m_connectionPassword with the value that does go on the
-	// wire, which would be useless here.
+	// md5 of the password, lower-cased -- the value both ends hold and neither
+	// transmits. Captured before the salted-challenge step overwrites
+	// m_connectionPassword with the value that does go on the wire.
 	//
-	// No longer key material: the channel key comes from the ephemeral
-	// exchange alone, or a password learned later would decrypt a recording
-	// made earlier. This is what the confirmation tags are keyed on instead.
+	// No longer key material: the channel key comes from the ephemeral exchange
+	// alone, or a password learned later would decrypt a recording made earlier.
+	// This is what the confirmation tags are keyed on instead.
 	wxString m_aeadSecret;
 
 	// Our confirmation, sent with EC_OP_AUTH_PASSWD, and the daemon's, which
@@ -182,20 +174,14 @@ private:
 	 */
 	bool VerifyServerConfirm(const CECPacket *reply) const;
 
-	// Set in ConnectToCore when the dialed server address resolves to
-	// a loopback / RFC1918 LAN / RFC3927 link-local IP. Drives the
-	// `EC_TAG_PREFER_NO_ZLIB` hint in the auth packet; see
-	// `CECLoginPacket` ctor and ECSocket.cpp's `m_isLocalPeer` per-
-	// packet bypass. Only meaningful when `m_canZLIB` is also true
-	// (no point sending the hint when the capability isn't advertised).
+	// Set in ConnectToCore when the dialed address resolves to a loopback, RFC1918
+	// LAN or RFC3927 link-local IP. Drives the EC_TAG_PREFER_NO_ZLIB hint in the
+	// auth packet, and is only meaningful when m_canZLIB is also true.
 	bool m_preferNoZlib;
 
-	// User override to always negotiate ZLIB regardless of dialed
-	// server locality. Use case: a WireGuard / Tailscale tunnel
-	// endpoint that resolves to an RFC1918 IP but whose underlying
-	// transit is slow Internet — the locality check would otherwise
-	// strip ZLIB and the user loses the perf they actually want.
-	// Set via SetForceZlib() from the caller's config/CLI plumbing.
+	// User override to always negotiate ZLIB regardless of dialed server locality,
+	// for a WireGuard or Tailscale endpoint that resolves to an RFC1918 IP over
+	// slow Internet transit. Set via SetForceZlib().
 	bool m_forceZlib;
 
 	// The daemon process this connection is talking to (EC_TAG_SESSION_ID
@@ -206,33 +192,28 @@ private:
 	// discard everything keyed by ECID rather than reconcile against it.
 	uint64 m_serverSessionId;
 
-	// Set when the server echoed `EC_TAG_CAN_PARTIAL_UPDATE` in AUTH_OK,
-	// confirming it speaks the partial-update INC_UPDATE protocol: skip
-	// the bulk "anything missing == deleted" loop and instead delete only
-	// what arrives in explicit `EC_TAG_FILE_REMOVED` markers. Old daemons
-	// don't echo the tag; we then fall back to the legacy bulk-deletion
-	// path (server emits alive-marker tags so it still works).
+	// Set when the server echoed EC_TAG_CAN_PARTIAL_UPDATE in AUTH_OK, confirming
+	// it speaks the partial-update INC_UPDATE protocol: skip the bulk "anything
+	// missing == deleted" loop and delete only what arrives in explicit
+	// EC_TAG_FILE_REMOVED markers. Old daemons do not echo it, and the legacy bulk
+	// path still works because the server emits alive-marker tags.
 	bool m_serverPartialUpdate;
 
-	// Set when the server echoed `EC_TAG_CAN_CLIENT_HISTORY` in AUTH_OK,
-	// confirming it answers `EC_OP_GET_CLIENT_HISTORY`. Unlike most of these
-	// flags this one is not an optimisation: a daemon that predates the
-	// request reaches the unknown-opcode branch of ProcessRequest2(), which
-	// asserts before it gets to the EC_OP_FAILED it would otherwise return --
-	// so on a debug daemon simply trying the request takes the core down.
+	// Set when the server echoed EC_TAG_CAN_CLIENT_HISTORY in AUTH_OK, confirming
+	// it answers EC_OP_GET_CLIENT_HISTORY. Not an optimisation: a daemon that
+	// predates the request reaches the unknown-opcode branch of ProcessRequest2(),
+	// which asserts before returning the EC_OP_FAILED it otherwise would.
 	bool m_serverClientHistory;
 
-	// Set when the server echoed `EC_TAG_CAN_PARTIAL_SEARCH` in AUTH_OK,
-	// confirming it may skip unchanged *search results* on the multi-search
-	// union poll and signal their removal with `EC_TAG_FILE_REMOVED`.
+	// Set when the server echoed EC_TAG_CAN_PARTIAL_SEARCH in AUTH_OK, confirming
+	// it may skip unchanged SEARCH RESULTS on the multi-search union poll and
+	// signal their removal with EC_TAG_FILE_REMOVED.
 	//
-	// Deliberately separate from `m_serverPartialUpdate`: that one is about
-	// the shared-file / download INC_UPDATE stream and is advertised by every
-	// client built since it landed, including ones with no idea that search
-	// results could be skipped too. Reusing it here would make an older
-	// amuleGUI -- which advertises it, speaks multi-search, and still deletes
-	// any result missing from the reply -- silently drop its search results
-	// against a newer daemon.
+	// Deliberately separate from m_serverPartialUpdate, which is about the
+	// shared-file / download stream and is advertised by every client built since
+	// it landed. Reusing it here would make an older amuleGUI -- which advertises
+	// it, speaks multi-search, and still deletes any result missing from the reply
+	// -- silently drop its search results against a newer daemon.
 	bool m_serverPartialSearch;
 
 	// Client opts into the multi-search protocol (advertise
@@ -251,13 +232,11 @@ private:
 	// selection there could not reach the daemon.
 	bool m_serverSharedDirsConfig;
 
-	// Set when the server echoed `EC_TAG_CAN_SEARCH_LIST` in AUTH_OK,
-	// confirming it serves EC_OP_SEARCH_LIST. Old daemons don't echo it, and
-	// the client must then not send that opcode at all: it predates #680, so
-	// the request falls through to ProcessRequest2's unknown-opcode branch,
-	// which logs "invalid opcode received: 0x60" and trips a wxFAIL. Without
-	// the list the GUI simply sees only the searches it started itself, which
-	// is the pre-#680 behaviour.
+	// Set when the server echoed EC_TAG_CAN_SEARCH_LIST in AUTH_OK, confirming it
+	// serves EC_OP_SEARCH_LIST. Old daemons do not echo it, and the client must
+	// then not send the opcode at all: it predates #680, so the request falls into
+	// ProcessRequest2's unknown-opcode branch and trips a wxFAIL. Without the list
+	// the GUI simply sees only the searches it started itself.
 	bool m_serverSearchList;
 
 	// Steady-clock stamp of the last packet received from the daemon. Steady,
@@ -265,13 +244,11 @@ private:
 	// readable as a stalled connection.
 	std::chrono::steady_clock::time_point m_lastReplyAt;
 
-	// Set when the server echoed `EC_TAG_CAN_SEARCH_PROGRESS_UNION` in
-	// AUTH_OK, confirming that an EC_OP_SEARCH_PROGRESS carrying no
-	// `EC_TAG_SEARCH_ID` reports every open search as children instead of
-	// just one. Advertised only alongside multi-search, so an id-less
-	// request from a single-search client keeps its legacy "current search"
-	// meaning. Old daemons don't echo it; the client then polls per id,
-	// which costs one round trip per open search tab.
+	// Set when the server echoed EC_TAG_CAN_SEARCH_PROGRESS_UNION in AUTH_OK,
+	// confirming an EC_OP_SEARCH_PROGRESS carrying no EC_TAG_SEARCH_ID reports
+	// every open search as children rather than just one. Advertised only alongside
+	// multi-search, so an id-less request from a single-search client keeps its
+	// legacy meaning. Old daemons do not echo it and the client polls per id.
 	bool m_serverSearchProgressUnion;
 
 	// Client opts into chat relay (advertise `EC_TAG_CAN_CHAT`). Off by
@@ -284,12 +261,12 @@ private:
 	bool m_serverChat;
 	// Client speaks the chat session ops (advertise `EC_TAG_CAN_CHAT_SESSIONS`).
 	bool m_canChatSessions;
-	// Set when the server echoed `EC_TAG_CAN_CHAT_SESSIONS` in AUTH_OK.
+	// Set when the server echoed EC_TAG_CAN_CHAT_SESSIONS in AUTH_OK.
 	//
-	// Distinct from m_serverChat on purpose. `EC_TAG_CAN_CHAT` is echoed by
-	// daemons that predate the session ops entirely, so gating on it would
-	// send EC_OP_GET_CHAT_SESSIONS to a core with no case for it -- straight
-	// into the unknown-opcode branch, which asserts before answering.
+	// Distinct from m_serverChat on purpose: EC_TAG_CAN_CHAT is echoed by daemons
+	// that predate the session ops entirely, so gating on it would send
+	// EC_OP_GET_CHAT_SESSIONS to a core with no case for it, straight into the
+	// unknown-opcode branch, which asserts before answering.
 	bool m_serverChatSessions;
 
 	void WriteDoneAndQueueEmpty();


### PR DESCRIPTION
Comment-only sweep of `src/libs/ec`: 7 files, 1133 -> 1033 comment lines (-100, -8.8%). Figures are over the touched files only; licence headers are untouched and form a floor in every count.

Part of a tree-wide pass split by scope. The scopes touch disjoint files, so this one merges independently of the others.

**What came out**

- Verbosity only. The capability-negotiation notes, the AEAD handshake rationale and the wire-format constraints are all kept, just tightened.

**What stayed**

Anything recording something the code cannot tell you by itself: a protocol constraint, a wire-format rule, a platform quirk, the reason a guard exists, the why behind a non-obvious default.

**Verification**

- Every file mechanically checked comment-only: comments stripped and whitespace normalised on both sides, then diffed against master. 7/7 identical, so no code changes.
- clang-format 18, the version CI pins, clean over all of `src/` and `unittests/`.
- Builds clean on macOS. Nothing here changes code, so the build cannot differ per scope.

**Reviewing**

`git diff master -w` is the whole change; there is no code to read.
