### PR TITLE
build: follow-ups from a post-merge review of the libutp vendoring

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -284,7 +284,18 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        build_type: [Debug, Release]
+        # ENABLE_UTP on one leg only. The vendored libutp compiles
+        # libutp_inet_ntop.cpp under if(WIN32), and both jobs that set
+        # ENABLE_ALL_EXPERIMENTAL run on ubuntu-latest, so that source was
+        # built by nothing: a pin bump or an MSYS2 toolchain shift would break
+        # Windows silently and be found by whoever first turned the switch on
+        # there. One leg is enough to compile it, and keeps the cost of a
+        # snapshot that does not build on Windows to a single job.
+        include:
+          - build_type: Debug
+            extra_config_flags: -DENABLE_UTP=YES
+          - build_type: Release
+            extra_config_flags: ""
     defaults:
       run:
         shell: msys2 {0}
@@ -325,7 +336,8 @@ jobs:
           cmake \
             -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
             ${{ env.cmake_common_config_flags }} \
-            ${{ env.cmake_mingw_w64_config_flags }}
+            ${{ env.cmake_mingw_w64_config_flags }} \
+            ${{ matrix.extra_config_flags }}
       - name: zero ccache stats
         run: ccache --zero-stats
       - name: make

--- a/cmake/libutp.cmake
+++ b/cmake/libutp.cmake
@@ -26,11 +26,38 @@ if (NOT EXISTS "${AMULE_LIBUTP_DIR}/CMakeLists.txt")
 endif()
 
 if (CMAKE_VERSION VERSION_LESS 3.12)
+	# Not "build without ENABLE_UTP": ENABLE_ALL_EXPERIMENTAL turns it on and
+	# wins over an individual switch, so -DENABLE_UTP=NO cannot be honoured as
+	# an opt-out (see the loop in cmake/options.cmake). Naming the switch that
+	# can actually be turned off is the difference between advice and a dead
+	# end, and 3.10 is this project's declared minimum.
 	message (FATAL_ERROR
 		"ENABLE_UTP requires CMake 3.12 or newer (the vendored libutp asks for "
-		"it); this is CMake ${CMAKE_VERSION}. Build without ENABLE_UTP, or "
-		"upgrade CMake.")
+		"it); this is CMake ${CMAKE_VERSION}. Upgrade CMake, or build without "
+		"uTP: turn ENABLE_UTP off, and if ENABLE_ALL_EXPERIMENTAL is on turn "
+		"that off too and name the other experimental switches individually.")
 endif()
+
+# Upstream's own switches, pinned before the subdirectory sees them. option()
+# leaves an existing cache entry alone, and INTERNAL keeps these out of
+# `cmake -LAH`, which docs/INSTALL.md tells users to run.
+#
+# Two of them are actively harmful here and none of them is ours to offer.
+# LIBUTP_BUILD_PROGRAMS wants ucat.c, which AMULE_PROVENANCE.md records as
+# deliberately not vendored, so turning it on fails configure with a missing
+# source that reads like a broken checkout. LIBUTP_ENABLE_INSTALL would make
+# `make install` write libutp.a, its headers and a cmake package into aMule's
+# prefix: a library we vendor for our own use is not one we ship. LIBUTP_SHARED
+# would build an uninstalled .so nothing links, and it defaults from
+# BUILD_SHARED_LIBS, so it is reachable without naming libutp at all.
+# FORCE, not just CACHE: a -D on the command line creates the entry before this
+# file runs, and set(CACHE) without FORCE adopts the type while keeping the
+# user's value. Without it the pin is decorative, which a probe run with
+# -DLIBUTP_BUILD_PROGRAMS=ON showed by still failing on the missing ucat.c.
+set (LIBUTP_SHARED OFF CACHE INTERNAL "aMule links the vendored libutp statically" FORCE)
+set (LIBUTP_ENABLE_INSTALL OFF CACHE INTERNAL "aMule does not install the vendored libutp" FORCE)
+set (LIBUTP_ENABLE_WERROR OFF CACHE INTERNAL "aMule does not gate on upstream's warnings" FORCE)
+set (LIBUTP_BUILD_PROGRAMS OFF CACHE INTERNAL "ucat.c is not vendored" FORCE)
 
 add_subdirectory ("${AMULE_LIBUTP_DIR}")
 


