### PR TITLE
fix(kad): follow-ups from a post-merge review of the Kad 0x0a work

### DIFF
--- a/src/PartFile.cpp
+++ b/src/PartFile.cpp
@@ -305,11 +305,19 @@ CPartFile::CPartFile(CSearchFile *searchresult)
 			// m_taglist, and nothing reads an AICH hash back out of there. This is the whole
 			// point of carrying the hash on a result -- a download that starts already knowing
 			// its root hash never has to collect one from a pool of peers before it can recover
-			// a corrupt part. AICH_VERIFIED matches the .part.met path above and the ed2k link
-			// path: in all three the hash arrived with something that vouches for it.
+			// a corrupt part.
+			//
+			// AICH_TRUSTED, not AICH_VERIFIED, and the difference matters. Nothing vouches for
+			// a search result: it is whatever the server or the Kad node chose to answer.
+			// AICH_VERIFIED is terminal -- UntrustedHashReceived() refuses to correct it -- so
+			// one wrong hash would break this download's recovery for good, persist to
+			// part.met, reload as verified on every later start, and go back out in our own
+			// ed2k and magnet links. AICH_TRUSTED is used for recovery exactly the same way
+			// and stays correctable by peer consensus, which is the whole difference between a
+			// hash we were told and a hash we can stand behind.
 			CAICHHash hash;
 			if (hash.DecodeBase32(pTag.GetStr()) == CAICHHash::GetHashSize()) {
-				m_pAICHHashSet->SetMasterHash(hash, AICH_VERIFIED);
+				m_pAICHHashSet->SetMasterHash(hash, AICH_TRUSTED);
 				MarkECChanged();
 				AddDebugLogLineN(logPartFile,
 					"CPartFile::CPartFile(CSearchFile*): took master AICH hash "

--- a/src/kademlia/kademlia/AICHHashList.cpp
+++ b/src/kademlia/kademlia/AICHHashList.cpp
@@ -43,6 +43,12 @@ uint16_t CKadAICHHashList::AddReference(const CKadAICHHash &hash)
 		}
 	}
 
+	if (m_hashes.size() >= MAX_SLOTS) {
+		// Refusing is the only safe answer: handing back a truncated index would alias an
+		// existing slot and credit this publisher's hash to a different one.
+		return INVALID_INDEX;
+	}
+
 	m_hashes.push_back(hash);
 	m_popularity.push_back(1);
 	return (uint16_t)(m_hashes.size() - 1);
@@ -81,6 +87,23 @@ const CKadAICHHash &CKadAICHHashList::GetHashAt(uint16_t index) const
 	// undefined behaviour.
 	static const CKadAICHHash s_empty = CKadAICHHash();
 	return (index < m_hashes.size()) ? m_hashes[index] : s_empty;
+}
+
+std::vector<uint16_t> CKadAICHHashList::Compact()
+{
+	std::vector<uint16_t> map = BuildCompactionMap();
+
+	std::vector<CKadAICHHash> hashes;
+	std::vector<uint8_t> popularity;
+	for (size_t i = 0; i < m_hashes.size(); ++i) {
+		if (map[i] != INVALID_INDEX) {
+			hashes.push_back(m_hashes[i]);
+			popularity.push_back(m_popularity[i]);
+		}
+	}
+	m_hashes.swap(hashes);
+	m_popularity.swap(popularity);
+	return map;
 }
 
 std::vector<uint16_t> CKadAICHHashList::BuildCompactionMap() const

--- a/src/kademlia/kademlia/AICHHashList.h
+++ b/src/kademlia/kademlia/AICHHashList.h
@@ -54,9 +54,10 @@ typedef std::array<uint8_t, KAD_AICH_HASH_SIZE> CKadAICHHash;
 // honest file has exactly one AICH hash, so several competing hashes -- or one hash with a single
 // publisher against a popular file -- is the signal a searcher wants.
 //
-// Slots are never removed once created, because publishers hold their hash by index;
-// DropReferenceAt() only decrements the popularity counter, and BuildCompactionMap() renumbers when
-// the entry is written to disk.
+// Publishers hold their hash by index, so DropReferenceAt() only decrements the popularity
+// counter and leaves the slot in place. Compact() is what actually removes the unreferenced ones
+// and renumbers, and the caller must apply the returned map to every index it holds.
+// BuildCompactionMap() is the same renumbering without the mutation, used when writing to disk.
 class CKadAICHHashList
 {
 public:
@@ -78,8 +79,15 @@ public:
 		CKadAICHHash m_hash;
 	};
 
