### PR TITLE
fix(core): report a backtrace when aMule dies of SIGABRT

### DIFF
--- a/src/ExternalConnector.cpp
+++ b/src/ExternalConnector.cpp
@@ -24,6 +24,8 @@
 
 #include "ExternalConnector.h"
 
+#include <common/MuleDebug.h> // Needed for InstallFatalAbortHandler
+
 #include <common/FileFunctions.h> // RestrictToOwner
 #include "config.h"               // Needed for VERSION and readline detection
 #include <common/Format.h>        // Needed for CFormat
@@ -722,6 +724,9 @@ bool CaMuleExternalConnector::OnInit()
 #if wxUSE_ON_FATAL_EXCEPTION
 	wxHandleFatalExceptions(true);
 #endif
+	// wx covers SIGSEGV/SIGBUS/SIGILL/SIGFPE and never SIGABRT, so a glibc heap abort kills the
+	// connector binaries as silently as it killed amuled in amule-org/amule#1338.
+	InstallFatalAbortHandler();
 #endif
 
 	// Pull the libc locale from the environment before any wxString -> char* conversion runs
@@ -739,6 +744,19 @@ bool CaMuleExternalConnector::OnInit()
 	InstallMuleExceptionHandler();
 
 	bool retval = wxApp::OnInit();
+
+	// Below wxApp::OnInit(), which is what runs OnInitCmdLine() and so sets m_appname: above it
+	// the name is still NULL and the banner would name no binary at all, which is the one thing
+	// it exists to say. amulecmd, amuleweb and amuleapi share a version string, so without the
+	// name a pasted report cannot be attributed. The handler is armed before this point and
+	// would report without a version line; that is strictly better than one that never has a
+	// name. Written from a signal handler, which cannot format, hence the fixed buffer.
+	// The casts matter: CFormat resolves char* to its pointer overload and would print the
+	// addresses, where const char* formats the string.
+	SetFatalAbortVersionLine((const char *)unicode2char(CFormat("%s %s on %s") % m_appname %
+							    (const char *)m_strFullVersion %
+							    (const char *)m_strOSDescription));
+
 	OnInitCommandSet();
 	InitCustomLanguages();
 	SetLocale(m_language);
@@ -797,6 +815,11 @@ void CaMuleExternalConnector::OnFatalException()
 
 	fprintf(stderr,
 		"\n--------------------------------------------------------------------------------\n");
+
+	// wx's handler calls abort() as soon as this returns, so without this the SIGABRT handler
+	// adds a second, raw backtrace under a banner that blames the allocator. The symbolicated
+	// one above is the report; this keeps it the only one.
+	SuppressNextAbortBacktrace();
 }
 #endif
 

--- a/src/Logger.cpp
+++ b/src/Logger.cpp
@@ -23,6 +23,8 @@
 //
 
 #include "Logger.h"
+
+#include <common/MuleDebug.h> // Needed for ReserveCrashFd
 #include "amule.h"
 #include "Preferences.h"
 #include <common/Macros.h>
@@ -193,6 +195,9 @@ bool CLogger::OpenLogfile(const wxString &name)
 	if (ret) {
 		FlushApplog();
 		m_LogfileName = name;
+		// A daemon's stderr is /dev/null, so the abort handler needs a real file to write to.
+		// Reserved rather than looked up on demand: it runs from a signal handler.
+		m_crashFd = ReserveCrashFd(m_crashFd, applog->GetFile()->fp());
 	} else {
 		CloseLogfile();
 	}

--- a/src/Logger.h
+++ b/src/Logger.h
@@ -219,6 +219,10 @@ public:
 	/// Name of the logfile.
 	const wxString &GetLogfileName() const { return m_LogfileName; }
 
+	/// Descriptor reserved for the crash path, or -1 before the first open. Survives a
+	/// close-and-reopen of the logfile; see ReserveCrashFd().
+	int CrashFd() const { return m_crashFd; }
+
 	/// Event handler.
 	void OnLoggingEvent(class CLoggingEvent &evt);
 
@@ -232,6 +236,7 @@ public:
 private:
 	class wxFFileOutputStream *applog; // the logfile
 	wxString m_LogfileName;
+	int m_crashFd = -1;
 	wxString m_ApplogBuf;
 	bool m_StdoutLog;
 	int m_count; // output line counter

--- a/src/amule-remote-gui.cpp
+++ b/src/amule-remote-gui.cpp
@@ -35,6 +35,7 @@
 #include <glib.h> // g_set_prgname() -- wl_app_id / WM_CLASS binding
 #endif
 
+#include <common/MuleDebug.h> // Needed for get_backtrace and SuppressNextAbortBacktrace
 #include <common/Format.h>
 #include <common/StringFunctions.h>
 #include <common/MD5Sum.h>
@@ -301,6 +302,11 @@ void CamuleRemoteGuiApp::OnFatalException()
 	    << "\n--------------------------------------------------------------------------------\n";
 
 	theLogger.EmergencyLog(msg, true);
+
+	// wx's handler calls abort() as soon as this returns, so without this the SIGABRT handler
+	// adds a second, raw backtrace under a banner that blames the allocator. The symbolicated
+	// one above is the report; this keeps it the only one.
+	SuppressNextAbortBacktrace();
 }
 #endif
 

--- a/src/amule.cpp
+++ b/src/amule.cpp
@@ -35,6 +35,7 @@
 		    //   HAVE_SYS_RESOURCE_H, HAVE_SYS_STATVFS_H, VERSION
 		    //   and ENABLE_NLS
 #include <common/ClientVersion.h>
+#include <common/MuleDebug.h> // Needed for SuppressNextAbortBacktrace
 
 #include <wx/cmdline.h> // Needed for wxCmdLineParser
 #ifndef AMULE_DAEMON
@@ -1758,6 +1759,11 @@ void CamuleApp::OnFatalException()
 	    << "\n--------------------------------------------------------------------------------\n";
 
 	theLogger.EmergencyLog(msg, true);
+
+	// wx's handler calls abort() as soon as this returns, so without this the SIGABRT handler
+	// adds a second, raw backtrace under a banner that blames the allocator. The symbolicated
+	// one above is the report; this keeps it the only one.
+	SuppressNextAbortBacktrace();
 }
 #endif
 

