### PR TITLE
fix(core): stop reporting a Kad bootstrap as "Kad stopped."

### DIFF
--- a/src/amule.cpp
+++ b/src/amule.cpp
@@ -3085,13 +3085,21 @@ void CamuleApp::ShowConnectionState(bool forceUpdate)
 			}
 		}
 
-		if (changed_flags & CONNECTED_KAD_NOT) {
-			// cppcheck-suppress duplicateBranch
-			if (state & CONNECTED_KAD_NOT) {
-				AddLogLineC(_("Kad started."));
-			} else {
-				AddLogLineC(_("Kad stopped."));
-			}
+		// Kad's three flags together mean "running"; CONNECTED_KAD_NOT alone
+		// means "running, but no contact yet". Keying these two messages on
+		// that single flag mislabelled both edges of it: finishing the
+		// bootstrap clears it and printed "Kad stopped.", losing contact sets
+		// it and printed "Kad started." A bug reporter read the first as a
+		// start/stop flap on startup and built a diagnosis on it, when the
+		// daemon was only connecting (amule-org/amule#1369). What this pair
+		// is about is whether Kad is running, so test that; the block below
+		// reports the connected edge on its own.
+		const uint8 kad_running_flags =
+			CONNECTED_KAD_NOT | CONNECTED_KAD_OK | CONNECTED_KAD_FIREWALLED;
+		const bool kad_was_running = (old_state & kad_running_flags) != 0;
+		const bool kad_is_running = (state & kad_running_flags) != 0;
+		if (kad_was_running != kad_is_running) {
+			AddLogLineC(kad_is_running ? _("Kad started.") : _("Kad stopped."));
 		}
 
 		if (changed_flags & (CONNECTED_KAD_OK | CONNECTED_KAD_FIREWALLED)) {


### PR DESCRIPTION
`CONNECTED_KAD_NOT` means "Kad is running but has no contact yet", not "Kad is off". `ShowConnectionState` keyed the started/stopped pair on that single flag, so **both** of its edges were mislabelled: finishing the bootstrap clears it and printed "Kad stopped.", and losing contact while still running sets it and printed "Kad started.".

On a normal daemon startup the log therefore reads:

```
10:58:24  amule.cpp(3091): Kad started.
10:58:25  amule.cpp(3093): Kad stopped.
10:58:25  amule.cpp(3103): Connected to Kad (firewalled)
```

which looks like a start/stop flap one second after startup. It is a healthy daemon connecting.

That cost a bug reporter real work. The diagnosis in #1369 is built on a flap that never happened, and the "only consistent correlate" it identifies occurs identically in the runs that do **not** crash, which the reporter's own workaround log shows without either of us noticing at first.

What these two messages are about is whether Kad is running, which is any of the three flags being set, so test that instead. The connected edge is already reported on its own by the block immediately below.

## Verification

Against a live Kad bootstrap on the same machine and config, daemon only:

| | log |
|---|---|
| master | `Kad started.` / `Kad stopped.` / `Connected to Kad (firewalled)` |
| this PR | `Kad started.` / `Connected to Kad (firewalled)` |

The control run reproduces the reporter's `3189`/`3191` pair exactly (line numbers differ between their commit and master), confirming it is a logging artefact rather than anything their daemon did.

No catalog work: no msgid changes, only which existing string is emitted. clang-format and both clang-tidy tiers clean on the diff.

This does not address the SIGSEGV in #1369, which is still open and unexplained. It removes the false lead.