-	// Adds one reference to `hash`, creating a slot for it if needed, and returns its index.
-	// Popularity saturates at 255 because it travels the wire as a uint8.
+	// A slot ceiling well under the 0xFFFF the index can express. With Compact() run after each
+	// merge the live count tracks the publisher list, which is capped at 100, so this is a
+	// backstop rather than a working limit: it exists so the index can never reach the
+	// INVALID_INDEX sentinel or wrap past it and alias an earlier slot.
+	static constexpr size_t MAX_SLOTS = 1024;
+
+	// Adds one reference to `hash`, creating a slot for it if needed, and returns its index, or
+	// INVALID_INDEX when the ceiling is reached. Popularity saturates at 255 because it travels
+	// the wire as a uint8.
 	uint16_t AddReference(const CKadAICHHash &hash);
 
 	// Drops one reference from the slot at `index`.  Out-of-range indexes
@@ -99,6 +107,12 @@ public:
 	// dropped, or INVALID_INDEX if it is dropped. Used when writing the keyword index to disk,
 	// so the stored publisher indexes stay consistent with the stored hashes.
 	std::vector<uint16_t> BuildCompactionMap() const;
+
+	// Drops every unreferenced slot and renumbers the rest, returning the same old-index to
+	// new-index map BuildCompactionMap() would. Without this the list only grows: a publisher
+	// that rotates its AICH hash leaves its previous slot behind on every republish, and the
+	// entry carries them all for as long as the process lives.
+	std::vector<uint16_t> Compact();
 
 	// Encodes the referenced hashes as a TAG_KADAICHHASHRESULT payload:
 	//   <Count 1>{<Publishers 1><AICH Hash KAD_AICH_HASH_SIZE>} Count