--- a/src/amuleAppCommon.cpp
+++ b/src/amuleAppCommon.cpp
@@ -83,6 +83,7 @@ bool CamuleAppCommon::ReportAssertFailure(const wxChar *file,
 	// watchdog script) sees a non-zero exit and can restart aMule. The errmsg above is already
 	// on stderr and in the log; nothing useful is lost by skipping the dialog.
 	if (m_disableFatal) {
+		SuppressNextAbortBacktrace();
 		raise(SIGABRT);
 		return false; // unreachable
 	}
@@ -96,6 +97,7 @@ bool CamuleAppCommon::ReportAssertFailure(const wxChar *file,
 		_wassert(s.wc_str(), file, line);
 #else
 		// Abort, allows gdb to catch the assertion
+		SuppressNextAbortBacktrace();
 		raise(SIGABRT);
 #endif
 		return false; // unreachable
@@ -606,6 +608,13 @@ bool CamuleAppCommon::InitCommon(int argc, wxChar **argv)
 		wxHandleFatalExceptions(true);
 	}
 #endif
+	// Armed whether or not wx's handlers are: --disable-fatal turns off the dialog and the
+	// wx-caught signals, but a glibc heap abort still kills us silently, and that is the case
+	// this exists to report. wx covers SIGSEGV/SIGBUS/SIGILL/SIGFPE and never SIGABRT.
+	InstallFatalAbortHandler();
+	// The banner is written from a signal handler and cannot format anything, so the build is
+	// recorded up front; without it a pasted report does not say which binary produced it.
+	SetFatalAbortVersionLine((const char *)unicode2char(CFormat("%s on %s") % FullMuleVersion % OSType));
 #endif
 
 	theLogger.SetEnabledStdoutLog(cmdline.Found("log-stdout"));
@@ -849,6 +858,15 @@ bool CamuleAppCommon::InitCommon(int argc, wxChar **argv)
 	if (!theLogger.OpenLogfile(logfileName.GetRaw())) {
 		fputs("ERROR: unable to open log file\n", stderr);
 		return false;
+	}
+
+	// Send the abort backtrace to the logfile, which is where EmergencyLog() already puts the
+	// SIGSEGV report, so both crash kinds land in the same place. Not conditional on
+	// --full-daemon: that mode points fd 0/1/2 at /dev/null, but a desktop-launched amule or
+	// amulegui has no useful stderr either. Nothing is given up by arming it: stderrUsable
+	// defaults to true, so a terminal still gets its copy.
+	if (theLogger.CrashFd() >= 0) {
+		SetFatalAbortRedirectFd(theLogger.CrashFd());
 	}
 
 	CPreferences::BuildItemList(thePrefs::GetConfigDir());

--- a/src/libs/common/MuleDebug.cpp
+++ b/src/libs/common/MuleDebug.cpp
@@ -26,18 +26,32 @@
 #include <cstdlib> // Needed for std::abort()
 #include <cstdio>  // Needed for popen/pclose/fgets in the addr2line fallback
 #include <cstring> // Needed for strlen in the addr2line fallback
+#include <cerrno>  // Needed for EINTR in the SIGABRT handler's write loop
+#include <csignal> // Needed for sigaction/raise in the SIGABRT handler
 #include <cstdint> // uintptr_t for pointer subtraction in the bfd
 		   // section-bounds check -- `unsigned long` is
 		   // 4 bytes on LLP64 and would silently truncate.
 
 #include "config.h" // Needed for HAVE_CXXABI and HAVE_EXECINFO
 
-#include "MuleDebug.h"       // Interface declaration
+#include "MuleDebug.h" // Interface declaration
+#include <string>      // Needed for the terminate report buffer
+
 #include "StringFunctions.h" // Needed for unicode2char
 #include "Format.h"          // Needed for CFormat
 
+#ifndef __WINDOWS__
+#include <fcntl.h>    // Needed for FD_CLOEXEC on the reserved descriptor
+#include <poll.h>     // Needed for the writability waits in WriteAll and the handler
+#include <sys/stat.h> // Needed for fstat in SameFile
+#include <unistd.h>   // Needed for dup/dup2 in ReserveCrashFd and write in WriteAll
+#endif
+
 #ifdef HAVE_EXECINFO
 #include <execinfo.h>
+#include <poll.h>     // Needed for the writability probe in the SIGABRT handler
+#include <sys/stat.h> // Needed for fstat in the SIGABRT handler
+#include <unistd.h>   // Needed for write()/STDERR_FILENO in the SIGABRT handler
 #include <wx/utils.h> // Needed for wxArrayString
 #ifndef HAVE_BFD
 #include <wx/thread.h> // Needed for wxThread
@@ -61,12 +75,66 @@
 #include <vector>
 #include <exception>
 
+// Defined below with the rest of the abort-redirect state.
+static int AbortConsoleFd(int fallback);
+#ifndef __WINDOWS__
+static int AbortRedirectFd();
+#endif
+#ifndef __WINDOWS__
+static void WriteAll(int fd, const char *data, size_t len);
+static bool SameFile(int a, int b);
+static bool FdCanTakeAWrite(int fd);
+#endif
+
+// One chunk of the terminate report, to every sink that wants it.
+static void EmitTerminateChunk(const std::string &chunk, FILE *output)
+{
+#ifdef __WINDOWS__
+	fputs(chunk.c_str(), output);
+	fflush(output);
+#else
+	const int redirect = AbortRedirectFd();
+	const int console = AbortConsoleFd(fileno(output));
+	// Compared against the descriptor this actually writes to, not fd 2: a registered console
+	// descriptor naming the same file as the log is a different number, and comparing the wrong
+	// pair would put the report in there twice. The signal handler compares the same way.
+	const bool haveDurable = redirect >= 0 && !SameFile(redirect, console);
+
+	// The probe picks the order. A console that polls ready will not block on a chunk this size,
+	// so taking it first costs nothing and guarantees something is emitted even if the durable
+	// sink then hangs -- a logfile on a hard-mounted NFS share blocks in write(2), and being a
+	// regular file it never returns EAGAIN, so neither the stall loop nor poll() can see it
+	// coming. poll() reports every regular file ready, so the durable sink cannot be probed at
+	// all; only the alarm bounds it.
+	const bool consoleFirst = FdCanTakeAWrite(console);
+	if (consoleFirst) {
+		WriteAll(console, chunk.data(), chunk.size());
+	}
+	if (haveDurable) {
+		WriteAll(redirect, chunk.data(), chunk.size());
+	}
+	// A console that failed the probe is skipped once a copy is out elsewhere. With no durable
+	// sink it is all there is, so it goes unprobed and the alarm bounds it.
+	if (!consoleFirst && !haveDurable) {
+		WriteAll(console, chunk.data(), chunk.size());
+	}
+#endif
+}
+
 // Prints a verbose description of any unhandled exception, then raises
 // SIGABRT.
 void OnUnhandledException()
 {
 	// Revert to the original handler so a fault in here cannot recurse.
 	std::set_terminate(std::abort);
+
+#ifndef __WINDOWS__
+	// Bounded like the SIGABRT handler. get_backtrace() popen()s addr2line on the non-BFD path,
+	// and the only sink may be a descriptor that never drains; a process that reports nothing
+	// and never exits is worse than one that dies.
+	signal(SIGALRM, SIG_DFL);
+	alarm(10);
+#endif
 
 #ifdef HAVE_CXXABI
 	std::type_info *t = __cxxabiv1::__cxa_current_exception_type();
@@ -86,22 +154,46 @@ void OnUnhandledException()
 #else
 		const char *name = "Unknown";
 #endif
-		fprintf(output, "\nTerminated after throwing an instance of '%s'\n", (status ? name : dem));
+		// The type and what() go out before the backtrace is built, not with it.
+		// get_backtrace() symbolicates: it allocates throughout and on the non-BFD path
+		// popen()s addr2line. If that subprocess hangs or the step faults, this much is
+		// already reported, which is what master did by writing straight to unbuffered
+		// stderr. Each chunk goes to both sinks; writing only to `output` while the
+		// reserved descriptor was dup2()ed over fd 2 took the report off the console
+		// entirely for a terminal-launched amule.
+		std::string head("\nTerminated after throwing an instance of '");
+		head += (status ? name : dem);
+		head += "'\n";
 		free(dem);
 
 		try {
 			throw;
 		} catch (const std::exception &e) {
-			fprintf(output, "\twhat(): %s\n", e.what());
+			head += "\twhat(): ";
+			head += e.what();
+			head += "\n";
 		} catch (const CMuleException &e) {
-			fprintf(output, "\twhat(): %s\n", (const char *)unicode2char(e.what()));
+			head += "\twhat(): ";
+			head += (const char *)unicode2char(e.what());
+			head += "\n";
 		} catch (const wxString &e) {
-			fprintf(output, "\twhat(): %s\n", (const char *)unicode2char(e));
+			head += "\twhat(): ";
+			head += (const char *)unicode2char(e);
+			head += "\n";
 		} catch (...) {
 			// Unable to retrieve cause of exception
 		}
+		EmitTerminateChunk(head, output);
 
-		fprintf(output, "\tbacktrace:\n%s\n", (const char *)unicode2char(get_backtrace(1)));
+		std::string trace("\tbacktrace:\n");
+		trace += (const char *)unicode2char(get_backtrace(1));
+		trace += "\n";
+		EmitTerminateChunk(trace, output);
+
+		// Inside the branch on purpose. std::terminate() with no active exception prints
+		// nothing at all, and suppressing there would trade the handler's raw backtrace for
+		// silence. A joinable std::thread destroyed without join() reaches exactly that.
+		SuppressNextAbortBacktrace();
 	}
 	std::abort();
 }
@@ -643,5 +735,286 @@ void print_backtrace(unsigned n)
 	// This is because the string is ansi anyway, and the conv classes are very slow
 	fprintf(stderr, "%s\n", (const char *)unicode2char(trace));
 }
