### PR TITLE
chore(utils): trim narration comments in wxCas and aLinkCreator

### DIFF
--- a/src/utils/aLinkCreator/src/alcframe.cpp
+++ b/src/utils/aLinkCreator/src/alcframe.cpp
@@ -60,11 +60,9 @@
 #include "alcpix.h"
 #include "alc.h"
 
-/// Constructor
 AlcFrame::AlcFrame(const wxString &title)
 : wxFrame((wxFrame *)NULL, -1, title)
 {
-	// Give it an icon
 #ifdef __WINDOWS__
 	wxIcon icon("alc");
 #else
@@ -73,37 +71,27 @@ AlcFrame::AlcFrame(const wxString &title)
 #endif
 	SetIcon(icon);
 
-	// Status Bar
 	CreateStatusBar();
 	SetStatusText(_("Welcome!"));
 
-	// Unused dialog for now
 	m_progressBar = NULL;
 
-	// Frame Vertical sizer
 	m_frameVBox = new wxBoxSizer(wxVERTICAL);
 
-	// Add Main panel to frame (needed by win32 for padding sub panels)
 	m_mainPanel = new wxPanel(this, -1);
 
-	// Main Panel Vertical Sizer
 	m_mainPanelVBox = new wxBoxSizer(wxVERTICAL);
 
-	// Main Panel static line
 	m_staticLine = new wxStaticLine(m_mainPanel, -1);
 	m_mainPanelVBox->Add(m_staticLine, wxSizerFlags().Expand().Border(wxALL, 0));
 
-	// Input Parameters
 	m_inputSBox = new wxStaticBox(m_mainPanel, -1, _("Input parameters"));
 	m_inputSBoxSizer = new wxStaticBoxSizer(m_inputSBox, wxHORIZONTAL);
 
-	// Input Grid
 	m_inputFlexSizer = new wxFlexGridSizer(6, 2, 5, 10);
 
-	// Left col is growable
 	m_inputFlexSizer->AddGrowableCol(0);
 
-	// Static texts
 	m_inputFileStaticText = new wxStaticText(
 		m_mainPanel, -1, _("File to Hash"), wxDefaultPosition, wxDefaultSize, wxALIGN_CENTRE);
 
@@ -114,7 +102,6 @@ AlcFrame::AlcFrame(const wxString &title)
 		wxDefaultSize,
 		wxALIGN_CENTRE);
 
-	// Text ctrls
 	m_inputFileTextCtrl = new wxTextCtrl(m_mainPanel, -1, "", wxDefaultPosition, wxSize(300, -1));
 	m_inputFileTextCtrl->SetToolTip(_("Enter here the file you want to compute the eD2k link"));
 
@@ -122,7 +109,6 @@ AlcFrame::AlcFrame(const wxString &title)
 	m_inputAddTextCtrl->SetToolTip(_("Enter here the URL you want to add to the eD2k link: Add / at the "
 					 "end to let aLinkCreator append the current file name"));
 
-	// List box
 	m_inputUrlListBox = new wxListBox(m_mainPanel,
 		-1,
 		wxDefaultPosition,
@@ -131,12 +117,10 @@ AlcFrame::AlcFrame(const wxString &title)
 		NULL,
 		wxLB_SINGLE | wxLB_NEEDED_SB | wxLB_HSCROLL);
 
-	// Buttons
 	m_inputFileBrowseButton = new wxButton(m_mainPanel, ID_BROWSE_BUTTON, wxString(_("Browse")));
 
 	m_inputAddButton = new wxButton(m_mainPanel, ID_ADD_BUTTON, wxString(_("Add")));
 
-	// Button bar
 	m_buttonUrlVBox = new wxBoxSizer(wxVERTICAL);
 	m_removeButton = new wxButton(m_mainPanel, ID_REMOVE_BUTTON, wxString(_("Remove")));
 	m_clearButton = new wxButton(m_mainPanel, ID_CLEAR_BUTTON, wxString(_("Clear")));
@@ -144,7 +128,6 @@ AlcFrame::AlcFrame(const wxString &title)
 	m_buttonUrlVBox->Add(m_removeButton, wxSizerFlags().Center().Border(wxTOP | wxBOTTOM, 5));
 	m_buttonUrlVBox->Add(m_clearButton, wxSizerFlags().Center().Border(wxTOP | wxBOTTOM, 5));
 
-	// Check button
 	m_parthashesCheck =
 		new wxCheckBox(m_mainPanel, ID_PARTHASHES_CHECK, _("Create link with part-hashes"));
 
@@ -153,7 +136,6 @@ AlcFrame::AlcFrame(const wxString &title)
 	m_parthashesCheck->SetToolTip(
 		_("Help to spread new and rare files faster, at the cost of an increased link size"));
 
-	// Add to sizers
 	m_inputFlexSizer->Add(m_inputFileStaticText, wxSizerFlags(1).Expand().Bottom().Border(wxTOP, 10));
 	m_inputFlexSizer->Add(1, 1);
 
@@ -176,11 +158,9 @@ AlcFrame::AlcFrame(const wxString &title)
 	m_mainPanelVBox->Add(m_inputSBoxSizer, wxSizerFlags().Expand().Center().Border(wxALL, 10));
 
 #ifdef WANT_MD4SUM