--- a/src/kademlia/kademlia/Entry.cpp
+++ b/src/kademlia/kademlia/Entry.cpp
@@ -185,22 +185,39 @@ void CEntry::WriteTagListInc(CFileDataIO *data, uint32_t increaseTagNumber)
 {
 	wxCHECK_RET(data != NULL, "data must not be NULL");
 
-	uint32_t count =
+	const uint32_t wanted =
 		GetTagCount() + increaseTagNumber; // will include name and size tag in the count if needed
-	wxASSERT(count <= 0xFF);
+
+	// The count goes on the wire as one byte, so it cannot describe more than 255 tags. Writing
+	// the truncated value and then all of them anyway is the worst of the options: the reader
+	// takes the wrapped count, stops early, and parses the remaining tags as whatever field it
+	// expected next, losing the rest of the packet. Clamp instead, so an over-full entry sends a
+	// short answer that still parses. The caller writes increaseTagNumber tags of its own after
+	// this returns, so they come out of the same budget.
+	const uint32_t count = wanted > 0xFF ? 0xFF : wanted;
+	if (wanted != count) {
+		AddDebugLogLineN(logKadEntryTracking,
+			CFormat("Kad entry has %u tags, more than the %u a search answer can "
+				"describe; dropping the surplus") %
+				wanted % count);
+	}
 	data->WriteUInt8((uint8_t)count);
 
-	if (!GetCommonFileName().IsEmpty()) {
-		wxASSERT(count > m_taglist.size());
+	// What this function may write, once the caller's own tags are reserved.
+	uint32_t budget = count > increaseTagNumber ? count - increaseTagNumber : 0;
+
+	if (!GetCommonFileName().IsEmpty() && budget > 0) {
 		data->WriteTag(CTagString(TAG_FILENAME, GetCommonFileName()));
+		budget--;
 	}
-	if (m_uSize != 0) {
-		wxASSERT(count > m_taglist.size());
+	if (m_uSize != 0 && budget > 0) {
 		data->WriteTag(CTagVarInt(TAG_FILESIZE, m_uSize));
+		budget--;
 	}
 
-	for (TagPtrList::const_iterator it = m_taglist.begin(); it != m_taglist.end(); ++it) {
+	for (TagPtrList::const_iterator it = m_taglist.begin(); it != m_taglist.end() && budget > 0; ++it) {
 		data->WriteTag(**it);
+		budget--;
 	}
 }
 
@@ -565,6 +582,23 @@ void CKeyEntry::MergeIPsAndFilenames(CKeyEntry *fromEntry)
 
 		ReCalculateTrustValue();
 	}
+
+	// Drop the slots no publisher points at any more and renumber the rest. DropReferenceAt()
+	// above only zeroes a popularity count, so without this the list keeps every AICH hash the
+	// entry has ever been told about: a publisher that rotates its hash each republish leaves a
+	// slot behind every time, and they accumulate for the life of the process. The publisher
+	// indexes are the only thing holding a slot, so they are remapped here in the same pass.
+	const std::vector<uint16_t> compacted = m_aichHashes.Compact();
+	for (auto &publisher : *m_publishingIPs) {
+		if (publisher.m_aichHashIdx < compacted.size()) {
+			publisher.m_aichHashIdx = compacted[publisher.m_aichHashIdx];
+		} else {
+			// INVALID_INDEX, or a stale index from a file written before the slot
+			// ceiling existed. Either way it points at no hash.
+			publisher.m_aichHashIdx = CKadAICHHashList::INVALID_INDEX;
+		}
+	}
+
 	AddDebugLogLineN(logKadEntryTracking,
 		CFormat("Indexed Keyword, Refresh: %s, Current Publisher: %s, Total Publishers: %u, Total "
 			"different Names: %u, TrustValue: %.2f, file: %s") %

--- a/unittests/tests/CMakeLists.txt
+++ b/unittests/tests/CMakeLists.txt
@@ -378,6 +378,38 @@ target_link_libraries (KadAICHHashListTest
 	mulecommon
 )
 
+# The single-byte tag count in a Kad search answer. CEntry/CKeyEntry pull in
+# nothing from the Kad core at link time -- every CIndexed reference in Entry.cpp
+# is in a comment -- so the writer can be driven directly and the answer parsed
+# back with the same CFileDataIO the receiver uses.
+add_executable (KadEntryTagListTest
+	KadEntryTagListTest.cpp
+	${CMAKE_SOURCE_DIR}/src/kademlia/kademlia/Entry.cpp
+	${CMAKE_SOURCE_DIR}/src/kademlia/kademlia/AICHHashList.cpp
+	${CMAKE_SOURCE_DIR}/src/SafeFile.cpp
+	${CMAKE_SOURCE_DIR}/src/MemFile.cpp
+	${CMAKE_SOURCE_DIR}/src/Tag.cpp
+	${CMAKE_SOURCE_DIR}/src/GetTickCount.cpp
+	# As for CValueMapTest: the no-op DoECLogLine / theLogger definitions, which
+	# Entry.cpp's AddDebugLogLine* calls resolve against in a Debug build.
+	${CMAKE_SOURCE_DIR}/src/LoggerConsole.cpp
+)
+
+add_test (NAME KadEntryTagListTest
+	COMMAND KadEntryTagListTest
+)
+
+target_include_directories (KadEntryTagListTest
+	PRIVATE ${CMAKE_BINARY_DIR}
+	PRIVATE ${CMAKE_SOURCE_DIR}/src
+	PRIVATE ${CMAKE_SOURCE_DIR}/src/include
+)
+
+target_link_libraries (KadEntryTagListTest
+	muleunit
+	mulecommon
+)
+
 # The adaptive Kad response-time ceiling. CFastKad takes "now" as a parameter
 # rather than reading a clock, which is what lets the cold start, a known series
 # of samples, the eviction rule and the window bound all be pinned without

--- a/unittests/tests/KadAICHHashListTest.cpp
+++ b/unittests/tests/KadAICHHashListTest.cpp
@@ -40,6 +40,19 @@ static CKadAICHHash MakeHash(uint8_t seed)
 	return hash;
 }
 
+// MakeHash() varies a single byte, so it can only produce 256 distinct values. The ceiling test
+// needs more than that.
+static CKadAICHHash MakeDistinctHash(uint16_t seed)
+{
+	CKadAICHHash hash;
+	for (size_t i = 0; i < hash.size(); ++i) {
+		hash[i] = (uint8_t)(i);
+	}
+	hash[0] = (uint8_t)(seed & 0xFF);
+	hash[1] = (uint8_t)(seed >> 8);
+	return hash;
+}
+
 DECLARE_SIMPLE(KadAICHHashList)
 
 TEST(KadAICHHashList, EmptyListEncodesNothing)
@@ -112,6 +125,65 @@ TEST(KadAICHHashList, BuildCompactionMapRenumbersReferencedSlotsOnly)
 	ASSERT_EQUALS((unsigned)CKadAICHHashList::INVALID_INDEX, (unsigned)map[1]);
 	ASSERT_EQUALS(1u, (unsigned)map[2]);
 	ASSERT_EQUALS(2u, (unsigned)list.GetReferencedCount());
+}
+
+// Compact() is BuildCompactionMap() plus the mutation: the dropped slots actually go away.
+TEST(KadAICHHashList, CompactRemovesUnreferencedSlotsAndRenumbers)
+{
+	CKadAICHHashList list;
+	list.AddReference(MakeHash(1)); // slot 0
+	list.AddReference(MakeHash(2)); // slot 1
+	list.AddReference(MakeHash(3)); // slot 2
+	list.DropReferenceAt(1);
+
+	const std::vector<uint16_t> map = list.Compact();
+	ASSERT_EQUALS(3u, (unsigned)map.size());
+	ASSERT_EQUALS(0u, (unsigned)map[0]);
+	ASSERT_EQUALS((unsigned)CKadAICHHashList::INVALID_INDEX, (unsigned)map[1]);
+	ASSERT_EQUALS(1u, (unsigned)map[2]);
+
+	// The difference from BuildCompactionMap(): the slot is gone, not just renumbered.
+	ASSERT_EQUALS(2u, (unsigned)list.GetSlotCount());
+	ASSERT_EQUALS(2u, (unsigned)list.GetReferencedCount());
+	ASSERT_TRUE(list.GetHashAt(0) == MakeHash(1));
+	ASSERT_TRUE(list.GetHashAt(1) == MakeHash(3));
+}
+
+// The reason Compact() exists. A publisher that reports a different AICH hash on every republish
+// used to leave its old slot behind each time, and the entry carried them all for the life of the
+// process. Compacting after each rotation keeps the list at the one hash actually referenced.
+TEST(KadAICHHashList, RotatingHashesDoNotAccumulateSlots)
+{
+	CKadAICHHashList list;
+	uint16_t held = list.AddReference(MakeDistinctHash(0));
+
+	for (uint16_t round = 1; round < 500; ++round) {
+		list.DropReferenceAt(held);
+		held = list.AddReference(MakeDistinctHash(round));
+		const std::vector<uint16_t> map = list.Compact();
+		ASSERT_TRUE(held < map.size());
+		held = map[held];
+	}
+
+	ASSERT_EQUALS(1u, (unsigned)list.GetSlotCount());
+	ASSERT_EQUALS(1u, (unsigned)list.GetReferencedCount());
+	ASSERT_TRUE(list.GetHashAt(held) == MakeDistinctHash(499));
+}
+
+// The backstop. An index is a uint16, so a list allowed to grow past 0xFFFF would hand back a
+// truncated index that aliases an earlier slot, crediting one publisher's hash to another.
+TEST(KadAICHHashList, AddReferenceRefusesPastTheSlotCeiling)
+{
+	CKadAICHHashList list;
+	for (size_t i = 0; i < CKadAICHHashList::MAX_SLOTS; ++i) {
+		const uint16_t index = list.AddReference(MakeDistinctHash((uint16_t)i));
+		ASSERT_EQUALS((unsigned)i, (unsigned)index);
+	}
+	ASSERT_EQUALS((unsigned)CKadAICHHashList::MAX_SLOTS, (unsigned)list.GetSlotCount());
+
+	const uint16_t refused = list.AddReference(MakeDistinctHash((uint16_t)CKadAICHHashList::MAX_SLOTS));
+	ASSERT_EQUALS((unsigned)CKadAICHHashList::INVALID_INDEX, (unsigned)refused);
+	ASSERT_EQUALS((unsigned)CKadAICHHashList::MAX_SLOTS, (unsigned)list.GetSlotCount());
 }
 
 // Wire format, pinned byte for byte:
@@ -279,7 +351,7 @@ TEST(KadAICHHashList, ALoneHashStillNeedsAThirdOfThePublishers)
 	ASSERT_TRUE(CKadAICHHashList::SelectTrusted(decoded, 10) == NULL);
 }
 