+
+// Set by SuppressNextAbortBacktrace(). sig_atomic_t because the handler reads it; volatile because
+// the write and the read are in different control flows and nothing else orders them.
+static volatile sig_atomic_t s_suppressAbortBacktrace = 0;
+
+void SuppressNextAbortBacktrace()
+{
+	s_suppressAbortBacktrace = 1;
+}
+
+// -1 until a caller redirects; read by the handler, so sig_atomic_t rather than int.
+static volatile sig_atomic_t s_abortRedirectFd = -1;
+
+// Where the console copy goes when fd 2 is not it; see the header.
+static volatile sig_atomic_t s_abortConsoleFd = -1;
+
+// Written once before any crash, read from a handler, so a fixed buffer rather than a wxString.
+// The length is kept with it: strlen() is not on the async-signal-safe list.
+static char s_versionLine[256] = { 0 };
+static volatile sig_atomic_t s_versionLineLen = 0;
+
+void SetFatalAbortRedirectFd(int fd)
+{
+	s_abortRedirectFd = fd;
+}
+
+void SetFatalAbortConsoleFd(int fd)
+{
+	s_abortConsoleFd = fd;
+}
+
+void SetFatalAbortVersionLine(const char *text)
+{
+	if (text == nullptr) {
+		s_versionLine[0] = '\0';
+		s_versionLineLen = 0;
+		return;
+	}
+	const int written = std::snprintf(s_versionLine, sizeof(s_versionLine), "%s\n", text);
+	if (written < 0) {
+		// Encoding failure: nothing was written, so the buffer still holds whatever it held.
+		// Reporting a length here would paste uninitialised bytes into a public issue.
+		s_versionLine[0] = '\0';
+		s_versionLineLen = 0;
+		return;
+	}
+	if (static_cast<size_t>(written) < sizeof(s_versionLine)) {
+		s_versionLineLen = written;
+		return;
+	}
+	// Truncated. The character lost is the trailing newline, which would glue the first
+	// backtrace frame onto the version line, so put it back over the last byte.
+	s_versionLine[sizeof(s_versionLine) - 2] = '\n';
+	s_versionLineLen = static_cast<int>(sizeof(s_versionLine) - 1);
+}
+
+#ifndef __WINDOWS__
+static int AbortRedirectFd()
+{
+	return s_abortRedirectFd;
+}
+#endif
+
+// Whether the console is worth a copy. With no redirect it is the only sink there is. With one, the
+// caller decides: amuleapi passes stderrUsable = false because its fd 2 is the tee pipe, and that
+// pipe's pump writes into the very log the reserved descriptor names, so a console copy would land
+// there twice. SameFile() cannot catch that, since it compares a pipe against a file.
+// The console copy's destination: the descriptor a caller handed over, else fd 2 itself.
+static int AbortConsoleFd(int fallback)
+{
+	return s_abortConsoleFd >= 0 ? s_abortConsoleFd : fallback;
+}
+
+#ifndef __WINDOWS__
+// write(2) can return short, and returns EINTR if a signal lands mid-call. Looping is what makes
+// the banner arrive whole; a partial one splices into whatever glibc printed and reads as garbage.
+static void WriteAll(int fd, const char *data, size_t len)
+{
+	// Waiting out a sink that is merely busy, bounded so a handler cannot sit here forever. A
+	// second is far longer than a report needs and far shorter than the alarm.
+	const int kStallMs = 50;
+	const int kMaxStalls = 20;
+
+	int stalls = 0;
+	while (len > 0) {
+		const ssize_t written = write(fd, data, len);
+		if (written > 0) {
+			data += written;
+			len -= static_cast<size_t>(written);
+			continue;
+		}
+		if (written < 0 && errno == EINTR) {
+			continue;
+		}
+		if (written < 0 && (errno == EAGAIN || errno == EWOULDBLOCK)) {
+			// Not gone, just not ready. This is reachable: poll(POLLOUT) on a pipe
+			// promises only PIPE_BUF, and a 64-frame backtrace is bigger than that, so
+			// a non-blocking sink goes short partway through a report that had already
+			// passed the probe. Returning here would truncate it mid-line.
+			if (++stalls > kMaxStalls) {
+				return;
+			}
+			struct pollfd wait;
+			wait.fd = fd;
+			wait.events = POLLOUT;
+			wait.revents = 0;
+			(void)poll(&wait, 1, kStallMs);
+			continue;
+		}
+		return; // EBADF, EPIPE and friends: there really is nowhere left to report this
+	}
+}
+
+// Whether a descriptor can take a write right now. A wedged journald socket or a pipe whose reader
+// has stopped answers no, and a reporting path with a copy already out elsewhere skips it rather
+// than blocking. poll() is on the async-signal-safe list.
+static bool FdCanTakeAWrite(int fd)
+{
+	// A budget rather than a poll of zero. In a container without a tty fd 2 is a pipe, and a
+	// reader that is merely behind would otherwise cost the `docker logs` copy on the instant
+	// the buffer happens to be full. Long enough to ride out a busy reader, short enough that a
+	// genuinely wedged sink is still skipped well inside the alarm.
+	const int kProbeMs = 100;
+
+	struct pollfd probe;
+	probe.fd = fd;
+	probe.events = POLLOUT;
+	probe.revents = 0;
+	return poll(&probe, 1, kProbeMs) == 1 && (probe.revents & POLLOUT) != 0;
+}
+
+// Two descriptors naming one file, so a report written to both would arrive twice. fstat() is on
+// the async-signal-safe list, which matters for the caller that runs from a signal handler.
+static bool SameFile(int a, int b)
+{
+	struct stat sa;
+	struct stat sb;
+	return fstat(a, &sa) == 0 && fstat(b, &sb) == 0 && sa.st_dev == sb.st_dev && sa.st_ino == sb.st_ino;
+}
+#endif
+
+int ReserveCrashFd(int reserved, std::FILE *fp)
+{
+#ifdef __WINDOWS__
+	// An open handle blocks rename() on Windows, and the SIGABRT handler this feeds never runs
+	// there: wx goes through SEH and ExitProcess() instead. Reserve nothing.
+	(void)fp;
+	return reserved;
+#else
+	if (fp == nullptr) {
+		return reserved;
+	}
+	const int fd = fileno(fp);
+	if (fd < 0) {
+		return reserved;
+	}
+	// FD_CLOEXEC on every path: this descriptor is deliberately never closed, so without it the
+	// logfile would be held open by every child aMule spawns (wxExecute in FileLaunch and
+	// friends). dup() and dup2() both clear the flag, so it is set again after each.
+	if (reserved < 0) {
+		const int dupped = dup(fd);
+		if (dupped >= 0) {
+			(void)fcntl(dupped, F_SETFD, FD_CLOEXEC);
+		}
+		return dupped;
+	}
+	// dup2() onto the number already handed out, so the handler's copy follows the reopen. A
+	// failure leaves it on the previous file, which is still better than a closed descriptor.
+	(void)dup2(fd, reserved);
+	(void)fcntl(reserved, F_SETFD, FD_CLOEXEC);
+	return reserved;
+#endif
+}
+
+#ifdef HAVE_EXECINFO
+
+// sizeof - 1 rather than strlen(): strlen is not on the async-signal-safe list, and for a literal
+// the length is known at compile time anyway.
+#define WRITE_LITERAL(fd, lit) WriteAll((fd), (lit), sizeof(lit) - 1)
+
+static void WriteAbortReport(int fd, void *const *frames, int count)
+{
+	WRITE_LITERAL(fd,
+		"\n-------------------------=| ABORT BACKTRACE FOLLOWS |=-------------------------\n"
+		"aMule was aborted (SIGABRT). If this followed a glibc allocator message such as\n"
+		"'double free or corruption', the frames below are where the damage was NOTICED,\n"
+		"not where it was caused. Please report them at\n"
+		"    https://github.com/amule-org/amule/issues\n\n");
+	// Which build produced this. Pasted reports are useless without it, and a handler cannot
+	// format one, so it was written into a fixed buffer before the crash.
+	if (s_versionLineLen > 0) {
+		WriteAll(fd, s_versionLine, static_cast<size_t>(s_versionLineLen));
+	}
+	if (count > 0) {
+		backtrace_symbols_fd(frames, count, fd);
+	} else {
+		WRITE_LITERAL(fd, "* Could not generate backtrace\n");
+	}
+	WRITE_LITERAL(
+		fd, "-------------------------------------------------------------------------------\n");
+}
+
+extern "C" void MuleFatalAbortHandler(int /*sig*/)
+{
+	// Bound the handler before doing anything that can block. backtrace() unwinds through
+	// dl_iterate_phdr(), which takes the loader's load lock, so an abort that interrupted
+	// another thread inside dlopen()/dlclose() would wait here forever. A process that hangs is
+	// worse than one that dies without a trace: a supervisor watching for a non-zero exit never
+	// restarts it. The install-time warm-up removes the dlopen this handler would do itself, not
+	// a lock some other thread already holds. SIG_DFL first, in case something installed a
+	// SIGALRM handler; both calls are async-signal-safe.
+	signal(SIGALRM, SIG_DFL);
+	alarm(10);
+
+	// Clear it here so the name stays true: the suppression covers this abort only.
+	const bool suppressed = s_suppressAbortBacktrace != 0;
+	s_suppressAbortBacktrace = 0;
+
+	if (!suppressed) {
+		// 64 frames: the deepest real trace on amule-org/amule#1338 was 31, and the array is
+		// on the handler's stack, which is the process stack here rather than a sigaltstack.
+		void *frames[64];
+		const int count = backtrace(frames, 64);
+
+		// Both sinks, the way EmergencyLog() already reports the SIGSEGV path: the file is
+		// the copy that survives a daemon, the console is the one an operator reads out of
+		// `docker logs`. Written to the descriptors directly rather than dup2()ed over fd 2,
+		// so neither sink costs the other. Ordering as in EmitTerminateChunk: whichever sink
+		// can be probed goes first, because the other one cannot be.
+		const int redirect = s_abortRedirectFd;
+		const int console = AbortConsoleFd(STDERR_FILENO);
+		const bool haveDurable = redirect >= 0 && !SameFile(redirect, console);
+		const bool consoleFirst = FdCanTakeAWrite(console);
+
+		if (consoleFirst) {
+			WriteAbortReport(console, frames, count);
+		}
+		if (haveDurable) {
+			WriteAbortReport(redirect, frames, count);
+		}
+		if (!consoleFirst && !haveDurable) {
+			WriteAbortReport(console, frames, count);
+		}
+	}
+
+	// SA_RESETHAND has already put SIG_DFL back, so this terminates. Raising rather than
+	// returning covers the delivery paths that are not abort(): a plain `kill -ABRT` would
+	// otherwise be swallowed and the process would carry on.
+	raise(SIGABRT);
+}
+
+void InstallFatalAbortHandler()
+{
+	// glibc's backtrace() dlopen()s libgcc's unwinder on first use, which allocates. Doing that
+	// for the first time inside the handler is exactly what this design exists to avoid, so
+	// force the lazy init now, while the heap is still sound.
+	//
+	// Load-bearing, not belt and braces: measured on glibc 2.43 against a smashed top-chunk
+	// size, a handler without this warm-up printed nothing at all -- backtrace() reached the
+	// corruption through its own first-use allocation and the process died mid-report. The same
+	// handler with the warm-up printed the full trace.
+	void *warmup[1];
+	(void)backtrace(warmup, 1);
+
+	struct sigaction sa;
+	memset(&sa, 0, sizeof(sa));
+	sa.sa_handler = MuleFatalAbortHandler;
+	sigemptyset(&sa.sa_mask);
+	// SA_RESETHAND so a fault inside the handler cannot loop back into it.
+	sa.sa_flags = SA_RESETHAND;
+	sigaction(SIGABRT, &sa, nullptr);
+}
+
+#else /* !HAVE_EXECINFO */
+
+void InstallFatalAbortHandler()
+{
+	// Nothing to print without backtrace(); leave the default disposition alone.
+}
+
+#endif /* HAVE_EXECINFO */
 
 // File_checked_for_headers

--- a/src/libs/common/MuleDebug.h
+++ b/src/libs/common/MuleDebug.h
@@ -28,6 +28,8 @@
 
 #include <wx/string.h>
 
+#include <cstdio>
+
 /**
  * Installs an exception handler that can handle CMuleExceptions.
  */
@@ -40,6 +42,95 @@ void print_backtrace(unsigned n);
 
 //! Returns a backtrace, skipping the first n frames.
 wxString get_backtrace(unsigned n);
