### PR TITLE
fix(net): follow-ups from a post-merge review of the internal address type

### DIFF
--- a/src/BanRecord.h
+++ b/src/BanRecord.h
@@ -66,7 +66,12 @@ public:
 	 * duration and not one tick longer, which is the reading its name gives. That is a
 	 * behaviour change, small and in one direction.
 	 */
-	static const uint64 BAN_DURATION_MS = CLIENTBANTIME;
+	// constexpr, not const: a plain static const member still needs an out-of-line definition
+	// the moment anything odr-uses it, and C++17 made only constexpr members implicitly inline.
+	// Every use today is arithmetic, which is a value computation, so it links; the first
+	// reference binding does not. ASSERT_EQUALS() is exactly that, since muleunit takes its
+	// arguments by const reference.
+	static constexpr uint64 BAN_DURATION_MS = CLIENTBANTIME;
 
 	/**
 	 * Ban @p ip, or refresh an existing ban.

--- a/src/NetworkAddress.h
+++ b/src/NetworkAddress.h
@@ -29,6 +29,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <cstring>
+#include <functional>
 #include <string>
 
 #include <wx/string.h>
@@ -45,8 +46,9 @@ struct IPv6ExcludedPrefix
 constexpr IPv6ExcludedPrefix kIPv6ExcludedPrefixes[] = { { {}, 128, "Unspecified" },
 	{ { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1 }, 128, "Loopback" },
 	{ { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xff, 0xff }, 96, "IPv4-mapped" },
-	// ::a.b.c.d, the deprecated IPv4-compatible form (RFC 4291). Listed after the two entries
-	// above so the unspecified address and the loopback keep their own names in a log.
+	// ::a.b.c.d, the deprecated IPv4-compatible form (RFC 4291). Its page also holds the
+	// unspecified address and the loopback, which have their own /128 entries above; the
+	// matcher stops at the first hit, so those keep the more specific name.
 	{ {}, 96, "IPv4-compatible" },
 	{ { 0x00, 0x64, 0xff, 0x9b }, 96, "Well-known NAT64" },
 	{ { 0x00, 0x64, 0xff, 0x9b, 0x00, 0x01 }, 48, "Local-use NAT64" },
@@ -580,9 +582,15 @@ public:
 	 * subscriber is delegated a prefix, not an address, so a per-address budget under
 	 * IPv6 counts to one forever (see PeerAddressing.h).
 	 *
+	 * The width is the effective family's, so an IPv4-mapped address is treated as the IPv4
+	 * address it carries and the result comes back in IPv4 form. The interface scope is
+	 * dropped at every width: a prefix is not interface-scoped, and returning it at one width
+	 * but not the next would make the same two addresses one value at /64 and two at /128.
+	 *
 	 * @param prefixBits Counted from the most significant bit of the address in its own
 	 *                   family: 0..32 for IPv4, 0..128 for IPv6. A value at or above the
-	 *                   family's width returns the address unchanged.
+	 *                   family's width returns the address with its scope dropped, and
+	 *                   otherwise unchanged.
 	 * @return The prefix's network address. An absent address is returned unchanged --
 	 *         there is no prefix to compute and none is invented.
 	 */
@@ -591,10 +599,11 @@ public:
 		if (IsAbsent()) {
 			return *this;
 		}