-// Task 1.5: mixed-version publish and search. Both the publish gate (TAG_KADAICHHASHPUB) and the
+// Mixed-version publish and search. Both the publish gate (TAG_KADAICHHASHPUB) and the
 // result gate (TAG_KADAICHHASHRESULT) consult this one predicate, so pinning it pins the version
 // behaviour of both directions.
 TEST(KadAICHHashList, AICHKeywordStorageIsGatedOnKadVersion0x09)

--- a/unittests/tests/KadEntryTagListTest.cpp
+++ b/unittests/tests/KadEntryTagListTest.cpp
@@ -1,0 +1,197 @@
+//								-*- C++ -*-
+// This file is part of the aMule Project.
+//
+// Copyright (c) 2003-2026 aMule Team ( https://amule-org.github.io )
+//
+// Any parts of this program derived from the xMule, lMule or eMule project,
+// or contributed by third-party developers are copyrighted by their
+// respective authors.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301, USA
+//
+
+#include <muleunit/test.h>
+#include <kademlia/kademlia/Entry.h>
+#include <kademlia/kademlia/AICHHashList.h>
+#include <MemFile.h>
+#include <Tag.h>
+#include <tags/FileTags.h>
+
+using namespace muleunit;
+using Kademlia::CKadAICHHashList;
+using Kademlia::CKeyEntry;
+
+// A search answer carries its tag count in a single byte, so the invariant these tests pin is that
+// the byte equals the number of tags that actually follow it. It matters more than it looks:
+// CKademliaUDPListener::ProcessSearchResponse() reads several answers out of one packet in
+// sequence, so a count that disagrees with the tags present does not merely garble its own answer,
+// it desynchronises every later one in the packet.
+//
+// Each test therefore appends a sentinel where the next answer would start and reads it back. That
+// catches a miscount in either direction, which asserting on the tag total alone does not.
+//
+// The expected tag total is deliberately never hardcoded: WriteTagListWithPublishInfo() writes one
+// tag of its own without ENABLE_KAD_PROTOCOL_10 and up to two with it, and these tests are meant
+// to hold in both configurations.
+
+static const uint32_t SENTINEL = 0xA1C4DEADu;
+
+// WriteTagListWithPublishInfo() needs a publisher, or it wxFAILs and falls back to a plain tag
+// list. Pushed straight onto the list rather than through the publish handler: the global subnet
+// tracking is not what is under test here, and DirtyDeletePublishData() lets the entry go away
+// again without decrementing counts that were never incremented.
+class CTestKeyEntry : public CKeyEntry
+{
+public:
+	void AddTestPublisher(uint32_t ip)
+	{
+		if (m_publishingIPs == NULL) {
+			m_publishingIPs = new PublishingIPList;
+		}
+		sPublishingIP publisher;
+		publisher.m_ip = ip;
+		publisher.m_lastPublish = 0;
+		publisher.m_aichHashIdx = CKadAICHHashList::INVALID_INDEX;
+		m_publishingIPs->push_back(publisher);
+	}
+
+	void AddDistinctTags(uint32_t count)
+	{
+		for (uint32_t i = 0; i < count; ++i) {
+			// Multi-character names, so none can collide with the single-byte tags the
+			// writer handles specially (TAG_FILENAME, TAG_FILESIZE, TAG_PUBLISHINFO).
+			AddTag(new CTagVarInt(wxString::Format(wxT("t%u"), i), i), 0);
+		}
+	}
+};
+
+// Writes one answer the way a keyword search response does, then a sentinel where the next answer
+// would begin. Returns the tag count byte the writer put on the wire.
+static uint8_t WriteAnswerWithSentinel(CTestKeyEntry &entry, CMemFile &file)
+{
+	entry.WriteTagListWithPublishInfo(&file);
+	file.WriteUInt32(SENTINEL);
+
+	file.Seek(0);
+	const uint8_t declared = file.ReadUInt8();
+	file.Seek(0);
+	return declared;
+}
+
+// Reads the tag list back and checks the stream lands exactly on the sentinel afterwards.
+static void ReadBackAndCheckAlignment(CMemFile &file, TagPtrList *tags)
+{
+	file.ReadTagPtrList(tags, false /*bOptACP*/);
+	ASSERT_EQUALS(SENTINEL, file.ReadUInt32());
+	ASSERT_EQUALS(file.GetLength(), file.GetPosition());
+}
+
+// How many of the tags came from AddDistinctTags().
+static uint32_t CountEntryTags(const TagPtrList &tags)
+{
+	uint32_t found = 0;
+	for (TagPtrList::const_iterator it = tags.begin(); it != tags.end(); ++it) {
+		if ((*it)->GetName().StartsWith(wxT("t"))) {
+			found++;
+		}
+	}
+	return found;
+}
+
+DECLARE_SIMPLE(KadEntryTagList)
+
+// The ordinary case: every tag the entry holds fits, and the count describes all of them plus the
+// writer's own.
+TEST(KadEntryTagList, CountDescribesEveryTagThatFollows)
+{
+	CTestKeyEntry entry;
+	entry.AddTestPublisher(0x0A000001);
+	entry.SetFileName(wxT("knoppix.iso"));
+	entry.m_uSize = 4096;
+	entry.AddDistinctTags(5);
+	ASSERT_EQUALS(7u, entry.GetTagCount()); // 5 + size + filename
+
+	CMemFile file;
+	const uint8_t declared = WriteAnswerWithSentinel(entry, file);
+
+	TagPtrList tags;
+	ReadBackAndCheckAlignment(file, &tags);
+
+	ASSERT_EQUALS((uint32_t)declared, (uint32_t)tags.size());
+	// Nothing was dropped: all five entry tags are there, as are the name and size.
+	ASSERT_EQUALS(5u, CountEntryTags(tags));
+	ASSERT_TRUE(tags.size() > entry.GetTagCount()); // plus at least the publish-info tag
+
+	deleteTagPtrListEntries(&tags);
+	entry.DirtyDeletePublishData();
+}
+
+// More tags than one byte can describe. Before the clamp the count wrapped to 0 and every tag was
+// written anyway, so a reader took 0 tags and then parsed tag bytes as the next answer's hash.
+TEST(KadEntryTagList, AnOverFullEntrySendsAShortAnswerThatStillParses)
+{
+	CTestKeyEntry entry;
+	entry.AddTestPublisher(0x0A000001);
+	entry.SetFileName(wxT("knoppix.iso"));
+	entry.m_uSize = 4096;
+	entry.AddDistinctTags(300);
+	ASSERT_EQUALS(302u, entry.GetTagCount());
+
+	CMemFile file;
+	const uint8_t declared = WriteAnswerWithSentinel(entry, file);
+
+	// Clamped to what the byte can express, not wrapped.
+	ASSERT_EQUALS(0xFFu, (uint32_t)declared);
+
+	TagPtrList tags;
+	ReadBackAndCheckAlignment(file, &tags);
+	ASSERT_EQUALS(0xFFu, (uint32_t)tags.size());
+
+	// The writer's own tags are reserved out of the same budget rather than dropped, so the
+	// surplus comes off the entry's tag list and the publish info still arrives.
+	ASSERT_TRUE(CountEntryTags(tags) < 0xFFu);
+	bool publishInfoPresent = false;
+	for (TagPtrList::const_iterator it = tags.begin(); it != tags.end(); ++it) {
+		if (!(*it)->GetName().Cmp(TAG_PUBLISHINFO)) {
+			publishInfoPresent = true;
+		}
+	}
+	ASSERT_TRUE(publishInfoPresent);
+
+	deleteTagPtrListEntries(&tags);
+	entry.DirtyDeletePublishData();
+}
+
+// Exactly at the boundary, where an off-by-one in the reservation would show up.
+TEST(KadEntryTagList, TheBoundaryIsDescribedExactly)
+{
+	CTestKeyEntry entry;
+	entry.AddTestPublisher(0x0A000001);
+	entry.SetFileName(wxT("knoppix.iso"));
+	entry.m_uSize = 4096;
+	entry.AddDistinctTags(253); // 253 + size + filename == 255
+	ASSERT_EQUALS(0xFFu, entry.GetTagCount());
+
+	CMemFile file;
+	const uint8_t declared = WriteAnswerWithSentinel(entry, file);
+	ASSERT_EQUALS(0xFFu, (uint32_t)declared);
+
+	TagPtrList tags;
+	ReadBackAndCheckAlignment(file, &tags);
+	ASSERT_EQUALS(0xFFu, (uint32_t)tags.size());
+
+	deleteTagPtrListEntries(&tags);
+	entry.DirtyDeletePublishData();
+}