+
+/**
+ * Arms a SIGABRT handler that writes a raw backtrace to stderr.
+ *
+ * wx's fatal-exception support covers SIGSEGV, SIGBUS, SIGILL and SIGFPE, so a glibc heap abort
+ * ("double free or corruption", "free(): invalid pointer") bypasses the whole reporting path and
+ * the process dies silently. That is what left amule-org/amule#1338 with no backtrace at all.
+ *
+ * Deliberately NOT get_backtrace(): we are entered from abort(), which glibc calls from
+ * malloc_printerr with the allocator's state already inconsistent and, above the tcache ceiling,
+ * its arena lock held. get_backtrace() allocates throughout -- backtrace_symbols(), std::vector,
+ * wxString -- and on the non-BFD path it popen()s addr2line. So this writes frames with
+ * backtrace_symbols_fd(), the variant documented not to allocate. They go to the descriptor set by
+ * SetFatalAbortRedirectFd(), or to STDERR_FILENO when none is set.
+ *
+ * Worth being exact about the risk, because it is a guarantee rather than an observed failure: an
+ * allocating handler does NOT reliably hang. Measured on glibc 2.43, a double free above the
+ * tcache ceiling reaches malloc_printerr with the arena lock held, yet a handler calling
+ * backtrace_symbols() still completed -- its own allocation was small enough to come from tcache,
+ * which needs no lock. The case against it is that this depends on a free chunk of the right size
+ * happening to be cached, on a heap already known to be damaged, with fork() in the fallback path.
+ * backtrace_symbols_fd() needs none of that to hold.
+ *
+ * The cost is raw output: module, offset and mangled symbol, no demangling and no line numbers.
+ * Run addr2line over the addresses offline.
+ *
+ * Call once per process, after the wx fatal handlers are armed.
+ */
+void InstallFatalAbortHandler();
+
+/**
+ * Tells the SIGABRT handler to stay quiet for the next abort.
+ *
+ * For callers that have already reported: ReportAssertFailure() prints a full symbolicated
+ * backtrace and then raise(SIGABRT)s to give gdb something to catch, and a second raw dump on top
+ * of it is noise.
+ */
+void SuppressNextAbortBacktrace();
+
+/**
+ * Gives the crash reporters a durable descriptor to report to.
+ *
+ * For a process that has put something other than a terminal on fd 2. amuleapi tees stdout and
+ * stderr through pipes that a forwarding thread drains, so a report written only to fd 2 leaves the
+ * backtrace in a pipe whose reader dies with the process moments later.
+ *
+ * The reporters write here and to the console descriptor both, so a container keeps the report in
+ * `docker logs` and a terminal still shows it. Pass -1 to go back to fd 2 alone.
+ *
+ * This covers the SIGABRT and std::terminate paths. It does NOT replace
+ * CamuleapiApp::OnFatalException's call to CLogTee::RedirectStderrToFileForCrash(): wx's own
+ * SIGSEGV/SIGBUS/SIGILL/SIGFPE handler reports through stderr, so without that dup2() the SIGSEGV
+ * backtrace still dies in the tee pipe.
+ */
+void SetFatalAbortRedirectFd(int fd);
+
+/**
+ * Where the console copy of a crash report goes, when fd 2 is not it.
+ *
+ * amuleapi routes fd 2 through its tee pipe, so a report written there reaches the console only if
+ * the pump thread is still scheduled -- true at std::terminate, not true in a signal handler.
+ * CLogTee::ConsoleFd() hands over the dup of the original fd 2 it already keeps, and writing
+ * straight to that reaches `docker logs` in both cases.
+ *
+ * Pass -1 (the default) to use fd 2. Clear it before the descriptor is closed, exactly as for
+ * SetFatalAbortRedirectFd().
+ */
+void SetFatalAbortConsoleFd(int fd);
+
+/**
+ * A one-line build identifier for the raw SIGABRT banner, copied into a fixed buffer.
+ *
+ * The banner is written from a signal handler, so it cannot format anything: a report pasted from
+ * the field would otherwise not say which build produced it. Call once the version is known.
+ */
+void SetFatalAbortVersionLine(const char *text);
+
+/**
+ * Re-points a reserved crash descriptor at the file behind @a fp, returning the reserved number.
+ *
+ * A fatal handler cannot look a descriptor up when it runs, because every path that resolves one
+ * locks. It holds a single number instead, and this keeps that number pointing at the current
+ * file: pass -1 the first time to reserve one, then pass the same value back after every reopen.
+ * The number itself is never closed, so it cannot be freed mid-rotation and handed out to another
+ * thread's socket while the handler still holds it.
+ *
+ * Returns @a reserved unchanged when @a fp is null or the dup fails.
+ */
+int ReserveCrashFd(int reserved, std::FILE *fp);
 
 /**
  * Base for the other exception types. Never catch this; catch the subtypes.

--- a/src/webapi/App.cpp
+++ b/src/webapi/App.cpp
@@ -24,6 +24,8 @@
 
 #include "App.h"
 
+#include <common/MuleDebug.h> // Needed for SetFatalAbortRedirectFd
+
 #include "Api.h"
 #include "HttpServer.h"
 #include "Jwt.h"
@@ -137,7 +139,14 @@ void TrimMallocArenas()
 } // namespace
 
 CamuleapiApp::CamuleapiApp() = default;
-CamuleapiApp::~CamuleapiApp() = default;
+CamuleapiApp::~CamuleapiApp()
+{
+	// wx skips OnExit() when OnInit() returns false, and destroying m_logTee below is what
+	// closes the descriptors the crash reporters hold. Drop both here so no exit path can leave
+	// one pointing at a closed, and by then possibly recycled, number.
+	SetFatalAbortRedirectFd(-1);
+	SetFatalAbortConsoleFd(-1);
+}
 
 void CamuleapiApp::OnInitCmdLine(wxCmdLineParser &parser)
 {
@@ -234,6 +243,31 @@ bool CamuleapiApp::OnInit()
 						 : m_logFile;
 		m_logTee = std::make_unique<webapi::CLogTee>();
 		if (m_logTee->Install(std::string(logPath.utf8_str()), kLogMaxBytes)) {
+			// fd 2 is now a pipe drained by a forwarding thread, and that thread is
+			// gone the moment an abort takes the process down. Send the SIGABRT
+			// backtrace straight to the file instead, the same way
+			// CamuleapiApp::OnFatalException already handles the SIGSEGV path.
+			// CrashFd() survives log rotation; see CRotatingLog::PointCrashFd().
+#ifndef _WIN32
+			// Windows reserves no crash descriptor on purpose and has no SIGABRT
+			// handler to feed, so the whole redirect is skipped there rather than
+			// warned about on every start.
+			//
+			// The console descriptor goes over too: fd 2 is this process's own tee
+			// pipe, which reaches the console only while the pump thread still runs,
+			// so a reporter writes the console copy to the saved fd 2 instead.
+			SetFatalAbortConsoleFd(m_logTee->ConsoleFd());
+			const int crashFd = m_logTee->CrashFd();
+			if (crashFd >= 0) {
+				SetFatalAbortRedirectFd(crashFd);
+			} else {
+				// Say so rather than fall back silently: without the redirect a
+				// backtrace goes into the pipe nobody drains, which is the exact
+				// silence the redirect exists to remove.
+				std::cerr << "amuleapi: WARN no crash descriptor for the log file, "
+					     "a fatal backtrace may be lost\n";
+			}
+#endif
 			Show(CFormat(_("amuleapi: logging to %s\n")) % logPath);
 		} else {
 			m_logTee.reset();
@@ -715,9 +749,20 @@ int CamuleapiApp::OnExit()
 	m_dispatcher.reset();
 	m_jwt.reset();
 	const int rc = CaMuleExternalConnector::OnExit();
-	// Tear the log tee down last so the shutdown output above is captured.
+	// Tear the log tee down last so the shutdown output above is captured. The two descriptors
+	// have different lifetimes and so are dropped at different points.
+	//
+	// The console one is the tee's dup of fd 2, which Uninstall() closes, so it goes first:
+	// between that close and the clear, the number is free for any thread's next socket, and a
+	// crash in the window would write the report into it.
+	//
+	// The crash redirect outlives the log file it points at, so it stays armed across
+	// Uninstall() and an abort mid-teardown still reaches the log. ~CLogTee via reset() is what
+	// finally closes that one.
 	if (m_logTee) {
+		SetFatalAbortConsoleFd(-1);
 		m_logTee->Uninstall();
+		SetFatalAbortRedirectFd(-1);
 		m_logTee.reset();
 	}
 	return rc;

--- a/src/webapi/LogTee.cpp
+++ b/src/webapi/LogTee.cpp
@@ -31,6 +31,7 @@
 #include <fcntl.h>
 #include <io.h>
 #else
+#include <fcntl.h>
 #include <unistd.h>
 #endif
 
@@ -68,6 +69,10 @@ long OsWrite(int fd, const void *buf, unsigned n)
 {
 	return _write(fd, buf, n);
 }
+int OsFileno(std::FILE *fp)
+{
+	return _fileno(fp);
+}
 int StdoutFd()
 {
 	return _fileno(stdout);
@@ -104,6 +109,10 @@ long OsRead(int fd, void *buf, unsigned n)
 long OsWrite(int fd, const void *buf, unsigned n)
 {
 	return ::write(fd, buf, n);
+}
+int OsFileno(std::FILE *fp)
+{
+	return fileno(fp);
 }
 int StdoutFd()
 {
@@ -152,6 +161,51 @@ void WriteAll(int fd, const char *buf, std::size_t n)
 CRotatingLog::~CRotatingLog()
 {
 	Close();
+	if (m_crashFd >= 0) {
+		OsClose(m_crashFd);
+		m_crashFd = -1;
+	}
+}
+
+int CRotatingLog::CrashFd() const
+{
+#ifdef _WIN32
+	std::lock_guard<std::mutex> lk(m_mx);
+	return m_fp != nullptr ? OsFileno(m_fp) : -1;
+#else
+	return m_crashFd;
+#endif
+}
+
+void CRotatingLog::PointCrashFd()
+{
+	// m_mx held by caller. Reserve a number on the first open and only ever re-point it at the
+	// current file. Never closing it is the point: a number that gets freed can be handed to a
+	// client socket on another thread before the crash handler uses it.
+	//
+	// Not on Windows. There, a file with an open handle cannot be renamed, so holding this would
+	// make Rotate()'s rename() fail and the reopen truncate the log instead of rotating it. The
+	// descriptor buys nothing there either: wx handles fatal errors through SEH and calls
+	// ExitProcess() rather than raising SIGABRT, so the handler this feeds never runs.
+#ifndef _WIN32
+	// A failed reopen leaves the reserved descriptor on the file just rotated to "<path>.1".
+	// That is deliberate: it is still a real file on disk, so a crash report goes somewhere
+	// rather than nowhere, which matters most for amuleapi where this is the only sink.
+	if (m_fp == nullptr) {
+		return;
+	}
+	const int fd = OsFileno(m_fp);
+	if (m_crashFd < 0) {
+		m_crashFd = OsDup(fd);
+	} else {
+		OsDup2(fd, m_crashFd);
+	}
+	// Never closed, so without FD_CLOEXEC it would follow every exec'd child and keep the log
+	// file's inode alive there. dup() and dup2() both clear the flag.
+	if (m_crashFd >= 0) {
+		(void)fcntl(m_crashFd, F_SETFD, FD_CLOEXEC);
+	}
+#endif
 }
 
 bool CRotatingLog::Open(const std::string &path, std::size_t maxBytes)
@@ -172,6 +226,7 @@ bool CRotatingLog::Open(const std::string &path, std::size_t maxBytes)
 	m_path = path;
 	m_maxBytes = maxBytes;
 	m_fp = fp;
+	PointCrashFd();
 	return true;
 }
 
@@ -186,6 +241,7 @@ void CRotatingLog::Rotate()
 	std::rename(m_path.c_str(), rotated.c_str());
 	m_fp = std::fopen(m_path.c_str(), "wb");
 	m_curSize = 0;
+	PointCrashFd();
 }
 
 void CRotatingLog::Write(const char *buf, std::size_t n)
@@ -214,16 +270,6 @@ void CRotatingLog::Close()
 		std::fclose(m_fp);
 		m_fp = nullptr;
 	}
-}
-
-int CRotatingLog::Fd() const
-{
-	std::lock_guard<std::mutex> lk(m_mx);
-#ifdef _WIN32
-	return m_fp != nullptr ? _fileno(m_fp) : -1;
-#else
-	return m_fp != nullptr ? fileno(m_fp) : -1;
-#endif
 }
 
 // CLogTee
@@ -316,7 +362,8 @@ void CLogTee::Pump(int readFd, int consoleFd)
 
 void CLogTee::RedirectStderrToFileForCrash()
 {
-	const int fd = m_log.Fd();
+	// CrashFd() takes no lock, which matters: this runs from a fatal signal handler.
+	const int fd = m_log.CrashFd();
 	if (fd >= 0) {
 		OsDup2(fd, StderrFd());
 	}

--- a/src/webapi/LogTee.h
+++ b/src/webapi/LogTee.h
@@ -25,6 +25,7 @@
 #ifndef WEBAPI_LOG_TEE_H
 #define WEBAPI_LOG_TEE_H
 
+#include <csignal>
 #include <cstddef>
 #include <cstdio>
 #include <mutex>
@@ -61,18 +62,30 @@ public:
 
 	void Close();
 
-	// Underlying file descriptor of the current file, or -1. Used only by the
-	// crash path to point stderr straight at the file; not for concurrent I/O.
-	int Fd() const;
+	// A descriptor for the crash path to write to, or -1 when there is none.
+	//
+	// On POSIX it is reserved: one number for the life of the object, only ever re-pointed, so a
+	// signal handler can read it without taking m_mx and the number can never be freed
+	// mid-rotation and handed to another thread's socket. Close() leaves it open on the last
+	// file, so the number is never a closed one in a reader's hands.
+	//
+	// Windows reserves nothing, because an open handle there blocks the rename() that rotation
+	// needs. It resolves the current file under m_mx instead, which is what this did before the
+	// reserved descriptor existed. The lock is a hazard in a handler, but the only Windows caller
+	// is CLogTee::RedirectStderrToFileForCrash() from an SEH filter, and losing the redirect
+	// altogether is worse: the report would sit in a pipe whose pump dies with the process.
+	int CrashFd() const;
 
 private:
-	void Rotate(); // caller holds m_mx
+	void Rotate();       // caller holds m_mx
+	void PointCrashFd(); // caller holds m_mx
 
 	mutable std::mutex m_mx;
 	std::string m_path;
 	std::size_t m_maxBytes = 0;
 	std::size_t m_curSize = 0;
 	std::FILE *m_fp = nullptr;
+	volatile std::sig_atomic_t m_crashFd = -1;
 };
 
 // Duplicates the process's stdout and stderr into a log file while leaving the original console
@@ -103,6 +116,17 @@ public:
 	// written synchronously, without depending on the forwarding thread being scheduled before
 	// the process dies.
 	void RedirectStderrToFileForCrash();
+
+	// The reserved crash descriptor, or -1 when not installed. For a crash reporter that has to
+	// write somewhere the forwarding threads are not needed to drain; see
+	// SetFatalAbortRedirectFd(). Stays valid across rotations; clear the reporter's copy before
+	// destroying this object, which is what closes it.
+	int CrashFd() const { return m_installed ? m_log.CrashFd() : -1; }
+
+	// The dup of the original fd 2, or -1 when not installed. A crash reporter writes the console
+	// copy here rather than to fd 2: fd 2 is the tee pipe, which reaches the console only while
+	// the pump thread is still scheduled, and in a signal handler it is not.
+	int ConsoleFd() const { return m_installed ? m_savedErr : -1; }
 
 	bool IsInstalled() const { return m_installed; }
 

--- a/unittests/tests/CMakeLists.txt
+++ b/unittests/tests/CMakeLists.txt
@@ -937,6 +937,17 @@ target_link_libraries (EtagTest
 	mulecommon
 )
 
+# The SIGABRT reporting path. Forks and corrupts the heap for real, so it covers the case the
+# handler exists for rather than only the easy raise(SIGABRT) one. mulecommon carries MuleDebug.
+add_executable (FatalAbortBacktraceTest
+	FatalAbortBacktraceTest.cpp
+)
+add_test (NAME FatalAbortBacktraceTest COMMAND FatalAbortBacktraceTest)
+target_link_libraries (FatalAbortBacktraceTest
+	muleunit
+	mulecommon
+)
+
 add_executable (StaticFsTest
 	StaticFsTest.cpp
 	${CMAKE_SOURCE_DIR}/src/webapi/StaticFs.cpp

--- a/unittests/tests/FatalAbortBacktraceTest.cpp
+++ b/unittests/tests/FatalAbortBacktraceTest.cpp
@@ -1,0 +1,497 @@
+//
+// This file is part of the aMule Project.
+//
+// Copyright (c) 2003-2026 aMule Team ( https://amule-org.github.io )
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+
+// The SIGABRT reporting path, exercised against a real glibc heap abort.
+//
+// amule-org/amule#1338 died on `double free or corruption (out)` and produced no backtrace at all,
+// because wx's fatal-exception support covers SIGSEGV/SIGBUS/SIGILL/SIGFPE and a heap abort is
+// SIGABRT. InstallFatalAbortHandler() closes that, and the interesting question is not whether it
+// prints -- it is whether it prints when the allocator is already broken.
+//
+// So the cases below fork, corrupt the heap in the child for real, and read what reaches the
+// child's stderr through a pipe. A handler that allocates would deadlock against the arena lock
+// malloc_printerr can hold, and that shows up here as the child never exiting, which the alarm
+// turns into a failure rather than a hung suite. That is the property worth the machinery: the
+// naive version of this handler passes every test that does not actually corrupt the heap.
+//
+// What these cases deliberately do NOT cover is the difference between this handler and an
+// allocating one, because that difference is not reachable from here. Measured directly on glibc
+// 2.43 with standalone probes: under corruption detected inside malloc() ("corrupted top size"),
+// an allocating handler re-enters malloc_printerr and dies having printed nothing, and a handler
+// that skips the install-time backtrace() warm-up fails the same way. Both are real, and both need
+// the fault to land on the top chunk, which needs a known heap layout. This binary links wx, so by
+// the time a child forks the layout is nothing like a minimal program's and the corruption simply
+// does not reproduce -- an attempt at it here aborted nothing and passed silently, for the safe and
+// unsafe builds alike. A test that always skips is worse than no test, so it is not kept.
+
+#include <muleunit/test.h>
+
+#include <common/MuleDebug.h>
+
+#include "config.h" // Needed for HAVE_EXECINFO
+
+// Without execinfo.h InstallFatalAbortHandler() is a no-op by design, so there is no backtrace to
+// assert on. Our own static musl build is exactly that case: Alpine has not packaged libexecinfo
+// since 3.17, so these cases would fail there for a reason that is not a regression.
+#if !defined(_WIN32) && defined(HAVE_EXECINFO)
+#define MULE_HAVE_ABORT_BACKTRACE 1
+#endif
+
+#ifdef MULE_HAVE_ABORT_BACKTRACE
+#include <cerrno>
+#include <csignal>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <exception>
+#include <fcntl.h>
+#include <stdexcept>
+#include <string>
+#include <sys/wait.h>
+#include <unistd.h>
+#endif
+
+using namespace muleunit;
+
+#ifdef MULE_HAVE_ABORT_BACKTRACE
+
+namespace
+{
+
+//! What a forked child did: everything it wrote to stderr, and how it died.
+struct ChildResult
+{
+	std::string stderr_text;
+	bool exited_on_signal = false;
+	int signal_number = 0;
+	bool timed_out = false;
+};
+
+// Runs `body` in a forked child with its stderr on a pipe, and returns what it wrote plus how it
+// died. The alarm is the deadlock detector: a handler that allocates can block forever inside
+// malloc, and without a bound that would hang the whole suite instead of failing one case.
+ChildResult RunInChild(void (*body)(), unsigned timeout_seconds = 10)
+{
+	ChildResult result;
+
+	int fds[2];
+	if (pipe(fds) != 0) {
+		return result;
+	}
+
+	// fork() duplicates whatever muleunit has buffered on stdout, and the child dies by signal
+	// without flushing -- except where it does, which replays the suite's own output once per
+	// case. Drain it here so the child inherits nothing to replay.
+	fflush(nullptr);
+
+	const pid_t pid = fork();
+	if (pid < 0) {
+		close(fds[0]);
+		close(fds[1]);
+		return result;
+	}
+
+	if (pid == 0) {
+		// Child. Redirect stderr to the pipe, then never return: body() is expected to abort.
+		close(fds[0]);
+		dup2(fds[1], STDERR_FILENO);
+		close(fds[1]);
+		alarm(timeout_seconds); // SIGALRM kills us if the handler wedges
+		body();
+		_exit(0); // body() did not abort, which the assertions below will catch
+	}
+
+	close(fds[1]);
+	char buffer[4096];
+	ssize_t got;
+	while ((got = read(fds[0], buffer, sizeof(buffer))) != 0) {
+		if (got > 0) {
+			result.stderr_text.append(buffer, static_cast<size_t>(got));
+		} else if (errno != EINTR) {
+			break;
+		}
+	}
+	close(fds[0]);
+
+	int status = 0;
+	waitpid(pid, &status, 0);
+	if (WIFSIGNALED(status)) {
+		result.exited_on_signal = true;
+		result.signal_number = WTERMSIG(status);
+		result.timed_out = (result.signal_number == SIGALRM);
+	}
+	return result;
+}
+
+// Hands a pointer back through an empty asm barrier. Without it an optimising build deletes the
+// malloc/free pair outright -- a double free is undefined, so the compiler is entitled to assume it
+// never happens. The Release CI job caught exactly that: the child ran to _exit(0) and the test
+// asserted on a process that had never corrupted anything.
+void *Launder(void *p)
+{
+	__asm__ __volatile__("" : "+r"(p) : : "memory");
+	return p;
+}
+
+void ChildDoubleFree()
+{
+	InstallFatalAbortHandler();
+	// A real double free, so the allocator's own detection runs and calls abort() from its
+	// error path. Deliberately not raise(SIGABRT): that would test the handler with a healthy
+	// heap and prove nothing about the hard case.
+	//
+	// The size is per-allocator, and both ends of it matter. glibc's tcache absorbs frees up to
+	// 1032 bytes and catches a double free there before taking the arena lock; above that
+	// ceiling the check runs inside the locked region, which is the state the handler has to
+	// survive. macOS goes the other way: a large block traps (SIGTRAP) rather than aborting, so
+	// the handler would never be entered and the case would test nothing.
+#if defined(__GLIBC__)
+	void *p = Launder(malloc(2048));
+#else
+	void *p = Launder(malloc(64));
+#endif
+	free(p);
+	free(Launder(p));
+	_exit(0); // not reached while the allocator detects the double free
+}
+
+void ChildPlainAbort()
+{
+	InstallFatalAbortHandler();
+	abort();
+}
+
+void ChildRaiseAbrt()
+{
+	InstallFatalAbortHandler();
+	raise(SIGABRT);
+	// Reached only if the handler swallowed the signal, which is the regression this catches.
+	_exit(42);
+}
+
+// std::terminate() with no active exception: OnUnhandledException() prints nothing at all, so the
+// raw backtrace is the only report there is. Reachable in production by destroying a joinable
+// std::thread without join(), which webapi has several of.
+void ChildTerminateWithoutException()
+{
+	InstallFatalAbortHandler();
+	InstallMuleExceptionHandler();
+	std::terminate();
+	_exit(43); // not reached
+}
+
+// Relative to the test's working directory, the build tree, rather than a fixed name in /tmp: a
+// leftover there owned by another uid makes the child's open() fail, and the failure then reports
+// as a missing signal, which says nothing about what broke. LogTeeTest picks paths the same way.
+// The pid keeps two binaries in one build tree apart; it is resolved at static-init time, so the
+// forked child and its parent name the same file.
+std::string ReadWholeFile(const std::string &path)
+{
+	std::string out;
+	char buf[4096];
+	const int fd = open(path.c_str(), O_RDONLY);
+	if (fd < 0) {
+		return out;
+	}
+	ssize_t n;
+	while ((n = read(fd, buf, sizeof(buf))) > 0) {
+		out.append(buf, static_cast<size_t>(n));
+	}
+	close(fd);
+	return out;
+}
+
+std::string TmpPath(const char *suffix)
+{
+	return std::string("amule_fatalabort_") + std::to_string(getpid()) + "_" + suffix;
+}
+
+const std::string kTeePath = TmpPath("tee");
+const std::string kDurablePath = TmpPath("durable");
+const std::string kConsolePath = TmpPath("console");
+const std::string kTeeWedgedPath = TmpPath("tee_wedged");
+
+// An unhandled exception with a crash descriptor armed. The report has to reach both sinks: the
+// descriptor, which is what survives a daemon, and stderr, which is the console an operator reads.
+void ChildTerminateTee()
+{
+	InstallFatalAbortHandler();
+	InstallMuleExceptionHandler();
+	const int fd = open(kTeePath.c_str(), O_CREAT | O_TRUNC | O_WRONLY, 0600);
+	if (fd < 0) {
+		_exit(44);
+	}
+	SetFatalAbortRedirectFd(fd);
+	throw std::runtime_error("tee probe");
+}
+
+// amuleapi's shape: fd 2 is the tee pipe, the durable sink is the log, and the console copy has to
+// go to the saved console descriptor instead of fd 2. Writing it to fd 2 would reach the console
+// only while the pump thread still runs, which is true at std::terminate and false in a signal
+// handler, and in amuleapi it would also land a second copy in the log the pump feeds.
+void ChildTerminateConsoleFd()
+{
+	InstallFatalAbortHandler();
+	InstallMuleExceptionHandler();
+	const int durable = open(kDurablePath.c_str(), O_CREAT | O_TRUNC | O_WRONLY, 0600);
+	const int console = open(kConsolePath.c_str(), O_CREAT | O_TRUNC | O_WRONLY, 0600);
+	if (durable < 0 || console < 0) {
+		_exit(44);
+	}
+	SetFatalAbortRedirectFd(durable);
+	SetFatalAbortConsoleFd(console);
+	throw std::runtime_error("console fd probe");
+}
+
+// A console that will never accept a write: a pipe filled to capacity with nobody draining it,
+// left blocking. Taking the console copy first would park in WriteAll() forever and the durable
+// copy would never happen, so the process would neither report nor exit.
+void ChildTerminateWedgedConsole()
+{
+	InstallFatalAbortHandler();
+	InstallMuleExceptionHandler();
+	const int fd = open(kTeeWedgedPath.c_str(), O_CREAT | O_TRUNC | O_WRONLY, 0600);
+	if (fd < 0) {
+		_exit(44);
+	}
+	SetFatalAbortRedirectFd(fd);
+
+	int pipefd[2];
+	if (pipe(pipefd) != 0) {
+		_exit(45);
+	}
+	// Fill it without blocking, then hand back a blocking descriptor with no room left.
+	const int flags = fcntl(pipefd[1], F_GETFL);
+	fcntl(pipefd[1], F_SETFL, flags | O_NONBLOCK);
+	char filler[4096];
+	memset(filler, 'x', sizeof(filler));
+	while (write(pipefd[1], filler, sizeof(filler)) > 0) {
+		// keep going until the pipe refuses
+	}
+	fcntl(pipefd[1], F_SETFL, flags);
+	dup2(pipefd[1], STDERR_FILENO);
+
+	throw std::runtime_error("wedged console probe");
+}
+
+// A version line longer than the buffer. The character truncation drops is the trailing newline,
+// which would glue the first backtrace frame onto the end of the version line.
+void ChildLongVersionLine()
+{
+	InstallFatalAbortHandler();
+	const std::string huge(400, 'V');
+	SetFatalAbortVersionLine(huge.c_str());
+	abort();
+}
+
+void ChildSuppressed()
+{
+	InstallFatalAbortHandler();
+	SuppressNextAbortBacktrace();
+	abort();
+}
+
+void ChildNoHandler()
+{
+	abort();
+}
+
+bool Contains(const std::string &haystack, const char *needle)
+{
+	return haystack.find(needle) != std::string::npos;
+}
+
+} // namespace
+
+DECLARE_SIMPLE(FatalAbortBacktrace)
+
+// The case the feature exists for. Everything else here is a control for this one.
+TEST(FatalAbortBacktrace, RealHeapCorruptionStillProducesABacktrace)
+{
+	const ChildResult r = RunInChild(ChildDoubleFree);
+
+	ASSERT_FALSE(r.timed_out); // a handler that allocates deadlocks here
+	ASSERT_TRUE(r.exited_on_signal);
+	ASSERT_EQUALS(SIGABRT, r.signal_number);
+	ASSERT_TRUE(Contains(r.stderr_text, "ABORT BACKTRACE FOLLOWS"));
+	// Frames, not just the banner. Deliberately matched on the module name rather than on the
+	// allocator's own wording: glibc says "free(): double free detected in tcache 2" and macOS
+	// reports through libmalloc, so any assertion on that text is a platform check. Matching a
+	// substring of our own banner would be worse still -- it says "double free or corruption"
+	// in its explanatory line, so asserting that passes whenever the banner prints at all.
+	ASSERT_TRUE(Contains(r.stderr_text, "FatalAbortBacktraceTest"));
+}
+
+// A terminate with nothing to describe must not end up silent. The suppression exists to stop a
+// second backtrace when a symbolicated one was already printed; when none was, it must not fire.
+TEST(FatalAbortBacktrace, TerminateWithoutExceptionStillReports)
+{
+	const ChildResult r = RunInChild(ChildTerminateWithoutException);
+
+	ASSERT_FALSE(r.timed_out);
+	ASSERT_TRUE(r.exited_on_signal);
+	ASSERT_EQUALS(SIGABRT, r.signal_number);
+	ASSERT_TRUE(Contains(r.stderr_text, "ABORT BACKTRACE FOLLOWS"));
+}
+
+// The terminate report goes to the console and to the durable descriptor both. Redirecting instead
+// of tee-ing made it durable by taking it off the console, and the SIGABRT handler cannot make up
+// for that: this path suppresses it.
+TEST(FatalAbortBacktrace, TerminateReportReachesBothSinks)
+{
+	unlink(kTeePath.c_str());
+	const ChildResult r = RunInChild(ChildTerminateTee);
+
+	ASSERT_FALSE(r.timed_out);
+	ASSERT_TRUE(r.exited_on_signal);
+
+	// The console copy.
+	ASSERT_TRUE(Contains(r.stderr_text, "Terminated after throwing an instance of"));
+	ASSERT_TRUE(Contains(r.stderr_text, "tee probe"));
+
+	// The durable copy.
+	std::string durable;
+	{
+		char buf[4096];
+		const int fd = open(kTeePath.c_str(), O_RDONLY);
+		ASSERT_TRUE(fd >= 0);
+		ssize_t n;
+		while ((n = read(fd, buf, sizeof(buf))) > 0) {
+			durable.append(buf, static_cast<size_t>(n));
+		}
+		close(fd);
+	}
+	ASSERT_TRUE(Contains(durable, "Terminated after throwing an instance of"));
+	ASSERT_TRUE(Contains(durable, "tee probe"));
+	unlink(kTeePath.c_str());
+}
+
+// Both files get the report and the inherited fd 2 gets none: the console copy followed the
+// descriptor it was given rather than fd 2.
+TEST(FatalAbortBacktrace, TerminateReportUsesTheConsoleDescriptor)
+{
+	unlink(kDurablePath.c_str());
+	unlink(kConsolePath.c_str());
+	const ChildResult r = RunInChild(ChildTerminateConsoleFd);
+
+	ASSERT_FALSE(r.timed_out);
+	ASSERT_TRUE(r.exited_on_signal);
+	ASSERT_FALSE(Contains(r.stderr_text, "console fd probe")); // fd 2 stays out of it
+
+	ASSERT_TRUE(Contains(ReadWholeFile(kDurablePath), "console fd probe"));
+	ASSERT_TRUE(Contains(ReadWholeFile(kConsolePath), "console fd probe"));
+	unlink(kDurablePath.c_str());
+	unlink(kConsolePath.c_str());
+}
+
+// A console that cannot take the write must not cost the durable copy, nor hang the process.
+TEST(FatalAbortBacktrace, TerminateSurvivesAWedgedConsole)
+{
+	unlink(kTeeWedgedPath.c_str());
+	const ChildResult r = RunInChild(ChildTerminateWedgedConsole);
+
+	ASSERT_FALSE(r.timed_out); // parked in fputs() on the console copy
+	ASSERT_TRUE(r.exited_on_signal);
+	ASSERT_EQUALS(SIGABRT, r.signal_number);
+
+	std::string durable;
+	{
+		char buf[4096];
+		const int fd = open(kTeeWedgedPath.c_str(), O_RDONLY);
+		ASSERT_TRUE(fd >= 0);
+		ssize_t n;
+		while ((n = read(fd, buf, sizeof(buf))) > 0) {
+			durable.append(buf, static_cast<size_t>(n));
+		}
+		close(fd);
+	}
+	ASSERT_TRUE(Contains(durable, "wedged console probe"));
+	unlink(kTeeWedgedPath.c_str());
+}
+
+// An over-long build string must still end the line it is on. Truncation that ate the newline would
+// run the version straight into the first frame.
+TEST(FatalAbortBacktrace, OverlongVersionLineStillEndsItsLine)
+{
+	const ChildResult r = RunInChild(ChildLongVersionLine);
+
+	ASSERT_FALSE(r.timed_out);
+	ASSERT_TRUE(r.exited_on_signal);
+
+	const std::string::size_type at = r.stderr_text.find("VVVV");
+	ASSERT_TRUE(at != std::string::npos);
+
+	// The run of V's has to end at a newline, not at a backtrace frame.
+	const std::string::size_type endOfRun = r.stderr_text.find_first_not_of('V', at);
+	ASSERT_TRUE(endOfRun != std::string::npos);
+	ASSERT_EQUALS('\n', r.stderr_text[endOfRun]);
+}
+
+// Frames, not just the banner. backtrace_symbols_fd() writes one line per frame naming the module,
+// so the test binary's own name has to appear -- that is the difference between a working unwind
+// and an empty one.
+TEST(FatalAbortBacktrace, TheBacktraceCarriesFrames)
+{
+	const ChildResult r = RunInChild(ChildPlainAbort);
+
+	ASSERT_FALSE(r.timed_out);
+	ASSERT_TRUE(Contains(r.stderr_text, "ABORT BACKTRACE FOLLOWS"));
+	ASSERT_TRUE(Contains(r.stderr_text, "FatalAbortBacktraceTest"));
+}
+
+// The process must still die, and die of SIGABRT. A handler that reports and returns would swallow
+// the signal, and a supervisor watching for a non-zero exit would never restart. This raises the
+// signal in-process rather than from outside; delivery to a single-threaded child is the same path.
+TEST(FatalAbortBacktrace, TheProcessStillDiesOfSigabrt)
+{
+	const ChildResult r = RunInChild(ChildRaiseAbrt);
+
+	ASSERT_FALSE(r.timed_out);
+	ASSERT_TRUE(r.exited_on_signal);
+	ASSERT_EQUALS(SIGABRT, r.signal_number);
+}
+
+// ReportAssertFailure() prints a full symbolicated backtrace and then raises SIGABRT, so the raw
+// dump has to stay quiet or every assertion failure reports itself twice.
+TEST(FatalAbortBacktrace, SuppressedAbortPrintsNoBacktrace)
+{
+	const ChildResult r = RunInChild(ChildSuppressed);
+
+	ASSERT_FALSE(r.timed_out);
+	ASSERT_TRUE(r.exited_on_signal);
+	ASSERT_EQUALS(SIGABRT, r.signal_number);
+	ASSERT_FALSE(Contains(r.stderr_text, "ABORT BACKTRACE FOLLOWS"));
+}
+
+// The control that stops the assertions above passing for the wrong reason: without the handler
+// the banner must be absent, so its presence elsewhere is attributable to InstallFatalAbortHandler
+// and not to something else on the process's stderr.
+TEST(FatalAbortBacktrace, WithoutTheHandlerThereIsNoBacktrace)
+{
+	const ChildResult r = RunInChild(ChildNoHandler);
+
+	ASSERT_FALSE(r.timed_out);
+	ASSERT_TRUE(r.exited_on_signal);
+	ASSERT_EQUALS(SIGABRT, r.signal_number);
+	ASSERT_FALSE(Contains(r.stderr_text, "ABORT BACKTRACE FOLLOWS"));
+}
+
+#else /* !MULE_HAVE_ABORT_BACKTRACE */
+
+// fork() has no Windows equivalent, and the handler is POSIX-only anyway.
+DECLARE_SIMPLE(FatalAbortBacktrace)
+
+TEST(FatalAbortBacktrace, NotApplicableOnWindows)
+{
+	ASSERT_TRUE(true);
+}
+
+#endif /* MULE_HAVE_ABORT_BACKTRACE */