-	// MD4 Hash Vertical Box Sizer
 	m_md4HashSBox = new wxStaticBox(m_mainPanel, -1, _("MD4 File Hash"));
 	m_md4HashSBoxSizer = new wxStaticBoxSizer(m_md4HashSBox, wxHORIZONTAL);
 
-	// MD4 Hash results
 	m_md4HashTextCtrl =
 		new wxTextCtrl(m_mainPanel, -1, "", wxDefaultPosition, wxDefaultSize, wxTE_READONLY);
 
@@ -188,22 +168,18 @@ AlcFrame::AlcFrame(const wxString &title)
 	m_mainPanelVBox->Add(m_md4HashSBoxSizer, wxSizerFlags().Expand().Border(wxALL, 10));
 #endif
 
-	// Hash Vertical Box Sizer
 	m_e2kHashSBox = new wxStaticBox(m_mainPanel, -1, _("eD2k File Hash"));
 	m_e2kHashSBoxSizer = new wxStaticBoxSizer(m_e2kHashSBox, wxHORIZONTAL);
 
-	// Hash results
 	m_e2kHashTextCtrl =
 		new wxTextCtrl(m_mainPanel, -1, "", wxDefaultPosition, wxDefaultSize, wxTE_READONLY);
 
 	m_e2kHashSBoxSizer->Add(m_e2kHashTextCtrl, wxSizerFlags(1).Center().Border(wxALL, 5));
 	m_mainPanelVBox->Add(m_e2kHashSBoxSizer, wxSizerFlags().Expand().Border(wxALL, 10));
 
-	// Ed2k Vertical Box Sizer
 	m_ed2kSBox = new wxStaticBox(m_mainPanel, -1, _("eD2k link"));
 	m_ed2kSBoxSizer = new wxStaticBoxSizer(m_ed2kSBox, wxVERTICAL);
 
-	// Ed2k results
 	m_ed2kTextCtrl = new wxTextCtrl(m_mainPanel,
 		-1,
 		"",
@@ -214,7 +190,6 @@ AlcFrame::AlcFrame(const wxString &title)
 	m_ed2kSBoxSizer->Add(m_ed2kTextCtrl, wxSizerFlags(1).Expand().Border(wxALL, 5));
 	m_mainPanelVBox->Add(m_ed2kSBoxSizer, wxSizerFlags(1).Expand().Border(wxALL, 10));
 
-	// Button bar
 	m_buttonHBox = new wxBoxSizer(wxHORIZONTAL);
 	m_startButton = new wxButton(m_mainPanel, ID_START_BUTTON, wxString(_("Start")));
 	m_saveButton = new wxButton(m_mainPanel, ID_SAVEAS_BUTTON, wxString(_("Save")));
@@ -229,13 +204,11 @@ AlcFrame::AlcFrame(const wxString &title)
 
 	m_mainPanelVBox->Add(m_buttonHBox, wxSizerFlags().Expand().Border(wxALL, 5));
 
-	// Toolbar Pixmaps
 	m_toolBarBitmaps[0] = AlcPix::getPixmap("open");
 	m_toolBarBitmaps[1] = AlcPix::getPixmap("copy");
 	m_toolBarBitmaps[2] = AlcPix::getPixmap("saveas");
 	m_toolBarBitmaps[3] = AlcPix::getPixmap("about");
 
-	// Constructing toolbar
 	m_toolbar = new wxToolBar(this, -1, wxDefaultPosition, wxDefaultSize, wxTB_HORIZONTAL | wxTB_FLAT);
 
 	m_toolbar->SetToolBitmapSize(wxSize(32, 32));
@@ -265,11 +238,9 @@ AlcFrame::AlcFrame(const wxString &title)
 
 	SetToolBar(m_toolbar);
 
-	// Main panel Layout
 	m_mainPanel->SetAutoLayout(true);
 	m_mainPanel->SetSizerAndFit(m_mainPanelVBox);
 
-	// Frame Layout
 	m_frameVBox->Add(m_mainPanel, wxSizerFlags(1).Expand().Border(wxALL, 0));
 	SetAutoLayout(true);
 	SetSizerAndFit(m_frameVBox);
@@ -277,10 +248,8 @@ AlcFrame::AlcFrame(const wxString &title)
 	m_startButton->SetFocus();
 }
 
-/// Destructor
 AlcFrame::~AlcFrame() {}
 
-/// Events table
 wxBEGIN_EVENT_TABLE(AlcFrame, wxFrame)
 	EVT_TOOL(ID_BAR_OPEN, AlcFrame::OnBarOpen)
 	EVT_TOOL(ID_BAR_SAVEAS, AlcFrame::OnBarSaveAs)
@@ -296,19 +265,16 @@ wxBEGIN_EVENT_TABLE(AlcFrame, wxFrame)
 	EVT_BUTTON(ID_CLEAR_BUTTON, AlcFrame::OnClearUrlButton)
 wxEND_EVENT_TABLE()
 
-/// Toolbar Open button
 void AlcFrame::OnBarOpen(wxCommandEvent &WXUNUSED(event))
 {
 	SetFileToHash();
 }
 
-/// Browse button to select file to hash
 void AlcFrame::OnBrowseButton(wxCommandEvent &WXUNUSED(event))
 {
 	SetFileToHash();
 }
 
