### PR TITLE
fix(net): follow-ups from a post-merge review of the address family policy

### DIFF
--- a/src/AddressFamilyPolicy.h
+++ b/src/AddressFamilyPolicy.h
@@ -77,14 +77,32 @@ inline void SetConfigured(Families families) noexcept
 	ConfiguredStorage().store(families, std::memory_order_relaxed);
 }
 
+// Both predicates switch rather than test for inequality, so an out-of-range value falls back the
+// same way ResolverFamilyForLookup() does. Comparing against one enumerator made a value outside
+// the enum permit *both* families while the resolver fell back to IPv4Only, and piece 4 will build
+// this from a configuration integer, which is exactly where such a value comes from.
 inline bool PermitsIPv4() noexcept
 {
-	return Configured() != Families::IPv6Only;
+	switch (Configured()) {
+	case Families::IPv4Only:
+	case Families::DualStack:
+		return true;
+	case Families::IPv6Only:
+		return false;
+	}
+	return true; // Same IPv4-only fallback as the resolver.
 }
 
 inline bool PermitsIPv6() noexcept
 {
-	return Configured() != Families::IPv4Only;
+	switch (Configured()) {
+	case Families::IPv6Only:
+	case Families::DualStack:
+		return true;
+	case Families::IPv4Only:
+		return false;
+	}
+	return false; // Same IPv4-only fallback as the resolver.
 }
 
 /**
@@ -93,12 +111,28 @@ inline bool PermitsIPv6() noexcept
  * An IPv4-mapped IPv6 target counts as IPv4: it narrows losslessly, so an IPv4-only configuration
  * can reach it.
  */
