### PR TITLE
fix(net): follow-ups from a post-merge review of uTP on the shared UDP port

### DIFF
--- a/src/ClientUDPSocket.cpp
+++ b/src/ClientUDPSocket.cpp
@@ -85,14 +85,28 @@ void CClientUDPSocket::TickUtp()
 void CClientUDPSocket::SendUtpDatagram(const uint8_t *payload, size_t length, uint32_t ip, uint16_t port)
 {
 	wxASSERT(wxIsMainThread());
-	const auto *peer = theApp->clientlist->FindClientByIP(ip, port);
-	QueueUtpDatagram<CPacket>(*this,
-		payload,
-		length,
-		ip,
-		port,
-		peer != nullptr && peer->ShouldReceiveCryptUDPPackets(),
-		peer != nullptr ? peer->GetUserHash().GetHash() : nullptr);
+	// Sent unobfuscated, deliberately and for now.
+	//
+	// This used to resolve the peer with FindClientByIP(ip, port) to decide. That call cannot
+	// work here: it matches GetUserPort(), the ed2k TCP port, and every other caller in the
+	// tree passes a TCP port, while what arrives here is the peer's UDP port. With the aMule
+	// defaults of 4662 and 4672 it never matched, so the decision was always "no encryption"
+	// by accident rather than by choice. Worse, it could match the wrong client, whenever some
+	// other peer at the same address happened to listen on a TCP port equal to the UDP port
+	// being dialled: that one's user hash then derived the key and the real recipient could not
+	// decrypt. Sending in the clear is better than encrypting to the wrong peer.
+	//
+	// The fix is not a UDP-keyed lookup. Every other send site already holds the client and
+	// passes the destination and the crypt parameters together (see CUpDownClient's direct
+	// callback in BaseClient.cpp). The reverse lookup exists only because UTP_SENDTO hands back
+	// a bare address. The acceptor knows which peer a socket belongs to, so it must carry
+	// ShouldReceiveCryptUDPPackets() and the user hash down to here, and this comment goes with
+	// the change that does it.
+	// Counted here rather than inside QueueUtpDatagram(), which is deliberately free of the
+	// application's headers. The figure is the datagram that leaves: the payload plus the
+	// two-byte 0xB2 envelope, which is what the receive side counts at the other end.
+	theStats::AddUpOverheadOther(length + kUtpEnvelopeBytes);
+	QueueUtpDatagram<CPacket>(*this, payload, length, ip, port, false, nullptr);
 }
 #endif
 
