### PR TITLE
chore(webserver): trim verbose comment blocks

### DIFF
--- a/src/webserver/src/WebInterface.cpp
+++ b/src/webserver/src/WebInterface.cpp
@@ -198,13 +198,11 @@ bool CamulewebApp::GetTemplateDir(const wxString &templateName, wxString &templa
 
 	dir = wxStandardPaths::Get().GetResourcesDir(); // Returns 'aMule' when we use 'amule' elsewhere
 #if defined(__WINDOWS__)
-	// Windows portable / installed layout puts amule.exe (and
-	// amuleweb.exe) in bin\ and installable data (webserver
-	// templates, skins, ...) in ..\share\amule\. wxStandardPaths
-	// returns the exe directory on Windows, so relocate up one
-	// level and into the FHS-style share/amule/ tree the installer
-	// actually populates. Mirrors the same adjustment Preferences.cpp
-	// applies for the skins lookup (#783). (#828)
+	// The Windows portable / installed layout puts amule.exe and amuleweb.exe in
+	// bin\ and installable data in ..\share\amule\. wxStandardPaths returns the exe
+	// directory there, so relocate up one level and into the FHS-style share/amule/
+	// tree the installer populates -- the same adjustment Preferences.cpp makes for
+	// the skins lookup (#783, #828).
 	dir = JoinPaths(JoinPaths(dir, ".."), "share");
 	dir = JoinPaths(dir, "amule");
 #elif !defined(__WXMAC__)
@@ -313,12 +311,10 @@ bool CamulewebApp::OnCmdLineParsed(wxCmdLineParser &parser)
 		m_KeepQuiet = true;
 		m_LoadSettingsFromAmule = true;
 
-		// m_configDir is normally set by CaMuleExternalConnector::
-		// OnCmdLineParsed, which this early-return branch skips. Leaving
-		// it empty made GetTemplateDir look for "webserver" relative to
-		// the CWD, so the per-user template dir (<config>/webserver/) was
-		// never found when amuleweb was spawned by the aMule GUI. Derive
-		// it from the config file we were handed instead.
+		// m_configDir is normally set by CaMuleExternalConnector::OnCmdLineParsed,
+		// which this early-return branch skips. Left empty, GetTemplateDir looked for
+		// "webserver" relative to the CWD, so the per-user template dir was never
+		// found when amuleweb was spawned by the aMule GUI.
 		m_configDir = wxFileName(aMuleConfigFile).GetPathWithSep();
 
 		if (!(m_TemplateOk = GetTemplateDir(m_TemplateName, m_TemplateDir))) {

--- a/src/webserver/src/WebServer.cpp
+++ b/src/webserver/src/WebServer.cpp
@@ -584,12 +584,10 @@ int CWebServerBase::GzipCompress(
 		0 /*xflags*/,
 		255);
 
-	// wire buffers
 	stream.next_in = const_cast<Bytef *>(source);
 	stream.avail_in = (uInt)sourceLen;
 	stream.next_out = ((Bytef *)dest) + 10;
 	stream.avail_out = *destLen - 18;
-	// doit
 	err = deflate(&stream, Z_FINISH);
 	if (err != Z_STREAM_END) {
 		deflateEnd(&stream);
@@ -597,17 +595,14 @@ int CWebServerBase::GzipCompress(
 	}
 	err = deflateEnd(&stream);
 	crc = crc32(crc, (const Bytef *)source, sourceLen);
-	// CRC
 	*(((Bytef *)dest) + 10 + stream.total_out) = (Bytef)(crc & 0xFF);
 	*(((Bytef *)dest) + 10 + stream.total_out + 1) = (Bytef)((crc >> 8) & 0xFF);
 	*(((Bytef *)dest) + 10 + stream.total_out + 2) = (Bytef)((crc >> 16) & 0xFF);
 	*(((Bytef *)dest) + 10 + stream.total_out + 3) = (Bytef)((crc >> 24) & 0xFF);
-	// Length
 	*(((Bytef *)dest) + 10 + stream.total_out + 4) = (Bytef)(sourceLen & 0xFF);
 	*(((Bytef *)dest) + 10 + stream.total_out + 5) = (Bytef)((sourceLen >> 8) & 0xFF);
 	*(((Bytef *)dest) + 10 + stream.total_out + 6) = (Bytef)((sourceLen >> 16) & 0xFF);
 	*(((Bytef *)dest) + 10 + stream.total_out + 7) = (Bytef)((sourceLen >> 24) & 0xFF);
-	// return  destLength
 	*destLen = 10 + stream.total_out + 8;
 
 	return err;
@@ -1043,22 +1038,16 @@ CProgressImage::~CProgressImage()
 
 void CProgressImage::CreateSpan()
 {
-	// Step 1: get gap list.  Use .data() rather than &m_Gaps[0] so the
-	// pointer is well-defined when the vector is empty (no gaps yet on
-	// a fresh partfile, or all gaps closed on a just-completed file).
-	// libstdc++ debug-mode catches the operator[]-on-empty case as a
-	// libstdc++ assertion -> SIGABRT; release builds previously got away
-	// with undefined behaviour.  The loop below is already bounded by
-	// gap_list_size, so when the vector is empty the pointer is never
-	// dereferenced.
+	// Step 1: get gap list. .data() rather than &m_Gaps[0], so the pointer is
+	// well-defined when the vector is empty -- no gaps yet on a fresh partfile, or
+	// all gaps closed on a just-completed one -- which libstdc++ debug mode
+	// otherwise catches as an assertion and SIGABRT. The loop below is bounded by
+	// gap_list_size, so an empty vector's pointer is never dereferenced.
 	const Gap_Struct *gap_list = (const Gap_Struct *)m_file->m_Gaps.data();
 	int gap_list_size = m_file->m_Gaps.size() / 2;
 
-	// allocate for worst case !
 	int color_gaps_alloc = 2 * (2 * gap_list_size + m_file->lFileSize / PARTSIZE + 1);
 	Color_Gap_Struct *colored_gaps = new Color_Gap_Struct[color_gaps_alloc];
-
-	// Step 2: combine gap and part status information
 
 	// Init first item to dummy info, so we will always have "previous" item
 	int colored_gaps_size = 0;
@@ -1125,7 +1114,6 @@ void CProgressImage::CreateSpan()
 				m_ColorLine[j] = colored_gaps[i].color;
 			}
 		}
-		// overwrite requested parts
 		for (uint32 i = 0; i < m_file->m_ReqParts.size(); i++) {
 			uint32 start = m_file->m_ReqParts[i].start / factor;
 			uint32 end = m_file->m_ReqParts[i].end / factor;
@@ -1177,7 +1165,6 @@ void CDynPngImage::png_write_fn(png_structp png_ptr, png_bytep data, png_size_t 
 
 unsigned char *CDynPngImage::RequestData(int &size)
 {
-	// write png into buffer
 	png_structp png_ptr = png_create_write_struct(PNG_LIBPNG_VER_STRING, 0, 0, 0);
 	png_infop info_ptr = png_create_info_struct(png_ptr);
 	png_set_IHDR(png_ptr,
@@ -1236,7 +1223,6 @@ void CDynProgressImage::DrawImage()
 
 unsigned char *CDynProgressImage::RequestData(int &size)
 {
-	// create new one
 	DrawImage();
 
 	return CDynPngImage::RequestData(size);

--- a/src/webserver/src/WebServer.h
+++ b/src/webserver/src/WebServer.h
@@ -56,12 +56,10 @@
 class CWebSocket;
 class CMD4Hash;
 
-// Idle window after which a CSession entry is dropped and the user is
-// asked to log in again. Has been a hardcoded 7200 (2 hours) in
-// CScriptWebServer::CheckLoggedin since forever; the named constant
-// existed but was never wired up (set to 300, but no `7200`-using site
-// referenced it). Keep the live behaviour (2 hours) and have the
-// macro own the value so the timeout can be changed in one place.
+// Idle window after which a CSession entry is dropped and the user is asked to
+// log in again. CheckLoggedin has hardcoded 7200 (2 hours) since forever, while
+// the named constant existed and was never wired up. The macro now owns the
+// value, so the timeout can be changed in one place.
 #define SESSION_TIMEOUT_SECS 7200 // 2 hours session expiration
 #define SHORT_FILENAME_LENGTH 40  // Max size of file name.
 

--- a/src/webserver/src/WebSocket.cpp
+++ b/src/webserver/src/WebSocket.cpp
@@ -62,15 +62,11 @@ CWebSocket::CWebSocket(CWebServerBase *parent)
 {
 	m_pHead = 0;
 	m_pTail = 0;
-	// Allocate one extra slot so the NUL terminator at the end of
-	// OnReceive() always has a home, even if Read() exactly fills the
-	// requested span and the grow loop is skipped (the off-by-one
-	// scenario in #873: first Read returns m_dwBufSize bytes AND
-	// LastError() is set, leaving m_dwRecv == m_dwBufSize when the
-	// loop exits). The allocation is +1 byte; m_dwBufSize keeps
-	// reflecting the *usable* span we hand to Read() so the
-	// `m_dwBufSize - m_dwRecv` reads below still leave the spare slot
-	// free for the terminator.
+	// Allocate one extra slot so the NUL terminator at the end of OnReceive()
+	// always has a home, even if Read() exactly fills the requested span and the
+	// grow loop is skipped (the off-by-one in #873). m_dwBufSize keeps reflecting
+	// the USABLE span handed to Read(), so the `m_dwBufSize - m_dwRecv` reads below
+	// still leave the spare slot free.
 	m_pBuf = new char[4096 + 1];
 	m_IsGet = false;
 	m_IsPost = false;

--- a/src/webserver/src/php_syntree.cpp
+++ b/src/webserver/src/php_syntree.cpp
@@ -169,7 +169,6 @@ PHP_EXP_NODE *make_func_param(PHP_EXP_NODE *list, PHP_EXP_NODE *var_exp_node, ch
 
 	param->si_var = var_exp_node->var_si_node;
 	param->si_var->type = PHP_SCOPE_PARAM;
-	// printf("mark %p->%p as param\n", param->si_var, param->si_var->var);
 
 	param->var = param->si_var->var;
 
@@ -423,8 +422,6 @@ void func_scope_init(PHP_FUNC_PARAM_DEF *params,
 	for (PHP_SCOPE_TABLE_TYPE::iterator i = curr_scope_map->begin(); i != curr_scope_map->end(); ++i) {
 		if ((i->second->type == PHP_SCOPE_VAR) || (i->second->type == PHP_SCOPE_PARAM)) {
 			if (!(i->second->var->flags & PHP_VARFLAG_STATIC)) {
-				// printf("Saving %s = %p->%p\n", i->first.c_str(), i->second,
-				// i->second->var);
 				saved_vars[i->first] = i->second->var;
 			}
 		}
@@ -445,7 +442,6 @@ void func_scope_init(PHP_FUNC_PARAM_DEF *params,
 			} else {
 				call_params[i] = make_var_node();
 				call_params[i]->ref_count = 1;
-				// printf("alloc var for callparam %d -> %p\n", i, call_params[i]);
 				php_expr_eval(
 					(PHP_EXP_NODE *)curr_arg_val->value.ptr_val, &call_params[i]->value);
 			}
@@ -459,8 +455,6 @@ void func_scope_init(PHP_FUNC_PARAM_DEF *params,
 	//
 	// Step 3: assign new values to call parameters
 	for (int i = 0; i < param_count; i++) {
-		// printf("assign new param si=%p var=%p -> %p\n", params[i].si_var, params[i].si_var->var,
-		// call_params[i]);
 		params[i].si_var->var = call_params[i];
 	}
 
@@ -470,11 +464,7 @@ void func_scope_init(PHP_FUNC_PARAM_DEF *params,
 		if (!((i->second->type == PHP_SCOPE_PARAM) || (i->second->type == PHP_SCOPE_VAR))) {
 			continue;
 		}
-		// printf("in scope: %p %s [ %s ] with flags %02x\n", i->second, i->second->type ==
-		// PHP_SCOPE_PARAM ? "param" : "var", 	i->first.c_str(), i->second->var->flags);
 		if (!(i->second->var->flags & PHP_VARFLAG_STATIC) && (i->second->type != PHP_SCOPE_PARAM)) {
-			// printf("alloc new for %s [ %p->%p ]\n", i->first.c_str(), i->second,
-			// i->second->var);
 			i->second->var = make_var_node();
 			i->second->var->ref_count = 1;
 		}
@@ -503,7 +493,6 @@ static void func_scope_copy_back(PHP_FUNC_PARAM_DEF *params,
 	for (int i = 0; i < param_count; i++) {
 		PHP_VAR_NODE *curr_arg_val = array_get_by_int_key(arg_array, i);
 		if (!((curr_arg_val->flags & PHP_VARFLAG_BYREF) || params[i].byref)) {
-			// printf("Delete param %d %p->%p\n", i, params[i].si_var, params[i].si_var->var);
 			call_params[call_param_2free_count++] = params[i].si_var->var;
 		}
 		params[i].si_var->var = params[i].var;
@@ -513,8 +502,6 @@ static void func_scope_copy_back(PHP_FUNC_PARAM_DEF *params,
 	for (PHP_SCOPE_TABLE_TYPE::iterator i = curr_scope_map->begin(); i != curr_scope_map->end(); ++i) {
 		if ((i->second->type == PHP_SCOPE_VAR) || (i->second->type == PHP_SCOPE_PARAM)) {
 			if (!(i->second->var->flags & PHP_VARFLAG_STATIC)) {
-				// printf("Restoring %s = %p->%p\n", i->first.c_str(), i->second,
-				// i->second->var); assert(saved_vars[i->first]);
 				if (i->second->type == PHP_SCOPE_VAR) {
 					value_value_free(&i->second->var->value);
 					delete i->second->var;
@@ -565,7 +552,6 @@ void delete_scope_table(PHP_SCOPE_TABLE scope)
 		case PHP_SCOPE_PARAM:
 			// break;
 		case PHP_SCOPE_VAR: {
-			// printf("removing %s\n", i->first.c_str());
 			PHP_VAR_NODE *var = i->second->var;
 			var_node_free(var);
 		} break;


### PR DESCRIPTION
Comment-only sweep of `src/webserver`: 5 files, 694 -> 657 comment lines (-37, -5.3%). Figures are over the touched files only; licence headers are untouched and form a floor in every count.

Part of a tree-wide pass split by scope. The scopes touch disjoint files, so this one merges independently of the others.

**What came out**

- Commented-out `printf` debugging in `php_syntree.cpp`.
- Long restatements in `WebServer.cpp` and `WebInterface.cpp`.

**What stayed**

Anything recording something the code cannot tell you by itself: a protocol constraint, a wire-format rule, a platform quirk, the reason a guard exists, the why behind a non-obvious default.

**Verification**

- Every file mechanically checked comment-only: comments stripped and whitespace normalised on both sides, then diffed against master. 5/5 identical, so no code changes.
- clang-format 18, the version CI pins, clean over all of `src/` and `unittests/`.
- Builds clean on macOS. Nothing here changes code, so the build cannot differ per scope.

**Reviewing**

`git diff master -w` is the whole change; there is no code to read.