-/// Set File to hash in wxTextCtrl
 void AlcFrame::SetFileToHash()
 {
 #ifdef __WINDOWS__
@@ -359,19 +325,16 @@ void AlcFrame::SetFileToHash()
 	}
 }
 
-/// Toolbar Save As button
 void AlcFrame::OnBarSaveAs(wxCommandEvent &WXUNUSED(event))
 {
 	SaveEd2kLinkToFile();
 }
 
-/// Save As button
 void AlcFrame::OnSaveAsButton(wxCommandEvent &WXUNUSED(event))
 {
 	SaveEd2kLinkToFile();
 }
 
-/// Copy Ed2k link to clip board
 void AlcFrame::CopyEd2kLinkToClipBoard()
 {
 	wxString link = m_ed2kTextCtrl->GetValue();
@@ -389,19 +352,16 @@ void AlcFrame::CopyEd2kLinkToClipBoard()
 	}
 }
 
-/// Copy button
 void AlcFrame::OnCopyButton(wxCommandEvent &WXUNUSED(event))
 {
 	CopyEd2kLinkToClipBoard();
 }
 
-/// Toolbar Copy button
 void AlcFrame::OnBarCopy(wxCommandEvent &WXUNUSED(event))
 {
 	CopyEd2kLinkToClipBoard();
 }
 
-/// Save computed Ed2k link to file
 void AlcFrame::SaveEd2kLinkToFile()
 {
 	wxString link(m_ed2kTextCtrl->GetValue());
@@ -432,7 +392,6 @@ void AlcFrame::SaveEd2kLinkToFile()
 	}
 }
 