--- a/unittests/tests/KadEntryTagListTest.cpp
+++ b/unittests/tests/KadEntryTagListTest.cpp
@@ -70,6 +70,12 @@ public:
 		AdjustGlobalPublishTracking(ip, true, wxT("test publisher"));
 	}
 
+	// GetTrustValue() only recalculates when its last result is older than ten minutes, and the
+	// timestamp starts at zero, so on a freshly booted machine the comparison is against uptime
+	// and the recalculation never happens. Force it instead of depending on how long the runner
+	// has been up.
+	void RecalculateTrustNow() { ReCalculateTrustValue(); }
+
 	void AddDistinctTags(uint32_t count)
 	{
 		for (uint32_t i = 0; i < count; ++i) {
@@ -128,7 +134,9 @@ TEST(KadEntryTagList, CountDescribesEveryTagThatFollows)
 
 	// The publisher is registered in the global per-subnet map, so the trust calculation finds
 	// its /24 and scores it. A zero here means the registration was skipped and
-	// ReCalculateTrustValue() took its wxFAIL branch instead.
+	// ReCalculateTrustValue() took its wxFAIL branch instead -- which is silent on some
+	// platforms, so this assertion is what makes that visible everywhere.
+	entry.RecalculateTrustNow();
 	ASSERT_TRUE(entry.GetTrustValue() > 0.0);
 
 	CMemFile file;

--- a/unittests/tests/KadEntryTagListTest.cpp
+++ b/unittests/tests/KadEntryTagListTest.cpp
@@ -49,9 +49,11 @@ using Kademlia::CKeyEntry;
 static const uint32_t SENTINEL = 0xA1C4DEADu;
 
 // WriteTagListWithPublishInfo() needs a publisher, or it wxFAILs and falls back to a plain tag
-// list. Pushed straight onto the list rather than through the publish handler: the global subnet
-// tracking is not what is under test here, and DirtyDeletePublishData() lets the entry go away
-// again without decrementing counts that were never incremented.
+// list. Registering one means two steps, not one: the entry's own list, and the global per-/24
+// count. ReCalculateTrustValue() looks the publisher's subnet up in that global map and wxFAILs
+// on a miss, so pushing onto the list alone leaves the entry in a state the trust calculation
+// treats as an inconsistency. The destructor decrements the same global count, so the two stay
+// balanced as long as the entry is left to destruct normally.
 class CTestKeyEntry : public CKeyEntry
 {
 public:
@@ -65,6 +67,7 @@ public:
 		publisher.m_lastPublish = 0;
 		publisher.m_aichHashIdx = CKadAICHHashList::INVALID_INDEX;
 		m_publishingIPs->push_back(publisher);
+		AdjustGlobalPublishTracking(ip, true, wxT("test publisher"));
 	}
 
 	void AddDistinctTags(uint32_t count)
@@ -123,6 +126,11 @@ TEST(KadEntryTagList, CountDescribesEveryTagThatFollows)
 	entry.AddDistinctTags(5);
 	ASSERT_EQUALS(7u, entry.GetTagCount()); // 5 + size + filename
 
+	// The publisher is registered in the global per-subnet map, so the trust calculation finds
+	// its /24 and scores it. A zero here means the registration was skipped and
+	// ReCalculateTrustValue() took its wxFAIL branch instead.
+	ASSERT_TRUE(entry.GetTrustValue() > 0.0);
+
 	CMemFile file;
 	const uint8_t declared = WriteAnswerWithSentinel(entry, file);
 
@@ -135,7 +143,6 @@ TEST(KadEntryTagList, CountDescribesEveryTagThatFollows)
 	ASSERT_TRUE(tags.size() > entry.GetTagCount()); // plus at least the publish-info tag
 
 	deleteTagPtrListEntries(&tags);
-	entry.DirtyDeletePublishData();
 }
 
 // More tags than one byte can describe. Before the clamp the count wrapped to 0 and every tag was
@@ -171,7 +178,6 @@ TEST(KadEntryTagList, AnOverFullEntrySendsAShortAnswerThatStillParses)
 	ASSERT_TRUE(publishInfoPresent);
 
 	deleteTagPtrListEntries(&tags);
-	entry.DirtyDeletePublishData();
 }
 
 // Exactly at the boundary, where an off-by-one in the reservation would show up.
