### PR TITLE
fix(net): follow-ups from a post-merge review of the peer-addressing decisions

### DIFF
--- a/src/NetworkAddress.h
+++ b/src/NetworkAddress.h
@@ -43,7 +43,11 @@ struct IPv6ExcludedPrefix
 	const char *name;
 };
 
-constexpr IPv6ExcludedPrefix kIPv6ExcludedPrefixes[] = { { {}, 128, "Unspecified" },
+// inline, because constexpr at namespace scope implies const and therefore internal linkage.
+// IsGloballyRoutableIPv6() is an inline member that uses this, so without inline every
+// translation unit gets its own entity: ill-formed with no diagnostic required, and a separate
+// copy of the table in each of the ~155 units that will include this header once callers exist.
+inline constexpr IPv6ExcludedPrefix kIPv6ExcludedPrefixes[] = { { {}, 128, "Unspecified" },
 	{ { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1 }, 128, "Loopback" },
 	{ { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xff, 0xff }, 96, "IPv4-mapped" },
 	// ::a.b.c.d, the deprecated IPv4-compatible form (RFC 4291). Its page also holds the
@@ -53,8 +57,13 @@ constexpr IPv6ExcludedPrefix kIPv6ExcludedPrefixes[] = { { {}, 128, "Unspecified
 	{ { 0x00, 0x64, 0xff, 0x9b }, 96, "Well-known NAT64" },
 	{ { 0x00, 0x64, 0xff, 0x9b, 0x00, 0x01 }, 48, "Local-use NAT64" },
 	{ { 0x01, 0x00 }, 64, "Discard-only" },
-	{ { 0x20, 0x01 }, 32, "Teredo" },
-	{ { 0x20, 0x01, 0x00, 0x20 }, 28, "ORCHIDv2" },
+	// The whole IETF Protocol Assignments block, rather than the handful of sub-blocks that
+	// have been carved out of it so far. None of 2001::/23 is globally routable unicast, and
+	// IANA keeps adding to it -- Teredo, ORCHID, benchmarking, AMT, ORCHIDv2 in 2014, Drone
+	// Remote ID in 2023 -- so a list of children is a list that goes stale. This entry
+	// replaces the separate Teredo (2001::/32) and ORCHIDv2 (2001:20::/28) ones and covers
+	// the rest for good. Documentation (2001:db8::/32) is outside the /23 and stays below.
+	{ { 0x20, 0x01 }, 23, "IETF Protocol Assignments" },
 	{ { 0x20, 0x01, 0x0d, 0xb8 }, 32, "Documentation" },
 	{ { 0x20, 0x02 }, 16, "6to4" },
 	{ { 0x5f, 0x00 }, 16, "Segment routing SIDs" },
@@ -66,13 +75,22 @@ constexpr IPv6ExcludedPrefix kIPv6ExcludedPrefixes[] = { { {}, 128, "Unspecified
 inline bool MatchesPrefix(
 	const std::array<std::uint8_t, 16> &address, const IPv6ExcludedPrefix &prefix) noexcept
 {
-	for (unsigned bit = 0; bit < prefix.bits; ++bit) {
-		const unsigned mask = 0x80u >> (bit % 8);
-		if ((address[bit / 8] & mask) != (prefix.bytes[bit / 8] & mask)) {
+	// Whole bytes first, then the one partial byte. The bit-at-a-time form was up to 128
+	// iterations per prefix on a path the callers below sit in front of obfuscation-key
+	// derivation, and every entry in the table is walked before an address is declared
+	// routable.
+	const unsigned wholeBytes = prefix.bits / 8u;
+	for (unsigned i = 0; i < wholeBytes; ++i) {
+		if (address[i] != prefix.bytes[i]) {
 			return false;
 		}
 	}
-	return true;
+	const unsigned remainder = prefix.bits % 8u;
+	if (remainder == 0) {
+		return true;
+	}
+	const std::uint8_t mask = static_cast<std::uint8_t>(0xFFu << (8u - remainder));
+	return (address[wholeBytes] & mask) == (prefix.bytes[wholeBytes] & mask);
 }
 } // namespace NetworkAddressPolicy
 

--- a/src/PeerAddressing.h
+++ b/src/PeerAddressing.h
@@ -95,13 +95,26 @@ inline CNetworkAddress IndexKey(const CNetworkAddress &address)
  * be published or persisted through them -- and must be @b omitted rather than written as a zero,
  * which would publish "0.0.0.0" to every peer that asked for sources.
  *
+ * The unspecified address is refused for the same reason, whether it arrives as @c 0.0.0.0 or as
+ * @c ::ffff:0.0.0.0 : it narrows successfully, to zero, which is the value the paragraph above
+ * says must never be written. Having a 32-bit form and being nameable in one are not the same
+ * question, and this predicate answers the second.
+ *
  * Widening those formats is a protocol change and needs its own capability bit, so this predicate
  * is the boundary until one exists.
  */
 inline bool HasEd2kWireForm(const CNetworkAddress &address) noexcept
 {
-	std::uint32_t unused = 0;
-	return address.ToIPv4NetworkOrder(unused);
+	std::uint32_t narrowed = 0;
+	if (!address.ToIPv4NetworkOrder(narrowed)) {
+		return false;
+	}
+	// The narrowing succeeding is not enough. 0.0.0.0 has a 32-bit form and ::ffff:0.0.0.0
+	// narrows to the same value, and writing either into these fields is the exact failure
+	// this predicate exists to prevent: a zero published as a source to every peer that asks,
+	// and persisted for the next start to dial. Absence is the correct answer for a peer we
+	// cannot name, so a value that names nobody is refused here rather than written out.
+	return narrowed != 0;
 }
 
 /**

--- a/unittests/tests/CMakeLists.txt
+++ b/unittests/tests/CMakeLists.txt
@@ -248,6 +248,10 @@ target_link_libraries (BanRecordTest
 # compiles Boost.Asio.
 add_executable (NetworkAddressTest
 	NetworkAddressTest.cpp
+	# A second unit including NetworkAddress.h, so the linkage of the exclusion
+	# table is observable: without `inline` the table is internal to each unit
+	# and the two addresses differ.
+	NetworkAddressTableLinkage.cpp
 	${CMAKE_SOURCE_DIR}/src/libs/common/Format.cpp
 	${CMAKE_SOURCE_DIR}/src/libs/common/strerror_r.c
 	# CNetworkAddress::FromString/ToString live in NetworkAddress.cpp: they are

--- a/unittests/tests/NetworkAddressTableLinkage.cpp
+++ b/unittests/tests/NetworkAddressTableLinkage.cpp
@@ -1,0 +1,35 @@
+//								-*- C++ -*-
+// This file is part of the aMule Project.
+//
+// Copyright (c) 2003-2026 aMule Team ( https://amule-org.github.io )
+//
+// Any parts of this program derived from the xMule, lMule or eMule project,
+// or contributed by third-party developers are copyrighted by their
+// respective authors.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301, USA
+//
+
+// A second translation unit that includes NetworkAddress.h, so the test beside it can ask whether
+// the exclusion table is one entity or a copy per unit. That is the whole content: without
+// `inline` on the table, `constexpr` at namespace scope implies `const` and therefore internal
+// linkage, and the address taken here differs from the one taken there.
+
+#include <NetworkAddress.h>
+
+const void *ExcludedPrefixTableAddressFromOtherUnit() noexcept
+{
+	return &NetworkAddressPolicy::kIPv6ExcludedPrefixes[0];
+}

--- a/unittests/tests/NetworkAddressTest.cpp
+++ b/unittests/tests/NetworkAddressTest.cpp
@@ -463,6 +463,22 @@ TEST(NetworkAddress, GloballyRoutableIPv4RejectsEveryUnroutableRange)
 	ASSERT_FALSE(CNetworkAddress::FromString("255.255.255.255").IsGloballyRoutableIPv4());
 }
 
+// Defined in NetworkAddressTableLinkage.cpp, a second unit that includes the same header.
+const void *ExcludedPrefixTableAddressFromOtherUnit() noexcept;
+
+// The exclusion table has to be one entity, not one per translation unit. `constexpr` at namespace
+// scope implies `const` and therefore internal linkage, and IsGloballyRoutableIPv6() is an inline
+// member that uses it: ill-formed with no diagnostic required, and a separate copy of the table in
+// every unit including the header.
+//
+// Nothing about that fails to compile or link, which is why it needs asking directly. Dropping the
+// `inline` makes this fail with two distinct addresses.
+TEST(NetworkAddress, TheExclusionTableIsOneEntityAcrossUnits)
+{
+	ASSERT_TRUE(ExcludedPrefixTableAddressFromOtherUnit() ==
+		    static_cast<const void *>(&NetworkAddressPolicy::kIPv6ExcludedPrefixes[0]));
+}
+
 // CNetworkAddress no longer stores a boost::asio::ip::address, so the three predicates that used to
 // be asio's -- loopback, link-local, unique-local -- are now prefix tests in NetworkAddress.h. This
 // pins each range it must reject, because getting one prefix wrong here does not fail a build: it
@@ -551,7 +567,7 @@ TEST(NetworkAddress, GloballyRoutableIPv6RejectsEveryUnreachableRange)
 	// Teredo and ORCHIDv2 still excluded, now by the containing block rather than their own.
 	ASSERT_FALSE(CNetworkAddress::FromString("2001::1").IsGloballyRoutableIPv6());
 	ASSERT_FALSE(CNetworkAddress::FromString("2001:20::1").IsGloballyRoutableIPv6());
-	// Just outside the block, and allocated: this is what stops the entry over-reaching.
+	// Immediately outside the block on both sides, which is what stops the entry over-reaching.
 	ASSERT_TRUE(CNetworkAddress::FromString("2001:200::1").IsGloballyRoutableIPv6());
 	ASSERT_TRUE(CNetworkAddress::FromString("2000:ffff::1").IsGloballyRoutableIPv6());
 

--- a/unittests/tests/NetworkAddressTest.cpp
+++ b/unittests/tests/NetworkAddressTest.cpp
@@ -514,11 +514,14 @@ TEST(NetworkAddress, GloballyRoutableIPv6RejectsEveryUnreachableRange)
 			"100::",
 			"100::ffff:ffff:ffff:ffff",
 			"100:0:0:1::" },
-		// 2001:20::/28
-		{ "2001:1f:ffff:ffff:ffff:ffff:ffff:ffff",
-			"2001:20::",
-			"2001:2f:ffff:ffff:ffff:ffff:ffff:ffff",
-			"2001:30::" },
+		// 2001::/23, the IETF Protocol Assignments block. Coarser than the ORCHIDv2 row it
+		// replaces, and still a literal IANA bound rather than a restatement of our table:
+		// /23 fixes bits 0 to 22, so the block runs to 2001:01ff:ffff:... and the first
+		// globally routable address above it is 2001:200::.
+		{ "2000:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+			"2001::",
+			"2001:1ff:ffff:ffff:ffff:ffff:ffff:ffff",
+			"2001:200::" },
 		// 2001:db8::/32
 		{ "2001:db7:ffff:ffff:ffff:ffff:ffff:ffff",
 			"2001:db8::",
@@ -537,6 +540,20 @@ TEST(NetworkAddress, GloballyRoutableIPv6RejectsEveryUnreachableRange)
 		ASSERT_TRUE(CNetworkAddress::FromString(range.after).IsGloballyRoutableIPv6());
 	}
 	ASSERT_TRUE(CNetworkAddress::FromString("2606:4700::1111").IsGloballyRoutableIPv6());
+
+	// The sub-blocks 2001::/23 covers that had no entry of their own. Asserted individually
+	// rather than left implied by the prefix length, because the reason each one is not
+	// globally routable is a separate fact about the registry.
+	ASSERT_FALSE(CNetworkAddress::FromString("2001:2::1").IsGloballyRoutableIPv6());  // benchmarking
+	ASSERT_FALSE(CNetworkAddress::FromString("2001:3::1").IsGloballyRoutableIPv6());  // AMT
+	ASSERT_FALSE(CNetworkAddress::FromString("2001:10::1").IsGloballyRoutableIPv6()); // old ORCHID
+	ASSERT_FALSE(CNetworkAddress::FromString("2001:30::1").IsGloballyRoutableIPv6()); // drone RID
+	// Teredo and ORCHIDv2 still excluded, now by the containing block rather than their own.
+	ASSERT_FALSE(CNetworkAddress::FromString("2001::1").IsGloballyRoutableIPv6());
+	ASSERT_FALSE(CNetworkAddress::FromString("2001:20::1").IsGloballyRoutableIPv6());
+	// Just outside the block, and allocated: this is what stops the entry over-reaching.
+	ASSERT_TRUE(CNetworkAddress::FromString("2001:200::1").IsGloballyRoutableIPv6());
+	ASSERT_TRUE(CNetworkAddress::FromString("2000:ffff::1").IsGloballyRoutableIPv6());
 
 	// Not an IPv6 address at all.
 	ASSERT_FALSE(CNetworkAddress::Absent().IsGloballyRoutableIPv6());

--- a/unittests/tests/PeerAddressingTest.cpp
+++ b/unittests/tests/PeerAddressingTest.cpp
@@ -351,10 +351,15 @@ TEST(PeerAddressing, Ed2kWireFormIsWhatMayBePublished)
 	// from those paths incidentally, by having no ed2k id and so reading as LowID. It is now
 	// correctly HighID, so the exclusion has to be this explicit test instead.
 	ASSERT_TRUE(HasEd2kWireForm(CNetworkAddress::FromString("192.0.2.1")));
-	ASSERT_TRUE(HasEd2kWireForm(CNetworkAddress::FromString("0.0.0.0")));
 	ASSERT_TRUE(HasEd2kWireForm(CNetworkAddress::FromString("::ffff:192.0.2.1")));
 	ASSERT_FALSE(HasEd2kWireForm(CNetworkAddress::FromString("2001:db8::1")));
 	ASSERT_FALSE(HasEd2kWireForm(CNetworkAddress::Absent()));
+
+	// The zero, in both spellings. It narrows successfully, which is why the old test passed
+	// it, but zero is the value the comment above says must never be written into these
+	// fields. Naming nobody is not the same as having a 32-bit form.
+	ASSERT_FALSE(HasEd2kWireForm(CNetworkAddress::FromString("0.0.0.0")));
+	ASSERT_FALSE(HasEd2kWireForm(CNetworkAddress::FromString("::ffff:0.0.0.0")));
 
 	// A peer that may be published is published with exactly the bytes it had before the
 	// widening -- the mapped spelling included, which narrows to its embedded IPv4 rather than


### PR DESCRIPTION
Four findings from re-reviewing #1345. Nothing outside the tests calls any of this yet, so they concern the contract the call sites will be written against.

## `HasEd2kWireForm()` admitted the zero

The narrowing succeeds for `0.0.0.0`, which is why it passed, but zero is precisely the value the function's own documentation says must never be written into these fields: published as a source to every peer that asks, and persisted for the next start to dial. Having a 32-bit form and being nameable in one are different questions, and this predicate answers the second. Both spellings are refused now.

The test asserted the permissive answer two lines below a comment arguing against it. It now asserts the refusal, for `0.0.0.0` and `::ffff:0.0.0.0`.

This is also where a finding from #1379's review landed. I had been asked whether `FromIPv6Bytes()` should reject `::ffff:0.0.0.0` and concluded it should not, because that factory is a decoder with no policy. This is the gate that does hold the policy, and it is the right place for the rejection.

## The exclusion table had internal linkage

`constexpr` at namespace scope implies `const` and therefore internal linkage, while the inline member `IsGloballyRoutableIPv6()` uses it. That is ill-formed, no diagnostic required, and once callers exist it puts a separate copy of the table in every translation unit including the header. `inline constexpr` now.

I first wrote that no test could distinguish this, which was wrong. Internal linkage compiles and links, but it gives each translation unit its own table and the addresses differ, so asking the question directly answers it. `NetworkAddressTableLinkage.cpp` is a second unit including the header, and `TheExclusionTableIsOneEntityAcrossUnits` compares the two. Dropping the `inline` again makes it fail.

## One entry for `2001::/23` instead of a list of its children

The table carved out Teredo and ORCHIDv2 but not the other non-global blocks inside the IETF Protocol Assignments range: benchmarking `2001:2::/48`, AMT `2001:3::/32`, the deprecated ORCHID page `2001:10::/28`, and Drone Remote ID `2001:30::/28`.

Rather than adding four entries, one `2001::/23` replaces both existing ones and covers the rest. None of that block is globally routable unicast and IANA keeps adding to it, most recently in 2014 and 2023, so a list of children is a list that goes stale. Documentation at `2001:db8::/32` sits outside the `/23` and stays separate.

The boundary-probe row moves with it. That table is deliberately written as literal IANA bounds rather than a restatement of our own table, so the replacement row is the real block: `/23` fixes bits 0 to 22, so it runs to `2001:01ff:ffff:...` and the first routable address above is `2001:200::`. The four newly covered blocks are also asserted individually, because the reason each is non-global is a separate fact about the registry rather than something the prefix length explains.

## `MatchesPrefix()` compared one bit at a time

Up to 128 iterations per prefix, with every entry walked before an address is declared routable, on a path the docs place in front of obfuscation-key derivation. Whole bytes plus one masked remainder byte now. No new test: the existing exhaustive bit-flip loop already covers it, confirmed by breaking the remainder handling and watching it fail.

## Two reported findings not changed here

**`IndexKey()` keeping the scope id.** Dropping it would be worse than the problem. `fe80::1%3` and `fe80::1%9` are different peers on different interfaces, and merging them converts a latent mismatch into a real one. The genuine asymmetry is that a socket-derived address carries a scope and a hello tag does not, which belongs at the tag edge where a link-local address is undialable anyway. A note for the call-site work.

**`RateLimitScope()` returning the absent address.** Not a defect. A present address always yields a present scope, so an absent return unambiguously means no budget and the caller distinguishes it with `IsAbsent()`.

## Verification

Default build clean, 62/62 ctest. Controls: restoring Teredo and ORCHIDv2 in place of the `/23` fails the boundary row, restoring the permissive predicate fails the zero assertion, zeroing the remainder handling fails the exhaustive prefix test, and dropping the `inline` fails the linkage test.

clang-format 18 clean, `git diff --check` clean, Tier-2 clang-tidy clean with zero compiler errors.

Refs #1177