-/// Toolbar About button
 void AlcFrame::OnBarAbout(wxCommandEvent &WXUNUSED(event))
 {
 	wxMessageBox(_("aLinkCreator, the aMule eD2k link creator\n\n(c) 2004 ThePolish "
@@ -443,7 +402,6 @@ void AlcFrame::OnBarAbout(wxCommandEvent &WXUNUSED(event))
 		wxOK | wxCENTRE | wxICON_INFORMATION);
 }
 
-/// Close Button
 void AlcFrame::OnCloseButton(wxCommandEvent &WXUNUSED(event))
 {
 	Close(false);

--- a/src/utils/aLinkCreator/src/ed2khash.cpp
+++ b/src/utils/aLinkCreator/src/ed2khash.cpp
@@ -31,7 +31,6 @@
 
 #include "ed2khash.h"
 
-/// Constructor
 Ed2kHash::Ed2kHash()
 : MD4()
 {
@@ -40,7 +39,6 @@ Ed2kHash::Ed2kHash()
 	m_fileSize = 0;
 }
 
-/// Destructor
 Ed2kHash::~Ed2kHash() {}
 
 /// Set Ed2k hash from a file

--- a/src/utils/aLinkCreator/src/md4.cpp
+++ b/src/utils/aLinkCreator/src/md4.cpp
@@ -76,7 +76,6 @@ void MD4::MD4Update(struct MD4Context *ctx, unsigned char const *buf, size_t len
 {
 	uint32_t t;
 
-	// Update bitcount
 	t = ctx->bits[0];
 	if ((ctx->bits[0] = t + ((uint32_t)len << 3)) < t)
 		ctx->bits[1]++; // Carry from low to high
@@ -84,7 +83,6 @@ void MD4::MD4Update(struct MD4Context *ctx, unsigned char const *buf, size_t len
 
 	t = (t >> 3) & 0x3f; // Bytes already in shsInfo->data
 
-	// Handle any leading odd-sized chunks
 	if (t) {
 		unsigned char *p = (unsigned char *)ctx->in + t;
 
@@ -100,7 +98,6 @@ void MD4::MD4Update(struct MD4Context *ctx, unsigned char const *buf, size_t len
 		len -= t;
 	}
 
-	// Process data in 64-byte chunks
 	while (len >= 64) {
 		memcpy(ctx->in, buf, 64);
 		byteReverse(ctx->in, 16);
@@ -109,7 +106,6 @@ void MD4::MD4Update(struct MD4Context *ctx, unsigned char const *buf, size_t len
 		len -= 64;
 	}
 
-	// Handle any remaining bytes of data.
 	memcpy(ctx->in, buf, len);
 }
 
@@ -120,7 +116,6 @@ void MD4::MD4Final(struct MD4Context *ctx, unsigned char *digest)
 	unsigned int count;
 	unsigned char *p;
 
-	// Compute number of bytes mod 64
 	count = (ctx->bits[0] >> 3) & 0x3F;
 
 	// Set the first char of padding to 0x80.
@@ -128,7 +123,6 @@ void MD4::MD4Final(struct MD4Context *ctx, unsigned char *digest)
 	p = ctx->in + count;
 	*p++ = 0x80;
 
-	// Bytes of padding needed to make 64 bytes
 	count = 64 - 1 - count;
 
 	// Pad out to 56 mod 64

--- a/src/utils/wxCas/src/onlinesig.h
+++ b/src/utils/wxCas/src/onlinesig.h
@@ -71,42 +71,31 @@ private:
 	unsigned int PullCount(unsigned int *runtime, const unsigned int count);
 
 public:
-	/// Constructor
 	OnLineSig(const wxFileName &file,
 		const double absoluteMaxDL = 0.0,
 		const wxDateTime absoluteMaxDlDate = wxDateTime::Now());
 
-	/// Destructor
 	~OnLineSig();
 
-	/// Set amulesig.dat file name and path
 	void SetAmuleSig(const wxFileName &file);
 
-	/// Refresh stored information
 	void Refresh();
 
-	/// Return TRUE if aMule is running
 	int GetAmuleState() const;
 
-	/// Return kad stat
 	int GetKadState() const;
 
-	/// Get server name
 	wxString GetServerName() const;
 
-	/// Get server IP
 	wxString GetServerIP() const;
 
-	/// Get server Port
 	wxString GetServerPort() const;
 
 	/// Get server connexion ID: H or L
 	wxString GetConnexionID() const;
 
-	/// Get Upload rate
 	wxString GetULRate() const;
 
-	/// Get Download rate
 	wxString GetDLRate() const;
 
 	/// Get number of clients in queue

--- a/src/utils/wxCas/src/wxcasframe.cpp
+++ b/src/utils/wxCas/src/wxcasframe.cpp
@@ -45,11 +45,9 @@
 #include "wxcascte.h"
 #include "wxcaspix.h"
 
-// Constructor
 WxCasFrame::WxCasFrame(const wxString &title)
 : wxFrame((wxFrame *)NULL, -1, title, wxDefaultPosition, wxDefaultSize, wxDEFAULT_FRAME_STYLE)
 {
-	// Give it an icon
 #ifdef __WINDOWS__
 	wxIcon icon("wxcas");
 #else
@@ -58,7 +56,6 @@ WxCasFrame::WxCasFrame(const wxString &title)
 #endif
 	SetIcon(icon);
 
-	// Prefs
 	wxConfigBase *prefs = wxConfigBase::Get();
 
 	m_maxLineCount = 0;
@@ -69,7 +66,6 @@ WxCasFrame::WxCasFrame(const wxString &title)
 	wxDateTime absoluteMaxDlDate(
 		(time_t)(prefs->Read(WxCasCte::ABSOLUTE_MAX_DL_DATE_KEY, (long)(time(NULL)))));
 
-	// Add Online Sig file
 	m_aMuleSig = new OnLineSig(
 		wxFileName(prefs->Read(WxCasCte::AMULESIG_PATH_KEY, WxCasCte::DEFAULT_AMULESIG_PATH),
 			WxCasCte::AMULESIG_FILENAME),
@@ -86,20 +82,15 @@ WxCasFrame::WxCasFrame(const wxString &title)
 	m_sysMonitor = new LinuxMon();
 #endif
 
-	// Status Bar
 	CreateStatusBar();
 	SetStatusText(_("Welcome!"));
 
-	// Frame Vertical sizer
 	m_frameVBox = new wxBoxSizer(wxVERTICAL);
 
-	// Add Main panel to frame (needed by win32 for padding sub panels)
 	m_mainPanel = new wxPanel(this, -1);
 
-	// Main Panel Vertical Sizer
 	m_mainPanelVBox = new wxBoxSizer(wxVERTICAL);
 
-	// Main Panel static line
 	m_staticLine = new wxStaticLine(m_mainPanel, -1);
 
 #ifdef __WINDOWS__
@@ -107,20 +98,16 @@ WxCasFrame::WxCasFrame(const wxString &title)
 	m_BottomStaticLine = new wxStaticLine(m_mainPanel, -1);
 #endif
 
-	// Statistics Static Vertical Box Sizer
 	m_sigPanelSBox = new wxStaticBox(m_mainPanel, -1, _("aMule"));
 	m_sigPanelSBoxSizer = new wxStaticBoxSizer(m_sigPanelSBox, wxVERTICAL);
 
-	// Hit Static Horizontal Box Sizer
 	m_hitPanelSBox = new wxStaticBox(m_mainPanel, -1, _("Maximum DL rate since wxCas is running"));
 	m_hitPanelSBoxSizer = new wxStaticBoxSizer(m_hitPanelSBox, wxHORIZONTAL);
 
-	// Hit Static Horizontal Box Sizer
 	m_absHitPanelSBox =
 		new wxStaticBox(m_mainPanel, -1, _("Absolute Maximum DL rate during wxCas previous runs"));
 	m_absHitPanelSBoxSizer = new wxStaticBoxSizer(m_absHitPanelSBox, wxHORIZONTAL);
 
-	// Statistic labels
 	m_statLine_1 = new wxStaticText(m_mainPanel, -1, MakeStatLine_1());
 	m_statLine_2 = new wxStaticText(m_mainPanel, -1, MakeStatLine_2());
 	m_statLine_3 = new wxStaticText(m_mainPanel, -1, MakeStatLine_3());
@@ -137,7 +124,6 @@ WxCasFrame::WxCasFrame(const wxString &title)
 
 #ifdef __LINUX__ // System monitoring on Linux
 
-	// Monitoring Static Vertical Box Sizer
 	m_monPanelSBox = new wxStaticBox(m_mainPanel, -1, _("System"));
 	m_monPanelSBoxSizer = new wxStaticBoxSizer(m_monPanelSBox, wxVERTICAL);
 
@@ -145,7 +131,6 @@ WxCasFrame::WxCasFrame(const wxString &title)
 	m_sysLine_2 = new wxStaticText(m_mainPanel, -1, MakeSysLine_2());
 #endif
 
-	// Statistic Panel Layout
 	m_sigPanelSBoxSizer->Add(m_statLine_1, wxSizerFlags().Expand().Center().Border(wxALL, 5));
 	m_sigPanelSBoxSizer->Add(m_statLine_2, wxSizerFlags().Expand().Center().Border(wxALL, 5));
 	m_sigPanelSBoxSizer->Add(m_statLine_3, wxSizerFlags().Expand().Center().Border(wxALL, 5));
@@ -166,7 +151,6 @@ WxCasFrame::WxCasFrame(const wxString &title)
 	m_monPanelSBoxSizer->Add(m_sysLine_2, wxSizerFlags().Expand().Center().Border(wxALL, 5));
 #endif
 
-	// Main panel Layout
 	m_mainPanelVBox->Add(m_staticLine, wxSizerFlags().Expand().Center().Border(wxALL, 0));
 
 	m_mainPanelVBox->Add(m_sigPanelSBoxSizer, wxSizerFlags().Expand().Center().Border(wxALL, 10));
@@ -185,7 +169,6 @@ WxCasFrame::WxCasFrame(const wxString &title)
 	m_mainPanelVBox->Add(m_BottomStaticLine, wxSizerFlags().Expand().Center().Border(wxALL, 0));
 #endif
 
-	// Toolbar Pixmaps
 	m_toolBarBitmaps[0] = WxCasPix::getPixmap("refresh");
 	m_toolBarBitmaps[1] = WxCasPix::getPixmap("save");
 	m_toolBarBitmaps[2] = WxCasPix::getPixmap("print");
@@ -193,7 +176,6 @@ WxCasFrame::WxCasFrame(const wxString &title)
 	m_toolBarBitmaps[4] = WxCasPix::getPixmap("stop");
 	m_toolBarBitmaps[5] = WxCasPix::getPixmap("prefs");
 
-	// Constructing toolbar
 	m_toolbar = new wxToolBar(this, -1, wxDefaultPosition, wxDefaultSize, wxTB_HORIZONTAL | wxTB_FLAT);
 
 	m_toolbar->SetToolBitmapSize(wxSize(32, 32));
@@ -217,27 +199,22 @@ WxCasFrame::WxCasFrame(const wxString &title)
 
 	SetToolBar(m_toolbar);
 
-	// Panel Layout
 	m_mainPanel->SetAutoLayout(true);
 	m_mainPanel->SetSizer(m_mainPanelVBox);
 
-	// Frame Layout
 	m_frameVBox->Add(m_mainPanel, wxSizerFlags(1).Expand().Border(wxALL, 0));
 	SetAutoLayout(TRUE);
 	SetSizerAndFit(m_frameVBox);
 
-	// Add refresh timer
 	m_refresh_timer = new wxTimer(this, ID_REFRESH_TIMER);
 	m_refresh_timer->Start(
 		1000 * prefs->Read(WxCasCte::REFRESH_RATE_KEY, WxCasCte::DEFAULT_REFRESH_RATE)); // s to ms
 
-	// Add FTP update timer
 	m_ftp_update_timer = new wxTimer(this, ID_FTP_UPDATE_TIMER);
 	m_ftp_update_timer->Start(60000 * prefs->Read(WxCasCte::FTP_UPDATE_RATE_KEY,
 						  WxCasCte::DEFAULT_FTP_UPDATE_RATE)); // min to ms
 }
 
-// Destructor
 WxCasFrame::~WxCasFrame()
 {
 	delete m_aMuleSig;
@@ -248,7 +225,6 @@ WxCasFrame::~WxCasFrame()
 #endif
 }
 
-// Events table
 wxBEGIN_EVENT_TABLE(WxCasFrame, wxFrame)
 	EVT_TOOL(ID_BAR_REFRESH, WxCasFrame::OnBarRefresh)
 	EVT_TOOL(ID_BAR_SAVE, WxCasFrame::OnBarSave)
@@ -261,7 +237,6 @@ wxBEGIN_EVENT_TABLE(WxCasFrame, wxFrame)
 	EVT_BUTTON(ID_ABS_HIT_BUTTON, WxCasFrame::OnAbsHitButton)
 wxEND_EVENT_TABLE()
 
-// Get Stat Bitmap
 wxImage *WxCasFrame::GetStatImage() const
 {
 	wxBitmap statBitmap = WxCasPix::getPixmap("stat");
@@ -292,7 +267,6 @@ wxImage *WxCasFrame::GetStatImage() const
 	return (statImage);
 }
 
-// Refresh button
 void WxCasFrame::OnBarRefresh(wxCommandEvent &WXUNUSED(event))
 {
 	if (m_refresh_timer->IsRunning()) {
@@ -324,7 +298,6 @@ void WxCasFrame::OnBarRefresh(wxCommandEvent &WXUNUSED(event))
 	}
 }
 
-// Save button
 void WxCasFrame::OnBarSave(wxCommandEvent &WXUNUSED(event))
 {
 	wxImage *statImage = GetStatImage();
@@ -363,7 +336,6 @@ void WxCasFrame::OnBarSave(wxCommandEvent &WXUNUSED(event))
 	delete statImage;
 }
 
-// Print button
 void WxCasFrame::OnBarPrint(wxCommandEvent &WXUNUSED(event))
 {
 	wxPrinter printer;
@@ -378,14 +350,12 @@ void WxCasFrame::OnBarPrint(wxCommandEvent &WXUNUSED(event))
 	}
 }
 
-// Prefs button
 void WxCasFrame::OnBarPrefs(wxCommandEvent &WXUNUSED(event))
 {
 	WxCasPrefs dlg(this);
 	dlg.ShowModal();
 }
 
-// About button
 void WxCasFrame::OnBarAbout(wxCommandEvent &WXUNUSED(event))
 {
 	wxMessageBox(_("wxCas, aMule OnLine Signature Statistics\n\n(c) 2004 ThePolish "
@@ -395,15 +365,12 @@ void WxCasFrame::OnBarAbout(wxCommandEvent &WXUNUSED(event))
 		wxOK | wxCENTRE | wxICON_INFORMATION);
 }
 
-// Refresh timer
 void WxCasFrame::OnRefreshTimer(wxTimerEvent &WXUNUSED(event))
 {
-	// Prefs
 	wxConfigBase *prefs = wxConfigBase::Get();
 
 	UpdateAll();
 
-	// Generate stat image if asked in config
 	if (prefs->Read(WxCasCte::ENABLE_AUTOSTATIMG_KEY, WxCasCte::DEFAULT_AUTOSTATIMG_ISENABLED)) {
 		wxImage *statImage = GetStatImage();
 
@@ -420,29 +387,24 @@ void WxCasFrame::OnRefreshTimer(wxTimerEvent &WXUNUSED(event))
 	}
 }
 
-// Ftp update timer
 void WxCasFrame::OnFtpUpdateTimer(wxTimerEvent &WXUNUSED(event))
 {
-	// Prefs
 	wxConfigBase *prefs = wxConfigBase::Get();
 
 	// Image must be autogenerated to be uploaded
 	if (prefs->Read(WxCasCte::ENABLE_AUTOSTATIMG_KEY, WxCasCte::DEFAULT_AUTOSTATIMG_ISENABLED) &&
 		prefs->Read(WxCasCte::ENABLE_FTP_UPDATE_KEY, WxCasCte::DEFAULT_FTP_UPDATE_ISENABLED)) {
-		// Get image file
 		wxFileName fileName(
 			prefs->Read(WxCasCte::AUTOSTATIMG_DIR_KEY, WxCasCte::DEFAULT_AUTOSTATIMG_PATH),
 			WxCasCte::AMULESIG_IMG_NAME,
 			prefs->Read(WxCasCte::AUTOSTATIMG_TYPE_KEY, WxCasCte::DEFAULT_AUTOSTATIMG_TYPE)
 				.Lower());
 
-		// If img doenst exist, return
 		if (!fileName.FileExists(fileName.GetFullPath())) {
 			wxLogError("Image file " + fileName.GetFullPath() + " doesn't exist");
 			return;
 		}
 
-		// Connect to ftp
 		wxFTP ftp;
 
 		ftp.SetUser(prefs->Read(WxCasCte::FTP_USER_KEY, WxCasCte::DEFAULT_FTP_USER));
@@ -454,7 +416,6 @@ void WxCasFrame::OnFtpUpdateTimer(wxTimerEvent &WXUNUSED(event))
 			return;
 		}
 
-		// Chdir
 		if (!ftp.ChDir(prefs->Read(WxCasCte::FTP_PATH_KEY, WxCasCte::DEFAULT_FTP_PATH))) {
 			wxLogError("Cannot chdir to " +
 				   prefs->Read(WxCasCte::FTP_PATH_KEY, WxCasCte::DEFAULT_FTP_PATH));
@@ -462,7 +423,6 @@ void WxCasFrame::OnFtpUpdateTimer(wxTimerEvent &WXUNUSED(event))
 			return;
 		}
 
-		// Upload image
 		ftp.SetBinary();
 		wxFileInputStream in(fileName.GetFullPath());
 		if (in.Ok()) {
@@ -477,19 +437,16 @@ void WxCasFrame::OnFtpUpdateTimer(wxTimerEvent &WXUNUSED(event))
 			wxLogError("Cannot open file stream to read image file");
 		}
 
-		// Close connexion
 		ftp.Close();
 	}
 }
 
-// Reset wxcas session hit
 void WxCasFrame::OnHitButton(wxCommandEvent &WXUNUSED(event))
 {
 	m_aMuleSig->ResetSessionMaxDL();
 	UpdateStatsPanel();
 }
 
-// Reset wxcas absolute hit
 void WxCasFrame::OnAbsHitButton(wxCommandEvent &WXUNUSED(event))
 {
 	m_aMuleSig->ResetAbsoluteMaxDL();

--- a/src/utils/wxCas/src/wxcasprefs.cpp
+++ b/src/utils/wxCas/src/wxcasprefs.cpp
@@ -34,17 +34,13 @@
 #include "wxcascte.h"
 #include "wxcasframe.h"
 
-// Constructor
 WxCasPrefs::WxCasPrefs(wxWindow *parent)
 : wxDialog(parent, -1, wxString(_("Preferences")))
 {
-	// Prefs
 	wxConfigBase *prefs = wxConfigBase::Get();
 
-	// Main vertical Sizer
 	m_mainVBox = new wxBoxSizer(wxVERTICAL);
 
-	// OS Path
 	m_osPathSBox = new wxStaticBox(this, -1, _("Directory containing amulesig.dat file"));
 	m_osPathSBoxSizer = new wxStaticBoxSizer(m_osPathSBox, wxHORIZONTAL);
 
@@ -55,7 +51,6 @@ WxCasPrefs::WxCasPrefs(wxWindow *parent)
 
 	prefs->Read(WxCasCte::AMULESIG_PATH_KEY, &str, WxCasCte::DEFAULT_AMULESIG_PATH);
 
-	// Text extent
 	wxInt32 charExtent, y;
 	m_osPathTextCtrl->GetTextExtent("8", &charExtent, &y);
 	m_osPathTextCtrl->SetSize(wxSize(charExtent * (str.Length() + 1), -1));
@@ -68,7 +63,6 @@ WxCasPrefs::WxCasPrefs(wxWindow *parent)
 
 	m_mainVBox->Add(m_osPathSBoxSizer, wxSizerFlags().Expand().Center().Border(wxALL, 10));
 
-	// Refresh rate
 	m_refreshSBox = new wxStaticBox(this, -1, "");
 	m_refreshSBoxSizer = new wxStaticBoxSizer(m_refreshSBox, wxHORIZONTAL);
 
@@ -87,7 +81,6 @@ WxCasPrefs::WxCasPrefs(wxWindow *parent)
 
 	m_mainVBox->Add(m_refreshSBoxSizer, wxSizerFlags().Expand().Center().Border(wxALL, 10));
 
-	// Auto generate stat image
 	m_autoStatImgSBox = new wxStaticBox(this, -1, "");
 	m_autoStatImgSBoxSizer = new wxStaticBoxSizer(m_autoStatImgSBox, wxVERTICAL);
 
@@ -126,33 +119,27 @@ WxCasPrefs::WxCasPrefs(wxWindow *parent)
 
 	m_mainVBox->Add(m_autoStatImgSBoxSizer, wxSizerFlags().Expand().Center().Border(wxALL, 5));
 
-	// Auto FTP update stat image
 	m_ftpUpdateSBox = new wxStaticBox(this, -1, "");
 	m_ftpUpdateSBoxSizer = new wxStaticBoxSizer(m_ftpUpdateSBox, wxVERTICAL);
 
-	// Check
 	m_ftpUpdateCheck = new wxCheckBox(
 		this, ID_FTP_UPDATE_CHECK, _("Upload periodically your stat image to FTP server"));
 	m_ftpUpdateSBoxSizer->Add(
 		m_ftpUpdateCheck, wxSizerFlags().Expand().CenterVertical().Border(wxALL, 5));
 
-	// Grid size
 	m_ftpUpdateGridSizer = new wxGridSizer(2);
 
-	// FTP Static text
 	m_ftpUrlStaticText = new wxStaticText(this, -1, _("FTP Url"));
 	m_ftpUpdateGridSizer->Add(m_ftpUrlStaticText, wxSizerFlags(1).Bottom().Border(wxALL, 5));
 
 	m_ftpPathStaticText = new wxStaticText(this, -1, _("FTP Path"));
 	m_ftpUpdateGridSizer->Add(m_ftpPathStaticText, wxSizerFlags(1).Bottom().Border(wxALL, 5));
-	// Url
 	m_ftpUrlTextCtrl = new wxTextCtrl(this, -1, "");
 	m_ftpUrlTextCtrl->SetValue(prefs->Read(WxCasCte::FTP_URL_KEY, WxCasCte::DEFAULT_FTP_URL));
 	m_ftpUrlTextCtrl->SetToolTip(_("Enter here the URL of your FTP server"));
 
 	m_ftpUpdateGridSizer->Add(m_ftpUrlTextCtrl, wxSizerFlags(1).Expand().Border(wxALL, 5));
 
-	// Path
 	m_ftpPathTextCtrl = new wxTextCtrl(this, -1, "");
 	m_ftpPathTextCtrl->SetValue(prefs->Read(WxCasCte::FTP_PATH_KEY, WxCasCte::DEFAULT_FTP_PATH));
 	m_ftpPathTextCtrl->SetToolTip(
@@ -160,32 +147,27 @@ WxCasPrefs::WxCasPrefs(wxWindow *parent)
 
 	m_ftpUpdateGridSizer->Add(m_ftpPathTextCtrl, wxSizerFlags(1).Expand().Border(wxALL, 5));
 
-	// Login Static text
 	m_ftpUserStaticText = new wxStaticText(this, -1, _("User"));
 	m_ftpUpdateGridSizer->Add(m_ftpUserStaticText, wxSizerFlags(1).Bottom().Border(wxALL, 5));
 
 	m_ftpPasswdStaticText = new wxStaticText(this, -1, _("Password"));
 	m_ftpUpdateGridSizer->Add(m_ftpPasswdStaticText, wxSizerFlags(1).Bottom().Border(wxALL, 5));
 
-	// User
 	m_ftpUserTextCtrl = new wxTextCtrl(this, -1, "");
 	m_ftpUserTextCtrl->SetValue(prefs->Read(WxCasCte::FTP_USER_KEY, WxCasCte::DEFAULT_FTP_USER));
 	m_ftpUserTextCtrl->SetToolTip(_("Enter here the User name to log into your FTP server"));
 
 	m_ftpUpdateGridSizer->Add(m_ftpUserTextCtrl, wxSizerFlags(1).Expand().Border(wxALL, 5));
 
-	// Passwd
 	m_ftpPasswdTextCtrl = new wxTextCtrl(this, -1, "", wxDefaultPosition, wxDefaultSize, wxTE_PASSWORD);
 	m_ftpPasswdTextCtrl->SetValue(prefs->Read(WxCasCte::FTP_PASSWD_KEY, WxCasCte::DEFAULT_FTP_PASSWD));
 	m_ftpPasswdTextCtrl->SetToolTip(_("Enter here the User password to log into your FTP server"));
 
 	m_ftpUpdateGridSizer->Add(m_ftpPasswdTextCtrl, wxSizerFlags(1).Expand().Border(wxALL, 5));
 
-	// Add to static sizer
 	m_ftpUpdateSBoxSizer->Add(
 		m_ftpUpdateGridSizer, wxSizerFlags(1).Expand().CenterVertical().Border(wxALL, 5));
 
-	// Upload rate
 	m_ftpRateHBoxSizer = new wxBoxSizer(wxHORIZONTAL);
 	m_ftpUpdateSpinButton = new wxSpinCtrl(this, -1);
 	m_ftpUpdateSpinButton->SetRange(WxCasCte::MIN_FTP_RATE, WxCasCte::MAX_FTP_RATE);
@@ -203,10 +185,8 @@ WxCasPrefs::WxCasPrefs(wxWindow *parent)
 	m_ftpUpdateSBoxSizer->Add(
 		m_ftpRateHBoxSizer, wxSizerFlags().Expand().CenterVertical().Border(wxALL, 5));
 
-	// Add to main sizer
 	m_mainVBox->Add(m_ftpUpdateSBoxSizer, wxSizerFlags().Expand().Center().Border(wxALL, 5));
 
-	// Mask auto stat img disabled controls
 	if (prefs->Read(WxCasCte::ENABLE_AUTOSTATIMG_KEY, WxCasCte::DEFAULT_AUTOSTATIMG_ISENABLED)) {
 		m_autoStatImgCheck->SetValue(TRUE);
 	} else {
@@ -217,7 +197,6 @@ WxCasPrefs::WxCasPrefs(wxWindow *parent)
 		EnableFtpUpdateCtrls(FALSE);
 	}
 
-	// Mask Ftp update disabled controls
 	if (prefs->Read(WxCasCte::ENABLE_FTP_UPDATE_KEY, WxCasCte::DEFAULT_FTP_UPDATE_ISENABLED)) {
 		m_ftpUpdateCheck->SetValue(TRUE);
 	} else {
@@ -225,11 +204,9 @@ WxCasPrefs::WxCasPrefs(wxWindow *parent)
 		EnableFtpUpdateCtrls(FALSE);
 	}
 
-	// Separator line
 	m_staticLine = new wxStaticLine(this, -1);
 	m_mainVBox->Add(m_staticLine, wxSizerFlags().Expand().Center().Border(wxALL, 0));
 
-	// Button bar
 	m_buttonHBox = new wxBoxSizer(wxHORIZONTAL);
 	m_validateButton = new wxButton(this, ID_VALIDATE_BUTTON, wxString(_("Validate")));
 	m_cancelButton = new wxButton(this, wxID_CANCEL, wxString(_("Cancel")));
@@ -239,7 +216,6 @@ WxCasPrefs::WxCasPrefs(wxWindow *parent)
 
 	m_mainVBox->Add(m_buttonHBox, wxSizerFlags().Center().Border(wxALL, 10));
 
-	// Layout
 	SetAutoLayout(TRUE);
 	SetSizerAndFit(m_mainVBox);
 
@@ -247,7 +223,6 @@ WxCasPrefs::WxCasPrefs(wxWindow *parent)
 	m_validateButton->SetDefault();
 }
 
-// Destructor
 WxCasPrefs::~WxCasPrefs() {}
 
 // Events table


### PR DESCRIPTION
Comment-only sweep of `src/utils`: 6 files, 512 -> 383 comment lines (-129, -25.2%). Figures are over the touched files only; licence headers are untouched and form a floor in every count.

Part of a tree-wide pass split by scope. The scopes touch disjoint files, so this one merges independently of the others.

**What came out**

- Pure narration in the wxCas and aLinkCreator GUIs: `// Constructor`, `// Destructor`, `// Status Bar`, `// Button bar`, one per widget, each restating the line beneath it.

**What stayed**

Anything recording something the code cannot tell you by itself: a protocol constraint, a wire-format rule, a platform quirk, the reason a guard exists, the why behind a non-obvious default.

**Verification**

- Every file mechanically checked comment-only: comments stripped and whitespace normalised on both sides, then diffed against master. 6/6 identical, so no code changes.
- clang-format 18, the version CI pins, clean over all of `src/` and `unittests/`.
- Builds clean on macOS. Nothing here changes code, so the build cannot differ per scope.

**Reviewing**

`git diff master -w` is the whole change; there is no code to read.
