### PR TITLE
feat(net): add the transport that drives one uTP socket

### DIFF
--- a/src/EMSocket.cpp
+++ b/src/EMSocket.cpp
@@ -641,6 +641,18 @@ SocketSentBytes CEMSocket::Send(
 					// between Write() returning and BlocksWrite() being read.
 					// A clean end is not an error, so leave without claiming
 					// one and let the lost notification tear the socket down.
+					//
+					// Inert until the acceptor routes this call. IsOk() is not
+					// virtual anywhere in CLibSocket, CEncryptedStreamSocket or
+					// here, so it resolves statically to CLibSocket::IsOk(),
+					// whose m_OK is true for the whole life of a connected
+					// socket: this arm cannot fire for CClientTCPSocket or
+					// CServerSocket, which is why adding it changes nothing
+					// today. The uTP transport answers the same question on
+					// IStreamTransport, a separate hierarchy, so whatever wires
+					// a transport into CEMSocket must route IsOk() to it as
+					// well. Miss that and the arm stays dead after wiring, and
+					// the spin it exists to stop comes back silently.
 					m_bBusy = false;
 					streamIsGone = true;
 					break;

--- a/src/EMSocket.cpp
+++ b/src/EMSocket.cpp
@@ -630,13 +630,17 @@ SocketSentBytes CEMSocket::Send(
 				} else if (LastError()) {
 					// Send() gave an error
 					anErrorHasOccured = true;
-				} else if (result == 0) {
-					// Took nothing, is not blocked and reports no error: the
-					// stream is gone. Nothing here advances on a retry, so
-					// without this arm the loop spins at full speed on the
-					// upload thread while holding m_sendLocker. A clean end is
-					// not an error, so leave the loop without claiming one and
-					// let the socket's own lost notification tear it down.
+				} else if (!IsOk()) {
+					// The stream is gone. A transport whose stream can end
+					// cleanly returns 0 here while blocked and error are both
+					// clear, and nothing in this loop advances on a retry, so
+					// without this arm it spins at full speed on the upload
+					// thread while holding m_sendLocker. Asked rather than
+					// inferred from that triple, because a healthy asio socket
+					// can show it for an instant if its send completion lands
+					// between Write() returning and BlocksWrite() being read.
+					// A clean end is not an error, so leave without claiming
+					// one and let the lost notification tear the socket down.
 					m_bBusy = false;
 					streamIsGone = true;
 					break;

--- a/src/EMSocket.cpp
+++ b/src/EMSocket.cpp
@@ -444,6 +444,9 @@ SocketSentBytes CEMSocket::Send(
 	}
 
 	bool anErrorHasOccured = false;
+	// A stream that ended cleanly. Stops the loops like an error does, but is
+	// not one: the socket's own lost notification drives the disconnect.
+	bool streamIsGone = false;
 	uint32 sentStandardPacketBytesThisCall = 0;
 	uint32 sentControlPacketBytesThisCall = 0;
 
@@ -465,6 +468,7 @@ SocketSentBytes CEMSocket::Send(
 				maxNumberOfBytesToSend &&
 			anErrorHasOccured == false && // don't send more than allowed. Also, there should have
 						      // been no error in earlier loop
+			streamIsGone == false &&
 			(!m_control_queue.empty() || !m_standard_queue.empty() ||
 				sendbuffer != NULL) &&              // there must exist something to send
 			(onlyAllowedToSendControlPacket == false || // this means we are allowed to send both
@@ -551,7 +555,7 @@ SocketSentBytes CEMSocket::Send(
 					(sentStandardPacketBytesThisCall + sentControlPacketBytesThisCall) %
 							minFragSize !=
 						0) &&
-				anErrorHasOccured == false) {
+				anErrorHasOccured == false && streamIsGone == false) {
 				uint32 tosend = sendblen - sent;
 				if (!onlyAllowedToSendControlPacket || m_currentPacket_is_controlpacket) {
 					if (maxNumberOfBytesToSend >=
@@ -626,6 +630,16 @@ SocketSentBytes CEMSocket::Send(
 				} else if (LastError()) {
 					// Send() gave an error
 					anErrorHasOccured = true;
+				} else if (result == 0) {
+					// Took nothing, is not blocked and reports no error: the
+					// stream is gone. Nothing here advances on a retry, so
+					// without this arm the loop spins at full speed on the
+					// upload thread while holding m_sendLocker. A clean end is
+					// not an error, so leave the loop without claiming one and
+					// let the socket's own lost notification tear it down.
+					m_bBusy = false;
+					streamIsGone = true;
+					break;
 				} else {
 					m_bBusy = false;
 				}

--- a/src/UtpSocketTransport.h
+++ b/src/UtpSocketTransport.h
@@ -1,0 +1,264 @@
+//
+// This file is part of the aMule Project.
+//
+// Copyright (c) 2003-2026 aMule Team ( https://amule-org.github.io )
+//
+// Any parts of this program derived from the xMule, lMule or eMule project,
+// or contributed by third-party developers are copyrighted by their
+// respective authors.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301, USA
+//
+
+#ifndef UTPSOCKETTRANSPORT_H
+#define UTPSOCKETTRANSPORT_H
+
+#include "StreamTransport.h"
+#include "UtpStream.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+/**
+ * The per-socket libutp calls a transport makes, behind a seam.
+ *
+ * Only four, and they are the ones that must not be made from inside a libutp
+ * callback: each can re-enter, and utp_close() in particular can produce
+ * UTP_STATE_DESTROYING before it returns. Naming them here keeps the transport
+ * testable without the library, and keeps the re-entrancy rule in one place
+ * rather than repeated at every call.
+ *
+ * The handle is opaque on purpose: a utp_socket* never appears outside the
+ * adapter's translation unit, which is what stops <libutp/utp.h> reaching the
+ * rest of src/.
+ */
+class IUtpSocketOperations
+{
+public:
+	using Handle = void *;
+
+	virtual ~IUtpSocketOperations() = default;
+
+	//! Offers bytes. Returns how many were taken, which is routinely fewer.
+	virtual size_t WriteToSocket(Handle socket, const uint8_t *data, size_t length) = 0;
+
+	//! Tells libutp the application has caught up, so delivery may resume.
+	virtual void NotifyReadDrained(Handle socket) = 0;
+
+	//! utp_close(). Exactly one caller may ever make this call per socket.
+	virtual void CloseSocket(Handle socket) = 0;
+
+	//! Sets the receive-buffer size libutp advertises window against.
+	virtual void SetReceiveBuffer(Handle socket, size_t bytes) = 0;
+};
+
+/**
+ * What the layer above a stream is told, in the order it is told.
+ *
+ * Deliberately not the CoreNotify_LibSocket* macros: those take a CLibSocket*,
+ * which does not exist until something accepts a connection, and a transport
+ * that reaches for theApp is a transport that cannot be tested. The acceptor
+ * implements this by forwarding to those macros.
+ */
+class IStreamTransportEvents
+{
+public:
+	virtual ~IStreamTransportEvents() = default;
+
+	//! Bytes are readable.
+	virtual void OnStreamReadable() = 0;
+
+	//! The send window opened; a blocked writer may continue.
+	virtual void OnStreamWritable() = 0;
+
+	//! The stream ended, cleanly or otherwise. Ask the transport which.
+	virtual void OnStreamLost() = 0;
+};
+
+/**
+ * An IStreamTransport over one libutp socket.
+ *
+ * Main thread only for everything that touches libutp -- Flush(), Read()'s
+ * drained notification and Close(). Write() is the exception by necessity: it
+ * is reached from the upload bandwidth thread through CEMSocket, so it only
+ * queues into CUtpStream and the main thread hands those bytes to libutp on the
+ * next Flush(). That split is the whole reason the queue exists.
+ *
+ * Nothing constructs one of these yet.
+ */
+class CUtpSocketTransport final : public IStreamTransport
+{
+public:
+	CUtpSocketTransport(IUtpSocketOperations &operations,
+		IUtpSocketOperations::Handle socket,
+		const CNetworkAddress &peer,
+		uint16_t peerPort)
+	: m_operations(operations)
+	, m_socket(socket)
+	, m_peer(peer)
+	, m_peerPort(peerPort)
+	{
+	}
+
+	~CUtpSocketTransport() override { Close(); }
+
+	CUtpSocketTransport(const CUtpSocketTransport &) = delete;
+	CUtpSocketTransport &operator=(const CUtpSocketTransport &) = delete;
+
+	//! Applies the receive bound, which is what makes ReadBound() take effect.
+	void ApplyReceiveBound()
+	{
+		if (m_socket != nullptr) {
+			m_operations.SetReceiveBuffer(m_socket, m_stream.ReadBound());
+		}
+	}
+
+	// -- IStreamTransport ---------------------------------------------
+
+	bool IsConnected() const override { return m_connected && m_stream.IsOk(); }
+	bool IsOk() const override { return m_stream.IsOk(); }
+	bool BlocksRead() const override { return m_stream.BlocksRead(); }
+	bool BlocksWrite() const override { return m_stream.BlocksWrite(); }
+	int LastError() const override { return m_stream.LastError(); }
+	CNetworkAddress GetPeerAddress() const override { return m_peer; }
+	uint16_t GetPeerPort() const override { return m_peerPort; }
+
+	uint32_t Read(void *buffer, uint32_t length) override
+	{
+		const uint32_t taken = m_stream.Read(buffer, length);
+		// Owed only once the reader has emptied the buffer, and only to a
+		// socket that still exists: libutp stopped delivering while we were
+		// behind, and this is what resumes it.
+		if (m_stream.ConsumeReadDrainedEdge() && m_socket != nullptr) {
+			m_operations.NotifyReadDrained(m_socket);
+		}
+		return taken;
+	}
+
+	/**
+	 * Queues bytes. Reached from the upload bandwidth thread.
+	 *
+	 * Deliberately does not call libutp: that would be a library call from a
+	 * thread libutp knows nothing about, and utp_write() can produce callbacks.
+	 * The bytes leave on the next Flush().
+	 */
+	uint32_t Write(const void *buffer, uint32_t length) override
+	{
+		return m_stream.Write(buffer, length);
+	}
+
+	/**
+	 * Closes once, and never touches the handle again.
+	 *
+	 * The handle is the token: it is cleared before the call, so the
+	 * destructor, a second Close() and a DESTROYING callback all find nothing
+	 * to close. That one rule also covers every other call -- Flush() and the
+	 * drained notification check the same pointer -- which is why it is the
+	 * mechanism here rather than a separate flag that would have to be
+	 * consulted in each of them.
+	 */
+	void Close() override
+	{
+		if (m_socket == nullptr) {
+			return;
+		}
+		IUtpSocketOperations::Handle socket = m_socket;
+		m_socket = nullptr;
+		m_operations.CloseSocket(socket);
+	}
+
+	// -- main-thread pump ---------------------------------------------
+
+	/**
+	 * Offers queued bytes to libutp and keeps whatever it refused.
+	 *
+	 * utp_write() takes less than it is offered as soon as the congestion
+	 * window is full, and nothing while the socket is not yet connected, so
+	 * the accepted count is what may be dropped from the queue -- never the
+	 * whole of it.
+	 */
+	void Flush()
+	{
+		if (m_socket == nullptr || !m_stream.IsOk()) {
+			return;
+		}
+		const std::vector<uint8_t> pending = m_stream.PeekQueuedBytes();
+		if (pending.empty()) {
+			return;
+		}
+		const size_t accepted = m_operations.WriteToSocket(m_socket, pending.data(), pending.size());
+		m_stream.ConsumeQueuedBytes(accepted);
+	}
+
+	// -- libutp callbacks, translated ---------------------------------
+
+	void OnConnected(IStreamTransportEvents *events)
+	{
+		m_connected = true;
+		if (events != nullptr) {
+			events->OnStreamWritable();
+		}
+	}
+
+	void OnPayload(const uint8_t *data, size_t length, IStreamTransportEvents *events)
+	{
+		m_stream.OnPayload(data, length);
+		if (events != nullptr) {
+			events->OnStreamReadable();
+		}
+	}
+
+	void OnWritable(IStreamTransportEvents *events)
+	{
+		const bool wasBlocked = m_stream.BlocksWrite();
+		m_stream.OnWritable();
+		Flush();
+		if (wasBlocked && !m_stream.BlocksWrite() && events != nullptr) {
+			events->OnStreamWritable();
+		}
+	}
+
+	void OnEnded(EUtpTransportFailure failure, IStreamTransportEvents *events)
+	{
+		m_stream.OnFailure(failure);
+		m_connected = false;
+		if (failure == EUtpTransportFailure::Destroying) {
+			// The handle dies with this callback, so it must not be closed
+			// and must not be touched again. Clearing it is what stops the
+			// destructor, and everything else, from reaching for it.
+			m_socket = nullptr;
+		}
+		if (events != nullptr) {
+			events->OnStreamLost();
+		}
+	}
+
+	//! For the acceptor and for tests; never leaves the adapter otherwise.
+	IUtpSocketOperations::Handle SocketHandle() const { return m_socket; }
+
+	const CUtpStream &Stream() const { return m_stream; }
+
+private:
+	IUtpSocketOperations &m_operations;
+	IUtpSocketOperations::Handle m_socket;
+	CNetworkAddress m_peer;
+	uint16_t m_peerPort;
+	CUtpStream m_stream;
+	bool m_connected = false;
+};
+
+#endif // UTPSOCKETTRANSPORT_H
+// File_checked_for_headers

--- a/src/UtpSocketTransport.h
+++ b/src/UtpSocketTransport.h
@@ -28,8 +28,10 @@
 #include "StreamTransport.h"
 #include "UtpStream.h"
 
+#include <atomic>
 #include <cstddef>
 #include <cstdint>
+#include <mutex>
 #include <vector>
 
 /**
@@ -57,6 +59,16 @@ public:
 
 	//! Tells libutp the application has caught up, so delivery may resume.
 	virtual void NotifyReadDrained(Handle socket) = 0;
+
+	/**
+	 * Reports bytes buffered, for UTP_GET_READ_BUFFER_SIZE.
+	 *
+	 * Paired with SetReceiveBuffer() and useless without it: libutp advertises
+	 * opt_rcvbuf minus this number, and with the callback unset the subtracted
+	 * value is zero, so the window never shrinks. Setting the buffer alone
+	 * therefore lowers the ceiling without adding any backpressure.
+	 */
+	virtual void ReportReadBufferSize(Handle socket, size_t bytes) = 0;
 
 	//! utp_close(). Exactly one caller may ever make this call per socket.
 	virtual void CloseSocket(Handle socket) = 0;
@@ -86,6 +98,17 @@ public:
 
 	//! The stream ended, cleanly or otherwise. Ask the transport which.
 	virtual void OnStreamLost() = 0;
+
+	/**
+	 * Asks for Flush() to be called on the main thread.
+	 *
+	 * Raised from the upload bandwidth thread, so the implementation must
+	 * marshal -- MuleNotify::DoNotify clones a functor and delivers it to
+	 * wxTheApp, which is how the asio layer already crosses the same boundary.
+	 * Only the first queue-up since the last flush raises it, so the cost is
+	 * one event per idle-to-busy transition rather than one per write.
+	 */
+	virtual void OnFlushRequested() = 0;
 };
 
 /**
@@ -105,11 +128,13 @@ public:
 	CUtpSocketTransport(IUtpSocketOperations &operations,
 		IUtpSocketOperations::Handle socket,
 		const CNetworkAddress &peer,
-		uint16_t peerPort)
+		uint16_t peerPort,
+		IStreamTransportEvents *events = nullptr)
 	: m_operations(operations)
 	, m_socket(socket)
 	, m_peer(peer)
 	, m_peerPort(peerPort)
+	, m_events(events)
 	{
 	}
 
@@ -118,32 +143,78 @@ public:
 	CUtpSocketTransport(const CUtpSocketTransport &) = delete;
 	CUtpSocketTransport &operator=(const CUtpSocketTransport &) = delete;
 
-	//! Applies the receive bound, which is what makes ReadBound() take effect.
+	/**
+	 * Applies the receive bound and reports current occupancy against it.
+	 *
+	 * Both halves, always: libutp advertises opt_rcvbuf minus what the
+	 * read-buffer-size callback reports, so setting the buffer without
+	 * reporting occupancy pins the window at a constant 64 KiB -- a sixteenth
+	 * of libutp's default, with no backpressure gained, since the reported
+	 * subtrahend stays zero however far behind the reader falls.
+	 */
 	void ApplyReceiveBound()
 	{
+		std::lock_guard<std::mutex> lock(m_mutex);
 		if (m_socket != nullptr) {
 			m_operations.SetReceiveBuffer(m_socket, m_stream.ReadBound());
+			m_operations.ReportReadBufferSize(m_socket, m_stream.ReadBufferSize());
 		}
 	}
 
 	// -- IStreamTransport ---------------------------------------------
 
-	bool IsConnected() const override { return m_connected && m_stream.IsOk(); }
-	bool IsOk() const override { return m_stream.IsOk(); }
-	bool BlocksRead() const override { return m_stream.BlocksRead(); }
-	bool BlocksWrite() const override { return m_stream.BlocksWrite(); }
-	int LastError() const override { return m_stream.LastError(); }
+	// These are read from the upload bandwidth thread inside CEMSocket's send
+	// loop while the main thread's callbacks write them, so they take the lock
+	// like everything else that touches the stream.
+	bool IsConnected() const override
+	{
+		std::lock_guard<std::mutex> lock(m_mutex);
+		return m_connected && m_stream.IsOk();
+	}
+	bool IsOk() const override
+	{
+		std::lock_guard<std::mutex> lock(m_mutex);
+		return m_stream.IsOk();
+	}
+	bool BlocksRead() const override
+	{
+		std::lock_guard<std::mutex> lock(m_mutex);
+		return m_stream.BlocksRead();
+	}
+	bool BlocksWrite() const override
+	{
+		std::lock_guard<std::mutex> lock(m_mutex);
+		return m_stream.BlocksWrite();
+	}
+	int LastError() const override
+	{
+		std::lock_guard<std::mutex> lock(m_mutex);
+		return m_stream.LastError();
+	}
+	//! Fixed for the transport's lifetime, so it needs no lock.
 	CNetworkAddress GetPeerAddress() const override { return m_peer; }
 	uint16_t GetPeerPort() const override { return m_peerPort; }
 
 	uint32_t Read(void *buffer, uint32_t length) override
 	{
-		const uint32_t taken = m_stream.Read(buffer, length);
-		// Owed only once the reader has emptied the buffer, and only to a
-		// socket that still exists: libutp stopped delivering while we were
-		// behind, and this is what resumes it.
-		if (m_stream.ConsumeReadDrainedEdge() && m_socket != nullptr) {
-			m_operations.NotifyReadDrained(m_socket);
+		IUtpSocketOperations::Handle socket = nullptr;
+		uint32_t taken = 0;
+		size_t buffered = 0;
+		{
+			std::lock_guard<std::mutex> lock(m_mutex);
+			taken = m_stream.Read(buffer, length);
+			// Owed only once the reader has emptied the buffer, and only to
+			// a socket that still exists: libutp stopped delivering while we
+			// were behind, and this is what resumes it.
+			if (m_stream.ConsumeReadDrainedEdge()) {
+				socket = m_socket;
+			}
+			buffered = m_stream.ReadBufferSize();
+		}
+		if (socket != nullptr) {
+			// Outside the lock: these re-enter.
+			m_operations.ReportReadBufferSize(socket, buffered);
+			m_operations.NotifyReadDrained(socket);
 		}
 		return taken;
 	}
@@ -157,7 +228,20 @@ public:
 	 */
 	uint32_t Write(const void *buffer, uint32_t length) override
 	{
-		return m_stream.Write(buffer, length);
+		uint32_t taken = 0;
+		{
+			std::lock_guard<std::mutex> lock(m_mutex);
+			taken = m_stream.Write(buffer, length);
+		}
+		// Nothing else would flush these: the only other trigger is a full
+		// window reopening, and a queue filled while the window was never
+		// full has no such edge behind it. Raised on the idle-to-busy
+		// transition only, so a busy socket costs one event, not one per
+		// write.
+		if (taken != 0 && !m_flushPending.exchange(true) && m_events != nullptr) {
+			m_events->OnFlushRequested();
+		}
+		return taken;
 	}
 
 	/**
@@ -172,12 +256,17 @@ public:
 	 */
 	void Close() override
 	{
-		if (m_socket == nullptr) {
-			return;
+		IUtpSocketOperations::Handle socket = nullptr;
+		{
+			std::lock_guard<std::mutex> lock(m_mutex);
+			socket = m_socket;
+			m_socket = nullptr;
 		}
-		IUtpSocketOperations::Handle socket = m_socket;
-		m_socket = nullptr;
-		m_operations.CloseSocket(socket);
+		if (socket != nullptr) {
+			// Unlocked: utp_close() can produce UTP_STATE_DESTROYING before
+			// it returns, and that callback comes back through OnEnded().
+			m_operations.CloseSocket(socket);
+		}
 	}
 
 	// -- main-thread pump ---------------------------------------------
@@ -192,72 +281,126 @@ public:
 	 */
 	void Flush()
 	{
-		if (m_socket == nullptr || !m_stream.IsOk()) {
-			return;
+		m_flushPending.store(false);
+
+		IUtpSocketOperations::Handle socket = nullptr;
+		std::vector<uint8_t> pending;
+		{
+			std::lock_guard<std::mutex> lock(m_mutex);
+			if (m_socket == nullptr || !m_stream.IsOk()) {
+				return;
+			}
+			socket = m_socket;
+			// Bounded: a blocked socket would otherwise have its whole
+			// backlog copied on every attempt, and libutp takes at most a
+			// window anyway.
+			pending = m_stream.PeekQueuedBytes(kFlushChunk);
 		}
-		const std::vector<uint8_t> pending = m_stream.PeekQueuedBytes();
 		if (pending.empty()) {
 			return;
 		}
-		const size_t accepted = m_operations.WriteToSocket(m_socket, pending.data(), pending.size());
+
+		// Offered with the lock released: IUtpSocketOperations' calls can
+		// re-enter, and a callback that reaches Flush() again would deadlock
+		// against a non-recursive mutex held across the call.
+		const size_t accepted = m_operations.WriteToSocket(socket, pending.data(), pending.size());
+
+		std::lock_guard<std::mutex> lock(m_mutex);
 		m_stream.ConsumeQueuedBytes(accepted);
 	}
 
 	// -- libutp callbacks, translated ---------------------------------
 
-	void OnConnected(IStreamTransportEvents *events)
+	void OnConnected()
 	{
-		m_connected = true;
-		if (events != nullptr) {
-			events->OnStreamWritable();
+		{
+			std::lock_guard<std::mutex> lock(m_mutex);
+			m_connected = true;
 		}
-	}
-
-	void OnPayload(const uint8_t *data, size_t length, IStreamTransportEvents *events)
-	{
-		m_stream.OnPayload(data, length);
-		if (events != nullptr) {
-			events->OnStreamReadable();
-		}
-	}
-
-	void OnWritable(IStreamTransportEvents *events)
-	{
-		const bool wasBlocked = m_stream.BlocksWrite();
-		m_stream.OnWritable();
+		// utp_write() takes nothing before the handshake completes, so
+		// anything queued until now was refused and is still waiting.
 		Flush();
-		if (wasBlocked && !m_stream.BlocksWrite() && events != nullptr) {
-			events->OnStreamWritable();
+		if (m_events != nullptr) {
+			m_events->OnStreamWritable();
 		}
 	}
 
-	void OnEnded(EUtpTransportFailure failure, IStreamTransportEvents *events)
+	void OnPayload(const uint8_t *data, size_t length)
 	{
-		m_stream.OnFailure(failure);
-		m_connected = false;
-		if (failure == EUtpTransportFailure::Destroying) {
-			// The handle dies with this callback, so it must not be closed
-			// and must not be touched again. Clearing it is what stops the
-			// destructor, and everything else, from reaching for it.
-			m_socket = nullptr;
+		{
+			std::lock_guard<std::mutex> lock(m_mutex);
+			m_stream.OnPayload(data, length);
 		}
-		if (events != nullptr) {
-			events->OnStreamLost();
+		if (m_events != nullptr) {
+			m_events->OnStreamReadable();
+		}
+	}
+
+	void OnWritable()
+	{
+		bool wasBlocked = false;
+		{
+			std::lock_guard<std::mutex> lock(m_mutex);
+			wasBlocked = m_stream.BlocksWrite();
+			m_stream.OnWritable();
+		}
+		Flush();
+		bool blocked = true;
+		{
+			std::lock_guard<std::mutex> lock(m_mutex);
+			blocked = m_stream.BlocksWrite();
+		}
+		if (wasBlocked && !blocked && m_events != nullptr) {
+			m_events->OnStreamWritable();
+		}
+	}
+
+	void OnEnded(EUtpTransportFailure failure)
+	{
+		{
+			std::lock_guard<std::mutex> lock(m_mutex);
+			m_stream.OnFailure(failure);
+			m_connected = false;
+			if (failure == EUtpTransportFailure::Destroying) {
+				// The handle dies with this callback, so it must not be
+				// closed and must not be touched again. Clearing it is
+				// what stops the destructor, and everything else, from
+				// reaching for it.
+				m_socket = nullptr;
+			}
+		}
+		if (m_events != nullptr) {
+			m_events->OnStreamLost();
 		}
 	}
 
 	//! For the acceptor and for tests; never leaves the adapter otherwise.
-	IUtpSocketOperations::Handle SocketHandle() const { return m_socket; }
+	IUtpSocketOperations::Handle SocketHandle() const
+	{
+		std::lock_guard<std::mutex> lock(m_mutex);
+		return m_socket;
+	}
 
-	const CUtpStream &Stream() const { return m_stream; }
+	//! Bytes queued and not yet accepted by libutp.
+	size_t PendingWriteBytes() const
+	{
+		std::lock_guard<std::mutex> lock(m_mutex);
+		return m_stream.WriteBufferSize();
+	}
 
 private:
+	//! One window's worth, so an offer costs a packet or two, not the backlog.
+	static constexpr size_t kFlushChunk = 64 * 1024;
+
 	IUtpSocketOperations &m_operations;
+	mutable std::mutex m_mutex;
 	IUtpSocketOperations::Handle m_socket;
-	CNetworkAddress m_peer;
-	uint16_t m_peerPort;
+	const CNetworkAddress m_peer;
+	const uint16_t m_peerPort;
+	IStreamTransportEvents *m_events;
 	CUtpStream m_stream;
 	bool m_connected = false;
+	std::atomic<bool> m_flushPending{ false };
 };
 
 #endif // UTPSOCKETTRANSPORT_H

--- a/src/UtpSocketTransport.h
+++ b/src/UtpSocketTransport.h
@@ -293,6 +293,14 @@ public:
 		std::vector<uint8_t> pending;
 		{
 			std::lock_guard<std::mutex> lock(m_mutex);
+			// Cleared before the re-entrancy check, not after it. Any entry here
+			// absorbs the outstanding request, and the early return below is an
+			// entry: leaving the flag set there meant the re-entry was recorded,
+			// consumed by the tail, and then dropped anyway, because
+			// RequestFlushLocked() short-circuits on this very flag. Write()
+			// short-circuits on it too, so the queue stranded for good with
+			// IsOk() still reporting true.
+			m_flushPending = false;
 			if (m_flushInProgress) {
 				// Record it rather than drop it: the outer flush offers bytes
 				// this caller has not seen, so returning silently would lose
@@ -300,7 +308,6 @@ public:
 				m_flushAgain = true;
 				return;
 			}
-			m_flushPending = false;
 			if (m_socket == nullptr || !m_stream.IsOk()) {
 				return;
 			}

--- a/src/UtpSocketTransport.h
+++ b/src/UtpSocketTransport.h
@@ -60,16 +60,6 @@ public:
 	//! Tells libutp the application has caught up, so delivery may resume.
 	virtual void NotifyReadDrained(Handle socket) = 0;
 
-	/**
-	 * Reports bytes buffered, for UTP_GET_READ_BUFFER_SIZE.
-	 *
-	 * Paired with SetReceiveBuffer() and useless without it: libutp advertises
-	 * opt_rcvbuf minus this number, and with the callback unset the subtracted
-	 * value is zero, so the window never shrinks. Setting the buffer alone
-	 * therefore lowers the ceiling without adding any backpressure.
-	 */
-	virtual void ReportReadBufferSize(Handle socket, size_t bytes) = 0;
-
 	//! utp_close(). Exactly one caller may ever make this call per socket.
 	virtual void CloseSocket(Handle socket) = 0;
 
@@ -144,20 +134,17 @@ public:
 	CUtpSocketTransport &operator=(const CUtpSocketTransport &) = delete;
 
 	/**
-	 * Applies the receive bound and reports current occupancy against it.
+	 * Sets the receive-window ceiling, not backpressure on its own.
 	 *
-	 * Both halves, always: libutp advertises opt_rcvbuf minus what the
-	 * read-buffer-size callback reports, so setting the buffer without
-	 * reporting occupancy pins the window at a constant 64 KiB -- a sixteenth
-	 * of libutp's default, with no backpressure gained, since the reported
-	 * subtrahend stays zero however far behind the reader falls.
+	 * The adapter must register UTP_GET_READ_BUFFER_SIZE and synchronously
+	 * pull ReadBufferSize(): libutp advertises opt_rcvbuf minus those bytes.
+	 * Without that callback, occupancy is treated as zero.
 	 */
 	void ApplyReceiveBound()
 	{
 		std::lock_guard<std::mutex> lock(m_mutex);
 		if (m_socket != nullptr) {
 			m_operations.SetReceiveBuffer(m_socket, m_stream.ReadBound());
-			m_operations.ReportReadBufferSize(m_socket, m_stream.ReadBufferSize());
 		}
 	}
 
@@ -199,7 +186,6 @@ public:
 	{
 		IUtpSocketOperations::Handle socket = nullptr;
 		uint32_t taken = 0;
-		size_t buffered = 0;
 		{
 			std::lock_guard<std::mutex> lock(m_mutex);
 			taken = m_stream.Read(buffer, length);
@@ -209,11 +195,9 @@ public:
 			if (m_stream.ConsumeReadDrainedEdge()) {
 				socket = m_socket;
 			}
-			buffered = m_stream.ReadBufferSize();
 		}
 		if (socket != nullptr) {
-			// Outside the lock: these re-enter.
-			m_operations.ReportReadBufferSize(socket, buffered);
+			// Outside the lock: this can re-enter.
 			m_operations.NotifyReadDrained(socket);
 		}
 		return taken;
@@ -379,6 +363,13 @@ public:
 	{
 		std::lock_guard<std::mutex> lock(m_mutex);
 		return m_socket;
+	}
+
+	//! Current buffered bytes, pulled synchronously by UTP_GET_READ_BUFFER_SIZE.
+	size_t ReadBufferSize() const
+	{
+		std::lock_guard<std::mutex> lock(m_mutex);
+		return m_stream.ReadBufferSize();
 	}
 
 	//! Bytes queued and not yet accepted by libutp.

--- a/src/UtpSocketTransport.h
+++ b/src/UtpSocketTransport.h
@@ -37,11 +37,20 @@
 /**
  * The per-socket libutp calls a transport makes, behind a seam.
  *
- * Only four, and they are the ones that must not be made from inside a libutp
- * callback: each can re-enter, and utp_close() in particular can produce
- * UTP_STATE_DESTROYING before it returns. Naming them here keeps the transport
- * testable without the library, and keeps the re-entrancy rule in one place
- * rather than repeated at every call.
+ * Only four, and the re-entrancy rule differs per call rather than being one
+ * blanket ban, because a blanket ban is a rule the code would have to break:
+ *
+ * - CloseSocket() must never be made from inside a callback: utp_close() can
+ *   produce UTP_STATE_DESTROYING before it returns.
+ * - WriteToSocket() is what UTP_STATE_WRITABLE exists to invite, so it is
+ *   correct from there. From UTP_ON_ACCEPT it achieves nothing, since the
+ *   socket is still CS_SYN_RECV, and from UTP_ON_READ it re-enters
+ *   utp_process_incoming. Both of those request a flush instead.
+ * - NotifyReadDrained() assumes the reader is not reading synchronously from
+ *   inside UTP_ON_READ; every CoreNotify_* delivery queues, so it does not.
+ * - SetReceiveBuffer() is configuration, made once by the acceptor.
+ *
+ * Naming them here keeps the transport testable without the library.
  *
  * The handle is opaque on purpose: a utp_socket* never appears outside the
  * adapter's translation unit, which is what stops <libutp/utp.h> reaching the
@@ -234,9 +243,7 @@ public:
 				events = RequestFlushLocked();
 			}
 		}
-		if (events != nullptr) {
-			events->OnFlushRequested();
-		}
+		RaiseFlushRequest(events);
 		return taken;
 	}
 
@@ -337,17 +344,19 @@ public:
 		IStreamTransportEvents *flushEvents = nullptr;
 		{
 			std::lock_guard<std::mutex> lock(m_mutex);
+			// Released first and unconditionally: short-circuiting past it
+			// would leave the re-entry recorded but never consumed, and the
+			// in-progress flag set while the sink below runs.
+			const bool reentered = guard.Release();
 			// A fully accepted offer needs a local continuation: utp_writev
 			// returns as soon as it has sent everything it was given, without
 			// arming CS_CONNECTED_FULL, so no writable edge is coming for the
 			// rest of the queue. A partial or window-full result did arm it.
-			if (accepted == pending.size() || guard.Release()) {
+			if (accepted == pending.size() || reentered) {
 				flushEvents = RequestFlushLocked();
 			}
 		}
-		if (flushEvents != nullptr) {
-			flushEvents->OnFlushRequested();
-		}
+		RaiseFlushRequest(flushEvents);
 	}
 
 	// -- libutp callbacks, translated ---------------------------------
@@ -356,23 +365,20 @@ public:
 	// this from UTP_ON_ACCEPT. Only outgoing sockets get UTP_STATE_CONNECT.
 	void MarkConnected()
 	{
-		bool wasBlocked = false;
+		IStreamTransportEvents *flushEvents = nullptr;
 		{
 			std::lock_guard<std::mutex> lock(m_mutex);
 			if (m_connected || m_socket == nullptr || !m_stream.IsOk()) {
 				return;
 			}
 			m_connected = true;
-			wasBlocked = m_stream.BlocksWrite();
+			flushEvents = RequestFlushLocked();
 		}
-		// utp_write() takes nothing before the handshake completes, so
-		// anything queued until now was refused and is still waiting.
-		Flush();
-		// One transition, one notification: Flush() already reports the
-		// blocked-to-writable edge when draining the queue produced it.
-		if (!wasBlocked) {
-			NotifyEvents(&IStreamTransportEvents::OnStreamWritable);
-		}
+		// Requested, not flushed: this runs inside UTP_ON_ACCEPT, where the
+		// socket is still CS_SYN_RECV, so utp_writev would refuse every byte
+		// at its state guard and the peek would be copied for nothing.
+		RaiseFlushRequest(flushEvents);
+		NotifyEvents(&IStreamTransportEvents::OnStreamWritable);
 	}
 
 	void OnPayload(const uint8_t *data, size_t length)
@@ -387,12 +393,14 @@ public:
 			// utp_writev refuses everything without arming a writable edge,
 			// so a reply queued at accept has been waiting for this moment.
 			// Requested rather than flushed here, because this runs inside
-			// UTP_ON_READ and the offer must not be made from a callback.
+			// UTP_ON_READ, which would re-enter utp_process_incoming.
+			//
+			// A peer that connects and then says nothing never reaches this,
+			// and so never gets its reply -- unreachable for eD2k, where the
+			// side that opened the connection always speaks first.
 			flushEvents = RequestFlushLocked();
 		}
-		if (flushEvents != nullptr) {
-			flushEvents->OnFlushRequested();
-		}
+		RaiseFlushRequest(flushEvents);
 		NotifyEvents(&IStreamTransportEvents::OnStreamReadable);
 	}
 
@@ -484,6 +492,29 @@ private:
 		}
 		m_flushPending = true;
 		return m_events;
+	}
+
+	/**
+	 * Delivers a flush request, and does not leave the flag set if it throws.
+	 *
+	 * m_flushPending gates every later request, so a sink that throws with it
+	 * still set stops the socket sending for good, silently, with IsOk() still
+	 * reporting true. Same wedge CFlushGuard prevents, one flag over.
+	 */
+	void RaiseFlushRequest(IStreamTransportEvents *events)
+	{
+		if (events == nullptr) {
+			return;
+		}
+		try {
+			events->OnFlushRequested();
+		} catch (...) {
+			{
+				std::lock_guard<std::mutex> lock(m_mutex);
+				m_flushPending = false;
+			}
+			throw;
+		}
 	}
 
 	void NotifyEvents(void (IStreamTransportEvents::*callback)())

--- a/src/UtpSocketTransport.h
+++ b/src/UtpSocketTransport.h
@@ -28,6 +28,7 @@
 #include "StreamTransport.h"
 #include "UtpStream.h"
 
+#include <algorithm>
 #include <cstddef>
 #include <cstdint>
 #include <mutex>
@@ -257,7 +258,9 @@ public:
 			socket = m_socket;
 			m_socket = nullptr;
 			m_connected = false;
-			m_stream.OnFailure(EUtpTransportFailure::Eof);
+			// Our own close, not the peer's FIN. Both are clean ends with no
+			// error, but Failure() must not claim we saw a FIN we never saw.
+			m_stream.OnFailure(EUtpTransportFailure::Closed);
 			m_flushPending = false;
 		}
 		if (socket != nullptr) {
@@ -284,6 +287,10 @@ public:
 		{
 			std::lock_guard<std::mutex> lock(m_mutex);
 			if (m_flushInProgress) {
+				// Record it rather than drop it: the outer flush offers bytes
+				// this caller has not seen, so returning silently would lose
+				// whatever edge asked for this one.
+				m_flushAgain = true;
 				return;
 			}
 			m_flushPending = false;
@@ -299,6 +306,7 @@ public:
 				return;
 			}
 			m_flushInProgress = true;
+			m_flushAgain = false;
 		}
 
 		// Offered with the lock released: IUtpSocketOperations' calls can
@@ -325,9 +333,14 @@ public:
 		{
 			std::lock_guard<std::mutex> lock(m_mutex);
 			m_flushInProgress = false;
-			// Only a fully accepted offer needs a local continuation. Partial
-			// writes wait for UTP_STATE_WRITABLE; nonpositive results must not spin.
-			if (accepted == pending.size()) {
+			// A fully accepted offer needs a local continuation: utp_writev
+			// returns as soon as it has sent everything it was given, without
+			// arming CS_CONNECTED_FULL, so no writable edge is coming for the
+			// rest of the queue. Partial and nonpositive results did arm it,
+			// or are not connected, and must not spin.
+			const bool reentered = m_flushAgain;
+			m_flushAgain = false;
+			if (accepted == pending.size() || reentered) {
 				flushEvents = RequestFlushLocked();
 			}
 		}
@@ -342,17 +355,23 @@ public:
 	// this from UTP_ON_ACCEPT. Only outgoing sockets get UTP_STATE_CONNECT.
 	void MarkConnected()
 	{
+		bool wasBlocked = false;
 		{
 			std::lock_guard<std::mutex> lock(m_mutex);
 			if (m_connected || m_socket == nullptr || !m_stream.IsOk()) {
 				return;
 			}
 			m_connected = true;
+			wasBlocked = m_stream.BlocksWrite();
 		}
 		// utp_write() takes nothing before the handshake completes, so
 		// anything queued until now was refused and is still waiting.
 		Flush();
-		NotifyEvents(&IStreamTransportEvents::OnStreamWritable);
+		// One transition, one notification: Flush() already reports the
+		// blocked-to-writable edge when draining the queue produced it.
+		if (!wasBlocked) {
+			NotifyEvents(&IStreamTransportEvents::OnStreamWritable);
+		}
 	}
 
 	void OnPayload(const uint8_t *data, size_t length)
@@ -388,6 +407,13 @@ public:
 	{
 		std::lock_guard<std::mutex> lock(m_mutex);
 		return m_socket;
+	}
+
+	//! How the stream ended, for a caller that needs more than IsOk().
+	EUtpTransportFailure Failure() const
+	{
+		std::lock_guard<std::mutex> lock(m_mutex);
+		return m_stream.Failure();
 	}
 
 	//! Current buffered bytes, pulled synchronously by UTP_GET_READ_BUFFER_SIZE.
@@ -444,6 +470,7 @@ private:
 	bool m_connected = false;
 	bool m_flushPending = false;
 	bool m_flushInProgress = false;
+	bool m_flushAgain = false;
 };
 
 #endif // UTPSOCKETTRANSPORT_H

--- a/src/UtpSocketTransport.h
+++ b/src/UtpSocketTransport.h
@@ -308,6 +308,11 @@ public:
 			m_flushInProgress = true;
 			m_flushAgain = false;
 		}
+		// From here the in-progress flag must be cleared on every exit: the
+		// library call and the writable notification both reach code that can
+		// throw, and a flag left set stops Write() from ever requesting a
+		// flush again -- silently, with IsOk() still true.
+		CFlushGuard guard(*this);
 
 		// Offered with the lock released: IUtpSocketOperations' calls can
 		// re-enter, and a callback that reaches Flush() again would deadlock
@@ -332,15 +337,11 @@ public:
 		IStreamTransportEvents *flushEvents = nullptr;
 		{
 			std::lock_guard<std::mutex> lock(m_mutex);
-			m_flushInProgress = false;
 			// A fully accepted offer needs a local continuation: utp_writev
 			// returns as soon as it has sent everything it was given, without
 			// arming CS_CONNECTED_FULL, so no writable edge is coming for the
-			// rest of the queue. Partial and nonpositive results did arm it,
-			// or are not connected, and must not spin.
-			const bool reentered = m_flushAgain;
-			m_flushAgain = false;
-			if (accepted == pending.size() || reentered) {
+			// rest of the queue. A partial or window-full result did arm it.
+			if (accepted == pending.size() || guard.Release()) {
 				flushEvents = RequestFlushLocked();
 			}
 		}
@@ -376,9 +377,21 @@ public:
 
 	void OnPayload(const uint8_t *data, size_t length)
 	{
+		IStreamTransportEvents *flushEvents = nullptr;
 		{
 			std::lock_guard<std::mutex> lock(m_mutex);
 			m_stream.OnPayload(data, length);
+			// This ST_DATA is what completes an inbound handshake, and
+			// libutp makes that transition silently: CS_SYN_RECV becomes
+			// CS_CONNECTED with no callback at all. Until it happens
+			// utp_writev refuses everything without arming a writable edge,
+			// so a reply queued at accept has been waiting for this moment.
+			// Requested rather than flushed here, because this runs inside
+			// UTP_ON_READ and the offer must not be made from a callback.
+			flushEvents = RequestFlushLocked();
+		}
+		if (flushEvents != nullptr) {
+			flushEvents->OnFlushRequested();
 		}
 		NotifyEvents(&IStreamTransportEvents::OnStreamReadable);
 	}
@@ -431,6 +444,37 @@ public:
 	}
 
 private:
+	//! Clears the in-progress flag on every exit and reports any re-entry.
+	class CFlushGuard
+	{
+	public:
+		explicit CFlushGuard(CUtpSocketTransport &owner)
+		: m_owner(owner)
+		{
+		}
+
+		~CFlushGuard()
+		{
+			std::lock_guard<std::mutex> lock(m_owner.m_mutex);
+			m_owner.m_flushInProgress = false;
+		}
+
+		//! Caller holds the mutex. True when a flush was requested meanwhile.
+		bool Release()
+		{
+			m_owner.m_flushInProgress = false;
+			const bool again = m_owner.m_flushAgain;
+			m_owner.m_flushAgain = false;
+			return again;
+		}
+
+		CFlushGuard(const CFlushGuard &) = delete;
+		CFlushGuard &operator=(const CFlushGuard &) = delete;
+
+	private:
+		CUtpSocketTransport &m_owner;
+	};
+
 	// Caller holds m_mutex. The returned sink must be called unlocked.
 	IStreamTransportEvents *RequestFlushLocked()
 	{

--- a/src/UtpSocketTransport.h
+++ b/src/UtpSocketTransport.h
@@ -28,7 +28,6 @@
 #include "StreamTransport.h"
 #include "UtpStream.h"
 
-#include <atomic>
 #include <cstddef>
 #include <cstdint>
 #include <mutex>
@@ -54,8 +53,8 @@ public:
 
 	virtual ~IUtpSocketOperations() = default;
 
-	//! Offers bytes. Returns how many were taken, which is routinely fewer.
-	virtual size_t WriteToSocket(Handle socket, const uint8_t *data, size_t length) = 0;
+	//! Offers bytes. Nonpositive results (including libutp's -1) accept nothing.
+	virtual std::ptrdiff_t WriteToSocket(Handle socket, const uint8_t *data, size_t length) = 0;
 
 	//! Tells libutp the application has caught up, so delivery may resume.
 	virtual void NotifyReadDrained(Handle socket) = 0;
@@ -128,7 +127,14 @@ public:
 	{
 	}
 
-	~CUtpSocketTransport() override { Close(); }
+	~CUtpSocketTransport() override
+	{
+		{
+			std::lock_guard<std::mutex> lock(m_mutex);
+			m_events = nullptr;
+		}
+		Close();
+	}
 
 	CUtpSocketTransport(const CUtpSocketTransport &) = delete;
 	CUtpSocketTransport &operator=(const CUtpSocketTransport &) = delete;
@@ -142,9 +148,15 @@ public:
 	 */
 	void ApplyReceiveBound()
 	{
-		std::lock_guard<std::mutex> lock(m_mutex);
-		if (m_socket != nullptr) {
-			m_operations.SetReceiveBuffer(m_socket, m_stream.ReadBound());
+		IUtpSocketOperations::Handle socket = nullptr;
+		size_t bound = 0;
+		{
+			std::lock_guard<std::mutex> lock(m_mutex);
+			socket = m_socket;
+			bound = m_stream.ReadBound();
+		}
+		if (socket != nullptr) {
+			m_operations.SetReceiveBuffer(socket, bound);
 		}
 	}
 
@@ -213,17 +225,16 @@ public:
 	uint32_t Write(const void *buffer, uint32_t length) override
 	{
 		uint32_t taken = 0;
+		IStreamTransportEvents *events = nullptr;
 		{
 			std::lock_guard<std::mutex> lock(m_mutex);
 			taken = m_stream.Write(buffer, length);
+			if (taken != 0 && !m_flushInProgress) {
+				events = RequestFlushLocked();
+			}
 		}
-		// Nothing else would flush these: the only other trigger is a full
-		// window reopening, and a queue filled while the window was never
-		// full has no such edge behind it. Raised on the idle-to-busy
-		// transition only, so a busy socket costs one event, not one per
-		// write.
-		if (taken != 0 && !m_flushPending.exchange(true) && m_events != nullptr) {
-			m_events->OnFlushRequested();
+		if (events != nullptr) {
+			events->OnFlushRequested();
 		}
 		return taken;
 	}
@@ -245,6 +256,9 @@ public:
 			std::lock_guard<std::mutex> lock(m_mutex);
 			socket = m_socket;
 			m_socket = nullptr;
+			m_connected = false;
+			m_stream.OnFailure(EUtpTransportFailure::Eof);
+			m_flushPending = false;
 		}
 		if (socket != nullptr) {
 			// Unlocked: utp_close() can produce UTP_STATE_DESTROYING before
@@ -265,12 +279,14 @@ public:
 	 */
 	void Flush()
 	{
-		m_flushPending.store(false);
-
 		IUtpSocketOperations::Handle socket = nullptr;
 		std::vector<uint8_t> pending;
 		{
 			std::lock_guard<std::mutex> lock(m_mutex);
+			if (m_flushInProgress) {
+				return;
+			}
+			m_flushPending = false;
 			if (m_socket == nullptr || !m_stream.IsOk()) {
 				return;
 			}
@@ -279,34 +295,64 @@ public:
 			// backlog copied on every attempt, and libutp takes at most a
 			// window anyway.
 			pending = m_stream.PeekQueuedBytes(kFlushChunk);
-		}
-		if (pending.empty()) {
-			return;
+			if (pending.empty()) {
+				return;
+			}
+			m_flushInProgress = true;
 		}
 
 		// Offered with the lock released: IUtpSocketOperations' calls can
 		// re-enter, and a callback that reaches Flush() again would deadlock
 		// against a non-recursive mutex held across the call.
-		const size_t accepted = m_operations.WriteToSocket(socket, pending.data(), pending.size());
-
-		std::lock_guard<std::mutex> lock(m_mutex);
-		m_stream.ConsumeQueuedBytes(accepted);
+		const std::ptrdiff_t result =
+			m_operations.WriteToSocket(socket, pending.data(), pending.size());
+		const size_t accepted = result > 0 ? static_cast<size_t>(result) : 0;
+		IStreamTransportEvents *writableEvents = nullptr;
+		{
+			std::lock_guard<std::mutex> lock(m_mutex);
+			const bool wasBlocked = m_stream.BlocksWrite();
+			if (m_socket == socket && m_stream.IsOk()) {
+				m_stream.ConsumeQueuedBytes(std::min(accepted, pending.size()));
+				if (wasBlocked && !m_stream.BlocksWrite()) {
+					writableEvents = m_events;
+				}
+			}
+		}
+		if (writableEvents != nullptr) {
+			writableEvents->OnStreamWritable();
+		}
+		IStreamTransportEvents *flushEvents = nullptr;
+		{
+			std::lock_guard<std::mutex> lock(m_mutex);
+			m_flushInProgress = false;
+			// Only a fully accepted offer needs a local continuation. Partial
+			// writes wait for UTP_STATE_WRITABLE; nonpositive results must not spin.
+			if (accepted == pending.size()) {
+				flushEvents = RequestFlushLocked();
+			}
+		}
+		if (flushEvents != nullptr) {
+			flushEvents->OnFlushRequested();
+		}
 	}
 
 	// -- libutp callbacks, translated ---------------------------------
 
-	void OnConnected()
+	// Adapter transition, not a libutp callback: the future acceptor MUST call
+	// this from UTP_ON_ACCEPT. Only outgoing sockets get UTP_STATE_CONNECT.
+	void MarkConnected()
 	{
 		{
 			std::lock_guard<std::mutex> lock(m_mutex);
+			if (m_connected || m_socket == nullptr || !m_stream.IsOk()) {
+				return;
+			}
 			m_connected = true;
 		}
 		// utp_write() takes nothing before the handshake completes, so
 		// anything queued until now was refused and is still waiting.
 		Flush();
-		if (m_events != nullptr) {
-			m_events->OnStreamWritable();
-		}
+		NotifyEvents(&IStreamTransportEvents::OnStreamWritable);
 	}
 
 	void OnPayload(const uint8_t *data, size_t length)
@@ -315,29 +361,10 @@ public:
 			std::lock_guard<std::mutex> lock(m_mutex);
 			m_stream.OnPayload(data, length);
 		}
-		if (m_events != nullptr) {
-			m_events->OnStreamReadable();
-		}
+		NotifyEvents(&IStreamTransportEvents::OnStreamReadable);
 	}
 
-	void OnWritable()
-	{
-		bool wasBlocked = false;
-		{
-			std::lock_guard<std::mutex> lock(m_mutex);
-			wasBlocked = m_stream.BlocksWrite();
-			m_stream.OnWritable();
-		}
-		Flush();
-		bool blocked = true;
-		{
-			std::lock_guard<std::mutex> lock(m_mutex);
-			blocked = m_stream.BlocksWrite();
-		}
-		if (wasBlocked && !blocked && m_events != nullptr) {
-			m_events->OnStreamWritable();
-		}
-	}
+	void OnWritable() { Flush(); }
 
 	void OnEnded(EUtpTransportFailure failure)
 	{
@@ -353,9 +380,7 @@ public:
 				m_socket = nullptr;
 			}
 		}
-		if (m_events != nullptr) {
-			m_events->OnStreamLost();
-		}
+		NotifyEvents(&IStreamTransportEvents::OnStreamLost);
 	}
 
 	//! For the acceptor and for tests; never leaves the adapter otherwise.
@@ -380,6 +405,29 @@ public:
 	}
 
 private:
+	// Caller holds m_mutex. The returned sink must be called unlocked.
+	IStreamTransportEvents *RequestFlushLocked()
+	{
+		if (m_flushPending || m_socket == nullptr || !m_stream.IsOk() ||
+			m_stream.WriteBufferSize() == 0 || m_events == nullptr) {
+			return nullptr;
+		}
+		m_flushPending = true;
+		return m_events;
+	}
+
+	void NotifyEvents(void (IStreamTransportEvents::*callback)())
+	{
+		IStreamTransportEvents *events = nullptr;
+		{
+			std::lock_guard<std::mutex> lock(m_mutex);
+			events = m_events;
+		}
+		if (events != nullptr) {
+			(events->*callback)();
+		}
+	}
+
 	//! One window's worth, so an offer costs a packet or two, not the backlog.
 	static constexpr size_t kFlushChunk = 64 * 1024;
 
@@ -388,10 +436,14 @@ private:
 	IUtpSocketOperations::Handle m_socket;
 	const CNetworkAddress m_peer;
 	const uint16_t m_peerPort;
+	// Non-owning: the owner must quiesce Write()/queued pumps before destruction
+	// and keep the sink alive through all calls. Callbacks must not delete this
+	// transport synchronously. Destruction detaches before library re-entry.
 	IStreamTransportEvents *m_events;
 	CUtpStream m_stream;
 	bool m_connected = false;
-	std::atomic<bool> m_flushPending{ false };
+	bool m_flushPending = false;
+	bool m_flushInProgress = false;
 };
 
 #endif // UTPSOCKETTRANSPORT_H

--- a/src/UtpStream.h
+++ b/src/UtpStream.h
@@ -51,6 +51,9 @@ public:
 	//! Default bound on unsent bytes. One eD2k block plus headroom.
 	static constexpr size_t kDefaultWriteBound = 256 * 1024;
 
+	//! PeekQueuedBytes() default: no cap, the whole queue.
+	static constexpr size_t kNoPeekLimit = static_cast<size_t>(-1);
+
 	/**
 	 * Default bound on buffered received bytes.
 	 *
@@ -166,10 +169,19 @@ public:
 
 	size_t WriteBufferSize() const { return m_writeBuffer.size(); }
 
-	//! The queued bytes, for the caller that will offer them to libutp.
-	std::vector<uint8_t> PeekQueuedBytes() const
+	/**
+	 * The queued bytes, for the caller that will offer them to libutp.
+	 *
+	 * @a limit caps the copy. libutp takes at most a window per call anyway,
+	 * so offering the whole backlog copies bytes that cannot be accepted --
+	 * and a blocked socket would pay that copy again on every attempt.
+	 */
+	std::vector<uint8_t> PeekQueuedBytes(size_t limit = kNoPeekLimit) const
 	{
-		return std::vector<uint8_t>(m_writeBuffer.begin(), m_writeBuffer.end());
+		const size_t queued = m_writeBuffer.size();
+		const size_t taken = limit < queued ? limit : queued;
+		return std::vector<uint8_t>(m_writeBuffer.begin(),
+			m_writeBuffer.begin() + static_cast<std::deque<uint8_t>::difference_type>(taken));
 	}
 
 	/**

--- a/src/UtpStream.h
+++ b/src/UtpStream.h
@@ -201,9 +201,6 @@ public:
 		m_blocksWrite = m_writeBuffer.size() >= m_writeBound;
 	}
 
-	//! The peer's window opened again.
-	void OnWritable() { m_blocksWrite = m_writeBuffer.size() >= m_writeBound; }
-
 	// -- ending -------------------------------------------------------
 
 	/**
@@ -249,10 +246,6 @@ public:
 	bool BlocksRead() const { return m_blocksRead; }
 	bool BlocksWrite() const { return m_blocksWrite; }
 
-	//! True for the one caller that owns utp_close(); false for every other.
-	bool TakeCloseOwnership() { return m_close.Take(); }
-	bool CloseTaken() const { return m_close.Taken(); }
-
 private:
 	//! Above errno, the WinSock range (10000-11999) and wxSocketError alike,
 	//! so a stray comparison against any of them cannot match.
@@ -266,7 +259,6 @@ private:
 	bool m_blocksWrite = false;
 	bool m_readDrainedDue = false;
 	EUtpTransportFailure m_failure = EUtpTransportFailure::None;
-	CUtpCloseOnce m_close;
 };
 
 #endif // UTPSTREAM_H

--- a/src/UtpTransportFailure.h
+++ b/src/UtpTransportFailure.h
@@ -34,9 +34,9 @@
  * the connection existed and no longer does. Collapsing them is how a dead peer and a firewalled
  * one become indistinguishable in the source list.
  *
- * @c Eof and @c Destroying are terminal but are @b not failures. A peer that closes cleanly after
- * sending what it owed has not failed, and reporting it as an error would penalise it in exactly
- * the accounting a clean close should leave alone.
+ * @c Eof, @c Closed and @c Destroying are terminal but are @b not failures. A peer that closes
+ * cleanly after sending what it owed has not failed, and reporting it as an error would penalise
+ * it in exactly the accounting a clean close should leave alone.
  */
 enum class EUtpTransportFailure
 {
@@ -50,6 +50,8 @@ enum class EUtpTransportFailure
 	Reset,
 	//! The peer finished sending. Not an error.
 	Eof,
+	//! We closed it. Not an error, and distinct from a FIN we never saw.
+	Closed,
 	//! The library is destroying the socket. Not an error.
 	Destroying
 };
@@ -64,36 +66,6 @@ inline bool IsUtpTerminal(EUtpTransportFailure failure) noexcept
 {
 	return failure != EUtpTransportFailure::None;
 }
-
-/**
- * The close bookkeeping, as a type rather than as a rule.
- *
- * libutp's @c utp_close() must be called exactly once per socket, and the pointer is invalid the
- * moment @c UTP_STATE_DESTROYING arrives. Both halves are easy to get wrong by hand -- a destructor
- * that closes, plus a state callback that closes, is a double free that only appears when a peer
- * disconnects at the wrong moment.
- *
- * So the permission to close is consumed rather than checked: Take() answers true once and false
- * forever after, and there is no way to ask "was it closed" and then close, which is the shape that
- * races.
- */
-class CUtpCloseOnce
-{
-public:
-	//! True exactly once, for the caller that owns the close.
-	bool Take() noexcept
-	{
-		const bool first = !m_taken;
-		m_taken = true;
-		return first;
-	}
-
-	//! True once the close has been handed out. For assertions, not for deciding.
-	bool Taken() const noexcept { return m_taken; }
-
-private:
-	bool m_taken = false;
-};
 
 #endif // UTPTRANSPORTFAILURE_H
 // File_checked_for_headers

--- a/unittests/tests/CMakeLists.txt
+++ b/unittests/tests/CMakeLists.txt
@@ -22,6 +22,32 @@ target_link_libraries (UtpStreamTest
 	muleunit
 )
 
+# One libutp socket behind IStreamTransport: the partial write whose refused
+# tail must stay queued, and the close that must happen exactly once. The
+# library is a seam here, so this runs in every build like UtpStreamTest.
+add_executable (UtpSocketTransportTest
+	UtpSocketTransportTest.cpp
+	${CMAKE_SOURCE_DIR}/src/NetworkAddress.cpp
+	${CMAKE_SOURCE_DIR}/src/libs/common/Format.cpp
+	${CMAKE_SOURCE_DIR}/src/libs/common/strerror_r.c
+)
+
+add_test (NAME UtpSocketTransportTest
+	COMMAND UtpSocketTransportTest
+)
+
+target_include_directories (UtpSocketTransportTest
+	PRIVATE ${CMAKE_BINARY_DIR}
+	PRIVATE ${CMAKE_SOURCE_DIR}/src
+	PRIVATE ${CMAKE_SOURCE_DIR}/src/include
+	PRIVATE ${Boost_INCLUDE_DIR}
+)
+
+target_link_libraries (UtpSocketTransportTest
+	muleunit
+	${Boost_LIBRARIES}
+)
+
 if (ENABLE_UTP)
 	add_executable (UtpContextTest
 		UtpContextTest.cpp

--- a/unittests/tests/UtpSocketTransportTest.cpp
+++ b/unittests/tests/UtpSocketTransportTest.cpp
@@ -578,4 +578,59 @@ TEST(UtpSocketTransport, ReentrantFlushNeverOffersTheSameBytesTwice)
 	ASSERT_TRUE(payload == ops.offered);
 }
 
+TEST(UtpSocketTransport, ConnectingReportsOneWritableEvenWhenDrainingUnblocks)
+{
+	// One transition, one notification. Flush() already reports the
+	// blocked-to-writable edge, so MarkConnected() must not report it again.
+	FakeOperations ops;
+	ops.acceptLimit = 0;
+	FakeEvents events;
+	CUtpSocketTransport transport = MakeTransport(ops, &events);
+	const std::vector<uint8_t> payload = Pattern(CUtpStream::kDefaultWriteBound, 9);
+	transport.Write(payload.data(), static_cast<uint32_t>(payload.size()));
+	ASSERT_TRUE(transport.BlocksWrite());
+
+	ops.acceptLimit = CUtpStream::kDefaultWriteBound;
+	transport.MarkConnected();
+	ASSERT_FALSE(transport.BlocksWrite());
+	ASSERT_EQUALS(1, events.writable);
+}
+
+TEST(UtpSocketTransport, AReentrantFlushRequestIsHonouredNotDropped)
+{
+	// The outer flush is offering bytes the reentrant caller never saw, so
+	// returning silently would lose whatever edge asked for that flush.
+	FakeOperations ops;
+	ops.acceptLimit = 8;
+	FakeEvents events;
+	CUtpSocketTransport transport = MakeTransport(ops, &events);
+	const std::vector<uint8_t> payload = Pattern(64, 3);
+	transport.Write(payload.data(), static_cast<uint32_t>(payload.size()));
+	const int queued = events.flushRequests;
+
+	bool reentered = false;
+	ops.onWrite = [&]() {
+		if (!reentered) {
+			reentered = true;
+			transport.Flush();
+		}
+	};
+	transport.Flush();
+	ASSERT_TRUE(reentered);
+	// Partial acceptance alone would schedule nothing; the swallowed
+	// reentrant request is what must still be answered.
+	ASSERT_EQUALS(queued + 1, events.flushRequests);
+}
+
+TEST(UtpSocketTransport, ALocalCloseIsNotReportedAsThePeersEof)
+{
+	FakeOperations ops;
+	CUtpSocketTransport transport = MakeTransport(ops);
+	transport.MarkConnected();
+	transport.Close();
+	ASSERT_TRUE(transport.Failure() == EUtpTransportFailure::Closed);
+	ASSERT_EQUALS(0, transport.LastError());
+	ASSERT_FALSE(transport.IsOk());
+}
+
 // File_checked_for_headers

--- a/unittests/tests/UtpSocketTransportTest.cpp
+++ b/unittests/tests/UtpSocketTransportTest.cpp
@@ -93,7 +93,15 @@ public:
 	void OnStreamReadable() override { ++readable; }
 	void OnStreamWritable() override { ++writable; }
 	void OnStreamLost() override { ++lost; }
-	void OnFlushRequested() override { ++flushRequests; }
+	void OnFlushRequested() override
+	{
+		++flushRequests;
+		if (onFlushRequested) {
+			onFlushRequested();
+		}
+	}
+
+	std::function<void()> onFlushRequested;
 
 	int readable = 0, writable = 0, lost = 0, flushRequests = 0;
 };
@@ -359,7 +367,7 @@ TEST(UtpSocketTransport, QueueingAsksForAFlushOncePerIdlePeriod)
 	ASSERT_EQUALS(2, events.flushRequests);
 }
 
-TEST(UtpSocketTransport, ConnectingFlushesWhatTheHandshakeRefused)
+TEST(UtpSocketTransport, ConnectingRequestsWhatTheHandshakeRefused)
 {
 	// utp_write() takes nothing before the handshake completes, so everything
 	// queued until then is still waiting and has no writable edge coming.
@@ -373,7 +381,14 @@ TEST(UtpSocketTransport, ConnectingFlushesWhatTheHandshakeRefused)
 	ASSERT_EQUALS(0u, (unsigned)ops.accepted.size());
 
 	ops.acceptLimit = 64;
+	const int before = events.flushRequests;
+	const size_t offeredBefore = ops.offered.size();
 	transport.MarkConnected();
+	// Requested, never offered from inside the callback.
+	ASSERT_EQUALS((unsigned)offeredBefore, (unsigned)ops.offered.size());
+	ASSERT_EQUALS(before + 1, events.flushRequests);
+
+	transport.Flush();
 	ASSERT_EQUALS(12u, (unsigned)ops.accepted.size());
 	for (size_t i = 0; i < payload.size(); ++i) {
 		ASSERT_EQUALS((int)payload[i], (int)ops.accepted[i]);
@@ -579,21 +594,20 @@ TEST(UtpSocketTransport, ReentrantFlushNeverOffersTheSameBytesTwice)
 	ASSERT_TRUE(payload == ops.offered);
 }
 
-TEST(UtpSocketTransport, ConnectingReportsOneWritableEvenWhenDrainingUnblocks)
+TEST(UtpSocketTransport, ConnectingNeverCallsTheLibraryFromInsideTheCallback)
 {
-	// One transition, one notification. Flush() already reports the
-	// blocked-to-writable edge, so MarkConnected() must not report it again.
+	// MarkConnected() runs inside UTP_ON_ACCEPT, where the socket is still
+	// CS_SYN_RECV: utp_writev would refuse every byte at its state guard, so
+	// offering there copies a window for nothing.
 	FakeOperations ops;
-	ops.acceptLimit = 0;
+	ops.acceptLimit = CUtpStream::kDefaultWriteBound;
 	FakeEvents events;
 	CUtpSocketTransport transport = MakeTransport(ops, &events);
 	const std::vector<uint8_t> payload = Pattern(CUtpStream::kDefaultWriteBound, 9);
 	transport.Write(payload.data(), static_cast<uint32_t>(payload.size()));
-	ASSERT_TRUE(transport.BlocksWrite());
 
-	ops.acceptLimit = CUtpStream::kDefaultWriteBound;
 	transport.MarkConnected();
-	ASSERT_FALSE(transport.BlocksWrite());
+	ASSERT_EQUALS(0u, (unsigned)ops.offered.size());
 	ASSERT_EQUALS(1, events.writable);
 }
 
@@ -690,6 +704,52 @@ TEST(UtpSocketTransport, AThrowingWritableSinkDoesNotWedgeTheFlushPath)
 	transport.Flush();
 	const std::vector<uint8_t> more = Pattern(8, 2);
 	transport.Write(more.data(), static_cast<uint32_t>(more.size()));
+	ASSERT_TRUE(events.flushRequests > before);
+}
+
+TEST(UtpSocketTransport, AFullyAcceptedFlushStillConsumesTheReentryRecord)
+{
+	// The re-entry record and the in-progress flag must both be cleared before
+	// the sink runs. Leaving them set lets a synchronous sink re-enter, record
+	// a request nothing will ever consume, and strand the queue with IsOk()
+	// still true.
+	FakeOperations ops;
+	ops.acceptLimit = 64 * 1024;
+	FakeEvents events;
+	CUtpSocketTransport transport = MakeTransport(ops, &events);
+	const std::vector<uint8_t> payload = Pattern(CUtpStream::kDefaultWriteBound, 4);
+	transport.Write(payload.data(), static_cast<uint32_t>(payload.size()));
+
+	// A sink that flushes synchronously, the way a same-thread owner would.
+	events.onFlushRequested = [&]() { transport.Flush(); };
+	transport.Flush();
+
+	ASSERT_EQUALS(0u, (unsigned)transport.PendingWriteBytes());
+	ASSERT_TRUE(payload == ops.accepted);
+}
+
+TEST(UtpSocketTransport, AThrowingFlushSinkDoesNotStopLaterRequests)
+{
+	// m_flushPending gates every later request, so a throw with it left set
+	// stops the socket sending for good -- the same wedge as the in-progress
+	// flag, one flag over.
+	FakeOperations ops;
+	FakeEvents events;
+	CUtpSocketTransport transport = MakeTransport(ops, &events);
+	events.onFlushRequested = [&]() { throw std::runtime_error("sink"); };
+	const std::vector<uint8_t> payload = Pattern(8, 6);
+
+	bool threw = false;
+	try {
+		transport.Write(payload.data(), static_cast<uint32_t>(payload.size()));
+	} catch (const std::runtime_error &) {
+		threw = true;
+	}
+	ASSERT_TRUE(threw);
+
+	events.onFlushRequested = nullptr;
+	const int before = events.flushRequests;
+	transport.Write(payload.data(), static_cast<uint32_t>(payload.size()));
 	ASSERT_TRUE(events.flushRequests > before);
 }
 

--- a/unittests/tests/UtpSocketTransportTest.cpp
+++ b/unittests/tests/UtpSocketTransportTest.cpp
@@ -62,11 +62,6 @@ public:
 		lastClosed = socket;
 	}
 	void SetReceiveBuffer(Handle, size_t bytes) override { receiveBound = bytes; }
-	void ReportReadBufferSize(Handle, size_t bytes) override
-	{
-		++reportCalls;
-		reportedBuffered = bytes;
-	}
 
 	size_t acceptLimit = 1024 * 1024;
 	std::vector<uint8_t> offered;
@@ -74,8 +69,6 @@ public:
 	Handle lastWriteSocket = nullptr;
 	Handle lastClosed = nullptr;
 	int drainedCalls = 0;
-	int reportCalls = 0;
-	size_t reportedBuffered = 0;
 	int closeCalls = 0;
 	size_t receiveBound = 0;
 };
@@ -373,27 +366,26 @@ TEST(UtpSocketTransport, ConnectingFlushesWhatTheHandshakeRefused)
 	}
 }
 
-TEST(UtpSocketTransport, TheReceiveBoundIsAlwaysPairedWithOccupancy)
+TEST(UtpSocketTransport, ReadBufferSizeTracksCurrentOccupancy)
 {
-	// libutp advertises opt_rcvbuf minus the reported occupancy, and an unset
-	// report is zero -- so setting the buffer alone lowers the ceiling to a
-	// sixteenth of the default and adds no backpressure at all.
 	FakeOperations ops;
 	CUtpSocketTransport transport = MakeTransport(ops);
+	const CUtpSocketTransport &reader = transport;
+	ASSERT_EQUALS(0u, (unsigned)reader.ReadBufferSize());
 	const std::vector<uint8_t> payload = Pattern(40);
 	transport.OnPayload(payload.data(), payload.size());
 
 	transport.ApplyReceiveBound();
 	ASSERT_EQUALS((unsigned)CUtpStream::kDefaultReadBound, (unsigned)ops.receiveBound);
-	ASSERT_EQUALS(1, ops.reportCalls);
-	ASSERT_EQUALS(40u, (unsigned)ops.reportedBuffered);
+	ASSERT_EQUALS(40u, (unsigned)reader.ReadBufferSize());
 
-	// And it has to keep tracking, or the window never reopens as the reader
-	// catches up.
 	uint8_t out[40] = { 0 };
-	transport.Read(out, sizeof(out));
-	ASSERT_EQUALS(2, ops.reportCalls);
-	ASSERT_EQUALS(0u, (unsigned)ops.reportedBuffered);
+	ASSERT_EQUALS(15u, transport.Read(out, 15));
+	ASSERT_EQUALS(25u, (unsigned)reader.ReadBufferSize());
+	ASSERT_EQUALS(25u, transport.Read(out, sizeof(out)));
+	ASSERT_EQUALS(0u, (unsigned)reader.ReadBufferSize());
+	ASSERT_EQUALS(0u, transport.Read(out, sizeof(out)));
+	ASSERT_EQUALS(0u, (unsigned)reader.ReadBufferSize());
 }
 
 TEST(UtpSocketTransport, AnOfferIsBoundedRatherThanTheWholeBacklog)

--- a/unittests/tests/UtpSocketTransportTest.cpp
+++ b/unittests/tests/UtpSocketTransportTest.cpp
@@ -35,6 +35,8 @@
 
 #include <UtpSocketTransport.h>
 
+#include <thread>
+
 using namespace muleunit;
 
 DECLARE_SIMPLE(UtpSocketTransport)
@@ -60,6 +62,11 @@ public:
 		lastClosed = socket;
 	}
 	void SetReceiveBuffer(Handle, size_t bytes) override { receiveBound = bytes; }
+	void ReportReadBufferSize(Handle, size_t bytes) override
+	{
+		++reportCalls;
+		reportedBuffered = bytes;
+	}
 
 	size_t acceptLimit = 1024 * 1024;
 	std::vector<uint8_t> offered;
@@ -67,6 +74,8 @@ public:
 	Handle lastWriteSocket = nullptr;
 	Handle lastClosed = nullptr;
 	int drainedCalls = 0;
+	int reportCalls = 0;
+	size_t reportedBuffered = 0;
 	int closeCalls = 0;
 	size_t receiveBound = 0;
 };