--- a/unittests/tests/LogTeeTest.cpp
+++ b/unittests/tests/LogTeeTest.cpp
@@ -28,6 +28,12 @@
 
 #include <cstdio>
 #include <fstream>
+#ifdef _WIN32
+#include <io.h>
+#else
+#include <fcntl.h>
+#include <unistd.h>
+#endif
 #include <sstream>
 #include <string>
 
@@ -45,6 +51,16 @@ std::string ReadFile(const std::string &path)
 	std::ostringstream ss;
 	ss << f.rdbuf();
 	return ss.str();
+}
+
+// Raw write to a descriptor, the way the crash handler reaches the log.
+long OsWriteFd(int fd, const void *buf, unsigned n)
+{
+#ifdef _WIN32
+	return _write(fd, buf, n);
+#else
+	return ::write(fd, buf, n);
+#endif
 }
 
 bool Exists(const std::string &path)
@@ -159,3 +175,89 @@ TEST(LogTee, OversizedChunkOnEmptyFileIsNotRotated)
 	ASSERT_EQUALS(std::string("abcdefgh"), ReadFile(path));
 	Cleanup(path);
 }
+
+// Every platform has to hand the crash path something to write to while the log is open. The rest
+// of the contract differs -- POSIX reserves a number, Windows resolves the current file, since an
+// open handle there blocks the rename() that rotation needs -- but this much is common, and it is
+// what CLogTee::RedirectStderrToFileForCrash() depends on for amuleapi's wx fatal handler. The
+// other cases below are POSIX-only, which is how a Windows regression here went unnoticed.
+TEST(LogTee, CrashFdIsAvailableWhileOpen)
+{
+	const std::string path = TmpPath("_j.log");
+	Cleanup(path);
+	{
+		CRotatingLog log;
+		ASSERT_TRUE(log.Open(path, 0));
+		ASSERT_TRUE(log.CrashFd() >= 0);
+	}
+	Cleanup(path);
+}
+
+#ifndef _WIN32
+
+// The crash descriptor is a reserved number that the log's own open/close cycle cannot free. A
+// fatal handler cannot re-resolve it (every Fd lookup locks), so it holds this number from install
+// to exit. If it were the FILE*'s own descriptor, Rotate()'s fclose() would free it and whatever
+// the process opened next would inherit it -- in amuleapi, an accepted client socket.
+//
+// Rotation must not move it, and it must address the file that is current afterwards.
+TEST(LogTee, CrashFdSurvivesRotation)
+{
+	const std::string path = TmpPath("_g.log");
+	const std::string rot = path + ".1";
+	Cleanup(path);
+	{
+		CRotatingLog log;
+		ASSERT_TRUE(log.Open(path, 10));
+		const int crashFd = log.CrashFd();
+
+		log.Write("AAAAAAAAAA", 10); // fills the cap
+		log.Write("BBBBB", 5);       // crosses it -> rotate, reopen
+
+		ASSERT_EQUALS(crashFd, log.CrashFd());
+		ASSERT_EQUALS(2L, static_cast<long>(OsWriteFd(crashFd, "CC", 2)));
+	}
+	ASSERT_EQUALS(std::string("AAAAAAAAAA"), ReadFile(rot));
+	ASSERT_EQUALS(std::string("BBBBBCC"), ReadFile(path));
+	Cleanup(path);
+}
+
+// Close() leaves it open on the last file on purpose, so a holder of the number never has a closed
+// descriptor. Writing to it after Close() must reach the file rather than fail. This is also the
+// assertion that tells the reserved descriptor apart from the FILE*'s own: a rotation hands the
+// same number back in a single-threaded test, so only closing the file separates the two.
+TEST(LogTee, CrashFdStaysUsableAfterClose)
+{
+	const std::string path = TmpPath("_h.log");
+	Cleanup(path);
+	{
+		CRotatingLog log;
+		ASSERT_TRUE(log.Open(path, 0));
+		log.Write("live", 4);
+		const int crashFd = log.CrashFd();
+
+		log.Close();
+
+		ASSERT_EQUALS(4L, static_cast<long>(OsWriteFd(crashFd, "dead", 4)));
+	}
+	ASSERT_EQUALS(std::string("livedead"), ReadFile(path));
+	Cleanup(path);
+}
+
+// The reserved descriptor is never closed, so it must not follow an exec'd child and hold the log
+// file open there. aMule spawns children via wxExecute.
+TEST(LogTee, CrashFdIsCloseOnExec)
+{
+	const std::string path = TmpPath("_i.log");
+	Cleanup(path);
+	{
+		CRotatingLog log;
+		ASSERT_TRUE(log.Open(path, 0));
+		const int flags = fcntl(log.CrashFd(), F_GETFD);
+		ASSERT_TRUE(flags >= 0);
+		ASSERT_TRUE((flags & FD_CLOEXEC) != 0);
+	}
+	Cleanup(path);
+}
+
+#endif /* !_WIN32 */


