### PR TITLE
fix(net): follow-ups from a post-merge review of the eMuleAI parity work

### DIFF
--- a/docs/EC_Protocol.md
+++ b/docs/EC_Protocol.md
@@ -625,11 +625,11 @@ from the session's absence in the next `EC_OP_CHAT_SESSIONS` reply.
 > `GetInt()` (which handles any integer width); clients sending them
 > should encode them as 32-bit values.
 
-### Peer vendor capabilities (`EC_TAG_CLIENT_MOD_CAPABILITIES = 0x0632`)
+### Peer vendor capabilities (`EC_TAG_CLIENT_MOD_CAPABILITIES = 0x0633`)
 
 | Tag                              | Code     | Type     | Description |
 | -------------------------------- | -------- | -------- | ----------- |
-| `EC_TAG_CLIENT_MOD_CAPABILITIES` | `0x0632` | `uint32` | Peer's eMuleAI vendor capability bitfield |
+| `EC_TAG_CLIENT_MOD_CAPABILITIES` | `0x0633` | `uint32` | Peer's eMuleAI vendor capability bitfield |
 
 A child of `EC_TAG_CLIENT`, carrying what the peer advertised in the
 eD2k handshake tag `CT_MOD_MISCOPTIONS` (`0xAA`):

--- a/src/ClientUDPSocket.cpp
+++ b/src/ClientUDPSocket.cpp
@@ -178,10 +178,16 @@ void CClientUDPSocket::OnPacketReceived(uint32 ip, uint16 port, uint8_t *buffer,
 				// protocol byte is a frame type, so it is dispatched here rather
 				// than through ProcessPacket(), whose second argument is an opcode.
 				//
-				// This branch reaches no packet accounting at all, which is what
+				// Counted as overhead like every sibling branch: these bytes cross
+				// the wire whether or not we can serve the frame, and leaving them
+				// out makes aMule's own figures disagree with what the link shows.
+				//
+				// This branch still reaches no *packet* accounting, which is what
 				// keeps a dropped frame from feeding a ban: CPacketTracking is only
 				// entered from the Kad listener, and an eMuleAI peer's NAT-T
-				// traffic would otherwise read as malformed.
+				// traffic would otherwise read as malformed. Statistics and bans are
+				// separate subsystems; only the second one must stay out of reach.
+				theStats::AddDownOverheadOther(length);
 				ProcessReservedProt2Frame(decryptedBuffer + 1, packetLen - 1, ip, port);
 				break;
 
@@ -210,9 +216,13 @@ void CClientUDPSocket::ProcessReservedProt2Frame(
 		// Nothing but the protocol byte arrived, so there is no type byte to read. Dropped
 		// without reading the window -- the guard is the point, this being the shortest
 		// datagram that can reach here.
-		AddDebugLogLineN(logClientUDP,
-			CFormat("Dropping truncated NAT-T datagram from %s:%u") % Uint32toStringIP(ip) %
-				port);
+		if (m_truncatedFrameLog.ShouldLog(::GetTickCount64())) {
+			AddDebugLogLineN(logClientUDP,
+				CFormat("Dropping truncated NAT-T datagram from %s:%u (%u further "
+					"occurrences suppressed)") %
+					Uint32toStringIP(ip) % port %
+					m_truncatedFrameLog.TakeSuppressedCount());
+		}
 		return;
 
 	case RP2_UNKNOWN_TYPE:
@@ -246,35 +256,55 @@ void CClientUDPSocket::ProcessReservedProt2Frame(
 		// Reached only when libutp has seen the datagram and disclaimed it: it belongs to
 		// no connection it holds. A different reason from the types below, so it does not
 		// borrow their message.
-		AddDebugLogLineN(logClientUDP,
-			CFormat("Dropping uTP frame from %s:%u: not for any open uTP connection") %
-				Uint32toStringIP(ip) % port);
+		if (m_utpUnmatchedFrameLog.ShouldLog(::GetTickCount64())) {
+			AddDebugLogLineN(logClientUDP,
+				CFormat("Dropping uTP frame from %s:%u: not for any open uTP connection "
+					"(%u further occurrences suppressed)") %
+					Uint32toStringIP(ip) % port %
+					m_utpUnmatchedFrameLog.TakeSuppressedCount());
+		}
 #else
-		AddDebugLogLineN(logClientUDP,
-			CFormat("Ignoring uTP NAT-T frame from %s:%u: no uTP transport in this build") %
-				Uint32toStringIP(ip) % port);
+		if (m_unservedFrameLog.ShouldLog(::GetTickCount64())) {
+			AddDebugLogLineN(logClientUDP,
+				CFormat("Ignoring uTP NAT-T frame from %s:%u: no uTP transport in this "
+					"build (%u further occurrences suppressed)") %
+					Uint32toStringIP(ip) % port %
+					m_unservedFrameLog.TakeSuppressedCount());
+		}
 #endif
 		break;
 
 	case OP_NATT_FRAME_QUIC:
-		AddDebugLogLineN(logClientUDP,
-			CFormat("Ignoring QUIC NAT-T frame from %s:%u: no QUIC transport in this build") %
-				Uint32toStringIP(ip) % port);
+		if (m_unservedFrameLog.ShouldLog(::GetTickCount64())) {
+			AddDebugLogLineN(logClientUDP,
+				CFormat("Ignoring QUIC NAT-T frame from %s:%u: no QUIC transport in this "
+					"build (%u further occurrences suppressed)") %
+					Uint32toStringIP(ip) % port %
+					m_unservedFrameLog.TakeSuppressedCount());
+		}
 		break;
 
 	case OP_NATT_FRAME_CAPS:
 	case OP_NATT_FRAME_CAPS_ACK:
 		// Answering the capability negotiation would claim a transport
 		// aMule does not have. Silence is the correct answer here.
-		AddDebugLogLineN(logClientUDP,
-			CFormat("Ignoring NAT-T capability frame 0x%02X from %s:%u: nothing to negotiate") %
-				classified.type % Uint32toStringIP(ip) % port);
+		if (m_unservedFrameLog.ShouldLog(::GetTickCount64())) {
+			AddDebugLogLineN(logClientUDP,
+				CFormat("Ignoring NAT-T capability frame 0x%02X from %s:%u: nothing to "
+					"negotiate (%u further occurrences suppressed)") %
+					classified.type % Uint32toStringIP(ip) % port %
+					m_unservedFrameLog.TakeSuppressedCount());
+		}
 		break;
 
 	case OP_NATT_FRAME_KEY:
-		AddDebugLogLineN(logClientUDP,
-			CFormat("Ignoring NAT-T key frame from %s:%u: no NAT traversal in this build") %
-				Uint32toStringIP(ip) % port);
+		if (m_unservedFrameLog.ShouldLog(::GetTickCount64())) {
+			AddDebugLogLineN(logClientUDP,
+				CFormat("Ignoring NAT-T key frame from %s:%u: no NAT traversal in this "
+					"build (%u further occurrences suppressed)") %
+					Uint32toStringIP(ip) % port %
+					m_unservedFrameLog.TakeSuppressedCount());
+		}
 		break;
 
 	default:

--- a/src/ClientUDPSocket.h
+++ b/src/ClientUDPSocket.h
@@ -27,7 +27,7 @@
 #define CLIENTUDPSOCKET_H
 
 #include "MuleUDPSocket.h"
-#include "ReservedProtocolFrames.h" // Needed for CUnknownFrameLogThrottle
+#include "ReservedProtocolFrames.h" // Needed for CFrameLogThrottle
 
 #ifdef AMULE_UTP_TRANSPORT
 #include "UtpContext.h"
@@ -70,7 +70,14 @@ private:
 	//! One unknown-frame line per minute, with a suppressed count. A peer speaking a frame type
 	//! this build does not know retries, so the useful information is that it happened plus how
 	//! often.
-	CUnknownFrameLogThrottle m_unknownFrameLog{ 60 * 1000 };
+	// One throttle per reason rather than one for the branch: a peer flooding
+	// any single kind of frame must not be able to silence the diagnostics for
+	// the others. The uTP case keeps its own because it is the line a developer
+	// is usually looking for, meaning libutp saw the datagram and disclaimed it.
+	CFrameLogThrottle m_truncatedFrameLog{ 60 * 1000 };
+	CFrameLogThrottle m_unknownFrameLog{ 60 * 1000 };
+	CFrameLogThrottle m_unservedFrameLog{ 60 * 1000 };
+	CFrameLogThrottle m_utpUnmatchedFrameLog{ 60 * 1000 };
 };
 
 #endif // CLIENTUDPSOCKET_H

--- a/src/PublicIPv6Corroboration.h
+++ b/src/PublicIPv6Corroboration.h
@@ -82,6 +82,18 @@
 //! addresses we hold.
 constexpr std::size_t PUBLIC_IPV6_CORROBORATION_THRESHOLD = 3;
 
+/**
+ * How many distinct observers are remembered per candidate.
+ *
+ * Deliberately above the threshold. Recording only as many votes as the quorum
+ * needs leaves no margin: when one observer falls out of the window the count
+ * drops below the quorum and the address is no longer corroborated, even though
+ * other peers had been agreeing the whole time and were turned away at the cap.
+ * The surplus is the redundancy that makes an expiry survivable, and it is what
+ * a peer cannot spend, since the bound still holds.
+ */
+constexpr std::size_t PUBLIC_IPV6_CORROBORATION_MAX_OBSERVERS = 8;
+
 //! How long one observer's claim keeps counting.
 //!
 //! Without a window, "three distinct peers agree" means "three peers said so at some point since
@@ -194,10 +206,11 @@ public:
 			// A peer that is still saying it keeps its vote alive. Without this the
 			// window would expire long-lived peers that never stopped agreeing.
 			observer->lastSeenMs = nowMs;
-		} else if (candidate->observers.size() < PUBLIC_IPV6_CORROBORATION_THRESHOLD) {
-			// Stops growing at the threshold: past it the count answers the only
-			// question asked of it, and extra addresses are just memory a peer can
-			// spend.
+		} else if (candidate->observers.size() < PUBLIC_IPV6_CORROBORATION_MAX_OBSERVERS) {
+			// Bounded, but above the quorum. Stopping at the threshold would mean
+			// the first observer to age out un-corroborates an address that other
+			// live peers still agree on, because their votes were refused at the
+			// cap and there is nothing left to fall back on.
 			Observer fresh;
 			fresh.address = observedFrom;
 			fresh.lastSeenMs = nowMs;

--- a/src/ReservedProtocolFrames.h
+++ b/src/ReservedProtocolFrames.h
@@ -119,11 +119,11 @@ inline SReservedProt2Frame ClassifyReservedProt2Frame(const uint8_t *frame, size
  * Not thread-safe, and does not need to be: the client UDP socket's receive path is posted to the
  * main thread.
  */
-class CUnknownFrameLogThrottle
+class CFrameLogThrottle
 {
 public:
 	//! @param intervalMs minimum gap between two logged lines.
-	explicit CUnknownFrameLogThrottle(uint64_t intervalMs)
+	explicit CFrameLogThrottle(uint64_t intervalMs)
 	: m_intervalMs(intervalMs)
 	{
 	}

--- a/unittests/tests/PublicIPv6CorroborationTest.cpp
+++ b/unittests/tests/PublicIPv6CorroborationTest.cpp
@@ -265,6 +265,54 @@ TEST(PublicIPv6Corroboration, OneObserverRepeatingItselfNeverCorroborates)
 	ASSERT_EQUALS(1u, (unsigned)tracker.DistinctObserversFor(claimed.data()));
 }
 
+// The reason the cap sits above the quorum. Three peers corroborate an address, three more agree
+// later, and when the first three fall out of the window the address is still held up by the
+// others. With the cap equal to the quorum those later votes were refused, so the first expiry
+// dropped the candidate outright even though half the network was still agreeing.
+TEST(PublicIPv6Corroboration, SurplusVotesCarryAnAddressThroughAnExpiry)
+{
+	CPublicIPv6Corroboration tracker;
+	const Address claimed = MakeAddress(0x01);
+	tracker.SetLocalAddresses(Held(claimed), START_MS);
+
+	for (unsigned i = 0; i < PUBLIC_IPV6_CORROBORATION_THRESHOLD; ++i) {
+		tracker.AddClaim(MakeObserver((uint8_t)(i + 1)), claimed.data(), START_MS);
+	}
+	ASSERT_TRUE(tracker.IsCorroborated());
+
+	// A second, later set of peers saying the same thing.
+	const uint64_t later = START_MS + 1000;
+	for (unsigned i = 0; i < PUBLIC_IPV6_CORROBORATION_THRESHOLD; ++i) {
+		tracker.AddClaim(MakeObserver((uint8_t)(i + 1 + PUBLIC_IPV6_CORROBORATION_THRESHOLD)),
+			claimed.data(),
+			later);
+	}
+	ASSERT_EQUALS((unsigned)(PUBLIC_IPV6_CORROBORATION_THRESHOLD * 2),
+		(unsigned)tracker.DistinctObserversFor(claimed.data()));
+
+	// Past the window for the first set, inside it for the second.
+	tracker.SetLocalAddresses(Held(claimed), START_MS + PUBLIC_IPV6_CORROBORATION_WINDOW_MS + 500);
+
+	ASSERT_TRUE(tracker.IsCorroborated());
+	ASSERT_EQUALS((unsigned)PUBLIC_IPV6_CORROBORATION_THRESHOLD,
+		(unsigned)tracker.DistinctObserversFor(claimed.data()));
+}
+
+// The cap is still a cap. Surplus is redundancy, not an unbounded list a peer can grow.
+TEST(PublicIPv6Corroboration, ObserversStopGrowingAtTheCap)
+{
+	CPublicIPv6Corroboration tracker;
+	const Address claimed = MakeAddress(0x01);
+	tracker.SetLocalAddresses(Held(claimed), START_MS);
+
+	for (unsigned i = 0; i < PUBLIC_IPV6_CORROBORATION_MAX_OBSERVERS + 4; ++i) {
+		tracker.AddClaim(MakeObserver((uint8_t)(i + 1)), claimed.data(), START_MS);
+	}
+
+	ASSERT_EQUALS((unsigned)PUBLIC_IPV6_CORROBORATION_MAX_OBSERVERS,
+		(unsigned)tracker.DistinctObserversFor(claimed.data()));
+}
+
 // Votes are counted per value, never in total: three peers naming three
 // different addresses agree about nothing.
 TEST(PublicIPv6Corroboration, DisagreeingPeersDoNotPoolIntoAQuorum)

--- a/unittests/tests/ReservedProtocolFramesTest.cpp
+++ b/unittests/tests/ReservedProtocolFramesTest.cpp
@@ -147,7 +147,7 @@ TEST(ReservedProtocolFrames, ClassificationDoesNotMutateTheDatagram)
 // window is counted, and the count is reported with the next line that does get through.
 TEST(ReservedProtocolFrames, UnknownFrameLogIsRateLimited)
 {
-	CUnknownFrameLogThrottle throttle(1000);
+	CFrameLogThrottle throttle(1000);
 
 	ASSERT_TRUE(throttle.ShouldLog(10000));
 	ASSERT_EQUALS(0u, throttle.TakeSuppressedCount());
@@ -169,7 +169,7 @@ TEST(ReservedProtocolFrames, UnknownFrameLogIsRateLimited)
 // with a silence lasting until it catches up -- opens the window rather than closing it.
 TEST(ReservedProtocolFrames, ThrottleToleratesNonMonotonicClock)
 {
-	CUnknownFrameLogThrottle throttle(1000);
+	CFrameLogThrottle throttle(1000);
 
 	ASSERT_TRUE(throttle.ShouldLog(10000));
 	ASSERT_TRUE(throttle.ShouldLog(500));


### PR DESCRIPTION
Four findings from re-reviewing #1288 after it merged. Nothing here changes what goes on the wire; the parity itself was checked against eMuleAI field by field and was correct.

## The EC docs name the wrong tag

`docs/EC_Protocol.md` gave `EC_TAG_CLIENT_MOD_CAPABILITIES` as `0x0632`. The real value is `0x0633` (`ECCodes.abstract:452`), and `0x0632` is `EC_TAG_CLIENT_CONNECTED`, a bool. Our code is right, so this only misleads third-party EC clients written from the spec, but that is exactly who the document is for.

## Only one of seven log sites was throttled

`ProcessReservedProt2Frame()` rate-limited its unknown-type line and nothing else. The other six logged once per datagram, including the truncated-frame case, which is the shortest datagram that reaches the branch and therefore the cheapest to forge. These are `AddDebugLogLineN`, so the cost is zero until someone turns `logClientUDP` on to diagnose something, at which point a peer sending NAT-T frames at data rates floods the log and whatever it is being written to.

Each reason now has its own throttle rather than one shared across the branch, so a flood of any single kind cannot silence the diagnostics for the others. The uTP case keeps a separate one deliberately: "libutp saw this datagram and disclaimed it" is the line a developer is usually looking for, and it should not be suppressed by a burst of QUIC frames from a peer we cannot serve anyway. `CUnknownFrameLogThrottle` is renamed `CFrameLogThrottle` to match what it now does.

## NAT-T datagrams were invisible in the statistics

The 0xB2 branch did no overhead accounting while every sibling in the file does, so those bytes crossed the wire without appearing in aMule's own figures. It now counts as other overhead.

It still reaches no *packet* accounting. That omission is deliberate and documented: `CPacketTracking` is entered only from the Kad listener, and routing NAT-T traffic into it would let a dropped frame feed a ban. Statistics and bans are separate subsystems and only the second one has to stay out of reach, so the comment now says which is which.

## The corroboration observer cap equalled the quorum

`PublicIPv6Corroboration` recorded observers only while `size() < THRESHOLD`, with the threshold at 3, so the fourth peer to agree was discarded. When one of the three later aged out of the 30-minute window the count fell below the quorum and the address was no longer corroborated, even though other live peers had been agreeing the whole time and had been turned away at the cap. It recovers on the next claim from a new peer, so the cost is a transient loss rather than a permanent one, but the redundancy that would have avoided it was being thrown away.

The cap is now `PUBLIC_IPV6_CORROBORATION_MAX_OBSERVERS = 8` against an unchanged quorum of 3. Still bounded, so a peer still cannot spend our memory.

Two tests cover it: one where three later voters carry an address through the expiry of the first three, and one asserting the cap still holds. Both fail against the old cap, at `Expected '6' but got '3'` and `Expected '8' but got '3'`.

## One reported finding that is not a defect

`CT_MOD_YOUR_IP` was reported as never reaching the quorum for inbound peers, on the grounds that `GetConnectIP()` is 0 during the hello tag loop because `SetIP()` runs after it at `BaseClient.cpp:740`. That misses the constructor: `CUpDownClient(CClientTCPSocket *sender)` assigns `m_socket` before calling `Init()`, and `Init()` runs `SetIP(m_socket->GetPeerInt())`, which sets `m_nConnectIP`. Inbound peers have a real address from construction, and outbound peers get theirs from the ed2k user ID. No change made.

## Verification

| Configuration | Build | ctest |
| --- | --- | --- |
| default | clean | 61/61 |
| `-DENABLE_UTP=YES` | clean | 62/62 |

Both needed: the uTP-disclaimed log site only compiles under `AMULE_UTP_TRANSPORT`. clang-format 18 clean, `git diff --check` clean, Tier-2 clang-tidy clean on the diff with zero compiler errors.

Refs #1177
