### PR TITLE
fix(kad): follow-ups from a post-merge review of the node-protection work

### DIFF
--- a/src/kademlia/kademlia/Search.cpp
+++ b/src/kademlia/kademlia/Search.cpp
@@ -295,15 +295,26 @@ void CSearch::JumpStart()
 
 	const uint64_t nowTick = ::GetTickCount64();
 
-	// Stop waiting on requests that have passed the ceiling, and remember those addresses as
-	// problematic so the next search does not queue behind the same dead nodes.
+	// Stop waiting on requests that have passed the ceiling. The record is marked rather than
+	// erased and kept for PENDING_SAMPLE_GRACE_MS, because an answer arriving after the
+	// ceiling is exactly the sample the estimator needs: erasing here meant no round-trip
+	// longer than the current estimate could ever be recorded, so on a link slower than the
+	// starting value the estimate could only ratchet down and every request stalled.
+	//
+	// A timeout deliberately does not reach safeKad. It is evidence of a slow or absent node,
+	// not of a misbehaving one, and TrackProblematicNode() is rung one of the ban ladder:
+	// nothing reads problematic state for scheduling, so its only effect was that the next
+	// rejected identity change went straight to a four-hour ban.
 	for (PendingRequestMap::iterator it = m_pendingRequests.begin(); it != m_pendingRequests.end();) {
-		if (nowTick - it->second.m_sentTick < maxPending) {
-			++it;
+		const uint64_t waited = nowTick - it->second.m_sentTick;
+		if (waited >= maxPending + PENDING_SAMPLE_GRACE_MS) {
+			m_pendingRequests.erase(it++);
 			continue;
 		}
-		safeKad.TrackProblematicNode(it->second.m_ip, it->second.m_port, time(nullptr));
-		m_pendingRequests.erase(it++);
+		if (waited >= maxPending) {
+			it->second.m_timedOut = true;
+		}
+		++it;
 	}
 
 	// If we had a response within the derived ceiling, no need to jumpstart.
@@ -411,15 +422,26 @@ void CSearch::ProcessResponse(uint32_t fromIP, uint16_t fromPort, ContactList *r
 			m_pendingRequests.erase(pending);
 		}
 
-		// The contact may have gone bad since we sent the request, and this is the point at
-		// which we know the node stands behind this identity. onlyOneNodePerIP is off here
-		// because the contact is already in our routing table, so a second port on the
+		// The contact may have gone bad since we sent the request. onlyOneNodePerIP is off
+		// here because the contact is already in our routing table, so a second port on the
 		// address is that table's problem.
+		//
+		// idVerified is false, and deliberately not the contact's own flag. An answer to a
+		// search proves the address is live; it proves nothing about the identity, which we
+		// took from wherever we learned the contact. CContact::IsIPVerified() is no better
+		// here: Process2BootstrapResponse() sets it by assumption for every contact in the
+		// answer when the routing table is empty, so trusting it would let one bootstrap
+		// peer hand us twenty addresses that can be escalated to a ban.
+		//
+		// Nothing is lost by passing false. Per TrackNode(), idVerified gates the
+		// escalation and not the refusal, so a bad node is still refused here; and the
+		// three-way handshake in CRoutingZone already records the address as verified,
+		// where the proof is real. That is the only caller that should ever pass true.
 		if (safeKad.IsBadNode(fromIP,
 			    fromPort,
 			    fromContact->GetClientID(),
 			    fromContact->GetVersion(),
-			    true,
+			    false,
 			    false,
 			    time(nullptr))) {
 			AddDebugLogLineN(logKadSearch,
@@ -1505,7 +1527,7 @@ void CSearch::SendFindValue(CContact *contact, bool reaskMore)
 			// shared response-time estimator, and JumpStart uses the same record to
 			// notice a request that has gone past the estimated ceiling.
 			sPendingRequest pending = {
-				::GetTickCount64(), contact->GetIPAddress(), contact->GetUDPPort()
+				::GetTickCount64(), contact->GetIPAddress(), contact->GetUDPPort(), false
 			};
 			m_pendingRequests[contact->GetClientID()] = pending;
 #endif

--- a/src/kademlia/kademlia/Search.cpp
+++ b/src/kademlia/kademlia/Search.cpp
@@ -295,11 +295,11 @@ void CSearch::JumpStart()
 
 	const uint64_t nowTick = ::GetTickCount64();
 
-	// Stop waiting on requests that have passed the ceiling. The record is marked rather than
-	// erased and kept for PENDING_SAMPLE_GRACE_MS, because an answer arriving after the
-	// ceiling is exactly the sample the estimator needs: erasing here meant no round-trip
-	// longer than the current estimate could ever be recorded, so on a link slower than the
-	// starting value the estimate could only ratchet down and every request stalled.
+	// Stop waiting on requests that have passed the ceiling, but keep the record until
+	// PENDING_SAMPLE_GRACE_MS past it, because an answer arriving after the ceiling is exactly
+	// the sample the estimator needs: erasing on the ceiling meant no round-trip longer than
+	// the current estimate could ever be recorded, so on a link slower than the starting value
+	// the estimate could only ratchet down and every request stalled.
 	//
 	// A timeout deliberately does not reach safeKad. It is evidence of a slow or absent node,
 	// not of a misbehaving one, and TrackProblematicNode() is rung one of the ban ladder:
@@ -310,9 +310,6 @@ void CSearch::JumpStart()
 		if (waited >= maxPending + PENDING_SAMPLE_GRACE_MS) {
 			m_pendingRequests.erase(it++);
 			continue;
-		}
-		if (waited >= maxPending) {
-			it->second.m_timedOut = true;
 		}
 		++it;
 	}
@@ -1527,7 +1524,7 @@ void CSearch::SendFindValue(CContact *contact, bool reaskMore)
 			// shared response-time estimator, and JumpStart uses the same record to
 			// notice a request that has gone past the estimated ceiling.
 			sPendingRequest pending = {
-				::GetTickCount64(), contact->GetIPAddress(), contact->GetUDPPort(), false
+				::GetTickCount64(), contact->GetIPAddress(), contact->GetUDPPort()
 			};
 			m_pendingRequests[contact->GetClientID()] = pending;
 #endif

--- a/src/kademlia/kademlia/Search.h
+++ b/src/kademlia/kademlia/Search.h
@@ -205,7 +205,17 @@ private:
 		uint64_t m_sentTick;
 		uint32_t m_ip;
 		uint16_t m_port;
+		// Set once the request has passed the ceiling. The record is kept for a grace
+		// window afterwards rather than erased, so an answer that arrives late still
+		// feeds its round-trip time to the estimator. Erasing on the ceiling made the
+		// estimate unable to rise: no sample above it could ever be recorded, so a link
+		// slower than the starting estimate never taught it anything.
+		bool m_timedOut;
 	};
+
+	// How long a timed-out record is kept for its round-trip sample. Long enough to cover
+	// a link well beyond the ceiling, short enough that the map does not accumulate.
+	static const uint64_t PENDING_SAMPLE_GRACE_MS = 10000;
 	typedef std::map<CUInt128, sPendingRequest> PendingRequestMap;
 
 	PendingRequestMap m_pendingRequests;

--- a/src/kademlia/kademlia/Search.h
+++ b/src/kademlia/kademlia/Search.h
@@ -205,16 +205,12 @@ private:
 		uint64_t m_sentTick;
 		uint32_t m_ip;
 		uint16_t m_port;
-		// Set once the request has passed the ceiling. The record is kept for a grace
-		// window afterwards rather than erased, so an answer that arrives late still
-		// feeds its round-trip time to the estimator. Erasing on the ceiling made the
-		// estimate unable to rise: no sample above it could ever be recorded, so a link
-		// slower than the starting estimate never taught it anything.
-		bool m_timedOut;
 	};
 