@@ -193,5 +199,4 @@ TEST(KadEntryTagList, TheBoundaryIsDescribedExactly)
 	ASSERT_EQUALS(0xFFu, (uint32_t)tags.size());
 
 	deleteTagPtrListEntries(&tags);
-	entry.DirtyDeletePublishData();
 }


### PR DESCRIPTION
Four findings from re-reviewing #1297 after it landed. The first two are live in default builds; the others need `ENABLE_KAD_PROTOCOL_10` or are cosmetic.

## A search-result AICH hash was permanently trusted

`PartFile.cpp` installed an `FT_AICH_HASH` from any ed2k search result with `AICH_VERIFIED`, outside the gate. That status is terminal: `UntrustedHashReceived()` returns on anything that is not `EMPTY`, `UNTRUSTED` or `TRUSTED`, so no quorum of honest peers can correct it afterwards.

The consequences compound, because `AICH_VERIFIED` is also the condition on persisting the hash and on exporting it. One wrong hash from a server broke that download's AICH recovery for good, was written to part.met, came back verified on every later start via the load path, and went back out in our own `h=` and magnet links.

Now `AICH_TRUSTED`. Recovery is unaffected: `PartFile.cpp` and `DownloadClient.cpp` both accept either status. What stops is persisting and re-exporting an unvetted hash, and it becomes correctable by peer consensus. The comparison the old comment drew with the ed2k-link path does not hold, since a link is pasted by the user and a search result is whatever answered.