### PR DESCRIPTION
wx's fatal-exception support covers SIGSEGV, SIGBUS, SIGILL and SIGFPE. A glibc heap abort raises SIGABRT, which is not in that set, so it bypassed the reporting path entirely and the process died silently. #1338 died on `double free or corruption (out)` and produced no backtrace at all, which left nothing to work from.

This installs a SIGABRT handler that reports before the process dies.

## Why not reuse get_backtrace()

The handler is entered from `abort()`, which glibc calls from `malloc_printerr` with the allocator already inconsistent and, above the tcache ceiling, its arena lock held. `get_backtrace()` allocates throughout and `popen()`s addr2line on the non-BFD path. This writes frames with `backtrace_symbols_fd()` instead, the variant documented not to allocate.

Worth being exact, because this is a guarantee rather than an observed failure: an allocating handler does not reliably hang. Measured on glibc 2.43, a double free above the tcache ceiling reaches `malloc_printerr` with the arena lock held, and a handler calling `backtrace_symbols()` still completed. The case against it is that this depends on a free chunk of the right size happening to be cached, on a heap already known to be damaged, with `fork()` in the fallback path.

Both halves are load-bearing, measured rather than assumed: the install-time warm-up matters because `backtrace()` dlopen's libgcc's unwinder on first use, which allocates. Only warm-up plus `backtrace_symbols_fd()` emits a trace under corruption detected inside `malloc()`.