+/**
+ * Whether @a target is reachable over IPv4, mapped form included.
+ *
+ * One definition, because the asio half asks the same question when it picks a protocol. Two
+ * copies would let a later change to what counts as IPv4, for NAT64 or 6to4, be applied to one
+ * of them and reintroduce a v4 socket opened towards a v6 endpoint.
+ */
+inline bool IsIPv4Reachable(const CNetworkAddress &target) noexcept
+{
+	return target.IsIPv4() || target.IsIPv4Mapped();
+}
+
 inline bool Permits(const CNetworkAddress &target) noexcept
 {
-	if (target.IsAbsent()) {
+	// Absence names no peer, and neither does the unspecified address. It reaches here as a
+	// present IPv4 value, so the family test would permit it under any configuration, and a
+	// call site replacing an old `if (ip)` guard would dial 0.0.0.0 -- which on Linux connects
+	// to this machine. "May a socket be opened towards this" has to answer no.
+	if (target.IsAbsent() || target.Unmapped().IsUnspecified()) {
 		return false;
 	}
-	if (target.IsIPv4() || target.IsIPv4Mapped()) {
+	if (IsIPv4Reachable(target)) {
 		return PermitsIPv4();
 	}
 	return PermitsIPv6();

--- a/src/AddressFamilyPolicy.h
+++ b/src/AddressFamilyPolicy.h
@@ -106,12 +106,6 @@ inline bool PermitsIPv6() noexcept
 }
 
 /**
- * Whether a socket may be opened towards @a target at all.
- *
- * An IPv4-mapped IPv6 target counts as IPv4: it narrows losslessly, so an IPv4-only configuration
- * can reach it.
- */
-/**
  * Whether @a target is reachable over IPv4, mapped form included.
  *
  * One definition, because the asio half asks the same question when it picks a protocol. Two
@@ -123,6 +117,17 @@ inline bool IsIPv4Reachable(const CNetworkAddress &target) noexcept
 	return target.IsIPv4() || target.IsIPv4Mapped();
 }
 
+/**
+ * Whether a socket may be opened towards @a target at all.
+ *
+ * An IPv4-mapped IPv6 target counts as IPv4: it narrows losslessly, so an IPv4-only configuration
+ * can reach it.
+ *
+ * Absence is refused, and so is the unspecified address in either spelling. It arrives as a
+ * present IPv4 value, so the family test alone would permit it under every configuration, and a
+ * call site replacing an old @c if(ip) guard would dial 0.0.0.0 -- which on Linux connects to
+ * this machine. A value that names nobody is not a target.
+ */
 inline bool Permits(const CNetworkAddress &target) noexcept
 {
 	// Absence names no peer, and neither does the unspecified address. It reaches here as a

--- a/src/AddressFamilyPolicyAsio.h
+++ b/src/AddressFamilyPolicyAsio.h
@@ -48,24 +48,6 @@
 namespace AddressFamilyPolicy
 {
 
-/**
- * The TCP protocol a socket towards @a target must be opened in.
- *
- * @return The protocol, or no value when @a target is absent or its family is not permitted by the
- *         configuration. There is no fallback: opening a v4 socket for a v6 target is how a
- *         truncated address turns into a connection to the wrong host.
- */
-inline boost::optional<boost::asio::ip::tcp> TcpProtocolForTarget(const CNetworkAddress &target) noexcept
-{
-	if (!Permits(target)) {
-		return boost::none;
-	}
-	if (IsIPv4Reachable(target)) {
-		return boost::asio::ip::tcp::v4();
-	}
-	return boost::asio::ip::tcp::v6();
-}
-
 /** A protocol and the endpoint address to use with it, guaranteed to be the same family. */
 struct SAsioTarget
 {
@@ -76,22 +58,32 @@ struct SAsioTarget
 /**
  * The protocol and address for one connection attempt, decided together.
  *
- * Asking TcpProtocolForTarget() and NetworkAddressAsio::ToAsioAddress() separately does not
- * work for an IPv4-mapped target: the first says @c tcp::v4() because a mapped address is
- * reachable over IPv4, the second preserves the family and hands back an @c address_v6, and
- * connecting the two gives EAFNOSUPPORT on every mapped peer. Narrowing the address here is
- * what makes the pair agree, and returning them together is what stops them drifting apart
- * again.
+ * Deciding the protocol and the address separately does not work for an IPv4-mapped target. The
+ * family test calls it IPv4, because a mapped address is reachable over IPv4, while
+ * NetworkAddressAsio::ToAsioAddress() preserves the family and hands back an @c address_v6, and
+ * connecting the two gives EAFNOSUPPORT on every mapped peer. Narrowing the address here is what
+ * makes the pair agree, and returning them together is what stops them drifting apart again.
+ *
+ * This supersedes a protocol-only accessor that took a target and returned just the @c tcp. It
+ * was removed rather than left beside this one: a caller reaching for it would pair it with
+ * ToAsioAddress() and land back on that same mismatch, and the protocol for a listening socket
+ * comes from the endpoint built on AnyAddress() rather than from a target.
  *
  * Returning one optional also removes the other half of that footgun. With two calls a caller
- * writes `sock.open(*TcpProtocolForTarget(t))` after a separate Permits() check, and
- * dereferences an empty optional if anything moved in between; here there is one decision and
- * one thing to test.
+ * writes `sock.open(*ProtocolFor(t))` after a separate Permits() check and dereferences an empty
+ * optional if anything moved in between; here there is one decision and one thing to test.
+ *
+ * There is no fallback: a v4 socket opened for a v6 target is how a truncated address turns into
+ * a connection to the wrong host, so a family the configuration refuses yields no pair at all.
+ *
+ * Not @c noexcept, unlike the predicates beside it: NetworkAddressAsio::ToAsioAddress() is an
+ * out-of-line function that makes no such promise, and inheriting one here would turn a future
+ * throw into a terminate rather than something a caller can handle.
  *
  * @return The pair, or no value when @a target is absent, unspecified, or of a family the
  *         configuration does not permit.
  */
-inline boost::optional<SAsioTarget> AsioTargetFor(const CNetworkAddress &target) noexcept
+inline boost::optional<SAsioTarget> AsioTargetFor(const CNetworkAddress &target)
 {
 	if (!Permits(target)) {
 		return boost::none;

--- a/src/AddressFamilyPolicyAsio.h
+++ b/src/AddressFamilyPolicyAsio.h
@@ -26,6 +26,7 @@
 #define ADDRESSFAMILYPOLICYASIO_H
 
 #include "AddressFamilyPolicy.h"
+#include "NetworkAddressAsio.h" // Needed for ToAsioAddress in AsioTargetFor
 
 #include <boost/optional.hpp>
 
@@ -59,10 +60,47 @@ inline boost::optional<boost::asio::ip::tcp> TcpProtocolForTarget(const CNetwork
 	if (!Permits(target)) {
 		return boost::none;
 	}
-	if (target.IsIPv4() || target.IsIPv4Mapped()) {
+	if (IsIPv4Reachable(target)) {
 		return boost::asio::ip::tcp::v4();
 	}
 	return boost::asio::ip::tcp::v6();
+}
+
+/** A protocol and the endpoint address to use with it, guaranteed to be the same family. */
+struct SAsioTarget
+{
+	boost::asio::ip::tcp protocol;
+	boost::asio::ip::address address;
+};
+
+/**
+ * The protocol and address for one connection attempt, decided together.
+ *
+ * Asking TcpProtocolForTarget() and NetworkAddressAsio::ToAsioAddress() separately does not
+ * work for an IPv4-mapped target: the first says @c tcp::v4() because a mapped address is
+ * reachable over IPv4, the second preserves the family and hands back an @c address_v6, and
+ * connecting the two gives EAFNOSUPPORT on every mapped peer. Narrowing the address here is
+ * what makes the pair agree, and returning them together is what stops them drifting apart
+ * again.
+ *
+ * Returning one optional also removes the other half of that footgun. With two calls a caller
+ * writes `sock.open(*TcpProtocolForTarget(t))` after a separate Permits() check, and
+ * dereferences an empty optional if anything moved in between; here there is one decision and
+ * one thing to test.
+ *
+ * @return The pair, or no value when @a target is absent, unspecified, or of a family the
+ *         configuration does not permit.
+ */
+inline boost::optional<SAsioTarget> AsioTargetFor(const CNetworkAddress &target) noexcept
+{
+	if (!Permits(target)) {
+		return boost::none;
+	}
+	const CNetworkAddress narrowed = target.Unmapped();
+	SAsioTarget result = { IsIPv4Reachable(narrowed) ? boost::asio::ip::tcp::v4()
+							 : boost::asio::ip::tcp::v6(),
+		NetworkAddressAsio::ToAsioAddress(narrowed) };
+	return result;
 }
 
 /** An explicit lookup-family restriction; Any means unrestricted, not refusal. */
@@ -111,6 +149,12 @@ inline boost::asio::ip::address AnyIPv6Address() noexcept
  * Prefer the IPv4 wildcard whenever IPv4 is permitted, including dual stack, so a single-socket
  * service is not implicitly moved to another family. Accepting both families on an IPv6 socket
  * requires explicitly choosing AnyIPv6Address() and clearing @c IPV6_V6ONLY.
+ *
+ * Under @c IPv6Only this returns the IPv6 wildcard, and the caller must then @b set
+ * @c IPV6_V6ONLY rather than leave it at the platform default. Linux defaults it off, so the
+ * listener would accept IPv4 peers as mapped addresses while Permits() refuses mapped addresses
+ * under that configuration: connections arriving that the policy will not talk to. This header
+ * cannot set socket options, so the obligation is the caller's either way.
  */
 inline boost::asio::ip::address AnyAddress() noexcept
 {

--- a/unittests/tests/AddressFamilyPolicyTest.cpp
+++ b/unittests/tests/AddressFamilyPolicyTest.cpp
@@ -72,6 +72,81 @@ CNetworkAddress Addr(const char *text)
 }
 } // namespace
 
+// Absence is not the only value that names no peer. 0.0.0.0 reaches Permits() as a present IPv4
+// address, so the family test alone permits it under every configuration, and a call site
+// replacing an old `if (ip)` guard would dial it -- which on Linux connects to this machine.
+TEST(AddressFamilyPolicy, TheUnspecifiedAddressIsNeverPermitted)
+{
+	const Families every[] = { Families::IPv4Only, Families::IPv6Only, Families::DualStack };
+	for (const Families families : every) {
+		ScopedFamilies scope(families);
+		ASSERT_FALSE(Permits(Addr("0.0.0.0")));
+		ASSERT_FALSE(Permits(Addr("::")));
+		ASSERT_FALSE(Permits(Addr("::ffff:0.0.0.0")));
+	}
+	// A real address of the permitted family still passes, so this did not just refuse
+	// everything.
+	{
+		ScopedFamilies scope(Families::DualStack);
+		ASSERT_TRUE(Permits(Addr("192.0.2.1")));
+		ASSERT_TRUE(Permits(Addr("2001:db8::1")));
+	}
+}
+
+// The protocol and the endpoint have to be the same family. Asked separately they are not for a
+// mapped target: the protocol is v4 because a mapped address is reachable over IPv4, while
+// ToAsioAddress() preserves the family and yields an address_v6. Connecting those is EAFNOSUPPORT.
+TEST(AddressFamilyPolicy, AsioTargetPairsTheProtocolWithAMatchingAddress)
+{
+	ScopedFamilies scope(Families::DualStack);
+
+	const boost::optional<SAsioTarget> mapped = AsioTargetFor(Addr("::ffff:192.0.2.1"));
+	ASSERT_TRUE((bool)mapped);
+	ASSERT_TRUE(mapped->protocol == boost::asio::ip::tcp::v4());
+	ASSERT_TRUE(mapped->address.is_v4());
+
+	const boost::optional<SAsioTarget> native = AsioTargetFor(Addr("192.0.2.1"));
+	ASSERT_TRUE((bool)native);
+	ASSERT_TRUE(native->protocol == boost::asio::ip::tcp::v4());
+	ASSERT_TRUE(native->address.is_v4());
+	// The mapped and native spellings of one peer reach the same wire target.
+	ASSERT_TRUE(mapped->address == native->address);
+
+	const boost::optional<SAsioTarget> v6 = AsioTargetFor(Addr("2001:db8::1"));
+	ASSERT_TRUE((bool)v6);
+	ASSERT_TRUE(v6->protocol == boost::asio::ip::tcp::v6());
+	ASSERT_TRUE(v6->address.is_v6());
+}
+
+// One decision, one thing to test: a refused target yields no pair at all, rather than a protocol
+// the caller might dereference after a separate and possibly stale Permits() check.
+TEST(AddressFamilyPolicy, AsioTargetIsEmptyForAnythingRefused)
+{
+	{
+		ScopedFamilies scope(Families::IPv4Only);
+		ASSERT_FALSE((bool)AsioTargetFor(Addr("2001:db8::1")));
+	}
+	{
+		ScopedFamilies scope(Families::DualStack);
+		ASSERT_FALSE((bool)AsioTargetFor(CNetworkAddress::Absent()));
+		ASSERT_FALSE((bool)AsioTargetFor(Addr("0.0.0.0")));
+	}
+}
+
+// Piece 4 will build this from a configuration integer, so a value outside the enum is reachable.
+// Testing inequality against one enumerator made such a value permit both families while the
+// resolver fell back to IPv4-only; every answer now agrees on the same fallback.
+TEST(AddressFamilyPolicy, AnOutOfRangeConfigurationFallsBackConsistently)
+{
+	ScopedFamilies scope(static_cast<Families>(99));
+
+	ASSERT_TRUE(PermitsIPv4());
+	ASSERT_FALSE(PermitsIPv6());
+	ASSERT_TRUE(ResolverFamilyForLookup() == ResolverFamily::IPv4Only);
+	ASSERT_TRUE(Permits(Addr("192.0.2.1")));
+	ASSERT_FALSE(Permits(Addr("2001:db8::1")));
+}
+
 TEST(AddressFamilyPolicy, DefaultIsIPv4Only)
 {
 	// Captured before any case ran. If this fails, the widening advertises a

--- a/unittests/tests/AddressFamilyPolicyTest.cpp
+++ b/unittests/tests/AddressFamilyPolicyTest.cpp
@@ -196,7 +196,7 @@ TEST(AddressFamilyPolicy, AbsentIsNeverPermitted)
 	const CNetworkAddress absent = CNetworkAddress::Absent();
 	ScopedFamilies scope(Families::DualStack);
 	ASSERT_FALSE(Permits(absent));
-	ASSERT_FALSE(TcpProtocolForTarget(absent));
+	ASSERT_FALSE((bool)AsioTargetFor(absent));
 }
 
 TEST(AddressFamilyPolicy, RefusalNeverFallsBackToTheOtherFamily)
@@ -205,20 +205,20 @@ TEST(AddressFamilyPolicy, RefusalNeverFallsBackToTheOtherFamily)
 	const CNetworkAddress v6 = Addr("2001:db8::1");
 	{
 		ScopedFamilies scope(Families::IPv4Only);
-		ASSERT_TRUE(TcpProtocolForTarget(v4) == boost::asio::ip::tcp::v4());
-		// Not v4() as a fallback: no protocol at all.
-		ASSERT_FALSE(TcpProtocolForTarget(v6));
+		ASSERT_TRUE(AsioTargetFor(v4)->protocol == boost::asio::ip::tcp::v4());
+		// Not v4() as a fallback: no pair at all.
+		ASSERT_FALSE((bool)AsioTargetFor(v6));
 	}
 	{
 		ScopedFamilies scope(Families::IPv6Only);
-		ASSERT_FALSE(TcpProtocolForTarget(v4));
-		ASSERT_TRUE(TcpProtocolForTarget(v6) == boost::asio::ip::tcp::v6());
+		ASSERT_FALSE((bool)AsioTargetFor(v4));
+		ASSERT_TRUE(AsioTargetFor(v6)->protocol == boost::asio::ip::tcp::v6());
 	}
 	{
 		ScopedFamilies scope(Families::DualStack);
-		ASSERT_TRUE(TcpProtocolForTarget(v4) == boost::asio::ip::tcp::v4());
-		ASSERT_TRUE(TcpProtocolForTarget(v6) == boost::asio::ip::tcp::v6());
-		ASSERT_TRUE(TcpProtocolForTarget(Addr("::ffff:192.0.2.1")) == boost::asio::ip::tcp::v4());
+		ASSERT_TRUE(AsioTargetFor(v4)->protocol == boost::asio::ip::tcp::v4());
+		ASSERT_TRUE(AsioTargetFor(v6)->protocol == boost::asio::ip::tcp::v6());
+		ASSERT_TRUE(AsioTargetFor(Addr("::ffff:192.0.2.1"))->protocol == boost::asio::ip::tcp::v4());
 	}
 }
 


### PR DESCRIPTION
Six findings from re-reviewing #1350. No production TU includes either header yet, so these are about the contract piece 4 will be written against.

## The protocol and the endpoint disagreed about a mapped target

`TcpProtocolForTarget()` answers `tcp::v4()` for an IPv4-mapped address, because it is reachable over IPv4 and `Permits()` treats it that way. `NetworkAddressAsio::ToAsioAddress()` preserves the family and hands back an `address_v6`. Opening one and connecting the other is `EAFNOSUPPORT` on every mapped peer, and since both live in this header a caller reading them has no way to tell which is the odd one out.

`AsioTargetFor()` returns the protocol and the narrowed address together, so they cannot drift apart. `TcpProtocolForTarget()` is removed rather than left beside it: a caller reaching for the protocol alone would pair it with `ToAsioAddress()` and land back on the same mismatch, and it sat above the safe function in the file. Nothing outside the tests used it, and no other caller shape wants it, since a listening socket takes its protocol from the endpoint built on `AnyAddress()`. Its tests are ported, not dropped, so `RefusalNeverFallsBackToTheOtherFamily` now pins the no-fallback property on the function callers will use.

It is also not `noexcept`, unlike the predicates beside it: `ToAsioAddress()` is out-of-line and makes no such promise, and inheriting one would turn a future throw into a terminate.

That also removes the unchecked-optional shape the review flagged separately. With two calls the natural spelling is `sock.open(*TcpProtocolForTarget(t))` after a separate `Permits()` check, which dereferences an empty optional if the configuration moved in between. #1177 makes a family change restart-only so the race is not reachable today, but one call returning one optional leaves nothing to get wrong later.

## `Permits()` accepted the unspecified address

It arrives as a present IPv4 value, so the family test permits it under every configuration, and a call site replacing an old `if (ip)` guard would dial `0.0.0.0`, which on Linux connects to this machine. "Whether a socket may be opened towards this target at all" has to answer no for a value that names nobody, in both spellings.

Same question as `HasEd2kWireForm()` on #1381, same answer: the predicate whose job is "may I use this" refuses it.

## An out-of-range configuration made the answers disagree

`PermitsIPv4()` and `PermitsIPv6()` tested inequality against one enumerator, so a value outside the enum permitted *both* families while `ResolverFamilyForLookup()` fell back to IPv4-only. Piece 4 builds this from a configuration integer, which is exactly where such a value comes from. Both predicates switch now and fall back the way the resolver does.

## `Permits()` and its documentation parted company

Adding `IsIPv4Reachable()` between `Permits()` and its comment block left two blocks stacked on the new function and the header's main entry point with none. The orphaned text reads plausibly as a description of the new function, which is how it survived review. It is back on `Permits()`, and now states the unspecified refusal above rather than describing only the mapped case.

## One definition of "reachable over IPv4"

`IsIPv4() || IsIPv4Mapped()` was written out in both headers, and the tests assert the two functions separately, so a later change for NAT64 or 6to4 applied to one copy would reintroduce the mismatch above with nothing catching it. `IsIPv4Reachable()` is now the single definition, used by both.

## `IPv6Only` and `IPV6_V6ONLY`

`AnyAddress()` returns the IPv6 wildcard under `IPv6Only`, and Linux defaults `IPV6_V6ONLY` off, so the listener accepts IPv4 peers as mapped addresses while `Permits()` refuses mapped addresses under that configuration: connections arriving that the policy will not talk to. The header cannot set socket options, so the fix is documentation. It now states the obligation in both directions rather than only for dual-stack acceptance.

## One reported finding that is not a defect

`AnyAddress()` preferring the IPv4 wildcard under `DualStack` was read as a half-enabled stack. It is the documented policy, and `AnyAddressStaysIPv4WhereverIPv4IsPermitted` pins it deliberately: handing `::` to the single-socket services, the EC listener and the web server, would move the daemon's control channel to another family as a side effect of ed2k work.

## Verification

Default build clean, 62/62 ctest. `AddressFamilyPolicyTest` 8 to 12 cases: four new, and two ported off the removed function rather than dropped, so the count is unchanged by the removal.

Controls: permitting the unspecified address again fails both the refusal test and the empty-pair one, restoring the inequality predicates fails the out-of-range test, and dropping the narrowing in `AsioTargetFor()` fails the pairing test. Removing the function cost no coverage either: making `Permits()` return true unconditionally still fails `RefusalNeverFallsBackToTheOtherFamily`, which is the assertion the removal had to preserve.

clang-format 18 clean, `git diff --check` clean, Tier-2 clang-tidy clean with zero compiler errors.

Refs #1177