### PR DESCRIPTION
Three findings from re-reviewing #1353. The provenance itself was checked and is clean: all twenty vendored files are byte-identical to the pinned upstream revision, and the omitted-file list matches `AMULE_PROVENANCE.md` exactly.

## Upstream's options were ours to offer, and two of them break things

`LIBUTP_SHARED`, `LIBUTP_ENABLE_INSTALL`, `LIBUTP_ENABLE_WERROR` and `LIBUTP_BUILD_PROGRAMS` were left as ordinary cache entries, so they appeared in `cmake -LAH`, which `docs/INSTALL.md` tells users to run.

`LIBUTP_BUILD_PROGRAMS` wants `ucat.c`, which `AMULE_PROVENANCE.md` records as deliberately not vendored, so turning it on fails configure with a missing source that reads like a broken checkout. `LIBUTP_ENABLE_INSTALL` would make `make install` write `libutp.a`, its headers and a cmake package into aMule's prefix: a library vendored for our own use is not one we ship. All four are pinned before `add_subdirectory` now.

**`FORCE` is load-bearing there and I nearly shipped without it.** A `-D` on the command line creates the cache entry before this file runs, and `set(CACHE)` without `FORCE` adopts the type while keeping the user's value. The first version of the pin left `LIBUTP_BUILD_PROGRAMS:INTERNAL=ON` and still failed on `ucat.c`: it looked correct and pinned nothing. Verified the other way afterwards, configuring with `LIBUTP_BUILD_PROGRAMS`, `LIBUTP_ENABLE_INSTALL` and `BUILD_SHARED_LIBS` all on, which now succeeds with every one overridden and the subdirectory contributing no install actions.

## The CMake 3.12 error gave advice the build refuses to accept

It said "build without ENABLE_UTP". `ENABLE_ALL_EXPERIMENTAL` turns that switch on and wins over an individual one, and `cmake/options.cmake` states outright that `-DENABLE_UTP=NO` "cannot be honoured as an opt-out". So on CMake 3.10, this project's declared minimum, that combination aborted telling you to do something impossible. The message now names the switch that can actually be turned off.

## The snapshot's Windows sources were compiled by nothing

libutp builds `libutp_inet_ntop.cpp` under `if(WIN32)`, and both jobs that set `ENABLE_ALL_EXPERIMENTAL` run on `ubuntu-latest`, so that source has never been built by CI. A pin bump or an MSYS2 toolchain shift would break Windows silently, and the first person to find out would be whoever turned the switch on there. The wrapper's own comment claimed the experimental set "is what gives the vendored snapshot CI coverage"; it gives it Linux coverage.

The mingw-w64 Debug leg now sets `ENABLE_UTP`. One leg rather than both, so a snapshot that does not build on Windows costs one red job rather than two.

**This is the part I cannot verify locally.** I have no mingw toolchain here and I am not going to claim libutp builds under mingw-w64 clang. If that job goes red, the gap was worse than reported and there is a real Windows break in the vendored snapshot. Either outcome is information the tree does not currently have.

## Already fixed

A note recorded against #1353 said the comment claiming aMule sets `CMAKE_CXX_STANDARD` nowhere had gone stale when #1360 pinned C++17. That was corrected before this branch.

## Verification

`-DENABLE_UTP=YES` build clean, 63/63 ctest. Default build unaffected, with zero `LIBUTP_` entries in its cache. `cmake -LAH` shows none of the four. `git diff --check` clean, `check-potfiles.sh` clean.

Refs #1177