-	// How long a timed-out record is kept for its round-trip sample. Long enough to cover
-	// a link well beyond the ceiling, short enough that the map does not accumulate.
+	// How long a record outlives the ceiling, so a late answer still feeds its round-trip
+	// time to the estimator. Erasing on the ceiling made the estimate unable to rise: no
+	// sample above it could ever be recorded, so a link slower than the starting estimate
+	// never taught it anything. Long enough to cover that, short enough not to accumulate.
 	static const uint64_t PENDING_SAMPLE_GRACE_MS = 10000;
 	typedef std::map<CUInt128, sPendingRequest> PendingRequestMap;
 

--- a/src/kademlia/net/SafeKad.cpp
+++ b/src/kademlia/net/SafeKad.cpp
@@ -103,10 +103,23 @@ bool CSafeKad::TrackNode(
 		}
 	}
 
-	tracked.m_lastReferenced = now;
-	// Verification is sticky: a node that once proved its identity is not
-	// downgraded by a later unverified packet.
-	if (!tracked.m_idVerified) {
+	// A verified entry is the protection itself, so refused traffic keeps it alive: letting it
+	// age out would mean an attacker only has to keep claiming a new ID until NODE_MAX_
+	// REFERENCE_AGE passes, and the identity it could not overwrite is reclaimed for it.
+	//
+	// An entry that is only ever refused and was never verified is the opposite case. It holds
+	// an ID nobody proved, so an attacker who merely spoke first from an address owns it, and
+	// every refused packet from the honest node at that address would renew the entry that is
+	// refusing it. Letting that one expire is what gives the honest node a way back.
+	if (accepted || tracked.m_idVerified) {
+		tracked.m_lastReferenced = now;
+	}
+	// Verification is sticky: a node that once proved its identity is not downgraded by a
+	// later unverified packet. Only on the accepted path, though: promoting here after a
+	// refusal would raise the flag for a claim we just rejected, while m_lastID still holds
+	// the previous one, marking an unproven ID verified and unlocking the escalation ladder
+	// against whoever actually holds the address.
+	if (accepted && !tracked.m_idVerified) {
 		tracked.m_idVerified = idVerified;
 	}
 	// The ban above may have dropped this entry, so only write it back if

--- a/src/kademlia/net/SafeKad.h
+++ b/src/kademlia/net/SafeKad.h
@@ -197,7 +197,11 @@ public:
 	// Eviction horizons for Cleanup(): an entry nothing has referenced for
 	// this long carries no information worth its memory.
 	static const time_t NODE_MAX_REFERENCE_AGE = 3600;
-	static const time_t BAN_MAX_REFERENCE_AGE = 3600;
+	// Must not be shorter than MAX_BAN_TIME. Cleanup() drops banned entries once they have
+	// gone this long without a reference, and a banned address stops being referenced as soon
+	// as it stops sending -- so a shorter horizon silently ends the ban early for exactly the
+	// attacker who backs off, which is the one the ban is for.
+	static const time_t BAN_MAX_REFERENCE_AGE = MAX_BAN_TIME;
 	static const time_t PROBLEMATIC_MAX_REFERENCE_AGE = 300;
 	// Cleanup() also runs from IsBadNode() at most this often.
 	static const time_t CLEANUP_INTERVAL = 600;

--- a/unittests/tests/SafeKadTest.cpp
+++ b/unittests/tests/SafeKadTest.cpp
@@ -330,8 +330,11 @@ TEST(SafeKad, ABanSurvivesAsLongAsItLasts)
 {
 	CSafeKad safe;
 	safe.BanAddress(IP_A, T0);
-	ASSERT_TRUE(safe.IsBanned(IP_A, T0 + 1));
 
+	// Deliberately no IsBanned() before the sweep. It refreshes m_lastReferenced, which is
+	// exactly what the horizon is measured against, so asking whether the address is banned
+	// would itself postpone the reclaim and hide the regression this pins.
+	//
 	// An hour of silence used to be enough to reclaim it.
 	safe.Cleanup(T0 + 3600 + 1);
 	ASSERT_EQUALS(1u, (unsigned)safe.GetBannedAddressCount());

--- a/unittests/tests/SafeKadTest.cpp
+++ b/unittests/tests/SafeKadTest.cpp
@@ -274,11 +274,71 @@ TEST(SafeKad, CleanupReclaimsEntriesPastTheirReferenceHorizon)
 	ASSERT_EQUALS(1u, (unsigned)safe.GetProblematicNodeCount());
 	ASSERT_EQUALS(1u, (unsigned)safe.GetBannedAddressCount());
 
-	// Nothing has referenced any of them for longer than every horizon.
+	// Past the node and problematic horizons, but not the ban one.
 	safe.Cleanup(T0 + CSafeKad::NODE_MAX_REFERENCE_AGE + 1);
 	ASSERT_EQUALS(0u, (unsigned)safe.GetTrackedNodeCount());
 	ASSERT_EQUALS(0u, (unsigned)safe.GetProblematicNodeCount());
+	ASSERT_EQUALS(1u, (unsigned)safe.GetBannedAddressCount());
+
+	// And past the ban horizon, which is the ban duration itself.
+	safe.Cleanup(T0 + CSafeKad::BAN_MAX_REFERENCE_AGE + 1);
 	ASSERT_EQUALS(0u, (unsigned)safe.GetBannedAddressCount());
+}
+
+// A refused claim must not be what marks an address verified. The flag gates the escalation
+// ladder, and m_lastID still holds the previous claim at that point, so promoting on a refusal
+// certifies an identity nobody proved.
+TEST(SafeKad, ARefusedRotationDoesNotConferVerification)
+{
+	CSafeKad safe;
+	// An unverified first claim: whoever spoke first, not necessarily the real node.
+	ASSERT_TRUE(safe.TrackNode(IP_A, PORT_A, Id(1), false, T0));
+
+	// A verified claim of a different ID, inside the interval, so it is refused.
+	ASSERT_FALSE(safe.TrackNode(IP_A, PORT_A, Id(2), true, T0 + 10));
+
+	// Nothing was ever verified at this address, so well past the interval an unverified
+	// claim is ordinary rotation and is accepted. It would be refused if the rejected claim
+	// above had been allowed to set the verified flag.
+	ASSERT_TRUE(safe.TrackNode(IP_A, PORT_A, Id(3), false, T0 + CSafeKad::MIN_ID_CHANGE_INTERVAL * 2));
+}
+
+// An entry holding an unproven ID must not be kept alive by the traffic it is refusing, or an
+// attacker who merely spoke first from an address owns it for as long as the honest node keeps
+// trying. A verified entry is the opposite: it is the protection, so refused traffic renews it.
+TEST(SafeKad, OnlyAVerifiedEntrySurvivesOnRefusedTrafficAlone)
+{
+	const time_t past = T0 + CSafeKad::NODE_MAX_REFERENCE_AGE + 1;
+
+	CSafeKad unproven;
+	ASSERT_TRUE(unproven.TrackNode(IP_A, PORT_A, Id(1), false, T0));
+	ASSERT_FALSE(unproven.TrackNode(IP_A, PORT_A, Id(2), false, T0 + 10));
+	unproven.Cleanup(past);
+	ASSERT_EQUALS(0u, (unsigned)unproven.GetTrackedNodeCount());
+
+	CSafeKad proven;
+	ASSERT_TRUE(proven.TrackNode(IP_A, PORT_A, Id(1), true, T0));
+	ASSERT_FALSE(proven.TrackNode(IP_A, PORT_A, Id(2), false, T0 + 10));
+	proven.Cleanup(past);
+	ASSERT_EQUALS(1u, (unsigned)proven.GetTrackedNodeCount());
+}
+
+// A ban has to outlive the quiet it causes. Reclaiming banned entries on a horizon shorter than
+// MAX_BAN_TIME ended the ban early for precisely the attacker who backs off, since an address
+// that stops sending stops being referenced.
+TEST(SafeKad, ABanSurvivesAsLongAsItLasts)
+{
+	CSafeKad safe;
+	safe.BanAddress(IP_A, T0);
+	ASSERT_TRUE(safe.IsBanned(IP_A, T0 + 1));
+
+	// An hour of silence used to be enough to reclaim it.
+	safe.Cleanup(T0 + 3600 + 1);
+	ASSERT_EQUALS(1u, (unsigned)safe.GetBannedAddressCount());
+	ASSERT_TRUE(safe.IsBanned(IP_A, T0 + 3600 + 1));
+
+	// It ends when the ban ends, not before.
+	ASSERT_FALSE(safe.IsBanned(IP_A, T0 + CSafeKad::MAX_BAN_TIME + 1));
 }
 
 TEST(SafeKad, CleanupKeepsRecentlyReferencedEntries)


### PR DESCRIPTION
Seven findings from re-reviewing #1304. **All are behind `ENABLE_KAD_NODE_PROTECTION`**, which is off by default and does not even compile `SafeKad.cpp` (`source-vars.cmake:65-70`), so none of this reaches a shipping build. They matter because it is the foundation the gate will eventually be turned on over.

## Three symptoms, one root cause

`idVerified` gates the ban ladder, but the things that set it do not mean identity proof.

**`TrackNode()` promoted the flag on a refused rotation.** The claim was rejected and `m_lastID` still held the previous one, so the effect was to certify an identity nobody proved and unlock escalation against whoever holds the address. An attacker who merely speaks first from an address could get the honest node banned. It is now promoted on the accepted path only.

**`CSearch::ProcessResponse()` hardcoded `true`.** An answer to a search proves the address is live, not that the ID we hold for it was ever verified. It now passes `false`.

Deliberately not `CContact::IsIPVerified()`, which was the obvious alternative and is wrong: `Process2BootstrapResponse()` sets that by assumption for every contact in the answer when the routing table is empty, so one bootstrap peer could hand us twenty bannable addresses. Nothing is lost by passing `false`, because `idVerified` gates the escalation and not the refusal, and the three-way handshake in `CRoutingZone` already records the address as verified where the proof is real. That is now the only caller passing `true`.

That last point also disposes of a reported finding about `assumeVerified` at bootstrap. It is pre-existing upstream behaviour, #1304 never touched that file, and removing it would break cold bootstrap. The real issue was #1304 making a signal that weak load-bearing for bans, which is what this closes.

## The timeout loop

**A timeout fed the ban ladder.** The sweep called `TrackProblematicNode()`, and its comment said the point was to stop the next search queueing behind dead nodes. Nothing reads problematic state for scheduling: `IsProblematic()` is consulted only by `Escalate()`. So the sole effect was that one timeout plus one rejected identity change reached a four-hour ban. A timeout is evidence of a slow node, not a misbehaving one, and no longer reaches `safeKad` at all.

**The estimator could only ratchet down.** The same sweep erased the pending record on the ceiling, so a round trip longer than the current estimate could never be sampled. The estimate could only fall from its 1000 ms default and never climb back toward the 3000 ms maximum, so on a slower link no sample was ever recorded and every request was declared stalled, which is worse than the fixed 3 s ceiling it replaced. Pending records are now kept for a grace window past the ceiling instead, so a late answer still teaches the estimator.

This is the one change here with no test. `CSearch` needs the Kad core to stand up, so there is no cheap unit test for it the way there is for `CSafeKad`, and the controls below cover the identity and ban changes only. Reviewing it means reading `JumpStart()` against `ProcessResponse()`, where `AddResponseTime()` runs for any record still in the map.

## Ban bookkeeping

**Refused traffic refreshed the reference unconditionally**, so an entry holding an unproven ID was kept alive by the very packets it was rejecting and never aged out. Now only an accepted reference refreshes it, or any reference to an entry that was already verified.

That second clause is load-bearing and I got it wrong first time. Refreshing only on accept let an attacker reclaim a verified identity by simply claiming new IDs until `NODE_MAX_REFERENCE_AGE` passed, because `IsBadNode()` calls `Cleanup()`. The existing `AnUnverifiedClaimCannotOverwriteAVerifiedIdentity` test caught it immediately.

**`BAN_MAX_REFERENCE_AGE` was one hour against a documented four-hour `MAX_BAN_TIME`**, and `Cleanup()` drops banned entries on that horizon. Since a banned address stops being referenced as soon as it stops sending, the ban ended early for precisely the attacker who backs off. It is now `MAX_BAN_TIME`.

## Verification

| Configuration | Build | ctest |
| --- | --- | --- |
| default | clean | 61/61 |
| `-DENABLE_KAD_NODE_PROTECTION=YES` | clean | 61/61 |

`SafeKadTest` goes from 29 to 32 cases. One existing test was updated, because it pinned the one-hour ban horizon this changes. Controls: restoring the unconditional promotion and refresh fails the two new identity tests, and restoring the one-hour horizon fails both the reference-horizon test and the ban-duration one.

That second control only holds after a fix from review. `ABanSurvivesAsLongAsItLasts` asked `IsBanned()` before the sweep, and `IsBanned()` refreshes `m_lastReferenced`, so the question itself postponed the reclaim and left `Cleanup()` measuring exactly the old horizon rather than one second past it. The test passed with the one-hour value still in place. The call is gone and it now fails as intended.

clang-format 18 clean, `git diff --check` clean, Tier-2 clang-tidy clean with zero compiler errors.

Refs #1177