## The Kad AICH slot list only ever grew

`MergeIPsAndFilenames()` takes the list over from the stored entry wholesale, `DropReferenceAt()` zeroes a popularity count without removing the slot, and `BuildCompactionMap()` is `const`. So a publisher that rotates its reported AICH hash left a slot behind on every republish, and the entry carried them all for the life of the process.

`Compact()` now drops the unreferenced slots and renumbers, called at the end of the merge with the publisher indexes remapped in the same pass. `AddReference()` gains a slot ceiling as a backstop so the `uint16` index can never reach the `INVALID_INDEX` sentinel or wrap past it and alias an earlier slot.

Reverting the mutation makes `RotatingHashesDoNotAccumulateSlots` fail at `Expected '1' but got '500'`, which is the growth itself; removing the ceiling makes the other fail at `Expected '65535' but got '1024'`.

## The tag-count cliff

`WriteTagListInc()` wrote the count into one byte and asserted it fitted, in debug only. Raising the increment to 2 for the AICH tag moved the cliff from 255 stored tags to 254. Past it a release build wrapped the count to 0 and wrote the tags anyway, so the peer read no tags and then parsed the rest of the search answer out of tag data.

The count is clamped and the writes are bounded by the same budget, so an over-full entry sends a short answer that still parses.

The truncating cast and the debug-only assert are upstream code that #1297 did not introduce; it only brought the cliff one tag nearer. That makes it upstream's bug rather than this branch's, but it is reachable without the gate and worth fixing here: with `ENABLE_KAD_PROTOCOL_10` off the increment is 1 and the cliff sits at 255 stored tags, and the publish handler reads a `uint8` tag count and feeds up to 255 tags through `AddTag()`, so a single publish packet is enough to reach it. The damage is not confined to the bad answer either, because `ProcessSearchResponse()` reads several answers out of one packet in sequence: a count that disagrees with the tags present desynchronises every later answer in that packet.

`KadEntryTagListTest` pins the invariant that the count byte equals the number of tags that follow it, driving the real caller in both configurations. Restoring the truncating cast makes the over-full case fail at `Expected '255' but got '47'` and the 255 boundary at `Expected '255' but got '0'`, which is the wrap itself.

## A plan reference in a test

`// Task 1.5:` removed. Plan numbering belongs in `.archive`.

## Verification

| Configuration | Build | ctest |
| --- | --- | --- |
| default | clean | 62/62 |
| `-DENABLE_KAD_PROTOCOL_10=YES` | clean | 62/62 |

Three new tests on `CKadAICHHashList` and three on the tag count, both configurations built and run, clang-format 18 clean, `git diff --check` clean, Tier-2 clang-tidy clean with zero compiler errors. Tier-2 initially flagged the new remap loop for `modernize-loop-convert`, since I had copied the iterator style from the surrounding code; it is a range-based `for` now.

Refs #1177