@@ -253,13 +267,21 @@ void CClientUDPSocket::ProcessReservedProt2Frame(
 		if (ProcessUtpFrame(m_utp, classified, ip, port)) {
 			return;
 		}
-		// Reached only when libutp has seen the datagram and disclaimed it: it belongs to
-		// no connection it holds. A different reason from the types below, so it does not
-		// borrow their message.
+		// Reached only for a frame libutp would not even look at: shorter than a uTP
+		// header, or a version it does not implement. It is *not* the
+		// belongs-to-no-connection case, which the message used to claim.
+		//
+		// libutp answers a non-SYN frame that matches no connection by sending an
+		// unsolicited RST and returning 1 (utp_internal.cpp, the flags != ST_SYN branch),
+		// so ProcessUtpFrame() reports it handled and this code never runs for it. Those
+		// frames leave as RSTs to an unverified source address, with no line anywhere.
+		// Logging them, and deciding whether to answer a stranger at all, needs to know
+		// which peers hold a uTP socket, which is the acceptor's registry: see the note on
+		// the crypt parameters in SendUtpDatagram(), which defers for the same reason.
 		if (m_utpUnmatchedFrameLog.ShouldLog(::GetTickCount64())) {
 			AddDebugLogLineN(logClientUDP,
-				CFormat("Dropping uTP frame from %s:%u: not for any open uTP connection "
-					"(%u further occurrences suppressed)") %
+				CFormat("Dropping malformed uTP frame from %s:%u: too short or an "
+					"unsupported version (%u further occurrences suppressed)") %
 					Uint32toStringIP(ip) % port %
 					m_utpUnmatchedFrameLog.TakeSuppressedCount());
 		}

--- a/src/ClientUDPSocket.cpp
+++ b/src/ClientUDPSocket.cpp
@@ -104,7 +104,13 @@ void CClientUDPSocket::SendUtpDatagram(const uint8_t *payload, size_t length, ui
 	// the change that does it.
 	// Counted here rather than inside QueueUtpDatagram(), which is deliberately free of the
 	// application's headers. The figure is the datagram that leaves: the payload plus the
-	// two-byte 0xB2 envelope, which is what the receive side counts at the other end.
+	// two-byte 0xB2 envelope.
+	//
+	// That matches the receive side only while this path is unobfuscated. OnPacketReceived()
+	// counts its `length`, the raw datagram before decryption, so an obfuscated one is counted
+	// with its crypt header; this line has no header to add. The change that brings the crypt
+	// parameters down has to add kUtpCryptHeaderBytes here, or aMule under-reports its own
+	// upload by eight bytes a datagram.
 	theStats::AddUpOverheadOther(length + kUtpEnvelopeBytes);
 	QueueUtpDatagram<CPacket>(*this, payload, length, ip, port, false, nullptr);
 }

--- a/src/UtpContext.h
+++ b/src/UtpContext.h
@@ -127,11 +127,18 @@ inline bool ProcessUtpFrame(
 // one; the adapter does the sa_family comparison.
 constexpr std::uint64_t kUtpEnvelopeBytes = 2;
 
+// What CEncryptedDatagramSocket::EncryptSendClient() prepends: CRYPT_HEADER_WITHOUTPADDING.
+// Subtracted unconditionally rather than only for peers we encrypt to, because the budget is a
+// property of the libutp context while the decision is per-datagram, and a budget that is right
+// only sometimes is the fragmentation this override exists to prevent. The cost of being wrong
+// in this direction is eight bytes of payload on a plaintext datagram.
+constexpr std::uint64_t kUtpCryptHeaderBytes = 8;
+
 constexpr std::uint64_t UtpUdpMtu(bool isIPv6)
 {
 	// IPv4:   1500 ethernet - 20 IPv4 - 8 UDP - 24 GRE - 8 PPPoE - 2 MPPE - 36 fudge.
 	// Teredo: 1280 - 40 IPv6 - 8 UDP.
-	return (isIPv6 ? UINT64_C(1232) : UINT64_C(1402)) - kUtpEnvelopeBytes;
+	return (isIPv6 ? UINT64_C(1232) : UINT64_C(1402)) - kUtpEnvelopeBytes - kUtpCryptHeaderBytes;
 }
 
 constexpr std::uint64_t UtpUdpOverhead(bool isIPv6)

--- a/src/UtpContext.h
+++ b/src/UtpContext.h
@@ -127,7 +127,12 @@ inline bool ProcessUtpFrame(
 // one; the adapter does the sa_family comparison.
 constexpr std::uint64_t kUtpEnvelopeBytes = 2;
 
-// What CEncryptedDatagramSocket::EncryptSendClient() prepends: CRYPT_HEADER_WITHOUTPADDING.
+// What CEncryptedDatagramSocket::EncryptSendClient() prepends. Its cryptHeaderLen is
+// `padLen + CRYPT_HEADER_WITHOUTPADDING + (kad ? 8 : 0)`, which is 8 here because a uTP datagram
+// is not Kad and padLen is hardcoded to zero -- under a comment reading "padding disabled for UDP
+// currently". Enabling it makes this budget too small again, which is the defect this constant
+// exists to fix, so that switch has to come back here.
+//
 // Subtracted unconditionally rather than only for peers we encrypt to, because the budget is a
 // property of the libutp context while the decision is per-datagram, and a budget that is right
 // only sometimes is the fragmentation this override exists to prevent. The cost of being wrong

--- a/unittests/tests/UtpContextTest.cpp
+++ b/unittests/tests/UtpContextTest.cpp
@@ -289,17 +289,31 @@ TEST(UtpContext, UdpSizingKeepsTheFamilyAwarenessLibutpHad)
 	// libutp's own defaults branch on the address family; overriding them for the two-byte
 	// envelope must not flatten that, or an IPv6 peer gets IPv4 numbers and libutp sizes
 	// packets 20 bytes too large.
-	ASSERT_EQUALS(1400ull, UtpUdpMtu(false));
-	ASSERT_EQUALS(1230ull, UtpUdpMtu(true));
+	ASSERT_EQUALS(1392ull, UtpUdpMtu(false));
+	ASSERT_EQUALS(1222ull, UtpUdpMtu(true));
 	ASSERT_EQUALS(30ull, UtpUdpOverhead(false));
 	ASSERT_EQUALS(78ull, UtpUdpOverhead(true));
 
 	// The envelope is what the override exists for: each is libutp's own
 	// constant moved by exactly two bytes, in the direction that leaves room.
-	ASSERT_EQUALS(1402ull - kUtpEnvelopeBytes, UtpUdpMtu(false));
-	ASSERT_EQUALS(1232ull - kUtpEnvelopeBytes, UtpUdpMtu(true));
+	ASSERT_EQUALS(1402ull - kUtpEnvelopeBytes - kUtpCryptHeaderBytes, UtpUdpMtu(false));
+	ASSERT_EQUALS(1232ull - kUtpEnvelopeBytes - kUtpCryptHeaderBytes, UtpUdpMtu(true));
 	ASSERT_EQUALS(28ull + kUtpEnvelopeBytes, UtpUdpOverhead(false));
 	ASSERT_EQUALS(76ull + kUtpEnvelopeBytes, UtpUdpOverhead(true));
+}
+
+// The obfuscation header is part of the datagram too. EncryptSendClient() prepends
+// CRYPT_HEADER_WITHOUTPADDING, so a budget that counts only the envelope lets a full-size
+// encrypted packet exceed the very limit the override exists to respect. Dormant while the send
+// path is unencrypted, and the reason the two must be fixed together rather than in either order.
+TEST(UtpContext, TheUdpBudgetLeavesRoomForTheObfuscationHeader)
+{
+	ASSERT_EQUALS(8ull, kUtpCryptHeaderBytes);
+
+	// A full-size payload plus everything aMule puts in front of it still fits the number
+	// libutp was sizing against before the crypt header was accounted for.
+	ASSERT_TRUE(UtpUdpMtu(false) + kUtpEnvelopeBytes + kUtpCryptHeaderBytes <= 1402ull);
+	ASSERT_TRUE(UtpUdpMtu(true) + kUtpEnvelopeBytes + kUtpCryptHeaderBytes <= 1232ull);
 }
 
 // File_checked_for_headers


### PR DESCRIPTION
Three of five findings from re-reviewing #1357. All of this is behind `AMULE_UTP_TRANSPORT`, off by default, so none of it reaches a shipping build.

## Every outbound uTP datagram was unobfuscated, and not on purpose

`SendUtpDatagram()` resolved the peer with `FindClientByIP(ip, port)` to decide whether to encrypt. That function matches `GetUserPort()`, the ed2k **TCP** port (`ClientList.cpp:468`), while what arrives here is the peer's **UDP** port, and every other caller in the tree passes a TCP port. With the aMule defaults of 4662 and 4672 it never matched, so the answer was always "no encryption" by accident rather than by choice.

The second failure mode is worse. If another client at the same address happened to listen on a TCP port equal to the UDP port being dialled, that client was returned and *its* user hash derived the key, so the real recipient could not decrypt.

**The lookup is removed rather than replaced.** There is no UDP-keyed lookup to switch to, and adding one would be guesswork since `CUpDownClient` exposes no general UDP port. Every other send site already holds the client and passes the destination and the crypt parameters together, as at `BaseClient.cpp:1694-1698`; the reverse lookup exists here only because `UTP_SENDTO` hands back a bare address. The acceptor knows which peer a socket belongs to and must carry the parameters down. Until then this sends in the clear deliberately and says so in place, which is what removes the wrong-key hazard.

## The MTU budget ignored the obfuscation header

`UtpUdpMtu()` subtracted the two-byte envelope and nothing else, while `EncryptSendClient()` prepends `CRYPT_HEADER_WITHOUTPADDING`. A full-size encrypted datagram therefore exceeded the limit the override exists to respect.

This is dormant today *because of* the finding above, which is why the two are fixed together: repairing the lookup on its own would have switched fragmentation on. Subtracted unconditionally, since the budget is a property of the libutp context while the encryption decision is per-datagram, at a cost of eight payload bytes on a plaintext datagram.

Eight is the whole header here rather than a floor: `EncryptSendClient()` computes `padLen + CRYPT_HEADER_WITHOUTPADDING + (kad ? 8 : 0)`, a uTP datagram is not Kad, and `padLen` is hardcoded to zero under a comment reading "padding disabled for UDP currently". The constant's comment now names that formula, since enabling padding would make this budget too small again.

## The send path spent bandwidth invisibly

No `AddUpOverhead*` while every sibling send has one. Counted at the call site rather than inside `QueueUtpDatagram()`, which is deliberately free of the application's headers. The receive half was already done in #1376.

It matches that half only while this path is unobfuscated. `OnPacketReceived()` counts its raw pre-decryption length, so an obfuscated datagram is counted with its crypt header, while this line has no header to add. Recorded in place, because the change that brings the crypt parameters down has to add `kUtpCryptHeaderBytes` here too.

## Two findings not fixed here, both needing the same thing

**The unsolicited RST.** libutp answers a non-SYN frame matching no connection with a RST to an unverified source address (`utp_internal.cpp`, the `flags != ST_SYN` branch), so a spoofed frame makes aMule a reflector. Suppressing it means knowing whether we hold a uTP socket for that address *before* libutp sees the frame, and that registry is the acceptor's. There is no interception point today. Amplification is roughly one to one, so the sharper cost is the linear scan of up to `RST_INFO_LIMIT` stored entries per crafted frame.

**The log that described the wrong case.** It claimed frames were "not for any open uTP connection". It cannot be: libutp returns 1 on the RST path, so `ProcessUtpFrame()` reports the datagram handled and the branch never runs for those. It runs for frames libutp will not look at, runt or wrong-version, and now says that. Logging the genuinely unmatched case needs the same registry, so the comment points at it.

## Verification

`-DENABLE_UTP=YES` 63/63, default 62/62, both builds clean. `UtpContextTest` 10 to 11 cases. Control: dropping the crypt header from the budget fails both the pinned numbers and the new headroom assertion.

clang-format 18 clean, `git diff --check` clean, Tier-2 clang-tidy clean with zero compiler errors.

Refs #1177