-		// The effective family, not the stored one. An IPv4-mapped address is IPv4 for every
-		// other accessor here, and taking 128 for it truncated the embedded octets away
-		// entirely: ::ffff:203.0.113.5 at /24 came back as ::, so every mapped peer landed in
-		// one bucket of the per-prefix budget this exists to feed.
+		// Normalising to the effective family is the fix. Truncating the stored octets of a
+		// mapped address zeroed the embedded ones away entirely: ::ffff:203.0.113.5 at /24
+		// came back as ::, so every mapped peer landed in one bucket of the per-prefix budget
+		// this exists to feed. Taking the width from the same subject only shortcuts the
+		// truncation below, which now reaches the same answer either way.
 		const CNetworkAddress subject = Unmapped();
 		const unsigned width = subject.IsIPv4() ? 32u : 128u;
 		if (prefixBits >= width) {

--- a/src/NetworkAddress.h
+++ b/src/NetworkAddress.h
@@ -45,6 +45,9 @@ struct IPv6ExcludedPrefix
 constexpr IPv6ExcludedPrefix kIPv6ExcludedPrefixes[] = { { {}, 128, "Unspecified" },
 	{ { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1 }, 128, "Loopback" },
 	{ { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xff, 0xff }, 96, "IPv4-mapped" },
+	// ::a.b.c.d, the deprecated IPv4-compatible form (RFC 4291). Listed after the two entries
+	// above so the unspecified address and the loopback keep their own names in a log.
+	{ {}, 96, "IPv4-compatible" },
 	{ { 0x00, 0x64, 0xff, 0x9b }, 96, "Well-known NAT64" },
 	{ { 0x00, 0x64, 0xff, 0x9b, 0x00, 0x01 }, 48, "Local-use NAT64" },
 	{ { 0x01, 0x00 }, 64, "Discard-only" },
@@ -364,6 +367,32 @@ public:
 	 * at sites that must treat the mapped and native forms as one address; the
 	 * comparison operators never do it for you.
 	 */
+	/**
+	 * A hash over exactly what operator== compares.
+	 *
+	 * A member rather than a loose function so it cannot drift from the comparison, and
+	 * supplied at all because a caller writing their own would reach for the object's bytes:
+	 * sizeof is 32 against 25 bytes of members, and no member initialiser touches the seven
+	 * bytes of tail padding, so a byte-wise hash disagrees with operator== for values that
+	 * compare equal.
+	 */
+	std::size_t HashValue() const noexcept
+	{
+		std::size_t result = static_cast<std::size_t>(m_family);
+		for (const std::uint8_t octet : m_octets) {
+			result = result * 131u + octet;
+		}
+		return result * 131u + static_cast<std::size_t>(m_scopeId);
+	}
+
+	//! The same address with no interface scope. A prefix is not interface-scoped.
+	CNetworkAddress WithoutScope() const
+	{
+		CNetworkAddress result = *this;
+		result.m_scopeId = 0;
+		return result;
+	}
+
 	CNetworkAddress Unmapped() const
 	{
 		if (IsIPv4Mapped()) {
@@ -562,11 +591,19 @@ public:
 		if (IsAbsent()) {
 			return *this;
 		}
-		const unsigned width = IsIPv4() ? 32u : 128u;
+		// The effective family, not the stored one. An IPv4-mapped address is IPv4 for every
+		// other accessor here, and taking 128 for it truncated the embedded octets away
+		// entirely: ::ffff:203.0.113.5 at /24 came back as ::, so every mapped peer landed in
+		// one bucket of the per-prefix budget this exists to feed.
+		const CNetworkAddress subject = Unmapped();
+		const unsigned width = subject.IsIPv4() ? 32u : 128u;
 		if (prefixBits >= width) {
-			return *this;
+			// Scope dropped here too. The truncating path below drops it deliberately, and
+			// returning it only on this branch made fe80::1%7 and fe80::1%9 one value at
+			// /64 and two at /128, which is a discontinuity at the boundary.
+			return subject.WithoutScope();
 		}
-		Octets bytes = m_octets;
+		Octets bytes = subject.m_octets;
 		for (std::size_t i = 0; i < bytes.size(); ++i) {
 			const unsigned bitsBefore = static_cast<unsigned>(i) * 8u;
 			if (prefixBits >= bitsBefore + 8u) {
@@ -579,7 +616,7 @@ public:
 					bytes[i] & (0xFFu << (bitsBefore + 8u - prefixBits)));
 			}
 		}
-		if (IsIPv4()) {
+		if (subject.IsIPv4()) {
 			return FromIPv4HostOrder(PackOctets(bytes[0], bytes[1], bytes[2], bytes[3]));
 		}
 		// The scope id is deliberately not carried over: a prefix is not interface-scoped, and
@@ -674,6 +711,22 @@ private:
 	//! None when unset. Never conflated with the all-zero address.
 	Family m_family = Family::None;
 };
+
+/**
+ * Hashing, over exactly the three members operator== compares.
+ *
+ * Supplied because the class is framed as a container key and a caller writing their own would
+ * reach for the object's bytes: sizeof is 32 against 25 bytes of members, and no member
+ * initialiser touches the seven bytes of tail padding, so a byte-wise hash disagrees with
+ * operator== for values that compare equal.
+ */
+namespace std
+{
+template <> struct hash<CNetworkAddress>
+{
+	std::size_t operator()(const CNetworkAddress &address) const noexcept { return address.HashValue(); }
+};
+} // namespace std
 
 #endif // NETWORKADDRESS_H
 // File_checked_for_headers

--- a/unittests/tests/BanRecordTest.cpp
+++ b/unittests/tests/BanRecordTest.cpp
@@ -43,6 +43,14 @@ const uint32 IP_B = 0x0200007f;
 // ban of the same address must answer false or the statistic drifts.
 // CUpDownClient::SetSpammer(true) calls Ban() with no IsBanned() check, which is how that second
 // call happens in practice.
+// ASSERT_EQUALS takes its arguments by const reference, so this odr-uses BAN_DURATION_MS. With
+// the member declared static const and defined nowhere, it does not link; constexpr is what makes
+// it work. The assertion itself is almost beside the point, the reference binding is the test.
+TEST(BanRecord, TheBanDurationConstantCanBeReferenced)
+{
+	ASSERT_EQUALS(static_cast<uint64>(CLIENTBANTIME), CBanRecord::BAN_DURATION_MS);
+}
+
 TEST(BanRecord, BanningTheSameAddressTwiceCountsOnce)
 {
 	CBanRecord record;

--- a/unittests/tests/NetworkAddressTest.cpp
+++ b/unittests/tests/NetworkAddressTest.cpp
@@ -38,6 +38,7 @@
 #include <algorithm>
 #include <map>
 #include <set>
+#include <unordered_map>
 
 using namespace muleunit;
 
@@ -46,6 +47,71 @@ DECLARE_SIMPLE(NetworkAddress)
 // 192.0.2.1 (RFC 5737 documentation range) in each of the two conventions.
 static const uint32_t TEST_IP_HOST_ORDER = 0xC0000201u;
 static const uint32_t TEST_IP_ED2K_ORDER = 0x010200C0u;
+
+// An IPv4-mapped address is IPv4 for every other accessor, so truncation has to use the effective
+// family too. Taking 128 bits for it zeroed the embedded octets away entirely, which put every
+// mapped peer into one bucket of the per-prefix budget this function exists to feed.
+TEST(NetworkAddress, TruncatingAMappedAddressUsesTheIPv4Width)
+{
+	const CNetworkAddress mapped = CNetworkAddress::FromString("::ffff:203.0.113.5");
+	ASSERT_TRUE(mapped.IsIPv4Mapped());
+
+	const CNetworkAddress prefix = mapped.TruncatedToPrefix(24);
+	ASSERT_FALSE(prefix.IsUnspecified());
+	ASSERT_TRUE(prefix == CNetworkAddress::FromString("203.0.113.0"));
+
+	// Two mapped peers in different /24s must not share a bucket.
+	const CNetworkAddress other = CNetworkAddress::FromString("::ffff:198.51.100.5");
+	ASSERT_FALSE(other.TruncatedToPrefix(24) == prefix);
+}
+
+// The scope is dropped on every path, not just the truncating one. Returning it only when
+// prefixBits reached the family width made the same two addresses one value at /64 and two at
+// /128, a discontinuity at the boundary that contradicts the function's own comment.
+TEST(NetworkAddress, TruncationDropsTheScopeAtEveryWidth)
+{
+	const CNetworkAddress a = CNetworkAddress::FromString("fe80::1%7");
+	const CNetworkAddress b = CNetworkAddress::FromString("fe80::1%9");
+	if (a.GetScopeId() == b.GetScopeId()) {
+		return; // The platform did not parse the scope suffixes; nothing to compare.
+	}
+
+	ASSERT_TRUE(a.TruncatedToPrefix(64) == b.TruncatedToPrefix(64));
+	ASSERT_TRUE(a.TruncatedToPrefix(128) == b.TruncatedToPrefix(128));
+}
+
+// ::a.b.c.d, the deprecated IPv4-compatible form. Advertising one burns a peer's connect attempt,
+// which is the cost this predicate exists to avoid.
+TEST(NetworkAddress, IPv4CompatibleAddressesAreNotGloballyRoutable)
+{
+	ASSERT_FALSE(CNetworkAddress::FromString("::203.0.113.5").IsGloballyRoutableIPv6());
+	// Still distinguished from the two values that share the same page.
+	ASSERT_FALSE(CNetworkAddress::FromString("::").IsGloballyRoutableIPv6());
+	ASSERT_FALSE(CNetworkAddress::FromString("::1").IsGloballyRoutableIPv6());
+	// And a real address is unaffected.
+	ASSERT_TRUE(CNetworkAddress::FromString("2001:4860:4860::8888").IsGloballyRoutableIPv6());
+}
+
+// The hash has to agree with operator==, which a byte-wise hash would not: sizeof is larger than
+// the members and nothing initialises the tail padding.
+TEST(NetworkAddress, HashingAgreesWithEquality)
+{
+	const CNetworkAddress a = CNetworkAddress::FromString("2001:db8::1");
+	const CNetworkAddress b = CNetworkAddress::FromString("2001:db8::1");
+	ASSERT_TRUE(a == b);
+	ASSERT_EQUALS(std::hash<CNetworkAddress>()(a), std::hash<CNetworkAddress>()(b));
+
+	std::unordered_map<CNetworkAddress, int> byAddress;
+	byAddress[a] = 1;
+	byAddress[b] = 2;
+	ASSERT_EQUALS(1u, (unsigned)byAddress.size());
+	ASSERT_EQUALS(2, byAddress[a]);
+
+	// Distinct values, including the mapped and native forms the type keeps apart.
+	byAddress[CNetworkAddress::FromString("203.0.113.5")] = 3;
+	byAddress[CNetworkAddress::FromString("::ffff:203.0.113.5")] = 4;
+	ASSERT_EQUALS(3u, (unsigned)byAddress.size());
+}
 
 TEST(NetworkAddress, ByteOrderIsInTheSignature)
 {

--- a/unittests/tests/NetworkAddressTest.cpp
+++ b/unittests/tests/NetworkAddressTest.cpp
@@ -70,11 +70,15 @@ TEST(NetworkAddress, TruncatingAMappedAddressUsesTheIPv4Width)
 // /128, a discontinuity at the boundary that contradicts the function's own comment.
 TEST(NetworkAddress, TruncationDropsTheScopeAtEveryWidth)
 {
-	const CNetworkAddress a = CNetworkAddress::FromString("fe80::1%7");
-	const CNetworkAddress b = CNetworkAddress::FromString("fe80::1%9");
-	if (a.GetScopeId() == b.GetScopeId()) {
-		return; // The platform did not parse the scope suffixes; nothing to compare.
-	}
+	// The scope ids are set directly rather than parsed out of "fe80::1%7". Whether a platform
+	// resolves a scope suffix is not what this pins, and skipping the comparison where it does
+	// not is indistinguishable from passing it.
+	const CNetworkAddress::Octets linkLocal = { 0xfe, 0x80, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1 };
+	const CNetworkAddress a = CNetworkAddress::IPv6FromOctets(linkLocal, 7);
+	const CNetworkAddress b = CNetworkAddress::IPv6FromOctets(linkLocal, 9);
+	ASSERT_EQUALS(7ul, a.GetScopeId());
+	ASSERT_EQUALS(9ul, b.GetScopeId());
+	ASSERT_FALSE(a == b); // the scope is the only thing separating them
 
 	ASSERT_TRUE(a.TruncatedToPrefix(64) == b.TruncatedToPrefix(64));
 	ASSERT_TRUE(a.TruncatedToPrefix(128) == b.TruncatedToPrefix(128));


### PR DESCRIPTION
Five findings from re-reviewing #1314 and #1318. Nothing outside the tests calls `CNetworkAddress` yet, so all of these are latent: they are about the contract the IPv6 call sites will be written against.

## `BAN_DURATION_MS` cannot be referenced (#1314)

Declared `static const` with no out-of-line definition. Every use today is arithmetic, a value computation, so it links. The first reference binding does not, and `ASSERT_EQUALS` is exactly that, since muleunit takes its arguments by `const&`. The new test fails to link without the fix, with `Undefined symbols for architecture arm64`. C++17 does not help here: only `constexpr` members became implicitly inline.

## `TruncatedToPrefix()` collapsed every mapped peer into one bucket

The function read the stored family rather than the effective one, and `IsIPv4()` is false for an IPv4-mapped address. So a mapped address took the 128-bit width and was truncated over its own mapped octets, zeroing the embedded ones away. `::ffff:203.0.113.5` at /24 returned `::`. The per-prefix budget this feeds would have become a single global bucket for every peer that arrived mapped, so one abusive peer throttles all of them. It now normalises to the effective family before truncating, which is the fix; taking the width from the same subject only shortcuts the truncation, which reaches the same answer either way. The function's Doxygen described the old behaviour and has been corrected: it promised that a `prefixBits` at or above the family width returns the address unchanged, and it returns the address with its scope dropped, in IPv4 form when the input was mapped.

## The scope id survived at one width and not the next

The same function returned the address unchanged, scope included, once `prefixBits` reached the family width, while the truncating path drops the scope deliberately. `fe80::1%7` and `fe80::1%9` were one value at /64 and two at /128. Dropped on both paths now.

## `::a.b.c.d` was globally routable

Only the /128 unspecified entry covered that page, so the deprecated IPv4-compatible form passed. Advertising one burns a peer's connect attempt, which is the cost the predicate exists to avoid. The other half of that finding, `64:ff9b::/96`, was already fixed by #1345's exclusion table.

## No `std::hash` on a type framed as a container key

`sizeof` is 32 against 25 bytes of members, and nothing initialises the seven bytes of tail padding, so the byte-wise hash a caller would reach for disagrees with `operator==` for values that compare equal. `HashValue()` hashes exactly the three members the comparison uses, and `std::hash` forwards to it.

## Two reported findings that are not defects

**`FromIPv6Bytes()` accepting `::ffff:0.0.0.0` is correct.** That factory's absence rule exists for one documented wire behaviour, a peer with no IPv6 address emitting the tag as all zeros, and the mapped zero is a valid address value rather than that sentinel. Rejecting it would put policy inside a decoder that deliberately holds none, and leave the same value reachable by every other route. The real gap is that `HasEd2kWireForm()` narrows it to 0 despite existing to stop exactly that, which is logged against #1345.

**Mapped and native being distinct to `operator==` is the intended layering.** The type holds values; `IndexKey()` in `PeerAddressing.h` is the identity normaliser. I tried unmapping in the asio bridge and the suite said no immediately: `FromString()` routes through the same function, and both `NetworkAddressTest` and `PeerAddressingTest` pin the two forms as distinct. Reverted.

## Verification

Rebased onto `d1de6be3a`, since #1377 and #1378 landed during this work. Default build clean, 62/62 ctest. `NetworkAddressTest` 12 to 16 cases, `BanRecordTest` 7 to 8. Controls, stated as they actually behave: reverting the `Unmapped()` normalisation fails the mapped-truncation test, reverting the scope drop fails the scope test, dropping the exclusion entry fails the routability test, removing the `std::hash` specialisation fails to compile, and reverting `constexpr` fails to link with `Undefined symbols`.

Reverting the width line alone fails nothing, which is why the comment above it no longer presents it as the fix.

`TruncationDropsTheScopeAtEveryWidth` returned early when the two scope ids compared equal, in case a platform did not parse `%7`. Where that fired it asserted nothing and looked identical to a pass, so the addresses are now built through `IPv6FromOctets()` with the scope ids set directly and no suffix is parsed.

Two changes in the diff carry no behaviour: `<functional>` is now included, because `std::hash` is specialised here rather than reached through whatever `<string>` happens to pull in, and the comment on the new exclusion entry no longer explains its position by a log that does not exist. `name` is read once, by a test asserting it is non-empty; what the ordering does is let the matcher stop at the more specific `/128` entry.

clang-format 18 clean, `git diff --check` clean, Tier-2 clang-tidy clean with zero compiler errors.

Refs #1177