The handler also arms `alarm(10)` before touching anything. `backtrace()` unwinds via `dl_iterate_phdr()`, which takes the loader's load lock, so an abort that interrupted another thread inside `dlopen()` would wait there forever. A hung process is worse than one that dies without a trace: a supervisor watching for a non-zero exit never restarts it.

The cost is raw output, so module, offset and mangled symbol, with no demangling and no line numbers. Symbolising is an offline addr2line step.

## Where the report goes

The report is written to a descriptor reserved on the log file, and to fd 2 as a second copy. Two sinks rather than a `dup2()` over fd 2, because that makes the report durable by taking it off the console. This is what `EmergencyLog()` already does for the SIGSEGV path.

Whether fd 2 outlives the process is **declared by the caller, not detected**. amuleapi passes `stderrUsable = false` because its fd 2 is a tee pipe drained by a thread that dies with it. Nothing about the descriptor could carry that: fd 2 is a pipe both for amuleapi's tee and for a container started without a tty, measured. An earlier version tested for a pipe and skipped it, which discarded the copy in exactly the deployment this exists to serve.

The terminate path writes the exception type and `what()` before it builds the backtrace, rather than buffering the whole report until symbolication returns. `get_backtrace()` allocates throughout and `popen()`s addr2line on the non-BFD path, so a hang there would otherwise cost the part already known.