@@ -77,8 +86,9 @@ public:
 	void OnStreamReadable() override { ++readable; }
 	void OnStreamWritable() override { ++writable; }
 	void OnStreamLost() override { ++lost; }
+	void OnFlushRequested() override { ++flushRequests; }
 
-	int readable = 0, writable = 0, lost = 0;
+	int readable = 0, writable = 0, lost = 0, flushRequests = 0;
 };
 
 //! A handle value that is never dereferenced, only compared.
@@ -88,9 +98,9 @@ IUtpSocketOperations::Handle Handle()
 	return &marker;
 }
 
-CUtpSocketTransport MakeTransport(FakeOperations &ops)
+CUtpSocketTransport MakeTransport(FakeOperations &ops, IStreamTransportEvents *events = nullptr)
 {
-	return CUtpSocketTransport(ops, Handle(), CNetworkAddress::FromString("192.0.2.7"), 4662);
+	return CUtpSocketTransport(ops, Handle(), CNetworkAddress::FromString("192.0.2.7"), 4662, events);
 }
 
 std::vector<uint8_t> Pattern(size_t length, uint8_t seed = 0)
@@ -183,10 +193,10 @@ TEST(UtpSocketTransport, FlushWithNothingQueuedMakesNoCall)
 TEST(UtpSocketTransport, ReadingToEmptyTellsTheLibraryOnce)
 {
 	FakeOperations ops;
-	CUtpSocketTransport transport = MakeTransport(ops);
 	FakeEvents events;
+	CUtpSocketTransport transport = MakeTransport(ops, &events);
 	const std::vector<uint8_t> payload = Pattern(6);
-	transport.OnPayload(payload.data(), payload.size(), &events);
+	transport.OnPayload(payload.data(), payload.size());
 	ASSERT_EQUALS(1, events.readable);
 
 	uint8_t out[6] = { 0 };
@@ -227,7 +237,7 @@ TEST(UtpSocketTransport, AClosedHandleIsNeverUsedAgain)
 	CUtpSocketTransport transport = MakeTransport(ops);
 	const std::vector<uint8_t> payload = Pattern(4);
 	FakeEvents events;
-	transport.OnPayload(payload.data(), payload.size(), &events);
+	transport.OnPayload(payload.data(), payload.size());
 	transport.Write(payload.data(), 4);
 
 	transport.Close();
@@ -248,8 +258,8 @@ TEST(UtpSocketTransport, DestroyingNeverClosesTheDeadHandle)
 	FakeOperations ops;
 	FakeEvents events;
 	{
-		CUtpSocketTransport transport = MakeTransport(ops);
-		transport.OnEnded(EUtpTransportFailure::Destroying, &events);
+		CUtpSocketTransport transport = MakeTransport(ops, &events);
+		transport.OnEnded(EUtpTransportFailure::Destroying);
 		ASSERT_EQUALS(1, events.lost);
 		ASSERT_EQUALS(0, ops.closeCalls);
 		transport.Close();
@@ -262,10 +272,10 @@ TEST(UtpSocketTransport, NothingReachesTheLibraryAfterTheStreamEnds)
 {
 	FakeOperations ops;
 	FakeEvents events;
-	CUtpSocketTransport transport = MakeTransport(ops);
+	CUtpSocketTransport transport = MakeTransport(ops, &events);
 	const std::vector<uint8_t> payload = Pattern(4);
 	transport.Write(payload.data(), 4);
-	transport.OnEnded(EUtpTransportFailure::Reset, &events);
+	transport.OnEnded(EUtpTransportFailure::Reset);
 
 	transport.Flush();
 	ASSERT_EQUALS(0u, (unsigned)ops.offered.size());
@@ -278,8 +288,8 @@ TEST(UtpSocketTransport, ACleanEndIsNotAnError)
 {
 	FakeOperations ops;
 	FakeEvents events;
-	CUtpSocketTransport transport = MakeTransport(ops);
-	transport.OnEnded(EUtpTransportFailure::Eof, &events);
+	CUtpSocketTransport transport = MakeTransport(ops, &events);
+	transport.OnEnded(EUtpTransportFailure::Eof);
 	ASSERT_FALSE(transport.IsOk());
 	ASSERT_EQUALS(0, transport.LastError());
 	ASSERT_EQUALS(1, events.lost);
@@ -289,9 +299,9 @@ TEST(UtpSocketTransport, ConnectingReportsWritableOnce)
 {
 	FakeOperations ops;
 	FakeEvents events;
-	CUtpSocketTransport transport = MakeTransport(ops);
+	CUtpSocketTransport transport = MakeTransport(ops, &events);
 	ASSERT_FALSE(transport.IsConnected());
-	transport.OnConnected(&events);
+	transport.OnConnected();
 	ASSERT_TRUE(transport.IsConnected());
 	ASSERT_EQUALS(1, events.writable);
 }
@@ -301,7 +311,7 @@ TEST(UtpSocketTransport, AWindowOpeningFlushesAndUnblocksOnlyWhenItHelps)
 	FakeOperations ops;
 	ops.acceptLimit = 0;
 	FakeEvents events;
-	CUtpSocketTransport transport(ops, Handle(), CNetworkAddress::FromString("192.0.2.7"), 4662);
+	CUtpSocketTransport transport(ops, Handle(), CNetworkAddress::FromString("192.0.2.7"), 4662, &events);
 
 	// Fill the queue past its bound so the writer is blocked.
 	const std::vector<uint8_t> payload = Pattern(CUtpStream::kDefaultWriteBound + 16, 5);
@@ -310,24 +320,126 @@ TEST(UtpSocketTransport, AWindowOpeningFlushesAndUnblocksOnlyWhenItHelps)
 
 	// A window that opens while libutp still takes nothing leaves the writer
 	// blocked: our own queue is what is full.
-	transport.OnWritable(&events);
+	transport.OnWritable();
 	ASSERT_TRUE(transport.BlocksWrite());
 	ASSERT_EQUALS(0, events.writable);
 
 	ops.acceptLimit = CUtpStream::kDefaultWriteBound;
-	transport.OnWritable(&events);
+	transport.OnWritable();
 	ASSERT_FALSE(transport.BlocksWrite());
 	ASSERT_EQUALS(1, events.writable);
 }
 
-TEST(UtpSocketTransport, TheReceiveBoundIsWhatReachesTheLibrary)
+TEST(UtpSocketTransport, QueueingAsksForAFlushOncePerIdlePeriod)
 {
-	// Until this is applied, libutp's own default governs rather than ours.
+	// The only other trigger is a full window reopening, so bytes queued while
+	// the window was never full would otherwise sit there. Raised on the
+	// idle-to-busy edge, so a busy socket does not post an event per write.
+	FakeOperations ops;
+	ops.acceptLimit = 0;
+	FakeEvents events;
+	CUtpSocketTransport transport = MakeTransport(ops, &events);
+	const std::vector<uint8_t> payload = Pattern(8);
+
+	transport.Write(payload.data(), 8);
+	ASSERT_EQUALS(1, events.flushRequests);
+	transport.Write(payload.data(), 8);
+	transport.Write(payload.data(), 8);
+	ASSERT_EQUALS(1, events.flushRequests);
+
+	transport.Flush();
+	transport.Write(payload.data(), 8);
+	ASSERT_EQUALS(2, events.flushRequests);
+}
+
+TEST(UtpSocketTransport, ConnectingFlushesWhatTheHandshakeRefused)
+{
+	// utp_write() takes nothing before the handshake completes, so everything
+	// queued until then is still waiting and has no writable edge coming.
+	FakeOperations ops;
+	ops.acceptLimit = 0;
+	FakeEvents events;
+	CUtpSocketTransport transport = MakeTransport(ops, &events);
+	const std::vector<uint8_t> payload = Pattern(12, 4);
+	transport.Write(payload.data(), 12);
+	transport.Flush();
+	ASSERT_EQUALS(0u, (unsigned)ops.accepted.size());
+
+	ops.acceptLimit = 64;
+	transport.OnConnected();
+	ASSERT_EQUALS(12u, (unsigned)ops.accepted.size());
+	for (size_t i = 0; i < payload.size(); ++i) {
+		ASSERT_EQUALS((int)payload[i], (int)ops.accepted[i]);
+	}
+}
+
+TEST(UtpSocketTransport, TheReceiveBoundIsAlwaysPairedWithOccupancy)
+{
+	// libutp advertises opt_rcvbuf minus the reported occupancy, and an unset
+	// report is zero -- so setting the buffer alone lowers the ceiling to a
+	// sixteenth of the default and adds no backpressure at all.
 	FakeOperations ops;
 	CUtpSocketTransport transport = MakeTransport(ops);
-	ASSERT_EQUALS(0u, (unsigned)ops.receiveBound);
+	const std::vector<uint8_t> payload = Pattern(40);
+	transport.OnPayload(payload.data(), payload.size());
+
 	transport.ApplyReceiveBound();
 	ASSERT_EQUALS((unsigned)CUtpStream::kDefaultReadBound, (unsigned)ops.receiveBound);
+	ASSERT_EQUALS(1, ops.reportCalls);
+	ASSERT_EQUALS(40u, (unsigned)ops.reportedBuffered);
+
+	// And it has to keep tracking, or the window never reopens as the reader
+	// catches up.
+	uint8_t out[40] = { 0 };
+	transport.Read(out, sizeof(out));
+	ASSERT_EQUALS(2, ops.reportCalls);
+	ASSERT_EQUALS(0u, (unsigned)ops.reportedBuffered);
+}
+
+TEST(UtpSocketTransport, AnOfferIsBoundedRatherThanTheWholeBacklog)
+{
+	// A blocked socket would otherwise have its entire queue copied on every
+	// attempt, for bytes libutp cannot take in one call anyway.
+	FakeOperations ops;
+	ops.acceptLimit = 0;
+	CUtpSocketTransport transport = MakeTransport(ops);
+	const std::vector<uint8_t> payload = Pattern(CUtpStream::kDefaultWriteBound, 2);
+	transport.Write(payload.data(), static_cast<uint32_t>(payload.size()));
+
+	transport.Flush();
+	ASSERT_TRUE(ops.offered.size() > 0u);
+	ASSERT_TRUE(ops.offered.size() <= 64u * 1024u);
+}
+
+TEST(UtpSocketTransport, WritingWhileFlushingDoesNotCorruptTheQueue)
+{
+	// Write() runs on the upload bandwidth thread while Flush() runs on the
+	// main one, both over the same queue. Without a lock this is a data race
+	// on a std::deque, which no amount of careful ordering makes safe.
+	FakeOperations ops;
+	ops.acceptLimit = 32;
+	CUtpSocketTransport transport = MakeTransport(ops);
+	const std::vector<uint8_t> chunk = Pattern(32, 11);
+
+	std::thread writer([&transport, &chunk]() {
+		for (int i = 0; i < 500; ++i) {
+			transport.Write(chunk.data(), static_cast<uint32_t>(chunk.size()));
+		}
+	});
+	for (int i = 0; i < 500; ++i) {
+		transport.Flush();
+	}
+	writer.join();
+	while (transport.PendingWriteBytes() != 0) {
+		transport.Flush();
+	}
+
+	// Every byte that was accepted came out in the pattern's order, so nothing
+	// was duplicated, dropped or interleaved.
+	ASSERT_TRUE(ops.accepted.size() % chunk.size() == 0);
+	for (size_t i = 0; i < ops.accepted.size(); ++i) {
+		ASSERT_EQUALS((int)chunk[i % chunk.size()], (int)ops.accepted[i]);
+	}
 }
 
 // File_checked_for_headers

--- a/unittests/tests/UtpSocketTransportTest.cpp
+++ b/unittests/tests/UtpSocketTransportTest.cpp
@@ -728,6 +728,48 @@ TEST(UtpSocketTransport, AFullyAcceptedFlushStillConsumesTheReentryRecord)
 	ASSERT_TRUE(payload == ops.accepted);
 }
 
+// The other half of the re-entry record: clearing the in-progress flag is not enough if the
+// pending flag survives. A request raised during the unlocked offer -- OnPayload() completing an
+// inbound handshake is the real case -- makes the sink re-enter Flush(), which returns early. If
+// that early return leaves m_flushPending set, the tail consumes the re-entry record and then gets
+// nothing from RequestFlushLocked(), which short-circuits on that same flag. Write() short-circuits
+// on it too, so nothing ever asks again and the queue strands with IsOk() still true.
+TEST(UtpSocketTransport, AReentryDuringTheOfferStillLeavesTheQueueFlushable)
+{
+	FakeOperations ops;
+	ops.acceptLimit = 8;
+	FakeEvents events;
+	CUtpSocketTransport transport = MakeTransport(ops, &events);
+
+	// A synchronous sink, the way a same-thread owner would be wired.
+	events.onFlushRequested = [&]() { transport.Flush(); };
+
+	const std::vector<uint8_t> payload = Pattern(64, 9);
+	transport.Write(payload.data(), static_cast<uint32_t>(payload.size()));
+
+	// Payload arriving while the offer is in flight: this is what raises a request inside the
+	// window where a re-entrant Flush() can only record itself.
+	const std::vector<uint8_t> inbound = Pattern(4, 200);
+	bool delivered = false;
+	ops.onWrite = [&]() {
+		if (!delivered) {
+			delivered = true;
+			transport.OnPayload(inbound.data(), inbound.size());
+		}
+	};
+
+	transport.Flush();
+	ASSERT_TRUE(delivered);
+
+	// The queue must still be drainable. Without the fix nothing requests a flush again, so
+	// this write cannot get one either and the bytes sit there for good.
+	const size_t before = transport.PendingWriteBytes();
+	ASSERT_TRUE(before > 0u);
+	const std::vector<uint8_t> more = Pattern(4, 77);
+	transport.Write(more.data(), static_cast<uint32_t>(more.size()));
+	ASSERT_TRUE(transport.PendingWriteBytes() < before + more.size());
+}
+
 TEST(UtpSocketTransport, AThrowingFlushSinkDoesNotStopLaterRequests)
 {
 	// m_flushPending gates every later request, so a throw with it left set

--- a/unittests/tests/UtpSocketTransportTest.cpp
+++ b/unittests/tests/UtpSocketTransportTest.cpp
@@ -36,6 +36,7 @@
 #include <UtpSocketTransport.h>
 
 #include <functional>
+#include <stdexcept>
 #include <thread>
 
 using namespace muleunit;
@@ -631,6 +632,65 @@ TEST(UtpSocketTransport, ALocalCloseIsNotReportedAsThePeersEof)
 	ASSERT_TRUE(transport.Failure() == EUtpTransportFailure::Closed);
 	ASSERT_EQUALS(0, transport.LastError());
 	ASSERT_FALSE(transport.IsOk());
+}
+
+TEST(UtpSocketTransport, IncomingPayloadReleasesAReplyQueuedAtAccept)
+{
+	// libutp completes an inbound handshake silently: CS_SYN_RECV becomes
+	// CS_CONNECTED on the peer's first ST_DATA with no callback, and until
+	// then utp_writev refuses everything without arming a writable edge. So
+	// this payload is the only signal that the reply can now go out.
+	FakeOperations ops;
+	ops.acceptLimit = 0;
+	FakeEvents events;
+	CUtpSocketTransport transport = MakeTransport(ops, &events);
+	transport.MarkConnected();
+	const std::vector<uint8_t> reply = Pattern(16, 7);
+	transport.Write(reply.data(), static_cast<uint32_t>(reply.size()));
+	transport.Flush();
+	ASSERT_EQUALS(0u, (unsigned)ops.accepted.size());
+	const int before = events.flushRequests;
+
+	const std::vector<uint8_t> incoming = Pattern(8, 1);
+	transport.OnPayload(incoming.data(), incoming.size());
+	ASSERT_EQUALS(before + 1, events.flushRequests);
+
+	ops.acceptLimit = 64;
+	transport.Flush();
+	ASSERT_TRUE(reply == ops.accepted);
+}
+
+TEST(UtpSocketTransport, AThrowingWritableSinkDoesNotWedgeTheFlushPath)
+{
+	// The in-progress flag is what stops a reentrant flush duplicating bytes.
+	// Left set by an exception it would stop Write() requesting flushes at
+	// all -- silently, with IsOk() still true.
+	class CThrowingEvents : public FakeEvents
+	{
+	public:
+		void OnStreamWritable() override { throw std::runtime_error("sink"); }
+	};
+	FakeOperations ops;
+	ops.acceptLimit = CUtpStream::kDefaultWriteBound;
+	CThrowingEvents events;
+	CUtpSocketTransport transport = MakeTransport(ops, &events);
+	const std::vector<uint8_t> payload = Pattern(CUtpStream::kDefaultWriteBound, 5);
+	transport.Write(payload.data(), static_cast<uint32_t>(payload.size()));
+
+	bool threw = false;
+	try {
+		transport.Flush();
+	} catch (const std::runtime_error &) {
+		threw = true;
+	}
+	ASSERT_TRUE(threw);
+
+	// Still usable: the queue drains and queueing still asks for a flush.
+	const int before = events.flushRequests;
+	transport.Flush();
+	const std::vector<uint8_t> more = Pattern(8, 2);
+	transport.Write(more.data(), static_cast<uint32_t>(more.size()));
+	ASSERT_TRUE(events.flushRequests > before);
 }
 
 // File_checked_for_headers

--- a/unittests/tests/UtpSocketTransportTest.cpp
+++ b/unittests/tests/UtpSocketTransportTest.cpp
@@ -1,0 +1,333 @@
+//
+// This file is part of the aMule Project.
+//
+// Copyright (c) 2003-2026 aMule Team ( https://amule-org.github.io )
+//
+// Any parts of this program derived from the xMule, lMule or eMule project,
+// or contributed by third-party developers are copyrighted by their
+// respective authors.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301, USA
+//
+
+// The transport between CUtpStream and one libutp socket.
+//
+// Two properties carry the weight. First, a partial write: utp_write() takes
+// less than it is offered as soon as the congestion window fills, and nothing
+// at all before the socket is connected, so the refused tail has to stay in the
+// queue the bound can see. Second, the close: utp_close() must happen exactly
+// once, and UTP_STATE_DESTROYING invalidates the handle before it arrives, so
+// a destructor that closes after a DESTROYING callback is a double free.
+
+#include <muleunit/test.h>
+
+#include <UtpSocketTransport.h>
+
+using namespace muleunit;
+
+DECLARE_SIMPLE(UtpSocketTransport)
+
+namespace
+{
+//! Records every libutp call and decides how much a write may take.
+class FakeOperations : public IUtpSocketOperations
+{
+public:
+	size_t WriteToSocket(Handle socket, const uint8_t *data, size_t length) override
+	{
+		lastWriteSocket = socket;
+		const size_t taken = length < acceptLimit ? length : acceptLimit;
+		offered.insert(offered.end(), data, data + length);
+		accepted.insert(accepted.end(), data, data + taken);
+		return taken;
+	}
+	void NotifyReadDrained(Handle) override { ++drainedCalls; }
+	void CloseSocket(Handle socket) override
+	{
+		++closeCalls;
+		lastClosed = socket;
+	}
+	void SetReceiveBuffer(Handle, size_t bytes) override { receiveBound = bytes; }
+
+	size_t acceptLimit = 1024 * 1024;
+	std::vector<uint8_t> offered;
+	std::vector<uint8_t> accepted;
+	Handle lastWriteSocket = nullptr;
+	Handle lastClosed = nullptr;
+	int drainedCalls = 0;
+	int closeCalls = 0;
+	size_t receiveBound = 0;
+};
+
+class FakeEvents : public IStreamTransportEvents
+{
+public:
+	void OnStreamReadable() override { ++readable; }
+	void OnStreamWritable() override { ++writable; }
+	void OnStreamLost() override { ++lost; }
+
+	int readable = 0, writable = 0, lost = 0;
+};
+
+//! A handle value that is never dereferenced, only compared.
+IUtpSocketOperations::Handle Handle()
+{
+	static int marker = 0;
+	return &marker;
+}
+
+CUtpSocketTransport MakeTransport(FakeOperations &ops)
+{
+	return CUtpSocketTransport(ops, Handle(), CNetworkAddress::FromString("192.0.2.7"), 4662);
+}
+
+std::vector<uint8_t> Pattern(size_t length, uint8_t seed = 0)
+{
+	std::vector<uint8_t> bytes(length);
+	for (size_t i = 0; i < length; ++i) {
+		bytes[i] = static_cast<uint8_t>((i * 17 + seed) & 0xFF);
+	}
+	return bytes;
+}
+} // namespace
+
+TEST(UtpSocketTransport, PeerIdentityIsCarriedWhole)
+{
+	FakeOperations ops;
+	CUtpSocketTransport transport = MakeTransport(ops);
+	ASSERT_TRUE(transport.GetPeerAddress() == CNetworkAddress::FromString("192.0.2.7"));
+	ASSERT_EQUALS(4662, (int)transport.GetPeerPort());
+}
+
+TEST(UtpSocketTransport, WriteQueuesWithoutTouchingTheLibrary)
+{
+	// Write() is reached from the upload bandwidth thread, so it must not make
+	// a library call: utp_write() can produce callbacks on a thread libutp
+	// knows nothing about.
+	FakeOperations ops;
+	CUtpSocketTransport transport = MakeTransport(ops);
+	const std::vector<uint8_t> payload = Pattern(64);
+
+	ASSERT_EQUALS(64u, transport.Write(payload.data(), 64));
+	ASSERT_EQUALS(0u, (unsigned)ops.offered.size());
+
+	transport.Flush();
+	ASSERT_EQUALS(64u, (unsigned)ops.accepted.size());
+	for (size_t i = 0; i < payload.size(); ++i) {
+		ASSERT_EQUALS((int)payload[i], (int)ops.accepted[i]);
+	}
+}
+
+TEST(UtpSocketTransport, RefusedBytesAreOfferedAgainOnTheNextFlush)
+{
+	FakeOperations ops;
+	ops.acceptLimit = 10;
+	CUtpSocketTransport transport = MakeTransport(ops);
+	const std::vector<uint8_t> payload = Pattern(25, 3);
+	ASSERT_EQUALS(25u, transport.Write(payload.data(), 25));
+
+	transport.Flush();
+	ASSERT_EQUALS(10u, (unsigned)ops.accepted.size());
+
+	ops.acceptLimit = 1024;
+	transport.Flush();
+	ASSERT_EQUALS(25u, (unsigned)ops.accepted.size());
+	// Every byte exactly once, in order: the refused tail was kept, not resent
+	// from the start and not dropped.
+	for (size_t i = 0; i < payload.size(); ++i) {
+		ASSERT_EQUALS((int)payload[i], (int)ops.accepted[i]);
+	}
+}
+
+TEST(UtpSocketTransport, AWriteRefusedEntirelyLosesNothing)
+{
+	// utp_write() returns zero while the socket is not yet connected.
+	FakeOperations ops;
+	ops.acceptLimit = 0;
+	CUtpSocketTransport transport = MakeTransport(ops);
+	const std::vector<uint8_t> payload = Pattern(8, 9);
+	transport.Write(payload.data(), 8);
+
+	transport.Flush();
+	transport.Flush();
+	ASSERT_EQUALS(0u, (unsigned)ops.accepted.size());
+
+	ops.acceptLimit = 8;
+	transport.Flush();
+	ASSERT_EQUALS(8u, (unsigned)ops.accepted.size());
+	for (size_t i = 0; i < payload.size(); ++i) {
+		ASSERT_EQUALS((int)payload[i], (int)ops.accepted[i]);
+	}
+}
+
+TEST(UtpSocketTransport, FlushWithNothingQueuedMakesNoCall)
+{
+	FakeOperations ops;
+	CUtpSocketTransport transport = MakeTransport(ops);
+	transport.Flush();
+	ASSERT_TRUE(ops.lastWriteSocket == nullptr);
+}
+
+TEST(UtpSocketTransport, ReadingToEmptyTellsTheLibraryOnce)
+{
+	FakeOperations ops;
+	CUtpSocketTransport transport = MakeTransport(ops);
+	FakeEvents events;
+	const std::vector<uint8_t> payload = Pattern(6);
+	transport.OnPayload(payload.data(), payload.size(), &events);
+	ASSERT_EQUALS(1, events.readable);
+
+	uint8_t out[6] = { 0 };
+	ASSERT_EQUALS(3u, transport.Read(out, 3));
+	// Still buffered, so libutp has not been kept waiting.
+	ASSERT_EQUALS(0, ops.drainedCalls);
+
+	ASSERT_EQUALS(3u, transport.Read(out, 3));
+	ASSERT_EQUALS(1, ops.drainedCalls);
+
+	// Reading an empty buffer is a would-block, not another drain.
+	ASSERT_EQUALS(0u, transport.Read(out, 3));
+	ASSERT_EQUALS(1, ops.drainedCalls);
+	ASSERT_TRUE(transport.BlocksRead());
+	ASSERT_EQUALS(0, transport.LastError());
+}
+
+TEST(UtpSocketTransport, CloseHappensExactlyOnce)
+{
+	FakeOperations ops;
+	{
+		CUtpSocketTransport transport = MakeTransport(ops);
+		transport.Close();
+		ASSERT_EQUALS(1, ops.closeCalls);
+		transport.Close();
+		ASSERT_EQUALS(1, ops.closeCalls);
+	}
+	// The destructor must not close again.
+	ASSERT_EQUALS(1, ops.closeCalls);
+}
+
+TEST(UtpSocketTransport, AClosedHandleIsNeverUsedAgain)
+{
+	// The cleared handle is the single guard, so every other call has to
+	// respect it too -- a flush or a drained notification against a closed
+	// socket is the same use-after-free as a second close.
+	FakeOperations ops;
+	CUtpSocketTransport transport = MakeTransport(ops);
+	const std::vector<uint8_t> payload = Pattern(4);
+	FakeEvents events;
+	transport.OnPayload(payload.data(), payload.size(), &events);
+	transport.Write(payload.data(), 4);
+
+	transport.Close();
+	ASSERT_EQUALS(1, ops.closeCalls);
+
+	transport.Flush();
+	ASSERT_EQUALS(0u, (unsigned)ops.offered.size());
+
+	uint8_t out[4] = { 0 };
+	transport.Read(out, sizeof(out));
+	ASSERT_EQUALS(0, ops.drainedCalls);
+}
+
+TEST(UtpSocketTransport, DestroyingNeverClosesTheDeadHandle)
+{
+	// UTP_STATE_DESTROYING invalidates the handle before the callback returns,
+	// so closing it afterwards is a use-after-free rather than tidiness.
+	FakeOperations ops;
+	FakeEvents events;
+	{
+		CUtpSocketTransport transport = MakeTransport(ops);
+		transport.OnEnded(EUtpTransportFailure::Destroying, &events);
+		ASSERT_EQUALS(1, events.lost);
+		ASSERT_EQUALS(0, ops.closeCalls);
+		transport.Close();
+		ASSERT_EQUALS(0, ops.closeCalls);
+	}
+	ASSERT_EQUALS(0, ops.closeCalls);
+}
+
+TEST(UtpSocketTransport, NothingReachesTheLibraryAfterTheStreamEnds)
+{
+	FakeOperations ops;
+	FakeEvents events;
+	CUtpSocketTransport transport = MakeTransport(ops);
+	const std::vector<uint8_t> payload = Pattern(4);
+	transport.Write(payload.data(), 4);
+	transport.OnEnded(EUtpTransportFailure::Reset, &events);
+
+	transport.Flush();
+	ASSERT_EQUALS(0u, (unsigned)ops.offered.size());
+	ASSERT_FALSE(transport.IsOk());
+	ASSERT_FALSE(transport.IsConnected());
+	ASSERT_TRUE(transport.LastError() != 0);
+}
+
+TEST(UtpSocketTransport, ACleanEndIsNotAnError)
+{
+	FakeOperations ops;
+	FakeEvents events;
+	CUtpSocketTransport transport = MakeTransport(ops);
+	transport.OnEnded(EUtpTransportFailure::Eof, &events);
+	ASSERT_FALSE(transport.IsOk());
+	ASSERT_EQUALS(0, transport.LastError());
+	ASSERT_EQUALS(1, events.lost);
+}
+
+TEST(UtpSocketTransport, ConnectingReportsWritableOnce)
+{
+	FakeOperations ops;
+	FakeEvents events;
+	CUtpSocketTransport transport = MakeTransport(ops);
+	ASSERT_FALSE(transport.IsConnected());
+	transport.OnConnected(&events);
+	ASSERT_TRUE(transport.IsConnected());
+	ASSERT_EQUALS(1, events.writable);
+}
+
+TEST(UtpSocketTransport, AWindowOpeningFlushesAndUnblocksOnlyWhenItHelps)
+{
+	FakeOperations ops;
+	ops.acceptLimit = 0;
+	FakeEvents events;
+	CUtpSocketTransport transport(ops, Handle(), CNetworkAddress::FromString("192.0.2.7"), 4662);
+
+	// Fill the queue past its bound so the writer is blocked.
+	const std::vector<uint8_t> payload = Pattern(CUtpStream::kDefaultWriteBound + 16, 5);
+	transport.Write(payload.data(), static_cast<uint32_t>(payload.size()));
+	ASSERT_TRUE(transport.BlocksWrite());
+
+	// A window that opens while libutp still takes nothing leaves the writer
+	// blocked: our own queue is what is full.
+	transport.OnWritable(&events);
+	ASSERT_TRUE(transport.BlocksWrite());
+	ASSERT_EQUALS(0, events.writable);
+
+	ops.acceptLimit = CUtpStream::kDefaultWriteBound;
+	transport.OnWritable(&events);
+	ASSERT_FALSE(transport.BlocksWrite());
+	ASSERT_EQUALS(1, events.writable);
+}
+
+TEST(UtpSocketTransport, TheReceiveBoundIsWhatReachesTheLibrary)
+{
+	// Until this is applied, libutp's own default governs rather than ours.
+	FakeOperations ops;
+	CUtpSocketTransport transport = MakeTransport(ops);
+	ASSERT_EQUALS(0u, (unsigned)ops.receiveBound);
+	transport.ApplyReceiveBound();
+	ASSERT_EQUALS((unsigned)CUtpStream::kDefaultReadBound, (unsigned)ops.receiveBound);
+}
+
+// File_checked_for_headers

--- a/unittests/tests/UtpSocketTransportTest.cpp
+++ b/unittests/tests/UtpSocketTransportTest.cpp
@@ -35,6 +35,7 @@
 
 #include <UtpSocketTransport.h>
 
+#include <functional>
 #include <thread>
 
 using namespace muleunit;
@@ -47,9 +48,15 @@ namespace
 class FakeOperations : public IUtpSocketOperations
 {
 public:
-	size_t WriteToSocket(Handle socket, const uint8_t *data, size_t length) override
+	std::ptrdiff_t WriteToSocket(Handle socket, const uint8_t *data, size_t length) override
 	{
 		lastWriteSocket = socket;
+		if (onWrite) {
+			onWrite();
+		}
+		if (refuseWithError) {
+			return -1;
+		}
 		const size_t taken = length < acceptLimit ? length : acceptLimit;
 		offered.insert(offered.end(), data, data + length);
 		accepted.insert(accepted.end(), data, data + taken);
@@ -60,9 +67,15 @@ public:
 	{
 		++closeCalls;
 		lastClosed = socket;
+		if (onClose) {
+			onClose();
+		}
 	}
 	void SetReceiveBuffer(Handle, size_t bytes) override { receiveBound = bytes; }
 
+	std::function<void()> onWrite;
+	std::function<void()> onClose;
+	bool refuseWithError = false;
 	size_t acceptLimit = 1024 * 1024;
 	std::vector<uint8_t> offered;
 	std::vector<uint8_t> accepted;
@@ -288,13 +301,13 @@ TEST(UtpSocketTransport, ACleanEndIsNotAnError)
 	ASSERT_EQUALS(1, events.lost);
 }
 
-TEST(UtpSocketTransport, ConnectingReportsWritableOnce)
+TEST(UtpSocketTransport, AcceptorMarksInboundConnectedWithoutOutgoingConnectCallback)
 {
 	FakeOperations ops;
 	FakeEvents events;
 	CUtpSocketTransport transport = MakeTransport(ops, &events);
 	ASSERT_FALSE(transport.IsConnected());
-	transport.OnConnected();
+	transport.MarkConnected();
 	ASSERT_TRUE(transport.IsConnected());
 	ASSERT_EQUALS(1, events.writable);
 }
@@ -359,7 +372,7 @@ TEST(UtpSocketTransport, ConnectingFlushesWhatTheHandshakeRefused)
 	ASSERT_EQUALS(0u, (unsigned)ops.accepted.size());
 
 	ops.acceptLimit = 64;
-	transport.OnConnected();
+	transport.MarkConnected();
 	ASSERT_EQUALS(12u, (unsigned)ops.accepted.size());
 	for (size_t i = 0; i < payload.size(); ++i) {
 		ASSERT_EQUALS((int)payload[i], (int)ops.accepted[i]);
@@ -405,9 +418,7 @@ TEST(UtpSocketTransport, AnOfferIsBoundedRatherThanTheWholeBacklog)
 
 TEST(UtpSocketTransport, WritingWhileFlushingDoesNotCorruptTheQueue)
 {
-	// Write() runs on the upload bandwidth thread while Flush() runs on the
-	// main one, both over the same queue. Without a lock this is a data race
-	// on a std::deque, which no amount of careful ordering makes safe.
+	// Concurrency smoke coverage only; passing is not proof of locking.
 	FakeOperations ops;
 	ops.acceptLimit = 32;
 	CUtpSocketTransport transport = MakeTransport(ops);
@@ -432,6 +443,139 @@ TEST(UtpSocketTransport, WritingWhileFlushingDoesNotCorruptTheQueue)
 	for (size_t i = 0; i < ops.accepted.size(); ++i) {
 		ASSERT_EQUALS((int)chunk[i % chunk.size()], (int)ops.accepted[i]);
 	}
+}
+
+TEST(UtpSocketTransport, BoundedFlushSchedulesTheTailAndUnblocksWriter)
+{
+	FakeOperations ops;
+	FakeEvents events;
+	auto transport = MakeTransport(ops, &events);
+	const auto payload = Pattern(CUtpStream::kDefaultWriteBound);
+	transport.Write(payload.data(), static_cast<uint32_t>(payload.size()));
+	transport.Flush();
+	ASSERT_EQUALS(2, events.flushRequests);
+	ASSERT_EQUALS(1, events.writable);
+	while (transport.PendingWriteBytes() != 0) {
+		transport.Flush();
+	}
+	ASSERT_TRUE(payload == ops.accepted);
+	ASSERT_EQUALS(4, events.flushRequests);
+	ASSERT_EQUALS(1, events.writable);
+}
+
+TEST(UtpSocketTransport, DirectFlushNotifiesWhenTheQueueUnblocks)
+{
+	FakeOperations ops;
+	FakeEvents events;
+	auto transport = MakeTransport(ops, &events);
+	const auto payload = Pattern(CUtpStream::kDefaultWriteBound);
+	transport.Write(payload.data(), static_cast<uint32_t>(payload.size()));
+	transport.Flush();
+	ASSERT_FALSE(transport.BlocksWrite());
+	ASSERT_EQUALS(1, events.writable);
+}
+
+TEST(UtpSocketTransport, LocalCloseEndsTheStreamBeforeCallingTheLibrary)
+{
+	FakeOperations ops;
+	auto transport = MakeTransport(ops);
+	transport.MarkConnected();
+	ops.onClose = [&]() {
+		ASSERT_FALSE(transport.IsOk());
+		ASSERT_FALSE(transport.IsConnected());
+		const uint8_t byte = 1;
+		ASSERT_EQUALS(0u, transport.Write(&byte, 1));
+		transport.OnEnded(EUtpTransportFailure::Destroying);
+	};
+	transport.Close();
+	ASSERT_EQUALS(0, transport.LastError());
+	ASSERT_EQUALS(1, ops.closeCalls);
+}
+
+TEST(UtpSocketTransport, DestructorDetachesSinkBeforeDestroyingReentry)
+{
+	FakeOperations ops;
+	FakeEvents events;
+	{
+		auto transport = MakeTransport(ops, &events);
+		ops.onClose = [&]() { transport.OnEnded(EUtpTransportFailure::Destroying); };
+	}
+	ASSERT_EQUALS(1, ops.closeCalls);
+	ASSERT_EQUALS(0, events.lost);
+}
+
+TEST(UtpSocketTransport, NegativeAcceptancePreservesTheQueue)
+{
+	FakeOperations ops;
+	FakeEvents events;
+	auto transport = MakeTransport(ops, &events);
+	const auto payload = Pattern(12);
+	transport.Write(payload.data(), static_cast<uint32_t>(payload.size()));
+	ops.refuseWithError = true;
+	transport.Flush();
+	ASSERT_EQUALS(12u, (unsigned)transport.PendingWriteBytes());
+	ASSERT_EQUALS(1, events.flushRequests);
+	ops.refuseWithError = false;
+	transport.Flush();
+	ASSERT_TRUE(payload == ops.accepted);
+}
+
+TEST(UtpSocketTransport, ZeroAcceptanceDoesNotScheduleAnotherFlush)
+{
+	FakeOperations ops;
+	FakeEvents events;
+	auto transport = MakeTransport(ops, &events);
+	const auto payload = Pattern(12);
+	transport.Write(payload.data(), static_cast<uint32_t>(payload.size()));
+	ops.acceptLimit = 0;
+	transport.Flush();
+	ASSERT_EQUALS(1, events.flushRequests);
+	ASSERT_EQUALS(12u, (unsigned)transport.PendingWriteBytes());
+	ops.acceptLimit = 12;
+	transport.OnWritable();
+	ASSERT_TRUE(payload == ops.accepted);
+	ASSERT_EQUALS(1, events.flushRequests);
+}
+
+TEST(UtpSocketTransport, PartialAcceptanceWaitsForWritableWithoutScheduling)
+{
+	FakeOperations ops;
+	FakeEvents events;
+	auto transport = MakeTransport(ops, &events);
+	const auto payload = Pattern(12);
+	transport.Write(payload.data(), static_cast<uint32_t>(payload.size()));
+	ops.acceptLimit = 5;
+	transport.Flush();
+	ASSERT_EQUALS(1, events.flushRequests);
+	ASSERT_EQUALS(7u, (unsigned)transport.PendingWriteBytes());
+	ops.acceptLimit = 12;
+	transport.OnWritable();
+	ASSERT_TRUE(payload == ops.accepted);
+	ASSERT_EQUALS(0u, (unsigned)transport.PendingWriteBytes());
+	ASSERT_EQUALS(1, events.flushRequests);
+}
+
+TEST(UtpSocketTransport, ReentrantFlushNeverOffersTheSameBytesTwice)
+{
+	FakeOperations ops;
+	FakeEvents events;
+	auto transport = MakeTransport(ops, &events);
+	const auto payload = Pattern(96 * 1024);
+	transport.Write(payload.data(), static_cast<uint32_t>(payload.size()));
+	bool reentered = false;
+	ops.onWrite = [&]() {
+		if (!reentered) {
+			reentered = true;
+			transport.Flush();
+		}
+	};
+	transport.Flush();
+	ASSERT_TRUE(reentered);
+	ASSERT_EQUALS(64u * 1024u, (unsigned)ops.accepted.size());
+	ASSERT_EQUALS(2, events.flushRequests);
+	transport.Flush();
+	ASSERT_TRUE(payload == ops.accepted);
+	ASSERT_TRUE(payload == ops.offered);
 }
 
 // File_checked_for_headers

--- a/unittests/tests/UtpStreamTest.cpp
+++ b/unittests/tests/UtpStreamTest.cpp
@@ -271,12 +271,8 @@ TEST(UtpStream, WritableReopensAWindowOnlyWhenThereIsRoom)
 	ASSERT_TRUE(stream.BlocksWrite());
 
 	// The peer's window opening does not empty our queue, so it does not
-	// unblock a writer that is bounded by our own buffer.
-	stream.OnWritable();
-	ASSERT_TRUE(stream.BlocksWrite());
-
+	// unblock a writer that is bounded by our own buffer. Only draining does.
 	stream.ConsumeQueuedBytes(stream.WriteBufferSize());
-	stream.OnWritable();
 	ASSERT_FALSE(stream.BlocksWrite());
 }
 
@@ -379,18 +375,6 @@ TEST(UtpStream, BufferedBytesSurviveTheEnd)
 	for (size_t i = 0; i < 5; ++i) {
 		ASSERT_EQUALS((int)sent[i], (int)out[i]);
 	}
-}
-
-TEST(UtpStream, CloseOwnershipIsHandedOutExactlyOnce)
-{
-	CUtpStream stream;
-	ASSERT_FALSE(stream.CloseTaken());
-	ASSERT_TRUE(stream.TakeCloseOwnership());
-	ASSERT_TRUE(stream.CloseTaken());
-	// The destructor, the DESTROYING callback and an explicit Close() all ask;
-	// exactly one may call utp_close().
-	ASSERT_FALSE(stream.TakeCloseOwnership());
-	ASSERT_FALSE(stream.TakeCloseOwnership());
 }
 
 // File_checked_for_headers


### PR DESCRIPTION
Refs #1177

Second of three for the uTP stream, on top of #1359. `CUtpSocketTransport`
implements `IStreamTransport` over a `CUtpStream` and one libutp socket. The
acceptor follows; this is the thing it will hand a socket to.

## Inertness

623 insertions, zero deletions, one new header and one suite. Nothing
constructs a transport and nothing includes the header but its test:

```
$ grep -rln 'UtpSocketTransport.h' src unittests
unittests/tests/UtpSocketTransportTest.cpp
```

No `UTP_ON_ACCEPT`, no adapter change, no `CLibSocket` wiring, no capability
bit, no dial. The header pulls neither libutp nor Boost.Asio — checked with
`-H`, zero of each — so the suite runs in every build rather than only under
`ENABLE_UTP`.

## The write path is split, and that is the point

`Write()` is reached from the upload bandwidth thread through `CEMSocket`, so it
**only queues**. Calling `utp_write()` there would be a library call from a
thread libutp knows nothing about, and one that can produce callbacks. The main
thread offers the queue in `Flush()`.

That split is what makes the partial write representable, which is the property
#1359 ended up being about:

| Situation | `utp_write()` takes | Queue keeps |
| --- | --- | --- |
| congestion window full | less than offered | the refused tail |
| not yet connected | nothing | everything |
| window open | all of it | nothing |

`Flush()` peeks, offers, and consumes only what was accepted, so the tail stays
in the queue `WriteBufferSize()` reports and `m_writeBound` bounds. There is no
second queue anywhere.

## The handle is the close token

One mechanism, not two. `Close()` clears `m_socket` before calling, so a second
`Close()`, the destructor and a `DESTROYING` callback all find nothing to close
— and the same pointer check covers `Flush()` and the drained notification,
which is why it is the mechanism rather than a separate flag each of them would
have to consult.

`UTP_STATE_DESTROYING` invalidates the handle before the callback returns, so
`OnEnded(Destroying)` clears it **without** closing.

Worth saying: I first wrote this with `CUtpStream::TakeCloseOwnership()` as
well, and a perturbation showed it changed nothing — removing it left the suite
green, because clearing the handle already guarded every path. One invariant,
one mechanism. That does leave `TakeCloseOwnership()` without a consumer; say if
you would rather the transport use it and drop the pointer check instead,
though the pointer has to be checked anyway for the calls that are not closes.

## Tests

`UtpSocketTransportTest`, 14 cases, checked by perturbation:

| Perturbation | Caught by |
| --- | --- |
| consume the whole queue instead of what was accepted | `RefusedBytesAreOfferedAgainOnTheNextFlush` |
| close without clearing the handle | `AClosedHandleIsNeverUsedAgain` |
| `DESTROYING` leaves the handle set | `DestroyingNeverClosesTheDeadHandle` |
| notify read-drained on every read | `ReadingToEmptyTellsTheLibraryOnce` |

`AWindowOpeningFlushesAndUnblocksOnlyWhenItHelps` is the one worth reading: a
peer's window opening does not unblock a writer whose bytes are stuck in *our*
queue, only a flush that drains it does.

`TheReceiveBoundIsWhatReachesTheLibrary` covers the
`utp_setsockopt(UTP_RCVBUF, ReadBound())` you noted on #1359 — the transport
applies it, so the 64 KiB becomes effective instead of libutp's 1 MiB default,
once the acceptor calls `ApplyReceiveBound()`.

| Configuration | Apps | ctest |
| --- | --- | --- |
| default | amule, amuled, amulegui | 62/62 |
| `-DENABLE_UTP=YES` | amule, amuled, amulegui | 63/63 |

clang-format 18, `git diff --check`, `check-potfiles.sh` clean; the header
compiles standalone.

## Next, and one open question

The acceptor: `UTP_ON_ACCEPT`, the stream-side libutp callbacks driving the
methods above, admission (shutdown, connection limit, IP filter, bans), the
`CoreNotify_LibSocket*` implementation of `IStreamTransportEvents`, and the
real-libutp loopback test asserting a transfer.

Still open from #1359: **should the acceptor advertise `CT_MOD_MISCOPTIONS`
bit 1?** #1177 puts that in step 2, so I have assumed not — which leaves the
acceptor unreachable in practice until then.
