### PR TITLE
fix(gui): parent the runtime search controls to the row they join

### DIFF
--- a/src/SearchDlg.cpp
+++ b/src/SearchDlg.cpp
@@ -186,10 +186,14 @@ CSearchDlg::CSearchDlg(wxWindow *pParent)
 			}
 			// Button first, then its divider, so both land before the anchor
 			// and the row stays button|divider|button all the way across.
-			m_clearHistoryBtn = new wxButton(this, wxID_ANY, _("Clear Search History"));
+			// Parent is the row's own, not the dialog: this sizer lives in a
+			// wxStaticBoxSizer and positions in the static box's client area, so a
+			// child of the dialog is drawn offset by the box frame and label.
+			wxWindow *const rowParent = clearResultsBtn->GetParent();
+			m_clearHistoryBtn = new wxButton(rowParent, wxID_ANY, _("Clear Search History"));
 			row->Insert(at, m_clearHistoryBtn, wxSizerFlags().Center().Border(wxALL, 5));
 			m_clearHistorySep = new wxStaticLine(
-				this, wxID_ANY, wxDefaultPosition, wxSize(-1, 20), wxLI_VERTICAL);
+				rowParent, wxID_ANY, wxDefaultPosition, wxSize(-1, 20), wxLI_VERTICAL);
 			row->Insert(at + 1, m_clearHistorySep, wxSizerFlags().Center().Border(wxALL, 5));
 			m_clearHistoryBtn->Bind(wxEVT_BUTTON, &CSearchDlg::OnBnClickedClearHistory, this);
 		}
@@ -267,9 +271,13 @@ wxTextEntry *CSearchDlg::RebuildSearchNameField(bool wantHistory)
 	// lose what the user was in the middle of typing.
 	const wxString typed = dynamic_cast<wxTextEntry *>(current)->GetValue();
 
+	// Same parent as the control being replaced, for the reason given at the
+	// clear-history button above.
+	wxWindow *const slotParent = current->GetParent();
+
 	wxWindow *replacement = nullptr;
 	if (wantHistory) {
-		wxComboBox *combo = new wxComboBox(this,
+		wxComboBox *combo = new wxComboBox(slotParent,
 			IDC_SEARCHNAME,
 			wxEmptyString,
 			wxDefaultPosition,
@@ -288,7 +296,7 @@ wxTextEntry *CSearchDlg::RebuildSearchNameField(bool wantHistory)
 		// EVT_TEXT_ENTER entry. A plain text control carries no history menu, so the binding is
 		// gone with the old combo.
 		m_searchNameCtxBound = false;
-		replacement = new wxTextCtrl(this,
+		replacement = new wxTextCtrl(slotParent,
 			IDC_SEARCHNAME,
 			wxEmptyString,
 			wxDefaultPosition,


### PR DESCRIPTION
The "Clear Search History" button is drawn above the button row instead of in it.

The row lives in a `wxStaticBoxSizer`, and `muuli_wdr` parents every control in it to the `wxStaticBox`:

```cpp
wxStaticBox *item2 = new wxStaticBox( parent, -1, _("Search") );
wxStaticBoxSizer *item1 = new wxStaticBoxSizer( item2, wxVERTICAL );
wxButton *item54 = new wxButton( item2, IDC_CLEAR_RESULTS, ... );
```

So the sizer lays out in the static box's client area. `CSearchDlg` created the button with the dialog as parent, so wx applied that position in the dialog's coordinates and the button landed higher by the box frame and label. The separator inserted with it has the same fault, and is only invisible because it is a thin line on a plain background.

The offset is the static box border, which differs per platform, so how visible this is varies. Reported on GTK.

`RebuildSearchNameField` has the same fault for the combo and text control it swaps into the search-name slot. That one bites only after toggling the remember-history preference: on a fresh start the early return keeps the control `muuli_wdr` built, which is parented correctly. Fixed here too rather than left as a second report.

The fix takes the parent from the sibling being joined or replaced. That is what `muuli_wdr` already does for these same ids, and their id-keyed handlers work from there, since command events propagate up to the dialog either way.

Reported in #1386, left open until the reporter confirms on GTK.