A `poll(POLLOUT, 0)` probe skips a sink that cannot take the write now, such as a wedged journald socket, rather than stalling until the alarm turns the death into SIGALRM. An inode check avoids writing twice when both descriptors reach the same file.

| deployment | fd 2 is | report goes to |
|---|---|---|
| amule / amulegui on a desktop or tty | tty or journal | logfile + console |
| amuled foreground in Docker, no `-t` | pipe, outlives us | logfile + `docker logs` |
| `amuled --full-daemon` | `/dev/null` | logfile |
| amuleapi | tee pipe, dies with us | `amuleapi.log` |
| amulecmd / amuleweb | tty | stderr, no logfile exists |
| static musl build | any | nothing: no `execinfo.h`, the handler is a no-op |
| Windows | any | n/a: wx uses SEH, no SIGABRT is raised |

The reserved descriptor keeps one number for the life of the process and is only ever re-pointed, so it cannot be freed mid-rotation and handed to another thread's socket. It is `FD_CLOEXEC`, since it is never closed and would otherwise ride into every child spawned through `wxExecute`. None of this exists on Windows: an open handle blocks `rename()` there, which broke log rotation, and the handler it feeds never runs anyway.

## Coverage

| binary | armed from |
| --- | --- |
| amule, amuled, amulegui | `CamuleAppCommon` |
| amulecmd, amuleweb, amuleapi | `CaMuleExternalConnector` |

The small utilities (alc, alcc, ed2k, cas, wxcas, fileview) are unchanged: they have no crash handler at all, which is a separate question.

Every path that prints a symbolicated report before aborting suppresses the raw one, so a crash produces a single report rather than a good one followed by a raw block under a banner blaming the allocator. That covers `ReportAssertFailure` (both raise paths), `OnUnhandledException`, and the four `OnFatalException` overrides. `EmergencyLog` does not suppress, because it is not a terminator. The full table is in a comment below.

## Tests

`unittests/tests/FatalAbortBacktraceTest.cpp` forks and corrupts the heap for real, above the tcache ceiling so the abort comes from the locked path rather than the lock-free tcache check. Each child carries an alarm, so a handler that does block shows up as a failure rather than a hung suite. Cases: real double free, plain `abort()`, an in-process `raise(SIGABRT)`, the suppression path, the no-handler control, terminate with no active exception, and the terminate report reaching both sinks and skipping an unusable console.

The double free goes through an empty asm barrier. Without one every Release job failed: a double free is undefined, so at `-O2` the compiler deletes the malloc/free pair outright and the child never corrupts anything.

`LogTeeTest` covers the reserved descriptor. Asserting only that the number survives a rotation proves nothing, since `fclose()` then `fopen()` hands back the same number in a single-threaded test; the assertions that discriminate are writing to it after `Close()` and checking `FD_CLOEXEC`.

One honest limitation, recorded in the test file: the suite tests the feature, not the safety property. Telling a safe handler from an allocating one needs a known heap layout, and the wx-linked test binary does not have one. An earlier attempt passed identically for safe and unsafe builds, so it was removed rather than left looking like coverage.

## Verification

- 64/64 ctest on macOS in Debug and Release, and on Linux glibc 2.43
- all six binaries build on both; `clang-format` and both clang-tidy tiers clean
- `kill -ABRT` end to end on live amuled (foreground, `--full-daemon`) and amuleapi
- in a real container without `-t`: the report reaches both `docker logs` and the logfile, and the pre-fix build reaches only the logfile

Not fixed here: the static musl build gets no backtrace, since Alpine has not packaged libexecinfo since 3.17. That needs a source build or a different unwinder and is left to its own change.

Closes part of the diagnostics gap in #1338. It does not fix that crash; it makes the next occurrence reportable.
